### PR TITLE
fix: pos screen ui ux

### DIFF
--- a/erpnext/accounts/doctype/pos_profile/pos_profile.json
+++ b/erpnext/accounts/doctype/pos_profile/pos_profile.json
@@ -32,6 +32,7 @@
   "allow_rate_change",
   "allow_discount_change",
   "set_grand_total_to_default_mop",
+  "always_save_invoice_on_new_invoice",
   "section_break_23",
   "item_groups",
   "column_break_25",
@@ -415,6 +416,12 @@
    "fieldname": "set_grand_total_to_default_mop",
    "fieldtype": "Check",
    "label": "Set Grand Total to Default Payment Method"
+  },
+  {
+   "default": "0",
+   "fieldname": "always_save_invoice_on_new_invoice",
+   "fieldtype": "Check",
+   "label": "Always Save Invoice on 'New Invoice'"
   }
  ],
  "grid_page_length": 50,
@@ -443,7 +450,7 @@
    "link_fieldname": "pos_profile"
   }
  ],
- "modified": "2025-05-09 11:23:28.632136",
+ "modified": "2025-05-15 22:57:47.778411",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "POS Profile",

--- a/erpnext/accounts/doctype/pos_profile/pos_profile.json
+++ b/erpnext/accounts/doctype/pos_profile/pos_profile.json
@@ -32,7 +32,7 @@
   "allow_rate_change",
   "allow_discount_change",
   "set_grand_total_to_default_mop",
-  "always_save_invoice_on_new_invoice",
+  "action_on_new_invoice",
   "section_break_23",
   "item_groups",
   "column_break_25",
@@ -418,10 +418,11 @@
    "label": "Set Grand Total to Default Payment Method"
   },
   {
-   "default": "0",
-   "fieldname": "always_save_invoice_on_new_invoice",
-   "fieldtype": "Check",
-   "label": "Always Save Invoice on 'New Invoice'"
+   "default": "Always Ask",
+   "fieldname": "action_on_new_invoice",
+   "fieldtype": "Select",
+   "label": "Action on New Invoice",
+   "options": "Always Ask\nSave changes and Load New Invoice\nDiscard changes and Load New Invoice"
   }
  ],
  "grid_page_length": 50,
@@ -450,7 +451,7 @@
    "link_fieldname": "pos_profile"
   }
  ],
- "modified": "2025-05-15 22:57:47.778411",
+ "modified": "2025-05-19 19:43:52.365563",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "POS Profile",

--- a/erpnext/accounts/doctype/pos_profile/pos_profile.json
+++ b/erpnext/accounts/doctype/pos_profile/pos_profile.json
@@ -422,7 +422,7 @@
    "fieldname": "action_on_new_invoice",
    "fieldtype": "Select",
    "label": "Action on New Invoice",
-   "options": "Always Ask\nSave changes and Load New Invoice\nDiscard changes and Load New Invoice"
+   "options": "Always Ask\nSave Changes and Load New Invoice\nDiscard Changes and Load New Invoice"
   }
  ],
  "grid_page_length": 50,
@@ -451,7 +451,7 @@
    "link_fieldname": "pos_profile"
   }
  ],
- "modified": "2025-05-19 19:43:52.365563",
+ "modified": "2025-05-23 12:12:32.247652",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "POS Profile",

--- a/erpnext/accounts/doctype/pos_profile/pos_profile.py
+++ b/erpnext/accounts/doctype/pos_profile/pos_profile.py
@@ -29,7 +29,7 @@ class POSProfile(Document):
 
 		account_for_change_amount: DF.Link | None
 		action_on_new_invoice: DF.Literal[
-			"Always Ask", "Save changes and Load New Invoice", "Discard changes and Load New Invoice"
+			"Always Ask", "Save Changes and Load New Invoice", "Discard Changes and Load New Invoice"
 		]
 		allow_discount_change: DF.Check
 		allow_rate_change: DF.Check

--- a/erpnext/accounts/doctype/pos_profile/pos_profile.py
+++ b/erpnext/accounts/doctype/pos_profile/pos_profile.py
@@ -28,9 +28,11 @@ class POSProfile(Document):
 		from erpnext.accounts.doctype.pos_profile_user.pos_profile_user import POSProfileUser
 
 		account_for_change_amount: DF.Link | None
+		action_on_new_invoice: DF.Literal[
+			"Always Ask", "Save changes and Load New Invoice", "Discard changes and Load New Invoice"
+		]
 		allow_discount_change: DF.Check
 		allow_rate_change: DF.Check
