### PR TITLE
fix: add descendants item groups to fetch the barcode items

### DIFF
--- a/erpnext/selling/page/point_of_sale/point_of_sale.py
+++ b/erpnext/selling/page/point_of_sale/point_of_sale.py
@@ -8,7 +8,7 @@ import frappe
 from frappe.utils import cint, get_datetime
 from frappe.utils.nestedset import get_root_of
 
-from erpnext.accounts.doctype.pos_invoice.pos_invoice import get_stock_availability
+from erpnext.accounts.doctype.pos_invoice.pos_invoice import get_item_group, get_stock_availability
 from erpnext.accounts.doctype.pos_profile.pos_profile import get_child_nodes, get_item_groups
 from erpnext.stock.utils import scan_barcode
 
@@ -109,7 +109,8 @@ def search_by_term(search_term, warehouse, price_list):
 
 def filter_result_items(result, pos_profile):
 	if result and result.get("items"):
-		pos_item_groups = frappe.db.get_all("POS Item Group", {"parent": pos_profile}, pluck="item_group")
+		pos_profile_doc = frappe.get_cached_doc("POS Profile", pos_profile)
+		pos_item_groups = get_item_group(pos_profile_doc)
 		if not pos_item_groups:
 			return
 		result["items"] = [item for item in result.get("items") if item.get("item_group") in pos_item_groups]


### PR DESCRIPTION
Issue: Item is not being fetched through barcode in the POS. The system only checks the item groups explicitly listed in the POS Profile and does not consider their descendant item groups.

Ref: [#40956](https://support.frappe.io/helpdesk/tickets/40956)


Before:

https://github.com/user-attachments/assets/1560fdac-4c6f-4cc5-a3dc-2c320bc678d5


After:

https://github.com/user-attachments/assets/05dccb6a-a95b-44d7-8792-e87dda90b979


Backport needed: Version-15
