### PR TITLE
feat: add overall discount to sales order and delivery note

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
@@ -556,21 +556,7 @@ erpnext.accounts.SalesInvoiceController = class SalesInvoiceController extends (
 	}
 
 	is_cash_or_non_trade_discount() {
-		this.frm.set_df_property(
-			"additional_discount_account",
-			"hidden",
-			1 - this.frm.doc.is_cash_or_non_trade_discount
-		);
-		this.frm.set_df_property(
-			"additional_discount_account",
-			"reqd",
-			this.frm.doc.is_cash_or_non_trade_discount
-		);
-
-		if (!this.frm.doc.is_cash_or_non_trade_discount) {
-			this.frm.set_value("additional_discount_account", "");
-		}
-
+		toggle_additional_discount_account(this.frm);
 		this.calculate_taxes_and_totals();
 	}
 };
@@ -784,6 +770,7 @@ frappe.ui.form.on("Sales Invoice", {
 	},
 	onload: function (frm) {
 		frm.redemption_conversion_factor = null;
+		toggle_additional_discount_account(frm);
 	},
 
 	update_stock: function (frm, dt, dn) {
@@ -1112,6 +1099,15 @@ var set_timesheet_detail_rate = function (cdt, cdn, currency, timelog) {
 		},
 	});
 };