-		always_save_invoice_on_new_invoice: DF.Check
 		applicable_for_users: DF.Table[POSProfileUser]
 		apply_discount_on: DF.Literal["Grand Total", "Net Total"]
 		auto_add_item_to_cart: DF.Check

--- a/erpnext/accounts/doctype/pos_profile/pos_profile.py
+++ b/erpnext/accounts/doctype/pos_profile/pos_profile.py
@@ -30,6 +30,7 @@ class POSProfile(Document):
 		account_for_change_amount: DF.Link | None
 		allow_discount_change: DF.Check
 		allow_rate_change: DF.Check
+		always_save_invoice_on_new_invoice: DF.Check
 		applicable_for_users: DF.Table[POSProfileUser]
 		apply_discount_on: DF.Literal["Grand Total", "Net Total"]
 		auto_add_item_to_cart: DF.Check

--- a/erpnext/hooks.py
+++ b/erpnext/hooks.py
@@ -28,6 +28,14 @@ web_include_js = "erpnext-web.bundle.js"
 web_include_css = "erpnext-web.bundle.css"
 email_css = "email_erpnext.bundle.css"
 
+app_include_icons = [
+	"/assets/erpnext/icons/pos-icons.svg",
+]
+
+web_include_icons = [
+	"/assets/erpnext/icons/pos-icons.svg",
+]
+
 doctype_js = {
 	"Address": "public/js/address.js",
 	"Communication": "public/js/communication.js",

--- a/erpnext/public/icons/pos-icons.svg
+++ b/erpnext/public/icons/pos-icons.svg
@@ -1,0 +1,15 @@
+<!-- Icons for POS Icon Buttons. Taken from frappe/public/icons/lucide.svg -->
+
+<svg id="frappe-symbols" aria-hidden="true" style="display: none;" class="icon" xmlns="http://www.w3.org/2000/svg">
+    <symbol xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="icon-fullscreen">
+		<path d="M3 7V5a2 2 0 0 1 2-2h2" />  <path d="M17 3h2a2 2 0 0 1 2 2v2" />  <path d="M21 17v2a2 2 0 0 1-2 2h-2" />  <path d="M7 21H5a2 2 0 0 1-2-2v-2" />  <rect width="10" height="8" x="7" y="8" rx="1" />
+	</symbol>
+
+	<symbol xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="icon-maximize">
+		<path d="M8 3H5a2 2 0 0 0-2 2v3" />  <path d="M21 8V5a2 2 0 0 0-2-2h-3" />  <path d="M3 16v3a2 2 0 0 0 2 2h3" />  <path d="M16 21h3a2 2 0 0 0 2-2v-3" />
+	</symbol>
+
+	<symbol xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" id="icon-minimize">
+		<path d="M8 3v3a2 2 0 0 1-2 2H3" />  <path d="M21 8h-3a2 2 0 0 1-2-2V3" />  <path d="M3 16h3a2 2 0 0 1 2 2v3" />  <path d="M16 21v-3a2 2 0 0 1 2-2h3" />
+	</symbol>
+</svg>

--- a/erpnext/public/scss/point-of-sale.scss
+++ b/erpnext/public/scss/point-of-sale.scss
@@ -579,7 +579,11 @@
 							align-items: center;
 							justify-content: center;
 							padding: var(--padding-md);
-							box-shadow: var(--shadow-sm);
+							box-shadow: var(--shadow-base);
+
+							&:hover {
+								background-color: var(--control-bg);
+							}
 						}
 
 						> .col-span-2 {
@@ -915,6 +919,10 @@
 								justify-content: center;
 								padding: var(--padding-md);
 								box-shadow: var(--shadow-base);
+
+								&:hover {
+									background-color: var(--control-bg);
+								}
 							}
 						}
 					}

--- a/erpnext/public/scss/point-of-sale.scss
+++ b/erpnext/public/scss/point-of-sale.scss
@@ -619,26 +619,30 @@
 			background-color: var(--control-bg);
 		}
 
