### PR TITLE
fix(UI): better ui/ux in asset capitalization

### DIFF
--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -208,14 +208,11 @@ class Asset(AccountsController):
 		add_asset_activity(self.name, _("Asset cancelled"))
 
 	def after_insert(self):
-		if (
-			not frappe.db.exists(
-				{
-					"doctype": "Asset Activity",
-					"asset": self.name,
-				}
-			)
-			and not self.flags.asset_created_via_asset_capitalization
+		if not frappe.db.exists(
+			{
+				"doctype": "Asset Activity",
+				"asset": self.name,
+			}
 		):
 			add_asset_activity(self.name, _("Asset created"))
 
@@ -1006,7 +1003,6 @@ def create_asset_capitalization(company, asset, asset_name, item_code):
 		{
 			"target_asset": asset,
 			"company": company,
-			"capitalization_method": "Choose a WIP composite asset",
 			"target_asset_name": asset_name,
 			"target_item_code": item_code,
 		}

--- a/erpnext/assets/doctype/asset_capitalization/asset_capitalization.js
+++ b/erpnext/assets/doctype/asset_capitalization/asset_capitalization.js
@@ -134,10 +134,7 @@ erpnext.assets.AssetCapitalization = class AssetCapitalization extends erpnext.s
 	}
 
 	target_asset() {
-		if (
-			this.frm.doc.target_asset &&
-			this.frm.doc.capitalization_method === "Choose a WIP composite asset"
-		) {
+		if (this.frm.doc.target_asset) {
 			this.set_consumed_stock_items_tagged_to_wip_composite_asset(this.frm.doc.target_asset);
 			this.get_target_asset_details();
 		}

--- a/erpnext/assets/doctype/asset_capitalization/asset_capitalization.json
+++ b/erpnext/assets/doctype/asset_capitalization/asset_capitalization.json
@@ -11,7 +11,6 @@
   "naming_series",
   "target_asset",
   "target_asset_name",
-  "target_asset_location",
   "target_item_code",
   "finance_book",
   "target_qty",
@@ -52,13 +51,13 @@
    "label": "Title"
   },
   {
-   "depends_on": "eval:(doc.target_item_code && !doc.__islocal && doc.capitalization_method !== 'Choose a WIP composite asset') || doc.capitalization_method=='Create a new composite asset'",
+   "depends_on": "eval:(doc.target_item_code && !doc.__islocal)",
    "fieldname": "target_item_code",
    "fieldtype": "Link",
    "in_standard_filter": 1,
    "label": "Target Item Code",
-   "mandatory_depends_on": "eval:doc.capitalization_method=='Create a new composite asset'",
-   "options": "Item"
+   "options": "Item",
+   "read_only": 1
   },
   {
    "default": "0",
@@ -286,20 +285,12 @@
    "label": "Target Fixed Asset Account",
    "options": "Account",
    "read_only": 1
-  },
-  {
-   "depends_on": "eval:doc.capitalization_method=='Create a new composite asset'",
-   "fieldname": "target_asset_location",
-   "fieldtype": "Link",
-   "label": "Target Asset Location",
-   "mandatory_depends_on": "eval:doc.capitalization_method=='Create a new composite asset'",
-   "options": "Location"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-05-20 15:03:47.485193",
+ "modified": "2025-05-20 15:15:12.110035",
  "modified_by": "Administrator",
  "module": "Assets",
  "name": "Asset Capitalization",

--- a/erpnext/assets/doctype/asset_capitalization/asset_capitalization.json
+++ b/erpnext/assets/doctype/asset_capitalization/asset_capitalization.json
@@ -9,19 +9,17 @@
  "field_order": [
   "title",
   "naming_series",
-  "capitalization_method",
-  "target_item_code",
-  "target_item_name",
   "target_asset",
   "target_asset_name",
-  "target_qty",
   "target_asset_location",
+  "target_item_code",
+  "finance_book",
+  "target_qty",
   "column_break_9",
   "company",
   "posting_date",
   "posting_time",
   "set_posting_time",
-  "finance_book",
   "target_batch_no",
   "target_serial_no",
   "amended_from",
@@ -63,14 +61,6 @@
    "options": "Item"
   },
   {
-   "depends_on": "eval:doc.target_item_code && doc.target_item_name != doc.target_item_code",
-   "fetch_from": "target_item_code.item_name",
-   "fieldname": "target_item_name",
-   "fieldtype": "Data",
-   "label": "Target Item Name",
-   "read_only": 1
-  },
-  {
    "default": "0",
    "fetch_from": "target_item_code.is_fixed_asset",
    "fieldname": "target_is_fixed_asset",
@@ -80,18 +70,14 @@
    "read_only": 1
   },
   {
-   "depends_on": "eval:(doc.target_asset && !doc.__islocal) || doc.capitalization_method=='Choose a WIP composite asset'",
    "fieldname": "target_asset",
    "fieldtype": "Link",
    "in_standard_filter": 1,
    "label": "Target Asset",
-   "mandatory_depends_on": "eval:doc.capitalization_method=='Choose a WIP composite asset'",
    "no_copy": 1,
-   "options": "Asset",
-   "read_only_depends_on": "eval:doc.capitalization_method=='Create a new composite asset'"
+   "options": "Asset"
   },
   {
-   "depends_on": "eval:(doc.target_asset_name && !doc.__islocal) || (doc.target_asset && doc.capitalization_method=='Choose a WIP composite asset')",
    "fetch_from": "target_asset.asset_name",
    "fieldname": "target_asset_name",
    "fieldtype": "Data",
@@ -176,7 +162,9 @@
    "default": "1",
    "fieldname": "target_qty",
    "fieldtype": "Float",
-   "label": "Target Qty"
+   "hidden": 1,
+   "label": "Target Qty",
+   "read_only": 1
   },
   {
    "default": "0",
@@ -306,18 +294,12 @@
    "label": "Target Asset Location",
    "mandatory_depends_on": "eval:doc.capitalization_method=='Create a new composite asset'",
    "options": "Location"
-  },
-  {
-   "fieldname": "capitalization_method",
-   "fieldtype": "Select",
-   "label": "Capitalization Method",
-   "options": "\nCreate a new composite asset\nChoose a WIP composite asset"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-01-08 13:14:33.008458",
+ "modified": "2025-05-20 15:03:47.485193",
  "modified_by": "Administrator",
  "module": "Assets",
  "name": "Asset Capitalization",
@@ -355,6 +337,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],

--- a/erpnext/assets/doctype/asset_capitalization/asset_capitalization.py
+++ b/erpnext/assets/doctype/asset_capitalization/asset_capitalization.py
@@ -547,45 +547,6 @@ class AssetCapitalization(StockController):
 				)
 			)
 