+
+function toggle_additional_discount_account(frm) {
+	frm.set_df_property("additional_discount_account", "hidden", !frm.doc.is_cash_or_non_trade_discount);
+	frm.set_df_property("additional_discount_account", "reqd", frm.doc.is_cash_or_non_trade_discount);
+
+	if (!frm.doc.is_cash_or_non_trade_discount) {
+		frm.set_value("additional_discount_account", "");
+	}
+}
 
 var select_loyalty_program = function (frm, loyalty_programs) {
 	var dialog = new frappe.ui.Dialog({

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
@@ -770,7 +770,9 @@ frappe.ui.form.on("Sales Invoice", {
 	},
 	onload: function (frm) {
 		frm.redemption_conversion_factor = null;
-		toggle_additional_discount_account(frm);
+		if (frm.doc.is_cash_or_non_trade_discount) {
+			toggle_additional_discount_account(frm);
+		}
 	},
 
 	update_stock: function (frm, dt, dn) {

--- a/erpnext/selling/doctype/sales_order/sales_order.js
+++ b/erpnext/selling/doctype/sales_order/sales_order.js
@@ -48,6 +48,14 @@ frappe.ui.form.on("Sales Order", {
 		frm.set_df_property("packed_items", "cannot_delete_rows", true);
 	},
 
+	is_cash_or_non_trade_discount: function (frm) {
+		if (!frm.doc.is_cash_or_non_trade_discount) {
+			frm.set_value("additional_discount_account", "");
+		}
+
+		frm.cscript.calculate_taxes_and_totals();
+	},
+
 	refresh: function (frm) {
 		if (frm.doc.docstatus === 1) {
 			if (

--- a/erpnext/selling/doctype/sales_order/sales_order.json
+++ b/erpnext/selling/doctype/sales_order/sales_order.json
@@ -84,6 +84,8 @@
   "apply_discount_on",
   "base_discount_amount",
   "coupon_code",
+  "is_cash_or_non_trade_discount",
+  "additional_discount_account",
   "column_break_50",
   "additional_discount_percentage",
   "discount_amount",
@@ -1681,13 +1683,29 @@
    "hidden": 1,
    "label": "Has Unit Price Items",
    "no_copy": 1
+  },
+  {
+   "default": "0",
+   "depends_on": "eval: doc.apply_discount_on == \"Grand Total\"",
+   "fieldname": "is_cash_or_non_trade_discount",
+   "fieldtype": "Check",
+   "label": "Is Cash or Non Trade Discount"
+  },
+  {
+   "allow_on_submit": 1,
+   "depends_on": "eval: doc.is_cash_or_non_trade_discount",
+   "fieldname": "additional_discount_account",
+   "fieldtype": "Link",
+   "label": "Discount Account",
+   "mandatory_depends_on": "eval: doc.is_cash_or_non_trade_discount",
+   "options": "Account"
   }
  ],
  "icon": "fa fa-file-text",
  "idx": 105,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-03-03 16:49:00.676927",
+ "modified": "2025-06-02 15:05:23.067656",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Sales Order",

--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -68,6 +68,7 @@ class SalesOrder(SellingController):
 		from erpnext.selling.doctype.sales_team.sales_team import SalesTeam
 		from erpnext.stock.doctype.packed_item.packed_item import PackedItem
 
+		additional_discount_account: DF.Link | None
 		additional_discount_percentage: DF.Float
 		address_display: DF.TextEditor | None
 		advance_paid: DF.Currency
@@ -119,6 +120,7 @@ class SalesOrder(SellingController):
 		in_words: DF.Data | None
 		incoterm: DF.Link | None
 		inter_company_order_reference: DF.Link | None
+		is_cash_or_non_trade_discount: DF.Check
 		is_internal_customer: DF.Check
 		items: DF.Table[SalesOrderItem]
 		language: DF.Link | None

--- a/erpnext/selling/doctype/sales_order/test_sales_order.py
+++ b/erpnext/selling/doctype/sales_order/test_sales_order.py
@@ -10,6 +10,7 @@ from frappe.core.doctype.user_permission.test_user_permission import create_user
 from frappe.tests import IntegrationTestCase, change_settings
 from frappe.utils import add_days, flt, getdate, nowdate, today
 
+from erpnext.accounts.doctype.account.test_account import create_account
 from erpnext.accounts.test.accounts_mixin import AccountsTestMixin
 from erpnext.controllers.accounts_controller import InvalidQtyError, update_child_qty_rate
 from erpnext.maintenance.doctype.maintenance_schedule.test_maintenance_schedule import (
@@ -160,6 +161,52 @@ class TestSalesOrder(AccountsTestMixin, IntegrationTestCase):
 
 		si1 = make_sales_invoice(so.name)
 		self.assertEqual(len(si1.get("items")), 0)
+
+	def test_overall_discount_calculatin(self):
+		so = make_sales_order(do_not_submit=True)
+
+		discount_percent = 5
+		grand_total = so.grand_total
+		additional_discount_account = create_account(
+			account_name="Discount Account",
+			parent_account="Indirect Expenses - _TC",
+			company="_Test Company",
+		)
+		discount_amount = grand_total * (discount_percent / 100)
+
+		so.apply_discount_on = "Grand Total"
+		so.additional_discount_percentage = discount_percent
+		so.is_cash_or_non_trade_discount = 1
+		so.additional_discount_account = additional_discount_account
+
+		so.save()
+
+		self.assertEqual(so.grand_total, (grand_total - discount_amount))
+
+	def test_sales_invoice_creation_from_sales_order_with_cash_discount_fields(self):
+		so = make_sales_order(do_not_submit=True)
+
+		additional_discount_account = create_account(
+			account_name="Discount Account",
+			parent_account="Indirect Expenses - _TC",
+			company="_Test Company",
+		)
+		discount_percent = 5
+
+		so.apply_discount_on = "Grand Total"
+		so.additional_discount_percentage = discount_percent
+		so.is_cash_or_non_trade_discount = 1
+		so.additional_discount_account = additional_discount_account
+
+		so.submit()
+
+		si = make_sales_invoice(so.name)
+
+		self.assertEqual(so.is_cash_or_non_trade_discount, si.is_cash_or_non_trade_discount)
+		self.assertEqual(so.additional_discount_account, si.additional_discount_account)
+		self.assertEqual(so.apply_discount_on, si.apply_discount_on)
+		self.assertEqual(so.additional_discount_percentage, si.additional_discount_percentage)
+		self.assertEqual(so.grand_total, si.grand_total)
 
 	def test_so_billed_amount_against_return_entry(self):
 		from erpnext.accounts.doctype.sales_invoice.sales_invoice import make_sales_return

--- a/erpnext/stock/doctype/delivery_note/delivery_note.js
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.js
@@ -74,6 +74,13 @@ frappe.ui.form.on("Delivery Note", {
 		frm.set_df_property("packed_items", "cannot_delete_rows", true);
 	},
 
+	is_cash_or_non_trade_discount: function (frm) {
+		if (!frm.doc.is_cash_or_non_trade_discount) {
+			frm.set_value("additional_discount_account", "");
+		}
+
+		frm.cscript.calculate_taxes_and_totals();
+	},
 	print_without_amount: function (frm) {
 		erpnext.stock.delivery_note.set_print_hide(frm.doc);
 	},

--- a/erpnext/stock/doctype/delivery_note/delivery_note.json
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.json
@@ -80,6 +80,8 @@
   "section_break_49",
   "apply_discount_on",
   "base_discount_amount",
+  "is_cash_or_non_trade_discount",
+  "additional_discount_account",
   "column_break_51",
   "additional_discount_percentage",
   "discount_amount",
@@ -1419,13 +1421,29 @@
    "label": "Company Contact Person",
    "options": "Contact",
    "print_hide": 1
+  },
+  {
+   "default": "0",
+   "depends_on": "eval: doc.apply_discount_on == \"Grand Total\"",
+   "fieldname": "is_cash_or_non_trade_discount",
+   "fieldtype": "Check",
+   "label": "Is Cash or Non Trade Discount"
+  },
+  {
+   "allow_on_submit": 1,
+   "depends_on": "eval: doc.is_cash_or_non_trade_discount",
+   "fieldname": "additional_discount_account",
+   "fieldtype": "Link",
+   "label": "Discount Account",
+   "mandatory_depends_on": "eval: doc.is_cash_or_non_trade_discount",
+   "options": "Account"
   }
  ],
  "icon": "fa fa-truck",
  "idx": 146,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-01-06 15:02:30.558756",
+ "modified": "2025-06-02 15:14:28.590001",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Delivery Note",
@@ -1516,6 +1534,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "search_fields": "status,customer,customer_name, territory,base_grand_total",
  "show_name_in_global_search": 1,
  "sort_field": "creation",

--- a/erpnext/stock/doctype/delivery_note/delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.py
@@ -33,6 +33,7 @@ class DeliveryNote(SellingController):
 		from erpnext.stock.doctype.delivery_note_item.delivery_note_item import DeliveryNoteItem
 		from erpnext.stock.doctype.packed_item.packed_item import PackedItem
 
+		additional_discount_account: DF.Link | None
 		additional_discount_percentage: DF.Float
 		address_display: DF.TextEditor | None
 		amended_from: DF.Link | None
@@ -79,6 +80,7 @@ class DeliveryNote(SellingController):
 		installation_status: DF.Literal[None]
 		instructions: DF.Text | None
 		inter_company_reference: DF.Link | None
+		is_cash_or_non_trade_discount: DF.Check
 		is_internal_customer: DF.Check
 		is_return: DF.Check
 		issue_credit_note: DF.Check

--- a/erpnext/stock/doctype/delivery_note/test_delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/test_delivery_note.py
@@ -9,7 +9,7 @@ import frappe
 from frappe.tests import IntegrationTestCase, UnitTestCase
 from frappe.utils import add_days, cstr, flt, getdate, nowdate, nowtime, today
 
-from erpnext.accounts.doctype.account.test_account import get_inventory_account
+from erpnext.accounts.doctype.account.test_account import create_account, get_inventory_account
 from erpnext.accounts.doctype.cost_center.test_cost_center import create_cost_center
 from erpnext.accounts.utils import get_balance_on
 from erpnext.controllers.accounts_controller import InvalidQtyError
@@ -1225,6 +1225,51 @@ class TestDeliveryNote(IntegrationTestCase):
 
 		si = make_sales_invoice(dn.name)
 		self.assertEqual(si.items[0].qty, 1)
+
+	def test_overall_discount_calculatin(self):
+		dn = create_delivery_note(do_not_submit=True)
+
+		discount_percent = 5
+		grand_total = dn.grand_total
+		additional_discount_account = create_account(
+			account_name="Discount Account",
+			parent_account="Indirect Expenses - _TC",
+			company="_Test Company",
+		)
+		discount_amount = grand_total * (discount_percent / 100)
+
+		dn.apply_discount_on = "Grand Total"
+		dn.additional_discount_percentage = discount_percent
+		dn.is_cash_or_non_trade_discount = 1
+		dn.additional_discount_account = additional_discount_account
+
+		dn.save()
+
+		self.assertEqual(dn.grand_total, (grand_total - discount_amount))
+
+	def test_sales_invoice_creation_from_delivery_note_with_cash_discount_fields(self):
+		dn = create_delivery_note(do_not_submit=True)
+
+		additional_discount_account = create_account(
+			account_name="Discount Account",
+			parent_account="Indirect Expenses - _TC",
+			company="_Test Company",
+		)
+
+		dn.apply_discount_on = "Grand Total"
+		dn.additional_discount_percentage = 5
+		dn.is_cash_or_non_trade_discount = 1
+		dn.additional_discount_account = additional_discount_account
+
+		dn.submit()
+
+		si = make_sales_invoice(dn.name)
+
+		self.assertEqual(dn.is_cash_or_non_trade_discount, si.is_cash_or_non_trade_discount)
+		self.assertEqual(dn.additional_discount_account, si.additional_discount_account)
+		self.assertEqual(dn.apply_discount_on, si.apply_discount_on)
+		self.assertEqual(dn.additional_discount_percentage, si.additional_discount_percentage)
+		self.assertEqual(dn.grand_total, si.grand_total)
 
 	def test_make_sales_invoice_from_dn_with_returned_qty_duplicate_items(self):
 		from erpnext.stock.doctype.delivery_note.delivery_note import make_sales_invoice


### PR DESCRIPTION
Enable overall discount on Sales Order and Delivery Note by checking the "Is Cash or Non Trade Discount" checkbox.

Apply discount on grand total and carry forward to Sales Invoice.

Align behavior with existing Sales Invoice logic.

Sales Order:


https://github.com/user-attachments/assets/4bd250f0-9b16-4ac9-8fc8-df308872fd3a


Delivery Note:


https://github.com/user-attachments/assets/a8386194-0e98-48cf-8310-babb34bd2db3

resolves[#47818 ](https://github.com/frappe/erpnext/issues/47818)

Backport needed: v15

no-docs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added options to specify cash or non-trade discounts and select an additional discount account on Sales Orders and Delivery Notes.
  * These fields are shown when applying a discount on the Grand Total and become mandatory as needed.

* **Bug Fixes**
  * Ensured that discount-related fields are cleared and recalculated appropriately when toggling the cash/non-trade discount option.

* **Tests**
  * Introduced new tests to verify correct calculation of overall discounts and the transfer of discount details to related Sales Invoices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->