### PR TITLE
fix: typo

### DIFF
--- a/erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.js
+++ b/erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.js
@@ -10,7 +10,7 @@ frappe.query_reports["Purchase Order Analysis"] = {
 			width: "80",
 			options: "Company",
 			reqd: 1,
-			default: frappe.defaults.get_user_default("company"),
+			default: frappe.defaults.get_user_default("Company"),
 		},
 		{
 			fieldname: "from_date",


### PR DESCRIPTION
typo in frappe.defaults.get_user_default("Company")

change "company" to "Company"

This PR is in response to a typo fix in previous PR fix: use user default for company instead of global default in purchase order analysis report #47854