### PR TITLE
fix: patch to set grand total to default mop if old column exists

### DIFF
--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -411,6 +411,6 @@ erpnext.patches.v15_0.rename_group_by_to_categorize_by
 execute:frappe.db.set_single_value("Accounts Settings", "receivable_payable_fetch_method", "Buffered Cursor")
 erpnext.patches.v14_0.set_update_price_list_based_on
 erpnext.patches.v15_0.update_journal_entry_type
-erpnext.patches.v15_0.set_grand_total_to_default_mop
+erpnext.patches.v15_0.set_grand_total_to_default_mop #2025-05-26
 execute:frappe.db.set_single_value("Accounts Settings", "use_new_budget_controller", True)
 erpnext.patches.v15_0.rename_group_by_to_categorize_by_in_custom_reports

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -411,6 +411,6 @@ erpnext.patches.v15_0.rename_group_by_to_categorize_by
 execute:frappe.db.set_single_value("Accounts Settings", "receivable_payable_fetch_method", "Buffered Cursor")
 erpnext.patches.v14_0.set_update_price_list_based_on
 erpnext.patches.v15_0.update_journal_entry_type
-erpnext.patches.v15_0.set_grand_total_to_default_mop #2025-05-26
+erpnext.patches.v15_0.set_grand_total_to_default_mop
 execute:frappe.db.set_single_value("Accounts Settings", "use_new_budget_controller", True)
 erpnext.patches.v15_0.rename_group_by_to_categorize_by_in_custom_reports

--- a/erpnext/patches/v15_0/set_grand_total_to_default_mop.py
+++ b/erpnext/patches/v15_0/set_grand_total_to_default_mop.py
@@ -2,8 +2,9 @@ import frappe
 
 
 def execute():
-	POSProfile = frappe.qb.DocType("POS Profile")
+	if frappe.db.has_column("POS Profile", "disable_grand_total_to_default_mop"):
+		POSProfile = frappe.qb.DocType("POS Profile")
 
-	frappe.qb.update(POSProfile).set(POSProfile.set_grand_total_to_default_mop, 1).where(
-		POSProfile.disable_grand_total_to_default_mop == 0
-	).run()
+		frappe.qb.update(POSProfile).set(POSProfile.set_grand_total_to_default_mop, 1).where(
+			POSProfile.disable_grand_total_to_default_mop == 0
+		).run()


### PR DESCRIPTION
Updated the patch to execute only if the `disable_grand_total_to_default_mop` column exists in the `POS Profile`.