### PR TITLE
fix: calculate discount percentage if discount amount is specified

### DIFF
--- a/erpnext/controllers/taxes_and_totals.py
+++ b/erpnext/controllers/taxes_and_totals.py
@@ -12,6 +12,7 @@ from frappe.utils import cint, flt, round_based_on_smallest_currency_fraction
 import erpnext
 from erpnext.accounts.doctype.journal_entry.journal_entry import get_exchange_rate
 from erpnext.accounts.doctype.pricing_rule.utils import get_applied_pricing_rules
+from erpnext.accounts.utils import get_currency_precision
 from erpnext.controllers.accounts_controller import (
 	validate_conversion_rate,
 	validate_inclusive_tax,
@@ -709,7 +710,11 @@ class calculate_taxes_and_totals:
 	def set_discount_amount(self):
 		if self.doc.discount_amount:
 			self.doc.additional_discount_percentage = flt(
-				(self.doc.discount_amount / flt(self.doc.get(scrub(self.doc.apply_discount_on)))) * 100,
+				flt(
+					self.doc.discount_amount / flt(self.doc.get(scrub(self.doc.apply_discount_on))),
+					get_currency_precision(),
+				)
+				* 100,
 				self.doc.precision("additional_discount_percentage"),
 			)
 		elif self.doc.additional_discount_percentage:

--- a/erpnext/controllers/taxes_and_totals.py
+++ b/erpnext/controllers/taxes_and_totals.py
@@ -25,8 +25,19 @@ ItemWiseTaxDetail = frappe._dict
 
 
 class calculate_taxes_and_totals:
+	@property
+	def discount_amount(self):
+		return self.doc.discount_amount
+
+	@discount_amount.setter
+	def discount_amount(self, value):
+		self.doc.discount_amount = value
+		self.doc.additional_discount_percentage = 0
+
 	def __init__(self, doc: Document):
 		self.doc = doc
+		self.discount_amount = self.doc.discount_amount
+
 		frappe.flags.round_off_applicable_accounts = []
 		frappe.flags.round_row_wise_tax = frappe.db.get_single_value(
 			"Accounts Settings", "round_row_wise_tax"
@@ -708,15 +719,15 @@ class calculate_taxes_and_totals:
 
 	def set_discount_amount(self):
 		if self.doc.additional_discount_percentage:
-			self.doc.discount_amount = flt(
+			self.discount_amount = flt(
 				flt(self.doc.get(scrub(self.doc.apply_discount_on)))
 				* self.doc.additional_discount_percentage
 				/ 100,
 				self.doc.precision("discount_amount"),
 			)
-		elif self.doc.discount_amount:
+		elif self.discount_amount:
 			self.doc.additional_discount_percentage = flt(
-				(self.doc.discount_amount / flt(self.doc.get(scrub(self.doc.apply_discount_on)))) * 100,
+				(self.discount_amount / flt(self.doc.get(scrub(self.doc.apply_discount_on)))) * 100,
 				self.doc.precision("additional_discount_percentage"),
 			)
 

--- a/erpnext/controllers/taxes_and_totals.py
+++ b/erpnext/controllers/taxes_and_totals.py
@@ -714,6 +714,11 @@ class calculate_taxes_and_totals:
 				/ 100,
 				self.doc.precision("discount_amount"),
 			)
+		elif self.doc.discount_amount:
+			self.doc.additional_discount_percentage = flt(
+				(self.doc.discount_amount / flt(self.doc.get(scrub(self.doc.apply_discount_on)))) * 100,
+				self.doc.precision("additional_discount_percentage"),
+			)
 
 	def apply_discount_amount(self):
 		if self.doc.discount_amount:

--- a/erpnext/controllers/taxes_and_totals.py
+++ b/erpnext/controllers/taxes_and_totals.py
@@ -25,19 +25,8 @@ ItemWiseTaxDetail = frappe._dict
 
 
 class calculate_taxes_and_totals:
-	@property
-	def discount_amount(self):
-		return self.doc.discount_amount
-
-	@discount_amount.setter
-	def discount_amount(self, value):
-		self.doc.discount_amount = value
-		self.doc.additional_discount_percentage = 0
-
 	def __init__(self, doc: Document):
 		self.doc = doc
-		self.discount_amount = self.doc.discount_amount
-
 		frappe.flags.round_off_applicable_accounts = []
 		frappe.flags.round_row_wise_tax = frappe.db.get_single_value(
 			"Accounts Settings", "round_row_wise_tax"
@@ -718,17 +707,17 @@ class calculate_taxes_and_totals:
 					tax.item_wise_tax_detail = json.dumps(tax.item_wise_tax_detail)
 
 	def set_discount_amount(self):
-		if self.doc.additional_discount_percentage:
-			self.discount_amount = flt(
+		if self.doc.discount_amount:
+			self.doc.additional_discount_percentage = flt(
+				(self.doc.discount_amount / flt(self.doc.get(scrub(self.doc.apply_discount_on)))) * 100,
+				self.doc.precision("additional_discount_percentage"),
+			)
+		elif self.doc.additional_discount_percentage:
+			self.doc.discount_amount = flt(
 				flt(self.doc.get(scrub(self.doc.apply_discount_on)))
 				* self.doc.additional_discount_percentage
 				/ 100,
 				self.doc.precision("discount_amount"),
-			)
-		elif self.discount_amount:
-			self.doc.additional_discount_percentage = flt(
-				(self.discount_amount / flt(self.doc.get(scrub(self.doc.apply_discount_on)))) * 100,
-				self.doc.precision("additional_discount_percentage"),
 			)
 
 	def apply_discount_amount(self):


### PR DESCRIPTION
Reference support ticket [39770](https://support.frappe.io/helpdesk/tickets/39770)

`Additional Discount Percentage` will now be calculated if `Additional Discount Amount` is present but percentage is not.