### PR TITLE
fix: update sql function usage syntax

### DIFF
--- a/.github/helper/install.sh
+++ b/.github/helper/install.sh
@@ -66,7 +66,7 @@ sed -i 's/schedule:/# schedule:/g' Procfile
 sed -i 's/socketio:/# socketio:/g' Procfile
 sed -i 's/redis_socketio:/# redis_socketio:/g' Procfile
 
-bench get-app payments --branch ${githubbranch%"-hotfix"}
+bench get-app payments --branch develop
 bench get-app erpnext "${GITHUB_WORKSPACE}"
 
 if [ "$TYPE" == "server" ]; then bench setup requirements --dev; fi

--- a/erpnext/accounts/doctype/payment_reconciliation/test_payment_reconciliation.py
+++ b/erpnext/accounts/doctype/payment_reconciliation/test_payment_reconciliation.py
@@ -1979,7 +1979,7 @@ class TestPaymentReconciliation(IntegrationTestCase):
 
 	def test_reconciliation_on_closed_period_payment(self):
 		# create backdated fiscal year
-		first_fy_start_date = frappe.db.get_value("Fiscal Year", {"disabled": 0}, "min(year_start_date)")
+		first_fy_start_date = frappe.db.get_value("Fiscal Year", {"disabled": 0}, [{'MIN': 'year_start_date'}])
 		prev_fy_start_date = add_years(first_fy_start_date, -1)
 		prev_fy_end_date = add_days(first_fy_start_date, -1)
 		create_fiscal_year(

--- a/erpnext/accounts/doctype/payment_reconciliation/test_payment_reconciliation.py
+++ b/erpnext/accounts/doctype/payment_reconciliation/test_payment_reconciliation.py
@@ -1979,7 +1979,9 @@ class TestPaymentReconciliation(IntegrationTestCase):
 
 	def test_reconciliation_on_closed_period_payment(self):
 		# create backdated fiscal year
-		first_fy_start_date = frappe.db.get_value("Fiscal Year", {"disabled": 0}, [{'MIN': 'year_start_date'}])
+		first_fy_start_date = frappe.db.get_value(
+			"Fiscal Year", {"disabled": 0}, [{"MIN": "year_start_date"}]
+		)
 		prev_fy_start_date = add_years(first_fy_start_date, -1)
 		prev_fy_end_date = add_days(first_fy_start_date, -1)
 		create_fiscal_year(

--- a/erpnext/accounts/doctype/tax_withholding_category/tax_withholding_category.py
+++ b/erpnext/accounts/doctype/tax_withholding_category/tax_withholding_category.py
@@ -657,7 +657,7 @@ def get_tcs_amount(parties, inv, tax_details, vouchers, adv_vouchers):
 				"company": inv.company,
 				"voucher_no": ["in", vouchers],
 			},
-			"sum(debit)",
+			[{"SUM": "debit"}],
 		)
 		or 0.0
 	)
@@ -735,7 +735,7 @@ def get_limit_consumed(ldc, parties):
 			"posting_date": ("between", (ldc.valid_from, ldc.valid_upto)),
 			"company": ldc.company,
 		},
-		"sum(tax_withholding_net_total)",
+		[{"SUM": "tax_withholding_net_total"}],
 	)
 
 	return limit_consumed

--- a/erpnext/accounts/general_ledger.py
+++ b/erpnext/accounts/general_ledger.py
@@ -766,7 +766,7 @@ def validate_against_pcv(is_opening, posting_date, company):
 		)
 
 	last_pcv_date = frappe.db.get_value(
-		"Period Closing Voucher", {"docstatus": 1, "company": company}, {"MAX": "period_end_date"}
+		"Period Closing Voucher", {"docstatus": 1, "company": company}, [{"MAX": "period_end_date"}]
 	)
 
 	if last_pcv_date and getdate(posting_date) <= getdate(last_pcv_date):

