### PR TITLE
refactor(Work Order): query_sales_order

### DIFF
--- a/erpnext/manufacturing/doctype/work_order/work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/work_order.py
@@ -1992,19 +1992,19 @@ def stop_unstop(work_order, status):
 
 
 @frappe.whitelist()
-def query_sales_order(production_item):
-	out = frappe.db.sql_list(
-		"""
-		select distinct so.name from `tabSales Order` so, `tabSales Order Item` so_item
-		where so_item.parent=so.name and so_item.item_code=%s and so.docstatus=1
-	union
-		select distinct so.name from `tabSales Order` so, `tabPacked Item` pi_item
-		where pi_item.parent=so.name and pi_item.item_code=%s and so.docstatus=1
-	""",
-		(production_item, production_item),
+def query_sales_order(production_item: str) -> list[str]:
+	return frappe.get_list(
+		"Sales Order",
+		filters=[
+			["Sales Order", "docstatus", "=", 1],
+		],
+		or_filters=[
+			["Sales Order Item", "item_code", "=", production_item],
+			["Packed Item", "item_code", "=", production_item],
+		],
+		pluck="name",
+		distinct=True,
 	)
-
-	return out
 
 
 @frappe.whitelist()


### PR DESCRIPTION
- Use `get_list` instead of `db.sql_list`

    The method is used for setting link options in the frontend:
    https://github.com/frappe/erpnext/blob/ffa014ecdc753ba67fbf6a9a44904338cad9634d/erpnext/manufacturing/doctype/work_order/work_order.js#L571-L586

    The Link field doesn't ignore permissions, so `get_list` should be fine here.

- Added type hints to enable argument validation.