### PR TITLE
fix: incorrect valuation rate due to positive qty

### DIFF
--- a/erpnext/assets/doctype/asset_capitalization/asset_capitalization.js
+++ b/erpnext/assets/doctype/asset_capitalization/asset_capitalization.js
@@ -402,7 +402,7 @@ erpnext.assets.AssetCapitalization = class AssetCapitalization extends erpnext.s
 					args: {
 						item_code: item.item_code,
 						warehouse: cstr(item.warehouse),
-						qty: flt(item.stock_qty),
+						qty: -1 * flt(item.stock_qty),
 						serial_no: item.serial_no,
 						posting_date: me.frm.doc.posting_date,
 						posting_time: me.frm.doc.posting_time,


### PR DESCRIPTION
In the get_warehouse_details call within the Asset Capitalization doctype's client script, the quantity was being passed as a positive value using qty: flt(item.stock_qty). This caused an issue where incoming rates were fetched incorrectly.

**Before**

https://github.com/user-attachments/assets/cbad27f6-61fc-4e28-84eb-9bbc910fe2a0

**After**

https://github.com/user-attachments/assets/4c0a889b-4f04-426f-9959-a9c1831c2b58