--- a/erpnext/accounts/general_ledger.py
+++ b/erpnext/accounts/general_ledger.py
@@ -766,7 +766,7 @@ def validate_against_pcv(is_opening, posting_date, company):
 		)
 
 	last_pcv_date = frappe.db.get_value(
-		"Period Closing Voucher", {"docstatus": 1, "company": company}, "max(period_end_date)"
+		"Period Closing Voucher", {"docstatus": 1, "company": company}, {"MAX": "period_end_date"}
 	)
 
 	if last_pcv_date and getdate(posting_date) <= getdate(last_pcv_date):

--- a/erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py
+++ b/erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py
@@ -525,7 +525,7 @@ def get_grand_total(filters, doctype):
 				"docstatus": 1,
 				"posting_date": ("between", [filters.get("from_date"), filters.get("to_date")]),
 			},
-			"sum(base_grand_total)",
+			[{"SUM": "base_grand_total"}],
 		)
 	)
 

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -2232,6 +2232,8 @@ class AccountsController(TransactionBase):
 	def set_advance_payment_status(self):
 		new_status = None
 
+
+		PaymentRequest = frappe.qb.DocType("Payment Request")
 		paid_amount = frappe.get_value(
 			doctype="Payment Request",
 			filters={
@@ -2239,7 +2241,7 @@ class AccountsController(TransactionBase):
 				"reference_name": self.name,
 				"docstatus": 1,
 			},
-			fieldname="sum(grand_total - outstanding_amount)",
+			fieldname=Sum(PaymentRequest.grand_total - PaymentRequest.outstanding_amount),
 		)
 
 		if not paid_amount:

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -2232,7 +2232,6 @@ class AccountsController(TransactionBase):
 	def set_advance_payment_status(self):
 		new_status = None
 
-
 		PaymentRequest = frappe.qb.DocType("Payment Request")
 		paid_amount = frappe.get_value(
 			doctype="Payment Request",

--- a/erpnext/controllers/sales_and_purchase_return.py
+++ b/erpnext/controllers/sales_and_purchase_return.py
@@ -663,9 +663,7 @@ def get_rate_for_return(
 		select_field = "incoming_rate"
 	else:
 		StockLedgerEntry = frappe.qb.DocType("Stock Ledger Entry")
-		select_field = Abs(
-			StockLedgerEntry.stock_value_difference / StockLedgerEntry.actual_qty
-		)
+		select_field = Abs(StockLedgerEntry.stock_value_difference / StockLedgerEntry.actual_qty)
 
 	rate = flt(frappe.db.get_value("Stock Ledger Entry", filters, select_field))
 	if not (rate and return_against) and voucher_type in ["Sales Invoice", "Delivery Note"]:

--- a/erpnext/controllers/sales_and_purchase_return.py
+++ b/erpnext/controllers/sales_and_purchase_return.py
@@ -7,6 +7,7 @@ import frappe
 from frappe import _
 from frappe.model.meta import get_field_precision
 from frappe.query_builder import DocType
+from frappe.query_builder.functions import Abs
 from frappe.utils import cint, flt, format_datetime, get_datetime
 
 import erpnext
@@ -661,7 +662,10 @@ def get_rate_for_return(
 	if voucher_type in ("Purchase Receipt", "Purchase Invoice", "Subcontracting Receipt"):
 		select_field = "incoming_rate"
 	else:
-		select_field = "abs(stock_value_difference / actual_qty)"
+		StockLedgerEntry = frappe.qb.DocType("Stock Ledger Entry")
+		select_field = Abs(
+			StockLedgerEntry.stock_value_difference / StockLedgerEntry.actual_qty
+		)
 
 	rate = flt(frappe.db.get_value("Stock Ledger Entry", filters, select_field))
 	if not (rate and return_against) and voucher_type in ["Sales Invoice", "Delivery Note"]:

--- a/erpnext/patches/v12_0/set_total_batch_quantity.py
+++ b/erpnext/patches/v12_0/set_total_batch_quantity.py
@@ -9,7 +9,7 @@ def execute():
 			frappe.db.get_value(
 				"Stock Ledger Entry",
 				{"docstatus": 1, "batch_no": batch.batch_id, "is_cancelled": 0},
-				"sum(actual_qty)",
+				[{"SUM": "actual_qty"}],
 			)
 			or 0.0
 		)

--- a/erpnext/setup/doctype/sales_person/sales_person.py
+++ b/erpnext/setup/doctype/sales_person/sales_person.py
@@ -72,7 +72,7 @@ class SalesPerson(NestedSet):
 			frappe.db.get_value(
 				"Sales Team",
 				{"docstatus": 1, "parenttype": "Sales Invoice", "sales_person": self.sales_person_name},
-				{"SUM": "allocated_amount"},
+				[{"SUM": "allocated_amount"}],
 			)
 		)
 

--- a/erpnext/setup/doctype/sales_person/sales_person.py
+++ b/erpnext/setup/doctype/sales_person/sales_person.py
@@ -64,7 +64,7 @@ class SalesPerson(NestedSet):
 			frappe.db.get_value(
 				"Sales Team",
 				{"docstatus": 1, "parenttype": "Sales Order", "sales_person": self.sales_person_name},
-				"sum(allocated_amount)",
+				[{"SUM": "allocated_amount"}],
 			)
 		)
 
