### PR TITLE
fix: do not allow capitalization from connection tab for submitted asset

### DIFF
--- a/erpnext/assets/doctype/asset/asset.js
+++ b/erpnext/assets/doctype/asset/asset.js
@@ -72,6 +72,12 @@ frappe.ui.form.on("Asset", {
 				filters: { item_code: doc.item_code },
 			};
 		});
+
+		if (frm.doc.docstatus == 1) {
+			frm.custom_make_buttons = {
+				"Asset Capitalization": "Asset Capitalization",
+			};
+		}
 	},
 
 	refresh: function (frm) {


### PR DESCRIPTION
Prevented Asset Capitalization from the Connections tab for submitted Assets. Added a condition to show the "Asset Capitalization" button only when the Asset is in Draft state (docstatus == 0), ensuring capitalization is not triggered from already submitted assets.