### PR TITLE
fix indonesia tax

### DIFF
--- a/erpnext/accounts/doctype/account/chart_of_accounts/verified/id_chart_of_accounts.json
+++ b/erpnext/accounts/doctype/account/chart_of_accounts/verified/id_chart_of_accounts.json
@@ -96,8 +96,20 @@
                         "account_number": "1132.000"
                     }, 
                     "account_number": "1130.000"
-                }, 
+                },
+                "Pajak Dibayar di Muka": {
+                    "PPN Masukan": {
+                        "account_number": "1151.001", 
+                        "account_type": "Tax"
+                    },
+                    "PPh 23 Dibayar di Muka": {
+                        "account_number": "1152.001", 
+                        "account_type": "Tax"
+                    }, 
+                    "account_number": "1150.000"
+                },
                 "account_number": "1100.000"
+                
             }, 
             "Aktiva Tetap": {
                 "Aktiva": {
@@ -557,6 +569,10 @@
                     "Hutang Pajak": {
                         "account_number": "2141.000", 
                         "account_type": "Payable"
+                    },
+                    "PPN Keluaran": {
+                        "account_number": "2142.000", 
+                        "account_type": "Tax"
                     }, 
                     "account_number": "2140.000"
                 }, 

--- a/erpnext/setup/setup_wizard/data/country_wise_tax.json
+++ b/erpnext/setup/setup_wizard/data/country_wise_tax.json
@@ -3900,9 +3900,13 @@
 	},
 
 	"Indonesia": {
-		"Indonesia Tax": {
-			"account_name": "VAT",
-			"tax_rate": 10.00
+		"Sales Tax": {
+			"account_name": "PPN Keluaran",
+			"tax_rate": 11.00
+		},
+		"Purchase Tax": {
+			"account_name": "PPn Masukan",
+			"tax_rate": 11.00
 		}
 	},
 


### PR DESCRIPTION
This Pull Request updates and restructures the Indonesian Chart of Accounts to better reflect local accounting and tax practices. The changes aim to improve the default tax account mappings used during initial company setup and ensure compliance with Indonesian tax regulations.

Key Changes:

Added Input VAT (PPN Masukan) and Prepaid Income Tax (PPh 23) under Current Assets → Prepaid Taxes as these are creditable taxes (classified as assets).

Ensured Output VAT (PPN Keluaran) remains under Tax Payable as it represents a liability to the government.

Improved naming consistency and structure for easier understanding by Indonesian users.


References:

Indonesian VAT Law (current standard rate: 11%)

Common accounting practices in Indonesian businesses