-		> .invoice-name-date {
+		&.invoice-selected {
+			background-color: var(--control-bg);
+		}
+
+		> .invoice-name-customer {
 			display: flex;
 			flex-direction: column;
 			justify-content: space-around;
 
-			> .invoice-name {
+			> .invoice-customer {
 				@extend .nowrap;
 				font-size: var(--text-md);
+				display: flex;
+				align-items: center;
 				font-weight: 700;
 			}
 
-			> .invoice-date {
+			> .invoice-name {
 				@extend .nowrap;
 				font-size: var(--text-sm);
-				display: flex;
-				align-items: center;
 			}
 		}
 
-		> .invoice-total-status {
+		> .invoice-total-date {
 			display: flex;
 			flex-direction: column;
 			font-weight: 500;
@@ -652,10 +656,12 @@
 				text-align: right;
 			}
 
-			> .invoice-status {
+			> .invoice-date {
 				display: flex;
 				align-items: center;
+				color: var(--gray-500);
 				justify-content: right;
+				font-weight: 400;
 			}
 		}
 	}
@@ -986,18 +992,23 @@
 			background-color: var(--fg-color);
 			padding: var(--padding-lg);
 
-			> .search-field {
-				width: 100%;
-				display: flex;
-				align-items: center;
+			> .status-search-fields {
+				display: grid;
+				grid-template-columns: 30% auto;
+				column-gap: 10px;
 				margin-top: var(--margin-md);
-				margin-bottom: var(--margin-xs);
-			}
 
-			> .status-field {
-				width: 100%;
-				display: flex;
-				align-items: center;
+				> .status-field {
+					width: 100%;
+					display: flex;
+					align-items: center;
+				}
+
+				> .search-field {
+					width: 100%;
+					display: flex;
+					align-items: center;
+				}
 			}
 		}
 

--- a/erpnext/public/scss/point-of-sale.scss
+++ b/erpnext/public/scss/point-of-sale.scss
@@ -658,7 +658,7 @@
 
 	> .item-details-container {
 		@extend .pos-card;
-		grid-column: span 4 / span 4;
+		grid-column: span 6 / span 6;
 		display: none;
 		flex-direction: column;
 		padding: var(--padding-lg);

--- a/erpnext/selling/page/point_of_sale/pos_controller.js
+++ b/erpnext/selling/page/point_of_sale/pos_controller.js
@@ -378,7 +378,7 @@ erpnext.PointOfSale.Controller = class {
 				get_frm: () => this.frm,
 
 				toggle_item_selector: (minimize) => {
-					this.item_selector.resize_selector(minimize);
+					this.item_selector.toggle_component(!minimize);
 					this.cart.toggle_numpad(minimize);
 				},
 

--- a/erpnext/selling/page/point_of_sale/pos_controller.js
+++ b/erpnext/selling/page/point_of_sale/pos_controller.js
@@ -299,7 +299,7 @@ erpnext.PointOfSale.Controller = class {
 					}
 				);
 				return;
-			} else if (this.settings.action_on_new_invoice === "Save changes and Load New Invoice") {
+			} else if (this.settings.action_on_new_invoice === "Save Changes and Load New Invoice") {
 				this.frm.save().then(me.load_new_invoice_on_pos.bind(me));
 				return;
 			}

--- a/erpnext/selling/page/point_of_sale/pos_controller.js
+++ b/erpnext/selling/page/point_of_sale/pos_controller.js
@@ -240,31 +240,36 @@ erpnext.PointOfSale.Controller = class {
 
 	prepare_btns() {
 		this.page.clear_custom_actions();
+		this.page.clear_icons();
 		this.page.set_primary_action(__("New Invoice"), this.new_invoice_event.bind(this));
 		this.page.set_secondary_action(__("Recent Orders"), this.toggle_recent_order.bind(this));
-		this.page.add_button("", this.bind_fullscreen_events.bind(this), {
-			btn_class: "btn-default btn-fullscreen",
-		});
-		this.update_tooltip_btn_fullscreen("fullscreen");
+		this.page.add_action_icon(
+			"fullscreen",
+			this.bind_fullscreen_events.bind(this),
+			"btn-fullscreen",
+			"Fullscreen"
+		);
+		this.page.add_action_icon(
+			"minimize",
+			this.bind_fullscreen_events.bind(this),
+			"btn-minimize hide",
+			"Minimize"
+		);
 	}
 
 	bind_fullscreen_events() {
 		if (!document.fullscreenElement) {
 			document.documentElement.requestFullscreen();
-			this.update_tooltip_btn_fullscreen("minimize");
+			this.toggle_fullscreen_btn(".btn-minimize", ".btn-fullscreen");
 		} else if (document.exitFullscreen) {
 			document.exitFullscreen();
-			this.update_tooltip_btn_fullscreen("fullscreen");
+			this.toggle_fullscreen_btn(".btn-fullscreen", ".btn-minimize");
 		}
 	}
 
-	update_tooltip_btn_fullscreen(label) {
-		const btn_fullscreen = this.page.page_actions.find(".btn-fullscreen");
-		btn_fullscreen.get(0).innerHTML = frappe.utils.icon(label);
-		if (!btn_fullscreen.attr("data-original-title")) {
-			btn_fullscreen.attr("title", "").tooltip({ delay: { show: 600, hide: 100 } });
-		}
-		btn_fullscreen.attr("data-original-title", __(label[0].toUpperCase() + label.substring(1)));
+	toggle_fullscreen_btn(show, hide) {
+		this.page.page_actions.find(hide).addClass("hide");
+		this.page.page_actions.find(show).removeClass("hide");
 	}
 
 	open_form_view() {

--- a/erpnext/selling/page/point_of_sale/pos_controller.js
+++ b/erpnext/selling/page/point_of_sale/pos_controller.js
@@ -317,8 +317,8 @@ erpnext.PointOfSale.Controller = class {
 		frappe.run_serially([
 			() => frappe.dom.freeze(),
 			() => this.make_new_invoice(),
-			() => this.payment.toggle_component(false),
-			() => this.item_selector.toggle_component(true),
+			() => this.toggle_recent_order_list(false),
+			() => this.toggle_components(true),
 			() => frappe.dom.unfreeze(),
 		]);
 	}
@@ -470,8 +470,7 @@ erpnext.PointOfSale.Controller = class {
 				submit_invoice: () => {
 					this.frm.savesubmit().then((r) => {
 						this.toggle_components(false);
-						this.order_summary.toggle_component(true);
-						this.order_summary.load_summary_of(this.frm.doc, true);
+						this.toggle_submitted_invoice_summary(true);
 						frappe.show_alert({
 							indicator: "green",
 							message: __("POS invoice {0} created successfully", [r.doc.name]),
@@ -552,17 +551,27 @@ erpnext.PointOfSale.Controller = class {
 	}
 
 	toggle_recent_order_list(show) {
-		this.toggle_components(!show);
+		this.frm.doc.docstatus === 1
+			? this.toggle_submitted_invoice_summary(!show)
+			: this.toggle_components(!show);
+
 		this.recent_order_list.toggle_component(show);
-		this.order_summary.toggle_component(show);
+		if (this.frm.doc.docstatus === 0) this.order_summary.toggle_component(show);
 	}
 
 	toggle_components(show) {
 		this.cart.toggle_component(show);
+		this.cart.toggle_numpad(!show);
+		this.cart.toggle_checkout_btn(show);
 		this.item_selector.toggle_component(show);
 
 		// do not show item details or payment if recent order is toggled off
 		!show ? this.item_details.toggle_component(false) || this.payment.toggle_component(false) : "";
+	}
+
+	toggle_submitted_invoice_summary(show) {
+		this.order_summary.toggle_component(show);
+		this.order_summary.load_summary_of(this.frm.doc, true);
 	}
 
 	make_new_invoice() {

--- a/erpnext/selling/page/point_of_sale/pos_controller.js
+++ b/erpnext/selling/page/point_of_sale/pos_controller.js
@@ -240,42 +240,31 @@ erpnext.PointOfSale.Controller = class {
 
 	prepare_btns() {
 		this.page.clear_custom_actions();
-		this.prepare_fullscreen_btn();
 		this.page.set_primary_action(__("New Invoice"), this.new_invoice_event.bind(this));
-		this.page.add_button(__("Recent Orders"), this.toggle_recent_order.bind(this), {
-			btn_class: "btn-default recent-order-btn",
+		this.page.set_secondary_action(__("Recent Orders"), this.toggle_recent_order.bind(this));
+		this.page.add_button("", this.bind_fullscreen_events.bind(this), {
+			btn_class: "btn-default btn-fullscreen",
 		});
-	}
-
-	prepare_fullscreen_btn() {
-		this.page.add_button(__("Full Screen"), null, { btn_class: "btn-default fullscreen-btn" });
-
-		this.bind_fullscreen_events();
+		this.update_tooltip_btn_fullscreen("fullscreen");
 	}
 
 	bind_fullscreen_events() {
-		this.$fullscreen_btn = this.page.page_actions.find(".fullscreen-btn");
-
-		this.$fullscreen_btn.on("click", function () {
-			if (!document.fullscreenElement) {
-				document.documentElement.requestFullscreen();
-			} else if (document.exitFullscreen) {
-				document.exitFullscreen();
-			}
-		});
-
-		$(document).on("fullscreenchange", this.handle_fullscreen_change_event.bind(this));
+		if (!document.fullscreenElement) {
+			document.documentElement.requestFullscreen();
+			this.update_tooltip_btn_fullscreen("minimize");
+		} else if (document.exitFullscreen) {
+			document.exitFullscreen();
+			this.update_tooltip_btn_fullscreen("fullscreen");
+		}
 	}
 
-	handle_fullscreen_change_event() {
-		let enable_fullscreen_label = __("Full Screen");
-		let exit_fullscreen_label = __("Exit Full Screen");
-
-		if (document.fullscreenElement) {
-			this.$fullscreen_btn[0].innerText = exit_fullscreen_label;
-		} else {
-			this.$fullscreen_btn[0].innerText = enable_fullscreen_label;
+	update_tooltip_btn_fullscreen(label) {
+		const btn_fullscreen = this.page.page_actions.find(".btn-fullscreen");
+		btn_fullscreen.get(0).innerHTML = frappe.utils.icon(label);
+		if (!btn_fullscreen.attr("data-original-title")) {
+			btn_fullscreen.attr("title", "").tooltip({ delay: { show: 600, hide: 100 } });
 		}
+		btn_fullscreen.attr("data-original-title", __(label[0].toUpperCase() + label.substring(1)));
 	}
 
 	open_form_view() {
@@ -285,8 +274,7 @@ erpnext.PointOfSale.Controller = class {
 
 	toggle_recent_order() {
 		const show = this.recent_order_list.$component.is(":hidden");
-		const recent_order_btn = this.page.page_actions.find(".recent-order-btn");
-		recent_order_btn.get(0).innerText = show ? __("Hide Recent Orders") : __("Recent Orders");
+		this.page.btn_secondary.get(0).innerText = show ? __("Hide Recent Orders") : __("Recent Orders");
 		this.toggle_recent_order_list(show);
 	}
 

--- a/erpnext/selling/page/point_of_sale/pos_item_cart.js
+++ b/erpnext/selling/page/point_of_sale/pos_item_cart.js
@@ -171,8 +171,11 @@ erpnext.PointOfSale.ItemCart = class {
 
 			me.toggle_item_highlight(this);
 
-			const scrollTop = $cart_item.offset().top - me.$cart_items_wrapper.offset().top;
-			me.$cart_items_wrapper.animate({ scrollTop });
+			const numpad_section_hidden = !me.$numpad_section.is(":visible");
+			if (numpad_section_hidden) {
+				const scrollTop = $cart_item.offset().top - me.$cart_items_wrapper.offset().top;
+				me.$cart_items_wrapper.animate({ scrollTop });
+			}
 
 			const payment_section_hidden = !me.$totals_section.find(".edit-cart-btn").is(":visible");
 			if (!payment_section_hidden) {

--- a/erpnext/selling/page/point_of_sale/pos_item_selector.js
+++ b/erpnext/selling/page/point_of_sale/pos_item_selector.js
@@ -188,7 +188,7 @@ erpnext.PointOfSale.ItemSelector = class {
 
 	attach_clear_btn() {
 		this.search_field.$wrapper.find(".control-input").append(
-			`<span class="link-btn" style="top: 2px;">
+			`<span class="link-btn">
 				<a class="btn-open no-decoration" title="${__("Clear")}">
 					${frappe.utils.icon("close", "sm")}
 				</a>

--- a/erpnext/selling/page/point_of_sale/pos_past_order_list.js
+++ b/erpnext/selling/page/point_of_sale/pos_past_order_list.js
@@ -17,8 +17,10 @@ erpnext.PointOfSale.PastOrderList = class {
 			`<section class="past-order-list">
 				<div class="filter-section">
 					<div class="label">${__("Recent Orders")}</div>
-					<div class="search-field"></div>
-					<div class="status-field"></div>
+					<div class="status-search-fields">
+						<div class="status-field"></div>
+						<div class="search-field"></div>
+					</div>
 				</div>
 				<div class="invoices-container"></div>
 			</section>`
@@ -38,8 +40,12 @@ erpnext.PointOfSale.PastOrderList = class {
 		});
 		const me = this;
 		this.$invoices_container.on("click", ".invoice-wrapper", function () {
-			const invoice_doctype = $(this).attr("data-invoice-doctype");
-			const invoice_name = unescape($(this).attr("data-invoice-name"));
+			const invoice_clicked = $(this);
+			const invoice_doctype = invoice_clicked.attr("data-invoice-doctype");
+			const invoice_name = unescape(invoice_clicked.attr("data-invoice-name"));
+
+			$(".invoice-wrapper").removeClass("invoice-selected");
+			invoice_clicked.addClass("invoice-selected");
 
 			me.events.open_invoice_data(invoice_doctype, invoice_name);
 		});
@@ -103,16 +109,16 @@ erpnext.PointOfSale.PastOrderList = class {
 		return `<div class="invoice-wrapper" data-invoice-doctype="${
 			invoice.doctype
 		}" data-invoice-name="${escape(invoice.name)}">
-				<div class="invoice-name-date">
-					<div class="invoice-name">${invoice.name}</div>
-					<div class="invoice-date">
+				<div class="invoice-name-customer">
+					<div class="invoice-customer">
 						<svg class="mr-2" width="12" height="12" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1" stroke-linecap="round" stroke-linejoin="round">
 							<path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/>
 						</svg>
 						${frappe.ellipsis(invoice.customer, 20)}
 					</div>
+					<div class="invoice-name">${invoice.name}</div>
 				</div>
-				<div class="invoice-total-status">
+				<div class="invoice-total-date">
 					<div class="invoice-total">${format_currency(invoice.grand_total, invoice.currency) || 0}</div>
 					<div class="invoice-date">${posting_datetime}</div>
 				</div>

--- a/erpnext/selling/page/point_of_sale/pos_past_order_summary.js
+++ b/erpnext/selling/page/point_of_sale/pos_past_order_summary.js
@@ -459,6 +459,7 @@ erpnext.PointOfSale.PastOrderSummary = class {
 	}
 
 	toggle_component(show) {
+		this.$component.css("grid-column", "span 6 / span 6");
 		show ? this.$component.css("display", "flex") : this.$component.css("display", "none");
 	}
 


### PR DESCRIPTION
Changes include:

- Trigger the submission of the invoice when clicking the 'Save' button after filling out the mandatory fields in the Additional Information Dialog. This eliminates the need for an additional 'Complete Order' click.
Demo: 

https://github.com/user-attachments/assets/57064d52-d03f-4de9-bd86-7d4a11f7b23a

- Moved the Menu Items to Action buttons.

Before: 
![pos-menu](https://github.com/user-attachments/assets/ab50f5e5-8ba2-471d-a559-3e4d05d15922)

After:
![pos-action-buttons](https://github.com/user-attachments/assets/ea7f9e90-57ab-4113-a0ae-c2456e2f35f3)

- Replaced text buttons for Fullscreen and Minimize Screen with Icon buttons.

<img src="https://github.com/user-attachments/assets/bbc801a3-fc58-428f-bbb1-cc3e172710ae" width="100px">

<img src="https://github.com/user-attachments/assets/a71f19ad-8ba4-4488-bcd5-885d17a1b220" width="100px">

- Replaced 'Save as Draft' menu Item with 'New Invoice' button. On clicking 'New Invoice', POS will load a new Invoice. If some items are added to the cart, POS will ask for confirmation to save or discard the changes. 

![image](https://github.com/user-attachments/assets/99c8e328-88fb-4c93-9ee0-7923f9f0fd0e)

Users can configure to always save or discard changes to an invoice before loading a new one from the POS Profile.

![image](https://github.com/user-attachments/assets/02445612-c88f-4f88-a189-04aaa20188c2)

- Hide Item Selector Panel if Items Display is visible.

Before:
![image](https://github.com/user-attachments/assets/26555e52-0bcb-4307-bb0d-43c258d77c3a)

After:
![image](https://github.com/user-attachments/assets/824a2e74-33e7-4d47-87fb-201531ce3bea)

- Added hovering effect on the Numpad

https://github.com/user-attachments/assets/f8622915-d9c2-44a8-a0eb-65f00ece23e6

- Rearranged the filter fields in the same row on Recent Order
 
![image](https://github.com/user-attachments/assets/578f8db6-1fab-4ee5-b412-22897accde16)
	
- Rearranged the Invoice Name and Customer Name on Order List Items on Recent Order
 
![image](https://github.com/user-attachments/assets/9d68284e-f3e9-401b-b543-614b387d1790)

- Fixed the issue with Recent Order toggling after invoice submission. Earlier, it used to open up the Item Selector and Item cart instead of the Summary of the Invoice
- If the user clicks New Invoice when the Recent Order List is toggled on, POS will toggle off the Recent Order List and open the Item Selector and Item Cart.
