### PR TITLE
fix(Timesheet): only update to_time if it's more than 1 second off

### DIFF
--- a/erpnext/projects/doctype/timesheet_detail/timesheet_detail.py
+++ b/erpnext/projects/doctype/timesheet_detail/timesheet_detail.py
@@ -5,7 +5,7 @@
 import frappe
 from frappe import _
 from frappe.model.document import Document
-from frappe.utils import add_to_date, flt, get_datetime, time_diff_in_hours
+from frappe.utils import add_to_date, flt, get_datetime, time_diff_in_hours, time_diff_in_seconds
 
 
 class TimesheetDetail(Document):
@@ -45,10 +45,12 @@ class TimesheetDetail(Document):
 
 	def set_to_time(self):
 		"""Set to_time based on from_time and hours."""
-		if not (self.from_time and self.hours):
+		if not (data.from_time and data.hours):
 			return
 
-		self.to_time = get_datetime(add_to_date(self.from_time, hours=self.hours, as_datetime=True))
+		_to_time = get_datetime(add_to_date(data.from_time, hours=data.hours, as_datetime=True))
+		if time_diff_in_seconds(_to_time, data.to_time) > 1:
+			data.to_time = _to_time
 
 	def set_project(self):
 		"""Set project based on task."""

--- a/erpnext/projects/doctype/timesheet_detail/timesheet_detail.py
+++ b/erpnext/projects/doctype/timesheet_detail/timesheet_detail.py
@@ -45,12 +45,12 @@ class TimesheetDetail(Document):
 
 	def set_to_time(self):
 		"""Set to_time based on from_time and hours."""
-		if not (data.from_time and data.hours):
+		if not (self.from_time and self.hours):
 			return
 
-		_to_time = get_datetime(add_to_date(data.from_time, hours=data.hours, as_datetime=True))
-		if time_diff_in_seconds(_to_time, data.to_time) > 1:
-			data.to_time = _to_time
+		_to_time = get_datetime(add_to_date(self.from_time, hours=self.hours, as_datetime=True))
+		if time_diff_in_seconds(_to_time, self.to_time) > 1:
+			self.to_time = _to_time
 
 	def set_project(self):
 		"""Set project based on task."""

--- a/erpnext/projects/doctype/timesheet_detail/timesheet_detail.py
+++ b/erpnext/projects/doctype/timesheet_detail/timesheet_detail.py
@@ -49,7 +49,7 @@ class TimesheetDetail(Document):
 			return
 
 		_to_time = get_datetime(add_to_date(self.from_time, hours=self.hours, as_datetime=True))
-		if time_diff_in_seconds(_to_time, self.to_time) > 1:
+		if abs(time_diff_in_seconds(_to_time, self.to_time)) >= 1:
 			self.to_time = _to_time
 
 	def set_project(self):


### PR DESCRIPTION
Before, to_time was updated even when it was almost the same as the expected time (like 17:20 vs 17:19:59.998). This causes problems because of small rounding errors and caused valid times like 17:20 to be reset. Now, to_time is only updated if the difference is greater than 1 second.

To reproduce the current error:

From Time 09:00:00
To Time 17:20:00 Save
To Time is 17:19:59

Since previous refactoring was not backported here the fix for version-15: https://github.com/frappe/erpnext/pull/47702 