### PR TITLE
fix: patch to rename group_by filter in custom reports

### DIFF
--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -413,3 +413,4 @@ erpnext.patches.v14_0.set_update_price_list_based_on
 erpnext.patches.v15_0.update_journal_entry_type
 erpnext.patches.v15_0.set_grand_total_to_default_mop
 execute:frappe.db.set_single_value("Accounts Settings", "use_new_budget_controller", True)
+erpnext.patches.v15_0.rename_group_by_to_categorize_by_in_custom_reports

--- a/erpnext/patches/v15_0/rename_group_by_to_categorize_by_in_custom_reports.py
+++ b/erpnext/patches/v15_0/rename_group_by_to_categorize_by_in_custom_reports.py
@@ -1,0 +1,21 @@
+import frappe
+
+
+def execute():
+	frappe.db.sql(
+		"""
+		UPDATE `tabReport`
+		SET `json` = JSON_SET(
+			JSON_REMOVE(json, '$.filters.group_by'),
+			'$.filters.categorize_by',
+			REPLACE(JSON_UNQUOTE(JSON_EXTRACT(json, '$.filters.group_by')), 'Group', 'Categorize')
+		)
+		WHERE
+			JSON_CONTAINS_PATH(json, 'one', '$.filters.group_by')
+			AND `reference_report` = CASE
+				WHEN `reference_report` = 'Supplier Quotation Comparison' THEN 'Supplier Quotation Comparison'
+				ELSE 'General Ledger'
+			END
+			AND `report_type` = 'Custom Report'
+		"""
+	)


### PR DESCRIPTION
Patch to rename the `group_by` filters to `categorize_by` and update the value of the filters in the Client Script of Custom Reports.

#47352 
