### PR TITLE
refactor: renamed gross purchase amount to net purchase amount

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
@@ -1220,7 +1220,7 @@ class PurchaseInvoice(BuyingController):
 						)
 
 			if item.is_fixed_asset and item.landed_cost_voucher_amount:
-				self.update_gross_purchase_amount_for_linked_assets(item)
+				self.update_net_purchase_amount_for_linked_assets(item)
 
 	def get_provisional_accounts(self):
 		self.provisional_accounts = frappe._dict()
@@ -1279,7 +1279,7 @@ class PurchaseInvoice(BuyingController):
 					),
 				)
 
-	def update_gross_purchase_amount_for_linked_assets(self, item):
+	def update_net_purchase_amount_for_linked_assets(self, item):
 		assets = frappe.db.get_all(
 			"Asset",
 			filters={
@@ -1295,7 +1295,7 @@ class PurchaseInvoice(BuyingController):
 				"Asset",
 				asset.name,
 				{
-					"gross_purchase_amount": purchase_amount,
+					"net_purchase_amount": purchase_amount,
 					"purchase_amount": purchase_amount,
 				},
 			)

--- a/erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.py
+++ b/erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.py
@@ -103,7 +103,7 @@ def get_data(filters):
 					"depreciation_amount": d.debit,
 					"depreciation_date": d.posting_date,
 					"value_after_depreciation": (
-						flt(row.gross_purchase_amount) - flt(row.accumulated_depreciation_amount)
+						flt(row.net_purchase_amount) - flt(row.accumulated_depreciation_amount)
 					),
 					"depreciation_entry": d.voucher_no,
 				}
@@ -119,7 +119,7 @@ def get_assets_details(assets):
 
 	fields = [
 		"name as asset",
-		"gross_purchase_amount",
+		"net_purchase_amount",
 		"opening_accumulated_depreciation",
 		"asset_category",
 		"status",
@@ -151,7 +151,7 @@ def get_columns():
 		},
 		{
 			"label": _("Purchase Amount"),
-			"fieldname": "gross_purchase_amount",
+			"fieldname": "net_purchase_amount",
 			"fieldtype": "Currency",
 			"width": 120,
 		},

--- a/erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py
+++ b/erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py
@@ -79,7 +79,7 @@ def get_asset_categories_for_grouped_by_category(filters):
 		SELECT a.asset_category,
 			   ifnull(sum(case when a.purchase_date < %(from_date)s then
 							   case when ifnull(a.disposal_date, 0) = 0 or a.disposal_date >= %(from_date)s then
-									a.gross_purchase_amount
+									a.net_purchase_amount
 							   else
 									0
 							   end
@@ -87,7 +87,7 @@ def get_asset_categories_for_grouped_by_category(filters):
 								0
 						   end), 0) as value_as_on_from_date,
 			   ifnull(sum(case when a.purchase_date >= %(from_date)s then
-			   						a.gross_purchase_amount
+			   						a.net_purchase_amount
 			   				   else
 			   				   		0
 			   				   end), 0) as value_of_new_purchase,
@@ -95,7 +95,7 @@ def get_asset_categories_for_grouped_by_category(filters):
 			   						and a.disposal_date >= %(from_date)s
 			   						and a.disposal_date <= %(to_date)s then
 							   case when a.status = "Sold" then
-							   		a.gross_purchase_amount
+							   		a.net_purchase_amount
 							   else
 							   		0
 							   end
@@ -106,7 +106,7 @@ def get_asset_categories_for_grouped_by_category(filters):
 			   						and a.disposal_date >= %(from_date)s
 			   						and a.disposal_date <= %(to_date)s then
 							   case when a.status = "Scrapped" then
-							   		a.gross_purchase_amount
+							   		a.net_purchase_amount
 							   else
 							   		0
 							   end
@@ -117,7 +117,7 @@ def get_asset_categories_for_grouped_by_category(filters):
 			   						and a.disposal_date >= %(from_date)s
 			   						and a.disposal_date <= %(to_date)s then
 							   case when a.status = "Capitalized" then
-							   		a.gross_purchase_amount
+							   		a.net_purchase_amount
 							   else
 							   		0
 							   end
@@ -282,7 +282,7 @@ def get_asset_details_for_grouped_by_category(filters):
 		SELECT a.name,
 			   ifnull(sum(case when a.purchase_date < %(from_date)s then
 							   case when ifnull(a.disposal_date, 0) = 0 or a.disposal_date >= %(from_date)s then
-									a.gross_purchase_amount
+									a.net_purchase_amount
 							   else
 									0
 							   end
@@ -290,7 +290,7 @@ def get_asset_details_for_grouped_by_category(filters):
 								0
 						   end), 0) as value_as_on_from_date,
 			   ifnull(sum(case when a.purchase_date >= %(from_date)s then
-			   						a.gross_purchase_amount
+			   						a.net_purchase_amount
 			   				   else
 			   				   		0
 			   				   end), 0) as value_of_new_purchase,
@@ -298,7 +298,7 @@ def get_asset_details_for_grouped_by_category(filters):
 			   						and a.disposal_date >= %(from_date)s
 			   						and a.disposal_date <= %(to_date)s then
 							   case when a.status = "Sold" then
