### PR TITLE
feat: show warning toast if rate is 0 and allow zero valuation rate c…

### DIFF
--- a/erpnext/controllers/stock_controller.py
+++ b/erpnext/controllers/stock_controller.py
@@ -64,6 +64,7 @@ class StockController(AccountsController):
 		self.validate_internal_transfer()
 		self.validate_putaway_capacity()
 		self.reset_conversion_factor()
+		self.check_zero_rate()
 
 	def reset_conversion_factor(self):
 		for row in self.get("items"):
@@ -77,6 +78,16 @@ class StockController(AccountsController):
 						"Conversion factor for item {0} has been reset to 1.0 as the uom {1} is same as stock uom {2}."
 					).format(bold(row.item_code), bold(row.uom), bold(row.stock_uom)),
 					alert=True,
+				)
+
+	def check_zero_rate(self):
+		for item in self.get("items"):
+			if not item.get("base_rate") and not item.get("allow_zero_valuation_rate"):
+				frappe.toast(
+					_(
+						"Row #{0}: Item {1} has zero rate but 'Allow Zero Valuation Rate' is not enabled."
+					).format(item.idx, frappe.bold(item.item_code)),
+					indicator="orange",
 				)
 
 	def validate_items_exist(self):


### PR DESCRIPTION
Show a warning if `rate` is 0 but `allow_zero_valuation_rate` is not enabled.

<img width="424" alt="image" src="https://github.com/user-attachments/assets/22f15697-fcd4-4f5e-bd0c-ff642055c610" />
