### PR TITLE
fix: pos order summary new order action

### DIFF
--- a/erpnext/selling/page/point_of_sale/pos_controller.js
+++ b/erpnext/selling/page/point_of_sale/pos_controller.js
@@ -541,7 +541,7 @@ erpnext.PointOfSale.Controller = class {
 					frappe.run_serially([
 						() => frappe.dom.freeze(),
 						() => this.make_new_invoice(),
-						() => this.item_selector.toggle_component(true),
+						() => this.toggle_components(true),
 						() => frappe.dom.unfreeze(),
 					]);
 				},


### PR DESCRIPTION
Fixed the issue where, on clicking the 'New Order' Button in the POS Order Summary was loading a new invoice with Numpad toggled on in the POS Item Cart. 