### PR TITLE
feat(cashflow): show opening/closing balance

### DIFF
--- a/erpnext/accounts/report/cash_flow/cash_flow.js
+++ b/erpnext/accounts/report/cash_flow/cash_flow.js
@@ -14,9 +14,16 @@ erpnext.utils.add_dimensions("Cash Flow", 10);
 
 frappe.query_reports["Cash Flow"]["filters"].splice(8, 1);
 
-frappe.query_reports["Cash Flow"]["filters"].push({
-	fieldname: "include_default_book_entries",
-	label: __("Include Default FB Entries"),
-	fieldtype: "Check",
-	default: 1,
-});
+frappe.query_reports["Cash Flow"]["filters"].push(
+	{
+		fieldname: "include_default_book_entries",
+		label: __("Include Default FB Entries"),
+		fieldtype: "Check",
+		default: 1,
+	},
+	{
+		fieldname: "carry_forward_opening",
+		label: __("Carry forward Opening"),
+		fieldtype: "Check",
+	}
+);

--- a/erpnext/accounts/report/cash_flow/cash_flow.js
+++ b/erpnext/accounts/report/cash_flow/cash_flow.js
@@ -22,8 +22,8 @@ frappe.query_reports["Cash Flow"]["filters"].push(
 		default: 1,
 	},
 	{
-		fieldname: "carry_forward_opening",
-		label: __("Carry forward Opening"),
+		fieldname: "show_opening_and_closing_balance",
+		label: __("Show Opening and Closing Balance"),
 		fieldtype: "Check",
 	}
 );

--- a/erpnext/accounts/report/cash_flow/cash_flow.py
+++ b/erpnext/accounts/report/cash_flow/cash_flow.py
@@ -284,8 +284,6 @@ def show_opening_and_closing_balance(out, period_list, currency, net_change_in_c
 		"section": "Closing (Opening + Total)",
 		"currency": currency,
 	}
-	net_change_in_cash["section_name"] = "'" + _("Total Net Change in Cash") + "'"
-	net_change_in_cash["section"] = "'" + _("Total Net Change in Cash") + "'"
 
 	opening_amount = get_opening_balance(filters.company, period_list, filters) or 0.0
 	running_total = opening_amount

--- a/erpnext/accounts/report/cash_flow/cash_flow.py
+++ b/erpnext/accounts/report/cash_flow/cash_flow.py
@@ -284,8 +284,8 @@ def show_opening_and_closing_balance(out, period_list, currency, net_change_in_c
 		"section": "Closing (Opening + Total)",
 		"currency": currency,
 	}
-	net_change_in_cash["section_name"] = "'" + _("{0}").format("Total Net Change in Cash") + "'"
-	net_change_in_cash["section"] = "'" + _("{0}").format("Total Net Change in Cash") + "'"
+	net_change_in_cash["section_name"] = "'" + _("Total Net Change in Cash") + "'"
+	net_change_in_cash["section"] = "'" + _("Total Net Change in Cash") + "'"
 
 	opening_amount = get_opening_balance(filters.company, period_list, filters) or 0.0
 	running_total = opening_amount

--- a/erpnext/accounts/report/cash_flow/cash_flow.py
+++ b/erpnext/accounts/report/cash_flow/cash_flow.py
@@ -128,8 +128,8 @@ def execute(filters=None):
 		data, data, _("Net Change in Cash"), period_list, company_currency, summary_data, filters
 	)
 
-	if filters.carry_forward_opening:
-		add_closing_balance(data, period_list, company_currency, net_change_in_cash, filters)
+	if filters.show_opening_and_closing_balance:
+		show_opening_and_closing_balance(data, period_list, company_currency, net_change_in_cash, filters)
 
 	columns = get_columns(
 		filters.periodicity,
@@ -137,7 +137,6 @@ def execute(filters=None):
 		filters.accumulated_values,
 		filters.company,
 		True,
-		filters.carry_forward_opening,
 	)
 
 	chart = get_chart_data(columns, data, company_currency)
