### PR TITLE
fix: use user default for company instead of global default in purchase order analysis report

### DIFF
--- a/erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.js
+++ b/erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.js
@@ -10,7 +10,7 @@ frappe.query_reports["Purchase Order Analysis"] = {
 			width: "80",
 			options: "Company",
 			reqd: 1,
-			default: frappe.defaults.get_default("company"),
+			default: frappe.defaults.get_user_default("company"),
 		},
 		{
 			fieldname: "from_date",


### PR DESCRIPTION
This PR updates the Purchase Order Analysis report to use the user's default company instead of the global default.

Replaced usage of frappe.defaults.get_default("company") with frappe.defaults.get_user_default("company")