### PR TITLE
fix: populate is_return and return_against fields in pos closing entry

### DIFF
--- a/erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.js
+++ b/erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.js
@@ -143,6 +143,8 @@ function add_to_transaction(d, frm) {
 		posting_date: d.posting_date,
 		grand_total: d.grand_total,
 		customer: d.customer,
+		is_return: d.is_return,
+		return_against: d.return_against,
 		...(d.doctype === "POS Invoice" && { pos_invoice: d.name }),
 		...(d.doctype === "Sales Invoice" && { sales_invoice: d.name }),
 	});


### PR DESCRIPTION
`is_return` and `return_against` fields were not set for Return Invoice inside `pos_invoices` and `sales_invoices` child tables in POS Closing Entry.

Also refactored the SQL Query to a single function that can be reused for POS Invoice and Sales Invoice.