### PR TITLE
Fix default indonesia vat

### DIFF
--- a/erpnext/setup/setup_wizard/data/country_wise_tax.json
+++ b/erpnext/setup/setup_wizard/data/country_wise_tax.json
@@ -3905,7 +3905,7 @@
 			"tax_rate": 11.00
 		},
 		"Purchase Tax": {
-			"account_name": "PPn Masukan",
+			"account_name": "PPN Masukan",
 			"tax_rate": 11.00
 		}
 	},


### PR DESCRIPTION
This Pull Request updates and restructures the Indonesian Chart of Accounts to better reflect local accounting and tax practices. The changes aim to improve the default tax account mappings used during initial company setup and ensure compliance with Indonesian tax regulations.

Key Changes:

Added Input VAT (PPN Masukan) and Prepaid Income Tax (PPh 23) under Current Assets → Prepaid Taxes as these are creditable taxes (classified as assets).

Ensured Output VAT (PPN Keluaran) remains under Tax Payable as it represents a liability to the government.

Improved naming consistency and structure for easier understanding by Indonesian users.

References:

Indonesian VAT Law (current standard rate: 11%)

Common accounting practices in Indonesian businesses