### PR TITLE
fix: add validation for exchange gain/loss entries

### DIFF
--- a/erpnext/accounts/report/general_ledger/general_ledger.py
+++ b/erpnext/accounts/report/general_ledger/general_ledger.py
@@ -200,7 +200,8 @@ def get_gl_entries(filters, accounting_dimensions):
 			voucher_type, voucher_subtype, voucher_no, {dimension_fields}
 			cost_center, project, {transaction_currency_fields}
 			against_voucher_type, against_voucher, account_currency,
-			against, is_opening, creation {select_fields}
+			against, is_opening, creation {select_fields},
+			transaction_currency
 		from `tabGL Entry`
 		where company=%(company)s {get_conditions(filters)}
 		{order_by_statement}

--- a/erpnext/accounts/report/general_ledger/test_general_ledger.py
+++ b/erpnext/accounts/report/general_ledger/test_general_ledger.py
@@ -3,12 +3,15 @@
 
 import frappe
 from frappe import qb
-from frappe.tests import IntegrationTestCase
+from frappe.tests import IntegrationTestCase, change_settings
 from frappe.utils import flt, today
 
+from erpnext.accounts.doctype.account.test_account import create_account
+from erpnext.accounts.doctype.payment_entry.test_payment_entry import create_payment_entry
 from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_sales_invoice
 from erpnext.accounts.report.general_ledger.general_ledger import execute
 from erpnext.controllers.sales_and_purchase_return import make_return_doc
+from erpnext.selling.doctype.customer.test_customer import create_internal_customer
 
 
 class TestGeneralLedger(IntegrationTestCase):
@@ -167,6 +170,90 @@ class TestGeneralLedger(IntegrationTestCase):
 		self.assertEqual(data[2]["credit"], 900)
 		self.assertEqual(data[3]["debit"], 100)
 		self.assertEqual(data[3]["credit"], 100)
+
+	@change_settings("Accounts Settings", {"delete_linked_ledger_entries": True})
+	def test_debit_in_exchange_gain_loss_account(self):
+		company = "_Test Company"
+
+		exchange_gain_loss_account = frappe.db.get_value("Company", "exchange_gain_loss_account")
+		if not exchange_gain_loss_account:
+			frappe.db.set_value(
+				"Company", company, "exchange_gain_loss_account", "_Test Exchange Gain/Loss - _TC"
+			)
+
+		account_name = "_Test Receivable USD - _TC"
+		customer_name = "_Test Customer USD"
+
+		sales_invoice = create_sales_invoice(
+			company=company,
+			customer=customer_name,
+			currency="USD",
+			debit_to=account_name,
+			conversion_rate=85,
+			posting_date=today(),
+		)
+
+		payment_entry = create_payment_entry(
+			company=company,
+			party_type="Customer",
+			party=customer_name,
+			payment_type="Receive",
+			paid_from=account_name,
+			paid_from_account_currency="USD",
+			paid_to="Cash - _TC",
+			paid_to_account_currency="INR",
+			paid_amount=10,
+			do_not_submit=True,
+		)
+		payment_entry.base_paid_amount = 800
+		payment_entry.received_amount = 800
+		payment_entry.currency = "USD"
+		payment_entry.source_exchange_rate = 80
+		payment_entry.append(
+			"references",
+			frappe._dict(
+				{
+					"reference_doctype": "Sales Invoice",
+					"reference_name": sales_invoice.name,
+					"total_amount": 10,
+					"outstanding_amount": 10,
+					"exchange_rate": 85,
+					"allocated_amount": 10,
+					"exchange_gain_loss": -50,
+				}
+			),
+		)
+		payment_entry.save()
+		payment_entry.submit()
+
+		journal_entry = frappe.get_all(
+			"Journal Entry Account", filters={"reference_name": sales_invoice.name}, fields=["parent"]
+		)
+
+		columns, data = execute(
+			frappe._dict(
+				{
+					"company": company,
+					"from_date": today(),
+					"to_date": today(),
+					"include_dimensions": 1,
+					"include_default_book_entries": 1,
+					"account": ["_Test Exchange Gain/Loss - _TC"],
+					"categorize_by": "Categorize by Voucher (Consolidated)",
+				}
+			)
+		)
+
+		entry = data[1]
+		self.assertEqual(entry["debit"], 50)
+		self.assertEqual(entry["voucher_type"], "Journal Entry")
+		self.assertEqual(entry["voucher_no"], journal_entry[0]["parent"])
+
+		payment_entry.cancel()
+		payment_entry.delete()
+		sales_invoice.reload()
+		sales_invoice.cancel()
+		sales_invoice.delete()
 
 	def test_ignore_exchange_rate_journals_filter(self):
 		# create a new account with USD currency

--- a/erpnext/accounts/report/utils.py
+++ b/erpnext/accounts/report/utils.py
@@ -101,13 +101,18 @@ def convert_to_presentation_currency(gl_entries, currency_info):
 	account_currencies = list(set(entry["account_currency"] for entry in gl_entries))
 
 	for entry in gl_entries:
+		transaction_currency = entry.get("transaction_currency")
 		debit = flt(entry["debit"])
 		credit = flt(entry["credit"])
 		debit_in_account_currency = flt(entry["debit_in_account_currency"])
 		credit_in_account_currency = flt(entry["credit_in_account_currency"])
 		account_currency = entry["account_currency"]
 
-		if len(account_currencies) == 1 and account_currency == presentation_currency:
+		if (
+			len(account_currencies) == 1
+			and account_currency == presentation_currency
+			and (transaction_currency is None or account_currency == transaction_currency)
+		):
 			entry["debit"] = debit_in_account_currency
 			entry["credit"] = credit_in_account_currency
 		else:


### PR DESCRIPTION
Issue: For a system posted exchange gain/loss entry the debit_in_account_curreny or credit_in_account_currency field won't be filled so when we filter that particular account in GL the debit credit showing as 0.

Solution: Added an extra if condition to pick the debit credit field instead of debit_in_account_curreny or credit_in_account_currency field if the account_currency and transaction currency are different.

Ref: [#39908](https://support.frappe.io/helpdesk/tickets/39908), [#40683](https://support.frappe.io/helpdesk/tickets/40683)

Before:

https://github.com/user-attachments/assets/5a576c57-bd36-443e-b77c-198dfb20ec6c

After:

https://github.com/user-attachments/assets/0f882732-c448-4828-bb3a-e8085e962e75



Backport Needed: version-15