-	# def create_target_asset(self):
-	# 	if self.capitalization_method != "Create a new composite asset":
-	# 		return
-
-	# 	total_target_asset_value = flt(self.total_value, self.precision("total_value"))
-
-	# 	asset_doc = frappe.new_doc("Asset")
-	# 	asset_doc.company = self.company
-	# 	asset_doc.item_code = self.target_item_code
-	# 	asset_doc.is_composite_asset = 1
-	# 	asset_doc.location = self.target_asset_location
-	# 	asset_doc.available_for_use_date = self.posting_date
-	# 	asset_doc.purchase_date = self.posting_date
-	# 	asset_doc.gross_purchase_amount = total_target_asset_value
-	# 	asset_doc.purchase_amount = total_target_asset_value
-	# 	asset_doc.flags.ignore_validate = True
-	# 	asset_doc.flags.asset_created_via_asset_capitalization = True
-	# 	asset_doc.insert()
-
-	# 	self.target_asset = asset_doc.name
-
-	# 	self.target_fixed_asset_account = get_asset_category_account(
-	# 		"fixed_asset_account", item=self.target_item_code, company=asset_doc.company
-	# 	)
-	# 	asset_doc.set_status("Work In Progress")
-
-	# 	add_asset_activity(
-	# 		asset_doc.name,
-	# 		_("Asset created after Asset Capitalization {0} was submitted").format(
-	# 			get_link_to_form("Asset Capitalization", self.name)
-	# 		),
-	# 	)
-
-	# 	frappe.msgprint(
-	# 		_("Asset {0} has been created. Please set the depreciation details if any and submit it.").format(
-	# 			get_link_to_form("Asset", asset_doc.name)
-	# 		)
-	# 	)
-
 	def update_target_asset(self):
 		total_target_asset_value = flt(self.total_value, self.precision("total_value"))
 		asset_doc = frappe.get_doc("Asset", self.target_asset)

--- a/erpnext/assets/doctype/asset_capitalization/asset_capitalization.py
+++ b/erpnext/assets/doctype/asset_capitalization/asset_capitalization.py
@@ -82,7 +82,6 @@ class AssetCapitalization(StockController):
 		stock_items: DF.Table[AssetCapitalizationStockItem]
 		stock_items_total: DF.Currency
 		target_asset: DF.Link | None
-		target_asset_location: DF.Link | None
 		target_asset_name: DF.Data | None
 		target_batch_no: DF.Link | None
 		target_fixed_asset_account: DF.Link | None
@@ -116,7 +115,7 @@ class AssetCapitalization(StockController):
 
 	def before_submit(self):
 		self.validate_source_mandatory()
-		self.create_target_asset()
+		# self.create_target_asset()
 
 	def on_submit(self):
 		self.make_bundle_using_old_serial_batch_fields()
