### PR TITLE
Improve pegged currency logic

### DIFF
--- a/.github/workflows/patch.yml
+++ b/.github/workflows/patch.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Check for valid Python & Merge Conflicts
         run: |
-          python -m compileall -f "${GITHUB_WORKSPACE}"
+          python -m compileall -fq "${GITHUB_WORKSPACE}"
           if grep -lr --exclude-dir=node_modules "^<<<<<<< " "${GITHUB_WORKSPACE}"
               then echo "Found merge conflicts"
               exit 1

--- a/.github/workflows/server-tests-mariadb.yml
+++ b/.github/workflows/server-tests-mariadb.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Check for valid Python & Merge Conflicts
         run: |
-          python -m compileall -f "${GITHUB_WORKSPACE}"
+          python -m compileall -fq "${GITHUB_WORKSPACE}"
           if grep -lr --exclude-dir=node_modules "^<<<<<<< " "${GITHUB_WORKSPACE}"
               then echo "Found merge conflicts"
               exit 1

--- a/.github/workflows/server-tests-postgres.yml
+++ b/.github/workflows/server-tests-postgres.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Check for valid Python & Merge Conflicts
         run: |
-          python -m compileall -f "${GITHUB_WORKSPACE}"
+          python -m compileall -fq "${GITHUB_WORKSPACE}"
           if grep -lr --exclude-dir=node_modules "^<<<<<<< " "${GITHUB_WORKSPACE}"
               then echo "Found merge conflicts"
               exit 1

--- a/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
+++ b/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
@@ -38,6 +38,11 @@
   "show_taxes_as_table_in_print",
   "column_break_12",
   "show_payment_schedule_in_print",
+  "item_price_settings_section",
+  "maintain_same_internal_transaction_rate",
+  "column_break_feyo",
+  "maintain_same_rate_action",
+  "role_to_override_stop_action",
   "currency_exchange_section",
   "allow_stale",
   "column_break_yuug",
@@ -569,6 +574,28 @@
    "label": "Legacy Fields"
   },
   {
+   "default": "0",
+   "fieldname": "maintain_same_internal_transaction_rate",
+   "fieldtype": "Check",
+   "label": "Maintain Same Rate Throughout Internal Transaction"
+  },
+  {
+   "default": "Stop",
+   "depends_on": "maintain_same_internal_transaction_rate",
+   "fieldname": "maintain_same_rate_action",
+   "fieldtype": "Select",
+   "label": "Action if Same Rate is Not Maintained Throughout  Internal Transaction",
+   "mandatory_depends_on": "maintain_same_internal_transaction_rate",
+   "options": "Stop\nWarn"
+  },
+  {
+   "depends_on": "eval: doc.maintain_same_internal_transaction_rate && doc.maintain_same_rate_action == 'Stop'",
+   "fieldname": "role_to_override_stop_action",
+   "fieldtype": "Link",
+   "label": "Role Allowed to Override Stop Action",
+   "options": "Role"
+  },
+  {
    "fieldname": "budget_settings",
    "fieldtype": "Tab Break",
    "label": "Budget"
@@ -578,6 +605,15 @@
    "fieldname": "use_new_budget_controller",
    "fieldtype": "Check",
    "label": "Use New Budget Controller"
+  },
+  {
+   "fieldname": "item_price_settings_section",
+   "fieldtype": "Section Break",
+   "label": "Item Price Settings"
+  },
+  {
+   "fieldname": "column_break_feyo",
+   "fieldtype": "Column Break"
   }
  ],
  "grid_page_length": 50,
@@ -586,7 +622,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-05-16 11:08:00.796886",
+ "modified": "2025-05-27 17:52:03.460522",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Accounts Settings",

--- a/erpnext/accounts/doctype/accounts_settings/accounts_settings.py
+++ b/erpnext/accounts/doctype/accounts_settings/accounts_settings.py
@@ -50,6 +50,8 @@ class AccountsSettings(Document):
 		general_ledger_remarks_length: DF.Int
 		ignore_account_closing_balance: DF.Check
 		ignore_is_opening_check_for_reporting: DF.Check
+		maintain_same_internal_transaction_rate: DF.Check
+		maintain_same_rate_action: DF.Literal["Stop", "Warn"]
 		make_payment_via_journal_entry: DF.Check
 		merge_similar_account_heads: DF.Check
 		over_billing_allowance: DF.Currency
@@ -58,6 +60,7 @@ class AccountsSettings(Document):
 		receivable_payable_remarks_length: DF.Int
 		reconciliation_queue_size: DF.Int
 		role_allowed_to_over_bill: DF.Link | None
+		role_to_override_stop_action: DF.Link | None
 		round_row_wise_tax: DF.Check
 		show_balance_in_coa: DF.Check
 		show_inclusive_tax_in_print: DF.Check

--- a/erpnext/accounts/doctype/pegged_currencies/pegged_currencies.js
+++ b/erpnext/accounts/doctype/pegged_currencies/pegged_currencies.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2025, Frappe Technologies Pvt. Ltd. and contributors
+// For license information, please see license.txt
+
+// frappe.ui.form.on("Pegged Currencies", {
+// 	refresh(frm) {
+
+// 	},
+// });

--- a/erpnext/accounts/doctype/pegged_currencies/pegged_currencies.json
+++ b/erpnext/accounts/doctype/pegged_currencies/pegged_currencies.json
@@ -1,0 +1,47 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2025-05-30 11:47:03.670913",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "pegged_currencies_item_section",
+  "pegged_currency_item"
+ ],
+ "fields": [
+  {
+   "fieldname": "pegged_currencies_item_section",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "pegged_currency_item",
+   "fieldtype": "Table",
+   "options": "Pegged Currency Details"
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "issingle": 1,
+ "links": [],
+ "modified": "2025-06-02 11:46:31.936714",
+ "modified_by": "Administrator",
+ "module": "Accounts",
+ "name": "Pegged Currencies",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "print": 1,
+   "read": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "row_format": "Dynamic",
+ "sort_field": "creation",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/erpnext/accounts/doctype/pegged_currencies/pegged_currencies.py
+++ b/erpnext/accounts/doctype/pegged_currencies/pegged_currencies.py
@@ -1,0 +1,22 @@
+# Copyright (c) 2025, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class PeggedCurrencies(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		from erpnext.accounts.doctype.pegged_currencies.pegged_currencies import PeggedCurrencies
+
+		pegged_currency_item: DF.Table[PeggedCurrencies]
+	# end: auto-generated types
+
+	pass

--- a/erpnext/accounts/doctype/pegged_currencies/test_pegged_currencies.py
+++ b/erpnext/accounts/doctype/pegged_currencies/test_pegged_currencies.py
@@ -1,0 +1,29 @@
+# Copyright (c) 2025, Frappe Technologies Pvt. Ltd. and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests import IntegrationTestCase, UnitTestCase
+
+# On IntegrationTestCase, the doctype test records and all
+# link-field test record dependencies are recursively loaded
+# Use these module variables to add/remove to/from that list
+EXTRA_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
+IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
+
+
+class UnitTestPeggedCurrencies(UnitTestCase):
+	"""
+	Unit tests for PeggedCurrencies.
+	Use this class for testing individual functions and methods.
+	"""
+
+	pass
+
+
+class IntegrationTestPeggedCurrencies(IntegrationTestCase):
+	"""
+	Integration tests for PeggedCurrencies.
+	Use this class for testing interactions between multiple components.
+	"""
+
+	pass

--- a/erpnext/accounts/doctype/pegged_currency_details/pegged_currency_details.json
+++ b/erpnext/accounts/doctype/pegged_currency_details/pegged_currency_details.json
@@ -1,0 +1,49 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2025-05-30 11:59:28.219277",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "source_currency",
+  "pegged_currency",
+  "currency_ratio"
+ ],
+ "fields": [
+  {
+   "fieldname": "pegged_currency",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Pegged Currency",
+   "options": "Currency"
+  },
+  {
+   "fieldname": "currency_ratio",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Currency Ratio"
+  },
+  {
+   "fieldname": "source_currency",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Currency",
+   "options": "Currency"
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2025-06-02 11:50:29.059345",
+ "modified_by": "Administrator",
+ "module": "Accounts",
+ "name": "Pegged Currency Details",
+ "owner": "Administrator",
+ "permissions": [],
+ "row_format": "Dynamic",
+ "sort_field": "creation",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/erpnext/accounts/doctype/pegged_currency_details/pegged_currency_details.py
+++ b/erpnext/accounts/doctype/pegged_currency_details/pegged_currency_details.py
@@ -1,0 +1,25 @@
+# Copyright (c) 2025, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class PeggedCurrencyDetails(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		currency_ratio: DF.Data | None
+		parent: DF.Data
+		parentfield: DF.Data
+		parenttype: DF.Data
+		pegged_currency: DF.Link | None
+		source_currency: DF.Link | None
+	# end: auto-generated types
+
+	pass

--- a/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.js
+++ b/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.js
@@ -60,6 +60,20 @@ frappe.ui.form.on("Process Statement Of Accounts", {
 				},
 			};
 		});
+		frm.set_query("cost_center", function () {
+			return {
+				filters: {
+					company: frm.doc.company,
+				},
+			};
+		});
+		frm.set_query("project", function () {
+			return {
+				filters: {
+					company: frm.doc.company,
+				},
+			};
+		});
 		if (frm.doc.__islocal) {
 			frm.set_value("from_date", frappe.datetime.add_months(frappe.datetime.get_today(), -1));
 			frm.set_value("to_date", frappe.datetime.get_today());

--- a/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
@@ -7,7 +7,7 @@ import json
 import frappe
 from frappe import qb
 from frappe.model.dynamic_links import get_dynamic_link_map
-from frappe.tests import IntegrationTestCase, UnitTestCase
+from frappe.tests import IntegrationTestCase, UnitTestCase, change_settings
 from frappe.utils import add_days, flt, format_date, getdate, nowdate, today
 
 import erpnext
@@ -73,6 +73,26 @@ class TestSalesInvoice(ERPNextTestSuite):
 			mode_of_payment, "_Test Company with perpetual inventory", "_Test Bank - TCP1"
 		)
 		frappe.db.set_single_value("Accounts Settings", "acc_frozen_upto", None)
+
+	@change_settings(
+		"Accounts Settings",
+		{"maintain_same_internal_transaction_rate": 1, "maintain_same_rate_action": "Stop"},
+	)
+	def test_invalid_rate_without_override(self):
+		from frappe import ValidationError
+
+		from erpnext.accounts.doctype.sales_invoice.sales_invoice import make_inter_company_purchase_invoice
+
+		si = create_sales_invoice(
+			customer="_Test Internal Customer 3", company="_Test Company", is_internal_customer=1, rate=100
+		)
+		pi = make_inter_company_purchase_invoice(si)
+		pi.items[0].rate = 120
+
+		with self.assertRaises(ValidationError) as e:
+			pi.insert()
+			pi.submit()
+		self.assertIn("Rate must be same", str(e.exception))
 
 	def tearDown(self):
 		frappe.db.rollback()
@@ -4483,6 +4503,7 @@ def create_sales_invoice(**args):
 	si.conversion_rate = args.conversion_rate or 1
 	si.naming_series = args.naming_series or "T-SINV-"
 	si.cost_center = args.parent_cost_center
+	si.is_internal_customer = args.is_internal_customer or 0
 
 	bundle_id = None
 	if si.update_stock and (args.get("batch_no") or args.get("serial_no")):
@@ -4682,6 +4703,12 @@ def create_internal_parties():
 		supplier_name="_Test Internal Supplier 2",
 		represents_company="_Test Company with perpetual inventory",
 		allowed_to_interact_with="_Test Company with perpetual inventory",
+	)
+
+	create_internal_supplier(
+		supplier_name="_Test Internal Customer 3",
+		represents_company="_Test Company",
+		allowed_to_interact_with="_Test Company",
 	)
 
 

--- a/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
+++ b/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
@@ -98,9 +98,6 @@ class ReceivablePayableReport:
 	def get_data(self):
 		self.get_sales_invoices_or_customers_based_on_sales_person()
 
-		# Build delivery note map against all sales invoices
-		self.build_delivery_note_map()
-
 		# Get invoice details like bill_no, due_date etc for all invoices
 		self.get_invoice_details()
 
@@ -108,7 +105,8 @@ class ReceivablePayableReport:
 		self.get_future_payments()
 
 		# Get return entries
-		self.get_return_entries()
+		if not self.filters.party_type or self.filters.party_type in ["Customer", "Supplier"]:
+			self.get_return_entries()
 
 		# Get Exchange Rate Revaluations
 		self.get_exchange_rate_revaluations()
@@ -121,6 +119,9 @@ class ReceivablePayableReport:
 			self.fetch_ple_in_buffered_cursor()
 		elif self.ple_fetch_method == "UnBuffered Cursor":
 			self.fetch_ple_in_unbuffered_cursor()
+
+		# Build delivery note map against all sales invoices
+		self.build_delivery_note_map()
 
 		self.build_data()
 

--- a/erpnext/accounts/report/cash_flow/cash_flow.py
+++ b/erpnext/accounts/report/cash_flow/cash_flow.py
@@ -75,7 +75,11 @@ def execute(filters=None):
 			# add first net income in operations section
 			if net_profit_loss:
 				net_profit_loss.update(
-					{"indent": 1, "parent_section": cash_flow_sections[0]["section_header"]}
+					{
+						"indent": 1,
+						"parent_section": cash_flow_sections[0]["section_header"],
+						"section": net_profit_loss["account"],
+					}
 				)
 				data.append(net_profit_loss)
 				section_data.append(net_profit_loss)

--- a/erpnext/accounts/report/financial_statements.html
+++ b/erpnext/accounts/report/financial_statements.html
@@ -47,12 +47,12 @@
 		{% for(let j=0, k=data.length; j<k; j++) { %}
 			{%
 				var row = data[j];
-				var row_class = data[j].parent_account ? "" : "financial-statements-important";
-				row_class += data[j].account_name ? "" : " financial-statements-blank-row";
+				var row_class = data[j].parent_account || data[j].parent_section ? "" : "financial-statements-important";
+				row_class += data[j].account_name || data[j].section ? "" : " financial-statements-blank-row";
 			%}
 			<tr class="{%= row_class %}">
 				<td>
-					<span style="padding-left: {%= cint(data[j].indent) * 2 %}em">{%= row.account_name %}</span>
+					<span style="padding-left: {%= cint(data[j].indent) * 2 %}em">{%= row.account_name || row.section %}</span>
 				</td>
 				{% for(let i=1, l=report_columns.length; i<l; i++) { %}
 					<td class="text-right">

--- a/erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.js
+++ b/erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.js
@@ -10,7 +10,7 @@ frappe.query_reports["Purchase Order Analysis"] = {
 			width: "80",
 			options: "Company",
 			reqd: 1,
-			default: frappe.defaults.get_default("company"),
+			default: frappe.defaults.get_user_default("company"),
 		},
 		{
 			fieldname: "from_date",

--- a/erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.js
+++ b/erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.js
@@ -10,7 +10,7 @@ frappe.query_reports["Purchase Order Analysis"] = {
 			width: "80",
 			options: "Company",
 			reqd: 1,
-			default: frappe.defaults.get_user_default("company"),
+			default: frappe.defaults.get_user_default("Company"),
 		},
 		{
 			fieldname: "from_date",

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -118,7 +118,7 @@ class AccountsController(TransactionBase):
 	def onload(self):
 		self.set_onload(
 			"make_payment_via_journal_entry",
-			frappe.db.get_single_value("Accounts Settings", "make_payment_via_journal_entry"),
+			frappe.client_cache.get_doc("Accounts Settings").make_payment_via_journal_entry,
 		)
 
 		if self.is_new():

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -230,6 +230,8 @@ class AccountsController(TransactionBase):
 		self.validate_party_accounts()
 
 		self.validate_inter_company_reference()
+		# validate inter  company transaction rate
+		self.validate_internal_transaction()
 
 		self.disable_pricing_rule_on_internal_transfer()
 		self.disable_tax_included_prices_for_internal_transfer()
@@ -740,6 +742,91 @@ class AccountsController(TransactionBase):
 				if not row.get(field):
 					msg = f"At Row {row.idx}: The field {bold(label)} is mandatory for internal transfer"
 					frappe.throw(_(msg), title=_("Internal Transfer Reference Missing"))
+
+	def validate_internal_transaction(self):
+		if not cint(
+			frappe.db.get_single_value("Accounts Settings", "maintain_same_internal_transaction_rate")
+		):
+			return
+
+		doctypes_list = ["Sales Order", "Sales Invoice", "Purchase Order", "Purchase Invoice"]
+
+		if self.doctype in doctypes_list and (
+			self.get("is_internal_customer") or self.get("is_internal_supplier")
+		):
+			self.validate_internal_transaction_based_on_voucher_type()
+
+	def validate_internal_transaction_based_on_voucher_type(self):
+		order = ["Sales Order", "Purchase Order"]
+		invoice = ["Sales Invoice", "Purchase Invoice"]
+
+		if self.doctype in order and self.get("inter_company_order_reference"):
+			# Fetch the linked order
+			linked_doctype = "Sales Order" if self.doctype == "Purchase Order" else "Purchase Order"
+			self.validate_line_items(
+				linked_doctype,
+				"sales_order" if linked_doctype == "Sales Order" else "purchase_order",
+				"sales_order_item" if linked_doctype == "Sales Order" else "purchase_order_item",
+			)
+		elif self.doctype in invoice and self.get("inter_company_invoice_reference"):
+			# Fetch the linked invoice
+			linked_doctype = "Sales Invoice" if self.doctype == "Purchase Invoice" else "Purchase Invoice"
+			self.validate_line_items(
+				linked_doctype,
+				"sales_invoice" if linked_doctype == "Sales Invoice" else "purchase_invoice",
+				"sales_invoice_item" if linked_doctype == "Sales Invoice" else "purchase_invoice_item",
+			)
+
+	def validate_line_items(self, ref_dt, ref_dn_field, ref_link_field):
+		action, role_allowed_to_override = frappe.get_cached_value(
+			"Accounts Settings", "None", ["maintain_same_rate_action", "role_to_override_stop_action"]
+		)
+
+		reference_names = [d.get(ref_link_field) for d in self.get("items") if d.get(ref_link_field)]
+		reference_details = self.get_reference_details(reference_names, ref_dt + " Item")
+
+		stop_actions = []
+
+		for d in self.get("items"):
+			if d.get(ref_link_field):
+				ref_rate = reference_details.get(d.get(ref_link_field))
+				if ref_rate is not None and abs(flt(d.rate - ref_rate, d.precision("rate"))) >= 0.01:
+					if action == "Stop":
+						user_roles = [
+							r["role"]
+							for r in frappe.get_all(
+								"Has Role", filters={"parent": frappe.session.user}, fields=["role"]
+							)
+						]
+						if role_allowed_to_override not in user_roles:
+							stop_actions.append(
+								_("Row #{0}: Rate must be same as {1}: {2} ({3} / {4})").format(
+									d.idx,
+									ref_dt,
+									self.inter_company_invoice_reference
+									if d.parenttype in ("Sales Invoice", "Purchase Invoice")
+									else d.get(ref_dn_field),
+									d.rate,
+									ref_rate,
+								)
+							)
+					else:
+						frappe.msgprint(
+							_("Row #{0}: Rate must be same as {1}: {2} ({3} / {4})").format(
+								d.idx,
+								ref_dt,
+								self.inter_company_invoice_reference
+								if d.parenttype in ("Sales Invoice", "Purchase Invoice")
+								else d.get(ref_dn_field),
+								d.rate,
+								ref_rate,
+							),
+							title=_("Warning"),
+							indicator="orange",
+						)
+
+		if stop_actions:
+			frappe.throw(stop_actions, as_list=True)
 
 	def disable_pricing_rule_on_internal_transfer(self):
 		if not self.get("ignore_pricing_rule") and self.is_internal_transfer():

--- a/erpnext/controllers/buying_controller.py
+++ b/erpnext/controllers/buying_controller.py
@@ -2,6 +2,8 @@
 # License: GNU General Public License v3. See license.txt
 
 
+import json
+
 import frappe
 from frappe import ValidationError, _, msgprint
 from frappe.contacts.doctype.address.address import render_address
@@ -318,32 +320,40 @@ class BuyingController(SubcontractingController):
 			if d.item_code and d.item_code in stock_and_asset_items:
 				stock_and_asset_items_qty += flt(d.qty)
 				stock_and_asset_items_amount += flt(d.base_net_amount)
-				last_item_idx = d.idx
 
-		total_valuation_amount = sum(
-			flt(d.base_tax_amount_after_discount_amount)
-			for d in self.get("taxes")
-			if d.category in ["Valuation", "Valuation and Total"]
-		)
+			last_item_idx = d.idx
 
-		valuation_amount_adjustment = total_valuation_amount
+		tax_accounts, total_valuation_amount, total_actual_tax_amount = self.get_tax_details()
+
 		for i, item in enumerate(self.get("items")):
-			if item.item_code and item.qty and item.item_code in stock_and_asset_items:
-				item_proportion = (
-					flt(item.base_net_amount) / stock_and_asset_items_amount
-					if stock_and_asset_items_amount
-					else flt(item.qty) / stock_and_asset_items_qty
-				)
-
+			if item.item_code and item.qty:
+				item_tax_amount, actual_tax_amount = 0.0, 0.0
 				if i == (last_item_idx - 1):
-					item.item_tax_amount = flt(
-						valuation_amount_adjustment, self.precision("item_tax_amount", item)
-					)
+					item_tax_amount = total_valuation_amount
+					actual_tax_amount = total_actual_tax_amount
 				else:
-					item.item_tax_amount = flt(
-						item_proportion * total_valuation_amount, self.precision("item_tax_amount", item)
-					)
-					valuation_amount_adjustment -= item.item_tax_amount
+					# calculate item tax amount
+					item_tax_amount = self.get_item_tax_amount(item, tax_accounts)
+					total_valuation_amount -= item_tax_amount
+
+					if total_actual_tax_amount:
+						actual_tax_amount = self.get_item_actual_tax_amount(
+							item,
+							total_actual_tax_amount,
+							stock_and_asset_items_amount,
+							stock_and_asset_items_qty,
+						)
+						total_actual_tax_amount -= actual_tax_amount
+
+				# This code is required here to calculate the correct valuation for stock items
+				if item.item_code not in stock_and_asset_items:
+					item.valuation_rate = 0.0
+					continue
+
+				# Item tax amount is the total tax amount applied on that item and actual tax type amount
+				item.item_tax_amount = flt(
+					item_tax_amount + actual_tax_amount, self.precision("item_tax_amount", item)
+				)
 
 				self.round_floats_in(item)
 				if flt(item.conversion_factor) == 0.0:
@@ -375,6 +385,50 @@ class BuyingController(SubcontractingController):
 				item.valuation_rate = 0.0
 
 		update_regional_item_valuation_rate(self)
+
+	def get_tax_details(self):
+		tax_accounts = []
+		total_valuation_amount = 0.0
+		total_actual_tax_amount = 0.0
+
+		for d in self.get("taxes"):
+			if d.category not in ["Valuation", "Valuation and Total"]:
+				continue
+
+			if d.charge_type == "On Net Total":
+				total_valuation_amount += flt(d.base_tax_amount_after_discount_amount)
+				tax_accounts.append(d.account_head)
+			else:
+				total_actual_tax_amount += flt(d.base_tax_amount_after_discount_amount)
+
+		return tax_accounts, total_valuation_amount, total_actual_tax_amount
+
+	def get_item_tax_amount(self, item, tax_accounts):
+		item_tax_amount = 0.0
+		if item.item_tax_rate:
+			tax_details = json.loads(item.item_tax_rate)
+			for account, rate in tax_details.items():
+				if account not in tax_accounts:
+					continue
+
+				net_rate = item.base_net_amount
+				if item.sales_incoming_rate:
+					net_rate = item.qty * item.sales_incoming_rate
+
+				item_tax_amount += flt(net_rate) * flt(rate) / 100
+
+		return item_tax_amount
+
+	def get_item_actual_tax_amount(
+		self, item, actual_tax_amount, stock_and_asset_items_amount, stock_and_asset_items_qty
+	):
+		item_proportion = (
+			flt(item.base_net_amount) / stock_and_asset_items_amount
+			if stock_and_asset_items_amount
+			else flt(item.qty) / stock_and_asset_items_qty
+		)
+
+		return flt(item_proportion * actual_tax_amount, self.precision("item_tax_amount", item))
 
 	def set_incoming_rate(self):
 		"""

--- a/erpnext/controllers/stock_controller.py
+++ b/erpnext/controllers/stock_controller.py
@@ -64,6 +64,7 @@ class StockController(AccountsController):
 		self.validate_internal_transfer()
 		self.validate_putaway_capacity()
 		self.reset_conversion_factor()
+		self.check_zero_rate()
 
 	def reset_conversion_factor(self):
 		for row in self.get("items"):
@@ -77,6 +78,16 @@ class StockController(AccountsController):
 						"Conversion factor for item {0} has been reset to 1.0 as the uom {1} is same as stock uom {2}."
 					).format(bold(row.item_code), bold(row.uom), bold(row.stock_uom)),
 					alert=True,
+				)
+
+	def check_zero_rate(self):
+		for item in self.get("items"):
+			if not item.get("base_rate") and not item.get("allow_zero_valuation_rate"):
+				frappe.toast(
+					_(
+						"Row #{0}: Item {1} has zero rate but 'Allow Zero Valuation Rate' is not enabled."
+					).format(item.idx, frappe.bold(item.item_code)),
+					indicator="orange",
 				)
 
 	def validate_items_exist(self):

--- a/erpnext/controllers/taxes_and_totals.py
+++ b/erpnext/controllers/taxes_and_totals.py
@@ -12,6 +12,7 @@ from frappe.utils import cint, flt, round_based_on_smallest_currency_fraction
 import erpnext
 from erpnext.accounts.doctype.journal_entry.journal_entry import get_exchange_rate
 from erpnext.accounts.doctype.pricing_rule.utils import get_applied_pricing_rules
+from erpnext.accounts.utils import get_currency_precision
 from erpnext.controllers.accounts_controller import (
 	validate_conversion_rate,
 	validate_inclusive_tax,
@@ -707,7 +708,16 @@ class calculate_taxes_and_totals:
 					tax.item_wise_tax_detail = json.dumps(tax.item_wise_tax_detail)
 
 	def set_discount_amount(self):
-		if self.doc.additional_discount_percentage:
+		if self.doc.discount_amount:
+			self.doc.additional_discount_percentage = flt(
+				flt(
+					self.doc.discount_amount / flt(self.doc.get(scrub(self.doc.apply_discount_on))),
+					get_currency_precision(),
+				)
+				* 100,
+				self.doc.precision("additional_discount_percentage"),
+			)
+		elif self.doc.additional_discount_percentage:
 			self.doc.discount_amount = flt(
 				flt(self.doc.get(scrub(self.doc.apply_discount_on)))
 				* self.doc.additional_discount_percentage

--- a/erpnext/hooks.py
+++ b/erpnext/hooks.py
@@ -64,9 +64,6 @@ setup_wizard_stages = "erpnext.setup.setup_wizard.setup_wizard.get_setup_stages"
 setup_wizard_complete = "erpnext.setup.setup_wizard.setup_wizard.setup_demo"
 setup_wizard_test = "erpnext.setup.setup_wizard.test_setup_wizard.run_setup_wizard_test"
 
-before_install = [
-	"erpnext.setup.install.check_setup_wizard_not_completed",
-]
 after_install = "erpnext.setup.install.after_install"
 
 boot_session = "erpnext.startup.boot.boot_session"

--- a/erpnext/locale/ar.po
+++ b/erpnext/locale/ar.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: frappe\n"
 "Report-Msgid-Bugs-To: hello@frappe.io\n"
-"POT-Creation-Date: 2025-05-25 09:35+0000\n"
-"PO-Revision-Date: 2025-05-25 20:34\n"
+"POT-Creation-Date: 2025-06-01 09:36+0000\n"
+"PO-Revision-Date: 2025-06-01 21:34\n"
 "Last-Translator: hello@frappe.io\n"
 "Language-Team: Arabic\n"
 "MIME-Version: 1.0\n"
@@ -83,15 +83,15 @@ msgstr ""
 msgid " Summary"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:235
+#: erpnext/stock/doctype/item/item.py:238
 msgid "\"Customer Provided Item\" cannot be Purchase Item also"
 msgstr "\"الأصناف المقدمة من العملاء\" لا يمكن شرائها"
 
-#: erpnext/stock/doctype/item/item.py:237
+#: erpnext/stock/doctype/item/item.py:240
 msgid "\"Customer Provided Item\" cannot have Valuation Rate"
 msgstr "\"الأصناف المقدمة من العملاء\" لا يمكن ان تحتوي على تكلفة"
 
-#: erpnext/stock/doctype/item/item.py:313
+#: erpnext/stock/doctype/item/item.py:316
 msgid "\"Is Fixed Asset\" cannot be unchecked, as Asset record exists against the item"
 msgstr "\"اصل ثابت\" لا يمكن أن يكون غير محدد، حيث يوجد سجل أصول مقابل البند"
 
@@ -213,7 +213,7 @@ msgstr ""
 msgid "% of materials delivered against this Sales Order"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2197
+#: erpnext/controllers/accounts_controller.py:2200
 msgid "'Account' in the Accounting section of Customer {0}"
 msgstr ""
 
@@ -225,15 +225,11 @@ msgstr ""
 msgid "'Based On' and 'Group By' can not be same"
 msgstr "'على أساس' و 'المجموعة حسب' لا يمكن أن يكونا نفس الشيء"
 
-#: erpnext/stock/report/product_bundle_balance/product_bundle_balance.py:233
-msgid "'Date' is required"
-msgstr "&quot;التاريخ&quot; مطلوب"
-
 #: erpnext/selling/report/inactive_customers/inactive_customers.py:18
 msgid "'Days Since Last Order' must be greater than or equal to zero"
 msgstr "يجب أن تكون \"الأيام منذ آخر طلب\" أكبر من أو تساوي الصفر"
 
-#: erpnext/controllers/accounts_controller.py:2202
+#: erpnext/controllers/accounts_controller.py:2205
 msgid "'Default {0} Account' in Company {1}"
 msgstr ""
 
@@ -243,7 +239,7 @@ msgstr "المدخلات لا يمكن أن تكون فارغة"
 
 #: erpnext/stock/report/batch_item_expiry_status/batch_item_expiry_status.py:24
 #: erpnext/stock/report/batch_wise_balance_history/batch_wise_balance_history.py:120
-#: erpnext/stock/report/stock_analytics/stock_analytics.py:314
+#: erpnext/stock/report/stock_analytics/stock_analytics.py:313
 msgid "'From Date' is required"
 msgstr "من تاريخ (مطلوب)"
 
@@ -251,7 +247,7 @@ msgstr "من تاريخ (مطلوب)"
 msgid "'From Date' must be after 'To Date'"
 msgstr "\"من تاريخ \" يجب أن يكون بعد \" إلى تاريخ \""
 
-#: erpnext/stock/doctype/item/item.py:398
+#: erpnext/stock/doctype/item/item.py:401
 msgid "'Has Serial No' can not be 'Yes' for non-stock item"
 msgstr "\"لهُ رقم تسلسل\"  لا يمكن ان يكون \"نعم\" لبند غير قابل للتخزين"
 
@@ -1075,7 +1071,7 @@ msgstr ""
 
 #. Label of the qty (Float) field in DocType 'Purchase Receipt Item'
 #. Label of the qty (Float) field in DocType 'Subcontracting Receipt Item'
-#: erpnext/public/js/controllers/transaction.js:2362
+#: erpnext/public/js/controllers/transaction.js:2388
 #: erpnext/stock/doctype/purchase_receipt_item/purchase_receipt_item.json
 #: erpnext/subcontracting/doctype/subcontracting_receipt_item/subcontracting_receipt_item.json
 msgid "Accepted Quantity"
@@ -1273,7 +1269,7 @@ msgid "Account Manager"
 msgstr "إدارة حساب المستخدم"
 
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:949
-#: erpnext/controllers/accounts_controller.py:2206
+#: erpnext/controllers/accounts_controller.py:2209
 msgid "Account Missing"
 msgstr "الحساب مفقود"
 
@@ -1448,7 +1444,7 @@ msgstr "تتم إضافة الحساب {0} في الشركة التابعة {1}"
 msgid "Account {0} is frozen"
 msgstr "الحساب {0} مجمد\\n<br>\\nAccount {0} is frozen"
 
-#: erpnext/controllers/accounts_controller.py:1288
+#: erpnext/controllers/accounts_controller.py:1291
 msgid "Account {0} is invalid. Account Currency must be {1}"
 msgstr "الحساب {0} غير صحيح. يجب أن تكون عملة الحساب {1}"
 
@@ -1484,7 +1480,7 @@ msgstr "الحساب: {0} لا يمكن تحديثه إلا من خلال معا
 msgid "Account: {0} is not permitted under Payment Entry"
 msgstr "الحساب: {0} غير مسموح به بموجب إدخال الدفع"
 
-#: erpnext/controllers/accounts_controller.py:3037
+#: erpnext/controllers/accounts_controller.py:3040
 msgid "Account: {0} with currency: {1} can not be selected"
 msgstr "الحساب: {0} مع العملة: {1} لا يمكن اختياره"
 
@@ -1757,7 +1753,7 @@ msgstr "القيود المحاسبة"
 msgid "Accounting Entry for Asset"
 msgstr "المدخلات الحسابية للأصول"
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:796
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:805
 msgid "Accounting Entry for Service"
 msgstr "القيد المحاسبي للخدمة"
 
@@ -1772,18 +1768,18 @@ msgstr "القيد المحاسبي للخدمة"
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py:1468
 #: erpnext/controllers/stock_controller.py:550
 #: erpnext/controllers/stock_controller.py:567
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:889
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:898
 #: erpnext/stock/doctype/stock_entry/stock_entry.py:1586
 #: erpnext/stock/doctype/stock_entry/stock_entry.py:1600
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py:561
 msgid "Accounting Entry for Stock"
 msgstr "القيود المحاسبية للمخزون"
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:717
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:726
 msgid "Accounting Entry for {0}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2247
+#: erpnext/controllers/accounts_controller.py:2250
 msgid "Accounting Entry for {0}: {1} can only be made in currency: {2}"
 msgstr "المدخل المحاسبي ل {0}: {1} يمكن أن يكون فقط بالعملة {1}.\\n<br>\\nAccounting Entry for {0}: {1} can only be made in currency: {2}"
 
@@ -2176,7 +2172,7 @@ msgstr "الاستهلاك المتراكم كما في"
 msgid "Accumulated Monthly"
 msgstr "متراكمة شهريا"
 
-#: erpnext/controllers/budget_controller.py:417
+#: erpnext/controllers/budget_controller.py:422
 msgid "Accumulated Monthly Budget for Account {0} against {1} {2} is {3}. It will be collectively ({4}) exceeded by {5}"
 msgstr ""
 
@@ -3290,7 +3286,7 @@ msgstr ""
 msgid "Adjustment Against"
 msgstr ""
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:634
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:643
 msgid "Adjustment based on Purchase Invoice rate"
 msgstr ""
 
@@ -3401,7 +3397,7 @@ msgstr ""
 msgid "Advance amount"
 msgstr "المبلغ مقدما"
 
-#: erpnext/controllers/taxes_and_totals.py:845
+#: erpnext/controllers/taxes_and_totals.py:855
 msgid "Advance amount cannot be greater than {0} {1}"
 msgstr "قيمة الدفعة المقدمة لا يمكن أن تكون أكبر من {0} {1}"
 
@@ -3612,7 +3608,7 @@ msgstr "عمر"
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:152
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:133
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1125
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1127
 msgid "Age (Days)"
 msgstr "(العمر (أيام"
 
@@ -3698,16 +3694,6 @@ msgstr ""
 #: erpnext/setup/setup_wizard/data/industry_type.txt:4
 msgid "Agriculture"
 msgstr ""
-
-#. Name of a role
-#: erpnext/assets/doctype/location/location.json
-msgid "Agriculture Manager"
-msgstr "مدير الزراعة"
-
-#. Name of a role
-#: erpnext/assets/doctype/location/location.json
-msgid "Agriculture User"
-msgstr "مستخدم بالقطاع الزراعي"
 
 #: erpnext/setup/setup_wizard/data/industry_type.txt:5
 msgid "Airline"
@@ -3899,7 +3885,7 @@ msgstr "يجب نقل جميع الاتصالات بما في ذلك وما فو
 msgid "All items are already requested"
 msgstr ""
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:1317
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:1326
 msgid "All items have already been Invoiced/Returned"
 msgstr "تم بالفعل تحرير / إرجاع جميع العناصر"
 
@@ -3911,7 +3897,7 @@ msgstr ""
 msgid "All items have already been transferred for this Work Order."
 msgstr "جميع الإصناف تم نقلها لأمر العمل"
 
-#: erpnext/public/js/controllers/transaction.js:2465
+#: erpnext/public/js/controllers/transaction.js:2491
 msgid "All items in this document already have a linked Quality Inspection."
 msgstr ""
 
@@ -4109,7 +4095,7 @@ msgstr ""
 msgid "Allow Item To Be Added Multiple Times in a Transaction"
 msgstr "السماح بإضافة العنصر عدة مرات في المعاملة"
 
-#: erpnext/controllers/selling_controller.py:755
+#: erpnext/controllers/selling_controller.py:763
 msgid "Allow Item to Be Added Multiple Times in a Transaction"
 msgstr ""
 
@@ -5055,7 +5041,7 @@ msgstr "سنوي"
 msgid "Annual Billing: {0}"
 msgstr "الفواتير السنوية:  {0}"
 
-#: erpnext/controllers/budget_controller.py:441
+#: erpnext/controllers/budget_controller.py:446
 msgid "Annual Budget for Account {0} against {1} {2} is {3}. It will be collectively ({4}) exceeded by {5}"
 msgstr ""
 
@@ -5544,7 +5530,7 @@ msgstr "نظرًا لتمكين الحقل {0} ، يكون الحقل {1} إلز
 msgid "As the field {0} is enabled, the value of the field {1} should be more than 1."
 msgstr "أثناء تمكين الحقل {0} ، يجب أن تكون قيمة الحقل {1} أكثر من 1."
 
-#: erpnext/stock/doctype/item/item.py:989
+#: erpnext/stock/doctype/item/item.py:983
 msgid "As there are existing submitted transactions against item {0}, you can not change the value of {1}."
 msgstr ""
 
@@ -5690,7 +5676,7 @@ msgstr "حساب فئة الأصول"
 msgid "Asset Category Name"
 msgstr "اسم فئة الأصول"
 
-#: erpnext/stock/doctype/item/item.py:304
+#: erpnext/stock/doctype/item/item.py:307
 msgid "Asset Category is mandatory for Fixed Asset item"
 msgstr "فئة الموجودات إلزامية لبنود الموجودات الثابتة\\n<br>\\nAsset Category is mandatory for Fixed Asset item"
 
@@ -6065,7 +6051,7 @@ msgstr ""
 msgid "Asset {0} must be submitted"
 msgstr "الاصل {0} يجب تقديمه"
 
-#: erpnext/controllers/buying_controller.py:851
+#: erpnext/controllers/buying_controller.py:859
 msgid "Asset {assets_link} created for {item_code}"
 msgstr ""
 
@@ -6095,11 +6081,11 @@ msgstr ""
 msgid "Assets"
 msgstr "الأصول"
 
-#: erpnext/controllers/buying_controller.py:869
+#: erpnext/controllers/buying_controller.py:877
 msgid "Assets not created for {item_code}. You will have to create asset manually."
 msgstr "لم يتم إنشاء الأصول لـ {item_code}. سيكون عليك إنشاء الأصل يدويًا."
 
-#: erpnext/controllers/buying_controller.py:856
+#: erpnext/controllers/buying_controller.py:864
 msgid "Assets {assets_link} created for {item_code}"
 msgstr ""
 
@@ -6194,7 +6180,7 @@ msgstr "في الصف # {0}: لا يمكن أن يكون معرف التسلسل
 msgid "At row #{0}: you have selected the Difference Account {1}, which is a Cost of Goods Sold type account. Please select a different account"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:864
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:865
 msgid "At row {0}: Batch No is mandatory for Item {1}"
 msgstr ""
 
@@ -6202,11 +6188,11 @@ msgstr ""
 msgid "At row {0}: Parent Row No cannot be set for item {1}"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:849
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:850
 msgid "At row {0}: Qty is mandatory for the batch {1}"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:856
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:857
 msgid "At row {0}: Serial No is mandatory for Item {1}"
 msgstr ""
 
@@ -6280,7 +6266,7 @@ msgstr "السمة اسم"
 msgid "Attribute Value"
 msgstr "السمة القيمة"
 
-#: erpnext/stock/doctype/item/item.py:930
+#: erpnext/stock/doctype/item/item.py:924
 msgid "Attribute table is mandatory"
 msgstr "جدول الخصائص إلزامي"
 
@@ -6288,11 +6274,11 @@ msgstr "جدول الخصائص إلزامي"
 msgid "Attribute value: {0} must appear only once"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:934
+#: erpnext/stock/doctype/item/item.py:928
 msgid "Attribute {0} selected multiple times in Attributes Table"
 msgstr "تم تحديد السمة {0} عدة مرات في جدول السمات\\n<br>\\nAttribute {0} selected multiple times in Attributes Table"
 
-#: erpnext/stock/doctype/item/item.py:862
+#: erpnext/stock/doctype/item/item.py:856
 msgid "Attributes"
 msgstr "سمات"
 
@@ -7576,11 +7562,11 @@ msgstr "الرمز الشريطي"
 msgid "Barcode Type"
 msgstr "نوع الباركود"
 
-#: erpnext/stock/doctype/item/item.py:457
+#: erpnext/stock/doctype/item/item.py:460
 msgid "Barcode {0} already used in Item {1}"
 msgstr "الباركود {0} مستخدم بالفعل في الصنف {1}"
 
-#: erpnext/stock/doctype/item/item.py:472
+#: erpnext/stock/doctype/item/item.py:475
 msgid "Barcode {0} is not a valid {1} code"
 msgstr "الباركود {0} ليس رمز {1} صالحًا"
 
@@ -7834,7 +7820,7 @@ msgstr "حالة انتهاء صلاحية الدفعة الصنف"
 #: erpnext/manufacturing/doctype/job_card/job_card.json
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.js:89
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.py:115
-#: erpnext/public/js/controllers/transaction.js:2388
+#: erpnext/public/js/controllers/transaction.js:2414
 #: erpnext/public/js/utils/barcode_scanner.js:260
 #: erpnext/public/js/utils/serial_no_batch_selector.js:438
 #: erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
@@ -7861,11 +7847,11 @@ msgstr "حالة انتهاء صلاحية الدفعة الصنف"
 msgid "Batch No"
 msgstr "رقم دفعة"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:867
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:868
 msgid "Batch No is mandatory"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2629
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2630
 msgid "Batch No {0} does not exists"
 msgstr ""
 
@@ -7873,7 +7859,7 @@ msgstr ""
 msgid "Batch No {0} is linked with Item {1} which has serial no. Please scan serial no instead."
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:364
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:365
 msgid "Batch No {0} is not present in the original {1} {2}, hence you can't return it against the {1} {2}"
 msgstr ""
 
@@ -7888,11 +7874,11 @@ msgstr ""
 msgid "Batch Nos"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1421
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1422
 msgid "Batch Nos are created successfully"
 msgstr ""
 
-#: erpnext/controllers/sales_and_purchase_return.py:1096
+#: erpnext/controllers/sales_and_purchase_return.py:1001
 msgid "Batch Not Available for Return"
 msgstr ""
 
@@ -7941,7 +7927,7 @@ msgstr ""
 msgid "Batch {0} and Warehouse"
 msgstr ""
 
-#: erpnext/controllers/sales_and_purchase_return.py:1095
+#: erpnext/controllers/sales_and_purchase_return.py:1000
 msgid "Batch {0} is not available in warehouse {1}"
 msgstr ""
 
@@ -7991,7 +7977,7 @@ msgstr ""
 #. Label of the bill_date (Date) field in DocType 'Journal Entry'
 #. Label of the bill_date (Date) field in DocType 'Subcontracting Receipt'
 #: erpnext/accounts/doctype/journal_entry/journal_entry.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1110
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1112
 #: erpnext/accounts/report/purchase_register/purchase_register.py:214
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.json
 msgid "Bill Date"
@@ -8000,7 +7986,7 @@ msgstr "تاريخ الفاتورة"
 #. Label of the bill_no (Data) field in DocType 'Journal Entry'
 #. Label of the bill_no (Data) field in DocType 'Subcontracting Receipt'
 #: erpnext/accounts/doctype/journal_entry/journal_entry.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1109
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1111
 #: erpnext/accounts/report/purchase_register/purchase_register.py:213
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.json
 msgid "Bill No"
@@ -8220,7 +8206,7 @@ msgstr "حالة الفواتير"
 msgid "Billing Zipcode"
 msgstr "الرمز البريدي للفواتير"
 
-#: erpnext/accounts/party.py:602
+#: erpnext/accounts/party.py:608
 msgid "Billing currency must be equal to either default company's currency or party account currency"
 msgstr "يجب أن تكون عملة الفوترة مساوية لعملة الشركة الافتراضية أو عملة حساب الطرف"
 
@@ -9217,7 +9203,7 @@ msgid "Can only make payment against unbilled {0}"
 msgstr "يمكن إجراء دفعة فقط مقابل فاتورة غير مدفوعة {0}"
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1458
-#: erpnext/controllers/accounts_controller.py:2946
+#: erpnext/controllers/accounts_controller.py:2949
 #: erpnext/public/js/controllers/accounts.js:90
 msgid "Can refer row only if the charge type is 'On Previous Row Amount' or 'Previous Row Total'"
 msgstr ""
@@ -9379,9 +9365,9 @@ msgstr "لا يمكن حساب وقت الوصول حيث أن عنوان برن
 msgid "Cannot Create Return"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:625
-#: erpnext/stock/doctype/item/item.py:638
-#: erpnext/stock/doctype/item/item.py:652
+#: erpnext/stock/doctype/item/item.py:631
+#: erpnext/stock/doctype/item/item.py:644
+#: erpnext/stock/doctype/item/item.py:658
 msgid "Cannot Merge"
 msgstr ""
 
@@ -9405,7 +9391,7 @@ msgstr ""
 msgid "Cannot apply TDS against multiple parties in one entry"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:307
+#: erpnext/stock/doctype/item/item.py:310
 msgid "Cannot be a fixed asset item as Stock Ledger is created."
 msgstr "لا يمكن أن يكون عنصر الأصول الثابتة كما يتم إنشاء دفتر الأستاذ."
 
@@ -9421,7 +9407,7 @@ msgstr "لا يمكن الإلغاء لان هناك تدوينات مخزون �
 msgid "Cannot cancel the transaction. Reposting of item valuation on submission is not completed yet."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:959
+#: erpnext/controllers/buying_controller.py:967
 msgid "Cannot cancel this document as it is linked with the submitted asset {asset_link}. Please cancel the asset to continue."
 msgstr ""
 
@@ -9429,7 +9415,7 @@ msgstr ""
 msgid "Cannot cancel transaction for Completed Work Order."
 msgstr "لا يمكن إلغاء المعاملة لأمر العمل المكتمل."
 
-#: erpnext/stock/doctype/item/item.py:882
+#: erpnext/stock/doctype/item/item.py:876
 msgid "Cannot change Attributes after stock transaction. Make a new Item and transfer stock to the new Item"
 msgstr "لا يمكن تغيير سمات بعد معاملة الأسهم. جعل عنصر جديد ونقل الأسهم إلى البند الجديد"
 
@@ -9445,7 +9431,7 @@ msgstr ""
 msgid "Cannot change Service Stop Date for item in row {0}"
 msgstr "لا يمكن تغيير تاريخ إيقاف الخدمة للعنصر الموجود في الصف {0}"
 
-#: erpnext/stock/doctype/item/item.py:873
+#: erpnext/stock/doctype/item/item.py:867
 msgid "Cannot change Variant properties after stock transaction. You will have to make a new Item to do this."
 msgstr "لا يمكن تغيير خصائص المتغير بعد معاملة المخزون. سيكون عليك عمل عنصر جديد للقيام بذلك."
 
@@ -9473,7 +9459,7 @@ msgstr ""
 msgid "Cannot covert to Group because Account Type is selected."
 msgstr "لا يمكن تحويل الحساب إلى تصنيف مجموعة لأن نوع الحساب تم اختياره."
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:972
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:981
 msgid "Cannot create Stock Reservation Entries for future dated Purchase Receipts."
 msgstr ""
 
@@ -9524,7 +9510,7 @@ msgstr "لا يمكن ضمان التسليم بواسطة Serial No حيث أن
 msgid "Cannot find Item with this Barcode"
 msgstr "لا يمكن العثور على عنصر بهذا الرمز الشريطي"
 
-#: erpnext/controllers/accounts_controller.py:3483
+#: erpnext/controllers/accounts_controller.py:3486
 msgid "Cannot find a default warehouse for item {0}. Please set one in the Item Master or in Stock Settings."
 msgstr ""
 
@@ -9532,7 +9518,7 @@ msgstr ""
 msgid "Cannot make any transactions until the deletion job is completed"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2074
+#: erpnext/controllers/accounts_controller.py:2077
 msgid "Cannot overbill for Item {0} in row {1} more than {2}. To allow over-billing, please set allowance in Accounts Settings"
 msgstr "لا يمكن زيادة حجم العنصر {0} في الصف {1} أكثر من {2}. للسماح بالإفراط في الفوترة ، يرجى تعيين بدل في إعدادات الحسابات"
 
@@ -9553,7 +9539,7 @@ msgid "Cannot receive from customer against negative outstanding"
 msgstr ""
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1475
-#: erpnext/controllers/accounts_controller.py:2961
+#: erpnext/controllers/accounts_controller.py:2964
 #: erpnext/public/js/controllers/accounts.js:100
 msgid "Cannot refer row number greater than or equal to current row number for this Charge type"
 msgstr "لا يمكن أن يشير رقم الصف أكبر من أو يساوي رقم الصف الحالي لهذا النوع المسؤول"
@@ -9569,7 +9555,7 @@ msgstr ""
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1467
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1646
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:1917
-#: erpnext/controllers/accounts_controller.py:2951
+#: erpnext/controllers/accounts_controller.py:2954
 #: erpnext/public/js/controllers/accounts.js:94
 #: erpnext/public/js/controllers/taxes_and_totals.js:470
 msgid "Cannot select charge type as 'On Previous Row Amount' or 'On Previous Row Total' for first row"
@@ -9583,15 +9569,15 @@ msgstr "لا يمكن أن تعين كخسارة لأنه تم تقديم أمر
 msgid "Cannot set authorization on basis of Discount for {0}"
 msgstr "لا يمكن تحديد التخويل على أساس الخصم ل {0}"
 
-#: erpnext/stock/doctype/item/item.py:716
+#: erpnext/stock/doctype/item/item.py:722
 msgid "Cannot set multiple Item Defaults for a company."
 msgstr "لا يمكن تعيين عدة عناصر افتراضية لأي شركة."
 
-#: erpnext/controllers/accounts_controller.py:3631
+#: erpnext/controllers/accounts_controller.py:3634
 msgid "Cannot set quantity less than delivered quantity"
 msgstr "لا يمكن ضبط كمية أقل من الكمية المسلمة"
 
-#: erpnext/controllers/accounts_controller.py:3634
+#: erpnext/controllers/accounts_controller.py:3637
 msgid "Cannot set quantity less than received quantity"
 msgstr "لا يمكن تعيين كمية أقل من الكمية المستلمة"
 
@@ -10014,7 +10000,7 @@ msgid "Channel Partner"
 msgstr "شريك القناة"
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:2346
-#: erpnext/controllers/accounts_controller.py:3014
+#: erpnext/controllers/accounts_controller.py:3017
 msgid "Charge of type 'Actual' in row {0} cannot be included in Item Rate or Paid Amount"
 msgstr ""
 
@@ -10197,7 +10183,7 @@ msgstr "عرض الشيك"
 
 #. Label of the reference_date (Date) field in DocType 'Payment Entry'
 #: erpnext/accounts/doctype/payment_entry/payment_entry.json
-#: erpnext/public/js/controllers/transaction.js:2299
+#: erpnext/public/js/controllers/transaction.js:2325
 msgid "Cheque/Reference Date"
 msgstr "تاريخ الصك / السند المرجع"
 
@@ -10245,7 +10231,7 @@ msgstr "اسم الطفل"
 
 #. Label of the child_row_reference (Data) field in DocType 'Quality
 #. Inspection'
-#: erpnext/public/js/controllers/transaction.js:2394
+#: erpnext/public/js/controllers/transaction.js:2420
 #: erpnext/stock/doctype/quality_inspection/quality_inspection.json
 msgid "Child Row Reference"
 msgstr ""
@@ -10957,7 +10943,7 @@ msgstr "شركات"
 #: erpnext/accounts/report/cheques_and_deposits_incorrectly_cleared/cheques_and_deposits_incorrectly_cleared.js:8
 #: erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.js:8
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:8
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:49
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:50
 #: erpnext/accounts/report/deferred_revenue_and_expense/deferred_revenue_and_expense.js:8
 #: erpnext/accounts/report/delivered_items_to_be_billed/delivered_items_to_be_billed.js:7
 #: erpnext/accounts/report/dimension_wise_accounts_balance_report/dimension_wise_accounts_balance_report.js:8
@@ -12190,7 +12176,7 @@ msgid "Content Type"
 msgstr "نوع المحتوى"
 
 #: erpnext/erpnext_integrations/doctype/plaid_settings/plaid_settings.js:162
-#: erpnext/public/js/controllers/transaction.js:2312
+#: erpnext/public/js/controllers/transaction.js:2338
 #: erpnext/selling/doctype/quotation/quotation.js:356
 msgid "Continue"
 msgstr "استمر"
@@ -12355,7 +12341,7 @@ msgstr "معامل التحويل"
 msgid "Conversion Rate"
 msgstr "معدل التحويل"
 
-#: erpnext/stock/doctype/item/item.py:393
+#: erpnext/stock/doctype/item/item.py:396
 msgid "Conversion factor for default Unit of Measure must be 1 in row {0}"
 msgstr "معامل التحويل الافتراضي لوحدة القياس يجب أن يكون 1 في الصف {0}"
 
@@ -12363,15 +12349,15 @@ msgstr "معامل التحويل الافتراضي لوحدة القياس ي�
 msgid "Conversion factor for item {0} has been reset to 1.0 as the uom {1} is same as stock uom {2}."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2767
+#: erpnext/controllers/accounts_controller.py:2770
 msgid "Conversion rate cannot be 0"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2774
+#: erpnext/controllers/accounts_controller.py:2777
 msgid "Conversion rate is 1.00, but document currency is different from company currency"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2770
+#: erpnext/controllers/accounts_controller.py:2773
 msgid "Conversion rate must be 1.00 if document currency is same as company currency"
 msgstr ""
 
@@ -12584,7 +12570,7 @@ msgstr "كلفة"
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:28
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:40
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:30
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1096
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1098
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:40
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.js:42
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.py:197
@@ -12677,7 +12663,7 @@ msgid "Cost Center is a part of Cost Center Allocation, hence cannot be converte
 msgstr ""
 
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py:1411
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:855
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:864
 msgid "Cost Center is required in row {0} in Taxes table for type {1}"
 msgstr "مركز التكلفة مطلوب في الصف {0} في جدول الضرائب للنوع {1}\\n<br>\\nCost Center is required in row {0} in Taxes table for type {1}"
 
@@ -12946,8 +12932,8 @@ msgstr ""
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:132
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:143
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:219
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:654
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:678
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:656
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:680
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.js:88
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.js:89
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.js:103
@@ -13004,8 +12990,8 @@ msgstr ""
 #: erpnext/projects/doctype/task/task_tree.js:81
 #: erpnext/public/js/communication.js:19 erpnext/public/js/communication.js:31
 #: erpnext/public/js/communication.js:41
-#: erpnext/public/js/controllers/transaction.js:336
-#: erpnext/public/js/controllers/transaction.js:2435
+#: erpnext/public/js/controllers/transaction.js:362
+#: erpnext/public/js/controllers/transaction.js:2461
 #: erpnext/selling/doctype/customer/customer.js:181
 #: erpnext/selling/doctype/quotation/quotation.js:124
 #: erpnext/selling/doctype/quotation/quotation.js:133
@@ -13300,7 +13286,7 @@ msgstr ""
 msgid "Create a variant with the template image."
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1877
+#: erpnext/stock/stock_ledger.py:1886
 msgid "Create an incoming stock transaction for the Item."
 msgstr "قم بإنشاء حركة مخزون واردة للصنف."
 
@@ -13360,7 +13346,7 @@ msgstr ""
 msgid "Creating Purchase Order ..."
 msgstr "إنشاء أمر شراء ..."
 
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:735
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:737
 #: erpnext/buying/doctype/purchase_order/purchase_order.js:552
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.js:73
 msgid "Creating Purchase Receipt ..."
@@ -13554,7 +13540,7 @@ msgstr "أشهر الائتمان"
 #: erpnext/accounts/doctype/journal_entry_template/journal_entry_template.json
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:174
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:147
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1119
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1121
 #: erpnext/controllers/sales_and_purchase_return.py:373
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:286
 #: erpnext/stock/doctype/delivery_note/delivery_note.js:89
@@ -13589,7 +13575,7 @@ msgstr "تم إنشاء ملاحظة الائتمان {0} تلقائيًا"
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py:368
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py:376
-#: erpnext/controllers/accounts_controller.py:2186
+#: erpnext/controllers/accounts_controller.py:2189
 msgid "Credit To"
 msgstr "دائن الى"
 
@@ -13774,7 +13760,7 @@ msgstr ""
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/subscription_plan/subscription_plan.json
 #: erpnext/accounts/report/account_balance/account_balance.py:28
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1129
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1131
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:205
 #: erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.py:101
 #: erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.js:118
@@ -14303,7 +14289,7 @@ msgstr "رمز العميل"
 #. Label of the customer_contact_display (Small Text) field in DocType
 #. 'Purchase Order'
 #. Label of the customer_contact (Small Text) field in DocType 'Delivery Stop'
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1090
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1092
 #: erpnext/buying/doctype/purchase_order/purchase_order.json
 #: erpnext/stock/doctype/delivery_stop/delivery_stop.json
 msgid "Customer Contact"
@@ -14399,7 +14385,7 @@ msgstr "ملاحظات العميل"
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/tax_rule/tax_rule.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:107
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1147
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1149
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:81
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:185
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:56
@@ -14443,7 +14429,7 @@ msgstr ""
 msgid "Customer Group Name"
 msgstr "أسم فئة العميل"
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1239
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1241
 msgid "Customer Group: {0} does not exist"
 msgstr ""
 
@@ -14462,7 +14448,7 @@ msgstr ""
 msgid "Customer Items"
 msgstr "منتجات العميل"
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1138
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1140
 msgid "Customer LPO"
 msgstr "العميل لبو"
 
@@ -14508,7 +14494,7 @@ msgstr "رقم محمول العميل"
 #: erpnext/accounts/doctype/pos_invoice/pos_invoice.json
 #: erpnext/accounts/doctype/process_statement_of_accounts_customer/process_statement_of_accounts_customer.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1080
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1082
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:156
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:92
 #: erpnext/accounts/report/delivered_items_to_be_billed/delivered_items_to_be_billed.py:35
@@ -15186,7 +15172,7 @@ msgstr ""
 #: erpnext/accounts/doctype/journal_entry_template/journal_entry_template.json
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:176
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:147
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1122
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1124
 #: erpnext/controllers/sales_and_purchase_return.py:377
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:287
 #: erpnext/stock/doctype/purchase_receipt/purchase_receipt.js:61
@@ -15215,7 +15201,7 @@ msgstr ""
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:953
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:964
-#: erpnext/controllers/accounts_controller.py:2186
+#: erpnext/controllers/accounts_controller.py:2189
 msgid "Debit To"
 msgstr "الخصم ل"
 
@@ -15248,11 +15234,11 @@ msgstr ""
 msgid "Debit-Credit mismatch"
 msgstr ""
 
-#: erpnext/accounts/party.py:609
+#: erpnext/accounts/party.py:615
 msgid "Debtor/Creditor"
 msgstr ""
 
-#: erpnext/accounts/party.py:612
+#: erpnext/accounts/party.py:618
 msgid "Debtor/Creditor Advance"
 msgstr ""
 
@@ -15372,7 +15358,7 @@ msgstr ""
 msgid "Default BOM"
 msgstr "الافتراضي BOM"
 
-#: erpnext/stock/doctype/item/item.py:418
+#: erpnext/stock/doctype/item/item.py:421
 msgid "Default BOM ({0}) must be active for this item or its template"
 msgstr "يجب أن تكون قائمة المواد الافتراضية ({0}) نشطة لهذا الصنف أو قوالبه"
 
@@ -15380,7 +15366,7 @@ msgstr "يجب أن تكون قائمة المواد الافتراضية ({0}) 
 msgid "Default BOM for {0} not found"
 msgstr "فاتورة المواد ل {0} غير موجودة\\n<br>\\nDefault BOM for {0} not found"
 
-#: erpnext/controllers/accounts_controller.py:3672
+#: erpnext/controllers/accounts_controller.py:3675
 msgid "Default BOM not found for FG Item {0}"
 msgstr ""
 
@@ -15715,15 +15701,15 @@ msgstr "الإقليم الافتراضي"
 msgid "Default Unit of Measure"
 msgstr "وحدة القياس الافتراضية"
 
-#: erpnext/stock/doctype/item/item.py:1272
+#: erpnext/stock/doctype/item/item.py:1266
 msgid "Default Unit of Measure for Item {0} cannot be changed directly because you have already made some transaction(s) with another UOM. You need to either cancel the linked documents or create a new Item."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1255
+#: erpnext/stock/doctype/item/item.py:1249
 msgid "Default Unit of Measure for Item {0} cannot be changed directly because you have already made some transaction(s) with another UOM. You will need to create a new Item to use a different Default UOM."
 msgstr "لا يمكن تغيير وحدة القياس الافتراضية للبند {0} مباشرة لأنك قمت بالفعل ببعض المعاملات (المعاملة) مع UOM أخرى. ستحتاج إلى إنشاء عنصر جديد لاستخدام واجهة مستخدم افتراضية مختلفة.\\n<br>\\nDefault Unit of Measure for Item {0} cannot be changed directly because you have already made some transaction(s) with another UOM. You will need to create a new Item to use a different Default UOM."
 
-#: erpnext/stock/doctype/item/item.py:908
+#: erpnext/stock/doctype/item/item.py:902
 msgid "Default Unit of Measure for Variant '{0}' must be same as in Template '{1}'"
 msgstr "وحدة القياس الافتراضية للمتغير '{0}' يجب أن تكون كما في النمودج '{1}'"
 
@@ -16182,7 +16168,7 @@ msgstr "توجهات إشعارات التسليم"
 msgid "Delivery Note {0} is not submitted"
 msgstr "لم يتم اعتماد ملاحظه التسليم {0}\\n<br>\\nDelivery Note {0} is not submitted"
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1142
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1144
 #: erpnext/stock/doctype/delivery_trip/delivery_trip.js:73
 msgid "Delivery Notes"
 msgstr "مذكرات التسليم"
@@ -16713,7 +16699,7 @@ msgstr ""
 #: erpnext/projects/doctype/task_type/task_type.json
 #: erpnext/projects/doctype/timesheet_detail/timesheet_detail.json
 #: erpnext/public/js/bank_reconciliation_tool/data_table_manager.js:55
-#: erpnext/public/js/controllers/transaction.js:2376
+#: erpnext/public/js/controllers/transaction.js:2402
 #: erpnext/selling/doctype/installation_note_item/installation_note_item.json
 #: erpnext/selling/doctype/product_bundle/product_bundle.json
 #: erpnext/selling/doctype/product_bundle_item/product_bundle_item.json
@@ -16901,7 +16887,7 @@ msgstr ""
 msgid "Difference Account must be a Asset/Liability type account (Temporary Opening), since this Stock Entry is an Opening Entry"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:954
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:950
 msgid "Difference Account must be a Asset/Liability type account, since this Stock Reconciliation is an Opening Entry"
 msgstr "حساب الفرق يجب أن يكون حساب الأصول / حساب نوع الالتزام، حيث يعتبر تسوية المخزون بمثابة مدخل افتتاح\\n<br>\\nDifference Account must be a Asset/Liability type account, since this Stock Reconciliation is an Opening Entry"
 
@@ -17167,11 +17153,11 @@ msgstr ""
 msgid "Disabled Warehouse {0} cannot be used for this transaction."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:745
+#: erpnext/controllers/accounts_controller.py:748
 msgid "Disabled pricing rules since this {} is an internal transfer"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:759
+#: erpnext/controllers/accounts_controller.py:762
 msgid "Disabled tax included prices since this {} is an internal transfer"
 msgstr ""
 
@@ -18113,7 +18099,7 @@ msgstr "إسقاط الشحن"
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.json
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/print_format/sales_invoice_print/sales_invoice_print.html:72
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1106
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1108
 #: erpnext/assets/doctype/asset_maintenance_log/asset_maintenance_log.json
 #: erpnext/selling/report/payment_terms_status_for_sales_order/payment_terms_status_for_sales_order.py:40
 msgid "Due Date"
@@ -18127,11 +18113,11 @@ msgstr "بسبب تاريخ"
 msgid "Due Date Based On"
 msgstr "تاريخ الاستحقاق بناء على"
 
-#: erpnext/accounts/party.py:695
+#: erpnext/accounts/party.py:701
 msgid "Due Date cannot be after {0}"
 msgstr ""
 
-#: erpnext/accounts/party.py:671
+#: erpnext/accounts/party.py:677
 msgid "Due Date cannot be before {0}"
 msgstr ""
 
@@ -18849,7 +18835,7 @@ msgstr "تمكين جدولة موعد"
 msgid "Enable Auto Email"
 msgstr "تفعيل البريد الإلكتروني التلقائي"
 
-#: erpnext/stock/doctype/item/item.py:1064
+#: erpnext/stock/doctype/item/item.py:1058
 msgid "Enable Auto Re-Order"
 msgstr "تمكين إعادة الطلب التلقائي"
 
@@ -19062,7 +19048,7 @@ msgstr "تاريخ التحصيل"
 msgid "End Date"
 msgstr "نهاية التاريخ"
 
-#: erpnext/crm/doctype/contract/contract.py:75
+#: erpnext/crm/doctype/contract/contract.py:83
 msgid "End Date cannot be before Start Date."
 msgstr "لا يمكن أن يكون تاريخ الانتهاء قبل تاريخ البدء."
 
@@ -19312,7 +19298,7 @@ msgstr ""
 #: erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.json
 #: erpnext/manufacturing/doctype/job_card/job_card.py:875
 #: erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.json
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:297
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:298
 msgid "Error"
 msgstr "خطأ"
 
@@ -19435,7 +19421,7 @@ msgstr ""
 msgid "Example URL"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:995
+#: erpnext/stock/doctype/item/item.py:989
 msgid "Example of a linked document: {0}"
 msgstr ""
 
@@ -19450,7 +19436,7 @@ msgstr ""
 msgid "Example: ABCD.#####. If series is set and Batch No is not mentioned in transactions, then automatic batch number will be created based on this series. If you always want to explicitly mention Batch No for this item, leave this blank. Note: this setting will take priority over the Naming Series Prefix in Stock Settings."
 msgstr "مثال: ABCD. #####. إذا تم ضبط المسلسل ولم يتم ذكر رقم الدفعة في المعاملات ، فسيتم إنشاء رقم الدفعة تلقائيًا استنادًا إلى هذه السلسلة. إذا كنت تريد دائمًا الإشارة صراحة إلى Batch No لهذا العنصر ، فاترك هذا فارغًا. ملاحظة: سيأخذ هذا الإعداد الأولوية على بادئة Naming Series في إعدادات المخزون."
 
-#: erpnext/stock/stock_ledger.py:2141
+#: erpnext/stock/stock_ledger.py:2149
 msgid "Example: Serial No {0} reserved in {1}."
 msgstr ""
 
@@ -19504,8 +19490,8 @@ msgstr ""
 msgid "Exchange Gain/Loss"
 msgstr "أرباح / خسائر الناتجة عن صرف العملة"
 
-#: erpnext/controllers/accounts_controller.py:1593
-#: erpnext/controllers/accounts_controller.py:1677
+#: erpnext/controllers/accounts_controller.py:1596
+#: erpnext/controllers/accounts_controller.py:1680
 msgid "Exchange Gain/Loss amount has been booked through {0}"
 msgstr ""
 
@@ -20241,7 +20227,7 @@ msgid "Fetching Error"
 msgstr ""
 
 #: erpnext/accounts/doctype/dunning/dunning.js:135
-#: erpnext/public/js/controllers/transaction.js:1251
+#: erpnext/public/js/controllers/transaction.js:1277
 msgid "Fetching exchange rates ..."
 msgstr ""
 
@@ -20536,15 +20522,15 @@ msgstr ""
 msgid "Finished Good Item Quantity"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3658
+#: erpnext/controllers/accounts_controller.py:3661
 msgid "Finished Good Item is not specified for service item {0}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3675
+#: erpnext/controllers/accounts_controller.py:3678
 msgid "Finished Good Item {0} Qty can not be zero"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3669
+#: erpnext/controllers/accounts_controller.py:3672
 msgid "Finished Good Item {0} must be a sub-contracted item"
 msgstr ""
 
@@ -20785,7 +20771,7 @@ msgstr "حساب الأصول الثابتة"
 msgid "Fixed Asset Defaults"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:301
+#: erpnext/stock/doctype/item/item.py:304
 msgid "Fixed Asset Item must be a non-stock item."
 msgstr "يجب أن يكون بند الأصول الثابتة عنصرا غير مخزون.<br>\\nFixed Asset Item must be a non-stock item."
 
@@ -20961,7 +20947,7 @@ msgstr "للكمية (الكمية المصنعة) إلزامية\\n<br>\\nFor Q
 msgid "For Raw Materials"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1259
+#: erpnext/controllers/accounts_controller.py:1262
 msgid "For Return Invoices with Stock effect, '0' qty Items are not allowed. Following rows are affected: {0}"
 msgstr ""
 
@@ -21062,7 +21048,7 @@ msgstr ""
 msgid "For the item {0}, the quantity should be {1} according to the BOM {2}."
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:1088
+#: erpnext/public/js/controllers/transaction.js:1114
 msgctxt "Clear payment terms template and/or payment schedule when due date is changed"
 msgid "For the new {0} to take effect, would you like to clear the current {1}?"
 msgstr ""
@@ -21071,7 +21057,7 @@ msgstr ""
 msgid "For the {0}, no stock is available for the return in the warehouse {1}."
 msgstr ""
 
-#: erpnext/controllers/sales_and_purchase_return.py:1144
+#: erpnext/controllers/sales_and_purchase_return.py:1049
 msgid "For the {0}, the quantity is required to make the return entry"
 msgstr ""
 
@@ -21408,7 +21394,7 @@ msgstr "(من تاريخ) لا يمكن أن يكون أكبر (الي التا�
 msgid "From Date is mandatory"
 msgstr ""
 
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:52
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:53
 #: erpnext/accounts/report/general_ledger/general_ledger.py:86
 #: erpnext/accounts/report/pos_register/pos_register.py:115
 #: erpnext/accounts/report/tax_withholding_details/tax_withholding_details.py:39
@@ -21785,14 +21771,14 @@ msgstr "العقد الإضافية التي يمكن أن تنشأ إلا في 
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:186
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:155
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1134
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1136
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:177
 msgid "Future Payment Amount"
 msgstr "مبلغ الدفع المستقبلي"
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:185
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:154
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1133
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1135
 msgid "Future Payment Ref"
 msgstr "الدفع في المستقبل المرجع"
 
@@ -22966,7 +22952,7 @@ msgstr ""
 msgid "Here are the error logs for the aforementioned failed depreciation entries: {0}"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1862
+#: erpnext/stock/stock_ledger.py:1871
 msgid "Here are the options to proceed:"
 msgstr ""
 
@@ -23488,7 +23474,7 @@ msgstr ""
 msgid "If more than one package of the same type (for print)"
 msgstr "إذا كان أكثر من حزمة واحدة من نفس النوع (للطباعة)"
 
-#: erpnext/stock/stock_ledger.py:1872
+#: erpnext/stock/stock_ledger.py:1881
 msgid "If not, you can Cancel / Submit this entry"
 msgstr ""
 
@@ -23513,7 +23499,7 @@ msgstr ""
 msgid "If the account is frozen, entries are allowed to restricted users."
 msgstr "إذا الحساب مجمد، يسمح بالدخول إلى المستخدمين المحددين."
 
-#: erpnext/stock/stock_ledger.py:1865
+#: erpnext/stock/stock_ledger.py:1874
 msgid "If the item is transacting as a Zero Valuation Rate item in this entry, please enable 'Allow Zero Valuation Rate' in the {0} Item table."
 msgstr "إذا كان العنصر يتعامل كعنصر سعر تقييم صفري في هذا الإدخال ، فالرجاء تمكين &quot;السماح بمعدل تقييم صفري&quot; في جدول العناصر {0}."
 
@@ -24511,7 +24497,7 @@ msgstr ""
 msgid "Incorrect Batch Consumed"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:514
+#: erpnext/stock/doctype/item/item.py:517
 msgid "Incorrect Check in (group) Warehouse for Reorder"
 msgstr ""
 
@@ -24560,7 +24546,7 @@ msgstr ""
 msgid "Incorrect Stock Value Report"
 msgstr ""
 
-#: erpnext/stock/serial_batch_bundle.py:134
+#: erpnext/stock/serial_batch_bundle.py:135
 msgid "Incorrect Type of Transaction"
 msgstr ""
 
@@ -24829,8 +24815,8 @@ msgstr "تعليمات"
 msgid "Insufficient Capacity"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3590
-#: erpnext/controllers/accounts_controller.py:3614
+#: erpnext/controllers/accounts_controller.py:3593
+#: erpnext/controllers/accounts_controller.py:3617
 msgid "Insufficient Permissions"
 msgstr "أذونات غير كافية"
 
@@ -24838,12 +24824,12 @@ msgstr "أذونات غير كافية"
 #: erpnext/stock/doctype/pick_list/pick_list.py:127
 #: erpnext/stock/doctype/pick_list/pick_list.py:975
 #: erpnext/stock/doctype/stock_entry/stock_entry.py:759
-#: erpnext/stock/serial_batch_bundle.py:989 erpnext/stock/stock_ledger.py:1559
-#: erpnext/stock/stock_ledger.py:2032
+#: erpnext/stock/serial_batch_bundle.py:1021 erpnext/stock/stock_ledger.py:1568
+#: erpnext/stock/stock_ledger.py:2040
 msgid "Insufficient Stock"
 msgstr "المالية غير كافية"
 
-#: erpnext/stock/stock_ledger.py:2047
+#: erpnext/stock/stock_ledger.py:2055
 msgid "Insufficient Stock for Batch"
 msgstr ""
 
@@ -24981,11 +24967,11 @@ msgstr ""
 msgid "Internal Customer for company {0} already exists"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:728
+#: erpnext/controllers/accounts_controller.py:731
 msgid "Internal Sale or Delivery Reference missing."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:730
+#: erpnext/controllers/accounts_controller.py:733
 msgid "Internal Sales Reference Missing"
 msgstr ""
 
@@ -25016,7 +25002,7 @@ msgstr ""
 msgid "Internal Transfer"
 msgstr "نقل داخلي"
 
-#: erpnext/controllers/accounts_controller.py:739
+#: erpnext/controllers/accounts_controller.py:742
 msgid "Internal Transfer Reference Missing"
 msgstr ""
 
@@ -25059,8 +25045,8 @@ msgstr "غير صالحة"
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:969
 #: erpnext/assets/doctype/asset_category/asset_category.py:69
 #: erpnext/assets/doctype/asset_category/asset_category.py:97
-#: erpnext/controllers/accounts_controller.py:2975
-#: erpnext/controllers/accounts_controller.py:2983
+#: erpnext/controllers/accounts_controller.py:2978
+#: erpnext/controllers/accounts_controller.py:2986
 msgid "Invalid Account"
 msgstr "حساب غير صالح"
 
@@ -25085,7 +25071,7 @@ msgstr ""
 msgid "Invalid Barcode. There is no Item attached to this barcode."
 msgstr "الباركود غير صالح. لا يوجد عنصر مرفق بهذا الرمز الشريطي."
 
-#: erpnext/public/js/controllers/transaction.js:2631
+#: erpnext/public/js/controllers/transaction.js:2657
 msgid "Invalid Blanket Order for the selected Customer and Item"
 msgstr "طلب فارغ غير صالح للعميل والعنصر المحدد"
 
@@ -25099,7 +25085,7 @@ msgstr "شركة غير صالحة للمعاملات بين الشركات."
 
 #: erpnext/assets/doctype/asset/asset.py:295
 #: erpnext/assets/doctype/asset/asset.py:302
-#: erpnext/controllers/accounts_controller.py:2998
+#: erpnext/controllers/accounts_controller.py:3001
 msgid "Invalid Cost Center"
 msgstr ""
 
@@ -25141,7 +25127,7 @@ msgstr ""
 msgid "Invalid Item"
 msgstr "عنصر غير صالح"
 
-#: erpnext/stock/doctype/item/item.py:1410
+#: erpnext/stock/doctype/item/item.py:1404
 msgid "Invalid Item Defaults"
 msgstr ""
 
@@ -25187,11 +25173,11 @@ msgstr ""
 msgid "Invalid Purchase Invoice"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3627
+#: erpnext/controllers/accounts_controller.py:3630
 msgid "Invalid Qty"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1277
+#: erpnext/controllers/accounts_controller.py:1280
 msgid "Invalid Quantity"
 msgstr "كمية غير صحيحة"
 
@@ -25208,7 +25194,7 @@ msgstr ""
 msgid "Invalid Schedule"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:243
+#: erpnext/controllers/selling_controller.py:251
 msgid "Invalid Selling Price"
 msgstr "سعر البيع غير صالح"
 
@@ -25241,7 +25227,7 @@ msgstr "تعبير شرط غير صالح"
 msgid "Invalid lost reason {0}, please create a new lost reason"
 msgstr "سبب ضائع غير صالح {0} ، يرجى إنشاء سبب ضائع جديد"
 
-#: erpnext/stock/doctype/item/item.py:408
+#: erpnext/stock/doctype/item/item.py:411
 msgid "Invalid naming series (. missing) for {0}"
 msgstr "سلسلة تسمية غير صالحة (. مفقود) لـ {0}"
 
@@ -25281,7 +25267,7 @@ msgstr "جرد"
 #. Name of a DocType
 #: erpnext/patches/v15_0/refactor_closing_stock_balance.py:43
 #: erpnext/stock/doctype/inventory_dimension/inventory_dimension.json
-#: erpnext/stock/doctype/inventory_dimension/inventory_dimension.py:180
+#: erpnext/stock/doctype/inventory_dimension/inventory_dimension.py:181
 msgid "Inventory Dimension"
 msgstr ""
 
@@ -25347,7 +25333,7 @@ msgstr "تاريخ الفاتورة"
 msgid "Invoice Discounting"
 msgstr "خصم الفواتير"
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1114
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1116
 msgid "Invoice Grand Total"
 msgstr "الفاتورة الكبرى المجموع"
 
@@ -25440,7 +25426,7 @@ msgstr "لا يمكن إجراء الفاتورة لمدة صفر ساعة"
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:169
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:144
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1116
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1118
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:164
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:165
 msgid "Invoiced Amount"
@@ -25846,6 +25832,11 @@ msgstr "تم افتتاح الدخول"
 msgid "Is Outward"
 msgstr ""
 
+#. Label of the is_packed (Check) field in DocType 'Serial and Batch Bundle'
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.json
+msgid "Is Packed"
+msgstr ""
+
 #. Label of the is_paid (Check) field in DocType 'Purchase Invoice'
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 msgid "Is Paid"
@@ -26128,11 +26119,11 @@ msgstr "تاريخ الإصدار"
 msgid "Issuing cannot be done to a location. Please enter employee to issue the Asset {0} to"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:565
+#: erpnext/stock/doctype/item/item.py:571
 msgid "It can take upto few hours for accurate stock values to be visible after merging items."
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2075
+#: erpnext/public/js/controllers/transaction.js:2101
 msgid "It is needed to fetch Item Details."
 msgstr "هناك حاجة لجلب تفاصيل البند."
 
@@ -26182,7 +26173,7 @@ msgstr ""
 #: erpnext/buying/report/supplier_quotation_comparison/supplier_quotation_comparison.js:33
 #: erpnext/buying/report/supplier_quotation_comparison/supplier_quotation_comparison.py:204
 #: erpnext/buying/workspace/buying/buying.json
-#: erpnext/controllers/taxes_and_totals.py:1125
+#: erpnext/controllers/taxes_and_totals.py:1135
 #: erpnext/manufacturing/doctype/blanket_order/blanket_order.json
 #: erpnext/manufacturing/doctype/bom/bom.js:944
 #: erpnext/manufacturing/doctype/bom/bom.json
@@ -26460,7 +26451,7 @@ msgstr ""
 #: erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py:86
 #: erpnext/manufacturing/report/work_order_stock_report/work_order_stock_report.py:119
 #: erpnext/projects/doctype/timesheet/timesheet.js:213
-#: erpnext/public/js/controllers/transaction.js:2350
+#: erpnext/public/js/controllers/transaction.js:2376
 #: erpnext/public/js/stock_reservation.js:112
 #: erpnext/public/js/stock_reservation.js:317 erpnext/public/js/utils.js:500
 #: erpnext/public/js/utils.js:656
@@ -26898,7 +26889,7 @@ msgstr "مادة المصنع"
 #: erpnext/manufacturing/report/production_planning_report/production_planning_report.py:359
 #: erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py:92
 #: erpnext/manufacturing/report/work_order_consumed_materials/work_order_consumed_materials.py:138
-#: erpnext/public/js/controllers/transaction.js:2356
+#: erpnext/public/js/controllers/transaction.js:2382
 #: erpnext/public/js/utils.js:746
 #: erpnext/selling/doctype/quotation_item/quotation_item.json
 #: erpnext/selling/doctype/sales_order_item/sales_order_item.json
@@ -27165,7 +27156,7 @@ msgstr "إعدادات متنوع السلعة"
 msgid "Item Variant {0} already exists with same attributes"
 msgstr "متغير الصنف {0} موجود بالفعل مع نفس الخصائص"
 
-#: erpnext/stock/doctype/item/item.py:781
+#: erpnext/stock/doctype/item/item.py:772
 msgid "Item Variants updated"
 msgstr "تم تحديث متغيرات العنصر"
 
@@ -27231,7 +27222,7 @@ msgstr "البند والضمان تفاصيل"
 msgid "Item for row {0} does not match Material Request"
 msgstr "عنصر الصف {0} لا يتطابق مع طلب المواد"
 
-#: erpnext/stock/doctype/item/item.py:795
+#: erpnext/stock/doctype/item/item.py:789
 msgid "Item has variants."
 msgstr "البند لديه متغيرات."
 
@@ -27257,7 +27248,7 @@ msgstr "اسم السلعة"
 msgid "Item operation"
 msgstr "عملية الصنف"
 
-#: erpnext/controllers/accounts_controller.py:3650
+#: erpnext/controllers/accounts_controller.py:3653
 msgid "Item qty can not be updated as raw materials are already processed."
 msgstr ""
 
@@ -27283,7 +27274,7 @@ msgstr ""
 msgid "Item valuation reposting in progress. Report might show incorrect item valuation."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:952
+#: erpnext/stock/doctype/item/item.py:946
 msgid "Item variant {0} exists with same attributes"
 msgstr "متغير العنصر {0} موجود بنفس السمات\\n<br>\\nItem variant {0} exists with same attributes"
 
@@ -27296,8 +27287,7 @@ msgid "Item {0} cannot be ordered more than {1} against Blanket Order {2}."
 msgstr ""
 
 #: erpnext/assets/doctype/asset/asset.py:277
-#: erpnext/stock/doctype/item/item.py:630
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:167
+#: erpnext/stock/doctype/item/item.py:636
 msgid "Item {0} does not exist"
 msgstr "العنصر {0} غير موجود\\n<br>\\nItem {0} does not exist"
 
@@ -27309,7 +27299,7 @@ msgstr "الصنف{0} غير موجود في النظام أو انتهت صلا
 msgid "Item {0} does not exist."
 msgstr "العنصر {0} غير موجود\\n<br>\\nItem {0} does not exist."
 
-#: erpnext/controllers/selling_controller.py:752
+#: erpnext/controllers/selling_controller.py:760
 msgid "Item {0} entered multiple times."
 msgstr ""
 
@@ -27325,7 +27315,7 @@ msgstr "الصنف{0} تم تعطيله"
 msgid "Item {0} has no Serial No. Only serialized items can have delivery based on Serial No"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1126
+#: erpnext/stock/doctype/item/item.py:1120
 msgid "Item {0} has reached its end of life on {1}"
 msgstr "الصنف{0} قد وصل إلى نهاية عمره في {1}"
 
@@ -27337,11 +27327,11 @@ msgstr "تم تجاهل الصنف {0} لأنه ليس بند مخزون"
 msgid "Item {0} is already reserved/delivered against Sales Order {1}."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1146
+#: erpnext/stock/doctype/item/item.py:1140
 msgid "Item {0} is cancelled"
 msgstr "تم إلغاء العنصر {0}\\n<br>\\nItem {0} is cancelled"
 
-#: erpnext/stock/doctype/item/item.py:1130
+#: erpnext/stock/doctype/item/item.py:1124
 msgid "Item {0} is disabled"
 msgstr "تم تعطيل البند {0}"
 
@@ -27349,7 +27339,7 @@ msgstr "تم تعطيل البند {0}"
 msgid "Item {0} is not a serialized Item"
 msgstr "البند {0} ليس بند لديه رقم تسلسلي"
 
-#: erpnext/stock/doctype/item/item.py:1138
+#: erpnext/stock/doctype/item/item.py:1132
 msgid "Item {0} is not a stock Item"
 msgstr "العنصر {0} ليس عنصر مخزون\\n<br>\\nItem {0} is not a stock Item"
 
@@ -27393,7 +27383,7 @@ msgstr "البند {0} الكمية المطلوبة {1} لا يمكن أن تك
 msgid "Item {0}: {1} qty produced. "
 msgstr "العنصر {0}: {1} الكمية المنتجة."
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1429
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1423
 msgid "Item {} does not exist."
 msgstr ""
 
@@ -27533,7 +27523,7 @@ msgstr "اصناف يمكن طلبه"
 msgid "Items and Pricing"
 msgstr "السلع والتسعيرات"
 
-#: erpnext/controllers/accounts_controller.py:3872
+#: erpnext/controllers/accounts_controller.py:3875
 msgid "Items cannot be updated as Subcontracting Order is created against the Purchase Order {0}."
 msgstr ""
 
@@ -28029,7 +28019,7 @@ msgstr "الضرائب التكلفة هبطت والرسوم"
 
 #. Name of a DocType
 #. Label of a Link in the Stock Workspace
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:674
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:676
 #: erpnext/stock/doctype/landed_cost_voucher/landed_cost_voucher.json
 #: erpnext/stock/doctype/purchase_receipt/purchase_receipt.js:104
 #: erpnext/stock/workspace/stock/stock.json
@@ -28644,7 +28634,7 @@ msgstr "الفواتير المرتبطة"
 msgid "Linked Location"
 msgstr "الموقع المرتبط"
 
-#: erpnext/stock/doctype/item/item.py:999
+#: erpnext/stock/doctype/item/item.py:993
 msgid "Linked with submitted documents"
 msgstr ""
 
@@ -29383,7 +29373,7 @@ msgstr ""
 #: erpnext/manufacturing/doctype/bom/bom.py:261
 #: erpnext/manufacturing/doctype/bom_update_log/bom_update_log.py:71
 #: erpnext/public/js/controllers/accounts.js:249
-#: erpnext/public/js/controllers/transaction.js:2753
+#: erpnext/public/js/controllers/transaction.js:2779
 #: erpnext/public/js/utils/party.js:321
 #: erpnext/stock/doctype/delivery_note/delivery_note.js:164
 #: erpnext/stock/doctype/inventory_dimension/inventory_dimension.json
@@ -30239,7 +30229,7 @@ msgstr "الاستخدام الأقصى"
 msgid "Maximum Value"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:212
+#: erpnext/controllers/selling_controller.py:220
 msgid "Maximum discount for Item {0} is {1}%"
 msgstr ""
 
@@ -30309,7 +30299,7 @@ msgstr ""
 msgid "Megawatt"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1878
+#: erpnext/stock/stock_ledger.py:1887
 msgid "Mention Valuation Rate in the Item master."
 msgstr "اذكر معدل التقييم في مدير السلعة."
 
@@ -30704,11 +30694,11 @@ msgstr "الدقائق"
 msgid "Miscellaneous Expenses"
 msgstr "نفقات متنوعة"
 
-#: erpnext/controllers/buying_controller.py:540
+#: erpnext/controllers/buying_controller.py:548
 msgid "Mismatch"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1430
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1424
 msgid "Missing"
 msgstr ""
 
@@ -31235,7 +31225,7 @@ msgstr "متغيرات متعددة"
 msgid "Multiple Warehouse Accounts"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1129
+#: erpnext/controllers/accounts_controller.py:1132
 msgid "Multiple fiscal years exist for the date {0}. Please set company in Fiscal Year"
 msgstr "يوجد سنوات مالية متعددة لنفس التاريخ {0}. الرجاء تحديد الشركة لهذه السنة المالية\\n<br>\\nMultiple fiscal years exist for the date {0}. Please set company in Fiscal Year"
 
@@ -31386,7 +31376,7 @@ msgstr "بادئة سلسلة التسمية"
 msgid "Naming Series and Price Defaults"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:90
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:91
 msgid "Naming Series is mandatory"
 msgstr ""
 
@@ -31425,15 +31415,15 @@ msgstr "غاز طبيعي"
 msgid "Needs Analysis"
 msgstr "تحليل الاحتياجات"
 
-#: erpnext/stock/serial_batch_bundle.py:1277
+#: erpnext/stock/serial_batch_bundle.py:1309
 msgid "Negative Batch Quantity"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:610
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:606
 msgid "Negative Quantity is not allowed"
 msgstr "الكمية السلبية غير مسموح بها\\n<br>\\nnegative Quantity is not allowed"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:615
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:611
 msgid "Negative Valuation Rate is not allowed"
 msgstr "معدل التقييم السلبي غير مسموح به\\n<br>\\nNegative Valuation Rate is not allowed"
 
@@ -31715,7 +31705,7 @@ msgstr "الوزن الصافي"
 msgid "Net Weight UOM"
 msgstr "الوزن الصافي لوحدة القياس"
 
-#: erpnext/controllers/accounts_controller.py:1483
+#: erpnext/controllers/accounts_controller.py:1486
 msgid "Net total calculation precision loss"
 msgstr ""
 
@@ -32058,7 +32048,7 @@ msgstr ""
 #: erpnext/accounts/doctype/journal_entry/journal_entry.py:1539
 #: erpnext/accounts/doctype/journal_entry/journal_entry.py:1599
 #: erpnext/accounts/doctype/journal_entry/journal_entry.py:1613
-#: erpnext/stock/doctype/item/item.py:1371
+#: erpnext/stock/doctype/item/item.py:1365
 msgid "No Permission"
 msgstr "لا يوجد تصريح"
 
@@ -32080,7 +32070,7 @@ msgstr "لا ملاحظات"
 msgid "No Selection"
 msgstr ""
 
-#: erpnext/controllers/sales_and_purchase_return.py:919
+#: erpnext/controllers/sales_and_purchase_return.py:824
 msgid "No Serial / Batches are available for return"
 msgstr ""
 
@@ -32116,7 +32106,7 @@ msgstr ""
 msgid "No Work Orders were created"
 msgstr ""
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:785
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:794
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py:689
 msgid "No accounting entries for the following warehouses"
 msgstr "لا القيود المحاسبية للمستودعات التالية"
@@ -32305,7 +32295,7 @@ msgstr ""
 msgid "No reserved stock to unreserve."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:773
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:769
 msgid "No stock ledger entries were created. Please set the quantity or valuation rate for the items properly and try again."
 msgstr ""
 
@@ -32389,7 +32379,7 @@ msgstr ""
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:566
 #: erpnext/assets/doctype/asset/asset.js:612
 #: erpnext/assets/doctype/asset/asset.js:627
-#: erpnext/controllers/buying_controller.py:225
+#: erpnext/controllers/buying_controller.py:233
 #: erpnext/selling/doctype/product_bundle/product_bundle.py:72
 #: erpnext/setup/doctype/transaction_deletion_record/transaction_deletion_record.py:80
 msgid "Not Allowed"
@@ -32510,10 +32500,10 @@ msgstr "غير مسموح به"
 #: erpnext/selling/doctype/customer/customer.py:129
 #: erpnext/selling/doctype/sales_order/sales_order.js:1168
 #: erpnext/stock/doctype/item/item.js:526
-#: erpnext/stock/doctype/item/item.py:567
+#: erpnext/stock/doctype/item/item.py:573
 #: erpnext/stock/doctype/item_price/item_price.json
 #: erpnext/stock/doctype/stock_entry/stock_entry.py:1374
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:972
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:968
 #: erpnext/templates/pages/timelog_info.html:43
 msgid "Note"
 msgstr "ملاحظات"
@@ -32522,7 +32512,7 @@ msgstr "ملاحظات"
 msgid "Note: Automatic log deletion only applies to logs of type <i>Update Cost</i>"
 msgstr ""
 
-#: erpnext/accounts/party.py:690
+#: erpnext/accounts/party.py:696
 msgid "Note: Due Date exceeds allowed {0} credit days by {1} day(s)"
 msgstr ""
 
@@ -32548,7 +32538,7 @@ msgstr "ملاحظة : لن يتم إنشاء تدوين المدفوعات نظ
 msgid "Note: This Cost Center is a Group. Cannot make accounting entries against groups."
 msgstr "ملاحظة: مركز التكلفة هذا هو مجموعة. لا يمكن إجراء القيود المحاسبية مقابل المجموعات."
 
-#: erpnext/stock/doctype/item/item.py:621
+#: erpnext/stock/doctype/item/item.py:627
 msgid "Note: To merge the items, create a separate Stock Reconciliation for the old item {0}"
 msgstr ""
 
@@ -33311,7 +33301,7 @@ msgstr ""
 
 #. Label of the opening_stock (Float) field in DocType 'Item'
 #. Option for the 'Purpose' (Select) field in DocType 'Stock Reconciliation'
-#: erpnext/stock/doctype/item/item.json erpnext/stock/doctype/item/item.py:296
+#: erpnext/stock/doctype/item/item.json erpnext/stock/doctype/item/item.py:299
 #: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.json
 msgid "Opening Stock"
 msgstr "مخزون أول المدة"
@@ -34031,7 +34021,7 @@ msgstr ""
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:149
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1123
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1125
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:167
 #: erpnext/accounts/report/purchase_register/purchase_register.py:289
 #: erpnext/accounts/report/sales_register/sales_register.py:319
@@ -34070,7 +34060,7 @@ msgstr "نحو الخارج"
 msgid "Over Billing Allowance (%)"
 msgstr ""
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:1242
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:1251
 msgid "Over Billing Allowance exceeded for Purchase Receipt Item {0} ({1}) by {2}%"
 msgstr ""
 
@@ -34111,7 +34101,7 @@ msgstr ""
 msgid "Overbilling of {0} {1} ignored for item {2} because you have {3} role."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2013
+#: erpnext/controllers/accounts_controller.py:2016
 msgid "Overbilling of {} ignored because you have {} role."
 msgstr ""
 
@@ -34618,7 +34608,7 @@ msgstr "مدفوع"
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:146
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1117
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1119
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:165
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:172
 #: erpnext/accounts/report/pos_register/pos_register.py:209
@@ -34851,7 +34841,7 @@ msgstr "الإجراء الرئيسي"
 msgid "Parent Row No"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom_creator/bom_creator.py:495
+#: erpnext/manufacturing/doctype/bom_creator/bom_creator.py:496
 msgid "Parent Row No not found for {0}"
 msgstr ""
 
@@ -35080,7 +35070,7 @@ msgstr ""
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:142
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:159
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:57
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1054
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1056
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:67
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:147
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:228
@@ -35106,7 +35096,7 @@ msgstr "الطرف المعني"
 
 #. Name of a DocType
 #: erpnext/accounts/doctype/party_account/party_account.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1065
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1067
 msgid "Party Account"
 msgstr "حساب طرف"
 
@@ -35133,7 +35123,7 @@ msgstr "عملة حساب الطرف"
 msgid "Party Account No. (Bank Statement)"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2278
+#: erpnext/controllers/accounts_controller.py:2281
 msgid "Party Account {0} currency ({1}) and document currency ({2}) should be same"
 msgstr ""
 
@@ -35150,6 +35140,11 @@ msgstr "حساب بنك الحزب"
 #: erpnext/accounts/doctype/payment_request/payment_request.json
 msgid "Party Details"
 msgstr "تفاصيل الحزب"
+
+#. Label of the party_full_name (Data) field in DocType 'Contract'
+#: erpnext/crm/doctype/contract/contract.json
+msgid "Party Full Name"
+msgstr ""
 
 #. Label of the bank_party_iban (Data) field in DocType 'Bank Transaction'
 #: erpnext/accounts/doctype/bank_transaction/bank_transaction.json
@@ -35234,7 +35229,7 @@ msgstr ""
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:84
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:54
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:44
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1048
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1050
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:54
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:141
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:219
@@ -35256,7 +35251,7 @@ msgstr ""
 msgid "Party Type"
 msgstr "نوع الطرف"
 
-#: erpnext/accounts/party.py:819
+#: erpnext/accounts/party.py:825
 msgid "Party Type and Party can only be set for Receivable / Payable account<br><br>{0}"
 msgstr ""
 
@@ -35378,7 +35373,7 @@ msgid "Payable"
 msgstr "واجب الدفع"
 
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:42
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1063
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1065
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:211
 #: erpnext/accounts/report/purchase_register/purchase_register.py:194
 #: erpnext/accounts/report/purchase_register/purchase_register.py:235
@@ -35544,7 +35539,7 @@ msgstr "تم تعديل تدوين مدفوعات بعد سحبه. يرجى سح
 msgid "Payment Entry is already created"
 msgstr "تدوين المدفوعات تم انشاؤه بالفعل"
 
-#: erpnext/controllers/accounts_controller.py:1434
+#: erpnext/controllers/accounts_controller.py:1437
 msgid "Payment Entry {0} is linked against Order {1}, check if it should be pulled as advance in this invoice."
 msgstr ""
 
@@ -35826,7 +35821,7 @@ msgstr ""
 #: erpnext/accounts/doctype/payment_schedule/payment_schedule.json
 #: erpnext/accounts/doctype/payment_term/payment_term.json
 #: erpnext/accounts/doctype/payment_terms_template_detail/payment_terms_template_detail.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1113
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1115
 #: erpnext/accounts/report/gross_profit/gross_profit.py:412
 #: erpnext/accounts/workspace/accounting/accounting.json
 #: erpnext/selling/report/payment_terms_status_for_sales_order/payment_terms_status_for_sales_order.py:30
@@ -36890,7 +36885,7 @@ msgstr ""
 msgid "Please create a new Accounting Dimension if required."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:729
+#: erpnext/controllers/accounts_controller.py:732
 msgid "Please create purchase from internal sale or delivery document itself"
 msgstr ""
 
@@ -36898,7 +36893,7 @@ msgstr ""
 msgid "Please create purchase receipt or purchase invoice for the item {0}"
 msgstr "الرجاء إنشاء إيصال شراء أو فاتورة شراء للعنصر {0}"
 
-#: erpnext/stock/doctype/item/item.py:649
+#: erpnext/stock/doctype/item/item.py:655
 msgid "Please delete Product Bundle {0}, before merging {1} into {2}"
 msgstr ""
 
@@ -36940,7 +36935,7 @@ msgstr "يرجى تمكين النوافذ المنبثقة"
 msgid "Please enable {0} in the {1}."
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:754
+#: erpnext/controllers/selling_controller.py:762
 msgid "Please enable {} in {} to allow same item in multiple rows"
 msgstr ""
 
@@ -36973,7 +36968,7 @@ msgstr "الرجاء إدخال الحساب لمبلغ التغيير\\n<br> \\
 msgid "Please enter Approving Role or Approving User"
 msgstr "الرجاء إدخال صلاحية المخول بالتصديق أو المستخدم المخول بالتصديق"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:939
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:935
 msgid "Please enter Cost Center"
 msgstr "يرجى إدخال مركز التكلفة\\n<br>\\nPlease enter Cost Center"
 
@@ -36985,7 +36980,7 @@ msgstr "الرجاء إدخال تاريخ التسليم"
 msgid "Please enter Employee Id of this sales person"
 msgstr "الرجاء إدخال معرف الموظف الخاص بشخص المبيعات هذا"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:948
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:944
 msgid "Please enter Expense Account"
 msgstr "الرجاء إدخال حساب النفقات\\n<br>\\nPlease enter Expense Account"
 
@@ -36994,7 +36989,7 @@ msgstr "الرجاء إدخال حساب النفقات\\n<br>\\nPlease enter Ex
 msgid "Please enter Item Code to get Batch Number"
 msgstr "الرجاء إدخال رمز العنصر للحصول على رقم الدفعة\\n<br>\\nPlease enter Item Code to get Batch Number"
 
-#: erpnext/public/js/controllers/transaction.js:2503
+#: erpnext/public/js/controllers/transaction.js:2529
 msgid "Please enter Item Code to get batch no"
 msgstr "الرجاء إدخال كود البند للحصول على رقم الدفعة"
 
@@ -37059,7 +37054,7 @@ msgstr "الرجاء إدخال الشركة أولا\\n<br>\\nPlease enter comp
 msgid "Please enter company name first"
 msgstr "الرجاء إدخال اسم الشركة اولاً"
 
-#: erpnext/controllers/accounts_controller.py:2764
+#: erpnext/controllers/accounts_controller.py:2767
 msgid "Please enter default currency in Company Master"
 msgstr "الرجاء إدخال العملة الافتراضية في شركة الرئيسية"
 
@@ -37095,7 +37090,7 @@ msgstr "الرجاء إدخال اسم الشركة للتأكيد"
 msgid "Please enter the phone number first"
 msgstr "الرجاء إدخال رقم الهاتف أولاً"
 
-#: erpnext/controllers/buying_controller.py:1007
+#: erpnext/controllers/buying_controller.py:1015
 msgid "Please enter the {schedule_date}."
 msgstr ""
 
@@ -37197,7 +37192,7 @@ msgstr "يرجى حفظ أولا"
 msgid "Please select <b>Template Type</b> to download template"
 msgstr "يرجى تحديد <b>نوع</b> القالب لتنزيل القالب"
 
-#: erpnext/controllers/taxes_and_totals.py:721
+#: erpnext/controllers/taxes_and_totals.py:731
 #: erpnext/public/js/controllers/taxes_and_totals.js:721
 msgid "Please select Apply Discount On"
 msgstr "الرجاء اختيار (تطبيق تخفيض على)"
@@ -37210,7 +37205,7 @@ msgstr "الرجاء اختيار بوم ضد العنصر {0}"
 msgid "Please select BOM for Item in Row {0}"
 msgstr "الرجاء تحديد قائمة المواد للبند في الصف {0}"
 
-#: erpnext/controllers/buying_controller.py:467
+#: erpnext/controllers/buying_controller.py:475
 msgid "Please select BOM in BOM field for Item {item_code}."
 msgstr "يرجى تحديد قائمة المواد في الحقل (قائمة المواد) للبند {item_code}."
 
@@ -37292,7 +37287,7 @@ msgstr "الرجاء اختيار قائمة الأسعار\\n<br>\\nPlease sele
 msgid "Please select Qty against item {0}"
 msgstr "الرجاء اختيار الكمية ضد العنصر {0}"
 
-#: erpnext/stock/doctype/item/item.py:320
+#: erpnext/stock/doctype/item/item.py:323
 msgid "Please select Sample Retention Warehouse in Stock Settings first"
 msgstr "يرجى تحديد نموذج الاحتفاظ مستودع في إعدادات المخزون أولا"
 
@@ -37308,7 +37303,7 @@ msgstr "الرجاء تحديد تاريخ البدء وتاريخ الانته�
 msgid "Please select Subcontracting Order instead of Purchase Order {0}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2613
+#: erpnext/controllers/accounts_controller.py:2616
 msgid "Please select Unrealized Profit / Loss account or add default Unrealized Profit / Loss account account for company {0}"
 msgstr ""
 
@@ -37324,7 +37319,7 @@ msgstr "الرجاء اختيار الشركة"
 #: erpnext/manufacturing/doctype/bom/bom.js:603
 #: erpnext/manufacturing/doctype/bom/bom.py:261
 #: erpnext/public/js/controllers/accounts.js:249
-#: erpnext/public/js/controllers/transaction.js:2753
+#: erpnext/public/js/controllers/transaction.js:2779
 msgid "Please select a Company first."
 msgstr "الرجاء تحديد شركة أولاً."
 
@@ -37482,7 +37477,7 @@ msgstr "الرجاء اختيار {0}"
 msgid "Please select {0} first"
 msgstr "الرجاء تحديد {0} أولا\\n<br>\\nPlease select {0} first"
 
-#: erpnext/public/js/controllers/transaction.js:77
+#: erpnext/public/js/controllers/transaction.js:100
 msgid "Please set 'Apply Additional Discount On'"
 msgstr "يرجى تحديد 'تطبيق خصم إضافي على'"
 
@@ -37667,7 +37662,7 @@ msgstr "يرجى ضبط الفلتر على أساس البند أو المخز�
 msgid "Please set filters"
 msgstr "يرجى تعيين المرشحات"
 
-#: erpnext/controllers/accounts_controller.py:2194
+#: erpnext/controllers/accounts_controller.py:2197
 msgid "Please set one of the following:"
 msgstr ""
 
@@ -37675,7 +37670,7 @@ msgstr ""
 msgid "Please set opening number of booked depreciations"
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2205
+#: erpnext/public/js/controllers/transaction.js:2231
 msgid "Please set recurring after saving"
 msgstr "يرجى تحديد (تكرار) بعد الحفظ"
 
@@ -37746,7 +37741,7 @@ msgstr ""
 msgid "Please share this email with your support team so that they can find and fix the issue."
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2073
+#: erpnext/public/js/controllers/transaction.js:2099
 msgid "Please specify"
 msgstr "رجاء حدد"
 
@@ -37761,7 +37756,7 @@ msgid "Please specify Company to proceed"
 msgstr "الرجاء تحديد الشركة للمضى قدما\\n<br>\\nPlease specify Company to proceed"
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1472
-#: erpnext/controllers/accounts_controller.py:2957
+#: erpnext/controllers/accounts_controller.py:2960
 #: erpnext/public/js/controllers/accounts.js:97
 msgid "Please specify a valid Row ID for row {0} in table {1}"
 msgstr "يرجى تحديد هوية الصف صالحة لصف {0} في الجدول {1}"
@@ -37774,7 +37769,7 @@ msgstr ""
 msgid "Please specify at least one attribute in the Attributes table"
 msgstr "يرجى تحديد خاصية واحدة على الأقل في جدول (الخاصيات)"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:605
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:601
 msgid "Please specify either Quantity or Valuation Rate or both"
 msgstr "يرجى تحديد الكمية أو التقييم إما قيم أو كليهما"
 
@@ -37955,7 +37950,7 @@ msgstr "نفقات بريدية"
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:16
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:15
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:18
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1046
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1048
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:15
 #: erpnext/accounts/report/bank_clearance_summary/bank_clearance_summary.py:35
 #: erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.html:7
@@ -40136,7 +40131,7 @@ msgstr "المدير الرئيسي للمشتريات"
 #: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.js:48
 #: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:203
 #: erpnext/buying/workspace/buying/buying.json
-#: erpnext/controllers/buying_controller.py:739
+#: erpnext/controllers/buying_controller.py:747
 #: erpnext/crm/doctype/contract/contract.json
 #: erpnext/manufacturing/doctype/blanket_order/blanket_order.js:54
 #: erpnext/manufacturing/doctype/production_plan_sub_assembly_item/production_plan_sub_assembly_item.json
@@ -40275,7 +40270,7 @@ msgstr "أوامر الشراء إلى الفاتورة"
 msgid "Purchase Orders to Receive"
 msgstr "أوامر الشراء لتلقي"
 
-#: erpnext/controllers/accounts_controller.py:1833
+#: erpnext/controllers/accounts_controller.py:1836
 msgid "Purchase Orders {0} are un-linked"
 msgstr ""
 
@@ -40299,8 +40294,8 @@ msgstr "قائمة أسعار الشراء"
 #. Label of a Link in the Stock Workspace
 #. Label of a shortcut in the Stock Workspace
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:171
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:650
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:660
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:652
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:662
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice_list.js:49
 #: erpnext/accounts/doctype/purchase_invoice_item/purchase_invoice_item.json
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:246
@@ -41035,7 +41030,7 @@ msgstr "قالب فحص الجودة"
 msgid "Quality Inspection Template Name"
 msgstr "قالب فحص الجودة اسم"
 
-#: erpnext/public/js/controllers/transaction.js:334
+#: erpnext/public/js/controllers/transaction.js:360
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:165
 msgid "Quality Inspection(s)"
 msgstr ""
@@ -42219,7 +42214,7 @@ msgid "Receivable / Payable Account"
 msgstr "القبض / حساب الدائنة"
 
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:71
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1061
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1063
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py:243
 #: erpnext/accounts/report/sales_register/sales_register.py:217
 #: erpnext/accounts/report/sales_register/sales_register.py:271
@@ -42701,7 +42696,7 @@ msgstr "المرجع # {0} بتاريخ {1}"
 msgid "Reference Date"
 msgstr "المرجع تاريخ"
 
-#: erpnext/public/js/controllers/transaction.js:2311
+#: erpnext/public/js/controllers/transaction.js:2337
 msgid "Reference Date for Early Payment Discount"
 msgstr ""
 
@@ -43025,7 +43020,7 @@ msgstr "منتظم"
 msgid "Rejected"
 msgstr "مرفوض"
 
-#: erpnext/stock/doctype/inventory_dimension/inventory_dimension.py:202
+#: erpnext/stock/doctype/inventory_dimension/inventory_dimension.py:203
 msgid "Rejected "
 msgstr "مرفوض "
 
@@ -43129,7 +43124,7 @@ msgstr ""
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:187
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:156
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1135
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1137
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:178
 msgid "Remaining Balance"
 msgstr "الرصيد المتبقي"
@@ -43182,7 +43177,7 @@ msgstr "كلام"
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:159
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:198
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:269
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1167
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1169
 #: erpnext/accounts/report/general_ledger/general_ledger.html:84
 #: erpnext/accounts/report/general_ledger/general_ledger.html:110
 #: erpnext/accounts/report/general_ledger/general_ledger.py:742
@@ -43931,7 +43926,7 @@ msgstr "الكمية المحجوزة"
 msgid "Reserved Quantity for Production"
 msgstr "الكمية المحجوزة للإنتاج"
 
-#: erpnext/stock/stock_ledger.py:2147
+#: erpnext/stock/stock_ledger.py:2155
 msgid "Reserved Serial No."
 msgstr ""
 
@@ -43947,11 +43942,11 @@ msgstr ""
 #: erpnext/stock/doctype/pick_list/pick_list.js:153
 #: erpnext/stock/report/reserved_stock/reserved_stock.json
 #: erpnext/stock/report/stock_balance/stock_balance.py:499
-#: erpnext/stock/stock_ledger.py:2131
+#: erpnext/stock/stock_ledger.py:2139
 msgid "Reserved Stock"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:2177
+#: erpnext/stock/stock_ledger.py:2185
 msgid "Reserved Stock for Batch"
 msgstr ""
 
@@ -43963,7 +43958,7 @@ msgstr ""
 msgid "Reserved Stock for Sub-assembly"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:476
+#: erpnext/controllers/buying_controller.py:484
 msgid "Reserved Warehouse is mandatory for the Item {item_code} in Raw Materials supplied."
 msgstr ""
 
@@ -44777,7 +44772,7 @@ msgstr "التوجيه"
 msgid "Routing Name"
 msgstr "اسم التوجيه"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:667
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:663
 msgid "Row #"
 msgstr ""
 
@@ -44815,7 +44810,7 @@ msgstr "الصف # {0} (جدول الدفع): يجب أن يكون المبلغ 
 msgid "Row #{0} (Payment Table): Amount must be positive"
 msgstr "الصف رقم {0} (جدول الدفع): يجب أن يكون المبلغ موجبا"
 
-#: erpnext/stock/doctype/item/item.py:495
+#: erpnext/stock/doctype/item/item.py:498
 msgid "Row #{0}: A reorder entry already exists for warehouse {1} with reorder type {2}."
 msgstr ""
 
@@ -44836,7 +44831,7 @@ msgstr ""
 msgid "Row #{0}: Accepted Warehouse is mandatory for the accepted Item {1}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1117
+#: erpnext/controllers/accounts_controller.py:1120
 msgid "Row #{0}: Account {1} does not belong to company {2}"
 msgstr "الصف # {0}: الحساب {1} لا ينتمي إلى الشركة {2}"
 
@@ -44877,27 +44872,27 @@ msgstr ""
 msgid "Row #{0}: Cannot allocate more than {1} against payment term {2}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3524
+#: erpnext/controllers/accounts_controller.py:3527
 msgid "Row #{0}: Cannot delete item {1} which has already been billed."
 msgstr "الصف # {0}: لا يمكن حذف العنصر {1} الذي تم تحرير فاتورة به بالفعل."
 
-#: erpnext/controllers/accounts_controller.py:3498
+#: erpnext/controllers/accounts_controller.py:3501
 msgid "Row #{0}: Cannot delete item {1} which has already been delivered"
 msgstr "الصف # {0}: لا يمكن حذف العنصر {1} الذي تم تسليمه بالفعل"
 
-#: erpnext/controllers/accounts_controller.py:3517
+#: erpnext/controllers/accounts_controller.py:3520
 msgid "Row #{0}: Cannot delete item {1} which has already been received"
 msgstr "الصف # {0}: لا يمكن حذف العنصر {1} الذي تم استلامه بالفعل"
 
-#: erpnext/controllers/accounts_controller.py:3504
+#: erpnext/controllers/accounts_controller.py:3507
 msgid "Row #{0}: Cannot delete item {1} which has work order assigned to it."
 msgstr "الصف # {0}: لا يمكن حذف العنصر {1} الذي تم تعيين ترتيب العمل إليه."
 
-#: erpnext/controllers/accounts_controller.py:3510
+#: erpnext/controllers/accounts_controller.py:3513
 msgid "Row #{0}: Cannot delete item {1} which is assigned to customer's purchase order."
 msgstr "الصف # {0}: لا يمكن حذف العنصر {1} الذي تم تعيينه لأمر شراء العميل."
 
-#: erpnext/controllers/accounts_controller.py:3765
+#: erpnext/controllers/accounts_controller.py:3768
 msgid "Row #{0}: Cannot set Rate if the billed amount is greater than the amount for Item {1}."
 msgstr ""
 
@@ -45017,7 +45012,7 @@ msgstr ""
 msgid "Row #{0}: Item {1} has been picked, please reserve stock from the Pick List."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:729
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:725
 msgid "Row #{0}: Item {1} is not a Serialized/Batched Item. It cannot have a Serial No/Batch No against it."
 msgstr "الصف # {0}: العنصر {1} ليس عنصرًا تسلسليًا / مُجمَّع. لا يمكن أن يكون له رقم مسلسل / لا دفعة ضده."
 
@@ -45073,7 +45068,7 @@ msgstr ""
 msgid "Row #{0}: Please select the Sub Assembly Warehouse"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:502
+#: erpnext/stock/doctype/item/item.py:505
 msgid "Row #{0}: Please set reorder quantity"
 msgstr "الصف # {0}: يرجى تعيين إعادة ترتيب الكمية\\n<br>\\nRow #{0}: Please set reorder quantity"
 
@@ -45106,8 +45101,8 @@ msgstr ""
 msgid "Row #{0}: Quality Inspection {1} was rejected for item {2}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1274
-#: erpnext/controllers/accounts_controller.py:3624
+#: erpnext/controllers/accounts_controller.py:1277
+#: erpnext/controllers/accounts_controller.py:3627
 msgid "Row #{0}: Quantity for Item {1} cannot be zero."
 msgstr "الصف # {0}: كمية البند {1} لا يمكن أن يكون صفرا"
 
@@ -45144,7 +45139,7 @@ msgstr ""
 msgid "Row #{0}: Scrap Item Qty cannot be zero"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:230
+#: erpnext/controllers/selling_controller.py:238
 msgid "Row #{0}: Selling rate for item {1} is lower than its {2}.\n"
 "\t\t\t\t\tSelling {3} should be atleast {4}.<br><br>Alternatively,\n"
 "\t\t\t\t\tyou can disable selling price validation in {5} to bypass\n"
@@ -45228,7 +45223,7 @@ msgstr ""
 msgid "Row #{0}: The batch {1} has already expired."
 msgstr "الصف رقم {0}: انتهت صلاحية الدفعة {1} بالفعل."
 
-#: erpnext/stock/doctype/item/item.py:511
+#: erpnext/stock/doctype/item/item.py:514
 msgid "Row #{0}: The warehouse {1} is not a child warehouse of a group warehouse {2}"
 msgstr ""
 
@@ -45268,39 +45263,39 @@ msgstr ""
 msgid "Row #{1}: Warehouse is mandatory for stock Item {0}"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:259
+#: erpnext/controllers/buying_controller.py:267
 msgid "Row #{idx}: Cannot select Supplier Warehouse while suppling raw materials to subcontractor."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:406
+#: erpnext/controllers/buying_controller.py:414
 msgid "Row #{idx}: Item rate has been updated as per valuation rate since its an internal stock transfer."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:881
+#: erpnext/controllers/buying_controller.py:889
 msgid "Row #{idx}: Please enter a location for the asset item {item_code}."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:537
+#: erpnext/controllers/buying_controller.py:545
 msgid "Row #{idx}: Received Qty must be equal to Accepted + Rejected Qty for Item {item_code}."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:550
+#: erpnext/controllers/buying_controller.py:558
 msgid "Row #{idx}: {field_label} can not be negative for item {item_code}."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:496
+#: erpnext/controllers/buying_controller.py:504
 msgid "Row #{idx}: {field_label} is mandatory."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:518
+#: erpnext/controllers/buying_controller.py:526
 msgid "Row #{idx}: {field_label} is not allowed in Purchase Return."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:250
+#: erpnext/controllers/buying_controller.py:258
 msgid "Row #{idx}: {from_warehouse_field} and {to_warehouse_field} cannot be same."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:999
+#: erpnext/controllers/buying_controller.py:1007
 msgid "Row #{idx}: {schedule_date} cannot be before {transaction_date}."
 msgstr ""
 
@@ -45365,7 +45360,7 @@ msgstr "رقم الصف {}: {}"
 msgid "Row #{}: {} {} does not exist."
 msgstr "الصف رقم {}: {} {} غير موجود."
 
-#: erpnext/stock/doctype/item/item.py:1403
+#: erpnext/stock/doctype/item/item.py:1397
 msgid "Row #{}: {} {} doesn't belong to Company {}. Please select valid {}."
 msgstr ""
 
@@ -45437,11 +45432,11 @@ msgstr "صف {0}: من مواد مشروع القانون لم يتم العثو
 msgid "Row {0}: Both Debit and Credit values cannot be zero"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:222
+#: erpnext/controllers/selling_controller.py:230
 msgid "Row {0}: Conversion Factor is mandatory"
 msgstr "الصف {0}: معامل التحويل إلزامي"
 
-#: erpnext/controllers/accounts_controller.py:2995
+#: erpnext/controllers/accounts_controller.py:2998
 msgid "Row {0}: Cost Center {1} does not belong to Company {2}"
 msgstr ""
 
@@ -45461,11 +45456,11 @@ msgstr "الصف {0}: العملة للـ BOM #{1} يجب أن يساوي الع
 msgid "Row {0}: Debit entry can not be linked with a {1}"
 msgstr "الصف {0}: لا يمكن ربط قيد مدين مع {1}"
 
-#: erpnext/controllers/selling_controller.py:776
+#: erpnext/controllers/selling_controller.py:784
 msgid "Row {0}: Delivery Warehouse ({1}) and Customer Warehouse ({2}) can not be same"
 msgstr "الصف {0}: لا يمكن أن يكون مستودع التسليم ({1}) ومستودع العميل ({2}) متماثلين"
 
-#: erpnext/controllers/accounts_controller.py:2529
+#: erpnext/controllers/accounts_controller.py:2532
 msgid "Row {0}: Due Date in the Payment Terms table cannot be before Posting Date"
 msgstr "الصف {0}: لا يمكن أن يكون تاريخ الاستحقاق في جدول شروط الدفع قبل تاريخ الترحيل"
 
@@ -45474,7 +45469,7 @@ msgid "Row {0}: Either Delivery Note Item or Packed Item reference is mandatory.
 msgstr ""
 
 #: erpnext/accounts/doctype/journal_entry/journal_entry.py:1010
-#: erpnext/controllers/taxes_and_totals.py:1205
+#: erpnext/controllers/taxes_and_totals.py:1215
 msgid "Row {0}: Exchange Rate is mandatory"
 msgstr "الصف {0}: سعر صرف إلزامي"
 
@@ -45523,11 +45518,11 @@ msgstr "صف {0}: يجب أن تكون قيمة الساعات أكبر من ا�
 msgid "Row {0}: Invalid reference {1}"
 msgstr "الصف {0}: مرجع غير صالحة {1}"
 
-#: erpnext/controllers/taxes_and_totals.py:142
+#: erpnext/controllers/taxes_and_totals.py:143
 msgid "Row {0}: Item Tax template updated as per validity and rate applied"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:541
+#: erpnext/controllers/selling_controller.py:549
 msgid "Row {0}: Item rate has been updated as per valuation rate since its an internal stock transfer"
 msgstr ""
 
@@ -45647,7 +45642,7 @@ msgstr ""
 msgid "Row {0}: The item {1}, quantity must be positive number"
 msgstr "الصف {0}: العنصر {1} ، يجب أن تكون الكمية رقمًا موجبًا"
 
-#: erpnext/controllers/accounts_controller.py:2972
+#: erpnext/controllers/accounts_controller.py:2975
 msgid "Row {0}: The {3} Account {1} does not belong to the company {2}"
 msgstr ""
 
@@ -45664,7 +45659,7 @@ msgstr "الصف {0}: عامل تحويل UOM إلزامي\\n<br>\\nRow {0}: UOM
 msgid "Row {0}: Workstation or Workstation Type is mandatory for an operation {1}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1011
+#: erpnext/controllers/accounts_controller.py:1014
 msgid "Row {0}: user has not applied the rule {1} on the item {2}"
 msgstr "الصف {0}: لم يطبق المستخدم القاعدة {1} على العنصر {2}"
 
@@ -45676,7 +45671,7 @@ msgstr ""
 msgid "Row {0}: {1} must be greater than 0"
 msgstr "الصف {0}: يجب أن يكون {1} أكبر من 0"
 
-#: erpnext/controllers/accounts_controller.py:706
+#: erpnext/controllers/accounts_controller.py:709
 msgid "Row {0}: {1} {2} cannot be same as {3} (Party Account) {4}"
 msgstr ""
 
@@ -45692,7 +45687,7 @@ msgstr ""
 msgid "Row {1}: Quantity ({0}) cannot be a fraction. To allow this, disable '{2}' in UOM {3}."
 msgstr "الصف {1}: لا يمكن أن تكون الكمية ({0}) كسرًا. للسماح بذلك ، قم بتعطيل &#39;{2}&#39; في UOM {3}."
 
-#: erpnext/controllers/buying_controller.py:863
+#: erpnext/controllers/buying_controller.py:871
 msgid "Row {idx}: Asset Naming Series is mandatory for the auto creation of assets for item {item_code}."
 msgstr ""
 
@@ -45718,7 +45713,7 @@ msgstr "تمت إزالة الصفوف في {0}"
 msgid "Rows with Same Account heads will be merged on Ledger"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2539
+#: erpnext/controllers/accounts_controller.py:2542
 msgid "Rows with duplicate due dates in other rows were found: {0}"
 msgstr "تم العثور على صفوف ذات تواريخ استحقاق مكررة في صفوف أخرى: {0}"
 
@@ -45788,7 +45783,7 @@ msgstr ""
 msgid "SLA Paused On"
 msgstr ""
 
-#: erpnext/public/js/utils.js:1167
+#: erpnext/public/js/utils.js:1163
 msgid "SLA is on hold since {0}"
 msgstr "اتفاقية مستوى الخدمة معلقة منذ {0}"
 
@@ -46189,7 +46184,7 @@ msgstr ""
 #: erpnext/accounts/report/sales_register/sales_register.py:238
 #: erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
 #: erpnext/buying/doctype/supplier_quotation_item/supplier_quotation_item.json
-#: erpnext/controllers/selling_controller.py:462
+#: erpnext/controllers/selling_controller.py:470
 #: erpnext/crm/doctype/contract/contract.json
 #: erpnext/maintenance/doctype/maintenance_schedule/maintenance_schedule.js:65
 #: erpnext/maintenance/doctype/maintenance_schedule_item/maintenance_schedule_item.json
@@ -46315,7 +46310,7 @@ msgstr "لا يتم اعتماد أمر التوريد {0}\\n<br>\\nSales Order 
 msgid "Sales Order {0} is not valid"
 msgstr "أمر البيع {0} غير موجود\\n<br>\\nSales Order {0} is not valid"
 
-#: erpnext/controllers/selling_controller.py:443
+#: erpnext/controllers/selling_controller.py:451
 #: erpnext/manufacturing/doctype/work_order/work_order.py:301
 msgid "Sales Order {0} is {1}"
 msgstr "طلب المبيعات {0} هو {1}"
@@ -46366,7 +46361,7 @@ msgstr "أوامر المبيعات لتقديم"
 #: erpnext/accounts/doctype/promotional_scheme/promotional_scheme.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:122
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1156
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1158
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:99
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:194
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:74
@@ -46464,7 +46459,7 @@ msgstr "ملخص دفع المبيعات"
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:156
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:137
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:128
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1153
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1155
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:105
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:191
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:80
@@ -46484,7 +46479,7 @@ msgstr "ملخص دفع المبيعات"
 msgid "Sales Person"
 msgstr "مندوب مبيعات"
 
-#: erpnext/controllers/selling_controller.py:204
+#: erpnext/controllers/selling_controller.py:212
 msgid "Sales Person <b>{0}</b> is disabled."
 msgstr ""
 
@@ -46765,7 +46760,7 @@ msgstr "مستودع الاحتفاظ بالعينات"
 
 #. Label of the sample_size (Float) field in DocType 'Quality Inspection'
 #: erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py:93
-#: erpnext/public/js/controllers/transaction.js:2369
+#: erpnext/public/js/controllers/transaction.js:2395
 #: erpnext/stock/doctype/quality_inspection/quality_inspection.json
 msgid "Sample Size"
 msgstr "حجم العينة"
@@ -47303,7 +47298,7 @@ msgstr "اختيار العناصر"
 msgid "Select Items based on Delivery Date"
 msgstr "حدد العناصر بناءً على تاريخ التسليم"
 
-#: erpnext/public/js/controllers/transaction.js:2405
+#: erpnext/public/js/controllers/transaction.js:2431
 msgid "Select Items for Quality Inspection"
 msgstr ""
 
@@ -47444,7 +47439,7 @@ msgstr "اختر الشركة أولا"
 msgid "Select company name first."
 msgstr "حدد اسم الشركة الأول."
 
-#: erpnext/controllers/accounts_controller.py:2785
+#: erpnext/controllers/accounts_controller.py:2788
 msgid "Select finance book for the item {0} at row {1}"
 msgstr "حدد دفتر تمويل للعنصر {0} في الصف {1}"
 
@@ -47657,7 +47652,7 @@ msgid "Send Now"
 msgstr "أرسل الآن"
 
 #. Label of the send_sms (Button) field in DocType 'SMS Center'
-#: erpnext/public/js/controllers/transaction.js:517
+#: erpnext/public/js/controllers/transaction.js:543
 #: erpnext/selling/doctype/sms_center/sms_center.json
 msgid "Send SMS"
 msgstr "SMS أرسل رسالة"
@@ -47815,7 +47810,7 @@ msgstr ""
 #: erpnext/manufacturing/doctype/job_card/job_card.json
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.js:74
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.py:114
-#: erpnext/public/js/controllers/transaction.js:2382
+#: erpnext/public/js/controllers/transaction.js:2408
 #: erpnext/public/js/utils/serial_no_batch_selector.js:421
 #: erpnext/selling/doctype/installation_note_item/installation_note_item.json
 #: erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
@@ -47864,7 +47859,7 @@ msgstr ""
 msgid "Serial No Range"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1894
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1895
 msgid "Serial No Reserved"
 msgstr ""
 
@@ -47904,7 +47899,7 @@ msgstr "الرقم التسلسلي والدفعة"
 msgid "Serial No and Batch Selector cannot be use when Use Serial / Batch Fields is enabled."
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:859
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:860
 msgid "Serial No is mandatory"
 msgstr ""
 
@@ -47933,7 +47928,7 @@ msgstr "الرقم المتسلسل {0} لا ينتمي إلى البند {1}\\n
 msgid "Serial No {0} does not exist"
 msgstr "الرقم المتسلسل {0} غير موجود\\n<br>\\nSerial No {0} does not exist"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2623
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2624
 msgid "Serial No {0} does not exists"
 msgstr ""
 
@@ -47941,7 +47936,7 @@ msgstr ""
 msgid "Serial No {0} is already added"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:357
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:358
 msgid "Serial No {0} is not present in the {1} {2}, hence you can't return it against the {1} {2}"
 msgstr ""
 
@@ -47978,11 +47973,11 @@ msgstr ""
 msgid "Serial Nos and Batches"
 msgstr "الرقم التسلسلي ودفعات"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1370
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1371
 msgid "Serial Nos are created successfully"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:2137
+#: erpnext/stock/stock_ledger.py:2145
 msgid "Serial Nos are reserved in Stock Reservation Entries, you need to unreserve them before proceeding."
 msgstr ""
 
@@ -48056,11 +48051,11 @@ msgstr ""
 msgid "Serial and Batch Bundle"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1598
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1599
 msgid "Serial and Batch Bundle created"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1664
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1665
 msgid "Serial and Batch Bundle updated"
 msgstr ""
 
@@ -48412,12 +48407,12 @@ msgid "Service Stop Date"
 msgstr "تاريخ توقف الخدمة"
 
 #: erpnext/accounts/deferred_revenue.py:44
-#: erpnext/public/js/controllers/transaction.js:1420
+#: erpnext/public/js/controllers/transaction.js:1446
 msgid "Service Stop Date cannot be after Service End Date"
 msgstr "لا يمكن أن يكون تاريخ إيقاف الخدمة بعد تاريخ انتهاء الخدمة"
 
 #: erpnext/accounts/deferred_revenue.py:41
-#: erpnext/public/js/controllers/transaction.js:1417
+#: erpnext/public/js/controllers/transaction.js:1443
 msgid "Service Stop Date cannot be before Service Start Date"
 msgstr "لا يمكن أن يكون تاريخ إيقاف الخدمة قبل تاريخ بدء الخدمة"
 
@@ -49852,7 +49847,7 @@ msgstr ""
 
 #: erpnext/setup/setup_wizard/operations/defaults_setup.py:70
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:463
-#: erpnext/stock/doctype/item/item.py:245
+#: erpnext/stock/doctype/item/item.py:248
 msgid "Standard Selling"
 msgstr "البيع القياسية"
 
@@ -50682,7 +50677,7 @@ msgstr "المخزون المتلقي ولكن غير مفوتر"
 #. Option for the 'Purpose' (Select) field in DocType 'Stock Reconciliation'
 #. Label of a Link in the Stock Workspace
 #: erpnext/setup/workspace/home/home.json
-#: erpnext/stock/doctype/item/item.py:612
+#: erpnext/stock/doctype/item/item.py:618
 #: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.json
 #: erpnext/stock/workspace/stock/stock.json
 msgid "Stock Reconciliation"
@@ -50693,7 +50688,7 @@ msgstr "جرد المخزون"
 msgid "Stock Reconciliation Item"
 msgstr "جرد عناصر المخزون"
 
-#: erpnext/stock/doctype/item/item.py:612
+#: erpnext/stock/doctype/item/item.py:618
 msgid "Stock Reconciliations"
 msgstr "تسويات المخزون"
 
@@ -50728,7 +50723,7 @@ msgstr ""
 #: erpnext/stock/doctype/pick_list/pick_list.js:150
 #: erpnext/stock/doctype/pick_list/pick_list.js:155
 #: erpnext/stock/doctype/stock_entry/stock_entry_dashboard.py:25
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:706
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:702
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:575
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:1138
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:1398
@@ -51128,7 +51123,7 @@ msgstr "لا يمكن إلغاء طلب العمل المتوقف ، قم بإل
 #: erpnext/setup/doctype/company/company.py:287
 #: erpnext/setup/setup_wizard/operations/defaults_setup.py:33
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:502
-#: erpnext/stock/doctype/item/item.py:282
+#: erpnext/stock/doctype/item/item.py:285
 msgid "Stores"
 msgstr "مخازن"
 
@@ -51663,7 +51658,7 @@ msgstr "تمت التسوية بنجاح\\n<br>\\nSuccessfully Reconciled"
 msgid "Successfully Set Supplier"
 msgstr "بنجاح تعيين المورد"
 
-#: erpnext/stock/doctype/item/item.py:339
+#: erpnext/stock/doctype/item/item.py:342
 msgid "Successfully changed Stock UOM, please redefine conversion factors for new UOM."
 msgstr ""
 
@@ -51965,7 +51960,7 @@ msgstr "تفاصيل المورد"
 #: erpnext/accounts/doctype/tax_rule/tax_rule.json
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:111
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:87
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1160
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1162
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:198
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:237
 #: erpnext/accounts/report/purchase_register/purchase_register.js:27
@@ -52065,7 +52060,7 @@ msgstr "ملخص دفتر الأستاذ"
 #. Label of the supplier_name (Data) field in DocType 'Purchase Receipt'
 #. Label of the supplier_name (Data) field in DocType 'Stock Entry'
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1077
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1079
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:156
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:198
 #: erpnext/accounts/report/purchase_register/purchase_register.py:177
@@ -52549,7 +52544,7 @@ msgstr ""
 msgid "System will fetch all the entries if limit value is zero."
 msgstr "سيقوم النظام بجلب كل الإدخالات إذا كانت قيمة الحد صفرا."
 
-#: erpnext/controllers/accounts_controller.py:1975
+#: erpnext/controllers/accounts_controller.py:1978
 msgid "System will not check over billing since amount for Item {0} in {1} is zero"
 msgstr ""
 
@@ -52808,7 +52803,7 @@ msgstr ""
 msgid "Target Warehouse is required before Submit"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:782
+#: erpnext/controllers/selling_controller.py:790
 msgid "Target Warehouse is set for some items but the customer is not an internal customer."
 msgstr ""
 
@@ -53047,7 +53042,7 @@ msgstr "تفكيك الضرائب"
 msgid "Tax Category"
 msgstr "الفئة الضريبية"
 
-#: erpnext/controllers/buying_controller.py:194
+#: erpnext/controllers/buying_controller.py:202
 msgid "Tax Category has been changed to \"Total\" because all the Items are non-stock items"
 msgstr "تم تغيير فئة الضرائب إلى &quot;توتال&quot; لأن جميع العناصر هي عناصر غير مخزون"
 
@@ -53252,7 +53247,7 @@ msgstr ""
 #. Label of the taxable_amount (Currency) field in DocType 'Tax Withheld
 #. Vouchers'
 #: erpnext/accounts/doctype/tax_withheld_vouchers/tax_withheld_vouchers.json
-#: erpnext/controllers/taxes_and_totals.py:1125
+#: erpnext/controllers/taxes_and_totals.py:1135
 msgid "Taxable Amount"
 msgstr "المبلغ الخاضع للضريبة"
 
@@ -53391,7 +53386,7 @@ msgstr "خصم الضرائب والرسوم"
 msgid "Taxes and Charges Deducted (Company Currency)"
 msgstr "الضرائب والرسوم مقطوعة (عملة الشركة)"
 
-#: erpnext/stock/doctype/item/item.py:352
+#: erpnext/stock/doctype/item/item.py:355
 msgid "Taxes row #{0}: {1} cannot be smaller than {2}"
 msgstr ""
 
@@ -53677,7 +53672,7 @@ msgstr "قالب الشروط والأحكام"
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/territory_item/territory_item.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:134
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1144
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1146
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:93
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:182
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:68
@@ -53781,7 +53776,7 @@ msgstr "تم تعطيل الوصول إلى طلب عرض الأسعار من ا
 msgid "The BOM which will be replaced"
 msgstr "وBOM التي سيتم استبدالها"
 
-#: erpnext/stock/serial_batch_bundle.py:1274
+#: erpnext/stock/serial_batch_bundle.py:1306
 msgid "The Batch {0} has negative quantity {1} in warehouse {2}. Please correct the quantity."
 msgstr ""
 
@@ -53833,7 +53828,7 @@ msgstr ""
 msgid "The Serial No at Row #{0}: {1} is not available in warehouse {2}."
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1891
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1892
 msgid "The Serial No {0} is reserved against the {1} {2} and cannot be used for any other transaction."
 msgstr ""
 
@@ -53916,7 +53911,7 @@ msgstr ""
 msgid "The following batches are expired, please restock them: <br> {0}"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:849
+#: erpnext/stock/doctype/item/item.py:843
 msgid "The following deleted attributes exist in Variants but not in the Template. You can either delete the Variants or keep the attribute(s) in template."
 msgstr "توجد السمات المحذوفة التالية في المتغيرات ولكن ليس في القالب. يمكنك إما حذف المتغيرات أو الاحتفاظ بالسمة (السمات) في القالب."
 
@@ -53941,15 +53936,15 @@ msgstr "الوزن الكلي للحزمة. الوزن الصافي عادة + �
 msgid "The holiday on {0} is not between From Date and To Date"
 msgstr "عطلة على {0} ليست بين من تاريخ وإلى تاريخ"
 
-#: erpnext/controllers/buying_controller.py:1066
+#: erpnext/controllers/buying_controller.py:1074
 msgid "The item {item} is not marked as {type_of} item. You can enable it as {type_of} item from its Item master."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:614
+#: erpnext/stock/doctype/item/item.py:620
 msgid "The items {0} and {1} are present in the following {2} :"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:1059
+#: erpnext/controllers/buying_controller.py:1067
 msgid "The items {items} are not marked as {type_of} item. You can enable them as {type_of} item from their Item masters."
 msgstr ""
 
@@ -54051,8 +54046,8 @@ msgstr "العنصر المحدد لا يمكن أن يكون دفعة"
 msgid "The seller and the buyer cannot be the same"
 msgstr "البائع والمشتري لا يمكن أن يكون هو نفسه"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:142
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:154
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:143
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:155
 msgid "The serial and batch bundle {0} not linked to {1} {2}"
 msgstr ""
 
@@ -54076,7 +54071,7 @@ msgstr "الأسهم غير موجودة مع {0}"
 msgid "The stock for the item {0} in the {1} warehouse was negative on the {2}. You should create a positive entry {3} before the date {4} and time {5} to post the correct valuation rate. For more details, please read the <a href='https://docs.erpnext.com/docs/user/manual/en/stock-adjustment-cogs-with-negative-stock'>documentation<a>."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:700
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:696
 msgid "The stock has been reserved for the following Items and Warehouses, un-reserve the same to {0} the Stock Reconciliation: <br /><br /> {1}"
 msgstr ""
 
@@ -54089,11 +54084,11 @@ msgstr ""
 msgid "The task has been enqueued as a background job."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:994
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:990
 msgid "The task has been enqueued as a background job. In case there is any issue on processing in background, the system will add a comment about the error on this Stock Reconciliation and revert to the Draft stage"
 msgstr "وقد تم إرساء المهمة كعمل خلفية. في حالة وجود أي مشكلة في المعالجة في الخلفية ، سيقوم النظام بإضافة تعليق حول الخطأ في تسوية المخزون هذا والعودة إلى مرحلة المسودة"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1005
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1001
 msgid "The task has been enqueued as a background job. In case there is any issue on processing in background, the system will add a comment about the error on this Stock Reconciliation and revert to the Submitted stage"
 msgstr ""
 
@@ -54143,7 +54138,7 @@ msgstr ""
 msgid "The {0} ({1}) must be equal to {2} ({3})"
 msgstr "يجب أن يكون {0} ({1}) مساويًا لـ {2} ({3})"
 
-#: erpnext/public/js/controllers/transaction.js:2790
+#: erpnext/public/js/controllers/transaction.js:2816
 msgid "The {0} contains Unit Price Items."
 msgstr ""
 
@@ -54191,7 +54186,7 @@ msgstr ""
 msgid "There can be multiple tiered collection factor based on the total spent. But the conversion factor for redemption will always be same for all the tier."
 msgstr ""
 
-#: erpnext/accounts/party.py:580
+#: erpnext/accounts/party.py:586
 msgid "There can only be 1 Account per Company in {0} {1}"
 msgstr "يمكن أن يكون هناك سوى 1 في حساب الشركة في {0} {1}"
 
@@ -54477,7 +54472,7 @@ msgstr "سيتم إلحاق هذا إلى بند رمز للمتغير. على �
 msgid "This will restrict user access to other employee records"
 msgstr "سيؤدي هذا إلى تقييد وصول المستخدم لسجلات الموظفين الأخرى"
 
-#: erpnext/controllers/selling_controller.py:783
+#: erpnext/controllers/selling_controller.py:791
 msgid "This {} will be treated as material transfer."
 msgstr ""
 
@@ -55191,11 +55186,11 @@ msgid "To include sub-assembly costs and scrap items in Finished Goods on a work
 msgstr ""
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:2337
-#: erpnext/controllers/accounts_controller.py:3005
+#: erpnext/controllers/accounts_controller.py:3008
 msgid "To include tax in row {0} in Item rate, taxes in rows {1} must also be included"
 msgstr "ل تشمل الضريبة في الصف {0} في معدل الإغلاق ، {1} ويجب أيضا تضمين الضرائب في الصفوف"
 
-#: erpnext/stock/doctype/item/item.py:636
+#: erpnext/stock/doctype/item/item.py:642
 msgid "To merge, following properties must be same for both items"
 msgstr "لدمج ، يجب أن يكون نفس الخصائص التالية ل كلا البندين"
 
@@ -55815,7 +55810,7 @@ msgstr "إجمالي المبلغ المستحق"
 msgid "Total Paid Amount"
 msgstr "إجمالي المبلغ المدفوع"
 
-#: erpnext/controllers/accounts_controller.py:2591
+#: erpnext/controllers/accounts_controller.py:2594
 msgid "Total Payment Amount in Payment Schedule must be equal to Grand / Rounded Total"
 msgstr "يجب أن يكون إجمالي مبلغ الدفع في جدول الدفع مساويا للمجموع الكبير / المستدير"
 
@@ -56100,15 +56095,15 @@ msgstr ""
 msgid "Total Working Hours"
 msgstr "مجموع ساعات العمل"
 
-#: erpnext/controllers/accounts_controller.py:2138
+#: erpnext/controllers/accounts_controller.py:2141
 msgid "Total advance ({0}) against Order {1} cannot be greater than the Grand Total ({2})"
 msgstr "مجموع مقدما ({0}) ضد النظام {1} لا يمكن أن يكون أكبر من المجموع الكلي ({2})"
 
-#: erpnext/controllers/selling_controller.py:190
+#: erpnext/controllers/selling_controller.py:198
 msgid "Total allocated percentage for sales team should be 100"
 msgstr "مجموع النسبة المئوية المخصصة ل فريق المبيعات يجب أن يكون 100"
 
-#: erpnext/selling/doctype/customer/customer.py:162
+#: erpnext/selling/doctype/customer/customer.py:161
 msgid "Total contribution percentage should be equal to 100"
 msgstr "يجب أن تكون نسبة المساهمة الإجمالية مساوية 100"
 
@@ -56993,7 +56988,7 @@ msgstr "وحدة القياس"
 msgid "Unit of Measure (UOM)"
 msgstr "وحدة القياس"
 
-#: erpnext/stock/doctype/item/item.py:384
+#: erpnext/stock/doctype/item/item.py:387
 msgid "Unit of Measure {0} has been entered more than once in Conversion Factor Table"
 msgstr "وحدة القياس {0} تم إدخال أكثر من مرة واحدة في معامل التحويل الجدول"
 
@@ -57435,7 +57430,7 @@ msgstr ""
 msgid "Update timestamp on new communication"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom_creator/bom_creator.py:533
+#: erpnext/manufacturing/doctype/bom_creator/bom_creator.py:534
 msgid "Updated successfully"
 msgstr "تم التحديث بنجاح"
 
@@ -57449,7 +57444,7 @@ msgstr "تم التحديث بنجاح"
 msgid "Updated via 'Time Log' (In Minutes)"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1387
+#: erpnext/stock/doctype/item/item.py:1381
 msgid "Updating Variants..."
 msgstr "جارٍ تحديث المتغيرات ..."
 
@@ -58007,19 +58002,19 @@ msgstr "سعر التقييم"
 msgid "Valuation Rate (In / Out)"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1881
+#: erpnext/stock/stock_ledger.py:1890
 msgid "Valuation Rate Missing"
 msgstr "معدل التقييم مفقود"
 
-#: erpnext/stock/stock_ledger.py:1859
+#: erpnext/stock/stock_ledger.py:1868
 msgid "Valuation Rate for the Item {0}, is required to do accounting entries for {1} {2}."
 msgstr "معدل التقييم للعنصر {0} ، مطلوب لإجراء إدخالات محاسبية لـ {1} {2}."
 
-#: erpnext/stock/doctype/item/item.py:266
+#: erpnext/stock/doctype/item/item.py:269
 msgid "Valuation Rate is mandatory if Opening Stock entered"
 msgstr "معدل التقييم إلزامي إذا ادخلت قيمة مبدئية للمخزون\\n<br>\\nValuation Rate is mandatory if Opening Stock entered"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:752
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:748
 msgid "Valuation Rate required for Item {0} at row {1}"
 msgstr "معدل التقييم مطلوب للبند {0} في الصف {1}"
 
@@ -58029,7 +58024,7 @@ msgstr "معدل التقييم مطلوب للبند {0} في الصف {1}"
 msgid "Valuation and Total"
 msgstr "التقييم والمجموع"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:971
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:967
 msgid "Valuation rate for customer provided items has been set to zero."
 msgstr ""
 
@@ -58043,7 +58038,7 @@ msgid "Valuation rate for the item as per Sales Invoice (Only for Internal Trans
 msgstr ""
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:2361
-#: erpnext/controllers/accounts_controller.py:3029
+#: erpnext/controllers/accounts_controller.py:3032
 msgid "Valuation type charges can not be marked as Inclusive"
 msgstr "لا يمكن تحديد رسوم نوع التقييم على أنها شاملة"
 
@@ -58199,7 +58194,7 @@ msgstr "التباين ({})"
 msgid "Variant"
 msgstr "مختلف"
 
-#: erpnext/stock/doctype/item/item.py:864
+#: erpnext/stock/doctype/item/item.py:858
 msgid "Variant Attribute Error"
 msgstr "خطأ في سمة المتغير"
 
@@ -58218,7 +58213,7 @@ msgstr "المتغير BOM"
 msgid "Variant Based On"
 msgstr "البديل القائم على"
 
-#: erpnext/stock/doctype/item/item.py:892
+#: erpnext/stock/doctype/item/item.py:886
 msgid "Variant Based On cannot be changed"
 msgstr "لا يمكن تغيير المتغير بناءً على"
 
@@ -58236,7 +58231,7 @@ msgstr "الحقل البديل"
 msgid "Variant Item"
 msgstr "عنصر متغير"
 
-#: erpnext/stock/doctype/item/item.py:862
+#: erpnext/stock/doctype/item/item.py:856
 msgid "Variant Items"
 msgstr "العناصر المتغيرة"
 
@@ -58354,7 +58349,7 @@ msgstr "اعدادات الفيديو"
 #: erpnext/accounts/doctype/cost_center/cost_center_tree.js:56
 #: erpnext/accounts/doctype/invoice_discounting/invoice_discounting.js:205
 #: erpnext/accounts/doctype/journal_entry/journal_entry.js:43
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:668
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:670
 #: erpnext/bulk_transaction/doctype/bulk_transaction_log/bulk_transaction_log.js:14
 #: erpnext/bulk_transaction/doctype/bulk_transaction_log/bulk_transaction_log.js:24
 #: erpnext/buying/doctype/request_for_quotation/request_for_quotation.js:167
@@ -58541,7 +58536,7 @@ msgstr ""
 #: erpnext/accounts/doctype/repost_accounting_ledger_items/repost_accounting_ledger_items.json
 #: erpnext/accounts/doctype/repost_payment_ledger_items/repost_payment_ledger_items.json
 #: erpnext/accounts/doctype/unreconcile_payment/unreconcile_payment.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1099
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1101
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.js:42
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:209
 #: erpnext/accounts/report/general_ledger/general_ledger.js:49
@@ -58572,7 +58567,7 @@ msgstr ""
 msgid "Voucher No"
 msgstr "رقم السند"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1087
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1088
 msgid "Voucher No is mandatory"
 msgstr ""
 
@@ -58614,7 +58609,7 @@ msgstr ""
 #: erpnext/accounts/doctype/repost_payment_ledger_items/repost_payment_ledger_items.json
 #: erpnext/accounts/doctype/tax_withheld_vouchers/tax_withheld_vouchers.json
 #: erpnext/accounts/doctype/unreconcile_payment/unreconcile_payment.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1097
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1099
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:200
 #: erpnext/accounts/report/general_ledger/general_ledger.py:697
 #: erpnext/accounts/report/invalid_ledger_entries/invalid_ledger_entries.py:31
@@ -58968,10 +58963,6 @@ msgstr "المستودع إلزامي"
 msgid "Warehouse not found against the account {0}"
 msgstr "لم يتم العثور على المستودع مقابل الحساب {0}"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:600
-msgid "Warehouse not found in the system"
-msgstr "لم يتم العثور على المستودع في النظام"
-
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:1130
 #: erpnext/stock/doctype/delivery_note/delivery_note.py:414
 msgid "Warehouse required for stock Item {0}"
@@ -59100,7 +59091,7 @@ msgid "Warn for new Request for Quotations"
 msgstr "تحذير لطلب جديد للاقتباسات"
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:744
-#: erpnext/controllers/accounts_controller.py:1978
+#: erpnext/controllers/accounts_controller.py:1981
 #: erpnext/stock/doctype/delivery_trip/delivery_trip.js:145
 #: erpnext/utilities/transaction_base.py:123
 msgid "Warning"
@@ -60072,7 +60063,7 @@ msgstr "نعم"
 msgid "You are importing data for the code list:"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3611
+#: erpnext/controllers/accounts_controller.py:3614
 msgid "You are not allowed to update as per the conditions set in {} Workflow."
 msgstr "غير مسموح لك بالتحديث وفقًا للشروط المحددة في {} سير العمل."
 
@@ -60137,7 +60128,7 @@ msgstr ""
 msgid "You can't make any changes to Job Card since Work Order is closed."
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:185
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:186
 msgid "You can't process the serial number {0} as it has already been used in the SABB {1}. {2} if you want to inward same serial number multiple times then enabled 'Allow existing Serial No to be Manufactured/Received again' in the {3}"
 msgstr ""
 
@@ -60197,7 +60188,7 @@ msgstr "لا يمكنك تقديم الطلب بدون دفع."
 msgid "You cannot {0} this document because another Period Closing Entry {1} exists after {2}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3587
+#: erpnext/controllers/accounts_controller.py:3590
 msgid "You do not have permissions to {} items in a {}."
 msgstr "ليس لديك أذونات لـ {} من العناصر في {}."
 
@@ -60225,7 +60216,7 @@ msgstr ""
 msgid "You have entered a duplicate Delivery Note on Row"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1063
+#: erpnext/stock/doctype/item/item.py:1057
 msgid "You have to enable auto re-order in Stock Settings to maintain re-order levels."
 msgstr "يجب عليك تمكين الطلب التلقائي في إعدادات الأسهم للحفاظ على مستويات إعادة الطلب."
 
@@ -60245,7 +60236,7 @@ msgstr "يجب عليك تحديد عميل قبل إضافة عنصر."
 msgid "You need to cancel POS Closing Entry {} to be able to cancel this document."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2980
+#: erpnext/controllers/accounts_controller.py:2983
 msgid "You selected the account group {1} as {2} Account in row {0}. Please select a single account."
 msgstr ""
 
@@ -60323,7 +60314,7 @@ msgstr "[هام] [ERPNext] إعادة ترتيب الأخطاء تلقائيًا
 msgid "`Allow Negative rates for Items`"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1873
+#: erpnext/stock/stock_ledger.py:1882
 msgid "after"
 msgstr ""
 
@@ -60471,7 +60462,7 @@ msgstr "LFT"
 msgid "material_request_item"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:151
+#: erpnext/controllers/selling_controller.py:159
 msgid "must be between 0 and 100"
 msgstr ""
 
@@ -60496,7 +60487,7 @@ msgstr ""
 msgid "on"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1289
+#: erpnext/controllers/accounts_controller.py:1292
 msgid "or"
 msgstr "أو"
 
@@ -60545,7 +60536,7 @@ msgstr ""
 msgid "per hour"
 msgstr "كل ساعة"
 
-#: erpnext/stock/stock_ledger.py:1874
+#: erpnext/stock/stock_ledger.py:1883
 msgid "performing either one below:"
 msgstr ""
 
@@ -60672,7 +60663,7 @@ msgstr "يجب عليك تحديد حساب رأس المال قيد التقد�
 msgid "{0}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1109
+#: erpnext/controllers/accounts_controller.py:1112
 msgid "{0} '{1}' is disabled"
 msgstr "{0} '{1}' معطل"
 
@@ -60688,7 +60679,7 @@ msgstr "{0} ({1}) لا يمكن أن يكون أكبر من الكمية الم�
 msgid "{0} <b>{1}</b> has submitted Assets. Remove Item <b>{2}</b> from table to continue."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2193
+#: erpnext/controllers/accounts_controller.py:2196
 msgid "{0} Account not found against Customer {1}."
 msgstr ""
 
@@ -60720,7 +60711,7 @@ msgstr "{0} العمليات: {1}"
 msgid "{0} Request for {1}"
 msgstr "{0} طلب {1}"
 
-#: erpnext/stock/doctype/item/item.py:323
+#: erpnext/stock/doctype/item/item.py:326
 msgid "{0} Retain Sample is based on batch, please check Has Batch No to retain sample of item"
 msgstr "{0} يعتمد الاحتفاظ بالعينة على الدُفعة ، يُرجى تحديد &quot;رقم الدُفعة&quot; للاحتفاظ بعينة من العنصر"
 
@@ -60811,7 +60802,7 @@ msgid "{0} entered twice in Item Tax"
 msgstr "{0} ادخل مرتين في ضريبة البند"
 
 #: erpnext/setup/doctype/item_group/item_group.py:48
-#: erpnext/stock/doctype/item/item.py:436
+#: erpnext/stock/doctype/item/item.py:439
 msgid "{0} entered twice {1} in Item Taxes"
 msgstr ""
 
@@ -60832,7 +60823,7 @@ msgstr "{0} تم التقديم بنجاح"
 msgid "{0} hours"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2534
+#: erpnext/controllers/accounts_controller.py:2537
 msgid "{0} in row {1}"
 msgstr "{0} في الحقل {1}"
 
@@ -60856,7 +60847,7 @@ msgstr "تم حظر {0} حتى لا تتم متابعة هذه المعاملة"
 
 #: erpnext/accounts/doctype/budget/budget.py:60
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:643
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:49
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:50
 #: erpnext/accounts/report/general_ledger/general_ledger.py:59
 #: erpnext/accounts/report/pos_register/pos_register.py:107
 #: erpnext/controllers/trends.py:50
@@ -60876,11 +60867,11 @@ msgstr ""
 msgid "{0} is mandatory. Maybe Currency Exchange record is not created for {1} to {2}"
 msgstr "{0} إلزامي. ربما لم يتم إنشاء سجل صرف العملات من {1} إلى {2}"
 
-#: erpnext/controllers/accounts_controller.py:2937
+#: erpnext/controllers/accounts_controller.py:2940
 msgid "{0} is mandatory. Maybe Currency Exchange record is not created for {1} to {2}."
 msgstr "{0} إلزامي. ربما لم يتم إنشاء سجل سعر صرف العملة ل{1} إلى {2}."
 
-#: erpnext/selling/doctype/customer/customer.py:204
+#: erpnext/selling/doctype/customer/customer.py:203
 msgid "{0} is not a company bank account"
 msgstr "{0} ليس حسابًا مصرفيًا للشركة"
 
@@ -60963,7 +60954,7 @@ msgstr ""
 msgid "{0} to {1}"
 msgstr "{0} إلى {1}"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:690
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:686
 msgid "{0} units are reserved for Item {1} in Warehouse {2}, please un-reserve the same to {3} the Stock Reconciliation."
 msgstr ""
 
@@ -60979,16 +60970,16 @@ msgstr ""
 msgid "{0} units of {1} are required in {2} with the inventory dimension: {3} ({4}) on {5} {6} for {7} to complete the transaction."
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1532 erpnext/stock/stock_ledger.py:2023
-#: erpnext/stock/stock_ledger.py:2037
+#: erpnext/stock/stock_ledger.py:1541 erpnext/stock/stock_ledger.py:2031
+#: erpnext/stock/stock_ledger.py:2045
 msgid "{0} units of {1} needed in {2} on {3} {4} for {5} to complete this transaction."
 msgstr "{0} وحدات من {1} لازمة ل {2} في {3} {4} ل {5} لإكمال هذه المعاملة."
 
-#: erpnext/stock/stock_ledger.py:2124 erpnext/stock/stock_ledger.py:2170
+#: erpnext/stock/stock_ledger.py:2132 erpnext/stock/stock_ledger.py:2178
 msgid "{0} units of {1} needed in {2} on {3} {4} to complete this transaction."
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1526
+#: erpnext/stock/stock_ledger.py:1535
 msgid "{0} units of {1} needed in {2} to complete this transaction."
 msgstr "{0} وحدات من  {1} لازمة في {2} لإكمال هذه المعاملة."
 
@@ -61034,7 +61025,7 @@ msgstr "{0} {1} إنشاء"
 msgid "{0} {1} does not exist"
 msgstr "{0} {1} غير موجود\\n<br>\\n{0} {1} does not exist"
 
-#: erpnext/accounts/party.py:560
+#: erpnext/accounts/party.py:566
 msgid "{0} {1} has accounting entries in currency {2} for company {3}. Please select a receivable or payable account with currency {2}."
 msgstr "{0} يحتوي {1} على إدخالات محاسبية بالعملة {2} للشركة {3}. الرجاء تحديد حساب مستحق أو دائن بالعملة {2}."
 
@@ -61068,7 +61059,7 @@ msgstr ""
 msgid "{0} {1} is associated with {2}, but Party Account is {3}"
 msgstr "{0} {1} مرتبط ب {2}، ولكن حساب الطرف هو {3}"
 
-#: erpnext/controllers/selling_controller.py:462
+#: erpnext/controllers/selling_controller.py:470
 #: erpnext/controllers/subcontracting_controller.py:954
 msgid "{0} {1} is cancelled or closed"
 msgstr "{0} {1} تم إلغائه أو مغلق"
@@ -61085,11 +61076,11 @@ msgstr "{0} {1} تم إلغاؤه لذلك لا يمكن إكمال الإجرا
 msgid "{0} {1} is closed"
 msgstr "{0} {1} مغلقة"
 
-#: erpnext/accounts/party.py:798
+#: erpnext/accounts/party.py:804
 msgid "{0} {1} is disabled"
 msgstr "{0} {1} معطل"
 
-#: erpnext/accounts/party.py:804
+#: erpnext/accounts/party.py:810
 msgid "{0} {1} is frozen"
 msgstr "{0} {1} مجمد"
 
@@ -61097,7 +61088,7 @@ msgstr "{0} {1} مجمد"
 msgid "{0} {1} is fully billed"
 msgstr "{0} {1} قدمت الفواتير بشكل كامل"
 
-#: erpnext/accounts/party.py:808
+#: erpnext/accounts/party.py:814
 msgid "{0} {1} is not active"
 msgstr "{0} {1} غير نشطة"
 
@@ -61223,15 +61214,15 @@ msgstr "{0}: {1} غير موجود"
 msgid "{0}: {1} must be less than {2}"
 msgstr "{0}: {1} يجب أن يكون أقل من {2}"
 
-#: erpnext/controllers/buying_controller.py:840
+#: erpnext/controllers/buying_controller.py:848
 msgid "{count} Assets created for {item_code}"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:738
+#: erpnext/controllers/buying_controller.py:746
 msgid "{doctype} {name} is cancelled or closed."
 msgstr "{doctype} {name} تم إلغائه أو مغلق."
 
-#: erpnext/controllers/buying_controller.py:459
+#: erpnext/controllers/buying_controller.py:467
 msgid "{field_label} is mandatory for sub-contracted {doctype}."
 msgstr ""
 
@@ -61239,7 +61230,7 @@ msgstr ""
 msgid "{item_name}'s Sample Size ({sample_size}) cannot be greater than the Accepted Quantity ({accepted_quantity})"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:563
+#: erpnext/controllers/buying_controller.py:571
 msgid "{ref_doctype} {ref_name} is {status}."
 msgstr ""
 
@@ -61305,7 +61296,7 @@ msgstr ""
 msgid "{} can't be cancelled since the Loyalty Points earned has been redeemed. First cancel the {} No {}"
 msgstr "لا يمكن إلغاء {} نظرًا لاسترداد نقاط الولاء المكتسبة. قم أولاً بإلغاء {} لا {}"
 
-#: erpnext/controllers/buying_controller.py:222
+#: erpnext/controllers/buying_controller.py:230
 msgid "{} has submitted assets linked to it. You need to cancel the assets to create purchase return."
 msgstr "قام {} بتقديم أصول مرتبطة به. تحتاج إلى إلغاء الأصول لإنشاء عائد شراء."
 

--- a/erpnext/locale/bs.po
+++ b/erpnext/locale/bs.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: frappe\n"
 "Report-Msgid-Bugs-To: hello@frappe.io\n"
-"POT-Creation-Date: 2025-05-25 09:35+0000\n"
-"PO-Revision-Date: 2025-05-25 20:35\n"
+"POT-Creation-Date: 2025-06-01 09:36+0000\n"
+"PO-Revision-Date: 2025-06-01 21:35\n"
 "Last-Translator: hello@frappe.io\n"
 "Language-Team: Bosnian\n"
 "MIME-Version: 1.0\n"
@@ -83,15 +83,15 @@ msgstr " Podsklop"
 msgid " Summary"
 msgstr " Sažetak"
 
-#: erpnext/stock/doctype/item/item.py:235
+#: erpnext/stock/doctype/item/item.py:238
 msgid "\"Customer Provided Item\" cannot be Purchase Item also"
 msgstr "\"Artikal koji osigurava Klijent\" ne može biti Kupovni Artikal"
 
-#: erpnext/stock/doctype/item/item.py:237
+#: erpnext/stock/doctype/item/item.py:240
 msgid "\"Customer Provided Item\" cannot have Valuation Rate"
 msgstr "\"Artikal koju daje Klijent\" ne može imati Stopu Vrednovanja"
 
-#: erpnext/stock/doctype/item/item.py:313
+#: erpnext/stock/doctype/item/item.py:316
 msgid "\"Is Fixed Asset\" cannot be unchecked, as Asset record exists against the item"
 msgstr "Ne može se poništiti izbor opcije \"Fiksna Imovina\", jer postoji zapis imovine naspram artikla"
 
@@ -213,7 +213,7 @@ msgstr "% materijala fakturisano naspram ovog Prodajnog Naloga"
 msgid "% of materials delivered against this Sales Order"
 msgstr "% materijala dostavljenog naspram ovog Prodajnog Naloga"
 
-#: erpnext/controllers/accounts_controller.py:2197
+#: erpnext/controllers/accounts_controller.py:2200
 msgid "'Account' in the Accounting section of Customer {0}"
 msgstr "'Račun' u sekciji Knjigovodstvo Klijenta {0}"
 
@@ -225,15 +225,11 @@ msgstr "'Dozvoli višestruke Prodajne Naloge naspram Kupovnog Naloga Klijenta'"
 msgid "'Based On' and 'Group By' can not be same"
 msgstr "'Na Osnovu' i 'Grupiraj Po' ne mogu biti isti"
 
-#: erpnext/stock/report/product_bundle_balance/product_bundle_balance.py:233
-msgid "'Date' is required"
-msgstr "'Datum' je obavezan"
-
 #: erpnext/selling/report/inactive_customers/inactive_customers.py:18
 msgid "'Days Since Last Order' must be greater than or equal to zero"
 msgstr "'Dana od posljednje narudžbe' mora biti veći ili jednako nuli"
 
-#: erpnext/controllers/accounts_controller.py:2202
+#: erpnext/controllers/accounts_controller.py:2205
 msgid "'Default {0} Account' in Company {1}"
 msgstr "'Standard {0} račun' u Kompaniji {1}"
 
@@ -243,7 +239,7 @@ msgstr "Polje 'Unosi' ne može biti prazno"
 
 #: erpnext/stock/report/batch_item_expiry_status/batch_item_expiry_status.py:24
 #: erpnext/stock/report/batch_wise_balance_history/batch_wise_balance_history.py:120
-#: erpnext/stock/report/stock_analytics/stock_analytics.py:314
+#: erpnext/stock/report/stock_analytics/stock_analytics.py:313
 msgid "'From Date' is required"
 msgstr "'Od datuma' je obavezan"
 
@@ -251,7 +247,7 @@ msgstr "'Od datuma' je obavezan"
 msgid "'From Date' must be after 'To Date'"
 msgstr "'Od datuma' mora biti nakon 'Do datuma'"
 
-#: erpnext/stock/doctype/item/item.py:398
+#: erpnext/stock/doctype/item/item.py:401
 msgid "'Has Serial No' can not be 'Yes' for non-stock item"
 msgstr "'Ima Serijski Broj' ne može biti 'Da' za artikal koji nije na zalihama"
 
@@ -1173,7 +1169,7 @@ msgstr "Prihvaćena Količina u Jedinici Zaliha"
 
 #. Label of the qty (Float) field in DocType 'Purchase Receipt Item'
 #. Label of the qty (Float) field in DocType 'Subcontracting Receipt Item'
-#: erpnext/public/js/controllers/transaction.js:2362
+#: erpnext/public/js/controllers/transaction.js:2388
 #: erpnext/stock/doctype/purchase_receipt_item/purchase_receipt_item.json
 #: erpnext/subcontracting/doctype/subcontracting_receipt_item/subcontracting_receipt_item.json
 msgid "Accepted Quantity"
@@ -1371,7 +1367,7 @@ msgid "Account Manager"
 msgstr "Upravitelj Knjogovodstva"
 
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:949
-#: erpnext/controllers/accounts_controller.py:2206
+#: erpnext/controllers/accounts_controller.py:2209
 msgid "Account Missing"
 msgstr "Račun Nedostaje"
 
@@ -1546,7 +1542,7 @@ msgstr "Račun {0} je dodan u podređenu kompaniju {1}"
 msgid "Account {0} is frozen"
 msgstr "Račun {0} je zamrznut"
 
-#: erpnext/controllers/accounts_controller.py:1288
+#: erpnext/controllers/accounts_controller.py:1291
 msgid "Account {0} is invalid. Account Currency must be {1}"
 msgstr "Račun {0} je nevažeći. Valuta Računa mora biti {1}"
 
@@ -1582,7 +1578,7 @@ msgstr "Račun: {0} se može ažurirati samo putem Transakcija Zaliha"
 msgid "Account: {0} is not permitted under Payment Entry"
 msgstr "Račun: {0} nije dozvoljen pod Unos plaćanja"
 
-#: erpnext/controllers/accounts_controller.py:3037
+#: erpnext/controllers/accounts_controller.py:3040
 msgid "Account: {0} with currency: {1} can not be selected"
 msgstr "Račun: {0} sa valutom: {1} se ne može odabrati"
 
@@ -1855,7 +1851,7 @@ msgstr "Knjigovodstveni Unosi"
 msgid "Accounting Entry for Asset"
 msgstr "Knjigovodstveni Unos za Imovinu"
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:796
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:805
 msgid "Accounting Entry for Service"
 msgstr "Knjigovodstveni Unos za Servis"
 
@@ -1870,18 +1866,18 @@ msgstr "Knjigovodstveni Unos za Servis"
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py:1468
 #: erpnext/controllers/stock_controller.py:550
 #: erpnext/controllers/stock_controller.py:567
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:889
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:898
 #: erpnext/stock/doctype/stock_entry/stock_entry.py:1586
 #: erpnext/stock/doctype/stock_entry/stock_entry.py:1600
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py:561
 msgid "Accounting Entry for Stock"
 msgstr "Knjigovodstveni Unos za Zalihe"
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:717
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:726
 msgid "Accounting Entry for {0}"
 msgstr "Knjigovodstveni Unos za {0}"
 
-#: erpnext/controllers/accounts_controller.py:2247
+#: erpnext/controllers/accounts_controller.py:2250
 msgid "Accounting Entry for {0}: {1} can only be made in currency: {2}"
 msgstr "Knjigovodstveni Unos za {0}: {1} može se napraviti samo u valuti: {2}"
 
@@ -2274,7 +2270,7 @@ msgstr "Akumulirana Amortizacija na dan"
 msgid "Accumulated Monthly"
 msgstr "Mjesečno Akumulirano"
 
-#: erpnext/controllers/budget_controller.py:417
+#: erpnext/controllers/budget_controller.py:422
 msgid "Accumulated Monthly Budget for Account {0} against {1} {2} is {3}. It will be collectively ({4}) exceeded by {5}"
 msgstr "Akumulirani mjesečni proračun za račun {0} u odnosu na {1} {2} iznosi {3}. Zajedno će biti ({4}) premašen za {5}"
 
@@ -3388,7 +3384,7 @@ msgstr "Uskladi vrijednost imovine"
 msgid "Adjustment Against"
 msgstr "Usaglašavanje Naspram"
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:634
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:643
 msgid "Adjustment based on Purchase Invoice rate"
 msgstr "Usklađivanje na osnovu stope fakture nabavke"
 
@@ -3499,7 +3495,7 @@ msgstr "Predujam Poreza i Naknada"
 msgid "Advance amount"
 msgstr "Iznos Predujma"
 
-#: erpnext/controllers/taxes_and_totals.py:845
+#: erpnext/controllers/taxes_and_totals.py:855
 msgid "Advance amount cannot be greater than {0} {1}"
 msgstr "Iznos Predujma ne može biti veći od {0} {1}"
 
@@ -3710,7 +3706,7 @@ msgstr "Dob"
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:152
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:133
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1125
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1127
 msgid "Age (Days)"
 msgstr "Dob (Dana)"
 
@@ -3796,16 +3792,6 @@ msgstr "Spakujte grupu artikala u drugu artikal. Ovo je korisno ako održavate z
 #: erpnext/setup/setup_wizard/data/industry_type.txt:4
 msgid "Agriculture"
 msgstr "Poljoprivreda"
-
-#. Name of a role
-#: erpnext/assets/doctype/location/location.json
-msgid "Agriculture Manager"
-msgstr "Poljoprivredni Upravitelj"
-
-#. Name of a role
-#: erpnext/assets/doctype/location/location.json
-msgid "Agriculture User"
-msgstr "Poljoprivredni Korisnik"
 
 #: erpnext/setup/setup_wizard/data/industry_type.txt:5
 msgid "Airline"
@@ -3997,7 +3983,7 @@ msgstr "Sva komunikacija uključujući i iznad ovoga bit će premještena u novi
 msgid "All items are already requested"
 msgstr "Svi artikli su već traženi"
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:1317
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:1326
 msgid "All items have already been Invoiced/Returned"
 msgstr "Svi Artikli su već Fakturisani/Vraćeni"
 
@@ -4009,7 +3995,7 @@ msgstr "Svi Artikli su već primljeni"
 msgid "All items have already been transferred for this Work Order."
 msgstr "Svi Artikli su već prenesen za ovaj Radni Nalog."
 
-#: erpnext/public/js/controllers/transaction.js:2465
+#: erpnext/public/js/controllers/transaction.js:2491
 msgid "All items in this document already have a linked Quality Inspection."
 msgstr "Svi Artiklie u ovom dokumentu već imaju povezanu Kontrolu Kvaliteta."
 
@@ -4207,7 +4193,7 @@ msgstr "Dozvoli interne transfere po tržišnoj cijeni"
 msgid "Allow Item To Be Added Multiple Times in a Transaction"
 msgstr "Dozvoli da se Artikal doda više puta u Transakciji"
 
-#: erpnext/controllers/selling_controller.py:755
+#: erpnext/controllers/selling_controller.py:763
 msgid "Allow Item to Be Added Multiple Times in a Transaction"
 msgstr "Dozvolite da se artikal doda više puta u transakciji"
 
@@ -5153,7 +5139,7 @@ msgstr "Godišnji"
 msgid "Annual Billing: {0}"
 msgstr "Godišnji Obračun: {0}"
 
-#: erpnext/controllers/budget_controller.py:441
+#: erpnext/controllers/budget_controller.py:446
 msgid "Annual Budget for Account {0} against {1} {2} is {3}. It will be collectively ({4}) exceeded by {5}"
 msgstr "Godišnji proračun za račun {0} u odnosu na {1} {2} iznosi {3}. Zajedno će biti ({4}) premašen za {5}"
 
@@ -5642,7 +5628,7 @@ msgstr "Pošto je polje {0} omogućeno, polje {1} je obavezno."
 msgid "As the field {0} is enabled, the value of the field {1} should be more than 1."
 msgstr "Pošto je polje {0} omogućeno, vrijednost polja {1} bi trebala biti veća od 1."
 
-#: erpnext/stock/doctype/item/item.py:989
+#: erpnext/stock/doctype/item/item.py:983
 msgid "As there are existing submitted transactions against item {0}, you can not change the value of {1}."
 msgstr "Pošto postoje postojeće podnešene transakcije naspram artikla {0}, ne možete promijeniti vrijednost {1}."
 
@@ -5788,7 +5774,7 @@ msgstr "Račun kategorije imovine"
 msgid "Asset Category Name"
 msgstr "Naziv kategorije imovine"
 
-#: erpnext/stock/doctype/item/item.py:304
+#: erpnext/stock/doctype/item/item.py:307
 msgid "Asset Category is mandatory for Fixed Asset item"
 msgstr "Kategorija Imovine je obavezna za Artikal Fiksne Imovine"
 
@@ -6163,7 +6149,7 @@ msgstr "Imovina {0} je ažurirana. Postavi detalje amortizacije ako ih ima i pod
 msgid "Asset {0} must be submitted"
 msgstr "Imovina {0} mora biti podnešena"
 
-#: erpnext/controllers/buying_controller.py:851
+#: erpnext/controllers/buying_controller.py:859
 msgid "Asset {assets_link} created for {item_code}"
 msgstr "Imovina {assets_link} kreirana za {item_code}"
 
@@ -6193,11 +6179,11 @@ msgstr "Vrijednost imovine prilagođena nakon podnošenja Ispravke Vrijednosti I
 msgid "Assets"
 msgstr "Imovina"
 
-#: erpnext/controllers/buying_controller.py:869
+#: erpnext/controllers/buying_controller.py:877
 msgid "Assets not created for {item_code}. You will have to create asset manually."
 msgstr "Imovina nije kreirana za {item_code}. Morat ćete kreirati Imovinu ručno."
 
-#: erpnext/controllers/buying_controller.py:856
+#: erpnext/controllers/buying_controller.py:864
 msgid "Assets {assets_link} created for {item_code}"
 msgstr "Imovina {assets_link} kreirana za {item_code}"
 
@@ -6292,7 +6278,7 @@ msgstr "U redu #{0}: id sekvence {1} ne može biti manji od id-a sekvence pretho
 msgid "At row #{0}: you have selected the Difference Account {1}, which is a Cost of Goods Sold type account. Please select a different account"
 msgstr "U redu #{0}: odabrali ste Račun Razlike {1}, koji je tip računa Troškovi Prodane Robe. Odaberi drugi račun"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:864
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:865
 msgid "At row {0}: Batch No is mandatory for Item {1}"
 msgstr "Red {0}: Broj Šarće je obavezan za Artikal {1}"
 
@@ -6300,11 +6286,11 @@ msgstr "Red {0}: Broj Šarće je obavezan za Artikal {1}"
 msgid "At row {0}: Parent Row No cannot be set for item {1}"
 msgstr "Red {0}: Nadređeni Redni Broj ne može se postaviti za artikal {1}"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:849
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:850
 msgid "At row {0}: Qty is mandatory for the batch {1}"
 msgstr "Red {0}: Količina je obavezna za Šaržu {1}"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:856
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:857
 msgid "At row {0}: Serial No is mandatory for Item {1}"
 msgstr "Red {0}: Serijski Broj je obavezan za Artikal {1}"
 
@@ -6378,7 +6364,7 @@ msgstr "Naziv Atributa"
 msgid "Attribute Value"
 msgstr "Vrijednost Atributa"
 
-#: erpnext/stock/doctype/item/item.py:930
+#: erpnext/stock/doctype/item/item.py:924
 msgid "Attribute table is mandatory"
 msgstr "Tabela Atributa je obavezna"
 
@@ -6386,11 +6372,11 @@ msgstr "Tabela Atributa je obavezna"
 msgid "Attribute value: {0} must appear only once"
 msgstr "Vrijednost Atributa: {0} se mora pojaviti samo jednom"
 
-#: erpnext/stock/doctype/item/item.py:934
+#: erpnext/stock/doctype/item/item.py:928
 msgid "Attribute {0} selected multiple times in Attributes Table"
 msgstr "Atribut {0} izabran više puta u Tabeli Atributa"
 
-#: erpnext/stock/doctype/item/item.py:862
+#: erpnext/stock/doctype/item/item.py:856
 msgid "Attributes"
 msgstr "Atributi"
 
@@ -7674,11 +7660,11 @@ msgstr "Barkod"
 msgid "Barcode Type"
 msgstr "Barkod Tip"
 
-#: erpnext/stock/doctype/item/item.py:457
+#: erpnext/stock/doctype/item/item.py:460
 msgid "Barcode {0} already used in Item {1}"
 msgstr "Barkod {0} se već koristi za artikal {1}"
 
-#: erpnext/stock/doctype/item/item.py:472
+#: erpnext/stock/doctype/item/item.py:475
 msgid "Barcode {0} is not a valid {1} code"
 msgstr "Barkod {0} nije važeći {1} kod"
 
@@ -7932,7 +7918,7 @@ msgstr "Status isteka roka Artikla Šarže"
 #: erpnext/manufacturing/doctype/job_card/job_card.json
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.js:89
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.py:115
-#: erpnext/public/js/controllers/transaction.js:2388
+#: erpnext/public/js/controllers/transaction.js:2414
 #: erpnext/public/js/utils/barcode_scanner.js:260
 #: erpnext/public/js/utils/serial_no_batch_selector.js:438
 #: erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
@@ -7959,11 +7945,11 @@ msgstr "Status isteka roka Artikla Šarže"
 msgid "Batch No"
 msgstr "Broj Šarže"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:867
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:868
 msgid "Batch No is mandatory"
 msgstr "Broj Šarže je obavezan"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2629
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2630
 msgid "Batch No {0} does not exists"
 msgstr "Broj Šarže {0} ne postoji"
 
@@ -7971,7 +7957,7 @@ msgstr "Broj Šarže {0} ne postoji"
 msgid "Batch No {0} is linked with Item {1} which has serial no. Please scan serial no instead."
 msgstr "Broj Šarže {0} je povezan sa artiklom {1} koji ima serijski broj. Umjesto toga, skenirajte serijski broj."
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:364
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:365
 msgid "Batch No {0} is not present in the original {1} {2}, hence you can't return it against the {1} {2}"
 msgstr "Broj Šarže {0} nije prisutan u originalnom {1} {2}, stoga ga ne možete vratiti naspram {1} {2}"
 
@@ -7986,11 +7972,11 @@ msgstr "Broj Šarže"
 msgid "Batch Nos"
 msgstr "Broj Šarže"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1421
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1422
 msgid "Batch Nos are created successfully"
 msgstr "Brojevi Šarže su uspješno kreirani"
 
-#: erpnext/controllers/sales_and_purchase_return.py:1096
+#: erpnext/controllers/sales_and_purchase_return.py:1001
 msgid "Batch Not Available for Return"
 msgstr "Šarža nije dostupna za povrat"
 
@@ -8039,7 +8025,7 @@ msgstr "Šarža nije kreirana za artikal {} jer nema Šaržu."
 msgid "Batch {0} and Warehouse"
 msgstr "Šarža {0} i Skladište"
 
-#: erpnext/controllers/sales_and_purchase_return.py:1095
+#: erpnext/controllers/sales_and_purchase_return.py:1000
 msgid "Batch {0} is not available in warehouse {1}"
 msgstr "Šarža {0} nije dostupna u skladištu {1}"
 
@@ -8089,7 +8075,7 @@ msgstr "Planovi Pretplate u nastavku imaju različite valute u odnosu na standar
 #. Label of the bill_date (Date) field in DocType 'Journal Entry'
 #. Label of the bill_date (Date) field in DocType 'Subcontracting Receipt'
 #: erpnext/accounts/doctype/journal_entry/journal_entry.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1110
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1112
 #: erpnext/accounts/report/purchase_register/purchase_register.py:214
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.json
 msgid "Bill Date"
@@ -8098,7 +8084,7 @@ msgstr "Datum Fakture"
 #. Label of the bill_no (Data) field in DocType 'Journal Entry'
 #. Label of the bill_no (Data) field in DocType 'Subcontracting Receipt'
 #: erpnext/accounts/doctype/journal_entry/journal_entry.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1109
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1111
 #: erpnext/accounts/report/purchase_register/purchase_register.py:213
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.json
 msgid "Bill No"
@@ -8318,7 +8304,7 @@ msgstr "Faktura Status"
 msgid "Billing Zipcode"
 msgstr "Faktura Poštanski Broj"
 
-#: erpnext/accounts/party.py:602
+#: erpnext/accounts/party.py:608
 msgid "Billing currency must be equal to either default company's currency or party account currency"
 msgstr "Faktura Valuta mora biti jednaka ili standard valuti kompanije ili valuti računa stranke"
 
@@ -9315,7 +9301,7 @@ msgid "Can only make payment against unbilled {0}"
 msgstr "Plaćanje se može izvršiti samo protiv nefakturisanog(e) {0}"
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1458
-#: erpnext/controllers/accounts_controller.py:2946
+#: erpnext/controllers/accounts_controller.py:2949
 #: erpnext/public/js/controllers/accounts.js:90
 msgid "Can refer row only if the charge type is 'On Previous Row Amount' or 'Previous Row Total'"
 msgstr "Može upućivati na red samo ako je tip naplate \"Na iznos prethodnog reda\" ili \"Ukupni prethodni red\""
@@ -9477,9 +9463,9 @@ msgstr "Nije moguće izračunati vrijeme dolaska jer nedostaje adresa vozača."
 msgid "Cannot Create Return"
 msgstr "Nije moguće Kreirati Povrat"
 
-#: erpnext/stock/doctype/item/item.py:625
-#: erpnext/stock/doctype/item/item.py:638
-#: erpnext/stock/doctype/item/item.py:652
+#: erpnext/stock/doctype/item/item.py:631
+#: erpnext/stock/doctype/item/item.py:644
+#: erpnext/stock/doctype/item/item.py:658
 msgid "Cannot Merge"
 msgstr "Nije moguće spojiti"
 
@@ -9503,7 +9489,7 @@ msgstr "Nije moguće izmijeniti {0} {1}, umjesto toga kreirajte novi."
 msgid "Cannot apply TDS against multiple parties in one entry"
 msgstr "Ne može se primijeniti TDS naspram više strana u jednom unosu"
 
-#: erpnext/stock/doctype/item/item.py:307
+#: erpnext/stock/doctype/item/item.py:310
 msgid "Cannot be a fixed asset item as Stock Ledger is created."
 msgstr "Ne može biti artikal fiksne imovine jer je kreiran Registar Zaliha."
 
@@ -9519,7 +9505,7 @@ msgstr "Nije moguće otkazati jer postoji podnešeni Unos Zaliha {0}"
 msgid "Cannot cancel the transaction. Reposting of item valuation on submission is not completed yet."
 msgstr "Nije moguće otkazati transakciju. Ponovno knjiženje procjene vrijednosti artikla prilikom podnošenja još nije završeno."
 
-#: erpnext/controllers/buying_controller.py:959
+#: erpnext/controllers/buying_controller.py:967
 msgid "Cannot cancel this document as it is linked with the submitted asset {asset_link}. Please cancel the asset to continue."
 msgstr "Ne može se poništiti ovaj dokument jer je povezan sa dostavljenom imovinom {asset_link}. Otkaži imovinu da nastavite."
 
@@ -9527,7 +9513,7 @@ msgstr "Ne može se poništiti ovaj dokument jer je povezan sa dostavljenom imov
 msgid "Cannot cancel transaction for Completed Work Order."
 msgstr "Nije moguće otkazati transakciju za Završeni Radni Nalog."
 
-#: erpnext/stock/doctype/item/item.py:882
+#: erpnext/stock/doctype/item/item.py:876
 msgid "Cannot change Attributes after stock transaction. Make a new Item and transfer stock to the new Item"
 msgstr "Nije moguće promijeniti atribute nakon transakcije zaliha. Napravi novi artikal i prebaci zalihe na novi artikal"
 
@@ -9543,7 +9529,7 @@ msgstr "Nije moguće promijeniti tip referentnog dokumenta."
 msgid "Cannot change Service Stop Date for item in row {0}"
 msgstr "Nije moguće promijeniti datum zaustavljanja servisa za artikal u redu {0}"
 
-#: erpnext/stock/doctype/item/item.py:873
+#: erpnext/stock/doctype/item/item.py:867
 msgid "Cannot change Variant properties after stock transaction. You will have to make a new Item to do this."
 msgstr "Ne mogu promijeniti svojstva varijante nakon transakcije zaliha. Morat ćete napraviti novi artikal da biste to učinili."
 
@@ -9571,7 +9557,7 @@ msgstr "Nije moguće pretvoriti u Grupu jer je odabran Tip Računa."
 msgid "Cannot covert to Group because Account Type is selected."
 msgstr "Nije moguće pretvoriti u Grupu jer je odabran Tip Računa."
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:972
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:981
 msgid "Cannot create Stock Reservation Entries for future dated Purchase Receipts."
 msgstr "Nije moguće kreirati Unose Rezervisanja Zaliha za buduće datume Kupovnih Priznanica."
 
@@ -9622,7 +9608,7 @@ msgstr "Nije moguće osigurati dostavu serijskim brojem jer je artikal {0} dodan
 msgid "Cannot find Item with this Barcode"
 msgstr "Ne mogu pronaći artikal s ovim Barkodom"
 
-#: erpnext/controllers/accounts_controller.py:3483
+#: erpnext/controllers/accounts_controller.py:3486
 msgid "Cannot find a default warehouse for item {0}. Please set one in the Item Master or in Stock Settings."
 msgstr "Ne može se pronaći zadano skladište za artikal {0}. Molimo vas da postavite jedan u Postavke Artikla ili u Postavke Zaliha."
 
@@ -9630,7 +9616,7 @@ msgstr "Ne može se pronaći zadano skladište za artikal {0}. Molimo vas da pos
 msgid "Cannot make any transactions until the deletion job is completed"
 msgstr "Ne mogu se izvršiti nikakve transakcije dok se posao brisanja ne završi"
 
-#: erpnext/controllers/accounts_controller.py:2074
+#: erpnext/controllers/accounts_controller.py:2077
 msgid "Cannot overbill for Item {0} in row {1} more than {2}. To allow over-billing, please set allowance in Accounts Settings"
 msgstr "Nije moguće prekomjerno fakturisanje za artikal {0} u redu {1} više od {2}. Da biste dozvolili prekomjerno fakturisanje, postavite dopuštenje u Postavkama Računa"
 
@@ -9651,7 +9637,7 @@ msgid "Cannot receive from customer against negative outstanding"
 msgstr "Ne može se primiti od klijenta naspram negativnog nepodmirenog"
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1475
-#: erpnext/controllers/accounts_controller.py:2961
+#: erpnext/controllers/accounts_controller.py:2964
 #: erpnext/public/js/controllers/accounts.js:100
 msgid "Cannot refer row number greater than or equal to current row number for this Charge type"
 msgstr "Ne može se upućivati na broj reda veći ili jednak trenutnom broju reda za ovaj tip naknade"
@@ -9667,7 +9653,7 @@ msgstr "Nije moguće preuzeti oznaku veze. Provjerite zapisnik grešaka za više
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1467
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1646
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:1917
-#: erpnext/controllers/accounts_controller.py:2951
+#: erpnext/controllers/accounts_controller.py:2954
 #: erpnext/public/js/controllers/accounts.js:94
 #: erpnext/public/js/controllers/taxes_and_totals.js:470
 msgid "Cannot select charge type as 'On Previous Row Amount' or 'On Previous Row Total' for first row"
@@ -9681,15 +9667,15 @@ msgstr "Ne može se postaviti kao Izgubljeno pošto je Prodajni Nalog napravljen
 msgid "Cannot set authorization on basis of Discount for {0}"
 msgstr "Nije moguće postaviti autorizaciju na osnovu Popusta za {0}"
 
-#: erpnext/stock/doctype/item/item.py:716
+#: erpnext/stock/doctype/item/item.py:722
 msgid "Cannot set multiple Item Defaults for a company."
 msgstr "Nije moguće postaviti više Standard Artikal Postavki za kompaniju."
 
-#: erpnext/controllers/accounts_controller.py:3631
+#: erpnext/controllers/accounts_controller.py:3634
 msgid "Cannot set quantity less than delivered quantity"
 msgstr "Nije moguće postaviti količinu manju od dostavne količine"
 
-#: erpnext/controllers/accounts_controller.py:3634
+#: erpnext/controllers/accounts_controller.py:3637
 msgid "Cannot set quantity less than received quantity"
 msgstr "Nije moguće postaviti količinu manju od primljene količine"
 
@@ -10112,7 +10098,7 @@ msgid "Channel Partner"
 msgstr "Partner"
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:2346
-#: erpnext/controllers/accounts_controller.py:3014
+#: erpnext/controllers/accounts_controller.py:3017
 msgid "Charge of type 'Actual' in row {0} cannot be included in Item Rate or Paid Amount"
 msgstr "Naknada tipa 'Stvarni' u redu {0} ne može se uključiti u Cijenu Artikla ili Plaćeni Iznos"
 
@@ -10295,7 +10281,7 @@ msgstr "Širina Čeka"
 
 #. Label of the reference_date (Date) field in DocType 'Payment Entry'
 #: erpnext/accounts/doctype/payment_entry/payment_entry.json
-#: erpnext/public/js/controllers/transaction.js:2299
+#: erpnext/public/js/controllers/transaction.js:2325
 msgid "Cheque/Reference Date"
 msgstr "Referentni Datum"
 
@@ -10343,7 +10329,7 @@ msgstr "Podređeni DocType"
 
 #. Label of the child_row_reference (Data) field in DocType 'Quality
 #. Inspection'
-#: erpnext/public/js/controllers/transaction.js:2394
+#: erpnext/public/js/controllers/transaction.js:2420
 #: erpnext/stock/doctype/quality_inspection/quality_inspection.json
 msgid "Child Row Reference"
 msgstr "Referenca za Podređeni Red"
@@ -11055,7 +11041,7 @@ msgstr "Kompanije"
 #: erpnext/accounts/report/cheques_and_deposits_incorrectly_cleared/cheques_and_deposits_incorrectly_cleared.js:8
 #: erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.js:8
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:8
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:49
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:50
 #: erpnext/accounts/report/deferred_revenue_and_expense/deferred_revenue_and_expense.js:8
 #: erpnext/accounts/report/delivered_items_to_be_billed/delivered_items_to_be_billed.js:7
 #: erpnext/accounts/report/dimension_wise_accounts_balance_report/dimension_wise_accounts_balance_report.js:8
@@ -12288,7 +12274,7 @@ msgid "Content Type"
 msgstr "Tip Sadržaja"
 
 #: erpnext/erpnext_integrations/doctype/plaid_settings/plaid_settings.js:162
-#: erpnext/public/js/controllers/transaction.js:2312
+#: erpnext/public/js/controllers/transaction.js:2338
 #: erpnext/selling/doctype/quotation/quotation.js:356
 msgid "Continue"
 msgstr "Nastavi"
@@ -12453,7 +12439,7 @@ msgstr "Faktor Pretvaranja"
 msgid "Conversion Rate"
 msgstr "Stopa Pretvaranja"
 
-#: erpnext/stock/doctype/item/item.py:393
+#: erpnext/stock/doctype/item/item.py:396
 msgid "Conversion factor for default Unit of Measure must be 1 in row {0}"
 msgstr "Faktor pretvaranja za standard jedinicu mora biti 1 u redu {0}"
 
@@ -12461,15 +12447,15 @@ msgstr "Faktor pretvaranja za standard jedinicu mora biti 1 u redu {0}"
 msgid "Conversion factor for item {0} has been reset to 1.0 as the uom {1} is same as stock uom {2}."
 msgstr "Faktor pretvaranja za artikal {0} je resetovan na 1.0 jer je jedinica {1} isti kao jedinica zalihe {2}."
 
-#: erpnext/controllers/accounts_controller.py:2767
+#: erpnext/controllers/accounts_controller.py:2770
 msgid "Conversion rate cannot be 0"
 msgstr "Stopa konverzije ne može biti 0"
 
-#: erpnext/controllers/accounts_controller.py:2774
+#: erpnext/controllers/accounts_controller.py:2777
 msgid "Conversion rate is 1.00, but document currency is different from company currency"
 msgstr "Stopa konverzije je 1,00, ali valuta dokumenta se razlikuje od valute kompanije"
 
-#: erpnext/controllers/accounts_controller.py:2770
+#: erpnext/controllers/accounts_controller.py:2773
 msgid "Conversion rate must be 1.00 if document currency is same as company currency"
 msgstr "Stopa konverzije mora biti 1,00 ako je valuta dokumenta ista kao valuta kompanije"
 
@@ -12682,7 +12668,7 @@ msgstr "Troškovi"
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:28
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:40
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:30
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1096
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1098
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:40
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.js:42
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.py:197
@@ -12775,7 +12761,7 @@ msgid "Cost Center is a part of Cost Center Allocation, hence cannot be converte
 msgstr "Centar Troškova je dio dodjele Centra Troškova, stoga se ne može konvertirati u grupu"
 
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py:1411
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:855
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:864
 msgid "Cost Center is required in row {0} in Taxes table for type {1}"
 msgstr "Centar Troškova je obavezan u redu {0} u tabeli PDV za tip {1}"
 
@@ -13044,8 +13030,8 @@ msgstr "Cr"
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:132
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:143
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:219
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:654
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:678
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:656
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:680
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.js:88
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.js:89
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.js:103
@@ -13102,8 +13088,8 @@ msgstr "Cr"
 #: erpnext/projects/doctype/task/task_tree.js:81
 #: erpnext/public/js/communication.js:19 erpnext/public/js/communication.js:31
 #: erpnext/public/js/communication.js:41
-#: erpnext/public/js/controllers/transaction.js:336
-#: erpnext/public/js/controllers/transaction.js:2435
+#: erpnext/public/js/controllers/transaction.js:362
+#: erpnext/public/js/controllers/transaction.js:2461
 #: erpnext/selling/doctype/customer/customer.js:181
 #: erpnext/selling/doctype/quotation/quotation.js:124
 #: erpnext/selling/doctype/quotation/quotation.js:133
@@ -13398,7 +13384,7 @@ msgstr "Kreiraj novu složenu imovinu"
 msgid "Create a variant with the template image."
 msgstr "Kreiraj Varijantu sa slikom šablona."
 
-#: erpnext/stock/stock_ledger.py:1877
+#: erpnext/stock/stock_ledger.py:1886
 msgid "Create an incoming stock transaction for the Item."
 msgstr "Kreirajte dolaznu transakciju zaliha za artikal."
 
@@ -13458,7 +13444,7 @@ msgstr "Kreiranje Kupovnih Faktura u toku..."
 msgid "Creating Purchase Order ..."
 msgstr "Kreiranje Kupovnog Naloga u toku..."
 
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:735
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:737
 #: erpnext/buying/doctype/purchase_order/purchase_order.js:552
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.js:73
 msgid "Creating Purchase Receipt ..."
@@ -13654,7 +13640,7 @@ msgstr "Kreditni Mjeseci"
 #: erpnext/accounts/doctype/journal_entry_template/journal_entry_template.json
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:174
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:147
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1119
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1121
 #: erpnext/controllers/sales_and_purchase_return.py:373
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:286
 #: erpnext/stock/doctype/delivery_note/delivery_note.js:89
@@ -13689,7 +13675,7 @@ msgstr "Kreditna Faktura {0} je kreirana automatski"
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py:368
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py:376
-#: erpnext/controllers/accounts_controller.py:2186
+#: erpnext/controllers/accounts_controller.py:2189
 msgid "Credit To"
 msgstr "Kredit Za"
 
@@ -13874,7 +13860,7 @@ msgstr "Kup"
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/subscription_plan/subscription_plan.json
 #: erpnext/accounts/report/account_balance/account_balance.py:28
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1129
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1131
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:205
 #: erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.py:101
 #: erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.js:118
@@ -14403,7 +14389,7 @@ msgstr "Kod Klijenta"
 #. Label of the customer_contact_display (Small Text) field in DocType
 #. 'Purchase Order'
 #. Label of the customer_contact (Small Text) field in DocType 'Delivery Stop'
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1090
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1092
 #: erpnext/buying/doctype/purchase_order/purchase_order.json
 #: erpnext/stock/doctype/delivery_stop/delivery_stop.json
 msgid "Customer Contact"
@@ -14499,7 +14485,7 @@ msgstr "Povratne informacije Klijenta"
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/tax_rule/tax_rule.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:107
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1147
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1149
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:81
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:185
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:56
@@ -14543,7 +14529,7 @@ msgstr "Artikal Grupa Klijenta"
 msgid "Customer Group Name"
 msgstr "Naziv Grupe Klijenta"
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1239
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1241
 msgid "Customer Group: {0} does not exist"
 msgstr "Grupa Klijenta: {0} ne postoji"
 
@@ -14562,7 +14548,7 @@ msgstr "Artikal Klijenta"
 msgid "Customer Items"
 msgstr "Artikli Klijenta"
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1138
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1140
 msgid "Customer LPO"
 msgstr "Lokalni Kupovni Nalog Klijenta"
 
@@ -14608,7 +14594,7 @@ msgstr "Mobilni Broj Klijenta"
 #: erpnext/accounts/doctype/pos_invoice/pos_invoice.json
 #: erpnext/accounts/doctype/process_statement_of_accounts_customer/process_statement_of_accounts_customer.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1080
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1082
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:156
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:92
 #: erpnext/accounts/report/delivered_items_to_be_billed/delivered_items_to_be_billed.py:35
@@ -15286,7 +15272,7 @@ msgstr "Debit Iznos u Valuti Transakcije"
 #: erpnext/accounts/doctype/journal_entry_template/journal_entry_template.json
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:176
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:147
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1122
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1124
 #: erpnext/controllers/sales_and_purchase_return.py:377
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:287
 #: erpnext/stock/doctype/purchase_receipt/purchase_receipt.js:61
@@ -15315,7 +15301,7 @@ msgstr "Debit Faktura će ažurirati svoj nepodmireni iznos, čak i ako je naved
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:953
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:964
-#: erpnext/controllers/accounts_controller.py:2186
+#: erpnext/controllers/accounts_controller.py:2189
 msgid "Debit To"
 msgstr "Debit prema"
 
@@ -15348,11 +15334,11 @@ msgstr "Debit-Kredit je neusklađeno"
 msgid "Debit-Credit mismatch"
 msgstr "Debit-Kredit je neusklađeno"
 
-#: erpnext/accounts/party.py:609
+#: erpnext/accounts/party.py:615
 msgid "Debtor/Creditor"
 msgstr "Dužnik/Povjerilac"
 
-#: erpnext/accounts/party.py:612
+#: erpnext/accounts/party.py:618
 msgid "Debtor/Creditor Advance"
 msgstr "Dužnik/Povjerilac Predujam"
 
@@ -15472,7 +15458,7 @@ msgstr "Standard Račun za Predujam Plaćanje"
 msgid "Default BOM"
 msgstr "Standard Sastavnica"
 
-#: erpnext/stock/doctype/item/item.py:418
+#: erpnext/stock/doctype/item/item.py:421
 msgid "Default BOM ({0}) must be active for this item or its template"
 msgstr "Standard Sastavnica ({0}) mora biti aktivna za ovaj artikal ili njegov šablon"
 
@@ -15480,7 +15466,7 @@ msgstr "Standard Sastavnica ({0}) mora biti aktivna za ovaj artikal ili njegov �
 msgid "Default BOM for {0} not found"
 msgstr "Standard Sastavnica {0} nije pronađena"
 
-#: erpnext/controllers/accounts_controller.py:3672
+#: erpnext/controllers/accounts_controller.py:3675
 msgid "Default BOM not found for FG Item {0}"
 msgstr "Standard Sastavnica nije pronađena za Artikal Gotovog Proizvoda {0}"
 
@@ -15815,15 +15801,15 @@ msgstr "Standard Distrikt"
 msgid "Default Unit of Measure"
 msgstr "Standard Jedinica"
 
-#: erpnext/stock/doctype/item/item.py:1272
+#: erpnext/stock/doctype/item/item.py:1266
 msgid "Default Unit of Measure for Item {0} cannot be changed directly because you have already made some transaction(s) with another UOM. You need to either cancel the linked documents or create a new Item."
 msgstr "Standard Jedinica za artikal {0} ne može se promijeniti direktno jer ste već izvršili neke transakcije sa drugom Jedinicom. Morate ili otkazati povezane dokumente ili kreirati novi artikal."
 
-#: erpnext/stock/doctype/item/item.py:1255
+#: erpnext/stock/doctype/item/item.py:1249
 msgid "Default Unit of Measure for Item {0} cannot be changed directly because you have already made some transaction(s) with another UOM. You will need to create a new Item to use a different Default UOM."
 msgstr "Standard Jedinica za artikal {0} ne može se promijeniti direktno jer ste već izvršili neke transakcije sa drugom Jedinicom. Morat ćete kreirati novi artikal da biste koristili drugu Jedinicu."
 
-#: erpnext/stock/doctype/item/item.py:908
+#: erpnext/stock/doctype/item/item.py:902
 msgid "Default Unit of Measure for Variant '{0}' must be same as in Template '{1}'"
 msgstr "Standard Jedinica za Varijantu '{0}' mora biti ista kao u Šablonu '{1}'"
 
@@ -16282,7 +16268,7 @@ msgstr "Trendovi Dostave"
 msgid "Delivery Note {0} is not submitted"
 msgstr "Dostavnica {0} nije podnešena"
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1142
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1144
 #: erpnext/stock/doctype/delivery_trip/delivery_trip.js:73
 msgid "Delivery Notes"
 msgstr "Dostavnice"
@@ -16813,7 +16799,7 @@ msgstr "Amortizacija eliminirana storniranjem"
 #: erpnext/projects/doctype/task_type/task_type.json
 #: erpnext/projects/doctype/timesheet_detail/timesheet_detail.json
 #: erpnext/public/js/bank_reconciliation_tool/data_table_manager.js:55
-#: erpnext/public/js/controllers/transaction.js:2376
+#: erpnext/public/js/controllers/transaction.js:2402
 #: erpnext/selling/doctype/installation_note_item/installation_note_item.json
 #: erpnext/selling/doctype/product_bundle/product_bundle.json
 #: erpnext/selling/doctype/product_bundle_item/product_bundle_item.json
@@ -17001,7 +16987,7 @@ msgstr "Račun Razlike u Postavkama Artikla"
 msgid "Difference Account must be a Asset/Liability type account (Temporary Opening), since this Stock Entry is an Opening Entry"
 msgstr "Razlika u računu mora biti tip računa Imovine/Obaveza (Privremeno Otvaranje), budući da je ovaj unos zaliha početni unos"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:954
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:950
 msgid "Difference Account must be a Asset/Liability type account, since this Stock Reconciliation is an Opening Entry"
 msgstr "Račun razlike mora biti račun tipa Imovina/Obaveze, budući da je ovo usaglašavanje Zaliha Početni Unos"
 
@@ -17267,11 +17253,11 @@ msgstr "Odabran je onemogućen Račun"
 msgid "Disabled Warehouse {0} cannot be used for this transaction."
 msgstr "Onemogućeno Skladište {0} se ne može koristiti za ovu transakciju."
 
-#: erpnext/controllers/accounts_controller.py:745
+#: erpnext/controllers/accounts_controller.py:748
 msgid "Disabled pricing rules since this {} is an internal transfer"
 msgstr "Onemogućena pravila određivanja cijena jer je ovo {} interni prijenos"
 
-#: erpnext/controllers/accounts_controller.py:759
+#: erpnext/controllers/accounts_controller.py:762
 msgid "Disabled tax included prices since this {} is an internal transfer"
 msgstr "Cijene bez PDV budući da je ovo {} interni prijenos"
 
@@ -18213,7 +18199,7 @@ msgstr "Drop Ship"
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.json
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/print_format/sales_invoice_print/sales_invoice_print.html:72
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1106
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1108
 #: erpnext/assets/doctype/asset_maintenance_log/asset_maintenance_log.json
 #: erpnext/selling/report/payment_terms_status_for_sales_order/payment_terms_status_for_sales_order.py:40
 msgid "Due Date"
@@ -18227,11 +18213,11 @@ msgstr "Krajnji Rok"
 msgid "Due Date Based On"
 msgstr "Krajnji rok na osnovu"
 
-#: erpnext/accounts/party.py:695
+#: erpnext/accounts/party.py:701
 msgid "Due Date cannot be after {0}"
 msgstr "Datum Dospijeća ne može biti nakon {0}"
 
-#: erpnext/accounts/party.py:671
+#: erpnext/accounts/party.py:677
 msgid "Due Date cannot be before {0}"
 msgstr "Datum Dospijeća ne može biti prije {0}"
 
@@ -18949,7 +18935,7 @@ msgstr "Omogući Zakazivanje Termina"
 msgid "Enable Auto Email"
 msgstr "Omogući Automatsku e-poštu"
 
-#: erpnext/stock/doctype/item/item.py:1064
+#: erpnext/stock/doctype/item/item.py:1058
 msgid "Enable Auto Re-Order"
 msgstr "Omogući Automatsku Ponovnu Naložbu"
 
@@ -19162,7 +19148,7 @@ msgstr "Datum Uplate"
 msgid "End Date"
 msgstr "Datum završetka"
 
-#: erpnext/crm/doctype/contract/contract.py:75
+#: erpnext/crm/doctype/contract/contract.py:83
 msgid "End Date cannot be before Start Date."
 msgstr "Datum završetka ne može biti prije datuma početka."
 
@@ -19413,7 +19399,7 @@ msgstr "Erg"
 #: erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.json
 #: erpnext/manufacturing/doctype/job_card/job_card.py:875
 #: erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.json
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:297
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:298
 msgid "Error"
 msgstr "Grеška"
 
@@ -19538,7 +19524,7 @@ msgstr "Ex Works"
 msgid "Example URL"
 msgstr "Primjer URL-a"
 
-#: erpnext/stock/doctype/item/item.py:995
+#: erpnext/stock/doctype/item/item.py:989
 msgid "Example of a linked document: {0}"
 msgstr "Primjer povezanog dokumenta: {0}"
 
@@ -19554,7 +19540,7 @@ msgstr "Primjer: ABCD.#####\n"
 msgid "Example: ABCD.#####. If series is set and Batch No is not mentioned in transactions, then automatic batch number will be created based on this series. If you always want to explicitly mention Batch No for this item, leave this blank. Note: this setting will take priority over the Naming Series Prefix in Stock Settings."
 msgstr "Primjer: ABCD.#####. Ako je serija postavljena, a broj šarže nije postavljen u transakcijama, automatski će se broj šarže kreirati na osnovu ove serije. Ako uvijek želite eksplicitno postavitii broj šarže za ovaj artikal, ostavite ovo prazno. Napomena: ova postavka će imati prioritet nad Prefiksom Serije Imenovanja u postavkama zaliha."
 
-#: erpnext/stock/stock_ledger.py:2141
+#: erpnext/stock/stock_ledger.py:2149
 msgid "Example: Serial No {0} reserved in {1}."
 msgstr "Primjer: Serijski Broj {0} je rezervisan u {1}."
 
@@ -19608,8 +19594,8 @@ msgstr "Rezultat Deviznog Kursa"
 msgid "Exchange Gain/Loss"
 msgstr "Rezultat Deviznog Kursa"
 
-#: erpnext/controllers/accounts_controller.py:1593
-#: erpnext/controllers/accounts_controller.py:1677
+#: erpnext/controllers/accounts_controller.py:1596
+#: erpnext/controllers/accounts_controller.py:1680
 msgid "Exchange Gain/Loss amount has been booked through {0}"
 msgstr "Iznos Rezultata Deviznog Kursa je knjižen preko {0}"
 
@@ -20345,7 +20331,7 @@ msgid "Fetching Error"
 msgstr "Greška pri Preuzimanju"
 
 #: erpnext/accounts/doctype/dunning/dunning.js:135
-#: erpnext/public/js/controllers/transaction.js:1251
+#: erpnext/public/js/controllers/transaction.js:1277
 msgid "Fetching exchange rates ..."
 msgstr "Preuzimaju se Devizni Kursevi..."
 
@@ -20640,15 +20626,15 @@ msgstr "Količina Artikla Gotovog Proizvoda"
 msgid "Finished Good Item Quantity"
 msgstr "Količina Artikla Gotovog Proizvoda"
 
-#: erpnext/controllers/accounts_controller.py:3658
+#: erpnext/controllers/accounts_controller.py:3661
 msgid "Finished Good Item is not specified for service item {0}"
 msgstr "Artikal Gotovog Proizvoda nije naveden za servisni artikal {0}"
 
-#: erpnext/controllers/accounts_controller.py:3675
+#: erpnext/controllers/accounts_controller.py:3678
 msgid "Finished Good Item {0} Qty can not be zero"
 msgstr "Količina Artikla Gotovog Proizvoda {0} ne može biti nula"
 
-#: erpnext/controllers/accounts_controller.py:3669
+#: erpnext/controllers/accounts_controller.py:3672
 msgid "Finished Good Item {0} must be a sub-contracted item"
 msgstr "Artikal Gotovog Proizvoda {0} mora biti podugovoreni artikal"
 
@@ -20889,7 +20875,7 @@ msgstr "Račun Fiksne Imovine"
 msgid "Fixed Asset Defaults"
 msgstr "Standard Postavke Fiksne Imovine"
 
-#: erpnext/stock/doctype/item/item.py:301
+#: erpnext/stock/doctype/item/item.py:304
 msgid "Fixed Asset Item must be a non-stock item."
 msgstr "Artikal Fiksne Imovine mora biti artikal koja nije na zalihama."
 
@@ -21065,7 +21051,7 @@ msgstr "Za Količinu (Proizvedena Količina) je obavezna"
 msgid "For Raw Materials"
 msgstr "Sirovine"
 
-#: erpnext/controllers/accounts_controller.py:1259
+#: erpnext/controllers/accounts_controller.py:1262
 msgid "For Return Invoices with Stock effect, '0' qty Items are not allowed. Following rows are affected: {0}"
 msgstr "Za Povratne Fakture sa efektom zaliha, '0' u količina Artikla nisu dozvoljeni. Ovo utiče na sledeće redove: {0}"
 
@@ -21166,7 +21152,7 @@ msgstr "Za praktičnost Klienta, ovi kodovi se mogu koristiti u formatima za isp
 msgid "For the item {0}, the quantity should be {1} according to the BOM {2}."
 msgstr "Za artikal {0}, količina bi trebala biti {1} prema Sastavnici {2}."
 
-#: erpnext/public/js/controllers/transaction.js:1088
+#: erpnext/public/js/controllers/transaction.js:1114
 msgctxt "Clear payment terms template and/or payment schedule when due date is changed"
 msgid "For the new {0} to take effect, would you like to clear the current {1}?"
 msgstr "Da bi novi {0} stupio na snagu, želite li izbrisati trenutni {1}?"
@@ -21175,7 +21161,7 @@ msgstr "Da bi novi {0} stupio na snagu, želite li izbrisati trenutni {1}?"
 msgid "For the {0}, no stock is available for the return in the warehouse {1}."
 msgstr "Za {0} nema raspoloživih zaliha za povrat u skladištu {1}."
 
-#: erpnext/controllers/sales_and_purchase_return.py:1144
+#: erpnext/controllers/sales_and_purchase_return.py:1049
 msgid "For the {0}, the quantity is required to make the return entry"
 msgstr "Za {0}, količina je obavezna za unos povrata"
 
@@ -21512,7 +21498,7 @@ msgstr "Od Datuma ne može biti kasnije od Do Datuma"
 msgid "From Date is mandatory"
 msgstr "Od datuma je obavezno"
 
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:52
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:53
 #: erpnext/accounts/report/general_ledger/general_ledger.py:86
 #: erpnext/accounts/report/pos_register/pos_register.py:115
 #: erpnext/accounts/report/tax_withholding_details/tax_withholding_details.py:39
@@ -21889,14 +21875,14 @@ msgstr "Dalji članovi se mogu kreirati samo pod članovima tipa 'Grupa'"
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:186
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:155
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1134
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1136
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:177
 msgid "Future Payment Amount"
 msgstr "Iznos Buduće Isplate"
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:185
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:154
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1133
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1135
 msgid "Future Payment Ref"
 msgstr "Referensa Buduće Isplate"
 
@@ -23070,7 +23056,7 @@ msgstr "Pomaže vam da raspodijelite Proračun/Cilj po mjesecima ako imate sezon
 msgid "Here are the error logs for the aforementioned failed depreciation entries: {0}"
 msgstr "Ovdje su zapisi grešaka za gore navedene neuspjele unose amortizacije: {0}"
 
-#: erpnext/stock/stock_ledger.py:1862
+#: erpnext/stock/stock_ledger.py:1871
 msgid "Here are the options to proceed:"
 msgstr "Ovdje su opcije za nastavak:"
 
@@ -23596,7 +23582,7 @@ msgstr "Ako je postavljeno, sistem će dozvoliti samo korisnicima sa ovom ulogom
 msgid "If more than one package of the same type (for print)"
 msgstr "Ako je više od jednog pakovanja istog tipa (za ispis)"
 
-#: erpnext/stock/stock_ledger.py:1872
+#: erpnext/stock/stock_ledger.py:1881
 msgid "If not, you can Cancel / Submit this entry"
 msgstr "Ako ne, možete Otkazati / Podnijeti ovaj unos"
 
@@ -23621,7 +23607,7 @@ msgstr "Ako Sastavnica rezultira otpadnim materijalom, potrebno je odabrati Skla
 msgid "If the account is frozen, entries are allowed to restricted users."
 msgstr "Ako je račun zamrznut, unosi su dozvoljeni ograničenim korisnicima."
 
-#: erpnext/stock/stock_ledger.py:1865
+#: erpnext/stock/stock_ledger.py:1874
 msgid "If the item is transacting as a Zero Valuation Rate item in this entry, please enable 'Allow Zero Valuation Rate' in the {0} Item table."
 msgstr "Ako se transakcije artikla vrši kao artikal nulte stope vrijednosti u ovom unosu, omogući 'Dozvoli Nultu Stopu Vrednovanja' u {0} Postavkama Artikla."
 
@@ -24619,7 +24605,7 @@ msgstr "Netačna količina stanja nakon transakcije"
 msgid "Incorrect Batch Consumed"
 msgstr "Potrošena Pogrešna Šarža"
 
-#: erpnext/stock/doctype/item/item.py:514
+#: erpnext/stock/doctype/item/item.py:517
 msgid "Incorrect Check in (group) Warehouse for Reorder"
 msgstr "Netačno prijavljivanje (grupno) skladište za ponovnu narudžbu"
 
@@ -24668,7 +24654,7 @@ msgstr "Pogrešan Serijski i Šaržni Paket"
 msgid "Incorrect Stock Value Report"
 msgstr "Netačan Izvještaj o Vrijednosti Zaliha"
 
-#: erpnext/stock/serial_batch_bundle.py:134
+#: erpnext/stock/serial_batch_bundle.py:135
 msgid "Incorrect Type of Transaction"
 msgstr "Netačan Tip Transakcije"
 
@@ -24937,8 +24923,8 @@ msgstr "Uputstva"
 msgid "Insufficient Capacity"
 msgstr "Nedovoljan Kapacitet"
 
-#: erpnext/controllers/accounts_controller.py:3590
-#: erpnext/controllers/accounts_controller.py:3614
+#: erpnext/controllers/accounts_controller.py:3593
+#: erpnext/controllers/accounts_controller.py:3617
 msgid "Insufficient Permissions"
 msgstr "Nedovoljne Dozvole"
 
@@ -24946,12 +24932,12 @@ msgstr "Nedovoljne Dozvole"
 #: erpnext/stock/doctype/pick_list/pick_list.py:127
 #: erpnext/stock/doctype/pick_list/pick_list.py:975
 #: erpnext/stock/doctype/stock_entry/stock_entry.py:759
-#: erpnext/stock/serial_batch_bundle.py:989 erpnext/stock/stock_ledger.py:1559
-#: erpnext/stock/stock_ledger.py:2032
+#: erpnext/stock/serial_batch_bundle.py:1021 erpnext/stock/stock_ledger.py:1568
+#: erpnext/stock/stock_ledger.py:2040
 msgid "Insufficient Stock"
 msgstr "Nedovoljne Zalihe"
 
-#: erpnext/stock/stock_ledger.py:2047
+#: erpnext/stock/stock_ledger.py:2055
 msgid "Insufficient Stock for Batch"
 msgstr "Nedovoljne Zalihe Šarže"
 
@@ -25089,11 +25075,11 @@ msgstr "Interni Klijent"
 msgid "Internal Customer for company {0} already exists"
 msgstr "Interni Klijent za kompaniju {0} već postoji"
 
-#: erpnext/controllers/accounts_controller.py:728
+#: erpnext/controllers/accounts_controller.py:731
 msgid "Internal Sale or Delivery Reference missing."
 msgstr "Nedostaje referenca za Internu Prodaju ili Dostavu."
 
-#: erpnext/controllers/accounts_controller.py:730
+#: erpnext/controllers/accounts_controller.py:733
 msgid "Internal Sales Reference Missing"
 msgstr "Nedostaje Interna Prodajna Referenca"
 
@@ -25124,7 +25110,7 @@ msgstr "Interni Dobavljač za kompaniju {0} već postoji"
 msgid "Internal Transfer"
 msgstr "Interni Prijenos"
 
-#: erpnext/controllers/accounts_controller.py:739
+#: erpnext/controllers/accounts_controller.py:742
 msgid "Internal Transfer Reference Missing"
 msgstr "Nedostaje Referenca Internog Prijenosa"
 
@@ -25167,8 +25153,8 @@ msgstr "Nevažeći"
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:969
 #: erpnext/assets/doctype/asset_category/asset_category.py:69
 #: erpnext/assets/doctype/asset_category/asset_category.py:97
-#: erpnext/controllers/accounts_controller.py:2975
-#: erpnext/controllers/accounts_controller.py:2983
+#: erpnext/controllers/accounts_controller.py:2978
+#: erpnext/controllers/accounts_controller.py:2986
 msgid "Invalid Account"
 msgstr "Nevažeći Račun"
 
@@ -25193,7 +25179,7 @@ msgstr "Nevažeći Datum Automatskog Ponavljanja"
 msgid "Invalid Barcode. There is no Item attached to this barcode."
 msgstr "Nevažeći Barkod. Nema artikla priloženog ovom barkodu."
 
-#: erpnext/public/js/controllers/transaction.js:2631
+#: erpnext/public/js/controllers/transaction.js:2657
 msgid "Invalid Blanket Order for the selected Customer and Item"
 msgstr "Nevažeća narudžba za odabranog Klijenta i Artikal"
 
@@ -25207,7 +25193,7 @@ msgstr "Nevažeća kompanija za međukompanijsku transakciju."
 
 #: erpnext/assets/doctype/asset/asset.py:295
 #: erpnext/assets/doctype/asset/asset.py:302
-#: erpnext/controllers/accounts_controller.py:2998
+#: erpnext/controllers/accounts_controller.py:3001
 msgid "Invalid Cost Center"
 msgstr "Nevažeći Centar Troškova"
 
@@ -25249,7 +25235,7 @@ msgstr "Nevažeća Grupa po"
 msgid "Invalid Item"
 msgstr "Nevažeći Artikal"
 
-#: erpnext/stock/doctype/item/item.py:1410
+#: erpnext/stock/doctype/item/item.py:1404
 msgid "Invalid Item Defaults"
 msgstr "Nevažeće Standard Postavke Artikla"
 
@@ -25295,11 +25281,11 @@ msgstr "Nevažeća Konfiguracija Gubitka Procesa"
 msgid "Invalid Purchase Invoice"
 msgstr "Nevažeća Kupovna Faktura"
 
-#: erpnext/controllers/accounts_controller.py:3627
+#: erpnext/controllers/accounts_controller.py:3630
 msgid "Invalid Qty"
 msgstr "Nevažeća Količina"
 
-#: erpnext/controllers/accounts_controller.py:1277
+#: erpnext/controllers/accounts_controller.py:1280
 msgid "Invalid Quantity"
 msgstr "Nevažeća Količina"
 
@@ -25316,7 +25302,7 @@ msgstr "Nevažeće Prodajne Fakture"
 msgid "Invalid Schedule"
 msgstr "Nevažeći Raspored"
 
-#: erpnext/controllers/selling_controller.py:243
+#: erpnext/controllers/selling_controller.py:251
 msgid "Invalid Selling Price"
 msgstr "Nevažeća Prodajna Cijena"
 
@@ -25349,7 +25335,7 @@ msgstr "Nevažeći Izraz Uvjeta"
 msgid "Invalid lost reason {0}, please create a new lost reason"
 msgstr "Nevažeći izgubljeni razlog {0}, kreiraj novi izgubljeni razlog"
 
-#: erpnext/stock/doctype/item/item.py:408
+#: erpnext/stock/doctype/item/item.py:411
 msgid "Invalid naming series (. missing) for {0}"
 msgstr "Nevažeća serija imenovanja (. nedostaje) za {0}"
 
@@ -25389,7 +25375,7 @@ msgstr "Zalihe"
 #. Name of a DocType
 #: erpnext/patches/v15_0/refactor_closing_stock_balance.py:43
 #: erpnext/stock/doctype/inventory_dimension/inventory_dimension.json
-#: erpnext/stock/doctype/inventory_dimension/inventory_dimension.py:180
+#: erpnext/stock/doctype/inventory_dimension/inventory_dimension.py:181
 msgid "Inventory Dimension"
 msgstr "Dimenzija Zaliha"
 
@@ -25455,7 +25441,7 @@ msgstr "Datum Fakture"
 msgid "Invoice Discounting"
 msgstr "Popust Fakture"
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1114
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1116
 msgid "Invoice Grand Total"
 msgstr "Ukupni Iznos Fakture"
 
@@ -25548,7 +25534,7 @@ msgstr "Faktura se ne može kreirati za nula sati za fakturisanje"
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:169
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:144
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1116
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1118
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:164
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:165
 msgid "Invoiced Amount"
@@ -25954,6 +25940,11 @@ msgstr "Početni Unos"
 msgid "Is Outward"
 msgstr "Dostava"
 
+#. Label of the is_packed (Check) field in DocType 'Serial and Batch Bundle'
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.json
+msgid "Is Packed"
+msgstr "Je Upakovan"
+
 #. Label of the is_paid (Check) field in DocType 'Purchase Invoice'
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 msgid "Is Paid"
@@ -26236,11 +26227,11 @@ msgstr "Datum Izdavanja"
 msgid "Issuing cannot be done to a location. Please enter employee to issue the Asset {0} to"
 msgstr "Izdavanje se ne može izvršiti na lokaciji. Unesi personal kojem će izdati imovina {0}"
 
-#: erpnext/stock/doctype/item/item.py:565
+#: erpnext/stock/doctype/item/item.py:571
 msgid "It can take upto few hours for accurate stock values to be visible after merging items."
 msgstr "Može potrajati i do nekoliko sati da tačne vrijednosti zaliha budu vidljive nakon spajanja artikala."
 
-#: erpnext/public/js/controllers/transaction.js:2075
+#: erpnext/public/js/controllers/transaction.js:2101
 msgid "It is needed to fetch Item Details."
 msgstr "Potreban je za preuzimanje Detalja Artikla."
 
@@ -26290,7 +26281,7 @@ msgstr "Nije moguće ravnomjerno raspodijeliti troškove kada je ukupan iznos nu
 #: erpnext/buying/report/supplier_quotation_comparison/supplier_quotation_comparison.js:33
 #: erpnext/buying/report/supplier_quotation_comparison/supplier_quotation_comparison.py:204
 #: erpnext/buying/workspace/buying/buying.json
-#: erpnext/controllers/taxes_and_totals.py:1125
+#: erpnext/controllers/taxes_and_totals.py:1135
 #: erpnext/manufacturing/doctype/blanket_order/blanket_order.json
 #: erpnext/manufacturing/doctype/bom/bom.js:944
 #: erpnext/manufacturing/doctype/bom/bom.json
@@ -26568,7 +26559,7 @@ msgstr "Artikal Korpe"
 #: erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py:86
 #: erpnext/manufacturing/report/work_order_stock_report/work_order_stock_report.py:119
 #: erpnext/projects/doctype/timesheet/timesheet.js:213
-#: erpnext/public/js/controllers/transaction.js:2350
+#: erpnext/public/js/controllers/transaction.js:2376
 #: erpnext/public/js/stock_reservation.js:112
 #: erpnext/public/js/stock_reservation.js:317 erpnext/public/js/utils.js:500
 #: erpnext/public/js/utils.js:656
@@ -27006,7 +26997,7 @@ msgstr "Proizvođač Artikla"
 #: erpnext/manufacturing/report/production_planning_report/production_planning_report.py:359
 #: erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py:92
 #: erpnext/manufacturing/report/work_order_consumed_materials/work_order_consumed_materials.py:138
-#: erpnext/public/js/controllers/transaction.js:2356
+#: erpnext/public/js/controllers/transaction.js:2382
 #: erpnext/public/js/utils.js:746
 #: erpnext/selling/doctype/quotation_item/quotation_item.json
 #: erpnext/selling/doctype/sales_order_item/sales_order_item.json
@@ -27273,7 +27264,7 @@ msgstr "Postavke Varijante Artikla"
 msgid "Item Variant {0} already exists with same attributes"
 msgstr "Varijanta Artikla {0} već postoji sa istim atributima"
 
-#: erpnext/stock/doctype/item/item.py:781
+#: erpnext/stock/doctype/item/item.py:772
 msgid "Item Variants updated"
 msgstr "Varijante Artikla Ažurirane"
 
@@ -27339,7 +27330,7 @@ msgstr "Detalji Artikla i Garancija"
 msgid "Item for row {0} does not match Material Request"
 msgstr "Artikal za red {0} ne odgovara Materijalnom Nalogu"
 
-#: erpnext/stock/doctype/item/item.py:795
+#: erpnext/stock/doctype/item/item.py:789
 msgid "Item has variants."
 msgstr "Artikal ima Varijante."
 
@@ -27365,7 +27356,7 @@ msgstr "Naziv Artikla"
 msgid "Item operation"
 msgstr "Artikal Operacija"
 
-#: erpnext/controllers/accounts_controller.py:3650
+#: erpnext/controllers/accounts_controller.py:3653
 msgid "Item qty can not be updated as raw materials are already processed."
 msgstr "Količina artikla se ne može ažurirati jer su sirovine već obrađene."
 
@@ -27391,7 +27382,7 @@ msgstr "Stopa vrednovanja artikla se preračunava s obzirom na iznos verifikata 
 msgid "Item valuation reposting in progress. Report might show incorrect item valuation."
 msgstr "Ponovno knjiženje vrijednosti artikla je u toku. Izvještaj može prikazati netačnu procjenu artikla."
 
-#: erpnext/stock/doctype/item/item.py:952
+#: erpnext/stock/doctype/item/item.py:946
 msgid "Item variant {0} exists with same attributes"
 msgstr "Varijanta Artikla {0} postoji sa istim atributima"
 
@@ -27404,8 +27395,7 @@ msgid "Item {0} cannot be ordered more than {1} against Blanket Order {2}."
 msgstr "Artikal {0} se nemože naručiti više od {1} u odnosu na Ugovorni Nalog {2}."
 
 #: erpnext/assets/doctype/asset/asset.py:277
-#: erpnext/stock/doctype/item/item.py:630
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:167
+#: erpnext/stock/doctype/item/item.py:636
 msgid "Item {0} does not exist"
 msgstr "Artikal {0} ne postoji"
 
@@ -27417,7 +27407,7 @@ msgstr "Artikal {0} ne postoji u sistemu ili je istekao"
 msgid "Item {0} does not exist."
 msgstr "Artikal {0} ne postoji."
 
-#: erpnext/controllers/selling_controller.py:752
+#: erpnext/controllers/selling_controller.py:760
 msgid "Item {0} entered multiple times."
 msgstr "Artikal {0} unesen više puta."
 
@@ -27433,7 +27423,7 @@ msgstr "Artikal {0} je onemogućen"
 msgid "Item {0} has no Serial No. Only serialized items can have delivery based on Serial No"
 msgstr "Artikal {0} nema serijski broj. Samo serijski artikli mogu imati dostavu na osnovu serijskog broja"
 
-#: erpnext/stock/doctype/item/item.py:1126
+#: erpnext/stock/doctype/item/item.py:1120
 msgid "Item {0} has reached its end of life on {1}"
 msgstr "Artikal {0} je dosego kraj svog vijeka trajanja {1}"
 
@@ -27445,11 +27435,11 @@ msgstr "Artikal {0} zanemaren jer nije artikal na zalihama"
 msgid "Item {0} is already reserved/delivered against Sales Order {1}."
 msgstr "Artikal {0} je već rezervisan/dostavljen naspram Prodajnog Naloga {1}."
 
-#: erpnext/stock/doctype/item/item.py:1146
+#: erpnext/stock/doctype/item/item.py:1140
 msgid "Item {0} is cancelled"
 msgstr "Artikal {0} je otkazan"
 
-#: erpnext/stock/doctype/item/item.py:1130
+#: erpnext/stock/doctype/item/item.py:1124
 msgid "Item {0} is disabled"
 msgstr "Artikal {0} je onemogućen"
 
@@ -27457,7 +27447,7 @@ msgstr "Artikal {0} je onemogućen"
 msgid "Item {0} is not a serialized Item"
 msgstr "Artikal {0} nije serijalizirani Artikal"
 
-#: erpnext/stock/doctype/item/item.py:1138
+#: erpnext/stock/doctype/item/item.py:1132
 msgid "Item {0} is not a stock Item"
 msgstr "Artikal {0} nije artikal na zalihama"
 
@@ -27501,7 +27491,7 @@ msgstr "Artikal {0}: Količina Naloga {1} ne može biti manja od minimalne koli�
 msgid "Item {0}: {1} qty produced. "
 msgstr "Artikal {0}: {1} količina proizvedena. "
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1429
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1423
 msgid "Item {} does not exist."
 msgstr "Atikal {} ne postoji."
 
@@ -27641,7 +27631,7 @@ msgstr "Kupovni Artikli"
 msgid "Items and Pricing"
 msgstr "Artikli & Cijene"
 
-#: erpnext/controllers/accounts_controller.py:3872
+#: erpnext/controllers/accounts_controller.py:3875
 msgid "Items cannot be updated as Subcontracting Order is created against the Purchase Order {0}."
 msgstr "Artikal se ne mođe ažurirati jer je Podugovorni Nalog kreiran naspram Kupovnog Naloga {0}."
 
@@ -28137,7 +28127,7 @@ msgstr "PDV i Naknade Obračunatog Troška"
 
 #. Name of a DocType
 #. Label of a Link in the Stock Workspace
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:674
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:676
 #: erpnext/stock/doctype/landed_cost_voucher/landed_cost_voucher.json
 #: erpnext/stock/doctype/purchase_receipt/purchase_receipt.js:104
 #: erpnext/stock/workspace/stock/stock.json
@@ -28752,7 +28742,7 @@ msgstr "Povezane Fakture"
 msgid "Linked Location"
 msgstr "Povezana Lokacija"
 
-#: erpnext/stock/doctype/item/item.py:999
+#: erpnext/stock/doctype/item/item.py:993
 msgid "Linked with submitted documents"
 msgstr "Povezano sa podnešenim dokumentima"
 
@@ -29491,7 +29481,7 @@ msgstr "Generalni Direktor"
 #: erpnext/manufacturing/doctype/bom/bom.py:261
 #: erpnext/manufacturing/doctype/bom_update_log/bom_update_log.py:71
 #: erpnext/public/js/controllers/accounts.js:249
-#: erpnext/public/js/controllers/transaction.js:2753
+#: erpnext/public/js/controllers/transaction.js:2779
 #: erpnext/public/js/utils/party.js:321
 #: erpnext/stock/doctype/delivery_note/delivery_note.js:164
 #: erpnext/stock/doctype/inventory_dimension/inventory_dimension.json
@@ -30347,7 +30337,7 @@ msgstr "Maksimalna Upotreba"
 msgid "Maximum Value"
 msgstr "Minimalna Vrijednost"
 
-#: erpnext/controllers/selling_controller.py:212
+#: erpnext/controllers/selling_controller.py:220
 msgid "Maximum discount for Item {0} is {1}%"
 msgstr "Maksimalni popust za Artikal {0} je {1}%"
 
@@ -30417,7 +30407,7 @@ msgstr "Megadžul"
 msgid "Megawatt"
 msgstr "Megavat"
 
-#: erpnext/stock/stock_ledger.py:1878
+#: erpnext/stock/stock_ledger.py:1887
 msgid "Mention Valuation Rate in the Item master."
 msgstr "Navedi Stopu Vrednovanja u Postavkama Artikla."
 
@@ -30812,11 +30802,11 @@ msgstr "Minuta"
 msgid "Miscellaneous Expenses"
 msgstr "Razni Troškovi"
 
-#: erpnext/controllers/buying_controller.py:540
+#: erpnext/controllers/buying_controller.py:548
 msgid "Mismatch"
 msgstr "Neusklađeno"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1430
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1424
 msgid "Missing"
 msgstr "Nedostaje"
 
@@ -31343,7 +31333,7 @@ msgstr "Više Varijanti"
 msgid "Multiple Warehouse Accounts"
 msgstr "Više Skladišnih Računa"
 
-#: erpnext/controllers/accounts_controller.py:1129
+#: erpnext/controllers/accounts_controller.py:1132
 msgid "Multiple fiscal years exist for the date {0}. Please set company in Fiscal Year"
 msgstr "Za datum {0} postoji više fiskalnih godina. Molimo postavite kompaniju u Fiskalnoj Godini"
 
@@ -31494,7 +31484,7 @@ msgstr "Prefiks Serije Imenovanja"
 msgid "Naming Series and Price Defaults"
 msgstr "Serija Imenovanja & Standard Cijene"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:90
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:91
 msgid "Naming Series is mandatory"
 msgstr "Serija Imenovanja je obavezna"
 
@@ -31533,15 +31523,15 @@ msgstr "Prirodni Gas"
 msgid "Needs Analysis"
 msgstr "Treba Analiza"
 
-#: erpnext/stock/serial_batch_bundle.py:1277
+#: erpnext/stock/serial_batch_bundle.py:1309
 msgid "Negative Batch Quantity"
 msgstr "Negativna količina Šarže"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:610
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:606
 msgid "Negative Quantity is not allowed"
 msgstr "Negativna Količina nije dozvoljena"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:615
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:611
 msgid "Negative Valuation Rate is not allowed"
 msgstr "Negativna Stopa Vrednovanja nije dozvoljena"
 
@@ -31823,7 +31813,7 @@ msgstr "Neto Težina"
 msgid "Net Weight UOM"
 msgstr "Jedinica Neto Težine"
 
-#: erpnext/controllers/accounts_controller.py:1483
+#: erpnext/controllers/accounts_controller.py:1486
 msgid "Net total calculation precision loss"
 msgstr "Ukupni neto gubitak preciznosti proračuna"
 
@@ -32166,7 +32156,7 @@ msgstr "Nije pronađen Kasa profil. Kreiraj novi Kasa Profil"
 #: erpnext/accounts/doctype/journal_entry/journal_entry.py:1539
 #: erpnext/accounts/doctype/journal_entry/journal_entry.py:1599
 #: erpnext/accounts/doctype/journal_entry/journal_entry.py:1613
-#: erpnext/stock/doctype/item/item.py:1371
+#: erpnext/stock/doctype/item/item.py:1365
 msgid "No Permission"
 msgstr "Bez Dozvole"
 
@@ -32188,7 +32178,7 @@ msgstr "Bez Primjedbi"
 msgid "No Selection"
 msgstr "Bez Odabira"
 
-#: erpnext/controllers/sales_and_purchase_return.py:919
+#: erpnext/controllers/sales_and_purchase_return.py:824
 msgid "No Serial / Batches are available for return"
 msgstr "Nema Serijskih Brojeva / Šarži dostupnih za povrat"
 
@@ -32224,7 +32214,7 @@ msgstr "Nisu pronađene neusaglašene uplate za ovu stranku"
 msgid "No Work Orders were created"
 msgstr "Radni Nalozi nisu kreirani"
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:785
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:794
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py:689
 msgid "No accounting entries for the following warehouses"
 msgstr "Nema knjigovodstvenih unosa za sljedeća skladišta"
@@ -32413,7 +32403,7 @@ msgstr "Nije pronađen zapis u tabeli Plaćanja"
 msgid "No reserved stock to unreserve."
 msgstr "Nema rezervisanih zaliha za poništavanje."
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:773
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:769
 msgid "No stock ledger entries were created. Please set the quantity or valuation rate for the items properly and try again."
 msgstr "Nisu kreirani unosi u glavnu knjigu zaliha. Molimo Vas da ispravno postavite količinu ili stopu vrednovanja za artikle i pokušate ponovno."
 
@@ -32497,7 +32487,7 @@ msgstr "kom."
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:566
 #: erpnext/assets/doctype/asset/asset.js:612
 #: erpnext/assets/doctype/asset/asset.js:627
-#: erpnext/controllers/buying_controller.py:225
+#: erpnext/controllers/buying_controller.py:233
 #: erpnext/selling/doctype/product_bundle/product_bundle.py:72
 #: erpnext/setup/doctype/transaction_deletion_record/transaction_deletion_record.py:80
 msgid "Not Allowed"
@@ -32618,10 +32608,10 @@ msgstr "Nije dozvoljeno"
 #: erpnext/selling/doctype/customer/customer.py:129
 #: erpnext/selling/doctype/sales_order/sales_order.js:1168
 #: erpnext/stock/doctype/item/item.js:526
-#: erpnext/stock/doctype/item/item.py:567
+#: erpnext/stock/doctype/item/item.py:573
 #: erpnext/stock/doctype/item_price/item_price.json
 #: erpnext/stock/doctype/stock_entry/stock_entry.py:1374
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:972
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:968
 #: erpnext/templates/pages/timelog_info.html:43
 msgid "Note"
 msgstr "Napomena"
@@ -32630,7 +32620,7 @@ msgstr "Napomena"
 msgid "Note: Automatic log deletion only applies to logs of type <i>Update Cost</i>"
 msgstr "Napomena: Automatsko brisanje zapisa primjenjuje se samo na zapise tipa <i>Ažuriraj Trošak</i>"
 
-#: erpnext/accounts/party.py:690
+#: erpnext/accounts/party.py:696
 msgid "Note: Due Date exceeds allowed {0} credit days by {1} day(s)"
 msgstr "Napomena: Datum dospijeća premašuje dozvoljenih {0} kreditnih dana za {1} dan/dana"
 
@@ -32656,7 +32646,7 @@ msgstr "Napomena: Unos plaćanja neće biti kreiran jer 'Gotovina ili Bankovni R
 msgid "Note: This Cost Center is a Group. Cannot make accounting entries against groups."
 msgstr "Napomena: Ovaj Centar Troškova je Grupa. Ne mogu se izvršiti knjigovodstveni unosi naspram grupa."
 
-#: erpnext/stock/doctype/item/item.py:621
+#: erpnext/stock/doctype/item/item.py:627
 msgid "Note: To merge the items, create a separate Stock Reconciliation for the old item {0}"
 msgstr "Napomena: Da biste spojili artikle, kreirajte zasebno Usaglašavanje Zaliha za stari artikal {0}"
 
@@ -33420,7 +33410,7 @@ msgstr "Početne Fakture Prodaje su kreirane."
 
 #. Label of the opening_stock (Float) field in DocType 'Item'
 #. Option for the 'Purpose' (Select) field in DocType 'Stock Reconciliation'
-#: erpnext/stock/doctype/item/item.json erpnext/stock/doctype/item/item.py:296
+#: erpnext/stock/doctype/item/item.json erpnext/stock/doctype/item/item.py:299
 #: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.json
 msgid "Opening Stock"
 msgstr "Početna Zaliha"
@@ -34140,7 +34130,7 @@ msgstr "Nepodmireno (Valuta Tvrtke)"
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:149
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1123
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1125
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:167
 #: erpnext/accounts/report/purchase_register/purchase_register.py:289
 #: erpnext/accounts/report/sales_register/sales_register.py:319
@@ -34179,7 +34169,7 @@ msgstr "Dostava"
 msgid "Over Billing Allowance (%)"
 msgstr "Dozvola za prekomjerno Fakturisanje (%)"
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:1242
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:1251
 msgid "Over Billing Allowance exceeded for Purchase Receipt Item {0} ({1}) by {2}%"
 msgstr "Dozvoljeni Iznos Prekoračenje Fakturisanja za Artikal Kupovnog Računa prekoračen {0} ({1}) za {2}%"
 
@@ -34220,7 +34210,7 @@ msgstr "Dozvola za prekomjerni Prenos (%)"
 msgid "Overbilling of {0} {1} ignored for item {2} because you have {3} role."
 msgstr "Prekomjerno Fakturisanje {0} {1} zanemareno za artikal {2} jer imate {3} ulogu."
 
-#: erpnext/controllers/accounts_controller.py:2013
+#: erpnext/controllers/accounts_controller.py:2016
 msgid "Overbilling of {} ignored because you have {} role."
 msgstr "Prekomjerno Fakturisanje {} zanemareno jer imate {} ulogu."
 
@@ -34727,7 +34717,7 @@ msgstr "Plaćeno"
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:146
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1117
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1119
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:165
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:172
 #: erpnext/accounts/report/pos_register/pos_register.py:209
@@ -34960,7 +34950,7 @@ msgstr "Nadređena Procedura"
 msgid "Parent Row No"
 msgstr "Nadređeni Red Broj"
 
-#: erpnext/manufacturing/doctype/bom_creator/bom_creator.py:495
+#: erpnext/manufacturing/doctype/bom_creator/bom_creator.py:496
 msgid "Parent Row No not found for {0}"
 msgstr "Nadređeni Red Broj nije pronađen za {0}"
 
@@ -35189,7 +35179,7 @@ msgstr "Dijelova na Milion"
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:142
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:159
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:57
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1054
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1056
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:67
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:147
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:228
@@ -35215,7 +35205,7 @@ msgstr "Stranka"
 
 #. Name of a DocType
 #: erpnext/accounts/doctype/party_account/party_account.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1065
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1067
 msgid "Party Account"
 msgstr "Račun Stranke"
 
@@ -35242,7 +35232,7 @@ msgstr "Valuta Računa Stranke"
 msgid "Party Account No. (Bank Statement)"
 msgstr "Broj Računa Stranke (Izvod iz Banke)"
 
-#: erpnext/controllers/accounts_controller.py:2278
+#: erpnext/controllers/accounts_controller.py:2281
 msgid "Party Account {0} currency ({1}) and document currency ({2}) should be same"
 msgstr "Valuta Računa Stranke {0} ({1}) i valuta dokumenta ({2}) trebaju biti iste"
 
@@ -35259,6 +35249,11 @@ msgstr "Bankovni Račun Stranke"
 #: erpnext/accounts/doctype/payment_request/payment_request.json
 msgid "Party Details"
 msgstr "Detalji Stranke"
+
+#. Label of the party_full_name (Data) field in DocType 'Contract'
+#: erpnext/crm/doctype/contract/contract.json
+msgid "Party Full Name"
+msgstr "Puno ime stranke"
 
 #. Label of the bank_party_iban (Data) field in DocType 'Bank Transaction'
 #: erpnext/accounts/doctype/bank_transaction/bank_transaction.json
@@ -35343,7 +35338,7 @@ msgstr "Specifični Artikal Stranke"
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:84
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:54
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:44
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1048
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1050
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:54
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:141
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:219
@@ -35365,7 +35360,7 @@ msgstr "Specifični Artikal Stranke"
 msgid "Party Type"
 msgstr "Tip Stranke"
 
-#: erpnext/accounts/party.py:819
+#: erpnext/accounts/party.py:825
 msgid "Party Type and Party can only be set for Receivable / Payable account<br><br>{0}"
 msgstr "Tip Stranke i Stranka mogu se postaviti samo za račun Potraživanja / Plaćanja<br><br>{0}"
 
@@ -35487,7 +35482,7 @@ msgid "Payable"
 msgstr "Plaća se"
 
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:42
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1063
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1065
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:211
 #: erpnext/accounts/report/purchase_register/purchase_register.py:194
 #: erpnext/accounts/report/purchase_register/purchase_register.py:235
@@ -35653,7 +35648,7 @@ msgstr "Unos plaćanja je izmijenjen nakon što ste ga povukli. Molim te povuci 
 msgid "Payment Entry is already created"
 msgstr "Unos plaćanja je već kreiran"
 
-#: erpnext/controllers/accounts_controller.py:1434
+#: erpnext/controllers/accounts_controller.py:1437
 msgid "Payment Entry {0} is linked against Order {1}, check if it should be pulled as advance in this invoice."
 msgstr "Unos plaćanja {0} je povezan naspram Naloga {1}, provjerite da li treba biti povučen kao predujam u ovoj fakturi."
 
@@ -35935,7 +35930,7 @@ msgstr "Status Plaćanja"
 #: erpnext/accounts/doctype/payment_schedule/payment_schedule.json
 #: erpnext/accounts/doctype/payment_term/payment_term.json
 #: erpnext/accounts/doctype/payment_terms_template_detail/payment_terms_template_detail.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1113
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1115
 #: erpnext/accounts/report/gross_profit/gross_profit.py:412
 #: erpnext/accounts/workspace/accounting/accounting.json
 #: erpnext/selling/report/payment_terms_status_for_sales_order/payment_terms_status_for_sales_order.py:30
@@ -36999,7 +36994,7 @@ msgstr "Kreiraj verifikate za Obračunate Troškove naspram Faktura koje imaju o
 msgid "Please create a new Accounting Dimension if required."
 msgstr "Kreiraj novu Knjigovodstvenu Dimenziju ako je potrebno."
 
-#: erpnext/controllers/accounts_controller.py:729
+#: erpnext/controllers/accounts_controller.py:732
 msgid "Please create purchase from internal sale or delivery document itself"
 msgstr "Kreiraj kupovinu iz interne prodaje ili samog dokumenta dostave"
 
@@ -37007,7 +37002,7 @@ msgstr "Kreiraj kupovinu iz interne prodaje ili samog dokumenta dostave"
 msgid "Please create purchase receipt or purchase invoice for the item {0}"
 msgstr "Kreiraj Kupovni Račun ili Kupovnu Fakturu za artikal {0}"
 
-#: erpnext/stock/doctype/item/item.py:649
+#: erpnext/stock/doctype/item/item.py:655
 msgid "Please delete Product Bundle {0}, before merging {1} into {2}"
 msgstr "Izbriši Artikal Paket {0}, prije spajanja {1} u {2}"
 
@@ -37049,7 +37044,7 @@ msgstr "Omogući iskačuće prozore"
 msgid "Please enable {0} in the {1}."
 msgstr "Omogući {0} u {1}."
 
-#: erpnext/controllers/selling_controller.py:754
+#: erpnext/controllers/selling_controller.py:762
 msgid "Please enable {} in {} to allow same item in multiple rows"
 msgstr "Omogući {} u {} da dozvolite isti artikal u više redova"
 
@@ -37082,7 +37077,7 @@ msgstr "Unesi Račun za Kusur"
 msgid "Please enter Approving Role or Approving User"
 msgstr "Unesi Odobravajuća Uloga ili Odobravajućeg Korisnika"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:939
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:935
 msgid "Please enter Cost Center"
 msgstr "Unesi Centar Troškova"
 
@@ -37094,7 +37089,7 @@ msgstr "Unesi Datum Dostave"
 msgid "Please enter Employee Id of this sales person"
 msgstr "Unesi Personal Id ovog Prodavača"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:948
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:944
 msgid "Please enter Expense Account"
 msgstr "Unesi Račun Troškova"
 
@@ -37103,7 +37098,7 @@ msgstr "Unesi Račun Troškova"
 msgid "Please enter Item Code to get Batch Number"
 msgstr "Unesi Kod Artikla da preuzmete Broj Šarže"
 
-#: erpnext/public/js/controllers/transaction.js:2503
+#: erpnext/public/js/controllers/transaction.js:2529
 msgid "Please enter Item Code to get batch no"
 msgstr "Unesi Kod Artikla da preuzmete Broj Šarže"
 
@@ -37168,7 +37163,7 @@ msgstr "Odaberi Kompaniju"
 msgid "Please enter company name first"
 msgstr "Unesi naziv kompanije"
 
-#: erpnext/controllers/accounts_controller.py:2764
+#: erpnext/controllers/accounts_controller.py:2767
 msgid "Please enter default currency in Company Master"
 msgstr "Unesi Standard Valutu u Postavkama Kompanije"
 
@@ -37204,7 +37199,7 @@ msgstr "Unesite Naziv Kompanije za potvrdu"
 msgid "Please enter the phone number first"
 msgstr "Unesi broj telefona"
 
-#: erpnext/controllers/buying_controller.py:1007
+#: erpnext/controllers/buying_controller.py:1015
 msgid "Please enter the {schedule_date}."
 msgstr "Unesi {schedule_date}."
 
@@ -37306,7 +37301,7 @@ msgstr "Spremi"
 msgid "Please select <b>Template Type</b> to download template"
 msgstr "Odaberi <b>Tip Šablona</b> za preuzimanje šablona"
 
-#: erpnext/controllers/taxes_and_totals.py:721
+#: erpnext/controllers/taxes_and_totals.py:731
 #: erpnext/public/js/controllers/taxes_and_totals.js:721
 msgid "Please select Apply Discount On"
 msgstr "Odaberi Primijeni Popust na"
@@ -37319,7 +37314,7 @@ msgstr "Odaberi Sastavnicu naspram Artikla {0}"
 msgid "Please select BOM for Item in Row {0}"
 msgstr "Odaberi Sastavnicu za artikal u redu {0}"
 
-#: erpnext/controllers/buying_controller.py:467
+#: erpnext/controllers/buying_controller.py:475
 msgid "Please select BOM in BOM field for Item {item_code}."
 msgstr "Odaberi Listu Materijala u Listi Materijala polja za Artikal {item_code}."
 
@@ -37401,7 +37396,7 @@ msgstr "Odaberi Cjenovnik"
 msgid "Please select Qty against item {0}"
 msgstr "Odaberi Količina naspram Artikla {0}"
 
-#: erpnext/stock/doctype/item/item.py:320
+#: erpnext/stock/doctype/item/item.py:323
 msgid "Please select Sample Retention Warehouse in Stock Settings first"
 msgstr "Odaberi Skladište za Zadržavanje Uzoraka u Postavkama Zaliha"
 
@@ -37417,7 +37412,7 @@ msgstr "Odaberi Datum Početka i Datum Završetka za Artikal {0}"
 msgid "Please select Subcontracting Order instead of Purchase Order {0}"
 msgstr "Odaberi Podizvođački umjesto Kupovnog Naloga {0}"
 
-#: erpnext/controllers/accounts_controller.py:2613
+#: erpnext/controllers/accounts_controller.py:2616
 msgid "Please select Unrealized Profit / Loss account or add default Unrealized Profit / Loss account account for company {0}"
 msgstr "Odaberi Račun Nerealiziranog Rezultata ili postavi Standard Račun Nerealiziranog Rezultata za kompaniju {0}"
 
@@ -37433,7 +37428,7 @@ msgstr "Odaberi Kompaniju"
 #: erpnext/manufacturing/doctype/bom/bom.js:603
 #: erpnext/manufacturing/doctype/bom/bom.py:261
 #: erpnext/public/js/controllers/accounts.js:249
-#: erpnext/public/js/controllers/transaction.js:2753
+#: erpnext/public/js/controllers/transaction.js:2779
 msgid "Please select a Company first."
 msgstr "Odaberi Kompaniju."
 
@@ -37591,7 +37586,7 @@ msgstr "Odaberi {0}"
 msgid "Please select {0} first"
 msgstr "Odaberi {0}"
 
-#: erpnext/public/js/controllers/transaction.js:77
+#: erpnext/public/js/controllers/transaction.js:100
 msgid "Please set 'Apply Additional Discount On'"
 msgstr "Postavi 'Primijeni Dodatni Popust Na'"
 
@@ -37776,7 +37771,7 @@ msgstr "Postavi filter na osnovu Artikla ili Skladišta"
 msgid "Please set filters"
 msgstr "Postavi filtere"
 
-#: erpnext/controllers/accounts_controller.py:2194
+#: erpnext/controllers/accounts_controller.py:2197
 msgid "Please set one of the following:"
 msgstr "Postavi jedno od sljedećeg:"
 
@@ -37784,7 +37779,7 @@ msgstr "Postavi jedno od sljedećeg:"
 msgid "Please set opening number of booked depreciations"
 msgstr "Postavi početni broj knjižene amortizacije"
 
-#: erpnext/public/js/controllers/transaction.js:2205
+#: erpnext/public/js/controllers/transaction.js:2231
 msgid "Please set recurring after saving"
 msgstr "Postavi ponavljanje nakon spremanja"
 
@@ -37855,7 +37850,7 @@ msgstr "Podesi i omogući grupni račun sa Kontnom Klasom - {0} za Kompaniju {1}
 msgid "Please share this email with your support team so that they can find and fix the issue."
 msgstr "Podijeli ovu e-poštu sa svojim timom za podršku kako bi mogli pronaći i riješiti problem."
 
-#: erpnext/public/js/controllers/transaction.js:2073
+#: erpnext/public/js/controllers/transaction.js:2099
 msgid "Please specify"
 msgstr "Navedi"
 
@@ -37870,7 +37865,7 @@ msgid "Please specify Company to proceed"
 msgstr "Navedi Kompaniju da nastavite"
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1472
-#: erpnext/controllers/accounts_controller.py:2957
+#: erpnext/controllers/accounts_controller.py:2960
 #: erpnext/public/js/controllers/accounts.js:97
 msgid "Please specify a valid Row ID for row {0} in table {1}"
 msgstr "Navedi važeći ID reda za red {0} u tabeli {1}"
@@ -37883,7 +37878,7 @@ msgstr "Navedi {0}."
 msgid "Please specify at least one attribute in the Attributes table"
 msgstr "Navedi barem jedan atribut u tabeli Atributa"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:605
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:601
 msgid "Please specify either Quantity or Valuation Rate or both"
 msgstr "Navedi ili Količinu ili Stopu Vrednovanja ili oboje"
 
@@ -38064,7 +38059,7 @@ msgstr "Poštanski Troškovi"
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:16
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:15
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:18
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1046
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1048
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:15
 #: erpnext/accounts/report/bank_clearance_summary/bank_clearance_summary.py:35
 #: erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.html:7
@@ -40245,7 +40240,7 @@ msgstr "Glavni Upravitelj Nabave"
 #: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.js:48
 #: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:203
 #: erpnext/buying/workspace/buying/buying.json
-#: erpnext/controllers/buying_controller.py:739
+#: erpnext/controllers/buying_controller.py:747
 #: erpnext/crm/doctype/contract/contract.json
 #: erpnext/manufacturing/doctype/blanket_order/blanket_order.js:54
 #: erpnext/manufacturing/doctype/production_plan_sub_assembly_item/production_plan_sub_assembly_item.json
@@ -40384,7 +40379,7 @@ msgstr "KupovniNalozi za Fakturisanje"
 msgid "Purchase Orders to Receive"
 msgstr "Kupovni Nalozi za Primiti"
 
-#: erpnext/controllers/accounts_controller.py:1833
+#: erpnext/controllers/accounts_controller.py:1836
 msgid "Purchase Orders {0} are un-linked"
 msgstr "Kupovni Nalozi {0} nisu povezani"
 
@@ -40408,8 +40403,8 @@ msgstr "Kupovni Cijenovnik"
 #. Label of a Link in the Stock Workspace
 #. Label of a shortcut in the Stock Workspace
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:171
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:650
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:660
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:652
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:662
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice_list.js:49
 #: erpnext/accounts/doctype/purchase_invoice_item/purchase_invoice_item.json
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:246
@@ -41144,7 +41139,7 @@ msgstr "Šablon Inspekciju Kvaliteta"
 msgid "Quality Inspection Template Name"
 msgstr "Naziv Šablona Kontrole Kvaliteta"
 
-#: erpnext/public/js/controllers/transaction.js:334
+#: erpnext/public/js/controllers/transaction.js:360
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:165
 msgid "Quality Inspection(s)"
 msgstr "Kontrola Kvaliteta"
@@ -42328,7 +42323,7 @@ msgid "Receivable / Payable Account"
 msgstr "Račun Potraživanja / Plaćanja"
 
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:71
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1061
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1063
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py:243
 #: erpnext/accounts/report/sales_register/sales_register.py:217
 #: erpnext/accounts/report/sales_register/sales_register.py:271
@@ -42810,7 +42805,7 @@ msgstr "Referenca #{0} datirana {1}"
 msgid "Reference Date"
 msgstr "Referentni Datum"
 
-#: erpnext/public/js/controllers/transaction.js:2311
+#: erpnext/public/js/controllers/transaction.js:2337
 msgid "Reference Date for Early Payment Discount"
 msgstr "Referentni Datum za popust pri ranijem plaćanju"
 
@@ -43134,7 +43129,7 @@ msgstr "Regularno"
 msgid "Rejected"
 msgstr "Odbijeno"
 
-#: erpnext/stock/doctype/inventory_dimension/inventory_dimension.py:202
+#: erpnext/stock/doctype/inventory_dimension/inventory_dimension.py:203
 msgid "Rejected "
 msgstr "Odbijeno "
 
@@ -43238,7 +43233,7 @@ msgstr "Preostali Iznos"
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:187
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:156
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1135
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1137
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:178
 msgid "Remaining Balance"
 msgstr "Preostalo Stanje"
@@ -43291,7 +43286,7 @@ msgstr "Napomena"
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:159
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:198
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:269
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1167
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1169
 #: erpnext/accounts/report/general_ledger/general_ledger.html:84
 #: erpnext/accounts/report/general_ledger/general_ledger.html:110
 #: erpnext/accounts/report/general_ledger/general_ledger.py:742
@@ -44041,7 +44036,7 @@ msgstr "Rezervisana Količina"
 msgid "Reserved Quantity for Production"
 msgstr "Rezervisana Količina za Proizvodnju"
 
-#: erpnext/stock/stock_ledger.py:2147
+#: erpnext/stock/stock_ledger.py:2155
 msgid "Reserved Serial No."
 msgstr "Rezervisani Serijski Broj"
 
@@ -44057,11 +44052,11 @@ msgstr "Rezervisani Serijski Broj"
 #: erpnext/stock/doctype/pick_list/pick_list.js:153
 #: erpnext/stock/report/reserved_stock/reserved_stock.json
 #: erpnext/stock/report/stock_balance/stock_balance.py:499
-#: erpnext/stock/stock_ledger.py:2131
+#: erpnext/stock/stock_ledger.py:2139
 msgid "Reserved Stock"
 msgstr "Rezervisane Zalihe"
 
-#: erpnext/stock/stock_ledger.py:2177
+#: erpnext/stock/stock_ledger.py:2185
 msgid "Reserved Stock for Batch"
 msgstr "Rezervisane Zalihe za Šaržu"
 
@@ -44073,7 +44068,7 @@ msgstr "Rezervsane Zalihe za Sirovine"
 msgid "Reserved Stock for Sub-assembly"
 msgstr "Rezervisane Zalihe za Podsklop"
 
-#: erpnext/controllers/buying_controller.py:476
+#: erpnext/controllers/buying_controller.py:484
 msgid "Reserved Warehouse is mandatory for the Item {item_code} in Raw Materials supplied."
 msgstr "Rezervisano Skladište je obavezno za artikal {item_code} u isporučenim Sirovinama."
 
@@ -44887,7 +44882,7 @@ msgstr "Redosllijed Operacija"
 msgid "Routing Name"
 msgstr "Naziv Redoslijeda Operacija"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:667
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:663
 msgid "Row #"
 msgstr "Red #"
 
@@ -44925,7 +44920,7 @@ msgstr "Red #{0} (Tabela Plaćanja): Iznos mora da je negativan"
 msgid "Row #{0} (Payment Table): Amount must be positive"
 msgstr "Red #{0} (Tabela Plaćanja): Iznos mora da je pozitivan"
 
-#: erpnext/stock/doctype/item/item.py:495
+#: erpnext/stock/doctype/item/item.py:498
 msgid "Row #{0}: A reorder entry already exists for warehouse {1} with reorder type {2}."
 msgstr "Red #{0}: Unos ponovnog naručivanja već postoji za skladište {1} sa tipom ponovnog naručivanja {2}."
 
@@ -44946,7 +44941,7 @@ msgstr "Red #{0}: Prihvaćeno Skladište i Odbijeno Skladište ne mogu biti isto
 msgid "Row #{0}: Accepted Warehouse is mandatory for the accepted Item {1}"
 msgstr "Red #{0}: Prihvaćeno Skladište je obavezno za Prihvaćeni Artikal {1}"
 
-#: erpnext/controllers/accounts_controller.py:1117
+#: erpnext/controllers/accounts_controller.py:1120
 msgid "Row #{0}: Account {1} does not belong to company {2}"
 msgstr "Red #{0}: Račun {1} ne pripada kompaniji {2}"
 
@@ -44987,27 +44982,27 @@ msgstr "Red #{0}: Broj Šarže {1} je već odabran."
 msgid "Row #{0}: Cannot allocate more than {1} against payment term {2}"
 msgstr "Red #{0}: Ne može se dodijeliti više od {1} naspram uslova plaćanja {2}"
 
-#: erpnext/controllers/accounts_controller.py:3524
+#: erpnext/controllers/accounts_controller.py:3527
 msgid "Row #{0}: Cannot delete item {1} which has already been billed."
 msgstr "Red #{0}: Ne mogu izbrisati artikal {1} koja je već fakturisana."
 
-#: erpnext/controllers/accounts_controller.py:3498
+#: erpnext/controllers/accounts_controller.py:3501
 msgid "Row #{0}: Cannot delete item {1} which has already been delivered"
 msgstr "Red #{0}: Ne mogu izbrisati artikal {1} koji je već dostavljen"
 
-#: erpnext/controllers/accounts_controller.py:3517
+#: erpnext/controllers/accounts_controller.py:3520
 msgid "Row #{0}: Cannot delete item {1} which has already been received"
 msgstr "Red #{0}: Ne mogu izbrisati artikal {1} koji je već preuzet"
 
-#: erpnext/controllers/accounts_controller.py:3504
+#: erpnext/controllers/accounts_controller.py:3507
 msgid "Row #{0}: Cannot delete item {1} which has work order assigned to it."
 msgstr "Red #{0}: Ne mogu izbrisati artikal {1} kojem je dodijeljen radni nalog."
 
-#: erpnext/controllers/accounts_controller.py:3510
+#: erpnext/controllers/accounts_controller.py:3513
 msgid "Row #{0}: Cannot delete item {1} which is assigned to customer's purchase order."
 msgstr "Red #{0}: Nije moguće izbrisati artikal {1} kojem je dodijeljen kupčev nalog."
 
-#: erpnext/controllers/accounts_controller.py:3765
+#: erpnext/controllers/accounts_controller.py:3768
 msgid "Row #{0}: Cannot set Rate if the billed amount is greater than the amount for Item {1}."
 msgstr "Red #{0}: Ne može se postaviti cijena ako je fakturisani iznos veći od iznosa za artikal {1}."
 
@@ -45127,7 +45122,7 @@ msgstr "Red #{0}: Artikel {1} ne postoji"
 msgid "Row #{0}: Item {1} has been picked, please reserve stock from the Pick List."
 msgstr "Red #{0}: Artikal {1} je odabran, rezerviši zalihe sa Liste Odabira."
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:729
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:725
 msgid "Row #{0}: Item {1} is not a Serialized/Batched Item. It cannot have a Serial No/Batch No against it."
 msgstr "Red #{0}: Artikal {1} nije Serijalizirani/Šaržirani Artikal. Ne može imati Serijski Broj / Broj Šarže naspram sebe."
 
@@ -45183,7 +45178,7 @@ msgstr "Red #{0}: Odaberi broj Spiska Materijala u Artiklima Montaže"
 msgid "Row #{0}: Please select the Sub Assembly Warehouse"
 msgstr "Red #{0}: Odaberi Skladište Podmontaže"
 
-#: erpnext/stock/doctype/item/item.py:502
+#: erpnext/stock/doctype/item/item.py:505
 msgid "Row #{0}: Please set reorder quantity"
 msgstr "Red #{0}: Postavite količinu za ponovnu narudžbu"
 
@@ -45216,8 +45211,8 @@ msgstr "Red #{0}: Kontrola kKvaliteta {1} nije dostavljena za artikal: {2}"
 msgid "Row #{0}: Quality Inspection {1} was rejected for item {2}"
 msgstr "Red #{0}: Kontrola Kvaliteta {1} je odbijena za artikal {2}"
 
-#: erpnext/controllers/accounts_controller.py:1274
-#: erpnext/controllers/accounts_controller.py:3624
+#: erpnext/controllers/accounts_controller.py:1277
+#: erpnext/controllers/accounts_controller.py:3627
 msgid "Row #{0}: Quantity for Item {1} cannot be zero."
 msgstr "Red #{0}: Količina za artikal {1} ne može biti nula."
 
@@ -45254,7 +45249,7 @@ msgstr "Red #{0}: Povrat Naspram za povrat imovine je obavezno"
 msgid "Row #{0}: Scrap Item Qty cannot be zero"
 msgstr "Red #{0}: Količina Otpadnih Artikala ne može biti nula"
 
-#: erpnext/controllers/selling_controller.py:230
+#: erpnext/controllers/selling_controller.py:238
 msgid "Row #{0}: Selling rate for item {1} is lower than its {2}.\n"
 "\t\t\t\t\tSelling {3} should be atleast {4}.<br><br>Alternatively,\n"
 "\t\t\t\t\tyou can disable selling price validation in {5} to bypass\n"
@@ -45341,7 +45336,7 @@ msgstr "Red #{0}: Zaliha nije dostupna za rezervisanje za artikal {1} u skladiš
 msgid "Row #{0}: The batch {1} has already expired."
 msgstr "Red #{0}: Šarža {1} je već istekla."
 
-#: erpnext/stock/doctype/item/item.py:511
+#: erpnext/stock/doctype/item/item.py:514
 msgid "Row #{0}: The warehouse {1} is not a child warehouse of a group warehouse {2}"
 msgstr "Red #{0}: Skladište {1} nije podređeno skladište grupnog skladišta {2}"
 
@@ -45381,39 +45376,39 @@ msgstr "Red #{0}: {1} od {2} bi trebao biti {3}. Ažuriraj {1} ili odaberi drugi
 msgid "Row #{1}: Warehouse is mandatory for stock Item {0}"
 msgstr "Red #{1}: Skladište je obavezno za artikal {0}"
 
-#: erpnext/controllers/buying_controller.py:259
+#: erpnext/controllers/buying_controller.py:267
 msgid "Row #{idx}: Cannot select Supplier Warehouse while suppling raw materials to subcontractor."
 msgstr "Red #{idx}: Ne može se odabrati Skladište Dobavljača dok isporučuje sirovine podizvođaču."
 
-#: erpnext/controllers/buying_controller.py:406
+#: erpnext/controllers/buying_controller.py:414
 msgid "Row #{idx}: Item rate has been updated as per valuation rate since its an internal stock transfer."
 msgstr "Red #{idx}: Cijena artikla je ažurirana prema stopi vrednovanja zato što je ovo interni prijenos zaliha."
 
-#: erpnext/controllers/buying_controller.py:881
+#: erpnext/controllers/buying_controller.py:889
 msgid "Row #{idx}: Please enter a location for the asset item {item_code}."
 msgstr "Red #{idx}: Unesi lokaciju za imovinski artikal {item_code}."
 
-#: erpnext/controllers/buying_controller.py:537
+#: erpnext/controllers/buying_controller.py:545
 msgid "Row #{idx}: Received Qty must be equal to Accepted + Rejected Qty for Item {item_code}."
 msgstr "Red #{idx}: Primljena količina mora biti jednaka Prihvaćenoj + Odbijenoj količini za Artikal {item_code}."
 
-#: erpnext/controllers/buying_controller.py:550
+#: erpnext/controllers/buying_controller.py:558
 msgid "Row #{idx}: {field_label} can not be negative for item {item_code}."
 msgstr "Red #{idx}: {field_label} ne može biti negativan za artikal {item_code}."
 
-#: erpnext/controllers/buying_controller.py:496
+#: erpnext/controllers/buying_controller.py:504
 msgid "Row #{idx}: {field_label} is mandatory."
 msgstr "Red #{idx}: {field_label} je obavezan."
 
-#: erpnext/controllers/buying_controller.py:518
+#: erpnext/controllers/buying_controller.py:526
 msgid "Row #{idx}: {field_label} is not allowed in Purchase Return."
 msgstr "Red #{idx}: {field_label} nije dozvoljen u Povratu Kupovine."
 
-#: erpnext/controllers/buying_controller.py:250
+#: erpnext/controllers/buying_controller.py:258
 msgid "Row #{idx}: {from_warehouse_field} and {to_warehouse_field} cannot be same."
 msgstr "Red #{idx}: {from_warehouse_field} i {to_warehouse_field} ne mogu biti isti."
 
-#: erpnext/controllers/buying_controller.py:999
+#: erpnext/controllers/buying_controller.py:1007
 msgid "Row #{idx}: {schedule_date} cannot be before {transaction_date}."
 msgstr "Red #{idx}: {schedule_date} ne može biti prije {transaction_date}."
 
@@ -45478,7 +45473,7 @@ msgstr "Red #{}: {}"
 msgid "Row #{}: {} {} does not exist."
 msgstr "Red #{}: {} {} ne postoji."
 
-#: erpnext/stock/doctype/item/item.py:1403
+#: erpnext/stock/doctype/item/item.py:1397
 msgid "Row #{}: {} {} doesn't belong to Company {}. Please select valid {}."
 msgstr "Red #{}: {} {} ne pripada kompaniji {}. Odaberi važeći {}."
 
@@ -45550,11 +45545,11 @@ msgstr "Red {0}: Sastavnica nije pronađena za Artikal {1}"
 msgid "Row {0}: Both Debit and Credit values cannot be zero"
 msgstr "Red {0}: Vrijednosti debita i kredita ne mogu biti nula"
 
-#: erpnext/controllers/selling_controller.py:222
+#: erpnext/controllers/selling_controller.py:230
 msgid "Row {0}: Conversion Factor is mandatory"
 msgstr "Red {0}: Faktor konverzije je obavezan"
 
-#: erpnext/controllers/accounts_controller.py:2995
+#: erpnext/controllers/accounts_controller.py:2998
 msgid "Row {0}: Cost Center {1} does not belong to Company {2}"
 msgstr "Red {0}: Centar Troškova {1} ne pripada kompaniji {2}"
 
@@ -45574,11 +45569,11 @@ msgstr "Red {0}: Valuta Sastavnice #{1} bi trebala biti jednaka odabranoj valuti
 msgid "Row {0}: Debit entry can not be linked with a {1}"
 msgstr "Red {0}: Unos debita ne može se povezati sa {1}"
 
-#: erpnext/controllers/selling_controller.py:776
+#: erpnext/controllers/selling_controller.py:784
 msgid "Row {0}: Delivery Warehouse ({1}) and Customer Warehouse ({2}) can not be same"
 msgstr "Red {0}: Skladište za Dostavu ({1}) i Skladište za Klijente ({2}) ne mogu biti isto"
 
-#: erpnext/controllers/accounts_controller.py:2529
+#: erpnext/controllers/accounts_controller.py:2532
 msgid "Row {0}: Due Date in the Payment Terms table cannot be before Posting Date"
 msgstr "Red {0}: Datum roka plaćanja u tabeli Uslovi Plaćanja ne može biti prije datuma knjiženja"
 
@@ -45587,7 +45582,7 @@ msgid "Row {0}: Either Delivery Note Item or Packed Item reference is mandatory.
 msgstr "Red {0}: Ili je Artikal Dostavnice ili Pakirani Artikal referenca obavezna."
 
 #: erpnext/accounts/doctype/journal_entry/journal_entry.py:1010
-#: erpnext/controllers/taxes_and_totals.py:1205
+#: erpnext/controllers/taxes_and_totals.py:1215
 msgid "Row {0}: Exchange Rate is mandatory"
 msgstr "Red {0}: Devizni Kurs je obavezan"
 
@@ -45636,11 +45631,11 @@ msgstr "Red {0}: Vrijednost sati mora biti veća od nule."
 msgid "Row {0}: Invalid reference {1}"
 msgstr "Red {0}: Nevažeća referenca {1}"
 
-#: erpnext/controllers/taxes_and_totals.py:142
+#: erpnext/controllers/taxes_and_totals.py:143
 msgid "Row {0}: Item Tax template updated as per validity and rate applied"
 msgstr "Red {0}: Šablon PDV-a za Artikal ažuriran je prema valjanosti i primijenjenoj cijeni"
 
-#: erpnext/controllers/selling_controller.py:541
+#: erpnext/controllers/selling_controller.py:549
 msgid "Row {0}: Item rate has been updated as per valuation rate since its an internal stock transfer"
 msgstr "Red {0}: Cijena artikla je ažurirana prema stopi vrednovanja zato što je ovo interni prijenos zaliha"
 
@@ -45760,7 +45755,7 @@ msgstr "Red {0}: Zadatak {1} ne pripada Projektu {2}"
 msgid "Row {0}: The item {1}, quantity must be positive number"
 msgstr "Red {0}: Artikal {1}, količina mora biti pozitivan broj"
 
-#: erpnext/controllers/accounts_controller.py:2972
+#: erpnext/controllers/accounts_controller.py:2975
 msgid "Row {0}: The {3} Account {1} does not belong to the company {2}"
 msgstr "Red {0}: {3} Račun {1} ne pripada kompaniji {2}"
 
@@ -45777,7 +45772,7 @@ msgstr "Red {0}: Jedinični Faktor Konverzije je obavezan"
 msgid "Row {0}: Workstation or Workstation Type is mandatory for an operation {1}"
 msgstr "Red {0}: Radna Stanica ili Tip Radne Stanice je obavezan za operaciju {1}"
 
-#: erpnext/controllers/accounts_controller.py:1011
+#: erpnext/controllers/accounts_controller.py:1014
 msgid "Row {0}: user has not applied the rule {1} on the item {2}"
 msgstr "Red {0}: korisnik nije primijenio pravilo {1} na artikal {2}"
 
@@ -45789,7 +45784,7 @@ msgstr "Red {0}: {1} račun je već primijenjen za Knjigovodstvenu Dimenziju {2}
 msgid "Row {0}: {1} must be greater than 0"
 msgstr "Red {0}: {1} mora biti veći od 0"
 
-#: erpnext/controllers/accounts_controller.py:706
+#: erpnext/controllers/accounts_controller.py:709
 msgid "Row {0}: {1} {2} cannot be same as {3} (Party Account) {4}"
 msgstr "Red {0}: {1} {2} ne može biti isto kao {3} (Račun Stranke) {4}"
 
@@ -45805,7 +45800,7 @@ msgstr "Red {0}: {2} Artikal {1} ne postoji u {2} {3}"
 msgid "Row {1}: Quantity ({0}) cannot be a fraction. To allow this, disable '{2}' in UOM {3}."
 msgstr "Red {1}: Količina ({0}) ne može biti razlomak. Da biste to omogućili, onemogućite '{2}' u Jedinici {3}."
 
-#: erpnext/controllers/buying_controller.py:863
+#: erpnext/controllers/buying_controller.py:871
 msgid "Row {idx}: Asset Naming Series is mandatory for the auto creation of assets for item {item_code}."
 msgstr "Red {idx}: Serija Imenovanja Imovine je obavezna za automatsko kreiranje sredstava za artikal {item_code}."
 
@@ -45831,7 +45826,7 @@ msgstr "Redovi uklonjeni u {0}"
 msgid "Rows with Same Account heads will be merged on Ledger"
 msgstr "Redovi sa unosom istog računa će se spojiti u Registru"
 
-#: erpnext/controllers/accounts_controller.py:2539
+#: erpnext/controllers/accounts_controller.py:2542
 msgid "Rows with duplicate due dates in other rows were found: {0}"
 msgstr "Pronađeni su redovi sa dupliranim rokovima u drugim redovima: {0}"
 
@@ -45901,7 +45896,7 @@ msgstr "Standard Nivo Servisa Ispunjen na Status"
 msgid "SLA Paused On"
 msgstr "Standard Nivo Servisa Pauziran"
 
-#: erpnext/public/js/utils.js:1167
+#: erpnext/public/js/utils.js:1163
 msgid "SLA is on hold since {0}"
 msgstr "Standard Nivo Servisa je na Čekanju od {0}"
 
@@ -46302,7 +46297,7 @@ msgstr "Mogućnos Prodaje prema Izvoru"
 #: erpnext/accounts/report/sales_register/sales_register.py:238
 #: erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
 #: erpnext/buying/doctype/supplier_quotation_item/supplier_quotation_item.json
-#: erpnext/controllers/selling_controller.py:462
+#: erpnext/controllers/selling_controller.py:470
 #: erpnext/crm/doctype/contract/contract.json
 #: erpnext/maintenance/doctype/maintenance_schedule/maintenance_schedule.js:65
 #: erpnext/maintenance/doctype/maintenance_schedule_item/maintenance_schedule_item.json
@@ -46428,7 +46423,7 @@ msgstr "Prodajni Nalog {0} nije podnešen"
 msgid "Sales Order {0} is not valid"
 msgstr "Prodajni Nalog {0} ne važi"
 
-#: erpnext/controllers/selling_controller.py:443
+#: erpnext/controllers/selling_controller.py:451
 #: erpnext/manufacturing/doctype/work_order/work_order.py:301
 msgid "Sales Order {0} is {1}"
 msgstr "Prodajni Nalog {0} je {1}"
@@ -46479,7 +46474,7 @@ msgstr "Prodajni Nalozi za Dostavu"
 #: erpnext/accounts/doctype/promotional_scheme/promotional_scheme.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:122
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1156
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1158
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:99
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:194
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:74
@@ -46577,7 +46572,7 @@ msgstr "Sažetak Prodajnog Plaćanja"
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:156
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:137
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:128
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1153
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1155
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:105
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:191
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:80
@@ -46597,7 +46592,7 @@ msgstr "Sažetak Prodajnog Plaćanja"
 msgid "Sales Person"
 msgstr "Prodavač"
 
-#: erpnext/controllers/selling_controller.py:204
+#: erpnext/controllers/selling_controller.py:212
 msgid "Sales Person <b>{0}</b> is disabled."
 msgstr "Prodavač <b>{0}</b> je onemogućen."
 
@@ -46878,7 +46873,7 @@ msgstr "Skladište Zadržavanja Uzoraka"
 
 #. Label of the sample_size (Float) field in DocType 'Quality Inspection'
 #: erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py:93
-#: erpnext/public/js/controllers/transaction.js:2369
+#: erpnext/public/js/controllers/transaction.js:2395
 #: erpnext/stock/doctype/quality_inspection/quality_inspection.json
 msgid "Sample Size"
 msgstr "Veličina Uzorka"
@@ -47418,7 +47413,7 @@ msgstr "Odaberi Artikle"
 msgid "Select Items based on Delivery Date"
 msgstr "OdaberiArtikal na osnovu Datuma Dostave"
 
-#: erpnext/public/js/controllers/transaction.js:2405
+#: erpnext/public/js/controllers/transaction.js:2431
 msgid "Select Items for Quality Inspection"
 msgstr "Odaberi Artikle za Inspekciju Kvaliteta"
 
@@ -47559,7 +47554,7 @@ msgstr "Odaberi Kompaniju"
 msgid "Select company name first."
 msgstr "Odaberite Naziv Kompanije."
 
-#: erpnext/controllers/accounts_controller.py:2785
+#: erpnext/controllers/accounts_controller.py:2788
 msgid "Select finance book for the item {0} at row {1}"
 msgstr "Odaberi Finansijski Registar za artikal {0} u redu {1}"
 
@@ -47773,7 +47768,7 @@ msgid "Send Now"
 msgstr "Pošalji Odmah"
 
 #. Label of the send_sms (Button) field in DocType 'SMS Center'
-#: erpnext/public/js/controllers/transaction.js:517
+#: erpnext/public/js/controllers/transaction.js:543
 #: erpnext/selling/doctype/sms_center/sms_center.json
 msgid "Send SMS"
 msgstr "Pošalji SMS"
@@ -47931,7 +47926,7 @@ msgstr "Serijski / Šaržni Broj"
 #: erpnext/manufacturing/doctype/job_card/job_card.json
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.js:74
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.py:114
-#: erpnext/public/js/controllers/transaction.js:2382
+#: erpnext/public/js/controllers/transaction.js:2408
 #: erpnext/public/js/utils/serial_no_batch_selector.js:421
 #: erpnext/selling/doctype/installation_note_item/installation_note_item.json
 #: erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
@@ -47980,7 +47975,7 @@ msgstr "Serijski Broj Registar"
 msgid "Serial No Range"
 msgstr "Serijski Broj Raspon"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1894
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1895
 msgid "Serial No Reserved"
 msgstr "Rezervisan Serijski Broj"
 
@@ -48020,7 +48015,7 @@ msgstr "Serijski Broj i Šarža"
 msgid "Serial No and Batch Selector cannot be use when Use Serial / Batch Fields is enabled."
 msgstr "Serijski Broj i odabirač Šarže ne mogu se koristiti kada je omogućeno Koristi Serijski Broj / Šaržna Polja."
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:859
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:860
 msgid "Serial No is mandatory"
 msgstr "Serijski Broj je Obavezan"
 
@@ -48049,7 +48044,7 @@ msgstr "Serijski Broj {0} ne pripada Artiklu {1}"
 msgid "Serial No {0} does not exist"
 msgstr "Serijski Broj {0} ne postoji"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2623
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2624
 msgid "Serial No {0} does not exists"
 msgstr "Serijski Broj {0} ne postoji"
 
@@ -48057,7 +48052,7 @@ msgstr "Serijski Broj {0} ne postoji"
 msgid "Serial No {0} is already added"
 msgstr "Serijski Broj {0} je već dodan"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:357
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:358
 msgid "Serial No {0} is not present in the {1} {2}, hence you can't return it against the {1} {2}"
 msgstr "Serijski broj {0} nije u {1} {2}, i ne može se vratiti naspram {1} {2}"
 
@@ -48094,11 +48089,11 @@ msgstr "Serijski Broj / Šaržni Broj"
 msgid "Serial Nos and Batches"
 msgstr "Serijski Brojevi & Šarže"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1370
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1371
 msgid "Serial Nos are created successfully"
 msgstr "Serijski Brojevi su uspješno kreirani"
 
-#: erpnext/stock/stock_ledger.py:2137
+#: erpnext/stock/stock_ledger.py:2145
 msgid "Serial Nos are reserved in Stock Reservation Entries, you need to unreserve them before proceeding."
 msgstr "Serijski brojevi su rezervisani u unosima za rezervacije zaliha, morate ih opozvati prije nego što nastavite."
 
@@ -48172,11 +48167,11 @@ msgstr "Serijski i Šarža"
 msgid "Serial and Batch Bundle"
 msgstr "Serijski i Šaržni Paket"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1598
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1599
 msgid "Serial and Batch Bundle created"
 msgstr "Serijski i Šaržni Paket je kreiran"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1664
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1665
 msgid "Serial and Batch Bundle updated"
 msgstr "Serijski i Šaržni Paket je ažuriran"
 
@@ -48528,12 +48523,12 @@ msgid "Service Stop Date"
 msgstr "Datum završetka Servisa"
 
 #: erpnext/accounts/deferred_revenue.py:44
-#: erpnext/public/js/controllers/transaction.js:1420
+#: erpnext/public/js/controllers/transaction.js:1446
 msgid "Service Stop Date cannot be after Service End Date"
 msgstr "Datum prekida servisa ne može biti nakon datuma završetka servisa"
 
 #: erpnext/accounts/deferred_revenue.py:41
-#: erpnext/public/js/controllers/transaction.js:1417
+#: erpnext/public/js/controllers/transaction.js:1443
 msgid "Service Stop Date cannot be before Service Start Date"
 msgstr "Datum zaustavljanja servisa ne može biti prije datuma početka servisa"
 
@@ -49970,7 +49965,7 @@ msgstr "Standard Ocenjeni Troškovi"
 
 #: erpnext/setup/setup_wizard/operations/defaults_setup.py:70
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:463
-#: erpnext/stock/doctype/item/item.py:245
+#: erpnext/stock/doctype/item/item.py:248
 msgid "Standard Selling"
 msgstr "Standard Prodaja"
 
@@ -50800,7 +50795,7 @@ msgstr "Zaliha Primljena, ali nije Fakturisana"
 #. Option for the 'Purpose' (Select) field in DocType 'Stock Reconciliation'
 #. Label of a Link in the Stock Workspace
 #: erpnext/setup/workspace/home/home.json
-#: erpnext/stock/doctype/item/item.py:612
+#: erpnext/stock/doctype/item/item.py:618
 #: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.json
 #: erpnext/stock/workspace/stock/stock.json
 msgid "Stock Reconciliation"
@@ -50811,7 +50806,7 @@ msgstr "Popis Zaliha"
 msgid "Stock Reconciliation Item"
 msgstr "Artikal Popisa Zaliha"
 
-#: erpnext/stock/doctype/item/item.py:612
+#: erpnext/stock/doctype/item/item.py:618
 msgid "Stock Reconciliations"
 msgstr "Popisi Zaliha"
 
@@ -50846,7 +50841,7 @@ msgstr "Postavke Ponovnog Knjiženja Zaliha"
 #: erpnext/stock/doctype/pick_list/pick_list.js:150
 #: erpnext/stock/doctype/pick_list/pick_list.js:155
 #: erpnext/stock/doctype/stock_entry/stock_entry_dashboard.py:25
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:706
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:702
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:575
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:1138
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:1398
@@ -51246,7 +51241,7 @@ msgstr "Zaustavljeni Radni Nalog se ne može otkazati, prvo ga prekini da biste 
 #: erpnext/setup/doctype/company/company.py:287
 #: erpnext/setup/setup_wizard/operations/defaults_setup.py:33
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:502
-#: erpnext/stock/doctype/item/item.py:282
+#: erpnext/stock/doctype/item/item.py:285
 msgid "Stores"
 msgstr "Prodavnice"
 
@@ -51781,7 +51776,7 @@ msgstr "Uspješno Usaglašeno"
 msgid "Successfully Set Supplier"
 msgstr "Uspješno Postavljen Dobavljač"
 
-#: erpnext/stock/doctype/item/item.py:339
+#: erpnext/stock/doctype/item/item.py:342
 msgid "Successfully changed Stock UOM, please redefine conversion factors for new UOM."
 msgstr "Uspješno promijenjena Jedinica Zaliha, redefinirajte faktore konverzije za novu Jedinicu."
 
@@ -52083,7 +52078,7 @@ msgstr "Detalji Dobavljača"
 #: erpnext/accounts/doctype/tax_rule/tax_rule.json
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:111
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:87
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1160
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1162
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:198
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:237
 #: erpnext/accounts/report/purchase_register/purchase_register.js:27
@@ -52183,7 +52178,7 @@ msgstr "Registar Dobavljača"
 #. Label of the supplier_name (Data) field in DocType 'Purchase Receipt'
 #. Label of the supplier_name (Data) field in DocType 'Stock Entry'
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1077
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1079
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:156
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:198
 #: erpnext/accounts/report/purchase_register/purchase_register.py:177
@@ -52667,7 +52662,7 @@ msgstr "Sistem će automatski kreirati serijske brojeve/šaržu za Gotov Proizvo
 msgid "System will fetch all the entries if limit value is zero."
 msgstr "Sistem će preuyeti sve unose ako je granična vrijednost nula."
 
-#: erpnext/controllers/accounts_controller.py:1975
+#: erpnext/controllers/accounts_controller.py:1978
 msgid "System will not check over billing since amount for Item {0} in {1} is zero"
 msgstr "Sistem neće provjeravati prekomjerno fakturisanje jer je iznos za Artikal {0} u {1} nula"
 
@@ -52926,7 +52921,7 @@ msgstr "Greška pri Rezervaciji Skladišta"
 msgid "Target Warehouse is required before Submit"
 msgstr "Skladište je obavezno prije Podnošenja"
 
-#: erpnext/controllers/selling_controller.py:782
+#: erpnext/controllers/selling_controller.py:790
 msgid "Target Warehouse is set for some items but the customer is not an internal customer."
 msgstr "Skladište je postavljeno za neke artikle, ali klijent nije interni klijent."
 
@@ -53165,7 +53160,7 @@ msgstr "PDV Raspodjela"
 msgid "Tax Category"
 msgstr "Kategorija PDV-a"
 
-#: erpnext/controllers/buying_controller.py:194
+#: erpnext/controllers/buying_controller.py:202
 msgid "Tax Category has been changed to \"Total\" because all the Items are non-stock items"
 msgstr "PDV Kategorija je promijenjena u \"Ukupno\" jer svi artikli nisu na zalihama"
 
@@ -53371,7 +53366,7 @@ msgstr "PDV će biti odbijen samo za iznos koji premašuje kumulativni prag"
 #. Label of the taxable_amount (Currency) field in DocType 'Tax Withheld
 #. Vouchers'
 #: erpnext/accounts/doctype/tax_withheld_vouchers/tax_withheld_vouchers.json
-#: erpnext/controllers/taxes_and_totals.py:1125
+#: erpnext/controllers/taxes_and_totals.py:1135
 msgid "Taxable Amount"
 msgstr "Oporezivi Iznos"
 
@@ -53510,7 +53505,7 @@ msgstr "Odbijeni PDV i Naknade"
 msgid "Taxes and Charges Deducted (Company Currency)"
 msgstr "Odbijeni PDV i Naknade (Valuta Kompanije)"
 
-#: erpnext/stock/doctype/item/item.py:352
+#: erpnext/stock/doctype/item/item.py:355
 msgid "Taxes row #{0}: {1} cannot be smaller than {2}"
 msgstr "PDV red #{0}: {1} ne može biti manji od {2}"
 
@@ -53796,7 +53791,7 @@ msgstr "Šablon Odredbi i Uslova"
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/territory_item/territory_item.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:134
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1144
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1146
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:93
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:182
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:68
@@ -53900,7 +53895,7 @@ msgstr "Pristup zahtjevu za ponudu sa portala je onemogućen. Da biste omogućil
 msgid "The BOM which will be replaced"
 msgstr "Sastavnica koja će biti zamijenjena"
 
-#: erpnext/stock/serial_batch_bundle.py:1274
+#: erpnext/stock/serial_batch_bundle.py:1306
 msgid "The Batch {0} has negative quantity {1} in warehouse {2}. Please correct the quantity."
 msgstr "Šarća {0} ima negativnu količinu {1} u skladištu {2}. Ispravi količinu."
 
@@ -53952,7 +53947,7 @@ msgstr "Prodavač je povezan sa {0}"
 msgid "The Serial No at Row #{0}: {1} is not available in warehouse {2}."
 msgstr "Serijski Broj u redu #{0}: {1} nije dostupan u skladištu {2}."
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1891
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1892
 msgid "The Serial No {0} is reserved against the {1} {2} and cannot be used for any other transaction."
 msgstr "Serijski Broj {0} je rezervisan naspram {1} {2} i ne može se koristiti za bilo koju drugu transakciju."
 
@@ -54035,7 +54030,7 @@ msgstr "Sljedeća imovina nije uspjela automatski knjižiti unose amortizacije: 
 msgid "The following batches are expired, please restock them: <br> {0}"
 msgstr "Sljedeće šarže su istekle, obnovi zalihe: <br> {0}"
 
-#: erpnext/stock/doctype/item/item.py:849
+#: erpnext/stock/doctype/item/item.py:843
 msgid "The following deleted attributes exist in Variants but not in the Template. You can either delete the Variants or keep the attribute(s) in template."
 msgstr "Sljedeći izbrisani atributi postoje u varijantama, ali ne i u šablonu. Možete ili izbrisati Varijante ili zadržati Atribut(e) u šablonu."
 
@@ -54060,15 +54055,15 @@ msgstr "Bruto težina paketa. Obično neto težina + težina materijala za pakov
 msgid "The holiday on {0} is not between From Date and To Date"
 msgstr "Praznik {0} nije između Od Datuma i Do Datuma"
 
-#: erpnext/controllers/buying_controller.py:1066
+#: erpnext/controllers/buying_controller.py:1074
 msgid "The item {item} is not marked as {type_of} item. You can enable it as {type_of} item from its Item master."
 msgstr "Artikal {item} nije označen kao {type_of} artikal. Možete ga omogućiti kao {type_of} Artikal u Postavkama Artikla."
 
-#: erpnext/stock/doctype/item/item.py:614
+#: erpnext/stock/doctype/item/item.py:620
 msgid "The items {0} and {1} are present in the following {2} :"
 msgstr "Artikli {0} i {1} se nalaze u sljedećem {2} :"
 
-#: erpnext/controllers/buying_controller.py:1059
+#: erpnext/controllers/buying_controller.py:1067
 msgid "The items {items} are not marked as {type_of} item. You can enable them as {type_of} item from their Item masters."
 msgstr "Artikli {items} nisu označeni kao {type_of} artikli. Možete ih omogućiti kao {type_of} artikle u Postavkama Artikala."
 
@@ -54170,8 +54165,8 @@ msgstr "Odabrani artikal ne može imati Šaržu"
 msgid "The seller and the buyer cannot be the same"
 msgstr "Prodavač i Kupac ne mogu biti isti"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:142
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:154
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:143
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:155
 msgid "The serial and batch bundle {0} not linked to {1} {2}"
 msgstr "Serijski i Šaržni Paket {0} nije povezan sa {1} {2}"
 
@@ -54195,7 +54190,7 @@ msgstr "Dionice ne postoje sa {0}"
 msgid "The stock for the item {0} in the {1} warehouse was negative on the {2}. You should create a positive entry {3} before the date {4} and time {5} to post the correct valuation rate. For more details, please read the <a href='https://docs.erpnext.com/docs/user/manual/en/stock-adjustment-cogs-with-negative-stock'>documentation<a>."
 msgstr "Zaliha za artikal {0} u {1} skladištu je bila negativna na {2}. Trebali biste kreirati pozitivan unos {3} prije datuma {4} i vremena {5} da biste knjižili ispravnu Stopu Vrednovanja. Za više detalja, molimo pročitaj <a href='https://docs.erpnext.com/docs/user/manual/en/stock-adjustment-cogs-with-negative-stock'>dokumentaciju<a>."
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:700
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:696
 msgid "The stock has been reserved for the following Items and Warehouses, un-reserve the same to {0} the Stock Reconciliation: <br /><br /> {1}"
 msgstr "Zalihe su rezervirane za sljedeće artikle i skladišta, poništite ih za {0} Usglašavanje Zaliha: <br /><br /> {1}"
 
@@ -54208,11 +54203,11 @@ msgstr "Sinhronizacija je počela u pozadini, provjerite listu {0} za nove zapis
 msgid "The task has been enqueued as a background job."
 msgstr "Zadatak je stavljen u red kao pozadinski posao."
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:994
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:990
 msgid "The task has been enqueued as a background job. In case there is any issue on processing in background, the system will add a comment about the error on this Stock Reconciliation and revert to the Draft stage"
 msgstr "Zadatak je stavljen u red kao pozadinski posao. U slučaju da postoji bilo kakav problem u obradi u pozadini, sistem će dodati komentar o grešci na ovom usaglašavanja zaliha i vratiti se u stanje nacrta"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1005
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1001
 msgid "The task has been enqueued as a background job. In case there is any issue on processing in background, the system will add a comment about the error on this Stock Reconciliation and revert to the Submitted stage"
 msgstr "Zadatak je stavljen u red kao pozadinski posao. U slučaju da postoji bilo kakav problem sa obradom u pozadini, sistem će dodati komentar o grešci na ovom usklađivanju zaliha i vratiti se na fazu Poslano"
 
@@ -54262,7 +54257,7 @@ msgstr "Skladište u koje će vaši artikli biti prebačeni kada započnete proi
 msgid "The {0} ({1}) must be equal to {2} ({3})"
 msgstr "{0} ({1}) mora biti jednako {2} ({3})"
 
-#: erpnext/public/js/controllers/transaction.js:2790
+#: erpnext/public/js/controllers/transaction.js:2816
 msgid "The {0} contains Unit Price Items."
 msgstr "{0} sadrži Artikle s Jediničnom Cijenom."
 
@@ -54310,7 +54305,7 @@ msgstr "Ne postoje varijante artikla za odabrani artikal"
 msgid "There can be multiple tiered collection factor based on the total spent. But the conversion factor for redemption will always be same for all the tier."
 msgstr "Može postojati višestruki faktor sakupljanja na osnovu ukupne potrošnje. Ali faktor konverzije za otkup će uvijek biti isti za sve nivoe."
 
-#: erpnext/accounts/party.py:580
+#: erpnext/accounts/party.py:586
 msgid "There can only be 1 Account per Company in {0} {1}"
 msgstr "Može postojati samo jedan račun po Kompaniji u {0} {1}"
 
@@ -54596,7 +54591,7 @@ msgstr "Ovo će biti dodato kodu artikla varijante. Na primjer, ako je vaša skr
 msgid "This will restrict user access to other employee records"
 msgstr "Ovo će ograničiti pristup korisnika drugim zapisima zaposlenih"
 
-#: erpnext/controllers/selling_controller.py:783
+#: erpnext/controllers/selling_controller.py:791
 msgid "This {} will be treated as material transfer."
 msgstr "Ovaj {} će se tretirati kao prijenos materijala."
 
@@ -55310,11 +55305,11 @@ msgid "To include sub-assembly costs and scrap items in Finished Goods on a work
 msgstr "Za uključivanje troškova podmontaže i otpadnih artikala u Gotov Proizvod na radnom nalogu bez upotrebe radne kartice, kada je omogućena opcija 'Koristi Višeslojnu Sastavnicu'."
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:2337
-#: erpnext/controllers/accounts_controller.py:3005
+#: erpnext/controllers/accounts_controller.py:3008
 msgid "To include tax in row {0} in Item rate, taxes in rows {1} must also be included"
 msgstr "Da biste uključili PDV u red {0} u cijenu artikla, PDV u redovima {1} također moraju biti uključeni"
 
-#: erpnext/stock/doctype/item/item.py:636
+#: erpnext/stock/doctype/item/item.py:642
 msgid "To merge, following properties must be same for both items"
 msgstr "Za spajanje, sljedeća svojstva moraju biti ista za obje stavke"
 
@@ -55934,7 +55929,7 @@ msgstr "Ukupni Neplaćeni Iznos"
 msgid "Total Paid Amount"
 msgstr "Ukupan Plaćeni Iznos"
 
-#: erpnext/controllers/accounts_controller.py:2591
+#: erpnext/controllers/accounts_controller.py:2594
 msgid "Total Payment Amount in Payment Schedule must be equal to Grand / Rounded Total"
 msgstr "Ukupan Iznos Plaćanja u Planu Plaćanja mora biti jednak Ukupnom / Zaokruženom Ukupnom Iznosu"
 
@@ -56219,15 +56214,15 @@ msgstr "Ukupna Težina (kg)"
 msgid "Total Working Hours"
 msgstr "Ukupno Radnih Sati"
 
-#: erpnext/controllers/accounts_controller.py:2138
+#: erpnext/controllers/accounts_controller.py:2141
 msgid "Total advance ({0}) against Order {1} cannot be greater than the Grand Total ({2})"
 msgstr "Ukupni predujam ({0}) naspram Naloga {1} ne može biti veći od Ukupnog Iznosa ({2})"
 
-#: erpnext/controllers/selling_controller.py:190
+#: erpnext/controllers/selling_controller.py:198
 msgid "Total allocated percentage for sales team should be 100"
 msgstr "Ukupna procentualna dodjela za prodajni tim treba biti 100"
 
-#: erpnext/selling/doctype/customer/customer.py:162
+#: erpnext/selling/doctype/customer/customer.py:161
 msgid "Total contribution percentage should be equal to 100"
 msgstr "Ukupan procenat doprinosa treba da bude jednak 100"
 
@@ -57112,7 +57107,7 @@ msgstr "Jedinica Mjere"
 msgid "Unit of Measure (UOM)"
 msgstr "Jedinica Mjere"
 
-#: erpnext/stock/doctype/item/item.py:384
+#: erpnext/stock/doctype/item/item.py:387
 msgid "Unit of Measure {0} has been entered more than once in Conversion Factor Table"
 msgstr "Jedinica mjere {0} je unesena više puta u Tablicu Faktora Konverzije"
 
@@ -57554,7 +57549,7 @@ msgstr "Ažuriraj izmijenjenu vremensku oznaku za novu korespondenciju primljene
 msgid "Update timestamp on new communication"
 msgstr "Ažuriraj vremensku oznaku za novu korespondenciju"
 
-#: erpnext/manufacturing/doctype/bom_creator/bom_creator.py:533
+#: erpnext/manufacturing/doctype/bom_creator/bom_creator.py:534
 msgid "Updated successfully"
 msgstr "Uspješno Ažurirano"
 
@@ -57568,7 +57563,7 @@ msgstr "Uspješno Ažurirano"
 msgid "Updated via 'Time Log' (In Minutes)"
 msgstr "Ažurirano putem 'Vremenski Zapisnik' (u minutama)"
 
-#: erpnext/stock/doctype/item/item.py:1387
+#: erpnext/stock/doctype/item/item.py:1381
 msgid "Updating Variants..."
 msgstr "Ažuriranje Varijanti u toku..."
 
@@ -58126,19 +58121,19 @@ msgstr "Procijenjena Vrijednost"
 msgid "Valuation Rate (In / Out)"
 msgstr "Stopa Vrednovnja (Ulaz / Izlaz)"
 
-#: erpnext/stock/stock_ledger.py:1881
+#: erpnext/stock/stock_ledger.py:1890
 msgid "Valuation Rate Missing"
 msgstr "Nedostaje Stopa Vrednovanja"
 
-#: erpnext/stock/stock_ledger.py:1859
+#: erpnext/stock/stock_ledger.py:1868
 msgid "Valuation Rate for the Item {0}, is required to do accounting entries for {1} {2}."
 msgstr "Stopa Vrednovanja za artikal {0}, je obavezna za knjigovodstvene unose za {1} {2}."
 
-#: erpnext/stock/doctype/item/item.py:266
+#: erpnext/stock/doctype/item/item.py:269
 msgid "Valuation Rate is mandatory if Opening Stock entered"
 msgstr "Procijenjano Vrijednovanje je obavezno ako se unese Početna Zaliha"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:752
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:748
 msgid "Valuation Rate required for Item {0} at row {1}"
 msgstr "Stopa Vrednovanja je obavezna za artikal {0} u redu {1}"
 
@@ -58148,7 +58143,7 @@ msgstr "Stopa Vrednovanja je obavezna za artikal {0} u redu {1}"
 msgid "Valuation and Total"
 msgstr "Vrednovanje i Ukupno"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:971
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:967
 msgid "Valuation rate for customer provided items has been set to zero."
 msgstr "Stopa Vrednovanja za Artikle koje je dostavio Klijent postavljena je na nulu."
 
@@ -58162,7 +58157,7 @@ msgid "Valuation rate for the item as per Sales Invoice (Only for Internal Trans
 msgstr "Stopa Vrednovanja artikla prema Prodajnoj Fakturi (samo za interne transfere)"
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:2361
-#: erpnext/controllers/accounts_controller.py:3029
+#: erpnext/controllers/accounts_controller.py:3032
 msgid "Valuation type charges can not be marked as Inclusive"
 msgstr "Naknade za tip vrijednovanja ne mogu biti označene kao Inkluzivne"
 
@@ -58318,7 +58313,7 @@ msgstr "Odstupanje ({})"
 msgid "Variant"
 msgstr "Varijanta"
 
-#: erpnext/stock/doctype/item/item.py:864
+#: erpnext/stock/doctype/item/item.py:858
 msgid "Variant Attribute Error"
 msgstr "Greška Atributa Varijante"
 
@@ -58337,7 +58332,7 @@ msgstr "Varijanta Sastavnice"
 msgid "Variant Based On"
 msgstr "Varijanta zasnovana na"
 
-#: erpnext/stock/doctype/item/item.py:892
+#: erpnext/stock/doctype/item/item.py:886
 msgid "Variant Based On cannot be changed"
 msgstr "Varijanta zasnovana na nemože se promijeniti"
 
@@ -58355,7 +58350,7 @@ msgstr "Polje Varijante"
 msgid "Variant Item"
 msgstr "Varijanta Artikla"
 
-#: erpnext/stock/doctype/item/item.py:862
+#: erpnext/stock/doctype/item/item.py:856
 msgid "Variant Items"
 msgstr "Varijanta Artikli"
 
@@ -58473,7 +58468,7 @@ msgstr "Video Postavke"
 #: erpnext/accounts/doctype/cost_center/cost_center_tree.js:56
 #: erpnext/accounts/doctype/invoice_discounting/invoice_discounting.js:205
 #: erpnext/accounts/doctype/journal_entry/journal_entry.js:43
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:668
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:670
 #: erpnext/bulk_transaction/doctype/bulk_transaction_log/bulk_transaction_log.js:14
 #: erpnext/bulk_transaction/doctype/bulk_transaction_log/bulk_transaction_log.js:24
 #: erpnext/buying/doctype/request_for_quotation/request_for_quotation.js:167
@@ -58660,7 +58655,7 @@ msgstr "Naziv Verifikata"
 #: erpnext/accounts/doctype/repost_accounting_ledger_items/repost_accounting_ledger_items.json
 #: erpnext/accounts/doctype/repost_payment_ledger_items/repost_payment_ledger_items.json
 #: erpnext/accounts/doctype/unreconcile_payment/unreconcile_payment.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1099
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1101
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.js:42
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:209
 #: erpnext/accounts/report/general_ledger/general_ledger.js:49
@@ -58691,7 +58686,7 @@ msgstr "Naziv Verifikata"
 msgid "Voucher No"
 msgstr "Broj Verifikata"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1087
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1088
 msgid "Voucher No is mandatory"
 msgstr "Broj Verifikata je obavezan"
 
@@ -58733,7 +58728,7 @@ msgstr "Podtip Verifikata"
 #: erpnext/accounts/doctype/repost_payment_ledger_items/repost_payment_ledger_items.json
 #: erpnext/accounts/doctype/tax_withheld_vouchers/tax_withheld_vouchers.json
 #: erpnext/accounts/doctype/unreconcile_payment/unreconcile_payment.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1097
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1099
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:200
 #: erpnext/accounts/report/general_ledger/general_ledger.py:697
 #: erpnext/accounts/report/invalid_ledger_entries/invalid_ledger_entries.py:31
@@ -59087,10 +59082,6 @@ msgstr "Skladište je Obavezno"
 msgid "Warehouse not found against the account {0}"
 msgstr "Skladište nije pronađeno naspram računu {0}"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:600
-msgid "Warehouse not found in the system"
-msgstr "Skladište nije pronađeno u sistemu"
-
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:1130
 #: erpnext/stock/doctype/delivery_note/delivery_note.py:414
 msgid "Warehouse required for stock Item {0}"
@@ -59219,7 +59210,7 @@ msgid "Warn for new Request for Quotations"
 msgstr "Upozori pri novim Zahtjevima za Ponudu"
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:744
-#: erpnext/controllers/accounts_controller.py:1978
+#: erpnext/controllers/accounts_controller.py:1981
 #: erpnext/stock/doctype/delivery_trip/delivery_trip.js:145
 #: erpnext/utilities/transaction_base.py:123
 msgid "Warning"
@@ -60191,7 +60182,7 @@ msgstr "Da"
 msgid "You are importing data for the code list:"
 msgstr "Uvoziš podatke za Listu Koda:"
 
-#: erpnext/controllers/accounts_controller.py:3611
+#: erpnext/controllers/accounts_controller.py:3614
 msgid "You are not allowed to update as per the conditions set in {} Workflow."
 msgstr "Nije vam dozvoljeno ažuriranje prema uslovima postavljenim u {} Radnom Toku."
 
@@ -60256,7 +60247,7 @@ msgstr "Možete ga postaviti kao naziv mašine ili tip operacije. Na primjer, ma
 msgid "You can't make any changes to Job Card since Work Order is closed."
 msgstr "Ne možete napraviti nikakve promjene na Radnoj Kartici jer je Radni Nalog zatvoren."
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:185
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:186
 msgid "You can't process the serial number {0} as it has already been used in the SABB {1}. {2} if you want to inward same serial number multiple times then enabled 'Allow existing Serial No to be Manufactured/Received again' in the {3}"
 msgstr "Ne možete obraditi serijski broj {0} jer je već korišten u Serijskom i Šaržnom Paketu {1}. {2} ako želite da primite isti serijski broj više puta, tada omogući 'Dozvoli da se postojeći Serijski Broj ponovo Proizvede/Primi' u {3}"
 
@@ -60316,7 +60307,7 @@ msgstr "Ne možete podnijeti nalog bez plaćanja."
 msgid "You cannot {0} this document because another Period Closing Entry {1} exists after {2}"
 msgstr "Ne možete {0} ovaj dokument jer postoji drugi Unos Zatvaranje Perioda {1} nakon {2}"
 
-#: erpnext/controllers/accounts_controller.py:3587
+#: erpnext/controllers/accounts_controller.py:3590
 msgid "You do not have permissions to {} items in a {}."
 msgstr "Nemate dozvole za {} artikala u {}."
 
@@ -60344,7 +60335,7 @@ msgstr "Pozvani ste da sarađujete na projektu {0}."
 msgid "You have entered a duplicate Delivery Note on Row"
 msgstr "Unijeli ste duplikat Dostavnice u red"
 
-#: erpnext/stock/doctype/item/item.py:1063
+#: erpnext/stock/doctype/item/item.py:1057
 msgid "You have to enable auto re-order in Stock Settings to maintain re-order levels."
 msgstr "Morate omogućiti automatsko ponovno naručivanje u Postavkama Zaliha kako biste održali nivoe ponovnog naručivanja."
 
@@ -60364,7 +60355,7 @@ msgstr "Morate odabrati Klijenta prije dodavanja Artikla."
 msgid "You need to cancel POS Closing Entry {} to be able to cancel this document."
 msgstr "Morate otkazati Unos Zatvaranje Kase {} da biste mogli otkazati ovaj dokument."
 
-#: erpnext/controllers/accounts_controller.py:2980
+#: erpnext/controllers/accounts_controller.py:2983
 msgid "You selected the account group {1} as {2} Account in row {0}. Please select a single account."
 msgstr "Odabrali ste grupni račun {1} kao {2} Račun u redu {0}. Odaberi jedan račun."
 
@@ -60442,7 +60433,7 @@ msgstr "[Važno] [ERPNext] Greške Automatskog Preuređenja"
 msgid "`Allow Negative rates for Items`"
 msgstr "`Dozvoli negativne cijene za Artikle`"
 
-#: erpnext/stock/stock_ledger.py:1873
+#: erpnext/stock/stock_ledger.py:1882
 msgid "after"
 msgstr "poslije"
 
@@ -60590,7 +60581,7 @@ msgstr "lijevo"
 msgid "material_request_item"
 msgstr "Artikal Materijalnog Naloga"
 
-#: erpnext/controllers/selling_controller.py:151
+#: erpnext/controllers/selling_controller.py:159
 msgid "must be between 0 and 100"
 msgstr "mora biti između 0 i 100"
 
@@ -60615,7 +60606,7 @@ msgstr "stari_nadređeni"
 msgid "on"
 msgstr "Završen"
 
-#: erpnext/controllers/accounts_controller.py:1289
+#: erpnext/controllers/accounts_controller.py:1292
 msgid "or"
 msgstr "ili"
 
@@ -60664,7 +60655,7 @@ msgstr "aplikacija za plaćanja nije instalirana. Instaliraj s {} ili {}"
 msgid "per hour"
 msgstr "po satu"
 
-#: erpnext/stock/stock_ledger.py:1874
+#: erpnext/stock/stock_ledger.py:1883
 msgid "performing either one below:"
 msgstr "izvodi bilo koje dolje:"
 
@@ -60791,7 +60782,7 @@ msgstr "morate odabrati Račun Kapitalnih Radova u Toku u Tabeli Računa"
 msgid "{0}"
 msgstr "{0}"
 
-#: erpnext/controllers/accounts_controller.py:1109
+#: erpnext/controllers/accounts_controller.py:1112
 msgid "{0} '{1}' is disabled"
 msgstr "{0} '{1}' je onemogućen"
 
@@ -60807,7 +60798,7 @@ msgstr "{0} ({1}) ne može biti veći od planirane količine ({2}) u Radnom Nalo
 msgid "{0} <b>{1}</b> has submitted Assets. Remove Item <b>{2}</b> from table to continue."
 msgstr "{0} <b>{1}</b> je podnijeo Imovinu. Ukloni Artikal <b>{2}</b> iz tabele da nastavite."
 
-#: erpnext/controllers/accounts_controller.py:2193
+#: erpnext/controllers/accounts_controller.py:2196
 msgid "{0} Account not found against Customer {1}."
 msgstr "{0} Račun nije pronađen prema Klijentu {1}."
 
@@ -60839,7 +60830,7 @@ msgstr "{0} Operacije: {1}"
 msgid "{0} Request for {1}"
 msgstr "{0} Zahtjev za {1}"
 
-#: erpnext/stock/doctype/item/item.py:323
+#: erpnext/stock/doctype/item/item.py:326
 msgid "{0} Retain Sample is based on batch, please check Has Batch No to retain sample of item"
 msgstr "{0} Zadržani Uzorak se zasniva na Šarži, provjeri Ima Broj Šarže da zadržite uzorak artikla"
 
@@ -60930,7 +60921,7 @@ msgid "{0} entered twice in Item Tax"
 msgstr "{0} uneseno dvaput u PDV Artikla"
 
 #: erpnext/setup/doctype/item_group/item_group.py:48
-#: erpnext/stock/doctype/item/item.py:436
+#: erpnext/stock/doctype/item/item.py:439
 msgid "{0} entered twice {1} in Item Taxes"
 msgstr "{0} uneseno dvaput {1} u PDV Artikla"
 
@@ -60951,7 +60942,7 @@ msgstr "{0} je uspješno podnešen"
 msgid "{0} hours"
 msgstr "{0} sati"
 
-#: erpnext/controllers/accounts_controller.py:2534
+#: erpnext/controllers/accounts_controller.py:2537
 msgid "{0} in row {1}"
 msgstr "{0} u redu {1}"
 
@@ -60975,7 +60966,7 @@ msgstr "{0} je blokiran tako da se ova transakcija ne može nastaviti"
 
 #: erpnext/accounts/doctype/budget/budget.py:60
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:643
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:49
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:50
 #: erpnext/accounts/report/general_ledger/general_ledger.py:59
 #: erpnext/accounts/report/pos_register/pos_register.py:107
 #: erpnext/controllers/trends.py:50
@@ -60995,11 +60986,11 @@ msgstr "{0} je obavezan za račun {1}"
 msgid "{0} is mandatory. Maybe Currency Exchange record is not created for {1} to {2}"
 msgstr "{0} je obavezan. Možda zapis o razmjeni valuta nije kreiran za {1} do {2}"
 
-#: erpnext/controllers/accounts_controller.py:2937
+#: erpnext/controllers/accounts_controller.py:2940
 msgid "{0} is mandatory. Maybe Currency Exchange record is not created for {1} to {2}."
 msgstr "{0} je obavezan. Možda zapis o razmjeni valuta nije kreiran za {1} do {2}."
 
-#: erpnext/selling/doctype/customer/customer.py:204
+#: erpnext/selling/doctype/customer/customer.py:203
 msgid "{0} is not a company bank account"
 msgstr "{0} nije bankovni račun kompanije"
 
@@ -61082,7 +61073,7 @@ msgstr "{0} količina artikla {1} se prima u Skladište {2} kapaciteta {3}."
 msgid "{0} to {1}"
 msgstr "{0} do {1}"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:690
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:686
 msgid "{0} units are reserved for Item {1} in Warehouse {2}, please un-reserve the same to {3} the Stock Reconciliation."
 msgstr "{0} jedinica je rezervisano za artikal {1} u Skladištu {2}, poništi rezervaciju iste za {3} Popis Zaliha."
 
@@ -61098,16 +61089,16 @@ msgstr "{0} jedinica artikla {1} je odabrano na drugoj Listi Odabira."
 msgid "{0} units of {1} are required in {2} with the inventory dimension: {3} ({4}) on {5} {6} for {7} to complete the transaction."
 msgstr "{0} jedinice {1} su obavezne u {2} sa dimenzijom zaliha: {3} ({4}) na {5} {6} za {7} za dovršetak transakcije."
 
-#: erpnext/stock/stock_ledger.py:1532 erpnext/stock/stock_ledger.py:2023
-#: erpnext/stock/stock_ledger.py:2037
+#: erpnext/stock/stock_ledger.py:1541 erpnext/stock/stock_ledger.py:2031
+#: erpnext/stock/stock_ledger.py:2045
 msgid "{0} units of {1} needed in {2} on {3} {4} for {5} to complete this transaction."
 msgstr "{0} jedinica {1} potrebnih u {2} na {3} {4} za {5} da se završi ova transakcija."
 
-#: erpnext/stock/stock_ledger.py:2124 erpnext/stock/stock_ledger.py:2170
+#: erpnext/stock/stock_ledger.py:2132 erpnext/stock/stock_ledger.py:2178
 msgid "{0} units of {1} needed in {2} on {3} {4} to complete this transaction."
 msgstr "{0} jedinica {1} potrebnih u {2} na {3} {4} za završetak ove transakcije."
 
-#: erpnext/stock/stock_ledger.py:1526
+#: erpnext/stock/stock_ledger.py:1535
 msgid "{0} units of {1} needed in {2} to complete this transaction."
 msgstr "{0} jedinica od {1} potrebnih u {2} za završetak ove transakcije."
 
@@ -61153,7 +61144,7 @@ msgstr "{0} {1} kreiran"
 msgid "{0} {1} does not exist"
 msgstr "{0} {1} ne postoji"
 
-#: erpnext/accounts/party.py:560
+#: erpnext/accounts/party.py:566
 msgid "{0} {1} has accounting entries in currency {2} for company {3}. Please select a receivable or payable account with currency {2}."
 msgstr "{0} {1} ima knjigovodstvene unose u valuti {2} za kompaniju {3}. Odaberi račun potraživanja ili plaćanja sa valutom {2}."
 
@@ -61187,7 +61178,7 @@ msgstr "{0} {1} je već povezan sa Zajedničkim Kodom {2}."
 msgid "{0} {1} is associated with {2}, but Party Account is {3}"
 msgstr "{0} {1} je povezan sa {2}, ali Račun Stranke je {3}"
 
-#: erpnext/controllers/selling_controller.py:462
+#: erpnext/controllers/selling_controller.py:470
 #: erpnext/controllers/subcontracting_controller.py:954
 msgid "{0} {1} is cancelled or closed"
 msgstr "{0} {1} je otkazan ili zatvoren"
@@ -61204,11 +61195,11 @@ msgstr "{0} {1} je otkazan tako da se radnja ne može dovršiti"
 msgid "{0} {1} is closed"
 msgstr "{0} {1} je zatvoren"
 
-#: erpnext/accounts/party.py:798
+#: erpnext/accounts/party.py:804
 msgid "{0} {1} is disabled"
 msgstr "{0} {1} je onemogućen"
 
-#: erpnext/accounts/party.py:804
+#: erpnext/accounts/party.py:810
 msgid "{0} {1} is frozen"
 msgstr "{0} {1} je zamrznut"
 
@@ -61216,7 +61207,7 @@ msgstr "{0} {1} je zamrznut"
 msgid "{0} {1} is fully billed"
 msgstr "{0} {1} je u potpunosti fakturisano"
 
-#: erpnext/accounts/party.py:808
+#: erpnext/accounts/party.py:814
 msgid "{0} {1} is not active"
 msgstr "{0} {1} nije aktivan"
 
@@ -61342,15 +61333,15 @@ msgstr "{0}: {1} ne postoji"
 msgid "{0}: {1} must be less than {2}"
 msgstr "{0}: {1} mora biti manje od {2}"
 
-#: erpnext/controllers/buying_controller.py:840
+#: erpnext/controllers/buying_controller.py:848
 msgid "{count} Assets created for {item_code}"
 msgstr "{count} Imovina kreirana za {item_code}"
 
-#: erpnext/controllers/buying_controller.py:738
+#: erpnext/controllers/buying_controller.py:746
 msgid "{doctype} {name} is cancelled or closed."
 msgstr "{doctype} {name} je otkazan ili zatvoren."
 
-#: erpnext/controllers/buying_controller.py:459
+#: erpnext/controllers/buying_controller.py:467
 msgid "{field_label} is mandatory for sub-contracted {doctype}."
 msgstr "{field_label} je obavezan za podugovoren {doctype}."
 
@@ -61358,7 +61349,7 @@ msgstr "{field_label} je obavezan za podugovoren {doctype}."
 msgid "{item_name}'s Sample Size ({sample_size}) cannot be greater than the Accepted Quantity ({accepted_quantity})"
 msgstr "{item_name} Veličina Uzorka ({sample_size}) ne može biti veća od Prihvaćene Količina ({accepted_quantity})"
 
-#: erpnext/controllers/buying_controller.py:563
+#: erpnext/controllers/buying_controller.py:571
 msgid "{ref_doctype} {ref_name} is {status}."
 msgstr "{ref_doctype} {ref_name} je {status}."
 
@@ -61424,7 +61415,7 @@ msgstr "{} Za Fakturisati"
 msgid "{} can't be cancelled since the Loyalty Points earned has been redeemed. First cancel the {} No {}"
 msgstr "{} se ne može otkazati jer su zarađeni Poeni Lojalnosti iskorišteni. Prvo otkažite {} Broj {}"
 
-#: erpnext/controllers/buying_controller.py:222
+#: erpnext/controllers/buying_controller.py:230
 msgid "{} has submitted assets linked to it. You need to cancel the assets to create purchase return."
 msgstr "{} je podnijeo imovinu koja je povezana s njim. Morate poništiti sredstva da biste kreirali povrat kupovine."
 

--- a/erpnext/locale/de.po
+++ b/erpnext/locale/de.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: frappe\n"
 "Report-Msgid-Bugs-To: hello@frappe.io\n"
-"POT-Creation-Date: 2025-05-25 09:35+0000\n"
-"PO-Revision-Date: 2025-05-25 20:34\n"
+"POT-Creation-Date: 2025-06-01 09:36+0000\n"
+"PO-Revision-Date: 2025-06-01 21:34\n"
 "Last-Translator: hello@frappe.io\n"
 "Language-Team: German\n"
 "MIME-Version: 1.0\n"
@@ -83,15 +83,15 @@ msgstr " Unterbaugruppe"
 msgid " Summary"
 msgstr " Zusammenfassung"
 
-#: erpnext/stock/doctype/item/item.py:235
+#: erpnext/stock/doctype/item/item.py:238
 msgid "\"Customer Provided Item\" cannot be Purchase Item also"
 msgstr "\"Vom Kunden beigestellter Artikel\" kann nicht gleichzeitig \"Einkaufsartikel\" sein"
 
-#: erpnext/stock/doctype/item/item.py:237
+#: erpnext/stock/doctype/item/item.py:240
 msgid "\"Customer Provided Item\" cannot have Valuation Rate"
 msgstr "\"Vom Kunden beigestellter Artikel\" kann keinen Bewertungssatz haben"
 
-#: erpnext/stock/doctype/item/item.py:313
+#: erpnext/stock/doctype/item/item.py:316
 msgid "\"Is Fixed Asset\" cannot be unchecked, as Asset record exists against the item"
 msgstr "\"Ist Anlagevermögen\" kann nicht deaktiviert werden, da Anlagebuchung für den Artikel vorhanden"
 
@@ -213,7 +213,7 @@ msgstr "% der für diesen Kundenauftrag in Rechnung gestellten Materialien"
 msgid "% of materials delivered against this Sales Order"
 msgstr "% der für diesen Auftrag gelieferten Materialien"
 
-#: erpnext/controllers/accounts_controller.py:2197
+#: erpnext/controllers/accounts_controller.py:2200
 msgid "'Account' in the Accounting section of Customer {0}"
 msgstr "„Konto“ im Abschnitt „Buchhaltung“ von Kunde {0}"
 
@@ -225,15 +225,11 @@ msgstr "Mehrere Aufträge (je Kunde) mit derselben Bestellnummer erlauben"
 msgid "'Based On' and 'Group By' can not be same"
 msgstr "„Basierend auf“ und „Gruppieren nach“ dürfen nicht identisch sein"
 
-#: erpnext/stock/report/product_bundle_balance/product_bundle_balance.py:233
-msgid "'Date' is required"
-msgstr "'Datum' ist erforderlich"
-
 #: erpnext/selling/report/inactive_customers/inactive_customers.py:18
 msgid "'Days Since Last Order' must be greater than or equal to zero"
 msgstr "„Tage seit der letzten Bestellung“ muss größer oder gleich null sein"
 
-#: erpnext/controllers/accounts_controller.py:2202
+#: erpnext/controllers/accounts_controller.py:2205
 msgid "'Default {0} Account' in Company {1}"
 msgstr "'Standardkonto {0} ' in Unternehmen {1}"
 
@@ -243,7 +239,7 @@ msgstr "\"Buchungen\" kann nicht leer sein"
 
 #: erpnext/stock/report/batch_item_expiry_status/batch_item_expiry_status.py:24
 #: erpnext/stock/report/batch_wise_balance_history/batch_wise_balance_history.py:120
-#: erpnext/stock/report/stock_analytics/stock_analytics.py:314
+#: erpnext/stock/report/stock_analytics/stock_analytics.py:313
 msgid "'From Date' is required"
 msgstr "\"Von-Datum\" ist erforderlich"
 
@@ -251,7 +247,7 @@ msgstr "\"Von-Datum\" ist erforderlich"
 msgid "'From Date' must be after 'To Date'"
 msgstr "\"Von-Datum\" muss nach \"Bis-Datum\" liegen"
 
-#: erpnext/stock/doctype/item/item.py:398
+#: erpnext/stock/doctype/item/item.py:401
 msgid "'Has Serial No' can not be 'Yes' for non-stock item"
 msgstr "„Hat Seriennummer“ kann für Artikel ohne Lagerhaltung nicht aktiviert werden"
 
@@ -1179,7 +1175,7 @@ msgstr "Angenommene Menge in Lagereinheit"
 
 #. Label of the qty (Float) field in DocType 'Purchase Receipt Item'
 #. Label of the qty (Float) field in DocType 'Subcontracting Receipt Item'
-#: erpnext/public/js/controllers/transaction.js:2362
+#: erpnext/public/js/controllers/transaction.js:2388
 #: erpnext/stock/doctype/purchase_receipt_item/purchase_receipt_item.json
 #: erpnext/subcontracting/doctype/subcontracting_receipt_item/subcontracting_receipt_item.json
 msgid "Accepted Quantity"
@@ -1377,7 +1373,7 @@ msgid "Account Manager"
 msgstr "Kundenbetreuer"
 
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:949
-#: erpnext/controllers/accounts_controller.py:2206
+#: erpnext/controllers/accounts_controller.py:2209
 msgid "Account Missing"
 msgstr "Konto fehlt"
 
@@ -1552,7 +1548,7 @@ msgstr "Konto {0} wurde im Tochterunternehmen {1} hinzugefügt"
 msgid "Account {0} is frozen"
 msgstr "Konto {0} ist eingefroren"
 
-#: erpnext/controllers/accounts_controller.py:1288
+#: erpnext/controllers/accounts_controller.py:1291
 msgid "Account {0} is invalid. Account Currency must be {1}"
 msgstr "Konto {0} ist ungültig. Kontenwährung muss {1} sein"
 
@@ -1588,7 +1584,7 @@ msgstr "Konto: {0} kann nur über Lagertransaktionen aktualisiert werden"
 msgid "Account: {0} is not permitted under Payment Entry"
 msgstr "Konto {0} kann nicht in Zahlung verwendet werden"
 
-#: erpnext/controllers/accounts_controller.py:3037
+#: erpnext/controllers/accounts_controller.py:3040
 msgid "Account: {0} with currency: {1} can not be selected"
 msgstr "Konto: {0} mit Währung: {1} kann nicht ausgewählt werden"
 
@@ -1861,7 +1857,7 @@ msgstr "Buchungen"
 msgid "Accounting Entry for Asset"
 msgstr "Buchungseintrag für Vermögenswert"
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:796
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:805
 msgid "Accounting Entry for Service"
 msgstr "Buchhaltungseintrag für Service"
 
@@ -1876,18 +1872,18 @@ msgstr "Buchhaltungseintrag für Service"
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py:1468
 #: erpnext/controllers/stock_controller.py:550
 #: erpnext/controllers/stock_controller.py:567
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:889
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:898
 #: erpnext/stock/doctype/stock_entry/stock_entry.py:1586
 #: erpnext/stock/doctype/stock_entry/stock_entry.py:1600
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py:561
 msgid "Accounting Entry for Stock"
 msgstr "Lagerbuchung"
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:717
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:726
 msgid "Accounting Entry for {0}"
 msgstr "Buchungen für {0}"
 
-#: erpnext/controllers/accounts_controller.py:2247
+#: erpnext/controllers/accounts_controller.py:2250
 msgid "Accounting Entry for {0}: {1} can only be made in currency: {2}"
 msgstr "Eine Buchung für {0}: {1} kann nur in der Währung: {2} vorgenommen werden"
 
@@ -2280,7 +2276,7 @@ msgstr "Kumulierte Abschreibungen zum"
 msgid "Accumulated Monthly"
 msgstr "Monatlich kumuliert"
 
-#: erpnext/controllers/budget_controller.py:417
+#: erpnext/controllers/budget_controller.py:422
 msgid "Accumulated Monthly Budget for Account {0} against {1} {2} is {3}. It will be collectively ({4}) exceeded by {5}"
 msgstr ""
 
@@ -3394,7 +3390,7 @@ msgstr "Wert des Vermögensgegenstands anpassen"
 msgid "Adjustment Against"
 msgstr "Anpassung gegen"
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:634
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:643
 msgid "Adjustment based on Purchase Invoice rate"
 msgstr "Anpassung basierend auf dem Rechnungspreis"
 
@@ -3505,7 +3501,7 @@ msgstr "Weitere Steuern und Abgaben"
 msgid "Advance amount"
 msgstr "Anzahlungsbetrag"
 
-#: erpnext/controllers/taxes_and_totals.py:845
+#: erpnext/controllers/taxes_and_totals.py:855
 msgid "Advance amount cannot be greater than {0} {1}"
 msgstr "Anzahlung kann nicht größer sein als {0} {1}"
 
@@ -3716,7 +3712,7 @@ msgstr "Alter"
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:152
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:133
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1125
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1127
 msgid "Age (Days)"
 msgstr "Alter (Tage)"
 
@@ -3802,16 +3798,6 @@ msgstr "Fassen Sie eine Gruppe von Artikeln in einem anderen Artikel zusammen. D
 #: erpnext/setup/setup_wizard/data/industry_type.txt:4
 msgid "Agriculture"
 msgstr "Landwirtschaft"
-
-#. Name of a role
-#: erpnext/assets/doctype/location/location.json
-msgid "Agriculture Manager"
-msgstr "Landwirtschaftsmanager"
-
-#. Name of a role
-#: erpnext/assets/doctype/location/location.json
-msgid "Agriculture User"
-msgstr "Benutzer Landwirtschaft"
 
 #: erpnext/setup/setup_wizard/data/industry_type.txt:5
 msgid "Airline"
@@ -4003,7 +3989,7 @@ msgstr "Alle Mitteilungen einschließlich und darüber sollen in die neue Ausgab
 msgid "All items are already requested"
 msgstr "Alle Artikel sind bereits angefordert"
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:1317
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:1326
 msgid "All items have already been Invoiced/Returned"
 msgstr "Alle Artikel wurden bereits in Rechnung gestellt / zurückgesandt"
 
@@ -4015,7 +4001,7 @@ msgstr "Alle Artikel sind bereits eingegangen"
 msgid "All items have already been transferred for this Work Order."
 msgstr "Alle Positionen wurden bereits für diesen Arbeitsauftrag übertragen."
 
-#: erpnext/public/js/controllers/transaction.js:2465
+#: erpnext/public/js/controllers/transaction.js:2491
 msgid "All items in this document already have a linked Quality Inspection."
 msgstr "Für alle Artikel in diesem Dokument ist bereits eine Qualitätsprüfung verknüpft."
 
@@ -4213,7 +4199,7 @@ msgstr "Interne Übertragungen zum Fremdvergleichspreis zulassen"
 msgid "Allow Item To Be Added Multiple Times in a Transaction"
 msgstr "Zulassen, dass ein Element in einer Transaktion mehrmals hinzugefügt wird"
 
-#: erpnext/controllers/selling_controller.py:755
+#: erpnext/controllers/selling_controller.py:763
 msgid "Allow Item to Be Added Multiple Times in a Transaction"
 msgstr "Mehrfaches Hinzufügen von Artikeln in einer Transaktion zulassen"
 
@@ -5159,7 +5145,7 @@ msgstr "Jährlich"
 msgid "Annual Billing: {0}"
 msgstr "Jährliche Abrechnung: {0}"
 
-#: erpnext/controllers/budget_controller.py:441
+#: erpnext/controllers/budget_controller.py:446
 msgid "Annual Budget for Account {0} against {1} {2} is {3}. It will be collectively ({4}) exceeded by {5}"
 msgstr ""
 
@@ -5648,7 +5634,7 @@ msgstr "Da das Feld {0} aktiviert ist, ist das Feld {1} obligatorisch."
 msgid "As the field {0} is enabled, the value of the field {1} should be more than 1."
 msgstr "Wenn das Feld {0} aktiviert ist, sollte der Wert des Feldes {1} größer als 1 sein."
 
-#: erpnext/stock/doctype/item/item.py:989
+#: erpnext/stock/doctype/item/item.py:983
 msgid "As there are existing submitted transactions against item {0}, you can not change the value of {1}."
 msgstr "Da es bereits gebuchte Transaktionen für den Artikel {0} gibt, können Sie den Wert von {1} nicht ändern."
 
@@ -5794,7 +5780,7 @@ msgstr "Vermögensgegenstand-Kategorie Konto"
 msgid "Asset Category Name"
 msgstr "Name der Anlagenkategorie"
 
-#: erpnext/stock/doctype/item/item.py:304
+#: erpnext/stock/doctype/item/item.py:307
 msgid "Asset Category is mandatory for Fixed Asset item"
 msgstr "Vermögensgegenstand-Kategorie ist obligatorisch für Artikel des Anlagevermögens"
 
@@ -6169,7 +6155,7 @@ msgstr "Vermögensgegenstand {0} wurde aktualisiert. Bitte geben Sie die Abschre
 msgid "Asset {0} must be submitted"
 msgstr "Vermögensgegenstand {0} muss gebucht werden"
 
-#: erpnext/controllers/buying_controller.py:851
+#: erpnext/controllers/buying_controller.py:859
 msgid "Asset {assets_link} created for {item_code}"
 msgstr ""
 
@@ -6199,11 +6185,11 @@ msgstr "Der Wert des Vermögensgegenstandes wurde nach der Buchung der Vermögen
 msgid "Assets"
 msgstr "Vermögenswerte"
 
-#: erpnext/controllers/buying_controller.py:869
+#: erpnext/controllers/buying_controller.py:877
 msgid "Assets not created for {item_code}. You will have to create asset manually."
 msgstr "Assets nicht für {item_code} erstellt. Sie müssen das Asset manuell erstellen."
 
-#: erpnext/controllers/buying_controller.py:856
+#: erpnext/controllers/buying_controller.py:864
 msgid "Assets {assets_link} created for {item_code}"
 msgstr ""
 
@@ -6298,7 +6284,7 @@ msgstr "In Zeile {0}: Die Sequenz-ID {1} darf nicht kleiner sein als die vorheri
 msgid "At row #{0}: you have selected the Difference Account {1}, which is a Cost of Goods Sold type account. Please select a different account"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:864
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:865
 msgid "At row {0}: Batch No is mandatory for Item {1}"
 msgstr "In Zeile {0}: Chargennummer ist obligatorisch für Artikel {1}"
 
@@ -6306,11 +6292,11 @@ msgstr "In Zeile {0}: Chargennummer ist obligatorisch für Artikel {1}"
 msgid "At row {0}: Parent Row No cannot be set for item {1}"
 msgstr "In Zeile {0}: Übergeordnete Zeilennummer kann für Element {1} nicht festgelegt werden"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:849
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:850
 msgid "At row {0}: Qty is mandatory for the batch {1}"
 msgstr "In der Zeile {0}: Menge ist obligatorisch für die Charge {1}"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:856
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:857
 msgid "At row {0}: Serial No is mandatory for Item {1}"
 msgstr "In Zeile {0}: Seriennummer ist obligatorisch für Artikel {1}"
 
@@ -6384,7 +6370,7 @@ msgstr "Attributname"
 msgid "Attribute Value"
 msgstr "Attributwert"
 
-#: erpnext/stock/doctype/item/item.py:930
+#: erpnext/stock/doctype/item/item.py:924
 msgid "Attribute table is mandatory"
 msgstr "Attributtabelle ist obligatorisch"
 
@@ -6392,11 +6378,11 @@ msgstr "Attributtabelle ist obligatorisch"
 msgid "Attribute value: {0} must appear only once"
 msgstr "Attributwert: {0} darf nur einmal vorkommen"
 
-#: erpnext/stock/doctype/item/item.py:934
+#: erpnext/stock/doctype/item/item.py:928
 msgid "Attribute {0} selected multiple times in Attributes Table"
 msgstr "Attribut {0} mehrfach in der Attributtabelle ausgewählt"
 
-#: erpnext/stock/doctype/item/item.py:862
+#: erpnext/stock/doctype/item/item.py:856
 msgid "Attributes"
 msgstr "Attribute"
 
@@ -7680,11 +7666,11 @@ msgstr "Barcode"
 msgid "Barcode Type"
 msgstr "Barcode-Typ"
 
-#: erpnext/stock/doctype/item/item.py:457
+#: erpnext/stock/doctype/item/item.py:460
 msgid "Barcode {0} already used in Item {1}"
 msgstr "Barcode {0} wird bereits für Artikel {1} verwendet"
 
-#: erpnext/stock/doctype/item/item.py:472
+#: erpnext/stock/doctype/item/item.py:475
 msgid "Barcode {0} is not a valid {1} code"
 msgstr "Der Barcode {0} ist kein gültiger {1} Code"
 
@@ -7938,7 +7924,7 @@ msgstr "Stapelobjekt Ablauf-Status"
 #: erpnext/manufacturing/doctype/job_card/job_card.json
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.js:89
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.py:115
-#: erpnext/public/js/controllers/transaction.js:2388
+#: erpnext/public/js/controllers/transaction.js:2414
 #: erpnext/public/js/utils/barcode_scanner.js:260
 #: erpnext/public/js/utils/serial_no_batch_selector.js:438
 #: erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
@@ -7965,11 +7951,11 @@ msgstr "Stapelobjekt Ablauf-Status"
 msgid "Batch No"
 msgstr "Chargennummer"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:867
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:868
 msgid "Batch No is mandatory"
 msgstr "Chargennummer ist obligatorisch"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2629
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2630
 msgid "Batch No {0} does not exists"
 msgstr "Charge Nr. {0} existiert nicht"
 
@@ -7977,7 +7963,7 @@ msgstr "Charge Nr. {0} existiert nicht"
 msgid "Batch No {0} is linked with Item {1} which has serial no. Please scan serial no instead."
 msgstr "Die Chargennummer {0} ist mit dem Artikel {1} verknüpft, der eine Seriennummer hat. Bitte scannen Sie stattdessen die Seriennummer."
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:364
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:365
 msgid "Batch No {0} is not present in the original {1} {2}, hence you can't return it against the {1} {2}"
 msgstr "Charge Nr. {0} ist im Original {1} {2} nicht vorhanden, daher können Sie sie nicht gegen {1} {2} zurückgeben"
 
@@ -7992,11 +7978,11 @@ msgstr "Chargennummer."
 msgid "Batch Nos"
 msgstr "Chargennummern"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1421
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1422
 msgid "Batch Nos are created successfully"
 msgstr "Chargennummern wurden erfolgreich erstellt"
 
-#: erpnext/controllers/sales_and_purchase_return.py:1096
+#: erpnext/controllers/sales_and_purchase_return.py:1001
 msgid "Batch Not Available for Return"
 msgstr "Charge nicht zur Rückgabe verfügbar"
 
@@ -8045,7 +8031,7 @@ msgstr "Für Artikel {} wurde keine Charge erstellt, da er keinen Nummernkreis f
 msgid "Batch {0} and Warehouse"
 msgstr "Charge {0} und Lager"
 
-#: erpnext/controllers/sales_and_purchase_return.py:1095
+#: erpnext/controllers/sales_and_purchase_return.py:1000
 msgid "Batch {0} is not available in warehouse {1}"
 msgstr "Charge {0} ist im Lager {1} nicht verfügbar"
 
@@ -8095,7 +8081,7 @@ msgstr "Die folgenden Abonnementpläne haben eine andere Währung als die Standa
 #. Label of the bill_date (Date) field in DocType 'Journal Entry'
 #. Label of the bill_date (Date) field in DocType 'Subcontracting Receipt'
 #: erpnext/accounts/doctype/journal_entry/journal_entry.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1110
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1112
 #: erpnext/accounts/report/purchase_register/purchase_register.py:214
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.json
 msgid "Bill Date"
@@ -8104,7 +8090,7 @@ msgstr "Rechnungsdatum"
 #. Label of the bill_no (Data) field in DocType 'Journal Entry'
 #. Label of the bill_no (Data) field in DocType 'Subcontracting Receipt'
 #: erpnext/accounts/doctype/journal_entry/journal_entry.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1109
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1111
 #: erpnext/accounts/report/purchase_register/purchase_register.py:213
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.json
 msgid "Bill No"
@@ -8324,7 +8310,7 @@ msgstr "Abrechnungsstatus"
 msgid "Billing Zipcode"
 msgstr "Postleitzahl laut Rechnungsadresse"
 
-#: erpnext/accounts/party.py:602
+#: erpnext/accounts/party.py:608
 msgid "Billing currency must be equal to either default company's currency or party account currency"
 msgstr "Die Abrechnungswährung muss entweder der Unternehmenswährung oder der Währung des Debitoren-/Kreditorenkontos entsprechen"
 
@@ -9321,7 +9307,7 @@ msgid "Can only make payment against unbilled {0}"
 msgstr "Zahlung kann nur zu einem noch nicht abgerechneten Beleg vom Typ {0} erstellt werden"
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1458
-#: erpnext/controllers/accounts_controller.py:2946
+#: erpnext/controllers/accounts_controller.py:2949
 #: erpnext/public/js/controllers/accounts.js:90
 msgid "Can refer row only if the charge type is 'On Previous Row Amount' or 'Previous Row Total'"
 msgstr "Kann sich nur auf eine Zeile beziehen, wenn die Berechnungsart der Kosten entweder \"auf vorherige Zeilensumme\" oder \"auf vorherigen Zeilenbetrag\" ist"
@@ -9483,9 +9469,9 @@ msgstr "Die Ankunftszeit kann nicht berechnet werden, da die Adresse des Fahrers
 msgid "Cannot Create Return"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:625
-#: erpnext/stock/doctype/item/item.py:638
-#: erpnext/stock/doctype/item/item.py:652
+#: erpnext/stock/doctype/item/item.py:631
+#: erpnext/stock/doctype/item/item.py:644
+#: erpnext/stock/doctype/item/item.py:658
 msgid "Cannot Merge"
 msgstr "Zusammenführung nicht möglich"
 
@@ -9509,7 +9495,7 @@ msgstr "{0} {1} kann nicht berichtigt werden. Bitte erstellen Sie stattdessen ei
 msgid "Cannot apply TDS against multiple parties in one entry"
 msgstr "Quellensteuer (TDS) kann nicht auf mehrere Parteien in einer Buchung angewendet werden"
 
-#: erpnext/stock/doctype/item/item.py:307
+#: erpnext/stock/doctype/item/item.py:310
 msgid "Cannot be a fixed asset item as Stock Ledger is created."
 msgstr "Kann keine Anlageposition sein, wenn das Stock Ledger erstellt wird."
 
@@ -9525,7 +9511,7 @@ msgstr "Kann nicht storniert werden, da die gebuchte Lagerbewegung {0} existiert
 msgid "Cannot cancel the transaction. Reposting of item valuation on submission is not completed yet."
 msgstr "Sie können die Transaktion nicht stornieren. Die Umbuchung der Artikelbewertung bei der Buchung ist noch nicht abgeschlossen."
 
-#: erpnext/controllers/buying_controller.py:959
+#: erpnext/controllers/buying_controller.py:967
 msgid "Cannot cancel this document as it is linked with the submitted asset {asset_link}. Please cancel the asset to continue."
 msgstr "Dieses Dokument kann nicht storniert werden, da es mit dem gebuchten Vermögensgegenstand {asset_link} verknüpft ist. Bitte stornieren Sie den Vermögensgegenstand, um fortzufahren."
 
@@ -9533,7 +9519,7 @@ msgstr "Dieses Dokument kann nicht storniert werden, da es mit dem gebuchten Ver
 msgid "Cannot cancel transaction for Completed Work Order."
 msgstr "Die Transaktion für den abgeschlossenen Arbeitsauftrag kann nicht storniert werden."
 
-#: erpnext/stock/doctype/item/item.py:882
+#: erpnext/stock/doctype/item/item.py:876
 msgid "Cannot change Attributes after stock transaction. Make a new Item and transfer stock to the new Item"
 msgstr "Attribute können nach einer Buchung nicht mehr geändert werden. Es muss ein neuer Artikel erstellt und der Bestand darauf übertragen werden."
 
@@ -9549,7 +9535,7 @@ msgstr "Der Referenzdokumenttyp kann nicht geändert werden."
 msgid "Cannot change Service Stop Date for item in row {0}"
 msgstr "Das Servicestoppdatum für das Element in der Zeile {0} kann nicht geändert werden"
 
-#: erpnext/stock/doctype/item/item.py:873
+#: erpnext/stock/doctype/item/item.py:867
 msgid "Cannot change Variant properties after stock transaction. You will have to make a new Item to do this."
 msgstr "Die Eigenschaften der Variante können nach der Buchung nicht mehr verändert werden. Hierzu muss ein neuer Artikel erstellt werden."
 
@@ -9577,7 +9563,7 @@ msgstr ""
 msgid "Cannot covert to Group because Account Type is selected."
 msgstr "Kann nicht in eine Gruppe umgewandelt werden, weil Kontentyp ausgewählt ist."
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:972
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:981
 msgid "Cannot create Stock Reservation Entries for future dated Purchase Receipts."
 msgstr "Für in der Zukunft datierte Kaufbelege kann keine Bestandsreservierung erstellt werden."
 
@@ -9628,7 +9614,7 @@ msgstr "Die Lieferung per Seriennummer kann nicht sichergestellt werden, da Arti
 msgid "Cannot find Item with this Barcode"
 msgstr "Artikel mit diesem Barcode kann nicht gefunden werden"
 
-#: erpnext/controllers/accounts_controller.py:3483
+#: erpnext/controllers/accounts_controller.py:3486
 msgid "Cannot find a default warehouse for item {0}. Please set one in the Item Master or in Stock Settings."
 msgstr "Es wurde kein Standardlager für den Artikel {0} gefunden. Bitte legen Sie eines im Artikelstamm oder in den Lagereinstellungen fest."
 
@@ -9636,7 +9622,7 @@ msgstr "Es wurde kein Standardlager für den Artikel {0} gefunden. Bitte legen S
 msgid "Cannot make any transactions until the deletion job is completed"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2074
+#: erpnext/controllers/accounts_controller.py:2077
 msgid "Cannot overbill for Item {0} in row {1} more than {2}. To allow over-billing, please set allowance in Accounts Settings"
 msgstr "Für Artikel {0} in Zeile {1} kann nicht mehr als {2} zusätzlich in Rechnung gestellt werden. Um diese Überfakturierung zuzulassen, passen Sie bitte die Grenzwerte in den Buchhaltungseinstellungen an."
 
@@ -9657,7 +9643,7 @@ msgid "Cannot receive from customer against negative outstanding"
 msgstr "Negativer Gesamtbetrag kann nicht vom Kunden empfangen werden"
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1475
-#: erpnext/controllers/accounts_controller.py:2961
+#: erpnext/controllers/accounts_controller.py:2964
 #: erpnext/public/js/controllers/accounts.js:100
 msgid "Cannot refer row number greater than or equal to current row number for this Charge type"
 msgstr "Für diese Berechnungsart kann keine Zeilennummern zugeschrieben werden, die größer oder gleich der aktuellen Zeilennummer ist"
@@ -9673,7 +9659,7 @@ msgstr "Link-Token kann nicht abgerufen werden. Prüfen Sie das Fehlerprotokoll 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1467
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1646
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:1917
-#: erpnext/controllers/accounts_controller.py:2951
+#: erpnext/controllers/accounts_controller.py:2954
 #: erpnext/public/js/controllers/accounts.js:94
 #: erpnext/public/js/controllers/taxes_and_totals.js:470
 msgid "Cannot select charge type as 'On Previous Row Amount' or 'On Previous Row Total' for first row"
@@ -9687,15 +9673,15 @@ msgstr "Kann nicht als verloren gekennzeichnet werden, da ein Auftrag dazu exist
 msgid "Cannot set authorization on basis of Discount for {0}"
 msgstr "Genehmigung kann nicht auf der Basis des Rabattes für {0} festgelegt werden"
 
-#: erpnext/stock/doctype/item/item.py:716
+#: erpnext/stock/doctype/item/item.py:722
 msgid "Cannot set multiple Item Defaults for a company."
 msgstr "Es können nicht mehrere Artikelstandards für ein Unternehmen festgelegt werden."
 
-#: erpnext/controllers/accounts_controller.py:3631
+#: erpnext/controllers/accounts_controller.py:3634
 msgid "Cannot set quantity less than delivered quantity"
 msgstr "Menge kann nicht kleiner als gelieferte Menge sein"
 
-#: erpnext/controllers/accounts_controller.py:3634
+#: erpnext/controllers/accounts_controller.py:3637
 msgid "Cannot set quantity less than received quantity"
 msgstr "Menge kann nicht kleiner als die empfangene Menge eingestellt werden"
 
@@ -10118,7 +10104,7 @@ msgid "Channel Partner"
 msgstr "Vertriebspartner"
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:2346
-#: erpnext/controllers/accounts_controller.py:3014
+#: erpnext/controllers/accounts_controller.py:3017
 msgid "Charge of type 'Actual' in row {0} cannot be included in Item Rate or Paid Amount"
 msgstr "Kosten für den Typ „Tatsächlich“ in Zeile {0} können nicht in den Artikelpreis oder den bezahlen Betrag einfließen"
 
@@ -10301,7 +10287,7 @@ msgstr "Scheck Breite"
 
 #. Label of the reference_date (Date) field in DocType 'Payment Entry'
 #: erpnext/accounts/doctype/payment_entry/payment_entry.json
-#: erpnext/public/js/controllers/transaction.js:2299
+#: erpnext/public/js/controllers/transaction.js:2325
 msgid "Cheque/Reference Date"
 msgstr "Scheck-/ Referenzdatum"
 
@@ -10349,7 +10335,7 @@ msgstr "Untergeordneter Dokumentname"
 
 #. Label of the child_row_reference (Data) field in DocType 'Quality
 #. Inspection'
-#: erpnext/public/js/controllers/transaction.js:2394
+#: erpnext/public/js/controllers/transaction.js:2420
 #: erpnext/stock/doctype/quality_inspection/quality_inspection.json
 msgid "Child Row Reference"
 msgstr "Zeilenreferenz"
@@ -11061,7 +11047,7 @@ msgstr "Firmen"
 #: erpnext/accounts/report/cheques_and_deposits_incorrectly_cleared/cheques_and_deposits_incorrectly_cleared.js:8
 #: erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.js:8
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:8
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:49
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:50
 #: erpnext/accounts/report/deferred_revenue_and_expense/deferred_revenue_and_expense.js:8
 #: erpnext/accounts/report/delivered_items_to_be_billed/delivered_items_to_be_billed.js:7
 #: erpnext/accounts/report/dimension_wise_accounts_balance_report/dimension_wise_accounts_balance_report.js:8
@@ -12294,7 +12280,7 @@ msgid "Content Type"
 msgstr "Inhaltstyp"
 
 #: erpnext/erpnext_integrations/doctype/plaid_settings/plaid_settings.js:162
-#: erpnext/public/js/controllers/transaction.js:2312
+#: erpnext/public/js/controllers/transaction.js:2338
 #: erpnext/selling/doctype/quotation/quotation.js:356
 msgid "Continue"
 msgstr "Fortsetzen"
@@ -12459,7 +12445,7 @@ msgstr "Umrechnungsfaktor"
 msgid "Conversion Rate"
 msgstr "Wechselkurs"
 
-#: erpnext/stock/doctype/item/item.py:393
+#: erpnext/stock/doctype/item/item.py:396
 msgid "Conversion factor for default Unit of Measure must be 1 in row {0}"
 msgstr "Umrechnungsfaktor für Standardmaßeinheit muss in Zeile {0} 1 sein"
 
@@ -12467,15 +12453,15 @@ msgstr "Umrechnungsfaktor für Standardmaßeinheit muss in Zeile {0} 1 sein"
 msgid "Conversion factor for item {0} has been reset to 1.0 as the uom {1} is same as stock uom {2}."
 msgstr "Der Umrechnungsfaktor für Artikel {0} wurde auf 1,0 zurückgesetzt, da die Maßeinheit {1} dieselbe ist wie die Lagermaßeinheit {2}."
 
-#: erpnext/controllers/accounts_controller.py:2767
+#: erpnext/controllers/accounts_controller.py:2770
 msgid "Conversion rate cannot be 0"
 msgstr "Der Umrechnungskurs kann nicht 0 sein"
 
-#: erpnext/controllers/accounts_controller.py:2774
+#: erpnext/controllers/accounts_controller.py:2777
 msgid "Conversion rate is 1.00, but document currency is different from company currency"
 msgstr "Der Umrechnungskurs beträgt 1,00, aber die Währung des Dokuments unterscheidet sich von der Währung des Unternehmens"
 
-#: erpnext/controllers/accounts_controller.py:2770
+#: erpnext/controllers/accounts_controller.py:2773
 msgid "Conversion rate must be 1.00 if document currency is same as company currency"
 msgstr "Der Umrechnungskurs muss 1,00 betragen, wenn die Belegwährung mit der Währung des Unternehmens übereinstimmt"
 
@@ -12688,7 +12674,7 @@ msgstr "Kosten"
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:28
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:40
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:30
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1096
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1098
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:40
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.js:42
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.py:197
@@ -12781,7 +12767,7 @@ msgid "Cost Center is a part of Cost Center Allocation, hence cannot be converte
 msgstr "Kostenstelle ist Teil der Kostenstellenzuordnung und kann daher nicht in eine Gruppe umgewandelt werden"
 
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py:1411
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:855
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:864
 msgid "Cost Center is required in row {0} in Taxes table for type {1}"
 msgstr "Kostenstelle wird in Zeile {0} der Steuertabelle für Typ {1} gebraucht"
 
@@ -13050,8 +13036,8 @@ msgstr "H"
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:132
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:143
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:219
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:654
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:678
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:656
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:680
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.js:88
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.js:89
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.js:103
@@ -13108,8 +13094,8 @@ msgstr "H"
 #: erpnext/projects/doctype/task/task_tree.js:81
 #: erpnext/public/js/communication.js:19 erpnext/public/js/communication.js:31
 #: erpnext/public/js/communication.js:41
-#: erpnext/public/js/controllers/transaction.js:336
-#: erpnext/public/js/controllers/transaction.js:2435
+#: erpnext/public/js/controllers/transaction.js:362
+#: erpnext/public/js/controllers/transaction.js:2461
 #: erpnext/selling/doctype/customer/customer.js:181
 #: erpnext/selling/doctype/quotation/quotation.js:124
 #: erpnext/selling/doctype/quotation/quotation.js:133
@@ -13404,7 +13390,7 @@ msgstr "Neuen zusammengesetzten Vermögensgegenstand erstellen"
 msgid "Create a variant with the template image."
 msgstr "Eine Variante mit dem Vorlagenbild erstellen."
 
-#: erpnext/stock/stock_ledger.py:1877
+#: erpnext/stock/stock_ledger.py:1886
 msgid "Create an incoming stock transaction for the Item."
 msgstr "Erstellen Sie eine eingehende Lagertransaktion für den Artikel."
 
@@ -13464,7 +13450,7 @@ msgstr "Eingangsrechnungen erstellen ..."
 msgid "Creating Purchase Order ..."
 msgstr "Bestellung anlegen ..."
 
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:735
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:737
 #: erpnext/buying/doctype/purchase_order/purchase_order.js:552
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.js:73
 msgid "Creating Purchase Receipt ..."
@@ -13660,7 +13646,7 @@ msgstr "Kreditmonate"
 #: erpnext/accounts/doctype/journal_entry_template/journal_entry_template.json
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:174
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:147
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1119
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1121
 #: erpnext/controllers/sales_and_purchase_return.py:373
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:286
 #: erpnext/stock/doctype/delivery_note/delivery_note.js:89
@@ -13695,7 +13681,7 @@ msgstr "Gutschrift {0} wurde automatisch erstellt"
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py:368
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py:376
-#: erpnext/controllers/accounts_controller.py:2186
+#: erpnext/controllers/accounts_controller.py:2189
 msgid "Credit To"
 msgstr "Gutschreiben auf"
 
@@ -13880,7 +13866,7 @@ msgstr "Tasse"
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/subscription_plan/subscription_plan.json
 #: erpnext/accounts/report/account_balance/account_balance.py:28
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1129
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1131
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:205
 #: erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.py:101
 #: erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.js:118
@@ -14409,7 +14395,7 @@ msgstr "Kunden-Nr."
 #. Label of the customer_contact_display (Small Text) field in DocType
 #. 'Purchase Order'
 #. Label of the customer_contact (Small Text) field in DocType 'Delivery Stop'
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1090
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1092
 #: erpnext/buying/doctype/purchase_order/purchase_order.json
 #: erpnext/stock/doctype/delivery_stop/delivery_stop.json
 msgid "Customer Contact"
@@ -14505,7 +14491,7 @@ msgstr "Kundenrückmeldung"
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/tax_rule/tax_rule.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:107
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1147
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1149
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:81
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:185
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:56
@@ -14549,7 +14535,7 @@ msgstr "Kundengruppe (Zeile)"
 msgid "Customer Group Name"
 msgstr "Kundengruppenname"
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1239
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1241
 msgid "Customer Group: {0} does not exist"
 msgstr "Kundengruppe: {0} existiert nicht"
 
@@ -14568,7 +14554,7 @@ msgstr "Kunden-Artikel"
 msgid "Customer Items"
 msgstr "Kunden-Artikel"
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1138
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1140
 msgid "Customer LPO"
 msgstr "Kunden LPO"
 
@@ -14614,7 +14600,7 @@ msgstr "Mobilnummer des Kunden"
 #: erpnext/accounts/doctype/pos_invoice/pos_invoice.json
 #: erpnext/accounts/doctype/process_statement_of_accounts_customer/process_statement_of_accounts_customer.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1080
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1082
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:156
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:92
 #: erpnext/accounts/report/delivered_items_to_be_billed/delivered_items_to_be_billed.py:35
@@ -15292,7 +15278,7 @@ msgstr "Soll-Betrag in Transaktionswährung"
 #: erpnext/accounts/doctype/journal_entry_template/journal_entry_template.json
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:176
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:147
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1122
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1124
 #: erpnext/controllers/sales_and_purchase_return.py:377
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:287
 #: erpnext/stock/doctype/purchase_receipt/purchase_receipt.js:61
@@ -15321,7 +15307,7 @@ msgstr "Den ausstehenden Betrag dieser Rechnungskorrektur separat buchen, statt 
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:953
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:964
-#: erpnext/controllers/accounts_controller.py:2186
+#: erpnext/controllers/accounts_controller.py:2189
 msgid "Debit To"
 msgstr "Forderungskonto"
 
@@ -15354,11 +15340,11 @@ msgstr "Soll-Haben-Diskrepanz"
 msgid "Debit-Credit mismatch"
 msgstr "Soll-Haben-Diskrepanz"
 
-#: erpnext/accounts/party.py:609
+#: erpnext/accounts/party.py:615
 msgid "Debtor/Creditor"
 msgstr "Schuldner/Gläubiger"
 
-#: erpnext/accounts/party.py:612
+#: erpnext/accounts/party.py:618
 msgid "Debtor/Creditor Advance"
 msgstr "Schuldner-/Gläubigervorschuss"
 
@@ -15478,7 +15464,7 @@ msgstr "Standardkonto für erhaltene Vorauszahlungen"
 msgid "Default BOM"
 msgstr "Standardstückliste"
 
-#: erpnext/stock/doctype/item/item.py:418
+#: erpnext/stock/doctype/item/item.py:421
 msgid "Default BOM ({0}) must be active for this item or its template"
 msgstr "Standardstückliste ({0}) muss für diesen Artikel oder dessen Vorlage aktiv sein"
 
@@ -15486,7 +15472,7 @@ msgstr "Standardstückliste ({0}) muss für diesen Artikel oder dessen Vorlage a
 msgid "Default BOM for {0} not found"
 msgstr "Standardstückliste für {0} nicht gefunden"
 
-#: erpnext/controllers/accounts_controller.py:3672
+#: erpnext/controllers/accounts_controller.py:3675
 msgid "Default BOM not found for FG Item {0}"
 msgstr "Standard Stückliste für Fertigprodukt {0} nicht gefunden"
 
@@ -15821,15 +15807,15 @@ msgstr "Standardregion"
 msgid "Default Unit of Measure"
 msgstr "Standardmaßeinheit"
 
-#: erpnext/stock/doctype/item/item.py:1272
+#: erpnext/stock/doctype/item/item.py:1266
 msgid "Default Unit of Measure for Item {0} cannot be changed directly because you have already made some transaction(s) with another UOM. You need to either cancel the linked documents or create a new Item."
 msgstr "Die Standardmaßeinheit für Artikel {0} kann nicht direkt geändert werden, da bereits einige Transaktionen mit einer anderen Maßeinheit durchgeführt wurden. Sie können entweder die verknüpften Dokumente stornieren oder einen neuen Artikel erstellen."
 
-#: erpnext/stock/doctype/item/item.py:1255
+#: erpnext/stock/doctype/item/item.py:1249
 msgid "Default Unit of Measure for Item {0} cannot be changed directly because you have already made some transaction(s) with another UOM. You will need to create a new Item to use a different Default UOM."
 msgstr "Die Standard-Maßeinheit für Artikel {0} kann nicht direkt geändert werden, weil Sie bereits einige Transaktionen mit einer anderen Maßeinheit durchgeführt haben. Sie müssen einen neuen Artikel erstellen, um eine andere Standard-Maßeinheit verwenden zukönnen."
 
-#: erpnext/stock/doctype/item/item.py:908
+#: erpnext/stock/doctype/item/item.py:902
 msgid "Default Unit of Measure for Variant '{0}' must be same as in Template '{1}'"
 msgstr "Standard-Maßeinheit für Variante '{0}' muss dieselbe wie in der Vorlage '{1}' sein"
 
@@ -16288,7 +16274,7 @@ msgstr "Entwicklung Lieferscheine"
 msgid "Delivery Note {0} is not submitted"
 msgstr "Lieferschein {0} ist nicht gebucht"
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1142
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1144
 #: erpnext/stock/doctype/delivery_trip/delivery_trip.js:73
 msgid "Delivery Notes"
 msgstr "Lieferscheine"
@@ -16819,7 +16805,7 @@ msgstr "Abschreibung durch Umkehr eliminiert"
 #: erpnext/projects/doctype/task_type/task_type.json
 #: erpnext/projects/doctype/timesheet_detail/timesheet_detail.json
 #: erpnext/public/js/bank_reconciliation_tool/data_table_manager.js:55
-#: erpnext/public/js/controllers/transaction.js:2376
+#: erpnext/public/js/controllers/transaction.js:2402
 #: erpnext/selling/doctype/installation_note_item/installation_note_item.json
 #: erpnext/selling/doctype/product_bundle/product_bundle.json
 #: erpnext/selling/doctype/product_bundle_item/product_bundle_item.json
@@ -17007,7 +16993,7 @@ msgstr ""
 msgid "Difference Account must be a Asset/Liability type account (Temporary Opening), since this Stock Entry is an Opening Entry"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:954
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:950
 msgid "Difference Account must be a Asset/Liability type account, since this Stock Reconciliation is an Opening Entry"
 msgstr "Differenzkonto muss ein Vermögens-/Verbindlichkeiten-Konto sein, da dieser Lagerabgleich eine Eröffnungsbuchung ist"
 
@@ -17273,11 +17259,11 @@ msgstr "Deaktiviertes Konto ausgewählt"
 msgid "Disabled Warehouse {0} cannot be used for this transaction."
 msgstr "Deaktiviertes Lager {0} kann für diese Transaktion nicht verwendet werden."
 
-#: erpnext/controllers/accounts_controller.py:745
+#: erpnext/controllers/accounts_controller.py:748
 msgid "Disabled pricing rules since this {} is an internal transfer"
 msgstr "Preisregeln deaktiviert, da es sich bei {} um eine interne Übertragung handelt"
 
-#: erpnext/controllers/accounts_controller.py:759
+#: erpnext/controllers/accounts_controller.py:762
 msgid "Disabled tax included prices since this {} is an internal transfer"
 msgstr "Bruttopreise deaktiviert, da es sich bei {} um eine interne Übertragung handelt"
 
@@ -18219,7 +18205,7 @@ msgstr "Streckengeschäft"
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.json
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/print_format/sales_invoice_print/sales_invoice_print.html:72
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1106
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1108
 #: erpnext/assets/doctype/asset_maintenance_log/asset_maintenance_log.json
 #: erpnext/selling/report/payment_terms_status_for_sales_order/payment_terms_status_for_sales_order.py:40
 msgid "Due Date"
@@ -18233,11 +18219,11 @@ msgstr "Fälligkeitsdatum"
 msgid "Due Date Based On"
 msgstr "Fälligkeitsdatum basiert auf"
 
-#: erpnext/accounts/party.py:695
+#: erpnext/accounts/party.py:701
 msgid "Due Date cannot be after {0}"
 msgstr "Das Fälligkeitsdatum darf nicht nach {0} liegen"
 
-#: erpnext/accounts/party.py:671
+#: erpnext/accounts/party.py:677
 msgid "Due Date cannot be before {0}"
 msgstr "Das Fälligkeitsdatum darf nicht vor {0} liegen"
 
@@ -18955,7 +18941,7 @@ msgstr "Terminplanung aktivieren"
 msgid "Enable Auto Email"
 msgstr "Aktivieren Sie die automatische E-Mail"
 
-#: erpnext/stock/doctype/item/item.py:1064
+#: erpnext/stock/doctype/item/item.py:1058
 msgid "Enable Auto Re-Order"
 msgstr "Aktivieren Sie die automatische Nachbestellung"
 
@@ -19168,7 +19154,7 @@ msgstr "Inkassodatum"
 msgid "End Date"
 msgstr "Enddatum"
 
-#: erpnext/crm/doctype/contract/contract.py:75
+#: erpnext/crm/doctype/contract/contract.py:83
 msgid "End Date cannot be before Start Date."
 msgstr "Das Enddatum darf nicht vor dem Startdatum liegen."
 
@@ -19419,7 +19405,7 @@ msgstr ""
 #: erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.json
 #: erpnext/manufacturing/doctype/job_card/job_card.py:875
 #: erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.json
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:297
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:298
 msgid "Error"
 msgstr "Fehler"
 
@@ -19544,7 +19530,7 @@ msgstr "Ab Werk"
 msgid "Example URL"
 msgstr "Beispiel URL"
 
-#: erpnext/stock/doctype/item/item.py:995
+#: erpnext/stock/doctype/item/item.py:989
 msgid "Example of a linked document: {0}"
 msgstr "Beispiel für ein verknüpftes Dokument: {0}"
 
@@ -19560,7 +19546,7 @@ msgstr "Beispiel: ABCD.#####\n"
 msgid "Example: ABCD.#####. If series is set and Batch No is not mentioned in transactions, then automatic batch number will be created based on this series. If you always want to explicitly mention Batch No for this item, leave this blank. Note: this setting will take priority over the Naming Series Prefix in Stock Settings."
 msgstr "Beispiel: ABCD. #####. Wenn die Serie gesetzt ist und die Chargennummer in den Transaktionen nicht erwähnt wird, wird die automatische Chargennummer basierend auf dieser Serie erstellt. Wenn Sie die Chargennummer für diesen Artikel immer explizit angeben möchten, lassen Sie dieses Feld leer. Hinweis: Diese Einstellung hat Vorrang vor dem Naming Series Prefix in den Stock Settings."
 
-#: erpnext/stock/stock_ledger.py:2141
+#: erpnext/stock/stock_ledger.py:2149
 msgid "Example: Serial No {0} reserved in {1}."
 msgstr "Beispiel: Seriennummer {0} reserviert in {1}."
 
@@ -19614,8 +19600,8 @@ msgstr "Wechselkursgewinn oder -verlust"
 msgid "Exchange Gain/Loss"
 msgstr "Exchange-Gewinn / Verlust"
 
-#: erpnext/controllers/accounts_controller.py:1593
-#: erpnext/controllers/accounts_controller.py:1677
+#: erpnext/controllers/accounts_controller.py:1596
+#: erpnext/controllers/accounts_controller.py:1680
 msgid "Exchange Gain/Loss amount has been booked through {0}"
 msgstr "Wechselkursgewinne/-verluste wurden über {0} verbucht"
 
@@ -20351,7 +20337,7 @@ msgid "Fetching Error"
 msgstr ""
 
 #: erpnext/accounts/doctype/dunning/dunning.js:135
-#: erpnext/public/js/controllers/transaction.js:1251
+#: erpnext/public/js/controllers/transaction.js:1277
 msgid "Fetching exchange rates ..."
 msgstr "Wechselkurse werden abgerufen ..."
 
@@ -20646,15 +20632,15 @@ msgstr "Fertigerzeugnisartikel Menge"
 msgid "Finished Good Item Quantity"
 msgstr "Fertigerzeugnisartikel Menge"
 
-#: erpnext/controllers/accounts_controller.py:3658
+#: erpnext/controllers/accounts_controller.py:3661
 msgid "Finished Good Item is not specified for service item {0}"
 msgstr "Fertigerzeugnisartikel ist nicht als Dienstleistungsartikel {0} angelegt"
 
-#: erpnext/controllers/accounts_controller.py:3675
+#: erpnext/controllers/accounts_controller.py:3678
 msgid "Finished Good Item {0} Qty can not be zero"
 msgstr "Menge für Fertigerzeugnis {0} kann nicht Null sein"
 
-#: erpnext/controllers/accounts_controller.py:3669
+#: erpnext/controllers/accounts_controller.py:3672
 msgid "Finished Good Item {0} must be a sub-contracted item"
 msgstr "Fertigerzeugnis {0} muss ein untervergebener Artikel sein"
 
@@ -20895,7 +20881,7 @@ msgstr "Konto für Anlagevermögen"
 msgid "Fixed Asset Defaults"
 msgstr " Standards für Anlagevermögen"
 
-#: erpnext/stock/doctype/item/item.py:301
+#: erpnext/stock/doctype/item/item.py:304
 msgid "Fixed Asset Item must be a non-stock item."
 msgstr "Posten des Anlagevermögens muss ein Artikel ohne Lagerhaltung sein."
 
@@ -21071,7 +21057,7 @@ msgstr "Für Menge (hergestellte Menge) ist zwingend erforderlich"
 msgid "For Raw Materials"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1259
+#: erpnext/controllers/accounts_controller.py:1262
 msgid "For Return Invoices with Stock effect, '0' qty Items are not allowed. Following rows are affected: {0}"
 msgstr ""
 
@@ -21172,7 +21158,7 @@ msgstr "Zur Vereinfachung für Kunden können diese Codes in Druckformaten wie R
 msgid "For the item {0}, the quantity should be {1} according to the BOM {2}."
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:1088
+#: erpnext/public/js/controllers/transaction.js:1114
 msgctxt "Clear payment terms template and/or payment schedule when due date is changed"
 msgid "For the new {0} to take effect, would you like to clear the current {1}?"
 msgstr "Möchten Sie die aktuellen Werte für {1} löschen, damit das neue {0} wirksam wird?"
@@ -21181,7 +21167,7 @@ msgstr "Möchten Sie die aktuellen Werte für {1} löschen, damit das neue {0} w
 msgid "For the {0}, no stock is available for the return in the warehouse {1}."
 msgstr ""
 
-#: erpnext/controllers/sales_and_purchase_return.py:1144
+#: erpnext/controllers/sales_and_purchase_return.py:1049
 msgid "For the {0}, the quantity is required to make the return entry"
 msgstr ""
 
@@ -21518,7 +21504,7 @@ msgstr "Von-Datum kann später liegen als Bis-Datum"
 msgid "From Date is mandatory"
 msgstr "Von-Datum ist obligatorisch"
 
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:52
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:53
 #: erpnext/accounts/report/general_ledger/general_ledger.py:86
 #: erpnext/accounts/report/pos_register/pos_register.py:115
 #: erpnext/accounts/report/tax_withholding_details/tax_withholding_details.py:39
@@ -21895,14 +21881,14 @@ msgstr "Weitere Knoten können nur unter Knoten vom Typ \"Gruppe\" erstellt werd
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:186
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:155
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1134
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1136
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:177
 msgid "Future Payment Amount"
 msgstr "Zukünftiger Zahlungsbetrag"
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:185
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:154
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1133
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1135
 msgid "Future Payment Ref"
 msgstr "Zukünftige Zahlung"
 
@@ -23076,7 +23062,7 @@ msgstr "Hilft Ihnen, das Budget/Ziel über die Monate zu verteilen, wenn Sie in 
 msgid "Here are the error logs for the aforementioned failed depreciation entries: {0}"
 msgstr "Hier sind die Fehlerprotokolle für die oben erwähnten fehlgeschlagenen Abschreibungseinträge: {0}"
 
-#: erpnext/stock/stock_ledger.py:1862
+#: erpnext/stock/stock_ledger.py:1871
 msgid "Here are the options to proceed:"
 msgstr "Hier sind die Optionen für das weitere Vorgehen:"
 
@@ -23600,7 +23586,7 @@ msgstr "Falls gesetzt, erlaubt das System nur Benutzern mit dieser Rolle, eine B
 msgid "If more than one package of the same type (for print)"
 msgstr "Wenn es mehr als ein Paket von der gleichen Art (für den Druck) gibt"
 
-#: erpnext/stock/stock_ledger.py:1872
+#: erpnext/stock/stock_ledger.py:1881
 msgid "If not, you can Cancel / Submit this entry"
 msgstr "Wenn nicht, können Sie diesen Eintrag stornieren / buchen"
 
@@ -23625,7 +23611,7 @@ msgstr "Wenn die Stückliste Schrottmaterial ergibt, muss ein Schrottlager ausge
 msgid "If the account is frozen, entries are allowed to restricted users."
 msgstr "Wenn das Konto gesperrt ist, sind einem eingeschränkten Benutzerkreis Buchungen erlaubt."
 
-#: erpnext/stock/stock_ledger.py:1865
+#: erpnext/stock/stock_ledger.py:1874
 msgid "If the item is transacting as a Zero Valuation Rate item in this entry, please enable 'Allow Zero Valuation Rate' in the {0} Item table."
 msgstr "Wenn der Artikel in diesem Eintrag als Artikel mit der Bewertung Null bewertet wird, aktivieren Sie in der Tabelle {0} Artikel die Option &#39;Nullbewertung zulassen&#39;."
 
@@ -24623,7 +24609,7 @@ msgstr "Falsche Saldo-Menge nach Transaktion"
 msgid "Incorrect Batch Consumed"
 msgstr "Falsche Charge verbraucht"
 
-#: erpnext/stock/doctype/item/item.py:514
+#: erpnext/stock/doctype/item/item.py:517
 msgid "Incorrect Check in (group) Warehouse for Reorder"
 msgstr ""
 
@@ -24672,7 +24658,7 @@ msgstr "Ungültiges Serien- und Chargenbündel"
 msgid "Incorrect Stock Value Report"
 msgstr "Falscher Lagerwertbericht"
 
-#: erpnext/stock/serial_batch_bundle.py:134
+#: erpnext/stock/serial_batch_bundle.py:135
 msgid "Incorrect Type of Transaction"
 msgstr "Falsche Transaktionsart"
 
@@ -24941,8 +24927,8 @@ msgstr "Anweisungen"
 msgid "Insufficient Capacity"
 msgstr "Unzureichende Kapazität"
 
-#: erpnext/controllers/accounts_controller.py:3590
-#: erpnext/controllers/accounts_controller.py:3614
+#: erpnext/controllers/accounts_controller.py:3593
+#: erpnext/controllers/accounts_controller.py:3617
 msgid "Insufficient Permissions"
 msgstr "Nicht ausreichende Berechtigungen"
 
@@ -24950,12 +24936,12 @@ msgstr "Nicht ausreichende Berechtigungen"
 #: erpnext/stock/doctype/pick_list/pick_list.py:127
 #: erpnext/stock/doctype/pick_list/pick_list.py:975
 #: erpnext/stock/doctype/stock_entry/stock_entry.py:759
-#: erpnext/stock/serial_batch_bundle.py:989 erpnext/stock/stock_ledger.py:1559
-#: erpnext/stock/stock_ledger.py:2032
+#: erpnext/stock/serial_batch_bundle.py:1021 erpnext/stock/stock_ledger.py:1568
+#: erpnext/stock/stock_ledger.py:2040
 msgid "Insufficient Stock"
 msgstr "Nicht genug Lagermenge."
 
-#: erpnext/stock/stock_ledger.py:2047
+#: erpnext/stock/stock_ledger.py:2055
 msgid "Insufficient Stock for Batch"
 msgstr "Unzureichender Bestand für Charge"
 
@@ -25093,11 +25079,11 @@ msgstr "Interner Kunde"
 msgid "Internal Customer for company {0} already exists"
 msgstr "Interner Kunde für Unternehmen {0} existiert bereits"
 
-#: erpnext/controllers/accounts_controller.py:728
+#: erpnext/controllers/accounts_controller.py:731
 msgid "Internal Sale or Delivery Reference missing."
 msgstr "Interne Verkaufs- oder Lieferreferenz fehlt."
 
-#: erpnext/controllers/accounts_controller.py:730
+#: erpnext/controllers/accounts_controller.py:733
 msgid "Internal Sales Reference Missing"
 msgstr "Interne Verkaufsreferenz Fehlt"
 
@@ -25128,7 +25114,7 @@ msgstr "Interner Lieferant für Unternehmen {0} existiert bereits"
 msgid "Internal Transfer"
 msgstr "Interner Transfer"
 
-#: erpnext/controllers/accounts_controller.py:739
+#: erpnext/controllers/accounts_controller.py:742
 msgid "Internal Transfer Reference Missing"
 msgstr "Interne Transferreferenz fehlt"
 
@@ -25171,8 +25157,8 @@ msgstr "Ungültig"
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:969
 #: erpnext/assets/doctype/asset_category/asset_category.py:69
 #: erpnext/assets/doctype/asset_category/asset_category.py:97
-#: erpnext/controllers/accounts_controller.py:2975
-#: erpnext/controllers/accounts_controller.py:2983
+#: erpnext/controllers/accounts_controller.py:2978
+#: erpnext/controllers/accounts_controller.py:2986
 msgid "Invalid Account"
 msgstr "Ungültiger Account"
 
@@ -25197,7 +25183,7 @@ msgstr "Ungültiges Datum für die automatische Wiederholung"
 msgid "Invalid Barcode. There is no Item attached to this barcode."
 msgstr "Ungültiger Barcode. Es ist kein Artikel an diesen Barcode angehängt."
 
-#: erpnext/public/js/controllers/transaction.js:2631
+#: erpnext/public/js/controllers/transaction.js:2657
 msgid "Invalid Blanket Order for the selected Customer and Item"
 msgstr "Ungültiger Rahmenauftrag für den ausgewählten Kunden und Artikel"
 
@@ -25211,7 +25197,7 @@ msgstr "Ungültige Firma für Inter Company-Transaktion."
 
 #: erpnext/assets/doctype/asset/asset.py:295
 #: erpnext/assets/doctype/asset/asset.py:302
-#: erpnext/controllers/accounts_controller.py:2998
+#: erpnext/controllers/accounts_controller.py:3001
 msgid "Invalid Cost Center"
 msgstr "Ungültige Kostenstelle"
 
@@ -25253,7 +25239,7 @@ msgstr "Ungültige Gruppierung"
 msgid "Invalid Item"
 msgstr "Ungültiger Artikel"
 
-#: erpnext/stock/doctype/item/item.py:1410
+#: erpnext/stock/doctype/item/item.py:1404
 msgid "Invalid Item Defaults"
 msgstr "Ungültige Artikel-Standardwerte"
 
@@ -25299,11 +25285,11 @@ msgstr "Ungültige Prozessverlust-Konfiguration"
 msgid "Invalid Purchase Invoice"
 msgstr "Ungültige Eingangsrechnung"
 
-#: erpnext/controllers/accounts_controller.py:3627
+#: erpnext/controllers/accounts_controller.py:3630
 msgid "Invalid Qty"
 msgstr "Ungültige Menge"
 
-#: erpnext/controllers/accounts_controller.py:1277
+#: erpnext/controllers/accounts_controller.py:1280
 msgid "Invalid Quantity"
 msgstr "Ungültige Menge"
 
@@ -25320,7 +25306,7 @@ msgstr ""
 msgid "Invalid Schedule"
 msgstr "Ungültiger Zeitplan"
 
-#: erpnext/controllers/selling_controller.py:243
+#: erpnext/controllers/selling_controller.py:251
 msgid "Invalid Selling Price"
 msgstr "Ungültiger Verkaufspreis"
 
@@ -25353,7 +25339,7 @@ msgstr "Ungültiger Bedingungsausdruck"
 msgid "Invalid lost reason {0}, please create a new lost reason"
 msgstr "Ungültiger Grund für verlorene(s) {0}, bitte erstellen Sie einen neuen Grund für Verlust"
 
-#: erpnext/stock/doctype/item/item.py:408
+#: erpnext/stock/doctype/item/item.py:411
 msgid "Invalid naming series (. missing) for {0}"
 msgstr "Ungültige Namensreihe (. Fehlt) für {0}"
 
@@ -25393,7 +25379,7 @@ msgstr "Lagerbestand"
 #. Name of a DocType
 #: erpnext/patches/v15_0/refactor_closing_stock_balance.py:43
 #: erpnext/stock/doctype/inventory_dimension/inventory_dimension.json
-#: erpnext/stock/doctype/inventory_dimension/inventory_dimension.py:180
+#: erpnext/stock/doctype/inventory_dimension/inventory_dimension.py:181
 msgid "Inventory Dimension"
 msgstr "Lagerbestandsdimension"
 
@@ -25459,7 +25445,7 @@ msgstr "Rechnungsdatum"
 msgid "Invoice Discounting"
 msgstr "Rechnungsrabatt"
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1114
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1116
 msgid "Invoice Grand Total"
 msgstr "Rechnungssumme"
 
@@ -25552,7 +25538,7 @@ msgstr "Die Rechnung kann nicht für die Null-Rechnungsstunde erstellt werden"
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:169
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:144
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1116
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1118
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:164
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:165
 msgid "Invoiced Amount"
@@ -25958,6 +25944,11 @@ msgstr "Ist Eröffnungsbuchung"
 msgid "Is Outward"
 msgstr "Ist Ausgehend"
 
+#. Label of the is_packed (Check) field in DocType 'Serial and Batch Bundle'
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.json
+msgid "Is Packed"
+msgstr ""
+
 #. Label of the is_paid (Check) field in DocType 'Purchase Invoice'
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 msgid "Is Paid"
@@ -26240,11 +26231,11 @@ msgstr "Ausstellungsdatum"
 msgid "Issuing cannot be done to a location. Please enter employee to issue the Asset {0} to"
 msgstr "Die Ausgabe kann nicht an einen Standort erfolgen. Bitte geben Sie den Mitarbeiter ein, der den Vermögensgegenstand erhalten soll {0}"
 
-#: erpnext/stock/doctype/item/item.py:565
+#: erpnext/stock/doctype/item/item.py:571
 msgid "It can take upto few hours for accurate stock values to be visible after merging items."
 msgstr "Es kann bis zu einigen Stunden dauern, bis nach der Zusammenführung von Artikeln genaue Bestandswerte sichtbar sind."
 
-#: erpnext/public/js/controllers/transaction.js:2075
+#: erpnext/public/js/controllers/transaction.js:2101
 msgid "It is needed to fetch Item Details."
 msgstr "Wird gebraucht, um Artikeldetails abzurufen"
 
@@ -26294,7 +26285,7 @@ msgstr "Es ist nicht möglich, die Gebühren gleichmäßig zu verteilen, wenn de
 #: erpnext/buying/report/supplier_quotation_comparison/supplier_quotation_comparison.js:33
 #: erpnext/buying/report/supplier_quotation_comparison/supplier_quotation_comparison.py:204
 #: erpnext/buying/workspace/buying/buying.json
-#: erpnext/controllers/taxes_and_totals.py:1125
+#: erpnext/controllers/taxes_and_totals.py:1135
 #: erpnext/manufacturing/doctype/blanket_order/blanket_order.json
 #: erpnext/manufacturing/doctype/bom/bom.js:944
 #: erpnext/manufacturing/doctype/bom/bom.json
@@ -26572,7 +26563,7 @@ msgstr "Artikel-Warenkorb"
 #: erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py:86
 #: erpnext/manufacturing/report/work_order_stock_report/work_order_stock_report.py:119
 #: erpnext/projects/doctype/timesheet/timesheet.js:213
-#: erpnext/public/js/controllers/transaction.js:2350
+#: erpnext/public/js/controllers/transaction.js:2376
 #: erpnext/public/js/stock_reservation.js:112
 #: erpnext/public/js/stock_reservation.js:317 erpnext/public/js/utils.js:500
 #: erpnext/public/js/utils.js:656
@@ -27010,7 +27001,7 @@ msgstr "Artikel Hersteller"
 #: erpnext/manufacturing/report/production_planning_report/production_planning_report.py:359
 #: erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py:92
 #: erpnext/manufacturing/report/work_order_consumed_materials/work_order_consumed_materials.py:138
-#: erpnext/public/js/controllers/transaction.js:2356
+#: erpnext/public/js/controllers/transaction.js:2382
 #: erpnext/public/js/utils.js:746
 #: erpnext/selling/doctype/quotation_item/quotation_item.json
 #: erpnext/selling/doctype/sales_order_item/sales_order_item.json
@@ -27277,7 +27268,7 @@ msgstr "Einstellungen zur Artikelvariante"
 msgid "Item Variant {0} already exists with same attributes"
 msgstr "Artikelvariante {0} mit denselben Attributen existiert bereits"
 
-#: erpnext/stock/doctype/item/item.py:781
+#: erpnext/stock/doctype/item/item.py:772
 msgid "Item Variants updated"
 msgstr "Artikelvarianten aktualisiert"
 
@@ -27343,7 +27334,7 @@ msgstr "Einzelheiten Artikel und Garantie"
 msgid "Item for row {0} does not match Material Request"
 msgstr "Artikel für Zeile {0} stimmt nicht mit Materialanforderung überein"
 
-#: erpnext/stock/doctype/item/item.py:795
+#: erpnext/stock/doctype/item/item.py:789
 msgid "Item has variants."
 msgstr "Artikel hat Varianten."
 
@@ -27369,7 +27360,7 @@ msgstr "Artikelname"
 msgid "Item operation"
 msgstr "Artikeloperation"
 
-#: erpnext/controllers/accounts_controller.py:3650
+#: erpnext/controllers/accounts_controller.py:3653
 msgid "Item qty can not be updated as raw materials are already processed."
 msgstr "Die Artikelmenge kann nicht aktualisiert werden, da das Rohmaterial bereits verarbeitet werden."
 
@@ -27395,7 +27386,7 @@ msgstr "Der Wertansatz wird unter Berücksichtigung des Einstandskostenbelegbetr
 msgid "Item valuation reposting in progress. Report might show incorrect item valuation."
 msgstr "Neubewertung der Artikel im Gange. Der Bericht könnte eine falsche Artikelbewertung anzeigen."
 
-#: erpnext/stock/doctype/item/item.py:952
+#: erpnext/stock/doctype/item/item.py:946
 msgid "Item variant {0} exists with same attributes"
 msgstr "Artikelvariante {0} mit denselben Attributen existiert"
 
@@ -27408,8 +27399,7 @@ msgid "Item {0} cannot be ordered more than {1} against Blanket Order {2}."
 msgstr "Artikel {0} kann nicht mehr als {1} im Rahmenauftrag {2} bestellt werden."
 
 #: erpnext/assets/doctype/asset/asset.py:277
-#: erpnext/stock/doctype/item/item.py:630
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:167
+#: erpnext/stock/doctype/item/item.py:636
 msgid "Item {0} does not exist"
 msgstr "Artikel {0} existiert nicht"
 
@@ -27421,7 +27411,7 @@ msgstr "Artikel {0} ist nicht im System vorhanden oder abgelaufen"
 msgid "Item {0} does not exist."
 msgstr "Artikel {0} existiert nicht."
 
-#: erpnext/controllers/selling_controller.py:752
+#: erpnext/controllers/selling_controller.py:760
 msgid "Item {0} entered multiple times."
 msgstr "Artikel {0} mehrfach eingegeben."
 
@@ -27437,7 +27427,7 @@ msgstr "Artikel {0} wurde deaktiviert"
 msgid "Item {0} has no Serial No. Only serialized items can have delivery based on Serial No"
 msgstr "Artikel {0} hat keine Seriennummer. Nur Artikel mit Seriennummer können basierend auf der Seriennummer geliefert werden"
 
-#: erpnext/stock/doctype/item/item.py:1126
+#: erpnext/stock/doctype/item/item.py:1120
 msgid "Item {0} has reached its end of life on {1}"
 msgstr "Artikel {0} hat das Ende seiner Lebensdauer erreicht zum Datum {1}"
 
@@ -27449,11 +27439,11 @@ msgstr "Artikel {0} ignoriert, da es sich nicht um einen Lagerartikel handelt"
 msgid "Item {0} is already reserved/delivered against Sales Order {1}."
 msgstr "Der Artikel {0} ist bereits für den Auftrag {1} reserviert/geliefert."
 
-#: erpnext/stock/doctype/item/item.py:1146
+#: erpnext/stock/doctype/item/item.py:1140
 msgid "Item {0} is cancelled"
 msgstr "Artikel {0} wird storniert"
 
-#: erpnext/stock/doctype/item/item.py:1130
+#: erpnext/stock/doctype/item/item.py:1124
 msgid "Item {0} is disabled"
 msgstr "Artikel {0} ist deaktiviert"
 
@@ -27461,7 +27451,7 @@ msgstr "Artikel {0} ist deaktiviert"
 msgid "Item {0} is not a serialized Item"
 msgstr "Artikel {0} ist kein Fortsetzungsartikel"
 
-#: erpnext/stock/doctype/item/item.py:1138
+#: erpnext/stock/doctype/item/item.py:1132
 msgid "Item {0} is not a stock Item"
 msgstr "Artikel {0} ist kein Lagerartikel"
 
@@ -27505,7 +27495,7 @@ msgstr "Artikel {0}: Bestellmenge {1} kann nicht weniger als Mindestbestellmenge
 msgid "Item {0}: {1} qty produced. "
 msgstr "Artikel {0}: {1} produzierte Menge."
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1429
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1423
 msgid "Item {} does not exist."
 msgstr "Artikel {0} existiert nicht."
 
@@ -27645,7 +27635,7 @@ msgstr "Anzufragende Artikel"
 msgid "Items and Pricing"
 msgstr "Artikel und Preise"
 
-#: erpnext/controllers/accounts_controller.py:3872
+#: erpnext/controllers/accounts_controller.py:3875
 msgid "Items cannot be updated as Subcontracting Order is created against the Purchase Order {0}."
 msgstr ""
 
@@ -28141,7 +28131,7 @@ msgstr "Einstandspreis Steuern und Gebühren"
 
 #. Name of a DocType
 #. Label of a Link in the Stock Workspace
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:674
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:676
 #: erpnext/stock/doctype/landed_cost_voucher/landed_cost_voucher.json
 #: erpnext/stock/doctype/purchase_receipt/purchase_receipt.js:104
 #: erpnext/stock/workspace/stock/stock.json
@@ -28757,7 +28747,7 @@ msgstr "Verknüpfte Rechnungen"
 msgid "Linked Location"
 msgstr "Verknüpfter Ort"
 
-#: erpnext/stock/doctype/item/item.py:999
+#: erpnext/stock/doctype/item/item.py:993
 msgid "Linked with submitted documents"
 msgstr "Verknüpft mit gebuchten Dokumenten"
 
@@ -29496,7 +29486,7 @@ msgstr "Geschäftsleitung"
 #: erpnext/manufacturing/doctype/bom/bom.py:261
 #: erpnext/manufacturing/doctype/bom_update_log/bom_update_log.py:71
 #: erpnext/public/js/controllers/accounts.js:249
-#: erpnext/public/js/controllers/transaction.js:2753
+#: erpnext/public/js/controllers/transaction.js:2779
 #: erpnext/public/js/utils/party.js:321
 #: erpnext/stock/doctype/delivery_note/delivery_note.js:164
 #: erpnext/stock/doctype/inventory_dimension/inventory_dimension.json
@@ -30352,7 +30342,7 @@ msgstr "Maximale Nutzung"
 msgid "Maximum Value"
 msgstr "Maximalwert"
 
-#: erpnext/controllers/selling_controller.py:212
+#: erpnext/controllers/selling_controller.py:220
 msgid "Maximum discount for Item {0} is {1}%"
 msgstr "Der maximale Rabatt für Artikel {0} beträgt {1}%"
 
@@ -30422,7 +30412,7 @@ msgstr "Megajoule"
 msgid "Megawatt"
 msgstr "Megawatt"
 
-#: erpnext/stock/stock_ledger.py:1878
+#: erpnext/stock/stock_ledger.py:1887
 msgid "Mention Valuation Rate in the Item master."
 msgstr "Erwähnen Sie die Bewertungsrate im Artikelstamm."
 
@@ -30817,11 +30807,11 @@ msgstr "Protokolle"
 msgid "Miscellaneous Expenses"
 msgstr "Sonstige Aufwendungen"
 
-#: erpnext/controllers/buying_controller.py:540
+#: erpnext/controllers/buying_controller.py:548
 msgid "Mismatch"
 msgstr "Keine Übereinstimmung"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1430
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1424
 msgid "Missing"
 msgstr "Fehlt"
 
@@ -31348,7 +31338,7 @@ msgstr "Mehrere Varianten"
 msgid "Multiple Warehouse Accounts"
 msgstr "Mehrere Lager-Konten"
 
-#: erpnext/controllers/accounts_controller.py:1129
+#: erpnext/controllers/accounts_controller.py:1132
 msgid "Multiple fiscal years exist for the date {0}. Please set company in Fiscal Year"
 msgstr "Mehrere Geschäftsjahre existieren für das Datum {0}. Bitte setzen Unternehmen im Geschäftsjahr"
 
@@ -31499,7 +31489,7 @@ msgstr "Präfix Nummernkreis"
 msgid "Naming Series and Price Defaults"
 msgstr "Nummernkreis und Preisvorgaben"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:90
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:91
 msgid "Naming Series is mandatory"
 msgstr "Nummernkreis ist obligatorisch"
 
@@ -31538,15 +31528,15 @@ msgstr "Erdgas"
 msgid "Needs Analysis"
 msgstr "Muss analysiert werden"
 
-#: erpnext/stock/serial_batch_bundle.py:1277
+#: erpnext/stock/serial_batch_bundle.py:1309
 msgid "Negative Batch Quantity"
 msgstr "Negative Chargenmenge"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:610
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:606
 msgid "Negative Quantity is not allowed"
 msgstr "Negative Menge ist nicht erlaubt"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:615
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:611
 msgid "Negative Valuation Rate is not allowed"
 msgstr "Negative Bewertung ist nicht erlaubt"
 
@@ -31828,7 +31818,7 @@ msgstr "Nettogewicht"
 msgid "Net Weight UOM"
 msgstr "Nettogewichtmaßeinheit"
 
-#: erpnext/controllers/accounts_controller.py:1483
+#: erpnext/controllers/accounts_controller.py:1486
 msgid "Net total calculation precision loss"
 msgstr "Präzisionsverlust bei Berechnung der Nettosumme"
 
@@ -32171,7 +32161,7 @@ msgstr "Kein POS-Profil gefunden. Bitte erstellen Sie zunächst ein neues POS-Pr
 #: erpnext/accounts/doctype/journal_entry/journal_entry.py:1539
 #: erpnext/accounts/doctype/journal_entry/journal_entry.py:1599
 #: erpnext/accounts/doctype/journal_entry/journal_entry.py:1613
-#: erpnext/stock/doctype/item/item.py:1371
+#: erpnext/stock/doctype/item/item.py:1365
 msgid "No Permission"
 msgstr "Keine Berechtigung"
 
@@ -32193,7 +32183,7 @@ msgstr "Keine Anmerkungen"
 msgid "No Selection"
 msgstr "Keine Auswahl"
 
-#: erpnext/controllers/sales_and_purchase_return.py:919
+#: erpnext/controllers/sales_and_purchase_return.py:824
 msgid "No Serial / Batches are available for return"
 msgstr "Es sind keine Serien / Chargen zur Rückgabe verfügbar"
 
@@ -32229,7 +32219,7 @@ msgstr "Für diese Partei wurden keine nicht abgestimmten Zahlungen gefunden"
 msgid "No Work Orders were created"
 msgstr "Es wurden keine Arbeitsaufträge erstellt"
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:785
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:794
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py:689
 msgid "No accounting entries for the following warehouses"
 msgstr "Keine Buchungen für die folgenden Lager"
@@ -32418,7 +32408,7 @@ msgstr "Keine Datensätze in der Zahlungstabelle gefunden"
 msgid "No reserved stock to unreserve."
 msgstr "Kein reservierter Bestand zum Aufheben der Reservierung."
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:773
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:769
 msgid "No stock ledger entries were created. Please set the quantity or valuation rate for the items properly and try again."
 msgstr ""
 
@@ -32502,7 +32492,7 @@ msgstr "Stk"
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:566
 #: erpnext/assets/doctype/asset/asset.js:612
 #: erpnext/assets/doctype/asset/asset.js:627
-#: erpnext/controllers/buying_controller.py:225
+#: erpnext/controllers/buying_controller.py:233
 #: erpnext/selling/doctype/product_bundle/product_bundle.py:72
 #: erpnext/setup/doctype/transaction_deletion_record/transaction_deletion_record.py:80
 msgid "Not Allowed"
@@ -32623,10 +32613,10 @@ msgstr "Nicht gestattet"
 #: erpnext/selling/doctype/customer/customer.py:129
 #: erpnext/selling/doctype/sales_order/sales_order.js:1168
 #: erpnext/stock/doctype/item/item.js:526
-#: erpnext/stock/doctype/item/item.py:567
+#: erpnext/stock/doctype/item/item.py:573
 #: erpnext/stock/doctype/item_price/item_price.json
 #: erpnext/stock/doctype/stock_entry/stock_entry.py:1374
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:972
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:968
 #: erpnext/templates/pages/timelog_info.html:43
 msgid "Note"
 msgstr "Anmerkung"
@@ -32635,7 +32625,7 @@ msgstr "Anmerkung"
 msgid "Note: Automatic log deletion only applies to logs of type <i>Update Cost</i>"
 msgstr "Hinweis: Die automatische Löschung von Protokollen gilt nur für Protokolle des Typs <i>Update Cost</i>"
 
-#: erpnext/accounts/party.py:690
+#: erpnext/accounts/party.py:696
 msgid "Note: Due Date exceeds allowed {0} credit days by {1} day(s)"
 msgstr ""
 
@@ -32661,7 +32651,7 @@ msgstr "Hinweis: Zahlungsbuchung wird nicht erstellt, da kein \"Kassen- oder Ban
 msgid "Note: This Cost Center is a Group. Cannot make accounting entries against groups."
 msgstr "Hinweis: Diese Kostenstelle ist eine Gruppe. Buchungen können nicht zu Gruppen erstellt werden."
 
-#: erpnext/stock/doctype/item/item.py:621
+#: erpnext/stock/doctype/item/item.py:627
 msgid "Note: To merge the items, create a separate Stock Reconciliation for the old item {0}"
 msgstr "Hinweis: Um die Artikel zusammenzuführen, erstellen Sie eine separate Bestandsabstimmung für den alten Artikel {0}"
 
@@ -33425,7 +33415,7 @@ msgstr "Eröffnungsrechnungen wurden erstellt."
 
 #. Label of the opening_stock (Float) field in DocType 'Item'
 #. Option for the 'Purpose' (Select) field in DocType 'Stock Reconciliation'
-#: erpnext/stock/doctype/item/item.json erpnext/stock/doctype/item/item.py:296
+#: erpnext/stock/doctype/item/item.json erpnext/stock/doctype/item/item.py:299
 #: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.json
 msgid "Opening Stock"
 msgstr "Anfangsbestand"
@@ -34145,7 +34135,7 @@ msgstr "Ausstehend (Unternehmenswährung)"
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:149
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1123
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1125
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:167
 #: erpnext/accounts/report/purchase_register/purchase_register.py:289
 #: erpnext/accounts/report/sales_register/sales_register.py:319
@@ -34184,7 +34174,7 @@ msgstr "Nach außen"
 msgid "Over Billing Allowance (%)"
 msgstr "Erlaubte Mehrabrechnung (%)"
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:1242
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:1251
 msgid "Over Billing Allowance exceeded for Purchase Receipt Item {0} ({1}) by {2}%"
 msgstr ""
 
@@ -34225,7 +34215,7 @@ msgstr ""
 msgid "Overbilling of {0} {1} ignored for item {2} because you have {3} role."
 msgstr "Überhöhte Abrechnung von Artikel {2} mit {0} {1} wurde ignoriert, weil Sie die Rolle {3} haben."
 
-#: erpnext/controllers/accounts_controller.py:2013
+#: erpnext/controllers/accounts_controller.py:2016
 msgid "Overbilling of {} ignored because you have {} role."
 msgstr ""
 
@@ -34732,7 +34722,7 @@ msgstr "Bezahlt"
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:146
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1117
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1119
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:165
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:172
 #: erpnext/accounts/report/pos_register/pos_register.py:209
@@ -34965,7 +34955,7 @@ msgstr "Übergeordnetes Verfahren"
 msgid "Parent Row No"
 msgstr "Übergeordnete Zeilennr"
 
-#: erpnext/manufacturing/doctype/bom_creator/bom_creator.py:495
+#: erpnext/manufacturing/doctype/bom_creator/bom_creator.py:496
 msgid "Parent Row No not found for {0}"
 msgstr "Übergeordnete Zeilennummer für {0} nicht gefunden"
 
@@ -35194,7 +35184,7 @@ msgstr "Teile pro Million"
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:142
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:159
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:57
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1054
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1056
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:67
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:147
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:228
@@ -35220,7 +35210,7 @@ msgstr "Partei"
 
 #. Name of a DocType
 #: erpnext/accounts/doctype/party_account/party_account.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1065
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1067
 msgid "Party Account"
 msgstr "Konto der Partei"
 
@@ -35247,7 +35237,7 @@ msgstr "Währung des Kontos der Partei"
 msgid "Party Account No. (Bank Statement)"
 msgstr "Konto-Nr. der Partei (Kontoauszug)"
 
-#: erpnext/controllers/accounts_controller.py:2278
+#: erpnext/controllers/accounts_controller.py:2281
 msgid "Party Account {0} currency ({1}) and document currency ({2}) should be same"
 msgstr "Die Währung des Kontos {0} ({1}) und die des Dokuments ({2}) müssen identisch sein"
 
@@ -35264,6 +35254,11 @@ msgstr "Bankkonto der Partei"
 #: erpnext/accounts/doctype/payment_request/payment_request.json
 msgid "Party Details"
 msgstr "Details der Partei"
+
+#. Label of the party_full_name (Data) field in DocType 'Contract'
+#: erpnext/crm/doctype/contract/contract.json
+msgid "Party Full Name"
+msgstr ""
 
 #. Label of the bank_party_iban (Data) field in DocType 'Bank Transaction'
 #: erpnext/accounts/doctype/bank_transaction/bank_transaction.json
@@ -35348,7 +35343,7 @@ msgstr "Parteispezifischer Artikel"
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:84
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:54
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:44
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1048
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1050
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:54
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:141
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:219
@@ -35370,7 +35365,7 @@ msgstr "Parteispezifischer Artikel"
 msgid "Party Type"
 msgstr "Partei-Typ"
 
-#: erpnext/accounts/party.py:819
+#: erpnext/accounts/party.py:825
 msgid "Party Type and Party can only be set for Receivable / Payable account<br><br>{0}"
 msgstr "Parteityp und Partei können nur für das Debitoren-/Kreditorenkonto {0} festgelegt werden."
 
@@ -35492,7 +35487,7 @@ msgid "Payable"
 msgstr "Zahlbar"
 
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:42
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1063
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1065
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:211
 #: erpnext/accounts/report/purchase_register/purchase_register.py:194
 #: erpnext/accounts/report/purchase_register/purchase_register.py:235
@@ -35658,7 +35653,7 @@ msgstr "Zahlungsbuchung wurde geändert, nachdem sie abgerufen wurde. Bitte erne
 msgid "Payment Entry is already created"
 msgstr "Payment Eintrag bereits erstellt"
 
-#: erpnext/controllers/accounts_controller.py:1434
+#: erpnext/controllers/accounts_controller.py:1437
 msgid "Payment Entry {0} is linked against Order {1}, check if it should be pulled as advance in this invoice."
 msgstr "Zahlungseintrag {0} ist mit Bestellung {1} verknüpft. Prüfen Sie, ob er in dieser Rechnung als Vorauszahlung ausgewiesen werden soll."
 
@@ -35940,7 +35935,7 @@ msgstr "Zahlungsstatus"
 #: erpnext/accounts/doctype/payment_schedule/payment_schedule.json
 #: erpnext/accounts/doctype/payment_term/payment_term.json
 #: erpnext/accounts/doctype/payment_terms_template_detail/payment_terms_template_detail.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1113
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1115
 #: erpnext/accounts/report/gross_profit/gross_profit.py:412
 #: erpnext/accounts/workspace/accounting/accounting.json
 #: erpnext/selling/report/payment_terms_status_for_sales_order/payment_terms_status_for_sales_order.py:30
@@ -37004,7 +36999,7 @@ msgstr ""
 msgid "Please create a new Accounting Dimension if required."
 msgstr "Bitte erstellen Sie bei Bedarf eine neue Buchhaltungsdimension."
 
-#: erpnext/controllers/accounts_controller.py:729
+#: erpnext/controllers/accounts_controller.py:732
 msgid "Please create purchase from internal sale or delivery document itself"
 msgstr "Bitte erstellen Sie den Kauf aus dem internen Verkaufs- oder Lieferbeleg selbst"
 
@@ -37012,7 +37007,7 @@ msgstr "Bitte erstellen Sie den Kauf aus dem internen Verkaufs- oder Lieferbeleg
 msgid "Please create purchase receipt or purchase invoice for the item {0}"
 msgstr "Bitte erstellen Sie eine Kaufquittung oder eine Eingangsrechnungen für den Artikel {0}"
 
-#: erpnext/stock/doctype/item/item.py:649
+#: erpnext/stock/doctype/item/item.py:655
 msgid "Please delete Product Bundle {0}, before merging {1} into {2}"
 msgstr "Bitte löschen Sie das Produktbündel {0}, bevor Sie {1} mit {2} zusammenführen"
 
@@ -37054,7 +37049,7 @@ msgstr "Bitte Pop-ups aktivieren"
 msgid "Please enable {0} in the {1}."
 msgstr "Bitte aktivieren Sie {0} in {1}."
 
-#: erpnext/controllers/selling_controller.py:754
+#: erpnext/controllers/selling_controller.py:762
 msgid "Please enable {} in {} to allow same item in multiple rows"
 msgstr "Bitte aktivieren Sie {} in {}, um denselben Artikel in mehreren Zeilen zuzulassen"
 
@@ -37087,7 +37082,7 @@ msgstr "Bitte geben Sie Konto für Änderungsbetrag"
 msgid "Please enter Approving Role or Approving User"
 msgstr "Bitte genehmigende Rolle oder genehmigenden Nutzer eingeben"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:939
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:935
 msgid "Please enter Cost Center"
 msgstr "Bitte die Kostenstelle eingeben"
 
@@ -37099,7 +37094,7 @@ msgstr "Bitte geben Sie das Lieferdatum ein"
 msgid "Please enter Employee Id of this sales person"
 msgstr "Bitte die Mitarbeiter-ID dieses Vertriebsmitarbeiters angeben"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:948
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:944
 msgid "Please enter Expense Account"
 msgstr "Bitte das Aufwandskonto angeben"
 
@@ -37108,7 +37103,7 @@ msgstr "Bitte das Aufwandskonto angeben"
 msgid "Please enter Item Code to get Batch Number"
 msgstr "Bitte geben Sie Item Code zu Chargennummer erhalten"
 
-#: erpnext/public/js/controllers/transaction.js:2503
+#: erpnext/public/js/controllers/transaction.js:2529
 msgid "Please enter Item Code to get batch no"
 msgstr "Bitte die Artikelnummer eingeben um die Chargennummer zu erhalten"
 
@@ -37173,7 +37168,7 @@ msgstr "Bitte zuerst Unternehmen angeben"
 msgid "Please enter company name first"
 msgstr "Bitte zuerst Firma angeben"
 
-#: erpnext/controllers/accounts_controller.py:2764
+#: erpnext/controllers/accounts_controller.py:2767
 msgid "Please enter default currency in Company Master"
 msgstr "Bitte die Standardwährung in die Stammdaten des Unternehmens eingeben"
 
@@ -37209,7 +37204,7 @@ msgstr "Bitte geben Sie den Firmennamen zur Bestätigung ein"
 msgid "Please enter the phone number first"
 msgstr "Bitte geben Sie zuerst die Telefonnummer ein"
 
-#: erpnext/controllers/buying_controller.py:1007
+#: erpnext/controllers/buying_controller.py:1015
 msgid "Please enter the {schedule_date}."
 msgstr "Bitte geben Sie das {schedule_date} ein."
 
@@ -37311,7 +37306,7 @@ msgstr "Bitte speichern Sie zuerst"
 msgid "Please select <b>Template Type</b> to download template"
 msgstr "Bitte wählen Sie <b>Vorlagentyp</b> , um die Vorlage herunterzuladen"
 
-#: erpnext/controllers/taxes_and_totals.py:721
+#: erpnext/controllers/taxes_and_totals.py:731
 #: erpnext/public/js/controllers/taxes_and_totals.js:721
 msgid "Please select Apply Discount On"
 msgstr "Bitte \"Rabatt anwenden auf\" auswählen"
@@ -37324,7 +37319,7 @@ msgstr "Bitte eine Stückliste für Artikel {0} auswählen"
 msgid "Please select BOM for Item in Row {0}"
 msgstr "Bitte eine Stückliste für den Artikel in Zeile {0} auswählen"
 
-#: erpnext/controllers/buying_controller.py:467
+#: erpnext/controllers/buying_controller.py:475
 msgid "Please select BOM in BOM field for Item {item_code}."
 msgstr "Bitte im Stücklistenfeld eine Stückliste für Artikel {item_code} auswählen."
 
@@ -37406,7 +37401,7 @@ msgstr "Bitte eine Preisliste auswählen"
 msgid "Please select Qty against item {0}"
 msgstr "Bitte wählen Sie Menge für Artikel {0}"
 
-#: erpnext/stock/doctype/item/item.py:320
+#: erpnext/stock/doctype/item/item.py:323
 msgid "Please select Sample Retention Warehouse in Stock Settings first"
 msgstr "Bitte wählen Sie in den Lagereinstellungen zuerst das Muster-Aufbewahrungslager aus"
 
@@ -37422,7 +37417,7 @@ msgstr "Bitte Start -und Enddatum für den Artikel {0} auswählen"
 msgid "Please select Subcontracting Order instead of Purchase Order {0}"
 msgstr "Bitte wählen Sie \"Unterauftrag\" anstatt \"Bestellung\" {0}"
 
-#: erpnext/controllers/accounts_controller.py:2613
+#: erpnext/controllers/accounts_controller.py:2616
 msgid "Please select Unrealized Profit / Loss account or add default Unrealized Profit / Loss account account for company {0}"
 msgstr ""
 
@@ -37438,7 +37433,7 @@ msgstr "Bitte ein Unternehmen auswählen"
 #: erpnext/manufacturing/doctype/bom/bom.js:603
 #: erpnext/manufacturing/doctype/bom/bom.py:261
 #: erpnext/public/js/controllers/accounts.js:249
-#: erpnext/public/js/controllers/transaction.js:2753
+#: erpnext/public/js/controllers/transaction.js:2779
 msgid "Please select a Company first."
 msgstr "Bitte wählen Sie zuerst eine Firma aus."
 
@@ -37596,7 +37591,7 @@ msgstr "Bitte {0} auswählen"
 msgid "Please select {0} first"
 msgstr "Bitte zuerst {0} auswählen"
 
-#: erpnext/public/js/controllers/transaction.js:77
+#: erpnext/public/js/controllers/transaction.js:100
 msgid "Please set 'Apply Additional Discount On'"
 msgstr "Bitte \"Zusätzlichen Rabatt anwenden auf\" aktivieren"
 
@@ -37781,7 +37776,7 @@ msgstr "Bitte setzen Sie Filter basierend auf Artikel oder Lager"
 msgid "Please set filters"
 msgstr "Bitte Filter einstellen"
 
-#: erpnext/controllers/accounts_controller.py:2194
+#: erpnext/controllers/accounts_controller.py:2197
 msgid "Please set one of the following:"
 msgstr "Bitte stellen Sie eine der folgenden Optionen ein:"
 
@@ -37789,7 +37784,7 @@ msgstr "Bitte stellen Sie eine der folgenden Optionen ein:"
 msgid "Please set opening number of booked depreciations"
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2205
+#: erpnext/public/js/controllers/transaction.js:2231
 msgid "Please set recurring after saving"
 msgstr "Bitte setzen Sie wiederkehrende nach dem Speichern"
 
@@ -37860,7 +37855,7 @@ msgstr "Bitte richten Sie ein Gruppenkonto mit dem Kontotyp - {0} für die Firma
 msgid "Please share this email with your support team so that they can find and fix the issue."
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2073
+#: erpnext/public/js/controllers/transaction.js:2099
 msgid "Please specify"
 msgstr "Bitte angeben"
 
@@ -37875,7 +37870,7 @@ msgid "Please specify Company to proceed"
 msgstr "Bitte Unternehmen angeben um fortzufahren"
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1472
-#: erpnext/controllers/accounts_controller.py:2957
+#: erpnext/controllers/accounts_controller.py:2960
 #: erpnext/public/js/controllers/accounts.js:97
 msgid "Please specify a valid Row ID for row {0} in table {1}"
 msgstr "Bitte eine gültige Zeilen-ID für die Zeile {0} in Tabelle {1} angeben"
@@ -37888,7 +37883,7 @@ msgstr "Bitte geben Sie zuerst {0} ein."
 msgid "Please specify at least one attribute in the Attributes table"
 msgstr "Bitte geben Sie mindestens ein Attribut in der Attributtabelle ein"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:605
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:601
 msgid "Please specify either Quantity or Valuation Rate or both"
 msgstr "Bitte entweder die Menge oder den Wertansatz oder beides eingeben"
 
@@ -38069,7 +38064,7 @@ msgstr "Portoaufwendungen"
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:16
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:15
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:18
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1046
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1048
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:15
 #: erpnext/accounts/report/bank_clearance_summary/bank_clearance_summary.py:35
 #: erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.html:7
@@ -40250,7 +40245,7 @@ msgstr "Einkaufsstammdaten-Manager"
 #: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.js:48
 #: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:203
 #: erpnext/buying/workspace/buying/buying.json
-#: erpnext/controllers/buying_controller.py:739
+#: erpnext/controllers/buying_controller.py:747
 #: erpnext/crm/doctype/contract/contract.json
 #: erpnext/manufacturing/doctype/blanket_order/blanket_order.js:54
 #: erpnext/manufacturing/doctype/production_plan_sub_assembly_item/production_plan_sub_assembly_item.json
@@ -40389,7 +40384,7 @@ msgstr "Bestellungen an Rechnung"
 msgid "Purchase Orders to Receive"
 msgstr "Anzuliefernde Bestellungen"
 
-#: erpnext/controllers/accounts_controller.py:1833
+#: erpnext/controllers/accounts_controller.py:1836
 msgid "Purchase Orders {0} are un-linked"
 msgstr ""
 
@@ -40413,8 +40408,8 @@ msgstr "Einkaufspreisliste"
 #. Label of a Link in the Stock Workspace
 #. Label of a shortcut in the Stock Workspace
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:171
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:650
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:660
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:652
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:662
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice_list.js:49
 #: erpnext/accounts/doctype/purchase_invoice_item/purchase_invoice_item.json
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:246
@@ -41149,7 +41144,7 @@ msgstr "Qualitätsinspektionsvorlage"
 msgid "Quality Inspection Template Name"
 msgstr "Name der Qualitätsinspektionsvorlage"
 
-#: erpnext/public/js/controllers/transaction.js:334
+#: erpnext/public/js/controllers/transaction.js:360
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:165
 msgid "Quality Inspection(s)"
 msgstr "Qualitätsprüfung(en)"
@@ -42333,7 +42328,7 @@ msgid "Receivable / Payable Account"
 msgstr "Forderungen-/Verbindlichkeiten-Konto"
 
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:71
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1061
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1063
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py:243
 #: erpnext/accounts/report/sales_register/sales_register.py:217
 #: erpnext/accounts/report/sales_register/sales_register.py:271
@@ -42815,7 +42810,7 @@ msgstr "Referenz #{0} vom {1}"
 msgid "Reference Date"
 msgstr "Referenzdatum"
 
-#: erpnext/public/js/controllers/transaction.js:2311
+#: erpnext/public/js/controllers/transaction.js:2337
 msgid "Reference Date for Early Payment Discount"
 msgstr "Stichtag für Skonto"
 
@@ -43139,7 +43134,7 @@ msgstr "Regulär"
 msgid "Rejected"
 msgstr "Abgelehnt"
 
-#: erpnext/stock/doctype/inventory_dimension/inventory_dimension.py:202
+#: erpnext/stock/doctype/inventory_dimension/inventory_dimension.py:203
 msgid "Rejected "
 msgstr "Abgelehnt "
 
@@ -43243,7 +43238,7 @@ msgstr ""
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:187
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:156
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1135
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1137
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:178
 msgid "Remaining Balance"
 msgstr "Verbleibendes Saldo"
@@ -43296,7 +43291,7 @@ msgstr "Bemerkung"
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:159
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:198
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:269
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1167
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1169
 #: erpnext/accounts/report/general_ledger/general_ledger.html:84
 #: erpnext/accounts/report/general_ledger/general_ledger.html:110
 #: erpnext/accounts/report/general_ledger/general_ledger.py:742
@@ -44046,7 +44041,7 @@ msgstr "Reservierte Menge"
 msgid "Reserved Quantity for Production"
 msgstr "Reservierte Menge für die Produktion"
 
-#: erpnext/stock/stock_ledger.py:2147
+#: erpnext/stock/stock_ledger.py:2155
 msgid "Reserved Serial No."
 msgstr "Reservierte Seriennr."
 
@@ -44062,11 +44057,11 @@ msgstr "Reservierte Seriennr."
 #: erpnext/stock/doctype/pick_list/pick_list.js:153
 #: erpnext/stock/report/reserved_stock/reserved_stock.json
 #: erpnext/stock/report/stock_balance/stock_balance.py:499
-#: erpnext/stock/stock_ledger.py:2131
+#: erpnext/stock/stock_ledger.py:2139
 msgid "Reserved Stock"
 msgstr "Reservierter Bestand"
 
-#: erpnext/stock/stock_ledger.py:2177
+#: erpnext/stock/stock_ledger.py:2185
 msgid "Reserved Stock for Batch"
 msgstr "Reservierter Bestand für Charge"
 
@@ -44078,7 +44073,7 @@ msgstr ""
 msgid "Reserved Stock for Sub-assembly"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:476
+#: erpnext/controllers/buying_controller.py:484
 msgid "Reserved Warehouse is mandatory for the Item {item_code} in Raw Materials supplied."
 msgstr ""
 
@@ -44892,7 +44887,7 @@ msgstr "Ablaufplanung"
 msgid "Routing Name"
 msgstr "Routing-Name"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:667
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:663
 msgid "Row #"
 msgstr "Zeile #"
 
@@ -44930,7 +44925,7 @@ msgstr "Zeile {0} (Zahlungstabelle): Betrag muss negativ sein"
 msgid "Row #{0} (Payment Table): Amount must be positive"
 msgstr "Zeile {0} (Zahlungstabelle): Betrag muss positiv sein"
 
-#: erpnext/stock/doctype/item/item.py:495
+#: erpnext/stock/doctype/item/item.py:498
 msgid "Row #{0}: A reorder entry already exists for warehouse {1} with reorder type {2}."
 msgstr "Zeile #{0}: Für das Lager {1} mit dem Nachbestellungstyp {2} ist bereits ein Nachbestellungseintrag vorhanden."
 
@@ -44951,7 +44946,7 @@ msgstr "Zeile #{0}: Annahme- und Ablehnungslager dürfen nicht identisch sein"
 msgid "Row #{0}: Accepted Warehouse is mandatory for the accepted Item {1}"
 msgstr "Zeile #{0}: Annahmelager ist obligatorisch für den angenommenen Artikel {1}"
 
-#: erpnext/controllers/accounts_controller.py:1117
+#: erpnext/controllers/accounts_controller.py:1120
 msgid "Row #{0}: Account {1} does not belong to company {2}"
 msgstr "Zeile {0}: Konto {1} gehört nicht zur Unternehmen {2}"
 
@@ -44992,27 +44987,27 @@ msgstr "Zeile #{0}: Die Chargennummer {1} ist bereits ausgewählt."
 msgid "Row #{0}: Cannot allocate more than {1} against payment term {2}"
 msgstr "Zeile {0}: Es kann nicht mehr als {1} zu Zahlungsbedingung {2} zugeordnet werden"
 
-#: erpnext/controllers/accounts_controller.py:3524
+#: erpnext/controllers/accounts_controller.py:3527
 msgid "Row #{0}: Cannot delete item {1} which has already been billed."
 msgstr "Zeile {0}: Der bereits abgerechnete Artikel {1} kann nicht gelöscht werden."
 
-#: erpnext/controllers/accounts_controller.py:3498
+#: erpnext/controllers/accounts_controller.py:3501
 msgid "Row #{0}: Cannot delete item {1} which has already been delivered"
 msgstr "Zeile {0}: Element {1}, das bereits geliefert wurde, kann nicht gelöscht werden"
 
-#: erpnext/controllers/accounts_controller.py:3517
+#: erpnext/controllers/accounts_controller.py:3520
 msgid "Row #{0}: Cannot delete item {1} which has already been received"
 msgstr "Zeile {0}: Element {1}, das bereits empfangen wurde, kann nicht gelöscht werden"
 
-#: erpnext/controllers/accounts_controller.py:3504
+#: erpnext/controllers/accounts_controller.py:3507
 msgid "Row #{0}: Cannot delete item {1} which has work order assigned to it."
 msgstr "Zeile {0}: Element {1}, dem ein Arbeitsauftrag zugewiesen wurde, kann nicht gelöscht werden."
 
-#: erpnext/controllers/accounts_controller.py:3510
+#: erpnext/controllers/accounts_controller.py:3513
 msgid "Row #{0}: Cannot delete item {1} which is assigned to customer's purchase order."
 msgstr "Zeile {0}: Artikel {1}, der der Bestellung des Kunden zugeordnet ist, kann nicht gelöscht werden."
 
-#: erpnext/controllers/accounts_controller.py:3765
+#: erpnext/controllers/accounts_controller.py:3768
 msgid "Row #{0}: Cannot set Rate if the billed amount is greater than the amount for Item {1}."
 msgstr ""
 
@@ -45132,7 +45127,7 @@ msgstr "Zeile #{0}: Artikel {1} existiert nicht"
 msgid "Row #{0}: Item {1} has been picked, please reserve stock from the Pick List."
 msgstr "Zeile #{0}: Artikel {1} wurde kommissioniert, bitte reservieren Sie den Bestand aus der Pickliste."
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:729
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:725
 msgid "Row #{0}: Item {1} is not a Serialized/Batched Item. It cannot have a Serial No/Batch No against it."
 msgstr "Zeile {0}: Element {1} ist kein serialisiertes / gestapeltes Element. Es kann keine Seriennummer / Chargennummer dagegen haben."
 
@@ -45188,7 +45183,7 @@ msgstr "Zeile #{0}: Bitte wählen Sie die Stücklisten-Nr. in den Montageartikel
 msgid "Row #{0}: Please select the Sub Assembly Warehouse"
 msgstr "Zeile #{0}: Bitte wählen Sie das Lager für Unterbaugruppen"
 
-#: erpnext/stock/doctype/item/item.py:502
+#: erpnext/stock/doctype/item/item.py:505
 msgid "Row #{0}: Please set reorder quantity"
 msgstr "Zeile {0}: Bitte Nachbestellmenge angeben"
 
@@ -45221,8 +45216,8 @@ msgstr "Zeile {0}: Qualitätsprüfung {1} wurde für den Artikel {2} nicht gebuc
 msgid "Row #{0}: Quality Inspection {1} was rejected for item {2}"
 msgstr "Zeile {0}: Qualitätsprüfung {1} wurde für Artikel {2} abgelehnt"
 
-#: erpnext/controllers/accounts_controller.py:1274
-#: erpnext/controllers/accounts_controller.py:3624
+#: erpnext/controllers/accounts_controller.py:1277
+#: erpnext/controllers/accounts_controller.py:3627
 msgid "Row #{0}: Quantity for Item {1} cannot be zero."
 msgstr "Zeile {0}: Artikelmenge {1} kann nicht Null sein."
 
@@ -45259,7 +45254,7 @@ msgstr ""
 msgid "Row #{0}: Scrap Item Qty cannot be zero"
 msgstr "Zeile #{0}: Die Menge des Ausschussartikels darf nicht Null sein"
 
-#: erpnext/controllers/selling_controller.py:230
+#: erpnext/controllers/selling_controller.py:238
 msgid "Row #{0}: Selling rate for item {1} is lower than its {2}.\n"
 "\t\t\t\t\tSelling {3} should be atleast {4}.<br><br>Alternatively,\n"
 "\t\t\t\t\tyou can disable selling price validation in {5} to bypass\n"
@@ -45343,7 +45338,7 @@ msgstr "Zeile #{0}: Kein Bestand für den Artikel {1} im Lager {2} verfügbar."
 msgid "Row #{0}: The batch {1} has already expired."
 msgstr "Zeile {0}: Der Stapel {1} ist bereits abgelaufen."
 
-#: erpnext/stock/doctype/item/item.py:511
+#: erpnext/stock/doctype/item/item.py:514
 msgid "Row #{0}: The warehouse {1} is not a child warehouse of a group warehouse {2}"
 msgstr "Zeile #{0}: Das Lager {1} ist kein untergeordnetes Lager eines Gruppenlagers {2}"
 
@@ -45383,39 +45378,39 @@ msgstr "Zeile #{0}: {1} von {2} sollte {3} sein. Bitte aktualisieren Sie die {1}
 msgid "Row #{1}: Warehouse is mandatory for stock Item {0}"
 msgstr "Zeile #{1}: Lager ist obligatorisch für Artikel {0}"
 
-#: erpnext/controllers/buying_controller.py:259
+#: erpnext/controllers/buying_controller.py:267
 msgid "Row #{idx}: Cannot select Supplier Warehouse while suppling raw materials to subcontractor."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:406
+#: erpnext/controllers/buying_controller.py:414
 msgid "Row #{idx}: Item rate has been updated as per valuation rate since its an internal stock transfer."
 msgstr "Zeile #{idx}: Der Einzelpreis wurde gemäß dem Bewertungskurs aktualisiert, da es sich um eine interne Umlagerung handelt."
 
-#: erpnext/controllers/buying_controller.py:881
+#: erpnext/controllers/buying_controller.py:889
 msgid "Row #{idx}: Please enter a location for the asset item {item_code}."
 msgstr "Zeile {idx}: Bitte geben Sie einen Standort für den Vermögensgegenstand {item_code} ein."
 
-#: erpnext/controllers/buying_controller.py:537
+#: erpnext/controllers/buying_controller.py:545
 msgid "Row #{idx}: Received Qty must be equal to Accepted + Rejected Qty for Item {item_code}."
 msgstr "Zeile #{idx}: Die erhaltene Menge muss gleich der angenommenen + abgelehnten Menge für Artikel {item_code} sein."
 
-#: erpnext/controllers/buying_controller.py:550
+#: erpnext/controllers/buying_controller.py:558
 msgid "Row #{idx}: {field_label} can not be negative for item {item_code}."
 msgstr "Zeile {idx}: {field_label} kann für Artikel {item_code} nicht negativ sein."
 
-#: erpnext/controllers/buying_controller.py:496
+#: erpnext/controllers/buying_controller.py:504
 msgid "Row #{idx}: {field_label} is mandatory."
 msgstr "Zeile {idx}: {field_label} ist obligatorisch."
 
-#: erpnext/controllers/buying_controller.py:518
+#: erpnext/controllers/buying_controller.py:526
 msgid "Row #{idx}: {field_label} is not allowed in Purchase Return."
 msgstr "Zeile #{idx}: {field_label} ist in der Kaufrückgabe nicht erlaubt."
 
-#: erpnext/controllers/buying_controller.py:250
+#: erpnext/controllers/buying_controller.py:258
 msgid "Row #{idx}: {from_warehouse_field} and {to_warehouse_field} cannot be same."
 msgstr "Zeile {idx}: {from_warehouse_field} und {to_warehouse_field} dürfen nicht identisch sein."
 
-#: erpnext/controllers/buying_controller.py:999
+#: erpnext/controllers/buying_controller.py:1007
 msgid "Row #{idx}: {schedule_date} cannot be before {transaction_date}."
 msgstr "Zeile {idx}: {schedule_date} darf nicht vor {transaction_date} liegen."
 
@@ -45480,7 +45475,7 @@ msgstr "Reihe #{}: {}"
 msgid "Row #{}: {} {} does not exist."
 msgstr "Zeile # {}: {} {} existiert nicht."
 
-#: erpnext/stock/doctype/item/item.py:1403
+#: erpnext/stock/doctype/item/item.py:1397
 msgid "Row #{}: {} {} doesn't belong to Company {}. Please select valid {}."
 msgstr "Zeile #{}: {} {} gehört nicht zur Firma {}. Bitte wählen Sie eine gültige {} aus."
 
@@ -45552,11 +45547,11 @@ msgstr "Zeile {0}: Bill of Materials nicht für den Artikel gefunden {1}"
 msgid "Row {0}: Both Debit and Credit values cannot be zero"
 msgstr "Zeile {0}: Sowohl Soll als auch Haben können nicht gleich Null sein"
 
-#: erpnext/controllers/selling_controller.py:222
+#: erpnext/controllers/selling_controller.py:230
 msgid "Row {0}: Conversion Factor is mandatory"
 msgstr "Zeile {0}: Umrechnungsfaktor ist zwingend erfoderlich"
 
-#: erpnext/controllers/accounts_controller.py:2995
+#: erpnext/controllers/accounts_controller.py:2998
 msgid "Row {0}: Cost Center {1} does not belong to Company {2}"
 msgstr "Zeile {0}: Die Kostenstelle {1} gehört nicht zum Unternehmen {2}"
 
@@ -45576,11 +45571,11 @@ msgstr "Zeile {0}: Währung der Stückliste # {1} sollte der gewählten Währung
 msgid "Row {0}: Debit entry can not be linked with a {1}"
 msgstr "Zeile {0}: Sollbuchung kann nicht mit ein(em) {1} verknüpft werden"
 
-#: erpnext/controllers/selling_controller.py:776
+#: erpnext/controllers/selling_controller.py:784
 msgid "Row {0}: Delivery Warehouse ({1}) and Customer Warehouse ({2}) can not be same"
 msgstr "Zeile {0}: Lieferlager ({1}) und Kundenlager ({2}) können nicht identisch sein"
 
-#: erpnext/controllers/accounts_controller.py:2529
+#: erpnext/controllers/accounts_controller.py:2532
 msgid "Row {0}: Due Date in the Payment Terms table cannot be before Posting Date"
 msgstr "Zeile {0}: Fälligkeitsdatum in der Tabelle &quot;Zahlungsbedingungen&quot; darf nicht vor dem Buchungsdatum liegen"
 
@@ -45589,7 +45584,7 @@ msgid "Row {0}: Either Delivery Note Item or Packed Item reference is mandatory.
 msgstr "Zeile {0}: Entweder die Referenz zu einem \"Lieferschein-Artikel\" oder \"Verpackter Artikel\" ist obligatorisch."
 
 #: erpnext/accounts/doctype/journal_entry/journal_entry.py:1010
-#: erpnext/controllers/taxes_and_totals.py:1205
+#: erpnext/controllers/taxes_and_totals.py:1215
 msgid "Row {0}: Exchange Rate is mandatory"
 msgstr "Zeile {0}: Wechselkurs ist erforderlich"
 
@@ -45638,11 +45633,11 @@ msgstr "Zeile {0}: Stunden-Wert muss größer als Null sein."
 msgid "Row {0}: Invalid reference {1}"
 msgstr "Zeile {0}: Ungültige Referenz {1}"
 
-#: erpnext/controllers/taxes_and_totals.py:142
+#: erpnext/controllers/taxes_and_totals.py:143
 msgid "Row {0}: Item Tax template updated as per validity and rate applied"
 msgstr "Zeile {0}: Artikelsteuervorlage aktualisiert gemäß Gültigkeit und angewendetem Satz"
 
-#: erpnext/controllers/selling_controller.py:541
+#: erpnext/controllers/selling_controller.py:549
 msgid "Row {0}: Item rate has been updated as per valuation rate since its an internal stock transfer"
 msgstr "Zeile {0}: Der Einzelpreis wurde gemäß dem Bewertungskurs aktualisiert, da es sich um eine interne Umlagerung handelt"
 
@@ -45762,7 +45757,7 @@ msgstr "Zeile {0}: Aufgabe {1} gehört nicht zum Projekt {2}"
 msgid "Row {0}: The item {1}, quantity must be positive number"
 msgstr "Zeile {0}: Die Menge des Artikels {1} muss eine positive Zahl sein"
 
-#: erpnext/controllers/accounts_controller.py:2972
+#: erpnext/controllers/accounts_controller.py:2975
 msgid "Row {0}: The {3} Account {1} does not belong to the company {2}"
 msgstr "Zeile {0}: Das {3}-Konto {1} gehört nicht zum Unternehmen {2}"
 
@@ -45779,7 +45774,7 @@ msgstr "Zeile {0}: Umrechnungsfaktor für Maßeinheit ist zwingend erforderlich"
 msgid "Row {0}: Workstation or Workstation Type is mandatory for an operation {1}"
 msgstr "Zeile {0}: Arbeitsplatz oder Arbeitsplatztyp ist obligatorisch für einen Vorgang {1}"
 
-#: erpnext/controllers/accounts_controller.py:1011
+#: erpnext/controllers/accounts_controller.py:1014
 msgid "Row {0}: user has not applied the rule {1} on the item {2}"
 msgstr "Zeile {0}: Der Nutzer hat die Regel {1} nicht auf das Element {2} angewendet."
 
@@ -45791,7 +45786,7 @@ msgstr "Zeile {0}: Konto {1} wird bereits für die Buchhaltungsdimension {2} ver
 msgid "Row {0}: {1} must be greater than 0"
 msgstr "Zeile {0}: {1} muss größer als 0 sein"
 
-#: erpnext/controllers/accounts_controller.py:706
+#: erpnext/controllers/accounts_controller.py:709
 msgid "Row {0}: {1} {2} cannot be same as {3} (Party Account) {4}"
 msgstr ""
 
@@ -45807,7 +45802,7 @@ msgstr "Zeile {0}: {2} Artikel {1} existiert nicht in {2} {3}"
 msgid "Row {1}: Quantity ({0}) cannot be a fraction. To allow this, disable '{2}' in UOM {3}."
 msgstr "Zeile {1}: Menge ({0}) darf kein Bruch sein. Deaktivieren Sie dazu &#39;{2}&#39; in UOM {3}."
 
-#: erpnext/controllers/buying_controller.py:863
+#: erpnext/controllers/buying_controller.py:871
 msgid "Row {idx}: Asset Naming Series is mandatory for the auto creation of assets for item {item_code}."
 msgstr "Zeile {idx}: Der Nummernkreis des Vermögensgegenstandes ist obligatorisch für die automatische Erstellung von Vermögenswerten für den Artikel {item_code}."
 
@@ -45833,7 +45828,7 @@ msgstr "Zeilen in {0} entfernt"
 msgid "Rows with Same Account heads will be merged on Ledger"
 msgstr "Zeilen mit denselben Konten werden im Hauptbuch zusammengefasst"
 
-#: erpnext/controllers/accounts_controller.py:2539
+#: erpnext/controllers/accounts_controller.py:2542
 msgid "Rows with duplicate due dates in other rows were found: {0}"
 msgstr "Zeilen mit doppelten Fälligkeitsdaten in anderen Zeilen wurden gefunden: {0}"
 
@@ -45903,7 +45898,7 @@ msgstr "SLA erfüllt am Status"
 msgid "SLA Paused On"
 msgstr "SLA pausiert am"
 
-#: erpnext/public/js/utils.js:1167
+#: erpnext/public/js/utils.js:1163
 msgid "SLA is on hold since {0}"
 msgstr "SLA ist seit {0} auf Eis gelegt"
 
@@ -46304,7 +46299,7 @@ msgstr "Verkaufschancen nach Quelle"
 #: erpnext/accounts/report/sales_register/sales_register.py:238
 #: erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
 #: erpnext/buying/doctype/supplier_quotation_item/supplier_quotation_item.json
-#: erpnext/controllers/selling_controller.py:462
+#: erpnext/controllers/selling_controller.py:470
 #: erpnext/crm/doctype/contract/contract.json
 #: erpnext/maintenance/doctype/maintenance_schedule/maintenance_schedule.js:65
 #: erpnext/maintenance/doctype/maintenance_schedule_item/maintenance_schedule_item.json
@@ -46430,7 +46425,7 @@ msgstr "Auftrag {0} ist nicht gebucht"
 msgid "Sales Order {0} is not valid"
 msgstr "Auftrag {0} ist nicht gültig"
 
-#: erpnext/controllers/selling_controller.py:443
+#: erpnext/controllers/selling_controller.py:451
 #: erpnext/manufacturing/doctype/work_order/work_order.py:301
 msgid "Sales Order {0} is {1}"
 msgstr "Auftrag {0} ist {1}"
@@ -46481,7 +46476,7 @@ msgstr "Auszuliefernde Aufträge"
 #: erpnext/accounts/doctype/promotional_scheme/promotional_scheme.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:122
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1156
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1158
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:99
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:194
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:74
@@ -46579,7 +46574,7 @@ msgstr "Zusammenfassung der Verkaufszahlung"
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:156
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:137
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:128
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1153
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1155
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:105
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:191
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:80
@@ -46599,7 +46594,7 @@ msgstr "Zusammenfassung der Verkaufszahlung"
 msgid "Sales Person"
 msgstr "Verkäufer"
 
-#: erpnext/controllers/selling_controller.py:204
+#: erpnext/controllers/selling_controller.py:212
 msgid "Sales Person <b>{0}</b> is disabled."
 msgstr "Verkäufer <b>{0}</b> ist deaktiviert."
 
@@ -46880,7 +46875,7 @@ msgstr "Beispiel Retention Warehouse"
 
 #. Label of the sample_size (Float) field in DocType 'Quality Inspection'
 #: erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py:93
-#: erpnext/public/js/controllers/transaction.js:2369
+#: erpnext/public/js/controllers/transaction.js:2395
 #: erpnext/stock/doctype/quality_inspection/quality_inspection.json
 msgid "Sample Size"
 msgstr "Stichprobenumfang"
@@ -47418,7 +47413,7 @@ msgstr "Gegenstände auswählen"
 msgid "Select Items based on Delivery Date"
 msgstr "Wählen Sie die Positionen nach dem Lieferdatum aus"
 
-#: erpnext/public/js/controllers/transaction.js:2405
+#: erpnext/public/js/controllers/transaction.js:2431
 msgid "Select Items for Quality Inspection"
 msgstr "Artikel für die Qualitätsprüfung auswählen"
 
@@ -47559,7 +47554,7 @@ msgstr "Zuerst das Unternehmen auswählen"
 msgid "Select company name first."
 msgstr "Zuerst Firma auswählen."
 
-#: erpnext/controllers/accounts_controller.py:2785
+#: erpnext/controllers/accounts_controller.py:2788
 msgid "Select finance book for the item {0} at row {1}"
 msgstr "Wählen Sie das Finanzbuch für das Element {0} in Zeile {1} aus."
 
@@ -47773,7 +47768,7 @@ msgid "Send Now"
 msgstr "Jetzt senden"
 
 #. Label of the send_sms (Button) field in DocType 'SMS Center'
-#: erpnext/public/js/controllers/transaction.js:517
+#: erpnext/public/js/controllers/transaction.js:543
 #: erpnext/selling/doctype/sms_center/sms_center.json
 msgid "Send SMS"
 msgstr "SMS verschicken"
@@ -47931,7 +47926,7 @@ msgstr ""
 #: erpnext/manufacturing/doctype/job_card/job_card.json
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.js:74
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.py:114
-#: erpnext/public/js/controllers/transaction.js:2382
+#: erpnext/public/js/controllers/transaction.js:2408
 #: erpnext/public/js/utils/serial_no_batch_selector.js:421
 #: erpnext/selling/doctype/installation_note_item/installation_note_item.json
 #: erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
@@ -47980,7 +47975,7 @@ msgstr ""
 msgid "Serial No Range"
 msgstr "Seriennummernbereich"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1894
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1895
 msgid "Serial No Reserved"
 msgstr "Seriennummer reserviert"
 
@@ -48020,7 +48015,7 @@ msgstr "Seriennummer und Chargen"
 msgid "Serial No and Batch Selector cannot be use when Use Serial / Batch Fields is enabled."
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:859
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:860
 msgid "Serial No is mandatory"
 msgstr "Seriennummer ist obligatorisch"
 
@@ -48049,7 +48044,7 @@ msgstr "Seriennummer {0} gehört nicht zu Artikel {1}"
 msgid "Serial No {0} does not exist"
 msgstr "Seriennummer {0} existiert nicht"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2623
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2624
 msgid "Serial No {0} does not exists"
 msgstr "Seriennummer {0} existiert nicht"
 
@@ -48057,7 +48052,7 @@ msgstr "Seriennummer {0} existiert nicht"
 msgid "Serial No {0} is already added"
 msgstr "Die Seriennummer {0} ist bereits hinzugefügt"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:357
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:358
 msgid "Serial No {0} is not present in the {1} {2}, hence you can't return it against the {1} {2}"
 msgstr ""
 
@@ -48094,11 +48089,11 @@ msgstr "Serien-/Chargennummern"
 msgid "Serial Nos and Batches"
 msgstr "Seriennummern und Chargen"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1370
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1371
 msgid "Serial Nos are created successfully"
 msgstr "Seriennummern wurden erfolgreich erstellt"
 
-#: erpnext/stock/stock_ledger.py:2137
+#: erpnext/stock/stock_ledger.py:2145
 msgid "Serial Nos are reserved in Stock Reservation Entries, you need to unreserve them before proceeding."
 msgstr "Seriennummern sind bereits reserviert. Sie müssen die Reservierung aufheben, bevor Sie fortfahren."
 
@@ -48172,11 +48167,11 @@ msgstr "Seriennummer und Charge"
 msgid "Serial and Batch Bundle"
 msgstr "Serien- und Chargenbündel"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1598
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1599
 msgid "Serial and Batch Bundle created"
 msgstr "Serien- und Chargenbündel erstellt"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1664
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1665
 msgid "Serial and Batch Bundle updated"
 msgstr "Serien- und Chargenbündel aktualisiert"
 
@@ -48528,12 +48523,12 @@ msgid "Service Stop Date"
 msgstr "Service-Stopp-Datum"
 
 #: erpnext/accounts/deferred_revenue.py:44
-#: erpnext/public/js/controllers/transaction.js:1420
+#: erpnext/public/js/controllers/transaction.js:1446
 msgid "Service Stop Date cannot be after Service End Date"
 msgstr "Das Service-Stopp-Datum kann nicht nach dem Service-Enddatum liegen"
 
 #: erpnext/accounts/deferred_revenue.py:41
-#: erpnext/public/js/controllers/transaction.js:1417
+#: erpnext/public/js/controllers/transaction.js:1443
 msgid "Service Stop Date cannot be before Service Start Date"
 msgstr "Das Servicestoppdatum darf nicht vor dem Servicestartdatum liegen"
 
@@ -49970,7 +49965,7 @@ msgstr ""
 
 #: erpnext/setup/setup_wizard/operations/defaults_setup.py:70
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:463
-#: erpnext/stock/doctype/item/item.py:245
+#: erpnext/stock/doctype/item/item.py:248
 msgid "Standard Selling"
 msgstr "Standard-Vertrieb"
 
@@ -50800,7 +50795,7 @@ msgstr "Empfangener, aber nicht berechneter Lagerbestand"
 #. Option for the 'Purpose' (Select) field in DocType 'Stock Reconciliation'
 #. Label of a Link in the Stock Workspace
 #: erpnext/setup/workspace/home/home.json
-#: erpnext/stock/doctype/item/item.py:612
+#: erpnext/stock/doctype/item/item.py:618
 #: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.json
 #: erpnext/stock/workspace/stock/stock.json
 msgid "Stock Reconciliation"
@@ -50811,7 +50806,7 @@ msgstr "Bestandsabgleich"
 msgid "Stock Reconciliation Item"
 msgstr "Bestandsabgleich-Artikel"
 
-#: erpnext/stock/doctype/item/item.py:612
+#: erpnext/stock/doctype/item/item.py:618
 msgid "Stock Reconciliations"
 msgstr "Bestandsabstimmungen"
 
@@ -50846,7 +50841,7 @@ msgstr ""
 #: erpnext/stock/doctype/pick_list/pick_list.js:150
 #: erpnext/stock/doctype/pick_list/pick_list.js:155
 #: erpnext/stock/doctype/stock_entry/stock_entry_dashboard.py:25
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:706
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:702
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:575
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:1138
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:1398
@@ -51246,7 +51241,7 @@ msgstr "Der angehaltene Arbeitsauftrag kann nicht abgebrochen werden. Stoppen Si
 #: erpnext/setup/doctype/company/company.py:287
 #: erpnext/setup/setup_wizard/operations/defaults_setup.py:33
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:502
-#: erpnext/stock/doctype/item/item.py:282
+#: erpnext/stock/doctype/item/item.py:285
 msgid "Stores"
 msgstr "Lagerräume"
 
@@ -51781,7 +51776,7 @@ msgstr "Erfolgreich abgestimmt"
 msgid "Successfully Set Supplier"
 msgstr "Setzen Sie den Lieferanten erfolgreich"
 
-#: erpnext/stock/doctype/item/item.py:339
+#: erpnext/stock/doctype/item/item.py:342
 msgid "Successfully changed Stock UOM, please redefine conversion factors for new UOM."
 msgstr "Lager-ME erfolgreich geändert. Bitte passen Sie nun die Umrechnungsfaktoren an."
 
@@ -52083,7 +52078,7 @@ msgstr "Lieferantendetails"
 #: erpnext/accounts/doctype/tax_rule/tax_rule.json
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:111
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:87
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1160
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1162
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:198
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:237
 #: erpnext/accounts/report/purchase_register/purchase_register.js:27
@@ -52183,7 +52178,7 @@ msgstr "Lieferanten-Ledger-Zusammenfassung"
 #. Label of the supplier_name (Data) field in DocType 'Purchase Receipt'
 #. Label of the supplier_name (Data) field in DocType 'Stock Entry'
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1077
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1079
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:156
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:198
 #: erpnext/accounts/report/purchase_register/purchase_register.py:177
@@ -52667,7 +52662,7 @@ msgstr "Falls aktiviert, erstellt das System bei der Buchung des Arbeitsauftrags
 msgid "System will fetch all the entries if limit value is zero."
 msgstr "Das System ruft alle Einträge ab, wenn der Grenzwert Null ist."
 
-#: erpnext/controllers/accounts_controller.py:1975
+#: erpnext/controllers/accounts_controller.py:1978
 msgid "System will not check over billing since amount for Item {0} in {1} is zero"
 msgstr ""
 
@@ -52926,7 +52921,7 @@ msgstr ""
 msgid "Target Warehouse is required before Submit"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:782
+#: erpnext/controllers/selling_controller.py:790
 msgid "Target Warehouse is set for some items but the customer is not an internal customer."
 msgstr ""
 
@@ -53165,7 +53160,7 @@ msgstr "Steuererhebung"
 msgid "Tax Category"
 msgstr "Steuerkategorie"
 
-#: erpnext/controllers/buying_controller.py:194
+#: erpnext/controllers/buying_controller.py:202
 msgid "Tax Category has been changed to \"Total\" because all the Items are non-stock items"
 msgstr "Steuer-Kategorie wurde in \"Total\" geändert, da alle Artikel \"Artikel ohne Lagerhaltung\" sind"
 
@@ -53371,7 +53366,7 @@ msgstr "Die Steuer wird nur für den Betrag einbehalten, der den kumulierten Sch
 #. Label of the taxable_amount (Currency) field in DocType 'Tax Withheld
 #. Vouchers'
 #: erpnext/accounts/doctype/tax_withheld_vouchers/tax_withheld_vouchers.json
-#: erpnext/controllers/taxes_and_totals.py:1125
+#: erpnext/controllers/taxes_and_totals.py:1135
 msgid "Taxable Amount"
 msgstr "Steuerpflichtiger Betrag"
 
@@ -53510,7 +53505,7 @@ msgstr "Steuern und Gebühren abgezogen"
 msgid "Taxes and Charges Deducted (Company Currency)"
 msgstr "Steuern und Gebühren abgezogen (Unternehmenswährung)"
 
-#: erpnext/stock/doctype/item/item.py:352
+#: erpnext/stock/doctype/item/item.py:355
 msgid "Taxes row #{0}: {1} cannot be smaller than {2}"
 msgstr ""
 
@@ -53796,7 +53791,7 @@ msgstr "Vorlage für Allgemeine Geschäftsbedingungen"
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/territory_item/territory_item.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:134
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1144
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1146
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:93
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:182
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:68
@@ -53900,7 +53895,7 @@ msgstr "Der Zugriff auf die Angebotsanfrage vom Portal ist deaktiviert. Um den Z
 msgid "The BOM which will be replaced"
 msgstr "Die Stückliste (BOM) wird ersetzt."
 
-#: erpnext/stock/serial_batch_bundle.py:1274
+#: erpnext/stock/serial_batch_bundle.py:1306
 msgid "The Batch {0} has negative quantity {1} in warehouse {2}. Please correct the quantity."
 msgstr "Die Charge {0} hat eine negative Menge {1} im Lager {2}. Bitte korrigieren Sie die Menge."
 
@@ -53952,7 +53947,7 @@ msgstr "Der Verkäufer ist mit {0} verknüpft"
 msgid "The Serial No at Row #{0}: {1} is not available in warehouse {2}."
 msgstr "Die Seriennummer in Zeile #{0}: {1} ist im Lager {2} nicht verfügbar."
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1891
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1892
 msgid "The Serial No {0} is reserved against the {1} {2} and cannot be used for any other transaction."
 msgstr "Die Seriennummer {0} ist für {1} {2} reserviert und kann für keine andere Transaktion verwendet werden."
 
@@ -54035,7 +54030,7 @@ msgstr "Bei den folgenden Vermögensgegenständen wurden die Abschreibungen nich
 msgid "The following batches are expired, please restock them: <br> {0}"
 msgstr "Die folgenden Chargen sind abgelaufen, bitte füllen Sie sie wieder auf: <br> {0}"
 
-#: erpnext/stock/doctype/item/item.py:849
+#: erpnext/stock/doctype/item/item.py:843
 msgid "The following deleted attributes exist in Variants but not in the Template. You can either delete the Variants or keep the attribute(s) in template."
 msgstr "Die folgenden gelöschten Attribute sind in Varianten vorhanden, jedoch nicht in der Vorlage. Sie können entweder die Varianten löschen oder die Attribute in der Vorlage behalten."
 
@@ -54060,15 +54055,15 @@ msgstr "Das Bruttogewicht des Pakets. Normalerweise Nettogewicht + Verpackungsg
 msgid "The holiday on {0} is not between From Date and To Date"
 msgstr "Der Urlaub am {0} ist nicht zwischen dem Von-Datum und dem Bis-Datum"
 
-#: erpnext/controllers/buying_controller.py:1066
+#: erpnext/controllers/buying_controller.py:1074
 msgid "The item {item} is not marked as {type_of} item. You can enable it as {type_of} item from its Item master."
 msgstr "Der Artikel {item} ist nicht als {type_of} Artikel gekennzeichnet. Sie können ihn als {type_of} Artikel in seinem Artikelstamm aktivieren."
 
-#: erpnext/stock/doctype/item/item.py:614
+#: erpnext/stock/doctype/item/item.py:620
 msgid "The items {0} and {1} are present in the following {2} :"
 msgstr "Die Artikel {0} und {1} sind im folgenden {2} zu finden:"
 
-#: erpnext/controllers/buying_controller.py:1059
+#: erpnext/controllers/buying_controller.py:1067
 msgid "The items {items} are not marked as {type_of} item. You can enable them as {type_of} item from their Item masters."
 msgstr "Die Artikel {items} sind nicht als {type_of} Artikel gekennzeichnet. Sie können sie in den Stammdaten der Artikel als {type_of} Artikel aktivieren."
 
@@ -54170,8 +54165,8 @@ msgstr "Der ausgewählte Artikel kann keine Charge haben"
 msgid "The seller and the buyer cannot be the same"
 msgstr "Der Verkäufer und der Käufer können nicht identisch sein"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:142
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:154
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:143
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:155
 msgid "The serial and batch bundle {0} not linked to {1} {2}"
 msgstr "Das Seriennummern- und Chargenbündel {0} ist nicht mit {1} {2} verknüpft"
 
@@ -54195,7 +54190,7 @@ msgstr "Die Freigaben existieren nicht mit der {0}"
 msgid "The stock for the item {0} in the {1} warehouse was negative on the {2}. You should create a positive entry {3} before the date {4} and time {5} to post the correct valuation rate. For more details, please read the <a href='https://docs.erpnext.com/docs/user/manual/en/stock-adjustment-cogs-with-negative-stock'>documentation<a>."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:700
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:696
 msgid "The stock has been reserved for the following Items and Warehouses, un-reserve the same to {0} the Stock Reconciliation: <br /><br /> {1}"
 msgstr ""
 
@@ -54208,11 +54203,11 @@ msgstr "Die Synchronisierung wurde im Hintergrund gestartet. Bitte überprüfen 
 msgid "The task has been enqueued as a background job."
 msgstr "Die Aufgabe wurde als Hintergrundjob in die Warteschlange gestellt."
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:994
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:990
 msgid "The task has been enqueued as a background job. In case there is any issue on processing in background, the system will add a comment about the error on this Stock Reconciliation and revert to the Draft stage"
 msgstr "Die Aufgabe wurde als Hintergrundjob in die Warteschlange gestellt. Falls bei der Verarbeitung im Hintergrund Probleme auftreten, fügt das System einen Kommentar zum Fehler in dieser Bestandsabstimmung hinzu und kehrt zum Entwurfsstadium zurück"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1005
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1001
 msgid "The task has been enqueued as a background job. In case there is any issue on processing in background, the system will add a comment about the error on this Stock Reconciliation and revert to the Submitted stage"
 msgstr "Die Aufgabe wurde als Hintergrundjob in die Warteschlange gestellt. Falls bei der Verarbeitung im Hintergrund ein Problem auftritt, fügt das System einen Kommentar über den Fehler bei dieser Bestandsabstimmung hinzu und kehrt zur Stufe Gebucht zurück"
 
@@ -54262,7 +54257,7 @@ msgstr "Das Lager, in das Ihre Artikel übertragen werden, wenn Sie mit der Prod
 msgid "The {0} ({1}) must be equal to {2} ({3})"
 msgstr "Die {0} ({1}) muss gleich {2} ({3}) sein."
 
-#: erpnext/public/js/controllers/transaction.js:2790
+#: erpnext/public/js/controllers/transaction.js:2816
 msgid "The {0} contains Unit Price Items."
 msgstr ""
 
@@ -54310,7 +54305,7 @@ msgstr "Für den ausgewählten Artikel sind keine Artikelvarianten vorhanden"
 msgid "There can be multiple tiered collection factor based on the total spent. But the conversion factor for redemption will always be same for all the tier."
 msgstr ""
 
-#: erpnext/accounts/party.py:580
+#: erpnext/accounts/party.py:586
 msgid "There can only be 1 Account per Company in {0} {1}"
 msgstr "Es kann nur EIN Konto pro Unternehmen in {0} {1} geben"
 
@@ -54596,7 +54591,7 @@ msgstr "Dies wird an den Artikelcode der Variante angehängt. Beispiel: Wenn Ihr
 msgid "This will restrict user access to other employee records"
 msgstr "Dies schränkt den Benutzerzugriff auf andere Mitarbeiterdatensätze ein"
 
-#: erpnext/controllers/selling_controller.py:783
+#: erpnext/controllers/selling_controller.py:791
 msgid "This {} will be treated as material transfer."
 msgstr "Diese(r) {} wird als Materialtransfer behandelt."
 
@@ -55310,11 +55305,11 @@ msgid "To include sub-assembly costs and scrap items in Finished Goods on a work
 msgstr ""
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:2337
-#: erpnext/controllers/accounts_controller.py:3005
+#: erpnext/controllers/accounts_controller.py:3008
 msgid "To include tax in row {0} in Item rate, taxes in rows {1} must also be included"
 msgstr "Um Steuern im Artikelpreis in Zeile {0} einzubeziehen, müssen Steuern in den Zeilen {1} ebenfalls einbezogen sein"
 
-#: erpnext/stock/doctype/item/item.py:636
+#: erpnext/stock/doctype/item/item.py:642
 msgid "To merge, following properties must be same for both items"
 msgstr "Um zwei Produkte zusammenzuführen, müssen folgende Eigenschaften für beide Produkte gleich sein"
 
@@ -55934,7 +55929,7 @@ msgstr "Summe ausstehende Beträge"
 msgid "Total Paid Amount"
 msgstr "Summe gezahlte Beträge"
 
-#: erpnext/controllers/accounts_controller.py:2591
+#: erpnext/controllers/accounts_controller.py:2594
 msgid "Total Payment Amount in Payment Schedule must be equal to Grand / Rounded Total"
 msgstr "Der gesamte Zahlungsbetrag im Zahlungsplan muss gleich Groß / Abgerundet sein"
 
@@ -56219,15 +56214,15 @@ msgstr "Gesamtgewicht (kg)"
 msgid "Total Working Hours"
 msgstr "Gesamtarbeitszeit"
 
-#: erpnext/controllers/accounts_controller.py:2138
+#: erpnext/controllers/accounts_controller.py:2141
 msgid "Total advance ({0}) against Order {1} cannot be greater than the Grand Total ({2})"
 msgstr "Insgesamt Voraus ({0}) gegen Bestellen {1} kann nicht größer sein als die Gesamtsumme ({2})"
 
-#: erpnext/controllers/selling_controller.py:190
+#: erpnext/controllers/selling_controller.py:198
 msgid "Total allocated percentage for sales team should be 100"
 msgstr "Insgesamt verteilte Prozentmenge für Vertriebsteam sollte 100 sein"
 
-#: erpnext/selling/doctype/customer/customer.py:162
+#: erpnext/selling/doctype/customer/customer.py:161
 msgid "Total contribution percentage should be equal to 100"
 msgstr "Der prozentuale Gesamtbeitrag sollte 100 betragen"
 
@@ -57112,7 +57107,7 @@ msgstr "Maßeinheit"
 msgid "Unit of Measure (UOM)"
 msgstr "Maßeinheit (ME)"
 
-#: erpnext/stock/doctype/item/item.py:384
+#: erpnext/stock/doctype/item/item.py:387
 msgid "Unit of Measure {0} has been entered more than once in Conversion Factor Table"
 msgstr "Die Mengeneinheit {0} wurde mehr als einmal in die Umrechnungsfaktortabelle eingetragen."
 
@@ -57554,7 +57549,7 @@ msgstr ""
 msgid "Update timestamp on new communication"
 msgstr "Zeitstempel bei neuer Kommunikation aktualisieren"
 
-#: erpnext/manufacturing/doctype/bom_creator/bom_creator.py:533
+#: erpnext/manufacturing/doctype/bom_creator/bom_creator.py:534
 msgid "Updated successfully"
 msgstr "Erfolgreich aktualisiert"
 
@@ -57568,7 +57563,7 @@ msgstr "Erfolgreich aktualisiert"
 msgid "Updated via 'Time Log' (In Minutes)"
 msgstr "Aktualisiert über „Zeitprotokoll“ (in Minuten)"
 
-#: erpnext/stock/doctype/item/item.py:1387
+#: erpnext/stock/doctype/item/item.py:1381
 msgid "Updating Variants..."
 msgstr "Varianten werden aktualisiert ..."
 
@@ -58126,19 +58121,19 @@ msgstr "Wertansatz"
 msgid "Valuation Rate (In / Out)"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1881
+#: erpnext/stock/stock_ledger.py:1890
 msgid "Valuation Rate Missing"
 msgstr "Bewertungsrate fehlt"
 
-#: erpnext/stock/stock_ledger.py:1859
+#: erpnext/stock/stock_ledger.py:1868
 msgid "Valuation Rate for the Item {0}, is required to do accounting entries for {1} {2}."
 msgstr "Der Bewertungssatz für den Posten {0} ist erforderlich, um Buchhaltungseinträge für {1} {2} vorzunehmen."
 
-#: erpnext/stock/doctype/item/item.py:266
+#: erpnext/stock/doctype/item/item.py:269
 msgid "Valuation Rate is mandatory if Opening Stock entered"
 msgstr "Bewertungskurs ist obligatorisch, wenn Öffnung Stock eingegeben"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:752
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:748
 msgid "Valuation Rate required for Item {0} at row {1}"
 msgstr "Bewertungssatz für Position {0} in Zeile {1} erforderlich"
 
@@ -58148,7 +58143,7 @@ msgstr "Bewertungssatz für Position {0} in Zeile {1} erforderlich"
 msgid "Valuation and Total"
 msgstr "Bewertung und Summe"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:971
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:967
 msgid "Valuation rate for customer provided items has been set to zero."
 msgstr "Die Bewertungsrate für von Kunden beigestellte Artikel wurde auf Null gesetzt."
 
@@ -58162,7 +58157,7 @@ msgid "Valuation rate for the item as per Sales Invoice (Only for Internal Trans
 msgstr ""
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:2361
-#: erpnext/controllers/accounts_controller.py:3029
+#: erpnext/controllers/accounts_controller.py:3032
 msgid "Valuation type charges can not be marked as Inclusive"
 msgstr "Bewertungsgebühren können nicht als Inklusiv gekennzeichnet werden"
 
@@ -58318,7 +58313,7 @@ msgstr "Varianz ({})"
 msgid "Variant"
 msgstr "Variante"
 
-#: erpnext/stock/doctype/item/item.py:864
+#: erpnext/stock/doctype/item/item.py:858
 msgid "Variant Attribute Error"
 msgstr "Variantenattributfehler"
 
@@ -58337,7 +58332,7 @@ msgstr "Variantenstückliste"
 msgid "Variant Based On"
 msgstr "Variante basierend auf"
 
-#: erpnext/stock/doctype/item/item.py:892
+#: erpnext/stock/doctype/item/item.py:886
 msgid "Variant Based On cannot be changed"
 msgstr "Variant Based On kann nicht geändert werden"
 
@@ -58355,7 +58350,7 @@ msgstr "Variantenfeld"
 msgid "Variant Item"
 msgstr "Variantenartikel"
 
-#: erpnext/stock/doctype/item/item.py:862
+#: erpnext/stock/doctype/item/item.py:856
 msgid "Variant Items"
 msgstr "Variantenartikel"
 
@@ -58473,7 +58468,7 @@ msgstr "Video-Einstellungen"
 #: erpnext/accounts/doctype/cost_center/cost_center_tree.js:56
 #: erpnext/accounts/doctype/invoice_discounting/invoice_discounting.js:205
 #: erpnext/accounts/doctype/journal_entry/journal_entry.js:43
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:668
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:670
 #: erpnext/bulk_transaction/doctype/bulk_transaction_log/bulk_transaction_log.js:14
 #: erpnext/bulk_transaction/doctype/bulk_transaction_log/bulk_transaction_log.js:24
 #: erpnext/buying/doctype/request_for_quotation/request_for_quotation.js:167
@@ -58660,7 +58655,7 @@ msgstr "Beleg"
 #: erpnext/accounts/doctype/repost_accounting_ledger_items/repost_accounting_ledger_items.json
 #: erpnext/accounts/doctype/repost_payment_ledger_items/repost_payment_ledger_items.json
 #: erpnext/accounts/doctype/unreconcile_payment/unreconcile_payment.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1099
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1101
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.js:42
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:209
 #: erpnext/accounts/report/general_ledger/general_ledger.js:49
@@ -58691,7 +58686,7 @@ msgstr "Beleg"
 msgid "Voucher No"
 msgstr "Belegnr."
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1087
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1088
 msgid "Voucher No is mandatory"
 msgstr "Beleg Nr. ist obligatorisch"
 
@@ -58733,7 +58728,7 @@ msgstr "Beleg Untertyp"
 #: erpnext/accounts/doctype/repost_payment_ledger_items/repost_payment_ledger_items.json
 #: erpnext/accounts/doctype/tax_withheld_vouchers/tax_withheld_vouchers.json
 #: erpnext/accounts/doctype/unreconcile_payment/unreconcile_payment.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1097
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1099
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:200
 #: erpnext/accounts/report/general_ledger/general_ledger.py:697
 #: erpnext/accounts/report/invalid_ledger_entries/invalid_ledger_entries.py:31
@@ -59087,10 +59082,6 @@ msgstr "Lager ist erforderlich"
 msgid "Warehouse not found against the account {0}"
 msgstr "Lager für Konto {0} nicht gefunden"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:600
-msgid "Warehouse not found in the system"
-msgstr "Lager im System nicht gefunden"
-
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:1130
 #: erpnext/stock/doctype/delivery_note/delivery_note.py:414
 msgid "Warehouse required for stock Item {0}"
@@ -59219,7 +59210,7 @@ msgid "Warn for new Request for Quotations"
 msgstr "Warnung für neue Angebotsanfrage"
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:744
-#: erpnext/controllers/accounts_controller.py:1978
+#: erpnext/controllers/accounts_controller.py:1981
 #: erpnext/stock/doctype/delivery_trip/delivery_trip.js:145
 #: erpnext/utilities/transaction_base.py:123
 msgid "Warning"
@@ -60191,7 +60182,7 @@ msgstr "Ja"
 msgid "You are importing data for the code list:"
 msgstr "Sie importieren Daten für die Codeliste:"
 
-#: erpnext/controllers/accounts_controller.py:3611
+#: erpnext/controllers/accounts_controller.py:3614
 msgid "You are not allowed to update as per the conditions set in {} Workflow."
 msgstr "Sie dürfen nicht gemäß den im {} Workflow festgelegten Bedingungen aktualisieren."
 
@@ -60256,7 +60247,7 @@ msgstr ""
 msgid "You can't make any changes to Job Card since Work Order is closed."
 msgstr "Sie können keine Änderungen an der Jobkarte vornehmen, da der Arbeitsauftrag geschlossen ist."
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:185
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:186
 msgid "You can't process the serial number {0} as it has already been used in the SABB {1}. {2} if you want to inward same serial number multiple times then enabled 'Allow existing Serial No to be Manufactured/Received again' in the {3}"
 msgstr ""
 
@@ -60316,7 +60307,7 @@ msgstr "Sie können die Bestellung nicht ohne Zahlung buchen."
 msgid "You cannot {0} this document because another Period Closing Entry {1} exists after {2}"
 msgstr "Sie können dieses Dokument nicht {0}, da nach {2} ein weiterer Periodenabschlusseintrag {1} existiert"
 
-#: erpnext/controllers/accounts_controller.py:3587
+#: erpnext/controllers/accounts_controller.py:3590
 msgid "You do not have permissions to {} items in a {}."
 msgstr "Sie haben keine Berechtigungen für {} Elemente in einem {}."
 
@@ -60344,7 +60335,7 @@ msgstr "Sie wurden eingeladen, am Projekt {0} mitzuarbeiten."
 msgid "You have entered a duplicate Delivery Note on Row"
 msgstr "Sie haben mehrere Lieferscheine eingegeben"
 
-#: erpnext/stock/doctype/item/item.py:1063
+#: erpnext/stock/doctype/item/item.py:1057
 msgid "You have to enable auto re-order in Stock Settings to maintain re-order levels."
 msgstr "Sie müssen die automatische Nachbestellung in den Lagereinstellungen aktivieren, um den Nachbestellungsstand beizubehalten."
 
@@ -60364,7 +60355,7 @@ msgstr "Sie müssen einen Kunden auswählen, bevor Sie einen Artikel hinzufügen
 msgid "You need to cancel POS Closing Entry {} to be able to cancel this document."
 msgstr "Sie müssen den POS-Abschlusseintrag {} stornieren, um diesen Beleg stornieren zu können."
 
-#: erpnext/controllers/accounts_controller.py:2980
+#: erpnext/controllers/accounts_controller.py:2983
 msgid "You selected the account group {1} as {2} Account in row {0}. Please select a single account."
 msgstr "Sie haben die Kontengruppe {1} als {2}-Konto in Zeile {0} ausgewählt. Bitte wählen Sie ein einzelnes Konto."
 
@@ -60442,7 +60433,7 @@ msgstr "[Wichtig] [ERPNext] Fehler bei der automatischen Neuordnung"
 msgid "`Allow Negative rates for Items`"
 msgstr "„Negative Preise für Artikel zulassen“"
 
-#: erpnext/stock/stock_ledger.py:1873
+#: erpnext/stock/stock_ledger.py:1882
 msgid "after"
 msgstr "nach"
 
@@ -60590,7 +60581,7 @@ msgstr "Links"
 msgid "material_request_item"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:151
+#: erpnext/controllers/selling_controller.py:159
 msgid "must be between 0 and 100"
 msgstr "muss zwischen 0 und 100 liegen"
 
@@ -60615,7 +60606,7 @@ msgstr "Altes übergeordnetes Element"
 msgid "on"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1289
+#: erpnext/controllers/accounts_controller.py:1292
 msgid "or"
 msgstr "oder"
 
@@ -60664,7 +60655,7 @@ msgstr "Die Zahlungs-App ist nicht installiert. Bitte installieren Sie sie von {
 msgid "per hour"
 msgstr "pro Stunde"
 
-#: erpnext/stock/stock_ledger.py:1874
+#: erpnext/stock/stock_ledger.py:1883
 msgid "performing either one below:"
 msgstr ""
 
@@ -60791,7 +60782,7 @@ msgstr "Sie müssen in der Kontentabelle das Konto &quot;Kapital in Bearbeitung&
 msgid "{0}"
 msgstr "{0}"
 
-#: erpnext/controllers/accounts_controller.py:1109
+#: erpnext/controllers/accounts_controller.py:1112
 msgid "{0} '{1}' is disabled"
 msgstr "{0} '{1}' ist deaktiviert"
 
@@ -60807,7 +60798,7 @@ msgstr "{0} ({1}) darf nicht größer als die geplante Menge ({2}) im Arbeitsauf
 msgid "{0} <b>{1}</b> has submitted Assets. Remove Item <b>{2}</b> from table to continue."
 msgstr "{0} <b>{1}</b> hat Vermögensgegenstände gebucht. Entfernen Sie Artikel <b>{2}</b> aus der Tabelle, um fortzufahren."
 
-#: erpnext/controllers/accounts_controller.py:2193
+#: erpnext/controllers/accounts_controller.py:2196
 msgid "{0} Account not found against Customer {1}."
 msgstr "{0} Konto für Kunde {1} nicht gefunden."
 
@@ -60839,7 +60830,7 @@ msgstr "{0} Operationen: {1}"
 msgid "{0} Request for {1}"
 msgstr "{0} Anfrage für {1}"
 
-#: erpnext/stock/doctype/item/item.py:323
+#: erpnext/stock/doctype/item/item.py:326
 msgid "{0} Retain Sample is based on batch, please check Has Batch No to retain sample of item"
 msgstr "{0} Probe aufbewahren basiert auf Charge. Bitte aktivieren Sie die Option Chargennummer, um die Probe des Artikels aufzubewahren"
 
@@ -60930,7 +60921,7 @@ msgid "{0} entered twice in Item Tax"
 msgstr "{0} in Artikelsteuer doppelt eingegeben"
 
 #: erpnext/setup/doctype/item_group/item_group.py:48
-#: erpnext/stock/doctype/item/item.py:436
+#: erpnext/stock/doctype/item/item.py:439
 msgid "{0} entered twice {1} in Item Taxes"
 msgstr ""
 
@@ -60951,7 +60942,7 @@ msgstr "{0} wurde erfolgreich gebucht"
 msgid "{0} hours"
 msgstr "{0} Stunden"
 
-#: erpnext/controllers/accounts_controller.py:2534
+#: erpnext/controllers/accounts_controller.py:2537
 msgid "{0} in row {1}"
 msgstr "{0} in Zeile {1}"
 
@@ -60975,7 +60966,7 @@ msgstr "{0} ist blockiert, daher kann diese Transaktion nicht fortgesetzt werden
 
 #: erpnext/accounts/doctype/budget/budget.py:60
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:643
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:49
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:50
 #: erpnext/accounts/report/general_ledger/general_ledger.py:59
 #: erpnext/accounts/report/pos_register/pos_register.py:107
 #: erpnext/controllers/trends.py:50
@@ -60995,11 +60986,11 @@ msgstr "{0} ist für Konto {1} obligatorisch"
 msgid "{0} is mandatory. Maybe Currency Exchange record is not created for {1} to {2}"
 msgstr "{0} ist obligatorisch. Möglicherweise wird kein Währungsumtauschdatensatz für {1} bis {2} erstellt."
 
-#: erpnext/controllers/accounts_controller.py:2937
+#: erpnext/controllers/accounts_controller.py:2940
 msgid "{0} is mandatory. Maybe Currency Exchange record is not created for {1} to {2}."
 msgstr "{0} ist zwingend erforderlich. Möglicherweise wurde der Datensatz für die Währungsumrechung für {1} bis {2} nicht erstellt."
 
-#: erpnext/selling/doctype/customer/customer.py:204
+#: erpnext/selling/doctype/customer/customer.py:203
 msgid "{0} is not a company bank account"
 msgstr "{0} ist kein Firmenbankkonto"
 
@@ -61082,7 +61073,7 @@ msgstr "Menge {0} des Artikels {1} wird im Lager {2} mit einer Kapazität von {3
 msgid "{0} to {1}"
 msgstr "{0} bis {1}"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:690
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:686
 msgid "{0} units are reserved for Item {1} in Warehouse {2}, please un-reserve the same to {3} the Stock Reconciliation."
 msgstr ""
 
@@ -61098,16 +61089,16 @@ msgstr "{0} Einheiten des Artikels {1} werden in einer anderen Pickliste kommiss
 msgid "{0} units of {1} are required in {2} with the inventory dimension: {3} ({4}) on {5} {6} for {7} to complete the transaction."
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1532 erpnext/stock/stock_ledger.py:2023
-#: erpnext/stock/stock_ledger.py:2037
+#: erpnext/stock/stock_ledger.py:1541 erpnext/stock/stock_ledger.py:2031
+#: erpnext/stock/stock_ledger.py:2045
 msgid "{0} units of {1} needed in {2} on {3} {4} for {5} to complete this transaction."
 msgstr "Es werden {0} Einheiten von {1} in {2} auf {3} {4} für {5} benötigt, um diesen Vorgang abzuschließen."
 
-#: erpnext/stock/stock_ledger.py:2124 erpnext/stock/stock_ledger.py:2170
+#: erpnext/stock/stock_ledger.py:2132 erpnext/stock/stock_ledger.py:2178
 msgid "{0} units of {1} needed in {2} on {3} {4} to complete this transaction."
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1526
+#: erpnext/stock/stock_ledger.py:1535
 msgid "{0} units of {1} needed in {2} to complete this transaction."
 msgstr "{0} Einheiten von {1} benötigt in {2} zum Abschluss dieser Transaktion."
 
@@ -61153,7 +61144,7 @@ msgstr "{0} {1} erstellt"
 msgid "{0} {1} does not exist"
 msgstr "{0} {1} existiert nicht"
 
-#: erpnext/accounts/party.py:560
+#: erpnext/accounts/party.py:566
 msgid "{0} {1} has accounting entries in currency {2} for company {3}. Please select a receivable or payable account with currency {2}."
 msgstr "{0} {1} hat Buchungen in der Währung {2} für das Unternehmen {3}. Bitte wählen Sie ein Forderungs- oder Verbindlichkeitskonto mit der Währung {2} aus."
 
@@ -61187,7 +61178,7 @@ msgstr ""
 msgid "{0} {1} is associated with {2}, but Party Account is {3}"
 msgstr "{0} {1} ist mit {2} verbunden, aber das Gegenkonto ist {3}"
 
-#: erpnext/controllers/selling_controller.py:462
+#: erpnext/controllers/selling_controller.py:470
 #: erpnext/controllers/subcontracting_controller.py:954
 msgid "{0} {1} is cancelled or closed"
 msgstr "{0} {1} wurde abgebrochen oder geschlossen"
@@ -61204,11 +61195,11 @@ msgstr "{0} {1} wurde abgebrochen, deshalb kann die Aktion nicht abgeschlossen w
 msgid "{0} {1} is closed"
 msgstr "{0} {1} ist geschlossen"
 
-#: erpnext/accounts/party.py:798
+#: erpnext/accounts/party.py:804
 msgid "{0} {1} is disabled"
 msgstr "{0} {1} ist deaktiviert"
 
-#: erpnext/accounts/party.py:804
+#: erpnext/accounts/party.py:810
 msgid "{0} {1} is frozen"
 msgstr "{0} {1} ist gesperrt"
 
@@ -61216,7 +61207,7 @@ msgstr "{0} {1} ist gesperrt"
 msgid "{0} {1} is fully billed"
 msgstr "{0} {1} wird voll in Rechnung gestellt"
 
-#: erpnext/accounts/party.py:808
+#: erpnext/accounts/party.py:814
 msgid "{0} {1} is not active"
 msgstr "{0} {1} ist nicht aktiv"
 
@@ -61342,15 +61333,15 @@ msgstr "{0}: {1} existiert nicht"
 msgid "{0}: {1} must be less than {2}"
 msgstr "{0}: {1} muss kleiner als {2} sein"
 
-#: erpnext/controllers/buying_controller.py:840
+#: erpnext/controllers/buying_controller.py:848
 msgid "{count} Assets created for {item_code}"
 msgstr "{count} Vermögensgegenstände erstellt für {item_code}"
 
-#: erpnext/controllers/buying_controller.py:738
+#: erpnext/controllers/buying_controller.py:746
 msgid "{doctype} {name} is cancelled or closed."
 msgstr "{doctype} {name} wurde abgebrochen oder geschlossen."
 
-#: erpnext/controllers/buying_controller.py:459
+#: erpnext/controllers/buying_controller.py:467
 msgid "{field_label} is mandatory for sub-contracted {doctype}."
 msgstr ""
 
@@ -61358,7 +61349,7 @@ msgstr ""
 msgid "{item_name}'s Sample Size ({sample_size}) cannot be greater than the Accepted Quantity ({accepted_quantity})"
 msgstr "Die Stichprobengröße von {item_name} ({sample_size}) darf nicht größer sein als die akzeptierte Menge ({accepted_quantity})"
 
-#: erpnext/controllers/buying_controller.py:563
+#: erpnext/controllers/buying_controller.py:571
 msgid "{ref_doctype} {ref_name} is {status}."
 msgstr ""
 
@@ -61424,7 +61415,7 @@ msgstr "{} Abzurechnen"
 msgid "{} can't be cancelled since the Loyalty Points earned has been redeemed. First cancel the {} No {}"
 msgstr "{} kann nicht storniert werden, da die gesammelten Treuepunkte eingelöst wurden. Brechen Sie zuerst das {} Nein {} ab"
 
-#: erpnext/controllers/buying_controller.py:222
+#: erpnext/controllers/buying_controller.py:230
 msgid "{} has submitted assets linked to it. You need to cancel the assets to create purchase return."
 msgstr "{} hat gebuchte Vermögensgegenstände, die mit ihm verknüpft sind. Sie müssen die Vermögensgegenstände stornieren, um eine Kaufrückgabe zu erstellen."
 

--- a/erpnext/locale/eo.po
+++ b/erpnext/locale/eo.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: frappe\n"
 "Report-Msgid-Bugs-To: hello@frappe.io\n"
-"POT-Creation-Date: 2025-05-25 09:35+0000\n"
-"PO-Revision-Date: 2025-05-25 20:35\n"
+"POT-Creation-Date: 2025-06-01 09:36+0000\n"
+"PO-Revision-Date: 2025-06-01 21:35\n"
 "Last-Translator: hello@frappe.io\n"
 "Language-Team: Esperanto\n"
 "MIME-Version: 1.0\n"
@@ -83,15 +83,15 @@ msgstr "crwdns132096:0crwdne132096:0"
 msgid " Summary"
 msgstr "crwdns62312:0crwdne62312:0"
 
-#: erpnext/stock/doctype/item/item.py:235
+#: erpnext/stock/doctype/item/item.py:238
 msgid "\"Customer Provided Item\" cannot be Purchase Item also"
 msgstr "crwdns62314:0crwdne62314:0"
 
-#: erpnext/stock/doctype/item/item.py:237
+#: erpnext/stock/doctype/item/item.py:240
 msgid "\"Customer Provided Item\" cannot have Valuation Rate"
 msgstr "crwdns62316:0crwdne62316:0"
 
-#: erpnext/stock/doctype/item/item.py:313
+#: erpnext/stock/doctype/item/item.py:316
 msgid "\"Is Fixed Asset\" cannot be unchecked, as Asset record exists against the item"
 msgstr "crwdns62318:0crwdne62318:0"
 
@@ -213,7 +213,7 @@ msgstr "crwdns132122:0crwdne132122:0"
 msgid "% of materials delivered against this Sales Order"
 msgstr "crwdns132124:0crwdne132124:0"
 
-#: erpnext/controllers/accounts_controller.py:2197
+#: erpnext/controllers/accounts_controller.py:2200
 msgid "'Account' in the Accounting section of Customer {0}"
 msgstr "crwdns62472:0{0}crwdne62472:0"
 
@@ -225,15 +225,11 @@ msgstr "crwdns62474:0crwdne62474:0"
 msgid "'Based On' and 'Group By' can not be same"
 msgstr "crwdns62476:0crwdne62476:0"
 
-#: erpnext/stock/report/product_bundle_balance/product_bundle_balance.py:233
-msgid "'Date' is required"
-msgstr "crwdns62478:0crwdne62478:0"
-
 #: erpnext/selling/report/inactive_customers/inactive_customers.py:18
 msgid "'Days Since Last Order' must be greater than or equal to zero"
 msgstr "crwdns62480:0crwdne62480:0"
 
-#: erpnext/controllers/accounts_controller.py:2202
+#: erpnext/controllers/accounts_controller.py:2205
 msgid "'Default {0} Account' in Company {1}"
 msgstr "crwdns62482:0{0}crwdnd62482:0{1}crwdne62482:0"
 
@@ -243,7 +239,7 @@ msgstr "crwdns62484:0crwdne62484:0"
 
 #: erpnext/stock/report/batch_item_expiry_status/batch_item_expiry_status.py:24
 #: erpnext/stock/report/batch_wise_balance_history/batch_wise_balance_history.py:120
-#: erpnext/stock/report/stock_analytics/stock_analytics.py:314
+#: erpnext/stock/report/stock_analytics/stock_analytics.py:313
 msgid "'From Date' is required"
 msgstr "crwdns62486:0crwdne62486:0"
 
@@ -251,7 +247,7 @@ msgstr "crwdns62486:0crwdne62486:0"
 msgid "'From Date' must be after 'To Date'"
 msgstr "crwdns62488:0crwdne62488:0"
 
-#: erpnext/stock/doctype/item/item.py:398
+#: erpnext/stock/doctype/item/item.py:401
 msgid "'Has Serial No' can not be 'Yes' for non-stock item"
 msgstr "crwdns62490:0crwdne62490:0"
 
@@ -1075,7 +1071,7 @@ msgstr "crwdns132228:0crwdne132228:0"
 
 #. Label of the qty (Float) field in DocType 'Purchase Receipt Item'
 #. Label of the qty (Float) field in DocType 'Subcontracting Receipt Item'
-#: erpnext/public/js/controllers/transaction.js:2362
+#: erpnext/public/js/controllers/transaction.js:2388
 #: erpnext/stock/doctype/purchase_receipt_item/purchase_receipt_item.json
 #: erpnext/subcontracting/doctype/subcontracting_receipt_item/subcontracting_receipt_item.json
 msgid "Accepted Quantity"
@@ -1273,7 +1269,7 @@ msgid "Account Manager"
 msgstr "crwdns132252:0crwdne132252:0"
 
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:949
-#: erpnext/controllers/accounts_controller.py:2206
+#: erpnext/controllers/accounts_controller.py:2209
 msgid "Account Missing"
 msgstr "crwdns62894:0crwdne62894:0"
 
@@ -1448,7 +1444,7 @@ msgstr "crwdns62984:0{0}crwdnd62984:0{1}crwdne62984:0"
 msgid "Account {0} is frozen"
 msgstr "crwdns62986:0{0}crwdne62986:0"
 
-#: erpnext/controllers/accounts_controller.py:1288
+#: erpnext/controllers/accounts_controller.py:1291
 msgid "Account {0} is invalid. Account Currency must be {1}"
 msgstr "crwdns62988:0{0}crwdnd62988:0{1}crwdne62988:0"
 
@@ -1484,7 +1480,7 @@ msgstr "crwdns63000:0{0}crwdne63000:0"
 msgid "Account: {0} is not permitted under Payment Entry"
 msgstr "crwdns63004:0{0}crwdne63004:0"
 
-#: erpnext/controllers/accounts_controller.py:3037
+#: erpnext/controllers/accounts_controller.py:3040
 msgid "Account: {0} with currency: {1} can not be selected"
 msgstr "crwdns63006:0{0}crwdnd63006:0{1}crwdne63006:0"
 
@@ -1757,7 +1753,7 @@ msgstr "crwdns132272:0crwdne132272:0"
 msgid "Accounting Entry for Asset"
 msgstr "crwdns63168:0crwdne63168:0"
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:796
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:805
 msgid "Accounting Entry for Service"
 msgstr "crwdns63170:0crwdne63170:0"
 
@@ -1772,18 +1768,18 @@ msgstr "crwdns63170:0crwdne63170:0"
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py:1468
 #: erpnext/controllers/stock_controller.py:550
 #: erpnext/controllers/stock_controller.py:567
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:889
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:898
 #: erpnext/stock/doctype/stock_entry/stock_entry.py:1586
 #: erpnext/stock/doctype/stock_entry/stock_entry.py:1600
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py:561
 msgid "Accounting Entry for Stock"
 msgstr "crwdns63172:0crwdne63172:0"
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:717
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:726
 msgid "Accounting Entry for {0}"
 msgstr "crwdns63174:0{0}crwdne63174:0"
 
-#: erpnext/controllers/accounts_controller.py:2247
+#: erpnext/controllers/accounts_controller.py:2250
 msgid "Accounting Entry for {0}: {1} can only be made in currency: {2}"
 msgstr "crwdns63176:0{0}crwdnd63176:0{1}crwdnd63176:0{2}crwdne63176:0"
 
@@ -2176,7 +2172,7 @@ msgstr "crwdns63278:0crwdne63278:0"
 msgid "Accumulated Monthly"
 msgstr "crwdns63280:0crwdne63280:0"
 
-#: erpnext/controllers/budget_controller.py:417
+#: erpnext/controllers/budget_controller.py:422
 msgid "Accumulated Monthly Budget for Account {0} against {1} {2} is {3}. It will be collectively ({4}) exceeded by {5}"
 msgstr "crwdns155130:0{0}crwdnd155130:0{1}crwdnd155130:0{2}crwdnd155130:0{3}crwdnd155130:0{4}crwdnd155130:0{5}crwdne155130:0"
 
@@ -3290,7 +3286,7 @@ msgstr "crwdns63812:0crwdne63812:0"
 msgid "Adjustment Against"
 msgstr "crwdns63814:0crwdne63814:0"
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:634
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:643
 msgid "Adjustment based on Purchase Invoice rate"
 msgstr "crwdns63816:0crwdne63816:0"
 
@@ -3401,7 +3397,7 @@ msgstr "crwdns63848:0crwdne63848:0"
 msgid "Advance amount"
 msgstr "crwdns132432:0crwdne132432:0"
 
-#: erpnext/controllers/taxes_and_totals.py:845
+#: erpnext/controllers/taxes_and_totals.py:855
 msgid "Advance amount cannot be greater than {0} {1}"
 msgstr "crwdns63854:0{0}crwdnd63854:0{1}crwdne63854:0"
 
@@ -3612,7 +3608,7 @@ msgstr "crwdns63942:0crwdne63942:0"
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:152
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:133
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1125
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1127
 msgid "Age (Days)"
 msgstr "crwdns63944:0crwdne63944:0"
 
@@ -3698,16 +3694,6 @@ msgstr "crwdns111608:0crwdne111608:0"
 #: erpnext/setup/setup_wizard/data/industry_type.txt:4
 msgid "Agriculture"
 msgstr "crwdns143334:0crwdne143334:0"
-
-#. Name of a role
-#: erpnext/assets/doctype/location/location.json
-msgid "Agriculture Manager"
-msgstr "crwdns63980:0crwdne63980:0"
-
-#. Name of a role
-#: erpnext/assets/doctype/location/location.json
-msgid "Agriculture User"
-msgstr "crwdns63982:0crwdne63982:0"
 
 #: erpnext/setup/setup_wizard/data/industry_type.txt:5
 msgid "Airline"
@@ -3899,7 +3885,7 @@ msgstr "crwdns64036:0crwdne64036:0"
 msgid "All items are already requested"
 msgstr "crwdns152148:0crwdne152148:0"
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:1317
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:1326
 msgid "All items have already been Invoiced/Returned"
 msgstr "crwdns64038:0crwdne64038:0"
 
@@ -3911,7 +3897,7 @@ msgstr "crwdns112194:0crwdne112194:0"
 msgid "All items have already been transferred for this Work Order."
 msgstr "crwdns64040:0crwdne64040:0"
 
-#: erpnext/public/js/controllers/transaction.js:2465
+#: erpnext/public/js/controllers/transaction.js:2491
 msgid "All items in this document already have a linked Quality Inspection."
 msgstr "crwdns64042:0crwdne64042:0"
 
@@ -4109,7 +4095,7 @@ msgstr "crwdns142934:0crwdne142934:0"
 msgid "Allow Item To Be Added Multiple Times in a Transaction"
 msgstr "crwdns132524:0crwdne132524:0"
 
-#: erpnext/controllers/selling_controller.py:755
+#: erpnext/controllers/selling_controller.py:763
 msgid "Allow Item to Be Added Multiple Times in a Transaction"
 msgstr "crwdns143338:0crwdne143338:0"
 
@@ -5055,7 +5041,7 @@ msgstr "crwdns64592:0crwdne64592:0"
 msgid "Annual Billing: {0}"
 msgstr "crwdns64594:0{0}crwdne64594:0"
 
-#: erpnext/controllers/budget_controller.py:441
+#: erpnext/controllers/budget_controller.py:446
 msgid "Annual Budget for Account {0} against {1} {2} is {3}. It will be collectively ({4}) exceeded by {5}"
 msgstr "crwdns155140:0{0}crwdnd155140:0{1}crwdnd155140:0{2}crwdnd155140:0{3}crwdnd155140:0{4}crwdnd155140:0{5}crwdne155140:0"
 
@@ -5544,7 +5530,7 @@ msgstr "crwdns64800:0{0}crwdnd64800:0{1}crwdne64800:0"
 msgid "As the field {0} is enabled, the value of the field {1} should be more than 1."
 msgstr "crwdns64802:0{0}crwdnd64802:0{1}crwdne64802:0"
 
-#: erpnext/stock/doctype/item/item.py:989
+#: erpnext/stock/doctype/item/item.py:983
 msgid "As there are existing submitted transactions against item {0}, you can not change the value of {1}."
 msgstr "crwdns64804:0{0}crwdnd64804:0{1}crwdne64804:0"
 
@@ -5690,7 +5676,7 @@ msgstr "crwdns64880:0crwdne64880:0"
 msgid "Asset Category Name"
 msgstr "crwdns132708:0crwdne132708:0"
 
-#: erpnext/stock/doctype/item/item.py:304
+#: erpnext/stock/doctype/item/item.py:307
 msgid "Asset Category is mandatory for Fixed Asset item"
 msgstr "crwdns64884:0crwdne64884:0"
 
@@ -6065,7 +6051,7 @@ msgstr "crwdns65068:0{0}crwdne65068:0"
 msgid "Asset {0} must be submitted"
 msgstr "crwdns65070:0{0}crwdne65070:0"
 
-#: erpnext/controllers/buying_controller.py:851
+#: erpnext/controllers/buying_controller.py:859
 msgid "Asset {assets_link} created for {item_code}"
 msgstr "crwdns154226:0{assets_link}crwdnd154226:0{item_code}crwdne154226:0"
 
@@ -6095,11 +6081,11 @@ msgstr "crwdns65076:0{0}crwdne65076:0"
 msgid "Assets"
 msgstr "crwdns65078:0crwdne65078:0"
 
-#: erpnext/controllers/buying_controller.py:869
+#: erpnext/controllers/buying_controller.py:877
 msgid "Assets not created for {item_code}. You will have to create asset manually."
 msgstr "crwdns154228:0{item_code}crwdne154228:0"
 
-#: erpnext/controllers/buying_controller.py:856
+#: erpnext/controllers/buying_controller.py:864
 msgid "Assets {assets_link} created for {item_code}"
 msgstr "crwdns154230:0{assets_link}crwdnd154230:0{item_code}crwdne154230:0"
 
@@ -6194,7 +6180,7 @@ msgstr "crwdns65110:0#{0}crwdnd65110:0{1}crwdnd65110:0{2}crwdne65110:0"
 msgid "At row #{0}: you have selected the Difference Account {1}, which is a Cost of Goods Sold type account. Please select a different account"
 msgstr "crwdns154856:0#{0}crwdnd154856:0{1}crwdne154856:0"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:864
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:865
 msgid "At row {0}: Batch No is mandatory for Item {1}"
 msgstr "crwdns65112:0{0}crwdnd65112:0{1}crwdne65112:0"
 
@@ -6202,11 +6188,11 @@ msgstr "crwdns65112:0{0}crwdnd65112:0{1}crwdne65112:0"
 msgid "At row {0}: Parent Row No cannot be set for item {1}"
 msgstr "crwdns132736:0{0}crwdnd132736:0{1}crwdne132736:0"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:849
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:850
 msgid "At row {0}: Qty is mandatory for the batch {1}"
 msgstr "crwdns127452:0{0}crwdnd127452:0{1}crwdne127452:0"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:856
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:857
 msgid "At row {0}: Serial No is mandatory for Item {1}"
 msgstr "crwdns65114:0{0}crwdnd65114:0{1}crwdne65114:0"
 
@@ -6280,7 +6266,7 @@ msgstr "crwdns132752:0crwdne132752:0"
 msgid "Attribute Value"
 msgstr "crwdns132754:0crwdne132754:0"
 
-#: erpnext/stock/doctype/item/item.py:930
+#: erpnext/stock/doctype/item/item.py:924
 msgid "Attribute table is mandatory"
 msgstr "crwdns65150:0crwdne65150:0"
 
@@ -6288,11 +6274,11 @@ msgstr "crwdns65150:0crwdne65150:0"
 msgid "Attribute value: {0} must appear only once"
 msgstr "crwdns65152:0{0}crwdne65152:0"
 
-#: erpnext/stock/doctype/item/item.py:934
+#: erpnext/stock/doctype/item/item.py:928
 msgid "Attribute {0} selected multiple times in Attributes Table"
 msgstr "crwdns65154:0{0}crwdne65154:0"
 
-#: erpnext/stock/doctype/item/item.py:862
+#: erpnext/stock/doctype/item/item.py:856
 msgid "Attributes"
 msgstr "crwdns65156:0crwdne65156:0"
 
@@ -7576,11 +7562,11 @@ msgstr "crwdns65708:0crwdne65708:0"
 msgid "Barcode Type"
 msgstr "crwdns132922:0crwdne132922:0"
 
-#: erpnext/stock/doctype/item/item.py:457
+#: erpnext/stock/doctype/item/item.py:460
 msgid "Barcode {0} already used in Item {1}"
 msgstr "crwdns65728:0{0}crwdnd65728:0{1}crwdne65728:0"
 
-#: erpnext/stock/doctype/item/item.py:472
+#: erpnext/stock/doctype/item/item.py:475
 msgid "Barcode {0} is not a valid {1} code"
 msgstr "crwdns65730:0{0}crwdnd65730:0{1}crwdne65730:0"
 
@@ -7834,7 +7820,7 @@ msgstr "crwdns65808:0crwdne65808:0"
 #: erpnext/manufacturing/doctype/job_card/job_card.json
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.js:89
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.py:115
-#: erpnext/public/js/controllers/transaction.js:2388
+#: erpnext/public/js/controllers/transaction.js:2414
 #: erpnext/public/js/utils/barcode_scanner.js:260
 #: erpnext/public/js/utils/serial_no_batch_selector.js:438
 #: erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
@@ -7861,11 +7847,11 @@ msgstr "crwdns65808:0crwdne65808:0"
 msgid "Batch No"
 msgstr "crwdns65810:0crwdne65810:0"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:867
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:868
 msgid "Batch No is mandatory"
 msgstr "crwdns65852:0crwdne65852:0"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2629
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2630
 msgid "Batch No {0} does not exists"
 msgstr "crwdns104540:0{0}crwdne104540:0"
 
@@ -7873,7 +7859,7 @@ msgstr "crwdns104540:0{0}crwdne104540:0"
 msgid "Batch No {0} is linked with Item {1} which has serial no. Please scan serial no instead."
 msgstr "crwdns65854:0{0}crwdnd65854:0{1}crwdne65854:0"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:364
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:365
 msgid "Batch No {0} is not present in the original {1} {2}, hence you can't return it against the {1} {2}"
 msgstr "crwdns151934:0{0}crwdnd151934:0{1}crwdnd151934:0{2}crwdnd151934:0{1}crwdnd151934:0{2}crwdne151934:0"
 
@@ -7888,11 +7874,11 @@ msgstr "crwdns132966:0crwdne132966:0"
 msgid "Batch Nos"
 msgstr "crwdns65858:0crwdne65858:0"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1421
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1422
 msgid "Batch Nos are created successfully"
 msgstr "crwdns65860:0crwdne65860:0"
 
-#: erpnext/controllers/sales_and_purchase_return.py:1096
+#: erpnext/controllers/sales_and_purchase_return.py:1001
 msgid "Batch Not Available for Return"
 msgstr "crwdns132968:0crwdne132968:0"
 
@@ -7941,7 +7927,7 @@ msgstr "crwdns65882:0crwdne65882:0"
 msgid "Batch {0} and Warehouse"
 msgstr "crwdns65884:0{0}crwdne65884:0"
 
-#: erpnext/controllers/sales_and_purchase_return.py:1095
+#: erpnext/controllers/sales_and_purchase_return.py:1000
 msgid "Batch {0} is not available in warehouse {1}"
 msgstr "crwdns132978:0{0}crwdnd132978:0{1}crwdne132978:0"
 
@@ -7991,7 +7977,7 @@ msgstr "crwdns104542:0{0}crwdne104542:0"
 #. Label of the bill_date (Date) field in DocType 'Journal Entry'
 #. Label of the bill_date (Date) field in DocType 'Subcontracting Receipt'
 #: erpnext/accounts/doctype/journal_entry/journal_entry.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1110
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1112
 #: erpnext/accounts/report/purchase_register/purchase_register.py:214
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.json
 msgid "Bill Date"
@@ -8000,7 +7986,7 @@ msgstr "crwdns65900:0crwdne65900:0"
 #. Label of the bill_no (Data) field in DocType 'Journal Entry'
 #. Label of the bill_no (Data) field in DocType 'Subcontracting Receipt'
 #: erpnext/accounts/doctype/journal_entry/journal_entry.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1109
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1111
 #: erpnext/accounts/report/purchase_register/purchase_register.py:213
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.json
 msgid "Bill No"
@@ -8220,7 +8206,7 @@ msgstr "crwdns66006:0crwdne66006:0"
 msgid "Billing Zipcode"
 msgstr "crwdns133018:0crwdne133018:0"
 
-#: erpnext/accounts/party.py:602
+#: erpnext/accounts/party.py:608
 msgid "Billing currency must be equal to either default company's currency or party account currency"
 msgstr "crwdns66012:0crwdne66012:0"
 
@@ -9217,7 +9203,7 @@ msgid "Can only make payment against unbilled {0}"
 msgstr "crwdns66406:0{0}crwdne66406:0"
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1458
-#: erpnext/controllers/accounts_controller.py:2946
+#: erpnext/controllers/accounts_controller.py:2949
 #: erpnext/public/js/controllers/accounts.js:90
 msgid "Can refer row only if the charge type is 'On Previous Row Amount' or 'Previous Row Total'"
 msgstr "crwdns66408:0crwdne66408:0"
@@ -9379,9 +9365,9 @@ msgstr "crwdns66520:0crwdne66520:0"
 msgid "Cannot Create Return"
 msgstr "crwdns154636:0crwdne154636:0"
 
-#: erpnext/stock/doctype/item/item.py:625
-#: erpnext/stock/doctype/item/item.py:638
-#: erpnext/stock/doctype/item/item.py:652
+#: erpnext/stock/doctype/item/item.py:631
+#: erpnext/stock/doctype/item/item.py:644
+#: erpnext/stock/doctype/item/item.py:658
 msgid "Cannot Merge"
 msgstr "crwdns66522:0crwdne66522:0"
 
@@ -9405,7 +9391,7 @@ msgstr "crwdns66530:0{0}crwdnd66530:0{1}crwdne66530:0"
 msgid "Cannot apply TDS against multiple parties in one entry"
 msgstr "crwdns66532:0crwdne66532:0"
 
-#: erpnext/stock/doctype/item/item.py:307
+#: erpnext/stock/doctype/item/item.py:310
 msgid "Cannot be a fixed asset item as Stock Ledger is created."
 msgstr "crwdns66534:0crwdne66534:0"
 
@@ -9421,7 +9407,7 @@ msgstr "crwdns66540:0{0}crwdne66540:0"
 msgid "Cannot cancel the transaction. Reposting of item valuation on submission is not completed yet."
 msgstr "crwdns66542:0crwdne66542:0"
 
-#: erpnext/controllers/buying_controller.py:959
+#: erpnext/controllers/buying_controller.py:967
 msgid "Cannot cancel this document as it is linked with the submitted asset {asset_link}. Please cancel the asset to continue."
 msgstr "crwdns154236:0{asset_link}crwdne154236:0"
 
@@ -9429,7 +9415,7 @@ msgstr "crwdns154236:0{asset_link}crwdne154236:0"
 msgid "Cannot cancel transaction for Completed Work Order."
 msgstr "crwdns66546:0crwdne66546:0"
 
-#: erpnext/stock/doctype/item/item.py:882
+#: erpnext/stock/doctype/item/item.py:876
 msgid "Cannot change Attributes after stock transaction. Make a new Item and transfer stock to the new Item"
 msgstr "crwdns66548:0crwdne66548:0"
 
@@ -9445,7 +9431,7 @@ msgstr "crwdns66552:0crwdne66552:0"
 msgid "Cannot change Service Stop Date for item in row {0}"
 msgstr "crwdns66554:0{0}crwdne66554:0"
 
-#: erpnext/stock/doctype/item/item.py:873
+#: erpnext/stock/doctype/item/item.py:867
 msgid "Cannot change Variant properties after stock transaction. You will have to make a new Item to do this."
 msgstr "crwdns66556:0crwdne66556:0"
 
@@ -9473,7 +9459,7 @@ msgstr "crwdns66566:0crwdne66566:0"
 msgid "Cannot covert to Group because Account Type is selected."
 msgstr "crwdns66568:0crwdne66568:0"
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:972
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:981
 msgid "Cannot create Stock Reservation Entries for future dated Purchase Receipts."
 msgstr "crwdns66570:0crwdne66570:0"
 
@@ -9524,7 +9510,7 @@ msgstr "crwdns66586:0{0}crwdne66586:0"
 msgid "Cannot find Item with this Barcode"
 msgstr "crwdns66588:0crwdne66588:0"
 
-#: erpnext/controllers/accounts_controller.py:3483
+#: erpnext/controllers/accounts_controller.py:3486
 msgid "Cannot find a default warehouse for item {0}. Please set one in the Item Master or in Stock Settings."
 msgstr "crwdns143360:0{0}crwdne143360:0"
 
@@ -9532,7 +9518,7 @@ msgstr "crwdns143360:0{0}crwdne143360:0"
 msgid "Cannot make any transactions until the deletion job is completed"
 msgstr "crwdns111642:0crwdne111642:0"
 
-#: erpnext/controllers/accounts_controller.py:2074
+#: erpnext/controllers/accounts_controller.py:2077
 msgid "Cannot overbill for Item {0} in row {1} more than {2}. To allow over-billing, please set allowance in Accounts Settings"
 msgstr "crwdns66592:0{0}crwdnd66592:0{1}crwdnd66592:0{2}crwdne66592:0"
 
@@ -9553,7 +9539,7 @@ msgid "Cannot receive from customer against negative outstanding"
 msgstr "crwdns66600:0crwdne66600:0"
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1475
-#: erpnext/controllers/accounts_controller.py:2961
+#: erpnext/controllers/accounts_controller.py:2964
 #: erpnext/public/js/controllers/accounts.js:100
 msgid "Cannot refer row number greater than or equal to current row number for this Charge type"
 msgstr "crwdns66602:0crwdne66602:0"
@@ -9569,7 +9555,7 @@ msgstr "crwdns66606:0crwdne66606:0"
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1467
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1646
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:1917
-#: erpnext/controllers/accounts_controller.py:2951
+#: erpnext/controllers/accounts_controller.py:2954
 #: erpnext/public/js/controllers/accounts.js:94
 #: erpnext/public/js/controllers/taxes_and_totals.js:470
 msgid "Cannot select charge type as 'On Previous Row Amount' or 'On Previous Row Total' for first row"
@@ -9583,15 +9569,15 @@ msgstr "crwdns66610:0crwdne66610:0"
 msgid "Cannot set authorization on basis of Discount for {0}"
 msgstr "crwdns66612:0{0}crwdne66612:0"
 
-#: erpnext/stock/doctype/item/item.py:716
+#: erpnext/stock/doctype/item/item.py:722
 msgid "Cannot set multiple Item Defaults for a company."
 msgstr "crwdns66614:0crwdne66614:0"
 
-#: erpnext/controllers/accounts_controller.py:3631
+#: erpnext/controllers/accounts_controller.py:3634
 msgid "Cannot set quantity less than delivered quantity"
 msgstr "crwdns66616:0crwdne66616:0"
 
-#: erpnext/controllers/accounts_controller.py:3634
+#: erpnext/controllers/accounts_controller.py:3637
 msgid "Cannot set quantity less than received quantity"
 msgstr "crwdns66618:0crwdne66618:0"
 
@@ -10014,7 +10000,7 @@ msgid "Channel Partner"
 msgstr "crwdns133188:0crwdne133188:0"
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:2346
-#: erpnext/controllers/accounts_controller.py:3014
+#: erpnext/controllers/accounts_controller.py:3017
 msgid "Charge of type 'Actual' in row {0} cannot be included in Item Rate or Paid Amount"
 msgstr "crwdns66766:0{0}crwdne66766:0"
 
@@ -10197,7 +10183,7 @@ msgstr "crwdns133228:0crwdne133228:0"
 
 #. Label of the reference_date (Date) field in DocType 'Payment Entry'
 #: erpnext/accounts/doctype/payment_entry/payment_entry.json
-#: erpnext/public/js/controllers/transaction.js:2299
+#: erpnext/public/js/controllers/transaction.js:2325
 msgid "Cheque/Reference Date"
 msgstr "crwdns66844:0crwdne66844:0"
 
@@ -10245,7 +10231,7 @@ msgstr "crwdns133230:0crwdne133230:0"
 
 #. Label of the child_row_reference (Data) field in DocType 'Quality
 #. Inspection'
-#: erpnext/public/js/controllers/transaction.js:2394
+#: erpnext/public/js/controllers/transaction.js:2420
 #: erpnext/stock/doctype/quality_inspection/quality_inspection.json
 msgid "Child Row Reference"
 msgstr "crwdns152086:0crwdne152086:0"
@@ -10957,7 +10943,7 @@ msgstr "crwdns133292:0crwdne133292:0"
 #: erpnext/accounts/report/cheques_and_deposits_incorrectly_cleared/cheques_and_deposits_incorrectly_cleared.js:8
 #: erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.js:8
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:8
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:49
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:50
 #: erpnext/accounts/report/deferred_revenue_and_expense/deferred_revenue_and_expense.js:8
 #: erpnext/accounts/report/delivered_items_to_be_billed/delivered_items_to_be_billed.js:7
 #: erpnext/accounts/report/dimension_wise_accounts_balance_report/dimension_wise_accounts_balance_report.js:8
@@ -12190,7 +12176,7 @@ msgid "Content Type"
 msgstr "crwdns133428:0crwdne133428:0"
 
 #: erpnext/erpnext_integrations/doctype/plaid_settings/plaid_settings.js:162
-#: erpnext/public/js/controllers/transaction.js:2312
+#: erpnext/public/js/controllers/transaction.js:2338
 #: erpnext/selling/doctype/quotation/quotation.js:356
 msgid "Continue"
 msgstr "crwdns67902:0crwdne67902:0"
@@ -12355,7 +12341,7 @@ msgstr "crwdns67944:0crwdne67944:0"
 msgid "Conversion Rate"
 msgstr "crwdns67978:0crwdne67978:0"
 
-#: erpnext/stock/doctype/item/item.py:393
+#: erpnext/stock/doctype/item/item.py:396
 msgid "Conversion factor for default Unit of Measure must be 1 in row {0}"
 msgstr "crwdns67986:0{0}crwdne67986:0"
 
@@ -12363,15 +12349,15 @@ msgstr "crwdns67986:0{0}crwdne67986:0"
 msgid "Conversion factor for item {0} has been reset to 1.0 as the uom {1} is same as stock uom {2}."
 msgstr "crwdns149164:0{0}crwdnd149164:0{1}crwdnd149164:0{2}crwdne149164:0"
 
-#: erpnext/controllers/accounts_controller.py:2767
+#: erpnext/controllers/accounts_controller.py:2770
 msgid "Conversion rate cannot be 0"
 msgstr "crwdns154377:0crwdne154377:0"
 
-#: erpnext/controllers/accounts_controller.py:2774
+#: erpnext/controllers/accounts_controller.py:2777
 msgid "Conversion rate is 1.00, but document currency is different from company currency"
 msgstr "crwdns154379:0crwdne154379:0"
 
-#: erpnext/controllers/accounts_controller.py:2770
+#: erpnext/controllers/accounts_controller.py:2773
 msgid "Conversion rate must be 1.00 if document currency is same as company currency"
 msgstr "crwdns154381:0crwdne154381:0"
 
@@ -12584,7 +12570,7 @@ msgstr "crwdns133466:0crwdne133466:0"
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:28
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:40
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:30
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1096
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1098
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:40
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.js:42
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.py:197
@@ -12677,7 +12663,7 @@ msgid "Cost Center is a part of Cost Center Allocation, hence cannot be converte
 msgstr "crwdns68164:0crwdne68164:0"
 
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py:1411
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:855
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:864
 msgid "Cost Center is required in row {0} in Taxes table for type {1}"
 msgstr "crwdns68166:0{0}crwdnd68166:0{1}crwdne68166:0"
 
@@ -12946,8 +12932,8 @@ msgstr "crwdns68298:0crwdne68298:0"
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:132
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:143
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:219
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:654
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:678
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:656
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:680
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.js:88
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.js:89
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.js:103
@@ -13004,8 +12990,8 @@ msgstr "crwdns68298:0crwdne68298:0"
 #: erpnext/projects/doctype/task/task_tree.js:81
 #: erpnext/public/js/communication.js:19 erpnext/public/js/communication.js:31
 #: erpnext/public/js/communication.js:41
-#: erpnext/public/js/controllers/transaction.js:336
-#: erpnext/public/js/controllers/transaction.js:2435
+#: erpnext/public/js/controllers/transaction.js:362
+#: erpnext/public/js/controllers/transaction.js:2461
 #: erpnext/selling/doctype/customer/customer.js:181
 #: erpnext/selling/doctype/quotation/quotation.js:124
 #: erpnext/selling/doctype/quotation/quotation.js:133
@@ -13300,7 +13286,7 @@ msgstr "crwdns133514:0crwdne133514:0"
 msgid "Create a variant with the template image."
 msgstr "crwdns142938:0crwdne142938:0"
 
-#: erpnext/stock/stock_ledger.py:1877
+#: erpnext/stock/stock_ledger.py:1886
 msgid "Create an incoming stock transaction for the Item."
 msgstr "crwdns68438:0crwdne68438:0"
 
@@ -13360,7 +13346,7 @@ msgstr "crwdns148770:0crwdne148770:0"
 msgid "Creating Purchase Order ..."
 msgstr "crwdns68472:0crwdne68472:0"
 
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:735
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:737
 #: erpnext/buying/doctype/purchase_order/purchase_order.js:552
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.js:73
 msgid "Creating Purchase Receipt ..."
@@ -13554,7 +13540,7 @@ msgstr "crwdns133536:0crwdne133536:0"
 #: erpnext/accounts/doctype/journal_entry_template/journal_entry_template.json
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:174
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:147
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1119
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1121
 #: erpnext/controllers/sales_and_purchase_return.py:373
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:286
 #: erpnext/stock/doctype/delivery_note/delivery_note.js:89
@@ -13589,7 +13575,7 @@ msgstr "crwdns68574:0{0}crwdne68574:0"
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py:368
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py:376
-#: erpnext/controllers/accounts_controller.py:2186
+#: erpnext/controllers/accounts_controller.py:2189
 msgid "Credit To"
 msgstr "crwdns133540:0crwdne133540:0"
 
@@ -13774,7 +13760,7 @@ msgstr "crwdns112294:0crwdne112294:0"
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/subscription_plan/subscription_plan.json
 #: erpnext/accounts/report/account_balance/account_balance.py:28
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1129
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1131
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:205
 #: erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.py:101
 #: erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.js:118
@@ -14303,7 +14289,7 @@ msgstr "crwdns133616:0crwdne133616:0"
 #. Label of the customer_contact_display (Small Text) field in DocType
 #. 'Purchase Order'
 #. Label of the customer_contact (Small Text) field in DocType 'Delivery Stop'
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1090
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1092
 #: erpnext/buying/doctype/purchase_order/purchase_order.json
 #: erpnext/stock/doctype/delivery_stop/delivery_stop.json
 msgid "Customer Contact"
@@ -14399,7 +14385,7 @@ msgstr "crwdns133624:0crwdne133624:0"
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/tax_rule/tax_rule.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:107
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1147
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1149
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:81
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:185
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:56
@@ -14443,7 +14429,7 @@ msgstr "crwdns68980:0crwdne68980:0"
 msgid "Customer Group Name"
 msgstr "crwdns133626:0crwdne133626:0"
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1239
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1241
 msgid "Customer Group: {0} does not exist"
 msgstr "crwdns68984:0{0}crwdne68984:0"
 
@@ -14462,7 +14448,7 @@ msgstr "crwdns68988:0crwdne68988:0"
 msgid "Customer Items"
 msgstr "crwdns133630:0crwdne133630:0"
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1138
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1140
 msgid "Customer LPO"
 msgstr "crwdns68992:0crwdne68992:0"
 
@@ -14508,7 +14494,7 @@ msgstr "crwdns133632:0crwdne133632:0"
 #: erpnext/accounts/doctype/pos_invoice/pos_invoice.json
 #: erpnext/accounts/doctype/process_statement_of_accounts_customer/process_statement_of_accounts_customer.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1080
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1082
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:156
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:92
 #: erpnext/accounts/report/delivered_items_to_be_billed/delivered_items_to_be_billed.py:35
@@ -15186,7 +15172,7 @@ msgstr "crwdns133722:0crwdne133722:0"
 #: erpnext/accounts/doctype/journal_entry_template/journal_entry_template.json
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:176
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:147
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1122
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1124
 #: erpnext/controllers/sales_and_purchase_return.py:377
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:287
 #: erpnext/stock/doctype/purchase_receipt/purchase_receipt.js:61
@@ -15215,7 +15201,7 @@ msgstr "crwdns152206:0crwdne152206:0"
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:953
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:964
-#: erpnext/controllers/accounts_controller.py:2186
+#: erpnext/controllers/accounts_controller.py:2189
 msgid "Debit To"
 msgstr "crwdns133728:0crwdne133728:0"
 
@@ -15248,11 +15234,11 @@ msgstr "crwdns133734:0crwdne133734:0"
 msgid "Debit-Credit mismatch"
 msgstr "crwdns133736:0crwdne133736:0"
 
-#: erpnext/accounts/party.py:609
+#: erpnext/accounts/party.py:615
 msgid "Debtor/Creditor"
 msgstr "crwdns149084:0crwdne149084:0"
 
-#: erpnext/accounts/party.py:612
+#: erpnext/accounts/party.py:618
 msgid "Debtor/Creditor Advance"
 msgstr "crwdns149086:0crwdne149086:0"
 
@@ -15372,7 +15358,7 @@ msgstr "crwdns133758:0crwdne133758:0"
 msgid "Default BOM"
 msgstr "crwdns133760:0crwdne133760:0"
 
-#: erpnext/stock/doctype/item/item.py:418
+#: erpnext/stock/doctype/item/item.py:421
 msgid "Default BOM ({0}) must be active for this item or its template"
 msgstr "crwdns69414:0{0}crwdne69414:0"
 
@@ -15380,7 +15366,7 @@ msgstr "crwdns69414:0{0}crwdne69414:0"
 msgid "Default BOM for {0} not found"
 msgstr "crwdns69416:0{0}crwdne69416:0"
 
-#: erpnext/controllers/accounts_controller.py:3672
+#: erpnext/controllers/accounts_controller.py:3675
 msgid "Default BOM not found for FG Item {0}"
 msgstr "crwdns69418:0{0}crwdne69418:0"
 
@@ -15715,15 +15701,15 @@ msgstr "crwdns133868:0crwdne133868:0"
 msgid "Default Unit of Measure"
 msgstr "crwdns133872:0crwdne133872:0"
 
-#: erpnext/stock/doctype/item/item.py:1272
+#: erpnext/stock/doctype/item/item.py:1266
 msgid "Default Unit of Measure for Item {0} cannot be changed directly because you have already made some transaction(s) with another UOM. You need to either cancel the linked documents or create a new Item."
 msgstr "crwdns69574:0{0}crwdne69574:0"
 
-#: erpnext/stock/doctype/item/item.py:1255
+#: erpnext/stock/doctype/item/item.py:1249
 msgid "Default Unit of Measure for Item {0} cannot be changed directly because you have already made some transaction(s) with another UOM. You will need to create a new Item to use a different Default UOM."
 msgstr "crwdns69576:0{0}crwdne69576:0"
 
-#: erpnext/stock/doctype/item/item.py:908
+#: erpnext/stock/doctype/item/item.py:902
 msgid "Default Unit of Measure for Variant '{0}' must be same as in Template '{1}'"
 msgstr "crwdns69578:0{0}crwdnd69578:0{1}crwdne69578:0"
 
@@ -16182,7 +16168,7 @@ msgstr "crwdns69774:0crwdne69774:0"
 msgid "Delivery Note {0} is not submitted"
 msgstr "crwdns69776:0{0}crwdne69776:0"
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1142
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1144
 #: erpnext/stock/doctype/delivery_trip/delivery_trip.js:73
 msgid "Delivery Notes"
 msgstr "crwdns69780:0crwdne69780:0"
@@ -16713,7 +16699,7 @@ msgstr "crwdns154183:0crwdne154183:0"
 #: erpnext/projects/doctype/task_type/task_type.json
 #: erpnext/projects/doctype/timesheet_detail/timesheet_detail.json
 #: erpnext/public/js/bank_reconciliation_tool/data_table_manager.js:55
-#: erpnext/public/js/controllers/transaction.js:2376
+#: erpnext/public/js/controllers/transaction.js:2402
 #: erpnext/selling/doctype/installation_note_item/installation_note_item.json
 #: erpnext/selling/doctype/product_bundle/product_bundle.json
 #: erpnext/selling/doctype/product_bundle_item/product_bundle_item.json
@@ -16901,7 +16887,7 @@ msgstr "crwdns154878:0crwdne154878:0"
 msgid "Difference Account must be a Asset/Liability type account (Temporary Opening), since this Stock Entry is an Opening Entry"
 msgstr "crwdns154766:0crwdne154766:0"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:954
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:950
 msgid "Difference Account must be a Asset/Liability type account, since this Stock Reconciliation is an Opening Entry"
 msgstr "crwdns70160:0crwdne70160:0"
 
@@ -17167,11 +17153,11 @@ msgstr "crwdns70302:0crwdne70302:0"
 msgid "Disabled Warehouse {0} cannot be used for this transaction."
 msgstr "crwdns70304:0{0}crwdne70304:0"
 
-#: erpnext/controllers/accounts_controller.py:745
+#: erpnext/controllers/accounts_controller.py:748
 msgid "Disabled pricing rules since this {} is an internal transfer"
 msgstr "crwdns70306:0crwdne70306:0"
 
-#: erpnext/controllers/accounts_controller.py:759
+#: erpnext/controllers/accounts_controller.py:762
 msgid "Disabled tax included prices since this {} is an internal transfer"
 msgstr "crwdns70308:0crwdne70308:0"
 
@@ -18113,7 +18099,7 @@ msgstr "crwdns134118:0crwdne134118:0"
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.json
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/print_format/sales_invoice_print/sales_invoice_print.html:72
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1106
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1108
 #: erpnext/assets/doctype/asset_maintenance_log/asset_maintenance_log.json
 #: erpnext/selling/report/payment_terms_status_for_sales_order/payment_terms_status_for_sales_order.py:40
 msgid "Due Date"
@@ -18127,11 +18113,11 @@ msgstr "crwdns70714:0crwdne70714:0"
 msgid "Due Date Based On"
 msgstr "crwdns134120:0crwdne134120:0"
 
-#: erpnext/accounts/party.py:695
+#: erpnext/accounts/party.py:701
 msgid "Due Date cannot be after {0}"
 msgstr "crwdns152150:0{0}crwdne152150:0"
 
-#: erpnext/accounts/party.py:671
+#: erpnext/accounts/party.py:677
 msgid "Due Date cannot be before {0}"
 msgstr "crwdns152152:0{0}crwdne152152:0"
 
@@ -18849,7 +18835,7 @@ msgstr "crwdns134200:0crwdne134200:0"
 msgid "Enable Auto Email"
 msgstr "crwdns134202:0crwdne134202:0"
 
-#: erpnext/stock/doctype/item/item.py:1064
+#: erpnext/stock/doctype/item/item.py:1058
 msgid "Enable Auto Re-Order"
 msgstr "crwdns71062:0crwdne71062:0"
 
@@ -19062,7 +19048,7 @@ msgstr "crwdns134246:0crwdne134246:0"
 msgid "End Date"
 msgstr "crwdns71120:0crwdne71120:0"
 
-#: erpnext/crm/doctype/contract/contract.py:75
+#: erpnext/crm/doctype/contract/contract.py:83
 msgid "End Date cannot be before Start Date."
 msgstr "crwdns71142:0crwdne71142:0"
 
@@ -19312,7 +19298,7 @@ msgstr "crwdns112322:0crwdne112322:0"
 #: erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.json
 #: erpnext/manufacturing/doctype/job_card/job_card.py:875
 #: erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.json
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:297
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:298
 msgid "Error"
 msgstr "crwdns71236:0crwdne71236:0"
 
@@ -19435,7 +19421,7 @@ msgstr "crwdns143418:0crwdne143418:0"
 msgid "Example URL"
 msgstr "crwdns134280:0crwdne134280:0"
 
-#: erpnext/stock/doctype/item/item.py:995
+#: erpnext/stock/doctype/item/item.py:989
 msgid "Example of a linked document: {0}"
 msgstr "crwdns71292:0{0}crwdne71292:0"
 
@@ -19450,7 +19436,7 @@ msgstr "crwdns134282:0crwdne134282:0"
 msgid "Example: ABCD.#####. If series is set and Batch No is not mentioned in transactions, then automatic batch number will be created based on this series. If you always want to explicitly mention Batch No for this item, leave this blank. Note: this setting will take priority over the Naming Series Prefix in Stock Settings."
 msgstr "crwdns134284:0crwdne134284:0"
 
-#: erpnext/stock/stock_ledger.py:2141
+#: erpnext/stock/stock_ledger.py:2149
 msgid "Example: Serial No {0} reserved in {1}."
 msgstr "crwdns71298:0{0}crwdnd71298:0{1}crwdne71298:0"
 
@@ -19504,8 +19490,8 @@ msgstr "crwdns134292:0crwdne134292:0"
 msgid "Exchange Gain/Loss"
 msgstr "crwdns71312:0crwdne71312:0"
 
-#: erpnext/controllers/accounts_controller.py:1593
-#: erpnext/controllers/accounts_controller.py:1677
+#: erpnext/controllers/accounts_controller.py:1596
+#: erpnext/controllers/accounts_controller.py:1680
 msgid "Exchange Gain/Loss amount has been booked through {0}"
 msgstr "crwdns71320:0{0}crwdne71320:0"
 
@@ -20241,7 +20227,7 @@ msgid "Fetching Error"
 msgstr "crwdns151676:0crwdne151676:0"
 
 #: erpnext/accounts/doctype/dunning/dunning.js:135
-#: erpnext/public/js/controllers/transaction.js:1251
+#: erpnext/public/js/controllers/transaction.js:1277
 msgid "Fetching exchange rates ..."
 msgstr "crwdns71690:0crwdne71690:0"
 
@@ -20536,15 +20522,15 @@ msgstr "crwdns71814:0crwdne71814:0"
 msgid "Finished Good Item Quantity"
 msgstr "crwdns134404:0crwdne134404:0"
 
-#: erpnext/controllers/accounts_controller.py:3658
+#: erpnext/controllers/accounts_controller.py:3661
 msgid "Finished Good Item is not specified for service item {0}"
 msgstr "crwdns71818:0{0}crwdne71818:0"
 
-#: erpnext/controllers/accounts_controller.py:3675
+#: erpnext/controllers/accounts_controller.py:3678
 msgid "Finished Good Item {0} Qty can not be zero"
 msgstr "crwdns71820:0{0}crwdne71820:0"
 
-#: erpnext/controllers/accounts_controller.py:3669
+#: erpnext/controllers/accounts_controller.py:3672
 msgid "Finished Good Item {0} must be a sub-contracted item"
 msgstr "crwdns71822:0{0}crwdne71822:0"
 
@@ -20785,7 +20771,7 @@ msgstr "crwdns134438:0crwdne134438:0"
 msgid "Fixed Asset Defaults"
 msgstr "crwdns134440:0crwdne134440:0"
 
-#: erpnext/stock/doctype/item/item.py:301
+#: erpnext/stock/doctype/item/item.py:304
 msgid "Fixed Asset Item must be a non-stock item."
 msgstr "crwdns71914:0crwdne71914:0"
 
@@ -20961,7 +20947,7 @@ msgstr "crwdns71966:0crwdne71966:0"
 msgid "For Raw Materials"
 msgstr "crwdns154892:0crwdne154892:0"
 
-#: erpnext/controllers/accounts_controller.py:1259
+#: erpnext/controllers/accounts_controller.py:1262
 msgid "For Return Invoices with Stock effect, '0' qty Items are not allowed. Following rows are affected: {0}"
 msgstr "crwdns111742:0{0}crwdne111742:0"
 
@@ -21062,7 +21048,7 @@ msgstr "crwdns111744:0crwdne111744:0"
 msgid "For the item {0}, the quantity should be {1} according to the BOM {2}."
 msgstr "crwdns148782:0{0}crwdnd148782:0{1}crwdnd148782:0{2}crwdne148782:0"
 
-#: erpnext/public/js/controllers/transaction.js:1088
+#: erpnext/public/js/controllers/transaction.js:1114
 msgctxt "Clear payment terms template and/or payment schedule when due date is changed"
 msgid "For the new {0} to take effect, would you like to clear the current {1}?"
 msgstr "crwdns154502:0{0}crwdnd154502:0{1}crwdne154502:0"
@@ -21071,7 +21057,7 @@ msgstr "crwdns154502:0{0}crwdnd154502:0{1}crwdne154502:0"
 msgid "For the {0}, no stock is available for the return in the warehouse {1}."
 msgstr "crwdns134480:0{0}crwdnd134480:0{1}crwdne134480:0"
 
-#: erpnext/controllers/sales_and_purchase_return.py:1144
+#: erpnext/controllers/sales_and_purchase_return.py:1049
 msgid "For the {0}, the quantity is required to make the return entry"
 msgstr "crwdns134482:0{0}crwdne134482:0"
 
@@ -21408,7 +21394,7 @@ msgstr "crwdns72130:0crwdne72130:0"
 msgid "From Date is mandatory"
 msgstr "crwdns143442:0crwdne143442:0"
 
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:52
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:53
 #: erpnext/accounts/report/general_ledger/general_ledger.py:86
 #: erpnext/accounts/report/pos_register/pos_register.py:115
 #: erpnext/accounts/report/tax_withholding_details/tax_withholding_details.py:39
@@ -21785,14 +21771,14 @@ msgstr "crwdns72304:0crwdne72304:0"
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:186
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:155
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1134
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1136
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:177
 msgid "Future Payment Amount"
 msgstr "crwdns72306:0crwdne72306:0"
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:185
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:154
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1133
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1135
 msgid "Future Payment Ref"
 msgstr "crwdns72308:0crwdne72308:0"
 
@@ -22966,7 +22952,7 @@ msgstr "crwdns111754:0crwdne111754:0"
 msgid "Here are the error logs for the aforementioned failed depreciation entries: {0}"
 msgstr "crwdns72768:0{0}crwdne72768:0"
 
-#: erpnext/stock/stock_ledger.py:1862
+#: erpnext/stock/stock_ledger.py:1871
 msgid "Here are the options to proceed:"
 msgstr "crwdns72770:0crwdne72770:0"
 
@@ -23488,7 +23474,7 @@ msgstr "crwdns134828:0crwdne134828:0"
 msgid "If more than one package of the same type (for print)"
 msgstr "crwdns134830:0crwdne134830:0"
 
-#: erpnext/stock/stock_ledger.py:1872
+#: erpnext/stock/stock_ledger.py:1881
 msgid "If not, you can Cancel / Submit this entry"
 msgstr "crwdns72958:0crwdne72958:0"
 
@@ -23513,7 +23499,7 @@ msgstr "crwdns72964:0crwdne72964:0"
 msgid "If the account is frozen, entries are allowed to restricted users."
 msgstr "crwdns134836:0crwdne134836:0"
 
-#: erpnext/stock/stock_ledger.py:1865
+#: erpnext/stock/stock_ledger.py:1874
 msgid "If the item is transacting as a Zero Valuation Rate item in this entry, please enable 'Allow Zero Valuation Rate' in the {0} Item table."
 msgstr "crwdns72968:0{0}crwdne72968:0"
 
@@ -24511,7 +24497,7 @@ msgstr "crwdns73454:0crwdne73454:0"
 msgid "Incorrect Batch Consumed"
 msgstr "crwdns73456:0crwdne73456:0"
 
-#: erpnext/stock/doctype/item/item.py:514
+#: erpnext/stock/doctype/item/item.py:517
 msgid "Incorrect Check in (group) Warehouse for Reorder"
 msgstr "crwdns127834:0crwdne127834:0"
 
@@ -24560,7 +24546,7 @@ msgstr "crwdns152384:0crwdne152384:0"
 msgid "Incorrect Stock Value Report"
 msgstr "crwdns73470:0crwdne73470:0"
 
-#: erpnext/stock/serial_batch_bundle.py:134
+#: erpnext/stock/serial_batch_bundle.py:135
 msgid "Incorrect Type of Transaction"
 msgstr "crwdns73472:0crwdne73472:0"
 
@@ -24829,8 +24815,8 @@ msgstr "crwdns134984:0crwdne134984:0"
 msgid "Insufficient Capacity"
 msgstr "crwdns73606:0crwdne73606:0"
 
-#: erpnext/controllers/accounts_controller.py:3590
-#: erpnext/controllers/accounts_controller.py:3614
+#: erpnext/controllers/accounts_controller.py:3593
+#: erpnext/controllers/accounts_controller.py:3617
 msgid "Insufficient Permissions"
 msgstr "crwdns73608:0crwdne73608:0"
 
@@ -24838,12 +24824,12 @@ msgstr "crwdns73608:0crwdne73608:0"
 #: erpnext/stock/doctype/pick_list/pick_list.py:127
 #: erpnext/stock/doctype/pick_list/pick_list.py:975
 #: erpnext/stock/doctype/stock_entry/stock_entry.py:759
-#: erpnext/stock/serial_batch_bundle.py:989 erpnext/stock/stock_ledger.py:1559
-#: erpnext/stock/stock_ledger.py:2032
+#: erpnext/stock/serial_batch_bundle.py:1021 erpnext/stock/stock_ledger.py:1568
+#: erpnext/stock/stock_ledger.py:2040
 msgid "Insufficient Stock"
 msgstr "crwdns73610:0crwdne73610:0"
 
-#: erpnext/stock/stock_ledger.py:2047
+#: erpnext/stock/stock_ledger.py:2055
 msgid "Insufficient Stock for Batch"
 msgstr "crwdns73612:0crwdne73612:0"
 
@@ -24981,11 +24967,11 @@ msgstr "crwdns135020:0crwdne135020:0"
 msgid "Internal Customer for company {0} already exists"
 msgstr "crwdns73670:0{0}crwdne73670:0"
 
-#: erpnext/controllers/accounts_controller.py:728
+#: erpnext/controllers/accounts_controller.py:731
 msgid "Internal Sale or Delivery Reference missing."
 msgstr "crwdns73672:0crwdne73672:0"
 
-#: erpnext/controllers/accounts_controller.py:730
+#: erpnext/controllers/accounts_controller.py:733
 msgid "Internal Sales Reference Missing"
 msgstr "crwdns73674:0crwdne73674:0"
 
@@ -25016,7 +25002,7 @@ msgstr "crwdns73678:0{0}crwdne73678:0"
 msgid "Internal Transfer"
 msgstr "crwdns73680:0crwdne73680:0"
 
-#: erpnext/controllers/accounts_controller.py:739
+#: erpnext/controllers/accounts_controller.py:742
 msgid "Internal Transfer Reference Missing"
 msgstr "crwdns73692:0crwdne73692:0"
 
@@ -25059,8 +25045,8 @@ msgstr "crwdns73710:0crwdne73710:0"
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:969
 #: erpnext/assets/doctype/asset_category/asset_category.py:69
 #: erpnext/assets/doctype/asset_category/asset_category.py:97
-#: erpnext/controllers/accounts_controller.py:2975
-#: erpnext/controllers/accounts_controller.py:2983
+#: erpnext/controllers/accounts_controller.py:2978
+#: erpnext/controllers/accounts_controller.py:2986
 msgid "Invalid Account"
 msgstr "crwdns73712:0crwdne73712:0"
 
@@ -25085,7 +25071,7 @@ msgstr "crwdns73716:0crwdne73716:0"
 msgid "Invalid Barcode. There is no Item attached to this barcode."
 msgstr "crwdns73718:0crwdne73718:0"
 
-#: erpnext/public/js/controllers/transaction.js:2631
+#: erpnext/public/js/controllers/transaction.js:2657
 msgid "Invalid Blanket Order for the selected Customer and Item"
 msgstr "crwdns73720:0crwdne73720:0"
 
@@ -25099,7 +25085,7 @@ msgstr "crwdns73724:0crwdne73724:0"
 
 #: erpnext/assets/doctype/asset/asset.py:295
 #: erpnext/assets/doctype/asset/asset.py:302
-#: erpnext/controllers/accounts_controller.py:2998
+#: erpnext/controllers/accounts_controller.py:3001
 msgid "Invalid Cost Center"
 msgstr "crwdns73726:0crwdne73726:0"
 
@@ -25141,7 +25127,7 @@ msgstr "crwdns73740:0crwdne73740:0"
 msgid "Invalid Item"
 msgstr "crwdns73742:0crwdne73742:0"
 
-#: erpnext/stock/doctype/item/item.py:1410
+#: erpnext/stock/doctype/item/item.py:1404
 msgid "Invalid Item Defaults"
 msgstr "crwdns73744:0crwdne73744:0"
 
@@ -25187,11 +25173,11 @@ msgstr "crwdns73760:0crwdne73760:0"
 msgid "Invalid Purchase Invoice"
 msgstr "crwdns73762:0crwdne73762:0"
 
-#: erpnext/controllers/accounts_controller.py:3627
+#: erpnext/controllers/accounts_controller.py:3630
 msgid "Invalid Qty"
 msgstr "crwdns73764:0crwdne73764:0"
 
-#: erpnext/controllers/accounts_controller.py:1277
+#: erpnext/controllers/accounts_controller.py:1280
 msgid "Invalid Quantity"
 msgstr "crwdns73766:0crwdne73766:0"
 
@@ -25208,7 +25194,7 @@ msgstr "crwdns154646:0crwdne154646:0"
 msgid "Invalid Schedule"
 msgstr "crwdns73768:0crwdne73768:0"
 
-#: erpnext/controllers/selling_controller.py:243
+#: erpnext/controllers/selling_controller.py:251
 msgid "Invalid Selling Price"
 msgstr "crwdns73770:0crwdne73770:0"
 
@@ -25241,7 +25227,7 @@ msgstr "crwdns73778:0crwdne73778:0"
 msgid "Invalid lost reason {0}, please create a new lost reason"
 msgstr "crwdns73780:0{0}crwdne73780:0"
 
-#: erpnext/stock/doctype/item/item.py:408
+#: erpnext/stock/doctype/item/item.py:411
 msgid "Invalid naming series (. missing) for {0}"
 msgstr "crwdns73782:0{0}crwdne73782:0"
 
@@ -25281,7 +25267,7 @@ msgstr "crwdns135028:0crwdne135028:0"
 #. Name of a DocType
 #: erpnext/patches/v15_0/refactor_closing_stock_balance.py:43
 #: erpnext/stock/doctype/inventory_dimension/inventory_dimension.json
-#: erpnext/stock/doctype/inventory_dimension/inventory_dimension.py:180
+#: erpnext/stock/doctype/inventory_dimension/inventory_dimension.py:181
 msgid "Inventory Dimension"
 msgstr "crwdns73798:0crwdne73798:0"
 
@@ -25347,7 +25333,7 @@ msgstr "crwdns135034:0crwdne135034:0"
 msgid "Invoice Discounting"
 msgstr "crwdns73820:0crwdne73820:0"
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1114
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1116
 msgid "Invoice Grand Total"
 msgstr "crwdns73824:0crwdne73824:0"
 
@@ -25440,7 +25426,7 @@ msgstr "crwdns73868:0crwdne73868:0"
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:169
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:144
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1116
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1118
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:164
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:165
 msgid "Invoiced Amount"
@@ -25846,6 +25832,11 @@ msgstr "crwdns135128:0crwdne135128:0"
 msgid "Is Outward"
 msgstr "crwdns135130:0crwdne135130:0"
 
+#. Label of the is_packed (Check) field in DocType 'Serial and Batch Bundle'
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.json
+msgid "Is Packed"
+msgstr "crwdns155218:0crwdne155218:0"
+
 #. Label of the is_paid (Check) field in DocType 'Purchase Invoice'
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 msgid "Is Paid"
@@ -26128,11 +26119,11 @@ msgstr "crwdns135184:0crwdne135184:0"
 msgid "Issuing cannot be done to a location. Please enter employee to issue the Asset {0} to"
 msgstr "crwdns74218:0{0}crwdne74218:0"
 
-#: erpnext/stock/doctype/item/item.py:565
+#: erpnext/stock/doctype/item/item.py:571
 msgid "It can take upto few hours for accurate stock values to be visible after merging items."
 msgstr "crwdns74220:0crwdne74220:0"
 
-#: erpnext/public/js/controllers/transaction.js:2075
+#: erpnext/public/js/controllers/transaction.js:2101
 msgid "It is needed to fetch Item Details."
 msgstr "crwdns74222:0crwdne74222:0"
 
@@ -26182,7 +26173,7 @@ msgstr "crwdns74224:0crwdne74224:0"
 #: erpnext/buying/report/supplier_quotation_comparison/supplier_quotation_comparison.js:33
 #: erpnext/buying/report/supplier_quotation_comparison/supplier_quotation_comparison.py:204
 #: erpnext/buying/workspace/buying/buying.json
-#: erpnext/controllers/taxes_and_totals.py:1125
+#: erpnext/controllers/taxes_and_totals.py:1135
 #: erpnext/manufacturing/doctype/blanket_order/blanket_order.json
 #: erpnext/manufacturing/doctype/bom/bom.js:944
 #: erpnext/manufacturing/doctype/bom/bom.json
@@ -26460,7 +26451,7 @@ msgstr "crwdns111786:0crwdne111786:0"
 #: erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py:86
 #: erpnext/manufacturing/report/work_order_stock_report/work_order_stock_report.py:119
 #: erpnext/projects/doctype/timesheet/timesheet.js:213
-#: erpnext/public/js/controllers/transaction.js:2350
+#: erpnext/public/js/controllers/transaction.js:2376
 #: erpnext/public/js/stock_reservation.js:112
 #: erpnext/public/js/stock_reservation.js:317 erpnext/public/js/utils.js:500
 #: erpnext/public/js/utils.js:656
@@ -26898,7 +26889,7 @@ msgstr "crwdns74534:0crwdne74534:0"
 #: erpnext/manufacturing/report/production_planning_report/production_planning_report.py:359
 #: erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py:92
 #: erpnext/manufacturing/report/work_order_consumed_materials/work_order_consumed_materials.py:138
-#: erpnext/public/js/controllers/transaction.js:2356
+#: erpnext/public/js/controllers/transaction.js:2382
 #: erpnext/public/js/utils.js:746
 #: erpnext/selling/doctype/quotation_item/quotation_item.json
 #: erpnext/selling/doctype/sales_order_item/sales_order_item.json
@@ -27165,7 +27156,7 @@ msgstr "crwdns74758:0crwdne74758:0"
 msgid "Item Variant {0} already exists with same attributes"
 msgstr "crwdns74762:0{0}crwdne74762:0"
 
-#: erpnext/stock/doctype/item/item.py:781
+#: erpnext/stock/doctype/item/item.py:772
 msgid "Item Variants updated"
 msgstr "crwdns74764:0crwdne74764:0"
 
@@ -27231,7 +27222,7 @@ msgstr "crwdns135228:0crwdne135228:0"
 msgid "Item for row {0} does not match Material Request"
 msgstr "crwdns74796:0{0}crwdne74796:0"
 
-#: erpnext/stock/doctype/item/item.py:795
+#: erpnext/stock/doctype/item/item.py:789
 msgid "Item has variants."
 msgstr "crwdns74798:0crwdne74798:0"
 
@@ -27257,7 +27248,7 @@ msgstr "crwdns74804:0crwdne74804:0"
 msgid "Item operation"
 msgstr "crwdns135230:0crwdne135230:0"
 
-#: erpnext/controllers/accounts_controller.py:3650
+#: erpnext/controllers/accounts_controller.py:3653
 msgid "Item qty can not be updated as raw materials are already processed."
 msgstr "crwdns74808:0crwdne74808:0"
 
@@ -27283,7 +27274,7 @@ msgstr "crwdns111790:0crwdne111790:0"
 msgid "Item valuation reposting in progress. Report might show incorrect item valuation."
 msgstr "crwdns74814:0crwdne74814:0"
 
-#: erpnext/stock/doctype/item/item.py:952
+#: erpnext/stock/doctype/item/item.py:946
 msgid "Item variant {0} exists with same attributes"
 msgstr "crwdns74816:0{0}crwdne74816:0"
 
@@ -27296,8 +27287,7 @@ msgid "Item {0} cannot be ordered more than {1} against Blanket Order {2}."
 msgstr "crwdns74820:0{0}crwdnd74820:0{1}crwdnd74820:0{2}crwdne74820:0"
 
 #: erpnext/assets/doctype/asset/asset.py:277
-#: erpnext/stock/doctype/item/item.py:630
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:167
+#: erpnext/stock/doctype/item/item.py:636
 msgid "Item {0} does not exist"
 msgstr "crwdns74822:0{0}crwdne74822:0"
 
@@ -27309,7 +27299,7 @@ msgstr "crwdns74824:0{0}crwdne74824:0"
 msgid "Item {0} does not exist."
 msgstr "crwdns149136:0{0}crwdne149136:0"
 
-#: erpnext/controllers/selling_controller.py:752
+#: erpnext/controllers/selling_controller.py:760
 msgid "Item {0} entered multiple times."
 msgstr "crwdns74826:0{0}crwdne74826:0"
 
@@ -27325,7 +27315,7 @@ msgstr "crwdns74830:0{0}crwdne74830:0"
 msgid "Item {0} has no Serial No. Only serialized items can have delivery based on Serial No"
 msgstr "crwdns104602:0{0}crwdne104602:0"
 
-#: erpnext/stock/doctype/item/item.py:1126
+#: erpnext/stock/doctype/item/item.py:1120
 msgid "Item {0} has reached its end of life on {1}"
 msgstr "crwdns74834:0{0}crwdnd74834:0{1}crwdne74834:0"
 
@@ -27337,11 +27327,11 @@ msgstr "crwdns74836:0{0}crwdne74836:0"
 msgid "Item {0} is already reserved/delivered against Sales Order {1}."
 msgstr "crwdns74838:0{0}crwdnd74838:0{1}crwdne74838:0"
 
-#: erpnext/stock/doctype/item/item.py:1146
+#: erpnext/stock/doctype/item/item.py:1140
 msgid "Item {0} is cancelled"
 msgstr "crwdns74840:0{0}crwdne74840:0"
 
-#: erpnext/stock/doctype/item/item.py:1130
+#: erpnext/stock/doctype/item/item.py:1124
 msgid "Item {0} is disabled"
 msgstr "crwdns74842:0{0}crwdne74842:0"
 
@@ -27349,7 +27339,7 @@ msgstr "crwdns74842:0{0}crwdne74842:0"
 msgid "Item {0} is not a serialized Item"
 msgstr "crwdns74844:0{0}crwdne74844:0"
 
-#: erpnext/stock/doctype/item/item.py:1138
+#: erpnext/stock/doctype/item/item.py:1132
 msgid "Item {0} is not a stock Item"
 msgstr "crwdns74846:0{0}crwdne74846:0"
 
@@ -27393,7 +27383,7 @@ msgstr "crwdns74862:0{0}crwdnd74862:0{1}crwdnd74862:0{2}crwdne74862:0"
 msgid "Item {0}: {1} qty produced. "
 msgstr "crwdns74864:0{0}crwdnd74864:0{1}crwdne74864:0"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1429
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1423
 msgid "Item {} does not exist."
 msgstr "crwdns74866:0crwdne74866:0"
 
@@ -27533,7 +27523,7 @@ msgstr "crwdns74940:0crwdne74940:0"
 msgid "Items and Pricing"
 msgstr "crwdns74942:0crwdne74942:0"
 
-#: erpnext/controllers/accounts_controller.py:3872
+#: erpnext/controllers/accounts_controller.py:3875
 msgid "Items cannot be updated as Subcontracting Order is created against the Purchase Order {0}."
 msgstr "crwdns74944:0{0}crwdne74944:0"
 
@@ -28029,7 +28019,7 @@ msgstr "crwdns75088:0crwdne75088:0"
 
 #. Name of a DocType
 #. Label of a Link in the Stock Workspace
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:674
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:676
 #: erpnext/stock/doctype/landed_cost_voucher/landed_cost_voucher.json
 #: erpnext/stock/doctype/purchase_receipt/purchase_receipt.js:104
 #: erpnext/stock/workspace/stock/stock.json
@@ -28644,7 +28634,7 @@ msgstr "crwdns135348:0crwdne135348:0"
 msgid "Linked Location"
 msgstr "crwdns75434:0crwdne75434:0"
 
-#: erpnext/stock/doctype/item/item.py:999
+#: erpnext/stock/doctype/item/item.py:993
 msgid "Linked with submitted documents"
 msgstr "crwdns75436:0crwdne75436:0"
 
@@ -29383,7 +29373,7 @@ msgstr "crwdns143466:0crwdne143466:0"
 #: erpnext/manufacturing/doctype/bom/bom.py:261
 #: erpnext/manufacturing/doctype/bom_update_log/bom_update_log.py:71
 #: erpnext/public/js/controllers/accounts.js:249
-#: erpnext/public/js/controllers/transaction.js:2753
+#: erpnext/public/js/controllers/transaction.js:2779
 #: erpnext/public/js/utils/party.js:321
 #: erpnext/stock/doctype/delivery_note/delivery_note.js:164
 #: erpnext/stock/doctype/inventory_dimension/inventory_dimension.json
@@ -30239,7 +30229,7 @@ msgstr "crwdns135526:0crwdne135526:0"
 msgid "Maximum Value"
 msgstr "crwdns135528:0crwdne135528:0"
 
-#: erpnext/controllers/selling_controller.py:212
+#: erpnext/controllers/selling_controller.py:220
 msgid "Maximum discount for Item {0} is {1}%"
 msgstr "crwdns76222:0{0}crwdnd76222:0{1}crwdne76222:0"
 
@@ -30309,7 +30299,7 @@ msgstr "crwdns112464:0crwdne112464:0"
 msgid "Megawatt"
 msgstr "crwdns112466:0crwdne112466:0"
 
-#: erpnext/stock/stock_ledger.py:1878
+#: erpnext/stock/stock_ledger.py:1887
 msgid "Mention Valuation Rate in the Item master."
 msgstr "crwdns76238:0crwdne76238:0"
 
@@ -30704,11 +30694,11 @@ msgstr "crwdns135586:0crwdne135586:0"
 msgid "Miscellaneous Expenses"
 msgstr "crwdns76346:0crwdne76346:0"
 
-#: erpnext/controllers/buying_controller.py:540
+#: erpnext/controllers/buying_controller.py:548
 msgid "Mismatch"
 msgstr "crwdns76348:0crwdne76348:0"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1430
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1424
 msgid "Missing"
 msgstr "crwdns76350:0crwdne76350:0"
 
@@ -31235,7 +31225,7 @@ msgstr "crwdns76636:0crwdne76636:0"
 msgid "Multiple Warehouse Accounts"
 msgstr "crwdns76638:0crwdne76638:0"
 
-#: erpnext/controllers/accounts_controller.py:1129
+#: erpnext/controllers/accounts_controller.py:1132
 msgid "Multiple fiscal years exist for the date {0}. Please set company in Fiscal Year"
 msgstr "crwdns76640:0{0}crwdne76640:0"
 
@@ -31386,7 +31376,7 @@ msgstr "crwdns135638:0crwdne135638:0"
 msgid "Naming Series and Price Defaults"
 msgstr "crwdns135640:0crwdne135640:0"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:90
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:91
 msgid "Naming Series is mandatory"
 msgstr "crwdns152587:0crwdne152587:0"
 
@@ -31425,15 +31415,15 @@ msgstr "crwdns135642:0crwdne135642:0"
 msgid "Needs Analysis"
 msgstr "crwdns76732:0crwdne76732:0"
 
-#: erpnext/stock/serial_batch_bundle.py:1277
+#: erpnext/stock/serial_batch_bundle.py:1309
 msgid "Negative Batch Quantity"
 msgstr "crwdns152340:0crwdne152340:0"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:610
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:606
 msgid "Negative Quantity is not allowed"
 msgstr "crwdns76734:0crwdne76734:0"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:615
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:611
 msgid "Negative Valuation Rate is not allowed"
 msgstr "crwdns76736:0crwdne76736:0"
 
@@ -31715,7 +31705,7 @@ msgstr "crwdns135656:0crwdne135656:0"
 msgid "Net Weight UOM"
 msgstr "crwdns135658:0crwdne135658:0"
 
-#: erpnext/controllers/accounts_controller.py:1483
+#: erpnext/controllers/accounts_controller.py:1486
 msgid "Net total calculation precision loss"
 msgstr "crwdns76898:0crwdne76898:0"
 
@@ -32058,7 +32048,7 @@ msgstr "crwdns77046:0crwdne77046:0"
 #: erpnext/accounts/doctype/journal_entry/journal_entry.py:1539
 #: erpnext/accounts/doctype/journal_entry/journal_entry.py:1599
 #: erpnext/accounts/doctype/journal_entry/journal_entry.py:1613
-#: erpnext/stock/doctype/item/item.py:1371
+#: erpnext/stock/doctype/item/item.py:1365
 msgid "No Permission"
 msgstr "crwdns77048:0crwdne77048:0"
 
@@ -32080,7 +32070,7 @@ msgstr "crwdns77052:0crwdne77052:0"
 msgid "No Selection"
 msgstr "crwdns154423:0crwdne154423:0"
 
-#: erpnext/controllers/sales_and_purchase_return.py:919
+#: erpnext/controllers/sales_and_purchase_return.py:824
 msgid "No Serial / Batches are available for return"
 msgstr "crwdns135694:0crwdne135694:0"
 
@@ -32116,7 +32106,7 @@ msgstr "crwdns77064:0crwdne77064:0"
 msgid "No Work Orders were created"
 msgstr "crwdns77066:0crwdne77066:0"
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:785
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:794
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py:689
 msgid "No accounting entries for the following warehouses"
 msgstr "crwdns77068:0crwdne77068:0"
@@ -32305,7 +32295,7 @@ msgstr "crwdns77144:0crwdne77144:0"
 msgid "No reserved stock to unreserve."
 msgstr "crwdns152342:0crwdne152342:0"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:773
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:769
 msgid "No stock ledger entries were created. Please set the quantity or valuation rate for the items properly and try again."
 msgstr "crwdns154776:0crwdne154776:0"
 
@@ -32389,7 +32379,7 @@ msgstr "crwdns77176:0crwdne77176:0"
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:566
 #: erpnext/assets/doctype/asset/asset.js:612
 #: erpnext/assets/doctype/asset/asset.js:627
-#: erpnext/controllers/buying_controller.py:225
+#: erpnext/controllers/buying_controller.py:233
 #: erpnext/selling/doctype/product_bundle/product_bundle.py:72
 #: erpnext/setup/doctype/transaction_deletion_record/transaction_deletion_record.py:80
 msgid "Not Allowed"
@@ -32510,10 +32500,10 @@ msgstr "crwdns77216:0crwdne77216:0"
 #: erpnext/selling/doctype/customer/customer.py:129
 #: erpnext/selling/doctype/sales_order/sales_order.js:1168
 #: erpnext/stock/doctype/item/item.js:526
-#: erpnext/stock/doctype/item/item.py:567
+#: erpnext/stock/doctype/item/item.py:573
 #: erpnext/stock/doctype/item_price/item_price.json
 #: erpnext/stock/doctype/stock_entry/stock_entry.py:1374
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:972
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:968
 #: erpnext/templates/pages/timelog_info.html:43
 msgid "Note"
 msgstr "crwdns77218:0crwdne77218:0"
@@ -32522,7 +32512,7 @@ msgstr "crwdns77218:0crwdne77218:0"
 msgid "Note: Automatic log deletion only applies to logs of type <i>Update Cost</i>"
 msgstr "crwdns77226:0crwdne77226:0"
 
-#: erpnext/accounts/party.py:690
+#: erpnext/accounts/party.py:696
 msgid "Note: Due Date exceeds allowed {0} credit days by {1} day(s)"
 msgstr "crwdns154914:0{0}crwdnd154914:0{1}crwdne154914:0"
 
@@ -32548,7 +32538,7 @@ msgstr "crwdns77234:0crwdne77234:0"
 msgid "Note: This Cost Center is a Group. Cannot make accounting entries against groups."
 msgstr "crwdns77236:0crwdne77236:0"
 
-#: erpnext/stock/doctype/item/item.py:621
+#: erpnext/stock/doctype/item/item.py:627
 msgid "Note: To merge the items, create a separate Stock Reconciliation for the old item {0}"
 msgstr "crwdns77238:0{0}crwdne77238:0"
 
@@ -33311,7 +33301,7 @@ msgstr "crwdns148808:0crwdne148808:0"
 
 #. Label of the opening_stock (Float) field in DocType 'Item'
 #. Option for the 'Purpose' (Select) field in DocType 'Stock Reconciliation'
-#: erpnext/stock/doctype/item/item.json erpnext/stock/doctype/item/item.py:296
+#: erpnext/stock/doctype/item/item.json erpnext/stock/doctype/item/item.py:299
 #: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.json
 msgid "Opening Stock"
 msgstr "crwdns77584:0crwdne77584:0"
@@ -34031,7 +34021,7 @@ msgstr "crwdns154389:0crwdne154389:0"
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:149
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1123
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1125
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:167
 #: erpnext/accounts/report/purchase_register/purchase_register.py:289
 #: erpnext/accounts/report/sales_register/sales_register.py:319
@@ -34070,7 +34060,7 @@ msgstr "crwdns135912:0crwdne135912:0"
 msgid "Over Billing Allowance (%)"
 msgstr "crwdns135914:0crwdne135914:0"
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:1242
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:1251
 msgid "Over Billing Allowance exceeded for Purchase Receipt Item {0} ({1}) by {2}%"
 msgstr "crwdns154918:0{0}crwdnd154918:0{1}crwdnd154918:0{2}crwdne154918:0"
 
@@ -34111,7 +34101,7 @@ msgstr "crwdns135920:0crwdne135920:0"
 msgid "Overbilling of {0} {1} ignored for item {2} because you have {3} role."
 msgstr "crwdns77942:0{0}crwdnd77942:0{1}crwdnd77942:0{2}crwdnd77942:0{3}crwdne77942:0"
 
-#: erpnext/controllers/accounts_controller.py:2013
+#: erpnext/controllers/accounts_controller.py:2016
 msgid "Overbilling of {} ignored because you have {} role."
 msgstr "crwdns77944:0crwdne77944:0"
 
@@ -34618,7 +34608,7 @@ msgstr "crwdns78204:0crwdne78204:0"
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:146
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1117
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1119
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:165
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:172
 #: erpnext/accounts/report/pos_register/pos_register.py:209
@@ -34851,7 +34841,7 @@ msgstr "crwdns136024:0crwdne136024:0"
 msgid "Parent Row No"
 msgstr "crwdns136026:0crwdne136026:0"
 
-#: erpnext/manufacturing/doctype/bom_creator/bom_creator.py:495
+#: erpnext/manufacturing/doctype/bom_creator/bom_creator.py:496
 msgid "Parent Row No not found for {0}"
 msgstr "crwdns152216:0{0}crwdne152216:0"
 
@@ -35080,7 +35070,7 @@ msgstr "crwdns112550:0crwdne112550:0"
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:142
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:159
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:57
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1054
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1056
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:67
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:147
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:228
@@ -35106,7 +35096,7 @@ msgstr "crwdns78408:0crwdne78408:0"
 
 #. Name of a DocType
 #: erpnext/accounts/doctype/party_account/party_account.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1065
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1067
 msgid "Party Account"
 msgstr "crwdns78442:0crwdne78442:0"
 
@@ -35133,7 +35123,7 @@ msgstr "crwdns136066:0crwdne136066:0"
 msgid "Party Account No. (Bank Statement)"
 msgstr "crwdns136068:0crwdne136068:0"
 
-#: erpnext/controllers/accounts_controller.py:2278
+#: erpnext/controllers/accounts_controller.py:2281
 msgid "Party Account {0} currency ({1}) and document currency ({2}) should be same"
 msgstr "crwdns78456:0{0}crwdnd78456:0{1}crwdnd78456:0{2}crwdne78456:0"
 
@@ -35150,6 +35140,11 @@ msgstr "crwdns136072:0crwdne136072:0"
 #: erpnext/accounts/doctype/payment_request/payment_request.json
 msgid "Party Details"
 msgstr "crwdns136074:0crwdne136074:0"
+
+#. Label of the party_full_name (Data) field in DocType 'Contract'
+#: erpnext/crm/doctype/contract/contract.json
+msgid "Party Full Name"
+msgstr "crwdns155220:0crwdne155220:0"
 
 #. Label of the bank_party_iban (Data) field in DocType 'Bank Transaction'
 #: erpnext/accounts/doctype/bank_transaction/bank_transaction.json
@@ -35234,7 +35229,7 @@ msgstr "crwdns78486:0crwdne78486:0"
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:84
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:54
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:44
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1048
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1050
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:54
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:141
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:219
@@ -35256,7 +35251,7 @@ msgstr "crwdns78486:0crwdne78486:0"
 msgid "Party Type"
 msgstr "crwdns78492:0crwdne78492:0"
 
-#: erpnext/accounts/party.py:819
+#: erpnext/accounts/party.py:825
 msgid "Party Type and Party can only be set for Receivable / Payable account<br><br>{0}"
 msgstr "crwdns152094:0{0}crwdne152094:0"
 
@@ -35378,7 +35373,7 @@ msgid "Payable"
 msgstr "crwdns78570:0crwdne78570:0"
 
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:42
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1063
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1065
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:211
 #: erpnext/accounts/report/purchase_register/purchase_register.py:194
 #: erpnext/accounts/report/purchase_register/purchase_register.py:235
@@ -35544,7 +35539,7 @@ msgstr "crwdns78642:0crwdne78642:0"
 msgid "Payment Entry is already created"
 msgstr "crwdns78644:0crwdne78644:0"
 
-#: erpnext/controllers/accounts_controller.py:1434
+#: erpnext/controllers/accounts_controller.py:1437
 msgid "Payment Entry {0} is linked against Order {1}, check if it should be pulled as advance in this invoice."
 msgstr "crwdns78646:0{0}crwdnd78646:0{1}crwdne78646:0"
 
@@ -35826,7 +35821,7 @@ msgstr "crwdns154193:0crwdne154193:0"
 #: erpnext/accounts/doctype/payment_schedule/payment_schedule.json
 #: erpnext/accounts/doctype/payment_term/payment_term.json
 #: erpnext/accounts/doctype/payment_terms_template_detail/payment_terms_template_detail.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1113
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1115
 #: erpnext/accounts/report/gross_profit/gross_profit.py:412
 #: erpnext/accounts/workspace/accounting/accounting.json
 #: erpnext/selling/report/payment_terms_status_for_sales_order/payment_terms_status_for_sales_order.py:30
@@ -36890,7 +36885,7 @@ msgstr "crwdns79246:0crwdne79246:0"
 msgid "Please create a new Accounting Dimension if required."
 msgstr "crwdns79248:0crwdne79248:0"
 
-#: erpnext/controllers/accounts_controller.py:729
+#: erpnext/controllers/accounts_controller.py:732
 msgid "Please create purchase from internal sale or delivery document itself"
 msgstr "crwdns79250:0crwdne79250:0"
 
@@ -36898,7 +36893,7 @@ msgstr "crwdns79250:0crwdne79250:0"
 msgid "Please create purchase receipt or purchase invoice for the item {0}"
 msgstr "crwdns79252:0{0}crwdne79252:0"
 
-#: erpnext/stock/doctype/item/item.py:649
+#: erpnext/stock/doctype/item/item.py:655
 msgid "Please delete Product Bundle {0}, before merging {1} into {2}"
 msgstr "crwdns79254:0{0}crwdnd79254:0{1}crwdnd79254:0{2}crwdne79254:0"
 
@@ -36940,7 +36935,7 @@ msgstr "crwdns79264:0crwdne79264:0"
 msgid "Please enable {0} in the {1}."
 msgstr "crwdns79266:0{0}crwdnd79266:0{1}crwdne79266:0"
 
-#: erpnext/controllers/selling_controller.py:754
+#: erpnext/controllers/selling_controller.py:762
 msgid "Please enable {} in {} to allow same item in multiple rows"
 msgstr "crwdns79268:0crwdne79268:0"
 
@@ -36973,7 +36968,7 @@ msgstr "crwdns79280:0crwdne79280:0"
 msgid "Please enter Approving Role or Approving User"
 msgstr "crwdns79282:0crwdne79282:0"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:939
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:935
 msgid "Please enter Cost Center"
 msgstr "crwdns79284:0crwdne79284:0"
 
@@ -36985,7 +36980,7 @@ msgstr "crwdns79286:0crwdne79286:0"
 msgid "Please enter Employee Id of this sales person"
 msgstr "crwdns79288:0crwdne79288:0"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:948
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:944
 msgid "Please enter Expense Account"
 msgstr "crwdns79290:0crwdne79290:0"
 
@@ -36994,7 +36989,7 @@ msgstr "crwdns79290:0crwdne79290:0"
 msgid "Please enter Item Code to get Batch Number"
 msgstr "crwdns79292:0crwdne79292:0"
 
-#: erpnext/public/js/controllers/transaction.js:2503
+#: erpnext/public/js/controllers/transaction.js:2529
 msgid "Please enter Item Code to get batch no"
 msgstr "crwdns79294:0crwdne79294:0"
 
@@ -37059,7 +37054,7 @@ msgstr "crwdns79326:0crwdne79326:0"
 msgid "Please enter company name first"
 msgstr "crwdns79328:0crwdne79328:0"
 
-#: erpnext/controllers/accounts_controller.py:2764
+#: erpnext/controllers/accounts_controller.py:2767
 msgid "Please enter default currency in Company Master"
 msgstr "crwdns79330:0crwdne79330:0"
 
@@ -37095,7 +37090,7 @@ msgstr "crwdns79344:0crwdne79344:0"
 msgid "Please enter the phone number first"
 msgstr "crwdns79346:0crwdne79346:0"
 
-#: erpnext/controllers/buying_controller.py:1007
+#: erpnext/controllers/buying_controller.py:1015
 msgid "Please enter the {schedule_date}."
 msgstr "crwdns154244:0{schedule_date}crwdne154244:0"
 
@@ -37197,7 +37192,7 @@ msgstr "crwdns79390:0crwdne79390:0"
 msgid "Please select <b>Template Type</b> to download template"
 msgstr "crwdns79392:0crwdne79392:0"
 
-#: erpnext/controllers/taxes_and_totals.py:721
+#: erpnext/controllers/taxes_and_totals.py:731
 #: erpnext/public/js/controllers/taxes_and_totals.js:721
 msgid "Please select Apply Discount On"
 msgstr "crwdns79394:0crwdne79394:0"
@@ -37210,7 +37205,7 @@ msgstr "crwdns79396:0{0}crwdne79396:0"
 msgid "Please select BOM for Item in Row {0}"
 msgstr "crwdns79398:0{0}crwdne79398:0"
 
-#: erpnext/controllers/buying_controller.py:467
+#: erpnext/controllers/buying_controller.py:475
 msgid "Please select BOM in BOM field for Item {item_code}."
 msgstr "crwdns154246:0{item_code}crwdne154246:0"
 
@@ -37292,7 +37287,7 @@ msgstr "crwdns79430:0crwdne79430:0"
 msgid "Please select Qty against item {0}"
 msgstr "crwdns79432:0{0}crwdne79432:0"
 
-#: erpnext/stock/doctype/item/item.py:320
+#: erpnext/stock/doctype/item/item.py:323
 msgid "Please select Sample Retention Warehouse in Stock Settings first"
 msgstr "crwdns79434:0crwdne79434:0"
 
@@ -37308,7 +37303,7 @@ msgstr "crwdns79438:0{0}crwdne79438:0"
 msgid "Please select Subcontracting Order instead of Purchase Order {0}"
 msgstr "crwdns79440:0{0}crwdne79440:0"
 
-#: erpnext/controllers/accounts_controller.py:2613
+#: erpnext/controllers/accounts_controller.py:2616
 msgid "Please select Unrealized Profit / Loss account or add default Unrealized Profit / Loss account account for company {0}"
 msgstr "crwdns79442:0{0}crwdne79442:0"
 
@@ -37324,7 +37319,7 @@ msgstr "crwdns79446:0crwdne79446:0"
 #: erpnext/manufacturing/doctype/bom/bom.js:603
 #: erpnext/manufacturing/doctype/bom/bom.py:261
 #: erpnext/public/js/controllers/accounts.js:249
-#: erpnext/public/js/controllers/transaction.js:2753
+#: erpnext/public/js/controllers/transaction.js:2779
 msgid "Please select a Company first."
 msgstr "crwdns79448:0crwdne79448:0"
 
@@ -37482,7 +37477,7 @@ msgstr "crwdns79508:0{0}crwdne79508:0"
 msgid "Please select {0} first"
 msgstr "crwdns79510:0{0}crwdne79510:0"
 
-#: erpnext/public/js/controllers/transaction.js:77
+#: erpnext/public/js/controllers/transaction.js:100
 msgid "Please set 'Apply Additional Discount On'"
 msgstr "crwdns79512:0crwdne79512:0"
 
@@ -37667,7 +37662,7 @@ msgstr "crwdns79586:0crwdne79586:0"
 msgid "Please set filters"
 msgstr "crwdns79588:0crwdne79588:0"
 
-#: erpnext/controllers/accounts_controller.py:2194
+#: erpnext/controllers/accounts_controller.py:2197
 msgid "Please set one of the following:"
 msgstr "crwdns79590:0crwdne79590:0"
 
@@ -37675,7 +37670,7 @@ msgstr "crwdns79590:0crwdne79590:0"
 msgid "Please set opening number of booked depreciations"
 msgstr "crwdns154924:0crwdne154924:0"
 
-#: erpnext/public/js/controllers/transaction.js:2205
+#: erpnext/public/js/controllers/transaction.js:2231
 msgid "Please set recurring after saving"
 msgstr "crwdns79592:0crwdne79592:0"
 
@@ -37746,7 +37741,7 @@ msgstr "crwdns111904:0{0}crwdnd111904:0{1}crwdne111904:0"
 msgid "Please share this email with your support team so that they can find and fix the issue."
 msgstr "crwdns79616:0crwdne79616:0"
 
-#: erpnext/public/js/controllers/transaction.js:2073
+#: erpnext/public/js/controllers/transaction.js:2099
 msgid "Please specify"
 msgstr "crwdns79618:0crwdne79618:0"
 
@@ -37761,7 +37756,7 @@ msgid "Please specify Company to proceed"
 msgstr "crwdns79622:0crwdne79622:0"
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1472
-#: erpnext/controllers/accounts_controller.py:2957
+#: erpnext/controllers/accounts_controller.py:2960
 #: erpnext/public/js/controllers/accounts.js:97
 msgid "Please specify a valid Row ID for row {0} in table {1}"
 msgstr "crwdns79624:0{0}crwdnd79624:0{1}crwdne79624:0"
@@ -37774,7 +37769,7 @@ msgstr "crwdns152324:0{0}crwdne152324:0"
 msgid "Please specify at least one attribute in the Attributes table"
 msgstr "crwdns79628:0crwdne79628:0"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:605
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:601
 msgid "Please specify either Quantity or Valuation Rate or both"
 msgstr "crwdns79630:0crwdne79630:0"
 
@@ -37955,7 +37950,7 @@ msgstr "crwdns79678:0crwdne79678:0"
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:16
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:15
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:18
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1046
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1048
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:15
 #: erpnext/accounts/report/bank_clearance_summary/bank_clearance_summary.py:35
 #: erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.html:7
@@ -40136,7 +40131,7 @@ msgstr "crwdns80810:0crwdne80810:0"
 #: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.js:48
 #: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:203
 #: erpnext/buying/workspace/buying/buying.json
-#: erpnext/controllers/buying_controller.py:739
+#: erpnext/controllers/buying_controller.py:747
 #: erpnext/crm/doctype/contract/contract.json
 #: erpnext/manufacturing/doctype/blanket_order/blanket_order.js:54
 #: erpnext/manufacturing/doctype/production_plan_sub_assembly_item/production_plan_sub_assembly_item.json
@@ -40275,7 +40270,7 @@ msgstr "crwdns136436:0crwdne136436:0"
 msgid "Purchase Orders to Receive"
 msgstr "crwdns136438:0crwdne136438:0"
 
-#: erpnext/controllers/accounts_controller.py:1833
+#: erpnext/controllers/accounts_controller.py:1836
 msgid "Purchase Orders {0} are un-linked"
 msgstr "crwdns80898:0{0}crwdne80898:0"
 
@@ -40299,8 +40294,8 @@ msgstr "crwdns80900:0crwdne80900:0"
 #. Label of a Link in the Stock Workspace
 #. Label of a shortcut in the Stock Workspace
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:171
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:650
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:660
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:652
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:662
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice_list.js:49
 #: erpnext/accounts/doctype/purchase_invoice_item/purchase_invoice_item.json
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:246
@@ -41035,7 +41030,7 @@ msgstr "crwdns81266:0crwdne81266:0"
 msgid "Quality Inspection Template Name"
 msgstr "crwdns136490:0crwdne136490:0"
 
-#: erpnext/public/js/controllers/transaction.js:334
+#: erpnext/public/js/controllers/transaction.js:360
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:165
 msgid "Quality Inspection(s)"
 msgstr "crwdns81282:0crwdne81282:0"
@@ -42219,7 +42214,7 @@ msgid "Receivable / Payable Account"
 msgstr "crwdns136632:0crwdne136632:0"
 
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:71
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1061
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1063
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py:243
 #: erpnext/accounts/report/sales_register/sales_register.py:217
 #: erpnext/accounts/report/sales_register/sales_register.py:271
@@ -42701,7 +42696,7 @@ msgstr "crwdns82078:0#{0}crwdnd82078:0{1}crwdne82078:0"
 msgid "Reference Date"
 msgstr "crwdns82080:0crwdne82080:0"
 
-#: erpnext/public/js/controllers/transaction.js:2311
+#: erpnext/public/js/controllers/transaction.js:2337
 msgid "Reference Date for Early Payment Discount"
 msgstr "crwdns82084:0crwdne82084:0"
 
@@ -43025,7 +43020,7 @@ msgstr "crwdns136732:0crwdne136732:0"
 msgid "Rejected"
 msgstr "crwdns136734:0crwdne136734:0"
 
-#: erpnext/stock/doctype/inventory_dimension/inventory_dimension.py:202
+#: erpnext/stock/doctype/inventory_dimension/inventory_dimension.py:203
 msgid "Rejected "
 msgstr "crwdns151600:0crwdne151600:0"
 
@@ -43129,7 +43124,7 @@ msgstr "crwdns154926:0crwdne154926:0"
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:187
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:156
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1135
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1137
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:178
 msgid "Remaining Balance"
 msgstr "crwdns82290:0crwdne82290:0"
@@ -43182,7 +43177,7 @@ msgstr "crwdns82292:0crwdne82292:0"
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:159
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:198
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:269
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1167
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1169
 #: erpnext/accounts/report/general_ledger/general_ledger.html:84
 #: erpnext/accounts/report/general_ledger/general_ledger.html:110
 #: erpnext/accounts/report/general_ledger/general_ledger.py:742
@@ -43931,7 +43926,7 @@ msgstr "crwdns82636:0crwdne82636:0"
 msgid "Reserved Quantity for Production"
 msgstr "crwdns82638:0crwdne82638:0"
 
-#: erpnext/stock/stock_ledger.py:2147
+#: erpnext/stock/stock_ledger.py:2155
 msgid "Reserved Serial No."
 msgstr "crwdns82640:0crwdne82640:0"
 
@@ -43947,11 +43942,11 @@ msgstr "crwdns82640:0crwdne82640:0"
 #: erpnext/stock/doctype/pick_list/pick_list.js:153
 #: erpnext/stock/report/reserved_stock/reserved_stock.json
 #: erpnext/stock/report/stock_balance/stock_balance.py:499
-#: erpnext/stock/stock_ledger.py:2131
+#: erpnext/stock/stock_ledger.py:2139
 msgid "Reserved Stock"
 msgstr "crwdns82642:0crwdne82642:0"
 
-#: erpnext/stock/stock_ledger.py:2177
+#: erpnext/stock/stock_ledger.py:2185
 msgid "Reserved Stock for Batch"
 msgstr "crwdns82646:0crwdne82646:0"
 
@@ -43963,7 +43958,7 @@ msgstr "crwdns154940:0crwdne154940:0"
 msgid "Reserved Stock for Sub-assembly"
 msgstr "crwdns154942:0crwdne154942:0"
 
-#: erpnext/controllers/buying_controller.py:476
+#: erpnext/controllers/buying_controller.py:484
 msgid "Reserved Warehouse is mandatory for the Item {item_code} in Raw Materials supplied."
 msgstr "crwdns154250:0{item_code}crwdne154250:0"
 
@@ -44777,7 +44772,7 @@ msgstr "crwdns83024:0crwdne83024:0"
 msgid "Routing Name"
 msgstr "crwdns136952:0crwdne136952:0"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:667
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:663
 msgid "Row #"
 msgstr "crwdns83032:0crwdne83032:0"
 
@@ -44815,7 +44810,7 @@ msgstr "crwdns83042:0#{0}crwdne83042:0"
 msgid "Row #{0} (Payment Table): Amount must be positive"
 msgstr "crwdns83044:0#{0}crwdne83044:0"
 
-#: erpnext/stock/doctype/item/item.py:495
+#: erpnext/stock/doctype/item/item.py:498
 msgid "Row #{0}: A reorder entry already exists for warehouse {1} with reorder type {2}."
 msgstr "crwdns83046:0#{0}crwdnd83046:0{1}crwdnd83046:0{2}crwdne83046:0"
 
@@ -44836,7 +44831,7 @@ msgstr "crwdns83052:0#{0}crwdne83052:0"
 msgid "Row #{0}: Accepted Warehouse is mandatory for the accepted Item {1}"
 msgstr "crwdns83056:0#{0}crwdnd83056:0{1}crwdne83056:0"
 
-#: erpnext/controllers/accounts_controller.py:1117
+#: erpnext/controllers/accounts_controller.py:1120
 msgid "Row #{0}: Account {1} does not belong to company {2}"
 msgstr "crwdns83058:0#{0}crwdnd83058:0{1}crwdnd83058:0{2}crwdne83058:0"
 
@@ -44877,27 +44872,27 @@ msgstr "crwdns83070:0#{0}crwdnd83070:0{1}crwdne83070:0"
 msgid "Row #{0}: Cannot allocate more than {1} against payment term {2}"
 msgstr "crwdns83072:0#{0}crwdnd83072:0{1}crwdnd83072:0{2}crwdne83072:0"
 
-#: erpnext/controllers/accounts_controller.py:3524
+#: erpnext/controllers/accounts_controller.py:3527
 msgid "Row #{0}: Cannot delete item {1} which has already been billed."
 msgstr "crwdns83074:0#{0}crwdnd83074:0{1}crwdne83074:0"
 
-#: erpnext/controllers/accounts_controller.py:3498
+#: erpnext/controllers/accounts_controller.py:3501
 msgid "Row #{0}: Cannot delete item {1} which has already been delivered"
 msgstr "crwdns83076:0#{0}crwdnd83076:0{1}crwdne83076:0"
 
-#: erpnext/controllers/accounts_controller.py:3517
+#: erpnext/controllers/accounts_controller.py:3520
 msgid "Row #{0}: Cannot delete item {1} which has already been received"
 msgstr "crwdns83078:0#{0}crwdnd83078:0{1}crwdne83078:0"
 
-#: erpnext/controllers/accounts_controller.py:3504
+#: erpnext/controllers/accounts_controller.py:3507
 msgid "Row #{0}: Cannot delete item {1} which has work order assigned to it."
 msgstr "crwdns83080:0#{0}crwdnd83080:0{1}crwdne83080:0"
 
-#: erpnext/controllers/accounts_controller.py:3510
+#: erpnext/controllers/accounts_controller.py:3513
 msgid "Row #{0}: Cannot delete item {1} which is assigned to customer's purchase order."
 msgstr "crwdns83082:0#{0}crwdnd83082:0{1}crwdne83082:0"
 
-#: erpnext/controllers/accounts_controller.py:3765
+#: erpnext/controllers/accounts_controller.py:3768
 msgid "Row #{0}: Cannot set Rate if the billed amount is greater than the amount for Item {1}."
 msgstr "crwdns154952:0#{0}crwdnd154952:0{1}crwdne154952:0"
 
@@ -45017,7 +45012,7 @@ msgstr "crwdns83134:0#{0}crwdnd83134:0{1}crwdne83134:0"
 msgid "Row #{0}: Item {1} has been picked, please reserve stock from the Pick List."
 msgstr "crwdns83136:0#{0}crwdnd83136:0{1}crwdne83136:0"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:729
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:725
 msgid "Row #{0}: Item {1} is not a Serialized/Batched Item. It cannot have a Serial No/Batch No against it."
 msgstr "crwdns83138:0#{0}crwdnd83138:0{1}crwdne83138:0"
 
@@ -45073,7 +45068,7 @@ msgstr "crwdns83158:0#{0}crwdne83158:0"
 msgid "Row #{0}: Please select the Sub Assembly Warehouse"
 msgstr "crwdns111962:0#{0}crwdne111962:0"
 
-#: erpnext/stock/doctype/item/item.py:502
+#: erpnext/stock/doctype/item/item.py:505
 msgid "Row #{0}: Please set reorder quantity"
 msgstr "crwdns83162:0#{0}crwdne83162:0"
 
@@ -45106,8 +45101,8 @@ msgstr "crwdns151834:0#{0}crwdnd151834:0{1}crwdnd151834:0{2}crwdne151834:0"
 msgid "Row #{0}: Quality Inspection {1} was rejected for item {2}"
 msgstr "crwdns151836:0#{0}crwdnd151836:0{1}crwdnd151836:0{2}crwdne151836:0"
 
-#: erpnext/controllers/accounts_controller.py:1274
-#: erpnext/controllers/accounts_controller.py:3624
+#: erpnext/controllers/accounts_controller.py:1277
+#: erpnext/controllers/accounts_controller.py:3627
 msgid "Row #{0}: Quantity for Item {1} cannot be zero."
 msgstr "crwdns83172:0#{0}crwdnd83172:0{1}crwdne83172:0"
 
@@ -45144,7 +45139,7 @@ msgstr "crwdns154964:0#{0}crwdne154964:0"
 msgid "Row #{0}: Scrap Item Qty cannot be zero"
 msgstr "crwdns83192:0#{0}crwdne83192:0"
 
-#: erpnext/controllers/selling_controller.py:230
+#: erpnext/controllers/selling_controller.py:238
 msgid "Row #{0}: Selling rate for item {1} is lower than its {2}.\n"
 "\t\t\t\t\tSelling {3} should be atleast {4}.<br><br>Alternatively,\n"
 "\t\t\t\t\tyou can disable selling price validation in {5} to bypass\n"
@@ -45228,7 +45223,7 @@ msgstr "crwdns83226:0#{0}crwdnd83226:0{1}crwdnd83226:0{2}crwdne83226:0"
 msgid "Row #{0}: The batch {1} has already expired."
 msgstr "crwdns83228:0#{0}crwdnd83228:0{1}crwdne83228:0"
 
-#: erpnext/stock/doctype/item/item.py:511
+#: erpnext/stock/doctype/item/item.py:514
 msgid "Row #{0}: The warehouse {1} is not a child warehouse of a group warehouse {2}"
 msgstr "crwdns127848:0#{0}crwdnd127848:0{1}crwdnd127848:0{2}crwdne127848:0"
 
@@ -45268,39 +45263,39 @@ msgstr "crwdns83246:0#{0}crwdnd83246:0{1}crwdnd83246:0{2}crwdnd83246:0{3}crwdnd8
 msgid "Row #{1}: Warehouse is mandatory for stock Item {0}"
 msgstr "crwdns83248:0#{1}crwdnd83248:0{0}crwdne83248:0"
 
-#: erpnext/controllers/buying_controller.py:259
+#: erpnext/controllers/buying_controller.py:267
 msgid "Row #{idx}: Cannot select Supplier Warehouse while suppling raw materials to subcontractor."
 msgstr "crwdns154252:0#{idx}crwdne154252:0"
 
-#: erpnext/controllers/buying_controller.py:406
+#: erpnext/controllers/buying_controller.py:414
 msgid "Row #{idx}: Item rate has been updated as per valuation rate since its an internal stock transfer."
 msgstr "crwdns154254:0#{idx}crwdne154254:0"
 
-#: erpnext/controllers/buying_controller.py:881
+#: erpnext/controllers/buying_controller.py:889
 msgid "Row #{idx}: Please enter a location for the asset item {item_code}."
 msgstr "crwdns154256:0#{idx}crwdnd154256:0{item_code}crwdne154256:0"
 
-#: erpnext/controllers/buying_controller.py:537
+#: erpnext/controllers/buying_controller.py:545
 msgid "Row #{idx}: Received Qty must be equal to Accepted + Rejected Qty for Item {item_code}."
 msgstr "crwdns154258:0#{idx}crwdnd154258:0{item_code}crwdne154258:0"
 
-#: erpnext/controllers/buying_controller.py:550
+#: erpnext/controllers/buying_controller.py:558
 msgid "Row #{idx}: {field_label} can not be negative for item {item_code}."
 msgstr "crwdns154260:0#{idx}crwdnd154260:0{field_label}crwdnd154260:0{item_code}crwdne154260:0"
 
-#: erpnext/controllers/buying_controller.py:496
+#: erpnext/controllers/buying_controller.py:504
 msgid "Row #{idx}: {field_label} is mandatory."
 msgstr "crwdns154262:0#{idx}crwdnd154262:0{field_label}crwdne154262:0"
 
-#: erpnext/controllers/buying_controller.py:518
+#: erpnext/controllers/buying_controller.py:526
 msgid "Row #{idx}: {field_label} is not allowed in Purchase Return."
 msgstr "crwdns154264:0#{idx}crwdnd154264:0{field_label}crwdne154264:0"
 
-#: erpnext/controllers/buying_controller.py:250
+#: erpnext/controllers/buying_controller.py:258
 msgid "Row #{idx}: {from_warehouse_field} and {to_warehouse_field} cannot be same."
 msgstr "crwdns154266:0#{idx}crwdnd154266:0{from_warehouse_field}crwdnd154266:0{to_warehouse_field}crwdne154266:0"
 
-#: erpnext/controllers/buying_controller.py:999
+#: erpnext/controllers/buying_controller.py:1007
 msgid "Row #{idx}: {schedule_date} cannot be before {transaction_date}."
 msgstr "crwdns154268:0#{idx}crwdnd154268:0{schedule_date}crwdnd154268:0{transaction_date}crwdne154268:0"
 
@@ -45365,7 +45360,7 @@ msgstr "crwdns83278:0crwdne83278:0"
 msgid "Row #{}: {} {} does not exist."
 msgstr "crwdns83280:0crwdne83280:0"
 
-#: erpnext/stock/doctype/item/item.py:1403
+#: erpnext/stock/doctype/item/item.py:1397
 msgid "Row #{}: {} {} doesn't belong to Company {}. Please select valid {}."
 msgstr "crwdns83282:0crwdne83282:0"
 
@@ -45437,11 +45432,11 @@ msgstr "crwdns83310:0{0}crwdnd83310:0{1}crwdne83310:0"
 msgid "Row {0}: Both Debit and Credit values cannot be zero"
 msgstr "crwdns83312:0{0}crwdne83312:0"
 
-#: erpnext/controllers/selling_controller.py:222
+#: erpnext/controllers/selling_controller.py:230
 msgid "Row {0}: Conversion Factor is mandatory"
 msgstr "crwdns83314:0{0}crwdne83314:0"
 
-#: erpnext/controllers/accounts_controller.py:2995
+#: erpnext/controllers/accounts_controller.py:2998
 msgid "Row {0}: Cost Center {1} does not belong to Company {2}"
 msgstr "crwdns83316:0{0}crwdnd83316:0{1}crwdnd83316:0{2}crwdne83316:0"
 
@@ -45461,11 +45456,11 @@ msgstr "crwdns83322:0{0}crwdnd83322:0#{1}crwdnd83322:0{2}crwdne83322:0"
 msgid "Row {0}: Debit entry can not be linked with a {1}"
 msgstr "crwdns83324:0{0}crwdnd83324:0{1}crwdne83324:0"
 
-#: erpnext/controllers/selling_controller.py:776
+#: erpnext/controllers/selling_controller.py:784
 msgid "Row {0}: Delivery Warehouse ({1}) and Customer Warehouse ({2}) can not be same"
 msgstr "crwdns83326:0{0}crwdnd83326:0{1}crwdnd83326:0{2}crwdne83326:0"
 
-#: erpnext/controllers/accounts_controller.py:2529
+#: erpnext/controllers/accounts_controller.py:2532
 msgid "Row {0}: Due Date in the Payment Terms table cannot be before Posting Date"
 msgstr "crwdns83330:0{0}crwdne83330:0"
 
@@ -45474,7 +45469,7 @@ msgid "Row {0}: Either Delivery Note Item or Packed Item reference is mandatory.
 msgstr "crwdns83332:0{0}crwdne83332:0"
 
 #: erpnext/accounts/doctype/journal_entry/journal_entry.py:1010
-#: erpnext/controllers/taxes_and_totals.py:1205
+#: erpnext/controllers/taxes_and_totals.py:1215
 msgid "Row {0}: Exchange Rate is mandatory"
 msgstr "crwdns83336:0{0}crwdne83336:0"
 
@@ -45523,11 +45518,11 @@ msgstr "crwdns83356:0{0}crwdne83356:0"
 msgid "Row {0}: Invalid reference {1}"
 msgstr "crwdns83358:0{0}crwdnd83358:0{1}crwdne83358:0"
 
-#: erpnext/controllers/taxes_and_totals.py:142
+#: erpnext/controllers/taxes_and_totals.py:143
 msgid "Row {0}: Item Tax template updated as per validity and rate applied"
 msgstr "crwdns83360:0{0}crwdne83360:0"
 
-#: erpnext/controllers/selling_controller.py:541
+#: erpnext/controllers/selling_controller.py:549
 msgid "Row {0}: Item rate has been updated as per valuation rate since its an internal stock transfer"
 msgstr "crwdns83362:0{0}crwdne83362:0"
 
@@ -45647,7 +45642,7 @@ msgstr "crwdns151452:0{0}crwdnd151452:0{1}crwdnd151452:0{2}crwdne151452:0"
 msgid "Row {0}: The item {1}, quantity must be positive number"
 msgstr "crwdns83414:0{0}crwdnd83414:0{1}crwdne83414:0"
 
-#: erpnext/controllers/accounts_controller.py:2972
+#: erpnext/controllers/accounts_controller.py:2975
 msgid "Row {0}: The {3} Account {1} does not belong to the company {2}"
 msgstr "crwdns149102:0{0}crwdnd149102:0{3}crwdnd149102:0{1}crwdnd149102:0{2}crwdne149102:0"
 
@@ -45664,7 +45659,7 @@ msgstr "crwdns83420:0{0}crwdne83420:0"
 msgid "Row {0}: Workstation or Workstation Type is mandatory for an operation {1}"
 msgstr "crwdns151454:0{0}crwdnd151454:0{1}crwdne151454:0"
 
-#: erpnext/controllers/accounts_controller.py:1011
+#: erpnext/controllers/accounts_controller.py:1014
 msgid "Row {0}: user has not applied the rule {1} on the item {2}"
 msgstr "crwdns83422:0{0}crwdnd83422:0{1}crwdnd83422:0{2}crwdne83422:0"
 
@@ -45676,7 +45671,7 @@ msgstr "crwdns83424:0{0}crwdnd83424:0{1}crwdnd83424:0{2}crwdne83424:0"
 msgid "Row {0}: {1} must be greater than 0"
 msgstr "crwdns83426:0{0}crwdnd83426:0{1}crwdne83426:0"
 
-#: erpnext/controllers/accounts_controller.py:706
+#: erpnext/controllers/accounts_controller.py:709
 msgid "Row {0}: {1} {2} cannot be same as {3} (Party Account) {4}"
 msgstr "crwdns83428:0{0}crwdnd83428:0{1}crwdnd83428:0{2}crwdnd83428:0{3}crwdnd83428:0{4}crwdne83428:0"
 
@@ -45692,7 +45687,7 @@ msgstr "crwdns111978:0{0}crwdnd111978:0{2}crwdnd111978:0{1}crwdnd111978:0{2}crwd
 msgid "Row {1}: Quantity ({0}) cannot be a fraction. To allow this, disable '{2}' in UOM {3}."
 msgstr "crwdns83434:0{1}crwdnd83434:0{0}crwdnd83434:0{2}crwdnd83434:0{3}crwdne83434:0"
 
-#: erpnext/controllers/buying_controller.py:863
+#: erpnext/controllers/buying_controller.py:871
 msgid "Row {idx}: Asset Naming Series is mandatory for the auto creation of assets for item {item_code}."
 msgstr "crwdns154270:0{idx}crwdnd154270:0{item_code}crwdne154270:0"
 
@@ -45718,7 +45713,7 @@ msgstr "crwdns83444:0{0}crwdne83444:0"
 msgid "Rows with Same Account heads will be merged on Ledger"
 msgstr "crwdns136958:0crwdne136958:0"
 
-#: erpnext/controllers/accounts_controller.py:2539
+#: erpnext/controllers/accounts_controller.py:2542
 msgid "Rows with duplicate due dates in other rows were found: {0}"
 msgstr "crwdns83448:0{0}crwdne83448:0"
 
@@ -45788,7 +45783,7 @@ msgstr "crwdns83484:0crwdne83484:0"
 msgid "SLA Paused On"
 msgstr "crwdns136972:0crwdne136972:0"
 
-#: erpnext/public/js/utils.js:1167
+#: erpnext/public/js/utils.js:1163
 msgid "SLA is on hold since {0}"
 msgstr "crwdns83488:0{0}crwdne83488:0"
 
@@ -46189,7 +46184,7 @@ msgstr "crwdns104650:0crwdne104650:0"
 #: erpnext/accounts/report/sales_register/sales_register.py:238
 #: erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
 #: erpnext/buying/doctype/supplier_quotation_item/supplier_quotation_item.json
-#: erpnext/controllers/selling_controller.py:462
+#: erpnext/controllers/selling_controller.py:470
 #: erpnext/crm/doctype/contract/contract.json
 #: erpnext/maintenance/doctype/maintenance_schedule/maintenance_schedule.js:65
 #: erpnext/maintenance/doctype/maintenance_schedule_item/maintenance_schedule_item.json
@@ -46315,7 +46310,7 @@ msgstr "crwdns83696:0{0}crwdne83696:0"
 msgid "Sales Order {0} is not valid"
 msgstr "crwdns83698:0{0}crwdne83698:0"
 
-#: erpnext/controllers/selling_controller.py:443
+#: erpnext/controllers/selling_controller.py:451
 #: erpnext/manufacturing/doctype/work_order/work_order.py:301
 msgid "Sales Order {0} is {1}"
 msgstr "crwdns83700:0{0}crwdnd83700:0{1}crwdne83700:0"
@@ -46366,7 +46361,7 @@ msgstr "crwdns137000:0crwdne137000:0"
 #: erpnext/accounts/doctype/promotional_scheme/promotional_scheme.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:122
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1156
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1158
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:99
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:194
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:74
@@ -46464,7 +46459,7 @@ msgstr "crwdns83756:0crwdne83756:0"
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:156
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:137
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:128
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1153
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1155
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:105
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:191
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:80
@@ -46484,7 +46479,7 @@ msgstr "crwdns83756:0crwdne83756:0"
 msgid "Sales Person"
 msgstr "crwdns83758:0crwdne83758:0"
 
-#: erpnext/controllers/selling_controller.py:204
+#: erpnext/controllers/selling_controller.py:212
 msgid "Sales Person <b>{0}</b> is disabled."
 msgstr "crwdns151700:0{0}crwdne151700:0"
 
@@ -46765,7 +46760,7 @@ msgstr "crwdns137022:0crwdne137022:0"
 
 #. Label of the sample_size (Float) field in DocType 'Quality Inspection'
 #: erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py:93
-#: erpnext/public/js/controllers/transaction.js:2369
+#: erpnext/public/js/controllers/transaction.js:2395
 #: erpnext/stock/doctype/quality_inspection/quality_inspection.json
 msgid "Sample Size"
 msgstr "crwdns83884:0crwdne83884:0"
@@ -47303,7 +47298,7 @@ msgstr "crwdns84128:0crwdne84128:0"
 msgid "Select Items based on Delivery Date"
 msgstr "crwdns84130:0crwdne84130:0"
 
-#: erpnext/public/js/controllers/transaction.js:2405
+#: erpnext/public/js/controllers/transaction.js:2431
 msgid "Select Items for Quality Inspection"
 msgstr "crwdns84132:0crwdne84132:0"
 
@@ -47444,7 +47439,7 @@ msgstr "crwdns84188:0crwdne84188:0"
 msgid "Select company name first."
 msgstr "crwdns137096:0crwdne137096:0"
 
-#: erpnext/controllers/accounts_controller.py:2785
+#: erpnext/controllers/accounts_controller.py:2788
 msgid "Select finance book for the item {0} at row {1}"
 msgstr "crwdns84192:0{0}crwdnd84192:0{1}crwdne84192:0"
 
@@ -47657,7 +47652,7 @@ msgid "Send Now"
 msgstr "crwdns84284:0crwdne84284:0"
 
 #. Label of the send_sms (Button) field in DocType 'SMS Center'
-#: erpnext/public/js/controllers/transaction.js:517
+#: erpnext/public/js/controllers/transaction.js:543
 #: erpnext/selling/doctype/sms_center/sms_center.json
 msgid "Send SMS"
 msgstr "crwdns84286:0crwdne84286:0"
@@ -47815,7 +47810,7 @@ msgstr "crwdns84330:0crwdne84330:0"
 #: erpnext/manufacturing/doctype/job_card/job_card.json
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.js:74
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.py:114
-#: erpnext/public/js/controllers/transaction.js:2382
+#: erpnext/public/js/controllers/transaction.js:2408
 #: erpnext/public/js/utils/serial_no_batch_selector.js:421
 #: erpnext/selling/doctype/installation_note_item/installation_note_item.json
 #: erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
@@ -47864,7 +47859,7 @@ msgstr "crwdns84384:0crwdne84384:0"
 msgid "Serial No Range"
 msgstr "crwdns149104:0crwdne149104:0"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1894
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1895
 msgid "Serial No Reserved"
 msgstr "crwdns152348:0crwdne152348:0"
 
@@ -47904,7 +47899,7 @@ msgstr "crwdns84392:0crwdne84392:0"
 msgid "Serial No and Batch Selector cannot be use when Use Serial / Batch Fields is enabled."
 msgstr "crwdns137146:0crwdne137146:0"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:859
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:860
 msgid "Serial No is mandatory"
 msgstr "crwdns84400:0crwdne84400:0"
 
@@ -47933,7 +47928,7 @@ msgstr "crwdns84410:0{0}crwdnd84410:0{1}crwdne84410:0"
 msgid "Serial No {0} does not exist"
 msgstr "crwdns84412:0{0}crwdne84412:0"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2623
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2624
 msgid "Serial No {0} does not exists"
 msgstr "crwdns104656:0{0}crwdne104656:0"
 
@@ -47941,7 +47936,7 @@ msgstr "crwdns104656:0{0}crwdne104656:0"
 msgid "Serial No {0} is already added"
 msgstr "crwdns84416:0{0}crwdne84416:0"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:357
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:358
 msgid "Serial No {0} is not present in the {1} {2}, hence you can't return it against the {1} {2}"
 msgstr "crwdns151940:0{0}crwdnd151940:0{1}crwdnd151940:0{2}crwdnd151940:0{1}crwdnd151940:0{2}crwdne151940:0"
 
@@ -47978,11 +47973,11 @@ msgstr "crwdns84428:0crwdne84428:0"
 msgid "Serial Nos and Batches"
 msgstr "crwdns137150:0crwdne137150:0"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1370
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1371
 msgid "Serial Nos are created successfully"
 msgstr "crwdns84434:0crwdne84434:0"
 
-#: erpnext/stock/stock_ledger.py:2137
+#: erpnext/stock/stock_ledger.py:2145
 msgid "Serial Nos are reserved in Stock Reservation Entries, you need to unreserve them before proceeding."
 msgstr "crwdns84436:0crwdne84436:0"
 
@@ -48056,11 +48051,11 @@ msgstr "crwdns137154:0crwdne137154:0"
 msgid "Serial and Batch Bundle"
 msgstr "crwdns84444:0crwdne84444:0"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1598
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1599
 msgid "Serial and Batch Bundle created"
 msgstr "crwdns84476:0crwdne84476:0"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1664
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1665
 msgid "Serial and Batch Bundle updated"
 msgstr "crwdns84478:0crwdne84478:0"
 
@@ -48412,12 +48407,12 @@ msgid "Service Stop Date"
 msgstr "crwdns137202:0crwdne137202:0"
 
 #: erpnext/accounts/deferred_revenue.py:44
-#: erpnext/public/js/controllers/transaction.js:1420
+#: erpnext/public/js/controllers/transaction.js:1446
 msgid "Service Stop Date cannot be after Service End Date"
 msgstr "crwdns84684:0crwdne84684:0"
 
 #: erpnext/accounts/deferred_revenue.py:41
-#: erpnext/public/js/controllers/transaction.js:1417
+#: erpnext/public/js/controllers/transaction.js:1443
 msgid "Service Stop Date cannot be before Service Start Date"
 msgstr "crwdns84686:0crwdne84686:0"
 
@@ -49852,7 +49847,7 @@ msgstr "crwdns85276:0crwdne85276:0"
 
 #: erpnext/setup/setup_wizard/operations/defaults_setup.py:70
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:463
-#: erpnext/stock/doctype/item/item.py:245
+#: erpnext/stock/doctype/item/item.py:248
 msgid "Standard Selling"
 msgstr "crwdns85278:0crwdne85278:0"
 
@@ -50682,7 +50677,7 @@ msgstr "crwdns85646:0crwdne85646:0"
 #. Option for the 'Purpose' (Select) field in DocType 'Stock Reconciliation'
 #. Label of a Link in the Stock Workspace
 #: erpnext/setup/workspace/home/home.json
-#: erpnext/stock/doctype/item/item.py:612
+#: erpnext/stock/doctype/item/item.py:618
 #: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.json
 #: erpnext/stock/workspace/stock/stock.json
 msgid "Stock Reconciliation"
@@ -50693,7 +50688,7 @@ msgstr "crwdns85652:0crwdne85652:0"
 msgid "Stock Reconciliation Item"
 msgstr "crwdns85656:0crwdne85656:0"
 
-#: erpnext/stock/doctype/item/item.py:612
+#: erpnext/stock/doctype/item/item.py:618
 msgid "Stock Reconciliations"
 msgstr "crwdns85658:0crwdne85658:0"
 
@@ -50728,7 +50723,7 @@ msgstr "crwdns85662:0crwdne85662:0"
 #: erpnext/stock/doctype/pick_list/pick_list.js:150
 #: erpnext/stock/doctype/pick_list/pick_list.js:155
 #: erpnext/stock/doctype/stock_entry/stock_entry_dashboard.py:25
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:706
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:702
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:575
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:1138
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:1398
@@ -51128,7 +51123,7 @@ msgstr "crwdns85824:0crwdne85824:0"
 #: erpnext/setup/doctype/company/company.py:287
 #: erpnext/setup/setup_wizard/operations/defaults_setup.py:33
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:502
-#: erpnext/stock/doctype/item/item.py:282
+#: erpnext/stock/doctype/item/item.py:285
 msgid "Stores"
 msgstr "crwdns85826:0crwdne85826:0"
 
@@ -51663,7 +51658,7 @@ msgstr "crwdns86058:0crwdne86058:0"
 msgid "Successfully Set Supplier"
 msgstr "crwdns86060:0crwdne86060:0"
 
-#: erpnext/stock/doctype/item/item.py:339
+#: erpnext/stock/doctype/item/item.py:342
 msgid "Successfully changed Stock UOM, please redefine conversion factors for new UOM."
 msgstr "crwdns86062:0crwdne86062:0"
 
@@ -51965,7 +51960,7 @@ msgstr "crwdns137544:0crwdne137544:0"
 #: erpnext/accounts/doctype/tax_rule/tax_rule.json
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:111
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:87
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1160
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1162
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:198
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:237
 #: erpnext/accounts/report/purchase_register/purchase_register.js:27
@@ -52065,7 +52060,7 @@ msgstr "crwdns86278:0crwdne86278:0"
 #. Label of the supplier_name (Data) field in DocType 'Purchase Receipt'
 #. Label of the supplier_name (Data) field in DocType 'Stock Entry'
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1077
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1079
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:156
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:198
 #: erpnext/accounts/report/purchase_register/purchase_register.py:177
@@ -52549,7 +52544,7 @@ msgstr "crwdns137590:0crwdne137590:0"
 msgid "System will fetch all the entries if limit value is zero."
 msgstr "crwdns137592:0crwdne137592:0"
 
-#: erpnext/controllers/accounts_controller.py:1975
+#: erpnext/controllers/accounts_controller.py:1978
 msgid "System will not check over billing since amount for Item {0} in {1} is zero"
 msgstr "crwdns86438:0{0}crwdnd86438:0{1}crwdne86438:0"
 
@@ -52808,7 +52803,7 @@ msgstr "crwdns152360:0crwdne152360:0"
 msgid "Target Warehouse is required before Submit"
 msgstr "crwdns137638:0crwdne137638:0"
 
-#: erpnext/controllers/selling_controller.py:782
+#: erpnext/controllers/selling_controller.py:790
 msgid "Target Warehouse is set for some items but the customer is not an internal customer."
 msgstr "crwdns86566:0crwdne86566:0"
 
@@ -53047,7 +53042,7 @@ msgstr "crwdns137662:0crwdne137662:0"
 msgid "Tax Category"
 msgstr "crwdns86664:0crwdne86664:0"
 
-#: erpnext/controllers/buying_controller.py:194
+#: erpnext/controllers/buying_controller.py:202
 msgid "Tax Category has been changed to \"Total\" because all the Items are non-stock items"
 msgstr "crwdns86700:0crwdne86700:0"
 
@@ -53252,7 +53247,7 @@ msgstr "crwdns137676:0crwdne137676:0"
 #. Label of the taxable_amount (Currency) field in DocType 'Tax Withheld
 #. Vouchers'
 #: erpnext/accounts/doctype/tax_withheld_vouchers/tax_withheld_vouchers.json
-#: erpnext/controllers/taxes_and_totals.py:1125
+#: erpnext/controllers/taxes_and_totals.py:1135
 msgid "Taxable Amount"
 msgstr "crwdns86794:0crwdne86794:0"
 
@@ -53391,7 +53386,7 @@ msgstr "crwdns137686:0crwdne137686:0"
 msgid "Taxes and Charges Deducted (Company Currency)"
 msgstr "crwdns137688:0crwdne137688:0"
 
-#: erpnext/stock/doctype/item/item.py:352
+#: erpnext/stock/doctype/item/item.py:355
 msgid "Taxes row #{0}: {1} cannot be smaller than {2}"
 msgstr "crwdns148632:0#{0}crwdnd148632:0{1}crwdnd148632:0{2}crwdne148632:0"
 
@@ -53677,7 +53672,7 @@ msgstr "crwdns143208:0crwdne143208:0"
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/territory_item/territory_item.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:134
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1144
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1146
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:93
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:182
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:68
@@ -53781,7 +53776,7 @@ msgstr "crwdns87056:0crwdne87056:0"
 msgid "The BOM which will be replaced"
 msgstr "crwdns137726:0crwdne137726:0"
 
-#: erpnext/stock/serial_batch_bundle.py:1274
+#: erpnext/stock/serial_batch_bundle.py:1306
 msgid "The Batch {0} has negative quantity {1} in warehouse {2}. Please correct the quantity."
 msgstr "crwdns152362:0{0}crwdnd152362:0{1}crwdnd152362:0{2}crwdne152362:0"
 
@@ -53833,7 +53828,7 @@ msgstr "crwdns152328:0{0}crwdne152328:0"
 msgid "The Serial No at Row #{0}: {1} is not available in warehouse {2}."
 msgstr "crwdns142842:0#{0}crwdnd142842:0{1}crwdnd142842:0{2}crwdne142842:0"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1891
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1892
 msgid "The Serial No {0} is reserved against the {1} {2} and cannot be used for any other transaction."
 msgstr "crwdns152364:0{0}crwdnd152364:0{1}crwdnd152364:0{2}crwdne152364:0"
 
@@ -53916,7 +53911,7 @@ msgstr "crwdns87120:0{0}crwdne87120:0"
 msgid "The following batches are expired, please restock them: <br> {0}"
 msgstr "crwdns154201:0{0}crwdne154201:0"
 
-#: erpnext/stock/doctype/item/item.py:849
+#: erpnext/stock/doctype/item/item.py:843
 msgid "The following deleted attributes exist in Variants but not in the Template. You can either delete the Variants or keep the attribute(s) in template."
 msgstr "crwdns87122:0crwdne87122:0"
 
@@ -53941,15 +53936,15 @@ msgstr "crwdns137732:0crwdne137732:0"
 msgid "The holiday on {0} is not between From Date and To Date"
 msgstr "crwdns87130:0{0}crwdne87130:0"
 
-#: erpnext/controllers/buying_controller.py:1066
+#: erpnext/controllers/buying_controller.py:1074
 msgid "The item {item} is not marked as {type_of} item. You can enable it as {type_of} item from its Item master."
 msgstr "crwdns154274:0{item}crwdnd154274:0{type_of}crwdnd154274:0{type_of}crwdne154274:0"
 
-#: erpnext/stock/doctype/item/item.py:614
+#: erpnext/stock/doctype/item/item.py:620
 msgid "The items {0} and {1} are present in the following {2} :"
 msgstr "crwdns87132:0{0}crwdnd87132:0{1}crwdnd87132:0{2}crwdne87132:0"
 
-#: erpnext/controllers/buying_controller.py:1059
+#: erpnext/controllers/buying_controller.py:1067
 msgid "The items {items} are not marked as {type_of} item. You can enable them as {type_of} item from their Item masters."
 msgstr "crwdns154276:0{items}crwdnd154276:0{type_of}crwdnd154276:0{type_of}crwdne154276:0"
 
@@ -54051,8 +54046,8 @@ msgstr "crwdns87164:0crwdne87164:0"
 msgid "The seller and the buyer cannot be the same"
 msgstr "crwdns87168:0crwdne87168:0"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:142
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:154
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:143
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:155
 msgid "The serial and batch bundle {0} not linked to {1} {2}"
 msgstr "crwdns152366:0{0}crwdnd152366:0{1}crwdnd152366:0{2}crwdne152366:0"
 
@@ -54076,7 +54071,7 @@ msgstr "crwdns87176:0{0}crwdne87176:0"
 msgid "The stock for the item {0} in the {1} warehouse was negative on the {2}. You should create a positive entry {3} before the date {4} and time {5} to post the correct valuation rate. For more details, please read the <a href='https://docs.erpnext.com/docs/user/manual/en/stock-adjustment-cogs-with-negative-stock'>documentation<a>."
 msgstr "crwdns143554:0{0}crwdnd143554:0{1}crwdnd143554:0{2}crwdnd143554:0{3}crwdnd143554:0{4}crwdnd143554:0{5}crwdne143554:0"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:700
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:696
 msgid "The stock has been reserved for the following Items and Warehouses, un-reserve the same to {0} the Stock Reconciliation: <br /><br /> {1}"
 msgstr "crwdns87178:0{0}crwdnd87178:0{1}crwdne87178:0"
 
@@ -54089,11 +54084,11 @@ msgstr "crwdns87180:0{0}crwdne87180:0"
 msgid "The task has been enqueued as a background job."
 msgstr "crwdns104668:0crwdne104668:0"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:994
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:990
 msgid "The task has been enqueued as a background job. In case there is any issue on processing in background, the system will add a comment about the error on this Stock Reconciliation and revert to the Draft stage"
 msgstr "crwdns87186:0crwdne87186:0"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1005
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1001
 msgid "The task has been enqueued as a background job. In case there is any issue on processing in background, the system will add a comment about the error on this Stock Reconciliation and revert to the Submitted stage"
 msgstr "crwdns87188:0crwdne87188:0"
 
@@ -54143,7 +54138,7 @@ msgstr "crwdns87204:0crwdne87204:0"
 msgid "The {0} ({1}) must be equal to {2} ({3})"
 msgstr "crwdns87206:0{0}crwdnd87206:0{1}crwdnd87206:0{2}crwdnd87206:0{3}crwdne87206:0"
 
-#: erpnext/public/js/controllers/transaction.js:2790
+#: erpnext/public/js/controllers/transaction.js:2816
 msgid "The {0} contains Unit Price Items."
 msgstr "crwdns154984:0{0}crwdne154984:0"
 
@@ -54191,7 +54186,7 @@ msgstr "crwdns87226:0crwdne87226:0"
 msgid "There can be multiple tiered collection factor based on the total spent. But the conversion factor for redemption will always be same for all the tier."
 msgstr "crwdns112060:0crwdne112060:0"
 
-#: erpnext/accounts/party.py:580
+#: erpnext/accounts/party.py:586
 msgid "There can only be 1 Account per Company in {0} {1}"
 msgstr "crwdns87228:0{0}crwdnd87228:0{1}crwdne87228:0"
 
@@ -54477,7 +54472,7 @@ msgstr "crwdns137764:0crwdne137764:0"
 msgid "This will restrict user access to other employee records"
 msgstr "crwdns137766:0crwdne137766:0"
 
-#: erpnext/controllers/selling_controller.py:783
+#: erpnext/controllers/selling_controller.py:791
 msgid "This {} will be treated as material transfer."
 msgstr "crwdns87364:0crwdne87364:0"
 
@@ -55191,11 +55186,11 @@ msgid "To include sub-assembly costs and scrap items in Finished Goods on a work
 msgstr "crwdns152230:0crwdne152230:0"
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:2337
-#: erpnext/controllers/accounts_controller.py:3005
+#: erpnext/controllers/accounts_controller.py:3008
 msgid "To include tax in row {0} in Item rate, taxes in rows {1} must also be included"
 msgstr "crwdns87724:0{0}crwdnd87724:0{1}crwdne87724:0"
 
-#: erpnext/stock/doctype/item/item.py:636
+#: erpnext/stock/doctype/item/item.py:642
 msgid "To merge, following properties must be same for both items"
 msgstr "crwdns87726:0crwdne87726:0"
 
@@ -55815,7 +55810,7 @@ msgstr "crwdns88002:0crwdne88002:0"
 msgid "Total Paid Amount"
 msgstr "crwdns88004:0crwdne88004:0"
 
-#: erpnext/controllers/accounts_controller.py:2591
+#: erpnext/controllers/accounts_controller.py:2594
 msgid "Total Payment Amount in Payment Schedule must be equal to Grand / Rounded Total"
 msgstr "crwdns88006:0crwdne88006:0"
 
@@ -56100,15 +56095,15 @@ msgstr "crwdns152595:0crwdne152595:0"
 msgid "Total Working Hours"
 msgstr "crwdns137950:0crwdne137950:0"
 
-#: erpnext/controllers/accounts_controller.py:2138
+#: erpnext/controllers/accounts_controller.py:2141
 msgid "Total advance ({0}) against Order {1} cannot be greater than the Grand Total ({2})"
 msgstr "crwdns88154:0{0}crwdnd88154:0{1}crwdnd88154:0{2}crwdne88154:0"
 
-#: erpnext/controllers/selling_controller.py:190
+#: erpnext/controllers/selling_controller.py:198
 msgid "Total allocated percentage for sales team should be 100"
 msgstr "crwdns88156:0crwdne88156:0"
 
-#: erpnext/selling/doctype/customer/customer.py:162
+#: erpnext/selling/doctype/customer/customer.py:161
 msgid "Total contribution percentage should be equal to 100"
 msgstr "crwdns88158:0crwdne88158:0"
 
@@ -56993,7 +56988,7 @@ msgstr "crwdns88602:0crwdne88602:0"
 msgid "Unit of Measure (UOM)"
 msgstr "crwdns143212:0crwdne143212:0"
 
-#: erpnext/stock/doctype/item/item.py:384
+#: erpnext/stock/doctype/item/item.py:387
 msgid "Unit of Measure {0} has been entered more than once in Conversion Factor Table"
 msgstr "crwdns88606:0{0}crwdne88606:0"
 
@@ -57435,7 +57430,7 @@ msgstr "crwdns152232:0crwdne152232:0"
 msgid "Update timestamp on new communication"
 msgstr "crwdns152234:0crwdne152234:0"
 
-#: erpnext/manufacturing/doctype/bom_creator/bom_creator.py:533
+#: erpnext/manufacturing/doctype/bom_creator/bom_creator.py:534
 msgid "Updated successfully"
 msgstr "crwdns138110:0crwdne138110:0"
 
@@ -57449,7 +57444,7 @@ msgstr "crwdns138110:0crwdne138110:0"
 msgid "Updated via 'Time Log' (In Minutes)"
 msgstr "crwdns138112:0crwdne138112:0"
 
-#: erpnext/stock/doctype/item/item.py:1387
+#: erpnext/stock/doctype/item/item.py:1381
 msgid "Updating Variants..."
 msgstr "crwdns88788:0crwdne88788:0"
 
@@ -58007,19 +58002,19 @@ msgstr "crwdns88992:0crwdne88992:0"
 msgid "Valuation Rate (In / Out)"
 msgstr "crwdns89020:0crwdne89020:0"
 
-#: erpnext/stock/stock_ledger.py:1881
+#: erpnext/stock/stock_ledger.py:1890
 msgid "Valuation Rate Missing"
 msgstr "crwdns89022:0crwdne89022:0"
 
-#: erpnext/stock/stock_ledger.py:1859
+#: erpnext/stock/stock_ledger.py:1868
 msgid "Valuation Rate for the Item {0}, is required to do accounting entries for {1} {2}."
 msgstr "crwdns89024:0{0}crwdnd89024:0{1}crwdnd89024:0{2}crwdne89024:0"
 
-#: erpnext/stock/doctype/item/item.py:266
+#: erpnext/stock/doctype/item/item.py:269
 msgid "Valuation Rate is mandatory if Opening Stock entered"
 msgstr "crwdns89026:0crwdne89026:0"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:752
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:748
 msgid "Valuation Rate required for Item {0} at row {1}"
 msgstr "crwdns89028:0{0}crwdnd89028:0{1}crwdne89028:0"
 
@@ -58029,7 +58024,7 @@ msgstr "crwdns89028:0{0}crwdnd89028:0{1}crwdne89028:0"
 msgid "Valuation and Total"
 msgstr "crwdns138192:0crwdne138192:0"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:971
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:967
 msgid "Valuation rate for customer provided items has been set to zero."
 msgstr "crwdns89032:0crwdne89032:0"
 
@@ -58043,7 +58038,7 @@ msgid "Valuation rate for the item as per Sales Invoice (Only for Internal Trans
 msgstr "crwdns142970:0crwdne142970:0"
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:2361
-#: erpnext/controllers/accounts_controller.py:3029
+#: erpnext/controllers/accounts_controller.py:3032
 msgid "Valuation type charges can not be marked as Inclusive"
 msgstr "crwdns89034:0crwdne89034:0"
 
@@ -58199,7 +58194,7 @@ msgstr "crwdns89086:0crwdne89086:0"
 msgid "Variant"
 msgstr "crwdns89088:0crwdne89088:0"
 
-#: erpnext/stock/doctype/item/item.py:864
+#: erpnext/stock/doctype/item/item.py:858
 msgid "Variant Attribute Error"
 msgstr "crwdns89090:0crwdne89090:0"
 
@@ -58218,7 +58213,7 @@ msgstr "crwdns89094:0crwdne89094:0"
 msgid "Variant Based On"
 msgstr "crwdns138204:0crwdne138204:0"
 
-#: erpnext/stock/doctype/item/item.py:892
+#: erpnext/stock/doctype/item/item.py:886
 msgid "Variant Based On cannot be changed"
 msgstr "crwdns89098:0crwdne89098:0"
 
@@ -58236,7 +58231,7 @@ msgstr "crwdns89102:0crwdne89102:0"
 msgid "Variant Item"
 msgstr "crwdns89104:0crwdne89104:0"
 
-#: erpnext/stock/doctype/item/item.py:862
+#: erpnext/stock/doctype/item/item.py:856
 msgid "Variant Items"
 msgstr "crwdns89106:0crwdne89106:0"
 
@@ -58354,7 +58349,7 @@ msgstr "crwdns89146:0crwdne89146:0"
 #: erpnext/accounts/doctype/cost_center/cost_center_tree.js:56
 #: erpnext/accounts/doctype/invoice_discounting/invoice_discounting.js:205
 #: erpnext/accounts/doctype/journal_entry/journal_entry.js:43
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:668
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:670
 #: erpnext/bulk_transaction/doctype/bulk_transaction_log/bulk_transaction_log.js:14
 #: erpnext/bulk_transaction/doctype/bulk_transaction_log/bulk_transaction_log.js:24
 #: erpnext/buying/doctype/request_for_quotation/request_for_quotation.js:167
@@ -58541,7 +58536,7 @@ msgstr "crwdns138236:0crwdne138236:0"
 #: erpnext/accounts/doctype/repost_accounting_ledger_items/repost_accounting_ledger_items.json
 #: erpnext/accounts/doctype/repost_payment_ledger_items/repost_payment_ledger_items.json
 #: erpnext/accounts/doctype/unreconcile_payment/unreconcile_payment.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1099
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1101
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.js:42
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:209
 #: erpnext/accounts/report/general_ledger/general_ledger.js:49
@@ -58572,7 +58567,7 @@ msgstr "crwdns138236:0crwdne138236:0"
 msgid "Voucher No"
 msgstr "crwdns89206:0crwdne89206:0"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1087
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1088
 msgid "Voucher No is mandatory"
 msgstr "crwdns127524:0crwdne127524:0"
 
@@ -58614,7 +58609,7 @@ msgstr "crwdns89230:0crwdne89230:0"
 #: erpnext/accounts/doctype/repost_payment_ledger_items/repost_payment_ledger_items.json
 #: erpnext/accounts/doctype/tax_withheld_vouchers/tax_withheld_vouchers.json
 #: erpnext/accounts/doctype/unreconcile_payment/unreconcile_payment.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1097
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1099
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:200
 #: erpnext/accounts/report/general_ledger/general_ledger.py:697
 #: erpnext/accounts/report/invalid_ledger_entries/invalid_ledger_entries.py:31
@@ -58968,10 +58963,6 @@ msgstr "crwdns89400:0crwdne89400:0"
 msgid "Warehouse not found against the account {0}"
 msgstr "crwdns89402:0{0}crwdne89402:0"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:600
-msgid "Warehouse not found in the system"
-msgstr "crwdns89404:0crwdne89404:0"
-
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:1130
 #: erpnext/stock/doctype/delivery_note/delivery_note.py:414
 msgid "Warehouse required for stock Item {0}"
@@ -59100,7 +59091,7 @@ msgid "Warn for new Request for Quotations"
 msgstr "crwdns138270:0crwdne138270:0"
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:744
-#: erpnext/controllers/accounts_controller.py:1978
+#: erpnext/controllers/accounts_controller.py:1981
 #: erpnext/stock/doctype/delivery_trip/delivery_trip.js:145
 #: erpnext/utilities/transaction_base.py:123
 msgid "Warning"
@@ -60072,7 +60063,7 @@ msgstr "crwdns138380:0crwdne138380:0"
 msgid "You are importing data for the code list:"
 msgstr "crwdns151712:0crwdne151712:0"
 
-#: erpnext/controllers/accounts_controller.py:3611
+#: erpnext/controllers/accounts_controller.py:3614
 msgid "You are not allowed to update as per the conditions set in {} Workflow."
 msgstr "crwdns89926:0crwdne89926:0"
 
@@ -60137,7 +60128,7 @@ msgstr "crwdns89956:0crwdne89956:0"
 msgid "You can't make any changes to Job Card since Work Order is closed."
 msgstr "crwdns89960:0crwdne89960:0"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:185
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:186
 msgid "You can't process the serial number {0} as it has already been used in the SABB {1}. {2} if you want to inward same serial number multiple times then enabled 'Allow existing Serial No to be Manufactured/Received again' in the {3}"
 msgstr "crwdns151954:0{0}crwdnd151954:0{1}crwdnd151954:0{2}crwdnd151954:0{3}crwdne151954:0"
 
@@ -60197,7 +60188,7 @@ msgstr "crwdns89986:0crwdne89986:0"
 msgid "You cannot {0} this document because another Period Closing Entry {1} exists after {2}"
 msgstr "crwdns151146:0{0}crwdnd151146:0{1}crwdnd151146:0{2}crwdne151146:0"
 
-#: erpnext/controllers/accounts_controller.py:3587
+#: erpnext/controllers/accounts_controller.py:3590
 msgid "You do not have permissions to {} items in a {}."
 msgstr "crwdns89988:0crwdne89988:0"
 
@@ -60225,7 +60216,7 @@ msgstr "crwdns152236:0{0}crwdne152236:0"
 msgid "You have entered a duplicate Delivery Note on Row"
 msgstr "crwdns90000:0crwdne90000:0"
 
-#: erpnext/stock/doctype/item/item.py:1063
+#: erpnext/stock/doctype/item/item.py:1057
 msgid "You have to enable auto re-order in Stock Settings to maintain re-order levels."
 msgstr "crwdns90002:0crwdne90002:0"
 
@@ -60245,7 +60236,7 @@ msgstr "crwdns90008:0crwdne90008:0"
 msgid "You need to cancel POS Closing Entry {} to be able to cancel this document."
 msgstr "crwdns90010:0crwdne90010:0"
 
-#: erpnext/controllers/accounts_controller.py:2980
+#: erpnext/controllers/accounts_controller.py:2983
 msgid "You selected the account group {1} as {2} Account in row {0}. Please select a single account."
 msgstr "crwdns149108:0{1}crwdnd149108:0{2}crwdnd149108:0{0}crwdne149108:0"
 
@@ -60323,7 +60314,7 @@ msgstr "crwdns90044:0crwdne90044:0"
 msgid "`Allow Negative rates for Items`"
 msgstr "crwdns90046:0crwdne90046:0"
 
-#: erpnext/stock/stock_ledger.py:1873
+#: erpnext/stock/stock_ledger.py:1882
 msgid "after"
 msgstr "crwdns112160:0crwdne112160:0"
 
@@ -60471,7 +60462,7 @@ msgstr "crwdns138408:0crwdne138408:0"
 msgid "material_request_item"
 msgstr "crwdns138410:0crwdne138410:0"
 
-#: erpnext/controllers/selling_controller.py:151
+#: erpnext/controllers/selling_controller.py:159
 msgid "must be between 0 and 100"
 msgstr "crwdns90102:0crwdne90102:0"
 
@@ -60496,7 +60487,7 @@ msgstr "crwdns138412:0crwdne138412:0"
 msgid "on"
 msgstr "crwdns112172:0crwdne112172:0"
 
-#: erpnext/controllers/accounts_controller.py:1289
+#: erpnext/controllers/accounts_controller.py:1292
 msgid "or"
 msgstr "crwdns90118:0crwdne90118:0"
 
@@ -60545,7 +60536,7 @@ msgstr "crwdns90126:0crwdne90126:0"
 msgid "per hour"
 msgstr "crwdns138414:0crwdne138414:0"
 
-#: erpnext/stock/stock_ledger.py:1874
+#: erpnext/stock/stock_ledger.py:1883
 msgid "performing either one below:"
 msgstr "crwdns90134:0crwdne90134:0"
 
@@ -60672,7 +60663,7 @@ msgstr "crwdns90194:0crwdne90194:0"
 msgid "{0}"
 msgstr "crwdns90196:0{0}crwdne90196:0"
 
-#: erpnext/controllers/accounts_controller.py:1109
+#: erpnext/controllers/accounts_controller.py:1112
 msgid "{0} '{1}' is disabled"
 msgstr "crwdns90198:0{0}crwdnd90198:0{1}crwdne90198:0"
 
@@ -60688,7 +60679,7 @@ msgstr "crwdns90202:0{0}crwdnd90202:0{1}crwdnd90202:0{2}crwdnd90202:0{3}crwdne90
 msgid "{0} <b>{1}</b> has submitted Assets. Remove Item <b>{2}</b> from table to continue."
 msgstr "crwdns90206:0{0}crwdnd90206:0{1}crwdnd90206:0{2}crwdne90206:0"
 
-#: erpnext/controllers/accounts_controller.py:2193
+#: erpnext/controllers/accounts_controller.py:2196
 msgid "{0} Account not found against Customer {1}."
 msgstr "crwdns90208:0{0}crwdnd90208:0{1}crwdne90208:0"
 
@@ -60720,7 +60711,7 @@ msgstr "crwdns90218:0{0}crwdnd90218:0{1}crwdne90218:0"
 msgid "{0} Request for {1}"
 msgstr "crwdns90220:0{0}crwdnd90220:0{1}crwdne90220:0"
 
-#: erpnext/stock/doctype/item/item.py:323
+#: erpnext/stock/doctype/item/item.py:326
 msgid "{0} Retain Sample is based on batch, please check Has Batch No to retain sample of item"
 msgstr "crwdns90222:0{0}crwdne90222:0"
 
@@ -60811,7 +60802,7 @@ msgid "{0} entered twice in Item Tax"
 msgstr "crwdns90260:0{0}crwdne90260:0"
 
 #: erpnext/setup/doctype/item_group/item_group.py:48
-#: erpnext/stock/doctype/item/item.py:436
+#: erpnext/stock/doctype/item/item.py:439
 msgid "{0} entered twice {1} in Item Taxes"
 msgstr "crwdns90262:0{0}crwdnd90262:0{1}crwdne90262:0"
 
@@ -60832,7 +60823,7 @@ msgstr "crwdns90268:0{0}crwdne90268:0"
 msgid "{0} hours"
 msgstr "crwdns112174:0{0}crwdne112174:0"
 
-#: erpnext/controllers/accounts_controller.py:2534
+#: erpnext/controllers/accounts_controller.py:2537
 msgid "{0} in row {1}"
 msgstr "crwdns90270:0{0}crwdnd90270:0{1}crwdne90270:0"
 
@@ -60856,7 +60847,7 @@ msgstr "crwdns90274:0{0}crwdne90274:0"
 
 #: erpnext/accounts/doctype/budget/budget.py:60
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:643
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:49
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:50
 #: erpnext/accounts/report/general_ledger/general_ledger.py:59
 #: erpnext/accounts/report/pos_register/pos_register.py:107
 #: erpnext/controllers/trends.py:50
@@ -60876,11 +60867,11 @@ msgstr "crwdns90280:0{0}crwdnd90280:0{1}crwdne90280:0"
 msgid "{0} is mandatory. Maybe Currency Exchange record is not created for {1} to {2}"
 msgstr "crwdns90282:0{0}crwdnd90282:0{1}crwdnd90282:0{2}crwdne90282:0"
 
-#: erpnext/controllers/accounts_controller.py:2937
+#: erpnext/controllers/accounts_controller.py:2940
 msgid "{0} is mandatory. Maybe Currency Exchange record is not created for {1} to {2}."
 msgstr "crwdns90284:0{0}crwdnd90284:0{1}crwdnd90284:0{2}crwdne90284:0"
 
-#: erpnext/selling/doctype/customer/customer.py:204
+#: erpnext/selling/doctype/customer/customer.py:203
 msgid "{0} is not a company bank account"
 msgstr "crwdns90286:0{0}crwdne90286:0"
 
@@ -60963,7 +60954,7 @@ msgstr "crwdns90318:0{0}crwdnd90318:0{1}crwdnd90318:0{2}crwdnd90318:0{3}crwdne90
 msgid "{0} to {1}"
 msgstr "crwdns154510:0{0}crwdnd154510:0{1}crwdne154510:0"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:690
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:686
 msgid "{0} units are reserved for Item {1} in Warehouse {2}, please un-reserve the same to {3} the Stock Reconciliation."
 msgstr "crwdns90320:0{0}crwdnd90320:0{1}crwdnd90320:0{2}crwdnd90320:0{3}crwdne90320:0"
 
@@ -60979,16 +60970,16 @@ msgstr "crwdns90324:0{0}crwdnd90324:0{1}crwdne90324:0"
 msgid "{0} units of {1} are required in {2} with the inventory dimension: {3} ({4}) on {5} {6} for {7} to complete the transaction."
 msgstr "crwdns151148:0{0}crwdnd151148:0{1}crwdnd151148:0{2}crwdnd151148:0{3}crwdnd151148:0{4}crwdnd151148:0{5}crwdnd151148:0{6}crwdnd151148:0{7}crwdne151148:0"
 
-#: erpnext/stock/stock_ledger.py:1532 erpnext/stock/stock_ledger.py:2023
-#: erpnext/stock/stock_ledger.py:2037
+#: erpnext/stock/stock_ledger.py:1541 erpnext/stock/stock_ledger.py:2031
+#: erpnext/stock/stock_ledger.py:2045
 msgid "{0} units of {1} needed in {2} on {3} {4} for {5} to complete this transaction."
 msgstr "crwdns90328:0{0}crwdnd90328:0{1}crwdnd90328:0{2}crwdnd90328:0{3}crwdnd90328:0{4}crwdnd90328:0{5}crwdne90328:0"
 
-#: erpnext/stock/stock_ledger.py:2124 erpnext/stock/stock_ledger.py:2170
+#: erpnext/stock/stock_ledger.py:2132 erpnext/stock/stock_ledger.py:2178
 msgid "{0} units of {1} needed in {2} on {3} {4} to complete this transaction."
 msgstr "crwdns90330:0{0}crwdnd90330:0{1}crwdnd90330:0{2}crwdnd90330:0{3}crwdnd90330:0{4}crwdne90330:0"
 
-#: erpnext/stock/stock_ledger.py:1526
+#: erpnext/stock/stock_ledger.py:1535
 msgid "{0} units of {1} needed in {2} to complete this transaction."
 msgstr "crwdns90332:0{0}crwdnd90332:0{1}crwdnd90332:0{2}crwdne90332:0"
 
@@ -61034,7 +61025,7 @@ msgstr "crwdns90346:0{0}crwdnd90346:0{1}crwdne90346:0"
 msgid "{0} {1} does not exist"
 msgstr "crwdns90348:0{0}crwdnd90348:0{1}crwdne90348:0"
 
-#: erpnext/accounts/party.py:560
+#: erpnext/accounts/party.py:566
 msgid "{0} {1} has accounting entries in currency {2} for company {3}. Please select a receivable or payable account with currency {2}."
 msgstr "crwdns90350:0{0}crwdnd90350:0{1}crwdnd90350:0{2}crwdnd90350:0{3}crwdnd90350:0{2}crwdne90350:0"
 
@@ -61068,7 +61059,7 @@ msgstr "crwdns151722:0{0}crwdnd151722:0{1}crwdnd151722:0{2}crwdne151722:0"
 msgid "{0} {1} is associated with {2}, but Party Account is {3}"
 msgstr "crwdns90362:0{0}crwdnd90362:0{1}crwdnd90362:0{2}crwdnd90362:0{3}crwdne90362:0"
 
-#: erpnext/controllers/selling_controller.py:462
+#: erpnext/controllers/selling_controller.py:470
 #: erpnext/controllers/subcontracting_controller.py:954
 msgid "{0} {1} is cancelled or closed"
 msgstr "crwdns90364:0{0}crwdnd90364:0{1}crwdne90364:0"
@@ -61085,11 +61076,11 @@ msgstr "crwdns90368:0{0}crwdnd90368:0{1}crwdne90368:0"
 msgid "{0} {1} is closed"
 msgstr "crwdns90370:0{0}crwdnd90370:0{1}crwdne90370:0"
 
-#: erpnext/accounts/party.py:798
+#: erpnext/accounts/party.py:804
 msgid "{0} {1} is disabled"
 msgstr "crwdns90372:0{0}crwdnd90372:0{1}crwdne90372:0"
 
-#: erpnext/accounts/party.py:804
+#: erpnext/accounts/party.py:810
 msgid "{0} {1} is frozen"
 msgstr "crwdns90374:0{0}crwdnd90374:0{1}crwdne90374:0"
 
@@ -61097,7 +61088,7 @@ msgstr "crwdns90374:0{0}crwdnd90374:0{1}crwdne90374:0"
 msgid "{0} {1} is fully billed"
 msgstr "crwdns90376:0{0}crwdnd90376:0{1}crwdne90376:0"
 
-#: erpnext/accounts/party.py:808
+#: erpnext/accounts/party.py:814
 msgid "{0} {1} is not active"
 msgstr "crwdns90378:0{0}crwdnd90378:0{1}crwdne90378:0"
 
@@ -61223,15 +61214,15 @@ msgstr "crwdns90434:0{0}crwdnd90434:0{1}crwdne90434:0"
 msgid "{0}: {1} must be less than {2}"
 msgstr "crwdns90436:0{0}crwdnd90436:0{1}crwdnd90436:0{2}crwdne90436:0"
 
-#: erpnext/controllers/buying_controller.py:840
+#: erpnext/controllers/buying_controller.py:848
 msgid "{count} Assets created for {item_code}"
 msgstr "crwdns154278:0{count}crwdnd154278:0{item_code}crwdne154278:0"
 
-#: erpnext/controllers/buying_controller.py:738
+#: erpnext/controllers/buying_controller.py:746
 msgid "{doctype} {name} is cancelled or closed."
 msgstr "crwdns154280:0{doctype}crwdnd154280:0{name}crwdne154280:0"
 
-#: erpnext/controllers/buying_controller.py:459
+#: erpnext/controllers/buying_controller.py:467
 msgid "{field_label} is mandatory for sub-contracted {doctype}."
 msgstr "crwdns154282:0{field_label}crwdnd154282:0{doctype}crwdne154282:0"
 
@@ -61239,7 +61230,7 @@ msgstr "crwdns154282:0{field_label}crwdnd154282:0{doctype}crwdne154282:0"
 msgid "{item_name}'s Sample Size ({sample_size}) cannot be greater than the Accepted Quantity ({accepted_quantity})"
 msgstr "crwdns90442:0{item_name}crwdnd90442:0{sample_size}crwdnd90442:0{accepted_quantity}crwdne90442:0"
 
-#: erpnext/controllers/buying_controller.py:563
+#: erpnext/controllers/buying_controller.py:571
 msgid "{ref_doctype} {ref_name} is {status}."
 msgstr "crwdns154284:0{ref_doctype}crwdnd154284:0{ref_name}crwdnd154284:0{status}crwdne154284:0"
 
@@ -61305,7 +61296,7 @@ msgstr "crwdns143236:0crwdne143236:0"
 msgid "{} can't be cancelled since the Loyalty Points earned has been redeemed. First cancel the {} No {}"
 msgstr "crwdns90450:0crwdne90450:0"
 
-#: erpnext/controllers/buying_controller.py:222
+#: erpnext/controllers/buying_controller.py:230
 msgid "{} has submitted assets linked to it. You need to cancel the assets to create purchase return."
 msgstr "crwdns90452:0crwdne90452:0"
 

--- a/erpnext/locale/es.po
+++ b/erpnext/locale/es.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: frappe\n"
 "Report-Msgid-Bugs-To: hello@frappe.io\n"
-"POT-Creation-Date: 2025-05-25 09:35+0000\n"
-"PO-Revision-Date: 2025-05-25 20:34\n"
+"POT-Creation-Date: 2025-06-01 09:36+0000\n"
+"PO-Revision-Date: 2025-06-01 21:34\n"
 "Last-Translator: hello@frappe.io\n"
 "Language-Team: Spanish\n"
 "MIME-Version: 1.0\n"
@@ -83,15 +83,15 @@ msgstr " Sub Ensamblado"
 msgid " Summary"
 msgstr " Resumen"
 
-#: erpnext/stock/doctype/item/item.py:235
+#: erpnext/stock/doctype/item/item.py:238
 msgid "\"Customer Provided Item\" cannot be Purchase Item also"
 msgstr "El \"artículo proporcionado por el cliente\" no puede ser un artículo de compra también"
 
-#: erpnext/stock/doctype/item/item.py:237
+#: erpnext/stock/doctype/item/item.py:240
 msgid "\"Customer Provided Item\" cannot have Valuation Rate"
 msgstr "El \"artículo proporcionado por el cliente\" no puede tener una tasa de valoración"
 
-#: erpnext/stock/doctype/item/item.py:313
+#: erpnext/stock/doctype/item/item.py:316
 msgid "\"Is Fixed Asset\" cannot be unchecked, as Asset record exists against the item"
 msgstr "\"Es activo fijo\" no puede estar sin marcar, ya que existe registro de activos contra el elemento"
 
@@ -213,7 +213,7 @@ msgstr "% de materiales facturados contra esta Orden de Venta"
 msgid "% of materials delivered against this Sales Order"
 msgstr "% de materiales entregados contra esta Orden de Venta"
 
-#: erpnext/controllers/accounts_controller.py:2197
+#: erpnext/controllers/accounts_controller.py:2200
 msgid "'Account' in the Accounting section of Customer {0}"
 msgstr "'Cuenta' en la sección Contabilidad de Cliente {0}"
 
@@ -225,15 +225,11 @@ msgstr "'Permitir múltiples órdenes de venta contra la orden de compra de un c
 msgid "'Based On' and 'Group By' can not be same"
 msgstr "'Basado en' y 'Agrupar por' no pueden ser iguales"
 
-#: erpnext/stock/report/product_bundle_balance/product_bundle_balance.py:233
-msgid "'Date' is required"
-msgstr "'Fecha' es requerido"
-
 #: erpnext/selling/report/inactive_customers/inactive_customers.py:18
 msgid "'Days Since Last Order' must be greater than or equal to zero"
 msgstr "'Días desde la última orden' debe ser mayor que o igual a cero"
 
-#: erpnext/controllers/accounts_controller.py:2202
+#: erpnext/controllers/accounts_controller.py:2205
 msgid "'Default {0} Account' in Company {1}"
 msgstr "'Cuenta {0} Predeterminada' en la Compañía {1}"
 
@@ -243,7 +239,7 @@ msgstr "'Entradas' no pueden estar vacías"
 
 #: erpnext/stock/report/batch_item_expiry_status/batch_item_expiry_status.py:24
 #: erpnext/stock/report/batch_wise_balance_history/batch_wise_balance_history.py:120
-#: erpnext/stock/report/stock_analytics/stock_analytics.py:314
+#: erpnext/stock/report/stock_analytics/stock_analytics.py:313
 msgid "'From Date' is required"
 msgstr "'Desde la fecha' es requerido"
 
@@ -251,7 +247,7 @@ msgstr "'Desde la fecha' es requerido"
 msgid "'From Date' must be after 'To Date'"
 msgstr "'Desde la fecha' debe ser después de 'Hasta Fecha'"
 
-#: erpnext/stock/doctype/item/item.py:398
+#: erpnext/stock/doctype/item/item.py:401
 msgid "'Has Serial No' can not be 'Yes' for non-stock item"
 msgstr "'Posee numero de serie' no puede ser \"Sí\" para los productos que NO son de stock"
 
@@ -1179,7 +1175,7 @@ msgstr "Cantidad Aceptada en UdM de Stock"
 
 #. Label of the qty (Float) field in DocType 'Purchase Receipt Item'
 #. Label of the qty (Float) field in DocType 'Subcontracting Receipt Item'
-#: erpnext/public/js/controllers/transaction.js:2362
+#: erpnext/public/js/controllers/transaction.js:2388
 #: erpnext/stock/doctype/purchase_receipt_item/purchase_receipt_item.json
 #: erpnext/subcontracting/doctype/subcontracting_receipt_item/subcontracting_receipt_item.json
 msgid "Accepted Quantity"
@@ -1377,7 +1373,7 @@ msgid "Account Manager"
 msgstr "Gerente de cuentas"
 
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:949
-#: erpnext/controllers/accounts_controller.py:2206
+#: erpnext/controllers/accounts_controller.py:2209
 msgid "Account Missing"
 msgstr "Cuenta Faltante"
 
@@ -1552,7 +1548,7 @@ msgstr "La cuenta {0} se agrega en la empresa secundaria {1}"
 msgid "Account {0} is frozen"
 msgstr "La cuenta {0} está congelada"
 
-#: erpnext/controllers/accounts_controller.py:1288
+#: erpnext/controllers/accounts_controller.py:1291
 msgid "Account {0} is invalid. Account Currency must be {1}"
 msgstr "La cuenta {0} no es válida. La divisa de la cuenta debe ser {1}"
 
@@ -1588,7 +1584,7 @@ msgstr "Cuenta: {0} sólo puede ser actualizada mediante transacciones de invent
 msgid "Account: {0} is not permitted under Payment Entry"
 msgstr "Cuenta: {0} no está permitido en Entrada de pago"
 
-#: erpnext/controllers/accounts_controller.py:3037
+#: erpnext/controllers/accounts_controller.py:3040
 msgid "Account: {0} with currency: {1} can not be selected"
 msgstr "Cuenta: {0} con divisa: {1} no puede ser seleccionada"
 
@@ -1861,7 +1857,7 @@ msgstr "Asientos contables"
 msgid "Accounting Entry for Asset"
 msgstr "Entrada Contable para Activos"
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:796
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:805
 msgid "Accounting Entry for Service"
 msgstr "Entrada contable para servicio"
 
@@ -1876,18 +1872,18 @@ msgstr "Entrada contable para servicio"
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py:1468
 #: erpnext/controllers/stock_controller.py:550
 #: erpnext/controllers/stock_controller.py:567
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:889
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:898
 #: erpnext/stock/doctype/stock_entry/stock_entry.py:1586
 #: erpnext/stock/doctype/stock_entry/stock_entry.py:1600
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py:561
 msgid "Accounting Entry for Stock"
 msgstr "Asiento contable para inventario"
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:717
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:726
 msgid "Accounting Entry for {0}"
 msgstr "Entrada contable para {0}"
 
-#: erpnext/controllers/accounts_controller.py:2247
+#: erpnext/controllers/accounts_controller.py:2250
 msgid "Accounting Entry for {0}: {1} can only be made in currency: {2}"
 msgstr "Asiento contable para {0}: {1} sólo puede realizarse con la divisa: {2}"
 
@@ -2280,7 +2276,7 @@ msgstr "La depreciación acumulada como en"
 msgid "Accumulated Monthly"
 msgstr "acumulado Mensual"
 
-#: erpnext/controllers/budget_controller.py:417
+#: erpnext/controllers/budget_controller.py:422
 msgid "Accumulated Monthly Budget for Account {0} against {1} {2} is {3}. It will be collectively ({4}) exceeded by {5}"
 msgstr ""
 
@@ -3394,7 +3390,7 @@ msgstr "Ajustar el valor del activo"
 msgid "Adjustment Against"
 msgstr "Ajuste contra"
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:634
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:643
 msgid "Adjustment based on Purchase Invoice rate"
 msgstr "Ajuste basado en la tarifa de la Factura de Compra"
 
@@ -3505,7 +3501,7 @@ msgstr "Impuestos y Cargos anticipados"
 msgid "Advance amount"
 msgstr "Importe Anticipado"
 
-#: erpnext/controllers/taxes_and_totals.py:845
+#: erpnext/controllers/taxes_and_totals.py:855
 msgid "Advance amount cannot be greater than {0} {1}"
 msgstr "Cantidad de avance no puede ser mayor que {0} {1}"
 
@@ -3716,7 +3712,7 @@ msgstr "Edad"
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:152
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:133
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1125
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1127
 msgid "Age (Days)"
 msgstr "Edad (Días)"
 
@@ -3802,16 +3798,6 @@ msgstr "Agregue un grupo de Artículos en otro Artículo. Esto es útil si está
 #: erpnext/setup/setup_wizard/data/industry_type.txt:4
 msgid "Agriculture"
 msgstr "Agricultura"
-
-#. Name of a role
-#: erpnext/assets/doctype/location/location.json
-msgid "Agriculture Manager"
-msgstr "Gerente de Agricultura"
-
-#. Name of a role
-#: erpnext/assets/doctype/location/location.json
-msgid "Agriculture User"
-msgstr "Usuario de Agricultura"
 
 #: erpnext/setup/setup_wizard/data/industry_type.txt:5
 msgid "Airline"
@@ -4003,7 +3989,7 @@ msgstr "Todas las comunicaciones incluidas y superiores se incluirán en el nuev
 msgid "All items are already requested"
 msgstr "Todos los artículos ya están solicitados"
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:1317
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:1326
 msgid "All items have already been Invoiced/Returned"
 msgstr "Todos los artículos ya han sido facturados / devueltos"
 
@@ -4015,7 +4001,7 @@ msgstr "Ya se han recibido todos los artículos"
 msgid "All items have already been transferred for this Work Order."
 msgstr "Todos los artículos ya han sido transferidos para esta Orden de Trabajo."
 
-#: erpnext/public/js/controllers/transaction.js:2465
+#: erpnext/public/js/controllers/transaction.js:2491
 msgid "All items in this document already have a linked Quality Inspection."
 msgstr "Todos los artículos de este documento ya tienen una Inspección de Calidad vinculada."
 
@@ -4213,7 +4199,7 @@ msgstr "Permitir Transferencias Internas a Precio de Mercado"
 msgid "Allow Item To Be Added Multiple Times in a Transaction"
 msgstr "Permitir que el artículo se agregue varias veces en una transacción"
 
-#: erpnext/controllers/selling_controller.py:755
+#: erpnext/controllers/selling_controller.py:763
 msgid "Allow Item to Be Added Multiple Times in a Transaction"
 msgstr "Permitir que un artículo se añada varias veces en una transacción"
 
@@ -5159,7 +5145,7 @@ msgstr "Anual"
 msgid "Annual Billing: {0}"
 msgstr "Facturación anual: {0}"
 
-#: erpnext/controllers/budget_controller.py:441
+#: erpnext/controllers/budget_controller.py:446
 msgid "Annual Budget for Account {0} against {1} {2} is {3}. It will be collectively ({4}) exceeded by {5}"
 msgstr ""
 
@@ -5648,7 +5634,7 @@ msgstr "Como el campo {0} está habilitado, el campo {1} es obligatorio."
 msgid "As the field {0} is enabled, the value of the field {1} should be more than 1."
 msgstr "Como el campo {0} está habilitado, el valor del campo {1} debe ser superior a 1."
 
-#: erpnext/stock/doctype/item/item.py:989
+#: erpnext/stock/doctype/item/item.py:983
 msgid "As there are existing submitted transactions against item {0}, you can not change the value of {1}."
 msgstr "Como ya existen transacciones validadas contra el artículo {0}, no puede cambiar el valor de {1}."
 
@@ -5794,7 +5780,7 @@ msgstr "Cuenta de categoría de activos"
 msgid "Asset Category Name"
 msgstr "Nombre de la Categoría de Activos"
 
-#: erpnext/stock/doctype/item/item.py:304
+#: erpnext/stock/doctype/item/item.py:307
 msgid "Asset Category is mandatory for Fixed Asset item"
 msgstr "Categoría activo es obligatorio para la partida del activo fijo"
 
@@ -6169,7 +6155,7 @@ msgstr "El activo {0} ha sido actualizado. Por favor, establezca los detalles de
 msgid "Asset {0} must be submitted"
 msgstr "Activo {0} debe ser validado"
 
-#: erpnext/controllers/buying_controller.py:851
+#: erpnext/controllers/buying_controller.py:859
 msgid "Asset {assets_link} created for {item_code}"
 msgstr ""
 
@@ -6199,11 +6185,11 @@ msgstr "Valor del activo ajustado tras el envío del ajuste del valor del activo
 msgid "Assets"
 msgstr "Bienes"
 
-#: erpnext/controllers/buying_controller.py:869
+#: erpnext/controllers/buying_controller.py:877
 msgid "Assets not created for {item_code}. You will have to create asset manually."
 msgstr "Activos no creados para {item_code}. Tendrá que crear el activo manualmente."
 
-#: erpnext/controllers/buying_controller.py:856
+#: erpnext/controllers/buying_controller.py:864
 msgid "Assets {assets_link} created for {item_code}"
 msgstr ""
 
@@ -6298,7 +6284,7 @@ msgstr "En la fila n.º {0}: el ID de secuencia {1} no puede ser menor que el ID
 msgid "At row #{0}: you have selected the Difference Account {1}, which is a Cost of Goods Sold type account. Please select a different account"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:864
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:865
 msgid "At row {0}: Batch No is mandatory for Item {1}"
 msgstr "En la fila {0}: el Núm. de Lote es obligatorio para el Producto {1}"
 
@@ -6306,11 +6292,11 @@ msgstr "En la fila {0}: el Núm. de Lote es obligatorio para el Producto {1}"
 msgid "At row {0}: Parent Row No cannot be set for item {1}"
 msgstr "En la fila {0}: No se puede establecer el nº de fila padre para el artículo {1}"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:849
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:850
 msgid "At row {0}: Qty is mandatory for the batch {1}"
 msgstr "En la fila {0}: La cant. es obligatoria para el lote {1}"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:856
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:857
 msgid "At row {0}: Serial No is mandatory for Item {1}"
 msgstr "En la fila {0}: el Núm. Serial es obligatorio para el Producto {1}"
 
@@ -6384,7 +6370,7 @@ msgstr "Nombre del Atributo"
 msgid "Attribute Value"
 msgstr "Valor del Atributo"
 
-#: erpnext/stock/doctype/item/item.py:930
+#: erpnext/stock/doctype/item/item.py:924
 msgid "Attribute table is mandatory"
 msgstr "Tabla de atributos es obligatoria"
 
@@ -6392,11 +6378,11 @@ msgstr "Tabla de atributos es obligatoria"
 msgid "Attribute value: {0} must appear only once"
 msgstr "Valor del atributo: {0} debe aparecer sólo una vez"
 
-#: erpnext/stock/doctype/item/item.py:934
+#: erpnext/stock/doctype/item/item.py:928
 msgid "Attribute {0} selected multiple times in Attributes Table"
 msgstr "Atributo {0} seleccionado varias veces en la tabla Atributos"
 
-#: erpnext/stock/doctype/item/item.py:862
+#: erpnext/stock/doctype/item/item.py:856
 msgid "Attributes"
 msgstr "Atributos"
 
@@ -7680,11 +7666,11 @@ msgstr "Código de barras"
 msgid "Barcode Type"
 msgstr "Tipo de Código de Barras"
 
-#: erpnext/stock/doctype/item/item.py:457
+#: erpnext/stock/doctype/item/item.py:460
 msgid "Barcode {0} already used in Item {1}"
 msgstr "El código de barras {0} ya se utiliza en el artículo {1}"
 
-#: erpnext/stock/doctype/item/item.py:472
+#: erpnext/stock/doctype/item/item.py:475
 msgid "Barcode {0} is not a valid {1} code"
 msgstr "Código de Barras {0} no es un código {1} válido"
 
@@ -7938,7 +7924,7 @@ msgstr "Estado de Caducidad de Lote de Productos"
 #: erpnext/manufacturing/doctype/job_card/job_card.json
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.js:89
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.py:115
-#: erpnext/public/js/controllers/transaction.js:2388
+#: erpnext/public/js/controllers/transaction.js:2414
 #: erpnext/public/js/utils/barcode_scanner.js:260
 #: erpnext/public/js/utils/serial_no_batch_selector.js:438
 #: erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
@@ -7965,11 +7951,11 @@ msgstr "Estado de Caducidad de Lote de Productos"
 msgid "Batch No"
 msgstr "Lote Nro."
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:867
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:868
 msgid "Batch No is mandatory"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2629
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2630
 msgid "Batch No {0} does not exists"
 msgstr "Lote núm. {0} no existe"
 
@@ -7977,7 +7963,7 @@ msgstr "Lote núm. {0} no existe"
 msgid "Batch No {0} is linked with Item {1} which has serial no. Please scan serial no instead."
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:364
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:365
 msgid "Batch No {0} is not present in the original {1} {2}, hence you can't return it against the {1} {2}"
 msgstr ""
 
@@ -7992,11 +7978,11 @@ msgstr "Nº de Lote"
 msgid "Batch Nos"
 msgstr "Números de Lote"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1421
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1422
 msgid "Batch Nos are created successfully"
 msgstr "Los Núm. de Lote se crearon correctamente"
 
-#: erpnext/controllers/sales_and_purchase_return.py:1096
+#: erpnext/controllers/sales_and_purchase_return.py:1001
 msgid "Batch Not Available for Return"
 msgstr ""
 
@@ -8045,7 +8031,7 @@ msgstr ""
 msgid "Batch {0} and Warehouse"
 msgstr ""
 
-#: erpnext/controllers/sales_and_purchase_return.py:1095
+#: erpnext/controllers/sales_and_purchase_return.py:1000
 msgid "Batch {0} is not available in warehouse {1}"
 msgstr ""
 
@@ -8095,7 +8081,7 @@ msgstr "Los siguientes planes de suscripción tienen una moneda diferente a la m
 #. Label of the bill_date (Date) field in DocType 'Journal Entry'
 #. Label of the bill_date (Date) field in DocType 'Subcontracting Receipt'
 #: erpnext/accounts/doctype/journal_entry/journal_entry.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1110
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1112
 #: erpnext/accounts/report/purchase_register/purchase_register.py:214
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.json
 msgid "Bill Date"
@@ -8104,7 +8090,7 @@ msgstr "Fecha de factura"
 #. Label of the bill_no (Data) field in DocType 'Journal Entry'
 #. Label of the bill_no (Data) field in DocType 'Subcontracting Receipt'
 #: erpnext/accounts/doctype/journal_entry/journal_entry.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1109
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1111
 #: erpnext/accounts/report/purchase_register/purchase_register.py:213
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.json
 msgid "Bill No"
@@ -8324,7 +8310,7 @@ msgstr "Estado de facturación"
 msgid "Billing Zipcode"
 msgstr "Código Postal de Facturación"
 
-#: erpnext/accounts/party.py:602
+#: erpnext/accounts/party.py:608
 msgid "Billing currency must be equal to either default company's currency or party account currency"
 msgstr "La moneda de facturación debe ser igual a la moneda de la compañía predeterminada o la moneda de la cuenta de la parte"
 
@@ -9321,7 +9307,7 @@ msgid "Can only make payment against unbilled {0}"
 msgstr "Sólo se puede crear el pago contra {0} impagado"
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1458
-#: erpnext/controllers/accounts_controller.py:2946
+#: erpnext/controllers/accounts_controller.py:2949
 #: erpnext/public/js/controllers/accounts.js:90
 msgid "Can refer row only if the charge type is 'On Previous Row Amount' or 'Previous Row Total'"
 msgstr "Puede referirse a la línea, sólo si el tipo de importe es 'previo al importe' o 'previo al total'"
@@ -9483,9 +9469,9 @@ msgstr "No se puede calcular la hora de llegada porque falta la dirección del c
 msgid "Cannot Create Return"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:625
-#: erpnext/stock/doctype/item/item.py:638
-#: erpnext/stock/doctype/item/item.py:652
+#: erpnext/stock/doctype/item/item.py:631
+#: erpnext/stock/doctype/item/item.py:644
+#: erpnext/stock/doctype/item/item.py:658
 msgid "Cannot Merge"
 msgstr "No se puede fusionar"
 
@@ -9509,7 +9495,7 @@ msgstr "No se puede modificar {0} {1}; en su lugar, cree uno nuevo."
 msgid "Cannot apply TDS against multiple parties in one entry"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:307
+#: erpnext/stock/doctype/item/item.py:310
 msgid "Cannot be a fixed asset item as Stock Ledger is created."
 msgstr "No puede ser un elemento de Activo Fijo ya que se creo un Libro de Stock ."
 
@@ -9525,7 +9511,7 @@ msgstr "No se puede cancelar debido a que existe una entrada de Stock validada e
 msgid "Cannot cancel the transaction. Reposting of item valuation on submission is not completed yet."
 msgstr "No se puede cancelar la transacción. La validación del traspaso de la valoración del artículo, aún no se ha completado."
 
-#: erpnext/controllers/buying_controller.py:959
+#: erpnext/controllers/buying_controller.py:967
 msgid "Cannot cancel this document as it is linked with the submitted asset {asset_link}. Please cancel the asset to continue."
 msgstr ""
 
@@ -9533,7 +9519,7 @@ msgstr ""
 msgid "Cannot cancel transaction for Completed Work Order."
 msgstr "No se puede cancelar la transacción para la orden de trabajo completada."
 
-#: erpnext/stock/doctype/item/item.py:882
+#: erpnext/stock/doctype/item/item.py:876
 msgid "Cannot change Attributes after stock transaction. Make a new Item and transfer stock to the new Item"
 msgstr "No se pueden cambiar los Atributos después de la Transacciones de Stock. Haga un nuevo Artículo y transfiera el stock al nuevo Artículo"
 
@@ -9549,7 +9535,7 @@ msgstr "No se puede cambiar el tipo de documento de referencia."
 msgid "Cannot change Service Stop Date for item in row {0}"
 msgstr "No se puede cambiar la fecha de detención del servicio para el artículo en la fila {0}"
 
-#: erpnext/stock/doctype/item/item.py:873
+#: erpnext/stock/doctype/item/item.py:867
 msgid "Cannot change Variant properties after stock transaction. You will have to make a new Item to do this."
 msgstr "No se pueden cambiar las propiedades de la Variante después de una transacción de stock. Deberá crear un nuevo ítem para hacer esto."
 
@@ -9577,7 +9563,7 @@ msgstr "No se puede convertir a Grupo porque Tipo de Cuenta está seleccionado."
 msgid "Cannot covert to Group because Account Type is selected."
 msgstr "No se puede convertir a 'Grupo' porque se seleccionó 'Tipo de Cuenta'."
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:972
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:981
 msgid "Cannot create Stock Reservation Entries for future dated Purchase Receipts."
 msgstr ""
 
@@ -9628,7 +9614,7 @@ msgstr "No se puede garantizar la entrega por número de serie ya que el artícu
 msgid "Cannot find Item with this Barcode"
 msgstr "No se puede encontrar el artículo con este código de barras"
 
-#: erpnext/controllers/accounts_controller.py:3483
+#: erpnext/controllers/accounts_controller.py:3486
 msgid "Cannot find a default warehouse for item {0}. Please set one in the Item Master or in Stock Settings."
 msgstr ""
 
@@ -9636,7 +9622,7 @@ msgstr ""
 msgid "Cannot make any transactions until the deletion job is completed"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2074
+#: erpnext/controllers/accounts_controller.py:2077
 msgid "Cannot overbill for Item {0} in row {1} more than {2}. To allow over-billing, please set allowance in Accounts Settings"
 msgstr "No se puede facturar en exceso el artículo {0} en la fila {1} más de {2}. Para permitir una facturación excesiva, configure la asignación en la Configuración de cuentas"
 
@@ -9657,7 +9643,7 @@ msgid "Cannot receive from customer against negative outstanding"
 msgstr ""
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1475
-#: erpnext/controllers/accounts_controller.py:2961
+#: erpnext/controllers/accounts_controller.py:2964
 #: erpnext/public/js/controllers/accounts.js:100
 msgid "Cannot refer row number greater than or equal to current row number for this Charge type"
 msgstr "No se puede referenciar a una línea mayor o igual al numero de línea actual."
@@ -9673,7 +9659,7 @@ msgstr ""
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1467
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1646
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:1917
-#: erpnext/controllers/accounts_controller.py:2951
+#: erpnext/controllers/accounts_controller.py:2954
 #: erpnext/public/js/controllers/accounts.js:94
 #: erpnext/public/js/controllers/taxes_and_totals.js:470
 msgid "Cannot select charge type as 'On Previous Row Amount' or 'On Previous Row Total' for first row"
@@ -9687,15 +9673,15 @@ msgstr "No se puede definir como pérdida, cuando la orden de venta esta hecha."
 msgid "Cannot set authorization on basis of Discount for {0}"
 msgstr "No se puede establecer la autorización sobre la base de descuento para {0}"
 
-#: erpnext/stock/doctype/item/item.py:716
+#: erpnext/stock/doctype/item/item.py:722
 msgid "Cannot set multiple Item Defaults for a company."
 msgstr "No se pueden establecer varios valores predeterminados de artículos para una empresa."
 
-#: erpnext/controllers/accounts_controller.py:3631
+#: erpnext/controllers/accounts_controller.py:3634
 msgid "Cannot set quantity less than delivered quantity"
 msgstr "No se puede establecer una cantidad menor que la cantidad entregada"
 
-#: erpnext/controllers/accounts_controller.py:3634
+#: erpnext/controllers/accounts_controller.py:3637
 msgid "Cannot set quantity less than received quantity"
 msgstr "No se puede establecer una cantidad menor que la cantidad recibida"
 
@@ -10118,7 +10104,7 @@ msgid "Channel Partner"
 msgstr "Canal de socio"
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:2346
-#: erpnext/controllers/accounts_controller.py:3014
+#: erpnext/controllers/accounts_controller.py:3017
 msgid "Charge of type 'Actual' in row {0} cannot be included in Item Rate or Paid Amount"
 msgstr ""
 
@@ -10301,7 +10287,7 @@ msgstr "Ancho Cheque"
 
 #. Label of the reference_date (Date) field in DocType 'Payment Entry'
 #: erpnext/accounts/doctype/payment_entry/payment_entry.json
-#: erpnext/public/js/controllers/transaction.js:2299
+#: erpnext/public/js/controllers/transaction.js:2325
 msgid "Cheque/Reference Date"
 msgstr "Cheque / Fecha de referencia"
 
@@ -10349,7 +10335,7 @@ msgstr "Nombre del documento secundario"
 
 #. Label of the child_row_reference (Data) field in DocType 'Quality
 #. Inspection'
-#: erpnext/public/js/controllers/transaction.js:2394
+#: erpnext/public/js/controllers/transaction.js:2420
 #: erpnext/stock/doctype/quality_inspection/quality_inspection.json
 msgid "Child Row Reference"
 msgstr ""
@@ -11061,7 +11047,7 @@ msgstr "Compañías"
 #: erpnext/accounts/report/cheques_and_deposits_incorrectly_cleared/cheques_and_deposits_incorrectly_cleared.js:8
 #: erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.js:8
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:8
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:49
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:50
 #: erpnext/accounts/report/deferred_revenue_and_expense/deferred_revenue_and_expense.js:8
 #: erpnext/accounts/report/delivered_items_to_be_billed/delivered_items_to_be_billed.js:7
 #: erpnext/accounts/report/dimension_wise_accounts_balance_report/dimension_wise_accounts_balance_report.js:8
@@ -12294,7 +12280,7 @@ msgid "Content Type"
 msgstr "Tipo de contenido"
 
 #: erpnext/erpnext_integrations/doctype/plaid_settings/plaid_settings.js:162
-#: erpnext/public/js/controllers/transaction.js:2312
+#: erpnext/public/js/controllers/transaction.js:2338
 #: erpnext/selling/doctype/quotation/quotation.js:356
 msgid "Continue"
 msgstr "Continuar"
@@ -12459,7 +12445,7 @@ msgstr "Factor de conversión"
 msgid "Conversion Rate"
 msgstr "Tasa de conversión"
 
-#: erpnext/stock/doctype/item/item.py:393
+#: erpnext/stock/doctype/item/item.py:396
 msgid "Conversion factor for default Unit of Measure must be 1 in row {0}"
 msgstr "El factor de conversión de la unidad de medida (UdM) en la línea {0} debe ser 1"
 
@@ -12467,15 +12453,15 @@ msgstr "El factor de conversión de la unidad de medida (UdM) en la línea {0} d
 msgid "Conversion factor for item {0} has been reset to 1.0 as the uom {1} is same as stock uom {2}."
 msgstr "El factor de conversión para el artículo {0} se ha restablecido a 1.0, ya que la unidad de medida {1} es la misma que la unidad de medida de stock {2}."
 
-#: erpnext/controllers/accounts_controller.py:2767
+#: erpnext/controllers/accounts_controller.py:2770
 msgid "Conversion rate cannot be 0"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2774
+#: erpnext/controllers/accounts_controller.py:2777
 msgid "Conversion rate is 1.00, but document currency is different from company currency"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2770
+#: erpnext/controllers/accounts_controller.py:2773
 msgid "Conversion rate must be 1.00 if document currency is same as company currency"
 msgstr ""
 
@@ -12688,7 +12674,7 @@ msgstr "Costo"
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:28
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:40
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:30
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1096
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1098
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:40
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.js:42
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.py:197
@@ -12781,7 +12767,7 @@ msgid "Cost Center is a part of Cost Center Allocation, hence cannot be converte
 msgstr ""
 
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py:1411
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:855
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:864
 msgid "Cost Center is required in row {0} in Taxes table for type {1}"
 msgstr "Centro de costos requerido para la línea {0} en la tabla Impuestos para el tipo {1}"
 
@@ -13050,8 +13036,8 @@ msgstr "Cr"
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:132
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:143
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:219
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:654
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:678
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:656
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:680
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.js:88
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.js:89
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.js:103
@@ -13108,8 +13094,8 @@ msgstr "Cr"
 #: erpnext/projects/doctype/task/task_tree.js:81
 #: erpnext/public/js/communication.js:19 erpnext/public/js/communication.js:31
 #: erpnext/public/js/communication.js:41
-#: erpnext/public/js/controllers/transaction.js:336
-#: erpnext/public/js/controllers/transaction.js:2435
+#: erpnext/public/js/controllers/transaction.js:362
+#: erpnext/public/js/controllers/transaction.js:2461
 #: erpnext/selling/doctype/customer/customer.js:181
 #: erpnext/selling/doctype/quotation/quotation.js:124
 #: erpnext/selling/doctype/quotation/quotation.js:133
@@ -13404,7 +13390,7 @@ msgstr ""
 msgid "Create a variant with the template image."
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1877
+#: erpnext/stock/stock_ledger.py:1886
 msgid "Create an incoming stock transaction for the Item."
 msgstr "Cree una transacción de stock entrante para el artículo."
 
@@ -13464,7 +13450,7 @@ msgstr ""
 msgid "Creating Purchase Order ..."
 msgstr "Creando orden de compra ..."
 
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:735
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:737
 #: erpnext/buying/doctype/purchase_order/purchase_order.js:552
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.js:73
 msgid "Creating Purchase Receipt ..."
@@ -13658,7 +13644,7 @@ msgstr "Meses de Crédito"
 #: erpnext/accounts/doctype/journal_entry_template/journal_entry_template.json
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:174
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:147
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1119
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1121
 #: erpnext/controllers/sales_and_purchase_return.py:373
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:286
 #: erpnext/stock/doctype/delivery_note/delivery_note.js:89
@@ -13693,7 +13679,7 @@ msgstr "Nota de crédito {0} se ha creado automáticamente"
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py:368
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py:376
-#: erpnext/controllers/accounts_controller.py:2186
+#: erpnext/controllers/accounts_controller.py:2189
 msgid "Credit To"
 msgstr "Acreditar en"
 
@@ -13878,7 +13864,7 @@ msgstr "Taza"
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/subscription_plan/subscription_plan.json
 #: erpnext/accounts/report/account_balance/account_balance.py:28
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1129
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1131
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:205
 #: erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.py:101
 #: erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.js:118
@@ -14407,7 +14393,7 @@ msgstr "Código de Cliente"
 #. Label of the customer_contact_display (Small Text) field in DocType
 #. 'Purchase Order'
 #. Label of the customer_contact (Small Text) field in DocType 'Delivery Stop'
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1090
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1092
 #: erpnext/buying/doctype/purchase_order/purchase_order.json
 #: erpnext/stock/doctype/delivery_stop/delivery_stop.json
 msgid "Customer Contact"
@@ -14503,7 +14489,7 @@ msgstr "Comentarios de cliente"
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/tax_rule/tax_rule.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:107
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1147
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1149
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:81
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:185
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:56
@@ -14547,7 +14533,7 @@ msgstr ""
 msgid "Customer Group Name"
 msgstr "Nombre de la categoría de cliente"
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1239
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1241
 msgid "Customer Group: {0} does not exist"
 msgstr "Grupo de Clientes: {0} no existe"
 
@@ -14566,7 +14552,7 @@ msgstr "Artículo del cliente"
 msgid "Customer Items"
 msgstr "Partidas de deudores"
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1138
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1140
 msgid "Customer LPO"
 msgstr "Cliente LPO"
 
@@ -14612,7 +14598,7 @@ msgstr "Numero de móvil de cliente"
 #: erpnext/accounts/doctype/pos_invoice/pos_invoice.json
 #: erpnext/accounts/doctype/process_statement_of_accounts_customer/process_statement_of_accounts_customer.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1080
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1082
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:156
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:92
 #: erpnext/accounts/report/delivered_items_to_be_billed/delivered_items_to_be_billed.py:35
@@ -15290,7 +15276,7 @@ msgstr ""
 #: erpnext/accounts/doctype/journal_entry_template/journal_entry_template.json
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:176
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:147
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1122
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1124
 #: erpnext/controllers/sales_and_purchase_return.py:377
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:287
 #: erpnext/stock/doctype/purchase_receipt/purchase_receipt.js:61
@@ -15319,7 +15305,7 @@ msgstr ""
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:953
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:964
-#: erpnext/controllers/accounts_controller.py:2186
+#: erpnext/controllers/accounts_controller.py:2189
 msgid "Debit To"
 msgstr "Debitar a"
 
@@ -15352,11 +15338,11 @@ msgstr "Desajuste débito-crédito"
 msgid "Debit-Credit mismatch"
 msgstr "Desajuste débito-crédito"
 
-#: erpnext/accounts/party.py:609
+#: erpnext/accounts/party.py:615
 msgid "Debtor/Creditor"
 msgstr "Deudor/Acreedor"
 
-#: erpnext/accounts/party.py:612
+#: erpnext/accounts/party.py:618
 msgid "Debtor/Creditor Advance"
 msgstr ""
 
@@ -15476,7 +15462,7 @@ msgstr ""
 msgid "Default BOM"
 msgstr "Lista de Materiales (LdM) por defecto"
 
-#: erpnext/stock/doctype/item/item.py:418
+#: erpnext/stock/doctype/item/item.py:421
 msgid "Default BOM ({0}) must be active for this item or its template"
 msgstr "La lista de materiales (LdM) por defecto ({0}) debe estar activa para este producto o plantilla"
 
@@ -15484,7 +15470,7 @@ msgstr "La lista de materiales (LdM) por defecto ({0}) debe estar activa para es
 msgid "Default BOM for {0} not found"
 msgstr "BOM por defecto para {0} no encontrado"
 
-#: erpnext/controllers/accounts_controller.py:3672
+#: erpnext/controllers/accounts_controller.py:3675
 msgid "Default BOM not found for FG Item {0}"
 msgstr ""
 
@@ -15819,15 +15805,15 @@ msgstr "Territorio predeterminado"
 msgid "Default Unit of Measure"
 msgstr "Unidad de Medida (UdM) predeterminada"
 
-#: erpnext/stock/doctype/item/item.py:1272
+#: erpnext/stock/doctype/item/item.py:1266
 msgid "Default Unit of Measure for Item {0} cannot be changed directly because you have already made some transaction(s) with another UOM. You need to either cancel the linked documents or create a new Item."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1255
+#: erpnext/stock/doctype/item/item.py:1249
 msgid "Default Unit of Measure for Item {0} cannot be changed directly because you have already made some transaction(s) with another UOM. You will need to create a new Item to use a different Default UOM."
 msgstr "Unidad de medida predeterminada para el artículo {0} no se puede cambiar directamente porque ya ha realizado alguna transacción (s) con otra UOM. Usted tendrá que crear un nuevo elemento a utilizar un UOM predeterminado diferente."
 
-#: erpnext/stock/doctype/item/item.py:908
+#: erpnext/stock/doctype/item/item.py:902
 msgid "Default Unit of Measure for Variant '{0}' must be same as in Template '{1}'"
 msgstr "Unidad de medida predeterminada para variante '{0}' debe ser la mismo que en la plantilla '{1}'"
 
@@ -16286,7 +16272,7 @@ msgstr "Evolución de las notas de entrega"
 msgid "Delivery Note {0} is not submitted"
 msgstr "La nota de entrega {0} no se ha validado"
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1142
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1144
 #: erpnext/stock/doctype/delivery_trip/delivery_trip.js:73
 msgid "Delivery Notes"
 msgstr "Notas de entrega"
@@ -16817,7 +16803,7 @@ msgstr ""
 #: erpnext/projects/doctype/task_type/task_type.json
 #: erpnext/projects/doctype/timesheet_detail/timesheet_detail.json
 #: erpnext/public/js/bank_reconciliation_tool/data_table_manager.js:55
-#: erpnext/public/js/controllers/transaction.js:2376
+#: erpnext/public/js/controllers/transaction.js:2402
 #: erpnext/selling/doctype/installation_note_item/installation_note_item.json
 #: erpnext/selling/doctype/product_bundle/product_bundle.json
 #: erpnext/selling/doctype/product_bundle_item/product_bundle_item.json
@@ -17005,7 +16991,7 @@ msgstr ""
 msgid "Difference Account must be a Asset/Liability type account (Temporary Opening), since this Stock Entry is an Opening Entry"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:954
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:950
 msgid "Difference Account must be a Asset/Liability type account, since this Stock Reconciliation is an Opening Entry"
 msgstr "Una cuenta distinta debe ser del tipo Activo / Pasivo, ya que la reconciliación del stock es una entrada de apertura"
 
@@ -17271,11 +17257,11 @@ msgstr ""
 msgid "Disabled Warehouse {0} cannot be used for this transaction."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:745
+#: erpnext/controllers/accounts_controller.py:748
 msgid "Disabled pricing rules since this {} is an internal transfer"
 msgstr "Deshabilitado las reglas de precios, ya que esta {} es una transferencia interna"
 
-#: erpnext/controllers/accounts_controller.py:759
+#: erpnext/controllers/accounts_controller.py:762
 msgid "Disabled tax included prices since this {} is an internal transfer"
 msgstr ""
 
@@ -18217,7 +18203,7 @@ msgstr "Envío Triangulado"
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.json
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/print_format/sales_invoice_print/sales_invoice_print.html:72
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1106
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1108
 #: erpnext/assets/doctype/asset_maintenance_log/asset_maintenance_log.json
 #: erpnext/selling/report/payment_terms_status_for_sales_order/payment_terms_status_for_sales_order.py:40
 msgid "Due Date"
@@ -18231,11 +18217,11 @@ msgstr "Fecha de vencimiento"
 msgid "Due Date Based On"
 msgstr "Fecha de Vencimiento basada en"
 
-#: erpnext/accounts/party.py:695
+#: erpnext/accounts/party.py:701
 msgid "Due Date cannot be after {0}"
 msgstr ""
 
-#: erpnext/accounts/party.py:671
+#: erpnext/accounts/party.py:677
 msgid "Due Date cannot be before {0}"
 msgstr ""
 
@@ -18953,7 +18939,7 @@ msgstr "Habilitar programación de citas"
 msgid "Enable Auto Email"
 msgstr "Habilitar correo electrónico automático"
 
-#: erpnext/stock/doctype/item/item.py:1064
+#: erpnext/stock/doctype/item/item.py:1058
 msgid "Enable Auto Re-Order"
 msgstr "Habilitar reordenamiento automático"
 
@@ -19166,7 +19152,7 @@ msgstr "Fecha de Cobro"
 msgid "End Date"
 msgstr "Fecha Final"
 
-#: erpnext/crm/doctype/contract/contract.py:75
+#: erpnext/crm/doctype/contract/contract.py:83
 msgid "End Date cannot be before Start Date."
 msgstr "La fecha de finalización no puede ser anterior a la fecha de inicio."
 
@@ -19416,7 +19402,7 @@ msgstr ""
 #: erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.json
 #: erpnext/manufacturing/doctype/job_card/job_card.py:875
 #: erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.json
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:297
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:298
 msgid "Error"
 msgstr "Error"
 
@@ -19541,7 +19527,7 @@ msgstr ""
 msgid "Example URL"
 msgstr "URL de ejemplo"
 
-#: erpnext/stock/doctype/item/item.py:995
+#: erpnext/stock/doctype/item/item.py:989
 msgid "Example of a linked document: {0}"
 msgstr "Ejemplo de documento vinculado: {0}"
 
@@ -19556,7 +19542,7 @@ msgstr ""
 msgid "Example: ABCD.#####. If series is set and Batch No is not mentioned in transactions, then automatic batch number will be created based on this series. If you always want to explicitly mention Batch No for this item, leave this blank. Note: this setting will take priority over the Naming Series Prefix in Stock Settings."
 msgstr "Ejemplo: ABCD. #####. Si se establece una serie y no se menciona el No de lote en las transacciones, se creará un número de lote automático basado en esta serie. Si siempre quiere mencionar explícitamente el No de lote para este artículo, déjelo en blanco. Nota: esta configuración tendrá prioridad sobre el Prefijo de denominación de serie en Configuración de stock."
 
-#: erpnext/stock/stock_ledger.py:2141
+#: erpnext/stock/stock_ledger.py:2149
 msgid "Example: Serial No {0} reserved in {1}."
 msgstr ""
 
@@ -19610,8 +19596,8 @@ msgstr "Ganancias o pérdidas por tipo de cambio"
 msgid "Exchange Gain/Loss"
 msgstr "Ganancia/Pérdida en Cambio"
 
-#: erpnext/controllers/accounts_controller.py:1593
-#: erpnext/controllers/accounts_controller.py:1677
+#: erpnext/controllers/accounts_controller.py:1596
+#: erpnext/controllers/accounts_controller.py:1680
 msgid "Exchange Gain/Loss amount has been booked through {0}"
 msgstr ""
 
@@ -20347,7 +20333,7 @@ msgid "Fetching Error"
 msgstr ""
 
 #: erpnext/accounts/doctype/dunning/dunning.js:135
-#: erpnext/public/js/controllers/transaction.js:1251
+#: erpnext/public/js/controllers/transaction.js:1277
 msgid "Fetching exchange rates ..."
 msgstr "Obteniendo tipos de cambio..."
 
@@ -20642,15 +20628,15 @@ msgstr ""
 msgid "Finished Good Item Quantity"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3658
+#: erpnext/controllers/accounts_controller.py:3661
 msgid "Finished Good Item is not specified for service item {0}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3675
+#: erpnext/controllers/accounts_controller.py:3678
 msgid "Finished Good Item {0} Qty can not be zero"
 msgstr "Producto terminado {0} La cantidad no puede ser cero"
 
-#: erpnext/controllers/accounts_controller.py:3669
+#: erpnext/controllers/accounts_controller.py:3672
 msgid "Finished Good Item {0} must be a sub-contracted item"
 msgstr ""
 
@@ -20891,7 +20877,7 @@ msgstr "Cuenta de activo fijo"
 msgid "Fixed Asset Defaults"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:301
+#: erpnext/stock/doctype/item/item.py:304
 msgid "Fixed Asset Item must be a non-stock item."
 msgstr "Artículo de Activos Fijos no debe ser un artículo de stock."
 
@@ -21067,7 +21053,7 @@ msgstr "Por cantidad (cantidad fabricada) es obligatoria"
 msgid "For Raw Materials"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1259
+#: erpnext/controllers/accounts_controller.py:1262
 msgid "For Return Invoices with Stock effect, '0' qty Items are not allowed. Following rows are affected: {0}"
 msgstr ""
 
@@ -21168,7 +21154,7 @@ msgstr ""
 msgid "For the item {0}, the quantity should be {1} according to the BOM {2}."
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:1088
+#: erpnext/public/js/controllers/transaction.js:1114
 msgctxt "Clear payment terms template and/or payment schedule when due date is changed"
 msgid "For the new {0} to take effect, would you like to clear the current {1}?"
 msgstr ""
@@ -21177,7 +21163,7 @@ msgstr ""
 msgid "For the {0}, no stock is available for the return in the warehouse {1}."
 msgstr ""
 
-#: erpnext/controllers/sales_and_purchase_return.py:1144
+#: erpnext/controllers/sales_and_purchase_return.py:1049
 msgid "For the {0}, the quantity is required to make the return entry"
 msgstr ""
 
@@ -21514,7 +21500,7 @@ msgstr "La fecha 'Desde' no puede ser mayor que la fecha 'Hasta'"
 msgid "From Date is mandatory"
 msgstr ""
 
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:52
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:53
 #: erpnext/accounts/report/general_ledger/general_ledger.py:86
 #: erpnext/accounts/report/pos_register/pos_register.py:115
 #: erpnext/accounts/report/tax_withholding_details/tax_withholding_details.py:39
@@ -21891,14 +21877,14 @@ msgstr "Sólo se pueden crear más nodos bajo nodos de tipo 'Grupo'"
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:186
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:155
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1134
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1136
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:177
 msgid "Future Payment Amount"
 msgstr "Monto de pago futuro"
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:185
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:154
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1133
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1135
 msgid "Future Payment Ref"
 msgstr "Ref. De pago futuro"
 
@@ -23072,7 +23058,7 @@ msgstr "Le ayuda a distribuir el Presupuesto/Objetivo a lo largo de los meses si
 msgid "Here are the error logs for the aforementioned failed depreciation entries: {0}"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1862
+#: erpnext/stock/stock_ledger.py:1871
 msgid "Here are the options to proceed:"
 msgstr "Estas son las opciones para proceder:"
 
@@ -23594,7 +23580,7 @@ msgstr ""
 msgid "If more than one package of the same type (for print)"
 msgstr "Si es más de un paquete del mismo tipo (para impresión)"
 
-#: erpnext/stock/stock_ledger.py:1872
+#: erpnext/stock/stock_ledger.py:1881
 msgid "If not, you can Cancel / Submit this entry"
 msgstr "En caso contrario, puedes Cancelar/Validar esta entrada"
 
@@ -23619,7 +23605,7 @@ msgstr ""
 msgid "If the account is frozen, entries are allowed to restricted users."
 msgstr "Si la cuenta está congelado, las entradas estarán permitidas a los usuarios restringidos."
 
-#: erpnext/stock/stock_ledger.py:1865
+#: erpnext/stock/stock_ledger.py:1874
 msgid "If the item is transacting as a Zero Valuation Rate item in this entry, please enable 'Allow Zero Valuation Rate' in the {0} Item table."
 msgstr "Si el artículo está realizando transacciones como un artículo de tasa de valoración cero en esta entrada, habilite &quot;Permitir tasa de valoración cero&quot; en la {0} tabla de artículos."
 
@@ -24617,7 +24603,7 @@ msgstr ""
 msgid "Incorrect Batch Consumed"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:514
+#: erpnext/stock/doctype/item/item.py:517
 msgid "Incorrect Check in (group) Warehouse for Reorder"
 msgstr ""
 
@@ -24666,7 +24652,7 @@ msgstr ""
 msgid "Incorrect Stock Value Report"
 msgstr ""
 
-#: erpnext/stock/serial_batch_bundle.py:134
+#: erpnext/stock/serial_batch_bundle.py:135
 msgid "Incorrect Type of Transaction"
 msgstr ""
 
@@ -24935,8 +24921,8 @@ msgstr "Instrucciones"
 msgid "Insufficient Capacity"
 msgstr "Capacidad Insuficiente"
 
-#: erpnext/controllers/accounts_controller.py:3590
-#: erpnext/controllers/accounts_controller.py:3614
+#: erpnext/controllers/accounts_controller.py:3593
+#: erpnext/controllers/accounts_controller.py:3617
 msgid "Insufficient Permissions"
 msgstr "Permisos Insuficientes"
 
@@ -24944,12 +24930,12 @@ msgstr "Permisos Insuficientes"
 #: erpnext/stock/doctype/pick_list/pick_list.py:127
 #: erpnext/stock/doctype/pick_list/pick_list.py:975
 #: erpnext/stock/doctype/stock_entry/stock_entry.py:759
-#: erpnext/stock/serial_batch_bundle.py:989 erpnext/stock/stock_ledger.py:1559
-#: erpnext/stock/stock_ledger.py:2032
+#: erpnext/stock/serial_batch_bundle.py:1021 erpnext/stock/stock_ledger.py:1568
+#: erpnext/stock/stock_ledger.py:2040
 msgid "Insufficient Stock"
 msgstr "Insuficiente Stock"
 
-#: erpnext/stock/stock_ledger.py:2047
+#: erpnext/stock/stock_ledger.py:2055
 msgid "Insufficient Stock for Batch"
 msgstr ""
 
@@ -25087,11 +25073,11 @@ msgstr "Cliente Interno"
 msgid "Internal Customer for company {0} already exists"
 msgstr "Cliente Interno para empresa {0} ya existe"
 
-#: erpnext/controllers/accounts_controller.py:728
+#: erpnext/controllers/accounts_controller.py:731
 msgid "Internal Sale or Delivery Reference missing."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:730
+#: erpnext/controllers/accounts_controller.py:733
 msgid "Internal Sales Reference Missing"
 msgstr ""
 
@@ -25122,7 +25108,7 @@ msgstr "Ya existe el proveedor interno de la empresa {0}"
 msgid "Internal Transfer"
 msgstr "Transferencia Interna"
 
-#: erpnext/controllers/accounts_controller.py:739
+#: erpnext/controllers/accounts_controller.py:742
 msgid "Internal Transfer Reference Missing"
 msgstr ""
 
@@ -25165,8 +25151,8 @@ msgstr "Inválido"
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:969
 #: erpnext/assets/doctype/asset_category/asset_category.py:69
 #: erpnext/assets/doctype/asset_category/asset_category.py:97
-#: erpnext/controllers/accounts_controller.py:2975
-#: erpnext/controllers/accounts_controller.py:2983
+#: erpnext/controllers/accounts_controller.py:2978
+#: erpnext/controllers/accounts_controller.py:2986
 msgid "Invalid Account"
 msgstr "Cuenta no válida"
 
@@ -25191,7 +25177,7 @@ msgstr "Fecha de repetición automática inválida"
 msgid "Invalid Barcode. There is no Item attached to this barcode."
 msgstr "Código de barras inválido. No hay ningún elemento adjunto a este código de barras."
 
-#: erpnext/public/js/controllers/transaction.js:2631
+#: erpnext/public/js/controllers/transaction.js:2657
 msgid "Invalid Blanket Order for the selected Customer and Item"
 msgstr "Pedido abierto inválido para el cliente y el artículo seleccionado"
 
@@ -25205,7 +25191,7 @@ msgstr "Empresa inválida para transacciones entre empresas."
 
 #: erpnext/assets/doctype/asset/asset.py:295
 #: erpnext/assets/doctype/asset/asset.py:302
-#: erpnext/controllers/accounts_controller.py:2998
+#: erpnext/controllers/accounts_controller.py:3001
 msgid "Invalid Cost Center"
 msgstr "Centro de Costo Inválido"
 
@@ -25247,7 +25233,7 @@ msgstr "Agrupar por no válido"
 msgid "Invalid Item"
 msgstr "Artículo Inválido"
 
-#: erpnext/stock/doctype/item/item.py:1410
+#: erpnext/stock/doctype/item/item.py:1404
 msgid "Invalid Item Defaults"
 msgstr ""
 
@@ -25293,11 +25279,11 @@ msgstr ""
 msgid "Invalid Purchase Invoice"
 msgstr "Factura de Compra no válida"
 
-#: erpnext/controllers/accounts_controller.py:3627
+#: erpnext/controllers/accounts_controller.py:3630
 msgid "Invalid Qty"
 msgstr "Cant. inválida"
 
-#: erpnext/controllers/accounts_controller.py:1277
+#: erpnext/controllers/accounts_controller.py:1280
 msgid "Invalid Quantity"
 msgstr "Cantidad inválida"
 
@@ -25314,7 +25300,7 @@ msgstr ""
 msgid "Invalid Schedule"
 msgstr "Programación no válida"
 
-#: erpnext/controllers/selling_controller.py:243
+#: erpnext/controllers/selling_controller.py:251
 msgid "Invalid Selling Price"
 msgstr "Precio de venta no válido"
 
@@ -25347,7 +25333,7 @@ msgstr "Expresión de condición no válida"
 msgid "Invalid lost reason {0}, please create a new lost reason"
 msgstr "Motivo perdido no válido {0}, cree un nuevo motivo perdido"
 
-#: erpnext/stock/doctype/item/item.py:408
+#: erpnext/stock/doctype/item/item.py:411
 msgid "Invalid naming series (. missing) for {0}"
 msgstr "Serie de nombres no válida (falta.) Para {0}"
 
@@ -25387,7 +25373,7 @@ msgstr "Inventario"
 #. Name of a DocType
 #: erpnext/patches/v15_0/refactor_closing_stock_balance.py:43
 #: erpnext/stock/doctype/inventory_dimension/inventory_dimension.json
-#: erpnext/stock/doctype/inventory_dimension/inventory_dimension.py:180
+#: erpnext/stock/doctype/inventory_dimension/inventory_dimension.py:181
 msgid "Inventory Dimension"
 msgstr ""
 
@@ -25453,7 +25439,7 @@ msgstr "Fecha de factura"
 msgid "Invoice Discounting"
 msgstr "Descuento de facturas"
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1114
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1116
 msgid "Invoice Grand Total"
 msgstr "Factura Gran Total"
 
@@ -25546,7 +25532,7 @@ msgstr "No se puede facturar por cero horas de facturación"
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:169
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:144
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1116
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1118
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:164
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:165
 msgid "Invoiced Amount"
@@ -25952,6 +25938,11 @@ msgstr "Es una entrada de apertura"
 msgid "Is Outward"
 msgstr ""
 
+#. Label of the is_packed (Check) field in DocType 'Serial and Batch Bundle'
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.json
+msgid "Is Packed"
+msgstr ""
+
 #. Label of the is_paid (Check) field in DocType 'Purchase Invoice'
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 msgid "Is Paid"
@@ -26234,11 +26225,11 @@ msgstr "Fecha de Emisión"
 msgid "Issuing cannot be done to a location. Please enter employee to issue the Asset {0} to"
 msgstr "La emisión no puede realizarse a una ubicación. Por favor, introduzca el empleado para emitir el Activo {0} a"
 
-#: erpnext/stock/doctype/item/item.py:565
+#: erpnext/stock/doctype/item/item.py:571
 msgid "It can take upto few hours for accurate stock values to be visible after merging items."
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2075
+#: erpnext/public/js/controllers/transaction.js:2101
 msgid "It is needed to fetch Item Details."
 msgstr "Se necesita a buscar Detalles del artículo."
 
@@ -26288,7 +26279,7 @@ msgstr ""
 #: erpnext/buying/report/supplier_quotation_comparison/supplier_quotation_comparison.js:33
 #: erpnext/buying/report/supplier_quotation_comparison/supplier_quotation_comparison.py:204
 #: erpnext/buying/workspace/buying/buying.json
-#: erpnext/controllers/taxes_and_totals.py:1125
+#: erpnext/controllers/taxes_and_totals.py:1135
 #: erpnext/manufacturing/doctype/blanket_order/blanket_order.json
 #: erpnext/manufacturing/doctype/bom/bom.js:944
 #: erpnext/manufacturing/doctype/bom/bom.json
@@ -26566,7 +26557,7 @@ msgstr "Carrito de Productos"
 #: erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py:86
 #: erpnext/manufacturing/report/work_order_stock_report/work_order_stock_report.py:119
 #: erpnext/projects/doctype/timesheet/timesheet.js:213
-#: erpnext/public/js/controllers/transaction.js:2350
+#: erpnext/public/js/controllers/transaction.js:2376
 #: erpnext/public/js/stock_reservation.js:112
 #: erpnext/public/js/stock_reservation.js:317 erpnext/public/js/utils.js:500
 #: erpnext/public/js/utils.js:656
@@ -27004,7 +26995,7 @@ msgstr "Fabricante del artículo"
 #: erpnext/manufacturing/report/production_planning_report/production_planning_report.py:359
 #: erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py:92
 #: erpnext/manufacturing/report/work_order_consumed_materials/work_order_consumed_materials.py:138
-#: erpnext/public/js/controllers/transaction.js:2356
+#: erpnext/public/js/controllers/transaction.js:2382
 #: erpnext/public/js/utils.js:746
 #: erpnext/selling/doctype/quotation_item/quotation_item.json
 #: erpnext/selling/doctype/sales_order_item/sales_order_item.json
@@ -27271,7 +27262,7 @@ msgstr "Configuraciones de Variante de Artículo"
 msgid "Item Variant {0} already exists with same attributes"
 msgstr "Artículo Variant {0} ya existe con los mismos atributos"
 
-#: erpnext/stock/doctype/item/item.py:781
+#: erpnext/stock/doctype/item/item.py:772
 msgid "Item Variants updated"
 msgstr "Variantes del artículo actualizadas"
 
@@ -27337,7 +27328,7 @@ msgstr "Producto y detalles de garantía"
 msgid "Item for row {0} does not match Material Request"
 msgstr "El artículo de la fila {0} no coincide con la solicitud de material"
 
-#: erpnext/stock/doctype/item/item.py:795
+#: erpnext/stock/doctype/item/item.py:789
 msgid "Item has variants."
 msgstr "El producto tiene variantes."
 
@@ -27363,7 +27354,7 @@ msgstr "Nombre del producto"
 msgid "Item operation"
 msgstr "Operación del artículo"
 
-#: erpnext/controllers/accounts_controller.py:3650
+#: erpnext/controllers/accounts_controller.py:3653
 msgid "Item qty can not be updated as raw materials are already processed."
 msgstr ""
 
@@ -27389,7 +27380,7 @@ msgstr ""
 msgid "Item valuation reposting in progress. Report might show incorrect item valuation."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:952
+#: erpnext/stock/doctype/item/item.py:946
 msgid "Item variant {0} exists with same attributes"
 msgstr "Existe la variante de artículo {0} con mismos atributos"
 
@@ -27402,8 +27393,7 @@ msgid "Item {0} cannot be ordered more than {1} against Blanket Order {2}."
 msgstr ""
 
 #: erpnext/assets/doctype/asset/asset.py:277
-#: erpnext/stock/doctype/item/item.py:630
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:167
+#: erpnext/stock/doctype/item/item.py:636
 msgid "Item {0} does not exist"
 msgstr "El elemento {0} no existe"
 
@@ -27415,7 +27405,7 @@ msgstr "El elemento {0} no existe en el sistema o ha expirado"
 msgid "Item {0} does not exist."
 msgstr "El artículo {0} no existe."
 
-#: erpnext/controllers/selling_controller.py:752
+#: erpnext/controllers/selling_controller.py:760
 msgid "Item {0} entered multiple times."
 msgstr "Producto {0} ingresado varias veces."
 
@@ -27431,7 +27421,7 @@ msgstr "Elemento {0} ha sido desactivado"
 msgid "Item {0} has no Serial No. Only serialized items can have delivery based on Serial No"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1126
+#: erpnext/stock/doctype/item/item.py:1120
 msgid "Item {0} has reached its end of life on {1}"
 msgstr "El producto {0} ha llegado al fin de la vida útil el {1}"
 
@@ -27443,11 +27433,11 @@ msgstr "El producto {0} ha sido ignorado ya que no es un elemento de stock"
 msgid "Item {0} is already reserved/delivered against Sales Order {1}."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1146
+#: erpnext/stock/doctype/item/item.py:1140
 msgid "Item {0} is cancelled"
 msgstr "El producto {0} esta cancelado"
 
-#: erpnext/stock/doctype/item/item.py:1130
+#: erpnext/stock/doctype/item/item.py:1124
 msgid "Item {0} is disabled"
 msgstr "Artículo {0} está deshabilitado"
 
@@ -27455,7 +27445,7 @@ msgstr "Artículo {0} está deshabilitado"
 msgid "Item {0} is not a serialized Item"
 msgstr "El producto {0} no es un producto serializado"
 
-#: erpnext/stock/doctype/item/item.py:1138
+#: erpnext/stock/doctype/item/item.py:1132
 msgid "Item {0} is not a stock Item"
 msgstr "El producto {0} no es un producto de stock"
 
@@ -27499,7 +27489,7 @@ msgstr "El producto {0}: Con la cantidad ordenada {1} no puede ser menor que el 
 msgid "Item {0}: {1} qty produced. "
 msgstr "Elemento {0}: {1} cantidad producida."
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1429
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1423
 msgid "Item {} does not exist."
 msgstr "Producto {0} no existe."
 
@@ -27639,7 +27629,7 @@ msgstr "Solicitud de Productos"
 msgid "Items and Pricing"
 msgstr "Productos y Precios"
 
-#: erpnext/controllers/accounts_controller.py:3872
+#: erpnext/controllers/accounts_controller.py:3875
 msgid "Items cannot be updated as Subcontracting Order is created against the Purchase Order {0}."
 msgstr ""
 
@@ -28135,7 +28125,7 @@ msgstr "Impuestos, cargos y costos de destino estimados"
 
 #. Name of a DocType
 #. Label of a Link in the Stock Workspace
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:674
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:676
 #: erpnext/stock/doctype/landed_cost_voucher/landed_cost_voucher.json
 #: erpnext/stock/doctype/purchase_receipt/purchase_receipt.js:104
 #: erpnext/stock/workspace/stock/stock.json
@@ -28750,7 +28740,7 @@ msgstr "Facturas Vinculadas"
 msgid "Linked Location"
 msgstr "Ubicación vinculada"
 
-#: erpnext/stock/doctype/item/item.py:999
+#: erpnext/stock/doctype/item/item.py:993
 msgid "Linked with submitted documents"
 msgstr ""
 
@@ -29489,7 +29479,7 @@ msgstr "Director General"
 #: erpnext/manufacturing/doctype/bom/bom.py:261
 #: erpnext/manufacturing/doctype/bom_update_log/bom_update_log.py:71
 #: erpnext/public/js/controllers/accounts.js:249
-#: erpnext/public/js/controllers/transaction.js:2753
+#: erpnext/public/js/controllers/transaction.js:2779
 #: erpnext/public/js/utils/party.js:321
 #: erpnext/stock/doctype/delivery_note/delivery_note.js:164
 #: erpnext/stock/doctype/inventory_dimension/inventory_dimension.json
@@ -30345,7 +30335,7 @@ msgstr "Uso maximo"
 msgid "Maximum Value"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:212
+#: erpnext/controllers/selling_controller.py:220
 msgid "Maximum discount for Item {0} is {1}%"
 msgstr ""
 
@@ -30415,7 +30405,7 @@ msgstr "Megajulio"
 msgid "Megawatt"
 msgstr "Megavatio"
 
-#: erpnext/stock/stock_ledger.py:1878
+#: erpnext/stock/stock_ledger.py:1887
 msgid "Mention Valuation Rate in the Item master."
 msgstr "Mencione Tasa de valoración en el maestro de artículos."
 
@@ -30810,11 +30800,11 @@ msgstr "Minutos"
 msgid "Miscellaneous Expenses"
 msgstr "Gastos varios"
 
-#: erpnext/controllers/buying_controller.py:540
+#: erpnext/controllers/buying_controller.py:548
 msgid "Mismatch"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1430
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1424
 msgid "Missing"
 msgstr ""
 
@@ -31341,7 +31331,7 @@ msgstr "Multiples Variantes"
 msgid "Multiple Warehouse Accounts"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1129
+#: erpnext/controllers/accounts_controller.py:1132
 msgid "Multiple fiscal years exist for the date {0}. Please set company in Fiscal Year"
 msgstr "Existen varios ejercicios para la fecha {0}. Por favor, establece la compañía en el año fiscal"
 
@@ -31492,7 +31482,7 @@ msgstr "Nombrar el Prefijo de la Serie"
 msgid "Naming Series and Price Defaults"
 msgstr "Series de Nombres y Precios por Defecto"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:90
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:91
 msgid "Naming Series is mandatory"
 msgstr ""
 
@@ -31531,15 +31521,15 @@ msgstr "Gas natural"
 msgid "Needs Analysis"
 msgstr "Necesita Anáisis"
 
-#: erpnext/stock/serial_batch_bundle.py:1277
+#: erpnext/stock/serial_batch_bundle.py:1309
 msgid "Negative Batch Quantity"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:610
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:606
 msgid "Negative Quantity is not allowed"
 msgstr "No se permiten cantidades negativas"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:615
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:611
 msgid "Negative Valuation Rate is not allowed"
 msgstr "La valoración negativa no está permitida"
 
@@ -31821,7 +31811,7 @@ msgstr "Peso neto"
 msgid "Net Weight UOM"
 msgstr "Unidad de medida para el peso neto"
 
-#: erpnext/controllers/accounts_controller.py:1483
+#: erpnext/controllers/accounts_controller.py:1486
 msgid "Net total calculation precision loss"
 msgstr ""
 
@@ -32164,7 +32154,7 @@ msgstr ""
 #: erpnext/accounts/doctype/journal_entry/journal_entry.py:1539
 #: erpnext/accounts/doctype/journal_entry/journal_entry.py:1599
 #: erpnext/accounts/doctype/journal_entry/journal_entry.py:1613
-#: erpnext/stock/doctype/item/item.py:1371
+#: erpnext/stock/doctype/item/item.py:1365
 msgid "No Permission"
 msgstr "Sin permiso"
 
@@ -32186,7 +32176,7 @@ msgstr "No hay observaciones"
 msgid "No Selection"
 msgstr ""
 
-#: erpnext/controllers/sales_and_purchase_return.py:919
+#: erpnext/controllers/sales_and_purchase_return.py:824
 msgid "No Serial / Batches are available for return"
 msgstr ""
 
@@ -32222,7 +32212,7 @@ msgstr "No se encontraron pagos no conciliados para este tercero"
 msgid "No Work Orders were created"
 msgstr ""
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:785
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:794
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py:689
 msgid "No accounting entries for the following warehouses"
 msgstr "No hay asientos contables para los siguientes almacenes"
@@ -32411,7 +32401,7 @@ msgstr ""
 msgid "No reserved stock to unreserve."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:773
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:769
 msgid "No stock ledger entries were created. Please set the quantity or valuation rate for the items properly and try again."
 msgstr ""
 
@@ -32495,7 +32485,7 @@ msgstr "Nos."
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:566
 #: erpnext/assets/doctype/asset/asset.js:612
 #: erpnext/assets/doctype/asset/asset.js:627
-#: erpnext/controllers/buying_controller.py:225
+#: erpnext/controllers/buying_controller.py:233
 #: erpnext/selling/doctype/product_bundle/product_bundle.py:72
 #: erpnext/setup/doctype/transaction_deletion_record/transaction_deletion_record.py:80
 msgid "Not Allowed"
@@ -32616,10 +32606,10 @@ msgstr "No permitido"
 #: erpnext/selling/doctype/customer/customer.py:129
 #: erpnext/selling/doctype/sales_order/sales_order.js:1168
 #: erpnext/stock/doctype/item/item.js:526
-#: erpnext/stock/doctype/item/item.py:567
+#: erpnext/stock/doctype/item/item.py:573
 #: erpnext/stock/doctype/item_price/item_price.json
 #: erpnext/stock/doctype/stock_entry/stock_entry.py:1374
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:972
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:968
 #: erpnext/templates/pages/timelog_info.html:43
 msgid "Note"
 msgstr "Nota"
@@ -32628,7 +32618,7 @@ msgstr "Nota"
 msgid "Note: Automatic log deletion only applies to logs of type <i>Update Cost</i>"
 msgstr ""
 
-#: erpnext/accounts/party.py:690
+#: erpnext/accounts/party.py:696
 msgid "Note: Due Date exceeds allowed {0} credit days by {1} day(s)"
 msgstr ""
 
@@ -32654,7 +32644,7 @@ msgstr "Nota : El registro del pago no se creará hasta que la cuenta del tipo '
 msgid "Note: This Cost Center is a Group. Cannot make accounting entries against groups."
 msgstr "Nota: este centro de costes es una categoría. No se pueden crear asientos contables en las categorías."
 
-#: erpnext/stock/doctype/item/item.py:621
+#: erpnext/stock/doctype/item/item.py:627
 msgid "Note: To merge the items, create a separate Stock Reconciliation for the old item {0}"
 msgstr ""
 
@@ -33417,7 +33407,7 @@ msgstr ""
 
 #. Label of the opening_stock (Float) field in DocType 'Item'
 #. Option for the 'Purpose' (Select) field in DocType 'Stock Reconciliation'
-#: erpnext/stock/doctype/item/item.json erpnext/stock/doctype/item/item.py:296
+#: erpnext/stock/doctype/item/item.json erpnext/stock/doctype/item/item.py:299
 #: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.json
 msgid "Opening Stock"
 msgstr "Stock de apertura"
@@ -34137,7 +34127,7 @@ msgstr ""
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:149
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1123
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1125
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:167
 #: erpnext/accounts/report/purchase_register/purchase_register.py:289
 #: erpnext/accounts/report/sales_register/sales_register.py:319
@@ -34176,7 +34166,7 @@ msgstr "Exterior"
 msgid "Over Billing Allowance (%)"
 msgstr ""
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:1242
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:1251
 msgid "Over Billing Allowance exceeded for Purchase Receipt Item {0} ({1}) by {2}%"
 msgstr ""
 
@@ -34217,7 +34207,7 @@ msgstr ""
 msgid "Overbilling of {0} {1} ignored for item {2} because you have {3} role."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2013
+#: erpnext/controllers/accounts_controller.py:2016
 msgid "Overbilling of {} ignored because you have {} role."
 msgstr ""
 
@@ -34724,7 +34714,7 @@ msgstr "Pagado"
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:146
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1117
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1119
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:165
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:172
 #: erpnext/accounts/report/pos_register/pos_register.py:209
@@ -34957,7 +34947,7 @@ msgstr "Procedimiento para padres"
 msgid "Parent Row No"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom_creator/bom_creator.py:495
+#: erpnext/manufacturing/doctype/bom_creator/bom_creator.py:496
 msgid "Parent Row No not found for {0}"
 msgstr ""
 
@@ -35186,7 +35176,7 @@ msgstr ""
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:142
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:159
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:57
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1054
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1056
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:67
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:147
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:228
@@ -35212,7 +35202,7 @@ msgstr "Tercero"
 
 #. Name of a DocType
 #: erpnext/accounts/doctype/party_account/party_account.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1065
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1067
 msgid "Party Account"
 msgstr "Cuenta asignada"
 
@@ -35239,7 +35229,7 @@ msgstr "Divisa de la cuenta de tercero/s"
 msgid "Party Account No. (Bank Statement)"
 msgstr "Número de cuenta del tercero (extracto bancario)"
 
-#: erpnext/controllers/accounts_controller.py:2278
+#: erpnext/controllers/accounts_controller.py:2281
 msgid "Party Account {0} currency ({1}) and document currency ({2}) should be same"
 msgstr "La moneda de la cuenta del tercero {0} ({1}) y la moneda del documento ({2}) deben ser iguales"
 
@@ -35256,6 +35246,11 @@ msgstr "Cuenta bancaria del partido"
 #: erpnext/accounts/doctype/payment_request/payment_request.json
 msgid "Party Details"
 msgstr "Detalles de la entidad"
+
+#. Label of the party_full_name (Data) field in DocType 'Contract'
+#: erpnext/crm/doctype/contract/contract.json
+msgid "Party Full Name"
+msgstr ""
 
 #. Label of the bank_party_iban (Data) field in DocType 'Bank Transaction'
 #: erpnext/accounts/doctype/bank_transaction/bank_transaction.json
@@ -35340,7 +35335,7 @@ msgstr "Producto específico de la Parte"
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:84
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:54
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:44
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1048
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1050
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:54
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:141
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:219
@@ -35362,7 +35357,7 @@ msgstr "Producto específico de la Parte"
 msgid "Party Type"
 msgstr "Tipo de entidad"
 
-#: erpnext/accounts/party.py:819
+#: erpnext/accounts/party.py:825
 msgid "Party Type and Party can only be set for Receivable / Payable account<br><br>{0}"
 msgstr ""
 
@@ -35484,7 +35479,7 @@ msgid "Payable"
 msgstr "Pagadero"
 
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:42
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1063
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1065
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:211
 #: erpnext/accounts/report/purchase_register/purchase_register.py:194
 #: erpnext/accounts/report/purchase_register/purchase_register.py:235
@@ -35650,7 +35645,7 @@ msgstr "El registro del pago ha sido modificado antes de su modificación. Por f
 msgid "Payment Entry is already created"
 msgstr "Entrada de Pago ya creada"
 
-#: erpnext/controllers/accounts_controller.py:1434
+#: erpnext/controllers/accounts_controller.py:1437
 msgid "Payment Entry {0} is linked against Order {1}, check if it should be pulled as advance in this invoice."
 msgstr ""
 
@@ -35932,7 +35927,7 @@ msgstr ""
 #: erpnext/accounts/doctype/payment_schedule/payment_schedule.json
 #: erpnext/accounts/doctype/payment_term/payment_term.json
 #: erpnext/accounts/doctype/payment_terms_template_detail/payment_terms_template_detail.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1113
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1115
 #: erpnext/accounts/report/gross_profit/gross_profit.py:412
 #: erpnext/accounts/workspace/accounting/accounting.json
 #: erpnext/selling/report/payment_terms_status_for_sales_order/payment_terms_status_for_sales_order.py:30
@@ -36996,7 +36991,7 @@ msgstr ""
 msgid "Please create a new Accounting Dimension if required."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:729
+#: erpnext/controllers/accounts_controller.py:732
 msgid "Please create purchase from internal sale or delivery document itself"
 msgstr ""
 
@@ -37004,7 +36999,7 @@ msgstr ""
 msgid "Please create purchase receipt or purchase invoice for the item {0}"
 msgstr "Cree un recibo de compra o una factura de compra para el artículo {0}"
 
-#: erpnext/stock/doctype/item/item.py:649
+#: erpnext/stock/doctype/item/item.py:655
 msgid "Please delete Product Bundle {0}, before merging {1} into {2}"
 msgstr ""
 
@@ -37046,7 +37041,7 @@ msgstr "Por favor, active los pop-ups"
 msgid "Please enable {0} in the {1}."
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:754
+#: erpnext/controllers/selling_controller.py:762
 msgid "Please enable {} in {} to allow same item in multiple rows"
 msgstr ""
 
@@ -37079,7 +37074,7 @@ msgstr "Por favor, introduzca la cuenta para el importe de cambio"
 msgid "Please enter Approving Role or Approving User"
 msgstr "Por favor, introduzca 'Función para aprobar' o 'Usuario de aprobación'---"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:939
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:935
 msgid "Please enter Cost Center"
 msgstr "Por favor, introduzca el centro de costos"
 
@@ -37091,7 +37086,7 @@ msgstr "Por favor, introduzca la Fecha de Entrega"
 msgid "Please enter Employee Id of this sales person"
 msgstr "Por favor, Introduzca ID de empleado para este vendedor"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:948
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:944
 msgid "Please enter Expense Account"
 msgstr "Introduzca la cuenta de gastos"
 
@@ -37100,7 +37095,7 @@ msgstr "Introduzca la cuenta de gastos"
 msgid "Please enter Item Code to get Batch Number"
 msgstr "Por favor, introduzca el código de artículo para obtener el número de lote"
 
-#: erpnext/public/js/controllers/transaction.js:2503
+#: erpnext/public/js/controllers/transaction.js:2529
 msgid "Please enter Item Code to get batch no"
 msgstr "Introduzca el código de artículo para obtener el número de lote"
 
@@ -37165,7 +37160,7 @@ msgstr "Por favor, ingrese primero la compañía"
 msgid "Please enter company name first"
 msgstr "Por favor, ingrese el nombre de la compañia"
 
-#: erpnext/controllers/accounts_controller.py:2764
+#: erpnext/controllers/accounts_controller.py:2767
 msgid "Please enter default currency in Company Master"
 msgstr "Por favor, ingrese la divisa por defecto en la compañía principal"
 
@@ -37201,7 +37196,7 @@ msgstr "Ingrese el nombre de la empresa para confirmar"
 msgid "Please enter the phone number first"
 msgstr "Primero ingrese el número de teléfono"
 
-#: erpnext/controllers/buying_controller.py:1007
+#: erpnext/controllers/buying_controller.py:1015
 msgid "Please enter the {schedule_date}."
 msgstr ""
 
@@ -37303,7 +37298,7 @@ msgstr "Por favor guarde primero"
 msgid "Please select <b>Template Type</b> to download template"
 msgstr "Seleccione <b>Tipo de plantilla</b> para descargar la plantilla"
 
-#: erpnext/controllers/taxes_and_totals.py:721
+#: erpnext/controllers/taxes_and_totals.py:731
 #: erpnext/public/js/controllers/taxes_and_totals.js:721
 msgid "Please select Apply Discount On"
 msgstr "Por favor seleccione 'Aplicar descuento en'"
@@ -37316,7 +37311,7 @@ msgstr "Seleccione la Lista de Materiales contra el Artículo {0}"
 msgid "Please select BOM for Item in Row {0}"
 msgstr "Por favor, seleccione la lista de materiales para el artículo en la fila {0}"
 
-#: erpnext/controllers/buying_controller.py:467
+#: erpnext/controllers/buying_controller.py:475
 msgid "Please select BOM in BOM field for Item {item_code}."
 msgstr "Por favor, seleccione la lista de materiales (LdM) para el producto {item_code}."
 
@@ -37398,7 +37393,7 @@ msgstr "Por favor, seleccione la lista de precios"
 msgid "Please select Qty against item {0}"
 msgstr "Seleccione Cant. contra el Elemento {0}"
 
-#: erpnext/stock/doctype/item/item.py:320
+#: erpnext/stock/doctype/item/item.py:323
 msgid "Please select Sample Retention Warehouse in Stock Settings first"
 msgstr "Seleccione primero Almacén de Retención de Muestras en la Configuración de Stock."
 
@@ -37414,7 +37409,7 @@ msgstr "Por favor, seleccione Fecha de inicio y Fecha de finalización para el e
 msgid "Please select Subcontracting Order instead of Purchase Order {0}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2613
+#: erpnext/controllers/accounts_controller.py:2616
 msgid "Please select Unrealized Profit / Loss account or add default Unrealized Profit / Loss account account for company {0}"
 msgstr ""
 
@@ -37430,7 +37425,7 @@ msgstr "Por favor, seleccione la compañía"
 #: erpnext/manufacturing/doctype/bom/bom.js:603
 #: erpnext/manufacturing/doctype/bom/bom.py:261
 #: erpnext/public/js/controllers/accounts.js:249
-#: erpnext/public/js/controllers/transaction.js:2753
+#: erpnext/public/js/controllers/transaction.js:2779
 msgid "Please select a Company first."
 msgstr "Primero seleccione una empresa."
 
@@ -37588,7 +37583,7 @@ msgstr "Por favor, seleccione {0}"
 msgid "Please select {0} first"
 msgstr "Por favor, seleccione primero {0}"
 
-#: erpnext/public/js/controllers/transaction.js:77
+#: erpnext/public/js/controllers/transaction.js:100
 msgid "Please set 'Apply Additional Discount On'"
 msgstr "Por favor, establece \"Aplicar descuento adicional en\""
 
@@ -37773,7 +37768,7 @@ msgstr "Por favor, configurar el filtro basado en Elemento o Almacén"
 msgid "Please set filters"
 msgstr "Por favor, defina los filtros"
 
-#: erpnext/controllers/accounts_controller.py:2194
+#: erpnext/controllers/accounts_controller.py:2197
 msgid "Please set one of the following:"
 msgstr ""
 
@@ -37781,7 +37776,7 @@ msgstr ""
 msgid "Please set opening number of booked depreciations"
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2205
+#: erpnext/public/js/controllers/transaction.js:2231
 msgid "Please set recurring after saving"
 msgstr "Por favor configura recurrente después de guardar"
 
@@ -37852,7 +37847,7 @@ msgstr ""
 msgid "Please share this email with your support team so that they can find and fix the issue."
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2073
+#: erpnext/public/js/controllers/transaction.js:2099
 msgid "Please specify"
 msgstr "Por favor, especifique"
 
@@ -37867,7 +37862,7 @@ msgid "Please specify Company to proceed"
 msgstr "Por favor, especifique la compañía para continuar"
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1472
-#: erpnext/controllers/accounts_controller.py:2957
+#: erpnext/controllers/accounts_controller.py:2960
 #: erpnext/public/js/controllers/accounts.js:97
 msgid "Please specify a valid Row ID for row {0} in table {1}"
 msgstr "Por favor, especifique un ID de fila válida para la línea {0} en la tabla {1}"
@@ -37880,7 +37875,7 @@ msgstr ""
 msgid "Please specify at least one attribute in the Attributes table"
 msgstr "Por favor, especifique al menos un atributo en la tabla"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:605
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:601
 msgid "Please specify either Quantity or Valuation Rate or both"
 msgstr "Por favor indique la Cantidad o el Tipo de Valoración, o ambos"
 
@@ -38061,7 +38056,7 @@ msgstr "Gastos postales"
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:16
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:15
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:18
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1046
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1048
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:15
 #: erpnext/accounts/report/bank_clearance_summary/bank_clearance_summary.py:35
 #: erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.html:7
@@ -40242,7 +40237,7 @@ msgstr "Director de compras"
 #: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.js:48
 #: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:203
 #: erpnext/buying/workspace/buying/buying.json
-#: erpnext/controllers/buying_controller.py:739
+#: erpnext/controllers/buying_controller.py:747
 #: erpnext/crm/doctype/contract/contract.json
 #: erpnext/manufacturing/doctype/blanket_order/blanket_order.js:54
 #: erpnext/manufacturing/doctype/production_plan_sub_assembly_item/production_plan_sub_assembly_item.json
@@ -40381,7 +40376,7 @@ msgstr "Órdenes de compra a Bill"
 msgid "Purchase Orders to Receive"
 msgstr "Órdenes de compra para recibir"
 
-#: erpnext/controllers/accounts_controller.py:1833
+#: erpnext/controllers/accounts_controller.py:1836
 msgid "Purchase Orders {0} are un-linked"
 msgstr ""
 
@@ -40405,8 +40400,8 @@ msgstr "Lista de precios para las compras"
 #. Label of a Link in the Stock Workspace
 #. Label of a shortcut in the Stock Workspace
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:171
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:650
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:660
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:652
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:662
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice_list.js:49
 #: erpnext/accounts/doctype/purchase_invoice_item/purchase_invoice_item.json
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:246
@@ -41141,7 +41136,7 @@ msgstr "Plantilla de Inspección de Calidad"
 msgid "Quality Inspection Template Name"
 msgstr "Nombre de Plantilla de Inspección de Calidad"
 
-#: erpnext/public/js/controllers/transaction.js:334
+#: erpnext/public/js/controllers/transaction.js:360
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:165
 msgid "Quality Inspection(s)"
 msgstr ""
@@ -42325,7 +42320,7 @@ msgid "Receivable / Payable Account"
 msgstr "Cuenta por Cobrar / Pagar"
 
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:71
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1061
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1063
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py:243
 #: erpnext/accounts/report/sales_register/sales_register.py:217
 #: erpnext/accounts/report/sales_register/sales_register.py:271
@@ -42807,7 +42802,7 @@ msgstr "Referencia #{0} con fecha {1}"
 msgid "Reference Date"
 msgstr "Fecha de referencia"
 
-#: erpnext/public/js/controllers/transaction.js:2311
+#: erpnext/public/js/controllers/transaction.js:2337
 msgid "Reference Date for Early Payment Discount"
 msgstr ""
 
@@ -43131,7 +43126,7 @@ msgstr ""
 msgid "Rejected"
 msgstr "Rechazado"
 
-#: erpnext/stock/doctype/inventory_dimension/inventory_dimension.py:202
+#: erpnext/stock/doctype/inventory_dimension/inventory_dimension.py:203
 msgid "Rejected "
 msgstr "Rechazado "
 
@@ -43235,7 +43230,7 @@ msgstr ""
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:187
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:156
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1135
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1137
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:178
 msgid "Remaining Balance"
 msgstr "Balance restante"
@@ -43288,7 +43283,7 @@ msgstr "Observación"
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:159
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:198
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:269
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1167
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1169
 #: erpnext/accounts/report/general_ledger/general_ledger.html:84
 #: erpnext/accounts/report/general_ledger/general_ledger.html:110
 #: erpnext/accounts/report/general_ledger/general_ledger.py:742
@@ -44037,7 +44032,7 @@ msgstr "Cantidad Reservada"
 msgid "Reserved Quantity for Production"
 msgstr "Cantidad reservada para producción"
 
-#: erpnext/stock/stock_ledger.py:2147
+#: erpnext/stock/stock_ledger.py:2155
 msgid "Reserved Serial No."
 msgstr ""
 
@@ -44053,11 +44048,11 @@ msgstr ""
 #: erpnext/stock/doctype/pick_list/pick_list.js:153
 #: erpnext/stock/report/reserved_stock/reserved_stock.json
 #: erpnext/stock/report/stock_balance/stock_balance.py:499
-#: erpnext/stock/stock_ledger.py:2131
+#: erpnext/stock/stock_ledger.py:2139
 msgid "Reserved Stock"
 msgstr "Existencias Reservadas"
 
-#: erpnext/stock/stock_ledger.py:2177
+#: erpnext/stock/stock_ledger.py:2185
 msgid "Reserved Stock for Batch"
 msgstr ""
 
@@ -44069,7 +44064,7 @@ msgstr ""
 msgid "Reserved Stock for Sub-assembly"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:476
+#: erpnext/controllers/buying_controller.py:484
 msgid "Reserved Warehouse is mandatory for the Item {item_code} in Raw Materials supplied."
 msgstr ""
 
@@ -44883,7 +44878,7 @@ msgstr "Enrutamiento"
 msgid "Routing Name"
 msgstr "Nombre de Enrutamiento"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:667
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:663
 msgid "Row #"
 msgstr "Fila #"
 
@@ -44921,7 +44916,7 @@ msgstr "Fila #{0} (Tabla de pagos): El importe debe ser negativo"
 msgid "Row #{0} (Payment Table): Amount must be positive"
 msgstr "Fila #{0} (Tabla de pagos): El importe debe ser positivo"
 
-#: erpnext/stock/doctype/item/item.py:495
+#: erpnext/stock/doctype/item/item.py:498
 msgid "Row #{0}: A reorder entry already exists for warehouse {1} with reorder type {2}."
 msgstr ""
 
@@ -44942,7 +44937,7 @@ msgstr "Fila #{0}: Almacén Aceptado y Almacén Rechazado no puede ser el mismo"
 msgid "Row #{0}: Accepted Warehouse is mandatory for the accepted Item {1}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1117
+#: erpnext/controllers/accounts_controller.py:1120
 msgid "Row #{0}: Account {1} does not belong to company {2}"
 msgstr "Fila #{0}: La Cuenta {1} no pertenece a la Empresa {2}"
 
@@ -44983,27 +44978,27 @@ msgstr ""
 msgid "Row #{0}: Cannot allocate more than {1} against payment term {2}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3524
+#: erpnext/controllers/accounts_controller.py:3527
 msgid "Row #{0}: Cannot delete item {1} which has already been billed."
 msgstr "Fila # {0}: no se puede eliminar el elemento {1} que ya se ha facturado."
 
-#: erpnext/controllers/accounts_controller.py:3498
+#: erpnext/controllers/accounts_controller.py:3501
 msgid "Row #{0}: Cannot delete item {1} which has already been delivered"
 msgstr "Fila # {0}: no se puede eliminar el elemento {1} que ya se entregó"
 
-#: erpnext/controllers/accounts_controller.py:3517
+#: erpnext/controllers/accounts_controller.py:3520
 msgid "Row #{0}: Cannot delete item {1} which has already been received"
 msgstr "Fila # {0}: no se puede eliminar el elemento {1} que ya se ha recibido"
 
-#: erpnext/controllers/accounts_controller.py:3504
+#: erpnext/controllers/accounts_controller.py:3507
 msgid "Row #{0}: Cannot delete item {1} which has work order assigned to it."
 msgstr "Fila # {0}: No se puede eliminar el elemento {1} que tiene una orden de trabajo asignada."
 
-#: erpnext/controllers/accounts_controller.py:3510
+#: erpnext/controllers/accounts_controller.py:3513
 msgid "Row #{0}: Cannot delete item {1} which is assigned to customer's purchase order."
 msgstr "Fila # {0}: No se puede eliminar el artículo {1} que se asigna a la orden de compra del cliente."
 
-#: erpnext/controllers/accounts_controller.py:3765
+#: erpnext/controllers/accounts_controller.py:3768
 msgid "Row #{0}: Cannot set Rate if the billed amount is greater than the amount for Item {1}."
 msgstr ""
 
@@ -45123,7 +45118,7 @@ msgstr ""
 msgid "Row #{0}: Item {1} has been picked, please reserve stock from the Pick List."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:729
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:725
 msgid "Row #{0}: Item {1} is not a Serialized/Batched Item. It cannot have a Serial No/Batch No against it."
 msgstr "Fila # {0}: el artículo {1} no es un artículo serializado / en lote. No puede tener un No de serie / No de lote en su contra."
 
@@ -45179,7 +45174,7 @@ msgstr ""
 msgid "Row #{0}: Please select the Sub Assembly Warehouse"
 msgstr "Fila #{0}: Por favor, seleccione el Almacén de Sub-montaje"
 
-#: erpnext/stock/doctype/item/item.py:502
+#: erpnext/stock/doctype/item/item.py:505
 msgid "Row #{0}: Please set reorder quantity"
 msgstr "Fila  #{0}: Configure la cantidad de pedido"
 
@@ -45212,8 +45207,8 @@ msgstr "Fila #{0}: La inspección de calidad {1} no se ha validado para el artí
 msgid "Row #{0}: Quality Inspection {1} was rejected for item {2}"
 msgstr "Fila #{0}: La inspección de calidad {1} fue rechazada para el artículo {2}"
 
-#: erpnext/controllers/accounts_controller.py:1274
-#: erpnext/controllers/accounts_controller.py:3624
+#: erpnext/controllers/accounts_controller.py:1277
+#: erpnext/controllers/accounts_controller.py:3627
 msgid "Row #{0}: Quantity for Item {1} cannot be zero."
 msgstr "Fila # {0}: La cantidad del artículo {1} no puede ser cero."
 
@@ -45250,7 +45245,7 @@ msgstr ""
 msgid "Row #{0}: Scrap Item Qty cannot be zero"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:230
+#: erpnext/controllers/selling_controller.py:238
 msgid "Row #{0}: Selling rate for item {1} is lower than its {2}.\n"
 "\t\t\t\t\tSelling {3} should be atleast {4}.<br><br>Alternatively,\n"
 "\t\t\t\t\tyou can disable selling price validation in {5} to bypass\n"
@@ -45337,7 +45332,7 @@ msgstr ""
 msgid "Row #{0}: The batch {1} has already expired."
 msgstr "Fila nº {0}: el lote {1} ya ha caducado."
 
-#: erpnext/stock/doctype/item/item.py:511
+#: erpnext/stock/doctype/item/item.py:514
 msgid "Row #{0}: The warehouse {1} is not a child warehouse of a group warehouse {2}"
 msgstr ""
 
@@ -45377,39 +45372,39 @@ msgstr ""
 msgid "Row #{1}: Warehouse is mandatory for stock Item {0}"
 msgstr "Fila #{1}: El Almacén es obligatorio para el producto en stock {0}"
 
-#: erpnext/controllers/buying_controller.py:259
+#: erpnext/controllers/buying_controller.py:267
 msgid "Row #{idx}: Cannot select Supplier Warehouse while suppling raw materials to subcontractor."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:406
+#: erpnext/controllers/buying_controller.py:414
 msgid "Row #{idx}: Item rate has been updated as per valuation rate since its an internal stock transfer."
 msgstr "Fila #{idx}: La tarifa del artículo se ha actualizado según la tarifa de valoración, ya que se trata de una transferencia de stock interna."
 
-#: erpnext/controllers/buying_controller.py:881
+#: erpnext/controllers/buying_controller.py:889
 msgid "Row #{idx}: Please enter a location for the asset item {item_code}."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:537
+#: erpnext/controllers/buying_controller.py:545
 msgid "Row #{idx}: Received Qty must be equal to Accepted + Rejected Qty for Item {item_code}."
 msgstr "Fila #{idx}: La cantidad recibida debe ser igual a la cantidad aceptada + rechazada para el artículo {item_code}."
 
-#: erpnext/controllers/buying_controller.py:550
+#: erpnext/controllers/buying_controller.py:558
 msgid "Row #{idx}: {field_label} can not be negative for item {item_code}."
 msgstr "Fila #{idx}: {field_label} no puede ser negativo para el elemento {item_code}."
 
-#: erpnext/controllers/buying_controller.py:496
+#: erpnext/controllers/buying_controller.py:504
 msgid "Row #{idx}: {field_label} is mandatory."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:518
+#: erpnext/controllers/buying_controller.py:526
 msgid "Row #{idx}: {field_label} is not allowed in Purchase Return."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:250
+#: erpnext/controllers/buying_controller.py:258
 msgid "Row #{idx}: {from_warehouse_field} and {to_warehouse_field} cannot be same."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:999
+#: erpnext/controllers/buying_controller.py:1007
 msgid "Row #{idx}: {schedule_date} cannot be before {transaction_date}."
 msgstr ""
 
@@ -45474,7 +45469,7 @@ msgstr "Fila #{}: {}"
 msgid "Row #{}: {} {} does not exist."
 msgstr "Fila # {}: {} {} no existe."
 
-#: erpnext/stock/doctype/item/item.py:1403
+#: erpnext/stock/doctype/item/item.py:1397
 msgid "Row #{}: {} {} doesn't belong to Company {}. Please select valid {}."
 msgstr ""
 
@@ -45546,11 +45541,11 @@ msgstr "Fila {0}: Lista de materiales no se encuentra para el elemento {1}"
 msgid "Row {0}: Both Debit and Credit values cannot be zero"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:222
+#: erpnext/controllers/selling_controller.py:230
 msgid "Row {0}: Conversion Factor is mandatory"
 msgstr "Línea {0}: El factor de conversión es obligatorio"
 
-#: erpnext/controllers/accounts_controller.py:2995
+#: erpnext/controllers/accounts_controller.py:2998
 msgid "Row {0}: Cost Center {1} does not belong to Company {2}"
 msgstr ""
 
@@ -45570,11 +45565,11 @@ msgstr "Fila {0}: Divisa de la lista de materiales # {1} debe ser igual a la mon
 msgid "Row {0}: Debit entry can not be linked with a {1}"
 msgstr "Línea {0}: La entrada de débito no puede vincularse con {1}"
 
-#: erpnext/controllers/selling_controller.py:776
+#: erpnext/controllers/selling_controller.py:784
 msgid "Row {0}: Delivery Warehouse ({1}) and Customer Warehouse ({2}) can not be same"
 msgstr "Fila {0}: el almacén de entrega ({1}) y el almacén del cliente ({2}) no pueden ser iguales"
 
-#: erpnext/controllers/accounts_controller.py:2529
+#: erpnext/controllers/accounts_controller.py:2532
 msgid "Row {0}: Due Date in the Payment Terms table cannot be before Posting Date"
 msgstr "Fila {0}: la fecha de vencimiento en la tabla de condiciones de pago no puede ser anterior a la fecha de publicación."
 
@@ -45583,7 +45578,7 @@ msgid "Row {0}: Either Delivery Note Item or Packed Item reference is mandatory.
 msgstr ""
 
 #: erpnext/accounts/doctype/journal_entry/journal_entry.py:1010
-#: erpnext/controllers/taxes_and_totals.py:1205
+#: erpnext/controllers/taxes_and_totals.py:1215
 msgid "Row {0}: Exchange Rate is mandatory"
 msgstr "Fila {0}: Tipo de cambio es obligatorio"
 
@@ -45632,11 +45627,11 @@ msgstr "Fila {0}: valor Horas debe ser mayor que cero."
 msgid "Row {0}: Invalid reference {1}"
 msgstr "Fila {0}: Referencia no válida {1}"
 
-#: erpnext/controllers/taxes_and_totals.py:142
+#: erpnext/controllers/taxes_and_totals.py:143
 msgid "Row {0}: Item Tax template updated as per validity and rate applied"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:541
+#: erpnext/controllers/selling_controller.py:549
 msgid "Row {0}: Item rate has been updated as per valuation rate since its an internal stock transfer"
 msgstr "Fila {0}: La tarifa del artículo se ha actualizado según la tarifa de valoración, ya que se trata de una transferencia de stock interna"
 
@@ -45756,7 +45751,7 @@ msgstr ""
 msgid "Row {0}: The item {1}, quantity must be positive number"
 msgstr "Fila {0}: el artículo {1}, la cantidad debe ser un número positivo"
 
-#: erpnext/controllers/accounts_controller.py:2972
+#: erpnext/controllers/accounts_controller.py:2975
 msgid "Row {0}: The {3} Account {1} does not belong to the company {2}"
 msgstr ""
 
@@ -45773,7 +45768,7 @@ msgstr "Línea {0}: El factor de conversión de (UdM) es obligatorio"
 msgid "Row {0}: Workstation or Workstation Type is mandatory for an operation {1}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1011
+#: erpnext/controllers/accounts_controller.py:1014
 msgid "Row {0}: user has not applied the rule {1} on the item {2}"
 msgstr "Fila {0}: el usuario no ha aplicado la regla {1} en el elemento {2}"
 
@@ -45785,7 +45780,7 @@ msgstr ""
 msgid "Row {0}: {1} must be greater than 0"
 msgstr "Fila {0}: {1} debe ser mayor que 0"
 
-#: erpnext/controllers/accounts_controller.py:706
+#: erpnext/controllers/accounts_controller.py:709
 msgid "Row {0}: {1} {2} cannot be same as {3} (Party Account) {4}"
 msgstr "Fila {0}: {1} {2} no puede ser la misma que {3} (Cuenta de la tercera parte) {4}"
 
@@ -45801,7 +45796,7 @@ msgstr "Fila {0}: {2} El elemento {1} no existe en {2} {3}"
 msgid "Row {1}: Quantity ({0}) cannot be a fraction. To allow this, disable '{2}' in UOM {3}."
 msgstr "Fila {1}: la cantidad ({0}) no puede ser una fracción. Para permitir esto, deshabilite &#39;{2}&#39; en UOM {3}."
 
-#: erpnext/controllers/buying_controller.py:863
+#: erpnext/controllers/buying_controller.py:871
 msgid "Row {idx}: Asset Naming Series is mandatory for the auto creation of assets for item {item_code}."
 msgstr ""
 
@@ -45827,7 +45822,7 @@ msgstr "Filas eliminadas en {0}"
 msgid "Rows with Same Account heads will be merged on Ledger"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2539
+#: erpnext/controllers/accounts_controller.py:2542
 msgid "Rows with duplicate due dates in other rows were found: {0}"
 msgstr "Se encontraron filas con fechas de vencimiento duplicadas en otras filas: {0}"
 
@@ -45897,7 +45892,7 @@ msgstr ""
 msgid "SLA Paused On"
 msgstr ""
 
-#: erpnext/public/js/utils.js:1167
+#: erpnext/public/js/utils.js:1163
 msgid "SLA is on hold since {0}"
 msgstr "El SLA está en espera desde {0}"
 
@@ -46298,7 +46293,7 @@ msgstr ""
 #: erpnext/accounts/report/sales_register/sales_register.py:238
 #: erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
 #: erpnext/buying/doctype/supplier_quotation_item/supplier_quotation_item.json
-#: erpnext/controllers/selling_controller.py:462
+#: erpnext/controllers/selling_controller.py:470
 #: erpnext/crm/doctype/contract/contract.json
 #: erpnext/maintenance/doctype/maintenance_schedule/maintenance_schedule.js:65
 #: erpnext/maintenance/doctype/maintenance_schedule_item/maintenance_schedule_item.json
@@ -46424,7 +46419,7 @@ msgstr "La órden de venta {0} no esta validada"
 msgid "Sales Order {0} is not valid"
 msgstr "Orden de venta {0} no es válida"
 
-#: erpnext/controllers/selling_controller.py:443
+#: erpnext/controllers/selling_controller.py:451
 #: erpnext/manufacturing/doctype/work_order/work_order.py:301
 msgid "Sales Order {0} is {1}"
 msgstr "Orden de Venta {0} es {1}"
@@ -46475,7 +46470,7 @@ msgstr "Órdenes de Ventas para Enviar"
 #: erpnext/accounts/doctype/promotional_scheme/promotional_scheme.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:122
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1156
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1158
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:99
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:194
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:74
@@ -46573,7 +46568,7 @@ msgstr "Resumen de Pago de Ventas"
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:156
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:137
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:128
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1153
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1155
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:105
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:191
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:80
@@ -46593,7 +46588,7 @@ msgstr "Resumen de Pago de Ventas"
 msgid "Sales Person"
 msgstr "Persona de ventas"
 
-#: erpnext/controllers/selling_controller.py:204
+#: erpnext/controllers/selling_controller.py:212
 msgid "Sales Person <b>{0}</b> is disabled."
 msgstr "Vendedor <b>{0}</b> está desactivado."
 
@@ -46874,7 +46869,7 @@ msgstr "Almacenamiento de Muestras de Retención"
 
 #. Label of the sample_size (Float) field in DocType 'Quality Inspection'
 #: erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py:93
-#: erpnext/public/js/controllers/transaction.js:2369
+#: erpnext/public/js/controllers/transaction.js:2395
 #: erpnext/stock/doctype/quality_inspection/quality_inspection.json
 msgid "Sample Size"
 msgstr "Tamaño de muestra"
@@ -47412,7 +47407,7 @@ msgstr "Seleccionar articulos"
 msgid "Select Items based on Delivery Date"
 msgstr "Seleccionar Elementos según la Fecha de Entrega"
 
-#: erpnext/public/js/controllers/transaction.js:2405
+#: erpnext/public/js/controllers/transaction.js:2431
 msgid "Select Items for Quality Inspection"
 msgstr ""
 
@@ -47553,7 +47548,7 @@ msgstr "Seleccione primero la Compañia"
 msgid "Select company name first."
 msgstr "Seleccione primero el nombre de la empresa."
 
-#: erpnext/controllers/accounts_controller.py:2785
+#: erpnext/controllers/accounts_controller.py:2788
 msgid "Select finance book for the item {0} at row {1}"
 msgstr "Seleccione el libro de finanzas para el artículo {0} en la fila {1}"
 
@@ -47766,7 +47761,7 @@ msgid "Send Now"
 msgstr "Enviar ahora"
 
 #. Label of the send_sms (Button) field in DocType 'SMS Center'
-#: erpnext/public/js/controllers/transaction.js:517
+#: erpnext/public/js/controllers/transaction.js:543
 #: erpnext/selling/doctype/sms_center/sms_center.json
 msgid "Send SMS"
 msgstr "Enviar mensaje SMS"
@@ -47924,7 +47919,7 @@ msgstr ""
 #: erpnext/manufacturing/doctype/job_card/job_card.json
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.js:74
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.py:114
-#: erpnext/public/js/controllers/transaction.js:2382
+#: erpnext/public/js/controllers/transaction.js:2408
 #: erpnext/public/js/utils/serial_no_batch_selector.js:421
 #: erpnext/selling/doctype/installation_note_item/installation_note_item.json
 #: erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
@@ -47973,7 +47968,7 @@ msgstr ""
 msgid "Serial No Range"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1894
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1895
 msgid "Serial No Reserved"
 msgstr ""
 
@@ -48013,7 +48008,7 @@ msgstr "Número de serie y de lote"
 msgid "Serial No and Batch Selector cannot be use when Use Serial / Batch Fields is enabled."
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:859
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:860
 msgid "Serial No is mandatory"
 msgstr ""
 
@@ -48042,7 +48037,7 @@ msgstr "Número de serie {0} no pertenece al producto {1}"
 msgid "Serial No {0} does not exist"
 msgstr "El número de serie {0} no existe"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2623
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2624
 msgid "Serial No {0} does not exists"
 msgstr ""
 
@@ -48050,7 +48045,7 @@ msgstr ""
 msgid "Serial No {0} is already added"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:357
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:358
 msgid "Serial No {0} is not present in the {1} {2}, hence you can't return it against the {1} {2}"
 msgstr ""
 
@@ -48087,11 +48082,11 @@ msgstr ""
 msgid "Serial Nos and Batches"
 msgstr "Números de serie y lotes"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1370
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1371
 msgid "Serial Nos are created successfully"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:2137
+#: erpnext/stock/stock_ledger.py:2145
 msgid "Serial Nos are reserved in Stock Reservation Entries, you need to unreserve them before proceeding."
 msgstr ""
 
@@ -48165,11 +48160,11 @@ msgstr ""
 msgid "Serial and Batch Bundle"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1598
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1599
 msgid "Serial and Batch Bundle created"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1664
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1665
 msgid "Serial and Batch Bundle updated"
 msgstr ""
 
@@ -48521,12 +48516,12 @@ msgid "Service Stop Date"
 msgstr "Fecha de Finalización del Servicio"
 
 #: erpnext/accounts/deferred_revenue.py:44
-#: erpnext/public/js/controllers/transaction.js:1420
+#: erpnext/public/js/controllers/transaction.js:1446
 msgid "Service Stop Date cannot be after Service End Date"
 msgstr "La Fecha de Detención del Servicio no puede ser posterior a la Fecha de Finalización del Servicio"
 
 #: erpnext/accounts/deferred_revenue.py:41
-#: erpnext/public/js/controllers/transaction.js:1417
+#: erpnext/public/js/controllers/transaction.js:1443
 msgid "Service Stop Date cannot be before Service Start Date"
 msgstr "La Fecha de Detención del Servicio no puede ser anterior a la Decha de Inicio del Servicio"
 
@@ -49961,7 +49956,7 @@ msgstr ""
 
 #: erpnext/setup/setup_wizard/operations/defaults_setup.py:70
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:463
-#: erpnext/stock/doctype/item/item.py:245
+#: erpnext/stock/doctype/item/item.py:248
 msgid "Standard Selling"
 msgstr "Venta estándar"
 
@@ -50791,7 +50786,7 @@ msgstr "Inventario Recibido pero no Facturado"
 #. Option for the 'Purpose' (Select) field in DocType 'Stock Reconciliation'
 #. Label of a Link in the Stock Workspace
 #: erpnext/setup/workspace/home/home.json
-#: erpnext/stock/doctype/item/item.py:612
+#: erpnext/stock/doctype/item/item.py:618
 #: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.json
 #: erpnext/stock/workspace/stock/stock.json
 msgid "Stock Reconciliation"
@@ -50802,7 +50797,7 @@ msgstr "Reconciliación de inventarios"
 msgid "Stock Reconciliation Item"
 msgstr "Elemento de reconciliación de inventarios"
 
-#: erpnext/stock/doctype/item/item.py:612
+#: erpnext/stock/doctype/item/item.py:618
 msgid "Stock Reconciliations"
 msgstr "Reconciliaciones de stock"
 
@@ -50837,7 +50832,7 @@ msgstr ""
 #: erpnext/stock/doctype/pick_list/pick_list.js:150
 #: erpnext/stock/doctype/pick_list/pick_list.js:155
 #: erpnext/stock/doctype/stock_entry/stock_entry_dashboard.py:25
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:706
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:702
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:575
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:1138
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:1398
@@ -51237,7 +51232,7 @@ msgstr "La Órden de Trabajo detenida no se puede cancelar, desactívela primero
 #: erpnext/setup/doctype/company/company.py:287
 #: erpnext/setup/setup_wizard/operations/defaults_setup.py:33
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:502
-#: erpnext/stock/doctype/item/item.py:282
+#: erpnext/stock/doctype/item/item.py:285
 msgid "Stores"
 msgstr "Sucursales"
 
@@ -51772,7 +51767,7 @@ msgstr "Reconciliado exitosamente"
 msgid "Successfully Set Supplier"
 msgstr "Proveedor establecido con éxito"
 
-#: erpnext/stock/doctype/item/item.py:339
+#: erpnext/stock/doctype/item/item.py:342
 msgid "Successfully changed Stock UOM, please redefine conversion factors for new UOM."
 msgstr ""
 
@@ -52074,7 +52069,7 @@ msgstr "Detalles del proveedor"
 #: erpnext/accounts/doctype/tax_rule/tax_rule.json
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:111
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:87
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1160
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1162
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:198
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:237
 #: erpnext/accounts/report/purchase_register/purchase_register.js:27
@@ -52174,7 +52169,7 @@ msgstr "Resumen del Libro Mayor de Proveedores"
 #. Label of the supplier_name (Data) field in DocType 'Purchase Receipt'
 #. Label of the supplier_name (Data) field in DocType 'Stock Entry'
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1077
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1079
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:156
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:198
 #: erpnext/accounts/report/purchase_register/purchase_register.py:177
@@ -52658,7 +52653,7 @@ msgstr ""
 msgid "System will fetch all the entries if limit value is zero."
 msgstr "El sistema buscará todas las entradas si el valor límite es cero."
 
-#: erpnext/controllers/accounts_controller.py:1975
+#: erpnext/controllers/accounts_controller.py:1978
 msgid "System will not check over billing since amount for Item {0} in {1} is zero"
 msgstr ""
 
@@ -52917,7 +52912,7 @@ msgstr ""
 msgid "Target Warehouse is required before Submit"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:782
+#: erpnext/controllers/selling_controller.py:790
 msgid "Target Warehouse is set for some items but the customer is not an internal customer."
 msgstr ""
 
@@ -53156,7 +53151,7 @@ msgstr "Desglose de impuestos"
 msgid "Tax Category"
 msgstr "Categoría de impuestos"
 
-#: erpnext/controllers/buying_controller.py:194
+#: erpnext/controllers/buying_controller.py:202
 msgid "Tax Category has been changed to \"Total\" because all the Items are non-stock items"
 msgstr "Categoría de Impuesto fue cambiada a \"Total\" debido a que todos los Productos son items de no stock"
 
@@ -53361,7 +53356,7 @@ msgstr ""
 #. Label of the taxable_amount (Currency) field in DocType 'Tax Withheld
 #. Vouchers'
 #: erpnext/accounts/doctype/tax_withheld_vouchers/tax_withheld_vouchers.json
-#: erpnext/controllers/taxes_and_totals.py:1125
+#: erpnext/controllers/taxes_and_totals.py:1135
 msgid "Taxable Amount"
 msgstr "Base imponible"
 
@@ -53500,7 +53495,7 @@ msgstr "Impuestos y cargos deducidos"
 msgid "Taxes and Charges Deducted (Company Currency)"
 msgstr "Impuestos y gastos deducibles (Divisa por defecto)"
 
-#: erpnext/stock/doctype/item/item.py:352
+#: erpnext/stock/doctype/item/item.py:355
 msgid "Taxes row #{0}: {1} cannot be smaller than {2}"
 msgstr ""
 
@@ -53786,7 +53781,7 @@ msgstr "Plantillas de términos y condiciones"
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/territory_item/territory_item.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:134
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1144
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1146
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:93
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:182
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:68
@@ -53890,7 +53885,7 @@ msgstr "El acceso a la solicitud de cotización del portal está deshabilitado. 
 msgid "The BOM which will be replaced"
 msgstr "La lista de materiales que será sustituida"
 
-#: erpnext/stock/serial_batch_bundle.py:1274
+#: erpnext/stock/serial_batch_bundle.py:1306
 msgid "The Batch {0} has negative quantity {1} in warehouse {2}. Please correct the quantity."
 msgstr ""
 
@@ -53942,7 +53937,7 @@ msgstr ""
 msgid "The Serial No at Row #{0}: {1} is not available in warehouse {2}."
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1891
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1892
 msgid "The Serial No {0} is reserved against the {1} {2} and cannot be used for any other transaction."
 msgstr ""
 
@@ -54025,7 +54020,7 @@ msgstr ""
 msgid "The following batches are expired, please restock them: <br> {0}"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:849
+#: erpnext/stock/doctype/item/item.py:843
 msgid "The following deleted attributes exist in Variants but not in the Template. You can either delete the Variants or keep the attribute(s) in template."
 msgstr "Los siguientes atributos eliminados existen en las variantes pero no en la plantilla. Puede eliminar las variantes o mantener los atributos en la plantilla."
 
@@ -54050,15 +54045,15 @@ msgstr "El peso bruto del paquete. Peso + embalaje Normalmente material neto . (
 msgid "The holiday on {0} is not between From Date and To Date"
 msgstr "El día de fiesta en {0} no es entre De la fecha y Hasta la fecha"
 
-#: erpnext/controllers/buying_controller.py:1066
+#: erpnext/controllers/buying_controller.py:1074
 msgid "The item {item} is not marked as {type_of} item. You can enable it as {type_of} item from its Item master."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:614
+#: erpnext/stock/doctype/item/item.py:620
 msgid "The items {0} and {1} are present in the following {2} :"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:1059
+#: erpnext/controllers/buying_controller.py:1067
 msgid "The items {items} are not marked as {type_of} item. You can enable them as {type_of} item from their Item masters."
 msgstr ""
 
@@ -54160,8 +54155,8 @@ msgstr "El producto seleccionado no puede contener lotes"
 msgid "The seller and the buyer cannot be the same"
 msgstr "El vendedor y el comprador no pueden ser el mismo"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:142
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:154
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:143
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:155
 msgid "The serial and batch bundle {0} not linked to {1} {2}"
 msgstr ""
 
@@ -54185,7 +54180,7 @@ msgstr "Las acciones no existen con el {0}"
 msgid "The stock for the item {0} in the {1} warehouse was negative on the {2}. You should create a positive entry {3} before the date {4} and time {5} to post the correct valuation rate. For more details, please read the <a href='https://docs.erpnext.com/docs/user/manual/en/stock-adjustment-cogs-with-negative-stock'>documentation<a>."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:700
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:696
 msgid "The stock has been reserved for the following Items and Warehouses, un-reserve the same to {0} the Stock Reconciliation: <br /><br /> {1}"
 msgstr ""
 
@@ -54198,11 +54193,11 @@ msgstr ""
 msgid "The task has been enqueued as a background job."
 msgstr "La tarea se ha puesto en cola como trabajo en segundo plano."
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:994
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:990
 msgid "The task has been enqueued as a background job. In case there is any issue on processing in background, the system will add a comment about the error on this Stock Reconciliation and revert to the Draft stage"
 msgstr "La tarea se ha puesto en cola como un trabajo en segundo plano. En caso de que haya algún problema con el procesamiento en segundo plano, el sistema agregará un comentario sobre el error en esta Reconciliación de inventario y volverá a la etapa Borrador"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1005
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1001
 msgid "The task has been enqueued as a background job. In case there is any issue on processing in background, the system will add a comment about the error on this Stock Reconciliation and revert to the Submitted stage"
 msgstr ""
 
@@ -54252,7 +54247,7 @@ msgstr ""
 msgid "The {0} ({1}) must be equal to {2} ({3})"
 msgstr "El {0} ({1}) debe ser igual a {2} ({3})"
 
-#: erpnext/public/js/controllers/transaction.js:2790
+#: erpnext/public/js/controllers/transaction.js:2816
 msgid "The {0} contains Unit Price Items."
 msgstr ""
 
@@ -54300,7 +54295,7 @@ msgstr ""
 msgid "There can be multiple tiered collection factor based on the total spent. But the conversion factor for redemption will always be same for all the tier."
 msgstr ""
 
-#: erpnext/accounts/party.py:580
+#: erpnext/accounts/party.py:586
 msgid "There can only be 1 Account per Company in {0} {1}"
 msgstr "Sólo puede existir una (1) cuenta por compañía en {0} {1}"
 
@@ -54586,7 +54581,7 @@ msgstr "Esto se añade al código del producto y la variante. Por ejemplo, si su
 msgid "This will restrict user access to other employee records"
 msgstr "Esto restringirá el acceso del usuario a otros registros de empleados"
 
-#: erpnext/controllers/selling_controller.py:783
+#: erpnext/controllers/selling_controller.py:791
 msgid "This {} will be treated as material transfer."
 msgstr ""
 
@@ -55300,11 +55295,11 @@ msgid "To include sub-assembly costs and scrap items in Finished Goods on a work
 msgstr ""
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:2337
-#: erpnext/controllers/accounts_controller.py:3005
+#: erpnext/controllers/accounts_controller.py:3008
 msgid "To include tax in row {0} in Item rate, taxes in rows {1} must also be included"
 msgstr "Para incluir el impuesto en la línea {0} los impuestos de las lineas {1} tambien deben ser incluidos"
 
-#: erpnext/stock/doctype/item/item.py:636
+#: erpnext/stock/doctype/item/item.py:642
 msgid "To merge, following properties must be same for both items"
 msgstr "Para fusionar, la siguientes propiedades deben ser las mismas en ambos productos"
 
@@ -55924,7 +55919,7 @@ msgstr "Monto total pendiente"
 msgid "Total Paid Amount"
 msgstr "Importe total pagado"
 
-#: erpnext/controllers/accounts_controller.py:2591
+#: erpnext/controllers/accounts_controller.py:2594
 msgid "Total Payment Amount in Payment Schedule must be equal to Grand / Rounded Total"
 msgstr "El monto total del pago en el cronograma de pago debe ser igual al total / Total Redondeado"
 
@@ -56209,15 +56204,15 @@ msgstr ""
 msgid "Total Working Hours"
 msgstr "Horas de trabajo total"
 
-#: erpnext/controllers/accounts_controller.py:2138
+#: erpnext/controllers/accounts_controller.py:2141
 msgid "Total advance ({0}) against Order {1} cannot be greater than the Grand Total ({2})"
 msgstr "Avance total ({0}) contra la Orden {1} no puede ser mayor que el Total ({2})"
 
-#: erpnext/controllers/selling_controller.py:190
+#: erpnext/controllers/selling_controller.py:198
 msgid "Total allocated percentage for sales team should be 100"
 msgstr "Porcentaje del total asignado para el equipo de ventas debe ser de 100"
 
-#: erpnext/selling/doctype/customer/customer.py:162
+#: erpnext/selling/doctype/customer/customer.py:161
 msgid "Total contribution percentage should be equal to 100"
 msgstr "El porcentaje de contribución total debe ser igual a 100"
 
@@ -57102,7 +57097,7 @@ msgstr "Unidad de Medida (UdM)"
 msgid "Unit of Measure (UOM)"
 msgstr "Unidad de Medida (UdM)"
 
-#: erpnext/stock/doctype/item/item.py:384
+#: erpnext/stock/doctype/item/item.py:387
 msgid "Unit of Measure {0} has been entered more than once in Conversion Factor Table"
 msgstr "Unidad de Medida (UdM) {0} se ha introducido más de una vez en la tabla de factores de conversión"
 
@@ -57544,7 +57539,7 @@ msgstr ""
 msgid "Update timestamp on new communication"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom_creator/bom_creator.py:533
+#: erpnext/manufacturing/doctype/bom_creator/bom_creator.py:534
 msgid "Updated successfully"
 msgstr "Actualizado exitosamente"
 
@@ -57558,7 +57553,7 @@ msgstr "Actualizado exitosamente"
 msgid "Updated via 'Time Log' (In Minutes)"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1387
+#: erpnext/stock/doctype/item/item.py:1381
 msgid "Updating Variants..."
 msgstr "Actualizando Variantes ..."
 
@@ -58116,19 +58111,19 @@ msgstr "Tasa de valoración"
 msgid "Valuation Rate (In / Out)"
 msgstr "Tasa de Valoración (Entrada/Salida)"
 
-#: erpnext/stock/stock_ledger.py:1881
+#: erpnext/stock/stock_ledger.py:1890
 msgid "Valuation Rate Missing"
 msgstr "Falta la tasa de valoración"
 
-#: erpnext/stock/stock_ledger.py:1859
+#: erpnext/stock/stock_ledger.py:1868
 msgid "Valuation Rate for the Item {0}, is required to do accounting entries for {1} {2}."
 msgstr "Tasa de valoración para el artículo {0}, se requiere para realizar asientos contables para {1} {2}."
 
-#: erpnext/stock/doctype/item/item.py:266
+#: erpnext/stock/doctype/item/item.py:269
 msgid "Valuation Rate is mandatory if Opening Stock entered"
 msgstr "Rango de Valoración es obligatorio si se ha ingresado una Apertura de Almacén"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:752
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:748
 msgid "Valuation Rate required for Item {0} at row {1}"
 msgstr "Tasa de valoración requerida para el artículo {0} en la fila {1}"
 
@@ -58138,7 +58133,7 @@ msgstr "Tasa de valoración requerida para el artículo {0} en la fila {1}"
 msgid "Valuation and Total"
 msgstr "Valuación y Total"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:971
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:967
 msgid "Valuation rate for customer provided items has been set to zero."
 msgstr ""
 
@@ -58152,7 +58147,7 @@ msgid "Valuation rate for the item as per Sales Invoice (Only for Internal Trans
 msgstr ""
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:2361
-#: erpnext/controllers/accounts_controller.py:3029
+#: erpnext/controllers/accounts_controller.py:3032
 msgid "Valuation type charges can not be marked as Inclusive"
 msgstr "Los cargos por tipo de valoración no se pueden marcar como inclusivos"
 
@@ -58308,7 +58303,7 @@ msgstr "Varianza ({})"
 msgid "Variant"
 msgstr "Variante"
 
-#: erpnext/stock/doctype/item/item.py:864
+#: erpnext/stock/doctype/item/item.py:858
 msgid "Variant Attribute Error"
 msgstr "Error de atributo de variante"
 
@@ -58327,7 +58322,7 @@ msgstr "Lista de materiales variante"
 msgid "Variant Based On"
 msgstr "Variante basada en"
 
-#: erpnext/stock/doctype/item/item.py:892
+#: erpnext/stock/doctype/item/item.py:886
 msgid "Variant Based On cannot be changed"
 msgstr "La variante basada en no se puede cambiar"
 
@@ -58345,7 +58340,7 @@ msgstr "Campo de Variante"
 msgid "Variant Item"
 msgstr "Elemento variante"
 
-#: erpnext/stock/doctype/item/item.py:862
+#: erpnext/stock/doctype/item/item.py:856
 msgid "Variant Items"
 msgstr "Elementos variantes"
 
@@ -58463,7 +58458,7 @@ msgstr "Ajustes de video"
 #: erpnext/accounts/doctype/cost_center/cost_center_tree.js:56
 #: erpnext/accounts/doctype/invoice_discounting/invoice_discounting.js:205
 #: erpnext/accounts/doctype/journal_entry/journal_entry.js:43
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:668
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:670
 #: erpnext/bulk_transaction/doctype/bulk_transaction_log/bulk_transaction_log.js:14
 #: erpnext/bulk_transaction/doctype/bulk_transaction_log/bulk_transaction_log.js:24
 #: erpnext/buying/doctype/request_for_quotation/request_for_quotation.js:167
@@ -58650,7 +58645,7 @@ msgstr ""
 #: erpnext/accounts/doctype/repost_accounting_ledger_items/repost_accounting_ledger_items.json
 #: erpnext/accounts/doctype/repost_payment_ledger_items/repost_payment_ledger_items.json
 #: erpnext/accounts/doctype/unreconcile_payment/unreconcile_payment.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1099
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1101
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.js:42
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:209
 #: erpnext/accounts/report/general_ledger/general_ledger.js:49
@@ -58681,7 +58676,7 @@ msgstr ""
 msgid "Voucher No"
 msgstr "Comprobante No."
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1087
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1088
 msgid "Voucher No is mandatory"
 msgstr ""
 
@@ -58723,7 +58718,7 @@ msgstr ""
 #: erpnext/accounts/doctype/repost_payment_ledger_items/repost_payment_ledger_items.json
 #: erpnext/accounts/doctype/tax_withheld_vouchers/tax_withheld_vouchers.json
 #: erpnext/accounts/doctype/unreconcile_payment/unreconcile_payment.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1097
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1099
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:200
 #: erpnext/accounts/report/general_ledger/general_ledger.py:697
 #: erpnext/accounts/report/invalid_ledger_entries/invalid_ledger_entries.py:31
@@ -59077,10 +59072,6 @@ msgstr "Almacén es Obligatorio"
 msgid "Warehouse not found against the account {0}"
 msgstr "Almacén no encontrado en la cuenta {0}"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:600
-msgid "Warehouse not found in the system"
-msgstr "El almacén no se encuentra en el sistema"
-
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:1130
 #: erpnext/stock/doctype/delivery_note/delivery_note.py:414
 msgid "Warehouse required for stock Item {0}"
@@ -59209,7 +59200,7 @@ msgid "Warn for new Request for Quotations"
 msgstr "Avisar de nuevas Solicitudes de Presupuesto"
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:744
-#: erpnext/controllers/accounts_controller.py:1978
+#: erpnext/controllers/accounts_controller.py:1981
 #: erpnext/stock/doctype/delivery_trip/delivery_trip.js:145
 #: erpnext/utilities/transaction_base.py:123
 msgid "Warning"
@@ -60181,7 +60172,7 @@ msgstr "Si"
 msgid "You are importing data for the code list:"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3611
+#: erpnext/controllers/accounts_controller.py:3614
 msgid "You are not allowed to update as per the conditions set in {} Workflow."
 msgstr "No se le permite actualizar según las condiciones establecidas en {} Flujo de trabajo."
 
@@ -60246,7 +60237,7 @@ msgstr ""
 msgid "You can't make any changes to Job Card since Work Order is closed."
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:185
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:186
 msgid "You can't process the serial number {0} as it has already been used in the SABB {1}. {2} if you want to inward same serial number multiple times then enabled 'Allow existing Serial No to be Manufactured/Received again' in the {3}"
 msgstr ""
 
@@ -60306,7 +60297,7 @@ msgstr "No puede validar el pedido sin pago."
 msgid "You cannot {0} this document because another Period Closing Entry {1} exists after {2}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3587
+#: erpnext/controllers/accounts_controller.py:3590
 msgid "You do not have permissions to {} items in a {}."
 msgstr "No tienes permisos para {} elementos en un {}."
 
@@ -60334,7 +60325,7 @@ msgstr ""
 msgid "You have entered a duplicate Delivery Note on Row"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1063
+#: erpnext/stock/doctype/item/item.py:1057
 msgid "You have to enable auto re-order in Stock Settings to maintain re-order levels."
 msgstr "Debe habilitar el reordenamiento automático en la Configuración de inventario para mantener los niveles de reordenamiento."
 
@@ -60354,7 +60345,7 @@ msgstr "Debe seleccionar un cliente antes de agregar un artículo."
 msgid "You need to cancel POS Closing Entry {} to be able to cancel this document."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2980
+#: erpnext/controllers/accounts_controller.py:2983
 msgid "You selected the account group {1} as {2} Account in row {0}. Please select a single account."
 msgstr ""
 
@@ -60432,7 +60423,7 @@ msgstr "[Importante] [ERPNext] Errores de reorden automático"
 msgid "`Allow Negative rates for Items`"
 msgstr "`Permitir precios Negativos para los Productos`"
 
-#: erpnext/stock/stock_ledger.py:1873
+#: erpnext/stock/stock_ledger.py:1882
 msgid "after"
 msgstr "después"
 
@@ -60580,7 +60571,7 @@ msgstr "Izquierda-"
 msgid "material_request_item"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:151
+#: erpnext/controllers/selling_controller.py:159
 msgid "must be between 0 and 100"
 msgstr ""
 
@@ -60605,7 +60596,7 @@ msgstr "old_parent"
 msgid "on"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1289
+#: erpnext/controllers/accounts_controller.py:1292
 msgid "or"
 msgstr "o"
 
@@ -60654,7 +60645,7 @@ msgstr ""
 msgid "per hour"
 msgstr "por hora"
 
-#: erpnext/stock/stock_ledger.py:1874
+#: erpnext/stock/stock_ledger.py:1883
 msgid "performing either one below:"
 msgstr ""
 
@@ -60781,7 +60772,7 @@ msgstr "debe seleccionar Cuenta Capital Work in Progress en la tabla de cuentas"
 msgid "{0}"
 msgstr "{0}"
 
-#: erpnext/controllers/accounts_controller.py:1109
+#: erpnext/controllers/accounts_controller.py:1112
 msgid "{0} '{1}' is disabled"
 msgstr "{0} '{1}' está deshabilitado"
 
@@ -60797,7 +60788,7 @@ msgstr "{0} ({1}) no puede ser mayor que la cantidad planificada ({2}) en la Ord
 msgid "{0} <b>{1}</b> has submitted Assets. Remove Item <b>{2}</b> from table to continue."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2193
+#: erpnext/controllers/accounts_controller.py:2196
 msgid "{0} Account not found against Customer {1}."
 msgstr ""
 
@@ -60829,7 +60820,7 @@ msgstr "{0} Operaciones: {1}"
 msgid "{0} Request for {1}"
 msgstr "{0} Solicitud de {1}"
 
-#: erpnext/stock/doctype/item/item.py:323
+#: erpnext/stock/doctype/item/item.py:326
 msgid "{0} Retain Sample is based on batch, please check Has Batch No to retain sample of item"
 msgstr "{0} Retener muestra se basa en el lote, marque Tiene número de lote para retener la muestra del artículo."
 
@@ -60920,7 +60911,7 @@ msgid "{0} entered twice in Item Tax"
 msgstr "{0} se ingresó dos veces en impuesto del artículo"
 
 #: erpnext/setup/doctype/item_group/item_group.py:48
-#: erpnext/stock/doctype/item/item.py:436
+#: erpnext/stock/doctype/item/item.py:439
 msgid "{0} entered twice {1} in Item Taxes"
 msgstr ""
 
@@ -60941,7 +60932,7 @@ msgstr "{0} se ha validado correctamente"
 msgid "{0} hours"
 msgstr "{0} horas"
 
-#: erpnext/controllers/accounts_controller.py:2534
+#: erpnext/controllers/accounts_controller.py:2537
 msgid "{0} in row {1}"
 msgstr "{0} en la fila {1}"
 
@@ -60965,7 +60956,7 @@ msgstr "{0} está bloqueado por lo que esta transacción no puede continuar"
 
 #: erpnext/accounts/doctype/budget/budget.py:60
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:643
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:49
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:50
 #: erpnext/accounts/report/general_ledger/general_ledger.py:59
 #: erpnext/accounts/report/pos_register/pos_register.py:107
 #: erpnext/controllers/trends.py:50
@@ -60985,11 +60976,11 @@ msgstr ""
 msgid "{0} is mandatory. Maybe Currency Exchange record is not created for {1} to {2}"
 msgstr "{0} es obligatorio. Quizás no se crea el registro de cambio de moneda para {1} a {2}"
 
-#: erpnext/controllers/accounts_controller.py:2937
+#: erpnext/controllers/accounts_controller.py:2940
 msgid "{0} is mandatory. Maybe Currency Exchange record is not created for {1} to {2}."
 msgstr "{0} es obligatorio. Posiblemente el registro de cambio de moneda no ha sido creado para {1} hasta {2}."
 
-#: erpnext/selling/doctype/customer/customer.py:204
+#: erpnext/selling/doctype/customer/customer.py:203
 msgid "{0} is not a company bank account"
 msgstr "{0} no es una cuenta bancaria de la empresa"
 
@@ -61072,7 +61063,7 @@ msgstr ""
 msgid "{0} to {1}"
 msgstr "{0} a {1}"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:690
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:686
 msgid "{0} units are reserved for Item {1} in Warehouse {2}, please un-reserve the same to {3} the Stock Reconciliation."
 msgstr ""
 
@@ -61088,16 +61079,16 @@ msgstr ""
 msgid "{0} units of {1} are required in {2} with the inventory dimension: {3} ({4}) on {5} {6} for {7} to complete the transaction."
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1532 erpnext/stock/stock_ledger.py:2023
-#: erpnext/stock/stock_ledger.py:2037
+#: erpnext/stock/stock_ledger.py:1541 erpnext/stock/stock_ledger.py:2031
+#: erpnext/stock/stock_ledger.py:2045
 msgid "{0} units of {1} needed in {2} on {3} {4} for {5} to complete this transaction."
 msgstr "{0} unidades de {1} necesaria en {2} sobre {3} {4} {5} para completar esta transacción."
 
-#: erpnext/stock/stock_ledger.py:2124 erpnext/stock/stock_ledger.py:2170
+#: erpnext/stock/stock_ledger.py:2132 erpnext/stock/stock_ledger.py:2178
 msgid "{0} units of {1} needed in {2} on {3} {4} to complete this transaction."
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1526
+#: erpnext/stock/stock_ledger.py:1535
 msgid "{0} units of {1} needed in {2} to complete this transaction."
 msgstr "{0} unidades de {1} necesaria en {2} para completar esta transacción."
 
@@ -61143,7 +61134,7 @@ msgstr "{0} {1} creado"
 msgid "{0} {1} does not exist"
 msgstr "{0} {1} no existe"
 
-#: erpnext/accounts/party.py:560
+#: erpnext/accounts/party.py:566
 msgid "{0} {1} has accounting entries in currency {2} for company {3}. Please select a receivable or payable account with currency {2}."
 msgstr "{0} {1} tiene asientos contables en la moneda {2} de la empresa {3}. Seleccione una cuenta por cobrar o por pagar con la moneda {2}."
 
@@ -61177,7 +61168,7 @@ msgstr ""
 msgid "{0} {1} is associated with {2}, but Party Account is {3}"
 msgstr "{0} {1} está asociado con {2}, pero la cuenta de grupo es {3}"
 
-#: erpnext/controllers/selling_controller.py:462
+#: erpnext/controllers/selling_controller.py:470
 #: erpnext/controllers/subcontracting_controller.py:954
 msgid "{0} {1} is cancelled or closed"
 msgstr "{0} {1} está cancelado o cerrado"
@@ -61194,11 +61185,11 @@ msgstr "{0} {1} está cancelado por lo tanto la acción no puede ser completada"
 msgid "{0} {1} is closed"
 msgstr "{0} {1} está cerrado"
 
-#: erpnext/accounts/party.py:798
+#: erpnext/accounts/party.py:804
 msgid "{0} {1} is disabled"
 msgstr "{0} {1} está desactivado"
 
-#: erpnext/accounts/party.py:804
+#: erpnext/accounts/party.py:810
 msgid "{0} {1} is frozen"
 msgstr "{0} {1} está congelado"
 
@@ -61206,7 +61197,7 @@ msgstr "{0} {1} está congelado"
 msgid "{0} {1} is fully billed"
 msgstr "{0} {1} está totalmente facturado"
 
-#: erpnext/accounts/party.py:808
+#: erpnext/accounts/party.py:814
 msgid "{0} {1} is not active"
 msgstr "{0} {1} no está activo"
 
@@ -61332,15 +61323,15 @@ msgstr "{0}: {1} no existe"
 msgid "{0}: {1} must be less than {2}"
 msgstr "{0}: {1} debe ser menor que {2}"
 
-#: erpnext/controllers/buying_controller.py:840
+#: erpnext/controllers/buying_controller.py:848
 msgid "{count} Assets created for {item_code}"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:738
+#: erpnext/controllers/buying_controller.py:746
 msgid "{doctype} {name} is cancelled or closed."
 msgstr "{doctype} {name} está cancelado o cerrado."
 
-#: erpnext/controllers/buying_controller.py:459
+#: erpnext/controllers/buying_controller.py:467
 msgid "{field_label} is mandatory for sub-contracted {doctype}."
 msgstr ""
 
@@ -61348,7 +61339,7 @@ msgstr ""
 msgid "{item_name}'s Sample Size ({sample_size}) cannot be greater than the Accepted Quantity ({accepted_quantity})"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:563
+#: erpnext/controllers/buying_controller.py:571
 msgid "{ref_doctype} {ref_name} is {status}."
 msgstr ""
 
@@ -61414,7 +61405,7 @@ msgstr ""
 msgid "{} can't be cancelled since the Loyalty Points earned has been redeemed. First cancel the {} No {}"
 msgstr "{} no se puede cancelar ya que se canjearon los puntos de fidelidad ganados. Primero cancele el {} No {}"
 
-#: erpnext/controllers/buying_controller.py:222
+#: erpnext/controllers/buying_controller.py:230
 msgid "{} has submitted assets linked to it. You need to cancel the assets to create purchase return."
 msgstr "{} tiene validados elementos vinculados a él. Debe cancelar los activos para crear una devolución de compra."
 

--- a/erpnext/locale/fa.po
+++ b/erpnext/locale/fa.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: frappe\n"
 "Report-Msgid-Bugs-To: hello@frappe.io\n"
-"POT-Creation-Date: 2025-05-25 09:35+0000\n"
-"PO-Revision-Date: 2025-05-27 20:41\n"
+"POT-Creation-Date: 2025-06-01 09:36+0000\n"
+"PO-Revision-Date: 2025-06-01 21:35\n"
 "Last-Translator: hello@frappe.io\n"
 "Language-Team: Persian\n"
 "MIME-Version: 1.0\n"
@@ -83,15 +83,15 @@ msgstr " زیر مونتاژ"
 msgid " Summary"
 msgstr " خلاصه"
 
-#: erpnext/stock/doctype/item/item.py:235
+#: erpnext/stock/doctype/item/item.py:238
 msgid "\"Customer Provided Item\" cannot be Purchase Item also"
 msgstr "\"آیتم تامین شده توسط مشتری\" نمی‌تواند آیتم خرید هم باشد"
 
-#: erpnext/stock/doctype/item/item.py:237
+#: erpnext/stock/doctype/item/item.py:240
 msgid "\"Customer Provided Item\" cannot have Valuation Rate"
 msgstr "\"آیتم تامین شده توسط مشتری\" نمی‌تواند دارای نرخ ارزش‌گذاری باشد"
 
-#: erpnext/stock/doctype/item/item.py:313
+#: erpnext/stock/doctype/item/item.py:316
 msgid "\"Is Fixed Asset\" cannot be unchecked, as Asset record exists against the item"
 msgstr "علامت \"دارایی ثابت است\" را نمی‌توان بردارید، زیرا رکورد دارایی در برابر آیتم وجود دارد"
 
@@ -213,7 +213,7 @@ msgstr "٪ از مواد در برابر این سفارش فروش صورتحس
 msgid "% of materials delivered against this Sales Order"
 msgstr "٪ از مواد در برابر این سفارش فروش تحویل شدند"
 
-#: erpnext/controllers/accounts_controller.py:2197
+#: erpnext/controllers/accounts_controller.py:2200
 msgid "'Account' in the Accounting section of Customer {0}"
 msgstr "حساب در بخش حسابداری مشتری {0}"
 
@@ -225,15 +225,11 @@ msgstr "اجازه ایجاد چندین سفارش فروش برای یک سف�
 msgid "'Based On' and 'Group By' can not be same"
 msgstr "بر اساس و \"گروه بر اساس\" نمی‌توانند یکسان باشند"
 
-#: erpnext/stock/report/product_bundle_balance/product_bundle_balance.py:233
-msgid "'Date' is required"
-msgstr "'تاریخ' الزامی است"
-
 #: erpnext/selling/report/inactive_customers/inactive_customers.py:18
 msgid "'Days Since Last Order' must be greater than or equal to zero"
 msgstr "روزهای پس از آخرین سفارش باید بزرگتر یا مساوی صفر باشد"
 
-#: erpnext/controllers/accounts_controller.py:2202
+#: erpnext/controllers/accounts_controller.py:2205
 msgid "'Default {0} Account' in Company {1}"
 msgstr "«حساب پیش‌فرض {0}» در شرکت {1}"
 
@@ -243,7 +239,7 @@ msgstr "ورودی ها نمی‌توانند خالی باشند"
 
 #: erpnext/stock/report/batch_item_expiry_status/batch_item_expiry_status.py:24
 #: erpnext/stock/report/batch_wise_balance_history/batch_wise_balance_history.py:120
-#: erpnext/stock/report/stock_analytics/stock_analytics.py:314
+#: erpnext/stock/report/stock_analytics/stock_analytics.py:313
 msgid "'From Date' is required"
 msgstr "«از تاریخ» مورد نیاز است"
 
@@ -251,7 +247,7 @@ msgstr "«از تاریخ» مورد نیاز است"
 msgid "'From Date' must be after 'To Date'"
 msgstr "«از تاریخ» باید بعد از «تا امروز» باشد"
 
-#: erpnext/stock/doctype/item/item.py:398
+#: erpnext/stock/doctype/item/item.py:401
 msgid "'Has Serial No' can not be 'Yes' for non-stock item"
 msgstr "دارای شماره سریال نمی‌تواند \"بله\" برای کالاهای غیر موجودی باشد"
 
@@ -1087,7 +1083,7 @@ msgstr "مقدار پذیرفته شده در انبار UOM"
 
 #. Label of the qty (Float) field in DocType 'Purchase Receipt Item'
 #. Label of the qty (Float) field in DocType 'Subcontracting Receipt Item'
-#: erpnext/public/js/controllers/transaction.js:2362
+#: erpnext/public/js/controllers/transaction.js:2388
 #: erpnext/stock/doctype/purchase_receipt_item/purchase_receipt_item.json
 #: erpnext/subcontracting/doctype/subcontracting_receipt_item/subcontracting_receipt_item.json
 msgid "Accepted Quantity"
@@ -1285,7 +1281,7 @@ msgid "Account Manager"
 msgstr "مدیر حساب"
 
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:949
-#: erpnext/controllers/accounts_controller.py:2206
+#: erpnext/controllers/accounts_controller.py:2209
 msgid "Account Missing"
 msgstr "حساب از دست رفته است"
 
@@ -1460,7 +1456,7 @@ msgstr "حساب {0} در شرکت فرزند {1} اضافه شد"
 msgid "Account {0} is frozen"
 msgstr "حساب {0} مسدود شده است"
 
-#: erpnext/controllers/accounts_controller.py:1288
+#: erpnext/controllers/accounts_controller.py:1291
 msgid "Account {0} is invalid. Account Currency must be {1}"
 msgstr "حساب {0} نامعتبر است. ارز حساب باید {1} باشد"
 
@@ -1496,7 +1492,7 @@ msgstr "حساب: {0} فقط از طریق معاملات موجودی قابل 
 msgid "Account: {0} is not permitted under Payment Entry"
 msgstr "حساب: {0} در قسمت ثبت پرداخت مجاز نیست"
 
-#: erpnext/controllers/accounts_controller.py:3037
+#: erpnext/controllers/accounts_controller.py:3040
 msgid "Account: {0} with currency: {1} can not be selected"
 msgstr "حساب: {0} با واحد پول: {1} قابل انتخاب نیست"
 
@@ -1769,7 +1765,7 @@ msgstr "ثبت‌های حسابداری"
 msgid "Accounting Entry for Asset"
 msgstr "ثبت حسابداری برای دارایی"
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:796
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:805
 msgid "Accounting Entry for Service"
 msgstr "ثبت حسابداری برای خدمات"
 
@@ -1784,18 +1780,18 @@ msgstr "ثبت حسابداری برای خدمات"
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py:1468
 #: erpnext/controllers/stock_controller.py:550
 #: erpnext/controllers/stock_controller.py:567
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:889
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:898
 #: erpnext/stock/doctype/stock_entry/stock_entry.py:1586
 #: erpnext/stock/doctype/stock_entry/stock_entry.py:1600
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py:561
 msgid "Accounting Entry for Stock"
 msgstr "ثبت حسابداری برای موجودی"
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:717
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:726
 msgid "Accounting Entry for {0}"
 msgstr "ثبت حسابداری برای {0}"
 
-#: erpnext/controllers/accounts_controller.py:2247
+#: erpnext/controllers/accounts_controller.py:2250
 msgid "Accounting Entry for {0}: {1} can only be made in currency: {2}"
 msgstr "ثبت حسابداری برای {0}: {1} فقط به ارز: {2} قابل انجام است"
 
@@ -2188,7 +2184,7 @@ msgstr "استهلاک انباشته به عنوان"
 msgid "Accumulated Monthly"
 msgstr "انباشته ماهانه"
 
-#: erpnext/controllers/budget_controller.py:417
+#: erpnext/controllers/budget_controller.py:422
 msgid "Accumulated Monthly Budget for Account {0} against {1} {2} is {3}. It will be collectively ({4}) exceeded by {5}"
 msgstr ""
 
@@ -3302,7 +3298,7 @@ msgstr "تعدیل ارزش دارایی"
 msgid "Adjustment Against"
 msgstr "تعدیل در مقابل"
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:634
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:643
 msgid "Adjustment based on Purchase Invoice rate"
 msgstr "تعدیل بر اساس نرخ فاکتور خرید"
 
@@ -3413,7 +3409,7 @@ msgstr "پیش پرداخت مالیات و هزینه ها"
 msgid "Advance amount"
 msgstr "مبلغ پیش پرداخت"
 
-#: erpnext/controllers/taxes_and_totals.py:845
+#: erpnext/controllers/taxes_and_totals.py:855
 msgid "Advance amount cannot be greater than {0} {1}"
 msgstr "مبلغ پیش پرداخت نمی‌تواند بیشتر از {0} {1} باشد"
 
@@ -3624,7 +3620,7 @@ msgstr "سن"
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:152
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:133
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1125
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1127
 msgid "Age (Days)"
 msgstr "سن (بر حسب روز)"
 
@@ -3710,16 +3706,6 @@ msgstr "گروهی از آیتم‌ها را در یک آیتم دیگر جمع 
 #: erpnext/setup/setup_wizard/data/industry_type.txt:4
 msgid "Agriculture"
 msgstr "کشاورزی"
-
-#. Name of a role
-#: erpnext/assets/doctype/location/location.json
-msgid "Agriculture Manager"
-msgstr "مدیر کشاورزی"
-
-#. Name of a role
-#: erpnext/assets/doctype/location/location.json
-msgid "Agriculture User"
-msgstr "کاربر کشاورزی"
 
 #: erpnext/setup/setup_wizard/data/industry_type.txt:5
 msgid "Airline"
@@ -3911,7 +3897,7 @@ msgstr "تمام ارتباطات از جمله و بالاتر از این با
 msgid "All items are already requested"
 msgstr "همه آیتم‌ها قبلا درخواست شده است"
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:1317
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:1326
 msgid "All items have already been Invoiced/Returned"
 msgstr "همه آیتم‌ها قبلاً صورتحساب/بازگردانده شده اند"
 
@@ -3923,7 +3909,7 @@ msgstr "همه آیتم‌ها قبلاً دریافت شده است"
 msgid "All items have already been transferred for this Work Order."
 msgstr "همه آیتم‌ها قبلاً برای این دستور کار منتقل شده اند."
 
-#: erpnext/public/js/controllers/transaction.js:2465
+#: erpnext/public/js/controllers/transaction.js:2491
 msgid "All items in this document already have a linked Quality Inspection."
 msgstr "همه آیتم‌ها در این سند قبلاً دارای یک بازرسی کیفیت مرتبط هستند."
 
@@ -4121,7 +4107,7 @@ msgstr "اجازه انتقالات داخلی با قیمت منصفانه"
 msgid "Allow Item To Be Added Multiple Times in a Transaction"
 msgstr "اجازه افزودن یک آیتم چندین بار در یک تراکنش"
 
-#: erpnext/controllers/selling_controller.py:755
+#: erpnext/controllers/selling_controller.py:763
 msgid "Allow Item to Be Added Multiple Times in a Transaction"
 msgstr "اجازه افزودن یک آیتم چندین بار در یک تراکنش"
 
@@ -5067,7 +5053,7 @@ msgstr "سالانه"
 msgid "Annual Billing: {0}"
 msgstr "صورتحساب سالانه: {0}"
 
-#: erpnext/controllers/budget_controller.py:441
+#: erpnext/controllers/budget_controller.py:446
 msgid "Annual Budget for Account {0} against {1} {2} is {3}. It will be collectively ({4}) exceeded by {5}"
 msgstr ""
 
@@ -5556,7 +5542,7 @@ msgstr "از آنجایی که فیلد {0} فعال است، فیلد {1} اج�
 msgid "As the field {0} is enabled, the value of the field {1} should be more than 1."
 msgstr "از آنجایی که فیلد {0} فعال است، مقدار فیلد {1} باید بیشتر از 1 باشد."
 
-#: erpnext/stock/doctype/item/item.py:989
+#: erpnext/stock/doctype/item/item.py:983
 msgid "As there are existing submitted transactions against item {0}, you can not change the value of {1}."
 msgstr "از آنجایی که تراکنش‌های ارسالی موجود در مقابل آیتم {0} وجود دارد، نمی‌توانید مقدار {1} را تغییر دهید."
 
@@ -5702,7 +5688,7 @@ msgstr "حساب دسته دارایی"
 msgid "Asset Category Name"
 msgstr "نام دسته دارایی"
 
-#: erpnext/stock/doctype/item/item.py:304
+#: erpnext/stock/doctype/item/item.py:307
 msgid "Asset Category is mandatory for Fixed Asset item"
 msgstr "دسته دارایی برای آیتم دارایی ثابت اجباری است"
 
@@ -6077,7 +6063,7 @@ msgstr "دارایی {0} به روز شده است. لطفاً جزئیات اس
 msgid "Asset {0} must be submitted"
 msgstr "دارایی {0} باید ارسال شود"
 
-#: erpnext/controllers/buying_controller.py:851
+#: erpnext/controllers/buying_controller.py:859
 msgid "Asset {assets_link} created for {item_code}"
 msgstr "دارایی {assets_link} برای {item_code} ایجاد شد"
 
@@ -6107,11 +6093,11 @@ msgstr "ارزش دارایی پس از ارسال تعدیل ارزش دارا�
 msgid "Assets"
 msgstr "دارایی‌ها"
 
-#: erpnext/controllers/buying_controller.py:869
+#: erpnext/controllers/buying_controller.py:877
 msgid "Assets not created for {item_code}. You will have to create asset manually."
 msgstr "دارایی برای {item_code} ایجاد نشده است. شما باید دارایی را به صورت دستی ایجاد کنید."
 
-#: erpnext/controllers/buying_controller.py:856
+#: erpnext/controllers/buying_controller.py:864
 msgid "Assets {assets_link} created for {item_code}"
 msgstr "دارایی‌های {assets_link} برای {item_code} ایجاد شد"
 
@@ -6206,7 +6192,7 @@ msgstr "در ردیف #{0}: شناسه دنباله {1} نمی‌تواند کم
 msgid "At row #{0}: you have selected the Difference Account {1}, which is a Cost of Goods Sold type account. Please select a different account"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:864
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:865
 msgid "At row {0}: Batch No is mandatory for Item {1}"
 msgstr "در ردیف {0}: شماره دسته برای مورد {1} اجباری است"
 
@@ -6214,11 +6200,11 @@ msgstr "در ردیف {0}: شماره دسته برای مورد {1} اجبار�
 msgid "At row {0}: Parent Row No cannot be set for item {1}"
 msgstr "در ردیف {0}: ردیف والد برای آیتم {1} قابل تنظیم نیست"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:849
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:850
 msgid "At row {0}: Qty is mandatory for the batch {1}"
 msgstr "در ردیف {0}: مقدار برای دسته {1} اجباری است"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:856
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:857
 msgid "At row {0}: Serial No is mandatory for Item {1}"
 msgstr "در ردیف {0}: شماره سریال برای آیتم {1} اجباری است"
 
@@ -6292,7 +6278,7 @@ msgstr "نام ویژگی"
 msgid "Attribute Value"
 msgstr "مقدار ویژگی"
 
-#: erpnext/stock/doctype/item/item.py:930
+#: erpnext/stock/doctype/item/item.py:924
 msgid "Attribute table is mandatory"
 msgstr "جدول مشخصات اجباری است"
 
@@ -6300,11 +6286,11 @@ msgstr "جدول مشخصات اجباری است"
 msgid "Attribute value: {0} must appear only once"
 msgstr "مقدار مشخصه: {0} باید فقط یک بار ظاهر شود"
 
-#: erpnext/stock/doctype/item/item.py:934
+#: erpnext/stock/doctype/item/item.py:928
 msgid "Attribute {0} selected multiple times in Attributes Table"
 msgstr "ویژگی {0} چندین بار در جدول ویژگی‌ها انتخاب شده است"
 
-#: erpnext/stock/doctype/item/item.py:862
+#: erpnext/stock/doctype/item/item.py:856
 msgid "Attributes"
 msgstr "ویژگی های"
 
@@ -7588,11 +7574,11 @@ msgstr "بارکد"
 msgid "Barcode Type"
 msgstr "نوع بارکد"
 
-#: erpnext/stock/doctype/item/item.py:457
+#: erpnext/stock/doctype/item/item.py:460
 msgid "Barcode {0} already used in Item {1}"
 msgstr "بارکد {0} قبلاً در آیتم {1} استفاده شده است"
 
-#: erpnext/stock/doctype/item/item.py:472
+#: erpnext/stock/doctype/item/item.py:475
 msgid "Barcode {0} is not a valid {1} code"
 msgstr "بارکد {0} یک کد {1} معتبر نیست"
 
@@ -7846,7 +7832,7 @@ msgstr "وضعیت انقضای آیتم دسته"
 #: erpnext/manufacturing/doctype/job_card/job_card.json
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.js:89
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.py:115
-#: erpnext/public/js/controllers/transaction.js:2388
+#: erpnext/public/js/controllers/transaction.js:2414
 #: erpnext/public/js/utils/barcode_scanner.js:260
 #: erpnext/public/js/utils/serial_no_batch_selector.js:438
 #: erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
@@ -7873,11 +7859,11 @@ msgstr "وضعیت انقضای آیتم دسته"
 msgid "Batch No"
 msgstr "شماره دسته"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:867
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:868
 msgid "Batch No is mandatory"
 msgstr "شماره دسته اجباری است"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2629
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2630
 msgid "Batch No {0} does not exists"
 msgstr "شماره دسته {0} وجود ندارد"
 
@@ -7885,7 +7871,7 @@ msgstr "شماره دسته {0} وجود ندارد"
 msgid "Batch No {0} is linked with Item {1} which has serial no. Please scan serial no instead."
 msgstr "شماره دسته {0} با آیتم {1} که دارای شماره سریال است پیوند داده شده است. لطفاً شماره سریال را اسکن کنید."
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:364
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:365
 msgid "Batch No {0} is not present in the original {1} {2}, hence you can't return it against the {1} {2}"
 msgstr ""
 
@@ -7900,11 +7886,11 @@ msgstr "شماره دسته"
 msgid "Batch Nos"
 msgstr "شماره های دسته"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1421
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1422
 msgid "Batch Nos are created successfully"
 msgstr "شماره های دسته با موفقیت ایجاد شد"
 
-#: erpnext/controllers/sales_and_purchase_return.py:1096
+#: erpnext/controllers/sales_and_purchase_return.py:1001
 msgid "Batch Not Available for Return"
 msgstr ""
 
@@ -7953,7 +7939,7 @@ msgstr "دسته ای برای آیتم {} ایجاد نشده است زیرا �
 msgid "Batch {0} and Warehouse"
 msgstr "دسته {0} و انبار"
 
-#: erpnext/controllers/sales_and_purchase_return.py:1095
+#: erpnext/controllers/sales_and_purchase_return.py:1000
 msgid "Batch {0} is not available in warehouse {1}"
 msgstr "دسته {0} در انبار {1} موجود نیست"
 
@@ -8003,7 +7989,7 @@ msgstr ""
 #. Label of the bill_date (Date) field in DocType 'Journal Entry'
 #. Label of the bill_date (Date) field in DocType 'Subcontracting Receipt'
 #: erpnext/accounts/doctype/journal_entry/journal_entry.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1110
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1112
 #: erpnext/accounts/report/purchase_register/purchase_register.py:214
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.json
 msgid "Bill Date"
@@ -8012,7 +7998,7 @@ msgstr "تاریخ صورتحساب"
 #. Label of the bill_no (Data) field in DocType 'Journal Entry'
 #. Label of the bill_no (Data) field in DocType 'Subcontracting Receipt'
 #: erpnext/accounts/doctype/journal_entry/journal_entry.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1109
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1111
 #: erpnext/accounts/report/purchase_register/purchase_register.py:213
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.json
 msgid "Bill No"
@@ -8232,7 +8218,7 @@ msgstr "وضعیت صورتحساب"
 msgid "Billing Zipcode"
 msgstr "کد پستی صورتحساب"
 
-#: erpnext/accounts/party.py:602
+#: erpnext/accounts/party.py:608
 msgid "Billing currency must be equal to either default company's currency or party account currency"
 msgstr "ارز صورتحساب باید با واحد پول پیش‌فرض شرکت یا واحد پول حساب طرف برابر باشد"
 
@@ -9229,7 +9215,7 @@ msgid "Can only make payment against unbilled {0}"
 msgstr "فقط می‌توانید با {0} پرداخت نشده انجام دهید"
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1458
-#: erpnext/controllers/accounts_controller.py:2946
+#: erpnext/controllers/accounts_controller.py:2949
 #: erpnext/public/js/controllers/accounts.js:90
 msgid "Can refer row only if the charge type is 'On Previous Row Amount' or 'Previous Row Total'"
 msgstr "فقط در صورتی می‌توان ردیف را ارجاع داد که نوع شارژ «بر مبلغ ردیف قبلی» یا «مجموع ردیف قبلی» باشد"
@@ -9391,9 +9377,9 @@ msgstr "نمی‌توان زمان رسیدن را محاسبه کرد زیرا 
 msgid "Cannot Create Return"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:625
-#: erpnext/stock/doctype/item/item.py:638
-#: erpnext/stock/doctype/item/item.py:652
+#: erpnext/stock/doctype/item/item.py:631
+#: erpnext/stock/doctype/item/item.py:644
+#: erpnext/stock/doctype/item/item.py:658
 msgid "Cannot Merge"
 msgstr "نمی‌توان ادغام کرد"
 
@@ -9417,7 +9403,7 @@ msgstr "نمی‌توان {0} {1} را اصلاح کرد، لطفاً در عو�
 msgid "Cannot apply TDS against multiple parties in one entry"
 msgstr "نمی‌توان TDS را در یک ثبت در مقابل چندین طرف اعمال کرد"
 
-#: erpnext/stock/doctype/item/item.py:307
+#: erpnext/stock/doctype/item/item.py:310
 msgid "Cannot be a fixed asset item as Stock Ledger is created."
 msgstr "نمی‌تواند یک آیتم دارایی ثابت باشد زیرا دفتر موجودی ایجاد شده است."
 
@@ -9433,7 +9419,7 @@ msgstr "نمی‌توان لغو کرد زیرا ثبت موجودی ارسال 
 msgid "Cannot cancel the transaction. Reposting of item valuation on submission is not completed yet."
 msgstr "نمی‌توان تراکنش را لغو کرد. ارسال مجدد ارزیابی اقلام هنگام ارسال هنوز تکمیل نشده است."
 
-#: erpnext/controllers/buying_controller.py:959
+#: erpnext/controllers/buying_controller.py:967
 msgid "Cannot cancel this document as it is linked with the submitted asset {asset_link}. Please cancel the asset to continue."
 msgstr ""
 
@@ -9441,7 +9427,7 @@ msgstr ""
 msgid "Cannot cancel transaction for Completed Work Order."
 msgstr "نمی‌توان تراکنش را برای دستور کار تکمیل شده لغو کرد."
 
-#: erpnext/stock/doctype/item/item.py:882
+#: erpnext/stock/doctype/item/item.py:876
 msgid "Cannot change Attributes after stock transaction. Make a new Item and transfer stock to the new Item"
 msgstr "پس از تراکنش موجودی نمی‌توان ویژگی ها را تغییر داد. یک آیتم جدید بسازید و موجودی را به آیتم جدید منتقل کنید"
 
@@ -9457,7 +9443,7 @@ msgstr "نمی‌توان نوع سند مرجع را تغییر داد."
 msgid "Cannot change Service Stop Date for item in row {0}"
 msgstr "نمی‌توان تاریخ توقف سرویس را برای مورد در ردیف {0} تغییر داد"
 
-#: erpnext/stock/doctype/item/item.py:873
+#: erpnext/stock/doctype/item/item.py:867
 msgid "Cannot change Variant properties after stock transaction. You will have to make a new Item to do this."
 msgstr "پس از تراکنش موجودی نمی‌توان ویژگی های گونه را تغییر داد. برای این کار باید یک آیتم جدید بسازید."
 
@@ -9485,7 +9471,7 @@ msgstr "نمی‌توان به گروه تبدیل کرد زیرا نوع حسا
 msgid "Cannot covert to Group because Account Type is selected."
 msgstr "نمی‌توان در گروه پنهان کرد زیرا نوع حساب انتخاب شده است."
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:972
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:981
 msgid "Cannot create Stock Reservation Entries for future dated Purchase Receipts."
 msgstr "نمی‌توان ورودی های رزرو موجودی را برای رسیدهای خرید با تاریخ آینده ایجاد کرد."
 
@@ -9536,7 +9522,7 @@ msgstr "نمی‌توان از تحویل با شماره سریال اطمین�
 msgid "Cannot find Item with this Barcode"
 msgstr "نمی‌توان آیتمی را با این بارکد پیدا کرد"
 
-#: erpnext/controllers/accounts_controller.py:3483
+#: erpnext/controllers/accounts_controller.py:3486
 msgid "Cannot find a default warehouse for item {0}. Please set one in the Item Master or in Stock Settings."
 msgstr "نمی‌توان یک انبار پیش‌فرض برای آیتم {0} پیدا کرد. لطفاً یکی را در مدیریت آیتم یا در تنظیمات موجودی تنظیم کنید."
 
@@ -9544,7 +9530,7 @@ msgstr "نمی‌توان یک انبار پیش‌فرض برای آیتم {0} 
 msgid "Cannot make any transactions until the deletion job is completed"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2074
+#: erpnext/controllers/accounts_controller.py:2077
 msgid "Cannot overbill for Item {0} in row {1} more than {2}. To allow over-billing, please set allowance in Accounts Settings"
 msgstr ""
 
@@ -9565,7 +9551,7 @@ msgid "Cannot receive from customer against negative outstanding"
 msgstr "نمی‌توان از مشتری در برابر معوقات منفی دریافت کرد"
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1475
-#: erpnext/controllers/accounts_controller.py:2961
+#: erpnext/controllers/accounts_controller.py:2964
 #: erpnext/public/js/controllers/accounts.js:100
 msgid "Cannot refer row number greater than or equal to current row number for this Charge type"
 msgstr "نمی‌توان شماره ردیف را بزرگتر یا مساوی با شماره ردیف فعلی برای این نوع شارژ ارجاع داد"
@@ -9581,7 +9567,7 @@ msgstr "توکن پیوند بازیابی نمی‌شود. برای اطلاع�
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1467
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1646
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:1917
-#: erpnext/controllers/accounts_controller.py:2951
+#: erpnext/controllers/accounts_controller.py:2954
 #: erpnext/public/js/controllers/accounts.js:94
 #: erpnext/public/js/controllers/taxes_and_totals.js:470
 msgid "Cannot select charge type as 'On Previous Row Amount' or 'On Previous Row Total' for first row"
@@ -9595,15 +9581,15 @@ msgstr "نمی‌توان آن را به عنوان گمشده تنظیم کرد
 msgid "Cannot set authorization on basis of Discount for {0}"
 msgstr "نمی‌توان مجوز را بر اساس تخفیف برای {0} تنظیم کرد"
 
-#: erpnext/stock/doctype/item/item.py:716
+#: erpnext/stock/doctype/item/item.py:722
 msgid "Cannot set multiple Item Defaults for a company."
 msgstr "نمی‌توان چندین مورد پیش‌فرض را برای یک شرکت تنظیم کرد."
 
-#: erpnext/controllers/accounts_controller.py:3631
+#: erpnext/controllers/accounts_controller.py:3634
 msgid "Cannot set quantity less than delivered quantity"
 msgstr "نمی‌توان مقدار کمتر از مقدار تحویلی را تنظیم کرد"
 
-#: erpnext/controllers/accounts_controller.py:3634
+#: erpnext/controllers/accounts_controller.py:3637
 msgid "Cannot set quantity less than received quantity"
 msgstr "نمی‌توان مقدار کمتر از مقدار دریافتی را تنظیم کرد"
 
@@ -10026,7 +10012,7 @@ msgid "Channel Partner"
 msgstr "شریک کانال"
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:2346
-#: erpnext/controllers/accounts_controller.py:3014
+#: erpnext/controllers/accounts_controller.py:3017
 msgid "Charge of type 'Actual' in row {0} cannot be included in Item Rate or Paid Amount"
 msgstr "هزینه از نوع \"واقعی\" در ردیف {0} نمی‌تواند در نرخ مورد یا مبلغ پرداختی لحاظ شود"
 
@@ -10209,7 +10195,7 @@ msgstr "عرض چک"
 
 #. Label of the reference_date (Date) field in DocType 'Payment Entry'
 #: erpnext/accounts/doctype/payment_entry/payment_entry.json
-#: erpnext/public/js/controllers/transaction.js:2299
+#: erpnext/public/js/controllers/transaction.js:2325
 msgid "Cheque/Reference Date"
 msgstr "تاریخ چک / مرجع"
 
@@ -10257,7 +10243,7 @@ msgstr "نام سند فرزند"
 
 #. Label of the child_row_reference (Data) field in DocType 'Quality
 #. Inspection'
-#: erpnext/public/js/controllers/transaction.js:2394
+#: erpnext/public/js/controllers/transaction.js:2420
 #: erpnext/stock/doctype/quality_inspection/quality_inspection.json
 msgid "Child Row Reference"
 msgstr ""
@@ -10969,7 +10955,7 @@ msgstr "شرکت ها"
 #: erpnext/accounts/report/cheques_and_deposits_incorrectly_cleared/cheques_and_deposits_incorrectly_cleared.js:8
 #: erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.js:8
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:8
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:49
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:50
 #: erpnext/accounts/report/deferred_revenue_and_expense/deferred_revenue_and_expense.js:8
 #: erpnext/accounts/report/delivered_items_to_be_billed/delivered_items_to_be_billed.js:7
 #: erpnext/accounts/report/dimension_wise_accounts_balance_report/dimension_wise_accounts_balance_report.js:8
@@ -12202,7 +12188,7 @@ msgid "Content Type"
 msgstr "نوع محتوا"
 
 #: erpnext/erpnext_integrations/doctype/plaid_settings/plaid_settings.js:162
-#: erpnext/public/js/controllers/transaction.js:2312
+#: erpnext/public/js/controllers/transaction.js:2338
 #: erpnext/selling/doctype/quotation/quotation.js:356
 msgid "Continue"
 msgstr "ادامه هید"
@@ -12367,7 +12353,7 @@ msgstr "ضریب تبدیل"
 msgid "Conversion Rate"
 msgstr "نرخ تبدیل"
 
-#: erpnext/stock/doctype/item/item.py:393
+#: erpnext/stock/doctype/item/item.py:396
 msgid "Conversion factor for default Unit of Measure must be 1 in row {0}"
 msgstr "ضریب تبدیل برای واحد اندازه گیری پیش‌فرض باید 1 در ردیف {0} باشد"
 
@@ -12375,15 +12361,15 @@ msgstr "ضریب تبدیل برای واحد اندازه گیری پیش‌ف�
 msgid "Conversion factor for item {0} has been reset to 1.0 as the uom {1} is same as stock uom {2}."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2767
+#: erpnext/controllers/accounts_controller.py:2770
 msgid "Conversion rate cannot be 0"
 msgstr "نرخ تبدیل نمی تواند 0 باشد"
 
-#: erpnext/controllers/accounts_controller.py:2774
+#: erpnext/controllers/accounts_controller.py:2777
 msgid "Conversion rate is 1.00, but document currency is different from company currency"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2770
+#: erpnext/controllers/accounts_controller.py:2773
 msgid "Conversion rate must be 1.00 if document currency is same as company currency"
 msgstr "اگر واحد پول سند با واحد پول شرکت یکسان باشد، نرخ تبدیل باید 1.00 باشد"
 
@@ -12596,7 +12582,7 @@ msgstr "هزینه"
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:28
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:40
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:30
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1096
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1098
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:40
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.js:42
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.py:197
@@ -12689,7 +12675,7 @@ msgid "Cost Center is a part of Cost Center Allocation, hence cannot be converte
 msgstr "مرکز هزینه بخشی از تخصیص مرکز هزینه است، بنابراین نمی‌توان آن را به یک گروه تبدیل کرد"
 
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py:1411
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:855
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:864
 msgid "Cost Center is required in row {0} in Taxes table for type {1}"
 msgstr "مرکز هزینه در ردیف {0} جدول مالیات برای نوع {1} لازم است"
 
@@ -12958,8 +12944,8 @@ msgstr "بس"
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:132
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:143
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:219
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:654
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:678
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:656
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:680
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.js:88
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.js:89
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.js:103
@@ -13016,8 +13002,8 @@ msgstr "بس"
 #: erpnext/projects/doctype/task/task_tree.js:81
 #: erpnext/public/js/communication.js:19 erpnext/public/js/communication.js:31
 #: erpnext/public/js/communication.js:41
-#: erpnext/public/js/controllers/transaction.js:336
-#: erpnext/public/js/controllers/transaction.js:2435
+#: erpnext/public/js/controllers/transaction.js:362
+#: erpnext/public/js/controllers/transaction.js:2461
 #: erpnext/selling/doctype/customer/customer.js:181
 #: erpnext/selling/doctype/quotation/quotation.js:124
 #: erpnext/selling/doctype/quotation/quotation.js:133
@@ -13312,7 +13298,7 @@ msgstr "یک دارایی ترکیبی جدید ایجاد کنید"
 msgid "Create a variant with the template image."
 msgstr "ایجاد یک گونه با تصویر قالب."
 
-#: erpnext/stock/stock_ledger.py:1877
+#: erpnext/stock/stock_ledger.py:1886
 msgid "Create an incoming stock transaction for the Item."
 msgstr "یک تراکنش موجودی ورودی برای آیتم ایجاد کنید."
 
@@ -13372,7 +13358,7 @@ msgstr "ایجاد فاکتورهای خرید ..."
 msgid "Creating Purchase Order ..."
 msgstr "ایجاد سفارش خرید ..."
 
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:735
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:737
 #: erpnext/buying/doctype/purchase_order/purchase_order.js:552
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.js:73
 msgid "Creating Purchase Receipt ..."
@@ -13566,7 +13552,7 @@ msgstr "ماه های اعتباری"
 #: erpnext/accounts/doctype/journal_entry_template/journal_entry_template.json
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:174
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:147
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1119
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1121
 #: erpnext/controllers/sales_and_purchase_return.py:373
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:286
 #: erpnext/stock/doctype/delivery_note/delivery_note.js:89
@@ -13601,7 +13587,7 @@ msgstr "یادداشت بستانکاری {0} به طور خودکار ایجا�
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py:368
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py:376
-#: erpnext/controllers/accounts_controller.py:2186
+#: erpnext/controllers/accounts_controller.py:2189
 msgid "Credit To"
 msgstr "بستانکار به"
 
@@ -13786,7 +13772,7 @@ msgstr "پیمانه"
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/subscription_plan/subscription_plan.json
 #: erpnext/accounts/report/account_balance/account_balance.py:28
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1129
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1131
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:205
 #: erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.py:101
 #: erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.js:118
@@ -14315,7 +14301,7 @@ msgstr "کد مشتری"
 #. Label of the customer_contact_display (Small Text) field in DocType
 #. 'Purchase Order'
 #. Label of the customer_contact (Small Text) field in DocType 'Delivery Stop'
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1090
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1092
 #: erpnext/buying/doctype/purchase_order/purchase_order.json
 #: erpnext/stock/doctype/delivery_stop/delivery_stop.json
 msgid "Customer Contact"
@@ -14411,7 +14397,7 @@ msgstr "بازخورد مشتری"
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/tax_rule/tax_rule.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:107
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1147
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1149
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:81
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:185
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:56
@@ -14455,7 +14441,7 @@ msgstr "آیتم گروه مشتری"
 msgid "Customer Group Name"
 msgstr "نام گروه مشتری"
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1239
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1241
 msgid "Customer Group: {0} does not exist"
 msgstr "گروه مشتری: {0} وجود ندارد"
 
@@ -14474,7 +14460,7 @@ msgstr "آیتم مشتری"
 msgid "Customer Items"
 msgstr "آیتم‌های مشتری"
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1138
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1140
 msgid "Customer LPO"
 msgstr "LPO مشتری"
 
@@ -14520,7 +14506,7 @@ msgstr "شماره موبایل مشتری"
 #: erpnext/accounts/doctype/pos_invoice/pos_invoice.json
 #: erpnext/accounts/doctype/process_statement_of_accounts_customer/process_statement_of_accounts_customer.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1080
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1082
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:156
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:92
 #: erpnext/accounts/report/delivered_items_to_be_billed/delivered_items_to_be_billed.py:35
@@ -15198,7 +15184,7 @@ msgstr "مبلغ بدهکار به ارز تراکنش"
 #: erpnext/accounts/doctype/journal_entry_template/journal_entry_template.json
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:176
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:147
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1122
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1124
 #: erpnext/controllers/sales_and_purchase_return.py:377
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:287
 #: erpnext/stock/doctype/purchase_receipt/purchase_receipt.js:61
@@ -15227,7 +15213,7 @@ msgstr ""
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:953
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:964
-#: erpnext/controllers/accounts_controller.py:2186
+#: erpnext/controllers/accounts_controller.py:2189
 msgid "Debit To"
 msgstr "بدهی به"
 
@@ -15260,11 +15246,11 @@ msgstr ""
 msgid "Debit-Credit mismatch"
 msgstr ""
 
-#: erpnext/accounts/party.py:609
+#: erpnext/accounts/party.py:615
 msgid "Debtor/Creditor"
 msgstr "بدهکار/ بستانکار"
 
-#: erpnext/accounts/party.py:612
+#: erpnext/accounts/party.py:618
 msgid "Debtor/Creditor Advance"
 msgstr "پیش پرداخت بدهکار/ بستانکار"
 
@@ -15384,7 +15370,7 @@ msgstr "پیش‌فرض پیش‌فرض حساب دریافت شده"
 msgid "Default BOM"
 msgstr "BOM پیش‌فرض"
 
-#: erpnext/stock/doctype/item/item.py:418
+#: erpnext/stock/doctype/item/item.py:421
 msgid "Default BOM ({0}) must be active for this item or its template"
 msgstr "BOM پیش‌فرض ({0}) باید برای این مورد یا الگوی آن فعال باشد"
 
@@ -15392,7 +15378,7 @@ msgstr "BOM پیش‌فرض ({0}) باید برای این مورد یا الگ�
 msgid "Default BOM for {0} not found"
 msgstr "BOM پیش‌فرض برای {0} یافت نشد"
 
-#: erpnext/controllers/accounts_controller.py:3672
+#: erpnext/controllers/accounts_controller.py:3675
 msgid "Default BOM not found for FG Item {0}"
 msgstr "BOM پیش‌فرض برای آیتم کالای تمام شده {0} یافت نشد"
 
@@ -15727,15 +15713,15 @@ msgstr "منطقه پیش‌فرض"
 msgid "Default Unit of Measure"
 msgstr "واحد اندازه گیری پیش‌فرض"
 
-#: erpnext/stock/doctype/item/item.py:1272
+#: erpnext/stock/doctype/item/item.py:1266
 msgid "Default Unit of Measure for Item {0} cannot be changed directly because you have already made some transaction(s) with another UOM. You need to either cancel the linked documents or create a new Item."
 msgstr "واحد اندازه گیری پیش‌فرض برای مورد {0} را نمی‌توان مستقیماً تغییر داد زیرا قبلاً تراکنش(هایی) را با UOM دیگری انجام داده اید. شما باید اسناد پیوند داده شده را لغو کنید یا یک مورد جدید ایجاد کنید."
 
-#: erpnext/stock/doctype/item/item.py:1255
+#: erpnext/stock/doctype/item/item.py:1249
 msgid "Default Unit of Measure for Item {0} cannot be changed directly because you have already made some transaction(s) with another UOM. You will need to create a new Item to use a different Default UOM."
 msgstr "واحد اندازه گیری پیش‌فرض برای مورد {0} را نمی‌توان مستقیماً تغییر داد زیرا قبلاً تراکنش(هایی) را با UOM دیگری انجام داده اید. برای استفاده از یک UOM پیش‌فرض متفاوت، باید یک آیتم جدید ایجاد کنید."
 
-#: erpnext/stock/doctype/item/item.py:908
+#: erpnext/stock/doctype/item/item.py:902
 msgid "Default Unit of Measure for Variant '{0}' must be same as in Template '{1}'"
 msgstr "واحد اندازه گیری پیش‌فرض برای گونه «{0}» باید مانند الگوی «{1}» باشد"
 
@@ -16194,7 +16180,7 @@ msgstr "روند یادداشت تحویل"
 msgid "Delivery Note {0} is not submitted"
 msgstr "یادداشت تحویل {0} ارسال نشده است"
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1142
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1144
 #: erpnext/stock/doctype/delivery_trip/delivery_trip.js:73
 msgid "Delivery Notes"
 msgstr "یادداشت های تحویل"
@@ -16725,7 +16711,7 @@ msgstr ""
 #: erpnext/projects/doctype/task_type/task_type.json
 #: erpnext/projects/doctype/timesheet_detail/timesheet_detail.json
 #: erpnext/public/js/bank_reconciliation_tool/data_table_manager.js:55
-#: erpnext/public/js/controllers/transaction.js:2376
+#: erpnext/public/js/controllers/transaction.js:2402
 #: erpnext/selling/doctype/installation_note_item/installation_note_item.json
 #: erpnext/selling/doctype/product_bundle/product_bundle.json
 #: erpnext/selling/doctype/product_bundle_item/product_bundle_item.json
@@ -16913,7 +16899,7 @@ msgstr ""
 msgid "Difference Account must be a Asset/Liability type account (Temporary Opening), since this Stock Entry is an Opening Entry"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:954
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:950
 msgid "Difference Account must be a Asset/Liability type account, since this Stock Reconciliation is an Opening Entry"
 msgstr "حساب تفاوت باید یک حساب از نوع دارایی/بدهی باشد، زیرا این تطبیق موجودی یک ثبت افتتاحیه است"
 
@@ -17179,11 +17165,11 @@ msgstr "حساب غیرفعال انتخاب شد"
 msgid "Disabled Warehouse {0} cannot be used for this transaction."
 msgstr "از انبار غیرفعال شده {0} نمی‌توان برای این تراکنش استفاده کرد."
 
-#: erpnext/controllers/accounts_controller.py:745
+#: erpnext/controllers/accounts_controller.py:748
 msgid "Disabled pricing rules since this {} is an internal transfer"
 msgstr "قوانین قیمت گذاری غیرفعال شده است زیرا این {} یک انتقال داخلی است"
 
-#: erpnext/controllers/accounts_controller.py:759
+#: erpnext/controllers/accounts_controller.py:762
 msgid "Disabled tax included prices since this {} is an internal transfer"
 msgstr "مالیات غیرفعال شامل قیمت‌ها می‌شود زیرا این {} یک انتقال داخلی است"
 
@@ -18125,7 +18111,7 @@ msgstr "ارسال مستقیم"
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.json
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/print_format/sales_invoice_print/sales_invoice_print.html:72
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1106
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1108
 #: erpnext/assets/doctype/asset_maintenance_log/asset_maintenance_log.json
 #: erpnext/selling/report/payment_terms_status_for_sales_order/payment_terms_status_for_sales_order.py:40
 msgid "Due Date"
@@ -18139,11 +18125,11 @@ msgstr "سررسید"
 msgid "Due Date Based On"
 msgstr "تاریخ سررسید بر اساس"
 
-#: erpnext/accounts/party.py:695
+#: erpnext/accounts/party.py:701
 msgid "Due Date cannot be after {0}"
 msgstr "تاریخ سررسید نمی‌تواند بعد از {0} باشد"
 
-#: erpnext/accounts/party.py:671
+#: erpnext/accounts/party.py:677
 msgid "Due Date cannot be before {0}"
 msgstr "تاریخ سررسید نمی‌تواند قبل از {0} باشد"
 
@@ -18861,7 +18847,7 @@ msgstr "زمان‌بندی قرار را فعال کنید"
 msgid "Enable Auto Email"
 msgstr "ایمیل خودکار را فعال کنید"
 
-#: erpnext/stock/doctype/item/item.py:1064
+#: erpnext/stock/doctype/item/item.py:1058
 msgid "Enable Auto Re-Order"
 msgstr "سفارش مجدد خودکار را فعال کنید"
 
@@ -19074,7 +19060,7 @@ msgstr "تاریخ بازخرید"
 msgid "End Date"
 msgstr "تاریخ پایان"
 
-#: erpnext/crm/doctype/contract/contract.py:75
+#: erpnext/crm/doctype/contract/contract.py:83
 msgid "End Date cannot be before Start Date."
 msgstr "تاریخ پایان نمی‌تواند قبل از تاریخ شروع باشد."
 
@@ -19324,7 +19310,7 @@ msgstr "ارگ"
 #: erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.json
 #: erpnext/manufacturing/doctype/job_card/job_card.py:875
 #: erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.json
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:297
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:298
 msgid "Error"
 msgstr "خطا"
 
@@ -19447,7 +19433,7 @@ msgstr "از محل کارخانه"
 msgid "Example URL"
 msgstr "URL مثال"
 
-#: erpnext/stock/doctype/item/item.py:995
+#: erpnext/stock/doctype/item/item.py:989
 msgid "Example of a linked document: {0}"
 msgstr "نمونه ای از یک سند پیوندی: {0}"
 
@@ -19462,7 +19448,7 @@ msgstr ""
 msgid "Example: ABCD.#####. If series is set and Batch No is not mentioned in transactions, then automatic batch number will be created based on this series. If you always want to explicitly mention Batch No for this item, leave this blank. Note: this setting will take priority over the Naming Series Prefix in Stock Settings."
 msgstr "مثال: ABCD.#####. اگر سری تنظیم شده باشد و Batch No در تراکنش ها ذکر نشده باشد، شماره دسته خودکار بر اساس این سری ایجاد می‌شود. اگر همیشه می‌خواهید به صراحت شماره دسته را برای این مورد ذکر کنید، این قسمت را خالی بگذارید. توجه: این تنظیم بر پیشوند سری نامگذاری در تنظیمات موجودی اولویت دارد."
 
-#: erpnext/stock/stock_ledger.py:2141
+#: erpnext/stock/stock_ledger.py:2149
 msgid "Example: Serial No {0} reserved in {1}."
 msgstr "مثال: شماره سریال {0} در {1} رزرو شده است."
 
@@ -19516,8 +19502,8 @@ msgstr "سود یا ضرر تبدیل"
 msgid "Exchange Gain/Loss"
 msgstr "سود/زیان تبدیل"
 
-#: erpnext/controllers/accounts_controller.py:1593
-#: erpnext/controllers/accounts_controller.py:1677
+#: erpnext/controllers/accounts_controller.py:1596
+#: erpnext/controllers/accounts_controller.py:1680
 msgid "Exchange Gain/Loss amount has been booked through {0}"
 msgstr "مبلغ سود/زیان تبدیل از طریق {0} رزرو شده است"
 
@@ -20253,7 +20239,7 @@ msgid "Fetching Error"
 msgstr ""
 
 #: erpnext/accounts/doctype/dunning/dunning.js:135
-#: erpnext/public/js/controllers/transaction.js:1251
+#: erpnext/public/js/controllers/transaction.js:1277
 msgid "Fetching exchange rates ..."
 msgstr "واکشی نرخ ارز ..."
 
@@ -20548,15 +20534,15 @@ msgstr "تعداد آیتم کالای تمام شده"
 msgid "Finished Good Item Quantity"
 msgstr "تعداد آیتم کالای تمام شده"
 
-#: erpnext/controllers/accounts_controller.py:3658
+#: erpnext/controllers/accounts_controller.py:3661
 msgid "Finished Good Item is not specified for service item {0}"
 msgstr "آیتم کالای تمام شده برای آیتم سرویس مشخص نشده است {0}"
 
-#: erpnext/controllers/accounts_controller.py:3675
+#: erpnext/controllers/accounts_controller.py:3678
 msgid "Finished Good Item {0} Qty can not be zero"
 msgstr "مقدار آیتم کالای تمام شده {0} تعداد نمی‌تواند صفر باشد"
 
-#: erpnext/controllers/accounts_controller.py:3669
+#: erpnext/controllers/accounts_controller.py:3672
 msgid "Finished Good Item {0} must be a sub-contracted item"
 msgstr "آیتم کالای تمام شده {0} باید یک آیتم قرارداد فرعی باشد"
 
@@ -20797,7 +20783,7 @@ msgstr "حساب دارایی ثابت"
 msgid "Fixed Asset Defaults"
 msgstr "پیش‌فرض دارایی های ثابت"
 
-#: erpnext/stock/doctype/item/item.py:301
+#: erpnext/stock/doctype/item/item.py:304
 msgid "Fixed Asset Item must be a non-stock item."
 msgstr "آیتم دارایی ثابت باید یک آیتم غیر موجودی باشد."
 
@@ -20973,7 +20959,7 @@ msgstr "برای مقدار (تعداد تولید شده) اجباری است"
 msgid "For Raw Materials"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1259
+#: erpnext/controllers/accounts_controller.py:1262
 msgid "For Return Invoices with Stock effect, '0' qty Items are not allowed. Following rows are affected: {0}"
 msgstr ""
 
@@ -21074,7 +21060,7 @@ msgstr ""
 msgid "For the item {0}, the quantity should be {1} according to the BOM {2}."
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:1088
+#: erpnext/public/js/controllers/transaction.js:1114
 msgctxt "Clear payment terms template and/or payment schedule when due date is changed"
 msgid "For the new {0} to take effect, would you like to clear the current {1}?"
 msgstr ""
@@ -21083,7 +21069,7 @@ msgstr ""
 msgid "For the {0}, no stock is available for the return in the warehouse {1}."
 msgstr ""
 
-#: erpnext/controllers/sales_and_purchase_return.py:1144
+#: erpnext/controllers/sales_and_purchase_return.py:1049
 msgid "For the {0}, the quantity is required to make the return entry"
 msgstr ""
 
@@ -21420,7 +21406,7 @@ msgstr "از تاریخ نمی‌تواند بزرگتر از تا تاریخ ب
 msgid "From Date is mandatory"
 msgstr "از تاریخ اجباری است"
 
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:52
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:53
 #: erpnext/accounts/report/general_ledger/general_ledger.py:86
 #: erpnext/accounts/report/pos_register/pos_register.py:115
 #: erpnext/accounts/report/tax_withholding_details/tax_withholding_details.py:39
@@ -21797,14 +21783,14 @@ msgstr "گره های بیشتر را فقط می‌توان تحت گره ها�
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:186
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:155
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1134
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1136
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:177
 msgid "Future Payment Amount"
 msgstr "مبلغ پرداخت آینده"
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:185
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:154
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1133
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1135
 msgid "Future Payment Ref"
 msgstr "مرجع پرداخت آینده"
 
@@ -22978,7 +22964,7 @@ msgstr ""
 msgid "Here are the error logs for the aforementioned failed depreciation entries: {0}"
 msgstr "در اینجا گزارش های خطا برای ورودی های استهلاک ناموفق فوق الذکر آمده است: {0}"
 
-#: erpnext/stock/stock_ledger.py:1862
+#: erpnext/stock/stock_ledger.py:1871
 msgid "Here are the options to proceed:"
 msgstr "در اینجا گزینه‌هایی برای ادامه وجود دارد:"
 
@@ -23501,7 +23487,7 @@ msgstr "در صورت ذکر شده، این سیستم فقط به کاربرا
 msgid "If more than one package of the same type (for print)"
 msgstr "اگر بیش از یک بسته از همان نوع (برای چاپ)"
 
-#: erpnext/stock/stock_ledger.py:1872
+#: erpnext/stock/stock_ledger.py:1881
 msgid "If not, you can Cancel / Submit this entry"
 msgstr "اگر نه، می‌توانید این ثبت را لغو / ارسال کنید"
 
@@ -23526,7 +23512,7 @@ msgstr "اگر BOM منجر به مواد ضایعات شود، انبار ضا�
 msgid "If the account is frozen, entries are allowed to restricted users."
 msgstr "اگر حساب مسدود شود، ورود به کاربران محدود مجاز است."
 
-#: erpnext/stock/stock_ledger.py:1865
+#: erpnext/stock/stock_ledger.py:1874
 msgid "If the item is transacting as a Zero Valuation Rate item in this entry, please enable 'Allow Zero Valuation Rate' in the {0} Item table."
 msgstr "اگر آیتم به عنوان یک آیتم نرخ ارزش‌گذاری صفر در این ثبت تراکنش می‌شود، لطفاً \"نرخ ارزش‌گذاری صفر مجاز\" را در جدول آیتم {0} فعال کنید."
 
@@ -24524,7 +24510,7 @@ msgstr "تعداد موجودی نادرست پس از تراکنش"
 msgid "Incorrect Batch Consumed"
 msgstr "دسته نادرست مصرف شده است"
 
-#: erpnext/stock/doctype/item/item.py:514
+#: erpnext/stock/doctype/item/item.py:517
 msgid "Incorrect Check in (group) Warehouse for Reorder"
 msgstr ""
 
@@ -24573,7 +24559,7 @@ msgstr "باندل سریال و دسته نادرست"
 msgid "Incorrect Stock Value Report"
 msgstr "گزارش ارزش موجودی نادرست است"
 
-#: erpnext/stock/serial_batch_bundle.py:134
+#: erpnext/stock/serial_batch_bundle.py:135
 msgid "Incorrect Type of Transaction"
 msgstr "نوع تراکنش نادرست"
 
@@ -24842,8 +24828,8 @@ msgstr "دستورالعمل ها"
 msgid "Insufficient Capacity"
 msgstr "ظرفیت ناکافی"
 
-#: erpnext/controllers/accounts_controller.py:3590
-#: erpnext/controllers/accounts_controller.py:3614
+#: erpnext/controllers/accounts_controller.py:3593
+#: erpnext/controllers/accounts_controller.py:3617
 msgid "Insufficient Permissions"
 msgstr "مجوزهای ناکافی"
 
@@ -24851,12 +24837,12 @@ msgstr "مجوزهای ناکافی"
 #: erpnext/stock/doctype/pick_list/pick_list.py:127
 #: erpnext/stock/doctype/pick_list/pick_list.py:975
 #: erpnext/stock/doctype/stock_entry/stock_entry.py:759
-#: erpnext/stock/serial_batch_bundle.py:989 erpnext/stock/stock_ledger.py:1559
-#: erpnext/stock/stock_ledger.py:2032
+#: erpnext/stock/serial_batch_bundle.py:1021 erpnext/stock/stock_ledger.py:1568
+#: erpnext/stock/stock_ledger.py:2040
 msgid "Insufficient Stock"
 msgstr "موجودی ناکافی"
 
-#: erpnext/stock/stock_ledger.py:2047
+#: erpnext/stock/stock_ledger.py:2055
 msgid "Insufficient Stock for Batch"
 msgstr "موجودی ناکافی برای دسته"
 
@@ -24994,11 +24980,11 @@ msgstr "مشتری داخلی"
 msgid "Internal Customer for company {0} already exists"
 msgstr "مشتری داخلی برای شرکت {0} از قبل وجود دارد"
 
-#: erpnext/controllers/accounts_controller.py:728
+#: erpnext/controllers/accounts_controller.py:731
 msgid "Internal Sale or Delivery Reference missing."
 msgstr "مرجع فروش داخلی یا تحویل موجود نیست."
 
-#: erpnext/controllers/accounts_controller.py:730
+#: erpnext/controllers/accounts_controller.py:733
 msgid "Internal Sales Reference Missing"
 msgstr "مرجع فروش داخلی وجود ندارد"
 
@@ -25029,7 +25015,7 @@ msgstr "تامین کننده داخلی برای شرکت {0} از قبل وج�
 msgid "Internal Transfer"
 msgstr "انتقال داخلی"
 
-#: erpnext/controllers/accounts_controller.py:739
+#: erpnext/controllers/accounts_controller.py:742
 msgid "Internal Transfer Reference Missing"
 msgstr "مرجع انتقال داخلی وجود ندارد"
 
@@ -25072,8 +25058,8 @@ msgstr "بی اعتبار"
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:969
 #: erpnext/assets/doctype/asset_category/asset_category.py:69
 #: erpnext/assets/doctype/asset_category/asset_category.py:97
-#: erpnext/controllers/accounts_controller.py:2975
-#: erpnext/controllers/accounts_controller.py:2983
+#: erpnext/controllers/accounts_controller.py:2978
+#: erpnext/controllers/accounts_controller.py:2986
 msgid "Invalid Account"
 msgstr "حساب نامعتبر"
 
@@ -25098,7 +25084,7 @@ msgstr "تاریخ تکرار خودکار نامعتبر است"
 msgid "Invalid Barcode. There is no Item attached to this barcode."
 msgstr "بارکد نامعتبر هیچ موردی به این بارکد متصل نیست."
 
-#: erpnext/public/js/controllers/transaction.js:2631
+#: erpnext/public/js/controllers/transaction.js:2657
 msgid "Invalid Blanket Order for the selected Customer and Item"
 msgstr "سفارش کلی نامعتبر برای مشتری و آیتم انتخاب شده"
 
@@ -25112,7 +25098,7 @@ msgstr "شرکت نامعتبر برای معاملات بین شرکتی."
 
 #: erpnext/assets/doctype/asset/asset.py:295
 #: erpnext/assets/doctype/asset/asset.py:302
-#: erpnext/controllers/accounts_controller.py:2998
+#: erpnext/controllers/accounts_controller.py:3001
 msgid "Invalid Cost Center"
 msgstr "مرکز هزینه نامعتبر است"
 
@@ -25154,7 +25140,7 @@ msgstr "گروه نامعتبر توسط"
 msgid "Invalid Item"
 msgstr "آیتم نامعتبر"
 
-#: erpnext/stock/doctype/item/item.py:1410
+#: erpnext/stock/doctype/item/item.py:1404
 msgid "Invalid Item Defaults"
 msgstr "پیش‌فرض های آیتم نامعتبر"
 
@@ -25200,11 +25186,11 @@ msgstr "پیکربندی هدررفت فرآیند نامعتبر است"
 msgid "Invalid Purchase Invoice"
 msgstr "فاکتور خرید نامعتبر"
 
-#: erpnext/controllers/accounts_controller.py:3627
+#: erpnext/controllers/accounts_controller.py:3630
 msgid "Invalid Qty"
 msgstr "تعداد نامعتبر است"
 
-#: erpnext/controllers/accounts_controller.py:1277
+#: erpnext/controllers/accounts_controller.py:1280
 msgid "Invalid Quantity"
 msgstr "مقدار نامعتبر"
 
@@ -25221,7 +25207,7 @@ msgstr "فاکتورهای فروش نامعتبر"
 msgid "Invalid Schedule"
 msgstr "زمان‌بندی نامعتبر است"
 
-#: erpnext/controllers/selling_controller.py:243
+#: erpnext/controllers/selling_controller.py:251
 msgid "Invalid Selling Price"
 msgstr "قیمت فروش نامعتبر"
 
@@ -25254,7 +25240,7 @@ msgstr "عبارت شرط نامعتبر است"
 msgid "Invalid lost reason {0}, please create a new lost reason"
 msgstr "دلیل از دست رفتن نامعتبر {0}، لطفاً یک دلیل از دست رفتن جدید ایجاد کنید"
 
-#: erpnext/stock/doctype/item/item.py:408
+#: erpnext/stock/doctype/item/item.py:411
 msgid "Invalid naming series (. missing) for {0}"
 msgstr "سری نام‌گذاری نامعتبر (. از دست رفته) برای {0}"
 
@@ -25294,7 +25280,7 @@ msgstr "فهرست موجودی"
 #. Name of a DocType
 #: erpnext/patches/v15_0/refactor_closing_stock_balance.py:43
 #: erpnext/stock/doctype/inventory_dimension/inventory_dimension.json
-#: erpnext/stock/doctype/inventory_dimension/inventory_dimension.py:180
+#: erpnext/stock/doctype/inventory_dimension/inventory_dimension.py:181
 msgid "Inventory Dimension"
 msgstr "ابعاد موجودی"
 
@@ -25360,7 +25346,7 @@ msgstr "تاریخ فاکتور"
 msgid "Invoice Discounting"
 msgstr "تخفیف فاکتور"
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1114
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1116
 msgid "Invoice Grand Total"
 msgstr "جمع کل فاکتور"
 
@@ -25453,7 +25439,7 @@ msgstr "برای ساعت صورتحساب صفر نمی‌توان فاکتور
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:169
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:144
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1116
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1118
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:164
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:165
 msgid "Invoiced Amount"
@@ -25859,6 +25845,11 @@ msgstr "آیا ثبت افتتاحیه است"
 msgid "Is Outward"
 msgstr "خروجی است"
 
+#. Label of the is_packed (Check) field in DocType 'Serial and Batch Bundle'
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.json
+msgid "Is Packed"
+msgstr ""
+
 #. Label of the is_paid (Check) field in DocType 'Purchase Invoice'
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 msgid "Is Paid"
@@ -26141,11 +26132,11 @@ msgstr "تاریخ صادر شدن"
 msgid "Issuing cannot be done to a location. Please enter employee to issue the Asset {0} to"
 msgstr "صدور را نمی‌توان به یک مکان انجام داد. لطفاً کارمند را وارد کنید تا دارایی {0} را صادر کند"
 
-#: erpnext/stock/doctype/item/item.py:565
+#: erpnext/stock/doctype/item/item.py:571
 msgid "It can take upto few hours for accurate stock values to be visible after merging items."
 msgstr "ممکن است چند ساعت طول بکشد تا ارزش موجودی دقیق پس از ادغام اقلام قابل مشاهده باشد."
 
-#: erpnext/public/js/controllers/transaction.js:2075
+#: erpnext/public/js/controllers/transaction.js:2101
 msgid "It is needed to fetch Item Details."
 msgstr "برای واکشی جزئیات آیتم نیاز است."
 
@@ -26195,7 +26186,7 @@ msgstr ""
 #: erpnext/buying/report/supplier_quotation_comparison/supplier_quotation_comparison.js:33
 #: erpnext/buying/report/supplier_quotation_comparison/supplier_quotation_comparison.py:204
 #: erpnext/buying/workspace/buying/buying.json
-#: erpnext/controllers/taxes_and_totals.py:1125
+#: erpnext/controllers/taxes_and_totals.py:1135
 #: erpnext/manufacturing/doctype/blanket_order/blanket_order.json
 #: erpnext/manufacturing/doctype/bom/bom.js:944
 #: erpnext/manufacturing/doctype/bom/bom.json
@@ -26473,7 +26464,7 @@ msgstr ""
 #: erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py:86
 #: erpnext/manufacturing/report/work_order_stock_report/work_order_stock_report.py:119
 #: erpnext/projects/doctype/timesheet/timesheet.js:213
-#: erpnext/public/js/controllers/transaction.js:2350
+#: erpnext/public/js/controllers/transaction.js:2376
 #: erpnext/public/js/stock_reservation.js:112
 #: erpnext/public/js/stock_reservation.js:317 erpnext/public/js/utils.js:500
 #: erpnext/public/js/utils.js:656
@@ -26911,7 +26902,7 @@ msgstr "تولید کننده آیتم"
 #: erpnext/manufacturing/report/production_planning_report/production_planning_report.py:359
 #: erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py:92
 #: erpnext/manufacturing/report/work_order_consumed_materials/work_order_consumed_materials.py:138
-#: erpnext/public/js/controllers/transaction.js:2356
+#: erpnext/public/js/controllers/transaction.js:2382
 #: erpnext/public/js/utils.js:746
 #: erpnext/selling/doctype/quotation_item/quotation_item.json
 #: erpnext/selling/doctype/sales_order_item/sales_order_item.json
@@ -27178,7 +27169,7 @@ msgstr "تنظیمات گونه آیتم"
 msgid "Item Variant {0} already exists with same attributes"
 msgstr "گونه آیتم {0} در حال حاضر با همان ویژگی ها وجود دارد"
 
-#: erpnext/stock/doctype/item/item.py:781
+#: erpnext/stock/doctype/item/item.py:772
 msgid "Item Variants updated"
 msgstr "گونه‌های آیتم به روز شد"
 
@@ -27244,7 +27235,7 @@ msgstr "جزئیات مورد و گارانتی"
 msgid "Item for row {0} does not match Material Request"
 msgstr "مورد ردیف {0} با درخواست مواد مطابقت ندارد"
 
-#: erpnext/stock/doctype/item/item.py:795
+#: erpnext/stock/doctype/item/item.py:789
 msgid "Item has variants."
 msgstr "آیتم دارای گونه است."
 
@@ -27270,7 +27261,7 @@ msgstr "نام آیتم"
 msgid "Item operation"
 msgstr "عملیات آیتم"
 
-#: erpnext/controllers/accounts_controller.py:3650
+#: erpnext/controllers/accounts_controller.py:3653
 msgid "Item qty can not be updated as raw materials are already processed."
 msgstr "تعداد مورد را نمی‌توان به روز کرد زیرا مواد خام قبلاً پردازش شده است."
 
@@ -27296,7 +27287,7 @@ msgstr ""
 msgid "Item valuation reposting in progress. Report might show incorrect item valuation."
 msgstr "ارسال مجدد ارزیابی آیتم در حال انجام است. گزارش ممکن است ارزش گذاری اقلام نادرست را نشان دهد."
 
-#: erpnext/stock/doctype/item/item.py:952
+#: erpnext/stock/doctype/item/item.py:946
 msgid "Item variant {0} exists with same attributes"
 msgstr "گونه آیتم {0} با همان ویژگی ها وجود دارد"
 
@@ -27309,8 +27300,7 @@ msgid "Item {0} cannot be ordered more than {1} against Blanket Order {2}."
 msgstr "آیتم {0} را نمی‌توان بیش از {1} در مقابل سفارش کلی {2} سفارش داد."
 
 #: erpnext/assets/doctype/asset/asset.py:277
-#: erpnext/stock/doctype/item/item.py:630
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:167
+#: erpnext/stock/doctype/item/item.py:636
 msgid "Item {0} does not exist"
 msgstr "آیتم {0} وجود ندارد"
 
@@ -27322,7 +27312,7 @@ msgstr "مورد {0} در سیستم وجود ندارد یا منقضی شده 
 msgid "Item {0} does not exist."
 msgstr "آیتم {0} وجود ندارد."
 
-#: erpnext/controllers/selling_controller.py:752
+#: erpnext/controllers/selling_controller.py:760
 msgid "Item {0} entered multiple times."
 msgstr "آیتم {0} چندین بار وارد شده است."
 
@@ -27338,7 +27328,7 @@ msgstr "مورد {0} غیرفعال شده است"
 msgid "Item {0} has no Serial No. Only serialized items can have delivery based on Serial No"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1126
+#: erpnext/stock/doctype/item/item.py:1120
 msgid "Item {0} has reached its end of life on {1}"
 msgstr "مورد {0} در تاریخ {1} به پایان عمر خود رسیده است"
 
@@ -27350,11 +27340,11 @@ msgstr "مورد {0} نادیده گرفته شد زیرا کالای موجود
 msgid "Item {0} is already reserved/delivered against Sales Order {1}."
 msgstr "مورد {0} قبلاً در برابر سفارش فروش {1} رزرو شده/تحویل شده است."
 
-#: erpnext/stock/doctype/item/item.py:1146
+#: erpnext/stock/doctype/item/item.py:1140
 msgid "Item {0} is cancelled"
 msgstr "آیتم {0} لغو شده است"
 
-#: erpnext/stock/doctype/item/item.py:1130
+#: erpnext/stock/doctype/item/item.py:1124
 msgid "Item {0} is disabled"
 msgstr "آیتم {0} غیرفعال است"
 
@@ -27362,7 +27352,7 @@ msgstr "آیتم {0} غیرفعال است"
 msgid "Item {0} is not a serialized Item"
 msgstr "آیتم {0} یک آیتم سریالی نیست"
 
-#: erpnext/stock/doctype/item/item.py:1138
+#: erpnext/stock/doctype/item/item.py:1132
 msgid "Item {0} is not a stock Item"
 msgstr "آیتم {0} یک آیتم موجودی نیست"
 
@@ -27406,7 +27396,7 @@ msgstr "مورد {0}: تعداد سفارش‌شده {1} نمی‌تواند ک�
 msgid "Item {0}: {1} qty produced. "
 msgstr "آیتم {0}: مقدار {1} تولید شده است. "
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1429
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1423
 msgid "Item {} does not exist."
 msgstr "آیتم {} وجود ندارد."
 
@@ -27546,7 +27536,7 @@ msgstr ""
 msgid "Items and Pricing"
 msgstr "آیتم‌ها و قیمت"
 
-#: erpnext/controllers/accounts_controller.py:3872
+#: erpnext/controllers/accounts_controller.py:3875
 msgid "Items cannot be updated as Subcontracting Order is created against the Purchase Order {0}."
 msgstr "آیتم‌ها را نمی‌توان به روز کرد زیرا سفارش پیمانکاری فرعی در برابر سفارش خرید {0} ایجاد شده است."
 
@@ -28042,7 +28032,7 @@ msgstr "مالیات و عوارض هزینه تمام شده تا درب انب
 
 #. Name of a DocType
 #. Label of a Link in the Stock Workspace
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:674
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:676
 #: erpnext/stock/doctype/landed_cost_voucher/landed_cost_voucher.json
 #: erpnext/stock/doctype/purchase_receipt/purchase_receipt.js:104
 #: erpnext/stock/workspace/stock/stock.json
@@ -28657,7 +28647,7 @@ msgstr "فاکتورهای مرتبط"
 msgid "Linked Location"
 msgstr "مکان پیوند داده شده"
 
-#: erpnext/stock/doctype/item/item.py:999
+#: erpnext/stock/doctype/item/item.py:993
 msgid "Linked with submitted documents"
 msgstr "مرتبط با اسناد ارسالی"
 
@@ -29396,7 +29386,7 @@ msgstr "مدیر عامل"
 #: erpnext/manufacturing/doctype/bom/bom.py:261
 #: erpnext/manufacturing/doctype/bom_update_log/bom_update_log.py:71
 #: erpnext/public/js/controllers/accounts.js:249
-#: erpnext/public/js/controllers/transaction.js:2753
+#: erpnext/public/js/controllers/transaction.js:2779
 #: erpnext/public/js/utils/party.js:321
 #: erpnext/stock/doctype/delivery_note/delivery_note.js:164
 #: erpnext/stock/doctype/inventory_dimension/inventory_dimension.json
@@ -30252,7 +30242,7 @@ msgstr "حداکثر استفاده"
 msgid "Maximum Value"
 msgstr "حداکثر مقدار"
 
-#: erpnext/controllers/selling_controller.py:212
+#: erpnext/controllers/selling_controller.py:220
 msgid "Maximum discount for Item {0} is {1}%"
 msgstr "حداکثر تخفیف برای آیتم {0} {1}% است"
 
@@ -30322,7 +30312,7 @@ msgstr "مگاژول"
 msgid "Megawatt"
 msgstr "مگاوات"
 
-#: erpnext/stock/stock_ledger.py:1878
+#: erpnext/stock/stock_ledger.py:1887
 msgid "Mention Valuation Rate in the Item master."
 msgstr "نرخ ارزش‌گذاری را در آیتم اصلی ذکر کنید."
 
@@ -30717,11 +30707,11 @@ msgstr "دقایق"
 msgid "Miscellaneous Expenses"
 msgstr "هزینه های متفرقه"
 
-#: erpnext/controllers/buying_controller.py:540
+#: erpnext/controllers/buying_controller.py:548
 msgid "Mismatch"
 msgstr "عدم تطابق"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1430
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1424
 msgid "Missing"
 msgstr "جا افتاده"
 
@@ -31248,7 +31238,7 @@ msgstr "چندین گونه"
 msgid "Multiple Warehouse Accounts"
 msgstr "چندین حساب انبار"
 
-#: erpnext/controllers/accounts_controller.py:1129
+#: erpnext/controllers/accounts_controller.py:1132
 msgid "Multiple fiscal years exist for the date {0}. Please set company in Fiscal Year"
 msgstr "چندین سال مالی برای تاریخ {0} وجود دارد. لطفا شرکت را در سال مالی تعیین کنید"
 
@@ -31399,7 +31389,7 @@ msgstr "پیشوند سری نامگذاری"
 msgid "Naming Series and Price Defaults"
 msgstr "نام گذاری سری ها و پیش‌فرض های قیمت"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:90
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:91
 msgid "Naming Series is mandatory"
 msgstr "سری نامگذاری اجباری است"
 
@@ -31438,15 +31428,15 @@ msgstr "گاز طبیعی"
 msgid "Needs Analysis"
 msgstr "نیاز به تحلیل دارد"
 
-#: erpnext/stock/serial_batch_bundle.py:1277
+#: erpnext/stock/serial_batch_bundle.py:1309
 msgid "Negative Batch Quantity"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:610
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:606
 msgid "Negative Quantity is not allowed"
 msgstr "مقدار منفی مجاز نیست"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:615
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:611
 msgid "Negative Valuation Rate is not allowed"
 msgstr "نرخ ارزش‌گذاری منفی مجاز نیست"
 
@@ -31728,7 +31718,7 @@ msgstr "وزن خالص"
 msgid "Net Weight UOM"
 msgstr "وزن خالص UOM"
 
-#: erpnext/controllers/accounts_controller.py:1483
+#: erpnext/controllers/accounts_controller.py:1486
 msgid "Net total calculation precision loss"
 msgstr "خالص از دست دادن دقت محاسبه کل"
 
@@ -32071,7 +32061,7 @@ msgstr "هیچ نمایه POS یافت نشد. لطفا ابتدا یک نمای
 #: erpnext/accounts/doctype/journal_entry/journal_entry.py:1539
 #: erpnext/accounts/doctype/journal_entry/journal_entry.py:1599
 #: erpnext/accounts/doctype/journal_entry/journal_entry.py:1613
-#: erpnext/stock/doctype/item/item.py:1371
+#: erpnext/stock/doctype/item/item.py:1365
 msgid "No Permission"
 msgstr "بدون مجوز و اجازه"
 
@@ -32093,7 +32083,7 @@ msgstr "بدون ملاحظات"
 msgid "No Selection"
 msgstr "بدون انتخاب"
 
-#: erpnext/controllers/sales_and_purchase_return.py:919
+#: erpnext/controllers/sales_and_purchase_return.py:824
 msgid "No Serial / Batches are available for return"
 msgstr ""
 
@@ -32129,7 +32119,7 @@ msgstr "هیچ پرداخت ناسازگاری برای این طرف یافت �
 msgid "No Work Orders were created"
 msgstr "هیچ دستور کار ایجاد نشد"
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:785
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:794
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py:689
 msgid "No accounting entries for the following warehouses"
 msgstr "ثبت حسابداری برای انبارهای زیر وجود ندارد"
@@ -32318,7 +32308,7 @@ msgstr "هیچ رکوردی در جدول پرداخت ها یافت نشد"
 msgid "No reserved stock to unreserve."
 msgstr "موجودی رزرو شده ای برای لغو رزرو وجود ندارد."
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:773
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:769
 msgid "No stock ledger entries were created. Please set the quantity or valuation rate for the items properly and try again."
 msgstr ""
 
@@ -32402,7 +32392,7 @@ msgstr "عدد"
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:566
 #: erpnext/assets/doctype/asset/asset.js:612
 #: erpnext/assets/doctype/asset/asset.js:627
-#: erpnext/controllers/buying_controller.py:225
+#: erpnext/controllers/buying_controller.py:233
 #: erpnext/selling/doctype/product_bundle/product_bundle.py:72
 #: erpnext/setup/doctype/transaction_deletion_record/transaction_deletion_record.py:80
 msgid "Not Allowed"
@@ -32523,10 +32513,10 @@ msgstr "غیر مجاز"
 #: erpnext/selling/doctype/customer/customer.py:129
 #: erpnext/selling/doctype/sales_order/sales_order.js:1168
 #: erpnext/stock/doctype/item/item.js:526
-#: erpnext/stock/doctype/item/item.py:567
+#: erpnext/stock/doctype/item/item.py:573
 #: erpnext/stock/doctype/item_price/item_price.json
 #: erpnext/stock/doctype/stock_entry/stock_entry.py:1374
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:972
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:968
 #: erpnext/templates/pages/timelog_info.html:43
 msgid "Note"
 msgstr "یادداشت"
@@ -32535,7 +32525,7 @@ msgstr "یادداشت"
 msgid "Note: Automatic log deletion only applies to logs of type <i>Update Cost</i>"
 msgstr "توجه: حذف خودکار لاگ فقط برای لاگ‌هایی از نوع <i>به‌روزرسانی هزینه</i> اعمال می‌شود"
 
-#: erpnext/accounts/party.py:690
+#: erpnext/accounts/party.py:696
 msgid "Note: Due Date exceeds allowed {0} credit days by {1} day(s)"
 msgstr ""
 
@@ -32561,7 +32551,7 @@ msgstr "توجه: ثبت پرداخت ایجاد نخواهد شد زیرا «ح
 msgid "Note: This Cost Center is a Group. Cannot make accounting entries against groups."
 msgstr "توجه: این مرکز هزینه یک گروه است. نمی‌توان در مقابل گروه‌ها ثبت حسابداری انجام داد."
 
-#: erpnext/stock/doctype/item/item.py:621
+#: erpnext/stock/doctype/item/item.py:627
 msgid "Note: To merge the items, create a separate Stock Reconciliation for the old item {0}"
 msgstr "توجه: برای ادغام آیتم‌ها، یک تطبیق موجودی جداگانه برای آیتم قدیمی {0} ایجاد کنید"
 
@@ -33031,7 +33021,8 @@ msgstr "فقط مواردی را از این گروه‌های مورد نشان
 #: erpnext/accounts/doctype/exchange_rate_revaluation/exchange_rate_revaluation.json
 msgid "Only values between [0,1) are allowed. Like {0.00, 0.04, 0.09, ...}\n"
 "Ex: If allowance is set at 0.07, accounts that have balance of 0.07 in either of the currencies will be considered as zero balance account"
-msgstr ""
+msgstr "فقط مقادیر بین [0,1) مجاز هستند. مانند {0.00، 0.04، 0.09، ...}\n"
+"مثال: اگر سقف مجاز 0.07 تعیین شود، حساب‌هایی که موجودی 0.07 در هر یک از ارزها داشته باشند، به عنوان حساب با موجودی صفر در نظر گرفته می‌شوند"
 
 #: erpnext/accounts/doctype/unreconcile_payment/unreconcile_payment.py:43
 msgid "Only {0} are supported"
@@ -33324,7 +33315,7 @@ msgstr "فاکتورهای فروش افتتاحیه ایجاد شده است."
 
 #. Label of the opening_stock (Float) field in DocType 'Item'
 #. Option for the 'Purpose' (Select) field in DocType 'Stock Reconciliation'
-#: erpnext/stock/doctype/item/item.json erpnext/stock/doctype/item/item.py:296
+#: erpnext/stock/doctype/item/item.json erpnext/stock/doctype/item/item.py:299
 #: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.json
 msgid "Opening Stock"
 msgstr "موجودی اولیه"
@@ -34044,7 +34035,7 @@ msgstr ""
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:149
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1123
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1125
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:167
 #: erpnext/accounts/report/purchase_register/purchase_register.py:289
 #: erpnext/accounts/report/sales_register/sales_register.py:319
@@ -34083,7 +34074,7 @@ msgstr "خروجی"
 msgid "Over Billing Allowance (%)"
 msgstr "اضافه صورتحساب مجاز (%)"
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:1242
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:1251
 msgid "Over Billing Allowance exceeded for Purchase Receipt Item {0} ({1}) by {2}%"
 msgstr ""
 
@@ -34124,7 +34115,7 @@ msgstr "مجاز به انتقال بیش از حد (%)"
 msgid "Overbilling of {0} {1} ignored for item {2} because you have {3} role."
 msgstr "اضافه صورتحساب {0} {1} برای مورد {2} نادیده گرفته شد زیرا شما نقش {3} را دارید."
 
-#: erpnext/controllers/accounts_controller.py:2013
+#: erpnext/controllers/accounts_controller.py:2016
 msgid "Overbilling of {} ignored because you have {} role."
 msgstr "پرداخت بیش از حد {} نادیده گرفته شد زیرا شما نقش {} را دارید."
 
@@ -34631,7 +34622,7 @@ msgstr "پرداخت شده"
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:146
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1117
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1119
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:165
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:172
 #: erpnext/accounts/report/pos_register/pos_register.py:209
@@ -34864,7 +34855,7 @@ msgstr "رویه والد"
 msgid "Parent Row No"
 msgstr "شماره ردیف والد"
 
-#: erpnext/manufacturing/doctype/bom_creator/bom_creator.py:495
+#: erpnext/manufacturing/doctype/bom_creator/bom_creator.py:496
 msgid "Parent Row No not found for {0}"
 msgstr "شماره ردیف والد برای {0} یافت نشد"
 
@@ -35093,7 +35084,7 @@ msgstr "قطعات در میلیون"
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:142
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:159
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:57
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1054
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1056
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:67
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:147
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:228
@@ -35119,7 +35110,7 @@ msgstr "طرف"
 
 #. Name of a DocType
 #: erpnext/accounts/doctype/party_account/party_account.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1065
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1067
 msgid "Party Account"
 msgstr "حساب طرف"
 
@@ -35146,7 +35137,7 @@ msgstr "ارز حساب طرف"
 msgid "Party Account No. (Bank Statement)"
 msgstr "شماره حساب طرف (صورتحساب بانکی)"
 
-#: erpnext/controllers/accounts_controller.py:2278
+#: erpnext/controllers/accounts_controller.py:2281
 msgid "Party Account {0} currency ({1}) and document currency ({2}) should be same"
 msgstr "واحد پول حساب طرف {0} ({1}) و واحد پول سند ({2}) باید یکسان باشند"
 
@@ -35163,6 +35154,11 @@ msgstr "حساب بانکی طرف"
 #: erpnext/accounts/doctype/payment_request/payment_request.json
 msgid "Party Details"
 msgstr "جزئیات طرف"
+
+#. Label of the party_full_name (Data) field in DocType 'Contract'
+#: erpnext/crm/doctype/contract/contract.json
+msgid "Party Full Name"
+msgstr ""
 
 #. Label of the bank_party_iban (Data) field in DocType 'Bank Transaction'
 #: erpnext/accounts/doctype/bank_transaction/bank_transaction.json
@@ -35247,7 +35243,7 @@ msgstr "آیتم خاص طرف"
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:84
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:54
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:44
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1048
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1050
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:54
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:141
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:219
@@ -35269,7 +35265,7 @@ msgstr "آیتم خاص طرف"
 msgid "Party Type"
 msgstr "نوع طرف"
 
-#: erpnext/accounts/party.py:819
+#: erpnext/accounts/party.py:825
 msgid "Party Type and Party can only be set for Receivable / Payable account<br><br>{0}"
 msgstr ""
 
@@ -35391,7 +35387,7 @@ msgid "Payable"
 msgstr "پرداختنی"
 
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:42
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1063
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1065
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:211
 #: erpnext/accounts/report/purchase_register/purchase_register.py:194
 #: erpnext/accounts/report/purchase_register/purchase_register.py:235
@@ -35557,7 +35553,7 @@ msgstr "ثبت پرداخت پس از اینکه شما آن را کشیدید �
 msgid "Payment Entry is already created"
 msgstr "ثبت پرداخت قبلا ایجاد شده است"
 
-#: erpnext/controllers/accounts_controller.py:1434
+#: erpnext/controllers/accounts_controller.py:1437
 msgid "Payment Entry {0} is linked against Order {1}, check if it should be pulled as advance in this invoice."
 msgstr "ثبت پرداخت {0} با سفارش {1} مرتبط است، بررسی کنید که آیا باید به عنوان پیش پرداخت در این فاکتور آورده شود."
 
@@ -35839,7 +35835,7 @@ msgstr "وضعیت پرداخت"
 #: erpnext/accounts/doctype/payment_schedule/payment_schedule.json
 #: erpnext/accounts/doctype/payment_term/payment_term.json
 #: erpnext/accounts/doctype/payment_terms_template_detail/payment_terms_template_detail.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1113
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1115
 #: erpnext/accounts/report/gross_profit/gross_profit.py:412
 #: erpnext/accounts/workspace/accounting/accounting.json
 #: erpnext/selling/report/payment_terms_status_for_sales_order/payment_terms_status_for_sales_order.py:30
@@ -36903,7 +36899,7 @@ msgstr "لطفاً در برابر فاکتورهایی که «به‌روزرس
 msgid "Please create a new Accounting Dimension if required."
 msgstr "لطفاً در صورت نیاز یک بعد حسابداری جدید ایجاد کنید."
 
-#: erpnext/controllers/accounts_controller.py:729
+#: erpnext/controllers/accounts_controller.py:732
 msgid "Please create purchase from internal sale or delivery document itself"
 msgstr "لطفا خرید را از فروش داخلی یا سند تحویل خود ایجاد کنید"
 
@@ -36911,7 +36907,7 @@ msgstr "لطفا خرید را از فروش داخلی یا سند تحویل �
 msgid "Please create purchase receipt or purchase invoice for the item {0}"
 msgstr "لطفاً رسید خرید یا فاکتور خرید برای آیتم {0} ایجاد کنید"
 
-#: erpnext/stock/doctype/item/item.py:649
+#: erpnext/stock/doctype/item/item.py:655
 msgid "Please delete Product Bundle {0}, before merging {1} into {2}"
 msgstr "لطفاً قبل از ادغام {1} در {2}، باندل محصول {0} را حذف کنید"
 
@@ -36953,7 +36949,7 @@ msgstr "لطفا پنجره های بازشو را فعال کنید"
 msgid "Please enable {0} in the {1}."
 msgstr "لطفاً {0} را در {1} فعال کنید."
 
-#: erpnext/controllers/selling_controller.py:754
+#: erpnext/controllers/selling_controller.py:762
 msgid "Please enable {} in {} to allow same item in multiple rows"
 msgstr "لطفاً {} را در {} فعال کنید تا یک مورد در چندین ردیف مجاز باشد"
 
@@ -36986,7 +36982,7 @@ msgstr "لطفاً حساب را برای تغییر مبلغ وارد کنید"
 msgid "Please enter Approving Role or Approving User"
 msgstr "لطفاً نقش تأیید یا تأیید کاربر را وارد کنید"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:939
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:935
 msgid "Please enter Cost Center"
 msgstr "لطفا مرکز هزینه را وارد کنید"
 
@@ -36998,7 +36994,7 @@ msgstr "لطفا تاریخ تحویل را وارد کنید"
 msgid "Please enter Employee Id of this sales person"
 msgstr "لطفا شناسه کارمند این فروشنده را وارد کنید"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:948
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:944
 msgid "Please enter Expense Account"
 msgstr "لطفا حساب هزینه را وارد کنید"
 
@@ -37007,7 +37003,7 @@ msgstr "لطفا حساب هزینه را وارد کنید"
 msgid "Please enter Item Code to get Batch Number"
 msgstr "لطفا کد مورد را برای دریافت شماره دسته وارد کنید"
 
-#: erpnext/public/js/controllers/transaction.js:2503
+#: erpnext/public/js/controllers/transaction.js:2529
 msgid "Please enter Item Code to get batch no"
 msgstr "لطفا کد مورد را برای دریافت شماره دسته وارد کنید"
 
@@ -37072,7 +37068,7 @@ msgstr "لطفا ابتدا شرکت را وارد کنید"
 msgid "Please enter company name first"
 msgstr "لطفا ابتدا نام شرکت را وارد کنید"
 
-#: erpnext/controllers/accounts_controller.py:2764
+#: erpnext/controllers/accounts_controller.py:2767
 msgid "Please enter default currency in Company Master"
 msgstr "لطفا ارز پیش‌فرض را در Company Master وارد کنید"
 
@@ -37108,7 +37104,7 @@ msgstr "لطفاً برای تأیید نام شرکت را وارد کنید"
 msgid "Please enter the phone number first"
 msgstr "لطفا ابتدا شماره تلفن را وارد کنید"
 
-#: erpnext/controllers/buying_controller.py:1007
+#: erpnext/controllers/buying_controller.py:1015
 msgid "Please enter the {schedule_date}."
 msgstr "لطفاً {schedule_date} را وارد کنید."
 
@@ -37170,7 +37166,7 @@ msgstr "لطفاً مطمئن شوید که واقعاً می‌خواهید ه�
 
 #: erpnext/stock/doctype/item/item.js:525
 msgid "Please mention 'Weight UOM' along with Weight."
-msgstr "لطفا \"وزن UOM\" را همراه با وزن ذکر کنید."
+msgstr "لطفا \"UOM وزن\" را همراه با وزن ذکر کنید."
 
 #: erpnext/accounts/general_ledger.py:622
 #: erpnext/accounts/general_ledger.py:629
@@ -37210,7 +37206,7 @@ msgstr "لطفا اول ذخیره کنید"
 msgid "Please select <b>Template Type</b> to download template"
 msgstr "لطفاً <b>نوع الگو</b> را برای دانلود الگو انتخاب کنید"
 
-#: erpnext/controllers/taxes_and_totals.py:721
+#: erpnext/controllers/taxes_and_totals.py:731
 #: erpnext/public/js/controllers/taxes_and_totals.js:721
 msgid "Please select Apply Discount On"
 msgstr "لطفاً Apply Discount On را انتخاب کنید"
@@ -37223,7 +37219,7 @@ msgstr "لطفاً BOM را در مقابل مورد {0} انتخاب کنید"
 msgid "Please select BOM for Item in Row {0}"
 msgstr "لطفاً BOM را برای مورد در ردیف {0} انتخاب کنید"
 
-#: erpnext/controllers/buying_controller.py:467
+#: erpnext/controllers/buying_controller.py:475
 msgid "Please select BOM in BOM field for Item {item_code}."
 msgstr "لطفاً BOM را در قسمت BOM برای مورد {item_code} انتخاب کردن کنید."
 
@@ -37305,7 +37301,7 @@ msgstr "لطفا لیست قیمت را انتخاب کنید"
 msgid "Please select Qty against item {0}"
 msgstr "لطفاً تعداد را در برابر مورد {0} انتخاب کنید"
 
-#: erpnext/stock/doctype/item/item.py:320
+#: erpnext/stock/doctype/item/item.py:323
 msgid "Please select Sample Retention Warehouse in Stock Settings first"
 msgstr "لطفاً ابتدا انبار نگهداری نمونه را در تنظیمات انبار انتخاب کنید"
 
@@ -37321,7 +37317,7 @@ msgstr "لطفاً تاریخ شروع و تاریخ پایان را برای م
 msgid "Please select Subcontracting Order instead of Purchase Order {0}"
 msgstr "لطفاً به جای سفارش خرید، سفارش پیمانکاری فرعی را انتخاب کنید {0}"
 
-#: erpnext/controllers/accounts_controller.py:2613
+#: erpnext/controllers/accounts_controller.py:2616
 msgid "Please select Unrealized Profit / Loss account or add default Unrealized Profit / Loss account account for company {0}"
 msgstr "لطفاً حساب سود / زیان تحقق نیافته را انتخاب کنید یا حساب سود / زیان پیش‌فرض را برای شرکت اضافه کنید {0}"
 
@@ -37337,7 +37333,7 @@ msgstr "لطفا یک شرکت را انتخاب کنید"
 #: erpnext/manufacturing/doctype/bom/bom.js:603
 #: erpnext/manufacturing/doctype/bom/bom.py:261
 #: erpnext/public/js/controllers/accounts.js:249
-#: erpnext/public/js/controllers/transaction.js:2753
+#: erpnext/public/js/controllers/transaction.js:2779
 msgid "Please select a Company first."
 msgstr "لطفا ابتدا یک شرکت را انتخاب کنید."
 
@@ -37495,7 +37491,7 @@ msgstr "لطفاً {0} را انتخاب کنید"
 msgid "Please select {0} first"
 msgstr "لطفاً ابتدا {0} را انتخاب کنید"
 
-#: erpnext/public/js/controllers/transaction.js:77
+#: erpnext/public/js/controllers/transaction.js:100
 msgid "Please set 'Apply Additional Discount On'"
 msgstr "لطفاً \"اعمال تخفیف اضافی\" را تنظیم کنید"
 
@@ -37680,7 +37676,7 @@ msgstr "لطفاً فیلتر را بر اساس کالا یا انبار تنظ
 msgid "Please set filters"
 msgstr "لطفا فیلترها را تنظیم کنید"
 
-#: erpnext/controllers/accounts_controller.py:2194
+#: erpnext/controllers/accounts_controller.py:2197
 msgid "Please set one of the following:"
 msgstr "لطفا یکی از موارد زیر را تنظیم کنید:"
 
@@ -37688,7 +37684,7 @@ msgstr "لطفا یکی از موارد زیر را تنظیم کنید:"
 msgid "Please set opening number of booked depreciations"
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2205
+#: erpnext/public/js/controllers/transaction.js:2231
 msgid "Please set recurring after saving"
 msgstr "لطفاً پس از ذخیره، تکرار شونده را تنظیم کنید"
 
@@ -37759,7 +37755,7 @@ msgstr ""
 msgid "Please share this email with your support team so that they can find and fix the issue."
 msgstr "لطفاً این ایمیل را با تیم پشتیبانی خود به اشتراک بگذارید تا آنها بتوانند مشکل را پیدا کرده و برطرف کنند."
 
-#: erpnext/public/js/controllers/transaction.js:2073
+#: erpnext/public/js/controllers/transaction.js:2099
 msgid "Please specify"
 msgstr "لطفا مشخص کنید"
 
@@ -37774,7 +37770,7 @@ msgid "Please specify Company to proceed"
 msgstr "لطفاً شرکت را برای ادامه مشخص کنید"
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1472
-#: erpnext/controllers/accounts_controller.py:2957
+#: erpnext/controllers/accounts_controller.py:2960
 #: erpnext/public/js/controllers/accounts.js:97
 msgid "Please specify a valid Row ID for row {0} in table {1}"
 msgstr "لطفاً یک شناسه ردیف معتبر برای ردیف {0} در جدول {1} مشخص کنید"
@@ -37787,7 +37783,7 @@ msgstr "لطفا ابتدا یک {0} را مشخص کنید."
 msgid "Please specify at least one attribute in the Attributes table"
 msgstr "لطفا حداقل یک ویژگی را در جدول Attributes مشخص کنید"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:605
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:601
 msgid "Please specify either Quantity or Valuation Rate or both"
 msgstr "لطفاً مقدار یا نرخ ارزش‌گذاری یا هر دو را مشخص کنید"
 
@@ -37968,7 +37964,7 @@ msgstr "هزینه های پستی"
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:16
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:15
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:18
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1046
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1048
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:15
 #: erpnext/accounts/report/bank_clearance_summary/bank_clearance_summary.py:35
 #: erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.html:7
@@ -40149,7 +40145,7 @@ msgstr "مدیر ارشد خرید"
 #: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.js:48
 #: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:203
 #: erpnext/buying/workspace/buying/buying.json
-#: erpnext/controllers/buying_controller.py:739
+#: erpnext/controllers/buying_controller.py:747
 #: erpnext/crm/doctype/contract/contract.json
 #: erpnext/manufacturing/doctype/blanket_order/blanket_order.js:54
 #: erpnext/manufacturing/doctype/production_plan_sub_assembly_item/production_plan_sub_assembly_item.json
@@ -40288,7 +40284,7 @@ msgstr "سفارش‌های خرید برای صورتحساب"
 msgid "Purchase Orders to Receive"
 msgstr "سفارش خرید برای دریافت"
 
-#: erpnext/controllers/accounts_controller.py:1833
+#: erpnext/controllers/accounts_controller.py:1836
 msgid "Purchase Orders {0} are un-linked"
 msgstr "سفارش‌های خرید {0} لغو پیوند هستند"
 
@@ -40312,8 +40308,8 @@ msgstr "لیست قیمت خرید"
 #. Label of a Link in the Stock Workspace
 #. Label of a shortcut in the Stock Workspace
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:171
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:650
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:660
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:652
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:662
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice_list.js:49
 #: erpnext/accounts/doctype/purchase_invoice_item/purchase_invoice_item.json
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:246
@@ -41048,7 +41044,7 @@ msgstr "الگوی بازرسی کیفیت"
 msgid "Quality Inspection Template Name"
 msgstr "نام الگوی بازرسی کیفیت"
 
-#: erpnext/public/js/controllers/transaction.js:334
+#: erpnext/public/js/controllers/transaction.js:360
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:165
 msgid "Quality Inspection(s)"
 msgstr "بازرسی(های) کیفیت"
@@ -42060,7 +42056,7 @@ msgstr "سطح سفارش مجدد"
 #. Label of the warehouse_reorder_qty (Float) field in DocType 'Item Reorder'
 #: erpnext/stock/doctype/item_reorder/item_reorder.json
 msgid "Re-order Qty"
-msgstr "تعداد سفارش مجدد"
+msgstr "مقدار سفارش مجدد"
 
 #: erpnext/accounts/doctype/bisect_accounting_statements/bisect_accounting_statements.py:227
 msgid "Reached Root"
@@ -42232,7 +42228,7 @@ msgid "Receivable / Payable Account"
 msgstr "حساب دریافتنی / پرداختنی"
 
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:71
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1061
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1063
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py:243
 #: erpnext/accounts/report/sales_register/sales_register.py:217
 #: erpnext/accounts/report/sales_register/sales_register.py:271
@@ -42714,7 +42710,7 @@ msgstr "مرجع #{0} به تاریخ {1}"
 msgid "Reference Date"
 msgstr "تاریخ مرجع"
 
-#: erpnext/public/js/controllers/transaction.js:2311
+#: erpnext/public/js/controllers/transaction.js:2337
 msgid "Reference Date for Early Payment Discount"
 msgstr "تاریخ مرجع برای تخفیف پرداخت زودهنگام"
 
@@ -43038,7 +43034,7 @@ msgstr "منظم"
 msgid "Rejected"
 msgstr "رد شده"
 
-#: erpnext/stock/doctype/inventory_dimension/inventory_dimension.py:202
+#: erpnext/stock/doctype/inventory_dimension/inventory_dimension.py:203
 msgid "Rejected "
 msgstr "رد شده "
 
@@ -43142,7 +43138,7 @@ msgstr "مبلغ باقی مانده"
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:187
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:156
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1135
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1137
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:178
 msgid "Remaining Balance"
 msgstr "موجودی باقی مانده"
@@ -43195,7 +43191,7 @@ msgstr "ملاحظات"
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:159
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:198
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:269
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1167
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1169
 #: erpnext/accounts/report/general_ledger/general_ledger.html:84
 #: erpnext/accounts/report/general_ledger/general_ledger.html:110
 #: erpnext/accounts/report/general_ledger/general_ledger.py:742
@@ -43944,7 +43940,7 @@ msgstr "مقدار رزرو شده"
 msgid "Reserved Quantity for Production"
 msgstr "مقدار رزرو شده برای تولید"
 
-#: erpnext/stock/stock_ledger.py:2147
+#: erpnext/stock/stock_ledger.py:2155
 msgid "Reserved Serial No."
 msgstr "شماره سریال رزرو شده"
 
@@ -43960,11 +43956,11 @@ msgstr "شماره سریال رزرو شده"
 #: erpnext/stock/doctype/pick_list/pick_list.js:153
 #: erpnext/stock/report/reserved_stock/reserved_stock.json
 #: erpnext/stock/report/stock_balance/stock_balance.py:499
-#: erpnext/stock/stock_ledger.py:2131
+#: erpnext/stock/stock_ledger.py:2139
 msgid "Reserved Stock"
 msgstr "موجودی رزرو شده"
 
-#: erpnext/stock/stock_ledger.py:2177
+#: erpnext/stock/stock_ledger.py:2185
 msgid "Reserved Stock for Batch"
 msgstr "موجودی رزرو شده برای دسته"
 
@@ -43976,7 +43972,7 @@ msgstr "موجودی رزرو شده برای مواد اولیه"
 msgid "Reserved Stock for Sub-assembly"
 msgstr "موجودی رزرو شده برای زیر مونتاژ"
 
-#: erpnext/controllers/buying_controller.py:476
+#: erpnext/controllers/buying_controller.py:484
 msgid "Reserved Warehouse is mandatory for the Item {item_code} in Raw Materials supplied."
 msgstr "انبار رزرو شده برای آیتم {item_code} در مواد خام عرضه شده الزامی است."
 
@@ -44790,7 +44786,7 @@ msgstr "مسیریابی"
 msgid "Routing Name"
 msgstr "نام مسیریابی"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:667
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:663
 msgid "Row #"
 msgstr "ردیف #"
 
@@ -44828,7 +44824,7 @@ msgstr "ردیف #{0} (جدول پرداخت): مبلغ باید منفی باش
 msgid "Row #{0} (Payment Table): Amount must be positive"
 msgstr "ردیف #{0} (جدول پرداخت): مبلغ باید مثبت باشد"
 
-#: erpnext/stock/doctype/item/item.py:495
+#: erpnext/stock/doctype/item/item.py:498
 msgid "Row #{0}: A reorder entry already exists for warehouse {1} with reorder type {2}."
 msgstr "ردیف #{0}: یک ورودی سفارش مجدد از قبل برای انبار {1} با نوع سفارش مجدد {2} وجود دارد."
 
@@ -44849,7 +44845,7 @@ msgstr "ردیف #{0}: انبار پذیرفته شده و انبار مرجوع
 msgid "Row #{0}: Accepted Warehouse is mandatory for the accepted Item {1}"
 msgstr "ردیف #{0}: انبار پذیرفته شده برای مورد پذیرفته شده اجباری است {1}"
 
-#: erpnext/controllers/accounts_controller.py:1117
+#: erpnext/controllers/accounts_controller.py:1120
 msgid "Row #{0}: Account {1} does not belong to company {2}"
 msgstr "ردیف #{0}: حساب {1} به شرکت {2} تعلق ندارد"
 
@@ -44890,27 +44886,27 @@ msgstr "ردیف #{0}: شماره دسته {1} قبلاً انتخاب شده ا
 msgid "Row #{0}: Cannot allocate more than {1} against payment term {2}"
 msgstr "ردیف #{0}: نمی‌توان بیش از {1} را در مقابل مدت پرداخت {2} تخصیص داد"
 
-#: erpnext/controllers/accounts_controller.py:3524
+#: erpnext/controllers/accounts_controller.py:3527
 msgid "Row #{0}: Cannot delete item {1} which has already been billed."
 msgstr "ردیف #{0}: نمی‌توان مورد {1} را که قبلاً صورتحساب شده است حذف کرد."
 
-#: erpnext/controllers/accounts_controller.py:3498
+#: erpnext/controllers/accounts_controller.py:3501
 msgid "Row #{0}: Cannot delete item {1} which has already been delivered"
 msgstr "ردیف #{0}: نمی‌توان مورد {1} را که قبلاً تحویل داده شده حذف کرد"
 
-#: erpnext/controllers/accounts_controller.py:3517
+#: erpnext/controllers/accounts_controller.py:3520
 msgid "Row #{0}: Cannot delete item {1} which has already been received"
 msgstr "ردیف #{0}: نمی‌توان مورد {1} را که قبلاً دریافت کرده است حذف کرد"
 
-#: erpnext/controllers/accounts_controller.py:3504
+#: erpnext/controllers/accounts_controller.py:3507
 msgid "Row #{0}: Cannot delete item {1} which has work order assigned to it."
 msgstr "ردیف #{0}: نمی‌توان مورد {1} را که دستور کار به آن اختصاص داده است حذف کرد."
 
-#: erpnext/controllers/accounts_controller.py:3510
+#: erpnext/controllers/accounts_controller.py:3513
 msgid "Row #{0}: Cannot delete item {1} which is assigned to customer's purchase order."
 msgstr "ردیف #{0}: نمی‌توان مورد {1} را که به سفارش خرید مشتری اختصاص داده است حذف کرد."
 
-#: erpnext/controllers/accounts_controller.py:3765
+#: erpnext/controllers/accounts_controller.py:3768
 msgid "Row #{0}: Cannot set Rate if the billed amount is greater than the amount for Item {1}."
 msgstr ""
 
@@ -45030,7 +45026,7 @@ msgstr "ردیف #{0}: مورد {1} وجود ندارد"
 msgid "Row #{0}: Item {1} has been picked, please reserve stock from the Pick List."
 msgstr "ردیف #{0}: مورد {1} انتخاب شده است، لطفاً موجودی را از فهرست انتخاب رزرو کنید."
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:729
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:725
 msgid "Row #{0}: Item {1} is not a Serialized/Batched Item. It cannot have a Serial No/Batch No against it."
 msgstr "ردیف #{0}: آیتم {1} یک آیتم سریال/دسته‌ای نیست. نمی‌تواند یک شماره سریال / شماره دسته در مقابل آن داشته باشد."
 
@@ -45086,7 +45082,7 @@ msgstr "ردیف #{0}: لطفاً شماره BOM را در آیتم‌های ا�
 msgid "Row #{0}: Please select the Sub Assembly Warehouse"
 msgstr "ردیف #{0}: لطفاً انبار زیر مونتاژ را انتخاب کنید"
 
-#: erpnext/stock/doctype/item/item.py:502
+#: erpnext/stock/doctype/item/item.py:505
 msgid "Row #{0}: Please set reorder quantity"
 msgstr "ردیف #{0}: لطفاً مقدار سفارش مجدد را تنظیم کنید"
 
@@ -45119,8 +45115,8 @@ msgstr ""
 msgid "Row #{0}: Quality Inspection {1} was rejected for item {2}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1274
-#: erpnext/controllers/accounts_controller.py:3624
+#: erpnext/controllers/accounts_controller.py:1277
+#: erpnext/controllers/accounts_controller.py:3627
 msgid "Row #{0}: Quantity for Item {1} cannot be zero."
 msgstr "ردیف #{0}: مقدار آیتم {1} نمی‌تواند صفر باشد."
 
@@ -45157,7 +45153,7 @@ msgstr ""
 msgid "Row #{0}: Scrap Item Qty cannot be zero"
 msgstr "ردیف #{0}: مقدار آیتم ضایعات نمی‌تواند صفر باشد"
 
-#: erpnext/controllers/selling_controller.py:230
+#: erpnext/controllers/selling_controller.py:238
 msgid "Row #{0}: Selling rate for item {1} is lower than its {2}.\n"
 "\t\t\t\t\tSelling {3} should be atleast {4}.<br><br>Alternatively,\n"
 "\t\t\t\t\tyou can disable selling price validation in {5} to bypass\n"
@@ -45241,7 +45237,7 @@ msgstr "ردیف #{0}: موجودی برای رزرو مورد {1} در انبا
 msgid "Row #{0}: The batch {1} has already expired."
 msgstr "ردیف #{0}: دسته {1} قبلاً منقضی شده است."
 
-#: erpnext/stock/doctype/item/item.py:511
+#: erpnext/stock/doctype/item/item.py:514
 msgid "Row #{0}: The warehouse {1} is not a child warehouse of a group warehouse {2}"
 msgstr ""
 
@@ -45281,39 +45277,39 @@ msgstr "ردیف #{0}: {1} از {2} باید {3} باشد. لطفاً {1} را �
 msgid "Row #{1}: Warehouse is mandatory for stock Item {0}"
 msgstr "ردیف #{1}: انبار برای کالای موجودی {0} اجباری است"
 
-#: erpnext/controllers/buying_controller.py:259
+#: erpnext/controllers/buying_controller.py:267
 msgid "Row #{idx}: Cannot select Supplier Warehouse while suppling raw materials to subcontractor."
 msgstr "ردیف #{idx}: هنگام تامین مواد خام به پیمانکار فرعی، نمی‌توان انبار تامین کننده را انتخاب کرد."
 
-#: erpnext/controllers/buying_controller.py:406
+#: erpnext/controllers/buying_controller.py:414
 msgid "Row #{idx}: Item rate has been updated as per valuation rate since its an internal stock transfer."
 msgstr "ردیف #{idx}: نرخ آیتم براساس نرخ ارزش‌گذاری به‌روزرسانی شده است، زیرا یک انتقال داخلی موجودی است."
 
-#: erpnext/controllers/buying_controller.py:881
+#: erpnext/controllers/buying_controller.py:889
 msgid "Row #{idx}: Please enter a location for the asset item {item_code}."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:537
+#: erpnext/controllers/buying_controller.py:545
 msgid "Row #{idx}: Received Qty must be equal to Accepted + Rejected Qty for Item {item_code}."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:550
+#: erpnext/controllers/buying_controller.py:558
 msgid "Row #{idx}: {field_label} can not be negative for item {item_code}."
 msgstr "ردیف #{idx}: {field_label} نمی‌تواند برای مورد {item_code} منفی باشد."
 
-#: erpnext/controllers/buying_controller.py:496
+#: erpnext/controllers/buying_controller.py:504
 msgid "Row #{idx}: {field_label} is mandatory."
 msgstr "ردیف #{idx}: {field_label} اجباری است."
 
-#: erpnext/controllers/buying_controller.py:518
+#: erpnext/controllers/buying_controller.py:526
 msgid "Row #{idx}: {field_label} is not allowed in Purchase Return."
 msgstr "ردیف #{idx}: {field_label} در مرجوعی خرید مجاز نیست."
 
-#: erpnext/controllers/buying_controller.py:250
+#: erpnext/controllers/buying_controller.py:258
 msgid "Row #{idx}: {from_warehouse_field} and {to_warehouse_field} cannot be same."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:999
+#: erpnext/controllers/buying_controller.py:1007
 msgid "Row #{idx}: {schedule_date} cannot be before {transaction_date}."
 msgstr ""
 
@@ -45378,7 +45374,7 @@ msgstr "ردیف #{}: {}"
 msgid "Row #{}: {} {} does not exist."
 msgstr "ردیف #{}: {} {} وجود ندارد."
 
-#: erpnext/stock/doctype/item/item.py:1403
+#: erpnext/stock/doctype/item/item.py:1397
 msgid "Row #{}: {} {} doesn't belong to Company {}. Please select valid {}."
 msgstr "ردیف #{}: {} {} به شرکت {} تعلق ندارد. لطفاً {} معتبر را انتخاب کنید."
 
@@ -45450,11 +45446,11 @@ msgstr "ردیف {0}: صورتحساب مواد برای آیتم {1} یافت �
 msgid "Row {0}: Both Debit and Credit values cannot be zero"
 msgstr "ردیف {0}: هر دو مقدار بدهی و اعتبار نمی‌توانند صفر باشند"
 
-#: erpnext/controllers/selling_controller.py:222
+#: erpnext/controllers/selling_controller.py:230
 msgid "Row {0}: Conversion Factor is mandatory"
 msgstr "ردیف {0}: ضریب تبدیل اجباری است"
 
-#: erpnext/controllers/accounts_controller.py:2995
+#: erpnext/controllers/accounts_controller.py:2998
 msgid "Row {0}: Cost Center {1} does not belong to Company {2}"
 msgstr "ردیف {0}: مرکز هزینه {1} به شرکت {2} تعلق ندارد"
 
@@ -45474,11 +45470,11 @@ msgstr "ردیف {0}: واحد پول BOM #{1} باید برابر با ارز �
 msgid "Row {0}: Debit entry can not be linked with a {1}"
 msgstr "ردیف {0}: ورودی بدهی را نمی‌توان با یک {1} پیوند داد"
 
-#: erpnext/controllers/selling_controller.py:776
+#: erpnext/controllers/selling_controller.py:784
 msgid "Row {0}: Delivery Warehouse ({1}) and Customer Warehouse ({2}) can not be same"
 msgstr "ردیف {0}: انبار تحویل ({1}) و انبار مشتری ({2}) نمی‌توانند یکسان باشند"
 
-#: erpnext/controllers/accounts_controller.py:2529
+#: erpnext/controllers/accounts_controller.py:2532
 msgid "Row {0}: Due Date in the Payment Terms table cannot be before Posting Date"
 msgstr "ردیف {0}: تاریخ سررسید در جدول شرایط پرداخت نمی‌تواند قبل از تاریخ ارسال باشد"
 
@@ -45487,7 +45483,7 @@ msgid "Row {0}: Either Delivery Note Item or Packed Item reference is mandatory.
 msgstr "ردیف {0}: مرجع مورد یادداشت تحویل یا کالای بسته بندی شده اجباری است."
 
 #: erpnext/accounts/doctype/journal_entry/journal_entry.py:1010
-#: erpnext/controllers/taxes_and_totals.py:1205
+#: erpnext/controllers/taxes_and_totals.py:1215
 msgid "Row {0}: Exchange Rate is mandatory"
 msgstr "ردیف {0}: نرخ ارز اجباری است"
 
@@ -45536,11 +45532,11 @@ msgstr "ردیف {0}: مقدار ساعت باید بزرگتر از صفر با
 msgid "Row {0}: Invalid reference {1}"
 msgstr "ردیف {0}: مرجع نامعتبر {1}"
 
-#: erpnext/controllers/taxes_and_totals.py:142
+#: erpnext/controllers/taxes_and_totals.py:143
 msgid "Row {0}: Item Tax template updated as per validity and rate applied"
 msgstr "ردیف {0}: الگوی مالیات آیتم بر اساس اعتبار و نرخ اعمال شده به روز شد"
 
-#: erpnext/controllers/selling_controller.py:541
+#: erpnext/controllers/selling_controller.py:549
 msgid "Row {0}: Item rate has been updated as per valuation rate since its an internal stock transfer"
 msgstr "ردیف {0}: نرخ اقلام براساس نرخ ارزش‌گذاری به‌روزرسانی شده است، زیرا یک انتقال داخلی موجودی است"
 
@@ -45660,7 +45656,7 @@ msgstr ""
 msgid "Row {0}: The item {1}, quantity must be positive number"
 msgstr "ردیف {0}: مورد {1}، مقدار باید عدد مثبت باشد"
 
-#: erpnext/controllers/accounts_controller.py:2972
+#: erpnext/controllers/accounts_controller.py:2975
 msgid "Row {0}: The {3} Account {1} does not belong to the company {2}"
 msgstr ""
 
@@ -45677,7 +45673,7 @@ msgstr "ردیف {0}: ضریب تبدیل UOM اجباری است"
 msgid "Row {0}: Workstation or Workstation Type is mandatory for an operation {1}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1011
+#: erpnext/controllers/accounts_controller.py:1014
 msgid "Row {0}: user has not applied the rule {1} on the item {2}"
 msgstr "ردیف {0}: کاربر قانون {1} را در مورد {2} اعمال نکرده است"
 
@@ -45689,7 +45685,7 @@ msgstr "ردیف {0}: حساب {1} قبلاً برای بعد حسابداری {
 msgid "Row {0}: {1} must be greater than 0"
 msgstr "ردیف {0}: {1} باید بزرگتر از 0 باشد"
 
-#: erpnext/controllers/accounts_controller.py:706
+#: erpnext/controllers/accounts_controller.py:709
 msgid "Row {0}: {1} {2} cannot be same as {3} (Party Account) {4}"
 msgstr "ردیف {0}: {1} {2} نمی‌تواند مانند {3} (حساب طرف) {4}"
 
@@ -45705,7 +45701,7 @@ msgstr ""
 msgid "Row {1}: Quantity ({0}) cannot be a fraction. To allow this, disable '{2}' in UOM {3}."
 msgstr "ردیف {1}: مقدار ({0}) نمی‌تواند کسری باشد. برای اجازه دادن به این کار، \"{2}\" را در UOM {3} غیرفعال کنید."
 
-#: erpnext/controllers/buying_controller.py:863
+#: erpnext/controllers/buying_controller.py:871
 msgid "Row {idx}: Asset Naming Series is mandatory for the auto creation of assets for item {item_code}."
 msgstr ""
 
@@ -45731,7 +45727,7 @@ msgstr "ردیف‌ها در {0} حذف شدند"
 msgid "Rows with Same Account heads will be merged on Ledger"
 msgstr "ردیف هایی با سرهای حساب یکسان در دفتر ادغام می‌شوند"
 
-#: erpnext/controllers/accounts_controller.py:2539
+#: erpnext/controllers/accounts_controller.py:2542
 msgid "Rows with duplicate due dates in other rows were found: {0}"
 msgstr "ردیف‌هایی با تاریخ سررسید تکراری در ردیف‌های دیگر یافت شد: {0}"
 
@@ -45801,7 +45797,7 @@ msgstr "SLA در وضعیت تکمیل شد"
 msgid "SLA Paused On"
 msgstr "SLA متوقف شد"
 
-#: erpnext/public/js/utils.js:1167
+#: erpnext/public/js/utils.js:1163
 msgid "SLA is on hold since {0}"
 msgstr "SLA از {0} در حالت تعلیق است"
 
@@ -46202,7 +46198,7 @@ msgstr "فرصت های فروش بر اساس منبع"
 #: erpnext/accounts/report/sales_register/sales_register.py:238
 #: erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
 #: erpnext/buying/doctype/supplier_quotation_item/supplier_quotation_item.json
-#: erpnext/controllers/selling_controller.py:462
+#: erpnext/controllers/selling_controller.py:470
 #: erpnext/crm/doctype/contract/contract.json
 #: erpnext/maintenance/doctype/maintenance_schedule/maintenance_schedule.js:65
 #: erpnext/maintenance/doctype/maintenance_schedule_item/maintenance_schedule_item.json
@@ -46328,7 +46324,7 @@ msgstr "سفارش فروش {0} ارسال نشده است"
 msgid "Sales Order {0} is not valid"
 msgstr "سفارش فروش {0} معتبر نیست"
 
-#: erpnext/controllers/selling_controller.py:443
+#: erpnext/controllers/selling_controller.py:451
 #: erpnext/manufacturing/doctype/work_order/work_order.py:301
 msgid "Sales Order {0} is {1}"
 msgstr "سفارش فروش {0} {1} است"
@@ -46379,7 +46375,7 @@ msgstr "سفارش‌های فروش برای تحویل"
 #: erpnext/accounts/doctype/promotional_scheme/promotional_scheme.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:122
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1156
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1158
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:99
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:194
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:74
@@ -46477,7 +46473,7 @@ msgstr "خلاصه پرداخت فروش"
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:156
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:137
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:128
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1153
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1155
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:105
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:191
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:80
@@ -46497,7 +46493,7 @@ msgstr "خلاصه پرداخت فروش"
 msgid "Sales Person"
 msgstr "شخص فروش"
 
-#: erpnext/controllers/selling_controller.py:204
+#: erpnext/controllers/selling_controller.py:212
 msgid "Sales Person <b>{0}</b> is disabled."
 msgstr ""
 
@@ -46778,7 +46774,7 @@ msgstr "انبار نگهداری نمونه"
 
 #. Label of the sample_size (Float) field in DocType 'Quality Inspection'
 #: erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py:93
-#: erpnext/public/js/controllers/transaction.js:2369
+#: erpnext/public/js/controllers/transaction.js:2395
 #: erpnext/stock/doctype/quality_inspection/quality_inspection.json
 msgid "Sample Size"
 msgstr "اندازه‌ی نمونه"
@@ -47316,7 +47312,7 @@ msgstr "انتخاب آیتم‌ها"
 msgid "Select Items based on Delivery Date"
 msgstr "آیتم‌ها را بر اساس تاریخ تحویل انتخاب کنید"
 
-#: erpnext/public/js/controllers/transaction.js:2405
+#: erpnext/public/js/controllers/transaction.js:2431
 msgid "Select Items for Quality Inspection"
 msgstr "انتخاب آیتم‌ها برای بازرسی کیفیت"
 
@@ -47457,7 +47453,7 @@ msgstr "ابتدا شرکت را انتخاب کنید"
 msgid "Select company name first."
 msgstr "ابتدا نام شرکت را انتخاب کنید"
 
-#: erpnext/controllers/accounts_controller.py:2785
+#: erpnext/controllers/accounts_controller.py:2788
 msgid "Select finance book for the item {0} at row {1}"
 msgstr "دفتر مالی را برای مورد {0} در ردیف {1} انتخاب کنید"
 
@@ -47671,7 +47667,7 @@ msgid "Send Now"
 msgstr "در حال حاضر ارسال"
 
 #. Label of the send_sms (Button) field in DocType 'SMS Center'
-#: erpnext/public/js/controllers/transaction.js:517
+#: erpnext/public/js/controllers/transaction.js:543
 #: erpnext/selling/doctype/sms_center/sms_center.json
 msgid "Send SMS"
 msgstr "ارسال پیامک"
@@ -47829,7 +47825,7 @@ msgstr "شماره های سریال / دسته ای"
 #: erpnext/manufacturing/doctype/job_card/job_card.json
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.js:74
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.py:114
-#: erpnext/public/js/controllers/transaction.js:2382
+#: erpnext/public/js/controllers/transaction.js:2408
 #: erpnext/public/js/utils/serial_no_batch_selector.js:421
 #: erpnext/selling/doctype/installation_note_item/installation_note_item.json
 #: erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
@@ -47878,7 +47874,7 @@ msgstr "دفتر شماره سریال"
 msgid "Serial No Range"
 msgstr "محدوده شماره سریال"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1894
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1895
 msgid "Serial No Reserved"
 msgstr "شماره سریال رزرو شده"
 
@@ -47918,7 +47914,7 @@ msgstr "شماره سریال و دسته"
 msgid "Serial No and Batch Selector cannot be use when Use Serial / Batch Fields is enabled."
 msgstr "انتخاب‌گر شماره سریال و دسته زمانی که فیلدهای شماره سریال / دسته فعال شده‌اند، قابل استفاده نیست."
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:859
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:860
 msgid "Serial No is mandatory"
 msgstr "شماره سریال اجباری است"
 
@@ -47947,7 +47943,7 @@ msgstr "شماره سریال {0} به آیتم {1} تعلق ندارد"
 msgid "Serial No {0} does not exist"
 msgstr "شماره سریال {0} وجود ندارد"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2623
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2624
 msgid "Serial No {0} does not exists"
 msgstr "شماره سریال {0} وجود ندارد"
 
@@ -47955,7 +47951,7 @@ msgstr "شماره سریال {0} وجود ندارد"
 msgid "Serial No {0} is already added"
 msgstr "شماره سریال {0} قبلاً اضافه شده است"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:357
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:358
 msgid "Serial No {0} is not present in the {1} {2}, hence you can't return it against the {1} {2}"
 msgstr "شماره سریال {0} در {1} {2} وجود ندارد، بنابراین نمی‌توانید آن را در برابر {1} {2} برگردانید"
 
@@ -47992,11 +47988,11 @@ msgstr "شماره های سریال / شماره های دسته ای"
 msgid "Serial Nos and Batches"
 msgstr "شماره های سریال و دسته ها"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1370
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1371
 msgid "Serial Nos are created successfully"
 msgstr "شماره های سریال با موفقیت ایجاد شد"
 
-#: erpnext/stock/stock_ledger.py:2137
+#: erpnext/stock/stock_ledger.py:2145
 msgid "Serial Nos are reserved in Stock Reservation Entries, you need to unreserve them before proceeding."
 msgstr "شماره های سریال در ورودی های رزرو موجودی رزرو شده اند، قبل از ادامه باید آنها را لغو رزرو کنید."
 
@@ -48070,11 +48066,11 @@ msgstr "سریال و دسته"
 msgid "Serial and Batch Bundle"
 msgstr "باندل سریال و دسته"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1598
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1599
 msgid "Serial and Batch Bundle created"
 msgstr "باندل سریال و دسته ایجاد شد"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1664
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1665
 msgid "Serial and Batch Bundle updated"
 msgstr "باندل سریال و دسته به روز شد"
 
@@ -48426,12 +48422,12 @@ msgid "Service Stop Date"
 msgstr "تاریخ توقف خدمات"
 
 #: erpnext/accounts/deferred_revenue.py:44
-#: erpnext/public/js/controllers/transaction.js:1420
+#: erpnext/public/js/controllers/transaction.js:1446
 msgid "Service Stop Date cannot be after Service End Date"
 msgstr "تاریخ توقف سرویس نمی‌تواند بعد از تاریخ پایان سرویس باشد"
 
 #: erpnext/accounts/deferred_revenue.py:41
-#: erpnext/public/js/controllers/transaction.js:1417
+#: erpnext/public/js/controllers/transaction.js:1443
 msgid "Service Stop Date cannot be before Service Start Date"
 msgstr "تاریخ توقف سرویس نمی‌تواند قبل از تاریخ شروع سرویس باشد"
 
@@ -49866,7 +49862,7 @@ msgstr "هزینه های رتبه بندی استاندارد"
 
 #: erpnext/setup/setup_wizard/operations/defaults_setup.py:70
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:463
-#: erpnext/stock/doctype/item/item.py:245
+#: erpnext/stock/doctype/item/item.py:248
 msgid "Standard Selling"
 msgstr "فروش استاندارد"
 
@@ -50696,7 +50692,7 @@ msgstr "موجودی دریافت شده اما صورتحساب نشده"
 #. Option for the 'Purpose' (Select) field in DocType 'Stock Reconciliation'
 #. Label of a Link in the Stock Workspace
 #: erpnext/setup/workspace/home/home.json
-#: erpnext/stock/doctype/item/item.py:612
+#: erpnext/stock/doctype/item/item.py:618
 #: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.json
 #: erpnext/stock/workspace/stock/stock.json
 msgid "Stock Reconciliation"
@@ -50707,7 +50703,7 @@ msgstr "تطبیق موجودی"
 msgid "Stock Reconciliation Item"
 msgstr "آیتم تطبیق موجودی"
 
-#: erpnext/stock/doctype/item/item.py:612
+#: erpnext/stock/doctype/item/item.py:618
 msgid "Stock Reconciliations"
 msgstr "تطبیق‌های موجودی"
 
@@ -50742,7 +50738,7 @@ msgstr "تنظیمات ارسال مجدد موجودی"
 #: erpnext/stock/doctype/pick_list/pick_list.js:150
 #: erpnext/stock/doctype/pick_list/pick_list.js:155
 #: erpnext/stock/doctype/stock_entry/stock_entry_dashboard.py:25
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:706
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:702
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:575
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:1138
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:1398
@@ -51142,7 +51138,7 @@ msgstr "دستور کار متوقف شده را نمی‌توان لغو کرد
 #: erpnext/setup/doctype/company/company.py:287
 #: erpnext/setup/setup_wizard/operations/defaults_setup.py:33
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:502
-#: erpnext/stock/doctype/item/item.py:282
+#: erpnext/stock/doctype/item/item.py:285
 msgid "Stores"
 msgstr "مغازه ها"
 
@@ -51677,7 +51673,7 @@ msgstr "با موفقیت تطبیق کرد"
 msgid "Successfully Set Supplier"
 msgstr "تامین کننده با موفقیت تنظیم شد"
 
-#: erpnext/stock/doctype/item/item.py:339
+#: erpnext/stock/doctype/item/item.py:342
 msgid "Successfully changed Stock UOM, please redefine conversion factors for new UOM."
 msgstr "UOM موجودی با موفقیت تغییر کرد، لطفاً فاکتورهای تبدیل را برای UOM جدید دوباره تعریف کنید."
 
@@ -51979,7 +51975,7 @@ msgstr "جزئیات تامین کننده"
 #: erpnext/accounts/doctype/tax_rule/tax_rule.json
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:111
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:87
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1160
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1162
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:198
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:237
 #: erpnext/accounts/report/purchase_register/purchase_register.js:27
@@ -52079,7 +52075,7 @@ msgstr "خلاصه دفتر تامین کننده"
 #. Label of the supplier_name (Data) field in DocType 'Purchase Receipt'
 #. Label of the supplier_name (Data) field in DocType 'Stock Entry'
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1077
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1079
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:156
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:198
 #: erpnext/accounts/report/purchase_register/purchase_register.py:177
@@ -52563,7 +52559,7 @@ msgstr "سیستم به طور خودکار شماره سریال / دسته ر�
 msgid "System will fetch all the entries if limit value is zero."
 msgstr "سیستم تمامی ثبت‌ها را واکشی خواهد کرد اگر مقدار حد صفر باشد."
 
-#: erpnext/controllers/accounts_controller.py:1975
+#: erpnext/controllers/accounts_controller.py:1978
 msgid "System will not check over billing since amount for Item {0} in {1} is zero"
 msgstr "سیستم صورتحساب را بررسی نمی‌کند زیرا مبلغ مورد {0} در {1} صفر است"
 
@@ -52822,7 +52818,7 @@ msgstr "خطای رزرو انبار هدف"
 msgid "Target Warehouse is required before Submit"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:782
+#: erpnext/controllers/selling_controller.py:790
 msgid "Target Warehouse is set for some items but the customer is not an internal customer."
 msgstr "انبار هدف برای برخی آیتم‌ها تنظیم شده است اما مشتری، یک مشتری داخلی نیست."
 
@@ -53061,7 +53057,7 @@ msgstr "تفکیک مالیاتی"
 msgid "Tax Category"
 msgstr "دسته مالیاتی"
 
-#: erpnext/controllers/buying_controller.py:194
+#: erpnext/controllers/buying_controller.py:202
 msgid "Tax Category has been changed to \"Total\" because all the Items are non-stock items"
 msgstr "دسته مالیات به \"کل\" تغییر یافته است زیرا همه آیتم‌ها، آیتم‌های غیر موجودی هستند"
 
@@ -53266,7 +53262,7 @@ msgstr "مالیات فقط برای مبلغی که بیش از آستانه ت
 #. Label of the taxable_amount (Currency) field in DocType 'Tax Withheld
 #. Vouchers'
 #: erpnext/accounts/doctype/tax_withheld_vouchers/tax_withheld_vouchers.json
-#: erpnext/controllers/taxes_and_totals.py:1125
+#: erpnext/controllers/taxes_and_totals.py:1135
 msgid "Taxable Amount"
 msgstr "مبلغ مشمول مالیات"
 
@@ -53405,7 +53401,7 @@ msgstr "مالیات ها و هزینه های کسر شده"
 msgid "Taxes and Charges Deducted (Company Currency)"
 msgstr "مالیات ها و هزینه های کسر شده (ارز شرکت)"
 
-#: erpnext/stock/doctype/item/item.py:352
+#: erpnext/stock/doctype/item/item.py:355
 msgid "Taxes row #{0}: {1} cannot be smaller than {2}"
 msgstr ""
 
@@ -53691,7 +53687,7 @@ msgstr "الگوی شرایط و ضوابط"
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/territory_item/territory_item.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:134
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1144
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1146
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:93
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:182
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:68
@@ -53795,7 +53791,7 @@ msgstr "دسترسی به درخواست پیش فاکتور از پورتال �
 msgid "The BOM which will be replaced"
 msgstr "BOM که جایگزین خواهد شد"
 
-#: erpnext/stock/serial_batch_bundle.py:1274
+#: erpnext/stock/serial_batch_bundle.py:1306
 msgid "The Batch {0} has negative quantity {1} in warehouse {2}. Please correct the quantity."
 msgstr ""
 
@@ -53847,7 +53843,7 @@ msgstr ""
 msgid "The Serial No at Row #{0}: {1} is not available in warehouse {2}."
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1891
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1892
 msgid "The Serial No {0} is reserved against the {1} {2} and cannot be used for any other transaction."
 msgstr ""
 
@@ -53930,7 +53926,7 @@ msgstr "دارایی های زیر به طور خودکار ورودی های ا
 msgid "The following batches are expired, please restock them: <br> {0}"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:849
+#: erpnext/stock/doctype/item/item.py:843
 msgid "The following deleted attributes exist in Variants but not in the Template. You can either delete the Variants or keep the attribute(s) in template."
 msgstr "ویژگی های حذف شده زیر در گونه‌ها وجود دارد اما در قالب وجود ندارد. می‌توانید گونه‌ها را حذف کنید یا ویژگی(ها) را در قالب نگه دارید."
 
@@ -53955,15 +53951,15 @@ msgstr "وزن ناخالص بسته. معمولاً وزن خالص + وزن م
 msgid "The holiday on {0} is not between From Date and To Date"
 msgstr "تعطیلات در {0} بین از تاریخ و تا تاریخ نیست"
 
-#: erpnext/controllers/buying_controller.py:1066
+#: erpnext/controllers/buying_controller.py:1074
 msgid "The item {item} is not marked as {type_of} item. You can enable it as {type_of} item from its Item master."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:614
+#: erpnext/stock/doctype/item/item.py:620
 msgid "The items {0} and {1} are present in the following {2} :"
 msgstr "آیتم‌های {0} و {1} در {2} زیر موجود هستند:"
 
-#: erpnext/controllers/buying_controller.py:1059
+#: erpnext/controllers/buying_controller.py:1067
 msgid "The items {items} are not marked as {type_of} item. You can enable them as {type_of} item from their Item masters."
 msgstr ""
 
@@ -54065,8 +54061,8 @@ msgstr "مورد انتخاب شده نمی‌تواند دسته ای داشت�
 msgid "The seller and the buyer cannot be the same"
 msgstr "فروشنده و خریدار نمی‌توانند یکسان باشند"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:142
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:154
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:143
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:155
 msgid "The serial and batch bundle {0} not linked to {1} {2}"
 msgstr "باندل سریال و دسته {0} به {1} {2} مرتبط نیست"
 
@@ -54090,7 +54086,7 @@ msgstr "اشتراک‌گذاری‌ها با {0} وجود ندارند"
 msgid "The stock for the item {0} in the {1} warehouse was negative on the {2}. You should create a positive entry {3} before the date {4} and time {5} to post the correct valuation rate. For more details, please read the <a href='https://docs.erpnext.com/docs/user/manual/en/stock-adjustment-cogs-with-negative-stock'>documentation<a>."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:700
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:696
 msgid "The stock has been reserved for the following Items and Warehouses, un-reserve the same to {0} the Stock Reconciliation: <br /><br /> {1}"
 msgstr "موجودی برای اقلام و انبارهای زیر رزرو شده است، همان را در {0} تطبیق موجودی لغو کنید: <br /><br /> {1}"
 
@@ -54103,11 +54099,11 @@ msgstr "همگام سازی در پس زمینه شروع شده است، لطف
 msgid "The task has been enqueued as a background job."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:994
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:990
 msgid "The task has been enqueued as a background job. In case there is any issue on processing in background, the system will add a comment about the error on this Stock Reconciliation and revert to the Draft stage"
 msgstr "تسک به عنوان یک کار پس زمینه در نوبت قرار گرفته است. در صورت وجود هرگونه مشکل در پردازش در پس‌زمینه، سیستم نظری در مورد خطا در این تطبیق موجودی اضافه می‌کند و به مرحله پیش‌نویس باز می‌گردد."
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1005
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1001
 msgid "The task has been enqueued as a background job. In case there is any issue on processing in background, the system will add a comment about the error on this Stock Reconciliation and revert to the Submitted stage"
 msgstr "تسک به عنوان یک کار پس زمینه در نوبت قرار گرفته است. در صورت وجود هرگونه مشکل در پردازش در پس‌زمینه، سیستم نظری در مورد خطا در این تطبیق موجودی اضافه می‌کند و به مرحله ارسال باز می‌گردد."
 
@@ -54143,7 +54139,7 @@ msgstr "مقدار {0} قبلاً به یک مورد موجود {1} اختصاص
 
 #: erpnext/manufacturing/doctype/work_order/work_order.js:1057
 msgid "The warehouse where you store finished Items before they are shipped."
-msgstr "انباری که اقلام تمام شده را قبل از ارسال در آن ذخیره می‌کنید."
+msgstr "انباری که آیتم‌های تمام شده را قبل از ارسال در آن ذخیره می‌کنید."
 
 #: erpnext/manufacturing/doctype/work_order/work_order.js:1050
 msgid "The warehouse where you store your raw materials. Each required item can have a separate source warehouse. Group warehouse also can be selected as source warehouse. On submission of the Work Order, the raw materials will be reserved in these warehouses for production usage."
@@ -54157,7 +54153,7 @@ msgstr "انباری که هنگام شروع تولید، اقلام شما د�
 msgid "The {0} ({1}) must be equal to {2} ({3})"
 msgstr "{0} ({1}) باید برابر با {2} ({3}) باشد"
 
-#: erpnext/public/js/controllers/transaction.js:2790
+#: erpnext/public/js/controllers/transaction.js:2816
 msgid "The {0} contains Unit Price Items."
 msgstr ""
 
@@ -54205,7 +54201,7 @@ msgstr "هیچ گونه آیتمی برای آیتم انتخابی وجود ن�
 msgid "There can be multiple tiered collection factor based on the total spent. But the conversion factor for redemption will always be same for all the tier."
 msgstr ""
 
-#: erpnext/accounts/party.py:580
+#: erpnext/accounts/party.py:586
 msgid "There can only be 1 Account per Company in {0} {1}"
 msgstr "برای هر شرکت فقط 1 حساب در {0} {1} وجود دارد"
 
@@ -54491,7 +54487,7 @@ msgstr "این به کد آیتم گونه اضافه خواهد شد. به عن
 msgid "This will restrict user access to other employee records"
 msgstr "این امر دسترسی کاربر به سایر رکوردهای کارمندان را محدود می‌کند"
 
-#: erpnext/controllers/selling_controller.py:783
+#: erpnext/controllers/selling_controller.py:791
 msgid "This {} will be treated as material transfer."
 msgstr "این {} به عنوان انتقال مواد در نظر گرفته می‌شود."
 
@@ -55205,11 +55201,11 @@ msgid "To include sub-assembly costs and scrap items in Finished Goods on a work
 msgstr "برای گنجاندن هزینه‌های زیر مونتاژ و آیتم‌های ضایعات در کالاهای نهایی در یک دستور کار بدون استفاده از کارت کار، زمانی که گزینه «استفاده از BOM چند سطحی» فعال است."
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:2337
-#: erpnext/controllers/accounts_controller.py:3005
+#: erpnext/controllers/accounts_controller.py:3008
 msgid "To include tax in row {0} in Item rate, taxes in rows {1} must also be included"
 msgstr "برای گنجاندن مالیات در ردیف {0} در نرخ مورد، مالیات‌های ردیف {1} نیز باید لحاظ شود"
 
-#: erpnext/stock/doctype/item/item.py:636
+#: erpnext/stock/doctype/item/item.py:642
 msgid "To merge, following properties must be same for both items"
 msgstr "برای ادغام، ویژگی های زیر باید برای هر دو مورد یکسان باشد"
 
@@ -55829,7 +55825,7 @@ msgstr "کل مبلغ معوقه"
 msgid "Total Paid Amount"
 msgstr "کل مبلغ پرداختی"
 
-#: erpnext/controllers/accounts_controller.py:2591
+#: erpnext/controllers/accounts_controller.py:2594
 msgid "Total Payment Amount in Payment Schedule must be equal to Grand / Rounded Total"
 msgstr "کل مبلغ پرداخت در برنامه پرداخت باید برابر با کل / کل گرد شده باشد"
 
@@ -56114,15 +56110,15 @@ msgstr "وزن کل (کیلوگرم)"
 msgid "Total Working Hours"
 msgstr "مجموع ساعات کاری"
 
-#: erpnext/controllers/accounts_controller.py:2138
+#: erpnext/controllers/accounts_controller.py:2141
 msgid "Total advance ({0}) against Order {1} cannot be greater than the Grand Total ({2})"
 msgstr "کل پیش پرداخت ({0}) در برابر سفارش {1} نمی‌تواند بیشتر از جمع کل ({2}) باشد"
 
-#: erpnext/controllers/selling_controller.py:190
+#: erpnext/controllers/selling_controller.py:198
 msgid "Total allocated percentage for sales team should be 100"
 msgstr "کل درصد تخصیص داده شده برای تیم فروش باید 100 باشد"
 
-#: erpnext/selling/doctype/customer/customer.py:162
+#: erpnext/selling/doctype/customer/customer.py:161
 msgid "Total contribution percentage should be equal to 100"
 msgstr "درصد کل مشارکت باید برابر با 100 باشد"
 
@@ -57007,7 +57003,7 @@ msgstr "واحد اندازه گیری"
 msgid "Unit of Measure (UOM)"
 msgstr "واحد اندازه گیری (UOM)"
 
-#: erpnext/stock/doctype/item/item.py:384
+#: erpnext/stock/doctype/item/item.py:387
 msgid "Unit of Measure {0} has been entered more than once in Conversion Factor Table"
 msgstr "واحد اندازه گیری {0} بیش از یک بار در جدول ضریب تبدیل وارد شده است"
 
@@ -57449,7 +57445,7 @@ msgstr "به‌روزرسانی تایم‌استمپ تغییرات بر روی
 msgid "Update timestamp on new communication"
 msgstr "به روز رسانی تایم‌استمپ در ارتباطات جدید"
 
-#: erpnext/manufacturing/doctype/bom_creator/bom_creator.py:533
+#: erpnext/manufacturing/doctype/bom_creator/bom_creator.py:534
 msgid "Updated successfully"
 msgstr "با موفقیت به روز شد"
 
@@ -57463,7 +57459,7 @@ msgstr "با موفقیت به روز شد"
 msgid "Updated via 'Time Log' (In Minutes)"
 msgstr "به روز شده از طریق \"Time Log\" (بر حسب دقیقه)"
 
-#: erpnext/stock/doctype/item/item.py:1387
+#: erpnext/stock/doctype/item/item.py:1381
 msgid "Updating Variants..."
 msgstr "به روز رسانی گونه‌ها..."
 
@@ -58021,19 +58017,19 @@ msgstr "نرخ ارزش‌گذاری"
 msgid "Valuation Rate (In / Out)"
 msgstr "نرخ ارزش‌گذاری (ورودی/خروجی)"
 
-#: erpnext/stock/stock_ledger.py:1881
+#: erpnext/stock/stock_ledger.py:1890
 msgid "Valuation Rate Missing"
 msgstr "نرخ ارزش‌گذاری وجود ندارد"
 
-#: erpnext/stock/stock_ledger.py:1859
+#: erpnext/stock/stock_ledger.py:1868
 msgid "Valuation Rate for the Item {0}, is required to do accounting entries for {1} {2}."
 msgstr "نرخ ارزش‌گذاری برای آیتم {0}، برای انجام ثبت‌های حسابداری برای {1} {2} لازم است."
 
-#: erpnext/stock/doctype/item/item.py:266
+#: erpnext/stock/doctype/item/item.py:269
 msgid "Valuation Rate is mandatory if Opening Stock entered"
 msgstr "در صورت ثبت موجودی افتتاحیه، نرخ ارزش‌گذاری الزامی است"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:752
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:748
 msgid "Valuation Rate required for Item {0} at row {1}"
 msgstr "نرخ ارزش‌گذاری الزامی است برای آیتم {0} در ردیف {1}"
 
@@ -58043,7 +58039,7 @@ msgstr "نرخ ارزش‌گذاری الزامی است برای آیتم {0} �
 msgid "Valuation and Total"
 msgstr "ارزش گذاری و کل"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:971
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:967
 msgid "Valuation rate for customer provided items has been set to zero."
 msgstr "نرخ ارزش‌گذاری برای آیتم‌های ارائه شده توسط مشتری صفر تعیین شده است."
 
@@ -58057,7 +58053,7 @@ msgid "Valuation rate for the item as per Sales Invoice (Only for Internal Trans
 msgstr ""
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:2361
-#: erpnext/controllers/accounts_controller.py:3029
+#: erpnext/controllers/accounts_controller.py:3032
 msgid "Valuation type charges can not be marked as Inclusive"
 msgstr "هزینه‌های نوع ارزیابی را نمی‌توان به‌عنوان فراگیر علامت‌گذاری کرد"
 
@@ -58213,7 +58209,7 @@ msgstr "واریانس ({})"
 msgid "Variant"
 msgstr "گونه"
 
-#: erpnext/stock/doctype/item/item.py:864
+#: erpnext/stock/doctype/item/item.py:858
 msgid "Variant Attribute Error"
 msgstr "خطای ویژگی گونه"
 
@@ -58232,7 +58228,7 @@ msgstr "BOM گونه"
 msgid "Variant Based On"
 msgstr "گونه بر اساس"
 
-#: erpnext/stock/doctype/item/item.py:892
+#: erpnext/stock/doctype/item/item.py:886
 msgid "Variant Based On cannot be changed"
 msgstr "گونه بر اساس قابل تغییر نیست"
 
@@ -58250,7 +58246,7 @@ msgstr "فیلد گونه"
 msgid "Variant Item"
 msgstr "آیتم گونه"
 
-#: erpnext/stock/doctype/item/item.py:862
+#: erpnext/stock/doctype/item/item.py:856
 msgid "Variant Items"
 msgstr "آیتم‌های گونه"
 
@@ -58368,7 +58364,7 @@ msgstr "تنظیمات ویدیو"
 #: erpnext/accounts/doctype/cost_center/cost_center_tree.js:56
 #: erpnext/accounts/doctype/invoice_discounting/invoice_discounting.js:205
 #: erpnext/accounts/doctype/journal_entry/journal_entry.js:43
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:668
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:670
 #: erpnext/bulk_transaction/doctype/bulk_transaction_log/bulk_transaction_log.js:14
 #: erpnext/bulk_transaction/doctype/bulk_transaction_log/bulk_transaction_log.js:24
 #: erpnext/buying/doctype/request_for_quotation/request_for_quotation.js:167
@@ -58555,7 +58551,7 @@ msgstr "نام سند مالی"
 #: erpnext/accounts/doctype/repost_accounting_ledger_items/repost_accounting_ledger_items.json
 #: erpnext/accounts/doctype/repost_payment_ledger_items/repost_payment_ledger_items.json
 #: erpnext/accounts/doctype/unreconcile_payment/unreconcile_payment.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1099
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1101
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.js:42
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:209
 #: erpnext/accounts/report/general_ledger/general_ledger.js:49
@@ -58586,7 +58582,7 @@ msgstr "نام سند مالی"
 msgid "Voucher No"
 msgstr "شماره سند مالی"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1087
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1088
 msgid "Voucher No is mandatory"
 msgstr "شماره سند مالی الزامی است"
 
@@ -58628,7 +58624,7 @@ msgstr "زیرنوع سند مالی"
 #: erpnext/accounts/doctype/repost_payment_ledger_items/repost_payment_ledger_items.json
 #: erpnext/accounts/doctype/tax_withheld_vouchers/tax_withheld_vouchers.json
 #: erpnext/accounts/doctype/unreconcile_payment/unreconcile_payment.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1097
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1099
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:200
 #: erpnext/accounts/report/general_ledger/general_ledger.py:697
 #: erpnext/accounts/report/invalid_ledger_entries/invalid_ledger_entries.py:31
@@ -58982,10 +58978,6 @@ msgstr "انبار اجباری است"
 msgid "Warehouse not found against the account {0}"
 msgstr "انبار در برابر حساب {0} پیدا نشد"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:600
-msgid "Warehouse not found in the system"
-msgstr "انباری در سیستم یافت نشد"
-
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:1130
 #: erpnext/stock/doctype/delivery_note/delivery_note.py:414
 msgid "Warehouse required for stock Item {0}"
@@ -59114,7 +59106,7 @@ msgid "Warn for new Request for Quotations"
 msgstr "هشدار برای درخواست جدید برای پیش فاکتور"
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:744
-#: erpnext/controllers/accounts_controller.py:1978
+#: erpnext/controllers/accounts_controller.py:1981
 #: erpnext/stock/doctype/delivery_trip/delivery_trip.js:145
 #: erpnext/utilities/transaction_base.py:123
 msgid "Warning"
@@ -59445,7 +59437,7 @@ msgstr "وزن در واحد"
 #: erpnext/stock/doctype/packing_slip_item/packing_slip_item.json
 #: erpnext/stock/doctype/purchase_receipt_item/purchase_receipt_item.json
 msgid "Weight UOM"
-msgstr "وزن UOM"
+msgstr "UOM وزن"
 
 #. Label of the weighting_function (Small Text) field in DocType 'Supplier
 #. Scorecard'
@@ -60086,7 +60078,7 @@ msgstr "بله"
 msgid "You are importing data for the code list:"
 msgstr "شما در حال درون‌برد داده ها برای لیست کد هستید:"
 
-#: erpnext/controllers/accounts_controller.py:3611
+#: erpnext/controllers/accounts_controller.py:3614
 msgid "You are not allowed to update as per the conditions set in {} Workflow."
 msgstr "شما مجاز به به روز رسانی طبق شرایط تنظیم شده در {} گردش کار نیستید."
 
@@ -60151,7 +60143,7 @@ msgstr "می‌توانید آن را به عنوان نام ماشین یا ن�
 msgid "You can't make any changes to Job Card since Work Order is closed."
 msgstr "از آنجایی که دستور کار بسته شده است، نمی‌توانید هیچ تغییری در کارت کار ایجاد کنید."
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:185
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:186
 msgid "You can't process the serial number {0} as it has already been used in the SABB {1}. {2} if you want to inward same serial number multiple times then enabled 'Allow existing Serial No to be Manufactured/Received again' in the {3}"
 msgstr "شما نمی‌توانید شماره سریال {0} را پردازش کنید زیرا قبلاً در SABB {1} استفاده شده است. {2} اگر می‌خواهید همان شماره سریال را چندین بار دریافت کنید، گزینه 'اجازه دریافت/تولید مجدد شماره سریال موجود' را در {3} فعال کنید"
 
@@ -60211,7 +60203,7 @@ msgstr "شما نمی‌توانید سفارش را بدون پرداخت ار�
 msgid "You cannot {0} this document because another Period Closing Entry {1} exists after {2}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3587
+#: erpnext/controllers/accounts_controller.py:3590
 msgid "You do not have permissions to {} items in a {}."
 msgstr "شما مجوز {} مورد در {} را ندارید."
 
@@ -60239,7 +60231,7 @@ msgstr "شما برای همکاری در پروژه {0} دعوت شده اید.
 msgid "You have entered a duplicate Delivery Note on Row"
 msgstr "شما یک یادداشت تحویل تکراری در ردیف وارد کرده اید"
 
-#: erpnext/stock/doctype/item/item.py:1063
+#: erpnext/stock/doctype/item/item.py:1057
 msgid "You have to enable auto re-order in Stock Settings to maintain re-order levels."
 msgstr "برای حفظ سطوح سفارش مجدد، باید سفارش مجدد خودکار را در تنظیمات موجودی فعال کنید."
 
@@ -60259,7 +60251,7 @@ msgstr "قبل از افزودن یک آیتم باید مشتری را انتخ
 msgid "You need to cancel POS Closing Entry {} to be able to cancel this document."
 msgstr "برای اینکه بتوانید این سند را لغو کنید، باید ثبت اختتامیه POS {} را لغو کنید."
 
-#: erpnext/controllers/accounts_controller.py:2980
+#: erpnext/controllers/accounts_controller.py:2983
 msgid "You selected the account group {1} as {2} Account in row {0}. Please select a single account."
 msgstr ""
 
@@ -60337,7 +60329,7 @@ msgstr "[مهم] [ERPNext] خطاهای سفارش مجدد خودکار"
 msgid "`Allow Negative rates for Items`"
 msgstr "«نرخ های منفی برای آیتم‌ها مجاز است»"
 
-#: erpnext/stock/stock_ledger.py:1873
+#: erpnext/stock/stock_ledger.py:1882
 msgid "after"
 msgstr ""
 
@@ -60485,7 +60477,7 @@ msgstr "ft"
 msgid "material_request_item"
 msgstr "ماده_درخواست_آیتم"
 
-#: erpnext/controllers/selling_controller.py:151
+#: erpnext/controllers/selling_controller.py:159
 msgid "must be between 0 and 100"
 msgstr "باید بین 0 تا 100 باشد"
 
@@ -60510,7 +60502,7 @@ msgstr "old_parent"
 msgid "on"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1289
+#: erpnext/controllers/accounts_controller.py:1292
 msgid "or"
 msgstr "یا"
 
@@ -60559,7 +60551,7 @@ msgstr "برنامه پرداخت نصب نشده است لطفاً آن را ا
 msgid "per hour"
 msgstr "در ساعت"
 
-#: erpnext/stock/stock_ledger.py:1874
+#: erpnext/stock/stock_ledger.py:1883
 msgid "performing either one below:"
 msgstr "انجام هر یک از موارد زیر:"
 
@@ -60686,7 +60678,7 @@ msgstr "باید در جدول حسابها، حساب سرمایه در جری�
 msgid "{0}"
 msgstr "{0}"
 
-#: erpnext/controllers/accounts_controller.py:1109
+#: erpnext/controllers/accounts_controller.py:1112
 msgid "{0} '{1}' is disabled"
 msgstr "{0} \"{1}\" غیرفعال است"
 
@@ -60702,7 +60694,7 @@ msgstr "{0} ({1}) نمی‌تواند بیشتر از مقدار برنامه ر
 msgid "{0} <b>{1}</b> has submitted Assets. Remove Item <b>{2}</b> from table to continue."
 msgstr "{0} <b>{1}</b> دارایی‌ها را ارسال کرده است. برای ادامه، آیتم <b>{2}</b> را از جدول حذف کنید."
 
-#: erpnext/controllers/accounts_controller.py:2193
+#: erpnext/controllers/accounts_controller.py:2196
 msgid "{0} Account not found against Customer {1}."
 msgstr "{0} حساب در مقابل مشتری پیدا نشد {1}."
 
@@ -60734,7 +60726,7 @@ msgstr "{0} عملیات: {1}"
 msgid "{0} Request for {1}"
 msgstr "درخواست {0} برای {1}"
 
-#: erpnext/stock/doctype/item/item.py:323
+#: erpnext/stock/doctype/item/item.py:326
 msgid "{0} Retain Sample is based on batch, please check Has Batch No to retain sample of item"
 msgstr "{0} Retain Sample بر اساس دسته است، لطفاً شماره دسته ای را دارد تا نمونه مورد را حفظ کنید"
 
@@ -60825,7 +60817,7 @@ msgid "{0} entered twice in Item Tax"
 msgstr "{0} دو بار در مالیات آیتم وارد شد"
 
 #: erpnext/setup/doctype/item_group/item_group.py:48
-#: erpnext/stock/doctype/item/item.py:436
+#: erpnext/stock/doctype/item/item.py:439
 msgid "{0} entered twice {1} in Item Taxes"
 msgstr "{0} دو بار {1} در مالیات آیتم وارد شد"
 
@@ -60846,7 +60838,7 @@ msgstr "{0} با موفقیت ارسال شد"
 msgid "{0} hours"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2534
+#: erpnext/controllers/accounts_controller.py:2537
 msgid "{0} in row {1}"
 msgstr "{0} در ردیف {1}"
 
@@ -60870,7 +60862,7 @@ msgstr "{0} مسدود شده است بنابراین این تراکنش نمی
 
 #: erpnext/accounts/doctype/budget/budget.py:60
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:643
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:49
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:50
 #: erpnext/accounts/report/general_ledger/general_ledger.py:59
 #: erpnext/accounts/report/pos_register/pos_register.py:107
 #: erpnext/controllers/trends.py:50
@@ -60890,11 +60882,11 @@ msgstr "{0} برای حساب {1} اجباری است"
 msgid "{0} is mandatory. Maybe Currency Exchange record is not created for {1} to {2}"
 msgstr "{0} اجباری است. شاید رکورد تبدیل ارز برای {1} تا {2} ایجاد نشده باشد"
 
-#: erpnext/controllers/accounts_controller.py:2937
+#: erpnext/controllers/accounts_controller.py:2940
 msgid "{0} is mandatory. Maybe Currency Exchange record is not created for {1} to {2}."
 msgstr "{0} اجباری است. شاید رکورد تبدیل ارز برای {1} تا {2} ایجاد نشده باشد."
 
-#: erpnext/selling/doctype/customer/customer.py:204
+#: erpnext/selling/doctype/customer/customer.py:203
 msgid "{0} is not a company bank account"
 msgstr "{0} یک حساب بانکی شرکت نیست"
 
@@ -60977,7 +60969,7 @@ msgstr "{0} تعداد مورد {1} در انبار {2} با ظرفیت {3} در
 msgid "{0} to {1}"
 msgstr "{0} تا {1}"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:690
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:686
 msgid "{0} units are reserved for Item {1} in Warehouse {2}, please un-reserve the same to {3} the Stock Reconciliation."
 msgstr "{0} واحد برای مورد {1} در انبار {2} رزرو شده است، لطفاً همان را در {3} تطبیق موجودی لغو کنید."
 
@@ -60993,16 +60985,16 @@ msgstr "{0} واحد از مورد {1} در فهرست انتخاب دیگری �
 msgid "{0} units of {1} are required in {2} with the inventory dimension: {3} ({4}) on {5} {6} for {7} to complete the transaction."
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1532 erpnext/stock/stock_ledger.py:2023
-#: erpnext/stock/stock_ledger.py:2037
+#: erpnext/stock/stock_ledger.py:1541 erpnext/stock/stock_ledger.py:2031
+#: erpnext/stock/stock_ledger.py:2045
 msgid "{0} units of {1} needed in {2} on {3} {4} for {5} to complete this transaction."
 msgstr "برای تکمیل این تراکنش به {0} واحد از {1} در {2} در {3} {4} برای {5} نیاز است."
 
-#: erpnext/stock/stock_ledger.py:2124 erpnext/stock/stock_ledger.py:2170
+#: erpnext/stock/stock_ledger.py:2132 erpnext/stock/stock_ledger.py:2178
 msgid "{0} units of {1} needed in {2} on {3} {4} to complete this transaction."
 msgstr "برای تکمیل این تراکنش به {0} واحد از {1} در {2} در {3} {4} نیاز است."
 
-#: erpnext/stock/stock_ledger.py:1526
+#: erpnext/stock/stock_ledger.py:1535
 msgid "{0} units of {1} needed in {2} to complete this transaction."
 msgstr "برای تکمیل این تراکنش به {0} واحد از {1} در {2} نیاز است."
 
@@ -61048,7 +61040,7 @@ msgstr "{0} {1} ایجاد شد"
 msgid "{0} {1} does not exist"
 msgstr "{0} {1} وجود ندارد"
 
-#: erpnext/accounts/party.py:560
+#: erpnext/accounts/party.py:566
 msgid "{0} {1} has accounting entries in currency {2} for company {3}. Please select a receivable or payable account with currency {2}."
 msgstr "{0} {1} دارای ثبت‌های حسابداری به ارز {2} برای شرکت {3} است. لطفاً یک حساب دریافتنی یا پرداختنی با ارز {2} انتخاب کنید."
 
@@ -61082,7 +61074,7 @@ msgstr ""
 msgid "{0} {1} is associated with {2}, but Party Account is {3}"
 msgstr "{0} {1} با {2} مرتبط است، اما حساب طرف {3} است"
 
-#: erpnext/controllers/selling_controller.py:462
+#: erpnext/controllers/selling_controller.py:470
 #: erpnext/controllers/subcontracting_controller.py:954
 msgid "{0} {1} is cancelled or closed"
 msgstr "{0} {1} لغو یا بسته شده است"
@@ -61099,11 +61091,11 @@ msgstr "{0} {1} لغو شده است بنابراین عمل نمی‌تواند
 msgid "{0} {1} is closed"
 msgstr "{0} {1} بسته است"
 
-#: erpnext/accounts/party.py:798
+#: erpnext/accounts/party.py:804
 msgid "{0} {1} is disabled"
 msgstr "{0} {1} غیرفعال است"
 
-#: erpnext/accounts/party.py:804
+#: erpnext/accounts/party.py:810
 msgid "{0} {1} is frozen"
 msgstr "{0} {1} ثابت است"
 
@@ -61111,7 +61103,7 @@ msgstr "{0} {1} ثابت است"
 msgid "{0} {1} is fully billed"
 msgstr "{0} {1} به طور کامل صورتحساب دارد"
 
-#: erpnext/accounts/party.py:808
+#: erpnext/accounts/party.py:814
 msgid "{0} {1} is not active"
 msgstr "{0} {1} فعال نیست"
 
@@ -61237,15 +61229,15 @@ msgstr "{0}: {1} وجود ندارد"
 msgid "{0}: {1} must be less than {2}"
 msgstr "{0}: {1} باید کمتر از {2} باشد"
 
-#: erpnext/controllers/buying_controller.py:840
+#: erpnext/controllers/buying_controller.py:848
 msgid "{count} Assets created for {item_code}"
 msgstr "{count} دارایی برای {item_code} ایجاد شد"
 
-#: erpnext/controllers/buying_controller.py:738
+#: erpnext/controllers/buying_controller.py:746
 msgid "{doctype} {name} is cancelled or closed."
 msgstr "{doctype} {name} لغو یا بسته شدهه است."
 
-#: erpnext/controllers/buying_controller.py:459
+#: erpnext/controllers/buying_controller.py:467
 msgid "{field_label} is mandatory for sub-contracted {doctype}."
 msgstr "{field_label} برای قراردادهای فرعی {doctype} اجباری است."
 
@@ -61253,7 +61245,7 @@ msgstr "{field_label} برای قراردادهای فرعی {doctype} اجبا�
 msgid "{item_name}'s Sample Size ({sample_size}) cannot be greater than the Accepted Quantity ({accepted_quantity})"
 msgstr "اندازه نمونه {item_name} ({sample_size}) نمی‌تواند بیشتر از مقدار مورد قبول ({accepted_quantity}) باشد."
 
-#: erpnext/controllers/buying_controller.py:563
+#: erpnext/controllers/buying_controller.py:571
 msgid "{ref_doctype} {ref_name} is {status}."
 msgstr "{ref_doctype} {ref_name} {status} است."
 
@@ -61319,7 +61311,7 @@ msgstr "{} برای صورتحساب"
 msgid "{} can't be cancelled since the Loyalty Points earned has been redeemed. First cancel the {} No {}"
 msgstr "{} را نمی‌توان لغو کرد زیرا امتیازهای وفاداری به دست آمده استفاده شده است. ابتدا {} خیر {} را لغو کنید"
 
-#: erpnext/controllers/buying_controller.py:222
+#: erpnext/controllers/buying_controller.py:230
 msgid "{} has submitted assets linked to it. You need to cancel the assets to create purchase return."
 msgstr "{} دارایی های مرتبط با آن را ارسال کرده است. برای ایجاد بازگشت خرید، باید دارایی ها را لغو کنید."
 

--- a/erpnext/locale/fr.po
+++ b/erpnext/locale/fr.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: frappe\n"
 "Report-Msgid-Bugs-To: hello@frappe.io\n"
-"POT-Creation-Date: 2025-05-25 09:35+0000\n"
-"PO-Revision-Date: 2025-05-25 20:34\n"
+"POT-Creation-Date: 2025-06-01 09:36+0000\n"
+"PO-Revision-Date: 2025-06-01 21:35\n"
 "Last-Translator: hello@frappe.io\n"
 "Language-Team: French\n"
 "MIME-Version: 1.0\n"
@@ -83,15 +83,15 @@ msgstr " Sous-Ruche"
 msgid " Summary"
 msgstr " Résumé"
 
-#: erpnext/stock/doctype/item/item.py:235
+#: erpnext/stock/doctype/item/item.py:238
 msgid "\"Customer Provided Item\" cannot be Purchase Item also"
 msgstr "Un \"article fourni par un client\" ne peut pas être également un article d'achat"
 
-#: erpnext/stock/doctype/item/item.py:237
+#: erpnext/stock/doctype/item/item.py:240
 msgid "\"Customer Provided Item\" cannot have Valuation Rate"
 msgstr "Un \"article fourni par un client\" ne peut pas avoir de taux de valorisation"
 
-#: erpnext/stock/doctype/item/item.py:313
+#: erpnext/stock/doctype/item/item.py:316
 msgid "\"Is Fixed Asset\" cannot be unchecked, as Asset record exists against the item"
 msgstr "'Est un Actif Immobilisé’ doit être coché car il existe une entrée d’Actif pour cet article"
 
@@ -213,7 +213,7 @@ msgstr "% de matériaux facturés sur cette commande de vente"
 msgid "% of materials delivered against this Sales Order"
 msgstr "% de matériaux livrés par rapport à cette commande"
 
-#: erpnext/controllers/accounts_controller.py:2197
+#: erpnext/controllers/accounts_controller.py:2200
 msgid "'Account' in the Accounting section of Customer {0}"
 msgstr "'Compte' dans la section comptabilité du client {0}"
 
@@ -225,15 +225,11 @@ msgstr "Autoriser les commandes multiples contre un bon de commande du client'"
 msgid "'Based On' and 'Group By' can not be same"
 msgstr "'Basé sur' et 'Groupé par' ne peuvent pas être identiques"
 
-#: erpnext/stock/report/product_bundle_balance/product_bundle_balance.py:233
-msgid "'Date' is required"
-msgstr "La 'date' est obligatoire"
-
 #: erpnext/selling/report/inactive_customers/inactive_customers.py:18
 msgid "'Days Since Last Order' must be greater than or equal to zero"
 msgstr "'Jours Depuis La Dernière Commande' doit être supérieur ou égal à zéro"
 
-#: erpnext/controllers/accounts_controller.py:2202
+#: erpnext/controllers/accounts_controller.py:2205
 msgid "'Default {0} Account' in Company {1}"
 msgstr "'Compte {0} par défaut' dans la société {1}"
 
@@ -243,7 +239,7 @@ msgstr "'Entrées' ne peuvent pas être vides"
 
 #: erpnext/stock/report/batch_item_expiry_status/batch_item_expiry_status.py:24
 #: erpnext/stock/report/batch_wise_balance_history/batch_wise_balance_history.py:120
-#: erpnext/stock/report/stock_analytics/stock_analytics.py:314
+#: erpnext/stock/report/stock_analytics/stock_analytics.py:313
 msgid "'From Date' is required"
 msgstr "'Date début' est requise"
 
@@ -251,7 +247,7 @@ msgstr "'Date début' est requise"
 msgid "'From Date' must be after 'To Date'"
 msgstr "La ‘Du (date)’ doit être antérieure à la ‘Au (date) ’"
 
-#: erpnext/stock/doctype/item/item.py:398
+#: erpnext/stock/doctype/item/item.py:401
 msgid "'Has Serial No' can not be 'Yes' for non-stock item"
 msgstr "'A un Numéro de Série' ne peut pas être 'Oui' pour un article non géré en stock"
 
@@ -1099,7 +1095,7 @@ msgstr "Quantité acceptée en UOM de Stock"
 
 #. Label of the qty (Float) field in DocType 'Purchase Receipt Item'
 #. Label of the qty (Float) field in DocType 'Subcontracting Receipt Item'
-#: erpnext/public/js/controllers/transaction.js:2362
+#: erpnext/public/js/controllers/transaction.js:2388
 #: erpnext/stock/doctype/purchase_receipt_item/purchase_receipt_item.json
 #: erpnext/subcontracting/doctype/subcontracting_receipt_item/subcontracting_receipt_item.json
 msgid "Accepted Quantity"
@@ -1297,7 +1293,7 @@ msgid "Account Manager"
 msgstr "Gestionnaire de la comptabilité"
 
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:949
-#: erpnext/controllers/accounts_controller.py:2206
+#: erpnext/controllers/accounts_controller.py:2209
 msgid "Account Missing"
 msgstr "Compte comptable manquant"
 
@@ -1472,7 +1468,7 @@ msgstr "Le compte {0} est ajouté dans la société enfant {1}."
 msgid "Account {0} is frozen"
 msgstr "Le compte {0} est gelé"
 
-#: erpnext/controllers/accounts_controller.py:1288
+#: erpnext/controllers/accounts_controller.py:1291
 msgid "Account {0} is invalid. Account Currency must be {1}"
 msgstr "Le compte {0} est invalide. La Devise du Compte doit être {1}"
 
@@ -1508,7 +1504,7 @@ msgstr "Compte : {0} peut uniquement être mis à jour via les Mouvements de Sto
 msgid "Account: {0} is not permitted under Payment Entry"
 msgstr "Compte: {0} n'est pas autorisé sous Saisie du paiement."
 
-#: erpnext/controllers/accounts_controller.py:3037
+#: erpnext/controllers/accounts_controller.py:3040
 msgid "Account: {0} with currency: {1} can not be selected"
 msgstr "Compte : {0} avec la devise : {1} ne peut pas être sélectionné"
 
@@ -1781,7 +1777,7 @@ msgstr "Écritures Comptables"
 msgid "Accounting Entry for Asset"
 msgstr "Ecriture comptable pour l'actif"
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:796
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:805
 msgid "Accounting Entry for Service"
 msgstr "Écriture comptable pour le service"
 
@@ -1796,18 +1792,18 @@ msgstr "Écriture comptable pour le service"
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py:1468
 #: erpnext/controllers/stock_controller.py:550
 #: erpnext/controllers/stock_controller.py:567
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:889
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:898
 #: erpnext/stock/doctype/stock_entry/stock_entry.py:1586
 #: erpnext/stock/doctype/stock_entry/stock_entry.py:1600
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py:561
 msgid "Accounting Entry for Stock"
 msgstr "Ecriture comptable pour stock"
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:717
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:726
 msgid "Accounting Entry for {0}"
 msgstr "Entrée comptable pour {0}"
 
-#: erpnext/controllers/accounts_controller.py:2247
+#: erpnext/controllers/accounts_controller.py:2250
 msgid "Accounting Entry for {0}: {1} can only be made in currency: {2}"
 msgstr "Écriture Comptable pour {0}: {1} ne peut être effectuée qu'en devise: {2}"
 
@@ -2200,7 +2196,7 @@ msgstr "Amortissement Cumulé depuis"
 msgid "Accumulated Monthly"
 msgstr "Cumul mensuel"
 
-#: erpnext/controllers/budget_controller.py:417
+#: erpnext/controllers/budget_controller.py:422
 msgid "Accumulated Monthly Budget for Account {0} against {1} {2} is {3}. It will be collectively ({4}) exceeded by {5}"
 msgstr ""
 
@@ -3314,7 +3310,7 @@ msgstr "Ajuster la valeur de l'actif"
 msgid "Adjustment Against"
 msgstr "Ajustement pour"
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:634
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:643
 msgid "Adjustment based on Purchase Invoice rate"
 msgstr "Ajustement basé sur le taux de la facture d'achat"
 
@@ -3425,7 +3421,7 @@ msgstr ""
 msgid "Advance amount"
 msgstr "Montant de l'Avance"
 
-#: erpnext/controllers/taxes_and_totals.py:845
+#: erpnext/controllers/taxes_and_totals.py:855
 msgid "Advance amount cannot be greater than {0} {1}"
 msgstr "Montant de l'avance ne peut être supérieur à {0} {1}"
 
@@ -3636,7 +3632,7 @@ msgstr "Âge"
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:152
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:133
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1125
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1127
 msgid "Age (Days)"
 msgstr "Age (jours)"
 
@@ -3722,16 +3718,6 @@ msgstr ""
 #: erpnext/setup/setup_wizard/data/industry_type.txt:4
 msgid "Agriculture"
 msgstr ""
-
-#. Name of a role
-#: erpnext/assets/doctype/location/location.json
-msgid "Agriculture Manager"
-msgstr "Directeur de l'agriculture"
-
-#. Name of a role
-#: erpnext/assets/doctype/location/location.json
-msgid "Agriculture User"
-msgstr "Agriculteur"
 
 #: erpnext/setup/setup_wizard/data/industry_type.txt:5
 msgid "Airline"
@@ -3923,7 +3909,7 @@ msgstr "Toutes les communications, celle-ci et celles au dessus de celle-ci incl
 msgid "All items are already requested"
 msgstr ""
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:1317
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:1326
 msgid "All items have already been Invoiced/Returned"
 msgstr "Tous les articles ont déjà été facturés / retournés"
 
@@ -3935,7 +3921,7 @@ msgstr ""
 msgid "All items have already been transferred for this Work Order."
 msgstr "Tous les articles ont déjà été transférés pour cet ordre de fabrication."
 
-#: erpnext/public/js/controllers/transaction.js:2465
+#: erpnext/public/js/controllers/transaction.js:2491
 msgid "All items in this document already have a linked Quality Inspection."
 msgstr ""
 
@@ -4133,7 +4119,7 @@ msgstr ""
 msgid "Allow Item To Be Added Multiple Times in a Transaction"
 msgstr "Autoriser l'ajout d'un article plusieurs fois dans une transaction"
 
-#: erpnext/controllers/selling_controller.py:755
+#: erpnext/controllers/selling_controller.py:763
 msgid "Allow Item to Be Added Multiple Times in a Transaction"
 msgstr ""
 
@@ -5079,7 +5065,7 @@ msgstr "Annuel"
 msgid "Annual Billing: {0}"
 msgstr "Facturation Annuelle : {0}"
 
-#: erpnext/controllers/budget_controller.py:441
+#: erpnext/controllers/budget_controller.py:446
 msgid "Annual Budget for Account {0} against {1} {2} is {3}. It will be collectively ({4}) exceeded by {5}"
 msgstr ""
 
@@ -5568,7 +5554,7 @@ msgstr "Comme le champ {0} est activé, le champ {1} est obligatoire."
 msgid "As the field {0} is enabled, the value of the field {1} should be more than 1."
 msgstr "Lorsque le champ {0} est activé, la valeur du champ {1} doit être supérieure à 1."
 
-#: erpnext/stock/doctype/item/item.py:989
+#: erpnext/stock/doctype/item/item.py:983
 msgid "As there are existing submitted transactions against item {0}, you can not change the value of {1}."
 msgstr ""
 
@@ -5714,7 +5700,7 @@ msgstr "Compte de Catégorie d'Actif"
 msgid "Asset Category Name"
 msgstr "Nom de Catégorie d'Actif"
 
-#: erpnext/stock/doctype/item/item.py:304
+#: erpnext/stock/doctype/item/item.py:307
 msgid "Asset Category is mandatory for Fixed Asset item"
 msgstr "Catégorie d'Actif est obligatoire pour l'article Immobilisé"
 
@@ -6089,7 +6075,7 @@ msgstr ""
 msgid "Asset {0} must be submitted"
 msgstr "L'actif {0} doit être soumis"
 
-#: erpnext/controllers/buying_controller.py:851
+#: erpnext/controllers/buying_controller.py:859
 msgid "Asset {assets_link} created for {item_code}"
 msgstr ""
 
@@ -6119,11 +6105,11 @@ msgstr ""
 msgid "Assets"
 msgstr "Actifs - Immo."
 
-#: erpnext/controllers/buying_controller.py:869
+#: erpnext/controllers/buying_controller.py:877
 msgid "Assets not created for {item_code}. You will have to create asset manually."
 msgstr "Éléments non créés pour {item_code}. Vous devrez créer un actif manuellement."
 
-#: erpnext/controllers/buying_controller.py:856
+#: erpnext/controllers/buying_controller.py:864
 msgid "Assets {assets_link} created for {item_code}"
 msgstr ""
 
@@ -6218,7 +6204,7 @@ msgstr "À la ligne n ° {0}: l'ID de séquence {1} ne peut pas être inférieur
 msgid "At row #{0}: you have selected the Difference Account {1}, which is a Cost of Goods Sold type account. Please select a different account"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:864
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:865
 msgid "At row {0}: Batch No is mandatory for Item {1}"
 msgstr ""
 
@@ -6226,11 +6212,11 @@ msgstr ""
 msgid "At row {0}: Parent Row No cannot be set for item {1}"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:849
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:850
 msgid "At row {0}: Qty is mandatory for the batch {1}"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:856
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:857
 msgid "At row {0}: Serial No is mandatory for Item {1}"
 msgstr ""
 
@@ -6304,7 +6290,7 @@ msgstr "Nom de l'Attribut"
 msgid "Attribute Value"
 msgstr "Valeur de l'Attribut"
 
-#: erpnext/stock/doctype/item/item.py:930
+#: erpnext/stock/doctype/item/item.py:924
 msgid "Attribute table is mandatory"
 msgstr "Table d'Attribut est obligatoire"
 
@@ -6312,11 +6298,11 @@ msgstr "Table d'Attribut est obligatoire"
 msgid "Attribute value: {0} must appear only once"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:934
+#: erpnext/stock/doctype/item/item.py:928
 msgid "Attribute {0} selected multiple times in Attributes Table"
 msgstr "Attribut {0} sélectionné à plusieurs reprises dans le Tableau des Attributs"
 
-#: erpnext/stock/doctype/item/item.py:862
+#: erpnext/stock/doctype/item/item.py:856
 msgid "Attributes"
 msgstr "Attributs"
 
@@ -7600,11 +7586,11 @@ msgstr "code à barre"
 msgid "Barcode Type"
 msgstr "Type de code-barres"
 
-#: erpnext/stock/doctype/item/item.py:457
+#: erpnext/stock/doctype/item/item.py:460
 msgid "Barcode {0} already used in Item {1}"
 msgstr "Le Code Barre {0} est déjà utilisé dans l'article {1}"
 
-#: erpnext/stock/doctype/item/item.py:472
+#: erpnext/stock/doctype/item/item.py:475
 msgid "Barcode {0} is not a valid {1} code"
 msgstr "Le code-barres {0} n'est pas un code {1} valide"
 
@@ -7858,7 +7844,7 @@ msgstr "Statut d'Expiration d'Article du Lot"
 #: erpnext/manufacturing/doctype/job_card/job_card.json
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.js:89
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.py:115
-#: erpnext/public/js/controllers/transaction.js:2388
+#: erpnext/public/js/controllers/transaction.js:2414
 #: erpnext/public/js/utils/barcode_scanner.js:260
 #: erpnext/public/js/utils/serial_no_batch_selector.js:438
 #: erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
@@ -7885,11 +7871,11 @@ msgstr "Statut d'Expiration d'Article du Lot"
 msgid "Batch No"
 msgstr "N° du Lot"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:867
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:868
 msgid "Batch No is mandatory"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2629
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2630
 msgid "Batch No {0} does not exists"
 msgstr ""
 
@@ -7897,7 +7883,7 @@ msgstr ""
 msgid "Batch No {0} is linked with Item {1} which has serial no. Please scan serial no instead."
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:364
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:365
 msgid "Batch No {0} is not present in the original {1} {2}, hence you can't return it against the {1} {2}"
 msgstr ""
 
@@ -7912,11 +7898,11 @@ msgstr ""
 msgid "Batch Nos"
 msgstr "Numéros de lots"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1421
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1422
 msgid "Batch Nos are created successfully"
 msgstr ""
 
-#: erpnext/controllers/sales_and_purchase_return.py:1096
+#: erpnext/controllers/sales_and_purchase_return.py:1001
 msgid "Batch Not Available for Return"
 msgstr ""
 
@@ -7965,7 +7951,7 @@ msgstr ""
 msgid "Batch {0} and Warehouse"
 msgstr ""
 
-#: erpnext/controllers/sales_and_purchase_return.py:1095
+#: erpnext/controllers/sales_and_purchase_return.py:1000
 msgid "Batch {0} is not available in warehouse {1}"
 msgstr ""
 
@@ -8015,7 +8001,7 @@ msgstr ""
 #. Label of the bill_date (Date) field in DocType 'Journal Entry'
 #. Label of the bill_date (Date) field in DocType 'Subcontracting Receipt'
 #: erpnext/accounts/doctype/journal_entry/journal_entry.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1110
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1112
 #: erpnext/accounts/report/purchase_register/purchase_register.py:214
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.json
 msgid "Bill Date"
@@ -8024,7 +8010,7 @@ msgstr "Date de la Facture"
 #. Label of the bill_no (Data) field in DocType 'Journal Entry'
 #. Label of the bill_no (Data) field in DocType 'Subcontracting Receipt'
 #: erpnext/accounts/doctype/journal_entry/journal_entry.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1109
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1111
 #: erpnext/accounts/report/purchase_register/purchase_register.py:213
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.json
 msgid "Bill No"
@@ -8244,7 +8230,7 @@ msgstr "Statut de la Facturation"
 msgid "Billing Zipcode"
 msgstr "Code postal de facturation"
 
-#: erpnext/accounts/party.py:602
+#: erpnext/accounts/party.py:608
 msgid "Billing currency must be equal to either default company's currency or party account currency"
 msgstr "La devise de facturation doit être égale à la devise de la société par défaut ou à la devise du compte du partenaire"
 
@@ -9241,7 +9227,7 @@ msgid "Can only make payment against unbilled {0}"
 msgstr "Le paiement n'est possible qu'avec les {0} non facturés"
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1458
-#: erpnext/controllers/accounts_controller.py:2946
+#: erpnext/controllers/accounts_controller.py:2949
 #: erpnext/public/js/controllers/accounts.js:90
 msgid "Can refer row only if the charge type is 'On Previous Row Amount' or 'Previous Row Total'"
 msgstr "Peut se référer à ligne seulement si le type de charge est 'Montant de la ligne précedente' ou 'Total des lignes précedente'"
@@ -9403,9 +9389,9 @@ msgstr "Impossible de calculer l'heure d'arrivée car l'adresse du conducteur es
 msgid "Cannot Create Return"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:625
-#: erpnext/stock/doctype/item/item.py:638
-#: erpnext/stock/doctype/item/item.py:652
+#: erpnext/stock/doctype/item/item.py:631
+#: erpnext/stock/doctype/item/item.py:644
+#: erpnext/stock/doctype/item/item.py:658
 msgid "Cannot Merge"
 msgstr ""
 
@@ -9429,7 +9415,7 @@ msgstr ""
 msgid "Cannot apply TDS against multiple parties in one entry"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:307
+#: erpnext/stock/doctype/item/item.py:310
 msgid "Cannot be a fixed asset item as Stock Ledger is created."
 msgstr "Ne peut pas être un article immobilisé car un Journal de Stock a été créé."
 
@@ -9445,7 +9431,7 @@ msgstr "Impossible d'annuler car l'Écriture de Stock soumise {0} existe"
 msgid "Cannot cancel the transaction. Reposting of item valuation on submission is not completed yet."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:959
+#: erpnext/controllers/buying_controller.py:967
 msgid "Cannot cancel this document as it is linked with the submitted asset {asset_link}. Please cancel the asset to continue."
 msgstr ""
 
@@ -9453,7 +9439,7 @@ msgstr ""
 msgid "Cannot cancel transaction for Completed Work Order."
 msgstr "Impossible d'annuler la transaction lorsque l'ordre de fabrication est terminé."
 
-#: erpnext/stock/doctype/item/item.py:882
+#: erpnext/stock/doctype/item/item.py:876
 msgid "Cannot change Attributes after stock transaction. Make a new Item and transfer stock to the new Item"
 msgstr "Impossible de modifier les attributs après des mouvements de stock. Faites un nouvel article et transférez la quantité en stock au nouvel article"
 
@@ -9469,7 +9455,7 @@ msgstr ""
 msgid "Cannot change Service Stop Date for item in row {0}"
 msgstr "Impossible de modifier la date d'arrêt du service pour l'élément de la ligne {0}"
 
-#: erpnext/stock/doctype/item/item.py:873
+#: erpnext/stock/doctype/item/item.py:867
 msgid "Cannot change Variant properties after stock transaction. You will have to make a new Item to do this."
 msgstr "Impossible de modifier les propriétés de variante après une transaction de stock. Vous devrez créer un nouvel article pour pouvoir le faire."
 
@@ -9497,7 +9483,7 @@ msgstr ""
 msgid "Cannot covert to Group because Account Type is selected."
 msgstr "Conversion impossible en Groupe car le Type de Compte est sélectionné."
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:972
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:981
 msgid "Cannot create Stock Reservation Entries for future dated Purchase Receipts."
 msgstr ""
 
@@ -9548,7 +9534,7 @@ msgstr "Impossible de garantir la livraison par numéro de série car l'article 
 msgid "Cannot find Item with this Barcode"
 msgstr "Impossible de trouver l'article avec ce code-barres"
 
-#: erpnext/controllers/accounts_controller.py:3483
+#: erpnext/controllers/accounts_controller.py:3486
 msgid "Cannot find a default warehouse for item {0}. Please set one in the Item Master or in Stock Settings."
 msgstr ""
 
@@ -9556,7 +9542,7 @@ msgstr ""
 msgid "Cannot make any transactions until the deletion job is completed"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2074
+#: erpnext/controllers/accounts_controller.py:2077
 msgid "Cannot overbill for Item {0} in row {1} more than {2}. To allow over-billing, please set allowance in Accounts Settings"
 msgstr "La surfacturation pour le poste {0} dans la ligne {1} ne peut pas dépasser {2}. Pour autoriser la surfacturation, définissez la provision dans les paramètres du compte."
 
@@ -9577,7 +9563,7 @@ msgid "Cannot receive from customer against negative outstanding"
 msgstr ""
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1475
-#: erpnext/controllers/accounts_controller.py:2961
+#: erpnext/controllers/accounts_controller.py:2964
 #: erpnext/public/js/controllers/accounts.js:100
 msgid "Cannot refer row number greater than or equal to current row number for this Charge type"
 msgstr "Impossible de se référer au numéro de la ligne supérieure ou égale au numéro de la ligne courante pour ce type de Charge"
@@ -9593,7 +9579,7 @@ msgstr ""
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1467
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1646
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:1917
-#: erpnext/controllers/accounts_controller.py:2951
+#: erpnext/controllers/accounts_controller.py:2954
 #: erpnext/public/js/controllers/accounts.js:94
 #: erpnext/public/js/controllers/taxes_and_totals.js:470
 msgid "Cannot select charge type as 'On Previous Row Amount' or 'On Previous Row Total' for first row"
@@ -9607,15 +9593,15 @@ msgstr "Impossible de définir comme perdu alors qu'une Commande client a été 
 msgid "Cannot set authorization on basis of Discount for {0}"
 msgstr "Impossible de définir l'autorisation sur la base des Prix Réduits pour {0}"
 
-#: erpnext/stock/doctype/item/item.py:716
+#: erpnext/stock/doctype/item/item.py:722
 msgid "Cannot set multiple Item Defaults for a company."
 msgstr "Impossible de définir plusieurs valeurs par défaut pour une entreprise."
 
-#: erpnext/controllers/accounts_controller.py:3631
+#: erpnext/controllers/accounts_controller.py:3634
 msgid "Cannot set quantity less than delivered quantity"
 msgstr "Impossible de définir une quantité inférieure à la quantité livrée"
 
-#: erpnext/controllers/accounts_controller.py:3634
+#: erpnext/controllers/accounts_controller.py:3637
 msgid "Cannot set quantity less than received quantity"
 msgstr "Impossible de définir une quantité inférieure à la quantité reçue"
 
@@ -10038,7 +10024,7 @@ msgid "Channel Partner"
 msgstr "Partenaire de Canal"
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:2346
-#: erpnext/controllers/accounts_controller.py:3014
+#: erpnext/controllers/accounts_controller.py:3017
 msgid "Charge of type 'Actual' in row {0} cannot be included in Item Rate or Paid Amount"
 msgstr ""
 
@@ -10221,7 +10207,7 @@ msgstr "Largeur du Chèque"
 
 #. Label of the reference_date (Date) field in DocType 'Payment Entry'
 #: erpnext/accounts/doctype/payment_entry/payment_entry.json
-#: erpnext/public/js/controllers/transaction.js:2299
+#: erpnext/public/js/controllers/transaction.js:2325
 msgid "Cheque/Reference Date"
 msgstr "Chèque/Date de Référence"
 
@@ -10269,7 +10255,7 @@ msgstr "Nom de l'enfant"
 
 #. Label of the child_row_reference (Data) field in DocType 'Quality
 #. Inspection'
-#: erpnext/public/js/controllers/transaction.js:2394
+#: erpnext/public/js/controllers/transaction.js:2420
 #: erpnext/stock/doctype/quality_inspection/quality_inspection.json
 msgid "Child Row Reference"
 msgstr ""
@@ -10981,7 +10967,7 @@ msgstr "Sociétés"
 #: erpnext/accounts/report/cheques_and_deposits_incorrectly_cleared/cheques_and_deposits_incorrectly_cleared.js:8
 #: erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.js:8
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:8
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:49
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:50
 #: erpnext/accounts/report/deferred_revenue_and_expense/deferred_revenue_and_expense.js:8
 #: erpnext/accounts/report/delivered_items_to_be_billed/delivered_items_to_be_billed.js:7
 #: erpnext/accounts/report/dimension_wise_accounts_balance_report/dimension_wise_accounts_balance_report.js:8
@@ -12214,7 +12200,7 @@ msgid "Content Type"
 msgstr "Type de Contenu"
 
 #: erpnext/erpnext_integrations/doctype/plaid_settings/plaid_settings.js:162
-#: erpnext/public/js/controllers/transaction.js:2312
+#: erpnext/public/js/controllers/transaction.js:2338
 #: erpnext/selling/doctype/quotation/quotation.js:356
 msgid "Continue"
 msgstr "Continuer"
@@ -12379,7 +12365,7 @@ msgstr "Facteur de Conversion"
 msgid "Conversion Rate"
 msgstr "Taux de Conversion"
 
-#: erpnext/stock/doctype/item/item.py:393
+#: erpnext/stock/doctype/item/item.py:396
 msgid "Conversion factor for default Unit of Measure must be 1 in row {0}"
 msgstr "Facteur de conversion de l'Unité de Mesure par défaut doit être 1 dans la ligne {0}"
 
@@ -12387,15 +12373,15 @@ msgstr "Facteur de conversion de l'Unité de Mesure par défaut doit être 1 dan
 msgid "Conversion factor for item {0} has been reset to 1.0 as the uom {1} is same as stock uom {2}."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2767
+#: erpnext/controllers/accounts_controller.py:2770
 msgid "Conversion rate cannot be 0"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2774
+#: erpnext/controllers/accounts_controller.py:2777
 msgid "Conversion rate is 1.00, but document currency is different from company currency"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2770
+#: erpnext/controllers/accounts_controller.py:2773
 msgid "Conversion rate must be 1.00 if document currency is same as company currency"
 msgstr ""
 
@@ -12608,7 +12594,7 @@ msgstr "Coût"
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:28
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:40
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:30
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1096
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1098
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:40
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.js:42
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.py:197
@@ -12701,7 +12687,7 @@ msgid "Cost Center is a part of Cost Center Allocation, hence cannot be converte
 msgstr ""
 
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py:1411
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:855
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:864
 msgid "Cost Center is required in row {0} in Taxes table for type {1}"
 msgstr "Le Centre de Coûts est requis à la ligne {0} dans le tableau des Taxes pour le type {1}"
 
@@ -12970,8 +12956,8 @@ msgstr ""
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:132
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:143
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:219
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:654
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:678
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:656
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:680
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.js:88
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.js:89
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.js:103
@@ -13028,8 +13014,8 @@ msgstr ""
 #: erpnext/projects/doctype/task/task_tree.js:81
 #: erpnext/public/js/communication.js:19 erpnext/public/js/communication.js:31
 #: erpnext/public/js/communication.js:41
-#: erpnext/public/js/controllers/transaction.js:336
-#: erpnext/public/js/controllers/transaction.js:2435
+#: erpnext/public/js/controllers/transaction.js:362
+#: erpnext/public/js/controllers/transaction.js:2461
 #: erpnext/selling/doctype/customer/customer.js:181
 #: erpnext/selling/doctype/quotation/quotation.js:124
 #: erpnext/selling/doctype/quotation/quotation.js:133
@@ -13324,7 +13310,7 @@ msgstr ""
 msgid "Create a variant with the template image."
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1877
+#: erpnext/stock/stock_ledger.py:1886
 msgid "Create an incoming stock transaction for the Item."
 msgstr "Créez une transaction de stock entrante pour l'article."
 
@@ -13384,7 +13370,7 @@ msgstr ""
 msgid "Creating Purchase Order ..."
 msgstr "Création d'une commande d'achat ..."
 
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:735
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:737
 #: erpnext/buying/doctype/purchase_order/purchase_order.js:552
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.js:73
 msgid "Creating Purchase Receipt ..."
@@ -13578,7 +13564,7 @@ msgstr "Mois de crédit"
 #: erpnext/accounts/doctype/journal_entry_template/journal_entry_template.json
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:174
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:147
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1119
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1121
 #: erpnext/controllers/sales_and_purchase_return.py:373
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:286
 #: erpnext/stock/doctype/delivery_note/delivery_note.js:89
@@ -13613,7 +13599,7 @@ msgstr "La note de crédit {0} a été créée automatiquement"
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py:368
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py:376
-#: erpnext/controllers/accounts_controller.py:2186
+#: erpnext/controllers/accounts_controller.py:2189
 msgid "Credit To"
 msgstr "À Créditer"
 
@@ -13798,7 +13784,7 @@ msgstr ""
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/subscription_plan/subscription_plan.json
 #: erpnext/accounts/report/account_balance/account_balance.py:28
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1129
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1131
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:205
 #: erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.py:101
 #: erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.js:118
@@ -14327,7 +14313,7 @@ msgstr "Code Client"
 #. Label of the customer_contact_display (Small Text) field in DocType
 #. 'Purchase Order'
 #. Label of the customer_contact (Small Text) field in DocType 'Delivery Stop'
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1090
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1092
 #: erpnext/buying/doctype/purchase_order/purchase_order.json
 #: erpnext/stock/doctype/delivery_stop/delivery_stop.json
 msgid "Customer Contact"
@@ -14423,7 +14409,7 @@ msgstr "Retour d'Expérience Client"
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/tax_rule/tax_rule.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:107
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1147
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1149
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:81
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:185
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:56
@@ -14467,7 +14453,7 @@ msgstr ""
 msgid "Customer Group Name"
 msgstr "Nom du Groupe Client"
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1239
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1241
 msgid "Customer Group: {0} does not exist"
 msgstr ""
 
@@ -14486,7 +14472,7 @@ msgstr ""
 msgid "Customer Items"
 msgstr "Articles du clients"
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1138
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1140
 msgid "Customer LPO"
 msgstr "Commande client locale"
 
@@ -14532,7 +14518,7 @@ msgstr "N° de Portable du Client"
 #: erpnext/accounts/doctype/pos_invoice/pos_invoice.json
 #: erpnext/accounts/doctype/process_statement_of_accounts_customer/process_statement_of_accounts_customer.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1080
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1082
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:156
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:92
 #: erpnext/accounts/report/delivered_items_to_be_billed/delivered_items_to_be_billed.py:35
@@ -15210,7 +15196,7 @@ msgstr ""
 #: erpnext/accounts/doctype/journal_entry_template/journal_entry_template.json
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:176
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:147
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1122
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1124
 #: erpnext/controllers/sales_and_purchase_return.py:377
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:287
 #: erpnext/stock/doctype/purchase_receipt/purchase_receipt.js:61
@@ -15239,7 +15225,7 @@ msgstr ""
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:953
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:964
-#: erpnext/controllers/accounts_controller.py:2186
+#: erpnext/controllers/accounts_controller.py:2189
 msgid "Debit To"
 msgstr "Débit Pour"
 
@@ -15272,11 +15258,11 @@ msgstr ""
 msgid "Debit-Credit mismatch"
 msgstr ""
 
-#: erpnext/accounts/party.py:609
+#: erpnext/accounts/party.py:615
 msgid "Debtor/Creditor"
 msgstr ""
 
-#: erpnext/accounts/party.py:612
+#: erpnext/accounts/party.py:618
 msgid "Debtor/Creditor Advance"
 msgstr ""
 
@@ -15396,7 +15382,7 @@ msgstr ""
 msgid "Default BOM"
 msgstr "Nomenclature par Défaut"
 
-#: erpnext/stock/doctype/item/item.py:418
+#: erpnext/stock/doctype/item/item.py:421
 msgid "Default BOM ({0}) must be active for this item or its template"
 msgstr "Nomenclature par défaut ({0}) doit être actif pour ce produit ou son modèle"
 
@@ -15404,7 +15390,7 @@ msgstr "Nomenclature par défaut ({0}) doit être actif pour ce produit ou son m
 msgid "Default BOM for {0} not found"
 msgstr "Nomenclature par défaut {0} introuvable"
 
-#: erpnext/controllers/accounts_controller.py:3672
+#: erpnext/controllers/accounts_controller.py:3675
 msgid "Default BOM not found for FG Item {0}"
 msgstr ""
 
@@ -15739,15 +15725,15 @@ msgstr "Région par Défaut"
 msgid "Default Unit of Measure"
 msgstr "Unité de Mesure par Défaut"
 
-#: erpnext/stock/doctype/item/item.py:1272
+#: erpnext/stock/doctype/item/item.py:1266
 msgid "Default Unit of Measure for Item {0} cannot be changed directly because you have already made some transaction(s) with another UOM. You need to either cancel the linked documents or create a new Item."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1255
+#: erpnext/stock/doctype/item/item.py:1249
 msgid "Default Unit of Measure for Item {0} cannot be changed directly because you have already made some transaction(s) with another UOM. You will need to create a new Item to use a different Default UOM."
 msgstr "L’Unité de Mesure par Défaut pour l’Article {0} ne peut pas être modifiée directement parce que vous avez déjà fait une (des) transaction (s) avec une autre unité de mesure. Vous devez créer un nouvel article pour utiliser une UdM par défaut différente."
 
-#: erpnext/stock/doctype/item/item.py:908
+#: erpnext/stock/doctype/item/item.py:902
 msgid "Default Unit of Measure for Variant '{0}' must be same as in Template '{1}'"
 msgstr "L’Unité de mesure par défaut pour la variante '{0}' doit être la même que dans le Modèle '{1}'"
 
@@ -16206,7 +16192,7 @@ msgstr "Tendance des Bordereaux de Livraisons"
 msgid "Delivery Note {0} is not submitted"
 msgstr "Bon de Livraison {0} n'est pas soumis"
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1142
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1144
 #: erpnext/stock/doctype/delivery_trip/delivery_trip.js:73
 msgid "Delivery Notes"
 msgstr "Bons de livraison"
@@ -16737,7 +16723,7 @@ msgstr ""
 #: erpnext/projects/doctype/task_type/task_type.json
 #: erpnext/projects/doctype/timesheet_detail/timesheet_detail.json
 #: erpnext/public/js/bank_reconciliation_tool/data_table_manager.js:55
-#: erpnext/public/js/controllers/transaction.js:2376
+#: erpnext/public/js/controllers/transaction.js:2402
 #: erpnext/selling/doctype/installation_note_item/installation_note_item.json
 #: erpnext/selling/doctype/product_bundle/product_bundle.json
 #: erpnext/selling/doctype/product_bundle_item/product_bundle_item.json
@@ -16925,7 +16911,7 @@ msgstr ""
 msgid "Difference Account must be a Asset/Liability type account (Temporary Opening), since this Stock Entry is an Opening Entry"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:954
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:950
 msgid "Difference Account must be a Asset/Liability type account, since this Stock Reconciliation is an Opening Entry"
 msgstr "Le Compte d’Écart doit être un compte de type Actif / Passif, puisque cette Réconciliation de Stock est une écriture d'à-nouveau"
 
@@ -17191,11 +17177,11 @@ msgstr ""
 msgid "Disabled Warehouse {0} cannot be used for this transaction."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:745
+#: erpnext/controllers/accounts_controller.py:748
 msgid "Disabled pricing rules since this {} is an internal transfer"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:759
+#: erpnext/controllers/accounts_controller.py:762
 msgid "Disabled tax included prices since this {} is an internal transfer"
 msgstr ""
 
@@ -18137,7 +18123,7 @@ msgstr "Expédition Directe"
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.json
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/print_format/sales_invoice_print/sales_invoice_print.html:72
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1106
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1108
 #: erpnext/assets/doctype/asset_maintenance_log/asset_maintenance_log.json
 #: erpnext/selling/report/payment_terms_status_for_sales_order/payment_terms_status_for_sales_order.py:40
 msgid "Due Date"
@@ -18151,11 +18137,11 @@ msgstr "Date d'Échéance"
 msgid "Due Date Based On"
 msgstr "Date d&#39;échéance basée sur"
 
-#: erpnext/accounts/party.py:695
+#: erpnext/accounts/party.py:701
 msgid "Due Date cannot be after {0}"
 msgstr ""
 
-#: erpnext/accounts/party.py:671
+#: erpnext/accounts/party.py:677
 msgid "Due Date cannot be before {0}"
 msgstr ""
 
@@ -18873,7 +18859,7 @@ msgstr "Activer la planification des rendez-vous"
 msgid "Enable Auto Email"
 msgstr "Activer la messagerie automatique"
 
-#: erpnext/stock/doctype/item/item.py:1064
+#: erpnext/stock/doctype/item/item.py:1058
 msgid "Enable Auto Re-Order"
 msgstr "Activer la re-commande automatique"
 
@@ -19086,7 +19072,7 @@ msgstr "Date de l'Encaissement"
 msgid "End Date"
 msgstr "Date de Fin"
 
-#: erpnext/crm/doctype/contract/contract.py:75
+#: erpnext/crm/doctype/contract/contract.py:83
 msgid "End Date cannot be before Start Date."
 msgstr "La date de fin ne peut pas être antérieure à la date de début."
 
@@ -19336,7 +19322,7 @@ msgstr ""
 #: erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.json
 #: erpnext/manufacturing/doctype/job_card/job_card.py:875
 #: erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.json
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:297
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:298
 msgid "Error"
 msgstr "Erreur"
 
@@ -19459,7 +19445,7 @@ msgstr ""
 msgid "Example URL"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:995
+#: erpnext/stock/doctype/item/item.py:989
 msgid "Example of a linked document: {0}"
 msgstr ""
 
@@ -19474,7 +19460,7 @@ msgstr ""
 msgid "Example: ABCD.#####. If series is set and Batch No is not mentioned in transactions, then automatic batch number will be created based on this series. If you always want to explicitly mention Batch No for this item, leave this blank. Note: this setting will take priority over the Naming Series Prefix in Stock Settings."
 msgstr "Exemple: ABCD. #####. Si le masque est définie et que le numéro de lot n'est pas mentionné dans les transactions, un numéro de lot sera automatiquement créé en avec ce masque. Si vous préferez mentionner explicitement et systématiquement le numéro de lot pour cet article, laissez ce champ vide. Remarque: ce paramètre aura la priorité sur le préfixe du masque dans les paramètres de stock."
 
-#: erpnext/stock/stock_ledger.py:2141
+#: erpnext/stock/stock_ledger.py:2149
 msgid "Example: Serial No {0} reserved in {1}."
 msgstr ""
 
@@ -19528,8 +19514,8 @@ msgstr ""
 msgid "Exchange Gain/Loss"
 msgstr "Profits / Pertes sur Change"
 
-#: erpnext/controllers/accounts_controller.py:1593
-#: erpnext/controllers/accounts_controller.py:1677
+#: erpnext/controllers/accounts_controller.py:1596
+#: erpnext/controllers/accounts_controller.py:1680
 msgid "Exchange Gain/Loss amount has been booked through {0}"
 msgstr ""
 
@@ -20265,7 +20251,7 @@ msgid "Fetching Error"
 msgstr ""
 
 #: erpnext/accounts/doctype/dunning/dunning.js:135
-#: erpnext/public/js/controllers/transaction.js:1251
+#: erpnext/public/js/controllers/transaction.js:1277
 msgid "Fetching exchange rates ..."
 msgstr ""
 
@@ -20560,15 +20546,15 @@ msgstr ""
 msgid "Finished Good Item Quantity"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3658
+#: erpnext/controllers/accounts_controller.py:3661
 msgid "Finished Good Item is not specified for service item {0}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3675
+#: erpnext/controllers/accounts_controller.py:3678
 msgid "Finished Good Item {0} Qty can not be zero"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3669
+#: erpnext/controllers/accounts_controller.py:3672
 msgid "Finished Good Item {0} must be a sub-contracted item"
 msgstr ""
 
@@ -20809,7 +20795,7 @@ msgstr "Compte d'Actif Immobilisé"
 msgid "Fixed Asset Defaults"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:301
+#: erpnext/stock/doctype/item/item.py:304
 msgid "Fixed Asset Item must be a non-stock item."
 msgstr "Un Article Immobilisé doit être un élément non stocké."
 
@@ -20985,7 +20971,7 @@ msgstr "Pour Quantité (Qté Produite) est obligatoire"
 msgid "For Raw Materials"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1259
+#: erpnext/controllers/accounts_controller.py:1262
 msgid "For Return Invoices with Stock effect, '0' qty Items are not allowed. Following rows are affected: {0}"
 msgstr ""
 
@@ -21086,7 +21072,7 @@ msgstr ""
 msgid "For the item {0}, the quantity should be {1} according to the BOM {2}."
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:1088
+#: erpnext/public/js/controllers/transaction.js:1114
 msgctxt "Clear payment terms template and/or payment schedule when due date is changed"
 msgid "For the new {0} to take effect, would you like to clear the current {1}?"
 msgstr ""
@@ -21095,7 +21081,7 @@ msgstr ""
 msgid "For the {0}, no stock is available for the return in the warehouse {1}."
 msgstr ""
 
-#: erpnext/controllers/sales_and_purchase_return.py:1144
+#: erpnext/controllers/sales_and_purchase_return.py:1049
 msgid "For the {0}, the quantity is required to make the return entry"
 msgstr ""
 
@@ -21432,7 +21418,7 @@ msgstr "La Date Initiale ne peut pas être postérieure à la Date Finale"
 msgid "From Date is mandatory"
 msgstr ""
 
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:52
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:53
 #: erpnext/accounts/report/general_ledger/general_ledger.py:86
 #: erpnext/accounts/report/pos_register/pos_register.py:115
 #: erpnext/accounts/report/tax_withholding_details/tax_withholding_details.py:39
@@ -21809,14 +21795,14 @@ msgstr "D'autres nœuds peuvent être créés uniquement sous les nœuds de type
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:186
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:155
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1134
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1136
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:177
 msgid "Future Payment Amount"
 msgstr "Montant du paiement futur"
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:185
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:154
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1133
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1135
 msgid "Future Payment Ref"
 msgstr "Paiement futur Ref"
 
@@ -22990,7 +22976,7 @@ msgstr ""
 msgid "Here are the error logs for the aforementioned failed depreciation entries: {0}"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1862
+#: erpnext/stock/stock_ledger.py:1871
 msgid "Here are the options to proceed:"
 msgstr ""
 
@@ -23512,7 +23498,7 @@ msgstr "Les utilisateur de ce role pourront creer et modifier des transactions d
 msgid "If more than one package of the same type (for print)"
 msgstr "Si plus d'un paquet du même type (pour l'impression)"
 
-#: erpnext/stock/stock_ledger.py:1872
+#: erpnext/stock/stock_ledger.py:1881
 msgid "If not, you can Cancel / Submit this entry"
 msgstr ""
 
@@ -23537,7 +23523,7 @@ msgstr ""
 msgid "If the account is frozen, entries are allowed to restricted users."
 msgstr "Si le compte est gelé, les écritures ne sont autorisés que pour un nombre restreint d'utilisateurs."
 
-#: erpnext/stock/stock_ledger.py:1865
+#: erpnext/stock/stock_ledger.py:1874
 msgid "If the item is transacting as a Zero Valuation Rate item in this entry, please enable 'Allow Zero Valuation Rate' in the {0} Item table."
 msgstr "Si l'article est traité comme un article à taux de valorisation nul dans cette entrée, veuillez activer &quot;Autoriser le taux de valorisation nul&quot; dans le {0} tableau des articles."
 
@@ -24535,7 +24521,7 @@ msgstr "Equilibre des quantités aprés une transaction"
 msgid "Incorrect Batch Consumed"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:514
+#: erpnext/stock/doctype/item/item.py:517
 msgid "Incorrect Check in (group) Warehouse for Reorder"
 msgstr ""
 
@@ -24584,7 +24570,7 @@ msgstr ""
 msgid "Incorrect Stock Value Report"
 msgstr ""
 
-#: erpnext/stock/serial_batch_bundle.py:134
+#: erpnext/stock/serial_batch_bundle.py:135
 msgid "Incorrect Type of Transaction"
 msgstr ""
 
@@ -24853,8 +24839,8 @@ msgstr ""
 msgid "Insufficient Capacity"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3590
-#: erpnext/controllers/accounts_controller.py:3614
+#: erpnext/controllers/accounts_controller.py:3593
+#: erpnext/controllers/accounts_controller.py:3617
 msgid "Insufficient Permissions"
 msgstr "Permissions insuffisantes"
 
@@ -24862,12 +24848,12 @@ msgstr "Permissions insuffisantes"
 #: erpnext/stock/doctype/pick_list/pick_list.py:127
 #: erpnext/stock/doctype/pick_list/pick_list.py:975
 #: erpnext/stock/doctype/stock_entry/stock_entry.py:759
-#: erpnext/stock/serial_batch_bundle.py:989 erpnext/stock/stock_ledger.py:1559
-#: erpnext/stock/stock_ledger.py:2032
+#: erpnext/stock/serial_batch_bundle.py:1021 erpnext/stock/stock_ledger.py:1568
+#: erpnext/stock/stock_ledger.py:2040
 msgid "Insufficient Stock"
 msgstr "Stock insuffisant"
 
-#: erpnext/stock/stock_ledger.py:2047
+#: erpnext/stock/stock_ledger.py:2055
 msgid "Insufficient Stock for Batch"
 msgstr ""
 
@@ -25005,11 +24991,11 @@ msgstr "Client interne"
 msgid "Internal Customer for company {0} already exists"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:728
+#: erpnext/controllers/accounts_controller.py:731
 msgid "Internal Sale or Delivery Reference missing."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:730
+#: erpnext/controllers/accounts_controller.py:733
 msgid "Internal Sales Reference Missing"
 msgstr ""
 
@@ -25040,7 +25026,7 @@ msgstr ""
 msgid "Internal Transfer"
 msgstr "Transfert Interne"
 
-#: erpnext/controllers/accounts_controller.py:739
+#: erpnext/controllers/accounts_controller.py:742
 msgid "Internal Transfer Reference Missing"
 msgstr ""
 
@@ -25083,8 +25069,8 @@ msgstr "Invalide"
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:969
 #: erpnext/assets/doctype/asset_category/asset_category.py:69
 #: erpnext/assets/doctype/asset_category/asset_category.py:97
-#: erpnext/controllers/accounts_controller.py:2975
-#: erpnext/controllers/accounts_controller.py:2983
+#: erpnext/controllers/accounts_controller.py:2978
+#: erpnext/controllers/accounts_controller.py:2986
 msgid "Invalid Account"
 msgstr "Compte invalide"
 
@@ -25109,7 +25095,7 @@ msgstr ""
 msgid "Invalid Barcode. There is no Item attached to this barcode."
 msgstr "Code à barres invalide. Il n'y a pas d'article attaché à ce code à barres."
 
-#: erpnext/public/js/controllers/transaction.js:2631
+#: erpnext/public/js/controllers/transaction.js:2657
 msgid "Invalid Blanket Order for the selected Customer and Item"
 msgstr "Commande avec limites non valide pour le client et l'article sélectionnés"
 
@@ -25123,7 +25109,7 @@ msgstr "Société non valide pour une transaction inter-sociétés."
 
 #: erpnext/assets/doctype/asset/asset.py:295
 #: erpnext/assets/doctype/asset/asset.py:302
-#: erpnext/controllers/accounts_controller.py:2998
+#: erpnext/controllers/accounts_controller.py:3001
 msgid "Invalid Cost Center"
 msgstr ""
 
@@ -25165,7 +25151,7 @@ msgstr ""
 msgid "Invalid Item"
 msgstr "Élément non valide"
 
-#: erpnext/stock/doctype/item/item.py:1410
+#: erpnext/stock/doctype/item/item.py:1404
 msgid "Invalid Item Defaults"
 msgstr ""
 
@@ -25211,11 +25197,11 @@ msgstr ""
 msgid "Invalid Purchase Invoice"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3627
+#: erpnext/controllers/accounts_controller.py:3630
 msgid "Invalid Qty"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1277
+#: erpnext/controllers/accounts_controller.py:1280
 msgid "Invalid Quantity"
 msgstr "Quantité invalide"
 
@@ -25232,7 +25218,7 @@ msgstr ""
 msgid "Invalid Schedule"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:243
+#: erpnext/controllers/selling_controller.py:251
 msgid "Invalid Selling Price"
 msgstr "Prix de vente invalide"
 
@@ -25265,7 +25251,7 @@ msgstr "Expression de condition non valide"
 msgid "Invalid lost reason {0}, please create a new lost reason"
 msgstr "Motif perdu non valide {0}, veuillez créer un nouveau motif perdu"
 
-#: erpnext/stock/doctype/item/item.py:408
+#: erpnext/stock/doctype/item/item.py:411
 msgid "Invalid naming series (. missing) for {0}"
 msgstr "Masque de numérotation non valide (. Manquante) pour {0}"
 
@@ -25305,7 +25291,7 @@ msgstr "Inventaire"
 #. Name of a DocType
 #: erpnext/patches/v15_0/refactor_closing_stock_balance.py:43
 #: erpnext/stock/doctype/inventory_dimension/inventory_dimension.json
-#: erpnext/stock/doctype/inventory_dimension/inventory_dimension.py:180
+#: erpnext/stock/doctype/inventory_dimension/inventory_dimension.py:181
 msgid "Inventory Dimension"
 msgstr ""
 
@@ -25371,7 +25357,7 @@ msgstr "Date de la Facture"
 msgid "Invoice Discounting"
 msgstr "Rabais de facture"
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1114
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1116
 msgid "Invoice Grand Total"
 msgstr "Total général de la facture"
 
@@ -25464,7 +25450,7 @@ msgstr "La facture ne peut pas être faite pour une heure facturée à zéro"
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:169
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:144
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1116
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1118
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:164
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:165
 msgid "Invoiced Amount"
@@ -25870,6 +25856,11 @@ msgstr "Est Écriture Ouverte"
 msgid "Is Outward"
 msgstr ""
 
+#. Label of the is_packed (Check) field in DocType 'Serial and Batch Bundle'
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.json
+msgid "Is Packed"
+msgstr ""
+
 #. Label of the is_paid (Check) field in DocType 'Purchase Invoice'
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 msgid "Is Paid"
@@ -26152,11 +26143,11 @@ msgstr "Date d'émission"
 msgid "Issuing cannot be done to a location. Please enter employee to issue the Asset {0} to"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:565
+#: erpnext/stock/doctype/item/item.py:571
 msgid "It can take upto few hours for accurate stock values to be visible after merging items."
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2075
+#: erpnext/public/js/controllers/transaction.js:2101
 msgid "It is needed to fetch Item Details."
 msgstr "Nécessaire pour aller chercher les Détails de l'Article."
 
@@ -26206,7 +26197,7 @@ msgstr ""
 #: erpnext/buying/report/supplier_quotation_comparison/supplier_quotation_comparison.js:33
 #: erpnext/buying/report/supplier_quotation_comparison/supplier_quotation_comparison.py:204
 #: erpnext/buying/workspace/buying/buying.json
-#: erpnext/controllers/taxes_and_totals.py:1125
+#: erpnext/controllers/taxes_and_totals.py:1135
 #: erpnext/manufacturing/doctype/blanket_order/blanket_order.json
 #: erpnext/manufacturing/doctype/bom/bom.js:944
 #: erpnext/manufacturing/doctype/bom/bom.json
@@ -26484,7 +26475,7 @@ msgstr ""
 #: erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py:86
 #: erpnext/manufacturing/report/work_order_stock_report/work_order_stock_report.py:119
 #: erpnext/projects/doctype/timesheet/timesheet.js:213
-#: erpnext/public/js/controllers/transaction.js:2350
+#: erpnext/public/js/controllers/transaction.js:2376
 #: erpnext/public/js/stock_reservation.js:112
 #: erpnext/public/js/stock_reservation.js:317 erpnext/public/js/utils.js:500
 #: erpnext/public/js/utils.js:656
@@ -26922,7 +26913,7 @@ msgstr "Fabricant d'Article"
 #: erpnext/manufacturing/report/production_planning_report/production_planning_report.py:359
 #: erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py:92
 #: erpnext/manufacturing/report/work_order_consumed_materials/work_order_consumed_materials.py:138
-#: erpnext/public/js/controllers/transaction.js:2356
+#: erpnext/public/js/controllers/transaction.js:2382
 #: erpnext/public/js/utils.js:746
 #: erpnext/selling/doctype/quotation_item/quotation_item.json
 #: erpnext/selling/doctype/sales_order_item/sales_order_item.json
@@ -27189,7 +27180,7 @@ msgstr "Paramètres de Variante d'Article"
 msgid "Item Variant {0} already exists with same attributes"
 msgstr "La Variante de l'Article {0} existe déjà avec les mêmes caractéristiques"
 
-#: erpnext/stock/doctype/item/item.py:781
+#: erpnext/stock/doctype/item/item.py:772
 msgid "Item Variants updated"
 msgstr "Variantes d'article mises à jour"
 
@@ -27255,7 +27246,7 @@ msgstr "Détails de l'Article et de la Garantie"
 msgid "Item for row {0} does not match Material Request"
 msgstr "L'élément de la ligne {0} ne correspond pas à la demande de matériel"
 
-#: erpnext/stock/doctype/item/item.py:795
+#: erpnext/stock/doctype/item/item.py:789
 msgid "Item has variants."
 msgstr "L'article a des variantes."
 
@@ -27281,7 +27272,7 @@ msgstr "Libellé de l'article"
 msgid "Item operation"
 msgstr "Opération de l'article"
 
-#: erpnext/controllers/accounts_controller.py:3650
+#: erpnext/controllers/accounts_controller.py:3653
 msgid "Item qty can not be updated as raw materials are already processed."
 msgstr ""
 
@@ -27307,7 +27298,7 @@ msgstr ""
 msgid "Item valuation reposting in progress. Report might show incorrect item valuation."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:952
+#: erpnext/stock/doctype/item/item.py:946
 msgid "Item variant {0} exists with same attributes"
 msgstr "La variante de l'article {0} existe avec les mêmes caractéristiques"
 
@@ -27320,8 +27311,7 @@ msgid "Item {0} cannot be ordered more than {1} against Blanket Order {2}."
 msgstr ""
 
 #: erpnext/assets/doctype/asset/asset.py:277
-#: erpnext/stock/doctype/item/item.py:630
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:167
+#: erpnext/stock/doctype/item/item.py:636
 msgid "Item {0} does not exist"
 msgstr "Article {0} n'existe pas"
 
@@ -27333,7 +27323,7 @@ msgstr "L'article {0} n'existe pas dans le système ou a expiré"
 msgid "Item {0} does not exist."
 msgstr "Article {0} n'existe pas."
 
-#: erpnext/controllers/selling_controller.py:752
+#: erpnext/controllers/selling_controller.py:760
 msgid "Item {0} entered multiple times."
 msgstr ""
 
@@ -27349,7 +27339,7 @@ msgstr "L'article {0} a été désactivé"
 msgid "Item {0} has no Serial No. Only serialized items can have delivery based on Serial No"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1126
+#: erpnext/stock/doctype/item/item.py:1120
 msgid "Item {0} has reached its end of life on {1}"
 msgstr "L'article {0} a atteint sa fin de vie le {1}"
 
@@ -27361,11 +27351,11 @@ msgstr "L'article {0} est ignoré puisqu'il n'est pas en stock"
 msgid "Item {0} is already reserved/delivered against Sales Order {1}."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1146
+#: erpnext/stock/doctype/item/item.py:1140
 msgid "Item {0} is cancelled"
 msgstr "Article {0} est annulé"
 
-#: erpnext/stock/doctype/item/item.py:1130
+#: erpnext/stock/doctype/item/item.py:1124
 msgid "Item {0} is disabled"
 msgstr "Article {0} est désactivé"
 
@@ -27373,7 +27363,7 @@ msgstr "Article {0} est désactivé"
 msgid "Item {0} is not a serialized Item"
 msgstr "L'article {0} n'est pas un article avec un numéro de série"
 
-#: erpnext/stock/doctype/item/item.py:1138
+#: erpnext/stock/doctype/item/item.py:1132
 msgid "Item {0} is not a stock Item"
 msgstr "Article {0} n'est pas un article stocké"
 
@@ -27417,7 +27407,7 @@ msgstr "L'article {0} : Qté commandée {1} ne peut pas être inférieure à la 
 msgid "Item {0}: {1} qty produced. "
 msgstr "Article {0}: {1} quantité produite."
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1429
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1423
 msgid "Item {} does not exist."
 msgstr ""
 
@@ -27557,7 +27547,7 @@ msgstr "Articles À Demander"
 msgid "Items and Pricing"
 msgstr "Articles et prix"
 
-#: erpnext/controllers/accounts_controller.py:3872
+#: erpnext/controllers/accounts_controller.py:3875
 msgid "Items cannot be updated as Subcontracting Order is created against the Purchase Order {0}."
 msgstr ""
 
@@ -28053,7 +28043,7 @@ msgstr "Taxes et Frais du Coût au Débarquement"
 
 #. Name of a DocType
 #. Label of a Link in the Stock Workspace
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:674
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:676
 #: erpnext/stock/doctype/landed_cost_voucher/landed_cost_voucher.json
 #: erpnext/stock/doctype/purchase_receipt/purchase_receipt.js:104
 #: erpnext/stock/workspace/stock/stock.json
@@ -28668,7 +28658,7 @@ msgstr "Factures liées"
 msgid "Linked Location"
 msgstr "Lieu lié"
 
-#: erpnext/stock/doctype/item/item.py:999
+#: erpnext/stock/doctype/item/item.py:993
 msgid "Linked with submitted documents"
 msgstr ""
 
@@ -29407,7 +29397,7 @@ msgstr ""
 #: erpnext/manufacturing/doctype/bom/bom.py:261
 #: erpnext/manufacturing/doctype/bom_update_log/bom_update_log.py:71
 #: erpnext/public/js/controllers/accounts.js:249
-#: erpnext/public/js/controllers/transaction.js:2753
+#: erpnext/public/js/controllers/transaction.js:2779
 #: erpnext/public/js/utils/party.js:321
 #: erpnext/stock/doctype/delivery_note/delivery_note.js:164
 #: erpnext/stock/doctype/inventory_dimension/inventory_dimension.json
@@ -30263,7 +30253,7 @@ msgstr "Utilisation maximale"
 msgid "Maximum Value"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:212
+#: erpnext/controllers/selling_controller.py:220
 msgid "Maximum discount for Item {0} is {1}%"
 msgstr ""
 
@@ -30333,7 +30323,7 @@ msgstr ""
 msgid "Megawatt"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1878
+#: erpnext/stock/stock_ledger.py:1887
 msgid "Mention Valuation Rate in the Item master."
 msgstr "Mentionnez le taux de valorisation dans la fiche article."
 
@@ -30728,11 +30718,11 @@ msgstr ""
 msgid "Miscellaneous Expenses"
 msgstr "Charges Diverses"
 
-#: erpnext/controllers/buying_controller.py:540
+#: erpnext/controllers/buying_controller.py:548
 msgid "Mismatch"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1430
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1424
 msgid "Missing"
 msgstr ""
 
@@ -31259,7 +31249,7 @@ msgstr "Variantes multiples"
 msgid "Multiple Warehouse Accounts"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1129
+#: erpnext/controllers/accounts_controller.py:1132
 msgid "Multiple fiscal years exist for the date {0}. Please set company in Fiscal Year"
 msgstr "Plusieurs Exercices existent pour la date {0}. Veuillez définir la société dans l'Exercice"
 
@@ -31410,7 +31400,7 @@ msgstr "Préfix du masque de numérotation"
 msgid "Naming Series and Price Defaults"
 msgstr "Nom de série et Tarifs"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:90
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:91
 msgid "Naming Series is mandatory"
 msgstr ""
 
@@ -31449,15 +31439,15 @@ msgstr "Gaz Naturel"
 msgid "Needs Analysis"
 msgstr "Analyse des besoins"
 
-#: erpnext/stock/serial_batch_bundle.py:1277
+#: erpnext/stock/serial_batch_bundle.py:1309
 msgid "Negative Batch Quantity"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:610
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:606
 msgid "Negative Quantity is not allowed"
 msgstr "Quantité Négative n'est pas autorisée"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:615
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:611
 msgid "Negative Valuation Rate is not allowed"
 msgstr "Taux de Valorisation Négatif n'est pas autorisé"
 
@@ -31739,7 +31729,7 @@ msgstr "Poids Net"
 msgid "Net Weight UOM"
 msgstr "UdM Poids Net"
 
-#: erpnext/controllers/accounts_controller.py:1483
+#: erpnext/controllers/accounts_controller.py:1486
 msgid "Net total calculation precision loss"
 msgstr ""
 
@@ -32082,7 +32072,7 @@ msgstr ""
 #: erpnext/accounts/doctype/journal_entry/journal_entry.py:1539
 #: erpnext/accounts/doctype/journal_entry/journal_entry.py:1599
 #: erpnext/accounts/doctype/journal_entry/journal_entry.py:1613
-#: erpnext/stock/doctype/item/item.py:1371
+#: erpnext/stock/doctype/item/item.py:1365
 msgid "No Permission"
 msgstr "Aucune autorisation"
 
@@ -32104,7 +32094,7 @@ msgstr "Aucune Remarque"
 msgid "No Selection"
 msgstr ""
 
-#: erpnext/controllers/sales_and_purchase_return.py:919
+#: erpnext/controllers/sales_and_purchase_return.py:824
 msgid "No Serial / Batches are available for return"
 msgstr ""
 
@@ -32140,7 +32130,7 @@ msgstr ""
 msgid "No Work Orders were created"
 msgstr ""
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:785
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:794
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py:689
 msgid "No accounting entries for the following warehouses"
 msgstr "Pas d’écritures comptables pour les entrepôts suivants"
@@ -32329,7 +32319,7 @@ msgstr ""
 msgid "No reserved stock to unreserve."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:773
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:769
 msgid "No stock ledger entries were created. Please set the quantity or valuation rate for the items properly and try again."
 msgstr ""
 
@@ -32413,7 +32403,7 @@ msgstr "N°"
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:566
 #: erpnext/assets/doctype/asset/asset.js:612
 #: erpnext/assets/doctype/asset/asset.js:627
-#: erpnext/controllers/buying_controller.py:225
+#: erpnext/controllers/buying_controller.py:233
 #: erpnext/selling/doctype/product_bundle/product_bundle.py:72
 #: erpnext/setup/doctype/transaction_deletion_record/transaction_deletion_record.py:80
 msgid "Not Allowed"
@@ -32534,10 +32524,10 @@ msgstr "Pas permis"
 #: erpnext/selling/doctype/customer/customer.py:129
 #: erpnext/selling/doctype/sales_order/sales_order.js:1168
 #: erpnext/stock/doctype/item/item.js:526
-#: erpnext/stock/doctype/item/item.py:567
+#: erpnext/stock/doctype/item/item.py:573
 #: erpnext/stock/doctype/item_price/item_price.json
 #: erpnext/stock/doctype/stock_entry/stock_entry.py:1374
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:972
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:968
 #: erpnext/templates/pages/timelog_info.html:43
 msgid "Note"
 msgstr ""
@@ -32546,7 +32536,7 @@ msgstr ""
 msgid "Note: Automatic log deletion only applies to logs of type <i>Update Cost</i>"
 msgstr ""
 
-#: erpnext/accounts/party.py:690
+#: erpnext/accounts/party.py:696
 msgid "Note: Due Date exceeds allowed {0} credit days by {1} day(s)"
 msgstr ""
 
@@ -32572,7 +32562,7 @@ msgstr "Remarque : Écriture de Paiement ne sera pas créée car le compte 'Comp
 msgid "Note: This Cost Center is a Group. Cannot make accounting entries against groups."
 msgstr "Remarque : Ce Centre de Coûts est un Groupe. Vous ne pouvez pas faire des écritures comptables sur des groupes."
 
-#: erpnext/stock/doctype/item/item.py:621
+#: erpnext/stock/doctype/item/item.py:627
 msgid "Note: To merge the items, create a separate Stock Reconciliation for the old item {0}"
 msgstr ""
 
@@ -33335,7 +33325,7 @@ msgstr ""
 
 #. Label of the opening_stock (Float) field in DocType 'Item'
 #. Option for the 'Purpose' (Select) field in DocType 'Stock Reconciliation'
-#: erpnext/stock/doctype/item/item.json erpnext/stock/doctype/item/item.py:296
+#: erpnext/stock/doctype/item/item.json erpnext/stock/doctype/item/item.py:299
 #: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.json
 msgid "Opening Stock"
 msgstr "Stock d'Ouverture"
@@ -34055,7 +34045,7 @@ msgstr ""
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:149
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1123
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1125
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:167
 #: erpnext/accounts/report/purchase_register/purchase_register.py:289
 #: erpnext/accounts/report/sales_register/sales_register.py:319
@@ -34094,7 +34084,7 @@ msgstr "À l'extérieur"
 msgid "Over Billing Allowance (%)"
 msgstr ""
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:1242
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:1251
 msgid "Over Billing Allowance exceeded for Purchase Receipt Item {0} ({1}) by {2}%"
 msgstr ""
 
@@ -34135,7 +34125,7 @@ msgstr ""
 msgid "Overbilling of {0} {1} ignored for item {2} because you have {3} role."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2013
+#: erpnext/controllers/accounts_controller.py:2016
 msgid "Overbilling of {} ignored because you have {} role."
 msgstr ""
 
@@ -34642,7 +34632,7 @@ msgstr "Payé"
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:146
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1117
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1119
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:165
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:172
 #: erpnext/accounts/report/pos_register/pos_register.py:209
@@ -34875,7 +34865,7 @@ msgstr "Procédure parentale"
 msgid "Parent Row No"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom_creator/bom_creator.py:495
+#: erpnext/manufacturing/doctype/bom_creator/bom_creator.py:496
 msgid "Parent Row No not found for {0}"
 msgstr ""
 
@@ -35104,7 +35094,7 @@ msgstr ""
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:142
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:159
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:57
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1054
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1056
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:67
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:147
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:228
@@ -35130,7 +35120,7 @@ msgstr "Tiers"
 
 #. Name of a DocType
 #: erpnext/accounts/doctype/party_account/party_account.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1065
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1067
 msgid "Party Account"
 msgstr "Compte de Tiers"
 
@@ -35157,7 +35147,7 @@ msgstr "Devise du Compte de Tiers"
 msgid "Party Account No. (Bank Statement)"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2278
+#: erpnext/controllers/accounts_controller.py:2281
 msgid "Party Account {0} currency ({1}) and document currency ({2}) should be same"
 msgstr ""
 
@@ -35174,6 +35164,11 @@ msgstr "Compte bancaire du parti"
 #: erpnext/accounts/doctype/payment_request/payment_request.json
 msgid "Party Details"
 msgstr "Parti Détails"
+
+#. Label of the party_full_name (Data) field in DocType 'Contract'
+#: erpnext/crm/doctype/contract/contract.json
+msgid "Party Full Name"
+msgstr ""
 
 #. Label of the bank_party_iban (Data) field in DocType 'Bank Transaction'
 #: erpnext/accounts/doctype/bank_transaction/bank_transaction.json
@@ -35258,7 +35253,7 @@ msgstr "Restriction d'article disponible"
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:84
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:54
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:44
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1048
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1050
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:54
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:141
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:219
@@ -35280,7 +35275,7 @@ msgstr "Restriction d'article disponible"
 msgid "Party Type"
 msgstr "Type de Tiers"
 
-#: erpnext/accounts/party.py:819
+#: erpnext/accounts/party.py:825
 msgid "Party Type and Party can only be set for Receivable / Payable account<br><br>{0}"
 msgstr ""
 
@@ -35402,7 +35397,7 @@ msgid "Payable"
 msgstr "Créditeur"
 
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:42
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1063
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1065
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:211
 #: erpnext/accounts/report/purchase_register/purchase_register.py:194
 #: erpnext/accounts/report/purchase_register/purchase_register.py:235
@@ -35568,7 +35563,7 @@ msgstr "L’Écriture de Paiement a été modifié après que vous l’ayez réc
 msgid "Payment Entry is already created"
 msgstr "L’Écriture de Paiement est déjà créée"
 
-#: erpnext/controllers/accounts_controller.py:1434
+#: erpnext/controllers/accounts_controller.py:1437
 msgid "Payment Entry {0} is linked against Order {1}, check if it should be pulled as advance in this invoice."
 msgstr ""
 
@@ -35850,7 +35845,7 @@ msgstr ""
 #: erpnext/accounts/doctype/payment_schedule/payment_schedule.json
 #: erpnext/accounts/doctype/payment_term/payment_term.json
 #: erpnext/accounts/doctype/payment_terms_template_detail/payment_terms_template_detail.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1113
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1115
 #: erpnext/accounts/report/gross_profit/gross_profit.py:412
 #: erpnext/accounts/workspace/accounting/accounting.json
 #: erpnext/selling/report/payment_terms_status_for_sales_order/payment_terms_status_for_sales_order.py:30
@@ -36914,7 +36909,7 @@ msgstr ""
 msgid "Please create a new Accounting Dimension if required."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:729
+#: erpnext/controllers/accounts_controller.py:732
 msgid "Please create purchase from internal sale or delivery document itself"
 msgstr ""
 
@@ -36922,7 +36917,7 @@ msgstr ""
 msgid "Please create purchase receipt or purchase invoice for the item {0}"
 msgstr "Veuillez créer un reçu d'achat ou une facture d'achat pour l'article {0}"
 
-#: erpnext/stock/doctype/item/item.py:649
+#: erpnext/stock/doctype/item/item.py:655
 msgid "Please delete Product Bundle {0}, before merging {1} into {2}"
 msgstr ""
 
@@ -36964,7 +36959,7 @@ msgstr "Veuillez autoriser les pop-ups"
 msgid "Please enable {0} in the {1}."
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:754
+#: erpnext/controllers/selling_controller.py:762
 msgid "Please enable {} in {} to allow same item in multiple rows"
 msgstr ""
 
@@ -36997,7 +36992,7 @@ msgstr "Veuillez entrez un Compte pour le Montant de Change"
 msgid "Please enter Approving Role or Approving User"
 msgstr "Veuillez entrer un Rôle Approbateur ou un Rôle Utilisateur"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:939
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:935
 msgid "Please enter Cost Center"
 msgstr "Veuillez entrer un Centre de Coûts"
 
@@ -37009,7 +37004,7 @@ msgstr "Entrez la Date de Livraison"
 msgid "Please enter Employee Id of this sales person"
 msgstr "Veuillez entrer l’ID Employé de ce commercial"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:948
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:944
 msgid "Please enter Expense Account"
 msgstr "Veuillez entrer un Compte de Charges"
 
@@ -37018,7 +37013,7 @@ msgstr "Veuillez entrer un Compte de Charges"
 msgid "Please enter Item Code to get Batch Number"
 msgstr "Veuillez entrer le Code d'Article pour obtenir le Numéro de Lot"
 
-#: erpnext/public/js/controllers/transaction.js:2503
+#: erpnext/public/js/controllers/transaction.js:2529
 msgid "Please enter Item Code to get batch no"
 msgstr "Veuillez entrer le Code d'Article pour obtenir n° de lot"
 
@@ -37083,7 +37078,7 @@ msgstr "Veuillez d’abord entrer une Société"
 msgid "Please enter company name first"
 msgstr "Veuillez d’abord entrer le nom de l'entreprise"
 
-#: erpnext/controllers/accounts_controller.py:2764
+#: erpnext/controllers/accounts_controller.py:2767
 msgid "Please enter default currency in Company Master"
 msgstr "Veuillez entrer la devise par défaut dans les Données de Base de la Société"
 
@@ -37119,7 +37114,7 @@ msgstr "Veuillez saisir le nom de l'entreprise pour confirmer"
 msgid "Please enter the phone number first"
 msgstr "Veuillez d'abord saisir le numéro de téléphone"
 
-#: erpnext/controllers/buying_controller.py:1007
+#: erpnext/controllers/buying_controller.py:1015
 msgid "Please enter the {schedule_date}."
 msgstr ""
 
@@ -37221,7 +37216,7 @@ msgstr "S'il vous plaît enregistrer en premier"
 msgid "Please select <b>Template Type</b> to download template"
 msgstr "Veuillez sélectionner le <b>type</b> de modèle pour télécharger le modèle"
 
-#: erpnext/controllers/taxes_and_totals.py:721
+#: erpnext/controllers/taxes_and_totals.py:731
 #: erpnext/public/js/controllers/taxes_and_totals.js:721
 msgid "Please select Apply Discount On"
 msgstr "Veuillez sélectionnez Appliquer Remise Sur"
@@ -37234,7 +37229,7 @@ msgstr "Veuillez sélectionner la nomenclature pour l'article {0}"
 msgid "Please select BOM for Item in Row {0}"
 msgstr "Veuillez sélectionnez une nomenclature pour l’Article à la Ligne {0}"
 
-#: erpnext/controllers/buying_controller.py:467
+#: erpnext/controllers/buying_controller.py:475
 msgid "Please select BOM in BOM field for Item {item_code}."
 msgstr "Veuillez sélectionner une nomenclature dans le champ nomenclature pour l’Article {item_code}."
 
@@ -37316,7 +37311,7 @@ msgstr "Veuillez sélectionner une Liste de Prix"
 msgid "Please select Qty against item {0}"
 msgstr "Veuillez sélectionner Qté par rapport à l'élément {0}"
 
-#: erpnext/stock/doctype/item/item.py:320
+#: erpnext/stock/doctype/item/item.py:323
 msgid "Please select Sample Retention Warehouse in Stock Settings first"
 msgstr "Veuillez d'abord définir un entrepôt de stockage des échantillons dans les paramètres de stock"
 
@@ -37332,7 +37327,7 @@ msgstr "Veuillez sélectionner la Date de Début et Date de Fin pour l'Article {
 msgid "Please select Subcontracting Order instead of Purchase Order {0}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2613
+#: erpnext/controllers/accounts_controller.py:2616
 msgid "Please select Unrealized Profit / Loss account or add default Unrealized Profit / Loss account account for company {0}"
 msgstr ""
 
@@ -37348,7 +37343,7 @@ msgstr "Veuillez sélectionner une Société"
 #: erpnext/manufacturing/doctype/bom/bom.js:603
 #: erpnext/manufacturing/doctype/bom/bom.py:261
 #: erpnext/public/js/controllers/accounts.js:249
-#: erpnext/public/js/controllers/transaction.js:2753
+#: erpnext/public/js/controllers/transaction.js:2779
 msgid "Please select a Company first."
 msgstr "Veuillez d'abord sélectionner une entreprise."
 
@@ -37506,7 +37501,7 @@ msgstr "Veuillez sélectionner {0}"
 msgid "Please select {0} first"
 msgstr "Veuillez d’abord sélectionner {0}"
 
-#: erpnext/public/js/controllers/transaction.js:77
+#: erpnext/public/js/controllers/transaction.js:100
 msgid "Please set 'Apply Additional Discount On'"
 msgstr "Veuillez définir ‘Appliquer Réduction Supplémentaire Sur ‘"
 
@@ -37691,7 +37686,7 @@ msgstr "Veuillez définir un filtre basé sur l'Article ou l'Entrepôt"
 msgid "Please set filters"
 msgstr "Veuillez définir des filtres"
 
-#: erpnext/controllers/accounts_controller.py:2194
+#: erpnext/controllers/accounts_controller.py:2197
 msgid "Please set one of the following:"
 msgstr ""
 
@@ -37699,7 +37694,7 @@ msgstr ""
 msgid "Please set opening number of booked depreciations"
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2205
+#: erpnext/public/js/controllers/transaction.js:2231
 msgid "Please set recurring after saving"
 msgstr "Veuillez définir la récurrence après avoir sauvegardé"
 
@@ -37770,7 +37765,7 @@ msgstr ""
 msgid "Please share this email with your support team so that they can find and fix the issue."
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2073
+#: erpnext/public/js/controllers/transaction.js:2099
 msgid "Please specify"
 msgstr "Veuillez spécifier"
 
@@ -37785,7 +37780,7 @@ msgid "Please specify Company to proceed"
 msgstr "Veuillez spécifier la Société pour continuer"
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1472
-#: erpnext/controllers/accounts_controller.py:2957
+#: erpnext/controllers/accounts_controller.py:2960
 #: erpnext/public/js/controllers/accounts.js:97
 msgid "Please specify a valid Row ID for row {0} in table {1}"
 msgstr "Veuillez spécifier un N° de Ligne valide pour la ligne {0} de la table {1}"
@@ -37798,7 +37793,7 @@ msgstr ""
 msgid "Please specify at least one attribute in the Attributes table"
 msgstr "Veuillez spécifier au moins un attribut dans la table Attributs"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:605
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:601
 msgid "Please specify either Quantity or Valuation Rate or both"
 msgstr "Veuillez spécifier la Quantité, le Taux de Valorisation ou les deux"
 
@@ -37979,7 +37974,7 @@ msgstr "Frais postaux"
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:16
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:15
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:18
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1046
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1048
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:15
 #: erpnext/accounts/report/bank_clearance_summary/bank_clearance_summary.py:35
 #: erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.html:7
@@ -40160,7 +40155,7 @@ msgstr "Responsable des Données d’Achats"
 #: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.js:48
 #: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:203
 #: erpnext/buying/workspace/buying/buying.json
-#: erpnext/controllers/buying_controller.py:739
+#: erpnext/controllers/buying_controller.py:747
 #: erpnext/crm/doctype/contract/contract.json
 #: erpnext/manufacturing/doctype/blanket_order/blanket_order.js:54
 #: erpnext/manufacturing/doctype/production_plan_sub_assembly_item/production_plan_sub_assembly_item.json
@@ -40299,7 +40294,7 @@ msgstr "Commandes d'achat à facturer"
 msgid "Purchase Orders to Receive"
 msgstr "Commandes d'achat à recevoir"
 
-#: erpnext/controllers/accounts_controller.py:1833
+#: erpnext/controllers/accounts_controller.py:1836
 msgid "Purchase Orders {0} are un-linked"
 msgstr ""
 
@@ -40323,8 +40318,8 @@ msgstr "Liste des Prix d'Achat"
 #. Label of a Link in the Stock Workspace
 #. Label of a shortcut in the Stock Workspace
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:171
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:650
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:660
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:652
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:662
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice_list.js:49
 #: erpnext/accounts/doctype/purchase_invoice_item/purchase_invoice_item.json
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:246
@@ -41059,7 +41054,7 @@ msgstr "Modèle d'inspection de la qualité"
 msgid "Quality Inspection Template Name"
 msgstr "Nom du modèle d'inspection de la qualité"
 
-#: erpnext/public/js/controllers/transaction.js:334
+#: erpnext/public/js/controllers/transaction.js:360
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:165
 msgid "Quality Inspection(s)"
 msgstr "Inspection(s) Qualite"
@@ -42243,7 +42238,7 @@ msgid "Receivable / Payable Account"
 msgstr "Compte Débiteur / Créditeur"
 
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:71
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1061
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1063
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py:243
 #: erpnext/accounts/report/sales_register/sales_register.py:217
 #: erpnext/accounts/report/sales_register/sales_register.py:271
@@ -42725,7 +42720,7 @@ msgstr "Référence #{0} datée du {1}"
 msgid "Reference Date"
 msgstr "Date de Référence"
 
-#: erpnext/public/js/controllers/transaction.js:2311
+#: erpnext/public/js/controllers/transaction.js:2337
 msgid "Reference Date for Early Payment Discount"
 msgstr ""
 
@@ -43049,7 +43044,7 @@ msgstr "Ordinaire"
 msgid "Rejected"
 msgstr "Rejeté"
 
-#: erpnext/stock/doctype/inventory_dimension/inventory_dimension.py:202
+#: erpnext/stock/doctype/inventory_dimension/inventory_dimension.py:203
 msgid "Rejected "
 msgstr "Rejeté "
 
@@ -43153,7 +43148,7 @@ msgstr ""
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:187
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:156
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1135
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1137
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:178
 msgid "Remaining Balance"
 msgstr "Solde restant"
@@ -43206,7 +43201,7 @@ msgstr "Remarque"
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:159
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:198
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:269
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1167
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1169
 #: erpnext/accounts/report/general_ledger/general_ledger.html:84
 #: erpnext/accounts/report/general_ledger/general_ledger.html:110
 #: erpnext/accounts/report/general_ledger/general_ledger.py:742
@@ -43955,7 +43950,7 @@ msgstr "Quantité Réservée"
 msgid "Reserved Quantity for Production"
 msgstr "Quantité réservée pour la production"
 
-#: erpnext/stock/stock_ledger.py:2147
+#: erpnext/stock/stock_ledger.py:2155
 msgid "Reserved Serial No."
 msgstr ""
 
@@ -43971,11 +43966,11 @@ msgstr ""
 #: erpnext/stock/doctype/pick_list/pick_list.js:153
 #: erpnext/stock/report/reserved_stock/reserved_stock.json
 #: erpnext/stock/report/stock_balance/stock_balance.py:499
-#: erpnext/stock/stock_ledger.py:2131
+#: erpnext/stock/stock_ledger.py:2139
 msgid "Reserved Stock"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:2177
+#: erpnext/stock/stock_ledger.py:2185
 msgid "Reserved Stock for Batch"
 msgstr ""
 
@@ -43987,7 +43982,7 @@ msgstr ""
 msgid "Reserved Stock for Sub-assembly"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:476
+#: erpnext/controllers/buying_controller.py:484
 msgid "Reserved Warehouse is mandatory for the Item {item_code} in Raw Materials supplied."
 msgstr ""
 
@@ -44801,7 +44796,7 @@ msgstr "Routage"
 msgid "Routing Name"
 msgstr "Nom d'acheminement"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:667
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:663
 msgid "Row #"
 msgstr ""
 
@@ -44839,7 +44834,7 @@ msgstr "Row # {0} (Table de paiement): le montant doit être négatif"
 msgid "Row #{0} (Payment Table): Amount must be positive"
 msgstr "Ligne #{0} (Table de paiement): Le montant doit être positif"
 
-#: erpnext/stock/doctype/item/item.py:495
+#: erpnext/stock/doctype/item/item.py:498
 msgid "Row #{0}: A reorder entry already exists for warehouse {1} with reorder type {2}."
 msgstr ""
 
@@ -44860,7 +44855,7 @@ msgstr ""
 msgid "Row #{0}: Accepted Warehouse is mandatory for the accepted Item {1}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1117
+#: erpnext/controllers/accounts_controller.py:1120
 msgid "Row #{0}: Account {1} does not belong to company {2}"
 msgstr "Ligne # {0}: le compte {1} n'appartient pas à la société {2}"
 
@@ -44901,27 +44896,27 @@ msgstr ""
 msgid "Row #{0}: Cannot allocate more than {1} against payment term {2}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3524
+#: erpnext/controllers/accounts_controller.py:3527
 msgid "Row #{0}: Cannot delete item {1} which has already been billed."
 msgstr "Ligne # {0}: impossible de supprimer l'élément {1} qui a déjà été facturé."
 
-#: erpnext/controllers/accounts_controller.py:3498
+#: erpnext/controllers/accounts_controller.py:3501
 msgid "Row #{0}: Cannot delete item {1} which has already been delivered"
 msgstr "Ligne # {0}: impossible de supprimer l'élément {1} qui a déjà été livré"
 
-#: erpnext/controllers/accounts_controller.py:3517
+#: erpnext/controllers/accounts_controller.py:3520
 msgid "Row #{0}: Cannot delete item {1} which has already been received"
 msgstr "Ligne # {0}: impossible de supprimer l'élément {1} qui a déjà été reçu"
 
-#: erpnext/controllers/accounts_controller.py:3504
+#: erpnext/controllers/accounts_controller.py:3507
 msgid "Row #{0}: Cannot delete item {1} which has work order assigned to it."
 msgstr "Ligne # {0}: impossible de supprimer l'élément {1} auquel un bon de travail est affecté."
 
-#: erpnext/controllers/accounts_controller.py:3510
+#: erpnext/controllers/accounts_controller.py:3513
 msgid "Row #{0}: Cannot delete item {1} which is assigned to customer's purchase order."
 msgstr "Ligne # {0}: impossible de supprimer l'article {1} affecté à la commande d'achat du client."
 
-#: erpnext/controllers/accounts_controller.py:3765
+#: erpnext/controllers/accounts_controller.py:3768
 msgid "Row #{0}: Cannot set Rate if the billed amount is greater than the amount for Item {1}."
 msgstr ""
 
@@ -45041,7 +45036,7 @@ msgstr ""
 msgid "Row #{0}: Item {1} has been picked, please reserve stock from the Pick List."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:729
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:725
 msgid "Row #{0}: Item {1} is not a Serialized/Batched Item. It cannot have a Serial No/Batch No against it."
 msgstr "Ligne # {0}: l'article {1} n'est pas un article sérialisé / en lot. Il ne peut pas avoir de numéro de série / de lot contre lui."
 
@@ -45097,7 +45092,7 @@ msgstr ""
 msgid "Row #{0}: Please select the Sub Assembly Warehouse"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:502
+#: erpnext/stock/doctype/item/item.py:505
 msgid "Row #{0}: Please set reorder quantity"
 msgstr "Ligne #{0} : Veuillez définir la quantité de réapprovisionnement"
 
@@ -45130,8 +45125,8 @@ msgstr ""
 msgid "Row #{0}: Quality Inspection {1} was rejected for item {2}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1274
-#: erpnext/controllers/accounts_controller.py:3624
+#: erpnext/controllers/accounts_controller.py:1277
+#: erpnext/controllers/accounts_controller.py:3627
 msgid "Row #{0}: Quantity for Item {1} cannot be zero."
 msgstr "Ligne n° {0}: La quantité de l'article {1} ne peut être nulle"
 
@@ -45168,7 +45163,7 @@ msgstr ""
 msgid "Row #{0}: Scrap Item Qty cannot be zero"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:230
+#: erpnext/controllers/selling_controller.py:238
 msgid "Row #{0}: Selling rate for item {1} is lower than its {2}.\n"
 "\t\t\t\t\tSelling {3} should be atleast {4}.<br><br>Alternatively,\n"
 "\t\t\t\t\tyou can disable selling price validation in {5} to bypass\n"
@@ -45252,7 +45247,7 @@ msgstr ""
 msgid "Row #{0}: The batch {1} has already expired."
 msgstr "Ligne n ° {0}: le lot {1} a déjà expiré."
 
-#: erpnext/stock/doctype/item/item.py:511
+#: erpnext/stock/doctype/item/item.py:514
 msgid "Row #{0}: The warehouse {1} is not a child warehouse of a group warehouse {2}"
 msgstr ""
 
@@ -45292,39 +45287,39 @@ msgstr ""
 msgid "Row #{1}: Warehouse is mandatory for stock Item {0}"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:259
+#: erpnext/controllers/buying_controller.py:267
 msgid "Row #{idx}: Cannot select Supplier Warehouse while suppling raw materials to subcontractor."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:406
+#: erpnext/controllers/buying_controller.py:414
 msgid "Row #{idx}: Item rate has been updated as per valuation rate since its an internal stock transfer."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:881
+#: erpnext/controllers/buying_controller.py:889
 msgid "Row #{idx}: Please enter a location for the asset item {item_code}."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:537
+#: erpnext/controllers/buying_controller.py:545
 msgid "Row #{idx}: Received Qty must be equal to Accepted + Rejected Qty for Item {item_code}."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:550
+#: erpnext/controllers/buying_controller.py:558
 msgid "Row #{idx}: {field_label} can not be negative for item {item_code}."
 msgstr "Ligne #{idx} : {field_label} ne peut pas être négatif pour l’article {item_code}."
 
-#: erpnext/controllers/buying_controller.py:496
+#: erpnext/controllers/buying_controller.py:504
 msgid "Row #{idx}: {field_label} is mandatory."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:518
+#: erpnext/controllers/buying_controller.py:526
 msgid "Row #{idx}: {field_label} is not allowed in Purchase Return."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:250
+#: erpnext/controllers/buying_controller.py:258
 msgid "Row #{idx}: {from_warehouse_field} and {to_warehouse_field} cannot be same."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:999
+#: erpnext/controllers/buying_controller.py:1007
 msgid "Row #{idx}: {schedule_date} cannot be before {transaction_date}."
 msgstr ""
 
@@ -45389,7 +45384,7 @@ msgstr "Rangée #{}: {}"
 msgid "Row #{}: {} {} does not exist."
 msgstr "Ligne n ° {}: {} {} n'existe pas."
 
-#: erpnext/stock/doctype/item/item.py:1403
+#: erpnext/stock/doctype/item/item.py:1397
 msgid "Row #{}: {} {} doesn't belong to Company {}. Please select valid {}."
 msgstr ""
 
@@ -45461,11 +45456,11 @@ msgstr "Ligne {0} : Nomenclature non trouvée pour l’Article {1}"
 msgid "Row {0}: Both Debit and Credit values cannot be zero"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:222
+#: erpnext/controllers/selling_controller.py:230
 msgid "Row {0}: Conversion Factor is mandatory"
 msgstr "Ligne {0} : Le Facteur de Conversion est obligatoire"
 
-#: erpnext/controllers/accounts_controller.py:2995
+#: erpnext/controllers/accounts_controller.py:2998
 msgid "Row {0}: Cost Center {1} does not belong to Company {2}"
 msgstr ""
 
@@ -45485,11 +45480,11 @@ msgstr "Ligne {0} : La devise de la nomenclature #{1} doit être égale à la de
 msgid "Row {0}: Debit entry can not be linked with a {1}"
 msgstr "Ligne {0} : L’Écriture de Débit ne peut pas être lié à un {1}"
 
-#: erpnext/controllers/selling_controller.py:776
+#: erpnext/controllers/selling_controller.py:784
 msgid "Row {0}: Delivery Warehouse ({1}) and Customer Warehouse ({2}) can not be same"
 msgstr "Ligne {0}: l'entrepôt de livraison ({1}) et l'entrepôt client ({2}) ne peuvent pas être identiques"
 
-#: erpnext/controllers/accounts_controller.py:2529
+#: erpnext/controllers/accounts_controller.py:2532
 msgid "Row {0}: Due Date in the Payment Terms table cannot be before Posting Date"
 msgstr "Ligne {0}: la date d'échéance dans le tableau des conditions de paiement ne peut pas être antérieure à la date comptable"
 
@@ -45498,7 +45493,7 @@ msgid "Row {0}: Either Delivery Note Item or Packed Item reference is mandatory.
 msgstr ""
 
 #: erpnext/accounts/doctype/journal_entry/journal_entry.py:1010
-#: erpnext/controllers/taxes_and_totals.py:1205
+#: erpnext/controllers/taxes_and_totals.py:1215
 msgid "Row {0}: Exchange Rate is mandatory"
 msgstr "Ligne {0} : Le Taux de Change est obligatoire"
 
@@ -45547,11 +45542,11 @@ msgstr "Ligne {0} : La valeur des heures doit être supérieure à zéro."
 msgid "Row {0}: Invalid reference {1}"
 msgstr "Ligne {0} : Référence {1} non valide"
 
-#: erpnext/controllers/taxes_and_totals.py:142
+#: erpnext/controllers/taxes_and_totals.py:143
 msgid "Row {0}: Item Tax template updated as per validity and rate applied"
 msgstr "Ligne {0}: Modèle de taxe d'article mis à jour selon la validité et le taux appliqué"
 
-#: erpnext/controllers/selling_controller.py:541
+#: erpnext/controllers/selling_controller.py:549
 msgid "Row {0}: Item rate has been updated as per valuation rate since its an internal stock transfer"
 msgstr ""
 
@@ -45671,7 +45666,7 @@ msgstr ""
 msgid "Row {0}: The item {1}, quantity must be positive number"
 msgstr "Ligne {0}: l'article {1}, la quantité doit être un nombre positif"
 
-#: erpnext/controllers/accounts_controller.py:2972
+#: erpnext/controllers/accounts_controller.py:2975
 msgid "Row {0}: The {3} Account {1} does not belong to the company {2}"
 msgstr ""
 
@@ -45688,7 +45683,7 @@ msgstr "Ligne {0} : Facteur de Conversion nomenclature est obligatoire"
 msgid "Row {0}: Workstation or Workstation Type is mandatory for an operation {1}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1011
+#: erpnext/controllers/accounts_controller.py:1014
 msgid "Row {0}: user has not applied the rule {1} on the item {2}"
 msgstr "Ligne {0}: l'utilisateur n'a pas appliqué la règle {1} sur l'élément {2}"
 
@@ -45700,7 +45695,7 @@ msgstr ""
 msgid "Row {0}: {1} must be greater than 0"
 msgstr "Ligne {0}: {1} doit être supérieure à 0"
 
-#: erpnext/controllers/accounts_controller.py:706
+#: erpnext/controllers/accounts_controller.py:709
 msgid "Row {0}: {1} {2} cannot be same as {3} (Party Account) {4}"
 msgstr ""
 
@@ -45716,7 +45711,7 @@ msgstr ""
 msgid "Row {1}: Quantity ({0}) cannot be a fraction. To allow this, disable '{2}' in UOM {3}."
 msgstr "Ligne {1}: la quantité ({0}) ne peut pas être une fraction. Pour autoriser cela, désactivez «{2}» dans UdM {3}."
 
-#: erpnext/controllers/buying_controller.py:863
+#: erpnext/controllers/buying_controller.py:871
 msgid "Row {idx}: Asset Naming Series is mandatory for the auto creation of assets for item {item_code}."
 msgstr ""
 
@@ -45742,7 +45737,7 @@ msgstr "Lignes supprimées dans {0}"
 msgid "Rows with Same Account heads will be merged on Ledger"
 msgstr "Les lignes associées aux mêmes codes comptables seront fusionnées dans le grand livre"
 
-#: erpnext/controllers/accounts_controller.py:2539
+#: erpnext/controllers/accounts_controller.py:2542
 msgid "Rows with duplicate due dates in other rows were found: {0}"
 msgstr "Des lignes avec des dates d'échéance en double dans les autres lignes ont été trouvées : {0}"
 
@@ -45812,7 +45807,7 @@ msgstr ""
 msgid "SLA Paused On"
 msgstr ""
 
-#: erpnext/public/js/utils.js:1167
+#: erpnext/public/js/utils.js:1163
 msgid "SLA is on hold since {0}"
 msgstr "SLA est en attente depuis le {0}"
 
@@ -46213,7 +46208,7 @@ msgstr ""
 #: erpnext/accounts/report/sales_register/sales_register.py:238
 #: erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
 #: erpnext/buying/doctype/supplier_quotation_item/supplier_quotation_item.json
-#: erpnext/controllers/selling_controller.py:462
+#: erpnext/controllers/selling_controller.py:470
 #: erpnext/crm/doctype/contract/contract.json
 #: erpnext/maintenance/doctype/maintenance_schedule/maintenance_schedule.js:65
 #: erpnext/maintenance/doctype/maintenance_schedule_item/maintenance_schedule_item.json
@@ -46339,7 +46334,7 @@ msgstr "Commande Client {0} n'a pas été transmise"
 msgid "Sales Order {0} is not valid"
 msgstr "Commande Client {0} invalide"
 
-#: erpnext/controllers/selling_controller.py:443
+#: erpnext/controllers/selling_controller.py:451
 #: erpnext/manufacturing/doctype/work_order/work_order.py:301
 msgid "Sales Order {0} is {1}"
 msgstr "Commande Client {0} est {1}"
@@ -46390,7 +46385,7 @@ msgstr "Commandes de vente à livrer"
 #: erpnext/accounts/doctype/promotional_scheme/promotional_scheme.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:122
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1156
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1158
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:99
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:194
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:74
@@ -46488,7 +46483,7 @@ msgstr "Résumé du paiement des ventes"
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:156
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:137
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:128
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1153
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1155
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:105
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:191
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:80
@@ -46508,7 +46503,7 @@ msgstr "Résumé du paiement des ventes"
 msgid "Sales Person"
 msgstr "Vendeur"
 
-#: erpnext/controllers/selling_controller.py:204
+#: erpnext/controllers/selling_controller.py:212
 msgid "Sales Person <b>{0}</b> is disabled."
 msgstr ""
 
@@ -46789,7 +46784,7 @@ msgstr "Entrepôt de stockage des échantillons"
 
 #. Label of the sample_size (Float) field in DocType 'Quality Inspection'
 #: erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py:93
-#: erpnext/public/js/controllers/transaction.js:2369
+#: erpnext/public/js/controllers/transaction.js:2395
 #: erpnext/stock/doctype/quality_inspection/quality_inspection.json
 msgid "Sample Size"
 msgstr "Taille de l'Échantillon"
@@ -47327,7 +47322,7 @@ msgstr "Sélectionner des éléments"
 msgid "Select Items based on Delivery Date"
 msgstr "Sélectionnez les articles en fonction de la Date de Livraison"
 
-#: erpnext/public/js/controllers/transaction.js:2405
+#: erpnext/public/js/controllers/transaction.js:2431
 msgid "Select Items for Quality Inspection"
 msgstr ""
 
@@ -47468,7 +47463,7 @@ msgstr "Sélectionnez d'abord la société"
 msgid "Select company name first."
 msgstr "Sélectionner d'abord le nom de la société."
 
-#: erpnext/controllers/accounts_controller.py:2785
+#: erpnext/controllers/accounts_controller.py:2788
 msgid "Select finance book for the item {0} at row {1}"
 msgstr "Sélectionnez le livre de financement pour l'élément {0} à la ligne {1}."
 
@@ -47681,7 +47676,7 @@ msgid "Send Now"
 msgstr "Envoyer Maintenant"
 
 #. Label of the send_sms (Button) field in DocType 'SMS Center'
-#: erpnext/public/js/controllers/transaction.js:517
+#: erpnext/public/js/controllers/transaction.js:543
 #: erpnext/selling/doctype/sms_center/sms_center.json
 msgid "Send SMS"
 msgstr "Envoyer un SMS"
@@ -47839,7 +47834,7 @@ msgstr ""
 #: erpnext/manufacturing/doctype/job_card/job_card.json
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.js:74
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.py:114
-#: erpnext/public/js/controllers/transaction.js:2382
+#: erpnext/public/js/controllers/transaction.js:2408
 #: erpnext/public/js/utils/serial_no_batch_selector.js:421
 #: erpnext/selling/doctype/installation_note_item/installation_note_item.json
 #: erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
@@ -47888,7 +47883,7 @@ msgstr ""
 msgid "Serial No Range"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1894
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1895
 msgid "Serial No Reserved"
 msgstr ""
 
@@ -47928,7 +47923,7 @@ msgstr "N° de Série et lot"
 msgid "Serial No and Batch Selector cannot be use when Use Serial / Batch Fields is enabled."
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:859
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:860
 msgid "Serial No is mandatory"
 msgstr ""
 
@@ -47957,7 +47952,7 @@ msgstr "N° de Série {0} n'appartient pas à l'Article {1}"
 msgid "Serial No {0} does not exist"
 msgstr "N° de Série {0} n’existe pas"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2623
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2624
 msgid "Serial No {0} does not exists"
 msgstr ""
 
@@ -47965,7 +47960,7 @@ msgstr ""
 msgid "Serial No {0} is already added"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:357
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:358
 msgid "Serial No {0} is not present in the {1} {2}, hence you can't return it against the {1} {2}"
 msgstr ""
 
@@ -48002,11 +47997,11 @@ msgstr ""
 msgid "Serial Nos and Batches"
 msgstr "N° de Série et Lots"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1370
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1371
 msgid "Serial Nos are created successfully"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:2137
+#: erpnext/stock/stock_ledger.py:2145
 msgid "Serial Nos are reserved in Stock Reservation Entries, you need to unreserve them before proceeding."
 msgstr ""
 
@@ -48080,11 +48075,11 @@ msgstr ""
 msgid "Serial and Batch Bundle"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1598
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1599
 msgid "Serial and Batch Bundle created"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1664
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1665
 msgid "Serial and Batch Bundle updated"
 msgstr ""
 
@@ -48436,12 +48431,12 @@ msgid "Service Stop Date"
 msgstr "Date d'arrêt du service"
 
 #: erpnext/accounts/deferred_revenue.py:44
-#: erpnext/public/js/controllers/transaction.js:1420
+#: erpnext/public/js/controllers/transaction.js:1446
 msgid "Service Stop Date cannot be after Service End Date"
 msgstr "La date d'arrêt du service ne peut pas être postérieure à la date de fin du service"
 
 #: erpnext/accounts/deferred_revenue.py:41
-#: erpnext/public/js/controllers/transaction.js:1417
+#: erpnext/public/js/controllers/transaction.js:1443
 msgid "Service Stop Date cannot be before Service Start Date"
 msgstr "La date d'arrêt du service ne peut pas être antérieure à la date de début du service"
 
@@ -49876,7 +49871,7 @@ msgstr ""
 
 #: erpnext/setup/setup_wizard/operations/defaults_setup.py:70
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:463
-#: erpnext/stock/doctype/item/item.py:245
+#: erpnext/stock/doctype/item/item.py:248
 msgid "Standard Selling"
 msgstr "Vente standard"
 
@@ -50706,7 +50701,7 @@ msgstr "Stock Reçus Mais Non Facturés"
 #. Option for the 'Purpose' (Select) field in DocType 'Stock Reconciliation'
 #. Label of a Link in the Stock Workspace
 #: erpnext/setup/workspace/home/home.json
-#: erpnext/stock/doctype/item/item.py:612
+#: erpnext/stock/doctype/item/item.py:618
 #: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.json
 #: erpnext/stock/workspace/stock/stock.json
 msgid "Stock Reconciliation"
@@ -50717,7 +50712,7 @@ msgstr "Réconciliation du Stock"
 msgid "Stock Reconciliation Item"
 msgstr "Article de Réconciliation du Stock"
 
-#: erpnext/stock/doctype/item/item.py:612
+#: erpnext/stock/doctype/item/item.py:618
 msgid "Stock Reconciliations"
 msgstr "Rapprochements des stocks"
 
@@ -50752,7 +50747,7 @@ msgstr ""
 #: erpnext/stock/doctype/pick_list/pick_list.js:150
 #: erpnext/stock/doctype/pick_list/pick_list.js:155
 #: erpnext/stock/doctype/stock_entry/stock_entry_dashboard.py:25
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:706
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:702
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:575
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:1138
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:1398
@@ -51152,7 +51147,7 @@ msgstr "Un ordre de fabrication arrêté ne peut être annulé, Re-démarrez le 
 #: erpnext/setup/doctype/company/company.py:287
 #: erpnext/setup/setup_wizard/operations/defaults_setup.py:33
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:502
-#: erpnext/stock/doctype/item/item.py:282
+#: erpnext/stock/doctype/item/item.py:285
 msgid "Stores"
 msgstr "Magasins"
 
@@ -51687,7 +51682,7 @@ msgstr "Réconcilié avec succès"
 msgid "Successfully Set Supplier"
 msgstr "Fournisseur défini avec succès"
 
-#: erpnext/stock/doctype/item/item.py:339
+#: erpnext/stock/doctype/item/item.py:342
 msgid "Successfully changed Stock UOM, please redefine conversion factors for new UOM."
 msgstr ""
 
@@ -51989,7 +51984,7 @@ msgstr "Détails du Fournisseur"
 #: erpnext/accounts/doctype/tax_rule/tax_rule.json
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:111
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:87
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1160
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1162
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:198
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:237
 #: erpnext/accounts/report/purchase_register/purchase_register.js:27
@@ -52089,7 +52084,7 @@ msgstr "Récapitulatif du grand livre des fournisseurs"
 #. Label of the supplier_name (Data) field in DocType 'Purchase Receipt'
 #. Label of the supplier_name (Data) field in DocType 'Stock Entry'
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1077
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1079
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:156
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:198
 #: erpnext/accounts/report/purchase_register/purchase_register.py:177
@@ -52573,7 +52568,7 @@ msgstr "le systéme va créer des numéros de séries / lots à la validation de
 msgid "System will fetch all the entries if limit value is zero."
 msgstr "Le système récupérera toutes les entrées si la valeur limite est zéro."
 
-#: erpnext/controllers/accounts_controller.py:1975
+#: erpnext/controllers/accounts_controller.py:1978
 msgid "System will not check over billing since amount for Item {0} in {1} is zero"
 msgstr ""
 
@@ -52832,7 +52827,7 @@ msgstr ""
 msgid "Target Warehouse is required before Submit"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:782
+#: erpnext/controllers/selling_controller.py:790
 msgid "Target Warehouse is set for some items but the customer is not an internal customer."
 msgstr ""
 
@@ -53071,7 +53066,7 @@ msgstr "Répartition des Taxes"
 msgid "Tax Category"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:194
+#: erpnext/controllers/buying_controller.py:202
 msgid "Tax Category has been changed to \"Total\" because all the Items are non-stock items"
 msgstr "La Catégorie de Taxe a été changée à \"Total\" car tous les articles sont des articles hors stock"
 
@@ -53276,7 +53271,7 @@ msgstr ""
 #. Label of the taxable_amount (Currency) field in DocType 'Tax Withheld
 #. Vouchers'
 #: erpnext/accounts/doctype/tax_withheld_vouchers/tax_withheld_vouchers.json
-#: erpnext/controllers/taxes_and_totals.py:1125
+#: erpnext/controllers/taxes_and_totals.py:1135
 msgid "Taxable Amount"
 msgstr "Montant Taxable"
 
@@ -53415,7 +53410,7 @@ msgstr "Taxes et Frais Déductibles"
 msgid "Taxes and Charges Deducted (Company Currency)"
 msgstr "Taxes et Frais Déductibles (Devise Société)"
 
-#: erpnext/stock/doctype/item/item.py:352
+#: erpnext/stock/doctype/item/item.py:355
 msgid "Taxes row #{0}: {1} cannot be smaller than {2}"
 msgstr ""
 
@@ -53701,7 +53696,7 @@ msgstr "Modèle des Termes et Conditions"
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/territory_item/territory_item.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:134
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1144
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1146
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:93
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:182
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:68
@@ -53805,7 +53800,7 @@ msgstr "L'accès à la demande de devis du portail est désactivé. Pour autoris
 msgid "The BOM which will be replaced"
 msgstr "La nomenclature qui sera remplacée"
 
-#: erpnext/stock/serial_batch_bundle.py:1274
+#: erpnext/stock/serial_batch_bundle.py:1306
 msgid "The Batch {0} has negative quantity {1} in warehouse {2}. Please correct the quantity."
 msgstr ""
 
@@ -53857,7 +53852,7 @@ msgstr ""
 msgid "The Serial No at Row #{0}: {1} is not available in warehouse {2}."
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1891
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1892
 msgid "The Serial No {0} is reserved against the {1} {2} and cannot be used for any other transaction."
 msgstr ""
 
@@ -53940,7 +53935,7 @@ msgstr ""
 msgid "The following batches are expired, please restock them: <br> {0}"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:849
+#: erpnext/stock/doctype/item/item.py:843
 msgid "The following deleted attributes exist in Variants but not in the Template. You can either delete the Variants or keep the attribute(s) in template."
 msgstr "Les attributs supprimés suivants existent dans les variantes mais pas dans le modèle. Vous pouvez supprimer les variantes ou conserver le ou les attributs dans le modèle."
 
@@ -53965,15 +53960,15 @@ msgstr "Le poids brut du colis. Habituellement poids net + poids du matériau d'
 msgid "The holiday on {0} is not between From Date and To Date"
 msgstr "Le jour de vacances {0} n’est pas compris entre la Date Initiale et la Date Finale"
 
-#: erpnext/controllers/buying_controller.py:1066
+#: erpnext/controllers/buying_controller.py:1074
 msgid "The item {item} is not marked as {type_of} item. You can enable it as {type_of} item from its Item master."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:614
+#: erpnext/stock/doctype/item/item.py:620
 msgid "The items {0} and {1} are present in the following {2} :"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:1059
+#: erpnext/controllers/buying_controller.py:1067
 msgid "The items {items} are not marked as {type_of} item. You can enable them as {type_of} item from their Item masters."
 msgstr ""
 
@@ -54075,8 +54070,8 @@ msgstr "L’article sélectionné ne peut pas avoir de Lot"
 msgid "The seller and the buyer cannot be the same"
 msgstr "Le vendeur et l'acheteur ne peuvent pas être les mêmes"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:142
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:154
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:143
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:155
 msgid "The serial and batch bundle {0} not linked to {1} {2}"
 msgstr ""
 
@@ -54100,7 +54095,7 @@ msgstr "Les actions n'existent pas pour {0}"
 msgid "The stock for the item {0} in the {1} warehouse was negative on the {2}. You should create a positive entry {3} before the date {4} and time {5} to post the correct valuation rate. For more details, please read the <a href='https://docs.erpnext.com/docs/user/manual/en/stock-adjustment-cogs-with-negative-stock'>documentation<a>."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:700
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:696
 msgid "The stock has been reserved for the following Items and Warehouses, un-reserve the same to {0} the Stock Reconciliation: <br /><br /> {1}"
 msgstr "Le stock a été réservé pour les articles et entrepôts suivants, annulez-le pour {0} l'inventaire: <br /><br /> {1}"
 
@@ -54113,11 +54108,11 @@ msgstr ""
 msgid "The task has been enqueued as a background job."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:994
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:990
 msgid "The task has been enqueued as a background job. In case there is any issue on processing in background, the system will add a comment about the error on this Stock Reconciliation and revert to the Draft stage"
 msgstr "La tâche a été mise en file d'attente en tant que tâche en arrière-plan. En cas de problème de traitement en arrière-plan, le système ajoute un commentaire concernant l'erreur sur ce rapprochement des stocks et revient au stade de brouillon."
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1005
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1001
 msgid "The task has been enqueued as a background job. In case there is any issue on processing in background, the system will add a comment about the error on this Stock Reconciliation and revert to the Submitted stage"
 msgstr ""
 
@@ -54167,7 +54162,7 @@ msgstr ""
 msgid "The {0} ({1}) must be equal to {2} ({3})"
 msgstr "Le {0} ({1}) doit être égal à {2} ({3})"
 
-#: erpnext/public/js/controllers/transaction.js:2790
+#: erpnext/public/js/controllers/transaction.js:2816
 msgid "The {0} contains Unit Price Items."
 msgstr ""
 
@@ -54215,7 +54210,7 @@ msgstr ""
 msgid "There can be multiple tiered collection factor based on the total spent. But the conversion factor for redemption will always be same for all the tier."
 msgstr ""
 
-#: erpnext/accounts/party.py:580
+#: erpnext/accounts/party.py:586
 msgid "There can only be 1 Account per Company in {0} {1}"
 msgstr "Il ne peut y avoir qu’un Compte par Société dans {0} {1}"
 
@@ -54501,7 +54496,7 @@ msgstr "Ce sera ajoutée au Code de la Variante de l'Article. Par exemple, si vo
 msgid "This will restrict user access to other employee records"
 msgstr "Cela limitera l'accès des utilisateurs aux données des autres employés"
 
-#: erpnext/controllers/selling_controller.py:783
+#: erpnext/controllers/selling_controller.py:791
 msgid "This {} will be treated as material transfer."
 msgstr ""
 
@@ -55215,11 +55210,11 @@ msgid "To include sub-assembly costs and scrap items in Finished Goods on a work
 msgstr ""
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:2337
-#: erpnext/controllers/accounts_controller.py:3005
+#: erpnext/controllers/accounts_controller.py:3008
 msgid "To include tax in row {0} in Item rate, taxes in rows {1} must also be included"
 msgstr "Pour inclure la taxe de la ligne {0} dans le prix de l'Article, les taxes des lignes {1} doivent également être incluses"
 
-#: erpnext/stock/doctype/item/item.py:636
+#: erpnext/stock/doctype/item/item.py:642
 msgid "To merge, following properties must be same for both items"
 msgstr "Pour fusionner, les propriétés suivantes doivent être les mêmes pour les deux articles"
 
@@ -55839,7 +55834,7 @@ msgstr "Encours total"
 msgid "Total Paid Amount"
 msgstr "Montant total payé"
 
-#: erpnext/controllers/accounts_controller.py:2591
+#: erpnext/controllers/accounts_controller.py:2594
 msgid "Total Payment Amount in Payment Schedule must be equal to Grand / Rounded Total"
 msgstr "Le montant total du paiement dans l'échéancier doit être égal au Total Général / Total Arrondi"
 
@@ -56124,15 +56119,15 @@ msgstr ""
 msgid "Total Working Hours"
 msgstr "Total des Heures Travaillées"
 
-#: erpnext/controllers/accounts_controller.py:2138
+#: erpnext/controllers/accounts_controller.py:2141
 msgid "Total advance ({0}) against Order {1} cannot be greater than the Grand Total ({2})"
 msgstr "Avance totale ({0}) pour la Commande {1} ne peut pas être supérieure au Total Général ({2})"
 
-#: erpnext/controllers/selling_controller.py:190
+#: erpnext/controllers/selling_controller.py:198
 msgid "Total allocated percentage for sales team should be 100"
 msgstr "Pourcentage total attribué à l'équipe commerciale devrait être de 100"
 
-#: erpnext/selling/doctype/customer/customer.py:162
+#: erpnext/selling/doctype/customer/customer.py:161
 msgid "Total contribution percentage should be equal to 100"
 msgstr "Le pourcentage total de contribution devrait être égal à 100"
 
@@ -57017,7 +57012,7 @@ msgstr "Unité de mesure"
 msgid "Unit of Measure (UOM)"
 msgstr "Unité de mesure (UdM)"
 
-#: erpnext/stock/doctype/item/item.py:384
+#: erpnext/stock/doctype/item/item.py:387
 msgid "Unit of Measure {0} has been entered more than once in Conversion Factor Table"
 msgstr "Unité de Mesure {0} a été saisie plus d'une fois dans la Table de Facteur de Conversion"
 
@@ -57459,7 +57454,7 @@ msgstr ""
 msgid "Update timestamp on new communication"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom_creator/bom_creator.py:533
+#: erpnext/manufacturing/doctype/bom_creator/bom_creator.py:534
 msgid "Updated successfully"
 msgstr "Mis à jour avec succés"
 
@@ -57473,7 +57468,7 @@ msgstr "Mis à jour avec succés"
 msgid "Updated via 'Time Log' (In Minutes)"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1387
+#: erpnext/stock/doctype/item/item.py:1381
 msgid "Updating Variants..."
 msgstr "Mise à jour des variantes ..."
 
@@ -58031,19 +58026,19 @@ msgstr "Taux de Valorisation"
 msgid "Valuation Rate (In / Out)"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1881
+#: erpnext/stock/stock_ledger.py:1890
 msgid "Valuation Rate Missing"
 msgstr "Taux de valorisation manquant"
 
-#: erpnext/stock/stock_ledger.py:1859
+#: erpnext/stock/stock_ledger.py:1868
 msgid "Valuation Rate for the Item {0}, is required to do accounting entries for {1} {2}."
 msgstr "Le taux de valorisation de l'article {0} est requis pour effectuer des écritures comptables pour {1} {2}."
 
-#: erpnext/stock/doctype/item/item.py:266
+#: erpnext/stock/doctype/item/item.py:269
 msgid "Valuation Rate is mandatory if Opening Stock entered"
 msgstr "Le Taux de Valorisation est obligatoire si un Stock Initial est entré"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:752
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:748
 msgid "Valuation Rate required for Item {0} at row {1}"
 msgstr "Taux de valorisation requis pour le poste {0} à la ligne {1}"
 
@@ -58053,7 +58048,7 @@ msgstr "Taux de valorisation requis pour le poste {0} à la ligne {1}"
 msgid "Valuation and Total"
 msgstr "Valorisation et Total"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:971
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:967
 msgid "Valuation rate for customer provided items has been set to zero."
 msgstr ""
 
@@ -58067,7 +58062,7 @@ msgid "Valuation rate for the item as per Sales Invoice (Only for Internal Trans
 msgstr ""
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:2361
-#: erpnext/controllers/accounts_controller.py:3029
+#: erpnext/controllers/accounts_controller.py:3032
 msgid "Valuation type charges can not be marked as Inclusive"
 msgstr "Les frais de type d'évaluation ne peuvent pas être marqués comme inclusifs"
 
@@ -58223,7 +58218,7 @@ msgstr ""
 msgid "Variant"
 msgstr "Variante"
 
-#: erpnext/stock/doctype/item/item.py:864
+#: erpnext/stock/doctype/item/item.py:858
 msgid "Variant Attribute Error"
 msgstr "Erreur d'attribut de variante"
 
@@ -58242,7 +58237,7 @@ msgstr "Variante de nomenclature"
 msgid "Variant Based On"
 msgstr "Variante Basée Sur"
 
-#: erpnext/stock/doctype/item/item.py:892
+#: erpnext/stock/doctype/item/item.py:886
 msgid "Variant Based On cannot be changed"
 msgstr "Les variantes basées sur ne peuvent pas être modifiées"
 
@@ -58260,7 +58255,7 @@ msgstr "Champ de Variante"
 msgid "Variant Item"
 msgstr "Élément de variante"
 
-#: erpnext/stock/doctype/item/item.py:862
+#: erpnext/stock/doctype/item/item.py:856
 msgid "Variant Items"
 msgstr "Articles de variante"
 
@@ -58378,7 +58373,7 @@ msgstr "Paramètres vidéo"
 #: erpnext/accounts/doctype/cost_center/cost_center_tree.js:56
 #: erpnext/accounts/doctype/invoice_discounting/invoice_discounting.js:205
 #: erpnext/accounts/doctype/journal_entry/journal_entry.js:43
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:668
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:670
 #: erpnext/bulk_transaction/doctype/bulk_transaction_log/bulk_transaction_log.js:14
 #: erpnext/bulk_transaction/doctype/bulk_transaction_log/bulk_transaction_log.js:24
 #: erpnext/buying/doctype/request_for_quotation/request_for_quotation.js:167
@@ -58565,7 +58560,7 @@ msgstr ""
 #: erpnext/accounts/doctype/repost_accounting_ledger_items/repost_accounting_ledger_items.json
 #: erpnext/accounts/doctype/repost_payment_ledger_items/repost_payment_ledger_items.json
 #: erpnext/accounts/doctype/unreconcile_payment/unreconcile_payment.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1099
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1101
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.js:42
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:209
 #: erpnext/accounts/report/general_ledger/general_ledger.js:49
@@ -58596,7 +58591,7 @@ msgstr ""
 msgid "Voucher No"
 msgstr "N° de Référence"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1087
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1088
 msgid "Voucher No is mandatory"
 msgstr ""
 
@@ -58638,7 +58633,7 @@ msgstr ""
 #: erpnext/accounts/doctype/repost_payment_ledger_items/repost_payment_ledger_items.json
 #: erpnext/accounts/doctype/tax_withheld_vouchers/tax_withheld_vouchers.json
 #: erpnext/accounts/doctype/unreconcile_payment/unreconcile_payment.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1097
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1099
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:200
 #: erpnext/accounts/report/general_ledger/general_ledger.py:697
 #: erpnext/accounts/report/invalid_ledger_entries/invalid_ledger_entries.py:31
@@ -58992,10 +58987,6 @@ msgstr "L'entrepôt est obligatoire"
 msgid "Warehouse not found against the account {0}"
 msgstr "Entrepôt introuvable sur le compte {0}"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:600
-msgid "Warehouse not found in the system"
-msgstr "L'entrepôt n'a pas été trouvé dans le système"
-
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:1130
 #: erpnext/stock/doctype/delivery_note/delivery_note.py:414
 msgid "Warehouse required for stock Item {0}"
@@ -59124,7 +59115,7 @@ msgid "Warn for new Request for Quotations"
 msgstr "Avertir lors d'une nouvelle Demande de Devis"
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:744
-#: erpnext/controllers/accounts_controller.py:1978
+#: erpnext/controllers/accounts_controller.py:1981
 #: erpnext/stock/doctype/delivery_trip/delivery_trip.js:145
 #: erpnext/utilities/transaction_base.py:123
 msgid "Warning"
@@ -60096,7 +60087,7 @@ msgstr "Oui"
 msgid "You are importing data for the code list:"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3611
+#: erpnext/controllers/accounts_controller.py:3614
 msgid "You are not allowed to update as per the conditions set in {} Workflow."
 msgstr "Vous n'êtes pas autorisé à effectuer la mise à jour selon les conditions définies dans {} Workflow."
 
@@ -60161,7 +60152,7 @@ msgstr ""
 msgid "You can't make any changes to Job Card since Work Order is closed."
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:185
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:186
 msgid "You can't process the serial number {0} as it has already been used in the SABB {1}. {2} if you want to inward same serial number multiple times then enabled 'Allow existing Serial No to be Manufactured/Received again' in the {3}"
 msgstr ""
 
@@ -60221,7 +60212,7 @@ msgstr "Vous ne pouvez pas valider la commande sans paiement."
 msgid "You cannot {0} this document because another Period Closing Entry {1} exists after {2}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3587
+#: erpnext/controllers/accounts_controller.py:3590
 msgid "You do not have permissions to {} items in a {}."
 msgstr "Vous ne disposez pas des autorisations nécessaires pour {} éléments dans un {}."
 
@@ -60249,7 +60240,7 @@ msgstr ""
 msgid "You have entered a duplicate Delivery Note on Row"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1063
+#: erpnext/stock/doctype/item/item.py:1057
 msgid "You have to enable auto re-order in Stock Settings to maintain re-order levels."
 msgstr "Vous devez activer la re-commande automatique dans les paramètres de stock pour maintenir les niveaux de ré-commande."
 
@@ -60269,7 +60260,7 @@ msgstr "Vous devez sélectionner un client avant d'ajouter un article."
 msgid "You need to cancel POS Closing Entry {} to be able to cancel this document."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2980
+#: erpnext/controllers/accounts_controller.py:2983
 msgid "You selected the account group {1} as {2} Account in row {0}. Please select a single account."
 msgstr ""
 
@@ -60347,7 +60338,7 @@ msgstr "[Important] [ERPNext] Erreurs de réorganisation automatique"
 msgid "`Allow Negative rates for Items`"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1873
+#: erpnext/stock/stock_ledger.py:1882
 msgid "after"
 msgstr ""
 
@@ -60495,7 +60486,7 @@ msgstr "Lft"
 msgid "material_request_item"
 msgstr "article_demande_de_materiel"
 
-#: erpnext/controllers/selling_controller.py:151
+#: erpnext/controllers/selling_controller.py:159
 msgid "must be between 0 and 100"
 msgstr ""
 
@@ -60520,7 +60511,7 @@ msgstr "grand_parent"
 msgid "on"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1289
+#: erpnext/controllers/accounts_controller.py:1292
 msgid "or"
 msgstr "ou"
 
@@ -60569,7 +60560,7 @@ msgstr ""
 msgid "per hour"
 msgstr "par heure"
 
-#: erpnext/stock/stock_ledger.py:1874
+#: erpnext/stock/stock_ledger.py:1883
 msgid "performing either one below:"
 msgstr ""
 
@@ -60696,7 +60687,7 @@ msgstr "vous devez sélectionner le compte des travaux d'immobilisations en cour
 msgid "{0}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1109
+#: erpnext/controllers/accounts_controller.py:1112
 msgid "{0} '{1}' is disabled"
 msgstr "{0} '{1}' est désactivé(e)"
 
@@ -60712,7 +60703,7 @@ msgstr "{0} ({1}) ne peut pas être supérieur à la quantité planifiée ({2}) 
 msgid "{0} <b>{1}</b> has submitted Assets. Remove Item <b>{2}</b> from table to continue."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2193
+#: erpnext/controllers/accounts_controller.py:2196
 msgid "{0} Account not found against Customer {1}."
 msgstr ""
 
@@ -60744,7 +60735,7 @@ msgstr "{0} Opérations: {1}"
 msgid "{0} Request for {1}"
 msgstr "{0} demande de {1}"
 
-#: erpnext/stock/doctype/item/item.py:323
+#: erpnext/stock/doctype/item/item.py:326
 msgid "{0} Retain Sample is based on batch, please check Has Batch No to retain sample of item"
 msgstr "{0} Conserver l'échantillon est basé sur le lot, veuillez cocher A un numéro de lot pour conserver l'échantillon d'article"
 
@@ -60835,7 +60826,7 @@ msgid "{0} entered twice in Item Tax"
 msgstr "{0} est entré deux fois dans la Taxe de l'Article"
 
 #: erpnext/setup/doctype/item_group/item_group.py:48
-#: erpnext/stock/doctype/item/item.py:436
+#: erpnext/stock/doctype/item/item.py:439
 msgid "{0} entered twice {1} in Item Taxes"
 msgstr ""
 
@@ -60856,7 +60847,7 @@ msgstr "{0} a été envoyé avec succès"
 msgid "{0} hours"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2534
+#: erpnext/controllers/accounts_controller.py:2537
 msgid "{0} in row {1}"
 msgstr "{0} dans la ligne {1}"
 
@@ -60880,7 +60871,7 @@ msgstr "{0} est bloqué donc cette transaction ne peut pas continuer"
 
 #: erpnext/accounts/doctype/budget/budget.py:60
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:643
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:49
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:50
 #: erpnext/accounts/report/general_ledger/general_ledger.py:59
 #: erpnext/accounts/report/pos_register/pos_register.py:107
 #: erpnext/controllers/trends.py:50
@@ -60900,11 +60891,11 @@ msgstr ""
 msgid "{0} is mandatory. Maybe Currency Exchange record is not created for {1} to {2}"
 msgstr "{0} est obligatoire. L'enregistrement de change de devises n'est peut-être pas créé pour le {1} au {2}"
 
-#: erpnext/controllers/accounts_controller.py:2937
+#: erpnext/controllers/accounts_controller.py:2940
 msgid "{0} is mandatory. Maybe Currency Exchange record is not created for {1} to {2}."
 msgstr "{0} est obligatoire. Peut-être qu’un enregistrement de Taux de Change n'est pas créé pour {1} et {2}."
 
-#: erpnext/selling/doctype/customer/customer.py:204
+#: erpnext/selling/doctype/customer/customer.py:203
 msgid "{0} is not a company bank account"
 msgstr "{0} n'est pas un compte bancaire d'entreprise"
 
@@ -60987,7 +60978,7 @@ msgstr ""
 msgid "{0} to {1}"
 msgstr "{0} à {1}"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:690
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:686
 msgid "{0} units are reserved for Item {1} in Warehouse {2}, please un-reserve the same to {3} the Stock Reconciliation."
 msgstr ""
 
@@ -61003,16 +60994,16 @@ msgstr ""
 msgid "{0} units of {1} are required in {2} with the inventory dimension: {3} ({4}) on {5} {6} for {7} to complete the transaction."
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1532 erpnext/stock/stock_ledger.py:2023
-#: erpnext/stock/stock_ledger.py:2037
+#: erpnext/stock/stock_ledger.py:1541 erpnext/stock/stock_ledger.py:2031
+#: erpnext/stock/stock_ledger.py:2045
 msgid "{0} units of {1} needed in {2} on {3} {4} for {5} to complete this transaction."
 msgstr "{0} unités de {1} nécessaires dans {2} sur {3} {4} pour {5} pour compléter cette transaction."
 
-#: erpnext/stock/stock_ledger.py:2124 erpnext/stock/stock_ledger.py:2170
+#: erpnext/stock/stock_ledger.py:2132 erpnext/stock/stock_ledger.py:2178
 msgid "{0} units of {1} needed in {2} on {3} {4} to complete this transaction."
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1526
+#: erpnext/stock/stock_ledger.py:1535
 msgid "{0} units of {1} needed in {2} to complete this transaction."
 msgstr "{0} unités de {1} nécessaires dans {2} pour compléter cette transaction."
 
@@ -61058,7 +61049,7 @@ msgstr "{0} {1} créé"
 msgid "{0} {1} does not exist"
 msgstr "{0} {1} n'existe pas"
 
-#: erpnext/accounts/party.py:560
+#: erpnext/accounts/party.py:566
 msgid "{0} {1} has accounting entries in currency {2} for company {3}. Please select a receivable or payable account with currency {2}."
 msgstr "{0} {1} a des écritures comptables dans la devise {2} pour l'entreprise {3}. Veuillez sélectionner un compte à recevoir ou à payer avec la devise {2}."
 
@@ -61092,7 +61083,7 @@ msgstr ""
 msgid "{0} {1} is associated with {2}, but Party Account is {3}"
 msgstr "{0} {1} est associé à {2}, mais le compte tiers est {3}"
 
-#: erpnext/controllers/selling_controller.py:462
+#: erpnext/controllers/selling_controller.py:470
 #: erpnext/controllers/subcontracting_controller.py:954
 msgid "{0} {1} is cancelled or closed"
 msgstr "{0} {1} est annulé ou fermé"
@@ -61109,11 +61100,11 @@ msgstr "{0} {1} est annulé, donc l'action ne peut pas être complétée"
 msgid "{0} {1} is closed"
 msgstr "{0} {1} est fermé"
 
-#: erpnext/accounts/party.py:798
+#: erpnext/accounts/party.py:804
 msgid "{0} {1} is disabled"
 msgstr "{0} {1} est désactivé"
 
-#: erpnext/accounts/party.py:804
+#: erpnext/accounts/party.py:810
 msgid "{0} {1} is frozen"
 msgstr "{0} {1} est gelée"
 
@@ -61121,7 +61112,7 @@ msgstr "{0} {1} est gelée"
 msgid "{0} {1} is fully billed"
 msgstr "{0} {1} est entièrement facturé"
 
-#: erpnext/accounts/party.py:808
+#: erpnext/accounts/party.py:814
 msgid "{0} {1} is not active"
 msgstr "{0} {1} n'est pas actif"
 
@@ -61247,15 +61238,15 @@ msgstr "{0} : {1} n’existe pas"
 msgid "{0}: {1} must be less than {2}"
 msgstr "{0}: {1} doit être inférieur à {2}"
 
-#: erpnext/controllers/buying_controller.py:840
+#: erpnext/controllers/buying_controller.py:848
 msgid "{count} Assets created for {item_code}"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:738
+#: erpnext/controllers/buying_controller.py:746
 msgid "{doctype} {name} is cancelled or closed."
 msgstr "{doctype} {name} est annulé ou fermé."
 
-#: erpnext/controllers/buying_controller.py:459
+#: erpnext/controllers/buying_controller.py:467
 msgid "{field_label} is mandatory for sub-contracted {doctype}."
 msgstr ""
 
@@ -61263,7 +61254,7 @@ msgstr ""
 msgid "{item_name}'s Sample Size ({sample_size}) cannot be greater than the Accepted Quantity ({accepted_quantity})"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:563
+#: erpnext/controllers/buying_controller.py:571
 msgid "{ref_doctype} {ref_name} is {status}."
 msgstr ""
 
@@ -61329,7 +61320,7 @@ msgstr ""
 msgid "{} can't be cancelled since the Loyalty Points earned has been redeemed. First cancel the {} No {}"
 msgstr "{} ne peut pas être annulé car les points de fidélité gagnés ont été utilisés. Annulez d'abord le {} Non {}"
 
-#: erpnext/controllers/buying_controller.py:222
+#: erpnext/controllers/buying_controller.py:230
 msgid "{} has submitted assets linked to it. You need to cancel the assets to create purchase return."
 msgstr "{} a soumis des éléments qui lui sont associés. Vous devez annuler les actifs pour créer un retour d'achat."
 

--- a/erpnext/locale/hr.po
+++ b/erpnext/locale/hr.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: frappe\n"
 "Report-Msgid-Bugs-To: hello@frappe.io\n"
-"POT-Creation-Date: 2025-05-25 09:35+0000\n"
-"PO-Revision-Date: 2025-05-25 20:35\n"
+"POT-Creation-Date: 2025-06-01 09:36+0000\n"
+"PO-Revision-Date: 2025-06-01 21:35\n"
 "Last-Translator: hello@frappe.io\n"
 "Language-Team: Croatian\n"
 "MIME-Version: 1.0\n"
@@ -83,15 +83,15 @@ msgstr " Podsklop"
 msgid " Summary"
 msgstr " Sažetak"
 
-#: erpnext/stock/doctype/item/item.py:235
+#: erpnext/stock/doctype/item/item.py:238
 msgid "\"Customer Provided Item\" cannot be Purchase Item also"
 msgstr "\"Artikal koji osigurava Klijent\" ne može biti Kupovni Artikal"
 
-#: erpnext/stock/doctype/item/item.py:237
+#: erpnext/stock/doctype/item/item.py:240
 msgid "\"Customer Provided Item\" cannot have Valuation Rate"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:313
+#: erpnext/stock/doctype/item/item.py:316
 msgid "\"Is Fixed Asset\" cannot be unchecked, as Asset record exists against the item"
 msgstr ""
 
@@ -213,7 +213,7 @@ msgstr ""
 msgid "% of materials delivered against this Sales Order"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2197
+#: erpnext/controllers/accounts_controller.py:2200
 msgid "'Account' in the Accounting section of Customer {0}"
 msgstr ""
 
@@ -225,15 +225,11 @@ msgstr ""
 msgid "'Based On' and 'Group By' can not be same"
 msgstr ""
 
-#: erpnext/stock/report/product_bundle_balance/product_bundle_balance.py:233
-msgid "'Date' is required"
-msgstr ""
-
 #: erpnext/selling/report/inactive_customers/inactive_customers.py:18
 msgid "'Days Since Last Order' must be greater than or equal to zero"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2202
+#: erpnext/controllers/accounts_controller.py:2205
 msgid "'Default {0} Account' in Company {1}"
 msgstr "'Standard {0} račun' u Tvrtki {1}"
 
@@ -243,7 +239,7 @@ msgstr ""
 
 #: erpnext/stock/report/batch_item_expiry_status/batch_item_expiry_status.py:24
 #: erpnext/stock/report/batch_wise_balance_history/batch_wise_balance_history.py:120
-#: erpnext/stock/report/stock_analytics/stock_analytics.py:314
+#: erpnext/stock/report/stock_analytics/stock_analytics.py:313
 msgid "'From Date' is required"
 msgstr ""
 
@@ -251,7 +247,7 @@ msgstr ""
 msgid "'From Date' must be after 'To Date'"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:398
+#: erpnext/stock/doctype/item/item.py:401
 msgid "'Has Serial No' can not be 'Yes' for non-stock item"
 msgstr ""
 
@@ -1075,7 +1071,7 @@ msgstr ""
 
 #. Label of the qty (Float) field in DocType 'Purchase Receipt Item'
 #. Label of the qty (Float) field in DocType 'Subcontracting Receipt Item'
-#: erpnext/public/js/controllers/transaction.js:2362
+#: erpnext/public/js/controllers/transaction.js:2388
 #: erpnext/stock/doctype/purchase_receipt_item/purchase_receipt_item.json
 #: erpnext/subcontracting/doctype/subcontracting_receipt_item/subcontracting_receipt_item.json
 msgid "Accepted Quantity"
@@ -1273,7 +1269,7 @@ msgid "Account Manager"
 msgstr ""
 
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:949
-#: erpnext/controllers/accounts_controller.py:2206
+#: erpnext/controllers/accounts_controller.py:2209
 msgid "Account Missing"
 msgstr ""
 
@@ -1448,7 +1444,7 @@ msgstr "Račun {0} je dodan u podređenu tvrtku {1}"
 msgid "Account {0} is frozen"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1288
+#: erpnext/controllers/accounts_controller.py:1291
 msgid "Account {0} is invalid. Account Currency must be {1}"
 msgstr ""
 
@@ -1484,7 +1480,7 @@ msgstr ""
 msgid "Account: {0} is not permitted under Payment Entry"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3037
+#: erpnext/controllers/accounts_controller.py:3040
 msgid "Account: {0} with currency: {1} can not be selected"
 msgstr ""
 
@@ -1757,7 +1753,7 @@ msgstr ""
 msgid "Accounting Entry for Asset"
 msgstr ""
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:796
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:805
 msgid "Accounting Entry for Service"
 msgstr ""
 
@@ -1772,18 +1768,18 @@ msgstr ""
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py:1468
 #: erpnext/controllers/stock_controller.py:550
 #: erpnext/controllers/stock_controller.py:567
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:889
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:898
 #: erpnext/stock/doctype/stock_entry/stock_entry.py:1586
 #: erpnext/stock/doctype/stock_entry/stock_entry.py:1600
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py:561
 msgid "Accounting Entry for Stock"
 msgstr ""
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:717
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:726
 msgid "Accounting Entry for {0}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2247
+#: erpnext/controllers/accounts_controller.py:2250
 msgid "Accounting Entry for {0}: {1} can only be made in currency: {2}"
 msgstr ""
 
@@ -2176,7 +2172,7 @@ msgstr ""
 msgid "Accumulated Monthly"
 msgstr ""
 
-#: erpnext/controllers/budget_controller.py:417
+#: erpnext/controllers/budget_controller.py:422
 msgid "Accumulated Monthly Budget for Account {0} against {1} {2} is {3}. It will be collectively ({4}) exceeded by {5}"
 msgstr ""
 
@@ -3290,7 +3286,7 @@ msgstr ""
 msgid "Adjustment Against"
 msgstr ""
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:634
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:643
 msgid "Adjustment based on Purchase Invoice rate"
 msgstr ""
 
@@ -3401,7 +3397,7 @@ msgstr ""
 msgid "Advance amount"
 msgstr ""
 
-#: erpnext/controllers/taxes_and_totals.py:845
+#: erpnext/controllers/taxes_and_totals.py:855
 msgid "Advance amount cannot be greater than {0} {1}"
 msgstr ""
 
@@ -3612,7 +3608,7 @@ msgstr ""
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:152
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:133
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1125
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1127
 msgid "Age (Days)"
 msgstr ""
 
@@ -3697,16 +3693,6 @@ msgstr ""
 
 #: erpnext/setup/setup_wizard/data/industry_type.txt:4
 msgid "Agriculture"
-msgstr ""
-
-#. Name of a role
-#: erpnext/assets/doctype/location/location.json
-msgid "Agriculture Manager"
-msgstr ""
-
-#. Name of a role
-#: erpnext/assets/doctype/location/location.json
-msgid "Agriculture User"
 msgstr ""
 
 #: erpnext/setup/setup_wizard/data/industry_type.txt:5
@@ -3899,7 +3885,7 @@ msgstr ""
 msgid "All items are already requested"
 msgstr ""
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:1317
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:1326
 msgid "All items have already been Invoiced/Returned"
 msgstr ""
 
@@ -3911,7 +3897,7 @@ msgstr ""
 msgid "All items have already been transferred for this Work Order."
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2465
+#: erpnext/public/js/controllers/transaction.js:2491
 msgid "All items in this document already have a linked Quality Inspection."
 msgstr ""
 
@@ -4109,7 +4095,7 @@ msgstr ""
 msgid "Allow Item To Be Added Multiple Times in a Transaction"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:755
+#: erpnext/controllers/selling_controller.py:763
 msgid "Allow Item to Be Added Multiple Times in a Transaction"
 msgstr ""
 
@@ -5055,7 +5041,7 @@ msgstr ""
 msgid "Annual Billing: {0}"
 msgstr ""
 
-#: erpnext/controllers/budget_controller.py:441
+#: erpnext/controllers/budget_controller.py:446
 msgid "Annual Budget for Account {0} against {1} {2} is {3}. It will be collectively ({4}) exceeded by {5}"
 msgstr ""
 
@@ -5544,7 +5530,7 @@ msgstr ""
 msgid "As the field {0} is enabled, the value of the field {1} should be more than 1."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:989
+#: erpnext/stock/doctype/item/item.py:983
 msgid "As there are existing submitted transactions against item {0}, you can not change the value of {1}."
 msgstr ""
 
@@ -5690,7 +5676,7 @@ msgstr ""
 msgid "Asset Category Name"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:304
+#: erpnext/stock/doctype/item/item.py:307
 msgid "Asset Category is mandatory for Fixed Asset item"
 msgstr ""
 
@@ -6065,7 +6051,7 @@ msgstr ""
 msgid "Asset {0} must be submitted"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:851
+#: erpnext/controllers/buying_controller.py:859
 msgid "Asset {assets_link} created for {item_code}"
 msgstr ""
 
@@ -6095,11 +6081,11 @@ msgstr ""
 msgid "Assets"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:869
+#: erpnext/controllers/buying_controller.py:877
 msgid "Assets not created for {item_code}. You will have to create asset manually."
 msgstr "Imovina nije kreirana za {item_code}. Morat ćete kreirati Imovinu ručno."
 
-#: erpnext/controllers/buying_controller.py:856
+#: erpnext/controllers/buying_controller.py:864
 msgid "Assets {assets_link} created for {item_code}"
 msgstr ""
 
@@ -6194,7 +6180,7 @@ msgstr ""
 msgid "At row #{0}: you have selected the Difference Account {1}, which is a Cost of Goods Sold type account. Please select a different account"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:864
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:865
 msgid "At row {0}: Batch No is mandatory for Item {1}"
 msgstr ""
 
@@ -6202,11 +6188,11 @@ msgstr ""
 msgid "At row {0}: Parent Row No cannot be set for item {1}"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:849
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:850
 msgid "At row {0}: Qty is mandatory for the batch {1}"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:856
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:857
 msgid "At row {0}: Serial No is mandatory for Item {1}"
 msgstr ""
 
@@ -6280,7 +6266,7 @@ msgstr ""
 msgid "Attribute Value"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:930
+#: erpnext/stock/doctype/item/item.py:924
 msgid "Attribute table is mandatory"
 msgstr ""
 
@@ -6288,11 +6274,11 @@ msgstr ""
 msgid "Attribute value: {0} must appear only once"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:934
+#: erpnext/stock/doctype/item/item.py:928
 msgid "Attribute {0} selected multiple times in Attributes Table"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:862
+#: erpnext/stock/doctype/item/item.py:856
 msgid "Attributes"
 msgstr ""
 
@@ -7576,11 +7562,11 @@ msgstr ""
 msgid "Barcode Type"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:457
+#: erpnext/stock/doctype/item/item.py:460
 msgid "Barcode {0} already used in Item {1}"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:472
+#: erpnext/stock/doctype/item/item.py:475
 msgid "Barcode {0} is not a valid {1} code"
 msgstr ""
 
@@ -7834,7 +7820,7 @@ msgstr ""
 #: erpnext/manufacturing/doctype/job_card/job_card.json
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.js:89
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.py:115
-#: erpnext/public/js/controllers/transaction.js:2388
+#: erpnext/public/js/controllers/transaction.js:2414
 #: erpnext/public/js/utils/barcode_scanner.js:260
 #: erpnext/public/js/utils/serial_no_batch_selector.js:438
 #: erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
@@ -7861,11 +7847,11 @@ msgstr ""
 msgid "Batch No"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:867
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:868
 msgid "Batch No is mandatory"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2629
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2630
 msgid "Batch No {0} does not exists"
 msgstr ""
 
@@ -7873,7 +7859,7 @@ msgstr ""
 msgid "Batch No {0} is linked with Item {1} which has serial no. Please scan serial no instead."
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:364
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:365
 msgid "Batch No {0} is not present in the original {1} {2}, hence you can't return it against the {1} {2}"
 msgstr ""
 
@@ -7888,11 +7874,11 @@ msgstr ""
 msgid "Batch Nos"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1421
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1422
 msgid "Batch Nos are created successfully"
 msgstr ""
 
-#: erpnext/controllers/sales_and_purchase_return.py:1096
+#: erpnext/controllers/sales_and_purchase_return.py:1001
 msgid "Batch Not Available for Return"
 msgstr ""
 
@@ -7941,7 +7927,7 @@ msgstr ""
 msgid "Batch {0} and Warehouse"
 msgstr ""
 
-#: erpnext/controllers/sales_and_purchase_return.py:1095
+#: erpnext/controllers/sales_and_purchase_return.py:1000
 msgid "Batch {0} is not available in warehouse {1}"
 msgstr ""
 
@@ -7991,7 +7977,7 @@ msgstr "Planovi Pretplate u nastavku imaju različite valute u odnosu na standar
 #. Label of the bill_date (Date) field in DocType 'Journal Entry'
 #. Label of the bill_date (Date) field in DocType 'Subcontracting Receipt'
 #: erpnext/accounts/doctype/journal_entry/journal_entry.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1110
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1112
 #: erpnext/accounts/report/purchase_register/purchase_register.py:214
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.json
 msgid "Bill Date"
@@ -8000,7 +7986,7 @@ msgstr ""
 #. Label of the bill_no (Data) field in DocType 'Journal Entry'
 #. Label of the bill_no (Data) field in DocType 'Subcontracting Receipt'
 #: erpnext/accounts/doctype/journal_entry/journal_entry.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1109
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1111
 #: erpnext/accounts/report/purchase_register/purchase_register.py:213
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.json
 msgid "Bill No"
@@ -8220,7 +8206,7 @@ msgstr ""
 msgid "Billing Zipcode"
 msgstr ""
 
-#: erpnext/accounts/party.py:602
+#: erpnext/accounts/party.py:608
 msgid "Billing currency must be equal to either default company's currency or party account currency"
 msgstr "Faktura Valuta mora biti jednaka ili standard valuti tvrtke ili valuti računa stranke"
 
@@ -9217,7 +9203,7 @@ msgid "Can only make payment against unbilled {0}"
 msgstr ""
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1458
-#: erpnext/controllers/accounts_controller.py:2946
+#: erpnext/controllers/accounts_controller.py:2949
 #: erpnext/public/js/controllers/accounts.js:90
 msgid "Can refer row only if the charge type is 'On Previous Row Amount' or 'Previous Row Total'"
 msgstr ""
@@ -9379,9 +9365,9 @@ msgstr ""
 msgid "Cannot Create Return"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:625
-#: erpnext/stock/doctype/item/item.py:638
-#: erpnext/stock/doctype/item/item.py:652
+#: erpnext/stock/doctype/item/item.py:631
+#: erpnext/stock/doctype/item/item.py:644
+#: erpnext/stock/doctype/item/item.py:658
 msgid "Cannot Merge"
 msgstr ""
 
@@ -9405,7 +9391,7 @@ msgstr ""
 msgid "Cannot apply TDS against multiple parties in one entry"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:307
+#: erpnext/stock/doctype/item/item.py:310
 msgid "Cannot be a fixed asset item as Stock Ledger is created."
 msgstr ""
 
@@ -9421,7 +9407,7 @@ msgstr ""
 msgid "Cannot cancel the transaction. Reposting of item valuation on submission is not completed yet."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:959
+#: erpnext/controllers/buying_controller.py:967
 msgid "Cannot cancel this document as it is linked with the submitted asset {asset_link}. Please cancel the asset to continue."
 msgstr ""
 
@@ -9429,7 +9415,7 @@ msgstr ""
 msgid "Cannot cancel transaction for Completed Work Order."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:882
+#: erpnext/stock/doctype/item/item.py:876
 msgid "Cannot change Attributes after stock transaction. Make a new Item and transfer stock to the new Item"
 msgstr ""
 
@@ -9445,7 +9431,7 @@ msgstr ""
 msgid "Cannot change Service Stop Date for item in row {0}"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:873
+#: erpnext/stock/doctype/item/item.py:867
 msgid "Cannot change Variant properties after stock transaction. You will have to make a new Item to do this."
 msgstr ""
 
@@ -9473,7 +9459,7 @@ msgstr ""
 msgid "Cannot covert to Group because Account Type is selected."
 msgstr ""
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:972
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:981
 msgid "Cannot create Stock Reservation Entries for future dated Purchase Receipts."
 msgstr ""
 
@@ -9524,7 +9510,7 @@ msgstr ""
 msgid "Cannot find Item with this Barcode"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3483
+#: erpnext/controllers/accounts_controller.py:3486
 msgid "Cannot find a default warehouse for item {0}. Please set one in the Item Master or in Stock Settings."
 msgstr ""
 
@@ -9532,7 +9518,7 @@ msgstr ""
 msgid "Cannot make any transactions until the deletion job is completed"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2074
+#: erpnext/controllers/accounts_controller.py:2077
 msgid "Cannot overbill for Item {0} in row {1} more than {2}. To allow over-billing, please set allowance in Accounts Settings"
 msgstr ""
 
@@ -9553,7 +9539,7 @@ msgid "Cannot receive from customer against negative outstanding"
 msgstr ""
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1475
-#: erpnext/controllers/accounts_controller.py:2961
+#: erpnext/controllers/accounts_controller.py:2964
 #: erpnext/public/js/controllers/accounts.js:100
 msgid "Cannot refer row number greater than or equal to current row number for this Charge type"
 msgstr ""
@@ -9569,7 +9555,7 @@ msgstr ""
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1467
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1646
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:1917
-#: erpnext/controllers/accounts_controller.py:2951
+#: erpnext/controllers/accounts_controller.py:2954
 #: erpnext/public/js/controllers/accounts.js:94
 #: erpnext/public/js/controllers/taxes_and_totals.js:470
 msgid "Cannot select charge type as 'On Previous Row Amount' or 'On Previous Row Total' for first row"
@@ -9583,15 +9569,15 @@ msgstr ""
 msgid "Cannot set authorization on basis of Discount for {0}"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:716
+#: erpnext/stock/doctype/item/item.py:722
 msgid "Cannot set multiple Item Defaults for a company."
 msgstr "Nije moguće postaviti više Standard Artikal Postavki za tvrtku."
 
-#: erpnext/controllers/accounts_controller.py:3631
+#: erpnext/controllers/accounts_controller.py:3634
 msgid "Cannot set quantity less than delivered quantity"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3634
+#: erpnext/controllers/accounts_controller.py:3637
 msgid "Cannot set quantity less than received quantity"
 msgstr ""
 
@@ -10014,7 +10000,7 @@ msgid "Channel Partner"
 msgstr ""
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:2346
-#: erpnext/controllers/accounts_controller.py:3014
+#: erpnext/controllers/accounts_controller.py:3017
 msgid "Charge of type 'Actual' in row {0} cannot be included in Item Rate or Paid Amount"
 msgstr ""
 
@@ -10197,7 +10183,7 @@ msgstr ""
 
 #. Label of the reference_date (Date) field in DocType 'Payment Entry'
 #: erpnext/accounts/doctype/payment_entry/payment_entry.json
-#: erpnext/public/js/controllers/transaction.js:2299
+#: erpnext/public/js/controllers/transaction.js:2325
 msgid "Cheque/Reference Date"
 msgstr ""
 
@@ -10245,7 +10231,7 @@ msgstr ""
 
 #. Label of the child_row_reference (Data) field in DocType 'Quality
 #. Inspection'
-#: erpnext/public/js/controllers/transaction.js:2394
+#: erpnext/public/js/controllers/transaction.js:2420
 #: erpnext/stock/doctype/quality_inspection/quality_inspection.json
 msgid "Child Row Reference"
 msgstr ""
@@ -10957,7 +10943,7 @@ msgstr "Tvrtke"
 #: erpnext/accounts/report/cheques_and_deposits_incorrectly_cleared/cheques_and_deposits_incorrectly_cleared.js:8
 #: erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.js:8
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:8
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:49
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:50
 #: erpnext/accounts/report/deferred_revenue_and_expense/deferred_revenue_and_expense.js:8
 #: erpnext/accounts/report/delivered_items_to_be_billed/delivered_items_to_be_billed.js:7
 #: erpnext/accounts/report/dimension_wise_accounts_balance_report/dimension_wise_accounts_balance_report.js:8
@@ -12190,7 +12176,7 @@ msgid "Content Type"
 msgstr ""
 
 #: erpnext/erpnext_integrations/doctype/plaid_settings/plaid_settings.js:162
-#: erpnext/public/js/controllers/transaction.js:2312
+#: erpnext/public/js/controllers/transaction.js:2338
 #: erpnext/selling/doctype/quotation/quotation.js:356
 msgid "Continue"
 msgstr ""
@@ -12355,7 +12341,7 @@ msgstr ""
 msgid "Conversion Rate"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:393
+#: erpnext/stock/doctype/item/item.py:396
 msgid "Conversion factor for default Unit of Measure must be 1 in row {0}"
 msgstr ""
 
@@ -12363,15 +12349,15 @@ msgstr ""
 msgid "Conversion factor for item {0} has been reset to 1.0 as the uom {1} is same as stock uom {2}."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2767
+#: erpnext/controllers/accounts_controller.py:2770
 msgid "Conversion rate cannot be 0"
 msgstr "Stopa konverzije ne može biti 0"
 
-#: erpnext/controllers/accounts_controller.py:2774
+#: erpnext/controllers/accounts_controller.py:2777
 msgid "Conversion rate is 1.00, but document currency is different from company currency"
 msgstr "Stopa konverzije je 1,00, ali valuta dokumenta razlikuje se od valute tvrtke"
 
-#: erpnext/controllers/accounts_controller.py:2770
+#: erpnext/controllers/accounts_controller.py:2773
 msgid "Conversion rate must be 1.00 if document currency is same as company currency"
 msgstr "Stopa konverzije mora biti 1,00 ako je valuta dokumenta ista kao valuta tvrtke"
 
@@ -12584,7 +12570,7 @@ msgstr ""
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:28
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:40
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:30
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1096
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1098
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:40
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.js:42
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.py:197
@@ -12677,7 +12663,7 @@ msgid "Cost Center is a part of Cost Center Allocation, hence cannot be converte
 msgstr ""
 
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py:1411
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:855
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:864
 msgid "Cost Center is required in row {0} in Taxes table for type {1}"
 msgstr ""
 
@@ -12946,8 +12932,8 @@ msgstr ""
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:132
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:143
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:219
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:654
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:678
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:656
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:680
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.js:88
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.js:89
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.js:103
@@ -13004,8 +12990,8 @@ msgstr ""
 #: erpnext/projects/doctype/task/task_tree.js:81
 #: erpnext/public/js/communication.js:19 erpnext/public/js/communication.js:31
 #: erpnext/public/js/communication.js:41
-#: erpnext/public/js/controllers/transaction.js:336
-#: erpnext/public/js/controllers/transaction.js:2435
+#: erpnext/public/js/controllers/transaction.js:362
+#: erpnext/public/js/controllers/transaction.js:2461
 #: erpnext/selling/doctype/customer/customer.js:181
 #: erpnext/selling/doctype/quotation/quotation.js:124
 #: erpnext/selling/doctype/quotation/quotation.js:133
@@ -13300,7 +13286,7 @@ msgstr ""
 msgid "Create a variant with the template image."
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1877
+#: erpnext/stock/stock_ledger.py:1886
 msgid "Create an incoming stock transaction for the Item."
 msgstr ""
 
@@ -13360,7 +13346,7 @@ msgstr ""
 msgid "Creating Purchase Order ..."
 msgstr ""
 
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:735
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:737
 #: erpnext/buying/doctype/purchase_order/purchase_order.js:552
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.js:73
 msgid "Creating Purchase Receipt ..."
@@ -13554,7 +13540,7 @@ msgstr ""
 #: erpnext/accounts/doctype/journal_entry_template/journal_entry_template.json
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:174
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:147
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1119
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1121
 #: erpnext/controllers/sales_and_purchase_return.py:373
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:286
 #: erpnext/stock/doctype/delivery_note/delivery_note.js:89
@@ -13589,7 +13575,7 @@ msgstr ""
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py:368
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py:376
-#: erpnext/controllers/accounts_controller.py:2186
+#: erpnext/controllers/accounts_controller.py:2189
 msgid "Credit To"
 msgstr ""
 
@@ -13774,7 +13760,7 @@ msgstr ""
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/subscription_plan/subscription_plan.json
 #: erpnext/accounts/report/account_balance/account_balance.py:28
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1129
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1131
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:205
 #: erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.py:101
 #: erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.js:118
@@ -14303,7 +14289,7 @@ msgstr ""
 #. Label of the customer_contact_display (Small Text) field in DocType
 #. 'Purchase Order'
 #. Label of the customer_contact (Small Text) field in DocType 'Delivery Stop'
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1090
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1092
 #: erpnext/buying/doctype/purchase_order/purchase_order.json
 #: erpnext/stock/doctype/delivery_stop/delivery_stop.json
 msgid "Customer Contact"
@@ -14399,7 +14385,7 @@ msgstr ""
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/tax_rule/tax_rule.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:107
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1147
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1149
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:81
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:185
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:56
@@ -14443,7 +14429,7 @@ msgstr ""
 msgid "Customer Group Name"
 msgstr ""
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1239
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1241
 msgid "Customer Group: {0} does not exist"
 msgstr ""
 
@@ -14462,7 +14448,7 @@ msgstr ""
 msgid "Customer Items"
 msgstr ""
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1138
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1140
 msgid "Customer LPO"
 msgstr ""
 
@@ -14508,7 +14494,7 @@ msgstr ""
 #: erpnext/accounts/doctype/pos_invoice/pos_invoice.json
 #: erpnext/accounts/doctype/process_statement_of_accounts_customer/process_statement_of_accounts_customer.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1080
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1082
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:156
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:92
 #: erpnext/accounts/report/delivered_items_to_be_billed/delivered_items_to_be_billed.py:35
@@ -15186,7 +15172,7 @@ msgstr ""
 #: erpnext/accounts/doctype/journal_entry_template/journal_entry_template.json
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:176
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:147
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1122
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1124
 #: erpnext/controllers/sales_and_purchase_return.py:377
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:287
 #: erpnext/stock/doctype/purchase_receipt/purchase_receipt.js:61
@@ -15215,7 +15201,7 @@ msgstr ""
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:953
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:964
-#: erpnext/controllers/accounts_controller.py:2186
+#: erpnext/controllers/accounts_controller.py:2189
 msgid "Debit To"
 msgstr ""
 
@@ -15248,11 +15234,11 @@ msgstr ""
 msgid "Debit-Credit mismatch"
 msgstr ""
 
-#: erpnext/accounts/party.py:609
+#: erpnext/accounts/party.py:615
 msgid "Debtor/Creditor"
 msgstr ""
 
-#: erpnext/accounts/party.py:612
+#: erpnext/accounts/party.py:618
 msgid "Debtor/Creditor Advance"
 msgstr ""
 
@@ -15372,7 +15358,7 @@ msgstr ""
 msgid "Default BOM"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:418
+#: erpnext/stock/doctype/item/item.py:421
 msgid "Default BOM ({0}) must be active for this item or its template"
 msgstr ""
 
@@ -15380,7 +15366,7 @@ msgstr ""
 msgid "Default BOM for {0} not found"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3672
+#: erpnext/controllers/accounts_controller.py:3675
 msgid "Default BOM not found for FG Item {0}"
 msgstr ""
 
@@ -15715,15 +15701,15 @@ msgstr ""
 msgid "Default Unit of Measure"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1272
+#: erpnext/stock/doctype/item/item.py:1266
 msgid "Default Unit of Measure for Item {0} cannot be changed directly because you have already made some transaction(s) with another UOM. You need to either cancel the linked documents or create a new Item."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1255
+#: erpnext/stock/doctype/item/item.py:1249
 msgid "Default Unit of Measure for Item {0} cannot be changed directly because you have already made some transaction(s) with another UOM. You will need to create a new Item to use a different Default UOM."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:908
+#: erpnext/stock/doctype/item/item.py:902
 msgid "Default Unit of Measure for Variant '{0}' must be same as in Template '{1}'"
 msgstr ""
 
@@ -16182,7 +16168,7 @@ msgstr ""
 msgid "Delivery Note {0} is not submitted"
 msgstr ""
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1142
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1144
 #: erpnext/stock/doctype/delivery_trip/delivery_trip.js:73
 msgid "Delivery Notes"
 msgstr ""
@@ -16713,7 +16699,7 @@ msgstr "Amortizacija eliminirana storniranjem"
 #: erpnext/projects/doctype/task_type/task_type.json
 #: erpnext/projects/doctype/timesheet_detail/timesheet_detail.json
 #: erpnext/public/js/bank_reconciliation_tool/data_table_manager.js:55
-#: erpnext/public/js/controllers/transaction.js:2376
+#: erpnext/public/js/controllers/transaction.js:2402
 #: erpnext/selling/doctype/installation_note_item/installation_note_item.json
 #: erpnext/selling/doctype/product_bundle/product_bundle.json
 #: erpnext/selling/doctype/product_bundle_item/product_bundle_item.json
@@ -16901,7 +16887,7 @@ msgstr ""
 msgid "Difference Account must be a Asset/Liability type account (Temporary Opening), since this Stock Entry is an Opening Entry"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:954
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:950
 msgid "Difference Account must be a Asset/Liability type account, since this Stock Reconciliation is an Opening Entry"
 msgstr ""
 
@@ -17167,11 +17153,11 @@ msgstr ""
 msgid "Disabled Warehouse {0} cannot be used for this transaction."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:745
+#: erpnext/controllers/accounts_controller.py:748
 msgid "Disabled pricing rules since this {} is an internal transfer"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:759
+#: erpnext/controllers/accounts_controller.py:762
 msgid "Disabled tax included prices since this {} is an internal transfer"
 msgstr ""
 
@@ -18113,7 +18099,7 @@ msgstr ""
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.json
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/print_format/sales_invoice_print/sales_invoice_print.html:72
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1106
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1108
 #: erpnext/assets/doctype/asset_maintenance_log/asset_maintenance_log.json
 #: erpnext/selling/report/payment_terms_status_for_sales_order/payment_terms_status_for_sales_order.py:40
 msgid "Due Date"
@@ -18127,11 +18113,11 @@ msgstr ""
 msgid "Due Date Based On"
 msgstr ""
 
-#: erpnext/accounts/party.py:695
+#: erpnext/accounts/party.py:701
 msgid "Due Date cannot be after {0}"
 msgstr ""
 
-#: erpnext/accounts/party.py:671
+#: erpnext/accounts/party.py:677
 msgid "Due Date cannot be before {0}"
 msgstr ""
 
@@ -18849,7 +18835,7 @@ msgstr ""
 msgid "Enable Auto Email"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1064
+#: erpnext/stock/doctype/item/item.py:1058
 msgid "Enable Auto Re-Order"
 msgstr ""
 
@@ -19062,7 +19048,7 @@ msgstr ""
 msgid "End Date"
 msgstr ""
 
-#: erpnext/crm/doctype/contract/contract.py:75
+#: erpnext/crm/doctype/contract/contract.py:83
 msgid "End Date cannot be before Start Date."
 msgstr ""
 
@@ -19312,7 +19298,7 @@ msgstr ""
 #: erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.json
 #: erpnext/manufacturing/doctype/job_card/job_card.py:875
 #: erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.json
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:297
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:298
 msgid "Error"
 msgstr ""
 
@@ -19437,7 +19423,7 @@ msgstr ""
 msgid "Example URL"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:995
+#: erpnext/stock/doctype/item/item.py:989
 msgid "Example of a linked document: {0}"
 msgstr ""
 
@@ -19452,7 +19438,7 @@ msgstr ""
 msgid "Example: ABCD.#####. If series is set and Batch No is not mentioned in transactions, then automatic batch number will be created based on this series. If you always want to explicitly mention Batch No for this item, leave this blank. Note: this setting will take priority over the Naming Series Prefix in Stock Settings."
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:2141
+#: erpnext/stock/stock_ledger.py:2149
 msgid "Example: Serial No {0} reserved in {1}."
 msgstr ""
 
@@ -19506,8 +19492,8 @@ msgstr ""
 msgid "Exchange Gain/Loss"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1593
-#: erpnext/controllers/accounts_controller.py:1677
+#: erpnext/controllers/accounts_controller.py:1596
+#: erpnext/controllers/accounts_controller.py:1680
 msgid "Exchange Gain/Loss amount has been booked through {0}"
 msgstr ""
 
@@ -20243,7 +20229,7 @@ msgid "Fetching Error"
 msgstr ""
 
 #: erpnext/accounts/doctype/dunning/dunning.js:135
-#: erpnext/public/js/controllers/transaction.js:1251
+#: erpnext/public/js/controllers/transaction.js:1277
 msgid "Fetching exchange rates ..."
 msgstr ""
 
@@ -20538,15 +20524,15 @@ msgstr ""
 msgid "Finished Good Item Quantity"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3658
+#: erpnext/controllers/accounts_controller.py:3661
 msgid "Finished Good Item is not specified for service item {0}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3675
+#: erpnext/controllers/accounts_controller.py:3678
 msgid "Finished Good Item {0} Qty can not be zero"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3669
+#: erpnext/controllers/accounts_controller.py:3672
 msgid "Finished Good Item {0} must be a sub-contracted item"
 msgstr ""
 
@@ -20787,7 +20773,7 @@ msgstr ""
 msgid "Fixed Asset Defaults"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:301
+#: erpnext/stock/doctype/item/item.py:304
 msgid "Fixed Asset Item must be a non-stock item."
 msgstr ""
 
@@ -20963,7 +20949,7 @@ msgstr ""
 msgid "For Raw Materials"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1259
+#: erpnext/controllers/accounts_controller.py:1262
 msgid "For Return Invoices with Stock effect, '0' qty Items are not allowed. Following rows are affected: {0}"
 msgstr ""
 
@@ -21064,7 +21050,7 @@ msgstr ""
 msgid "For the item {0}, the quantity should be {1} according to the BOM {2}."
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:1088
+#: erpnext/public/js/controllers/transaction.js:1114
 msgctxt "Clear payment terms template and/or payment schedule when due date is changed"
 msgid "For the new {0} to take effect, would you like to clear the current {1}?"
 msgstr ""
@@ -21073,7 +21059,7 @@ msgstr ""
 msgid "For the {0}, no stock is available for the return in the warehouse {1}."
 msgstr ""
 
-#: erpnext/controllers/sales_and_purchase_return.py:1144
+#: erpnext/controllers/sales_and_purchase_return.py:1049
 msgid "For the {0}, the quantity is required to make the return entry"
 msgstr ""
 
@@ -21410,7 +21396,7 @@ msgstr ""
 msgid "From Date is mandatory"
 msgstr ""
 
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:52
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:53
 #: erpnext/accounts/report/general_ledger/general_ledger.py:86
 #: erpnext/accounts/report/pos_register/pos_register.py:115
 #: erpnext/accounts/report/tax_withholding_details/tax_withholding_details.py:39
@@ -21787,14 +21773,14 @@ msgstr ""
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:186
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:155
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1134
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1136
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:177
 msgid "Future Payment Amount"
 msgstr ""
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:185
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:154
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1133
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1135
 msgid "Future Payment Ref"
 msgstr ""
 
@@ -22968,7 +22954,7 @@ msgstr ""
 msgid "Here are the error logs for the aforementioned failed depreciation entries: {0}"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1862
+#: erpnext/stock/stock_ledger.py:1871
 msgid "Here are the options to proceed:"
 msgstr ""
 
@@ -23490,7 +23476,7 @@ msgstr ""
 msgid "If more than one package of the same type (for print)"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1872
+#: erpnext/stock/stock_ledger.py:1881
 msgid "If not, you can Cancel / Submit this entry"
 msgstr ""
 
@@ -23515,7 +23501,7 @@ msgstr ""
 msgid "If the account is frozen, entries are allowed to restricted users."
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1865
+#: erpnext/stock/stock_ledger.py:1874
 msgid "If the item is transacting as a Zero Valuation Rate item in this entry, please enable 'Allow Zero Valuation Rate' in the {0} Item table."
 msgstr ""
 
@@ -24513,7 +24499,7 @@ msgstr ""
 msgid "Incorrect Batch Consumed"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:514
+#: erpnext/stock/doctype/item/item.py:517
 msgid "Incorrect Check in (group) Warehouse for Reorder"
 msgstr ""
 
@@ -24562,7 +24548,7 @@ msgstr ""
 msgid "Incorrect Stock Value Report"
 msgstr ""
 
-#: erpnext/stock/serial_batch_bundle.py:134
+#: erpnext/stock/serial_batch_bundle.py:135
 msgid "Incorrect Type of Transaction"
 msgstr ""
 
@@ -24831,8 +24817,8 @@ msgstr ""
 msgid "Insufficient Capacity"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3590
-#: erpnext/controllers/accounts_controller.py:3614
+#: erpnext/controllers/accounts_controller.py:3593
+#: erpnext/controllers/accounts_controller.py:3617
 msgid "Insufficient Permissions"
 msgstr ""
 
@@ -24840,12 +24826,12 @@ msgstr ""
 #: erpnext/stock/doctype/pick_list/pick_list.py:127
 #: erpnext/stock/doctype/pick_list/pick_list.py:975
 #: erpnext/stock/doctype/stock_entry/stock_entry.py:759
-#: erpnext/stock/serial_batch_bundle.py:989 erpnext/stock/stock_ledger.py:1559
-#: erpnext/stock/stock_ledger.py:2032
+#: erpnext/stock/serial_batch_bundle.py:1021 erpnext/stock/stock_ledger.py:1568
+#: erpnext/stock/stock_ledger.py:2040
 msgid "Insufficient Stock"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:2047
+#: erpnext/stock/stock_ledger.py:2055
 msgid "Insufficient Stock for Batch"
 msgstr ""
 
@@ -24983,11 +24969,11 @@ msgstr ""
 msgid "Internal Customer for company {0} already exists"
 msgstr "Interni Klijent za tvrtku {0} već postoji"
 
-#: erpnext/controllers/accounts_controller.py:728
+#: erpnext/controllers/accounts_controller.py:731
 msgid "Internal Sale or Delivery Reference missing."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:730
+#: erpnext/controllers/accounts_controller.py:733
 msgid "Internal Sales Reference Missing"
 msgstr ""
 
@@ -25018,7 +25004,7 @@ msgstr "Interni Dobavljač za tvrtku {0} već postoji"
 msgid "Internal Transfer"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:739
+#: erpnext/controllers/accounts_controller.py:742
 msgid "Internal Transfer Reference Missing"
 msgstr ""
 
@@ -25061,8 +25047,8 @@ msgstr ""
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:969
 #: erpnext/assets/doctype/asset_category/asset_category.py:69
 #: erpnext/assets/doctype/asset_category/asset_category.py:97
-#: erpnext/controllers/accounts_controller.py:2975
-#: erpnext/controllers/accounts_controller.py:2983
+#: erpnext/controllers/accounts_controller.py:2978
+#: erpnext/controllers/accounts_controller.py:2986
 msgid "Invalid Account"
 msgstr ""
 
@@ -25087,7 +25073,7 @@ msgstr ""
 msgid "Invalid Barcode. There is no Item attached to this barcode."
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2631
+#: erpnext/public/js/controllers/transaction.js:2657
 msgid "Invalid Blanket Order for the selected Customer and Item"
 msgstr ""
 
@@ -25101,7 +25087,7 @@ msgstr "Nevažeća Tvrtka za transakcije između tvrtki."
 
 #: erpnext/assets/doctype/asset/asset.py:295
 #: erpnext/assets/doctype/asset/asset.py:302
-#: erpnext/controllers/accounts_controller.py:2998
+#: erpnext/controllers/accounts_controller.py:3001
 msgid "Invalid Cost Center"
 msgstr ""
 
@@ -25143,7 +25129,7 @@ msgstr ""
 msgid "Invalid Item"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1410
+#: erpnext/stock/doctype/item/item.py:1404
 msgid "Invalid Item Defaults"
 msgstr ""
 
@@ -25189,11 +25175,11 @@ msgstr ""
 msgid "Invalid Purchase Invoice"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3627
+#: erpnext/controllers/accounts_controller.py:3630
 msgid "Invalid Qty"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1277
+#: erpnext/controllers/accounts_controller.py:1280
 msgid "Invalid Quantity"
 msgstr ""
 
@@ -25210,7 +25196,7 @@ msgstr ""
 msgid "Invalid Schedule"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:243
+#: erpnext/controllers/selling_controller.py:251
 msgid "Invalid Selling Price"
 msgstr ""
 
@@ -25243,7 +25229,7 @@ msgstr ""
 msgid "Invalid lost reason {0}, please create a new lost reason"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:408
+#: erpnext/stock/doctype/item/item.py:411
 msgid "Invalid naming series (. missing) for {0}"
 msgstr ""
 
@@ -25283,7 +25269,7 @@ msgstr ""
 #. Name of a DocType
 #: erpnext/patches/v15_0/refactor_closing_stock_balance.py:43
 #: erpnext/stock/doctype/inventory_dimension/inventory_dimension.json
-#: erpnext/stock/doctype/inventory_dimension/inventory_dimension.py:180
+#: erpnext/stock/doctype/inventory_dimension/inventory_dimension.py:181
 msgid "Inventory Dimension"
 msgstr ""
 
@@ -25349,7 +25335,7 @@ msgstr ""
 msgid "Invoice Discounting"
 msgstr ""
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1114
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1116
 msgid "Invoice Grand Total"
 msgstr ""
 
@@ -25442,7 +25428,7 @@ msgstr ""
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:169
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:144
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1116
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1118
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:164
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:165
 msgid "Invoiced Amount"
@@ -25848,6 +25834,11 @@ msgstr ""
 msgid "Is Outward"
 msgstr ""
 
+#. Label of the is_packed (Check) field in DocType 'Serial and Batch Bundle'
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.json
+msgid "Is Packed"
+msgstr ""
+
 #. Label of the is_paid (Check) field in DocType 'Purchase Invoice'
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 msgid "Is Paid"
@@ -26130,11 +26121,11 @@ msgstr ""
 msgid "Issuing cannot be done to a location. Please enter employee to issue the Asset {0} to"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:565
+#: erpnext/stock/doctype/item/item.py:571
 msgid "It can take upto few hours for accurate stock values to be visible after merging items."
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2075
+#: erpnext/public/js/controllers/transaction.js:2101
 msgid "It is needed to fetch Item Details."
 msgstr ""
 
@@ -26184,7 +26175,7 @@ msgstr ""
 #: erpnext/buying/report/supplier_quotation_comparison/supplier_quotation_comparison.js:33
 #: erpnext/buying/report/supplier_quotation_comparison/supplier_quotation_comparison.py:204
 #: erpnext/buying/workspace/buying/buying.json
-#: erpnext/controllers/taxes_and_totals.py:1125
+#: erpnext/controllers/taxes_and_totals.py:1135
 #: erpnext/manufacturing/doctype/blanket_order/blanket_order.json
 #: erpnext/manufacturing/doctype/bom/bom.js:944
 #: erpnext/manufacturing/doctype/bom/bom.json
@@ -26462,7 +26453,7 @@ msgstr ""
 #: erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py:86
 #: erpnext/manufacturing/report/work_order_stock_report/work_order_stock_report.py:119
 #: erpnext/projects/doctype/timesheet/timesheet.js:213
-#: erpnext/public/js/controllers/transaction.js:2350
+#: erpnext/public/js/controllers/transaction.js:2376
 #: erpnext/public/js/stock_reservation.js:112
 #: erpnext/public/js/stock_reservation.js:317 erpnext/public/js/utils.js:500
 #: erpnext/public/js/utils.js:656
@@ -26900,7 +26891,7 @@ msgstr ""
 #: erpnext/manufacturing/report/production_planning_report/production_planning_report.py:359
 #: erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py:92
 #: erpnext/manufacturing/report/work_order_consumed_materials/work_order_consumed_materials.py:138
-#: erpnext/public/js/controllers/transaction.js:2356
+#: erpnext/public/js/controllers/transaction.js:2382
 #: erpnext/public/js/utils.js:746
 #: erpnext/selling/doctype/quotation_item/quotation_item.json
 #: erpnext/selling/doctype/sales_order_item/sales_order_item.json
@@ -27167,7 +27158,7 @@ msgstr ""
 msgid "Item Variant {0} already exists with same attributes"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:781
+#: erpnext/stock/doctype/item/item.py:772
 msgid "Item Variants updated"
 msgstr ""
 
@@ -27233,7 +27224,7 @@ msgstr ""
 msgid "Item for row {0} does not match Material Request"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:795
+#: erpnext/stock/doctype/item/item.py:789
 msgid "Item has variants."
 msgstr ""
 
@@ -27259,7 +27250,7 @@ msgstr ""
 msgid "Item operation"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3650
+#: erpnext/controllers/accounts_controller.py:3653
 msgid "Item qty can not be updated as raw materials are already processed."
 msgstr ""
 
@@ -27285,7 +27276,7 @@ msgstr ""
 msgid "Item valuation reposting in progress. Report might show incorrect item valuation."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:952
+#: erpnext/stock/doctype/item/item.py:946
 msgid "Item variant {0} exists with same attributes"
 msgstr ""
 
@@ -27298,8 +27289,7 @@ msgid "Item {0} cannot be ordered more than {1} against Blanket Order {2}."
 msgstr ""
 
 #: erpnext/assets/doctype/asset/asset.py:277
-#: erpnext/stock/doctype/item/item.py:630
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:167
+#: erpnext/stock/doctype/item/item.py:636
 msgid "Item {0} does not exist"
 msgstr ""
 
@@ -27311,7 +27301,7 @@ msgstr ""
 msgid "Item {0} does not exist."
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:752
+#: erpnext/controllers/selling_controller.py:760
 msgid "Item {0} entered multiple times."
 msgstr ""
 
@@ -27327,7 +27317,7 @@ msgstr ""
 msgid "Item {0} has no Serial No. Only serialized items can have delivery based on Serial No"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1126
+#: erpnext/stock/doctype/item/item.py:1120
 msgid "Item {0} has reached its end of life on {1}"
 msgstr ""
 
@@ -27339,11 +27329,11 @@ msgstr ""
 msgid "Item {0} is already reserved/delivered against Sales Order {1}."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1146
+#: erpnext/stock/doctype/item/item.py:1140
 msgid "Item {0} is cancelled"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1130
+#: erpnext/stock/doctype/item/item.py:1124
 msgid "Item {0} is disabled"
 msgstr ""
 
@@ -27351,7 +27341,7 @@ msgstr ""
 msgid "Item {0} is not a serialized Item"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1138
+#: erpnext/stock/doctype/item/item.py:1132
 msgid "Item {0} is not a stock Item"
 msgstr ""
 
@@ -27395,7 +27385,7 @@ msgstr ""
 msgid "Item {0}: {1} qty produced. "
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1429
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1423
 msgid "Item {} does not exist."
 msgstr ""
 
@@ -27535,7 +27525,7 @@ msgstr ""
 msgid "Items and Pricing"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3872
+#: erpnext/controllers/accounts_controller.py:3875
 msgid "Items cannot be updated as Subcontracting Order is created against the Purchase Order {0}."
 msgstr ""
 
@@ -28031,7 +28021,7 @@ msgstr ""
 
 #. Name of a DocType
 #. Label of a Link in the Stock Workspace
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:674
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:676
 #: erpnext/stock/doctype/landed_cost_voucher/landed_cost_voucher.json
 #: erpnext/stock/doctype/purchase_receipt/purchase_receipt.js:104
 #: erpnext/stock/workspace/stock/stock.json
@@ -28646,7 +28636,7 @@ msgstr ""
 msgid "Linked Location"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:999
+#: erpnext/stock/doctype/item/item.py:993
 msgid "Linked with submitted documents"
 msgstr ""
 
@@ -29385,7 +29375,7 @@ msgstr ""
 #: erpnext/manufacturing/doctype/bom/bom.py:261
 #: erpnext/manufacturing/doctype/bom_update_log/bom_update_log.py:71
 #: erpnext/public/js/controllers/accounts.js:249
-#: erpnext/public/js/controllers/transaction.js:2753
+#: erpnext/public/js/controllers/transaction.js:2779
 #: erpnext/public/js/utils/party.js:321
 #: erpnext/stock/doctype/delivery_note/delivery_note.js:164
 #: erpnext/stock/doctype/inventory_dimension/inventory_dimension.json
@@ -30241,7 +30231,7 @@ msgstr ""
 msgid "Maximum Value"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:212
+#: erpnext/controllers/selling_controller.py:220
 msgid "Maximum discount for Item {0} is {1}%"
 msgstr ""
 
@@ -30311,7 +30301,7 @@ msgstr ""
 msgid "Megawatt"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1878
+#: erpnext/stock/stock_ledger.py:1887
 msgid "Mention Valuation Rate in the Item master."
 msgstr ""
 
@@ -30706,11 +30696,11 @@ msgstr ""
 msgid "Miscellaneous Expenses"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:540
+#: erpnext/controllers/buying_controller.py:548
 msgid "Mismatch"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1430
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1424
 msgid "Missing"
 msgstr ""
 
@@ -31237,7 +31227,7 @@ msgstr ""
 msgid "Multiple Warehouse Accounts"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1129
+#: erpnext/controllers/accounts_controller.py:1132
 msgid "Multiple fiscal years exist for the date {0}. Please set company in Fiscal Year"
 msgstr "Za datum {0} postoji više fiskalnih godina. Postavi Tvrtku u Fiskalnoj Godini"
 
@@ -31388,7 +31378,7 @@ msgstr ""
 msgid "Naming Series and Price Defaults"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:90
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:91
 msgid "Naming Series is mandatory"
 msgstr ""
 
@@ -31427,15 +31417,15 @@ msgstr ""
 msgid "Needs Analysis"
 msgstr ""
 
-#: erpnext/stock/serial_batch_bundle.py:1277
+#: erpnext/stock/serial_batch_bundle.py:1309
 msgid "Negative Batch Quantity"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:610
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:606
 msgid "Negative Quantity is not allowed"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:615
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:611
 msgid "Negative Valuation Rate is not allowed"
 msgstr ""
 
@@ -31717,7 +31707,7 @@ msgstr ""
 msgid "Net Weight UOM"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1483
+#: erpnext/controllers/accounts_controller.py:1486
 msgid "Net total calculation precision loss"
 msgstr ""
 
@@ -32060,7 +32050,7 @@ msgstr ""
 #: erpnext/accounts/doctype/journal_entry/journal_entry.py:1539
 #: erpnext/accounts/doctype/journal_entry/journal_entry.py:1599
 #: erpnext/accounts/doctype/journal_entry/journal_entry.py:1613
-#: erpnext/stock/doctype/item/item.py:1371
+#: erpnext/stock/doctype/item/item.py:1365
 msgid "No Permission"
 msgstr ""
 
@@ -32082,7 +32072,7 @@ msgstr ""
 msgid "No Selection"
 msgstr "Bez Odabira"
 
-#: erpnext/controllers/sales_and_purchase_return.py:919
+#: erpnext/controllers/sales_and_purchase_return.py:824
 msgid "No Serial / Batches are available for return"
 msgstr ""
 
@@ -32118,7 +32108,7 @@ msgstr ""
 msgid "No Work Orders were created"
 msgstr ""
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:785
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:794
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py:689
 msgid "No accounting entries for the following warehouses"
 msgstr ""
@@ -32307,7 +32297,7 @@ msgstr ""
 msgid "No reserved stock to unreserve."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:773
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:769
 msgid "No stock ledger entries were created. Please set the quantity or valuation rate for the items properly and try again."
 msgstr ""
 
@@ -32391,7 +32381,7 @@ msgstr ""
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:566
 #: erpnext/assets/doctype/asset/asset.js:612
 #: erpnext/assets/doctype/asset/asset.js:627
-#: erpnext/controllers/buying_controller.py:225
+#: erpnext/controllers/buying_controller.py:233
 #: erpnext/selling/doctype/product_bundle/product_bundle.py:72
 #: erpnext/setup/doctype/transaction_deletion_record/transaction_deletion_record.py:80
 msgid "Not Allowed"
@@ -32512,10 +32502,10 @@ msgstr ""
 #: erpnext/selling/doctype/customer/customer.py:129
 #: erpnext/selling/doctype/sales_order/sales_order.js:1168
 #: erpnext/stock/doctype/item/item.js:526
-#: erpnext/stock/doctype/item/item.py:567
+#: erpnext/stock/doctype/item/item.py:573
 #: erpnext/stock/doctype/item_price/item_price.json
 #: erpnext/stock/doctype/stock_entry/stock_entry.py:1374
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:972
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:968
 #: erpnext/templates/pages/timelog_info.html:43
 msgid "Note"
 msgstr ""
@@ -32524,7 +32514,7 @@ msgstr ""
 msgid "Note: Automatic log deletion only applies to logs of type <i>Update Cost</i>"
 msgstr ""
 
-#: erpnext/accounts/party.py:690
+#: erpnext/accounts/party.py:696
 msgid "Note: Due Date exceeds allowed {0} credit days by {1} day(s)"
 msgstr ""
 
@@ -32550,7 +32540,7 @@ msgstr ""
 msgid "Note: This Cost Center is a Group. Cannot make accounting entries against groups."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:621
+#: erpnext/stock/doctype/item/item.py:627
 msgid "Note: To merge the items, create a separate Stock Reconciliation for the old item {0}"
 msgstr ""
 
@@ -33313,7 +33303,7 @@ msgstr ""
 
 #. Label of the opening_stock (Float) field in DocType 'Item'
 #. Option for the 'Purpose' (Select) field in DocType 'Stock Reconciliation'
-#: erpnext/stock/doctype/item/item.json erpnext/stock/doctype/item/item.py:296
+#: erpnext/stock/doctype/item/item.json erpnext/stock/doctype/item/item.py:299
 #: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.json
 msgid "Opening Stock"
 msgstr ""
@@ -34033,7 +34023,7 @@ msgstr "Nepodmireno (Valuta Tvrtke)"
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:149
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1123
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1125
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:167
 #: erpnext/accounts/report/purchase_register/purchase_register.py:289
 #: erpnext/accounts/report/sales_register/sales_register.py:319
@@ -34072,7 +34062,7 @@ msgstr ""
 msgid "Over Billing Allowance (%)"
 msgstr ""
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:1242
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:1251
 msgid "Over Billing Allowance exceeded for Purchase Receipt Item {0} ({1}) by {2}%"
 msgstr ""
 
@@ -34113,7 +34103,7 @@ msgstr ""
 msgid "Overbilling of {0} {1} ignored for item {2} because you have {3} role."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2013
+#: erpnext/controllers/accounts_controller.py:2016
 msgid "Overbilling of {} ignored because you have {} role."
 msgstr ""
 
@@ -34620,7 +34610,7 @@ msgstr ""
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:146
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1117
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1119
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:165
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:172
 #: erpnext/accounts/report/pos_register/pos_register.py:209
@@ -34853,7 +34843,7 @@ msgstr ""
 msgid "Parent Row No"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom_creator/bom_creator.py:495
+#: erpnext/manufacturing/doctype/bom_creator/bom_creator.py:496
 msgid "Parent Row No not found for {0}"
 msgstr ""
 
@@ -35082,7 +35072,7 @@ msgstr ""
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:142
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:159
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:57
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1054
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1056
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:67
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:147
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:228
@@ -35108,7 +35098,7 @@ msgstr ""
 
 #. Name of a DocType
 #: erpnext/accounts/doctype/party_account/party_account.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1065
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1067
 msgid "Party Account"
 msgstr ""
 
@@ -35135,7 +35125,7 @@ msgstr ""
 msgid "Party Account No. (Bank Statement)"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2278
+#: erpnext/controllers/accounts_controller.py:2281
 msgid "Party Account {0} currency ({1}) and document currency ({2}) should be same"
 msgstr ""
 
@@ -35151,6 +35141,11 @@ msgstr ""
 #: erpnext/accounts/doctype/bank_account/bank_account.json
 #: erpnext/accounts/doctype/payment_request/payment_request.json
 msgid "Party Details"
+msgstr ""
+
+#. Label of the party_full_name (Data) field in DocType 'Contract'
+#: erpnext/crm/doctype/contract/contract.json
+msgid "Party Full Name"
 msgstr ""
 
 #. Label of the bank_party_iban (Data) field in DocType 'Bank Transaction'
@@ -35236,7 +35231,7 @@ msgstr ""
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:84
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:54
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:44
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1048
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1050
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:54
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:141
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:219
@@ -35258,7 +35253,7 @@ msgstr ""
 msgid "Party Type"
 msgstr ""
 
-#: erpnext/accounts/party.py:819
+#: erpnext/accounts/party.py:825
 msgid "Party Type and Party can only be set for Receivable / Payable account<br><br>{0}"
 msgstr ""
 
@@ -35380,7 +35375,7 @@ msgid "Payable"
 msgstr ""
 
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:42
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1063
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1065
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:211
 #: erpnext/accounts/report/purchase_register/purchase_register.py:194
 #: erpnext/accounts/report/purchase_register/purchase_register.py:235
@@ -35546,7 +35541,7 @@ msgstr ""
 msgid "Payment Entry is already created"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1434
+#: erpnext/controllers/accounts_controller.py:1437
 msgid "Payment Entry {0} is linked against Order {1}, check if it should be pulled as advance in this invoice."
 msgstr ""
 
@@ -35828,7 +35823,7 @@ msgstr "Status Plaćanja"
 #: erpnext/accounts/doctype/payment_schedule/payment_schedule.json
 #: erpnext/accounts/doctype/payment_term/payment_term.json
 #: erpnext/accounts/doctype/payment_terms_template_detail/payment_terms_template_detail.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1113
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1115
 #: erpnext/accounts/report/gross_profit/gross_profit.py:412
 #: erpnext/accounts/workspace/accounting/accounting.json
 #: erpnext/selling/report/payment_terms_status_for_sales_order/payment_terms_status_for_sales_order.py:30
@@ -36892,7 +36887,7 @@ msgstr ""
 msgid "Please create a new Accounting Dimension if required."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:729
+#: erpnext/controllers/accounts_controller.py:732
 msgid "Please create purchase from internal sale or delivery document itself"
 msgstr ""
 
@@ -36900,7 +36895,7 @@ msgstr ""
 msgid "Please create purchase receipt or purchase invoice for the item {0}"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:649
+#: erpnext/stock/doctype/item/item.py:655
 msgid "Please delete Product Bundle {0}, before merging {1} into {2}"
 msgstr ""
 
@@ -36942,7 +36937,7 @@ msgstr ""
 msgid "Please enable {0} in the {1}."
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:754
+#: erpnext/controllers/selling_controller.py:762
 msgid "Please enable {} in {} to allow same item in multiple rows"
 msgstr ""
 
@@ -36975,7 +36970,7 @@ msgstr ""
 msgid "Please enter Approving Role or Approving User"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:939
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:935
 msgid "Please enter Cost Center"
 msgstr ""
 
@@ -36987,7 +36982,7 @@ msgstr ""
 msgid "Please enter Employee Id of this sales person"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:948
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:944
 msgid "Please enter Expense Account"
 msgstr ""
 
@@ -36996,7 +36991,7 @@ msgstr ""
 msgid "Please enter Item Code to get Batch Number"
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2503
+#: erpnext/public/js/controllers/transaction.js:2529
 msgid "Please enter Item Code to get batch no"
 msgstr ""
 
@@ -37061,7 +37056,7 @@ msgstr "Odaberi Tvrtku"
 msgid "Please enter company name first"
 msgstr "Unesi naziv tvrtke"
 
-#: erpnext/controllers/accounts_controller.py:2764
+#: erpnext/controllers/accounts_controller.py:2767
 msgid "Please enter default currency in Company Master"
 msgstr "Unesi Standard Valutu u Postavkama Tvrtke"
 
@@ -37097,7 +37092,7 @@ msgstr "Unesi Naziv Tvrtke za potvrdu"
 msgid "Please enter the phone number first"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:1007
+#: erpnext/controllers/buying_controller.py:1015
 msgid "Please enter the {schedule_date}."
 msgstr ""
 
@@ -37199,7 +37194,7 @@ msgstr ""
 msgid "Please select <b>Template Type</b> to download template"
 msgstr ""
 
-#: erpnext/controllers/taxes_and_totals.py:721
+#: erpnext/controllers/taxes_and_totals.py:731
 #: erpnext/public/js/controllers/taxes_and_totals.js:721
 msgid "Please select Apply Discount On"
 msgstr ""
@@ -37212,7 +37207,7 @@ msgstr ""
 msgid "Please select BOM for Item in Row {0}"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:467
+#: erpnext/controllers/buying_controller.py:475
 msgid "Please select BOM in BOM field for Item {item_code}."
 msgstr "Odaberi Listu Materijala u Listi Materijala polja za Artikal {item_code}."
 
@@ -37294,7 +37289,7 @@ msgstr ""
 msgid "Please select Qty against item {0}"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:320
+#: erpnext/stock/doctype/item/item.py:323
 msgid "Please select Sample Retention Warehouse in Stock Settings first"
 msgstr ""
 
@@ -37310,7 +37305,7 @@ msgstr ""
 msgid "Please select Subcontracting Order instead of Purchase Order {0}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2613
+#: erpnext/controllers/accounts_controller.py:2616
 msgid "Please select Unrealized Profit / Loss account or add default Unrealized Profit / Loss account account for company {0}"
 msgstr "Odaberi Račun Nerealiziranog Rezultata ili postavi Standard Račun Nerealiziranog Rezultata za tvrtku {0}"
 
@@ -37326,7 +37321,7 @@ msgstr "Odaberi Tvrtku"
 #: erpnext/manufacturing/doctype/bom/bom.js:603
 #: erpnext/manufacturing/doctype/bom/bom.py:261
 #: erpnext/public/js/controllers/accounts.js:249
-#: erpnext/public/js/controllers/transaction.js:2753
+#: erpnext/public/js/controllers/transaction.js:2779
 msgid "Please select a Company first."
 msgstr "Odaberi Tvrtku."
 
@@ -37484,7 +37479,7 @@ msgstr ""
 msgid "Please select {0} first"
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:77
+#: erpnext/public/js/controllers/transaction.js:100
 msgid "Please set 'Apply Additional Discount On'"
 msgstr ""
 
@@ -37669,7 +37664,7 @@ msgstr ""
 msgid "Please set filters"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2194
+#: erpnext/controllers/accounts_controller.py:2197
 msgid "Please set one of the following:"
 msgstr ""
 
@@ -37677,7 +37672,7 @@ msgstr ""
 msgid "Please set opening number of booked depreciations"
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2205
+#: erpnext/public/js/controllers/transaction.js:2231
 msgid "Please set recurring after saving"
 msgstr ""
 
@@ -37748,7 +37743,7 @@ msgstr "Podesi i omogući grupni račun sa Kontnom Klasom - {0} za Tvrtku {1}"
 msgid "Please share this email with your support team so that they can find and fix the issue."
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2073
+#: erpnext/public/js/controllers/transaction.js:2099
 msgid "Please specify"
 msgstr ""
 
@@ -37763,7 +37758,7 @@ msgid "Please specify Company to proceed"
 msgstr "Navedi Tvrtku za nastavak"
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1472
-#: erpnext/controllers/accounts_controller.py:2957
+#: erpnext/controllers/accounts_controller.py:2960
 #: erpnext/public/js/controllers/accounts.js:97
 msgid "Please specify a valid Row ID for row {0} in table {1}"
 msgstr ""
@@ -37776,7 +37771,7 @@ msgstr ""
 msgid "Please specify at least one attribute in the Attributes table"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:605
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:601
 msgid "Please specify either Quantity or Valuation Rate or both"
 msgstr ""
 
@@ -37957,7 +37952,7 @@ msgstr ""
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:16
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:15
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:18
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1046
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1048
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:15
 #: erpnext/accounts/report/bank_clearance_summary/bank_clearance_summary.py:35
 #: erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.html:7
@@ -40138,7 +40133,7 @@ msgstr ""
 #: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.js:48
 #: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:203
 #: erpnext/buying/workspace/buying/buying.json
-#: erpnext/controllers/buying_controller.py:739
+#: erpnext/controllers/buying_controller.py:747
 #: erpnext/crm/doctype/contract/contract.json
 #: erpnext/manufacturing/doctype/blanket_order/blanket_order.js:54
 #: erpnext/manufacturing/doctype/production_plan_sub_assembly_item/production_plan_sub_assembly_item.json
@@ -40277,7 +40272,7 @@ msgstr ""
 msgid "Purchase Orders to Receive"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1833
+#: erpnext/controllers/accounts_controller.py:1836
 msgid "Purchase Orders {0} are un-linked"
 msgstr ""
 
@@ -40301,8 +40296,8 @@ msgstr ""
 #. Label of a Link in the Stock Workspace
 #. Label of a shortcut in the Stock Workspace
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:171
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:650
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:660
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:652
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:662
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice_list.js:49
 #: erpnext/accounts/doctype/purchase_invoice_item/purchase_invoice_item.json
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:246
@@ -41037,7 +41032,7 @@ msgstr ""
 msgid "Quality Inspection Template Name"
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:334
+#: erpnext/public/js/controllers/transaction.js:360
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:165
 msgid "Quality Inspection(s)"
 msgstr ""
@@ -42221,7 +42216,7 @@ msgid "Receivable / Payable Account"
 msgstr ""
 
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:71
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1061
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1063
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py:243
 #: erpnext/accounts/report/sales_register/sales_register.py:217
 #: erpnext/accounts/report/sales_register/sales_register.py:271
@@ -42703,7 +42698,7 @@ msgstr ""
 msgid "Reference Date"
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2311
+#: erpnext/public/js/controllers/transaction.js:2337
 msgid "Reference Date for Early Payment Discount"
 msgstr ""
 
@@ -43027,7 +43022,7 @@ msgstr ""
 msgid "Rejected"
 msgstr ""
 
-#: erpnext/stock/doctype/inventory_dimension/inventory_dimension.py:202
+#: erpnext/stock/doctype/inventory_dimension/inventory_dimension.py:203
 msgid "Rejected "
 msgstr ""
 
@@ -43131,7 +43126,7 @@ msgstr ""
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:187
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:156
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1135
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1137
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:178
 msgid "Remaining Balance"
 msgstr ""
@@ -43184,7 +43179,7 @@ msgstr ""
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:159
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:198
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:269
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1167
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1169
 #: erpnext/accounts/report/general_ledger/general_ledger.html:84
 #: erpnext/accounts/report/general_ledger/general_ledger.html:110
 #: erpnext/accounts/report/general_ledger/general_ledger.py:742
@@ -43933,7 +43928,7 @@ msgstr ""
 msgid "Reserved Quantity for Production"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:2147
+#: erpnext/stock/stock_ledger.py:2155
 msgid "Reserved Serial No."
 msgstr ""
 
@@ -43949,11 +43944,11 @@ msgstr ""
 #: erpnext/stock/doctype/pick_list/pick_list.js:153
 #: erpnext/stock/report/reserved_stock/reserved_stock.json
 #: erpnext/stock/report/stock_balance/stock_balance.py:499
-#: erpnext/stock/stock_ledger.py:2131
+#: erpnext/stock/stock_ledger.py:2139
 msgid "Reserved Stock"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:2177
+#: erpnext/stock/stock_ledger.py:2185
 msgid "Reserved Stock for Batch"
 msgstr ""
 
@@ -43965,7 +43960,7 @@ msgstr ""
 msgid "Reserved Stock for Sub-assembly"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:476
+#: erpnext/controllers/buying_controller.py:484
 msgid "Reserved Warehouse is mandatory for the Item {item_code} in Raw Materials supplied."
 msgstr ""
 
@@ -44779,7 +44774,7 @@ msgstr ""
 msgid "Routing Name"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:667
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:663
 msgid "Row #"
 msgstr ""
 
@@ -44817,7 +44812,7 @@ msgstr ""
 msgid "Row #{0} (Payment Table): Amount must be positive"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:495
+#: erpnext/stock/doctype/item/item.py:498
 msgid "Row #{0}: A reorder entry already exists for warehouse {1} with reorder type {2}."
 msgstr ""
 
@@ -44838,7 +44833,7 @@ msgstr ""
 msgid "Row #{0}: Accepted Warehouse is mandatory for the accepted Item {1}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1117
+#: erpnext/controllers/accounts_controller.py:1120
 msgid "Row #{0}: Account {1} does not belong to company {2}"
 msgstr "Red #{0}: Račun {1} ne pripada tvrtki {2}"
 
@@ -44879,27 +44874,27 @@ msgstr ""
 msgid "Row #{0}: Cannot allocate more than {1} against payment term {2}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3524
+#: erpnext/controllers/accounts_controller.py:3527
 msgid "Row #{0}: Cannot delete item {1} which has already been billed."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3498
+#: erpnext/controllers/accounts_controller.py:3501
 msgid "Row #{0}: Cannot delete item {1} which has already been delivered"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3517
+#: erpnext/controllers/accounts_controller.py:3520
 msgid "Row #{0}: Cannot delete item {1} which has already been received"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3504
+#: erpnext/controllers/accounts_controller.py:3507
 msgid "Row #{0}: Cannot delete item {1} which has work order assigned to it."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3510
+#: erpnext/controllers/accounts_controller.py:3513
 msgid "Row #{0}: Cannot delete item {1} which is assigned to customer's purchase order."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3765
+#: erpnext/controllers/accounts_controller.py:3768
 msgid "Row #{0}: Cannot set Rate if the billed amount is greater than the amount for Item {1}."
 msgstr ""
 
@@ -45019,7 +45014,7 @@ msgstr ""
 msgid "Row #{0}: Item {1} has been picked, please reserve stock from the Pick List."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:729
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:725
 msgid "Row #{0}: Item {1} is not a Serialized/Batched Item. It cannot have a Serial No/Batch No against it."
 msgstr ""
 
@@ -45075,7 +45070,7 @@ msgstr ""
 msgid "Row #{0}: Please select the Sub Assembly Warehouse"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:502
+#: erpnext/stock/doctype/item/item.py:505
 msgid "Row #{0}: Please set reorder quantity"
 msgstr ""
 
@@ -45108,8 +45103,8 @@ msgstr ""
 msgid "Row #{0}: Quality Inspection {1} was rejected for item {2}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1274
-#: erpnext/controllers/accounts_controller.py:3624
+#: erpnext/controllers/accounts_controller.py:1277
+#: erpnext/controllers/accounts_controller.py:3627
 msgid "Row #{0}: Quantity for Item {1} cannot be zero."
 msgstr ""
 
@@ -45146,7 +45141,7 @@ msgstr ""
 msgid "Row #{0}: Scrap Item Qty cannot be zero"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:230
+#: erpnext/controllers/selling_controller.py:238
 msgid "Row #{0}: Selling rate for item {1} is lower than its {2}.\n"
 "\t\t\t\t\tSelling {3} should be atleast {4}.<br><br>Alternatively,\n"
 "\t\t\t\t\tyou can disable selling price validation in {5} to bypass\n"
@@ -45230,7 +45225,7 @@ msgstr ""
 msgid "Row #{0}: The batch {1} has already expired."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:511
+#: erpnext/stock/doctype/item/item.py:514
 msgid "Row #{0}: The warehouse {1} is not a child warehouse of a group warehouse {2}"
 msgstr ""
 
@@ -45270,39 +45265,39 @@ msgstr ""
 msgid "Row #{1}: Warehouse is mandatory for stock Item {0}"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:259
+#: erpnext/controllers/buying_controller.py:267
 msgid "Row #{idx}: Cannot select Supplier Warehouse while suppling raw materials to subcontractor."
 msgstr "Red #{idx}: Ne može se odabrati Skladište Dobavljača dok isporučuje sirovine podizvođaču."
 
-#: erpnext/controllers/buying_controller.py:406
+#: erpnext/controllers/buying_controller.py:414
 msgid "Row #{idx}: Item rate has been updated as per valuation rate since its an internal stock transfer."
 msgstr "Red #{idx}: Cijena artikla je ažurirana prema stopi vrednovanja zato što je ovo interni prijenos zaliha."
 
-#: erpnext/controllers/buying_controller.py:881
+#: erpnext/controllers/buying_controller.py:889
 msgid "Row #{idx}: Please enter a location for the asset item {item_code}."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:537
+#: erpnext/controllers/buying_controller.py:545
 msgid "Row #{idx}: Received Qty must be equal to Accepted + Rejected Qty for Item {item_code}."
 msgstr "Red #{idx}: Primljena količina mora biti jednaka Prihvaćenoj + Odbijenoj količini za Artikal {item_code}."
 
-#: erpnext/controllers/buying_controller.py:550
+#: erpnext/controllers/buying_controller.py:558
 msgid "Row #{idx}: {field_label} can not be negative for item {item_code}."
 msgstr "Red #{idx}: {field_label} ne može biti negativan za artikal {item_code}."
 
-#: erpnext/controllers/buying_controller.py:496
+#: erpnext/controllers/buying_controller.py:504
 msgid "Row #{idx}: {field_label} is mandatory."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:518
+#: erpnext/controllers/buying_controller.py:526
 msgid "Row #{idx}: {field_label} is not allowed in Purchase Return."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:250
+#: erpnext/controllers/buying_controller.py:258
 msgid "Row #{idx}: {from_warehouse_field} and {to_warehouse_field} cannot be same."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:999
+#: erpnext/controllers/buying_controller.py:1007
 msgid "Row #{idx}: {schedule_date} cannot be before {transaction_date}."
 msgstr ""
 
@@ -45367,7 +45362,7 @@ msgstr ""
 msgid "Row #{}: {} {} does not exist."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1403
+#: erpnext/stock/doctype/item/item.py:1397
 msgid "Row #{}: {} {} doesn't belong to Company {}. Please select valid {}."
 msgstr "Red #{}: {} {} ne pripada tvrtki {}. Odaberi važeći {}."
 
@@ -45439,11 +45434,11 @@ msgstr ""
 msgid "Row {0}: Both Debit and Credit values cannot be zero"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:222
+#: erpnext/controllers/selling_controller.py:230
 msgid "Row {0}: Conversion Factor is mandatory"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2995
+#: erpnext/controllers/accounts_controller.py:2998
 msgid "Row {0}: Cost Center {1} does not belong to Company {2}"
 msgstr "Red {0}: Centar Troškova {1} ne pripada tvrtki {2}"
 
@@ -45463,11 +45458,11 @@ msgstr ""
 msgid "Row {0}: Debit entry can not be linked with a {1}"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:776
+#: erpnext/controllers/selling_controller.py:784
 msgid "Row {0}: Delivery Warehouse ({1}) and Customer Warehouse ({2}) can not be same"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2529
+#: erpnext/controllers/accounts_controller.py:2532
 msgid "Row {0}: Due Date in the Payment Terms table cannot be before Posting Date"
 msgstr ""
 
@@ -45476,7 +45471,7 @@ msgid "Row {0}: Either Delivery Note Item or Packed Item reference is mandatory.
 msgstr ""
 
 #: erpnext/accounts/doctype/journal_entry/journal_entry.py:1010
-#: erpnext/controllers/taxes_and_totals.py:1205
+#: erpnext/controllers/taxes_and_totals.py:1215
 msgid "Row {0}: Exchange Rate is mandatory"
 msgstr ""
 
@@ -45525,11 +45520,11 @@ msgstr ""
 msgid "Row {0}: Invalid reference {1}"
 msgstr ""
 
-#: erpnext/controllers/taxes_and_totals.py:142
+#: erpnext/controllers/taxes_and_totals.py:143
 msgid "Row {0}: Item Tax template updated as per validity and rate applied"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:541
+#: erpnext/controllers/selling_controller.py:549
 msgid "Row {0}: Item rate has been updated as per valuation rate since its an internal stock transfer"
 msgstr ""
 
@@ -45649,7 +45644,7 @@ msgstr ""
 msgid "Row {0}: The item {1}, quantity must be positive number"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2972
+#: erpnext/controllers/accounts_controller.py:2975
 msgid "Row {0}: The {3} Account {1} does not belong to the company {2}"
 msgstr "Red {0}: {3} Račun {1} ne pripada tvrtki {2}"
 
@@ -45666,7 +45661,7 @@ msgstr ""
 msgid "Row {0}: Workstation or Workstation Type is mandatory for an operation {1}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1011
+#: erpnext/controllers/accounts_controller.py:1014
 msgid "Row {0}: user has not applied the rule {1} on the item {2}"
 msgstr ""
 
@@ -45678,7 +45673,7 @@ msgstr ""
 msgid "Row {0}: {1} must be greater than 0"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:706
+#: erpnext/controllers/accounts_controller.py:709
 msgid "Row {0}: {1} {2} cannot be same as {3} (Party Account) {4}"
 msgstr ""
 
@@ -45694,7 +45689,7 @@ msgstr ""
 msgid "Row {1}: Quantity ({0}) cannot be a fraction. To allow this, disable '{2}' in UOM {3}."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:863
+#: erpnext/controllers/buying_controller.py:871
 msgid "Row {idx}: Asset Naming Series is mandatory for the auto creation of assets for item {item_code}."
 msgstr ""
 
@@ -45720,7 +45715,7 @@ msgstr ""
 msgid "Rows with Same Account heads will be merged on Ledger"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2539
+#: erpnext/controllers/accounts_controller.py:2542
 msgid "Rows with duplicate due dates in other rows were found: {0}"
 msgstr ""
 
@@ -45790,7 +45785,7 @@ msgstr ""
 msgid "SLA Paused On"
 msgstr ""
 
-#: erpnext/public/js/utils.js:1167
+#: erpnext/public/js/utils.js:1163
 msgid "SLA is on hold since {0}"
 msgstr ""
 
@@ -46191,7 +46186,7 @@ msgstr ""
 #: erpnext/accounts/report/sales_register/sales_register.py:238
 #: erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
 #: erpnext/buying/doctype/supplier_quotation_item/supplier_quotation_item.json
-#: erpnext/controllers/selling_controller.py:462
+#: erpnext/controllers/selling_controller.py:470
 #: erpnext/crm/doctype/contract/contract.json
 #: erpnext/maintenance/doctype/maintenance_schedule/maintenance_schedule.js:65
 #: erpnext/maintenance/doctype/maintenance_schedule_item/maintenance_schedule_item.json
@@ -46317,7 +46312,7 @@ msgstr ""
 msgid "Sales Order {0} is not valid"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:443
+#: erpnext/controllers/selling_controller.py:451
 #: erpnext/manufacturing/doctype/work_order/work_order.py:301
 msgid "Sales Order {0} is {1}"
 msgstr ""
@@ -46368,7 +46363,7 @@ msgstr ""
 #: erpnext/accounts/doctype/promotional_scheme/promotional_scheme.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:122
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1156
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1158
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:99
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:194
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:74
@@ -46466,7 +46461,7 @@ msgstr ""
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:156
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:137
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:128
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1153
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1155
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:105
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:191
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:80
@@ -46486,7 +46481,7 @@ msgstr ""
 msgid "Sales Person"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:204
+#: erpnext/controllers/selling_controller.py:212
 msgid "Sales Person <b>{0}</b> is disabled."
 msgstr ""
 
@@ -46767,7 +46762,7 @@ msgstr ""
 
 #. Label of the sample_size (Float) field in DocType 'Quality Inspection'
 #: erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py:93
-#: erpnext/public/js/controllers/transaction.js:2369
+#: erpnext/public/js/controllers/transaction.js:2395
 #: erpnext/stock/doctype/quality_inspection/quality_inspection.json
 msgid "Sample Size"
 msgstr ""
@@ -47305,7 +47300,7 @@ msgstr ""
 msgid "Select Items based on Delivery Date"
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2405
+#: erpnext/public/js/controllers/transaction.js:2431
 msgid "Select Items for Quality Inspection"
 msgstr ""
 
@@ -47446,7 +47441,7 @@ msgstr ""
 msgid "Select company name first."
 msgstr "Odaberi Naziv Tvrtke."
 
-#: erpnext/controllers/accounts_controller.py:2785
+#: erpnext/controllers/accounts_controller.py:2788
 msgid "Select finance book for the item {0} at row {1}"
 msgstr ""
 
@@ -47659,7 +47654,7 @@ msgid "Send Now"
 msgstr ""
 
 #. Label of the send_sms (Button) field in DocType 'SMS Center'
-#: erpnext/public/js/controllers/transaction.js:517
+#: erpnext/public/js/controllers/transaction.js:543
 #: erpnext/selling/doctype/sms_center/sms_center.json
 msgid "Send SMS"
 msgstr ""
@@ -47817,7 +47812,7 @@ msgstr ""
 #: erpnext/manufacturing/doctype/job_card/job_card.json
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.js:74
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.py:114
-#: erpnext/public/js/controllers/transaction.js:2382
+#: erpnext/public/js/controllers/transaction.js:2408
 #: erpnext/public/js/utils/serial_no_batch_selector.js:421
 #: erpnext/selling/doctype/installation_note_item/installation_note_item.json
 #: erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
@@ -47866,7 +47861,7 @@ msgstr ""
 msgid "Serial No Range"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1894
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1895
 msgid "Serial No Reserved"
 msgstr ""
 
@@ -47906,7 +47901,7 @@ msgstr ""
 msgid "Serial No and Batch Selector cannot be use when Use Serial / Batch Fields is enabled."
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:859
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:860
 msgid "Serial No is mandatory"
 msgstr ""
 
@@ -47935,7 +47930,7 @@ msgstr ""
 msgid "Serial No {0} does not exist"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2623
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2624
 msgid "Serial No {0} does not exists"
 msgstr ""
 
@@ -47943,7 +47938,7 @@ msgstr ""
 msgid "Serial No {0} is already added"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:357
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:358
 msgid "Serial No {0} is not present in the {1} {2}, hence you can't return it against the {1} {2}"
 msgstr ""
 
@@ -47980,11 +47975,11 @@ msgstr ""
 msgid "Serial Nos and Batches"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1370
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1371
 msgid "Serial Nos are created successfully"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:2137
+#: erpnext/stock/stock_ledger.py:2145
 msgid "Serial Nos are reserved in Stock Reservation Entries, you need to unreserve them before proceeding."
 msgstr ""
 
@@ -48058,11 +48053,11 @@ msgstr ""
 msgid "Serial and Batch Bundle"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1598
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1599
 msgid "Serial and Batch Bundle created"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1664
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1665
 msgid "Serial and Batch Bundle updated"
 msgstr ""
 
@@ -48414,12 +48409,12 @@ msgid "Service Stop Date"
 msgstr ""
 
 #: erpnext/accounts/deferred_revenue.py:44
-#: erpnext/public/js/controllers/transaction.js:1420
+#: erpnext/public/js/controllers/transaction.js:1446
 msgid "Service Stop Date cannot be after Service End Date"
 msgstr ""
 
 #: erpnext/accounts/deferred_revenue.py:41
-#: erpnext/public/js/controllers/transaction.js:1417
+#: erpnext/public/js/controllers/transaction.js:1443
 msgid "Service Stop Date cannot be before Service Start Date"
 msgstr ""
 
@@ -49854,7 +49849,7 @@ msgstr ""
 
 #: erpnext/setup/setup_wizard/operations/defaults_setup.py:70
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:463
-#: erpnext/stock/doctype/item/item.py:245
+#: erpnext/stock/doctype/item/item.py:248
 msgid "Standard Selling"
 msgstr ""
 
@@ -50684,7 +50679,7 @@ msgstr ""
 #. Option for the 'Purpose' (Select) field in DocType 'Stock Reconciliation'
 #. Label of a Link in the Stock Workspace
 #: erpnext/setup/workspace/home/home.json
-#: erpnext/stock/doctype/item/item.py:612
+#: erpnext/stock/doctype/item/item.py:618
 #: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.json
 #: erpnext/stock/workspace/stock/stock.json
 msgid "Stock Reconciliation"
@@ -50695,7 +50690,7 @@ msgstr ""
 msgid "Stock Reconciliation Item"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:612
+#: erpnext/stock/doctype/item/item.py:618
 msgid "Stock Reconciliations"
 msgstr ""
 
@@ -50730,7 +50725,7 @@ msgstr ""
 #: erpnext/stock/doctype/pick_list/pick_list.js:150
 #: erpnext/stock/doctype/pick_list/pick_list.js:155
 #: erpnext/stock/doctype/stock_entry/stock_entry_dashboard.py:25
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:706
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:702
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:575
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:1138
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:1398
@@ -51130,7 +51125,7 @@ msgstr ""
 #: erpnext/setup/doctype/company/company.py:287
 #: erpnext/setup/setup_wizard/operations/defaults_setup.py:33
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:502
-#: erpnext/stock/doctype/item/item.py:282
+#: erpnext/stock/doctype/item/item.py:285
 msgid "Stores"
 msgstr ""
 
@@ -51665,7 +51660,7 @@ msgstr ""
 msgid "Successfully Set Supplier"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:339
+#: erpnext/stock/doctype/item/item.py:342
 msgid "Successfully changed Stock UOM, please redefine conversion factors for new UOM."
 msgstr ""
 
@@ -51967,7 +51962,7 @@ msgstr ""
 #: erpnext/accounts/doctype/tax_rule/tax_rule.json
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:111
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:87
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1160
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1162
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:198
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:237
 #: erpnext/accounts/report/purchase_register/purchase_register.js:27
@@ -52067,7 +52062,7 @@ msgstr ""
 #. Label of the supplier_name (Data) field in DocType 'Purchase Receipt'
 #. Label of the supplier_name (Data) field in DocType 'Stock Entry'
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1077
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1079
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:156
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:198
 #: erpnext/accounts/report/purchase_register/purchase_register.py:177
@@ -52551,7 +52546,7 @@ msgstr ""
 msgid "System will fetch all the entries if limit value is zero."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1975
+#: erpnext/controllers/accounts_controller.py:1978
 msgid "System will not check over billing since amount for Item {0} in {1} is zero"
 msgstr ""
 
@@ -52810,7 +52805,7 @@ msgstr ""
 msgid "Target Warehouse is required before Submit"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:782
+#: erpnext/controllers/selling_controller.py:790
 msgid "Target Warehouse is set for some items but the customer is not an internal customer."
 msgstr ""
 
@@ -53049,7 +53044,7 @@ msgstr ""
 msgid "Tax Category"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:194
+#: erpnext/controllers/buying_controller.py:202
 msgid "Tax Category has been changed to \"Total\" because all the Items are non-stock items"
 msgstr ""
 
@@ -53254,7 +53249,7 @@ msgstr ""
 #. Label of the taxable_amount (Currency) field in DocType 'Tax Withheld
 #. Vouchers'
 #: erpnext/accounts/doctype/tax_withheld_vouchers/tax_withheld_vouchers.json
-#: erpnext/controllers/taxes_and_totals.py:1125
+#: erpnext/controllers/taxes_and_totals.py:1135
 msgid "Taxable Amount"
 msgstr ""
 
@@ -53393,7 +53388,7 @@ msgstr ""
 msgid "Taxes and Charges Deducted (Company Currency)"
 msgstr "Odbijeni PDV i Naknade (Valuta Tvrtke)"
 
-#: erpnext/stock/doctype/item/item.py:352
+#: erpnext/stock/doctype/item/item.py:355
 msgid "Taxes row #{0}: {1} cannot be smaller than {2}"
 msgstr ""
 
@@ -53679,7 +53674,7 @@ msgstr ""
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/territory_item/territory_item.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:134
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1144
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1146
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:93
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:182
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:68
@@ -53783,7 +53778,7 @@ msgstr ""
 msgid "The BOM which will be replaced"
 msgstr ""
 
-#: erpnext/stock/serial_batch_bundle.py:1274
+#: erpnext/stock/serial_batch_bundle.py:1306
 msgid "The Batch {0} has negative quantity {1} in warehouse {2}. Please correct the quantity."
 msgstr ""
 
@@ -53835,7 +53830,7 @@ msgstr ""
 msgid "The Serial No at Row #{0}: {1} is not available in warehouse {2}."
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1891
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1892
 msgid "The Serial No {0} is reserved against the {1} {2} and cannot be used for any other transaction."
 msgstr ""
 
@@ -53918,7 +53913,7 @@ msgstr ""
 msgid "The following batches are expired, please restock them: <br> {0}"
 msgstr "Sljedeće šarže su istekle, obnovi zalihe: <br> {0}"
 
-#: erpnext/stock/doctype/item/item.py:849
+#: erpnext/stock/doctype/item/item.py:843
 msgid "The following deleted attributes exist in Variants but not in the Template. You can either delete the Variants or keep the attribute(s) in template."
 msgstr ""
 
@@ -53943,15 +53938,15 @@ msgstr ""
 msgid "The holiday on {0} is not between From Date and To Date"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:1066
+#: erpnext/controllers/buying_controller.py:1074
 msgid "The item {item} is not marked as {type_of} item. You can enable it as {type_of} item from its Item master."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:614
+#: erpnext/stock/doctype/item/item.py:620
 msgid "The items {0} and {1} are present in the following {2} :"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:1059
+#: erpnext/controllers/buying_controller.py:1067
 msgid "The items {items} are not marked as {type_of} item. You can enable them as {type_of} item from their Item masters."
 msgstr ""
 
@@ -54053,8 +54048,8 @@ msgstr ""
 msgid "The seller and the buyer cannot be the same"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:142
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:154
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:143
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:155
 msgid "The serial and batch bundle {0} not linked to {1} {2}"
 msgstr ""
 
@@ -54078,7 +54073,7 @@ msgstr ""
 msgid "The stock for the item {0} in the {1} warehouse was negative on the {2}. You should create a positive entry {3} before the date {4} and time {5} to post the correct valuation rate. For more details, please read the <a href='https://docs.erpnext.com/docs/user/manual/en/stock-adjustment-cogs-with-negative-stock'>documentation<a>."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:700
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:696
 msgid "The stock has been reserved for the following Items and Warehouses, un-reserve the same to {0} the Stock Reconciliation: <br /><br /> {1}"
 msgstr ""
 
@@ -54091,11 +54086,11 @@ msgstr ""
 msgid "The task has been enqueued as a background job."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:994
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:990
 msgid "The task has been enqueued as a background job. In case there is any issue on processing in background, the system will add a comment about the error on this Stock Reconciliation and revert to the Draft stage"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1005
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1001
 msgid "The task has been enqueued as a background job. In case there is any issue on processing in background, the system will add a comment about the error on this Stock Reconciliation and revert to the Submitted stage"
 msgstr ""
 
@@ -54145,7 +54140,7 @@ msgstr ""
 msgid "The {0} ({1}) must be equal to {2} ({3})"
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2790
+#: erpnext/public/js/controllers/transaction.js:2816
 msgid "The {0} contains Unit Price Items."
 msgstr ""
 
@@ -54193,7 +54188,7 @@ msgstr ""
 msgid "There can be multiple tiered collection factor based on the total spent. But the conversion factor for redemption will always be same for all the tier."
 msgstr ""
 
-#: erpnext/accounts/party.py:580
+#: erpnext/accounts/party.py:586
 msgid "There can only be 1 Account per Company in {0} {1}"
 msgstr "Može postojati samo jedan račun po Tvrtki u {0} {1}"
 
@@ -54479,7 +54474,7 @@ msgstr ""
 msgid "This will restrict user access to other employee records"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:783
+#: erpnext/controllers/selling_controller.py:791
 msgid "This {} will be treated as material transfer."
 msgstr ""
 
@@ -55193,11 +55188,11 @@ msgid "To include sub-assembly costs and scrap items in Finished Goods on a work
 msgstr ""
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:2337
-#: erpnext/controllers/accounts_controller.py:3005
+#: erpnext/controllers/accounts_controller.py:3008
 msgid "To include tax in row {0} in Item rate, taxes in rows {1} must also be included"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:636
+#: erpnext/stock/doctype/item/item.py:642
 msgid "To merge, following properties must be same for both items"
 msgstr ""
 
@@ -55817,7 +55812,7 @@ msgstr ""
 msgid "Total Paid Amount"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2591
+#: erpnext/controllers/accounts_controller.py:2594
 msgid "Total Payment Amount in Payment Schedule must be equal to Grand / Rounded Total"
 msgstr ""
 
@@ -56102,15 +56097,15 @@ msgstr ""
 msgid "Total Working Hours"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2138
+#: erpnext/controllers/accounts_controller.py:2141
 msgid "Total advance ({0}) against Order {1} cannot be greater than the Grand Total ({2})"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:190
+#: erpnext/controllers/selling_controller.py:198
 msgid "Total allocated percentage for sales team should be 100"
 msgstr ""
 
-#: erpnext/selling/doctype/customer/customer.py:162
+#: erpnext/selling/doctype/customer/customer.py:161
 msgid "Total contribution percentage should be equal to 100"
 msgstr ""
 
@@ -56995,7 +56990,7 @@ msgstr ""
 msgid "Unit of Measure (UOM)"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:384
+#: erpnext/stock/doctype/item/item.py:387
 msgid "Unit of Measure {0} has been entered more than once in Conversion Factor Table"
 msgstr ""
 
@@ -57437,7 +57432,7 @@ msgstr ""
 msgid "Update timestamp on new communication"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom_creator/bom_creator.py:533
+#: erpnext/manufacturing/doctype/bom_creator/bom_creator.py:534
 msgid "Updated successfully"
 msgstr ""
 
@@ -57451,7 +57446,7 @@ msgstr ""
 msgid "Updated via 'Time Log' (In Minutes)"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1387
+#: erpnext/stock/doctype/item/item.py:1381
 msgid "Updating Variants..."
 msgstr ""
 
@@ -58009,19 +58004,19 @@ msgstr ""
 msgid "Valuation Rate (In / Out)"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1881
+#: erpnext/stock/stock_ledger.py:1890
 msgid "Valuation Rate Missing"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1859
+#: erpnext/stock/stock_ledger.py:1868
 msgid "Valuation Rate for the Item {0}, is required to do accounting entries for {1} {2}."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:266
+#: erpnext/stock/doctype/item/item.py:269
 msgid "Valuation Rate is mandatory if Opening Stock entered"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:752
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:748
 msgid "Valuation Rate required for Item {0} at row {1}"
 msgstr ""
 
@@ -58031,7 +58026,7 @@ msgstr ""
 msgid "Valuation and Total"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:971
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:967
 msgid "Valuation rate for customer provided items has been set to zero."
 msgstr ""
 
@@ -58045,7 +58040,7 @@ msgid "Valuation rate for the item as per Sales Invoice (Only for Internal Trans
 msgstr ""
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:2361
-#: erpnext/controllers/accounts_controller.py:3029
+#: erpnext/controllers/accounts_controller.py:3032
 msgid "Valuation type charges can not be marked as Inclusive"
 msgstr ""
 
@@ -58201,7 +58196,7 @@ msgstr ""
 msgid "Variant"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:864
+#: erpnext/stock/doctype/item/item.py:858
 msgid "Variant Attribute Error"
 msgstr ""
 
@@ -58220,7 +58215,7 @@ msgstr ""
 msgid "Variant Based On"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:892
+#: erpnext/stock/doctype/item/item.py:886
 msgid "Variant Based On cannot be changed"
 msgstr ""
 
@@ -58238,7 +58233,7 @@ msgstr ""
 msgid "Variant Item"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:862
+#: erpnext/stock/doctype/item/item.py:856
 msgid "Variant Items"
 msgstr ""
 
@@ -58356,7 +58351,7 @@ msgstr ""
 #: erpnext/accounts/doctype/cost_center/cost_center_tree.js:56
 #: erpnext/accounts/doctype/invoice_discounting/invoice_discounting.js:205
 #: erpnext/accounts/doctype/journal_entry/journal_entry.js:43
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:668
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:670
 #: erpnext/bulk_transaction/doctype/bulk_transaction_log/bulk_transaction_log.js:14
 #: erpnext/bulk_transaction/doctype/bulk_transaction_log/bulk_transaction_log.js:24
 #: erpnext/buying/doctype/request_for_quotation/request_for_quotation.js:167
@@ -58543,7 +58538,7 @@ msgstr ""
 #: erpnext/accounts/doctype/repost_accounting_ledger_items/repost_accounting_ledger_items.json
 #: erpnext/accounts/doctype/repost_payment_ledger_items/repost_payment_ledger_items.json
 #: erpnext/accounts/doctype/unreconcile_payment/unreconcile_payment.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1099
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1101
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.js:42
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:209
 #: erpnext/accounts/report/general_ledger/general_ledger.js:49
@@ -58574,7 +58569,7 @@ msgstr ""
 msgid "Voucher No"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1087
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1088
 msgid "Voucher No is mandatory"
 msgstr ""
 
@@ -58616,7 +58611,7 @@ msgstr ""
 #: erpnext/accounts/doctype/repost_payment_ledger_items/repost_payment_ledger_items.json
 #: erpnext/accounts/doctype/tax_withheld_vouchers/tax_withheld_vouchers.json
 #: erpnext/accounts/doctype/unreconcile_payment/unreconcile_payment.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1097
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1099
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:200
 #: erpnext/accounts/report/general_ledger/general_ledger.py:697
 #: erpnext/accounts/report/invalid_ledger_entries/invalid_ledger_entries.py:31
@@ -58970,10 +58965,6 @@ msgstr ""
 msgid "Warehouse not found against the account {0}"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:600
-msgid "Warehouse not found in the system"
-msgstr ""
-
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:1130
 #: erpnext/stock/doctype/delivery_note/delivery_note.py:414
 msgid "Warehouse required for stock Item {0}"
@@ -59102,7 +59093,7 @@ msgid "Warn for new Request for Quotations"
 msgstr ""
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:744
-#: erpnext/controllers/accounts_controller.py:1978
+#: erpnext/controllers/accounts_controller.py:1981
 #: erpnext/stock/doctype/delivery_trip/delivery_trip.js:145
 #: erpnext/utilities/transaction_base.py:123
 msgid "Warning"
@@ -60074,7 +60065,7 @@ msgstr ""
 msgid "You are importing data for the code list:"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3611
+#: erpnext/controllers/accounts_controller.py:3614
 msgid "You are not allowed to update as per the conditions set in {} Workflow."
 msgstr ""
 
@@ -60139,7 +60130,7 @@ msgstr ""
 msgid "You can't make any changes to Job Card since Work Order is closed."
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:185
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:186
 msgid "You can't process the serial number {0} as it has already been used in the SABB {1}. {2} if you want to inward same serial number multiple times then enabled 'Allow existing Serial No to be Manufactured/Received again' in the {3}"
 msgstr ""
 
@@ -60199,7 +60190,7 @@ msgstr ""
 msgid "You cannot {0} this document because another Period Closing Entry {1} exists after {2}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3587
+#: erpnext/controllers/accounts_controller.py:3590
 msgid "You do not have permissions to {} items in a {}."
 msgstr ""
 
@@ -60227,7 +60218,7 @@ msgstr ""
 msgid "You have entered a duplicate Delivery Note on Row"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1063
+#: erpnext/stock/doctype/item/item.py:1057
 msgid "You have to enable auto re-order in Stock Settings to maintain re-order levels."
 msgstr ""
 
@@ -60247,7 +60238,7 @@ msgstr ""
 msgid "You need to cancel POS Closing Entry {} to be able to cancel this document."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2980
+#: erpnext/controllers/accounts_controller.py:2983
 msgid "You selected the account group {1} as {2} Account in row {0}. Please select a single account."
 msgstr ""
 
@@ -60325,7 +60316,7 @@ msgstr ""
 msgid "`Allow Negative rates for Items`"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1873
+#: erpnext/stock/stock_ledger.py:1882
 msgid "after"
 msgstr ""
 
@@ -60473,7 +60464,7 @@ msgstr ""
 msgid "material_request_item"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:151
+#: erpnext/controllers/selling_controller.py:159
 msgid "must be between 0 and 100"
 msgstr ""
 
@@ -60498,7 +60489,7 @@ msgstr ""
 msgid "on"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1289
+#: erpnext/controllers/accounts_controller.py:1292
 msgid "or"
 msgstr ""
 
@@ -60547,7 +60538,7 @@ msgstr ""
 msgid "per hour"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1874
+#: erpnext/stock/stock_ledger.py:1883
 msgid "performing either one below:"
 msgstr ""
 
@@ -60674,7 +60665,7 @@ msgstr ""
 msgid "{0}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1109
+#: erpnext/controllers/accounts_controller.py:1112
 msgid "{0} '{1}' is disabled"
 msgstr ""
 
@@ -60690,7 +60681,7 @@ msgstr ""
 msgid "{0} <b>{1}</b> has submitted Assets. Remove Item <b>{2}</b> from table to continue."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2193
+#: erpnext/controllers/accounts_controller.py:2196
 msgid "{0} Account not found against Customer {1}."
 msgstr ""
 
@@ -60722,7 +60713,7 @@ msgstr ""
 msgid "{0} Request for {1}"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:323
+#: erpnext/stock/doctype/item/item.py:326
 msgid "{0} Retain Sample is based on batch, please check Has Batch No to retain sample of item"
 msgstr ""
 
@@ -60813,7 +60804,7 @@ msgid "{0} entered twice in Item Tax"
 msgstr ""
 
 #: erpnext/setup/doctype/item_group/item_group.py:48
-#: erpnext/stock/doctype/item/item.py:436
+#: erpnext/stock/doctype/item/item.py:439
 msgid "{0} entered twice {1} in Item Taxes"
 msgstr ""
 
@@ -60834,7 +60825,7 @@ msgstr ""
 msgid "{0} hours"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2534
+#: erpnext/controllers/accounts_controller.py:2537
 msgid "{0} in row {1}"
 msgstr ""
 
@@ -60858,7 +60849,7 @@ msgstr ""
 
 #: erpnext/accounts/doctype/budget/budget.py:60
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:643
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:49
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:50
 #: erpnext/accounts/report/general_ledger/general_ledger.py:59
 #: erpnext/accounts/report/pos_register/pos_register.py:107
 #: erpnext/controllers/trends.py:50
@@ -60878,11 +60869,11 @@ msgstr ""
 msgid "{0} is mandatory. Maybe Currency Exchange record is not created for {1} to {2}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2937
+#: erpnext/controllers/accounts_controller.py:2940
 msgid "{0} is mandatory. Maybe Currency Exchange record is not created for {1} to {2}."
 msgstr ""
 
-#: erpnext/selling/doctype/customer/customer.py:204
+#: erpnext/selling/doctype/customer/customer.py:203
 msgid "{0} is not a company bank account"
 msgstr "{0} nije bankovni račun tvrtke"
 
@@ -60965,7 +60956,7 @@ msgstr ""
 msgid "{0} to {1}"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:690
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:686
 msgid "{0} units are reserved for Item {1} in Warehouse {2}, please un-reserve the same to {3} the Stock Reconciliation."
 msgstr ""
 
@@ -60981,16 +60972,16 @@ msgstr ""
 msgid "{0} units of {1} are required in {2} with the inventory dimension: {3} ({4}) on {5} {6} for {7} to complete the transaction."
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1532 erpnext/stock/stock_ledger.py:2023
-#: erpnext/stock/stock_ledger.py:2037
+#: erpnext/stock/stock_ledger.py:1541 erpnext/stock/stock_ledger.py:2031
+#: erpnext/stock/stock_ledger.py:2045
 msgid "{0} units of {1} needed in {2} on {3} {4} for {5} to complete this transaction."
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:2124 erpnext/stock/stock_ledger.py:2170
+#: erpnext/stock/stock_ledger.py:2132 erpnext/stock/stock_ledger.py:2178
 msgid "{0} units of {1} needed in {2} on {3} {4} to complete this transaction."
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1526
+#: erpnext/stock/stock_ledger.py:1535
 msgid "{0} units of {1} needed in {2} to complete this transaction."
 msgstr ""
 
@@ -61036,7 +61027,7 @@ msgstr ""
 msgid "{0} {1} does not exist"
 msgstr ""
 
-#: erpnext/accounts/party.py:560
+#: erpnext/accounts/party.py:566
 msgid "{0} {1} has accounting entries in currency {2} for company {3}. Please select a receivable or payable account with currency {2}."
 msgstr "{0} {1} ima knjigovodstvene unose u valuti {2} za tvrtku {3}. Odaberi račun potraživanja ili plaćanja sa valutom {2}."
 
@@ -61070,7 +61061,7 @@ msgstr ""
 msgid "{0} {1} is associated with {2}, but Party Account is {3}"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:462
+#: erpnext/controllers/selling_controller.py:470
 #: erpnext/controllers/subcontracting_controller.py:954
 msgid "{0} {1} is cancelled or closed"
 msgstr ""
@@ -61087,11 +61078,11 @@ msgstr ""
 msgid "{0} {1} is closed"
 msgstr ""
 
-#: erpnext/accounts/party.py:798
+#: erpnext/accounts/party.py:804
 msgid "{0} {1} is disabled"
 msgstr ""
 
-#: erpnext/accounts/party.py:804
+#: erpnext/accounts/party.py:810
 msgid "{0} {1} is frozen"
 msgstr ""
 
@@ -61099,7 +61090,7 @@ msgstr ""
 msgid "{0} {1} is fully billed"
 msgstr ""
 
-#: erpnext/accounts/party.py:808
+#: erpnext/accounts/party.py:814
 msgid "{0} {1} is not active"
 msgstr ""
 
@@ -61225,15 +61216,15 @@ msgstr ""
 msgid "{0}: {1} must be less than {2}"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:840
+#: erpnext/controllers/buying_controller.py:848
 msgid "{count} Assets created for {item_code}"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:738
+#: erpnext/controllers/buying_controller.py:746
 msgid "{doctype} {name} is cancelled or closed."
 msgstr "{doctype} {name} je otkazan ili zatvoren."
 
-#: erpnext/controllers/buying_controller.py:459
+#: erpnext/controllers/buying_controller.py:467
 msgid "{field_label} is mandatory for sub-contracted {doctype}."
 msgstr ""
 
@@ -61241,7 +61232,7 @@ msgstr ""
 msgid "{item_name}'s Sample Size ({sample_size}) cannot be greater than the Accepted Quantity ({accepted_quantity})"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:563
+#: erpnext/controllers/buying_controller.py:571
 msgid "{ref_doctype} {ref_name} is {status}."
 msgstr ""
 
@@ -61307,7 +61298,7 @@ msgstr ""
 msgid "{} can't be cancelled since the Loyalty Points earned has been redeemed. First cancel the {} No {}"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:222
+#: erpnext/controllers/buying_controller.py:230
 msgid "{} has submitted assets linked to it. You need to cancel the assets to create purchase return."
 msgstr ""
 

--- a/erpnext/locale/hu.po
+++ b/erpnext/locale/hu.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: frappe\n"
 "Report-Msgid-Bugs-To: hello@frappe.io\n"
-"POT-Creation-Date: 2025-05-25 09:35+0000\n"
-"PO-Revision-Date: 2025-05-25 20:34\n"
+"POT-Creation-Date: 2025-06-01 09:36+0000\n"
+"PO-Revision-Date: 2025-06-01 21:34\n"
 "Last-Translator: hello@frappe.io\n"
 "Language-Team: Hungarian\n"
 "MIME-Version: 1.0\n"
@@ -83,15 +83,15 @@ msgstr ""
 msgid " Summary"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:235
+#: erpnext/stock/doctype/item/item.py:238
 msgid "\"Customer Provided Item\" cannot be Purchase Item also"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:237
+#: erpnext/stock/doctype/item/item.py:240
 msgid "\"Customer Provided Item\" cannot have Valuation Rate"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:313
+#: erpnext/stock/doctype/item/item.py:316
 msgid "\"Is Fixed Asset\" cannot be unchecked, as Asset record exists against the item"
 msgstr ""
 
@@ -213,7 +213,7 @@ msgstr ""
 msgid "% of materials delivered against this Sales Order"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2197
+#: erpnext/controllers/accounts_controller.py:2200
 msgid "'Account' in the Accounting section of Customer {0}"
 msgstr ""
 
@@ -225,15 +225,11 @@ msgstr ""
 msgid "'Based On' and 'Group By' can not be same"
 msgstr ""
 
-#: erpnext/stock/report/product_bundle_balance/product_bundle_balance.py:233
-msgid "'Date' is required"
-msgstr ""
-
 #: erpnext/selling/report/inactive_customers/inactive_customers.py:18
 msgid "'Days Since Last Order' must be greater than or equal to zero"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2202
+#: erpnext/controllers/accounts_controller.py:2205
 msgid "'Default {0} Account' in Company {1}"
 msgstr ""
 
@@ -243,7 +239,7 @@ msgstr ""
 
 #: erpnext/stock/report/batch_item_expiry_status/batch_item_expiry_status.py:24
 #: erpnext/stock/report/batch_wise_balance_history/batch_wise_balance_history.py:120
-#: erpnext/stock/report/stock_analytics/stock_analytics.py:314
+#: erpnext/stock/report/stock_analytics/stock_analytics.py:313
 msgid "'From Date' is required"
 msgstr ""
 
@@ -251,7 +247,7 @@ msgstr ""
 msgid "'From Date' must be after 'To Date'"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:398
+#: erpnext/stock/doctype/item/item.py:401
 msgid "'Has Serial No' can not be 'Yes' for non-stock item"
 msgstr ""
 
@@ -1075,7 +1071,7 @@ msgstr ""
 
 #. Label of the qty (Float) field in DocType 'Purchase Receipt Item'
 #. Label of the qty (Float) field in DocType 'Subcontracting Receipt Item'
-#: erpnext/public/js/controllers/transaction.js:2362
+#: erpnext/public/js/controllers/transaction.js:2388
 #: erpnext/stock/doctype/purchase_receipt_item/purchase_receipt_item.json
 #: erpnext/subcontracting/doctype/subcontracting_receipt_item/subcontracting_receipt_item.json
 msgid "Accepted Quantity"
@@ -1273,7 +1269,7 @@ msgid "Account Manager"
 msgstr ""
 
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:949
-#: erpnext/controllers/accounts_controller.py:2206
+#: erpnext/controllers/accounts_controller.py:2209
 msgid "Account Missing"
 msgstr ""
 
@@ -1448,7 +1444,7 @@ msgstr ""
 msgid "Account {0} is frozen"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1288
+#: erpnext/controllers/accounts_controller.py:1291
 msgid "Account {0} is invalid. Account Currency must be {1}"
 msgstr ""
 
@@ -1484,7 +1480,7 @@ msgstr ""
 msgid "Account: {0} is not permitted under Payment Entry"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3037
+#: erpnext/controllers/accounts_controller.py:3040
 msgid "Account: {0} with currency: {1} can not be selected"
 msgstr ""
 
@@ -1757,7 +1753,7 @@ msgstr ""
 msgid "Accounting Entry for Asset"
 msgstr ""
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:796
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:805
 msgid "Accounting Entry for Service"
 msgstr ""
 
@@ -1772,18 +1768,18 @@ msgstr ""
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py:1468
 #: erpnext/controllers/stock_controller.py:550
 #: erpnext/controllers/stock_controller.py:567
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:889
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:898
 #: erpnext/stock/doctype/stock_entry/stock_entry.py:1586
 #: erpnext/stock/doctype/stock_entry/stock_entry.py:1600
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py:561
 msgid "Accounting Entry for Stock"
 msgstr ""
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:717
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:726
 msgid "Accounting Entry for {0}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2247
+#: erpnext/controllers/accounts_controller.py:2250
 msgid "Accounting Entry for {0}: {1} can only be made in currency: {2}"
 msgstr ""
 
@@ -2176,7 +2172,7 @@ msgstr ""
 msgid "Accumulated Monthly"
 msgstr ""
 
-#: erpnext/controllers/budget_controller.py:417
+#: erpnext/controllers/budget_controller.py:422
 msgid "Accumulated Monthly Budget for Account {0} against {1} {2} is {3}. It will be collectively ({4}) exceeded by {5}"
 msgstr ""
 
@@ -3290,7 +3286,7 @@ msgstr ""
 msgid "Adjustment Against"
 msgstr ""
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:634
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:643
 msgid "Adjustment based on Purchase Invoice rate"
 msgstr ""
 
@@ -3401,7 +3397,7 @@ msgstr ""
 msgid "Advance amount"
 msgstr ""
 
-#: erpnext/controllers/taxes_and_totals.py:845
+#: erpnext/controllers/taxes_and_totals.py:855
 msgid "Advance amount cannot be greater than {0} {1}"
 msgstr ""
 
@@ -3612,7 +3608,7 @@ msgstr ""
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:152
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:133
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1125
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1127
 msgid "Age (Days)"
 msgstr ""
 
@@ -3697,16 +3693,6 @@ msgstr ""
 
 #: erpnext/setup/setup_wizard/data/industry_type.txt:4
 msgid "Agriculture"
-msgstr ""
-
-#. Name of a role
-#: erpnext/assets/doctype/location/location.json
-msgid "Agriculture Manager"
-msgstr ""
-
-#. Name of a role
-#: erpnext/assets/doctype/location/location.json
-msgid "Agriculture User"
 msgstr ""
 
 #: erpnext/setup/setup_wizard/data/industry_type.txt:5
@@ -3899,7 +3885,7 @@ msgstr ""
 msgid "All items are already requested"
 msgstr ""
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:1317
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:1326
 msgid "All items have already been Invoiced/Returned"
 msgstr ""
 
@@ -3911,7 +3897,7 @@ msgstr ""
 msgid "All items have already been transferred for this Work Order."
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2465
+#: erpnext/public/js/controllers/transaction.js:2491
 msgid "All items in this document already have a linked Quality Inspection."
 msgstr ""
 
@@ -4109,7 +4095,7 @@ msgstr ""
 msgid "Allow Item To Be Added Multiple Times in a Transaction"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:755
+#: erpnext/controllers/selling_controller.py:763
 msgid "Allow Item to Be Added Multiple Times in a Transaction"
 msgstr ""
 
@@ -5055,7 +5041,7 @@ msgstr ""
 msgid "Annual Billing: {0}"
 msgstr ""
 
-#: erpnext/controllers/budget_controller.py:441
+#: erpnext/controllers/budget_controller.py:446
 msgid "Annual Budget for Account {0} against {1} {2} is {3}. It will be collectively ({4}) exceeded by {5}"
 msgstr ""
 
@@ -5544,7 +5530,7 @@ msgstr ""
 msgid "As the field {0} is enabled, the value of the field {1} should be more than 1."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:989
+#: erpnext/stock/doctype/item/item.py:983
 msgid "As there are existing submitted transactions against item {0}, you can not change the value of {1}."
 msgstr ""
 
@@ -5690,7 +5676,7 @@ msgstr ""
 msgid "Asset Category Name"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:304
+#: erpnext/stock/doctype/item/item.py:307
 msgid "Asset Category is mandatory for Fixed Asset item"
 msgstr ""
 
@@ -6065,7 +6051,7 @@ msgstr ""
 msgid "Asset {0} must be submitted"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:851
+#: erpnext/controllers/buying_controller.py:859
 msgid "Asset {assets_link} created for {item_code}"
 msgstr ""
 
@@ -6095,11 +6081,11 @@ msgstr ""
 msgid "Assets"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:869
+#: erpnext/controllers/buying_controller.py:877
 msgid "Assets not created for {item_code}. You will have to create asset manually."
 msgstr "A (z) {item_code} domainhez nem létrehozott eszközök Az eszközt manuálisan kell létrehoznia."
 
-#: erpnext/controllers/buying_controller.py:856
+#: erpnext/controllers/buying_controller.py:864
 msgid "Assets {assets_link} created for {item_code}"
 msgstr ""
 
@@ -6194,7 +6180,7 @@ msgstr ""
 msgid "At row #{0}: you have selected the Difference Account {1}, which is a Cost of Goods Sold type account. Please select a different account"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:864
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:865
 msgid "At row {0}: Batch No is mandatory for Item {1}"
 msgstr ""
 
@@ -6202,11 +6188,11 @@ msgstr ""
 msgid "At row {0}: Parent Row No cannot be set for item {1}"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:849
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:850
 msgid "At row {0}: Qty is mandatory for the batch {1}"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:856
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:857
 msgid "At row {0}: Serial No is mandatory for Item {1}"
 msgstr ""
 
@@ -6280,7 +6266,7 @@ msgstr ""
 msgid "Attribute Value"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:930
+#: erpnext/stock/doctype/item/item.py:924
 msgid "Attribute table is mandatory"
 msgstr ""
 
@@ -6288,11 +6274,11 @@ msgstr ""
 msgid "Attribute value: {0} must appear only once"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:934
+#: erpnext/stock/doctype/item/item.py:928
 msgid "Attribute {0} selected multiple times in Attributes Table"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:862
+#: erpnext/stock/doctype/item/item.py:856
 msgid "Attributes"
 msgstr ""
 
@@ -7576,11 +7562,11 @@ msgstr ""
 msgid "Barcode Type"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:457
+#: erpnext/stock/doctype/item/item.py:460
 msgid "Barcode {0} already used in Item {1}"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:472
+#: erpnext/stock/doctype/item/item.py:475
 msgid "Barcode {0} is not a valid {1} code"
 msgstr ""
 
@@ -7834,7 +7820,7 @@ msgstr ""
 #: erpnext/manufacturing/doctype/job_card/job_card.json
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.js:89
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.py:115
-#: erpnext/public/js/controllers/transaction.js:2388
+#: erpnext/public/js/controllers/transaction.js:2414
 #: erpnext/public/js/utils/barcode_scanner.js:260
 #: erpnext/public/js/utils/serial_no_batch_selector.js:438
 #: erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
@@ -7861,11 +7847,11 @@ msgstr ""
 msgid "Batch No"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:867
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:868
 msgid "Batch No is mandatory"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2629
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2630
 msgid "Batch No {0} does not exists"
 msgstr ""
 
@@ -7873,7 +7859,7 @@ msgstr ""
 msgid "Batch No {0} is linked with Item {1} which has serial no. Please scan serial no instead."
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:364
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:365
 msgid "Batch No {0} is not present in the original {1} {2}, hence you can't return it against the {1} {2}"
 msgstr ""
 
@@ -7888,11 +7874,11 @@ msgstr ""
 msgid "Batch Nos"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1421
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1422
 msgid "Batch Nos are created successfully"
 msgstr ""
 
-#: erpnext/controllers/sales_and_purchase_return.py:1096
+#: erpnext/controllers/sales_and_purchase_return.py:1001
 msgid "Batch Not Available for Return"
 msgstr ""
 
@@ -7941,7 +7927,7 @@ msgstr ""
 msgid "Batch {0} and Warehouse"
 msgstr ""
 
-#: erpnext/controllers/sales_and_purchase_return.py:1095
+#: erpnext/controllers/sales_and_purchase_return.py:1000
 msgid "Batch {0} is not available in warehouse {1}"
 msgstr ""
 
@@ -7991,7 +7977,7 @@ msgstr ""
 #. Label of the bill_date (Date) field in DocType 'Journal Entry'
 #. Label of the bill_date (Date) field in DocType 'Subcontracting Receipt'
 #: erpnext/accounts/doctype/journal_entry/journal_entry.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1110
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1112
 #: erpnext/accounts/report/purchase_register/purchase_register.py:214
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.json
 msgid "Bill Date"
@@ -8000,7 +7986,7 @@ msgstr ""
 #. Label of the bill_no (Data) field in DocType 'Journal Entry'
 #. Label of the bill_no (Data) field in DocType 'Subcontracting Receipt'
 #: erpnext/accounts/doctype/journal_entry/journal_entry.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1109
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1111
 #: erpnext/accounts/report/purchase_register/purchase_register.py:213
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.json
 msgid "Bill No"
@@ -8220,7 +8206,7 @@ msgstr ""
 msgid "Billing Zipcode"
 msgstr ""
 
-#: erpnext/accounts/party.py:602
+#: erpnext/accounts/party.py:608
 msgid "Billing currency must be equal to either default company's currency or party account currency"
 msgstr ""
 
@@ -9217,7 +9203,7 @@ msgid "Can only make payment against unbilled {0}"
 msgstr ""
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1458
-#: erpnext/controllers/accounts_controller.py:2946
+#: erpnext/controllers/accounts_controller.py:2949
 #: erpnext/public/js/controllers/accounts.js:90
 msgid "Can refer row only if the charge type is 'On Previous Row Amount' or 'Previous Row Total'"
 msgstr ""
@@ -9379,9 +9365,9 @@ msgstr ""
 msgid "Cannot Create Return"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:625
-#: erpnext/stock/doctype/item/item.py:638
-#: erpnext/stock/doctype/item/item.py:652
+#: erpnext/stock/doctype/item/item.py:631
+#: erpnext/stock/doctype/item/item.py:644
+#: erpnext/stock/doctype/item/item.py:658
 msgid "Cannot Merge"
 msgstr ""
 
@@ -9405,7 +9391,7 @@ msgstr ""
 msgid "Cannot apply TDS against multiple parties in one entry"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:307
+#: erpnext/stock/doctype/item/item.py:310
 msgid "Cannot be a fixed asset item as Stock Ledger is created."
 msgstr ""
 
@@ -9421,7 +9407,7 @@ msgstr ""
 msgid "Cannot cancel the transaction. Reposting of item valuation on submission is not completed yet."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:959
+#: erpnext/controllers/buying_controller.py:967
 msgid "Cannot cancel this document as it is linked with the submitted asset {asset_link}. Please cancel the asset to continue."
 msgstr ""
 
@@ -9429,7 +9415,7 @@ msgstr ""
 msgid "Cannot cancel transaction for Completed Work Order."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:882
+#: erpnext/stock/doctype/item/item.py:876
 msgid "Cannot change Attributes after stock transaction. Make a new Item and transfer stock to the new Item"
 msgstr ""
 
@@ -9445,7 +9431,7 @@ msgstr ""
 msgid "Cannot change Service Stop Date for item in row {0}"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:873
+#: erpnext/stock/doctype/item/item.py:867
 msgid "Cannot change Variant properties after stock transaction. You will have to make a new Item to do this."
 msgstr ""
 
@@ -9473,7 +9459,7 @@ msgstr ""
 msgid "Cannot covert to Group because Account Type is selected."
 msgstr ""
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:972
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:981
 msgid "Cannot create Stock Reservation Entries for future dated Purchase Receipts."
 msgstr ""
 
@@ -9524,7 +9510,7 @@ msgstr ""
 msgid "Cannot find Item with this Barcode"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3483
+#: erpnext/controllers/accounts_controller.py:3486
 msgid "Cannot find a default warehouse for item {0}. Please set one in the Item Master or in Stock Settings."
 msgstr ""
 
@@ -9532,7 +9518,7 @@ msgstr ""
 msgid "Cannot make any transactions until the deletion job is completed"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2074
+#: erpnext/controllers/accounts_controller.py:2077
 msgid "Cannot overbill for Item {0} in row {1} more than {2}. To allow over-billing, please set allowance in Accounts Settings"
 msgstr ""
 
@@ -9553,7 +9539,7 @@ msgid "Cannot receive from customer against negative outstanding"
 msgstr ""
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1475
-#: erpnext/controllers/accounts_controller.py:2961
+#: erpnext/controllers/accounts_controller.py:2964
 #: erpnext/public/js/controllers/accounts.js:100
 msgid "Cannot refer row number greater than or equal to current row number for this Charge type"
 msgstr ""
@@ -9569,7 +9555,7 @@ msgstr ""
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1467
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1646
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:1917
-#: erpnext/controllers/accounts_controller.py:2951
+#: erpnext/controllers/accounts_controller.py:2954
 #: erpnext/public/js/controllers/accounts.js:94
 #: erpnext/public/js/controllers/taxes_and_totals.js:470
 msgid "Cannot select charge type as 'On Previous Row Amount' or 'On Previous Row Total' for first row"
@@ -9583,15 +9569,15 @@ msgstr ""
 msgid "Cannot set authorization on basis of Discount for {0}"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:716
+#: erpnext/stock/doctype/item/item.py:722
 msgid "Cannot set multiple Item Defaults for a company."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3631
+#: erpnext/controllers/accounts_controller.py:3634
 msgid "Cannot set quantity less than delivered quantity"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3634
+#: erpnext/controllers/accounts_controller.py:3637
 msgid "Cannot set quantity less than received quantity"
 msgstr ""
 
@@ -10014,7 +10000,7 @@ msgid "Channel Partner"
 msgstr ""
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:2346
-#: erpnext/controllers/accounts_controller.py:3014
+#: erpnext/controllers/accounts_controller.py:3017
 msgid "Charge of type 'Actual' in row {0} cannot be included in Item Rate or Paid Amount"
 msgstr ""
 
@@ -10197,7 +10183,7 @@ msgstr ""
 
 #. Label of the reference_date (Date) field in DocType 'Payment Entry'
 #: erpnext/accounts/doctype/payment_entry/payment_entry.json
-#: erpnext/public/js/controllers/transaction.js:2299
+#: erpnext/public/js/controllers/transaction.js:2325
 msgid "Cheque/Reference Date"
 msgstr ""
 
@@ -10245,7 +10231,7 @@ msgstr ""
 
 #. Label of the child_row_reference (Data) field in DocType 'Quality
 #. Inspection'
-#: erpnext/public/js/controllers/transaction.js:2394
+#: erpnext/public/js/controllers/transaction.js:2420
 #: erpnext/stock/doctype/quality_inspection/quality_inspection.json
 msgid "Child Row Reference"
 msgstr ""
@@ -10957,7 +10943,7 @@ msgstr ""
 #: erpnext/accounts/report/cheques_and_deposits_incorrectly_cleared/cheques_and_deposits_incorrectly_cleared.js:8
 #: erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.js:8
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:8
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:49
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:50
 #: erpnext/accounts/report/deferred_revenue_and_expense/deferred_revenue_and_expense.js:8
 #: erpnext/accounts/report/delivered_items_to_be_billed/delivered_items_to_be_billed.js:7
 #: erpnext/accounts/report/dimension_wise_accounts_balance_report/dimension_wise_accounts_balance_report.js:8
@@ -12190,7 +12176,7 @@ msgid "Content Type"
 msgstr ""
 
 #: erpnext/erpnext_integrations/doctype/plaid_settings/plaid_settings.js:162
-#: erpnext/public/js/controllers/transaction.js:2312
+#: erpnext/public/js/controllers/transaction.js:2338
 #: erpnext/selling/doctype/quotation/quotation.js:356
 msgid "Continue"
 msgstr ""
@@ -12355,7 +12341,7 @@ msgstr ""
 msgid "Conversion Rate"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:393
+#: erpnext/stock/doctype/item/item.py:396
 msgid "Conversion factor for default Unit of Measure must be 1 in row {0}"
 msgstr ""
 
@@ -12363,15 +12349,15 @@ msgstr ""
 msgid "Conversion factor for item {0} has been reset to 1.0 as the uom {1} is same as stock uom {2}."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2767
+#: erpnext/controllers/accounts_controller.py:2770
 msgid "Conversion rate cannot be 0"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2774
+#: erpnext/controllers/accounts_controller.py:2777
 msgid "Conversion rate is 1.00, but document currency is different from company currency"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2770
+#: erpnext/controllers/accounts_controller.py:2773
 msgid "Conversion rate must be 1.00 if document currency is same as company currency"
 msgstr ""
 
@@ -12584,7 +12570,7 @@ msgstr ""
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:28
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:40
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:30
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1096
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1098
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:40
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.js:42
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.py:197
@@ -12677,7 +12663,7 @@ msgid "Cost Center is a part of Cost Center Allocation, hence cannot be converte
 msgstr ""
 
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py:1411
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:855
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:864
 msgid "Cost Center is required in row {0} in Taxes table for type {1}"
 msgstr ""
 
@@ -12946,8 +12932,8 @@ msgstr ""
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:132
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:143
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:219
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:654
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:678
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:656
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:680
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.js:88
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.js:89
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.js:103
@@ -13004,8 +12990,8 @@ msgstr ""
 #: erpnext/projects/doctype/task/task_tree.js:81
 #: erpnext/public/js/communication.js:19 erpnext/public/js/communication.js:31
 #: erpnext/public/js/communication.js:41
-#: erpnext/public/js/controllers/transaction.js:336
-#: erpnext/public/js/controllers/transaction.js:2435
+#: erpnext/public/js/controllers/transaction.js:362
+#: erpnext/public/js/controllers/transaction.js:2461
 #: erpnext/selling/doctype/customer/customer.js:181
 #: erpnext/selling/doctype/quotation/quotation.js:124
 #: erpnext/selling/doctype/quotation/quotation.js:133
@@ -13300,7 +13286,7 @@ msgstr ""
 msgid "Create a variant with the template image."
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1877
+#: erpnext/stock/stock_ledger.py:1886
 msgid "Create an incoming stock transaction for the Item."
 msgstr ""
 
@@ -13360,7 +13346,7 @@ msgstr ""
 msgid "Creating Purchase Order ..."
 msgstr ""
 
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:735
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:737
 #: erpnext/buying/doctype/purchase_order/purchase_order.js:552
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.js:73
 msgid "Creating Purchase Receipt ..."
@@ -13554,7 +13540,7 @@ msgstr ""
 #: erpnext/accounts/doctype/journal_entry_template/journal_entry_template.json
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:174
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:147
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1119
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1121
 #: erpnext/controllers/sales_and_purchase_return.py:373
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:286
 #: erpnext/stock/doctype/delivery_note/delivery_note.js:89
@@ -13589,7 +13575,7 @@ msgstr ""
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py:368
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py:376
-#: erpnext/controllers/accounts_controller.py:2186
+#: erpnext/controllers/accounts_controller.py:2189
 msgid "Credit To"
 msgstr ""
 
@@ -13774,7 +13760,7 @@ msgstr ""
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/subscription_plan/subscription_plan.json
 #: erpnext/accounts/report/account_balance/account_balance.py:28
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1129
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1131
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:205
 #: erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.py:101
 #: erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.js:118
@@ -14303,7 +14289,7 @@ msgstr ""
 #. Label of the customer_contact_display (Small Text) field in DocType
 #. 'Purchase Order'
 #. Label of the customer_contact (Small Text) field in DocType 'Delivery Stop'
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1090
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1092
 #: erpnext/buying/doctype/purchase_order/purchase_order.json
 #: erpnext/stock/doctype/delivery_stop/delivery_stop.json
 msgid "Customer Contact"
@@ -14399,7 +14385,7 @@ msgstr ""
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/tax_rule/tax_rule.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:107
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1147
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1149
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:81
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:185
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:56
@@ -14443,7 +14429,7 @@ msgstr ""
 msgid "Customer Group Name"
 msgstr ""
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1239
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1241
 msgid "Customer Group: {0} does not exist"
 msgstr ""
 
@@ -14462,7 +14448,7 @@ msgstr ""
 msgid "Customer Items"
 msgstr ""
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1138
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1140
 msgid "Customer LPO"
 msgstr ""
 
@@ -14508,7 +14494,7 @@ msgstr ""
 #: erpnext/accounts/doctype/pos_invoice/pos_invoice.json
 #: erpnext/accounts/doctype/process_statement_of_accounts_customer/process_statement_of_accounts_customer.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1080
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1082
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:156
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:92
 #: erpnext/accounts/report/delivered_items_to_be_billed/delivered_items_to_be_billed.py:35
@@ -15186,7 +15172,7 @@ msgstr ""
 #: erpnext/accounts/doctype/journal_entry_template/journal_entry_template.json
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:176
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:147
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1122
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1124
 #: erpnext/controllers/sales_and_purchase_return.py:377
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:287
 #: erpnext/stock/doctype/purchase_receipt/purchase_receipt.js:61
@@ -15215,7 +15201,7 @@ msgstr ""
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:953
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:964
-#: erpnext/controllers/accounts_controller.py:2186
+#: erpnext/controllers/accounts_controller.py:2189
 msgid "Debit To"
 msgstr ""
 
@@ -15248,11 +15234,11 @@ msgstr ""
 msgid "Debit-Credit mismatch"
 msgstr ""
 
-#: erpnext/accounts/party.py:609
+#: erpnext/accounts/party.py:615
 msgid "Debtor/Creditor"
 msgstr ""
 
-#: erpnext/accounts/party.py:612
+#: erpnext/accounts/party.py:618
 msgid "Debtor/Creditor Advance"
 msgstr ""
 
@@ -15372,7 +15358,7 @@ msgstr ""
 msgid "Default BOM"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:418
+#: erpnext/stock/doctype/item/item.py:421
 msgid "Default BOM ({0}) must be active for this item or its template"
 msgstr ""
 
@@ -15380,7 +15366,7 @@ msgstr ""
 msgid "Default BOM for {0} not found"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3672
+#: erpnext/controllers/accounts_controller.py:3675
 msgid "Default BOM not found for FG Item {0}"
 msgstr ""
 
@@ -15715,15 +15701,15 @@ msgstr ""
 msgid "Default Unit of Measure"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1272
+#: erpnext/stock/doctype/item/item.py:1266
 msgid "Default Unit of Measure for Item {0} cannot be changed directly because you have already made some transaction(s) with another UOM. You need to either cancel the linked documents or create a new Item."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1255
+#: erpnext/stock/doctype/item/item.py:1249
 msgid "Default Unit of Measure for Item {0} cannot be changed directly because you have already made some transaction(s) with another UOM. You will need to create a new Item to use a different Default UOM."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:908
+#: erpnext/stock/doctype/item/item.py:902
 msgid "Default Unit of Measure for Variant '{0}' must be same as in Template '{1}'"
 msgstr ""
 
@@ -16182,7 +16168,7 @@ msgstr ""
 msgid "Delivery Note {0} is not submitted"
 msgstr ""
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1142
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1144
 #: erpnext/stock/doctype/delivery_trip/delivery_trip.js:73
 msgid "Delivery Notes"
 msgstr ""
@@ -16713,7 +16699,7 @@ msgstr ""
 #: erpnext/projects/doctype/task_type/task_type.json
 #: erpnext/projects/doctype/timesheet_detail/timesheet_detail.json
 #: erpnext/public/js/bank_reconciliation_tool/data_table_manager.js:55
-#: erpnext/public/js/controllers/transaction.js:2376
+#: erpnext/public/js/controllers/transaction.js:2402
 #: erpnext/selling/doctype/installation_note_item/installation_note_item.json
 #: erpnext/selling/doctype/product_bundle/product_bundle.json
 #: erpnext/selling/doctype/product_bundle_item/product_bundle_item.json
@@ -16901,7 +16887,7 @@ msgstr ""
 msgid "Difference Account must be a Asset/Liability type account (Temporary Opening), since this Stock Entry is an Opening Entry"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:954
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:950
 msgid "Difference Account must be a Asset/Liability type account, since this Stock Reconciliation is an Opening Entry"
 msgstr ""
 
@@ -17167,11 +17153,11 @@ msgstr ""
 msgid "Disabled Warehouse {0} cannot be used for this transaction."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:745
+#: erpnext/controllers/accounts_controller.py:748
 msgid "Disabled pricing rules since this {} is an internal transfer"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:759
+#: erpnext/controllers/accounts_controller.py:762
 msgid "Disabled tax included prices since this {} is an internal transfer"
 msgstr ""
 
@@ -18113,7 +18099,7 @@ msgstr ""
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.json
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/print_format/sales_invoice_print/sales_invoice_print.html:72
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1106
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1108
 #: erpnext/assets/doctype/asset_maintenance_log/asset_maintenance_log.json
 #: erpnext/selling/report/payment_terms_status_for_sales_order/payment_terms_status_for_sales_order.py:40
 msgid "Due Date"
@@ -18127,11 +18113,11 @@ msgstr ""
 msgid "Due Date Based On"
 msgstr ""
 
-#: erpnext/accounts/party.py:695
+#: erpnext/accounts/party.py:701
 msgid "Due Date cannot be after {0}"
 msgstr ""
 
-#: erpnext/accounts/party.py:671
+#: erpnext/accounts/party.py:677
 msgid "Due Date cannot be before {0}"
 msgstr ""
 
@@ -18849,7 +18835,7 @@ msgstr ""
 msgid "Enable Auto Email"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1064
+#: erpnext/stock/doctype/item/item.py:1058
 msgid "Enable Auto Re-Order"
 msgstr ""
 
@@ -19062,7 +19048,7 @@ msgstr ""
 msgid "End Date"
 msgstr ""
 
-#: erpnext/crm/doctype/contract/contract.py:75
+#: erpnext/crm/doctype/contract/contract.py:83
 msgid "End Date cannot be before Start Date."
 msgstr ""
 
@@ -19312,7 +19298,7 @@ msgstr ""
 #: erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.json
 #: erpnext/manufacturing/doctype/job_card/job_card.py:875
 #: erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.json
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:297
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:298
 msgid "Error"
 msgstr ""
 
@@ -19435,7 +19421,7 @@ msgstr ""
 msgid "Example URL"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:995
+#: erpnext/stock/doctype/item/item.py:989
 msgid "Example of a linked document: {0}"
 msgstr ""
 
@@ -19450,7 +19436,7 @@ msgstr ""
 msgid "Example: ABCD.#####. If series is set and Batch No is not mentioned in transactions, then automatic batch number will be created based on this series. If you always want to explicitly mention Batch No for this item, leave this blank. Note: this setting will take priority over the Naming Series Prefix in Stock Settings."
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:2141
+#: erpnext/stock/stock_ledger.py:2149
 msgid "Example: Serial No {0} reserved in {1}."
 msgstr ""
 
@@ -19504,8 +19490,8 @@ msgstr ""
 msgid "Exchange Gain/Loss"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1593
-#: erpnext/controllers/accounts_controller.py:1677
+#: erpnext/controllers/accounts_controller.py:1596
+#: erpnext/controllers/accounts_controller.py:1680
 msgid "Exchange Gain/Loss amount has been booked through {0}"
 msgstr ""
 
@@ -20241,7 +20227,7 @@ msgid "Fetching Error"
 msgstr ""
 
 #: erpnext/accounts/doctype/dunning/dunning.js:135
-#: erpnext/public/js/controllers/transaction.js:1251
+#: erpnext/public/js/controllers/transaction.js:1277
 msgid "Fetching exchange rates ..."
 msgstr ""
 
@@ -20536,15 +20522,15 @@ msgstr ""
 msgid "Finished Good Item Quantity"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3658
+#: erpnext/controllers/accounts_controller.py:3661
 msgid "Finished Good Item is not specified for service item {0}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3675
+#: erpnext/controllers/accounts_controller.py:3678
 msgid "Finished Good Item {0} Qty can not be zero"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3669
+#: erpnext/controllers/accounts_controller.py:3672
 msgid "Finished Good Item {0} must be a sub-contracted item"
 msgstr ""
 
@@ -20785,7 +20771,7 @@ msgstr ""
 msgid "Fixed Asset Defaults"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:301
+#: erpnext/stock/doctype/item/item.py:304
 msgid "Fixed Asset Item must be a non-stock item."
 msgstr ""
 
@@ -20961,7 +20947,7 @@ msgstr ""
 msgid "For Raw Materials"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1259
+#: erpnext/controllers/accounts_controller.py:1262
 msgid "For Return Invoices with Stock effect, '0' qty Items are not allowed. Following rows are affected: {0}"
 msgstr ""
 
@@ -21062,7 +21048,7 @@ msgstr ""
 msgid "For the item {0}, the quantity should be {1} according to the BOM {2}."
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:1088
+#: erpnext/public/js/controllers/transaction.js:1114
 msgctxt "Clear payment terms template and/or payment schedule when due date is changed"
 msgid "For the new {0} to take effect, would you like to clear the current {1}?"
 msgstr ""
@@ -21071,7 +21057,7 @@ msgstr ""
 msgid "For the {0}, no stock is available for the return in the warehouse {1}."
 msgstr ""
 
-#: erpnext/controllers/sales_and_purchase_return.py:1144
+#: erpnext/controllers/sales_and_purchase_return.py:1049
 msgid "For the {0}, the quantity is required to make the return entry"
 msgstr ""
 
@@ -21408,7 +21394,7 @@ msgstr ""
 msgid "From Date is mandatory"
 msgstr ""
 
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:52
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:53
 #: erpnext/accounts/report/general_ledger/general_ledger.py:86
 #: erpnext/accounts/report/pos_register/pos_register.py:115
 #: erpnext/accounts/report/tax_withholding_details/tax_withholding_details.py:39
@@ -21785,14 +21771,14 @@ msgstr ""
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:186
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:155
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1134
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1136
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:177
 msgid "Future Payment Amount"
 msgstr ""
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:185
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:154
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1133
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1135
 msgid "Future Payment Ref"
 msgstr ""
 
@@ -22966,7 +22952,7 @@ msgstr ""
 msgid "Here are the error logs for the aforementioned failed depreciation entries: {0}"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1862
+#: erpnext/stock/stock_ledger.py:1871
 msgid "Here are the options to proceed:"
 msgstr ""
 
@@ -23488,7 +23474,7 @@ msgstr ""
 msgid "If more than one package of the same type (for print)"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1872
+#: erpnext/stock/stock_ledger.py:1881
 msgid "If not, you can Cancel / Submit this entry"
 msgstr ""
 
@@ -23513,7 +23499,7 @@ msgstr ""
 msgid "If the account is frozen, entries are allowed to restricted users."
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1865
+#: erpnext/stock/stock_ledger.py:1874
 msgid "If the item is transacting as a Zero Valuation Rate item in this entry, please enable 'Allow Zero Valuation Rate' in the {0} Item table."
 msgstr ""
 
@@ -24511,7 +24497,7 @@ msgstr ""
 msgid "Incorrect Batch Consumed"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:514
+#: erpnext/stock/doctype/item/item.py:517
 msgid "Incorrect Check in (group) Warehouse for Reorder"
 msgstr ""
 
@@ -24560,7 +24546,7 @@ msgstr ""
 msgid "Incorrect Stock Value Report"
 msgstr ""
 
-#: erpnext/stock/serial_batch_bundle.py:134
+#: erpnext/stock/serial_batch_bundle.py:135
 msgid "Incorrect Type of Transaction"
 msgstr ""
 
@@ -24829,8 +24815,8 @@ msgstr ""
 msgid "Insufficient Capacity"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3590
-#: erpnext/controllers/accounts_controller.py:3614
+#: erpnext/controllers/accounts_controller.py:3593
+#: erpnext/controllers/accounts_controller.py:3617
 msgid "Insufficient Permissions"
 msgstr ""
 
@@ -24838,12 +24824,12 @@ msgstr ""
 #: erpnext/stock/doctype/pick_list/pick_list.py:127
 #: erpnext/stock/doctype/pick_list/pick_list.py:975
 #: erpnext/stock/doctype/stock_entry/stock_entry.py:759
-#: erpnext/stock/serial_batch_bundle.py:989 erpnext/stock/stock_ledger.py:1559
-#: erpnext/stock/stock_ledger.py:2032
+#: erpnext/stock/serial_batch_bundle.py:1021 erpnext/stock/stock_ledger.py:1568
+#: erpnext/stock/stock_ledger.py:2040
 msgid "Insufficient Stock"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:2047
+#: erpnext/stock/stock_ledger.py:2055
 msgid "Insufficient Stock for Batch"
 msgstr ""
 
@@ -24981,11 +24967,11 @@ msgstr ""
 msgid "Internal Customer for company {0} already exists"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:728
+#: erpnext/controllers/accounts_controller.py:731
 msgid "Internal Sale or Delivery Reference missing."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:730
+#: erpnext/controllers/accounts_controller.py:733
 msgid "Internal Sales Reference Missing"
 msgstr ""
 
@@ -25016,7 +25002,7 @@ msgstr ""
 msgid "Internal Transfer"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:739
+#: erpnext/controllers/accounts_controller.py:742
 msgid "Internal Transfer Reference Missing"
 msgstr ""
 
@@ -25059,8 +25045,8 @@ msgstr ""
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:969
 #: erpnext/assets/doctype/asset_category/asset_category.py:69
 #: erpnext/assets/doctype/asset_category/asset_category.py:97
-#: erpnext/controllers/accounts_controller.py:2975
-#: erpnext/controllers/accounts_controller.py:2983
+#: erpnext/controllers/accounts_controller.py:2978
+#: erpnext/controllers/accounts_controller.py:2986
 msgid "Invalid Account"
 msgstr ""
 
@@ -25085,7 +25071,7 @@ msgstr ""
 msgid "Invalid Barcode. There is no Item attached to this barcode."
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2631
+#: erpnext/public/js/controllers/transaction.js:2657
 msgid "Invalid Blanket Order for the selected Customer and Item"
 msgstr ""
 
@@ -25099,7 +25085,7 @@ msgstr ""
 
 #: erpnext/assets/doctype/asset/asset.py:295
 #: erpnext/assets/doctype/asset/asset.py:302
-#: erpnext/controllers/accounts_controller.py:2998
+#: erpnext/controllers/accounts_controller.py:3001
 msgid "Invalid Cost Center"
 msgstr ""
 
@@ -25141,7 +25127,7 @@ msgstr ""
 msgid "Invalid Item"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1410
+#: erpnext/stock/doctype/item/item.py:1404
 msgid "Invalid Item Defaults"
 msgstr ""
 
@@ -25187,11 +25173,11 @@ msgstr ""
 msgid "Invalid Purchase Invoice"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3627
+#: erpnext/controllers/accounts_controller.py:3630
 msgid "Invalid Qty"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1277
+#: erpnext/controllers/accounts_controller.py:1280
 msgid "Invalid Quantity"
 msgstr ""
 
@@ -25208,7 +25194,7 @@ msgstr ""
 msgid "Invalid Schedule"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:243
+#: erpnext/controllers/selling_controller.py:251
 msgid "Invalid Selling Price"
 msgstr ""
 
@@ -25241,7 +25227,7 @@ msgstr ""
 msgid "Invalid lost reason {0}, please create a new lost reason"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:408
+#: erpnext/stock/doctype/item/item.py:411
 msgid "Invalid naming series (. missing) for {0}"
 msgstr ""
 
@@ -25281,7 +25267,7 @@ msgstr ""
 #. Name of a DocType
 #: erpnext/patches/v15_0/refactor_closing_stock_balance.py:43
 #: erpnext/stock/doctype/inventory_dimension/inventory_dimension.json
-#: erpnext/stock/doctype/inventory_dimension/inventory_dimension.py:180
+#: erpnext/stock/doctype/inventory_dimension/inventory_dimension.py:181
 msgid "Inventory Dimension"
 msgstr ""
 
@@ -25347,7 +25333,7 @@ msgstr ""
 msgid "Invoice Discounting"
 msgstr ""
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1114
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1116
 msgid "Invoice Grand Total"
 msgstr ""
 
@@ -25440,7 +25426,7 @@ msgstr ""
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:169
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:144
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1116
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1118
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:164
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:165
 msgid "Invoiced Amount"
@@ -25846,6 +25832,11 @@ msgstr ""
 msgid "Is Outward"
 msgstr ""
 
+#. Label of the is_packed (Check) field in DocType 'Serial and Batch Bundle'
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.json
+msgid "Is Packed"
+msgstr ""
+
 #. Label of the is_paid (Check) field in DocType 'Purchase Invoice'
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 msgid "Is Paid"
@@ -26128,11 +26119,11 @@ msgstr ""
 msgid "Issuing cannot be done to a location. Please enter employee to issue the Asset {0} to"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:565
+#: erpnext/stock/doctype/item/item.py:571
 msgid "It can take upto few hours for accurate stock values to be visible after merging items."
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2075
+#: erpnext/public/js/controllers/transaction.js:2101
 msgid "It is needed to fetch Item Details."
 msgstr ""
 
@@ -26182,7 +26173,7 @@ msgstr ""
 #: erpnext/buying/report/supplier_quotation_comparison/supplier_quotation_comparison.js:33
 #: erpnext/buying/report/supplier_quotation_comparison/supplier_quotation_comparison.py:204
 #: erpnext/buying/workspace/buying/buying.json
-#: erpnext/controllers/taxes_and_totals.py:1125
+#: erpnext/controllers/taxes_and_totals.py:1135
 #: erpnext/manufacturing/doctype/blanket_order/blanket_order.json
 #: erpnext/manufacturing/doctype/bom/bom.js:944
 #: erpnext/manufacturing/doctype/bom/bom.json
@@ -26460,7 +26451,7 @@ msgstr ""
 #: erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py:86
 #: erpnext/manufacturing/report/work_order_stock_report/work_order_stock_report.py:119
 #: erpnext/projects/doctype/timesheet/timesheet.js:213
-#: erpnext/public/js/controllers/transaction.js:2350
+#: erpnext/public/js/controllers/transaction.js:2376
 #: erpnext/public/js/stock_reservation.js:112
 #: erpnext/public/js/stock_reservation.js:317 erpnext/public/js/utils.js:500
 #: erpnext/public/js/utils.js:656
@@ -26898,7 +26889,7 @@ msgstr ""
 #: erpnext/manufacturing/report/production_planning_report/production_planning_report.py:359
 #: erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py:92
 #: erpnext/manufacturing/report/work_order_consumed_materials/work_order_consumed_materials.py:138
-#: erpnext/public/js/controllers/transaction.js:2356
+#: erpnext/public/js/controllers/transaction.js:2382
 #: erpnext/public/js/utils.js:746
 #: erpnext/selling/doctype/quotation_item/quotation_item.json
 #: erpnext/selling/doctype/sales_order_item/sales_order_item.json
@@ -27165,7 +27156,7 @@ msgstr ""
 msgid "Item Variant {0} already exists with same attributes"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:781
+#: erpnext/stock/doctype/item/item.py:772
 msgid "Item Variants updated"
 msgstr ""
 
@@ -27231,7 +27222,7 @@ msgstr ""
 msgid "Item for row {0} does not match Material Request"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:795
+#: erpnext/stock/doctype/item/item.py:789
 msgid "Item has variants."
 msgstr ""
 
@@ -27257,7 +27248,7 @@ msgstr ""
 msgid "Item operation"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3650
+#: erpnext/controllers/accounts_controller.py:3653
 msgid "Item qty can not be updated as raw materials are already processed."
 msgstr ""
 
@@ -27283,7 +27274,7 @@ msgstr ""
 msgid "Item valuation reposting in progress. Report might show incorrect item valuation."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:952
+#: erpnext/stock/doctype/item/item.py:946
 msgid "Item variant {0} exists with same attributes"
 msgstr ""
 
@@ -27296,8 +27287,7 @@ msgid "Item {0} cannot be ordered more than {1} against Blanket Order {2}."
 msgstr ""
 
 #: erpnext/assets/doctype/asset/asset.py:277
-#: erpnext/stock/doctype/item/item.py:630
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:167
+#: erpnext/stock/doctype/item/item.py:636
 msgid "Item {0} does not exist"
 msgstr ""
 
@@ -27309,7 +27299,7 @@ msgstr ""
 msgid "Item {0} does not exist."
 msgstr "Tétel: {0}, nem létezik."
 
-#: erpnext/controllers/selling_controller.py:752
+#: erpnext/controllers/selling_controller.py:760
 msgid "Item {0} entered multiple times."
 msgstr ""
 
@@ -27325,7 +27315,7 @@ msgstr ""
 msgid "Item {0} has no Serial No. Only serialized items can have delivery based on Serial No"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1126
+#: erpnext/stock/doctype/item/item.py:1120
 msgid "Item {0} has reached its end of life on {1}"
 msgstr ""
 
@@ -27337,11 +27327,11 @@ msgstr ""
 msgid "Item {0} is already reserved/delivered against Sales Order {1}."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1146
+#: erpnext/stock/doctype/item/item.py:1140
 msgid "Item {0} is cancelled"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1130
+#: erpnext/stock/doctype/item/item.py:1124
 msgid "Item {0} is disabled"
 msgstr ""
 
@@ -27349,7 +27339,7 @@ msgstr ""
 msgid "Item {0} is not a serialized Item"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1138
+#: erpnext/stock/doctype/item/item.py:1132
 msgid "Item {0} is not a stock Item"
 msgstr ""
 
@@ -27393,7 +27383,7 @@ msgstr ""
 msgid "Item {0}: {1} qty produced. "
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1429
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1423
 msgid "Item {} does not exist."
 msgstr ""
 
@@ -27533,7 +27523,7 @@ msgstr ""
 msgid "Items and Pricing"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3872
+#: erpnext/controllers/accounts_controller.py:3875
 msgid "Items cannot be updated as Subcontracting Order is created against the Purchase Order {0}."
 msgstr ""
 
@@ -28029,7 +28019,7 @@ msgstr ""
 
 #. Name of a DocType
 #. Label of a Link in the Stock Workspace
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:674
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:676
 #: erpnext/stock/doctype/landed_cost_voucher/landed_cost_voucher.json
 #: erpnext/stock/doctype/purchase_receipt/purchase_receipt.js:104
 #: erpnext/stock/workspace/stock/stock.json
@@ -28644,7 +28634,7 @@ msgstr ""
 msgid "Linked Location"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:999
+#: erpnext/stock/doctype/item/item.py:993
 msgid "Linked with submitted documents"
 msgstr ""
 
@@ -29383,7 +29373,7 @@ msgstr ""
 #: erpnext/manufacturing/doctype/bom/bom.py:261
 #: erpnext/manufacturing/doctype/bom_update_log/bom_update_log.py:71
 #: erpnext/public/js/controllers/accounts.js:249
-#: erpnext/public/js/controllers/transaction.js:2753
+#: erpnext/public/js/controllers/transaction.js:2779
 #: erpnext/public/js/utils/party.js:321
 #: erpnext/stock/doctype/delivery_note/delivery_note.js:164
 #: erpnext/stock/doctype/inventory_dimension/inventory_dimension.json
@@ -30239,7 +30229,7 @@ msgstr ""
 msgid "Maximum Value"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:212
+#: erpnext/controllers/selling_controller.py:220
 msgid "Maximum discount for Item {0} is {1}%"
 msgstr ""
 
@@ -30309,7 +30299,7 @@ msgstr ""
 msgid "Megawatt"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1878
+#: erpnext/stock/stock_ledger.py:1887
 msgid "Mention Valuation Rate in the Item master."
 msgstr ""
 
@@ -30704,11 +30694,11 @@ msgstr ""
 msgid "Miscellaneous Expenses"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:540
+#: erpnext/controllers/buying_controller.py:548
 msgid "Mismatch"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1430
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1424
 msgid "Missing"
 msgstr ""
 
@@ -31235,7 +31225,7 @@ msgstr ""
 msgid "Multiple Warehouse Accounts"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1129
+#: erpnext/controllers/accounts_controller.py:1132
 msgid "Multiple fiscal years exist for the date {0}. Please set company in Fiscal Year"
 msgstr ""
 
@@ -31386,7 +31376,7 @@ msgstr ""
 msgid "Naming Series and Price Defaults"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:90
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:91
 msgid "Naming Series is mandatory"
 msgstr ""
 
@@ -31425,15 +31415,15 @@ msgstr ""
 msgid "Needs Analysis"
 msgstr ""
 
-#: erpnext/stock/serial_batch_bundle.py:1277
+#: erpnext/stock/serial_batch_bundle.py:1309
 msgid "Negative Batch Quantity"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:610
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:606
 msgid "Negative Quantity is not allowed"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:615
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:611
 msgid "Negative Valuation Rate is not allowed"
 msgstr ""
 
@@ -31715,7 +31705,7 @@ msgstr ""
 msgid "Net Weight UOM"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1483
+#: erpnext/controllers/accounts_controller.py:1486
 msgid "Net total calculation precision loss"
 msgstr ""
 
@@ -32058,7 +32048,7 @@ msgstr ""
 #: erpnext/accounts/doctype/journal_entry/journal_entry.py:1539
 #: erpnext/accounts/doctype/journal_entry/journal_entry.py:1599
 #: erpnext/accounts/doctype/journal_entry/journal_entry.py:1613
-#: erpnext/stock/doctype/item/item.py:1371
+#: erpnext/stock/doctype/item/item.py:1365
 msgid "No Permission"
 msgstr ""
 
@@ -32080,7 +32070,7 @@ msgstr ""
 msgid "No Selection"
 msgstr ""
 
-#: erpnext/controllers/sales_and_purchase_return.py:919
+#: erpnext/controllers/sales_and_purchase_return.py:824
 msgid "No Serial / Batches are available for return"
 msgstr ""
 
@@ -32116,7 +32106,7 @@ msgstr ""
 msgid "No Work Orders were created"
 msgstr ""
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:785
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:794
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py:689
 msgid "No accounting entries for the following warehouses"
 msgstr ""
@@ -32305,7 +32295,7 @@ msgstr ""
 msgid "No reserved stock to unreserve."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:773
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:769
 msgid "No stock ledger entries were created. Please set the quantity or valuation rate for the items properly and try again."
 msgstr ""
 
@@ -32389,7 +32379,7 @@ msgstr ""
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:566
 #: erpnext/assets/doctype/asset/asset.js:612
 #: erpnext/assets/doctype/asset/asset.js:627
-#: erpnext/controllers/buying_controller.py:225
+#: erpnext/controllers/buying_controller.py:233
 #: erpnext/selling/doctype/product_bundle/product_bundle.py:72
 #: erpnext/setup/doctype/transaction_deletion_record/transaction_deletion_record.py:80
 msgid "Not Allowed"
@@ -32510,10 +32500,10 @@ msgstr ""
 #: erpnext/selling/doctype/customer/customer.py:129
 #: erpnext/selling/doctype/sales_order/sales_order.js:1168
 #: erpnext/stock/doctype/item/item.js:526
-#: erpnext/stock/doctype/item/item.py:567
+#: erpnext/stock/doctype/item/item.py:573
 #: erpnext/stock/doctype/item_price/item_price.json
 #: erpnext/stock/doctype/stock_entry/stock_entry.py:1374
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:972
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:968
 #: erpnext/templates/pages/timelog_info.html:43
 msgid "Note"
 msgstr ""
@@ -32522,7 +32512,7 @@ msgstr ""
 msgid "Note: Automatic log deletion only applies to logs of type <i>Update Cost</i>"
 msgstr ""
 
-#: erpnext/accounts/party.py:690
+#: erpnext/accounts/party.py:696
 msgid "Note: Due Date exceeds allowed {0} credit days by {1} day(s)"
 msgstr ""
 
@@ -32548,7 +32538,7 @@ msgstr ""
 msgid "Note: This Cost Center is a Group. Cannot make accounting entries against groups."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:621
+#: erpnext/stock/doctype/item/item.py:627
 msgid "Note: To merge the items, create a separate Stock Reconciliation for the old item {0}"
 msgstr ""
 
@@ -33311,7 +33301,7 @@ msgstr ""
 
 #. Label of the opening_stock (Float) field in DocType 'Item'
 #. Option for the 'Purpose' (Select) field in DocType 'Stock Reconciliation'
-#: erpnext/stock/doctype/item/item.json erpnext/stock/doctype/item/item.py:296
+#: erpnext/stock/doctype/item/item.json erpnext/stock/doctype/item/item.py:299
 #: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.json
 msgid "Opening Stock"
 msgstr ""
@@ -34031,7 +34021,7 @@ msgstr ""
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:149
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1123
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1125
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:167
 #: erpnext/accounts/report/purchase_register/purchase_register.py:289
 #: erpnext/accounts/report/sales_register/sales_register.py:319
@@ -34070,7 +34060,7 @@ msgstr ""
 msgid "Over Billing Allowance (%)"
 msgstr ""
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:1242
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:1251
 msgid "Over Billing Allowance exceeded for Purchase Receipt Item {0} ({1}) by {2}%"
 msgstr ""
 
@@ -34111,7 +34101,7 @@ msgstr ""
 msgid "Overbilling of {0} {1} ignored for item {2} because you have {3} role."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2013
+#: erpnext/controllers/accounts_controller.py:2016
 msgid "Overbilling of {} ignored because you have {} role."
 msgstr ""
 
@@ -34618,7 +34608,7 @@ msgstr ""
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:146
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1117
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1119
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:165
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:172
 #: erpnext/accounts/report/pos_register/pos_register.py:209
@@ -34851,7 +34841,7 @@ msgstr ""
 msgid "Parent Row No"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom_creator/bom_creator.py:495
+#: erpnext/manufacturing/doctype/bom_creator/bom_creator.py:496
 msgid "Parent Row No not found for {0}"
 msgstr ""
 
@@ -35080,7 +35070,7 @@ msgstr ""
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:142
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:159
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:57
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1054
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1056
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:67
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:147
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:228
@@ -35106,7 +35096,7 @@ msgstr ""
 
 #. Name of a DocType
 #: erpnext/accounts/doctype/party_account/party_account.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1065
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1067
 msgid "Party Account"
 msgstr ""
 
@@ -35133,7 +35123,7 @@ msgstr ""
 msgid "Party Account No. (Bank Statement)"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2278
+#: erpnext/controllers/accounts_controller.py:2281
 msgid "Party Account {0} currency ({1}) and document currency ({2}) should be same"
 msgstr ""
 
@@ -35149,6 +35139,11 @@ msgstr ""
 #: erpnext/accounts/doctype/bank_account/bank_account.json
 #: erpnext/accounts/doctype/payment_request/payment_request.json
 msgid "Party Details"
+msgstr ""
+
+#. Label of the party_full_name (Data) field in DocType 'Contract'
+#: erpnext/crm/doctype/contract/contract.json
+msgid "Party Full Name"
 msgstr ""
 
 #. Label of the bank_party_iban (Data) field in DocType 'Bank Transaction'
@@ -35234,7 +35229,7 @@ msgstr ""
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:84
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:54
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:44
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1048
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1050
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:54
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:141
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:219
@@ -35256,7 +35251,7 @@ msgstr ""
 msgid "Party Type"
 msgstr ""
 
-#: erpnext/accounts/party.py:819
+#: erpnext/accounts/party.py:825
 msgid "Party Type and Party can only be set for Receivable / Payable account<br><br>{0}"
 msgstr ""
 
@@ -35378,7 +35373,7 @@ msgid "Payable"
 msgstr ""
 
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:42
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1063
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1065
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:211
 #: erpnext/accounts/report/purchase_register/purchase_register.py:194
 #: erpnext/accounts/report/purchase_register/purchase_register.py:235
@@ -35544,7 +35539,7 @@ msgstr ""
 msgid "Payment Entry is already created"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1434
+#: erpnext/controllers/accounts_controller.py:1437
 msgid "Payment Entry {0} is linked against Order {1}, check if it should be pulled as advance in this invoice."
 msgstr ""
 
@@ -35826,7 +35821,7 @@ msgstr ""
 #: erpnext/accounts/doctype/payment_schedule/payment_schedule.json
 #: erpnext/accounts/doctype/payment_term/payment_term.json
 #: erpnext/accounts/doctype/payment_terms_template_detail/payment_terms_template_detail.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1113
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1115
 #: erpnext/accounts/report/gross_profit/gross_profit.py:412
 #: erpnext/accounts/workspace/accounting/accounting.json
 #: erpnext/selling/report/payment_terms_status_for_sales_order/payment_terms_status_for_sales_order.py:30
@@ -36890,7 +36885,7 @@ msgstr ""
 msgid "Please create a new Accounting Dimension if required."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:729
+#: erpnext/controllers/accounts_controller.py:732
 msgid "Please create purchase from internal sale or delivery document itself"
 msgstr ""
 
@@ -36898,7 +36893,7 @@ msgstr ""
 msgid "Please create purchase receipt or purchase invoice for the item {0}"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:649
+#: erpnext/stock/doctype/item/item.py:655
 msgid "Please delete Product Bundle {0}, before merging {1} into {2}"
 msgstr ""
 
@@ -36940,7 +36935,7 @@ msgstr ""
 msgid "Please enable {0} in the {1}."
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:754
+#: erpnext/controllers/selling_controller.py:762
 msgid "Please enable {} in {} to allow same item in multiple rows"
 msgstr ""
 
@@ -36973,7 +36968,7 @@ msgstr ""
 msgid "Please enter Approving Role or Approving User"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:939
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:935
 msgid "Please enter Cost Center"
 msgstr ""
 
@@ -36985,7 +36980,7 @@ msgstr ""
 msgid "Please enter Employee Id of this sales person"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:948
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:944
 msgid "Please enter Expense Account"
 msgstr ""
 
@@ -36994,7 +36989,7 @@ msgstr ""
 msgid "Please enter Item Code to get Batch Number"
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2503
+#: erpnext/public/js/controllers/transaction.js:2529
 msgid "Please enter Item Code to get batch no"
 msgstr ""
 
@@ -37059,7 +37054,7 @@ msgstr ""
 msgid "Please enter company name first"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2764
+#: erpnext/controllers/accounts_controller.py:2767
 msgid "Please enter default currency in Company Master"
 msgstr ""
 
@@ -37095,7 +37090,7 @@ msgstr ""
 msgid "Please enter the phone number first"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:1007
+#: erpnext/controllers/buying_controller.py:1015
 msgid "Please enter the {schedule_date}."
 msgstr ""
 
@@ -37197,7 +37192,7 @@ msgstr ""
 msgid "Please select <b>Template Type</b> to download template"
 msgstr ""
 
-#: erpnext/controllers/taxes_and_totals.py:721
+#: erpnext/controllers/taxes_and_totals.py:731
 #: erpnext/public/js/controllers/taxes_and_totals.js:721
 msgid "Please select Apply Discount On"
 msgstr ""
@@ -37210,7 +37205,7 @@ msgstr ""
 msgid "Please select BOM for Item in Row {0}"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:467
+#: erpnext/controllers/buying_controller.py:475
 msgid "Please select BOM in BOM field for Item {item_code}."
 msgstr "Kérjük, válasszon ANYGJZ az ANYGJZ mezőben erre a tételre {item_code}."
 
@@ -37292,7 +37287,7 @@ msgstr ""
 msgid "Please select Qty against item {0}"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:320
+#: erpnext/stock/doctype/item/item.py:323
 msgid "Please select Sample Retention Warehouse in Stock Settings first"
 msgstr ""
 
@@ -37308,7 +37303,7 @@ msgstr ""
 msgid "Please select Subcontracting Order instead of Purchase Order {0}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2613
+#: erpnext/controllers/accounts_controller.py:2616
 msgid "Please select Unrealized Profit / Loss account or add default Unrealized Profit / Loss account account for company {0}"
 msgstr ""
 
@@ -37324,7 +37319,7 @@ msgstr ""
 #: erpnext/manufacturing/doctype/bom/bom.js:603
 #: erpnext/manufacturing/doctype/bom/bom.py:261
 #: erpnext/public/js/controllers/accounts.js:249
-#: erpnext/public/js/controllers/transaction.js:2753
+#: erpnext/public/js/controllers/transaction.js:2779
 msgid "Please select a Company first."
 msgstr ""
 
@@ -37482,7 +37477,7 @@ msgstr ""
 msgid "Please select {0} first"
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:77
+#: erpnext/public/js/controllers/transaction.js:100
 msgid "Please set 'Apply Additional Discount On'"
 msgstr ""
 
@@ -37667,7 +37662,7 @@ msgstr ""
 msgid "Please set filters"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2194
+#: erpnext/controllers/accounts_controller.py:2197
 msgid "Please set one of the following:"
 msgstr ""
 
@@ -37675,7 +37670,7 @@ msgstr ""
 msgid "Please set opening number of booked depreciations"
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2205
+#: erpnext/public/js/controllers/transaction.js:2231
 msgid "Please set recurring after saving"
 msgstr ""
 
@@ -37746,7 +37741,7 @@ msgstr ""
 msgid "Please share this email with your support team so that they can find and fix the issue."
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2073
+#: erpnext/public/js/controllers/transaction.js:2099
 msgid "Please specify"
 msgstr ""
 
@@ -37761,7 +37756,7 @@ msgid "Please specify Company to proceed"
 msgstr ""
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1472
-#: erpnext/controllers/accounts_controller.py:2957
+#: erpnext/controllers/accounts_controller.py:2960
 #: erpnext/public/js/controllers/accounts.js:97
 msgid "Please specify a valid Row ID for row {0} in table {1}"
 msgstr ""
@@ -37774,7 +37769,7 @@ msgstr ""
 msgid "Please specify at least one attribute in the Attributes table"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:605
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:601
 msgid "Please specify either Quantity or Valuation Rate or both"
 msgstr ""
 
@@ -37955,7 +37950,7 @@ msgstr ""
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:16
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:15
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:18
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1046
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1048
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:15
 #: erpnext/accounts/report/bank_clearance_summary/bank_clearance_summary.py:35
 #: erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.html:7
@@ -40136,7 +40131,7 @@ msgstr ""
 #: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.js:48
 #: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:203
 #: erpnext/buying/workspace/buying/buying.json
-#: erpnext/controllers/buying_controller.py:739
+#: erpnext/controllers/buying_controller.py:747
 #: erpnext/crm/doctype/contract/contract.json
 #: erpnext/manufacturing/doctype/blanket_order/blanket_order.js:54
 #: erpnext/manufacturing/doctype/production_plan_sub_assembly_item/production_plan_sub_assembly_item.json
@@ -40275,7 +40270,7 @@ msgstr ""
 msgid "Purchase Orders to Receive"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1833
+#: erpnext/controllers/accounts_controller.py:1836
 msgid "Purchase Orders {0} are un-linked"
 msgstr ""
 
@@ -40299,8 +40294,8 @@ msgstr ""
 #. Label of a Link in the Stock Workspace
 #. Label of a shortcut in the Stock Workspace
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:171
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:650
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:660
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:652
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:662
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice_list.js:49
 #: erpnext/accounts/doctype/purchase_invoice_item/purchase_invoice_item.json
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:246
@@ -41035,7 +41030,7 @@ msgstr ""
 msgid "Quality Inspection Template Name"
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:334
+#: erpnext/public/js/controllers/transaction.js:360
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:165
 msgid "Quality Inspection(s)"
 msgstr ""
@@ -42219,7 +42214,7 @@ msgid "Receivable / Payable Account"
 msgstr ""
 
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:71
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1061
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1063
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py:243
 #: erpnext/accounts/report/sales_register/sales_register.py:217
 #: erpnext/accounts/report/sales_register/sales_register.py:271
@@ -42701,7 +42696,7 @@ msgstr ""
 msgid "Reference Date"
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2311
+#: erpnext/public/js/controllers/transaction.js:2337
 msgid "Reference Date for Early Payment Discount"
 msgstr ""
 
@@ -43025,7 +43020,7 @@ msgstr ""
 msgid "Rejected"
 msgstr ""
 
-#: erpnext/stock/doctype/inventory_dimension/inventory_dimension.py:202
+#: erpnext/stock/doctype/inventory_dimension/inventory_dimension.py:203
 msgid "Rejected "
 msgstr "Elutasítva "
 
@@ -43129,7 +43124,7 @@ msgstr ""
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:187
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:156
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1135
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1137
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:178
 msgid "Remaining Balance"
 msgstr ""
@@ -43182,7 +43177,7 @@ msgstr ""
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:159
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:198
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:269
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1167
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1169
 #: erpnext/accounts/report/general_ledger/general_ledger.html:84
 #: erpnext/accounts/report/general_ledger/general_ledger.html:110
 #: erpnext/accounts/report/general_ledger/general_ledger.py:742
@@ -43931,7 +43926,7 @@ msgstr ""
 msgid "Reserved Quantity for Production"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:2147
+#: erpnext/stock/stock_ledger.py:2155
 msgid "Reserved Serial No."
 msgstr ""
 
@@ -43947,11 +43942,11 @@ msgstr ""
 #: erpnext/stock/doctype/pick_list/pick_list.js:153
 #: erpnext/stock/report/reserved_stock/reserved_stock.json
 #: erpnext/stock/report/stock_balance/stock_balance.py:499
-#: erpnext/stock/stock_ledger.py:2131
+#: erpnext/stock/stock_ledger.py:2139
 msgid "Reserved Stock"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:2177
+#: erpnext/stock/stock_ledger.py:2185
 msgid "Reserved Stock for Batch"
 msgstr ""
 
@@ -43963,7 +43958,7 @@ msgstr ""
 msgid "Reserved Stock for Sub-assembly"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:476
+#: erpnext/controllers/buying_controller.py:484
 msgid "Reserved Warehouse is mandatory for the Item {item_code} in Raw Materials supplied."
 msgstr ""
 
@@ -44777,7 +44772,7 @@ msgstr ""
 msgid "Routing Name"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:667
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:663
 msgid "Row #"
 msgstr ""
 
@@ -44815,7 +44810,7 @@ msgstr ""
 msgid "Row #{0} (Payment Table): Amount must be positive"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:495
+#: erpnext/stock/doctype/item/item.py:498
 msgid "Row #{0}: A reorder entry already exists for warehouse {1} with reorder type {2}."
 msgstr ""
 
@@ -44836,7 +44831,7 @@ msgstr ""
 msgid "Row #{0}: Accepted Warehouse is mandatory for the accepted Item {1}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1117
+#: erpnext/controllers/accounts_controller.py:1120
 msgid "Row #{0}: Account {1} does not belong to company {2}"
 msgstr ""
 
@@ -44877,27 +44872,27 @@ msgstr ""
 msgid "Row #{0}: Cannot allocate more than {1} against payment term {2}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3524
+#: erpnext/controllers/accounts_controller.py:3527
 msgid "Row #{0}: Cannot delete item {1} which has already been billed."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3498
+#: erpnext/controllers/accounts_controller.py:3501
 msgid "Row #{0}: Cannot delete item {1} which has already been delivered"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3517
+#: erpnext/controllers/accounts_controller.py:3520
 msgid "Row #{0}: Cannot delete item {1} which has already been received"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3504
+#: erpnext/controllers/accounts_controller.py:3507
 msgid "Row #{0}: Cannot delete item {1} which has work order assigned to it."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3510
+#: erpnext/controllers/accounts_controller.py:3513
 msgid "Row #{0}: Cannot delete item {1} which is assigned to customer's purchase order."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3765
+#: erpnext/controllers/accounts_controller.py:3768
 msgid "Row #{0}: Cannot set Rate if the billed amount is greater than the amount for Item {1}."
 msgstr ""
 
@@ -45017,7 +45012,7 @@ msgstr ""
 msgid "Row #{0}: Item {1} has been picked, please reserve stock from the Pick List."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:729
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:725
 msgid "Row #{0}: Item {1} is not a Serialized/Batched Item. It cannot have a Serial No/Batch No against it."
 msgstr ""
 
@@ -45073,7 +45068,7 @@ msgstr ""
 msgid "Row #{0}: Please select the Sub Assembly Warehouse"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:502
+#: erpnext/stock/doctype/item/item.py:505
 msgid "Row #{0}: Please set reorder quantity"
 msgstr ""
 
@@ -45106,8 +45101,8 @@ msgstr ""
 msgid "Row #{0}: Quality Inspection {1} was rejected for item {2}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1274
-#: erpnext/controllers/accounts_controller.py:3624
+#: erpnext/controllers/accounts_controller.py:1277
+#: erpnext/controllers/accounts_controller.py:3627
 msgid "Row #{0}: Quantity for Item {1} cannot be zero."
 msgstr ""
 
@@ -45144,7 +45139,7 @@ msgstr ""
 msgid "Row #{0}: Scrap Item Qty cannot be zero"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:230
+#: erpnext/controllers/selling_controller.py:238
 msgid "Row #{0}: Selling rate for item {1} is lower than its {2}.\n"
 "\t\t\t\t\tSelling {3} should be atleast {4}.<br><br>Alternatively,\n"
 "\t\t\t\t\tyou can disable selling price validation in {5} to bypass\n"
@@ -45228,7 +45223,7 @@ msgstr ""
 msgid "Row #{0}: The batch {1} has already expired."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:511
+#: erpnext/stock/doctype/item/item.py:514
 msgid "Row #{0}: The warehouse {1} is not a child warehouse of a group warehouse {2}"
 msgstr ""
 
@@ -45268,39 +45263,39 @@ msgstr ""
 msgid "Row #{1}: Warehouse is mandatory for stock Item {0}"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:259
+#: erpnext/controllers/buying_controller.py:267
 msgid "Row #{idx}: Cannot select Supplier Warehouse while suppling raw materials to subcontractor."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:406
+#: erpnext/controllers/buying_controller.py:414
 msgid "Row #{idx}: Item rate has been updated as per valuation rate since its an internal stock transfer."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:881
+#: erpnext/controllers/buying_controller.py:889
 msgid "Row #{idx}: Please enter a location for the asset item {item_code}."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:537
+#: erpnext/controllers/buying_controller.py:545
 msgid "Row #{idx}: Received Qty must be equal to Accepted + Rejected Qty for Item {item_code}."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:550
+#: erpnext/controllers/buying_controller.py:558
 msgid "Row #{idx}: {field_label} can not be negative for item {item_code}."
 msgstr "#{idx}sor: {field_label} nem lehet negatív a tételre: {item_code}."
 
-#: erpnext/controllers/buying_controller.py:496
+#: erpnext/controllers/buying_controller.py:504
 msgid "Row #{idx}: {field_label} is mandatory."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:518
+#: erpnext/controllers/buying_controller.py:526
 msgid "Row #{idx}: {field_label} is not allowed in Purchase Return."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:250
+#: erpnext/controllers/buying_controller.py:258
 msgid "Row #{idx}: {from_warehouse_field} and {to_warehouse_field} cannot be same."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:999
+#: erpnext/controllers/buying_controller.py:1007
 msgid "Row #{idx}: {schedule_date} cannot be before {transaction_date}."
 msgstr ""
 
@@ -45365,7 +45360,7 @@ msgstr ""
 msgid "Row #{}: {} {} does not exist."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1403
+#: erpnext/stock/doctype/item/item.py:1397
 msgid "Row #{}: {} {} doesn't belong to Company {}. Please select valid {}."
 msgstr ""
 
@@ -45437,11 +45432,11 @@ msgstr ""
 msgid "Row {0}: Both Debit and Credit values cannot be zero"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:222
+#: erpnext/controllers/selling_controller.py:230
 msgid "Row {0}: Conversion Factor is mandatory"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2995
+#: erpnext/controllers/accounts_controller.py:2998
 msgid "Row {0}: Cost Center {1} does not belong to Company {2}"
 msgstr ""
 
@@ -45461,11 +45456,11 @@ msgstr ""
 msgid "Row {0}: Debit entry can not be linked with a {1}"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:776
+#: erpnext/controllers/selling_controller.py:784
 msgid "Row {0}: Delivery Warehouse ({1}) and Customer Warehouse ({2}) can not be same"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2529
+#: erpnext/controllers/accounts_controller.py:2532
 msgid "Row {0}: Due Date in the Payment Terms table cannot be before Posting Date"
 msgstr ""
 
@@ -45474,7 +45469,7 @@ msgid "Row {0}: Either Delivery Note Item or Packed Item reference is mandatory.
 msgstr ""
 
 #: erpnext/accounts/doctype/journal_entry/journal_entry.py:1010
-#: erpnext/controllers/taxes_and_totals.py:1205
+#: erpnext/controllers/taxes_and_totals.py:1215
 msgid "Row {0}: Exchange Rate is mandatory"
 msgstr ""
 
@@ -45523,11 +45518,11 @@ msgstr ""
 msgid "Row {0}: Invalid reference {1}"
 msgstr ""
 
-#: erpnext/controllers/taxes_and_totals.py:142
+#: erpnext/controllers/taxes_and_totals.py:143
 msgid "Row {0}: Item Tax template updated as per validity and rate applied"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:541
+#: erpnext/controllers/selling_controller.py:549
 msgid "Row {0}: Item rate has been updated as per valuation rate since its an internal stock transfer"
 msgstr ""
 
@@ -45647,7 +45642,7 @@ msgstr ""
 msgid "Row {0}: The item {1}, quantity must be positive number"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2972
+#: erpnext/controllers/accounts_controller.py:2975
 msgid "Row {0}: The {3} Account {1} does not belong to the company {2}"
 msgstr ""
 
@@ -45664,7 +45659,7 @@ msgstr ""
 msgid "Row {0}: Workstation or Workstation Type is mandatory for an operation {1}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1011
+#: erpnext/controllers/accounts_controller.py:1014
 msgid "Row {0}: user has not applied the rule {1} on the item {2}"
 msgstr ""
 
@@ -45676,7 +45671,7 @@ msgstr ""
 msgid "Row {0}: {1} must be greater than 0"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:706
+#: erpnext/controllers/accounts_controller.py:709
 msgid "Row {0}: {1} {2} cannot be same as {3} (Party Account) {4}"
 msgstr ""
 
@@ -45692,7 +45687,7 @@ msgstr ""
 msgid "Row {1}: Quantity ({0}) cannot be a fraction. To allow this, disable '{2}' in UOM {3}."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:863
+#: erpnext/controllers/buying_controller.py:871
 msgid "Row {idx}: Asset Naming Series is mandatory for the auto creation of assets for item {item_code}."
 msgstr ""
 
@@ -45718,7 +45713,7 @@ msgstr ""
 msgid "Rows with Same Account heads will be merged on Ledger"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2539
+#: erpnext/controllers/accounts_controller.py:2542
 msgid "Rows with duplicate due dates in other rows were found: {0}"
 msgstr ""
 
@@ -45788,7 +45783,7 @@ msgstr ""
 msgid "SLA Paused On"
 msgstr ""
 
-#: erpnext/public/js/utils.js:1167
+#: erpnext/public/js/utils.js:1163
 msgid "SLA is on hold since {0}"
 msgstr ""
 
@@ -46189,7 +46184,7 @@ msgstr ""
 #: erpnext/accounts/report/sales_register/sales_register.py:238
 #: erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
 #: erpnext/buying/doctype/supplier_quotation_item/supplier_quotation_item.json
-#: erpnext/controllers/selling_controller.py:462
+#: erpnext/controllers/selling_controller.py:470
 #: erpnext/crm/doctype/contract/contract.json
 #: erpnext/maintenance/doctype/maintenance_schedule/maintenance_schedule.js:65
 #: erpnext/maintenance/doctype/maintenance_schedule_item/maintenance_schedule_item.json
@@ -46315,7 +46310,7 @@ msgstr ""
 msgid "Sales Order {0} is not valid"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:443
+#: erpnext/controllers/selling_controller.py:451
 #: erpnext/manufacturing/doctype/work_order/work_order.py:301
 msgid "Sales Order {0} is {1}"
 msgstr ""
@@ -46366,7 +46361,7 @@ msgstr ""
 #: erpnext/accounts/doctype/promotional_scheme/promotional_scheme.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:122
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1156
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1158
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:99
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:194
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:74
@@ -46464,7 +46459,7 @@ msgstr ""
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:156
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:137
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:128
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1153
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1155
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:105
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:191
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:80
@@ -46484,7 +46479,7 @@ msgstr ""
 msgid "Sales Person"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:204
+#: erpnext/controllers/selling_controller.py:212
 msgid "Sales Person <b>{0}</b> is disabled."
 msgstr ""
 
@@ -46765,7 +46760,7 @@ msgstr ""
 
 #. Label of the sample_size (Float) field in DocType 'Quality Inspection'
 #: erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py:93
-#: erpnext/public/js/controllers/transaction.js:2369
+#: erpnext/public/js/controllers/transaction.js:2395
 #: erpnext/stock/doctype/quality_inspection/quality_inspection.json
 msgid "Sample Size"
 msgstr ""
@@ -47303,7 +47298,7 @@ msgstr ""
 msgid "Select Items based on Delivery Date"
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2405
+#: erpnext/public/js/controllers/transaction.js:2431
 msgid "Select Items for Quality Inspection"
 msgstr ""
 
@@ -47444,7 +47439,7 @@ msgstr ""
 msgid "Select company name first."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2785
+#: erpnext/controllers/accounts_controller.py:2788
 msgid "Select finance book for the item {0} at row {1}"
 msgstr ""
 
@@ -47657,7 +47652,7 @@ msgid "Send Now"
 msgstr ""
 
 #. Label of the send_sms (Button) field in DocType 'SMS Center'
-#: erpnext/public/js/controllers/transaction.js:517
+#: erpnext/public/js/controllers/transaction.js:543
 #: erpnext/selling/doctype/sms_center/sms_center.json
 msgid "Send SMS"
 msgstr ""
@@ -47815,7 +47810,7 @@ msgstr ""
 #: erpnext/manufacturing/doctype/job_card/job_card.json
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.js:74
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.py:114
-#: erpnext/public/js/controllers/transaction.js:2382
+#: erpnext/public/js/controllers/transaction.js:2408
 #: erpnext/public/js/utils/serial_no_batch_selector.js:421
 #: erpnext/selling/doctype/installation_note_item/installation_note_item.json
 #: erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
@@ -47864,7 +47859,7 @@ msgstr ""
 msgid "Serial No Range"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1894
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1895
 msgid "Serial No Reserved"
 msgstr ""
 
@@ -47904,7 +47899,7 @@ msgstr ""
 msgid "Serial No and Batch Selector cannot be use when Use Serial / Batch Fields is enabled."
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:859
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:860
 msgid "Serial No is mandatory"
 msgstr ""
 
@@ -47933,7 +47928,7 @@ msgstr ""
 msgid "Serial No {0} does not exist"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2623
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2624
 msgid "Serial No {0} does not exists"
 msgstr ""
 
@@ -47941,7 +47936,7 @@ msgstr ""
 msgid "Serial No {0} is already added"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:357
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:358
 msgid "Serial No {0} is not present in the {1} {2}, hence you can't return it against the {1} {2}"
 msgstr ""
 
@@ -47978,11 +47973,11 @@ msgstr ""
 msgid "Serial Nos and Batches"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1370
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1371
 msgid "Serial Nos are created successfully"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:2137
+#: erpnext/stock/stock_ledger.py:2145
 msgid "Serial Nos are reserved in Stock Reservation Entries, you need to unreserve them before proceeding."
 msgstr ""
 
@@ -48056,11 +48051,11 @@ msgstr ""
 msgid "Serial and Batch Bundle"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1598
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1599
 msgid "Serial and Batch Bundle created"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1664
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1665
 msgid "Serial and Batch Bundle updated"
 msgstr ""
 
@@ -48412,12 +48407,12 @@ msgid "Service Stop Date"
 msgstr ""
 
 #: erpnext/accounts/deferred_revenue.py:44
-#: erpnext/public/js/controllers/transaction.js:1420
+#: erpnext/public/js/controllers/transaction.js:1446
 msgid "Service Stop Date cannot be after Service End Date"
 msgstr ""
 
 #: erpnext/accounts/deferred_revenue.py:41
-#: erpnext/public/js/controllers/transaction.js:1417
+#: erpnext/public/js/controllers/transaction.js:1443
 msgid "Service Stop Date cannot be before Service Start Date"
 msgstr ""
 
@@ -49852,7 +49847,7 @@ msgstr ""
 
 #: erpnext/setup/setup_wizard/operations/defaults_setup.py:70
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:463
-#: erpnext/stock/doctype/item/item.py:245
+#: erpnext/stock/doctype/item/item.py:248
 msgid "Standard Selling"
 msgstr ""
 
@@ -50682,7 +50677,7 @@ msgstr ""
 #. Option for the 'Purpose' (Select) field in DocType 'Stock Reconciliation'
 #. Label of a Link in the Stock Workspace
 #: erpnext/setup/workspace/home/home.json
-#: erpnext/stock/doctype/item/item.py:612
+#: erpnext/stock/doctype/item/item.py:618
 #: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.json
 #: erpnext/stock/workspace/stock/stock.json
 msgid "Stock Reconciliation"
@@ -50693,7 +50688,7 @@ msgstr ""
 msgid "Stock Reconciliation Item"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:612
+#: erpnext/stock/doctype/item/item.py:618
 msgid "Stock Reconciliations"
 msgstr ""
 
@@ -50728,7 +50723,7 @@ msgstr ""
 #: erpnext/stock/doctype/pick_list/pick_list.js:150
 #: erpnext/stock/doctype/pick_list/pick_list.js:155
 #: erpnext/stock/doctype/stock_entry/stock_entry_dashboard.py:25
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:706
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:702
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:575
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:1138
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:1398
@@ -51128,7 +51123,7 @@ msgstr ""
 #: erpnext/setup/doctype/company/company.py:287
 #: erpnext/setup/setup_wizard/operations/defaults_setup.py:33
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:502
-#: erpnext/stock/doctype/item/item.py:282
+#: erpnext/stock/doctype/item/item.py:285
 msgid "Stores"
 msgstr ""
 
@@ -51663,7 +51658,7 @@ msgstr ""
 msgid "Successfully Set Supplier"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:339
+#: erpnext/stock/doctype/item/item.py:342
 msgid "Successfully changed Stock UOM, please redefine conversion factors for new UOM."
 msgstr ""
 
@@ -51965,7 +51960,7 @@ msgstr ""
 #: erpnext/accounts/doctype/tax_rule/tax_rule.json
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:111
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:87
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1160
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1162
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:198
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:237
 #: erpnext/accounts/report/purchase_register/purchase_register.js:27
@@ -52065,7 +52060,7 @@ msgstr ""
 #. Label of the supplier_name (Data) field in DocType 'Purchase Receipt'
 #. Label of the supplier_name (Data) field in DocType 'Stock Entry'
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1077
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1079
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:156
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:198
 #: erpnext/accounts/report/purchase_register/purchase_register.py:177
@@ -52549,7 +52544,7 @@ msgstr ""
 msgid "System will fetch all the entries if limit value is zero."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1975
+#: erpnext/controllers/accounts_controller.py:1978
 msgid "System will not check over billing since amount for Item {0} in {1} is zero"
 msgstr ""
 
@@ -52808,7 +52803,7 @@ msgstr ""
 msgid "Target Warehouse is required before Submit"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:782
+#: erpnext/controllers/selling_controller.py:790
 msgid "Target Warehouse is set for some items but the customer is not an internal customer."
 msgstr ""
 
@@ -53047,7 +53042,7 @@ msgstr ""
 msgid "Tax Category"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:194
+#: erpnext/controllers/buying_controller.py:202
 msgid "Tax Category has been changed to \"Total\" because all the Items are non-stock items"
 msgstr ""
 
@@ -53252,7 +53247,7 @@ msgstr ""
 #. Label of the taxable_amount (Currency) field in DocType 'Tax Withheld
 #. Vouchers'
 #: erpnext/accounts/doctype/tax_withheld_vouchers/tax_withheld_vouchers.json
-#: erpnext/controllers/taxes_and_totals.py:1125
+#: erpnext/controllers/taxes_and_totals.py:1135
 msgid "Taxable Amount"
 msgstr ""
 
@@ -53391,7 +53386,7 @@ msgstr ""
 msgid "Taxes and Charges Deducted (Company Currency)"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:352
+#: erpnext/stock/doctype/item/item.py:355
 msgid "Taxes row #{0}: {1} cannot be smaller than {2}"
 msgstr ""
 
@@ -53677,7 +53672,7 @@ msgstr ""
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/territory_item/territory_item.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:134
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1144
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1146
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:93
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:182
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:68
@@ -53781,7 +53776,7 @@ msgstr ""
 msgid "The BOM which will be replaced"
 msgstr ""
 
-#: erpnext/stock/serial_batch_bundle.py:1274
+#: erpnext/stock/serial_batch_bundle.py:1306
 msgid "The Batch {0} has negative quantity {1} in warehouse {2}. Please correct the quantity."
 msgstr ""
 
@@ -53833,7 +53828,7 @@ msgstr ""
 msgid "The Serial No at Row #{0}: {1} is not available in warehouse {2}."
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1891
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1892
 msgid "The Serial No {0} is reserved against the {1} {2} and cannot be used for any other transaction."
 msgstr ""
 
@@ -53916,7 +53911,7 @@ msgstr ""
 msgid "The following batches are expired, please restock them: <br> {0}"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:849
+#: erpnext/stock/doctype/item/item.py:843
 msgid "The following deleted attributes exist in Variants but not in the Template. You can either delete the Variants or keep the attribute(s) in template."
 msgstr ""
 
@@ -53941,15 +53936,15 @@ msgstr ""
 msgid "The holiday on {0} is not between From Date and To Date"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:1066
+#: erpnext/controllers/buying_controller.py:1074
 msgid "The item {item} is not marked as {type_of} item. You can enable it as {type_of} item from its Item master."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:614
+#: erpnext/stock/doctype/item/item.py:620
 msgid "The items {0} and {1} are present in the following {2} :"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:1059
+#: erpnext/controllers/buying_controller.py:1067
 msgid "The items {items} are not marked as {type_of} item. You can enable them as {type_of} item from their Item masters."
 msgstr ""
 
@@ -54051,8 +54046,8 @@ msgstr ""
 msgid "The seller and the buyer cannot be the same"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:142
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:154
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:143
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:155
 msgid "The serial and batch bundle {0} not linked to {1} {2}"
 msgstr ""
 
@@ -54076,7 +54071,7 @@ msgstr ""
 msgid "The stock for the item {0} in the {1} warehouse was negative on the {2}. You should create a positive entry {3} before the date {4} and time {5} to post the correct valuation rate. For more details, please read the <a href='https://docs.erpnext.com/docs/user/manual/en/stock-adjustment-cogs-with-negative-stock'>documentation<a>."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:700
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:696
 msgid "The stock has been reserved for the following Items and Warehouses, un-reserve the same to {0} the Stock Reconciliation: <br /><br /> {1}"
 msgstr ""
 
@@ -54089,11 +54084,11 @@ msgstr ""
 msgid "The task has been enqueued as a background job."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:994
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:990
 msgid "The task has been enqueued as a background job. In case there is any issue on processing in background, the system will add a comment about the error on this Stock Reconciliation and revert to the Draft stage"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1005
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1001
 msgid "The task has been enqueued as a background job. In case there is any issue on processing in background, the system will add a comment about the error on this Stock Reconciliation and revert to the Submitted stage"
 msgstr ""
 
@@ -54143,7 +54138,7 @@ msgstr ""
 msgid "The {0} ({1}) must be equal to {2} ({3})"
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2790
+#: erpnext/public/js/controllers/transaction.js:2816
 msgid "The {0} contains Unit Price Items."
 msgstr ""
 
@@ -54191,7 +54186,7 @@ msgstr ""
 msgid "There can be multiple tiered collection factor based on the total spent. But the conversion factor for redemption will always be same for all the tier."
 msgstr ""
 
-#: erpnext/accounts/party.py:580
+#: erpnext/accounts/party.py:586
 msgid "There can only be 1 Account per Company in {0} {1}"
 msgstr ""
 
@@ -54477,7 +54472,7 @@ msgstr ""
 msgid "This will restrict user access to other employee records"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:783
+#: erpnext/controllers/selling_controller.py:791
 msgid "This {} will be treated as material transfer."
 msgstr ""
 
@@ -55191,11 +55186,11 @@ msgid "To include sub-assembly costs and scrap items in Finished Goods on a work
 msgstr ""
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:2337
-#: erpnext/controllers/accounts_controller.py:3005
+#: erpnext/controllers/accounts_controller.py:3008
 msgid "To include tax in row {0} in Item rate, taxes in rows {1} must also be included"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:636
+#: erpnext/stock/doctype/item/item.py:642
 msgid "To merge, following properties must be same for both items"
 msgstr ""
 
@@ -55815,7 +55810,7 @@ msgstr ""
 msgid "Total Paid Amount"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2591
+#: erpnext/controllers/accounts_controller.py:2594
 msgid "Total Payment Amount in Payment Schedule must be equal to Grand / Rounded Total"
 msgstr ""
 
@@ -56100,15 +56095,15 @@ msgstr ""
 msgid "Total Working Hours"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2138
+#: erpnext/controllers/accounts_controller.py:2141
 msgid "Total advance ({0}) against Order {1} cannot be greater than the Grand Total ({2})"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:190
+#: erpnext/controllers/selling_controller.py:198
 msgid "Total allocated percentage for sales team should be 100"
 msgstr ""
 
-#: erpnext/selling/doctype/customer/customer.py:162
+#: erpnext/selling/doctype/customer/customer.py:161
 msgid "Total contribution percentage should be equal to 100"
 msgstr ""
 
@@ -56993,7 +56988,7 @@ msgstr ""
 msgid "Unit of Measure (UOM)"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:384
+#: erpnext/stock/doctype/item/item.py:387
 msgid "Unit of Measure {0} has been entered more than once in Conversion Factor Table"
 msgstr ""
 
@@ -57435,7 +57430,7 @@ msgstr ""
 msgid "Update timestamp on new communication"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom_creator/bom_creator.py:533
+#: erpnext/manufacturing/doctype/bom_creator/bom_creator.py:534
 msgid "Updated successfully"
 msgstr ""
 
@@ -57449,7 +57444,7 @@ msgstr ""
 msgid "Updated via 'Time Log' (In Minutes)"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1387
+#: erpnext/stock/doctype/item/item.py:1381
 msgid "Updating Variants..."
 msgstr ""
 
@@ -58007,19 +58002,19 @@ msgstr ""
 msgid "Valuation Rate (In / Out)"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1881
+#: erpnext/stock/stock_ledger.py:1890
 msgid "Valuation Rate Missing"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1859
+#: erpnext/stock/stock_ledger.py:1868
 msgid "Valuation Rate for the Item {0}, is required to do accounting entries for {1} {2}."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:266
+#: erpnext/stock/doctype/item/item.py:269
 msgid "Valuation Rate is mandatory if Opening Stock entered"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:752
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:748
 msgid "Valuation Rate required for Item {0} at row {1}"
 msgstr ""
 
@@ -58029,7 +58024,7 @@ msgstr ""
 msgid "Valuation and Total"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:971
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:967
 msgid "Valuation rate for customer provided items has been set to zero."
 msgstr ""
 
@@ -58043,7 +58038,7 @@ msgid "Valuation rate for the item as per Sales Invoice (Only for Internal Trans
 msgstr ""
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:2361
-#: erpnext/controllers/accounts_controller.py:3029
+#: erpnext/controllers/accounts_controller.py:3032
 msgid "Valuation type charges can not be marked as Inclusive"
 msgstr ""
 
@@ -58199,7 +58194,7 @@ msgstr ""
 msgid "Variant"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:864
+#: erpnext/stock/doctype/item/item.py:858
 msgid "Variant Attribute Error"
 msgstr ""
 
@@ -58218,7 +58213,7 @@ msgstr ""
 msgid "Variant Based On"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:892
+#: erpnext/stock/doctype/item/item.py:886
 msgid "Variant Based On cannot be changed"
 msgstr ""
 
@@ -58236,7 +58231,7 @@ msgstr ""
 msgid "Variant Item"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:862
+#: erpnext/stock/doctype/item/item.py:856
 msgid "Variant Items"
 msgstr ""
 
@@ -58354,7 +58349,7 @@ msgstr ""
 #: erpnext/accounts/doctype/cost_center/cost_center_tree.js:56
 #: erpnext/accounts/doctype/invoice_discounting/invoice_discounting.js:205
 #: erpnext/accounts/doctype/journal_entry/journal_entry.js:43
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:668
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:670
 #: erpnext/bulk_transaction/doctype/bulk_transaction_log/bulk_transaction_log.js:14
 #: erpnext/bulk_transaction/doctype/bulk_transaction_log/bulk_transaction_log.js:24
 #: erpnext/buying/doctype/request_for_quotation/request_for_quotation.js:167
@@ -58541,7 +58536,7 @@ msgstr ""
 #: erpnext/accounts/doctype/repost_accounting_ledger_items/repost_accounting_ledger_items.json
 #: erpnext/accounts/doctype/repost_payment_ledger_items/repost_payment_ledger_items.json
 #: erpnext/accounts/doctype/unreconcile_payment/unreconcile_payment.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1099
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1101
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.js:42
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:209
 #: erpnext/accounts/report/general_ledger/general_ledger.js:49
@@ -58572,7 +58567,7 @@ msgstr ""
 msgid "Voucher No"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1087
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1088
 msgid "Voucher No is mandatory"
 msgstr ""
 
@@ -58614,7 +58609,7 @@ msgstr ""
 #: erpnext/accounts/doctype/repost_payment_ledger_items/repost_payment_ledger_items.json
 #: erpnext/accounts/doctype/tax_withheld_vouchers/tax_withheld_vouchers.json
 #: erpnext/accounts/doctype/unreconcile_payment/unreconcile_payment.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1097
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1099
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:200
 #: erpnext/accounts/report/general_ledger/general_ledger.py:697
 #: erpnext/accounts/report/invalid_ledger_entries/invalid_ledger_entries.py:31
@@ -58968,10 +58963,6 @@ msgstr ""
 msgid "Warehouse not found against the account {0}"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:600
-msgid "Warehouse not found in the system"
-msgstr ""
-
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:1130
 #: erpnext/stock/doctype/delivery_note/delivery_note.py:414
 msgid "Warehouse required for stock Item {0}"
@@ -59100,7 +59091,7 @@ msgid "Warn for new Request for Quotations"
 msgstr ""
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:744
-#: erpnext/controllers/accounts_controller.py:1978
+#: erpnext/controllers/accounts_controller.py:1981
 #: erpnext/stock/doctype/delivery_trip/delivery_trip.js:145
 #: erpnext/utilities/transaction_base.py:123
 msgid "Warning"
@@ -60072,7 +60063,7 @@ msgstr ""
 msgid "You are importing data for the code list:"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3611
+#: erpnext/controllers/accounts_controller.py:3614
 msgid "You are not allowed to update as per the conditions set in {} Workflow."
 msgstr ""
 
@@ -60137,7 +60128,7 @@ msgstr ""
 msgid "You can't make any changes to Job Card since Work Order is closed."
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:185
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:186
 msgid "You can't process the serial number {0} as it has already been used in the SABB {1}. {2} if you want to inward same serial number multiple times then enabled 'Allow existing Serial No to be Manufactured/Received again' in the {3}"
 msgstr ""
 
@@ -60197,7 +60188,7 @@ msgstr ""
 msgid "You cannot {0} this document because another Period Closing Entry {1} exists after {2}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3587
+#: erpnext/controllers/accounts_controller.py:3590
 msgid "You do not have permissions to {} items in a {}."
 msgstr ""
 
@@ -60225,7 +60216,7 @@ msgstr ""
 msgid "You have entered a duplicate Delivery Note on Row"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1063
+#: erpnext/stock/doctype/item/item.py:1057
 msgid "You have to enable auto re-order in Stock Settings to maintain re-order levels."
 msgstr ""
 
@@ -60245,7 +60236,7 @@ msgstr ""
 msgid "You need to cancel POS Closing Entry {} to be able to cancel this document."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2980
+#: erpnext/controllers/accounts_controller.py:2983
 msgid "You selected the account group {1} as {2} Account in row {0}. Please select a single account."
 msgstr ""
 
@@ -60323,7 +60314,7 @@ msgstr ""
 msgid "`Allow Negative rates for Items`"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1873
+#: erpnext/stock/stock_ledger.py:1882
 msgid "after"
 msgstr ""
 
@@ -60471,7 +60462,7 @@ msgstr ""
 msgid "material_request_item"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:151
+#: erpnext/controllers/selling_controller.py:159
 msgid "must be between 0 and 100"
 msgstr ""
 
@@ -60496,7 +60487,7 @@ msgstr ""
 msgid "on"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1289
+#: erpnext/controllers/accounts_controller.py:1292
 msgid "or"
 msgstr ""
 
@@ -60545,7 +60536,7 @@ msgstr ""
 msgid "per hour"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1874
+#: erpnext/stock/stock_ledger.py:1883
 msgid "performing either one below:"
 msgstr ""
 
@@ -60672,7 +60663,7 @@ msgstr ""
 msgid "{0}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1109
+#: erpnext/controllers/accounts_controller.py:1112
 msgid "{0} '{1}' is disabled"
 msgstr ""
 
@@ -60688,7 +60679,7 @@ msgstr ""
 msgid "{0} <b>{1}</b> has submitted Assets. Remove Item <b>{2}</b> from table to continue."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2193
+#: erpnext/controllers/accounts_controller.py:2196
 msgid "{0} Account not found against Customer {1}."
 msgstr ""
 
@@ -60720,7 +60711,7 @@ msgstr ""
 msgid "{0} Request for {1}"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:323
+#: erpnext/stock/doctype/item/item.py:326
 msgid "{0} Retain Sample is based on batch, please check Has Batch No to retain sample of item"
 msgstr ""
 
@@ -60811,7 +60802,7 @@ msgid "{0} entered twice in Item Tax"
 msgstr ""
 
 #: erpnext/setup/doctype/item_group/item_group.py:48
-#: erpnext/stock/doctype/item/item.py:436
+#: erpnext/stock/doctype/item/item.py:439
 msgid "{0} entered twice {1} in Item Taxes"
 msgstr ""
 
@@ -60832,7 +60823,7 @@ msgstr ""
 msgid "{0} hours"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2534
+#: erpnext/controllers/accounts_controller.py:2537
 msgid "{0} in row {1}"
 msgstr ""
 
@@ -60856,7 +60847,7 @@ msgstr ""
 
 #: erpnext/accounts/doctype/budget/budget.py:60
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:643
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:49
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:50
 #: erpnext/accounts/report/general_ledger/general_ledger.py:59
 #: erpnext/accounts/report/pos_register/pos_register.py:107
 #: erpnext/controllers/trends.py:50
@@ -60876,11 +60867,11 @@ msgstr ""
 msgid "{0} is mandatory. Maybe Currency Exchange record is not created for {1} to {2}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2937
+#: erpnext/controllers/accounts_controller.py:2940
 msgid "{0} is mandatory. Maybe Currency Exchange record is not created for {1} to {2}."
 msgstr ""
 
-#: erpnext/selling/doctype/customer/customer.py:204
+#: erpnext/selling/doctype/customer/customer.py:203
 msgid "{0} is not a company bank account"
 msgstr ""
 
@@ -60963,7 +60954,7 @@ msgstr ""
 msgid "{0} to {1}"
 msgstr "{0} a {1} címre"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:690
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:686
 msgid "{0} units are reserved for Item {1} in Warehouse {2}, please un-reserve the same to {3} the Stock Reconciliation."
 msgstr ""
 
@@ -60979,16 +60970,16 @@ msgstr ""
 msgid "{0} units of {1} are required in {2} with the inventory dimension: {3} ({4}) on {5} {6} for {7} to complete the transaction."
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1532 erpnext/stock/stock_ledger.py:2023
-#: erpnext/stock/stock_ledger.py:2037
+#: erpnext/stock/stock_ledger.py:1541 erpnext/stock/stock_ledger.py:2031
+#: erpnext/stock/stock_ledger.py:2045
 msgid "{0} units of {1} needed in {2} on {3} {4} for {5} to complete this transaction."
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:2124 erpnext/stock/stock_ledger.py:2170
+#: erpnext/stock/stock_ledger.py:2132 erpnext/stock/stock_ledger.py:2178
 msgid "{0} units of {1} needed in {2} on {3} {4} to complete this transaction."
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1526
+#: erpnext/stock/stock_ledger.py:1535
 msgid "{0} units of {1} needed in {2} to complete this transaction."
 msgstr ""
 
@@ -61034,7 +61025,7 @@ msgstr ""
 msgid "{0} {1} does not exist"
 msgstr ""
 
-#: erpnext/accounts/party.py:560
+#: erpnext/accounts/party.py:566
 msgid "{0} {1} has accounting entries in currency {2} for company {3}. Please select a receivable or payable account with currency {2}."
 msgstr ""
 
@@ -61068,7 +61059,7 @@ msgstr ""
 msgid "{0} {1} is associated with {2}, but Party Account is {3}"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:462
+#: erpnext/controllers/selling_controller.py:470
 #: erpnext/controllers/subcontracting_controller.py:954
 msgid "{0} {1} is cancelled or closed"
 msgstr ""
@@ -61085,11 +61076,11 @@ msgstr ""
 msgid "{0} {1} is closed"
 msgstr ""
 
-#: erpnext/accounts/party.py:798
+#: erpnext/accounts/party.py:804
 msgid "{0} {1} is disabled"
 msgstr ""
 
-#: erpnext/accounts/party.py:804
+#: erpnext/accounts/party.py:810
 msgid "{0} {1} is frozen"
 msgstr ""
 
@@ -61097,7 +61088,7 @@ msgstr ""
 msgid "{0} {1} is fully billed"
 msgstr ""
 
-#: erpnext/accounts/party.py:808
+#: erpnext/accounts/party.py:814
 msgid "{0} {1} is not active"
 msgstr ""
 
@@ -61223,15 +61214,15 @@ msgstr ""
 msgid "{0}: {1} must be less than {2}"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:840
+#: erpnext/controllers/buying_controller.py:848
 msgid "{count} Assets created for {item_code}"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:738
+#: erpnext/controllers/buying_controller.py:746
 msgid "{doctype} {name} is cancelled or closed."
 msgstr "{doctype} {name} törlik vagy zárva."
 
-#: erpnext/controllers/buying_controller.py:459
+#: erpnext/controllers/buying_controller.py:467
 msgid "{field_label} is mandatory for sub-contracted {doctype}."
 msgstr ""
 
@@ -61239,7 +61230,7 @@ msgstr ""
 msgid "{item_name}'s Sample Size ({sample_size}) cannot be greater than the Accepted Quantity ({accepted_quantity})"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:563
+#: erpnext/controllers/buying_controller.py:571
 msgid "{ref_doctype} {ref_name} is {status}."
 msgstr ""
 
@@ -61305,7 +61296,7 @@ msgstr ""
 msgid "{} can't be cancelled since the Loyalty Points earned has been redeemed. First cancel the {} No {}"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:222
+#: erpnext/controllers/buying_controller.py:230
 msgid "{} has submitted assets linked to it. You need to cancel the assets to create purchase return."
 msgstr ""
 

--- a/erpnext/locale/main.pot
+++ b/erpnext/locale/main.pot
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ERPNext VERSION\n"
 "Report-Msgid-Bugs-To: hello@frappe.io\n"
-"POT-Creation-Date: 2025-05-25 09:35+0000\n"
-"PO-Revision-Date: 2025-05-25 09:35+0000\n"
+"POT-Creation-Date: 2025-06-01 09:36+0000\n"
+"PO-Revision-Date: 2025-06-01 09:36+0000\n"
 "Last-Translator: hello@frappe.io\n"
 "Language-Team: hello@frappe.io\n"
 "MIME-Version: 1.0\n"
@@ -81,15 +81,15 @@ msgstr ""
 msgid " Summary"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:235
+#: erpnext/stock/doctype/item/item.py:238
 msgid "\"Customer Provided Item\" cannot be Purchase Item also"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:237
+#: erpnext/stock/doctype/item/item.py:240
 msgid "\"Customer Provided Item\" cannot have Valuation Rate"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:313
+#: erpnext/stock/doctype/item/item.py:316
 msgid "\"Is Fixed Asset\" cannot be unchecked, as Asset record exists against the item"
 msgstr ""
 
@@ -211,7 +211,7 @@ msgstr ""
 msgid "% of materials delivered against this Sales Order"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2197
+#: erpnext/controllers/accounts_controller.py:2200
 msgid "'Account' in the Accounting section of Customer {0}"
 msgstr ""
 
@@ -223,15 +223,11 @@ msgstr ""
 msgid "'Based On' and 'Group By' can not be same"
 msgstr ""
 
-#: erpnext/stock/report/product_bundle_balance/product_bundle_balance.py:233
-msgid "'Date' is required"
-msgstr ""
-
 #: erpnext/selling/report/inactive_customers/inactive_customers.py:18
 msgid "'Days Since Last Order' must be greater than or equal to zero"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2202
+#: erpnext/controllers/accounts_controller.py:2205
 msgid "'Default {0} Account' in Company {1}"
 msgstr ""
 
@@ -241,7 +237,7 @@ msgstr ""
 
 #: erpnext/stock/report/batch_item_expiry_status/batch_item_expiry_status.py:24
 #: erpnext/stock/report/batch_wise_balance_history/batch_wise_balance_history.py:120
-#: erpnext/stock/report/stock_analytics/stock_analytics.py:314
+#: erpnext/stock/report/stock_analytics/stock_analytics.py:313
 msgid "'From Date' is required"
 msgstr ""
 
@@ -249,7 +245,7 @@ msgstr ""
 msgid "'From Date' must be after 'To Date'"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:398
+#: erpnext/stock/doctype/item/item.py:401
 msgid "'Has Serial No' can not be 'Yes' for non-stock item"
 msgstr ""
 
@@ -1121,7 +1117,7 @@ msgstr ""
 
 #. Label of the qty (Float) field in DocType 'Purchase Receipt Item'
 #. Label of the qty (Float) field in DocType 'Subcontracting Receipt Item'
-#: erpnext/public/js/controllers/transaction.js:2362
+#: erpnext/public/js/controllers/transaction.js:2388
 #: erpnext/stock/doctype/purchase_receipt_item/purchase_receipt_item.json
 #: erpnext/subcontracting/doctype/subcontracting_receipt_item/subcontracting_receipt_item.json
 msgid "Accepted Quantity"
@@ -1319,7 +1315,7 @@ msgid "Account Manager"
 msgstr ""
 
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:949
-#: erpnext/controllers/accounts_controller.py:2206
+#: erpnext/controllers/accounts_controller.py:2209
 msgid "Account Missing"
 msgstr ""
 
@@ -1494,7 +1490,7 @@ msgstr ""
 msgid "Account {0} is frozen"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1288
+#: erpnext/controllers/accounts_controller.py:1291
 msgid "Account {0} is invalid. Account Currency must be {1}"
 msgstr ""
 
@@ -1530,7 +1526,7 @@ msgstr ""
 msgid "Account: {0} is not permitted under Payment Entry"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3037
+#: erpnext/controllers/accounts_controller.py:3040
 msgid "Account: {0} with currency: {1} can not be selected"
 msgstr ""
 
@@ -1803,7 +1799,7 @@ msgstr ""
 msgid "Accounting Entry for Asset"
 msgstr ""
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:796
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:805
 msgid "Accounting Entry for Service"
 msgstr ""
 
@@ -1818,18 +1814,18 @@ msgstr ""
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py:1468
 #: erpnext/controllers/stock_controller.py:550
 #: erpnext/controllers/stock_controller.py:567
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:889
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:898
 #: erpnext/stock/doctype/stock_entry/stock_entry.py:1586
 #: erpnext/stock/doctype/stock_entry/stock_entry.py:1600
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py:561
 msgid "Accounting Entry for Stock"
 msgstr ""
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:717
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:726
 msgid "Accounting Entry for {0}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2247
+#: erpnext/controllers/accounts_controller.py:2250
 msgid "Accounting Entry for {0}: {1} can only be made in currency: {2}"
 msgstr ""
 
@@ -2222,7 +2218,7 @@ msgstr ""
 msgid "Accumulated Monthly"
 msgstr ""
 
-#: erpnext/controllers/budget_controller.py:417
+#: erpnext/controllers/budget_controller.py:422
 msgid "Accumulated Monthly Budget for Account {0} against {1} {2} is {3}. It will be collectively ({4}) exceeded by {5}"
 msgstr ""
 
@@ -3336,7 +3332,7 @@ msgstr ""
 msgid "Adjustment Against"
 msgstr ""
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:634
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:643
 msgid "Adjustment based on Purchase Invoice rate"
 msgstr ""
 
@@ -3447,7 +3443,7 @@ msgstr ""
 msgid "Advance amount"
 msgstr ""
 
-#: erpnext/controllers/taxes_and_totals.py:845
+#: erpnext/controllers/taxes_and_totals.py:855
 msgid "Advance amount cannot be greater than {0} {1}"
 msgstr ""
 
@@ -3658,7 +3654,7 @@ msgstr ""
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:152
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:133
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1125
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1127
 msgid "Age (Days)"
 msgstr ""
 
@@ -3743,16 +3739,6 @@ msgstr ""
 
 #: erpnext/setup/setup_wizard/data/industry_type.txt:4
 msgid "Agriculture"
-msgstr ""
-
-#. Name of a role
-#: erpnext/assets/doctype/location/location.json
-msgid "Agriculture Manager"
-msgstr ""
-
-#. Name of a role
-#: erpnext/assets/doctype/location/location.json
-msgid "Agriculture User"
 msgstr ""
 
 #: erpnext/setup/setup_wizard/data/industry_type.txt:5
@@ -3945,7 +3931,7 @@ msgstr ""
 msgid "All items are already requested"
 msgstr ""
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:1317
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:1326
 msgid "All items have already been Invoiced/Returned"
 msgstr ""
 
@@ -3957,7 +3943,7 @@ msgstr ""
 msgid "All items have already been transferred for this Work Order."
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2465
+#: erpnext/public/js/controllers/transaction.js:2491
 msgid "All items in this document already have a linked Quality Inspection."
 msgstr ""
 
@@ -4155,7 +4141,7 @@ msgstr ""
 msgid "Allow Item To Be Added Multiple Times in a Transaction"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:755
+#: erpnext/controllers/selling_controller.py:763
 msgid "Allow Item to Be Added Multiple Times in a Transaction"
 msgstr ""
 
@@ -5101,7 +5087,7 @@ msgstr ""
 msgid "Annual Billing: {0}"
 msgstr ""
 
-#: erpnext/controllers/budget_controller.py:441
+#: erpnext/controllers/budget_controller.py:446
 msgid "Annual Budget for Account {0} against {1} {2} is {3}. It will be collectively ({4}) exceeded by {5}"
 msgstr ""
 
@@ -5590,7 +5576,7 @@ msgstr ""
 msgid "As the field {0} is enabled, the value of the field {1} should be more than 1."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:989
+#: erpnext/stock/doctype/item/item.py:983
 msgid "As there are existing submitted transactions against item {0}, you can not change the value of {1}."
 msgstr ""
 
@@ -5736,7 +5722,7 @@ msgstr ""
 msgid "Asset Category Name"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:304
+#: erpnext/stock/doctype/item/item.py:307
 msgid "Asset Category is mandatory for Fixed Asset item"
 msgstr ""
 
@@ -6111,7 +6097,7 @@ msgstr ""
 msgid "Asset {0} must be submitted"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:851
+#: erpnext/controllers/buying_controller.py:859
 msgid "Asset {assets_link} created for {item_code}"
 msgstr ""
 
@@ -6141,11 +6127,11 @@ msgstr ""
 msgid "Assets"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:869
+#: erpnext/controllers/buying_controller.py:877
 msgid "Assets not created for {item_code}. You will have to create asset manually."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:856
+#: erpnext/controllers/buying_controller.py:864
 msgid "Assets {assets_link} created for {item_code}"
 msgstr ""
 
@@ -6240,7 +6226,7 @@ msgstr ""
 msgid "At row #{0}: you have selected the Difference Account {1}, which is a Cost of Goods Sold type account. Please select a different account"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:864
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:865
 msgid "At row {0}: Batch No is mandatory for Item {1}"
 msgstr ""
 
@@ -6248,11 +6234,11 @@ msgstr ""
 msgid "At row {0}: Parent Row No cannot be set for item {1}"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:849
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:850
 msgid "At row {0}: Qty is mandatory for the batch {1}"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:856
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:857
 msgid "At row {0}: Serial No is mandatory for Item {1}"
 msgstr ""
 
@@ -6326,7 +6312,7 @@ msgstr ""
 msgid "Attribute Value"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:930
+#: erpnext/stock/doctype/item/item.py:924
 msgid "Attribute table is mandatory"
 msgstr ""
 
@@ -6334,11 +6320,11 @@ msgstr ""
 msgid "Attribute value: {0} must appear only once"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:934
+#: erpnext/stock/doctype/item/item.py:928
 msgid "Attribute {0} selected multiple times in Attributes Table"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:862
+#: erpnext/stock/doctype/item/item.py:856
 msgid "Attributes"
 msgstr ""
 
@@ -7622,11 +7608,11 @@ msgstr ""
 msgid "Barcode Type"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:457
+#: erpnext/stock/doctype/item/item.py:460
 msgid "Barcode {0} already used in Item {1}"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:472
+#: erpnext/stock/doctype/item/item.py:475
 msgid "Barcode {0} is not a valid {1} code"
 msgstr ""
 
@@ -7880,7 +7866,7 @@ msgstr ""
 #: erpnext/manufacturing/doctype/job_card/job_card.json
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.js:89
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.py:115
-#: erpnext/public/js/controllers/transaction.js:2388
+#: erpnext/public/js/controllers/transaction.js:2414
 #: erpnext/public/js/utils/barcode_scanner.js:260
 #: erpnext/public/js/utils/serial_no_batch_selector.js:438
 #: erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
@@ -7907,11 +7893,11 @@ msgstr ""
 msgid "Batch No"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:867
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:868
 msgid "Batch No is mandatory"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2629
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2630
 msgid "Batch No {0} does not exists"
 msgstr ""
 
@@ -7919,7 +7905,7 @@ msgstr ""
 msgid "Batch No {0} is linked with Item {1} which has serial no. Please scan serial no instead."
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:364
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:365
 msgid "Batch No {0} is not present in the original {1} {2}, hence you can't return it against the {1} {2}"
 msgstr ""
 
@@ -7934,11 +7920,11 @@ msgstr ""
 msgid "Batch Nos"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1421
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1422
 msgid "Batch Nos are created successfully"
 msgstr ""
 
-#: erpnext/controllers/sales_and_purchase_return.py:1096
+#: erpnext/controllers/sales_and_purchase_return.py:1001
 msgid "Batch Not Available for Return"
 msgstr ""
 
@@ -7987,7 +7973,7 @@ msgstr ""
 msgid "Batch {0} and Warehouse"
 msgstr ""
 
-#: erpnext/controllers/sales_and_purchase_return.py:1095
+#: erpnext/controllers/sales_and_purchase_return.py:1000
 msgid "Batch {0} is not available in warehouse {1}"
 msgstr ""
 
@@ -8037,7 +8023,7 @@ msgstr ""
 #. Label of the bill_date (Date) field in DocType 'Journal Entry'
 #. Label of the bill_date (Date) field in DocType 'Subcontracting Receipt'
 #: erpnext/accounts/doctype/journal_entry/journal_entry.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1110
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1112
 #: erpnext/accounts/report/purchase_register/purchase_register.py:214
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.json
 msgid "Bill Date"
@@ -8046,7 +8032,7 @@ msgstr ""
 #. Label of the bill_no (Data) field in DocType 'Journal Entry'
 #. Label of the bill_no (Data) field in DocType 'Subcontracting Receipt'
 #: erpnext/accounts/doctype/journal_entry/journal_entry.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1109
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1111
 #: erpnext/accounts/report/purchase_register/purchase_register.py:213
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.json
 msgid "Bill No"
@@ -8266,7 +8252,7 @@ msgstr ""
 msgid "Billing Zipcode"
 msgstr ""
 
-#: erpnext/accounts/party.py:602
+#: erpnext/accounts/party.py:608
 msgid "Billing currency must be equal to either default company's currency or party account currency"
 msgstr ""
 
@@ -9263,7 +9249,7 @@ msgid "Can only make payment against unbilled {0}"
 msgstr ""
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1458
-#: erpnext/controllers/accounts_controller.py:2946
+#: erpnext/controllers/accounts_controller.py:2949
 #: erpnext/public/js/controllers/accounts.js:90
 msgid "Can refer row only if the charge type is 'On Previous Row Amount' or 'Previous Row Total'"
 msgstr ""
@@ -9425,9 +9411,9 @@ msgstr ""
 msgid "Cannot Create Return"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:625
-#: erpnext/stock/doctype/item/item.py:638
-#: erpnext/stock/doctype/item/item.py:652
+#: erpnext/stock/doctype/item/item.py:631
+#: erpnext/stock/doctype/item/item.py:644
+#: erpnext/stock/doctype/item/item.py:658
 msgid "Cannot Merge"
 msgstr ""
 
@@ -9451,7 +9437,7 @@ msgstr ""
 msgid "Cannot apply TDS against multiple parties in one entry"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:307
+#: erpnext/stock/doctype/item/item.py:310
 msgid "Cannot be a fixed asset item as Stock Ledger is created."
 msgstr ""
 
@@ -9467,7 +9453,7 @@ msgstr ""
 msgid "Cannot cancel the transaction. Reposting of item valuation on submission is not completed yet."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:959
+#: erpnext/controllers/buying_controller.py:967
 msgid "Cannot cancel this document as it is linked with the submitted asset {asset_link}. Please cancel the asset to continue."
 msgstr ""
 
@@ -9475,7 +9461,7 @@ msgstr ""
 msgid "Cannot cancel transaction for Completed Work Order."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:882
+#: erpnext/stock/doctype/item/item.py:876
 msgid "Cannot change Attributes after stock transaction. Make a new Item and transfer stock to the new Item"
 msgstr ""
 
@@ -9491,7 +9477,7 @@ msgstr ""
 msgid "Cannot change Service Stop Date for item in row {0}"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:873
+#: erpnext/stock/doctype/item/item.py:867
 msgid "Cannot change Variant properties after stock transaction. You will have to make a new Item to do this."
 msgstr ""
 
@@ -9519,7 +9505,7 @@ msgstr ""
 msgid "Cannot covert to Group because Account Type is selected."
 msgstr ""
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:972
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:981
 msgid "Cannot create Stock Reservation Entries for future dated Purchase Receipts."
 msgstr ""
 
@@ -9570,7 +9556,7 @@ msgstr ""
 msgid "Cannot find Item with this Barcode"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3483
+#: erpnext/controllers/accounts_controller.py:3486
 msgid "Cannot find a default warehouse for item {0}. Please set one in the Item Master or in Stock Settings."
 msgstr ""
 
@@ -9578,7 +9564,7 @@ msgstr ""
 msgid "Cannot make any transactions until the deletion job is completed"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2074
+#: erpnext/controllers/accounts_controller.py:2077
 msgid "Cannot overbill for Item {0} in row {1} more than {2}. To allow over-billing, please set allowance in Accounts Settings"
 msgstr ""
 
@@ -9599,7 +9585,7 @@ msgid "Cannot receive from customer against negative outstanding"
 msgstr ""
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1475
-#: erpnext/controllers/accounts_controller.py:2961
+#: erpnext/controllers/accounts_controller.py:2964
 #: erpnext/public/js/controllers/accounts.js:100
 msgid "Cannot refer row number greater than or equal to current row number for this Charge type"
 msgstr ""
@@ -9615,7 +9601,7 @@ msgstr ""
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1467
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1646
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:1917
-#: erpnext/controllers/accounts_controller.py:2951
+#: erpnext/controllers/accounts_controller.py:2954
 #: erpnext/public/js/controllers/accounts.js:94
 #: erpnext/public/js/controllers/taxes_and_totals.js:470
 msgid "Cannot select charge type as 'On Previous Row Amount' or 'On Previous Row Total' for first row"
@@ -9629,15 +9615,15 @@ msgstr ""
 msgid "Cannot set authorization on basis of Discount for {0}"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:716
+#: erpnext/stock/doctype/item/item.py:722
 msgid "Cannot set multiple Item Defaults for a company."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3631
+#: erpnext/controllers/accounts_controller.py:3634
 msgid "Cannot set quantity less than delivered quantity"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3634
+#: erpnext/controllers/accounts_controller.py:3637
 msgid "Cannot set quantity less than received quantity"
 msgstr ""
 
@@ -10060,7 +10046,7 @@ msgid "Channel Partner"
 msgstr ""
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:2346
-#: erpnext/controllers/accounts_controller.py:3014
+#: erpnext/controllers/accounts_controller.py:3017
 msgid "Charge of type 'Actual' in row {0} cannot be included in Item Rate or Paid Amount"
 msgstr ""
 
@@ -10243,7 +10229,7 @@ msgstr ""
 
 #. Label of the reference_date (Date) field in DocType 'Payment Entry'
 #: erpnext/accounts/doctype/payment_entry/payment_entry.json
-#: erpnext/public/js/controllers/transaction.js:2299
+#: erpnext/public/js/controllers/transaction.js:2325
 msgid "Cheque/Reference Date"
 msgstr ""
 
@@ -10291,7 +10277,7 @@ msgstr ""
 
 #. Label of the child_row_reference (Data) field in DocType 'Quality
 #. Inspection'
-#: erpnext/public/js/controllers/transaction.js:2394
+#: erpnext/public/js/controllers/transaction.js:2420
 #: erpnext/stock/doctype/quality_inspection/quality_inspection.json
 msgid "Child Row Reference"
 msgstr ""
@@ -11003,7 +10989,7 @@ msgstr ""
 #: erpnext/accounts/report/cheques_and_deposits_incorrectly_cleared/cheques_and_deposits_incorrectly_cleared.js:8
 #: erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.js:8
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:8
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:49
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:50
 #: erpnext/accounts/report/deferred_revenue_and_expense/deferred_revenue_and_expense.js:8
 #: erpnext/accounts/report/delivered_items_to_be_billed/delivered_items_to_be_billed.js:7
 #: erpnext/accounts/report/dimension_wise_accounts_balance_report/dimension_wise_accounts_balance_report.js:8
@@ -12236,7 +12222,7 @@ msgid "Content Type"
 msgstr ""
 
 #: erpnext/erpnext_integrations/doctype/plaid_settings/plaid_settings.js:162
-#: erpnext/public/js/controllers/transaction.js:2312
+#: erpnext/public/js/controllers/transaction.js:2338
 #: erpnext/selling/doctype/quotation/quotation.js:356
 msgid "Continue"
 msgstr ""
@@ -12401,7 +12387,7 @@ msgstr ""
 msgid "Conversion Rate"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:393
+#: erpnext/stock/doctype/item/item.py:396
 msgid "Conversion factor for default Unit of Measure must be 1 in row {0}"
 msgstr ""
 
@@ -12409,15 +12395,15 @@ msgstr ""
 msgid "Conversion factor for item {0} has been reset to 1.0 as the uom {1} is same as stock uom {2}."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2767
+#: erpnext/controllers/accounts_controller.py:2770
 msgid "Conversion rate cannot be 0"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2774
+#: erpnext/controllers/accounts_controller.py:2777
 msgid "Conversion rate is 1.00, but document currency is different from company currency"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2770
+#: erpnext/controllers/accounts_controller.py:2773
 msgid "Conversion rate must be 1.00 if document currency is same as company currency"
 msgstr ""
 
@@ -12630,7 +12616,7 @@ msgstr ""
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:28
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:40
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:30
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1096
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1098
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:40
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.js:42
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.py:197
@@ -12723,7 +12709,7 @@ msgid "Cost Center is a part of Cost Center Allocation, hence cannot be converte
 msgstr ""
 
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py:1411
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:855
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:864
 msgid "Cost Center is required in row {0} in Taxes table for type {1}"
 msgstr ""
 
@@ -12992,8 +12978,8 @@ msgstr ""
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:132
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:143
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:219
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:654
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:678
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:656
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:680
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.js:88
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.js:89
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.js:103
@@ -13050,8 +13036,8 @@ msgstr ""
 #: erpnext/projects/doctype/task/task_tree.js:81
 #: erpnext/public/js/communication.js:19 erpnext/public/js/communication.js:31
 #: erpnext/public/js/communication.js:41
-#: erpnext/public/js/controllers/transaction.js:336
-#: erpnext/public/js/controllers/transaction.js:2435
+#: erpnext/public/js/controllers/transaction.js:362
+#: erpnext/public/js/controllers/transaction.js:2461
 #: erpnext/selling/doctype/customer/customer.js:181
 #: erpnext/selling/doctype/quotation/quotation.js:124
 #: erpnext/selling/doctype/quotation/quotation.js:133
@@ -13346,7 +13332,7 @@ msgstr ""
 msgid "Create a variant with the template image."
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1877
+#: erpnext/stock/stock_ledger.py:1886
 msgid "Create an incoming stock transaction for the Item."
 msgstr ""
 
@@ -13406,7 +13392,7 @@ msgstr ""
 msgid "Creating Purchase Order ..."
 msgstr ""
 
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:735
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:737
 #: erpnext/buying/doctype/purchase_order/purchase_order.js:552
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.js:73
 msgid "Creating Purchase Receipt ..."
@@ -13602,7 +13588,7 @@ msgstr ""
 #: erpnext/accounts/doctype/journal_entry_template/journal_entry_template.json
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:174
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:147
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1119
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1121
 #: erpnext/controllers/sales_and_purchase_return.py:373
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:286
 #: erpnext/stock/doctype/delivery_note/delivery_note.js:89
@@ -13637,7 +13623,7 @@ msgstr ""
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py:368
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py:376
-#: erpnext/controllers/accounts_controller.py:2186
+#: erpnext/controllers/accounts_controller.py:2189
 msgid "Credit To"
 msgstr ""
 
@@ -13822,7 +13808,7 @@ msgstr ""
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/subscription_plan/subscription_plan.json
 #: erpnext/accounts/report/account_balance/account_balance.py:28
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1129
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1131
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:205
 #: erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.py:101
 #: erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.js:118
@@ -14351,7 +14337,7 @@ msgstr ""
 #. Label of the customer_contact_display (Small Text) field in DocType
 #. 'Purchase Order'
 #. Label of the customer_contact (Small Text) field in DocType 'Delivery Stop'
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1090
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1092
 #: erpnext/buying/doctype/purchase_order/purchase_order.json
 #: erpnext/stock/doctype/delivery_stop/delivery_stop.json
 msgid "Customer Contact"
@@ -14447,7 +14433,7 @@ msgstr ""
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/tax_rule/tax_rule.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:107
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1147
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1149
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:81
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:185
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:56
@@ -14491,7 +14477,7 @@ msgstr ""
 msgid "Customer Group Name"
 msgstr ""
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1239
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1241
 msgid "Customer Group: {0} does not exist"
 msgstr ""
 
@@ -14510,7 +14496,7 @@ msgstr ""
 msgid "Customer Items"
 msgstr ""
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1138
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1140
 msgid "Customer LPO"
 msgstr ""
 
@@ -14556,7 +14542,7 @@ msgstr ""
 #: erpnext/accounts/doctype/pos_invoice/pos_invoice.json
 #: erpnext/accounts/doctype/process_statement_of_accounts_customer/process_statement_of_accounts_customer.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1080
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1082
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:156
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:92
 #: erpnext/accounts/report/delivered_items_to_be_billed/delivered_items_to_be_billed.py:35
@@ -15234,7 +15220,7 @@ msgstr ""
 #: erpnext/accounts/doctype/journal_entry_template/journal_entry_template.json
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:176
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:147
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1122
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1124
 #: erpnext/controllers/sales_and_purchase_return.py:377
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:287
 #: erpnext/stock/doctype/purchase_receipt/purchase_receipt.js:61
@@ -15263,7 +15249,7 @@ msgstr ""
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:953
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:964
-#: erpnext/controllers/accounts_controller.py:2186
+#: erpnext/controllers/accounts_controller.py:2189
 msgid "Debit To"
 msgstr ""
 
@@ -15296,11 +15282,11 @@ msgstr ""
 msgid "Debit-Credit mismatch"
 msgstr ""
 
-#: erpnext/accounts/party.py:609
+#: erpnext/accounts/party.py:615
 msgid "Debtor/Creditor"
 msgstr ""
 
-#: erpnext/accounts/party.py:612
+#: erpnext/accounts/party.py:618
 msgid "Debtor/Creditor Advance"
 msgstr ""
 
@@ -15420,7 +15406,7 @@ msgstr ""
 msgid "Default BOM"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:418
+#: erpnext/stock/doctype/item/item.py:421
 msgid "Default BOM ({0}) must be active for this item or its template"
 msgstr ""
 
@@ -15428,7 +15414,7 @@ msgstr ""
 msgid "Default BOM for {0} not found"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3672
+#: erpnext/controllers/accounts_controller.py:3675
 msgid "Default BOM not found for FG Item {0}"
 msgstr ""
 
@@ -15763,15 +15749,15 @@ msgstr ""
 msgid "Default Unit of Measure"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1272
+#: erpnext/stock/doctype/item/item.py:1266
 msgid "Default Unit of Measure for Item {0} cannot be changed directly because you have already made some transaction(s) with another UOM. You need to either cancel the linked documents or create a new Item."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1255
+#: erpnext/stock/doctype/item/item.py:1249
 msgid "Default Unit of Measure for Item {0} cannot be changed directly because you have already made some transaction(s) with another UOM. You will need to create a new Item to use a different Default UOM."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:908
+#: erpnext/stock/doctype/item/item.py:902
 msgid "Default Unit of Measure for Variant '{0}' must be same as in Template '{1}'"
 msgstr ""
 
@@ -16230,7 +16216,7 @@ msgstr ""
 msgid "Delivery Note {0} is not submitted"
 msgstr ""
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1142
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1144
 #: erpnext/stock/doctype/delivery_trip/delivery_trip.js:73
 msgid "Delivery Notes"
 msgstr ""
@@ -16761,7 +16747,7 @@ msgstr ""
 #: erpnext/projects/doctype/task_type/task_type.json
 #: erpnext/projects/doctype/timesheet_detail/timesheet_detail.json
 #: erpnext/public/js/bank_reconciliation_tool/data_table_manager.js:55
-#: erpnext/public/js/controllers/transaction.js:2376
+#: erpnext/public/js/controllers/transaction.js:2402
 #: erpnext/selling/doctype/installation_note_item/installation_note_item.json
 #: erpnext/selling/doctype/product_bundle/product_bundle.json
 #: erpnext/selling/doctype/product_bundle_item/product_bundle_item.json
@@ -16949,7 +16935,7 @@ msgstr ""
 msgid "Difference Account must be a Asset/Liability type account (Temporary Opening), since this Stock Entry is an Opening Entry"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:954
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:950
 msgid "Difference Account must be a Asset/Liability type account, since this Stock Reconciliation is an Opening Entry"
 msgstr ""
 
@@ -17215,11 +17201,11 @@ msgstr ""
 msgid "Disabled Warehouse {0} cannot be used for this transaction."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:745
+#: erpnext/controllers/accounts_controller.py:748
 msgid "Disabled pricing rules since this {} is an internal transfer"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:759
+#: erpnext/controllers/accounts_controller.py:762
 msgid "Disabled tax included prices since this {} is an internal transfer"
 msgstr ""
 
@@ -18161,7 +18147,7 @@ msgstr ""
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.json
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/print_format/sales_invoice_print/sales_invoice_print.html:72
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1106
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1108
 #: erpnext/assets/doctype/asset_maintenance_log/asset_maintenance_log.json
 #: erpnext/selling/report/payment_terms_status_for_sales_order/payment_terms_status_for_sales_order.py:40
 msgid "Due Date"
@@ -18175,11 +18161,11 @@ msgstr ""
 msgid "Due Date Based On"
 msgstr ""
 
-#: erpnext/accounts/party.py:695
+#: erpnext/accounts/party.py:701
 msgid "Due Date cannot be after {0}"
 msgstr ""
 
-#: erpnext/accounts/party.py:671
+#: erpnext/accounts/party.py:677
 msgid "Due Date cannot be before {0}"
 msgstr ""
 
@@ -18897,7 +18883,7 @@ msgstr ""
 msgid "Enable Auto Email"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1064
+#: erpnext/stock/doctype/item/item.py:1058
 msgid "Enable Auto Re-Order"
 msgstr ""
 
@@ -19110,7 +19096,7 @@ msgstr ""
 msgid "End Date"
 msgstr ""
 
-#: erpnext/crm/doctype/contract/contract.py:75
+#: erpnext/crm/doctype/contract/contract.py:83
 msgid "End Date cannot be before Start Date."
 msgstr ""
 
@@ -19362,7 +19348,7 @@ msgstr ""
 #: erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.json
 #: erpnext/manufacturing/doctype/job_card/job_card.py:875
 #: erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.json
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:297
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:298
 msgid "Error"
 msgstr ""
 
@@ -19486,7 +19472,7 @@ msgstr ""
 msgid "Example URL"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:995
+#: erpnext/stock/doctype/item/item.py:989
 msgid "Example of a linked document: {0}"
 msgstr ""
 
@@ -19502,7 +19488,7 @@ msgstr ""
 msgid "Example: ABCD.#####. If series is set and Batch No is not mentioned in transactions, then automatic batch number will be created based on this series. If you always want to explicitly mention Batch No for this item, leave this blank. Note: this setting will take priority over the Naming Series Prefix in Stock Settings."
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:2141
+#: erpnext/stock/stock_ledger.py:2149
 msgid "Example: Serial No {0} reserved in {1}."
 msgstr ""
 
@@ -19556,8 +19542,8 @@ msgstr ""
 msgid "Exchange Gain/Loss"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1593
-#: erpnext/controllers/accounts_controller.py:1677
+#: erpnext/controllers/accounts_controller.py:1596
+#: erpnext/controllers/accounts_controller.py:1680
 msgid "Exchange Gain/Loss amount has been booked through {0}"
 msgstr ""
 
@@ -20293,7 +20279,7 @@ msgid "Fetching Error"
 msgstr ""
 
 #: erpnext/accounts/doctype/dunning/dunning.js:135
-#: erpnext/public/js/controllers/transaction.js:1251
+#: erpnext/public/js/controllers/transaction.js:1277
 msgid "Fetching exchange rates ..."
 msgstr ""
 
@@ -20588,15 +20574,15 @@ msgstr ""
 msgid "Finished Good Item Quantity"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3658
+#: erpnext/controllers/accounts_controller.py:3661
 msgid "Finished Good Item is not specified for service item {0}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3675
+#: erpnext/controllers/accounts_controller.py:3678
 msgid "Finished Good Item {0} Qty can not be zero"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3669
+#: erpnext/controllers/accounts_controller.py:3672
 msgid "Finished Good Item {0} must be a sub-contracted item"
 msgstr ""
 
@@ -20837,7 +20823,7 @@ msgstr ""
 msgid "Fixed Asset Defaults"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:301
+#: erpnext/stock/doctype/item/item.py:304
 msgid "Fixed Asset Item must be a non-stock item."
 msgstr ""
 
@@ -21013,7 +20999,7 @@ msgstr ""
 msgid "For Raw Materials"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1259
+#: erpnext/controllers/accounts_controller.py:1262
 msgid "For Return Invoices with Stock effect, '0' qty Items are not allowed. Following rows are affected: {0}"
 msgstr ""
 
@@ -21114,7 +21100,7 @@ msgstr ""
 msgid "For the item {0}, the quantity should be {1} according to the BOM {2}."
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:1088
+#: erpnext/public/js/controllers/transaction.js:1114
 msgctxt "Clear payment terms template and/or payment schedule when due date is changed"
 msgid "For the new {0} to take effect, would you like to clear the current {1}?"
 msgstr ""
@@ -21123,7 +21109,7 @@ msgstr ""
 msgid "For the {0}, no stock is available for the return in the warehouse {1}."
 msgstr ""
 
-#: erpnext/controllers/sales_and_purchase_return.py:1144
+#: erpnext/controllers/sales_and_purchase_return.py:1049
 msgid "For the {0}, the quantity is required to make the return entry"
 msgstr ""
 
@@ -21460,7 +21446,7 @@ msgstr ""
 msgid "From Date is mandatory"
 msgstr ""
 
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:52
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:53
 #: erpnext/accounts/report/general_ledger/general_ledger.py:86
 #: erpnext/accounts/report/pos_register/pos_register.py:115
 #: erpnext/accounts/report/tax_withholding_details/tax_withholding_details.py:39
@@ -21837,14 +21823,14 @@ msgstr ""
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:186
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:155
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1134
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1136
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:177
 msgid "Future Payment Amount"
 msgstr ""
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:185
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:154
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1133
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1135
 msgid "Future Payment Ref"
 msgstr ""
 
@@ -23018,7 +23004,7 @@ msgstr ""
 msgid "Here are the error logs for the aforementioned failed depreciation entries: {0}"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1862
+#: erpnext/stock/stock_ledger.py:1871
 msgid "Here are the options to proceed:"
 msgstr ""
 
@@ -23544,7 +23530,7 @@ msgstr ""
 msgid "If more than one package of the same type (for print)"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1872
+#: erpnext/stock/stock_ledger.py:1881
 msgid "If not, you can Cancel / Submit this entry"
 msgstr ""
 
@@ -23569,7 +23555,7 @@ msgstr ""
 msgid "If the account is frozen, entries are allowed to restricted users."
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1865
+#: erpnext/stock/stock_ledger.py:1874
 msgid "If the item is transacting as a Zero Valuation Rate item in this entry, please enable 'Allow Zero Valuation Rate' in the {0} Item table."
 msgstr ""
 
@@ -24567,7 +24553,7 @@ msgstr ""
 msgid "Incorrect Batch Consumed"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:514
+#: erpnext/stock/doctype/item/item.py:517
 msgid "Incorrect Check in (group) Warehouse for Reorder"
 msgstr ""
 
@@ -24616,7 +24602,7 @@ msgstr ""
 msgid "Incorrect Stock Value Report"
 msgstr ""
 
-#: erpnext/stock/serial_batch_bundle.py:134
+#: erpnext/stock/serial_batch_bundle.py:135
 msgid "Incorrect Type of Transaction"
 msgstr ""
 
@@ -24885,8 +24871,8 @@ msgstr ""
 msgid "Insufficient Capacity"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3590
-#: erpnext/controllers/accounts_controller.py:3614
+#: erpnext/controllers/accounts_controller.py:3593
+#: erpnext/controllers/accounts_controller.py:3617
 msgid "Insufficient Permissions"
 msgstr ""
 
@@ -24894,12 +24880,12 @@ msgstr ""
 #: erpnext/stock/doctype/pick_list/pick_list.py:127
 #: erpnext/stock/doctype/pick_list/pick_list.py:975
 #: erpnext/stock/doctype/stock_entry/stock_entry.py:759
-#: erpnext/stock/serial_batch_bundle.py:989 erpnext/stock/stock_ledger.py:1559
-#: erpnext/stock/stock_ledger.py:2032
+#: erpnext/stock/serial_batch_bundle.py:1021 erpnext/stock/stock_ledger.py:1568
+#: erpnext/stock/stock_ledger.py:2040
 msgid "Insufficient Stock"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:2047
+#: erpnext/stock/stock_ledger.py:2055
 msgid "Insufficient Stock for Batch"
 msgstr ""
 
@@ -25037,11 +25023,11 @@ msgstr ""
 msgid "Internal Customer for company {0} already exists"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:728
+#: erpnext/controllers/accounts_controller.py:731
 msgid "Internal Sale or Delivery Reference missing."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:730
+#: erpnext/controllers/accounts_controller.py:733
 msgid "Internal Sales Reference Missing"
 msgstr ""
 
@@ -25072,7 +25058,7 @@ msgstr ""
 msgid "Internal Transfer"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:739
+#: erpnext/controllers/accounts_controller.py:742
 msgid "Internal Transfer Reference Missing"
 msgstr ""
 
@@ -25115,8 +25101,8 @@ msgstr ""
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:969
 #: erpnext/assets/doctype/asset_category/asset_category.py:69
 #: erpnext/assets/doctype/asset_category/asset_category.py:97
-#: erpnext/controllers/accounts_controller.py:2975
-#: erpnext/controllers/accounts_controller.py:2983
+#: erpnext/controllers/accounts_controller.py:2978
+#: erpnext/controllers/accounts_controller.py:2986
 msgid "Invalid Account"
 msgstr ""
 
@@ -25141,7 +25127,7 @@ msgstr ""
 msgid "Invalid Barcode. There is no Item attached to this barcode."
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2631
+#: erpnext/public/js/controllers/transaction.js:2657
 msgid "Invalid Blanket Order for the selected Customer and Item"
 msgstr ""
 
@@ -25155,7 +25141,7 @@ msgstr ""
 
 #: erpnext/assets/doctype/asset/asset.py:295
 #: erpnext/assets/doctype/asset/asset.py:302
-#: erpnext/controllers/accounts_controller.py:2998
+#: erpnext/controllers/accounts_controller.py:3001
 msgid "Invalid Cost Center"
 msgstr ""
 
@@ -25197,7 +25183,7 @@ msgstr ""
 msgid "Invalid Item"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1410
+#: erpnext/stock/doctype/item/item.py:1404
 msgid "Invalid Item Defaults"
 msgstr ""
 
@@ -25243,11 +25229,11 @@ msgstr ""
 msgid "Invalid Purchase Invoice"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3627
+#: erpnext/controllers/accounts_controller.py:3630
 msgid "Invalid Qty"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1277
+#: erpnext/controllers/accounts_controller.py:1280
 msgid "Invalid Quantity"
 msgstr ""
 
@@ -25264,7 +25250,7 @@ msgstr ""
 msgid "Invalid Schedule"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:243
+#: erpnext/controllers/selling_controller.py:251
 msgid "Invalid Selling Price"
 msgstr ""
 
@@ -25297,7 +25283,7 @@ msgstr ""
 msgid "Invalid lost reason {0}, please create a new lost reason"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:408
+#: erpnext/stock/doctype/item/item.py:411
 msgid "Invalid naming series (. missing) for {0}"
 msgstr ""
 
@@ -25337,7 +25323,7 @@ msgstr ""
 #. Name of a DocType
 #: erpnext/patches/v15_0/refactor_closing_stock_balance.py:43
 #: erpnext/stock/doctype/inventory_dimension/inventory_dimension.json
-#: erpnext/stock/doctype/inventory_dimension/inventory_dimension.py:180
+#: erpnext/stock/doctype/inventory_dimension/inventory_dimension.py:181
 msgid "Inventory Dimension"
 msgstr ""
 
@@ -25403,7 +25389,7 @@ msgstr ""
 msgid "Invoice Discounting"
 msgstr ""
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1114
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1116
 msgid "Invoice Grand Total"
 msgstr ""
 
@@ -25496,7 +25482,7 @@ msgstr ""
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:169
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:144
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1116
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1118
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:164
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:165
 msgid "Invoiced Amount"
@@ -25902,6 +25888,11 @@ msgstr ""
 msgid "Is Outward"
 msgstr ""
 
+#. Label of the is_packed (Check) field in DocType 'Serial and Batch Bundle'
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.json
+msgid "Is Packed"
+msgstr ""
+
 #. Label of the is_paid (Check) field in DocType 'Purchase Invoice'
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 msgid "Is Paid"
@@ -26184,11 +26175,11 @@ msgstr ""
 msgid "Issuing cannot be done to a location. Please enter employee to issue the Asset {0} to"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:565
+#: erpnext/stock/doctype/item/item.py:571
 msgid "It can take upto few hours for accurate stock values to be visible after merging items."
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2075
+#: erpnext/public/js/controllers/transaction.js:2101
 msgid "It is needed to fetch Item Details."
 msgstr ""
 
@@ -26238,7 +26229,7 @@ msgstr ""
 #: erpnext/buying/report/supplier_quotation_comparison/supplier_quotation_comparison.js:33
 #: erpnext/buying/report/supplier_quotation_comparison/supplier_quotation_comparison.py:204
 #: erpnext/buying/workspace/buying/buying.json
-#: erpnext/controllers/taxes_and_totals.py:1125
+#: erpnext/controllers/taxes_and_totals.py:1135
 #: erpnext/manufacturing/doctype/blanket_order/blanket_order.json
 #: erpnext/manufacturing/doctype/bom/bom.js:944
 #: erpnext/manufacturing/doctype/bom/bom.json
@@ -26516,7 +26507,7 @@ msgstr ""
 #: erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py:86
 #: erpnext/manufacturing/report/work_order_stock_report/work_order_stock_report.py:119
 #: erpnext/projects/doctype/timesheet/timesheet.js:213
-#: erpnext/public/js/controllers/transaction.js:2350
+#: erpnext/public/js/controllers/transaction.js:2376
 #: erpnext/public/js/stock_reservation.js:112
 #: erpnext/public/js/stock_reservation.js:317 erpnext/public/js/utils.js:500
 #: erpnext/public/js/utils.js:656
@@ -26954,7 +26945,7 @@ msgstr ""
 #: erpnext/manufacturing/report/production_planning_report/production_planning_report.py:359
 #: erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py:92
 #: erpnext/manufacturing/report/work_order_consumed_materials/work_order_consumed_materials.py:138
-#: erpnext/public/js/controllers/transaction.js:2356
+#: erpnext/public/js/controllers/transaction.js:2382
 #: erpnext/public/js/utils.js:746
 #: erpnext/selling/doctype/quotation_item/quotation_item.json
 #: erpnext/selling/doctype/sales_order_item/sales_order_item.json
@@ -27221,7 +27212,7 @@ msgstr ""
 msgid "Item Variant {0} already exists with same attributes"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:781
+#: erpnext/stock/doctype/item/item.py:772
 msgid "Item Variants updated"
 msgstr ""
 
@@ -27287,7 +27278,7 @@ msgstr ""
 msgid "Item for row {0} does not match Material Request"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:795
+#: erpnext/stock/doctype/item/item.py:789
 msgid "Item has variants."
 msgstr ""
 
@@ -27313,7 +27304,7 @@ msgstr ""
 msgid "Item operation"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3650
+#: erpnext/controllers/accounts_controller.py:3653
 msgid "Item qty can not be updated as raw materials are already processed."
 msgstr ""
 
@@ -27339,7 +27330,7 @@ msgstr ""
 msgid "Item valuation reposting in progress. Report might show incorrect item valuation."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:952
+#: erpnext/stock/doctype/item/item.py:946
 msgid "Item variant {0} exists with same attributes"
 msgstr ""
 
@@ -27352,8 +27343,7 @@ msgid "Item {0} cannot be ordered more than {1} against Blanket Order {2}."
 msgstr ""
 
 #: erpnext/assets/doctype/asset/asset.py:277
-#: erpnext/stock/doctype/item/item.py:630
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:167
+#: erpnext/stock/doctype/item/item.py:636
 msgid "Item {0} does not exist"
 msgstr ""
 
@@ -27365,7 +27355,7 @@ msgstr ""
 msgid "Item {0} does not exist."
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:752
+#: erpnext/controllers/selling_controller.py:760
 msgid "Item {0} entered multiple times."
 msgstr ""
 
@@ -27381,7 +27371,7 @@ msgstr ""
 msgid "Item {0} has no Serial No. Only serialized items can have delivery based on Serial No"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1126
+#: erpnext/stock/doctype/item/item.py:1120
 msgid "Item {0} has reached its end of life on {1}"
 msgstr ""
 
@@ -27393,11 +27383,11 @@ msgstr ""
 msgid "Item {0} is already reserved/delivered against Sales Order {1}."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1146
+#: erpnext/stock/doctype/item/item.py:1140
 msgid "Item {0} is cancelled"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1130
+#: erpnext/stock/doctype/item/item.py:1124
 msgid "Item {0} is disabled"
 msgstr ""
 
@@ -27405,7 +27395,7 @@ msgstr ""
 msgid "Item {0} is not a serialized Item"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1138
+#: erpnext/stock/doctype/item/item.py:1132
 msgid "Item {0} is not a stock Item"
 msgstr ""
 
@@ -27449,7 +27439,7 @@ msgstr ""
 msgid "Item {0}: {1} qty produced. "
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1429
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1423
 msgid "Item {} does not exist."
 msgstr ""
 
@@ -27589,7 +27579,7 @@ msgstr ""
 msgid "Items and Pricing"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3872
+#: erpnext/controllers/accounts_controller.py:3875
 msgid "Items cannot be updated as Subcontracting Order is created against the Purchase Order {0}."
 msgstr ""
 
@@ -28085,7 +28075,7 @@ msgstr ""
 
 #. Name of a DocType
 #. Label of a Link in the Stock Workspace
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:674
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:676
 #: erpnext/stock/doctype/landed_cost_voucher/landed_cost_voucher.json
 #: erpnext/stock/doctype/purchase_receipt/purchase_receipt.js:104
 #: erpnext/stock/workspace/stock/stock.json
@@ -28701,7 +28691,7 @@ msgstr ""
 msgid "Linked Location"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:999
+#: erpnext/stock/doctype/item/item.py:993
 msgid "Linked with submitted documents"
 msgstr ""
 
@@ -29440,7 +29430,7 @@ msgstr ""
 #: erpnext/manufacturing/doctype/bom/bom.py:261
 #: erpnext/manufacturing/doctype/bom_update_log/bom_update_log.py:71
 #: erpnext/public/js/controllers/accounts.js:249
-#: erpnext/public/js/controllers/transaction.js:2753
+#: erpnext/public/js/controllers/transaction.js:2779
 #: erpnext/public/js/utils/party.js:321
 #: erpnext/stock/doctype/delivery_note/delivery_note.js:164
 #: erpnext/stock/doctype/inventory_dimension/inventory_dimension.json
@@ -30296,7 +30286,7 @@ msgstr ""
 msgid "Maximum Value"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:212
+#: erpnext/controllers/selling_controller.py:220
 msgid "Maximum discount for Item {0} is {1}%"
 msgstr ""
 
@@ -30366,7 +30356,7 @@ msgstr ""
 msgid "Megawatt"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1878
+#: erpnext/stock/stock_ledger.py:1887
 msgid "Mention Valuation Rate in the Item master."
 msgstr ""
 
@@ -30761,11 +30751,11 @@ msgstr ""
 msgid "Miscellaneous Expenses"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:540
+#: erpnext/controllers/buying_controller.py:548
 msgid "Mismatch"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1430
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1424
 msgid "Missing"
 msgstr ""
 
@@ -31292,7 +31282,7 @@ msgstr ""
 msgid "Multiple Warehouse Accounts"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1129
+#: erpnext/controllers/accounts_controller.py:1132
 msgid "Multiple fiscal years exist for the date {0}. Please set company in Fiscal Year"
 msgstr ""
 
@@ -31443,7 +31433,7 @@ msgstr ""
 msgid "Naming Series and Price Defaults"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:90
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:91
 msgid "Naming Series is mandatory"
 msgstr ""
 
@@ -31482,15 +31472,15 @@ msgstr ""
 msgid "Needs Analysis"
 msgstr ""
 
-#: erpnext/stock/serial_batch_bundle.py:1277
+#: erpnext/stock/serial_batch_bundle.py:1309
 msgid "Negative Batch Quantity"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:610
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:606
 msgid "Negative Quantity is not allowed"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:615
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:611
 msgid "Negative Valuation Rate is not allowed"
 msgstr ""
 
@@ -31772,7 +31762,7 @@ msgstr ""
 msgid "Net Weight UOM"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1483
+#: erpnext/controllers/accounts_controller.py:1486
 msgid "Net total calculation precision loss"
 msgstr ""
 
@@ -32115,7 +32105,7 @@ msgstr ""
 #: erpnext/accounts/doctype/journal_entry/journal_entry.py:1539
 #: erpnext/accounts/doctype/journal_entry/journal_entry.py:1599
 #: erpnext/accounts/doctype/journal_entry/journal_entry.py:1613
-#: erpnext/stock/doctype/item/item.py:1371
+#: erpnext/stock/doctype/item/item.py:1365
 msgid "No Permission"
 msgstr ""
 
@@ -32137,7 +32127,7 @@ msgstr ""
 msgid "No Selection"
 msgstr ""
 
-#: erpnext/controllers/sales_and_purchase_return.py:919
+#: erpnext/controllers/sales_and_purchase_return.py:824
 msgid "No Serial / Batches are available for return"
 msgstr ""
 
@@ -32173,7 +32163,7 @@ msgstr ""
 msgid "No Work Orders were created"
 msgstr ""
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:785
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:794
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py:689
 msgid "No accounting entries for the following warehouses"
 msgstr ""
@@ -32362,7 +32352,7 @@ msgstr ""
 msgid "No reserved stock to unreserve."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:773
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:769
 msgid "No stock ledger entries were created. Please set the quantity or valuation rate for the items properly and try again."
 msgstr ""
 
@@ -32446,7 +32436,7 @@ msgstr ""
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:566
 #: erpnext/assets/doctype/asset/asset.js:612
 #: erpnext/assets/doctype/asset/asset.js:627
-#: erpnext/controllers/buying_controller.py:225
+#: erpnext/controllers/buying_controller.py:233
 #: erpnext/selling/doctype/product_bundle/product_bundle.py:72
 #: erpnext/setup/doctype/transaction_deletion_record/transaction_deletion_record.py:80
 msgid "Not Allowed"
@@ -32567,10 +32557,10 @@ msgstr ""
 #: erpnext/selling/doctype/customer/customer.py:129
 #: erpnext/selling/doctype/sales_order/sales_order.js:1168
 #: erpnext/stock/doctype/item/item.js:526
-#: erpnext/stock/doctype/item/item.py:567
+#: erpnext/stock/doctype/item/item.py:573
 #: erpnext/stock/doctype/item_price/item_price.json
 #: erpnext/stock/doctype/stock_entry/stock_entry.py:1374
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:972
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:968
 #: erpnext/templates/pages/timelog_info.html:43
 msgid "Note"
 msgstr ""
@@ -32579,7 +32569,7 @@ msgstr ""
 msgid "Note: Automatic log deletion only applies to logs of type <i>Update Cost</i>"
 msgstr ""
 
-#: erpnext/accounts/party.py:690
+#: erpnext/accounts/party.py:696
 msgid "Note: Due Date exceeds allowed {0} credit days by {1} day(s)"
 msgstr ""
 
@@ -32605,7 +32595,7 @@ msgstr ""
 msgid "Note: This Cost Center is a Group. Cannot make accounting entries against groups."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:621
+#: erpnext/stock/doctype/item/item.py:627
 msgid "Note: To merge the items, create a separate Stock Reconciliation for the old item {0}"
 msgstr ""
 
@@ -33369,7 +33359,7 @@ msgstr ""
 
 #. Label of the opening_stock (Float) field in DocType 'Item'
 #. Option for the 'Purpose' (Select) field in DocType 'Stock Reconciliation'
-#: erpnext/stock/doctype/item/item.json erpnext/stock/doctype/item/item.py:296
+#: erpnext/stock/doctype/item/item.json erpnext/stock/doctype/item/item.py:299
 #: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.json
 msgid "Opening Stock"
 msgstr ""
@@ -34089,7 +34079,7 @@ msgstr ""
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:149
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1123
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1125
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:167
 #: erpnext/accounts/report/purchase_register/purchase_register.py:289
 #: erpnext/accounts/report/sales_register/sales_register.py:319
@@ -34128,7 +34118,7 @@ msgstr ""
 msgid "Over Billing Allowance (%)"
 msgstr ""
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:1242
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:1251
 msgid "Over Billing Allowance exceeded for Purchase Receipt Item {0} ({1}) by {2}%"
 msgstr ""
 
@@ -34169,7 +34159,7 @@ msgstr ""
 msgid "Overbilling of {0} {1} ignored for item {2} because you have {3} role."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2013
+#: erpnext/controllers/accounts_controller.py:2016
 msgid "Overbilling of {} ignored because you have {} role."
 msgstr ""
 
@@ -34676,7 +34666,7 @@ msgstr ""
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:146
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1117
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1119
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:165
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:172
 #: erpnext/accounts/report/pos_register/pos_register.py:209
@@ -34909,7 +34899,7 @@ msgstr ""
 msgid "Parent Row No"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom_creator/bom_creator.py:495
+#: erpnext/manufacturing/doctype/bom_creator/bom_creator.py:496
 msgid "Parent Row No not found for {0}"
 msgstr ""
 
@@ -35138,7 +35128,7 @@ msgstr ""
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:142
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:159
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:57
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1054
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1056
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:67
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:147
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:228
@@ -35164,7 +35154,7 @@ msgstr ""
 
 #. Name of a DocType
 #: erpnext/accounts/doctype/party_account/party_account.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1065
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1067
 msgid "Party Account"
 msgstr ""
 
@@ -35191,7 +35181,7 @@ msgstr ""
 msgid "Party Account No. (Bank Statement)"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2278
+#: erpnext/controllers/accounts_controller.py:2281
 msgid "Party Account {0} currency ({1}) and document currency ({2}) should be same"
 msgstr ""
 
@@ -35207,6 +35197,11 @@ msgstr ""
 #: erpnext/accounts/doctype/bank_account/bank_account.json
 #: erpnext/accounts/doctype/payment_request/payment_request.json
 msgid "Party Details"
+msgstr ""
+
+#. Label of the party_full_name (Data) field in DocType 'Contract'
+#: erpnext/crm/doctype/contract/contract.json
+msgid "Party Full Name"
 msgstr ""
 
 #. Label of the bank_party_iban (Data) field in DocType 'Bank Transaction'
@@ -35292,7 +35287,7 @@ msgstr ""
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:84
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:54
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:44
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1048
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1050
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:54
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:141
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:219
@@ -35314,7 +35309,7 @@ msgstr ""
 msgid "Party Type"
 msgstr ""
 
-#: erpnext/accounts/party.py:819
+#: erpnext/accounts/party.py:825
 msgid "Party Type and Party can only be set for Receivable / Payable account<br><br>{0}"
 msgstr ""
 
@@ -35436,7 +35431,7 @@ msgid "Payable"
 msgstr ""
 
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:42
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1063
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1065
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:211
 #: erpnext/accounts/report/purchase_register/purchase_register.py:194
 #: erpnext/accounts/report/purchase_register/purchase_register.py:235
@@ -35602,7 +35597,7 @@ msgstr ""
 msgid "Payment Entry is already created"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1434
+#: erpnext/controllers/accounts_controller.py:1437
 msgid "Payment Entry {0} is linked against Order {1}, check if it should be pulled as advance in this invoice."
 msgstr ""
 
@@ -35884,7 +35879,7 @@ msgstr ""
 #: erpnext/accounts/doctype/payment_schedule/payment_schedule.json
 #: erpnext/accounts/doctype/payment_term/payment_term.json
 #: erpnext/accounts/doctype/payment_terms_template_detail/payment_terms_template_detail.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1113
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1115
 #: erpnext/accounts/report/gross_profit/gross_profit.py:412
 #: erpnext/accounts/workspace/accounting/accounting.json
 #: erpnext/selling/report/payment_terms_status_for_sales_order/payment_terms_status_for_sales_order.py:30
@@ -36948,7 +36943,7 @@ msgstr ""
 msgid "Please create a new Accounting Dimension if required."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:729
+#: erpnext/controllers/accounts_controller.py:732
 msgid "Please create purchase from internal sale or delivery document itself"
 msgstr ""
 
@@ -36956,7 +36951,7 @@ msgstr ""
 msgid "Please create purchase receipt or purchase invoice for the item {0}"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:649
+#: erpnext/stock/doctype/item/item.py:655
 msgid "Please delete Product Bundle {0}, before merging {1} into {2}"
 msgstr ""
 
@@ -36998,7 +36993,7 @@ msgstr ""
 msgid "Please enable {0} in the {1}."
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:754
+#: erpnext/controllers/selling_controller.py:762
 msgid "Please enable {} in {} to allow same item in multiple rows"
 msgstr ""
 
@@ -37031,7 +37026,7 @@ msgstr ""
 msgid "Please enter Approving Role or Approving User"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:939
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:935
 msgid "Please enter Cost Center"
 msgstr ""
 
@@ -37043,7 +37038,7 @@ msgstr ""
 msgid "Please enter Employee Id of this sales person"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:948
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:944
 msgid "Please enter Expense Account"
 msgstr ""
 
@@ -37052,7 +37047,7 @@ msgstr ""
 msgid "Please enter Item Code to get Batch Number"
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2503
+#: erpnext/public/js/controllers/transaction.js:2529
 msgid "Please enter Item Code to get batch no"
 msgstr ""
 
@@ -37117,7 +37112,7 @@ msgstr ""
 msgid "Please enter company name first"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2764
+#: erpnext/controllers/accounts_controller.py:2767
 msgid "Please enter default currency in Company Master"
 msgstr ""
 
@@ -37153,7 +37148,7 @@ msgstr ""
 msgid "Please enter the phone number first"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:1007
+#: erpnext/controllers/buying_controller.py:1015
 msgid "Please enter the {schedule_date}."
 msgstr ""
 
@@ -37255,7 +37250,7 @@ msgstr ""
 msgid "Please select <b>Template Type</b> to download template"
 msgstr ""
 
-#: erpnext/controllers/taxes_and_totals.py:721
+#: erpnext/controllers/taxes_and_totals.py:731
 #: erpnext/public/js/controllers/taxes_and_totals.js:721
 msgid "Please select Apply Discount On"
 msgstr ""
@@ -37268,7 +37263,7 @@ msgstr ""
 msgid "Please select BOM for Item in Row {0}"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:467
+#: erpnext/controllers/buying_controller.py:475
 msgid "Please select BOM in BOM field for Item {item_code}."
 msgstr ""
 
@@ -37350,7 +37345,7 @@ msgstr ""
 msgid "Please select Qty against item {0}"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:320
+#: erpnext/stock/doctype/item/item.py:323
 msgid "Please select Sample Retention Warehouse in Stock Settings first"
 msgstr ""
 
@@ -37366,7 +37361,7 @@ msgstr ""
 msgid "Please select Subcontracting Order instead of Purchase Order {0}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2613
+#: erpnext/controllers/accounts_controller.py:2616
 msgid "Please select Unrealized Profit / Loss account or add default Unrealized Profit / Loss account account for company {0}"
 msgstr ""
 
@@ -37382,7 +37377,7 @@ msgstr ""
 #: erpnext/manufacturing/doctype/bom/bom.js:603
 #: erpnext/manufacturing/doctype/bom/bom.py:261
 #: erpnext/public/js/controllers/accounts.js:249
-#: erpnext/public/js/controllers/transaction.js:2753
+#: erpnext/public/js/controllers/transaction.js:2779
 msgid "Please select a Company first."
 msgstr ""
 
@@ -37540,7 +37535,7 @@ msgstr ""
 msgid "Please select {0} first"
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:77
+#: erpnext/public/js/controllers/transaction.js:100
 msgid "Please set 'Apply Additional Discount On'"
 msgstr ""
 
@@ -37725,7 +37720,7 @@ msgstr ""
 msgid "Please set filters"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2194
+#: erpnext/controllers/accounts_controller.py:2197
 msgid "Please set one of the following:"
 msgstr ""
 
@@ -37733,7 +37728,7 @@ msgstr ""
 msgid "Please set opening number of booked depreciations"
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2205
+#: erpnext/public/js/controllers/transaction.js:2231
 msgid "Please set recurring after saving"
 msgstr ""
 
@@ -37804,7 +37799,7 @@ msgstr ""
 msgid "Please share this email with your support team so that they can find and fix the issue."
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2073
+#: erpnext/public/js/controllers/transaction.js:2099
 msgid "Please specify"
 msgstr ""
 
@@ -37819,7 +37814,7 @@ msgid "Please specify Company to proceed"
 msgstr ""
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1472
-#: erpnext/controllers/accounts_controller.py:2957
+#: erpnext/controllers/accounts_controller.py:2960
 #: erpnext/public/js/controllers/accounts.js:97
 msgid "Please specify a valid Row ID for row {0} in table {1}"
 msgstr ""
@@ -37832,7 +37827,7 @@ msgstr ""
 msgid "Please specify at least one attribute in the Attributes table"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:605
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:601
 msgid "Please specify either Quantity or Valuation Rate or both"
 msgstr ""
 
@@ -38013,7 +38008,7 @@ msgstr ""
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:16
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:15
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:18
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1046
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1048
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:15
 #: erpnext/accounts/report/bank_clearance_summary/bank_clearance_summary.py:35
 #: erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.html:7
@@ -40194,7 +40189,7 @@ msgstr ""
 #: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.js:48
 #: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:203
 #: erpnext/buying/workspace/buying/buying.json
-#: erpnext/controllers/buying_controller.py:739
+#: erpnext/controllers/buying_controller.py:747
 #: erpnext/crm/doctype/contract/contract.json
 #: erpnext/manufacturing/doctype/blanket_order/blanket_order.js:54
 #: erpnext/manufacturing/doctype/production_plan_sub_assembly_item/production_plan_sub_assembly_item.json
@@ -40333,7 +40328,7 @@ msgstr ""
 msgid "Purchase Orders to Receive"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1833
+#: erpnext/controllers/accounts_controller.py:1836
 msgid "Purchase Orders {0} are un-linked"
 msgstr ""
 
@@ -40357,8 +40352,8 @@ msgstr ""
 #. Label of a Link in the Stock Workspace
 #. Label of a shortcut in the Stock Workspace
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:171
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:650
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:660
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:652
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:662
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice_list.js:49
 #: erpnext/accounts/doctype/purchase_invoice_item/purchase_invoice_item.json
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:246
@@ -41093,7 +41088,7 @@ msgstr ""
 msgid "Quality Inspection Template Name"
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:334
+#: erpnext/public/js/controllers/transaction.js:360
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:165
 msgid "Quality Inspection(s)"
 msgstr ""
@@ -42277,7 +42272,7 @@ msgid "Receivable / Payable Account"
 msgstr ""
 
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:71
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1061
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1063
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py:243
 #: erpnext/accounts/report/sales_register/sales_register.py:217
 #: erpnext/accounts/report/sales_register/sales_register.py:271
@@ -42759,7 +42754,7 @@ msgstr ""
 msgid "Reference Date"
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2311
+#: erpnext/public/js/controllers/transaction.js:2337
 msgid "Reference Date for Early Payment Discount"
 msgstr ""
 
@@ -43083,7 +43078,7 @@ msgstr ""
 msgid "Rejected"
 msgstr ""
 
-#: erpnext/stock/doctype/inventory_dimension/inventory_dimension.py:202
+#: erpnext/stock/doctype/inventory_dimension/inventory_dimension.py:203
 msgid "Rejected "
 msgstr ""
 
@@ -43187,7 +43182,7 @@ msgstr ""
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:187
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:156
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1135
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1137
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:178
 msgid "Remaining Balance"
 msgstr ""
@@ -43240,7 +43235,7 @@ msgstr ""
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:159
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:198
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:269
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1167
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1169
 #: erpnext/accounts/report/general_ledger/general_ledger.html:84
 #: erpnext/accounts/report/general_ledger/general_ledger.html:110
 #: erpnext/accounts/report/general_ledger/general_ledger.py:742
@@ -43990,7 +43985,7 @@ msgstr ""
 msgid "Reserved Quantity for Production"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:2147
+#: erpnext/stock/stock_ledger.py:2155
 msgid "Reserved Serial No."
 msgstr ""
 
@@ -44006,11 +44001,11 @@ msgstr ""
 #: erpnext/stock/doctype/pick_list/pick_list.js:153
 #: erpnext/stock/report/reserved_stock/reserved_stock.json
 #: erpnext/stock/report/stock_balance/stock_balance.py:499
-#: erpnext/stock/stock_ledger.py:2131
+#: erpnext/stock/stock_ledger.py:2139
 msgid "Reserved Stock"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:2177
+#: erpnext/stock/stock_ledger.py:2185
 msgid "Reserved Stock for Batch"
 msgstr ""
 
@@ -44022,7 +44017,7 @@ msgstr ""
 msgid "Reserved Stock for Sub-assembly"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:476
+#: erpnext/controllers/buying_controller.py:484
 msgid "Reserved Warehouse is mandatory for the Item {item_code} in Raw Materials supplied."
 msgstr ""
 
@@ -44836,7 +44831,7 @@ msgstr ""
 msgid "Routing Name"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:667
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:663
 msgid "Row #"
 msgstr ""
 
@@ -44874,7 +44869,7 @@ msgstr ""
 msgid "Row #{0} (Payment Table): Amount must be positive"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:495
+#: erpnext/stock/doctype/item/item.py:498
 msgid "Row #{0}: A reorder entry already exists for warehouse {1} with reorder type {2}."
 msgstr ""
 
@@ -44895,7 +44890,7 @@ msgstr ""
 msgid "Row #{0}: Accepted Warehouse is mandatory for the accepted Item {1}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1117
+#: erpnext/controllers/accounts_controller.py:1120
 msgid "Row #{0}: Account {1} does not belong to company {2}"
 msgstr ""
 
@@ -44936,27 +44931,27 @@ msgstr ""
 msgid "Row #{0}: Cannot allocate more than {1} against payment term {2}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3524
+#: erpnext/controllers/accounts_controller.py:3527
 msgid "Row #{0}: Cannot delete item {1} which has already been billed."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3498
+#: erpnext/controllers/accounts_controller.py:3501
 msgid "Row #{0}: Cannot delete item {1} which has already been delivered"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3517
+#: erpnext/controllers/accounts_controller.py:3520
 msgid "Row #{0}: Cannot delete item {1} which has already been received"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3504
+#: erpnext/controllers/accounts_controller.py:3507
 msgid "Row #{0}: Cannot delete item {1} which has work order assigned to it."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3510
+#: erpnext/controllers/accounts_controller.py:3513
 msgid "Row #{0}: Cannot delete item {1} which is assigned to customer's purchase order."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3765
+#: erpnext/controllers/accounts_controller.py:3768
 msgid "Row #{0}: Cannot set Rate if the billed amount is greater than the amount for Item {1}."
 msgstr ""
 
@@ -45076,7 +45071,7 @@ msgstr ""
 msgid "Row #{0}: Item {1} has been picked, please reserve stock from the Pick List."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:729
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:725
 msgid "Row #{0}: Item {1} is not a Serialized/Batched Item. It cannot have a Serial No/Batch No against it."
 msgstr ""
 
@@ -45132,7 +45127,7 @@ msgstr ""
 msgid "Row #{0}: Please select the Sub Assembly Warehouse"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:502
+#: erpnext/stock/doctype/item/item.py:505
 msgid "Row #{0}: Please set reorder quantity"
 msgstr ""
 
@@ -45165,8 +45160,8 @@ msgstr ""
 msgid "Row #{0}: Quality Inspection {1} was rejected for item {2}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1274
-#: erpnext/controllers/accounts_controller.py:3624
+#: erpnext/controllers/accounts_controller.py:1277
+#: erpnext/controllers/accounts_controller.py:3627
 msgid "Row #{0}: Quantity for Item {1} cannot be zero."
 msgstr ""
 
@@ -45203,7 +45198,7 @@ msgstr ""
 msgid "Row #{0}: Scrap Item Qty cannot be zero"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:230
+#: erpnext/controllers/selling_controller.py:238
 msgid ""
 "Row #{0}: Selling rate for item {1} is lower than its {2}.\n"
 "\t\t\t\t\tSelling {3} should be atleast {4}.<br><br>Alternatively,\n"
@@ -45288,7 +45283,7 @@ msgstr ""
 msgid "Row #{0}: The batch {1} has already expired."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:511
+#: erpnext/stock/doctype/item/item.py:514
 msgid "Row #{0}: The warehouse {1} is not a child warehouse of a group warehouse {2}"
 msgstr ""
 
@@ -45328,39 +45323,39 @@ msgstr ""
 msgid "Row #{1}: Warehouse is mandatory for stock Item {0}"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:259
+#: erpnext/controllers/buying_controller.py:267
 msgid "Row #{idx}: Cannot select Supplier Warehouse while suppling raw materials to subcontractor."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:406
+#: erpnext/controllers/buying_controller.py:414
 msgid "Row #{idx}: Item rate has been updated as per valuation rate since its an internal stock transfer."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:881
+#: erpnext/controllers/buying_controller.py:889
 msgid "Row #{idx}: Please enter a location for the asset item {item_code}."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:537
+#: erpnext/controllers/buying_controller.py:545
 msgid "Row #{idx}: Received Qty must be equal to Accepted + Rejected Qty for Item {item_code}."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:550
+#: erpnext/controllers/buying_controller.py:558
 msgid "Row #{idx}: {field_label} can not be negative for item {item_code}."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:496
+#: erpnext/controllers/buying_controller.py:504
 msgid "Row #{idx}: {field_label} is mandatory."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:518
+#: erpnext/controllers/buying_controller.py:526
 msgid "Row #{idx}: {field_label} is not allowed in Purchase Return."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:250
+#: erpnext/controllers/buying_controller.py:258
 msgid "Row #{idx}: {from_warehouse_field} and {to_warehouse_field} cannot be same."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:999
+#: erpnext/controllers/buying_controller.py:1007
 msgid "Row #{idx}: {schedule_date} cannot be before {transaction_date}."
 msgstr ""
 
@@ -45425,7 +45420,7 @@ msgstr ""
 msgid "Row #{}: {} {} does not exist."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1403
+#: erpnext/stock/doctype/item/item.py:1397
 msgid "Row #{}: {} {} doesn't belong to Company {}. Please select valid {}."
 msgstr ""
 
@@ -45497,11 +45492,11 @@ msgstr ""
 msgid "Row {0}: Both Debit and Credit values cannot be zero"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:222
+#: erpnext/controllers/selling_controller.py:230
 msgid "Row {0}: Conversion Factor is mandatory"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2995
+#: erpnext/controllers/accounts_controller.py:2998
 msgid "Row {0}: Cost Center {1} does not belong to Company {2}"
 msgstr ""
 
@@ -45521,11 +45516,11 @@ msgstr ""
 msgid "Row {0}: Debit entry can not be linked with a {1}"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:776
+#: erpnext/controllers/selling_controller.py:784
 msgid "Row {0}: Delivery Warehouse ({1}) and Customer Warehouse ({2}) can not be same"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2529
+#: erpnext/controllers/accounts_controller.py:2532
 msgid "Row {0}: Due Date in the Payment Terms table cannot be before Posting Date"
 msgstr ""
 
@@ -45534,7 +45529,7 @@ msgid "Row {0}: Either Delivery Note Item or Packed Item reference is mandatory.
 msgstr ""
 
 #: erpnext/accounts/doctype/journal_entry/journal_entry.py:1010
-#: erpnext/controllers/taxes_and_totals.py:1205
+#: erpnext/controllers/taxes_and_totals.py:1215
 msgid "Row {0}: Exchange Rate is mandatory"
 msgstr ""
 
@@ -45583,11 +45578,11 @@ msgstr ""
 msgid "Row {0}: Invalid reference {1}"
 msgstr ""
 
-#: erpnext/controllers/taxes_and_totals.py:142
+#: erpnext/controllers/taxes_and_totals.py:143
 msgid "Row {0}: Item Tax template updated as per validity and rate applied"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:541
+#: erpnext/controllers/selling_controller.py:549
 msgid "Row {0}: Item rate has been updated as per valuation rate since its an internal stock transfer"
 msgstr ""
 
@@ -45707,7 +45702,7 @@ msgstr ""
 msgid "Row {0}: The item {1}, quantity must be positive number"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2972
+#: erpnext/controllers/accounts_controller.py:2975
 msgid "Row {0}: The {3} Account {1} does not belong to the company {2}"
 msgstr ""
 
@@ -45724,7 +45719,7 @@ msgstr ""
 msgid "Row {0}: Workstation or Workstation Type is mandatory for an operation {1}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1011
+#: erpnext/controllers/accounts_controller.py:1014
 msgid "Row {0}: user has not applied the rule {1} on the item {2}"
 msgstr ""
 
@@ -45736,7 +45731,7 @@ msgstr ""
 msgid "Row {0}: {1} must be greater than 0"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:706
+#: erpnext/controllers/accounts_controller.py:709
 msgid "Row {0}: {1} {2} cannot be same as {3} (Party Account) {4}"
 msgstr ""
 
@@ -45752,7 +45747,7 @@ msgstr ""
 msgid "Row {1}: Quantity ({0}) cannot be a fraction. To allow this, disable '{2}' in UOM {3}."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:863
+#: erpnext/controllers/buying_controller.py:871
 msgid "Row {idx}: Asset Naming Series is mandatory for the auto creation of assets for item {item_code}."
 msgstr ""
 
@@ -45778,7 +45773,7 @@ msgstr ""
 msgid "Rows with Same Account heads will be merged on Ledger"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2539
+#: erpnext/controllers/accounts_controller.py:2542
 msgid "Rows with duplicate due dates in other rows were found: {0}"
 msgstr ""
 
@@ -45848,7 +45843,7 @@ msgstr ""
 msgid "SLA Paused On"
 msgstr ""
 
-#: erpnext/public/js/utils.js:1167
+#: erpnext/public/js/utils.js:1163
 msgid "SLA is on hold since {0}"
 msgstr ""
 
@@ -46249,7 +46244,7 @@ msgstr ""
 #: erpnext/accounts/report/sales_register/sales_register.py:238
 #: erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
 #: erpnext/buying/doctype/supplier_quotation_item/supplier_quotation_item.json
-#: erpnext/controllers/selling_controller.py:462
+#: erpnext/controllers/selling_controller.py:470
 #: erpnext/crm/doctype/contract/contract.json
 #: erpnext/maintenance/doctype/maintenance_schedule/maintenance_schedule.js:65
 #: erpnext/maintenance/doctype/maintenance_schedule_item/maintenance_schedule_item.json
@@ -46375,7 +46370,7 @@ msgstr ""
 msgid "Sales Order {0} is not valid"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:443
+#: erpnext/controllers/selling_controller.py:451
 #: erpnext/manufacturing/doctype/work_order/work_order.py:301
 msgid "Sales Order {0} is {1}"
 msgstr ""
@@ -46426,7 +46421,7 @@ msgstr ""
 #: erpnext/accounts/doctype/promotional_scheme/promotional_scheme.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:122
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1156
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1158
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:99
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:194
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:74
@@ -46524,7 +46519,7 @@ msgstr ""
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:156
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:137
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:128
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1153
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1155
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:105
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:191
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:80
@@ -46544,7 +46539,7 @@ msgstr ""
 msgid "Sales Person"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:204
+#: erpnext/controllers/selling_controller.py:212
 msgid "Sales Person <b>{0}</b> is disabled."
 msgstr ""
 
@@ -46825,7 +46820,7 @@ msgstr ""
 
 #. Label of the sample_size (Float) field in DocType 'Quality Inspection'
 #: erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py:93
-#: erpnext/public/js/controllers/transaction.js:2369
+#: erpnext/public/js/controllers/transaction.js:2395
 #: erpnext/stock/doctype/quality_inspection/quality_inspection.json
 msgid "Sample Size"
 msgstr ""
@@ -47364,7 +47359,7 @@ msgstr ""
 msgid "Select Items based on Delivery Date"
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2405
+#: erpnext/public/js/controllers/transaction.js:2431
 msgid "Select Items for Quality Inspection"
 msgstr ""
 
@@ -47505,7 +47500,7 @@ msgstr ""
 msgid "Select company name first."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2785
+#: erpnext/controllers/accounts_controller.py:2788
 msgid "Select finance book for the item {0} at row {1}"
 msgstr ""
 
@@ -47719,7 +47714,7 @@ msgid "Send Now"
 msgstr ""
 
 #. Label of the send_sms (Button) field in DocType 'SMS Center'
-#: erpnext/public/js/controllers/transaction.js:517
+#: erpnext/public/js/controllers/transaction.js:543
 #: erpnext/selling/doctype/sms_center/sms_center.json
 msgid "Send SMS"
 msgstr ""
@@ -47877,7 +47872,7 @@ msgstr ""
 #: erpnext/manufacturing/doctype/job_card/job_card.json
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.js:74
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.py:114
-#: erpnext/public/js/controllers/transaction.js:2382
+#: erpnext/public/js/controllers/transaction.js:2408
 #: erpnext/public/js/utils/serial_no_batch_selector.js:421
 #: erpnext/selling/doctype/installation_note_item/installation_note_item.json
 #: erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
@@ -47926,7 +47921,7 @@ msgstr ""
 msgid "Serial No Range"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1894
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1895
 msgid "Serial No Reserved"
 msgstr ""
 
@@ -47966,7 +47961,7 @@ msgstr ""
 msgid "Serial No and Batch Selector cannot be use when Use Serial / Batch Fields is enabled."
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:859
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:860
 msgid "Serial No is mandatory"
 msgstr ""
 
@@ -47995,7 +47990,7 @@ msgstr ""
 msgid "Serial No {0} does not exist"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2623
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2624
 msgid "Serial No {0} does not exists"
 msgstr ""
 
@@ -48003,7 +47998,7 @@ msgstr ""
 msgid "Serial No {0} is already added"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:357
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:358
 msgid "Serial No {0} is not present in the {1} {2}, hence you can't return it against the {1} {2}"
 msgstr ""
 
@@ -48040,11 +48035,11 @@ msgstr ""
 msgid "Serial Nos and Batches"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1370
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1371
 msgid "Serial Nos are created successfully"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:2137
+#: erpnext/stock/stock_ledger.py:2145
 msgid "Serial Nos are reserved in Stock Reservation Entries, you need to unreserve them before proceeding."
 msgstr ""
 
@@ -48118,11 +48113,11 @@ msgstr ""
 msgid "Serial and Batch Bundle"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1598
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1599
 msgid "Serial and Batch Bundle created"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1664
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1665
 msgid "Serial and Batch Bundle updated"
 msgstr ""
 
@@ -48474,12 +48469,12 @@ msgid "Service Stop Date"
 msgstr ""
 
 #: erpnext/accounts/deferred_revenue.py:44
-#: erpnext/public/js/controllers/transaction.js:1420
+#: erpnext/public/js/controllers/transaction.js:1446
 msgid "Service Stop Date cannot be after Service End Date"
 msgstr ""
 
 #: erpnext/accounts/deferred_revenue.py:41
-#: erpnext/public/js/controllers/transaction.js:1417
+#: erpnext/public/js/controllers/transaction.js:1443
 msgid "Service Stop Date cannot be before Service Start Date"
 msgstr ""
 
@@ -49915,7 +49910,7 @@ msgstr ""
 
 #: erpnext/setup/setup_wizard/operations/defaults_setup.py:70
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:463
-#: erpnext/stock/doctype/item/item.py:245
+#: erpnext/stock/doctype/item/item.py:248
 msgid "Standard Selling"
 msgstr ""
 
@@ -50745,7 +50740,7 @@ msgstr ""
 #. Option for the 'Purpose' (Select) field in DocType 'Stock Reconciliation'
 #. Label of a Link in the Stock Workspace
 #: erpnext/setup/workspace/home/home.json
-#: erpnext/stock/doctype/item/item.py:612
+#: erpnext/stock/doctype/item/item.py:618
 #: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.json
 #: erpnext/stock/workspace/stock/stock.json
 msgid "Stock Reconciliation"
@@ -50756,7 +50751,7 @@ msgstr ""
 msgid "Stock Reconciliation Item"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:612
+#: erpnext/stock/doctype/item/item.py:618
 msgid "Stock Reconciliations"
 msgstr ""
 
@@ -50791,7 +50786,7 @@ msgstr ""
 #: erpnext/stock/doctype/pick_list/pick_list.js:150
 #: erpnext/stock/doctype/pick_list/pick_list.js:155
 #: erpnext/stock/doctype/stock_entry/stock_entry_dashboard.py:25
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:706
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:702
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:575
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:1138
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:1398
@@ -51191,7 +51186,7 @@ msgstr ""
 #: erpnext/setup/doctype/company/company.py:287
 #: erpnext/setup/setup_wizard/operations/defaults_setup.py:33
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:502
-#: erpnext/stock/doctype/item/item.py:282
+#: erpnext/stock/doctype/item/item.py:285
 msgid "Stores"
 msgstr ""
 
@@ -51726,7 +51721,7 @@ msgstr ""
 msgid "Successfully Set Supplier"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:339
+#: erpnext/stock/doctype/item/item.py:342
 msgid "Successfully changed Stock UOM, please redefine conversion factors for new UOM."
 msgstr ""
 
@@ -52028,7 +52023,7 @@ msgstr ""
 #: erpnext/accounts/doctype/tax_rule/tax_rule.json
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:111
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:87
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1160
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1162
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:198
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:237
 #: erpnext/accounts/report/purchase_register/purchase_register.js:27
@@ -52128,7 +52123,7 @@ msgstr ""
 #. Label of the supplier_name (Data) field in DocType 'Purchase Receipt'
 #. Label of the supplier_name (Data) field in DocType 'Stock Entry'
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1077
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1079
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:156
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:198
 #: erpnext/accounts/report/purchase_register/purchase_register.py:177
@@ -52612,7 +52607,7 @@ msgstr ""
 msgid "System will fetch all the entries if limit value is zero."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1975
+#: erpnext/controllers/accounts_controller.py:1978
 msgid "System will not check over billing since amount for Item {0} in {1} is zero"
 msgstr ""
 
@@ -52871,7 +52866,7 @@ msgstr ""
 msgid "Target Warehouse is required before Submit"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:782
+#: erpnext/controllers/selling_controller.py:790
 msgid "Target Warehouse is set for some items but the customer is not an internal customer."
 msgstr ""
 
@@ -53110,7 +53105,7 @@ msgstr ""
 msgid "Tax Category"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:194
+#: erpnext/controllers/buying_controller.py:202
 msgid "Tax Category has been changed to \"Total\" because all the Items are non-stock items"
 msgstr ""
 
@@ -53316,7 +53311,7 @@ msgstr ""
 #. Label of the taxable_amount (Currency) field in DocType 'Tax Withheld
 #. Vouchers'
 #: erpnext/accounts/doctype/tax_withheld_vouchers/tax_withheld_vouchers.json
-#: erpnext/controllers/taxes_and_totals.py:1125
+#: erpnext/controllers/taxes_and_totals.py:1135
 msgid "Taxable Amount"
 msgstr ""
 
@@ -53455,7 +53450,7 @@ msgstr ""
 msgid "Taxes and Charges Deducted (Company Currency)"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:352
+#: erpnext/stock/doctype/item/item.py:355
 msgid "Taxes row #{0}: {1} cannot be smaller than {2}"
 msgstr ""
 
@@ -53741,7 +53736,7 @@ msgstr ""
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/territory_item/territory_item.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:134
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1144
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1146
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:93
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:182
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:68
@@ -53845,7 +53840,7 @@ msgstr ""
 msgid "The BOM which will be replaced"
 msgstr ""
 
-#: erpnext/stock/serial_batch_bundle.py:1274
+#: erpnext/stock/serial_batch_bundle.py:1306
 msgid "The Batch {0} has negative quantity {1} in warehouse {2}. Please correct the quantity."
 msgstr ""
 
@@ -53897,7 +53892,7 @@ msgstr ""
 msgid "The Serial No at Row #{0}: {1} is not available in warehouse {2}."
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1891
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1892
 msgid "The Serial No {0} is reserved against the {1} {2} and cannot be used for any other transaction."
 msgstr ""
 
@@ -53980,7 +53975,7 @@ msgstr ""
 msgid "The following batches are expired, please restock them: <br> {0}"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:849
+#: erpnext/stock/doctype/item/item.py:843
 msgid "The following deleted attributes exist in Variants but not in the Template. You can either delete the Variants or keep the attribute(s) in template."
 msgstr ""
 
@@ -54005,15 +54000,15 @@ msgstr ""
 msgid "The holiday on {0} is not between From Date and To Date"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:1066
+#: erpnext/controllers/buying_controller.py:1074
 msgid "The item {item} is not marked as {type_of} item. You can enable it as {type_of} item from its Item master."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:614
+#: erpnext/stock/doctype/item/item.py:620
 msgid "The items {0} and {1} are present in the following {2} :"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:1059
+#: erpnext/controllers/buying_controller.py:1067
 msgid "The items {items} are not marked as {type_of} item. You can enable them as {type_of} item from their Item masters."
 msgstr ""
 
@@ -54115,8 +54110,8 @@ msgstr ""
 msgid "The seller and the buyer cannot be the same"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:142
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:154
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:143
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:155
 msgid "The serial and batch bundle {0} not linked to {1} {2}"
 msgstr ""
 
@@ -54140,7 +54135,7 @@ msgstr ""
 msgid "The stock for the item {0} in the {1} warehouse was negative on the {2}. You should create a positive entry {3} before the date {4} and time {5} to post the correct valuation rate. For more details, please read the <a href='https://docs.erpnext.com/docs/user/manual/en/stock-adjustment-cogs-with-negative-stock'>documentation<a>."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:700
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:696
 msgid "The stock has been reserved for the following Items and Warehouses, un-reserve the same to {0} the Stock Reconciliation: <br /><br /> {1}"
 msgstr ""
 
@@ -54153,11 +54148,11 @@ msgstr ""
 msgid "The task has been enqueued as a background job."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:994
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:990
 msgid "The task has been enqueued as a background job. In case there is any issue on processing in background, the system will add a comment about the error on this Stock Reconciliation and revert to the Draft stage"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1005
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1001
 msgid "The task has been enqueued as a background job. In case there is any issue on processing in background, the system will add a comment about the error on this Stock Reconciliation and revert to the Submitted stage"
 msgstr ""
 
@@ -54207,7 +54202,7 @@ msgstr ""
 msgid "The {0} ({1}) must be equal to {2} ({3})"
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2790
+#: erpnext/public/js/controllers/transaction.js:2816
 msgid "The {0} contains Unit Price Items."
 msgstr ""
 
@@ -54255,7 +54250,7 @@ msgstr ""
 msgid "There can be multiple tiered collection factor based on the total spent. But the conversion factor for redemption will always be same for all the tier."
 msgstr ""
 
-#: erpnext/accounts/party.py:580
+#: erpnext/accounts/party.py:586
 msgid "There can only be 1 Account per Company in {0} {1}"
 msgstr ""
 
@@ -54541,7 +54536,7 @@ msgstr ""
 msgid "This will restrict user access to other employee records"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:783
+#: erpnext/controllers/selling_controller.py:791
 msgid "This {} will be treated as material transfer."
 msgstr ""
 
@@ -55255,11 +55250,11 @@ msgid "To include sub-assembly costs and scrap items in Finished Goods on a work
 msgstr ""
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:2337
-#: erpnext/controllers/accounts_controller.py:3005
+#: erpnext/controllers/accounts_controller.py:3008
 msgid "To include tax in row {0} in Item rate, taxes in rows {1} must also be included"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:636
+#: erpnext/stock/doctype/item/item.py:642
 msgid "To merge, following properties must be same for both items"
 msgstr ""
 
@@ -55879,7 +55874,7 @@ msgstr ""
 msgid "Total Paid Amount"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2591
+#: erpnext/controllers/accounts_controller.py:2594
 msgid "Total Payment Amount in Payment Schedule must be equal to Grand / Rounded Total"
 msgstr ""
 
@@ -56164,15 +56159,15 @@ msgstr ""
 msgid "Total Working Hours"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2138
+#: erpnext/controllers/accounts_controller.py:2141
 msgid "Total advance ({0}) against Order {1} cannot be greater than the Grand Total ({2})"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:190
+#: erpnext/controllers/selling_controller.py:198
 msgid "Total allocated percentage for sales team should be 100"
 msgstr ""
 
-#: erpnext/selling/doctype/customer/customer.py:162
+#: erpnext/selling/doctype/customer/customer.py:161
 msgid "Total contribution percentage should be equal to 100"
 msgstr ""
 
@@ -57057,7 +57052,7 @@ msgstr ""
 msgid "Unit of Measure (UOM)"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:384
+#: erpnext/stock/doctype/item/item.py:387
 msgid "Unit of Measure {0} has been entered more than once in Conversion Factor Table"
 msgstr ""
 
@@ -57499,7 +57494,7 @@ msgstr ""
 msgid "Update timestamp on new communication"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom_creator/bom_creator.py:533
+#: erpnext/manufacturing/doctype/bom_creator/bom_creator.py:534
 msgid "Updated successfully"
 msgstr ""
 
@@ -57513,7 +57508,7 @@ msgstr ""
 msgid "Updated via 'Time Log' (In Minutes)"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1387
+#: erpnext/stock/doctype/item/item.py:1381
 msgid "Updating Variants..."
 msgstr ""
 
@@ -58071,19 +58066,19 @@ msgstr ""
 msgid "Valuation Rate (In / Out)"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1881
+#: erpnext/stock/stock_ledger.py:1890
 msgid "Valuation Rate Missing"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1859
+#: erpnext/stock/stock_ledger.py:1868
 msgid "Valuation Rate for the Item {0}, is required to do accounting entries for {1} {2}."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:266
+#: erpnext/stock/doctype/item/item.py:269
 msgid "Valuation Rate is mandatory if Opening Stock entered"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:752
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:748
 msgid "Valuation Rate required for Item {0} at row {1}"
 msgstr ""
 
@@ -58093,7 +58088,7 @@ msgstr ""
 msgid "Valuation and Total"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:971
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:967
 msgid "Valuation rate for customer provided items has been set to zero."
 msgstr ""
 
@@ -58107,7 +58102,7 @@ msgid "Valuation rate for the item as per Sales Invoice (Only for Internal Trans
 msgstr ""
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:2361
-#: erpnext/controllers/accounts_controller.py:3029
+#: erpnext/controllers/accounts_controller.py:3032
 msgid "Valuation type charges can not be marked as Inclusive"
 msgstr ""
 
@@ -58263,7 +58258,7 @@ msgstr ""
 msgid "Variant"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:864
+#: erpnext/stock/doctype/item/item.py:858
 msgid "Variant Attribute Error"
 msgstr ""
 
@@ -58282,7 +58277,7 @@ msgstr ""
 msgid "Variant Based On"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:892
+#: erpnext/stock/doctype/item/item.py:886
 msgid "Variant Based On cannot be changed"
 msgstr ""
 
@@ -58300,7 +58295,7 @@ msgstr ""
 msgid "Variant Item"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:862
+#: erpnext/stock/doctype/item/item.py:856
 msgid "Variant Items"
 msgstr ""
 
@@ -58418,7 +58413,7 @@ msgstr ""
 #: erpnext/accounts/doctype/cost_center/cost_center_tree.js:56
 #: erpnext/accounts/doctype/invoice_discounting/invoice_discounting.js:205
 #: erpnext/accounts/doctype/journal_entry/journal_entry.js:43
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:668
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:670
 #: erpnext/bulk_transaction/doctype/bulk_transaction_log/bulk_transaction_log.js:14
 #: erpnext/bulk_transaction/doctype/bulk_transaction_log/bulk_transaction_log.js:24
 #: erpnext/buying/doctype/request_for_quotation/request_for_quotation.js:167
@@ -58605,7 +58600,7 @@ msgstr ""
 #: erpnext/accounts/doctype/repost_accounting_ledger_items/repost_accounting_ledger_items.json
 #: erpnext/accounts/doctype/repost_payment_ledger_items/repost_payment_ledger_items.json
 #: erpnext/accounts/doctype/unreconcile_payment/unreconcile_payment.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1099
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1101
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.js:42
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:209
 #: erpnext/accounts/report/general_ledger/general_ledger.js:49
@@ -58636,7 +58631,7 @@ msgstr ""
 msgid "Voucher No"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1087
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1088
 msgid "Voucher No is mandatory"
 msgstr ""
 
@@ -58678,7 +58673,7 @@ msgstr ""
 #: erpnext/accounts/doctype/repost_payment_ledger_items/repost_payment_ledger_items.json
 #: erpnext/accounts/doctype/tax_withheld_vouchers/tax_withheld_vouchers.json
 #: erpnext/accounts/doctype/unreconcile_payment/unreconcile_payment.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1097
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1099
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:200
 #: erpnext/accounts/report/general_ledger/general_ledger.py:697
 #: erpnext/accounts/report/invalid_ledger_entries/invalid_ledger_entries.py:31
@@ -59032,10 +59027,6 @@ msgstr ""
 msgid "Warehouse not found against the account {0}"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:600
-msgid "Warehouse not found in the system"
-msgstr ""
-
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:1130
 #: erpnext/stock/doctype/delivery_note/delivery_note.py:414
 msgid "Warehouse required for stock Item {0}"
@@ -59164,7 +59155,7 @@ msgid "Warn for new Request for Quotations"
 msgstr ""
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:744
-#: erpnext/controllers/accounts_controller.py:1978
+#: erpnext/controllers/accounts_controller.py:1981
 #: erpnext/stock/doctype/delivery_trip/delivery_trip.js:145
 #: erpnext/utilities/transaction_base.py:123
 msgid "Warning"
@@ -60136,7 +60127,7 @@ msgstr ""
 msgid "You are importing data for the code list:"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3611
+#: erpnext/controllers/accounts_controller.py:3614
 msgid "You are not allowed to update as per the conditions set in {} Workflow."
 msgstr ""
 
@@ -60201,7 +60192,7 @@ msgstr ""
 msgid "You can't make any changes to Job Card since Work Order is closed."
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:185
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:186
 msgid "You can't process the serial number {0} as it has already been used in the SABB {1}. {2} if you want to inward same serial number multiple times then enabled 'Allow existing Serial No to be Manufactured/Received again' in the {3}"
 msgstr ""
 
@@ -60261,7 +60252,7 @@ msgstr ""
 msgid "You cannot {0} this document because another Period Closing Entry {1} exists after {2}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3587
+#: erpnext/controllers/accounts_controller.py:3590
 msgid "You do not have permissions to {} items in a {}."
 msgstr ""
 
@@ -60289,7 +60280,7 @@ msgstr ""
 msgid "You have entered a duplicate Delivery Note on Row"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1063
+#: erpnext/stock/doctype/item/item.py:1057
 msgid "You have to enable auto re-order in Stock Settings to maintain re-order levels."
 msgstr ""
 
@@ -60309,7 +60300,7 @@ msgstr ""
 msgid "You need to cancel POS Closing Entry {} to be able to cancel this document."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2980
+#: erpnext/controllers/accounts_controller.py:2983
 msgid "You selected the account group {1} as {2} Account in row {0}. Please select a single account."
 msgstr ""
 
@@ -60387,7 +60378,7 @@ msgstr ""
 msgid "`Allow Negative rates for Items`"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1873
+#: erpnext/stock/stock_ledger.py:1882
 msgid "after"
 msgstr ""
 
@@ -60535,7 +60526,7 @@ msgstr ""
 msgid "material_request_item"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:151
+#: erpnext/controllers/selling_controller.py:159
 msgid "must be between 0 and 100"
 msgstr ""
 
@@ -60560,7 +60551,7 @@ msgstr ""
 msgid "on"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1289
+#: erpnext/controllers/accounts_controller.py:1292
 msgid "or"
 msgstr ""
 
@@ -60609,7 +60600,7 @@ msgstr ""
 msgid "per hour"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1874
+#: erpnext/stock/stock_ledger.py:1883
 msgid "performing either one below:"
 msgstr ""
 
@@ -60736,7 +60727,7 @@ msgstr ""
 msgid "{0}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1109
+#: erpnext/controllers/accounts_controller.py:1112
 msgid "{0} '{1}' is disabled"
 msgstr ""
 
@@ -60752,7 +60743,7 @@ msgstr ""
 msgid "{0} <b>{1}</b> has submitted Assets. Remove Item <b>{2}</b> from table to continue."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2193
+#: erpnext/controllers/accounts_controller.py:2196
 msgid "{0} Account not found against Customer {1}."
 msgstr ""
 
@@ -60784,7 +60775,7 @@ msgstr ""
 msgid "{0} Request for {1}"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:323
+#: erpnext/stock/doctype/item/item.py:326
 msgid "{0} Retain Sample is based on batch, please check Has Batch No to retain sample of item"
 msgstr ""
 
@@ -60875,7 +60866,7 @@ msgid "{0} entered twice in Item Tax"
 msgstr ""
 
 #: erpnext/setup/doctype/item_group/item_group.py:48
-#: erpnext/stock/doctype/item/item.py:436
+#: erpnext/stock/doctype/item/item.py:439
 msgid "{0} entered twice {1} in Item Taxes"
 msgstr ""
 
@@ -60896,7 +60887,7 @@ msgstr ""
 msgid "{0} hours"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2534
+#: erpnext/controllers/accounts_controller.py:2537
 msgid "{0} in row {1}"
 msgstr ""
 
@@ -60920,7 +60911,7 @@ msgstr ""
 
 #: erpnext/accounts/doctype/budget/budget.py:60
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:643
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:49
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:50
 #: erpnext/accounts/report/general_ledger/general_ledger.py:59
 #: erpnext/accounts/report/pos_register/pos_register.py:107
 #: erpnext/controllers/trends.py:50
@@ -60940,11 +60931,11 @@ msgstr ""
 msgid "{0} is mandatory. Maybe Currency Exchange record is not created for {1} to {2}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2937
+#: erpnext/controllers/accounts_controller.py:2940
 msgid "{0} is mandatory. Maybe Currency Exchange record is not created for {1} to {2}."
 msgstr ""
 
-#: erpnext/selling/doctype/customer/customer.py:204
+#: erpnext/selling/doctype/customer/customer.py:203
 msgid "{0} is not a company bank account"
 msgstr ""
 
@@ -61027,7 +61018,7 @@ msgstr ""
 msgid "{0} to {1}"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:690
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:686
 msgid "{0} units are reserved for Item {1} in Warehouse {2}, please un-reserve the same to {3} the Stock Reconciliation."
 msgstr ""
 
@@ -61043,16 +61034,16 @@ msgstr ""
 msgid "{0} units of {1} are required in {2} with the inventory dimension: {3} ({4}) on {5} {6} for {7} to complete the transaction."
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1532 erpnext/stock/stock_ledger.py:2023
-#: erpnext/stock/stock_ledger.py:2037
+#: erpnext/stock/stock_ledger.py:1541 erpnext/stock/stock_ledger.py:2031
+#: erpnext/stock/stock_ledger.py:2045
 msgid "{0} units of {1} needed in {2} on {3} {4} for {5} to complete this transaction."
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:2124 erpnext/stock/stock_ledger.py:2170
+#: erpnext/stock/stock_ledger.py:2132 erpnext/stock/stock_ledger.py:2178
 msgid "{0} units of {1} needed in {2} on {3} {4} to complete this transaction."
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1526
+#: erpnext/stock/stock_ledger.py:1535
 msgid "{0} units of {1} needed in {2} to complete this transaction."
 msgstr ""
 
@@ -61098,7 +61089,7 @@ msgstr ""
 msgid "{0} {1} does not exist"
 msgstr ""
 
-#: erpnext/accounts/party.py:560
+#: erpnext/accounts/party.py:566
 msgid "{0} {1} has accounting entries in currency {2} for company {3}. Please select a receivable or payable account with currency {2}."
 msgstr ""
 
@@ -61132,7 +61123,7 @@ msgstr ""
 msgid "{0} {1} is associated with {2}, but Party Account is {3}"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:462
+#: erpnext/controllers/selling_controller.py:470
 #: erpnext/controllers/subcontracting_controller.py:954
 msgid "{0} {1} is cancelled or closed"
 msgstr ""
@@ -61149,11 +61140,11 @@ msgstr ""
 msgid "{0} {1} is closed"
 msgstr ""
 
-#: erpnext/accounts/party.py:798
+#: erpnext/accounts/party.py:804
 msgid "{0} {1} is disabled"
 msgstr ""
 
-#: erpnext/accounts/party.py:804
+#: erpnext/accounts/party.py:810
 msgid "{0} {1} is frozen"
 msgstr ""
 
@@ -61161,7 +61152,7 @@ msgstr ""
 msgid "{0} {1} is fully billed"
 msgstr ""
 
-#: erpnext/accounts/party.py:808
+#: erpnext/accounts/party.py:814
 msgid "{0} {1} is not active"
 msgstr ""
 
@@ -61287,15 +61278,15 @@ msgstr ""
 msgid "{0}: {1} must be less than {2}"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:840
+#: erpnext/controllers/buying_controller.py:848
 msgid "{count} Assets created for {item_code}"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:738
+#: erpnext/controllers/buying_controller.py:746
 msgid "{doctype} {name} is cancelled or closed."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:459
+#: erpnext/controllers/buying_controller.py:467
 msgid "{field_label} is mandatory for sub-contracted {doctype}."
 msgstr ""
 
@@ -61303,7 +61294,7 @@ msgstr ""
 msgid "{item_name}'s Sample Size ({sample_size}) cannot be greater than the Accepted Quantity ({accepted_quantity})"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:563
+#: erpnext/controllers/buying_controller.py:571
 msgid "{ref_doctype} {ref_name} is {status}."
 msgstr ""
 
@@ -61369,7 +61360,7 @@ msgstr ""
 msgid "{} can't be cancelled since the Loyalty Points earned has been redeemed. First cancel the {} No {}"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:222
+#: erpnext/controllers/buying_controller.py:230
 msgid "{} has submitted assets linked to it. You need to cancel the assets to create purchase return."
 msgstr ""
 

--- a/erpnext/locale/pl.po
+++ b/erpnext/locale/pl.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: frappe\n"
 "Report-Msgid-Bugs-To: hello@frappe.io\n"
-"POT-Creation-Date: 2025-05-25 09:35+0000\n"
-"PO-Revision-Date: 2025-05-25 20:34\n"
+"POT-Creation-Date: 2025-06-01 09:36+0000\n"
+"PO-Revision-Date: 2025-06-01 21:35\n"
 "Last-Translator: hello@frappe.io\n"
 "Language-Team: Polish\n"
 "MIME-Version: 1.0\n"
@@ -83,15 +83,15 @@ msgstr ""
 msgid " Summary"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:235
+#: erpnext/stock/doctype/item/item.py:238
 msgid "\"Customer Provided Item\" cannot be Purchase Item also"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:237
+#: erpnext/stock/doctype/item/item.py:240
 msgid "\"Customer Provided Item\" cannot have Valuation Rate"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:313
+#: erpnext/stock/doctype/item/item.py:316
 msgid "\"Is Fixed Asset\" cannot be unchecked, as Asset record exists against the item"
 msgstr ""
 
@@ -213,7 +213,7 @@ msgstr "% materiałów zafakturowanych na podstawie tego Zamówienia Sprzedaży"
 msgid "% of materials delivered against this Sales Order"
 msgstr "% materiałów dostarczonych w ramach tego Zamówienia Sprzedaży"
 
-#: erpnext/controllers/accounts_controller.py:2197
+#: erpnext/controllers/accounts_controller.py:2200
 msgid "'Account' in the Accounting section of Customer {0}"
 msgstr ""
 
@@ -225,15 +225,11 @@ msgstr ""
 msgid "'Based On' and 'Group By' can not be same"
 msgstr ""
 
-#: erpnext/stock/report/product_bundle_balance/product_bundle_balance.py:233
-msgid "'Date' is required"
-msgstr ""
-
 #: erpnext/selling/report/inactive_customers/inactive_customers.py:18
 msgid "'Days Since Last Order' must be greater than or equal to zero"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2202
+#: erpnext/controllers/accounts_controller.py:2205
 msgid "'Default {0} Account' in Company {1}"
 msgstr "„Domyślne konto {0} ” w firmie {1}"
 
@@ -243,7 +239,7 @@ msgstr ""
 
 #: erpnext/stock/report/batch_item_expiry_status/batch_item_expiry_status.py:24
 #: erpnext/stock/report/batch_wise_balance_history/batch_wise_balance_history.py:120
-#: erpnext/stock/report/stock_analytics/stock_analytics.py:314
+#: erpnext/stock/report/stock_analytics/stock_analytics.py:313
 msgid "'From Date' is required"
 msgstr ""
 
@@ -251,7 +247,7 @@ msgstr ""
 msgid "'From Date' must be after 'To Date'"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:398
+#: erpnext/stock/doctype/item/item.py:401
 msgid "'Has Serial No' can not be 'Yes' for non-stock item"
 msgstr ""
 
@@ -1123,7 +1119,7 @@ msgstr ""
 
 #. Label of the qty (Float) field in DocType 'Purchase Receipt Item'
 #. Label of the qty (Float) field in DocType 'Subcontracting Receipt Item'
-#: erpnext/public/js/controllers/transaction.js:2362
+#: erpnext/public/js/controllers/transaction.js:2388
 #: erpnext/stock/doctype/purchase_receipt_item/purchase_receipt_item.json
 #: erpnext/subcontracting/doctype/subcontracting_receipt_item/subcontracting_receipt_item.json
 msgid "Accepted Quantity"
@@ -1321,7 +1317,7 @@ msgid "Account Manager"
 msgstr ""
 
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:949
-#: erpnext/controllers/accounts_controller.py:2206
+#: erpnext/controllers/accounts_controller.py:2209
 msgid "Account Missing"
 msgstr ""
 
@@ -1496,7 +1492,7 @@ msgstr ""
 msgid "Account {0} is frozen"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1288
+#: erpnext/controllers/accounts_controller.py:1291
 msgid "Account {0} is invalid. Account Currency must be {1}"
 msgstr ""
 
@@ -1532,7 +1528,7 @@ msgstr ""
 msgid "Account: {0} is not permitted under Payment Entry"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3037
+#: erpnext/controllers/accounts_controller.py:3040
 msgid "Account: {0} with currency: {1} can not be selected"
 msgstr ""
 
@@ -1805,7 +1801,7 @@ msgstr "Zapisy księgowe"
 msgid "Accounting Entry for Asset"
 msgstr ""
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:796
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:805
 msgid "Accounting Entry for Service"
 msgstr ""
 
@@ -1820,18 +1816,18 @@ msgstr ""
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py:1468
 #: erpnext/controllers/stock_controller.py:550
 #: erpnext/controllers/stock_controller.py:567
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:889
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:898
 #: erpnext/stock/doctype/stock_entry/stock_entry.py:1586
 #: erpnext/stock/doctype/stock_entry/stock_entry.py:1600
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py:561
 msgid "Accounting Entry for Stock"
 msgstr ""
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:717
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:726
 msgid "Accounting Entry for {0}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2247
+#: erpnext/controllers/accounts_controller.py:2250
 msgid "Accounting Entry for {0}: {1} can only be made in currency: {2}"
 msgstr ""
 
@@ -2224,7 +2220,7 @@ msgstr ""
 msgid "Accumulated Monthly"
 msgstr "Skumulowane miesięczne"
 
-#: erpnext/controllers/budget_controller.py:417
+#: erpnext/controllers/budget_controller.py:422
 msgid "Accumulated Monthly Budget for Account {0} against {1} {2} is {3}. It will be collectively ({4}) exceeded by {5}"
 msgstr ""
 
@@ -3338,7 +3334,7 @@ msgstr ""
 msgid "Adjustment Against"
 msgstr ""
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:634
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:643
 msgid "Adjustment based on Purchase Invoice rate"
 msgstr "Korekta w oparciu o kurs faktury zakupu"
 
@@ -3449,7 +3445,7 @@ msgstr ""
 msgid "Advance amount"
 msgstr "Kwota Zaliczki"
 
-#: erpnext/controllers/taxes_and_totals.py:845
+#: erpnext/controllers/taxes_and_totals.py:855
 msgid "Advance amount cannot be greater than {0} {1}"
 msgstr ""
 
@@ -3660,7 +3656,7 @@ msgstr ""
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:152
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:133
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1125
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1127
 msgid "Age (Days)"
 msgstr ""
 
@@ -3745,16 +3741,6 @@ msgstr ""
 
 #: erpnext/setup/setup_wizard/data/industry_type.txt:4
 msgid "Agriculture"
-msgstr ""
-
-#. Name of a role
-#: erpnext/assets/doctype/location/location.json
-msgid "Agriculture Manager"
-msgstr ""
-
-#. Name of a role
-#: erpnext/assets/doctype/location/location.json
-msgid "Agriculture User"
 msgstr ""
 
 #: erpnext/setup/setup_wizard/data/industry_type.txt:5
@@ -3947,7 +3933,7 @@ msgstr ""
 msgid "All items are already requested"
 msgstr ""
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:1317
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:1326
 msgid "All items have already been Invoiced/Returned"
 msgstr ""
 
@@ -3959,7 +3945,7 @@ msgstr ""
 msgid "All items have already been transferred for this Work Order."
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2465
+#: erpnext/public/js/controllers/transaction.js:2491
 msgid "All items in this document already have a linked Quality Inspection."
 msgstr ""
 
@@ -4157,7 +4143,7 @@ msgstr ""
 msgid "Allow Item To Be Added Multiple Times in a Transaction"
 msgstr "Zezwalaj na wielokrotne dodawanie przedmiotu w transakcji"
 
-#: erpnext/controllers/selling_controller.py:755
+#: erpnext/controllers/selling_controller.py:763
 msgid "Allow Item to Be Added Multiple Times in a Transaction"
 msgstr "Zezwalaj na wielokrotne dodawanie przedmiotu w transakcji"
 
@@ -5103,7 +5089,7 @@ msgstr ""
 msgid "Annual Billing: {0}"
 msgstr ""
 
-#: erpnext/controllers/budget_controller.py:441
+#: erpnext/controllers/budget_controller.py:446
 msgid "Annual Budget for Account {0} against {1} {2} is {3}. It will be collectively ({4}) exceeded by {5}"
 msgstr ""
 
@@ -5592,7 +5578,7 @@ msgstr ""
 msgid "As the field {0} is enabled, the value of the field {1} should be more than 1."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:989
+#: erpnext/stock/doctype/item/item.py:983
 msgid "As there are existing submitted transactions against item {0}, you can not change the value of {1}."
 msgstr ""
 
@@ -5738,7 +5724,7 @@ msgstr ""
 msgid "Asset Category Name"
 msgstr "Zaleta Nazwa kategorii"
 
-#: erpnext/stock/doctype/item/item.py:304
+#: erpnext/stock/doctype/item/item.py:307
 msgid "Asset Category is mandatory for Fixed Asset item"
 msgstr "Kategoria atutem jest obowiązkowe dla Fixed pozycja aktywów"
 
@@ -6113,7 +6099,7 @@ msgstr ""
 msgid "Asset {0} must be submitted"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:851
+#: erpnext/controllers/buying_controller.py:859
 msgid "Asset {assets_link} created for {item_code}"
 msgstr ""
 
@@ -6143,11 +6129,11 @@ msgstr ""
 msgid "Assets"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:869
+#: erpnext/controllers/buying_controller.py:877
 msgid "Assets not created for {item_code}. You will have to create asset manually."
 msgstr "Zasoby nie zostały utworzone dla {item_code}. Będziesz musiał utworzyć zasób ręcznie."
 
-#: erpnext/controllers/buying_controller.py:856
+#: erpnext/controllers/buying_controller.py:864
 msgid "Assets {assets_link} created for {item_code}"
 msgstr ""
 
@@ -6242,7 +6228,7 @@ msgstr ""
 msgid "At row #{0}: you have selected the Difference Account {1}, which is a Cost of Goods Sold type account. Please select a different account"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:864
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:865
 msgid "At row {0}: Batch No is mandatory for Item {1}"
 msgstr ""
 
@@ -6250,11 +6236,11 @@ msgstr ""
 msgid "At row {0}: Parent Row No cannot be set for item {1}"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:849
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:850
 msgid "At row {0}: Qty is mandatory for the batch {1}"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:856
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:857
 msgid "At row {0}: Serial No is mandatory for Item {1}"
 msgstr ""
 
@@ -6328,7 +6314,7 @@ msgstr ""
 msgid "Attribute Value"
 msgstr "Wartość atrybutu"
 
-#: erpnext/stock/doctype/item/item.py:930
+#: erpnext/stock/doctype/item/item.py:924
 msgid "Attribute table is mandatory"
 msgstr ""
 
@@ -6336,11 +6322,11 @@ msgstr ""
 msgid "Attribute value: {0} must appear only once"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:934
+#: erpnext/stock/doctype/item/item.py:928
 msgid "Attribute {0} selected multiple times in Attributes Table"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:862
+#: erpnext/stock/doctype/item/item.py:856
 msgid "Attributes"
 msgstr ""
 
@@ -7624,11 +7610,11 @@ msgstr ""
 msgid "Barcode Type"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:457
+#: erpnext/stock/doctype/item/item.py:460
 msgid "Barcode {0} already used in Item {1}"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:472
+#: erpnext/stock/doctype/item/item.py:475
 msgid "Barcode {0} is not a valid {1} code"
 msgstr ""
 
@@ -7882,7 +7868,7 @@ msgstr ""
 #: erpnext/manufacturing/doctype/job_card/job_card.json
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.js:89
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.py:115
-#: erpnext/public/js/controllers/transaction.js:2388
+#: erpnext/public/js/controllers/transaction.js:2414
 #: erpnext/public/js/utils/barcode_scanner.js:260
 #: erpnext/public/js/utils/serial_no_batch_selector.js:438
 #: erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
@@ -7909,11 +7895,11 @@ msgstr ""
 msgid "Batch No"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:867
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:868
 msgid "Batch No is mandatory"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2629
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2630
 msgid "Batch No {0} does not exists"
 msgstr ""
 
@@ -7921,7 +7907,7 @@ msgstr ""
 msgid "Batch No {0} is linked with Item {1} which has serial no. Please scan serial no instead."
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:364
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:365
 msgid "Batch No {0} is not present in the original {1} {2}, hence you can't return it against the {1} {2}"
 msgstr ""
 
@@ -7936,11 +7922,11 @@ msgstr ""
 msgid "Batch Nos"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1421
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1422
 msgid "Batch Nos are created successfully"
 msgstr ""
 
-#: erpnext/controllers/sales_and_purchase_return.py:1096
+#: erpnext/controllers/sales_and_purchase_return.py:1001
 msgid "Batch Not Available for Return"
 msgstr ""
 
@@ -7989,7 +7975,7 @@ msgstr ""
 msgid "Batch {0} and Warehouse"
 msgstr ""
 
-#: erpnext/controllers/sales_and_purchase_return.py:1095
+#: erpnext/controllers/sales_and_purchase_return.py:1000
 msgid "Batch {0} is not available in warehouse {1}"
 msgstr ""
 
@@ -8039,7 +8025,7 @@ msgstr ""
 #. Label of the bill_date (Date) field in DocType 'Journal Entry'
 #. Label of the bill_date (Date) field in DocType 'Subcontracting Receipt'
 #: erpnext/accounts/doctype/journal_entry/journal_entry.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1110
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1112
 #: erpnext/accounts/report/purchase_register/purchase_register.py:214
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.json
 msgid "Bill Date"
@@ -8048,7 +8034,7 @@ msgstr ""
 #. Label of the bill_no (Data) field in DocType 'Journal Entry'
 #. Label of the bill_no (Data) field in DocType 'Subcontracting Receipt'
 #: erpnext/accounts/doctype/journal_entry/journal_entry.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1109
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1111
 #: erpnext/accounts/report/purchase_register/purchase_register.py:213
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.json
 msgid "Bill No"
@@ -8268,7 +8254,7 @@ msgstr ""
 msgid "Billing Zipcode"
 msgstr "Kod pocztowy do rozliczeń"
 
-#: erpnext/accounts/party.py:602
+#: erpnext/accounts/party.py:608
 msgid "Billing currency must be equal to either default company's currency or party account currency"
 msgstr ""
 
@@ -9265,7 +9251,7 @@ msgid "Can only make payment against unbilled {0}"
 msgstr "Mogą jedynie wpłaty przed Unbilled {0}"
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1458
-#: erpnext/controllers/accounts_controller.py:2946
+#: erpnext/controllers/accounts_controller.py:2949
 #: erpnext/public/js/controllers/accounts.js:90
 msgid "Can refer row only if the charge type is 'On Previous Row Amount' or 'Previous Row Total'"
 msgstr "Może odnosić się do wierdza tylko wtedy, gdy typ opłata jest \"Poprzedniej Wartości Wiersza Suma\" lub \"poprzedniego wiersza Razem\""
@@ -9427,9 +9413,9 @@ msgstr ""
 msgid "Cannot Create Return"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:625
-#: erpnext/stock/doctype/item/item.py:638
-#: erpnext/stock/doctype/item/item.py:652
+#: erpnext/stock/doctype/item/item.py:631
+#: erpnext/stock/doctype/item/item.py:644
+#: erpnext/stock/doctype/item/item.py:658
 msgid "Cannot Merge"
 msgstr ""
 
@@ -9453,7 +9439,7 @@ msgstr ""
 msgid "Cannot apply TDS against multiple parties in one entry"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:307
+#: erpnext/stock/doctype/item/item.py:310
 msgid "Cannot be a fixed asset item as Stock Ledger is created."
 msgstr ""
 
@@ -9469,7 +9455,7 @@ msgstr ""
 msgid "Cannot cancel the transaction. Reposting of item valuation on submission is not completed yet."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:959
+#: erpnext/controllers/buying_controller.py:967
 msgid "Cannot cancel this document as it is linked with the submitted asset {asset_link}. Please cancel the asset to continue."
 msgstr ""
 
@@ -9477,7 +9463,7 @@ msgstr ""
 msgid "Cannot cancel transaction for Completed Work Order."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:882
+#: erpnext/stock/doctype/item/item.py:876
 msgid "Cannot change Attributes after stock transaction. Make a new Item and transfer stock to the new Item"
 msgstr ""
 
@@ -9493,7 +9479,7 @@ msgstr ""
 msgid "Cannot change Service Stop Date for item in row {0}"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:873
+#: erpnext/stock/doctype/item/item.py:867
 msgid "Cannot change Variant properties after stock transaction. You will have to make a new Item to do this."
 msgstr ""
 
@@ -9521,7 +9507,7 @@ msgstr ""
 msgid "Cannot covert to Group because Account Type is selected."
 msgstr ""
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:972
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:981
 msgid "Cannot create Stock Reservation Entries for future dated Purchase Receipts."
 msgstr ""
 
@@ -9572,7 +9558,7 @@ msgstr "Nie można zapewnić dostawy według numeru seryjnego, ponieważ pozycja
 msgid "Cannot find Item with this Barcode"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3483
+#: erpnext/controllers/accounts_controller.py:3486
 msgid "Cannot find a default warehouse for item {0}. Please set one in the Item Master or in Stock Settings."
 msgstr ""
 
@@ -9580,7 +9566,7 @@ msgstr ""
 msgid "Cannot make any transactions until the deletion job is completed"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2074
+#: erpnext/controllers/accounts_controller.py:2077
 msgid "Cannot overbill for Item {0} in row {1} more than {2}. To allow over-billing, please set allowance in Accounts Settings"
 msgstr ""
 
@@ -9601,7 +9587,7 @@ msgid "Cannot receive from customer against negative outstanding"
 msgstr ""
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1475
-#: erpnext/controllers/accounts_controller.py:2961
+#: erpnext/controllers/accounts_controller.py:2964
 #: erpnext/public/js/controllers/accounts.js:100
 msgid "Cannot refer row number greater than or equal to current row number for this Charge type"
 msgstr ""
@@ -9617,7 +9603,7 @@ msgstr ""
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1467
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1646
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:1917
-#: erpnext/controllers/accounts_controller.py:2951
+#: erpnext/controllers/accounts_controller.py:2954
 #: erpnext/public/js/controllers/accounts.js:94
 #: erpnext/public/js/controllers/taxes_and_totals.js:470
 msgid "Cannot select charge type as 'On Previous Row Amount' or 'On Previous Row Total' for first row"
@@ -9631,15 +9617,15 @@ msgstr ""
 msgid "Cannot set authorization on basis of Discount for {0}"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:716
+#: erpnext/stock/doctype/item/item.py:722
 msgid "Cannot set multiple Item Defaults for a company."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3631
+#: erpnext/controllers/accounts_controller.py:3634
 msgid "Cannot set quantity less than delivered quantity"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3634
+#: erpnext/controllers/accounts_controller.py:3637
 msgid "Cannot set quantity less than received quantity"
 msgstr ""
 
@@ -10062,7 +10048,7 @@ msgid "Channel Partner"
 msgstr ""
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:2346
-#: erpnext/controllers/accounts_controller.py:3014
+#: erpnext/controllers/accounts_controller.py:3017
 msgid "Charge of type 'Actual' in row {0} cannot be included in Item Rate or Paid Amount"
 msgstr ""
 
@@ -10245,7 +10231,7 @@ msgstr "Czek Szerokość"
 
 #. Label of the reference_date (Date) field in DocType 'Payment Entry'
 #: erpnext/accounts/doctype/payment_entry/payment_entry.json
-#: erpnext/public/js/controllers/transaction.js:2299
+#: erpnext/public/js/controllers/transaction.js:2325
 msgid "Cheque/Reference Date"
 msgstr "Czek / Reference Data"
 
@@ -10293,7 +10279,7 @@ msgstr "Nazwa dziecka"
 
 #. Label of the child_row_reference (Data) field in DocType 'Quality
 #. Inspection'
-#: erpnext/public/js/controllers/transaction.js:2394
+#: erpnext/public/js/controllers/transaction.js:2420
 #: erpnext/stock/doctype/quality_inspection/quality_inspection.json
 msgid "Child Row Reference"
 msgstr ""
@@ -11005,7 +10991,7 @@ msgstr ""
 #: erpnext/accounts/report/cheques_and_deposits_incorrectly_cleared/cheques_and_deposits_incorrectly_cleared.js:8
 #: erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.js:8
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:8
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:49
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:50
 #: erpnext/accounts/report/deferred_revenue_and_expense/deferred_revenue_and_expense.js:8
 #: erpnext/accounts/report/delivered_items_to_be_billed/delivered_items_to_be_billed.js:7
 #: erpnext/accounts/report/dimension_wise_accounts_balance_report/dimension_wise_accounts_balance_report.js:8
@@ -12238,7 +12224,7 @@ msgid "Content Type"
 msgstr "Typ zawartości"
 
 #: erpnext/erpnext_integrations/doctype/plaid_settings/plaid_settings.js:162
-#: erpnext/public/js/controllers/transaction.js:2312
+#: erpnext/public/js/controllers/transaction.js:2338
 #: erpnext/selling/doctype/quotation/quotation.js:356
 msgid "Continue"
 msgstr ""
@@ -12403,7 +12389,7 @@ msgstr ""
 msgid "Conversion Rate"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:393
+#: erpnext/stock/doctype/item/item.py:396
 msgid "Conversion factor for default Unit of Measure must be 1 in row {0}"
 msgstr ""
 
@@ -12411,15 +12397,15 @@ msgstr ""
 msgid "Conversion factor for item {0} has been reset to 1.0 as the uom {1} is same as stock uom {2}."
 msgstr "Współczynnik przeliczeniowy dla przedmiotu {0} został zresetowany na 1,0, ponieważ jm {1} jest taka sama jak magazynowa jm {2}  "
 
-#: erpnext/controllers/accounts_controller.py:2767
+#: erpnext/controllers/accounts_controller.py:2770
 msgid "Conversion rate cannot be 0"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2774
+#: erpnext/controllers/accounts_controller.py:2777
 msgid "Conversion rate is 1.00, but document currency is different from company currency"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2770
+#: erpnext/controllers/accounts_controller.py:2773
 msgid "Conversion rate must be 1.00 if document currency is same as company currency"
 msgstr ""
 
@@ -12632,7 +12618,7 @@ msgstr ""
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:28
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:40
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:30
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1096
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1098
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:40
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.js:42
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.py:197
@@ -12725,7 +12711,7 @@ msgid "Cost Center is a part of Cost Center Allocation, hence cannot be converte
 msgstr "Centrum kosztów jest częścią przydziału centrum kosztów, dlatego nie może zostać przekonwertowane na grupę  "
 
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py:1411
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:855
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:864
 msgid "Cost Center is required in row {0} in Taxes table for type {1}"
 msgstr ""
 
@@ -12994,8 +12980,8 @@ msgstr ""
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:132
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:143
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:219
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:654
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:678
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:656
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:680
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.js:88
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.js:89
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.js:103
@@ -13052,8 +13038,8 @@ msgstr ""
 #: erpnext/projects/doctype/task/task_tree.js:81
 #: erpnext/public/js/communication.js:19 erpnext/public/js/communication.js:31
 #: erpnext/public/js/communication.js:41
-#: erpnext/public/js/controllers/transaction.js:336
-#: erpnext/public/js/controllers/transaction.js:2435
+#: erpnext/public/js/controllers/transaction.js:362
+#: erpnext/public/js/controllers/transaction.js:2461
 #: erpnext/selling/doctype/customer/customer.js:181
 #: erpnext/selling/doctype/quotation/quotation.js:124
 #: erpnext/selling/doctype/quotation/quotation.js:133
@@ -13348,7 +13334,7 @@ msgstr ""
 msgid "Create a variant with the template image."
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1877
+#: erpnext/stock/stock_ledger.py:1886
 msgid "Create an incoming stock transaction for the Item."
 msgstr ""
 
@@ -13408,7 +13394,7 @@ msgstr ""
 msgid "Creating Purchase Order ..."
 msgstr ""
 
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:735
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:737
 #: erpnext/buying/doctype/purchase_order/purchase_order.js:552
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.js:73
 msgid "Creating Purchase Receipt ..."
@@ -13603,7 +13589,7 @@ msgstr "Miesiące kredytowe"
 #: erpnext/accounts/doctype/journal_entry_template/journal_entry_template.json
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:174
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:147
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1119
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1121
 #: erpnext/controllers/sales_and_purchase_return.py:373
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:286
 #: erpnext/stock/doctype/delivery_note/delivery_note.js:89
@@ -13638,7 +13624,7 @@ msgstr ""
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py:368
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py:376
-#: erpnext/controllers/accounts_controller.py:2186
+#: erpnext/controllers/accounts_controller.py:2189
 msgid "Credit To"
 msgstr ""
 
@@ -13823,7 +13809,7 @@ msgstr ""
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/subscription_plan/subscription_plan.json
 #: erpnext/accounts/report/account_balance/account_balance.py:28
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1129
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1131
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:205
 #: erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.py:101
 #: erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.js:118
@@ -14352,7 +14338,7 @@ msgstr "Kod Klienta"
 #. Label of the customer_contact_display (Small Text) field in DocType
 #. 'Purchase Order'
 #. Label of the customer_contact (Small Text) field in DocType 'Delivery Stop'
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1090
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1092
 #: erpnext/buying/doctype/purchase_order/purchase_order.json
 #: erpnext/stock/doctype/delivery_stop/delivery_stop.json
 msgid "Customer Contact"
@@ -14448,7 +14434,7 @@ msgstr "Informacja zwrotna Klienta"
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/tax_rule/tax_rule.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:107
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1147
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1149
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:81
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:185
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:56
@@ -14492,7 +14478,7 @@ msgstr ""
 msgid "Customer Group Name"
 msgstr "Nazwa Grupy Klientów"
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1239
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1241
 msgid "Customer Group: {0} does not exist"
 msgstr ""
 
@@ -14511,7 +14497,7 @@ msgstr ""
 msgid "Customer Items"
 msgstr "Pozycje klientów"
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1138
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1140
 msgid "Customer LPO"
 msgstr ""
 
@@ -14557,7 +14543,7 @@ msgstr "Komórka klienta Nie"
 #: erpnext/accounts/doctype/pos_invoice/pos_invoice.json
 #: erpnext/accounts/doctype/process_statement_of_accounts_customer/process_statement_of_accounts_customer.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1080
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1082
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:156
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:92
 #: erpnext/accounts/report/delivered_items_to_be_billed/delivered_items_to_be_billed.py:35
@@ -15235,7 +15221,7 @@ msgstr ""
 #: erpnext/accounts/doctype/journal_entry_template/journal_entry_template.json
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:176
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:147
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1122
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1124
 #: erpnext/controllers/sales_and_purchase_return.py:377
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:287
 #: erpnext/stock/doctype/purchase_receipt/purchase_receipt.js:61
@@ -15264,7 +15250,7 @@ msgstr ""
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:953
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:964
-#: erpnext/controllers/accounts_controller.py:2186
+#: erpnext/controllers/accounts_controller.py:2189
 msgid "Debit To"
 msgstr ""
 
@@ -15297,11 +15283,11 @@ msgstr ""
 msgid "Debit-Credit mismatch"
 msgstr ""
 
-#: erpnext/accounts/party.py:609
+#: erpnext/accounts/party.py:615
 msgid "Debtor/Creditor"
 msgstr ""
 
-#: erpnext/accounts/party.py:612
+#: erpnext/accounts/party.py:618
 msgid "Debtor/Creditor Advance"
 msgstr ""
 
@@ -15421,7 +15407,7 @@ msgstr ""
 msgid "Default BOM"
 msgstr "Domyślne Zestawienie Materiałów"
 
-#: erpnext/stock/doctype/item/item.py:418
+#: erpnext/stock/doctype/item/item.py:421
 msgid "Default BOM ({0}) must be active for this item or its template"
 msgstr ""
 
@@ -15429,7 +15415,7 @@ msgstr ""
 msgid "Default BOM for {0} not found"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3672
+#: erpnext/controllers/accounts_controller.py:3675
 msgid "Default BOM not found for FG Item {0}"
 msgstr ""
 
@@ -15764,15 +15750,15 @@ msgstr "Domyślne terytorium"
 msgid "Default Unit of Measure"
 msgstr "Domyślna jednostka miary"
 
-#: erpnext/stock/doctype/item/item.py:1272
+#: erpnext/stock/doctype/item/item.py:1266
 msgid "Default Unit of Measure for Item {0} cannot be changed directly because you have already made some transaction(s) with another UOM. You need to either cancel the linked documents or create a new Item."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1255
+#: erpnext/stock/doctype/item/item.py:1249
 msgid "Default Unit of Measure for Item {0} cannot be changed directly because you have already made some transaction(s) with another UOM. You will need to create a new Item to use a different Default UOM."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:908
+#: erpnext/stock/doctype/item/item.py:902
 msgid "Default Unit of Measure for Variant '{0}' must be same as in Template '{1}'"
 msgstr ""
 
@@ -16231,7 +16217,7 @@ msgstr ""
 msgid "Delivery Note {0} is not submitted"
 msgstr ""
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1142
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1144
 #: erpnext/stock/doctype/delivery_trip/delivery_trip.js:73
 msgid "Delivery Notes"
 msgstr ""
@@ -16762,7 +16748,7 @@ msgstr ""
 #: erpnext/projects/doctype/task_type/task_type.json
 #: erpnext/projects/doctype/timesheet_detail/timesheet_detail.json
 #: erpnext/public/js/bank_reconciliation_tool/data_table_manager.js:55
-#: erpnext/public/js/controllers/transaction.js:2376
+#: erpnext/public/js/controllers/transaction.js:2402
 #: erpnext/selling/doctype/installation_note_item/installation_note_item.json
 #: erpnext/selling/doctype/product_bundle/product_bundle.json
 #: erpnext/selling/doctype/product_bundle_item/product_bundle_item.json
@@ -16950,7 +16936,7 @@ msgstr ""
 msgid "Difference Account must be a Asset/Liability type account (Temporary Opening), since this Stock Entry is an Opening Entry"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:954
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:950
 msgid "Difference Account must be a Asset/Liability type account, since this Stock Reconciliation is an Opening Entry"
 msgstr "Konto różnicowe musi być kontem typu Aktywa/Zobowiązania, ponieważ ta rekonsyliacja magazynowa jest wpisem otwarcia"
 
@@ -17216,11 +17202,11 @@ msgstr ""
 msgid "Disabled Warehouse {0} cannot be used for this transaction."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:745
+#: erpnext/controllers/accounts_controller.py:748
 msgid "Disabled pricing rules since this {} is an internal transfer"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:759
+#: erpnext/controllers/accounts_controller.py:762
 msgid "Disabled tax included prices since this {} is an internal transfer"
 msgstr ""
 
@@ -18162,7 +18148,7 @@ msgstr ""
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.json
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/print_format/sales_invoice_print/sales_invoice_print.html:72
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1106
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1108
 #: erpnext/assets/doctype/asset_maintenance_log/asset_maintenance_log.json
 #: erpnext/selling/report/payment_terms_status_for_sales_order/payment_terms_status_for_sales_order.py:40
 msgid "Due Date"
@@ -18176,11 +18162,11 @@ msgstr ""
 msgid "Due Date Based On"
 msgstr "Termin wykonania oparty na"
 
-#: erpnext/accounts/party.py:695
+#: erpnext/accounts/party.py:701
 msgid "Due Date cannot be after {0}"
 msgstr ""
 
-#: erpnext/accounts/party.py:671
+#: erpnext/accounts/party.py:677
 msgid "Due Date cannot be before {0}"
 msgstr ""
 
@@ -18898,7 +18884,7 @@ msgstr "Włącz harmonogram spotkań"
 msgid "Enable Auto Email"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1064
+#: erpnext/stock/doctype/item/item.py:1058
 msgid "Enable Auto Re-Order"
 msgstr ""
 
@@ -19111,7 +19097,7 @@ msgstr "Data Inkaso"
 msgid "End Date"
 msgstr ""
 
-#: erpnext/crm/doctype/contract/contract.py:75
+#: erpnext/crm/doctype/contract/contract.py:83
 msgid "End Date cannot be before Start Date."
 msgstr ""
 
@@ -19361,7 +19347,7 @@ msgstr ""
 #: erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.json
 #: erpnext/manufacturing/doctype/job_card/job_card.py:875
 #: erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.json
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:297
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:298
 msgid "Error"
 msgstr ""
 
@@ -19484,7 +19470,7 @@ msgstr ""
 msgid "Example URL"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:995
+#: erpnext/stock/doctype/item/item.py:989
 msgid "Example of a linked document: {0}"
 msgstr ""
 
@@ -19499,7 +19485,7 @@ msgstr ""
 msgid "Example: ABCD.#####. If series is set and Batch No is not mentioned in transactions, then automatic batch number will be created based on this series. If you always want to explicitly mention Batch No for this item, leave this blank. Note: this setting will take priority over the Naming Series Prefix in Stock Settings."
 msgstr "Przykład: ABCD. #####. Jeśli seria jest ustawiona, a numer partii nie jest wymieniony w transakcjach, na podstawie tej serii zostanie utworzony automatyczny numer partii. Jeśli zawsze chcesz wyraźnie podać numer partii dla tego produktu, pozostaw to pole puste. Uwaga: to ustawienie ma pierwszeństwo przed prefiksem serii nazw w Ustawieniach fotografii."
 
-#: erpnext/stock/stock_ledger.py:2141
+#: erpnext/stock/stock_ledger.py:2149
 msgid "Example: Serial No {0} reserved in {1}."
 msgstr ""
 
@@ -19553,8 +19539,8 @@ msgstr ""
 msgid "Exchange Gain/Loss"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1593
-#: erpnext/controllers/accounts_controller.py:1677
+#: erpnext/controllers/accounts_controller.py:1596
+#: erpnext/controllers/accounts_controller.py:1680
 msgid "Exchange Gain/Loss amount has been booked through {0}"
 msgstr ""
 
@@ -20290,7 +20276,7 @@ msgid "Fetching Error"
 msgstr ""
 
 #: erpnext/accounts/doctype/dunning/dunning.js:135
-#: erpnext/public/js/controllers/transaction.js:1251
+#: erpnext/public/js/controllers/transaction.js:1277
 msgid "Fetching exchange rates ..."
 msgstr ""
 
@@ -20585,15 +20571,15 @@ msgstr ""
 msgid "Finished Good Item Quantity"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3658
+#: erpnext/controllers/accounts_controller.py:3661
 msgid "Finished Good Item is not specified for service item {0}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3675
+#: erpnext/controllers/accounts_controller.py:3678
 msgid "Finished Good Item {0} Qty can not be zero"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3669
+#: erpnext/controllers/accounts_controller.py:3672
 msgid "Finished Good Item {0} must be a sub-contracted item"
 msgstr ""
 
@@ -20834,7 +20820,7 @@ msgstr "Konto trwałego"
 msgid "Fixed Asset Defaults"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:301
+#: erpnext/stock/doctype/item/item.py:304
 msgid "Fixed Asset Item must be a non-stock item."
 msgstr ""
 
@@ -21010,7 +20996,7 @@ msgstr ""
 msgid "For Raw Materials"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1259
+#: erpnext/controllers/accounts_controller.py:1262
 msgid "For Return Invoices with Stock effect, '0' qty Items are not allowed. Following rows are affected: {0}"
 msgstr ""
 
@@ -21111,7 +21097,7 @@ msgstr "Dla wygody klientów, te kody mogą być użyte w formacie drukowania ja
 msgid "For the item {0}, the quantity should be {1} according to the BOM {2}."
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:1088
+#: erpnext/public/js/controllers/transaction.js:1114
 msgctxt "Clear payment terms template and/or payment schedule when due date is changed"
 msgid "For the new {0} to take effect, would you like to clear the current {1}?"
 msgstr ""
@@ -21120,7 +21106,7 @@ msgstr ""
 msgid "For the {0}, no stock is available for the return in the warehouse {1}."
 msgstr "Dla {0} brak zapasów na zwrot w magazynie {1}."
 
-#: erpnext/controllers/sales_and_purchase_return.py:1144
+#: erpnext/controllers/sales_and_purchase_return.py:1049
 msgid "For the {0}, the quantity is required to make the return entry"
 msgstr ""
 
@@ -21457,7 +21443,7 @@ msgstr ""
 msgid "From Date is mandatory"
 msgstr ""
 
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:52
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:53
 #: erpnext/accounts/report/general_ledger/general_ledger.py:86
 #: erpnext/accounts/report/pos_register/pos_register.py:115
 #: erpnext/accounts/report/tax_withholding_details/tax_withholding_details.py:39
@@ -21834,14 +21820,14 @@ msgstr ""
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:186
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:155
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1134
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1136
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:177
 msgid "Future Payment Amount"
 msgstr ""
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:185
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:154
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1133
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1135
 msgid "Future Payment Ref"
 msgstr ""
 
@@ -23015,7 +23001,7 @@ msgstr ""
 msgid "Here are the error logs for the aforementioned failed depreciation entries: {0}"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1862
+#: erpnext/stock/stock_ledger.py:1871
 msgid "Here are the options to proceed:"
 msgstr ""
 
@@ -23537,7 +23523,7 @@ msgstr ""
 msgid "If more than one package of the same type (for print)"
 msgstr "Jeśli więcej niż jedna paczka tego samego typu (do druku)"
 
-#: erpnext/stock/stock_ledger.py:1872
+#: erpnext/stock/stock_ledger.py:1881
 msgid "If not, you can Cancel / Submit this entry"
 msgstr ""
 
@@ -23562,7 +23548,7 @@ msgstr ""
 msgid "If the account is frozen, entries are allowed to restricted users."
 msgstr "Jeśli konto jest zamrożone, zapisy mogą wykonywać tylko wyznaczone osoby."
 
-#: erpnext/stock/stock_ledger.py:1865
+#: erpnext/stock/stock_ledger.py:1874
 msgid "If the item is transacting as a Zero Valuation Rate item in this entry, please enable 'Allow Zero Valuation Rate' in the {0} Item table."
 msgstr ""
 
@@ -24560,7 +24546,7 @@ msgstr ""
 msgid "Incorrect Batch Consumed"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:514
+#: erpnext/stock/doctype/item/item.py:517
 msgid "Incorrect Check in (group) Warehouse for Reorder"
 msgstr ""
 
@@ -24609,7 +24595,7 @@ msgstr ""
 msgid "Incorrect Stock Value Report"
 msgstr ""
 
-#: erpnext/stock/serial_batch_bundle.py:134
+#: erpnext/stock/serial_batch_bundle.py:135
 msgid "Incorrect Type of Transaction"
 msgstr ""
 
@@ -24878,8 +24864,8 @@ msgstr ""
 msgid "Insufficient Capacity"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3590
-#: erpnext/controllers/accounts_controller.py:3614
+#: erpnext/controllers/accounts_controller.py:3593
+#: erpnext/controllers/accounts_controller.py:3617
 msgid "Insufficient Permissions"
 msgstr ""
 
@@ -24887,12 +24873,12 @@ msgstr ""
 #: erpnext/stock/doctype/pick_list/pick_list.py:127
 #: erpnext/stock/doctype/pick_list/pick_list.py:975
 #: erpnext/stock/doctype/stock_entry/stock_entry.py:759
-#: erpnext/stock/serial_batch_bundle.py:989 erpnext/stock/stock_ledger.py:1559
-#: erpnext/stock/stock_ledger.py:2032
+#: erpnext/stock/serial_batch_bundle.py:1021 erpnext/stock/stock_ledger.py:1568
+#: erpnext/stock/stock_ledger.py:2040
 msgid "Insufficient Stock"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:2047
+#: erpnext/stock/stock_ledger.py:2055
 msgid "Insufficient Stock for Batch"
 msgstr ""
 
@@ -25030,11 +25016,11 @@ msgstr ""
 msgid "Internal Customer for company {0} already exists"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:728
+#: erpnext/controllers/accounts_controller.py:731
 msgid "Internal Sale or Delivery Reference missing."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:730
+#: erpnext/controllers/accounts_controller.py:733
 msgid "Internal Sales Reference Missing"
 msgstr ""
 
@@ -25065,7 +25051,7 @@ msgstr ""
 msgid "Internal Transfer"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:739
+#: erpnext/controllers/accounts_controller.py:742
 msgid "Internal Transfer Reference Missing"
 msgstr ""
 
@@ -25108,8 +25094,8 @@ msgstr ""
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:969
 #: erpnext/assets/doctype/asset_category/asset_category.py:69
 #: erpnext/assets/doctype/asset_category/asset_category.py:97
-#: erpnext/controllers/accounts_controller.py:2975
-#: erpnext/controllers/accounts_controller.py:2983
+#: erpnext/controllers/accounts_controller.py:2978
+#: erpnext/controllers/accounts_controller.py:2986
 msgid "Invalid Account"
 msgstr ""
 
@@ -25134,7 +25120,7 @@ msgstr ""
 msgid "Invalid Barcode. There is no Item attached to this barcode."
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2631
+#: erpnext/public/js/controllers/transaction.js:2657
 msgid "Invalid Blanket Order for the selected Customer and Item"
 msgstr ""
 
@@ -25148,7 +25134,7 @@ msgstr ""
 
 #: erpnext/assets/doctype/asset/asset.py:295
 #: erpnext/assets/doctype/asset/asset.py:302
-#: erpnext/controllers/accounts_controller.py:2998
+#: erpnext/controllers/accounts_controller.py:3001
 msgid "Invalid Cost Center"
 msgstr ""
 
@@ -25190,7 +25176,7 @@ msgstr ""
 msgid "Invalid Item"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1410
+#: erpnext/stock/doctype/item/item.py:1404
 msgid "Invalid Item Defaults"
 msgstr ""
 
@@ -25236,11 +25222,11 @@ msgstr ""
 msgid "Invalid Purchase Invoice"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3627
+#: erpnext/controllers/accounts_controller.py:3630
 msgid "Invalid Qty"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1277
+#: erpnext/controllers/accounts_controller.py:1280
 msgid "Invalid Quantity"
 msgstr ""
 
@@ -25257,7 +25243,7 @@ msgstr ""
 msgid "Invalid Schedule"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:243
+#: erpnext/controllers/selling_controller.py:251
 msgid "Invalid Selling Price"
 msgstr ""
 
@@ -25290,7 +25276,7 @@ msgstr ""
 msgid "Invalid lost reason {0}, please create a new lost reason"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:408
+#: erpnext/stock/doctype/item/item.py:411
 msgid "Invalid naming series (. missing) for {0}"
 msgstr ""
 
@@ -25330,7 +25316,7 @@ msgstr "Inwentarz"
 #. Name of a DocType
 #: erpnext/patches/v15_0/refactor_closing_stock_balance.py:43
 #: erpnext/stock/doctype/inventory_dimension/inventory_dimension.json
-#: erpnext/stock/doctype/inventory_dimension/inventory_dimension.py:180
+#: erpnext/stock/doctype/inventory_dimension/inventory_dimension.py:181
 msgid "Inventory Dimension"
 msgstr ""
 
@@ -25396,7 +25382,7 @@ msgstr ""
 msgid "Invoice Discounting"
 msgstr ""
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1114
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1116
 msgid "Invoice Grand Total"
 msgstr ""
 
@@ -25489,7 +25475,7 @@ msgstr ""
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:169
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:144
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1116
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1118
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:164
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:165
 msgid "Invoiced Amount"
@@ -25895,6 +25881,11 @@ msgstr ""
 msgid "Is Outward"
 msgstr ""
 
+#. Label of the is_packed (Check) field in DocType 'Serial and Batch Bundle'
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.json
+msgid "Is Packed"
+msgstr ""
+
 #. Label of the is_paid (Check) field in DocType 'Purchase Invoice'
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 msgid "Is Paid"
@@ -26177,11 +26168,11 @@ msgstr "Data emisji"
 msgid "Issuing cannot be done to a location. Please enter employee to issue the Asset {0} to"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:565
+#: erpnext/stock/doctype/item/item.py:571
 msgid "It can take upto few hours for accurate stock values to be visible after merging items."
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2075
+#: erpnext/public/js/controllers/transaction.js:2101
 msgid "It is needed to fetch Item Details."
 msgstr ""
 
@@ -26231,7 +26222,7 @@ msgstr ""
 #: erpnext/buying/report/supplier_quotation_comparison/supplier_quotation_comparison.js:33
 #: erpnext/buying/report/supplier_quotation_comparison/supplier_quotation_comparison.py:204
 #: erpnext/buying/workspace/buying/buying.json
-#: erpnext/controllers/taxes_and_totals.py:1125
+#: erpnext/controllers/taxes_and_totals.py:1135
 #: erpnext/manufacturing/doctype/blanket_order/blanket_order.json
 #: erpnext/manufacturing/doctype/bom/bom.js:944
 #: erpnext/manufacturing/doctype/bom/bom.json
@@ -26509,7 +26500,7 @@ msgstr "poz Koszyk"
 #: erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py:86
 #: erpnext/manufacturing/report/work_order_stock_report/work_order_stock_report.py:119
 #: erpnext/projects/doctype/timesheet/timesheet.js:213
-#: erpnext/public/js/controllers/transaction.js:2350
+#: erpnext/public/js/controllers/transaction.js:2376
 #: erpnext/public/js/stock_reservation.js:112
 #: erpnext/public/js/stock_reservation.js:317 erpnext/public/js/utils.js:500
 #: erpnext/public/js/utils.js:656
@@ -26947,7 +26938,7 @@ msgstr ""
 #: erpnext/manufacturing/report/production_planning_report/production_planning_report.py:359
 #: erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py:92
 #: erpnext/manufacturing/report/work_order_consumed_materials/work_order_consumed_materials.py:138
-#: erpnext/public/js/controllers/transaction.js:2356
+#: erpnext/public/js/controllers/transaction.js:2382
 #: erpnext/public/js/utils.js:746
 #: erpnext/selling/doctype/quotation_item/quotation_item.json
 #: erpnext/selling/doctype/sales_order_item/sales_order_item.json
@@ -27214,7 +27205,7 @@ msgstr ""
 msgid "Item Variant {0} already exists with same attributes"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:781
+#: erpnext/stock/doctype/item/item.py:772
 msgid "Item Variants updated"
 msgstr ""
 
@@ -27280,7 +27271,7 @@ msgstr "Przedmiot i gwarancji Szczegóły"
 msgid "Item for row {0} does not match Material Request"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:795
+#: erpnext/stock/doctype/item/item.py:789
 msgid "Item has variants."
 msgstr ""
 
@@ -27306,7 +27297,7 @@ msgstr ""
 msgid "Item operation"
 msgstr "Obsługa przedmiotu"
 
-#: erpnext/controllers/accounts_controller.py:3650
+#: erpnext/controllers/accounts_controller.py:3653
 msgid "Item qty can not be updated as raw materials are already processed."
 msgstr ""
 
@@ -27332,7 +27323,7 @@ msgstr "Jednostkowy wskaźnik wyceny przeliczone z uwzględnieniem kosztów ilo�
 msgid "Item valuation reposting in progress. Report might show incorrect item valuation."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:952
+#: erpnext/stock/doctype/item/item.py:946
 msgid "Item variant {0} exists with same attributes"
 msgstr ""
 
@@ -27345,8 +27336,7 @@ msgid "Item {0} cannot be ordered more than {1} against Blanket Order {2}."
 msgstr ""
 
 #: erpnext/assets/doctype/asset/asset.py:277
-#: erpnext/stock/doctype/item/item.py:630
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:167
+#: erpnext/stock/doctype/item/item.py:636
 msgid "Item {0} does not exist"
 msgstr ""
 
@@ -27358,7 +27348,7 @@ msgstr ""
 msgid "Item {0} does not exist."
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:752
+#: erpnext/controllers/selling_controller.py:760
 msgid "Item {0} entered multiple times."
 msgstr ""
 
@@ -27374,7 +27364,7 @@ msgstr ""
 msgid "Item {0} has no Serial No. Only serialized items can have delivery based on Serial No"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1126
+#: erpnext/stock/doctype/item/item.py:1120
 msgid "Item {0} has reached its end of life on {1}"
 msgstr ""
 
@@ -27386,11 +27376,11 @@ msgstr ""
 msgid "Item {0} is already reserved/delivered against Sales Order {1}."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1146
+#: erpnext/stock/doctype/item/item.py:1140
 msgid "Item {0} is cancelled"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1130
+#: erpnext/stock/doctype/item/item.py:1124
 msgid "Item {0} is disabled"
 msgstr ""
 
@@ -27398,7 +27388,7 @@ msgstr ""
 msgid "Item {0} is not a serialized Item"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1138
+#: erpnext/stock/doctype/item/item.py:1132
 msgid "Item {0} is not a stock Item"
 msgstr ""
 
@@ -27442,7 +27432,7 @@ msgstr ""
 msgid "Item {0}: {1} qty produced. "
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1429
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1423
 msgid "Item {} does not exist."
 msgstr ""
 
@@ -27582,7 +27572,7 @@ msgstr ""
 msgid "Items and Pricing"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3872
+#: erpnext/controllers/accounts_controller.py:3875
 msgid "Items cannot be updated as Subcontracting Order is created against the Purchase Order {0}."
 msgstr ""
 
@@ -28078,7 +28068,7 @@ msgstr ""
 
 #. Name of a DocType
 #. Label of a Link in the Stock Workspace
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:674
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:676
 #: erpnext/stock/doctype/landed_cost_voucher/landed_cost_voucher.json
 #: erpnext/stock/doctype/purchase_receipt/purchase_receipt.js:104
 #: erpnext/stock/workspace/stock/stock.json
@@ -28693,7 +28683,7 @@ msgstr ""
 msgid "Linked Location"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:999
+#: erpnext/stock/doctype/item/item.py:993
 msgid "Linked with submitted documents"
 msgstr ""
 
@@ -29432,7 +29422,7 @@ msgstr ""
 #: erpnext/manufacturing/doctype/bom/bom.py:261
 #: erpnext/manufacturing/doctype/bom_update_log/bom_update_log.py:71
 #: erpnext/public/js/controllers/accounts.js:249
-#: erpnext/public/js/controllers/transaction.js:2753
+#: erpnext/public/js/controllers/transaction.js:2779
 #: erpnext/public/js/utils/party.js:321
 #: erpnext/stock/doctype/delivery_note/delivery_note.js:164
 #: erpnext/stock/doctype/inventory_dimension/inventory_dimension.json
@@ -30288,7 +30278,7 @@ msgstr "Maksymalne wykorzystanie"
 msgid "Maximum Value"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:212
+#: erpnext/controllers/selling_controller.py:220
 msgid "Maximum discount for Item {0} is {1}%"
 msgstr ""
 
@@ -30358,7 +30348,7 @@ msgstr ""
 msgid "Megawatt"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1878
+#: erpnext/stock/stock_ledger.py:1887
 msgid "Mention Valuation Rate in the Item master."
 msgstr ""
 
@@ -30753,11 +30743,11 @@ msgstr ""
 msgid "Miscellaneous Expenses"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:540
+#: erpnext/controllers/buying_controller.py:548
 msgid "Mismatch"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1430
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1424
 msgid "Missing"
 msgstr ""
 
@@ -31284,7 +31274,7 @@ msgstr ""
 msgid "Multiple Warehouse Accounts"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1129
+#: erpnext/controllers/accounts_controller.py:1132
 msgid "Multiple fiscal years exist for the date {0}. Please set company in Fiscal Year"
 msgstr ""
 
@@ -31435,7 +31425,7 @@ msgstr ""
 msgid "Naming Series and Price Defaults"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:90
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:91
 msgid "Naming Series is mandatory"
 msgstr ""
 
@@ -31474,15 +31464,15 @@ msgstr "Gazu ziemnego"
 msgid "Needs Analysis"
 msgstr ""
 
-#: erpnext/stock/serial_batch_bundle.py:1277
+#: erpnext/stock/serial_batch_bundle.py:1309
 msgid "Negative Batch Quantity"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:610
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:606
 msgid "Negative Quantity is not allowed"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:615
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:611
 msgid "Negative Valuation Rate is not allowed"
 msgstr ""
 
@@ -31764,7 +31754,7 @@ msgstr ""
 msgid "Net Weight UOM"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1483
+#: erpnext/controllers/accounts_controller.py:1486
 msgid "Net total calculation precision loss"
 msgstr ""
 
@@ -32107,7 +32097,7 @@ msgstr ""
 #: erpnext/accounts/doctype/journal_entry/journal_entry.py:1539
 #: erpnext/accounts/doctype/journal_entry/journal_entry.py:1599
 #: erpnext/accounts/doctype/journal_entry/journal_entry.py:1613
-#: erpnext/stock/doctype/item/item.py:1371
+#: erpnext/stock/doctype/item/item.py:1365
 msgid "No Permission"
 msgstr ""
 
@@ -32129,7 +32119,7 @@ msgstr ""
 msgid "No Selection"
 msgstr ""
 
-#: erpnext/controllers/sales_and_purchase_return.py:919
+#: erpnext/controllers/sales_and_purchase_return.py:824
 msgid "No Serial / Batches are available for return"
 msgstr ""
 
@@ -32165,7 +32155,7 @@ msgstr ""
 msgid "No Work Orders were created"
 msgstr ""
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:785
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:794
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py:689
 msgid "No accounting entries for the following warehouses"
 msgstr ""
@@ -32354,7 +32344,7 @@ msgstr ""
 msgid "No reserved stock to unreserve."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:773
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:769
 msgid "No stock ledger entries were created. Please set the quantity or valuation rate for the items properly and try again."
 msgstr ""
 
@@ -32438,7 +32428,7 @@ msgstr ""
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:566
 #: erpnext/assets/doctype/asset/asset.js:612
 #: erpnext/assets/doctype/asset/asset.js:627
-#: erpnext/controllers/buying_controller.py:225
+#: erpnext/controllers/buying_controller.py:233
 #: erpnext/selling/doctype/product_bundle/product_bundle.py:72
 #: erpnext/setup/doctype/transaction_deletion_record/transaction_deletion_record.py:80
 msgid "Not Allowed"
@@ -32559,10 +32549,10 @@ msgstr ""
 #: erpnext/selling/doctype/customer/customer.py:129
 #: erpnext/selling/doctype/sales_order/sales_order.js:1168
 #: erpnext/stock/doctype/item/item.js:526
-#: erpnext/stock/doctype/item/item.py:567
+#: erpnext/stock/doctype/item/item.py:573
 #: erpnext/stock/doctype/item_price/item_price.json
 #: erpnext/stock/doctype/stock_entry/stock_entry.py:1374
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:972
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:968
 #: erpnext/templates/pages/timelog_info.html:43
 msgid "Note"
 msgstr ""
@@ -32571,7 +32561,7 @@ msgstr ""
 msgid "Note: Automatic log deletion only applies to logs of type <i>Update Cost</i>"
 msgstr "Uwaga: Automatyczne usuwanie logów dotyczy tylko logów typu <i>Update Cost</i>"
 
-#: erpnext/accounts/party.py:690
+#: erpnext/accounts/party.py:696
 msgid "Note: Due Date exceeds allowed {0} credit days by {1} day(s)"
 msgstr ""
 
@@ -32597,7 +32587,7 @@ msgstr ""
 msgid "Note: This Cost Center is a Group. Cannot make accounting entries against groups."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:621
+#: erpnext/stock/doctype/item/item.py:627
 msgid "Note: To merge the items, create a separate Stock Reconciliation for the old item {0}"
 msgstr ""
 
@@ -33360,7 +33350,7 @@ msgstr ""
 
 #. Label of the opening_stock (Float) field in DocType 'Item'
 #. Option for the 'Purpose' (Select) field in DocType 'Stock Reconciliation'
-#: erpnext/stock/doctype/item/item.json erpnext/stock/doctype/item/item.py:296
+#: erpnext/stock/doctype/item/item.json erpnext/stock/doctype/item/item.py:299
 #: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.json
 msgid "Opening Stock"
 msgstr ""
@@ -34080,7 +34070,7 @@ msgstr ""
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:149
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1123
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1125
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:167
 #: erpnext/accounts/report/purchase_register/purchase_register.py:289
 #: erpnext/accounts/report/sales_register/sales_register.py:319
@@ -34119,7 +34109,7 @@ msgstr "Zewnętrzny"
 msgid "Over Billing Allowance (%)"
 msgstr "Dopuszczalne przekroczenie fakturowania (%)"
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:1242
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:1251
 msgid "Over Billing Allowance exceeded for Purchase Receipt Item {0} ({1}) by {2}%"
 msgstr ""
 
@@ -34160,7 +34150,7 @@ msgstr "Dopuszczalne przekroczenie transferu (%)"
 msgid "Overbilling of {0} {1} ignored for item {2} because you have {3} role."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2013
+#: erpnext/controllers/accounts_controller.py:2016
 msgid "Overbilling of {} ignored because you have {} role."
 msgstr ""
 
@@ -34667,7 +34657,7 @@ msgstr ""
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:146
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1117
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1119
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:165
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:172
 #: erpnext/accounts/report/pos_register/pos_register.py:209
@@ -34900,7 +34890,7 @@ msgstr "Procedura rodzicielska"
 msgid "Parent Row No"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom_creator/bom_creator.py:495
+#: erpnext/manufacturing/doctype/bom_creator/bom_creator.py:496
 msgid "Parent Row No not found for {0}"
 msgstr ""
 
@@ -35129,7 +35119,7 @@ msgstr ""
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:142
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:159
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:57
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1054
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1056
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:67
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:147
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:228
@@ -35155,7 +35145,7 @@ msgstr ""
 
 #. Name of a DocType
 #: erpnext/accounts/doctype/party_account/party_account.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1065
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1067
 msgid "Party Account"
 msgstr ""
 
@@ -35182,7 +35172,7 @@ msgstr "Partia konto Waluta"
 msgid "Party Account No. (Bank Statement)"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2278
+#: erpnext/controllers/accounts_controller.py:2281
 msgid "Party Account {0} currency ({1}) and document currency ({2}) should be same"
 msgstr ""
 
@@ -35199,6 +35189,11 @@ msgstr ""
 #: erpnext/accounts/doctype/payment_request/payment_request.json
 msgid "Party Details"
 msgstr "Strona Szczegóły"
+
+#. Label of the party_full_name (Data) field in DocType 'Contract'
+#: erpnext/crm/doctype/contract/contract.json
+msgid "Party Full Name"
+msgstr ""
 
 #. Label of the bank_party_iban (Data) field in DocType 'Bank Transaction'
 #: erpnext/accounts/doctype/bank_transaction/bank_transaction.json
@@ -35283,7 +35278,7 @@ msgstr ""
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:84
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:54
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:44
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1048
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1050
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:54
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:141
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:219
@@ -35305,7 +35300,7 @@ msgstr ""
 msgid "Party Type"
 msgstr ""
 
-#: erpnext/accounts/party.py:819
+#: erpnext/accounts/party.py:825
 msgid "Party Type and Party can only be set for Receivable / Payable account<br><br>{0}"
 msgstr ""
 
@@ -35427,7 +35422,7 @@ msgid "Payable"
 msgstr ""
 
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:42
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1063
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1065
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:211
 #: erpnext/accounts/report/purchase_register/purchase_register.py:194
 #: erpnext/accounts/report/purchase_register/purchase_register.py:235
@@ -35593,7 +35588,7 @@ msgstr ""
 msgid "Payment Entry is already created"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1434
+#: erpnext/controllers/accounts_controller.py:1437
 msgid "Payment Entry {0} is linked against Order {1}, check if it should be pulled as advance in this invoice."
 msgstr ""
 
@@ -35875,7 +35870,7 @@ msgstr ""
 #: erpnext/accounts/doctype/payment_schedule/payment_schedule.json
 #: erpnext/accounts/doctype/payment_term/payment_term.json
 #: erpnext/accounts/doctype/payment_terms_template_detail/payment_terms_template_detail.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1113
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1115
 #: erpnext/accounts/report/gross_profit/gross_profit.py:412
 #: erpnext/accounts/workspace/accounting/accounting.json
 #: erpnext/selling/report/payment_terms_status_for_sales_order/payment_terms_status_for_sales_order.py:30
@@ -36939,7 +36934,7 @@ msgstr ""
 msgid "Please create a new Accounting Dimension if required."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:729
+#: erpnext/controllers/accounts_controller.py:732
 msgid "Please create purchase from internal sale or delivery document itself"
 msgstr ""
 
@@ -36947,7 +36942,7 @@ msgstr ""
 msgid "Please create purchase receipt or purchase invoice for the item {0}"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:649
+#: erpnext/stock/doctype/item/item.py:655
 msgid "Please delete Product Bundle {0}, before merging {1} into {2}"
 msgstr ""
 
@@ -36989,7 +36984,7 @@ msgstr ""
 msgid "Please enable {0} in the {1}."
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:754
+#: erpnext/controllers/selling_controller.py:762
 msgid "Please enable {} in {} to allow same item in multiple rows"
 msgstr ""
 
@@ -37022,7 +37017,7 @@ msgstr ""
 msgid "Please enter Approving Role or Approving User"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:939
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:935
 msgid "Please enter Cost Center"
 msgstr ""
 
@@ -37034,7 +37029,7 @@ msgstr ""
 msgid "Please enter Employee Id of this sales person"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:948
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:944
 msgid "Please enter Expense Account"
 msgstr ""
 
@@ -37043,7 +37038,7 @@ msgstr ""
 msgid "Please enter Item Code to get Batch Number"
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2503
+#: erpnext/public/js/controllers/transaction.js:2529
 msgid "Please enter Item Code to get batch no"
 msgstr ""
 
@@ -37108,7 +37103,7 @@ msgstr ""
 msgid "Please enter company name first"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2764
+#: erpnext/controllers/accounts_controller.py:2767
 msgid "Please enter default currency in Company Master"
 msgstr ""
 
@@ -37144,7 +37139,7 @@ msgstr ""
 msgid "Please enter the phone number first"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:1007
+#: erpnext/controllers/buying_controller.py:1015
 msgid "Please enter the {schedule_date}."
 msgstr ""
 
@@ -37246,7 +37241,7 @@ msgstr ""
 msgid "Please select <b>Template Type</b> to download template"
 msgstr ""
 
-#: erpnext/controllers/taxes_and_totals.py:721
+#: erpnext/controllers/taxes_and_totals.py:731
 #: erpnext/public/js/controllers/taxes_and_totals.js:721
 msgid "Please select Apply Discount On"
 msgstr ""
@@ -37259,7 +37254,7 @@ msgstr ""
 msgid "Please select BOM for Item in Row {0}"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:467
+#: erpnext/controllers/buying_controller.py:475
 msgid "Please select BOM in BOM field for Item {item_code}."
 msgstr "Proszę wybrać BOM w polu BOM dla przedmiotu {item_code}."
 
@@ -37341,7 +37336,7 @@ msgstr ""
 msgid "Please select Qty against item {0}"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:320
+#: erpnext/stock/doctype/item/item.py:323
 msgid "Please select Sample Retention Warehouse in Stock Settings first"
 msgstr ""
 
@@ -37357,7 +37352,7 @@ msgstr ""
 msgid "Please select Subcontracting Order instead of Purchase Order {0}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2613
+#: erpnext/controllers/accounts_controller.py:2616
 msgid "Please select Unrealized Profit / Loss account or add default Unrealized Profit / Loss account account for company {0}"
 msgstr ""
 
@@ -37373,7 +37368,7 @@ msgstr ""
 #: erpnext/manufacturing/doctype/bom/bom.js:603
 #: erpnext/manufacturing/doctype/bom/bom.py:261
 #: erpnext/public/js/controllers/accounts.js:249
-#: erpnext/public/js/controllers/transaction.js:2753
+#: erpnext/public/js/controllers/transaction.js:2779
 msgid "Please select a Company first."
 msgstr ""
 
@@ -37531,7 +37526,7 @@ msgstr ""
 msgid "Please select {0} first"
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:77
+#: erpnext/public/js/controllers/transaction.js:100
 msgid "Please set 'Apply Additional Discount On'"
 msgstr ""
 
@@ -37716,7 +37711,7 @@ msgstr ""
 msgid "Please set filters"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2194
+#: erpnext/controllers/accounts_controller.py:2197
 msgid "Please set one of the following:"
 msgstr ""
 
@@ -37724,7 +37719,7 @@ msgstr ""
 msgid "Please set opening number of booked depreciations"
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2205
+#: erpnext/public/js/controllers/transaction.js:2231
 msgid "Please set recurring after saving"
 msgstr ""
 
@@ -37795,7 +37790,7 @@ msgstr ""
 msgid "Please share this email with your support team so that they can find and fix the issue."
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2073
+#: erpnext/public/js/controllers/transaction.js:2099
 msgid "Please specify"
 msgstr ""
 
@@ -37810,7 +37805,7 @@ msgid "Please specify Company to proceed"
 msgstr ""
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1472
-#: erpnext/controllers/accounts_controller.py:2957
+#: erpnext/controllers/accounts_controller.py:2960
 #: erpnext/public/js/controllers/accounts.js:97
 msgid "Please specify a valid Row ID for row {0} in table {1}"
 msgstr ""
@@ -37823,7 +37818,7 @@ msgstr ""
 msgid "Please specify at least one attribute in the Attributes table"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:605
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:601
 msgid "Please specify either Quantity or Valuation Rate or both"
 msgstr ""
 
@@ -38004,7 +37999,7 @@ msgstr ""
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:16
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:15
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:18
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1046
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1048
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:15
 #: erpnext/accounts/report/bank_clearance_summary/bank_clearance_summary.py:35
 #: erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.html:7
@@ -40185,7 +40180,7 @@ msgstr ""
 #: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.js:48
 #: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:203
 #: erpnext/buying/workspace/buying/buying.json
-#: erpnext/controllers/buying_controller.py:739
+#: erpnext/controllers/buying_controller.py:747
 #: erpnext/crm/doctype/contract/contract.json
 #: erpnext/manufacturing/doctype/blanket_order/blanket_order.js:54
 #: erpnext/manufacturing/doctype/production_plan_sub_assembly_item/production_plan_sub_assembly_item.json
@@ -40324,7 +40319,7 @@ msgstr "Zamówienia zakupu do rachunku"
 msgid "Purchase Orders to Receive"
 msgstr "Zamówienia zakupu do odbioru"
 
-#: erpnext/controllers/accounts_controller.py:1833
+#: erpnext/controllers/accounts_controller.py:1836
 msgid "Purchase Orders {0} are un-linked"
 msgstr ""
 
@@ -40348,8 +40343,8 @@ msgstr ""
 #. Label of a Link in the Stock Workspace
 #. Label of a shortcut in the Stock Workspace
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:171
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:650
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:660
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:652
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:662
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice_list.js:49
 #: erpnext/accounts/doctype/purchase_invoice_item/purchase_invoice_item.json
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:246
@@ -41084,7 +41079,7 @@ msgstr ""
 msgid "Quality Inspection Template Name"
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:334
+#: erpnext/public/js/controllers/transaction.js:360
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:165
 msgid "Quality Inspection(s)"
 msgstr ""
@@ -42268,7 +42263,7 @@ msgid "Receivable / Payable Account"
 msgstr "Konto Należności / Zobowiązań"
 
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:71
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1061
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1063
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py:243
 #: erpnext/accounts/report/sales_register/sales_register.py:217
 #: erpnext/accounts/report/sales_register/sales_register.py:271
@@ -42750,7 +42745,7 @@ msgstr ""
 msgid "Reference Date"
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2311
+#: erpnext/public/js/controllers/transaction.js:2337
 msgid "Reference Date for Early Payment Discount"
 msgstr ""
 
@@ -43074,7 +43069,7 @@ msgstr ""
 msgid "Rejected"
 msgstr ""
 
-#: erpnext/stock/doctype/inventory_dimension/inventory_dimension.py:202
+#: erpnext/stock/doctype/inventory_dimension/inventory_dimension.py:203
 msgid "Rejected "
 msgstr ""
 
@@ -43178,7 +43173,7 @@ msgstr ""
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:187
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:156
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1135
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1137
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:178
 msgid "Remaining Balance"
 msgstr ""
@@ -43231,7 +43226,7 @@ msgstr ""
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:159
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:198
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:269
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1167
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1169
 #: erpnext/accounts/report/general_ledger/general_ledger.html:84
 #: erpnext/accounts/report/general_ledger/general_ledger.html:110
 #: erpnext/accounts/report/general_ledger/general_ledger.py:742
@@ -43980,7 +43975,7 @@ msgstr ""
 msgid "Reserved Quantity for Production"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:2147
+#: erpnext/stock/stock_ledger.py:2155
 msgid "Reserved Serial No."
 msgstr ""
 
@@ -43996,11 +43991,11 @@ msgstr ""
 #: erpnext/stock/doctype/pick_list/pick_list.js:153
 #: erpnext/stock/report/reserved_stock/reserved_stock.json
 #: erpnext/stock/report/stock_balance/stock_balance.py:499
-#: erpnext/stock/stock_ledger.py:2131
+#: erpnext/stock/stock_ledger.py:2139
 msgid "Reserved Stock"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:2177
+#: erpnext/stock/stock_ledger.py:2185
 msgid "Reserved Stock for Batch"
 msgstr ""
 
@@ -44012,7 +44007,7 @@ msgstr ""
 msgid "Reserved Stock for Sub-assembly"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:476
+#: erpnext/controllers/buying_controller.py:484
 msgid "Reserved Warehouse is mandatory for the Item {item_code} in Raw Materials supplied."
 msgstr ""
 
@@ -44826,7 +44821,7 @@ msgstr ""
 msgid "Routing Name"
 msgstr "Nazwa trasy"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:667
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:663
 msgid "Row #"
 msgstr ""
 
@@ -44864,7 +44859,7 @@ msgstr ""
 msgid "Row #{0} (Payment Table): Amount must be positive"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:495
+#: erpnext/stock/doctype/item/item.py:498
 msgid "Row #{0}: A reorder entry already exists for warehouse {1} with reorder type {2}."
 msgstr ""
 
@@ -44885,7 +44880,7 @@ msgstr ""
 msgid "Row #{0}: Accepted Warehouse is mandatory for the accepted Item {1}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1117
+#: erpnext/controllers/accounts_controller.py:1120
 msgid "Row #{0}: Account {1} does not belong to company {2}"
 msgstr ""
 
@@ -44926,27 +44921,27 @@ msgstr ""
 msgid "Row #{0}: Cannot allocate more than {1} against payment term {2}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3524
+#: erpnext/controllers/accounts_controller.py:3527
 msgid "Row #{0}: Cannot delete item {1} which has already been billed."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3498
+#: erpnext/controllers/accounts_controller.py:3501
 msgid "Row #{0}: Cannot delete item {1} which has already been delivered"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3517
+#: erpnext/controllers/accounts_controller.py:3520
 msgid "Row #{0}: Cannot delete item {1} which has already been received"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3504
+#: erpnext/controllers/accounts_controller.py:3507
 msgid "Row #{0}: Cannot delete item {1} which has work order assigned to it."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3510
+#: erpnext/controllers/accounts_controller.py:3513
 msgid "Row #{0}: Cannot delete item {1} which is assigned to customer's purchase order."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3765
+#: erpnext/controllers/accounts_controller.py:3768
 msgid "Row #{0}: Cannot set Rate if the billed amount is greater than the amount for Item {1}."
 msgstr ""
 
@@ -45066,7 +45061,7 @@ msgstr ""
 msgid "Row #{0}: Item {1} has been picked, please reserve stock from the Pick List."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:729
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:725
 msgid "Row #{0}: Item {1} is not a Serialized/Batched Item. It cannot have a Serial No/Batch No against it."
 msgstr "Wiersz #{0}: Przedmiot {1} nie jest seryjny ani partiowy. Nie można przypisać numeru seryjnego/partii do niego."
 
@@ -45122,7 +45117,7 @@ msgstr ""
 msgid "Row #{0}: Please select the Sub Assembly Warehouse"
 msgstr "Wiersz #{0}: Proszę wybrać magazyn podmontażowy"
 
-#: erpnext/stock/doctype/item/item.py:502
+#: erpnext/stock/doctype/item/item.py:505
 msgid "Row #{0}: Please set reorder quantity"
 msgstr ""
 
@@ -45155,8 +45150,8 @@ msgstr ""
 msgid "Row #{0}: Quality Inspection {1} was rejected for item {2}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1274
-#: erpnext/controllers/accounts_controller.py:3624
+#: erpnext/controllers/accounts_controller.py:1277
+#: erpnext/controllers/accounts_controller.py:3627
 msgid "Row #{0}: Quantity for Item {1} cannot be zero."
 msgstr ""
 
@@ -45193,7 +45188,7 @@ msgstr ""
 msgid "Row #{0}: Scrap Item Qty cannot be zero"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:230
+#: erpnext/controllers/selling_controller.py:238
 msgid "Row #{0}: Selling rate for item {1} is lower than its {2}.\n"
 "\t\t\t\t\tSelling {3} should be atleast {4}.<br><br>Alternatively,\n"
 "\t\t\t\t\tyou can disable selling price validation in {5} to bypass\n"
@@ -45277,7 +45272,7 @@ msgstr ""
 msgid "Row #{0}: The batch {1} has already expired."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:511
+#: erpnext/stock/doctype/item/item.py:514
 msgid "Row #{0}: The warehouse {1} is not a child warehouse of a group warehouse {2}"
 msgstr ""
 
@@ -45317,39 +45312,39 @@ msgstr ""
 msgid "Row #{1}: Warehouse is mandatory for stock Item {0}"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:259
+#: erpnext/controllers/buying_controller.py:267
 msgid "Row #{idx}: Cannot select Supplier Warehouse while suppling raw materials to subcontractor."
 msgstr "Wiersz #{idx}: Nie można wybrać magazynu dostawcy podczas dostarczania surowców do podwykonawcy."
 
-#: erpnext/controllers/buying_controller.py:406
+#: erpnext/controllers/buying_controller.py:414
 msgid "Row #{idx}: Item rate has been updated as per valuation rate since its an internal stock transfer."
 msgstr "Wiersz #{idx}: Stawka przedmiotu została zaktualizowana zgodnie z wyceną, ponieważ jest to transfer wewnętrzny zapasów."
 
-#: erpnext/controllers/buying_controller.py:881
+#: erpnext/controllers/buying_controller.py:889
 msgid "Row #{idx}: Please enter a location for the asset item {item_code}."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:537
+#: erpnext/controllers/buying_controller.py:545
 msgid "Row #{idx}: Received Qty must be equal to Accepted + Rejected Qty for Item {item_code}."
 msgstr "Wiersz #{idx}: Odebrana ilość musi być równa zaakceptowanej + odrzuconej ilości dla przedmiotu {item_code}."
 
-#: erpnext/controllers/buying_controller.py:550
+#: erpnext/controllers/buying_controller.py:558
 msgid "Row #{idx}: {field_label} can not be negative for item {item_code}."
 msgstr "Wiersz #{idx}: {field_label} nie może być ujemne dla przedmiotu {item_code}."
 
-#: erpnext/controllers/buying_controller.py:496
+#: erpnext/controllers/buying_controller.py:504
 msgid "Row #{idx}: {field_label} is mandatory."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:518
+#: erpnext/controllers/buying_controller.py:526
 msgid "Row #{idx}: {field_label} is not allowed in Purchase Return."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:250
+#: erpnext/controllers/buying_controller.py:258
 msgid "Row #{idx}: {from_warehouse_field} and {to_warehouse_field} cannot be same."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:999
+#: erpnext/controllers/buying_controller.py:1007
 msgid "Row #{idx}: {schedule_date} cannot be before {transaction_date}."
 msgstr ""
 
@@ -45414,7 +45409,7 @@ msgstr "Wiersz #{}: {}"
 msgid "Row #{}: {} {} does not exist."
 msgstr "Wiersz #{}: {} {} nie istnieje."
 
-#: erpnext/stock/doctype/item/item.py:1403
+#: erpnext/stock/doctype/item/item.py:1397
 msgid "Row #{}: {} {} doesn't belong to Company {}. Please select valid {}."
 msgstr "Wiersz #{}: {} {} nie należy do firmy {}. Proszę wybrać poprawne {}."
 
@@ -45486,11 +45481,11 @@ msgstr ""
 msgid "Row {0}: Both Debit and Credit values cannot be zero"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:222
+#: erpnext/controllers/selling_controller.py:230
 msgid "Row {0}: Conversion Factor is mandatory"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2995
+#: erpnext/controllers/accounts_controller.py:2998
 msgid "Row {0}: Cost Center {1} does not belong to Company {2}"
 msgstr ""
 
@@ -45510,11 +45505,11 @@ msgstr ""
 msgid "Row {0}: Debit entry can not be linked with a {1}"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:776
+#: erpnext/controllers/selling_controller.py:784
 msgid "Row {0}: Delivery Warehouse ({1}) and Customer Warehouse ({2}) can not be same"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2529
+#: erpnext/controllers/accounts_controller.py:2532
 msgid "Row {0}: Due Date in the Payment Terms table cannot be before Posting Date"
 msgstr ""
 
@@ -45523,7 +45518,7 @@ msgid "Row {0}: Either Delivery Note Item or Packed Item reference is mandatory.
 msgstr ""
 
 #: erpnext/accounts/doctype/journal_entry/journal_entry.py:1010
-#: erpnext/controllers/taxes_and_totals.py:1205
+#: erpnext/controllers/taxes_and_totals.py:1215
 msgid "Row {0}: Exchange Rate is mandatory"
 msgstr ""
 
@@ -45572,11 +45567,11 @@ msgstr ""
 msgid "Row {0}: Invalid reference {1}"
 msgstr ""
 
-#: erpnext/controllers/taxes_and_totals.py:142
+#: erpnext/controllers/taxes_and_totals.py:143
 msgid "Row {0}: Item Tax template updated as per validity and rate applied"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:541
+#: erpnext/controllers/selling_controller.py:549
 msgid "Row {0}: Item rate has been updated as per valuation rate since its an internal stock transfer"
 msgstr ""
 
@@ -45696,7 +45691,7 @@ msgstr ""
 msgid "Row {0}: The item {1}, quantity must be positive number"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2972
+#: erpnext/controllers/accounts_controller.py:2975
 msgid "Row {0}: The {3} Account {1} does not belong to the company {2}"
 msgstr ""
 
@@ -45713,7 +45708,7 @@ msgstr ""
 msgid "Row {0}: Workstation or Workstation Type is mandatory for an operation {1}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1011
+#: erpnext/controllers/accounts_controller.py:1014
 msgid "Row {0}: user has not applied the rule {1} on the item {2}"
 msgstr ""
 
@@ -45725,7 +45720,7 @@ msgstr ""
 msgid "Row {0}: {1} must be greater than 0"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:706
+#: erpnext/controllers/accounts_controller.py:709
 msgid "Row {0}: {1} {2} cannot be same as {3} (Party Account) {4}"
 msgstr ""
 
@@ -45741,7 +45736,7 @@ msgstr ""
 msgid "Row {1}: Quantity ({0}) cannot be a fraction. To allow this, disable '{2}' in UOM {3}."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:863
+#: erpnext/controllers/buying_controller.py:871
 msgid "Row {idx}: Asset Naming Series is mandatory for the auto creation of assets for item {item_code}."
 msgstr ""
 
@@ -45767,7 +45762,7 @@ msgstr ""
 msgid "Rows with Same Account heads will be merged on Ledger"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2539
+#: erpnext/controllers/accounts_controller.py:2542
 msgid "Rows with duplicate due dates in other rows were found: {0}"
 msgstr ""
 
@@ -45837,7 +45832,7 @@ msgstr ""
 msgid "SLA Paused On"
 msgstr ""
 
-#: erpnext/public/js/utils.js:1167
+#: erpnext/public/js/utils.js:1163
 msgid "SLA is on hold since {0}"
 msgstr ""
 
@@ -46238,7 +46233,7 @@ msgstr ""
 #: erpnext/accounts/report/sales_register/sales_register.py:238
 #: erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
 #: erpnext/buying/doctype/supplier_quotation_item/supplier_quotation_item.json
-#: erpnext/controllers/selling_controller.py:462
+#: erpnext/controllers/selling_controller.py:470
 #: erpnext/crm/doctype/contract/contract.json
 #: erpnext/maintenance/doctype/maintenance_schedule/maintenance_schedule.js:65
 #: erpnext/maintenance/doctype/maintenance_schedule_item/maintenance_schedule_item.json
@@ -46364,7 +46359,7 @@ msgstr ""
 msgid "Sales Order {0} is not valid"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:443
+#: erpnext/controllers/selling_controller.py:451
 #: erpnext/manufacturing/doctype/work_order/work_order.py:301
 msgid "Sales Order {0} is {1}"
 msgstr ""
@@ -46415,7 +46410,7 @@ msgstr "Zlecenia sprzedaży do realizacji"
 #: erpnext/accounts/doctype/promotional_scheme/promotional_scheme.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:122
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1156
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1158
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:99
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:194
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:74
@@ -46513,7 +46508,7 @@ msgstr ""
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:156
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:137
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:128
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1153
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1155
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:105
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:191
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:80
@@ -46533,7 +46528,7 @@ msgstr ""
 msgid "Sales Person"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:204
+#: erpnext/controllers/selling_controller.py:212
 msgid "Sales Person <b>{0}</b> is disabled."
 msgstr ""
 
@@ -46814,7 +46809,7 @@ msgstr "Przykładowy magazyn retencyjny"
 
 #. Label of the sample_size (Float) field in DocType 'Quality Inspection'
 #: erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py:93
-#: erpnext/public/js/controllers/transaction.js:2369
+#: erpnext/public/js/controllers/transaction.js:2395
 #: erpnext/stock/doctype/quality_inspection/quality_inspection.json
 msgid "Sample Size"
 msgstr ""
@@ -47354,7 +47349,7 @@ msgstr ""
 msgid "Select Items based on Delivery Date"
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2405
+#: erpnext/public/js/controllers/transaction.js:2431
 msgid "Select Items for Quality Inspection"
 msgstr ""
 
@@ -47495,7 +47490,7 @@ msgstr ""
 msgid "Select company name first."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2785
+#: erpnext/controllers/accounts_controller.py:2788
 msgid "Select finance book for the item {0} at row {1}"
 msgstr ""
 
@@ -47708,7 +47703,7 @@ msgid "Send Now"
 msgstr ""
 
 #. Label of the send_sms (Button) field in DocType 'SMS Center'
-#: erpnext/public/js/controllers/transaction.js:517
+#: erpnext/public/js/controllers/transaction.js:543
 #: erpnext/selling/doctype/sms_center/sms_center.json
 msgid "Send SMS"
 msgstr ""
@@ -47866,7 +47861,7 @@ msgstr ""
 #: erpnext/manufacturing/doctype/job_card/job_card.json
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.js:74
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.py:114
-#: erpnext/public/js/controllers/transaction.js:2382
+#: erpnext/public/js/controllers/transaction.js:2408
 #: erpnext/public/js/utils/serial_no_batch_selector.js:421
 #: erpnext/selling/doctype/installation_note_item/installation_note_item.json
 #: erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
@@ -47915,7 +47910,7 @@ msgstr ""
 msgid "Serial No Range"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1894
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1895
 msgid "Serial No Reserved"
 msgstr ""
 
@@ -47955,7 +47950,7 @@ msgstr ""
 msgid "Serial No and Batch Selector cannot be use when Use Serial / Batch Fields is enabled."
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:859
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:860
 msgid "Serial No is mandatory"
 msgstr ""
 
@@ -47984,7 +47979,7 @@ msgstr ""
 msgid "Serial No {0} does not exist"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2623
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2624
 msgid "Serial No {0} does not exists"
 msgstr ""
 
@@ -47992,7 +47987,7 @@ msgstr ""
 msgid "Serial No {0} is already added"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:357
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:358
 msgid "Serial No {0} is not present in the {1} {2}, hence you can't return it against the {1} {2}"
 msgstr ""
 
@@ -48029,11 +48024,11 @@ msgstr ""
 msgid "Serial Nos and Batches"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1370
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1371
 msgid "Serial Nos are created successfully"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:2137
+#: erpnext/stock/stock_ledger.py:2145
 msgid "Serial Nos are reserved in Stock Reservation Entries, you need to unreserve them before proceeding."
 msgstr "Numery seryjne są zarezerwowane w wpisach rezerwacji stanów magazynowych, należy je odblokować przed kontynuowaniem."
 
@@ -48107,11 +48102,11 @@ msgstr ""
 msgid "Serial and Batch Bundle"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1598
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1599
 msgid "Serial and Batch Bundle created"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1664
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1665
 msgid "Serial and Batch Bundle updated"
 msgstr ""
 
@@ -48463,12 +48458,12 @@ msgid "Service Stop Date"
 msgstr ""
 
 #: erpnext/accounts/deferred_revenue.py:44
-#: erpnext/public/js/controllers/transaction.js:1420
+#: erpnext/public/js/controllers/transaction.js:1446
 msgid "Service Stop Date cannot be after Service End Date"
 msgstr ""
 
 #: erpnext/accounts/deferred_revenue.py:41
-#: erpnext/public/js/controllers/transaction.js:1417
+#: erpnext/public/js/controllers/transaction.js:1443
 msgid "Service Stop Date cannot be before Service Start Date"
 msgstr ""
 
@@ -49903,7 +49898,7 @@ msgstr ""
 
 #: erpnext/setup/setup_wizard/operations/defaults_setup.py:70
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:463
-#: erpnext/stock/doctype/item/item.py:245
+#: erpnext/stock/doctype/item/item.py:248
 msgid "Standard Selling"
 msgstr ""
 
@@ -50733,7 +50728,7 @@ msgstr ""
 #. Option for the 'Purpose' (Select) field in DocType 'Stock Reconciliation'
 #. Label of a Link in the Stock Workspace
 #: erpnext/setup/workspace/home/home.json
-#: erpnext/stock/doctype/item/item.py:612
+#: erpnext/stock/doctype/item/item.py:618
 #: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.json
 #: erpnext/stock/workspace/stock/stock.json
 msgid "Stock Reconciliation"
@@ -50744,7 +50739,7 @@ msgstr ""
 msgid "Stock Reconciliation Item"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:612
+#: erpnext/stock/doctype/item/item.py:618
 msgid "Stock Reconciliations"
 msgstr ""
 
@@ -50779,7 +50774,7 @@ msgstr ""
 #: erpnext/stock/doctype/pick_list/pick_list.js:150
 #: erpnext/stock/doctype/pick_list/pick_list.js:155
 #: erpnext/stock/doctype/stock_entry/stock_entry_dashboard.py:25
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:706
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:702
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:575
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:1138
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:1398
@@ -51179,7 +51174,7 @@ msgstr ""
 #: erpnext/setup/doctype/company/company.py:287
 #: erpnext/setup/setup_wizard/operations/defaults_setup.py:33
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:502
-#: erpnext/stock/doctype/item/item.py:282
+#: erpnext/stock/doctype/item/item.py:285
 msgid "Stores"
 msgstr ""
 
@@ -51714,7 +51709,7 @@ msgstr ""
 msgid "Successfully Set Supplier"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:339
+#: erpnext/stock/doctype/item/item.py:342
 msgid "Successfully changed Stock UOM, please redefine conversion factors for new UOM."
 msgstr ""
 
@@ -52016,7 +52011,7 @@ msgstr ""
 #: erpnext/accounts/doctype/tax_rule/tax_rule.json
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:111
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:87
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1160
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1162
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:198
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:237
 #: erpnext/accounts/report/purchase_register/purchase_register.js:27
@@ -52116,7 +52111,7 @@ msgstr ""
 #. Label of the supplier_name (Data) field in DocType 'Purchase Receipt'
 #. Label of the supplier_name (Data) field in DocType 'Stock Entry'
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1077
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1079
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:156
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:198
 #: erpnext/accounts/report/purchase_register/purchase_register.py:177
@@ -52600,7 +52595,7 @@ msgstr ""
 msgid "System will fetch all the entries if limit value is zero."
 msgstr "System pobierze wszystkie wpisy, jeśli wartość graniczna wynosi zero."
 
-#: erpnext/controllers/accounts_controller.py:1975
+#: erpnext/controllers/accounts_controller.py:1978
 msgid "System will not check over billing since amount for Item {0} in {1} is zero"
 msgstr ""
 
@@ -52859,7 +52854,7 @@ msgstr ""
 msgid "Target Warehouse is required before Submit"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:782
+#: erpnext/controllers/selling_controller.py:790
 msgid "Target Warehouse is set for some items but the customer is not an internal customer."
 msgstr ""
 
@@ -53098,7 +53093,7 @@ msgstr "Podział podatków"
 msgid "Tax Category"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:194
+#: erpnext/controllers/buying_controller.py:202
 msgid "Tax Category has been changed to \"Total\" because all the Items are non-stock items"
 msgstr ""
 
@@ -53303,7 +53298,7 @@ msgstr ""
 #. Label of the taxable_amount (Currency) field in DocType 'Tax Withheld
 #. Vouchers'
 #: erpnext/accounts/doctype/tax_withheld_vouchers/tax_withheld_vouchers.json
-#: erpnext/controllers/taxes_and_totals.py:1125
+#: erpnext/controllers/taxes_and_totals.py:1135
 msgid "Taxable Amount"
 msgstr ""
 
@@ -53442,7 +53437,7 @@ msgstr "Podatki i opłaty potrącenia"
 msgid "Taxes and Charges Deducted (Company Currency)"
 msgstr "Podatki i opłaty potrącone (Firmowe)"
 
-#: erpnext/stock/doctype/item/item.py:352
+#: erpnext/stock/doctype/item/item.py:355
 msgid "Taxes row #{0}: {1} cannot be smaller than {2}"
 msgstr ""
 
@@ -53728,7 +53723,7 @@ msgstr "Szablony warunków i regulaminów"
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/territory_item/territory_item.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:134
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1144
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1146
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:93
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:182
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:68
@@ -53832,7 +53827,7 @@ msgstr ""
 msgid "The BOM which will be replaced"
 msgstr "BOM zostanie zastąpiony"
 
-#: erpnext/stock/serial_batch_bundle.py:1274
+#: erpnext/stock/serial_batch_bundle.py:1306
 msgid "The Batch {0} has negative quantity {1} in warehouse {2}. Please correct the quantity."
 msgstr ""
 
@@ -53884,7 +53879,7 @@ msgstr ""
 msgid "The Serial No at Row #{0}: {1} is not available in warehouse {2}."
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1891
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1892
 msgid "The Serial No {0} is reserved against the {1} {2} and cannot be used for any other transaction."
 msgstr ""
 
@@ -53967,7 +53962,7 @@ msgstr ""
 msgid "The following batches are expired, please restock them: <br> {0}"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:849
+#: erpnext/stock/doctype/item/item.py:843
 msgid "The following deleted attributes exist in Variants but not in the Template. You can either delete the Variants or keep the attribute(s) in template."
 msgstr ""
 
@@ -53992,15 +53987,15 @@ msgstr "Waga brutto opakowania. Zazwyczaj waga netto + waga materiału z jakiego
 msgid "The holiday on {0} is not between From Date and To Date"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:1066
+#: erpnext/controllers/buying_controller.py:1074
 msgid "The item {item} is not marked as {type_of} item. You can enable it as {type_of} item from its Item master."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:614
+#: erpnext/stock/doctype/item/item.py:620
 msgid "The items {0} and {1} are present in the following {2} :"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:1059
+#: erpnext/controllers/buying_controller.py:1067
 msgid "The items {items} are not marked as {type_of} item. You can enable them as {type_of} item from their Item masters."
 msgstr ""
 
@@ -54102,8 +54097,8 @@ msgstr ""
 msgid "The seller and the buyer cannot be the same"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:142
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:154
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:143
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:155
 msgid "The serial and batch bundle {0} not linked to {1} {2}"
 msgstr ""
 
@@ -54127,7 +54122,7 @@ msgstr ""
 msgid "The stock for the item {0} in the {1} warehouse was negative on the {2}. You should create a positive entry {3} before the date {4} and time {5} to post the correct valuation rate. For more details, please read the <a href='https://docs.erpnext.com/docs/user/manual/en/stock-adjustment-cogs-with-negative-stock'>documentation<a>."
 msgstr "Zapasy dla pozycji {0} w magazynie {1} były ujemne w dniu {2}. Powinieneś utworzyć pozytywny zapis {3} przed datą {4} i godziną {5}, aby zaksięgować prawidłową wartość wyceny. Aby uzyskać więcej informacji, przeczytaj <a href='https://docs.erpnext.com/docs/user/manual/en/stock-adjustment-cogs-with-negative-stock'>dokumentację<a>."
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:700
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:696
 msgid "The stock has been reserved for the following Items and Warehouses, un-reserve the same to {0} the Stock Reconciliation: <br /><br /> {1}"
 msgstr ""
 
@@ -54140,11 +54135,11 @@ msgstr ""
 msgid "The task has been enqueued as a background job."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:994
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:990
 msgid "The task has been enqueued as a background job. In case there is any issue on processing in background, the system will add a comment about the error on this Stock Reconciliation and revert to the Draft stage"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1005
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1001
 msgid "The task has been enqueued as a background job. In case there is any issue on processing in background, the system will add a comment about the error on this Stock Reconciliation and revert to the Submitted stage"
 msgstr ""
 
@@ -54194,7 +54189,7 @@ msgstr ""
 msgid "The {0} ({1}) must be equal to {2} ({3})"
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2790
+#: erpnext/public/js/controllers/transaction.js:2816
 msgid "The {0} contains Unit Price Items."
 msgstr ""
 
@@ -54242,7 +54237,7 @@ msgstr ""
 msgid "There can be multiple tiered collection factor based on the total spent. But the conversion factor for redemption will always be same for all the tier."
 msgstr "Może istnieć wiele warstwowych współczynników zbierania w oparciu o całkowitą ilość wydanych pieniędzy. Jednak współczynnik konwersji dla umorzenia będzie zawsze taki sam dla wszystkich poziomów."
 
-#: erpnext/accounts/party.py:580
+#: erpnext/accounts/party.py:586
 msgid "There can only be 1 Account per Company in {0} {1}"
 msgstr ""
 
@@ -54528,7 +54523,7 @@ msgstr "To będzie dołączany do Kodeksu poz wariantu. Na przykład, jeśli skr
 msgid "This will restrict user access to other employee records"
 msgstr "To ograniczy dostęp użytkowników do innych rekordów pracowników"
 
-#: erpnext/controllers/selling_controller.py:783
+#: erpnext/controllers/selling_controller.py:791
 msgid "This {} will be treated as material transfer."
 msgstr ""
 
@@ -55242,11 +55237,11 @@ msgid "To include sub-assembly costs and scrap items in Finished Goods on a work
 msgstr ""
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:2337
-#: erpnext/controllers/accounts_controller.py:3005
+#: erpnext/controllers/accounts_controller.py:3008
 msgid "To include tax in row {0} in Item rate, taxes in rows {1} must also be included"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:636
+#: erpnext/stock/doctype/item/item.py:642
 msgid "To merge, following properties must be same for both items"
 msgstr ""
 
@@ -55866,7 +55861,7 @@ msgstr ""
 msgid "Total Paid Amount"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2591
+#: erpnext/controllers/accounts_controller.py:2594
 msgid "Total Payment Amount in Payment Schedule must be equal to Grand / Rounded Total"
 msgstr ""
 
@@ -56151,15 +56146,15 @@ msgstr ""
 msgid "Total Working Hours"
 msgstr "Całkowita liczba godzin pracy"
 
-#: erpnext/controllers/accounts_controller.py:2138
+#: erpnext/controllers/accounts_controller.py:2141
 msgid "Total advance ({0}) against Order {1} cannot be greater than the Grand Total ({2})"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:190
+#: erpnext/controllers/selling_controller.py:198
 msgid "Total allocated percentage for sales team should be 100"
 msgstr ""
 
-#: erpnext/selling/doctype/customer/customer.py:162
+#: erpnext/selling/doctype/customer/customer.py:161
 msgid "Total contribution percentage should be equal to 100"
 msgstr ""
 
@@ -57044,7 +57039,7 @@ msgstr ""
 msgid "Unit of Measure (UOM)"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:384
+#: erpnext/stock/doctype/item/item.py:387
 msgid "Unit of Measure {0} has been entered more than once in Conversion Factor Table"
 msgstr ""
 
@@ -57486,7 +57481,7 @@ msgstr ""
 msgid "Update timestamp on new communication"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom_creator/bom_creator.py:533
+#: erpnext/manufacturing/doctype/bom_creator/bom_creator.py:534
 msgid "Updated successfully"
 msgstr ""
 
@@ -57500,7 +57495,7 @@ msgstr ""
 msgid "Updated via 'Time Log' (In Minutes)"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1387
+#: erpnext/stock/doctype/item/item.py:1381
 msgid "Updating Variants..."
 msgstr ""
 
@@ -58058,19 +58053,19 @@ msgstr ""
 msgid "Valuation Rate (In / Out)"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1881
+#: erpnext/stock/stock_ledger.py:1890
 msgid "Valuation Rate Missing"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1859
+#: erpnext/stock/stock_ledger.py:1868
 msgid "Valuation Rate for the Item {0}, is required to do accounting entries for {1} {2}."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:266
+#: erpnext/stock/doctype/item/item.py:269
 msgid "Valuation Rate is mandatory if Opening Stock entered"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:752
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:748
 msgid "Valuation Rate required for Item {0} at row {1}"
 msgstr ""
 
@@ -58080,7 +58075,7 @@ msgstr ""
 msgid "Valuation and Total"
 msgstr "Wycena i kwota całkowita"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:971
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:967
 msgid "Valuation rate for customer provided items has been set to zero."
 msgstr ""
 
@@ -58094,7 +58089,7 @@ msgid "Valuation rate for the item as per Sales Invoice (Only for Internal Trans
 msgstr ""
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:2361
-#: erpnext/controllers/accounts_controller.py:3029
+#: erpnext/controllers/accounts_controller.py:3032
 msgid "Valuation type charges can not be marked as Inclusive"
 msgstr ""
 
@@ -58250,7 +58245,7 @@ msgstr ""
 msgid "Variant"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:864
+#: erpnext/stock/doctype/item/item.py:858
 msgid "Variant Attribute Error"
 msgstr ""
 
@@ -58269,7 +58264,7 @@ msgstr ""
 msgid "Variant Based On"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:892
+#: erpnext/stock/doctype/item/item.py:886
 msgid "Variant Based On cannot be changed"
 msgstr ""
 
@@ -58287,7 +58282,7 @@ msgstr ""
 msgid "Variant Item"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:862
+#: erpnext/stock/doctype/item/item.py:856
 msgid "Variant Items"
 msgstr ""
 
@@ -58405,7 +58400,7 @@ msgstr ""
 #: erpnext/accounts/doctype/cost_center/cost_center_tree.js:56
 #: erpnext/accounts/doctype/invoice_discounting/invoice_discounting.js:205
 #: erpnext/accounts/doctype/journal_entry/journal_entry.js:43
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:668
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:670
 #: erpnext/bulk_transaction/doctype/bulk_transaction_log/bulk_transaction_log.js:14
 #: erpnext/bulk_transaction/doctype/bulk_transaction_log/bulk_transaction_log.js:24
 #: erpnext/buying/doctype/request_for_quotation/request_for_quotation.js:167
@@ -58592,7 +58587,7 @@ msgstr "Nazwa Voucheru"
 #: erpnext/accounts/doctype/repost_accounting_ledger_items/repost_accounting_ledger_items.json
 #: erpnext/accounts/doctype/repost_payment_ledger_items/repost_payment_ledger_items.json
 #: erpnext/accounts/doctype/unreconcile_payment/unreconcile_payment.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1099
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1101
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.js:42
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:209
 #: erpnext/accounts/report/general_ledger/general_ledger.js:49
@@ -58623,7 +58618,7 @@ msgstr "Nazwa Voucheru"
 msgid "Voucher No"
 msgstr "Nr Voucheru"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1087
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1088
 msgid "Voucher No is mandatory"
 msgstr "Nr Voucheru jest wymagany"
 
@@ -58665,7 +58660,7 @@ msgstr "Podtyp Voucheru"
 #: erpnext/accounts/doctype/repost_payment_ledger_items/repost_payment_ledger_items.json
 #: erpnext/accounts/doctype/tax_withheld_vouchers/tax_withheld_vouchers.json
 #: erpnext/accounts/doctype/unreconcile_payment/unreconcile_payment.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1097
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1099
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:200
 #: erpnext/accounts/report/general_ledger/general_ledger.py:697
 #: erpnext/accounts/report/invalid_ledger_entries/invalid_ledger_entries.py:31
@@ -59019,10 +59014,6 @@ msgstr ""
 msgid "Warehouse not found against the account {0}"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:600
-msgid "Warehouse not found in the system"
-msgstr ""
-
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:1130
 #: erpnext/stock/doctype/delivery_note/delivery_note.py:414
 msgid "Warehouse required for stock Item {0}"
@@ -59151,7 +59142,7 @@ msgid "Warn for new Request for Quotations"
 msgstr "Ostrzegaj przed nowym żądaniem ofert"
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:744
-#: erpnext/controllers/accounts_controller.py:1978
+#: erpnext/controllers/accounts_controller.py:1981
 #: erpnext/stock/doctype/delivery_trip/delivery_trip.js:145
 #: erpnext/utilities/transaction_base.py:123
 msgid "Warning"
@@ -60123,7 +60114,7 @@ msgstr ""
 msgid "You are importing data for the code list:"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3611
+#: erpnext/controllers/accounts_controller.py:3614
 msgid "You are not allowed to update as per the conditions set in {} Workflow."
 msgstr ""
 
@@ -60188,7 +60179,7 @@ msgstr ""
 msgid "You can't make any changes to Job Card since Work Order is closed."
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:185
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:186
 msgid "You can't process the serial number {0} as it has already been used in the SABB {1}. {2} if you want to inward same serial number multiple times then enabled 'Allow existing Serial No to be Manufactured/Received again' in the {3}"
 msgstr ""
 
@@ -60248,7 +60239,7 @@ msgstr ""
 msgid "You cannot {0} this document because another Period Closing Entry {1} exists after {2}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3587
+#: erpnext/controllers/accounts_controller.py:3590
 msgid "You do not have permissions to {} items in a {}."
 msgstr ""
 
@@ -60276,7 +60267,7 @@ msgstr ""
 msgid "You have entered a duplicate Delivery Note on Row"
 msgstr "Wprowadziłeś zduplikowaną notę dostawy w wierszu."
 
-#: erpnext/stock/doctype/item/item.py:1063
+#: erpnext/stock/doctype/item/item.py:1057
 msgid "You have to enable auto re-order in Stock Settings to maintain re-order levels."
 msgstr ""
 
@@ -60296,7 +60287,7 @@ msgstr ""
 msgid "You need to cancel POS Closing Entry {} to be able to cancel this document."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2980
+#: erpnext/controllers/accounts_controller.py:2983
 msgid "You selected the account group {1} as {2} Account in row {0}. Please select a single account."
 msgstr ""
 
@@ -60374,7 +60365,7 @@ msgstr ""
 msgid "`Allow Negative rates for Items`"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1873
+#: erpnext/stock/stock_ledger.py:1882
 msgid "after"
 msgstr ""
 
@@ -60522,7 +60513,7 @@ msgstr "lft"
 msgid "material_request_item"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:151
+#: erpnext/controllers/selling_controller.py:159
 msgid "must be between 0 and 100"
 msgstr ""
 
@@ -60547,7 +60538,7 @@ msgstr ""
 msgid "on"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1289
+#: erpnext/controllers/accounts_controller.py:1292
 msgid "or"
 msgstr ""
 
@@ -60596,7 +60587,7 @@ msgstr ""
 msgid "per hour"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1874
+#: erpnext/stock/stock_ledger.py:1883
 msgid "performing either one below:"
 msgstr ""
 
@@ -60723,7 +60714,7 @@ msgstr ""
 msgid "{0}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1109
+#: erpnext/controllers/accounts_controller.py:1112
 msgid "{0} '{1}' is disabled"
 msgstr ""
 
@@ -60739,7 +60730,7 @@ msgstr ""
 msgid "{0} <b>{1}</b> has submitted Assets. Remove Item <b>{2}</b> from table to continue."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2193
+#: erpnext/controllers/accounts_controller.py:2196
 msgid "{0} Account not found against Customer {1}."
 msgstr ""
 
@@ -60771,7 +60762,7 @@ msgstr ""
 msgid "{0} Request for {1}"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:323
+#: erpnext/stock/doctype/item/item.py:326
 msgid "{0} Retain Sample is based on batch, please check Has Batch No to retain sample of item"
 msgstr ""
 
@@ -60862,7 +60853,7 @@ msgid "{0} entered twice in Item Tax"
 msgstr ""
 
 #: erpnext/setup/doctype/item_group/item_group.py:48
-#: erpnext/stock/doctype/item/item.py:436
+#: erpnext/stock/doctype/item/item.py:439
 msgid "{0} entered twice {1} in Item Taxes"
 msgstr ""
 
@@ -60883,7 +60874,7 @@ msgstr ""
 msgid "{0} hours"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2534
+#: erpnext/controllers/accounts_controller.py:2537
 msgid "{0} in row {1}"
 msgstr ""
 
@@ -60907,7 +60898,7 @@ msgstr ""
 
 #: erpnext/accounts/doctype/budget/budget.py:60
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:643
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:49
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:50
 #: erpnext/accounts/report/general_ledger/general_ledger.py:59
 #: erpnext/accounts/report/pos_register/pos_register.py:107
 #: erpnext/controllers/trends.py:50
@@ -60927,11 +60918,11 @@ msgstr ""
 msgid "{0} is mandatory. Maybe Currency Exchange record is not created for {1} to {2}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2937
+#: erpnext/controllers/accounts_controller.py:2940
 msgid "{0} is mandatory. Maybe Currency Exchange record is not created for {1} to {2}."
 msgstr ""
 
-#: erpnext/selling/doctype/customer/customer.py:204
+#: erpnext/selling/doctype/customer/customer.py:203
 msgid "{0} is not a company bank account"
 msgstr ""
 
@@ -61014,7 +61005,7 @@ msgstr ""
 msgid "{0} to {1}"
 msgstr "{0} do {1}"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:690
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:686
 msgid "{0} units are reserved for Item {1} in Warehouse {2}, please un-reserve the same to {3} the Stock Reconciliation."
 msgstr ""
 
@@ -61030,16 +61021,16 @@ msgstr ""
 msgid "{0} units of {1} are required in {2} with the inventory dimension: {3} ({4}) on {5} {6} for {7} to complete the transaction."
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1532 erpnext/stock/stock_ledger.py:2023
-#: erpnext/stock/stock_ledger.py:2037
+#: erpnext/stock/stock_ledger.py:1541 erpnext/stock/stock_ledger.py:2031
+#: erpnext/stock/stock_ledger.py:2045
 msgid "{0} units of {1} needed in {2} on {3} {4} for {5} to complete this transaction."
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:2124 erpnext/stock/stock_ledger.py:2170
+#: erpnext/stock/stock_ledger.py:2132 erpnext/stock/stock_ledger.py:2178
 msgid "{0} units of {1} needed in {2} on {3} {4} to complete this transaction."
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1526
+#: erpnext/stock/stock_ledger.py:1535
 msgid "{0} units of {1} needed in {2} to complete this transaction."
 msgstr ""
 
@@ -61085,7 +61076,7 @@ msgstr ""
 msgid "{0} {1} does not exist"
 msgstr ""
 
-#: erpnext/accounts/party.py:560
+#: erpnext/accounts/party.py:566
 msgid "{0} {1} has accounting entries in currency {2} for company {3}. Please select a receivable or payable account with currency {2}."
 msgstr ""
 
@@ -61119,7 +61110,7 @@ msgstr ""
 msgid "{0} {1} is associated with {2}, but Party Account is {3}"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:462
+#: erpnext/controllers/selling_controller.py:470
 #: erpnext/controllers/subcontracting_controller.py:954
 msgid "{0} {1} is cancelled or closed"
 msgstr ""
@@ -61136,11 +61127,11 @@ msgstr ""
 msgid "{0} {1} is closed"
 msgstr ""
 
-#: erpnext/accounts/party.py:798
+#: erpnext/accounts/party.py:804
 msgid "{0} {1} is disabled"
 msgstr ""
 
-#: erpnext/accounts/party.py:804
+#: erpnext/accounts/party.py:810
 msgid "{0} {1} is frozen"
 msgstr ""
 
@@ -61148,7 +61139,7 @@ msgstr ""
 msgid "{0} {1} is fully billed"
 msgstr ""
 
-#: erpnext/accounts/party.py:808
+#: erpnext/accounts/party.py:814
 msgid "{0} {1} is not active"
 msgstr ""
 
@@ -61274,15 +61265,15 @@ msgstr ""
 msgid "{0}: {1} must be less than {2}"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:840
+#: erpnext/controllers/buying_controller.py:848
 msgid "{count} Assets created for {item_code}"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:738
+#: erpnext/controllers/buying_controller.py:746
 msgid "{doctype} {name} is cancelled or closed."
 msgstr "{doctype} {name} zostanie anulowane lub zamknięte."
 
-#: erpnext/controllers/buying_controller.py:459
+#: erpnext/controllers/buying_controller.py:467
 msgid "{field_label} is mandatory for sub-contracted {doctype}."
 msgstr ""
 
@@ -61290,7 +61281,7 @@ msgstr ""
 msgid "{item_name}'s Sample Size ({sample_size}) cannot be greater than the Accepted Quantity ({accepted_quantity})"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:563
+#: erpnext/controllers/buying_controller.py:571
 msgid "{ref_doctype} {ref_name} is {status}."
 msgstr ""
 
@@ -61356,7 +61347,7 @@ msgstr ""
 msgid "{} can't be cancelled since the Loyalty Points earned has been redeemed. First cancel the {} No {}"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:222
+#: erpnext/controllers/buying_controller.py:230
 msgid "{} has submitted assets linked to it. You need to cancel the assets to create purchase return."
 msgstr ""
 

--- a/erpnext/locale/pt.po
+++ b/erpnext/locale/pt.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: frappe\n"
 "Report-Msgid-Bugs-To: hello@frappe.io\n"
-"POT-Creation-Date: 2025-05-25 09:35+0000\n"
-"PO-Revision-Date: 2025-05-25 20:35\n"
+"POT-Creation-Date: 2025-06-01 09:36+0000\n"
+"PO-Revision-Date: 2025-06-01 21:35\n"
 "Last-Translator: hello@frappe.io\n"
 "Language-Team: Portuguese\n"
 "MIME-Version: 1.0\n"
@@ -83,15 +83,15 @@ msgstr ""
 msgid " Summary"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:235
+#: erpnext/stock/doctype/item/item.py:238
 msgid "\"Customer Provided Item\" cannot be Purchase Item also"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:237
+#: erpnext/stock/doctype/item/item.py:240
 msgid "\"Customer Provided Item\" cannot have Valuation Rate"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:313
+#: erpnext/stock/doctype/item/item.py:316
 msgid "\"Is Fixed Asset\" cannot be unchecked, as Asset record exists against the item"
 msgstr ""
 
@@ -213,7 +213,7 @@ msgstr ""
 msgid "% of materials delivered against this Sales Order"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2197
+#: erpnext/controllers/accounts_controller.py:2200
 msgid "'Account' in the Accounting section of Customer {0}"
 msgstr ""
 
@@ -225,15 +225,11 @@ msgstr ""
 msgid "'Based On' and 'Group By' can not be same"
 msgstr ""
 
-#: erpnext/stock/report/product_bundle_balance/product_bundle_balance.py:233
-msgid "'Date' is required"
-msgstr ""
-
 #: erpnext/selling/report/inactive_customers/inactive_customers.py:18
 msgid "'Days Since Last Order' must be greater than or equal to zero"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2202
+#: erpnext/controllers/accounts_controller.py:2205
 msgid "'Default {0} Account' in Company {1}"
 msgstr ""
 
@@ -243,7 +239,7 @@ msgstr ""
 
 #: erpnext/stock/report/batch_item_expiry_status/batch_item_expiry_status.py:24
 #: erpnext/stock/report/batch_wise_balance_history/batch_wise_balance_history.py:120
-#: erpnext/stock/report/stock_analytics/stock_analytics.py:314
+#: erpnext/stock/report/stock_analytics/stock_analytics.py:313
 msgid "'From Date' is required"
 msgstr ""
 
@@ -251,7 +247,7 @@ msgstr ""
 msgid "'From Date' must be after 'To Date'"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:398
+#: erpnext/stock/doctype/item/item.py:401
 msgid "'Has Serial No' can not be 'Yes' for non-stock item"
 msgstr ""
 
@@ -1075,7 +1071,7 @@ msgstr ""
 
 #. Label of the qty (Float) field in DocType 'Purchase Receipt Item'
 #. Label of the qty (Float) field in DocType 'Subcontracting Receipt Item'
-#: erpnext/public/js/controllers/transaction.js:2362
+#: erpnext/public/js/controllers/transaction.js:2388
 #: erpnext/stock/doctype/purchase_receipt_item/purchase_receipt_item.json
 #: erpnext/subcontracting/doctype/subcontracting_receipt_item/subcontracting_receipt_item.json
 msgid "Accepted Quantity"
@@ -1273,7 +1269,7 @@ msgid "Account Manager"
 msgstr ""
 
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:949
-#: erpnext/controllers/accounts_controller.py:2206
+#: erpnext/controllers/accounts_controller.py:2209
 msgid "Account Missing"
 msgstr ""
 
@@ -1448,7 +1444,7 @@ msgstr ""
 msgid "Account {0} is frozen"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1288
+#: erpnext/controllers/accounts_controller.py:1291
 msgid "Account {0} is invalid. Account Currency must be {1}"
 msgstr ""
 
@@ -1484,7 +1480,7 @@ msgstr ""
 msgid "Account: {0} is not permitted under Payment Entry"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3037
+#: erpnext/controllers/accounts_controller.py:3040
 msgid "Account: {0} with currency: {1} can not be selected"
 msgstr ""
 
@@ -1757,7 +1753,7 @@ msgstr ""
 msgid "Accounting Entry for Asset"
 msgstr ""
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:796
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:805
 msgid "Accounting Entry for Service"
 msgstr ""
 
@@ -1772,18 +1768,18 @@ msgstr ""
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py:1468
 #: erpnext/controllers/stock_controller.py:550
 #: erpnext/controllers/stock_controller.py:567
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:889
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:898
 #: erpnext/stock/doctype/stock_entry/stock_entry.py:1586
 #: erpnext/stock/doctype/stock_entry/stock_entry.py:1600
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py:561
 msgid "Accounting Entry for Stock"
 msgstr ""
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:717
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:726
 msgid "Accounting Entry for {0}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2247
+#: erpnext/controllers/accounts_controller.py:2250
 msgid "Accounting Entry for {0}: {1} can only be made in currency: {2}"
 msgstr ""
 
@@ -2176,7 +2172,7 @@ msgstr ""
 msgid "Accumulated Monthly"
 msgstr ""
 
-#: erpnext/controllers/budget_controller.py:417
+#: erpnext/controllers/budget_controller.py:422
 msgid "Accumulated Monthly Budget for Account {0} against {1} {2} is {3}. It will be collectively ({4}) exceeded by {5}"
 msgstr ""
 
@@ -3290,7 +3286,7 @@ msgstr ""
 msgid "Adjustment Against"
 msgstr ""
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:634
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:643
 msgid "Adjustment based on Purchase Invoice rate"
 msgstr ""
 
@@ -3401,7 +3397,7 @@ msgstr ""
 msgid "Advance amount"
 msgstr ""
 
-#: erpnext/controllers/taxes_and_totals.py:845
+#: erpnext/controllers/taxes_and_totals.py:855
 msgid "Advance amount cannot be greater than {0} {1}"
 msgstr ""
 
@@ -3612,7 +3608,7 @@ msgstr ""
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:152
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:133
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1125
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1127
 msgid "Age (Days)"
 msgstr ""
 
@@ -3697,16 +3693,6 @@ msgstr ""
 
 #: erpnext/setup/setup_wizard/data/industry_type.txt:4
 msgid "Agriculture"
-msgstr ""
-
-#. Name of a role
-#: erpnext/assets/doctype/location/location.json
-msgid "Agriculture Manager"
-msgstr ""
-
-#. Name of a role
-#: erpnext/assets/doctype/location/location.json
-msgid "Agriculture User"
 msgstr ""
 
 #: erpnext/setup/setup_wizard/data/industry_type.txt:5
@@ -3899,7 +3885,7 @@ msgstr ""
 msgid "All items are already requested"
 msgstr ""
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:1317
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:1326
 msgid "All items have already been Invoiced/Returned"
 msgstr ""
 
@@ -3911,7 +3897,7 @@ msgstr ""
 msgid "All items have already been transferred for this Work Order."
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2465
+#: erpnext/public/js/controllers/transaction.js:2491
 msgid "All items in this document already have a linked Quality Inspection."
 msgstr ""
 
@@ -4109,7 +4095,7 @@ msgstr ""
 msgid "Allow Item To Be Added Multiple Times in a Transaction"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:755
+#: erpnext/controllers/selling_controller.py:763
 msgid "Allow Item to Be Added Multiple Times in a Transaction"
 msgstr ""
 
@@ -5055,7 +5041,7 @@ msgstr ""
 msgid "Annual Billing: {0}"
 msgstr ""
 
-#: erpnext/controllers/budget_controller.py:441
+#: erpnext/controllers/budget_controller.py:446
 msgid "Annual Budget for Account {0} against {1} {2} is {3}. It will be collectively ({4}) exceeded by {5}"
 msgstr ""
 
@@ -5544,7 +5530,7 @@ msgstr ""
 msgid "As the field {0} is enabled, the value of the field {1} should be more than 1."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:989
+#: erpnext/stock/doctype/item/item.py:983
 msgid "As there are existing submitted transactions against item {0}, you can not change the value of {1}."
 msgstr ""
 
@@ -5690,7 +5676,7 @@ msgstr ""
 msgid "Asset Category Name"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:304
+#: erpnext/stock/doctype/item/item.py:307
 msgid "Asset Category is mandatory for Fixed Asset item"
 msgstr ""
 
@@ -6065,7 +6051,7 @@ msgstr ""
 msgid "Asset {0} must be submitted"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:851
+#: erpnext/controllers/buying_controller.py:859
 msgid "Asset {assets_link} created for {item_code}"
 msgstr ""
 
@@ -6095,11 +6081,11 @@ msgstr ""
 msgid "Assets"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:869
+#: erpnext/controllers/buying_controller.py:877
 msgid "Assets not created for {item_code}. You will have to create asset manually."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:856
+#: erpnext/controllers/buying_controller.py:864
 msgid "Assets {assets_link} created for {item_code}"
 msgstr ""
 
@@ -6194,7 +6180,7 @@ msgstr ""
 msgid "At row #{0}: you have selected the Difference Account {1}, which is a Cost of Goods Sold type account. Please select a different account"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:864
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:865
 msgid "At row {0}: Batch No is mandatory for Item {1}"
 msgstr ""
 
@@ -6202,11 +6188,11 @@ msgstr ""
 msgid "At row {0}: Parent Row No cannot be set for item {1}"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:849
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:850
 msgid "At row {0}: Qty is mandatory for the batch {1}"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:856
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:857
 msgid "At row {0}: Serial No is mandatory for Item {1}"
 msgstr ""
 
@@ -6280,7 +6266,7 @@ msgstr ""
 msgid "Attribute Value"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:930
+#: erpnext/stock/doctype/item/item.py:924
 msgid "Attribute table is mandatory"
 msgstr ""
 
@@ -6288,11 +6274,11 @@ msgstr ""
 msgid "Attribute value: {0} must appear only once"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:934
+#: erpnext/stock/doctype/item/item.py:928
 msgid "Attribute {0} selected multiple times in Attributes Table"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:862
+#: erpnext/stock/doctype/item/item.py:856
 msgid "Attributes"
 msgstr ""
 
@@ -7576,11 +7562,11 @@ msgstr ""
 msgid "Barcode Type"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:457
+#: erpnext/stock/doctype/item/item.py:460
 msgid "Barcode {0} already used in Item {1}"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:472
+#: erpnext/stock/doctype/item/item.py:475
 msgid "Barcode {0} is not a valid {1} code"
 msgstr ""
 
@@ -7834,7 +7820,7 @@ msgstr ""
 #: erpnext/manufacturing/doctype/job_card/job_card.json
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.js:89
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.py:115
-#: erpnext/public/js/controllers/transaction.js:2388
+#: erpnext/public/js/controllers/transaction.js:2414
 #: erpnext/public/js/utils/barcode_scanner.js:260
 #: erpnext/public/js/utils/serial_no_batch_selector.js:438
 #: erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
@@ -7861,11 +7847,11 @@ msgstr ""
 msgid "Batch No"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:867
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:868
 msgid "Batch No is mandatory"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2629
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2630
 msgid "Batch No {0} does not exists"
 msgstr ""
 
@@ -7873,7 +7859,7 @@ msgstr ""
 msgid "Batch No {0} is linked with Item {1} which has serial no. Please scan serial no instead."
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:364
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:365
 msgid "Batch No {0} is not present in the original {1} {2}, hence you can't return it against the {1} {2}"
 msgstr ""
 
@@ -7888,11 +7874,11 @@ msgstr ""
 msgid "Batch Nos"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1421
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1422
 msgid "Batch Nos are created successfully"
 msgstr ""
 
-#: erpnext/controllers/sales_and_purchase_return.py:1096
+#: erpnext/controllers/sales_and_purchase_return.py:1001
 msgid "Batch Not Available for Return"
 msgstr ""
 
@@ -7941,7 +7927,7 @@ msgstr ""
 msgid "Batch {0} and Warehouse"
 msgstr ""
 
-#: erpnext/controllers/sales_and_purchase_return.py:1095
+#: erpnext/controllers/sales_and_purchase_return.py:1000
 msgid "Batch {0} is not available in warehouse {1}"
 msgstr ""
 
@@ -7991,7 +7977,7 @@ msgstr ""
 #. Label of the bill_date (Date) field in DocType 'Journal Entry'
 #. Label of the bill_date (Date) field in DocType 'Subcontracting Receipt'
 #: erpnext/accounts/doctype/journal_entry/journal_entry.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1110
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1112
 #: erpnext/accounts/report/purchase_register/purchase_register.py:214
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.json
 msgid "Bill Date"
@@ -8000,7 +7986,7 @@ msgstr ""
 #. Label of the bill_no (Data) field in DocType 'Journal Entry'
 #. Label of the bill_no (Data) field in DocType 'Subcontracting Receipt'
 #: erpnext/accounts/doctype/journal_entry/journal_entry.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1109
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1111
 #: erpnext/accounts/report/purchase_register/purchase_register.py:213
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.json
 msgid "Bill No"
@@ -8220,7 +8206,7 @@ msgstr ""
 msgid "Billing Zipcode"
 msgstr ""
 
-#: erpnext/accounts/party.py:602
+#: erpnext/accounts/party.py:608
 msgid "Billing currency must be equal to either default company's currency or party account currency"
 msgstr ""
 
@@ -9217,7 +9203,7 @@ msgid "Can only make payment against unbilled {0}"
 msgstr ""
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1458
-#: erpnext/controllers/accounts_controller.py:2946
+#: erpnext/controllers/accounts_controller.py:2949
 #: erpnext/public/js/controllers/accounts.js:90
 msgid "Can refer row only if the charge type is 'On Previous Row Amount' or 'Previous Row Total'"
 msgstr ""
@@ -9379,9 +9365,9 @@ msgstr ""
 msgid "Cannot Create Return"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:625
-#: erpnext/stock/doctype/item/item.py:638
-#: erpnext/stock/doctype/item/item.py:652
+#: erpnext/stock/doctype/item/item.py:631
+#: erpnext/stock/doctype/item/item.py:644
+#: erpnext/stock/doctype/item/item.py:658
 msgid "Cannot Merge"
 msgstr ""
 
@@ -9405,7 +9391,7 @@ msgstr ""
 msgid "Cannot apply TDS against multiple parties in one entry"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:307
+#: erpnext/stock/doctype/item/item.py:310
 msgid "Cannot be a fixed asset item as Stock Ledger is created."
 msgstr ""
 
@@ -9421,7 +9407,7 @@ msgstr ""
 msgid "Cannot cancel the transaction. Reposting of item valuation on submission is not completed yet."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:959
+#: erpnext/controllers/buying_controller.py:967
 msgid "Cannot cancel this document as it is linked with the submitted asset {asset_link}. Please cancel the asset to continue."
 msgstr ""
 
@@ -9429,7 +9415,7 @@ msgstr ""
 msgid "Cannot cancel transaction for Completed Work Order."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:882
+#: erpnext/stock/doctype/item/item.py:876
 msgid "Cannot change Attributes after stock transaction. Make a new Item and transfer stock to the new Item"
 msgstr ""
 
@@ -9445,7 +9431,7 @@ msgstr ""
 msgid "Cannot change Service Stop Date for item in row {0}"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:873
+#: erpnext/stock/doctype/item/item.py:867
 msgid "Cannot change Variant properties after stock transaction. You will have to make a new Item to do this."
 msgstr ""
 
@@ -9473,7 +9459,7 @@ msgstr ""
 msgid "Cannot covert to Group because Account Type is selected."
 msgstr ""
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:972
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:981
 msgid "Cannot create Stock Reservation Entries for future dated Purchase Receipts."
 msgstr ""
 
@@ -9524,7 +9510,7 @@ msgstr ""
 msgid "Cannot find Item with this Barcode"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3483
+#: erpnext/controllers/accounts_controller.py:3486
 msgid "Cannot find a default warehouse for item {0}. Please set one in the Item Master or in Stock Settings."
 msgstr ""
 
@@ -9532,7 +9518,7 @@ msgstr ""
 msgid "Cannot make any transactions until the deletion job is completed"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2074
+#: erpnext/controllers/accounts_controller.py:2077
 msgid "Cannot overbill for Item {0} in row {1} more than {2}. To allow over-billing, please set allowance in Accounts Settings"
 msgstr ""
 
@@ -9553,7 +9539,7 @@ msgid "Cannot receive from customer against negative outstanding"
 msgstr ""
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1475
-#: erpnext/controllers/accounts_controller.py:2961
+#: erpnext/controllers/accounts_controller.py:2964
 #: erpnext/public/js/controllers/accounts.js:100
 msgid "Cannot refer row number greater than or equal to current row number for this Charge type"
 msgstr ""
@@ -9569,7 +9555,7 @@ msgstr ""
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1467
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1646
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:1917
-#: erpnext/controllers/accounts_controller.py:2951
+#: erpnext/controllers/accounts_controller.py:2954
 #: erpnext/public/js/controllers/accounts.js:94
 #: erpnext/public/js/controllers/taxes_and_totals.js:470
 msgid "Cannot select charge type as 'On Previous Row Amount' or 'On Previous Row Total' for first row"
@@ -9583,15 +9569,15 @@ msgstr ""
 msgid "Cannot set authorization on basis of Discount for {0}"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:716
+#: erpnext/stock/doctype/item/item.py:722
 msgid "Cannot set multiple Item Defaults for a company."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3631
+#: erpnext/controllers/accounts_controller.py:3634
 msgid "Cannot set quantity less than delivered quantity"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3634
+#: erpnext/controllers/accounts_controller.py:3637
 msgid "Cannot set quantity less than received quantity"
 msgstr ""
 
@@ -10014,7 +10000,7 @@ msgid "Channel Partner"
 msgstr ""
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:2346
-#: erpnext/controllers/accounts_controller.py:3014
+#: erpnext/controllers/accounts_controller.py:3017
 msgid "Charge of type 'Actual' in row {0} cannot be included in Item Rate or Paid Amount"
 msgstr ""
 
@@ -10197,7 +10183,7 @@ msgstr ""
 
 #. Label of the reference_date (Date) field in DocType 'Payment Entry'
 #: erpnext/accounts/doctype/payment_entry/payment_entry.json
-#: erpnext/public/js/controllers/transaction.js:2299
+#: erpnext/public/js/controllers/transaction.js:2325
 msgid "Cheque/Reference Date"
 msgstr ""
 
@@ -10245,7 +10231,7 @@ msgstr ""
 
 #. Label of the child_row_reference (Data) field in DocType 'Quality
 #. Inspection'
-#: erpnext/public/js/controllers/transaction.js:2394
+#: erpnext/public/js/controllers/transaction.js:2420
 #: erpnext/stock/doctype/quality_inspection/quality_inspection.json
 msgid "Child Row Reference"
 msgstr ""
@@ -10957,7 +10943,7 @@ msgstr ""
 #: erpnext/accounts/report/cheques_and_deposits_incorrectly_cleared/cheques_and_deposits_incorrectly_cleared.js:8
 #: erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.js:8
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:8
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:49
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:50
 #: erpnext/accounts/report/deferred_revenue_and_expense/deferred_revenue_and_expense.js:8
 #: erpnext/accounts/report/delivered_items_to_be_billed/delivered_items_to_be_billed.js:7
 #: erpnext/accounts/report/dimension_wise_accounts_balance_report/dimension_wise_accounts_balance_report.js:8
@@ -12190,7 +12176,7 @@ msgid "Content Type"
 msgstr ""
 
 #: erpnext/erpnext_integrations/doctype/plaid_settings/plaid_settings.js:162
-#: erpnext/public/js/controllers/transaction.js:2312
+#: erpnext/public/js/controllers/transaction.js:2338
 #: erpnext/selling/doctype/quotation/quotation.js:356
 msgid "Continue"
 msgstr ""
@@ -12355,7 +12341,7 @@ msgstr ""
 msgid "Conversion Rate"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:393
+#: erpnext/stock/doctype/item/item.py:396
 msgid "Conversion factor for default Unit of Measure must be 1 in row {0}"
 msgstr ""
 
@@ -12363,15 +12349,15 @@ msgstr ""
 msgid "Conversion factor for item {0} has been reset to 1.0 as the uom {1} is same as stock uom {2}."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2767
+#: erpnext/controllers/accounts_controller.py:2770
 msgid "Conversion rate cannot be 0"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2774
+#: erpnext/controllers/accounts_controller.py:2777
 msgid "Conversion rate is 1.00, but document currency is different from company currency"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2770
+#: erpnext/controllers/accounts_controller.py:2773
 msgid "Conversion rate must be 1.00 if document currency is same as company currency"
 msgstr ""
 
@@ -12584,7 +12570,7 @@ msgstr ""
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:28
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:40
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:30
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1096
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1098
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:40
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.js:42
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.py:197
@@ -12677,7 +12663,7 @@ msgid "Cost Center is a part of Cost Center Allocation, hence cannot be converte
 msgstr ""
 
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py:1411
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:855
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:864
 msgid "Cost Center is required in row {0} in Taxes table for type {1}"
 msgstr ""
 
@@ -12946,8 +12932,8 @@ msgstr ""
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:132
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:143
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:219
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:654
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:678
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:656
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:680
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.js:88
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.js:89
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.js:103
@@ -13004,8 +12990,8 @@ msgstr ""
 #: erpnext/projects/doctype/task/task_tree.js:81
 #: erpnext/public/js/communication.js:19 erpnext/public/js/communication.js:31
 #: erpnext/public/js/communication.js:41
-#: erpnext/public/js/controllers/transaction.js:336
-#: erpnext/public/js/controllers/transaction.js:2435
+#: erpnext/public/js/controllers/transaction.js:362
+#: erpnext/public/js/controllers/transaction.js:2461
 #: erpnext/selling/doctype/customer/customer.js:181
 #: erpnext/selling/doctype/quotation/quotation.js:124
 #: erpnext/selling/doctype/quotation/quotation.js:133
@@ -13300,7 +13286,7 @@ msgstr ""
 msgid "Create a variant with the template image."
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1877
+#: erpnext/stock/stock_ledger.py:1886
 msgid "Create an incoming stock transaction for the Item."
 msgstr ""
 
@@ -13360,7 +13346,7 @@ msgstr ""
 msgid "Creating Purchase Order ..."
 msgstr ""
 
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:735
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:737
 #: erpnext/buying/doctype/purchase_order/purchase_order.js:552
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.js:73
 msgid "Creating Purchase Receipt ..."
@@ -13554,7 +13540,7 @@ msgstr ""
 #: erpnext/accounts/doctype/journal_entry_template/journal_entry_template.json
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:174
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:147
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1119
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1121
 #: erpnext/controllers/sales_and_purchase_return.py:373
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:286
 #: erpnext/stock/doctype/delivery_note/delivery_note.js:89
@@ -13589,7 +13575,7 @@ msgstr ""
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py:368
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py:376
-#: erpnext/controllers/accounts_controller.py:2186
+#: erpnext/controllers/accounts_controller.py:2189
 msgid "Credit To"
 msgstr ""
 
@@ -13774,7 +13760,7 @@ msgstr ""
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/subscription_plan/subscription_plan.json
 #: erpnext/accounts/report/account_balance/account_balance.py:28
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1129
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1131
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:205
 #: erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.py:101
 #: erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.js:118
@@ -14303,7 +14289,7 @@ msgstr ""
 #. Label of the customer_contact_display (Small Text) field in DocType
 #. 'Purchase Order'
 #. Label of the customer_contact (Small Text) field in DocType 'Delivery Stop'
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1090
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1092
 #: erpnext/buying/doctype/purchase_order/purchase_order.json
 #: erpnext/stock/doctype/delivery_stop/delivery_stop.json
 msgid "Customer Contact"
@@ -14399,7 +14385,7 @@ msgstr ""
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/tax_rule/tax_rule.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:107
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1147
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1149
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:81
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:185
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:56
@@ -14443,7 +14429,7 @@ msgstr ""
 msgid "Customer Group Name"
 msgstr ""
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1239
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1241
 msgid "Customer Group: {0} does not exist"
 msgstr ""
 
@@ -14462,7 +14448,7 @@ msgstr ""
 msgid "Customer Items"
 msgstr ""
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1138
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1140
 msgid "Customer LPO"
 msgstr ""
 
@@ -14508,7 +14494,7 @@ msgstr ""
 #: erpnext/accounts/doctype/pos_invoice/pos_invoice.json
 #: erpnext/accounts/doctype/process_statement_of_accounts_customer/process_statement_of_accounts_customer.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1080
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1082
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:156
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:92
 #: erpnext/accounts/report/delivered_items_to_be_billed/delivered_items_to_be_billed.py:35
@@ -15186,7 +15172,7 @@ msgstr ""
 #: erpnext/accounts/doctype/journal_entry_template/journal_entry_template.json
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:176
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:147
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1122
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1124
 #: erpnext/controllers/sales_and_purchase_return.py:377
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:287
 #: erpnext/stock/doctype/purchase_receipt/purchase_receipt.js:61
@@ -15215,7 +15201,7 @@ msgstr ""
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:953
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:964
-#: erpnext/controllers/accounts_controller.py:2186
+#: erpnext/controllers/accounts_controller.py:2189
 msgid "Debit To"
 msgstr ""
 
@@ -15248,11 +15234,11 @@ msgstr ""
 msgid "Debit-Credit mismatch"
 msgstr ""
 
-#: erpnext/accounts/party.py:609
+#: erpnext/accounts/party.py:615
 msgid "Debtor/Creditor"
 msgstr ""
 
-#: erpnext/accounts/party.py:612
+#: erpnext/accounts/party.py:618
 msgid "Debtor/Creditor Advance"
 msgstr ""
 
@@ -15372,7 +15358,7 @@ msgstr ""
 msgid "Default BOM"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:418
+#: erpnext/stock/doctype/item/item.py:421
 msgid "Default BOM ({0}) must be active for this item or its template"
 msgstr ""
 
@@ -15380,7 +15366,7 @@ msgstr ""
 msgid "Default BOM for {0} not found"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3672
+#: erpnext/controllers/accounts_controller.py:3675
 msgid "Default BOM not found for FG Item {0}"
 msgstr ""
 
@@ -15715,15 +15701,15 @@ msgstr ""
 msgid "Default Unit of Measure"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1272
+#: erpnext/stock/doctype/item/item.py:1266
 msgid "Default Unit of Measure for Item {0} cannot be changed directly because you have already made some transaction(s) with another UOM. You need to either cancel the linked documents or create a new Item."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1255
+#: erpnext/stock/doctype/item/item.py:1249
 msgid "Default Unit of Measure for Item {0} cannot be changed directly because you have already made some transaction(s) with another UOM. You will need to create a new Item to use a different Default UOM."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:908
+#: erpnext/stock/doctype/item/item.py:902
 msgid "Default Unit of Measure for Variant '{0}' must be same as in Template '{1}'"
 msgstr ""
 
@@ -16182,7 +16168,7 @@ msgstr ""
 msgid "Delivery Note {0} is not submitted"
 msgstr ""
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1142
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1144
 #: erpnext/stock/doctype/delivery_trip/delivery_trip.js:73
 msgid "Delivery Notes"
 msgstr ""
@@ -16713,7 +16699,7 @@ msgstr ""
 #: erpnext/projects/doctype/task_type/task_type.json
 #: erpnext/projects/doctype/timesheet_detail/timesheet_detail.json
 #: erpnext/public/js/bank_reconciliation_tool/data_table_manager.js:55
-#: erpnext/public/js/controllers/transaction.js:2376
+#: erpnext/public/js/controllers/transaction.js:2402
 #: erpnext/selling/doctype/installation_note_item/installation_note_item.json
 #: erpnext/selling/doctype/product_bundle/product_bundle.json
 #: erpnext/selling/doctype/product_bundle_item/product_bundle_item.json
@@ -16901,7 +16887,7 @@ msgstr ""
 msgid "Difference Account must be a Asset/Liability type account (Temporary Opening), since this Stock Entry is an Opening Entry"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:954
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:950
 msgid "Difference Account must be a Asset/Liability type account, since this Stock Reconciliation is an Opening Entry"
 msgstr ""
 
@@ -17167,11 +17153,11 @@ msgstr ""
 msgid "Disabled Warehouse {0} cannot be used for this transaction."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:745
+#: erpnext/controllers/accounts_controller.py:748
 msgid "Disabled pricing rules since this {} is an internal transfer"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:759
+#: erpnext/controllers/accounts_controller.py:762
 msgid "Disabled tax included prices since this {} is an internal transfer"
 msgstr ""
 
@@ -18113,7 +18099,7 @@ msgstr ""
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.json
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/print_format/sales_invoice_print/sales_invoice_print.html:72
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1106
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1108
 #: erpnext/assets/doctype/asset_maintenance_log/asset_maintenance_log.json
 #: erpnext/selling/report/payment_terms_status_for_sales_order/payment_terms_status_for_sales_order.py:40
 msgid "Due Date"
@@ -18127,11 +18113,11 @@ msgstr ""
 msgid "Due Date Based On"
 msgstr ""
 
-#: erpnext/accounts/party.py:695
+#: erpnext/accounts/party.py:701
 msgid "Due Date cannot be after {0}"
 msgstr ""
 
-#: erpnext/accounts/party.py:671
+#: erpnext/accounts/party.py:677
 msgid "Due Date cannot be before {0}"
 msgstr ""
 
@@ -18849,7 +18835,7 @@ msgstr ""
 msgid "Enable Auto Email"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1064
+#: erpnext/stock/doctype/item/item.py:1058
 msgid "Enable Auto Re-Order"
 msgstr ""
 
@@ -19062,7 +19048,7 @@ msgstr ""
 msgid "End Date"
 msgstr ""
 
-#: erpnext/crm/doctype/contract/contract.py:75
+#: erpnext/crm/doctype/contract/contract.py:83
 msgid "End Date cannot be before Start Date."
 msgstr ""
 
@@ -19312,7 +19298,7 @@ msgstr ""
 #: erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.json
 #: erpnext/manufacturing/doctype/job_card/job_card.py:875
 #: erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.json
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:297
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:298
 msgid "Error"
 msgstr ""
 
@@ -19435,7 +19421,7 @@ msgstr ""
 msgid "Example URL"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:995
+#: erpnext/stock/doctype/item/item.py:989
 msgid "Example of a linked document: {0}"
 msgstr ""
 
@@ -19450,7 +19436,7 @@ msgstr ""
 msgid "Example: ABCD.#####. If series is set and Batch No is not mentioned in transactions, then automatic batch number will be created based on this series. If you always want to explicitly mention Batch No for this item, leave this blank. Note: this setting will take priority over the Naming Series Prefix in Stock Settings."
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:2141
+#: erpnext/stock/stock_ledger.py:2149
 msgid "Example: Serial No {0} reserved in {1}."
 msgstr ""
 
@@ -19504,8 +19490,8 @@ msgstr ""
 msgid "Exchange Gain/Loss"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1593
-#: erpnext/controllers/accounts_controller.py:1677
+#: erpnext/controllers/accounts_controller.py:1596
+#: erpnext/controllers/accounts_controller.py:1680
 msgid "Exchange Gain/Loss amount has been booked through {0}"
 msgstr ""
 
@@ -20241,7 +20227,7 @@ msgid "Fetching Error"
 msgstr ""
 
 #: erpnext/accounts/doctype/dunning/dunning.js:135
-#: erpnext/public/js/controllers/transaction.js:1251
+#: erpnext/public/js/controllers/transaction.js:1277
 msgid "Fetching exchange rates ..."
 msgstr ""
 
@@ -20536,15 +20522,15 @@ msgstr ""
 msgid "Finished Good Item Quantity"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3658
+#: erpnext/controllers/accounts_controller.py:3661
 msgid "Finished Good Item is not specified for service item {0}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3675
+#: erpnext/controllers/accounts_controller.py:3678
 msgid "Finished Good Item {0} Qty can not be zero"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3669
+#: erpnext/controllers/accounts_controller.py:3672
 msgid "Finished Good Item {0} must be a sub-contracted item"
 msgstr ""
 
@@ -20785,7 +20771,7 @@ msgstr ""
 msgid "Fixed Asset Defaults"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:301
+#: erpnext/stock/doctype/item/item.py:304
 msgid "Fixed Asset Item must be a non-stock item."
 msgstr ""
 
@@ -20961,7 +20947,7 @@ msgstr ""
 msgid "For Raw Materials"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1259
+#: erpnext/controllers/accounts_controller.py:1262
 msgid "For Return Invoices with Stock effect, '0' qty Items are not allowed. Following rows are affected: {0}"
 msgstr ""
 
@@ -21062,7 +21048,7 @@ msgstr ""
 msgid "For the item {0}, the quantity should be {1} according to the BOM {2}."
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:1088
+#: erpnext/public/js/controllers/transaction.js:1114
 msgctxt "Clear payment terms template and/or payment schedule when due date is changed"
 msgid "For the new {0} to take effect, would you like to clear the current {1}?"
 msgstr ""
@@ -21071,7 +21057,7 @@ msgstr ""
 msgid "For the {0}, no stock is available for the return in the warehouse {1}."
 msgstr ""
 
-#: erpnext/controllers/sales_and_purchase_return.py:1144
+#: erpnext/controllers/sales_and_purchase_return.py:1049
 msgid "For the {0}, the quantity is required to make the return entry"
 msgstr ""
 
@@ -21408,7 +21394,7 @@ msgstr ""
 msgid "From Date is mandatory"
 msgstr ""
 
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:52
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:53
 #: erpnext/accounts/report/general_ledger/general_ledger.py:86
 #: erpnext/accounts/report/pos_register/pos_register.py:115
 #: erpnext/accounts/report/tax_withholding_details/tax_withholding_details.py:39
@@ -21785,14 +21771,14 @@ msgstr ""
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:186
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:155
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1134
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1136
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:177
 msgid "Future Payment Amount"
 msgstr ""
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:185
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:154
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1133
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1135
 msgid "Future Payment Ref"
 msgstr ""
 
@@ -22966,7 +22952,7 @@ msgstr ""
 msgid "Here are the error logs for the aforementioned failed depreciation entries: {0}"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1862
+#: erpnext/stock/stock_ledger.py:1871
 msgid "Here are the options to proceed:"
 msgstr ""
 
@@ -23488,7 +23474,7 @@ msgstr ""
 msgid "If more than one package of the same type (for print)"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1872
+#: erpnext/stock/stock_ledger.py:1881
 msgid "If not, you can Cancel / Submit this entry"
 msgstr ""
 
@@ -23513,7 +23499,7 @@ msgstr ""
 msgid "If the account is frozen, entries are allowed to restricted users."
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1865
+#: erpnext/stock/stock_ledger.py:1874
 msgid "If the item is transacting as a Zero Valuation Rate item in this entry, please enable 'Allow Zero Valuation Rate' in the {0} Item table."
 msgstr ""
 
@@ -24511,7 +24497,7 @@ msgstr ""
 msgid "Incorrect Batch Consumed"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:514
+#: erpnext/stock/doctype/item/item.py:517
 msgid "Incorrect Check in (group) Warehouse for Reorder"
 msgstr ""
 
@@ -24560,7 +24546,7 @@ msgstr ""
 msgid "Incorrect Stock Value Report"
 msgstr ""
 
-#: erpnext/stock/serial_batch_bundle.py:134
+#: erpnext/stock/serial_batch_bundle.py:135
 msgid "Incorrect Type of Transaction"
 msgstr ""
 
@@ -24829,8 +24815,8 @@ msgstr ""
 msgid "Insufficient Capacity"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3590
-#: erpnext/controllers/accounts_controller.py:3614
+#: erpnext/controllers/accounts_controller.py:3593
+#: erpnext/controllers/accounts_controller.py:3617
 msgid "Insufficient Permissions"
 msgstr ""
 
@@ -24838,12 +24824,12 @@ msgstr ""
 #: erpnext/stock/doctype/pick_list/pick_list.py:127
 #: erpnext/stock/doctype/pick_list/pick_list.py:975
 #: erpnext/stock/doctype/stock_entry/stock_entry.py:759
-#: erpnext/stock/serial_batch_bundle.py:989 erpnext/stock/stock_ledger.py:1559
-#: erpnext/stock/stock_ledger.py:2032
+#: erpnext/stock/serial_batch_bundle.py:1021 erpnext/stock/stock_ledger.py:1568
+#: erpnext/stock/stock_ledger.py:2040
 msgid "Insufficient Stock"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:2047
+#: erpnext/stock/stock_ledger.py:2055
 msgid "Insufficient Stock for Batch"
 msgstr ""
 
@@ -24981,11 +24967,11 @@ msgstr ""
 msgid "Internal Customer for company {0} already exists"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:728
+#: erpnext/controllers/accounts_controller.py:731
 msgid "Internal Sale or Delivery Reference missing."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:730
+#: erpnext/controllers/accounts_controller.py:733
 msgid "Internal Sales Reference Missing"
 msgstr ""
 
@@ -25016,7 +25002,7 @@ msgstr ""
 msgid "Internal Transfer"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:739
+#: erpnext/controllers/accounts_controller.py:742
 msgid "Internal Transfer Reference Missing"
 msgstr ""
 
@@ -25059,8 +25045,8 @@ msgstr ""
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:969
 #: erpnext/assets/doctype/asset_category/asset_category.py:69
 #: erpnext/assets/doctype/asset_category/asset_category.py:97
-#: erpnext/controllers/accounts_controller.py:2975
-#: erpnext/controllers/accounts_controller.py:2983
+#: erpnext/controllers/accounts_controller.py:2978
+#: erpnext/controllers/accounts_controller.py:2986
 msgid "Invalid Account"
 msgstr ""
 
@@ -25085,7 +25071,7 @@ msgstr ""
 msgid "Invalid Barcode. There is no Item attached to this barcode."
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2631
+#: erpnext/public/js/controllers/transaction.js:2657
 msgid "Invalid Blanket Order for the selected Customer and Item"
 msgstr ""
 
@@ -25099,7 +25085,7 @@ msgstr ""
 
 #: erpnext/assets/doctype/asset/asset.py:295
 #: erpnext/assets/doctype/asset/asset.py:302
-#: erpnext/controllers/accounts_controller.py:2998
+#: erpnext/controllers/accounts_controller.py:3001
 msgid "Invalid Cost Center"
 msgstr ""
 
@@ -25141,7 +25127,7 @@ msgstr ""
 msgid "Invalid Item"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1410
+#: erpnext/stock/doctype/item/item.py:1404
 msgid "Invalid Item Defaults"
 msgstr ""
 
@@ -25187,11 +25173,11 @@ msgstr ""
 msgid "Invalid Purchase Invoice"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3627
+#: erpnext/controllers/accounts_controller.py:3630
 msgid "Invalid Qty"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1277
+#: erpnext/controllers/accounts_controller.py:1280
 msgid "Invalid Quantity"
 msgstr ""
 
@@ -25208,7 +25194,7 @@ msgstr ""
 msgid "Invalid Schedule"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:243
+#: erpnext/controllers/selling_controller.py:251
 msgid "Invalid Selling Price"
 msgstr ""
 
@@ -25241,7 +25227,7 @@ msgstr ""
 msgid "Invalid lost reason {0}, please create a new lost reason"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:408
+#: erpnext/stock/doctype/item/item.py:411
 msgid "Invalid naming series (. missing) for {0}"
 msgstr ""
 
@@ -25281,7 +25267,7 @@ msgstr ""
 #. Name of a DocType
 #: erpnext/patches/v15_0/refactor_closing_stock_balance.py:43
 #: erpnext/stock/doctype/inventory_dimension/inventory_dimension.json
-#: erpnext/stock/doctype/inventory_dimension/inventory_dimension.py:180
+#: erpnext/stock/doctype/inventory_dimension/inventory_dimension.py:181
 msgid "Inventory Dimension"
 msgstr ""
 
@@ -25347,7 +25333,7 @@ msgstr ""
 msgid "Invoice Discounting"
 msgstr ""
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1114
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1116
 msgid "Invoice Grand Total"
 msgstr ""
 
@@ -25440,7 +25426,7 @@ msgstr ""
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:169
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:144
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1116
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1118
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:164
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:165
 msgid "Invoiced Amount"
@@ -25846,6 +25832,11 @@ msgstr ""
 msgid "Is Outward"
 msgstr ""
 
+#. Label of the is_packed (Check) field in DocType 'Serial and Batch Bundle'
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.json
+msgid "Is Packed"
+msgstr ""
+
 #. Label of the is_paid (Check) field in DocType 'Purchase Invoice'
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 msgid "Is Paid"
@@ -26128,11 +26119,11 @@ msgstr ""
 msgid "Issuing cannot be done to a location. Please enter employee to issue the Asset {0} to"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:565
+#: erpnext/stock/doctype/item/item.py:571
 msgid "It can take upto few hours for accurate stock values to be visible after merging items."
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2075
+#: erpnext/public/js/controllers/transaction.js:2101
 msgid "It is needed to fetch Item Details."
 msgstr ""
 
@@ -26182,7 +26173,7 @@ msgstr ""
 #: erpnext/buying/report/supplier_quotation_comparison/supplier_quotation_comparison.js:33
 #: erpnext/buying/report/supplier_quotation_comparison/supplier_quotation_comparison.py:204
 #: erpnext/buying/workspace/buying/buying.json
-#: erpnext/controllers/taxes_and_totals.py:1125
+#: erpnext/controllers/taxes_and_totals.py:1135
 #: erpnext/manufacturing/doctype/blanket_order/blanket_order.json
 #: erpnext/manufacturing/doctype/bom/bom.js:944
 #: erpnext/manufacturing/doctype/bom/bom.json
@@ -26460,7 +26451,7 @@ msgstr ""
 #: erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py:86
 #: erpnext/manufacturing/report/work_order_stock_report/work_order_stock_report.py:119
 #: erpnext/projects/doctype/timesheet/timesheet.js:213
-#: erpnext/public/js/controllers/transaction.js:2350
+#: erpnext/public/js/controllers/transaction.js:2376
 #: erpnext/public/js/stock_reservation.js:112
 #: erpnext/public/js/stock_reservation.js:317 erpnext/public/js/utils.js:500
 #: erpnext/public/js/utils.js:656
@@ -26898,7 +26889,7 @@ msgstr ""
 #: erpnext/manufacturing/report/production_planning_report/production_planning_report.py:359
 #: erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py:92
 #: erpnext/manufacturing/report/work_order_consumed_materials/work_order_consumed_materials.py:138
-#: erpnext/public/js/controllers/transaction.js:2356
+#: erpnext/public/js/controllers/transaction.js:2382
 #: erpnext/public/js/utils.js:746
 #: erpnext/selling/doctype/quotation_item/quotation_item.json
 #: erpnext/selling/doctype/sales_order_item/sales_order_item.json
@@ -27165,7 +27156,7 @@ msgstr ""
 msgid "Item Variant {0} already exists with same attributes"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:781
+#: erpnext/stock/doctype/item/item.py:772
 msgid "Item Variants updated"
 msgstr ""
 
@@ -27231,7 +27222,7 @@ msgstr ""
 msgid "Item for row {0} does not match Material Request"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:795
+#: erpnext/stock/doctype/item/item.py:789
 msgid "Item has variants."
 msgstr ""
 
@@ -27257,7 +27248,7 @@ msgstr ""
 msgid "Item operation"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3650
+#: erpnext/controllers/accounts_controller.py:3653
 msgid "Item qty can not be updated as raw materials are already processed."
 msgstr ""
 
@@ -27283,7 +27274,7 @@ msgstr ""
 msgid "Item valuation reposting in progress. Report might show incorrect item valuation."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:952
+#: erpnext/stock/doctype/item/item.py:946
 msgid "Item variant {0} exists with same attributes"
 msgstr ""
 
@@ -27296,8 +27287,7 @@ msgid "Item {0} cannot be ordered more than {1} against Blanket Order {2}."
 msgstr ""
 
 #: erpnext/assets/doctype/asset/asset.py:277
-#: erpnext/stock/doctype/item/item.py:630
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:167
+#: erpnext/stock/doctype/item/item.py:636
 msgid "Item {0} does not exist"
 msgstr ""
 
@@ -27309,7 +27299,7 @@ msgstr ""
 msgid "Item {0} does not exist."
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:752
+#: erpnext/controllers/selling_controller.py:760
 msgid "Item {0} entered multiple times."
 msgstr ""
 
@@ -27325,7 +27315,7 @@ msgstr ""
 msgid "Item {0} has no Serial No. Only serialized items can have delivery based on Serial No"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1126
+#: erpnext/stock/doctype/item/item.py:1120
 msgid "Item {0} has reached its end of life on {1}"
 msgstr ""
 
@@ -27337,11 +27327,11 @@ msgstr ""
 msgid "Item {0} is already reserved/delivered against Sales Order {1}."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1146
+#: erpnext/stock/doctype/item/item.py:1140
 msgid "Item {0} is cancelled"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1130
+#: erpnext/stock/doctype/item/item.py:1124
 msgid "Item {0} is disabled"
 msgstr ""
 
@@ -27349,7 +27339,7 @@ msgstr ""
 msgid "Item {0} is not a serialized Item"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1138
+#: erpnext/stock/doctype/item/item.py:1132
 msgid "Item {0} is not a stock Item"
 msgstr ""
 
@@ -27393,7 +27383,7 @@ msgstr ""
 msgid "Item {0}: {1} qty produced. "
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1429
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1423
 msgid "Item {} does not exist."
 msgstr ""
 
@@ -27533,7 +27523,7 @@ msgstr ""
 msgid "Items and Pricing"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3872
+#: erpnext/controllers/accounts_controller.py:3875
 msgid "Items cannot be updated as Subcontracting Order is created against the Purchase Order {0}."
 msgstr ""
 
@@ -28029,7 +28019,7 @@ msgstr ""
 
 #. Name of a DocType
 #. Label of a Link in the Stock Workspace
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:674
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:676
 #: erpnext/stock/doctype/landed_cost_voucher/landed_cost_voucher.json
 #: erpnext/stock/doctype/purchase_receipt/purchase_receipt.js:104
 #: erpnext/stock/workspace/stock/stock.json
@@ -28644,7 +28634,7 @@ msgstr ""
 msgid "Linked Location"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:999
+#: erpnext/stock/doctype/item/item.py:993
 msgid "Linked with submitted documents"
 msgstr ""
 
@@ -29383,7 +29373,7 @@ msgstr ""
 #: erpnext/manufacturing/doctype/bom/bom.py:261
 #: erpnext/manufacturing/doctype/bom_update_log/bom_update_log.py:71
 #: erpnext/public/js/controllers/accounts.js:249
-#: erpnext/public/js/controllers/transaction.js:2753
+#: erpnext/public/js/controllers/transaction.js:2779
 #: erpnext/public/js/utils/party.js:321
 #: erpnext/stock/doctype/delivery_note/delivery_note.js:164
 #: erpnext/stock/doctype/inventory_dimension/inventory_dimension.json
@@ -30239,7 +30229,7 @@ msgstr ""
 msgid "Maximum Value"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:212
+#: erpnext/controllers/selling_controller.py:220
 msgid "Maximum discount for Item {0} is {1}%"
 msgstr ""
 
@@ -30309,7 +30299,7 @@ msgstr ""
 msgid "Megawatt"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1878
+#: erpnext/stock/stock_ledger.py:1887
 msgid "Mention Valuation Rate in the Item master."
 msgstr ""
 
@@ -30704,11 +30694,11 @@ msgstr ""
 msgid "Miscellaneous Expenses"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:540
+#: erpnext/controllers/buying_controller.py:548
 msgid "Mismatch"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1430
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1424
 msgid "Missing"
 msgstr ""
 
@@ -31235,7 +31225,7 @@ msgstr ""
 msgid "Multiple Warehouse Accounts"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1129
+#: erpnext/controllers/accounts_controller.py:1132
 msgid "Multiple fiscal years exist for the date {0}. Please set company in Fiscal Year"
 msgstr ""
 
@@ -31386,7 +31376,7 @@ msgstr ""
 msgid "Naming Series and Price Defaults"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:90
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:91
 msgid "Naming Series is mandatory"
 msgstr ""
 
@@ -31425,15 +31415,15 @@ msgstr ""
 msgid "Needs Analysis"
 msgstr ""
 
-#: erpnext/stock/serial_batch_bundle.py:1277
+#: erpnext/stock/serial_batch_bundle.py:1309
 msgid "Negative Batch Quantity"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:610
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:606
 msgid "Negative Quantity is not allowed"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:615
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:611
 msgid "Negative Valuation Rate is not allowed"
 msgstr ""
 
@@ -31715,7 +31705,7 @@ msgstr ""
 msgid "Net Weight UOM"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1483
+#: erpnext/controllers/accounts_controller.py:1486
 msgid "Net total calculation precision loss"
 msgstr ""
 
@@ -32058,7 +32048,7 @@ msgstr ""
 #: erpnext/accounts/doctype/journal_entry/journal_entry.py:1539
 #: erpnext/accounts/doctype/journal_entry/journal_entry.py:1599
 #: erpnext/accounts/doctype/journal_entry/journal_entry.py:1613
-#: erpnext/stock/doctype/item/item.py:1371
+#: erpnext/stock/doctype/item/item.py:1365
 msgid "No Permission"
 msgstr ""
 
@@ -32080,7 +32070,7 @@ msgstr ""
 msgid "No Selection"
 msgstr ""
 
-#: erpnext/controllers/sales_and_purchase_return.py:919
+#: erpnext/controllers/sales_and_purchase_return.py:824
 msgid "No Serial / Batches are available for return"
 msgstr ""
 
@@ -32116,7 +32106,7 @@ msgstr ""
 msgid "No Work Orders were created"
 msgstr ""
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:785
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:794
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py:689
 msgid "No accounting entries for the following warehouses"
 msgstr ""
@@ -32305,7 +32295,7 @@ msgstr ""
 msgid "No reserved stock to unreserve."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:773
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:769
 msgid "No stock ledger entries were created. Please set the quantity or valuation rate for the items properly and try again."
 msgstr ""
 
@@ -32389,7 +32379,7 @@ msgstr ""
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:566
 #: erpnext/assets/doctype/asset/asset.js:612
 #: erpnext/assets/doctype/asset/asset.js:627
-#: erpnext/controllers/buying_controller.py:225
+#: erpnext/controllers/buying_controller.py:233
 #: erpnext/selling/doctype/product_bundle/product_bundle.py:72
 #: erpnext/setup/doctype/transaction_deletion_record/transaction_deletion_record.py:80
 msgid "Not Allowed"
@@ -32510,10 +32500,10 @@ msgstr ""
 #: erpnext/selling/doctype/customer/customer.py:129
 #: erpnext/selling/doctype/sales_order/sales_order.js:1168
 #: erpnext/stock/doctype/item/item.js:526
-#: erpnext/stock/doctype/item/item.py:567
+#: erpnext/stock/doctype/item/item.py:573
 #: erpnext/stock/doctype/item_price/item_price.json
 #: erpnext/stock/doctype/stock_entry/stock_entry.py:1374
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:972
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:968
 #: erpnext/templates/pages/timelog_info.html:43
 msgid "Note"
 msgstr ""
@@ -32522,7 +32512,7 @@ msgstr ""
 msgid "Note: Automatic log deletion only applies to logs of type <i>Update Cost</i>"
 msgstr ""
 
-#: erpnext/accounts/party.py:690
+#: erpnext/accounts/party.py:696
 msgid "Note: Due Date exceeds allowed {0} credit days by {1} day(s)"
 msgstr ""
 
@@ -32548,7 +32538,7 @@ msgstr ""
 msgid "Note: This Cost Center is a Group. Cannot make accounting entries against groups."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:621
+#: erpnext/stock/doctype/item/item.py:627
 msgid "Note: To merge the items, create a separate Stock Reconciliation for the old item {0}"
 msgstr ""
 
@@ -33311,7 +33301,7 @@ msgstr ""
 
 #. Label of the opening_stock (Float) field in DocType 'Item'
 #. Option for the 'Purpose' (Select) field in DocType 'Stock Reconciliation'
-#: erpnext/stock/doctype/item/item.json erpnext/stock/doctype/item/item.py:296
+#: erpnext/stock/doctype/item/item.json erpnext/stock/doctype/item/item.py:299
 #: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.json
 msgid "Opening Stock"
 msgstr ""
@@ -34031,7 +34021,7 @@ msgstr ""
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:149
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1123
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1125
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:167
 #: erpnext/accounts/report/purchase_register/purchase_register.py:289
 #: erpnext/accounts/report/sales_register/sales_register.py:319
@@ -34070,7 +34060,7 @@ msgstr ""
 msgid "Over Billing Allowance (%)"
 msgstr ""
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:1242
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:1251
 msgid "Over Billing Allowance exceeded for Purchase Receipt Item {0} ({1}) by {2}%"
 msgstr ""
 
@@ -34111,7 +34101,7 @@ msgstr ""
 msgid "Overbilling of {0} {1} ignored for item {2} because you have {3} role."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2013
+#: erpnext/controllers/accounts_controller.py:2016
 msgid "Overbilling of {} ignored because you have {} role."
 msgstr ""
 
@@ -34618,7 +34608,7 @@ msgstr ""
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:146
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1117
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1119
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:165
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:172
 #: erpnext/accounts/report/pos_register/pos_register.py:209
@@ -34851,7 +34841,7 @@ msgstr ""
 msgid "Parent Row No"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom_creator/bom_creator.py:495
+#: erpnext/manufacturing/doctype/bom_creator/bom_creator.py:496
 msgid "Parent Row No not found for {0}"
 msgstr ""
 
@@ -35080,7 +35070,7 @@ msgstr ""
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:142
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:159
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:57
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1054
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1056
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:67
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:147
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:228
@@ -35106,7 +35096,7 @@ msgstr ""
 
 #. Name of a DocType
 #: erpnext/accounts/doctype/party_account/party_account.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1065
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1067
 msgid "Party Account"
 msgstr ""
 
@@ -35133,7 +35123,7 @@ msgstr ""
 msgid "Party Account No. (Bank Statement)"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2278
+#: erpnext/controllers/accounts_controller.py:2281
 msgid "Party Account {0} currency ({1}) and document currency ({2}) should be same"
 msgstr ""
 
@@ -35149,6 +35139,11 @@ msgstr ""
 #: erpnext/accounts/doctype/bank_account/bank_account.json
 #: erpnext/accounts/doctype/payment_request/payment_request.json
 msgid "Party Details"
+msgstr ""
+
+#. Label of the party_full_name (Data) field in DocType 'Contract'
+#: erpnext/crm/doctype/contract/contract.json
+msgid "Party Full Name"
 msgstr ""
 
 #. Label of the bank_party_iban (Data) field in DocType 'Bank Transaction'
@@ -35234,7 +35229,7 @@ msgstr ""
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:84
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:54
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:44
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1048
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1050
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:54
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:141
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:219
@@ -35256,7 +35251,7 @@ msgstr ""
 msgid "Party Type"
 msgstr ""
 
-#: erpnext/accounts/party.py:819
+#: erpnext/accounts/party.py:825
 msgid "Party Type and Party can only be set for Receivable / Payable account<br><br>{0}"
 msgstr ""
 
@@ -35378,7 +35373,7 @@ msgid "Payable"
 msgstr ""
 
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:42
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1063
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1065
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:211
 #: erpnext/accounts/report/purchase_register/purchase_register.py:194
 #: erpnext/accounts/report/purchase_register/purchase_register.py:235
@@ -35544,7 +35539,7 @@ msgstr ""
 msgid "Payment Entry is already created"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1434
+#: erpnext/controllers/accounts_controller.py:1437
 msgid "Payment Entry {0} is linked against Order {1}, check if it should be pulled as advance in this invoice."
 msgstr ""
 
@@ -35826,7 +35821,7 @@ msgstr ""
 #: erpnext/accounts/doctype/payment_schedule/payment_schedule.json
 #: erpnext/accounts/doctype/payment_term/payment_term.json
 #: erpnext/accounts/doctype/payment_terms_template_detail/payment_terms_template_detail.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1113
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1115
 #: erpnext/accounts/report/gross_profit/gross_profit.py:412
 #: erpnext/accounts/workspace/accounting/accounting.json
 #: erpnext/selling/report/payment_terms_status_for_sales_order/payment_terms_status_for_sales_order.py:30
@@ -36890,7 +36885,7 @@ msgstr ""
 msgid "Please create a new Accounting Dimension if required."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:729
+#: erpnext/controllers/accounts_controller.py:732
 msgid "Please create purchase from internal sale or delivery document itself"
 msgstr ""
 
@@ -36898,7 +36893,7 @@ msgstr ""
 msgid "Please create purchase receipt or purchase invoice for the item {0}"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:649
+#: erpnext/stock/doctype/item/item.py:655
 msgid "Please delete Product Bundle {0}, before merging {1} into {2}"
 msgstr ""
 
@@ -36940,7 +36935,7 @@ msgstr ""
 msgid "Please enable {0} in the {1}."
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:754
+#: erpnext/controllers/selling_controller.py:762
 msgid "Please enable {} in {} to allow same item in multiple rows"
 msgstr ""
 
@@ -36973,7 +36968,7 @@ msgstr ""
 msgid "Please enter Approving Role or Approving User"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:939
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:935
 msgid "Please enter Cost Center"
 msgstr ""
 
@@ -36985,7 +36980,7 @@ msgstr ""
 msgid "Please enter Employee Id of this sales person"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:948
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:944
 msgid "Please enter Expense Account"
 msgstr ""
 
@@ -36994,7 +36989,7 @@ msgstr ""
 msgid "Please enter Item Code to get Batch Number"
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2503
+#: erpnext/public/js/controllers/transaction.js:2529
 msgid "Please enter Item Code to get batch no"
 msgstr ""
 
@@ -37059,7 +37054,7 @@ msgstr ""
 msgid "Please enter company name first"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2764
+#: erpnext/controllers/accounts_controller.py:2767
 msgid "Please enter default currency in Company Master"
 msgstr ""
 
@@ -37095,7 +37090,7 @@ msgstr ""
 msgid "Please enter the phone number first"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:1007
+#: erpnext/controllers/buying_controller.py:1015
 msgid "Please enter the {schedule_date}."
 msgstr ""
 
@@ -37197,7 +37192,7 @@ msgstr ""
 msgid "Please select <b>Template Type</b> to download template"
 msgstr ""
 
-#: erpnext/controllers/taxes_and_totals.py:721
+#: erpnext/controllers/taxes_and_totals.py:731
 #: erpnext/public/js/controllers/taxes_and_totals.js:721
 msgid "Please select Apply Discount On"
 msgstr ""
@@ -37210,7 +37205,7 @@ msgstr ""
 msgid "Please select BOM for Item in Row {0}"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:467
+#: erpnext/controllers/buying_controller.py:475
 msgid "Please select BOM in BOM field for Item {item_code}."
 msgstr ""
 
@@ -37292,7 +37287,7 @@ msgstr ""
 msgid "Please select Qty against item {0}"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:320
+#: erpnext/stock/doctype/item/item.py:323
 msgid "Please select Sample Retention Warehouse in Stock Settings first"
 msgstr ""
 
@@ -37308,7 +37303,7 @@ msgstr ""
 msgid "Please select Subcontracting Order instead of Purchase Order {0}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2613
+#: erpnext/controllers/accounts_controller.py:2616
 msgid "Please select Unrealized Profit / Loss account or add default Unrealized Profit / Loss account account for company {0}"
 msgstr ""
 
@@ -37324,7 +37319,7 @@ msgstr ""
 #: erpnext/manufacturing/doctype/bom/bom.js:603
 #: erpnext/manufacturing/doctype/bom/bom.py:261
 #: erpnext/public/js/controllers/accounts.js:249
-#: erpnext/public/js/controllers/transaction.js:2753
+#: erpnext/public/js/controllers/transaction.js:2779
 msgid "Please select a Company first."
 msgstr ""
 
@@ -37482,7 +37477,7 @@ msgstr ""
 msgid "Please select {0} first"
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:77
+#: erpnext/public/js/controllers/transaction.js:100
 msgid "Please set 'Apply Additional Discount On'"
 msgstr ""
 
@@ -37667,7 +37662,7 @@ msgstr ""
 msgid "Please set filters"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2194
+#: erpnext/controllers/accounts_controller.py:2197
 msgid "Please set one of the following:"
 msgstr ""
 
@@ -37675,7 +37670,7 @@ msgstr ""
 msgid "Please set opening number of booked depreciations"
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2205
+#: erpnext/public/js/controllers/transaction.js:2231
 msgid "Please set recurring after saving"
 msgstr ""
 
@@ -37746,7 +37741,7 @@ msgstr ""
 msgid "Please share this email with your support team so that they can find and fix the issue."
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2073
+#: erpnext/public/js/controllers/transaction.js:2099
 msgid "Please specify"
 msgstr ""
 
@@ -37761,7 +37756,7 @@ msgid "Please specify Company to proceed"
 msgstr ""
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1472
-#: erpnext/controllers/accounts_controller.py:2957
+#: erpnext/controllers/accounts_controller.py:2960
 #: erpnext/public/js/controllers/accounts.js:97
 msgid "Please specify a valid Row ID for row {0} in table {1}"
 msgstr ""
@@ -37774,7 +37769,7 @@ msgstr ""
 msgid "Please specify at least one attribute in the Attributes table"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:605
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:601
 msgid "Please specify either Quantity or Valuation Rate or both"
 msgstr ""
 
@@ -37955,7 +37950,7 @@ msgstr ""
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:16
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:15
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:18
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1046
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1048
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:15
 #: erpnext/accounts/report/bank_clearance_summary/bank_clearance_summary.py:35
 #: erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.html:7
@@ -40136,7 +40131,7 @@ msgstr ""
 #: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.js:48
 #: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:203
 #: erpnext/buying/workspace/buying/buying.json
-#: erpnext/controllers/buying_controller.py:739
+#: erpnext/controllers/buying_controller.py:747
 #: erpnext/crm/doctype/contract/contract.json
 #: erpnext/manufacturing/doctype/blanket_order/blanket_order.js:54
 #: erpnext/manufacturing/doctype/production_plan_sub_assembly_item/production_plan_sub_assembly_item.json
@@ -40275,7 +40270,7 @@ msgstr ""
 msgid "Purchase Orders to Receive"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1833
+#: erpnext/controllers/accounts_controller.py:1836
 msgid "Purchase Orders {0} are un-linked"
 msgstr ""
 
@@ -40299,8 +40294,8 @@ msgstr ""
 #. Label of a Link in the Stock Workspace
 #. Label of a shortcut in the Stock Workspace
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:171
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:650
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:660
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:652
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:662
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice_list.js:49
 #: erpnext/accounts/doctype/purchase_invoice_item/purchase_invoice_item.json
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:246
@@ -41035,7 +41030,7 @@ msgstr ""
 msgid "Quality Inspection Template Name"
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:334
+#: erpnext/public/js/controllers/transaction.js:360
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:165
 msgid "Quality Inspection(s)"
 msgstr ""
@@ -42219,7 +42214,7 @@ msgid "Receivable / Payable Account"
 msgstr ""
 
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:71
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1061
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1063
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py:243
 #: erpnext/accounts/report/sales_register/sales_register.py:217
 #: erpnext/accounts/report/sales_register/sales_register.py:271
@@ -42701,7 +42696,7 @@ msgstr ""
 msgid "Reference Date"
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2311
+#: erpnext/public/js/controllers/transaction.js:2337
 msgid "Reference Date for Early Payment Discount"
 msgstr ""
 
@@ -43025,7 +43020,7 @@ msgstr ""
 msgid "Rejected"
 msgstr ""
 
-#: erpnext/stock/doctype/inventory_dimension/inventory_dimension.py:202
+#: erpnext/stock/doctype/inventory_dimension/inventory_dimension.py:203
 msgid "Rejected "
 msgstr ""
 
@@ -43129,7 +43124,7 @@ msgstr ""
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:187
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:156
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1135
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1137
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:178
 msgid "Remaining Balance"
 msgstr ""
@@ -43182,7 +43177,7 @@ msgstr ""
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:159
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:198
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:269
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1167
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1169
 #: erpnext/accounts/report/general_ledger/general_ledger.html:84
 #: erpnext/accounts/report/general_ledger/general_ledger.html:110
 #: erpnext/accounts/report/general_ledger/general_ledger.py:742
@@ -43931,7 +43926,7 @@ msgstr ""
 msgid "Reserved Quantity for Production"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:2147
+#: erpnext/stock/stock_ledger.py:2155
 msgid "Reserved Serial No."
 msgstr ""
 
@@ -43947,11 +43942,11 @@ msgstr ""
 #: erpnext/stock/doctype/pick_list/pick_list.js:153
 #: erpnext/stock/report/reserved_stock/reserved_stock.json
 #: erpnext/stock/report/stock_balance/stock_balance.py:499
-#: erpnext/stock/stock_ledger.py:2131
+#: erpnext/stock/stock_ledger.py:2139
 msgid "Reserved Stock"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:2177
+#: erpnext/stock/stock_ledger.py:2185
 msgid "Reserved Stock for Batch"
 msgstr ""
 
@@ -43963,7 +43958,7 @@ msgstr ""
 msgid "Reserved Stock for Sub-assembly"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:476
+#: erpnext/controllers/buying_controller.py:484
 msgid "Reserved Warehouse is mandatory for the Item {item_code} in Raw Materials supplied."
 msgstr ""
 
@@ -44777,7 +44772,7 @@ msgstr ""
 msgid "Routing Name"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:667
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:663
 msgid "Row #"
 msgstr ""
 
@@ -44815,7 +44810,7 @@ msgstr ""
 msgid "Row #{0} (Payment Table): Amount must be positive"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:495
+#: erpnext/stock/doctype/item/item.py:498
 msgid "Row #{0}: A reorder entry already exists for warehouse {1} with reorder type {2}."
 msgstr ""
 
@@ -44836,7 +44831,7 @@ msgstr ""
 msgid "Row #{0}: Accepted Warehouse is mandatory for the accepted Item {1}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1117
+#: erpnext/controllers/accounts_controller.py:1120
 msgid "Row #{0}: Account {1} does not belong to company {2}"
 msgstr ""
 
@@ -44877,27 +44872,27 @@ msgstr ""
 msgid "Row #{0}: Cannot allocate more than {1} against payment term {2}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3524
+#: erpnext/controllers/accounts_controller.py:3527
 msgid "Row #{0}: Cannot delete item {1} which has already been billed."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3498
+#: erpnext/controllers/accounts_controller.py:3501
 msgid "Row #{0}: Cannot delete item {1} which has already been delivered"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3517
+#: erpnext/controllers/accounts_controller.py:3520
 msgid "Row #{0}: Cannot delete item {1} which has already been received"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3504
+#: erpnext/controllers/accounts_controller.py:3507
 msgid "Row #{0}: Cannot delete item {1} which has work order assigned to it."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3510
+#: erpnext/controllers/accounts_controller.py:3513
 msgid "Row #{0}: Cannot delete item {1} which is assigned to customer's purchase order."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3765
+#: erpnext/controllers/accounts_controller.py:3768
 msgid "Row #{0}: Cannot set Rate if the billed amount is greater than the amount for Item {1}."
 msgstr ""
 
@@ -45017,7 +45012,7 @@ msgstr ""
 msgid "Row #{0}: Item {1} has been picked, please reserve stock from the Pick List."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:729
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:725
 msgid "Row #{0}: Item {1} is not a Serialized/Batched Item. It cannot have a Serial No/Batch No against it."
 msgstr ""
 
@@ -45073,7 +45068,7 @@ msgstr ""
 msgid "Row #{0}: Please select the Sub Assembly Warehouse"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:502
+#: erpnext/stock/doctype/item/item.py:505
 msgid "Row #{0}: Please set reorder quantity"
 msgstr ""
 
@@ -45106,8 +45101,8 @@ msgstr ""
 msgid "Row #{0}: Quality Inspection {1} was rejected for item {2}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1274
-#: erpnext/controllers/accounts_controller.py:3624
+#: erpnext/controllers/accounts_controller.py:1277
+#: erpnext/controllers/accounts_controller.py:3627
 msgid "Row #{0}: Quantity for Item {1} cannot be zero."
 msgstr ""
 
@@ -45144,7 +45139,7 @@ msgstr ""
 msgid "Row #{0}: Scrap Item Qty cannot be zero"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:230
+#: erpnext/controllers/selling_controller.py:238
 msgid "Row #{0}: Selling rate for item {1} is lower than its {2}.\n"
 "\t\t\t\t\tSelling {3} should be atleast {4}.<br><br>Alternatively,\n"
 "\t\t\t\t\tyou can disable selling price validation in {5} to bypass\n"
@@ -45228,7 +45223,7 @@ msgstr ""
 msgid "Row #{0}: The batch {1} has already expired."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:511
+#: erpnext/stock/doctype/item/item.py:514
 msgid "Row #{0}: The warehouse {1} is not a child warehouse of a group warehouse {2}"
 msgstr ""
 
@@ -45268,39 +45263,39 @@ msgstr ""
 msgid "Row #{1}: Warehouse is mandatory for stock Item {0}"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:259
+#: erpnext/controllers/buying_controller.py:267
 msgid "Row #{idx}: Cannot select Supplier Warehouse while suppling raw materials to subcontractor."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:406
+#: erpnext/controllers/buying_controller.py:414
 msgid "Row #{idx}: Item rate has been updated as per valuation rate since its an internal stock transfer."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:881
+#: erpnext/controllers/buying_controller.py:889
 msgid "Row #{idx}: Please enter a location for the asset item {item_code}."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:537
+#: erpnext/controllers/buying_controller.py:545
 msgid "Row #{idx}: Received Qty must be equal to Accepted + Rejected Qty for Item {item_code}."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:550
+#: erpnext/controllers/buying_controller.py:558
 msgid "Row #{idx}: {field_label} can not be negative for item {item_code}."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:496
+#: erpnext/controllers/buying_controller.py:504
 msgid "Row #{idx}: {field_label} is mandatory."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:518
+#: erpnext/controllers/buying_controller.py:526
 msgid "Row #{idx}: {field_label} is not allowed in Purchase Return."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:250
+#: erpnext/controllers/buying_controller.py:258
 msgid "Row #{idx}: {from_warehouse_field} and {to_warehouse_field} cannot be same."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:999
+#: erpnext/controllers/buying_controller.py:1007
 msgid "Row #{idx}: {schedule_date} cannot be before {transaction_date}."
 msgstr ""
 
@@ -45365,7 +45360,7 @@ msgstr ""
 msgid "Row #{}: {} {} does not exist."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1403
+#: erpnext/stock/doctype/item/item.py:1397
 msgid "Row #{}: {} {} doesn't belong to Company {}. Please select valid {}."
 msgstr ""
 
@@ -45437,11 +45432,11 @@ msgstr ""
 msgid "Row {0}: Both Debit and Credit values cannot be zero"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:222
+#: erpnext/controllers/selling_controller.py:230
 msgid "Row {0}: Conversion Factor is mandatory"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2995
+#: erpnext/controllers/accounts_controller.py:2998
 msgid "Row {0}: Cost Center {1} does not belong to Company {2}"
 msgstr ""
 
@@ -45461,11 +45456,11 @@ msgstr ""
 msgid "Row {0}: Debit entry can not be linked with a {1}"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:776
+#: erpnext/controllers/selling_controller.py:784
 msgid "Row {0}: Delivery Warehouse ({1}) and Customer Warehouse ({2}) can not be same"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2529
+#: erpnext/controllers/accounts_controller.py:2532
 msgid "Row {0}: Due Date in the Payment Terms table cannot be before Posting Date"
 msgstr ""
 
@@ -45474,7 +45469,7 @@ msgid "Row {0}: Either Delivery Note Item or Packed Item reference is mandatory.
 msgstr ""
 
 #: erpnext/accounts/doctype/journal_entry/journal_entry.py:1010
-#: erpnext/controllers/taxes_and_totals.py:1205
+#: erpnext/controllers/taxes_and_totals.py:1215
 msgid "Row {0}: Exchange Rate is mandatory"
 msgstr ""
 
@@ -45523,11 +45518,11 @@ msgstr ""
 msgid "Row {0}: Invalid reference {1}"
 msgstr ""
 
-#: erpnext/controllers/taxes_and_totals.py:142
+#: erpnext/controllers/taxes_and_totals.py:143
 msgid "Row {0}: Item Tax template updated as per validity and rate applied"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:541
+#: erpnext/controllers/selling_controller.py:549
 msgid "Row {0}: Item rate has been updated as per valuation rate since its an internal stock transfer"
 msgstr ""
 
@@ -45647,7 +45642,7 @@ msgstr ""
 msgid "Row {0}: The item {1}, quantity must be positive number"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2972
+#: erpnext/controllers/accounts_controller.py:2975
 msgid "Row {0}: The {3} Account {1} does not belong to the company {2}"
 msgstr ""
 
@@ -45664,7 +45659,7 @@ msgstr ""
 msgid "Row {0}: Workstation or Workstation Type is mandatory for an operation {1}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1011
+#: erpnext/controllers/accounts_controller.py:1014
 msgid "Row {0}: user has not applied the rule {1} on the item {2}"
 msgstr ""
 
@@ -45676,7 +45671,7 @@ msgstr ""
 msgid "Row {0}: {1} must be greater than 0"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:706
+#: erpnext/controllers/accounts_controller.py:709
 msgid "Row {0}: {1} {2} cannot be same as {3} (Party Account) {4}"
 msgstr ""
 
@@ -45692,7 +45687,7 @@ msgstr ""
 msgid "Row {1}: Quantity ({0}) cannot be a fraction. To allow this, disable '{2}' in UOM {3}."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:863
+#: erpnext/controllers/buying_controller.py:871
 msgid "Row {idx}: Asset Naming Series is mandatory for the auto creation of assets for item {item_code}."
 msgstr ""
 
@@ -45718,7 +45713,7 @@ msgstr ""
 msgid "Rows with Same Account heads will be merged on Ledger"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2539
+#: erpnext/controllers/accounts_controller.py:2542
 msgid "Rows with duplicate due dates in other rows were found: {0}"
 msgstr ""
 
@@ -45788,7 +45783,7 @@ msgstr ""
 msgid "SLA Paused On"
 msgstr ""
 
-#: erpnext/public/js/utils.js:1167
+#: erpnext/public/js/utils.js:1163
 msgid "SLA is on hold since {0}"
 msgstr ""
 
@@ -46189,7 +46184,7 @@ msgstr ""
 #: erpnext/accounts/report/sales_register/sales_register.py:238
 #: erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
 #: erpnext/buying/doctype/supplier_quotation_item/supplier_quotation_item.json
-#: erpnext/controllers/selling_controller.py:462
+#: erpnext/controllers/selling_controller.py:470
 #: erpnext/crm/doctype/contract/contract.json
 #: erpnext/maintenance/doctype/maintenance_schedule/maintenance_schedule.js:65
 #: erpnext/maintenance/doctype/maintenance_schedule_item/maintenance_schedule_item.json
@@ -46315,7 +46310,7 @@ msgstr ""
 msgid "Sales Order {0} is not valid"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:443
+#: erpnext/controllers/selling_controller.py:451
 #: erpnext/manufacturing/doctype/work_order/work_order.py:301
 msgid "Sales Order {0} is {1}"
 msgstr ""
@@ -46366,7 +46361,7 @@ msgstr ""
 #: erpnext/accounts/doctype/promotional_scheme/promotional_scheme.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:122
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1156
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1158
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:99
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:194
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:74
@@ -46464,7 +46459,7 @@ msgstr ""
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:156
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:137
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:128
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1153
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1155
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:105
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:191
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:80
@@ -46484,7 +46479,7 @@ msgstr ""
 msgid "Sales Person"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:204
+#: erpnext/controllers/selling_controller.py:212
 msgid "Sales Person <b>{0}</b> is disabled."
 msgstr ""
 
@@ -46765,7 +46760,7 @@ msgstr ""
 
 #. Label of the sample_size (Float) field in DocType 'Quality Inspection'
 #: erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py:93
-#: erpnext/public/js/controllers/transaction.js:2369
+#: erpnext/public/js/controllers/transaction.js:2395
 #: erpnext/stock/doctype/quality_inspection/quality_inspection.json
 msgid "Sample Size"
 msgstr ""
@@ -47303,7 +47298,7 @@ msgstr ""
 msgid "Select Items based on Delivery Date"
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2405
+#: erpnext/public/js/controllers/transaction.js:2431
 msgid "Select Items for Quality Inspection"
 msgstr ""
 
@@ -47444,7 +47439,7 @@ msgstr ""
 msgid "Select company name first."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2785
+#: erpnext/controllers/accounts_controller.py:2788
 msgid "Select finance book for the item {0} at row {1}"
 msgstr ""
 
@@ -47657,7 +47652,7 @@ msgid "Send Now"
 msgstr ""
 
 #. Label of the send_sms (Button) field in DocType 'SMS Center'
-#: erpnext/public/js/controllers/transaction.js:517
+#: erpnext/public/js/controllers/transaction.js:543
 #: erpnext/selling/doctype/sms_center/sms_center.json
 msgid "Send SMS"
 msgstr ""
@@ -47815,7 +47810,7 @@ msgstr ""
 #: erpnext/manufacturing/doctype/job_card/job_card.json
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.js:74
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.py:114
-#: erpnext/public/js/controllers/transaction.js:2382
+#: erpnext/public/js/controllers/transaction.js:2408
 #: erpnext/public/js/utils/serial_no_batch_selector.js:421
 #: erpnext/selling/doctype/installation_note_item/installation_note_item.json
 #: erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
@@ -47864,7 +47859,7 @@ msgstr ""
 msgid "Serial No Range"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1894
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1895
 msgid "Serial No Reserved"
 msgstr ""
 
@@ -47904,7 +47899,7 @@ msgstr ""
 msgid "Serial No and Batch Selector cannot be use when Use Serial / Batch Fields is enabled."
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:859
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:860
 msgid "Serial No is mandatory"
 msgstr ""
 
@@ -47933,7 +47928,7 @@ msgstr ""
 msgid "Serial No {0} does not exist"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2623
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2624
 msgid "Serial No {0} does not exists"
 msgstr ""
 
@@ -47941,7 +47936,7 @@ msgstr ""
 msgid "Serial No {0} is already added"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:357
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:358
 msgid "Serial No {0} is not present in the {1} {2}, hence you can't return it against the {1} {2}"
 msgstr ""
 
@@ -47978,11 +47973,11 @@ msgstr ""
 msgid "Serial Nos and Batches"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1370
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1371
 msgid "Serial Nos are created successfully"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:2137
+#: erpnext/stock/stock_ledger.py:2145
 msgid "Serial Nos are reserved in Stock Reservation Entries, you need to unreserve them before proceeding."
 msgstr ""
 
@@ -48056,11 +48051,11 @@ msgstr ""
 msgid "Serial and Batch Bundle"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1598
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1599
 msgid "Serial and Batch Bundle created"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1664
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1665
 msgid "Serial and Batch Bundle updated"
 msgstr ""
 
@@ -48412,12 +48407,12 @@ msgid "Service Stop Date"
 msgstr ""
 
 #: erpnext/accounts/deferred_revenue.py:44
-#: erpnext/public/js/controllers/transaction.js:1420
+#: erpnext/public/js/controllers/transaction.js:1446
 msgid "Service Stop Date cannot be after Service End Date"
 msgstr ""
 
 #: erpnext/accounts/deferred_revenue.py:41
-#: erpnext/public/js/controllers/transaction.js:1417
+#: erpnext/public/js/controllers/transaction.js:1443
 msgid "Service Stop Date cannot be before Service Start Date"
 msgstr ""
 
@@ -49852,7 +49847,7 @@ msgstr ""
 
 #: erpnext/setup/setup_wizard/operations/defaults_setup.py:70
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:463
-#: erpnext/stock/doctype/item/item.py:245
+#: erpnext/stock/doctype/item/item.py:248
 msgid "Standard Selling"
 msgstr ""
 
@@ -50682,7 +50677,7 @@ msgstr ""
 #. Option for the 'Purpose' (Select) field in DocType 'Stock Reconciliation'
 #. Label of a Link in the Stock Workspace
 #: erpnext/setup/workspace/home/home.json
-#: erpnext/stock/doctype/item/item.py:612
+#: erpnext/stock/doctype/item/item.py:618
 #: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.json
 #: erpnext/stock/workspace/stock/stock.json
 msgid "Stock Reconciliation"
@@ -50693,7 +50688,7 @@ msgstr ""
 msgid "Stock Reconciliation Item"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:612
+#: erpnext/stock/doctype/item/item.py:618
 msgid "Stock Reconciliations"
 msgstr ""
 
@@ -50728,7 +50723,7 @@ msgstr ""
 #: erpnext/stock/doctype/pick_list/pick_list.js:150
 #: erpnext/stock/doctype/pick_list/pick_list.js:155
 #: erpnext/stock/doctype/stock_entry/stock_entry_dashboard.py:25
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:706
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:702
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:575
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:1138
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:1398
@@ -51128,7 +51123,7 @@ msgstr ""
 #: erpnext/setup/doctype/company/company.py:287
 #: erpnext/setup/setup_wizard/operations/defaults_setup.py:33
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:502
-#: erpnext/stock/doctype/item/item.py:282
+#: erpnext/stock/doctype/item/item.py:285
 msgid "Stores"
 msgstr ""
 
@@ -51663,7 +51658,7 @@ msgstr ""
 msgid "Successfully Set Supplier"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:339
+#: erpnext/stock/doctype/item/item.py:342
 msgid "Successfully changed Stock UOM, please redefine conversion factors for new UOM."
 msgstr ""
 
@@ -51965,7 +51960,7 @@ msgstr ""
 #: erpnext/accounts/doctype/tax_rule/tax_rule.json
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:111
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:87
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1160
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1162
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:198
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:237
 #: erpnext/accounts/report/purchase_register/purchase_register.js:27
@@ -52065,7 +52060,7 @@ msgstr ""
 #. Label of the supplier_name (Data) field in DocType 'Purchase Receipt'
 #. Label of the supplier_name (Data) field in DocType 'Stock Entry'
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1077
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1079
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:156
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:198
 #: erpnext/accounts/report/purchase_register/purchase_register.py:177
@@ -52549,7 +52544,7 @@ msgstr ""
 msgid "System will fetch all the entries if limit value is zero."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1975
+#: erpnext/controllers/accounts_controller.py:1978
 msgid "System will not check over billing since amount for Item {0} in {1} is zero"
 msgstr ""
 
@@ -52808,7 +52803,7 @@ msgstr ""
 msgid "Target Warehouse is required before Submit"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:782
+#: erpnext/controllers/selling_controller.py:790
 msgid "Target Warehouse is set for some items but the customer is not an internal customer."
 msgstr ""
 
@@ -53047,7 +53042,7 @@ msgstr ""
 msgid "Tax Category"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:194
+#: erpnext/controllers/buying_controller.py:202
 msgid "Tax Category has been changed to \"Total\" because all the Items are non-stock items"
 msgstr ""
 
@@ -53252,7 +53247,7 @@ msgstr ""
 #. Label of the taxable_amount (Currency) field in DocType 'Tax Withheld
 #. Vouchers'
 #: erpnext/accounts/doctype/tax_withheld_vouchers/tax_withheld_vouchers.json
-#: erpnext/controllers/taxes_and_totals.py:1125
+#: erpnext/controllers/taxes_and_totals.py:1135
 msgid "Taxable Amount"
 msgstr ""
 
@@ -53391,7 +53386,7 @@ msgstr ""
 msgid "Taxes and Charges Deducted (Company Currency)"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:352
+#: erpnext/stock/doctype/item/item.py:355
 msgid "Taxes row #{0}: {1} cannot be smaller than {2}"
 msgstr ""
 
@@ -53677,7 +53672,7 @@ msgstr ""
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/territory_item/territory_item.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:134
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1144
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1146
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:93
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:182
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:68
@@ -53781,7 +53776,7 @@ msgstr ""
 msgid "The BOM which will be replaced"
 msgstr ""
 
-#: erpnext/stock/serial_batch_bundle.py:1274
+#: erpnext/stock/serial_batch_bundle.py:1306
 msgid "The Batch {0} has negative quantity {1} in warehouse {2}. Please correct the quantity."
 msgstr ""
 
@@ -53833,7 +53828,7 @@ msgstr ""
 msgid "The Serial No at Row #{0}: {1} is not available in warehouse {2}."
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1891
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1892
 msgid "The Serial No {0} is reserved against the {1} {2} and cannot be used for any other transaction."
 msgstr ""
 
@@ -53916,7 +53911,7 @@ msgstr ""
 msgid "The following batches are expired, please restock them: <br> {0}"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:849
+#: erpnext/stock/doctype/item/item.py:843
 msgid "The following deleted attributes exist in Variants but not in the Template. You can either delete the Variants or keep the attribute(s) in template."
 msgstr ""
 
@@ -53941,15 +53936,15 @@ msgstr ""
 msgid "The holiday on {0} is not between From Date and To Date"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:1066
+#: erpnext/controllers/buying_controller.py:1074
 msgid "The item {item} is not marked as {type_of} item. You can enable it as {type_of} item from its Item master."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:614
+#: erpnext/stock/doctype/item/item.py:620
 msgid "The items {0} and {1} are present in the following {2} :"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:1059
+#: erpnext/controllers/buying_controller.py:1067
 msgid "The items {items} are not marked as {type_of} item. You can enable them as {type_of} item from their Item masters."
 msgstr ""
 
@@ -54051,8 +54046,8 @@ msgstr ""
 msgid "The seller and the buyer cannot be the same"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:142
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:154
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:143
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:155
 msgid "The serial and batch bundle {0} not linked to {1} {2}"
 msgstr ""
 
@@ -54076,7 +54071,7 @@ msgstr ""
 msgid "The stock for the item {0} in the {1} warehouse was negative on the {2}. You should create a positive entry {3} before the date {4} and time {5} to post the correct valuation rate. For more details, please read the <a href='https://docs.erpnext.com/docs/user/manual/en/stock-adjustment-cogs-with-negative-stock'>documentation<a>."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:700
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:696
 msgid "The stock has been reserved for the following Items and Warehouses, un-reserve the same to {0} the Stock Reconciliation: <br /><br /> {1}"
 msgstr ""
 
@@ -54089,11 +54084,11 @@ msgstr ""
 msgid "The task has been enqueued as a background job."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:994
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:990
 msgid "The task has been enqueued as a background job. In case there is any issue on processing in background, the system will add a comment about the error on this Stock Reconciliation and revert to the Draft stage"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1005
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1001
 msgid "The task has been enqueued as a background job. In case there is any issue on processing in background, the system will add a comment about the error on this Stock Reconciliation and revert to the Submitted stage"
 msgstr ""
 
@@ -54143,7 +54138,7 @@ msgstr ""
 msgid "The {0} ({1}) must be equal to {2} ({3})"
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2790
+#: erpnext/public/js/controllers/transaction.js:2816
 msgid "The {0} contains Unit Price Items."
 msgstr ""
 
@@ -54191,7 +54186,7 @@ msgstr ""
 msgid "There can be multiple tiered collection factor based on the total spent. But the conversion factor for redemption will always be same for all the tier."
 msgstr ""
 
-#: erpnext/accounts/party.py:580
+#: erpnext/accounts/party.py:586
 msgid "There can only be 1 Account per Company in {0} {1}"
 msgstr ""
 
@@ -54477,7 +54472,7 @@ msgstr ""
 msgid "This will restrict user access to other employee records"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:783
+#: erpnext/controllers/selling_controller.py:791
 msgid "This {} will be treated as material transfer."
 msgstr ""
 
@@ -55191,11 +55186,11 @@ msgid "To include sub-assembly costs and scrap items in Finished Goods on a work
 msgstr ""
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:2337
-#: erpnext/controllers/accounts_controller.py:3005
+#: erpnext/controllers/accounts_controller.py:3008
 msgid "To include tax in row {0} in Item rate, taxes in rows {1} must also be included"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:636
+#: erpnext/stock/doctype/item/item.py:642
 msgid "To merge, following properties must be same for both items"
 msgstr ""
 
@@ -55815,7 +55810,7 @@ msgstr ""
 msgid "Total Paid Amount"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2591
+#: erpnext/controllers/accounts_controller.py:2594
 msgid "Total Payment Amount in Payment Schedule must be equal to Grand / Rounded Total"
 msgstr ""
 
@@ -56100,15 +56095,15 @@ msgstr ""
 msgid "Total Working Hours"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2138
+#: erpnext/controllers/accounts_controller.py:2141
 msgid "Total advance ({0}) against Order {1} cannot be greater than the Grand Total ({2})"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:190
+#: erpnext/controllers/selling_controller.py:198
 msgid "Total allocated percentage for sales team should be 100"
 msgstr ""
 
-#: erpnext/selling/doctype/customer/customer.py:162
+#: erpnext/selling/doctype/customer/customer.py:161
 msgid "Total contribution percentage should be equal to 100"
 msgstr ""
 
@@ -56993,7 +56988,7 @@ msgstr ""
 msgid "Unit of Measure (UOM)"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:384
+#: erpnext/stock/doctype/item/item.py:387
 msgid "Unit of Measure {0} has been entered more than once in Conversion Factor Table"
 msgstr ""
 
@@ -57435,7 +57430,7 @@ msgstr ""
 msgid "Update timestamp on new communication"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom_creator/bom_creator.py:533
+#: erpnext/manufacturing/doctype/bom_creator/bom_creator.py:534
 msgid "Updated successfully"
 msgstr ""
 
@@ -57449,7 +57444,7 @@ msgstr ""
 msgid "Updated via 'Time Log' (In Minutes)"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1387
+#: erpnext/stock/doctype/item/item.py:1381
 msgid "Updating Variants..."
 msgstr ""
 
@@ -58007,19 +58002,19 @@ msgstr ""
 msgid "Valuation Rate (In / Out)"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1881
+#: erpnext/stock/stock_ledger.py:1890
 msgid "Valuation Rate Missing"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1859
+#: erpnext/stock/stock_ledger.py:1868
 msgid "Valuation Rate for the Item {0}, is required to do accounting entries for {1} {2}."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:266
+#: erpnext/stock/doctype/item/item.py:269
 msgid "Valuation Rate is mandatory if Opening Stock entered"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:752
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:748
 msgid "Valuation Rate required for Item {0} at row {1}"
 msgstr ""
 
@@ -58029,7 +58024,7 @@ msgstr ""
 msgid "Valuation and Total"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:971
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:967
 msgid "Valuation rate for customer provided items has been set to zero."
 msgstr ""
 
@@ -58043,7 +58038,7 @@ msgid "Valuation rate for the item as per Sales Invoice (Only for Internal Trans
 msgstr ""
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:2361
-#: erpnext/controllers/accounts_controller.py:3029
+#: erpnext/controllers/accounts_controller.py:3032
 msgid "Valuation type charges can not be marked as Inclusive"
 msgstr ""
 
@@ -58199,7 +58194,7 @@ msgstr ""
 msgid "Variant"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:864
+#: erpnext/stock/doctype/item/item.py:858
 msgid "Variant Attribute Error"
 msgstr ""
 
@@ -58218,7 +58213,7 @@ msgstr ""
 msgid "Variant Based On"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:892
+#: erpnext/stock/doctype/item/item.py:886
 msgid "Variant Based On cannot be changed"
 msgstr ""
 
@@ -58236,7 +58231,7 @@ msgstr ""
 msgid "Variant Item"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:862
+#: erpnext/stock/doctype/item/item.py:856
 msgid "Variant Items"
 msgstr ""
 
@@ -58354,7 +58349,7 @@ msgstr ""
 #: erpnext/accounts/doctype/cost_center/cost_center_tree.js:56
 #: erpnext/accounts/doctype/invoice_discounting/invoice_discounting.js:205
 #: erpnext/accounts/doctype/journal_entry/journal_entry.js:43
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:668
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:670
 #: erpnext/bulk_transaction/doctype/bulk_transaction_log/bulk_transaction_log.js:14
 #: erpnext/bulk_transaction/doctype/bulk_transaction_log/bulk_transaction_log.js:24
 #: erpnext/buying/doctype/request_for_quotation/request_for_quotation.js:167
@@ -58541,7 +58536,7 @@ msgstr ""
 #: erpnext/accounts/doctype/repost_accounting_ledger_items/repost_accounting_ledger_items.json
 #: erpnext/accounts/doctype/repost_payment_ledger_items/repost_payment_ledger_items.json
 #: erpnext/accounts/doctype/unreconcile_payment/unreconcile_payment.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1099
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1101
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.js:42
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:209
 #: erpnext/accounts/report/general_ledger/general_ledger.js:49
@@ -58572,7 +58567,7 @@ msgstr ""
 msgid "Voucher No"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1087
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1088
 msgid "Voucher No is mandatory"
 msgstr ""
 
@@ -58614,7 +58609,7 @@ msgstr ""
 #: erpnext/accounts/doctype/repost_payment_ledger_items/repost_payment_ledger_items.json
 #: erpnext/accounts/doctype/tax_withheld_vouchers/tax_withheld_vouchers.json
 #: erpnext/accounts/doctype/unreconcile_payment/unreconcile_payment.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1097
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1099
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:200
 #: erpnext/accounts/report/general_ledger/general_ledger.py:697
 #: erpnext/accounts/report/invalid_ledger_entries/invalid_ledger_entries.py:31
@@ -58968,10 +58963,6 @@ msgstr ""
 msgid "Warehouse not found against the account {0}"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:600
-msgid "Warehouse not found in the system"
-msgstr ""
-
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:1130
 #: erpnext/stock/doctype/delivery_note/delivery_note.py:414
 msgid "Warehouse required for stock Item {0}"
@@ -59100,7 +59091,7 @@ msgid "Warn for new Request for Quotations"
 msgstr ""
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:744
-#: erpnext/controllers/accounts_controller.py:1978
+#: erpnext/controllers/accounts_controller.py:1981
 #: erpnext/stock/doctype/delivery_trip/delivery_trip.js:145
 #: erpnext/utilities/transaction_base.py:123
 msgid "Warning"
@@ -60072,7 +60063,7 @@ msgstr "Sim"
 msgid "You are importing data for the code list:"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3611
+#: erpnext/controllers/accounts_controller.py:3614
 msgid "You are not allowed to update as per the conditions set in {} Workflow."
 msgstr ""
 
@@ -60137,7 +60128,7 @@ msgstr ""
 msgid "You can't make any changes to Job Card since Work Order is closed."
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:185
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:186
 msgid "You can't process the serial number {0} as it has already been used in the SABB {1}. {2} if you want to inward same serial number multiple times then enabled 'Allow existing Serial No to be Manufactured/Received again' in the {3}"
 msgstr ""
 
@@ -60197,7 +60188,7 @@ msgstr ""
 msgid "You cannot {0} this document because another Period Closing Entry {1} exists after {2}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3587
+#: erpnext/controllers/accounts_controller.py:3590
 msgid "You do not have permissions to {} items in a {}."
 msgstr ""
 
@@ -60225,7 +60216,7 @@ msgstr ""
 msgid "You have entered a duplicate Delivery Note on Row"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1063
+#: erpnext/stock/doctype/item/item.py:1057
 msgid "You have to enable auto re-order in Stock Settings to maintain re-order levels."
 msgstr ""
 
@@ -60245,7 +60236,7 @@ msgstr ""
 msgid "You need to cancel POS Closing Entry {} to be able to cancel this document."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2980
+#: erpnext/controllers/accounts_controller.py:2983
 msgid "You selected the account group {1} as {2} Account in row {0}. Please select a single account."
 msgstr ""
 
@@ -60323,7 +60314,7 @@ msgstr ""
 msgid "`Allow Negative rates for Items`"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1873
+#: erpnext/stock/stock_ledger.py:1882
 msgid "after"
 msgstr ""
 
@@ -60471,7 +60462,7 @@ msgstr ""
 msgid "material_request_item"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:151
+#: erpnext/controllers/selling_controller.py:159
 msgid "must be between 0 and 100"
 msgstr ""
 
@@ -60496,7 +60487,7 @@ msgstr ""
 msgid "on"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1289
+#: erpnext/controllers/accounts_controller.py:1292
 msgid "or"
 msgstr ""
 
@@ -60545,7 +60536,7 @@ msgstr ""
 msgid "per hour"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1874
+#: erpnext/stock/stock_ledger.py:1883
 msgid "performing either one below:"
 msgstr ""
 
@@ -60672,7 +60663,7 @@ msgstr ""
 msgid "{0}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1109
+#: erpnext/controllers/accounts_controller.py:1112
 msgid "{0} '{1}' is disabled"
 msgstr ""
 
@@ -60688,7 +60679,7 @@ msgstr ""
 msgid "{0} <b>{1}</b> has submitted Assets. Remove Item <b>{2}</b> from table to continue."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2193
+#: erpnext/controllers/accounts_controller.py:2196
 msgid "{0} Account not found against Customer {1}."
 msgstr ""
 
@@ -60720,7 +60711,7 @@ msgstr ""
 msgid "{0} Request for {1}"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:323
+#: erpnext/stock/doctype/item/item.py:326
 msgid "{0} Retain Sample is based on batch, please check Has Batch No to retain sample of item"
 msgstr ""
 
@@ -60811,7 +60802,7 @@ msgid "{0} entered twice in Item Tax"
 msgstr ""
 
 #: erpnext/setup/doctype/item_group/item_group.py:48
-#: erpnext/stock/doctype/item/item.py:436
+#: erpnext/stock/doctype/item/item.py:439
 msgid "{0} entered twice {1} in Item Taxes"
 msgstr ""
 
@@ -60832,7 +60823,7 @@ msgstr ""
 msgid "{0} hours"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2534
+#: erpnext/controllers/accounts_controller.py:2537
 msgid "{0} in row {1}"
 msgstr ""
 
@@ -60856,7 +60847,7 @@ msgstr ""
 
 #: erpnext/accounts/doctype/budget/budget.py:60
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:643
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:49
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:50
 #: erpnext/accounts/report/general_ledger/general_ledger.py:59
 #: erpnext/accounts/report/pos_register/pos_register.py:107
 #: erpnext/controllers/trends.py:50
@@ -60876,11 +60867,11 @@ msgstr ""
 msgid "{0} is mandatory. Maybe Currency Exchange record is not created for {1} to {2}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2937
+#: erpnext/controllers/accounts_controller.py:2940
 msgid "{0} is mandatory. Maybe Currency Exchange record is not created for {1} to {2}."
 msgstr ""
 
-#: erpnext/selling/doctype/customer/customer.py:204
+#: erpnext/selling/doctype/customer/customer.py:203
 msgid "{0} is not a company bank account"
 msgstr ""
 
@@ -60963,7 +60954,7 @@ msgstr ""
 msgid "{0} to {1}"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:690
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:686
 msgid "{0} units are reserved for Item {1} in Warehouse {2}, please un-reserve the same to {3} the Stock Reconciliation."
 msgstr ""
 
@@ -60979,16 +60970,16 @@ msgstr ""
 msgid "{0} units of {1} are required in {2} with the inventory dimension: {3} ({4}) on {5} {6} for {7} to complete the transaction."
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1532 erpnext/stock/stock_ledger.py:2023
-#: erpnext/stock/stock_ledger.py:2037
+#: erpnext/stock/stock_ledger.py:1541 erpnext/stock/stock_ledger.py:2031
+#: erpnext/stock/stock_ledger.py:2045
 msgid "{0} units of {1} needed in {2} on {3} {4} for {5} to complete this transaction."
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:2124 erpnext/stock/stock_ledger.py:2170
+#: erpnext/stock/stock_ledger.py:2132 erpnext/stock/stock_ledger.py:2178
 msgid "{0} units of {1} needed in {2} on {3} {4} to complete this transaction."
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1526
+#: erpnext/stock/stock_ledger.py:1535
 msgid "{0} units of {1} needed in {2} to complete this transaction."
 msgstr ""
 
@@ -61034,7 +61025,7 @@ msgstr ""
 msgid "{0} {1} does not exist"
 msgstr ""
 
-#: erpnext/accounts/party.py:560
+#: erpnext/accounts/party.py:566
 msgid "{0} {1} has accounting entries in currency {2} for company {3}. Please select a receivable or payable account with currency {2}."
 msgstr ""
 
@@ -61068,7 +61059,7 @@ msgstr ""
 msgid "{0} {1} is associated with {2}, but Party Account is {3}"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:462
+#: erpnext/controllers/selling_controller.py:470
 #: erpnext/controllers/subcontracting_controller.py:954
 msgid "{0} {1} is cancelled or closed"
 msgstr ""
@@ -61085,11 +61076,11 @@ msgstr ""
 msgid "{0} {1} is closed"
 msgstr ""
 
-#: erpnext/accounts/party.py:798
+#: erpnext/accounts/party.py:804
 msgid "{0} {1} is disabled"
 msgstr ""
 
-#: erpnext/accounts/party.py:804
+#: erpnext/accounts/party.py:810
 msgid "{0} {1} is frozen"
 msgstr ""
 
@@ -61097,7 +61088,7 @@ msgstr ""
 msgid "{0} {1} is fully billed"
 msgstr ""
 
-#: erpnext/accounts/party.py:808
+#: erpnext/accounts/party.py:814
 msgid "{0} {1} is not active"
 msgstr ""
 
@@ -61223,15 +61214,15 @@ msgstr ""
 msgid "{0}: {1} must be less than {2}"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:840
+#: erpnext/controllers/buying_controller.py:848
 msgid "{count} Assets created for {item_code}"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:738
+#: erpnext/controllers/buying_controller.py:746
 msgid "{doctype} {name} is cancelled or closed."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:459
+#: erpnext/controllers/buying_controller.py:467
 msgid "{field_label} is mandatory for sub-contracted {doctype}."
 msgstr ""
 
@@ -61239,7 +61230,7 @@ msgstr ""
 msgid "{item_name}'s Sample Size ({sample_size}) cannot be greater than the Accepted Quantity ({accepted_quantity})"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:563
+#: erpnext/controllers/buying_controller.py:571
 msgid "{ref_doctype} {ref_name} is {status}."
 msgstr ""
 
@@ -61305,7 +61296,7 @@ msgstr ""
 msgid "{} can't be cancelled since the Loyalty Points earned has been redeemed. First cancel the {} No {}"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:222
+#: erpnext/controllers/buying_controller.py:230
 msgid "{} has submitted assets linked to it. You need to cancel the assets to create purchase return."
 msgstr ""
 

--- a/erpnext/locale/pt_BR.po
+++ b/erpnext/locale/pt_BR.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: frappe\n"
 "Report-Msgid-Bugs-To: hello@frappe.io\n"
-"POT-Creation-Date: 2025-05-25 09:35+0000\n"
-"PO-Revision-Date: 2025-05-25 20:35\n"
+"POT-Creation-Date: 2025-06-01 09:36+0000\n"
+"PO-Revision-Date: 2025-06-01 21:35\n"
 "Last-Translator: hello@frappe.io\n"
 "Language-Team: Portuguese, Brazilian\n"
 "MIME-Version: 1.0\n"
@@ -83,15 +83,15 @@ msgstr ""
 msgid " Summary"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:235
+#: erpnext/stock/doctype/item/item.py:238
 msgid "\"Customer Provided Item\" cannot be Purchase Item also"
 msgstr "\"Item fornecido pelo cliente\" não pode ser item de compra também"
 
-#: erpnext/stock/doctype/item/item.py:237
+#: erpnext/stock/doctype/item/item.py:240
 msgid "\"Customer Provided Item\" cannot have Valuation Rate"
 msgstr "\"Item fornecido pelo cliente\" não pode ter taxa de avaliação"
 
-#: erpnext/stock/doctype/item/item.py:313
+#: erpnext/stock/doctype/item/item.py:316
 msgid "\"Is Fixed Asset\" cannot be unchecked, as Asset record exists against the item"
 msgstr ""
 
@@ -213,7 +213,7 @@ msgstr ""
 msgid "% of materials delivered against this Sales Order"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2197
+#: erpnext/controllers/accounts_controller.py:2200
 msgid "'Account' in the Accounting section of Customer {0}"
 msgstr ""
 
@@ -225,15 +225,11 @@ msgstr ""
 msgid "'Based On' and 'Group By' can not be same"
 msgstr "'Baseado em' e 'Agrupar por' não podem ser o mesmo"
 
-#: erpnext/stock/report/product_bundle_balance/product_bundle_balance.py:233
-msgid "'Date' is required"
-msgstr ""
-
 #: erpnext/selling/report/inactive_customers/inactive_customers.py:18
 msgid "'Days Since Last Order' must be greater than or equal to zero"
 msgstr "'Dias desde a última Ordem' deve ser maior ou igual a zero"
 
-#: erpnext/controllers/accounts_controller.py:2202
+#: erpnext/controllers/accounts_controller.py:2205
 msgid "'Default {0} Account' in Company {1}"
 msgstr ""
 
@@ -243,7 +239,7 @@ msgstr "'Entradas' não pode estar vazio"
 
 #: erpnext/stock/report/batch_item_expiry_status/batch_item_expiry_status.py:24
 #: erpnext/stock/report/batch_wise_balance_history/batch_wise_balance_history.py:120
-#: erpnext/stock/report/stock_analytics/stock_analytics.py:314
+#: erpnext/stock/report/stock_analytics/stock_analytics.py:313
 msgid "'From Date' is required"
 msgstr "'Informe a 'Data Inicial'"
 
@@ -251,7 +247,7 @@ msgstr "'Informe a 'Data Inicial'"
 msgid "'From Date' must be after 'To Date'"
 msgstr "A 'Data Final' deve ser posterior a 'Data Inicial'"
 
-#: erpnext/stock/doctype/item/item.py:398
+#: erpnext/stock/doctype/item/item.py:401
 msgid "'Has Serial No' can not be 'Yes' for non-stock item"
 msgstr "'Tem Número Serial' não pode ser confirmado para itens sem controle de estoque"
 
@@ -1075,7 +1071,7 @@ msgstr ""
 
 #. Label of the qty (Float) field in DocType 'Purchase Receipt Item'
 #. Label of the qty (Float) field in DocType 'Subcontracting Receipt Item'
-#: erpnext/public/js/controllers/transaction.js:2362
+#: erpnext/public/js/controllers/transaction.js:2388
 #: erpnext/stock/doctype/purchase_receipt_item/purchase_receipt_item.json
 #: erpnext/subcontracting/doctype/subcontracting_receipt_item/subcontracting_receipt_item.json
 msgid "Accepted Quantity"
@@ -1273,7 +1269,7 @@ msgid "Account Manager"
 msgstr ""
 
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:949
-#: erpnext/controllers/accounts_controller.py:2206
+#: erpnext/controllers/accounts_controller.py:2209
 msgid "Account Missing"
 msgstr "Falta de Conta"
 
@@ -1448,7 +1444,7 @@ msgstr "Conta {0} é adicionada na empresa filha {1}"
 msgid "Account {0} is frozen"
 msgstr "A Conta {0} está congelada"
 
-#: erpnext/controllers/accounts_controller.py:1288
+#: erpnext/controllers/accounts_controller.py:1291
 msgid "Account {0} is invalid. Account Currency must be {1}"
 msgstr "Conta {0} é inválido. Conta de moeda deve ser {1}"
 
@@ -1484,7 +1480,7 @@ msgstr "Conta: {0} só pode ser atualizado via transações de ações"
 msgid "Account: {0} is not permitted under Payment Entry"
 msgstr "Conta: {0} não é permitida em Entrada de pagamento"
 
-#: erpnext/controllers/accounts_controller.py:3037
+#: erpnext/controllers/accounts_controller.py:3040
 msgid "Account: {0} with currency: {1} can not be selected"
 msgstr "A Conta: {0} com moeda: {1} não pode ser selecionada"
 
@@ -1757,7 +1753,7 @@ msgstr ""
 msgid "Accounting Entry for Asset"
 msgstr "Entrada Contábil de Ativo"
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:796
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:805
 msgid "Accounting Entry for Service"
 msgstr "Lançamento Contábil Para Serviço"
 
@@ -1772,18 +1768,18 @@ msgstr "Lançamento Contábil Para Serviço"
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py:1468
 #: erpnext/controllers/stock_controller.py:550
 #: erpnext/controllers/stock_controller.py:567
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:889
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:898
 #: erpnext/stock/doctype/stock_entry/stock_entry.py:1586
 #: erpnext/stock/doctype/stock_entry/stock_entry.py:1600
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py:561
 msgid "Accounting Entry for Stock"
 msgstr "Lançamento Contábil de Estoque"
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:717
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:726
 msgid "Accounting Entry for {0}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2247
+#: erpnext/controllers/accounts_controller.py:2250
 msgid "Accounting Entry for {0}: {1} can only be made in currency: {2}"
 msgstr "Contabilidade de entrada para {0}: {1} só pode ser feito em moeda: {2}"
 
@@ -2176,7 +2172,7 @@ msgstr "Depreciação Acumulada Como Em"
 msgid "Accumulated Monthly"
 msgstr "Acumulada Mensalmente"
 
-#: erpnext/controllers/budget_controller.py:417
+#: erpnext/controllers/budget_controller.py:422
 msgid "Accumulated Monthly Budget for Account {0} against {1} {2} is {3}. It will be collectively ({4}) exceeded by {5}"
 msgstr ""
 
@@ -3290,7 +3286,7 @@ msgstr ""
 msgid "Adjustment Against"
 msgstr ""
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:634
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:643
 msgid "Adjustment based on Purchase Invoice rate"
 msgstr ""
 
@@ -3401,7 +3397,7 @@ msgstr ""
 msgid "Advance amount"
 msgstr ""
 
-#: erpnext/controllers/taxes_and_totals.py:845
+#: erpnext/controllers/taxes_and_totals.py:855
 msgid "Advance amount cannot be greater than {0} {1}"
 msgstr ""
 
@@ -3612,7 +3608,7 @@ msgstr "Idade"
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:152
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:133
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1125
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1127
 msgid "Age (Days)"
 msgstr "Idade (dias)"
 
@@ -3698,16 +3694,6 @@ msgstr ""
 #: erpnext/setup/setup_wizard/data/industry_type.txt:4
 msgid "Agriculture"
 msgstr ""
-
-#. Name of a role
-#: erpnext/assets/doctype/location/location.json
-msgid "Agriculture Manager"
-msgstr "Gerente de Agricultura"
-
-#. Name of a role
-#: erpnext/assets/doctype/location/location.json
-msgid "Agriculture User"
-msgstr "Usuário da Agricultura"
 
 #: erpnext/setup/setup_wizard/data/industry_type.txt:5
 msgid "Airline"
@@ -3899,7 +3885,7 @@ msgstr ""
 msgid "All items are already requested"
 msgstr ""
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:1317
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:1326
 msgid "All items have already been Invoiced/Returned"
 msgstr "Todos os itens já foram faturados / devolvidos"
 
@@ -3911,7 +3897,7 @@ msgstr ""
 msgid "All items have already been transferred for this Work Order."
 msgstr "Todos os itens já foram transferidos para esta Ordem de Serviço."
 
-#: erpnext/public/js/controllers/transaction.js:2465
+#: erpnext/public/js/controllers/transaction.js:2491
 msgid "All items in this document already have a linked Quality Inspection."
 msgstr ""
 
@@ -4109,7 +4095,7 @@ msgstr ""
 msgid "Allow Item To Be Added Multiple Times in a Transaction"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:755
+#: erpnext/controllers/selling_controller.py:763
 msgid "Allow Item to Be Added Multiple Times in a Transaction"
 msgstr ""
 
@@ -5055,7 +5041,7 @@ msgstr "Anual"
 msgid "Annual Billing: {0}"
 msgstr "Faturação Anual: {0}"
 
-#: erpnext/controllers/budget_controller.py:441
+#: erpnext/controllers/budget_controller.py:446
 msgid "Annual Budget for Account {0} against {1} {2} is {3}. It will be collectively ({4}) exceeded by {5}"
 msgstr ""
 
@@ -5544,7 +5530,7 @@ msgstr "Como o campo {0} está habilitado, o campo {1} é obrigatório."
 msgid "As the field {0} is enabled, the value of the field {1} should be more than 1."
 msgstr "Como o campo {0} está habilitado, o valor do campo {1} deve ser maior que 1."
 
-#: erpnext/stock/doctype/item/item.py:989
+#: erpnext/stock/doctype/item/item.py:983
 msgid "As there are existing submitted transactions against item {0}, you can not change the value of {1}."
 msgstr ""
 
@@ -5690,7 +5676,7 @@ msgstr "Ativo Categoria Conta"
 msgid "Asset Category Name"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:304
+#: erpnext/stock/doctype/item/item.py:307
 msgid "Asset Category is mandatory for Fixed Asset item"
 msgstr ""
 
@@ -6065,7 +6051,7 @@ msgstr ""
 msgid "Asset {0} must be submitted"
 msgstr "O Ativo {0} deve ser enviado"
 
-#: erpnext/controllers/buying_controller.py:851
+#: erpnext/controllers/buying_controller.py:859
 msgid "Asset {assets_link} created for {item_code}"
 msgstr ""
 
@@ -6095,11 +6081,11 @@ msgstr ""
 msgid "Assets"
 msgstr "Ativos"
 
-#: erpnext/controllers/buying_controller.py:869
+#: erpnext/controllers/buying_controller.py:877
 msgid "Assets not created for {item_code}. You will have to create asset manually."
 msgstr "Recursos não criados para {item_code}. Você terá que criar o ativo manualmente."
 
-#: erpnext/controllers/buying_controller.py:856
+#: erpnext/controllers/buying_controller.py:864
 msgid "Assets {assets_link} created for {item_code}"
 msgstr ""
 
@@ -6194,7 +6180,7 @@ msgstr ""
 msgid "At row #{0}: you have selected the Difference Account {1}, which is a Cost of Goods Sold type account. Please select a different account"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:864
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:865
 msgid "At row {0}: Batch No is mandatory for Item {1}"
 msgstr ""
 
@@ -6202,11 +6188,11 @@ msgstr ""
 msgid "At row {0}: Parent Row No cannot be set for item {1}"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:849
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:850
 msgid "At row {0}: Qty is mandatory for the batch {1}"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:856
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:857
 msgid "At row {0}: Serial No is mandatory for Item {1}"
 msgstr ""
 
@@ -6280,7 +6266,7 @@ msgstr ""
 msgid "Attribute Value"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:930
+#: erpnext/stock/doctype/item/item.py:924
 msgid "Attribute table is mandatory"
 msgstr "A tabela de atributos é obrigatório"
 
@@ -6288,11 +6274,11 @@ msgstr "A tabela de atributos é obrigatório"
 msgid "Attribute value: {0} must appear only once"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:934
+#: erpnext/stock/doctype/item/item.py:928
 msgid "Attribute {0} selected multiple times in Attributes Table"
 msgstr "Atributo {0} selecionada várias vezes na tabela de atributos"
 
-#: erpnext/stock/doctype/item/item.py:862
+#: erpnext/stock/doctype/item/item.py:856
 msgid "Attributes"
 msgstr "Atributos"
 
@@ -7576,11 +7562,11 @@ msgstr "Código de Barras"
 msgid "Barcode Type"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:457
+#: erpnext/stock/doctype/item/item.py:460
 msgid "Barcode {0} already used in Item {1}"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:472
+#: erpnext/stock/doctype/item/item.py:475
 msgid "Barcode {0} is not a valid {1} code"
 msgstr "O código de barras {0} não é um código {1} válido"
 
@@ -7834,7 +7820,7 @@ msgstr ""
 #: erpnext/manufacturing/doctype/job_card/job_card.json
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.js:89
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.py:115
-#: erpnext/public/js/controllers/transaction.js:2388
+#: erpnext/public/js/controllers/transaction.js:2414
 #: erpnext/public/js/utils/barcode_scanner.js:260
 #: erpnext/public/js/utils/serial_no_batch_selector.js:438
 #: erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
@@ -7861,11 +7847,11 @@ msgstr ""
 msgid "Batch No"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:867
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:868
 msgid "Batch No is mandatory"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2629
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2630
 msgid "Batch No {0} does not exists"
 msgstr ""
 
@@ -7873,7 +7859,7 @@ msgstr ""
 msgid "Batch No {0} is linked with Item {1} which has serial no. Please scan serial no instead."
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:364
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:365
 msgid "Batch No {0} is not present in the original {1} {2}, hence you can't return it against the {1} {2}"
 msgstr ""
 
@@ -7888,11 +7874,11 @@ msgstr ""
 msgid "Batch Nos"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1421
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1422
 msgid "Batch Nos are created successfully"
 msgstr ""
 
-#: erpnext/controllers/sales_and_purchase_return.py:1096
+#: erpnext/controllers/sales_and_purchase_return.py:1001
 msgid "Batch Not Available for Return"
 msgstr ""
 
@@ -7941,7 +7927,7 @@ msgstr ""
 msgid "Batch {0} and Warehouse"
 msgstr ""
 
-#: erpnext/controllers/sales_and_purchase_return.py:1095
+#: erpnext/controllers/sales_and_purchase_return.py:1000
 msgid "Batch {0} is not available in warehouse {1}"
 msgstr ""
 
@@ -7991,7 +7977,7 @@ msgstr ""
 #. Label of the bill_date (Date) field in DocType 'Journal Entry'
 #. Label of the bill_date (Date) field in DocType 'Subcontracting Receipt'
 #: erpnext/accounts/doctype/journal_entry/journal_entry.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1110
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1112
 #: erpnext/accounts/report/purchase_register/purchase_register.py:214
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.json
 msgid "Bill Date"
@@ -8000,7 +7986,7 @@ msgstr "Data de Faturamento"
 #. Label of the bill_no (Data) field in DocType 'Journal Entry'
 #. Label of the bill_no (Data) field in DocType 'Subcontracting Receipt'
 #: erpnext/accounts/doctype/journal_entry/journal_entry.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1109
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1111
 #: erpnext/accounts/report/purchase_register/purchase_register.py:213
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.json
 msgid "Bill No"
@@ -8220,7 +8206,7 @@ msgstr ""
 msgid "Billing Zipcode"
 msgstr ""
 
-#: erpnext/accounts/party.py:602
+#: erpnext/accounts/party.py:608
 msgid "Billing currency must be equal to either default company's currency or party account currency"
 msgstr ""
 
@@ -9217,7 +9203,7 @@ msgid "Can only make payment against unbilled {0}"
 msgstr "Só pode fazer o pagamento contra a faturar {0}"
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1458
-#: erpnext/controllers/accounts_controller.py:2946
+#: erpnext/controllers/accounts_controller.py:2949
 #: erpnext/public/js/controllers/accounts.js:90
 msgid "Can refer row only if the charge type is 'On Previous Row Amount' or 'Previous Row Total'"
 msgstr ""
@@ -9379,9 +9365,9 @@ msgstr ""
 msgid "Cannot Create Return"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:625
-#: erpnext/stock/doctype/item/item.py:638
-#: erpnext/stock/doctype/item/item.py:652
+#: erpnext/stock/doctype/item/item.py:631
+#: erpnext/stock/doctype/item/item.py:644
+#: erpnext/stock/doctype/item/item.py:658
 msgid "Cannot Merge"
 msgstr ""
 
@@ -9405,7 +9391,7 @@ msgstr ""
 msgid "Cannot apply TDS against multiple parties in one entry"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:307
+#: erpnext/stock/doctype/item/item.py:310
 msgid "Cannot be a fixed asset item as Stock Ledger is created."
 msgstr ""
 
@@ -9421,7 +9407,7 @@ msgstr ""
 msgid "Cannot cancel the transaction. Reposting of item valuation on submission is not completed yet."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:959
+#: erpnext/controllers/buying_controller.py:967
 msgid "Cannot cancel this document as it is linked with the submitted asset {asset_link}. Please cancel the asset to continue."
 msgstr ""
 
@@ -9429,7 +9415,7 @@ msgstr ""
 msgid "Cannot cancel transaction for Completed Work Order."
 msgstr "Não é possível cancelar a transação para a ordem de serviço concluída."
 
-#: erpnext/stock/doctype/item/item.py:882
+#: erpnext/stock/doctype/item/item.py:876
 msgid "Cannot change Attributes after stock transaction. Make a new Item and transfer stock to the new Item"
 msgstr "Não é possível alterar os Atributos após a transação do estoque. Faça um novo Item e transfira estoque para o novo Item"
 
@@ -9445,7 +9431,7 @@ msgstr ""
 msgid "Cannot change Service Stop Date for item in row {0}"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:873
+#: erpnext/stock/doctype/item/item.py:867
 msgid "Cannot change Variant properties after stock transaction. You will have to make a new Item to do this."
 msgstr ""
 
@@ -9473,7 +9459,7 @@ msgstr ""
 msgid "Cannot covert to Group because Account Type is selected."
 msgstr ""
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:972
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:981
 msgid "Cannot create Stock Reservation Entries for future dated Purchase Receipts."
 msgstr ""
 
@@ -9524,7 +9510,7 @@ msgstr ""
 msgid "Cannot find Item with this Barcode"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3483
+#: erpnext/controllers/accounts_controller.py:3486
 msgid "Cannot find a default warehouse for item {0}. Please set one in the Item Master or in Stock Settings."
 msgstr ""
 
@@ -9532,7 +9518,7 @@ msgstr ""
 msgid "Cannot make any transactions until the deletion job is completed"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2074
+#: erpnext/controllers/accounts_controller.py:2077
 msgid "Cannot overbill for Item {0} in row {1} more than {2}. To allow over-billing, please set allowance in Accounts Settings"
 msgstr ""
 
@@ -9553,7 +9539,7 @@ msgid "Cannot receive from customer against negative outstanding"
 msgstr ""
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1475
-#: erpnext/controllers/accounts_controller.py:2961
+#: erpnext/controllers/accounts_controller.py:2964
 #: erpnext/public/js/controllers/accounts.js:100
 msgid "Cannot refer row number greater than or equal to current row number for this Charge type"
 msgstr ""
@@ -9569,7 +9555,7 @@ msgstr ""
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1467
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1646
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:1917
-#: erpnext/controllers/accounts_controller.py:2951
+#: erpnext/controllers/accounts_controller.py:2954
 #: erpnext/public/js/controllers/accounts.js:94
 #: erpnext/public/js/controllers/taxes_and_totals.js:470
 msgid "Cannot select charge type as 'On Previous Row Amount' or 'On Previous Row Total' for first row"
@@ -9583,15 +9569,15 @@ msgstr ""
 msgid "Cannot set authorization on basis of Discount for {0}"
 msgstr "Não é possível definir a autorização com base em desconto para {0}"
 
-#: erpnext/stock/doctype/item/item.py:716
+#: erpnext/stock/doctype/item/item.py:722
 msgid "Cannot set multiple Item Defaults for a company."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3631
+#: erpnext/controllers/accounts_controller.py:3634
 msgid "Cannot set quantity less than delivered quantity"
 msgstr "Não é possível definir quantidade menor que a quantidade fornecida"
 
-#: erpnext/controllers/accounts_controller.py:3634
+#: erpnext/controllers/accounts_controller.py:3637
 msgid "Cannot set quantity less than received quantity"
 msgstr "Não é possível definir quantidade menor que a quantidade recebida"
 
@@ -10014,7 +10000,7 @@ msgid "Channel Partner"
 msgstr ""
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:2346
-#: erpnext/controllers/accounts_controller.py:3014
+#: erpnext/controllers/accounts_controller.py:3017
 msgid "Charge of type 'Actual' in row {0} cannot be included in Item Rate or Paid Amount"
 msgstr ""
 
@@ -10197,7 +10183,7 @@ msgstr ""
 
 #. Label of the reference_date (Date) field in DocType 'Payment Entry'
 #: erpnext/accounts/doctype/payment_entry/payment_entry.json
-#: erpnext/public/js/controllers/transaction.js:2299
+#: erpnext/public/js/controllers/transaction.js:2325
 msgid "Cheque/Reference Date"
 msgstr "Data do Cheque/referência"
 
@@ -10245,7 +10231,7 @@ msgstr ""
 
 #. Label of the child_row_reference (Data) field in DocType 'Quality
 #. Inspection'
-#: erpnext/public/js/controllers/transaction.js:2394
+#: erpnext/public/js/controllers/transaction.js:2420
 #: erpnext/stock/doctype/quality_inspection/quality_inspection.json
 msgid "Child Row Reference"
 msgstr ""
@@ -10957,7 +10943,7 @@ msgstr ""
 #: erpnext/accounts/report/cheques_and_deposits_incorrectly_cleared/cheques_and_deposits_incorrectly_cleared.js:8
 #: erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.js:8
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:8
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:49
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:50
 #: erpnext/accounts/report/deferred_revenue_and_expense/deferred_revenue_and_expense.js:8
 #: erpnext/accounts/report/delivered_items_to_be_billed/delivered_items_to_be_billed.js:7
 #: erpnext/accounts/report/dimension_wise_accounts_balance_report/dimension_wise_accounts_balance_report.js:8
@@ -12190,7 +12176,7 @@ msgid "Content Type"
 msgstr ""
 
 #: erpnext/erpnext_integrations/doctype/plaid_settings/plaid_settings.js:162
-#: erpnext/public/js/controllers/transaction.js:2312
+#: erpnext/public/js/controllers/transaction.js:2338
 #: erpnext/selling/doctype/quotation/quotation.js:356
 msgid "Continue"
 msgstr "Continuar"
@@ -12355,7 +12341,7 @@ msgstr "Fator de Conversão"
 msgid "Conversion Rate"
 msgstr "Taxa de Conversão"
 
-#: erpnext/stock/doctype/item/item.py:393
+#: erpnext/stock/doctype/item/item.py:396
 msgid "Conversion factor for default Unit of Measure must be 1 in row {0}"
 msgstr "Fator de conversão de unidade de medida padrão deve ser 1 na linha {0}"
 
@@ -12363,15 +12349,15 @@ msgstr "Fator de conversão de unidade de medida padrão deve ser 1 na linha {0}
 msgid "Conversion factor for item {0} has been reset to 1.0 as the uom {1} is same as stock uom {2}."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2767
+#: erpnext/controllers/accounts_controller.py:2770
 msgid "Conversion rate cannot be 0"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2774
+#: erpnext/controllers/accounts_controller.py:2777
 msgid "Conversion rate is 1.00, but document currency is different from company currency"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2770
+#: erpnext/controllers/accounts_controller.py:2773
 msgid "Conversion rate must be 1.00 if document currency is same as company currency"
 msgstr ""
 
@@ -12584,7 +12570,7 @@ msgstr ""
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:28
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:40
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:30
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1096
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1098
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:40
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.js:42
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.py:197
@@ -12677,7 +12663,7 @@ msgid "Cost Center is a part of Cost Center Allocation, hence cannot be converte
 msgstr ""
 
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py:1411
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:855
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:864
 msgid "Cost Center is required in row {0} in Taxes table for type {1}"
 msgstr "Centro de Custo é necessária na linha {0} no Imposto de mesa para o tipo {1}"
 
@@ -12946,8 +12932,8 @@ msgstr ""
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:132
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:143
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:219
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:654
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:678
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:656
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:680
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.js:88
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.js:89
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.js:103
@@ -13004,8 +12990,8 @@ msgstr ""
 #: erpnext/projects/doctype/task/task_tree.js:81
 #: erpnext/public/js/communication.js:19 erpnext/public/js/communication.js:31
 #: erpnext/public/js/communication.js:41
-#: erpnext/public/js/controllers/transaction.js:336
-#: erpnext/public/js/controllers/transaction.js:2435
+#: erpnext/public/js/controllers/transaction.js:362
+#: erpnext/public/js/controllers/transaction.js:2461
 #: erpnext/selling/doctype/customer/customer.js:181
 #: erpnext/selling/doctype/quotation/quotation.js:124
 #: erpnext/selling/doctype/quotation/quotation.js:133
@@ -13300,7 +13286,7 @@ msgstr ""
 msgid "Create a variant with the template image."
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1877
+#: erpnext/stock/stock_ledger.py:1886
 msgid "Create an incoming stock transaction for the Item."
 msgstr ""
 
@@ -13360,7 +13346,7 @@ msgstr ""
 msgid "Creating Purchase Order ..."
 msgstr "Criando Pedido de Compra..."
 
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:735
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:737
 #: erpnext/buying/doctype/purchase_order/purchase_order.js:552
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.js:73
 msgid "Creating Purchase Receipt ..."
@@ -13554,7 +13540,7 @@ msgstr ""
 #: erpnext/accounts/doctype/journal_entry_template/journal_entry_template.json
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:174
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:147
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1119
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1121
 #: erpnext/controllers/sales_and_purchase_return.py:373
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:286
 #: erpnext/stock/doctype/delivery_note/delivery_note.js:89
@@ -13589,7 +13575,7 @@ msgstr "A nota de crédito {0} foi criada automaticamente"
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py:368
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py:376
-#: erpnext/controllers/accounts_controller.py:2186
+#: erpnext/controllers/accounts_controller.py:2189
 msgid "Credit To"
 msgstr ""
 
@@ -13774,7 +13760,7 @@ msgstr ""
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/subscription_plan/subscription_plan.json
 #: erpnext/accounts/report/account_balance/account_balance.py:28
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1129
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1131
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:205
 #: erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.py:101
 #: erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.js:118
@@ -14303,7 +14289,7 @@ msgstr ""
 #. Label of the customer_contact_display (Small Text) field in DocType
 #. 'Purchase Order'
 #. Label of the customer_contact (Small Text) field in DocType 'Delivery Stop'
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1090
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1092
 #: erpnext/buying/doctype/purchase_order/purchase_order.json
 #: erpnext/stock/doctype/delivery_stop/delivery_stop.json
 msgid "Customer Contact"
@@ -14399,7 +14385,7 @@ msgstr ""
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/tax_rule/tax_rule.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:107
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1147
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1149
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:81
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:185
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:56
@@ -14443,7 +14429,7 @@ msgstr ""
 msgid "Customer Group Name"
 msgstr ""
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1239
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1241
 msgid "Customer Group: {0} does not exist"
 msgstr ""
 
@@ -14462,7 +14448,7 @@ msgstr ""
 msgid "Customer Items"
 msgstr ""
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1138
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1140
 msgid "Customer LPO"
 msgstr "LPO do Cliente"
 
@@ -14508,7 +14494,7 @@ msgstr ""
 #: erpnext/accounts/doctype/pos_invoice/pos_invoice.json
 #: erpnext/accounts/doctype/process_statement_of_accounts_customer/process_statement_of_accounts_customer.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1080
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1082
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:156
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:92
 #: erpnext/accounts/report/delivered_items_to_be_billed/delivered_items_to_be_billed.py:35
@@ -15186,7 +15172,7 @@ msgstr ""
 #: erpnext/accounts/doctype/journal_entry_template/journal_entry_template.json
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:176
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:147
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1122
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1124
 #: erpnext/controllers/sales_and_purchase_return.py:377
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:287
 #: erpnext/stock/doctype/purchase_receipt/purchase_receipt.js:61
@@ -15215,7 +15201,7 @@ msgstr ""
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:953
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:964
-#: erpnext/controllers/accounts_controller.py:2186
+#: erpnext/controllers/accounts_controller.py:2189
 msgid "Debit To"
 msgstr ""
 
@@ -15248,11 +15234,11 @@ msgstr ""
 msgid "Debit-Credit mismatch"
 msgstr ""
 
-#: erpnext/accounts/party.py:609
+#: erpnext/accounts/party.py:615
 msgid "Debtor/Creditor"
 msgstr ""
 
-#: erpnext/accounts/party.py:612
+#: erpnext/accounts/party.py:618
 msgid "Debtor/Creditor Advance"
 msgstr ""
 
@@ -15372,7 +15358,7 @@ msgstr ""
 msgid "Default BOM"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:418
+#: erpnext/stock/doctype/item/item.py:421
 msgid "Default BOM ({0}) must be active for this item or its template"
 msgstr ""
 
@@ -15380,7 +15366,7 @@ msgstr ""
 msgid "Default BOM for {0} not found"
 msgstr "Não foi encontrado a LDM Padrão para {0}"
 
-#: erpnext/controllers/accounts_controller.py:3672
+#: erpnext/controllers/accounts_controller.py:3675
 msgid "Default BOM not found for FG Item {0}"
 msgstr ""
 
@@ -15715,15 +15701,15 @@ msgstr ""
 msgid "Default Unit of Measure"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1272
+#: erpnext/stock/doctype/item/item.py:1266
 msgid "Default Unit of Measure for Item {0} cannot be changed directly because you have already made some transaction(s) with another UOM. You need to either cancel the linked documents or create a new Item."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1255
+#: erpnext/stock/doctype/item/item.py:1249
 msgid "Default Unit of Measure for Item {0} cannot be changed directly because you have already made some transaction(s) with another UOM. You will need to create a new Item to use a different Default UOM."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:908
+#: erpnext/stock/doctype/item/item.py:902
 msgid "Default Unit of Measure for Variant '{0}' must be same as in Template '{1}'"
 msgstr "A unidade de medida padrão para a variante '{0}' deve ser o mesmo que no modelo '{1}'"
 
@@ -16182,7 +16168,7 @@ msgstr "Tendência de Remessas"
 msgid "Delivery Note {0} is not submitted"
 msgstr "A Guia de Remessa {0} não foi enviada"
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1142
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1144
 #: erpnext/stock/doctype/delivery_trip/delivery_trip.js:73
 msgid "Delivery Notes"
 msgstr "Notas de Entrega"
@@ -16713,7 +16699,7 @@ msgstr ""
 #: erpnext/projects/doctype/task_type/task_type.json
 #: erpnext/projects/doctype/timesheet_detail/timesheet_detail.json
 #: erpnext/public/js/bank_reconciliation_tool/data_table_manager.js:55
-#: erpnext/public/js/controllers/transaction.js:2376
+#: erpnext/public/js/controllers/transaction.js:2402
 #: erpnext/selling/doctype/installation_note_item/installation_note_item.json
 #: erpnext/selling/doctype/product_bundle/product_bundle.json
 #: erpnext/selling/doctype/product_bundle_item/product_bundle_item.json
@@ -16901,7 +16887,7 @@ msgstr ""
 msgid "Difference Account must be a Asset/Liability type account (Temporary Opening), since this Stock Entry is an Opening Entry"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:954
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:950
 msgid "Difference Account must be a Asset/Liability type account, since this Stock Reconciliation is an Opening Entry"
 msgstr ""
 
@@ -17167,11 +17153,11 @@ msgstr ""
 msgid "Disabled Warehouse {0} cannot be used for this transaction."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:745
+#: erpnext/controllers/accounts_controller.py:748
 msgid "Disabled pricing rules since this {} is an internal transfer"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:759
+#: erpnext/controllers/accounts_controller.py:762
 msgid "Disabled tax included prices since this {} is an internal transfer"
 msgstr ""
 
@@ -18113,7 +18099,7 @@ msgstr ""
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.json
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/print_format/sales_invoice_print/sales_invoice_print.html:72
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1106
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1108
 #: erpnext/assets/doctype/asset_maintenance_log/asset_maintenance_log.json
 #: erpnext/selling/report/payment_terms_status_for_sales_order/payment_terms_status_for_sales_order.py:40
 msgid "Due Date"
@@ -18127,11 +18113,11 @@ msgstr "Data de Vencimento"
 msgid "Due Date Based On"
 msgstr "Data de vencimento baseada em"
 
-#: erpnext/accounts/party.py:695
+#: erpnext/accounts/party.py:701
 msgid "Due Date cannot be after {0}"
 msgstr ""
 
-#: erpnext/accounts/party.py:671
+#: erpnext/accounts/party.py:677
 msgid "Due Date cannot be before {0}"
 msgstr ""
 
@@ -18849,7 +18835,7 @@ msgstr ""
 msgid "Enable Auto Email"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1064
+#: erpnext/stock/doctype/item/item.py:1058
 msgid "Enable Auto Re-Order"
 msgstr "Ativar Reordenação Automática"
 
@@ -19062,7 +19048,7 @@ msgstr ""
 msgid "End Date"
 msgstr "Data Final"
 
-#: erpnext/crm/doctype/contract/contract.py:75
+#: erpnext/crm/doctype/contract/contract.py:83
 msgid "End Date cannot be before Start Date."
 msgstr "A data de término não pode ser anterior à data de início."
 
@@ -19312,7 +19298,7 @@ msgstr ""
 #: erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.json
 #: erpnext/manufacturing/doctype/job_card/job_card.py:875
 #: erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.json
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:297
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:298
 msgid "Error"
 msgstr "Erro"
 
@@ -19435,7 +19421,7 @@ msgstr ""
 msgid "Example URL"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:995
+#: erpnext/stock/doctype/item/item.py:989
 msgid "Example of a linked document: {0}"
 msgstr ""
 
@@ -19450,7 +19436,7 @@ msgstr ""
 msgid "Example: ABCD.#####. If series is set and Batch No is not mentioned in transactions, then automatic batch number will be created based on this series. If you always want to explicitly mention Batch No for this item, leave this blank. Note: this setting will take priority over the Naming Series Prefix in Stock Settings."
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:2141
+#: erpnext/stock/stock_ledger.py:2149
 msgid "Example: Serial No {0} reserved in {1}."
 msgstr ""
 
@@ -19504,8 +19490,8 @@ msgstr ""
 msgid "Exchange Gain/Loss"
 msgstr "Ganho/perda Com Câmbio"
 
-#: erpnext/controllers/accounts_controller.py:1593
-#: erpnext/controllers/accounts_controller.py:1677
+#: erpnext/controllers/accounts_controller.py:1596
+#: erpnext/controllers/accounts_controller.py:1680
 msgid "Exchange Gain/Loss amount has been booked through {0}"
 msgstr ""
 
@@ -20241,7 +20227,7 @@ msgid "Fetching Error"
 msgstr ""
 
 #: erpnext/accounts/doctype/dunning/dunning.js:135
-#: erpnext/public/js/controllers/transaction.js:1251
+#: erpnext/public/js/controllers/transaction.js:1277
 msgid "Fetching exchange rates ..."
 msgstr ""
 
@@ -20536,15 +20522,15 @@ msgstr ""
 msgid "Finished Good Item Quantity"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3658
+#: erpnext/controllers/accounts_controller.py:3661
 msgid "Finished Good Item is not specified for service item {0}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3675
+#: erpnext/controllers/accounts_controller.py:3678
 msgid "Finished Good Item {0} Qty can not be zero"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3669
+#: erpnext/controllers/accounts_controller.py:3672
 msgid "Finished Good Item {0} must be a sub-contracted item"
 msgstr ""
 
@@ -20785,7 +20771,7 @@ msgstr ""
 msgid "Fixed Asset Defaults"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:301
+#: erpnext/stock/doctype/item/item.py:304
 msgid "Fixed Asset Item must be a non-stock item."
 msgstr ""
 
@@ -20961,7 +20947,7 @@ msgstr ""
 msgid "For Raw Materials"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1259
+#: erpnext/controllers/accounts_controller.py:1262
 msgid "For Return Invoices with Stock effect, '0' qty Items are not allowed. Following rows are affected: {0}"
 msgstr ""
 
@@ -21062,7 +21048,7 @@ msgstr ""
 msgid "For the item {0}, the quantity should be {1} according to the BOM {2}."
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:1088
+#: erpnext/public/js/controllers/transaction.js:1114
 msgctxt "Clear payment terms template and/or payment schedule when due date is changed"
 msgid "For the new {0} to take effect, would you like to clear the current {1}?"
 msgstr ""
@@ -21071,7 +21057,7 @@ msgstr ""
 msgid "For the {0}, no stock is available for the return in the warehouse {1}."
 msgstr ""
 
-#: erpnext/controllers/sales_and_purchase_return.py:1144
+#: erpnext/controllers/sales_and_purchase_return.py:1049
 msgid "For the {0}, the quantity is required to make the return entry"
 msgstr ""
 
@@ -21408,7 +21394,7 @@ msgstr "A partir de data não pode ser maior que a Data"
 msgid "From Date is mandatory"
 msgstr ""
 
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:52
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:53
 #: erpnext/accounts/report/general_ledger/general_ledger.py:86
 #: erpnext/accounts/report/pos_register/pos_register.py:115
 #: erpnext/accounts/report/tax_withholding_details/tax_withholding_details.py:39
@@ -21785,14 +21771,14 @@ msgstr ""
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:186
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:155
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1134
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1136
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:177
 msgid "Future Payment Amount"
 msgstr "Valor do Pagamento Futuro"
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:185
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:154
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1133
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1135
 msgid "Future Payment Ref"
 msgstr "Referência de Pagamento Futuro"
 
@@ -22966,7 +22952,7 @@ msgstr ""
 msgid "Here are the error logs for the aforementioned failed depreciation entries: {0}"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1862
+#: erpnext/stock/stock_ledger.py:1871
 msgid "Here are the options to proceed:"
 msgstr ""
 
@@ -23488,7 +23474,7 @@ msgstr ""
 msgid "If more than one package of the same type (for print)"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1872
+#: erpnext/stock/stock_ledger.py:1881
 msgid "If not, you can Cancel / Submit this entry"
 msgstr ""
 
@@ -23513,7 +23499,7 @@ msgstr ""
 msgid "If the account is frozen, entries are allowed to restricted users."
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1865
+#: erpnext/stock/stock_ledger.py:1874
 msgid "If the item is transacting as a Zero Valuation Rate item in this entry, please enable 'Allow Zero Valuation Rate' in the {0} Item table."
 msgstr ""
 
@@ -24511,7 +24497,7 @@ msgstr ""
 msgid "Incorrect Batch Consumed"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:514
+#: erpnext/stock/doctype/item/item.py:517
 msgid "Incorrect Check in (group) Warehouse for Reorder"
 msgstr ""
 
@@ -24560,7 +24546,7 @@ msgstr ""
 msgid "Incorrect Stock Value Report"
 msgstr ""
 
-#: erpnext/stock/serial_batch_bundle.py:134
+#: erpnext/stock/serial_batch_bundle.py:135
 msgid "Incorrect Type of Transaction"
 msgstr ""
 
@@ -24829,8 +24815,8 @@ msgstr ""
 msgid "Insufficient Capacity"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3590
-#: erpnext/controllers/accounts_controller.py:3614
+#: erpnext/controllers/accounts_controller.py:3593
+#: erpnext/controllers/accounts_controller.py:3617
 msgid "Insufficient Permissions"
 msgstr "Permissões Insuficientes"
 
@@ -24838,12 +24824,12 @@ msgstr "Permissões Insuficientes"
 #: erpnext/stock/doctype/pick_list/pick_list.py:127
 #: erpnext/stock/doctype/pick_list/pick_list.py:975
 #: erpnext/stock/doctype/stock_entry/stock_entry.py:759
-#: erpnext/stock/serial_batch_bundle.py:989 erpnext/stock/stock_ledger.py:1559
-#: erpnext/stock/stock_ledger.py:2032
+#: erpnext/stock/serial_batch_bundle.py:1021 erpnext/stock/stock_ledger.py:1568
+#: erpnext/stock/stock_ledger.py:2040
 msgid "Insufficient Stock"
 msgstr "Estoque Insuficiente"
 
-#: erpnext/stock/stock_ledger.py:2047
+#: erpnext/stock/stock_ledger.py:2055
 msgid "Insufficient Stock for Batch"
 msgstr ""
 
@@ -24981,11 +24967,11 @@ msgstr ""
 msgid "Internal Customer for company {0} already exists"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:728
+#: erpnext/controllers/accounts_controller.py:731
 msgid "Internal Sale or Delivery Reference missing."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:730
+#: erpnext/controllers/accounts_controller.py:733
 msgid "Internal Sales Reference Missing"
 msgstr ""
 
@@ -25016,7 +25002,7 @@ msgstr ""
 msgid "Internal Transfer"
 msgstr "Transferência Interna"
 
-#: erpnext/controllers/accounts_controller.py:739
+#: erpnext/controllers/accounts_controller.py:742
 msgid "Internal Transfer Reference Missing"
 msgstr ""
 
@@ -25059,8 +25045,8 @@ msgstr ""
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:969
 #: erpnext/assets/doctype/asset_category/asset_category.py:69
 #: erpnext/assets/doctype/asset_category/asset_category.py:97
-#: erpnext/controllers/accounts_controller.py:2975
-#: erpnext/controllers/accounts_controller.py:2983
+#: erpnext/controllers/accounts_controller.py:2978
+#: erpnext/controllers/accounts_controller.py:2986
 msgid "Invalid Account"
 msgstr "Conta Inválida"
 
@@ -25085,7 +25071,7 @@ msgstr ""
 msgid "Invalid Barcode. There is no Item attached to this barcode."
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2631
+#: erpnext/public/js/controllers/transaction.js:2657
 msgid "Invalid Blanket Order for the selected Customer and Item"
 msgstr ""
 
@@ -25099,7 +25085,7 @@ msgstr "Empresa Inválida Para Transação Entre Empresas."
 
 #: erpnext/assets/doctype/asset/asset.py:295
 #: erpnext/assets/doctype/asset/asset.py:302
-#: erpnext/controllers/accounts_controller.py:2998
+#: erpnext/controllers/accounts_controller.py:3001
 msgid "Invalid Cost Center"
 msgstr ""
 
@@ -25141,7 +25127,7 @@ msgstr ""
 msgid "Invalid Item"
 msgstr "Artigo Inválido"
 
-#: erpnext/stock/doctype/item/item.py:1410
+#: erpnext/stock/doctype/item/item.py:1404
 msgid "Invalid Item Defaults"
 msgstr ""
 
@@ -25187,11 +25173,11 @@ msgstr ""
 msgid "Invalid Purchase Invoice"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3627
+#: erpnext/controllers/accounts_controller.py:3630
 msgid "Invalid Qty"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1277
+#: erpnext/controllers/accounts_controller.py:1280
 msgid "Invalid Quantity"
 msgstr "Quantidade Inválida"
 
@@ -25208,7 +25194,7 @@ msgstr ""
 msgid "Invalid Schedule"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:243
+#: erpnext/controllers/selling_controller.py:251
 msgid "Invalid Selling Price"
 msgstr "Preço de Venda Inválido"
 
@@ -25241,7 +25227,7 @@ msgstr "Expressão de condição inválida"
 msgid "Invalid lost reason {0}, please create a new lost reason"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:408
+#: erpnext/stock/doctype/item/item.py:411
 msgid "Invalid naming series (. missing) for {0}"
 msgstr "Série de nomenclatura inválida (. Ausente) para {0}"
 
@@ -25281,7 +25267,7 @@ msgstr ""
 #. Name of a DocType
 #: erpnext/patches/v15_0/refactor_closing_stock_balance.py:43
 #: erpnext/stock/doctype/inventory_dimension/inventory_dimension.json
-#: erpnext/stock/doctype/inventory_dimension/inventory_dimension.py:180
+#: erpnext/stock/doctype/inventory_dimension/inventory_dimension.py:181
 msgid "Inventory Dimension"
 msgstr ""
 
@@ -25347,7 +25333,7 @@ msgstr ""
 msgid "Invoice Discounting"
 msgstr "Desconto de Fatura"
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1114
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1116
 msgid "Invoice Grand Total"
 msgstr "Total Geral da Fatura"
 
@@ -25440,7 +25426,7 @@ msgstr "A fatura não pode ser feita para zero hora de cobrança"
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:169
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:144
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1116
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1118
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:164
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:165
 msgid "Invoiced Amount"
@@ -25846,6 +25832,11 @@ msgstr ""
 msgid "Is Outward"
 msgstr ""
 
+#. Label of the is_packed (Check) field in DocType 'Serial and Batch Bundle'
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.json
+msgid "Is Packed"
+msgstr ""
+
 #. Label of the is_paid (Check) field in DocType 'Purchase Invoice'
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 msgid "Is Paid"
@@ -26128,11 +26119,11 @@ msgstr ""
 msgid "Issuing cannot be done to a location. Please enter employee to issue the Asset {0} to"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:565
+#: erpnext/stock/doctype/item/item.py:571
 msgid "It can take upto few hours for accurate stock values to be visible after merging items."
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2075
+#: erpnext/public/js/controllers/transaction.js:2101
 msgid "It is needed to fetch Item Details."
 msgstr ""
 
@@ -26182,7 +26173,7 @@ msgstr ""
 #: erpnext/buying/report/supplier_quotation_comparison/supplier_quotation_comparison.js:33
 #: erpnext/buying/report/supplier_quotation_comparison/supplier_quotation_comparison.py:204
 #: erpnext/buying/workspace/buying/buying.json
-#: erpnext/controllers/taxes_and_totals.py:1125
+#: erpnext/controllers/taxes_and_totals.py:1135
 #: erpnext/manufacturing/doctype/blanket_order/blanket_order.json
 #: erpnext/manufacturing/doctype/bom/bom.js:944
 #: erpnext/manufacturing/doctype/bom/bom.json
@@ -26460,7 +26451,7 @@ msgstr ""
 #: erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py:86
 #: erpnext/manufacturing/report/work_order_stock_report/work_order_stock_report.py:119
 #: erpnext/projects/doctype/timesheet/timesheet.js:213
-#: erpnext/public/js/controllers/transaction.js:2350
+#: erpnext/public/js/controllers/transaction.js:2376
 #: erpnext/public/js/stock_reservation.js:112
 #: erpnext/public/js/stock_reservation.js:317 erpnext/public/js/utils.js:500
 #: erpnext/public/js/utils.js:656
@@ -26898,7 +26889,7 @@ msgstr ""
 #: erpnext/manufacturing/report/production_planning_report/production_planning_report.py:359
 #: erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py:92
 #: erpnext/manufacturing/report/work_order_consumed_materials/work_order_consumed_materials.py:138
-#: erpnext/public/js/controllers/transaction.js:2356
+#: erpnext/public/js/controllers/transaction.js:2382
 #: erpnext/public/js/utils.js:746
 #: erpnext/selling/doctype/quotation_item/quotation_item.json
 #: erpnext/selling/doctype/sales_order_item/sales_order_item.json
@@ -27165,7 +27156,7 @@ msgstr "Configurações da Variante de Item"
 msgid "Item Variant {0} already exists with same attributes"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:781
+#: erpnext/stock/doctype/item/item.py:772
 msgid "Item Variants updated"
 msgstr ""
 
@@ -27231,7 +27222,7 @@ msgstr ""
 msgid "Item for row {0} does not match Material Request"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:795
+#: erpnext/stock/doctype/item/item.py:789
 msgid "Item has variants."
 msgstr ""
 
@@ -27257,7 +27248,7 @@ msgstr ""
 msgid "Item operation"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3650
+#: erpnext/controllers/accounts_controller.py:3653
 msgid "Item qty can not be updated as raw materials are already processed."
 msgstr ""
 
@@ -27283,7 +27274,7 @@ msgstr ""
 msgid "Item valuation reposting in progress. Report might show incorrect item valuation."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:952
+#: erpnext/stock/doctype/item/item.py:946
 msgid "Item variant {0} exists with same attributes"
 msgstr ""
 
@@ -27296,8 +27287,7 @@ msgid "Item {0} cannot be ordered more than {1} against Blanket Order {2}."
 msgstr ""
 
 #: erpnext/assets/doctype/asset/asset.py:277
-#: erpnext/stock/doctype/item/item.py:630
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:167
+#: erpnext/stock/doctype/item/item.py:636
 msgid "Item {0} does not exist"
 msgstr ""
 
@@ -27309,7 +27299,7 @@ msgstr ""
 msgid "Item {0} does not exist."
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:752
+#: erpnext/controllers/selling_controller.py:760
 msgid "Item {0} entered multiple times."
 msgstr ""
 
@@ -27325,7 +27315,7 @@ msgstr ""
 msgid "Item {0} has no Serial No. Only serialized items can have delivery based on Serial No"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1126
+#: erpnext/stock/doctype/item/item.py:1120
 msgid "Item {0} has reached its end of life on {1}"
 msgstr ""
 
@@ -27337,11 +27327,11 @@ msgstr ""
 msgid "Item {0} is already reserved/delivered against Sales Order {1}."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1146
+#: erpnext/stock/doctype/item/item.py:1140
 msgid "Item {0} is cancelled"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1130
+#: erpnext/stock/doctype/item/item.py:1124
 msgid "Item {0} is disabled"
 msgstr ""
 
@@ -27349,7 +27339,7 @@ msgstr ""
 msgid "Item {0} is not a serialized Item"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1138
+#: erpnext/stock/doctype/item/item.py:1132
 msgid "Item {0} is not a stock Item"
 msgstr ""
 
@@ -27393,7 +27383,7 @@ msgstr ""
 msgid "Item {0}: {1} qty produced. "
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1429
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1423
 msgid "Item {} does not exist."
 msgstr ""
 
@@ -27533,7 +27523,7 @@ msgstr "Itens Para Requisitar"
 msgid "Items and Pricing"
 msgstr "Itens e Preços"
 
-#: erpnext/controllers/accounts_controller.py:3872
+#: erpnext/controllers/accounts_controller.py:3875
 msgid "Items cannot be updated as Subcontracting Order is created against the Purchase Order {0}."
 msgstr ""
 
@@ -28029,7 +28019,7 @@ msgstr "Impostos e Encargos Sobre Custos de Desembarque"
 
 #. Name of a DocType
 #. Label of a Link in the Stock Workspace
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:674
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:676
 #: erpnext/stock/doctype/landed_cost_voucher/landed_cost_voucher.json
 #: erpnext/stock/doctype/purchase_receipt/purchase_receipt.js:104
 #: erpnext/stock/workspace/stock/stock.json
@@ -28644,7 +28634,7 @@ msgstr ""
 msgid "Linked Location"
 msgstr "Local Vinculado"
 
-#: erpnext/stock/doctype/item/item.py:999
+#: erpnext/stock/doctype/item/item.py:993
 msgid "Linked with submitted documents"
 msgstr ""
 
@@ -29383,7 +29373,7 @@ msgstr ""
 #: erpnext/manufacturing/doctype/bom/bom.py:261
 #: erpnext/manufacturing/doctype/bom_update_log/bom_update_log.py:71
 #: erpnext/public/js/controllers/accounts.js:249
-#: erpnext/public/js/controllers/transaction.js:2753
+#: erpnext/public/js/controllers/transaction.js:2779
 #: erpnext/public/js/utils/party.js:321
 #: erpnext/stock/doctype/delivery_note/delivery_note.js:164
 #: erpnext/stock/doctype/inventory_dimension/inventory_dimension.json
@@ -30239,7 +30229,7 @@ msgstr ""
 msgid "Maximum Value"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:212
+#: erpnext/controllers/selling_controller.py:220
 msgid "Maximum discount for Item {0} is {1}%"
 msgstr ""
 
@@ -30309,7 +30299,7 @@ msgstr ""
 msgid "Megawatt"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1878
+#: erpnext/stock/stock_ledger.py:1887
 msgid "Mention Valuation Rate in the Item master."
 msgstr "Mencione a taxa de avaliação no cadastro de itens."
 
@@ -30704,11 +30694,11 @@ msgstr ""
 msgid "Miscellaneous Expenses"
 msgstr "Despesas Diversas"
 
-#: erpnext/controllers/buying_controller.py:540
+#: erpnext/controllers/buying_controller.py:548
 msgid "Mismatch"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1430
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1424
 msgid "Missing"
 msgstr ""
 
@@ -31235,7 +31225,7 @@ msgstr "Variantes Múltiplas"
 msgid "Multiple Warehouse Accounts"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1129
+#: erpnext/controllers/accounts_controller.py:1132
 msgid "Multiple fiscal years exist for the date {0}. Please set company in Fiscal Year"
 msgstr ""
 
@@ -31386,7 +31376,7 @@ msgstr ""
 msgid "Naming Series and Price Defaults"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:90
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:91
 msgid "Naming Series is mandatory"
 msgstr ""
 
@@ -31425,15 +31415,15 @@ msgstr ""
 msgid "Needs Analysis"
 msgstr "Precisa de Análise"
 
-#: erpnext/stock/serial_batch_bundle.py:1277
+#: erpnext/stock/serial_batch_bundle.py:1309
 msgid "Negative Batch Quantity"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:610
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:606
 msgid "Negative Quantity is not allowed"
 msgstr "Negativo Quantidade não é permitido"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:615
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:611
 msgid "Negative Valuation Rate is not allowed"
 msgstr "Taxa de Avaliação negativa não é permitida"
 
@@ -31715,7 +31705,7 @@ msgstr ""
 msgid "Net Weight UOM"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1483
+#: erpnext/controllers/accounts_controller.py:1486
 msgid "Net total calculation precision loss"
 msgstr ""
 
@@ -32058,7 +32048,7 @@ msgstr ""
 #: erpnext/accounts/doctype/journal_entry/journal_entry.py:1539
 #: erpnext/accounts/doctype/journal_entry/journal_entry.py:1599
 #: erpnext/accounts/doctype/journal_entry/journal_entry.py:1613
-#: erpnext/stock/doctype/item/item.py:1371
+#: erpnext/stock/doctype/item/item.py:1365
 msgid "No Permission"
 msgstr "Nenhuma Permissão"
 
@@ -32080,7 +32070,7 @@ msgstr "Sem Observações"
 msgid "No Selection"
 msgstr ""
 
-#: erpnext/controllers/sales_and_purchase_return.py:919
+#: erpnext/controllers/sales_and_purchase_return.py:824
 msgid "No Serial / Batches are available for return"
 msgstr ""
 
@@ -32116,7 +32106,7 @@ msgstr ""
 msgid "No Work Orders were created"
 msgstr ""
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:785
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:794
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py:689
 msgid "No accounting entries for the following warehouses"
 msgstr "Nenhuma entrada de contabilidade para os seguintes armazéns"
@@ -32305,7 +32295,7 @@ msgstr ""
 msgid "No reserved stock to unreserve."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:773
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:769
 msgid "No stock ledger entries were created. Please set the quantity or valuation rate for the items properly and try again."
 msgstr ""
 
@@ -32389,7 +32379,7 @@ msgstr ""
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:566
 #: erpnext/assets/doctype/asset/asset.js:612
 #: erpnext/assets/doctype/asset/asset.js:627
-#: erpnext/controllers/buying_controller.py:225
+#: erpnext/controllers/buying_controller.py:233
 #: erpnext/selling/doctype/product_bundle/product_bundle.py:72
 #: erpnext/setup/doctype/transaction_deletion_record/transaction_deletion_record.py:80
 msgid "Not Allowed"
@@ -32510,10 +32500,10 @@ msgstr "Não Permitido"
 #: erpnext/selling/doctype/customer/customer.py:129
 #: erpnext/selling/doctype/sales_order/sales_order.js:1168
 #: erpnext/stock/doctype/item/item.js:526
-#: erpnext/stock/doctype/item/item.py:567
+#: erpnext/stock/doctype/item/item.py:573
 #: erpnext/stock/doctype/item_price/item_price.json
 #: erpnext/stock/doctype/stock_entry/stock_entry.py:1374
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:972
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:968
 #: erpnext/templates/pages/timelog_info.html:43
 msgid "Note"
 msgstr "Nota"
@@ -32522,7 +32512,7 @@ msgstr "Nota"
 msgid "Note: Automatic log deletion only applies to logs of type <i>Update Cost</i>"
 msgstr ""
 
-#: erpnext/accounts/party.py:690
+#: erpnext/accounts/party.py:696
 msgid "Note: Due Date exceeds allowed {0} credit days by {1} day(s)"
 msgstr ""
 
@@ -32548,7 +32538,7 @@ msgstr ""
 msgid "Note: This Cost Center is a Group. Cannot make accounting entries against groups."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:621
+#: erpnext/stock/doctype/item/item.py:627
 msgid "Note: To merge the items, create a separate Stock Reconciliation for the old item {0}"
 msgstr ""
 
@@ -33311,7 +33301,7 @@ msgstr ""
 
 #. Label of the opening_stock (Float) field in DocType 'Item'
 #. Option for the 'Purpose' (Select) field in DocType 'Stock Reconciliation'
-#: erpnext/stock/doctype/item/item.json erpnext/stock/doctype/item/item.py:296
+#: erpnext/stock/doctype/item/item.json erpnext/stock/doctype/item/item.py:299
 #: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.json
 msgid "Opening Stock"
 msgstr "Abertura de Estoque"
@@ -34031,7 +34021,7 @@ msgstr ""
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:149
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1123
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1125
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:167
 #: erpnext/accounts/report/purchase_register/purchase_register.py:289
 #: erpnext/accounts/report/sales_register/sales_register.py:319
@@ -34070,7 +34060,7 @@ msgstr ""
 msgid "Over Billing Allowance (%)"
 msgstr ""
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:1242
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:1251
 msgid "Over Billing Allowance exceeded for Purchase Receipt Item {0} ({1}) by {2}%"
 msgstr ""
 
@@ -34111,7 +34101,7 @@ msgstr ""
 msgid "Overbilling of {0} {1} ignored for item {2} because you have {3} role."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2013
+#: erpnext/controllers/accounts_controller.py:2016
 msgid "Overbilling of {} ignored because you have {} role."
 msgstr ""
 
@@ -34618,7 +34608,7 @@ msgstr "Pago"
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:146
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1117
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1119
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:165
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:172
 #: erpnext/accounts/report/pos_register/pos_register.py:209
@@ -34851,7 +34841,7 @@ msgstr ""
 msgid "Parent Row No"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom_creator/bom_creator.py:495
+#: erpnext/manufacturing/doctype/bom_creator/bom_creator.py:496
 msgid "Parent Row No not found for {0}"
 msgstr ""
 
@@ -35080,7 +35070,7 @@ msgstr ""
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:142
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:159
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:57
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1054
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1056
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:67
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:147
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:228
@@ -35106,7 +35096,7 @@ msgstr "Parceiro"
 
 #. Name of a DocType
 #: erpnext/accounts/doctype/party_account/party_account.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1065
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1067
 msgid "Party Account"
 msgstr "Conta do Parceiro"
 
@@ -35133,7 +35123,7 @@ msgstr ""
 msgid "Party Account No. (Bank Statement)"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2278
+#: erpnext/controllers/accounts_controller.py:2281
 msgid "Party Account {0} currency ({1}) and document currency ({2}) should be same"
 msgstr ""
 
@@ -35149,6 +35139,11 @@ msgstr ""
 #: erpnext/accounts/doctype/bank_account/bank_account.json
 #: erpnext/accounts/doctype/payment_request/payment_request.json
 msgid "Party Details"
+msgstr ""
+
+#. Label of the party_full_name (Data) field in DocType 'Contract'
+#: erpnext/crm/doctype/contract/contract.json
+msgid "Party Full Name"
 msgstr ""
 
 #. Label of the bank_party_iban (Data) field in DocType 'Bank Transaction'
@@ -35234,7 +35229,7 @@ msgstr ""
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:84
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:54
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:44
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1048
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1050
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:54
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:141
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:219
@@ -35256,7 +35251,7 @@ msgstr ""
 msgid "Party Type"
 msgstr ""
 
-#: erpnext/accounts/party.py:819
+#: erpnext/accounts/party.py:825
 msgid "Party Type and Party can only be set for Receivable / Payable account<br><br>{0}"
 msgstr ""
 
@@ -35378,7 +35373,7 @@ msgid "Payable"
 msgstr "A Pagar"
 
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:42
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1063
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1065
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:211
 #: erpnext/accounts/report/purchase_register/purchase_register.py:194
 #: erpnext/accounts/report/purchase_register/purchase_register.py:235
@@ -35544,7 +35539,7 @@ msgstr ""
 msgid "Payment Entry is already created"
 msgstr "Entrada de pagamento já foi criada"
 
-#: erpnext/controllers/accounts_controller.py:1434
+#: erpnext/controllers/accounts_controller.py:1437
 msgid "Payment Entry {0} is linked against Order {1}, check if it should be pulled as advance in this invoice."
 msgstr ""
 
@@ -35826,7 +35821,7 @@ msgstr ""
 #: erpnext/accounts/doctype/payment_schedule/payment_schedule.json
 #: erpnext/accounts/doctype/payment_term/payment_term.json
 #: erpnext/accounts/doctype/payment_terms_template_detail/payment_terms_template_detail.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1113
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1115
 #: erpnext/accounts/report/gross_profit/gross_profit.py:412
 #: erpnext/accounts/workspace/accounting/accounting.json
 #: erpnext/selling/report/payment_terms_status_for_sales_order/payment_terms_status_for_sales_order.py:30
@@ -36890,7 +36885,7 @@ msgstr ""
 msgid "Please create a new Accounting Dimension if required."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:729
+#: erpnext/controllers/accounts_controller.py:732
 msgid "Please create purchase from internal sale or delivery document itself"
 msgstr ""
 
@@ -36898,7 +36893,7 @@ msgstr ""
 msgid "Please create purchase receipt or purchase invoice for the item {0}"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:649
+#: erpnext/stock/doctype/item/item.py:655
 msgid "Please delete Product Bundle {0}, before merging {1} into {2}"
 msgstr ""
 
@@ -36940,7 +36935,7 @@ msgstr ""
 msgid "Please enable {0} in the {1}."
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:754
+#: erpnext/controllers/selling_controller.py:762
 msgid "Please enable {} in {} to allow same item in multiple rows"
 msgstr ""
 
@@ -36973,7 +36968,7 @@ msgstr ""
 msgid "Please enter Approving Role or Approving User"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:939
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:935
 msgid "Please enter Cost Center"
 msgstr ""
 
@@ -36985,7 +36980,7 @@ msgstr "Digite Data de Entrega"
 msgid "Please enter Employee Id of this sales person"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:948
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:944
 msgid "Please enter Expense Account"
 msgstr ""
 
@@ -36994,7 +36989,7 @@ msgstr ""
 msgid "Please enter Item Code to get Batch Number"
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2503
+#: erpnext/public/js/controllers/transaction.js:2529
 msgid "Please enter Item Code to get batch no"
 msgstr ""
 
@@ -37059,7 +37054,7 @@ msgstr ""
 msgid "Please enter company name first"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2764
+#: erpnext/controllers/accounts_controller.py:2767
 msgid "Please enter default currency in Company Master"
 msgstr ""
 
@@ -37095,7 +37090,7 @@ msgstr "Insira o nome da empresa para confirmar"
 msgid "Please enter the phone number first"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:1007
+#: erpnext/controllers/buying_controller.py:1015
 msgid "Please enter the {schedule_date}."
 msgstr ""
 
@@ -37197,7 +37192,7 @@ msgstr ""
 msgid "Please select <b>Template Type</b> to download template"
 msgstr ""
 
-#: erpnext/controllers/taxes_and_totals.py:721
+#: erpnext/controllers/taxes_and_totals.py:731
 #: erpnext/public/js/controllers/taxes_and_totals.js:721
 msgid "Please select Apply Discount On"
 msgstr ""
@@ -37210,7 +37205,7 @@ msgstr ""
 msgid "Please select BOM for Item in Row {0}"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:467
+#: erpnext/controllers/buying_controller.py:475
 msgid "Please select BOM in BOM field for Item {item_code}."
 msgstr "Por favor selecione a LDM no campo LDM para o Item {item_code}."
 
@@ -37292,7 +37287,7 @@ msgstr ""
 msgid "Please select Qty against item {0}"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:320
+#: erpnext/stock/doctype/item/item.py:323
 msgid "Please select Sample Retention Warehouse in Stock Settings first"
 msgstr ""
 
@@ -37308,7 +37303,7 @@ msgstr ""
 msgid "Please select Subcontracting Order instead of Purchase Order {0}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2613
+#: erpnext/controllers/accounts_controller.py:2616
 msgid "Please select Unrealized Profit / Loss account or add default Unrealized Profit / Loss account account for company {0}"
 msgstr ""
 
@@ -37324,7 +37319,7 @@ msgstr ""
 #: erpnext/manufacturing/doctype/bom/bom.js:603
 #: erpnext/manufacturing/doctype/bom/bom.py:261
 #: erpnext/public/js/controllers/accounts.js:249
-#: erpnext/public/js/controllers/transaction.js:2753
+#: erpnext/public/js/controllers/transaction.js:2779
 msgid "Please select a Company first."
 msgstr "Selecione uma empresa primeiro."
 
@@ -37482,7 +37477,7 @@ msgstr ""
 msgid "Please select {0} first"
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:77
+#: erpnext/public/js/controllers/transaction.js:100
 msgid "Please set 'Apply Additional Discount On'"
 msgstr ""
 
@@ -37667,7 +37662,7 @@ msgstr ""
 msgid "Please set filters"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2194
+#: erpnext/controllers/accounts_controller.py:2197
 msgid "Please set one of the following:"
 msgstr ""
 
@@ -37675,7 +37670,7 @@ msgstr ""
 msgid "Please set opening number of booked depreciations"
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2205
+#: erpnext/public/js/controllers/transaction.js:2231
 msgid "Please set recurring after saving"
 msgstr ""
 
@@ -37746,7 +37741,7 @@ msgstr ""
 msgid "Please share this email with your support team so that they can find and fix the issue."
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2073
+#: erpnext/public/js/controllers/transaction.js:2099
 msgid "Please specify"
 msgstr ""
 
@@ -37761,7 +37756,7 @@ msgid "Please specify Company to proceed"
 msgstr ""
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1472
-#: erpnext/controllers/accounts_controller.py:2957
+#: erpnext/controllers/accounts_controller.py:2960
 #: erpnext/public/js/controllers/accounts.js:97
 msgid "Please specify a valid Row ID for row {0} in table {1}"
 msgstr ""
@@ -37774,7 +37769,7 @@ msgstr ""
 msgid "Please specify at least one attribute in the Attributes table"
 msgstr "Especifique pelo menos um atributo na tabela de atributos"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:605
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:601
 msgid "Please specify either Quantity or Valuation Rate or both"
 msgstr ""
 
@@ -37955,7 +37950,7 @@ msgstr "Despesas Postais"
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:16
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:15
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:18
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1046
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1048
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:15
 #: erpnext/accounts/report/bank_clearance_summary/bank_clearance_summary.py:35
 #: erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.html:7
@@ -40136,7 +40131,7 @@ msgstr "Gerente de Cadastros de Compras"
 #: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.js:48
 #: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:203
 #: erpnext/buying/workspace/buying/buying.json
-#: erpnext/controllers/buying_controller.py:739
+#: erpnext/controllers/buying_controller.py:747
 #: erpnext/crm/doctype/contract/contract.json
 #: erpnext/manufacturing/doctype/blanket_order/blanket_order.js:54
 #: erpnext/manufacturing/doctype/production_plan_sub_assembly_item/production_plan_sub_assembly_item.json
@@ -40275,7 +40270,7 @@ msgstr ""
 msgid "Purchase Orders to Receive"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1833
+#: erpnext/controllers/accounts_controller.py:1836
 msgid "Purchase Orders {0} are un-linked"
 msgstr ""
 
@@ -40299,8 +40294,8 @@ msgstr "Preço de Compra Lista"
 #. Label of a Link in the Stock Workspace
 #. Label of a shortcut in the Stock Workspace
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:171
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:650
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:660
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:652
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:662
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice_list.js:49
 #: erpnext/accounts/doctype/purchase_invoice_item/purchase_invoice_item.json
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:246
@@ -41035,7 +41030,7 @@ msgstr "Modelo de Inspeção de Qualidade"
 msgid "Quality Inspection Template Name"
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:334
+#: erpnext/public/js/controllers/transaction.js:360
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:165
 msgid "Quality Inspection(s)"
 msgstr ""
@@ -42219,7 +42214,7 @@ msgid "Receivable / Payable Account"
 msgstr ""
 
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:71
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1061
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1063
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py:243
 #: erpnext/accounts/report/sales_register/sales_register.py:217
 #: erpnext/accounts/report/sales_register/sales_register.py:271
@@ -42701,7 +42696,7 @@ msgstr "Referência #{0} datado de {1}"
 msgid "Reference Date"
 msgstr "Data de Referência"
 
-#: erpnext/public/js/controllers/transaction.js:2311
+#: erpnext/public/js/controllers/transaction.js:2337
 msgid "Reference Date for Early Payment Discount"
 msgstr ""
 
@@ -43025,7 +43020,7 @@ msgstr ""
 msgid "Rejected"
 msgstr ""
 
-#: erpnext/stock/doctype/inventory_dimension/inventory_dimension.py:202
+#: erpnext/stock/doctype/inventory_dimension/inventory_dimension.py:203
 msgid "Rejected "
 msgstr ""
 
@@ -43129,7 +43124,7 @@ msgstr ""
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:187
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:156
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1135
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1137
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:178
 msgid "Remaining Balance"
 msgstr "Saldo Remanescente"
@@ -43182,7 +43177,7 @@ msgstr "Observação"
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:159
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:198
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:269
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1167
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1169
 #: erpnext/accounts/report/general_ledger/general_ledger.html:84
 #: erpnext/accounts/report/general_ledger/general_ledger.html:110
 #: erpnext/accounts/report/general_ledger/general_ledger.py:742
@@ -43931,7 +43926,7 @@ msgstr "Quantidade Reservada"
 msgid "Reserved Quantity for Production"
 msgstr "Quantidade Reservada Para Produção"
 
-#: erpnext/stock/stock_ledger.py:2147
+#: erpnext/stock/stock_ledger.py:2155
 msgid "Reserved Serial No."
 msgstr ""
 
@@ -43947,11 +43942,11 @@ msgstr ""
 #: erpnext/stock/doctype/pick_list/pick_list.js:153
 #: erpnext/stock/report/reserved_stock/reserved_stock.json
 #: erpnext/stock/report/stock_balance/stock_balance.py:499
-#: erpnext/stock/stock_ledger.py:2131
+#: erpnext/stock/stock_ledger.py:2139
 msgid "Reserved Stock"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:2177
+#: erpnext/stock/stock_ledger.py:2185
 msgid "Reserved Stock for Batch"
 msgstr ""
 
@@ -43963,7 +43958,7 @@ msgstr ""
 msgid "Reserved Stock for Sub-assembly"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:476
+#: erpnext/controllers/buying_controller.py:484
 msgid "Reserved Warehouse is mandatory for the Item {item_code} in Raw Materials supplied."
 msgstr ""
 
@@ -44777,7 +44772,7 @@ msgstr "Encaminhamento"
 msgid "Routing Name"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:667
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:663
 msgid "Row #"
 msgstr ""
 
@@ -44815,7 +44810,7 @@ msgstr ""
 msgid "Row #{0} (Payment Table): Amount must be positive"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:495
+#: erpnext/stock/doctype/item/item.py:498
 msgid "Row #{0}: A reorder entry already exists for warehouse {1} with reorder type {2}."
 msgstr ""
 
@@ -44836,7 +44831,7 @@ msgstr ""
 msgid "Row #{0}: Accepted Warehouse is mandatory for the accepted Item {1}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1117
+#: erpnext/controllers/accounts_controller.py:1120
 msgid "Row #{0}: Account {1} does not belong to company {2}"
 msgstr ""
 
@@ -44877,27 +44872,27 @@ msgstr ""
 msgid "Row #{0}: Cannot allocate more than {1} against payment term {2}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3524
+#: erpnext/controllers/accounts_controller.py:3527
 msgid "Row #{0}: Cannot delete item {1} which has already been billed."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3498
+#: erpnext/controllers/accounts_controller.py:3501
 msgid "Row #{0}: Cannot delete item {1} which has already been delivered"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3517
+#: erpnext/controllers/accounts_controller.py:3520
 msgid "Row #{0}: Cannot delete item {1} which has already been received"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3504
+#: erpnext/controllers/accounts_controller.py:3507
 msgid "Row #{0}: Cannot delete item {1} which has work order assigned to it."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3510
+#: erpnext/controllers/accounts_controller.py:3513
 msgid "Row #{0}: Cannot delete item {1} which is assigned to customer's purchase order."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3765
+#: erpnext/controllers/accounts_controller.py:3768
 msgid "Row #{0}: Cannot set Rate if the billed amount is greater than the amount for Item {1}."
 msgstr ""
 
@@ -45017,7 +45012,7 @@ msgstr ""
 msgid "Row #{0}: Item {1} has been picked, please reserve stock from the Pick List."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:729
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:725
 msgid "Row #{0}: Item {1} is not a Serialized/Batched Item. It cannot have a Serial No/Batch No against it."
 msgstr ""
 
@@ -45073,7 +45068,7 @@ msgstr ""
 msgid "Row #{0}: Please select the Sub Assembly Warehouse"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:502
+#: erpnext/stock/doctype/item/item.py:505
 msgid "Row #{0}: Please set reorder quantity"
 msgstr ""
 
@@ -45106,8 +45101,8 @@ msgstr ""
 msgid "Row #{0}: Quality Inspection {1} was rejected for item {2}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1274
-#: erpnext/controllers/accounts_controller.py:3624
+#: erpnext/controllers/accounts_controller.py:1277
+#: erpnext/controllers/accounts_controller.py:3627
 msgid "Row #{0}: Quantity for Item {1} cannot be zero."
 msgstr ""
 
@@ -45144,7 +45139,7 @@ msgstr ""
 msgid "Row #{0}: Scrap Item Qty cannot be zero"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:230
+#: erpnext/controllers/selling_controller.py:238
 msgid "Row #{0}: Selling rate for item {1} is lower than its {2}.\n"
 "\t\t\t\t\tSelling {3} should be atleast {4}.<br><br>Alternatively,\n"
 "\t\t\t\t\tyou can disable selling price validation in {5} to bypass\n"
@@ -45228,7 +45223,7 @@ msgstr ""
 msgid "Row #{0}: The batch {1} has already expired."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:511
+#: erpnext/stock/doctype/item/item.py:514
 msgid "Row #{0}: The warehouse {1} is not a child warehouse of a group warehouse {2}"
 msgstr ""
 
@@ -45268,39 +45263,39 @@ msgstr ""
 msgid "Row #{1}: Warehouse is mandatory for stock Item {0}"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:259
+#: erpnext/controllers/buying_controller.py:267
 msgid "Row #{idx}: Cannot select Supplier Warehouse while suppling raw materials to subcontractor."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:406
+#: erpnext/controllers/buying_controller.py:414
 msgid "Row #{idx}: Item rate has been updated as per valuation rate since its an internal stock transfer."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:881
+#: erpnext/controllers/buying_controller.py:889
 msgid "Row #{idx}: Please enter a location for the asset item {item_code}."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:537
+#: erpnext/controllers/buying_controller.py:545
 msgid "Row #{idx}: Received Qty must be equal to Accepted + Rejected Qty for Item {item_code}."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:550
+#: erpnext/controllers/buying_controller.py:558
 msgid "Row #{idx}: {field_label} can not be negative for item {item_code}."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:496
+#: erpnext/controllers/buying_controller.py:504
 msgid "Row #{idx}: {field_label} is mandatory."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:518
+#: erpnext/controllers/buying_controller.py:526
 msgid "Row #{idx}: {field_label} is not allowed in Purchase Return."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:250
+#: erpnext/controllers/buying_controller.py:258
 msgid "Row #{idx}: {from_warehouse_field} and {to_warehouse_field} cannot be same."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:999
+#: erpnext/controllers/buying_controller.py:1007
 msgid "Row #{idx}: {schedule_date} cannot be before {transaction_date}."
 msgstr ""
 
@@ -45365,7 +45360,7 @@ msgstr "Linha #{}: {}"
 msgid "Row #{}: {} {} does not exist."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1403
+#: erpnext/stock/doctype/item/item.py:1397
 msgid "Row #{}: {} {} doesn't belong to Company {}. Please select valid {}."
 msgstr ""
 
@@ -45437,11 +45432,11 @@ msgstr ""
 msgid "Row {0}: Both Debit and Credit values cannot be zero"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:222
+#: erpnext/controllers/selling_controller.py:230
 msgid "Row {0}: Conversion Factor is mandatory"
 msgstr "Linha {0}: Fator de Conversão é obrigatório"
 
-#: erpnext/controllers/accounts_controller.py:2995
+#: erpnext/controllers/accounts_controller.py:2998
 msgid "Row {0}: Cost Center {1} does not belong to Company {2}"
 msgstr ""
 
@@ -45461,11 +45456,11 @@ msgstr ""
 msgid "Row {0}: Debit entry can not be linked with a {1}"
 msgstr "Linha {0}: Lançamento de débito não pode ser relacionado a uma {1}"
 
-#: erpnext/controllers/selling_controller.py:776
+#: erpnext/controllers/selling_controller.py:784
 msgid "Row {0}: Delivery Warehouse ({1}) and Customer Warehouse ({2}) can not be same"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2529
+#: erpnext/controllers/accounts_controller.py:2532
 msgid "Row {0}: Due Date in the Payment Terms table cannot be before Posting Date"
 msgstr "Linha {0}: a data de vencimento na tabela Condições de pagamento não pode ser anterior à data de lançamento"
 
@@ -45474,7 +45469,7 @@ msgid "Row {0}: Either Delivery Note Item or Packed Item reference is mandatory.
 msgstr ""
 
 #: erpnext/accounts/doctype/journal_entry/journal_entry.py:1010
-#: erpnext/controllers/taxes_and_totals.py:1205
+#: erpnext/controllers/taxes_and_totals.py:1215
 msgid "Row {0}: Exchange Rate is mandatory"
 msgstr "Linha {0}: Taxa de Câmbio é obrigatória"
 
@@ -45523,11 +45518,11 @@ msgstr ""
 msgid "Row {0}: Invalid reference {1}"
 msgstr "Linha {0}: referência inválida {1}"
 
-#: erpnext/controllers/taxes_and_totals.py:142
+#: erpnext/controllers/taxes_and_totals.py:143
 msgid "Row {0}: Item Tax template updated as per validity and rate applied"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:541
+#: erpnext/controllers/selling_controller.py:549
 msgid "Row {0}: Item rate has been updated as per valuation rate since its an internal stock transfer"
 msgstr ""
 
@@ -45647,7 +45642,7 @@ msgstr ""
 msgid "Row {0}: The item {1}, quantity must be positive number"
 msgstr "Linha {0}: o item {1}, a quantidade deve ser um número positivo"
 
-#: erpnext/controllers/accounts_controller.py:2972
+#: erpnext/controllers/accounts_controller.py:2975
 msgid "Row {0}: The {3} Account {1} does not belong to the company {2}"
 msgstr ""
 
@@ -45664,7 +45659,7 @@ msgstr "Linha {0}: Fator de Conversão da Unidade de Medida é obrigatório"
 msgid "Row {0}: Workstation or Workstation Type is mandatory for an operation {1}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1011
+#: erpnext/controllers/accounts_controller.py:1014
 msgid "Row {0}: user has not applied the rule {1} on the item {2}"
 msgstr ""
 
@@ -45676,7 +45671,7 @@ msgstr ""
 msgid "Row {0}: {1} must be greater than 0"
 msgstr "Linha {0}: {1} deve ser maior que 0"
 
-#: erpnext/controllers/accounts_controller.py:706
+#: erpnext/controllers/accounts_controller.py:709
 msgid "Row {0}: {1} {2} cannot be same as {3} (Party Account) {4}"
 msgstr ""
 
@@ -45692,7 +45687,7 @@ msgstr ""
 msgid "Row {1}: Quantity ({0}) cannot be a fraction. To allow this, disable '{2}' in UOM {3}."
 msgstr "Linha {1}: Quantidade ({0}) não pode ser uma fração. Para permitir isso, desative ';{2}'; no UOM {3}."
 
-#: erpnext/controllers/buying_controller.py:863
+#: erpnext/controllers/buying_controller.py:871
 msgid "Row {idx}: Asset Naming Series is mandatory for the auto creation of assets for item {item_code}."
 msgstr ""
 
@@ -45718,7 +45713,7 @@ msgstr "Linhas Removidas Em {0}"
 msgid "Rows with Same Account heads will be merged on Ledger"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2539
+#: erpnext/controllers/accounts_controller.py:2542
 msgid "Rows with duplicate due dates in other rows were found: {0}"
 msgstr "Linhas com datas de vencimento duplicadas em outras linhas foram encontradas: {0}"
 
@@ -45788,7 +45783,7 @@ msgstr ""
 msgid "SLA Paused On"
 msgstr ""
 
-#: erpnext/public/js/utils.js:1167
+#: erpnext/public/js/utils.js:1163
 msgid "SLA is on hold since {0}"
 msgstr "SLA está em espera desde {0}"
 
@@ -46189,7 +46184,7 @@ msgstr ""
 #: erpnext/accounts/report/sales_register/sales_register.py:238
 #: erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
 #: erpnext/buying/doctype/supplier_quotation_item/supplier_quotation_item.json
-#: erpnext/controllers/selling_controller.py:462
+#: erpnext/controllers/selling_controller.py:470
 #: erpnext/crm/doctype/contract/contract.json
 #: erpnext/maintenance/doctype/maintenance_schedule/maintenance_schedule.js:65
 #: erpnext/maintenance/doctype/maintenance_schedule_item/maintenance_schedule_item.json
@@ -46315,7 +46310,7 @@ msgstr "Pedido de Venda {0} não foi enviado"
 msgid "Sales Order {0} is not valid"
 msgstr "Pedido de Venda {0} não é válido"
 
-#: erpnext/controllers/selling_controller.py:443
+#: erpnext/controllers/selling_controller.py:451
 #: erpnext/manufacturing/doctype/work_order/work_order.py:301
 msgid "Sales Order {0} is {1}"
 msgstr "Pedido de Venda {0} É {1}"
@@ -46366,7 +46361,7 @@ msgstr ""
 #: erpnext/accounts/doctype/promotional_scheme/promotional_scheme.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:122
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1156
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1158
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:99
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:194
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:74
@@ -46464,7 +46459,7 @@ msgstr "Resumo de Recebimento de Vendas"
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:156
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:137
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:128
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1153
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1155
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:105
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:191
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:80
@@ -46484,7 +46479,7 @@ msgstr "Resumo de Recebimento de Vendas"
 msgid "Sales Person"
 msgstr "Vendedor"
 
-#: erpnext/controllers/selling_controller.py:204
+#: erpnext/controllers/selling_controller.py:212
 msgid "Sales Person <b>{0}</b> is disabled."
 msgstr ""
 
@@ -46765,7 +46760,7 @@ msgstr ""
 
 #. Label of the sample_size (Float) field in DocType 'Quality Inspection'
 #: erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py:93
-#: erpnext/public/js/controllers/transaction.js:2369
+#: erpnext/public/js/controllers/transaction.js:2395
 #: erpnext/stock/doctype/quality_inspection/quality_inspection.json
 msgid "Sample Size"
 msgstr "Tamanho da Amostra"
@@ -47303,7 +47298,7 @@ msgstr "Selecione Itens"
 msgid "Select Items based on Delivery Date"
 msgstr "Selecione itens com base na data de entrega"
 
-#: erpnext/public/js/controllers/transaction.js:2405
+#: erpnext/public/js/controllers/transaction.js:2431
 msgid "Select Items for Quality Inspection"
 msgstr ""
 
@@ -47444,7 +47439,7 @@ msgstr "Selecione a empresa primeiro"
 msgid "Select company name first."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2785
+#: erpnext/controllers/accounts_controller.py:2788
 msgid "Select finance book for the item {0} at row {1}"
 msgstr ""
 
@@ -47657,7 +47652,7 @@ msgid "Send Now"
 msgstr "Enviar Agora"
 
 #. Label of the send_sms (Button) field in DocType 'SMS Center'
-#: erpnext/public/js/controllers/transaction.js:517
+#: erpnext/public/js/controllers/transaction.js:543
 #: erpnext/selling/doctype/sms_center/sms_center.json
 msgid "Send SMS"
 msgstr "Envie SMS"
@@ -47815,7 +47810,7 @@ msgstr ""
 #: erpnext/manufacturing/doctype/job_card/job_card.json
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.js:74
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.py:114
-#: erpnext/public/js/controllers/transaction.js:2382
+#: erpnext/public/js/controllers/transaction.js:2408
 #: erpnext/public/js/utils/serial_no_batch_selector.js:421
 #: erpnext/selling/doctype/installation_note_item/installation_note_item.json
 #: erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
@@ -47864,7 +47859,7 @@ msgstr ""
 msgid "Serial No Range"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1894
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1895
 msgid "Serial No Reserved"
 msgstr ""
 
@@ -47904,7 +47899,7 @@ msgstr "Número de Série e Lote"
 msgid "Serial No and Batch Selector cannot be use when Use Serial / Batch Fields is enabled."
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:859
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:860
 msgid "Serial No is mandatory"
 msgstr ""
 
@@ -47933,7 +47928,7 @@ msgstr ""
 msgid "Serial No {0} does not exist"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2623
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2624
 msgid "Serial No {0} does not exists"
 msgstr ""
 
@@ -47941,7 +47936,7 @@ msgstr ""
 msgid "Serial No {0} is already added"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:357
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:358
 msgid "Serial No {0} is not present in the {1} {2}, hence you can't return it against the {1} {2}"
 msgstr ""
 
@@ -47978,11 +47973,11 @@ msgstr ""
 msgid "Serial Nos and Batches"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1370
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1371
 msgid "Serial Nos are created successfully"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:2137
+#: erpnext/stock/stock_ledger.py:2145
 msgid "Serial Nos are reserved in Stock Reservation Entries, you need to unreserve them before proceeding."
 msgstr ""
 
@@ -48056,11 +48051,11 @@ msgstr ""
 msgid "Serial and Batch Bundle"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1598
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1599
 msgid "Serial and Batch Bundle created"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1664
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1665
 msgid "Serial and Batch Bundle updated"
 msgstr ""
 
@@ -48412,12 +48407,12 @@ msgid "Service Stop Date"
 msgstr ""
 
 #: erpnext/accounts/deferred_revenue.py:44
-#: erpnext/public/js/controllers/transaction.js:1420
+#: erpnext/public/js/controllers/transaction.js:1446
 msgid "Service Stop Date cannot be after Service End Date"
 msgstr "Data de parada de serviço não pode ser após a data de término do serviço"
 
 #: erpnext/accounts/deferred_revenue.py:41
-#: erpnext/public/js/controllers/transaction.js:1417
+#: erpnext/public/js/controllers/transaction.js:1443
 msgid "Service Stop Date cannot be before Service Start Date"
 msgstr "A data de parada de serviço não pode ser anterior à data de início do serviço"
 
@@ -49852,7 +49847,7 @@ msgstr ""
 
 #: erpnext/setup/setup_wizard/operations/defaults_setup.py:70
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:463
-#: erpnext/stock/doctype/item/item.py:245
+#: erpnext/stock/doctype/item/item.py:248
 msgid "Standard Selling"
 msgstr "Venda Padrão"
 
@@ -50682,7 +50677,7 @@ msgstr ""
 #. Option for the 'Purpose' (Select) field in DocType 'Stock Reconciliation'
 #. Label of a Link in the Stock Workspace
 #: erpnext/setup/workspace/home/home.json
-#: erpnext/stock/doctype/item/item.py:612
+#: erpnext/stock/doctype/item/item.py:618
 #: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.json
 #: erpnext/stock/workspace/stock/stock.json
 msgid "Stock Reconciliation"
@@ -50693,7 +50688,7 @@ msgstr "Conciliação de Estoque"
 msgid "Stock Reconciliation Item"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:612
+#: erpnext/stock/doctype/item/item.py:618
 msgid "Stock Reconciliations"
 msgstr "Reconciliações de Estoque"
 
@@ -50728,7 +50723,7 @@ msgstr ""
 #: erpnext/stock/doctype/pick_list/pick_list.js:150
 #: erpnext/stock/doctype/pick_list/pick_list.js:155
 #: erpnext/stock/doctype/stock_entry/stock_entry_dashboard.py:25
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:706
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:702
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:575
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:1138
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:1398
@@ -51128,7 +51123,7 @@ msgstr "A ordem de trabalho interrompida não pode ser cancelada, descompacte-a 
 #: erpnext/setup/doctype/company/company.py:287
 #: erpnext/setup/setup_wizard/operations/defaults_setup.py:33
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:502
-#: erpnext/stock/doctype/item/item.py:282
+#: erpnext/stock/doctype/item/item.py:285
 msgid "Stores"
 msgstr "Lojas"
 
@@ -51663,7 +51658,7 @@ msgstr "Reconciliados Com Sucesso"
 msgid "Successfully Set Supplier"
 msgstr "Definir o Fornecedor Com Sucesso"
 
-#: erpnext/stock/doctype/item/item.py:339
+#: erpnext/stock/doctype/item/item.py:342
 msgid "Successfully changed Stock UOM, please redefine conversion factors for new UOM."
 msgstr ""
 
@@ -51965,7 +51960,7 @@ msgstr ""
 #: erpnext/accounts/doctype/tax_rule/tax_rule.json
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:111
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:87
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1160
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1162
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:198
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:237
 #: erpnext/accounts/report/purchase_register/purchase_register.js:27
@@ -52065,7 +52060,7 @@ msgstr ""
 #. Label of the supplier_name (Data) field in DocType 'Purchase Receipt'
 #. Label of the supplier_name (Data) field in DocType 'Stock Entry'
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1077
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1079
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:156
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:198
 #: erpnext/accounts/report/purchase_register/purchase_register.py:177
@@ -52549,7 +52544,7 @@ msgstr ""
 msgid "System will fetch all the entries if limit value is zero."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1975
+#: erpnext/controllers/accounts_controller.py:1978
 msgid "System will not check over billing since amount for Item {0} in {1} is zero"
 msgstr ""
 
@@ -52808,7 +52803,7 @@ msgstr ""
 msgid "Target Warehouse is required before Submit"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:782
+#: erpnext/controllers/selling_controller.py:790
 msgid "Target Warehouse is set for some items but the customer is not an internal customer."
 msgstr ""
 
@@ -53047,7 +53042,7 @@ msgstr ""
 msgid "Tax Category"
 msgstr "Categoria de Impostos"
 
-#: erpnext/controllers/buying_controller.py:194
+#: erpnext/controllers/buying_controller.py:202
 msgid "Tax Category has been changed to \"Total\" because all the Items are non-stock items"
 msgstr ""
 
@@ -53252,7 +53247,7 @@ msgstr ""
 #. Label of the taxable_amount (Currency) field in DocType 'Tax Withheld
 #. Vouchers'
 #: erpnext/accounts/doctype/tax_withheld_vouchers/tax_withheld_vouchers.json
-#: erpnext/controllers/taxes_and_totals.py:1125
+#: erpnext/controllers/taxes_and_totals.py:1135
 msgid "Taxable Amount"
 msgstr "Valor Tributável"
 
@@ -53391,7 +53386,7 @@ msgstr ""
 msgid "Taxes and Charges Deducted (Company Currency)"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:352
+#: erpnext/stock/doctype/item/item.py:355
 msgid "Taxes row #{0}: {1} cannot be smaller than {2}"
 msgstr ""
 
@@ -53677,7 +53672,7 @@ msgstr ""
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/territory_item/territory_item.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:134
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1144
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1146
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:93
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:182
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:68
@@ -53781,7 +53776,7 @@ msgstr "O Acesso À Solicitação de Cotação do Portal Está Desabilitado. Par
 msgid "The BOM which will be replaced"
 msgstr ""
 
-#: erpnext/stock/serial_batch_bundle.py:1274
+#: erpnext/stock/serial_batch_bundle.py:1306
 msgid "The Batch {0} has negative quantity {1} in warehouse {2}. Please correct the quantity."
 msgstr ""
 
@@ -53833,7 +53828,7 @@ msgstr ""
 msgid "The Serial No at Row #{0}: {1} is not available in warehouse {2}."
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1891
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1892
 msgid "The Serial No {0} is reserved against the {1} {2} and cannot be used for any other transaction."
 msgstr ""
 
@@ -53916,7 +53911,7 @@ msgstr ""
 msgid "The following batches are expired, please restock them: <br> {0}"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:849
+#: erpnext/stock/doctype/item/item.py:843
 msgid "The following deleted attributes exist in Variants but not in the Template. You can either delete the Variants or keep the attribute(s) in template."
 msgstr ""
 
@@ -53941,15 +53936,15 @@ msgstr ""
 msgid "The holiday on {0} is not between From Date and To Date"
 msgstr "O feriado em {0} não é entre de Data e To Date"
 
-#: erpnext/controllers/buying_controller.py:1066
+#: erpnext/controllers/buying_controller.py:1074
 msgid "The item {item} is not marked as {type_of} item. You can enable it as {type_of} item from its Item master."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:614
+#: erpnext/stock/doctype/item/item.py:620
 msgid "The items {0} and {1} are present in the following {2} :"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:1059
+#: erpnext/controllers/buying_controller.py:1067
 msgid "The items {items} are not marked as {type_of} item. You can enable them as {type_of} item from their Item masters."
 msgstr ""
 
@@ -54051,8 +54046,8 @@ msgstr ""
 msgid "The seller and the buyer cannot be the same"
 msgstr "O vendedor e o comprador não podem ser os mesmos"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:142
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:154
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:143
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:155
 msgid "The serial and batch bundle {0} not linked to {1} {2}"
 msgstr ""
 
@@ -54076,7 +54071,7 @@ msgstr "As ações não existem com o {0}"
 msgid "The stock for the item {0} in the {1} warehouse was negative on the {2}. You should create a positive entry {3} before the date {4} and time {5} to post the correct valuation rate. For more details, please read the <a href='https://docs.erpnext.com/docs/user/manual/en/stock-adjustment-cogs-with-negative-stock'>documentation<a>."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:700
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:696
 msgid "The stock has been reserved for the following Items and Warehouses, un-reserve the same to {0} the Stock Reconciliation: <br /><br /> {1}"
 msgstr ""
 
@@ -54089,11 +54084,11 @@ msgstr ""
 msgid "The task has been enqueued as a background job."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:994
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:990
 msgid "The task has been enqueued as a background job. In case there is any issue on processing in background, the system will add a comment about the error on this Stock Reconciliation and revert to the Draft stage"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1005
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1001
 msgid "The task has been enqueued as a background job. In case there is any issue on processing in background, the system will add a comment about the error on this Stock Reconciliation and revert to the Submitted stage"
 msgstr ""
 
@@ -54143,7 +54138,7 @@ msgstr ""
 msgid "The {0} ({1}) must be equal to {2} ({3})"
 msgstr "O {0} ({1}) deve ser igual a {2} ({3})"
 
-#: erpnext/public/js/controllers/transaction.js:2790
+#: erpnext/public/js/controllers/transaction.js:2816
 msgid "The {0} contains Unit Price Items."
 msgstr ""
 
@@ -54191,7 +54186,7 @@ msgstr ""
 msgid "There can be multiple tiered collection factor based on the total spent. But the conversion factor for redemption will always be same for all the tier."
 msgstr ""
 
-#: erpnext/accounts/party.py:580
+#: erpnext/accounts/party.py:586
 msgid "There can only be 1 Account per Company in {0} {1}"
 msgstr ""
 
@@ -54477,7 +54472,7 @@ msgstr ""
 msgid "This will restrict user access to other employee records"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:783
+#: erpnext/controllers/selling_controller.py:791
 msgid "This {} will be treated as material transfer."
 msgstr ""
 
@@ -55191,11 +55186,11 @@ msgid "To include sub-assembly costs and scrap items in Finished Goods on a work
 msgstr ""
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:2337
-#: erpnext/controllers/accounts_controller.py:3005
+#: erpnext/controllers/accounts_controller.py:3008
 msgid "To include tax in row {0} in Item rate, taxes in rows {1} must also be included"
 msgstr "Para incluir impostos na linha {0} na taxa de Item, os impostos em linhas {1} também deve ser incluída"
 
-#: erpnext/stock/doctype/item/item.py:636
+#: erpnext/stock/doctype/item/item.py:642
 msgid "To merge, following properties must be same for both items"
 msgstr ""
 
@@ -55815,7 +55810,7 @@ msgstr "Saldo Devedor Total"
 msgid "Total Paid Amount"
 msgstr "Valor Total Pago"
 
-#: erpnext/controllers/accounts_controller.py:2591
+#: erpnext/controllers/accounts_controller.py:2594
 msgid "Total Payment Amount in Payment Schedule must be equal to Grand / Rounded Total"
 msgstr ""
 
@@ -56100,15 +56095,15 @@ msgstr ""
 msgid "Total Working Hours"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2138
+#: erpnext/controllers/accounts_controller.py:2141
 msgid "Total advance ({0}) against Order {1} cannot be greater than the Grand Total ({2})"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:190
+#: erpnext/controllers/selling_controller.py:198
 msgid "Total allocated percentage for sales team should be 100"
 msgstr "Porcentagem total alocado para a equipe de vendas deve ser de 100"
 
-#: erpnext/selling/doctype/customer/customer.py:162
+#: erpnext/selling/doctype/customer/customer.py:161
 msgid "Total contribution percentage should be equal to 100"
 msgstr "A porcentagem total de contribuição deve ser igual a 100"
 
@@ -56993,7 +56988,7 @@ msgstr "Unidade de Medida"
 msgid "Unit of Measure (UOM)"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:384
+#: erpnext/stock/doctype/item/item.py:387
 msgid "Unit of Measure {0} has been entered more than once in Conversion Factor Table"
 msgstr "Unidade de Medida {0} foi inserida mais de uma vez na Tabela de Conversão de Fator"
 
@@ -57435,7 +57430,7 @@ msgstr ""
 msgid "Update timestamp on new communication"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom_creator/bom_creator.py:533
+#: erpnext/manufacturing/doctype/bom_creator/bom_creator.py:534
 msgid "Updated successfully"
 msgstr ""
 
@@ -57449,7 +57444,7 @@ msgstr ""
 msgid "Updated via 'Time Log' (In Minutes)"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1387
+#: erpnext/stock/doctype/item/item.py:1381
 msgid "Updating Variants..."
 msgstr "Atualizando Variantes..."
 
@@ -58007,19 +58002,19 @@ msgstr "Taxa de Avaliação"
 msgid "Valuation Rate (In / Out)"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1881
+#: erpnext/stock/stock_ledger.py:1890
 msgid "Valuation Rate Missing"
 msgstr "Taxa de Avaliação Ausente"
 
-#: erpnext/stock/stock_ledger.py:1859
+#: erpnext/stock/stock_ledger.py:1868
 msgid "Valuation Rate for the Item {0}, is required to do accounting entries for {1} {2}."
 msgstr "Taxa de avaliação para o item {0}, é necessária para fazer lançamentos contábeis para {1} {2}."
 
-#: erpnext/stock/doctype/item/item.py:266
+#: erpnext/stock/doctype/item/item.py:269
 msgid "Valuation Rate is mandatory if Opening Stock entered"
 msgstr "É obrigatório colocar a Taxa de Avaliação se foi introduzido o Estoque de Abertura"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:752
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:748
 msgid "Valuation Rate required for Item {0} at row {1}"
 msgstr ""
 
@@ -58029,7 +58024,7 @@ msgstr ""
 msgid "Valuation and Total"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:971
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:967
 msgid "Valuation rate for customer provided items has been set to zero."
 msgstr ""
 
@@ -58043,7 +58038,7 @@ msgid "Valuation rate for the item as per Sales Invoice (Only for Internal Trans
 msgstr ""
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:2361
-#: erpnext/controllers/accounts_controller.py:3029
+#: erpnext/controllers/accounts_controller.py:3032
 msgid "Valuation type charges can not be marked as Inclusive"
 msgstr ""
 
@@ -58199,7 +58194,7 @@ msgstr "Variação ({})"
 msgid "Variant"
 msgstr "Variante"
 
-#: erpnext/stock/doctype/item/item.py:864
+#: erpnext/stock/doctype/item/item.py:858
 msgid "Variant Attribute Error"
 msgstr "Erro de Atributo Variante"
 
@@ -58218,7 +58213,7 @@ msgstr "Bom Variante"
 msgid "Variant Based On"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:892
+#: erpnext/stock/doctype/item/item.py:886
 msgid "Variant Based On cannot be changed"
 msgstr "A variante baseada em não pode ser alterada"
 
@@ -58236,7 +58231,7 @@ msgstr "Campo Variante"
 msgid "Variant Item"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:862
+#: erpnext/stock/doctype/item/item.py:856
 msgid "Variant Items"
 msgstr "Itens Variantes"
 
@@ -58354,7 +58349,7 @@ msgstr "Configurações de Vídeo"
 #: erpnext/accounts/doctype/cost_center/cost_center_tree.js:56
 #: erpnext/accounts/doctype/invoice_discounting/invoice_discounting.js:205
 #: erpnext/accounts/doctype/journal_entry/journal_entry.js:43
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:668
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:670
 #: erpnext/bulk_transaction/doctype/bulk_transaction_log/bulk_transaction_log.js:14
 #: erpnext/bulk_transaction/doctype/bulk_transaction_log/bulk_transaction_log.js:24
 #: erpnext/buying/doctype/request_for_quotation/request_for_quotation.js:167
@@ -58541,7 +58536,7 @@ msgstr ""
 #: erpnext/accounts/doctype/repost_accounting_ledger_items/repost_accounting_ledger_items.json
 #: erpnext/accounts/doctype/repost_payment_ledger_items/repost_payment_ledger_items.json
 #: erpnext/accounts/doctype/unreconcile_payment/unreconcile_payment.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1099
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1101
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.js:42
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:209
 #: erpnext/accounts/report/general_ledger/general_ledger.js:49
@@ -58572,7 +58567,7 @@ msgstr ""
 msgid "Voucher No"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1087
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1088
 msgid "Voucher No is mandatory"
 msgstr ""
 
@@ -58614,7 +58609,7 @@ msgstr ""
 #: erpnext/accounts/doctype/repost_payment_ledger_items/repost_payment_ledger_items.json
 #: erpnext/accounts/doctype/tax_withheld_vouchers/tax_withheld_vouchers.json
 #: erpnext/accounts/doctype/unreconcile_payment/unreconcile_payment.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1097
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1099
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:200
 #: erpnext/accounts/report/general_ledger/general_ledger.py:697
 #: erpnext/accounts/report/invalid_ledger_entries/invalid_ledger_entries.py:31
@@ -58968,10 +58963,6 @@ msgstr "Armazém é obrigatório"
 msgid "Warehouse not found against the account {0}"
 msgstr "Armazém não encontrado na conta {0}"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:600
-msgid "Warehouse not found in the system"
-msgstr "Armazém não foi encontrado no sistema"
-
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:1130
 #: erpnext/stock/doctype/delivery_note/delivery_note.py:414
 msgid "Warehouse required for stock Item {0}"
@@ -59100,7 +59091,7 @@ msgid "Warn for new Request for Quotations"
 msgstr ""
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:744
-#: erpnext/controllers/accounts_controller.py:1978
+#: erpnext/controllers/accounts_controller.py:1981
 #: erpnext/stock/doctype/delivery_trip/delivery_trip.js:145
 #: erpnext/utilities/transaction_base.py:123
 msgid "Warning"
@@ -60072,7 +60063,7 @@ msgstr ""
 msgid "You are importing data for the code list:"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3611
+#: erpnext/controllers/accounts_controller.py:3614
 msgid "You are not allowed to update as per the conditions set in {} Workflow."
 msgstr ""
 
@@ -60137,7 +60128,7 @@ msgstr ""
 msgid "You can't make any changes to Job Card since Work Order is closed."
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:185
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:186
 msgid "You can't process the serial number {0} as it has already been used in the SABB {1}. {2} if you want to inward same serial number multiple times then enabled 'Allow existing Serial No to be Manufactured/Received again' in the {3}"
 msgstr ""
 
@@ -60197,7 +60188,7 @@ msgstr "Você não pode enviar o pedido sem pagamento."
 msgid "You cannot {0} this document because another Period Closing Entry {1} exists after {2}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3587
+#: erpnext/controllers/accounts_controller.py:3590
 msgid "You do not have permissions to {} items in a {}."
 msgstr "Você não tem permissão para {} itens em um {}."
 
@@ -60225,7 +60216,7 @@ msgstr ""
 msgid "You have entered a duplicate Delivery Note on Row"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1063
+#: erpnext/stock/doctype/item/item.py:1057
 msgid "You have to enable auto re-order in Stock Settings to maintain re-order levels."
 msgstr "Você precisa habilitar a reordenação automática nas Configurações de estoque para manter os níveis de reordenamento."
 
@@ -60245,7 +60236,7 @@ msgstr ""
 msgid "You need to cancel POS Closing Entry {} to be able to cancel this document."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2980
+#: erpnext/controllers/accounts_controller.py:2983
 msgid "You selected the account group {1} as {2} Account in row {0}. Please select a single account."
 msgstr ""
 
@@ -60323,7 +60314,7 @@ msgstr "[Importante] [ERPNext] Erros de reordenamento automático"
 msgid "`Allow Negative rates for Items`"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1873
+#: erpnext/stock/stock_ledger.py:1882
 msgid "after"
 msgstr ""
 
@@ -60471,7 +60462,7 @@ msgstr ""
 msgid "material_request_item"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:151
+#: erpnext/controllers/selling_controller.py:159
 msgid "must be between 0 and 100"
 msgstr ""
 
@@ -60496,7 +60487,7 @@ msgstr ""
 msgid "on"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1289
+#: erpnext/controllers/accounts_controller.py:1292
 msgid "or"
 msgstr "ou"
 
@@ -60545,7 +60536,7 @@ msgstr ""
 msgid "per hour"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1874
+#: erpnext/stock/stock_ledger.py:1883
 msgid "performing either one below:"
 msgstr ""
 
@@ -60672,7 +60663,7 @@ msgstr ""
 msgid "{0}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1109
+#: erpnext/controllers/accounts_controller.py:1112
 msgid "{0} '{1}' is disabled"
 msgstr "{0} '{1}' está desativado"
 
@@ -60688,7 +60679,7 @@ msgstr "{0} ({1}) não pode ser maior que a quantidade planejada ({2}) na Ordem 
 msgid "{0} <b>{1}</b> has submitted Assets. Remove Item <b>{2}</b> from table to continue."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2193
+#: erpnext/controllers/accounts_controller.py:2196
 msgid "{0} Account not found against Customer {1}."
 msgstr ""
 
@@ -60720,7 +60711,7 @@ msgstr "{0} Operações: {1}"
 msgid "{0} Request for {1}"
 msgstr "{0} pedido para {1}"
 
-#: erpnext/stock/doctype/item/item.py:323
+#: erpnext/stock/doctype/item/item.py:326
 msgid "{0} Retain Sample is based on batch, please check Has Batch No to retain sample of item"
 msgstr ""
 
@@ -60811,7 +60802,7 @@ msgid "{0} entered twice in Item Tax"
 msgstr "{0} entrou duas vezes no Imposto do Item"
 
 #: erpnext/setup/doctype/item_group/item_group.py:48
-#: erpnext/stock/doctype/item/item.py:436
+#: erpnext/stock/doctype/item/item.py:439
 msgid "{0} entered twice {1} in Item Taxes"
 msgstr ""
 
@@ -60832,7 +60823,7 @@ msgstr "{0} foi enviado com sucesso"
 msgid "{0} hours"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2534
+#: erpnext/controllers/accounts_controller.py:2537
 msgid "{0} in row {1}"
 msgstr "{0} na linha {1}"
 
@@ -60856,7 +60847,7 @@ msgstr ""
 
 #: erpnext/accounts/doctype/budget/budget.py:60
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:643
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:49
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:50
 #: erpnext/accounts/report/general_ledger/general_ledger.py:59
 #: erpnext/accounts/report/pos_register/pos_register.py:107
 #: erpnext/controllers/trends.py:50
@@ -60876,11 +60867,11 @@ msgstr ""
 msgid "{0} is mandatory. Maybe Currency Exchange record is not created for {1} to {2}"
 msgstr "{0} é obrigatório. Talvez o registro de câmbio não tenha sido criado para {1} a {2}"
 
-#: erpnext/controllers/accounts_controller.py:2937
+#: erpnext/controllers/accounts_controller.py:2940
 msgid "{0} is mandatory. Maybe Currency Exchange record is not created for {1} to {2}."
 msgstr "{0} é obrigatório. Talvez o valor de câmbio não exista de {1} para {2}."
 
-#: erpnext/selling/doctype/customer/customer.py:204
+#: erpnext/selling/doctype/customer/customer.py:203
 msgid "{0} is not a company bank account"
 msgstr "{0} não é uma conta bancária da empresa"
 
@@ -60963,7 +60954,7 @@ msgstr ""
 msgid "{0} to {1}"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:690
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:686
 msgid "{0} units are reserved for Item {1} in Warehouse {2}, please un-reserve the same to {3} the Stock Reconciliation."
 msgstr ""
 
@@ -60979,16 +60970,16 @@ msgstr ""
 msgid "{0} units of {1} are required in {2} with the inventory dimension: {3} ({4}) on {5} {6} for {7} to complete the transaction."
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1532 erpnext/stock/stock_ledger.py:2023
-#: erpnext/stock/stock_ledger.py:2037
+#: erpnext/stock/stock_ledger.py:1541 erpnext/stock/stock_ledger.py:2031
+#: erpnext/stock/stock_ledger.py:2045
 msgid "{0} units of {1} needed in {2} on {3} {4} for {5} to complete this transaction."
 msgstr "São necessárias {0} unidades de {1} em {2} em {3} {4} para {5} para concluir esta transação."
 
-#: erpnext/stock/stock_ledger.py:2124 erpnext/stock/stock_ledger.py:2170
+#: erpnext/stock/stock_ledger.py:2132 erpnext/stock/stock_ledger.py:2178
 msgid "{0} units of {1} needed in {2} on {3} {4} to complete this transaction."
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1526
+#: erpnext/stock/stock_ledger.py:1535
 msgid "{0} units of {1} needed in {2} to complete this transaction."
 msgstr "São necessárias {0} unidades de {1} em {2} para concluir esta transação."
 
@@ -61034,7 +61025,7 @@ msgstr "{0} {1} criado"
 msgid "{0} {1} does not exist"
 msgstr "{0} {1} não existe"
 
-#: erpnext/accounts/party.py:560
+#: erpnext/accounts/party.py:566
 msgid "{0} {1} has accounting entries in currency {2} for company {3}. Please select a receivable or payable account with currency {2}."
 msgstr "{0} {1} possui entradas contábeis na moeda {2} para a empresa {3}. Selecione uma conta a receber ou a pagar com a moeda {2}."
 
@@ -61068,7 +61059,7 @@ msgstr ""
 msgid "{0} {1} is associated with {2}, but Party Account is {3}"
 msgstr "{0} {1} está associado a {2}, mas a Conta do Partido é {3}"
 
-#: erpnext/controllers/selling_controller.py:462
+#: erpnext/controllers/selling_controller.py:470
 #: erpnext/controllers/subcontracting_controller.py:954
 msgid "{0} {1} is cancelled or closed"
 msgstr ""
@@ -61085,11 +61076,11 @@ msgstr "{0} {1} é cancelado então a ação não pode ser concluída"
 msgid "{0} {1} is closed"
 msgstr ""
 
-#: erpnext/accounts/party.py:798
+#: erpnext/accounts/party.py:804
 msgid "{0} {1} is disabled"
 msgstr "{0} {1} está desativado"
 
-#: erpnext/accounts/party.py:804
+#: erpnext/accounts/party.py:810
 msgid "{0} {1} is frozen"
 msgstr "{0} {1} está congelado"
 
@@ -61097,7 +61088,7 @@ msgstr "{0} {1} está congelado"
 msgid "{0} {1} is fully billed"
 msgstr "{0} {1} está totalmente faturado"
 
-#: erpnext/accounts/party.py:808
+#: erpnext/accounts/party.py:814
 msgid "{0} {1} is not active"
 msgstr "{0} {1} não está ativo"
 
@@ -61223,15 +61214,15 @@ msgstr ""
 msgid "{0}: {1} must be less than {2}"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:840
+#: erpnext/controllers/buying_controller.py:848
 msgid "{count} Assets created for {item_code}"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:738
+#: erpnext/controllers/buying_controller.py:746
 msgid "{doctype} {name} is cancelled or closed."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:459
+#: erpnext/controllers/buying_controller.py:467
 msgid "{field_label} is mandatory for sub-contracted {doctype}."
 msgstr ""
 
@@ -61239,7 +61230,7 @@ msgstr ""
 msgid "{item_name}'s Sample Size ({sample_size}) cannot be greater than the Accepted Quantity ({accepted_quantity})"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:563
+#: erpnext/controllers/buying_controller.py:571
 msgid "{ref_doctype} {ref_name} is {status}."
 msgstr ""
 
@@ -61305,7 +61296,7 @@ msgstr ""
 msgid "{} can't be cancelled since the Loyalty Points earned has been redeemed. First cancel the {} No {}"
 msgstr "{} não pode ser cancelado porque os pontos de fidelidade ganhos foram resgatados. Primeiro cancele o {} Não {}"
 
-#: erpnext/controllers/buying_controller.py:222
+#: erpnext/controllers/buying_controller.py:230
 msgid "{} has submitted assets linked to it. You need to cancel the assets to create purchase return."
 msgstr "{} enviou ativos vinculados a ele. Você precisa cancelar os ativos para criar o retorno de compra."
 

--- a/erpnext/locale/ru.po
+++ b/erpnext/locale/ru.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: frappe\n"
 "Report-Msgid-Bugs-To: hello@frappe.io\n"
-"POT-Creation-Date: 2025-05-25 09:35+0000\n"
-"PO-Revision-Date: 2025-05-25 20:34\n"
+"POT-Creation-Date: 2025-06-01 09:36+0000\n"
+"PO-Revision-Date: 2025-06-01 21:35\n"
 "Last-Translator: hello@frappe.io\n"
 "Language-Team: Russian\n"
 "MIME-Version: 1.0\n"
@@ -83,15 +83,15 @@ msgstr ""
 msgid " Summary"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:235
+#: erpnext/stock/doctype/item/item.py:238
 msgid "\"Customer Provided Item\" cannot be Purchase Item also"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:237
+#: erpnext/stock/doctype/item/item.py:240
 msgid "\"Customer Provided Item\" cannot have Valuation Rate"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:313
+#: erpnext/stock/doctype/item/item.py:316
 msgid "\"Is Fixed Asset\" cannot be unchecked, as Asset record exists against the item"
 msgstr ""
 
@@ -213,7 +213,7 @@ msgstr ""
 msgid "% of materials delivered against this Sales Order"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2197
+#: erpnext/controllers/accounts_controller.py:2200
 msgid "'Account' in the Accounting section of Customer {0}"
 msgstr ""
 
@@ -225,15 +225,11 @@ msgstr ""
 msgid "'Based On' and 'Group By' can not be same"
 msgstr ""
 
-#: erpnext/stock/report/product_bundle_balance/product_bundle_balance.py:233
-msgid "'Date' is required"
-msgstr ""
-
 #: erpnext/selling/report/inactive_customers/inactive_customers.py:18
 msgid "'Days Since Last Order' must be greater than or equal to zero"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2202
+#: erpnext/controllers/accounts_controller.py:2205
 msgid "'Default {0} Account' in Company {1}"
 msgstr ""
 
@@ -243,7 +239,7 @@ msgstr ""
 
 #: erpnext/stock/report/batch_item_expiry_status/batch_item_expiry_status.py:24
 #: erpnext/stock/report/batch_wise_balance_history/batch_wise_balance_history.py:120
-#: erpnext/stock/report/stock_analytics/stock_analytics.py:314
+#: erpnext/stock/report/stock_analytics/stock_analytics.py:313
 msgid "'From Date' is required"
 msgstr ""
 
@@ -251,7 +247,7 @@ msgstr ""
 msgid "'From Date' must be after 'To Date'"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:398
+#: erpnext/stock/doctype/item/item.py:401
 msgid "'Has Serial No' can not be 'Yes' for non-stock item"
 msgstr ""
 
@@ -1075,7 +1071,7 @@ msgstr ""
 
 #. Label of the qty (Float) field in DocType 'Purchase Receipt Item'
 #. Label of the qty (Float) field in DocType 'Subcontracting Receipt Item'
-#: erpnext/public/js/controllers/transaction.js:2362
+#: erpnext/public/js/controllers/transaction.js:2388
 #: erpnext/stock/doctype/purchase_receipt_item/purchase_receipt_item.json
 #: erpnext/subcontracting/doctype/subcontracting_receipt_item/subcontracting_receipt_item.json
 msgid "Accepted Quantity"
@@ -1273,7 +1269,7 @@ msgid "Account Manager"
 msgstr ""
 
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:949
-#: erpnext/controllers/accounts_controller.py:2206
+#: erpnext/controllers/accounts_controller.py:2209
 msgid "Account Missing"
 msgstr ""
 
@@ -1448,7 +1444,7 @@ msgstr ""
 msgid "Account {0} is frozen"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1288
+#: erpnext/controllers/accounts_controller.py:1291
 msgid "Account {0} is invalid. Account Currency must be {1}"
 msgstr ""
 
@@ -1484,7 +1480,7 @@ msgstr ""
 msgid "Account: {0} is not permitted under Payment Entry"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3037
+#: erpnext/controllers/accounts_controller.py:3040
 msgid "Account: {0} with currency: {1} can not be selected"
 msgstr ""
 
@@ -1757,7 +1753,7 @@ msgstr ""
 msgid "Accounting Entry for Asset"
 msgstr ""
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:796
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:805
 msgid "Accounting Entry for Service"
 msgstr ""
 
@@ -1772,18 +1768,18 @@ msgstr ""
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py:1468
 #: erpnext/controllers/stock_controller.py:550
 #: erpnext/controllers/stock_controller.py:567
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:889
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:898
 #: erpnext/stock/doctype/stock_entry/stock_entry.py:1586
 #: erpnext/stock/doctype/stock_entry/stock_entry.py:1600
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py:561
 msgid "Accounting Entry for Stock"
 msgstr ""
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:717
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:726
 msgid "Accounting Entry for {0}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2247
+#: erpnext/controllers/accounts_controller.py:2250
 msgid "Accounting Entry for {0}: {1} can only be made in currency: {2}"
 msgstr ""
 
@@ -2176,7 +2172,7 @@ msgstr ""
 msgid "Accumulated Monthly"
 msgstr ""
 
-#: erpnext/controllers/budget_controller.py:417
+#: erpnext/controllers/budget_controller.py:422
 msgid "Accumulated Monthly Budget for Account {0} against {1} {2} is {3}. It will be collectively ({4}) exceeded by {5}"
 msgstr ""
 
@@ -3290,7 +3286,7 @@ msgstr ""
 msgid "Adjustment Against"
 msgstr ""
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:634
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:643
 msgid "Adjustment based on Purchase Invoice rate"
 msgstr ""
 
@@ -3401,7 +3397,7 @@ msgstr ""
 msgid "Advance amount"
 msgstr ""
 
-#: erpnext/controllers/taxes_and_totals.py:845
+#: erpnext/controllers/taxes_and_totals.py:855
 msgid "Advance amount cannot be greater than {0} {1}"
 msgstr ""
 
@@ -3612,7 +3608,7 @@ msgstr ""
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:152
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:133
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1125
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1127
 msgid "Age (Days)"
 msgstr ""
 
@@ -3697,16 +3693,6 @@ msgstr ""
 
 #: erpnext/setup/setup_wizard/data/industry_type.txt:4
 msgid "Agriculture"
-msgstr ""
-
-#. Name of a role
-#: erpnext/assets/doctype/location/location.json
-msgid "Agriculture Manager"
-msgstr ""
-
-#. Name of a role
-#: erpnext/assets/doctype/location/location.json
-msgid "Agriculture User"
 msgstr ""
 
 #: erpnext/setup/setup_wizard/data/industry_type.txt:5
@@ -3899,7 +3885,7 @@ msgstr ""
 msgid "All items are already requested"
 msgstr ""
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:1317
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:1326
 msgid "All items have already been Invoiced/Returned"
 msgstr ""
 
@@ -3911,7 +3897,7 @@ msgstr ""
 msgid "All items have already been transferred for this Work Order."
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2465
+#: erpnext/public/js/controllers/transaction.js:2491
 msgid "All items in this document already have a linked Quality Inspection."
 msgstr ""
 
@@ -4109,7 +4095,7 @@ msgstr ""
 msgid "Allow Item To Be Added Multiple Times in a Transaction"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:755
+#: erpnext/controllers/selling_controller.py:763
 msgid "Allow Item to Be Added Multiple Times in a Transaction"
 msgstr ""
 
@@ -5055,7 +5041,7 @@ msgstr ""
 msgid "Annual Billing: {0}"
 msgstr ""
 
-#: erpnext/controllers/budget_controller.py:441
+#: erpnext/controllers/budget_controller.py:446
 msgid "Annual Budget for Account {0} against {1} {2} is {3}. It will be collectively ({4}) exceeded by {5}"
 msgstr ""
 
@@ -5544,7 +5530,7 @@ msgstr ""
 msgid "As the field {0} is enabled, the value of the field {1} should be more than 1."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:989
+#: erpnext/stock/doctype/item/item.py:983
 msgid "As there are existing submitted transactions against item {0}, you can not change the value of {1}."
 msgstr ""
 
@@ -5690,7 +5676,7 @@ msgstr ""
 msgid "Asset Category Name"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:304
+#: erpnext/stock/doctype/item/item.py:307
 msgid "Asset Category is mandatory for Fixed Asset item"
 msgstr ""
 
@@ -6065,7 +6051,7 @@ msgstr ""
 msgid "Asset {0} must be submitted"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:851
+#: erpnext/controllers/buying_controller.py:859
 msgid "Asset {assets_link} created for {item_code}"
 msgstr ""
 
@@ -6095,11 +6081,11 @@ msgstr ""
 msgid "Assets"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:869
+#: erpnext/controllers/buying_controller.py:877
 msgid "Assets not created for {item_code}. You will have to create asset manually."
 msgstr "Активы не созданы для {item_code}. Вам придется создать актив вручную."
 
-#: erpnext/controllers/buying_controller.py:856
+#: erpnext/controllers/buying_controller.py:864
 msgid "Assets {assets_link} created for {item_code}"
 msgstr ""
 
@@ -6194,7 +6180,7 @@ msgstr ""
 msgid "At row #{0}: you have selected the Difference Account {1}, which is a Cost of Goods Sold type account. Please select a different account"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:864
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:865
 msgid "At row {0}: Batch No is mandatory for Item {1}"
 msgstr ""
 
@@ -6202,11 +6188,11 @@ msgstr ""
 msgid "At row {0}: Parent Row No cannot be set for item {1}"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:849
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:850
 msgid "At row {0}: Qty is mandatory for the batch {1}"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:856
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:857
 msgid "At row {0}: Serial No is mandatory for Item {1}"
 msgstr ""
 
@@ -6280,7 +6266,7 @@ msgstr ""
 msgid "Attribute Value"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:930
+#: erpnext/stock/doctype/item/item.py:924
 msgid "Attribute table is mandatory"
 msgstr ""
 
@@ -6288,11 +6274,11 @@ msgstr ""
 msgid "Attribute value: {0} must appear only once"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:934
+#: erpnext/stock/doctype/item/item.py:928
 msgid "Attribute {0} selected multiple times in Attributes Table"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:862
+#: erpnext/stock/doctype/item/item.py:856
 msgid "Attributes"
 msgstr ""
 
@@ -7576,11 +7562,11 @@ msgstr ""
 msgid "Barcode Type"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:457
+#: erpnext/stock/doctype/item/item.py:460
 msgid "Barcode {0} already used in Item {1}"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:472
+#: erpnext/stock/doctype/item/item.py:475
 msgid "Barcode {0} is not a valid {1} code"
 msgstr ""
 
@@ -7834,7 +7820,7 @@ msgstr ""
 #: erpnext/manufacturing/doctype/job_card/job_card.json
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.js:89
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.py:115
-#: erpnext/public/js/controllers/transaction.js:2388
+#: erpnext/public/js/controllers/transaction.js:2414
 #: erpnext/public/js/utils/barcode_scanner.js:260
 #: erpnext/public/js/utils/serial_no_batch_selector.js:438
 #: erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
@@ -7861,11 +7847,11 @@ msgstr ""
 msgid "Batch No"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:867
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:868
 msgid "Batch No is mandatory"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2629
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2630
 msgid "Batch No {0} does not exists"
 msgstr ""
 
@@ -7873,7 +7859,7 @@ msgstr ""
 msgid "Batch No {0} is linked with Item {1} which has serial no. Please scan serial no instead."
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:364
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:365
 msgid "Batch No {0} is not present in the original {1} {2}, hence you can't return it against the {1} {2}"
 msgstr ""
 
@@ -7888,11 +7874,11 @@ msgstr ""
 msgid "Batch Nos"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1421
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1422
 msgid "Batch Nos are created successfully"
 msgstr ""
 
-#: erpnext/controllers/sales_and_purchase_return.py:1096
+#: erpnext/controllers/sales_and_purchase_return.py:1001
 msgid "Batch Not Available for Return"
 msgstr ""
 
@@ -7941,7 +7927,7 @@ msgstr ""
 msgid "Batch {0} and Warehouse"
 msgstr ""
 
-#: erpnext/controllers/sales_and_purchase_return.py:1095
+#: erpnext/controllers/sales_and_purchase_return.py:1000
 msgid "Batch {0} is not available in warehouse {1}"
 msgstr ""
 
@@ -7991,7 +7977,7 @@ msgstr ""
 #. Label of the bill_date (Date) field in DocType 'Journal Entry'
 #. Label of the bill_date (Date) field in DocType 'Subcontracting Receipt'
 #: erpnext/accounts/doctype/journal_entry/journal_entry.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1110
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1112
 #: erpnext/accounts/report/purchase_register/purchase_register.py:214
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.json
 msgid "Bill Date"
@@ -8000,7 +7986,7 @@ msgstr ""
 #. Label of the bill_no (Data) field in DocType 'Journal Entry'
 #. Label of the bill_no (Data) field in DocType 'Subcontracting Receipt'
 #: erpnext/accounts/doctype/journal_entry/journal_entry.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1109
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1111
 #: erpnext/accounts/report/purchase_register/purchase_register.py:213
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.json
 msgid "Bill No"
@@ -8220,7 +8206,7 @@ msgstr ""
 msgid "Billing Zipcode"
 msgstr ""
 
-#: erpnext/accounts/party.py:602
+#: erpnext/accounts/party.py:608
 msgid "Billing currency must be equal to either default company's currency or party account currency"
 msgstr ""
 
@@ -9217,7 +9203,7 @@ msgid "Can only make payment against unbilled {0}"
 msgstr ""
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1458
-#: erpnext/controllers/accounts_controller.py:2946
+#: erpnext/controllers/accounts_controller.py:2949
 #: erpnext/public/js/controllers/accounts.js:90
 msgid "Can refer row only if the charge type is 'On Previous Row Amount' or 'Previous Row Total'"
 msgstr ""
@@ -9379,9 +9365,9 @@ msgstr ""
 msgid "Cannot Create Return"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:625
-#: erpnext/stock/doctype/item/item.py:638
-#: erpnext/stock/doctype/item/item.py:652
+#: erpnext/stock/doctype/item/item.py:631
+#: erpnext/stock/doctype/item/item.py:644
+#: erpnext/stock/doctype/item/item.py:658
 msgid "Cannot Merge"
 msgstr ""
 
@@ -9405,7 +9391,7 @@ msgstr ""
 msgid "Cannot apply TDS against multiple parties in one entry"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:307
+#: erpnext/stock/doctype/item/item.py:310
 msgid "Cannot be a fixed asset item as Stock Ledger is created."
 msgstr ""
 
@@ -9421,7 +9407,7 @@ msgstr ""
 msgid "Cannot cancel the transaction. Reposting of item valuation on submission is not completed yet."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:959
+#: erpnext/controllers/buying_controller.py:967
 msgid "Cannot cancel this document as it is linked with the submitted asset {asset_link}. Please cancel the asset to continue."
 msgstr ""
 
@@ -9429,7 +9415,7 @@ msgstr ""
 msgid "Cannot cancel transaction for Completed Work Order."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:882
+#: erpnext/stock/doctype/item/item.py:876
 msgid "Cannot change Attributes after stock transaction. Make a new Item and transfer stock to the new Item"
 msgstr ""
 
@@ -9445,7 +9431,7 @@ msgstr ""
 msgid "Cannot change Service Stop Date for item in row {0}"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:873
+#: erpnext/stock/doctype/item/item.py:867
 msgid "Cannot change Variant properties after stock transaction. You will have to make a new Item to do this."
 msgstr ""
 
@@ -9473,7 +9459,7 @@ msgstr ""
 msgid "Cannot covert to Group because Account Type is selected."
 msgstr ""
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:972
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:981
 msgid "Cannot create Stock Reservation Entries for future dated Purchase Receipts."
 msgstr ""
 
@@ -9524,7 +9510,7 @@ msgstr ""
 msgid "Cannot find Item with this Barcode"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3483
+#: erpnext/controllers/accounts_controller.py:3486
 msgid "Cannot find a default warehouse for item {0}. Please set one in the Item Master or in Stock Settings."
 msgstr ""
 
@@ -9532,7 +9518,7 @@ msgstr ""
 msgid "Cannot make any transactions until the deletion job is completed"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2074
+#: erpnext/controllers/accounts_controller.py:2077
 msgid "Cannot overbill for Item {0} in row {1} more than {2}. To allow over-billing, please set allowance in Accounts Settings"
 msgstr ""
 
@@ -9553,7 +9539,7 @@ msgid "Cannot receive from customer against negative outstanding"
 msgstr ""
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1475
-#: erpnext/controllers/accounts_controller.py:2961
+#: erpnext/controllers/accounts_controller.py:2964
 #: erpnext/public/js/controllers/accounts.js:100
 msgid "Cannot refer row number greater than or equal to current row number for this Charge type"
 msgstr ""
@@ -9569,7 +9555,7 @@ msgstr ""
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1467
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1646
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:1917
-#: erpnext/controllers/accounts_controller.py:2951
+#: erpnext/controllers/accounts_controller.py:2954
 #: erpnext/public/js/controllers/accounts.js:94
 #: erpnext/public/js/controllers/taxes_and_totals.js:470
 msgid "Cannot select charge type as 'On Previous Row Amount' or 'On Previous Row Total' for first row"
@@ -9583,15 +9569,15 @@ msgstr ""
 msgid "Cannot set authorization on basis of Discount for {0}"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:716
+#: erpnext/stock/doctype/item/item.py:722
 msgid "Cannot set multiple Item Defaults for a company."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3631
+#: erpnext/controllers/accounts_controller.py:3634
 msgid "Cannot set quantity less than delivered quantity"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3634
+#: erpnext/controllers/accounts_controller.py:3637
 msgid "Cannot set quantity less than received quantity"
 msgstr ""
 
@@ -10014,7 +10000,7 @@ msgid "Channel Partner"
 msgstr ""
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:2346
-#: erpnext/controllers/accounts_controller.py:3014
+#: erpnext/controllers/accounts_controller.py:3017
 msgid "Charge of type 'Actual' in row {0} cannot be included in Item Rate or Paid Amount"
 msgstr ""
 
@@ -10197,7 +10183,7 @@ msgstr ""
 
 #. Label of the reference_date (Date) field in DocType 'Payment Entry'
 #: erpnext/accounts/doctype/payment_entry/payment_entry.json
-#: erpnext/public/js/controllers/transaction.js:2299
+#: erpnext/public/js/controllers/transaction.js:2325
 msgid "Cheque/Reference Date"
 msgstr ""
 
@@ -10245,7 +10231,7 @@ msgstr ""
 
 #. Label of the child_row_reference (Data) field in DocType 'Quality
 #. Inspection'
-#: erpnext/public/js/controllers/transaction.js:2394
+#: erpnext/public/js/controllers/transaction.js:2420
 #: erpnext/stock/doctype/quality_inspection/quality_inspection.json
 msgid "Child Row Reference"
 msgstr ""
@@ -10957,7 +10943,7 @@ msgstr ""
 #: erpnext/accounts/report/cheques_and_deposits_incorrectly_cleared/cheques_and_deposits_incorrectly_cleared.js:8
 #: erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.js:8
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:8
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:49
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:50
 #: erpnext/accounts/report/deferred_revenue_and_expense/deferred_revenue_and_expense.js:8
 #: erpnext/accounts/report/delivered_items_to_be_billed/delivered_items_to_be_billed.js:7
 #: erpnext/accounts/report/dimension_wise_accounts_balance_report/dimension_wise_accounts_balance_report.js:8
@@ -12190,7 +12176,7 @@ msgid "Content Type"
 msgstr ""
 
 #: erpnext/erpnext_integrations/doctype/plaid_settings/plaid_settings.js:162
-#: erpnext/public/js/controllers/transaction.js:2312
+#: erpnext/public/js/controllers/transaction.js:2338
 #: erpnext/selling/doctype/quotation/quotation.js:356
 msgid "Continue"
 msgstr ""
@@ -12355,7 +12341,7 @@ msgstr ""
 msgid "Conversion Rate"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:393
+#: erpnext/stock/doctype/item/item.py:396
 msgid "Conversion factor for default Unit of Measure must be 1 in row {0}"
 msgstr ""
 
@@ -12363,15 +12349,15 @@ msgstr ""
 msgid "Conversion factor for item {0} has been reset to 1.0 as the uom {1} is same as stock uom {2}."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2767
+#: erpnext/controllers/accounts_controller.py:2770
 msgid "Conversion rate cannot be 0"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2774
+#: erpnext/controllers/accounts_controller.py:2777
 msgid "Conversion rate is 1.00, but document currency is different from company currency"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2770
+#: erpnext/controllers/accounts_controller.py:2773
 msgid "Conversion rate must be 1.00 if document currency is same as company currency"
 msgstr ""
 
@@ -12584,7 +12570,7 @@ msgstr ""
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:28
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:40
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:30
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1096
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1098
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:40
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.js:42
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.py:197
@@ -12677,7 +12663,7 @@ msgid "Cost Center is a part of Cost Center Allocation, hence cannot be converte
 msgstr ""
 
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py:1411
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:855
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:864
 msgid "Cost Center is required in row {0} in Taxes table for type {1}"
 msgstr ""
 
@@ -12946,8 +12932,8 @@ msgstr ""
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:132
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:143
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:219
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:654
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:678
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:656
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:680
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.js:88
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.js:89
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.js:103
@@ -13004,8 +12990,8 @@ msgstr ""
 #: erpnext/projects/doctype/task/task_tree.js:81
 #: erpnext/public/js/communication.js:19 erpnext/public/js/communication.js:31
 #: erpnext/public/js/communication.js:41
-#: erpnext/public/js/controllers/transaction.js:336
-#: erpnext/public/js/controllers/transaction.js:2435
+#: erpnext/public/js/controllers/transaction.js:362
+#: erpnext/public/js/controllers/transaction.js:2461
 #: erpnext/selling/doctype/customer/customer.js:181
 #: erpnext/selling/doctype/quotation/quotation.js:124
 #: erpnext/selling/doctype/quotation/quotation.js:133
@@ -13300,7 +13286,7 @@ msgstr ""
 msgid "Create a variant with the template image."
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1877
+#: erpnext/stock/stock_ledger.py:1886
 msgid "Create an incoming stock transaction for the Item."
 msgstr ""
 
@@ -13360,7 +13346,7 @@ msgstr ""
 msgid "Creating Purchase Order ..."
 msgstr ""
 
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:735
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:737
 #: erpnext/buying/doctype/purchase_order/purchase_order.js:552
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.js:73
 msgid "Creating Purchase Receipt ..."
@@ -13554,7 +13540,7 @@ msgstr ""
 #: erpnext/accounts/doctype/journal_entry_template/journal_entry_template.json
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:174
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:147
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1119
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1121
 #: erpnext/controllers/sales_and_purchase_return.py:373
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:286
 #: erpnext/stock/doctype/delivery_note/delivery_note.js:89
@@ -13589,7 +13575,7 @@ msgstr ""
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py:368
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py:376
-#: erpnext/controllers/accounts_controller.py:2186
+#: erpnext/controllers/accounts_controller.py:2189
 msgid "Credit To"
 msgstr ""
 
@@ -13774,7 +13760,7 @@ msgstr ""
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/subscription_plan/subscription_plan.json
 #: erpnext/accounts/report/account_balance/account_balance.py:28
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1129
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1131
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:205
 #: erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.py:101
 #: erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.js:118
@@ -14303,7 +14289,7 @@ msgstr ""
 #. Label of the customer_contact_display (Small Text) field in DocType
 #. 'Purchase Order'
 #. Label of the customer_contact (Small Text) field in DocType 'Delivery Stop'
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1090
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1092
 #: erpnext/buying/doctype/purchase_order/purchase_order.json
 #: erpnext/stock/doctype/delivery_stop/delivery_stop.json
 msgid "Customer Contact"
@@ -14399,7 +14385,7 @@ msgstr ""
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/tax_rule/tax_rule.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:107
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1147
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1149
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:81
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:185
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:56
@@ -14443,7 +14429,7 @@ msgstr ""
 msgid "Customer Group Name"
 msgstr ""
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1239
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1241
 msgid "Customer Group: {0} does not exist"
 msgstr ""
 
@@ -14462,7 +14448,7 @@ msgstr ""
 msgid "Customer Items"
 msgstr ""
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1138
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1140
 msgid "Customer LPO"
 msgstr ""
 
@@ -14508,7 +14494,7 @@ msgstr ""
 #: erpnext/accounts/doctype/pos_invoice/pos_invoice.json
 #: erpnext/accounts/doctype/process_statement_of_accounts_customer/process_statement_of_accounts_customer.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1080
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1082
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:156
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:92
 #: erpnext/accounts/report/delivered_items_to_be_billed/delivered_items_to_be_billed.py:35
@@ -15186,7 +15172,7 @@ msgstr ""
 #: erpnext/accounts/doctype/journal_entry_template/journal_entry_template.json
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:176
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:147
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1122
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1124
 #: erpnext/controllers/sales_and_purchase_return.py:377
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:287
 #: erpnext/stock/doctype/purchase_receipt/purchase_receipt.js:61
@@ -15215,7 +15201,7 @@ msgstr ""
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:953
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:964
-#: erpnext/controllers/accounts_controller.py:2186
+#: erpnext/controllers/accounts_controller.py:2189
 msgid "Debit To"
 msgstr ""
 
@@ -15248,11 +15234,11 @@ msgstr ""
 msgid "Debit-Credit mismatch"
 msgstr ""
 
-#: erpnext/accounts/party.py:609
+#: erpnext/accounts/party.py:615
 msgid "Debtor/Creditor"
 msgstr ""
 
-#: erpnext/accounts/party.py:612
+#: erpnext/accounts/party.py:618
 msgid "Debtor/Creditor Advance"
 msgstr ""
 
@@ -15372,7 +15358,7 @@ msgstr ""
 msgid "Default BOM"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:418
+#: erpnext/stock/doctype/item/item.py:421
 msgid "Default BOM ({0}) must be active for this item or its template"
 msgstr ""
 
@@ -15380,7 +15366,7 @@ msgstr ""
 msgid "Default BOM for {0} not found"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3672
+#: erpnext/controllers/accounts_controller.py:3675
 msgid "Default BOM not found for FG Item {0}"
 msgstr ""
 
@@ -15715,15 +15701,15 @@ msgstr ""
 msgid "Default Unit of Measure"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1272
+#: erpnext/stock/doctype/item/item.py:1266
 msgid "Default Unit of Measure for Item {0} cannot be changed directly because you have already made some transaction(s) with another UOM. You need to either cancel the linked documents or create a new Item."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1255
+#: erpnext/stock/doctype/item/item.py:1249
 msgid "Default Unit of Measure for Item {0} cannot be changed directly because you have already made some transaction(s) with another UOM. You will need to create a new Item to use a different Default UOM."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:908
+#: erpnext/stock/doctype/item/item.py:902
 msgid "Default Unit of Measure for Variant '{0}' must be same as in Template '{1}'"
 msgstr ""
 
@@ -16182,7 +16168,7 @@ msgstr ""
 msgid "Delivery Note {0} is not submitted"
 msgstr ""
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1142
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1144
 #: erpnext/stock/doctype/delivery_trip/delivery_trip.js:73
 msgid "Delivery Notes"
 msgstr ""
@@ -16713,7 +16699,7 @@ msgstr ""
 #: erpnext/projects/doctype/task_type/task_type.json
 #: erpnext/projects/doctype/timesheet_detail/timesheet_detail.json
 #: erpnext/public/js/bank_reconciliation_tool/data_table_manager.js:55
-#: erpnext/public/js/controllers/transaction.js:2376
+#: erpnext/public/js/controllers/transaction.js:2402
 #: erpnext/selling/doctype/installation_note_item/installation_note_item.json
 #: erpnext/selling/doctype/product_bundle/product_bundle.json
 #: erpnext/selling/doctype/product_bundle_item/product_bundle_item.json
@@ -16901,7 +16887,7 @@ msgstr ""
 msgid "Difference Account must be a Asset/Liability type account (Temporary Opening), since this Stock Entry is an Opening Entry"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:954
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:950
 msgid "Difference Account must be a Asset/Liability type account, since this Stock Reconciliation is an Opening Entry"
 msgstr ""
 
@@ -17167,11 +17153,11 @@ msgstr ""
 msgid "Disabled Warehouse {0} cannot be used for this transaction."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:745
+#: erpnext/controllers/accounts_controller.py:748
 msgid "Disabled pricing rules since this {} is an internal transfer"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:759
+#: erpnext/controllers/accounts_controller.py:762
 msgid "Disabled tax included prices since this {} is an internal transfer"
 msgstr ""
 
@@ -18113,7 +18099,7 @@ msgstr ""
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.json
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/print_format/sales_invoice_print/sales_invoice_print.html:72
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1106
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1108
 #: erpnext/assets/doctype/asset_maintenance_log/asset_maintenance_log.json
 #: erpnext/selling/report/payment_terms_status_for_sales_order/payment_terms_status_for_sales_order.py:40
 msgid "Due Date"
@@ -18127,11 +18113,11 @@ msgstr ""
 msgid "Due Date Based On"
 msgstr ""
 
-#: erpnext/accounts/party.py:695
+#: erpnext/accounts/party.py:701
 msgid "Due Date cannot be after {0}"
 msgstr ""
 
-#: erpnext/accounts/party.py:671
+#: erpnext/accounts/party.py:677
 msgid "Due Date cannot be before {0}"
 msgstr ""
 
@@ -18849,7 +18835,7 @@ msgstr ""
 msgid "Enable Auto Email"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1064
+#: erpnext/stock/doctype/item/item.py:1058
 msgid "Enable Auto Re-Order"
 msgstr ""
 
@@ -19062,7 +19048,7 @@ msgstr ""
 msgid "End Date"
 msgstr ""
 
-#: erpnext/crm/doctype/contract/contract.py:75
+#: erpnext/crm/doctype/contract/contract.py:83
 msgid "End Date cannot be before Start Date."
 msgstr ""
 
@@ -19312,7 +19298,7 @@ msgstr ""
 #: erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.json
 #: erpnext/manufacturing/doctype/job_card/job_card.py:875
 #: erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.json
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:297
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:298
 msgid "Error"
 msgstr ""
 
@@ -19437,7 +19423,7 @@ msgstr ""
 msgid "Example URL"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:995
+#: erpnext/stock/doctype/item/item.py:989
 msgid "Example of a linked document: {0}"
 msgstr ""
 
@@ -19452,7 +19438,7 @@ msgstr ""
 msgid "Example: ABCD.#####. If series is set and Batch No is not mentioned in transactions, then automatic batch number will be created based on this series. If you always want to explicitly mention Batch No for this item, leave this blank. Note: this setting will take priority over the Naming Series Prefix in Stock Settings."
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:2141
+#: erpnext/stock/stock_ledger.py:2149
 msgid "Example: Serial No {0} reserved in {1}."
 msgstr ""
 
@@ -19506,8 +19492,8 @@ msgstr ""
 msgid "Exchange Gain/Loss"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1593
-#: erpnext/controllers/accounts_controller.py:1677
+#: erpnext/controllers/accounts_controller.py:1596
+#: erpnext/controllers/accounts_controller.py:1680
 msgid "Exchange Gain/Loss amount has been booked through {0}"
 msgstr ""
 
@@ -20243,7 +20229,7 @@ msgid "Fetching Error"
 msgstr ""
 
 #: erpnext/accounts/doctype/dunning/dunning.js:135
-#: erpnext/public/js/controllers/transaction.js:1251
+#: erpnext/public/js/controllers/transaction.js:1277
 msgid "Fetching exchange rates ..."
 msgstr ""
 
@@ -20538,15 +20524,15 @@ msgstr ""
 msgid "Finished Good Item Quantity"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3658
+#: erpnext/controllers/accounts_controller.py:3661
 msgid "Finished Good Item is not specified for service item {0}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3675
+#: erpnext/controllers/accounts_controller.py:3678
 msgid "Finished Good Item {0} Qty can not be zero"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3669
+#: erpnext/controllers/accounts_controller.py:3672
 msgid "Finished Good Item {0} must be a sub-contracted item"
 msgstr ""
 
@@ -20787,7 +20773,7 @@ msgstr ""
 msgid "Fixed Asset Defaults"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:301
+#: erpnext/stock/doctype/item/item.py:304
 msgid "Fixed Asset Item must be a non-stock item."
 msgstr ""
 
@@ -20963,7 +20949,7 @@ msgstr ""
 msgid "For Raw Materials"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1259
+#: erpnext/controllers/accounts_controller.py:1262
 msgid "For Return Invoices with Stock effect, '0' qty Items are not allowed. Following rows are affected: {0}"
 msgstr ""
 
@@ -21064,7 +21050,7 @@ msgstr ""
 msgid "For the item {0}, the quantity should be {1} according to the BOM {2}."
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:1088
+#: erpnext/public/js/controllers/transaction.js:1114
 msgctxt "Clear payment terms template and/or payment schedule when due date is changed"
 msgid "For the new {0} to take effect, would you like to clear the current {1}?"
 msgstr ""
@@ -21073,7 +21059,7 @@ msgstr ""
 msgid "For the {0}, no stock is available for the return in the warehouse {1}."
 msgstr ""
 
-#: erpnext/controllers/sales_and_purchase_return.py:1144
+#: erpnext/controllers/sales_and_purchase_return.py:1049
 msgid "For the {0}, the quantity is required to make the return entry"
 msgstr ""
 
@@ -21410,7 +21396,7 @@ msgstr ""
 msgid "From Date is mandatory"
 msgstr ""
 
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:52
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:53
 #: erpnext/accounts/report/general_ledger/general_ledger.py:86
 #: erpnext/accounts/report/pos_register/pos_register.py:115
 #: erpnext/accounts/report/tax_withholding_details/tax_withholding_details.py:39
@@ -21787,14 +21773,14 @@ msgstr ""
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:186
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:155
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1134
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1136
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:177
 msgid "Future Payment Amount"
 msgstr ""
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:185
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:154
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1133
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1135
 msgid "Future Payment Ref"
 msgstr ""
 
@@ -22968,7 +22954,7 @@ msgstr ""
 msgid "Here are the error logs for the aforementioned failed depreciation entries: {0}"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1862
+#: erpnext/stock/stock_ledger.py:1871
 msgid "Here are the options to proceed:"
 msgstr ""
 
@@ -23490,7 +23476,7 @@ msgstr ""
 msgid "If more than one package of the same type (for print)"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1872
+#: erpnext/stock/stock_ledger.py:1881
 msgid "If not, you can Cancel / Submit this entry"
 msgstr ""
 
@@ -23515,7 +23501,7 @@ msgstr ""
 msgid "If the account is frozen, entries are allowed to restricted users."
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1865
+#: erpnext/stock/stock_ledger.py:1874
 msgid "If the item is transacting as a Zero Valuation Rate item in this entry, please enable 'Allow Zero Valuation Rate' in the {0} Item table."
 msgstr ""
 
@@ -24513,7 +24499,7 @@ msgstr ""
 msgid "Incorrect Batch Consumed"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:514
+#: erpnext/stock/doctype/item/item.py:517
 msgid "Incorrect Check in (group) Warehouse for Reorder"
 msgstr ""
 
@@ -24562,7 +24548,7 @@ msgstr ""
 msgid "Incorrect Stock Value Report"
 msgstr ""
 
-#: erpnext/stock/serial_batch_bundle.py:134
+#: erpnext/stock/serial_batch_bundle.py:135
 msgid "Incorrect Type of Transaction"
 msgstr ""
 
@@ -24831,8 +24817,8 @@ msgstr ""
 msgid "Insufficient Capacity"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3590
-#: erpnext/controllers/accounts_controller.py:3614
+#: erpnext/controllers/accounts_controller.py:3593
+#: erpnext/controllers/accounts_controller.py:3617
 msgid "Insufficient Permissions"
 msgstr ""
 
@@ -24840,12 +24826,12 @@ msgstr ""
 #: erpnext/stock/doctype/pick_list/pick_list.py:127
 #: erpnext/stock/doctype/pick_list/pick_list.py:975
 #: erpnext/stock/doctype/stock_entry/stock_entry.py:759
-#: erpnext/stock/serial_batch_bundle.py:989 erpnext/stock/stock_ledger.py:1559
-#: erpnext/stock/stock_ledger.py:2032
+#: erpnext/stock/serial_batch_bundle.py:1021 erpnext/stock/stock_ledger.py:1568
+#: erpnext/stock/stock_ledger.py:2040
 msgid "Insufficient Stock"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:2047
+#: erpnext/stock/stock_ledger.py:2055
 msgid "Insufficient Stock for Batch"
 msgstr ""
 
@@ -24983,11 +24969,11 @@ msgstr ""
 msgid "Internal Customer for company {0} already exists"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:728
+#: erpnext/controllers/accounts_controller.py:731
 msgid "Internal Sale or Delivery Reference missing."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:730
+#: erpnext/controllers/accounts_controller.py:733
 msgid "Internal Sales Reference Missing"
 msgstr ""
 
@@ -25018,7 +25004,7 @@ msgstr ""
 msgid "Internal Transfer"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:739
+#: erpnext/controllers/accounts_controller.py:742
 msgid "Internal Transfer Reference Missing"
 msgstr ""
 
@@ -25061,8 +25047,8 @@ msgstr ""
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:969
 #: erpnext/assets/doctype/asset_category/asset_category.py:69
 #: erpnext/assets/doctype/asset_category/asset_category.py:97
-#: erpnext/controllers/accounts_controller.py:2975
-#: erpnext/controllers/accounts_controller.py:2983
+#: erpnext/controllers/accounts_controller.py:2978
+#: erpnext/controllers/accounts_controller.py:2986
 msgid "Invalid Account"
 msgstr ""
 
@@ -25087,7 +25073,7 @@ msgstr ""
 msgid "Invalid Barcode. There is no Item attached to this barcode."
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2631
+#: erpnext/public/js/controllers/transaction.js:2657
 msgid "Invalid Blanket Order for the selected Customer and Item"
 msgstr ""
 
@@ -25101,7 +25087,7 @@ msgstr ""
 
 #: erpnext/assets/doctype/asset/asset.py:295
 #: erpnext/assets/doctype/asset/asset.py:302
-#: erpnext/controllers/accounts_controller.py:2998
+#: erpnext/controllers/accounts_controller.py:3001
 msgid "Invalid Cost Center"
 msgstr ""
 
@@ -25143,7 +25129,7 @@ msgstr ""
 msgid "Invalid Item"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1410
+#: erpnext/stock/doctype/item/item.py:1404
 msgid "Invalid Item Defaults"
 msgstr ""
 
@@ -25189,11 +25175,11 @@ msgstr ""
 msgid "Invalid Purchase Invoice"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3627
+#: erpnext/controllers/accounts_controller.py:3630
 msgid "Invalid Qty"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1277
+#: erpnext/controllers/accounts_controller.py:1280
 msgid "Invalid Quantity"
 msgstr ""
 
@@ -25210,7 +25196,7 @@ msgstr ""
 msgid "Invalid Schedule"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:243
+#: erpnext/controllers/selling_controller.py:251
 msgid "Invalid Selling Price"
 msgstr ""
 
@@ -25243,7 +25229,7 @@ msgstr ""
 msgid "Invalid lost reason {0}, please create a new lost reason"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:408
+#: erpnext/stock/doctype/item/item.py:411
 msgid "Invalid naming series (. missing) for {0}"
 msgstr ""
 
@@ -25283,7 +25269,7 @@ msgstr ""
 #. Name of a DocType
 #: erpnext/patches/v15_0/refactor_closing_stock_balance.py:43
 #: erpnext/stock/doctype/inventory_dimension/inventory_dimension.json
-#: erpnext/stock/doctype/inventory_dimension/inventory_dimension.py:180
+#: erpnext/stock/doctype/inventory_dimension/inventory_dimension.py:181
 msgid "Inventory Dimension"
 msgstr ""
 
@@ -25349,7 +25335,7 @@ msgstr ""
 msgid "Invoice Discounting"
 msgstr ""
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1114
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1116
 msgid "Invoice Grand Total"
 msgstr ""
 
@@ -25442,7 +25428,7 @@ msgstr ""
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:169
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:144
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1116
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1118
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:164
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:165
 msgid "Invoiced Amount"
@@ -25848,6 +25834,11 @@ msgstr ""
 msgid "Is Outward"
 msgstr ""
 
+#. Label of the is_packed (Check) field in DocType 'Serial and Batch Bundle'
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.json
+msgid "Is Packed"
+msgstr ""
+
 #. Label of the is_paid (Check) field in DocType 'Purchase Invoice'
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 msgid "Is Paid"
@@ -26130,11 +26121,11 @@ msgstr ""
 msgid "Issuing cannot be done to a location. Please enter employee to issue the Asset {0} to"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:565
+#: erpnext/stock/doctype/item/item.py:571
 msgid "It can take upto few hours for accurate stock values to be visible after merging items."
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2075
+#: erpnext/public/js/controllers/transaction.js:2101
 msgid "It is needed to fetch Item Details."
 msgstr ""
 
@@ -26184,7 +26175,7 @@ msgstr ""
 #: erpnext/buying/report/supplier_quotation_comparison/supplier_quotation_comparison.js:33
 #: erpnext/buying/report/supplier_quotation_comparison/supplier_quotation_comparison.py:204
 #: erpnext/buying/workspace/buying/buying.json
-#: erpnext/controllers/taxes_and_totals.py:1125
+#: erpnext/controllers/taxes_and_totals.py:1135
 #: erpnext/manufacturing/doctype/blanket_order/blanket_order.json
 #: erpnext/manufacturing/doctype/bom/bom.js:944
 #: erpnext/manufacturing/doctype/bom/bom.json
@@ -26462,7 +26453,7 @@ msgstr ""
 #: erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py:86
 #: erpnext/manufacturing/report/work_order_stock_report/work_order_stock_report.py:119
 #: erpnext/projects/doctype/timesheet/timesheet.js:213
-#: erpnext/public/js/controllers/transaction.js:2350
+#: erpnext/public/js/controllers/transaction.js:2376
 #: erpnext/public/js/stock_reservation.js:112
 #: erpnext/public/js/stock_reservation.js:317 erpnext/public/js/utils.js:500
 #: erpnext/public/js/utils.js:656
@@ -26900,7 +26891,7 @@ msgstr ""
 #: erpnext/manufacturing/report/production_planning_report/production_planning_report.py:359
 #: erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py:92
 #: erpnext/manufacturing/report/work_order_consumed_materials/work_order_consumed_materials.py:138
-#: erpnext/public/js/controllers/transaction.js:2356
+#: erpnext/public/js/controllers/transaction.js:2382
 #: erpnext/public/js/utils.js:746
 #: erpnext/selling/doctype/quotation_item/quotation_item.json
 #: erpnext/selling/doctype/sales_order_item/sales_order_item.json
@@ -27167,7 +27158,7 @@ msgstr ""
 msgid "Item Variant {0} already exists with same attributes"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:781
+#: erpnext/stock/doctype/item/item.py:772
 msgid "Item Variants updated"
 msgstr ""
 
@@ -27233,7 +27224,7 @@ msgstr ""
 msgid "Item for row {0} does not match Material Request"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:795
+#: erpnext/stock/doctype/item/item.py:789
 msgid "Item has variants."
 msgstr ""
 
@@ -27259,7 +27250,7 @@ msgstr ""
 msgid "Item operation"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3650
+#: erpnext/controllers/accounts_controller.py:3653
 msgid "Item qty can not be updated as raw materials are already processed."
 msgstr ""
 
@@ -27285,7 +27276,7 @@ msgstr ""
 msgid "Item valuation reposting in progress. Report might show incorrect item valuation."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:952
+#: erpnext/stock/doctype/item/item.py:946
 msgid "Item variant {0} exists with same attributes"
 msgstr ""
 
@@ -27298,8 +27289,7 @@ msgid "Item {0} cannot be ordered more than {1} against Blanket Order {2}."
 msgstr ""
 
 #: erpnext/assets/doctype/asset/asset.py:277
-#: erpnext/stock/doctype/item/item.py:630
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:167
+#: erpnext/stock/doctype/item/item.py:636
 msgid "Item {0} does not exist"
 msgstr ""
 
@@ -27311,7 +27301,7 @@ msgstr ""
 msgid "Item {0} does not exist."
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:752
+#: erpnext/controllers/selling_controller.py:760
 msgid "Item {0} entered multiple times."
 msgstr ""
 
@@ -27327,7 +27317,7 @@ msgstr ""
 msgid "Item {0} has no Serial No. Only serialized items can have delivery based on Serial No"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1126
+#: erpnext/stock/doctype/item/item.py:1120
 msgid "Item {0} has reached its end of life on {1}"
 msgstr ""
 
@@ -27339,11 +27329,11 @@ msgstr ""
 msgid "Item {0} is already reserved/delivered against Sales Order {1}."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1146
+#: erpnext/stock/doctype/item/item.py:1140
 msgid "Item {0} is cancelled"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1130
+#: erpnext/stock/doctype/item/item.py:1124
 msgid "Item {0} is disabled"
 msgstr ""
 
@@ -27351,7 +27341,7 @@ msgstr ""
 msgid "Item {0} is not a serialized Item"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1138
+#: erpnext/stock/doctype/item/item.py:1132
 msgid "Item {0} is not a stock Item"
 msgstr ""
 
@@ -27395,7 +27385,7 @@ msgstr ""
 msgid "Item {0}: {1} qty produced. "
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1429
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1423
 msgid "Item {} does not exist."
 msgstr ""
 
@@ -27535,7 +27525,7 @@ msgstr ""
 msgid "Items and Pricing"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3872
+#: erpnext/controllers/accounts_controller.py:3875
 msgid "Items cannot be updated as Subcontracting Order is created against the Purchase Order {0}."
 msgstr ""
 
@@ -28031,7 +28021,7 @@ msgstr ""
 
 #. Name of a DocType
 #. Label of a Link in the Stock Workspace
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:674
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:676
 #: erpnext/stock/doctype/landed_cost_voucher/landed_cost_voucher.json
 #: erpnext/stock/doctype/purchase_receipt/purchase_receipt.js:104
 #: erpnext/stock/workspace/stock/stock.json
@@ -28646,7 +28636,7 @@ msgstr ""
 msgid "Linked Location"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:999
+#: erpnext/stock/doctype/item/item.py:993
 msgid "Linked with submitted documents"
 msgstr ""
 
@@ -29385,7 +29375,7 @@ msgstr ""
 #: erpnext/manufacturing/doctype/bom/bom.py:261
 #: erpnext/manufacturing/doctype/bom_update_log/bom_update_log.py:71
 #: erpnext/public/js/controllers/accounts.js:249
-#: erpnext/public/js/controllers/transaction.js:2753
+#: erpnext/public/js/controllers/transaction.js:2779
 #: erpnext/public/js/utils/party.js:321
 #: erpnext/stock/doctype/delivery_note/delivery_note.js:164
 #: erpnext/stock/doctype/inventory_dimension/inventory_dimension.json
@@ -30241,7 +30231,7 @@ msgstr ""
 msgid "Maximum Value"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:212
+#: erpnext/controllers/selling_controller.py:220
 msgid "Maximum discount for Item {0} is {1}%"
 msgstr ""
 
@@ -30311,7 +30301,7 @@ msgstr ""
 msgid "Megawatt"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1878
+#: erpnext/stock/stock_ledger.py:1887
 msgid "Mention Valuation Rate in the Item master."
 msgstr ""
 
@@ -30706,11 +30696,11 @@ msgstr ""
 msgid "Miscellaneous Expenses"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:540
+#: erpnext/controllers/buying_controller.py:548
 msgid "Mismatch"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1430
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1424
 msgid "Missing"
 msgstr ""
 
@@ -31237,7 +31227,7 @@ msgstr ""
 msgid "Multiple Warehouse Accounts"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1129
+#: erpnext/controllers/accounts_controller.py:1132
 msgid "Multiple fiscal years exist for the date {0}. Please set company in Fiscal Year"
 msgstr ""
 
@@ -31388,7 +31378,7 @@ msgstr ""
 msgid "Naming Series and Price Defaults"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:90
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:91
 msgid "Naming Series is mandatory"
 msgstr ""
 
@@ -31427,15 +31417,15 @@ msgstr ""
 msgid "Needs Analysis"
 msgstr ""
 
-#: erpnext/stock/serial_batch_bundle.py:1277
+#: erpnext/stock/serial_batch_bundle.py:1309
 msgid "Negative Batch Quantity"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:610
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:606
 msgid "Negative Quantity is not allowed"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:615
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:611
 msgid "Negative Valuation Rate is not allowed"
 msgstr ""
 
@@ -31717,7 +31707,7 @@ msgstr ""
 msgid "Net Weight UOM"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1483
+#: erpnext/controllers/accounts_controller.py:1486
 msgid "Net total calculation precision loss"
 msgstr ""
 
@@ -32060,7 +32050,7 @@ msgstr ""
 #: erpnext/accounts/doctype/journal_entry/journal_entry.py:1539
 #: erpnext/accounts/doctype/journal_entry/journal_entry.py:1599
 #: erpnext/accounts/doctype/journal_entry/journal_entry.py:1613
-#: erpnext/stock/doctype/item/item.py:1371
+#: erpnext/stock/doctype/item/item.py:1365
 msgid "No Permission"
 msgstr ""
 
@@ -32082,7 +32072,7 @@ msgstr ""
 msgid "No Selection"
 msgstr ""
 
-#: erpnext/controllers/sales_and_purchase_return.py:919
+#: erpnext/controllers/sales_and_purchase_return.py:824
 msgid "No Serial / Batches are available for return"
 msgstr ""
 
@@ -32118,7 +32108,7 @@ msgstr ""
 msgid "No Work Orders were created"
 msgstr ""
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:785
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:794
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py:689
 msgid "No accounting entries for the following warehouses"
 msgstr ""
@@ -32307,7 +32297,7 @@ msgstr ""
 msgid "No reserved stock to unreserve."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:773
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:769
 msgid "No stock ledger entries were created. Please set the quantity or valuation rate for the items properly and try again."
 msgstr ""
 
@@ -32391,7 +32381,7 @@ msgstr ""
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:566
 #: erpnext/assets/doctype/asset/asset.js:612
 #: erpnext/assets/doctype/asset/asset.js:627
-#: erpnext/controllers/buying_controller.py:225
+#: erpnext/controllers/buying_controller.py:233
 #: erpnext/selling/doctype/product_bundle/product_bundle.py:72
 #: erpnext/setup/doctype/transaction_deletion_record/transaction_deletion_record.py:80
 msgid "Not Allowed"
@@ -32512,10 +32502,10 @@ msgstr ""
 #: erpnext/selling/doctype/customer/customer.py:129
 #: erpnext/selling/doctype/sales_order/sales_order.js:1168
 #: erpnext/stock/doctype/item/item.js:526
-#: erpnext/stock/doctype/item/item.py:567
+#: erpnext/stock/doctype/item/item.py:573
 #: erpnext/stock/doctype/item_price/item_price.json
 #: erpnext/stock/doctype/stock_entry/stock_entry.py:1374
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:972
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:968
 #: erpnext/templates/pages/timelog_info.html:43
 msgid "Note"
 msgstr ""
@@ -32524,7 +32514,7 @@ msgstr ""
 msgid "Note: Automatic log deletion only applies to logs of type <i>Update Cost</i>"
 msgstr ""
 
-#: erpnext/accounts/party.py:690
+#: erpnext/accounts/party.py:696
 msgid "Note: Due Date exceeds allowed {0} credit days by {1} day(s)"
 msgstr ""
 
@@ -32550,7 +32540,7 @@ msgstr ""
 msgid "Note: This Cost Center is a Group. Cannot make accounting entries against groups."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:621
+#: erpnext/stock/doctype/item/item.py:627
 msgid "Note: To merge the items, create a separate Stock Reconciliation for the old item {0}"
 msgstr ""
 
@@ -33313,7 +33303,7 @@ msgstr ""
 
 #. Label of the opening_stock (Float) field in DocType 'Item'
 #. Option for the 'Purpose' (Select) field in DocType 'Stock Reconciliation'
-#: erpnext/stock/doctype/item/item.json erpnext/stock/doctype/item/item.py:296
+#: erpnext/stock/doctype/item/item.json erpnext/stock/doctype/item/item.py:299
 #: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.json
 msgid "Opening Stock"
 msgstr ""
@@ -34033,7 +34023,7 @@ msgstr ""
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:149
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1123
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1125
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:167
 #: erpnext/accounts/report/purchase_register/purchase_register.py:289
 #: erpnext/accounts/report/sales_register/sales_register.py:319
@@ -34072,7 +34062,7 @@ msgstr ""
 msgid "Over Billing Allowance (%)"
 msgstr ""
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:1242
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:1251
 msgid "Over Billing Allowance exceeded for Purchase Receipt Item {0} ({1}) by {2}%"
 msgstr ""
 
@@ -34113,7 +34103,7 @@ msgstr ""
 msgid "Overbilling of {0} {1} ignored for item {2} because you have {3} role."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2013
+#: erpnext/controllers/accounts_controller.py:2016
 msgid "Overbilling of {} ignored because you have {} role."
 msgstr ""
 
@@ -34620,7 +34610,7 @@ msgstr ""
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:146
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1117
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1119
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:165
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:172
 #: erpnext/accounts/report/pos_register/pos_register.py:209
@@ -34853,7 +34843,7 @@ msgstr ""
 msgid "Parent Row No"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom_creator/bom_creator.py:495
+#: erpnext/manufacturing/doctype/bom_creator/bom_creator.py:496
 msgid "Parent Row No not found for {0}"
 msgstr ""
 
@@ -35082,7 +35072,7 @@ msgstr ""
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:142
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:159
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:57
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1054
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1056
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:67
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:147
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:228
@@ -35108,7 +35098,7 @@ msgstr ""
 
 #. Name of a DocType
 #: erpnext/accounts/doctype/party_account/party_account.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1065
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1067
 msgid "Party Account"
 msgstr ""
 
@@ -35135,7 +35125,7 @@ msgstr ""
 msgid "Party Account No. (Bank Statement)"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2278
+#: erpnext/controllers/accounts_controller.py:2281
 msgid "Party Account {0} currency ({1}) and document currency ({2}) should be same"
 msgstr ""
 
@@ -35151,6 +35141,11 @@ msgstr ""
 #: erpnext/accounts/doctype/bank_account/bank_account.json
 #: erpnext/accounts/doctype/payment_request/payment_request.json
 msgid "Party Details"
+msgstr ""
+
+#. Label of the party_full_name (Data) field in DocType 'Contract'
+#: erpnext/crm/doctype/contract/contract.json
+msgid "Party Full Name"
 msgstr ""
 
 #. Label of the bank_party_iban (Data) field in DocType 'Bank Transaction'
@@ -35236,7 +35231,7 @@ msgstr ""
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:84
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:54
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:44
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1048
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1050
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:54
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:141
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:219
@@ -35258,7 +35253,7 @@ msgstr ""
 msgid "Party Type"
 msgstr ""
 
-#: erpnext/accounts/party.py:819
+#: erpnext/accounts/party.py:825
 msgid "Party Type and Party can only be set for Receivable / Payable account<br><br>{0}"
 msgstr ""
 
@@ -35380,7 +35375,7 @@ msgid "Payable"
 msgstr ""
 
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:42
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1063
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1065
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:211
 #: erpnext/accounts/report/purchase_register/purchase_register.py:194
 #: erpnext/accounts/report/purchase_register/purchase_register.py:235
@@ -35546,7 +35541,7 @@ msgstr ""
 msgid "Payment Entry is already created"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1434
+#: erpnext/controllers/accounts_controller.py:1437
 msgid "Payment Entry {0} is linked against Order {1}, check if it should be pulled as advance in this invoice."
 msgstr ""
 
@@ -35828,7 +35823,7 @@ msgstr ""
 #: erpnext/accounts/doctype/payment_schedule/payment_schedule.json
 #: erpnext/accounts/doctype/payment_term/payment_term.json
 #: erpnext/accounts/doctype/payment_terms_template_detail/payment_terms_template_detail.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1113
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1115
 #: erpnext/accounts/report/gross_profit/gross_profit.py:412
 #: erpnext/accounts/workspace/accounting/accounting.json
 #: erpnext/selling/report/payment_terms_status_for_sales_order/payment_terms_status_for_sales_order.py:30
@@ -36892,7 +36887,7 @@ msgstr ""
 msgid "Please create a new Accounting Dimension if required."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:729
+#: erpnext/controllers/accounts_controller.py:732
 msgid "Please create purchase from internal sale or delivery document itself"
 msgstr ""
 
@@ -36900,7 +36895,7 @@ msgstr ""
 msgid "Please create purchase receipt or purchase invoice for the item {0}"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:649
+#: erpnext/stock/doctype/item/item.py:655
 msgid "Please delete Product Bundle {0}, before merging {1} into {2}"
 msgstr ""
 
@@ -36942,7 +36937,7 @@ msgstr ""
 msgid "Please enable {0} in the {1}."
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:754
+#: erpnext/controllers/selling_controller.py:762
 msgid "Please enable {} in {} to allow same item in multiple rows"
 msgstr ""
 
@@ -36975,7 +36970,7 @@ msgstr ""
 msgid "Please enter Approving Role or Approving User"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:939
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:935
 msgid "Please enter Cost Center"
 msgstr ""
 
@@ -36987,7 +36982,7 @@ msgstr ""
 msgid "Please enter Employee Id of this sales person"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:948
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:944
 msgid "Please enter Expense Account"
 msgstr ""
 
@@ -36996,7 +36991,7 @@ msgstr ""
 msgid "Please enter Item Code to get Batch Number"
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2503
+#: erpnext/public/js/controllers/transaction.js:2529
 msgid "Please enter Item Code to get batch no"
 msgstr ""
 
@@ -37061,7 +37056,7 @@ msgstr ""
 msgid "Please enter company name first"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2764
+#: erpnext/controllers/accounts_controller.py:2767
 msgid "Please enter default currency in Company Master"
 msgstr ""
 
@@ -37097,7 +37092,7 @@ msgstr ""
 msgid "Please enter the phone number first"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:1007
+#: erpnext/controllers/buying_controller.py:1015
 msgid "Please enter the {schedule_date}."
 msgstr ""
 
@@ -37199,7 +37194,7 @@ msgstr ""
 msgid "Please select <b>Template Type</b> to download template"
 msgstr ""
 
-#: erpnext/controllers/taxes_and_totals.py:721
+#: erpnext/controllers/taxes_and_totals.py:731
 #: erpnext/public/js/controllers/taxes_and_totals.js:721
 msgid "Please select Apply Discount On"
 msgstr ""
@@ -37212,7 +37207,7 @@ msgstr ""
 msgid "Please select BOM for Item in Row {0}"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:467
+#: erpnext/controllers/buying_controller.py:475
 msgid "Please select BOM in BOM field for Item {item_code}."
 msgstr "Выберите спецификацию в поле спецификации для продукта {item_code}."
 
@@ -37294,7 +37289,7 @@ msgstr ""
 msgid "Please select Qty against item {0}"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:320
+#: erpnext/stock/doctype/item/item.py:323
 msgid "Please select Sample Retention Warehouse in Stock Settings first"
 msgstr ""
 
@@ -37310,7 +37305,7 @@ msgstr ""
 msgid "Please select Subcontracting Order instead of Purchase Order {0}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2613
+#: erpnext/controllers/accounts_controller.py:2616
 msgid "Please select Unrealized Profit / Loss account or add default Unrealized Profit / Loss account account for company {0}"
 msgstr ""
 
@@ -37326,7 +37321,7 @@ msgstr ""
 #: erpnext/manufacturing/doctype/bom/bom.js:603
 #: erpnext/manufacturing/doctype/bom/bom.py:261
 #: erpnext/public/js/controllers/accounts.js:249
-#: erpnext/public/js/controllers/transaction.js:2753
+#: erpnext/public/js/controllers/transaction.js:2779
 msgid "Please select a Company first."
 msgstr ""
 
@@ -37484,7 +37479,7 @@ msgstr ""
 msgid "Please select {0} first"
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:77
+#: erpnext/public/js/controllers/transaction.js:100
 msgid "Please set 'Apply Additional Discount On'"
 msgstr ""
 
@@ -37669,7 +37664,7 @@ msgstr ""
 msgid "Please set filters"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2194
+#: erpnext/controllers/accounts_controller.py:2197
 msgid "Please set one of the following:"
 msgstr ""
 
@@ -37677,7 +37672,7 @@ msgstr ""
 msgid "Please set opening number of booked depreciations"
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2205
+#: erpnext/public/js/controllers/transaction.js:2231
 msgid "Please set recurring after saving"
 msgstr ""
 
@@ -37748,7 +37743,7 @@ msgstr ""
 msgid "Please share this email with your support team so that they can find and fix the issue."
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2073
+#: erpnext/public/js/controllers/transaction.js:2099
 msgid "Please specify"
 msgstr ""
 
@@ -37763,7 +37758,7 @@ msgid "Please specify Company to proceed"
 msgstr ""
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1472
-#: erpnext/controllers/accounts_controller.py:2957
+#: erpnext/controllers/accounts_controller.py:2960
 #: erpnext/public/js/controllers/accounts.js:97
 msgid "Please specify a valid Row ID for row {0} in table {1}"
 msgstr ""
@@ -37776,7 +37771,7 @@ msgstr ""
 msgid "Please specify at least one attribute in the Attributes table"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:605
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:601
 msgid "Please specify either Quantity or Valuation Rate or both"
 msgstr ""
 
@@ -37957,7 +37952,7 @@ msgstr ""
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:16
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:15
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:18
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1046
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1048
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:15
 #: erpnext/accounts/report/bank_clearance_summary/bank_clearance_summary.py:35
 #: erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.html:7
@@ -40138,7 +40133,7 @@ msgstr ""
 #: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.js:48
 #: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:203
 #: erpnext/buying/workspace/buying/buying.json
-#: erpnext/controllers/buying_controller.py:739
+#: erpnext/controllers/buying_controller.py:747
 #: erpnext/crm/doctype/contract/contract.json
 #: erpnext/manufacturing/doctype/blanket_order/blanket_order.js:54
 #: erpnext/manufacturing/doctype/production_plan_sub_assembly_item/production_plan_sub_assembly_item.json
@@ -40277,7 +40272,7 @@ msgstr ""
 msgid "Purchase Orders to Receive"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1833
+#: erpnext/controllers/accounts_controller.py:1836
 msgid "Purchase Orders {0} are un-linked"
 msgstr ""
 
@@ -40301,8 +40296,8 @@ msgstr ""
 #. Label of a Link in the Stock Workspace
 #. Label of a shortcut in the Stock Workspace
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:171
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:650
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:660
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:652
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:662
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice_list.js:49
 #: erpnext/accounts/doctype/purchase_invoice_item/purchase_invoice_item.json
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:246
@@ -41037,7 +41032,7 @@ msgstr ""
 msgid "Quality Inspection Template Name"
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:334
+#: erpnext/public/js/controllers/transaction.js:360
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:165
 msgid "Quality Inspection(s)"
 msgstr ""
@@ -42221,7 +42216,7 @@ msgid "Receivable / Payable Account"
 msgstr ""
 
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:71
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1061
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1063
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py:243
 #: erpnext/accounts/report/sales_register/sales_register.py:217
 #: erpnext/accounts/report/sales_register/sales_register.py:271
@@ -42703,7 +42698,7 @@ msgstr ""
 msgid "Reference Date"
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2311
+#: erpnext/public/js/controllers/transaction.js:2337
 msgid "Reference Date for Early Payment Discount"
 msgstr ""
 
@@ -43027,7 +43022,7 @@ msgstr ""
 msgid "Rejected"
 msgstr ""
 
-#: erpnext/stock/doctype/inventory_dimension/inventory_dimension.py:202
+#: erpnext/stock/doctype/inventory_dimension/inventory_dimension.py:203
 msgid "Rejected "
 msgstr "Отклонено "
 
@@ -43131,7 +43126,7 @@ msgstr ""
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:187
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:156
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1135
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1137
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:178
 msgid "Remaining Balance"
 msgstr ""
@@ -43184,7 +43179,7 @@ msgstr ""
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:159
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:198
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:269
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1167
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1169
 #: erpnext/accounts/report/general_ledger/general_ledger.html:84
 #: erpnext/accounts/report/general_ledger/general_ledger.html:110
 #: erpnext/accounts/report/general_ledger/general_ledger.py:742
@@ -43933,7 +43928,7 @@ msgstr ""
 msgid "Reserved Quantity for Production"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:2147
+#: erpnext/stock/stock_ledger.py:2155
 msgid "Reserved Serial No."
 msgstr ""
 
@@ -43949,11 +43944,11 @@ msgstr ""
 #: erpnext/stock/doctype/pick_list/pick_list.js:153
 #: erpnext/stock/report/reserved_stock/reserved_stock.json
 #: erpnext/stock/report/stock_balance/stock_balance.py:499
-#: erpnext/stock/stock_ledger.py:2131
+#: erpnext/stock/stock_ledger.py:2139
 msgid "Reserved Stock"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:2177
+#: erpnext/stock/stock_ledger.py:2185
 msgid "Reserved Stock for Batch"
 msgstr ""
 
@@ -43965,7 +43960,7 @@ msgstr ""
 msgid "Reserved Stock for Sub-assembly"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:476
+#: erpnext/controllers/buying_controller.py:484
 msgid "Reserved Warehouse is mandatory for the Item {item_code} in Raw Materials supplied."
 msgstr ""
 
@@ -44779,7 +44774,7 @@ msgstr ""
 msgid "Routing Name"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:667
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:663
 msgid "Row #"
 msgstr ""
 
@@ -44817,7 +44812,7 @@ msgstr ""
 msgid "Row #{0} (Payment Table): Amount must be positive"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:495
+#: erpnext/stock/doctype/item/item.py:498
 msgid "Row #{0}: A reorder entry already exists for warehouse {1} with reorder type {2}."
 msgstr ""
 
@@ -44838,7 +44833,7 @@ msgstr ""
 msgid "Row #{0}: Accepted Warehouse is mandatory for the accepted Item {1}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1117
+#: erpnext/controllers/accounts_controller.py:1120
 msgid "Row #{0}: Account {1} does not belong to company {2}"
 msgstr ""
 
@@ -44879,27 +44874,27 @@ msgstr ""
 msgid "Row #{0}: Cannot allocate more than {1} against payment term {2}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3524
+#: erpnext/controllers/accounts_controller.py:3527
 msgid "Row #{0}: Cannot delete item {1} which has already been billed."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3498
+#: erpnext/controllers/accounts_controller.py:3501
 msgid "Row #{0}: Cannot delete item {1} which has already been delivered"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3517
+#: erpnext/controllers/accounts_controller.py:3520
 msgid "Row #{0}: Cannot delete item {1} which has already been received"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3504
+#: erpnext/controllers/accounts_controller.py:3507
 msgid "Row #{0}: Cannot delete item {1} which has work order assigned to it."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3510
+#: erpnext/controllers/accounts_controller.py:3513
 msgid "Row #{0}: Cannot delete item {1} which is assigned to customer's purchase order."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3765
+#: erpnext/controllers/accounts_controller.py:3768
 msgid "Row #{0}: Cannot set Rate if the billed amount is greater than the amount for Item {1}."
 msgstr ""
 
@@ -45019,7 +45014,7 @@ msgstr ""
 msgid "Row #{0}: Item {1} has been picked, please reserve stock from the Pick List."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:729
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:725
 msgid "Row #{0}: Item {1} is not a Serialized/Batched Item. It cannot have a Serial No/Batch No against it."
 msgstr ""
 
@@ -45075,7 +45070,7 @@ msgstr ""
 msgid "Row #{0}: Please select the Sub Assembly Warehouse"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:502
+#: erpnext/stock/doctype/item/item.py:505
 msgid "Row #{0}: Please set reorder quantity"
 msgstr ""
 
@@ -45108,8 +45103,8 @@ msgstr ""
 msgid "Row #{0}: Quality Inspection {1} was rejected for item {2}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1274
-#: erpnext/controllers/accounts_controller.py:3624
+#: erpnext/controllers/accounts_controller.py:1277
+#: erpnext/controllers/accounts_controller.py:3627
 msgid "Row #{0}: Quantity for Item {1} cannot be zero."
 msgstr ""
 
@@ -45146,7 +45141,7 @@ msgstr ""
 msgid "Row #{0}: Scrap Item Qty cannot be zero"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:230
+#: erpnext/controllers/selling_controller.py:238
 msgid "Row #{0}: Selling rate for item {1} is lower than its {2}.\n"
 "\t\t\t\t\tSelling {3} should be atleast {4}.<br><br>Alternatively,\n"
 "\t\t\t\t\tyou can disable selling price validation in {5} to bypass\n"
@@ -45230,7 +45225,7 @@ msgstr ""
 msgid "Row #{0}: The batch {1} has already expired."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:511
+#: erpnext/stock/doctype/item/item.py:514
 msgid "Row #{0}: The warehouse {1} is not a child warehouse of a group warehouse {2}"
 msgstr ""
 
@@ -45270,39 +45265,39 @@ msgstr ""
 msgid "Row #{1}: Warehouse is mandatory for stock Item {0}"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:259
+#: erpnext/controllers/buying_controller.py:267
 msgid "Row #{idx}: Cannot select Supplier Warehouse while suppling raw materials to subcontractor."
 msgstr "Строка #{idx}: невозможно выбрать склад поставщика при подаче сырья субподрядчику."
 
-#: erpnext/controllers/buying_controller.py:406
+#: erpnext/controllers/buying_controller.py:414
 msgid "Row #{idx}: Item rate has been updated as per valuation rate since its an internal stock transfer."
 msgstr "Строка #{idx}: Стоимость товара была обновлена в соответствии с оценочной ставкой, поскольку это внутреннее перемещение запасов."
 
-#: erpnext/controllers/buying_controller.py:881
+#: erpnext/controllers/buying_controller.py:889
 msgid "Row #{idx}: Please enter a location for the asset item {item_code}."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:537
+#: erpnext/controllers/buying_controller.py:545
 msgid "Row #{idx}: Received Qty must be equal to Accepted + Rejected Qty for Item {item_code}."
 msgstr "Строка #{idx}: Полученное количество должно быть равно принятому + отклоненному количеству для товара {item_code}."
 
-#: erpnext/controllers/buying_controller.py:550
+#: erpnext/controllers/buying_controller.py:558
 msgid "Row #{idx}: {field_label} can not be negative for item {item_code}."
 msgstr "Строка #{idx}: {field_label} не может быть отрицательным для {item_code}."
 
-#: erpnext/controllers/buying_controller.py:496
+#: erpnext/controllers/buying_controller.py:504
 msgid "Row #{idx}: {field_label} is mandatory."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:518
+#: erpnext/controllers/buying_controller.py:526
 msgid "Row #{idx}: {field_label} is not allowed in Purchase Return."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:250
+#: erpnext/controllers/buying_controller.py:258
 msgid "Row #{idx}: {from_warehouse_field} and {to_warehouse_field} cannot be same."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:999
+#: erpnext/controllers/buying_controller.py:1007
 msgid "Row #{idx}: {schedule_date} cannot be before {transaction_date}."
 msgstr ""
 
@@ -45367,7 +45362,7 @@ msgstr ""
 msgid "Row #{}: {} {} does not exist."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1403
+#: erpnext/stock/doctype/item/item.py:1397
 msgid "Row #{}: {} {} doesn't belong to Company {}. Please select valid {}."
 msgstr ""
 
@@ -45439,11 +45434,11 @@ msgstr ""
 msgid "Row {0}: Both Debit and Credit values cannot be zero"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:222
+#: erpnext/controllers/selling_controller.py:230
 msgid "Row {0}: Conversion Factor is mandatory"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2995
+#: erpnext/controllers/accounts_controller.py:2998
 msgid "Row {0}: Cost Center {1} does not belong to Company {2}"
 msgstr ""
 
@@ -45463,11 +45458,11 @@ msgstr ""
 msgid "Row {0}: Debit entry can not be linked with a {1}"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:776
+#: erpnext/controllers/selling_controller.py:784
 msgid "Row {0}: Delivery Warehouse ({1}) and Customer Warehouse ({2}) can not be same"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2529
+#: erpnext/controllers/accounts_controller.py:2532
 msgid "Row {0}: Due Date in the Payment Terms table cannot be before Posting Date"
 msgstr ""
 
@@ -45476,7 +45471,7 @@ msgid "Row {0}: Either Delivery Note Item or Packed Item reference is mandatory.
 msgstr ""
 
 #: erpnext/accounts/doctype/journal_entry/journal_entry.py:1010
-#: erpnext/controllers/taxes_and_totals.py:1205
+#: erpnext/controllers/taxes_and_totals.py:1215
 msgid "Row {0}: Exchange Rate is mandatory"
 msgstr ""
 
@@ -45525,11 +45520,11 @@ msgstr ""
 msgid "Row {0}: Invalid reference {1}"
 msgstr ""
 
-#: erpnext/controllers/taxes_and_totals.py:142
+#: erpnext/controllers/taxes_and_totals.py:143
 msgid "Row {0}: Item Tax template updated as per validity and rate applied"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:541
+#: erpnext/controllers/selling_controller.py:549
 msgid "Row {0}: Item rate has been updated as per valuation rate since its an internal stock transfer"
 msgstr ""
 
@@ -45649,7 +45644,7 @@ msgstr ""
 msgid "Row {0}: The item {1}, quantity must be positive number"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2972
+#: erpnext/controllers/accounts_controller.py:2975
 msgid "Row {0}: The {3} Account {1} does not belong to the company {2}"
 msgstr ""
 
@@ -45666,7 +45661,7 @@ msgstr ""
 msgid "Row {0}: Workstation or Workstation Type is mandatory for an operation {1}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1011
+#: erpnext/controllers/accounts_controller.py:1014
 msgid "Row {0}: user has not applied the rule {1} on the item {2}"
 msgstr ""
 
@@ -45678,7 +45673,7 @@ msgstr ""
 msgid "Row {0}: {1} must be greater than 0"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:706
+#: erpnext/controllers/accounts_controller.py:709
 msgid "Row {0}: {1} {2} cannot be same as {3} (Party Account) {4}"
 msgstr ""
 
@@ -45694,7 +45689,7 @@ msgstr ""
 msgid "Row {1}: Quantity ({0}) cannot be a fraction. To allow this, disable '{2}' in UOM {3}."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:863
+#: erpnext/controllers/buying_controller.py:871
 msgid "Row {idx}: Asset Naming Series is mandatory for the auto creation of assets for item {item_code}."
 msgstr ""
 
@@ -45720,7 +45715,7 @@ msgstr ""
 msgid "Rows with Same Account heads will be merged on Ledger"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2539
+#: erpnext/controllers/accounts_controller.py:2542
 msgid "Rows with duplicate due dates in other rows were found: {0}"
 msgstr ""
 
@@ -45790,7 +45785,7 @@ msgstr ""
 msgid "SLA Paused On"
 msgstr ""
 
-#: erpnext/public/js/utils.js:1167
+#: erpnext/public/js/utils.js:1163
 msgid "SLA is on hold since {0}"
 msgstr ""
 
@@ -46191,7 +46186,7 @@ msgstr ""
 #: erpnext/accounts/report/sales_register/sales_register.py:238
 #: erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
 #: erpnext/buying/doctype/supplier_quotation_item/supplier_quotation_item.json
-#: erpnext/controllers/selling_controller.py:462
+#: erpnext/controllers/selling_controller.py:470
 #: erpnext/crm/doctype/contract/contract.json
 #: erpnext/maintenance/doctype/maintenance_schedule/maintenance_schedule.js:65
 #: erpnext/maintenance/doctype/maintenance_schedule_item/maintenance_schedule_item.json
@@ -46317,7 +46312,7 @@ msgstr ""
 msgid "Sales Order {0} is not valid"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:443
+#: erpnext/controllers/selling_controller.py:451
 #: erpnext/manufacturing/doctype/work_order/work_order.py:301
 msgid "Sales Order {0} is {1}"
 msgstr ""
@@ -46368,7 +46363,7 @@ msgstr ""
 #: erpnext/accounts/doctype/promotional_scheme/promotional_scheme.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:122
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1156
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1158
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:99
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:194
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:74
@@ -46466,7 +46461,7 @@ msgstr ""
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:156
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:137
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:128
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1153
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1155
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:105
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:191
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:80
@@ -46486,7 +46481,7 @@ msgstr ""
 msgid "Sales Person"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:204
+#: erpnext/controllers/selling_controller.py:212
 msgid "Sales Person <b>{0}</b> is disabled."
 msgstr ""
 
@@ -46767,7 +46762,7 @@ msgstr ""
 
 #. Label of the sample_size (Float) field in DocType 'Quality Inspection'
 #: erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py:93
-#: erpnext/public/js/controllers/transaction.js:2369
+#: erpnext/public/js/controllers/transaction.js:2395
 #: erpnext/stock/doctype/quality_inspection/quality_inspection.json
 msgid "Sample Size"
 msgstr ""
@@ -47305,7 +47300,7 @@ msgstr ""
 msgid "Select Items based on Delivery Date"
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2405
+#: erpnext/public/js/controllers/transaction.js:2431
 msgid "Select Items for Quality Inspection"
 msgstr ""
 
@@ -47446,7 +47441,7 @@ msgstr ""
 msgid "Select company name first."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2785
+#: erpnext/controllers/accounts_controller.py:2788
 msgid "Select finance book for the item {0} at row {1}"
 msgstr ""
 
@@ -47659,7 +47654,7 @@ msgid "Send Now"
 msgstr ""
 
 #. Label of the send_sms (Button) field in DocType 'SMS Center'
-#: erpnext/public/js/controllers/transaction.js:517
+#: erpnext/public/js/controllers/transaction.js:543
 #: erpnext/selling/doctype/sms_center/sms_center.json
 msgid "Send SMS"
 msgstr ""
@@ -47817,7 +47812,7 @@ msgstr ""
 #: erpnext/manufacturing/doctype/job_card/job_card.json
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.js:74
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.py:114
-#: erpnext/public/js/controllers/transaction.js:2382
+#: erpnext/public/js/controllers/transaction.js:2408
 #: erpnext/public/js/utils/serial_no_batch_selector.js:421
 #: erpnext/selling/doctype/installation_note_item/installation_note_item.json
 #: erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
@@ -47866,7 +47861,7 @@ msgstr ""
 msgid "Serial No Range"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1894
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1895
 msgid "Serial No Reserved"
 msgstr ""
 
@@ -47906,7 +47901,7 @@ msgstr ""
 msgid "Serial No and Batch Selector cannot be use when Use Serial / Batch Fields is enabled."
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:859
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:860
 msgid "Serial No is mandatory"
 msgstr ""
 
@@ -47935,7 +47930,7 @@ msgstr ""
 msgid "Serial No {0} does not exist"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2623
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2624
 msgid "Serial No {0} does not exists"
 msgstr ""
 
@@ -47943,7 +47938,7 @@ msgstr ""
 msgid "Serial No {0} is already added"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:357
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:358
 msgid "Serial No {0} is not present in the {1} {2}, hence you can't return it against the {1} {2}"
 msgstr ""
 
@@ -47980,11 +47975,11 @@ msgstr ""
 msgid "Serial Nos and Batches"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1370
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1371
 msgid "Serial Nos are created successfully"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:2137
+#: erpnext/stock/stock_ledger.py:2145
 msgid "Serial Nos are reserved in Stock Reservation Entries, you need to unreserve them before proceeding."
 msgstr ""
 
@@ -48058,11 +48053,11 @@ msgstr ""
 msgid "Serial and Batch Bundle"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1598
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1599
 msgid "Serial and Batch Bundle created"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1664
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1665
 msgid "Serial and Batch Bundle updated"
 msgstr ""
 
@@ -48414,12 +48409,12 @@ msgid "Service Stop Date"
 msgstr ""
 
 #: erpnext/accounts/deferred_revenue.py:44
-#: erpnext/public/js/controllers/transaction.js:1420
+#: erpnext/public/js/controllers/transaction.js:1446
 msgid "Service Stop Date cannot be after Service End Date"
 msgstr ""
 
 #: erpnext/accounts/deferred_revenue.py:41
-#: erpnext/public/js/controllers/transaction.js:1417
+#: erpnext/public/js/controllers/transaction.js:1443
 msgid "Service Stop Date cannot be before Service Start Date"
 msgstr ""
 
@@ -49854,7 +49849,7 @@ msgstr ""
 
 #: erpnext/setup/setup_wizard/operations/defaults_setup.py:70
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:463
-#: erpnext/stock/doctype/item/item.py:245
+#: erpnext/stock/doctype/item/item.py:248
 msgid "Standard Selling"
 msgstr ""
 
@@ -50684,7 +50679,7 @@ msgstr ""
 #. Option for the 'Purpose' (Select) field in DocType 'Stock Reconciliation'
 #. Label of a Link in the Stock Workspace
 #: erpnext/setup/workspace/home/home.json
-#: erpnext/stock/doctype/item/item.py:612
+#: erpnext/stock/doctype/item/item.py:618
 #: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.json
 #: erpnext/stock/workspace/stock/stock.json
 msgid "Stock Reconciliation"
@@ -50695,7 +50690,7 @@ msgstr ""
 msgid "Stock Reconciliation Item"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:612
+#: erpnext/stock/doctype/item/item.py:618
 msgid "Stock Reconciliations"
 msgstr ""
 
@@ -50730,7 +50725,7 @@ msgstr ""
 #: erpnext/stock/doctype/pick_list/pick_list.js:150
 #: erpnext/stock/doctype/pick_list/pick_list.js:155
 #: erpnext/stock/doctype/stock_entry/stock_entry_dashboard.py:25
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:706
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:702
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:575
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:1138
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:1398
@@ -51130,7 +51125,7 @@ msgstr ""
 #: erpnext/setup/doctype/company/company.py:287
 #: erpnext/setup/setup_wizard/operations/defaults_setup.py:33
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:502
-#: erpnext/stock/doctype/item/item.py:282
+#: erpnext/stock/doctype/item/item.py:285
 msgid "Stores"
 msgstr ""
 
@@ -51665,7 +51660,7 @@ msgstr ""
 msgid "Successfully Set Supplier"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:339
+#: erpnext/stock/doctype/item/item.py:342
 msgid "Successfully changed Stock UOM, please redefine conversion factors for new UOM."
 msgstr ""
 
@@ -51967,7 +51962,7 @@ msgstr ""
 #: erpnext/accounts/doctype/tax_rule/tax_rule.json
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:111
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:87
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1160
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1162
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:198
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:237
 #: erpnext/accounts/report/purchase_register/purchase_register.js:27
@@ -52067,7 +52062,7 @@ msgstr ""
 #. Label of the supplier_name (Data) field in DocType 'Purchase Receipt'
 #. Label of the supplier_name (Data) field in DocType 'Stock Entry'
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1077
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1079
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:156
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:198
 #: erpnext/accounts/report/purchase_register/purchase_register.py:177
@@ -52551,7 +52546,7 @@ msgstr ""
 msgid "System will fetch all the entries if limit value is zero."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1975
+#: erpnext/controllers/accounts_controller.py:1978
 msgid "System will not check over billing since amount for Item {0} in {1} is zero"
 msgstr ""
 
@@ -52810,7 +52805,7 @@ msgstr ""
 msgid "Target Warehouse is required before Submit"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:782
+#: erpnext/controllers/selling_controller.py:790
 msgid "Target Warehouse is set for some items but the customer is not an internal customer."
 msgstr ""
 
@@ -53049,7 +53044,7 @@ msgstr ""
 msgid "Tax Category"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:194
+#: erpnext/controllers/buying_controller.py:202
 msgid "Tax Category has been changed to \"Total\" because all the Items are non-stock items"
 msgstr ""
 
@@ -53254,7 +53249,7 @@ msgstr ""
 #. Label of the taxable_amount (Currency) field in DocType 'Tax Withheld
 #. Vouchers'
 #: erpnext/accounts/doctype/tax_withheld_vouchers/tax_withheld_vouchers.json
-#: erpnext/controllers/taxes_and_totals.py:1125
+#: erpnext/controllers/taxes_and_totals.py:1135
 msgid "Taxable Amount"
 msgstr ""
 
@@ -53393,7 +53388,7 @@ msgstr ""
 msgid "Taxes and Charges Deducted (Company Currency)"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:352
+#: erpnext/stock/doctype/item/item.py:355
 msgid "Taxes row #{0}: {1} cannot be smaller than {2}"
 msgstr ""
 
@@ -53679,7 +53674,7 @@ msgstr ""
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/territory_item/territory_item.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:134
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1144
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1146
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:93
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:182
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:68
@@ -53783,7 +53778,7 @@ msgstr ""
 msgid "The BOM which will be replaced"
 msgstr ""
 
-#: erpnext/stock/serial_batch_bundle.py:1274
+#: erpnext/stock/serial_batch_bundle.py:1306
 msgid "The Batch {0} has negative quantity {1} in warehouse {2}. Please correct the quantity."
 msgstr ""
 
@@ -53835,7 +53830,7 @@ msgstr ""
 msgid "The Serial No at Row #{0}: {1} is not available in warehouse {2}."
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1891
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1892
 msgid "The Serial No {0} is reserved against the {1} {2} and cannot be used for any other transaction."
 msgstr ""
 
@@ -53918,7 +53913,7 @@ msgstr ""
 msgid "The following batches are expired, please restock them: <br> {0}"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:849
+#: erpnext/stock/doctype/item/item.py:843
 msgid "The following deleted attributes exist in Variants but not in the Template. You can either delete the Variants or keep the attribute(s) in template."
 msgstr ""
 
@@ -53943,15 +53938,15 @@ msgstr ""
 msgid "The holiday on {0} is not between From Date and To Date"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:1066
+#: erpnext/controllers/buying_controller.py:1074
 msgid "The item {item} is not marked as {type_of} item. You can enable it as {type_of} item from its Item master."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:614
+#: erpnext/stock/doctype/item/item.py:620
 msgid "The items {0} and {1} are present in the following {2} :"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:1059
+#: erpnext/controllers/buying_controller.py:1067
 msgid "The items {items} are not marked as {type_of} item. You can enable them as {type_of} item from their Item masters."
 msgstr ""
 
@@ -54053,8 +54048,8 @@ msgstr ""
 msgid "The seller and the buyer cannot be the same"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:142
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:154
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:143
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:155
 msgid "The serial and batch bundle {0} not linked to {1} {2}"
 msgstr ""
 
@@ -54078,7 +54073,7 @@ msgstr ""
 msgid "The stock for the item {0} in the {1} warehouse was negative on the {2}. You should create a positive entry {3} before the date {4} and time {5} to post the correct valuation rate. For more details, please read the <a href='https://docs.erpnext.com/docs/user/manual/en/stock-adjustment-cogs-with-negative-stock'>documentation<a>."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:700
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:696
 msgid "The stock has been reserved for the following Items and Warehouses, un-reserve the same to {0} the Stock Reconciliation: <br /><br /> {1}"
 msgstr ""
 
@@ -54091,11 +54086,11 @@ msgstr ""
 msgid "The task has been enqueued as a background job."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:994
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:990
 msgid "The task has been enqueued as a background job. In case there is any issue on processing in background, the system will add a comment about the error on this Stock Reconciliation and revert to the Draft stage"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1005
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1001
 msgid "The task has been enqueued as a background job. In case there is any issue on processing in background, the system will add a comment about the error on this Stock Reconciliation and revert to the Submitted stage"
 msgstr ""
 
@@ -54145,7 +54140,7 @@ msgstr ""
 msgid "The {0} ({1}) must be equal to {2} ({3})"
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2790
+#: erpnext/public/js/controllers/transaction.js:2816
 msgid "The {0} contains Unit Price Items."
 msgstr ""
 
@@ -54193,7 +54188,7 @@ msgstr ""
 msgid "There can be multiple tiered collection factor based on the total spent. But the conversion factor for redemption will always be same for all the tier."
 msgstr ""
 
-#: erpnext/accounts/party.py:580
+#: erpnext/accounts/party.py:586
 msgid "There can only be 1 Account per Company in {0} {1}"
 msgstr ""
 
@@ -54479,7 +54474,7 @@ msgstr ""
 msgid "This will restrict user access to other employee records"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:783
+#: erpnext/controllers/selling_controller.py:791
 msgid "This {} will be treated as material transfer."
 msgstr ""
 
@@ -55193,11 +55188,11 @@ msgid "To include sub-assembly costs and scrap items in Finished Goods on a work
 msgstr ""
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:2337
-#: erpnext/controllers/accounts_controller.py:3005
+#: erpnext/controllers/accounts_controller.py:3008
 msgid "To include tax in row {0} in Item rate, taxes in rows {1} must also be included"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:636
+#: erpnext/stock/doctype/item/item.py:642
 msgid "To merge, following properties must be same for both items"
 msgstr ""
 
@@ -55817,7 +55812,7 @@ msgstr ""
 msgid "Total Paid Amount"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2591
+#: erpnext/controllers/accounts_controller.py:2594
 msgid "Total Payment Amount in Payment Schedule must be equal to Grand / Rounded Total"
 msgstr ""
 
@@ -56102,15 +56097,15 @@ msgstr ""
 msgid "Total Working Hours"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2138
+#: erpnext/controllers/accounts_controller.py:2141
 msgid "Total advance ({0}) against Order {1} cannot be greater than the Grand Total ({2})"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:190
+#: erpnext/controllers/selling_controller.py:198
 msgid "Total allocated percentage for sales team should be 100"
 msgstr ""
 
-#: erpnext/selling/doctype/customer/customer.py:162
+#: erpnext/selling/doctype/customer/customer.py:161
 msgid "Total contribution percentage should be equal to 100"
 msgstr ""
 
@@ -56995,7 +56990,7 @@ msgstr ""
 msgid "Unit of Measure (UOM)"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:384
+#: erpnext/stock/doctype/item/item.py:387
 msgid "Unit of Measure {0} has been entered more than once in Conversion Factor Table"
 msgstr ""
 
@@ -57437,7 +57432,7 @@ msgstr ""
 msgid "Update timestamp on new communication"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom_creator/bom_creator.py:533
+#: erpnext/manufacturing/doctype/bom_creator/bom_creator.py:534
 msgid "Updated successfully"
 msgstr ""
 
@@ -57451,7 +57446,7 @@ msgstr ""
 msgid "Updated via 'Time Log' (In Minutes)"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1387
+#: erpnext/stock/doctype/item/item.py:1381
 msgid "Updating Variants..."
 msgstr ""
 
@@ -58009,19 +58004,19 @@ msgstr ""
 msgid "Valuation Rate (In / Out)"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1881
+#: erpnext/stock/stock_ledger.py:1890
 msgid "Valuation Rate Missing"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1859
+#: erpnext/stock/stock_ledger.py:1868
 msgid "Valuation Rate for the Item {0}, is required to do accounting entries for {1} {2}."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:266
+#: erpnext/stock/doctype/item/item.py:269
 msgid "Valuation Rate is mandatory if Opening Stock entered"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:752
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:748
 msgid "Valuation Rate required for Item {0} at row {1}"
 msgstr ""
 
@@ -58031,7 +58026,7 @@ msgstr ""
 msgid "Valuation and Total"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:971
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:967
 msgid "Valuation rate for customer provided items has been set to zero."
 msgstr ""
 
@@ -58045,7 +58040,7 @@ msgid "Valuation rate for the item as per Sales Invoice (Only for Internal Trans
 msgstr ""
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:2361
-#: erpnext/controllers/accounts_controller.py:3029
+#: erpnext/controllers/accounts_controller.py:3032
 msgid "Valuation type charges can not be marked as Inclusive"
 msgstr ""
 
@@ -58201,7 +58196,7 @@ msgstr ""
 msgid "Variant"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:864
+#: erpnext/stock/doctype/item/item.py:858
 msgid "Variant Attribute Error"
 msgstr ""
 
@@ -58220,7 +58215,7 @@ msgstr ""
 msgid "Variant Based On"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:892
+#: erpnext/stock/doctype/item/item.py:886
 msgid "Variant Based On cannot be changed"
 msgstr ""
 
@@ -58238,7 +58233,7 @@ msgstr ""
 msgid "Variant Item"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:862
+#: erpnext/stock/doctype/item/item.py:856
 msgid "Variant Items"
 msgstr ""
 
@@ -58356,7 +58351,7 @@ msgstr ""
 #: erpnext/accounts/doctype/cost_center/cost_center_tree.js:56
 #: erpnext/accounts/doctype/invoice_discounting/invoice_discounting.js:205
 #: erpnext/accounts/doctype/journal_entry/journal_entry.js:43
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:668
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:670
 #: erpnext/bulk_transaction/doctype/bulk_transaction_log/bulk_transaction_log.js:14
 #: erpnext/bulk_transaction/doctype/bulk_transaction_log/bulk_transaction_log.js:24
 #: erpnext/buying/doctype/request_for_quotation/request_for_quotation.js:167
@@ -58543,7 +58538,7 @@ msgstr ""
 #: erpnext/accounts/doctype/repost_accounting_ledger_items/repost_accounting_ledger_items.json
 #: erpnext/accounts/doctype/repost_payment_ledger_items/repost_payment_ledger_items.json
 #: erpnext/accounts/doctype/unreconcile_payment/unreconcile_payment.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1099
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1101
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.js:42
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:209
 #: erpnext/accounts/report/general_ledger/general_ledger.js:49
@@ -58574,7 +58569,7 @@ msgstr ""
 msgid "Voucher No"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1087
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1088
 msgid "Voucher No is mandatory"
 msgstr ""
 
@@ -58616,7 +58611,7 @@ msgstr ""
 #: erpnext/accounts/doctype/repost_payment_ledger_items/repost_payment_ledger_items.json
 #: erpnext/accounts/doctype/tax_withheld_vouchers/tax_withheld_vouchers.json
 #: erpnext/accounts/doctype/unreconcile_payment/unreconcile_payment.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1097
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1099
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:200
 #: erpnext/accounts/report/general_ledger/general_ledger.py:697
 #: erpnext/accounts/report/invalid_ledger_entries/invalid_ledger_entries.py:31
@@ -58970,10 +58965,6 @@ msgstr ""
 msgid "Warehouse not found against the account {0}"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:600
-msgid "Warehouse not found in the system"
-msgstr ""
-
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:1130
 #: erpnext/stock/doctype/delivery_note/delivery_note.py:414
 msgid "Warehouse required for stock Item {0}"
@@ -59102,7 +59093,7 @@ msgid "Warn for new Request for Quotations"
 msgstr ""
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:744
-#: erpnext/controllers/accounts_controller.py:1978
+#: erpnext/controllers/accounts_controller.py:1981
 #: erpnext/stock/doctype/delivery_trip/delivery_trip.js:145
 #: erpnext/utilities/transaction_base.py:123
 msgid "Warning"
@@ -60074,7 +60065,7 @@ msgstr ""
 msgid "You are importing data for the code list:"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3611
+#: erpnext/controllers/accounts_controller.py:3614
 msgid "You are not allowed to update as per the conditions set in {} Workflow."
 msgstr ""
 
@@ -60139,7 +60130,7 @@ msgstr ""
 msgid "You can't make any changes to Job Card since Work Order is closed."
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:185
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:186
 msgid "You can't process the serial number {0} as it has already been used in the SABB {1}. {2} if you want to inward same serial number multiple times then enabled 'Allow existing Serial No to be Manufactured/Received again' in the {3}"
 msgstr ""
 
@@ -60199,7 +60190,7 @@ msgstr ""
 msgid "You cannot {0} this document because another Period Closing Entry {1} exists after {2}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3587
+#: erpnext/controllers/accounts_controller.py:3590
 msgid "You do not have permissions to {} items in a {}."
 msgstr ""
 
@@ -60227,7 +60218,7 @@ msgstr ""
 msgid "You have entered a duplicate Delivery Note on Row"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1063
+#: erpnext/stock/doctype/item/item.py:1057
 msgid "You have to enable auto re-order in Stock Settings to maintain re-order levels."
 msgstr ""
 
@@ -60247,7 +60238,7 @@ msgstr ""
 msgid "You need to cancel POS Closing Entry {} to be able to cancel this document."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2980
+#: erpnext/controllers/accounts_controller.py:2983
 msgid "You selected the account group {1} as {2} Account in row {0}. Please select a single account."
 msgstr ""
 
@@ -60325,7 +60316,7 @@ msgstr ""
 msgid "`Allow Negative rates for Items`"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1873
+#: erpnext/stock/stock_ledger.py:1882
 msgid "after"
 msgstr ""
 
@@ -60473,7 +60464,7 @@ msgstr ""
 msgid "material_request_item"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:151
+#: erpnext/controllers/selling_controller.py:159
 msgid "must be between 0 and 100"
 msgstr ""
 
@@ -60498,7 +60489,7 @@ msgstr ""
 msgid "on"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1289
+#: erpnext/controllers/accounts_controller.py:1292
 msgid "or"
 msgstr ""
 
@@ -60547,7 +60538,7 @@ msgstr ""
 msgid "per hour"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1874
+#: erpnext/stock/stock_ledger.py:1883
 msgid "performing either one below:"
 msgstr ""
 
@@ -60674,7 +60665,7 @@ msgstr ""
 msgid "{0}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1109
+#: erpnext/controllers/accounts_controller.py:1112
 msgid "{0} '{1}' is disabled"
 msgstr ""
 
@@ -60690,7 +60681,7 @@ msgstr ""
 msgid "{0} <b>{1}</b> has submitted Assets. Remove Item <b>{2}</b> from table to continue."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2193
+#: erpnext/controllers/accounts_controller.py:2196
 msgid "{0} Account not found against Customer {1}."
 msgstr ""
 
@@ -60722,7 +60713,7 @@ msgstr ""
 msgid "{0} Request for {1}"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:323
+#: erpnext/stock/doctype/item/item.py:326
 msgid "{0} Retain Sample is based on batch, please check Has Batch No to retain sample of item"
 msgstr ""
 
@@ -60813,7 +60804,7 @@ msgid "{0} entered twice in Item Tax"
 msgstr ""
 
 #: erpnext/setup/doctype/item_group/item_group.py:48
-#: erpnext/stock/doctype/item/item.py:436
+#: erpnext/stock/doctype/item/item.py:439
 msgid "{0} entered twice {1} in Item Taxes"
 msgstr ""
 
@@ -60834,7 +60825,7 @@ msgstr ""
 msgid "{0} hours"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2534
+#: erpnext/controllers/accounts_controller.py:2537
 msgid "{0} in row {1}"
 msgstr ""
 
@@ -60858,7 +60849,7 @@ msgstr ""
 
 #: erpnext/accounts/doctype/budget/budget.py:60
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:643
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:49
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:50
 #: erpnext/accounts/report/general_ledger/general_ledger.py:59
 #: erpnext/accounts/report/pos_register/pos_register.py:107
 #: erpnext/controllers/trends.py:50
@@ -60878,11 +60869,11 @@ msgstr ""
 msgid "{0} is mandatory. Maybe Currency Exchange record is not created for {1} to {2}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2937
+#: erpnext/controllers/accounts_controller.py:2940
 msgid "{0} is mandatory. Maybe Currency Exchange record is not created for {1} to {2}."
 msgstr ""
 
-#: erpnext/selling/doctype/customer/customer.py:204
+#: erpnext/selling/doctype/customer/customer.py:203
 msgid "{0} is not a company bank account"
 msgstr ""
 
@@ -60965,7 +60956,7 @@ msgstr ""
 msgid "{0} to {1}"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:690
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:686
 msgid "{0} units are reserved for Item {1} in Warehouse {2}, please un-reserve the same to {3} the Stock Reconciliation."
 msgstr ""
 
@@ -60981,16 +60972,16 @@ msgstr ""
 msgid "{0} units of {1} are required in {2} with the inventory dimension: {3} ({4}) on {5} {6} for {7} to complete the transaction."
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1532 erpnext/stock/stock_ledger.py:2023
-#: erpnext/stock/stock_ledger.py:2037
+#: erpnext/stock/stock_ledger.py:1541 erpnext/stock/stock_ledger.py:2031
+#: erpnext/stock/stock_ledger.py:2045
 msgid "{0} units of {1} needed in {2} on {3} {4} for {5} to complete this transaction."
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:2124 erpnext/stock/stock_ledger.py:2170
+#: erpnext/stock/stock_ledger.py:2132 erpnext/stock/stock_ledger.py:2178
 msgid "{0} units of {1} needed in {2} on {3} {4} to complete this transaction."
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1526
+#: erpnext/stock/stock_ledger.py:1535
 msgid "{0} units of {1} needed in {2} to complete this transaction."
 msgstr ""
 
@@ -61036,7 +61027,7 @@ msgstr ""
 msgid "{0} {1} does not exist"
 msgstr ""
 
-#: erpnext/accounts/party.py:560
+#: erpnext/accounts/party.py:566
 msgid "{0} {1} has accounting entries in currency {2} for company {3}. Please select a receivable or payable account with currency {2}."
 msgstr ""
 
@@ -61070,7 +61061,7 @@ msgstr ""
 msgid "{0} {1} is associated with {2}, but Party Account is {3}"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:462
+#: erpnext/controllers/selling_controller.py:470
 #: erpnext/controllers/subcontracting_controller.py:954
 msgid "{0} {1} is cancelled or closed"
 msgstr ""
@@ -61087,11 +61078,11 @@ msgstr ""
 msgid "{0} {1} is closed"
 msgstr ""
 
-#: erpnext/accounts/party.py:798
+#: erpnext/accounts/party.py:804
 msgid "{0} {1} is disabled"
 msgstr ""
 
-#: erpnext/accounts/party.py:804
+#: erpnext/accounts/party.py:810
 msgid "{0} {1} is frozen"
 msgstr ""
 
@@ -61099,7 +61090,7 @@ msgstr ""
 msgid "{0} {1} is fully billed"
 msgstr ""
 
-#: erpnext/accounts/party.py:808
+#: erpnext/accounts/party.py:814
 msgid "{0} {1} is not active"
 msgstr ""
 
@@ -61225,15 +61216,15 @@ msgstr ""
 msgid "{0}: {1} must be less than {2}"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:840
+#: erpnext/controllers/buying_controller.py:848
 msgid "{count} Assets created for {item_code}"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:738
+#: erpnext/controllers/buying_controller.py:746
 msgid "{doctype} {name} is cancelled or closed."
 msgstr "{doctype} {name} отменено или закрыто."
 
-#: erpnext/controllers/buying_controller.py:459
+#: erpnext/controllers/buying_controller.py:467
 msgid "{field_label} is mandatory for sub-contracted {doctype}."
 msgstr ""
 
@@ -61241,7 +61232,7 @@ msgstr ""
 msgid "{item_name}'s Sample Size ({sample_size}) cannot be greater than the Accepted Quantity ({accepted_quantity})"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:563
+#: erpnext/controllers/buying_controller.py:571
 msgid "{ref_doctype} {ref_name} is {status}."
 msgstr ""
 
@@ -61307,7 +61298,7 @@ msgstr ""
 msgid "{} can't be cancelled since the Loyalty Points earned has been redeemed. First cancel the {} No {}"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:222
+#: erpnext/controllers/buying_controller.py:230
 msgid "{} has submitted assets linked to it. You need to cancel the assets to create purchase return."
 msgstr ""
 

--- a/erpnext/locale/sr_CS.po
+++ b/erpnext/locale/sr_CS.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: frappe\n"
 "Report-Msgid-Bugs-To: hello@frappe.io\n"
-"POT-Creation-Date: 2025-05-25 09:35+0000\n"
-"PO-Revision-Date: 2025-05-27 20:41\n"
+"POT-Creation-Date: 2025-06-01 09:36+0000\n"
+"PO-Revision-Date: 2025-06-01 21:35\n"
 "Last-Translator: hello@frappe.io\n"
 "Language-Team: Serbian (Latin)\n"
 "MIME-Version: 1.0\n"
@@ -83,15 +83,15 @@ msgstr " Podsklop"
 msgid " Summary"
 msgstr " Rezime"
 
-#: erpnext/stock/doctype/item/item.py:235
+#: erpnext/stock/doctype/item/item.py:238
 msgid "\"Customer Provided Item\" cannot be Purchase Item also"
 msgstr "\"Stavka obezbeđena od strane kupca\" ne može biti i stavka za nabavku"
 
-#: erpnext/stock/doctype/item/item.py:237
+#: erpnext/stock/doctype/item/item.py:240
 msgid "\"Customer Provided Item\" cannot have Valuation Rate"
 msgstr "\"Stavka obezbeđena od strane kupca\" ne može imati stopu vrednovanja"
 
-#: erpnext/stock/doctype/item/item.py:313
+#: erpnext/stock/doctype/item/item.py:316
 msgid "\"Is Fixed Asset\" cannot be unchecked, as Asset record exists against the item"
 msgstr "\"Da li je osnovno sredstvo\" mora biti označeno, jer postoji zapis o imovini za ovu stavku"
 
@@ -213,7 +213,7 @@ msgstr "% od materijala fakturisanih u odnosu na ovu prodajnu porudžbinu"
 msgid "% of materials delivered against this Sales Order"
 msgstr "% od materijala isporučenim prema ovoj prodajnoj porudžbini"
 
-#: erpnext/controllers/accounts_controller.py:2197
+#: erpnext/controllers/accounts_controller.py:2200
 msgid "'Account' in the Accounting section of Customer {0}"
 msgstr "'Račun' u odeljku za računovodstvo kupca {0}"
 
@@ -225,15 +225,11 @@ msgstr "'Dozvoli više prodajnih porudžbina vezanih za nabavnu porudžbinu kupc
 msgid "'Based On' and 'Group By' can not be same"
 msgstr "'Na osnovu' i 'Grupisano po' ne mogu biti isti"
 
-#: erpnext/stock/report/product_bundle_balance/product_bundle_balance.py:233
-msgid "'Date' is required"
-msgstr "'Datum' je obavezan"
-
 #: erpnext/selling/report/inactive_customers/inactive_customers.py:18
 msgid "'Days Since Last Order' must be greater than or equal to zero"
 msgstr "'Dani od poslednje narudžbine' moraju biti veći ili jednaki nuli"
 
-#: erpnext/controllers/accounts_controller.py:2202
+#: erpnext/controllers/accounts_controller.py:2205
 msgid "'Default {0} Account' in Company {1}"
 msgstr "'Podrazumevani {0} račun' u kompaniji {1}"
 
@@ -243,7 +239,7 @@ msgstr "'Unosi' ne mogu biti prazni"
 
 #: erpnext/stock/report/batch_item_expiry_status/batch_item_expiry_status.py:24
 #: erpnext/stock/report/batch_wise_balance_history/batch_wise_balance_history.py:120
-#: erpnext/stock/report/stock_analytics/stock_analytics.py:314
+#: erpnext/stock/report/stock_analytics/stock_analytics.py:313
 msgid "'From Date' is required"
 msgstr "'Datum početka' je obavezan"
 
@@ -251,7 +247,7 @@ msgstr "'Datum početka' je obavezan"
 msgid "'From Date' must be after 'To Date'"
 msgstr "'Datum početka' mora biti manji od 'Datum završetka'"
 
-#: erpnext/stock/doctype/item/item.py:398
+#: erpnext/stock/doctype/item/item.py:401
 msgid "'Has Serial No' can not be 'Yes' for non-stock item"
 msgstr "'Ima serijski broj' ne može biti 'Da' za stavke van zaliha"
 
@@ -1179,7 +1175,7 @@ msgstr "Prihvaćena količina u jedinici mere zaliha"
 
 #. Label of the qty (Float) field in DocType 'Purchase Receipt Item'
 #. Label of the qty (Float) field in DocType 'Subcontracting Receipt Item'
-#: erpnext/public/js/controllers/transaction.js:2362
+#: erpnext/public/js/controllers/transaction.js:2388
 #: erpnext/stock/doctype/purchase_receipt_item/purchase_receipt_item.json
 #: erpnext/subcontracting/doctype/subcontracting_receipt_item/subcontracting_receipt_item.json
 msgid "Accepted Quantity"
@@ -1377,7 +1373,7 @@ msgid "Account Manager"
 msgstr "Account Manager"
 
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:949
-#: erpnext/controllers/accounts_controller.py:2206
+#: erpnext/controllers/accounts_controller.py:2209
 msgid "Account Missing"
 msgstr "Račun nedostaje"
 
@@ -1552,7 +1548,7 @@ msgstr "Račun {0} je dodat u zavisnu kompaniju {1}"
 msgid "Account {0} is frozen"
 msgstr "Račun {0} je zaključan"
 
-#: erpnext/controllers/accounts_controller.py:1288
+#: erpnext/controllers/accounts_controller.py:1291
 msgid "Account {0} is invalid. Account Currency must be {1}"
 msgstr "Račun {0} je nevažeći. Valuta računa mora biti {1}"
 
@@ -1588,7 +1584,7 @@ msgstr "Račun: {0} može biti ažuriran samo putem transakcija zaliha"
 msgid "Account: {0} is not permitted under Payment Entry"
 msgstr "Račun: {0} nije dozvoljen u okviru unosa uplate"
 
-#: erpnext/controllers/accounts_controller.py:3037
+#: erpnext/controllers/accounts_controller.py:3040
 msgid "Account: {0} with currency: {1} can not be selected"
 msgstr "Račun: {0} sa valutom: {1} ne može biti izabran"
 
@@ -1861,7 +1857,7 @@ msgstr "Računovodstveni unosi"
 msgid "Accounting Entry for Asset"
 msgstr "Računovodstveni unos za imovinu"
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:796
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:805
 msgid "Accounting Entry for Service"
 msgstr "Računovodstveni unos za uslugu"
 
@@ -1876,18 +1872,18 @@ msgstr "Računovodstveni unos za uslugu"
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py:1468
 #: erpnext/controllers/stock_controller.py:550
 #: erpnext/controllers/stock_controller.py:567
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:889
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:898
 #: erpnext/stock/doctype/stock_entry/stock_entry.py:1586
 #: erpnext/stock/doctype/stock_entry/stock_entry.py:1600
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py:561
 msgid "Accounting Entry for Stock"
 msgstr "Računovodstveni unos za zalihe"
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:717
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:726
 msgid "Accounting Entry for {0}"
 msgstr "Računovodstveni unos za {0}"
 
-#: erpnext/controllers/accounts_controller.py:2247
+#: erpnext/controllers/accounts_controller.py:2250
 msgid "Accounting Entry for {0}: {1} can only be made in currency: {2}"
 msgstr "Računovodstveni unos za {0}: {1} može biti samo u valuti: {2}"
 
@@ -2280,7 +2276,7 @@ msgstr "Akumulirana amortizacija na dan"
 msgid "Accumulated Monthly"
 msgstr "Mesečno akumulirano"
 
-#: erpnext/controllers/budget_controller.py:417
+#: erpnext/controllers/budget_controller.py:422
 msgid "Accumulated Monthly Budget for Account {0} against {1} {2} is {3}. It will be collectively ({4}) exceeded by {5}"
 msgstr "Akumulirani mesečni budžet za račun {0} protiv {1} {2} iznosi {3}. Ukupno ({4}) će biti premašen za {5}"
 
@@ -3394,7 +3390,7 @@ msgstr "Podesi vrednost imovine"
 msgid "Adjustment Against"
 msgstr "Prilagođavanje prema"
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:634
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:643
 msgid "Adjustment based on Purchase Invoice rate"
 msgstr "Prilagođavanje na osnovu cene iz ulazne fakture"
 
@@ -3505,7 +3501,7 @@ msgstr "Akontacija poreza i taksi"
 msgid "Advance amount"
 msgstr "Iznos avansa"
 
-#: erpnext/controllers/taxes_and_totals.py:845
+#: erpnext/controllers/taxes_and_totals.py:855
 msgid "Advance amount cannot be greater than {0} {1}"
 msgstr "Iznos avansa ne može biti veći od {0} {1}"
 
@@ -3716,7 +3712,7 @@ msgstr "Starost"
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:152
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:133
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1125
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1127
 msgid "Age (Days)"
 msgstr "Starost (dani)"
 
@@ -3802,16 +3798,6 @@ msgstr "Objedinite grupu stavki u drugu stavku. Ovo je korisno ukoliko održavat
 #: erpnext/setup/setup_wizard/data/industry_type.txt:4
 msgid "Agriculture"
 msgstr "Poljoprivreda"
-
-#. Name of a role
-#: erpnext/assets/doctype/location/location.json
-msgid "Agriculture Manager"
-msgstr "Poljoprivredni menadžer"
-
-#. Name of a role
-#: erpnext/assets/doctype/location/location.json
-msgid "Agriculture User"
-msgstr "Poljoprivredni korisnik"
 
 #: erpnext/setup/setup_wizard/data/industry_type.txt:5
 msgid "Airline"
@@ -4003,7 +3989,7 @@ msgstr "Sve komunikacije uključujući i one iznad biće premeštene kao novi pr
 msgid "All items are already requested"
 msgstr "Sve stavke su već zahtevane"
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:1317
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:1326
 msgid "All items have already been Invoiced/Returned"
 msgstr "Sve stavke su već fakturisane/vraćene"
 
@@ -4015,7 +4001,7 @@ msgstr "Sve stavke su već primljene"
 msgid "All items have already been transferred for this Work Order."
 msgstr "Sve stavke su već prebačene za ovaj radni nalog."
 
-#: erpnext/public/js/controllers/transaction.js:2465
+#: erpnext/public/js/controllers/transaction.js:2491
 msgid "All items in this document already have a linked Quality Inspection."
 msgstr "Sve stavke u ovom dokumentu već imaju povezanu inspekciju kvaliteta."
 
@@ -4213,7 +4199,7 @@ msgstr "Dozvoli interne transfere po tržišnim cenama"
 msgid "Allow Item To Be Added Multiple Times in a Transaction"
 msgstr "Dozvoli dodavanje stavki više puta u transakciji"
 
-#: erpnext/controllers/selling_controller.py:755
+#: erpnext/controllers/selling_controller.py:763
 msgid "Allow Item to Be Added Multiple Times in a Transaction"
 msgstr "Dozvoli dodeljivanje stavki više puta u transakciji"
 
@@ -4337,11 +4323,11 @@ msgstr "Dozvoli zahtev za ponudu sa nultom količinom"
 #. DocType 'Support Settings'
 #: erpnext/support/doctype/support_settings/support_settings.json
 msgid "Allow Resetting Service Level Agreement"
-msgstr "Dozvoli ponovno postavljanje Ugovora o nivou usluge"
+msgstr "Dozvoli ponovno postavljanje sporazuma o nivou usluge"
 
 #: erpnext/support/doctype/service_level_agreement/service_level_agreement.py:777
 msgid "Allow Resetting Service Level Agreement from Support Settings."
-msgstr "Dozvoli ponovno postavljanje Ugovora o nivou usluge iz podešavanja podrške."
+msgstr "Dozvoli ponovno postavljanje sporazuma o nivou usluge iz podešavanja podrške."
 
 #. Label of the is_sales_item (Check) field in DocType 'Item'
 #: erpnext/stock/doctype/item/item.json
@@ -5159,7 +5145,7 @@ msgstr "Godišnji"
 msgid "Annual Billing: {0}"
 msgstr "Godišnje fakturisanje: {0}"
 
-#: erpnext/controllers/budget_controller.py:441
+#: erpnext/controllers/budget_controller.py:446
 msgid "Annual Budget for Account {0} against {1} {2} is {3}. It will be collectively ({4}) exceeded by {5}"
 msgstr "Godišnji budžet za račun {0} protiv {1} {2} iznosi {3}. Ukupno ({4}) će biti premašen za {5}"
 
@@ -5459,7 +5445,7 @@ msgstr "Primeni pravilo na ostale"
 #. Level Agreement'
 #: erpnext/support/doctype/service_level_agreement/service_level_agreement.json
 msgid "Apply SLA for Resolution Time"
-msgstr "Primeni Ugovor o nivou usluga za vreme rešavanja"
+msgstr "Primeni sporazuma o nivou usluge za vreme rešavanja"
 
 #. Label of the apply_tds (Check) field in DocType 'Purchase Invoice Item'
 #. Label of the apply_tds (Check) field in DocType 'Purchase Order Item'
@@ -5648,7 +5634,7 @@ msgstr "Pošto je polje {0} omogućeno, polje {1} je obavezno."
 msgid "As the field {0} is enabled, the value of the field {1} should be more than 1."
 msgstr "Pošto je polje {0} omogućeno, vrednost polja {1} treba da bude veća od 1."
 
-#: erpnext/stock/doctype/item/item.py:989
+#: erpnext/stock/doctype/item/item.py:983
 msgid "As there are existing submitted transactions against item {0}, you can not change the value of {1}."
 msgstr "Pošto već postoje podnete transakcije za stavku {0}, ne možete promeniti vrednost za {1}."
 
@@ -5794,7 +5780,7 @@ msgstr "Račun kategorije imovine"
 msgid "Asset Category Name"
 msgstr "Naziv kategorije imovine"
 
-#: erpnext/stock/doctype/item/item.py:304
+#: erpnext/stock/doctype/item/item.py:307
 msgid "Asset Category is mandatory for Fixed Asset item"
 msgstr "Kategorija imovine je obavezna za osnovno sredstvo"
 
@@ -6169,7 +6155,7 @@ msgstr "Imovina {0} je ažurirana. Molimo Vas da postavite detalje o amortizacij
 msgid "Asset {0} must be submitted"
 msgstr "Imovina {0} mora biti podneta"
 
-#: erpnext/controllers/buying_controller.py:851
+#: erpnext/controllers/buying_controller.py:859
 msgid "Asset {assets_link} created for {item_code}"
 msgstr "Imovina {assets_link} je kreirana za {item_code}"
 
@@ -6199,11 +6185,11 @@ msgstr "Vrednost imovine je podešena nakon podnošenja korekcije vrednosti imov
 msgid "Assets"
 msgstr "Imovina"
 
-#: erpnext/controllers/buying_controller.py:869
+#: erpnext/controllers/buying_controller.py:877
 msgid "Assets not created for {item_code}. You will have to create asset manually."
 msgstr "Imovina nije kreirana za {item_code}. Moraćete da kreirate imovinu ručno."
 
-#: erpnext/controllers/buying_controller.py:856
+#: erpnext/controllers/buying_controller.py:864
 msgid "Assets {assets_link} created for {item_code}"
 msgstr "Imovina {assets_link} je kreirana za {item_code}"
 
@@ -6298,7 +6284,7 @@ msgstr "U redu #{0}: Identifikator sekvence {1} ne može biti manji od identifik
 msgid "At row #{0}: you have selected the Difference Account {1}, which is a Cost of Goods Sold type account. Please select a different account"
 msgstr "U redu #{0}: Izabrali ste račun razlike {1}, koji je vrste računa trošak prodate robe. Molimo Vas da izaberete drugi račun"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:864
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:865
 msgid "At row {0}: Batch No is mandatory for Item {1}"
 msgstr "U redu {0}: Broj šarže je obavezan za stavku {1}"
 
@@ -6306,11 +6292,11 @@ msgstr "U redu {0}: Broj šarže je obavezan za stavku {1}"
 msgid "At row {0}: Parent Row No cannot be set for item {1}"
 msgstr "U redu {0}: Broj matičnog reda ne može biti postavljen za stavku {1}"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:849
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:850
 msgid "At row {0}: Qty is mandatory for the batch {1}"
 msgstr "U redu {0}: Količina je obavezna za šaržu {1}"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:856
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:857
 msgid "At row {0}: Serial No is mandatory for Item {1}"
 msgstr "U redu {0}: Broj serije je obavezan za stavku {1}"
 
@@ -6384,7 +6370,7 @@ msgstr "Naziv atributa"
 msgid "Attribute Value"
 msgstr "Vrednost atributa"
 
-#: erpnext/stock/doctype/item/item.py:930
+#: erpnext/stock/doctype/item/item.py:924
 msgid "Attribute table is mandatory"
 msgstr "Tabela atributa je obavezna"
 
@@ -6392,11 +6378,11 @@ msgstr "Tabela atributa je obavezna"
 msgid "Attribute value: {0} must appear only once"
 msgstr "Vrednost atributa: {0} mora se pojaviti samo jednom"
 
-#: erpnext/stock/doctype/item/item.py:934
+#: erpnext/stock/doctype/item/item.py:928
 msgid "Attribute {0} selected multiple times in Attributes Table"
 msgstr "Atribut {0} je više puta izabran u tabeli atributa"
 
-#: erpnext/stock/doctype/item/item.py:862
+#: erpnext/stock/doctype/item/item.py:856
 msgid "Attributes"
 msgstr "Atributi"
 
@@ -7680,11 +7666,11 @@ msgstr "Bar-kod"
 msgid "Barcode Type"
 msgstr "Vrsta bar-koda"
 
-#: erpnext/stock/doctype/item/item.py:457
+#: erpnext/stock/doctype/item/item.py:460
 msgid "Barcode {0} already used in Item {1}"
 msgstr "Bar-kod {0} se već koristi u stavci {1}"
 
-#: erpnext/stock/doctype/item/item.py:472
+#: erpnext/stock/doctype/item/item.py:475
 msgid "Barcode {0} is not a valid {1} code"
 msgstr "Bar-kod {0} nije validni {1} kod"
 
@@ -7938,7 +7924,7 @@ msgstr "Status isteka stavke šarže"
 #: erpnext/manufacturing/doctype/job_card/job_card.json
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.js:89
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.py:115
-#: erpnext/public/js/controllers/transaction.js:2388
+#: erpnext/public/js/controllers/transaction.js:2414
 #: erpnext/public/js/utils/barcode_scanner.js:260
 #: erpnext/public/js/utils/serial_no_batch_selector.js:438
 #: erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
@@ -7965,11 +7951,11 @@ msgstr "Status isteka stavke šarže"
 msgid "Batch No"
 msgstr "Broj šarže"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:867
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:868
 msgid "Batch No is mandatory"
 msgstr "Broj šarže je obavezan"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2629
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2630
 msgid "Batch No {0} does not exists"
 msgstr "Broj šarže {0} ne postoji"
 
@@ -7977,7 +7963,7 @@ msgstr "Broj šarže {0} ne postoji"
 msgid "Batch No {0} is linked with Item {1} which has serial no. Please scan serial no instead."
 msgstr "Broj šarže {0} je povezan sa stavkom {1} koji ima broj serije. Molimo Vas da skenirate broj serije."
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:364
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:365
 msgid "Batch No {0} is not present in the original {1} {2}, hence you can't return it against the {1} {2}"
 msgstr "Broj šarže {0} nije prisutan u originalnom {1} {2}, samim tim nije moguće vratiti je protiv {1} {2}"
 
@@ -7992,11 +7978,11 @@ msgstr "Broj šarže."
 msgid "Batch Nos"
 msgstr "Brojevi šarže"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1421
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1422
 msgid "Batch Nos are created successfully"
 msgstr "Brojevi šarže su uspešno kreirani"
 
-#: erpnext/controllers/sales_and_purchase_return.py:1096
+#: erpnext/controllers/sales_and_purchase_return.py:1001
 msgid "Batch Not Available for Return"
 msgstr "Šarža nije dostupna za povrat"
 
@@ -8045,7 +8031,7 @@ msgstr "Šarža nije kreirana za stavku {} jer nema seriju šarže."
 msgid "Batch {0} and Warehouse"
 msgstr "Šarža {0} i skladište"
 
-#: erpnext/controllers/sales_and_purchase_return.py:1095
+#: erpnext/controllers/sales_and_purchase_return.py:1000
 msgid "Batch {0} is not available in warehouse {1}"
 msgstr "Šarža {0} nije dostupna u skladištu {1}"
 
@@ -8095,7 +8081,7 @@ msgstr "Navedeni planovi pretplate koriste različite valute od podrazumevane va
 #. Label of the bill_date (Date) field in DocType 'Journal Entry'
 #. Label of the bill_date (Date) field in DocType 'Subcontracting Receipt'
 #: erpnext/accounts/doctype/journal_entry/journal_entry.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1110
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1112
 #: erpnext/accounts/report/purchase_register/purchase_register.py:214
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.json
 msgid "Bill Date"
@@ -8104,7 +8090,7 @@ msgstr "Datum računa"
 #. Label of the bill_no (Data) field in DocType 'Journal Entry'
 #. Label of the bill_no (Data) field in DocType 'Subcontracting Receipt'
 #: erpnext/accounts/doctype/journal_entry/journal_entry.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1109
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1111
 #: erpnext/accounts/report/purchase_register/purchase_register.py:213
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.json
 msgid "Bill No"
@@ -8324,7 +8310,7 @@ msgstr "Status fakturisanja"
 msgid "Billing Zipcode"
 msgstr "Poštanski broj"
 
-#: erpnext/accounts/party.py:602
+#: erpnext/accounts/party.py:608
 msgid "Billing currency must be equal to either default company's currency or party account currency"
 msgstr "Valuta fakturisanja mora biti ista kao valuta podrazumevane valute kompanije ili valute računa stranke"
 
@@ -9321,7 +9307,7 @@ msgid "Can only make payment against unbilled {0}"
 msgstr "Može se izvršiti plaćanje samo za neizmirene {0}"
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1458
-#: erpnext/controllers/accounts_controller.py:2946
+#: erpnext/controllers/accounts_controller.py:2949
 #: erpnext/public/js/controllers/accounts.js:90
 msgid "Can refer row only if the charge type is 'On Previous Row Amount' or 'Previous Row Total'"
 msgstr "Možete se pozvati na red samo ako je vrsta naplate 'Na iznos prethodnog reda' ili 'Ukupan iznos prethodnog reda'"
@@ -9483,9 +9469,9 @@ msgstr "Nije moguće izračunati vreme jer nedostaje adresa vozača."
 msgid "Cannot Create Return"
 msgstr "Nije moguće kreirati povrat"
 
-#: erpnext/stock/doctype/item/item.py:625
-#: erpnext/stock/doctype/item/item.py:638
-#: erpnext/stock/doctype/item/item.py:652
+#: erpnext/stock/doctype/item/item.py:631
+#: erpnext/stock/doctype/item/item.py:644
+#: erpnext/stock/doctype/item/item.py:658
 msgid "Cannot Merge"
 msgstr "Nije moguće spojiti"
 
@@ -9509,7 +9495,7 @@ msgstr "Ne može se izmeniti {0} {1}, molimo Vas da umesto toga kreirate novi."
 msgid "Cannot apply TDS against multiple parties in one entry"
 msgstr "Ne može se primeniti porez odbijen na izvoru protiv više stranaka u jednom unosu"
 
-#: erpnext/stock/doctype/item/item.py:307
+#: erpnext/stock/doctype/item/item.py:310
 msgid "Cannot be a fixed asset item as Stock Ledger is created."
 msgstr "Ne može biti osnovno sredstvo jer je kreirana knjiga zaliha."
 
@@ -9525,7 +9511,7 @@ msgstr "Ne može se otkazati jer već postoji unos zaliha {0}"
 msgid "Cannot cancel the transaction. Reposting of item valuation on submission is not completed yet."
 msgstr "Nije moguće otkazati transakciju. Ponovna obrada vrednovanja stavki pri predaji još nije završena."
 
-#: erpnext/controllers/buying_controller.py:959
+#: erpnext/controllers/buying_controller.py:967
 msgid "Cannot cancel this document as it is linked with the submitted asset {asset_link}. Please cancel the asset to continue."
 msgstr "Ne može se otkazati ovaj dokument jer je povezan sa podnetom imovinom {asset_link}. Molimo Vas da je otkažete da biste nastavili."
 
@@ -9533,7 +9519,7 @@ msgstr "Ne može se otkazati ovaj dokument jer je povezan sa podnetom imovinom {
 msgid "Cannot cancel transaction for Completed Work Order."
 msgstr "Ne može se otkazati transakcija za završeni radni nalog."
 
-#: erpnext/stock/doctype/item/item.py:882
+#: erpnext/stock/doctype/item/item.py:876
 msgid "Cannot change Attributes after stock transaction. Make a new Item and transfer stock to the new Item"
 msgstr "Nije moguće menjanje atributa nakon transakcije sa zalihama. Kreirajte novu stavku i prenesite zalihe"
 
@@ -9549,7 +9535,7 @@ msgstr "Ne može se promeniti vrsta referentnog dokumenta."
 msgid "Cannot change Service Stop Date for item in row {0}"
 msgstr "Ne može se promeniti datum zaustavljanja usluge za stavku u redu {0}"
 
-#: erpnext/stock/doctype/item/item.py:873
+#: erpnext/stock/doctype/item/item.py:867
 msgid "Cannot change Variant properties after stock transaction. You will have to make a new Item to do this."
 msgstr "Nije moguće promeniti svojstva varijante nakon transakcije za zalihama. Morate kreirati novu stavku da biste to uradili."
 
@@ -9577,7 +9563,7 @@ msgstr "Ne može se konvertovati u grupu jer je izabrana vrsta računa."
 msgid "Cannot covert to Group because Account Type is selected."
 msgstr "Ne može se skloniti u grupu jer je izabrana vrsta računa."
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:972
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:981
 msgid "Cannot create Stock Reservation Entries for future dated Purchase Receipts."
 msgstr "Ne mogu se kreirati unosi za rezervaciju zaliha za prijemnicu nabavke sa budućim datumom."
 
@@ -9628,7 +9614,7 @@ msgstr "Ne može se obezbediti isporuka po broju serije jer je stavka {0} dodata
 msgid "Cannot find Item with this Barcode"
 msgstr "Ne može se pronaći stavka sa ovim bar-kodom"
 
-#: erpnext/controllers/accounts_controller.py:3483
+#: erpnext/controllers/accounts_controller.py:3486
 msgid "Cannot find a default warehouse for item {0}. Please set one in the Item Master or in Stock Settings."
 msgstr "Ne može se pronaći podrazumevano skladište za stavku {0}. Molimo Vas da postavite jedan u master podacima stavke ili podešavanjima zaliha."
 
@@ -9636,7 +9622,7 @@ msgstr "Ne može se pronaći podrazumevano skladište za stavku {0}. Molimo Vas 
 msgid "Cannot make any transactions until the deletion job is completed"
 msgstr "Nije moguće izvršenje transakcija dok posao brisanja nije završen"
 
-#: erpnext/controllers/accounts_controller.py:2074
+#: erpnext/controllers/accounts_controller.py:2077
 msgid "Cannot overbill for Item {0} in row {1} more than {2}. To allow over-billing, please set allowance in Accounts Settings"
 msgstr "Ne može se fakturisati više od {2} za stavku {0} u redu {1}. Da biste omogućili fakturisanje preko limita, molimo Vas da postavite dozvolu u podešavanjima računa"
 
@@ -9657,7 +9643,7 @@ msgid "Cannot receive from customer against negative outstanding"
 msgstr "Ne može se primiti od kupca protiv negativnih neizmirenih obaveza"
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1475
-#: erpnext/controllers/accounts_controller.py:2961
+#: erpnext/controllers/accounts_controller.py:2964
 #: erpnext/public/js/controllers/accounts.js:100
 msgid "Cannot refer row number greater than or equal to current row number for this Charge type"
 msgstr "Ne može se pozvati broj reda veći ili jednak trenutnom broju reda za ovu vrstu naplate"
@@ -9673,7 +9659,7 @@ msgstr "Nije moguće preuzeti token za povezivanje. Proverite evidenciju grešak
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1467
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1646
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:1917
-#: erpnext/controllers/accounts_controller.py:2951
+#: erpnext/controllers/accounts_controller.py:2954
 #: erpnext/public/js/controllers/accounts.js:94
 #: erpnext/public/js/controllers/taxes_and_totals.js:470
 msgid "Cannot select charge type as 'On Previous Row Amount' or 'On Previous Row Total' for first row"
@@ -9687,15 +9673,15 @@ msgstr "Ne može se postaviti kao izgubljeno jer je napravljena prodajna porudž
 msgid "Cannot set authorization on basis of Discount for {0}"
 msgstr "Ne može se postaviti autorizacija na osnovu popusta za {0}"
 
-#: erpnext/stock/doctype/item/item.py:716
+#: erpnext/stock/doctype/item/item.py:722
 msgid "Cannot set multiple Item Defaults for a company."
 msgstr "Ne može se postaviti više podrazumevanih stavki za jednu kompaniju."
 
-#: erpnext/controllers/accounts_controller.py:3631
+#: erpnext/controllers/accounts_controller.py:3634
 msgid "Cannot set quantity less than delivered quantity"
 msgstr "Ne može se postaviti količina manja od isporučene količine"
 
-#: erpnext/controllers/accounts_controller.py:3634
+#: erpnext/controllers/accounts_controller.py:3637
 msgid "Cannot set quantity less than received quantity"
 msgstr "Ne može se postaviti količina manja od primljene količine"
 
@@ -10118,7 +10104,7 @@ msgid "Channel Partner"
 msgstr "Kanal partnera"
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:2346
-#: erpnext/controllers/accounts_controller.py:3014
+#: erpnext/controllers/accounts_controller.py:3017
 msgid "Charge of type 'Actual' in row {0} cannot be included in Item Rate or Paid Amount"
 msgstr "Naknada vrste 'Stvarno' u redu {0} ne može biti uključena u cenu stavke ili plaćeni iznos"
 
@@ -10301,7 +10287,7 @@ msgstr "Širina čeka"
 
 #. Label of the reference_date (Date) field in DocType 'Payment Entry'
 #: erpnext/accounts/doctype/payment_entry/payment_entry.json
-#: erpnext/public/js/controllers/transaction.js:2299
+#: erpnext/public/js/controllers/transaction.js:2325
 msgid "Cheque/Reference Date"
 msgstr "Datum čeka / reference"
 
@@ -10349,7 +10335,7 @@ msgstr "Zavisni Docname"
 
 #. Label of the child_row_reference (Data) field in DocType 'Quality
 #. Inspection'
-#: erpnext/public/js/controllers/transaction.js:2394
+#: erpnext/public/js/controllers/transaction.js:2420
 #: erpnext/stock/doctype/quality_inspection/quality_inspection.json
 msgid "Child Row Reference"
 msgstr "Referenca zavisnog reda"
@@ -11061,7 +11047,7 @@ msgstr "Kompanije"
 #: erpnext/accounts/report/cheques_and_deposits_incorrectly_cleared/cheques_and_deposits_incorrectly_cleared.js:8
 #: erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.js:8
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:8
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:49
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:50
 #: erpnext/accounts/report/deferred_revenue_and_expense/deferred_revenue_and_expense.js:8
 #: erpnext/accounts/report/delivered_items_to_be_billed/delivered_items_to_be_billed.js:7
 #: erpnext/accounts/report/dimension_wise_accounts_balance_report/dimension_wise_accounts_balance_report.js:8
@@ -12294,7 +12280,7 @@ msgid "Content Type"
 msgstr "Vrsta sadržaja"
 
 #: erpnext/erpnext_integrations/doctype/plaid_settings/plaid_settings.js:162
-#: erpnext/public/js/controllers/transaction.js:2312
+#: erpnext/public/js/controllers/transaction.js:2338
 #: erpnext/selling/doctype/quotation/quotation.js:356
 msgid "Continue"
 msgstr "Nastavi"
@@ -12459,7 +12445,7 @@ msgstr "Faktor konverzije"
 msgid "Conversion Rate"
 msgstr "Stopa konverzije"
 
-#: erpnext/stock/doctype/item/item.py:393
+#: erpnext/stock/doctype/item/item.py:396
 msgid "Conversion factor for default Unit of Measure must be 1 in row {0}"
 msgstr "Faktor konverzije za podrazumevanu jedinicu mere mora biti 1 u redu {0}"
 
@@ -12467,15 +12453,15 @@ msgstr "Faktor konverzije za podrazumevanu jedinicu mere mora biti 1 u redu {0}"
 msgid "Conversion factor for item {0} has been reset to 1.0 as the uom {1} is same as stock uom {2}."
 msgstr "Faktor konverzije za stavku {0} je vraćen na 1.0 jer je jedinica mere {1} ista kao jedinica mere zaliha {2}."
 
-#: erpnext/controllers/accounts_controller.py:2767
+#: erpnext/controllers/accounts_controller.py:2770
 msgid "Conversion rate cannot be 0"
 msgstr "Stopa konverzije ne može biti 0"
 
-#: erpnext/controllers/accounts_controller.py:2774
+#: erpnext/controllers/accounts_controller.py:2777
 msgid "Conversion rate is 1.00, but document currency is different from company currency"
 msgstr "Stopa konverzije je 1.00, ali valuta dokumenta se razlikuje od valute kompanije"
 
-#: erpnext/controllers/accounts_controller.py:2770
+#: erpnext/controllers/accounts_controller.py:2773
 msgid "Conversion rate must be 1.00 if document currency is same as company currency"
 msgstr "Stopa konverzije mora biti 1.00 ukoliko je valuta dokumenta ista kao valuta kompanije"
 
@@ -12688,7 +12674,7 @@ msgstr "Trošak"
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:28
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:40
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:30
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1096
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1098
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:40
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.js:42
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.py:197
@@ -12781,7 +12767,7 @@ msgid "Cost Center is a part of Cost Center Allocation, hence cannot be converte
 msgstr "Troškovni centar je deo raspodele troškovnog centra, stoga ne može biti konvertovan u grupu"
 
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py:1411
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:855
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:864
 msgid "Cost Center is required in row {0} in Taxes table for type {1}"
 msgstr "Troškovni centar je obavezan u redu {0} u tabeli poreza za vrstu {1}"
 
@@ -13050,8 +13036,8 @@ msgstr "Potražuje"
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:132
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:143
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:219
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:654
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:678
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:656
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:680
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.js:88
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.js:89
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.js:103
@@ -13108,8 +13094,8 @@ msgstr "Potražuje"
 #: erpnext/projects/doctype/task/task_tree.js:81
 #: erpnext/public/js/communication.js:19 erpnext/public/js/communication.js:31
 #: erpnext/public/js/communication.js:41
-#: erpnext/public/js/controllers/transaction.js:336
-#: erpnext/public/js/controllers/transaction.js:2435
+#: erpnext/public/js/controllers/transaction.js:362
+#: erpnext/public/js/controllers/transaction.js:2461
 #: erpnext/selling/doctype/customer/customer.js:181
 #: erpnext/selling/doctype/quotation/quotation.js:124
 #: erpnext/selling/doctype/quotation/quotation.js:133
@@ -13404,7 +13390,7 @@ msgstr "Kreiraj novu kompozitnu imovinu"
 msgid "Create a variant with the template image."
 msgstr "Kreiraj varijantu sa šablonskom slikom."
 
-#: erpnext/stock/stock_ledger.py:1877
+#: erpnext/stock/stock_ledger.py:1886
 msgid "Create an incoming stock transaction for the Item."
 msgstr "Kreiraj transakciju ulaznih zaliha za stavku."
 
@@ -13464,7 +13450,7 @@ msgstr "Kreiranje ulaznih faktura …"
 msgid "Creating Purchase Order ..."
 msgstr "Kreiranje nabavne porudžbine ..."
 
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:735
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:737
 #: erpnext/buying/doctype/purchase_order/purchase_order.js:552
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.js:73
 msgid "Creating Purchase Receipt ..."
@@ -13660,7 +13646,7 @@ msgstr "Potraživanje po mesecima"
 #: erpnext/accounts/doctype/journal_entry_template/journal_entry_template.json
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:174
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:147
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1119
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1121
 #: erpnext/controllers/sales_and_purchase_return.py:373
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:286
 #: erpnext/stock/doctype/delivery_note/delivery_note.js:89
@@ -13695,7 +13681,7 @@ msgstr "Dokument o smanjenju {0} je automatski kreiran"
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py:368
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py:376
-#: erpnext/controllers/accounts_controller.py:2186
+#: erpnext/controllers/accounts_controller.py:2189
 msgid "Credit To"
 msgstr "Potražuje"
 
@@ -13880,7 +13866,7 @@ msgstr "Šolja"
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/subscription_plan/subscription_plan.json
 #: erpnext/accounts/report/account_balance/account_balance.py:28
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1129
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1131
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:205
 #: erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.py:101
 #: erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.js:118
@@ -14409,7 +14395,7 @@ msgstr "Šifra kupca"
 #. Label of the customer_contact_display (Small Text) field in DocType
 #. 'Purchase Order'
 #. Label of the customer_contact (Small Text) field in DocType 'Delivery Stop'
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1090
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1092
 #: erpnext/buying/doctype/purchase_order/purchase_order.json
 #: erpnext/stock/doctype/delivery_stop/delivery_stop.json
 msgid "Customer Contact"
@@ -14505,7 +14491,7 @@ msgstr "Povratne informacije kupca"
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/tax_rule/tax_rule.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:107
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1147
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1149
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:81
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:185
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:56
@@ -14549,7 +14535,7 @@ msgstr "Stavke grupe kupaca"
 msgid "Customer Group Name"
 msgstr "Naziv grupe kupaca"
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1239
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1241
 msgid "Customer Group: {0} does not exist"
 msgstr "Grupa kupaca: {0} ne postoji"
 
@@ -14568,7 +14554,7 @@ msgstr "Stavka kupca"
 msgid "Customer Items"
 msgstr "Stavke kupca"
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1138
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1140
 msgid "Customer LPO"
 msgstr "Kupac lokalna narudžbina"
 
@@ -14614,7 +14600,7 @@ msgstr "Broj mobilnog telefona kupca"
 #: erpnext/accounts/doctype/pos_invoice/pos_invoice.json
 #: erpnext/accounts/doctype/process_statement_of_accounts_customer/process_statement_of_accounts_customer.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1080
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1082
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:156
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:92
 #: erpnext/accounts/report/delivered_items_to_be_billed/delivered_items_to_be_billed.py:35
@@ -15292,7 +15278,7 @@ msgstr "Dugovni iznos u valuti transakcije"
 #: erpnext/accounts/doctype/journal_entry_template/journal_entry_template.json
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:176
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:147
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1122
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1124
 #: erpnext/controllers/sales_and_purchase_return.py:377
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:287
 #: erpnext/stock/doctype/purchase_receipt/purchase_receipt.js:61
@@ -15321,7 +15307,7 @@ msgstr "Dokument o povećanju će ažurirati sopstveni iznos koji nije izmiren, 
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:953
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:964
-#: erpnext/controllers/accounts_controller.py:2186
+#: erpnext/controllers/accounts_controller.py:2189
 msgid "Debit To"
 msgstr "Duguje prema"
 
@@ -15354,11 +15340,11 @@ msgstr "Duguje-Potražuje nisu u ravnoteži"
 msgid "Debit-Credit mismatch"
 msgstr "Duguje-Potražuje nisu u ravnoteži"
 
-#: erpnext/accounts/party.py:609
+#: erpnext/accounts/party.py:615
 msgid "Debtor/Creditor"
 msgstr "Dužnik/Poverilac"
 
-#: erpnext/accounts/party.py:612
+#: erpnext/accounts/party.py:618
 msgid "Debtor/Creditor Advance"
 msgstr "Avans dužnika/poverioca"
 
@@ -15478,7 +15464,7 @@ msgstr "Podrazumevani račun primljenih avansa"
 msgid "Default BOM"
 msgstr "Podrazumevana sastavnica"
 
-#: erpnext/stock/doctype/item/item.py:418
+#: erpnext/stock/doctype/item/item.py:421
 msgid "Default BOM ({0}) must be active for this item or its template"
 msgstr "Podrazumevana sastavnica ({0}) mora biti aktivna za ovu stavku ili njen šablon"
 
@@ -15486,7 +15472,7 @@ msgstr "Podrazumevana sastavnica ({0}) mora biti aktivna za ovu stavku ili njen 
 msgid "Default BOM for {0} not found"
 msgstr "Podrazumevana sastavnica za {0} nije pronađena"
 
-#: erpnext/controllers/accounts_controller.py:3672
+#: erpnext/controllers/accounts_controller.py:3675
 msgid "Default BOM not found for FG Item {0}"
 msgstr "Podrazumevana sastavnica nije pronađena za gotov proizvod {0}"
 
@@ -15774,11 +15760,11 @@ msgstr "Podrazumevani uslovi prodaje"
 #. 'Service Level Agreement'
 #: erpnext/support/doctype/service_level_agreement/service_level_agreement.json
 msgid "Default Service Level Agreement"
-msgstr "Podrazumevani Ugovor o nivou usluge"
+msgstr "Podrazumevani sporazum o nivou usluge"
 
 #: erpnext/support/doctype/service_level_agreement/service_level_agreement.py:161
 msgid "Default Service Level Agreement for {0} already exists."
-msgstr "Podrazumevani Ugovor o nivou usluga {0} već postoji."
+msgstr "Podrazumevani sporazum o nivou usluge {0} već postoji."
 
 #. Label of the default_source_warehouse (Link) field in DocType 'BOM'
 #. Label of the default_warehouse (Link) field in DocType 'BOM Creator'
@@ -15821,15 +15807,15 @@ msgstr "Podrazumevana teritorija"
 msgid "Default Unit of Measure"
 msgstr "Podrazumevana jedinica mere"
 
-#: erpnext/stock/doctype/item/item.py:1272
+#: erpnext/stock/doctype/item/item.py:1266
 msgid "Default Unit of Measure for Item {0} cannot be changed directly because you have already made some transaction(s) with another UOM. You need to either cancel the linked documents or create a new Item."
 msgstr "Podrazumevana jedinica mere za stavku {0} ne može se direktno promeniti jer je transakcija već izvršena sa drugom jedinicom mere. Potrebno je otkazati povezana dokumenta ili kreiranje nove stavke."
 
-#: erpnext/stock/doctype/item/item.py:1255
+#: erpnext/stock/doctype/item/item.py:1249
 msgid "Default Unit of Measure for Item {0} cannot be changed directly because you have already made some transaction(s) with another UOM. You will need to create a new Item to use a different Default UOM."
 msgstr "Podrazumevana jedinica mere za stavku {0} ne može se direktno promeniti jer je već izvršena transakcija sa drugom jedinicom mere. Neophodno je kreiranje nove stavke u cilju korišćenja podrazumevane jedinice mere."
 
-#: erpnext/stock/doctype/item/item.py:908
+#: erpnext/stock/doctype/item/item.py:902
 msgid "Default Unit of Measure for Variant '{0}' must be same as in Template '{1}'"
 msgstr "Podrazumevana jedinica mere za varijantu '{0}' mora biti ista kao u šablonu '{1}'"
 
@@ -16288,7 +16274,7 @@ msgstr "Analiza otpremnica"
 msgid "Delivery Note {0} is not submitted"
 msgstr "Otpremnica {0} nije podneta"
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1142
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1144
 #: erpnext/stock/doctype/delivery_trip/delivery_trip.js:73
 msgid "Delivery Notes"
 msgstr "Otpremnice"
@@ -16819,7 +16805,7 @@ msgstr "Amortizacija eliminisana putem poništavanja"
 #: erpnext/projects/doctype/task_type/task_type.json
 #: erpnext/projects/doctype/timesheet_detail/timesheet_detail.json
 #: erpnext/public/js/bank_reconciliation_tool/data_table_manager.js:55
-#: erpnext/public/js/controllers/transaction.js:2376
+#: erpnext/public/js/controllers/transaction.js:2402
 #: erpnext/selling/doctype/installation_note_item/installation_note_item.json
 #: erpnext/selling/doctype/product_bundle/product_bundle.json
 #: erpnext/selling/doctype/product_bundle_item/product_bundle_item.json
@@ -17007,7 +16993,7 @@ msgstr "Račun razlike u tabeli stavki"
 msgid "Difference Account must be a Asset/Liability type account (Temporary Opening), since this Stock Entry is an Opening Entry"
 msgstr "Račun razlike mora biti račun imovine ili obaveza (privremeno početno stanje), jer je ovaj unos zaliha unos otvaranja početnog stanja"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:954
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:950
 msgid "Difference Account must be a Asset/Liability type account, since this Stock Reconciliation is an Opening Entry"
 msgstr "Račun razlike mora biti račun imovine ili obaveza, jer ovo usklađivanje zaliha predstavlja unos početnog stanja"
 
@@ -17273,11 +17259,11 @@ msgstr "Izabran onemogućeni račun"
 msgid "Disabled Warehouse {0} cannot be used for this transaction."
 msgstr "Onemogućeno skladište {0} se ne može koristiti za ovu transakciju."
 
-#: erpnext/controllers/accounts_controller.py:745
+#: erpnext/controllers/accounts_controller.py:748
 msgid "Disabled pricing rules since this {} is an internal transfer"
 msgstr "Cenovna pravila su onemogućena jer je ovo {} interna transakcija"
 
-#: erpnext/controllers/accounts_controller.py:759
+#: erpnext/controllers/accounts_controller.py:762
 msgid "Disabled tax included prices since this {} is an internal transfer"
 msgstr "Cene sa uključenim porezom su onemogućene jer je ovo {} interna transakcija"
 
@@ -18219,7 +18205,7 @@ msgstr "Direktna dostava"
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.json
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/print_format/sales_invoice_print/sales_invoice_print.html:72
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1106
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1108
 #: erpnext/assets/doctype/asset_maintenance_log/asset_maintenance_log.json
 #: erpnext/selling/report/payment_terms_status_for_sales_order/payment_terms_status_for_sales_order.py:40
 msgid "Due Date"
@@ -18233,11 +18219,11 @@ msgstr "Datum dospeća"
 msgid "Due Date Based On"
 msgstr "Datum dospeća zasnovan na"
 
-#: erpnext/accounts/party.py:695
+#: erpnext/accounts/party.py:701
 msgid "Due Date cannot be after {0}"
 msgstr "Datum dospeća ne može biti nakon {0}"
 
-#: erpnext/accounts/party.py:671
+#: erpnext/accounts/party.py:677
 msgid "Due Date cannot be before {0}"
 msgstr "Datum dospeća ne može biti pre {0}"
 
@@ -18955,7 +18941,7 @@ msgstr "Omogućite zakazivanje termina"
 msgid "Enable Auto Email"
 msgstr "Omogućite automatski imejl"
 
-#: erpnext/stock/doctype/item/item.py:1064
+#: erpnext/stock/doctype/item/item.py:1058
 msgid "Enable Auto Re-Order"
 msgstr "Omogućite automatsko ponovno naručivanje"
 
@@ -19074,7 +19060,7 @@ msgstr "Omogući ovu opciju za izračunavanje dnevne amortizacije uzimajući u o
 
 #: erpnext/support/doctype/service_level_agreement/service_level_agreement.js:34
 msgid "Enable to apply SLA on every {0}"
-msgstr "Omogući primenu Ugovora o nivou usluge za svaki {0}"
+msgstr "Omogući primenu sporazuma o nivou usluge za svaki {0}"
 
 #. Label of the enabled (Check) field in DocType 'Mode of Payment'
 #. Label of the enabled (Check) field in DocType 'Plaid Settings'
@@ -19168,7 +19154,7 @@ msgstr "Datum unovčenja"
 msgid "End Date"
 msgstr "Datum završetka"
 
-#: erpnext/crm/doctype/contract/contract.py:75
+#: erpnext/crm/doctype/contract/contract.py:83
 msgid "End Date cannot be before Start Date."
 msgstr "Datum ne može biti pre datuma početka."
 
@@ -19419,7 +19405,7 @@ msgstr "Erg"
 #: erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.json
 #: erpnext/manufacturing/doctype/job_card/job_card.py:875
 #: erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.json
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:297
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:298
 msgid "Error"
 msgstr "Greška"
 
@@ -19544,7 +19530,7 @@ msgstr "Franko fabrika (EXW)"
 msgid "Example URL"
 msgstr "Primer URL-a"
 
-#: erpnext/stock/doctype/item/item.py:995
+#: erpnext/stock/doctype/item/item.py:989
 msgid "Example of a linked document: {0}"
 msgstr "Primer povezanog dokumenta: {0}"
 
@@ -19560,7 +19546,7 @@ msgstr "Primer: ABCD.#####\n"
 msgid "Example: ABCD.#####. If series is set and Batch No is not mentioned in transactions, then automatic batch number will be created based on this series. If you always want to explicitly mention Batch No for this item, leave this blank. Note: this setting will take priority over the Naming Series Prefix in Stock Settings."
 msgstr "Primer: ABCD.#####. Ukoliko je serija postavljena i broj šarže nije naveden u transakcijama, automatski će biti kreiran broj šarže na osnovu ove serije. Ukoliko želite da eksplicitno navedete broj šarže za ovu stavku, ostavite ovo prazno. Napomena: ovo podešavanje ima prioritet u odnosu na prefiks serije za imenovanje u postavkama zaliha."
 
-#: erpnext/stock/stock_ledger.py:2141
+#: erpnext/stock/stock_ledger.py:2149
 msgid "Example: Serial No {0} reserved in {1}."
 msgstr "Primer: Broj serije {0} je rezervisan u {1}."
 
@@ -19614,8 +19600,8 @@ msgstr "Prihod ili rashod kursnih razlika"
 msgid "Exchange Gain/Loss"
 msgstr "Prihod/Rashod kursnih razlika"
 
-#: erpnext/controllers/accounts_controller.py:1593
-#: erpnext/controllers/accounts_controller.py:1677
+#: erpnext/controllers/accounts_controller.py:1596
+#: erpnext/controllers/accounts_controller.py:1680
 msgid "Exchange Gain/Loss amount has been booked through {0}"
 msgstr "Iznos prihoda/rashoda kursnih razlika evidentiran je preko {0}"
 
@@ -20351,7 +20337,7 @@ msgid "Fetching Error"
 msgstr "Greška prilikom preuzimanja"
 
 #: erpnext/accounts/doctype/dunning/dunning.js:135
-#: erpnext/public/js/controllers/transaction.js:1251
+#: erpnext/public/js/controllers/transaction.js:1277
 msgid "Fetching exchange rates ..."
 msgstr "Preuzimanje deviznih kursnih lista ..."
 
@@ -20646,15 +20632,15 @@ msgstr "Količina gotovog proizvoda"
 msgid "Finished Good Item Quantity"
 msgstr "Količina gotovog proizvoda"
 
-#: erpnext/controllers/accounts_controller.py:3658
+#: erpnext/controllers/accounts_controller.py:3661
 msgid "Finished Good Item is not specified for service item {0}"
 msgstr "Gotov proizvod nije definisan za uslužnu stavku {0}"
 
-#: erpnext/controllers/accounts_controller.py:3675
+#: erpnext/controllers/accounts_controller.py:3678
 msgid "Finished Good Item {0} Qty can not be zero"
 msgstr "Količina gotovog proizvoda {0} ne može biti nula"
 
-#: erpnext/controllers/accounts_controller.py:3669
+#: erpnext/controllers/accounts_controller.py:3672
 msgid "Finished Good Item {0} must be a sub-contracted item"
 msgstr "Gotov proizvod {0} mora biti proizvod koji je proizveden putem podugovaranja"
 
@@ -20778,7 +20764,7 @@ msgstr "Rok za prvi odgovor"
 #: erpnext/support/doctype/issue/test_issue.py:238
 #: erpnext/support/doctype/service_level_agreement/service_level_agreement.py:898
 msgid "First Response SLA Failed by {}"
-msgstr "Prvi odgovor u okviru ugovora o nivou usluge nije ispoštovan od {}"
+msgstr "Prvi odgovor u okviru sporazuma o nivou usluge nije ispoštovan od {}"
 
 #. Label of the first_response_time (Duration) field in DocType 'Opportunity'
 #. Label of the first_response_time (Duration) field in DocType 'Issue'
@@ -20895,7 +20881,7 @@ msgstr "Račun osnovnih sredstava"
 msgid "Fixed Asset Defaults"
 msgstr "Zadati podaci za osnovna sredstva"
 
-#: erpnext/stock/doctype/item/item.py:301
+#: erpnext/stock/doctype/item/item.py:304
 msgid "Fixed Asset Item must be a non-stock item."
 msgstr "Osnovno sredstvo mora biti stavka van zaliha."
 
@@ -21071,7 +21057,7 @@ msgstr "Za količinu (proizvedena količina) je obavezna"
 msgid "For Raw Materials"
 msgstr "Za sirovine"
 
-#: erpnext/controllers/accounts_controller.py:1259
+#: erpnext/controllers/accounts_controller.py:1262
 msgid "For Return Invoices with Stock effect, '0' qty Items are not allowed. Following rows are affected: {0}"
 msgstr "Za reklamacione fakture koje utiču na skladište, stavke sa količinom '0' nisu dozvoljene. Sledeći redovi su pogođeni: {0}"
 
@@ -21172,7 +21158,7 @@ msgstr "Radi pogodnosti kupaca, ove šifre mogu se koristiti u formatima za šta
 msgid "For the item {0}, the quantity should be {1} according to the BOM {2}."
 msgstr "Za stavku {0}, količina treba da bude {1} u skladu sa sastavnicom {2}."
 
-#: erpnext/public/js/controllers/transaction.js:1088
+#: erpnext/public/js/controllers/transaction.js:1114
 msgctxt "Clear payment terms template and/or payment schedule when due date is changed"
 msgid "For the new {0} to take effect, would you like to clear the current {1}?"
 msgstr "Da bi novi {0} stupio na snagu, želite li da obrišete trenutni {1}?"
@@ -21181,7 +21167,7 @@ msgstr "Da bi novi {0} stupio na snagu, želite li da obrišete trenutni {1}?"
 msgid "For the {0}, no stock is available for the return in the warehouse {1}."
 msgstr "Za stavku {0}, nema dostupnog skladišđta za povratak u skladište {1}."
 
-#: erpnext/controllers/sales_and_purchase_return.py:1144
+#: erpnext/controllers/sales_and_purchase_return.py:1049
 msgid "For the {0}, the quantity is required to make the return entry"
 msgstr "Za {0}, količina je obavezna za unos povrata"
 
@@ -21518,7 +21504,7 @@ msgstr "Datum početka ne može biti veći od datum završetka"
 msgid "From Date is mandatory"
 msgstr "Datum početka je obavezan"
 
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:52
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:53
 #: erpnext/accounts/report/general_ledger/general_ledger.py:86
 #: erpnext/accounts/report/pos_register/pos_register.py:115
 #: erpnext/accounts/report/tax_withholding_details/tax_withholding_details.py:39
@@ -21895,14 +21881,14 @@ msgstr "Dalje čvorove je moguće kreirati samo u okviru čvorova vrste 'Grupa'"
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:186
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:155
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1134
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1136
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:177
 msgid "Future Payment Amount"
 msgstr "Iznos budućeg plaćanja"
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:185
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:154
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1133
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1135
 msgid "Future Payment Ref"
 msgstr "Referenca budućeg plaćanja"
 
@@ -23076,7 +23062,7 @@ msgstr "Pomaže Vam da raspodelite budžet/cilj po mesecima ako imate sezonalnos
 msgid "Here are the error logs for the aforementioned failed depreciation entries: {0}"
 msgstr "Ovo su evidencije grešaka za prethodno neuspele unose amortizacije: {0}"
 
-#: erpnext/stock/stock_ledger.py:1862
+#: erpnext/stock/stock_ledger.py:1871
 msgid "Here are the options to proceed:"
 msgstr "Evo opacija za nastavak:"
 
@@ -23602,7 +23588,7 @@ msgstr "Ukoliko je navedeno, sistem će omogućiti samo korisnicima sa ovom ulog
 msgid "If more than one package of the same type (for print)"
 msgstr "Ukoliko ima više od jednog pakovanja iste vrste (za štampu)"
 
-#: erpnext/stock/stock_ledger.py:1872
+#: erpnext/stock/stock_ledger.py:1881
 msgid "If not, you can Cancel / Submit this entry"
 msgstr "Ukoliko nije, možete otkazati/ podneti ovaj unos"
 
@@ -23627,7 +23613,7 @@ msgstr "Ukoliko sastavnica rezultira otpisanim stavkama, potrebno je izabrati sk
 msgid "If the account is frozen, entries are allowed to restricted users."
 msgstr "Ukoliko je račun zaključan, unos je dozvoljen samo ograničenom broju korisnika."
 
-#: erpnext/stock/stock_ledger.py:1865
+#: erpnext/stock/stock_ledger.py:1874
 msgid "If the item is transacting as a Zero Valuation Rate item in this entry, please enable 'Allow Zero Valuation Rate' in the {0} Item table."
 msgstr "Ukoliko se stavka knjiži kao stavka sa nultom stopom vrednovanja u ovom unosu, omogućite opciju 'Dozvoli nultu stopu vrednovanja' u tabeli stavki {0}."
 
@@ -24625,7 +24611,7 @@ msgstr "Pogrešan saldo količine nakon transakcije"
 msgid "Incorrect Batch Consumed"
 msgstr "Utrošena netačna šarža"
 
-#: erpnext/stock/doctype/item/item.py:514
+#: erpnext/stock/doctype/item/item.py:517
 msgid "Incorrect Check in (group) Warehouse for Reorder"
 msgstr "Netačno skladište za ponovno naručivanje"
 
@@ -24674,7 +24660,7 @@ msgstr "Netačni paketi serija i šarži"
 msgid "Incorrect Stock Value Report"
 msgstr "Izveštaj o netačnoj vrednosti zaliha"
 
-#: erpnext/stock/serial_batch_bundle.py:134
+#: erpnext/stock/serial_batch_bundle.py:135
 msgid "Incorrect Type of Transaction"
 msgstr "Netačan vrsta transakcije"
 
@@ -24943,8 +24929,8 @@ msgstr "Uputstva"
 msgid "Insufficient Capacity"
 msgstr "Nedovoljan kapacitet"
 
-#: erpnext/controllers/accounts_controller.py:3590
-#: erpnext/controllers/accounts_controller.py:3614
+#: erpnext/controllers/accounts_controller.py:3593
+#: erpnext/controllers/accounts_controller.py:3617
 msgid "Insufficient Permissions"
 msgstr "Nedovoljne dozvole"
 
@@ -24952,12 +24938,12 @@ msgstr "Nedovoljne dozvole"
 #: erpnext/stock/doctype/pick_list/pick_list.py:127
 #: erpnext/stock/doctype/pick_list/pick_list.py:975
 #: erpnext/stock/doctype/stock_entry/stock_entry.py:759
-#: erpnext/stock/serial_batch_bundle.py:989 erpnext/stock/stock_ledger.py:1559
-#: erpnext/stock/stock_ledger.py:2032
+#: erpnext/stock/serial_batch_bundle.py:1021 erpnext/stock/stock_ledger.py:1568
+#: erpnext/stock/stock_ledger.py:2040
 msgid "Insufficient Stock"
 msgstr "Nedovoljno zaliha"
 
-#: erpnext/stock/stock_ledger.py:2047
+#: erpnext/stock/stock_ledger.py:2055
 msgid "Insufficient Stock for Batch"
 msgstr "Nedovoljno zaliha za šaržu"
 
@@ -25095,11 +25081,11 @@ msgstr "Interni kupac"
 msgid "Internal Customer for company {0} already exists"
 msgstr "Interni kupac za kompaniju {0} već postoji"
 
-#: erpnext/controllers/accounts_controller.py:728
+#: erpnext/controllers/accounts_controller.py:731
 msgid "Internal Sale or Delivery Reference missing."
 msgstr "Nedostaje referenca za internu prodaju ili isporuku."
 
-#: erpnext/controllers/accounts_controller.py:730
+#: erpnext/controllers/accounts_controller.py:733
 msgid "Internal Sales Reference Missing"
 msgstr "Nedostaje referenca za internu prodaju"
 
@@ -25130,7 +25116,7 @@ msgstr "Interni dobavljač za kompaniju {0} već postoji"
 msgid "Internal Transfer"
 msgstr "Interni transfer"
 
-#: erpnext/controllers/accounts_controller.py:739
+#: erpnext/controllers/accounts_controller.py:742
 msgid "Internal Transfer Reference Missing"
 msgstr "Nedostaje referenca za interni transfer"
 
@@ -25173,8 +25159,8 @@ msgstr "Nevažeće"
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:969
 #: erpnext/assets/doctype/asset_category/asset_category.py:69
 #: erpnext/assets/doctype/asset_category/asset_category.py:97
-#: erpnext/controllers/accounts_controller.py:2975
-#: erpnext/controllers/accounts_controller.py:2983
+#: erpnext/controllers/accounts_controller.py:2978
+#: erpnext/controllers/accounts_controller.py:2986
 msgid "Invalid Account"
 msgstr "Nevažeći račun"
 
@@ -25199,7 +25185,7 @@ msgstr "Nevažeći datum automatskog ponavljanja"
 msgid "Invalid Barcode. There is no Item attached to this barcode."
 msgstr "Nevažeći bar-kod. Ne postoji stavka koja je priložena sa ovim bar-kodom."
 
-#: erpnext/public/js/controllers/transaction.js:2631
+#: erpnext/public/js/controllers/transaction.js:2657
 msgid "Invalid Blanket Order for the selected Customer and Item"
 msgstr "Nevažeća okvirna narudžbina za izabranog kupca i stavku"
 
@@ -25213,7 +25199,7 @@ msgstr "Nevažeća kompanija za međukompanijsku transakciju."
 
 #: erpnext/assets/doctype/asset/asset.py:295
 #: erpnext/assets/doctype/asset/asset.py:302
-#: erpnext/controllers/accounts_controller.py:2998
+#: erpnext/controllers/accounts_controller.py:3001
 msgid "Invalid Cost Center"
 msgstr "Nevažeći troškovni centar"
 
@@ -25255,7 +25241,7 @@ msgstr "Nevažeće grupisanje po"
 msgid "Invalid Item"
 msgstr "Nevažeća stavka"
 
-#: erpnext/stock/doctype/item/item.py:1410
+#: erpnext/stock/doctype/item/item.py:1404
 msgid "Invalid Item Defaults"
 msgstr "Nevažeći podrazumevani podaci za stavku"
 
@@ -25301,11 +25287,11 @@ msgstr "Nevažeća konfiguracija gubitaka u procesu"
 msgid "Invalid Purchase Invoice"
 msgstr "Nevažeća ulazna faktura"
 
-#: erpnext/controllers/accounts_controller.py:3627
+#: erpnext/controllers/accounts_controller.py:3630
 msgid "Invalid Qty"
 msgstr "Nevažeća količina"
 
-#: erpnext/controllers/accounts_controller.py:1277
+#: erpnext/controllers/accounts_controller.py:1280
 msgid "Invalid Quantity"
 msgstr "Nevažeća količina"
 
@@ -25322,7 +25308,7 @@ msgstr "Nevažeće izlazne fakture"
 msgid "Invalid Schedule"
 msgstr "Nevažeći raspored"
 
-#: erpnext/controllers/selling_controller.py:243
+#: erpnext/controllers/selling_controller.py:251
 msgid "Invalid Selling Price"
 msgstr "Nevažeća prodajna cena"
 
@@ -25355,7 +25341,7 @@ msgstr "Nevažeći izraz uslova"
 msgid "Invalid lost reason {0}, please create a new lost reason"
 msgstr "Nevažeći razlog gubitka {0}, molimo kreirajte nov razlog gubitka"
 
-#: erpnext/stock/doctype/item/item.py:408
+#: erpnext/stock/doctype/item/item.py:411
 msgid "Invalid naming series (. missing) for {0}"
 msgstr "Nevažeća serija imenovanja (. nedostaje) za {0}"
 
@@ -25395,7 +25381,7 @@ msgstr "Inventar"
 #. Name of a DocType
 #: erpnext/patches/v15_0/refactor_closing_stock_balance.py:43
 #: erpnext/stock/doctype/inventory_dimension/inventory_dimension.json
-#: erpnext/stock/doctype/inventory_dimension/inventory_dimension.py:180
+#: erpnext/stock/doctype/inventory_dimension/inventory_dimension.py:181
 msgid "Inventory Dimension"
 msgstr "Dimenzija inventara"
 
@@ -25461,7 +25447,7 @@ msgstr "Datum izdavanja"
 msgid "Invoice Discounting"
 msgstr "Diskontovanje fakture"
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1114
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1116
 msgid "Invoice Grand Total"
 msgstr "Ukupan zbir fakture"
 
@@ -25554,7 +25540,7 @@ msgstr "Faktura ne može biti napravljena za nula fakturisanih sati"
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:169
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:144
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1116
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1118
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:164
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:165
 msgid "Invoiced Amount"
@@ -25960,6 +25946,11 @@ msgstr "Unos početnog stanja"
 msgid "Is Outward"
 msgstr "Izlazno"
 
+#. Label of the is_packed (Check) field in DocType 'Serial and Batch Bundle'
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.json
+msgid "Is Packed"
+msgstr ""
+
 #. Label of the is_paid (Check) field in DocType 'Purchase Invoice'
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 msgid "Is Paid"
@@ -26242,11 +26233,11 @@ msgstr "Datum izdavanja"
 msgid "Issuing cannot be done to a location. Please enter employee to issue the Asset {0} to"
 msgstr "Izdavanje ne može biti izvršeno na lokaciji. Molimo Vas da unesite zaposleno lice kojem će biti dodeljena imovina {0}"
 
-#: erpnext/stock/doctype/item/item.py:565
+#: erpnext/stock/doctype/item/item.py:571
 msgid "It can take upto few hours for accurate stock values to be visible after merging items."
 msgstr "Može potrajati nekoliko sati da tačne vrednosti zaliha postanu vidljive nakon spajanja stavki."
 
-#: erpnext/public/js/controllers/transaction.js:2075
+#: erpnext/public/js/controllers/transaction.js:2101
 msgid "It is needed to fetch Item Details."
 msgstr "Potrebno je preuzeti detalje stavki."
 
@@ -26296,7 +26287,7 @@ msgstr "Nije moguće ravnomerno raspodeliti troškove kada je ukupni iznos nula,
 #: erpnext/buying/report/supplier_quotation_comparison/supplier_quotation_comparison.js:33
 #: erpnext/buying/report/supplier_quotation_comparison/supplier_quotation_comparison.py:204
 #: erpnext/buying/workspace/buying/buying.json
-#: erpnext/controllers/taxes_and_totals.py:1125
+#: erpnext/controllers/taxes_and_totals.py:1135
 #: erpnext/manufacturing/doctype/blanket_order/blanket_order.json
 #: erpnext/manufacturing/doctype/bom/bom.js:944
 #: erpnext/manufacturing/doctype/bom/bom.json
@@ -26574,7 +26565,7 @@ msgstr "Korpa stavke"
 #: erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py:86
 #: erpnext/manufacturing/report/work_order_stock_report/work_order_stock_report.py:119
 #: erpnext/projects/doctype/timesheet/timesheet.js:213
-#: erpnext/public/js/controllers/transaction.js:2350
+#: erpnext/public/js/controllers/transaction.js:2376
 #: erpnext/public/js/stock_reservation.js:112
 #: erpnext/public/js/stock_reservation.js:317 erpnext/public/js/utils.js:500
 #: erpnext/public/js/utils.js:656
@@ -27012,7 +27003,7 @@ msgstr "Proizvođač stavke"
 #: erpnext/manufacturing/report/production_planning_report/production_planning_report.py:359
 #: erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py:92
 #: erpnext/manufacturing/report/work_order_consumed_materials/work_order_consumed_materials.py:138
-#: erpnext/public/js/controllers/transaction.js:2356
+#: erpnext/public/js/controllers/transaction.js:2382
 #: erpnext/public/js/utils.js:746
 #: erpnext/selling/doctype/quotation_item/quotation_item.json
 #: erpnext/selling/doctype/sales_order_item/sales_order_item.json
@@ -27279,7 +27270,7 @@ msgstr "Podešavanja varijante stavke"
 msgid "Item Variant {0} already exists with same attributes"
 msgstr "Varijanta stavke {0} već postoji sa istim atributima"
 
-#: erpnext/stock/doctype/item/item.py:781
+#: erpnext/stock/doctype/item/item.py:772
 msgid "Item Variants updated"
 msgstr "Varijante stavke ažurirane"
 
@@ -27345,7 +27336,7 @@ msgstr "Detalji stavke i garancije"
 msgid "Item for row {0} does not match Material Request"
 msgstr "Stavke za red {0} ne odgovaraju zahtevu za nabavku"
 
-#: erpnext/stock/doctype/item/item.py:795
+#: erpnext/stock/doctype/item/item.py:789
 msgid "Item has variants."
 msgstr "Stavka ima varijante."
 
@@ -27371,7 +27362,7 @@ msgstr "Naziv stavke"
 msgid "Item operation"
 msgstr "Stavka operacije"
 
-#: erpnext/controllers/accounts_controller.py:3650
+#: erpnext/controllers/accounts_controller.py:3653
 msgid "Item qty can not be updated as raw materials are already processed."
 msgstr "Količina stavki ne može biti ažurirana jer su sirovine već obrađene."
 
@@ -27397,7 +27388,7 @@ msgstr "Stopa vrednovanja stavke je preračunata uzimajući u obzir dodatne tro�
 msgid "Item valuation reposting in progress. Report might show incorrect item valuation."
 msgstr "Ponovna obrada vrednovanja stavke je u toku. Izveštaj može prikazati netačno vrednovanje stavke."
 
-#: erpnext/stock/doctype/item/item.py:952
+#: erpnext/stock/doctype/item/item.py:946
 msgid "Item variant {0} exists with same attributes"
 msgstr "Varijanta stavke {0} postoji sa istim atributima"
 
@@ -27410,8 +27401,7 @@ msgid "Item {0} cannot be ordered more than {1} against Blanket Order {2}."
 msgstr "Stavka {0} ne može biti naručena u količini većoj od {1} prema okvirnom nalogu {2}."
 
 #: erpnext/assets/doctype/asset/asset.py:277
-#: erpnext/stock/doctype/item/item.py:630
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:167
+#: erpnext/stock/doctype/item/item.py:636
 msgid "Item {0} does not exist"
 msgstr "Stavka {0} ne postoji"
 
@@ -27423,7 +27413,7 @@ msgstr "Stavka {0} ne postoji u sistemu ili je istekla"
 msgid "Item {0} does not exist."
 msgstr "Stavka {0} ne postoji."
 
-#: erpnext/controllers/selling_controller.py:752
+#: erpnext/controllers/selling_controller.py:760
 msgid "Item {0} entered multiple times."
 msgstr "Stavka {0} je unesena više puta."
 
@@ -27439,7 +27429,7 @@ msgstr "Stavka {0} je onemogućena"
 msgid "Item {0} has no Serial No. Only serialized items can have delivery based on Serial No"
 msgstr "Stavka {0} nema broj serije. Samo stavke sa brojem serije mogu imati isporuku na osnovu serijskog broja"
 
-#: erpnext/stock/doctype/item/item.py:1126
+#: erpnext/stock/doctype/item/item.py:1120
 msgid "Item {0} has reached its end of life on {1}"
 msgstr "Stavka {0} je dostigla kraj svog životnog veka na dan {1}"
 
@@ -27451,11 +27441,11 @@ msgstr "Stavka {0} je zanemarena jer nije stavka na zalihama"
 msgid "Item {0} is already reserved/delivered against Sales Order {1}."
 msgstr "Stavka {0} je već rezervisana / isporučena prema prodajnoj porudžbini {1}."
 
-#: erpnext/stock/doctype/item/item.py:1146
+#: erpnext/stock/doctype/item/item.py:1140
 msgid "Item {0} is cancelled"
 msgstr "Stavka {0} je otkazana"
 
-#: erpnext/stock/doctype/item/item.py:1130
+#: erpnext/stock/doctype/item/item.py:1124
 msgid "Item {0} is disabled"
 msgstr "Stavka {0} je onemogućena"
 
@@ -27463,7 +27453,7 @@ msgstr "Stavka {0} je onemogućena"
 msgid "Item {0} is not a serialized Item"
 msgstr "Stavka {0} nije serijalizovana stavka"
 
-#: erpnext/stock/doctype/item/item.py:1138
+#: erpnext/stock/doctype/item/item.py:1132
 msgid "Item {0} is not a stock Item"
 msgstr "Stavka {0} nije stavka na zalihama"
 
@@ -27507,7 +27497,7 @@ msgstr "Stavka {0}: Naručena količina {1} ne može biti manja od minimalne kol
 msgid "Item {0}: {1} qty produced. "
 msgstr "Stavka {0}: Proizvedena količina {1}. "
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1429
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1423
 msgid "Item {} does not exist."
 msgstr "Stavka {} ne postoji."
 
@@ -27647,7 +27637,7 @@ msgstr "Stavke koje treba da se poruče"
 msgid "Items and Pricing"
 msgstr "Stavke i cene"
 
-#: erpnext/controllers/accounts_controller.py:3872
+#: erpnext/controllers/accounts_controller.py:3875
 msgid "Items cannot be updated as Subcontracting Order is created against the Purchase Order {0}."
 msgstr "Stavke ne mogu biti ažurirane jer je kreiran nalog za podugovaranje prema nabavnoj porudžbini {0}."
 
@@ -28143,7 +28133,7 @@ msgstr "Porezi i takse ukupni troškova isporuke"
 
 #. Name of a DocType
 #. Label of a Link in the Stock Workspace
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:674
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:676
 #: erpnext/stock/doctype/landed_cost_voucher/landed_cost_voucher.json
 #: erpnext/stock/doctype/purchase_receipt/purchase_receipt.js:104
 #: erpnext/stock/workspace/stock/stock.json
@@ -28759,7 +28749,7 @@ msgstr "Povezani računi"
 msgid "Linked Location"
 msgstr "Povezana lokacija"
 
-#: erpnext/stock/doctype/item/item.py:999
+#: erpnext/stock/doctype/item/item.py:993
 msgid "Linked with submitted documents"
 msgstr "Povezano sa podnetim dokumentima"
 
@@ -29498,7 +29488,7 @@ msgstr "Generalni direktor"
 #: erpnext/manufacturing/doctype/bom/bom.py:261
 #: erpnext/manufacturing/doctype/bom_update_log/bom_update_log.py:71
 #: erpnext/public/js/controllers/accounts.js:249
-#: erpnext/public/js/controllers/transaction.js:2753
+#: erpnext/public/js/controllers/transaction.js:2779
 #: erpnext/public/js/utils/party.js:321
 #: erpnext/stock/doctype/delivery_note/delivery_note.js:164
 #: erpnext/stock/doctype/inventory_dimension/inventory_dimension.json
@@ -30354,7 +30344,7 @@ msgstr "Maksimalna upotreba"
 msgid "Maximum Value"
 msgstr "Maksimalna vrednost"
 
-#: erpnext/controllers/selling_controller.py:212
+#: erpnext/controllers/selling_controller.py:220
 msgid "Maximum discount for Item {0} is {1}%"
 msgstr "Maksimalni popust za stavku {0} je {1}%"
 
@@ -30424,7 +30414,7 @@ msgstr "Megadžul"
 msgid "Megawatt"
 msgstr "Megavat"
 
-#: erpnext/stock/stock_ledger.py:1878
+#: erpnext/stock/stock_ledger.py:1887
 msgid "Mention Valuation Rate in the Item master."
 msgstr "Navesti stopu vrednovanja u master podacima stavki."
 
@@ -30819,11 +30809,11 @@ msgstr "Minute"
 msgid "Miscellaneous Expenses"
 msgstr "Razni troškovi"
 
-#: erpnext/controllers/buying_controller.py:540
+#: erpnext/controllers/buying_controller.py:548
 msgid "Mismatch"
 msgstr "Nepodudaranje"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1430
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1424
 msgid "Missing"
 msgstr "Nedostaje"
 
@@ -31350,7 +31340,7 @@ msgstr "Više varijanti"
 msgid "Multiple Warehouse Accounts"
 msgstr "Račun za više skladišta"
 
-#: erpnext/controllers/accounts_controller.py:1129
+#: erpnext/controllers/accounts_controller.py:1132
 msgid "Multiple fiscal years exist for the date {0}. Please set company in Fiscal Year"
 msgstr "Postoji više fiskalnih godina za datum {0}. Molimo postavite kompaniju u fiskalnu godinu"
 
@@ -31501,7 +31491,7 @@ msgstr "Prefiks serije imenovanja"
 msgid "Naming Series and Price Defaults"
 msgstr "Serija imenovanja i podrazumevane cene"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:90
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:91
 msgid "Naming Series is mandatory"
 msgstr "Serija imenovanja je obavezna"
 
@@ -31540,15 +31530,15 @@ msgstr "Prirodni gas"
 msgid "Needs Analysis"
 msgstr "Analiza potrebna"
 
-#: erpnext/stock/serial_batch_bundle.py:1277
+#: erpnext/stock/serial_batch_bundle.py:1309
 msgid "Negative Batch Quantity"
 msgstr "Negativna količina šarže"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:610
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:606
 msgid "Negative Quantity is not allowed"
 msgstr "Negativna količina nije dozvoljena"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:615
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:611
 msgid "Negative Valuation Rate is not allowed"
 msgstr "Negativna stopa vrednovanja nije dozvoljena"
 
@@ -31830,7 +31820,7 @@ msgstr "Neto težina"
 msgid "Net Weight UOM"
 msgstr "Jedinica mere neto težine"
 
-#: erpnext/controllers/accounts_controller.py:1483
+#: erpnext/controllers/accounts_controller.py:1486
 msgid "Net total calculation precision loss"
 msgstr "Gubitak preciznosti u izračunavanju neto ukupnog iznosa"
 
@@ -32173,7 +32163,7 @@ msgstr "Ne postoji profil maloprodaje. Molimo Vas da kreirate novi profil malopr
 #: erpnext/accounts/doctype/journal_entry/journal_entry.py:1539
 #: erpnext/accounts/doctype/journal_entry/journal_entry.py:1599
 #: erpnext/accounts/doctype/journal_entry/journal_entry.py:1613
-#: erpnext/stock/doctype/item/item.py:1371
+#: erpnext/stock/doctype/item/item.py:1365
 msgid "No Permission"
 msgstr "Bez dozvole"
 
@@ -32195,7 +32185,7 @@ msgstr "Bez napomena"
 msgid "No Selection"
 msgstr "Nije izvršen izbor"
 
-#: erpnext/controllers/sales_and_purchase_return.py:919
+#: erpnext/controllers/sales_and_purchase_return.py:824
 msgid "No Serial / Batches are available for return"
 msgstr "Nema serija / šarži dostupnih za povrat"
 
@@ -32231,7 +32221,7 @@ msgstr "Nema neusklađenih uplata za ovu stranku"
 msgid "No Work Orders were created"
 msgstr "Nisu kreirani radni nalozi"
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:785
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:794
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py:689
 msgid "No accounting entries for the following warehouses"
 msgstr "Nema računovodstvenih unosa za sledeća skladišta"
@@ -32420,7 +32410,7 @@ msgstr "Nije pronađen zapis u tabeli uplata"
 msgid "No reserved stock to unreserve."
 msgstr "Nisu pronađene rezervisane zalihe za poništavanje."
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:773
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:769
 msgid "No stock ledger entries were created. Please set the quantity or valuation rate for the items properly and try again."
 msgstr "Unosi u knjigu zaliha nisu kreirani. Molimo Vas da pravilno podesite količinu ili stopu vrednovanja za stavke i da pokušate ponovo."
 
@@ -32504,7 +32494,7 @@ msgstr "Komad"
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:566
 #: erpnext/assets/doctype/asset/asset.js:612
 #: erpnext/assets/doctype/asset/asset.js:627
-#: erpnext/controllers/buying_controller.py:225
+#: erpnext/controllers/buying_controller.py:233
 #: erpnext/selling/doctype/product_bundle/product_bundle.py:72
 #: erpnext/setup/doctype/transaction_deletion_record/transaction_deletion_record.py:80
 msgid "Not Allowed"
@@ -32625,10 +32615,10 @@ msgstr "Nije dozvoljeno"
 #: erpnext/selling/doctype/customer/customer.py:129
 #: erpnext/selling/doctype/sales_order/sales_order.js:1168
 #: erpnext/stock/doctype/item/item.js:526
-#: erpnext/stock/doctype/item/item.py:567
+#: erpnext/stock/doctype/item/item.py:573
 #: erpnext/stock/doctype/item_price/item_price.json
 #: erpnext/stock/doctype/stock_entry/stock_entry.py:1374
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:972
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:968
 #: erpnext/templates/pages/timelog_info.html:43
 msgid "Note"
 msgstr "Napomena"
@@ -32637,7 +32627,7 @@ msgstr "Napomena"
 msgid "Note: Automatic log deletion only applies to logs of type <i>Update Cost</i>"
 msgstr "Napomena: Automatsko brisanje evidencija primenjuje se samo na evidencije vrste: <i>Ažuriranje troška</i>"
 
-#: erpnext/accounts/party.py:690
+#: erpnext/accounts/party.py:696
 msgid "Note: Due Date exceeds allowed {0} credit days by {1} day(s)"
 msgstr "Napomena: Datum dospeća premašuje dozvoljeno odloženo plaćanje od {0} dana za {1} dan(a)"
 
@@ -32663,7 +32653,7 @@ msgstr "Napomena: Unos uplate neće biti kreiran jer nije navedena 'Blagajna ili
 msgid "Note: This Cost Center is a Group. Cannot make accounting entries against groups."
 msgstr "Napomena: Ovaj troškovni centar je grupa. Nije moguće napraviti računovodstvene unose protiv grupa."
 
-#: erpnext/stock/doctype/item/item.py:621
+#: erpnext/stock/doctype/item/item.py:627
 msgid "Note: To merge the items, create a separate Stock Reconciliation for the old item {0}"
 msgstr "Napomena: Da biste spojili stavke, kreirajte zasebno usklađivanje zaliha za stariju stavku {0}"
 
@@ -33427,7 +33417,7 @@ msgstr "Početne izlazne fakture su kreirane."
 
 #. Label of the opening_stock (Float) field in DocType 'Item'
 #. Option for the 'Purpose' (Select) field in DocType 'Stock Reconciliation'
-#: erpnext/stock/doctype/item/item.json erpnext/stock/doctype/item/item.py:296
+#: erpnext/stock/doctype/item/item.json erpnext/stock/doctype/item/item.py:299
 #: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.json
 msgid "Opening Stock"
 msgstr "Početni lager"
@@ -34147,7 +34137,7 @@ msgstr "Neizmireno (valuta kompanije)"
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:149
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1123
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1125
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:167
 #: erpnext/accounts/report/purchase_register/purchase_register.py:289
 #: erpnext/accounts/report/sales_register/sales_register.py:319
@@ -34186,7 +34176,7 @@ msgstr "Izlazno"
 msgid "Over Billing Allowance (%)"
 msgstr "Dozvola za fakturisanje preko limita (%)"
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:1242
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:1251
 msgid "Over Billing Allowance exceeded for Purchase Receipt Item {0} ({1}) by {2}%"
 msgstr "Dozvola za fakturisanje preko limita je premašena za stavku ulazne fakture {0} ({1}) za {2}%"
 
@@ -34227,7 +34217,7 @@ msgstr "Dozvola za prekoračenje prenosa (%)"
 msgid "Overbilling of {0} {1} ignored for item {2} because you have {3} role."
 msgstr "Prekoračenje naplate od {0} {1} zanemareno za stavku {2} jer imate ulogu {3}."
 
-#: erpnext/controllers/accounts_controller.py:2013
+#: erpnext/controllers/accounts_controller.py:2016
 msgid "Overbilling of {} ignored because you have {} role."
 msgstr "Prekoračenje naplate od {} zanemareno jer imate ulogu {}."
 
@@ -34734,7 +34724,7 @@ msgstr "Plaćeno"
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:146
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1117
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1119
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:165
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:172
 #: erpnext/accounts/report/pos_register/pos_register.py:209
@@ -34967,7 +34957,7 @@ msgstr "Matična procedura"
 msgid "Parent Row No"
 msgstr "Matični redni broj"
 
-#: erpnext/manufacturing/doctype/bom_creator/bom_creator.py:495
+#: erpnext/manufacturing/doctype/bom_creator/bom_creator.py:496
 msgid "Parent Row No not found for {0}"
 msgstr "Nije pronađen broj matičnog reda za {0}"
 
@@ -35196,7 +35186,7 @@ msgstr "Milioniti deo"
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:142
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:159
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:57
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1054
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1056
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:67
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:147
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:228
@@ -35222,7 +35212,7 @@ msgstr "Stranka"
 
 #. Name of a DocType
 #: erpnext/accounts/doctype/party_account/party_account.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1065
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1067
 msgid "Party Account"
 msgstr "Račun stranke"
 
@@ -35249,7 +35239,7 @@ msgstr "Valuta računa stranke"
 msgid "Party Account No. (Bank Statement)"
 msgstr "Broj računa stranke (Bankarski izvod)"
 
-#: erpnext/controllers/accounts_controller.py:2278
+#: erpnext/controllers/accounts_controller.py:2281
 msgid "Party Account {0} currency ({1}) and document currency ({2}) should be same"
 msgstr "Valuta računa stranke {0} ({1}) i valuta dokumenta ({2}) treba da bude ista"
 
@@ -35266,6 +35256,11 @@ msgstr "Bankarski račun stranke"
 #: erpnext/accounts/doctype/payment_request/payment_request.json
 msgid "Party Details"
 msgstr "Detalji stranke"
+
+#. Label of the party_full_name (Data) field in DocType 'Contract'
+#: erpnext/crm/doctype/contract/contract.json
+msgid "Party Full Name"
+msgstr ""
 
 #. Label of the bank_party_iban (Data) field in DocType 'Bank Transaction'
 #: erpnext/accounts/doctype/bank_transaction/bank_transaction.json
@@ -35350,7 +35345,7 @@ msgstr "Specifična stavka stranke"
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:84
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:54
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:44
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1048
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1050
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:54
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:141
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:219
@@ -35372,7 +35367,7 @@ msgstr "Specifična stavka stranke"
 msgid "Party Type"
 msgstr "Vrsta stranke"
 
-#: erpnext/accounts/party.py:819
+#: erpnext/accounts/party.py:825
 msgid "Party Type and Party can only be set for Receivable / Payable account<br><br>{0}"
 msgstr "Vrsta stranke i stranka mogu biti postavljeni za račun potraživanja / obaveza <br><br>{0}"
 
@@ -35456,7 +35451,7 @@ msgstr "Pauziraj posao"
 #. Name of a DocType
 #: erpnext/support/doctype/pause_sla_on_status/pause_sla_on_status.json
 msgid "Pause SLA On Status"
-msgstr "Pauziran Ugovor o nivou usluge u statusu"
+msgstr "Pauziran sporazum o nivou usluge u statusu"
 
 #. Option for the 'Status' (Select) field in DocType 'Process Payment
 #. Reconciliation'
@@ -35494,7 +35489,7 @@ msgid "Payable"
 msgstr "Plativ"
 
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:42
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1063
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1065
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:211
 #: erpnext/accounts/report/purchase_register/purchase_register.py:194
 #: erpnext/accounts/report/purchase_register/purchase_register.py:235
@@ -35660,7 +35655,7 @@ msgstr "Unos uplate je izmenjen nakon što ste ga povukli. Molimo Vas da ga pono
 msgid "Payment Entry is already created"
 msgstr "Unoć uplate je već kreiran"
 
-#: erpnext/controllers/accounts_controller.py:1434
+#: erpnext/controllers/accounts_controller.py:1437
 msgid "Payment Entry {0} is linked against Order {1}, check if it should be pulled as advance in this invoice."
 msgstr "Unos uplate {0} je povezan sa narudžbinom {1}, proverite da li treba da bude povučen kao avans u ovoj fakturi."
 
@@ -35942,7 +35937,7 @@ msgstr "Status naplate"
 #: erpnext/accounts/doctype/payment_schedule/payment_schedule.json
 #: erpnext/accounts/doctype/payment_term/payment_term.json
 #: erpnext/accounts/doctype/payment_terms_template_detail/payment_terms_template_detail.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1113
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1115
 #: erpnext/accounts/report/gross_profit/gross_profit.py:412
 #: erpnext/accounts/workspace/accounting/accounting.json
 #: erpnext/selling/report/payment_terms_status_for_sales_order/payment_terms_status_for_sales_order.py:30
@@ -37006,7 +37001,7 @@ msgstr "Molimo Vas da kreirate dokument za troškove nabavke za fakture koje ima
 msgid "Please create a new Accounting Dimension if required."
 msgstr "Molimo Vas da kreirate novu računovodstvenu dimenziju ukoliko je potrebno."
 
-#: erpnext/controllers/accounts_controller.py:729
+#: erpnext/controllers/accounts_controller.py:732
 msgid "Please create purchase from internal sale or delivery document itself"
 msgstr "Molimo Vas da kreirate nabavku iz interne prodaje ili iz samog dokumenta o isporuci"
 
@@ -37014,7 +37009,7 @@ msgstr "Molimo Vas da kreirate nabavku iz interne prodaje ili iz samog dokumenta
 msgid "Please create purchase receipt or purchase invoice for the item {0}"
 msgstr "Molimo Vas da kreirate prijemnicu nabavke ili ulaznu fakturu za stavku {0}"
 
-#: erpnext/stock/doctype/item/item.py:649
+#: erpnext/stock/doctype/item/item.py:655
 msgid "Please delete Product Bundle {0}, before merging {1} into {2}"
 msgstr "Molimo Vas da obrišete proizvodnu kombinaciju {0}, pre nego što spojite {1} u {2}"
 
@@ -37056,7 +37051,7 @@ msgstr "Molimo Vas da omogućite iskačuće prozore (pop-ups)"
 msgid "Please enable {0} in the {1}."
 msgstr "Molimo Vas da omogućite {0} u {1}."
 
-#: erpnext/controllers/selling_controller.py:754
+#: erpnext/controllers/selling_controller.py:762
 msgid "Please enable {} in {} to allow same item in multiple rows"
 msgstr "Molimo Vas da omogućite {} u {} da biste omogućili istu stavku u više redova"
 
@@ -37089,7 +37084,7 @@ msgstr "Molimo Vas da unesete račun za razliku u iznosu"
 msgid "Please enter Approving Role or Approving User"
 msgstr "Molimo Vas da unesete ulogu odobravanja ili korisnika koji odobrava"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:939
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:935
 msgid "Please enter Cost Center"
 msgstr "Molimo Vas da uneste troškovni centar"
 
@@ -37101,7 +37096,7 @@ msgstr "Molimo Vas da unesete datum isporuke"
 msgid "Please enter Employee Id of this sales person"
 msgstr "Molimo Vas da unesete ID zaposlenog lica za ovog prodavca"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:948
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:944
 msgid "Please enter Expense Account"
 msgstr "Molimo Vas da uneste račun rashoda"
 
@@ -37110,7 +37105,7 @@ msgstr "Molimo Vas da uneste račun rashoda"
 msgid "Please enter Item Code to get Batch Number"
 msgstr "Molimo Vas da unesete šifru stavke da biste dobili broj šarže"
 
-#: erpnext/public/js/controllers/transaction.js:2503
+#: erpnext/public/js/controllers/transaction.js:2529
 msgid "Please enter Item Code to get batch no"
 msgstr "Molimo Vas da uneste šifru stavke da biste dobili broj šarže"
 
@@ -37175,7 +37170,7 @@ msgstr "Molimo Vas da prvo unesete kompaniju"
 msgid "Please enter company name first"
 msgstr "Molimo Vas da prvo unesete naziv kompanije"
 
-#: erpnext/controllers/accounts_controller.py:2764
+#: erpnext/controllers/accounts_controller.py:2767
 msgid "Please enter default currency in Company Master"
 msgstr "Molimo Vas da unesete podrazumevanu valutu u master podacima o kompaniji"
 
@@ -37211,7 +37206,7 @@ msgstr "Molimo Vas da unesete naziv kompanije da biste potvrdili"
 msgid "Please enter the phone number first"
 msgstr "Molimo Vas da prvo unesete broj telefona"
 
-#: erpnext/controllers/buying_controller.py:1007
+#: erpnext/controllers/buying_controller.py:1015
 msgid "Please enter the {schedule_date}."
 msgstr "Molimo Vas da unesete {schedule_date}."
 
@@ -37313,7 +37308,7 @@ msgstr "Molimo Vas da prvo sačuvate"
 msgid "Please select <b>Template Type</b> to download template"
 msgstr "Molimo Vas da izaberete <b>Vrstu šablona</b> da preuzmete šablon"
 
-#: erpnext/controllers/taxes_and_totals.py:721
+#: erpnext/controllers/taxes_and_totals.py:731
 #: erpnext/public/js/controllers/taxes_and_totals.js:721
 msgid "Please select Apply Discount On"
 msgstr "Molimo Vas da izaberete na šta će se primeniti popust"
@@ -37326,7 +37321,7 @@ msgstr "Molimo Vas da izaberete sastavnicu za stavku {0}"
 msgid "Please select BOM for Item in Row {0}"
 msgstr "Molimo Vas da izaberete sastavnicu za stavku u redu {0}"
 
-#: erpnext/controllers/buying_controller.py:467
+#: erpnext/controllers/buying_controller.py:475
 msgid "Please select BOM in BOM field for Item {item_code}."
 msgstr "Molimo Vas da izaberete sastavnicu u polju sastavnice za stavku {item_code}."
 
@@ -37408,7 +37403,7 @@ msgstr "Molimo Vas da izaberete cenovnik"
 msgid "Please select Qty against item {0}"
 msgstr "Molimo Vas da izaberete količinu za stavku {0}"
 
-#: erpnext/stock/doctype/item/item.py:320
+#: erpnext/stock/doctype/item/item.py:323
 msgid "Please select Sample Retention Warehouse in Stock Settings first"
 msgstr "Molimo Vas da prvo izaberete skladište za zadržane uzorke u podešavanjima zaliha"
 
@@ -37424,7 +37419,7 @@ msgstr "Molimo Vas da izaberete datum početka i datum završetka za stavku {0}"
 msgid "Please select Subcontracting Order instead of Purchase Order {0}"
 msgstr "Molimo Vas da izaberete nalog za podugovaranje umesto nabavne porudžbine {0}"
 
-#: erpnext/controllers/accounts_controller.py:2613
+#: erpnext/controllers/accounts_controller.py:2616
 msgid "Please select Unrealized Profit / Loss account or add default Unrealized Profit / Loss account account for company {0}"
 msgstr "Molimo Vas da izaberete račun nerealizovanog dobitka/gubitka ili da dodate podrazumevani račun nerealizovanog dobitka/gubitka za kompaniju {0}"
 
@@ -37440,7 +37435,7 @@ msgstr "Molimo Vas da izaberete kompaniju"
 #: erpnext/manufacturing/doctype/bom/bom.js:603
 #: erpnext/manufacturing/doctype/bom/bom.py:261
 #: erpnext/public/js/controllers/accounts.js:249
-#: erpnext/public/js/controllers/transaction.js:2753
+#: erpnext/public/js/controllers/transaction.js:2779
 msgid "Please select a Company first."
 msgstr "Molimo Vas da prvo izaberete kompaniju."
 
@@ -37598,7 +37593,7 @@ msgstr "Molimo Vas da izaberete {0}"
 msgid "Please select {0} first"
 msgstr "Molimo Vas da prvo izaberete {0}"
 
-#: erpnext/public/js/controllers/transaction.js:77
+#: erpnext/public/js/controllers/transaction.js:100
 msgid "Please set 'Apply Additional Discount On'"
 msgstr "Molimo Vas da postavite 'Primeni dodatni popust na'"
 
@@ -37783,7 +37778,7 @@ msgstr "Molimo Vas da postavite filter na osnovu stavke ili skladišta"
 msgid "Please set filters"
 msgstr "Molimo Vas da postavite filtere"
 
-#: erpnext/controllers/accounts_controller.py:2194
+#: erpnext/controllers/accounts_controller.py:2197
 msgid "Please set one of the following:"
 msgstr "Molimo Vas da postavite jedno od sledećeg:"
 
@@ -37791,7 +37786,7 @@ msgstr "Molimo Vas da postavite jedno od sledećeg:"
 msgid "Please set opening number of booked depreciations"
 msgstr "Molimo Vas da unesete početni broj knjiženih amortizacija"
 
-#: erpnext/public/js/controllers/transaction.js:2205
+#: erpnext/public/js/controllers/transaction.js:2231
 msgid "Please set recurring after saving"
 msgstr "Molimo Vas da postavite ponavljanje nakon čuvanja"
 
@@ -37862,7 +37857,7 @@ msgstr "Molimo Vas da postavite i omogućite grupni račun sa vrstom računa - {
 msgid "Please share this email with your support team so that they can find and fix the issue."
 msgstr "Molimo Vas da podelite ovaj imejl sa Vašim timom za podršku kako bi mogli pronaći i rešiti problem."
 
-#: erpnext/public/js/controllers/transaction.js:2073
+#: erpnext/public/js/controllers/transaction.js:2099
 msgid "Please specify"
 msgstr "Molimo Vas da precizirate"
 
@@ -37877,7 +37872,7 @@ msgid "Please specify Company to proceed"
 msgstr "Molimo Vas da precizirate kompaniju da biste nastavili"
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1472
-#: erpnext/controllers/accounts_controller.py:2957
+#: erpnext/controllers/accounts_controller.py:2960
 #: erpnext/public/js/controllers/accounts.js:97
 msgid "Please specify a valid Row ID for row {0} in table {1}"
 msgstr "Molimo Vas da precizirate validan ID red za red {0} u tabeli {1}"
@@ -37890,7 +37885,7 @@ msgstr "Molimo Vas precizirajte {0}."
 msgid "Please specify at least one attribute in the Attributes table"
 msgstr "Molimo Vas da precizirate barem jedan atribut u tabeli atributa"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:605
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:601
 msgid "Please specify either Quantity or Valuation Rate or both"
 msgstr "Molimo Vas da precizirate ili količinu ili stopu vrednovanja ili oba"
 
@@ -38071,7 +38066,7 @@ msgstr "Poštanski troškovi"
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:16
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:15
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:18
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1046
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1048
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:15
 #: erpnext/accounts/report/bank_clearance_summary/bank_clearance_summary.py:35
 #: erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.html:7
@@ -40252,7 +40247,7 @@ msgstr "Glavni mendžer za nabavku"
 #: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.js:48
 #: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:203
 #: erpnext/buying/workspace/buying/buying.json
-#: erpnext/controllers/buying_controller.py:739
+#: erpnext/controllers/buying_controller.py:747
 #: erpnext/crm/doctype/contract/contract.json
 #: erpnext/manufacturing/doctype/blanket_order/blanket_order.js:54
 #: erpnext/manufacturing/doctype/production_plan_sub_assembly_item/production_plan_sub_assembly_item.json
@@ -40391,7 +40386,7 @@ msgstr "Nabavne porudžbine za fakturisanje"
 msgid "Purchase Orders to Receive"
 msgstr "Nabavne porudžbine za prijem"
 
-#: erpnext/controllers/accounts_controller.py:1833
+#: erpnext/controllers/accounts_controller.py:1836
 msgid "Purchase Orders {0} are un-linked"
 msgstr "Nabavne porudžbine {0} nisu povezane"
 
@@ -40415,8 +40410,8 @@ msgstr "Cenovnik nabavke"
 #. Label of a Link in the Stock Workspace
 #. Label of a shortcut in the Stock Workspace
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:171
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:650
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:660
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:652
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:662
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice_list.js:49
 #: erpnext/accounts/doctype/purchase_invoice_item/purchase_invoice_item.json
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:246
@@ -41151,7 +41146,7 @@ msgstr "Šablon inspekcije kvaliteta"
 msgid "Quality Inspection Template Name"
 msgstr "Naziv šablona inspekcije kvaliteta"
 
-#: erpnext/public/js/controllers/transaction.js:334
+#: erpnext/public/js/controllers/transaction.js:360
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:165
 msgid "Quality Inspection(s)"
 msgstr "Inspekcije kvaliteta"
@@ -42335,7 +42330,7 @@ msgid "Receivable / Payable Account"
 msgstr "Račun potraživanja / obaveza"
 
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:71
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1061
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1063
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py:243
 #: erpnext/accounts/report/sales_register/sales_register.py:217
 #: erpnext/accounts/report/sales_register/sales_register.py:271
@@ -42817,7 +42812,7 @@ msgstr "Referenca #{0} od {1}"
 msgid "Reference Date"
 msgstr "Datum reference"
 
-#: erpnext/public/js/controllers/transaction.js:2311
+#: erpnext/public/js/controllers/transaction.js:2337
 msgid "Reference Date for Early Payment Discount"
 msgstr "Datum reference za popust na raniju uplatu"
 
@@ -43141,7 +43136,7 @@ msgstr "Regularno"
 msgid "Rejected"
 msgstr "Odbijeno"
 
-#: erpnext/stock/doctype/inventory_dimension/inventory_dimension.py:202
+#: erpnext/stock/doctype/inventory_dimension/inventory_dimension.py:203
 msgid "Rejected "
 msgstr "Odbijeno "
 
@@ -43245,7 +43240,7 @@ msgstr "Preostali iznos"
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:187
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:156
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1135
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1137
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:178
 msgid "Remaining Balance"
 msgstr "Preostali saldo"
@@ -43298,7 +43293,7 @@ msgstr "Napomena"
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:159
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:198
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:269
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1167
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1169
 #: erpnext/accounts/report/general_ledger/general_ledger.html:84
 #: erpnext/accounts/report/general_ledger/general_ledger.html:110
 #: erpnext/accounts/report/general_ledger/general_ledger.py:742
@@ -44048,7 +44043,7 @@ msgstr "Rezervisana količina"
 msgid "Reserved Quantity for Production"
 msgstr "Rezervisana količina za proizvodnju"
 
-#: erpnext/stock/stock_ledger.py:2147
+#: erpnext/stock/stock_ledger.py:2155
 msgid "Reserved Serial No."
 msgstr "Rezervisani broj serije."
 
@@ -44064,11 +44059,11 @@ msgstr "Rezervisani broj serije."
 #: erpnext/stock/doctype/pick_list/pick_list.js:153
 #: erpnext/stock/report/reserved_stock/reserved_stock.json
 #: erpnext/stock/report/stock_balance/stock_balance.py:499
-#: erpnext/stock/stock_ledger.py:2131
+#: erpnext/stock/stock_ledger.py:2139
 msgid "Reserved Stock"
 msgstr "Rezervisane zalihe"
 
-#: erpnext/stock/stock_ledger.py:2177
+#: erpnext/stock/stock_ledger.py:2185
 msgid "Reserved Stock for Batch"
 msgstr "Rezervisane zalihe za šaržu"
 
@@ -44080,7 +44075,7 @@ msgstr "Rezervisane zalihe za sirovine"
 msgid "Reserved Stock for Sub-assembly"
 msgstr "Rezervisane zalihe za podsklopove"
 
-#: erpnext/controllers/buying_controller.py:476
+#: erpnext/controllers/buying_controller.py:484
 msgid "Reserved Warehouse is mandatory for the Item {item_code} in Raw Materials supplied."
 msgstr "Rezervisano skladište je obavezno za stavku {item_code} u nabavljenim sirovinama."
 
@@ -44143,11 +44138,11 @@ msgstr "Resetuj tabelu sirovina"
 #: erpnext/support/doctype/issue/issue.js:48
 #: erpnext/support/doctype/issue/issue.json
 msgid "Reset Service Level Agreement"
-msgstr "Resetuj Ugovor o nivou usluga"
+msgstr "Resetuj sporazum o nivou usluge"
 
 #: erpnext/support/doctype/issue/issue.js:65
 msgid "Resetting Service Level Agreement."
-msgstr "Resetovanje Ugovora o nivou usluga."
+msgstr "Resetovanje sporazuma o nivou usluge."
 
 #. Label of the resignation_letter_date (Date) field in DocType 'Employee'
 #: erpnext/setup/doctype/employee/employee.json
@@ -44894,7 +44889,7 @@ msgstr "Rutiranje"
 msgid "Routing Name"
 msgstr "Naziv za rutiranje"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:667
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:663
 msgid "Row #"
 msgstr "Red #"
 
@@ -44932,7 +44927,7 @@ msgstr "Red #{0} (Evidencija plaćanja): Iznos mora biti negativan"
 msgid "Row #{0} (Payment Table): Amount must be positive"
 msgstr "Red #{0} (Evidencija plaćanja): Iznos mora biti pozitivan"
 
-#: erpnext/stock/doctype/item/item.py:495
+#: erpnext/stock/doctype/item/item.py:498
 msgid "Row #{0}: A reorder entry already exists for warehouse {1} with reorder type {2}."
 msgstr "Red #{0}: Unos za ponovnu narudžbinu već postoji za skladište {1} sa vrstom ponovne narudžbine {2}."
 
@@ -44953,7 +44948,7 @@ msgstr "Red #{0}: Skladište prihvaćenih zaliha i Skladište odbijenih zaliha n
 msgid "Row #{0}: Accepted Warehouse is mandatory for the accepted Item {1}"
 msgstr "Red #{0}: Skladište prihvaćenih zaliha je obavezno za prihvaćenu stavku {1}"
 
-#: erpnext/controllers/accounts_controller.py:1117
+#: erpnext/controllers/accounts_controller.py:1120
 msgid "Row #{0}: Account {1} does not belong to company {2}"
 msgstr "Red #{0}: Račun {1} ne pripada kompaniji {2}"
 
@@ -44994,27 +44989,27 @@ msgstr "Red #{0}: Broj šarže {1} je već izabran."
 msgid "Row #{0}: Cannot allocate more than {1} against payment term {2}"
 msgstr "Red #{0}: Ne može se raspodeliti više od {1} za uslov plaćanja {2}"
 
-#: erpnext/controllers/accounts_controller.py:3524
+#: erpnext/controllers/accounts_controller.py:3527
 msgid "Row #{0}: Cannot delete item {1} which has already been billed."
 msgstr "Red #{0}: Ne može se obrisati stavka {1} koja je već fakturisana."
 
-#: erpnext/controllers/accounts_controller.py:3498
+#: erpnext/controllers/accounts_controller.py:3501
 msgid "Row #{0}: Cannot delete item {1} which has already been delivered"
 msgstr "Red #{0}: Ne može se obrisati stavka {1} koja je već isporučena"
 
-#: erpnext/controllers/accounts_controller.py:3517
+#: erpnext/controllers/accounts_controller.py:3520
 msgid "Row #{0}: Cannot delete item {1} which has already been received"
 msgstr "Red #{0}: Ne može se obrisati stavka {1} koja je već primljena"
 
-#: erpnext/controllers/accounts_controller.py:3504
+#: erpnext/controllers/accounts_controller.py:3507
 msgid "Row #{0}: Cannot delete item {1} which has work order assigned to it."
 msgstr "Red #{0}: Ne može se obrisati stavka {1} kojoj je dodeljen radni nalog."
 
-#: erpnext/controllers/accounts_controller.py:3510
+#: erpnext/controllers/accounts_controller.py:3513
 msgid "Row #{0}: Cannot delete item {1} which is assigned to customer's purchase order."
 msgstr "Red #{0}: Ne može se obrisati stavka {1} koja je dodeljena nabavnoj porudžbini."
 
-#: erpnext/controllers/accounts_controller.py:3765
+#: erpnext/controllers/accounts_controller.py:3768
 msgid "Row #{0}: Cannot set Rate if the billed amount is greater than the amount for Item {1}."
 msgstr "Red #{0}: Nije moguće postaviti cenu ukoliko je fakturisani iznos veći od iznosa za stavku {1}."
 
@@ -45134,7 +45129,7 @@ msgstr "Red #{0}: Stavka {1} ne postoji"
 msgid "Row #{0}: Item {1} has been picked, please reserve stock from the Pick List."
 msgstr "Red #{0}: Stavka {1} je odabrana, molimo Vas da rezervišite zalihe sa liste za odabir."
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:729
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:725
 msgid "Row #{0}: Item {1} is not a Serialized/Batched Item. It cannot have a Serial No/Batch No against it."
 msgstr "Red #{0}: Stavka {1} nije stavka serije / šarže. Ne može imati broj serije / šarže."
 
@@ -45190,7 +45185,7 @@ msgstr "Red #{0}: Molimo Vas da izaberete broj sastavnice u sastavljenim stavkam
 msgid "Row #{0}: Please select the Sub Assembly Warehouse"
 msgstr "Red #{0}: Molimo Vas da izaberete skladište podsklopova"
 
-#: erpnext/stock/doctype/item/item.py:502
+#: erpnext/stock/doctype/item/item.py:505
 msgid "Row #{0}: Please set reorder quantity"
 msgstr "Red #{0}: Molimo Vas da postavite količinu za naručivanje"
 
@@ -45223,8 +45218,8 @@ msgstr "Red #{0}: Inspekcija kvaliteta {1} nije podneta za stavku: {2}"
 msgid "Row #{0}: Quality Inspection {1} was rejected for item {2}"
 msgstr "Red #{0}: Inspekcija kvaliteta {1} je odbijena za stavku {2}"
 
-#: erpnext/controllers/accounts_controller.py:1274
-#: erpnext/controllers/accounts_controller.py:3624
+#: erpnext/controllers/accounts_controller.py:1277
+#: erpnext/controllers/accounts_controller.py:3627
 msgid "Row #{0}: Quantity for Item {1} cannot be zero."
 msgstr "Red #{0}: Količina za stavku {1} ne može biti nula."
 
@@ -45261,7 +45256,7 @@ msgstr "Red #{0}: Povrat po osnovu je neophodan za vraćanje imovine"
 msgid "Row #{0}: Scrap Item Qty cannot be zero"
 msgstr "Red #{0}: Količina otpisa ne može biti nula"
 
-#: erpnext/controllers/selling_controller.py:230
+#: erpnext/controllers/selling_controller.py:238
 msgid "Row #{0}: Selling rate for item {1} is lower than its {2}.\n"
 "\t\t\t\t\tSelling {3} should be atleast {4}.<br><br>Alternatively,\n"
 "\t\t\t\t\tyou can disable selling price validation in {5} to bypass\n"
@@ -45348,7 +45343,7 @@ msgstr "Red #{0}: Zalihe nisu dostupne za rezervaciju za stavku {1} u skladištu
 msgid "Row #{0}: The batch {1} has already expired."
 msgstr "Red #{0}: Šarža {1} je već istekla."
 
-#: erpnext/stock/doctype/item/item.py:511
+#: erpnext/stock/doctype/item/item.py:514
 msgid "Row #{0}: The warehouse {1} is not a child warehouse of a group warehouse {2}"
 msgstr "Red #{0}: Skladište {1} nije zavisno skladište grupnog skladišta {2}"
 
@@ -45388,39 +45383,39 @@ msgstr "Red #{0}: {1} od {2} treba da bude {3}. Molimo Vas da ažurirate {1} ili
 msgid "Row #{1}: Warehouse is mandatory for stock Item {0}"
 msgstr "Red #{1}: Skladište je obavezno za skladišne stavke {0}"
 
-#: erpnext/controllers/buying_controller.py:259
+#: erpnext/controllers/buying_controller.py:267
 msgid "Row #{idx}: Cannot select Supplier Warehouse while suppling raw materials to subcontractor."
 msgstr "Red #{idx}: Ne može se izabrati skladište dobavljača prilikom isporuke sirovina podugovarača."
 
-#: erpnext/controllers/buying_controller.py:406
+#: erpnext/controllers/buying_controller.py:414
 msgid "Row #{idx}: Item rate has been updated as per valuation rate since its an internal stock transfer."
 msgstr "Red #{idx}: Cena stavke je ažurirana prema stopi vrednovanja jer je u pitanju interni prenos zaliha."
 
-#: erpnext/controllers/buying_controller.py:881
+#: erpnext/controllers/buying_controller.py:889
 msgid "Row #{idx}: Please enter a location for the asset item {item_code}."
 msgstr "Red# {idx}: Unesite lokaciju za stavku imovine {item_code}."
 
-#: erpnext/controllers/buying_controller.py:537
+#: erpnext/controllers/buying_controller.py:545
 msgid "Row #{idx}: Received Qty must be equal to Accepted + Rejected Qty for Item {item_code}."
 msgstr "Red #{idx}: Primljena količina mora biti jednaka zbiru prihvaćene i odbijene količine za stavku {item_code}."
 
-#: erpnext/controllers/buying_controller.py:550
+#: erpnext/controllers/buying_controller.py:558
 msgid "Row #{idx}: {field_label} can not be negative for item {item_code}."
 msgstr "Red #{idx}: {field_label} ne može biti negativno za stavku {item_code}."
 
-#: erpnext/controllers/buying_controller.py:496
+#: erpnext/controllers/buying_controller.py:504
 msgid "Row #{idx}: {field_label} is mandatory."
 msgstr "Red #{idx}: {field_label} je obavezan."
 
-#: erpnext/controllers/buying_controller.py:518
+#: erpnext/controllers/buying_controller.py:526
 msgid "Row #{idx}: {field_label} is not allowed in Purchase Return."
 msgstr "Red #{idx}: {field_label} nije dozvoljeno u povraćaju nabavke."
 
-#: erpnext/controllers/buying_controller.py:250
+#: erpnext/controllers/buying_controller.py:258
 msgid "Row #{idx}: {from_warehouse_field} and {to_warehouse_field} cannot be same."
 msgstr "Red #{idx}: {from_warehouse_field} i {to_warehouse_field} ne mogu biti isto."
 
-#: erpnext/controllers/buying_controller.py:999
+#: erpnext/controllers/buying_controller.py:1007
 msgid "Row #{idx}: {schedule_date} cannot be before {transaction_date}."
 msgstr "Red #{idx}: {schedule_date} ne može biti pre {transaction_date}."
 
@@ -45485,7 +45480,7 @@ msgstr "Red #{}: {}"
 msgid "Row #{}: {} {} does not exist."
 msgstr "Red #{}: {} {} ne postoji."
 
-#: erpnext/stock/doctype/item/item.py:1403
+#: erpnext/stock/doctype/item/item.py:1397
 msgid "Row #{}: {} {} doesn't belong to Company {}. Please select valid {}."
 msgstr "Red #{}: {} {} ne pripada kompaniji {}. Molimo Vas da izaberete važeći {}."
 
@@ -45557,11 +45552,11 @@ msgstr "Red {0}: Sastavnica nije pronađena za stavku {1}"
 msgid "Row {0}: Both Debit and Credit values cannot be zero"
 msgstr "Red {0}: Dugovna i potražna strana ne mogu biti nula"
 
-#: erpnext/controllers/selling_controller.py:222
+#: erpnext/controllers/selling_controller.py:230
 msgid "Row {0}: Conversion Factor is mandatory"
 msgstr "Red {0}: Faktor konverzije je obavezan"
 
-#: erpnext/controllers/accounts_controller.py:2995
+#: erpnext/controllers/accounts_controller.py:2998
 msgid "Row {0}: Cost Center {1} does not belong to Company {2}"
 msgstr "Red {0}: Troškovni centar {1} ne pripada kompaniji {2}"
 
@@ -45581,11 +45576,11 @@ msgstr "Red {0}: Valuta za sastavnicu #{1} treba da bude jednaka izabranoj valut
 msgid "Row {0}: Debit entry can not be linked with a {1}"
 msgstr "Red {0}: Unos dugovne strane ne može biti povezan sa {1}"
 
-#: erpnext/controllers/selling_controller.py:776
+#: erpnext/controllers/selling_controller.py:784
 msgid "Row {0}: Delivery Warehouse ({1}) and Customer Warehouse ({2}) can not be same"
 msgstr "Red {0}: Skladište za isporuku ({1}) i skladište kupca ({2}) ne mogu biti isti"
 
-#: erpnext/controllers/accounts_controller.py:2529
+#: erpnext/controllers/accounts_controller.py:2532
 msgid "Row {0}: Due Date in the Payment Terms table cannot be before Posting Date"
 msgstr "Red {0}: Datum dospeća u tabeli uslova plaćanja ne može biti pre datuma knjiženja"
 
@@ -45594,7 +45589,7 @@ msgid "Row {0}: Either Delivery Note Item or Packed Item reference is mandatory.
 msgstr "Red {0}: Stavka iz otpremnice ili referenca upakovane stavke je obavezna."
 
 #: erpnext/accounts/doctype/journal_entry/journal_entry.py:1010
-#: erpnext/controllers/taxes_and_totals.py:1205
+#: erpnext/controllers/taxes_and_totals.py:1215
 msgid "Row {0}: Exchange Rate is mandatory"
 msgstr "Red {0}: Devizni kurs je obavezan"
 
@@ -45643,11 +45638,11 @@ msgstr "Red {0}: Vrednost časova mora biti veća od nule."
 msgid "Row {0}: Invalid reference {1}"
 msgstr "Red {0}: Nevažeća referenca {1}"
 
-#: erpnext/controllers/taxes_and_totals.py:142
+#: erpnext/controllers/taxes_and_totals.py:143
 msgid "Row {0}: Item Tax template updated as per validity and rate applied"
 msgstr "Red {0}: Šablon stavke poreza ažuriran prema važenju i primenjenoj stopi"
 
-#: erpnext/controllers/selling_controller.py:541
+#: erpnext/controllers/selling_controller.py:549
 msgid "Row {0}: Item rate has been updated as per valuation rate since its an internal stock transfer"
 msgstr "Red {0}: Cena stavke je ažurirana prema stopi vrednovanja jer je u pitanju interni prenos zaliha"
 
@@ -45767,7 +45762,7 @@ msgstr "Red {0}: Zadatak {1} ne pripada projektu {2}"
 msgid "Row {0}: The item {1}, quantity must be positive number"
 msgstr "Red {0}: Stavka {1}, količina mora biti pozitivan broj"
 
-#: erpnext/controllers/accounts_controller.py:2972
+#: erpnext/controllers/accounts_controller.py:2975
 msgid "Row {0}: The {3} Account {1} does not belong to the company {2}"
 msgstr "Red {0}: Račun {3} {1} ne pripada kompaniji {2}"
 
@@ -45784,7 +45779,7 @@ msgstr "Red {0}: Faktor konverzije jedinica mere je obavezan"
 msgid "Row {0}: Workstation or Workstation Type is mandatory for an operation {1}"
 msgstr "Red {0}: Radna stanica ili vrsta radne stanice je obavezna za operaciju {1}"
 
-#: erpnext/controllers/accounts_controller.py:1011
+#: erpnext/controllers/accounts_controller.py:1014
 msgid "Row {0}: user has not applied the rule {1} on the item {2}"
 msgstr "Red {0}: Korisnik nije primenio pravilo {1} na stavku {2}"
 
@@ -45796,7 +45791,7 @@ msgstr "Red {0}: Račun {1} je već primenjen na računovodstvenu dimenziju {2}"
 msgid "Row {0}: {1} must be greater than 0"
 msgstr "Red {0}: {1} mora biti veće od 0"
 
-#: erpnext/controllers/accounts_controller.py:706
+#: erpnext/controllers/accounts_controller.py:709
 msgid "Row {0}: {1} {2} cannot be same as {3} (Party Account) {4}"
 msgstr "Red {0}: {1} {2} ne može biti isto kao {3} (Račun stranke) {4}"
 
@@ -45812,7 +45807,7 @@ msgstr "Red {0}: Stavka {2} {1} ne postoji u {2} {3}"
 msgid "Row {1}: Quantity ({0}) cannot be a fraction. To allow this, disable '{2}' in UOM {3}."
 msgstr "Red {1}: Količina ({0}) ne može biti razlomak. Da biste to omogućili, onemogućite opciju '{2}' u jedinici mere {3}."
 
-#: erpnext/controllers/buying_controller.py:863
+#: erpnext/controllers/buying_controller.py:871
 msgid "Row {idx}: Asset Naming Series is mandatory for the auto creation of assets for item {item_code}."
 msgstr "Red {idx}: Serija imenovanja za imovinu je obavezna za automatsko kreiranje imovine za stavku {item_code}."
 
@@ -45838,7 +45833,7 @@ msgstr "Redovi uklonjeni u {0}"
 msgid "Rows with Same Account heads will be merged on Ledger"
 msgstr "Redovi sa istim analitičkim računima će biti spojeni u jedan račun"
 
-#: erpnext/controllers/accounts_controller.py:2539
+#: erpnext/controllers/accounts_controller.py:2542
 msgid "Rows with duplicate due dates in other rows were found: {0}"
 msgstr "Pronađeni su redovi sa duplim datumima dospeća u drugim redovima: {0}"
 
@@ -45896,29 +45891,29 @@ msgstr "Nabavljene stavke od dobavljača"
 #. Agreement'
 #: erpnext/support/doctype/service_level_agreement/service_level_agreement.json
 msgid "SLA Fulfilled On"
-msgstr "Ugovor o nivou usluge ispunjen"
+msgstr "Sporazum o nivou usluge ispunjen"
 
 #. Name of a DocType
 #: erpnext/support/doctype/sla_fulfilled_on_status/sla_fulfilled_on_status.json
 msgid "SLA Fulfilled On Status"
-msgstr "Status ispunjenja Ugovora o nivou usluge"
+msgstr "Status ispunjenja sporazuma o nivou usluge"
 
 #. Label of the pause_sla_on (Table) field in DocType 'Service Level Agreement'
 #: erpnext/support/doctype/service_level_agreement/service_level_agreement.json
 msgid "SLA Paused On"
-msgstr "Ugovor o nivou usluge je pauziran"
+msgstr "Sporazum o nivou usluge je pauziran"
 
-#: erpnext/public/js/utils.js:1167
+#: erpnext/public/js/utils.js:1163
 msgid "SLA is on hold since {0}"
-msgstr "Ugovor o nivou usluge je na čekanju od {0}"
+msgstr "Sporazum o nivou usluge je na čekanju od {0}"
 
 #: erpnext/support/doctype/service_level_agreement/service_level_agreement.js:52
 msgid "SLA will be applied if {1} is set as {2}{3}"
-msgstr "Ugovor o nivou usluge će se primeniti ukoliko je {1} podešen kao {2}{3}"
+msgstr "Sporazum o nivou usluge će se primeniti ukoliko je {1} podešen kao {2}{3}"
 
 #: erpnext/support/doctype/service_level_agreement/service_level_agreement.js:32
 msgid "SLA will be applied on every {0}"
-msgstr "Ugovor o nivou usluge će se primenjivati svakog {0}"
+msgstr "Sporazum o nivou usluge će se primenjivati svakog {0}"
 
 #. Label of a Link in the CRM Workspace
 #. Name of a DocType
@@ -46309,7 +46304,7 @@ msgstr "Prodajne prilike po izvoru"
 #: erpnext/accounts/report/sales_register/sales_register.py:238
 #: erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
 #: erpnext/buying/doctype/supplier_quotation_item/supplier_quotation_item.json
-#: erpnext/controllers/selling_controller.py:462
+#: erpnext/controllers/selling_controller.py:470
 #: erpnext/crm/doctype/contract/contract.json
 #: erpnext/maintenance/doctype/maintenance_schedule/maintenance_schedule.js:65
 #: erpnext/maintenance/doctype/maintenance_schedule_item/maintenance_schedule_item.json
@@ -46435,7 +46430,7 @@ msgstr "Prodajna porudžbina {0} nije podneta"
 msgid "Sales Order {0} is not valid"
 msgstr "Prodajna porudžbina {0} nije validna"
 
-#: erpnext/controllers/selling_controller.py:443
+#: erpnext/controllers/selling_controller.py:451
 #: erpnext/manufacturing/doctype/work_order/work_order.py:301
 msgid "Sales Order {0} is {1}"
 msgstr "Prodajna porudžbina {0} je {1}"
@@ -46486,7 +46481,7 @@ msgstr "Prodajne porudžbine za isporuku"
 #: erpnext/accounts/doctype/promotional_scheme/promotional_scheme.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:122
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1156
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1158
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:99
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:194
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:74
@@ -46584,7 +46579,7 @@ msgstr "Rezime uplate prodaje"
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:156
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:137
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:128
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1153
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1155
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:105
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:191
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:80
@@ -46604,7 +46599,7 @@ msgstr "Rezime uplate prodaje"
 msgid "Sales Person"
 msgstr "Prodavac"
 
-#: erpnext/controllers/selling_controller.py:204
+#: erpnext/controllers/selling_controller.py:212
 msgid "Sales Person <b>{0}</b> is disabled."
 msgstr "Prodavac <b>{0}</b> je onemogućen."
 
@@ -46885,7 +46880,7 @@ msgstr "Skladište za zadržane uzorke"
 
 #. Label of the sample_size (Float) field in DocType 'Quality Inspection'
 #: erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py:93
-#: erpnext/public/js/controllers/transaction.js:2369
+#: erpnext/public/js/controllers/transaction.js:2395
 #: erpnext/stock/doctype/quality_inspection/quality_inspection.json
 msgid "Sample Size"
 msgstr "Veličina uzorka"
@@ -47425,7 +47420,7 @@ msgstr "Izaberite stavke"
 msgid "Select Items based on Delivery Date"
 msgstr "Izaberite stavke na osnovu datuma isporuke"
 
-#: erpnext/public/js/controllers/transaction.js:2405
+#: erpnext/public/js/controllers/transaction.js:2431
 msgid "Select Items for Quality Inspection"
 msgstr "Izaberite stavke za kontrolu kvaliteta"
 
@@ -47566,7 +47561,7 @@ msgstr "Prvo izaberite kompaniju"
 msgid "Select company name first."
 msgstr "Prvo izaberite naziv kompanije."
 
-#: erpnext/controllers/accounts_controller.py:2785
+#: erpnext/controllers/accounts_controller.py:2788
 msgid "Select finance book for the item {0} at row {1}"
 msgstr "Izaberite finansijsku evidenciju za stavku {0} u redu {1}"
 
@@ -47780,7 +47775,7 @@ msgid "Send Now"
 msgstr "Pošalji sada"
 
 #. Label of the send_sms (Button) field in DocType 'SMS Center'
-#: erpnext/public/js/controllers/transaction.js:517
+#: erpnext/public/js/controllers/transaction.js:543
 #: erpnext/selling/doctype/sms_center/sms_center.json
 msgid "Send SMS"
 msgstr "Pošalji SMS"
@@ -47938,7 +47933,7 @@ msgstr "Brojevi serije / šarže"
 #: erpnext/manufacturing/doctype/job_card/job_card.json
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.js:74
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.py:114
-#: erpnext/public/js/controllers/transaction.js:2382
+#: erpnext/public/js/controllers/transaction.js:2408
 #: erpnext/public/js/utils/serial_no_batch_selector.js:421
 #: erpnext/selling/doctype/installation_note_item/installation_note_item.json
 #: erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
@@ -47987,7 +47982,7 @@ msgstr "Dnevnik brojeva serija"
 msgid "Serial No Range"
 msgstr "Opseg serijskih brojeva"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1894
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1895
 msgid "Serial No Reserved"
 msgstr "Rezervisani broj serije"
 
@@ -48027,7 +48022,7 @@ msgstr "Broj serije i šarža"
 msgid "Serial No and Batch Selector cannot be use when Use Serial / Batch Fields is enabled."
 msgstr "Selektor broja serije i šarže ne može biti korišćen kada je opcija koristi polja za seriju / šaržu omogućena."
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:859
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:860
 msgid "Serial No is mandatory"
 msgstr "Broj serije je obavezan"
 
@@ -48056,7 +48051,7 @@ msgstr "Broj serije {0} ne pripada stavci {1}"
 msgid "Serial No {0} does not exist"
 msgstr "Broj serije {0} ne postoji"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2623
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2624
 msgid "Serial No {0} does not exists"
 msgstr "Broj serije {0} ne postoji"
 
@@ -48064,7 +48059,7 @@ msgstr "Broj serije {0} ne postoji"
 msgid "Serial No {0} is already added"
 msgstr "Broj serije {0} je već dodat"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:357
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:358
 msgid "Serial No {0} is not present in the {1} {2}, hence you can't return it against the {1} {2}"
 msgstr "Broj serije {0} nije prisutan u {1} {2}, stoga ga ne možete vratiti protiv {1} {2}"
 
@@ -48101,11 +48096,11 @@ msgstr "Brojevi serije / Brojevi šarže"
 msgid "Serial Nos and Batches"
 msgstr "Brojevi serije i šarže"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1370
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1371
 msgid "Serial Nos are created successfully"
 msgstr "Brojevi serije su uspešno kreirani"
 
-#: erpnext/stock/stock_ledger.py:2137
+#: erpnext/stock/stock_ledger.py:2145
 msgid "Serial Nos are reserved in Stock Reservation Entries, you need to unreserve them before proceeding."
 msgstr "Brojevi serije su rezervisani u unosima rezervacije zalihe, morate poništiti rezervisanje pre nego što nastavite."
 
@@ -48179,11 +48174,11 @@ msgstr "Serija i šarža"
 msgid "Serial and Batch Bundle"
 msgstr "Paket serije i šarže"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1598
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1599
 msgid "Serial and Batch Bundle created"
 msgstr "Paket serije i šarže je kreiran"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1664
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1665
 msgid "Serial and Batch Bundle updated"
 msgstr "Paket serije i šarže je ažuriran"
 
@@ -48453,40 +48448,40 @@ msgstr "Uslužne stavke"
 #: erpnext/support/doctype/service_level_agreement/service_level_agreement.json
 #: erpnext/support/workspace/support/support.json
 msgid "Service Level Agreement"
-msgstr "Ugovor o nivou usluge"
+msgstr "Sporazum o nivou usluge"
 
 #. Label of the service_level_agreement_creation (Datetime) field in DocType
 #. 'Issue'
 #: erpnext/support/doctype/issue/issue.json
 msgid "Service Level Agreement Creation"
-msgstr "Kreiranje Ugovora o nivou usluge"
+msgstr "Kreiranje sporazuma o nivou usluge"
 
 #. Label of the service_level_section (Section Break) field in DocType 'Issue'
 #: erpnext/support/doctype/issue/issue.json
 msgid "Service Level Agreement Details"
-msgstr "Detalji Ugovora o nivou usluge"
+msgstr "Detalji sporazuma o nivou usluge"
 
 #. Label of the agreement_status (Select) field in DocType 'Issue'
 #: erpnext/support/doctype/issue/issue.json
 msgid "Service Level Agreement Status"
-msgstr "Status Ugovora o nivou usluge"
+msgstr "Status sporazuma o nivou usluge"
 
 #: erpnext/support/doctype/service_level_agreement/service_level_agreement.py:176
 msgid "Service Level Agreement for {0} {1} already exists."
-msgstr "Ugovor o nivou usluge za {0} {1} već postoji."
+msgstr "Sporazum o nivou usluge za {0} {1} već postoji."
 
 #: erpnext/support/doctype/service_level_agreement/service_level_agreement.py:763
 msgid "Service Level Agreement has been changed to {0}."
-msgstr "Ugovor o nivou usluge je promenjen na {0}."
+msgstr "Sporazum o nivou usluge je promenjen na {0}."
 
 #: erpnext/support/doctype/issue/issue.js:79
 msgid "Service Level Agreement was reset."
-msgstr "Ugovor o nivou usluge je resetovan."
+msgstr "Sporazum o nivou usluge je resetovan."
 
 #. Label of the sb_00 (Section Break) field in DocType 'Support Settings'
 #: erpnext/support/doctype/support_settings/support_settings.json
 msgid "Service Level Agreements"
-msgstr "Ugovori o nivou usluge"
+msgstr "Sporazumi o nivou usluge"
 
 #. Label of the service_level (Data) field in DocType 'Service Level Agreement'
 #: erpnext/support/doctype/service_level_agreement/service_level_agreement.json
@@ -48535,12 +48530,12 @@ msgid "Service Stop Date"
 msgstr "Datum prekidanja usluge"
 
 #: erpnext/accounts/deferred_revenue.py:44
-#: erpnext/public/js/controllers/transaction.js:1420
+#: erpnext/public/js/controllers/transaction.js:1446
 msgid "Service Stop Date cannot be after Service End Date"
 msgstr "Datum prekidanja usluge ne može biti posle datuma završetka usluge"
 
 #: erpnext/accounts/deferred_revenue.py:41
-#: erpnext/public/js/controllers/transaction.js:1417
+#: erpnext/public/js/controllers/transaction.js:1443
 msgid "Service Stop Date cannot be before Service Start Date"
 msgstr "Datum prekidanja usluge ne može biti pre datuma početka usluge"
 
@@ -49977,7 +49972,7 @@ msgstr "Standardni ocenjeni troškovi"
 
 #: erpnext/setup/setup_wizard/operations/defaults_setup.py:70
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:463
-#: erpnext/stock/doctype/item/item.py:245
+#: erpnext/stock/doctype/item/item.py:248
 msgid "Standard Selling"
 msgstr "Standardna prodaja"
 
@@ -50807,7 +50802,7 @@ msgstr "Zalihe primljene ali nisu fakturisane"
 #. Option for the 'Purpose' (Select) field in DocType 'Stock Reconciliation'
 #. Label of a Link in the Stock Workspace
 #: erpnext/setup/workspace/home/home.json
-#: erpnext/stock/doctype/item/item.py:612
+#: erpnext/stock/doctype/item/item.py:618
 #: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.json
 #: erpnext/stock/workspace/stock/stock.json
 msgid "Stock Reconciliation"
@@ -50818,7 +50813,7 @@ msgstr "Usklađivanje zaliha"
 msgid "Stock Reconciliation Item"
 msgstr "Stavka usklađivanja zaliha"
 
-#: erpnext/stock/doctype/item/item.py:612
+#: erpnext/stock/doctype/item/item.py:618
 msgid "Stock Reconciliations"
 msgstr "Usklađivanja zaliha"
 
@@ -50853,7 +50848,7 @@ msgstr "Podešavanje ponovne obrade zaliha"
 #: erpnext/stock/doctype/pick_list/pick_list.js:150
 #: erpnext/stock/doctype/pick_list/pick_list.js:155
 #: erpnext/stock/doctype/stock_entry/stock_entry_dashboard.py:25
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:706
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:702
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:575
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:1138
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:1398
@@ -51253,7 +51248,7 @@ msgstr "Zaustavljeni radni nalozi ne mogu biti otkazani. Prvo je potrebno otkaza
 #: erpnext/setup/doctype/company/company.py:287
 #: erpnext/setup/setup_wizard/operations/defaults_setup.py:33
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:502
-#: erpnext/stock/doctype/item/item.py:282
+#: erpnext/stock/doctype/item/item.py:285
 msgid "Stores"
 msgstr "Prodavnica"
 
@@ -51788,7 +51783,7 @@ msgstr "Uspešno usklađeno"
 msgid "Successfully Set Supplier"
 msgstr "Dobavljač uspešno postavljen"
 
-#: erpnext/stock/doctype/item/item.py:339
+#: erpnext/stock/doctype/item/item.py:342
 msgid "Successfully changed Stock UOM, please redefine conversion factors for new UOM."
 msgstr "Jedinica mere na zalihama je uspešno promenjena, redefinišite faktore konverzije za novu jedinicu mere."
 
@@ -52090,7 +52085,7 @@ msgstr "Detalji o dobavljaču"
 #: erpnext/accounts/doctype/tax_rule/tax_rule.json
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:111
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:87
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1160
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1162
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:198
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:237
 #: erpnext/accounts/report/purchase_register/purchase_register.js:27
@@ -52190,7 +52185,7 @@ msgstr "Rezime dobavljača"
 #. Label of the supplier_name (Data) field in DocType 'Purchase Receipt'
 #. Label of the supplier_name (Data) field in DocType 'Stock Entry'
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1077
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1079
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:156
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:198
 #: erpnext/accounts/report/purchase_register/purchase_register.py:177
@@ -52674,7 +52669,7 @@ msgstr "Sistem će automatski kreirati brojeve serije / šarže za gotov proizvo
 msgid "System will fetch all the entries if limit value is zero."
 msgstr "Sistem će povući sve unose ako je vrednost limita nula."
 
-#: erpnext/controllers/accounts_controller.py:1975
+#: erpnext/controllers/accounts_controller.py:1978
 msgid "System will not check over billing since amount for Item {0} in {1} is zero"
 msgstr "Sistem neće proveravati naplatu jer je iznos za stavku {0} u {1} nula"
 
@@ -52933,7 +52928,7 @@ msgstr "Greška rezervacije u ciljanom skladištu"
 msgid "Target Warehouse is required before Submit"
 msgstr "Ciljano skladište je obavezno pre nego što se podnese"
 
-#: erpnext/controllers/selling_controller.py:782
+#: erpnext/controllers/selling_controller.py:790
 msgid "Target Warehouse is set for some items but the customer is not an internal customer."
 msgstr "Ciljano skladište je postavljeno za neke stavke, ali kupac nije unutrašnji kupac."
 
@@ -53172,7 +53167,7 @@ msgstr "Raspodela poreza"
 msgid "Tax Category"
 msgstr "Poreska kategorija"
 
-#: erpnext/controllers/buying_controller.py:194
+#: erpnext/controllers/buying_controller.py:202
 msgid "Tax Category has been changed to \"Total\" because all the Items are non-stock items"
 msgstr "Poreska kategorija je promenjena na \"Ukupno\" jer su sve stavke zapravo stavke van zaliha"
 
@@ -53378,7 +53373,7 @@ msgstr "Porez će biti zadržan samo za iznos koji premašuje kumulativni prag"
 #. Label of the taxable_amount (Currency) field in DocType 'Tax Withheld
 #. Vouchers'
 #: erpnext/accounts/doctype/tax_withheld_vouchers/tax_withheld_vouchers.json
-#: erpnext/controllers/taxes_and_totals.py:1125
+#: erpnext/controllers/taxes_and_totals.py:1135
 msgid "Taxable Amount"
 msgstr "Oporezivi iznos"
 
@@ -53517,7 +53512,7 @@ msgstr "Odbijeni porezi i naknade"
 msgid "Taxes and Charges Deducted (Company Currency)"
 msgstr "Odbijeni porezi i naknade (valuta kompanije)"
 
-#: erpnext/stock/doctype/item/item.py:352
+#: erpnext/stock/doctype/item/item.py:355
 msgid "Taxes row #{0}: {1} cannot be smaller than {2}"
 msgstr "Red poreza #{0}: {1} ne može biti manji od {2}"
 
@@ -53803,7 +53798,7 @@ msgstr "Šablon uslova i odredbi"
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/territory_item/territory_item.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:134
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1144
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1146
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:93
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:182
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:68
@@ -53907,7 +53902,7 @@ msgstr "Pristup zahtevu za ponudu sa portala je onemogućeno. Da biste omogućil
 msgid "The BOM which will be replaced"
 msgstr "Sastavnica koja će biti zamenjena"
 
-#: erpnext/stock/serial_batch_bundle.py:1274
+#: erpnext/stock/serial_batch_bundle.py:1306
 msgid "The Batch {0} has negative quantity {1} in warehouse {2}. Please correct the quantity."
 msgstr "Šarža {0} sadrži negativnu količinu {1} u skladištu {2}. Molimo Vas da ispravite količinu."
 
@@ -53921,7 +53916,7 @@ msgstr "Uslov '{0}' je nevažeći"
 
 #: erpnext/support/doctype/service_level_agreement/service_level_agreement.py:206
 msgid "The Document Type {0} must have a Status field to configure Service Level Agreement"
-msgstr "Vrsta dokumenta {0} mora imati polje status za konfiguraciju Ugovora o nivou usluga"
+msgstr "Vrsta dokumenta {0} mora imati polje status za konfiguraciju sporazuma o nivou usluge"
 
 #: erpnext/accounts/doctype/period_closing_voucher/period_closing_voucher.py:154
 msgid "The GL Entries and closing balances will be processed in the background, it can take a few minutes."
@@ -53959,7 +53954,7 @@ msgstr "Prodavac je povezan sa {0}"
 msgid "The Serial No at Row #{0}: {1} is not available in warehouse {2}."
 msgstr "Broj serije u redu #{0}: {1} nije dostupan u skladištu {2}."
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1891
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1892
 msgid "The Serial No {0} is reserved against the {1} {2} and cannot be used for any other transaction."
 msgstr "Serijski broj {0} je rezervisan za {1} {2} i ne može se koristiti za bilo koju drugu transakciju."
 
@@ -54042,7 +54037,7 @@ msgstr "Sledeća imovina nije mogla automatski da postavi unose za amortizaciju:
 msgid "The following batches are expired, please restock them: <br> {0}"
 msgstr "Sledeće šarže su istekle, molimo Vas da ih dopunite: <br> {0}"
 
-#: erpnext/stock/doctype/item/item.py:849
+#: erpnext/stock/doctype/item/item.py:843
 msgid "The following deleted attributes exist in Variants but not in the Template. You can either delete the Variants or keep the attribute(s) in template."
 msgstr "Sledeći obrisani atributi postoje u varijantama, ali ne i u šablonima. Možete ili obrisati varijante ili zadržati atribute u šablonu."
 
@@ -54067,15 +54062,15 @@ msgstr "Bruto težina paketa. Obično neto težina + težina pakovanja (za štam
 msgid "The holiday on {0} is not between From Date and To Date"
 msgstr "Praznik koji pada na {0} nije između datum početka i datuma završetka"
 
-#: erpnext/controllers/buying_controller.py:1066
+#: erpnext/controllers/buying_controller.py:1074
 msgid "The item {item} is not marked as {type_of} item. You can enable it as {type_of} item from its Item master."
 msgstr "Sledeća stavka {item} nije označena kao {type_of} stavka. Možete je omogućiti kao {type_of} stavku iz master podataka stavke."
 
-#: erpnext/stock/doctype/item/item.py:614
+#: erpnext/stock/doctype/item/item.py:620
 msgid "The items {0} and {1} are present in the following {2} :"
 msgstr "Stavke {0} i {1} su prisutne u sledećem {2} :"
 
-#: erpnext/controllers/buying_controller.py:1059
+#: erpnext/controllers/buying_controller.py:1067
 msgid "The items {items} are not marked as {type_of} item. You can enable them as {type_of} item from their Item masters."
 msgstr "Sledeće stavke {items} nisu označene kao {type_of} stavke. Možete ih omogućiti kao {type_of} stavke iz master podataka stavke."
 
@@ -54177,8 +54172,8 @@ msgstr "Izabrana stavka ne može imati šaržu"
 msgid "The seller and the buyer cannot be the same"
 msgstr "Prodavac i kupac ne mogu biti isto lice"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:142
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:154
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:143
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:155
 msgid "The serial and batch bundle {0} not linked to {1} {2}"
 msgstr "Paket serije i šarže {0} nije povezan sa {1} {2}"
 
@@ -54202,7 +54197,7 @@ msgstr "Udeli ne postoje sa {0}"
 msgid "The stock for the item {0} in the {1} warehouse was negative on the {2}. You should create a positive entry {3} before the date {4} and time {5} to post the correct valuation rate. For more details, please read the <a href='https://docs.erpnext.com/docs/user/manual/en/stock-adjustment-cogs-with-negative-stock'>documentation<a>."
 msgstr "Zalihe za stavku {0} u skladištu {1} su bile negativne na {2}. Trebalo bi da kreirate pozitivan unos {3} pre datuma {4} i vremena {5} kako biste uneli ispravnu stopu vrednovanja. Za više detalja pročitajte <a href='https://docs.erpnext.com/docs/user/manual/en/stock-adjustment-cogs-with-negative-stock'>dokumentaciju.<a>."
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:700
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:696
 msgid "The stock has been reserved for the following Items and Warehouses, un-reserve the same to {0} the Stock Reconciliation: <br /><br /> {1}"
 msgstr "Zalihe su rezervisane za sledeće stavke i skladišta, poništite rezervisanje kako biste mogli da {0} uskladite zalihe: <br /><br /> {1}"
 
@@ -54215,11 +54210,11 @@ msgstr "Sinhronizacija je započeta u pozadini, proverite listu {0} za nove zapi
 msgid "The task has been enqueued as a background job."
 msgstr "Zadatak je stavljen u status čekanja kao pozadinski proces."
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:994
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:990
 msgid "The task has been enqueued as a background job. In case there is any issue on processing in background, the system will add a comment about the error on this Stock Reconciliation and revert to the Draft stage"
 msgstr "Zadatak je stavljen u status čekanja kao pozadinski proces. U slučaju problema pri obradi u pozadini, sistem će dodati komentar o grešci u ovom usklađivanju zaliha i vratiti ga u fazu nacrta"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1005
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1001
 msgid "The task has been enqueued as a background job. In case there is any issue on processing in background, the system will add a comment about the error on this Stock Reconciliation and revert to the Submitted stage"
 msgstr "Zadatak je stavljen u status čekanja kao pozadinski proces. U slučaju problema pri obradi u pozadini, sistem će dodati komentar o grešci u ovom usklađivanju zaliha i vratiti ga u status podneto"
 
@@ -54269,7 +54264,7 @@ msgstr "Skladište u koje će Vaše stavke biti premeštene kada započnete proi
 msgid "The {0} ({1}) must be equal to {2} ({3})"
 msgstr "{0} ({1}) mora biti jednako {2} ({3})"
 
-#: erpnext/public/js/controllers/transaction.js:2790
+#: erpnext/public/js/controllers/transaction.js:2816
 msgid "The {0} contains Unit Price Items."
 msgstr "{0} sadrži stavke sa jediničnom cenom."
 
@@ -54317,7 +54312,7 @@ msgstr "Ne postoje varijante stavke za izabranu stavku"
 msgid "There can be multiple tiered collection factor based on the total spent. But the conversion factor for redemption will always be same for all the tier."
 msgstr "Mogu postojati višestrukti nivoi naplate na osnovu ukupno potrošenog iznosa. Faktor konverzije za iskorišćenje će uvek biti isti za sve iznose."
 
-#: erpnext/accounts/party.py:580
+#: erpnext/accounts/party.py:586
 msgid "There can only be 1 Account per Company in {0} {1}"
 msgstr "Može poostojati samo jedan račun po kompaniji {0} {1}"
 
@@ -54603,7 +54598,7 @@ msgstr "Ovo će biti dodato šifri stavke varijante. Na primer, ukoliko je Vaša
 msgid "This will restrict user access to other employee records"
 msgstr "Ovo će ograničiti korisnički pristup zapisima drugih zaposlenih lica"
 
-#: erpnext/controllers/selling_controller.py:783
+#: erpnext/controllers/selling_controller.py:791
 msgid "This {} will be treated as material transfer."
 msgstr "Ovo {} će se tretirati kao prenos materijala."
 
@@ -55317,11 +55312,11 @@ msgid "To include sub-assembly costs and scrap items in Finished Goods on a work
 msgstr "Da biste uključili troškove podsklopova i otpisanih stavki u gotovim proizvodima u radnom nalogu bez korišćenja radne kartice, kada je opcija 'Koristi višeslojnu sastavnicu' omogućena."
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:2337
-#: erpnext/controllers/accounts_controller.py:3005
+#: erpnext/controllers/accounts_controller.py:3008
 msgid "To include tax in row {0} in Item rate, taxes in rows {1} must also be included"
 msgstr "Da bi porez bio uključen u red {0} u ceni stavke, porezi u redovima {1} takođe moraju biti uključeni"
 
-#: erpnext/stock/doctype/item/item.py:636
+#: erpnext/stock/doctype/item/item.py:642
 msgid "To merge, following properties must be same for both items"
 msgstr "Za spajanje, sledeće osobine moraju biti iste za obe stavke"
 
@@ -55941,7 +55936,7 @@ msgstr "Ukupan neizmireni iznos"
 msgid "Total Paid Amount"
 msgstr "Ukupno plaćeni iznos"
 
-#: erpnext/controllers/accounts_controller.py:2591
+#: erpnext/controllers/accounts_controller.py:2594
 msgid "Total Payment Amount in Payment Schedule must be equal to Grand / Rounded Total"
 msgstr "Ukupni iznos u rasporedu plaćanja mora biti jednak ukupnom / zaokruženom ukupnom iznosu"
 
@@ -56226,15 +56221,15 @@ msgstr "Ukupna težina (kg)"
 msgid "Total Working Hours"
 msgstr "Ukupno radnih sati"
 
-#: erpnext/controllers/accounts_controller.py:2138
+#: erpnext/controllers/accounts_controller.py:2141
 msgid "Total advance ({0}) against Order {1} cannot be greater than the Grand Total ({2})"
 msgstr "Ukupni avans ({0}) prema narudžbini {1} ne može biti veći od ukupnog iznosa ({2})"
 
-#: erpnext/controllers/selling_controller.py:190
+#: erpnext/controllers/selling_controller.py:198
 msgid "Total allocated percentage for sales team should be 100"
 msgstr "Ukupno raspoređeni procenat za prodajni tim treba biti 100"
 
-#: erpnext/selling/doctype/customer/customer.py:162
+#: erpnext/selling/doctype/customer/customer.py:161
 msgid "Total contribution percentage should be equal to 100"
 msgstr "Ukupni procenat doprinosa treba biti 100"
 
@@ -56325,7 +56320,7 @@ msgstr "Praćenje poluproizvoda"
 #: erpnext/support/doctype/service_level_agreement/service_level_agreement.py:147
 #: erpnext/support/doctype/support_settings/support_settings.json
 msgid "Track Service Level Agreement"
-msgstr "Praćenje Ugovora o nivou usluga"
+msgstr "Praćenje sporazuma o nivou usluge"
 
 #. Description of a DocType
 #: erpnext/accounts/doctype/cost_center/cost_center.json
@@ -57119,7 +57114,7 @@ msgstr "Jedinica mere"
 msgid "Unit of Measure (UOM)"
 msgstr "Jedinica mere"
 
-#: erpnext/stock/doctype/item/item.py:384
+#: erpnext/stock/doctype/item/item.py:387
 msgid "Unit of Measure {0} has been entered more than once in Conversion Factor Table"
 msgstr "Jedinica mere {0} je uneta više puta u tabelu faktora konverzije"
 
@@ -57561,7 +57556,7 @@ msgstr "Ažuriraj modifikovani vremenski žig za nove komunikacije primljene kod
 msgid "Update timestamp on new communication"
 msgstr "Ažuriraj vremenski žig za nove komunikacije"
 
-#: erpnext/manufacturing/doctype/bom_creator/bom_creator.py:533
+#: erpnext/manufacturing/doctype/bom_creator/bom_creator.py:534
 msgid "Updated successfully"
 msgstr "Ažuriranje uspešno"
 
@@ -57575,7 +57570,7 @@ msgstr "Ažuriranje uspešno"
 msgid "Updated via 'Time Log' (In Minutes)"
 msgstr "Ažurirano putem 'Zapis vremena' (u minutima)"
 
-#: erpnext/stock/doctype/item/item.py:1387
+#: erpnext/stock/doctype/item/item.py:1381
 msgid "Updating Variants..."
 msgstr "Ažuriranje varijanti..."
 
@@ -58133,19 +58128,19 @@ msgstr "Stopa vrednovanja"
 msgid "Valuation Rate (In / Out)"
 msgstr "Stopa vrednovaja (ulaz/izlaz)"
 
-#: erpnext/stock/stock_ledger.py:1881
+#: erpnext/stock/stock_ledger.py:1890
 msgid "Valuation Rate Missing"
 msgstr "Nedostaje stopa vrednovanja"
 
-#: erpnext/stock/stock_ledger.py:1859
+#: erpnext/stock/stock_ledger.py:1868
 msgid "Valuation Rate for the Item {0}, is required to do accounting entries for {1} {2}."
 msgstr "Stopa vrednovanja za stavku {0} je neophodna za računovodstvene unose za {1} {2}."
 
-#: erpnext/stock/doctype/item/item.py:266
+#: erpnext/stock/doctype/item/item.py:269
 msgid "Valuation Rate is mandatory if Opening Stock entered"
 msgstr "Stopa vrednovanja je obavezna ukoliko je unet početni inventar"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:752
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:748
 msgid "Valuation Rate required for Item {0} at row {1}"
 msgstr "Stopa vrednovanja je obavezna za stavku {0} u redu {1}"
 
@@ -58155,7 +58150,7 @@ msgstr "Stopa vrednovanja je obavezna za stavku {0} u redu {1}"
 msgid "Valuation and Total"
 msgstr "Vrednovanje i ukupno"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:971
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:967
 msgid "Valuation rate for customer provided items has been set to zero."
 msgstr "Stopa vrednovanja za stavke obezbeđene od strane kupca je postavljena na nulu."
 
@@ -58169,7 +58164,7 @@ msgid "Valuation rate for the item as per Sales Invoice (Only for Internal Trans
 msgstr "Stopa vrednovanja za stavku prema izlaznoj fakturi (samo za unutrašnje transfere)"
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:2361
-#: erpnext/controllers/accounts_controller.py:3029
+#: erpnext/controllers/accounts_controller.py:3032
 msgid "Valuation type charges can not be marked as Inclusive"
 msgstr "Naknade sa vrstom vrednovanja ne mogu biti označene kao uključene u cenu"
 
@@ -58325,7 +58320,7 @@ msgstr "Odstupanje ({})"
 msgid "Variant"
 msgstr "Varijanta"
 
-#: erpnext/stock/doctype/item/item.py:864
+#: erpnext/stock/doctype/item/item.py:858
 msgid "Variant Attribute Error"
 msgstr "Greška atributa varijante"
 
@@ -58344,7 +58339,7 @@ msgstr "Varijanta sastavnice"
 msgid "Variant Based On"
 msgstr "Varijanta zasnovana na"
 
-#: erpnext/stock/doctype/item/item.py:892
+#: erpnext/stock/doctype/item/item.py:886
 msgid "Variant Based On cannot be changed"
 msgstr "Varijanta zasnovana na se ne može promeniti"
 
@@ -58362,7 +58357,7 @@ msgstr "Polje varijante"
 msgid "Variant Item"
 msgstr "Stavka varijante"
 
-#: erpnext/stock/doctype/item/item.py:862
+#: erpnext/stock/doctype/item/item.py:856
 msgid "Variant Items"
 msgstr "Stavke varijante"
 
@@ -58480,7 +58475,7 @@ msgstr "Video podešavanje"
 #: erpnext/accounts/doctype/cost_center/cost_center_tree.js:56
 #: erpnext/accounts/doctype/invoice_discounting/invoice_discounting.js:205
 #: erpnext/accounts/doctype/journal_entry/journal_entry.js:43
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:668
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:670
 #: erpnext/bulk_transaction/doctype/bulk_transaction_log/bulk_transaction_log.js:14
 #: erpnext/bulk_transaction/doctype/bulk_transaction_log/bulk_transaction_log.js:24
 #: erpnext/buying/doctype/request_for_quotation/request_for_quotation.js:167
@@ -58667,7 +58662,7 @@ msgstr "Naziv dokumenta"
 #: erpnext/accounts/doctype/repost_accounting_ledger_items/repost_accounting_ledger_items.json
 #: erpnext/accounts/doctype/repost_payment_ledger_items/repost_payment_ledger_items.json
 #: erpnext/accounts/doctype/unreconcile_payment/unreconcile_payment.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1099
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1101
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.js:42
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:209
 #: erpnext/accounts/report/general_ledger/general_ledger.js:49
@@ -58698,7 +58693,7 @@ msgstr "Naziv dokumenta"
 msgid "Voucher No"
 msgstr "Dokument broj"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1087
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1088
 msgid "Voucher No is mandatory"
 msgstr "Broj dokumenta je obavezan"
 
@@ -58740,7 +58735,7 @@ msgstr "Podvrsta dokumenta"
 #: erpnext/accounts/doctype/repost_payment_ledger_items/repost_payment_ledger_items.json
 #: erpnext/accounts/doctype/tax_withheld_vouchers/tax_withheld_vouchers.json
 #: erpnext/accounts/doctype/unreconcile_payment/unreconcile_payment.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1097
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1099
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:200
 #: erpnext/accounts/report/general_ledger/general_ledger.py:697
 #: erpnext/accounts/report/invalid_ledger_entries/invalid_ledger_entries.py:31
@@ -59094,10 +59089,6 @@ msgstr "Skladište je obavezno"
 msgid "Warehouse not found against the account {0}"
 msgstr "Skladište nije pronađeno za račun {0}"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:600
-msgid "Warehouse not found in the system"
-msgstr "Skladište nije pronađeno u sistemu"
-
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:1130
 #: erpnext/stock/doctype/delivery_note/delivery_note.py:414
 msgid "Warehouse required for stock Item {0}"
@@ -59226,7 +59217,7 @@ msgid "Warn for new Request for Quotations"
 msgstr "Upozorenje na nove zahteve za ponudu"
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:744
-#: erpnext/controllers/accounts_controller.py:1978
+#: erpnext/controllers/accounts_controller.py:1981
 #: erpnext/stock/doctype/delivery_trip/delivery_trip.js:145
 #: erpnext/utilities/transaction_base.py:123
 msgid "Warning"
@@ -60198,7 +60189,7 @@ msgstr "Da"
 msgid "You are importing data for the code list:"
 msgstr "Uvozite podatke za listu šifara:"
 
-#: erpnext/controllers/accounts_controller.py:3611
+#: erpnext/controllers/accounts_controller.py:3614
 msgid "You are not allowed to update as per the conditions set in {} Workflow."
 msgstr "Niste ovlašćeni da ažurirate prema uslovima postavljenim u radnom toku {}."
 
@@ -60263,7 +60254,7 @@ msgstr "Možete to postaviti kao naziv mašine ili vrstu operacije. Na primer, m
 msgid "You can't make any changes to Job Card since Work Order is closed."
 msgstr "Ne možete izvršiti nikakve izmene na radnoj kartici jer je radni nalog zatvoren."
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:185
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:186
 msgid "You can't process the serial number {0} as it has already been used in the SABB {1}. {2} if you want to inward same serial number multiple times then enabled 'Allow existing Serial No to be Manufactured/Received again' in the {3}"
 msgstr "Ne možete obraditi broj serije {0} jer je već korišćen u SABB {1}. {2} ukoliko želite da ponovo koristite isti serijski broj više puta, omogućite opciju 'Dozvoli da postojeći broj serije bude ponovo proizveden/primljen' u {3}"
 
@@ -60323,7 +60314,7 @@ msgstr "Ne možete poslati narudžbinu bez plaćanja."
 msgid "You cannot {0} this document because another Period Closing Entry {1} exists after {2}"
 msgstr "Ne možete {0} ovaj dokument jer postoji drugi unos za periodično zatvaranje {1} posle {2}"
 
-#: erpnext/controllers/accounts_controller.py:3587
+#: erpnext/controllers/accounts_controller.py:3590
 msgid "You do not have permissions to {} items in a {}."
 msgstr "Nemate dozvolu da {} stavke u {}."
 
@@ -60351,7 +60342,7 @@ msgstr "Pozvani ste da sarađujete na projektu: {0}."
 msgid "You have entered a duplicate Delivery Note on Row"
 msgstr "Uneli ste duplu otpremnicu u redu"
 
-#: erpnext/stock/doctype/item/item.py:1063
+#: erpnext/stock/doctype/item/item.py:1057
 msgid "You have to enable auto re-order in Stock Settings to maintain re-order levels."
 msgstr "Morate omogućiti automatsko ponovno naručivanje u podešavanjima zaliha da biste održali nivoe ponovnog naručivanja."
 
@@ -60371,7 +60362,7 @@ msgstr "Morate da izaberete kupca pre nego što dodate stavku."
 msgid "You need to cancel POS Closing Entry {} to be able to cancel this document."
 msgstr "Morate otkazati unos zatvaranja maloprodaje {} da biste mogli da otkažete ovaj dokument."
 
-#: erpnext/controllers/accounts_controller.py:2980
+#: erpnext/controllers/accounts_controller.py:2983
 msgid "You selected the account group {1} as {2} Account in row {0}. Please select a single account."
 msgstr "Izabrali ste grupu računa {1} kao {2} račun u redu {0}. Molimo Vas da izaberete jedan račun."
 
@@ -60449,7 +60440,7 @@ msgstr "[Important] [ERPNext] Greške automatskog ponovnog naručivanja"
 msgid "`Allow Negative rates for Items`"
 msgstr "`Dozvoli negativne cene za artikle`"
 
-#: erpnext/stock/stock_ledger.py:1873
+#: erpnext/stock/stock_ledger.py:1882
 msgid "after"
 msgstr "posle"
 
@@ -60597,7 +60588,7 @@ msgstr "leva pozicija"
 msgid "material_request_item"
 msgstr "material_request_item"
 
-#: erpnext/controllers/selling_controller.py:151
+#: erpnext/controllers/selling_controller.py:159
 msgid "must be between 0 and 100"
 msgstr "mora biti između 0 i 100"
 
@@ -60622,7 +60613,7 @@ msgstr "old_parent"
 msgid "on"
 msgstr "na"
 
-#: erpnext/controllers/accounts_controller.py:1289
+#: erpnext/controllers/accounts_controller.py:1292
 msgid "or"
 msgstr "ili"
 
@@ -60671,7 +60662,7 @@ msgstr "aplikacija za plaćanje nije instalirana. Instalirajte je sa {0} ili {1}
 msgid "per hour"
 msgstr "po času"
 
-#: erpnext/stock/stock_ledger.py:1874
+#: erpnext/stock/stock_ledger.py:1883
 msgid "performing either one below:"
 msgstr "obavljajući bilo koju od dole navedenih:"
 
@@ -60798,7 +60789,7 @@ msgstr "morate izabrati račun nedovršenih kapitalnih radova u tabeli računa"
 msgid "{0}"
 msgstr "{0}"
 
-#: erpnext/controllers/accounts_controller.py:1109
+#: erpnext/controllers/accounts_controller.py:1112
 msgid "{0} '{1}' is disabled"
 msgstr "{0} '{1}' je onemogućen"
 
@@ -60814,7 +60805,7 @@ msgstr "{0} ({1}) ne može biti veći od planirane količine ({2}) u radnom nalo
 msgid "{0} <b>{1}</b> has submitted Assets. Remove Item <b>{2}</b> from table to continue."
 msgstr "{0} <b>{1}</b>ima podnetu imovinu. Uklonite stavku <b>{2}</b> iz tabele da biste nastavili."
 
-#: erpnext/controllers/accounts_controller.py:2193
+#: erpnext/controllers/accounts_controller.py:2196
 msgid "{0} Account not found against Customer {1}."
 msgstr "{0} račun nije pronađen za kupca {1}."
 
@@ -60846,7 +60837,7 @@ msgstr "{0} operacije: {1}"
 msgid "{0} Request for {1}"
 msgstr "{0} zahtev za {1}"
 
-#: erpnext/stock/doctype/item/item.py:323
+#: erpnext/stock/doctype/item/item.py:326
 msgid "{0} Retain Sample is based on batch, please check Has Batch No to retain sample of item"
 msgstr "{0} zadržavanje uzorka se zasniva na šarži, molimo Vas da proverite da li stavka ima broj šarže kako biste zadržali uzorak"
 
@@ -60937,7 +60928,7 @@ msgid "{0} entered twice in Item Tax"
 msgstr "{0} unet dva puta u stavke poreza"
 
 #: erpnext/setup/doctype/item_group/item_group.py:48
-#: erpnext/stock/doctype/item/item.py:436
+#: erpnext/stock/doctype/item/item.py:439
 msgid "{0} entered twice {1} in Item Taxes"
 msgstr "{0} unet dva puta {1} u stavke poreza"
 
@@ -60958,7 +60949,7 @@ msgstr "{0} je uspešno podnet"
 msgid "{0} hours"
 msgstr "{0} časova"
 
-#: erpnext/controllers/accounts_controller.py:2534
+#: erpnext/controllers/accounts_controller.py:2537
 msgid "{0} in row {1}"
 msgstr "{0} u redu {1}"
 
@@ -60982,7 +60973,7 @@ msgstr "{0} je blokiran, samim tim ova transakcija ne može biti nastavljena"
 
 #: erpnext/accounts/doctype/budget/budget.py:60
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:643
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:49
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:50
 #: erpnext/accounts/report/general_ledger/general_ledger.py:59
 #: erpnext/accounts/report/pos_register/pos_register.py:107
 #: erpnext/controllers/trends.py:50
@@ -61002,11 +60993,11 @@ msgstr "{0} je obavezno za račun {1}"
 msgid "{0} is mandatory. Maybe Currency Exchange record is not created for {1} to {2}"
 msgstr "{0} je obavezno. Možda evidencija deviznih kurseva nije kreirana za {1} u {2}"
 
-#: erpnext/controllers/accounts_controller.py:2937
+#: erpnext/controllers/accounts_controller.py:2940
 msgid "{0} is mandatory. Maybe Currency Exchange record is not created for {1} to {2}."
 msgstr "{0} je obavezno. Možda evidencija deviznih kurseva nije kreirana za {1} u {2}"
 
-#: erpnext/selling/doctype/customer/customer.py:204
+#: erpnext/selling/doctype/customer/customer.py:203
 msgid "{0} is not a company bank account"
 msgstr "{0} nije tekući račun kompanije"
 
@@ -61089,7 +61080,7 @@ msgstr "Količina {0} za stavku {1} se prima u skladište {2} sa kapacitetom {3}
 msgid "{0} to {1}"
 msgstr "{0} za {1}"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:690
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:686
 msgid "{0} units are reserved for Item {1} in Warehouse {2}, please un-reserve the same to {3} the Stock Reconciliation."
 msgstr "{0} jedinica je rezervisano za stavku {1} u skladištu {2}, molimo Vas da poništite rezervisanje u {3} da uskladite zalihe."
 
@@ -61105,16 +61096,16 @@ msgstr "{0} jedinica stavke {1} je odabrano na drugoj listi za odabir."
 msgid "{0} units of {1} are required in {2} with the inventory dimension: {3} ({4}) on {5} {6} for {7} to complete the transaction."
 msgstr "{0} jedinica {1} je potrebno u {2} sa dimenzijom inventara: {3} ({4}) na {5} {6} za {7} kako bi se transakcija završila."
 
-#: erpnext/stock/stock_ledger.py:1532 erpnext/stock/stock_ledger.py:2023
-#: erpnext/stock/stock_ledger.py:2037
+#: erpnext/stock/stock_ledger.py:1541 erpnext/stock/stock_ledger.py:2031
+#: erpnext/stock/stock_ledger.py:2045
 msgid "{0} units of {1} needed in {2} on {3} {4} for {5} to complete this transaction."
 msgstr "{0} jedinica {1} je potrebno u {2} na {3} {4} za {5} kako bi se ova transakcija završila."
 
-#: erpnext/stock/stock_ledger.py:2124 erpnext/stock/stock_ledger.py:2170
+#: erpnext/stock/stock_ledger.py:2132 erpnext/stock/stock_ledger.py:2178
 msgid "{0} units of {1} needed in {2} on {3} {4} to complete this transaction."
 msgstr "{0} jedinica {1} je potrebno u {2} na {3} {4} kako bi se ova transakcija završila."
 
-#: erpnext/stock/stock_ledger.py:1526
+#: erpnext/stock/stock_ledger.py:1535
 msgid "{0} units of {1} needed in {2} to complete this transaction."
 msgstr "{0} jedinica {1} je potrebno u {2} kako bi se ova transakcija završila."
 
@@ -61160,7 +61151,7 @@ msgstr "{0} {1} kreirano"
 msgid "{0} {1} does not exist"
 msgstr "{0} {1} ne postoji"
 
-#: erpnext/accounts/party.py:560
+#: erpnext/accounts/party.py:566
 msgid "{0} {1} has accounting entries in currency {2} for company {3}. Please select a receivable or payable account with currency {2}."
 msgstr "{0} {1} ima računovodstvene unose u valuti {2} za kompaniju {3}. Molimo Vas da izaberete račun potraživanja ili obaveza u valuti {2}."
 
@@ -61194,7 +61185,7 @@ msgstr "{0} {1} je već povezano sa zajedničkom šifrom {2}."
 msgid "{0} {1} is associated with {2}, but Party Account is {3}"
 msgstr "{0} {1} je povezano sa {2}, ali je račun stranke {3}"
 
-#: erpnext/controllers/selling_controller.py:462
+#: erpnext/controllers/selling_controller.py:470
 #: erpnext/controllers/subcontracting_controller.py:954
 msgid "{0} {1} is cancelled or closed"
 msgstr "{0} {1} je otkazano ili zatvoreno"
@@ -61211,11 +61202,11 @@ msgstr "{0} {1} je otkazano, samim tim radnja se ne može završiti"
 msgid "{0} {1} is closed"
 msgstr "{0} {1} je zatvoreo"
 
-#: erpnext/accounts/party.py:798
+#: erpnext/accounts/party.py:804
 msgid "{0} {1} is disabled"
 msgstr "{0} {1} je onemogućeno"
 
-#: erpnext/accounts/party.py:804
+#: erpnext/accounts/party.py:810
 msgid "{0} {1} is frozen"
 msgstr "{0} {1} je zaključano"
 
@@ -61223,7 +61214,7 @@ msgstr "{0} {1} je zaključano"
 msgid "{0} {1} is fully billed"
 msgstr "{0} {1} je u potpunosti fakturisano"
 
-#: erpnext/accounts/party.py:808
+#: erpnext/accounts/party.py:814
 msgid "{0} {1} is not active"
 msgstr "{0} {1} nije aktivno"
 
@@ -61349,15 +61340,15 @@ msgstr "{0}: {1} ne postoji"
 msgid "{0}: {1} must be less than {2}"
 msgstr "{0}: {1} mora biti manje od {2}"
 
-#: erpnext/controllers/buying_controller.py:840
+#: erpnext/controllers/buying_controller.py:848
 msgid "{count} Assets created for {item_code}"
 msgstr "{count} imovine kreirane za {item_code}"
 
-#: erpnext/controllers/buying_controller.py:738
+#: erpnext/controllers/buying_controller.py:746
 msgid "{doctype} {name} is cancelled or closed."
 msgstr "{doctype} {name} je otkazano ili zatvoreno."
 
-#: erpnext/controllers/buying_controller.py:459
+#: erpnext/controllers/buying_controller.py:467
 msgid "{field_label} is mandatory for sub-contracted {doctype}."
 msgstr "{field_label} je obavezno za podugovoreni posao {doctype}."
 
@@ -61365,7 +61356,7 @@ msgstr "{field_label} je obavezno za podugovoreni posao {doctype}."
 msgid "{item_name}'s Sample Size ({sample_size}) cannot be greater than the Accepted Quantity ({accepted_quantity})"
 msgstr "Veličina uzorka za {item_name} ({sample_size}) ne može biti veća od prihvaćene količine ({accepted_quantity})"
 
-#: erpnext/controllers/buying_controller.py:563
+#: erpnext/controllers/buying_controller.py:571
 msgid "{ref_doctype} {ref_name} is {status}."
 msgstr "{ref_doctype} {ref_name} je {status}."
 
@@ -61431,7 +61422,7 @@ msgstr "{} za fakturisanje"
 msgid "{} can't be cancelled since the Loyalty Points earned has been redeemed. First cancel the {} No {}"
 msgstr "{} ne može biti otkazano jer su zarađeni poeni lojalnosti iskorišćeni. Prvo otkažite {} broj {}"
 
-#: erpnext/controllers/buying_controller.py:222
+#: erpnext/controllers/buying_controller.py:230
 msgid "{} has submitted assets linked to it. You need to cancel the assets to create purchase return."
 msgstr "{} ima podnetu povezanu imovinu. Morate otkazati imovinu da biste kreirali povraćaj nabavke ."
 

--- a/erpnext/locale/sv.po
+++ b/erpnext/locale/sv.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: frappe\n"
 "Report-Msgid-Bugs-To: hello@frappe.io\n"
-"POT-Creation-Date: 2025-05-25 09:35+0000\n"
-"PO-Revision-Date: 2025-05-27 20:41\n"
+"POT-Creation-Date: 2025-06-01 09:36+0000\n"
+"PO-Revision-Date: 2025-06-01 21:35\n"
 "Last-Translator: hello@frappe.io\n"
 "Language-Team: Swedish\n"
 "MIME-Version: 1.0\n"
@@ -83,15 +83,15 @@ msgstr " Underenhet"
 msgid " Summary"
 msgstr "Översikt"
 
-#: erpnext/stock/doctype/item/item.py:235
+#: erpnext/stock/doctype/item/item.py:238
 msgid "\"Customer Provided Item\" cannot be Purchase Item also"
 msgstr "\"Kund Försedd Artikel\" kan inte vara Försäljning Artikel"
 
-#: erpnext/stock/doctype/item/item.py:237
+#: erpnext/stock/doctype/item/item.py:240
 msgid "\"Customer Provided Item\" cannot have Valuation Rate"
 msgstr "\"Kund Försedd Artikel\" kan inte ha Grund Pris"
 
-#: erpnext/stock/doctype/item/item.py:313
+#: erpnext/stock/doctype/item/item.py:316
 msgid "\"Is Fixed Asset\" cannot be unchecked, as Asset record exists against the item"
 msgstr "\"Är Fast Tillgång\" kan inte ångras då Tillgång Register finns mot denna Artikel"
 
@@ -213,7 +213,7 @@ msgstr "% av material fakturerad mot denna Försäljning Order"
 msgid "% of materials delivered against this Sales Order"
 msgstr "% av materia levererad mot denna Försäljning Order"
 
-#: erpnext/controllers/accounts_controller.py:2197
+#: erpnext/controllers/accounts_controller.py:2200
 msgid "'Account' in the Accounting section of Customer {0}"
 msgstr "\"Konto\" i Bokföring Sektion för Kund {0}"
 
@@ -225,15 +225,11 @@ msgstr "\"Tillåt flera Försäljning Order mot Kund Inköp Order\""
 msgid "'Based On' and 'Group By' can not be same"
 msgstr "\"Baserad på\" och \"Gruppera efter\" kan inte vara samma"
 
-#: erpnext/stock/report/product_bundle_balance/product_bundle_balance.py:233
-msgid "'Date' is required"
-msgstr "'Datum' erfordras"
-
 #: erpnext/selling/report/inactive_customers/inactive_customers.py:18
 msgid "'Days Since Last Order' must be greater than or equal to zero"
 msgstr "\"Dagar sedan senaste order\" måste vara högre än eller lika med noll"
 
-#: erpnext/controllers/accounts_controller.py:2202
+#: erpnext/controllers/accounts_controller.py:2205
 msgid "'Default {0} Account' in Company {1}"
 msgstr "\"Standard {0} Konto\" i Bolag {1}"
 
@@ -243,7 +239,7 @@ msgstr "'Poster' kan inte vara tom"
 
 #: erpnext/stock/report/batch_item_expiry_status/batch_item_expiry_status.py:24
 #: erpnext/stock/report/batch_wise_balance_history/batch_wise_balance_history.py:120
-#: erpnext/stock/report/stock_analytics/stock_analytics.py:314
+#: erpnext/stock/report/stock_analytics/stock_analytics.py:313
 msgid "'From Date' is required"
 msgstr "'Från Datum' erfodras"
 
@@ -251,7 +247,7 @@ msgstr "'Från Datum' erfodras"
 msgid "'From Date' must be after 'To Date'"
 msgstr "'Från Datum' måste vara efter 'Till Datum'"
 
-#: erpnext/stock/doctype/item/item.py:398
+#: erpnext/stock/doctype/item/item.py:401
 msgid "'Has Serial No' can not be 'Yes' for non-stock item"
 msgstr "'Har Serie Nummer' kan inte vara 'Ja' för ej Lager Artikel"
 
@@ -1179,7 +1175,7 @@ msgstr "Accepterad Kvantitet i Lager Enhet"
 
 #. Label of the qty (Float) field in DocType 'Purchase Receipt Item'
 #. Label of the qty (Float) field in DocType 'Subcontracting Receipt Item'
-#: erpnext/public/js/controllers/transaction.js:2362
+#: erpnext/public/js/controllers/transaction.js:2388
 #: erpnext/stock/doctype/purchase_receipt_item/purchase_receipt_item.json
 #: erpnext/subcontracting/doctype/subcontracting_receipt_item/subcontracting_receipt_item.json
 msgid "Accepted Quantity"
@@ -1377,7 +1373,7 @@ msgid "Account Manager"
 msgstr "Konto Ansvarig"
 
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:949
-#: erpnext/controllers/accounts_controller.py:2206
+#: erpnext/controllers/accounts_controller.py:2209
 msgid "Account Missing"
 msgstr "Konto Saknas"
 
@@ -1552,7 +1548,7 @@ msgstr "Konto {0} lagd till i Dotter Bolag {1}"
 msgid "Account {0} is frozen"
 msgstr "Konto {0} är låst"
 
-#: erpnext/controllers/accounts_controller.py:1288
+#: erpnext/controllers/accounts_controller.py:1291
 msgid "Account {0} is invalid. Account Currency must be {1}"
 msgstr "Konto {0} är ogiltig. Konto Valuta måste vara {1}"
 
@@ -1588,7 +1584,7 @@ msgstr "Konto: {0} kan endast uppdateras via Lager Transaktioner"
 msgid "Account: {0} is not permitted under Payment Entry"
 msgstr "Konto: {0} är inte tillåtet enligt Betalning Post"
 
-#: erpnext/controllers/accounts_controller.py:3037
+#: erpnext/controllers/accounts_controller.py:3040
 msgid "Account: {0} with currency: {1} can not be selected"
 msgstr "Konto: {0} med valuta: kan inte väljas {1}"
 
@@ -1861,7 +1857,7 @@ msgstr "Bokföring Poster"
 msgid "Accounting Entry for Asset"
 msgstr "Bokföring Post för Tillgång"
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:796
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:805
 msgid "Accounting Entry for Service"
 msgstr "Bokföring Post för Service"
 
@@ -1876,18 +1872,18 @@ msgstr "Bokföring Post för Service"
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py:1468
 #: erpnext/controllers/stock_controller.py:550
 #: erpnext/controllers/stock_controller.py:567
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:889
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:898
 #: erpnext/stock/doctype/stock_entry/stock_entry.py:1586
 #: erpnext/stock/doctype/stock_entry/stock_entry.py:1600
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py:561
 msgid "Accounting Entry for Stock"
 msgstr "Bokföring Post för Lager"
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:717
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:726
 msgid "Accounting Entry for {0}"
 msgstr "Bokföring Post för {0}"
 
-#: erpnext/controllers/accounts_controller.py:2247
+#: erpnext/controllers/accounts_controller.py:2250
 msgid "Accounting Entry for {0}: {1} can only be made in currency: {2}"
 msgstr "Bokföring Post för {0}: {1} kan endast skapas i valuta: {2}"
 
@@ -2280,7 +2276,7 @@ msgstr "Ackumulerad Avskrivning per "
 msgid "Accumulated Monthly"
 msgstr "Ackumulerad per Månad"
 
-#: erpnext/controllers/budget_controller.py:417
+#: erpnext/controllers/budget_controller.py:422
 msgid "Accumulated Monthly Budget for Account {0} against {1} {2} is {3}. It will be collectively ({4}) exceeded by {5}"
 msgstr "Ackumulerad månadsbudget för konto {0} mot {1} {2} är {3}. Den kommer sammantaget ({4}) att överskridas med {5}"
 
@@ -3394,7 +3390,7 @@ msgstr "Justera Tillgång Värde"
 msgid "Adjustment Against"
 msgstr "Justering Mot"
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:634
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:643
 msgid "Adjustment based on Purchase Invoice rate"
 msgstr "Justering Baserad på Inköp Faktura Pris"
 
@@ -3505,7 +3501,7 @@ msgstr "Förskott Moms och Avgifter"
 msgid "Advance amount"
 msgstr "Förskott Belopp"
 
-#: erpnext/controllers/taxes_and_totals.py:845
+#: erpnext/controllers/taxes_and_totals.py:855
 msgid "Advance amount cannot be greater than {0} {1}"
 msgstr "Förskott Belopp kan inte vara högre än {0} {1}"
 
@@ -3716,7 +3712,7 @@ msgstr "Ålder"
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:152
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:133
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1125
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1127
 msgid "Age (Days)"
 msgstr "Ålder (Dagar)"
 
@@ -3802,16 +3798,6 @@ msgstr "Paketera flera Artiklar till en annan Artikel. Användbart om lager base
 #: erpnext/setup/setup_wizard/data/industry_type.txt:4
 msgid "Agriculture"
 msgstr "Lantbruk"
-
-#. Name of a role
-#: erpnext/assets/doctype/location/location.json
-msgid "Agriculture Manager"
-msgstr "Jordbruk Ansvarig"
-
-#. Name of a role
-#: erpnext/assets/doctype/location/location.json
-msgid "Agriculture User"
-msgstr "Jordbrukare"
 
 #: erpnext/setup/setup_wizard/data/industry_type.txt:5
 msgid "Airline"
@@ -4003,7 +3989,7 @@ msgstr "All kommunikation inklusive och ovanför detta ska flyttas till ny Ären
 msgid "All items are already requested"
 msgstr "Alla artiklar är redan efterfrågade"
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:1317
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:1326
 msgid "All items have already been Invoiced/Returned"
 msgstr "Alla Artiklar är redan Fakturerade / Återlämnade"
 
@@ -4015,7 +4001,7 @@ msgstr "Alla Artiklar är redan mottagna"
 msgid "All items have already been transferred for this Work Order."
 msgstr "Alla Artikel har redan överförts för denna Arbetsorder."
 
-#: erpnext/public/js/controllers/transaction.js:2465
+#: erpnext/public/js/controllers/transaction.js:2491
 msgid "All items in this document already have a linked Quality Inspection."
 msgstr "Alla Artiklar i detta dokument har redan länkad Kvalitet Kontroll."
 
@@ -4213,7 +4199,7 @@ msgstr "Tillåt Interna Överföringar till Marknadsmässig Pris"
 msgid "Allow Item To Be Added Multiple Times in a Transaction"
 msgstr "Tillåt att Artikel läggs till flera gånger i en transaktion"
 
-#: erpnext/controllers/selling_controller.py:755
+#: erpnext/controllers/selling_controller.py:763
 msgid "Allow Item to Be Added Multiple Times in a Transaction"
 msgstr "Tillåt att Artikel läggs till flera gånger i Transaktion"
 
@@ -5159,7 +5145,7 @@ msgstr "Årlig"
 msgid "Annual Billing: {0}"
 msgstr "Årlig Fakturering: {0}"
 
-#: erpnext/controllers/budget_controller.py:441
+#: erpnext/controllers/budget_controller.py:446
 msgid "Annual Budget for Account {0} against {1} {2} is {3}. It will be collectively ({4}) exceeded by {5}"
 msgstr "Årsbudget för konto {0} mot {1} {2} är {3}. Den kommer sammantaget ({4}) att överskridas med {5}"
 
@@ -5648,7 +5634,7 @@ msgstr "Eftersom fält {0} är aktiverad erfordras fält {1}."
 msgid "As the field {0} is enabled, the value of the field {1} should be more than 1."
 msgstr "Eftersom fält {0} är aktiverad ska värdet för fält {1} vara mer än 1."
 
-#: erpnext/stock/doctype/item/item.py:989
+#: erpnext/stock/doctype/item/item.py:983
 msgid "As there are existing submitted transactions against item {0}, you can not change the value of {1}."
 msgstr "Eftersom det finns befintliga godkäAda transaktioner mot artikel {0} kan man inte ändra värdet på {1}."
 
@@ -5794,7 +5780,7 @@ msgstr "Tillgång Kategori Konto"
 msgid "Asset Category Name"
 msgstr "Tillgång Kategori Namn"
 
-#: erpnext/stock/doctype/item/item.py:304
+#: erpnext/stock/doctype/item/item.py:307
 msgid "Asset Category is mandatory for Fixed Asset item"
 msgstr "Tillgång Kategori erfordras för Fast Tillgång post"
 
@@ -6169,7 +6155,7 @@ msgstr "Tillgång {0} uppdaterad. Ange avskrivning detaljer och godkänn den."
 msgid "Asset {0} must be submitted"
 msgstr "Tillgång {0} måste godkännas"
 
-#: erpnext/controllers/buying_controller.py:851
+#: erpnext/controllers/buying_controller.py:859
 msgid "Asset {assets_link} created for {item_code}"
 msgstr "Tillgång {assets_link} skapad för {item_code}"
 
@@ -6199,11 +6185,11 @@ msgstr "Tillgångens Värde Justerat efter godkänade av Tillgång Värde Juster
 msgid "Assets"
 msgstr "Tillgångar"
 
-#: erpnext/controllers/buying_controller.py:869
+#: erpnext/controllers/buying_controller.py:877
 msgid "Assets not created for {item_code}. You will have to create asset manually."
 msgstr "Tillgångar har inte skapats för {item_code}. Skapa Tillgång manuellt."
 
-#: erpnext/controllers/buying_controller.py:856
+#: erpnext/controllers/buying_controller.py:864
 msgid "Assets {assets_link} created for {item_code}"
 msgstr "Tillgångar {assets_link} skapade för {item_code}"
 
@@ -6298,7 +6284,7 @@ msgstr "Rad # {0}: sekvens nummer {1} får inte vara lägre än föregående rad
 msgid "At row #{0}: you have selected the Difference Account {1}, which is a Cost of Goods Sold type account. Please select a different account"
 msgstr "På rad #{0}: har du valt Differens Konto {1}, som är konto av typ Kostnad för Sålda Artiklar. Välj ett annat konto"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:864
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:865
 msgid "At row {0}: Batch No is mandatory for Item {1}"
 msgstr "Rad {0}: Parti Nummer erfordras för Artikel {1}"
 
@@ -6306,11 +6292,11 @@ msgstr "Rad {0}: Parti Nummer erfordras för Artikel {1}"
 msgid "At row {0}: Parent Row No cannot be set for item {1}"
 msgstr "Rad {0}: Överordnad rad nummer kan inte anges för artikel {1}"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:849
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:850
 msgid "At row {0}: Qty is mandatory for the batch {1}"
 msgstr "Rad {0}: Kvantitet erfordras för Artikel {1}"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:856
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:857
 msgid "At row {0}: Serial No is mandatory for Item {1}"
 msgstr "Rad {0}: Serie Nummer erfordras för Artikel {1}"
 
@@ -6384,7 +6370,7 @@ msgstr "Egenskap Namn"
 msgid "Attribute Value"
 msgstr "Egenskap Värde"
 
-#: erpnext/stock/doctype/item/item.py:930
+#: erpnext/stock/doctype/item/item.py:924
 msgid "Attribute table is mandatory"
 msgstr "Egenskap Tabell erfordras"
 
@@ -6392,11 +6378,11 @@ msgstr "Egenskap Tabell erfordras"
 msgid "Attribute value: {0} must appear only once"
 msgstr "Egenskap Värde: {0} får endast visas en gång"
 
-#: erpnext/stock/doctype/item/item.py:934
+#: erpnext/stock/doctype/item/item.py:928
 msgid "Attribute {0} selected multiple times in Attributes Table"
 msgstr "Egenskaper {0} valda flera gånger i Egenskap Tabell"
 
-#: erpnext/stock/doctype/item/item.py:862
+#: erpnext/stock/doctype/item/item.py:856
 msgid "Attributes"
 msgstr "Egenskaper"
 
@@ -7653,7 +7639,7 @@ msgstr "Bank"
 #. Name of a UOM
 #: erpnext/setup/setup_wizard/data/uom_data.json
 msgid "Bar"
-msgstr "Bar"
+msgstr "Stapel"
 
 #. Label of the barcode (Data) field in DocType 'POS Invoice Item'
 #. Label of the barcode (Data) field in DocType 'Sales Invoice Item'
@@ -7680,11 +7666,11 @@ msgstr "Streck/Qr Kod"
 msgid "Barcode Type"
 msgstr "Streck/QR Kod Typ"
 
-#: erpnext/stock/doctype/item/item.py:457
+#: erpnext/stock/doctype/item/item.py:460
 msgid "Barcode {0} already used in Item {1}"
 msgstr "Streck/QR Kod {0} används redan i Artikel {1}"
 
-#: erpnext/stock/doctype/item/item.py:472
+#: erpnext/stock/doctype/item/item.py:475
 msgid "Barcode {0} is not a valid {1} code"
 msgstr "Streck/QR Kod {0} är inte giltig {1} kod"
 
@@ -7938,7 +7924,7 @@ msgstr "Parti Artikel Utgång Status"
 #: erpnext/manufacturing/doctype/job_card/job_card.json
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.js:89
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.py:115
-#: erpnext/public/js/controllers/transaction.js:2388
+#: erpnext/public/js/controllers/transaction.js:2414
 #: erpnext/public/js/utils/barcode_scanner.js:260
 #: erpnext/public/js/utils/serial_no_batch_selector.js:438
 #: erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
@@ -7965,11 +7951,11 @@ msgstr "Parti Artikel Utgång Status"
 msgid "Batch No"
 msgstr "Parti Nummer"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:867
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:868
 msgid "Batch No is mandatory"
 msgstr "Parti Nummer erfordras"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2629
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2630
 msgid "Batch No {0} does not exists"
 msgstr "Parti Nummer {0} finns inte"
 
@@ -7977,7 +7963,7 @@ msgstr "Parti Nummer {0} finns inte"
 msgid "Batch No {0} is linked with Item {1} which has serial no. Please scan serial no instead."
 msgstr "Parti Nummer {0} är länkat till Artikel {1} som har serie nummer. Skanna serie nummer istället."
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:364
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:365
 msgid "Batch No {0} is not present in the original {1} {2}, hence you can't return it against the {1} {2}"
 msgstr "Parti nr {0} finns inte i {1} {2}, därför kan du inte returnera det mot {1} {2}"
 
@@ -7992,11 +7978,11 @@ msgstr "Parti Nummer"
 msgid "Batch Nos"
 msgstr "Parti Nummer"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1421
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1422
 msgid "Batch Nos are created successfully"
 msgstr "Parti Nummer Skapade"
 
-#: erpnext/controllers/sales_and_purchase_return.py:1096
+#: erpnext/controllers/sales_and_purchase_return.py:1001
 msgid "Batch Not Available for Return"
 msgstr "Parti Ej Tillgänglig för Retur"
 
@@ -8045,7 +8031,7 @@ msgstr "Parti är inte skapad för Artikel {} eftersom den inte har Parti Nummer
 msgid "Batch {0} and Warehouse"
 msgstr "Parti {0} och Lager"
 
-#: erpnext/controllers/sales_and_purchase_return.py:1095
+#: erpnext/controllers/sales_and_purchase_return.py:1000
 msgid "Batch {0} is not available in warehouse {1}"
 msgstr "Parti {0} är inte tillgängligt i lager {1}"
 
@@ -8095,7 +8081,7 @@ msgstr "Nedan Prenumeration Planer är i annan valuta än Parti standard valuta/
 #. Label of the bill_date (Date) field in DocType 'Journal Entry'
 #. Label of the bill_date (Date) field in DocType 'Subcontracting Receipt'
 #: erpnext/accounts/doctype/journal_entry/journal_entry.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1110
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1112
 #: erpnext/accounts/report/purchase_register/purchase_register.py:214
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.json
 msgid "Bill Date"
@@ -8104,7 +8090,7 @@ msgstr "Faktura Datum"
 #. Label of the bill_no (Data) field in DocType 'Journal Entry'
 #. Label of the bill_no (Data) field in DocType 'Subcontracting Receipt'
 #: erpnext/accounts/doctype/journal_entry/journal_entry.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1109
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1111
 #: erpnext/accounts/report/purchase_register/purchase_register.py:213
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.json
 msgid "Bill No"
@@ -8324,7 +8310,7 @@ msgstr "Faktura Status"
 msgid "Billing Zipcode"
 msgstr "Faktura Postnummer"
 
-#: erpnext/accounts/party.py:602
+#: erpnext/accounts/party.py:608
 msgid "Billing currency must be equal to either default company's currency or party account currency"
 msgstr "Faktura Valuta måste vara lika med antingen Standard Bolag Valuta eller Parti Konto Valuta"
 
@@ -9321,7 +9307,7 @@ msgid "Can only make payment against unbilled {0}"
 msgstr "Kan bara skapa betalning mot ofakturerad {0}"
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1458
-#: erpnext/controllers/accounts_controller.py:2946
+#: erpnext/controllers/accounts_controller.py:2949
 #: erpnext/public/js/controllers/accounts.js:90
 msgid "Can refer row only if the charge type is 'On Previous Row Amount' or 'Previous Row Total'"
 msgstr "Kan hänvisa till rad endast om avgiften är \"På Föregående Rad Belopp\" eller \"Föregående Rad Totalt\""
@@ -9483,9 +9469,9 @@ msgstr "Kan inte Beräkna Ankomst Tid eftersom Förare Adress saknas."
 msgid "Cannot Create Return"
 msgstr "Kan inte Skapa Retur"
 
-#: erpnext/stock/doctype/item/item.py:625
-#: erpnext/stock/doctype/item/item.py:638
-#: erpnext/stock/doctype/item/item.py:652
+#: erpnext/stock/doctype/item/item.py:631
+#: erpnext/stock/doctype/item/item.py:644
+#: erpnext/stock/doctype/item/item.py:658
 msgid "Cannot Merge"
 msgstr "Kan inte Slå Samman"
 
@@ -9509,7 +9495,7 @@ msgstr "Kan inte ändra {0} {1}, skapa ny istället."
 msgid "Cannot apply TDS against multiple parties in one entry"
 msgstr "Kan inte tillämpa TDS mot flera parter i en post"
 
-#: erpnext/stock/doctype/item/item.py:307
+#: erpnext/stock/doctype/item/item.py:310
 msgid "Cannot be a fixed asset item as Stock Ledger is created."
 msgstr "Kan inte vara Fast Tillgång artikel när Lager Register är skapad."
 
@@ -9525,7 +9511,7 @@ msgstr "Kan inte annullera eftersom godkänd Lager Post {0} finns redan"
 msgid "Cannot cancel the transaction. Reposting of item valuation on submission is not completed yet."
 msgstr "Kan inte annullera transaktion. Ompostering av artikel värdering vid godkännande är inte klar ännu."
 
-#: erpnext/controllers/buying_controller.py:959
+#: erpnext/controllers/buying_controller.py:967
 msgid "Cannot cancel this document as it is linked with the submitted asset {asset_link}. Please cancel the asset to continue."
 msgstr "Kan inte annullera detta dokument eftersom det är länkad med godkänd tillgång {asset_link}. Annullera att fortsätta."
 
@@ -9533,7 +9519,7 @@ msgstr "Kan inte annullera detta dokument eftersom det är länkad med godkänd 
 msgid "Cannot cancel transaction for Completed Work Order."
 msgstr "Kan inte annullera transaktion för Klar Arbetsorder."
 
-#: erpnext/stock/doctype/item/item.py:882
+#: erpnext/stock/doctype/item/item.py:876
 msgid "Cannot change Attributes after stock transaction. Make a new Item and transfer stock to the new Item"
 msgstr "Kan inte ändra egenskap efter Lager transaktion. Skapa ny Artikel och överför kvantitet till ny Artikel"
 
@@ -9549,7 +9535,7 @@ msgstr "Kan inte ändra Referens Dokument Typ"
 msgid "Cannot change Service Stop Date for item in row {0}"
 msgstr "Kan inte ändra Service Stopp Datum för Artikel på rad {0}"
 
-#: erpnext/stock/doctype/item/item.py:873
+#: erpnext/stock/doctype/item/item.py:867
 msgid "Cannot change Variant properties after stock transaction. You will have to make a new Item to do this."
 msgstr "Kan inte ändra Variant Egenskaper efter Lager transaktion.Skapa ny Artikel för att göra detta."
 
@@ -9577,7 +9563,7 @@ msgstr "Kan inte konvertera till Grupp eftersom Konto Typ är vald."
 msgid "Cannot covert to Group because Account Type is selected."
 msgstr "Kan inte konvertera till Grupp eftersom Konto Typ valts."
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:972
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:981
 msgid "Cannot create Stock Reservation Entries for future dated Purchase Receipts."
 msgstr "Kan inte skapa Lager Reservation Poster för framtid daterade Inköp Följesedlar."
 
@@ -9628,7 +9614,7 @@ msgstr "Kan inte säkerställa leverans efter Serie Nummer eftersom Artikel {0} 
 msgid "Cannot find Item with this Barcode"
 msgstr "Kan inte hitta Artikel med denna Streck/QR Kod"
 
-#: erpnext/controllers/accounts_controller.py:3483
+#: erpnext/controllers/accounts_controller.py:3486
 msgid "Cannot find a default warehouse for item {0}. Please set one in the Item Master or in Stock Settings."
 msgstr "Kan inte hitta standardlager för artikel {0}. Ange det i Artikelinställningar eller i Lagerinställningar."
 
@@ -9636,7 +9622,7 @@ msgstr "Kan inte hitta standardlager för artikel {0}. Ange det i Artikelinstäl
 msgid "Cannot make any transactions until the deletion job is completed"
 msgstr "Kan inte skapa transaktioner förrän borttagning jobb är slutfört"
 
-#: erpnext/controllers/accounts_controller.py:2074
+#: erpnext/controllers/accounts_controller.py:2077
 msgid "Cannot overbill for Item {0} in row {1} more than {2}. To allow over-billing, please set allowance in Accounts Settings"
 msgstr "Kan inte överbeställa för artikel {0} på rad {1} mer än {2}. För Över Fakturering Tillåtelse, ange Ersättning i Konto Inställningar"
 
@@ -9657,7 +9643,7 @@ msgid "Cannot receive from customer against negative outstanding"
 msgstr "Kan inte ta emot från kund mot negativt utestående"
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1475
-#: erpnext/controllers/accounts_controller.py:2961
+#: erpnext/controllers/accounts_controller.py:2964
 #: erpnext/public/js/controllers/accounts.js:100
 msgid "Cannot refer row number greater than or equal to current row number for this Charge type"
 msgstr "Kan inte hänvisa till rad nummer högre än eller lika med aktuell rad nummer för denna avgift typ"
@@ -9673,7 +9659,7 @@ msgstr "Kan inte hämta länk token. Se fellogg för mer information"
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1467
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1646
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:1917
-#: erpnext/controllers/accounts_controller.py:2951
+#: erpnext/controllers/accounts_controller.py:2954
 #: erpnext/public/js/controllers/accounts.js:94
 #: erpnext/public/js/controllers/taxes_and_totals.js:470
 msgid "Cannot select charge type as 'On Previous Row Amount' or 'On Previous Row Total' for first row"
@@ -9687,15 +9673,15 @@ msgstr "Kan inte ange som förlorad eftersom Försäljning Order är skapad."
 msgid "Cannot set authorization on basis of Discount for {0}"
 msgstr "Kan inte ange auktorisering på grund av Rabatt för {0}"
 
-#: erpnext/stock/doctype/item/item.py:716
+#: erpnext/stock/doctype/item/item.py:722
 msgid "Cannot set multiple Item Defaults for a company."
 msgstr "Kan inte ange flera Artikel Standard för Bolag."
 
-#: erpnext/controllers/accounts_controller.py:3631
+#: erpnext/controllers/accounts_controller.py:3634
 msgid "Cannot set quantity less than delivered quantity"
 msgstr "Kan inte ange kvantitet som är lägre än levererad kvantitet"
 
-#: erpnext/controllers/accounts_controller.py:3634
+#: erpnext/controllers/accounts_controller.py:3637
 msgid "Cannot set quantity less than received quantity"
 msgstr "Kan inte ange kvantitet som är lägre än mottagen kvantitet"
 
@@ -10118,7 +10104,7 @@ msgid "Channel Partner"
 msgstr "Partner"
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:2346
-#: erpnext/controllers/accounts_controller.py:3014
+#: erpnext/controllers/accounts_controller.py:3017
 msgid "Charge of type 'Actual' in row {0} cannot be included in Item Rate or Paid Amount"
 msgstr "Debitering av typ \"Verklig\" i rad {0} kan inte inkluderas i Artikel Pris eller Betald Belopp"
 
@@ -10301,7 +10287,7 @@ msgstr "Check Bredd"
 
 #. Label of the reference_date (Date) field in DocType 'Payment Entry'
 #: erpnext/accounts/doctype/payment_entry/payment_entry.json
-#: erpnext/public/js/controllers/transaction.js:2299
+#: erpnext/public/js/controllers/transaction.js:2325
 msgid "Cheque/Reference Date"
 msgstr "Referens Datum"
 
@@ -10349,7 +10335,7 @@ msgstr "Underordnad Dokument Namn"
 
 #. Label of the child_row_reference (Data) field in DocType 'Quality
 #. Inspection'
-#: erpnext/public/js/controllers/transaction.js:2394
+#: erpnext/public/js/controllers/transaction.js:2420
 #: erpnext/stock/doctype/quality_inspection/quality_inspection.json
 msgid "Child Row Reference"
 msgstr "Underordnad Rad Referens"
@@ -11061,7 +11047,7 @@ msgstr "Bolag"
 #: erpnext/accounts/report/cheques_and_deposits_incorrectly_cleared/cheques_and_deposits_incorrectly_cleared.js:8
 #: erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.js:8
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:8
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:49
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:50
 #: erpnext/accounts/report/deferred_revenue_and_expense/deferred_revenue_and_expense.js:8
 #: erpnext/accounts/report/delivered_items_to_be_billed/delivered_items_to_be_billed.js:7
 #: erpnext/accounts/report/dimension_wise_accounts_balance_report/dimension_wise_accounts_balance_report.js:8
@@ -12294,7 +12280,7 @@ msgid "Content Type"
 msgstr "Innehåll Typ"
 
 #: erpnext/erpnext_integrations/doctype/plaid_settings/plaid_settings.js:162
-#: erpnext/public/js/controllers/transaction.js:2312
+#: erpnext/public/js/controllers/transaction.js:2338
 #: erpnext/selling/doctype/quotation/quotation.js:356
 msgid "Continue"
 msgstr "Fortsätt"
@@ -12459,7 +12445,7 @@ msgstr "Konvertering Faktor"
 msgid "Conversion Rate"
 msgstr "Konvertering Sats"
 
-#: erpnext/stock/doctype/item/item.py:393
+#: erpnext/stock/doctype/item/item.py:396
 msgid "Conversion factor for default Unit of Measure must be 1 in row {0}"
 msgstr "Konvertering Faktor för Standard Enhet måste vara 1 på rad {0}"
 
@@ -12467,15 +12453,15 @@ msgstr "Konvertering Faktor för Standard Enhet måste vara 1 på rad {0}"
 msgid "Conversion factor for item {0} has been reset to 1.0 as the uom {1} is same as stock uom {2}."
 msgstr "Konvertering faktor för artikel {0} är återställd till 1,0 eftersom enhet {1} är samma som lager enhet {2}."
 
-#: erpnext/controllers/accounts_controller.py:2767
+#: erpnext/controllers/accounts_controller.py:2770
 msgid "Conversion rate cannot be 0"
 msgstr "Konverteringsvärde kan inte vara 0"
 
-#: erpnext/controllers/accounts_controller.py:2774
+#: erpnext/controllers/accounts_controller.py:2777
 msgid "Conversion rate is 1.00, but document currency is different from company currency"
 msgstr "Konverteringsvärde är 1.00, men dokument valuta skiljer sig från bolag valuta"
 
-#: erpnext/controllers/accounts_controller.py:2770
+#: erpnext/controllers/accounts_controller.py:2773
 msgid "Conversion rate must be 1.00 if document currency is same as company currency"
 msgstr "Konverteringsvärde måste vara 1,00 om dokument valuta är samma som bolag valuta"
 
@@ -12688,7 +12674,7 @@ msgstr "Kostnad"
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:28
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:40
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:30
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1096
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1098
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:40
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.js:42
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.py:197
@@ -12781,7 +12767,7 @@ msgid "Cost Center is a part of Cost Center Allocation, hence cannot be converte
 msgstr "Resultat Enhet är del av Resultat Enhet Tilldelning och kan därför inte konverteras till grupp"
 
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py:1411
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:855
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:864
 msgid "Cost Center is required in row {0} in Taxes table for type {1}"
 msgstr "Resultat Enhet erfodras på rad {0} i Moms Tabell för typ {1}"
 
@@ -13050,8 +13036,8 @@ msgstr "Cr"
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:132
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:143
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:219
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:654
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:678
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:656
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:680
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.js:88
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.js:89
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.js:103
@@ -13108,8 +13094,8 @@ msgstr "Cr"
 #: erpnext/projects/doctype/task/task_tree.js:81
 #: erpnext/public/js/communication.js:19 erpnext/public/js/communication.js:31
 #: erpnext/public/js/communication.js:41
-#: erpnext/public/js/controllers/transaction.js:336
-#: erpnext/public/js/controllers/transaction.js:2435
+#: erpnext/public/js/controllers/transaction.js:362
+#: erpnext/public/js/controllers/transaction.js:2461
 #: erpnext/selling/doctype/customer/customer.js:181
 #: erpnext/selling/doctype/quotation/quotation.js:124
 #: erpnext/selling/doctype/quotation/quotation.js:133
@@ -13404,7 +13390,7 @@ msgstr "Skapa ny Sammansatt Tillgång"
 msgid "Create a variant with the template image."
 msgstr "Skapa variant med Mall Bild."
 
-#: erpnext/stock/stock_ledger.py:1877
+#: erpnext/stock/stock_ledger.py:1886
 msgid "Create an incoming stock transaction for the Item."
 msgstr "Skapa inkommande Lager Transaktion för Artikel."
 
@@ -13464,7 +13450,7 @@ msgstr "Skapar Inköp Ordrar ..."
 msgid "Creating Purchase Order ..."
 msgstr "Skapar Inköp Order ..."
 
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:735
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:737
 #: erpnext/buying/doctype/purchase_order/purchase_order.js:552
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.js:73
 msgid "Creating Purchase Receipt ..."
@@ -13660,7 +13646,7 @@ msgstr "Kredit Månader"
 #: erpnext/accounts/doctype/journal_entry_template/journal_entry_template.json
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:174
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:147
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1119
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1121
 #: erpnext/controllers/sales_and_purchase_return.py:373
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:286
 #: erpnext/stock/doctype/delivery_note/delivery_note.js:89
@@ -13695,7 +13681,7 @@ msgstr "Kredit Faktura {0} skapad automatiskt"
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py:368
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py:376
-#: erpnext/controllers/accounts_controller.py:2186
+#: erpnext/controllers/accounts_controller.py:2189
 msgid "Credit To"
 msgstr "Kredit Till"
 
@@ -13880,7 +13866,7 @@ msgstr "Cup"
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/subscription_plan/subscription_plan.json
 #: erpnext/accounts/report/account_balance/account_balance.py:28
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1129
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1131
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:205
 #: erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.py:101
 #: erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.js:118
@@ -14409,7 +14395,7 @@ msgstr "Kund Kod"
 #. Label of the customer_contact_display (Small Text) field in DocType
 #. 'Purchase Order'
 #. Label of the customer_contact (Small Text) field in DocType 'Delivery Stop'
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1090
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1092
 #: erpnext/buying/doctype/purchase_order/purchase_order.json
 #: erpnext/stock/doctype/delivery_stop/delivery_stop.json
 msgid "Customer Contact"
@@ -14505,7 +14491,7 @@ msgstr "Kund Återkoppling"
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/tax_rule/tax_rule.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:107
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1147
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1149
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:81
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:185
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:56
@@ -14549,7 +14535,7 @@ msgstr "Kund Grupp Artikel"
 msgid "Customer Group Name"
 msgstr "Kund Grupp Namn"
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1239
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1241
 msgid "Customer Group: {0} does not exist"
 msgstr "Kund Grupp: {0} finns inte"
 
@@ -14568,7 +14554,7 @@ msgstr "Kund Artikel"
 msgid "Customer Items"
 msgstr "Kund Artiklar"
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1138
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1140
 msgid "Customer LPO"
 msgstr "Kund Lokal Inköp Order"
 
@@ -14614,7 +14600,7 @@ msgstr "Kund Mobil Nummer"
 #: erpnext/accounts/doctype/pos_invoice/pos_invoice.json
 #: erpnext/accounts/doctype/process_statement_of_accounts_customer/process_statement_of_accounts_customer.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1080
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1082
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:156
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:92
 #: erpnext/accounts/report/delivered_items_to_be_billed/delivered_items_to_be_billed.py:35
@@ -15292,7 +15278,7 @@ msgstr "Debet Belopp i Transaktion Valuta"
 #: erpnext/accounts/doctype/journal_entry_template/journal_entry_template.json
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:176
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:147
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1122
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1124
 #: erpnext/controllers/sales_and_purchase_return.py:377
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:287
 #: erpnext/stock/doctype/purchase_receipt/purchase_receipt.js:61
@@ -15321,7 +15307,7 @@ msgstr "Debet Faktura kommer att uppdatera sitt eget utestående belopp, även o
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:953
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:964
-#: erpnext/controllers/accounts_controller.py:2186
+#: erpnext/controllers/accounts_controller.py:2189
 msgid "Debit To"
 msgstr "Debet Till"
 
@@ -15354,11 +15340,11 @@ msgstr "Debet-Kredit överensstämmer ej"
 msgid "Debit-Credit mismatch"
 msgstr "Debet-Kredit överensstämmer ej"
 
-#: erpnext/accounts/party.py:609
+#: erpnext/accounts/party.py:615
 msgid "Debtor/Creditor"
 msgstr "Debitor/Kreditor"
 
-#: erpnext/accounts/party.py:612
+#: erpnext/accounts/party.py:618
 msgid "Debtor/Creditor Advance"
 msgstr "Debitor/Kreditor Förskott"
 
@@ -15478,7 +15464,7 @@ msgstr "Standard Förskött Intäkt Konto"
 msgid "Default BOM"
 msgstr "Standard Stycklista"
 
-#: erpnext/stock/doctype/item/item.py:418
+#: erpnext/stock/doctype/item/item.py:421
 msgid "Default BOM ({0}) must be active for this item or its template"
 msgstr "Standard Stycklista ({0}) måste vara aktiv för denna artikel eller dess mall"
 
@@ -15486,7 +15472,7 @@ msgstr "Standard Stycklista ({0}) måste vara aktiv för denna artikel eller des
 msgid "Default BOM for {0} not found"
 msgstr "Standard Stycklista för {0} hittades inte"
 
-#: erpnext/controllers/accounts_controller.py:3672
+#: erpnext/controllers/accounts_controller.py:3675
 msgid "Default BOM not found for FG Item {0}"
 msgstr "Standard Stycklista hittades inte för Färdig Artikel {0}"
 
@@ -15821,15 +15807,15 @@ msgstr " Standard Distrikt"
 msgid "Default Unit of Measure"
 msgstr "Standard Enhet"
 
-#: erpnext/stock/doctype/item/item.py:1272
+#: erpnext/stock/doctype/item/item.py:1266
 msgid "Default Unit of Measure for Item {0} cannot be changed directly because you have already made some transaction(s) with another UOM. You need to either cancel the linked documents or create a new Item."
 msgstr "Standard Enhet för Artikel {0} kan inte ändras eftersom det finns några transaktion(er) med annan Enhet. Man måste antingen annullera länkade dokument eller skapa ny  artikel."
 
-#: erpnext/stock/doctype/item/item.py:1255
+#: erpnext/stock/doctype/item/item.py:1249
 msgid "Default Unit of Measure for Item {0} cannot be changed directly because you have already made some transaction(s) with another UOM. You will need to create a new Item to use a different Default UOM."
 msgstr "Standard Enhet för Artikel {0} kan inte ändras direkt eftersom man redan har skapat vissa transaktioner (s) med annan enhet. Man måste skapa ny Artikel för att använda annan standard enhet."
 
-#: erpnext/stock/doctype/item/item.py:908
+#: erpnext/stock/doctype/item/item.py:902
 msgid "Default Unit of Measure for Variant '{0}' must be same as in Template '{1}'"
 msgstr "Standard Enhet för Variant '{0}' måste vara samma som i Mall '{1}'"
 
@@ -16288,7 +16274,7 @@ msgstr "Försäljning Följesedel Trender"
 msgid "Delivery Note {0} is not submitted"
 msgstr "Försäljning Följesedel {0} ej godkänd"
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1142
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1144
 #: erpnext/stock/doctype/delivery_trip/delivery_trip.js:73
 msgid "Delivery Notes"
 msgstr "Försäljning Följesedlar"
@@ -16819,7 +16805,7 @@ msgstr "Avskrivning eliminerad via återföring"
 #: erpnext/projects/doctype/task_type/task_type.json
 #: erpnext/projects/doctype/timesheet_detail/timesheet_detail.json
 #: erpnext/public/js/bank_reconciliation_tool/data_table_manager.js:55
-#: erpnext/public/js/controllers/transaction.js:2376
+#: erpnext/public/js/controllers/transaction.js:2402
 #: erpnext/selling/doctype/installation_note_item/installation_note_item.json
 #: erpnext/selling/doctype/product_bundle/product_bundle.json
 #: erpnext/selling/doctype/product_bundle_item/product_bundle_item.json
@@ -17007,7 +16993,7 @@ msgstr "Differens Konto i Artikel Inställningar"
 msgid "Difference Account must be a Asset/Liability type account (Temporary Opening), since this Stock Entry is an Opening Entry"
 msgstr "Differens konto måste vara konto av typ Tillgång/Skuld (Tillfällig Öppning), eftersom denna Lager Post är Öppning Post."
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:954
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:950
 msgid "Difference Account must be a Asset/Liability type account, since this Stock Reconciliation is an Opening Entry"
 msgstr "Differens Konto måste vara Tillgång / Skuld Konto Typ, eftersom denna Inventering är Öppning Post"
 
@@ -17273,11 +17259,11 @@ msgstr "Inaktiverad Konto Vald"
 msgid "Disabled Warehouse {0} cannot be used for this transaction."
 msgstr "Inaktiverad Lager {0} kan inte användas för denna transaktion."
 
-#: erpnext/controllers/accounts_controller.py:745
+#: erpnext/controllers/accounts_controller.py:748
 msgid "Disabled pricing rules since this {} is an internal transfer"
 msgstr "Inaktiverade Prissättning Regler eftersom detta {} är intern överföring"
 
-#: erpnext/controllers/accounts_controller.py:759
+#: erpnext/controllers/accounts_controller.py:762
 msgid "Disabled tax included prices since this {} is an internal transfer"
 msgstr "Inaktiverade Pris Inklusive Moms eftersom detta {} är intern överföring"
 
@@ -18219,7 +18205,7 @@ msgstr "Direkt Leverans"
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.json
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/print_format/sales_invoice_print/sales_invoice_print.html:72
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1106
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1108
 #: erpnext/assets/doctype/asset_maintenance_log/asset_maintenance_log.json
 #: erpnext/selling/report/payment_terms_status_for_sales_order/payment_terms_status_for_sales_order.py:40
 msgid "Due Date"
@@ -18233,11 +18219,11 @@ msgstr "Förfallo Datum"
 msgid "Due Date Based On"
 msgstr "Förfallo Datum Baserad På"
 
-#: erpnext/accounts/party.py:695
+#: erpnext/accounts/party.py:701
 msgid "Due Date cannot be after {0}"
 msgstr "Förfallodatum kan inte vara efter {0}"
 
-#: erpnext/accounts/party.py:671
+#: erpnext/accounts/party.py:677
 msgid "Due Date cannot be before {0}"
 msgstr "Förfallodatum kan inte vara före {0}"
 
@@ -18955,7 +18941,7 @@ msgstr "Aktivera Tid Bokning Schema"
 msgid "Enable Auto Email"
 msgstr "Aktivera Automatisk E-post"
 
-#: erpnext/stock/doctype/item/item.py:1064
+#: erpnext/stock/doctype/item/item.py:1058
 msgid "Enable Auto Re-Order"
 msgstr "Aktivera Automatisk Ombeställning"
 
@@ -19168,7 +19154,7 @@ msgstr "Uttag Datum"
 msgid "End Date"
 msgstr "Slut Datum"
 
-#: erpnext/crm/doctype/contract/contract.py:75
+#: erpnext/crm/doctype/contract/contract.py:83
 msgid "End Date cannot be before Start Date."
 msgstr "Slut datum kan inte vara tidigare än Start datum."
 
@@ -19419,7 +19405,7 @@ msgstr "Erg"
 #: erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.json
 #: erpnext/manufacturing/doctype/job_card/job_card.py:875
 #: erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.json
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:297
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:298
 msgid "Error"
 msgstr "Fel"
 
@@ -19544,7 +19530,7 @@ msgstr "Fritt Fabrik"
 msgid "Example URL"
 msgstr "Exempel URL"
 
-#: erpnext/stock/doctype/item/item.py:995
+#: erpnext/stock/doctype/item/item.py:989
 msgid "Example of a linked document: {0}"
 msgstr "Exempel på länkad dokument: {0}"
 
@@ -19559,7 +19545,7 @@ msgstr "Exempel:. ABCD ##### Om serie är angiven och Serie Nummer inte anges i 
 msgid "Example: ABCD.#####. If series is set and Batch No is not mentioned in transactions, then automatic batch number will be created based on this series. If you always want to explicitly mention Batch No for this item, leave this blank. Note: this setting will take priority over the Naming Series Prefix in Stock Settings."
 msgstr "Exempel: ABCD.#####. Om serie är angiven och Parti Nummer inte anges i transaktioner kommer Parti Nummer automatiskt att skapas baserat på denna serie. Om man alltid vill ange Parti Nummer för denna artikel, lämna detta tomt. Obs: denna inställning kommer att ha prioritet över Nummer Serie i Lager Inställningar."
 
-#: erpnext/stock/stock_ledger.py:2141
+#: erpnext/stock/stock_ledger.py:2149
 msgid "Example: Serial No {0} reserved in {1}."
 msgstr "Exempel: Serie Nummer {0} reserverad i {1}."
 
@@ -19613,8 +19599,8 @@ msgstr "Valutaväxling Resultat"
 msgid "Exchange Gain/Loss"
 msgstr "Valutaväxling Resultat"
 
-#: erpnext/controllers/accounts_controller.py:1593
-#: erpnext/controllers/accounts_controller.py:1677
+#: erpnext/controllers/accounts_controller.py:1596
+#: erpnext/controllers/accounts_controller.py:1680
 msgid "Exchange Gain/Loss amount has been booked through {0}"
 msgstr "Valutaväxling Resultat Belopp har bokförts genom {0}"
 
@@ -20350,7 +20336,7 @@ msgid "Fetching Error"
 msgstr "Hämtar Fel"
 
 #: erpnext/accounts/doctype/dunning/dunning.js:135
-#: erpnext/public/js/controllers/transaction.js:1251
+#: erpnext/public/js/controllers/transaction.js:1277
 msgid "Fetching exchange rates ..."
 msgstr "Hämtar växel kurs ..."
 
@@ -20645,15 +20631,15 @@ msgstr "Färdig Artikel Kvantitet"
 msgid "Finished Good Item Quantity"
 msgstr "Färdig Artikel Kvantitet"
 
-#: erpnext/controllers/accounts_controller.py:3658
+#: erpnext/controllers/accounts_controller.py:3661
 msgid "Finished Good Item is not specified for service item {0}"
 msgstr "Färdig Artikel är inte specificerad för service artikel {0}"
 
-#: erpnext/controllers/accounts_controller.py:3675
+#: erpnext/controllers/accounts_controller.py:3678
 msgid "Finished Good Item {0} Qty can not be zero"
 msgstr "Färdig Artikel {0} kvantitet kan inte vara noll"
 
-#: erpnext/controllers/accounts_controller.py:3669
+#: erpnext/controllers/accounts_controller.py:3672
 msgid "Finished Good Item {0} must be a sub-contracted item"
 msgstr "Färdig Artikel {0} måste vara underleverantör artikel"
 
@@ -20894,7 +20880,7 @@ msgstr "Fast Tillgång Konto"
 msgid "Fixed Asset Defaults"
 msgstr "Fasta Tillgångar"
 
-#: erpnext/stock/doctype/item/item.py:301
+#: erpnext/stock/doctype/item/item.py:304
 msgid "Fixed Asset Item must be a non-stock item."
 msgstr "Fast Tillgång Artikel får ej vara Lager Artikel."
 
@@ -21070,7 +21056,7 @@ msgstr "För Kvantitet (Producerad Kvantitet) erfordras"
 msgid "For Raw Materials"
 msgstr "Råmaterial"
 
-#: erpnext/controllers/accounts_controller.py:1259
+#: erpnext/controllers/accounts_controller.py:1262
 msgid "For Return Invoices with Stock effect, '0' qty Items are not allowed. Following rows are affected: {0}"
 msgstr "För Retur Fakturor med Lager påverkan, '0' kvantitet artiklar är inte tillåtna. Följande rader påverkas: {0}"
 
@@ -21171,7 +21157,7 @@ msgstr "För kundernas bekvämlighet kan dessa koder användas i utskriftsformat
 msgid "For the item {0}, the quantity should be {1} according to the BOM {2}."
 msgstr "För artikel {0} ska kvantitet vara {1} enligt stycklista {2}."
 
-#: erpnext/public/js/controllers/transaction.js:1088
+#: erpnext/public/js/controllers/transaction.js:1114
 msgctxt "Clear payment terms template and/or payment schedule when due date is changed"
 msgid "For the new {0} to take effect, would you like to clear the current {1}?"
 msgstr "För att ny {0} ska gälla, vill du radera nuvarande {1}?"
@@ -21180,7 +21166,7 @@ msgstr "För att ny {0} ska gälla, vill du radera nuvarande {1}?"
 msgid "For the {0}, no stock is available for the return in the warehouse {1}."
 msgstr "För {0} finns inget kvantitet tillgängligt för retur i lager {1}."
 
-#: erpnext/controllers/sales_and_purchase_return.py:1144
+#: erpnext/controllers/sales_and_purchase_return.py:1049
 msgid "For the {0}, the quantity is required to make the return entry"
 msgstr "För {0} erfordras kvantitet för att skapa retur post"
 
@@ -21517,7 +21503,7 @@ msgstr "Från Datum kan inte vara senare än Till Datum"
 msgid "From Date is mandatory"
 msgstr "Från Datum Erfordras"
 
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:52
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:53
 #: erpnext/accounts/report/general_ledger/general_ledger.py:86
 #: erpnext/accounts/report/pos_register/pos_register.py:115
 #: erpnext/accounts/report/tax_withholding_details/tax_withholding_details.py:39
@@ -21894,14 +21880,14 @@ msgstr "Fler noder kan endast skapas under 'Grupp' Typ noder"
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:186
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:155
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1134
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1136
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:177
 msgid "Future Payment Amount"
 msgstr "Framtida Betalning Belopp"
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:185
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:154
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1133
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1135
 msgid "Future Payment Ref"
 msgstr "Framtida Betalning Referens"
 
@@ -23075,7 +23061,7 @@ msgstr "Hjälper vid fördelning av Budget/ Mål över månader om bolag har sä
 msgid "Here are the error logs for the aforementioned failed depreciation entries: {0}"
 msgstr "Här är felloggar för ovannämnda misslyckade avskrivning poster: {0}"
 
-#: erpnext/stock/stock_ledger.py:1862
+#: erpnext/stock/stock_ledger.py:1871
 msgid "Here are the options to proceed:"
 msgstr "Här är alternativ för att fortsätta:"
 
@@ -23601,7 +23587,7 @@ msgstr "Om angiven kommer system att tillåta Användare med denna roll att skap
 msgid "If more than one package of the same type (for print)"
 msgstr "Om mer än en förpackning av samma typ (för utskrift)"
 
-#: erpnext/stock/stock_ledger.py:1872
+#: erpnext/stock/stock_ledger.py:1881
 msgid "If not, you can Cancel / Submit this entry"
 msgstr "Om inte kan man Annullera/Godkänna denna post"
 
@@ -23626,7 +23612,7 @@ msgstr "Om Stycklista har Rest Material måste Rest Lager väljas."
 msgid "If the account is frozen, entries are allowed to restricted users."
 msgstr "Om konto är låst, tillåts poster för Behöriga Användare."
 
-#: erpnext/stock/stock_ledger.py:1865
+#: erpnext/stock/stock_ledger.py:1874
 msgid "If the item is transacting as a Zero Valuation Rate item in this entry, please enable 'Allow Zero Valuation Rate' in the {0} Item table."
 msgstr "Om artikel handlas som Noll Värderingssats i denna post, aktivera 'Tillåt Noll Värderingssats' i {0} Artikel Tabell."
 
@@ -24624,7 +24610,7 @@ msgstr "Felaktig Saldo Kvantitet Efter Transaktion"
 msgid "Incorrect Batch Consumed"
 msgstr "Felaktig Parti Förbrukad"
 
-#: erpnext/stock/doctype/item/item.py:514
+#: erpnext/stock/doctype/item/item.py:517
 msgid "Incorrect Check in (group) Warehouse for Reorder"
 msgstr "Felaktig vald (grupp) Lager för Ombeställning"
 
@@ -24673,7 +24659,7 @@ msgstr "Felaktig Serie och Parti Paket"
 msgid "Incorrect Stock Value Report"
 msgstr "Felaktig Lager Värde Rapport"
 
-#: erpnext/stock/serial_batch_bundle.py:134
+#: erpnext/stock/serial_batch_bundle.py:135
 msgid "Incorrect Type of Transaction"
 msgstr "Felaktig Typ av Transaktion"
 
@@ -24942,8 +24928,8 @@ msgstr "Instruktioner"
 msgid "Insufficient Capacity"
 msgstr "Otillräcklig Kapacitet"
 
-#: erpnext/controllers/accounts_controller.py:3590
-#: erpnext/controllers/accounts_controller.py:3614
+#: erpnext/controllers/accounts_controller.py:3593
+#: erpnext/controllers/accounts_controller.py:3617
 msgid "Insufficient Permissions"
 msgstr "Otillräckliga Behörigheter"
 
@@ -24951,12 +24937,12 @@ msgstr "Otillräckliga Behörigheter"
 #: erpnext/stock/doctype/pick_list/pick_list.py:127
 #: erpnext/stock/doctype/pick_list/pick_list.py:975
 #: erpnext/stock/doctype/stock_entry/stock_entry.py:759
-#: erpnext/stock/serial_batch_bundle.py:989 erpnext/stock/stock_ledger.py:1559
-#: erpnext/stock/stock_ledger.py:2032
+#: erpnext/stock/serial_batch_bundle.py:1021 erpnext/stock/stock_ledger.py:1568
+#: erpnext/stock/stock_ledger.py:2040
 msgid "Insufficient Stock"
 msgstr "Otillräcklig Lager"
 
-#: erpnext/stock/stock_ledger.py:2047
+#: erpnext/stock/stock_ledger.py:2055
 msgid "Insufficient Stock for Batch"
 msgstr "Otillräcklig Lager för Parti"
 
@@ -25094,11 +25080,11 @@ msgstr "Intern Kund"
 msgid "Internal Customer for company {0} already exists"
 msgstr "Intern Kund för Bolag {0} finns redan"
 
-#: erpnext/controllers/accounts_controller.py:728
+#: erpnext/controllers/accounts_controller.py:731
 msgid "Internal Sale or Delivery Reference missing."
 msgstr "Intern Försäljning eller Leverans Referens saknas."
 
-#: erpnext/controllers/accounts_controller.py:730
+#: erpnext/controllers/accounts_controller.py:733
 msgid "Internal Sales Reference Missing"
 msgstr "Intern Försäljning Referens saknas"
 
@@ -25129,7 +25115,7 @@ msgstr "Intern Leverantör för Bolag {0} finns redan"
 msgid "Internal Transfer"
 msgstr "Intern Överföring"
 
-#: erpnext/controllers/accounts_controller.py:739
+#: erpnext/controllers/accounts_controller.py:742
 msgid "Internal Transfer Reference Missing"
 msgstr "Intern Överföring Referens saknas"
 
@@ -25172,8 +25158,8 @@ msgstr "Ogiltig"
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:969
 #: erpnext/assets/doctype/asset_category/asset_category.py:69
 #: erpnext/assets/doctype/asset_category/asset_category.py:97
-#: erpnext/controllers/accounts_controller.py:2975
-#: erpnext/controllers/accounts_controller.py:2983
+#: erpnext/controllers/accounts_controller.py:2978
+#: erpnext/controllers/accounts_controller.py:2986
 msgid "Invalid Account"
 msgstr "Ogiltig Konto"
 
@@ -25198,7 +25184,7 @@ msgstr "Ogiltig Återkommande Datum"
 msgid "Invalid Barcode. There is no Item attached to this barcode."
 msgstr "Ogiltig Streck/QR Kod. Det finns ingen Artikel med denna Streck/QR Kod."
 
-#: erpnext/public/js/controllers/transaction.js:2631
+#: erpnext/public/js/controllers/transaction.js:2657
 msgid "Invalid Blanket Order for the selected Customer and Item"
 msgstr "Ogiltig Avtal Order för vald Kund och Artikel"
 
@@ -25212,7 +25198,7 @@ msgstr "Ogiltig Bolag för Intern Bolag Transaktion"
 
 #: erpnext/assets/doctype/asset/asset.py:295
 #: erpnext/assets/doctype/asset/asset.py:302
-#: erpnext/controllers/accounts_controller.py:2998
+#: erpnext/controllers/accounts_controller.py:3001
 msgid "Invalid Cost Center"
 msgstr "Ogiltig Resultat Enhet"
 
@@ -25254,7 +25240,7 @@ msgstr "Ogiltig Gruppera Efter"
 msgid "Invalid Item"
 msgstr "Ogiltig Artikel"
 
-#: erpnext/stock/doctype/item/item.py:1410
+#: erpnext/stock/doctype/item/item.py:1404
 msgid "Invalid Item Defaults"
 msgstr "Ogiltig Artikel Standard"
 
@@ -25300,11 +25286,11 @@ msgstr "Ogiltig Process Förlust Konfiguration"
 msgid "Invalid Purchase Invoice"
 msgstr "Ogiltig Inköp Faktura"
 
-#: erpnext/controllers/accounts_controller.py:3627
+#: erpnext/controllers/accounts_controller.py:3630
 msgid "Invalid Qty"
 msgstr "Ogiltig Kvantitet"
 
-#: erpnext/controllers/accounts_controller.py:1277
+#: erpnext/controllers/accounts_controller.py:1280
 msgid "Invalid Quantity"
 msgstr "Ogiltig Kvantitet"
 
@@ -25321,7 +25307,7 @@ msgstr "Ogiltiga Försäljning Fakturor"
 msgid "Invalid Schedule"
 msgstr "Ogiltig Schema"
 
-#: erpnext/controllers/selling_controller.py:243
+#: erpnext/controllers/selling_controller.py:251
 msgid "Invalid Selling Price"
 msgstr "Ogiltig Försäljning Pris"
 
@@ -25354,7 +25340,7 @@ msgstr "Ogiltig Villkor Uttryck"
 msgid "Invalid lost reason {0}, please create a new lost reason"
 msgstr "Ogiltig förlorad anledning {0}, skapa ny förlorad anledning"
 
-#: erpnext/stock/doctype/item/item.py:408
+#: erpnext/stock/doctype/item/item.py:411
 msgid "Invalid naming series (. missing) for {0}"
 msgstr "Ogiltig nummer serie (. saknas) för {0}"
 
@@ -25394,7 +25380,7 @@ msgstr "Lager"
 #. Name of a DocType
 #: erpnext/patches/v15_0/refactor_closing_stock_balance.py:43
 #: erpnext/stock/doctype/inventory_dimension/inventory_dimension.json
-#: erpnext/stock/doctype/inventory_dimension/inventory_dimension.py:180
+#: erpnext/stock/doctype/inventory_dimension/inventory_dimension.py:181
 msgid "Inventory Dimension"
 msgstr "Lager Dimension"
 
@@ -25460,7 +25446,7 @@ msgstr "Faktura Datum"
 msgid "Invoice Discounting"
 msgstr "Faktura Rabatt"
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1114
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1116
 msgid "Invoice Grand Total"
 msgstr "Fakturera Totalt Belopp"
 
@@ -25553,7 +25539,7 @@ msgstr "Faktura kan inte skapas för noll fakturerbar tid"
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:169
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:144
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1116
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1118
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:164
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:165
 msgid "Invoiced Amount"
@@ -25959,6 +25945,11 @@ msgstr "Är Öppning Post"
 msgid "Is Outward"
 msgstr "Är Utleverans"
 
+#. Label of the is_packed (Check) field in DocType 'Serial and Batch Bundle'
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.json
+msgid "Is Packed"
+msgstr "Är Paketerad"
+
 #. Label of the is_paid (Check) field in DocType 'Purchase Invoice'
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 msgid "Is Paid"
@@ -26241,11 +26232,11 @@ msgstr "Utfärdande Datum"
 msgid "Issuing cannot be done to a location. Please enter employee to issue the Asset {0} to"
 msgstr "Utfärdande kan inte göras till plats. Ange personal att utfärda Tillgång {0} "
 
-#: erpnext/stock/doctype/item/item.py:565
+#: erpnext/stock/doctype/item/item.py:571
 msgid "It can take upto few hours for accurate stock values to be visible after merging items."
 msgstr "Det kan ta upp till några timmar för korrekta lagervärden att vara synliga efter sammanslagning av artiklar."
 
-#: erpnext/public/js/controllers/transaction.js:2075
+#: erpnext/public/js/controllers/transaction.js:2101
 msgid "It is needed to fetch Item Details."
 msgstr "Behövs för att hämta Artikel Detaljer."
 
@@ -26295,7 +26286,7 @@ msgstr "Det är inte möjligt att fördela avgifter lika när det totala beloppe
 #: erpnext/buying/report/supplier_quotation_comparison/supplier_quotation_comparison.js:33
 #: erpnext/buying/report/supplier_quotation_comparison/supplier_quotation_comparison.py:204
 #: erpnext/buying/workspace/buying/buying.json
-#: erpnext/controllers/taxes_and_totals.py:1125
+#: erpnext/controllers/taxes_and_totals.py:1135
 #: erpnext/manufacturing/doctype/blanket_order/blanket_order.json
 #: erpnext/manufacturing/doctype/bom/bom.js:944
 #: erpnext/manufacturing/doctype/bom/bom.json
@@ -26573,7 +26564,7 @@ msgstr "Artikel Kundkorg"
 #: erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py:86
 #: erpnext/manufacturing/report/work_order_stock_report/work_order_stock_report.py:119
 #: erpnext/projects/doctype/timesheet/timesheet.js:213
-#: erpnext/public/js/controllers/transaction.js:2350
+#: erpnext/public/js/controllers/transaction.js:2376
 #: erpnext/public/js/stock_reservation.js:112
 #: erpnext/public/js/stock_reservation.js:317 erpnext/public/js/utils.js:500
 #: erpnext/public/js/utils.js:656
@@ -27011,7 +27002,7 @@ msgstr "Artikel Producent"
 #: erpnext/manufacturing/report/production_planning_report/production_planning_report.py:359
 #: erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py:92
 #: erpnext/manufacturing/report/work_order_consumed_materials/work_order_consumed_materials.py:138
-#: erpnext/public/js/controllers/transaction.js:2356
+#: erpnext/public/js/controllers/transaction.js:2382
 #: erpnext/public/js/utils.js:746
 #: erpnext/selling/doctype/quotation_item/quotation_item.json
 #: erpnext/selling/doctype/sales_order_item/sales_order_item.json
@@ -27278,7 +27269,7 @@ msgstr "Artikel Variant Inställningar"
 msgid "Item Variant {0} already exists with same attributes"
 msgstr "Artikel Variant {0} finns redan med samma attribut"
 
-#: erpnext/stock/doctype/item/item.py:781
+#: erpnext/stock/doctype/item/item.py:772
 msgid "Item Variants updated"
 msgstr "Artikel Varianter uppdaterade"
 
@@ -27344,7 +27335,7 @@ msgstr "Artikel och Garanti Information"
 msgid "Item for row {0} does not match Material Request"
 msgstr "Artikel för rad {0} matchar inte Material Begäran"
 
-#: erpnext/stock/doctype/item/item.py:795
+#: erpnext/stock/doctype/item/item.py:789
 msgid "Item has variants."
 msgstr "Artikel har varianter."
 
@@ -27370,7 +27361,7 @@ msgstr "Artikel Namn"
 msgid "Item operation"
 msgstr "Artikel Åtgärd"
 
-#: erpnext/controllers/accounts_controller.py:3650
+#: erpnext/controllers/accounts_controller.py:3653
 msgid "Item qty can not be updated as raw materials are already processed."
 msgstr "Artikel kvantitet kan inte uppdateras eftersom råmaterial redan är bearbetad."
 
@@ -27396,7 +27387,7 @@ msgstr "Värderingssats räknas om med hänsyn till landad kostnad verifikat bel
 msgid "Item valuation reposting in progress. Report might show incorrect item valuation."
 msgstr "Artikel värdering omläggning pågår. Rapport kan visa felaktig artikelvärde."
 
-#: erpnext/stock/doctype/item/item.py:952
+#: erpnext/stock/doctype/item/item.py:946
 msgid "Item variant {0} exists with same attributes"
 msgstr "Artikel variant {0} finns med lika egenskap"
 
@@ -27409,8 +27400,7 @@ msgid "Item {0} cannot be ordered more than {1} against Blanket Order {2}."
 msgstr "Artikel {0} kan inte skapas order för mer än {1} mot Avtal Order {2}."
 
 #: erpnext/assets/doctype/asset/asset.py:277
-#: erpnext/stock/doctype/item/item.py:630
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:167
+#: erpnext/stock/doctype/item/item.py:636
 msgid "Item {0} does not exist"
 msgstr "Artikel {0} finns inte"
 
@@ -27422,7 +27412,7 @@ msgstr "Artikel finns inte {0} i system eller har förfallit"
 msgid "Item {0} does not exist."
 msgstr "Artikel {0} finns inte."
 
-#: erpnext/controllers/selling_controller.py:752
+#: erpnext/controllers/selling_controller.py:760
 msgid "Item {0} entered multiple times."
 msgstr "Artikel {0} är angiven flera gånger."
 
@@ -27438,7 +27428,7 @@ msgstr "Artikel {0} är inaktiverad"
 msgid "Item {0} has no Serial No. Only serialized items can have delivery based on Serial No"
 msgstr "Artikel {0} har ingen serie nummer. Endast serie nummer artiklar kan ha leverans baserat på serie nummer"
 
-#: erpnext/stock/doctype/item/item.py:1126
+#: erpnext/stock/doctype/item/item.py:1120
 msgid "Item {0} has reached its end of life on {1}"
 msgstr "Artikel {0} har nått slut på sin livslängd {1}"
 
@@ -27450,11 +27440,11 @@ msgstr "Artikel {0} ignorerad eftersom det inte är Lager Artikel"
 msgid "Item {0} is already reserved/delivered against Sales Order {1}."
 msgstr "Artikel {0} är redan reserverad/levererad mot Försäljning Order {1}."
 
-#: erpnext/stock/doctype/item/item.py:1146
+#: erpnext/stock/doctype/item/item.py:1140
 msgid "Item {0} is cancelled"
 msgstr "Artikel {0} är anullerad"
 
-#: erpnext/stock/doctype/item/item.py:1130
+#: erpnext/stock/doctype/item/item.py:1124
 msgid "Item {0} is disabled"
 msgstr "Artikel {0} är inaktiverad"
 
@@ -27462,7 +27452,7 @@ msgstr "Artikel {0} är inaktiverad"
 msgid "Item {0} is not a serialized Item"
 msgstr "Artikel {0} är inte serialiserad Artikel"
 
-#: erpnext/stock/doctype/item/item.py:1138
+#: erpnext/stock/doctype/item/item.py:1132
 msgid "Item {0} is not a stock Item"
 msgstr "Artikel {0} är inte Lager Artikel"
 
@@ -27506,7 +27496,7 @@ msgstr "Artikel {0}: Order Kvantitet {1} kan inte vara lägre än minimum order 
 msgid "Item {0}: {1} qty produced. "
 msgstr "Artikel {0}: {1} Kvantitet producerad ."
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1429
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1423
 msgid "Item {} does not exist."
 msgstr "Artikel {} finns inte."
 
@@ -27646,7 +27636,7 @@ msgstr "Inköp Artiklar"
 msgid "Items and Pricing"
 msgstr "Artiklar & Prissättning"
 
-#: erpnext/controllers/accounts_controller.py:3872
+#: erpnext/controllers/accounts_controller.py:3875
 msgid "Items cannot be updated as Subcontracting Order is created against the Purchase Order {0}."
 msgstr "Artiklar kan inte uppdateras eftersom underleverantör order är skapad mot Inköp Order {0}."
 
@@ -28142,7 +28132,7 @@ msgstr "Landad Kostnad Moms och Avgifter"
 
 #. Name of a DocType
 #. Label of a Link in the Stock Workspace
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:674
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:676
 #: erpnext/stock/doctype/landed_cost_voucher/landed_cost_voucher.json
 #: erpnext/stock/doctype/purchase_receipt/purchase_receipt.js:104
 #: erpnext/stock/workspace/stock/stock.json
@@ -28497,7 +28487,7 @@ msgstr "Register Sammanslagning Konton"
 #. Label of a Card Break in the Financial Reports Workspace
 #: erpnext/accounts/workspace/financial_reports/financial_reports.json
 msgid "Ledgers"
-msgstr "Register"
+msgstr "Bokföring Register"
 
 #. Option for the 'Status' (Select) field in DocType 'Driver'
 #. Option for the 'Status' (Select) field in DocType 'Employee'
@@ -28757,7 +28747,7 @@ msgstr "Länkade Fakturor"
 msgid "Linked Location"
 msgstr "Länkad Plats"
 
-#: erpnext/stock/doctype/item/item.py:999
+#: erpnext/stock/doctype/item/item.py:993
 msgid "Linked with submitted documents"
 msgstr "Länkad med godkända dokument"
 
@@ -29496,7 +29486,7 @@ msgstr "Verkställande Direktör"
 #: erpnext/manufacturing/doctype/bom/bom.py:261
 #: erpnext/manufacturing/doctype/bom_update_log/bom_update_log.py:71
 #: erpnext/public/js/controllers/accounts.js:249
-#: erpnext/public/js/controllers/transaction.js:2753
+#: erpnext/public/js/controllers/transaction.js:2779
 #: erpnext/public/js/utils/party.js:321
 #: erpnext/stock/doctype/delivery_note/delivery_note.js:164
 #: erpnext/stock/doctype/inventory_dimension/inventory_dimension.json
@@ -30352,7 +30342,7 @@ msgstr "Maximum Användning"
 msgid "Maximum Value"
 msgstr "Maximum Värde"
 
-#: erpnext/controllers/selling_controller.py:212
+#: erpnext/controllers/selling_controller.py:220
 msgid "Maximum discount for Item {0} is {1}%"
 msgstr "Maximum rabatt för Artikel {0} är {1} %"
 
@@ -30422,7 +30412,7 @@ msgstr "Megajoule"
 msgid "Megawatt"
 msgstr "Megawatt"
 
-#: erpnext/stock/stock_ledger.py:1878
+#: erpnext/stock/stock_ledger.py:1887
 msgid "Mention Valuation Rate in the Item master."
 msgstr "Ange Värderingssats i Artikel Inställningar."
 
@@ -30817,11 +30807,11 @@ msgstr "Minuter"
 msgid "Miscellaneous Expenses"
 msgstr "Diverse Kostnader"
 
-#: erpnext/controllers/buying_controller.py:540
+#: erpnext/controllers/buying_controller.py:548
 msgid "Mismatch"
 msgstr "Felavstämd"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1430
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1424
 msgid "Missing"
 msgstr "Saknas"
 
@@ -31348,7 +31338,7 @@ msgstr "Flera Varianter"
 msgid "Multiple Warehouse Accounts"
 msgstr "Flera Lager Konton"
 
-#: erpnext/controllers/accounts_controller.py:1129
+#: erpnext/controllers/accounts_controller.py:1132
 msgid "Multiple fiscal years exist for the date {0}. Please set company in Fiscal Year"
 msgstr "Flera Bokföringsår finns för datum {0}. Ange Bolag under Bokföringsår"
 
@@ -31499,7 +31489,7 @@ msgstr "Nummer Serie Prefix"
 msgid "Naming Series and Price Defaults"
 msgstr "Nummer Serie & Pris Standard"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:90
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:91
 msgid "Naming Series is mandatory"
 msgstr "Nummer Serie erfodras"
 
@@ -31538,15 +31528,15 @@ msgstr "Naturgas"
 msgid "Needs Analysis"
 msgstr "Behöver Analys"
 
-#: erpnext/stock/serial_batch_bundle.py:1277
+#: erpnext/stock/serial_batch_bundle.py:1309
 msgid "Negative Batch Quantity"
 msgstr "Negativ Parti Kvantitet"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:610
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:606
 msgid "Negative Quantity is not allowed"
 msgstr "Negativ Kvantitet är inte tillåtet"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:615
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:611
 msgid "Negative Valuation Rate is not allowed"
 msgstr "Negativ Värderingssats är inte tillåtet"
 
@@ -31828,7 +31818,7 @@ msgstr "Netto Vikt"
 msgid "Net Weight UOM"
 msgstr "Netto Vikt Enhet"
 
-#: erpnext/controllers/accounts_controller.py:1483
+#: erpnext/controllers/accounts_controller.py:1486
 msgid "Net total calculation precision loss"
 msgstr "Netto Total Beräkning Precision Förlust"
 
@@ -32171,7 +32161,7 @@ msgstr "Ingen Kassa Profil hittad. Skapa ny Kassa Profil"
 #: erpnext/accounts/doctype/journal_entry/journal_entry.py:1539
 #: erpnext/accounts/doctype/journal_entry/journal_entry.py:1599
 #: erpnext/accounts/doctype/journal_entry/journal_entry.py:1613
-#: erpnext/stock/doctype/item/item.py:1371
+#: erpnext/stock/doctype/item/item.py:1365
 msgid "No Permission"
 msgstr "Ingen Behörighet"
 
@@ -32193,7 +32183,7 @@ msgstr "Inga Anmärkningar"
 msgid "No Selection"
 msgstr "Inget valt"
 
-#: erpnext/controllers/sales_and_purchase_return.py:919
+#: erpnext/controllers/sales_and_purchase_return.py:824
 msgid "No Serial / Batches are available for return"
 msgstr "Inga Serie Nummer/Partier är tillgängliga för retur"
 
@@ -32229,7 +32219,7 @@ msgstr "Inga Oavstämda Betalningar hittades för denna parti"
 msgid "No Work Orders were created"
 msgstr "Inga Arbetsordrar skapades"
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:785
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:794
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py:689
 msgid "No accounting entries for the following warehouses"
 msgstr "Inga bokföring poster för följande Lager"
@@ -32418,7 +32408,7 @@ msgstr "Inga poster hittades i Betalning Tabell"
 msgid "No reserved stock to unreserve."
 msgstr "Inget reserverad lager att ångra."
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:773
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:769
 msgid "No stock ledger entries were created. Please set the quantity or valuation rate for the items properly and try again."
 msgstr "Inga Lager Register Poster har skapats. Ange kvantitet eller grund pris för artiklar på rätt sätt och försök igen."
 
@@ -32502,7 +32492,7 @@ msgstr "St"
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:566
 #: erpnext/assets/doctype/asset/asset.js:612
 #: erpnext/assets/doctype/asset/asset.js:627
-#: erpnext/controllers/buying_controller.py:225
+#: erpnext/controllers/buying_controller.py:233
 #: erpnext/selling/doctype/product_bundle/product_bundle.py:72
 #: erpnext/setup/doctype/transaction_deletion_record/transaction_deletion_record.py:80
 msgid "Not Allowed"
@@ -32623,10 +32613,10 @@ msgstr "Ej Tillåtet"
 #: erpnext/selling/doctype/customer/customer.py:129
 #: erpnext/selling/doctype/sales_order/sales_order.js:1168
 #: erpnext/stock/doctype/item/item.js:526
-#: erpnext/stock/doctype/item/item.py:567
+#: erpnext/stock/doctype/item/item.py:573
 #: erpnext/stock/doctype/item_price/item_price.json
 #: erpnext/stock/doctype/stock_entry/stock_entry.py:1374
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:972
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:968
 #: erpnext/templates/pages/timelog_info.html:43
 msgid "Note"
 msgstr "Anteckning"
@@ -32635,7 +32625,7 @@ msgstr "Anteckning"
 msgid "Note: Automatic log deletion only applies to logs of type <i>Update Cost</i>"
 msgstr "Obs: Automatisk logg radering gäller endast loggar av typ <i>Uppdatera Kostnad</i>"
 
-#: erpnext/accounts/party.py:690
+#: erpnext/accounts/party.py:696
 msgid "Note: Due Date exceeds allowed {0} credit days by {1} day(s)"
 msgstr "Obs: Förfallodatum överskrider tillåtna {0} kreditdagar med {1} dag(ar)"
 
@@ -32661,7 +32651,7 @@ msgstr "Obs: Betalning post kommer inte skapas eftersom \"Kassa eller Bank Konto
 msgid "Note: This Cost Center is a Group. Cannot make accounting entries against groups."
 msgstr "Obs: Detta Resultat Enhet är en Grupp. Kan inte skapa bokföring poster mot Grupper."
 
-#: erpnext/stock/doctype/item/item.py:621
+#: erpnext/stock/doctype/item/item.py:627
 msgid "Note: To merge the items, create a separate Stock Reconciliation for the old item {0}"
 msgstr "Obs: För att slå samman artiklar skapar separat lager avstämning för gamla artikel {0}"
 
@@ -33425,7 +33415,7 @@ msgstr "Öppning Försäljning Fakturor är skapade."
 
 #. Label of the opening_stock (Float) field in DocType 'Item'
 #. Option for the 'Purpose' (Select) field in DocType 'Stock Reconciliation'
-#: erpnext/stock/doctype/item/item.json erpnext/stock/doctype/item/item.py:296
+#: erpnext/stock/doctype/item/item.json erpnext/stock/doctype/item/item.py:299
 #: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.json
 msgid "Opening Stock"
 msgstr "Öppning Lager"
@@ -34145,7 +34135,7 @@ msgstr "Utestående (Bolag Valuta)"
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:149
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1123
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1125
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:167
 #: erpnext/accounts/report/purchase_register/purchase_register.py:289
 #: erpnext/accounts/report/sales_register/sales_register.py:319
@@ -34184,7 +34174,7 @@ msgstr "Utleverans"
 msgid "Over Billing Allowance (%)"
 msgstr "Över Fakturering Tillåtelse (%)"
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:1242
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:1251
 msgid "Over Billing Allowance exceeded for Purchase Receipt Item {0} ({1}) by {2}%"
 msgstr "Överfakturering Tillåtelse för Inköp Följesedel Artikel {0} ({1}) överskreds med {2}%"
 
@@ -34225,7 +34215,7 @@ msgstr "Över Överföring Tillåtelse (%)"
 msgid "Overbilling of {0} {1} ignored for item {2} because you have {3} role."
 msgstr "Överfakturering av {0} {1} ignoreras för artikel {2} eftersom du har {3} roll."
 
-#: erpnext/controllers/accounts_controller.py:2013
+#: erpnext/controllers/accounts_controller.py:2016
 msgid "Overbilling of {} ignored because you have {} role."
 msgstr "Överfakturering av {} ignoreras eftersom du har {} roll."
 
@@ -34732,7 +34722,7 @@ msgstr "Betald"
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:146
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1117
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1119
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:165
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:172
 #: erpnext/accounts/report/pos_register/pos_register.py:209
@@ -34965,7 +34955,7 @@ msgstr "Överordnad Procedur"
 msgid "Parent Row No"
 msgstr "Överordnad Rad Nummer"
 
-#: erpnext/manufacturing/doctype/bom_creator/bom_creator.py:495
+#: erpnext/manufacturing/doctype/bom_creator/bom_creator.py:496
 msgid "Parent Row No not found for {0}"
 msgstr "Överordnad Rad Nummer hittades inte för {0}"
 
@@ -35194,7 +35184,7 @@ msgstr "Delar Per Million"
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:142
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:159
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:57
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1054
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1056
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:67
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:147
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:228
@@ -35220,7 +35210,7 @@ msgstr "Parti"
 
 #. Name of a DocType
 #: erpnext/accounts/doctype/party_account/party_account.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1065
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1067
 msgid "Party Account"
 msgstr "Parti Konto"
 
@@ -35247,7 +35237,7 @@ msgstr "Parti Konto Valuta"
 msgid "Party Account No. (Bank Statement)"
 msgstr "Parti Konto Nummer (Kontoutdrag)"
 
-#: erpnext/controllers/accounts_controller.py:2278
+#: erpnext/controllers/accounts_controller.py:2281
 msgid "Party Account {0} currency ({1}) and document currency ({2}) should be same"
 msgstr "Parti Konto {0} valuta ({1}) och dokument valuta ({2}) ska vara samma"
 
@@ -35264,6 +35254,11 @@ msgstr "Parti Bank Konto"
 #: erpnext/accounts/doctype/payment_request/payment_request.json
 msgid "Party Details"
 msgstr "Parti Detaljer"
+
+#. Label of the party_full_name (Data) field in DocType 'Contract'
+#: erpnext/crm/doctype/contract/contract.json
+msgid "Party Full Name"
+msgstr "Partens Fullständiga Namn"
 
 #. Label of the bank_party_iban (Data) field in DocType 'Bank Transaction'
 #: erpnext/accounts/doctype/bank_transaction/bank_transaction.json
@@ -35348,7 +35343,7 @@ msgstr "Parti Specifik Artikel"
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:84
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:54
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:44
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1048
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1050
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:54
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:141
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:219
@@ -35370,7 +35365,7 @@ msgstr "Parti Specifik Artikel"
 msgid "Party Type"
 msgstr "Parti Typ"
 
-#: erpnext/accounts/party.py:819
+#: erpnext/accounts/party.py:825
 msgid "Party Type and Party can only be set for Receivable / Payable account<br><br>{0}"
 msgstr "Parti Typ och Parti kan endast anges för Fordring / Skuld konto<br><br>{0}"
 
@@ -35492,7 +35487,7 @@ msgid "Payable"
 msgstr "Betalning Konto"
 
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:42
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1063
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1065
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:211
 #: erpnext/accounts/report/purchase_register/purchase_register.py:194
 #: erpnext/accounts/report/purchase_register/purchase_register.py:235
@@ -35658,7 +35653,7 @@ msgstr "Betalning Post har ändrats efter hämtning.Hämta igen."
 msgid "Payment Entry is already created"
 msgstr "Betalning Post är redan skapad"
 
-#: erpnext/controllers/accounts_controller.py:1434
+#: erpnext/controllers/accounts_controller.py:1437
 msgid "Payment Entry {0} is linked against Order {1}, check if it should be pulled as advance in this invoice."
 msgstr "Betalning Post {0} är länkad till Order {1}, kontrollera om den ska hämtas som förskott på denna faktura."
 
@@ -35940,7 +35935,7 @@ msgstr "Betalningsstatus"
 #: erpnext/accounts/doctype/payment_schedule/payment_schedule.json
 #: erpnext/accounts/doctype/payment_term/payment_term.json
 #: erpnext/accounts/doctype/payment_terms_template_detail/payment_terms_template_detail.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1113
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1115
 #: erpnext/accounts/report/gross_profit/gross_profit.py:412
 #: erpnext/accounts/workspace/accounting/accounting.json
 #: erpnext/selling/report/payment_terms_status_for_sales_order/payment_terms_status_for_sales_order.py:30
@@ -37004,7 +36999,7 @@ msgstr "Skapa Landad Kostnad Verifikat mot fakturor som har \"Uppdatera Lager\" 
 msgid "Please create a new Accounting Dimension if required."
 msgstr "Skapa Bokföring Dimension vid behov."
 
-#: erpnext/controllers/accounts_controller.py:729
+#: erpnext/controllers/accounts_controller.py:732
 msgid "Please create purchase from internal sale or delivery document itself"
 msgstr "Skapa Inköp från intern Försäljning eller Följesedel"
 
@@ -37012,7 +37007,7 @@ msgstr "Skapa Inköp från intern Försäljning eller Följesedel"
 msgid "Please create purchase receipt or purchase invoice for the item {0}"
 msgstr "Skapa Inköp Följesdel eller Inköp Faktura för Artikel {0}"
 
-#: erpnext/stock/doctype/item/item.py:649
+#: erpnext/stock/doctype/item/item.py:655
 msgid "Please delete Product Bundle {0}, before merging {1} into {2}"
 msgstr "Ta bort Artikel Paket {0} innan sammanslagning av {1} med {2}"
 
@@ -37054,7 +37049,7 @@ msgstr "Aktivera pop-ups"
 msgid "Please enable {0} in the {1}."
 msgstr "Aktivera {0} i {1}."
 
-#: erpnext/controllers/selling_controller.py:754
+#: erpnext/controllers/selling_controller.py:762
 msgid "Please enable {} in {} to allow same item in multiple rows"
 msgstr "Aktivera {} i {} för att tillåta samma Artikel i flera rader"
 
@@ -37087,7 +37082,7 @@ msgstr "Ange Växel Belopp Konto"
 msgid "Please enter Approving Role or Approving User"
 msgstr "Ange Godkännande Roll eller Godkännande Användare"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:939
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:935
 msgid "Please enter Cost Center"
 msgstr "Ange Resultat Enhet"
 
@@ -37099,7 +37094,7 @@ msgstr "Ange Leverans Datum"
 msgid "Please enter Employee Id of this sales person"
 msgstr "Ange Anställning ID för denna Säljare"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:948
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:944
 msgid "Please enter Expense Account"
 msgstr "Ange Kostnad Konto"
 
@@ -37108,7 +37103,7 @@ msgstr "Ange Kostnad Konto"
 msgid "Please enter Item Code to get Batch Number"
 msgstr "Ange Artikel Kod att hämta Parti Nummer"
 
-#: erpnext/public/js/controllers/transaction.js:2503
+#: erpnext/public/js/controllers/transaction.js:2529
 msgid "Please enter Item Code to get batch no"
 msgstr "Ange Artikel Kod att hämta Parti Nummer"
 
@@ -37173,7 +37168,7 @@ msgstr "Ange Bolag"
 msgid "Please enter company name first"
 msgstr "Ange Bolag Namn"
 
-#: erpnext/controllers/accounts_controller.py:2764
+#: erpnext/controllers/accounts_controller.py:2767
 msgid "Please enter default currency in Company Master"
 msgstr "Ange Standard Valuta i Bolag Tabell"
 
@@ -37209,7 +37204,7 @@ msgstr "Ange Bolag Namn att bekräfta"
 msgid "Please enter the phone number first"
 msgstr "Ange Telefon Nummer"
 
-#: erpnext/controllers/buying_controller.py:1007
+#: erpnext/controllers/buying_controller.py:1015
 msgid "Please enter the {schedule_date}."
 msgstr "Ange {schedule_date}."
 
@@ -37311,7 +37306,7 @@ msgstr "Spara"
 msgid "Please select <b>Template Type</b> to download template"
 msgstr "Välj <b>Mall Typ</b> att ladda ner mall"
 
-#: erpnext/controllers/taxes_and_totals.py:721
+#: erpnext/controllers/taxes_and_totals.py:731
 #: erpnext/public/js/controllers/taxes_and_totals.js:721
 msgid "Please select Apply Discount On"
 msgstr "Välj Tillämpa Rabatt på"
@@ -37324,7 +37319,7 @@ msgstr "Välj Stycklista mot Artikel {0}"
 msgid "Please select BOM for Item in Row {0}"
 msgstr "Välj Stycklista för Artikel på rad {0}"
 
-#: erpnext/controllers/buying_controller.py:467
+#: erpnext/controllers/buying_controller.py:475
 msgid "Please select BOM in BOM field for Item {item_code}."
 msgstr "Välj Stycklista i Stycklista Fält för Artikel{item_code}."
 
@@ -37406,7 +37401,7 @@ msgstr "Välj Prislista"
 msgid "Please select Qty against item {0}"
 msgstr "Välj Kvantitet mot Artikel {0}"
 
-#: erpnext/stock/doctype/item/item.py:320
+#: erpnext/stock/doctype/item/item.py:323
 msgid "Please select Sample Retention Warehouse in Stock Settings first"
 msgstr "Välj Prov Lager i Lager Inställningar"
 
@@ -37422,7 +37417,7 @@ msgstr "Välj Startdatum och Slutdatum för Artikel {0}"
 msgid "Please select Subcontracting Order instead of Purchase Order {0}"
 msgstr "Välj Underleverantör Order istället för Inköp Order {0}"
 
-#: erpnext/controllers/accounts_controller.py:2613
+#: erpnext/controllers/accounts_controller.py:2616
 msgid "Please select Unrealized Profit / Loss account or add default Unrealized Profit / Loss account account for company {0}"
 msgstr "Välj Orealiserad Resultat Konto eller ange standard konto för Orealiserad Resultat Konto för Bolag {0}"
 
@@ -37438,7 +37433,7 @@ msgstr "Välj Bolag"
 #: erpnext/manufacturing/doctype/bom/bom.js:603
 #: erpnext/manufacturing/doctype/bom/bom.py:261
 #: erpnext/public/js/controllers/accounts.js:249
-#: erpnext/public/js/controllers/transaction.js:2753
+#: erpnext/public/js/controllers/transaction.js:2779
 msgid "Please select a Company first."
 msgstr "Välj Bolag"
 
@@ -37596,7 +37591,7 @@ msgstr "Välj {0}"
 msgid "Please select {0} first"
 msgstr "Välj {0}"
 
-#: erpnext/public/js/controllers/transaction.js:77
+#: erpnext/public/js/controllers/transaction.js:100
 msgid "Please set 'Apply Additional Discount On'"
 msgstr "Ange 'Tillämpa Extra Rabatt På'"
 
@@ -37781,7 +37776,7 @@ msgstr "Ange filter baserad på Artikel eller Lager"
 msgid "Please set filters"
 msgstr "Ange Filter"
 
-#: erpnext/controllers/accounts_controller.py:2194
+#: erpnext/controllers/accounts_controller.py:2197
 msgid "Please set one of the following:"
 msgstr "Ange något av följande:"
 
@@ -37789,7 +37784,7 @@ msgstr "Ange något av följande:"
 msgid "Please set opening number of booked depreciations"
 msgstr "Ange Öppning Nummer för Bokförda Avskrivningar"
 
-#: erpnext/public/js/controllers/transaction.js:2205
+#: erpnext/public/js/controllers/transaction.js:2231
 msgid "Please set recurring after saving"
 msgstr "Ange Återkommande efter spara"
 
@@ -37860,7 +37855,7 @@ msgstr "Konfigurera och aktivera Kontoplan Grupp med Kontoklass {0} för bolag {
 msgid "Please share this email with your support team so that they can find and fix the issue."
 msgstr "Dela detta e-post meddelande med support så att de kan hitta och åtgärda problem. "
 
-#: erpnext/public/js/controllers/transaction.js:2073
+#: erpnext/public/js/controllers/transaction.js:2099
 msgid "Please specify"
 msgstr "Specificera"
 
@@ -37875,7 +37870,7 @@ msgid "Please specify Company to proceed"
 msgstr "Ange Bolag att fortsätta"
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1472
-#: erpnext/controllers/accounts_controller.py:2957
+#: erpnext/controllers/accounts_controller.py:2960
 #: erpnext/public/js/controllers/accounts.js:97
 msgid "Please specify a valid Row ID for row {0} in table {1}"
 msgstr "Ange giltig Rad ID för Rad {0} i Tabell {1}"
@@ -37888,7 +37883,7 @@ msgstr "Ange {0} först."
 msgid "Please specify at least one attribute in the Attributes table"
 msgstr "Ange minst en Egenskap i Egenskap Tabell"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:605
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:601
 msgid "Please specify either Quantity or Valuation Rate or both"
 msgstr "Ange antingen Kvantitet eller Värderingssats eller båda"
 
@@ -38069,7 +38064,7 @@ msgstr "Post Kostnader Konto"
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:16
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:15
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:18
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1046
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1048
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:15
 #: erpnext/accounts/report/bank_clearance_summary/bank_clearance_summary.py:35
 #: erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.html:7
@@ -40250,7 +40245,7 @@ msgstr "Inköp Huvudansvarig"
 #: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.js:48
 #: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:203
 #: erpnext/buying/workspace/buying/buying.json
-#: erpnext/controllers/buying_controller.py:739
+#: erpnext/controllers/buying_controller.py:747
 #: erpnext/crm/doctype/contract/contract.json
 #: erpnext/manufacturing/doctype/blanket_order/blanket_order.js:54
 #: erpnext/manufacturing/doctype/production_plan_sub_assembly_item/production_plan_sub_assembly_item.json
@@ -40389,7 +40384,7 @@ msgstr "Inköp Ordrar att Betala"
 msgid "Purchase Orders to Receive"
 msgstr "Inköp Ordrar att Ta Emot"
 
-#: erpnext/controllers/accounts_controller.py:1833
+#: erpnext/controllers/accounts_controller.py:1836
 msgid "Purchase Orders {0} are un-linked"
 msgstr "Inköp Ordrar {0} är inte länkade"
 
@@ -40413,8 +40408,8 @@ msgstr "Inköp Prislista"
 #. Label of a Link in the Stock Workspace
 #. Label of a shortcut in the Stock Workspace
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:171
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:650
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:660
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:652
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:662
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice_list.js:49
 #: erpnext/accounts/doctype/purchase_invoice_item/purchase_invoice_item.json
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:246
@@ -41149,7 +41144,7 @@ msgstr "Kvalitet Kontroll Mall"
 msgid "Quality Inspection Template Name"
 msgstr "Kvalitet Kontroll Mall Namn"
 
-#: erpnext/public/js/controllers/transaction.js:334
+#: erpnext/public/js/controllers/transaction.js:360
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:165
 msgid "Quality Inspection(s)"
 msgstr "Kvalitet Kontroll"
@@ -42333,7 +42328,7 @@ msgid "Receivable / Payable Account"
 msgstr "Fordring / Skuld Konto"
 
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:71
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1061
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1063
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py:243
 #: erpnext/accounts/report/sales_register/sales_register.py:217
 #: erpnext/accounts/report/sales_register/sales_register.py:271
@@ -42815,7 +42810,7 @@ msgstr "Referens # {0} daterad {1}"
 msgid "Reference Date"
 msgstr "Referens Datum"
 
-#: erpnext/public/js/controllers/transaction.js:2311
+#: erpnext/public/js/controllers/transaction.js:2337
 msgid "Reference Date for Early Payment Discount"
 msgstr "Referens Datum för Tidig Betalning Rabatt"
 
@@ -43139,7 +43134,7 @@ msgstr "Regelbunden"
 msgid "Rejected"
 msgstr "Avvisad"
 
-#: erpnext/stock/doctype/inventory_dimension/inventory_dimension.py:202
+#: erpnext/stock/doctype/inventory_dimension/inventory_dimension.py:203
 msgid "Rejected "
 msgstr "Avvisad "
 
@@ -43243,7 +43238,7 @@ msgstr "Återstående Belopp"
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:187
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:156
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1135
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1137
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:178
 msgid "Remaining Balance"
 msgstr "Återstående Saldo"
@@ -43296,7 +43291,7 @@ msgstr "Anmärkning"
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:159
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:198
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:269
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1167
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1169
 #: erpnext/accounts/report/general_ledger/general_ledger.html:84
 #: erpnext/accounts/report/general_ledger/general_ledger.html:110
 #: erpnext/accounts/report/general_ledger/general_ledger.py:742
@@ -44046,7 +44041,7 @@ msgstr "Reserverad Kvantitet"
 msgid "Reserved Quantity for Production"
 msgstr "Reserverad Kvantitet för Produktion"
 
-#: erpnext/stock/stock_ledger.py:2147
+#: erpnext/stock/stock_ledger.py:2155
 msgid "Reserved Serial No."
 msgstr "Reserverad Serie Nummer"
 
@@ -44062,11 +44057,11 @@ msgstr "Reserverad Serie Nummer"
 #: erpnext/stock/doctype/pick_list/pick_list.js:153
 #: erpnext/stock/report/reserved_stock/reserved_stock.json
 #: erpnext/stock/report/stock_balance/stock_balance.py:499
-#: erpnext/stock/stock_ledger.py:2131
+#: erpnext/stock/stock_ledger.py:2139
 msgid "Reserved Stock"
 msgstr "Reserverad"
 
-#: erpnext/stock/stock_ledger.py:2177
+#: erpnext/stock/stock_ledger.py:2185
 msgid "Reserved Stock for Batch"
 msgstr "Reserverad för Parti"
 
@@ -44078,7 +44073,7 @@ msgstr "Reserverad Lager för Råvaror"
 msgid "Reserved Stock for Sub-assembly"
 msgstr "Reserverad Lager för Undermontering"
 
-#: erpnext/controllers/buying_controller.py:476
+#: erpnext/controllers/buying_controller.py:484
 msgid "Reserved Warehouse is mandatory for the Item {item_code} in Raw Materials supplied."
 msgstr "Reserverat Lager erfordras för artikel {item_code} i levererade Råvaror."
 
@@ -44892,7 +44887,7 @@ msgstr "Åtgärd Följd"
 msgid "Routing Name"
 msgstr "Åtgärd Följd Namn"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:667
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:663
 msgid "Row #"
 msgstr "Rad #"
 
@@ -44930,7 +44925,7 @@ msgstr "Rad # {0} (Betalning Tabell): Belopp måste vara negativ"
 msgid "Row #{0} (Payment Table): Amount must be positive"
 msgstr "Rad # {0} (Betalning Tabell): Belopp måste vara positiv"
 
-#: erpnext/stock/doctype/item/item.py:495
+#: erpnext/stock/doctype/item/item.py:498
 msgid "Row #{0}: A reorder entry already exists for warehouse {1} with reorder type {2}."
 msgstr "Rad # {0}: Återbeställning Post finns redan för lager {1} med återbeställning typ {2}."
 
@@ -44951,7 +44946,7 @@ msgstr "Rad # {0}: Godkänd Lager och Avvisat Lager kan inte vara samma"
 msgid "Row #{0}: Accepted Warehouse is mandatory for the accepted Item {1}"
 msgstr "Rad # {0}: Godkänd Lager erfodras för godkänd Artikel {1}"
 
-#: erpnext/controllers/accounts_controller.py:1117
+#: erpnext/controllers/accounts_controller.py:1120
 msgid "Row #{0}: Account {1} does not belong to company {2}"
 msgstr "Rad # {0}: Konto {1} tillhör inte Bolag {2}"
 
@@ -44992,27 +44987,27 @@ msgstr "Rad # {0}: Parti Nummer {1} är redan vald."
 msgid "Row #{0}: Cannot allocate more than {1} against payment term {2}"
 msgstr "Rad # {0}: Kan inte tilldela mer än {1} mot betalning villkor {2}"
 
-#: erpnext/controllers/accounts_controller.py:3524
+#: erpnext/controllers/accounts_controller.py:3527
 msgid "Row #{0}: Cannot delete item {1} which has already been billed."
 msgstr "Rad # {0}: Kan inte ta bort Artikel {1} som redan är fakturerad."
 
-#: erpnext/controllers/accounts_controller.py:3498
+#: erpnext/controllers/accounts_controller.py:3501
 msgid "Row #{0}: Cannot delete item {1} which has already been delivered"
 msgstr "Rad # {0}: Kan inte ta bort artikel {1} som redan är levererad"
 
-#: erpnext/controllers/accounts_controller.py:3517
+#: erpnext/controllers/accounts_controller.py:3520
 msgid "Row #{0}: Cannot delete item {1} which has already been received"
 msgstr "Rad #{0}: Kan inte ta bort Artikel {1} som redan är mottagen"
 
-#: erpnext/controllers/accounts_controller.py:3504
+#: erpnext/controllers/accounts_controller.py:3507
 msgid "Row #{0}: Cannot delete item {1} which has work order assigned to it."
 msgstr "Rad # {0}: Kan inte ta bort Artikel {1} som har tilldelad Arbetsorder."
 
-#: erpnext/controllers/accounts_controller.py:3510
+#: erpnext/controllers/accounts_controller.py:3513
 msgid "Row #{0}: Cannot delete item {1} which is assigned to customer's purchase order."
 msgstr "Rad # {0}: Kan inte ta bort Artikel {1} som är tilldelad Kund Inköp Order."
 
-#: erpnext/controllers/accounts_controller.py:3765
+#: erpnext/controllers/accounts_controller.py:3768
 msgid "Row #{0}: Cannot set Rate if the billed amount is greater than the amount for Item {1}."
 msgstr "Rad #{0}: Kan inte ange Pris om fakturerad belopp är högre än belopp för artikel {1}."
 
@@ -45132,7 +45127,7 @@ msgstr "Rad # {0}: Artikel {1} finns inte"
 msgid "Row #{0}: Item {1} has been picked, please reserve stock from the Pick List."
 msgstr "Rad # {0}: Artikel {1} är plockad, reservera lager från Plocklista. "
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:729
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:725
 msgid "Row #{0}: Item {1} is not a Serialized/Batched Item. It cannot have a Serial No/Batch No against it."
 msgstr "Rad # {0}: Artikel {1} är inte Serialiserad/Parti Artikel. Det kan inte ha Serie Nummer / Parti Nummer mot det."
 
@@ -45188,7 +45183,7 @@ msgstr "Rad # {0}: Välj Stycklista Nummer för Montering Artiklar"
 msgid "Row #{0}: Please select the Sub Assembly Warehouse"
 msgstr "Rad #{0}: Välj Underenhet Lager"
 
-#: erpnext/stock/doctype/item/item.py:502
+#: erpnext/stock/doctype/item/item.py:505
 msgid "Row #{0}: Please set reorder quantity"
 msgstr "Rad # {0}: Ange Ombeställning Kvantitet"
 
@@ -45221,8 +45216,8 @@ msgstr "Rad #{0}: Kvalitet Kontroll {1} är inte godkänd för artikel: {2}"
 msgid "Row #{0}: Quality Inspection {1} was rejected for item {2}"
 msgstr "Rad #{0}: Kvalitet Kontroll {1} avvisades för artikel {2}"
 
-#: erpnext/controllers/accounts_controller.py:1274
-#: erpnext/controllers/accounts_controller.py:3624
+#: erpnext/controllers/accounts_controller.py:1277
+#: erpnext/controllers/accounts_controller.py:3627
 msgid "Row #{0}: Quantity for Item {1} cannot be zero."
 msgstr "Rad # {0}: Kvantitet för Artikel {1} kan inte vara noll."
 
@@ -45259,7 +45254,7 @@ msgstr "Rad #{0}: Retur mot erfordras för returnerande tillgång"
 msgid "Row #{0}: Scrap Item Qty cannot be zero"
 msgstr "Rad # {0}: Skrot Artikel Kvantitet kan inte vara noll"
 
-#: erpnext/controllers/selling_controller.py:230
+#: erpnext/controllers/selling_controller.py:238
 msgid "Row #{0}: Selling rate for item {1} is lower than its {2}.\n"
 "\t\t\t\t\tSelling {3} should be atleast {4}.<br><br>Alternatively,\n"
 "\t\t\t\t\tyou can disable selling price validation in {5} to bypass\n"
@@ -45346,7 +45341,7 @@ msgstr "Rad # {0}: Kvantitet ej tillgänglig för reservation för Artikel {1} p
 msgid "Row #{0}: The batch {1} has already expired."
 msgstr "Rad # {0}: Parti {1} har förfallit."
 
-#: erpnext/stock/doctype/item/item.py:511
+#: erpnext/stock/doctype/item/item.py:514
 msgid "Row #{0}: The warehouse {1} is not a child warehouse of a group warehouse {2}"
 msgstr "Rad # {0}: Lager {1} är inte underordnad till grupp lager {2}"
 
@@ -45386,39 +45381,39 @@ msgstr "Rad # {0}: {1} av {2} ska vara {3}. Uppdatera {1} eller välj ett annat 
 msgid "Row #{1}: Warehouse is mandatory for stock Item {0}"
 msgstr "Rad # {1}: Lager erfodras för lager artikel {0} "
 
-#: erpnext/controllers/buying_controller.py:259
+#: erpnext/controllers/buying_controller.py:267
 msgid "Row #{idx}: Cannot select Supplier Warehouse while suppling raw materials to subcontractor."
 msgstr "Rad #{idx}: Kan inte välja Leverantör Lager medan råvaror levereras till underleverantör."
 
-#: erpnext/controllers/buying_controller.py:406
+#: erpnext/controllers/buying_controller.py:414
 msgid "Row #{idx}: Item rate has been updated as per valuation rate since its an internal stock transfer."
 msgstr "Rad # #{idx}: Artikel Pris är uppdaterad enligt Värderingssats eftersom det är intern lager överföring."
 
-#: erpnext/controllers/buying_controller.py:881
+#: erpnext/controllers/buying_controller.py:889
 msgid "Row #{idx}: Please enter a location for the asset item {item_code}."
 msgstr "Rad #{idx}: Ange plats för tillgång artikel {item_code}."
 
-#: erpnext/controllers/buying_controller.py:537
+#: erpnext/controllers/buying_controller.py:545
 msgid "Row #{idx}: Received Qty must be equal to Accepted + Rejected Qty for Item {item_code}."
 msgstr "Rad #{idx}: Mottaget Kvantitet måste vara lika med Godkänd + Avvisad Kvantitet för Artikel {item_code}."
 
-#: erpnext/controllers/buying_controller.py:550
+#: erpnext/controllers/buying_controller.py:558
 msgid "Row #{idx}: {field_label} can not be negative for item {item_code}."
 msgstr "Rad #{idx}: {field_label} kan inte vara negativ för artikel {item_code}."
 
-#: erpnext/controllers/buying_controller.py:496
+#: erpnext/controllers/buying_controller.py:504
 msgid "Row #{idx}: {field_label} is mandatory."
 msgstr "Rad #{idx}: {field_label} erfordras."
 
-#: erpnext/controllers/buying_controller.py:518
+#: erpnext/controllers/buying_controller.py:526
 msgid "Row #{idx}: {field_label} is not allowed in Purchase Return."
 msgstr "Rad #{idx}: {field_label} är inte tillåtet i Inköp Retur."
 
-#: erpnext/controllers/buying_controller.py:250
+#: erpnext/controllers/buying_controller.py:258
 msgid "Row #{idx}: {from_warehouse_field} and {to_warehouse_field} cannot be same."
 msgstr "Rad #{idx}: {from_warehouse_field} och {to_warehouse_field} kan inte vara samma."
 
-#: erpnext/controllers/buying_controller.py:999
+#: erpnext/controllers/buying_controller.py:1007
 msgid "Row #{idx}: {schedule_date} cannot be before {transaction_date}."
 msgstr "Rad #{idx}: {schedule_date} kan inte vara före {transaction_date}."
 
@@ -45483,7 +45478,7 @@ msgstr "Rad # {}: {}"
 msgid "Row #{}: {} {} does not exist."
 msgstr "Rad # {}: {} {} finns inte."
 
-#: erpnext/stock/doctype/item/item.py:1403
+#: erpnext/stock/doctype/item/item.py:1397
 msgid "Row #{}: {} {} doesn't belong to Company {}. Please select valid {}."
 msgstr "Rad # {}: {} {} tillhör inte bolag {}. Välj giltig {}."
 
@@ -45555,11 +45550,11 @@ msgstr "Rad # {0}: Stycklista hittades inte för Artikel {1}"
 msgid "Row {0}: Both Debit and Credit values cannot be zero"
 msgstr "Rad # {0}: Både debet och kredit värdena kan inte vara noll"
 
-#: erpnext/controllers/selling_controller.py:222
+#: erpnext/controllers/selling_controller.py:230
 msgid "Row {0}: Conversion Factor is mandatory"
 msgstr "Rad # {0}: Konvertering Faktor erfodras"
 
-#: erpnext/controllers/accounts_controller.py:2995
+#: erpnext/controllers/accounts_controller.py:2998
 msgid "Row {0}: Cost Center {1} does not belong to Company {2}"
 msgstr "Rad # {0}: Resultat Enhet {1} tillhör inte Bolag {2}"
 
@@ -45579,11 +45574,11 @@ msgstr "Rad # {0}: Valuta för Stycklista # {1} ska vara lika med vald valuta {2
 msgid "Row {0}: Debit entry can not be linked with a {1}"
 msgstr "Rad # {0}: Debet Post kan inte länkas till {1}"
 
-#: erpnext/controllers/selling_controller.py:776
+#: erpnext/controllers/selling_controller.py:784
 msgid "Row {0}: Delivery Warehouse ({1}) and Customer Warehouse ({2}) can not be same"
 msgstr "Rad # {0}: Leverans Lager ({1}) och Kund Lager ({2}) kan inte vara samma"
 
-#: erpnext/controllers/accounts_controller.py:2529
+#: erpnext/controllers/accounts_controller.py:2532
 msgid "Row {0}: Due Date in the Payment Terms table cannot be before Posting Date"
 msgstr "Rad # {0}: Förfallodatum i Betalning Villkor Tabell får inte vara före Bokföring Datum"
 
@@ -45592,7 +45587,7 @@ msgid "Row {0}: Either Delivery Note Item or Packed Item reference is mandatory.
 msgstr "Rad # {0}: Antingen Följesedel eller Packad Artikel Referens erfordras"
 
 #: erpnext/accounts/doctype/journal_entry/journal_entry.py:1010
-#: erpnext/controllers/taxes_and_totals.py:1205
+#: erpnext/controllers/taxes_and_totals.py:1215
 msgid "Row {0}: Exchange Rate is mandatory"
 msgstr "Rad # {0}: Valutaväxling Kurs erfodras"
 
@@ -45641,11 +45636,11 @@ msgstr "Rad # {0}: Antal Timmar måste vara högre än noll."
 msgid "Row {0}: Invalid reference {1}"
 msgstr "Rad # {0}: Ogiltig Referens {1}"
 
-#: erpnext/controllers/taxes_and_totals.py:142
+#: erpnext/controllers/taxes_and_totals.py:143
 msgid "Row {0}: Item Tax template updated as per validity and rate applied"
 msgstr "Rad # {0}: Artikel Moms Mall uppdaterad enligt giltighet och tillämpad moms sats"
 
-#: erpnext/controllers/selling_controller.py:541
+#: erpnext/controllers/selling_controller.py:549
 msgid "Row {0}: Item rate has been updated as per valuation rate since its an internal stock transfer"
 msgstr "Rad # {0}: Artikel Pris är uppdaterad enligt Värderingssats eftersom det är intern lager överföring"
 
@@ -45765,7 +45760,7 @@ msgstr "Rad {0}: Uppgift {1} tillhör inte Projekt {2}"
 msgid "Row {0}: The item {1}, quantity must be positive number"
 msgstr "Rad # {0}: Artikel {1}, Kvantitet måste vara positivt tal"
 
-#: erpnext/controllers/accounts_controller.py:2972
+#: erpnext/controllers/accounts_controller.py:2975
 msgid "Row {0}: The {3} Account {1} does not belong to the company {2}"
 msgstr "Rad {0}: {3} Konto {1} tillhör inte bolag {2}"
 
@@ -45782,7 +45777,7 @@ msgstr "Rad # {0}: Enhet Konvertering Faktor erfordras"
 msgid "Row {0}: Workstation or Workstation Type is mandatory for an operation {1}"
 msgstr "Rad {0}: Arbetsplats eller Arbetsplats Typ erfordras för åtgärd {1}"
 
-#: erpnext/controllers/accounts_controller.py:1011
+#: erpnext/controllers/accounts_controller.py:1014
 msgid "Row {0}: user has not applied the rule {1} on the item {2}"
 msgstr "Rad # {0}: Användare har inte tillämpat regel {1} på Artikel {2}"
 
@@ -45794,7 +45789,7 @@ msgstr "Rad # {0}: {1} konto är redan tillämpad för Bokföring Dimension {2}"
 msgid "Row {0}: {1} must be greater than 0"
 msgstr "Rad # {0}: {1} måste vara högre än 0"
 
-#: erpnext/controllers/accounts_controller.py:706
+#: erpnext/controllers/accounts_controller.py:709
 msgid "Row {0}: {1} {2} cannot be same as {3} (Party Account) {4}"
 msgstr "Rad # {0}: {1} {2} kan inte vara samma som {3} (Parti Konto) {4}"
 
@@ -45810,7 +45805,7 @@ msgstr "Rad # {0}: {2} Artikel {1} finns inte i {2} {3}"
 msgid "Row {1}: Quantity ({0}) cannot be a fraction. To allow this, disable '{2}' in UOM {3}."
 msgstr "Rad # {1}: Kvantitet ({0}) kan inte vara bråkdel. För att tillåta detta, inaktivera '{2}' i Enhet {3}."
 
-#: erpnext/controllers/buying_controller.py:863
+#: erpnext/controllers/buying_controller.py:871
 msgid "Row {idx}: Asset Naming Series is mandatory for the auto creation of assets for item {item_code}."
 msgstr "Rad {idx}: Tillgång Nummer Serie erfordras för att automatiskt skapa tillgångar för artikel {item_code}."
 
@@ -45836,7 +45831,7 @@ msgstr "Rader Borttagna i {0}"
 msgid "Rows with Same Account heads will be merged on Ledger"
 msgstr "Rader med samma Konto Poster kommer slås samman i Bokföring Register"
 
-#: erpnext/controllers/accounts_controller.py:2539
+#: erpnext/controllers/accounts_controller.py:2542
 msgid "Rows with duplicate due dates in other rows were found: {0}"
 msgstr "Rader med dubbla förfallodatum hittades i andra rader: {0}"
 
@@ -45906,7 +45901,7 @@ msgstr "Service Nivå Avtal Uppfylld Status"
 msgid "SLA Paused On"
 msgstr "Service Nivå Avtal Pausad"
 
-#: erpnext/public/js/utils.js:1167
+#: erpnext/public/js/utils.js:1163
 msgid "SLA is on hold since {0}"
 msgstr "Service Nivå Avtal Parkerad sedan {0}"
 
@@ -46308,7 +46303,7 @@ msgstr "Försäljning Möjligheter efter Källa"
 #: erpnext/accounts/report/sales_register/sales_register.py:238
 #: erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
 #: erpnext/buying/doctype/supplier_quotation_item/supplier_quotation_item.json
-#: erpnext/controllers/selling_controller.py:462
+#: erpnext/controllers/selling_controller.py:470
 #: erpnext/crm/doctype/contract/contract.json
 #: erpnext/maintenance/doctype/maintenance_schedule/maintenance_schedule.js:65
 #: erpnext/maintenance/doctype/maintenance_schedule_item/maintenance_schedule_item.json
@@ -46434,7 +46429,7 @@ msgstr "Försäljning Order {0} ej godkänd"
 msgid "Sales Order {0} is not valid"
 msgstr "Försäljning Order {0} är inte giltig"
 
-#: erpnext/controllers/selling_controller.py:443
+#: erpnext/controllers/selling_controller.py:451
 #: erpnext/manufacturing/doctype/work_order/work_order.py:301
 msgid "Sales Order {0} is {1}"
 msgstr "Försäljning Order {0} är {1}"
@@ -46485,7 +46480,7 @@ msgstr "Försäljning Ordrar att Leverera"
 #: erpnext/accounts/doctype/promotional_scheme/promotional_scheme.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:122
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1156
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1158
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:99
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:194
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:74
@@ -46583,7 +46578,7 @@ msgstr "Försäljning Betalning Översikt"
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:156
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:137
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:128
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1153
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1155
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:105
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:191
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:80
@@ -46603,7 +46598,7 @@ msgstr "Försäljning Betalning Översikt"
 msgid "Sales Person"
 msgstr "Säljare"
 
-#: erpnext/controllers/selling_controller.py:204
+#: erpnext/controllers/selling_controller.py:212
 msgid "Sales Person <b>{0}</b> is disabled."
 msgstr "Säljare <b>{0}</b> är inaktiverad."
 
@@ -46884,7 +46879,7 @@ msgstr "Prov Lager"
 
 #. Label of the sample_size (Float) field in DocType 'Quality Inspection'
 #: erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py:93
-#: erpnext/public/js/controllers/transaction.js:2369
+#: erpnext/public/js/controllers/transaction.js:2395
 #: erpnext/stock/doctype/quality_inspection/quality_inspection.json
 msgid "Sample Size"
 msgstr "Prov Kvantitet"
@@ -47424,7 +47419,7 @@ msgstr "Välj Artiklar"
 msgid "Select Items based on Delivery Date"
 msgstr "Välj Artiklar baserad på Leverans Datum"
 
-#: erpnext/public/js/controllers/transaction.js:2405
+#: erpnext/public/js/controllers/transaction.js:2431
 msgid "Select Items for Quality Inspection"
 msgstr " Välj Artiklar för Kvalitet Kontroll"
 
@@ -47565,7 +47560,7 @@ msgstr "Välj Bolag"
 msgid "Select company name first."
 msgstr "Välj Bolag Namn."
 
-#: erpnext/controllers/accounts_controller.py:2785
+#: erpnext/controllers/accounts_controller.py:2788
 msgid "Select finance book for the item {0} at row {1}"
 msgstr "Välj Finans Register för artikel {0} på rad {1}"
 
@@ -47779,7 +47774,7 @@ msgid "Send Now"
 msgstr "Skicka Nu"
 
 #. Label of the send_sms (Button) field in DocType 'SMS Center'
-#: erpnext/public/js/controllers/transaction.js:517
+#: erpnext/public/js/controllers/transaction.js:543
 #: erpnext/selling/doctype/sms_center/sms_center.json
 msgid "Send SMS"
 msgstr "Skicka SMS"
@@ -47937,7 +47932,7 @@ msgstr "Serie / Parti Nummer"
 #: erpnext/manufacturing/doctype/job_card/job_card.json
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.js:74
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.py:114
-#: erpnext/public/js/controllers/transaction.js:2382
+#: erpnext/public/js/controllers/transaction.js:2408
 #: erpnext/public/js/utils/serial_no_batch_selector.js:421
 #: erpnext/selling/doctype/installation_note_item/installation_note_item.json
 #: erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
@@ -47986,7 +47981,7 @@ msgstr "Serie Nummer Register"
 msgid "Serial No Range"
 msgstr "Serienummer Intervall"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1894
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1895
 msgid "Serial No Reserved"
 msgstr "Serienummer Reserverad"
 
@@ -48026,7 +48021,7 @@ msgstr "Serie Nummer & Parti"
 msgid "Serial No and Batch Selector cannot be use when Use Serial / Batch Fields is enabled."
 msgstr "Serie Nummer och Parti Väljare kan inte användas när Använd Serie Nummer / Parti Fält är aktiverad."
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:859
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:860
 msgid "Serial No is mandatory"
 msgstr "Serie Nummer erfodras"
 
@@ -48055,7 +48050,7 @@ msgstr "Serie Nummer {0} tillhör inte Artikel {1}"
 msgid "Serial No {0} does not exist"
 msgstr "Serie Nummer {0} finns inte"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2623
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2624
 msgid "Serial No {0} does not exists"
 msgstr "Serie Nummer {0} finns inte "
 
@@ -48063,7 +48058,7 @@ msgstr "Serie Nummer {0} finns inte "
 msgid "Serial No {0} is already added"
 msgstr "Serie Nummer {0} har redan lagts till"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:357
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:358
 msgid "Serial No {0} is not present in the {1} {2}, hence you can't return it against the {1} {2}"
 msgstr "Serienummer {0} finns inte i {1} {2}, därför kan du inte returnera det mot {1} {2}"
 
@@ -48100,11 +48095,11 @@ msgstr "Serie Nummer. / Parti Nummer."
 msgid "Serial Nos and Batches"
 msgstr "Serie Nummer & Partier"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1370
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1371
 msgid "Serial Nos are created successfully"
 msgstr "Serie Nummer skapade"
 
-#: erpnext/stock/stock_ledger.py:2137
+#: erpnext/stock/stock_ledger.py:2145
 msgid "Serial Nos are reserved in Stock Reservation Entries, you need to unreserve them before proceeding."
 msgstr "Serie Nmmer är reserverade iLagerreservationsinlägg, du måste avboka dem innan du fortsätter."
 
@@ -48178,11 +48173,11 @@ msgstr "Serie Nummer och Parti "
 msgid "Serial and Batch Bundle"
 msgstr "Serie och Parti Paket"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1598
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1599
 msgid "Serial and Batch Bundle created"
 msgstr "Serie och Parti Paket skapad"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1664
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1665
 msgid "Serial and Batch Bundle updated"
 msgstr "Serie och Parti Paket uppdaterad"
 
@@ -48534,12 +48529,12 @@ msgid "Service Stop Date"
 msgstr "Service Stopp Datum"
 
 #: erpnext/accounts/deferred_revenue.py:44
-#: erpnext/public/js/controllers/transaction.js:1420
+#: erpnext/public/js/controllers/transaction.js:1446
 msgid "Service Stop Date cannot be after Service End Date"
 msgstr "Service Stopp Datum kan inte vara efter Service Slut Datum"
 
 #: erpnext/accounts/deferred_revenue.py:41
-#: erpnext/public/js/controllers/transaction.js:1417
+#: erpnext/public/js/controllers/transaction.js:1443
 msgid "Service Stop Date cannot be before Service Start Date"
 msgstr "Service Stopp Datum kan inte vara före Service Start Datum"
 
@@ -49976,7 +49971,7 @@ msgstr "Standard Klassade Kostnader"
 
 #: erpnext/setup/setup_wizard/operations/defaults_setup.py:70
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:463
-#: erpnext/stock/doctype/item/item.py:245
+#: erpnext/stock/doctype/item/item.py:248
 msgid "Standard Selling"
 msgstr "Standard Försäljning"
 
@@ -50806,7 +50801,7 @@ msgstr "Lager Mottagen men ej Fakturerad Konto"
 #. Option for the 'Purpose' (Select) field in DocType 'Stock Reconciliation'
 #. Label of a Link in the Stock Workspace
 #: erpnext/setup/workspace/home/home.json
-#: erpnext/stock/doctype/item/item.py:612
+#: erpnext/stock/doctype/item/item.py:618
 #: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.json
 #: erpnext/stock/workspace/stock/stock.json
 msgid "Stock Reconciliation"
@@ -50817,7 +50812,7 @@ msgstr "Inventering"
 msgid "Stock Reconciliation Item"
 msgstr "Inventering Post"
 
-#: erpnext/stock/doctype/item/item.py:612
+#: erpnext/stock/doctype/item/item.py:618
 msgid "Stock Reconciliations"
 msgstr "Lager Inventeringar"
 
@@ -50852,7 +50847,7 @@ msgstr "Lager Ompostering Inställningar"
 #: erpnext/stock/doctype/pick_list/pick_list.js:150
 #: erpnext/stock/doctype/pick_list/pick_list.js:155
 #: erpnext/stock/doctype/stock_entry/stock_entry_dashboard.py:25
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:706
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:702
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:575
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:1138
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:1398
@@ -51252,7 +51247,7 @@ msgstr "Stoppad Arbetsorder kan inte annulleras, Ångra först för att annuller
 #: erpnext/setup/doctype/company/company.py:287
 #: erpnext/setup/setup_wizard/operations/defaults_setup.py:33
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:502
-#: erpnext/stock/doctype/item/item.py:282
+#: erpnext/stock/doctype/item/item.py:285
 msgid "Stores"
 msgstr "Butiker"
 
@@ -51787,7 +51782,7 @@ msgstr "Avstämd"
 msgid "Successfully Set Supplier"
 msgstr "Leverantör vald"
 
-#: erpnext/stock/doctype/item/item.py:339
+#: erpnext/stock/doctype/item/item.py:342
 msgid "Successfully changed Stock UOM, please redefine conversion factors for new UOM."
 msgstr "Lager Enhet ändrad, ändra konvertering faktor för ny enhet."
 
@@ -52089,7 +52084,7 @@ msgstr "Leverantör Detaljer"
 #: erpnext/accounts/doctype/tax_rule/tax_rule.json
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:111
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:87
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1160
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1162
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:198
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:237
 #: erpnext/accounts/report/purchase_register/purchase_register.js:27
@@ -52189,7 +52184,7 @@ msgstr "Leverantör Register"
 #. Label of the supplier_name (Data) field in DocType 'Purchase Receipt'
 #. Label of the supplier_name (Data) field in DocType 'Stock Entry'
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1077
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1079
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:156
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:198
 #: erpnext/accounts/report/purchase_register/purchase_register.py:177
@@ -52673,7 +52668,7 @@ msgstr "System kommer automatiskt att skapa serienummer/parti för färdig artik
 msgid "System will fetch all the entries if limit value is zero."
 msgstr "System hämtar alla poster om gräns värde är noll."
 
-#: erpnext/controllers/accounts_controller.py:1975
+#: erpnext/controllers/accounts_controller.py:1978
 msgid "System will not check over billing since amount for Item {0} in {1} is zero"
 msgstr "System kontrollerar inte överfakturering eftersom belopp för Artikel {0} i {1} är noll"
 
@@ -52932,7 +52927,7 @@ msgstr "Fel vid reservation av Till Lager"
 msgid "Target Warehouse is required before Submit"
 msgstr "För Lager erfodras före Godkännande"
 
-#: erpnext/controllers/selling_controller.py:782
+#: erpnext/controllers/selling_controller.py:790
 msgid "Target Warehouse is set for some items but the customer is not an internal customer."
 msgstr "Till Lager angiven för vissa artiklar men kund är inte intern kund."
 
@@ -53171,7 +53166,7 @@ msgstr "Moms Fördelning"
 msgid "Tax Category"
 msgstr "Moms Kategori"
 
-#: erpnext/controllers/buying_controller.py:194
+#: erpnext/controllers/buying_controller.py:202
 msgid "Tax Category has been changed to \"Total\" because all the Items are non-stock items"
 msgstr "Moms Kategori har ändrats till 'Totalt' eftersom alla Artiklar är Ej Lager Artiklar"
 
@@ -53377,7 +53372,7 @@ msgstr "Moms kommer att dras av bara för belopp som överstiger kumulativ trös
 #. Label of the taxable_amount (Currency) field in DocType 'Tax Withheld
 #. Vouchers'
 #: erpnext/accounts/doctype/tax_withheld_vouchers/tax_withheld_vouchers.json
-#: erpnext/controllers/taxes_and_totals.py:1125
+#: erpnext/controllers/taxes_and_totals.py:1135
 msgid "Taxable Amount"
 msgstr "Moms Belopp"
 
@@ -53516,7 +53511,7 @@ msgstr "Moms och Avgifter Avdragna"
 msgid "Taxes and Charges Deducted (Company Currency)"
 msgstr "Moms och Avgifter Avdragna (Bolag Valuta)"
 
-#: erpnext/stock/doctype/item/item.py:352
+#: erpnext/stock/doctype/item/item.py:355
 msgid "Taxes row #{0}: {1} cannot be smaller than {2}"
 msgstr "Momsrad #{0}: {1} kan inte vara lägre än {2}"
 
@@ -53802,7 +53797,7 @@ msgstr "Regler och Villkor Mall"
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/territory_item/territory_item.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:134
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1144
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1146
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:93
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:182
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:68
@@ -53906,7 +53901,7 @@ msgstr "Åtkomst till Inköp Offert från Portal är inaktiverad. För att till�
 msgid "The BOM which will be replaced"
 msgstr "Stycklista före"
 
-#: erpnext/stock/serial_batch_bundle.py:1274
+#: erpnext/stock/serial_batch_bundle.py:1306
 msgid "The Batch {0} has negative quantity {1} in warehouse {2}. Please correct the quantity."
 msgstr "Parti {0} har negativ kvantitet {1} i lager {2}. Korrigera kvantitet."
 
@@ -53958,7 +53953,7 @@ msgstr "Säljare är länkad till {0}"
 msgid "The Serial No at Row #{0}: {1} is not available in warehouse {2}."
 msgstr "Serie Nummer på rad #{0}: {1} är inte tillgänglig i lager {2}."
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1891
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1892
 msgid "The Serial No {0} is reserved against the {1} {2} and cannot be used for any other transaction."
 msgstr "Serienummer {0} är reserverad för {1} {2} och får inte användas för någon annan transaktion."
 
@@ -54041,7 +54036,7 @@ msgstr "Följande tillgångar kunde inte bokföra avskrivning poster automatiskt
 msgid "The following batches are expired, please restock them: <br> {0}"
 msgstr "Följande partier är utgångna, fyll på dem: <br> {0}"
 
-#: erpnext/stock/doctype/item/item.py:849
+#: erpnext/stock/doctype/item/item.py:843
 msgid "The following deleted attributes exist in Variants but not in the Template. You can either delete the Variants or keep the attribute(s) in template."
 msgstr "Följande raderade egenskaper finns i varianter men inte i mall. Antingen ta bort varianter eller behålla egenskaper i mall."
 
@@ -54066,15 +54061,15 @@ msgstr "Brutto Vikt på förpackning. Vanligtvis Netto Vikt + Förpackning Mater
 msgid "The holiday on {0} is not between From Date and To Date"
 msgstr "Helgdag {0} är inte mellan Från Datum och Till Datum"
 
-#: erpnext/controllers/buying_controller.py:1066
+#: erpnext/controllers/buying_controller.py:1074
 msgid "The item {item} is not marked as {type_of} item. You can enable it as {type_of} item from its Item master."
 msgstr "Artikel {item} är inte angiven som {type_of} artikel. Du kan aktivera det som {type_of} artikel från dess Artikel Inställningar."
 
-#: erpnext/stock/doctype/item/item.py:614
+#: erpnext/stock/doctype/item/item.py:620
 msgid "The items {0} and {1} are present in the following {2} :"
 msgstr "Artiklar {0} och {1} finns i följande {2}:"
 
-#: erpnext/controllers/buying_controller.py:1059
+#: erpnext/controllers/buying_controller.py:1067
 msgid "The items {items} are not marked as {type_of} item. You can enable them as {type_of} item from their Item masters."
 msgstr "Artiklar {items} är inte angivna som {type_of} artiklar. Du kan aktivera dem som {type_of} artiklar från deras Artikel Inställningar."
 
@@ -54176,8 +54171,8 @@ msgstr "Vald Artikel kan inte ha Parti"
 msgid "The seller and the buyer cannot be the same"
 msgstr "Säljare och Köpare kan inte vara samma"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:142
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:154
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:143
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:155
 msgid "The serial and batch bundle {0} not linked to {1} {2}"
 msgstr "Serie och Parti Paket {0} är inte kopplat till {1} {2}"
 
@@ -54201,7 +54196,7 @@ msgstr "Aktier finns inte med {0}"
 msgid "The stock for the item {0} in the {1} warehouse was negative on the {2}. You should create a positive entry {3} before the date {4} and time {5} to post the correct valuation rate. For more details, please read the <a href='https://docs.erpnext.com/docs/user/manual/en/stock-adjustment-cogs-with-negative-stock'>documentation<a>."
 msgstr "Lager för artikel {0} i {1} lager var negativt {2}. Skapa positiv post {3} före {4} och {5} för att bokföra rätt Värderingssats. För mer information, läs dokumentation <a href='https://docs.erpnext.com/docs/user/manual/en/stock-adjustment-cogs-with-negative-stock'><a>."
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:700
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:696
 msgid "The stock has been reserved for the following Items and Warehouses, un-reserve the same to {0} the Stock Reconciliation: <br /><br /> {1}"
 msgstr "Lager är reserverad för följande Artiklar och Lager, ta bort reservation till {0} Lager Inventering : <br /><br /> {1}"
 
@@ -54214,11 +54209,11 @@ msgstr "Synkronisering startad i bakgrunden. Kolla {0} lista för nya poster."
 msgid "The task has been enqueued as a background job."
 msgstr "Uppgift är i kö som bakgrund jobb."
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:994
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:990
 msgid "The task has been enqueued as a background job. In case there is any issue on processing in background, the system will add a comment about the error on this Stock Reconciliation and revert to the Draft stage"
 msgstr "Uppgift är i kö som bakgrund jobb. Om det finns problem med behandling i bakgrund kommer system att lägga till kommentar om fel i denna Lager Inventering och återgå till Utkast status."
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1005
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1001
 msgid "The task has been enqueued as a background job. In case there is any issue on processing in background, the system will add a comment about the error on this Stock Reconciliation and revert to the Submitted stage"
 msgstr "Uppgift är i kö som ett bakgrund jobb. Om det finns några problem med bearbetning i bakgrund kommer system att lägga till kommentar om fel på denna Lager Inventering och återgå till Godkänd status"
 
@@ -54268,7 +54263,7 @@ msgstr "Lager där artiklar kommer att överföras när produktion påbörjas. G
 msgid "The {0} ({1}) must be equal to {2} ({3})"
 msgstr "{0} ({1}) måste vara lika med {2} ({3})"
 
-#: erpnext/public/js/controllers/transaction.js:2790
+#: erpnext/public/js/controllers/transaction.js:2816
 msgid "The {0} contains Unit Price Items."
 msgstr "{0} innehåller Enhet Pris Artiklar."
 
@@ -54316,7 +54311,7 @@ msgstr "Det finns inga artikelvarianter för vald artikel"
 msgid "There can be multiple tiered collection factor based on the total spent. But the conversion factor for redemption will always be same for all the tier."
 msgstr "Det kan finnas flera nivåer insamling faktor baserat på totalt spenderade. Men konvertering faktor för inlösen kommer alltid att vara densamma för alla nivåer."
 
-#: erpnext/accounts/party.py:580
+#: erpnext/accounts/party.py:586
 msgid "There can only be 1 Account per Company in {0} {1}"
 msgstr "Det kan bara finnas ett konto per Bolag i {0} {1}"
 
@@ -54602,7 +54597,7 @@ msgstr "Detta kommer att läggas till Artikel Kod Variant. Till exempel, om din 
 msgid "This will restrict user access to other employee records"
 msgstr "Detta kommer att begränsa användar åtkomst till annan Personal Register"
 
-#: erpnext/controllers/selling_controller.py:783
+#: erpnext/controllers/selling_controller.py:791
 msgid "This {} will be treated as material transfer."
 msgstr "Denna {} kommer att behandlas som material överföring."
 
@@ -55316,11 +55311,11 @@ msgid "To include sub-assembly costs and scrap items in Finished Goods on a work
 msgstr "Inkludera kostnader för underenheter och skrot artiklar i Färdiga Artiklar på Arbetsorder utan att använda Jobbkort, när alternativ \"Använd Flernivå Stycklista\" är aktiverat."
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:2337
-#: erpnext/controllers/accounts_controller.py:3005
+#: erpnext/controllers/accounts_controller.py:3008
 msgid "To include tax in row {0} in Item rate, taxes in rows {1} must also be included"
 msgstr "Att inkludera moms på rad {0} i artikel pris, moms i rader {1} måste också inkluderas"
 
-#: erpnext/stock/doctype/item/item.py:636
+#: erpnext/stock/doctype/item/item.py:642
 msgid "To merge, following properties must be same for both items"
 msgstr "Att slå samman, måste följande egenskaper vara samma för båda artiklar"
 
@@ -55940,7 +55935,7 @@ msgstr "Totalt Utestående Belopp"
 msgid "Total Paid Amount"
 msgstr "Totalt Betald Belopp"
 
-#: erpnext/controllers/accounts_controller.py:2591
+#: erpnext/controllers/accounts_controller.py:2594
 msgid "Total Payment Amount in Payment Schedule must be equal to Grand / Rounded Total"
 msgstr "Totalt Betalning Belopp i Betalning Plan måste vara lika med Totalt Summa / Avrundad Totalt"
 
@@ -56225,15 +56220,15 @@ msgstr "Total Vikt (kg)"
 msgid "Total Working Hours"
 msgstr "Totalt Arbetstid"
 
-#: erpnext/controllers/accounts_controller.py:2138
+#: erpnext/controllers/accounts_controller.py:2141
 msgid "Total advance ({0}) against Order {1} cannot be greater than the Grand Total ({2})"
 msgstr "Totalt förskott ({0}) mot Order {1} kan inte vara högre än Totalt Summa ({2})"
 
-#: erpnext/controllers/selling_controller.py:190
+#: erpnext/controllers/selling_controller.py:198
 msgid "Total allocated percentage for sales team should be 100"
 msgstr "Totalt tilldelad procentsats för Försäljning Team ska vara 100%"
 
-#: erpnext/selling/doctype/customer/customer.py:162
+#: erpnext/selling/doctype/customer/customer.py:161
 msgid "Total contribution percentage should be equal to 100"
 msgstr "Totalt bidrag procentsats ska vara lika med 100%"
 
@@ -57118,7 +57113,7 @@ msgstr "Enhet"
 msgid "Unit of Measure (UOM)"
 msgstr "Enhet"
 
-#: erpnext/stock/doctype/item/item.py:384
+#: erpnext/stock/doctype/item/item.py:387
 msgid "Unit of Measure {0} has been entered more than once in Conversion Factor Table"
 msgstr "Enhet {0} är angiven mer än en gång i Konvertering Faktor Tabell"
 
@@ -57560,7 +57555,7 @@ msgstr "Uppdatera ändrad tidsstämpel på ny konversation mottagen i Potentiell
 msgid "Update timestamp on new communication"
 msgstr "Uppdatera tidsstämpel på ny Konversation"
 
-#: erpnext/manufacturing/doctype/bom_creator/bom_creator.py:533
+#: erpnext/manufacturing/doctype/bom_creator/bom_creator.py:534
 msgid "Updated successfully"
 msgstr "Uppdaterad"
 
@@ -57574,7 +57569,7 @@ msgstr "Uppdaterad"
 msgid "Updated via 'Time Log' (In Minutes)"
 msgstr "Uppdaterad via 'Tid Logg' (i Minuter)"
 
-#: erpnext/stock/doctype/item/item.py:1387
+#: erpnext/stock/doctype/item/item.py:1381
 msgid "Updating Variants..."
 msgstr "Uppdaterar Varianter..."
 
@@ -58132,19 +58127,19 @@ msgstr "Grund Pris"
 msgid "Valuation Rate (In / Out)"
 msgstr "Grund Pris (In/Ut)"
 
-#: erpnext/stock/stock_ledger.py:1881
+#: erpnext/stock/stock_ledger.py:1890
 msgid "Valuation Rate Missing"
 msgstr "Grund Pris Saknas"
 
-#: erpnext/stock/stock_ledger.py:1859
+#: erpnext/stock/stock_ledger.py:1868
 msgid "Valuation Rate for the Item {0}, is required to do accounting entries for {1} {2}."
 msgstr "Grund Pris för Artikel {0} erfodras att skapa bokföring poster för {1} {2}."
 
-#: erpnext/stock/doctype/item/item.py:266
+#: erpnext/stock/doctype/item/item.py:269
 msgid "Valuation Rate is mandatory if Opening Stock entered"
 msgstr "Grund Pris erfodras om Öppning Lager anges"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:752
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:748
 msgid "Valuation Rate required for Item {0} at row {1}"
 msgstr "Grund Pris erfordras för Artikel {0} på rad {1}"
 
@@ -58154,7 +58149,7 @@ msgstr "Grund Pris erfordras för Artikel {0} på rad {1}"
 msgid "Valuation and Total"
 msgstr "Värdering och Totalt"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:971
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:967
 msgid "Valuation rate for customer provided items has been set to zero."
 msgstr "Grund Pris för Kund Försedda Artiklar sattes till noll."
 
@@ -58168,7 +58163,7 @@ msgid "Valuation rate for the item as per Sales Invoice (Only for Internal Trans
 msgstr "Grund Pris för artikel enligt Försäljning Faktura (endast för Interna Överföringar)"
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:2361
-#: erpnext/controllers/accounts_controller.py:3029
+#: erpnext/controllers/accounts_controller.py:3032
 msgid "Valuation type charges can not be marked as Inclusive"
 msgstr "Värdering typ avgifter kan inte väljas som Inklusiva"
 
@@ -58324,7 +58319,7 @@ msgstr "Avvikelse ({})"
 msgid "Variant"
 msgstr "Variant"
 
-#: erpnext/stock/doctype/item/item.py:864
+#: erpnext/stock/doctype/item/item.py:858
 msgid "Variant Attribute Error"
 msgstr "Variant Egenskap Fel"
 
@@ -58343,7 +58338,7 @@ msgstr "Variant Stycklista"
 msgid "Variant Based On"
 msgstr "Variant Baserad På"
 
-#: erpnext/stock/doctype/item/item.py:892
+#: erpnext/stock/doctype/item/item.py:886
 msgid "Variant Based On cannot be changed"
 msgstr "Variant Baserad På kan inte ändras"
 
@@ -58361,7 +58356,7 @@ msgstr "Variant Fält"
 msgid "Variant Item"
 msgstr "Variant Artikel"
 
-#: erpnext/stock/doctype/item/item.py:862
+#: erpnext/stock/doctype/item/item.py:856
 msgid "Variant Items"
 msgstr "Variant Artiklar"
 
@@ -58479,7 +58474,7 @@ msgstr "Video Inställningar"
 #: erpnext/accounts/doctype/cost_center/cost_center_tree.js:56
 #: erpnext/accounts/doctype/invoice_discounting/invoice_discounting.js:205
 #: erpnext/accounts/doctype/journal_entry/journal_entry.js:43
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:668
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:670
 #: erpnext/bulk_transaction/doctype/bulk_transaction_log/bulk_transaction_log.js:14
 #: erpnext/bulk_transaction/doctype/bulk_transaction_log/bulk_transaction_log.js:24
 #: erpnext/buying/doctype/request_for_quotation/request_for_quotation.js:167
@@ -58666,7 +58661,7 @@ msgstr "Verifikat Namn"
 #: erpnext/accounts/doctype/repost_accounting_ledger_items/repost_accounting_ledger_items.json
 #: erpnext/accounts/doctype/repost_payment_ledger_items/repost_payment_ledger_items.json
 #: erpnext/accounts/doctype/unreconcile_payment/unreconcile_payment.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1099
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1101
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.js:42
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:209
 #: erpnext/accounts/report/general_ledger/general_ledger.js:49
@@ -58697,7 +58692,7 @@ msgstr "Verifikat Namn"
 msgid "Voucher No"
 msgstr "Verifikat Nummer"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1087
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1088
 msgid "Voucher No is mandatory"
 msgstr "Verifikat Nummer Erfodras"
 
@@ -58739,7 +58734,7 @@ msgstr "Verifikat Undertyp"
 #: erpnext/accounts/doctype/repost_payment_ledger_items/repost_payment_ledger_items.json
 #: erpnext/accounts/doctype/tax_withheld_vouchers/tax_withheld_vouchers.json
 #: erpnext/accounts/doctype/unreconcile_payment/unreconcile_payment.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1097
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1099
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:200
 #: erpnext/accounts/report/general_ledger/general_ledger.py:697
 #: erpnext/accounts/report/invalid_ledger_entries/invalid_ledger_entries.py:31
@@ -59093,10 +59088,6 @@ msgstr "Lager erfordras"
 msgid "Warehouse not found against the account {0}"
 msgstr "Lager hittades inte mot konto {0}"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:600
-msgid "Warehouse not found in the system"
-msgstr "Lager hittades inte i system"
-
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:1130
 #: erpnext/stock/doctype/delivery_note/delivery_note.py:414
 msgid "Warehouse required for stock Item {0}"
@@ -59225,7 +59216,7 @@ msgid "Warn for new Request for Quotations"
 msgstr "Varna för nya Inköp Offerter"
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:744
-#: erpnext/controllers/accounts_controller.py:1978
+#: erpnext/controllers/accounts_controller.py:1981
 #: erpnext/stock/doctype/delivery_trip/delivery_trip.js:145
 #: erpnext/utilities/transaction_base.py:123
 msgid "Warning"
@@ -60197,7 +60188,7 @@ msgstr "Ja"
 msgid "You are importing data for the code list:"
 msgstr "Du importerar data för Kod Lista:"
 
-#: erpnext/controllers/accounts_controller.py:3611
+#: erpnext/controllers/accounts_controller.py:3614
 msgid "You are not allowed to update as per the conditions set in {} Workflow."
 msgstr "Du är inte behörig att uppdatera enligt villkoren i {} Arbetsflöde."
 
@@ -60262,7 +60253,7 @@ msgstr "Du kan ange den som maskin namn eller åtgärd typ. Till exempel sy mask
 msgid "You can't make any changes to Job Card since Work Order is closed."
 msgstr "Du kan inte göra några ändringar i Jobbkort eftersom Arbetsorder är stängd."
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:185
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:186
 msgid "You can't process the serial number {0} as it has already been used in the SABB {1}. {2} if you want to inward same serial number multiple times then enabled 'Allow existing Serial No to be Manufactured/Received again' in the {3}"
 msgstr "Du kan inte behandla serienummer {0} eftersom det redan har använts i Serienummer och Parti Paket {1}. {2} Om du vill leverera in samma serienummer flera gånger aktiverar du \"Tillåt att befintligt serienummer produceras/tas emot igen\" i {3}"
 
@@ -60322,7 +60313,7 @@ msgstr "Du kan inte godkänna order utan betalning."
 msgid "You cannot {0} this document because another Period Closing Entry {1} exists after {2}"
 msgstr "Du kan inte {0} detta dokument eftersom en annan Period Stängning Post {1} finns efter {2}"
 
-#: erpnext/controllers/accounts_controller.py:3587
+#: erpnext/controllers/accounts_controller.py:3590
 msgid "You do not have permissions to {} items in a {}."
 msgstr "Du har inte behörighet att {} artikel i {}."
 
@@ -60350,7 +60341,7 @@ msgstr "Du är inbjuden att medverka i projekt {0}."
 msgid "You have entered a duplicate Delivery Note on Row"
 msgstr "Du har angett dubblett Försäljning Följesedel på Rad"
 
-#: erpnext/stock/doctype/item/item.py:1063
+#: erpnext/stock/doctype/item/item.py:1057
 msgid "You have to enable auto re-order in Stock Settings to maintain re-order levels."
 msgstr "Du måste aktivera automatisk ombeställning i lager inställningar för att behålla ombeställning nivåer."
 
@@ -60370,7 +60361,7 @@ msgstr "Välj Kund före Artikel."
 msgid "You need to cancel POS Closing Entry {} to be able to cancel this document."
 msgstr "Annullera Kassa Stängning Post {} för att annullera detta dokument."
 
-#: erpnext/controllers/accounts_controller.py:2980
+#: erpnext/controllers/accounts_controller.py:2983
 msgid "You selected the account group {1} as {2} Account in row {0}. Please select a single account."
 msgstr "Du valde kontogrupp {1} som {2} Konto på rad {0}. Välj ett enskilt konto."
 
@@ -60448,7 +60439,7 @@ msgstr "[Viktigt] [System] Automatisk Ombeställning Fel"
 msgid "`Allow Negative rates for Items`"
 msgstr "\"Tillåt Negativa Priser för Artiklar\"."
 
-#: erpnext/stock/stock_ledger.py:1873
+#: erpnext/stock/stock_ledger.py:1882
 msgid "after"
 msgstr "efter"
 
@@ -60596,7 +60587,7 @@ msgstr "vänster"
 msgid "material_request_item"
 msgstr "material_begäran_artikel"
 
-#: erpnext/controllers/selling_controller.py:151
+#: erpnext/controllers/selling_controller.py:159
 msgid "must be between 0 and 100"
 msgstr "måste vara mellan 0 och 100"
 
@@ -60621,7 +60612,7 @@ msgstr "gammal_överordnad"
 msgid "on"
 msgstr "Klar "
 
-#: erpnext/controllers/accounts_controller.py:1289
+#: erpnext/controllers/accounts_controller.py:1292
 msgid "or"
 msgstr "eller"
 
@@ -60670,7 +60661,7 @@ msgstr "payment app är inte installerad. Installera det från {0} eller {1}"
 msgid "per hour"
 msgstr "Kostnad per Timme"
 
-#: erpnext/stock/stock_ledger.py:1874
+#: erpnext/stock/stock_ledger.py:1883
 msgid "performing either one below:"
 msgstr "utför någon av dem nedan:"
 
@@ -60797,7 +60788,7 @@ msgstr "Välj Kapitalarbete Pågår Konto i Konto Tabell"
 msgid "{0}"
 msgstr "{0}"
 
-#: erpnext/controllers/accounts_controller.py:1109
+#: erpnext/controllers/accounts_controller.py:1112
 msgid "{0} '{1}' is disabled"
 msgstr "{0} {1} är inaktiverad"
 
@@ -60813,7 +60804,7 @@ msgstr "{0} ({1}) kan inte vara högre än planerad kvantitet ({2}) i arbetsorde
 msgid "{0} <b>{1}</b> has submitted Assets. Remove Item <b>{2}</b> from table to continue."
 msgstr "{0} <b>{1}</b> har godkänt tillgångar. Ta bort Artikel <b>{2}</b> från tabell för att fortsätta."
 
-#: erpnext/controllers/accounts_controller.py:2193
+#: erpnext/controllers/accounts_controller.py:2196
 msgid "{0} Account not found against Customer {1}."
 msgstr "{0} Konto hittades inte mot Kund {1}."
 
@@ -60845,7 +60836,7 @@ msgstr "{0} Åtgärder: {1}"
 msgid "{0} Request for {1}"
 msgstr "{0} Begäran för {1}"
 
-#: erpnext/stock/doctype/item/item.py:323
+#: erpnext/stock/doctype/item/item.py:326
 msgid "{0} Retain Sample is based on batch, please check Has Batch No to retain sample of item"
 msgstr "{0} Behåll Prov är baserad på Parti. välj Har Parti Nummer att behålla prov på Artikel"
 
@@ -60936,7 +60927,7 @@ msgid "{0} entered twice in Item Tax"
 msgstr "{0} angiven två gånger under Artikel Moms"
 
 #: erpnext/setup/doctype/item_group/item_group.py:48
-#: erpnext/stock/doctype/item/item.py:436
+#: erpnext/stock/doctype/item/item.py:439
 msgid "{0} entered twice {1} in Item Taxes"
 msgstr "{0} angiven två gånger {1} under Artikel Moms"
 
@@ -60957,7 +60948,7 @@ msgstr "{0} är godkänd"
 msgid "{0} hours"
 msgstr "{0} timmar"
 
-#: erpnext/controllers/accounts_controller.py:2534
+#: erpnext/controllers/accounts_controller.py:2537
 msgid "{0} in row {1}"
 msgstr "{0} på rad {1}"
 
@@ -60981,7 +60972,7 @@ msgstr "{0} är spärrad så denna transaktion kan inte fortsätta"
 
 #: erpnext/accounts/doctype/budget/budget.py:60
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:643
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:49
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:50
 #: erpnext/accounts/report/general_ledger/general_ledger.py:59
 #: erpnext/accounts/report/pos_register/pos_register.py:107
 #: erpnext/controllers/trends.py:50
@@ -61001,11 +60992,11 @@ msgstr "{0} är erfodrad för konto {1}"
 msgid "{0} is mandatory. Maybe Currency Exchange record is not created for {1} to {2}"
 msgstr "{0} är erfordrad. Kanske Valutaväxling Post är inte skapad för {1} till {2}"
 
-#: erpnext/controllers/accounts_controller.py:2937
+#: erpnext/controllers/accounts_controller.py:2940
 msgid "{0} is mandatory. Maybe Currency Exchange record is not created for {1} to {2}."
 msgstr "{0} är erfordrad. Kanske Valutaväxling Post är inte skapad för {1} till {2}."
 
-#: erpnext/selling/doctype/customer/customer.py:204
+#: erpnext/selling/doctype/customer/customer.py:203
 msgid "{0} is not a company bank account"
 msgstr "{0} är inte bolag bank konto"
 
@@ -61088,7 +61079,7 @@ msgstr "{0} kvantitet av artikel {1} tas emot i Lager {2} med kapacitet {3}."
 msgid "{0} to {1}"
 msgstr "{0} till {1}"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:690
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:686
 msgid "{0} units are reserved for Item {1} in Warehouse {2}, please un-reserve the same to {3} the Stock Reconciliation."
 msgstr "{0} enheter är reserverade för Artikel {1} i Lager {2}, ta bort reservation för {3} Lager Inventering."
 
@@ -61104,16 +61095,16 @@ msgstr "{0} enheter av Artikel {1} är vald  i en annan Plocklista."
 msgid "{0} units of {1} are required in {2} with the inventory dimension: {3} ({4}) on {5} {6} for {7} to complete the transaction."
 msgstr "{0} enheter av {1} erfordras i {2} med lagerdimension: {3} ({4}) på {5} {6} för {7} för att slutföra transaktion."
 
-#: erpnext/stock/stock_ledger.py:1532 erpnext/stock/stock_ledger.py:2023
-#: erpnext/stock/stock_ledger.py:2037
+#: erpnext/stock/stock_ledger.py:1541 erpnext/stock/stock_ledger.py:2031
+#: erpnext/stock/stock_ledger.py:2045
 msgid "{0} units of {1} needed in {2} on {3} {4} for {5} to complete this transaction."
 msgstr "{0} enheter av {1} behövs i {2} den {3} {4} för {5} för att slutföra denna transaktion."
 
-#: erpnext/stock/stock_ledger.py:2124 erpnext/stock/stock_ledger.py:2170
+#: erpnext/stock/stock_ledger.py:2132 erpnext/stock/stock_ledger.py:2178
 msgid "{0} units of {1} needed in {2} on {3} {4} to complete this transaction."
 msgstr "{0} enheter av {1} behövs i {2} den {3} {4} för att slutföra denna transaktion."
 
-#: erpnext/stock/stock_ledger.py:1526
+#: erpnext/stock/stock_ledger.py:1535
 msgid "{0} units of {1} needed in {2} to complete this transaction."
 msgstr "{0} enheter av {1} behövs i {2} för att slutföra denna transaktion."
 
@@ -61159,7 +61150,7 @@ msgstr "{0} {1} skapad"
 msgid "{0} {1} does not exist"
 msgstr "{0} {1} finns inte"
 
-#: erpnext/accounts/party.py:560
+#: erpnext/accounts/party.py:566
 msgid "{0} {1} has accounting entries in currency {2} for company {3}. Please select a receivable or payable account with currency {2}."
 msgstr "{0} {1} har bokföring poster i valuta {2} för bolag {3}. Välj Intäkt eller Skuld Konto med valuta {2}."
 
@@ -61193,7 +61184,7 @@ msgstr "{0} {1} är redan länkad till Gemensam kod {2}."
 msgid "{0} {1} is associated with {2}, but Party Account is {3}"
 msgstr "{0} {1} är associerad med {2}, men Parti Konto är {3}"
 
-#: erpnext/controllers/selling_controller.py:462
+#: erpnext/controllers/selling_controller.py:470
 #: erpnext/controllers/subcontracting_controller.py:954
 msgid "{0} {1} is cancelled or closed"
 msgstr "{0} {1} är annullerad eller stängd"
@@ -61210,11 +61201,11 @@ msgstr "{0} {1} är annullerad så åtgärd kan inte slutföras"
 msgid "{0} {1} is closed"
 msgstr "{0} {1} är stängd"
 
-#: erpnext/accounts/party.py:798
+#: erpnext/accounts/party.py:804
 msgid "{0} {1} is disabled"
 msgstr "{0} {1} är inaktiverad"
 
-#: erpnext/accounts/party.py:804
+#: erpnext/accounts/party.py:810
 msgid "{0} {1} is frozen"
 msgstr "{0} {1} är låst"
 
@@ -61222,7 +61213,7 @@ msgstr "{0} {1} är låst"
 msgid "{0} {1} is fully billed"
 msgstr "{0} {1} är fullt fakturerad"
 
-#: erpnext/accounts/party.py:808
+#: erpnext/accounts/party.py:814
 msgid "{0} {1} is not active"
 msgstr "{0} {1} är inte aktiv"
 
@@ -61348,15 +61339,15 @@ msgstr "{0}: {1} finns inte"
 msgid "{0}: {1} must be less than {2}"
 msgstr "{0}: {1} måste vara mindre än {2}"
 
-#: erpnext/controllers/buying_controller.py:840
+#: erpnext/controllers/buying_controller.py:848
 msgid "{count} Assets created for {item_code}"
 msgstr "{count} Tillgångar skapade för {item_code}"
 
-#: erpnext/controllers/buying_controller.py:738
+#: erpnext/controllers/buying_controller.py:746
 msgid "{doctype} {name} is cancelled or closed."
 msgstr "{doctype} {name} är annullerad eller stängd."
 
-#: erpnext/controllers/buying_controller.py:459
+#: erpnext/controllers/buying_controller.py:467
 msgid "{field_label} is mandatory for sub-contracted {doctype}."
 msgstr "{field_label} erfordras för underleverantör {doctype}."
 
@@ -61364,7 +61355,7 @@ msgstr "{field_label} erfordras för underleverantör {doctype}."
 msgid "{item_name}'s Sample Size ({sample_size}) cannot be greater than the Accepted Quantity ({accepted_quantity})"
 msgstr "{item_name} Prov Kvantitet ({sample_size}) kan inte vara högre än accepterad kvantitete ({accepted_quantity})"
 
-#: erpnext/controllers/buying_controller.py:563
+#: erpnext/controllers/buying_controller.py:571
 msgid "{ref_doctype} {ref_name} is {status}."
 msgstr "{ref_doctype} {ref_name} är {status}."
 
@@ -61430,7 +61421,7 @@ msgstr "{} Att Fakturera"
 msgid "{} can't be cancelled since the Loyalty Points earned has been redeemed. First cancel the {} No {}"
 msgstr "{} kan inte annulleras eftersom intjänade Lojalitet Poäng har lösts in. Först annullera {} Nummer {}"
 
-#: erpnext/controllers/buying_controller.py:222
+#: erpnext/controllers/buying_controller.py:230
 msgid "{} has submitted assets linked to it. You need to cancel the assets to create purchase return."
 msgstr "{} har befintliga tillgångar kopplade till den. Annullera tillgångar att skapa Inköp Retur."
 

--- a/erpnext/locale/th.po
+++ b/erpnext/locale/th.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: frappe\n"
 "Report-Msgid-Bugs-To: hello@frappe.io\n"
-"POT-Creation-Date: 2025-05-25 09:35+0000\n"
-"PO-Revision-Date: 2025-05-25 20:35\n"
+"POT-Creation-Date: 2025-06-01 09:36+0000\n"
+"PO-Revision-Date: 2025-06-01 21:35\n"
 "Last-Translator: hello@frappe.io\n"
 "Language-Team: Thai\n"
 "MIME-Version: 1.0\n"
@@ -83,15 +83,15 @@ msgstr " ส่วนประกอบย่อย"
 msgid " Summary"
 msgstr " สรุป"
 
-#: erpnext/stock/doctype/item/item.py:235
+#: erpnext/stock/doctype/item/item.py:238
 msgid "\"Customer Provided Item\" cannot be Purchase Item also"
 msgstr "\"สินค้าที่ลูกค้าจัดเตรียมให้\" ไม่สามารถเป็นสินค้าที่ซื้อได้เช่นกัน"
 
-#: erpnext/stock/doctype/item/item.py:237
+#: erpnext/stock/doctype/item/item.py:240
 msgid "\"Customer Provided Item\" cannot have Valuation Rate"
 msgstr "\"รายการที่ลูกค้าจัดเตรียมไว้\" ไม่สามารถมีอัตราการประเมินค่าได้"
 
-#: erpnext/stock/doctype/item/item.py:313
+#: erpnext/stock/doctype/item/item.py:316
 msgid "\"Is Fixed Asset\" cannot be unchecked, as Asset record exists against the item"
 msgstr "ไม่สามารถยกเลิกการเลือก \"เป็นสินทรัพย์ถาวร\" ได้ เนื่องจากมีบันทึกสินทรัพย์อยู่ในรายการ"
 
@@ -213,7 +213,7 @@ msgstr "% ของวัสดุที่ถูกเรียกเก็บ�
 msgid "% of materials delivered against this Sales Order"
 msgstr "% ของวัสดุที่ถูกเรียกเก็บเงินตามใบสั่งขายนี้"
 
-#: erpnext/controllers/accounts_controller.py:2197
+#: erpnext/controllers/accounts_controller.py:2200
 msgid "'Account' in the Accounting section of Customer {0}"
 msgstr ""
 
@@ -225,15 +225,11 @@ msgstr "'ยอมให้มีใบสั่งซื้อหลายใ�
 msgid "'Based On' and 'Group By' can not be same"
 msgstr "'Based On' กับ 'Group By' ไม่ต้องเหมือนกัน"
 
-#: erpnext/stock/report/product_bundle_balance/product_bundle_balance.py:233
-msgid "'Date' is required"
-msgstr "กรุณากรอกวันที่"
-
 #: erpnext/selling/report/inactive_customers/inactive_customers.py:18
 msgid "'Days Since Last Order' must be greater than or equal to zero"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2202
+#: erpnext/controllers/accounts_controller.py:2205
 msgid "'Default {0} Account' in Company {1}"
 msgstr ""
 
@@ -243,7 +239,7 @@ msgstr ""
 
 #: erpnext/stock/report/batch_item_expiry_status/batch_item_expiry_status.py:24
 #: erpnext/stock/report/batch_wise_balance_history/batch_wise_balance_history.py:120
-#: erpnext/stock/report/stock_analytics/stock_analytics.py:314
+#: erpnext/stock/report/stock_analytics/stock_analytics.py:313
 msgid "'From Date' is required"
 msgstr "กรุณากรอก 'ตั้งแต่วันที่'"
 
@@ -251,7 +247,7 @@ msgstr "กรุณากรอก 'ตั้งแต่วันที่'"
 msgid "'From Date' must be after 'To Date'"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:398
+#: erpnext/stock/doctype/item/item.py:401
 msgid "'Has Serial No' can not be 'Yes' for non-stock item"
 msgstr ""
 
@@ -1075,7 +1071,7 @@ msgstr ""
 
 #. Label of the qty (Float) field in DocType 'Purchase Receipt Item'
 #. Label of the qty (Float) field in DocType 'Subcontracting Receipt Item'
-#: erpnext/public/js/controllers/transaction.js:2362
+#: erpnext/public/js/controllers/transaction.js:2388
 #: erpnext/stock/doctype/purchase_receipt_item/purchase_receipt_item.json
 #: erpnext/subcontracting/doctype/subcontracting_receipt_item/subcontracting_receipt_item.json
 msgid "Accepted Quantity"
@@ -1273,7 +1269,7 @@ msgid "Account Manager"
 msgstr ""
 
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:949
-#: erpnext/controllers/accounts_controller.py:2206
+#: erpnext/controllers/accounts_controller.py:2209
 msgid "Account Missing"
 msgstr ""
 
@@ -1448,7 +1444,7 @@ msgstr ""
 msgid "Account {0} is frozen"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1288
+#: erpnext/controllers/accounts_controller.py:1291
 msgid "Account {0} is invalid. Account Currency must be {1}"
 msgstr ""
 
@@ -1484,7 +1480,7 @@ msgstr ""
 msgid "Account: {0} is not permitted under Payment Entry"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3037
+#: erpnext/controllers/accounts_controller.py:3040
 msgid "Account: {0} with currency: {1} can not be selected"
 msgstr ""
 
@@ -1757,7 +1753,7 @@ msgstr ""
 msgid "Accounting Entry for Asset"
 msgstr ""
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:796
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:805
 msgid "Accounting Entry for Service"
 msgstr ""
 
@@ -1772,18 +1768,18 @@ msgstr ""
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py:1468
 #: erpnext/controllers/stock_controller.py:550
 #: erpnext/controllers/stock_controller.py:567
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:889
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:898
 #: erpnext/stock/doctype/stock_entry/stock_entry.py:1586
 #: erpnext/stock/doctype/stock_entry/stock_entry.py:1600
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py:561
 msgid "Accounting Entry for Stock"
 msgstr ""
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:717
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:726
 msgid "Accounting Entry for {0}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2247
+#: erpnext/controllers/accounts_controller.py:2250
 msgid "Accounting Entry for {0}: {1} can only be made in currency: {2}"
 msgstr ""
 
@@ -2176,7 +2172,7 @@ msgstr ""
 msgid "Accumulated Monthly"
 msgstr ""
 
-#: erpnext/controllers/budget_controller.py:417
+#: erpnext/controllers/budget_controller.py:422
 msgid "Accumulated Monthly Budget for Account {0} against {1} {2} is {3}. It will be collectively ({4}) exceeded by {5}"
 msgstr ""
 
@@ -3290,7 +3286,7 @@ msgstr ""
 msgid "Adjustment Against"
 msgstr ""
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:634
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:643
 msgid "Adjustment based on Purchase Invoice rate"
 msgstr ""
 
@@ -3401,7 +3397,7 @@ msgstr ""
 msgid "Advance amount"
 msgstr ""
 
-#: erpnext/controllers/taxes_and_totals.py:845
+#: erpnext/controllers/taxes_and_totals.py:855
 msgid "Advance amount cannot be greater than {0} {1}"
 msgstr ""
 
@@ -3612,7 +3608,7 @@ msgstr ""
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:152
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:133
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1125
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1127
 msgid "Age (Days)"
 msgstr ""
 
@@ -3697,16 +3693,6 @@ msgstr ""
 
 #: erpnext/setup/setup_wizard/data/industry_type.txt:4
 msgid "Agriculture"
-msgstr ""
-
-#. Name of a role
-#: erpnext/assets/doctype/location/location.json
-msgid "Agriculture Manager"
-msgstr ""
-
-#. Name of a role
-#: erpnext/assets/doctype/location/location.json
-msgid "Agriculture User"
 msgstr ""
 
 #: erpnext/setup/setup_wizard/data/industry_type.txt:5
@@ -3899,7 +3885,7 @@ msgstr ""
 msgid "All items are already requested"
 msgstr ""
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:1317
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:1326
 msgid "All items have already been Invoiced/Returned"
 msgstr ""
 
@@ -3911,7 +3897,7 @@ msgstr ""
 msgid "All items have already been transferred for this Work Order."
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2465
+#: erpnext/public/js/controllers/transaction.js:2491
 msgid "All items in this document already have a linked Quality Inspection."
 msgstr ""
 
@@ -4109,7 +4095,7 @@ msgstr ""
 msgid "Allow Item To Be Added Multiple Times in a Transaction"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:755
+#: erpnext/controllers/selling_controller.py:763
 msgid "Allow Item to Be Added Multiple Times in a Transaction"
 msgstr ""
 
@@ -5055,7 +5041,7 @@ msgstr ""
 msgid "Annual Billing: {0}"
 msgstr ""
 
-#: erpnext/controllers/budget_controller.py:441
+#: erpnext/controllers/budget_controller.py:446
 msgid "Annual Budget for Account {0} against {1} {2} is {3}. It will be collectively ({4}) exceeded by {5}"
 msgstr ""
 
@@ -5544,7 +5530,7 @@ msgstr ""
 msgid "As the field {0} is enabled, the value of the field {1} should be more than 1."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:989
+#: erpnext/stock/doctype/item/item.py:983
 msgid "As there are existing submitted transactions against item {0}, you can not change the value of {1}."
 msgstr ""
 
@@ -5690,7 +5676,7 @@ msgstr ""
 msgid "Asset Category Name"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:304
+#: erpnext/stock/doctype/item/item.py:307
 msgid "Asset Category is mandatory for Fixed Asset item"
 msgstr ""
 
@@ -6065,7 +6051,7 @@ msgstr ""
 msgid "Asset {0} must be submitted"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:851
+#: erpnext/controllers/buying_controller.py:859
 msgid "Asset {assets_link} created for {item_code}"
 msgstr ""
 
@@ -6095,11 +6081,11 @@ msgstr ""
 msgid "Assets"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:869
+#: erpnext/controllers/buying_controller.py:877
 msgid "Assets not created for {item_code}. You will have to create asset manually."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:856
+#: erpnext/controllers/buying_controller.py:864
 msgid "Assets {assets_link} created for {item_code}"
 msgstr ""
 
@@ -6194,7 +6180,7 @@ msgstr ""
 msgid "At row #{0}: you have selected the Difference Account {1}, which is a Cost of Goods Sold type account. Please select a different account"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:864
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:865
 msgid "At row {0}: Batch No is mandatory for Item {1}"
 msgstr ""
 
@@ -6202,11 +6188,11 @@ msgstr ""
 msgid "At row {0}: Parent Row No cannot be set for item {1}"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:849
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:850
 msgid "At row {0}: Qty is mandatory for the batch {1}"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:856
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:857
 msgid "At row {0}: Serial No is mandatory for Item {1}"
 msgstr ""
 
@@ -6280,7 +6266,7 @@ msgstr ""
 msgid "Attribute Value"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:930
+#: erpnext/stock/doctype/item/item.py:924
 msgid "Attribute table is mandatory"
 msgstr ""
 
@@ -6288,11 +6274,11 @@ msgstr ""
 msgid "Attribute value: {0} must appear only once"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:934
+#: erpnext/stock/doctype/item/item.py:928
 msgid "Attribute {0} selected multiple times in Attributes Table"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:862
+#: erpnext/stock/doctype/item/item.py:856
 msgid "Attributes"
 msgstr ""
 
@@ -7576,11 +7562,11 @@ msgstr ""
 msgid "Barcode Type"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:457
+#: erpnext/stock/doctype/item/item.py:460
 msgid "Barcode {0} already used in Item {1}"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:472
+#: erpnext/stock/doctype/item/item.py:475
 msgid "Barcode {0} is not a valid {1} code"
 msgstr ""
 
@@ -7834,7 +7820,7 @@ msgstr ""
 #: erpnext/manufacturing/doctype/job_card/job_card.json
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.js:89
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.py:115
-#: erpnext/public/js/controllers/transaction.js:2388
+#: erpnext/public/js/controllers/transaction.js:2414
 #: erpnext/public/js/utils/barcode_scanner.js:260
 #: erpnext/public/js/utils/serial_no_batch_selector.js:438
 #: erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
@@ -7861,11 +7847,11 @@ msgstr ""
 msgid "Batch No"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:867
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:868
 msgid "Batch No is mandatory"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2629
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2630
 msgid "Batch No {0} does not exists"
 msgstr ""
 
@@ -7873,7 +7859,7 @@ msgstr ""
 msgid "Batch No {0} is linked with Item {1} which has serial no. Please scan serial no instead."
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:364
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:365
 msgid "Batch No {0} is not present in the original {1} {2}, hence you can't return it against the {1} {2}"
 msgstr ""
 
@@ -7888,11 +7874,11 @@ msgstr ""
 msgid "Batch Nos"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1421
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1422
 msgid "Batch Nos are created successfully"
 msgstr ""
 
-#: erpnext/controllers/sales_and_purchase_return.py:1096
+#: erpnext/controllers/sales_and_purchase_return.py:1001
 msgid "Batch Not Available for Return"
 msgstr ""
 
@@ -7941,7 +7927,7 @@ msgstr ""
 msgid "Batch {0} and Warehouse"
 msgstr ""
 
-#: erpnext/controllers/sales_and_purchase_return.py:1095
+#: erpnext/controllers/sales_and_purchase_return.py:1000
 msgid "Batch {0} is not available in warehouse {1}"
 msgstr ""
 
@@ -7991,7 +7977,7 @@ msgstr ""
 #. Label of the bill_date (Date) field in DocType 'Journal Entry'
 #. Label of the bill_date (Date) field in DocType 'Subcontracting Receipt'
 #: erpnext/accounts/doctype/journal_entry/journal_entry.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1110
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1112
 #: erpnext/accounts/report/purchase_register/purchase_register.py:214
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.json
 msgid "Bill Date"
@@ -8000,7 +7986,7 @@ msgstr ""
 #. Label of the bill_no (Data) field in DocType 'Journal Entry'
 #. Label of the bill_no (Data) field in DocType 'Subcontracting Receipt'
 #: erpnext/accounts/doctype/journal_entry/journal_entry.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1109
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1111
 #: erpnext/accounts/report/purchase_register/purchase_register.py:213
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.json
 msgid "Bill No"
@@ -8220,7 +8206,7 @@ msgstr ""
 msgid "Billing Zipcode"
 msgstr ""
 
-#: erpnext/accounts/party.py:602
+#: erpnext/accounts/party.py:608
 msgid "Billing currency must be equal to either default company's currency or party account currency"
 msgstr ""
 
@@ -9217,7 +9203,7 @@ msgid "Can only make payment against unbilled {0}"
 msgstr ""
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1458
-#: erpnext/controllers/accounts_controller.py:2946
+#: erpnext/controllers/accounts_controller.py:2949
 #: erpnext/public/js/controllers/accounts.js:90
 msgid "Can refer row only if the charge type is 'On Previous Row Amount' or 'Previous Row Total'"
 msgstr ""
@@ -9379,9 +9365,9 @@ msgstr ""
 msgid "Cannot Create Return"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:625
-#: erpnext/stock/doctype/item/item.py:638
-#: erpnext/stock/doctype/item/item.py:652
+#: erpnext/stock/doctype/item/item.py:631
+#: erpnext/stock/doctype/item/item.py:644
+#: erpnext/stock/doctype/item/item.py:658
 msgid "Cannot Merge"
 msgstr ""
 
@@ -9405,7 +9391,7 @@ msgstr ""
 msgid "Cannot apply TDS against multiple parties in one entry"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:307
+#: erpnext/stock/doctype/item/item.py:310
 msgid "Cannot be a fixed asset item as Stock Ledger is created."
 msgstr ""
 
@@ -9421,7 +9407,7 @@ msgstr ""
 msgid "Cannot cancel the transaction. Reposting of item valuation on submission is not completed yet."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:959
+#: erpnext/controllers/buying_controller.py:967
 msgid "Cannot cancel this document as it is linked with the submitted asset {asset_link}. Please cancel the asset to continue."
 msgstr ""
 
@@ -9429,7 +9415,7 @@ msgstr ""
 msgid "Cannot cancel transaction for Completed Work Order."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:882
+#: erpnext/stock/doctype/item/item.py:876
 msgid "Cannot change Attributes after stock transaction. Make a new Item and transfer stock to the new Item"
 msgstr ""
 
@@ -9445,7 +9431,7 @@ msgstr ""
 msgid "Cannot change Service Stop Date for item in row {0}"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:873
+#: erpnext/stock/doctype/item/item.py:867
 msgid "Cannot change Variant properties after stock transaction. You will have to make a new Item to do this."
 msgstr ""
 
@@ -9473,7 +9459,7 @@ msgstr ""
 msgid "Cannot covert to Group because Account Type is selected."
 msgstr ""
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:972
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:981
 msgid "Cannot create Stock Reservation Entries for future dated Purchase Receipts."
 msgstr ""
 
@@ -9524,7 +9510,7 @@ msgstr ""
 msgid "Cannot find Item with this Barcode"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3483
+#: erpnext/controllers/accounts_controller.py:3486
 msgid "Cannot find a default warehouse for item {0}. Please set one in the Item Master or in Stock Settings."
 msgstr ""
 
@@ -9532,7 +9518,7 @@ msgstr ""
 msgid "Cannot make any transactions until the deletion job is completed"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2074
+#: erpnext/controllers/accounts_controller.py:2077
 msgid "Cannot overbill for Item {0} in row {1} more than {2}. To allow over-billing, please set allowance in Accounts Settings"
 msgstr ""
 
@@ -9553,7 +9539,7 @@ msgid "Cannot receive from customer against negative outstanding"
 msgstr ""
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1475
-#: erpnext/controllers/accounts_controller.py:2961
+#: erpnext/controllers/accounts_controller.py:2964
 #: erpnext/public/js/controllers/accounts.js:100
 msgid "Cannot refer row number greater than or equal to current row number for this Charge type"
 msgstr ""
@@ -9569,7 +9555,7 @@ msgstr ""
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1467
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1646
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:1917
-#: erpnext/controllers/accounts_controller.py:2951
+#: erpnext/controllers/accounts_controller.py:2954
 #: erpnext/public/js/controllers/accounts.js:94
 #: erpnext/public/js/controllers/taxes_and_totals.js:470
 msgid "Cannot select charge type as 'On Previous Row Amount' or 'On Previous Row Total' for first row"
@@ -9583,15 +9569,15 @@ msgstr ""
 msgid "Cannot set authorization on basis of Discount for {0}"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:716
+#: erpnext/stock/doctype/item/item.py:722
 msgid "Cannot set multiple Item Defaults for a company."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3631
+#: erpnext/controllers/accounts_controller.py:3634
 msgid "Cannot set quantity less than delivered quantity"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3634
+#: erpnext/controllers/accounts_controller.py:3637
 msgid "Cannot set quantity less than received quantity"
 msgstr ""
 
@@ -10014,7 +10000,7 @@ msgid "Channel Partner"
 msgstr ""
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:2346
-#: erpnext/controllers/accounts_controller.py:3014
+#: erpnext/controllers/accounts_controller.py:3017
 msgid "Charge of type 'Actual' in row {0} cannot be included in Item Rate or Paid Amount"
 msgstr ""
 
@@ -10197,7 +10183,7 @@ msgstr ""
 
 #. Label of the reference_date (Date) field in DocType 'Payment Entry'
 #: erpnext/accounts/doctype/payment_entry/payment_entry.json
-#: erpnext/public/js/controllers/transaction.js:2299
+#: erpnext/public/js/controllers/transaction.js:2325
 msgid "Cheque/Reference Date"
 msgstr ""
 
@@ -10245,7 +10231,7 @@ msgstr ""
 
 #. Label of the child_row_reference (Data) field in DocType 'Quality
 #. Inspection'
-#: erpnext/public/js/controllers/transaction.js:2394
+#: erpnext/public/js/controllers/transaction.js:2420
 #: erpnext/stock/doctype/quality_inspection/quality_inspection.json
 msgid "Child Row Reference"
 msgstr ""
@@ -10957,7 +10943,7 @@ msgstr ""
 #: erpnext/accounts/report/cheques_and_deposits_incorrectly_cleared/cheques_and_deposits_incorrectly_cleared.js:8
 #: erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.js:8
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:8
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:49
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:50
 #: erpnext/accounts/report/deferred_revenue_and_expense/deferred_revenue_and_expense.js:8
 #: erpnext/accounts/report/delivered_items_to_be_billed/delivered_items_to_be_billed.js:7
 #: erpnext/accounts/report/dimension_wise_accounts_balance_report/dimension_wise_accounts_balance_report.js:8
@@ -12190,7 +12176,7 @@ msgid "Content Type"
 msgstr ""
 
 #: erpnext/erpnext_integrations/doctype/plaid_settings/plaid_settings.js:162
-#: erpnext/public/js/controllers/transaction.js:2312
+#: erpnext/public/js/controllers/transaction.js:2338
 #: erpnext/selling/doctype/quotation/quotation.js:356
 msgid "Continue"
 msgstr ""
@@ -12355,7 +12341,7 @@ msgstr ""
 msgid "Conversion Rate"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:393
+#: erpnext/stock/doctype/item/item.py:396
 msgid "Conversion factor for default Unit of Measure must be 1 in row {0}"
 msgstr ""
 
@@ -12363,15 +12349,15 @@ msgstr ""
 msgid "Conversion factor for item {0} has been reset to 1.0 as the uom {1} is same as stock uom {2}."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2767
+#: erpnext/controllers/accounts_controller.py:2770
 msgid "Conversion rate cannot be 0"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2774
+#: erpnext/controllers/accounts_controller.py:2777
 msgid "Conversion rate is 1.00, but document currency is different from company currency"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2770
+#: erpnext/controllers/accounts_controller.py:2773
 msgid "Conversion rate must be 1.00 if document currency is same as company currency"
 msgstr ""
 
@@ -12584,7 +12570,7 @@ msgstr ""
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:28
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:40
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:30
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1096
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1098
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:40
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.js:42
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.py:197
@@ -12677,7 +12663,7 @@ msgid "Cost Center is a part of Cost Center Allocation, hence cannot be converte
 msgstr ""
 
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py:1411
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:855
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:864
 msgid "Cost Center is required in row {0} in Taxes table for type {1}"
 msgstr ""
 
@@ -12946,8 +12932,8 @@ msgstr ""
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:132
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:143
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:219
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:654
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:678
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:656
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:680
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.js:88
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.js:89
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.js:103
@@ -13004,8 +12990,8 @@ msgstr ""
 #: erpnext/projects/doctype/task/task_tree.js:81
 #: erpnext/public/js/communication.js:19 erpnext/public/js/communication.js:31
 #: erpnext/public/js/communication.js:41
-#: erpnext/public/js/controllers/transaction.js:336
-#: erpnext/public/js/controllers/transaction.js:2435
+#: erpnext/public/js/controllers/transaction.js:362
+#: erpnext/public/js/controllers/transaction.js:2461
 #: erpnext/selling/doctype/customer/customer.js:181
 #: erpnext/selling/doctype/quotation/quotation.js:124
 #: erpnext/selling/doctype/quotation/quotation.js:133
@@ -13300,7 +13286,7 @@ msgstr ""
 msgid "Create a variant with the template image."
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1877
+#: erpnext/stock/stock_ledger.py:1886
 msgid "Create an incoming stock transaction for the Item."
 msgstr ""
 
@@ -13360,7 +13346,7 @@ msgstr ""
 msgid "Creating Purchase Order ..."
 msgstr ""
 
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:735
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:737
 #: erpnext/buying/doctype/purchase_order/purchase_order.js:552
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.js:73
 msgid "Creating Purchase Receipt ..."
@@ -13554,7 +13540,7 @@ msgstr ""
 #: erpnext/accounts/doctype/journal_entry_template/journal_entry_template.json
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:174
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:147
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1119
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1121
 #: erpnext/controllers/sales_and_purchase_return.py:373
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:286
 #: erpnext/stock/doctype/delivery_note/delivery_note.js:89
@@ -13589,7 +13575,7 @@ msgstr ""
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py:368
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py:376
-#: erpnext/controllers/accounts_controller.py:2186
+#: erpnext/controllers/accounts_controller.py:2189
 msgid "Credit To"
 msgstr ""
 
@@ -13774,7 +13760,7 @@ msgstr ""
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/subscription_plan/subscription_plan.json
 #: erpnext/accounts/report/account_balance/account_balance.py:28
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1129
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1131
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:205
 #: erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.py:101
 #: erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.js:118
@@ -14303,7 +14289,7 @@ msgstr ""
 #. Label of the customer_contact_display (Small Text) field in DocType
 #. 'Purchase Order'
 #. Label of the customer_contact (Small Text) field in DocType 'Delivery Stop'
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1090
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1092
 #: erpnext/buying/doctype/purchase_order/purchase_order.json
 #: erpnext/stock/doctype/delivery_stop/delivery_stop.json
 msgid "Customer Contact"
@@ -14399,7 +14385,7 @@ msgstr ""
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/tax_rule/tax_rule.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:107
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1147
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1149
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:81
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:185
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:56
@@ -14443,7 +14429,7 @@ msgstr ""
 msgid "Customer Group Name"
 msgstr ""
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1239
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1241
 msgid "Customer Group: {0} does not exist"
 msgstr ""
 
@@ -14462,7 +14448,7 @@ msgstr ""
 msgid "Customer Items"
 msgstr ""
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1138
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1140
 msgid "Customer LPO"
 msgstr ""
 
@@ -14508,7 +14494,7 @@ msgstr ""
 #: erpnext/accounts/doctype/pos_invoice/pos_invoice.json
 #: erpnext/accounts/doctype/process_statement_of_accounts_customer/process_statement_of_accounts_customer.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1080
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1082
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:156
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:92
 #: erpnext/accounts/report/delivered_items_to_be_billed/delivered_items_to_be_billed.py:35
@@ -15186,7 +15172,7 @@ msgstr ""
 #: erpnext/accounts/doctype/journal_entry_template/journal_entry_template.json
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:176
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:147
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1122
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1124
 #: erpnext/controllers/sales_and_purchase_return.py:377
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:287
 #: erpnext/stock/doctype/purchase_receipt/purchase_receipt.js:61
@@ -15215,7 +15201,7 @@ msgstr ""
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:953
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:964
-#: erpnext/controllers/accounts_controller.py:2186
+#: erpnext/controllers/accounts_controller.py:2189
 msgid "Debit To"
 msgstr ""
 
@@ -15248,11 +15234,11 @@ msgstr ""
 msgid "Debit-Credit mismatch"
 msgstr ""
 
-#: erpnext/accounts/party.py:609
+#: erpnext/accounts/party.py:615
 msgid "Debtor/Creditor"
 msgstr ""
 
-#: erpnext/accounts/party.py:612
+#: erpnext/accounts/party.py:618
 msgid "Debtor/Creditor Advance"
 msgstr ""
 
@@ -15372,7 +15358,7 @@ msgstr ""
 msgid "Default BOM"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:418
+#: erpnext/stock/doctype/item/item.py:421
 msgid "Default BOM ({0}) must be active for this item or its template"
 msgstr ""
 
@@ -15380,7 +15366,7 @@ msgstr ""
 msgid "Default BOM for {0} not found"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3672
+#: erpnext/controllers/accounts_controller.py:3675
 msgid "Default BOM not found for FG Item {0}"
 msgstr ""
 
@@ -15715,15 +15701,15 @@ msgstr ""
 msgid "Default Unit of Measure"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1272
+#: erpnext/stock/doctype/item/item.py:1266
 msgid "Default Unit of Measure for Item {0} cannot be changed directly because you have already made some transaction(s) with another UOM. You need to either cancel the linked documents or create a new Item."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1255
+#: erpnext/stock/doctype/item/item.py:1249
 msgid "Default Unit of Measure for Item {0} cannot be changed directly because you have already made some transaction(s) with another UOM. You will need to create a new Item to use a different Default UOM."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:908
+#: erpnext/stock/doctype/item/item.py:902
 msgid "Default Unit of Measure for Variant '{0}' must be same as in Template '{1}'"
 msgstr ""
 
@@ -16182,7 +16168,7 @@ msgstr ""
 msgid "Delivery Note {0} is not submitted"
 msgstr ""
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1142
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1144
 #: erpnext/stock/doctype/delivery_trip/delivery_trip.js:73
 msgid "Delivery Notes"
 msgstr ""
@@ -16713,7 +16699,7 @@ msgstr ""
 #: erpnext/projects/doctype/task_type/task_type.json
 #: erpnext/projects/doctype/timesheet_detail/timesheet_detail.json
 #: erpnext/public/js/bank_reconciliation_tool/data_table_manager.js:55
-#: erpnext/public/js/controllers/transaction.js:2376
+#: erpnext/public/js/controllers/transaction.js:2402
 #: erpnext/selling/doctype/installation_note_item/installation_note_item.json
 #: erpnext/selling/doctype/product_bundle/product_bundle.json
 #: erpnext/selling/doctype/product_bundle_item/product_bundle_item.json
@@ -16901,7 +16887,7 @@ msgstr ""
 msgid "Difference Account must be a Asset/Liability type account (Temporary Opening), since this Stock Entry is an Opening Entry"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:954
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:950
 msgid "Difference Account must be a Asset/Liability type account, since this Stock Reconciliation is an Opening Entry"
 msgstr ""
 
@@ -17167,11 +17153,11 @@ msgstr ""
 msgid "Disabled Warehouse {0} cannot be used for this transaction."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:745
+#: erpnext/controllers/accounts_controller.py:748
 msgid "Disabled pricing rules since this {} is an internal transfer"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:759
+#: erpnext/controllers/accounts_controller.py:762
 msgid "Disabled tax included prices since this {} is an internal transfer"
 msgstr ""
 
@@ -18113,7 +18099,7 @@ msgstr ""
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.json
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/print_format/sales_invoice_print/sales_invoice_print.html:72
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1106
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1108
 #: erpnext/assets/doctype/asset_maintenance_log/asset_maintenance_log.json
 #: erpnext/selling/report/payment_terms_status_for_sales_order/payment_terms_status_for_sales_order.py:40
 msgid "Due Date"
@@ -18127,11 +18113,11 @@ msgstr ""
 msgid "Due Date Based On"
 msgstr ""
 
-#: erpnext/accounts/party.py:695
+#: erpnext/accounts/party.py:701
 msgid "Due Date cannot be after {0}"
 msgstr ""
 
-#: erpnext/accounts/party.py:671
+#: erpnext/accounts/party.py:677
 msgid "Due Date cannot be before {0}"
 msgstr ""
 
@@ -18849,7 +18835,7 @@ msgstr ""
 msgid "Enable Auto Email"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1064
+#: erpnext/stock/doctype/item/item.py:1058
 msgid "Enable Auto Re-Order"
 msgstr ""
 
@@ -19062,7 +19048,7 @@ msgstr ""
 msgid "End Date"
 msgstr ""
 
-#: erpnext/crm/doctype/contract/contract.py:75
+#: erpnext/crm/doctype/contract/contract.py:83
 msgid "End Date cannot be before Start Date."
 msgstr ""
 
@@ -19312,7 +19298,7 @@ msgstr ""
 #: erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.json
 #: erpnext/manufacturing/doctype/job_card/job_card.py:875
 #: erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.json
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:297
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:298
 msgid "Error"
 msgstr ""
 
@@ -19435,7 +19421,7 @@ msgstr ""
 msgid "Example URL"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:995
+#: erpnext/stock/doctype/item/item.py:989
 msgid "Example of a linked document: {0}"
 msgstr ""
 
@@ -19450,7 +19436,7 @@ msgstr ""
 msgid "Example: ABCD.#####. If series is set and Batch No is not mentioned in transactions, then automatic batch number will be created based on this series. If you always want to explicitly mention Batch No for this item, leave this blank. Note: this setting will take priority over the Naming Series Prefix in Stock Settings."
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:2141
+#: erpnext/stock/stock_ledger.py:2149
 msgid "Example: Serial No {0} reserved in {1}."
 msgstr ""
 
@@ -19504,8 +19490,8 @@ msgstr ""
 msgid "Exchange Gain/Loss"
 msgstr "กำไร/ขาดทุนจากอัตราการแลกเปลี่ยน"
 
-#: erpnext/controllers/accounts_controller.py:1593
-#: erpnext/controllers/accounts_controller.py:1677
+#: erpnext/controllers/accounts_controller.py:1596
+#: erpnext/controllers/accounts_controller.py:1680
 msgid "Exchange Gain/Loss amount has been booked through {0}"
 msgstr ""
 
@@ -20241,7 +20227,7 @@ msgid "Fetching Error"
 msgstr ""
 
 #: erpnext/accounts/doctype/dunning/dunning.js:135
-#: erpnext/public/js/controllers/transaction.js:1251
+#: erpnext/public/js/controllers/transaction.js:1277
 msgid "Fetching exchange rates ..."
 msgstr ""
 
@@ -20536,15 +20522,15 @@ msgstr ""
 msgid "Finished Good Item Quantity"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3658
+#: erpnext/controllers/accounts_controller.py:3661
 msgid "Finished Good Item is not specified for service item {0}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3675
+#: erpnext/controllers/accounts_controller.py:3678
 msgid "Finished Good Item {0} Qty can not be zero"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3669
+#: erpnext/controllers/accounts_controller.py:3672
 msgid "Finished Good Item {0} must be a sub-contracted item"
 msgstr ""
 
@@ -20785,7 +20771,7 @@ msgstr ""
 msgid "Fixed Asset Defaults"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:301
+#: erpnext/stock/doctype/item/item.py:304
 msgid "Fixed Asset Item must be a non-stock item."
 msgstr ""
 
@@ -20961,7 +20947,7 @@ msgstr ""
 msgid "For Raw Materials"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1259
+#: erpnext/controllers/accounts_controller.py:1262
 msgid "For Return Invoices with Stock effect, '0' qty Items are not allowed. Following rows are affected: {0}"
 msgstr ""
 
@@ -21062,7 +21048,7 @@ msgstr ""
 msgid "For the item {0}, the quantity should be {1} according to the BOM {2}."
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:1088
+#: erpnext/public/js/controllers/transaction.js:1114
 msgctxt "Clear payment terms template and/or payment schedule when due date is changed"
 msgid "For the new {0} to take effect, would you like to clear the current {1}?"
 msgstr ""
@@ -21071,7 +21057,7 @@ msgstr ""
 msgid "For the {0}, no stock is available for the return in the warehouse {1}."
 msgstr ""
 
-#: erpnext/controllers/sales_and_purchase_return.py:1144
+#: erpnext/controllers/sales_and_purchase_return.py:1049
 msgid "For the {0}, the quantity is required to make the return entry"
 msgstr ""
 
@@ -21408,7 +21394,7 @@ msgstr ""
 msgid "From Date is mandatory"
 msgstr ""
 
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:52
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:53
 #: erpnext/accounts/report/general_ledger/general_ledger.py:86
 #: erpnext/accounts/report/pos_register/pos_register.py:115
 #: erpnext/accounts/report/tax_withholding_details/tax_withholding_details.py:39
@@ -21785,14 +21771,14 @@ msgstr ""
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:186
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:155
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1134
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1136
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:177
 msgid "Future Payment Amount"
 msgstr ""
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:185
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:154
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1133
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1135
 msgid "Future Payment Ref"
 msgstr ""
 
@@ -22966,7 +22952,7 @@ msgstr ""
 msgid "Here are the error logs for the aforementioned failed depreciation entries: {0}"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1862
+#: erpnext/stock/stock_ledger.py:1871
 msgid "Here are the options to proceed:"
 msgstr ""
 
@@ -23488,7 +23474,7 @@ msgstr ""
 msgid "If more than one package of the same type (for print)"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1872
+#: erpnext/stock/stock_ledger.py:1881
 msgid "If not, you can Cancel / Submit this entry"
 msgstr ""
 
@@ -23513,7 +23499,7 @@ msgstr ""
 msgid "If the account is frozen, entries are allowed to restricted users."
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1865
+#: erpnext/stock/stock_ledger.py:1874
 msgid "If the item is transacting as a Zero Valuation Rate item in this entry, please enable 'Allow Zero Valuation Rate' in the {0} Item table."
 msgstr ""
 
@@ -24511,7 +24497,7 @@ msgstr ""
 msgid "Incorrect Batch Consumed"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:514
+#: erpnext/stock/doctype/item/item.py:517
 msgid "Incorrect Check in (group) Warehouse for Reorder"
 msgstr ""
 
@@ -24560,7 +24546,7 @@ msgstr ""
 msgid "Incorrect Stock Value Report"
 msgstr ""
 
-#: erpnext/stock/serial_batch_bundle.py:134
+#: erpnext/stock/serial_batch_bundle.py:135
 msgid "Incorrect Type of Transaction"
 msgstr ""
 
@@ -24829,8 +24815,8 @@ msgstr ""
 msgid "Insufficient Capacity"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3590
-#: erpnext/controllers/accounts_controller.py:3614
+#: erpnext/controllers/accounts_controller.py:3593
+#: erpnext/controllers/accounts_controller.py:3617
 msgid "Insufficient Permissions"
 msgstr ""
 
@@ -24838,12 +24824,12 @@ msgstr ""
 #: erpnext/stock/doctype/pick_list/pick_list.py:127
 #: erpnext/stock/doctype/pick_list/pick_list.py:975
 #: erpnext/stock/doctype/stock_entry/stock_entry.py:759
-#: erpnext/stock/serial_batch_bundle.py:989 erpnext/stock/stock_ledger.py:1559
-#: erpnext/stock/stock_ledger.py:2032
+#: erpnext/stock/serial_batch_bundle.py:1021 erpnext/stock/stock_ledger.py:1568
+#: erpnext/stock/stock_ledger.py:2040
 msgid "Insufficient Stock"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:2047
+#: erpnext/stock/stock_ledger.py:2055
 msgid "Insufficient Stock for Batch"
 msgstr ""
 
@@ -24981,11 +24967,11 @@ msgstr ""
 msgid "Internal Customer for company {0} already exists"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:728
+#: erpnext/controllers/accounts_controller.py:731
 msgid "Internal Sale or Delivery Reference missing."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:730
+#: erpnext/controllers/accounts_controller.py:733
 msgid "Internal Sales Reference Missing"
 msgstr ""
 
@@ -25016,7 +25002,7 @@ msgstr ""
 msgid "Internal Transfer"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:739
+#: erpnext/controllers/accounts_controller.py:742
 msgid "Internal Transfer Reference Missing"
 msgstr ""
 
@@ -25059,8 +25045,8 @@ msgstr ""
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:969
 #: erpnext/assets/doctype/asset_category/asset_category.py:69
 #: erpnext/assets/doctype/asset_category/asset_category.py:97
-#: erpnext/controllers/accounts_controller.py:2975
-#: erpnext/controllers/accounts_controller.py:2983
+#: erpnext/controllers/accounts_controller.py:2978
+#: erpnext/controllers/accounts_controller.py:2986
 msgid "Invalid Account"
 msgstr ""
 
@@ -25085,7 +25071,7 @@ msgstr ""
 msgid "Invalid Barcode. There is no Item attached to this barcode."
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2631
+#: erpnext/public/js/controllers/transaction.js:2657
 msgid "Invalid Blanket Order for the selected Customer and Item"
 msgstr ""
 
@@ -25099,7 +25085,7 @@ msgstr ""
 
 #: erpnext/assets/doctype/asset/asset.py:295
 #: erpnext/assets/doctype/asset/asset.py:302
-#: erpnext/controllers/accounts_controller.py:2998
+#: erpnext/controllers/accounts_controller.py:3001
 msgid "Invalid Cost Center"
 msgstr ""
 
@@ -25141,7 +25127,7 @@ msgstr ""
 msgid "Invalid Item"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1410
+#: erpnext/stock/doctype/item/item.py:1404
 msgid "Invalid Item Defaults"
 msgstr ""
 
@@ -25187,11 +25173,11 @@ msgstr ""
 msgid "Invalid Purchase Invoice"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3627
+#: erpnext/controllers/accounts_controller.py:3630
 msgid "Invalid Qty"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1277
+#: erpnext/controllers/accounts_controller.py:1280
 msgid "Invalid Quantity"
 msgstr ""
 
@@ -25208,7 +25194,7 @@ msgstr ""
 msgid "Invalid Schedule"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:243
+#: erpnext/controllers/selling_controller.py:251
 msgid "Invalid Selling Price"
 msgstr ""
 
@@ -25241,7 +25227,7 @@ msgstr ""
 msgid "Invalid lost reason {0}, please create a new lost reason"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:408
+#: erpnext/stock/doctype/item/item.py:411
 msgid "Invalid naming series (. missing) for {0}"
 msgstr ""
 
@@ -25281,7 +25267,7 @@ msgstr ""
 #. Name of a DocType
 #: erpnext/patches/v15_0/refactor_closing_stock_balance.py:43
 #: erpnext/stock/doctype/inventory_dimension/inventory_dimension.json
-#: erpnext/stock/doctype/inventory_dimension/inventory_dimension.py:180
+#: erpnext/stock/doctype/inventory_dimension/inventory_dimension.py:181
 msgid "Inventory Dimension"
 msgstr ""
 
@@ -25347,7 +25333,7 @@ msgstr ""
 msgid "Invoice Discounting"
 msgstr ""
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1114
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1116
 msgid "Invoice Grand Total"
 msgstr ""
 
@@ -25440,7 +25426,7 @@ msgstr ""
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:169
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:144
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1116
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1118
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:164
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:165
 msgid "Invoiced Amount"
@@ -25846,6 +25832,11 @@ msgstr ""
 msgid "Is Outward"
 msgstr ""
 
+#. Label of the is_packed (Check) field in DocType 'Serial and Batch Bundle'
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.json
+msgid "Is Packed"
+msgstr ""
+
 #. Label of the is_paid (Check) field in DocType 'Purchase Invoice'
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 msgid "Is Paid"
@@ -26128,11 +26119,11 @@ msgstr ""
 msgid "Issuing cannot be done to a location. Please enter employee to issue the Asset {0} to"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:565
+#: erpnext/stock/doctype/item/item.py:571
 msgid "It can take upto few hours for accurate stock values to be visible after merging items."
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2075
+#: erpnext/public/js/controllers/transaction.js:2101
 msgid "It is needed to fetch Item Details."
 msgstr ""
 
@@ -26182,7 +26173,7 @@ msgstr ""
 #: erpnext/buying/report/supplier_quotation_comparison/supplier_quotation_comparison.js:33
 #: erpnext/buying/report/supplier_quotation_comparison/supplier_quotation_comparison.py:204
 #: erpnext/buying/workspace/buying/buying.json
-#: erpnext/controllers/taxes_and_totals.py:1125
+#: erpnext/controllers/taxes_and_totals.py:1135
 #: erpnext/manufacturing/doctype/blanket_order/blanket_order.json
 #: erpnext/manufacturing/doctype/bom/bom.js:944
 #: erpnext/manufacturing/doctype/bom/bom.json
@@ -26460,7 +26451,7 @@ msgstr ""
 #: erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py:86
 #: erpnext/manufacturing/report/work_order_stock_report/work_order_stock_report.py:119
 #: erpnext/projects/doctype/timesheet/timesheet.js:213
-#: erpnext/public/js/controllers/transaction.js:2350
+#: erpnext/public/js/controllers/transaction.js:2376
 #: erpnext/public/js/stock_reservation.js:112
 #: erpnext/public/js/stock_reservation.js:317 erpnext/public/js/utils.js:500
 #: erpnext/public/js/utils.js:656
@@ -26898,7 +26889,7 @@ msgstr ""
 #: erpnext/manufacturing/report/production_planning_report/production_planning_report.py:359
 #: erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py:92
 #: erpnext/manufacturing/report/work_order_consumed_materials/work_order_consumed_materials.py:138
-#: erpnext/public/js/controllers/transaction.js:2356
+#: erpnext/public/js/controllers/transaction.js:2382
 #: erpnext/public/js/utils.js:746
 #: erpnext/selling/doctype/quotation_item/quotation_item.json
 #: erpnext/selling/doctype/sales_order_item/sales_order_item.json
@@ -27165,7 +27156,7 @@ msgstr ""
 msgid "Item Variant {0} already exists with same attributes"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:781
+#: erpnext/stock/doctype/item/item.py:772
 msgid "Item Variants updated"
 msgstr ""
 
@@ -27231,7 +27222,7 @@ msgstr ""
 msgid "Item for row {0} does not match Material Request"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:795
+#: erpnext/stock/doctype/item/item.py:789
 msgid "Item has variants."
 msgstr ""
 
@@ -27257,7 +27248,7 @@ msgstr ""
 msgid "Item operation"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3650
+#: erpnext/controllers/accounts_controller.py:3653
 msgid "Item qty can not be updated as raw materials are already processed."
 msgstr ""
 
@@ -27283,7 +27274,7 @@ msgstr ""
 msgid "Item valuation reposting in progress. Report might show incorrect item valuation."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:952
+#: erpnext/stock/doctype/item/item.py:946
 msgid "Item variant {0} exists with same attributes"
 msgstr ""
 
@@ -27296,8 +27287,7 @@ msgid "Item {0} cannot be ordered more than {1} against Blanket Order {2}."
 msgstr ""
 
 #: erpnext/assets/doctype/asset/asset.py:277
-#: erpnext/stock/doctype/item/item.py:630
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:167
+#: erpnext/stock/doctype/item/item.py:636
 msgid "Item {0} does not exist"
 msgstr ""
 
@@ -27309,7 +27299,7 @@ msgstr ""
 msgid "Item {0} does not exist."
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:752
+#: erpnext/controllers/selling_controller.py:760
 msgid "Item {0} entered multiple times."
 msgstr ""
 
@@ -27325,7 +27315,7 @@ msgstr ""
 msgid "Item {0} has no Serial No. Only serialized items can have delivery based on Serial No"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1126
+#: erpnext/stock/doctype/item/item.py:1120
 msgid "Item {0} has reached its end of life on {1}"
 msgstr ""
 
@@ -27337,11 +27327,11 @@ msgstr ""
 msgid "Item {0} is already reserved/delivered against Sales Order {1}."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1146
+#: erpnext/stock/doctype/item/item.py:1140
 msgid "Item {0} is cancelled"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1130
+#: erpnext/stock/doctype/item/item.py:1124
 msgid "Item {0} is disabled"
 msgstr ""
 
@@ -27349,7 +27339,7 @@ msgstr ""
 msgid "Item {0} is not a serialized Item"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1138
+#: erpnext/stock/doctype/item/item.py:1132
 msgid "Item {0} is not a stock Item"
 msgstr ""
 
@@ -27393,7 +27383,7 @@ msgstr ""
 msgid "Item {0}: {1} qty produced. "
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1429
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1423
 msgid "Item {} does not exist."
 msgstr ""
 
@@ -27533,7 +27523,7 @@ msgstr ""
 msgid "Items and Pricing"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3872
+#: erpnext/controllers/accounts_controller.py:3875
 msgid "Items cannot be updated as Subcontracting Order is created against the Purchase Order {0}."
 msgstr ""
 
@@ -28029,7 +28019,7 @@ msgstr ""
 
 #. Name of a DocType
 #. Label of a Link in the Stock Workspace
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:674
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:676
 #: erpnext/stock/doctype/landed_cost_voucher/landed_cost_voucher.json
 #: erpnext/stock/doctype/purchase_receipt/purchase_receipt.js:104
 #: erpnext/stock/workspace/stock/stock.json
@@ -28644,7 +28634,7 @@ msgstr ""
 msgid "Linked Location"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:999
+#: erpnext/stock/doctype/item/item.py:993
 msgid "Linked with submitted documents"
 msgstr ""
 
@@ -29383,7 +29373,7 @@ msgstr ""
 #: erpnext/manufacturing/doctype/bom/bom.py:261
 #: erpnext/manufacturing/doctype/bom_update_log/bom_update_log.py:71
 #: erpnext/public/js/controllers/accounts.js:249
-#: erpnext/public/js/controllers/transaction.js:2753
+#: erpnext/public/js/controllers/transaction.js:2779
 #: erpnext/public/js/utils/party.js:321
 #: erpnext/stock/doctype/delivery_note/delivery_note.js:164
 #: erpnext/stock/doctype/inventory_dimension/inventory_dimension.json
@@ -30239,7 +30229,7 @@ msgstr ""
 msgid "Maximum Value"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:212
+#: erpnext/controllers/selling_controller.py:220
 msgid "Maximum discount for Item {0} is {1}%"
 msgstr ""
 
@@ -30309,7 +30299,7 @@ msgstr ""
 msgid "Megawatt"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1878
+#: erpnext/stock/stock_ledger.py:1887
 msgid "Mention Valuation Rate in the Item master."
 msgstr ""
 
@@ -30704,11 +30694,11 @@ msgstr ""
 msgid "Miscellaneous Expenses"
 msgstr "ค่าใช้จ่ายเบ็ดเตล็ด"
 
-#: erpnext/controllers/buying_controller.py:540
+#: erpnext/controllers/buying_controller.py:548
 msgid "Mismatch"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1430
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1424
 msgid "Missing"
 msgstr ""
 
@@ -31235,7 +31225,7 @@ msgstr ""
 msgid "Multiple Warehouse Accounts"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1129
+#: erpnext/controllers/accounts_controller.py:1132
 msgid "Multiple fiscal years exist for the date {0}. Please set company in Fiscal Year"
 msgstr ""
 
@@ -31386,7 +31376,7 @@ msgstr ""
 msgid "Naming Series and Price Defaults"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:90
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:91
 msgid "Naming Series is mandatory"
 msgstr ""
 
@@ -31425,15 +31415,15 @@ msgstr ""
 msgid "Needs Analysis"
 msgstr ""
 
-#: erpnext/stock/serial_batch_bundle.py:1277
+#: erpnext/stock/serial_batch_bundle.py:1309
 msgid "Negative Batch Quantity"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:610
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:606
 msgid "Negative Quantity is not allowed"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:615
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:611
 msgid "Negative Valuation Rate is not allowed"
 msgstr ""
 
@@ -31715,7 +31705,7 @@ msgstr ""
 msgid "Net Weight UOM"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1483
+#: erpnext/controllers/accounts_controller.py:1486
 msgid "Net total calculation precision loss"
 msgstr ""
 
@@ -32058,7 +32048,7 @@ msgstr ""
 #: erpnext/accounts/doctype/journal_entry/journal_entry.py:1539
 #: erpnext/accounts/doctype/journal_entry/journal_entry.py:1599
 #: erpnext/accounts/doctype/journal_entry/journal_entry.py:1613
-#: erpnext/stock/doctype/item/item.py:1371
+#: erpnext/stock/doctype/item/item.py:1365
 msgid "No Permission"
 msgstr ""
 
@@ -32080,7 +32070,7 @@ msgstr ""
 msgid "No Selection"
 msgstr ""
 
-#: erpnext/controllers/sales_and_purchase_return.py:919
+#: erpnext/controllers/sales_and_purchase_return.py:824
 msgid "No Serial / Batches are available for return"
 msgstr ""
 
@@ -32116,7 +32106,7 @@ msgstr ""
 msgid "No Work Orders were created"
 msgstr ""
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:785
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:794
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py:689
 msgid "No accounting entries for the following warehouses"
 msgstr ""
@@ -32305,7 +32295,7 @@ msgstr ""
 msgid "No reserved stock to unreserve."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:773
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:769
 msgid "No stock ledger entries were created. Please set the quantity or valuation rate for the items properly and try again."
 msgstr ""
 
@@ -32389,7 +32379,7 @@ msgstr ""
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:566
 #: erpnext/assets/doctype/asset/asset.js:612
 #: erpnext/assets/doctype/asset/asset.js:627
-#: erpnext/controllers/buying_controller.py:225
+#: erpnext/controllers/buying_controller.py:233
 #: erpnext/selling/doctype/product_bundle/product_bundle.py:72
 #: erpnext/setup/doctype/transaction_deletion_record/transaction_deletion_record.py:80
 msgid "Not Allowed"
@@ -32510,10 +32500,10 @@ msgstr ""
 #: erpnext/selling/doctype/customer/customer.py:129
 #: erpnext/selling/doctype/sales_order/sales_order.js:1168
 #: erpnext/stock/doctype/item/item.js:526
-#: erpnext/stock/doctype/item/item.py:567
+#: erpnext/stock/doctype/item/item.py:573
 #: erpnext/stock/doctype/item_price/item_price.json
 #: erpnext/stock/doctype/stock_entry/stock_entry.py:1374
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:972
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:968
 #: erpnext/templates/pages/timelog_info.html:43
 msgid "Note"
 msgstr ""
@@ -32522,7 +32512,7 @@ msgstr ""
 msgid "Note: Automatic log deletion only applies to logs of type <i>Update Cost</i>"
 msgstr ""
 
-#: erpnext/accounts/party.py:690
+#: erpnext/accounts/party.py:696
 msgid "Note: Due Date exceeds allowed {0} credit days by {1} day(s)"
 msgstr ""
 
@@ -32548,7 +32538,7 @@ msgstr ""
 msgid "Note: This Cost Center is a Group. Cannot make accounting entries against groups."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:621
+#: erpnext/stock/doctype/item/item.py:627
 msgid "Note: To merge the items, create a separate Stock Reconciliation for the old item {0}"
 msgstr ""
 
@@ -33311,7 +33301,7 @@ msgstr ""
 
 #. Label of the opening_stock (Float) field in DocType 'Item'
 #. Option for the 'Purpose' (Select) field in DocType 'Stock Reconciliation'
-#: erpnext/stock/doctype/item/item.json erpnext/stock/doctype/item/item.py:296
+#: erpnext/stock/doctype/item/item.json erpnext/stock/doctype/item/item.py:299
 #: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.json
 msgid "Opening Stock"
 msgstr ""
@@ -34031,7 +34021,7 @@ msgstr ""
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:149
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1123
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1125
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:167
 #: erpnext/accounts/report/purchase_register/purchase_register.py:289
 #: erpnext/accounts/report/sales_register/sales_register.py:319
@@ -34070,7 +34060,7 @@ msgstr ""
 msgid "Over Billing Allowance (%)"
 msgstr ""
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:1242
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:1251
 msgid "Over Billing Allowance exceeded for Purchase Receipt Item {0} ({1}) by {2}%"
 msgstr ""
 
@@ -34111,7 +34101,7 @@ msgstr ""
 msgid "Overbilling of {0} {1} ignored for item {2} because you have {3} role."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2013
+#: erpnext/controllers/accounts_controller.py:2016
 msgid "Overbilling of {} ignored because you have {} role."
 msgstr ""
 
@@ -34618,7 +34608,7 @@ msgstr ""
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:146
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1117
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1119
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:165
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:172
 #: erpnext/accounts/report/pos_register/pos_register.py:209
@@ -34851,7 +34841,7 @@ msgstr ""
 msgid "Parent Row No"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom_creator/bom_creator.py:495
+#: erpnext/manufacturing/doctype/bom_creator/bom_creator.py:496
 msgid "Parent Row No not found for {0}"
 msgstr ""
 
@@ -35080,7 +35070,7 @@ msgstr ""
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:142
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:159
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:57
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1054
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1056
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:67
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:147
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:228
@@ -35106,7 +35096,7 @@ msgstr ""
 
 #. Name of a DocType
 #: erpnext/accounts/doctype/party_account/party_account.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1065
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1067
 msgid "Party Account"
 msgstr ""
 
@@ -35133,7 +35123,7 @@ msgstr ""
 msgid "Party Account No. (Bank Statement)"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2278
+#: erpnext/controllers/accounts_controller.py:2281
 msgid "Party Account {0} currency ({1}) and document currency ({2}) should be same"
 msgstr ""
 
@@ -35149,6 +35139,11 @@ msgstr ""
 #: erpnext/accounts/doctype/bank_account/bank_account.json
 #: erpnext/accounts/doctype/payment_request/payment_request.json
 msgid "Party Details"
+msgstr ""
+
+#. Label of the party_full_name (Data) field in DocType 'Contract'
+#: erpnext/crm/doctype/contract/contract.json
+msgid "Party Full Name"
 msgstr ""
 
 #. Label of the bank_party_iban (Data) field in DocType 'Bank Transaction'
@@ -35234,7 +35229,7 @@ msgstr ""
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:84
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:54
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:44
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1048
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1050
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:54
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:141
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:219
@@ -35256,7 +35251,7 @@ msgstr ""
 msgid "Party Type"
 msgstr ""
 
-#: erpnext/accounts/party.py:819
+#: erpnext/accounts/party.py:825
 msgid "Party Type and Party can only be set for Receivable / Payable account<br><br>{0}"
 msgstr ""
 
@@ -35378,7 +35373,7 @@ msgid "Payable"
 msgstr ""
 
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:42
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1063
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1065
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:211
 #: erpnext/accounts/report/purchase_register/purchase_register.py:194
 #: erpnext/accounts/report/purchase_register/purchase_register.py:235
@@ -35544,7 +35539,7 @@ msgstr ""
 msgid "Payment Entry is already created"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1434
+#: erpnext/controllers/accounts_controller.py:1437
 msgid "Payment Entry {0} is linked against Order {1}, check if it should be pulled as advance in this invoice."
 msgstr ""
 
@@ -35826,7 +35821,7 @@ msgstr ""
 #: erpnext/accounts/doctype/payment_schedule/payment_schedule.json
 #: erpnext/accounts/doctype/payment_term/payment_term.json
 #: erpnext/accounts/doctype/payment_terms_template_detail/payment_terms_template_detail.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1113
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1115
 #: erpnext/accounts/report/gross_profit/gross_profit.py:412
 #: erpnext/accounts/workspace/accounting/accounting.json
 #: erpnext/selling/report/payment_terms_status_for_sales_order/payment_terms_status_for_sales_order.py:30
@@ -36890,7 +36885,7 @@ msgstr ""
 msgid "Please create a new Accounting Dimension if required."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:729
+#: erpnext/controllers/accounts_controller.py:732
 msgid "Please create purchase from internal sale or delivery document itself"
 msgstr ""
 
@@ -36898,7 +36893,7 @@ msgstr ""
 msgid "Please create purchase receipt or purchase invoice for the item {0}"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:649
+#: erpnext/stock/doctype/item/item.py:655
 msgid "Please delete Product Bundle {0}, before merging {1} into {2}"
 msgstr ""
 
@@ -36940,7 +36935,7 @@ msgstr ""
 msgid "Please enable {0} in the {1}."
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:754
+#: erpnext/controllers/selling_controller.py:762
 msgid "Please enable {} in {} to allow same item in multiple rows"
 msgstr ""
 
@@ -36973,7 +36968,7 @@ msgstr ""
 msgid "Please enter Approving Role or Approving User"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:939
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:935
 msgid "Please enter Cost Center"
 msgstr ""
 
@@ -36985,7 +36980,7 @@ msgstr ""
 msgid "Please enter Employee Id of this sales person"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:948
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:944
 msgid "Please enter Expense Account"
 msgstr ""
 
@@ -36994,7 +36989,7 @@ msgstr ""
 msgid "Please enter Item Code to get Batch Number"
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2503
+#: erpnext/public/js/controllers/transaction.js:2529
 msgid "Please enter Item Code to get batch no"
 msgstr ""
 
@@ -37059,7 +37054,7 @@ msgstr ""
 msgid "Please enter company name first"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2764
+#: erpnext/controllers/accounts_controller.py:2767
 msgid "Please enter default currency in Company Master"
 msgstr ""
 
@@ -37095,7 +37090,7 @@ msgstr ""
 msgid "Please enter the phone number first"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:1007
+#: erpnext/controllers/buying_controller.py:1015
 msgid "Please enter the {schedule_date}."
 msgstr ""
 
@@ -37197,7 +37192,7 @@ msgstr ""
 msgid "Please select <b>Template Type</b> to download template"
 msgstr "กรุณาเลือก <b>ประเภทเทมเพลต</b> เพื่อดาวน์โหลดเทมเพลต"
 
-#: erpnext/controllers/taxes_and_totals.py:721
+#: erpnext/controllers/taxes_and_totals.py:731
 #: erpnext/public/js/controllers/taxes_and_totals.js:721
 msgid "Please select Apply Discount On"
 msgstr ""
@@ -37210,7 +37205,7 @@ msgstr ""
 msgid "Please select BOM for Item in Row {0}"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:467
+#: erpnext/controllers/buying_controller.py:475
 msgid "Please select BOM in BOM field for Item {item_code}."
 msgstr ""
 
@@ -37292,7 +37287,7 @@ msgstr ""
 msgid "Please select Qty against item {0}"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:320
+#: erpnext/stock/doctype/item/item.py:323
 msgid "Please select Sample Retention Warehouse in Stock Settings first"
 msgstr ""
 
@@ -37308,7 +37303,7 @@ msgstr ""
 msgid "Please select Subcontracting Order instead of Purchase Order {0}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2613
+#: erpnext/controllers/accounts_controller.py:2616
 msgid "Please select Unrealized Profit / Loss account or add default Unrealized Profit / Loss account account for company {0}"
 msgstr ""
 
@@ -37324,7 +37319,7 @@ msgstr ""
 #: erpnext/manufacturing/doctype/bom/bom.js:603
 #: erpnext/manufacturing/doctype/bom/bom.py:261
 #: erpnext/public/js/controllers/accounts.js:249
-#: erpnext/public/js/controllers/transaction.js:2753
+#: erpnext/public/js/controllers/transaction.js:2779
 msgid "Please select a Company first."
 msgstr ""
 
@@ -37482,7 +37477,7 @@ msgstr ""
 msgid "Please select {0} first"
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:77
+#: erpnext/public/js/controllers/transaction.js:100
 msgid "Please set 'Apply Additional Discount On'"
 msgstr ""
 
@@ -37667,7 +37662,7 @@ msgstr ""
 msgid "Please set filters"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2194
+#: erpnext/controllers/accounts_controller.py:2197
 msgid "Please set one of the following:"
 msgstr ""
 
@@ -37675,7 +37670,7 @@ msgstr ""
 msgid "Please set opening number of booked depreciations"
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2205
+#: erpnext/public/js/controllers/transaction.js:2231
 msgid "Please set recurring after saving"
 msgstr ""
 
@@ -37746,7 +37741,7 @@ msgstr ""
 msgid "Please share this email with your support team so that they can find and fix the issue."
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2073
+#: erpnext/public/js/controllers/transaction.js:2099
 msgid "Please specify"
 msgstr ""
 
@@ -37761,7 +37756,7 @@ msgid "Please specify Company to proceed"
 msgstr ""
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1472
-#: erpnext/controllers/accounts_controller.py:2957
+#: erpnext/controllers/accounts_controller.py:2960
 #: erpnext/public/js/controllers/accounts.js:97
 msgid "Please specify a valid Row ID for row {0} in table {1}"
 msgstr ""
@@ -37774,7 +37769,7 @@ msgstr ""
 msgid "Please specify at least one attribute in the Attributes table"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:605
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:601
 msgid "Please specify either Quantity or Valuation Rate or both"
 msgstr ""
 
@@ -37955,7 +37950,7 @@ msgstr "ค่าส่งไปรษณีย์"
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:16
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:15
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:18
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1046
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1048
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:15
 #: erpnext/accounts/report/bank_clearance_summary/bank_clearance_summary.py:35
 #: erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.html:7
@@ -40136,7 +40131,7 @@ msgstr ""
 #: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.js:48
 #: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:203
 #: erpnext/buying/workspace/buying/buying.json
-#: erpnext/controllers/buying_controller.py:739
+#: erpnext/controllers/buying_controller.py:747
 #: erpnext/crm/doctype/contract/contract.json
 #: erpnext/manufacturing/doctype/blanket_order/blanket_order.js:54
 #: erpnext/manufacturing/doctype/production_plan_sub_assembly_item/production_plan_sub_assembly_item.json
@@ -40275,7 +40270,7 @@ msgstr ""
 msgid "Purchase Orders to Receive"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1833
+#: erpnext/controllers/accounts_controller.py:1836
 msgid "Purchase Orders {0} are un-linked"
 msgstr ""
 
@@ -40299,8 +40294,8 @@ msgstr ""
 #. Label of a Link in the Stock Workspace
 #. Label of a shortcut in the Stock Workspace
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:171
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:650
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:660
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:652
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:662
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice_list.js:49
 #: erpnext/accounts/doctype/purchase_invoice_item/purchase_invoice_item.json
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:246
@@ -41035,7 +41030,7 @@ msgstr ""
 msgid "Quality Inspection Template Name"
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:334
+#: erpnext/public/js/controllers/transaction.js:360
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:165
 msgid "Quality Inspection(s)"
 msgstr ""
@@ -42219,7 +42214,7 @@ msgid "Receivable / Payable Account"
 msgstr ""
 
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:71
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1061
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1063
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py:243
 #: erpnext/accounts/report/sales_register/sales_register.py:217
 #: erpnext/accounts/report/sales_register/sales_register.py:271
@@ -42701,7 +42696,7 @@ msgstr ""
 msgid "Reference Date"
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2311
+#: erpnext/public/js/controllers/transaction.js:2337
 msgid "Reference Date for Early Payment Discount"
 msgstr ""
 
@@ -43025,7 +43020,7 @@ msgstr ""
 msgid "Rejected"
 msgstr ""
 
-#: erpnext/stock/doctype/inventory_dimension/inventory_dimension.py:202
+#: erpnext/stock/doctype/inventory_dimension/inventory_dimension.py:203
 msgid "Rejected "
 msgstr ""
 
@@ -43129,7 +43124,7 @@ msgstr ""
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:187
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:156
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1135
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1137
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:178
 msgid "Remaining Balance"
 msgstr ""
@@ -43182,7 +43177,7 @@ msgstr ""
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:159
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:198
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:269
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1167
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1169
 #: erpnext/accounts/report/general_ledger/general_ledger.html:84
 #: erpnext/accounts/report/general_ledger/general_ledger.html:110
 #: erpnext/accounts/report/general_ledger/general_ledger.py:742
@@ -43931,7 +43926,7 @@ msgstr ""
 msgid "Reserved Quantity for Production"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:2147
+#: erpnext/stock/stock_ledger.py:2155
 msgid "Reserved Serial No."
 msgstr ""
 
@@ -43947,11 +43942,11 @@ msgstr ""
 #: erpnext/stock/doctype/pick_list/pick_list.js:153
 #: erpnext/stock/report/reserved_stock/reserved_stock.json
 #: erpnext/stock/report/stock_balance/stock_balance.py:499
-#: erpnext/stock/stock_ledger.py:2131
+#: erpnext/stock/stock_ledger.py:2139
 msgid "Reserved Stock"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:2177
+#: erpnext/stock/stock_ledger.py:2185
 msgid "Reserved Stock for Batch"
 msgstr ""
 
@@ -43963,7 +43958,7 @@ msgstr ""
 msgid "Reserved Stock for Sub-assembly"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:476
+#: erpnext/controllers/buying_controller.py:484
 msgid "Reserved Warehouse is mandatory for the Item {item_code} in Raw Materials supplied."
 msgstr ""
 
@@ -44777,7 +44772,7 @@ msgstr ""
 msgid "Routing Name"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:667
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:663
 msgid "Row #"
 msgstr ""
 
@@ -44815,7 +44810,7 @@ msgstr ""
 msgid "Row #{0} (Payment Table): Amount must be positive"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:495
+#: erpnext/stock/doctype/item/item.py:498
 msgid "Row #{0}: A reorder entry already exists for warehouse {1} with reorder type {2}."
 msgstr ""
 
@@ -44836,7 +44831,7 @@ msgstr ""
 msgid "Row #{0}: Accepted Warehouse is mandatory for the accepted Item {1}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1117
+#: erpnext/controllers/accounts_controller.py:1120
 msgid "Row #{0}: Account {1} does not belong to company {2}"
 msgstr ""
 
@@ -44877,27 +44872,27 @@ msgstr ""
 msgid "Row #{0}: Cannot allocate more than {1} against payment term {2}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3524
+#: erpnext/controllers/accounts_controller.py:3527
 msgid "Row #{0}: Cannot delete item {1} which has already been billed."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3498
+#: erpnext/controllers/accounts_controller.py:3501
 msgid "Row #{0}: Cannot delete item {1} which has already been delivered"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3517
+#: erpnext/controllers/accounts_controller.py:3520
 msgid "Row #{0}: Cannot delete item {1} which has already been received"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3504
+#: erpnext/controllers/accounts_controller.py:3507
 msgid "Row #{0}: Cannot delete item {1} which has work order assigned to it."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3510
+#: erpnext/controllers/accounts_controller.py:3513
 msgid "Row #{0}: Cannot delete item {1} which is assigned to customer's purchase order."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3765
+#: erpnext/controllers/accounts_controller.py:3768
 msgid "Row #{0}: Cannot set Rate if the billed amount is greater than the amount for Item {1}."
 msgstr ""
 
@@ -45017,7 +45012,7 @@ msgstr ""
 msgid "Row #{0}: Item {1} has been picked, please reserve stock from the Pick List."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:729
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:725
 msgid "Row #{0}: Item {1} is not a Serialized/Batched Item. It cannot have a Serial No/Batch No against it."
 msgstr ""
 
@@ -45073,7 +45068,7 @@ msgstr ""
 msgid "Row #{0}: Please select the Sub Assembly Warehouse"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:502
+#: erpnext/stock/doctype/item/item.py:505
 msgid "Row #{0}: Please set reorder quantity"
 msgstr ""
 
@@ -45106,8 +45101,8 @@ msgstr ""
 msgid "Row #{0}: Quality Inspection {1} was rejected for item {2}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1274
-#: erpnext/controllers/accounts_controller.py:3624
+#: erpnext/controllers/accounts_controller.py:1277
+#: erpnext/controllers/accounts_controller.py:3627
 msgid "Row #{0}: Quantity for Item {1} cannot be zero."
 msgstr ""
 
@@ -45144,7 +45139,7 @@ msgstr ""
 msgid "Row #{0}: Scrap Item Qty cannot be zero"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:230
+#: erpnext/controllers/selling_controller.py:238
 msgid "Row #{0}: Selling rate for item {1} is lower than its {2}.\n"
 "\t\t\t\t\tSelling {3} should be atleast {4}.<br><br>Alternatively,\n"
 "\t\t\t\t\tyou can disable selling price validation in {5} to bypass\n"
@@ -45228,7 +45223,7 @@ msgstr ""
 msgid "Row #{0}: The batch {1} has already expired."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:511
+#: erpnext/stock/doctype/item/item.py:514
 msgid "Row #{0}: The warehouse {1} is not a child warehouse of a group warehouse {2}"
 msgstr ""
 
@@ -45268,39 +45263,39 @@ msgstr ""
 msgid "Row #{1}: Warehouse is mandatory for stock Item {0}"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:259
+#: erpnext/controllers/buying_controller.py:267
 msgid "Row #{idx}: Cannot select Supplier Warehouse while suppling raw materials to subcontractor."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:406
+#: erpnext/controllers/buying_controller.py:414
 msgid "Row #{idx}: Item rate has been updated as per valuation rate since its an internal stock transfer."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:881
+#: erpnext/controllers/buying_controller.py:889
 msgid "Row #{idx}: Please enter a location for the asset item {item_code}."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:537
+#: erpnext/controllers/buying_controller.py:545
 msgid "Row #{idx}: Received Qty must be equal to Accepted + Rejected Qty for Item {item_code}."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:550
+#: erpnext/controllers/buying_controller.py:558
 msgid "Row #{idx}: {field_label} can not be negative for item {item_code}."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:496
+#: erpnext/controllers/buying_controller.py:504
 msgid "Row #{idx}: {field_label} is mandatory."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:518
+#: erpnext/controllers/buying_controller.py:526
 msgid "Row #{idx}: {field_label} is not allowed in Purchase Return."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:250
+#: erpnext/controllers/buying_controller.py:258
 msgid "Row #{idx}: {from_warehouse_field} and {to_warehouse_field} cannot be same."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:999
+#: erpnext/controllers/buying_controller.py:1007
 msgid "Row #{idx}: {schedule_date} cannot be before {transaction_date}."
 msgstr ""
 
@@ -45365,7 +45360,7 @@ msgstr ""
 msgid "Row #{}: {} {} does not exist."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1403
+#: erpnext/stock/doctype/item/item.py:1397
 msgid "Row #{}: {} {} doesn't belong to Company {}. Please select valid {}."
 msgstr ""
 
@@ -45437,11 +45432,11 @@ msgstr ""
 msgid "Row {0}: Both Debit and Credit values cannot be zero"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:222
+#: erpnext/controllers/selling_controller.py:230
 msgid "Row {0}: Conversion Factor is mandatory"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2995
+#: erpnext/controllers/accounts_controller.py:2998
 msgid "Row {0}: Cost Center {1} does not belong to Company {2}"
 msgstr ""
 
@@ -45461,11 +45456,11 @@ msgstr ""
 msgid "Row {0}: Debit entry can not be linked with a {1}"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:776
+#: erpnext/controllers/selling_controller.py:784
 msgid "Row {0}: Delivery Warehouse ({1}) and Customer Warehouse ({2}) can not be same"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2529
+#: erpnext/controllers/accounts_controller.py:2532
 msgid "Row {0}: Due Date in the Payment Terms table cannot be before Posting Date"
 msgstr ""
 
@@ -45474,7 +45469,7 @@ msgid "Row {0}: Either Delivery Note Item or Packed Item reference is mandatory.
 msgstr ""
 
 #: erpnext/accounts/doctype/journal_entry/journal_entry.py:1010
-#: erpnext/controllers/taxes_and_totals.py:1205
+#: erpnext/controllers/taxes_and_totals.py:1215
 msgid "Row {0}: Exchange Rate is mandatory"
 msgstr ""
 
@@ -45523,11 +45518,11 @@ msgstr ""
 msgid "Row {0}: Invalid reference {1}"
 msgstr ""
 
-#: erpnext/controllers/taxes_and_totals.py:142
+#: erpnext/controllers/taxes_and_totals.py:143
 msgid "Row {0}: Item Tax template updated as per validity and rate applied"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:541
+#: erpnext/controllers/selling_controller.py:549
 msgid "Row {0}: Item rate has been updated as per valuation rate since its an internal stock transfer"
 msgstr ""
 
@@ -45647,7 +45642,7 @@ msgstr ""
 msgid "Row {0}: The item {1}, quantity must be positive number"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2972
+#: erpnext/controllers/accounts_controller.py:2975
 msgid "Row {0}: The {3} Account {1} does not belong to the company {2}"
 msgstr ""
 
@@ -45664,7 +45659,7 @@ msgstr ""
 msgid "Row {0}: Workstation or Workstation Type is mandatory for an operation {1}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1011
+#: erpnext/controllers/accounts_controller.py:1014
 msgid "Row {0}: user has not applied the rule {1} on the item {2}"
 msgstr ""
 
@@ -45676,7 +45671,7 @@ msgstr ""
 msgid "Row {0}: {1} must be greater than 0"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:706
+#: erpnext/controllers/accounts_controller.py:709
 msgid "Row {0}: {1} {2} cannot be same as {3} (Party Account) {4}"
 msgstr ""
 
@@ -45692,7 +45687,7 @@ msgstr ""
 msgid "Row {1}: Quantity ({0}) cannot be a fraction. To allow this, disable '{2}' in UOM {3}."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:863
+#: erpnext/controllers/buying_controller.py:871
 msgid "Row {idx}: Asset Naming Series is mandatory for the auto creation of assets for item {item_code}."
 msgstr ""
 
@@ -45718,7 +45713,7 @@ msgstr ""
 msgid "Rows with Same Account heads will be merged on Ledger"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2539
+#: erpnext/controllers/accounts_controller.py:2542
 msgid "Rows with duplicate due dates in other rows were found: {0}"
 msgstr ""
 
@@ -45788,7 +45783,7 @@ msgstr ""
 msgid "SLA Paused On"
 msgstr ""
 
-#: erpnext/public/js/utils.js:1167
+#: erpnext/public/js/utils.js:1163
 msgid "SLA is on hold since {0}"
 msgstr ""
 
@@ -46189,7 +46184,7 @@ msgstr ""
 #: erpnext/accounts/report/sales_register/sales_register.py:238
 #: erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
 #: erpnext/buying/doctype/supplier_quotation_item/supplier_quotation_item.json
-#: erpnext/controllers/selling_controller.py:462
+#: erpnext/controllers/selling_controller.py:470
 #: erpnext/crm/doctype/contract/contract.json
 #: erpnext/maintenance/doctype/maintenance_schedule/maintenance_schedule.js:65
 #: erpnext/maintenance/doctype/maintenance_schedule_item/maintenance_schedule_item.json
@@ -46315,7 +46310,7 @@ msgstr ""
 msgid "Sales Order {0} is not valid"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:443
+#: erpnext/controllers/selling_controller.py:451
 #: erpnext/manufacturing/doctype/work_order/work_order.py:301
 msgid "Sales Order {0} is {1}"
 msgstr ""
@@ -46366,7 +46361,7 @@ msgstr ""
 #: erpnext/accounts/doctype/promotional_scheme/promotional_scheme.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:122
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1156
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1158
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:99
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:194
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:74
@@ -46464,7 +46459,7 @@ msgstr ""
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:156
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:137
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:128
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1153
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1155
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:105
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:191
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:80
@@ -46484,7 +46479,7 @@ msgstr ""
 msgid "Sales Person"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:204
+#: erpnext/controllers/selling_controller.py:212
 msgid "Sales Person <b>{0}</b> is disabled."
 msgstr ""
 
@@ -46765,7 +46760,7 @@ msgstr ""
 
 #. Label of the sample_size (Float) field in DocType 'Quality Inspection'
 #: erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py:93
-#: erpnext/public/js/controllers/transaction.js:2369
+#: erpnext/public/js/controllers/transaction.js:2395
 #: erpnext/stock/doctype/quality_inspection/quality_inspection.json
 msgid "Sample Size"
 msgstr ""
@@ -47303,7 +47298,7 @@ msgstr ""
 msgid "Select Items based on Delivery Date"
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2405
+#: erpnext/public/js/controllers/transaction.js:2431
 msgid "Select Items for Quality Inspection"
 msgstr ""
 
@@ -47444,7 +47439,7 @@ msgstr ""
 msgid "Select company name first."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2785
+#: erpnext/controllers/accounts_controller.py:2788
 msgid "Select finance book for the item {0} at row {1}"
 msgstr ""
 
@@ -47657,7 +47652,7 @@ msgid "Send Now"
 msgstr ""
 
 #. Label of the send_sms (Button) field in DocType 'SMS Center'
-#: erpnext/public/js/controllers/transaction.js:517
+#: erpnext/public/js/controllers/transaction.js:543
 #: erpnext/selling/doctype/sms_center/sms_center.json
 msgid "Send SMS"
 msgstr ""
@@ -47815,7 +47810,7 @@ msgstr ""
 #: erpnext/manufacturing/doctype/job_card/job_card.json
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.js:74
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.py:114
-#: erpnext/public/js/controllers/transaction.js:2382
+#: erpnext/public/js/controllers/transaction.js:2408
 #: erpnext/public/js/utils/serial_no_batch_selector.js:421
 #: erpnext/selling/doctype/installation_note_item/installation_note_item.json
 #: erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
@@ -47864,7 +47859,7 @@ msgstr ""
 msgid "Serial No Range"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1894
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1895
 msgid "Serial No Reserved"
 msgstr ""
 
@@ -47904,7 +47899,7 @@ msgstr ""
 msgid "Serial No and Batch Selector cannot be use when Use Serial / Batch Fields is enabled."
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:859
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:860
 msgid "Serial No is mandatory"
 msgstr ""
 
@@ -47933,7 +47928,7 @@ msgstr ""
 msgid "Serial No {0} does not exist"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2623
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2624
 msgid "Serial No {0} does not exists"
 msgstr ""
 
@@ -47941,7 +47936,7 @@ msgstr ""
 msgid "Serial No {0} is already added"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:357
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:358
 msgid "Serial No {0} is not present in the {1} {2}, hence you can't return it against the {1} {2}"
 msgstr ""
 
@@ -47978,11 +47973,11 @@ msgstr ""
 msgid "Serial Nos and Batches"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1370
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1371
 msgid "Serial Nos are created successfully"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:2137
+#: erpnext/stock/stock_ledger.py:2145
 msgid "Serial Nos are reserved in Stock Reservation Entries, you need to unreserve them before proceeding."
 msgstr ""
 
@@ -48056,11 +48051,11 @@ msgstr ""
 msgid "Serial and Batch Bundle"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1598
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1599
 msgid "Serial and Batch Bundle created"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1664
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1665
 msgid "Serial and Batch Bundle updated"
 msgstr ""
 
@@ -48412,12 +48407,12 @@ msgid "Service Stop Date"
 msgstr ""
 
 #: erpnext/accounts/deferred_revenue.py:44
-#: erpnext/public/js/controllers/transaction.js:1420
+#: erpnext/public/js/controllers/transaction.js:1446
 msgid "Service Stop Date cannot be after Service End Date"
 msgstr ""
 
 #: erpnext/accounts/deferred_revenue.py:41
-#: erpnext/public/js/controllers/transaction.js:1417
+#: erpnext/public/js/controllers/transaction.js:1443
 msgid "Service Stop Date cannot be before Service Start Date"
 msgstr ""
 
@@ -49852,7 +49847,7 @@ msgstr ""
 
 #: erpnext/setup/setup_wizard/operations/defaults_setup.py:70
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:463
-#: erpnext/stock/doctype/item/item.py:245
+#: erpnext/stock/doctype/item/item.py:248
 msgid "Standard Selling"
 msgstr ""
 
@@ -50682,7 +50677,7 @@ msgstr "ได้รับสินค้าแล้วแต่ยังไม
 #. Option for the 'Purpose' (Select) field in DocType 'Stock Reconciliation'
 #. Label of a Link in the Stock Workspace
 #: erpnext/setup/workspace/home/home.json
-#: erpnext/stock/doctype/item/item.py:612
+#: erpnext/stock/doctype/item/item.py:618
 #: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.json
 #: erpnext/stock/workspace/stock/stock.json
 msgid "Stock Reconciliation"
@@ -50693,7 +50688,7 @@ msgstr ""
 msgid "Stock Reconciliation Item"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:612
+#: erpnext/stock/doctype/item/item.py:618
 msgid "Stock Reconciliations"
 msgstr ""
 
@@ -50728,7 +50723,7 @@ msgstr ""
 #: erpnext/stock/doctype/pick_list/pick_list.js:150
 #: erpnext/stock/doctype/pick_list/pick_list.js:155
 #: erpnext/stock/doctype/stock_entry/stock_entry_dashboard.py:25
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:706
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:702
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:575
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:1138
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:1398
@@ -51128,7 +51123,7 @@ msgstr ""
 #: erpnext/setup/doctype/company/company.py:287
 #: erpnext/setup/setup_wizard/operations/defaults_setup.py:33
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:502
-#: erpnext/stock/doctype/item/item.py:282
+#: erpnext/stock/doctype/item/item.py:285
 msgid "Stores"
 msgstr ""
 
@@ -51663,7 +51658,7 @@ msgstr ""
 msgid "Successfully Set Supplier"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:339
+#: erpnext/stock/doctype/item/item.py:342
 msgid "Successfully changed Stock UOM, please redefine conversion factors for new UOM."
 msgstr ""
 
@@ -51965,7 +51960,7 @@ msgstr ""
 #: erpnext/accounts/doctype/tax_rule/tax_rule.json
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:111
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:87
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1160
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1162
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:198
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:237
 #: erpnext/accounts/report/purchase_register/purchase_register.js:27
@@ -52065,7 +52060,7 @@ msgstr ""
 #. Label of the supplier_name (Data) field in DocType 'Purchase Receipt'
 #. Label of the supplier_name (Data) field in DocType 'Stock Entry'
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1077
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1079
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:156
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:198
 #: erpnext/accounts/report/purchase_register/purchase_register.py:177
@@ -52549,7 +52544,7 @@ msgstr ""
 msgid "System will fetch all the entries if limit value is zero."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1975
+#: erpnext/controllers/accounts_controller.py:1978
 msgid "System will not check over billing since amount for Item {0} in {1} is zero"
 msgstr ""
 
@@ -52808,7 +52803,7 @@ msgstr ""
 msgid "Target Warehouse is required before Submit"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:782
+#: erpnext/controllers/selling_controller.py:790
 msgid "Target Warehouse is set for some items but the customer is not an internal customer."
 msgstr ""
 
@@ -53047,7 +53042,7 @@ msgstr ""
 msgid "Tax Category"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:194
+#: erpnext/controllers/buying_controller.py:202
 msgid "Tax Category has been changed to \"Total\" because all the Items are non-stock items"
 msgstr ""
 
@@ -53252,7 +53247,7 @@ msgstr ""
 #. Label of the taxable_amount (Currency) field in DocType 'Tax Withheld
 #. Vouchers'
 #: erpnext/accounts/doctype/tax_withheld_vouchers/tax_withheld_vouchers.json
-#: erpnext/controllers/taxes_and_totals.py:1125
+#: erpnext/controllers/taxes_and_totals.py:1135
 msgid "Taxable Amount"
 msgstr ""
 
@@ -53391,7 +53386,7 @@ msgstr ""
 msgid "Taxes and Charges Deducted (Company Currency)"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:352
+#: erpnext/stock/doctype/item/item.py:355
 msgid "Taxes row #{0}: {1} cannot be smaller than {2}"
 msgstr ""
 
@@ -53677,7 +53672,7 @@ msgstr ""
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/territory_item/territory_item.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:134
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1144
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1146
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:93
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:182
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:68
@@ -53781,7 +53776,7 @@ msgstr ""
 msgid "The BOM which will be replaced"
 msgstr ""
 
-#: erpnext/stock/serial_batch_bundle.py:1274
+#: erpnext/stock/serial_batch_bundle.py:1306
 msgid "The Batch {0} has negative quantity {1} in warehouse {2}. Please correct the quantity."
 msgstr ""
 
@@ -53833,7 +53828,7 @@ msgstr ""
 msgid "The Serial No at Row #{0}: {1} is not available in warehouse {2}."
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1891
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1892
 msgid "The Serial No {0} is reserved against the {1} {2} and cannot be used for any other transaction."
 msgstr ""
 
@@ -53916,7 +53911,7 @@ msgstr ""
 msgid "The following batches are expired, please restock them: <br> {0}"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:849
+#: erpnext/stock/doctype/item/item.py:843
 msgid "The following deleted attributes exist in Variants but not in the Template. You can either delete the Variants or keep the attribute(s) in template."
 msgstr ""
 
@@ -53941,15 +53936,15 @@ msgstr ""
 msgid "The holiday on {0} is not between From Date and To Date"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:1066
+#: erpnext/controllers/buying_controller.py:1074
 msgid "The item {item} is not marked as {type_of} item. You can enable it as {type_of} item from its Item master."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:614
+#: erpnext/stock/doctype/item/item.py:620
 msgid "The items {0} and {1} are present in the following {2} :"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:1059
+#: erpnext/controllers/buying_controller.py:1067
 msgid "The items {items} are not marked as {type_of} item. You can enable them as {type_of} item from their Item masters."
 msgstr ""
 
@@ -54051,8 +54046,8 @@ msgstr ""
 msgid "The seller and the buyer cannot be the same"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:142
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:154
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:143
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:155
 msgid "The serial and batch bundle {0} not linked to {1} {2}"
 msgstr ""
 
@@ -54076,7 +54071,7 @@ msgstr ""
 msgid "The stock for the item {0} in the {1} warehouse was negative on the {2}. You should create a positive entry {3} before the date {4} and time {5} to post the correct valuation rate. For more details, please read the <a href='https://docs.erpnext.com/docs/user/manual/en/stock-adjustment-cogs-with-negative-stock'>documentation<a>."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:700
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:696
 msgid "The stock has been reserved for the following Items and Warehouses, un-reserve the same to {0} the Stock Reconciliation: <br /><br /> {1}"
 msgstr ""
 
@@ -54089,11 +54084,11 @@ msgstr ""
 msgid "The task has been enqueued as a background job."
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:994
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:990
 msgid "The task has been enqueued as a background job. In case there is any issue on processing in background, the system will add a comment about the error on this Stock Reconciliation and revert to the Draft stage"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1005
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1001
 msgid "The task has been enqueued as a background job. In case there is any issue on processing in background, the system will add a comment about the error on this Stock Reconciliation and revert to the Submitted stage"
 msgstr ""
 
@@ -54143,7 +54138,7 @@ msgstr ""
 msgid "The {0} ({1}) must be equal to {2} ({3})"
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2790
+#: erpnext/public/js/controllers/transaction.js:2816
 msgid "The {0} contains Unit Price Items."
 msgstr ""
 
@@ -54191,7 +54186,7 @@ msgstr ""
 msgid "There can be multiple tiered collection factor based on the total spent. But the conversion factor for redemption will always be same for all the tier."
 msgstr ""
 
-#: erpnext/accounts/party.py:580
+#: erpnext/accounts/party.py:586
 msgid "There can only be 1 Account per Company in {0} {1}"
 msgstr ""
 
@@ -54477,7 +54472,7 @@ msgstr ""
 msgid "This will restrict user access to other employee records"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:783
+#: erpnext/controllers/selling_controller.py:791
 msgid "This {} will be treated as material transfer."
 msgstr ""
 
@@ -55191,11 +55186,11 @@ msgid "To include sub-assembly costs and scrap items in Finished Goods on a work
 msgstr ""
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:2337
-#: erpnext/controllers/accounts_controller.py:3005
+#: erpnext/controllers/accounts_controller.py:3008
 msgid "To include tax in row {0} in Item rate, taxes in rows {1} must also be included"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:636
+#: erpnext/stock/doctype/item/item.py:642
 msgid "To merge, following properties must be same for both items"
 msgstr ""
 
@@ -55815,7 +55810,7 @@ msgstr ""
 msgid "Total Paid Amount"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2591
+#: erpnext/controllers/accounts_controller.py:2594
 msgid "Total Payment Amount in Payment Schedule must be equal to Grand / Rounded Total"
 msgstr ""
 
@@ -56100,15 +56095,15 @@ msgstr ""
 msgid "Total Working Hours"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2138
+#: erpnext/controllers/accounts_controller.py:2141
 msgid "Total advance ({0}) against Order {1} cannot be greater than the Grand Total ({2})"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:190
+#: erpnext/controllers/selling_controller.py:198
 msgid "Total allocated percentage for sales team should be 100"
 msgstr ""
 
-#: erpnext/selling/doctype/customer/customer.py:162
+#: erpnext/selling/doctype/customer/customer.py:161
 msgid "Total contribution percentage should be equal to 100"
 msgstr ""
 
@@ -56993,7 +56988,7 @@ msgstr ""
 msgid "Unit of Measure (UOM)"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:384
+#: erpnext/stock/doctype/item/item.py:387
 msgid "Unit of Measure {0} has been entered more than once in Conversion Factor Table"
 msgstr ""
 
@@ -57435,7 +57430,7 @@ msgstr ""
 msgid "Update timestamp on new communication"
 msgstr ""
 
-#: erpnext/manufacturing/doctype/bom_creator/bom_creator.py:533
+#: erpnext/manufacturing/doctype/bom_creator/bom_creator.py:534
 msgid "Updated successfully"
 msgstr ""
 
@@ -57449,7 +57444,7 @@ msgstr ""
 msgid "Updated via 'Time Log' (In Minutes)"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1387
+#: erpnext/stock/doctype/item/item.py:1381
 msgid "Updating Variants..."
 msgstr ""
 
@@ -58007,19 +58002,19 @@ msgstr ""
 msgid "Valuation Rate (In / Out)"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1881
+#: erpnext/stock/stock_ledger.py:1890
 msgid "Valuation Rate Missing"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1859
+#: erpnext/stock/stock_ledger.py:1868
 msgid "Valuation Rate for the Item {0}, is required to do accounting entries for {1} {2}."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:266
+#: erpnext/stock/doctype/item/item.py:269
 msgid "Valuation Rate is mandatory if Opening Stock entered"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:752
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:748
 msgid "Valuation Rate required for Item {0} at row {1}"
 msgstr ""
 
@@ -58029,7 +58024,7 @@ msgstr ""
 msgid "Valuation and Total"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:971
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:967
 msgid "Valuation rate for customer provided items has been set to zero."
 msgstr ""
 
@@ -58043,7 +58038,7 @@ msgid "Valuation rate for the item as per Sales Invoice (Only for Internal Trans
 msgstr ""
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:2361
-#: erpnext/controllers/accounts_controller.py:3029
+#: erpnext/controllers/accounts_controller.py:3032
 msgid "Valuation type charges can not be marked as Inclusive"
 msgstr ""
 
@@ -58199,7 +58194,7 @@ msgstr ""
 msgid "Variant"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:864
+#: erpnext/stock/doctype/item/item.py:858
 msgid "Variant Attribute Error"
 msgstr ""
 
@@ -58218,7 +58213,7 @@ msgstr ""
 msgid "Variant Based On"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:892
+#: erpnext/stock/doctype/item/item.py:886
 msgid "Variant Based On cannot be changed"
 msgstr ""
 
@@ -58236,7 +58231,7 @@ msgstr ""
 msgid "Variant Item"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:862
+#: erpnext/stock/doctype/item/item.py:856
 msgid "Variant Items"
 msgstr ""
 
@@ -58354,7 +58349,7 @@ msgstr ""
 #: erpnext/accounts/doctype/cost_center/cost_center_tree.js:56
 #: erpnext/accounts/doctype/invoice_discounting/invoice_discounting.js:205
 #: erpnext/accounts/doctype/journal_entry/journal_entry.js:43
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:668
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:670
 #: erpnext/bulk_transaction/doctype/bulk_transaction_log/bulk_transaction_log.js:14
 #: erpnext/bulk_transaction/doctype/bulk_transaction_log/bulk_transaction_log.js:24
 #: erpnext/buying/doctype/request_for_quotation/request_for_quotation.js:167
@@ -58541,7 +58536,7 @@ msgstr ""
 #: erpnext/accounts/doctype/repost_accounting_ledger_items/repost_accounting_ledger_items.json
 #: erpnext/accounts/doctype/repost_payment_ledger_items/repost_payment_ledger_items.json
 #: erpnext/accounts/doctype/unreconcile_payment/unreconcile_payment.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1099
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1101
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.js:42
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:209
 #: erpnext/accounts/report/general_ledger/general_ledger.js:49
@@ -58572,7 +58567,7 @@ msgstr ""
 msgid "Voucher No"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1087
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1088
 msgid "Voucher No is mandatory"
 msgstr ""
 
@@ -58614,7 +58609,7 @@ msgstr ""
 #: erpnext/accounts/doctype/repost_payment_ledger_items/repost_payment_ledger_items.json
 #: erpnext/accounts/doctype/tax_withheld_vouchers/tax_withheld_vouchers.json
 #: erpnext/accounts/doctype/unreconcile_payment/unreconcile_payment.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1097
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1099
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:200
 #: erpnext/accounts/report/general_ledger/general_ledger.py:697
 #: erpnext/accounts/report/invalid_ledger_entries/invalid_ledger_entries.py:31
@@ -58968,10 +58963,6 @@ msgstr ""
 msgid "Warehouse not found against the account {0}"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:600
-msgid "Warehouse not found in the system"
-msgstr ""
-
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:1130
 #: erpnext/stock/doctype/delivery_note/delivery_note.py:414
 msgid "Warehouse required for stock Item {0}"
@@ -59100,7 +59091,7 @@ msgid "Warn for new Request for Quotations"
 msgstr ""
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:744
-#: erpnext/controllers/accounts_controller.py:1978
+#: erpnext/controllers/accounts_controller.py:1981
 #: erpnext/stock/doctype/delivery_trip/delivery_trip.js:145
 #: erpnext/utilities/transaction_base.py:123
 msgid "Warning"
@@ -60072,7 +60063,7 @@ msgstr ""
 msgid "You are importing data for the code list:"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3611
+#: erpnext/controllers/accounts_controller.py:3614
 msgid "You are not allowed to update as per the conditions set in {} Workflow."
 msgstr ""
 
@@ -60137,7 +60128,7 @@ msgstr ""
 msgid "You can't make any changes to Job Card since Work Order is closed."
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:185
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:186
 msgid "You can't process the serial number {0} as it has already been used in the SABB {1}. {2} if you want to inward same serial number multiple times then enabled 'Allow existing Serial No to be Manufactured/Received again' in the {3}"
 msgstr ""
 
@@ -60197,7 +60188,7 @@ msgstr ""
 msgid "You cannot {0} this document because another Period Closing Entry {1} exists after {2}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:3587
+#: erpnext/controllers/accounts_controller.py:3590
 msgid "You do not have permissions to {} items in a {}."
 msgstr ""
 
@@ -60225,7 +60216,7 @@ msgstr ""
 msgid "You have entered a duplicate Delivery Note on Row"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:1063
+#: erpnext/stock/doctype/item/item.py:1057
 msgid "You have to enable auto re-order in Stock Settings to maintain re-order levels."
 msgstr ""
 
@@ -60245,7 +60236,7 @@ msgstr ""
 msgid "You need to cancel POS Closing Entry {} to be able to cancel this document."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2980
+#: erpnext/controllers/accounts_controller.py:2983
 msgid "You selected the account group {1} as {2} Account in row {0}. Please select a single account."
 msgstr ""
 
@@ -60323,7 +60314,7 @@ msgstr ""
 msgid "`Allow Negative rates for Items`"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1873
+#: erpnext/stock/stock_ledger.py:1882
 msgid "after"
 msgstr ""
 
@@ -60471,7 +60462,7 @@ msgstr ""
 msgid "material_request_item"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:151
+#: erpnext/controllers/selling_controller.py:159
 msgid "must be between 0 and 100"
 msgstr ""
 
@@ -60496,7 +60487,7 @@ msgstr ""
 msgid "on"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1289
+#: erpnext/controllers/accounts_controller.py:1292
 msgid "or"
 msgstr ""
 
@@ -60545,7 +60536,7 @@ msgstr ""
 msgid "per hour"
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1874
+#: erpnext/stock/stock_ledger.py:1883
 msgid "performing either one below:"
 msgstr ""
 
@@ -60672,7 +60663,7 @@ msgstr ""
 msgid "{0}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1109
+#: erpnext/controllers/accounts_controller.py:1112
 msgid "{0} '{1}' is disabled"
 msgstr ""
 
@@ -60688,7 +60679,7 @@ msgstr ""
 msgid "{0} <b>{1}</b> has submitted Assets. Remove Item <b>{2}</b> from table to continue."
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2193
+#: erpnext/controllers/accounts_controller.py:2196
 msgid "{0} Account not found against Customer {1}."
 msgstr ""
 
@@ -60720,7 +60711,7 @@ msgstr ""
 msgid "{0} Request for {1}"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:323
+#: erpnext/stock/doctype/item/item.py:326
 msgid "{0} Retain Sample is based on batch, please check Has Batch No to retain sample of item"
 msgstr ""
 
@@ -60811,7 +60802,7 @@ msgid "{0} entered twice in Item Tax"
 msgstr ""
 
 #: erpnext/setup/doctype/item_group/item_group.py:48
-#: erpnext/stock/doctype/item/item.py:436
+#: erpnext/stock/doctype/item/item.py:439
 msgid "{0} entered twice {1} in Item Taxes"
 msgstr ""
 
@@ -60832,7 +60823,7 @@ msgstr ""
 msgid "{0} hours"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2534
+#: erpnext/controllers/accounts_controller.py:2537
 msgid "{0} in row {1}"
 msgstr ""
 
@@ -60856,7 +60847,7 @@ msgstr ""
 
 #: erpnext/accounts/doctype/budget/budget.py:60
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:643
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:49
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:50
 #: erpnext/accounts/report/general_ledger/general_ledger.py:59
 #: erpnext/accounts/report/pos_register/pos_register.py:107
 #: erpnext/controllers/trends.py:50
@@ -60876,11 +60867,11 @@ msgstr ""
 msgid "{0} is mandatory. Maybe Currency Exchange record is not created for {1} to {2}"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2937
+#: erpnext/controllers/accounts_controller.py:2940
 msgid "{0} is mandatory. Maybe Currency Exchange record is not created for {1} to {2}."
 msgstr ""
 
-#: erpnext/selling/doctype/customer/customer.py:204
+#: erpnext/selling/doctype/customer/customer.py:203
 msgid "{0} is not a company bank account"
 msgstr ""
 
@@ -60963,7 +60954,7 @@ msgstr ""
 msgid "{0} to {1}"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:690
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:686
 msgid "{0} units are reserved for Item {1} in Warehouse {2}, please un-reserve the same to {3} the Stock Reconciliation."
 msgstr ""
 
@@ -60979,16 +60970,16 @@ msgstr ""
 msgid "{0} units of {1} are required in {2} with the inventory dimension: {3} ({4}) on {5} {6} for {7} to complete the transaction."
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1532 erpnext/stock/stock_ledger.py:2023
-#: erpnext/stock/stock_ledger.py:2037
+#: erpnext/stock/stock_ledger.py:1541 erpnext/stock/stock_ledger.py:2031
+#: erpnext/stock/stock_ledger.py:2045
 msgid "{0} units of {1} needed in {2} on {3} {4} for {5} to complete this transaction."
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:2124 erpnext/stock/stock_ledger.py:2170
+#: erpnext/stock/stock_ledger.py:2132 erpnext/stock/stock_ledger.py:2178
 msgid "{0} units of {1} needed in {2} on {3} {4} to complete this transaction."
 msgstr ""
 
-#: erpnext/stock/stock_ledger.py:1526
+#: erpnext/stock/stock_ledger.py:1535
 msgid "{0} units of {1} needed in {2} to complete this transaction."
 msgstr ""
 
@@ -61034,7 +61025,7 @@ msgstr ""
 msgid "{0} {1} does not exist"
 msgstr ""
 
-#: erpnext/accounts/party.py:560
+#: erpnext/accounts/party.py:566
 msgid "{0} {1} has accounting entries in currency {2} for company {3}. Please select a receivable or payable account with currency {2}."
 msgstr ""
 
@@ -61068,7 +61059,7 @@ msgstr ""
 msgid "{0} {1} is associated with {2}, but Party Account is {3}"
 msgstr ""
 
-#: erpnext/controllers/selling_controller.py:462
+#: erpnext/controllers/selling_controller.py:470
 #: erpnext/controllers/subcontracting_controller.py:954
 msgid "{0} {1} is cancelled or closed"
 msgstr ""
@@ -61085,11 +61076,11 @@ msgstr ""
 msgid "{0} {1} is closed"
 msgstr ""
 
-#: erpnext/accounts/party.py:798
+#: erpnext/accounts/party.py:804
 msgid "{0} {1} is disabled"
 msgstr ""
 
-#: erpnext/accounts/party.py:804
+#: erpnext/accounts/party.py:810
 msgid "{0} {1} is frozen"
 msgstr ""
 
@@ -61097,7 +61088,7 @@ msgstr ""
 msgid "{0} {1} is fully billed"
 msgstr ""
 
-#: erpnext/accounts/party.py:808
+#: erpnext/accounts/party.py:814
 msgid "{0} {1} is not active"
 msgstr ""
 
@@ -61223,15 +61214,15 @@ msgstr ""
 msgid "{0}: {1} must be less than {2}"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:840
+#: erpnext/controllers/buying_controller.py:848
 msgid "{count} Assets created for {item_code}"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:738
+#: erpnext/controllers/buying_controller.py:746
 msgid "{doctype} {name} is cancelled or closed."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:459
+#: erpnext/controllers/buying_controller.py:467
 msgid "{field_label} is mandatory for sub-contracted {doctype}."
 msgstr ""
 
@@ -61239,7 +61230,7 @@ msgstr ""
 msgid "{item_name}'s Sample Size ({sample_size}) cannot be greater than the Accepted Quantity ({accepted_quantity})"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:563
+#: erpnext/controllers/buying_controller.py:571
 msgid "{ref_doctype} {ref_name} is {status}."
 msgstr ""
 
@@ -61305,7 +61296,7 @@ msgstr ""
 msgid "{} can't be cancelled since the Loyalty Points earned has been redeemed. First cancel the {} No {}"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:222
+#: erpnext/controllers/buying_controller.py:230
 msgid "{} has submitted assets linked to it. You need to cancel the assets to create purchase return."
 msgstr ""
 

--- a/erpnext/locale/tr.po
+++ b/erpnext/locale/tr.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: frappe\n"
 "Report-Msgid-Bugs-To: hello@frappe.io\n"
-"POT-Creation-Date: 2025-05-25 09:35+0000\n"
-"PO-Revision-Date: 2025-05-25 20:35\n"
+"POT-Creation-Date: 2025-06-01 09:36+0000\n"
+"PO-Revision-Date: 2025-06-01 21:35\n"
 "Last-Translator: hello@frappe.io\n"
 "Language-Team: Turkish\n"
 "MIME-Version: 1.0\n"
@@ -83,15 +83,15 @@ msgstr " Alt Montaj"
 msgid " Summary"
 msgstr " Özet"
 
-#: erpnext/stock/doctype/item/item.py:235
+#: erpnext/stock/doctype/item/item.py:238
 msgid "\"Customer Provided Item\" cannot be Purchase Item also"
 msgstr "\"Müşterinin Tedarik Ettiği Ürün\" aynı zamanda Satın Alma Ürünü olamaz."
 
-#: erpnext/stock/doctype/item/item.py:237
+#: erpnext/stock/doctype/item/item.py:240
 msgid "\"Customer Provided Item\" cannot have Valuation Rate"
 msgstr "\"Müşterinin Tedarik Ettiği Ürün\" Değerleme Oranına sahip olamaz."
 
-#: erpnext/stock/doctype/item/item.py:313
+#: erpnext/stock/doctype/item/item.py:316
 msgid "\"Is Fixed Asset\" cannot be unchecked, as Asset record exists against the item"
 msgstr "Varlık kaydı yapıldığından, 'Sabit Varlık' seçimi kaldırılamaz."
 
@@ -213,7 +213,7 @@ msgstr "Bu Satış Siparişine göre faturalandırılan malzemelerin yüzdesi"
 msgid "% of materials delivered against this Sales Order"
 msgstr "Satış Siparişine karşılık teslim edilen malzemelerin yüzdesi"
 
-#: erpnext/controllers/accounts_controller.py:2197
+#: erpnext/controllers/accounts_controller.py:2200
 msgid "'Account' in the Accounting section of Customer {0}"
 msgstr "{0} isimli Müşterinin Muhasebe bölümündeki ‘Hesap’"
 
@@ -225,15 +225,11 @@ msgstr "'Müşterinin Satın Alma Siparişine Karşı Çoklu Satış Siparişler
 msgid "'Based On' and 'Group By' can not be same"
 msgstr "'Şuna Göre' ve 'Gruplandırma Ölçütü' aynı olamaz"
 
-#: erpnext/stock/report/product_bundle_balance/product_bundle_balance.py:233
-msgid "'Date' is required"
-msgstr "'Tarih' gerekli"
-
 #: erpnext/selling/report/inactive_customers/inactive_customers.py:18
 msgid "'Days Since Last Order' must be greater than or equal to zero"
 msgstr "'Son Siparişten bu yana geçen süre' sıfırdan büyük veya sıfıra eşit olmalıdır"
 
-#: erpnext/controllers/accounts_controller.py:2202
+#: erpnext/controllers/accounts_controller.py:2205
 msgid "'Default {0} Account' in Company {1}"
 msgstr "Şirket {1} için Varsayılan {0} Hesabı"
 
@@ -243,7 +239,7 @@ msgstr "'Girdiler' boş olamaz"
 
 #: erpnext/stock/report/batch_item_expiry_status/batch_item_expiry_status.py:24
 #: erpnext/stock/report/batch_wise_balance_history/batch_wise_balance_history.py:120
-#: erpnext/stock/report/stock_analytics/stock_analytics.py:314
+#: erpnext/stock/report/stock_analytics/stock_analytics.py:313
 msgid "'From Date' is required"
 msgstr "'Başlangıç Tarihi' alanı zorunlu"
 
@@ -251,7 +247,7 @@ msgstr "'Başlangıç Tarihi' alanı zorunlu"
 msgid "'From Date' must be after 'To Date'"
 msgstr "Başlangıç Tarihi Bitiş Tarihinden önce olmalıdır"
 
-#: erpnext/stock/doctype/item/item.py:398
+#: erpnext/stock/doctype/item/item.py:401
 msgid "'Has Serial No' can not be 'Yes' for non-stock item"
 msgstr "Stokta olmayan ürünün 'Seri No' değeri 'Evet' olamaz."
 
@@ -1179,7 +1175,7 @@ msgstr "Stok Biriminde Kabul Edilen Miktar"
 
 #. Label of the qty (Float) field in DocType 'Purchase Receipt Item'
 #. Label of the qty (Float) field in DocType 'Subcontracting Receipt Item'
-#: erpnext/public/js/controllers/transaction.js:2362
+#: erpnext/public/js/controllers/transaction.js:2388
 #: erpnext/stock/doctype/purchase_receipt_item/purchase_receipt_item.json
 #: erpnext/subcontracting/doctype/subcontracting_receipt_item/subcontracting_receipt_item.json
 msgid "Accepted Quantity"
@@ -1377,7 +1373,7 @@ msgid "Account Manager"
 msgstr "Muhasebe Müdürü"
 
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:949
-#: erpnext/controllers/accounts_controller.py:2206
+#: erpnext/controllers/accounts_controller.py:2209
 msgid "Account Missing"
 msgstr "Hesap Eksik"
 
@@ -1552,7 +1548,7 @@ msgstr "{0} Hesabı, {1} isimli alt şirkete eklendi"
 msgid "Account {0} is frozen"
 msgstr "{0} Hesabı donduruldu"
 
-#: erpnext/controllers/accounts_controller.py:1288
+#: erpnext/controllers/accounts_controller.py:1291
 msgid "Account {0} is invalid. Account Currency must be {1}"
 msgstr "Hesap {0} geçersiz. Hesap Para Birimi {1} olmalıdır"
 
@@ -1588,7 +1584,7 @@ msgstr "Hesap: {0} yalnızca Stok İşlemleri aracılığıyla güncellenebilir"
 msgid "Account: {0} is not permitted under Payment Entry"
 msgstr "Hesap: {0} Ödeme Girişi altında izin verilmiyor"
 
-#: erpnext/controllers/accounts_controller.py:3037
+#: erpnext/controllers/accounts_controller.py:3040
 msgid "Account: {0} with currency: {1} can not be selected"
 msgstr "Hesap: {0} para ile: {1} seçilemez"
 
@@ -1861,7 +1857,7 @@ msgstr "Muhasebe Girişleri"
 msgid "Accounting Entry for Asset"
 msgstr "Varlık İçin Muhasebe Girişi"
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:796
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:805
 msgid "Accounting Entry for Service"
 msgstr "Hizmet için Muhasebe Girişi"
 
@@ -1876,18 +1872,18 @@ msgstr "Hizmet için Muhasebe Girişi"
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py:1468
 #: erpnext/controllers/stock_controller.py:550
 #: erpnext/controllers/stock_controller.py:567
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:889
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:898
 #: erpnext/stock/doctype/stock_entry/stock_entry.py:1586
 #: erpnext/stock/doctype/stock_entry/stock_entry.py:1600
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py:561
 msgid "Accounting Entry for Stock"
 msgstr "Stok İçin Muhasebe Girişi"
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:717
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:726
 msgid "Accounting Entry for {0}"
 msgstr "{0} için Muhasebe Girişi"
 
-#: erpnext/controllers/accounts_controller.py:2247
+#: erpnext/controllers/accounts_controller.py:2250
 msgid "Accounting Entry for {0}: {1} can only be made in currency: {2}"
 msgstr "{0}: {1} için Muhasebe Kaydı yalnızca {2} para biriminde yapılabilir."
 
@@ -2280,7 +2276,7 @@ msgstr "Birikmiş Amortisman"
 msgid "Accumulated Monthly"
 msgstr "Aylık Birikim"
 
-#: erpnext/controllers/budget_controller.py:417
+#: erpnext/controllers/budget_controller.py:422
 msgid "Accumulated Monthly Budget for Account {0} against {1} {2} is {3}. It will be collectively ({4}) exceeded by {5}"
 msgstr ""
 
@@ -3394,7 +3390,7 @@ msgstr "Varlık Değerini Ayarla"
 msgid "Adjustment Against"
 msgstr "Karşılığına Yapılan Düzenleme"
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:634
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:643
 msgid "Adjustment based on Purchase Invoice rate"
 msgstr "Satın Alma Faturası oranına göre düzeltme"
 
@@ -3505,7 +3501,7 @@ msgstr "Peşin Vergiler ve Harçlar"
 msgid "Advance amount"
 msgstr "Avans Tutarı"
 
-#: erpnext/controllers/taxes_and_totals.py:845
+#: erpnext/controllers/taxes_and_totals.py:855
 msgid "Advance amount cannot be greater than {0} {1}"
 msgstr "{0} Avans miktarı {1} tutarından fazla olamaz."
 
@@ -3716,7 +3712,7 @@ msgstr "Gün"
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:152
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:133
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1125
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1127
 msgid "Age (Days)"
 msgstr "Yaş (Gün)"
 
@@ -3802,16 +3798,6 @@ msgstr "Bir grup Ürünü başka bir Ürün altında birleştirin. Bu, paketlenm
 #: erpnext/setup/setup_wizard/data/industry_type.txt:4
 msgid "Agriculture"
 msgstr "Tarım"
-
-#. Name of a role
-#: erpnext/assets/doctype/location/location.json
-msgid "Agriculture Manager"
-msgstr "Tarım Yöneticisi"
-
-#. Name of a role
-#: erpnext/assets/doctype/location/location.json
-msgid "Agriculture User"
-msgstr "Tarım Kullanıcısı"
 
 #: erpnext/setup/setup_wizard/data/industry_type.txt:5
 msgid "Airline"
@@ -4003,7 +3989,7 @@ msgstr "Bu ve bunun üzerindeki tüm iletişimler yeni Sayıya taşınacaktır."
 msgid "All items are already requested"
 msgstr "Tüm ürünler zaten talep edildi"
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:1317
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:1326
 msgid "All items have already been Invoiced/Returned"
 msgstr "Tüm ürünler zaten Faturalandırıldı/İade Edildi"
 
@@ -4015,7 +4001,7 @@ msgstr "Tüm ürünler zaten alındı"
 msgid "All items have already been transferred for this Work Order."
 msgstr "Bu İş Emri için tüm öğeler zaten aktarıldı."
 
-#: erpnext/public/js/controllers/transaction.js:2465
+#: erpnext/public/js/controllers/transaction.js:2491
 msgid "All items in this document already have a linked Quality Inspection."
 msgstr "Bu belgedeki tüm Ürünlerin zaten bağlantılı bir Kalite Kontrolü var."
 
@@ -4213,7 +4199,7 @@ msgstr "İç Transferlerde Piyasa Fiyatına İzin Ver"
 msgid "Allow Item To Be Added Multiple Times in a Transaction"
 msgstr "Bir İşlemde Öğenin Birden Fazla Kez Eklenmesine İzin Ver"
 
-#: erpnext/controllers/selling_controller.py:755
+#: erpnext/controllers/selling_controller.py:763
 msgid "Allow Item to Be Added Multiple Times in a Transaction"
 msgstr "Öğenin Bir İşlemde Birden Fazla Kez Eklenmesine İzin Verin"
 
@@ -5159,7 +5145,7 @@ msgstr "Yıllık"
 msgid "Annual Billing: {0}"
 msgstr "Yıllık Fatura: {0}"
 
-#: erpnext/controllers/budget_controller.py:441
+#: erpnext/controllers/budget_controller.py:446
 msgid "Annual Budget for Account {0} against {1} {2} is {3}. It will be collectively ({4}) exceeded by {5}"
 msgstr ""
 
@@ -5648,7 +5634,7 @@ msgstr "{0} alanı etkinleştirildiğinden, {1} alanı zorunludur."
 msgid "As the field {0} is enabled, the value of the field {1} should be more than 1."
 msgstr "{0} alanı etkinleştirildiğinden, {1} alanının değeri 1'den fazla olmalıdır."
 
-#: erpnext/stock/doctype/item/item.py:989
+#: erpnext/stock/doctype/item/item.py:983
 msgid "As there are existing submitted transactions against item {0}, you can not change the value of {1}."
 msgstr "{0} Ürününe karşı mevcut gönderilmiş işlemler olduğundan, {1} değerini değiştiremezsiniz."
 
@@ -5794,7 +5780,7 @@ msgstr "Varlık Kategorisi Hesabı"
 msgid "Asset Category Name"
 msgstr "Varlık Kategorisi Adı"
 
-#: erpnext/stock/doctype/item/item.py:304
+#: erpnext/stock/doctype/item/item.py:307
 msgid "Asset Category is mandatory for Fixed Asset item"
 msgstr "Duran Varlık için Varlık Kategorisi zorunludur"
 
@@ -6169,7 +6155,7 @@ msgstr "Varlık {0} güncellendi. Lütfen varsa amortisman ayrıntılarını aya
 msgid "Asset {0} must be submitted"
 msgstr "Varlık {0} kaydedilmelidir"
 
-#: erpnext/controllers/buying_controller.py:851
+#: erpnext/controllers/buying_controller.py:859
 msgid "Asset {assets_link} created for {item_code}"
 msgstr ""
 
@@ -6199,11 +6185,11 @@ msgstr "Varlık Değer Düzeltmesinin sunulmasından sonra düzeltilen varlık d
 msgid "Assets"
 msgstr "Varlıklar"
 
-#: erpnext/controllers/buying_controller.py:869
+#: erpnext/controllers/buying_controller.py:877
 msgid "Assets not created for {item_code}. You will have to create asset manually."
 msgstr "{item_code} için varlıklar oluşturulamadı. Varlığı manuel olarak oluşturmanız gerekecek."
 
-#: erpnext/controllers/buying_controller.py:856
+#: erpnext/controllers/buying_controller.py:864
 msgid "Assets {assets_link} created for {item_code}"
 msgstr ""
 
@@ -6298,7 +6284,7 @@ msgstr "Satır #{0}: Sıra numarası {1}, önceki satırın sıra numarası {2} 
 msgid "At row #{0}: you have selected the Difference Account {1}, which is a Cost of Goods Sold type account. Please select a different account"
 msgstr ""
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:864
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:865
 msgid "At row {0}: Batch No is mandatory for Item {1}"
 msgstr "Satır {0}: Parti No, {1} Ürünü için zorunludur"
 
@@ -6306,11 +6292,11 @@ msgstr "Satır {0}: Parti No, {1} Ürünü için zorunludur"
 msgid "At row {0}: Parent Row No cannot be set for item {1}"
 msgstr "Satır {0}: Üst Satır No, {1} öğesi için ayarlanamıyor"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:849
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:850
 msgid "At row {0}: Qty is mandatory for the batch {1}"
 msgstr "Satır {0}: {1} partisi için miktar zorunludur"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:856
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:857
 msgid "At row {0}: Serial No is mandatory for Item {1}"
 msgstr "Satır {0}: Seri No, {1} Ürünü için zorunludur"
 
@@ -6384,7 +6370,7 @@ msgstr "Özellik İsmi"
 msgid "Attribute Value"
 msgstr "Özellik Değeri"
 
-#: erpnext/stock/doctype/item/item.py:930
+#: erpnext/stock/doctype/item/item.py:924
 msgid "Attribute table is mandatory"
 msgstr "Özellik tablosu zorunludur"
 
@@ -6392,11 +6378,11 @@ msgstr "Özellik tablosu zorunludur"
 msgid "Attribute value: {0} must appear only once"
 msgstr "Özellik değeri: {0} yalnızca bir kez görünmelidir"
 
-#: erpnext/stock/doctype/item/item.py:934
+#: erpnext/stock/doctype/item/item.py:928
 msgid "Attribute {0} selected multiple times in Attributes Table"
 msgstr "Özellik {0}, Özellikler Tablosunda birden çok kez seçilmiş"
 
-#: erpnext/stock/doctype/item/item.py:862
+#: erpnext/stock/doctype/item/item.py:856
 msgid "Attributes"
 msgstr "Özellikler"
 
@@ -7680,11 +7666,11 @@ msgstr "Barkod"
 msgid "Barcode Type"
 msgstr "Barkod Türü"
 
-#: erpnext/stock/doctype/item/item.py:457
+#: erpnext/stock/doctype/item/item.py:460
 msgid "Barcode {0} already used in Item {1}"
 msgstr "{0} barkodu zaten {1} ürününde kullanılmış"
 
-#: erpnext/stock/doctype/item/item.py:472
+#: erpnext/stock/doctype/item/item.py:475
 msgid "Barcode {0} is not a valid {1} code"
 msgstr "Barkod {0}, geçerli bir {1} kodu değil"
 
@@ -7938,7 +7924,7 @@ msgstr "Parti Ürünü Son Kullanma Durumu"
 #: erpnext/manufacturing/doctype/job_card/job_card.json
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.js:89
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.py:115
-#: erpnext/public/js/controllers/transaction.js:2388
+#: erpnext/public/js/controllers/transaction.js:2414
 #: erpnext/public/js/utils/barcode_scanner.js:260
 #: erpnext/public/js/utils/serial_no_batch_selector.js:438
 #: erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
@@ -7965,11 +7951,11 @@ msgstr "Parti Ürünü Son Kullanma Durumu"
 msgid "Batch No"
 msgstr "Parti No"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:867
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:868
 msgid "Batch No is mandatory"
 msgstr "Parti Numarası Zorunlu"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2629
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2630
 msgid "Batch No {0} does not exists"
 msgstr "Parti No {0} mevcut değil"
 
@@ -7977,7 +7963,7 @@ msgstr "Parti No {0} mevcut değil"
 msgid "Batch No {0} is linked with Item {1} which has serial no. Please scan serial no instead."
 msgstr "Parti No {0} , seri numarası olan {1} öğesi ile bağlantılıdır. Lütfen bunun yerine seri numarasını tarayın."
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:364
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:365
 msgid "Batch No {0} is not present in the original {1} {2}, hence you can't return it against the {1} {2}"
 msgstr "Parti No {0}, orijinalinde {1} {2} için mevcut değil, bu nedenle bunu {1} {2} adına iade edemezsiniz."
 
@@ -7992,11 +7978,11 @@ msgstr "Parti No."
 msgid "Batch Nos"
 msgstr "Parti Numaraları"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1421
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1422
 msgid "Batch Nos are created successfully"
 msgstr "Parti Numaraları başarıyla oluşturuldu"
 
-#: erpnext/controllers/sales_and_purchase_return.py:1096
+#: erpnext/controllers/sales_and_purchase_return.py:1001
 msgid "Batch Not Available for Return"
 msgstr "Parti İade İçin Uygun Değil"
 
@@ -8045,7 +8031,7 @@ msgstr "{} öğesi için parti oluşturulamadı çünkü parti serisi yok."
 msgid "Batch {0} and Warehouse"
 msgstr "Parti {0} ve Depo"
 
-#: erpnext/controllers/sales_and_purchase_return.py:1095
+#: erpnext/controllers/sales_and_purchase_return.py:1000
 msgid "Batch {0} is not available in warehouse {1}"
 msgstr "{0} partisi {1} deposunda mevcut değil"
 
@@ -8095,7 +8081,7 @@ msgstr "Aşağıdaki Abonelik Planları, carinin varsayılan Fatura Para Birimi 
 #. Label of the bill_date (Date) field in DocType 'Journal Entry'
 #. Label of the bill_date (Date) field in DocType 'Subcontracting Receipt'
 #: erpnext/accounts/doctype/journal_entry/journal_entry.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1110
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1112
 #: erpnext/accounts/report/purchase_register/purchase_register.py:214
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.json
 msgid "Bill Date"
@@ -8104,7 +8090,7 @@ msgstr "Fatura Tarihi"
 #. Label of the bill_no (Data) field in DocType 'Journal Entry'
 #. Label of the bill_no (Data) field in DocType 'Subcontracting Receipt'
 #: erpnext/accounts/doctype/journal_entry/journal_entry.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1109
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1111
 #: erpnext/accounts/report/purchase_register/purchase_register.py:213
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.json
 msgid "Bill No"
@@ -8324,7 +8310,7 @@ msgstr "Fatura Durumu"
 msgid "Billing Zipcode"
 msgstr "Fatura Posta Kodu"
 
-#: erpnext/accounts/party.py:602
+#: erpnext/accounts/party.py:608
 msgid "Billing currency must be equal to either default company's currency or party account currency"
 msgstr "Fatura para birimi, şirketin varsayılan para birimi veya carinin hesap para birimi ile aynı olmalıdır."
 
@@ -9321,7 +9307,7 @@ msgid "Can only make payment against unbilled {0}"
 msgstr "Sadece faturalandırılmamış ödemeler yapılabilir {0}"
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1458
-#: erpnext/controllers/accounts_controller.py:2946
+#: erpnext/controllers/accounts_controller.py:2949
 #: erpnext/public/js/controllers/accounts.js:90
 msgid "Can refer row only if the charge type is 'On Previous Row Amount' or 'Previous Row Total'"
 msgstr "Yalnızca ücret türü 'Önceki Satır Tutarında' veya 'Önceki Satır Toplamında' ise satıra referans verebilir"
@@ -9483,9 +9469,9 @@ msgstr "Sürücü Adresi Eksik Olduğu İçin Varış Saati Hesaplanamıyor."
 msgid "Cannot Create Return"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:625
-#: erpnext/stock/doctype/item/item.py:638
-#: erpnext/stock/doctype/item/item.py:652
+#: erpnext/stock/doctype/item/item.py:631
+#: erpnext/stock/doctype/item/item.py:644
+#: erpnext/stock/doctype/item/item.py:658
 msgid "Cannot Merge"
 msgstr "Birleştirilemez"
 
@@ -9509,7 +9495,7 @@ msgstr "{0} {1} değiştirilemiyor, lütfen bunu düzenlemek yerine yeni bir tan
 msgid "Cannot apply TDS against multiple parties in one entry"
 msgstr "Bir girişte birden fazla tarafa karşı Stopaj Vergisi uygulanamaz"
 
-#: erpnext/stock/doctype/item/item.py:307
+#: erpnext/stock/doctype/item/item.py:310
 msgid "Cannot be a fixed asset item as Stock Ledger is created."
 msgstr "Stok Defterine girişi olan bir kalem Sabit Varlık olarak ayarlanamaz."
 
@@ -9525,7 +9511,7 @@ msgstr "Gönderilen Stok Girişi {0} mevcut olduğundan iptal edilemiyor"
 msgid "Cannot cancel the transaction. Reposting of item valuation on submission is not completed yet."
 msgstr "İşlem iptal edilemiyor. Gönderim sırasında Ürün değerlemesinin yeniden yayınlanması henüz tamamlanmadı."
 
-#: erpnext/controllers/buying_controller.py:959
+#: erpnext/controllers/buying_controller.py:967
 msgid "Cannot cancel this document as it is linked with the submitted asset {asset_link}. Please cancel the asset to continue."
 msgstr ""
 
@@ -9533,7 +9519,7 @@ msgstr ""
 msgid "Cannot cancel transaction for Completed Work Order."
 msgstr "Tamamlanan İş Emri için işlem iptal edilemez."
 
-#: erpnext/stock/doctype/item/item.py:882
+#: erpnext/stock/doctype/item/item.py:876
 msgid "Cannot change Attributes after stock transaction. Make a new Item and transfer stock to the new Item"
 msgstr "Stok işlemi sonrasında Özellikler değiştirilemez. Yeni bir Ürün oluşturun ve stoğu yeni Ürüne aktarmayı deneyin."
 
@@ -9549,7 +9535,7 @@ msgstr "Referans Belge Türü değiştirilemiyor."
 msgid "Cannot change Service Stop Date for item in row {0}"
 msgstr "{0} satırındaki öğe için Hizmet Durdurma Tarihi değiştirilemiyor"
 
-#: erpnext/stock/doctype/item/item.py:873
+#: erpnext/stock/doctype/item/item.py:867
 msgid "Cannot change Variant properties after stock transaction. You will have to make a new Item to do this."
 msgstr "Stok işlemi sonrasında Varyant özellikleri değiştirilemez. Bunu yapmak için yeni bir Ürün oluşturmanız gerekecektir."
 
@@ -9577,7 +9563,7 @@ msgstr "Hesap Türü seçili olduğundan Gruba dönüştürülemiyor."
 msgid "Cannot covert to Group because Account Type is selected."
 msgstr "Hesap Türü seçili olduğundan Gruba dönüştürülemiyor."
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:972
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:981
 msgid "Cannot create Stock Reservation Entries for future dated Purchase Receipts."
 msgstr "İleri tarihli Alış İrsaliyeleri için Stok Rezervasyon Girişleri oluşturulamıyor."
 
@@ -9628,7 +9614,7 @@ msgstr "{0} Ürünü Seri No ile \"Teslimatı Sağla ile ve Seri No ile Teslimat
 msgid "Cannot find Item with this Barcode"
 msgstr "Bu Barkoda Sahip Ürün Bulunamadı"
 
-#: erpnext/controllers/accounts_controller.py:3483
+#: erpnext/controllers/accounts_controller.py:3486
 msgid "Cannot find a default warehouse for item {0}. Please set one in the Item Master or in Stock Settings."
 msgstr "{0} ürünü için varsayılan bir depo bulunamadı. Lütfen Ürün Ana Verisi'nde veya Stok Ayarları'nda bir tane ayarlayın."
 
@@ -9636,7 +9622,7 @@ msgstr "{0} ürünü için varsayılan bir depo bulunamadı. Lütfen Ürün Ana 
 msgid "Cannot make any transactions until the deletion job is completed"
 msgstr "Silme işi tamamlanana kadar herhangi bir işlem yapılamaz"
 
-#: erpnext/controllers/accounts_controller.py:2074
+#: erpnext/controllers/accounts_controller.py:2077
 msgid "Cannot overbill for Item {0} in row {1} more than {2}. To allow over-billing, please set allowance in Accounts Settings"
 msgstr "{1} satırındaki {0} öğesi için {2} değerinden daha fazla faturalandırma yapılamaz. Fazla faturalandırmaya izin vermek için lütfen Hesap Ayarları'nda ödenek ayarlayın"
 
@@ -9657,7 +9643,7 @@ msgid "Cannot receive from customer against negative outstanding"
 msgstr "Negatif bakiye karşılığında müşteriden teslim alınamıyor"
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1475
-#: erpnext/controllers/accounts_controller.py:2961
+#: erpnext/controllers/accounts_controller.py:2964
 #: erpnext/public/js/controllers/accounts.js:100
 msgid "Cannot refer row number greater than or equal to current row number for this Charge type"
 msgstr "Bu ücret türü için geçerli satır numarasından büyük veya bu satır numarasına eşit satır numarası verilemiyor"
@@ -9673,7 +9659,7 @@ msgstr "Güncelleme için bağlantı token'ı alınamıyor. Daha fazla bilgi iç
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1467
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1646
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:1917
-#: erpnext/controllers/accounts_controller.py:2951
+#: erpnext/controllers/accounts_controller.py:2954
 #: erpnext/public/js/controllers/accounts.js:94
 #: erpnext/public/js/controllers/taxes_and_totals.js:470
 msgid "Cannot select charge type as 'On Previous Row Amount' or 'On Previous Row Total' for first row"
@@ -9687,15 +9673,15 @@ msgstr "Satış Siparişi verildiği için Kayıp olarak ayarlanamaz."
 msgid "Cannot set authorization on basis of Discount for {0}"
 msgstr "{0} için İndirim bazında yetkilendirme ayarlanamıyor"
 
-#: erpnext/stock/doctype/item/item.py:716
+#: erpnext/stock/doctype/item/item.py:722
 msgid "Cannot set multiple Item Defaults for a company."
 msgstr "Bir şirket için birden fazla Ürün Varsayılanı belirlenemez."
 
-#: erpnext/controllers/accounts_controller.py:3631
+#: erpnext/controllers/accounts_controller.py:3634
 msgid "Cannot set quantity less than delivered quantity"
 msgstr "Teslim edilen miktardan daha az miktar ayarlanamıyor"
 
-#: erpnext/controllers/accounts_controller.py:3634
+#: erpnext/controllers/accounts_controller.py:3637
 msgid "Cannot set quantity less than received quantity"
 msgstr "Alınan miktardan daha az miktar ayarlanamıyor"
 
@@ -10118,7 +10104,7 @@ msgid "Channel Partner"
 msgstr "Kanal Ortağı"
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:2346
-#: erpnext/controllers/accounts_controller.py:3014
+#: erpnext/controllers/accounts_controller.py:3017
 msgid "Charge of type 'Actual' in row {0} cannot be included in Item Rate or Paid Amount"
 msgstr "{0} satırındaki 'Gerçekleşen' türündeki ücret Kalem Oranına veya Ödenen Tutara dahil edilemez"
 
@@ -10301,7 +10287,7 @@ msgstr "Çek Genişliği"
 
 #. Label of the reference_date (Date) field in DocType 'Payment Entry'
 #: erpnext/accounts/doctype/payment_entry/payment_entry.json
-#: erpnext/public/js/controllers/transaction.js:2299
+#: erpnext/public/js/controllers/transaction.js:2325
 msgid "Cheque/Reference Date"
 msgstr "İşlem Tarihi"
 
@@ -10349,7 +10335,7 @@ msgstr "Alt Dokuman Adı"
 
 #. Label of the child_row_reference (Data) field in DocType 'Quality
 #. Inspection'
-#: erpnext/public/js/controllers/transaction.js:2394
+#: erpnext/public/js/controllers/transaction.js:2420
 #: erpnext/stock/doctype/quality_inspection/quality_inspection.json
 msgid "Child Row Reference"
 msgstr "Alt Satır Referansı"
@@ -11061,7 +11047,7 @@ msgstr "Şirketler"
 #: erpnext/accounts/report/cheques_and_deposits_incorrectly_cleared/cheques_and_deposits_incorrectly_cleared.js:8
 #: erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.js:8
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:8
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:49
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:50
 #: erpnext/accounts/report/deferred_revenue_and_expense/deferred_revenue_and_expense.js:8
 #: erpnext/accounts/report/delivered_items_to_be_billed/delivered_items_to_be_billed.js:7
 #: erpnext/accounts/report/dimension_wise_accounts_balance_report/dimension_wise_accounts_balance_report.js:8
@@ -12294,7 +12280,7 @@ msgid "Content Type"
 msgstr "İçerik Türü"
 
 #: erpnext/erpnext_integrations/doctype/plaid_settings/plaid_settings.js:162
-#: erpnext/public/js/controllers/transaction.js:2312
+#: erpnext/public/js/controllers/transaction.js:2338
 #: erpnext/selling/doctype/quotation/quotation.js:356
 msgid "Continue"
 msgstr "Devam Et"
@@ -12459,7 +12445,7 @@ msgstr "Dönüşüm Faktörü"
 msgid "Conversion Rate"
 msgstr "Dönüşüm Oranı"
 
-#: erpnext/stock/doctype/item/item.py:393
+#: erpnext/stock/doctype/item/item.py:396
 msgid "Conversion factor for default Unit of Measure must be 1 in row {0}"
 msgstr "Varsayılan Ölçü Birimi için dönüşüm faktörü {0} satırında 1 olmalıdır"
 
@@ -12467,15 +12453,15 @@ msgstr "Varsayılan Ölçü Birimi için dönüşüm faktörü {0} satırında 1
 msgid "Conversion factor for item {0} has been reset to 1.0 as the uom {1} is same as stock uom {2}."
 msgstr "Ürün {0} için dönüşüm faktörü, birimi {1} stok birimi {2} ile aynı olduğu için 1.0 olarak sıfırlandı"
 
-#: erpnext/controllers/accounts_controller.py:2767
+#: erpnext/controllers/accounts_controller.py:2770
 msgid "Conversion rate cannot be 0"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2774
+#: erpnext/controllers/accounts_controller.py:2777
 msgid "Conversion rate is 1.00, but document currency is different from company currency"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:2770
+#: erpnext/controllers/accounts_controller.py:2773
 msgid "Conversion rate must be 1.00 if document currency is same as company currency"
 msgstr ""
 
@@ -12688,7 +12674,7 @@ msgstr "Maliyet"
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:28
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:40
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:30
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1096
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1098
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:40
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.js:42
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.py:197
@@ -12781,7 +12767,7 @@ msgid "Cost Center is a part of Cost Center Allocation, hence cannot be converte
 msgstr "Maliyet Merkezi, Maliyet Merkezi Tahsisinin bir parçasıdır, dolayısıyla bir gruba dönüştürülemez"
 
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py:1411
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:855
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:864
 msgid "Cost Center is required in row {0} in Taxes table for type {1}"
 msgstr "{1} türü için Vergiler tablosundaki {0} satırında Maliyet Merkezi gereklidir"
 
@@ -13050,8 +13036,8 @@ msgstr "Alacak"
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:132
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:143
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:219
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:654
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:678
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:656
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:680
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.js:88
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.js:89
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.js:103
@@ -13108,8 +13094,8 @@ msgstr "Alacak"
 #: erpnext/projects/doctype/task/task_tree.js:81
 #: erpnext/public/js/communication.js:19 erpnext/public/js/communication.js:31
 #: erpnext/public/js/communication.js:41
-#: erpnext/public/js/controllers/transaction.js:336
-#: erpnext/public/js/controllers/transaction.js:2435
+#: erpnext/public/js/controllers/transaction.js:362
+#: erpnext/public/js/controllers/transaction.js:2461
 #: erpnext/selling/doctype/customer/customer.js:181
 #: erpnext/selling/doctype/quotation/quotation.js:124
 #: erpnext/selling/doctype/quotation/quotation.js:133
@@ -13404,7 +13390,7 @@ msgstr "Yeni bir bileşik varlık oluşturun"
 msgid "Create a variant with the template image."
 msgstr "Şablon görselini kullanarak bir varyant oluşturun."
 
-#: erpnext/stock/stock_ledger.py:1877
+#: erpnext/stock/stock_ledger.py:1886
 msgid "Create an incoming stock transaction for the Item."
 msgstr "Ürün için yeni bir stok girişi oluşturun."
 
@@ -13464,7 +13450,7 @@ msgstr "Satın Alma Faturaları Oluşturuluyor..."
 msgid "Creating Purchase Order ..."
 msgstr "Satın Alma Siparişi Oluşturuluyor..."
 
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:735
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:737
 #: erpnext/buying/doctype/purchase_order/purchase_order.js:552
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.js:73
 msgid "Creating Purchase Receipt ..."
@@ -13660,7 +13646,7 @@ msgstr "Alacak Ayı"
 #: erpnext/accounts/doctype/journal_entry_template/journal_entry_template.json
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:174
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:147
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1119
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1121
 #: erpnext/controllers/sales_and_purchase_return.py:373
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:286
 #: erpnext/stock/doctype/delivery_note/delivery_note.js:89
@@ -13695,7 +13681,7 @@ msgstr "Alacak Dekontu {0} otomatik olarak kurulmuştur"
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py:368
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py:376
-#: erpnext/controllers/accounts_controller.py:2186
+#: erpnext/controllers/accounts_controller.py:2189
 msgid "Credit To"
 msgstr "Bakiye Eklenecek Hesap"
 
@@ -13880,7 +13866,7 @@ msgstr "Fincan"
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/subscription_plan/subscription_plan.json
 #: erpnext/accounts/report/account_balance/account_balance.py:28
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1129
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1131
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:205
 #: erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.py:101
 #: erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.js:118
@@ -14409,7 +14395,7 @@ msgstr "Müşteri Kodu"
 #. Label of the customer_contact_display (Small Text) field in DocType
 #. 'Purchase Order'
 #. Label of the customer_contact (Small Text) field in DocType 'Delivery Stop'
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1090
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1092
 #: erpnext/buying/doctype/purchase_order/purchase_order.json
 #: erpnext/stock/doctype/delivery_stop/delivery_stop.json
 msgid "Customer Contact"
@@ -14505,7 +14491,7 @@ msgstr "Müşteri Görüşleri"
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/tax_rule/tax_rule.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:107
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1147
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1149
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:81
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:185
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:56
@@ -14549,7 +14535,7 @@ msgstr "Müşteri Grubu Öğesi"
 msgid "Customer Group Name"
 msgstr "Müşteri Grubu"
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1239
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1241
 msgid "Customer Group: {0} does not exist"
 msgstr "Müşteri Grubu: {0} mevcut değil"
 
@@ -14568,7 +14554,7 @@ msgstr "Müşteri Ürünü"
 msgid "Customer Items"
 msgstr "Müşteri Ürünleri"
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1138
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1140
 msgid "Customer LPO"
 msgstr "Müşteri Yerel Satın Alma Emri"
 
@@ -14614,7 +14600,7 @@ msgstr "Müşteri Mobil No"
 #: erpnext/accounts/doctype/pos_invoice/pos_invoice.json
 #: erpnext/accounts/doctype/process_statement_of_accounts_customer/process_statement_of_accounts_customer.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1080
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1082
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:156
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:92
 #: erpnext/accounts/report/delivered_items_to_be_billed/delivered_items_to_be_billed.py:35
@@ -15292,7 +15278,7 @@ msgstr "İşlem Para Birimindeki Borç Tutarı"
 #: erpnext/accounts/doctype/journal_entry_template/journal_entry_template.json
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:176
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:147
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1122
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1124
 #: erpnext/controllers/sales_and_purchase_return.py:377
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:287
 #: erpnext/stock/doctype/purchase_receipt/purchase_receipt.js:61
@@ -15321,7 +15307,7 @@ msgstr "İade Faturası, ‘Karşı Fatura’ belirtilmiş olsa bile kendi açı
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:953
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:964
-#: erpnext/controllers/accounts_controller.py:2186
+#: erpnext/controllers/accounts_controller.py:2189
 msgid "Debit To"
 msgstr "Borçlandırma"
 
@@ -15354,11 +15340,11 @@ msgstr "Borç-Alacak Uyuşmazlığı"
 msgid "Debit-Credit mismatch"
 msgstr "Borç-Alacak uyuşmazlığı"
 
-#: erpnext/accounts/party.py:609
+#: erpnext/accounts/party.py:615
 msgid "Debtor/Creditor"
 msgstr "Borçlu/Alacaklı"
 
-#: erpnext/accounts/party.py:612
+#: erpnext/accounts/party.py:618
 msgid "Debtor/Creditor Advance"
 msgstr "Borçlu/Alacaklı Avansı"
 
@@ -15478,7 +15464,7 @@ msgstr "Varsayılan Alınan Avans Hesabı"
 msgid "Default BOM"
 msgstr "Varsayılan Ürün Ağacı"
 
-#: erpnext/stock/doctype/item/item.py:418
+#: erpnext/stock/doctype/item/item.py:421
 msgid "Default BOM ({0}) must be active for this item or its template"
 msgstr "Bu ürün veya şablonu için varsayılan Ürün Ağacı ({0}) aktif olmalıdır"
 
@@ -15486,7 +15472,7 @@ msgstr "Bu ürün veya şablonu için varsayılan Ürün Ağacı ({0}) aktif olm
 msgid "Default BOM for {0} not found"
 msgstr "{0} İçin Ürün Ağacı Bulunamadı"
 
-#: erpnext/controllers/accounts_controller.py:3672
+#: erpnext/controllers/accounts_controller.py:3675
 msgid "Default BOM not found for FG Item {0}"
 msgstr "{0} Ürünü için Varsayılan Ürün Ağacı bulunamadı"
 
@@ -15821,15 +15807,15 @@ msgstr "Varsayılan Bölge"
 msgid "Default Unit of Measure"
 msgstr "Varsayılan Ölçü Birimi"
 
-#: erpnext/stock/doctype/item/item.py:1272
+#: erpnext/stock/doctype/item/item.py:1266
 msgid "Default Unit of Measure for Item {0} cannot be changed directly because you have already made some transaction(s) with another UOM. You need to either cancel the linked documents or create a new Item."
 msgstr "{0} Ürünü için Varsayılan Ölçü Birimi doğrudan değiştirilemez çünkü zaten başka bir Ölçü Birimi ile bazı işlemler yaptınız. Ya bağlantılı belgeleri iptal etmeniz ya da yeni bir Ürün oluşturmanız gerekir."
 
-#: erpnext/stock/doctype/item/item.py:1255
+#: erpnext/stock/doctype/item/item.py:1249
 msgid "Default Unit of Measure for Item {0} cannot be changed directly because you have already made some transaction(s) with another UOM. You will need to create a new Item to use a different Default UOM."
 msgstr "Ürün {0} için Varsayılan Ölçü Birimi doğrudan değiştirilemez çünkü başka bir ölçü birimiyle işlem yapılmıştır. Farklı bir Varsayılan Ölçü Birimi kullanmak için yeni bir Ürün oluşturmanız gerekecek."
 
-#: erpnext/stock/doctype/item/item.py:908
+#: erpnext/stock/doctype/item/item.py:902
 msgid "Default Unit of Measure for Variant '{0}' must be same as in Template '{1}'"
 msgstr "Değişiklik için varsayılan ölçü birimi '{0}' şablondaki ile aynı olmalıdır '{1}'"
 
@@ -16288,7 +16274,7 @@ msgstr "İrsaliye Trendleri"
 msgid "Delivery Note {0} is not submitted"
 msgstr "Satış İrsaliyesi {0} kaydedilmedi"
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1142
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1144
 #: erpnext/stock/doctype/delivery_trip/delivery_trip.js:73
 msgid "Delivery Notes"
 msgstr "İrsaliyeler"
@@ -16819,7 +16805,7 @@ msgstr ""
 #: erpnext/projects/doctype/task_type/task_type.json
 #: erpnext/projects/doctype/timesheet_detail/timesheet_detail.json
 #: erpnext/public/js/bank_reconciliation_tool/data_table_manager.js:55
-#: erpnext/public/js/controllers/transaction.js:2376
+#: erpnext/public/js/controllers/transaction.js:2402
 #: erpnext/selling/doctype/installation_note_item/installation_note_item.json
 #: erpnext/selling/doctype/product_bundle/product_bundle.json
 #: erpnext/selling/doctype/product_bundle_item/product_bundle_item.json
@@ -17007,7 +16993,7 @@ msgstr ""
 msgid "Difference Account must be a Asset/Liability type account (Temporary Opening), since this Stock Entry is an Opening Entry"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:954
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:950
 msgid "Difference Account must be a Asset/Liability type account, since this Stock Reconciliation is an Opening Entry"
 msgstr "Fark Hesabı, bu Stok Mutabakatı bir Açılış Girişi olduğundan Varlık/Yükümlülük türü bir hesap olmalıdır"
 
@@ -17273,11 +17259,11 @@ msgstr "Devre Dışı Hesap Seçildi"
 msgid "Disabled Warehouse {0} cannot be used for this transaction."
 msgstr "{0} Deposu devre dışı bırakıldığından, bu işlem için kullanılamaz."
 
-#: erpnext/controllers/accounts_controller.py:745
+#: erpnext/controllers/accounts_controller.py:748
 msgid "Disabled pricing rules since this {} is an internal transfer"
 msgstr "{} iç transfer olduğu için, fiyatlandırma kuralı devre dışı bırakıldı."
 
-#: erpnext/controllers/accounts_controller.py:759
+#: erpnext/controllers/accounts_controller.py:762
 msgid "Disabled tax included prices since this {} is an internal transfer"
 msgstr "{0} bir dahili transfer olduğundan, vergiler dahil fiyatlar devre dışı bırakıldı"
 
@@ -18219,7 +18205,7 @@ msgstr "Stoksuz Satış"
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.json
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/print_format/sales_invoice_print/sales_invoice_print.html:72
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1106
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1108
 #: erpnext/assets/doctype/asset_maintenance_log/asset_maintenance_log.json
 #: erpnext/selling/report/payment_terms_status_for_sales_order/payment_terms_status_for_sales_order.py:40
 msgid "Due Date"
@@ -18233,11 +18219,11 @@ msgstr "Termin Tarihi"
 msgid "Due Date Based On"
 msgstr "Vade Tarihine göre"
 
-#: erpnext/accounts/party.py:695
+#: erpnext/accounts/party.py:701
 msgid "Due Date cannot be after {0}"
 msgstr "Son Tarih {0} tarihinden sonra olamaz"
 
-#: erpnext/accounts/party.py:671
+#: erpnext/accounts/party.py:677
 msgid "Due Date cannot be before {0}"
 msgstr "Son Tarih {0} tarihinden önce olamaz"
 
@@ -18955,7 +18941,7 @@ msgstr "Randevu Zamanlamayı Etkinleştirme"
 msgid "Enable Auto Email"
 msgstr "Otomatik E-postayı Etkinleştir"
 
-#: erpnext/stock/doctype/item/item.py:1064
+#: erpnext/stock/doctype/item/item.py:1058
 msgid "Enable Auto Re-Order"
 msgstr "Otomatik Yeniden Siparişi Etkinleştir"
 
@@ -19168,7 +19154,7 @@ msgstr "Çıkış Ödemesi Tarihi"
 msgid "End Date"
 msgstr "Bitiş Tarihi"
 
-#: erpnext/crm/doctype/contract/contract.py:75
+#: erpnext/crm/doctype/contract/contract.py:83
 msgid "End Date cannot be before Start Date."
 msgstr "Bitiş Tarihi, Başlangıç Tarihi'nden önce olamaz."
 
@@ -19419,7 +19405,7 @@ msgstr "Erg"
 #: erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.json
 #: erpnext/manufacturing/doctype/job_card/job_card.py:875
 #: erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.json
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:297
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:298
 msgid "Error"
 msgstr "Hata"
 
@@ -19544,7 +19530,7 @@ msgstr "Fabrika Teslim "
 msgid "Example URL"
 msgstr "Örnek URL"
 
-#: erpnext/stock/doctype/item/item.py:995
+#: erpnext/stock/doctype/item/item.py:989
 msgid "Example of a linked document: {0}"
 msgstr "Bağlantılı bir döküman örneği: {0}"
 
@@ -19560,7 +19546,7 @@ msgstr "Örnek: ABCD.#####\n"
 msgid "Example: ABCD.#####. If series is set and Batch No is not mentioned in transactions, then automatic batch number will be created based on this series. If you always want to explicitly mention Batch No for this item, leave this blank. Note: this setting will take priority over the Naming Series Prefix in Stock Settings."
 msgstr "Örnek: ABCD.#####. Seri ayarlanmışsa ve işlemlerde Parti No belirtilmemişse, bu seriye göre otomatik parti numarası oluşturulacaktır. Bu kalem için her zaman açıkça Parti No belirtmek istiyorsanız, bunu boş bırakın. Not: Bu ayar, Stok Ayarları'ndaki Seri Öneki Adlandırma'ya göre öncelikli olacaktır."
 
-#: erpnext/stock/stock_ledger.py:2141
+#: erpnext/stock/stock_ledger.py:2149
 msgid "Example: Serial No {0} reserved in {1}."
 msgstr "Örnek: Seri No {0} {1} adresinde ayrılmıştır."
 
@@ -19614,8 +19600,8 @@ msgstr "Döviz Kazancı veya Zararı"
 msgid "Exchange Gain/Loss"
 msgstr "Döviz Kazancı/Zararı"
 
-#: erpnext/controllers/accounts_controller.py:1593
-#: erpnext/controllers/accounts_controller.py:1677
+#: erpnext/controllers/accounts_controller.py:1596
+#: erpnext/controllers/accounts_controller.py:1680
 msgid "Exchange Gain/Loss amount has been booked through {0}"
 msgstr "Döviz Kar/Zarar tutarı {0} adresinde muhasebeleştirilmiştir."
 
@@ -20351,7 +20337,7 @@ msgid "Fetching Error"
 msgstr "Veri Çekme Hatası"
 
 #: erpnext/accounts/doctype/dunning/dunning.js:135
-#: erpnext/public/js/controllers/transaction.js:1251
+#: erpnext/public/js/controllers/transaction.js:1277
 msgid "Fetching exchange rates ..."
 msgstr "Döviz kurları alınıyor ..."
 
@@ -20646,15 +20632,15 @@ msgstr "Bitmiş Ürün Miktarı"
 msgid "Finished Good Item Quantity"
 msgstr "Bitmiş Ürün Miktarı"
 
-#: erpnext/controllers/accounts_controller.py:3658
+#: erpnext/controllers/accounts_controller.py:3661
 msgid "Finished Good Item is not specified for service item {0}"
 msgstr "{0} Hizmet kalemi için Tamamlanmış Ürün belirtilmemiş"
 
-#: erpnext/controllers/accounts_controller.py:3675
+#: erpnext/controllers/accounts_controller.py:3678
 msgid "Finished Good Item {0} Qty can not be zero"
 msgstr "Bitmiş Ürün {0} Miktarı sıfır olamaz"
 
-#: erpnext/controllers/accounts_controller.py:3669
+#: erpnext/controllers/accounts_controller.py:3672
 msgid "Finished Good Item {0} must be a sub-contracted item"
 msgstr "Bitmiş Ürün {0} alt yüklenici ürünü olmalıdır"
 
@@ -20895,7 +20881,7 @@ msgstr "Sabit Varlık Hesabı"
 msgid "Fixed Asset Defaults"
 msgstr "Sabit Varlık Varsayılanları"
 
-#: erpnext/stock/doctype/item/item.py:301
+#: erpnext/stock/doctype/item/item.py:304
 msgid "Fixed Asset Item must be a non-stock item."
 msgstr "Sabit Varlık Kalemi stok dışı bir kalem olmalıdır."
 
@@ -21071,7 +21057,7 @@ msgstr "Üretim Miktarı zorunludur"
 msgid "For Raw Materials"
 msgstr ""
 
-#: erpnext/controllers/accounts_controller.py:1259
+#: erpnext/controllers/accounts_controller.py:1262
 msgid "For Return Invoices with Stock effect, '0' qty Items are not allowed. Following rows are affected: {0}"
 msgstr "Stok etkili İade Faturaları için '0' adetlik Kalemlere izin verilmez. Aşağıdaki satırlar etkilenir: {0}"
 
@@ -21172,7 +21158,7 @@ msgstr "Müşterilere kolaylık sağlamak için bu kodlar Fatura ve İrsaliye gi
 msgid "For the item {0}, the quantity should be {1} according to the BOM {2}."
 msgstr "Ürün {0} için miktar, {2} Ürün Ağacına göre {1} olmalıdır."
 
-#: erpnext/public/js/controllers/transaction.js:1088
+#: erpnext/public/js/controllers/transaction.js:1114
 msgctxt "Clear payment terms template and/or payment schedule when due date is changed"
 msgid "For the new {0} to take effect, would you like to clear the current {1}?"
 msgstr ""
@@ -21181,7 +21167,7 @@ msgstr ""
 msgid "For the {0}, no stock is available for the return in the warehouse {1}."
 msgstr "{0} için {1} deposunda iade için stok bulunmamaktadır."
 
-#: erpnext/controllers/sales_and_purchase_return.py:1144
+#: erpnext/controllers/sales_and_purchase_return.py:1049
 msgid "For the {0}, the quantity is required to make the return entry"
 msgstr "{0} için iade girişini oluşturmak amacıyla miktar gereklidir."
 
@@ -21518,7 +21504,7 @@ msgstr "Başlangıç Tarihi Bitiş Tarihinden büyük olamaz"
 msgid "From Date is mandatory"
 msgstr "Başlangıç Tarihi zorunludur"
 
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:52
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:53
 #: erpnext/accounts/report/general_ledger/general_ledger.py:86
 #: erpnext/accounts/report/pos_register/pos_register.py:115
 #: erpnext/accounts/report/tax_withholding_details/tax_withholding_details.py:39
@@ -21895,14 +21881,14 @@ msgstr "Alt elemanlar yalnızca 'Grup' altında oluşturulabilir."
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:186
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:155
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1134
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1136
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:177
 msgid "Future Payment Amount"
 msgstr "Gelecekteki Ödeme Tutarı"
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:185
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:154
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1133
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1135
 msgid "Future Payment Ref"
 msgstr "Yaklaşan Ödeme Referansı"
 
@@ -23076,7 +23062,7 @@ msgstr "İşletmenizde mevsimsel çalışma varsa Bütçeyi/Hedefi aylara dağı
 msgid "Here are the error logs for the aforementioned failed depreciation entries: {0}"
 msgstr "Yukarıda bahsedilen başarısız amortisman girişleri için hata kayıtları şunlardır: {0}"
 
-#: erpnext/stock/stock_ledger.py:1862
+#: erpnext/stock/stock_ledger.py:1871
 msgid "Here are the options to proceed:"
 msgstr "İşleme devam etmek için seçenekleriniz:"
 
@@ -23600,7 +23586,7 @@ msgstr "Sistem, bu Roldeki kullanıcılara belirli bir ürün ve depo için en s
 msgid "If more than one package of the same type (for print)"
 msgstr "Aynı türden birden fazla paket varsa (baskı için)"
 
-#: erpnext/stock/stock_ledger.py:1872
+#: erpnext/stock/stock_ledger.py:1881
 msgid "If not, you can Cancel / Submit this entry"
 msgstr "Aksi takdirde, bu girişi İptal Edebilir veya Gönderebilirsiniz"
 
@@ -23625,7 +23611,7 @@ msgstr "Ürün Ağacının Hurda malzemeyle sonuçlanması durumunda Hurda Depos
 msgid "If the account is frozen, entries are allowed to restricted users."
 msgstr "Eğer hesap dondurulursa, yeni girişleri belirli kullanıcılar yapabilir."
 
-#: erpnext/stock/stock_ledger.py:1865
+#: erpnext/stock/stock_ledger.py:1874
 msgid "If the item is transacting as a Zero Valuation Rate item in this entry, please enable 'Allow Zero Valuation Rate' in the {0} Item table."
 msgstr "Eğer ürünün değerinin sıfır olmasını istiyorsanız, Ürünler tablosundan \"Sıfır Değerlemeye İzin Ver\" kutusunu işaretleyebilirsiniz."
 
@@ -24623,7 +24609,7 @@ msgstr "İşlem Sonrası Yanlış Bakiye Miktarı"
 msgid "Incorrect Batch Consumed"
 msgstr "Yanlış Parti Tüketildi"
 
-#: erpnext/stock/doctype/item/item.py:514
+#: erpnext/stock/doctype/item/item.py:517
 msgid "Incorrect Check in (group) Warehouse for Reorder"
 msgstr "Yeniden Sipariş İçin Depoda Yanlış Giriş (grup)"
 
@@ -24672,7 +24658,7 @@ msgstr "Geçersiz Seri ve Parti"
 msgid "Incorrect Stock Value Report"
 msgstr "Yanlış Stok Değeri Raporu"
 
-#: erpnext/stock/serial_batch_bundle.py:134
+#: erpnext/stock/serial_batch_bundle.py:135
 msgid "Incorrect Type of Transaction"
 msgstr "Yanlış İşlem Türü"
 
@@ -24941,8 +24927,8 @@ msgstr "Talimatlar"
 msgid "Insufficient Capacity"
 msgstr "Yetersiz Kapasite"
 
-#: erpnext/controllers/accounts_controller.py:3590
-#: erpnext/controllers/accounts_controller.py:3614
+#: erpnext/controllers/accounts_controller.py:3593
+#: erpnext/controllers/accounts_controller.py:3617
 msgid "Insufficient Permissions"
 msgstr "Yetersiz Yetki"
 
@@ -24950,12 +24936,12 @@ msgstr "Yetersiz Yetki"
 #: erpnext/stock/doctype/pick_list/pick_list.py:127
 #: erpnext/stock/doctype/pick_list/pick_list.py:975
 #: erpnext/stock/doctype/stock_entry/stock_entry.py:759
-#: erpnext/stock/serial_batch_bundle.py:989 erpnext/stock/stock_ledger.py:1559
-#: erpnext/stock/stock_ledger.py:2032
+#: erpnext/stock/serial_batch_bundle.py:1021 erpnext/stock/stock_ledger.py:1568
+#: erpnext/stock/stock_ledger.py:2040
 msgid "Insufficient Stock"
 msgstr "Yetersiz Stok"
 
-#: erpnext/stock/stock_ledger.py:2047
+#: erpnext/stock/stock_ledger.py:2055
 msgid "Insufficient Stock for Batch"
 msgstr "Parti için Yetersiz Stok"
 
@@ -25093,11 +25079,11 @@ msgstr "İç Müşteri"
 msgid "Internal Customer for company {0} already exists"
 msgstr "Şirket için İç Müşteri {0} zaten mevcut"
 
-#: erpnext/controllers/accounts_controller.py:728
+#: erpnext/controllers/accounts_controller.py:731
 msgid "Internal Sale or Delivery Reference missing."
 msgstr "Dahili Satış veya Teslimat Referansı eksik."
 
-#: erpnext/controllers/accounts_controller.py:730
+#: erpnext/controllers/accounts_controller.py:733
 msgid "Internal Sales Reference Missing"
 msgstr "Dahili Satış Referansı Eksik"
 
@@ -25128,7 +25114,7 @@ msgstr "{0} şirketinin Dahili Tedarikçisi zaten mevcut"
 msgid "Internal Transfer"
 msgstr "Hesaplar Arası Transfer"
 
-#: erpnext/controllers/accounts_controller.py:739
+#: erpnext/controllers/accounts_controller.py:742
 msgid "Internal Transfer Reference Missing"
 msgstr "Dahili Transfer Referansı Eksik"
 
@@ -25171,8 +25157,8 @@ msgstr "Geçersiz"
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:969
 #: erpnext/assets/doctype/asset_category/asset_category.py:69
 #: erpnext/assets/doctype/asset_category/asset_category.py:97
-#: erpnext/controllers/accounts_controller.py:2975
-#: erpnext/controllers/accounts_controller.py:2983
+#: erpnext/controllers/accounts_controller.py:2978
+#: erpnext/controllers/accounts_controller.py:2986
 msgid "Invalid Account"
 msgstr "Geçersiz Hesap"
 
@@ -25197,7 +25183,7 @@ msgstr "Geçersiz Otomatik Tekrar Tarihi"
 msgid "Invalid Barcode. There is no Item attached to this barcode."
 msgstr "Geçersiz Barkod. Bu barkoda bağlı bir Ürün yok."
 
-#: erpnext/public/js/controllers/transaction.js:2631
+#: erpnext/public/js/controllers/transaction.js:2657
 msgid "Invalid Blanket Order for the selected Customer and Item"
 msgstr "Seçilen Müşteri ve Ürün için Geçersiz Genel Sipariş"
 
@@ -25211,7 +25197,7 @@ msgstr "Şirketler Arası İşlem için Geçersiz Şirket."
 
 #: erpnext/assets/doctype/asset/asset.py:295
 #: erpnext/assets/doctype/asset/asset.py:302
-#: erpnext/controllers/accounts_controller.py:2998
+#: erpnext/controllers/accounts_controller.py:3001
 msgid "Invalid Cost Center"
 msgstr "Geçersiz Maliyet Merkezi"
 
@@ -25253,7 +25239,7 @@ msgstr "Geçersiz Gruplama Ölçütü"
 msgid "Invalid Item"
 msgstr "Geçersiz Öğe"
 
-#: erpnext/stock/doctype/item/item.py:1410
+#: erpnext/stock/doctype/item/item.py:1404
 msgid "Invalid Item Defaults"
 msgstr "Geçersiz Ürün Varsayılanları"
 
@@ -25299,11 +25285,11 @@ msgstr "Geçersiz Proses Kaybı Yapılandırması"
 msgid "Invalid Purchase Invoice"
 msgstr "Geçersiz Satın Alma Faturası"
 
-#: erpnext/controllers/accounts_controller.py:3627
+#: erpnext/controllers/accounts_controller.py:3630
 msgid "Invalid Qty"
 msgstr "Geçersiz Miktar"
 
-#: erpnext/controllers/accounts_controller.py:1277
+#: erpnext/controllers/accounts_controller.py:1280
 msgid "Invalid Quantity"
 msgstr "Geçersiz Miktar"
 
@@ -25320,7 +25306,7 @@ msgstr ""
 msgid "Invalid Schedule"
 msgstr "Geçersiz Program"
 
-#: erpnext/controllers/selling_controller.py:243
+#: erpnext/controllers/selling_controller.py:251
 msgid "Invalid Selling Price"
 msgstr "Geçersiz Satış Fiyatı"
 
@@ -25353,7 +25339,7 @@ msgstr "Geçersiz koşul ifadesi"
 msgid "Invalid lost reason {0}, please create a new lost reason"
 msgstr "Geçersiz kayıp nedeni {0}, lütfen yeni bir kayıp nedeni oluşturun"
 
-#: erpnext/stock/doctype/item/item.py:408
+#: erpnext/stock/doctype/item/item.py:411
 msgid "Invalid naming series (. missing) for {0}"
 msgstr "{0} için geçersiz adlandırma serisi (. eksik)"
 
@@ -25393,7 +25379,7 @@ msgstr "Envanter"
 #. Name of a DocType
 #: erpnext/patches/v15_0/refactor_closing_stock_balance.py:43
 #: erpnext/stock/doctype/inventory_dimension/inventory_dimension.json
-#: erpnext/stock/doctype/inventory_dimension/inventory_dimension.py:180
+#: erpnext/stock/doctype/inventory_dimension/inventory_dimension.py:181
 msgid "Inventory Dimension"
 msgstr "Envanter Boyutu"
 
@@ -25459,7 +25445,7 @@ msgstr "Fatura Tarihi"
 msgid "Invoice Discounting"
 msgstr "Fatura İndirimi"
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1114
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1116
 msgid "Invoice Grand Total"
 msgstr "Fatura Genel Toplamı"
 
@@ -25552,7 +25538,7 @@ msgstr "Sıfır fatura saati için fatura kesilemez"
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:169
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:144
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1116
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1118
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:164
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:165
 msgid "Invoiced Amount"
@@ -25958,6 +25944,11 @@ msgstr "Açılış Kaydı"
 msgid "Is Outward"
 msgstr "Giden"
 
+#. Label of the is_packed (Check) field in DocType 'Serial and Batch Bundle'
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.json
+msgid "Is Packed"
+msgstr ""
+
 #. Label of the is_paid (Check) field in DocType 'Purchase Invoice'
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 msgid "Is Paid"
@@ -26240,11 +26231,11 @@ msgstr "Veriliş Tarihi"
 msgid "Issuing cannot be done to a location. Please enter employee to issue the Asset {0} to"
 msgstr "Çıkış işlemi bir lokasyona yapılamaz. Lütfen {0} varlığını çıkış yapmak için bir personel seçin."
 
-#: erpnext/stock/doctype/item/item.py:565
+#: erpnext/stock/doctype/item/item.py:571
 msgid "It can take upto few hours for accurate stock values to be visible after merging items."
 msgstr "Ürünlerin birleştirilmesinden sonra doğru stok değerlerinin görünür hale gelmesi birkaç saat sürebilir."
 
-#: erpnext/public/js/controllers/transaction.js:2075
+#: erpnext/public/js/controllers/transaction.js:2101
 msgid "It is needed to fetch Item Details."
 msgstr "Ürün Detaylarını almak için gereklidir."
 
@@ -26294,7 +26285,7 @@ msgstr "Toplam tutar sıfır olduğunda ücretleri eşit olarak dağıtmak mümk
 #: erpnext/buying/report/supplier_quotation_comparison/supplier_quotation_comparison.js:33
 #: erpnext/buying/report/supplier_quotation_comparison/supplier_quotation_comparison.py:204
 #: erpnext/buying/workspace/buying/buying.json
-#: erpnext/controllers/taxes_and_totals.py:1125
+#: erpnext/controllers/taxes_and_totals.py:1135
 #: erpnext/manufacturing/doctype/blanket_order/blanket_order.json
 #: erpnext/manufacturing/doctype/bom/bom.js:944
 #: erpnext/manufacturing/doctype/bom/bom.json
@@ -26572,7 +26563,7 @@ msgstr "Ürün Sepeti"
 #: erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py:86
 #: erpnext/manufacturing/report/work_order_stock_report/work_order_stock_report.py:119
 #: erpnext/projects/doctype/timesheet/timesheet.js:213
-#: erpnext/public/js/controllers/transaction.js:2350
+#: erpnext/public/js/controllers/transaction.js:2376
 #: erpnext/public/js/stock_reservation.js:112
 #: erpnext/public/js/stock_reservation.js:317 erpnext/public/js/utils.js:500
 #: erpnext/public/js/utils.js:656
@@ -27010,7 +27001,7 @@ msgstr "Üretici Firma"
 #: erpnext/manufacturing/report/production_planning_report/production_planning_report.py:359
 #: erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py:92
 #: erpnext/manufacturing/report/work_order_consumed_materials/work_order_consumed_materials.py:138
-#: erpnext/public/js/controllers/transaction.js:2356
+#: erpnext/public/js/controllers/transaction.js:2382
 #: erpnext/public/js/utils.js:746
 #: erpnext/selling/doctype/quotation_item/quotation_item.json
 #: erpnext/selling/doctype/sales_order_item/sales_order_item.json
@@ -27277,7 +27268,7 @@ msgstr "Ürün Varyant Ayarları"
 msgid "Item Variant {0} already exists with same attributes"
 msgstr "Öğe Varyantı {0} aynı niteliklerle zaten mevcut"
 
-#: erpnext/stock/doctype/item/item.py:781
+#: erpnext/stock/doctype/item/item.py:772
 msgid "Item Variants updated"
 msgstr "Ürün Varyantları Güncellendi"
 
@@ -27343,7 +27334,7 @@ msgstr "Ürün ve Garanti Detayları"
 msgid "Item for row {0} does not match Material Request"
 msgstr "{0} satırındaki Kalem Malzeme Talebi ile eşleşmiyor"
 
-#: erpnext/stock/doctype/item/item.py:795
+#: erpnext/stock/doctype/item/item.py:789
 msgid "Item has variants."
 msgstr "Ürünün varyantları mevcut."
 
@@ -27369,7 +27360,7 @@ msgstr "Ürün Adı"
 msgid "Item operation"
 msgstr "Operasyon"
 
-#: erpnext/controllers/accounts_controller.py:3650
+#: erpnext/controllers/accounts_controller.py:3653
 msgid "Item qty can not be updated as raw materials are already processed."
 msgstr "Ürün miktarı güncellenemez çünkü hammaddeler zaten işlenmiş durumda."
 
@@ -27395,7 +27386,7 @@ msgstr "Ürün değerleme oranı, indirilmiş maliyet kuponu tutarı dikkate al�
 msgid "Item valuation reposting in progress. Report might show incorrect item valuation."
 msgstr "Ürün değerlemesi yeniden yapılıyor. Rapor geçici olarak yanlış değerleme gösterebilir."
 
-#: erpnext/stock/doctype/item/item.py:952
+#: erpnext/stock/doctype/item/item.py:946
 msgid "Item variant {0} exists with same attributes"
 msgstr "Öğe Varyantı {0} aynı niteliklerle zaten mevcut"
 
@@ -27408,8 +27399,7 @@ msgid "Item {0} cannot be ordered more than {1} against Blanket Order {2}."
 msgstr "Ürün {0}, Toplu Sipariş {2} kapsamında {1} miktarından daha fazla sipariş edilemez."
 
 #: erpnext/assets/doctype/asset/asset.py:277
-#: erpnext/stock/doctype/item/item.py:630
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:167
+#: erpnext/stock/doctype/item/item.py:636
 msgid "Item {0} does not exist"
 msgstr "{0} ürünü mevcut değil"
 
@@ -27421,7 +27411,7 @@ msgstr "{0} Ürünü sistemde mevcut değil veya süresi dolmuş"
 msgid "Item {0} does not exist."
 msgstr "{0} ürünü mevcut değil."
 
-#: erpnext/controllers/selling_controller.py:752
+#: erpnext/controllers/selling_controller.py:760
 msgid "Item {0} entered multiple times."
 msgstr "{0} ürünü birden fazla kez girildi."
 
@@ -27437,7 +27427,7 @@ msgstr "Ürün {0} Devre dışı bırakılmış"
 msgid "Item {0} has no Serial No. Only serialized items can have delivery based on Serial No"
 msgstr "{0} Ürününe ait Seri Numarası yoktur. Yalnızca serileştirilmiş Ürünler Seri Numarasına göre teslimat yapılabilir"
 
-#: erpnext/stock/doctype/item/item.py:1126
+#: erpnext/stock/doctype/item/item.py:1120
 msgid "Item {0} has reached its end of life on {1}"
 msgstr "Ürün {0} {1} tarihinde kullanım süresinin sonuna gelmiştir."
 
@@ -27449,11 +27439,11 @@ msgstr "{0} Stok Kalemi olmadığından, ürün yok sayılır"
 msgid "Item {0} is already reserved/delivered against Sales Order {1}."
 msgstr "Ürün {0} zaten {1} Satış Siparişi karşılığında rezerve edilmiş/teslim edilmiştir."
 
-#: erpnext/stock/doctype/item/item.py:1146
+#: erpnext/stock/doctype/item/item.py:1140
 msgid "Item {0} is cancelled"
 msgstr "Ürün {0} iptal edildi"
 
-#: erpnext/stock/doctype/item/item.py:1130
+#: erpnext/stock/doctype/item/item.py:1124
 msgid "Item {0} is disabled"
 msgstr "{0} ürünü devre dışı bırakıldı"
 
@@ -27461,7 +27451,7 @@ msgstr "{0} ürünü devre dışı bırakıldı"
 msgid "Item {0} is not a serialized Item"
 msgstr "Ürün {0} bir serileştirilmiş Ürün değildir"
 
-#: erpnext/stock/doctype/item/item.py:1138
+#: erpnext/stock/doctype/item/item.py:1132
 msgid "Item {0} is not a stock Item"
 msgstr "Ürün {0} bir stok ürünü değildir"
 
@@ -27505,7 +27495,7 @@ msgstr "{0} ürünü {1} adetten daha az sipariş edilemez. Bu ayar ürün sayfa
 msgid "Item {0}: {1} qty produced. "
 msgstr "{0} Ürünü {1} adet üretildi. "
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1429
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1423
 msgid "Item {} does not exist."
 msgstr "{0} Ürünü mevcut değil."
 
@@ -27645,7 +27635,7 @@ msgstr "Talep Edilen Ürünler"
 msgid "Items and Pricing"
 msgstr "Ürünler ve Fiyatlar"
 
-#: erpnext/controllers/accounts_controller.py:3872
+#: erpnext/controllers/accounts_controller.py:3875
 msgid "Items cannot be updated as Subcontracting Order is created against the Purchase Order {0}."
 msgstr "Alt Yüklenici Siparişi {0} Satın Alma Siparişine karşı oluşturulduğu için kalemler güncellenemez."
 
@@ -28141,7 +28131,7 @@ msgstr "İthalat Vergileri ve Masrafları"
 
 #. Name of a DocType
 #. Label of a Link in the Stock Workspace
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:674
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:676
 #: erpnext/stock/doctype/landed_cost_voucher/landed_cost_voucher.json
 #: erpnext/stock/doctype/purchase_receipt/purchase_receipt.js:104
 #: erpnext/stock/workspace/stock/stock.json
@@ -28757,7 +28747,7 @@ msgstr "Bağlı Faturalar"
 msgid "Linked Location"
 msgstr "Bağlantılı Konum"
 
-#: erpnext/stock/doctype/item/item.py:999
+#: erpnext/stock/doctype/item/item.py:993
 msgid "Linked with submitted documents"
 msgstr "Gönderilen belgelerle bağlantılı"
 
@@ -29496,7 +29486,7 @@ msgstr "Genel Müdür"
 #: erpnext/manufacturing/doctype/bom/bom.py:261
 #: erpnext/manufacturing/doctype/bom_update_log/bom_update_log.py:71
 #: erpnext/public/js/controllers/accounts.js:249
-#: erpnext/public/js/controllers/transaction.js:2753
+#: erpnext/public/js/controllers/transaction.js:2779
 #: erpnext/public/js/utils/party.js:321
 #: erpnext/stock/doctype/delivery_note/delivery_note.js:164
 #: erpnext/stock/doctype/inventory_dimension/inventory_dimension.json
@@ -30352,7 +30342,7 @@ msgstr "Maksimum kullanım"
 msgid "Maximum Value"
 msgstr "Maksimum Değer"
 
-#: erpnext/controllers/selling_controller.py:212
+#: erpnext/controllers/selling_controller.py:220
 msgid "Maximum discount for Item {0} is {1}%"
 msgstr "{0} Kalemi için maksimum indirim %{1} kadardır"
 
@@ -30422,7 +30412,7 @@ msgstr "Megajoule"
 msgid "Megawatt"
 msgstr "Megawatt"
 
-#: erpnext/stock/stock_ledger.py:1878
+#: erpnext/stock/stock_ledger.py:1887
 msgid "Mention Valuation Rate in the Item master."
 msgstr "Ürün ana verisinde Değerleme Oranını belirtin."
 
@@ -30817,11 +30807,11 @@ msgstr "Süreler"
 msgid "Miscellaneous Expenses"
 msgstr "Çeşitli Giderler"
 
-#: erpnext/controllers/buying_controller.py:540
+#: erpnext/controllers/buying_controller.py:548
 msgid "Mismatch"
 msgstr "Uyuşmazlık"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1430
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1424
 msgid "Missing"
 msgstr "Eksik"
 
@@ -31348,7 +31338,7 @@ msgstr "Çoklu Varyantlar"
 msgid "Multiple Warehouse Accounts"
 msgstr "Çoklu Depo Hesapları"
 
-#: erpnext/controllers/accounts_controller.py:1129
+#: erpnext/controllers/accounts_controller.py:1132
 msgid "Multiple fiscal years exist for the date {0}. Please set company in Fiscal Year"
 msgstr "{0} tarihi için birden fazla mali yıl var. Lütfen Mali Yıl'da şirketi ayarlayın"
 
@@ -31499,7 +31489,7 @@ msgstr "Seri Öneki Adlandırma"
 msgid "Naming Series and Price Defaults"
 msgstr "Adlandırma Serisi ve Fiyatlar"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:90
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:91
 msgid "Naming Series is mandatory"
 msgstr ""
 
@@ -31538,15 +31528,15 @@ msgstr "Doğal gaz"
 msgid "Needs Analysis"
 msgstr "İhtiyaç Analizi"
 
-#: erpnext/stock/serial_batch_bundle.py:1277
+#: erpnext/stock/serial_batch_bundle.py:1309
 msgid "Negative Batch Quantity"
 msgstr "Negatif Parti Miktarı"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:610
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:606
 msgid "Negative Quantity is not allowed"
 msgstr "Negatif Miktara izin verilmez"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:615
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:611
 msgid "Negative Valuation Rate is not allowed"
 msgstr "Negatif Değerleme Oranına izin verilmez"
 
@@ -31828,7 +31818,7 @@ msgstr "Net Ağırlığı"
 msgid "Net Weight UOM"
 msgstr "Net Ağırlık Ölçü Birimi"
 
-#: erpnext/controllers/accounts_controller.py:1483
+#: erpnext/controllers/accounts_controller.py:1486
 msgid "Net total calculation precision loss"
 msgstr "Net toplam hesaplama hassasiyet kaybı"
 
@@ -32171,7 +32161,7 @@ msgstr "POS Profili bulunamadı. Lütfen önce Yeni bir POS Profili oluşturun"
 #: erpnext/accounts/doctype/journal_entry/journal_entry.py:1539
 #: erpnext/accounts/doctype/journal_entry/journal_entry.py:1599
 #: erpnext/accounts/doctype/journal_entry/journal_entry.py:1613
-#: erpnext/stock/doctype/item/item.py:1371
+#: erpnext/stock/doctype/item/item.py:1365
 msgid "No Permission"
 msgstr "İzin yok"
 
@@ -32193,7 +32183,7 @@ msgstr "Açıklama Yok"
 msgid "No Selection"
 msgstr ""
 
-#: erpnext/controllers/sales_and_purchase_return.py:919
+#: erpnext/controllers/sales_and_purchase_return.py:824
 msgid "No Serial / Batches are available for return"
 msgstr "İade için Seri / Parti mevcut değil"
 
@@ -32229,7 +32219,7 @@ msgstr "Bu Cari için Uzlaşılmamış Ödeme bulunamadı"
 msgid "No Work Orders were created"
 msgstr "Hiçbir İş Emri oluşturulmadı"
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:785
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:794
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py:689
 msgid "No accounting entries for the following warehouses"
 msgstr "Aşağıdaki depolar için muhasebe kaydı yok"
@@ -32418,7 +32408,7 @@ msgstr "Ödemeler tablosunda kayıt bulunamadı"
 msgid "No reserved stock to unreserve."
 msgstr "Ayrılmış stok bulunmadığı için iptal edilecek stok yok."
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:773
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:769
 msgid "No stock ledger entries were created. Please set the quantity or valuation rate for the items properly and try again."
 msgstr ""
 
@@ -32502,7 +32492,7 @@ msgstr "Nos"
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:566
 #: erpnext/assets/doctype/asset/asset.js:612
 #: erpnext/assets/doctype/asset/asset.js:627
-#: erpnext/controllers/buying_controller.py:225
+#: erpnext/controllers/buying_controller.py:233
 #: erpnext/selling/doctype/product_bundle/product_bundle.py:72
 #: erpnext/setup/doctype/transaction_deletion_record/transaction_deletion_record.py:80
 msgid "Not Allowed"
@@ -32623,10 +32613,10 @@ msgstr "İzin Verilmedi"
 #: erpnext/selling/doctype/customer/customer.py:129
 #: erpnext/selling/doctype/sales_order/sales_order.js:1168
 #: erpnext/stock/doctype/item/item.js:526
-#: erpnext/stock/doctype/item/item.py:567
+#: erpnext/stock/doctype/item/item.py:573
 #: erpnext/stock/doctype/item_price/item_price.json
 #: erpnext/stock/doctype/stock_entry/stock_entry.py:1374
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:972
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:968
 #: erpnext/templates/pages/timelog_info.html:43
 msgid "Note"
 msgstr "Not"
@@ -32635,7 +32625,7 @@ msgstr "Not"
 msgid "Note: Automatic log deletion only applies to logs of type <i>Update Cost</i>"
 msgstr "Not: Otomatik kayıt silme yalnızca <i>Maliyet Güncelleme</i> türündeki kayıtlar için geçerlidir"
 
-#: erpnext/accounts/party.py:690
+#: erpnext/accounts/party.py:696
 msgid "Note: Due Date exceeds allowed {0} credit days by {1} day(s)"
 msgstr ""
 
@@ -32661,7 +32651,7 @@ msgstr "Not: 'Nakit veya Banka Hesabı' belirtilmediği için Ödeme Girişi olu
 msgid "Note: This Cost Center is a Group. Cannot make accounting entries against groups."
 msgstr "Not: Bu Maliyet Merkezi bir Gruptur. Gruplara karşı muhasebe girişleri yapılamaz."
 
-#: erpnext/stock/doctype/item/item.py:621
+#: erpnext/stock/doctype/item/item.py:627
 msgid "Note: To merge the items, create a separate Stock Reconciliation for the old item {0}"
 msgstr "Kalemleri birleştirmek istiyorsanız, eski kalem {0} için ayrı bir Stok Mutabakatı oluşturun"
 
@@ -33425,7 +33415,7 @@ msgstr "Açılış Satış Faturaları oluşturuldu."
 
 #. Label of the opening_stock (Float) field in DocType 'Item'
 #. Option for the 'Purpose' (Select) field in DocType 'Stock Reconciliation'
-#: erpnext/stock/doctype/item/item.json erpnext/stock/doctype/item/item.py:296
+#: erpnext/stock/doctype/item/item.json erpnext/stock/doctype/item/item.py:299
 #: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.json
 msgid "Opening Stock"
 msgstr "Açılış Stoku"
@@ -34145,7 +34135,7 @@ msgstr ""
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:149
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1123
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1125
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:167
 #: erpnext/accounts/report/purchase_register/purchase_register.py:289
 #: erpnext/accounts/report/sales_register/sales_register.py:319
@@ -34184,7 +34174,7 @@ msgstr "Giden"
 msgid "Over Billing Allowance (%)"
 msgstr "Fazla Fatura Ödeneği (%)"
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:1242
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:1251
 msgid "Over Billing Allowance exceeded for Purchase Receipt Item {0} ({1}) by {2}%"
 msgstr ""
 
@@ -34225,7 +34215,7 @@ msgstr "Fazla Transfer İzni (%)"
 msgid "Overbilling of {0} {1} ignored for item {2} because you have {3} role."
 msgstr "{3} rolüne sahip olduğunuz için {2} ürünü için {0} {1} fazla faturalandırma göz ardı edildi."
 
-#: erpnext/controllers/accounts_controller.py:2013
+#: erpnext/controllers/accounts_controller.py:2016
 msgid "Overbilling of {} ignored because you have {} role."
 msgstr "Rolünüz {} olduğu için {} fazla fatura türü göz ardı edildi."
 
@@ -34732,7 +34722,7 @@ msgstr "Ödenmiş"
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:146
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1117
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1119
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:165
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:172
 #: erpnext/accounts/report/pos_register/pos_register.py:209
@@ -34965,7 +34955,7 @@ msgstr "Ana Prosedür"
 msgid "Parent Row No"
 msgstr "Üst Satır No"
 
-#: erpnext/manufacturing/doctype/bom_creator/bom_creator.py:495
+#: erpnext/manufacturing/doctype/bom_creator/bom_creator.py:496
 msgid "Parent Row No not found for {0}"
 msgstr "Üst Satır No {0} için bulunamadı"
 
@@ -35194,7 +35184,7 @@ msgstr "Milyonda Parça Sayısı"
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:142
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:159
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:57
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1054
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1056
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:67
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:147
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:228
@@ -35220,7 +35210,7 @@ msgstr "Cari"
 
 #. Name of a DocType
 #: erpnext/accounts/doctype/party_account/party_account.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1065
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1067
 msgid "Party Account"
 msgstr "Cari Hesabı"
 
@@ -35247,7 +35237,7 @@ msgstr "Cari Hesabı Para Birimi"
 msgid "Party Account No. (Bank Statement)"
 msgstr "Taraf Hesap No. (Banka Hesap Özeti)"
 
-#: erpnext/controllers/accounts_controller.py:2278
+#: erpnext/controllers/accounts_controller.py:2281
 msgid "Party Account {0} currency ({1}) and document currency ({2}) should be same"
 msgstr "Cari Hesabı {0} para birimi ({1}) ve belge para birimi ({2}) aynı olmalıdır"
 
@@ -35264,6 +35254,11 @@ msgstr "Taraf Banka Hesabı"
 #: erpnext/accounts/doctype/payment_request/payment_request.json
 msgid "Party Details"
 msgstr "Taraf Detayları"
+
+#. Label of the party_full_name (Data) field in DocType 'Contract'
+#: erpnext/crm/doctype/contract/contract.json
+msgid "Party Full Name"
+msgstr ""
 
 #. Label of the bank_party_iban (Data) field in DocType 'Bank Transaction'
 #: erpnext/accounts/doctype/bank_transaction/bank_transaction.json
@@ -35348,7 +35343,7 @@ msgstr "Partiye Özel Ürün"
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:84
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:54
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:44
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1048
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1050
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:54
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:141
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:219
@@ -35370,7 +35365,7 @@ msgstr "Partiye Özel Ürün"
 msgid "Party Type"
 msgstr "Cari Türü"
 
-#: erpnext/accounts/party.py:819
+#: erpnext/accounts/party.py:825
 msgid "Party Type and Party can only be set for Receivable / Payable account<br><br>{0}"
 msgstr "Cari ve Cari Türü yalnızca Alacaklı / Borçlu hesaplar için ayarlanabilir<br><br>{0}"
 
@@ -35492,7 +35487,7 @@ msgid "Payable"
 msgstr "Ödenecek Borç"
 
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:42
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1063
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1065
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:211
 #: erpnext/accounts/report/purchase_register/purchase_register.py:194
 #: erpnext/accounts/report/purchase_register/purchase_register.py:235
@@ -35658,7 +35653,7 @@ msgstr "Ödeme Girişi, aldıktan sonra değiştirildi. Lütfen tekrar alın."
 msgid "Payment Entry is already created"
 msgstr "Ödeme Girişi zaten oluşturuldu"
 
-#: erpnext/controllers/accounts_controller.py:1434
+#: erpnext/controllers/accounts_controller.py:1437
 msgid "Payment Entry {0} is linked against Order {1}, check if it should be pulled as advance in this invoice."
 msgstr "Ödeme Girişi {0}, Sipariş {1} ile bağlantılı. Bu ödemenin bu faturada avans olarak kullanılıp kullanılmayacağını kontrol edin."
 
@@ -35940,7 +35935,7 @@ msgstr ""
 #: erpnext/accounts/doctype/payment_schedule/payment_schedule.json
 #: erpnext/accounts/doctype/payment_term/payment_term.json
 #: erpnext/accounts/doctype/payment_terms_template_detail/payment_terms_template_detail.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1113
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1115
 #: erpnext/accounts/report/gross_profit/gross_profit.py:412
 #: erpnext/accounts/workspace/accounting/accounting.json
 #: erpnext/selling/report/payment_terms_status_for_sales_order/payment_terms_status_for_sales_order.py:30
@@ -37004,7 +36999,7 @@ msgstr "Lütfen ‘Stok Güncelle’ seçeneği etkin olan faturalar için İndi
 msgid "Please create a new Accounting Dimension if required."
 msgstr "Gerekirse lütfen yeni bir Muhasebe Boyutu oluşturun."
 
-#: erpnext/controllers/accounts_controller.py:729
+#: erpnext/controllers/accounts_controller.py:732
 msgid "Please create purchase from internal sale or delivery document itself"
 msgstr "Lütfen satın alma işlemini dahili satış veya teslimat belgesinin kendisinden oluşturun"
 
@@ -37012,7 +37007,7 @@ msgstr "Lütfen satın alma işlemini dahili satış veya teslimat belgesinin ke
 msgid "Please create purchase receipt or purchase invoice for the item {0}"
 msgstr "Lütfen {0} ürünü için alış irsaliyesi veya alış faturası alın"
 
-#: erpnext/stock/doctype/item/item.py:649
+#: erpnext/stock/doctype/item/item.py:655
 msgid "Please delete Product Bundle {0}, before merging {1} into {2}"
 msgstr "Lütfen {1} adresini {2} adresiyle birleştirmeden önce {0} Ürün Paketini silin"
 
@@ -37054,7 +37049,7 @@ msgstr "Lütfen açılır pencereleri etkinleştirin"
 msgid "Please enable {0} in the {1}."
 msgstr "Lütfen {1} içindeki {0} öğesini etkinleştirin."
 
-#: erpnext/controllers/selling_controller.py:754
+#: erpnext/controllers/selling_controller.py:762
 msgid "Please enable {} in {} to allow same item in multiple rows"
 msgstr "Aynı öğeye birden fazla satırda izin vermek için lütfen {} içinde {} ayarını etkinleştirin"
 
@@ -37087,7 +37082,7 @@ msgstr "Değişim Miktarı Hesabı girin"
 msgid "Please enter Approving Role or Approving User"
 msgstr "Lütfen Onaylayan Rolü veya Onaylayan Kullanıcıyı girin"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:939
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:935
 msgid "Please enter Cost Center"
 msgstr "Lütfen maliyet merkezini girin"
 
@@ -37099,7 +37094,7 @@ msgstr "Lütfen Teslimat Tarihini giriniz"
 msgid "Please enter Employee Id of this sales person"
 msgstr "Lütfen bu satış elemanının Personel Kimliğini girin"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:948
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:944
 msgid "Please enter Expense Account"
 msgstr "Lütfen Gider Hesabını girin"
 
@@ -37108,7 +37103,7 @@ msgstr "Lütfen Gider Hesabını girin"
 msgid "Please enter Item Code to get Batch Number"
 msgstr "Parti Numarasını almak için lütfen Ürün Kodunu girin"
 
-#: erpnext/public/js/controllers/transaction.js:2503
+#: erpnext/public/js/controllers/transaction.js:2529
 msgid "Please enter Item Code to get batch no"
 msgstr "Parti numarasını almak için lütfen Ürün Kodunu girin"
 
@@ -37173,7 +37168,7 @@ msgstr "Lütfen ilk önce şirketi girin"
 msgid "Please enter company name first"
 msgstr "Lütfen önce şirket adını girin"
 
-#: erpnext/controllers/accounts_controller.py:2764
+#: erpnext/controllers/accounts_controller.py:2767
 msgid "Please enter default currency in Company Master"
 msgstr "Lütfen Şirket Ana Verisi'ne varsayılan para birimini girin"
 
@@ -37209,7 +37204,7 @@ msgstr "Lütfen onaylamak için şirket adını girin"
 msgid "Please enter the phone number first"
 msgstr "Lütfen önce telefon numaranızı giriniz"
 
-#: erpnext/controllers/buying_controller.py:1007
+#: erpnext/controllers/buying_controller.py:1015
 msgid "Please enter the {schedule_date}."
 msgstr ""
 
@@ -37311,7 +37306,7 @@ msgstr "Lütfen önce kaydedin"
 msgid "Please select <b>Template Type</b> to download template"
 msgstr "Şablonu indirmek için lütfen <b>Şablon Türünü</b> seçin"
 
-#: erpnext/controllers/taxes_and_totals.py:721
+#: erpnext/controllers/taxes_and_totals.py:731
 #: erpnext/public/js/controllers/taxes_and_totals.js:721
 msgid "Please select Apply Discount On"
 msgstr "Lütfen indirim uygula seçeneğini belirleyin"
@@ -37324,7 +37319,7 @@ msgstr "Lütfen {0} Ürününe karşı Ürün Ağacını Seçin"
 msgid "Please select BOM for Item in Row {0}"
 msgstr "Lütfen {0} satırındaki ürün için Ürün Ağacını seçin"
 
-#: erpnext/controllers/buying_controller.py:467
+#: erpnext/controllers/buying_controller.py:475
 msgid "Please select BOM in BOM field for Item {item_code}."
 msgstr "Lütfen {item_code} Ürünü için Ürün Ağacını seçin."
 
@@ -37406,7 +37401,7 @@ msgstr "Lütfen Fiyat Listesini Seçin"
 msgid "Please select Qty against item {0}"
 msgstr "Lütfen {0} ürünü için miktar seçin"
 
-#: erpnext/stock/doctype/item/item.py:320
+#: erpnext/stock/doctype/item/item.py:323
 msgid "Please select Sample Retention Warehouse in Stock Settings first"
 msgstr "Lütfen önce Stok Ayarlarında Numune Saklama Deposunu seçin"
 
@@ -37422,7 +37417,7 @@ msgstr "Ürün {0} için Başlangıç ve Bitiş tarihini seçiniz"
 msgid "Please select Subcontracting Order instead of Purchase Order {0}"
 msgstr "Lütfen Satın Alma Siparişi yerine Alt Yüklenici Siparişini seçin {0}"
 
-#: erpnext/controllers/accounts_controller.py:2613
+#: erpnext/controllers/accounts_controller.py:2616
 msgid "Please select Unrealized Profit / Loss account or add default Unrealized Profit / Loss account account for company {0}"
 msgstr "Lütfen Gerçekleşmemiş Kâr / Zarar hesabını seçin veya {0} şirketi için varsayılan Gerçekleşmemiş Kâr / Zarar hesabı hesabını ekleyin"
 
@@ -37438,7 +37433,7 @@ msgstr "Bir Şirket Seçiniz"
 #: erpnext/manufacturing/doctype/bom/bom.js:603
 #: erpnext/manufacturing/doctype/bom/bom.py:261
 #: erpnext/public/js/controllers/accounts.js:249
-#: erpnext/public/js/controllers/transaction.js:2753
+#: erpnext/public/js/controllers/transaction.js:2779
 msgid "Please select a Company first."
 msgstr "Lütfen önce bir Şirket seçin."
 
@@ -37596,7 +37591,7 @@ msgstr "Lütfen {0} seçin"
 msgid "Please select {0} first"
 msgstr "Lütfen Önce {0} Seçin"
 
-#: erpnext/public/js/controllers/transaction.js:77
+#: erpnext/public/js/controllers/transaction.js:100
 msgid "Please set 'Apply Additional Discount On'"
 msgstr "Lütfen 'Ek İndirim Uygula' seçeneğini ayarlayın"
 
@@ -37781,7 +37776,7 @@ msgstr "Lütfen filtreyi Ürüne veya Depoya göre ayarlayın"
 msgid "Please set filters"
 msgstr "Lütfen filtreleri ayarlayın"
 
-#: erpnext/controllers/accounts_controller.py:2194
+#: erpnext/controllers/accounts_controller.py:2197
 msgid "Please set one of the following:"
 msgstr "Lütfen aşağıdakilerden birini ayarlayın:"
 
@@ -37789,7 +37784,7 @@ msgstr "Lütfen aşağıdakilerden birini ayarlayın:"
 msgid "Please set opening number of booked depreciations"
 msgstr ""
 
-#: erpnext/public/js/controllers/transaction.js:2205
+#: erpnext/public/js/controllers/transaction.js:2231
 msgid "Please set recurring after saving"
 msgstr "Lütfen kaydettikten sonra yinelemeyi ayarlayın"
 
@@ -37860,7 +37855,7 @@ msgstr "Lütfen {1} şirketi için Hesap Türü {0} olan bir grup hesabı kurun 
 msgid "Please share this email with your support team so that they can find and fix the issue."
 msgstr "Sorunu bulup çözebilmeleri için lütfen bu e-postayı destek ekibinizle paylaşın."
 
-#: erpnext/public/js/controllers/transaction.js:2073
+#: erpnext/public/js/controllers/transaction.js:2099
 msgid "Please specify"
 msgstr "Lütfen belirtin"
 
@@ -37875,7 +37870,7 @@ msgid "Please specify Company to proceed"
 msgstr "Lütfen devam etmek için Şirketi belirtin"
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1472
-#: erpnext/controllers/accounts_controller.py:2957
+#: erpnext/controllers/accounts_controller.py:2960
 #: erpnext/public/js/controllers/accounts.js:97
 msgid "Please specify a valid Row ID for row {0} in table {1}"
 msgstr "Lütfen {1} tablosundaki {0} satırında geçerli bir Satır Kimliği belirtin"
@@ -37888,7 +37883,7 @@ msgstr "Lütfen önce bir {0} belirtin."
 msgid "Please specify at least one attribute in the Attributes table"
 msgstr "Lütfen Özellikler tablosunda en az bir özelliği belirtin"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:605
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:601
 msgid "Please specify either Quantity or Valuation Rate or both"
 msgstr "Miktar veya Birim Fiyatı ya da her ikisini de belirtiniz"
 
@@ -38069,7 +38064,7 @@ msgstr "Posta Giderleri"
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:16
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:15
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:18
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1046
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1048
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:15
 #: erpnext/accounts/report/bank_clearance_summary/bank_clearance_summary.py:35
 #: erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.html:7
@@ -40250,7 +40245,7 @@ msgstr "Satın Alma Genel Müdürü"
 #: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.js:48
 #: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:203
 #: erpnext/buying/workspace/buying/buying.json
-#: erpnext/controllers/buying_controller.py:739
+#: erpnext/controllers/buying_controller.py:747
 #: erpnext/crm/doctype/contract/contract.json
 #: erpnext/manufacturing/doctype/blanket_order/blanket_order.js:54
 #: erpnext/manufacturing/doctype/production_plan_sub_assembly_item/production_plan_sub_assembly_item.json
@@ -40389,7 +40384,7 @@ msgstr "Faturalanacak Satınalma Siparişleri"
 msgid "Purchase Orders to Receive"
 msgstr "Alınacak Satınalma Siparişleri"
 
-#: erpnext/controllers/accounts_controller.py:1833
+#: erpnext/controllers/accounts_controller.py:1836
 msgid "Purchase Orders {0} are un-linked"
 msgstr "Satın Alma Siparişleri {0} bağlantısı kaldırıldı"
 
@@ -40413,8 +40408,8 @@ msgstr "Satın Alma Fiyat Listesi"
 #. Label of a Link in the Stock Workspace
 #. Label of a shortcut in the Stock Workspace
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:171
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:650
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:660
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:652
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:662
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice_list.js:49
 #: erpnext/accounts/doctype/purchase_invoice_item/purchase_invoice_item.json
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:246
@@ -41149,7 +41144,7 @@ msgstr "Kalite Kontrol Şablonu"
 msgid "Quality Inspection Template Name"
 msgstr "Kalite Kontrol Şablonu Adı"
 
-#: erpnext/public/js/controllers/transaction.js:334
+#: erpnext/public/js/controllers/transaction.js:360
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:165
 msgid "Quality Inspection(s)"
 msgstr "Kalite Kontrolleri"
@@ -42333,7 +42328,7 @@ msgid "Receivable / Payable Account"
 msgstr "Alacak / Borç Hesabı"
 
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:71
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1061
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1063
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py:243
 #: erpnext/accounts/report/sales_register/sales_register.py:217
 #: erpnext/accounts/report/sales_register/sales_register.py:271
@@ -42815,7 +42810,7 @@ msgstr "Referans #{0} tarih {1}"
 msgid "Reference Date"
 msgstr "Referans Tarihi"
 
-#: erpnext/public/js/controllers/transaction.js:2311
+#: erpnext/public/js/controllers/transaction.js:2337
 msgid "Reference Date for Early Payment Discount"
 msgstr "Erken Ödeme İndirimi için Referans Tarihi"
 
@@ -43139,7 +43134,7 @@ msgstr "Düzenli"
 msgid "Rejected"
 msgstr "Reddedildi"
 
-#: erpnext/stock/doctype/inventory_dimension/inventory_dimension.py:202
+#: erpnext/stock/doctype/inventory_dimension/inventory_dimension.py:203
 msgid "Rejected "
 msgstr "Reddedildi "
 
@@ -43243,7 +43238,7 @@ msgstr ""
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:187
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:156
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1135
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1137
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:178
 msgid "Remaining Balance"
 msgstr "Kalan Bakiye"
@@ -43296,7 +43291,7 @@ msgstr "Açıklama"
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:159
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:198
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:269
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1167
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1169
 #: erpnext/accounts/report/general_ledger/general_ledger.html:84
 #: erpnext/accounts/report/general_ledger/general_ledger.html:110
 #: erpnext/accounts/report/general_ledger/general_ledger.py:742
@@ -44045,7 +44040,7 @@ msgstr "Ayrılan Miktar"
 msgid "Reserved Quantity for Production"
 msgstr "Üretim İçin Ayrılan Miktar"
 
-#: erpnext/stock/stock_ledger.py:2147
+#: erpnext/stock/stock_ledger.py:2155
 msgid "Reserved Serial No."
 msgstr "Ayrılmış Seri No."
 
@@ -44061,11 +44056,11 @@ msgstr "Ayrılmış Seri No."
 #: erpnext/stock/doctype/pick_list/pick_list.js:153
 #: erpnext/stock/report/reserved_stock/reserved_stock.json
 #: erpnext/stock/report/stock_balance/stock_balance.py:499
-#: erpnext/stock/stock_ledger.py:2131
+#: erpnext/stock/stock_ledger.py:2139
 msgid "Reserved Stock"
 msgstr "Ayrılmış Stok"
 
-#: erpnext/stock/stock_ledger.py:2177
+#: erpnext/stock/stock_ledger.py:2185
 msgid "Reserved Stock for Batch"
 msgstr "Parti için Ayrılmış Stok"
 
@@ -44077,7 +44072,7 @@ msgstr ""
 msgid "Reserved Stock for Sub-assembly"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:476
+#: erpnext/controllers/buying_controller.py:484
 msgid "Reserved Warehouse is mandatory for the Item {item_code} in Raw Materials supplied."
 msgstr ""
 
@@ -44891,7 +44886,7 @@ msgstr "Rota"
 msgid "Routing Name"
 msgstr "Rota İsmi"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:667
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:663
 msgid "Row #"
 msgstr "Satır #"
 
@@ -44929,7 +44924,7 @@ msgstr "Satır #{0} (Ödeme Tablosu): Tutar negatif olmalıdır"
 msgid "Row #{0} (Payment Table): Amount must be positive"
 msgstr "Satır #{0} (Ödeme Tablosu): Tutar pozitif olmalıdır"
 
-#: erpnext/stock/doctype/item/item.py:495
+#: erpnext/stock/doctype/item/item.py:498
 msgid "Row #{0}: A reorder entry already exists for warehouse {1} with reorder type {2}."
 msgstr "Satır #{0}: {1} deposu için {2} yeniden sipariş türüyle zaten yeniden bir sipariş girişi mevcut."
 
@@ -44950,7 +44945,7 @@ msgstr "Satır #{0}: Kabul Deposu ve Red Deposu aynı olamaz"
 msgid "Row #{0}: Accepted Warehouse is mandatory for the accepted Item {1}"
 msgstr "Satır #{0}: Kabul Deposu, kabul edilen {1} Ürünü için zorunludur"
 
-#: erpnext/controllers/accounts_controller.py:1117
+#: erpnext/controllers/accounts_controller.py:1120
 msgid "Row #{0}: Account {1} does not belong to company {2}"
 msgstr "Sıra # {0}: Hesap {1}, şirkete {2} ait değil"
 
@@ -44991,27 +44986,27 @@ msgstr "Satır #{0}: Parti No {1} zaten seçili."
 msgid "Row #{0}: Cannot allocate more than {1} against payment term {2}"
 msgstr "Satır #{0}: Ödeme süresi {2} için {1} değerinden daha fazla tahsis edilemez"
 
-#: erpnext/controllers/accounts_controller.py:3524
+#: erpnext/controllers/accounts_controller.py:3527
 msgid "Row #{0}: Cannot delete item {1} which has already been billed."
 msgstr "Satır #{0}: Zaten faturalandırılmış olan {1} kalemi silinemiyor."
 
-#: erpnext/controllers/accounts_controller.py:3498
+#: erpnext/controllers/accounts_controller.py:3501
 msgid "Row #{0}: Cannot delete item {1} which has already been delivered"
 msgstr "Satır #{0}: Zaten teslim edilmiş olan {1} kalem silinemiyor"
 
-#: erpnext/controllers/accounts_controller.py:3517
+#: erpnext/controllers/accounts_controller.py:3520
 msgid "Row #{0}: Cannot delete item {1} which has already been received"
 msgstr "Satır #{0}: Daha önce alınmış olan {1} kalem silinemiyor"
 
-#: erpnext/controllers/accounts_controller.py:3504
+#: erpnext/controllers/accounts_controller.py:3507
 msgid "Row #{0}: Cannot delete item {1} which has work order assigned to it."
 msgstr "Satır # {0}: İş emri atanmış {1} kalem silinemez."
 
-#: erpnext/controllers/accounts_controller.py:3510
+#: erpnext/controllers/accounts_controller.py:3513
 msgid "Row #{0}: Cannot delete item {1} which is assigned to customer's purchase order."
 msgstr "Satır #{0}: Müşterinin satın alma siparişine atanmış olan {1} kalem silinemiyor."
 
-#: erpnext/controllers/accounts_controller.py:3765
+#: erpnext/controllers/accounts_controller.py:3768
 msgid "Row #{0}: Cannot set Rate if the billed amount is greater than the amount for Item {1}."
 msgstr ""
 
@@ -45131,7 +45126,7 @@ msgstr "Satır #{0}: {1} öğesi mevcut değil"
 msgid "Row #{0}: Item {1} has been picked, please reserve stock from the Pick List."
 msgstr "Satır #{0}: Ürün {1} toplandı, lütfen Toplama Listesinden stok ayırın."
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:729
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:725
 msgid "Row #{0}: Item {1} is not a Serialized/Batched Item. It cannot have a Serial No/Batch No against it."
 msgstr "Satır #{0}: Ürün {1}, Serili/Partili bir ürün değil. Seri No/Parti No’su atanamaz."
 
@@ -45187,7 +45182,7 @@ msgstr "Satır #{0}: Lütfen Montaj Kalemleri için Ürün Ağacı No'yu seçin"
 msgid "Row #{0}: Please select the Sub Assembly Warehouse"
 msgstr "Satır #{0}: Lütfen Alt Montaj Deposunu seçin"
 
-#: erpnext/stock/doctype/item/item.py:502
+#: erpnext/stock/doctype/item/item.py:505
 msgid "Row #{0}: Please set reorder quantity"
 msgstr "Satır #{0}: Lütfen yeniden sipariş miktarını ayarlayın"
 
@@ -45220,8 +45215,8 @@ msgstr "Satır #{0}: {1} Kalite Kontrol {2} Ürünü için gönderilmemiş"
 msgid "Row #{0}: Quality Inspection {1} was rejected for item {2}"
 msgstr "Satır #{0}: {1} Kalite Kontrolü {2} Ürünü için reddedildi"
 
-#: erpnext/controllers/accounts_controller.py:1274
-#: erpnext/controllers/accounts_controller.py:3624
+#: erpnext/controllers/accounts_controller.py:1277
+#: erpnext/controllers/accounts_controller.py:3627
 msgid "Row #{0}: Quantity for Item {1} cannot be zero."
 msgstr "Satır #{0}: {1} kalemi için miktar sıfır olamaz."
 
@@ -45258,7 +45253,7 @@ msgstr ""
 msgid "Row #{0}: Scrap Item Qty cannot be zero"
 msgstr "Satır #{0}: Hurda Ürün Miktarı sıfır olamaz"
 
-#: erpnext/controllers/selling_controller.py:230
+#: erpnext/controllers/selling_controller.py:238
 msgid "Row #{0}: Selling rate for item {1} is lower than its {2}.\n"
 "\t\t\t\t\tSelling {3} should be atleast {4}.<br><br>Alternatively,\n"
 "\t\t\t\t\tyou can disable selling price validation in {5} to bypass\n"
@@ -45345,7 +45340,7 @@ msgstr "Satır #{0}: {2} Deposundaki {1} Ürünü için rezerve edilecek stok me
 msgid "Row #{0}: The batch {1} has already expired."
 msgstr "Satır #{0}: {1} grubu zaten sona erdi."
 
-#: erpnext/stock/doctype/item/item.py:511
+#: erpnext/stock/doctype/item/item.py:514
 msgid "Row #{0}: The warehouse {1} is not a child warehouse of a group warehouse {2}"
 msgstr "Satır #{0}: {1} deposu, {2} grup deposunun alt deposu değildir."
 
@@ -45385,39 +45380,39 @@ msgstr "Satır #{0}: {1}/{2} değeri {3} olmalıdır. Lütfen {1} alanını gün
 msgid "Row #{1}: Warehouse is mandatory for stock Item {0}"
 msgstr "Satır #{1}: {0} Stok Ürünü için Depo zorunludur"
 
-#: erpnext/controllers/buying_controller.py:259
+#: erpnext/controllers/buying_controller.py:267
 msgid "Row #{idx}: Cannot select Supplier Warehouse while suppling raw materials to subcontractor."
 msgstr "Satır #{idx}: Alt yükleniciye hammadde tedarik ederken Tedarikçi Deposu seçilemez."
 
-#: erpnext/controllers/buying_controller.py:406
+#: erpnext/controllers/buying_controller.py:414
 msgid "Row #{idx}: Item rate has been updated as per valuation rate since its an internal stock transfer."
 msgstr "Satır #{idx}: Ürün oranı, dahili bir stok transferi olduğu için değerleme oranına göre güncellenmiştir."
 
-#: erpnext/controllers/buying_controller.py:881
+#: erpnext/controllers/buying_controller.py:889
 msgid "Row #{idx}: Please enter a location for the asset item {item_code}."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:537
+#: erpnext/controllers/buying_controller.py:545
 msgid "Row #{idx}: Received Qty must be equal to Accepted + Rejected Qty for Item {item_code}."
 msgstr "Satır #{idx}: Alınan Miktar, {item_code} Kalemi için Kabul Edilen + Reddedilen Miktara eşit olmalıdır."
 
-#: erpnext/controllers/buying_controller.py:550
+#: erpnext/controllers/buying_controller.py:558
 msgid "Row #{idx}: {field_label} can not be negative for item {item_code}."
 msgstr "Satır #{idx}: {field_label} kalemi {item_code} için negatif olamaz."
 
-#: erpnext/controllers/buying_controller.py:496
+#: erpnext/controllers/buying_controller.py:504
 msgid "Row #{idx}: {field_label} is mandatory."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:518
+#: erpnext/controllers/buying_controller.py:526
 msgid "Row #{idx}: {field_label} is not allowed in Purchase Return."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:250
+#: erpnext/controllers/buying_controller.py:258
 msgid "Row #{idx}: {from_warehouse_field} and {to_warehouse_field} cannot be same."
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:999
+#: erpnext/controllers/buying_controller.py:1007
 msgid "Row #{idx}: {schedule_date} cannot be before {transaction_date}."
 msgstr ""
 
@@ -45482,7 +45477,7 @@ msgstr "Satır #{}: {}"
 msgid "Row #{}: {} {} does not exist."
 msgstr "Satır #{}: {} {} mevcut değil."
 
-#: erpnext/stock/doctype/item/item.py:1403
+#: erpnext/stock/doctype/item/item.py:1397
 msgid "Row #{}: {} {} doesn't belong to Company {}. Please select valid {}."
 msgstr "Satır #{}: {} {}, {} Şirketine ait değil. Lütfen geçerli {} seçin."
 
@@ -45554,11 +45549,11 @@ msgstr "Satır {0}: {1} Ürünü için Ürün Ağacı bulunamadı"
 msgid "Row {0}: Both Debit and Credit values cannot be zero"
 msgstr "Satır {0}: Hem Borç hem de Alacak değerleri sıfır olamaz"
 
-#: erpnext/controllers/selling_controller.py:222
+#: erpnext/controllers/selling_controller.py:230
 msgid "Row {0}: Conversion Factor is mandatory"
 msgstr "Satır {0}: Dönüşüm Faktörü zorunludur"
 
-#: erpnext/controllers/accounts_controller.py:2995
+#: erpnext/controllers/accounts_controller.py:2998
 msgid "Row {0}: Cost Center {1} does not belong to Company {2}"
 msgstr "Satır {0}: Maliyet Merkezi {1} {2} şirketine ait değil"
 
@@ -45578,11 +45573,11 @@ msgstr "Satır {0}: Ürün Ağacı #{1} para birimi, seçilen para birimi {2} il
 msgid "Row {0}: Debit entry can not be linked with a {1}"
 msgstr "Satır {0}: Borç girişi {1} ile ilişkilendirilemez"
 
-#: erpnext/controllers/selling_controller.py:776
+#: erpnext/controllers/selling_controller.py:784
 msgid "Row {0}: Delivery Warehouse ({1}) and Customer Warehouse ({2}) can not be same"
 msgstr "Satır {0}: Teslimat Deposu ({1}) ve Müşteri Deposu ({2}) aynı olamaz"
 
-#: erpnext/controllers/accounts_controller.py:2529
+#: erpnext/controllers/accounts_controller.py:2532
 msgid "Row {0}: Due Date in the Payment Terms table cannot be before Posting Date"
 msgstr "Satır {0}: Ödeme Koşulları tablosundaki Son Tarih, Gönderim Tarihinden önce olamaz"
 
@@ -45591,7 +45586,7 @@ msgid "Row {0}: Either Delivery Note Item or Packed Item reference is mandatory.
 msgstr "Satır {0}: Ya İrsaliye Kalemi ya da Paketlenmiş Kalem referansı zorunludur."
 
 #: erpnext/accounts/doctype/journal_entry/journal_entry.py:1010
-#: erpnext/controllers/taxes_and_totals.py:1205
+#: erpnext/controllers/taxes_and_totals.py:1215
 msgid "Row {0}: Exchange Rate is mandatory"
 msgstr "Satır {0}: Döviz Kuru zorunludur"
 
@@ -45640,11 +45635,11 @@ msgstr "Satır {0}: Saat değeri sıfırdan büyük olmalıdır."
 msgid "Row {0}: Invalid reference {1}"
 msgstr "Satır {0}: Geçersiz referans {1}"
 
-#: erpnext/controllers/taxes_and_totals.py:142
+#: erpnext/controllers/taxes_and_totals.py:143
 msgid "Row {0}: Item Tax template updated as per validity and rate applied"
 msgstr "Satır {0}: Ürün Vergi şablonu geçerliliğe ve uygulanan orana göre güncellendi"
 
-#: erpnext/controllers/selling_controller.py:541
+#: erpnext/controllers/selling_controller.py:549
 msgid "Row {0}: Item rate has been updated as per valuation rate since its an internal stock transfer"
 msgstr "Satır {0}: Ürün oranı, dahili bir stok transferi olduğu için değerleme oranına göre güncellenmiştir"
 
@@ -45764,7 +45759,7 @@ msgstr "Satır {0}: Görev {1}, {2} Projesine ait değil"
 msgid "Row {0}: The item {1}, quantity must be positive number"
 msgstr "Satır {0}: Ürün {1} için miktar pozitif sayı olmalıdır"
 
-#: erpnext/controllers/accounts_controller.py:2972
+#: erpnext/controllers/accounts_controller.py:2975
 msgid "Row {0}: The {3} Account {1} does not belong to the company {2}"
 msgstr "Satır {0}: {3} Hesabı {1} {2} şirketine ait değildir"
 
@@ -45781,7 +45776,7 @@ msgstr "Satır {0}: Ölçü Birimi Dönüşüm Faktörü zorunludur"
 msgid "Row {0}: Workstation or Workstation Type is mandatory for an operation {1}"
 msgstr "Satır {0}: Bir Operasyon için İş İstasyonu veya İş İstasyonu Türü zorunludur {1}"
 
-#: erpnext/controllers/accounts_controller.py:1011
+#: erpnext/controllers/accounts_controller.py:1014
 msgid "Row {0}: user has not applied the rule {1} on the item {2}"
 msgstr "Satır {0}: kullanıcı {2} öğesinde {1} kuralını uygulamadı"
 
@@ -45793,7 +45788,7 @@ msgstr "Satır {0}: {1} hesabı zaten Muhasebe Boyutu {2} için başvurdu"
 msgid "Row {0}: {1} must be greater than 0"
 msgstr "Satır {0}: {1} 0'dan büyük olmalıdır"
 
-#: erpnext/controllers/accounts_controller.py:706
+#: erpnext/controllers/accounts_controller.py:709
 msgid "Row {0}: {1} {2} cannot be same as {3} (Party Account) {4}"
 msgstr "Satır {0}: {1} {2} , {3} (Cari Hesabı) {4} ile aynı olamaz"
 
@@ -45809,7 +45804,7 @@ msgstr "Satır {0}: {2} Öğe {1} {2} {3} içinde mevcut değil"
 msgid "Row {1}: Quantity ({0}) cannot be a fraction. To allow this, disable '{2}' in UOM {3}."
 msgstr "Satır {1}: Miktar ({0}) kesirli olamaz. Bunu etkinleştirmek için, {3} Ölçü Biriminde ‘{2}’ seçeneğini devre dışı bırakın."
 
-#: erpnext/controllers/buying_controller.py:863
+#: erpnext/controllers/buying_controller.py:871
 msgid "Row {idx}: Asset Naming Series is mandatory for the auto creation of assets for item {item_code}."
 msgstr ""
 
@@ -45835,7 +45830,7 @@ msgstr "{0} İçinde Silinen Satırlar"
 msgid "Rows with Same Account heads will be merged on Ledger"
 msgstr "Aynı Hesap Başlığına sahip satırlar, Muhasebe Defterinde birleştirilecektir."
 
-#: erpnext/controllers/accounts_controller.py:2539
+#: erpnext/controllers/accounts_controller.py:2542
 msgid "Rows with duplicate due dates in other rows were found: {0}"
 msgstr "Diğer satırlardaki yinelenen teslim dosyalarına sahip satırlar bulundu: {0}"
 
@@ -45905,7 +45900,7 @@ msgstr "SLA Gerçekleştirildi Durumu"
 msgid "SLA Paused On"
 msgstr "SLA Duraklatıldığı Tarih"
 
-#: erpnext/public/js/utils.js:1167
+#: erpnext/public/js/utils.js:1163
 msgid "SLA is on hold since {0}"
 msgstr "SLA {0} tarihinden beri beklemede"
 
@@ -46306,7 +46301,7 @@ msgstr "Kaynağa Göre Satış Fırsatları"
 #: erpnext/accounts/report/sales_register/sales_register.py:238
 #: erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
 #: erpnext/buying/doctype/supplier_quotation_item/supplier_quotation_item.json
-#: erpnext/controllers/selling_controller.py:462
+#: erpnext/controllers/selling_controller.py:470
 #: erpnext/crm/doctype/contract/contract.json
 #: erpnext/maintenance/doctype/maintenance_schedule/maintenance_schedule.js:65
 #: erpnext/maintenance/doctype/maintenance_schedule_item/maintenance_schedule_item.json
@@ -46432,7 +46427,7 @@ msgstr "Satış Siparişi {0} kaydedilmedi"
 msgid "Sales Order {0} is not valid"
 msgstr "Satış Sipariş {0} geçerli değildir"
 
-#: erpnext/controllers/selling_controller.py:443
+#: erpnext/controllers/selling_controller.py:451
 #: erpnext/manufacturing/doctype/work_order/work_order.py:301
 msgid "Sales Order {0} is {1}"
 msgstr "Satış Sipariş {0} {1}"
@@ -46483,7 +46478,7 @@ msgstr "Teslim Edilecek Satış Siparişleri"
 #: erpnext/accounts/doctype/promotional_scheme/promotional_scheme.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:122
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1156
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1158
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:99
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:194
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:74
@@ -46581,7 +46576,7 @@ msgstr "Satış Ödeme Özeti"
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:156
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:137
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:128
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1153
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1155
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:105
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:191
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:80
@@ -46601,7 +46596,7 @@ msgstr "Satış Ödeme Özeti"
 msgid "Sales Person"
 msgstr "Satış Personeli"
 
-#: erpnext/controllers/selling_controller.py:204
+#: erpnext/controllers/selling_controller.py:212
 msgid "Sales Person <b>{0}</b> is disabled."
 msgstr "Satış Personeli <b>{0}</b> devre dışı bırakıldı."
 
@@ -46882,7 +46877,7 @@ msgstr "Numune Saklama Deposu"
 
 #. Label of the sample_size (Float) field in DocType 'Quality Inspection'
 #: erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py:93
-#: erpnext/public/js/controllers/transaction.js:2369
+#: erpnext/public/js/controllers/transaction.js:2395
 #: erpnext/stock/doctype/quality_inspection/quality_inspection.json
 msgid "Sample Size"
 msgstr "Numune Boyutu"
@@ -47422,7 +47417,7 @@ msgstr "Ürünleri Seçin"
 msgid "Select Items based on Delivery Date"
 msgstr "Ürünleri Teslimat Tarihine Göre Seçin"
 
-#: erpnext/public/js/controllers/transaction.js:2405
+#: erpnext/public/js/controllers/transaction.js:2431
 msgid "Select Items for Quality Inspection"
 msgstr "Kalite Kontrolü için Ürün Seçimi"
 
@@ -47563,7 +47558,7 @@ msgstr "Önce şirketi seçin"
 msgid "Select company name first."
 msgstr "Önce şirket adını seçin."
 
-#: erpnext/controllers/accounts_controller.py:2785
+#: erpnext/controllers/accounts_controller.py:2788
 msgid "Select finance book for the item {0} at row {1}"
 msgstr "{1} satırındaki {0} kalemi için finans defterini seçin"
 
@@ -47777,7 +47772,7 @@ msgid "Send Now"
 msgstr "Şimdi Gönder"
 
 #. Label of the send_sms (Button) field in DocType 'SMS Center'
-#: erpnext/public/js/controllers/transaction.js:517
+#: erpnext/public/js/controllers/transaction.js:543
 #: erpnext/selling/doctype/sms_center/sms_center.json
 msgid "Send SMS"
 msgstr "SMS Gönder"
@@ -47935,7 +47930,7 @@ msgstr "Seri ve Parti Numaraları"
 #: erpnext/manufacturing/doctype/job_card/job_card.json
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.js:74
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.py:114
-#: erpnext/public/js/controllers/transaction.js:2382
+#: erpnext/public/js/controllers/transaction.js:2408
 #: erpnext/public/js/utils/serial_no_batch_selector.js:421
 #: erpnext/selling/doctype/installation_note_item/installation_note_item.json
 #: erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
@@ -47984,7 +47979,7 @@ msgstr "Seri No Kayıtları"
 msgid "Serial No Range"
 msgstr "Seri No Aralığı"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1894
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1895
 msgid "Serial No Reserved"
 msgstr "Seri No Ayrılmış"
 
@@ -48024,7 +48019,7 @@ msgstr "Seri No ve Parti"
 msgid "Serial No and Batch Selector cannot be use when Use Serial / Batch Fields is enabled."
 msgstr "Seri / Parti Alanlarını Kullan etkinleştirildiğinde Seri No ve Parti Seçici kullanılamaz."
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:859
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:860
 msgid "Serial No is mandatory"
 msgstr "Seri No zorunludur"
 
@@ -48053,7 +48048,7 @@ msgstr "Seri No {0} {1} Ürününe ait değildir"
 msgid "Serial No {0} does not exist"
 msgstr "Seri No {0} mevcut değil"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2623
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2624
 msgid "Serial No {0} does not exists"
 msgstr "Seri No {0} mevcut değil"
 
@@ -48061,7 +48056,7 @@ msgstr "Seri No {0} mevcut değil"
 msgid "Serial No {0} is already added"
 msgstr "Seri No {0} zaten eklendi"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:357
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:358
 msgid "Serial No {0} is not present in the {1} {2}, hence you can't return it against the {1} {2}"
 msgstr "Seri No {0} {1} {2} içinde mevcut değildir, bu nedenle {1} {2} adına iade edemezsiniz"
 
@@ -48098,11 +48093,11 @@ msgstr "Seri / Parti Numaraları"
 msgid "Serial Nos and Batches"
 msgstr "Seri No ve Partiler"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1370
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1371
 msgid "Serial Nos are created successfully"
 msgstr "Seri Numaraları başarıyla oluşturuldu"
 
-#: erpnext/stock/stock_ledger.py:2137
+#: erpnext/stock/stock_ledger.py:2145
 msgid "Serial Nos are reserved in Stock Reservation Entries, you need to unreserve them before proceeding."
 msgstr "Seri Numaraları Stok Rezervasyon Girişlerinde rezerve edilmiştir, devam etmeden önce rezervasyonlarını kaldırmanız gerekmektedir."
 
@@ -48176,11 +48171,11 @@ msgstr "Seri No ve Parti"
 msgid "Serial and Batch Bundle"
 msgstr "Seri ve Parti Paketi"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1598
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1599
 msgid "Serial and Batch Bundle created"
 msgstr "Seri ve Toplu Paket oluşturuldu"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1664
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1665
 msgid "Serial and Batch Bundle updated"
 msgstr "Seri ve Toplu Paket güncellendi"
 
@@ -48532,12 +48527,12 @@ msgid "Service Stop Date"
 msgstr "Servis Durdurma Tarihi"
 
 #: erpnext/accounts/deferred_revenue.py:44
-#: erpnext/public/js/controllers/transaction.js:1420
+#: erpnext/public/js/controllers/transaction.js:1446
 msgid "Service Stop Date cannot be after Service End Date"
 msgstr "Hizmet Durdurma Tarihi, Hizmet Bitiş Tarihinden sonra olamaz"
 
 #: erpnext/accounts/deferred_revenue.py:41
-#: erpnext/public/js/controllers/transaction.js:1417
+#: erpnext/public/js/controllers/transaction.js:1443
 msgid "Service Stop Date cannot be before Service Start Date"
 msgstr "Hizmet Durdurma Tarihi, Hizmet Başlangıç Tarihinden önce olamaz"
 
@@ -49974,7 +49969,7 @@ msgstr "Standart Oranlı Giderler"
 
 #: erpnext/setup/setup_wizard/operations/defaults_setup.py:70
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:463
-#: erpnext/stock/doctype/item/item.py:245
+#: erpnext/stock/doctype/item/item.py:248
 msgid "Standard Selling"
 msgstr "Standart Satış"
 
@@ -50804,7 +50799,7 @@ msgstr "Faturalanmamış Alınan Stok"
 #. Option for the 'Purpose' (Select) field in DocType 'Stock Reconciliation'
 #. Label of a Link in the Stock Workspace
 #: erpnext/setup/workspace/home/home.json
-#: erpnext/stock/doctype/item/item.py:612
+#: erpnext/stock/doctype/item/item.py:618
 #: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.json
 #: erpnext/stock/workspace/stock/stock.json
 msgid "Stock Reconciliation"
@@ -50815,7 +50810,7 @@ msgstr "Stok Sayımı"
 msgid "Stock Reconciliation Item"
 msgstr "Stok Sayımı Kalemi"
 
-#: erpnext/stock/doctype/item/item.py:612
+#: erpnext/stock/doctype/item/item.py:618
 msgid "Stock Reconciliations"
 msgstr "Stok Sayımı"
 
@@ -50850,7 +50845,7 @@ msgstr "Stok Yeniden Gönderim Ayarları"
 #: erpnext/stock/doctype/pick_list/pick_list.js:150
 #: erpnext/stock/doctype/pick_list/pick_list.js:155
 #: erpnext/stock/doctype/stock_entry/stock_entry_dashboard.py:25
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:706
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:702
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:575
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:1138
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:1398
@@ -51250,7 +51245,7 @@ msgstr "Durdurulan İş Emri iptal edilemez, iptal etmek için önce durdurmayı
 #: erpnext/setup/doctype/company/company.py:287
 #: erpnext/setup/setup_wizard/operations/defaults_setup.py:33
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:502
-#: erpnext/stock/doctype/item/item.py:282
+#: erpnext/stock/doctype/item/item.py:285
 msgid "Stores"
 msgstr "Mağazalar"
 
@@ -51785,7 +51780,7 @@ msgstr "Başarıyla Uzlaştırıldı"
 msgid "Successfully Set Supplier"
 msgstr "Tedarikçi Başarıyla Ayarlandı"
 
-#: erpnext/stock/doctype/item/item.py:339
+#: erpnext/stock/doctype/item/item.py:342
 msgid "Successfully changed Stock UOM, please redefine conversion factors for new UOM."
 msgstr "Stok Ölçü Birimi başarıyla değiştirildi, lütfen yeni Ölçü Birimi için dönüşüm faktörlerini yeniden tanımlayın."
 
@@ -52087,7 +52082,7 @@ msgstr "Tedarikçi Detayları"
 #: erpnext/accounts/doctype/tax_rule/tax_rule.json
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:111
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:87
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1160
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1162
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:198
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:237
 #: erpnext/accounts/report/purchase_register/purchase_register.js:27
@@ -52187,7 +52182,7 @@ msgstr "Tedarikçi Defteri Özeti"
 #. Label of the supplier_name (Data) field in DocType 'Purchase Receipt'
 #. Label of the supplier_name (Data) field in DocType 'Stock Entry'
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1077
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1079
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:156
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:198
 #: erpnext/accounts/report/purchase_register/purchase_register.py:177
@@ -52671,7 +52666,7 @@ msgstr "Sistem, iş emrinin sunulması üzerine Ürün için seri numaralarını
 msgid "System will fetch all the entries if limit value is zero."
 msgstr "Eğer limit değeri sıfırsa, sistem tüm kayıtlarını alır."
 
-#: erpnext/controllers/accounts_controller.py:1975
+#: erpnext/controllers/accounts_controller.py:1978
 msgid "System will not check over billing since amount for Item {0} in {1} is zero"
 msgstr "{1} içinde {0} ürünü için tutar sıfır olduğundan, sistem fazla faturalandırmayı kontrol etmeyecek."
 
@@ -52930,7 +52925,7 @@ msgstr "Hedef Depo Stok Rezerve Edilemedi"
 msgid "Target Warehouse is required before Submit"
 msgstr "Kaydetmeden önce Devam Eden İşler Deposu gereklidir"
 
-#: erpnext/controllers/selling_controller.py:782
+#: erpnext/controllers/selling_controller.py:790
 msgid "Target Warehouse is set for some items but the customer is not an internal customer."
 msgstr "Bazı ürünler için Hedef Depo ayarlanmış ancak Müşteri İç Müşteri değil."
 
@@ -53169,7 +53164,7 @@ msgstr "Vergi Dağılımı"
 msgid "Tax Category"
 msgstr "Vergi Kategorisi"
 
-#: erpnext/controllers/buying_controller.py:194
+#: erpnext/controllers/buying_controller.py:202
 msgid "Tax Category has been changed to \"Total\" because all the Items are non-stock items"
 msgstr "Vergi Kategorisi \"Toplam\" olarak değiştirildi çünkü tüm Ürünler stok dışı kalemlerdir"
 
@@ -53375,7 +53370,7 @@ msgstr "Vergi sadece kümülatif eşiği aşan tutar için kesilecektir"
 #. Label of the taxable_amount (Currency) field in DocType 'Tax Withheld
 #. Vouchers'
 #: erpnext/accounts/doctype/tax_withheld_vouchers/tax_withheld_vouchers.json
-#: erpnext/controllers/taxes_and_totals.py:1125
+#: erpnext/controllers/taxes_and_totals.py:1135
 msgid "Taxable Amount"
 msgstr "Vergilendirilebilir Tutar"
 
@@ -53514,7 +53509,7 @@ msgstr "Çıkarılan Vergiler"
 msgid "Taxes and Charges Deducted (Company Currency)"
 msgstr "Düşülen Vergi ve Harçlar (Şirket Para Biriminde)"
 
-#: erpnext/stock/doctype/item/item.py:352
+#: erpnext/stock/doctype/item/item.py:355
 msgid "Taxes row #{0}: {1} cannot be smaller than {2}"
 msgstr "Vergi Satırı #{0}: {1} değeri {2} değerinden küçük olamaz"
 
@@ -53800,7 +53795,7 @@ msgstr "Şartlar ve Koşullar"
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/territory_item/territory_item.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:134
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1144
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1146
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:93
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:182
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:68
@@ -53904,7 +53899,7 @@ msgstr "Portaldan Teklif İsteğine Erişim Devre Dışı Bırakıldı. Erişime
 msgid "The BOM which will be replaced"
 msgstr "Değiştirilecek Ürün Ağacı"
 
-#: erpnext/stock/serial_batch_bundle.py:1274
+#: erpnext/stock/serial_batch_bundle.py:1306
 msgid "The Batch {0} has negative quantity {1} in warehouse {2}. Please correct the quantity."
 msgstr "{0} Partisinin {2} deposunda negatif {1} değer var. Lütfen miktarı düzeltin."
 
@@ -53956,7 +53951,7 @@ msgstr "Satış Personeli {0} ile bağlantılıdır"
 msgid "The Serial No at Row #{0}: {1} is not available in warehouse {2}."
 msgstr "Satır #{0}: {1} Seri Numarası, {2} deposunda mevcut değil."
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1891
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1892
 msgid "The Serial No {0} is reserved against the {1} {2} and cannot be used for any other transaction."
 msgstr "Seri No {0} , {1} {2} için ayrılmıştır ve başka bir işlem için kullanılamaz."
 
@@ -54039,7 +54034,7 @@ msgstr "Aşağıdaki varlıklar amortisman girişlerini otomatik olarak kaydedem
 msgid "The following batches are expired, please restock them: <br> {0}"
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:849
+#: erpnext/stock/doctype/item/item.py:843
 msgid "The following deleted attributes exist in Variants but not in the Template. You can either delete the Variants or keep the attribute(s) in template."
 msgstr "Aşağıdaki silinmiş nitelikler Varyantlarda mevcuttur ancak Şablonda mevcut değildir. Varyantları silebilir veya nitelikleri şablonda tutabilirsiniz."
 
@@ -54064,15 +54059,15 @@ msgstr "Paketin brüt ağırlığı. Genellikle net ağırlık + ambalaj malzeme
 msgid "The holiday on {0} is not between From Date and To Date"
 msgstr "{0} tarihindeki tatil Başlangıç Tarihi ile Bitiş Tarihi arasında değil"
 
-#: erpnext/controllers/buying_controller.py:1066
+#: erpnext/controllers/buying_controller.py:1074
 msgid "The item {item} is not marked as {type_of} item. You can enable it as {type_of} item from its Item master."
 msgstr ""
 
-#: erpnext/stock/doctype/item/item.py:614
+#: erpnext/stock/doctype/item/item.py:620
 msgid "The items {0} and {1} are present in the following {2} :"
 msgstr "Ürünler {0} ve {1}, aşağıdaki {2} içinde bulunmaktadır:"
 
-#: erpnext/controllers/buying_controller.py:1059
+#: erpnext/controllers/buying_controller.py:1067
 msgid "The items {items} are not marked as {type_of} item. You can enable them as {type_of} item from their Item masters."
 msgstr ""
 
@@ -54174,8 +54169,8 @@ msgstr "Seçili öğe toplu iş olamaz"
 msgid "The seller and the buyer cannot be the same"
 msgstr "Satıcı ve alıcı aynı olamaz"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:142
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:154
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:143
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:155
 msgid "The serial and batch bundle {0} not linked to {1} {2}"
 msgstr "Seri ve parti paketi {0}, {1} {2} ile bağlantılı değil"
 
@@ -54199,7 +54194,7 @@ msgstr "{0} ile paylaşımlar mevcut değil"
 msgid "The stock for the item {0} in the {1} warehouse was negative on the {2}. You should create a positive entry {3} before the date {4} and time {5} to post the correct valuation rate. For more details, please read the <a href='https://docs.erpnext.com/docs/user/manual/en/stock-adjustment-cogs-with-negative-stock'>documentation<a>."
 msgstr "{1} deposundaki {0} ürünü için stok, {2} tarihinde negatife düştü. Bu durumu düzeltmek için {4} tarihi ve {5} saatinden önce {3} işlemiyle pozitif bir stok girişi oluşturmalısınız. Aksi takdirde, sistem doğru değerleme oranını hesaplayamaz."
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:700
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:696
 msgid "The stock has been reserved for the following Items and Warehouses, un-reserve the same to {0} the Stock Reconciliation: <br /><br /> {1}"
 msgstr "Stok aşağıdaki Ürünler ve Depolar için rezerve edilmiştir, Stok Sayımı {0} için rezerve edilmeyen hale getirin: <br /><br /> {1}"
 
@@ -54212,11 +54207,11 @@ msgstr "Senkronizasyon arka planda başladı, lütfen yeni kayıtlar için {0} l
 msgid "The task has been enqueued as a background job."
 msgstr "Görev arka plan işi olarak kuyruğa alındı."
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:994
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:990
 msgid "The task has been enqueued as a background job. In case there is any issue on processing in background, the system will add a comment about the error on this Stock Reconciliation and revert to the Draft stage"
 msgstr "Görev arka plan işi olarak sıraya alındı. Arka planda işlemede herhangi bir sorun olması durumunda, sistem bu Stok Sayımı hata hakkında bir yorum ekleyecek ve Taslak aşamasına geri dönecektir."
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1005
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1001
 msgid "The task has been enqueued as a background job. In case there is any issue on processing in background, the system will add a comment about the error on this Stock Reconciliation and revert to the Submitted stage"
 msgstr "Görev arka plan işi olarak kuyruğa alındı. Arka planda işlem yapılmasında herhangi bir sorun olması durumunda sistem bu Stok Sayımı hata hakkında yorum ekleyecek ve Gönderildi aşamasına geri dönecektir."
 
@@ -54266,7 +54261,7 @@ msgstr "Üretim başladığında ürünlerinizin aktarılacağı depo. Grup Depo
 msgid "The {0} ({1}) must be equal to {2} ({3})"
 msgstr "{0} ({1}) ile {2} ({3}) eşit olmalıdır"
 
-#: erpnext/public/js/controllers/transaction.js:2790
+#: erpnext/public/js/controllers/transaction.js:2816
 msgid "The {0} contains Unit Price Items."
 msgstr ""
 
@@ -54314,7 +54309,7 @@ msgstr "Seçili kalem için herhangi bir varyant yok"
 msgid "There can be multiple tiered collection factor based on the total spent. But the conversion factor for redemption will always be same for all the tier."
 msgstr "Toplam harcamaya bağlı olarak birden fazla kademeli tahsilat faktörü olabilir. Ancak geri ödeme için dönüşüm faktörü tüm katmanlar için her zaman aynı olacaktır."
 
-#: erpnext/accounts/party.py:580
+#: erpnext/accounts/party.py:586
 msgid "There can only be 1 Account per Company in {0} {1}"
 msgstr "{0} {1} adresinde Şirket başına yalnızca 1 Hesap olabilir"
 
@@ -54600,7 +54595,7 @@ msgstr "Bu tahmini Ürün Kodu eklenecektir. Senin anlatımı \"SM\", ve eğer, 
 msgid "This will restrict user access to other employee records"
 msgstr "Kullanıcının diğer personel kayıtlarına erişimini kısıtlayacaktır."
 
-#: erpnext/controllers/selling_controller.py:783
+#: erpnext/controllers/selling_controller.py:791
 msgid "This {} will be treated as material transfer."
 msgstr "Bu {} hammadde transferi olarak değerlendirilecektir."
 
@@ -55314,11 +55309,11 @@ msgid "To include sub-assembly costs and scrap items in Finished Goods on a work
 msgstr "Bir İş Emrinde İş Kartı kullanmadan, 'Çok Seviyeli Ürün Ağacı' seçeneği etkinleştirildiğinde, alt montaj maliyetleri ve hurda ürünler iş emrinde bitmiş ürün maliyetine dahil edilir.\n\n"
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:2337
-#: erpnext/controllers/accounts_controller.py:3005
+#: erpnext/controllers/accounts_controller.py:3008
 msgid "To include tax in row {0} in Item rate, taxes in rows {1} must also be included"
 msgstr "{0} nolu satırdaki verginin ürün fiyatına dahil edilebilmesi için, {1} satırındaki vergiler de dahil edilmelidir"
 
-#: erpnext/stock/doctype/item/item.py:636
+#: erpnext/stock/doctype/item/item.py:642
 msgid "To merge, following properties must be same for both items"
 msgstr "Birleştirmek için, aşağıdaki özellikler her iki öğe için de aynı olmalıdır"
 
@@ -55938,7 +55933,7 @@ msgstr "Toplam Ödenmemiş Tutar"
 msgid "Total Paid Amount"
 msgstr "Toplam Ödenen Tutar"
 
-#: erpnext/controllers/accounts_controller.py:2591
+#: erpnext/controllers/accounts_controller.py:2594
 msgid "Total Payment Amount in Payment Schedule must be equal to Grand / Rounded Total"
 msgstr "Ödeme Planındaki Toplam Ödeme Tutarı Genel / Yuvarlanmış Toplam'a eşit olmalıdır"
 
@@ -56223,15 +56218,15 @@ msgstr ""
 msgid "Total Working Hours"
 msgstr "Toplam Çalışma Saati"
 
-#: erpnext/controllers/accounts_controller.py:2138
+#: erpnext/controllers/accounts_controller.py:2141
 msgid "Total advance ({0}) against Order {1} cannot be greater than the Grand Total ({2})"
 msgstr "{1} Siparişine karşı toplam avans ({0}), Genel Toplamdan ({2}) büyük olamaz"
 
-#: erpnext/controllers/selling_controller.py:190
+#: erpnext/controllers/selling_controller.py:198
 msgid "Total allocated percentage for sales team should be 100"
 msgstr "Satış ekibine ayrılan toplam yüzde 100 olmalıdır"
 
-#: erpnext/selling/doctype/customer/customer.py:162
+#: erpnext/selling/doctype/customer/customer.py:161
 msgid "Total contribution percentage should be equal to 100"
 msgstr "Toplam katkı yüzdesi 100'e eşit olmalıdır"
 
@@ -57116,7 +57111,7 @@ msgstr "Ölçü Birimi"
 msgid "Unit of Measure (UOM)"
 msgstr "Ölçü Birimi"
 
-#: erpnext/stock/doctype/item/item.py:384
+#: erpnext/stock/doctype/item/item.py:387
 msgid "Unit of Measure {0} has been entered more than once in Conversion Factor Table"
 msgstr "Ölçü Birimi {0} Dönüşüm Faktörü Tablosuna birden fazla girildi"
 
@@ -57558,7 +57553,7 @@ msgstr "Yeni iletişimlerde Potansiyel Müşteri ve Fırsat kayıtlarının değ
 msgid "Update timestamp on new communication"
 msgstr "Yeni İletişimde Zaman Damgasını Güncelle"
 
-#: erpnext/manufacturing/doctype/bom_creator/bom_creator.py:533
+#: erpnext/manufacturing/doctype/bom_creator/bom_creator.py:534
 msgid "Updated successfully"
 msgstr "Başarıyla Güncellendi"
 
@@ -57572,7 +57567,7 @@ msgstr "Başarıyla Güncellendi"
 msgid "Updated via 'Time Log' (In Minutes)"
 msgstr "'Zaman Kaydı' ile güncellendi. (Dakika)"
 
-#: erpnext/stock/doctype/item/item.py:1387
+#: erpnext/stock/doctype/item/item.py:1381
 msgid "Updating Variants..."
 msgstr "Varyantlar Güncelleniyor..."
 
@@ -58130,19 +58125,19 @@ msgstr "Değerleme Fiyatı / Oranı"
 msgid "Valuation Rate (In / Out)"
 msgstr "Değerleme Fiyatı (Giriş / Çıkış)"
 
-#: erpnext/stock/stock_ledger.py:1881
+#: erpnext/stock/stock_ledger.py:1890
 msgid "Valuation Rate Missing"
 msgstr "Değerleme Fiyatı Eksik"
 
-#: erpnext/stock/stock_ledger.py:1859
+#: erpnext/stock/stock_ledger.py:1868
 msgid "Valuation Rate for the Item {0}, is required to do accounting entries for {1} {2}."
 msgstr "Ürün {0} için Değerleme Oranı, {1} {2} muhasebe kayıtlarını yapmak için gereklidir."
 
-#: erpnext/stock/doctype/item/item.py:266
+#: erpnext/stock/doctype/item/item.py:269
 msgid "Valuation Rate is mandatory if Opening Stock entered"
 msgstr "Açılış Stoku girilirse Değerleme Oranı zorunludur"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:752
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:748
 msgid "Valuation Rate required for Item {0} at row {1}"
 msgstr "{1} nolu satırdaki {0} Ürünü için Değerleme Oranı gereklidir"
 
@@ -58152,7 +58147,7 @@ msgstr "{1} nolu satırdaki {0} Ürünü için Değerleme Oranı gereklidir"
 msgid "Valuation and Total"
 msgstr "Değerleme ve Toplam"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:971
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:967
 msgid "Valuation rate for customer provided items has been set to zero."
 msgstr "Müşteri tarafından sağlanan ürünler için değerleme oranı sıfır olarak ayarlandı."
 
@@ -58166,7 +58161,7 @@ msgid "Valuation rate for the item as per Sales Invoice (Only for Internal Trans
 msgstr "Satış Faturasına göre ürün için değerleme oranı (Sadece Dahili Transferler için)"
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:2361
-#: erpnext/controllers/accounts_controller.py:3029
+#: erpnext/controllers/accounts_controller.py:3032
 msgid "Valuation type charges can not be marked as Inclusive"
 msgstr "Değerleme türü ücretleri Dahil olarak işaretlenemez"
 
@@ -58322,7 +58317,7 @@ msgstr "Varyans ({})"
 msgid "Variant"
 msgstr "Varyant"
 
-#: erpnext/stock/doctype/item/item.py:864
+#: erpnext/stock/doctype/item/item.py:858
 msgid "Variant Attribute Error"
 msgstr "Varyant Özelliği Hatası"
 
@@ -58341,7 +58336,7 @@ msgstr "Varyant Ürün Ağacı"
 msgid "Variant Based On"
 msgstr "Varyant Referansı"
 
-#: erpnext/stock/doctype/item/item.py:892
+#: erpnext/stock/doctype/item/item.py:886
 msgid "Variant Based On cannot be changed"
 msgstr "Varyant Tabanlı değiştirilemez"
 
@@ -58359,7 +58354,7 @@ msgstr "Varyant Alanı"
 msgid "Variant Item"
 msgstr "Varyant Ürün"
 
-#: erpnext/stock/doctype/item/item.py:862
+#: erpnext/stock/doctype/item/item.py:856
 msgid "Variant Items"
 msgstr "Varyant Ürünler"
 
@@ -58477,7 +58472,7 @@ msgstr "Video Ayarları"
 #: erpnext/accounts/doctype/cost_center/cost_center_tree.js:56
 #: erpnext/accounts/doctype/invoice_discounting/invoice_discounting.js:205
 #: erpnext/accounts/doctype/journal_entry/journal_entry.js:43
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:668
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:670
 #: erpnext/bulk_transaction/doctype/bulk_transaction_log/bulk_transaction_log.js:14
 #: erpnext/bulk_transaction/doctype/bulk_transaction_log/bulk_transaction_log.js:24
 #: erpnext/buying/doctype/request_for_quotation/request_for_quotation.js:167
@@ -58664,7 +58659,7 @@ msgstr "Belge Adı"
 #: erpnext/accounts/doctype/repost_accounting_ledger_items/repost_accounting_ledger_items.json
 #: erpnext/accounts/doctype/repost_payment_ledger_items/repost_payment_ledger_items.json
 #: erpnext/accounts/doctype/unreconcile_payment/unreconcile_payment.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1099
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1101
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.js:42
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:209
 #: erpnext/accounts/report/general_ledger/general_ledger.js:49
@@ -58695,7 +58690,7 @@ msgstr "Belge Adı"
 msgid "Voucher No"
 msgstr "Belge Numarası"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1087
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1088
 msgid "Voucher No is mandatory"
 msgstr "Belge No Zorunludur"
 
@@ -58737,7 +58732,7 @@ msgstr "Giriş Türü"
 #: erpnext/accounts/doctype/repost_payment_ledger_items/repost_payment_ledger_items.json
 #: erpnext/accounts/doctype/tax_withheld_vouchers/tax_withheld_vouchers.json
 #: erpnext/accounts/doctype/unreconcile_payment/unreconcile_payment.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1097
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1099
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:200
 #: erpnext/accounts/report/general_ledger/general_ledger.py:697
 #: erpnext/accounts/report/invalid_ledger_entries/invalid_ledger_entries.py:31
@@ -59091,10 +59086,6 @@ msgstr "Depo Zorunludur"
 msgid "Warehouse not found against the account {0}"
 msgstr "Hesap {0} karşılığında depo bulunamadı."
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:600
-msgid "Warehouse not found in the system"
-msgstr "Depo sistemde bulunamadı"
-
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:1130
 #: erpnext/stock/doctype/delivery_note/delivery_note.py:414
 msgid "Warehouse required for stock Item {0}"
@@ -59223,7 +59214,7 @@ msgid "Warn for new Request for Quotations"
 msgstr "Yeni Fiyat Teklifi Talebi için Uyar"
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:744
-#: erpnext/controllers/accounts_controller.py:1978
+#: erpnext/controllers/accounts_controller.py:1981
 #: erpnext/stock/doctype/delivery_trip/delivery_trip.js:145
 #: erpnext/utilities/transaction_base.py:123
 msgid "Warning"
@@ -60195,7 +60186,7 @@ msgstr "Evet"
 msgid "You are importing data for the code list:"
 msgstr "Kod listesi için veri aktarıyorsunuz:"
 
-#: erpnext/controllers/accounts_controller.py:3611
+#: erpnext/controllers/accounts_controller.py:3614
 msgid "You are not allowed to update as per the conditions set in {} Workflow."
 msgstr "{} İş Akışında belirlenen koşullara göre güncelleme yapmanıza izin verilmiyor."
 
@@ -60260,7 +60251,7 @@ msgstr "Bunu bir makine adı veya işlem türü olarak ayarlayabilirsiniz. Örne
 msgid "You can't make any changes to Job Card since Work Order is closed."
 msgstr "İş Emri kapalı olduğundan İş Kartında herhangi bir değişiklik yapamazsınız."
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:185
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:186
 msgid "You can't process the serial number {0} as it has already been used in the SABB {1}. {2} if you want to inward same serial number multiple times then enabled 'Allow existing Serial No to be Manufactured/Received again' in the {3}"
 msgstr "Seri ve Parti Paketi {1} içinde zaten kullanılmış olduğu için seri numarası {0} işlenemez. {2} Eğer aynı seri numarasını birden fazla kez almak veya üretmek istiyorsanız, {3} içinde ‘Mevcut Seri Numarasının Yeniden Üretilmesine/Alınmasına İzin Ver’ seçeneğini etkinleştirin."
 
@@ -60320,7 +60311,7 @@ msgstr "Ödeme yapılmadan siparişi gönderemezsiniz."
 msgid "You cannot {0} this document because another Period Closing Entry {1} exists after {2}"
 msgstr "Bu belgeyi {0} yapamazsınız çünkü {2} tarihinden sonra sonra başka bir Dönem Kapanış Girişi {1} mevcuttur"
 
-#: erpnext/controllers/accounts_controller.py:3587
+#: erpnext/controllers/accounts_controller.py:3590
 msgid "You do not have permissions to {} items in a {}."
 msgstr "{} içindeki {} öğelerine ilişkin izniniz yok."
 
@@ -60348,7 +60339,7 @@ msgstr "Projede işbirliği yapmak üzere davet edildiniz: {0}."
 msgid "You have entered a duplicate Delivery Note on Row"
 msgstr "Satırda tekrarlayan bir İrsaliye girdiniz"
 
-#: erpnext/stock/doctype/item/item.py:1063
+#: erpnext/stock/doctype/item/item.py:1057
 msgid "You have to enable auto re-order in Stock Settings to maintain re-order levels."
 msgstr "Yeniden sipariş seviyelerini korumak için Stok Ayarlarında otomatik yeniden siparişi etkinleştirmeniz gerekir."
 
@@ -60368,7 +60359,7 @@ msgstr "Bir Ürün eklemeden önce Müşteri seçmelisiniz."
 msgid "You need to cancel POS Closing Entry {} to be able to cancel this document."
 msgstr "Bu belgeyi iptal edebilmek için POS Kapanış Girişini {} iptal etmeniz gerekmektedir."
 
-#: erpnext/controllers/accounts_controller.py:2980
+#: erpnext/controllers/accounts_controller.py:2983
 msgid "You selected the account group {1} as {2} Account in row {0}. Please select a single account."
 msgstr "Satır {0} için {2} Hesap olarak {1} hesap grubunu seçtiniz. Lütfen tek bir hesap seçin."
 
@@ -60446,7 +60437,7 @@ msgstr "[Önemli] [ERPNext] Otomatik Yeniden Sıralama Hataları"
 msgid "`Allow Negative rates for Items`"
 msgstr "`Ürünler için Negatif değerlere izin ver`"
 
-#: erpnext/stock/stock_ledger.py:1873
+#: erpnext/stock/stock_ledger.py:1882
 msgid "after"
 msgstr "sonra"
 
@@ -60594,7 +60585,7 @@ msgstr "lft"
 msgid "material_request_item"
 msgstr "malzeme_isteği_öğesi"
 
-#: erpnext/controllers/selling_controller.py:151
+#: erpnext/controllers/selling_controller.py:159
 msgid "must be between 0 and 100"
 msgstr "0 ile 100 arasında olmalıdır"
 
@@ -60619,7 +60610,7 @@ msgstr "eski_ebeveyn"
 msgid "on"
 msgstr "tarihinde"
 
-#: erpnext/controllers/accounts_controller.py:1289
+#: erpnext/controllers/accounts_controller.py:1292
 msgid "or"
 msgstr "veya"
 
@@ -60668,7 +60659,7 @@ msgstr "ödeme uygulaması yüklü değil. Lütfen {} veya {} adresinden yükley
 msgid "per hour"
 msgstr "Saat Başı"
 
-#: erpnext/stock/stock_ledger.py:1874
+#: erpnext/stock/stock_ledger.py:1883
 msgid "performing either one below:"
 msgstr "aşağıdakilerden birini gerçekleştirin:"
 
@@ -60795,7 +60786,7 @@ msgstr "Hesaplar tablosunda Sermaye Çalışması Devam Eden Hesabı'nı seçmel
 msgid "{0}"
 msgstr "{0}"
 
-#: erpnext/controllers/accounts_controller.py:1109
+#: erpnext/controllers/accounts_controller.py:1112
 msgid "{0} '{1}' is disabled"
 msgstr "{0} '{1}' devre dışı bırakıldı."
 
@@ -60811,7 +60802,7 @@ msgstr "{0} ({1}) İş Emrindeki üretilecek ({2}) miktar {3} değerinden fazla 
 msgid "{0} <b>{1}</b> has submitted Assets. Remove Item <b>{2}</b> from table to continue."
 msgstr "{0} <b>{1}</b> Varlıklar gönderdi. Devam etmek için tablodan <b>{2}</b> Kalemini kaldırın."
 
-#: erpnext/controllers/accounts_controller.py:2193
+#: erpnext/controllers/accounts_controller.py:2196
 msgid "{0} Account not found against Customer {1}."
 msgstr "{1} Müşterisine ait {0} hesabı bulunamadı."
 
@@ -60843,7 +60834,7 @@ msgstr "{0} Operasyonlar: {1}"
 msgid "{0} Request for {1}"
 msgstr "{1} için {0} Talebi"
 
-#: erpnext/stock/doctype/item/item.py:323
+#: erpnext/stock/doctype/item/item.py:326
 msgid "{0} Retain Sample is based on batch, please check Has Batch No to retain sample of item"
 msgstr "{0} Numune Saklama partiye dayalıdır, lütfen Ürünün numunesini saklamak için Parti Numarası Var seçeneğini işaretleyin"
 
@@ -60934,7 +60925,7 @@ msgid "{0} entered twice in Item Tax"
 msgstr "{0} iki kere ürün vergisi girildi"
 
 #: erpnext/setup/doctype/item_group/item_group.py:48
-#: erpnext/stock/doctype/item/item.py:436
+#: erpnext/stock/doctype/item/item.py:439
 msgid "{0} entered twice {1} in Item Taxes"
 msgstr "{1} Ürün Vergilerinde iki kez {0} olarak girildi"
 
@@ -60955,7 +60946,7 @@ msgstr "{0} Başarıyla Gönderildi"
 msgid "{0} hours"
 msgstr "{0} saat"
 
-#: erpnext/controllers/accounts_controller.py:2534
+#: erpnext/controllers/accounts_controller.py:2537
 msgid "{0} in row {1}"
 msgstr "{0} {1} satırında"
 
@@ -60979,7 +60970,7 @@ msgstr "{0} engellendi, bu işleme devam edilemiyor"
 
 #: erpnext/accounts/doctype/budget/budget.py:60
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:643
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:49
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:50
 #: erpnext/accounts/report/general_ledger/general_ledger.py:59
 #: erpnext/accounts/report/pos_register/pos_register.py:107
 #: erpnext/controllers/trends.py:50
@@ -60999,11 +60990,11 @@ msgstr "{0} {1} hesabı için zorunludur"
 msgid "{0} is mandatory. Maybe Currency Exchange record is not created for {1} to {2}"
 msgstr "{0} zorunludur. Belki {1} ile {2} arasında Döviz Kuru kaydı oluşturulmamış olabilir"
 
-#: erpnext/controllers/accounts_controller.py:2937
+#: erpnext/controllers/accounts_controller.py:2940
 msgid "{0} is mandatory. Maybe Currency Exchange record is not created for {1} to {2}."
 msgstr "{0} zorunludur. Belki {1} ile {2} arasında Döviz Kuru kaydı oluşturulmamış olabilir."
 
-#: erpnext/selling/doctype/customer/customer.py:204
+#: erpnext/selling/doctype/customer/customer.py:203
 msgid "{0} is not a company bank account"
 msgstr "{0} bir şirket banka hesabı değildir"
 
@@ -61086,7 +61077,7 @@ msgstr "{1} ürününden {0} miktarı, {3} kapasiteli {2} deposuna alınmaktadı
 msgid "{0} to {1}"
 msgstr ""
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:690
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:686
 msgid "{0} units are reserved for Item {1} in Warehouse {2}, please un-reserve the same to {3} the Stock Reconciliation."
 msgstr "{0} birim {1} Ürünü için {2} Deposunda rezerve edilmiştir, lütfen Stok Doğrulamasını {3} yapabilmek için stok rezevini kaldırın."
 
@@ -61102,16 +61093,16 @@ msgstr "{0} adet {1} ürünü başka bir Çekme Listesinde işaretlenmiş."
 msgid "{0} units of {1} are required in {2} with the inventory dimension: {3} ({4}) on {5} {6} for {7} to complete the transaction."
 msgstr "{2} içinde {3} ({4}) envanter boyutuyla {0} adet {1} ürünü gereklidir. İşlemi tamamlamak için {5} {6} tarihinde {7} için bu miktarın sağlanması gerekir."
 
-#: erpnext/stock/stock_ledger.py:1532 erpnext/stock/stock_ledger.py:2023
-#: erpnext/stock/stock_ledger.py:2037
+#: erpnext/stock/stock_ledger.py:1541 erpnext/stock/stock_ledger.py:2031
+#: erpnext/stock/stock_ledger.py:2045
 msgid "{0} units of {1} needed in {2} on {3} {4} for {5} to complete this transaction."
 msgstr "Bu işlemi tamamlamak için {5} için {3} {4} üzerinde {2} içinde {0} birim {1} gereklidir."
 
-#: erpnext/stock/stock_ledger.py:2124 erpnext/stock/stock_ledger.py:2170
+#: erpnext/stock/stock_ledger.py:2132 erpnext/stock/stock_ledger.py:2178
 msgid "{0} units of {1} needed in {2} on {3} {4} to complete this transaction."
 msgstr "Bu işlemi tamamlamak için {3} {4} tarihinde {2} içinde {0} adet {1} gereklidir."
 
-#: erpnext/stock/stock_ledger.py:1526
+#: erpnext/stock/stock_ledger.py:1535
 msgid "{0} units of {1} needed in {2} to complete this transaction."
 msgstr "Bu işlemi yapmak için {2} içinde {0} birim {1} gerekli."
 
@@ -61157,7 +61148,7 @@ msgstr "{0} {1} oluşturdu"
 msgid "{0} {1} does not exist"
 msgstr "{0} {1} mevcut değil"
 
-#: erpnext/accounts/party.py:560
+#: erpnext/accounts/party.py:566
 msgid "{0} {1} has accounting entries in currency {2} for company {3}. Please select a receivable or payable account with currency {2}."
 msgstr "{0} {1}, {3} Şirketi için {2} Para Biriminde muhasebe kayıtlarına sahiptir. Lütfen {2} Para Biriminde bir Alacak veya Borç Hesabı seçin."
 
@@ -61191,7 +61182,7 @@ msgstr "{0} {1} zaten Ortak Kod {2} ile bağlantılıdır."
 msgid "{0} {1} is associated with {2}, but Party Account is {3}"
 msgstr "{0} {1} {2} ile ilişkilidir, ancak Cari Hesabı {3} olarak tanımlanmıştır"
 
-#: erpnext/controllers/selling_controller.py:462
+#: erpnext/controllers/selling_controller.py:470
 #: erpnext/controllers/subcontracting_controller.py:954
 msgid "{0} {1} is cancelled or closed"
 msgstr "{0} {1} iptal edildi veya kapatıldı"
@@ -61208,11 +61199,11 @@ msgstr "{0} {1} iptal edildi, bu nedenle eylem tamamlanamıyor"
 msgid "{0} {1} is closed"
 msgstr "{0} {1} kapatıldı"
 
-#: erpnext/accounts/party.py:798
+#: erpnext/accounts/party.py:804
 msgid "{0} {1} is disabled"
 msgstr "{0} {1} devre dışı"
 
-#: erpnext/accounts/party.py:804
+#: erpnext/accounts/party.py:810
 msgid "{0} {1} is frozen"
 msgstr "{0} {1} donduruldu"
 
@@ -61220,7 +61211,7 @@ msgstr "{0} {1} donduruldu"
 msgid "{0} {1} is fully billed"
 msgstr "{0} {1} tamamen faturalandırıldı"
 
-#: erpnext/accounts/party.py:808
+#: erpnext/accounts/party.py:814
 msgid "{0} {1} is not active"
 msgstr "{0} {1} etkin değil"
 
@@ -61346,15 +61337,15 @@ msgstr "{0}: {1} mevcut değil"
 msgid "{0}: {1} must be less than {2}"
 msgstr "{0}: {1} {2} değerinden küçük olmalıdır"
 
-#: erpnext/controllers/buying_controller.py:840
+#: erpnext/controllers/buying_controller.py:848
 msgid "{count} Assets created for {item_code}"
 msgstr ""
 
-#: erpnext/controllers/buying_controller.py:738
+#: erpnext/controllers/buying_controller.py:746
 msgid "{doctype} {name} is cancelled or closed."
 msgstr "{doctype} {name} iptal edildi veya kapatıldı."
 
-#: erpnext/controllers/buying_controller.py:459
+#: erpnext/controllers/buying_controller.py:467
 msgid "{field_label} is mandatory for sub-contracted {doctype}."
 msgstr ""
 
@@ -61362,7 +61353,7 @@ msgstr ""
 msgid "{item_name}'s Sample Size ({sample_size}) cannot be greater than the Accepted Quantity ({accepted_quantity})"
 msgstr "{item_name} için Numune Boyutu ({sample_size}) Kabul Edilen Miktardan ({accepted_quantity}) büyük olamaz"
 
-#: erpnext/controllers/buying_controller.py:563
+#: erpnext/controllers/buying_controller.py:571
 msgid "{ref_doctype} {ref_name} is {status}."
 msgstr ""
 
@@ -61428,7 +61419,7 @@ msgstr "{} Faturalanacak"
 msgid "{} can't be cancelled since the Loyalty Points earned has been redeemed. First cancel the {} No {}"
 msgstr "Kazanılan Sadakat Puanları kullanıldığından {} iptal edilemez. Önce {} No {}'yu iptal edin"
 
-#: erpnext/controllers/buying_controller.py:222
+#: erpnext/controllers/buying_controller.py:230
 msgid "{} has submitted assets linked to it. You need to cancel the assets to create purchase return."
 msgstr "{} kendisine bağlı varlıkları gönderdi. Satın alma iadesi oluşturmak için varlıkları iptal etmeniz gerekiyor."
 

--- a/erpnext/locale/zh.po
+++ b/erpnext/locale/zh.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: frappe\n"
 "Report-Msgid-Bugs-To: hello@frappe.io\n"
-"POT-Creation-Date: 2025-05-25 09:35+0000\n"
-"PO-Revision-Date: 2025-05-25 20:35\n"
+"POT-Creation-Date: 2025-06-01 09:36+0000\n"
+"PO-Revision-Date: 2025-06-01 21:35\n"
 "Last-Translator: hello@frappe.io\n"
 "Language-Team: Chinese Simplified\n"
 "MIME-Version: 1.0\n"
@@ -83,15 +83,15 @@ msgstr "子装配件"
 msgid " Summary"
 msgstr "摘要"
 
-#: erpnext/stock/doctype/item/item.py:235
+#: erpnext/stock/doctype/item/item.py:238
 msgid "\"Customer Provided Item\" cannot be Purchase Item also"
 msgstr "“客户提供的物料”不能同时作为采购物料"
 
-#: erpnext/stock/doctype/item/item.py:237
+#: erpnext/stock/doctype/item/item.py:240
 msgid "\"Customer Provided Item\" cannot have Valuation Rate"
 msgstr "“客户提供的物料”不能设置估价率"
 
-#: erpnext/stock/doctype/item/item.py:313
+#: erpnext/stock/doctype/item/item.py:316
 msgid "\"Is Fixed Asset\" cannot be unchecked, as Asset record exists against the item"
 msgstr "“是否为固定资产”不能取消勾选，因该物料存在相关资产记录"
 
@@ -213,7 +213,7 @@ msgstr "本销售订单关联材料开票比例"
 msgid "% of materials delivered against this Sales Order"
 msgstr "本销售订单关联材料交付比例"
 
-#: erpnext/controllers/accounts_controller.py:2197
+#: erpnext/controllers/accounts_controller.py:2200
 msgid "'Account' in the Accounting section of Customer {0}"
 msgstr "客户{0}会计科目中的'账户'"
 
@@ -225,15 +225,11 @@ msgstr "允许针对客户采购订单创建多张销售订单"
 msgid "'Based On' and 'Group By' can not be same"
 msgstr "'依据项'与'分组项'不可相同"
 
-#: erpnext/stock/report/product_bundle_balance/product_bundle_balance.py:233
-msgid "'Date' is required"
-msgstr "'日期'为必填项"
-
 #: erpnext/selling/report/inactive_customers/inactive_customers.py:18
 msgid "'Days Since Last Order' must be greater than or equal to zero"
 msgstr "'距上次下单天数'必须大于等于零"
 
-#: erpnext/controllers/accounts_controller.py:2202
+#: erpnext/controllers/accounts_controller.py:2205
 msgid "'Default {0} Account' in Company {1}"
 msgstr "公司{1}的'默认{0}科目'"
 
@@ -243,7 +239,7 @@ msgstr "'分录'不能为空"
 
 #: erpnext/stock/report/batch_item_expiry_status/batch_item_expiry_status.py:24
 #: erpnext/stock/report/batch_wise_balance_history/batch_wise_balance_history.py:120
-#: erpnext/stock/report/stock_analytics/stock_analytics.py:314
+#: erpnext/stock/report/stock_analytics/stock_analytics.py:313
 msgid "'From Date' is required"
 msgstr "'起始日期'为必填项"
 
@@ -251,7 +247,7 @@ msgstr "'起始日期'为必填项"
 msgid "'From Date' must be after 'To Date'"
 msgstr "'起始日期'必须在'结束日期'之后"
 
-#: erpnext/stock/doctype/item/item.py:398
+#: erpnext/stock/doctype/item/item.py:401
 msgid "'Has Serial No' can not be 'Yes' for non-stock item"
 msgstr "非库存物料'序列号管理'不能设为'是'"
 
@@ -1179,7 +1175,7 @@ msgstr "已验收数量（库存单位）"
 
 #. Label of the qty (Float) field in DocType 'Purchase Receipt Item'
 #. Label of the qty (Float) field in DocType 'Subcontracting Receipt Item'
-#: erpnext/public/js/controllers/transaction.js:2362
+#: erpnext/public/js/controllers/transaction.js:2388
 #: erpnext/stock/doctype/purchase_receipt_item/purchase_receipt_item.json
 #: erpnext/subcontracting/doctype/subcontracting_receipt_item/subcontracting_receipt_item.json
 msgid "Accepted Quantity"
@@ -1377,7 +1373,7 @@ msgid "Account Manager"
 msgstr "客户经理"
 
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:949
-#: erpnext/controllers/accounts_controller.py:2206
+#: erpnext/controllers/accounts_controller.py:2209
 msgid "Account Missing"
 msgstr "科目缺失"
 
@@ -1552,7 +1548,7 @@ msgstr "科目{0}已添加至子公司{1}"
 msgid "Account {0} is frozen"
 msgstr "科目{0}已冻结"
 
-#: erpnext/controllers/accounts_controller.py:1288
+#: erpnext/controllers/accounts_controller.py:1291
 msgid "Account {0} is invalid. Account Currency must be {1}"
 msgstr "科目{0}无效，货币必须为{1}"
 
@@ -1588,7 +1584,7 @@ msgstr "科目{0}仅可通过库存交易更新"
 msgid "Account: {0} is not permitted under Payment Entry"
 msgstr "支付条目中不允许使用科目{0}"
 
-#: erpnext/controllers/accounts_controller.py:3037
+#: erpnext/controllers/accounts_controller.py:3040
 msgid "Account: {0} with currency: {1} can not be selected"
 msgstr "不可选择货币为{1}的科目{0}"
 
@@ -1861,7 +1857,7 @@ msgstr "会计凭证"
 msgid "Accounting Entry for Asset"
 msgstr "资产会计凭证"
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:796
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:805
 msgid "Accounting Entry for Service"
 msgstr "服务会计凭证"
 
@@ -1876,18 +1872,18 @@ msgstr "服务会计凭证"
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py:1468
 #: erpnext/controllers/stock_controller.py:550
 #: erpnext/controllers/stock_controller.py:567
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:889
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:898
 #: erpnext/stock/doctype/stock_entry/stock_entry.py:1586
 #: erpnext/stock/doctype/stock_entry/stock_entry.py:1600
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py:561
 msgid "Accounting Entry for Stock"
 msgstr "库存会计凭证"
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:717
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:726
 msgid "Accounting Entry for {0}"
 msgstr "{0}会计凭证"
 
-#: erpnext/controllers/accounts_controller.py:2247
+#: erpnext/controllers/accounts_controller.py:2250
 msgid "Accounting Entry for {0}: {1} can only be made in currency: {2}"
 msgstr "{0}会计凭证：{1}只能使用{2}货币"
 
@@ -2280,7 +2276,7 @@ msgstr "截至{0}的累计折旧"
 msgid "Accumulated Monthly"
 msgstr "月度累计"
 
-#: erpnext/controllers/budget_controller.py:417
+#: erpnext/controllers/budget_controller.py:422
 msgid "Accumulated Monthly Budget for Account {0} against {1} {2} is {3}. It will be collectively ({4}) exceeded by {5}"
 msgstr ""
 
@@ -3394,7 +3390,7 @@ msgstr "调整资产价值"
 msgid "Adjustment Against"
 msgstr "调整对应项"
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:634
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:643
 msgid "Adjustment based on Purchase Invoice rate"
 msgstr "基于采购发票汇率的调整"
 
@@ -3505,7 +3501,7 @@ msgstr "预付税费"
 msgid "Advance amount"
 msgstr "预付金额"
 
-#: erpnext/controllers/taxes_and_totals.py:845
+#: erpnext/controllers/taxes_and_totals.py:855
 msgid "Advance amount cannot be greater than {0} {1}"
 msgstr "预付金额不能超过{0}{1}"
 
@@ -3716,7 +3712,7 @@ msgstr "账龄"
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:152
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:133
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1125
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1127
 msgid "Age (Days)"
 msgstr "账龄（天数）"
 
@@ -3802,16 +3798,6 @@ msgstr "将物料组聚合至另一物料（适用于维护包装件而非组合
 #: erpnext/setup/setup_wizard/data/industry_type.txt:4
 msgid "Agriculture"
 msgstr "农业"
-
-#. Name of a role
-#: erpnext/assets/doctype/location/location.json
-msgid "Agriculture Manager"
-msgstr "农业经理"
-
-#. Name of a role
-#: erpnext/assets/doctype/location/location.json
-msgid "Agriculture User"
-msgstr "农业用户"
 
 #: erpnext/setup/setup_wizard/data/industry_type.txt:5
 msgid "Airline"
@@ -4003,7 +3989,7 @@ msgstr "包含本信息及以上的所有沟通记录将迁移至新工单"
 msgid "All items are already requested"
 msgstr "所有物料已申请"
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:1317
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:1326
 msgid "All items have already been Invoiced/Returned"
 msgstr "所有物料已开具发票/退回"
 
@@ -4015,7 +4001,7 @@ msgstr "所有物料已收货"
 msgid "All items have already been transferred for this Work Order."
 msgstr "本工单所有物料已转移"
 
-#: erpnext/public/js/controllers/transaction.js:2465
+#: erpnext/public/js/controllers/transaction.js:2491
 msgid "All items in this document already have a linked Quality Inspection."
 msgstr "本单据所有物料均已关联质检单"
 
@@ -4213,7 +4199,7 @@ msgstr "允许按公允价格进行内部调拨"
 msgid "Allow Item To Be Added Multiple Times in a Transaction"
 msgstr "允许在交易中多次添加同一物料"
 
-#: erpnext/controllers/selling_controller.py:755
+#: erpnext/controllers/selling_controller.py:763
 msgid "Allow Item to Be Added Multiple Times in a Transaction"
 msgstr "允许在交易中多次添加同一物料"
 
@@ -5159,7 +5145,7 @@ msgstr "年度"
 msgid "Annual Billing: {0}"
 msgstr "年度结算：{0}"
 
-#: erpnext/controllers/budget_controller.py:441
+#: erpnext/controllers/budget_controller.py:446
 msgid "Annual Budget for Account {0} against {1} {2} is {3}. It will be collectively ({4}) exceeded by {5}"
 msgstr ""
 
@@ -5648,7 +5634,7 @@ msgstr "由于字段{0}已启用，字段{1}为必填项"
 msgid "As the field {0} is enabled, the value of the field {1} should be more than 1."
 msgstr "由于字段{0}已启用，字段{1}值必须大于1"
 
-#: erpnext/stock/doctype/item/item.py:989
+#: erpnext/stock/doctype/item/item.py:983
 msgid "As there are existing submitted transactions against item {0}, you can not change the value of {1}."
 msgstr "由于存在针对物料{0}的已提交交易，不可修改{1}的值"
 
@@ -5794,7 +5780,7 @@ msgstr "资产类别科目"
 msgid "Asset Category Name"
 msgstr "资产类别名称"
 
-#: erpnext/stock/doctype/item/item.py:304
+#: erpnext/stock/doctype/item/item.py:307
 msgid "Asset Category is mandatory for Fixed Asset item"
 msgstr "固定资产物料必须指定资产类别"
 
@@ -6169,7 +6155,7 @@ msgstr "资产{0}已更新，请设置折旧明细并提交"
 msgid "Asset {0} must be submitted"
 msgstr "资产{0}必须提交"
 
-#: erpnext/controllers/buying_controller.py:851
+#: erpnext/controllers/buying_controller.py:859
 msgid "Asset {assets_link} created for {item_code}"
 msgstr "已为{item_code}创建资产{assets_link}"
 
@@ -6199,11 +6185,11 @@ msgstr "提交资产价值调整{0}后更新资产价值"
 msgid "Assets"
 msgstr "资产列表"
 
-#: erpnext/controllers/buying_controller.py:869
+#: erpnext/controllers/buying_controller.py:877
 msgid "Assets not created for {item_code}. You will have to create asset manually."
 msgstr "未为{item_code}创建资产，请手动创建"
 
-#: erpnext/controllers/buying_controller.py:856
+#: erpnext/controllers/buying_controller.py:864
 msgid "Assets {assets_link} created for {item_code}"
 msgstr "已为{item_code}创建资产{assets_link}"
 
@@ -6298,7 +6284,7 @@ msgstr "行{0}：序列ID{1}不能小于前一行的序列ID{2}"
 msgid "At row #{0}: you have selected the Difference Account {1}, which is a Cost of Goods Sold type account. Please select a different account"
 msgstr "第{0}行：所选差异科目{1}为销售成本类型科目，请选择其他科目。"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:864
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:865
 msgid "At row {0}: Batch No is mandatory for Item {1}"
 msgstr "行{0}：物料{1}必须填写批次号"
 
@@ -6306,11 +6292,11 @@ msgstr "行{0}：物料{1}必须填写批次号"
 msgid "At row {0}: Parent Row No cannot be set for item {1}"
 msgstr "行{0}：物料{1}不能设置父行号"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:849
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:850
 msgid "At row {0}: Qty is mandatory for the batch {1}"
 msgstr "行{0}：批次{1}的数量为必填项"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:856
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:857
 msgid "At row {0}: Serial No is mandatory for Item {1}"
 msgstr "行{0}：物料{1}必须填写序列号"
 
@@ -6384,7 +6370,7 @@ msgstr "属性名称"
 msgid "Attribute Value"
 msgstr "属性值"
 
-#: erpnext/stock/doctype/item/item.py:930
+#: erpnext/stock/doctype/item/item.py:924
 msgid "Attribute table is mandatory"
 msgstr "属性表为必填项"
 
@@ -6392,11 +6378,11 @@ msgstr "属性表为必填项"
 msgid "Attribute value: {0} must appear only once"
 msgstr "属性值{0}必须唯一"
 
-#: erpnext/stock/doctype/item/item.py:934
+#: erpnext/stock/doctype/item/item.py:928
 msgid "Attribute {0} selected multiple times in Attributes Table"
 msgstr "属性{0}在属性表中被多次选择"
 
-#: erpnext/stock/doctype/item/item.py:862
+#: erpnext/stock/doctype/item/item.py:856
 msgid "Attributes"
 msgstr "属性列表"
 
@@ -7680,11 +7666,11 @@ msgstr "条码"
 msgid "Barcode Type"
 msgstr "条码类型"
 
-#: erpnext/stock/doctype/item/item.py:457
+#: erpnext/stock/doctype/item/item.py:460
 msgid "Barcode {0} already used in Item {1}"
 msgstr "条码{0}已在物料{1}中使用"
 
-#: erpnext/stock/doctype/item/item.py:472
+#: erpnext/stock/doctype/item/item.py:475
 msgid "Barcode {0} is not a valid {1} code"
 msgstr "条码{0}不是有效的{1}编码"
 
@@ -7938,7 +7924,7 @@ msgstr "批次物料到期状态"
 #: erpnext/manufacturing/doctype/job_card/job_card.json
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.js:89
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.py:115
-#: erpnext/public/js/controllers/transaction.js:2388
+#: erpnext/public/js/controllers/transaction.js:2414
 #: erpnext/public/js/utils/barcode_scanner.js:260
 #: erpnext/public/js/utils/serial_no_batch_selector.js:438
 #: erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
@@ -7965,11 +7951,11 @@ msgstr "批次物料到期状态"
 msgid "Batch No"
 msgstr "批次号"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:867
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:868
 msgid "Batch No is mandatory"
 msgstr "批次号为必填项"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2629
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2630
 msgid "Batch No {0} does not exists"
 msgstr "批次号{0}不存在"
 
@@ -7977,7 +7963,7 @@ msgstr "批次号{0}不存在"
 msgid "Batch No {0} is linked with Item {1} which has serial no. Please scan serial no instead."
 msgstr "批次号{0}关联的物料{1}需使用序列号，请扫描序列号"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:364
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:365
 msgid "Batch No {0} is not present in the original {1} {2}, hence you can't return it against the {1} {2}"
 msgstr "批次号{0}在原{1}{2}中不存在，因此不能针对{1}{2}退回"
 
@@ -7992,11 +7978,11 @@ msgstr "批次号"
 msgid "Batch Nos"
 msgstr "批次号列表"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1421
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1422
 msgid "Batch Nos are created successfully"
 msgstr "批次号创建成功"
 
-#: erpnext/controllers/sales_and_purchase_return.py:1096
+#: erpnext/controllers/sales_and_purchase_return.py:1001
 msgid "Batch Not Available for Return"
 msgstr "批次不可退回"
 
@@ -8045,7 +8031,7 @@ msgstr "未为物料{}创建批次，因其无批次编号规则"
 msgid "Batch {0} and Warehouse"
 msgstr "批次{0}与仓库"
 
-#: erpnext/controllers/sales_and_purchase_return.py:1095
+#: erpnext/controllers/sales_and_purchase_return.py:1000
 msgid "Batch {0} is not available in warehouse {1}"
 msgstr "批次{0}在仓库{1}中不可用"
 
@@ -8095,7 +8081,7 @@ msgstr "以下订阅计划货币与交易方默认账单货币/公司货币不�
 #. Label of the bill_date (Date) field in DocType 'Journal Entry'
 #. Label of the bill_date (Date) field in DocType 'Subcontracting Receipt'
 #: erpnext/accounts/doctype/journal_entry/journal_entry.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1110
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1112
 #: erpnext/accounts/report/purchase_register/purchase_register.py:214
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.json
 msgid "Bill Date"
@@ -8104,7 +8090,7 @@ msgstr "账单日期"
 #. Label of the bill_no (Data) field in DocType 'Journal Entry'
 #. Label of the bill_no (Data) field in DocType 'Subcontracting Receipt'
 #: erpnext/accounts/doctype/journal_entry/journal_entry.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1109
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1111
 #: erpnext/accounts/report/purchase_register/purchase_register.py:213
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.json
 msgid "Bill No"
@@ -8324,7 +8310,7 @@ msgstr "账单状态"
 msgid "Billing Zipcode"
 msgstr "账单邮编"
 
-#: erpnext/accounts/party.py:602
+#: erpnext/accounts/party.py:608
 msgid "Billing currency must be equal to either default company's currency or party account currency"
 msgstr "账单货币必须等于公司默认货币或交易方账户货币"
 
@@ -9321,7 +9307,7 @@ msgid "Can only make payment against unbilled {0}"
 msgstr "仅可为未开票的{0}付款"
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1458
-#: erpnext/controllers/accounts_controller.py:2946
+#: erpnext/controllers/accounts_controller.py:2949
 #: erpnext/public/js/controllers/accounts.js:90
 msgid "Can refer row only if the charge type is 'On Previous Row Amount' or 'Previous Row Total'"
 msgstr "仅当费用类型为'基于前一行金额'或'前一行总额'时可引用行号"
@@ -9483,9 +9469,9 @@ msgstr "缺少司机地址，无法计算到达时间"
 msgid "Cannot Create Return"
 msgstr "无法创建退货"
 
-#: erpnext/stock/doctype/item/item.py:625
-#: erpnext/stock/doctype/item/item.py:638
-#: erpnext/stock/doctype/item/item.py:652
+#: erpnext/stock/doctype/item/item.py:631
+#: erpnext/stock/doctype/item/item.py:644
+#: erpnext/stock/doctype/item/item.py:658
 msgid "Cannot Merge"
 msgstr "无法合并"
 
@@ -9509,7 +9495,7 @@ msgstr "无法修改{0}{1}，请新建凭证"
 msgid "Cannot apply TDS against multiple parties in one entry"
 msgstr "单笔凭证不能为多方应用源头减税"
 
-#: erpnext/stock/doctype/item/item.py:307
+#: erpnext/stock/doctype/item/item.py:310
 msgid "Cannot be a fixed asset item as Stock Ledger is created."
 msgstr "已创建库存分类账，不可设为固定资产物料"
 
@@ -9525,7 +9511,7 @@ msgstr "存在已提交的库存交易{0}，无法取消"
 msgid "Cannot cancel the transaction. Reposting of item valuation on submission is not completed yet."
 msgstr "物料价值重估未完成，无法取消交易"
 
-#: erpnext/controllers/buying_controller.py:959
+#: erpnext/controllers/buying_controller.py:967
 msgid "Cannot cancel this document as it is linked with the submitted asset {asset_link}. Please cancel the asset to continue."
 msgstr "该单据关联已提交资产{asset_link}，需先取消资产"
 
@@ -9533,7 +9519,7 @@ msgstr "该单据关联已提交资产{asset_link}，需先取消资产"
 msgid "Cannot cancel transaction for Completed Work Order."
 msgstr "已完成工单的交易不可取消"
 
-#: erpnext/stock/doctype/item/item.py:882
+#: erpnext/stock/doctype/item/item.py:876
 msgid "Cannot change Attributes after stock transaction. Make a new Item and transfer stock to the new Item"
 msgstr "存在库存交易后不可修改属性，请新建物料并转移库存"
 
@@ -9549,7 +9535,7 @@ msgstr "不可修改参考单据类型"
 msgid "Cannot change Service Stop Date for item in row {0}"
 msgstr "不可修改行{0}物料的停服日期"
 
-#: erpnext/stock/doctype/item/item.py:873
+#: erpnext/stock/doctype/item/item.py:867
 msgid "Cannot change Variant properties after stock transaction. You will have to make a new Item to do this."
 msgstr "存在库存交易后不可修改变体属性，请新建物料"
 
@@ -9577,7 +9563,7 @@ msgstr "已选择科目类型，不可转为科目组"
 msgid "Cannot covert to Group because Account Type is selected."
 msgstr "已选择科目类型，不可转为科目组"
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:972
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:981
 msgid "Cannot create Stock Reservation Entries for future dated Purchase Receipts."
 msgstr "无法为未来日期的采购收据创建库存预留"
 
@@ -9628,7 +9614,7 @@ msgstr "物料{0}同时存在启用和未启用序列号交付，无法确保"
 msgid "Cannot find Item with this Barcode"
 msgstr "找不到该条码对应的物料"
 
-#: erpnext/controllers/accounts_controller.py:3483
+#: erpnext/controllers/accounts_controller.py:3486
 msgid "Cannot find a default warehouse for item {0}. Please set one in the Item Master or in Stock Settings."
 msgstr "找不到物料{0}的默认仓库，请在物料主数据或库存设置中设置"
 
@@ -9636,7 +9622,7 @@ msgstr "找不到物料{0}的默认仓库，请在物料主数据或库存设置
 msgid "Cannot make any transactions until the deletion job is completed"
 msgstr "删除任务完成前不可进行任何交易"
 
-#: erpnext/controllers/accounts_controller.py:2074
+#: erpnext/controllers/accounts_controller.py:2077
 msgid "Cannot overbill for Item {0} in row {1} more than {2}. To allow over-billing, please set allowance in Accounts Settings"
 msgstr "行{1}物料{0}不可超开票超过{2}，请在账户设置中设置超开票限额"
 
@@ -9657,7 +9643,7 @@ msgid "Cannot receive from customer against negative outstanding"
 msgstr "存在负未清金额时不可从客户收货"
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1475
-#: erpnext/controllers/accounts_controller.py:2961
+#: erpnext/controllers/accounts_controller.py:2964
 #: erpnext/public/js/controllers/accounts.js:100
 msgid "Cannot refer row number greater than or equal to current row number for this Charge type"
 msgstr "当前行号不可引用大于等于自身的行号"
@@ -9673,7 +9659,7 @@ msgstr "无法获取链接令牌，查看错误日志"
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1467
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1646
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:1917
-#: erpnext/controllers/accounts_controller.py:2951
+#: erpnext/controllers/accounts_controller.py:2954
 #: erpnext/public/js/controllers/accounts.js:94
 #: erpnext/public/js/controllers/taxes_and_totals.js:470
 msgid "Cannot select charge type as 'On Previous Row Amount' or 'On Previous Row Total' for first row"
@@ -9687,15 +9673,15 @@ msgstr "已生成销售订单，不可标记为丢失"
 msgid "Cannot set authorization on basis of Discount for {0}"
 msgstr "无法以折扣为基础设置{0}的授权"
 
-#: erpnext/stock/doctype/item/item.py:716
+#: erpnext/stock/doctype/item/item.py:722
 msgid "Cannot set multiple Item Defaults for a company."
 msgstr "同一公司不可设置多个物料默认值"
 
-#: erpnext/controllers/accounts_controller.py:3631
+#: erpnext/controllers/accounts_controller.py:3634
 msgid "Cannot set quantity less than delivered quantity"
 msgstr "数量不可小于已交付数量"
 
-#: erpnext/controllers/accounts_controller.py:3634
+#: erpnext/controllers/accounts_controller.py:3637
 msgid "Cannot set quantity less than received quantity"
 msgstr "数量不可小于已接收数量"
 
@@ -10118,7 +10104,7 @@ msgid "Channel Partner"
 msgstr "渠道合作伙伴"
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:2346
-#: erpnext/controllers/accounts_controller.py:3014
+#: erpnext/controllers/accounts_controller.py:3017
 msgid "Charge of type 'Actual' in row {0} cannot be included in Item Rate or Paid Amount"
 msgstr "行{0}的'实际'类型费用不可包含在物料单价或实付金额中"
 
@@ -10301,7 +10287,7 @@ msgstr "支票宽度"
 
 #. Label of the reference_date (Date) field in DocType 'Payment Entry'
 #: erpnext/accounts/doctype/payment_entry/payment_entry.json
-#: erpnext/public/js/controllers/transaction.js:2299
+#: erpnext/public/js/controllers/transaction.js:2325
 msgid "Cheque/Reference Date"
 msgstr "支票/参考日期"
 
@@ -10349,7 +10335,7 @@ msgstr "子单据名称"
 
 #. Label of the child_row_reference (Data) field in DocType 'Quality
 #. Inspection'
-#: erpnext/public/js/controllers/transaction.js:2394
+#: erpnext/public/js/controllers/transaction.js:2420
 #: erpnext/stock/doctype/quality_inspection/quality_inspection.json
 msgid "Child Row Reference"
 msgstr "子行引用"
@@ -11061,7 +11047,7 @@ msgstr "公司列表"
 #: erpnext/accounts/report/cheques_and_deposits_incorrectly_cleared/cheques_and_deposits_incorrectly_cleared.js:8
 #: erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.js:8
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:8
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:49
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:50
 #: erpnext/accounts/report/deferred_revenue_and_expense/deferred_revenue_and_expense.js:8
 #: erpnext/accounts/report/delivered_items_to_be_billed/delivered_items_to_be_billed.js:7
 #: erpnext/accounts/report/dimension_wise_accounts_balance_report/dimension_wise_accounts_balance_report.js:8
@@ -12294,7 +12280,7 @@ msgid "Content Type"
 msgstr "内容类型"
 
 #: erpnext/erpnext_integrations/doctype/plaid_settings/plaid_settings.js:162
-#: erpnext/public/js/controllers/transaction.js:2312
+#: erpnext/public/js/controllers/transaction.js:2338
 #: erpnext/selling/doctype/quotation/quotation.js:356
 msgid "Continue"
 msgstr "继续"
@@ -12459,7 +12445,7 @@ msgstr "换算系数"
 msgid "Conversion Rate"
 msgstr "换算率"
 
-#: erpnext/stock/doctype/item/item.py:393
+#: erpnext/stock/doctype/item/item.py:396
 msgid "Conversion factor for default Unit of Measure must be 1 in row {0}"
 msgstr "默认单位的换算系数在行{0}必须为1"
 
@@ -12467,15 +12453,15 @@ msgstr "默认单位的换算系数在行{0}必须为1"
 msgid "Conversion factor for item {0} has been reset to 1.0 as the uom {1} is same as stock uom {2}."
 msgstr "物料{0}的换算系数已重置为1.0，因其单位{1}与库存单位{2}相同"
 
-#: erpnext/controllers/accounts_controller.py:2767
+#: erpnext/controllers/accounts_controller.py:2770
 msgid "Conversion rate cannot be 0"
 msgstr "汇率不能为 0"
 
-#: erpnext/controllers/accounts_controller.py:2774
+#: erpnext/controllers/accounts_controller.py:2777
 msgid "Conversion rate is 1.00, but document currency is different from company currency"
 msgstr "汇率设置为1.00，但单据货币与公司货币不同"
 
-#: erpnext/controllers/accounts_controller.py:2770
+#: erpnext/controllers/accounts_controller.py:2773
 msgid "Conversion rate must be 1.00 if document currency is same as company currency"
 msgstr "单据货币与公司本位币相同时，汇率必须为1.00"
 
@@ -12688,7 +12674,7 @@ msgstr "成本"
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:28
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:40
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:30
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1096
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1098
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:40
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.js:42
 #: erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.py:197
@@ -12781,7 +12767,7 @@ msgid "Cost Center is a part of Cost Center Allocation, hence cannot be converte
 msgstr "成本中心参与分配，不可转换为组"
 
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py:1411
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:855
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:864
 msgid "Cost Center is required in row {0} in Taxes table for type {1}"
 msgstr "行{0}的税种{1}必须填写成本中心"
 
@@ -13050,8 +13036,8 @@ msgstr "贷方"
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:132
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:143
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:219
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:654
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:678
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:656
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:680
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.js:88
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.js:89
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.js:103
@@ -13108,8 +13094,8 @@ msgstr "贷方"
 #: erpnext/projects/doctype/task/task_tree.js:81
 #: erpnext/public/js/communication.js:19 erpnext/public/js/communication.js:31
 #: erpnext/public/js/communication.js:41
-#: erpnext/public/js/controllers/transaction.js:336
-#: erpnext/public/js/controllers/transaction.js:2435
+#: erpnext/public/js/controllers/transaction.js:362
+#: erpnext/public/js/controllers/transaction.js:2461
 #: erpnext/selling/doctype/customer/customer.js:181
 #: erpnext/selling/doctype/quotation/quotation.js:124
 #: erpnext/selling/doctype/quotation/quotation.js:133
@@ -13404,7 +13390,7 @@ msgstr "新建组合资产"
 msgid "Create a variant with the template image."
 msgstr "使用模板图像创建变型"
 
-#: erpnext/stock/stock_ledger.py:1877
+#: erpnext/stock/stock_ledger.py:1886
 msgid "Create an incoming stock transaction for the Item."
 msgstr "为物料创建入库库存交易"
 
@@ -13464,7 +13450,7 @@ msgstr "正在创建采购发票..."
 msgid "Creating Purchase Order ..."
 msgstr "正在创建采购订单..."
 
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:735
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:737
 #: erpnext/buying/doctype/purchase_order/purchase_order.js:552
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.js:73
 msgid "Creating Purchase Receipt ..."
@@ -13660,7 +13646,7 @@ msgstr "信用月数"
 #: erpnext/accounts/doctype/journal_entry_template/journal_entry_template.json
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:174
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:147
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1119
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1121
 #: erpnext/controllers/sales_and_purchase_return.py:373
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:286
 #: erpnext/stock/doctype/delivery_note/delivery_note.js:89
@@ -13695,7 +13681,7 @@ msgstr "贷项凭证{0}已自动创建"
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py:368
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py:376
-#: erpnext/controllers/accounts_controller.py:2186
+#: erpnext/controllers/accounts_controller.py:2189
 msgid "Credit To"
 msgstr "贷记至"
 
@@ -13880,7 +13866,7 @@ msgstr "杯"
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/subscription_plan/subscription_plan.json
 #: erpnext/accounts/report/account_balance/account_balance.py:28
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1129
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1131
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:205
 #: erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.py:101
 #: erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.js:118
@@ -14409,7 +14395,7 @@ msgstr "客户代码"
 #. Label of the customer_contact_display (Small Text) field in DocType
 #. 'Purchase Order'
 #. Label of the customer_contact (Small Text) field in DocType 'Delivery Stop'
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1090
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1092
 #: erpnext/buying/doctype/purchase_order/purchase_order.json
 #: erpnext/stock/doctype/delivery_stop/delivery_stop.json
 msgid "Customer Contact"
@@ -14505,7 +14491,7 @@ msgstr "客户反馈"
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/tax_rule/tax_rule.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:107
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1147
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1149
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:81
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:185
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:56
@@ -14549,7 +14535,7 @@ msgstr "客户组物料"
 msgid "Customer Group Name"
 msgstr "客户组名称"
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1239
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1241
 msgid "Customer Group: {0} does not exist"
 msgstr "客户组：{0}不存在"
 
@@ -14568,7 +14554,7 @@ msgstr "客户物料"
 msgid "Customer Items"
 msgstr "客户物料"
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1138
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1140
 msgid "Customer LPO"
 msgstr "客户采购订单"
 
@@ -14614,7 +14600,7 @@ msgstr "客户手机号码"
 #: erpnext/accounts/doctype/pos_invoice/pos_invoice.json
 #: erpnext/accounts/doctype/process_statement_of_accounts_customer/process_statement_of_accounts_customer.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1080
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1082
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:156
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:92
 #: erpnext/accounts/report/delivered_items_to_be_billed/delivered_items_to_be_billed.py:35
@@ -15292,7 +15278,7 @@ msgstr "交易货币借方金额"
 #: erpnext/accounts/doctype/journal_entry_template/journal_entry_template.json
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:176
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:147
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1122
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1124
 #: erpnext/controllers/sales_and_purchase_return.py:377
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:287
 #: erpnext/stock/doctype/purchase_receipt/purchase_receipt.js:61
@@ -15321,7 +15307,7 @@ msgstr "即使指定'退货依据'，借项凭证仍将更新自身未清金额"
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:953
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:964
-#: erpnext/controllers/accounts_controller.py:2186
+#: erpnext/controllers/accounts_controller.py:2189
 msgid "Debit To"
 msgstr "借记至"
 
@@ -15354,11 +15340,11 @@ msgstr "借贷不平"
 msgid "Debit-Credit mismatch"
 msgstr "借贷不平"
 
-#: erpnext/accounts/party.py:609
+#: erpnext/accounts/party.py:615
 msgid "Debtor/Creditor"
 msgstr "债务人/债权人"
 
-#: erpnext/accounts/party.py:612
+#: erpnext/accounts/party.py:618
 msgid "Debtor/Creditor Advance"
 msgstr "债务人/债权人预付款"
 
@@ -15478,7 +15464,7 @@ msgstr "默认预收账款科目"
 msgid "Default BOM"
 msgstr "默认物料清单"
 
-#: erpnext/stock/doctype/item/item.py:418
+#: erpnext/stock/doctype/item/item.py:421
 msgid "Default BOM ({0}) must be active for this item or its template"
 msgstr "默认物料清单（{0}）必须在此物料或其模板中处于激活状态"
 
@@ -15486,7 +15472,7 @@ msgstr "默认物料清单（{0}）必须在此物料或其模板中处于激活
 msgid "Default BOM for {0} not found"
 msgstr "未找到{0}的默认物料清单"
 
-#: erpnext/controllers/accounts_controller.py:3672
+#: erpnext/controllers/accounts_controller.py:3675
 msgid "Default BOM not found for FG Item {0}"
 msgstr "未找到产成品{0}的默认物料清单"
 
@@ -15821,15 +15807,15 @@ msgstr "默认区域"
 msgid "Default Unit of Measure"
 msgstr "默认计量单位"
 
-#: erpnext/stock/doctype/item/item.py:1272
+#: erpnext/stock/doctype/item/item.py:1266
 msgid "Default Unit of Measure for Item {0} cannot be changed directly because you have already made some transaction(s) with another UOM. You need to either cancel the linked documents or create a new Item."
 msgstr "物料{0}的默认计量单位不可直接更改，因已存在其他计量单位的交易。需取消关联单据或创建新物料"
 
-#: erpnext/stock/doctype/item/item.py:1255
+#: erpnext/stock/doctype/item/item.py:1249
 msgid "Default Unit of Measure for Item {0} cannot be changed directly because you have already made some transaction(s) with another UOM. You will need to create a new Item to use a different Default UOM."
 msgstr "物料{0}的默认计量单位不可直接更改，因已存在其他计量单位的交易。需创建新物料以使用不同默认计量单位"
 
-#: erpnext/stock/doctype/item/item.py:908
+#: erpnext/stock/doctype/item/item.py:902
 msgid "Default Unit of Measure for Variant '{0}' must be same as in Template '{1}'"
 msgstr "变型'{0}'的默认计量单位必须与模板'{1}'一致"
 
@@ -16288,7 +16274,7 @@ msgstr "交货单趋势"
 msgid "Delivery Note {0} is not submitted"
 msgstr "交货单{0}未提交"
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1142
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1144
 #: erpnext/stock/doctype/delivery_trip/delivery_trip.js:73
 msgid "Delivery Notes"
 msgstr "交货单"
@@ -16819,7 +16805,7 @@ msgstr "通过冲销消除折旧"
 #: erpnext/projects/doctype/task_type/task_type.json
 #: erpnext/projects/doctype/timesheet_detail/timesheet_detail.json
 #: erpnext/public/js/bank_reconciliation_tool/data_table_manager.js:55
-#: erpnext/public/js/controllers/transaction.js:2376
+#: erpnext/public/js/controllers/transaction.js:2402
 #: erpnext/selling/doctype/installation_note_item/installation_note_item.json
 #: erpnext/selling/doctype/product_bundle/product_bundle.json
 #: erpnext/selling/doctype/product_bundle_item/product_bundle_item.json
@@ -17007,7 +16993,7 @@ msgstr "物料表中的差异科目"
 msgid "Difference Account must be a Asset/Liability type account (Temporary Opening), since this Stock Entry is an Opening Entry"
 msgstr "因本库存凭证为期初凭证，差异科目必须为资产/负债类科目（临时期初）。"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:954
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:950
 msgid "Difference Account must be a Asset/Liability type account, since this Stock Reconciliation is an Opening Entry"
 msgstr "差额科目必须为资产/负债类科目，因该库存对账为期初录入"
 
@@ -17273,11 +17259,11 @@ msgstr "选中了禁用账户"
 msgid "Disabled Warehouse {0} cannot be used for this transaction."
 msgstr "已禁用仓库{0}不可用于此交易"
 
-#: erpnext/controllers/accounts_controller.py:745
+#: erpnext/controllers/accounts_controller.py:748
 msgid "Disabled pricing rules since this {} is an internal transfer"
 msgstr "因{}为内部调拨，已禁用定价规则"
 
-#: erpnext/controllers/accounts_controller.py:759
+#: erpnext/controllers/accounts_controller.py:762
 msgid "Disabled tax included prices since this {} is an internal transfer"
 msgstr "因{}为内部调拨，已禁用含税价格"
 
@@ -18219,7 +18205,7 @@ msgstr "直运"
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.json
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/print_format/sales_invoice_print/sales_invoice_print.html:72
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1106
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1108
 #: erpnext/assets/doctype/asset_maintenance_log/asset_maintenance_log.json
 #: erpnext/selling/report/payment_terms_status_for_sales_order/payment_terms_status_for_sales_order.py:40
 msgid "Due Date"
@@ -18233,11 +18219,11 @@ msgstr "到期日"
 msgid "Due Date Based On"
 msgstr "到期日依据"
 
-#: erpnext/accounts/party.py:695
+#: erpnext/accounts/party.py:701
 msgid "Due Date cannot be after {0}"
 msgstr "到期日不可晚于{0}"
 
-#: erpnext/accounts/party.py:671
+#: erpnext/accounts/party.py:677
 msgid "Due Date cannot be before {0}"
 msgstr "到期日不可早于{0}"
 
@@ -18955,7 +18941,7 @@ msgstr "启用预约排程"
 msgid "Enable Auto Email"
 msgstr "启用自动邮件"
 
-#: erpnext/stock/doctype/item/item.py:1064
+#: erpnext/stock/doctype/item/item.py:1058
 msgid "Enable Auto Re-Order"
 msgstr "启用自动补货"
 
@@ -19168,7 +19154,7 @@ msgstr "兑现日期"
 msgid "End Date"
 msgstr "结束日期"
 
-#: erpnext/crm/doctype/contract/contract.py:75
+#: erpnext/crm/doctype/contract/contract.py:83
 msgid "End Date cannot be before Start Date."
 msgstr "结束日期不可早于开始日期"
 
@@ -19419,7 +19405,7 @@ msgstr "尔格"
 #: erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.json
 #: erpnext/manufacturing/doctype/job_card/job_card.py:875
 #: erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.json
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:297
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:298
 msgid "Error"
 msgstr "错误"
 
@@ -19544,7 +19530,7 @@ msgstr "工厂交货"
 msgid "Example URL"
 msgstr "示例URL"
 
-#: erpnext/stock/doctype/item/item.py:995
+#: erpnext/stock/doctype/item/item.py:989
 msgid "Example of a linked document: {0}"
 msgstr "关联文档示例：{0}"
 
@@ -19560,7 +19546,7 @@ msgstr "例如：ABCD.#####\n"
 msgid "Example: ABCD.#####. If series is set and Batch No is not mentioned in transactions, then automatic batch number will be created based on this series. If you always want to explicitly mention Batch No for this item, leave this blank. Note: this setting will take priority over the Naming Series Prefix in Stock Settings."
 msgstr "示例：ABCD.#####。若设置序列且交易中未提及批次号，将基于此序列自动生成。若需明确指定批次号，请留空。注：此设置优先于库存设置的命名序列前缀"
 
-#: erpnext/stock/stock_ledger.py:2141
+#: erpnext/stock/stock_ledger.py:2149
 msgid "Example: Serial No {0} reserved in {1}."
 msgstr "示例：序列号{0}在{1}中预留"
 
@@ -19614,8 +19600,8 @@ msgstr "汇兑损益"
 msgid "Exchange Gain/Loss"
 msgstr "汇兑损益"
 
-#: erpnext/controllers/accounts_controller.py:1593
-#: erpnext/controllers/accounts_controller.py:1677
+#: erpnext/controllers/accounts_controller.py:1596
+#: erpnext/controllers/accounts_controller.py:1680
 msgid "Exchange Gain/Loss amount has been booked through {0}"
 msgstr "已通过{0}登记汇兑损益金额"
 
@@ -20351,7 +20337,7 @@ msgid "Fetching Error"
 msgstr "获取错误"
 
 #: erpnext/accounts/doctype/dunning/dunning.js:135
-#: erpnext/public/js/controllers/transaction.js:1251
+#: erpnext/public/js/controllers/transaction.js:1277
 msgid "Fetching exchange rates ..."
 msgstr "正在获取汇率..."
 
@@ -20646,15 +20632,15 @@ msgstr "产成品物料数量"
 msgid "Finished Good Item Quantity"
 msgstr "产成品物料数量"
 
-#: erpnext/controllers/accounts_controller.py:3658
+#: erpnext/controllers/accounts_controller.py:3661
 msgid "Finished Good Item is not specified for service item {0}"
 msgstr "服务物料{0}未指定产成品物料"
 
-#: erpnext/controllers/accounts_controller.py:3675
+#: erpnext/controllers/accounts_controller.py:3678
 msgid "Finished Good Item {0} Qty can not be zero"
 msgstr "产成品物料{0}数量不可为零"
 
-#: erpnext/controllers/accounts_controller.py:3669
+#: erpnext/controllers/accounts_controller.py:3672
 msgid "Finished Good Item {0} must be a sub-contracted item"
 msgstr "产成品物料{0}必须为外协物料"
 
@@ -20895,7 +20881,7 @@ msgstr "固定资产科目"
 msgid "Fixed Asset Defaults"
 msgstr "固定资产默认值"
 
-#: erpnext/stock/doctype/item/item.py:301
+#: erpnext/stock/doctype/item/item.py:304
 msgid "Fixed Asset Item must be a non-stock item."
 msgstr "固定资产物料必须为非库存物料"
 
@@ -21071,7 +21057,7 @@ msgstr "生产数量必填"
 msgid "For Raw Materials"
 msgstr "针对原材料"
 
-#: erpnext/controllers/accounts_controller.py:1259
+#: erpnext/controllers/accounts_controller.py:1262
 msgid "For Return Invoices with Stock effect, '0' qty Items are not allowed. Following rows are affected: {0}"
 msgstr "库存影响的退货发票中不允许零数量物料，受影响行：{0}"
 
@@ -21172,7 +21158,7 @@ msgstr "为方便客户，这些代码可用于发票和交货单等打印格式
 msgid "For the item {0}, the quantity should be {1} according to the BOM {2}."
 msgstr "物料{0}的数量根据BOM{2}应为{1}"
 
-#: erpnext/public/js/controllers/transaction.js:1088
+#: erpnext/public/js/controllers/transaction.js:1114
 msgctxt "Clear payment terms template and/or payment schedule when due date is changed"
 msgid "For the new {0} to take effect, would you like to clear the current {1}?"
 msgstr "为使新{0}生效，是否清除当前{1}？"
@@ -21181,7 +21167,7 @@ msgstr "为使新{0}生效，是否清除当前{1}？"
 msgid "For the {0}, no stock is available for the return in the warehouse {1}."
 msgstr "{0}在仓库{1}中无可用退货库存"
 
-#: erpnext/controllers/sales_and_purchase_return.py:1144
+#: erpnext/controllers/sales_and_purchase_return.py:1049
 msgid "For the {0}, the quantity is required to make the return entry"
 msgstr "{0}需要数量才能创建退货分录"
 
@@ -21518,7 +21504,7 @@ msgstr "起始日期不能晚于截止日期"
 msgid "From Date is mandatory"
 msgstr "起始日期必填"
 
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:52
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:53
 #: erpnext/accounts/report/general_ledger/general_ledger.py:86
 #: erpnext/accounts/report/pos_register/pos_register.py:115
 #: erpnext/accounts/report/tax_withholding_details/tax_withholding_details.py:39
@@ -21895,14 +21881,14 @@ msgstr "子节点只能创建于'组'类型节点下"
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:186
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:155
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1134
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1136
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:177
 msgid "Future Payment Amount"
 msgstr "未来付款金额"
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:185
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:154
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1133
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1135
 msgid "Future Payment Ref"
 msgstr "未来付款参考"
 
@@ -23076,7 +23062,7 @@ msgstr "若业务存在季节性波动，可帮助您将预算/目标分摊至�
 msgid "Here are the error logs for the aforementioned failed depreciation entries: {0}"
 msgstr "上述失败折旧分录的错误日志如下：{0}"
 
-#: erpnext/stock/stock_ledger.py:1862
+#: erpnext/stock/stock_ledger.py:1871
 msgid "Here are the options to proceed:"
 msgstr "以下是可执行的操作选项："
 
@@ -23602,7 +23588,7 @@ msgstr "若设置，仅允许具有此角色的用户创建或修改早于特定
 msgid "If more than one package of the same type (for print)"
 msgstr "若存在多个同类型包裹（用于打印）"
 
-#: erpnext/stock/stock_ledger.py:1872
+#: erpnext/stock/stock_ledger.py:1881
 msgid "If not, you can Cancel / Submit this entry"
 msgstr "若否，可取消/提交此分录"
 
@@ -23627,7 +23613,7 @@ msgstr "若物料清单产生废料，需选择废品仓库"
 msgid "If the account is frozen, entries are allowed to restricted users."
 msgstr "若账户冻结，仅允许受限用户录入分录"
 
-#: erpnext/stock/stock_ledger.py:1865
+#: erpnext/stock/stock_ledger.py:1874
 msgid "If the item is transacting as a Zero Valuation Rate item in this entry, please enable 'Allow Zero Valuation Rate' in the {0} Item table."
 msgstr "若此分录中物料以零计价汇率交易，请在{0}物料表中启用'允许零计价汇率'"
 
@@ -24625,7 +24611,7 @@ msgstr "交易后结余数量错误"
 msgid "Incorrect Batch Consumed"
 msgstr "消耗批次错误"
 
-#: erpnext/stock/doctype/item/item.py:514
+#: erpnext/stock/doctype/item/item.py:517
 msgid "Incorrect Check in (group) Warehouse for Reorder"
 msgstr "再订购（组）仓库检查错误"
 
@@ -24674,7 +24660,7 @@ msgstr "序列及批次包错误"
 msgid "Incorrect Stock Value Report"
 msgstr "库存价值报告错误"
 
-#: erpnext/stock/serial_batch_bundle.py:134
+#: erpnext/stock/serial_batch_bundle.py:135
 msgid "Incorrect Type of Transaction"
 msgstr "交易类型错误"
 
@@ -24943,8 +24929,8 @@ msgstr "说明"
 msgid "Insufficient Capacity"
 msgstr "产能不足"
 
-#: erpnext/controllers/accounts_controller.py:3590
-#: erpnext/controllers/accounts_controller.py:3614
+#: erpnext/controllers/accounts_controller.py:3593
+#: erpnext/controllers/accounts_controller.py:3617
 msgid "Insufficient Permissions"
 msgstr "权限不足"
 
@@ -24952,12 +24938,12 @@ msgstr "权限不足"
 #: erpnext/stock/doctype/pick_list/pick_list.py:127
 #: erpnext/stock/doctype/pick_list/pick_list.py:975
 #: erpnext/stock/doctype/stock_entry/stock_entry.py:759
-#: erpnext/stock/serial_batch_bundle.py:989 erpnext/stock/stock_ledger.py:1559
-#: erpnext/stock/stock_ledger.py:2032
+#: erpnext/stock/serial_batch_bundle.py:1021 erpnext/stock/stock_ledger.py:1568
+#: erpnext/stock/stock_ledger.py:2040
 msgid "Insufficient Stock"
 msgstr "库存不足"
 
-#: erpnext/stock/stock_ledger.py:2047
+#: erpnext/stock/stock_ledger.py:2055
 msgid "Insufficient Stock for Batch"
 msgstr "批次库存不足"
 
@@ -25095,11 +25081,11 @@ msgstr "内部客户"
 msgid "Internal Customer for company {0} already exists"
 msgstr "公司{0}的内部客户已存在"
 
-#: erpnext/controllers/accounts_controller.py:728
+#: erpnext/controllers/accounts_controller.py:731
 msgid "Internal Sale or Delivery Reference missing."
 msgstr "缺少内部销售或交付参考"
 
-#: erpnext/controllers/accounts_controller.py:730
+#: erpnext/controllers/accounts_controller.py:733
 msgid "Internal Sales Reference Missing"
 msgstr "缺少内部销售参考"
 
@@ -25130,7 +25116,7 @@ msgstr "公司{0}的内部供应商已存在"
 msgid "Internal Transfer"
 msgstr "内部调拨"
 
-#: erpnext/controllers/accounts_controller.py:739
+#: erpnext/controllers/accounts_controller.py:742
 msgid "Internal Transfer Reference Missing"
 msgstr "缺少内部调拨参考"
 
@@ -25173,8 +25159,8 @@ msgstr "无效"
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:969
 #: erpnext/assets/doctype/asset_category/asset_category.py:69
 #: erpnext/assets/doctype/asset_category/asset_category.py:97
-#: erpnext/controllers/accounts_controller.py:2975
-#: erpnext/controllers/accounts_controller.py:2983
+#: erpnext/controllers/accounts_controller.py:2978
+#: erpnext/controllers/accounts_controller.py:2986
 msgid "Invalid Account"
 msgstr "无效科目"
 
@@ -25199,7 +25185,7 @@ msgstr "无效自动重复日期"
 msgid "Invalid Barcode. There is no Item attached to this barcode."
 msgstr "无效条码，未关联任何物料"
 
-#: erpnext/public/js/controllers/transaction.js:2631
+#: erpnext/public/js/controllers/transaction.js:2657
 msgid "Invalid Blanket Order for the selected Customer and Item"
 msgstr "所选客户和物料的无效一揽子订单"
 
@@ -25213,7 +25199,7 @@ msgstr "无效的内部交易公司"
 
 #: erpnext/assets/doctype/asset/asset.py:295
 #: erpnext/assets/doctype/asset/asset.py:302
-#: erpnext/controllers/accounts_controller.py:2998
+#: erpnext/controllers/accounts_controller.py:3001
 msgid "Invalid Cost Center"
 msgstr "无效成本中心"
 
@@ -25255,7 +25241,7 @@ msgstr "无效分组依据"
 msgid "Invalid Item"
 msgstr "无效物料"
 
-#: erpnext/stock/doctype/item/item.py:1410
+#: erpnext/stock/doctype/item/item.py:1404
 msgid "Invalid Item Defaults"
 msgstr "无效物料默认值"
 
@@ -25301,11 +25287,11 @@ msgstr "无效的工艺损耗配置"
 msgid "Invalid Purchase Invoice"
 msgstr "无效的采购发票"
 
-#: erpnext/controllers/accounts_controller.py:3627
+#: erpnext/controllers/accounts_controller.py:3630
 msgid "Invalid Qty"
 msgstr "无效的数量"
 
-#: erpnext/controllers/accounts_controller.py:1277
+#: erpnext/controllers/accounts_controller.py:1280
 msgid "Invalid Quantity"
 msgstr "无效的物料数量"
 
@@ -25322,7 +25308,7 @@ msgstr "无效销售发票"
 msgid "Invalid Schedule"
 msgstr "无效的排程计划"
 
-#: erpnext/controllers/selling_controller.py:243
+#: erpnext/controllers/selling_controller.py:251
 msgid "Invalid Selling Price"
 msgstr "无效的销售单价"
 
@@ -25355,7 +25341,7 @@ msgstr "无效的条件表达式"
 msgid "Invalid lost reason {0}, please create a new lost reason"
 msgstr "无效的流失原因{0}，请创建新的流失原因"
 
-#: erpnext/stock/doctype/item/item.py:408
+#: erpnext/stock/doctype/item/item.py:411
 msgid "Invalid naming series (. missing) for {0}"
 msgstr "编号规则无效（缺少.）于{0}"
 
@@ -25395,7 +25381,7 @@ msgstr "库存"
 #. Name of a DocType
 #: erpnext/patches/v15_0/refactor_closing_stock_balance.py:43
 #: erpnext/stock/doctype/inventory_dimension/inventory_dimension.json
-#: erpnext/stock/doctype/inventory_dimension/inventory_dimension.py:180
+#: erpnext/stock/doctype/inventory_dimension/inventory_dimension.py:181
 msgid "Inventory Dimension"
 msgstr "库存维度"
 
@@ -25461,7 +25447,7 @@ msgstr "发票日期"
 msgid "Invoice Discounting"
 msgstr "发票贴现"
 
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1114
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1116
 msgid "Invoice Grand Total"
 msgstr "发票价税合计"
 
@@ -25554,7 +25540,7 @@ msgstr "零计费时段无法开具发票"
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:169
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:144
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1116
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1118
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:164
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:165
 msgid "Invoiced Amount"
@@ -25960,6 +25946,11 @@ msgstr "是否期初分录"
 msgid "Is Outward"
 msgstr "是否出库"
 
+#. Label of the is_packed (Check) field in DocType 'Serial and Batch Bundle'
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.json
+msgid "Is Packed"
+msgstr ""
+
 #. Label of the is_paid (Check) field in DocType 'Purchase Invoice'
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 msgid "Is Paid"
@@ -26242,11 +26233,11 @@ msgstr "发放日期"
 msgid "Issuing cannot be done to a location. Please enter employee to issue the Asset {0} to"
 msgstr "资产{0}不能发放至库位，请输入领用员工"
 
-#: erpnext/stock/doctype/item/item.py:565
+#: erpnext/stock/doctype/item/item.py:571
 msgid "It can take upto few hours for accurate stock values to be visible after merging items."
 msgstr "物料合并后需等待数小时才能查看准确的库存值。"
 
-#: erpnext/public/js/controllers/transaction.js:2075
+#: erpnext/public/js/controllers/transaction.js:2101
 msgid "It is needed to fetch Item Details."
 msgstr "需要获取物料详细信息。"
 
@@ -26296,7 +26287,7 @@ msgstr "总金额为零时无法按金额分摊费用，请将'费用分摊基�
 #: erpnext/buying/report/supplier_quotation_comparison/supplier_quotation_comparison.js:33
 #: erpnext/buying/report/supplier_quotation_comparison/supplier_quotation_comparison.py:204
 #: erpnext/buying/workspace/buying/buying.json
-#: erpnext/controllers/taxes_and_totals.py:1125
+#: erpnext/controllers/taxes_and_totals.py:1135
 #: erpnext/manufacturing/doctype/blanket_order/blanket_order.json
 #: erpnext/manufacturing/doctype/bom/bom.js:944
 #: erpnext/manufacturing/doctype/bom/bom.json
@@ -26574,7 +26565,7 @@ msgstr "物料购物车"
 #: erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py:86
 #: erpnext/manufacturing/report/work_order_stock_report/work_order_stock_report.py:119
 #: erpnext/projects/doctype/timesheet/timesheet.js:213
-#: erpnext/public/js/controllers/transaction.js:2350
+#: erpnext/public/js/controllers/transaction.js:2376
 #: erpnext/public/js/stock_reservation.js:112
 #: erpnext/public/js/stock_reservation.js:317 erpnext/public/js/utils.js:500
 #: erpnext/public/js/utils.js:656
@@ -27012,7 +27003,7 @@ msgstr "物料制造商"
 #: erpnext/manufacturing/report/production_planning_report/production_planning_report.py:359
 #: erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py:92
 #: erpnext/manufacturing/report/work_order_consumed_materials/work_order_consumed_materials.py:138
-#: erpnext/public/js/controllers/transaction.js:2356
+#: erpnext/public/js/controllers/transaction.js:2382
 #: erpnext/public/js/utils.js:746
 #: erpnext/selling/doctype/quotation_item/quotation_item.json
 #: erpnext/selling/doctype/sales_order_item/sales_order_item.json
@@ -27279,7 +27270,7 @@ msgstr "物料变体参数设置"
 msgid "Item Variant {0} already exists with same attributes"
 msgstr "物料变体{0}已存在相同属性"
 
-#: erpnext/stock/doctype/item/item.py:781
+#: erpnext/stock/doctype/item/item.py:772
 msgid "Item Variants updated"
 msgstr "物料变体已更新"
 
@@ -27345,7 +27336,7 @@ msgstr "物料与质保明细"
 msgid "Item for row {0} does not match Material Request"
 msgstr "行{0}的物料与物料请求不匹配"
 
-#: erpnext/stock/doctype/item/item.py:795
+#: erpnext/stock/doctype/item/item.py:789
 msgid "Item has variants."
 msgstr "该物料存在变体。"
 
@@ -27371,7 +27362,7 @@ msgstr "物料名称"
 msgid "Item operation"
 msgstr "物料工序"
 
-#: erpnext/controllers/accounts_controller.py:3650
+#: erpnext/controllers/accounts_controller.py:3653
 msgid "Item qty can not be updated as raw materials are already processed."
 msgstr "因原材料已处理，物料数量不可更新"
 
@@ -27397,7 +27388,7 @@ msgstr "物料估价率已根据到岸成本凭证金额重新计算"
 msgid "Item valuation reposting in progress. Report might show incorrect item valuation."
 msgstr "正在进行物料估价重过账，报表可能显示错误估价"
 
-#: erpnext/stock/doctype/item/item.py:952
+#: erpnext/stock/doctype/item/item.py:946
 msgid "Item variant {0} exists with same attributes"
 msgstr "物料变体{0}已存在相同属性"
 
@@ -27410,8 +27401,7 @@ msgid "Item {0} cannot be ordered more than {1} against Blanket Order {2}."
 msgstr "物料{0}在总括订单{2}下不可订购超过{1}"
 
 #: erpnext/assets/doctype/asset/asset.py:277
-#: erpnext/stock/doctype/item/item.py:630
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:167
+#: erpnext/stock/doctype/item/item.py:636
 msgid "Item {0} does not exist"
 msgstr "物料{0}不存在"
 
@@ -27423,7 +27413,7 @@ msgstr "物料{0}在系统中不存在或已过期"
 msgid "Item {0} does not exist."
 msgstr "物料{0}不存在"
 
-#: erpnext/controllers/selling_controller.py:752
+#: erpnext/controllers/selling_controller.py:760
 msgid "Item {0} entered multiple times."
 msgstr "物料{0}重复输入"
 
@@ -27439,7 +27429,7 @@ msgstr "物料{0}已被停用"
 msgid "Item {0} has no Serial No. Only serialized items can have delivery based on Serial No"
 msgstr "物料{0}无序列号，只有序列化物料可按序列号交货"
 
-#: erpnext/stock/doctype/item/item.py:1126
+#: erpnext/stock/doctype/item/item.py:1120
 msgid "Item {0} has reached its end of life on {1}"
 msgstr "物料{0}已于{1}达到生命周期终止"
 
@@ -27451,11 +27441,11 @@ msgstr "物料{0}被忽略，因非库存物料"
 msgid "Item {0} is already reserved/delivered against Sales Order {1}."
 msgstr "物料{0}已针对销售订单{1}预留/交货"
 
-#: erpnext/stock/doctype/item/item.py:1146
+#: erpnext/stock/doctype/item/item.py:1140
 msgid "Item {0} is cancelled"
 msgstr "物料{0}已取消"
 
-#: erpnext/stock/doctype/item/item.py:1130
+#: erpnext/stock/doctype/item/item.py:1124
 msgid "Item {0} is disabled"
 msgstr "物料{0}已停用"
 
@@ -27463,7 +27453,7 @@ msgstr "物料{0}已停用"
 msgid "Item {0} is not a serialized Item"
 msgstr "物料{0}非序列化物料"
 
-#: erpnext/stock/doctype/item/item.py:1138
+#: erpnext/stock/doctype/item/item.py:1132
 msgid "Item {0} is not a stock Item"
 msgstr "物料{0}非库存物料"
 
@@ -27507,7 +27497,7 @@ msgstr "物料{0}：订购数量{1}不可小于最小订单量{2}（物料定义
 msgid "Item {0}: {1} qty produced. "
 msgstr "物料{0}：已生产数量{1}"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1429
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1423
 msgid "Item {} does not exist."
 msgstr "物料{}不存在"
 
@@ -27647,7 +27637,7 @@ msgstr "待申请物料"
 msgid "Items and Pricing"
 msgstr "物料与价格"
 
-#: erpnext/controllers/accounts_controller.py:3872
+#: erpnext/controllers/accounts_controller.py:3875
 msgid "Items cannot be updated as Subcontracting Order is created against the Purchase Order {0}."
 msgstr "因已针对采购订单{0}创建外协订单，物料不可更新"
 
@@ -28143,7 +28133,7 @@ msgstr "到岸成本税费"
 
 #. Name of a DocType
 #. Label of a Link in the Stock Workspace
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:674
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:676
 #: erpnext/stock/doctype/landed_cost_voucher/landed_cost_voucher.json
 #: erpnext/stock/doctype/purchase_receipt/purchase_receipt.js:104
 #: erpnext/stock/workspace/stock/stock.json
@@ -28759,7 +28749,7 @@ msgstr "关联发票"
 msgid "Linked Location"
 msgstr "关联位置"
 
-#: erpnext/stock/doctype/item/item.py:999
+#: erpnext/stock/doctype/item/item.py:993
 msgid "Linked with submitted documents"
 msgstr "与已提交单据关联"
 
@@ -29498,7 +29488,7 @@ msgstr "总经理"
 #: erpnext/manufacturing/doctype/bom/bom.py:261
 #: erpnext/manufacturing/doctype/bom_update_log/bom_update_log.py:71
 #: erpnext/public/js/controllers/accounts.js:249
-#: erpnext/public/js/controllers/transaction.js:2753
+#: erpnext/public/js/controllers/transaction.js:2779
 #: erpnext/public/js/utils/party.js:321
 #: erpnext/stock/doctype/delivery_note/delivery_note.js:164
 #: erpnext/stock/doctype/inventory_dimension/inventory_dimension.json
@@ -30354,7 +30344,7 @@ msgstr "最大使用量"
 msgid "Maximum Value"
 msgstr "最大值"
 
-#: erpnext/controllers/selling_controller.py:212
+#: erpnext/controllers/selling_controller.py:220
 msgid "Maximum discount for Item {0} is {1}%"
 msgstr "物料{0}的最大折扣为{1}%"
 
@@ -30424,7 +30414,7 @@ msgstr "兆焦耳"
 msgid "Megawatt"
 msgstr "兆瓦"
 
-#: erpnext/stock/stock_ledger.py:1878
+#: erpnext/stock/stock_ledger.py:1887
 msgid "Mention Valuation Rate in the Item master."
 msgstr "请在物料主数据中注明估值率"
 
@@ -30819,11 +30809,11 @@ msgstr "分钟数"
 msgid "Miscellaneous Expenses"
 msgstr "杂项费用"
 
-#: erpnext/controllers/buying_controller.py:540
+#: erpnext/controllers/buying_controller.py:548
 msgid "Mismatch"
 msgstr "不匹配"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1430
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1424
 msgid "Missing"
 msgstr "缺失"
 
@@ -31350,7 +31340,7 @@ msgstr "多规格型号"
 msgid "Multiple Warehouse Accounts"
 msgstr "多仓库科目"
 
-#: erpnext/controllers/accounts_controller.py:1129
+#: erpnext/controllers/accounts_controller.py:1132
 msgid "Multiple fiscal years exist for the date {0}. Please set company in Fiscal Year"
 msgstr "日期{0}对应多个会计年度，请在会计年度中设置公司"
 
@@ -31501,7 +31491,7 @@ msgstr "命名规则前缀"
 msgid "Naming Series and Price Defaults"
 msgstr "命名规则与价格默认值"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:90
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:91
 msgid "Naming Series is mandatory"
 msgstr "命名规则为必填项"
 
@@ -31540,15 +31530,15 @@ msgstr "天然气"
 msgid "Needs Analysis"
 msgstr "需求分析"
 
-#: erpnext/stock/serial_batch_bundle.py:1277
+#: erpnext/stock/serial_batch_bundle.py:1309
 msgid "Negative Batch Quantity"
 msgstr "负批次数量"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:610
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:606
 msgid "Negative Quantity is not allowed"
 msgstr "不允许负数量"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:615
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:611
 msgid "Negative Valuation Rate is not allowed"
 msgstr "不允许负计价率"
 
@@ -31830,7 +31820,7 @@ msgstr "净重"
 msgid "Net Weight UOM"
 msgstr "净重单位"
 
-#: erpnext/controllers/accounts_controller.py:1483
+#: erpnext/controllers/accounts_controller.py:1486
 msgid "Net total calculation precision loss"
 msgstr "净总计计算精度损失"
 
@@ -32173,7 +32163,7 @@ msgstr "未找到POS配置，请先创建新POS配置"
 #: erpnext/accounts/doctype/journal_entry/journal_entry.py:1539
 #: erpnext/accounts/doctype/journal_entry/journal_entry.py:1599
 #: erpnext/accounts/doctype/journal_entry/journal_entry.py:1613
-#: erpnext/stock/doctype/item/item.py:1371
+#: erpnext/stock/doctype/item/item.py:1365
 msgid "No Permission"
 msgstr "无权限"
 
@@ -32195,7 +32185,7 @@ msgstr "无备注"
 msgid "No Selection"
 msgstr "无选择项"
 
-#: erpnext/controllers/sales_and_purchase_return.py:919
+#: erpnext/controllers/sales_and_purchase_return.py:824
 msgid "No Serial / Batches are available for return"
 msgstr "无可用退换货的序列号/批次"
 
@@ -32231,7 +32221,7 @@ msgstr "未找到该交易方的未对账付款"
 msgid "No Work Orders were created"
 msgstr "未创建工单"
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:785
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:794
 #: erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py:689
 msgid "No accounting entries for the following warehouses"
 msgstr "以下仓库无会计凭证"
@@ -32420,7 +32410,7 @@ msgstr "付款表中无记录"
 msgid "No reserved stock to unreserve."
 msgstr "无预留库存可取消预留"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:773
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:769
 msgid "No stock ledger entries were created. Please set the quantity or valuation rate for the items properly and try again."
 msgstr "未生成库存分类账条目。请正确设置物料数量或计价率后重试。"
 
@@ -32504,7 +32494,7 @@ msgstr "数量"
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:566
 #: erpnext/assets/doctype/asset/asset.js:612
 #: erpnext/assets/doctype/asset/asset.js:627
-#: erpnext/controllers/buying_controller.py:225
+#: erpnext/controllers/buying_controller.py:233
 #: erpnext/selling/doctype/product_bundle/product_bundle.py:72
 #: erpnext/setup/doctype/transaction_deletion_record/transaction_deletion_record.py:80
 msgid "Not Allowed"
@@ -32625,10 +32615,10 @@ msgstr "不允许"
 #: erpnext/selling/doctype/customer/customer.py:129
 #: erpnext/selling/doctype/sales_order/sales_order.js:1168
 #: erpnext/stock/doctype/item/item.js:526
-#: erpnext/stock/doctype/item/item.py:567
+#: erpnext/stock/doctype/item/item.py:573
 #: erpnext/stock/doctype/item_price/item_price.json
 #: erpnext/stock/doctype/stock_entry/stock_entry.py:1374
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:972
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:968
 #: erpnext/templates/pages/timelog_info.html:43
 msgid "Note"
 msgstr "备注"
@@ -32637,7 +32627,7 @@ msgstr "备注"
 msgid "Note: Automatic log deletion only applies to logs of type <i>Update Cost</i>"
 msgstr "注：自动日志删除仅适用于<i>更新成本</i>类型的日志"
 
-#: erpnext/accounts/party.py:690
+#: erpnext/accounts/party.py:696
 msgid "Note: Due Date exceeds allowed {0} credit days by {1} day(s)"
 msgstr "注意：到期日超过允许的{0}天信用期{1}天。"
 
@@ -32663,7 +32653,7 @@ msgstr "注：未指定'现金或银行账户'，不会创建付款凭证"
 msgid "Note: This Cost Center is a Group. Cannot make accounting entries against groups."
 msgstr "注：该成本中心为组，不能针对组创建会计凭证"
 
-#: erpnext/stock/doctype/item/item.py:621
+#: erpnext/stock/doctype/item/item.py:627
 msgid "Note: To merge the items, create a separate Stock Reconciliation for the old item {0}"
 msgstr "注：要合并物料，请为旧物料{0}创建单独的库存对账"
 
@@ -33427,7 +33417,7 @@ msgstr "已创建期初销售发票"
 
 #. Label of the opening_stock (Float) field in DocType 'Item'
 #. Option for the 'Purpose' (Select) field in DocType 'Stock Reconciliation'
-#: erpnext/stock/doctype/item/item.json erpnext/stock/doctype/item/item.py:296
+#: erpnext/stock/doctype/item/item.json erpnext/stock/doctype/item/item.py:299
 #: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.json
 msgid "Opening Stock"
 msgstr "期初库存"
@@ -34147,7 +34137,7 @@ msgstr "未清金额（公司货币）"
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:149
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1123
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1125
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:167
 #: erpnext/accounts/report/purchase_register/purchase_register.py:289
 #: erpnext/accounts/report/sales_register/sales_register.py:319
@@ -34186,7 +34176,7 @@ msgstr "外向"
 msgid "Over Billing Allowance (%)"
 msgstr "超计费容差率（%）"
 
-#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:1242
+#: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py:1251
 msgid "Over Billing Allowance exceeded for Purchase Receipt Item {0} ({1}) by {2}%"
 msgstr "采购收据物料{0}（{1}）超账单容差达{2}%。"
 
@@ -34227,7 +34217,7 @@ msgstr "超调拨容差率（%）"
 msgid "Overbilling of {0} {1} ignored for item {2} because you have {3} role."
 msgstr "因您具有{3}角色，物料{2}的{0} {1}超计费已被忽略"
 
-#: erpnext/controllers/accounts_controller.py:2013
+#: erpnext/controllers/accounts_controller.py:2016
 msgid "Overbilling of {} ignored because you have {} role."
 msgstr "因您具有{}角色，{}超计费已被忽略"
 
@@ -34734,7 +34724,7 @@ msgstr "已付款"
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:146
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1117
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1119
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:165
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:172
 #: erpnext/accounts/report/pos_register/pos_register.py:209
@@ -34967,7 +34957,7 @@ msgstr "上级流程"
 msgid "Parent Row No"
 msgstr "上级行号"
 
-#: erpnext/manufacturing/doctype/bom_creator/bom_creator.py:495
+#: erpnext/manufacturing/doctype/bom_creator/bom_creator.py:496
 msgid "Parent Row No not found for {0}"
 msgstr "未找到{0}的上级行号"
 
@@ -35196,7 +35186,7 @@ msgstr "百万分率"
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:142
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:159
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:57
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1054
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1056
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:67
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:147
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:228
@@ -35222,7 +35212,7 @@ msgstr "交易方"
 
 #. Name of a DocType
 #: erpnext/accounts/doctype/party_account/party_account.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1065
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1067
 msgid "Party Account"
 msgstr "交易方账户"
 
@@ -35249,7 +35239,7 @@ msgstr "交易方账户币种"
 msgid "Party Account No. (Bank Statement)"
 msgstr "交易方账号（银行对账单）"
 
-#: erpnext/controllers/accounts_controller.py:2278
+#: erpnext/controllers/accounts_controller.py:2281
 msgid "Party Account {0} currency ({1}) and document currency ({2}) should be same"
 msgstr "交易方账户{0}币种（{1}）应与单据币种（{2}）一致"
 
@@ -35266,6 +35256,11 @@ msgstr "交易方银行账户"
 #: erpnext/accounts/doctype/payment_request/payment_request.json
 msgid "Party Details"
 msgstr "交易方明细"
+
+#. Label of the party_full_name (Data) field in DocType 'Contract'
+#: erpnext/crm/doctype/contract/contract.json
+msgid "Party Full Name"
+msgstr ""
 
 #. Label of the bank_party_iban (Data) field in DocType 'Bank Transaction'
 #: erpnext/accounts/doctype/bank_transaction/bank_transaction.json
@@ -35350,7 +35345,7 @@ msgstr "交易方特定物料"
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:84
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:54
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:44
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1048
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1050
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:54
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:141
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:219
@@ -35372,7 +35367,7 @@ msgstr "交易方特定物料"
 msgid "Party Type"
 msgstr "交易方类型"
 
-#: erpnext/accounts/party.py:819
+#: erpnext/accounts/party.py:825
 msgid "Party Type and Party can only be set for Receivable / Payable account<br><br>{0}"
 msgstr "交易方类型和交易方仅可设置应收/应付账户<br><br>{0}"
 
@@ -35494,7 +35489,7 @@ msgid "Payable"
 msgstr "应付"
 
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:42
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1063
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1065
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:211
 #: erpnext/accounts/report/purchase_register/purchase_register.py:194
 #: erpnext/accounts/report/purchase_register/purchase_register.py:235
@@ -35660,7 +35655,7 @@ msgstr "付款分录已被修改，请重新拉取"
 msgid "Payment Entry is already created"
 msgstr "付款分录已创建"
 
-#: erpnext/controllers/accounts_controller.py:1434
+#: erpnext/controllers/accounts_controller.py:1437
 msgid "Payment Entry {0} is linked against Order {1}, check if it should be pulled as advance in this invoice."
 msgstr "付款分录{0}关联订单{1}，请检查是否应作为预付款拉入本发票"
 
@@ -35942,7 +35937,7 @@ msgstr "付款状态"
 #: erpnext/accounts/doctype/payment_schedule/payment_schedule.json
 #: erpnext/accounts/doctype/payment_term/payment_term.json
 #: erpnext/accounts/doctype/payment_terms_template_detail/payment_terms_template_detail.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1113
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1115
 #: erpnext/accounts/report/gross_profit/gross_profit.py:412
 #: erpnext/accounts/workspace/accounting/accounting.json
 #: erpnext/selling/report/payment_terms_status_for_sales_order/payment_terms_status_for_sales_order.py:30
@@ -37006,7 +37001,7 @@ msgstr "请对启用'更新库存'的发票创建到岸成本凭证"
 msgid "Please create a new Accounting Dimension if required."
 msgstr "如需，请新建会计维度"
 
-#: erpnext/controllers/accounts_controller.py:729
+#: erpnext/controllers/accounts_controller.py:732
 msgid "Please create purchase from internal sale or delivery document itself"
 msgstr "请通过内部销售或交货单据创建采购"
 
@@ -37014,7 +37009,7 @@ msgstr "请通过内部销售或交货单据创建采购"
 msgid "Please create purchase receipt or purchase invoice for the item {0}"
 msgstr "请为物料{0}创建采购收据或采购发票"
 
-#: erpnext/stock/doctype/item/item.py:649
+#: erpnext/stock/doctype/item/item.py:655
 msgid "Please delete Product Bundle {0}, before merging {1} into {2}"
 msgstr "在合并{1}到{2}前，请先删除产品套装{0}"
 
@@ -37056,7 +37051,7 @@ msgstr "请启用弹出窗口"
 msgid "Please enable {0} in the {1}."
 msgstr "请在{1}中启用{0}"
 
-#: erpnext/controllers/selling_controller.py:754
+#: erpnext/controllers/selling_controller.py:762
 msgid "Please enable {} in {} to allow same item in multiple rows"
 msgstr "请在{}中启用{}以允许同一物料多行显示"
 
@@ -37089,7 +37084,7 @@ msgstr "请输入找零金额账户"
 msgid "Please enter Approving Role or Approving User"
 msgstr "请输入审批角色或审批用户"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:939
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:935
 msgid "Please enter Cost Center"
 msgstr "请输入成本中心"
 
@@ -37101,7 +37096,7 @@ msgstr "请输入交货日期"
 msgid "Please enter Employee Id of this sales person"
 msgstr "请输入该销售员的员工编号"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:948
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:944
 msgid "Please enter Expense Account"
 msgstr "请输入费用账户"
 
@@ -37110,7 +37105,7 @@ msgstr "请输入费用账户"
 msgid "Please enter Item Code to get Batch Number"
 msgstr "请输入物料编码以获取批次号"
 
-#: erpnext/public/js/controllers/transaction.js:2503
+#: erpnext/public/js/controllers/transaction.js:2529
 msgid "Please enter Item Code to get batch no"
 msgstr "请输入物料编码以获取批次号"
 
@@ -37175,7 +37170,7 @@ msgstr "请先输入公司"
 msgid "Please enter company name first"
 msgstr "请先输入公司名称"
 
-#: erpnext/controllers/accounts_controller.py:2764
+#: erpnext/controllers/accounts_controller.py:2767
 msgid "Please enter default currency in Company Master"
 msgstr "请在主公司中输入默认货币"
 
@@ -37211,7 +37206,7 @@ msgstr "请输入公司名称以确认"
 msgid "Please enter the phone number first"
 msgstr "请先输入电话号码"
 
-#: erpnext/controllers/buying_controller.py:1007
+#: erpnext/controllers/buying_controller.py:1015
 msgid "Please enter the {schedule_date}."
 msgstr "请输入{schedule_date}"
 
@@ -37313,7 +37308,7 @@ msgstr "请先保存"
 msgid "Please select <b>Template Type</b> to download template"
 msgstr "请选择<b>模板类型</b>以下载模板"
 
-#: erpnext/controllers/taxes_and_totals.py:721
+#: erpnext/controllers/taxes_and_totals.py:731
 #: erpnext/public/js/controllers/taxes_and_totals.js:721
 msgid "Please select Apply Discount On"
 msgstr "请选择应用折扣于"
@@ -37326,7 +37321,7 @@ msgstr "请为物料{0}选择物料清单"
 msgid "Please select BOM for Item in Row {0}"
 msgstr "请为行{0}的物料选择物料清单"
 
-#: erpnext/controllers/buying_controller.py:467
+#: erpnext/controllers/buying_controller.py:475
 msgid "Please select BOM in BOM field for Item {item_code}."
 msgstr "请为物料{item_code}在BOM字段选择物料清单"
 
@@ -37408,7 +37403,7 @@ msgstr "请选择价格表"
 msgid "Please select Qty against item {0}"
 msgstr "请选择物料{0}的数量"
 
-#: erpnext/stock/doctype/item/item.py:320
+#: erpnext/stock/doctype/item/item.py:323
 msgid "Please select Sample Retention Warehouse in Stock Settings first"
 msgstr "请先在库存设置中选择留样仓库"
 
@@ -37424,7 +37419,7 @@ msgstr "请选择物料{0}的起止日期"
 msgid "Please select Subcontracting Order instead of Purchase Order {0}"
 msgstr "请选择委外订单而非采购订单{0}"
 
-#: erpnext/controllers/accounts_controller.py:2613
+#: erpnext/controllers/accounts_controller.py:2616
 msgid "Please select Unrealized Profit / Loss account or add default Unrealized Profit / Loss account account for company {0}"
 msgstr "请选择未实现损益账户或为公司{0}添加默认未实现损益账户"
 
@@ -37440,7 +37435,7 @@ msgstr "请选择公司"
 #: erpnext/manufacturing/doctype/bom/bom.js:603
 #: erpnext/manufacturing/doctype/bom/bom.py:261
 #: erpnext/public/js/controllers/accounts.js:249
-#: erpnext/public/js/controllers/transaction.js:2753
+#: erpnext/public/js/controllers/transaction.js:2779
 msgid "Please select a Company first."
 msgstr "请先选择公司"
 
@@ -37598,7 +37593,7 @@ msgstr "请选择{0}"
 msgid "Please select {0} first"
 msgstr "请先选择{0}"
 
-#: erpnext/public/js/controllers/transaction.js:77
+#: erpnext/public/js/controllers/transaction.js:100
 msgid "Please set 'Apply Additional Discount On'"
 msgstr "请设置'应用额外折扣于'"
 
@@ -37783,7 +37778,7 @@ msgstr "请根据物料或仓库设置筛选条件"
 msgid "Please set filters"
 msgstr "请设置筛选条件"
 
-#: erpnext/controllers/accounts_controller.py:2194
+#: erpnext/controllers/accounts_controller.py:2197
 msgid "Please set one of the following:"
 msgstr "请设置以下其中一项："
 
@@ -37791,7 +37786,7 @@ msgstr "请设置以下其中一项："
 msgid "Please set opening number of booked depreciations"
 msgstr "请设置已登记折旧的期初数量。"
 
-#: erpnext/public/js/controllers/transaction.js:2205
+#: erpnext/public/js/controllers/transaction.js:2231
 msgid "Please set recurring after saving"
 msgstr "保存后请设置循环"
 
@@ -37862,7 +37857,7 @@ msgstr "请为公司{1}设置并启用账户类型为{0}的组账户"
 msgid "Please share this email with your support team so that they can find and fix the issue."
 msgstr "请将此邮件转发给支持团队以便排查和解决问题"
 
-#: erpnext/public/js/controllers/transaction.js:2073
+#: erpnext/public/js/controllers/transaction.js:2099
 msgid "Please specify"
 msgstr "请具体说明"
 
@@ -37877,7 +37872,7 @@ msgid "Please specify Company to proceed"
 msgstr "请指定公司以继续"
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.js:1472
-#: erpnext/controllers/accounts_controller.py:2957
+#: erpnext/controllers/accounts_controller.py:2960
 #: erpnext/public/js/controllers/accounts.js:97
 msgid "Please specify a valid Row ID for row {0} in table {1}"
 msgstr "请为表{1}行{0}指定有效行ID"
@@ -37890,7 +37885,7 @@ msgstr "请先指定{0}"
 msgid "Please specify at least one attribute in the Attributes table"
 msgstr "请在属性表中至少指定一个属性"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:605
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:601
 msgid "Please specify either Quantity or Valuation Rate or both"
 msgstr "请指定数量或估价率或两者"
 
@@ -38071,7 +38066,7 @@ msgstr "邮递费用"
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:16
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:15
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:18
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1046
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1048
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:15
 #: erpnext/accounts/report/bank_clearance_summary/bank_clearance_summary.py:35
 #: erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.html:7
@@ -40252,7 +40247,7 @@ msgstr "采购主数据管理"
 #: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.js:48
 #: erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py:203
 #: erpnext/buying/workspace/buying/buying.json
-#: erpnext/controllers/buying_controller.py:739
+#: erpnext/controllers/buying_controller.py:747
 #: erpnext/crm/doctype/contract/contract.json
 #: erpnext/manufacturing/doctype/blanket_order/blanket_order.js:54
 #: erpnext/manufacturing/doctype/production_plan_sub_assembly_item/production_plan_sub_assembly_item.json
@@ -40391,7 +40386,7 @@ msgstr "待开票采购订单"
 msgid "Purchase Orders to Receive"
 msgstr "待接收采购订单"
 
-#: erpnext/controllers/accounts_controller.py:1833
+#: erpnext/controllers/accounts_controller.py:1836
 msgid "Purchase Orders {0} are un-linked"
 msgstr "采购订单{0}已取消关联"
 
@@ -40415,8 +40410,8 @@ msgstr "采购价格表"
 #. Label of a Link in the Stock Workspace
 #. Label of a shortcut in the Stock Workspace
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:171
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:650
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:660
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:652
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:662
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice_list.js:49
 #: erpnext/accounts/doctype/purchase_invoice_item/purchase_invoice_item.json
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:246
@@ -41151,7 +41146,7 @@ msgstr "质量检验模板"
 msgid "Quality Inspection Template Name"
 msgstr "质量检验模板名称"
 
-#: erpnext/public/js/controllers/transaction.js:334
+#: erpnext/public/js/controllers/transaction.js:360
 #: erpnext/stock/doctype/stock_entry/stock_entry.js:165
 msgid "Quality Inspection(s)"
 msgstr "质量检验"
@@ -42335,7 +42330,7 @@ msgid "Receivable / Payable Account"
 msgstr "应收/应付账户"
 
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:71
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1061
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1063
 #: erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py:243
 #: erpnext/accounts/report/sales_register/sales_register.py:217
 #: erpnext/accounts/report/sales_register/sales_register.py:271
@@ -42817,7 +42812,7 @@ msgstr "编号{0}的参考文件，日期{1}"
 msgid "Reference Date"
 msgstr "参考日期"
 
-#: erpnext/public/js/controllers/transaction.js:2311
+#: erpnext/public/js/controllers/transaction.js:2337
 msgid "Reference Date for Early Payment Discount"
 msgstr "提前付款折扣的参考日期"
 
@@ -43141,7 +43136,7 @@ msgstr "常规"
 msgid "Rejected"
 msgstr "已拒绝 "
 
-#: erpnext/stock/doctype/inventory_dimension/inventory_dimension.py:202
+#: erpnext/stock/doctype/inventory_dimension/inventory_dimension.py:203
 msgid "Rejected "
 msgstr "已拒绝 "
 
@@ -43245,7 +43240,7 @@ msgstr "剩余金额"
 
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:187
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:156
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1135
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1137
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:178
 msgid "Remaining Balance"
 msgstr "剩余余额"
@@ -43298,7 +43293,7 @@ msgstr "备注"
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:159
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:198
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:269
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1167
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1169
 #: erpnext/accounts/report/general_ledger/general_ledger.html:84
 #: erpnext/accounts/report/general_ledger/general_ledger.html:110
 #: erpnext/accounts/report/general_ledger/general_ledger.py:742
@@ -44048,7 +44043,7 @@ msgstr "预留数量"
 msgid "Reserved Quantity for Production"
 msgstr "生产预留数量"
 
-#: erpnext/stock/stock_ledger.py:2147
+#: erpnext/stock/stock_ledger.py:2155
 msgid "Reserved Serial No."
 msgstr "预留序列号"
 
@@ -44064,11 +44059,11 @@ msgstr "预留序列号"
 #: erpnext/stock/doctype/pick_list/pick_list.js:153
 #: erpnext/stock/report/reserved_stock/reserved_stock.json
 #: erpnext/stock/report/stock_balance/stock_balance.py:499
-#: erpnext/stock/stock_ledger.py:2131
+#: erpnext/stock/stock_ledger.py:2139
 msgid "Reserved Stock"
 msgstr "预留库存"
 
-#: erpnext/stock/stock_ledger.py:2177
+#: erpnext/stock/stock_ledger.py:2185
 msgid "Reserved Stock for Batch"
 msgstr "批次预留库存"
 
@@ -44080,7 +44075,7 @@ msgstr "原材料预留库存"
 msgid "Reserved Stock for Sub-assembly"
 msgstr "子装配件预留库存"
 
-#: erpnext/controllers/buying_controller.py:476
+#: erpnext/controllers/buying_controller.py:484
 msgid "Reserved Warehouse is mandatory for the Item {item_code} in Raw Materials supplied."
 msgstr "供应原材料中的物料{item_code}必须指定预留仓库"
 
@@ -44894,7 +44889,7 @@ msgstr "工艺路线"
 msgid "Routing Name"
 msgstr "工艺路线名称"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:667
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:663
 msgid "Row #"
 msgstr "行号#"
 
@@ -44932,7 +44927,7 @@ msgstr "行号{0}（付款表）：金额必须为负数"
 msgid "Row #{0} (Payment Table): Amount must be positive"
 msgstr "行号{0}（付款表）：金额必须为正数"
 
-#: erpnext/stock/doctype/item/item.py:495
+#: erpnext/stock/doctype/item/item.py:498
 msgid "Row #{0}: A reorder entry already exists for warehouse {1} with reorder type {2}."
 msgstr "行号{0}：仓库{1}已存在类型为{2}的再订货条目"
 
@@ -44953,7 +44948,7 @@ msgstr "行号{0}：验收仓库与拒收仓库不能相同"
 msgid "Row #{0}: Accepted Warehouse is mandatory for the accepted Item {1}"
 msgstr "行号{0}：验收物料{1}必须指定验收仓库"
 
-#: erpnext/controllers/accounts_controller.py:1117
+#: erpnext/controllers/accounts_controller.py:1120
 msgid "Row #{0}: Account {1} does not belong to company {2}"
 msgstr "行号{0}：账户{1}不属于公司{2}"
 
@@ -44994,27 +44989,27 @@ msgstr "行号#{0}：批次号{1}已被选择"
 msgid "Row #{0}: Cannot allocate more than {1} against payment term {2}"
 msgstr "行号#{0}：支付条款{2}的分配金额不能超过{1}"
 
-#: erpnext/controllers/accounts_controller.py:3524
+#: erpnext/controllers/accounts_controller.py:3527
 msgid "Row #{0}: Cannot delete item {1} which has already been billed."
 msgstr "行号#{0}：无法删除已开票的物料{1}"
 
-#: erpnext/controllers/accounts_controller.py:3498
+#: erpnext/controllers/accounts_controller.py:3501
 msgid "Row #{0}: Cannot delete item {1} which has already been delivered"
 msgstr "行号#{0}：无法删除已交货的物料{1}"
 
-#: erpnext/controllers/accounts_controller.py:3517
+#: erpnext/controllers/accounts_controller.py:3520
 msgid "Row #{0}: Cannot delete item {1} which has already been received"
 msgstr "行号#{0}：无法删除已接收的物料{1}"
 
-#: erpnext/controllers/accounts_controller.py:3504
+#: erpnext/controllers/accounts_controller.py:3507
 msgid "Row #{0}: Cannot delete item {1} which has work order assigned to it."
 msgstr "行号#{0}：无法删除已分配工单的物料{1}"
 
-#: erpnext/controllers/accounts_controller.py:3510
+#: erpnext/controllers/accounts_controller.py:3513
 msgid "Row #{0}: Cannot delete item {1} which is assigned to customer's purchase order."
 msgstr "行号#{0}：无法删除分配给客户采购订单的物料{1}"
 
-#: erpnext/controllers/accounts_controller.py:3765
+#: erpnext/controllers/accounts_controller.py:3768
 msgid "Row #{0}: Cannot set Rate if the billed amount is greater than the amount for Item {1}."
 msgstr "第{0}行：开票金额超过物料{1}金额时不可设置费率。"
 
@@ -45134,7 +45129,7 @@ msgstr "行号#{0}：物料{1}不存在"
 msgid "Row #{0}: Item {1} has been picked, please reserve stock from the Pick List."
 msgstr "行号#{0}：物料{1}已拣配，请通过拣配单预留库存"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:729
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:725
 msgid "Row #{0}: Item {1} is not a Serialized/Batched Item. It cannot have a Serial No/Batch No against it."
 msgstr "行号#{0}：物料{1}未序列化/批次管理，不可关联序列号/批次号"
 
@@ -45190,7 +45185,7 @@ msgstr "行号#{0}：请在组装物料中选择物料清单编号"
 msgid "Row #{0}: Please select the Sub Assembly Warehouse"
 msgstr "行号#{0}：请选择子装配仓库"
 
-#: erpnext/stock/doctype/item/item.py:502
+#: erpnext/stock/doctype/item/item.py:505
 msgid "Row #{0}: Please set reorder quantity"
 msgstr "行号#{0}：请设置再订货数量"
 
@@ -45223,8 +45218,8 @@ msgstr "行号#{0}：物料{2}的质量检验{1}未提交"
 msgid "Row #{0}: Quality Inspection {1} was rejected for item {2}"
 msgstr "行号#{0}：物料{2}的质量检验{1}被拒收"
 
-#: erpnext/controllers/accounts_controller.py:1274
-#: erpnext/controllers/accounts_controller.py:3624
+#: erpnext/controllers/accounts_controller.py:1277
+#: erpnext/controllers/accounts_controller.py:3627
 msgid "Row #{0}: Quantity for Item {1} cannot be zero."
 msgstr "行号#{0}：物料{1}数量不能为零"
 
@@ -45261,7 +45256,7 @@ msgstr "第{0}行：资产退货必须填写退货依据。"
 msgid "Row #{0}: Scrap Item Qty cannot be zero"
 msgstr "行号#{0}：废品数量不能为零"
 
-#: erpnext/controllers/selling_controller.py:230
+#: erpnext/controllers/selling_controller.py:238
 msgid "Row #{0}: Selling rate for item {1} is lower than its {2}.\n"
 "\t\t\t\t\tSelling {3} should be atleast {4}.<br><br>Alternatively,\n"
 "\t\t\t\t\tyou can disable selling price validation in {5} to bypass\n"
@@ -45348,7 +45343,7 @@ msgstr "行号#{0}：仓库{2}中物料{1}无可用库存可预留"
 msgid "Row #{0}: The batch {1} has already expired."
 msgstr "行号#{0}：批次{1}已过期"
 
-#: erpnext/stock/doctype/item/item.py:511
+#: erpnext/stock/doctype/item/item.py:514
 msgid "Row #{0}: The warehouse {1} is not a child warehouse of a group warehouse {2}"
 msgstr "行号#{0}：仓库{1}不是组仓库{2}的子仓库"
 
@@ -45388,39 +45383,39 @@ msgstr "行号#{0}：{2}的{1}应为{3}，请更新{1}或选择其他科目"
 msgid "Row #{1}: Warehouse is mandatory for stock Item {0}"
 msgstr "行号#{1}：库存物料{0}必须指定仓库"
 
-#: erpnext/controllers/buying_controller.py:259
+#: erpnext/controllers/buying_controller.py:267
 msgid "Row #{idx}: Cannot select Supplier Warehouse while suppling raw materials to subcontractor."
 msgstr "行号#{idx}：外协供料时不可选择供应商仓库"
 
-#: erpnext/controllers/buying_controller.py:406
+#: erpnext/controllers/buying_controller.py:414
 msgid "Row #{idx}: Item rate has been updated as per valuation rate since its an internal stock transfer."
 msgstr "行号#{idx}：内部调拨时物料单价已按估价率更新"
 
-#: erpnext/controllers/buying_controller.py:881
+#: erpnext/controllers/buying_controller.py:889
 msgid "Row #{idx}: Please enter a location for the asset item {item_code}."
 msgstr "行号#{idx}：请为资产物料{item_code}输入位置"
 
-#: erpnext/controllers/buying_controller.py:537
+#: erpnext/controllers/buying_controller.py:545
 msgid "Row #{idx}: Received Qty must be equal to Accepted + Rejected Qty for Item {item_code}."
 msgstr "行号#{idx}：物料{item_code}的接收数量必须等于接受数量+拒收数量"
 
-#: erpnext/controllers/buying_controller.py:550
+#: erpnext/controllers/buying_controller.py:558
 msgid "Row #{idx}: {field_label} can not be negative for item {item_code}."
 msgstr "行号#{idx}：物料{item_code}的{field_label}不能为负数"
 
-#: erpnext/controllers/buying_controller.py:496
+#: erpnext/controllers/buying_controller.py:504
 msgid "Row #{idx}: {field_label} is mandatory."
 msgstr "行号#{idx}：{field_label}为必填项"
 
-#: erpnext/controllers/buying_controller.py:518
+#: erpnext/controllers/buying_controller.py:526
 msgid "Row #{idx}: {field_label} is not allowed in Purchase Return."
 msgstr "行号#{idx}：采购退货中不允许{field_label}"
 
-#: erpnext/controllers/buying_controller.py:250
+#: erpnext/controllers/buying_controller.py:258
 msgid "Row #{idx}: {from_warehouse_field} and {to_warehouse_field} cannot be same."
 msgstr "行号#{idx}：{from_warehouse_field}和{to_warehouse_field}不能相同"
 
-#: erpnext/controllers/buying_controller.py:999
+#: erpnext/controllers/buying_controller.py:1007
 msgid "Row #{idx}: {schedule_date} cannot be before {transaction_date}."
 msgstr "行号#{idx}：{schedule_date}不能早于{transaction_date}"
 
@@ -45485,7 +45480,7 @@ msgstr "行号#{}：{}"
 msgid "Row #{}: {} {} does not exist."
 msgstr "行号#{}：{} {}不存在"
 
-#: erpnext/stock/doctype/item/item.py:1403
+#: erpnext/stock/doctype/item/item.py:1397
 msgid "Row #{}: {} {} doesn't belong to Company {}. Please select valid {}."
 msgstr "行号#{}：{} {}不属于公司{}，请选择有效的{}"
 
@@ -45557,11 +45552,11 @@ msgstr "行号{0}：未找到物料{1}的物料清单（BOM）"
 msgid "Row {0}: Both Debit and Credit values cannot be zero"
 msgstr "行号{0}：借贷方金额不能同时为零"
 
-#: erpnext/controllers/selling_controller.py:222
+#: erpnext/controllers/selling_controller.py:230
 msgid "Row {0}: Conversion Factor is mandatory"
 msgstr "行号{0}：转换系数为必填项"
 
-#: erpnext/controllers/accounts_controller.py:2995
+#: erpnext/controllers/accounts_controller.py:2998
 msgid "Row {0}: Cost Center {1} does not belong to Company {2}"
 msgstr "行号{0}：成本中心{1}不属于公司{2}"
 
@@ -45581,11 +45576,11 @@ msgstr "行号{0}：BOM#{1}的货币应与选择货币{2}一致"
 msgid "Row {0}: Debit entry can not be linked with a {1}"
 msgstr "行号{0}：借项分录不能与{1}关联"
 
-#: erpnext/controllers/selling_controller.py:776
+#: erpnext/controllers/selling_controller.py:784
 msgid "Row {0}: Delivery Warehouse ({1}) and Customer Warehouse ({2}) can not be same"
 msgstr "行号{0}：交货仓库{1}与客户仓库{2}不能相同"
 
-#: erpnext/controllers/accounts_controller.py:2529
+#: erpnext/controllers/accounts_controller.py:2532
 msgid "Row {0}: Due Date in the Payment Terms table cannot be before Posting Date"
 msgstr "行号{0}：支付条款表中的到期日不能早于过账日期"
 
@@ -45594,7 +45589,7 @@ msgid "Row {0}: Either Delivery Note Item or Packed Item reference is mandatory.
 msgstr "行号{0}：必须关联交货单物料或包装物料"
 
 #: erpnext/accounts/doctype/journal_entry/journal_entry.py:1010
-#: erpnext/controllers/taxes_and_totals.py:1205
+#: erpnext/controllers/taxes_and_totals.py:1215
 msgid "Row {0}: Exchange Rate is mandatory"
 msgstr "行号{0}：汇率为必填项"
 
@@ -45643,11 +45638,11 @@ msgstr "行号{0}：工时值必须大于零"
 msgid "Row {0}: Invalid reference {1}"
 msgstr "行号{0}：无效引用{1}"
 
-#: erpnext/controllers/taxes_and_totals.py:142
+#: erpnext/controllers/taxes_and_totals.py:143
 msgid "Row {0}: Item Tax template updated as per validity and rate applied"
 msgstr "行号{0}：物料税模板已按有效税率更新"
 
-#: erpnext/controllers/selling_controller.py:541
+#: erpnext/controllers/selling_controller.py:549
 msgid "Row {0}: Item rate has been updated as per valuation rate since its an internal stock transfer"
 msgstr "行号{0}：内部调拨时物料单价已按估价率更新"
 
@@ -45767,7 +45762,7 @@ msgstr "行号{0}：任务{1}不属于项目{2}"
 msgid "Row {0}: The item {1}, quantity must be positive number"
 msgstr "行号{0}：物料{1}的数量必须为正数"
 
-#: erpnext/controllers/accounts_controller.py:2972
+#: erpnext/controllers/accounts_controller.py:2975
 msgid "Row {0}: The {3} Account {1} does not belong to the company {2}"
 msgstr "行号{0}：{3}科目{1}不属于公司{2}"
 
@@ -45784,7 +45779,7 @@ msgstr "行号{0}：单位转换系数为必填项"
 msgid "Row {0}: Workstation or Workstation Type is mandatory for an operation {1}"
 msgstr "行号{0}：工序{1}必须指定工作站或工作站类型"
 
-#: erpnext/controllers/accounts_controller.py:1011
+#: erpnext/controllers/accounts_controller.py:1014
 msgid "Row {0}: user has not applied the rule {1} on the item {2}"
 msgstr "行号{0}：用户未对物料{2}应用规则{1}"
 
@@ -45796,7 +45791,7 @@ msgstr "行 {0}: {1} 帐户已经应用于会计尺寸 {2}"
 msgid "Row {0}: {1} must be greater than 0"
 msgstr "行{0}：{1}必须大于0"
 
-#: erpnext/controllers/accounts_controller.py:706
+#: erpnext/controllers/accounts_controller.py:709
 msgid "Row {0}: {1} {2} cannot be same as {3} (Party Account) {4}"
 msgstr "行 {0}: {1} {2} 不能与 {3} (组队帐户) {4}"
 
@@ -45812,7 +45807,7 @@ msgstr "行 {0}: {2} 项目 {1} 在 {2} {3} 中不存在"
 msgid "Row {1}: Quantity ({0}) cannot be a fraction. To allow this, disable '{2}' in UOM {3}."
 msgstr "第{1}行：数量（{0}）不能为小数。为此，请在UOM {3}中禁用“ {2}”。"
 
-#: erpnext/controllers/buying_controller.py:863
+#: erpnext/controllers/buying_controller.py:871
 msgid "Row {idx}: Asset Naming Series is mandatory for the auto creation of assets for item {item_code}."
 msgstr "行号{idx}：自动创建物料{item_code}的资产必须指定资产命名规则。"
 
@@ -45838,7 +45833,7 @@ msgstr "在{0}中删除的行"
 msgid "Rows with Same Account heads will be merged on Ledger"
 msgstr "具有相同帐户头的行将在分类帐上合并"
 
-#: erpnext/controllers/accounts_controller.py:2539
+#: erpnext/controllers/accounts_controller.py:2542
 msgid "Rows with duplicate due dates in other rows were found: {0}"
 msgstr "发现其他行中具有重复截止日期的行：{0}"
 
@@ -45908,7 +45903,7 @@ msgstr "SLA 已完成状态"
 msgid "SLA Paused On"
 msgstr "SLA 暂停于"
 
-#: erpnext/public/js/utils.js:1167
+#: erpnext/public/js/utils.js:1163
 msgid "SLA is on hold since {0}"
 msgstr "自{0}起，SLA处于保留状态"
 
@@ -46309,7 +46304,7 @@ msgstr "按来源划分的销售机会"
 #: erpnext/accounts/report/sales_register/sales_register.py:238
 #: erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
 #: erpnext/buying/doctype/supplier_quotation_item/supplier_quotation_item.json
-#: erpnext/controllers/selling_controller.py:462
+#: erpnext/controllers/selling_controller.py:470
 #: erpnext/crm/doctype/contract/contract.json
 #: erpnext/maintenance/doctype/maintenance_schedule/maintenance_schedule.js:65
 #: erpnext/maintenance/doctype/maintenance_schedule_item/maintenance_schedule_item.json
@@ -46435,7 +46430,7 @@ msgstr "销售订单{0}未提交"
 msgid "Sales Order {0} is not valid"
 msgstr "销售订单{0}无效"
 
-#: erpnext/controllers/selling_controller.py:443
+#: erpnext/controllers/selling_controller.py:451
 #: erpnext/manufacturing/doctype/work_order/work_order.py:301
 msgid "Sales Order {0} is {1}"
 msgstr "销售订单{0} {1}"
@@ -46486,7 +46481,7 @@ msgstr "销售订单到交付"
 #: erpnext/accounts/doctype/promotional_scheme/promotional_scheme.json
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:122
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1156
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1158
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:99
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:194
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:74
@@ -46584,7 +46579,7 @@ msgstr "销售付款摘要"
 #: erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html:156
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.html:137
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:128
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1153
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1155
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:105
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:191
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:80
@@ -46604,7 +46599,7 @@ msgstr "销售付款摘要"
 msgid "Sales Person"
 msgstr "销售人员"
 
-#: erpnext/controllers/selling_controller.py:204
+#: erpnext/controllers/selling_controller.py:212
 msgid "Sales Person <b>{0}</b> is disabled."
 msgstr "销售员<b>{0}</b>已被停用。"
 
@@ -46885,7 +46880,7 @@ msgstr "保留仓库示例"
 
 #. Label of the sample_size (Float) field in DocType 'Quality Inspection'
 #: erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py:93
-#: erpnext/public/js/controllers/transaction.js:2369
+#: erpnext/public/js/controllers/transaction.js:2395
 #: erpnext/stock/doctype/quality_inspection/quality_inspection.json
 msgid "Sample Size"
 msgstr "样本大小"
@@ -47425,7 +47420,7 @@ msgstr "选择物料"
 msgid "Select Items based on Delivery Date"
 msgstr "按交货日期筛选物料"
 
-#: erpnext/public/js/controllers/transaction.js:2405
+#: erpnext/public/js/controllers/transaction.js:2431
 msgid "Select Items for Quality Inspection"
 msgstr "选择待质检物料"
 
@@ -47566,7 +47561,7 @@ msgstr "请先选择公司"
 msgid "Select company name first."
 msgstr "请先选择公司名称。"
 
-#: erpnext/controllers/accounts_controller.py:2785
+#: erpnext/controllers/accounts_controller.py:2788
 msgid "Select finance book for the item {0} at row {1}"
 msgstr "为第{1}行的物料{0}选择财务账簿"
 
@@ -47780,7 +47775,7 @@ msgid "Send Now"
 msgstr "立即发送"
 
 #. Label of the send_sms (Button) field in DocType 'SMS Center'
-#: erpnext/public/js/controllers/transaction.js:517
+#: erpnext/public/js/controllers/transaction.js:543
 #: erpnext/selling/doctype/sms_center/sms_center.json
 msgid "Send SMS"
 msgstr "发送短信"
@@ -47938,7 +47933,7 @@ msgstr "序列号/批次号"
 #: erpnext/manufacturing/doctype/job_card/job_card.json
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.js:74
 #: erpnext/manufacturing/report/cost_of_poor_quality_report/cost_of_poor_quality_report.py:114
-#: erpnext/public/js/controllers/transaction.js:2382
+#: erpnext/public/js/controllers/transaction.js:2408
 #: erpnext/public/js/utils/serial_no_batch_selector.js:421
 #: erpnext/selling/doctype/installation_note_item/installation_note_item.json
 #: erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
@@ -47987,7 +47982,7 @@ msgstr "序列号台账"
 msgid "Serial No Range"
 msgstr "序列号范围"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1894
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1895
 msgid "Serial No Reserved"
 msgstr "已预留序列号"
 
@@ -48027,7 +48022,7 @@ msgstr "序列号与批次"
 msgid "Serial No and Batch Selector cannot be use when Use Serial / Batch Fields is enabled."
 msgstr "启用序列号/批次字段时不可使用序列号批次选择器"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:859
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:860
 msgid "Serial No is mandatory"
 msgstr "序列号为必填项"
 
@@ -48056,7 +48051,7 @@ msgstr "序列号{0}不属于物料{1}"
 msgid "Serial No {0} does not exist"
 msgstr "序列号{0}不存在"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2623
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:2624
 msgid "Serial No {0} does not exists"
 msgstr "序列号{0}不存在"
 
@@ -48064,7 +48059,7 @@ msgstr "序列号{0}不存在"
 msgid "Serial No {0} is already added"
 msgstr "序列号{0}已添加"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:357
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:358
 msgid "Serial No {0} is not present in the {1} {2}, hence you can't return it against the {1} {2}"
 msgstr "序列号{0}未存在于{1}{2}中，因此不能针对该{1}{2}进行退回"
 
@@ -48101,11 +48096,11 @@ msgstr "序列号/批次号"
 msgid "Serial Nos and Batches"
 msgstr "序列号与批次"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1370
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1371
 msgid "Serial Nos are created successfully"
 msgstr "序列号创建成功"
 
-#: erpnext/stock/stock_ledger.py:2137
+#: erpnext/stock/stock_ledger.py:2145
 msgid "Serial Nos are reserved in Stock Reservation Entries, you need to unreserve them before proceeding."
 msgstr "序列号已在库存预留条目中预留，继续操作前需取消预留。"
 
@@ -48179,11 +48174,11 @@ msgstr "序列号与批次"
 msgid "Serial and Batch Bundle"
 msgstr "序列号批次组合"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1598
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1599
 msgid "Serial and Batch Bundle created"
 msgstr "序列号批次组合已创建"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1664
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1665
 msgid "Serial and Batch Bundle updated"
 msgstr "序列号批次组合已更新"
 
@@ -48535,12 +48530,12 @@ msgid "Service Stop Date"
 msgstr "服务中止日期"
 
 #: erpnext/accounts/deferred_revenue.py:44
-#: erpnext/public/js/controllers/transaction.js:1420
+#: erpnext/public/js/controllers/transaction.js:1446
 msgid "Service Stop Date cannot be after Service End Date"
 msgstr "服务中止日期不能晚于服务结束日期"
 
 #: erpnext/accounts/deferred_revenue.py:41
-#: erpnext/public/js/controllers/transaction.js:1417
+#: erpnext/public/js/controllers/transaction.js:1443
 msgid "Service Stop Date cannot be before Service Start Date"
 msgstr "服务中止日期不能早于服务开始日期"
 
@@ -49977,7 +49972,7 @@ msgstr "标准税率费用"
 
 #: erpnext/setup/setup_wizard/operations/defaults_setup.py:70
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:463
-#: erpnext/stock/doctype/item/item.py:245
+#: erpnext/stock/doctype/item/item.py:248
 msgid "Standard Selling"
 msgstr "标准售价"
 
@@ -50807,7 +50802,7 @@ msgstr "已收未开票库存"
 #. Option for the 'Purpose' (Select) field in DocType 'Stock Reconciliation'
 #. Label of a Link in the Stock Workspace
 #: erpnext/setup/workspace/home/home.json
-#: erpnext/stock/doctype/item/item.py:612
+#: erpnext/stock/doctype/item/item.py:618
 #: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.json
 #: erpnext/stock/workspace/stock/stock.json
 msgid "Stock Reconciliation"
@@ -50818,7 +50813,7 @@ msgstr "库存对账"
 msgid "Stock Reconciliation Item"
 msgstr "库存对账项"
 
-#: erpnext/stock/doctype/item/item.py:612
+#: erpnext/stock/doctype/item/item.py:618
 msgid "Stock Reconciliations"
 msgstr "库存对账"
 
@@ -50853,7 +50848,7 @@ msgstr "库存重新过账设置"
 #: erpnext/stock/doctype/pick_list/pick_list.js:150
 #: erpnext/stock/doctype/pick_list/pick_list.js:155
 #: erpnext/stock/doctype/stock_entry/stock_entry_dashboard.py:25
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:706
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:702
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:575
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:1138
 #: erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py:1398
@@ -51253,7 +51248,7 @@ msgstr "已停止的工单无法取消，请先恢复后取消"
 #: erpnext/setup/doctype/company/company.py:287
 #: erpnext/setup/setup_wizard/operations/defaults_setup.py:33
 #: erpnext/setup/setup_wizard/operations/install_fixtures.py:502
-#: erpnext/stock/doctype/item/item.py:282
+#: erpnext/stock/doctype/item/item.py:285
 msgid "Stores"
 msgstr "仓储"
 
@@ -51788,7 +51783,7 @@ msgstr "成功对账"
 msgid "Successfully Set Supplier"
 msgstr "成功设置供应商"
 
-#: erpnext/stock/doctype/item/item.py:339
+#: erpnext/stock/doctype/item/item.py:342
 msgid "Successfully changed Stock UOM, please redefine conversion factors for new UOM."
 msgstr "已成功更改库存单位，请重新定义新单位的换算系数"
 
@@ -52090,7 +52085,7 @@ msgstr "供应商明细"
 #: erpnext/accounts/doctype/tax_rule/tax_rule.json
 #: erpnext/accounts/report/accounts_payable/accounts_payable.js:111
 #: erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js:87
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1160
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1162
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:198
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:237
 #: erpnext/accounts/report/purchase_register/purchase_register.js:27
@@ -52190,7 +52185,7 @@ msgstr "供应商分类账汇总"
 #. Label of the supplier_name (Data) field in DocType 'Purchase Receipt'
 #. Label of the supplier_name (Data) field in DocType 'Stock Entry'
 #: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1077
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1079
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:156
 #: erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py:198
 #: erpnext/accounts/report/purchase_register/purchase_register.py:177
@@ -52674,7 +52669,7 @@ msgstr "提交工单时系统将自动创建成品的序列号/批次"
 msgid "System will fetch all the entries if limit value is zero."
 msgstr "若限制值为零，系统将获取所有条目"
 
-#: erpnext/controllers/accounts_controller.py:1975
+#: erpnext/controllers/accounts_controller.py:1978
 msgid "System will not check over billing since amount for Item {0} in {1} is zero"
 msgstr "因{1}中物料{0}的金额为零，系统不检查超额开票"
 
@@ -52933,7 +52928,7 @@ msgstr "目标仓库预留错误"
 msgid "Target Warehouse is required before Submit"
 msgstr "提交前需填写目标仓库"
 
-#: erpnext/controllers/selling_controller.py:782
+#: erpnext/controllers/selling_controller.py:790
 msgid "Target Warehouse is set for some items but the customer is not an internal customer."
 msgstr "部分物料设置了目标仓库，但客户不是内部客户"
 
@@ -53172,7 +53167,7 @@ msgstr "税款分解"
 msgid "Tax Category"
 msgstr "税种分类"
 
-#: erpnext/controllers/buying_controller.py:194
+#: erpnext/controllers/buying_controller.py:202
 msgid "Tax Category has been changed to \"Total\" because all the Items are non-stock items"
 msgstr "税项类别已更改为“合计”，因为所有物料均为非库存物料"
 
@@ -53378,7 +53373,7 @@ msgstr "仅对超过累计起征点的金额进行税款代扣"
 #. Label of the taxable_amount (Currency) field in DocType 'Tax Withheld
 #. Vouchers'
 #: erpnext/accounts/doctype/tax_withheld_vouchers/tax_withheld_vouchers.json
-#: erpnext/controllers/taxes_and_totals.py:1125
+#: erpnext/controllers/taxes_and_totals.py:1135
 msgid "Taxable Amount"
 msgstr "应税金额"
 
@@ -53517,7 +53512,7 @@ msgstr "减征税费"
 msgid "Taxes and Charges Deducted (Company Currency)"
 msgstr "减征税费（公司货币）"
 
-#: erpnext/stock/doctype/item/item.py:352
+#: erpnext/stock/doctype/item/item.py:355
 msgid "Taxes row #{0}: {1} cannot be smaller than {2}"
 msgstr "第{0}行税项：{1}不能小于{2}"
 
@@ -53803,7 +53798,7 @@ msgstr "条款模板"
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.json
 #: erpnext/accounts/doctype/territory_item/territory_item.json
 #: erpnext/accounts/report/accounts_receivable/accounts_receivable.js:134
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1144
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1146
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js:93
 #: erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py:182
 #: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.js:68
@@ -53907,7 +53902,7 @@ msgstr "门户询价申请功能已禁用。如需启用，请在门户设置中
 msgid "The BOM which will be replaced"
 msgstr "将被替换的物料清单"
 
-#: erpnext/stock/serial_batch_bundle.py:1274
+#: erpnext/stock/serial_batch_bundle.py:1306
 msgid "The Batch {0} has negative quantity {1} in warehouse {2}. Please correct the quantity."
 msgstr "批次{0}在仓库{2}中存在负数量{1}。请更正数量"
 
@@ -53959,7 +53954,7 @@ msgstr "该销售员与{0}相关联"
 msgid "The Serial No at Row #{0}: {1} is not available in warehouse {2}."
 msgstr "第{0}行的序列号{1}在仓库{2}中不可用"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1891
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1892
 msgid "The Serial No {0} is reserved against the {1} {2} and cannot be used for any other transaction."
 msgstr "序列号{0}已为{1}{2}预留，不能用于其他交易"
 
@@ -54042,7 +54037,7 @@ msgstr "以下资产自动计提折旧失败：{0}"
 msgid "The following batches are expired, please restock them: <br> {0}"
 msgstr "以下批次已过期，请补货：<br>{0}"
 
-#: erpnext/stock/doctype/item/item.py:849
+#: erpnext/stock/doctype/item/item.py:843
 msgid "The following deleted attributes exist in Variants but not in the Template. You can either delete the Variants or keep the attribute(s) in template."
 msgstr "以下已删除属性存在于变体但不存在于模板。请删除变体或在模板保留属性"
 
@@ -54067,15 +54062,15 @@ msgstr "包裹毛重（打印用），通常为净重加包装材料重量"
 msgid "The holiday on {0} is not between From Date and To Date"
 msgstr "{0}的假期不在起止日期范围内"
 
-#: erpnext/controllers/buying_controller.py:1066
+#: erpnext/controllers/buying_controller.py:1074
 msgid "The item {item} is not marked as {type_of} item. You can enable it as {type_of} item from its Item master."
 msgstr "物料{item}未标记为{type_of}物料。可在物料主数据中启用"
 
-#: erpnext/stock/doctype/item/item.py:614
+#: erpnext/stock/doctype/item/item.py:620
 msgid "The items {0} and {1} are present in the following {2} :"
 msgstr "物料{0}和{1}存在于以下{2}中："
 
-#: erpnext/controllers/buying_controller.py:1059
+#: erpnext/controllers/buying_controller.py:1067
 msgid "The items {items} are not marked as {type_of} item. You can enable them as {type_of} item from their Item masters."
 msgstr "物料{items}未标记为{type_of}物料。可在各自主数据中启用"
 
@@ -54177,8 +54172,8 @@ msgstr "所选物料未启用批次管理"
 msgid "The seller and the buyer cannot be the same"
 msgstr "买卖方不能为同一方"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:142
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:154
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:143
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:155
 msgid "The serial and batch bundle {0} not linked to {1} {2}"
 msgstr "序列号批次组合{0}未链接到{1}{2}"
 
@@ -54202,7 +54197,7 @@ msgstr "股份不存在于{0}"
 msgid "The stock for the item {0} in the {1} warehouse was negative on the {2}. You should create a positive entry {3} before the date {4} and time {5} to post the correct valuation rate. For more details, please read the <a href='https://docs.erpnext.com/docs/user/manual/en/stock-adjustment-cogs-with-negative-stock'>documentation<a>."
 msgstr "物料{0}在仓库{1}的库存于{2}出现负数。应在{4} {5}前创建正数分录{3}以记录正确计价。详情参阅<a href='https://docs.erpnext.com/docs/user/manual/en/stock-adjustment-cogs-with-negative-stock'>文档</a>"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:700
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:696
 msgid "The stock has been reserved for the following Items and Warehouses, un-reserve the same to {0} the Stock Reconciliation: <br /><br /> {1}"
 msgstr "以下物料和仓库的库存已被预留，请取消预留以{0}库存对账：<br /><br />{1}"
 
@@ -54215,11 +54210,11 @@ msgstr "同步已在后台启动，请查看{0}列表获取新记录"
 msgid "The task has been enqueued as a background job."
 msgstr "任务已加入后台队列"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:994
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:990
 msgid "The task has been enqueued as a background job. In case there is any issue on processing in background, the system will add a comment about the error on this Stock Reconciliation and revert to the Draft stage"
 msgstr "任务已加入后台队列。若后台处理出错，系统将在库存对账添加错误注释并恢复为草稿状态"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1005
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:1001
 msgid "The task has been enqueued as a background job. In case there is any issue on processing in background, the system will add a comment about the error on this Stock Reconciliation and revert to the Submitted stage"
 msgstr "任务已加入后台队列。若后台处理出错，系统将在库存对账添加错误注释并恢复为已提交状态"
 
@@ -54269,7 +54264,7 @@ msgstr "生产开始时物料转移的目标仓库，可选择组仓库作为在
 msgid "The {0} ({1}) must be equal to {2} ({3})"
 msgstr "{0}（{1}）必须等于{2}（{3}）"
 
-#: erpnext/public/js/controllers/transaction.js:2790
+#: erpnext/public/js/controllers/transaction.js:2816
 msgid "The {0} contains Unit Price Items."
 msgstr "{0}包含单价物料。"
 
@@ -54317,7 +54312,7 @@ msgstr "所选物料无变体"
 msgid "There can be multiple tiered collection factor based on the total spent. But the conversion factor for redemption will always be same for all the tier."
 msgstr "可根据总消费设置多级积分规则，但兑换转换率各层级统一"
 
-#: erpnext/accounts/party.py:580
+#: erpnext/accounts/party.py:586
 msgid "There can only be 1 Account per Company in {0} {1}"
 msgstr "{0}{1}每个公司只能有一个科目"
 
@@ -54603,7 +54598,7 @@ msgstr "这将附加到变体的商品代码中。例如，如果您的缩写是
 msgid "This will restrict user access to other employee records"
 msgstr "将限制用户访问其他员工记录"
 
-#: erpnext/controllers/selling_controller.py:783
+#: erpnext/controllers/selling_controller.py:791
 msgid "This {} will be treated as material transfer."
 msgstr "此{}将被视为物料转移"
 
@@ -55317,11 +55312,11 @@ msgid "To include sub-assembly costs and scrap items in Finished Goods on a work
 msgstr "启用'多层级BOM'选项时，允许工单直接归集子装配件成本和废品到产成品，无需作业卡。"
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:2337
-#: erpnext/controllers/accounts_controller.py:3005
+#: erpnext/controllers/accounts_controller.py:3008
 msgid "To include tax in row {0} in Item rate, taxes in rows {1} must also be included"
 msgstr "要包括税款，行{0}项率，税收行{1}也必须包括在内"
 
-#: erpnext/stock/doctype/item/item.py:636
+#: erpnext/stock/doctype/item/item.py:642
 msgid "To merge, following properties must be same for both items"
 msgstr "若要合并，两个物料的以下属性必须相同"
 
@@ -55941,7 +55936,7 @@ msgstr "未结金额合计"
 msgid "Total Paid Amount"
 msgstr "已付金额合计"
 
-#: erpnext/controllers/accounts_controller.py:2591
+#: erpnext/controllers/accounts_controller.py:2594
 msgid "Total Payment Amount in Payment Schedule must be equal to Grand / Rounded Total"
 msgstr "付款计划中的总付款金额必须等于总计/舍入总额"
 
@@ -56226,15 +56221,15 @@ msgstr "总重量（千克）"
 msgid "Total Working Hours"
 msgstr "总工时数"
 
-#: erpnext/controllers/accounts_controller.py:2138
+#: erpnext/controllers/accounts_controller.py:2141
 msgid "Total advance ({0}) against Order {1} cannot be greater than the Grand Total ({2})"
 msgstr "订单{1}的预付款总额（{0}）不可超过总计金额（{2}）"
 
-#: erpnext/controllers/selling_controller.py:190
+#: erpnext/controllers/selling_controller.py:198
 msgid "Total allocated percentage for sales team should be 100"
 msgstr "销售团队分配比例总和应为100%"
 
-#: erpnext/selling/doctype/customer/customer.py:162
+#: erpnext/selling/doctype/customer/customer.py:161
 msgid "Total contribution percentage should be equal to 100"
 msgstr "贡献比例总和应等于100%"
 
@@ -57119,7 +57114,7 @@ msgstr "计量单位"
 msgid "Unit of Measure (UOM)"
 msgstr "计量单位（UOM）"
 
-#: erpnext/stock/doctype/item/item.py:384
+#: erpnext/stock/doctype/item/item.py:387
 msgid "Unit of Measure {0} has been entered more than once in Conversion Factor Table"
 msgstr "换算系数表中重复输入计量单位{0}"
 
@@ -57561,7 +57556,7 @@ msgstr "更新线索与商机中收到新沟通的修改时间戳"
 msgid "Update timestamp on new communication"
 msgstr "新沟通时更新时间戳"
 
-#: erpnext/manufacturing/doctype/bom_creator/bom_creator.py:533
+#: erpnext/manufacturing/doctype/bom_creator/bom_creator.py:534
 msgid "Updated successfully"
 msgstr "更新成功"
 
@@ -57575,7 +57570,7 @@ msgstr "更新成功"
 msgid "Updated via 'Time Log' (In Minutes)"
 msgstr "通过'工时记录'更新（分钟）"
 
-#: erpnext/stock/doctype/item/item.py:1387
+#: erpnext/stock/doctype/item/item.py:1381
 msgid "Updating Variants..."
 msgstr "正在更新变体..."
 
@@ -58133,19 +58128,19 @@ msgstr "计价单价"
 msgid "Valuation Rate (In / Out)"
 msgstr "计价单价（进/出）"
 
-#: erpnext/stock/stock_ledger.py:1881
+#: erpnext/stock/stock_ledger.py:1890
 msgid "Valuation Rate Missing"
 msgstr "计价单价缺失"
 
-#: erpnext/stock/stock_ledger.py:1859
+#: erpnext/stock/stock_ledger.py:1868
 msgid "Valuation Rate for the Item {0}, is required to do accounting entries for {1} {2}."
 msgstr "物料{0}的计价单价是生成{1}{2}会计凭证的必要条件"
 
-#: erpnext/stock/doctype/item/item.py:266
+#: erpnext/stock/doctype/item/item.py:269
 msgid "Valuation Rate is mandatory if Opening Stock entered"
 msgstr "若录入期初库存则必须填写计价单价"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:752
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:748
 msgid "Valuation Rate required for Item {0} at row {1}"
 msgstr "第{1}行物料{0}需要计价单价"
 
@@ -58155,7 +58150,7 @@ msgstr "第{1}行物料{0}需要计价单价"
 msgid "Valuation and Total"
 msgstr "计价与合计"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:971
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:967
 msgid "Valuation rate for customer provided items has been set to zero."
 msgstr "客户提供物料的计价单价已设为零"
 
@@ -58169,7 +58164,7 @@ msgid "Valuation rate for the item as per Sales Invoice (Only for Internal Trans
 msgstr "按销售发票的物料计价单价（仅限内部调拨）"
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:2361
-#: erpnext/controllers/accounts_controller.py:3029
+#: erpnext/controllers/accounts_controller.py:3032
 msgid "Valuation type charges can not be marked as Inclusive"
 msgstr "计价类型费用不可标记为含税"
 
@@ -58325,7 +58320,7 @@ msgstr "差异（{}）"
 msgid "Variant"
 msgstr "变体"
 
-#: erpnext/stock/doctype/item/item.py:864
+#: erpnext/stock/doctype/item/item.py:858
 msgid "Variant Attribute Error"
 msgstr "变体属性错误"
 
@@ -58344,7 +58339,7 @@ msgstr "变体BOM"
 msgid "Variant Based On"
 msgstr "变体基于"
 
-#: erpnext/stock/doctype/item/item.py:892
+#: erpnext/stock/doctype/item/item.py:886
 msgid "Variant Based On cannot be changed"
 msgstr "变体基础不可更改"
 
@@ -58362,7 +58357,7 @@ msgstr "变体字段"
 msgid "Variant Item"
 msgstr "变体物料"
 
-#: erpnext/stock/doctype/item/item.py:862
+#: erpnext/stock/doctype/item/item.py:856
 msgid "Variant Items"
 msgstr "变体物料"
 
@@ -58480,7 +58475,7 @@ msgstr "视频设置"
 #: erpnext/accounts/doctype/cost_center/cost_center_tree.js:56
 #: erpnext/accounts/doctype/invoice_discounting/invoice_discounting.js:205
 #: erpnext/accounts/doctype/journal_entry/journal_entry.js:43
-#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:668
+#: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js:670
 #: erpnext/bulk_transaction/doctype/bulk_transaction_log/bulk_transaction_log.js:14
 #: erpnext/bulk_transaction/doctype/bulk_transaction_log/bulk_transaction_log.js:24
 #: erpnext/buying/doctype/request_for_quotation/request_for_quotation.js:167
@@ -58667,7 +58662,7 @@ msgstr "凭证名称"
 #: erpnext/accounts/doctype/repost_accounting_ledger_items/repost_accounting_ledger_items.json
 #: erpnext/accounts/doctype/repost_payment_ledger_items/repost_payment_ledger_items.json
 #: erpnext/accounts/doctype/unreconcile_payment/unreconcile_payment.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1099
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1101
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.js:42
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:209
 #: erpnext/accounts/report/general_ledger/general_ledger.js:49
@@ -58698,7 +58693,7 @@ msgstr "凭证名称"
 msgid "Voucher No"
 msgstr "凭证编号"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1087
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:1088
 msgid "Voucher No is mandatory"
 msgstr "凭证编号必填"
 
@@ -58740,7 +58735,7 @@ msgstr "凭证子类型"
 #: erpnext/accounts/doctype/repost_payment_ledger_items/repost_payment_ledger_items.json
 #: erpnext/accounts/doctype/tax_withheld_vouchers/tax_withheld_vouchers.json
 #: erpnext/accounts/doctype/unreconcile_payment/unreconcile_payment.json
-#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1097
+#: erpnext/accounts/report/accounts_receivable/accounts_receivable.py:1099
 #: erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py:200
 #: erpnext/accounts/report/general_ledger/general_ledger.py:697
 #: erpnext/accounts/report/invalid_ledger_entries/invalid_ledger_entries.py:31
@@ -59094,10 +59089,6 @@ msgstr "仓库必填"
 msgid "Warehouse not found against the account {0}"
 msgstr "账户{0}未关联仓库"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:600
-msgid "Warehouse not found in the system"
-msgstr "系统中未找到仓库"
-
 #: erpnext/accounts/doctype/sales_invoice/sales_invoice.py:1130
 #: erpnext/stock/doctype/delivery_note/delivery_note.py:414
 msgid "Warehouse required for stock Item {0}"
@@ -59226,7 +59217,7 @@ msgid "Warn for new Request for Quotations"
 msgstr "新询价单预警"
 
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:744
-#: erpnext/controllers/accounts_controller.py:1978
+#: erpnext/controllers/accounts_controller.py:1981
 #: erpnext/stock/doctype/delivery_trip/delivery_trip.js:145
 #: erpnext/utilities/transaction_base.py:123
 msgid "Warning"
@@ -60198,7 +60189,7 @@ msgstr "是"
 msgid "You are importing data for the code list:"
 msgstr "您正在导入代码列表的数据："
 
-#: erpnext/controllers/accounts_controller.py:3611
+#: erpnext/controllers/accounts_controller.py:3614
 msgid "You are not allowed to update as per the conditions set in {} Workflow."
 msgstr "根据{}工作流设置的条件，您无权更新"
 
@@ -60263,7 +60254,7 @@ msgstr "可设置为机器名称或工序类型，例如：缝纫机12号"
 msgid "You can't make any changes to Job Card since Work Order is closed."
 msgstr "生产工单已关闭，无法修改作业卡"
 
-#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:185
+#: erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py:186
 msgid "You can't process the serial number {0} as it has already been used in the SABB {1}. {2} if you want to inward same serial number multiple times then enabled 'Allow existing Serial No to be Manufactured/Received again' in the {3}"
 msgstr "无法处理序列号{0}，因其已在序列和批次凭证{1}中使用。如需多次入库相同序列号，请在{3}启用'允许重复生产/接收现有序列号'"
 
@@ -60323,7 +60314,7 @@ msgstr "未付款的订单不能提交"
 msgid "You cannot {0} this document because another Period Closing Entry {1} exists after {2}"
 msgstr "无法{0}此单据，因为存在后续的期间结账分录{1}在{2}之后"
 
-#: erpnext/controllers/accounts_controller.py:3587
+#: erpnext/controllers/accounts_controller.py:3590
 msgid "You do not have permissions to {} items in a {}."
 msgstr "您没有权限在{}中对物料进行{}操作"
 
@@ -60351,7 +60342,7 @@ msgstr "您已被邀请参与项目{0}的协作"
 msgid "You have entered a duplicate Delivery Note on Row"
 msgstr "您在第行输入了重复的送货单"
 
-#: erpnext/stock/doctype/item/item.py:1063
+#: erpnext/stock/doctype/item/item.py:1057
 msgid "You have to enable auto re-order in Stock Settings to maintain re-order levels."
 msgstr "需在库存设置中启用自动补货以维护再订购水平"
 
@@ -60371,7 +60362,7 @@ msgstr "添加物料前需先选择客户"
 msgid "You need to cancel POS Closing Entry {} to be able to cancel this document."
 msgstr "需先取消POS结算单{}才能取消此单据"
 
-#: erpnext/controllers/accounts_controller.py:2980
+#: erpnext/controllers/accounts_controller.py:2983
 msgid "You selected the account group {1} as {2} Account in row {0}. Please select a single account."
 msgstr "第{0}行选择账户组{1}作为{2}科目，请选择单个科目"
 
@@ -60449,7 +60440,7 @@ msgstr "[重要][ERPNext]自动补货错误"
 msgid "`Allow Negative rates for Items`"
 msgstr "`允许物料负单价`"
 
-#: erpnext/stock/stock_ledger.py:1873
+#: erpnext/stock/stock_ledger.py:1882
 msgid "after"
 msgstr "之后"
 
@@ -60597,7 +60588,7 @@ msgstr "左值"
 msgid "material_request_item"
 msgstr "物料申请单条目"
 
-#: erpnext/controllers/selling_controller.py:151
+#: erpnext/controllers/selling_controller.py:159
 msgid "must be between 0 and 100"
 msgstr "必须在0到100之间"
 
@@ -60622,7 +60613,7 @@ msgstr "原上级"
 msgid "on"
 msgstr "在"
 
-#: erpnext/controllers/accounts_controller.py:1289
+#: erpnext/controllers/accounts_controller.py:1292
 msgid "or"
 msgstr "或"
 
@@ -60671,7 +60662,7 @@ msgstr "未安装支付应用，请从{}或{}安装"
 msgid "per hour"
 msgstr "每小时"
 
-#: erpnext/stock/stock_ledger.py:1874
+#: erpnext/stock/stock_ledger.py:1883
 msgid "performing either one below:"
 msgstr "执行以下任一操作："
 
@@ -60798,7 +60789,7 @@ msgstr "必须在账户表中选择在建工程科目"
 msgid "{0}"
 msgstr "{0}"
 
-#: erpnext/controllers/accounts_controller.py:1109
+#: erpnext/controllers/accounts_controller.py:1112
 msgid "{0} '{1}' is disabled"
 msgstr "{0}'{1}'已停用"
 
@@ -60814,7 +60805,7 @@ msgstr "{0}({1})不能超过生产工单{3}的计划数量({2})"
 msgid "{0} <b>{1}</b> has submitted Assets. Remove Item <b>{2}</b> from table to continue."
 msgstr "{0}<b>{1}</b>已提交资产，请从表中移除物料<b>{2}</b>以继续"
 
-#: erpnext/controllers/accounts_controller.py:2193
+#: erpnext/controllers/accounts_controller.py:2196
 msgid "{0} Account not found against Customer {1}."
 msgstr "客户{1}未找到{0}科目"
 
@@ -60846,7 +60837,7 @@ msgstr "{0}个工序：{1}"
 msgid "{0} Request for {1}"
 msgstr "{0}个{1}申请"
 
-#: erpnext/stock/doctype/item/item.py:323
+#: erpnext/stock/doctype/item/item.py:326
 msgid "{0} Retain Sample is based on batch, please check Has Batch No to retain sample of item"
 msgstr "{0}保留样本基于批次管理，请勾选'启用批次号'以保留物料样本"
 
@@ -60937,7 +60928,7 @@ msgid "{0} entered twice in Item Tax"
 msgstr "{0}在物料税中重复输入"
 
 #: erpnext/setup/doctype/item_group/item_group.py:48
-#: erpnext/stock/doctype/item/item.py:436
+#: erpnext/stock/doctype/item/item.py:439
 msgid "{0} entered twice {1} in Item Taxes"
 msgstr "{0}在物料税{1}中重复输入"
 
@@ -60958,7 +60949,7 @@ msgstr "{0}已成功提交"
 msgid "{0} hours"
 msgstr "{0}小时"
 
-#: erpnext/controllers/accounts_controller.py:2534
+#: erpnext/controllers/accounts_controller.py:2537
 msgid "{0} in row {1}"
 msgstr "第{1}行中的{0}"
 
@@ -60982,7 +60973,7 @@ msgstr "{0}已被阻止，无法继续此交易"
 
 #: erpnext/accounts/doctype/budget/budget.py:60
 #: erpnext/accounts/doctype/payment_entry/payment_entry.py:643
-#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:49
+#: erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py:50
 #: erpnext/accounts/report/general_ledger/general_ledger.py:59
 #: erpnext/accounts/report/pos_register/pos_register.py:107
 #: erpnext/controllers/trends.py:50
@@ -61002,11 +60993,11 @@ msgstr "科目{1}的{0}必填"
 msgid "{0} is mandatory. Maybe Currency Exchange record is not created for {1} to {2}"
 msgstr "{0}必填。可能未创建{1}到{2}的汇率记录"
 
-#: erpnext/controllers/accounts_controller.py:2937
+#: erpnext/controllers/accounts_controller.py:2940
 msgid "{0} is mandatory. Maybe Currency Exchange record is not created for {1} to {2}."
 msgstr "{0}必填。可能未创建{1}到{2}的汇率记录"
 
-#: erpnext/selling/doctype/customer/customer.py:204
+#: erpnext/selling/doctype/customer/customer.py:203
 msgid "{0} is not a company bank account"
 msgstr "{0}不是公司银行账户"
 
@@ -61089,7 +61080,7 @@ msgstr "正在将物料{1}的{0}数量接收到容量为{3}的仓库{2}"
 msgid "{0} to {1}"
 msgstr "{0}至{1}"
 
-#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:690
+#: erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py:686
 msgid "{0} units are reserved for Item {1} in Warehouse {2}, please un-reserve the same to {3} the Stock Reconciliation."
 msgstr "仓库{2}中物料{1}已预留{0}单位，请取消预留以{3}库存对账"
 
@@ -61105,16 +61096,16 @@ msgstr "物料{1}的{0}单位已在其他拣货单中被拣选"
 msgid "{0} units of {1} are required in {2} with the inventory dimension: {3} ({4}) on {5} {6} for {7} to complete the transaction."
 msgstr "需在{2}中准备{1}的{0}单位，库存维度：{3}({4})，日期{5}{6}，用于{7}以完成交易"
 
-#: erpnext/stock/stock_ledger.py:1532 erpnext/stock/stock_ledger.py:2023
-#: erpnext/stock/stock_ledger.py:2037
+#: erpnext/stock/stock_ledger.py:1541 erpnext/stock/stock_ledger.py:2031
+#: erpnext/stock/stock_ledger.py:2045
 msgid "{0} units of {1} needed in {2} on {3} {4} for {5} to complete this transaction."
 msgstr "需在{2}的{3}{4}准备{1}的{0}单位用于{5}以完成本交易"
 
-#: erpnext/stock/stock_ledger.py:2124 erpnext/stock/stock_ledger.py:2170
+#: erpnext/stock/stock_ledger.py:2132 erpnext/stock/stock_ledger.py:2178
 msgid "{0} units of {1} needed in {2} on {3} {4} to complete this transaction."
 msgstr "需在{2}的{3}{4}准备{1}的{0}单位以完成本交易"
 
-#: erpnext/stock/stock_ledger.py:1526
+#: erpnext/stock/stock_ledger.py:1535
 msgid "{0} units of {1} needed in {2} to complete this transaction."
 msgstr "需在{2}准备{1}的{0}单位以完成本交易"
 
@@ -61160,7 +61151,7 @@ msgstr "已创建{0}{1}"
 msgid "{0} {1} does not exist"
 msgstr "{0}{1}不存在"
 
-#: erpnext/accounts/party.py:560
+#: erpnext/accounts/party.py:566
 msgid "{0} {1} has accounting entries in currency {2} for company {3}. Please select a receivable or payable account with currency {2}."
 msgstr "{0}{1}存在公司{3}的{2}币种会计凭证。请选择对应{2}币种的应收/应付科目"
 
@@ -61194,7 +61185,7 @@ msgstr "{0}{1}已关联至通用代码{2}"
 msgid "{0} {1} is associated with {2}, but Party Account is {3}"
 msgstr "{0}{1}关联{2}，但往来科目为{3}"
 
-#: erpnext/controllers/selling_controller.py:462
+#: erpnext/controllers/selling_controller.py:470
 #: erpnext/controllers/subcontracting_controller.py:954
 msgid "{0} {1} is cancelled or closed"
 msgstr "{0}{1}已取消或关闭"
@@ -61211,11 +61202,11 @@ msgstr "{0}{1}已取消，无法完成操作"
 msgid "{0} {1} is closed"
 msgstr "{0}{1}已关闭"
 
-#: erpnext/accounts/party.py:798
+#: erpnext/accounts/party.py:804
 msgid "{0} {1} is disabled"
 msgstr "{0}{1}已停用"
 
-#: erpnext/accounts/party.py:804
+#: erpnext/accounts/party.py:810
 msgid "{0} {1} is frozen"
 msgstr "{0}{1}已冻结"
 
@@ -61223,7 +61214,7 @@ msgstr "{0}{1}已冻结"
 msgid "{0} {1} is fully billed"
 msgstr "{0}{1}已全额开票"
 
-#: erpnext/accounts/party.py:808
+#: erpnext/accounts/party.py:814
 msgid "{0} {1} is not active"
 msgstr "{0}{1}未启用"
 
@@ -61349,15 +61340,15 @@ msgstr "{0}: {1}不存在"
 msgid "{0}: {1} must be less than {2}"
 msgstr "{0}: {1}必须小于{2}"
 
-#: erpnext/controllers/buying_controller.py:840
+#: erpnext/controllers/buying_controller.py:848
 msgid "{count} Assets created for {item_code}"
 msgstr "已为{item_code}创建{count}项资产"
 
-#: erpnext/controllers/buying_controller.py:738
+#: erpnext/controllers/buying_controller.py:746
 msgid "{doctype} {name} is cancelled or closed."
 msgstr "{doctype}{name}已取消或关闭"
 
-#: erpnext/controllers/buying_controller.py:459
+#: erpnext/controllers/buying_controller.py:467
 msgid "{field_label} is mandatory for sub-contracted {doctype}."
 msgstr "外协{doctype}必须填写{field_label}"
 
@@ -61365,7 +61356,7 @@ msgstr "外协{doctype}必须填写{field_label}"
 msgid "{item_name}'s Sample Size ({sample_size}) cannot be greater than the Accepted Quantity ({accepted_quantity})"
 msgstr "{item_name}的样本量({sample_size})不得超过验收数量({accepted_quantity})"
 
-#: erpnext/controllers/buying_controller.py:563
+#: erpnext/controllers/buying_controller.py:571
 msgid "{ref_doctype} {ref_name} is {status}."
 msgstr "{ref_doctype}{ref_name}的状态为{status}"
 
@@ -61431,7 +61422,7 @@ msgstr "{} 待开票"
 msgid "{} can't be cancelled since the Loyalty Points earned has been redeemed. First cancel the {} No {}"
 msgstr "无法取消{}，因已兑换获得的积分。请先取消{}编号{}"
 
-#: erpnext/controllers/buying_controller.py:222
+#: erpnext/controllers/buying_controller.py:230
 msgid "{} has submitted assets linked to it. You need to cancel the assets to create purchase return."
 msgstr "{}已提交关联资产。需先取消资产才能创建采购退货"
 

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -417,3 +417,4 @@ erpnext.patches.v15_0.set_cancelled_status_to_cancelled_pos_invoice
 erpnext.patches.v15_0.rename_group_by_to_categorize_by_in_custom_reports
 erpnext.patches.v15_0.remove_agriculture_roles
 erpnext.patches.v14_0.update_full_name_in_contract
+erpnext.patches.v15_0.update_pegged_currencies

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -417,8 +417,5 @@ erpnext.patches.v15_0.set_cancelled_status_to_cancelled_pos_invoice
 erpnext.patches.v15_0.rename_group_by_to_categorize_by_in_custom_reports
 erpnext.patches.v15_0.remove_agriculture_roles
 erpnext.patches.v14_0.update_full_name_in_contract
-<<<<<<< HEAD
-erpnext.patches.v15_0.update_pegged_currencies
-=======
 erpnext.patches.v15_0.drop_sle_indexes
->>>>>>> b49a835b4c (fix: improved indexing for SLE queries. (#47194))
+erpnext.patches.v15_0.update_pegged_currencies

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -417,4 +417,8 @@ erpnext.patches.v15_0.set_cancelled_status_to_cancelled_pos_invoice
 erpnext.patches.v15_0.rename_group_by_to_categorize_by_in_custom_reports
 erpnext.patches.v15_0.remove_agriculture_roles
 erpnext.patches.v14_0.update_full_name_in_contract
+<<<<<<< HEAD
 erpnext.patches.v15_0.update_pegged_currencies
+=======
+erpnext.patches.v15_0.drop_sle_indexes
+>>>>>>> b49a835b4c (fix: improved indexing for SLE queries. (#47194))

--- a/erpnext/patches/v15_0/drop_sle_indexes.py
+++ b/erpnext/patches/v15_0/drop_sle_indexes.py
@@ -1,0 +1,17 @@
+import click
+import frappe
+
+
+def execute():
+	table = "tabStock Ledger Entry"
+	index_list = ["posting_datetime_creation_index", "item_warehouse"]
+
+	for index in index_list:
+		if not frappe.db.has_index(table, index):
+			continue
+
+		try:
+			frappe.db.sql_ddl(f"ALTER TABLE `{table}` DROP INDEX `{index}`")
+			click.echo(f"✓ dropped {index} index from {table}")
+		except Exception:
+			frappe.log_error("Failed to drop index")

--- a/erpnext/patches/v15_0/update_pegged_currencies.py
+++ b/erpnext/patches/v15_0/update_pegged_currencies.py
@@ -1,0 +1,7 @@
+import frappe
+
+from erpnext.setup.install import update_pegged_currencies
+
+
+def execute():
+	update_pegged_currencies()

--- a/erpnext/projects/doctype/timesheet_detail/timesheet_detail.py
+++ b/erpnext/projects/doctype/timesheet_detail/timesheet_detail.py
@@ -5,7 +5,7 @@
 import frappe
 from frappe import _
 from frappe.model.document import Document
-from frappe.utils import add_to_date, flt, get_datetime, time_diff_in_hours
+from frappe.utils import add_to_date, flt, get_datetime, time_diff_in_hours, time_diff_in_seconds
 
 
 class TimesheetDetail(Document):
@@ -48,7 +48,9 @@ class TimesheetDetail(Document):
 		if not (self.from_time and self.hours):
 			return
 
-		self.to_time = get_datetime(add_to_date(self.from_time, hours=self.hours, as_datetime=True))
+		_to_time = get_datetime(add_to_date(self.from_time, hours=self.hours, as_datetime=True))
+		if abs(time_diff_in_seconds(_to_time, self.to_time)) >= 1:
+			self.to_time = _to_time
 
 	def set_project(self):
 		"""Set project based on task."""

--- a/erpnext/public/js/financial_statements.js
+++ b/erpnext/public/js/financial_statements.js
@@ -41,7 +41,7 @@ erpnext.financial_statements = {
 			}
 		}
 
-		if (data && column.fieldname == "account") {
+		if (data && column.fieldname == this.name_field) {
 			// first column
 			value = data.section_name || data.account_name || value;
 

--- a/erpnext/public/js/setup_wizard.js
+++ b/erpnext/public/js/setup_wizard.js
@@ -8,6 +8,13 @@ frappe.pages["setup-wizard"].on_page_load = function (wrapper) {
 };
 
 frappe.setup.on("before_load", function () {
+	if (
+		frappe.boot.setup_wizard_completed_apps?.length &&
+		frappe.boot.setup_wizard_completed_apps.includes("erpnext")
+	) {
+		return;
+	}
+
 	erpnext.setup.slides_settings.map(frappe.setup.add_slide);
 });
 
@@ -91,7 +98,7 @@ erpnext.setup.slides_settings = [
 		},
 
 		set_fy_dates: function (slide) {
-			var country = frappe.wizard.values.country;
+			var country = frappe.wizard.values.country || frappe.defaults.get_default("country");
 
 			if (country) {
 				let fy = erpnext.setup.fiscal_years[country];
@@ -113,7 +120,7 @@ erpnext.setup.slides_settings = [
 		},
 
 		load_chart_of_accounts: function (slide) {
-			let country = frappe.wizard.values.country;
+			let country = frappe.wizard.values.country || frappe.defaults.get_default("country");
 
 			if (country) {
 				frappe.call({

--- a/erpnext/selling/doctype/quotation/quotation.py
+++ b/erpnext/selling/doctype/quotation/quotation.py
@@ -175,29 +175,22 @@ class Quotation(SellingController):
 		)
 
 	def get_ordered_status(self):
-		status = "Open"
-		ordered_items = frappe._dict(
-			frappe.db.get_all(
-				"Sales Order Item",
-				{"prevdoc_docname": self.name, "docstatus": 1},
-				["item_code", "sum(qty)"],
-				group_by="item_code",
-				as_list=1,
-			)
-		)
+		ordered_items = get_ordered_items(self.name)
 
 		if not ordered_items:
-			return status
+			return "Open"
 
-		has_alternatives = any(row.is_alternative for row in self.get("items"))
-		self._items = self.get_valid_items() if has_alternatives else self.get("items")
+		self._items = (
+			self.get_valid_items()
+			if any(row.is_alternative for row in self.get("items"))
+			else self.get("items")
+		)
 
-		if any(row.qty > ordered_items.get(row.item_code, 0.0) for row in self._items):
-			status = "Partially Ordered"
-		else:
-			status = "Ordered"
+		for row in self._items:
+			if row.name not in ordered_items or row.qty > ordered_items[row.name]:
+				return "Partially Ordered"
 
-		return status
+		return "Ordered"
 
 	def get_valid_items(self):
 		"""
@@ -372,15 +365,7 @@ def make_sales_order(source_name: str, target_doc=None):
 
 def _make_sales_order(source_name, target_doc=None, ignore_permissions=False):
 	customer = _make_customer(source_name, ignore_permissions)
-	ordered_items = frappe._dict(
-		frappe.db.get_all(
-			"Sales Order Item",
-			{"prevdoc_docname": source_name, "docstatus": 1},
-			["item_code", "sum(qty)"],
-			group_by="item_code",
-			as_list=1,
-		)
-	)
+	ordered_items = get_ordered_items(source_name)
 
 	selected_rows = [x.get("name") for x in frappe.flags.get("args", {}).get("selected_items", [])]
 
@@ -418,7 +403,7 @@ def _make_sales_order(source_name, target_doc=None, ignore_permissions=False):
 		target.run_method("calculate_taxes_and_totals")
 
 	def update_item(obj, target, source_parent):
-		balance_qty = obj.qty if is_unit_price_row(obj) else obj.qty - ordered_items.get(obj.item_code, 0.0)
+		balance_qty = obj.qty if is_unit_price_row(obj) else obj.qty - ordered_items.get(obj.name, 0.0)
 		target.qty = balance_qty if balance_qty > 0 else 0
 		target.stock_qty = flt(target.qty) * flt(obj.conversion_factor)
 
@@ -434,10 +419,7 @@ def _make_sales_order(source_name, target_doc=None, ignore_permissions=False):
 		2. If selections: Is Alternative Item/Has Alternative Item: Map if selected and adequate qty
 		3. If no selections: Simple row: Map if adequate qty
 		"""
-		balance_qty = item.qty - ordered_items.get(item.item_code, 0.0)
-		has_valid_qty: bool = (balance_qty > 0) or is_unit_price_row(item)
-
-		if not has_valid_qty:
+		if not ((item.qty > ordered_items.get(item.name, 0.0)) or is_unit_price_row(item)):
 			return False
 
 		if not selected_rows:
@@ -604,3 +586,28 @@ def handle_mandatory_error(e, customer, lead_name):
 	message += _("Please create Customer from Lead {0}.").format(get_link_to_form("Lead", lead_name))
 
 	frappe.throw(message, title=_("Mandatory Missing"))
+
+
+def get_ordered_items(quotation: str):
+	"""
+	Returns a dict of ordered items with their total qty based on quotation row name.
+
+	In `Sales Order Item`, `quotation_item` is the row name of `Quotation Item`.
+
+	Example:
+	```
+	{
+	    "refsdjhd2": 10,
+	    "ygdhdshrt": 5,
+	}
+	```
+	"""
+	return frappe._dict(
+		frappe.get_all(
+			"Sales Order Item",
+			filters={"prevdoc_docname": quotation, "docstatus": 1},
+			fields=["quotation_item", "sum(qty)"],
+			group_by="quotation_item",
+			as_list=1,
+		)
+	)

--- a/erpnext/selling/doctype/quotation/test_quotation.py
+++ b/erpnext/selling/doctype/quotation/test_quotation.py
@@ -3,9 +3,10 @@
 
 import frappe
 from frappe.tests import IntegrationTestCase, UnitTestCase, change_settings
-from frappe.utils import add_days, add_months, flt, getdate, nowdate
+from frappe.utils import add_days, add_months, flt, getdate, nowdate, today
 
 from erpnext.controllers.accounts_controller import InvalidQtyError
+from erpnext.setup.utils import get_exchange_rate
 
 EXTRA_TEST_RECORD_DEPENDENCIES = ["Product Bundle"]
 
@@ -825,6 +826,20 @@ class TestQuotation(IntegrationTestCase):
 
 		quotation.reload()
 		self.assertEqual(quotation.status, "Ordered")
+
+	def test_make_quotation_qar_to_inr(self):
+		quotation = make_quotation(
+			currency="QAR",
+			transaction_date="2026-06-04",
+		)
+
+		expected_rate = 23.521978021978022
+
+		self.assertEqual(
+			quotation.conversion_rate,
+			expected_rate,
+			f"Expected conversion rate {expected_rate}, got {quotation.conversion_rate}",
+		)
 
 
 def enable_calculate_bundle_price(enable=1):

--- a/erpnext/selling/doctype/quotation/test_quotation.py
+++ b/erpnext/selling/doctype/quotation/test_quotation.py
@@ -887,6 +887,21 @@ class TestQuotation(IntegrationTestCase):
 		sales_order_2.submit()
 		quotation.reload()
 		self.assertEqual(quotation.status, "Ordered")
+  
+  
+	def test_make_quotation_qar_to_inr(self):
+		quotation = make_quotation(
+			currency="QAR",
+			transaction_date="2026-06-04",
+		)
+
+		expected_rate = 23.521978021978022
+
+		self.assertEqual(
+			quotation.conversion_rate,
+			expected_rate,
+			f"Expected conversion rate {expected_rate}, got {quotation.conversion_rate}",
+		)
 
 
 def enable_calculate_bundle_price(enable=1):

--- a/erpnext/selling/doctype/sales_order/sales_order.js
+++ b/erpnext/selling/doctype/sales_order/sales_order.js
@@ -1021,7 +1021,7 @@ erpnext.selling.SalesOrderController = class SalesOrderController extends erpnex
 						items: data,
 						company: me.frm.doc.company,
 						sales_order: me.frm.docname,
-						project: me.frm.project,
+						project: me.frm.doc.project,
 					},
 					freeze: true,
 					callback: function (r) {

--- a/erpnext/selling/doctype/sales_order/sales_order_dashboard.py
+++ b/erpnext/selling/doctype/sales_order/sales_order_dashboard.py
@@ -17,6 +17,7 @@ def get_data():
 			"Quotation": ["items", "prevdoc_docname"],
 			"BOM": ["items", "bom_no"],
 			"Blanket Order": ["items", "blanket_order"],
+			"Purchase Order": ["items", "purchase_order"],
 		},
 		"transactions": [
 			{

--- a/erpnext/selling/page/point_of_sale/pos_controller.js
+++ b/erpnext/selling/page/point_of_sale/pos_controller.js
@@ -541,7 +541,7 @@ erpnext.PointOfSale.Controller = class {
 					frappe.run_serially([
 						() => frappe.dom.freeze(),
 						() => this.make_new_invoice(),
-						() => this.item_selector.toggle_component(true),
+						() => this.toggle_components(true),
 						() => frappe.dom.unfreeze(),
 					]);
 				},

--- a/erpnext/selling/page/point_of_sale/pos_controller.js
+++ b/erpnext/selling/page/point_of_sale/pos_controller.js
@@ -160,19 +160,18 @@ erpnext.PointOfSale.Controller = class {
 		this.setup_listener_for_pos_closing();
 	}
 
-	fetch_invoice_fields() {
-		const me = this;
-		frappe.db.get_doc("POS Settings", undefined).then((doc) => {
-			me.settings.invoice_fields = doc.invoice_fields.map((field) => {
-				return {
-					fieldname: field.fieldname,
-					label: field.label,
-					fieldtype: field.fieldtype,
-					reqd: field.reqd,
-					options: field.options,
-					default_value: field.default_value,
-					read_only: field.read_only,
-				};
+	async fetch_invoice_fields() {
+		this.settings.invoice_fields = new Array();
+		const pos_settings = await frappe.db.get_doc("POS Settings", undefined);
+		pos_settings.invoice_fields.forEach((field) => {
+			this.settings.invoice_fields.push({
+				fieldname: field.fieldname,
+				label: field.label,
+				fieldtype: field.fieldtype,
+				reqd: field.reqd,
+				options: field.options,
+				default_value: field.default_value,
+				read_only: field.read_only,
 			});
 		});
 	}

--- a/erpnext/setup/install.py
+++ b/erpnext/setup/install.py
@@ -32,6 +32,7 @@ def after_install():
 	add_app_name()
 	update_roles()
 	make_default_operations()
+	update_pegged_currencies()
 	frappe.db.commit()
 
 
@@ -228,6 +229,28 @@ def create_default_role_profiles():
 			role_profile.append("roles", {"role": role})
 
 		role_profile.insert(ignore_permissions=True)
+
+
+def update_pegged_currencies():
+	doc = frappe.get_doc("Pegged Currencies", "Pegged Currencies")
+
+	existing_sources = {item.source_currency for item in doc.pegged_currency_item}
+
+	currencies_to_add = [
+		{"source_currency": "AED", "pegged_currency": "USD", "currency_ratio": 3.6725},
+		{"source_currency": "BHD", "pegged_currency": "USD", "currency_ratio": 0.376},
+		{"source_currency": "JOD", "pegged_currency": "USD", "currency_ratio": 0.709},
+		{"source_currency": "OMR", "pegged_currency": "USD", "currency_ratio": 0.3845},
+		{"source_currency": "QAR", "pegged_currency": "USD", "currency_ratio": 3.64},
+		{"source_currency": "SAR", "pegged_currency": "USD", "currency_ratio": 3.75},
+	]
+
+	for currency in currencies_to_add:
+		if currency["source_currency"] not in existing_sources:
+			doc.append("pegged_currency_item", currency)
+
+	doc.save()
+	frappe.db.commit()
 
 
 DEFAULT_ROLE_PROFILES = {

--- a/erpnext/setup/install.py
+++ b/erpnext/setup/install.py
@@ -36,13 +36,6 @@ def after_install():
 	frappe.db.commit()
 
 
-def check_setup_wizard_not_completed():
-	if cint(frappe.db.get_single_value("System Settings", "setup_complete") or 0):
-		message = """ERPNext can only be installed on a fresh site where the setup wizard is not completed.
-You can reinstall this site (after saving your data) using: bench --site [sitename] reinstall"""
-		frappe.throw(message)  # nosemgrep
-
-
 def make_default_operations():
 	for operation in ["Assembly"]:
 		if not frappe.db.exists("Operation", operation):

--- a/erpnext/setup/utils.py
+++ b/erpnext/setup/utils.py
@@ -9,10 +9,6 @@ from frappe.utils.nestedset import get_root_of
 
 from erpnext import get_default_company
 
-PEGGED_CURRENCIES = {
-	"USD": {"AED": 3.6725},  # AED is pegged to USD at a rate of 3.6725 since 1997
-}
-
 
 def before_tests():
 	frappe.clear_cache()
@@ -47,11 +43,52 @@ def before_tests():
 	frappe.db.commit()
 
 
-def get_pegged_rate(from_currency: str, to_currency: str, transaction_date) -> float | None:
-	if rate := PEGGED_CURRENCIES.get(from_currency, {}).get(to_currency):
-		return rate
-	elif rate := PEGGED_CURRENCIES.get(to_currency, {}).get(from_currency):
-		return 1 / rate
+def get_pegged_currencies():
+	pegged_currencies = frappe.get_all(
+		"Pegged Currency Details",
+		filters={"parent": "Pegged Currencies"},
+		fields=["source_currency", "pegged_currency", "currency_ratio"],
+	)
+
+	pegged_map = {
+		currency.source_currency: {
+			"pegged_currency": currency.pegged_currency,
+			"ratio": flt(currency.currency_ratio),
+		}
+		for currency in pegged_currencies
+	}
+	return pegged_map
+
+
+def get_pegged_rate(pegged_map, from_currency, to_currency, transaction_date=None):
+	from_entry = pegged_map.get(from_currency)
+	to_entry = pegged_map.get(to_currency)
+
+	if from_currency in pegged_map and to_currency in pegged_map:
+		# Case 1: Both are present and pegged to same bases
+		if from_entry["pegged_currency"] == to_entry["pegged_currency"]:
+			print("Both currencies are pegged to the same base currency")
+			return (1 / from_entry["ratio"]) * to_entry["ratio"]
+
+		# Case 2: Both are present but pegged to different bases
+		base_from = from_entry["pegged_currency"]
+		base_to = to_entry["pegged_currency"]
+		base_rate = get_exchange_rate(base_from, base_to, transaction_date)
+
+		if not base_rate:
+			return None
+
+		return (1 / from_entry["ratio"]) * base_rate * to_entry["ratio"]
+
+	# Case 3: from_currency is pegged to to_currency
+	if from_entry and from_entry["pegged_currency"] == to_currency:
+		return flt(from_entry["ratio"])
+
+	# Case 4: to_currency is pegged to from_currency
+	if to_entry and to_entry["pegged_currency"] == from_currency:
+		return 1 / flt(to_entry["ratio"])
+
+	""" If only one entry exists but doesn’t match pegged currency logic, return None """
 	return None
 
 
@@ -95,7 +132,9 @@ def get_exchange_rate(from_currency, to_currency, transaction_date=None, args=No
 	if frappe.get_cached_value("Currency Exchange Settings", "Currency Exchange Settings", "disabled"):
 		return 0.00
 
-	if rate := get_pegged_rate(from_currency, to_currency, transaction_date):
+	pegged_currencies = get_pegged_currencies()
+
+	if rate := get_pegged_rate(pegged_currencies, from_currency, to_currency, transaction_date):
 		return rate
 
 	try:
@@ -109,8 +148,12 @@ def get_exchange_rate(from_currency, to_currency, transaction_date=None, args=No
 			settings = frappe.get_cached_doc("Currency Exchange Settings")
 			req_params = {
 				"transaction_date": transaction_date,
-				"from_currency": from_currency if from_currency != "AED" else "USD",
-				"to_currency": to_currency if to_currency != "AED" else "USD",
+				"from_currency": from_currency
+				if from_currency not in pegged_currencies
+				else pegged_currencies[from_currency]["pegged_currency"],
+				"to_currency": to_currency
+				if to_currency not in pegged_currencies
+				else pegged_currencies[to_currency]["pegged_currency"],
 			}
 			params = {}
 			for row in settings.req_params:
@@ -123,12 +166,12 @@ def get_exchange_rate(from_currency, to_currency, transaction_date=None, args=No
 				value = value[format_ces_api(str(res_key.key), req_params)]
 			cache.setex(name=key, time=21600, value=flt(value))
 
-		# Support AED conversion through pegged USD
+		# Support multiple pegged currencies
 		value = flt(value)
-		if to_currency == "AED":
-			value *= 3.6725
-		if from_currency == "AED":
-			value /= 3.6725
+		if to_currency in pegged_currencies:
+			value *= flt(pegged_currencies[to_currency]["ratio"])
+		if from_currency in pegged_currencies:
+			value /= flt(pegged_currencies[from_currency]["ratio"])
 
 		return flt(value)
 	except Exception:

--- a/erpnext/stock/doctype/delivery_note/test_delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/test_delivery_note.py
@@ -2605,6 +2605,49 @@ class TestDeliveryNote(IntegrationTestCase):
 		self.assertEqual(dn.per_billed, 100)
 		self.assertEqual(dn.per_returned, 100)
 
+	def test_packed_item_serial_no_status(self):
+		from erpnext.selling.doctype.product_bundle.test_product_bundle import make_product_bundle
+		from erpnext.stock.doctype.item.test_item import make_item
+
+		# test Update Items with product bundle
+		if not frappe.db.exists("Item", "_Test Product Bundle Item New 1"):
+			bundle_item = make_item("_Test Product Bundle Item New 1", {"is_stock_item": 0})
+			bundle_item.append(
+				"item_defaults", {"company": "_Test Company", "default_warehouse": "_Test Warehouse - _TC"}
+			)
+			bundle_item.save(ignore_permissions=True)
+
+		make_item(
+			"_Packed Item New Sn Item",
+			{"is_stock_item": 1, "has_serial_no": 1, "serial_no_series": "SN-PACKED-NEW-.#####"},
+		)
+		make_product_bundle("_Test Product Bundle Item New 1", ["_Packed Item New Sn Item"], 1)
+
+		make_stock_entry(item="_Packed Item New Sn Item", target="_Test Warehouse - _TC", qty=5, rate=100)
+
+		dn = create_delivery_note(
+			item_code="_Test Product Bundle Item New 1",
+			warehouse="_Test Warehouse - _TC",
+			qty=5,
+		)
+
+		dn.reload()
+
+		serial_nos = []
+		for row in dn.packed_items:
+			self.assertTrue(row.serial_and_batch_bundle)
+			doc = frappe.get_doc("Serial and Batch Bundle", row.serial_and_batch_bundle)
+			for row in doc.entries:
+				status = frappe.db.get_value("Serial No", row.serial_no, "status")
+				self.assertEqual(status, "Delivered")
+				serial_nos.append(row.serial_no)
+
+		dn.cancel()
+
+		for row in serial_nos:
+			status = frappe.db.get_value("Serial No", row, "status")
+			self.assertEqual(status, "Active")
+
 
 def create_delivery_note(**args):
 	dn = frappe.new_doc("Delivery Note")

--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
@@ -1244,7 +1244,7 @@ def update_billing_percentage(pr_doc, update_modified=True, adjust_incoming_rate
 
 			adjusted_amt = flt(adjusted_amt * flt(pr_doc.conversion_rate), item.precision("amount"))
 			item.db_set("amount_difference_with_purchase_invoice", adjusted_amt, update_modified=False)
-		elif item.billed_amt > amount:
+		elif amount and item.billed_amt > amount:
 			per_over_billed = (flt(item.billed_amt / amount, 2) * 100) - 100
 			if per_over_billed > over_billing_allowance:
 				frappe.throw(

--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
@@ -513,6 +513,15 @@ class PurchaseReceipt(BuyingController):
 			)
 
 		def make_stock_received_but_not_billed_entry(item):
+			if (
+				self.get("is_return")
+				and item.return_qty_from_rejected_warehouse
+				and not frappe.db.get_single_value(
+					"Buying Settings", "set_valuation_rate_for_rejected_materials"
+				)
+			):
+				return 0.0
+
 			account = (
 				warehouse_account[item.from_warehouse]["account"] if item.from_warehouse else stock_asset_rbnb
 			)

--- a/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.json
+++ b/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.json
@@ -34,6 +34,7 @@
   "returned_against",
   "section_break_wzou",
   "is_cancelled",
+  "is_packed",
   "is_rejected",
   "amended_from"
  ],
@@ -251,12 +252,19 @@
    "label": "Naming Series",
    "options": "\nSABB-.########",
    "set_only_once": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "is_packed",
+   "fieldtype": "Check",
+   "label": "Is Packed"
   }
  ],
+ "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-02-17 16:22:36.056205",
+ "modified": "2025-05-30 18:05:55.489195",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Serial and Batch Bundle",
@@ -390,6 +398,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],

--- a/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py
+++ b/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py
@@ -65,6 +65,7 @@ class SerialandBatchBundle(Document):
 		has_batch_no: DF.Check
 		has_serial_no: DF.Check
 		is_cancelled: DF.Check
+		is_packed: DF.Check
 		is_rejected: DF.Check
 		item_code: DF.Link
 		item_group: DF.Link | None

--- a/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py
+++ b/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py
@@ -726,19 +726,19 @@ class SerialandBatchBundle(Document):
 
 	def reset_qty(self, row, qty_field=None):
 		qty_field = self.get_qty_field(row, qty_field=qty_field)
-		qty = abs(row.get(qty_field))
+		qty = abs(flt(row.get(qty_field), self.precision("total_qty")))
 
 		idx = None
 		while qty > 0:
 			for d in self.entries:
-				row_qty = abs(d.qty)
+				row_qty = abs(flt(d.qty, d.precision("qty")))
 				if row_qty >= qty:
 					d.db_set("qty", qty if self.type_of_transaction == "Inward" else qty * -1)
 					qty = 0
 					idx = d.idx
 					break
 				else:
-					qty -= row_qty
+					qty = flt(qty - row_qty, d.precision("qty"))
 					idx = d.idx
 
 		if idx and len(self.entries) > idx:

--- a/erpnext/stock/doctype/stock_ledger_entry/stock_ledger_entry.json
+++ b/erpnext/stock/doctype/stock_ledger_entry/stock_ledger_entry.json
@@ -57,7 +57,6 @@
    "options": "Item",
    "print_width": "100px",
    "read_only": 1,
-   "search_index": 1,
    "width": "100px"
   },
   {
@@ -88,7 +87,6 @@
    "options": "Warehouse",
    "print_width": "100px",
    "read_only": 1,
-   "search_index": 1,
    "width": "100px"
   },
   {
@@ -101,7 +99,6 @@
    "oldfieldtype": "Date",
    "print_width": "100px",
    "read_only": 1,
-   "search_index": 1,
    "width": "100px"
   },
   {
@@ -356,13 +353,14 @@
    "label": "Posting Datetime"
   }
  ],
+ "grid_page_length": 50,
  "hide_toolbar": 1,
  "icon": "fa fa-list",
  "idx": 1,
  "in_create": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-12-23 18:03:05.171023",
+ "modified": "2025-04-22 12:37:41.304109",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Stock Ledger Entry",
@@ -383,6 +381,7 @@
    "role": "Accounts Manager"
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": []

--- a/erpnext/stock/doctype/stock_ledger_entry/stock_ledger_entry.py
+++ b/erpnext/stock/doctype/stock_ledger_entry/stock_ledger_entry.py
@@ -345,5 +345,4 @@ class StockLedgerEntry(Document):
 def on_doctype_update():
 	frappe.db.add_index("Stock Ledger Entry", ["voucher_no", "voucher_type"])
 	frappe.db.add_index("Stock Ledger Entry", ["batch_no", "item_code", "warehouse"])
-	frappe.db.add_index("Stock Ledger Entry", ["warehouse", "item_code"], "item_warehouse")
-	frappe.db.add_index("Stock Ledger Entry", ["posting_datetime", "creation"])
+	frappe.db.add_index("Stock Ledger Entry", ["item_code", "warehouse", "posting_datetime", "creation"])

--- a/erpnext/stock/doctype/warehouse/warehouse.py
+++ b/erpnext/stock/doctype/warehouse/warehouse.py
@@ -8,6 +8,7 @@ import frappe
 from frappe import _, throw
 from frappe.contacts.address_and_contact import load_address_and_contact
 from frappe.utils import cint
+from frappe.utils.caching import request_cache
 from frappe.utils.nestedset import NestedSet
 from pypika.terms import ExistsCriterion
 
@@ -221,6 +222,7 @@ def convert_to_group_or_ledger(docname=None):
 	return frappe.get_doc("Warehouse", docname).convert_to_group_or_ledger()
 
 
+@request_cache
 def get_child_warehouses(warehouse):
 	from frappe.utils.nestedset import get_descendants_of
 

--- a/erpnext/stock/report/available_batch_report/available_batch_report.py
+++ b/erpnext/stock/report/available_batch_report/available_batch_report.py
@@ -6,7 +6,7 @@ from collections import defaultdict
 import frappe
 from frappe import _
 from frappe.query_builder.functions import Sum
-from frappe.utils import flt, today
+from frappe.utils import flt, get_datetime, today
 
 
 def execute(filters=None):
@@ -167,7 +167,8 @@ def get_query_based_on_filters(query, batch, table, filters):
 		query = query.where(batch.batch_qty > 0)
 
 	else:
-		query = query.where(table.posting_date <= filters.to_date)
+		to_date = get_datetime(str(filters.to_date) + " 23:59:59")
+		query = query.where(table.posting_datetime <= to_date)
 
 	if filters.warehouse:
 		lft, rgt = frappe.db.get_value("Warehouse", filters.warehouse, ["lft", "rgt"])

--- a/erpnext/stock/report/batch_wise_balance_history/batch_wise_balance_history.py
+++ b/erpnext/stock/report/batch_wise_balance_history/batch_wise_balance_history.py
@@ -140,7 +140,6 @@ def get_stock_ledger_entries_for_batch_no(filters):
 			& (sle.posting_datetime < posting_datetime)
 		)
 		.groupby(sle.voucher_no, sle.batch_no, sle.item_code, sle.warehouse)
-		.orderby(sle.item_code, sle.warehouse)
 	)
 
 	query = apply_warehouse_filter(query, sle, filters)
@@ -188,7 +187,6 @@ def get_stock_ledger_entries_for_batch_bundle(filters):
 			& (sle.posting_datetime <= to_date)
 		)
 		.groupby(sle.voucher_no, batch_package.batch_no, batch_package.warehouse)
-		.orderby(sle.item_code, sle.warehouse)
 	)
 
 	query = apply_warehouse_filter(query, sle, filters)

--- a/erpnext/stock/report/fifo_queue_vs_qty_after_transaction_comparison/fifo_queue_vs_qty_after_transaction_comparison.py
+++ b/erpnext/stock/report/fifo_queue_vs_qty_after_transaction_comparison/fifo_queue_vs_qty_after_transaction_comparison.py
@@ -66,7 +66,7 @@ def get_stock_ledger_entries(filters):
 		"Stock Ledger Entry",
 		fields=SLE_FIELDS,
 		filters=sle_filters,
-		order_by="timestamp(posting_date, posting_time), creation",
+		order_by="posting_datetime, creation",
 	)
 
 

--- a/erpnext/stock/report/stock_analytics/stock_analytics.py
+++ b/erpnext/stock/report/stock_analytics/stock_analytics.py
@@ -5,8 +5,8 @@ import datetime
 import frappe
 from frappe import _, scrub
 from frappe.query_builder.functions import CombineDatetime
+from frappe.utils import get_datetime, get_first_day_of_week, get_quarter_start, getdate
 from frappe.utils import get_first_day as get_first_day_of_month
-from frappe.utils import get_first_day_of_week, get_quarter_start, getdate
 from frappe.utils.nestedset import get_descendants_of
 
 from erpnext.accounts.utils import get_fiscal_year
@@ -294,9 +294,8 @@ def get_stock_ledger_entries(filters, items):
 			sle.batch_no,
 		)
 		.where((sle.docstatus < 2) & (sle.is_cancelled == 0))
-		.orderby(CombineDatetime(sle.posting_date, sle.posting_time))
+		.orderby(sle.posting_datetime)
 		.orderby(sle.creation)
-		.orderby(sle.actual_qty)
 	)
 
 	if items:
@@ -314,7 +313,8 @@ def apply_conditions(query, filters):
 		frappe.throw(_("'From Date' is required"))
 
 	if to_date := filters.get("to_date"):
-		query = query.where(sle.posting_date <= to_date)
+		to_date = get_datetime(str(to_date) + " 23:59:59")
+		query = query.where(sle.posting_datetime <= to_date)
 	else:
 		frappe.throw(_("'To Date' is required"))
 

--- a/erpnext/stock/report/stock_ledger_invariant_check/stock_ledger_invariant_check.py
+++ b/erpnext/stock/report/stock_ledger_invariant_check/stock_ledger_invariant_check.py
@@ -44,7 +44,7 @@ def get_stock_ledger_entries(filters):
 		"Stock Ledger Entry",
 		fields=SLE_FIELDS,
 		filters={"item_code": filters.item_code, "warehouse": filters.warehouse, "is_cancelled": 0},
-		order_by="timestamp(posting_date, posting_time), creation",
+		order_by="posting_datetime, creation",
 	)
 
 

--- a/erpnext/stock/serial_batch_bundle.py
+++ b/erpnext/stock/serial_batch_bundle.py
@@ -111,6 +111,7 @@ class SerialBatchBundle:
 				"type_of_transaction": "Inward" if self.sle.actual_qty > 0 else "Outward",
 				"company": self.company,
 				"is_rejected": self.is_rejected_entry(),
+				"is_packed": self.is_packed_entry(),
 				"make_bundle_from_sle": 1,
 			}
 		).make_serial_and_batch_bundle()
@@ -194,7 +195,21 @@ class SerialBatchBundle:
 				elif sn_doc.has_batch_no and len(sn_doc.entries) == 1:
 					values_to_update["batch_no"] = sn_doc.entries[0].batch_no
 
-			frappe.db.set_value(self.child_doctype, self.sle.voucher_detail_no, values_to_update)
+			doctype = self.child_doctype
+			name = self.sle.voucher_detail_no
+			if sn_doc.is_packed:
+				doctype = "Packed Item"
+				name = frappe.db.get_value(
+					"Packed Item",
+					{
+						"parent_detail_docname": sn_doc.voucher_detail_no,
+						"item_code": self.sle.item_code,
+						"serial_and_batch_bundle": ("is", "not set"),
+					},
+					"name",
+				)
+
+			frappe.db.set_value(doctype, name, values_to_update)
 
 	@property
 	def child_doctype(self):
@@ -216,6 +231,19 @@ class SerialBatchBundle:
 
 	def is_rejected_entry(self):
 		return is_rejected(self.sle.voucher_type, self.sle.voucher_detail_no, self.sle.warehouse)
+
+	def is_packed_entry(self):
+		if self.sle.voucher_type in ["Delivery Note", "Sales Invoice"]:
+			item_code = frappe.db.get_value(
+				self.sle.voucher_type + " Item",
+				self.sle.voucher_detail_no,
+				"item_code",
+			)
+
+			if item_code != self.sle.item_code:
+				return frappe.db.get_value("Item", item_code, "is_stock_item") == 0
+
+		return False
 
 	def process_batch_no(self):
 		if (
@@ -268,6 +296,10 @@ class SerialBatchBundle:
 			update_values["rejected_serial_and_batch_bundle"] = ""
 
 		frappe.db.set_value(self.child_doctype, self.sle.voucher_detail_no, update_values)
+		if self.child_doctype == "Delivery Note":
+			frappe.db.set_value(
+				"Packed Item", {"parent_detail_docname": self.sle.voucher_detail_no}, update_values
+			)
 
 		frappe.db.set_value(
 			"Serial and Batch Bundle",

--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -1422,7 +1422,10 @@ class update_entries_after:
 					return 0.0
 
 			stock_queue.remove_stock(
-				qty=abs(actual_qty), outgoing_rate=outgoing_rate, rate_generator=rate_generator
+				qty=abs(actual_qty),
+				outgoing_rate=outgoing_rate,
+				rate_generator=rate_generator,
+				is_return_purchase_entry=self.is_return_purchase_entry(sle),
 			)
 
 		_qty, stock_value = stock_queue.get_total_stock_and_value()
@@ -1439,6 +1442,12 @@ class update_entries_after:
 
 		if self.wh_data.qty_after_transaction:
 			self.wh_data.valuation_rate = self.wh_data.stock_value / self.wh_data.qty_after_transaction
+
+	def is_return_purchase_entry(self, sle):
+		if sle.voucher_type in ["Purchase Invoice", "Purchase Receipt"]:
+			return frappe.get_cached_value(sle.voucher_type, sle.voucher_no, "is_return")
+
+		return False
 
 	def update_batched_values(self, sle):
 		from erpnext.stock.serial_batch_bundle import BatchNoValuation

--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -912,8 +912,11 @@ class update_entries_after:
 		if not sle.is_adjustment_entry:
 			sle.stock_value_difference = stock_value_difference
 		elif sle.is_adjustment_entry and not self.args.get("sle_id"):
-			sle.stock_value_difference = get_stock_value_difference(
-				sle.item_code, sle.warehouse, sle.posting_date, sle.posting_time, sle.voucher_no
+			sle.stock_value_difference = (
+				get_stock_value_difference(
+					sle.item_code, sle.warehouse, sle.posting_date, sle.posting_time, sle.voucher_no
+				)
+				* -1
 			)
 
 		sle.doctype = "Stock Ledger Entry"

--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -1822,7 +1822,7 @@ def get_valuation_rate(
 	# Get valuation rate from last sle for the same item and warehouse
 	if last_valuation_rate := frappe.db.sql(  # nosemgrep
 		"""select valuation_rate
-		from `tabStock Ledger Entry` force index (item_warehouse)
+		from `tabStock Ledger Entry`
 		where
 			item_code = %s
 			AND warehouse = %s
@@ -1966,7 +1966,6 @@ def get_next_stock_reco(kwargs):
 			sle.actual_qty,
 			sle.has_batch_no,
 		)
-		.force_index("item_warehouse")
 		.where(
 			(sle.item_code == kwargs.get("item_code"))
 			& (sle.warehouse == kwargs.get("warehouse"))

--- a/erpnext/stock/valuation.py
+++ b/erpnext/stock/valuation.py
@@ -18,7 +18,11 @@ class BinWiseValuation(ABC):
 
 	@abstractmethod
 	def remove_stock(
-		self, qty: float, outgoing_rate: float = 0.0, rate_generator: Callable[[], float] | None = None
+		self,
+		qty: float,
+		outgoing_rate: float = 0.0,
+		rate_generator: Callable[[], float] | None = None,
+		is_return_purchase_entry: bool = False,
 	) -> list[StockBin]:
 		pass
 
@@ -96,7 +100,11 @@ class FIFOValuation(BinWiseValuation):
 					self.queue[-1][QTY] = qty
 
 	def remove_stock(
-		self, qty: float, outgoing_rate: float = 0.0, rate_generator: Callable[[], float] | None = None
+		self,
+		qty: float,
+		outgoing_rate: float = 0.0,
+		rate_generator: Callable[[], float] | None = None,
+		is_return_purchase_entry: bool = False,
 	) -> list[StockBin]:
 		"""Remove stock from the queue and return popped bins.
 
@@ -115,7 +123,7 @@ class FIFOValuation(BinWiseValuation):
 				self.queue.append([0, rate_generator()])
 
 			index = None
-			if outgoing_rate > 0:
+			if outgoing_rate > 0 or is_return_purchase_entry:
 				# Find the entry where rate matched with outgoing rate
 				for idx, fifo_bin in enumerate(self.queue):
 					if fifo_bin[RATE] == outgoing_rate:
@@ -202,7 +210,11 @@ class LIFOValuation(BinWiseValuation):
 					self.stack[-1][QTY] = qty
 
 	def remove_stock(
-		self, qty: float, outgoing_rate: float = 0.0, rate_generator: Callable[[], float] | None = None
+		self,
+		qty: float,
+		outgoing_rate: float = 0.0,
+		rate_generator: Callable[[], float] | None = None,
+		is_return_purchase_entry: bool = False,
 	) -> list[StockBin]:
 		"""Remove stock from the stack and return popped bins.
 

--- a/erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py
+++ b/erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py
@@ -145,6 +145,9 @@ class SubcontractingReceipt(SubcontractingController):
 		self.reset_default_field_value("rejected_warehouse", "items", "rejected_warehouse")
 		self.get_current_stock()
 
+		self.set_supplied_items_expense_account()
+		self.set_supplied_items_cost_center()
+
 	def on_submit(self):
 		self.validate_closed_subcontracting_order()
 		self.validate_available_qty_for_consumption()
@@ -248,15 +251,16 @@ class SubcontractingReceipt(SubcontractingController):
 				if not item.cost_center:
 					item.cost_center = cost_center
 
-			for item in self.supplied_items:
-				if not item.cost_center:
-					item.cost_center = get_default_cost_center(
-						{"project": self.project},
-						get_item_defaults(item.rm_item_code, self.company),
-						get_item_group_defaults(item.rm_item_code, self.company),
-						get_brand_defaults(item.rm_item_code, self.company),
-						self.company,
-					)
+	def set_supplied_items_cost_center(self):
+		for item in self.supplied_items:
+			if not item.cost_center:
+				item.cost_center = get_default_cost_center(
+					{"project": self.project},
+					get_item_defaults(item.rm_item_code, self.company),
+					get_item_group_defaults(item.rm_item_code, self.company),
+					get_brand_defaults(item.rm_item_code, self.company),
+					self.company,
+				)
 
 	def set_items_expense_account(self):
 		if self.company:
@@ -266,14 +270,21 @@ class SubcontractingReceipt(SubcontractingController):
 				if not item.expense_account:
 					item.expense_account = expense_account
 
-			for item in self.supplied_items:
-				if not item.expense_account:
-					item.expense_account = get_default_expense_account(
-						frappe._dict({"expense_account": expense_account}),
-						get_item_defaults(item.rm_item_code, self.company),
-						get_item_group_defaults(item.rm_item_code, self.company),
-						get_brand_defaults(item.rm_item_code, self.company),
-					)
+	def set_supplied_items_expense_account(self):
+		for item in self.supplied_items:
+			if not item.expense_account:
+				item.expense_account = get_default_expense_account(
+					frappe._dict(
+						{
+							"expense_account": self.get_company_default(
+								"default_expense_account", ignore_validation=True
+							)
+						}
+					),
+					get_item_defaults(item.rm_item_code, self.company),
+					get_item_group_defaults(item.rm_item_code, self.company),
+					get_brand_defaults(item.rm_item_code, self.company),
+				)
 
 	def reset_supplied_items(self):
 		if (

--- a/erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py
+++ b/erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py
@@ -11,6 +11,10 @@ import erpnext
 from erpnext.accounts.utils import get_account_currency
 from erpnext.buying.utils import check_on_hold_or_closed_status
 from erpnext.controllers.subcontracting_controller import SubcontractingController
+from erpnext.setup.doctype.brand.brand import get_brand_defaults
+from erpnext.setup.doctype.item_group.item_group import get_item_group_defaults
+from erpnext.stock.doctype.item.item import get_item_defaults
+from erpnext.stock.get_item_details import get_default_cost_center, get_default_expense_account
 from erpnext.stock.stock_ledger import get_valuation_rate
 
 
@@ -244,6 +248,16 @@ class SubcontractingReceipt(SubcontractingController):
 				if not item.cost_center:
 					item.cost_center = cost_center
 
+			for item in self.supplied_items:
+				if not item.cost_center:
+					item.cost_center = get_default_cost_center(
+						{"project": self.project},
+						get_item_defaults(item.rm_item_code, self.company),
+						get_item_group_defaults(item.rm_item_code, self.company),
+						get_brand_defaults(item.rm_item_code, self.company),
+						self.company,
+					)
+
 	def set_items_expense_account(self):
 		if self.company:
 			expense_account = self.get_company_default("default_expense_account", ignore_validation=True)
@@ -251,6 +265,15 @@ class SubcontractingReceipt(SubcontractingController):
 			for item in self.items:
 				if not item.expense_account:
 					item.expense_account = expense_account
+
+			for item in self.supplied_items:
+				if not item.expense_account:
+					item.expense_account = get_default_expense_account(
+						frappe._dict({"expense_account": expense_account}),
+						get_item_defaults(item.rm_item_code, self.company),
+						get_item_group_defaults(item.rm_item_code, self.company),
+						get_brand_defaults(item.rm_item_code, self.company),
+					)
 
 	def reset_supplied_items(self):
 		if (

--- a/erpnext/subcontracting/doctype/subcontracting_receipt/test_subcontracting_receipt.py
+++ b/erpnext/subcontracting/doctype/subcontracting_receipt/test_subcontracting_receipt.py
@@ -412,6 +412,9 @@ class TestSubcontractingReceipt(IntegrationTestCase):
 		scr.save()
 		scr.submit()
 
+		for item in scr.supplied_items:
+			self.assertTrue(item.expense_account)
+
 		gl_entries = get_gl_entries("Subcontracting Receipt", scr.name)
 		self.assertTrue(gl_entries)
 

--- a/erpnext/subcontracting/doctype/subcontracting_receipt/test_subcontracting_receipt.py
+++ b/erpnext/subcontracting/doctype/subcontracting_receipt/test_subcontracting_receipt.py
@@ -381,6 +381,52 @@ class TestSubcontractingReceipt(IntegrationTestCase):
 		self.assertTrue(get_gl_entries("Subcontracting Receipt", scr.name))
 		frappe.db.set_single_value("Stock Settings", "use_serial_batch_fields", 1)
 
+	def test_subcontracting_receipt_gl_entry_with_different_rm_expense_accounts(self):
+		service_items = [
+			{
+				"warehouse": "Stores - TCP1",
+				"item_code": "Subcontracted Service Item 7",
+				"qty": 10,
+				"rate": 100,
+				"fg_item": "Subcontracted Item SA4",
+				"fg_item_qty": 10,
+			},
+		]
+		sco = get_subcontracting_order(
+			company="_Test Company with perpetual inventory",
+			warehouse="Stores - TCP1",
+			supplier_warehouse="Work In Progress - TCP1",
+			service_items=service_items,
+		)
+		rm_items = get_rm_items(sco.supplied_items)
+		itemwise_details = make_stock_in_entry(rm_items=rm_items)
+		make_stock_transfer_entry(
+			sco_no=sco.name,
+			rm_items=rm_items,
+			itemwise_details=copy.deepcopy(itemwise_details),
+		)
+
+		scr = make_subcontracting_receipt(sco.name)
+		scr.save()
+		scr.supplied_items[1].expense_account = "_Test Write Off - TCP1"
+		scr.save()
+		scr.submit()
+
+		gl_entries = get_gl_entries("Subcontracting Receipt", scr.name)
+		self.assertTrue(gl_entries)
+
+		fg_warehouse_ac = get_inventory_account(scr.company, scr.items[0].warehouse)
+		expense_account = scr.items[0].expense_account
+		expected_values = {
+			fg_warehouse_ac: [4000, 3000],
+			expense_account: [2000, 4000],
+			"_Test Write Off - TCP1": [1000, 0],
+		}
+
+		for gle in gl_entries:
+			self.assertEqual(expected_values[gle.account][0], gle.debit)
+			self.assertEqual(expected_values[gle.account][1], gle.credit)
+
 	@IntegrationTestCase.change_settings("Stock Settings", {"use_serial_batch_fields": 0})
 	def test_subcontracting_receipt_with_zero_service_cost(self):
 		warehouse = "Stores - TCP1"

--- a/erpnext/subcontracting/doctype/subcontracting_receipt_supplied_item/subcontracting_receipt_supplied_item.json
+++ b/erpnext/subcontracting/doctype/subcontracting_receipt_supplied_item/subcontracting_receipt_supplied_item.json
@@ -33,7 +33,11 @@
   "section_break_zwnh",
   "serial_no",
   "column_break_qibi",
-  "batch_no"
+  "batch_no",
+  "accounting_details_section",
+  "expense_account",
+  "accounting_dimensions_section",
+  "cost_center"
  ],
  "fields": [
   {
@@ -103,7 +107,7 @@
   {
    "fieldname": "stock_uom",
    "fieldtype": "Link",
-   "label": "Stock Uom",
+   "label": "Stock UOM",
    "options": "UOM",
    "read_only": 1
   },
@@ -231,18 +235,43 @@
    "fieldname": "add_serial_batch_bundle",
    "fieldtype": "Button",
    "label": "Add Serial / Batch Bundle"
+  },
+  {
+   "fieldname": "accounting_details_section",
+   "fieldtype": "Section Break",
+   "label": "Accounting Details"
+  },
+  {
+   "fieldname": "expense_account",
+   "fieldtype": "Link",
+   "label": "Expense Account",
+   "options": "Account"
+  },
+  {
+   "fieldname": "accounting_dimensions_section",
+   "fieldtype": "Section Break",
+   "label": "Accounting Dimensions"
+  },
+  {
+   "depends_on": "eval:cint(erpnext.is_perpetual_inventory_enabled(parent.company))",
+   "fieldname": "cost_center",
+   "fieldtype": "Link",
+   "label": "Cost Center",
+   "options": "Cost Center",
+   "print_hide": 1
   }
  ],
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-03-30 10:26:27.237371",
+ "modified": "2025-05-27 12:33:58.772638",
  "modified_by": "Administrator",
  "module": "Subcontracting",
  "name": "Subcontracting Receipt Supplied Item",
  "naming_rule": "Autoincrement",
  "owner": "Administrator",
  "permissions": [],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": [],

--- a/erpnext/subcontracting/doctype/subcontracting_receipt_supplied_item/subcontracting_receipt_supplied_item.py
+++ b/erpnext/subcontracting/doctype/subcontracting_receipt_supplied_item/subcontracting_receipt_supplied_item.py
@@ -20,8 +20,10 @@ class SubcontractingReceiptSuppliedItem(Document):
 		bom_detail_no: DF.Data | None
 		consumed_qty: DF.Float
 		conversion_factor: DF.Float
+		cost_center: DF.Link | None
 		current_stock: DF.Float
 		description: DF.TextEditor | None
+		expense_account: DF.Link | None
 		item_name: DF.Data | None
 		main_item_code: DF.Link | None
 		parent: DF.Data

--- a/erpnext/tests/test_perf.py
+++ b/erpnext/tests/test_perf.py
@@ -5,7 +5,6 @@ INDEXED_FIELDS = {
 	"Bin": ["item_code"],
 	"GL Entry": ["voucher_no", "posting_date", "company", "party"],
 	"Purchase Order Item": ["item_code"],
-	"Stock Ledger Entry": ["warehouse"],
 }
 
 

--- a/erpnext/utilities/activation.py
+++ b/erpnext/utilities/activation.py
@@ -4,6 +4,7 @@
 
 import frappe
 from frappe import _
+from frappe.core.doctype.installed_applications.installed_applications import get_setup_wizard_completed_apps
 
 import erpnext
 
@@ -45,7 +46,7 @@ def get_level():
 			activation_level += 1
 		sales_data.append({doctype: count})
 
-	if frappe.db.get_single_value("System Settings", "setup_complete"):
+	if "erpnext" in get_setup_wizard_completed_apps():
 		activation_level += 1
 
 	communication_number = frappe.db.count("Communication", dict(communication_medium="Email"))


### PR DESCRIPTION
Issue:
Unable to fetch exchange rate for QAR to INR as QAR is a pegged currency and there is no direct exchange rate available.

Solution:
Enhanced the exchange rate calculation to support pegged currencies by deriving rates through their base currencies when a direct exchange rate between two currencies is not available.

Ref: [39794](https://support.frappe.io/helpdesk/tickets/39794)

Before:

[old_logic.webm](https://github.com/user-attachments/assets/402fb1bc-bbe7-4836-9c71-9b9315244c56)

After:

[enhanced_logic.webm](https://github.com/user-attachments/assets/7d3bb038-fb18-4c81-b258-e099b22bb1a6)

Backport needed - version 15
