### PR TITLE
fix: fetch correct item tax template on item rate update

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -44,23 +44,22 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 
 			if (item.item_code && item.rate) {
 				frappe.call({
-					method: "frappe.client.get_value",
+					method: "erpnext.stock.get_item_details.get_item_tax_template",
 					args: {
-						doctype: "Item Tax",
-						parent: "Item",
-						filters: {
-							parent: item.item_code,
-							minimum_net_rate: ["<=", item.rate],
-							maximum_net_rate: [">=", item.rate]
-						},
-						fieldname: "item_tax_template"
+						ctx: {
+							item_code: item.item_code,
+							company: frm.doc.company,
+							base_net_rate: item.base_net_rate,
+							tax_category: frm.doc.tax_category,
+							item_tax_template: item.item_tax_template,
+							posting_date: frm.doc.posting_date,
+							bill_date: frm.doc.bill_date,
+							transaction_date: frm.doc.transaction_date,
+						}
 					},
 					callback: function(r) {
-						const tax_rule = r.message;
-
-						let matched_template = tax_rule ? tax_rule.item_tax_template : null;
-
-						frappe.model.set_value(cdt, cdn, 'item_tax_template', matched_template);
+						const item_tax_template = r.message;
+						frappe.model.set_value(cdt, cdn, 'item_tax_template', item_tax_template);
 					}
 				});
 			}


### PR DESCRIPTION
Fixed the issue where the correct Item Tax Template was not fetching on Item Rate Update.