### PR TITLE
fix: check valid_from date and set  template with 0 min max rate when rate doesn't match

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -44,22 +44,14 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 
 			if (item.item_code && item.rate) {
 				frappe.call({
-					method: "erpnext.stock.get_item_details.get_item_tax_template",
+					method: "erpnext.stock.get_item_details.get_applicable_item_tax_template",
 					args: {
-						ctx: {
-							item_code: item.item_code,
-							company: frm.doc.company,
-							base_net_rate: item.base_net_rate,
-							tax_category: frm.doc.tax_category,
-							item_tax_template: item.item_tax_template,
-							posting_date: frm.doc.posting_date,
-							bill_date: frm.doc.bill_date,
-							transaction_date: frm.doc.transaction_date,
-						}
+						item_name: item.item_code,
+						item_price: item?.rate,
+						valid_from: frm.doc.transaction_date || frm.doc.bill_date || frm.doc.posting_date
 					},
 					callback: function(r) {
-						const item_tax_template = r.message;
-						frappe.model.set_value(cdt, cdn, 'item_tax_template', item_tax_template);
+						frappe.model.set_value(cdt, cdn, 'item_tax_template', r.message ? r.message	 : null);
 					}
 				});
 			}


### PR DESCRIPTION
Issue:
When an Item Master includes an Item Tax Template with both minimum and maximum tax rates set to 0, the tax template is set to null for the item when a sales invoice is created.

Before:


https://github.com/user-attachments/assets/ca814218-ed1b-4d77-955a-9e7ab59f0c15

After:


https://github.com/user-attachments/assets/8529e79a-41e1-4f9f-90cf-bd560d12c642

Regression of #47763 

Backport needed - version 15 