### PR TITLE
fix: better integration of Pick List with Delivery Note

### DIFF
--- a/erpnext/controllers/status_updater.py
+++ b/erpnext/controllers/status_updater.py
@@ -164,6 +164,17 @@ status_map = {
 		["Draft", None],
 		["Completed", "eval:self.docstatus == 1"],
 	],
+	"Pick List": [
+		["Draft", None],
+		["Open", "eval:self.docstatus == 1"],
+		["Completed", "has_linked_document"],
+		[
+			"Partly Delivered",
+			"eval:self.purpose == 'Delivery' and self.delivery_status == 'Partly Delivered'",
+		],
+		["Completed", "eval:self.purpose == 'Delivery' and self.delivery_status == 'Fully Delivered'"],
+		["Cancelled", "eval:self.docstatus == 2"],
+	],
 }
 
 

--- a/erpnext/controllers/status_updater.py
+++ b/erpnext/controllers/status_updater.py
@@ -167,7 +167,7 @@ status_map = {
 	"Pick List": [
 		["Draft", None],
 		["Open", "eval:self.docstatus == 1"],
-		["Completed", "has_linked_document"],
+		["Completed", "stock_entry_exists"],
 		[
 			"Partly Delivered",
 			"eval:self.purpose == 'Delivery' and self.delivery_status == 'Partly Delivered'",

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -418,3 +418,4 @@ erpnext.patches.v15_0.rename_group_by_to_categorize_by_in_custom_reports
 erpnext.patches.v15_0.remove_agriculture_roles
 erpnext.patches.v14_0.update_full_name_in_contract
 erpnext.patches.v15_0.drop_sle_indexes
+erpnext.patches.v15_0.update_pick_list_fields

--- a/erpnext/patches/v15_0/update_pick_list_fields.py
+++ b/erpnext/patches/v15_0/update_pick_list_fields.py
@@ -1,0 +1,41 @@
+import frappe
+
+
+def execute():
+	update_delivery_note()
+	update_pick_list_items()
+
+
+def update_delivery_note():
+	delivery_notes = frappe.get_all(
+		"Delivery Note",
+		fields=["name", "pick_list"],
+		filters={"pick_list": ("is", "set")},
+	)
+
+	for delivery_note in delivery_notes:
+		frappe.db.set_value(
+			"Delivery Note Item",
+			{"parent": delivery_note.name},
+			"against_pick_list",
+			delivery_note.pick_list,
+		)
+
+
+def update_pick_list_items():
+	PICK_LIST = frappe.qb.DocType("Pick List")
+	PICK_LIST_ITEM = frappe.qb.DocType("Pick List Item")
+
+	pick_lists = (
+		frappe.qb.from_(PICK_LIST)
+		.select(PICK_LIST.name)
+		.where(PICK_LIST.status == "Completed")
+		.run(pluck="name")
+	)
+
+	if not pick_lists:
+		return
+
+	frappe.qb.update(PICK_LIST_ITEM).set(PICK_LIST_ITEM.delivered_qty, PICK_LIST_ITEM.picked_qty).where(
+		PICK_LIST_ITEM.parent.isin(pick_lists)
+	).run()

--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -1031,7 +1031,7 @@ erpnext.utils.map_current_doc = function (opts) {
 
 				if (
 					opts.allow_child_item_selection ||
-					["Purchase Receipt", "Delivery Note"].includes(opts.source_doctype)
+					["Purchase Receipt", "Delivery Note", "Pick List"].includes(opts.source_doctype)
 				) {
 					// args contains filtered child docnames
 					opts.args = args;

--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -1769,8 +1769,8 @@ def create_pick_list(source_name, target_doc=None):
 				"doctype": "Pick List Item",
 				"field_map": {
 					"parent": "sales_order",
-					"name": "sales_order_item",
-					"parent_detail_docname": "product_bundle_item",
+					"parent_detail_docname": "sales_order_item",
+					"name": "product_bundle_item",
 				},
 				"field_no_map": ["picked_qty"],
 				"postprocess": update_packed_item_qty,

--- a/erpnext/stock/doctype/delivery_note/delivery_note.js
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.js
@@ -230,6 +230,7 @@ erpnext.stock.DeliveryNoteController = class DeliveryNoteController extends (
 							company: me.frm.doc.company,
 						},
 						get_query_method: "erpnext.stock.doctype.pick_list.pick_list.get_pick_list_query",
+						size: "extra-large",
 					});
 				},
 				__("Get Items From")

--- a/erpnext/stock/doctype/delivery_note/delivery_note.js
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.js
@@ -205,7 +205,7 @@ erpnext.stock.DeliveryNoteController = class DeliveryNoteController extends (
 						});
 					}
 					erpnext.utils.map_current_doc({
-						method: "erpnext.stock.doctype.pick_list.pick_list.make_delivery_note",
+						method: "erpnext.stock.doctype.pick_list.pick_list.create_dn_for_pick_lists",
 						source_doctype: "Pick List",
 						target: me.frm,
 						setters: [

--- a/erpnext/stock/doctype/delivery_note/delivery_note.js
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.js
@@ -229,8 +229,7 @@ erpnext.stock.DeliveryNoteController = class DeliveryNoteController extends (
 						get_query_filters: {
 							company: me.frm.doc.company,
 						},
-						get_query_method:
-							"erpnext.stock.doctype.pick_list.pick_list.get_purchase_invoice_query",
+						get_query_method: "erpnext.stock.doctype.pick_list.pick_list.get_pick_list_query",
 					});
 				},
 				__("Get Items From")

--- a/erpnext/stock/doctype/delivery_note/delivery_note.js
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.js
@@ -188,6 +188,55 @@ erpnext.stock.DeliveryNoteController = class DeliveryNoteController extends (
 			);
 		}
 