-							   		a.gross_purchase_amount
+							   		a.net_purchase_amount
 							   else
 							   		0
 							   end
@@ -309,7 +309,7 @@ def get_asset_details_for_grouped_by_category(filters):
 			   						and a.disposal_date >= %(from_date)s
 			   						and a.disposal_date <= %(to_date)s then
 							   case when a.status = "Scrapped" then
-							   		a.gross_purchase_amount
+							   		a.net_purchase_amount
 							   else
 							   		0
 							   end
@@ -320,7 +320,7 @@ def get_asset_details_for_grouped_by_category(filters):
 			   						and a.disposal_date >= %(from_date)s
 			   						and a.disposal_date <= %(to_date)s then
 							   case when a.status = "Capitalized" then
-							   		a.gross_purchase_amount
+							   		a.net_purchase_amount
 							   else
 							   		0
 							   end

--- a/erpnext/assets/doctype/asset/asset.json
+++ b/erpnext/assets/doctype/asset/asset.json
@@ -31,7 +31,7 @@
   "purchase_date",
   "available_for_use_date",
   "column_break_23",
-  "gross_purchase_amount",
+  "net_purchase_amount",
   "purchase_amount",
   "asset_quantity",
   "additional_asset_cost",
@@ -225,13 +225,6 @@
    "options": "Journal Entry",
    "print_hide": 1,
    "read_only": 1
-  },
-  {
-   "fieldname": "gross_purchase_amount",
-   "fieldtype": "Currency",
-   "label": "Net Purchase Amount",
-   "mandatory_depends_on": "eval:(!doc.is_composite_asset || doc.docstatus==1)",
-   "options": "Company:company:default_currency"
   },
   {
    "fieldname": "available_for_use_date",
@@ -558,6 +551,13 @@
    "fieldname": "is_composite_component",
    "fieldtype": "Check",
    "label": "Is Composite Component"
+  },
+  {
+   "fieldname": "net_purchase_amount",
+   "fieldtype": "Currency",
+   "label": "Net Purchase Amount",
+   "mandatory_depends_on": "eval:(!doc.is_composite_asset || doc.docstatus==1)",
+   "options": "Company:company:default_currency"
   }
  ],
  "idx": 72,
@@ -601,7 +601,7 @@
    "link_fieldname": "target_asset"
   }
  ],
- "modified": "2025-05-20 13:44:06.229177",
+ "modified": "2025-05-23 00:53:54.249309",
  "modified_by": "Administrator",
  "module": "Assets",
  "name": "Asset",

--- a/erpnext/assets/doctype/asset/asset.json
+++ b/erpnext/assets/doctype/asset/asset.json
@@ -237,7 +237,7 @@
    "fieldname": "calculate_depreciation",
    "fieldtype": "Check",
    "label": "Calculate Depreciation",
