### PR TITLE
fix: handle NoneType in sub_operations to prevent TypeError in ERPNext

### DIFF
--- a/erpnext/manufacturing/doctype/job_card/job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/job_card.py
@@ -273,7 +273,7 @@ class JobCard(Document):
 			self.total_completed_qty = flt(self.total_completed_qty, self.precision("total_completed_qty"))
 
 		for row in self.sub_operations:
-			self.total_completed_qty += row.completed_qty
+			self.total_completed_qty += flt(row.completed_qty)
 
 	def get_overlap_for(self, args, open_job_cards=None):
 		time_logs = []


### PR DESCRIPTION

When creating a correction job card from existing job card , we are getting an error if sub_operations  is blank

<img width="1440" alt="Screenshot 2025-06-12 at 9 36 44 AM" src="https://github.com/user-attachments/assets/19b6c06a-6222-46eb-a617-c4ae38bdc934" />