+		if (
+			!doc.is_return &&
+			doc.status != "Closed" &&
+			this.frm.has_perm("write") &&
+			frappe.model.can_read("Pick List") &&
+			this.frm.doc.docstatus === 0
+		) {
+			this.frm.add_custom_button(
+				__("Pick List"),
+				function () {
+					if (!me.frm.doc.customer) {
+						frappe.throw({
+							title: __("Mandatory"),
+							message: __("Please Select a Customer"),
+						});
+					}
+					erpnext.utils.map_current_doc({
+						method: "erpnext.stock.doctype.pick_list.pick_list.make_delivery_note",
+						source_doctype: "Pick List",
+						target: me.frm,
+						setters: [
+							{
+								fieldname: "customer",
+								default: me.frm.doc.customer,
+								label: __("Customer"),
+								fieldtype: "Link",
+								options: "Customer",
+								reqd: 1,
+								read_only: 1,
+							},
+							{
+								fieldname: "sales_order",
+								label: __("Sales Order"),
+								fieldtype: "Link",
+								options: "Sales Order",
+								link_filters: `[["Sales Order","customer","=","${me.frm.doc.customer}"],["Sales Order","docstatus","=","1"],["Sales Order","delivery_status","not in",["Closed","Fully Delivered"]]]`,
+							},
+						],
+						get_query_filters: {
+							company: me.frm.doc.company,
+						},
+						get_query_method:
+							"erpnext.stock.doctype.pick_list.pick_list.get_purchase_invoice_query",
+					});
+				},
+				__("Get Items From")
+			);
+		}
+
 		if (!doc.is_return && doc.status != "Closed") {
 			if (doc.docstatus == 1 && frappe.model.can_create("Shipment")) {
 				this.frm.add_custom_button(

--- a/erpnext/stock/doctype/delivery_note/delivery_note.json
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.json
@@ -37,7 +37,6 @@
   "ignore_pricing_rule",
   "items_section",
   "scan_barcode",
-  "pick_list",
   "col_break_warehouse",
   "set_warehouse",
   "set_target_warehouse",
@@ -1195,15 +1194,6 @@
    "oldfieldtype": "Table",
    "options": "Sales Team",
    "print_hide": 1
-  },
-  {
-   "fieldname": "pick_list",
-   "fieldtype": "Link",
-   "hidden": 1,
-   "label": "Pick List",
-   "options": "Pick List",
-   "read_only": 1,
-   "search_index": 1
   },
   {
    "default": "0",

--- a/erpnext/stock/doctype/delivery_note/delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.py
@@ -176,6 +176,19 @@ class DeliveryNote(SellingController):
 				"overflow_type": "delivery",
 				"no_allowance": 1,
 			},
+			{
+				"source_dt": "Delivery Note Item",
+				"target_dt": "Pick List Item",
+				"join_field": "pick_list_item",
+				"target_field": "delivered_qty",
+				"target_parent_dt": "Pick List",
+				"target_parent_field": "per_delivered",
+				"target_ref_field": "picked_qty",
+				"source_field": "stock_qty",
+				"percent_join_field": "against_pick_list",
+				"status_field": "delivery_status",
+				"keyword": "Delivered",
+			},
 		]
 		if cint(self.is_return):
 			self.status_updater.extend(

--- a/erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
+++ b/erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
@@ -77,6 +77,7 @@
   "against_sales_invoice",
   "si_detail",
   "dn_detail",
+  "against_pick_list",
   "pick_list_item",
   "section_break_40",
   "pick_serial_and_batch",
@@ -935,6 +936,16 @@
   {
    "fieldname": "column_break_fguf",
    "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "against_pick_list",
+   "fieldtype": "Link",
+   "label": "Against Pick List",
+   "no_copy": 1,
+   "options": "Pick List",
+   "print_hide": 1,
+   "read_only": 1,
+   "search_index": 1
   }
  ],
  "grid_page_length": 50,
@@ -942,7 +953,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-03-07 12:33:40.868499",
+ "modified": "2025-05-31 18:51:32.651562",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Delivery Note Item",

--- a/erpnext/stock/doctype/delivery_note_item/delivery_note_item.py
+++ b/erpnext/stock/doctype/delivery_note_item/delivery_note_item.py
@@ -16,6 +16,7 @@ class DeliveryNoteItem(Document):
 
 		actual_batch_qty: DF.Float
 		actual_qty: DF.Float
+		against_pick_list: DF.Link | None
 		against_sales_invoice: DF.Link | None
 		against_sales_order: DF.Link | None
 		allow_zero_valuation_rate: DF.Check

--- a/erpnext/stock/doctype/pick_list/pick_list.js
+++ b/erpnext/stock/doctype/pick_list/pick_list.js
@@ -98,34 +98,28 @@ frappe.ui.form.on("Pick List", {
 	refresh: (frm) => {
 		frm.trigger("add_get_items_button");
 		if (frm.doc.docstatus === 1) {
-			frappe
-				.xcall("erpnext.stock.doctype.pick_list.pick_list.target_document_exists", {
-					pick_list_name: frm.doc.name,
-					purpose: frm.doc.purpose,
-				})
-				.then((target_document_exists) => {
-					frm.set_df_property("locations", "allow_on_submit", target_document_exists ? 0 : 1);
+			const status_completed = frm.doc.status === "Completed";
+			frm.set_df_property("locations", "allow_on_submit", status_completed ? 0 : 1);
 
-					if (target_document_exists) return;
+			if (!status_completed) {
+				frm.add_custom_button(__("Update Current Stock"), () =>
+					frm.trigger("update_pick_list_stock")
+				);
 
-					frm.add_custom_button(__("Update Current Stock"), () =>
-						frm.trigger("update_pick_list_stock")
+				if (frm.doc.purpose === "Delivery") {
+					frm.add_custom_button(
+						__("Create Delivery Note"),
+						() => frm.trigger("create_delivery_note"),
+						__("Create")
 					);
-
-					if (frm.doc.purpose === "Delivery") {
-						frm.add_custom_button(
-							__("Delivery Note"),
-							() => frm.trigger("create_delivery_note"),
-							__("Create")
-						);
-					} else {
-						frm.add_custom_button(
-							__("Stock Entry"),
-							() => frm.trigger("create_stock_entry"),
-							__("Create")
-						);
-					}
-				});
+				} else {
+					frm.add_custom_button(
+						__("Create Stock Entry"),
+						() => frm.trigger("create_stock_entry"),
+						__("Create")
+					);
+				}
+			}
 
 			if (frm.doc.purpose === "Delivery" && frm.doc.status === "Open") {
 				if (frm.doc.__onload && frm.doc.__onload.has_unreserved_stock) {

--- a/erpnext/stock/doctype/pick_list/pick_list.json
+++ b/erpnext/stock/doctype/pick_list/pick_list.json
@@ -30,7 +30,11 @@
   "amended_from",
   "print_settings_section",
   "group_same_items",
-  "status"
+  "status_section",
+  "status",
+  "column_break_qyam",
+  "delivery_status",
+  "per_delivered"
  ],
  "fields": [
   {
@@ -181,7 +185,7 @@
    "in_standard_filter": 1,
    "label": "Status",
    "no_copy": 1,
-   "options": "Draft\nOpen\nCompleted\nCancelled",
+   "options": "Draft\nOpen\nPartly Delivered\nCompleted\nCancelled",
    "print_hide": 1,
    "read_only": 1,
    "report_hide": 1,
@@ -208,11 +212,42 @@
    "fieldname": "ignore_pricing_rule",
    "fieldtype": "Check",
    "label": "Ignore Pricing Rule"
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "status_section",
+   "fieldtype": "Section Break",
+   "label": "Status",
+   "print_hide": 1
+  },
+  {
+   "fieldname": "delivery_status",
+   "fieldtype": "Select",
+   "hidden": 1,
+   "in_standard_filter": 1,
+   "label": "Delivery Status",
+   "no_copy": 1,
+   "options": "Not Delivered\nFully Delivered\nPartly Delivered",
+   "print_hide": 1
+  },
+  {
+   "depends_on": "eval:!doc.__islocal && doc.purpose === \"Delivery\"",
+   "description": "% of materials delivered against this Pick List",
+   "fieldname": "per_delivered",
+   "fieldtype": "Percent",
+   "label": "% Delivered",
+   "no_copy": 1,
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_qyam",
+   "fieldtype": "Column Break"
   }
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2024-08-14 13:20:42.168827",
+ "modified": "2025-05-31 19:18:30.860044",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Pick List",
@@ -280,6 +315,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": [],

--- a/erpnext/stock/doctype/pick_list/pick_list.py
+++ b/erpnext/stock/doctype/pick_list/pick_list.py
@@ -1527,7 +1527,11 @@ def get_pick_list_query(doctype, txt, searchfield, start, page_len, filters):
 		frappe.qb.from_(PICK_LIST)
 		.join(PICK_LIST_ITEM)
 		.on(PICK_LIST.name == PICK_LIST_ITEM.parent)
-		.select(PICK_LIST.name, PICK_LIST.customer, PICK_LIST_ITEM.sales_order)
+		.select(
+			PICK_LIST.name,
+			PICK_LIST.customer,
+			Replace(GROUP_CONCAT(PICK_LIST_ITEM.sales_order).distinct(), ",", "<br>").as_("sales_order"),
+		)
 		.where(PICK_LIST.docstatus == 1)
 		.where(PICK_LIST.status.isin(["Open", "Partly Delivered"]))
 		.where(PICK_LIST.company == filters.get("company"))

--- a/erpnext/stock/doctype/pick_list/pick_list.py
+++ b/erpnext/stock/doctype/pick_list/pick_list.py
@@ -1284,7 +1284,7 @@ def map_pl_locations(pick_list, item_mapper, delivery_note, sales_order=None):
 			dn_item.pick_list_item = location.name
 			dn_item.warehouse = location.warehouse
 			dn_item.qty = flt(location.picked_qty - location.delivered_qty) / (
-				flt(dn_item.conversion_factor) or 1
+				flt(location.conversion_factor) or 1
 			)
 			dn_item.batch_no = location.batch_no
 			dn_item.serial_no = location.serial_no

--- a/erpnext/stock/doctype/pick_list/pick_list.py
+++ b/erpnext/stock/doctype/pick_list/pick_list.py
@@ -1504,7 +1504,7 @@ def get_purchase_invoice_query(doctype, txt, searchfield, start, page_len, filte
 	frappe.has_permission("Purchase Invoice", throw=True)
 
 	if not filters.get("company"):
-		frappe.throw(_("Please select a Company "))
+		frappe.throw(_("Please select a Company"))
 
 	PICK_LIST = frappe.qb.DocType("Pick List")
 	PICK_LIST_ITEM = frappe.qb.DocType("Pick List Item")

--- a/erpnext/stock/doctype/pick_list/pick_list.py
+++ b/erpnext/stock/doctype/pick_list/pick_list.py
@@ -203,7 +203,6 @@ class PickList(TransactionBase):
 	def validate_picked_items(self):
 		for item in self.locations:
 			if self.scan_mode and item.picked_qty < item.stock_qty:
-				return
 				frappe.throw(
 					_(
 						"Row {0} picked quantity is less than the required quantity, additional {1} {2} required."

--- a/erpnext/stock/doctype/pick_list/pick_list.py
+++ b/erpnext/stock/doctype/pick_list/pick_list.py
@@ -1283,7 +1283,7 @@ def map_pl_locations(pick_list, item_mapper, delivery_note, sales_order=None):
 			dn_item.pick_list_item = location.name
 			dn_item.warehouse = location.warehouse
 			dn_item.qty = flt(location.picked_qty - location.delivered_qty) / (
-				flt(location.conversion_factor) or 1
+				flt(dn_item.conversion_factor) or 1
 			)
 			dn_item.batch_no = location.batch_no
 			dn_item.serial_no = location.serial_no

--- a/erpnext/stock/doctype/pick_list/pick_list.py
+++ b/erpnext/stock/doctype/pick_list/pick_list.py
@@ -1510,8 +1510,8 @@ def get_rejected_warehouses():
 
 
 @frappe.whitelist()
-def get_purchase_invoice_query(doctype, txt, searchfield, start, page_len, filters):
-	frappe.has_permission("Purchase Invoice", throw=True)
+def get_pick_list_query(doctype, txt, searchfield, start, page_len, filters):
+	frappe.has_permission("Pick List", throw=True)
 
 	if not filters.get("company"):
 		frappe.throw(_("Please select a Company"))

--- a/erpnext/stock/doctype/pick_list/pick_list.py
+++ b/erpnext/stock/doctype/pick_list/pick_list.py
@@ -163,12 +163,6 @@ class PickList(TransactionBase):
 						["company", "="],
 					],
 				},
-				"Sales Order Item": {
-					"ref_dn_field": "sales_order_item",
-					"compare_fields": [["item_code", "="]],
-					"is_child_table": True,
-					"allow_duplicate_prev_row_id": True,
-				},
 			}
 		)
 
@@ -763,10 +757,11 @@ class PickList(TransactionBase):
 		for item in self.locations:
 			if not item.product_bundle_item:
 				continue
-			product_bundles[item.product_bundle_item] = frappe.db.get_value(
-				"Sales Order Item",
+
+			product_bundles[item.sales_order_item] = frappe.db.get_value(
+				"Packed Item",
 				item.product_bundle_item,
-				"item_code",
+				"parent_item",
 			)
 		return product_bundles
 
@@ -781,10 +776,9 @@ class PickList(TransactionBase):
 	def _compute_picked_qty_for_bundle(self, bundle_row, bundle_items) -> int:
 		"""Compute how many full bundles can be created from picked items."""
 		precision = frappe.get_precision("Stock Ledger Entry", "qty_after_transaction")
-
 		possible_bundles = []
 		for item in self.locations:
-			if item.product_bundle_item != bundle_row:
+			if item.sales_order_item != bundle_row:
 				continue
 
 			if qty_in_bundle := bundle_items.get(item.item_code):

--- a/erpnext/stock/doctype/pick_list/pick_list_list.js
+++ b/erpnext/stock/doctype/pick_list/pick_list_list.js
@@ -6,6 +6,7 @@ frappe.listview_settings["Pick List"] = {
 		const status_colors = {
 			Draft: "red",
 			Open: "orange",
+			"Partly Delivered": "orange",
 			Completed: "green",
 			Cancelled: "red",
 		};

--- a/erpnext/stock/doctype/pick_list/test_pick_list.py
+++ b/erpnext/stock/doctype/pick_list/test_pick_list.py
@@ -407,9 +407,7 @@ class TestPickList(IntegrationTestCase):
 		self.assertEqual(pick_list.locations[1].sales_order_item, sales_order.items[0].name)
 
 	def test_pick_list_for_items_with_multiple_UOM(self):
-		item_code = make_item(
-			uoms=[{"uom": "Nos", "conversion_factor": 1}, {"uom": "Unit", "conversion_factor": 0.5}]
-		).name
+		item_code = make_item().name
 		purchase_receipt = make_purchase_receipt(item_code=item_code, qty=10)
 		purchase_receipt.submit()
 
@@ -451,7 +449,7 @@ class TestPickList(IntegrationTestCase):
 						"item_code": item_code,
 						"qty": 2,
 						"stock_qty": 1,
-						"stock_uom": "Unit",
+						"conversion_factor": 0.5,
 						"sales_order": sales_order.name,
 						"sales_order_item": sales_order.items[0].name,
 					},
@@ -459,7 +457,7 @@ class TestPickList(IntegrationTestCase):
 						"item_code": item_code,
 						"qty": 1,
 						"stock_qty": 1,
-						"stock_uom": "Nos",
+						"conversion_factor": 1,
 						"sales_order": sales_order.name,
 						"sales_order_item": sales_order.items[1].name,
 					},

--- a/erpnext/stock/doctype/pick_list/test_pick_list.py
+++ b/erpnext/stock/doctype/pick_list/test_pick_list.py
@@ -1325,7 +1325,7 @@ class TestPickList(IntegrationTestCase):
 			self.assertEqual(loc.batch_no, batch2)
 
 	def test_multiple_pick_lists_delivery_note(self):
-		from erpnext.stock.doctype.pick_list.pick_list import make_delivery_note
+		from erpnext.stock.doctype.pick_list.pick_list import create_dn_for_pick_lists
 
 		item_code = make_item().name
 		warehouse = "_Test Warehouse - _TC"
@@ -1359,8 +1359,8 @@ class TestPickList(IntegrationTestCase):
 		pick_list_1 = create_pick_list(10)
 		pick_list_2 = create_pick_list(20)
 
-		delivery_note = make_delivery_note(pick_list_1.name)
-		delivery_note = make_delivery_note(pick_list_2.name, delivery_note)
+		delivery_note = create_dn_for_pick_lists(pick_list_1.name)
+		delivery_note = create_dn_for_pick_lists(pick_list_2.name, delivery_note)
 		delivery_note.items[0].qty = 5
 		delivery_note.submit()
 

--- a/erpnext/stock/doctype/pick_list_item/pick_list_item.json
+++ b/erpnext/stock/doctype/pick_list_item/pick_list_item.json
@@ -21,6 +21,7 @@
   "uom",
   "conversion_factor",
   "stock_uom",
+  "delivered_qty",
   "serial_no_and_batch_section",
   "pick_serial_and_batch",
   "serial_and_batch_bundle",
@@ -237,17 +238,28 @@
   {
    "fieldname": "column_break_belw",
    "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "fieldname": "delivered_qty",
+   "fieldtype": "Float",
+   "label": "Delivered Qty (in Stock UOM)",
+   "no_copy": 1,
+   "print_hide": 1,
+   "read_only": 1,
+   "report_hide": 1
   }
  ],
  "istable": 1,
  "links": [],
- "modified": "2024-05-07 15:32:42.905446",
+ "modified": "2025-05-31 19:57:43.531298",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Pick List Item",
  "owner": "Administrator",
  "permissions": [],
  "quick_entry": 1,
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],

--- a/erpnext/stock/doctype/pick_list_item/pick_list_item.py
+++ b/erpnext/stock/doctype/pick_list_item/pick_list_item.py
@@ -17,6 +17,7 @@ class PickListItem(Document):
 
 		batch_no: DF.Link | None
 		conversion_factor: DF.Float
+		delivered_qty: DF.Float
 		description: DF.Text | None
 		item_code: DF.Link
 		item_group: DF.Data | None


### PR DESCRIPTION
### User Story

User uses pick list to pick for multiple orders simultaneously. User may also use multiple pick lists against one order, which should be delivered through one delivery note.

### Issue

Integration between picklist to delivery note needed some work. Current limitations were

- One DN per customer is auto-created from Pick List. There was no good way to get items from multiple pick lists in DN.
- Validations of item picked in DN were not robust.
- Status of Pick List could be misleading where partial deliveries are generated.
- Minor fixes around usage of different UOMs while picking

### TODOs

- [x] Create fields in DN and Pick List
- [x] Use status updater to update delivered qty and percent delivered in Pick List
- [x] Remove old references
- [x] Validate PickList against Sales Order
- [x] Use `map_current_doc` to get items from PickList in Delivery Note
- [x] Patch
- [x] Test Cases
- [ ] Docs



