### PR TITLE
fix: use `query.walk() `for escaping special chars in receiable/payable report

### DIFF
--- a/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
+++ b/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
@@ -125,7 +125,8 @@ class ReceivablePayableReport:
 		self.build_data()
 
 	def fetch_ple_in_buffered_cursor(self):
-		self.ple_entries = frappe.db.sql(self.ple_query.get_sql(), as_dict=True)
+		query, param = self.ple_query.walk()
+		self.ple_entries = frappe.db.sql(query, param, as_dict=True)
 
 		for ple in self.ple_entries:
 			self.init_voucher_balance(ple)  # invoiced, paid, credit_note, outstanding
@@ -138,8 +139,9 @@ class ReceivablePayableReport:
 
 	def fetch_ple_in_unbuffered_cursor(self):
 		self.ple_entries = []
+		query, param = self.ple_query.walk()
 		with frappe.db.unbuffered_cursor():
-			for ple in frappe.db.sql(self.ple_query.get_sql(), as_dict=True, as_iterator=True):
+			for ple in frappe.db.sql(query, param, as_dict=True, as_iterator=True):
 				self.init_voucher_balance(ple)  # invoiced, paid, credit_note, outstanding
 				self.ple_entries.append(ple)
 


### PR DESCRIPTION
Issue: Special characters are not escaped in the query.get_sql()
regression: https://github.com/frappe/erpnext/pull/47145

Before
```
SELECT `name`, `account`, `voucher_type`, `voucher_no`, `against_voucher_type`, `against_voucher_no`, `party_type`, `cost_center`, `party`, `posting_date`, `due_date`, `account_currency`, `amount`, `amount_in_account_currency` FROM `tabPayment Ledger Entry` WHERE `delinked`=0 AND `company`='Parent' AND `party_type`='Customer' AND `party` IN ('CUST\196') AND `account` IN ('Cheque receivable - FP', 'Debtors - FP', 'Advance Rec - FP', 'Debtors USD - FP', 'jpy1 - FP') AND `posting_date`<='2025-05-28' ORDER BY `posting_date`, `party`
```

After
```
SELECT `name`,`account`,`voucher_type`,`voucher_no`,`against_voucher_type`,`against_voucher_no`,`party_type`,`cost_center`,`party`,`posting_date`,`due_date`,`account_currency`,`amount`,`amount_in_account_currency` FROM `tabPayment Ledger Entry` WHERE `delinked`=0 AND `company`='Parent' AND `party_type`='Customer' AND `party` IN ('CUST\\196') AND `account` IN ('Cheque receivable - FP','Debtors - FP','Advance Rec - FP','Debtors USD - FP','jpy1 - FP') AND `posting_date`<='2025-05-28' ORDER BY `posting_date`,`party`
```