### PR TITLE
fix: available qty in BOM Stock Report

### DIFF
--- a/erpnext/manufacturing/report/bom_stock_report/bom_stock_report.py
+++ b/erpnext/manufacturing/report/bom_stock_report/bom_stock_report.py
@@ -79,7 +79,7 @@ def get_bom_stock(filters):
 			BOM_ITEM.stock_qty,
 			BOM_ITEM.stock_uom,
 			BOM_ITEM.stock_qty * qty_to_produce / BOM.quantity,
-			Sum(BIN.actual_qty).as_("actual_qty"),
+			BIN.actual_qty.as_("actual_qty"),
 			Sum(Floor(BIN.actual_qty / (BOM_ITEM.stock_qty * qty_to_produce / BOM.quantity))),
 		)
 		.where((BOM_ITEM.parent == filters.get("bom")) & (BOM_ITEM.parenttype == "BOM"))


### PR DESCRIPTION
**Issue**

- Incorrect available qty in the BOM Stock Report.
- To replicate the issue add the same raw material two times in the BOM


<img width="1215" alt="Screenshot 2025-06-06 at 4 06 41 PM" src="https://github.com/user-attachments/assets/2d4c6c38-7c2a-4cef-a2db-1985da18ac38" />

After Fix

<img width="1268" alt="Screenshot 2025-06-06 at 4 13 15 PM" src="https://github.com/user-attachments/assets/9870938a-f270-40ac-bc7d-2bd2fbb3d5af" />
