### PR TITLE
fix: use `flt` value of bin qty

### DIFF
--- a/erpnext/stock/doctype/pick_list/pick_list.py
+++ b/erpnext/stock/doctype/pick_list/pick_list.py
@@ -113,13 +113,15 @@ class PickList(Document):
 
 				continue
 
-			bin_qty = frappe.db.get_value(
-				"Bin",
-				{"item_code": row.item_code, "warehouse": row.warehouse},
-				"actual_qty",
+			bin_qty = flt(
+				frappe.db.get_value(
+					"Bin",
+					{"item_code": row.item_code, "warehouse": row.warehouse},
+					"actual_qty",
+				)
 			)
 
-			if row.picked_qty > flt(bin_qty):
+			if row.picked_qty > bin_qty:
 				frappe.throw(
 					_(
 						"At Row #{0}: The picked quantity {1} for the item {2} is greater than available stock {3} in the warehouse {4}."


### PR DESCRIPTION
**Issue:** If `bin_qty` returns `None`, it may be because the filtered bin does not exist. In that case, the error message shows `bin_qty` as `None` instead of `0.0`.

 
**Before:**

```bash
frappe.exceptions.ValidationError: At Row #6: The picked quantity 2.0 for the item 10002 is greater than available stock None in the warehouse PF-A1 - LL.
```


**After:**

```bash
frappe.exceptions.ValidationError: At Row #6: The picked quantity 2.0 for the item 10002 is greater than available stock 0.0 in the warehouse PF-A1 - LL.
```