### PR TITLE
fix: pos item price in get_item and item search

### DIFF
--- a/erpnext/selling/page/point_of_sale/point_of_sale.py
+++ b/erpnext/selling/page/point_of_sale/point_of_sale.py
@@ -5,7 +5,6 @@
 import json
 
 import frappe
-from frappe.query_builder import DocType
 from frappe.utils import cint, get_datetime
 from frappe.utils.nestedset import get_root_of
 

--- a/erpnext/selling/page/point_of_sale/point_of_sale.py
+++ b/erpnext/selling/page/point_of_sale/point_of_sale.py
@@ -229,7 +229,7 @@ def get_items(start, page_length, price_list, item_group, pos_profile, search_te
 
 		item_conversion_factor = get_conversion_factor(item.item_code, item_uom).get("conversion_factor")
 
-		if item.stock_uom != item_uom_price.get("uom"):
+		if item.stock_uom != item_uom:
 			item.actual_qty = item.actual_qty // item_conversion_factor
 
 		if item_uom_price and item_uom != item_uom_price.get("uom"):


### PR DESCRIPTION
Changes include:
- If an Item is searched using a Serial Number, POS will display the Item Price for the Item's `stock_uom`.
- Changed the logic to display the Item Prices on the POS Item Selector. Item Price for Item's `sales_uom` will be prioritized, after which Item Price for Item's `stock_uom` will be displayed, and if either of them is not available, it will fetch the latest Item Price added for the Item.