### PR TITLE
fix: patch to sales_persons commission_rate decimal separator

### DIFF
--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -272,6 +272,7 @@ erpnext.patches.v14_0.update_reference_due_date_in_journal_entry
 erpnext.patches.v14_0.france_depreciation_warning
 erpnext.patches.v14_0.clear_reconciliation_values_from_singles
 erpnext.patches.v14_0.update_proprietorship_to_individual
+erpnext.patches.v14_0.update_sales_person_commission_rate
 
 [post_model_sync]
 execute:frappe.delete_doc_if_exists('Workspace', 'ERPNext Integrations Settings')

--- a/erpnext/patches/v14_0/update_sales_person_commission_rate.py
+++ b/erpnext/patches/v14_0/update_sales_person_commission_rate.py
@@ -1,0 +1,18 @@
+import frappe
+import re
+
+def execute():
+	number_format = frappe.db.get_default("number_format")
+	if number_format in ["#.###,##", "#,###", "# ###,##"]:
+
+		sales_persons = frappe.get_all("Sales Person",
+			fields=["commission_rate", "name"]
+		)
+
+		for sp in sales_persons:
+			if not sp.commission_rate:
+				sp.commission_rate = 0
+			commission_rate = str(sp.commission_rate).replace(",", ".")
+			if not re.fullmatch(r'^[0-9]+(\.[0-9]+)?$', str(commission_rate)):
+				commission_rate = 0
+			frappe.db.set_value("Sales Person", sp.name, "commission_rate", commission_rate)


### PR DESCRIPTION
## Description

This pull request fixes a known issue in ERPNext where some Sales Person documents have a commission rate formatted with a comma (",") instead of a dot (".") as the decimal separator. This causes errors when converting the commission rate to a float.

## Problem Statement

In some countries, the decimal separator is a comma (",") instead of a dot ("."). However, in ERPNext, the commission rate is expected to be in the format of a dot (".") as the decimal separator. This mismatch causes errors when trying to convert the commission rate to a float in all reports that use this value.

![cgo18rgQQYKBkC81pxmd2A](https://github.com/user-attachments/assets/bc8252fc-1de1-4bbe-801a-f053f018b9f4)


## Solution

The solution is to update the commission rate of Sales Person documents to use a dot (".") as the decimal separator. This is achieved by running a patch that iterates through all Sales Person documents, checks if the commission rate is formatted with a comma (","), and updates it to use a dot (".") if necessary.

## Changes

* Updated the `update_sales_person_commission_rate.py` patch to iterate through all Sales Person documents and update the commission rate to use a dot (".") as the decimal separator.

https://github.com/frappe/erpnext/issues/47239
