### PR TITLE
feat: show item name for raw materials in BOM creator

### DIFF
--- a/erpnext/manufacturing/doctype/bom_creator/bom_creator.py
+++ b/erpnext/manufacturing/doctype/bom_creator/bom_creator.py
@@ -359,6 +359,7 @@ def get_children(doctype=None, parent=None, **kwargs):
 
 	fields = [
 		"item_code as value",
+		"item_name as title",
 		"is_expandable as expandable",
 		"parent as parent_id",
 		"qty",


### PR DESCRIPTION
Reference support ticket [39718](https://support.frappe.io/helpdesk/tickets/39718)