### PR TITLE
fix: reorder function call

### DIFF
--- a/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
+++ b/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
@@ -98,9 +98,6 @@ class ReceivablePayableReport:
 	def get_data(self):
 		self.get_sales_invoices_or_customers_based_on_sales_person()
 
-		# Build delivery note map against all sales invoices
-		self.build_delivery_note_map()
-
 		# Get invoice details like bill_no, due_date etc for all invoices
 		self.get_invoice_details()
 
@@ -121,6 +118,9 @@ class ReceivablePayableReport:
 			self.fetch_ple_in_buffered_cursor()
 		elif self.ple_fetch_method == "UnBuffered Cursor":
 			self.fetch_ple_in_unbuffered_cursor()
+
+		# Build delivery note map against all sales invoices
+		self.build_delivery_note_map()
 
 		self.build_data()
 

--- a/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
+++ b/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
@@ -105,7 +105,8 @@ class ReceivablePayableReport:
 		self.get_future_payments()
 
 		# Get return entries
-		self.get_return_entries()
+		if not self.filters.party_type or self.filters.party_type in ["Customer", "Supplier"]:
+			self.get_return_entries()
 
 		# Get Exchange Rate Revaluations
 		self.get_exchange_rate_revaluations()


### PR DESCRIPTION
Issue: The Accounts Receivable report generates an error when the "Show Linked Delivery Notes" checkbox is enabled. The Accounts Payable report throws an error when the party type is selected as "Employee."

Ref: [#39650](https://support.frappe.io/helpdesk/tickets/39650)

**Accounts Receivable:**

Before:

![image](https://github.com/user-attachments/assets/23749615-e7da-4a02-abdb-da19a865bc82)

After:

![image](https://github.com/user-attachments/assets/51c91298-3dac-4d7f-bd78-ba390336c0cc)

**Accounts Payable:**

Before:

![image](https://github.com/user-attachments/assets/ff1210ca-7160-45e8-91ee-5784e33b25ab)


After:

![image](https://github.com/user-attachments/assets/42a9a0b9-f029-4d1a-a9cc-9e7527a61c85)



Backport needed: Version-15