-   "read_only_depends_on": "eval:(doc.is_composite_asset && !doc.gross_purchase_amount) || doc.is_composite_component"
+   "read_only_depends_on": "eval:(doc.is_composite_asset && !doc.net_purchase_amount) || doc.is_composite_component"
   },
   {
    "default": "0",

--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -70,7 +70,6 @@ class Asset(AccountsController):
 		disposal_date: DF.Date | None
 		finance_books: DF.Table[AssetFinanceBook]
 		frequency_of_depreciation: DF.Int
-		gross_purchase_amount: DF.Currency
 		image: DF.AttachImage | None
 		insurance_end_date: DF.Date | None
 		insurance_start_date: DF.Date | None
@@ -86,6 +85,7 @@ class Asset(AccountsController):
 		location: DF.Link
 		maintenance_required: DF.Check
 		naming_series: DF.Literal["ACC-ASS-.YYYY.-"]
+		net_purchase_amount: DF.Currency
 		next_depreciation_date: DF.Date | None
 		opening_accumulated_depreciation: DF.Currency
 		opening_number_of_booked_depreciations: DF.Int

--- a/erpnext/assets/doctype/asset/depreciation.py
+++ b/erpnext/assets/doctype/asset/depreciation.py
@@ -589,8 +589,8 @@ def get_gl_entries_on_asset_regain(
 		asset.get_gl_dict(
 			{
 				"account": fixed_asset_account,
-				"debit_in_account_currency": asset.gross_purchase_amount,
-				"debit": asset.gross_purchase_amount,
+				"debit_in_account_currency": asset.net_purchase_amount,
+				"debit": asset.net_purchase_amount,
 				"cost_center": depreciation_cost_center,
 				"posting_date": date,
 			},
@@ -642,8 +642,8 @@ def get_gl_entries_on_asset_disposal(
 		asset.get_gl_dict(
 			{
 				"account": fixed_asset_account,
-				"credit_in_account_currency": asset.gross_purchase_amount,
-				"credit": asset.gross_purchase_amount,
+				"credit_in_account_currency": asset.net_purchase_amount,
+				"credit": asset.net_purchase_amount,
 				"cost_center": depreciation_cost_center,
 				"posting_date": date,
 			},
@@ -681,7 +681,7 @@ def get_gl_entries_on_asset_disposal(
 
 def get_asset_details(asset, finance_book=None):
 	value_after_depreciation = asset.get_value_after_depreciation(finance_book)
-	accumulated_depr_amount = flt(asset.gross_purchase_amount) - flt(value_after_depreciation)
+	accumulated_depr_amount = flt(asset.net_purchase_amount) - flt(value_after_depreciation)
 
 	fixed_asset_account, accumulated_depr_account, _ = get_depreciation_accounts(
 		asset.asset_category, asset.company
@@ -792,7 +792,7 @@ def get_value_after_depreciation_on_disposal_date(asset, disposal_date, finance_
 	validate_disposal_date(asset_doc.available_for_use_date, getdate(disposal_date), "available for use")
 
 	if asset_doc.available_for_use_date == getdate(disposal_date):
-		return flt(asset_doc.gross_purchase_amount - asset_doc.opening_accumulated_depreciation)
+		return flt(asset_doc.net_purchase_amount - asset_doc.opening_accumulated_depreciation)
 
 	if not asset_doc.calculate_depreciation:
 		return flt(asset_doc.value_after_depreciation)
@@ -813,8 +813,8 @@ def get_value_after_depreciation_on_disposal_date(asset, disposal_date, finance_
 	].accumulated_depreciation_amount
 
 	return flt(
-		flt(asset_doc.gross_purchase_amount) - accumulated_depr_amount,
-		asset_doc.precision("gross_purchase_amount"),
+		flt(asset_doc.net_purchase_amount) - accumulated_depr_amount,
+		asset_doc.precision("net_purchase_amount"),
 	)
 
 

--- a/erpnext/assets/doctype/asset_capitalization/asset_capitalization.py
+++ b/erpnext/assets/doctype/asset_capitalization/asset_capitalization.py
@@ -572,7 +572,7 @@ class AssetCapitalization(StockController):
 		asset_doc.location = self.target_asset_location
 		asset_doc.available_for_use_date = self.posting_date
 		asset_doc.purchase_date = self.posting_date
-		asset_doc.gross_purchase_amount = total_target_asset_value
+		asset_doc.net_purchase_amount = total_target_asset_value
 		asset_doc.purchase_amount = total_target_asset_value
 		asset_doc.flags.ignore_validate = True
 		asset_doc.flags.asset_created_via_asset_capitalization = True
@@ -606,14 +606,14 @@ class AssetCapitalization(StockController):
 		asset_doc = frappe.get_doc("Asset", self.target_asset)
 
 		if self.docstatus == 2:
-			gross_purchase_amount = asset_doc.gross_purchase_amount - total_target_asset_value
+			net_purchase_amount = asset_doc.net_purchase_amount - total_target_asset_value
 			purchase_amount = asset_doc.purchase_amount - total_target_asset_value
 			asset_doc.db_set("total_asset_cost", asset_doc.total_asset_cost - total_target_asset_value)
 		else:
-			gross_purchase_amount = asset_doc.gross_purchase_amount + total_target_asset_value
+			net_purchase_amount = asset_doc.net_purchase_amount + total_target_asset_value
 			purchase_amount = asset_doc.purchase_amount + total_target_asset_value
 
-		asset_doc.db_set("gross_purchase_amount", gross_purchase_amount)
+		asset_doc.db_set("net_purchase_amount", net_purchase_amount)
 		asset_doc.db_set("purchase_amount", purchase_amount)
 
 		frappe.msgprint(

--- a/erpnext/assets/doctype/asset_capitalization/test_asset_capitalization.py
+++ b/erpnext/assets/doctype/asset_capitalization/test_asset_capitalization.py
@@ -92,7 +92,7 @@ class TestAssetCapitalization(IntegrationTestCase):
 
 		# Test Target Asset values
 		target_asset = frappe.get_doc("Asset", asset_capitalization.target_asset)
-		self.assertEqual(target_asset.gross_purchase_amount, total_amount)
+		self.assertEqual(target_asset.net_purchase_amount, total_amount)
 		self.assertEqual(target_asset.purchase_amount, total_amount)
 		self.assertEqual(target_asset.status, "Work In Progress")
 
@@ -181,7 +181,7 @@ class TestAssetCapitalization(IntegrationTestCase):
 
 		# Test Target Asset values
 		target_asset = frappe.get_doc("Asset", asset_capitalization.target_asset)
-		self.assertEqual(target_asset.gross_purchase_amount, total_amount)
+		self.assertEqual(target_asset.net_purchase_amount, total_amount)
 		self.assertEqual(target_asset.purchase_amount, total_amount)
 
 		# Test Consumed Asset values
@@ -263,7 +263,7 @@ class TestAssetCapitalization(IntegrationTestCase):
 
 		# Test Target Asset values
 		target_asset = frappe.get_doc("Asset", asset_capitalization.target_asset)
-		self.assertEqual(target_asset.gross_purchase_amount, total_amount)
+		self.assertEqual(target_asset.net_purchase_amount, total_amount)
 		self.assertEqual(target_asset.purchase_amount, total_amount)
 		self.assertEqual(target_asset.status, "Work In Progress")
 
@@ -324,7 +324,7 @@ class TestAssetCapitalization(IntegrationTestCase):
 		self.assertEqual(asset_capitalization.service_items_total, service_amount)
 
 		target_asset = frappe.get_doc("Asset", asset_capitalization.target_asset)
-		self.assertEqual(target_asset.gross_purchase_amount, total_amount)
+		self.assertEqual(target_asset.net_purchase_amount, total_amount)
 		self.assertEqual(target_asset.purchase_amount, total_amount)
 
 		expected_gle = {
@@ -476,8 +476,8 @@ def create_depreciation_asset(**args):
 	asset.purchase_date = args.purchase_date or "2020-01-01"
 	asset.available_for_use_date = args.available_for_use_date or asset.purchase_date
 
-	asset.gross_purchase_amount = args.asset_value or 100000
-	asset.purchase_amount = asset.gross_purchase_amount
+	asset.net_purchase_amount = args.asset_value or 100000
+	asset.purchase_amount = asset.net_purchase_amount
 
 	finance_book = asset.append("finance_books")
 	finance_book.depreciation_start_date = args.depreciation_start_date or "2020-12-31"

--- a/erpnext/assets/doctype/asset_depreciation_schedule/asset_depreciation_schedule.json
+++ b/erpnext/assets/doctype/asset_depreciation_schedule/asset_depreciation_schedule.json
@@ -11,7 +11,7 @@
   "naming_series",
   "company",
   "column_break_2",
-  "gross_purchase_amount",
+  "net_purchase_amount",
   "opening_accumulated_depreciation",
   "opening_number_of_booked_depreciations",
   "finance_book",
@@ -164,15 +164,6 @@
    "read_only": 1
   },
   {
-   "fieldname": "gross_purchase_amount",
-   "fieldtype": "Currency",
-   "hidden": 1,
-   "label": "Gross Purchase Amount",
-   "options": "Company:company:default_currency",
-   "print_hide": 1,
-   "read_only": 1
-  },
-  {
    "fieldname": "opening_number_of_booked_depreciations",
    "fieldtype": "Int",
    "hidden": 1,
@@ -210,12 +201,21 @@
    "fieldtype": "Currency",
    "label": "Value After Depreciation",
    "read_only": 1
+  },
+  {
+   "fieldname": "net_purchase_amount",
+   "fieldtype": "Currency",
+   "hidden": 1,
+   "label": "Net Purchase Amount",
+   "options": "Company:company:default_currency",
+   "print_hide": 1,
+   "read_only": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-12-02 17:54:20.635668",
+ "modified": "2025-05-23 01:17:16.708004",
  "modified_by": "Administrator",
  "module": "Assets",
  "name": "Asset Depreciation Schedule",
@@ -252,6 +252,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": []

--- a/erpnext/assets/doctype/asset_depreciation_schedule/asset_depreciation_schedule.py
+++ b/erpnext/assets/doctype/asset_depreciation_schedule/asset_depreciation_schedule.py
@@ -39,8 +39,8 @@ class AssetDepreciationSchedule(DepreciationScheduleController):
 		finance_book: DF.Link | None
 		finance_book_id: DF.Int
 		frequency_of_depreciation: DF.Int
-		gross_purchase_amount: DF.Currency
 		naming_series: DF.Literal["ACC-ADS-.YYYY.-"]
+		net_purchase_amount: DF.Currency
 		notes: DF.SmallText | None
 		opening_accumulated_depreciation: DF.Currency
 		opening_number_of_booked_depreciations: DF.Int
@@ -126,7 +126,7 @@ class AssetDepreciationSchedule(DepreciationScheduleController):
 		self.opening_number_of_booked_depreciations = (
 			self.asset_doc.opening_number_of_booked_depreciations or 0
 		)
-		self.gross_purchase_amount = self.asset_doc.gross_purchase_amount
+		self.net_purchase_amount = self.asset_doc.net_purchase_amount
 		self.depreciation_method = self.fb_row.depreciation_method
 		self.total_number_of_depreciations = self.fb_row.total_number_of_depreciations
 		self.frequency_of_depreciation = self.fb_row.frequency_of_depreciation

--- a/erpnext/assets/doctype/asset_depreciation_schedule/deppreciation_schedule_controller.py
+++ b/erpnext/assets/doctype/asset_depreciation_schedule/deppreciation_schedule_controller.py
@@ -82,19 +82,19 @@ class DepreciationScheduleController(StraightLineMethod, WDVMethod):
 				self.set_depreciation_amount_for_last_row(row_idx)
 
 			self.depreciation_amount = flt(
-				self.depreciation_amount, self.asset_doc.precision("gross_purchase_amount")
+				self.depreciation_amount, self.asset_doc.precision("net_purchase_amount")
 			)
 			if not self.depreciation_amount:
 				break
 
 			self.pending_depreciation_amount = flt(
 				self.pending_depreciation_amount - self.depreciation_amount,
-				self.asset_doc.precision("gross_purchase_amount"),
+				self.asset_doc.precision("net_purchase_amount"),
 			)
 
 			self.adjust_depr_amount_for_salvage_value(row_idx)
 
-			if flt(self.depreciation_amount, self.asset_doc.precision("gross_purchase_amount")) > 0:
+			if flt(self.depreciation_amount, self.asset_doc.precision("net_purchase_amount")) > 0:
 				self.add_depr_schedule_row(row_idx)
 
 	def initialize_variables(self):
@@ -310,7 +310,7 @@ class DepreciationScheduleController(StraightLineMethod, WDVMethod):
 		)
 
 		self.depreciation_amount = flt(
-			self.depreciation_amount, self.asset_doc.precision("gross_purchase_amount")
+			self.depreciation_amount, self.asset_doc.precision("net_purchase_amount")
 		)
 		if self.depreciation_amount > 0:
 			self.schedule_date = self.disposal_date
@@ -383,10 +383,10 @@ class DepreciationScheduleController(StraightLineMethod, WDVMethod):
 		If gross purchase amount is too low, then depreciation amount
 		can come zero sometimes based on the frequency and number of depreciations.
 		"""
-		if flt(self.depreciation_amount, self.asset_doc.precision("gross_purchase_amount")) <= 0:
+		if flt(self.depreciation_amount, self.asset_doc.precision("net_purchase_amount")) <= 0:
 			frappe.throw(
 				_("Gross Purchase Amount {0} cannot be depreciated over {1} cycles.").format(
-					frappe.bold(self.asset_doc.gross_purchase_amount),
+					frappe.bold(self.asset_doc.net_purchase_amount),
 					frappe.bold(self.fb_row.total_number_of_depreciations),
 				)
 			)

--- a/erpnext/assets/doctype/asset_depreciation_schedule/test_asset_depreciation_schedule.py
+++ b/erpnext/assets/doctype/asset_depreciation_schedule/test_asset_depreciation_schedule.py
@@ -102,7 +102,7 @@ class TestAssetDepreciationSchedule(IntegrationTestCase):
 			depreciation_start_date="2024-07-31",
 			total_number_of_depreciations=24,
 			frequency_of_depreciation=1,
-			gross_purchase_amount=731,
+			net_purchase_amount=731,
 			daily_prorata_based=1,
 		)
 
@@ -142,7 +142,7 @@ class TestAssetDepreciationSchedule(IntegrationTestCase):
 			depreciation_start_date="2024-07-31",
 			total_number_of_depreciations=24,
 			frequency_of_depreciation=1,
-			gross_purchase_amount=731,
+			net_purchase_amount=731,
 		)
 
 		expected_schedules = [
@@ -180,7 +180,7 @@ class TestAssetDepreciationSchedule(IntegrationTestCase):
 			depreciation_start_date="2024-12-31",
 			total_number_of_depreciations=12,
 			frequency_of_depreciation=3,
-			gross_purchase_amount=731,
+			net_purchase_amount=731,
 		)
 
 		expected_schedules = [
@@ -208,7 +208,7 @@ class TestAssetDepreciationSchedule(IntegrationTestCase):
 			calculate_depreciation=1,
 			depreciation_method="Straight Line",
 			daily_prorata_based=1,
-			gross_purchase_amount=1096,
+			net_purchase_amount=1096,
 			available_for_use_date="2020-01-15",
 			depreciation_start_date="2020-01-31",
 			frequency_of_depreciation=1,
@@ -386,7 +386,7 @@ class TestAssetDepreciationSchedule(IntegrationTestCase):
 	def test_depreciation_schedule_after_cancelling_asset_repair(self):
 		asset = create_asset(
 			item_code="Macbook Pro",
-			gross_purchase_amount=500,
+			net_purchase_amount=500,
 			calculate_depreciation=1,
 			depreciation_method="Straight Line",
 			available_for_use_date="2023-01-01",
@@ -466,7 +466,7 @@ class TestAssetDepreciationSchedule(IntegrationTestCase):
 	def test_depreciation_schedule_after_cancelling_asset_repair_for_6_months_frequency(self):
 		asset = create_asset(
 			item_code="Macbook Pro",
-			gross_purchase_amount=500,
+			net_purchase_amount=500,
 			calculate_depreciation=1,
 			depreciation_method="Straight Line",
 			available_for_use_date="2023-01-01",
@@ -531,7 +531,7 @@ class TestAssetDepreciationSchedule(IntegrationTestCase):
 	def test_depreciation_schedule_after_cancelling_asset_repair_for_existing_asset(self):
 		asset = create_asset(
 			item_code="Macbook Pro",
-			gross_purchase_amount=500,
+			net_purchase_amount=500,
 			calculate_depreciation=1,
 			depreciation_method="Straight Line",
 			available_for_use_date="2023-01-15",
@@ -610,7 +610,7 @@ class TestAssetDepreciationSchedule(IntegrationTestCase):
 	def test_wdv_depreciation_schedule_after_cancelling_asset_repair(self):
 		asset = create_asset(
 			item_code="Macbook Pro",
-			gross_purchase_amount=500,
+			net_purchase_amount=500,
 			calculate_depreciation=1,
 			depreciation_method="Written Down Value",
 			available_for_use_date="2023-04-01",
@@ -671,7 +671,7 @@ class TestAssetDepreciationSchedule(IntegrationTestCase):
 	def test_daily_prorata_based_depreciation_schedule_after_cancelling_asset_repair_for(self):
 		asset = create_asset(
 			item_code="Macbook Pro",
-			gross_purchase_amount=500,
+			net_purchase_amount=500,
 			calculate_depreciation=1,
 			depreciation_method="Straight Line",
 			available_for_use_date="2023-01-01",
@@ -751,7 +751,7 @@ class TestAssetDepreciationSchedule(IntegrationTestCase):
 	def test_depreciation_schedule_after_cancelling_asset_value_adjustent(self):
 		asset = create_asset(
 			item_code="Macbook Pro",
-			gross_purchase_amount=1000,
+			net_purchase_amount=1000,
 			calculate_depreciation=1,
 			depreciation_method="Straight Line",
 			available_for_use_date="2023-01-01",
@@ -853,7 +853,7 @@ class TestAssetDepreciationSchedule(IntegrationTestCase):
 	def test_depreciation_schedule_after_cancelling_asset_value_adjustent_for_existing_asset(self):
 		asset = create_asset(
 			item_code="Macbook Pro",
-			gross_purchase_amount=500,
+			net_purchase_amount=500,
 			calculate_depreciation=1,
 			depreciation_method="Straight Line",
 			available_for_use_date="2023-01-15",
@@ -927,7 +927,7 @@ class TestAssetDepreciationSchedule(IntegrationTestCase):
 	def test_depreciation_schedule_for_parallel_adjustment_and_repair(self):
 		asset = create_asset(
 			item_code="Macbook Pro",
-			gross_purchase_amount=600,
+			net_purchase_amount=600,
 			calculate_depreciation=1,
 			depreciation_method="Straight Line",
 			available_for_use_date="2021-01-01",
@@ -1016,7 +1016,7 @@ class TestAssetDepreciationSchedule(IntegrationTestCase):
 	def test_depreciation_schedule_after_sale_of_asset(self):
 		asset = create_asset(
 			item_code="Macbook Pro",
-			gross_purchase_amount=600,
+			net_purchase_amount=600,
 			calculate_depreciation=1,
 			depreciation_method="Straight Line",
 			available_for_use_date="2021-01-01",
@@ -1094,7 +1094,7 @@ class TestAssetDepreciationSchedule(IntegrationTestCase):
 	def test_depreciation_schedule_after_sale_of_asset_wdv_method(self):
 		asset = create_asset(
 			item_code="Macbook Pro",
-			gross_purchase_amount=500,
+			net_purchase_amount=500,
 			calculate_depreciation=1,
 			depreciation_method="Written Down Value",
 			available_for_use_date="2021-01-01",

--- a/erpnext/assets/doctype/asset_shift_allocation/test_asset_shift_allocation.py
+++ b/erpnext/assets/doctype/asset_shift_allocation/test_asset_shift_allocation.py
@@ -35,7 +35,7 @@ class TestAssetShiftAllocation(IntegrationTestCase):
 			calculate_depreciation=1,
 			available_for_use_date="2023-01-01",
 			purchase_date="2023-01-01",
-			gross_purchase_amount=120000,
+			net_purchase_amount=120000,
 			depreciation_start_date="2023-01-31",
 			total_number_of_depreciations=12,
 			frequency_of_depreciation=1,

--- a/erpnext/assets/report/fixed_asset_register/fixed_asset_register.py
+++ b/erpnext/assets/report/fixed_asset_register/fixed_asset_register.py
@@ -113,7 +113,7 @@ def get_data(filters):
 		"purchase_receipt",
 		"asset_category",
 		"purchase_date",
-		"gross_purchase_amount",
+		"net_purchase_amount",
 		"location",
 		"available_for_use_date",
 		"purchase_invoice",
@@ -126,9 +126,7 @@ def get_data(filters):
 			continue
 
 		depreciation_amount = depreciation_amount_map.get(asset.asset_id) or 0.0
-		asset_value = (
-			asset.gross_purchase_amount - asset.opening_accumulated_depreciation - depreciation_amount
-		)
+		asset_value = asset.net_purchase_amount - asset.opening_accumulated_depreciation - depreciation_amount
 
 		row = {
 			"asset_id": asset.asset_id,
@@ -138,7 +136,7 @@ def get_data(filters):
 			"cost_center": asset.cost_center,
 			"vendor_name": pr_supplier_map.get(asset.purchase_receipt)
 			or pi_supplier_map.get(asset.purchase_invoice),
-			"gross_purchase_amount": asset.gross_purchase_amount,
+			"net_purchase_amount": asset.net_purchase_amount,
 			"opening_accumulated_depreciation": asset.opening_accumulated_depreciation,
 			"depreciated_amount": depreciation_amount,
 			"available_for_use_date": asset.available_for_use_date,
@@ -294,7 +292,7 @@ def get_group_by_data(group_by, conditions, assets_linked_to_fb, depreciation_am
 	fields = [
 		group_by,
 		"name",
-		"gross_purchase_amount",
+		"net_purchase_amount",
 		"opening_accumulated_depreciation",
 		"calculate_depreciation",
 	]
@@ -308,7 +306,7 @@ def get_group_by_data(group_by, conditions, assets_linked_to_fb, depreciation_am
 
 		a["depreciated_amount"] = depreciation_amount_map.get(a["name"], 0.0)
 		a["asset_value"] = (
-			a["gross_purchase_amount"] - a["opening_accumulated_depreciation"] - a["depreciated_amount"]
+			a["net_purchase_amount"] - a["opening_accumulated_depreciation"] - a["depreciated_amount"]
 		)
 
 		del a["name"]
@@ -319,7 +317,7 @@ def get_group_by_data(group_by, conditions, assets_linked_to_fb, depreciation_am
 			data.append(a)
 		else:
 			for field in (
-				"gross_purchase_amount",
+				"net_purchase_amount",
 				"opening_accumulated_depreciation",
 				"depreciated_amount",
 				"asset_value",
@@ -371,7 +369,7 @@ def get_columns(filters):
 			},
 			{
 				"label": _("Gross Purchase Amount"),
-				"fieldname": "gross_purchase_amount",
+				"fieldname": "net_purchase_amount",
 				"fieldtype": "Currency",
 				"options": "Company:company:default_currency",
 				"width": 250,
@@ -432,7 +430,7 @@ def get_columns(filters):
 		},
 		{
 			"label": _("Gross Purchase Amount"),
-			"fieldname": "gross_purchase_amount",
+			"fieldname": "net_purchase_amount",
 			"fieldtype": "Currency",
 			"options": "Company:company:default_currency",
 			"width": 100,

--- a/erpnext/controllers/buying_controller.py
+++ b/erpnext/controllers/buying_controller.py
@@ -903,7 +903,7 @@ class BuyingController(SubcontractingController):
 				"purchase_date": self.posting_date,
 				"calculate_depreciation": 0,
 				"purchase_amount": purchase_amount,
-				"gross_purchase_amount": purchase_amount,
+				"net_purchase_amount": purchase_amount,
 				"asset_quantity": asset_quantity,
 				"purchase_receipt": self.name if self.doctype == "Purchase Receipt" else None,
 				"purchase_invoice": self.name if self.doctype == "Purchase Invoice" else None,

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -413,3 +413,4 @@ erpnext.patches.v14_0.set_update_price_list_based_on
 erpnext.patches.v15_0.update_journal_entry_type
 erpnext.patches.v15_0.set_grand_total_to_default_mop
 execute:frappe.db.set_single_value("Accounts Settings", "use_new_budget_controller", True)
+erpnext.patches.v15_0.rename_gross_purchase_amount_to_net_purchase_amount

--- a/erpnext/patches/v14_0/update_total_asset_cost_field.py
+++ b/erpnext/patches/v14_0/update_total_asset_cost_field.py
@@ -3,7 +3,7 @@ import frappe
 
 def execute():
 	asset = frappe.qb.DocType("Asset")
-	frappe.qb.update(asset).set(asset.total_asset_cost, asset.gross_purchase_amount).run()
+	frappe.qb.update(asset).set(asset.total_asset_cost, asset.net_purchase_amount).run()
 
 	asset_repair_list = frappe.db.get_all(
 		"Asset Repair",

--- a/erpnext/patches/v15_0/correct_asset_value_if_je_with_workflow.py
+++ b/erpnext/patches/v15_0/correct_asset_value_if_je_with_workflow.py
@@ -35,7 +35,7 @@ def correct_value_for_assets_with_manual_depr_entries():
 		.on(company.name == asset.company)
 		.select(
 			asset.name.as_("asset_name"),
-			asset.gross_purchase_amount.as_("gross_purchase_amount"),
+			asset.net_purchase_amount.as_("net_purchase_amount"),
 			asset.opening_accumulated_depreciation.as_("opening_accumulated_depreciation"),
 			Sum(gle.debit).as_("depr_amount"),
 		)
@@ -51,7 +51,7 @@ def correct_value_for_assets_with_manual_depr_entries():
 		asset_details_and_depr_amount_map.asset_name == asset.name
 	).set(
 		asset.value_after_depreciation,
-		asset_details_and_depr_amount_map.gross_purchase_amount
+		asset_details_and_depr_amount_map.net_purchase_amount
 		- asset_details_and_depr_amount_map.opening_accumulated_depreciation
 		- asset_details_and_depr_amount_map.depr_amount,
 	).run()
@@ -74,7 +74,7 @@ def correct_value_for_assets_with_auto_depr(fb_name=None):
 		.on(company.name == asset.company)
 		.select(
 			asset.name.as_("asset_name"),
-			asset.gross_purchase_amount.as_("gross_purchase_amount"),
+			asset.net_purchase_amount.as_("net_purchase_amount"),
 			asset.opening_accumulated_depreciation.as_("opening_accumulated_depreciation"),
 			Sum(gle.debit).as_("depr_amount"),
 		)
@@ -101,7 +101,7 @@ def correct_value_for_assets_with_auto_depr(fb_name=None):
 		.on(asset_details_and_depr_amount_map.asset_name == afb.parent)
 		.set(
 			afb.value_after_depreciation,
-			asset_details_and_depr_amount_map.gross_purchase_amount
+			asset_details_and_depr_amount_map.net_purchase_amount
 			- asset_details_and_depr_amount_map.opening_accumulated_depreciation
 			- asset_details_and_depr_amount_map.depr_amount,
 		)

--- a/erpnext/patches/v15_0/create_asset_depreciation_schedules_from_assets.py
+++ b/erpnext/patches/v15_0/create_asset_depreciation_schedules_from_assets.py
@@ -48,7 +48,7 @@ def get_asset_finance_books_map():
 			asset.docstatus,
 			asset.name,
 			asset.opening_accumulated_depreciation,
-			asset.gross_purchase_amount,
+			asset.net_purchase_amount,
 			asset.opening_number_of_booked_depreciations,
 		)
 		.where(asset.docstatus < 2)

--- a/erpnext/patches/v15_0/link_purchase_item_to_asset_doc.py
+++ b/erpnext/patches/v15_0/link_purchase_item_to_asset_doc.py
@@ -14,7 +14,7 @@ def execute():
 				"item_code",
 				"purchase_invoice",
 				"purchase_receipt",
-				"gross_purchase_amount",
+				"net_purchase_amount",
 				"asset_quantity",
 				"purchase_invoice_item",
 				"purchase_receipt_item",
@@ -28,7 +28,7 @@ def execute():
 					"Purchase Invoice Item",
 					asset.purchase_invoice,
 					asset.item_code,
-					asset.gross_purchase_amount,
+					asset.net_purchase_amount,
 					asset.asset_quantity,
 				)
 				frappe.db.set_value("Asset", asset.name, "purchase_invoice_item", purchase_invoice_item)
@@ -39,7 +39,7 @@ def execute():
 					"Purchase Receipt Item",
 					asset.purchase_receipt,
 					asset.item_code,
-					asset.gross_purchase_amount,
+					asset.net_purchase_amount,
 					asset.asset_quantity,
 				)
 				frappe.db.set_value("Asset", asset.name, "purchase_receipt_item", purchase_receipt_item)

--- a/erpnext/patches/v15_0/rename_gross_purchase_amount_to_net_purchase_amount.py
+++ b/erpnext/patches/v15_0/rename_gross_purchase_amount_to_net_purchase_amount.py
@@ -1,0 +1,6 @@
+from frappe.model.utils.rename_field import rename_field
+
+
+def execute():
+	rename_field("Asset", "gross_purchase_amount", "net_purchase_amount")
+	rename_field("Asset Depreciation Schedule", "gross_purchase_amount", "net_purchase_amount")

--- a/erpnext/patches/v15_0/update_gpa_and_ndb_for_assdeprsch.py
+++ b/erpnext/patches/v15_0/update_gpa_and_ndb_for_assdeprsch.py
@@ -8,11 +8,11 @@ def execute():
         JOIN `tabAsset`
         ON `tabAsset Depreciation Schedule`.`asset`=`tabAsset`.`name`
         SET
-            `tabAsset Depreciation Schedule`.`gross_purchase_amount`=`tabAsset`.`gross_purchase_amount`,
+            `tabAsset Depreciation Schedule`.`net_purchase_amount`=`tabAsset`.`net_purchase_amount`,
             `tabAsset Depreciation Schedule`.`opening_number_of_booked_depreciations`=`tabAsset`.`opening_number_of_booked_depreciations`
         WHERE
         (
-            `tabAsset Depreciation Schedule`.`gross_purchase_amount`<>`tabAsset`.`gross_purchase_amount`
+            `tabAsset Depreciation Schedule`.`net_purchase_amount`<>`tabAsset`.`net_purchase_amount`
             OR
             `tabAsset Depreciation Schedule`.`opening_number_of_booked_depreciations`<>`tabAsset`.`opening_number_of_booked_depreciations`
         )

--- a/erpnext/stock/doctype/landed_cost_voucher/test_landed_cost_voucher.py
+++ b/erpnext/stock/doctype/landed_cost_voucher/test_landed_cost_voucher.py
@@ -599,7 +599,7 @@ class TestLandedCostVoucher(IntegrationTestCase):
 		lcv.submit()
 
 		# lcv updates amount in draft asset
-		self.assertEqual(frappe.db.get_value("Asset", assets[0].name, "gross_purchase_amount"), 50080)
+		self.assertEqual(frappe.db.get_value("Asset", assets[0].name, "net_purchase_amount"), 50080)
 
 		# tear down
 		lcv.cancel()

--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
@@ -910,7 +910,7 @@ class PurchaseReceipt(BuyingController):
 				"Asset",
 				asset.name,
 				{
-					"gross_purchase_amount": purchase_amount,
+					"net_purchase_amount": purchase_amount,
 					"purchase_amount": purchase_amount,
 				},
 			)

--- a/erpnext/stock/doctype/purchase_receipt/test_purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/test_purchase_receipt.py
@@ -838,7 +838,7 @@ class TestPurchaseReceipt(IntegrationTestCase):
 
 		asset = frappe.get_doc("Asset", {"purchase_receipt": pr.name})
 		asset.available_for_use_date = frappe.utils.nowdate()
-		asset.gross_purchase_amount = 50.0
+		asset.net_purchase_amount = 50.0
 		asset.append(
 			"finance_books",
 			{


### PR DESCRIPTION
The field name gross_purchase_amount in the Asset Doctype was misleading, as it did not include taxes. To ensure clarity and accuracy, I renamed the field to net_purchase_amount. The same change was also made in the Asset Depreciation Schedule Doctype. A data patch was added to update existing records accordingly, ensuring consistency across the system.

Extends PR https://github.com/frappe/erpnext/pull/46051 to include code-level rename and patch.