### PR TITLE
fix(Timesheet): Only update to_time if it's more than 1 second off

### DIFF
--- a/erpnext/projects/doctype/timesheet/timesheet.py
+++ b/erpnext/projects/doctype/timesheet/timesheet.py
@@ -7,7 +7,7 @@ import json
 import frappe
 from frappe import _
 from frappe.model.document import Document
-from frappe.utils import add_to_date, flt, get_datetime, getdate, time_diff_in_hours
+from frappe.utils import add_to_date, flt, get_datetime, getdate, time_diff_in_hours, time_diff_in_seconds
 
 from erpnext.controllers.queries import get_match_cond
 from erpnext.setup.utils import get_exchange_rate
@@ -194,7 +194,7 @@ class Timesheet(Document):
 			return
 
 		_to_time = get_datetime(add_to_date(data.from_time, hours=data.hours, as_datetime=True))
-		if data.to_time != _to_time:
+		if time_diff_in_seconds(_to_time, data.to_time) > 1:
 			data.to_time = _to_time
 
 	def validate_overlap(self, data):

--- a/erpnext/projects/doctype/timesheet/timesheet.py
+++ b/erpnext/projects/doctype/timesheet/timesheet.py
@@ -194,7 +194,7 @@ class Timesheet(Document):
 			return
 
 		_to_time = get_datetime(add_to_date(data.from_time, hours=data.hours, as_datetime=True))
-		if abs(time_diff_in_seconds(_to_time, data.to_time)) > 1:
+		if abs(time_diff_in_seconds(_to_time, data.to_time)) >= 1:
 			data.to_time = _to_time
 
 	def validate_overlap(self, data):

--- a/erpnext/projects/doctype/timesheet/timesheet.py
+++ b/erpnext/projects/doctype/timesheet/timesheet.py
@@ -194,7 +194,7 @@ class Timesheet(Document):
 			return
 
 		_to_time = get_datetime(add_to_date(data.from_time, hours=data.hours, as_datetime=True))
-		if time_diff_in_seconds(_to_time, data.to_time) > 1:
+		if abs(time_diff_in_seconds(_to_time, data.to_time)) > 1:
 			data.to_time = _to_time
 
 	def validate_overlap(self, data):


### PR DESCRIPTION
Before, to_time was updated even when it was almost the same as the expected time (like 17:20 vs 17:19:59.998). This causes problems because of small rounding errors and caused valid times like 17:20 to be reset. Now, to_time is only updated if the difference is greater than 1 second.

To reproduce the current error:
* From Time 09:00:00
* To Time 17:20:00 Save 
To Time is 17:19:59

@barredterra I saw you moved the implementation of this in https://github.com/frappe/erpnext/commit/b42e7d4b32aabf5046ae9356da0c2351bcf4aaed#diff-bf724a8fc0e2fe5d2d89003eb098b42c362e0a7a563fc443d879fb46ee402fe4 on the develop branch. Since you also changed the implementation there slightly do you think the problem also exists there?