### PR TITLE
fix: filter of item for manufacture type material request

### DIFF
--- a/erpnext/stock/doctype/material_request/material_request.js
+++ b/erpnext/stock/doctype/material_request/material_request.js
@@ -568,25 +568,23 @@ erpnext.buying.MaterialRequestController = class MaterialRequestController exten
 
 	onload() {
 		this.frm.set_query("item_code", "items", function (doc, cdt, cdn) {
+			let filters = { is_stock_item: 1 };
+
 			if (doc.material_request_type == "Customer Provided") {
-				return {
-					query: "erpnext.controllers.queries.item_query",
-					filters: {
-						customer: doc.customer,
-						is_stock_item: 1,
-					},
-				};
-			} else if (doc.material_request_type == "Purchase") {
-				return {
-					query: "erpnext.controllers.queries.item_query",
-					filters: { is_purchase_item: 1 },
-				};
-			} else {
-				return {
-					query: "erpnext.controllers.queries.item_query",
-					filters: { is_stock_item: 1 },
-				};
+				filters.customer = doc.customer;
+			} else if (
+				doc.material_request_type == "Purchase" ||
+				doc.material_request_type == "Subcontracting"
+			) {
+				filters = { is_purchase_item: 1 };
+			} else if (doc.material_request_type == "Manufacture") {
+				filters.include_item_in_manufacturing = 1;
 			}
+
+			return {
+				query: "erpnext.controllers.queries.item_query",
+				filters: filters,
+			};
 		});
 	}
 


### PR DESCRIPTION
**Issue**

"Include Item In Manufacturing" filter is missing for items in the material request of Manufacture type

<img width="461" alt="Screenshot 2025-05-24 at 10 22 00 AM" src="https://github.com/user-attachments/assets/3f09d36d-fe02-459e-afd0-680914f2dcd4" />



**After Fix**

<img width="440" alt="Screenshot 2025-05-24 at 10 24 54 AM" src="https://github.com/user-attachments/assets/d3cbbb81-3812-4210-9dd5-f2c790159dfa" />