@@ -72,7 +72,7 @@ class SalesPerson(NestedSet):
 			frappe.db.get_value(
 				"Sales Team",
 				{"docstatus": 1, "parenttype": "Sales Invoice", "sales_person": self.sales_person_name},
-				"sum(allocated_amount)",
+				{"SUM": "allocated_amount"},
 			)
 		)
 

--- a/erpnext/stock/doctype/packing_slip/packing_slip.py
+++ b/erpnext/stock/doctype/packing_slip/packing_slip.py
@@ -174,7 +174,7 @@ class PackingSlip(StatusUpdater):
 		return (
 			cint(
 				frappe.db.get_value(
-					"Packing Slip", {"delivery_note": self.delivery_note, "docstatus": 1}, {"MAX": "to_case_no"}
+					"Packing Slip", {"delivery_note": self.delivery_note, "docstatus": 1}, [{"MAX": "to_case_no"}]
 				)
 			)
 			+ 1

--- a/erpnext/stock/doctype/packing_slip/packing_slip.py
+++ b/erpnext/stock/doctype/packing_slip/packing_slip.py
@@ -4,8 +4,9 @@
 
 import frappe
 from frappe import _
-from frappe.utils import cint, flt
 from frappe.query_builder.functions import Sum
+from frappe.utils import cint, flt
+
 from erpnext.controllers.status_updater import StatusUpdater
 
 
@@ -174,7 +175,9 @@ class PackingSlip(StatusUpdater):
 		return (
 			cint(
 				frappe.db.get_value(
-					"Packing Slip", {"delivery_note": self.delivery_note, "docstatus": 1}, [{"MAX": "to_case_no"}]
+					"Packing Slip",
+					{"delivery_note": self.delivery_note, "docstatus": 1},
+					[{"MAX": "to_case_no"}],
 				)
 			)
 			+ 1

--- a/erpnext/stock/doctype/packing_slip/packing_slip.py
+++ b/erpnext/stock/doctype/packing_slip/packing_slip.py
@@ -5,7 +5,7 @@
 import frappe
 from frappe import _
 from frappe.utils import cint, flt
-
+from frappe.query_builder.functions import Sum
 from erpnext.controllers.status_updater import StatusUpdater
 
 
@@ -128,11 +128,11 @@ class PackingSlip(StatusUpdater):
 						item.idx
 					)
 				)
