### PR TITLE
fix: add no_copy for lost reasons

### DIFF
--- a/erpnext/selling/doctype/quotation/quotation.json
+++ b/erpnext/selling/doctype/quotation/quotation.json
@@ -910,6 +910,7 @@
    "fieldname": "lost_reasons",
    "fieldtype": "Table MultiSelect",
    "label": "Lost Reasons",
+   "no_copy": 1,
    "options": "Quotation Lost Reason Detail",
    "read_only": 1
   },
@@ -1104,7 +1105,7 @@
  "idx": 82,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-03-03 16:49:20.050303",
+ "modified": "2025-05-27 16:04:39.208077",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Quotation",


### PR DESCRIPTION
Issue: When duplicating a record, the "Lost Reason" field is carried forward and cannot be edited.

Ref: [#39513](https://support.frappe.io/helpdesk/tickets/39513)

Before:

[Screencast from 27-05-25 05:27:01 PM IST.webm](https://github.com/user-attachments/assets/571760fa-92b1-40ee-a9aa-790548e85950)


After:

[Screencast from 27-05-25 05:29:00 PM IST.webm](https://github.com/user-attachments/assets/454bb815-bc12-49e0-b4d4-e89f35b9ea3a)



Backport needed: Version-15

