### PR TITLE
Fix: Expected Time Required (In Mins) Not Copied to Job Cards from Work Order

### DIFF
--- a/erpnext/manufacturing/doctype/work_order/work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/work_order.py
@@ -1635,6 +1635,8 @@ def create_job_card(work_order, row, enable_capacity_planning=False, auto_create
 		doc.flags.ignore_mandatory = True
 		if enable_capacity_planning:
 			doc.schedule_time_logs(row)
+		else:
+			doc.time_required = row.get("time_in_mins")
 
 		doc.insert()
 		frappe.msgprint(_("Job card {0} created").format(get_link_to_form("Job Card", doc.name)), alert=True)


### PR DESCRIPTION
This PR ensures that the Expected Time Required (In Mins) field is copied from the operations to the job cards when creating them from a work order.

closes https://github.com/frappe/erpnext/issues/46995

Please Refer Previous PR - https://github.com/frappe/erpnext/pull/47000