### PR TITLE
fix: zero division error in purchase receipt

### DIFF
--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
@@ -1244,7 +1244,7 @@ def update_billing_percentage(pr_doc, update_modified=True, adjust_incoming_rate
 
 			adjusted_amt = flt(adjusted_amt * flt(pr_doc.conversion_rate), item.precision("amount"))
 			item.db_set("amount_difference_with_purchase_invoice", adjusted_amt, update_modified=False)
-		elif item.billed_amt > amount:
+		elif amount and item.billed_amt > amount:
 			per_over_billed = (flt(item.billed_amt / amount, 2) * 100) - 100
 			if per_over_billed > over_billing_allowance:
 				frappe.throw(


### PR DESCRIPTION
Reference support ticket [40223](https://support.frappe.io/helpdesk/tickets/40223)