### PR TITLE
refactor: sales invoice integration with pos

### DIFF
--- a/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
+++ b/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
@@ -65,7 +65,7 @@
   "pos_setting_section",
   "post_change_gl_entries",
   "column_break_xrnd",
-  "use_sales_invoice_in_pos",
+  "invoice_doctype_in_pos",
   "assets_tab",
   "asset_settings_section",
   "calculate_depr_using_total_days",
@@ -551,13 +551,6 @@
    "fieldtype": "Column Break"
   },
   {
-   "default": "0",
-   "description": "If enabled, Sales Invoice will be generated instead of POS Invoice in POS Transactions for real-time update of G/L and Stock Ledger.",
-   "fieldname": "use_sales_invoice_in_pos",
-   "fieldtype": "Check",
-   "label": "Use Sales Invoice"
-  },
-  {
    "default": "Buffered Cursor",
    "fieldname": "receivable_payable_fetch_method",
    "fieldtype": "Select",
@@ -622,6 +615,14 @@
   {
    "fieldname": "column_break_feyo",
    "fieldtype": "Column Break"
+  },
+  {
+   "default": "Sales Invoice",
+   "description": "For high-volume transactions, it is advisable to use POS Invoice.",
+   "fieldname": "invoice_doctype_in_pos",
+   "fieldtype": "Select",
+   "label": "Invoice DocType",
+   "options": "Sales Invoice\nPOS Invoice"
   }
  ],
  "grid_page_length": 50,

--- a/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
+++ b/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
@@ -65,7 +65,6 @@
   "pos_setting_section",
   "post_change_gl_entries",
   "column_break_xrnd",
-  "invoice_doctype_in_pos",
   "assets_tab",
   "asset_settings_section",
   "calculate_depr_using_total_days",
@@ -615,14 +614,6 @@
   {
    "fieldname": "column_break_feyo",
    "fieldtype": "Column Break"
-  },
-  {
-   "default": "Sales Invoice",
-   "description": "For high-volume transactions, it is advisable to use POS Invoice.",
-   "fieldname": "invoice_doctype_in_pos",
-   "fieldtype": "Select",
-   "label": "Invoice DocType",
-   "options": "Sales Invoice\nPOS Invoice"
   }
  ],
  "grid_page_length": 50,
@@ -631,7 +622,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-05-27 17:52:03.460522",
+ "modified": "2025-06-06 11:03:28.095723",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Accounts Settings",

--- a/erpnext/accounts/doctype/accounts_settings/accounts_settings.py
+++ b/erpnext/accounts/doctype/accounts_settings/accounts_settings.py
@@ -53,7 +53,6 @@ class AccountsSettings(Document):
 		ignore_is_opening_check_for_reporting: DF.Check
 		maintain_same_internal_transaction_rate: DF.Check
 		maintain_same_rate_action: DF.Literal["Stop", "Warn"]
-		invoice_doctype_in_pos: DF.Literal["Sales Invoice", "POS Invoice"]
 		make_payment_via_journal_entry: DF.Check
 		merge_similar_account_heads: DF.Check
 		over_billing_allowance: DF.Currency
@@ -99,9 +98,6 @@ class AccountsSettings(Document):
 		if old_doc.acc_frozen_upto != self.acc_frozen_upto:
 			self.validate_pending_reposts()
 
-		if old_doc.invoice_doctype_in_pos != self.invoice_doctype_in_pos:
-			self.validate_invoice_type_switch_in_pos()
-
 		if clear_cache:
 			frappe.clear_cache()
 
@@ -145,15 +141,3 @@ class AccountsSettings(Document):
 		if self.has_value_changed("reconciliation_queue_size"):
 			if cint(self.reconciliation_queue_size) < 5 or cint(self.reconciliation_queue_size) > 100:
 				frappe.throw(_("Queue Size should be between 5 and 100"))
-
-	def validate_invoice_type_switch_in_pos(self):
-		pos_opening_entries_count = frappe.db.count(
-			"POS Opening Entry", filters={"docstatus": 1, "status": "Open"}
-		)
-		if pos_opening_entries_count:
-			frappe.throw(
-				_("{0} cannot be changed without closing all POS Opening Entries.").format(
-					frappe.bold(_("Invoice Type"))
-				),
-				title=_("Switch Invoice DocType Error"),
-			)

--- a/erpnext/accounts/doctype/pos_closing_entry/closing_voucher_details.html
+++ b/erpnext/accounts/doctype/pos_closing_entry/closing_voucher_details.html
@@ -1,11 +1,11 @@
 <div class="clearfix"></div>
 <div class="box">
-		<div class="grid-body">
+		<div class="grid-body" style="background-color: transparent;">
 			<div class="rows text-center">
 
 				<!-- Sales summary section -->
 				<div>
-						<h6 class="text-center uppercase" style="color: #8D99A6">{{ _("Sales Summary") }}</h6>
+						<h6 class="text-center uppercase">{{ _("Sales Summary") }}</h6>
 						<div class="tax-break-up" style="overflow-x: auto;">
 							<table class="table table-bordered table-hover">
 								<thead>
@@ -32,7 +32,7 @@
 
 				<!-- Mode of payment section -->
 				<div>
-						<h6 class="text-center uppercase" style="color: #8D99A6">{{ _("Mode of Payments") }}</h6>
+						<h6 class="text-center uppercase">{{ _("Mode of Payments") }}</h6>
 						<div class="tax-break-up" style="overflow-x: auto;">
 							<table class="table table-bordered table-hover">
 								<thead>
@@ -57,7 +57,7 @@
 				<!-- Taxes section -->
 				{% if data.taxes %}
 				<div>
-						<h6 class="text-center uppercase" style="color: #8D99A6">{{ _("Taxes") }}</h6>
+						<h6 class="text-center uppercase">{{ _("Taxes") }}</h6>
 						<div class="tax-break-up" style="overflow-x: auto;">
 							<table class="table table-bordered table-hover">
 								<thead>

