### PR TITLE
feat(bank-statement-import): add support for uploading MT940 format b…

### DIFF
--- a/erpnext/accounts/doctype/bank_statement_import/bank_statement_import.json
+++ b/erpnext/accounts/doctype/bank_statement_import/bank_statement_import.json
@@ -11,6 +11,7 @@
   "bank_account",
   "bank",
   "column_break_4",
+  "import_mt940_fromat",
   "custom_delimiters",
   "delimiter_options",
   "google_sheets_url",
@@ -20,6 +21,7 @@
   "download_template",
   "status",
   "template_options",
+  "use_csv_sniffer",
   "import_warnings_section",
   "template_warnings",
   "import_warnings",
@@ -207,14 +209,28 @@
    "fieldname": "delimiter_options",
    "fieldtype": "Data",
    "label": "Delimiter options"
+  },
+  {
+   "default": "0",
+   "fieldname": "use_csv_sniffer",
+   "fieldtype": "Check",
+   "hidden": 1,
+   "label": "Use CSV Sniffer"
+  },
+  {
+   "default": "0",
+   "fieldname": "import_mt940_fromat",
+   "fieldtype": "Check",
+   "label": "Import MT940 Fromat"
   }
  ],
  "hide_toolbar": 1,
  "links": [],
- "modified": "2024-06-25 17:32:07.658250",
+ "modified": "2025-06-11 02:23:22.159961",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Bank Statement Import",
+ "naming_rule": "Expression",
  "owner": "Administrator",
  "permissions": [
   {
@@ -230,6 +246,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,9 @@ dependencies = [
 
     # Not used directly - required by PyQRCode for PNG generation
     "pypng~=0.20220715.0",
+
+    # MT940 parser for bank statements
+    "mt-940>=4.26.0"
 ]
 
 [build-system]


### PR DESCRIPTION
This feature enables ERPNext to support the import of bank statements in the MT940 format through the Bank Statement Import doctype. It simplifies bank reconciliation for financial institutions that provide statements in the standardized MT940.txt format.

- File type and content validation for MT940 format
- Parsing of MT940 structured data into transactions
- Conversion to CSV compatible with the import process
- Smooth integration into the existing statement import flow

This feature is valuable for businesses that receive MT940 files from SWIFT-compliant banks, making statement imports more efficient and less manual.

Before:

 [Before mt940 integration.webm](https://github.com/user-attachments/assets/6c5ebad1-b5e4-47a2-8194-d49121b04cad)

After:

 [After mt940 integartion.webm](https://github.com/user-attachments/assets/d7ded80d-9416-4c3b-931a-9e09c78ab9df)

no-docs