-
+			DocType = frappe.qb.DocType("Delivery Note Item" if item.dn_detail else "Packed Item")
 			remaining_qty = frappe.db.get_value(
 				"Delivery Note Item" if item.dn_detail else "Packed Item",
 				{"name": item.dn_detail or item.pi_detail, "docstatus": 0},
-				["sum(qty - packed_qty)"],
+				Sum(DocType.qty - DocType.packed_qty),
 			)
 
 			if remaining_qty is None:
@@ -174,7 +174,7 @@ class PackingSlip(StatusUpdater):
 		return (
 			cint(
 				frappe.db.get_value(
-					"Packing Slip", {"delivery_note": self.delivery_note, "docstatus": 1}, ["max(to_case_no)"]
+					"Packing Slip", {"delivery_note": self.delivery_note, "docstatus": 1}, {"MAX": "to_case_no"}
 				)
 			)
 			+ 1

--- a/erpnext/stock/doctype/purchase_receipt/test_purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/test_purchase_receipt.py
@@ -2128,7 +2128,7 @@ class TestPurchaseReceipt(IntegrationTestCase):
 		self.assertEqual(flt(pr.total * pr.conversion_rate, 2), flt(pr.base_total, 2))
 
 		# Test - 2: Sum of Debit or Credit should be equal to Purchase Receipt Base Total
-		amount = frappe.db.get_value("GL Entry", {"docstatus": 1, "voucher_no": pr.name}, [{'SUM': 'debit'}])
+		amount = frappe.db.get_value("GL Entry", {"docstatus": 1, "voucher_no": pr.name}, [{"SUM": "debit"}])
 		expected_amount = pr.base_total
 		self.assertEqual(amount, expected_amount)
 

--- a/erpnext/stock/doctype/purchase_receipt/test_purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/test_purchase_receipt.py
@@ -1799,7 +1799,7 @@ class TestPurchaseReceipt(IntegrationTestCase):
 				"voucher_no": pr.name,
 				"is_cancelled": 0,
 			},
-			fieldname=["sum(stock_value_difference)"],
+			fieldname=[{"SUM": "stock_value_difference"}],
 		)
 
 		# Value of Stock Account should be equal to the sum of Stock Value Difference

--- a/erpnext/stock/doctype/purchase_receipt/test_purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/test_purchase_receipt.py
@@ -2128,7 +2128,7 @@ class TestPurchaseReceipt(IntegrationTestCase):
 		self.assertEqual(flt(pr.total * pr.conversion_rate, 2), flt(pr.base_total, 2))
 
 		# Test - 2: Sum of Debit or Credit should be equal to Purchase Receipt Base Total
-		amount = frappe.db.get_value("GL Entry", {"docstatus": 1, "voucher_no": pr.name}, ["sum(debit)"])
+		amount = frappe.db.get_value("GL Entry", {"docstatus": 1, "voucher_no": pr.name}, [{'SUM': 'debit'}])
 		expected_amount = pr.base_total
 		self.assertEqual(amount, expected_amount)
 

--- a/erpnext/stock/doctype/stock_ledger_entry/test_stock_ledger_entry.py
+++ b/erpnext/stock/doctype/stock_ledger_entry/test_stock_ledger_entry.py
@@ -1039,7 +1039,7 @@ class TestStockLedgerEntry(IntegrationTestCase, StockTestMixin):
 					"is_cancelled": 0,
 					"account": "Stock In Hand - TCP1",
 				},
-				"sum(credit)",
+				[{"SUM": "credit"}],
 			)
 
 		def _day(days):


### PR DESCRIPTION
Because of breaking changes in https://github.com/frappe/frappe/pull/32381

```
Before: 
first_fy_start_date = frappe.db.get_value("Fiscal Year", {"disabled": 0}, "min(year_start_date)")

After:
first_fy_start_date = frappe.db.get_value("Fiscal Year", {"disabled": 0}, [{'MIN': 'year_start_date'}])
```