### PR TITLE
fix: skip last purchase rate for free item

### DIFF
--- a/erpnext/buying/utils.py
+++ b/erpnext/buying/utils.py
@@ -20,6 +20,9 @@ def update_last_purchase_rate(doc, is_submit) -> None:
 	this_purchase_date = getdate(doc.get("posting_date") or doc.get("transaction_date"))
 
 	for d in doc.get("items"):
+		if d.get("is_free_item"):
+			continue
+
 		# get last purchase details
 		last_purchase_details = get_last_purchase_details(d.item_code, doc.name)
 


### PR DESCRIPTION
**Issue**

- Create pricing rule for free item
- Create the purchase order, system will add free item with zero cost
- On submission of the purchase order, system update the last purchase rate as zero for the free item