### PR TITLE
fix: consider the sales uom or stock uom to fetch item price rate to …

### DIFF
--- a/erpnext/selling/page/point_of_sale/point_of_sale.py
+++ b/erpnext/selling/page/point_of_sale/point_of_sale.py
@@ -157,6 +157,7 @@ def get_items(start, page_length, price_list, item_group, pos_profile, search_te
 			item.item_name,
 			item.description,
 			item.stock_uom,
+			item.sales_uom,
 			item.image AS item_image,
 			item.is_stock_item
 		FROM
@@ -195,13 +196,14 @@ def get_items(start, page_length, price_list, item_group, pos_profile, search_te
 		uoms = frappe.get_doc("Item", item.item_code).get("uoms", [])
 
 		item.actual_qty, _ = get_stock_availability(item.item_code, warehouse)
-		item.uom = item.stock_uom
+		item.uom = item.sales_uom or item.stock_uom
 
 		item_price = frappe.get_all(
 			"Item Price",
 			fields=["price_list_rate", "currency", "uom", "batch_no", "valid_from", "valid_upto"],
 			filters={
 				"price_list": price_list,
+				"uom": item.sales_uom or item.stock_uom,
 				"item_code": item.item_code,
 				"selling": True,
 				"valid_from": ["<=", current_date],


### PR DESCRIPTION
Issue: Sales UOM or Default UOM is not showing in POS, instead the first created item price list UOM is considered, it should maintain the same UOM throughout the sales operation

Ref: [#40936](https://support.frappe.io/helpdesk/tickets/40936)

Before:

[Screencast from 16-06-25 11:28:18 AM IST.webm](https://github.com/user-attachments/assets/e8fe2e2e-41c5-4403-aec1-dbce859cb1cb)

After:

[Screencast from 16-06-25 11:31:05 AM IST.webm](https://github.com/user-attachments/assets/ad1525bd-0f8d-47d8-a997-ae4e0bcf7ef9)






Backport needed: Version-15