@@ -299,16 +298,7 @@ class AssetCapitalization(StockController):
 				d.cost_center = frappe.get_cached_value("Company", self.company, "cost_center")
 
 	def validate_source_mandatory(self):
-		if self.capitalization_method == "Create a new composite asset" and not (
-			self.get("stock_items") or self.get("asset_items")
-		):
-			frappe.throw(
-				_(
-					"Consumed Stock Items or Consumed Asset Items are mandatory for creating new composite asset"
-				)
-			)
-
-		elif not (self.get("stock_items") or self.get("asset_items") or self.get("service_items")):
+		if not (self.get("stock_items") or self.get("asset_items") or self.get("service_items")):
 			frappe.throw(
 				_(
 					"Consumed Stock Items, Consumed Asset Items or Consumed Service Items is mandatory for Capitalization"
@@ -557,49 +547,46 @@ class AssetCapitalization(StockController):
 				)
 			)
 
-	def create_target_asset(self):
-		if self.capitalization_method != "Create a new composite asset":
-			return
+	# def create_target_asset(self):
+	# 	if self.capitalization_method != "Create a new composite asset":
+	# 		return
 
-		total_target_asset_value = flt(self.total_value, self.precision("total_value"))
+	# 	total_target_asset_value = flt(self.total_value, self.precision("total_value"))
 
-		asset_doc = frappe.new_doc("Asset")
-		asset_doc.company = self.company
-		asset_doc.item_code = self.target_item_code
-		asset_doc.is_composite_asset = 1
-		asset_doc.location = self.target_asset_location
-		asset_doc.available_for_use_date = self.posting_date
-		asset_doc.purchase_date = self.posting_date
-		asset_doc.gross_purchase_amount = total_target_asset_value
-		asset_doc.purchase_amount = total_target_asset_value
-		asset_doc.flags.ignore_validate = True
-		asset_doc.flags.asset_created_via_asset_capitalization = True
-		asset_doc.insert()
+	# 	asset_doc = frappe.new_doc("Asset")
+	# 	asset_doc.company = self.company
+	# 	asset_doc.item_code = self.target_item_code
+	# 	asset_doc.is_composite_asset = 1
+	# 	asset_doc.location = self.target_asset_location
+	# 	asset_doc.available_for_use_date = self.posting_date
+	# 	asset_doc.purchase_date = self.posting_date
+	# 	asset_doc.gross_purchase_amount = total_target_asset_value
+	# 	asset_doc.purchase_amount = total_target_asset_value
+	# 	asset_doc.flags.ignore_validate = True
+	# 	asset_doc.flags.asset_created_via_asset_capitalization = True
+	# 	asset_doc.insert()
 
-		self.target_asset = asset_doc.name
+	# 	self.target_asset = asset_doc.name
 
-		self.target_fixed_asset_account = get_asset_category_account(
-			"fixed_asset_account", item=self.target_item_code, company=asset_doc.company
-		)
-		asset_doc.set_status("Work In Progress")
+	# 	self.target_fixed_asset_account = get_asset_category_account(
+	# 		"fixed_asset_account", item=self.target_item_code, company=asset_doc.company
+	# 	)
+	# 	asset_doc.set_status("Work In Progress")
 
-		add_asset_activity(
-			asset_doc.name,
-			_("Asset created after Asset Capitalization {0} was submitted").format(
-				get_link_to_form("Asset Capitalization", self.name)
-			),
-		)
+	# 	add_asset_activity(
+	# 		asset_doc.name,
+	# 		_("Asset created after Asset Capitalization {0} was submitted").format(
+	# 			get_link_to_form("Asset Capitalization", self.name)
+	# 		),
+	# 	)
 
-		frappe.msgprint(
-			_("Asset {0} has been created. Please set the depreciation details if any and submit it.").format(
-				get_link_to_form("Asset", asset_doc.name)
-			)
-		)
+	# 	frappe.msgprint(
+	# 		_("Asset {0} has been created. Please set the depreciation details if any and submit it.").format(
+	# 			get_link_to_form("Asset", asset_doc.name)
+	# 		)
+	# 	)
 
 	def update_target_asset(self):
-		if self.capitalization_method != "Choose a WIP composite asset":
-			return
-
 		total_target_asset_value = flt(self.total_value, self.precision("total_value"))
 		asset_doc = frappe.get_doc("Asset", self.target_asset)
 

--- a/erpnext/assets/doctype/asset_capitalization/asset_capitalization.py
+++ b/erpnext/assets/doctype/asset_capitalization/asset_capitalization.py
@@ -70,7 +70,6 @@ class AssetCapitalization(StockController):
 		amended_from: DF.Link | None
 		asset_items: DF.Table[AssetCapitalizationAssetItem]
 		asset_items_total: DF.Currency
