### PR TITLE
fix: update sql function usage syntax

### DIFF
--- a/erpnext/accounts/doctype/payment_reconciliation/test_payment_reconciliation.py
+++ b/erpnext/accounts/doctype/payment_reconciliation/test_payment_reconciliation.py
@@ -1988,7 +1988,7 @@ class TestPaymentReconciliation(IntegrationTestCase):
 
 	def test_reconciliation_on_closed_period_payment(self):
 		# create backdated fiscal year
-		first_fy_start_date = frappe.db.get_value("Fiscal Year", {"disabled": 0}, "min(year_start_date)")
+		first_fy_start_date = frappe.db.get_value("Fiscal Year", {"disabled": 0}, [{'MIN': 'year_start_date'}])
 		prev_fy_start_date = add_years(first_fy_start_date, -1)
 		prev_fy_end_date = add_days(first_fy_start_date, -1)
 		create_fiscal_year(

--- a/erpnext/stock/doctype/purchase_receipt/test_purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/test_purchase_receipt.py
@@ -2137,7 +2137,7 @@ class TestPurchaseReceipt(IntegrationTestCase):
 		self.assertEqual(flt(pr.total * pr.conversion_rate, 2), flt(pr.base_total, 2))
 
 		# Test - 2: Sum of Debit or Credit should be equal to Purchase Receipt Base Total
-		amount = frappe.db.get_value("GL Entry", {"docstatus": 1, "voucher_no": pr.name}, ["sum(debit)"])
+		amount = frappe.db.get_value("GL Entry", {"docstatus": 1, "voucher_no": pr.name}, [{'SUM': 'debit'}])
 		expected_amount = pr.base_total
 		self.assertEqual(amount, expected_amount)
 


### PR DESCRIPTION
Because of breaking changes in https://github.com/frappe/frappe/pull/32381

```
Before: 
first_fy_start_date = frappe.db.get_value("Fiscal Year", {"disabled": 0}, "min(year_start_date)")

After:
first_fy_start_date = frappe.db.get_value("Fiscal Year", {"disabled": 0}, [{'MIN': 'year_start_date'}])
```