### PR TITLE
fix: pos settings invoice_fields not fetched at pos setup

### DIFF
--- a/erpnext/selling/page/point_of_sale/pos_controller.js
+++ b/erpnext/selling/page/point_of_sale/pos_controller.js
@@ -160,19 +160,18 @@ erpnext.PointOfSale.Controller = class {
 		this.setup_listener_for_pos_closing();
 	}
 
-	fetch_invoice_fields() {
-		const me = this;
-		frappe.db.get_doc("POS Settings", undefined).then((doc) => {
-			me.settings.invoice_fields = doc.invoice_fields.map((field) => {
-				return {
-					fieldname: field.fieldname,
-					label: field.label,
-					fieldtype: field.fieldtype,
-					reqd: field.reqd,
-					options: field.options,
-					default_value: field.default_value,
-					read_only: field.read_only,
-				};
+	async fetch_invoice_fields() {
+		this.settings.invoice_fields = new Array();
+		const pos_settings = await frappe.db.get_doc("POS Settings", undefined);
+		pos_settings.invoice_fields.forEach((field) => {
+			this.settings.invoice_fields.push({
+				fieldname: field.fieldname,
+				label: field.label,
+				fieldtype: field.fieldtype,
+				reqd: field.reqd,
+				options: field.options,
+				default_value: field.default_value,
+				read_only: field.read_only,
 			});
 		});
 	}


### PR DESCRIPTION
Fixed the issue where the POS Settings Invoice Fields were not fetching at the POS Setup.