### PR TITLE
fix: Drop duplicate index

### DIFF
--- a/erpnext/stock/doctype/stock_ledger_entry/stock_ledger_entry.json
+++ b/erpnext/stock/doctype/stock_ledger_entry/stock_ledger_entry.json
@@ -353,8 +353,7 @@
   {
    "fieldname": "posting_datetime",
    "fieldtype": "Datetime",
-   "label": "Posting Datetime",
-   "search_index": 1
+   "label": "Posting Datetime"
   }
  ],
  "hide_toolbar": 1,


### PR DESCRIPTION
This isn't required as it's prefix of posting_datetime_creation index.

When this index gets picked it causes more conflicts in highly
concurrent requests.

Just dropping this index eliminated 75% of deadlocks.


ref: #47787 