-		capitalization_method: DF.Literal["", "Create new composite asset", "Use existing composite asset"]
 		company: DF.Link
 		cost_center: DF.Link | None
 		finance_book: DF.Link | None
@@ -92,7 +91,6 @@ class AssetCapitalization(StockController):
 		target_incoming_rate: DF.Currency
 		target_is_fixed_asset: DF.Check
 		target_item_code: DF.Link | None
-		target_item_name: DF.Data | None
 		target_qty: DF.Float
 		target_serial_no: DF.SmallText | None
 		title: DF.Data | None

--- a/erpnext/assets/doctype/asset_capitalization/asset_capitalization.py
+++ b/erpnext/assets/doctype/asset_capitalization/asset_capitalization.py
@@ -140,7 +140,7 @@ class AssetCapitalization(StockController):
 		self.update_target_asset()
 
 	def set_title(self):
-		self.title = self.target_asset_name or self.target_item_name or self.target_item_code
+		self.title = self.target_asset_name or self.target_item_code
 
 	def set_missing_values(self, for_validate=False):
 		target_item_details = get_target_item_details(self.target_item_code, self.company)

--- a/erpnext/assets/doctype/asset_capitalization/test_asset_capitalization.py
+++ b/erpnext/assets/doctype/asset_capitalization/test_asset_capitalization.py
@@ -59,10 +59,16 @@ class TestAssetCapitalization(IntegrationTestCase):
 			company=company,
 		)
 
+		wip_composite_asset = create_asset(
+			asset_name="Asset Capitalization WIP Composite Asset",
+			is_composite_asset=1,
+			warehouse="Stores - TCP1",
+			company=company,
+		)
+
 		# Create and submit Asset Captitalization
 		asset_capitalization = create_asset_capitalization(
-			capitalization_method="Create a new composite asset",
-			target_item_code="Macbook Pro",
+			target_asset=wip_composite_asset.name,
 			target_asset_location="Test Location",
 			stock_qty=stock_qty,
 			stock_rate=stock_rate,
@@ -148,10 +154,16 @@ class TestAssetCapitalization(IntegrationTestCase):
 			company=company,
 		)
 
+		wip_composite_asset = create_asset(
+			asset_name="Asset Capitalization WIP Composite Asset",
+			is_composite_asset=1,
+			warehouse="Stores - TCP1",
+			company=company,
+		)
+
 		# Create and submit Asset Captitalization
 		asset_capitalization = create_asset_capitalization(
-			capitalization_method="Create a new composite asset",
-			target_item_code="Macbook Pro",
+			target_asset=wip_composite_asset.name,
 			target_asset_location="Test Location",
 			stock_qty=stock_qty,
 			stock_rate=stock_rate,
@@ -240,7 +252,6 @@ class TestAssetCapitalization(IntegrationTestCase):
 
 		# Create and submit Asset Captitalization
 		asset_capitalization = create_asset_capitalization(
-			capitalization_method="Choose a WIP composite asset",
 			target_asset=wip_composite_asset.name,
 			target_asset_location="Test Location",
 			stock_qty=stock_qty,
@@ -251,7 +262,6 @@ class TestAssetCapitalization(IntegrationTestCase):
 		)
 
 		# Test Asset Capitalization values
-		self.assertEqual(asset_capitalization.capitalization_method, "Choose a WIP composite asset")
 		self.assertEqual(asset_capitalization.target_qty, 1)
 
 		self.assertEqual(asset_capitalization.stock_items[0].valuation_rate, stock_rate)
@@ -310,7 +320,6 @@ class TestAssetCapitalization(IntegrationTestCase):
 
 		# Create and submit Asset Captitalization
 		asset_capitalization = create_asset_capitalization(
-			capitalization_method="Choose a WIP composite asset",
 			target_asset=wip_composite_asset.name,
 			target_asset_location="Test Location",
 			service_qty=service_qty,
@@ -362,7 +371,6 @@ def create_asset_capitalization(**args):
 	asset_capitalization = frappe.new_doc("Asset Capitalization")
 	asset_capitalization.update(
 		{
-			"capitalization_method": args.capitalization_method or None,
 			"company": company,
 			"posting_date": args.posting_date or now.strftime("%Y-%m-%d"),
 			"posting_time": args.posting_time or now.strftime("%H:%M:%S.%f"),


### PR DESCRIPTION
Enhanced the Asset Capitalization form by removing the previous select box used to choose between creating a new asset or using a Work-in-Progress (WIP) asset.
This UI was unintuitive and added unnecessary complexity. The form now directly allows selection of a WIP asset through a simple input field. 


Previous UI:

https://github.com/user-attachments/assets/4805a168-feab-4b79-b2e7-72d029fa46f9

New UI:

https://github.com/user-attachments/assets/d50ef1a5-5d69-45b5-afdb-dc57b87d2545