@@ -274,7 +273,7 @@ def add_total_row_account(out, data, label, period_list, currency, summary_data,
 	return total_row
 
 
-def add_closing_balance(out, period_list, currency, net_change_in_cash, filters):
+def show_opening_and_closing_balance(out, period_list, currency, net_change_in_cash, filters):
 	opening_balance = {
 		"section_name": "Opening",
 		"section": "Opening",
@@ -285,6 +284,8 @@ def add_closing_balance(out, period_list, currency, net_change_in_cash, filters)
 		"section": "Closing (Opening + Total)",
 		"currency": currency,
 	}
+	net_change_in_cash["section_name"] = "'" + _("{0}").format("Total Net Change in Cash") + "'"
+	net_change_in_cash["section"] = "'" + _("{0}").format("Total Net Change in Cash") + "'"
 
 	opening_amount = get_opening_balance(filters.company, period_list, filters) or 0.0
 	running_total = opening_amount
@@ -297,7 +298,10 @@ def add_closing_balance(out, period_list, currency, net_change_in_cash, filters)
 		running_total += change
 		closing_balance[key] = running_total
 
-	out.extend([opening_balance, closing_balance, {}])
+	opening_balance["total"] = opening_balance[period_list[0]["key"]]
+	closing_balance["total"] = closing_balance[period_list[-1]["key"]]
+
+	out.extend([opening_balance, net_change_in_cash, closing_balance, {}])
 
 
 def get_opening_balance(company, period_list, filters):

--- a/erpnext/accounts/report/financial_statements.py
+++ b/erpnext/accounts/report/financial_statements.py
@@ -642,7 +642,9 @@ def get_cost_centers_with_children(cost_centers):
 	return list(set(all_cost_centers))
 
 
-def get_columns(periodicity, period_list, accumulated_values=1, company=None, cash_flow=False):
+def get_columns(
+	periodicity, period_list, accumulated_values=1, company=None, cash_flow=False, carry_forward_opening=False
+):
 	columns = [
 		{
 			"fieldname": "account" if not cash_flow else "section",
@@ -691,7 +693,7 @@ def get_columns(periodicity, period_list, accumulated_values=1, company=None, ca
 				"width": 150,
 			}
 		)
-	if periodicity != "Yearly":
+	if periodicity != "Yearly" and not carry_forward_opening:
 		if not accumulated_values:
 			columns.append(
 				{

--- a/erpnext/accounts/report/financial_statements.py
+++ b/erpnext/accounts/report/financial_statements.py
@@ -642,9 +642,7 @@ def get_cost_centers_with_children(cost_centers):
 	return list(set(all_cost_centers))
 
 
-def get_columns(
-	periodicity, period_list, accumulated_values=1, company=None, cash_flow=False, carry_forward_opening=False
-):
+def get_columns(periodicity, period_list, accumulated_values=1, company=None, cash_flow=False):
 	columns = [
 		{
 			"fieldname": "account" if not cash_flow else "section",
@@ -693,7 +691,7 @@ def get_columns(
 				"width": 150,
 			}
 		)
-	if periodicity != "Yearly" and not carry_forward_opening:
+	if periodicity != "Yearly":
 		if not accumulated_values:
 			columns.append(
 				{


### PR DESCRIPTION
Issue: Opening balance not carryfowarding 

### **Calculation:**

Opening Balance at the start of the period.
Closing Balance computed as: `Opening + Net Change in Cash`

**Computes the total opening balance by aggregating:**

-  Cash-equivalent accounts (e.g., Operating, Investing, Financing, Depreciation).

- Calculates net income = **`Total Income - Total Expense`**

- Uses **`set_gl_entries_by_account()`** to aggregate GL entries, filtering out period closing entries.



Ref: [#35598](https://support.frappe.io/helpdesk/tickets/35598)

<img width="1866" height="898" alt="image_2025-07-17_19-13-00" src="https://github.com/user-attachments/assets/353a9632-83bb-4525-b14a-d1dde697b2fc" />


<img width="1871" height="901" alt="image_2025-07-17_19-13-29" src="https://github.com/user-attachments/assets/d269b9e0-a455-48ee-9e0d-cc75d29fcc2d" />

no-docs

**Backport Needed: Version-15**