### PR TITLE
fix: setting paid amount to 0 when is_paid is unchecked in purchase invoice

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js
@@ -437,6 +437,8 @@ erpnext.accounts.PurchaseInvoice = class PurchaseInvoice extends erpnext.buying.
 				this.frm.set_value("is_paid", 0);
 				frappe.msgprint(__("Please specify Company to proceed"));
 			}
+		} else {
+			this.frm.set_value("paid_amount", 0);
 		}
 		this.calculate_outstanding_amount();
 		this.frm.refresh_fields();

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -650,6 +650,9 @@ class AccountsController(TransactionBase):
 				self.base_paid_amount = flt(
 					self.paid_amount * self.conversion_rate, self.precision("base_paid_amount")
 				)
+			else:
+				self.paid_amount = 0
+				self.base_paid_amount = 0
 
 	def set_missing_values(self, for_validate=False):
 		if frappe.flags.in_test:


### PR DESCRIPTION
If the is_paid checkbox is initially marked as 1 and a value is entered in the paid_amount field, and then is_paid is later unchecked (set to 0), the system still considers the value in paid_amount when calculating the outstanding amount.

This appears to be inconsistent, as unchecking is_paid should ideally reset or ignore the paid_amount value in the outstanding calculation.


Frappe Support Issue: https://support.frappe.io/app/hd-ticket/39071