### PR TITLE
fix: Fix SLA resolution by date time calculation with hold time

### DIFF
--- a/erpnext/support/doctype/service_level_agreement/service_level_agreement.py
+++ b/erpnext/support/doctype/service_level_agreement/service_level_agreement.py
@@ -882,13 +882,14 @@ def set_response_by(doc, start_date_time, priority):
 
 def set_resolution_by(doc, start_date_time, priority):
 	if doc.meta.has_field("sla_resolution_by"):
+		if doc.meta.has_field("total_hold_time") and doc.get("total_hold_time"):
+			start_date_time = add_to_date(
+				start_date_time, seconds=round(doc.get("total_hold_time")), as_datetime=True
+			)
+
 		doc.sla_resolution_by = get_expected_time_for(
 			parameter="resolution", service_level=priority, start_date_time=start_date_time
 		)
-		if doc.meta.has_field("total_hold_time") and doc.get("total_hold_time"):
-			doc.sla_resolution_by = add_to_date(
-				doc.sla_resolution_by, seconds=round(doc.get("total_hold_time"))
-			)
 
 
 def record_assigned_users_on_failure(doc):


### PR DESCRIPTION
## Fix: SLA resolution by date time calculation with hold time

This PR addresses an issue where the Resolution Time calculation incorrectly included hold time, leading to a total resolution duration that could exceed the defined SLA working hours or days.

The logic has been updated to account for hold time *before* calculating the **Resolution By** datetime. This ensures that the final **Resolution By** datetime remains accurate and in line with SLA settings.

**SLA Configurations**
![image](https://github.com/user-attachments/assets/7baee99e-7bb7-45d3-a684-718704e9613a)

**Before**
![image](https://github.com/user-attachments/assets/62365bf8-13dc-4ab9-90be-56a8ce792270)

**After**
![image](https://github.com/user-attachments/assets/98ab8e9b-3e8f-485e-a4e0-96bf3c8323c9)
