### PR TITLE
feat: populate Timer dialog project field from Timesheet parent_project

### DIFF
--- a/erpnext/public/js/projects/timer.js
+++ b/erpnext/public/js/projects/timer.js
@@ -18,7 +18,6 @@ erpnext.timesheet.timer = function (frm, row, timestamp = 0) {
 			{ fieldtype: "HTML", fieldname: "timer_html" },
 		],
 	});
-	let project_value = (row && row.project) || frm.doc.parent_project;
 	if (row) {
 		dialog.set_values({
 			activity_type: row.activity_type,
@@ -28,7 +27,7 @@ erpnext.timesheet.timer = function (frm, row, timestamp = 0) {
 		});
 	} else {
 		dialog.set_values({
-			project: project_value,
+			project: frm.doc.parent_project,
 		});
 	}
 	dialog.get_field("timer_html").$wrapper.append(get_timer_html());

--- a/erpnext/public/js/projects/timer.js
+++ b/erpnext/public/js/projects/timer.js
@@ -26,8 +26,7 @@ erpnext.timesheet.timer = function (frm, row, timestamp = 0) {
 			task: row.task,
 			expected_hours: row.expected_hours,
 		});
-	}
-	else {
+	} else {
 		dialog.set_values({
 			project: project_value,
 		});

--- a/erpnext/public/js/projects/timer.js
+++ b/erpnext/public/js/projects/timer.js
@@ -18,13 +18,18 @@ erpnext.timesheet.timer = function (frm, row, timestamp = 0) {
 			{ fieldtype: "HTML", fieldname: "timer_html" },
 		],
 	});
-
+	let project_value = (row && row.project) || frm.doc.parent_project;
 	if (row) {
 		dialog.set_values({
 			activity_type: row.activity_type,
 			project: row.project,
 			task: row.task,
 			expected_hours: row.expected_hours,
+		});
+	}
+	else {
+		dialog.set_values({
+			project: project_value,
 		});
 	}
 	dialog.get_field("timer_html").$wrapper.append(get_timer_html());


### PR DESCRIPTION
- If `parent_project` is set in Timesheet, the Timer dialog will prefill the `project` field with it.
- If not set, the field will remain blank (manual selection required).

https://github.com/user-attachments/assets/eb4371db-fec5-46c9-a37e-9ddf3d3ed6a2

`no-docs`

Closes #47940 