### PR TITLE
fix: add internal link field in Sales Order connections for internal …

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order_dashboard.py
+++ b/erpnext/selling/doctype/sales_order/sales_order_dashboard.py
@@ -17,6 +17,7 @@ def get_data():
 			"Quotation": ["items", "prevdoc_docname"],
 			"BOM": ["items", "bom_no"],
 			"Blanket Order": ["items", "blanket_order"],
+			"Purchase Order": ["items", "purchase_order"],
 		},
 		"transactions": [
 			{


### PR DESCRIPTION
Issue:
When a Sales Order is created by referencing a Purchase Order, the internal connection to the Purchase Order is not reflected in the Sales Order’s connection view. As a result, the connected Purchase Order count is not displayed under internal transactions.

Ref: [37764](https://support.frappe.io/helpdesk/tickets/37764)

![Sales_order_connection](https://github.com/user-attachments/assets/23cc66f8-0d38-4f81-8e52-9c750a785d7b)

Backport needed - version 15