--- a/erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.js
+++ b/erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.js
@@ -3,7 +3,7 @@
 
 frappe.ui.form.on("POS Closing Entry", {
 	onload: async function (frm) {
-		frm.ignore_doctypes_on_cancel_all = ["POS Invoice Merge Log"];
+		frm.ignore_doctypes_on_cancel_all = ["POS Invoice Merge Log", "Sales Invoice"];
 		frm.set_query("pos_profile", function (doc) {
 			return {
 				filters: { user: doc.user },

--- a/erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.js
+++ b/erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.js
@@ -36,8 +36,6 @@ frappe.ui.form.on("POS Closing Entry", {
 			}
 		});
 
-		set_html_data(frm);
-
 		if (frm.doc.docstatus == 1) {
 			if (!frm.doc.posting_date) {
 				frm.set_value("posting_date", frappe.datetime.nowdate());
@@ -115,7 +113,6 @@ frappe.ui.form.on("POS Closing Entry", {
 				let inv_docs = r.message;
 				set_transaction_form_data(inv_docs, frm);
 				refresh_fields(frm);
-				set_html_data(frm);
 			},
 		});
 	},
@@ -134,6 +131,7 @@ function set_transaction_form_data(data, frm) {
 		frm.doc.grand_total += flt(d.grand_total);
 		frm.doc.net_total += flt(d.net_total);
 		frm.doc.total_quantity += flt(d.total_qty);
+		frm.doc.total_taxes_and_charges += flt(d.total_taxes_and_charges);
 		refresh_payments(d, frm, true);
 		refresh_taxes(d, frm);
 	});
@@ -195,6 +193,7 @@ function reset_values(frm) {
 	frm.set_value("taxes", []);
 	frm.set_value("grand_total", 0);
 	frm.set_value("net_total", 0);
+	frm.set_value("total_taxes_and_charges", 0);
 	frm.set_value("total_quantity", 0);
 }
 
@@ -205,17 +204,6 @@ function refresh_fields(frm) {
 	frm.refresh_field("taxes");
 	frm.refresh_field("grand_total");
 	frm.refresh_field("net_total");
+	frm.refresh_field("total_taxes_and_charges");
 	frm.refresh_field("total_quantity");
-}
-
-function set_html_data(frm) {
-	if (frm.doc.docstatus === 1 && frm.doc.status == "Submitted") {
-		frappe.call({
-			method: "get_payment_reconciliation_details",
-			doc: frm.doc,
-			callback: (r) => {
-				frm.get_field("payment_reconciliation_details").$wrapper.html(r.message);
-			},
-		});
-	}
 }

--- a/erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.js
+++ b/erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.js
@@ -36,12 +36,12 @@ frappe.ui.form.on("POS Closing Entry", {
 			}
 		});
 
-		const is_pos_using_sales_invoice = await frappe.db.get_single_value(
+		const invoice_doctype_in_pos = await frappe.db.get_single_value(
 			"Accounts Settings",
-			"use_sales_invoice_in_pos"
+			"invoice_doctype_in_pos"
 		);
 
-		if (is_pos_using_sales_invoice) {
+		if (invoice_doctype_in_pos === "Sales Invoice") {
 			frm.set_df_property("pos_transactions", "hidden", 1);
 		}
 
@@ -160,12 +160,12 @@ frappe.ui.form.on("POS Closing Entry", {
 			row.expected_amount = row.opening_amount;
 		}
 
-		const is_pos_using_sales_invoice = await frappe.db.get_single_value(
+		const invoice_doctype_in_pos = await frappe.db.get_single_value(
 			"Accounts Settings",
-			"use_sales_invoice_in_pos"
+			"invoice_doctype_in_pos"
 		);
 
-		if (is_pos_using_sales_invoice) {
+		if (invoice_doctype_in_pos === "Sales Invoice") {
 			await Promise.all([
 				frappe.call({
 					method: "erpnext.accounts.doctype.pos_closing_entry.pos_closing_entry.get_pos_invoices",

--- a/erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.json
+++ b/erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.json
@@ -22,8 +22,6 @@
   "section_break_12",
   "pos_invoices",
   "sales_invoices",
-  "section_break_11",
-  "payment_reconciliation",
   "taxes_and_charges_section",
   "taxes",
   "section_break_13",
@@ -33,6 +31,8 @@
   "net_total",
   "total_taxes_and_charges",
   "grand_total",
+  "section_break_11",
+  "payment_reconciliation",
   "failure_description_section",
   "error_message",
   "section_break_14",
@@ -74,10 +74,12 @@
    "label": "User Details"
   },
   {
+   "fetch_if_empty": 1,
    "fieldname": "company",
    "fieldtype": "Link",
    "label": "Company",
    "options": "Company",
+   "read_only": 1,
    "reqd": 1
   },
   {
@@ -86,11 +88,13 @@
   },
   {
    "fetch_from": "pos_opening_entry.pos_profile",
+   "fetch_if_empty": 1,
    "fieldname": "pos_profile",
    "fieldtype": "Link",
    "in_list_view": 1,
    "label": "POS Profile",
    "options": "POS Profile",
+   "read_only": 1,
    "reqd": 1
   },
   {
@@ -231,6 +235,7 @@
    "read_only": 1
   },
   {
+   "collapsible": 1,
    "fieldname": "taxes_and_charges_section",
    "fieldtype": "Section Break",
    "label": "Taxes and Charges"
@@ -254,7 +259,7 @@
    "link_fieldname": "pos_closing_entry"
   }
  ],
- "modified": "2025-05-29 11:20:57.138300",
+ "modified": "2025-06-06 12:00:31.955176",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "POS Closing Entry",

--- a/erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.json
+++ b/erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.json
@@ -22,16 +22,17 @@
   "section_break_12",
   "pos_invoices",
   "sales_invoices",
-  "section_break_9",
-  "payment_reconciliation_details",
   "section_break_11",
   "payment_reconciliation",
-  "section_break_13",
-  "grand_total",
-  "net_total",
-  "total_quantity",
-  "column_break_16",
+  "taxes_and_charges_section",
   "taxes",
+  "section_break_13",
+  "column_break_16",
+  "total_quantity",
+  "column_break_ywgl",
+  "net_total",
+  "total_taxes_and_charges",
+  "grand_total",
   "failure_description_section",
   "error_message",
   "section_break_14",
@@ -101,16 +102,6 @@
    "reqd": 1
   },
   {
-   "fieldname": "section_break_9",
-   "fieldtype": "Section Break",
-   "read_only": 1
-  },
-  {
-   "depends_on": "eval:doc.docstatus==1",
-   "fieldname": "payment_reconciliation_details",
-   "fieldtype": "HTML"
-  },
-  {
    "fieldname": "section_break_11",
    "fieldtype": "Section Break",
    "label": "Modes of Payment"
@@ -122,7 +113,6 @@
    "options": "POS Closing Entry Detail"
   },
   {
-   "collapsible": 1,
    "collapsible_depends_on": "eval:doc.docstatus==0",
    "fieldname": "section_break_13",
    "fieldtype": "Section Break",
@@ -182,6 +172,7 @@
    "fieldtype": "Link",
    "label": "POS Opening Entry",
    "options": "POS Opening Entry",
+   "print_hide": 1,
    "reqd": 1
   },
   {
@@ -228,6 +219,7 @@
    "fieldtype": "Table",
    "label": "POS Transactions",
    "options": "POS Invoice Reference",
+   "print_hide": 1,
    "read_only": 1
   },
   {
@@ -235,6 +227,22 @@
    "fieldtype": "Table",
    "label": "Sales Invoice Transactions",
    "options": "Sales Invoice Reference",
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "taxes_and_charges_section",
+   "fieldtype": "Section Break",
+   "label": "Taxes and Charges"
+  },
+  {
+   "fieldname": "column_break_ywgl",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "total_taxes_and_charges",
+   "fieldtype": "Currency",
+   "label": "Total Taxes and Charges",
    "read_only": 1
   }
  ],
@@ -246,7 +254,7 @@
    "link_fieldname": "pos_closing_entry"
   }
  ],
- "modified": "2025-05-27 17:14:18.905902",
+ "modified": "2025-05-29 11:20:57.138300",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "POS Closing Entry",

--- a/erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.json
+++ b/erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.json
@@ -20,8 +20,8 @@
   "pos_profile",
   "user",
   "section_break_12",
-  "pos_transactions",
-  "sales_invoice_transactions",
+  "pos_invoices",
+  "sales_invoices",
   "section_break_9",
   "payment_reconciliation_details",
   "section_break_11",
@@ -178,12 +178,6 @@
    "read_only": 1
   },
   {
-   "fieldname": "pos_transactions",
-   "fieldtype": "Table",
-   "label": "POS Transactions",
-   "options": "POS Invoice Reference"
-  },
-  {
    "fieldname": "pos_opening_entry",
    "fieldtype": "Link",
    "label": "POS Opening Entry",
@@ -230,10 +224,18 @@
    "reqd": 1
   },
   {
-   "fieldname": "sales_invoice_transactions",
+   "fieldname": "pos_invoices",
+   "fieldtype": "Table",
+   "label": "POS Transactions",
+   "options": "POS Invoice Reference",
+   "read_only": 1
+  },
+  {
+   "fieldname": "sales_invoices",
    "fieldtype": "Table",
    "label": "Sales Invoice Transactions",
-   "options": "Sales Invoice Reference"
+   "options": "Sales Invoice Reference",
+   "read_only": 1
   }
  ],
  "grid_page_length": 50,
@@ -244,7 +246,7 @@
    "link_fieldname": "pos_closing_entry"
   }
  ],
- "modified": "2025-03-19 19:49:58.845697",
+ "modified": "2025-05-27 17:14:18.905902",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "POS Closing Entry",

--- a/erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.py
+++ b/erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.py
@@ -7,7 +7,7 @@ from frappe import _
 from frappe.query_builder import DocType
 from frappe.query_builder import functions as fn
 from frappe.query_builder.custom import ConstantColumn
-from frappe.utils import flt, get_datetime
+from frappe.utils import flt
 
 from erpnext.accounts.doctype.pos_invoice_merge_log.pos_invoice_merge_log import (
 	consolidate_pos_invoices,
@@ -64,8 +64,10 @@ class POSClosingEntry(StatusUpdater):
 		self.validate_invoice_mode()
 
 	def set_posting_date_and_time(self):
-		self.posting_date = self.posting_date or frappe.utils.nowdate()
-		self.posting_time = self.posting_time or frappe.utils.nowtime()
+		if self.posting_date:
+			self.posting_date = frappe.utils.nowdate()
+		if self.posting_time:
+			self.posting_time = frappe.utils.nowtime()
 
 	def fetch_invoice_doctype_in_pos(self):
 		self.invoice_doctype_in_pos = frappe.db.get_single_value(

--- a/erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.py
+++ b/erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.py
@@ -292,7 +292,7 @@ def get_invoices(start, end, pos_profile, user):
 				POSInvoice.grand_total,
 				POSInvoice.net_total,
 				POSInvoice.total_qty,
-				SalesInvoice.total_taxes_and_charges,
+				POSInvoice.total_taxes_and_charges,
 				fn.Timestamp(POSInvoice.posting_date, POSInvoice.posting_time).as_("timestamp"),
 				ConstantColumn("POS Invoice").as_("doctype"),
 				POSInvoice.change_amount,

--- a/erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.py
+++ b/erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.py
@@ -60,15 +60,20 @@ class POSClosingEntry(StatusUpdater):
 		if frappe.db.get_value("POS Opening Entry", self.pos_opening_entry, "status") != "Open":
 			frappe.throw(_("Selected POS Opening Entry should be open."), title=_("Invalid Opening Entry"))
 
+<<<<<<< HEAD
 		self.is_pos_using_sales_invoice = frappe.get_single_value(
 			"Accounts Settings", "use_sales_invoice_in_pos"
+=======
+		self.invoice_doctype_in_pos = frappe.db.get_single_value(
+			"Accounts Settings", "invoice_doctype_in_pos"
+>>>>>>> 57ad7c1924 (fix: invoice doctype selection in accounts settings)
 		)
 
-		if self.is_pos_using_sales_invoice == 0:
+		if self.invoice_doctype_in_pos == "POS Invoice":
 			self.validate_duplicate_pos_invoices()
 			self.validate_pos_invoices()
 
-		if self.is_pos_using_sales_invoice == 1:
+		if self.invoice_doctype_in_pos == "Sales Invoice":
 			if len(self.pos_transactions) != 0:
 				frappe.throw(_("POS Invoices can't be added when Sales Invoice is enabled"))
 
@@ -301,7 +306,7 @@ def make_closing_entry_from_opening(opening_entry):
 	closing_entry.net_total = 0
 	closing_entry.total_quantity = 0
 
-	is_pos_using_sales_invoice = frappe.get_single_value("Accounts Settings", "use_sales_invoice_in_pos")
+	invoice_doctype_in_pos = frappe.db.get_single_value("Accounts Settings", "invoice_doctype_in_pos")
 
 	pos_invoices = (
 		get_pos_invoices(
@@ -310,7 +315,7 @@ def make_closing_entry_from_opening(opening_entry):
 			closing_entry.pos_profile,
 			closing_entry.user,
 		)
-		if is_pos_using_sales_invoice == 0
+		if invoice_doctype_in_pos == "POS Invoice"
 		else []
 	)
 

--- a/erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.py
+++ b/erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.py
@@ -59,7 +59,7 @@ class POSClosingEntry(StatusUpdater):
 
 	def validate(self):
 		self.set_posting_date_and_time()
-		self.fetch_invoice_doctype_in_pos()
+		self.fetch_invoice_type()
 		self.validate_pos_opening_entry()
 		self.validate_invoice_mode()
 
@@ -69,21 +69,19 @@ class POSClosingEntry(StatusUpdater):
 		if self.posting_time:
 			self.posting_time = frappe.utils.nowtime()
 
-	def fetch_invoice_doctype_in_pos(self):
-		self.invoice_doctype_in_pos = frappe.db.get_single_value(
-			"Accounts Settings", "invoice_doctype_in_pos"
-		)
+	def fetch_invoice_type(self):
+		self.invoice_type = frappe.db.get_single_value("POS Settings", "invoice_type")
 
 	def validate_pos_opening_entry(self):
 		if frappe.db.get_value("POS Opening Entry", self.pos_opening_entry, "status") != "Open":
 			frappe.throw(_("Selected POS Opening Entry should be open."), title=_("Invalid Opening Entry"))
 
 	def validate_invoice_mode(self):
-		if self.invoice_doctype_in_pos == "POS Invoice":
+		if self.invoice_type == "POS Invoice":
 			self.validate_duplicate_pos_invoices()
 			self.validate_pos_invoices()
 
-		if self.invoice_doctype_in_pos == "Sales Invoice":
+		if self.invoice_type == "Sales Invoice":
 			if len(self.pos_invoices) != 0:
 				frappe.throw(_("POS Invoices can't be added when Sales Invoice is enabled"))
 
@@ -249,7 +247,7 @@ def get_cashiers(doctype, txt, searchfield, start, page_len, filters):
 
 @frappe.whitelist()
 def get_invoices(start, end, pos_profile, user):
-	invoice_doctype = frappe.db.get_single_value("Accounts Settings", "invoice_doctype_in_pos")
+	invoice_doctype = frappe.db.get_single_value("POS Settings", "invoice_type")
 
 	SalesInvoice = DocType("Sales Invoice")
 	sales_inv_query = (

--- a/erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.py
+++ b/erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.py
@@ -312,8 +312,7 @@ def get_invoices(start, end, pos_profile, user):
 		query = query + pos_inv_query
 
 	query = query.orderby(query.timestamp)
-	sql_query, params = query.walk()
-	invoices = frappe.db.sql(sql_query, params, as_dict=1)
+	invoices = query.run(as_dict=1)
 
 	data = {"invoices": invoices, "payments": get_payments(invoices), "taxes": get_taxes(invoices)}
 
@@ -340,8 +339,7 @@ def get_payments(invoices):
 			fn.Sum(SalesInvoicePayment.amount).as_("amount"),
 		)
 	)
-	sql_query, params = query.walk()
-	data = frappe.db.sql(sql_query, params, as_dict=1)
+	data = query.run(as_dict=1)
 
 	change_amount_by_account = {}
 	for d in invoices:
@@ -374,8 +372,7 @@ def get_taxes(invoices):
 			fn.Sum(SalesInvoiceTaxesCharges.tax_amount_after_discount_amount).as_("tax_amount"),
 		)
 	)
-	sql_query, params = query.walk()
-	data = frappe.db.sql(sql_query, params, as_dict=1)
+	data = query.run(as_dict=1)
 
 	return data
 

--- a/erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.py
+++ b/erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.py
@@ -415,7 +415,7 @@ def make_closing_entry_from_opening(opening_entry):
 
 	for d in data.get("invoices"):
 		invoice = "pos_invoice" if d.doctype == "POS Invoice" else "sales_invoice"
-		data = frappe._dict(
+		invoice_data = frappe._dict(
 			{
 				invoice: d.name,
 				"posting_date": d.posting_date,
@@ -424,9 +424,9 @@ def make_closing_entry_from_opening(opening_entry):
 			}
 		)
 		if d.doctype == "POS Invoice":
-			pos_invoices.append(data)
+			pos_invoices.append(invoice_data)
 		else:
-			sales_invoices.append(data)
+			sales_invoices.append(invoice_data)
 
 		closing_entry.grand_total += flt(d.grand_total)
 		closing_entry.net_total += flt(d.net_total)

--- a/erpnext/accounts/doctype/pos_closing_entry/test_pos_closing_entry.py
+++ b/erpnext/accounts/doctype/pos_closing_entry/test_pos_closing_entry.py
@@ -28,9 +28,7 @@ class TestPOSClosingEntry(IntegrationTestCase):
 	@classmethod
 	def setUpClass(cls):
 		frappe.db.sql("delete from `tabPOS Opening Entry`")
-		cls.enterClassContext(
-			cls.change_settings("Accounts Settings", {"invoice_doctype_in_pos": "POS Invoice"})
-		)
+		cls.enterClassContext(cls.change_settings("POS Settings", {"invoice_type": "POS Invoice"}))
 
 	@classmethod
 	def tearDownClass(cls):
@@ -304,7 +302,7 @@ class TestPOSClosingEntry(IntegrationTestCase):
 		batch_qty_with_pos = get_batch_qty(batch_no, "_Test Warehouse - _TC", item_code)
 		self.assertEqual(batch_qty_with_pos, 10.0)
 
-	@IntegrationTestCase.change_settings("Accounts Settings", {"invoice_doctype_in_pos": "Sales Invoice"})
+	@IntegrationTestCase.change_settings("POS Settings", {"invoice_type": "Sales Invoice"})
 	def test_closing_entries_with_sales_invoice(self):
 		test_user, pos_profile = init_user_and_profile()
 		opening_entry = create_opening_entry(pos_profile, test_user.name)
@@ -348,7 +346,7 @@ class TestPOSClosingEntry(IntegrationTestCase):
 
 		test_user, pos_profile = init_user_and_profile()
 
-		with self.change_settings("Accounts Settings", {"invoice_doctype_in_pos": "Sales Invoice"}):
+		with self.change_settings("POS Settings", {"invoice_type": "Sales Invoice"}):
 			opening_entry1 = create_opening_entry(pos_profile, test_user.name)
 
 			pos_si1 = create_sales_invoice(
@@ -382,7 +380,7 @@ class TestPOSClosingEntry(IntegrationTestCase):
 			self.assertEqual(pos_si1.pos_closing_entry, pcv_doc1.name)
 			self.assertEqual(pos_si2.pos_closing_entry, pcv_doc1.name)
 
-		with self.change_settings("Accounts Settings", {"invoice_doctype_in_pos": "POS Invoice"}):
+		with self.change_settings("POS Settings", {"invoice_type": "POS Invoice"}):
 			opening_entry2 = create_opening_entry(pos_profile, test_user.name)
 
 			pos_inv1 = create_pos_invoice(rate=100, do_not_submit=1)
@@ -424,7 +422,7 @@ class TestPOSClosingEntry(IntegrationTestCase):
 
 		test_user, pos_profile = init_user_and_profile()
 
-		with self.change_settings("Accounts Settings", {"invoice_doctype_in_pos": "POS Invoice"}):
+		with self.change_settings("POS Settings", {"invoice_type": "POS Invoice"}):
 			opening_entry1 = create_opening_entry(pos_profile, test_user.name)
 
 			pos_inv1 = create_pos_invoice(rate=100, do_not_save=1)
@@ -456,7 +454,7 @@ class TestPOSClosingEntry(IntegrationTestCase):
 			self.assertIn(pos_inv1.name, [d.pos_invoice for d in pcv_doc1.pos_invoices])
 			self.assertEqual(pcv_doc1.grand_total, 300)
 
-		with self.change_settings("Accounts Settings", {"invoice_doctype_in_pos": "Sales Invoice"}):
+		with self.change_settings("POS Settings", {"invoice_type": "Sales Invoice"}):
 			opening_entry2 = create_opening_entry(pos_profile, test_user.name)
 
 			pos_si1 = create_sales_invoice(

--- a/erpnext/accounts/doctype/pos_closing_entry/test_pos_closing_entry.py
+++ b/erpnext/accounts/doctype/pos_closing_entry/test_pos_closing_entry.py
@@ -505,7 +505,7 @@ def get_test_item_qty(pos_profile):
 
 
 def create_multiple_sales_invoices(pos_profile):
-	pos_si1 = create_sales_invoice(qty=1, is_created_using_pos=1, pos_profile=pos_profile, do_not_save=1)
+	pos_si1 = create_sales_invoice(qty=1, is_created_using_pos=1, pos_profile=pos_profile.name, do_not_save=1)
 	pos_si1.append("payments", {"mode_of_payment": "Cash", "account": "Cash - _TC", "amount": 100})
 	pos_si1.save()
 	pos_si1.submit()
@@ -519,12 +519,12 @@ def create_multiple_sales_invoices(pos_profile):
 
 
 def create_multiple_pos_invoices(pos_profile):
-	pos_inv1 = create_pos_invoice(pos_profile=pos_profile, rate=100, do_not_save=1)
+	pos_inv1 = create_pos_invoice(pos_profile=pos_profile.name, rate=100, do_not_save=1)
 	pos_inv1.append("payments", {"mode_of_payment": "Cash", "account": "Cash - _TC", "amount": 100})
 	pos_inv1.save()
 	pos_inv1.submit()
 
-	pos_inv2 = create_pos_invoice(pos_profile=pos_profile, qty=2, do_not_save=1)
+	pos_inv2 = create_pos_invoice(pos_profile=pos_profile.name, qty=2, do_not_save=1)
 	pos_inv2.append("payments", {"mode_of_payment": "Cash", "account": "Cash - _TC", "amount": 200})
 	pos_inv2.save()
 	pos_inv2.submit()

--- a/erpnext/accounts/doctype/pos_closing_entry/test_pos_closing_entry.py
+++ b/erpnext/accounts/doctype/pos_closing_entry/test_pos_closing_entry.py
@@ -340,6 +340,82 @@ class TestPOSClosingEntry(IntegrationTestCase):
 		pos_si2.reload()
 		self.assertEqual(pos_si2.pos_closing_entry, pcv_doc.name)
 
+	def test_sales_invoice_in_pos_invoice_mode(self):
+		"""
+		Test Sales Invoice and Return Sales Invoice creation during POS Invoice mode.
+		"""
+		from erpnext.accounts.doctype.sales_invoice.sales_invoice import make_sales_return
+
+		test_user, pos_profile = init_user_and_profile()
+
+		with self.change_settings("Accounts Settings", {"invoice_doctype_in_pos": "Sales Invoice"}):
+			opening_entry1 = create_opening_entry(pos_profile, test_user.name)
+
+			pos_si1 = create_sales_invoice(
+				qty=1, is_created_using_pos=1, pos_profile=pos_profile.name, do_not_save=1
+			)
+			pos_si1.append("payments", {"mode_of_payment": "Cash", "account": "Cash - _TC", "amount": 100})
+			pos_si1.save()
+			pos_si1.submit()
+
+			pos_inv = create_pos_invoice(rate=100, do_not_save=1)
+			pos_inv.append("payments", {"mode_of_payment": "Cash", "account": "Cash - _TC", "amount": 100})
+			self.assertRaises(frappe.ValidationError, pos_inv.save)
+
+			pos_si2 = create_sales_invoice(
+				qty=2, is_created_using_pos=1, pos_profile=pos_profile.name, do_not_save=1
+			)
+			pos_si2.append("payments", {"mode_of_payment": "Cash", "account": "Cash - _TC", "amount": 200})
+			pos_si2.save()
+			pos_si2.submit()
+
+			pcv_doc1 = make_closing_entry_from_opening(opening_entry1)
+			for d in pcv_doc1.payment_reconciliation:
+				if d.mode_of_payment == "Cash":
+					d.closing_amount = 300
+
+			pcv_doc1.submit()
+			self.assertTrue(pcv_doc1.name)
+
+			pos_si1.reload()
+			pos_si2.reload()
+			self.assertEqual(pos_si1.pos_closing_entry, pcv_doc1.name)
+			self.assertEqual(pos_si2.pos_closing_entry, pcv_doc1.name)
+
+		with self.change_settings("Accounts Settings", {"invoice_doctype_in_pos": "POS Invoice"}):
+			opening_entry2 = create_opening_entry(pos_profile, test_user.name)
+
+			pos_inv1 = create_pos_invoice(rate=100, do_not_submit=1)
+			pos_inv1.append("payments", {"mode_of_payment": "Cash", "account": "Cash - _TC", "amount": 100})
+			pos_inv1.save()
+			pos_inv1.submit()
+
+			# Trying to create Sales Invoice when invoice_doctype_in_pos is set to POS Invoice.
+			pos_si3 = create_sales_invoice(
+				qty=1, is_created_using_pos=1, pos_profile=pos_profile.name, do_not_save=1
+			)
+			pos_si3.append("payments", {"mode_of_payment": "Cash", "account": "Cash - _TC", "amount": 100})
+			self.assertRaises(frappe.ValidationError, pos_si3.save)
+
+			# Trying to create Return Sales Invoice.
+			pos_rsi1 = make_sales_return(pos_si1.name)
+			pos_rsi1.save()
+			pos_rsi1.submit()
+
+			self.assertEqual(pos_rsi1.paid_amount, -100)
+
+			pcv_doc2 = make_closing_entry_from_opening(opening_entry2)
+			pcv_doc2.submit()
+
+			self.assertTrue(pcv_doc2.name)
+
+			pos_rsi1.reload()
+			self.assertEqual(pos_rsi1.pos_closing_entry, pcv_doc2.name)
+
+			self.assertIn(pos_inv1.name, [d.pos_invoice for d in pcv_doc2.pos_invoices])
+			self.assertIn(pos_rsi1.name, [d.sales_invoice for d in pcv_doc2.sales_invoices])
+			self.assertEqual(pcv_doc2.grand_total, 0)
+
 
 def init_user_and_profile(**args):
 	user = "test@example.com"

--- a/erpnext/accounts/doctype/pos_closing_entry_taxes/pos_closing_entry_taxes.json
+++ b/erpnext/accounts/doctype/pos_closing_entry_taxes/pos_closing_entry_taxes.json
@@ -6,17 +6,9 @@
  "engine": "InnoDB",
  "field_order": [
   "account_head",
-  "rate",
   "amount"
  ],
  "fields": [
-  {
-   "fieldname": "rate",
-   "fieldtype": "Percent",
-   "in_list_view": 1,
-   "label": "Tax Rate",
-   "read_only": 1
-  },
   {
    "fieldname": "amount",
    "fieldtype": "Currency",
@@ -35,13 +27,14 @@
  ],
  "istable": 1,
  "links": [],
- "modified": "2024-03-27 13:10:14.420657",
+ "modified": "2025-06-06 11:54:02.414461",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "POS Closing Entry Taxes",
  "owner": "Administrator",
  "permissions": [],
  "quick_entry": 1,
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],

--- a/erpnext/accounts/doctype/pos_closing_entry_taxes/pos_closing_entry_taxes.py
+++ b/erpnext/accounts/doctype/pos_closing_entry_taxes/pos_closing_entry_taxes.py
@@ -19,7 +19,6 @@ class POSClosingEntryTaxes(Document):
 		parent: DF.Data
 		parentfield: DF.Data
 		parenttype: DF.Data
-		rate: DF.Percent
 	# end: auto-generated types
 
 	pass

--- a/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
+++ b/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
@@ -243,7 +243,7 @@ class POSInvoice(SalesInvoice):
 			update_coupon_code_count(self.coupon_code, "used")
 		self.clear_unallocated_mode_of_payments()
 
-		if self.is_return and self.is_pos_using_sales_invoice:
+		if self.is_return and self.invoice_doctype_in_pos == "Sales Invoice":
 			self.create_and_add_consolidated_sales_invoice()
 
 	def before_cancel(self):
@@ -424,10 +424,10 @@ class POSInvoice(SalesInvoice):
 					)
 
 	def validate_is_pos_using_sales_invoice(self):
-		self.is_pos_using_sales_invoice = frappe.get_single_value(
-			"Accounts Settings", "use_sales_invoice_in_pos"
+		self.invoice_doctype_in_pos = frappe.db.get_single_value(
+			"Accounts Settings", "invoice_doctype_in_pos"
 		)
-		if self.is_pos_using_sales_invoice and not self.is_return:
+		if self.invoice_doctype_in_pos == "Sales Invoice" and not self.is_return:
 			frappe.throw(_("Sales Invoice mode is activated in POS. Please create Sales Invoice instead."))
 
 	def validate_serialised_or_batched_item(self):

--- a/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
+++ b/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
@@ -243,7 +243,7 @@ class POSInvoice(SalesInvoice):
 			update_coupon_code_count(self.coupon_code, "used")
 		self.clear_unallocated_mode_of_payments()
 
-		if self.is_return and self.invoice_doctype_in_pos == "Sales Invoice":
+		if self.is_return and self.invoice_type_in_pos == "Sales Invoice":
 			self.create_and_add_consolidated_sales_invoice()
 
 	def before_cancel(self):
@@ -424,10 +424,8 @@ class POSInvoice(SalesInvoice):
 					)
 
 	def validate_is_pos_using_sales_invoice(self):
-		self.invoice_doctype_in_pos = frappe.db.get_single_value(
-			"Accounts Settings", "invoice_doctype_in_pos"
-		)
-		if self.invoice_doctype_in_pos == "Sales Invoice" and not self.is_return:
+		self.invoice_type_in_pos = frappe.db.get_single_value("POS Settings", "invoice_type")
+		if self.invoice_type_in_pos == "Sales Invoice" and not self.is_return:
 			frappe.throw(_("Sales Invoice mode is activated in POS. Please create Sales Invoice instead."))
 
 	def validate_serialised_or_batched_item(self):

--- a/erpnext/accounts/doctype/pos_invoice/test_pos_invoice.py
+++ b/erpnext/accounts/doctype/pos_invoice/test_pos_invoice.py
@@ -37,7 +37,7 @@ class TestPOSInvoice(IntegrationTestCase):
 		from erpnext.accounts.doctype.pos_opening_entry.test_pos_opening_entry import create_opening_entry
 
 		cls.test_user, cls.pos_profile = init_user_and_profile()
-		cls.opening_entry = create_opening_entry(cls.pos_profile, cls.test_user)
+		cls.opening_entry = create_opening_entry(cls.pos_profile, cls.test_user.name)
 		mode_of_payment = frappe.get_doc("Mode of Payment", "Bank Draft")
 		set_default_account_for_mode_of_payment(mode_of_payment, "_Test Company", "_Test Bank - _TC")
 

--- a/erpnext/accounts/doctype/pos_invoice/test_pos_invoice.py
+++ b/erpnext/accounts/doctype/pos_invoice/test_pos_invoice.py
@@ -29,7 +29,7 @@ class TestPOSInvoice(IntegrationTestCase):
 	def setUpClass(cls):
 		super().setUpClass()
 		cls.enterClassContext(cls.change_settings("Selling Settings", validate_selling_price=0))
-		cls.enterClassContext(cls.change_settings("Accounts Settings", invoice_doctype_in_pos="POS Invoice"))
+		cls.enterClassContext(cls.change_settings("POS Settings", invoice_type="POS Invoice"))
 		make_stock_entry(target="_Test Warehouse - _TC", item_code="_Test Item", qty=800, basic_rate=100)
 		frappe.db.sql("delete from `tabTax Rule`")
 

--- a/erpnext/accounts/doctype/pos_invoice/test_pos_invoice.py
+++ b/erpnext/accounts/doctype/pos_invoice/test_pos_invoice.py
@@ -29,6 +29,7 @@ class TestPOSInvoice(IntegrationTestCase):
 	def setUpClass(cls):
 		super().setUpClass()
 		cls.enterClassContext(cls.change_settings("Selling Settings", validate_selling_price=0))
+		cls.enterClassContext(cls.change_settings("Accounts Settings", invoice_doctype_in_pos="POS Invoice"))
 		make_stock_entry(target="_Test Warehouse - _TC", item_code="_Test Item", qty=800, basic_rate=100)
 		frappe.db.sql("delete from `tabTax Rule`")
 
@@ -36,9 +37,15 @@ class TestPOSInvoice(IntegrationTestCase):
 		from erpnext.accounts.doctype.pos_opening_entry.test_pos_opening_entry import create_opening_entry
 
 		cls.test_user, cls.pos_profile = init_user_and_profile()
-		create_opening_entry(cls.pos_profile, cls.test_user.name)
+		cls.opening_entry = create_opening_entry(cls.pos_profile, cls.test_user)
 		mode_of_payment = frappe.get_doc("Mode of Payment", "Bank Draft")
 		set_default_account_for_mode_of_payment(mode_of_payment, "_Test Company", "_Test Bank - _TC")
+
+	@classmethod
+	def tearDownClass(cls):
+		frappe.db.sql("delete from `tabPOS Invoice`")
+		opening_entry_doc = frappe.get_doc("POS Opening Entry", cls.opening_entry.name)
+		opening_entry_doc.cancel()
 
 	def tearDown(self):
 		if frappe.session.user != "Administrator":

--- a/erpnext/accounts/doctype/pos_invoice_merge_log/pos_invoice_merge_log.py
+++ b/erpnext/accounts/doctype/pos_invoice_merge_log/pos_invoice_merge_log.py
@@ -491,7 +491,7 @@ def split_invoices_by_accounting_dimension(pos_invoices):
 
 
 def consolidate_pos_invoices(pos_invoices=None, closing_entry=None):
-	invoices = pos_invoices or (closing_entry and closing_entry.get("pos_transactions"))
+	invoices = pos_invoices or (closing_entry and closing_entry.get("pos_invoices"))
 	if frappe.flags.in_test and not invoices:
 		invoices = get_all_unconsolidated_invoices()
 
@@ -509,7 +509,7 @@ def unconsolidate_pos_invoices(closing_entry):
 		"POS Invoice Merge Log", filters={"pos_closing_entry": closing_entry.name}, pluck="name"
 	)
 
-	if len(closing_entry.pos_transactions) >= 10:
+	if len(closing_entry.pos_invoices) >= 10:
 		closing_entry.set_status(update=True, status="Queued")
 		enqueue_job(cancel_merge_logs, merge_logs=merge_logs, closing_entry=closing_entry)
 	else:

--- a/erpnext/accounts/doctype/pos_invoice_merge_log/test_pos_invoice_merge_log.py
+++ b/erpnext/accounts/doctype/pos_invoice_merge_log/test_pos_invoice_merge_log.py
@@ -41,7 +41,7 @@ class TestPOSInvoiceMergeLog(IntegrationTestCase):
 
 	def test_consolidated_invoice_creation(self):
 		test_user, pos_profile = init_user_and_profile()
-		opening_entry = create_opening_entry(pos_profile, test_user)
+		opening_entry = create_opening_entry(pos_profile, test_user.name)
 
 		pos_inv = create_pos_invoice(rate=300, do_not_submit=1)
 		pos_inv.append("payments", {"mode_of_payment": "Cash", "account": "Cash - _TC", "amount": 300})
@@ -72,7 +72,7 @@ class TestPOSInvoiceMergeLog(IntegrationTestCase):
 
 	def test_consolidated_credit_note_creation(self):
 		test_user, pos_profile = init_user_and_profile()
-		opening_entry = create_opening_entry(pos_profile, test_user)
+		opening_entry = create_opening_entry(pos_profile, test_user.name)
 
 		pos_inv = create_pos_invoice(rate=300, do_not_submit=1)
 		pos_inv.append("payments", {"mode_of_payment": "Cash", "account": "Cash - _TC", "amount": 300})
@@ -119,7 +119,7 @@ class TestPOSInvoiceMergeLog(IntegrationTestCase):
 
 	def test_consolidated_invoice_item_taxes(self):
 		test_user, pos_profile = init_user_and_profile()
-		opening_entry = create_opening_entry(pos_profile, test_user)
+		opening_entry = create_opening_entry(pos_profile, test_user.name)
 
 		inv = create_pos_invoice(qty=1, rate=100, do_not_save=True)
 
@@ -192,7 +192,7 @@ class TestPOSInvoiceMergeLog(IntegrationTestCase):
 		)
 
 		test_user, pos_profile = init_user_and_profile()
-		opening_entry = create_opening_entry(pos_profile, test_user)
+		opening_entry = create_opening_entry(pos_profile, test_user.name)
 
 		inv = create_pos_invoice(qty=3, rate=10000, do_not_save=True)
 		inv.append(
@@ -249,7 +249,7 @@ class TestPOSInvoiceMergeLog(IntegrationTestCase):
 		)
 
 		test_user, pos_profile = init_user_and_profile()
-		opening_entry = create_opening_entry(pos_profile, test_user)
+		opening_entry = create_opening_entry(pos_profile, test_user.name)
 
 		inv = create_pos_invoice(qty=6, rate=10000, do_not_save=True)
 		inv.append(
@@ -310,7 +310,7 @@ class TestPOSInvoiceMergeLog(IntegrationTestCase):
 			qty=10,
 		)
 		test_user, pos_profile = init_user_and_profile()
-		opening_entry = create_opening_entry(pos_profile, test_user)
+		opening_entry = create_opening_entry(pos_profile, test_user.name)
 
 		item_rates = [69, 59, 29]
 		for _i in [1, 2]:
@@ -368,7 +368,7 @@ class TestPOSInvoiceMergeLog(IntegrationTestCase):
 		)
 
 		test_user, pos_profile = init_user_and_profile()
-		opening_entry = create_opening_entry(pos_profile, test_user)
+		opening_entry = create_opening_entry(pos_profile, test_user.name)
 
 		inv = create_pos_invoice(qty=1, rate=69.5, do_not_save=True)
 		inv.append("payments", {"mode_of_payment": "Cash", "account": "Cash - _TC", "amount": 70})
@@ -405,7 +405,7 @@ class TestPOSInvoiceMergeLog(IntegrationTestCase):
 		serial_no = get_serial_nos_from_bundle(se.get("items")[0].serial_and_batch_bundle)[0]
 
 		test_user, pos_profile = init_user_and_profile()
-		opening_entry = create_opening_entry(pos_profile, test_user)
+		opening_entry = create_opening_entry(pos_profile, test_user.name)
 
 		pos_inv = create_pos_invoice(
 			item_code="_Test Serialized Item With Series",
@@ -455,7 +455,7 @@ class TestPOSInvoiceMergeLog(IntegrationTestCase):
 		create_cost_center(cost_center_name="_Test POS Cost Center 2", is_group=0)
 
 		test_user, pos_profile = init_user_and_profile()
-		opening_entry = create_opening_entry(pos_profile, test_user)
+		opening_entry = create_opening_entry(pos_profile, test_user.name)
 
 		pos_inv = create_pos_invoice(rate=300, do_not_submit=1)
 		pos_inv.append("payments", {"mode_of_payment": "Cash", "account": "Cash - _TC", "amount": 300})

--- a/erpnext/accounts/doctype/pos_invoice_merge_log/test_pos_invoice_merge_log.py
+++ b/erpnext/accounts/doctype/pos_invoice_merge_log/test_pos_invoice_merge_log.py
@@ -27,7 +27,7 @@ class TestPOSInvoiceMergeLog(IntegrationTestCase):
 		super().setUpClass()
 		frappe.db.sql("delete from `tabPOS Opening Entry`")
 		cls.enterClassContext(cls.change_settings("Selling Settings", validate_selling_price=0))
-		cls.enterClassContext(cls.change_settings("Accounts Settings", invoice_doctype_in_pos="POS Invoice"))
+		cls.enterClassContext(cls.change_settings("POS Settings", invoice_type="POS Invoice"))
 		mode_of_payment = frappe.get_doc("Mode of Payment", "Bank Draft")
 		set_default_account_for_mode_of_payment(mode_of_payment, "_Test Company", "_Test Bank - _TC")
 

--- a/erpnext/accounts/doctype/pos_invoice_merge_log/test_pos_invoice_merge_log.py
+++ b/erpnext/accounts/doctype/pos_invoice_merge_log/test_pos_invoice_merge_log.py
@@ -5,12 +5,16 @@ import json
 import frappe
 from frappe.tests import IntegrationTestCase
 
+from erpnext.accounts.doctype.mode_of_payment.test_mode_of_payment import (
+	set_default_account_for_mode_of_payment,
+)
+from erpnext.accounts.doctype.pos_closing_entry.pos_closing_entry import (
+	make_closing_entry_from_opening,
+)
 from erpnext.accounts.doctype.pos_closing_entry.test_pos_closing_entry import init_user_and_profile
 from erpnext.accounts.doctype.pos_invoice.pos_invoice import make_sales_return
 from erpnext.accounts.doctype.pos_invoice.test_pos_invoice import create_pos_invoice
-from erpnext.accounts.doctype.pos_invoice_merge_log.pos_invoice_merge_log import (
-	consolidate_pos_invoices,
-)
+from erpnext.accounts.doctype.pos_opening_entry.test_pos_opening_entry import create_opening_entry
 from erpnext.stock.doctype.serial_and_batch_bundle.test_serial_and_batch_bundle import (
 	get_serial_nos_from_bundle,
 )
@@ -21,241 +25,310 @@ class TestPOSInvoiceMergeLog(IntegrationTestCase):
 	@classmethod
 	def setUpClass(cls):
 		super().setUpClass()
+		frappe.db.sql("delete from `tabPOS Opening Entry`")
 		cls.enterClassContext(cls.change_settings("Selling Settings", validate_selling_price=0))
+		cls.enterClassContext(cls.change_settings("Accounts Settings", invoice_doctype_in_pos="POS Invoice"))
+		mode_of_payment = frappe.get_doc("Mode of Payment", "Bank Draft")
+		set_default_account_for_mode_of_payment(mode_of_payment, "_Test Company", "_Test Bank - _TC")
+
+	def setUp(self):
+		frappe.db.sql("delete from `tabPOS Invoice`")
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		frappe.db.sql("delete from `tabPOS Profile`")
+		frappe.db.sql("delete from `tabPOS Invoice`")
 
 	def test_consolidated_invoice_creation(self):
-		frappe.db.sql("delete from `tabPOS Invoice`")
+		test_user, pos_profile = init_user_and_profile()
+		opening_entry = create_opening_entry(pos_profile, test_user)
 
-		try:
-			test_user, pos_profile = init_user_and_profile()
+		pos_inv = create_pos_invoice(rate=300, do_not_submit=1)
+		pos_inv.append("payments", {"mode_of_payment": "Cash", "account": "Cash - _TC", "amount": 300})
+		pos_inv.save()
+		pos_inv.submit()
 
-			pos_inv = create_pos_invoice(rate=300, do_not_submit=1)
-			pos_inv.append("payments", {"mode_of_payment": "Cash", "account": "Cash - _TC", "amount": 300})
-			pos_inv.save()
-			pos_inv.submit()
+		pos_inv2 = create_pos_invoice(rate=3200, do_not_submit=1)
+		pos_inv2.append("payments", {"mode_of_payment": "Cash", "account": "Cash - _TC", "amount": 3200})
+		pos_inv2.save()
+		pos_inv2.submit()
 
-			pos_inv2 = create_pos_invoice(rate=3200, do_not_submit=1)
-			pos_inv2.append("payments", {"mode_of_payment": "Cash", "account": "Cash - _TC", "amount": 3200})
-			pos_inv2.save()
-			pos_inv2.submit()
+		pos_inv3 = create_pos_invoice(customer="_Test Customer 2", rate=2300, do_not_submit=1)
+		pos_inv3.append("payments", {"mode_of_payment": "Cash", "account": "Cash - _TC", "amount": 2300})
+		pos_inv3.save()
+		pos_inv3.submit()
 
-			pos_inv3 = create_pos_invoice(customer="_Test Customer 2", rate=2300, do_not_submit=1)
-			pos_inv3.append("payments", {"mode_of_payment": "Cash", "account": "Cash - _TC", "amount": 2300})
-			pos_inv3.save()
-			pos_inv3.submit()
+		closing_entry = make_closing_entry_from_opening(opening_entry)
+		closing_entry.insert()
+		closing_entry.submit()
 
-			consolidate_pos_invoices()
+		pos_inv.load_from_db()
+		self.assertTrue(frappe.db.exists("Sales Invoice", pos_inv.consolidated_invoice))
 
-			pos_inv.load_from_db()
-			self.assertTrue(frappe.db.exists("Sales Invoice", pos_inv.consolidated_invoice))
+		pos_inv3.load_from_db()
+		self.assertTrue(frappe.db.exists("Sales Invoice", pos_inv3.consolidated_invoice))
 
-			pos_inv3.load_from_db()
-			self.assertTrue(frappe.db.exists("Sales Invoice", pos_inv3.consolidated_invoice))
-
-			self.assertFalse(pos_inv.consolidated_invoice == pos_inv3.consolidated_invoice)
-
-		finally:
-			frappe.set_user("Administrator")
-			frappe.db.sql("delete from `tabPOS Profile`")
-			frappe.db.sql("delete from `tabPOS Invoice`")
+		self.assertFalse(pos_inv.consolidated_invoice == pos_inv3.consolidated_invoice)
 
 	def test_consolidated_credit_note_creation(self):
-		frappe.db.sql("delete from `tabPOS Invoice`")
+		test_user, pos_profile = init_user_and_profile()
+		opening_entry = create_opening_entry(pos_profile, test_user)
 
-		try:
-			test_user, pos_profile = init_user_and_profile()
+		pos_inv = create_pos_invoice(rate=300, do_not_submit=1)
+		pos_inv.append("payments", {"mode_of_payment": "Cash", "account": "Cash - _TC", "amount": 300})
+		pos_inv.save()
+		pos_inv.submit()
 
-			pos_inv = create_pos_invoice(rate=300, do_not_submit=1)
-			pos_inv.append("payments", {"mode_of_payment": "Cash", "account": "Cash - _TC", "amount": 300})
-			pos_inv.save()
-			pos_inv.submit()
+		pos_inv2 = create_pos_invoice(rate=3200, do_not_submit=1)
+		pos_inv2.append("payments", {"mode_of_payment": "Cash", "account": "Cash - _TC", "amount": 3200})
+		pos_inv2.save()
+		pos_inv2.submit()
 
-			pos_inv2 = create_pos_invoice(rate=3200, do_not_submit=1)
-			pos_inv2.append("payments", {"mode_of_payment": "Cash", "account": "Cash - _TC", "amount": 3200})
-			pos_inv2.save()
-			pos_inv2.submit()
+		pos_inv3 = create_pos_invoice(customer="_Test Customer 2", rate=2300, do_not_submit=1)
+		pos_inv3.append("payments", {"mode_of_payment": "Cash", "account": "Cash - _TC", "amount": 2300})
+		pos_inv3.save()
+		pos_inv3.submit()
 
-			pos_inv3 = create_pos_invoice(customer="_Test Customer 2", rate=2300, do_not_submit=1)
-			pos_inv3.append("payments", {"mode_of_payment": "Cash", "account": "Cash - _TC", "amount": 2300})
-			pos_inv3.save()
-			pos_inv3.submit()
+		pos_inv_cn = make_sales_return(pos_inv.name)
+		pos_inv_cn.set("payments", [])
+		pos_inv_cn.append("payments", {"mode_of_payment": "Cash", "account": "Cash - _TC", "amount": -100})
+		pos_inv_cn.append(
+			"payments", {"mode_of_payment": "Bank Draft", "account": "_Test Bank - _TC", "amount": -200}
+		)
+		pos_inv_cn.paid_amount = -300
+		pos_inv_cn.submit()
 
-			pos_inv_cn = make_sales_return(pos_inv.name)
-			pos_inv_cn.set("payments", [])
-			pos_inv_cn.append(
-				"payments", {"mode_of_payment": "Cash", "account": "Cash - _TC", "amount": -100}
-			)
-			pos_inv_cn.append(
-				"payments", {"mode_of_payment": "Bank Draft", "account": "_Test Bank - _TC", "amount": -200}
-			)
-			pos_inv_cn.paid_amount = -300
-			pos_inv_cn.submit()
+		closing_entry = make_closing_entry_from_opening(opening_entry)
+		closing_entry.insert()
+		closing_entry.submit()
 
-			consolidate_pos_invoices()
+		pos_inv.load_from_db()
+		self.assertTrue(frappe.db.exists("Sales Invoice", pos_inv.consolidated_invoice))
 
-			pos_inv.load_from_db()
-			self.assertTrue(frappe.db.exists("Sales Invoice", pos_inv.consolidated_invoice))
+		pos_inv3.load_from_db()
+		self.assertTrue(frappe.db.exists("Sales Invoice", pos_inv3.consolidated_invoice))
 
-			pos_inv3.load_from_db()
-			self.assertTrue(frappe.db.exists("Sales Invoice", pos_inv3.consolidated_invoice))
-
-			pos_inv_cn.load_from_db()
-			self.assertTrue(frappe.db.exists("Sales Invoice", pos_inv_cn.consolidated_invoice))
-			consolidated_credit_note = frappe.get_doc("Sales Invoice", pos_inv_cn.consolidated_invoice)
-			self.assertEqual(consolidated_credit_note.is_return, 1)
-			self.assertEqual(consolidated_credit_note.payments[0].mode_of_payment, "Cash")
-			self.assertEqual(consolidated_credit_note.payments[0].amount, -100)
-			self.assertEqual(consolidated_credit_note.payments[1].mode_of_payment, "Bank Draft")
-			self.assertEqual(consolidated_credit_note.payments[1].amount, -200)
-
-		finally:
-			frappe.set_user("Administrator")
-			frappe.db.sql("delete from `tabPOS Profile`")
-			frappe.db.sql("delete from `tabPOS Invoice`")
+		pos_inv_cn.load_from_db()
+		self.assertTrue(frappe.db.exists("Sales Invoice", pos_inv_cn.consolidated_invoice))
+		consolidated_credit_note = frappe.get_doc("Sales Invoice", pos_inv_cn.consolidated_invoice)
+		self.assertEqual(consolidated_credit_note.is_return, 1)
+		self.assertEqual(consolidated_credit_note.payments[0].mode_of_payment, "Cash")
+		self.assertEqual(consolidated_credit_note.payments[0].amount, -100)
+		self.assertEqual(consolidated_credit_note.payments[1].mode_of_payment, "Bank Draft")
+		self.assertEqual(consolidated_credit_note.payments[1].amount, -200)
 
 	def test_consolidated_invoice_item_taxes(self):
-		frappe.db.sql("delete from `tabPOS Invoice`")
+		test_user, pos_profile = init_user_and_profile()
+		opening_entry = create_opening_entry(pos_profile, test_user)
 
-		try:
-			inv = create_pos_invoice(qty=1, rate=100, do_not_save=True)
+		inv = create_pos_invoice(qty=1, rate=100, do_not_save=True)
 
-			inv.append(
-				"taxes",
-				{
-					"account_head": "_Test Account VAT - _TC",
-					"charge_type": "On Net Total",
-					"cost_center": "_Test Cost Center - _TC",
-					"description": "VAT",
-					"doctype": "Sales Taxes and Charges",
-					"rate": 9,
-				},
-			)
-			inv.insert()
-			inv.payments[0].amount = inv.grand_total
-			inv.save()
-			inv.submit()
+		inv.append(
+			"taxes",
+			{
+				"account_head": "_Test Account VAT - _TC",
+				"charge_type": "On Net Total",
+				"cost_center": "_Test Cost Center - _TC",
+				"description": "VAT",
+				"doctype": "Sales Taxes and Charges",
+				"rate": 9,
+			},
+		)
+		inv.insert()
+		inv.payments[0].amount = inv.grand_total
+		inv.save()
+		inv.submit()
 
-			inv2 = create_pos_invoice(qty=1, rate=100, do_not_save=True)
-			inv2.get("items")[0].item_code = "_Test Item 2"
-			inv2.append(
-				"taxes",
-				{
-					"account_head": "_Test Account VAT - _TC",
-					"charge_type": "On Net Total",
-					"cost_center": "_Test Cost Center - _TC",
-					"description": "VAT",
-					"doctype": "Sales Taxes and Charges",
-					"rate": 5,
-				},
-			)
-			inv2.insert()
-			inv2.payments[0].amount = inv.grand_total
-			inv2.save()
-			inv2.submit()
+		inv2 = create_pos_invoice(qty=1, rate=100, do_not_save=True)
+		inv2.get("items")[0].item_code = "_Test Item 2"
+		inv2.append(
+			"taxes",
+			{
+				"account_head": "_Test Account VAT - _TC",
+				"charge_type": "On Net Total",
+				"cost_center": "_Test Cost Center - _TC",
+				"description": "VAT",
+				"doctype": "Sales Taxes and Charges",
+				"rate": 5,
+			},
+		)
+		inv2.insert()
+		inv2.payments[0].amount = inv.grand_total
+		inv2.save()
+		inv2.submit()
 
-			consolidate_pos_invoices()
-			inv.load_from_db()
+		closing_entry = make_closing_entry_from_opening(opening_entry)
+		closing_entry.insert()
+		closing_entry.submit()
 
-			consolidated_invoice = frappe.get_doc("Sales Invoice", inv.consolidated_invoice)
-			item_wise_tax_detail = json.loads(consolidated_invoice.get("taxes")[0].item_wise_tax_detail)
-			expected_item_wise_tax_detail = {
-				"_Test Item": {
-					"tax_rate": 9,
-					"tax_amount": 9,
-					"net_amount": 100,
-				},
-				"_Test Item 2": {
-					"tax_rate": 5,
-					"tax_amount": 5,
-					"net_amount": 100,
-				},
-			}
-			self.assertEqual(item_wise_tax_detail, expected_item_wise_tax_detail)
-		finally:
-			frappe.set_user("Administrator")
-			frappe.db.sql("delete from `tabPOS Profile`")
-			frappe.db.sql("delete from `tabPOS Invoice`")
+		inv.load_from_db()
+
+		consolidated_invoice = frappe.get_doc("Sales Invoice", inv.consolidated_invoice)
+		item_wise_tax_detail = json.loads(consolidated_invoice.get("taxes")[0].item_wise_tax_detail)
+		expected_item_wise_tax_detail = {
+			"_Test Item": {
+				"tax_rate": 9,
+				"tax_amount": 9,
+				"net_amount": 100,
+			},
+			"_Test Item 2": {
+				"tax_rate": 5,
+				"tax_amount": 5,
+				"net_amount": 100,
+			},
+		}
+		self.assertEqual(item_wise_tax_detail, expected_item_wise_tax_detail)
 
 	def test_consolidation_round_off_error_1(self):
 		"""
 		Test round off error in consolidated invoice creation if POS Invoice has inclusive tax
 		"""
 
-		frappe.db.sql("delete from `tabPOS Invoice`")
+		make_stock_entry(
+			to_warehouse="_Test Warehouse - _TC",
+			item_code="_Test Item",
+			rate=8000,
+			qty=10,
+		)
 
-		try:
-			make_stock_entry(
-				to_warehouse="_Test Warehouse - _TC",
-				item_code="_Test Item",
-				rate=8000,
-				qty=10,
-			)
+		test_user, pos_profile = init_user_and_profile()
+		opening_entry = create_opening_entry(pos_profile, test_user)
 
-			init_user_and_profile()
+		inv = create_pos_invoice(qty=3, rate=10000, do_not_save=True)
+		inv.append(
+			"taxes",
+			{
+				"account_head": "_Test Account VAT - _TC",
+				"charge_type": "On Net Total",
+				"cost_center": "_Test Cost Center - _TC",
+				"description": "VAT",
+				"doctype": "Sales Taxes and Charges",
+				"rate": 7.5,
+				"included_in_print_rate": 1,
+			},
+		)
+		inv.append("payments", {"mode_of_payment": "Cash", "account": "Cash - _TC", "amount": 30000})
+		inv.insert()
+		inv.submit()
 
-			inv = create_pos_invoice(qty=3, rate=10000, do_not_save=True)
-			inv.append(
-				"taxes",
-				{
-					"account_head": "_Test Account VAT - _TC",
-					"charge_type": "On Net Total",
-					"cost_center": "_Test Cost Center - _TC",
-					"description": "VAT",
-					"doctype": "Sales Taxes and Charges",
-					"rate": 7.5,
-					"included_in_print_rate": 1,
-				},
-			)
-			inv.append("payments", {"mode_of_payment": "Cash", "account": "Cash - _TC", "amount": 30000})
-			inv.insert()
-			inv.submit()
+		inv2 = create_pos_invoice(qty=3, rate=10000, do_not_save=True)
+		inv2.append(
+			"taxes",
+			{
+				"account_head": "_Test Account VAT - _TC",
+				"charge_type": "On Net Total",
+				"cost_center": "_Test Cost Center - _TC",
+				"description": "VAT",
+				"doctype": "Sales Taxes and Charges",
+				"rate": 7.5,
+				"included_in_print_rate": 1,
+			},
+		)
+		inv2.append("payments", {"mode_of_payment": "Cash", "account": "Cash - _TC", "amount": 30000})
+		inv2.insert()
+		inv2.submit()
 
-			inv2 = create_pos_invoice(qty=3, rate=10000, do_not_save=True)
-			inv2.append(
-				"taxes",
-				{
-					"account_head": "_Test Account VAT - _TC",
-					"charge_type": "On Net Total",
-					"cost_center": "_Test Cost Center - _TC",
-					"description": "VAT",
-					"doctype": "Sales Taxes and Charges",
-					"rate": 7.5,
-					"included_in_print_rate": 1,
-				},
-			)
-			inv2.append("payments", {"mode_of_payment": "Cash", "account": "Cash - _TC", "amount": 30000})
-			inv2.insert()
-			inv2.submit()
+		closing_entry = make_closing_entry_from_opening(opening_entry)
+		closing_entry.insert()
+		closing_entry.submit()
 
-			consolidate_pos_invoices()
-
-			inv.load_from_db()
-			consolidated_invoice = frappe.get_doc("Sales Invoice", inv.consolidated_invoice)
-			self.assertEqual(consolidated_invoice.outstanding_amount, 0)
-			self.assertEqual(consolidated_invoice.status, "Paid")
-
-		finally:
-			frappe.set_user("Administrator")
-			frappe.db.sql("delete from `tabPOS Profile`")
-			frappe.db.sql("delete from `tabPOS Invoice`")
+		inv.load_from_db()
+		consolidated_invoice = frappe.get_doc("Sales Invoice", inv.consolidated_invoice)
+		self.assertEqual(consolidated_invoice.outstanding_amount, 0)
+		self.assertEqual(consolidated_invoice.status, "Paid")
 
 	def test_consolidation_round_off_error_2(self):
 		"""
 		Test the same case as above but with an Unpaid POS Invoice
 		"""
-		frappe.db.sql("delete from `tabPOS Invoice`")
+		make_stock_entry(
+			to_warehouse="_Test Warehouse - _TC",
+			item_code="_Test Item",
+			rate=8000,
+			qty=10,
+		)
 
-		try:
-			make_stock_entry(
-				to_warehouse="_Test Warehouse - _TC",
-				item_code="_Test Item",
-				rate=8000,
-				qty=10,
-			)
+		test_user, pos_profile = init_user_and_profile()
+		opening_entry = create_opening_entry(pos_profile, test_user)
 
-			init_user_and_profile()
+		inv = create_pos_invoice(qty=6, rate=10000, do_not_save=True)
+		inv.append(
+			"taxes",
+			{
+				"account_head": "_Test Account VAT - _TC",
+				"charge_type": "On Net Total",
+				"cost_center": "_Test Cost Center - _TC",
+				"description": "VAT",
+				"doctype": "Sales Taxes and Charges",
+				"rate": 7.5,
+				"included_in_print_rate": 1,
+			},
+		)
+		inv.append("payments", {"mode_of_payment": "Cash", "account": "Cash - _TC", "amount": 60000})
+		inv.insert()
+		inv.submit()
 
-			inv = create_pos_invoice(qty=6, rate=10000, do_not_save=True)
+		inv2 = create_pos_invoice(qty=6, rate=10000, do_not_save=True)
+		inv2.append(
+			"taxes",
+			{
+				"account_head": "_Test Account VAT - _TC",
+				"charge_type": "On Net Total",
+				"cost_center": "_Test Cost Center - _TC",
+				"description": "VAT",
+				"doctype": "Sales Taxes and Charges",
+				"rate": 7.5,
+				"included_in_print_rate": 1,
+			},
+		)
+		inv2.append("payments", {"mode_of_payment": "Cash", "account": "Cash - _TC", "amount": 60000})
+		inv2.insert()
+		inv2.submit()
+
+		inv3 = create_pos_invoice(qty=3, rate=600, do_not_save=True)
+		inv3.append("payments", {"mode_of_payment": "Cash", "account": "Cash - _TC", "amount": 1800})
+		inv3.insert()
+		inv3.submit()
+
+		closing_entry = make_closing_entry_from_opening(opening_entry)
+		closing_entry.insert()
+		closing_entry.submit()
+
+		inv.load_from_db()
+		consolidated_invoice = frappe.get_doc("Sales Invoice", inv.consolidated_invoice)
+		self.assertNotEqual(consolidated_invoice.outstanding_amount, 800)
+		self.assertEqual(consolidated_invoice.status, "Paid")
+
+	@IntegrationTestCase.change_settings(
+		"System Settings", {"number_format": "#,###.###", "currency_precision": 3, "float_precision": 3}
+	)
+	def test_consolidation_round_off_error_3(self):
+		make_stock_entry(
+			to_warehouse="_Test Warehouse - _TC",
+			item_code="_Test Item",
+			rate=8000,
+			qty=10,
+		)
+		test_user, pos_profile = init_user_and_profile()
+		opening_entry = create_opening_entry(pos_profile, test_user)
+
+		item_rates = [69, 59, 29]
+		for _i in [1, 2]:
+			inv = create_pos_invoice(is_return=1, do_not_save=1)
+			inv.items = []
+			for rate in item_rates:
+				inv.append(
+					"items",
+					{
+						"item_code": "_Test Item",
+						"warehouse": "_Test Warehouse - _TC",
+						"qty": -1,
+						"rate": rate,
+						"income_account": "Sales - _TC",
+						"expense_account": "Cost of Goods Sold - _TC",
+						"cost_center": "_Test Cost Center - _TC",
+					},
+				)
 			inv.append(
 				"taxes",
 				{
@@ -264,146 +337,56 @@ class TestPOSInvoiceMergeLog(IntegrationTestCase):
 					"cost_center": "_Test Cost Center - _TC",
 					"description": "VAT",
 					"doctype": "Sales Taxes and Charges",
-					"rate": 7.5,
+					"rate": 15,
 					"included_in_print_rate": 1,
 				},
 			)
-			inv.append("payments", {"mode_of_payment": "Cash", "account": "Cash - _TC", "amount": 60000})
-			inv.insert()
+			inv.payments = []
+			inv.append("payments", {"mode_of_payment": "Cash", "account": "Cash - _TC", "amount": -157})
+			inv.paid_amount = -157
+			inv.save()
 			inv.submit()
 
-			inv2 = create_pos_invoice(qty=6, rate=10000, do_not_save=True)
-			inv2.append(
-				"taxes",
-				{
-					"account_head": "_Test Account VAT - _TC",
-					"charge_type": "On Net Total",
-					"cost_center": "_Test Cost Center - _TC",
-					"description": "VAT",
-					"doctype": "Sales Taxes and Charges",
-					"rate": 7.5,
-					"included_in_print_rate": 1,
-				},
-			)
-			inv2.append("payments", {"mode_of_payment": "Cash", "account": "Cash - _TC", "amount": 60000})
-			inv2.insert()
-			inv2.submit()
+		closing_entry = make_closing_entry_from_opening(opening_entry)
+		closing_entry.insert()
+		closing_entry.submit()
 
-			inv3 = create_pos_invoice(qty=3, rate=600, do_not_save=True)
-			inv3.append("payments", {"mode_of_payment": "Cash", "account": "Cash - _TC", "amount": 1800})
-			inv3.insert()
-			inv3.submit()
-
-			consolidate_pos_invoices()
-
-			inv.load_from_db()
-			consolidated_invoice = frappe.get_doc("Sales Invoice", inv.consolidated_invoice)
-			self.assertNotEqual(consolidated_invoice.outstanding_amount, 800)
-			self.assertEqual(consolidated_invoice.status, "Paid")
-
-		finally:
-			frappe.set_user("Administrator")
-			frappe.db.sql("delete from `tabPOS Profile`")
-			frappe.db.sql("delete from `tabPOS Invoice`")
-
-	@IntegrationTestCase.change_settings(
-		"System Settings", {"number_format": "#,###.###", "currency_precision": 3, "float_precision": 3}
-	)
-	def test_consolidation_round_off_error_3(self):
-		frappe.db.sql("delete from `tabPOS Invoice`")
-
-		try:
-			make_stock_entry(
-				to_warehouse="_Test Warehouse - _TC",
-				item_code="_Test Item",
-				rate=8000,
-				qty=10,
-			)
-			init_user_and_profile()
-
-			item_rates = [69, 59, 29]
-			for _i in [1, 2]:
-				inv = create_pos_invoice(is_return=1, do_not_save=1)
-				inv.items = []
-				for rate in item_rates:
-					inv.append(
-						"items",
-						{
-							"item_code": "_Test Item",
-							"warehouse": "_Test Warehouse - _TC",
-							"qty": -1,
-							"rate": rate,
-							"income_account": "Sales - _TC",
-							"expense_account": "Cost of Goods Sold - _TC",
-							"cost_center": "_Test Cost Center - _TC",
-						},
-					)
-				inv.append(
-					"taxes",
-					{
-						"account_head": "_Test Account VAT - _TC",
-						"charge_type": "On Net Total",
-						"cost_center": "_Test Cost Center - _TC",
-						"description": "VAT",
-						"doctype": "Sales Taxes and Charges",
-						"rate": 15,
-						"included_in_print_rate": 1,
-					},
-				)
-				inv.payments = []
-				inv.append("payments", {"mode_of_payment": "Cash", "account": "Cash - _TC", "amount": -157})
-				inv.paid_amount = -157
-				inv.save()
-				inv.submit()
-
-			consolidate_pos_invoices()
-
-			inv.load_from_db()
-			consolidated_invoice = frappe.get_doc("Sales Invoice", inv.consolidated_invoice)
-			self.assertEqual(consolidated_invoice.status, "Return")
-			self.assertEqual(consolidated_invoice.rounding_adjustment, -0.002)
-
-		finally:
-			frappe.set_user("Administrator")
-			frappe.db.sql("delete from `tabPOS Profile`")
-			frappe.db.sql("delete from `tabPOS Invoice`")
+		inv.load_from_db()
+		consolidated_invoice = frappe.get_doc("Sales Invoice", inv.consolidated_invoice)
+		self.assertEqual(consolidated_invoice.status, "Return")
+		self.assertEqual(consolidated_invoice.rounding_adjustment, -0.002)
 
 	def test_consolidation_rounding_adjustment(self):
 		"""
 		Test if the rounding adjustment is calculated correctly
 		"""
-		frappe.db.sql("delete from `tabPOS Invoice`")
+		make_stock_entry(
+			to_warehouse="_Test Warehouse - _TC",
+			item_code="_Test Item",
+			rate=8000,
+			qty=10,
+		)
 
-		try:
-			make_stock_entry(
-				to_warehouse="_Test Warehouse - _TC",
-				item_code="_Test Item",
-				rate=8000,
-				qty=10,
-			)
+		test_user, pos_profile = init_user_and_profile()
+		opening_entry = create_opening_entry(pos_profile, test_user)
 
-			init_user_and_profile()
+		inv = create_pos_invoice(qty=1, rate=69.5, do_not_save=True)
+		inv.append("payments", {"mode_of_payment": "Cash", "account": "Cash - _TC", "amount": 70})
+		inv.insert()
+		inv.submit()
 
-			inv = create_pos_invoice(qty=1, rate=69.5, do_not_save=True)
-			inv.append("payments", {"mode_of_payment": "Cash", "account": "Cash - _TC", "amount": 70})
-			inv.insert()
-			inv.submit()
+		inv2 = create_pos_invoice(qty=1, rate=59.5, do_not_save=True)
+		inv2.append("payments", {"mode_of_payment": "Cash", "account": "Cash - _TC", "amount": 60})
+		inv2.insert()
+		inv2.submit()
 
-			inv2 = create_pos_invoice(qty=1, rate=59.5, do_not_save=True)
-			inv2.append("payments", {"mode_of_payment": "Cash", "account": "Cash - _TC", "amount": 60})
-			inv2.insert()
-			inv2.submit()
+		closing_entry = make_closing_entry_from_opening(opening_entry)
+		closing_entry.insert()
+		closing_entry.submit()
 
-			consolidate_pos_invoices()
-
-			inv.load_from_db()
-			consolidated_invoice = frappe.get_doc("Sales Invoice", inv.consolidated_invoice)
-			self.assertEqual(consolidated_invoice.rounding_adjustment, 1)
-
-		finally:
-			frappe.set_user("Administrator")
-			frappe.db.sql("delete from `tabPOS Profile`")
-			frappe.db.sql("delete from `tabPOS Invoice`")
+		inv.load_from_db()
+		consolidated_invoice = frappe.get_doc("Sales Invoice", inv.consolidated_invoice)
+		self.assertEqual(consolidated_invoice.rounding_adjustment, 1)
 
 	def test_serial_no_case_1(self):
 		"""
@@ -418,51 +401,46 @@ class TestPOSInvoiceMergeLog(IntegrationTestCase):
 
 		from erpnext.stock.doctype.stock_entry.test_stock_entry import make_serialized_item
 
-		frappe.db.sql("delete from `tabPOS Invoice`")
+		se = make_serialized_item(self)
+		serial_no = get_serial_nos_from_bundle(se.get("items")[0].serial_and_batch_bundle)[0]
 
-		try:
-			se = make_serialized_item(self)
-			serial_no = get_serial_nos_from_bundle(se.get("items")[0].serial_and_batch_bundle)[0]
+		test_user, pos_profile = init_user_and_profile()
+		opening_entry = create_opening_entry(pos_profile, test_user)
 
-			init_user_and_profile()
+		pos_inv = create_pos_invoice(
+			item_code="_Test Serialized Item With Series",
+			serial_no=[serial_no],
+			qty=1,
+			rate=100,
+			do_not_submit=1,
+		)
+		pos_inv.append("payments", {"mode_of_payment": "Cash", "account": "Cash - _TC", "amount": 100})
+		pos_inv.save()
+		pos_inv.submit()
 
-			pos_inv = create_pos_invoice(
-				item_code="_Test Serialized Item With Series",
-				serial_no=[serial_no],
-				qty=1,
-				rate=100,
-				do_not_submit=1,
-			)
-			pos_inv.append("payments", {"mode_of_payment": "Cash", "account": "Cash - _TC", "amount": 100})
-			pos_inv.save()
-			pos_inv.submit()
+		pos_inv_cn = make_sales_return(pos_inv.name)
+		pos_inv_cn.paid_amount = -100
+		pos_inv_cn.submit()
 
-			pos_inv_cn = make_sales_return(pos_inv.name)
-			pos_inv_cn.paid_amount = -100
-			pos_inv_cn.submit()
+		pos_inv2 = create_pos_invoice(
+			item_code="_Test Serialized Item With Series",
+			serial_no=[serial_no],
+			qty=1,
+			rate=100,
+			do_not_submit=1,
+		)
+		pos_inv2.append("payments", {"mode_of_payment": "Cash", "account": "Cash - _TC", "amount": 100})
+		pos_inv2.save()
+		pos_inv2.submit()
 
-			pos_inv2 = create_pos_invoice(
-				item_code="_Test Serialized Item With Series",
-				serial_no=[serial_no],
-				qty=1,
-				rate=100,
-				do_not_submit=1,
-			)
-			pos_inv2.append("payments", {"mode_of_payment": "Cash", "account": "Cash - _TC", "amount": 100})
-			pos_inv2.save()
-			pos_inv2.submit()
+		closing_entry = make_closing_entry_from_opening(opening_entry)
+		closing_entry.insert()
+		closing_entry.submit()
 
-			consolidate_pos_invoices()
+		pos_inv.load_from_db()
+		pos_inv2.load_from_db()
 
-			pos_inv.load_from_db()
-			pos_inv2.load_from_db()
-
-			self.assertNotEqual(pos_inv.consolidated_invoice, pos_inv2.consolidated_invoice)
-
-		finally:
-			frappe.set_user("Administrator")
-			frappe.db.sql("delete from `tabPOS Profile`")
-			frappe.db.sql("delete from `tabPOS Invoice`")
+		self.assertNotEqual(pos_inv.consolidated_invoice, pos_inv2.consolidated_invoice)
 
 	def test_separate_consolidated_invoice_for_different_accounting_dimensions(self):
 		"""
@@ -473,48 +451,43 @@ class TestPOSInvoiceMergeLog(IntegrationTestCase):
 		"""
 		from erpnext.accounts.doctype.cost_center.test_cost_center import create_cost_center
 
-		frappe.db.sql("delete from `tabPOS Invoice`")
-
 		create_cost_center(cost_center_name="_Test POS Cost Center 1", is_group=0)
 		create_cost_center(cost_center_name="_Test POS Cost Center 2", is_group=0)
 
-		try:
-			test_user, pos_profile = init_user_and_profile()
+		test_user, pos_profile = init_user_and_profile()
+		opening_entry = create_opening_entry(pos_profile, test_user)
 
-			pos_inv = create_pos_invoice(rate=300, do_not_submit=1)
-			pos_inv.append("payments", {"mode_of_payment": "Cash", "account": "Cash - _TC", "amount": 300})
-			pos_inv.cost_center = "_Test POS Cost Center 1 - _TC"
-			pos_inv.save()
-			pos_inv.submit()
+		pos_inv = create_pos_invoice(rate=300, do_not_submit=1)
+		pos_inv.append("payments", {"mode_of_payment": "Cash", "account": "Cash - _TC", "amount": 300})
+		pos_inv.cost_center = "_Test POS Cost Center 1 - _TC"
+		pos_inv.save()
+		pos_inv.submit()
 
-			pos_inv2 = create_pos_invoice(rate=3200, do_not_submit=1)
-			pos_inv2.append("payments", {"mode_of_payment": "Cash", "account": "Cash - _TC", "amount": 3200})
-			pos_inv.cost_center = "_Test POS Cost Center 2 - _TC"
-			pos_inv2.save()
-			pos_inv2.submit()
+		pos_inv2 = create_pos_invoice(rate=3200, do_not_submit=1)
+		pos_inv2.append("payments", {"mode_of_payment": "Cash", "account": "Cash - _TC", "amount": 3200})
+		pos_inv.cost_center = "_Test POS Cost Center 2 - _TC"
+		pos_inv2.save()
+		pos_inv2.submit()
 
-			pos_inv3 = create_pos_invoice(rate=2300, do_not_submit=1)
-			pos_inv3.append("payments", {"mode_of_payment": "Cash", "account": "Cash - _TC", "amount": 2300})
-			pos_inv.cost_center = "_Test POS Cost Center 2 - _TC"
-			pos_inv3.save()
-			pos_inv3.submit()
+		pos_inv3 = create_pos_invoice(rate=2300, do_not_submit=1)
+		pos_inv3.append("payments", {"mode_of_payment": "Cash", "account": "Cash - _TC", "amount": 2300})
+		pos_inv.cost_center = "_Test POS Cost Center 2 - _TC"
+		pos_inv3.save()
+		pos_inv3.submit()
 
-			consolidate_pos_invoices()
+		closing_entry = make_closing_entry_from_opening(opening_entry)
+		closing_entry.insert()
+		closing_entry.submit()
 
-			pos_inv.load_from_db()
-			self.assertTrue(frappe.db.exists("Sales Invoice", pos_inv.consolidated_invoice))
+		pos_inv.load_from_db()
+		self.assertTrue(frappe.db.exists("Sales Invoice", pos_inv.consolidated_invoice))
 
-			pos_inv2.load_from_db()
-			self.assertTrue(frappe.db.exists("Sales Invoice", pos_inv2.consolidated_invoice))
+		pos_inv2.load_from_db()
+		self.assertTrue(frappe.db.exists("Sales Invoice", pos_inv2.consolidated_invoice))
 
-			self.assertFalse(pos_inv.consolidated_invoice == pos_inv3.consolidated_invoice)
+		self.assertFalse(pos_inv.consolidated_invoice == pos_inv3.consolidated_invoice)
 
-			pos_inv3.load_from_db()
-			self.assertTrue(frappe.db.exists("Sales Invoice", pos_inv3.consolidated_invoice))
+		pos_inv3.load_from_db()
+		self.assertTrue(frappe.db.exists("Sales Invoice", pos_inv3.consolidated_invoice))
 
-			self.assertTrue(pos_inv2.consolidated_invoice == pos_inv3.consolidated_invoice)
-
-		finally:
-			frappe.set_user("Administrator")
-			frappe.db.sql("delete from `tabPOS Profile`")
-			frappe.db.sql("delete from `tabPOS Invoice`")
+		self.assertTrue(pos_inv2.consolidated_invoice == pos_inv3.consolidated_invoice)

--- a/erpnext/accounts/doctype/pos_settings/pos_settings.json
+++ b/erpnext/accounts/doctype/pos_settings/pos_settings.json
@@ -14,7 +14,7 @@
   {
    "fieldname": "invoice_fields",
    "fieldtype": "Table",
-   "label": "POS Field",
+   "label": "POS Additional Fields",
    "options": "POS Field"
   },
   {
@@ -38,7 +38,7 @@
  ],
  "issingle": 1,
  "links": [],
- "modified": "2025-06-06 11:31:41.530242",
+ "modified": "2025-06-06 11:36:44.885353",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "POS Settings",

--- a/erpnext/accounts/doctype/pos_settings/pos_settings.json
+++ b/erpnext/accounts/doctype/pos_settings/pos_settings.json
@@ -5,6 +5,8 @@
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
+  "invoice_type",
+  "section_break_gyos",
   "invoice_fields",
   "pos_search_fields"
  ],
@@ -20,11 +22,23 @@
    "fieldtype": "Table",
    "label": "POS Search Fields",
    "options": "POS Search Fields"
+  },
+  {
+   "default": "Sales Invoice",
+   "description": "The system will create a Sales Invoice or a POS Invoice from the POS interface based on this setting. For high-volume transactions, it is recommended to use POS Invoice.",
+   "fieldname": "invoice_type",
+   "fieldtype": "Select",
+   "label": "Invoice Type Created via POS Screen",
+   "options": "Sales Invoice\nPOS Invoice"
+  },
+  {
+   "fieldname": "section_break_gyos",
+   "fieldtype": "Section Break"
   }
  ],
  "issingle": 1,
  "links": [],
- "modified": "2024-03-27 13:10:17.083132",
+ "modified": "2025-06-06 11:31:41.530242",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "POS Settings",
@@ -56,6 +70,7 @@
   }
  ],
  "quick_entry": 1,
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -1096,10 +1096,8 @@ class SalesInvoice(SellingController):
 		if self.is_created_using_pos and not self.pos_profile:
 			frappe.throw(_("POS Profile is mandatory to mark this invoice as POS Transaction."))
 
-		self.invoice_doctype_in_pos = frappe.db.get_single_value(
-			"Accounts Settings", "invoice_doctype_in_pos"
-		)
-		if self.invoice_doctype_in_pos == "POS Invoice" and not self.is_return:
+		self.invoice_type_in_pos = frappe.db.get_single_value("POS Settings", "invoice_type")
+		if self.invoice_type_in_pos == "POS Invoice" and not self.is_return:
 			frappe.throw(_("Transactions using Sales Invoice in POS are disabled."))
 
 	def validate_full_payment(self):

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -1096,10 +1096,10 @@ class SalesInvoice(SellingController):
 		if self.is_created_using_pos and not self.pos_profile:
 			frappe.throw(_("POS Profile is mandatory to mark this invoice as POS Transaction."))
 
-		self.is_pos_using_sales_invoice = frappe.get_single_value(
-			"Accounts Settings", "use_sales_invoice_in_pos"
+		self.invoice_doctype_in_pos = frappe.db.get_single_value(
+			"Accounts Settings", "invoice_doctype_in_pos"
 		)
-		if not self.is_pos_using_sales_invoice and not self.is_return:
+		if self.invoice_doctype_in_pos == "POS Invoice" and not self.is_return:
 			frappe.throw(_("Transactions using Sales Invoice in POS are disabled."))
 
 	def validate_full_payment(self):

--- a/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
@@ -4425,7 +4425,7 @@ class TestSalesInvoice(ERPNextTestSuite):
 		# Deleting all opening entry
 		frappe.db.sql("delete from `tabPOS Opening Entry`")
 
-		with self.change_settings("Accounts Settings", {"invoice_doctype_in_pos": "POS Invoice"}):
+		with self.change_settings("POS Settings", {"invoice_type": "POS Invoice"}):
 			pos_profile = make_pos_profile()
 
 			pos_profile.payments = []

--- a/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
@@ -4495,6 +4495,14 @@ def create_sales_invoice(**args):
 	si.naming_series = args.naming_series or "T-SINV-"
 	si.cost_center = args.parent_cost_center
 	si.is_internal_customer = args.is_internal_customer or 0
+	if args.is_created_using_pos:
+		si.is_pos = 1
+		si.is_created_using_pos = 1
+		pos_profile = None
+		if not args.pos_profile:
+			pos_profile = make_pos_profile()
+			pos_profile.save()
+		si.pos_profile = args.pos_profile or pos_profile.name
 
 	bundle_id = None
 	if si.update_stock and (args.get("batch_no") or args.get("serial_no")):

--- a/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
@@ -4425,7 +4425,7 @@ class TestSalesInvoice(ERPNextTestSuite):
 		# Deleting all opening entry
 		frappe.db.sql("delete from `tabPOS Opening Entry`")
 
-		with self.change_settings("Accounts Settings", {"use_sales_invoice_in_pos": 0}):
+		with self.change_settings("Accounts Settings", {"invoice_doctype_in_pos": "POS Invoice"}):
 			pos_profile = make_pos_profile()
 
 			pos_profile.payments = []

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -420,3 +420,4 @@ erpnext.patches.v15_0.remove_agriculture_roles
 erpnext.patches.v14_0.update_full_name_in_contract
 erpnext.patches.v15_0.drop_sle_indexes
 execute:frappe.db.set_single_value("Accounts Settings", "confirm_before_resetting_posting_date", 1)
+erpnext.patches.v15_0.rename_pos_closing_entry_fields

--- a/erpnext/patches/v15_0/rename_pos_closing_entry_fields.py
+++ b/erpnext/patches/v15_0/rename_pos_closing_entry_fields.py
@@ -1,0 +1,6 @@
+from frappe.model.utils.rename_field import rename_field
+
+
+def execute():
+	rename_field("POS Closing Entry", "pos_transactions", "pos_invoices")
+	rename_field("POS Closing Entry", "sales_invoice_transactions", "sales_invoices")

--- a/erpnext/selling/page/point_of_sale/pos_controller.js
+++ b/erpnext/selling/page/point_of_sale/pos_controller.js
@@ -139,10 +139,7 @@ erpnext.PointOfSale.Controller = class {
 			this.allow_negative_stock = flt(message.allow_negative_stock) || false;
 		});
 
-		const invoice_doctype = await frappe.db.get_single_value(
-			"Accounts Settings",
-			"invoice_doctype_in_pos"
-		);
+		const invoice_doctype = await frappe.db.get_single_value("POS Settings", "invoice_type");
 
 		frappe.call({
 			method: "erpnext.selling.page.point_of_sale.point_of_sale.get_pos_profile_data",

--- a/erpnext/selling/page/point_of_sale/pos_controller.js
+++ b/erpnext/selling/page/point_of_sale/pos_controller.js
@@ -139,9 +139,9 @@ erpnext.PointOfSale.Controller = class {
 			this.allow_negative_stock = flt(message.allow_negative_stock) || false;
 		});
 
-		const use_sales_invoice_in_pos = await frappe.db.get_single_value(
+		const invoice_doctype = await frappe.db.get_single_value(
 			"Accounts Settings",
-			"use_sales_invoice_in_pos"
+			"invoice_doctype_in_pos"
 		);
 
 		frappe.call({
@@ -151,7 +151,7 @@ erpnext.PointOfSale.Controller = class {
 				const profile = res.message;
 				Object.assign(this.settings, profile);
 				this.settings.customer_groups = profile.customer_groups.map((group) => group.name);
-				this.settings.frm_doctype = use_sales_invoice_in_pos ? "Sales Invoice" : "POS Invoice";
+				this.settings.frm_doctype = invoice_doctype;
 				this.make_app();
 			},
 		});


### PR DESCRIPTION
Changes Include:

- Replaced Check field with Select Field on POS Settings, allowing users to select Invoice DocType, which will be used in POS to create Invoice
		Before: ![image](https://github.com/user-attachments/assets/0530ced2-b748-4eed-a922-4f6850f5b92b)
		After: ![image](https://github.com/user-attachments/assets/2a5173de-eda8-4361-a5b5-397bebc58c06)

- Refactored as suggested in https://github.com/frappe/erpnext/pull/46485#pullrequestreview-2753190075
- Replaced the `get_doc` method in `get_invoices` with SQL using Query Builder.
- Rearranged fields and removed Sales Summary in POS Closing Entry.
- Refactored existing test cases and added tests for the Sales Invoice Integration with POS.

