### PR TITLE
fix: patch to update child table parentfield name in pos closing entry

### DIFF
--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -420,4 +420,4 @@ erpnext.patches.v15_0.remove_agriculture_roles
 erpnext.patches.v14_0.update_full_name_in_contract
 erpnext.patches.v15_0.drop_sle_indexes
 execute:frappe.db.set_single_value("Accounts Settings", "confirm_before_resetting_posting_date", 1)
-erpnext.patches.v15_0.rename_pos_closing_entry_fields
+erpnext.patches.v15_0.rename_pos_closing_entry_fields #2025-06-13

--- a/erpnext/patches/v15_0/rename_pos_closing_entry_fields.py
+++ b/erpnext/patches/v15_0/rename_pos_closing_entry_fields.py
@@ -1,6 +1,8 @@
+import frappe
 from frappe.model.utils.rename_field import rename_field
 
 
 def execute():
-	rename_field("POS Closing Entry", "pos_transactions", "pos_invoices")
-	rename_field("POS Closing Entry", "sales_invoice_transactions", "sales_invoices")
+	rename_field("POS Closing Entry", "pos_transactions", "pos_invoices", validate=False)
+	if frappe.db.exists("DocType", "Sales Invoice Reference"):
+		rename_field("POS Closing Entry", "sales_invoice_transactions", "sales_invoices", validate=False)


### PR DESCRIPTION
Fixed the issue where the patch `erpnext/patches/v15_0/rename_pos_closing_entry_fields.py` was not renaming the `parentfield` name in `POS Invoice Reference` and `Sales Invoice Reference`.