### PR TITLE
fix: cash flow report fixes

### DIFF
--- a/erpnext/accounts/report/cash_flow/cash_flow.py
+++ b/erpnext/accounts/report/cash_flow/cash_flow.py
@@ -75,7 +75,11 @@ def execute(filters=None):
 			# add first net income in operations section
 			if net_profit_loss:
 				net_profit_loss.update(
-					{"indent": 1, "parent_section": cash_flow_sections[0]["section_header"]}
+					{
+						"indent": 1,
+						"parent_section": cash_flow_sections[0]["section_header"],
+						"section": net_profit_loss["account"],
+					}
 				)
 				data.append(net_profit_loss)
 				section_data.append(net_profit_loss)

--- a/erpnext/accounts/report/financial_statements.html
+++ b/erpnext/accounts/report/financial_statements.html
@@ -47,12 +47,12 @@
 		{% for(let j=0, k=data.length; j<k; j++) { %}
 			{%
 				var row = data[j];
-				var row_class = data[j].parent_account ? "" : "financial-statements-important";
-				row_class += data[j].account_name ? "" : " financial-statements-blank-row";
+				var row_class = data[j].parent_account || data[j].parent_section ? "" : "financial-statements-important";
+				row_class += data[j].account_name || data[j].section ? "" : " financial-statements-blank-row";
 			%}
 			<tr class="{%= row_class %}">
 				<td>
-					<span style="padding-left: {%= cint(data[j].indent) * 2 %}em">{%= row.account_name %}</span>
+					<span style="padding-left: {%= cint(data[j].indent) * 2 %}em">{%= row.account_name || row.section %}</span>
 				</td>
 				{% for(let i=1, l=report_columns.length; i<l; i++) { %}
 					<td class="text-right">

--- a/erpnext/public/js/financial_statements.js
+++ b/erpnext/public/js/financial_statements.js
@@ -41,7 +41,7 @@ erpnext.financial_statements = {
 			}
 		}
 
-		if (data && column.fieldname == "account") {
+		if (data && column.fieldname == this.name_field) {
 			// first column
 			value = data.section_name || data.account_name || value;
 


### PR DESCRIPTION
Fixed Multiple issues:

1) The Profit and Loss column was not visible.
2) PDF generated with empty rows.
3) Links were not clickable


Before: 
![image](https://github.com/user-attachments/assets/5adc4dac-552b-407a-9939-8f56242ee2bc)
![image](https://github.com/user-attachments/assets/d9eeaf17-f1c0-4d47-8570-9d5edc90538f)
![image](https://github.com/user-attachments/assets/e3c99544-e8e2-4096-885e-7977780a3140)




After:
![image](https://github.com/user-attachments/assets/bcd19210-c3f7-4175-ab69-d3cc02f2c608)
![image](https://github.com/user-attachments/assets/7baa314b-159f-4613-ace5-17ea2ca15b09)
![image](https://github.com/user-attachments/assets/70313c35-eb4f-468f-9a6a-b022ab887dc9)


Frappe Support Issue: https://support.frappe.io/app/hd-ticket/39855
