### PR TITLE
fix: correct UOM conversion in create DN from picklist

### DIFF
--- a/erpnext/stock/doctype/pick_list/pick_list.py
+++ b/erpnext/stock/doctype/pick_list/pick_list.py
@@ -1254,7 +1254,7 @@ def map_pl_locations(pick_list, item_mapper, delivery_note, sales_order=None):
 		if dn_item:
 			dn_item.pick_list_item = location.name
 			dn_item.warehouse = location.warehouse
-			dn_item.qty = flt(location.picked_qty) / (flt(location.conversion_factor) or 1)
+			dn_item.qty = flt(location.picked_qty) / (flt(dn_item.conversion_factor) or 1)
 			dn_item.batch_no = location.batch_no
 			dn_item.serial_no = location.serial_no
 			dn_item.use_serial_batch_fields = location.use_serial_batch_fields


### PR DESCRIPTION
### Steps to Replicate the Issue

- Stock UOM is PCS
- UOM is Sales Order is Box (120 pcs)
- UOM in PickList is Pack (12 pcs)

When creating a DN from Picklist, incorrect qty was captured in Delivery Note. This was because UOM was captured from Sales Order, but conversion factor used was from Picklist.

### Solution

Use conversion factor from delivery note (as captured from Sales Order).

### Before

https://github.com/user-attachments/assets/9f33e3c4-904c-4fcf-a96e-d717af714240

### After

https://github.com/user-attachments/assets/09210228-4157-4793-a1aa-e150881f7049

