### PR TITLE
fix: get year_start_date and year_end_date from fiscal year instead of global default

### DIFF
--- a/erpnext/stock/report/stock_analytics/stock_analytics.js
+++ b/erpnext/stock/report/stock_analytics/stock_analytics.js
@@ -61,14 +61,14 @@ frappe.query_reports["Stock Analytics"] = {
 			fieldname: "from_date",
 			label: __("From Date"),
 			fieldtype: "Date",
-			default: frappe.defaults.get_global_default("year_start_date"),
+			default: erpnext.utils.get_fiscal_year(frappe.datetime.get_today(), true)[1],
 			reqd: 1,
 		},
 		{
 			fieldname: "to_date",
 			label: __("To Date"),
 			fieldtype: "Date",
-			default: frappe.defaults.get_global_default("year_end_date"),
+			default: erpnext.utils.get_fiscal_year(frappe.datetime.get_today(), true)[2],
 			reqd: 1,
 		},
 		{


### PR DESCRIPTION
This PR fixes an issue where the year_start_date and year_end_date were previously being fetched from Global Defaults.

Updated the logic to fetch the fiscal year start and end dates from the Fiscal Year DocType instead of relying on Global Defaults in Stock Analytics Report