### PR TITLE
fix: pos invoice consolidation row refer issue

### DIFF
--- a/erpnext/accounts/doctype/pos_invoice_merge_log/pos_invoice_merge_log.py
+++ b/erpnext/accounts/doctype/pos_invoice_merge_log/pos_invoice_merge_log.py
@@ -259,6 +259,7 @@ class POSInvoiceMergeLog(Document):
 				if not found:
 					tax.charge_type = "Actual"
 					tax.idx = idx
+					tax.row_id = None
 					idx += 1
 					tax.included_in_print_rate = 0
 					tax.tax_amount = tax.tax_amount_after_discount_amount


### PR DESCRIPTION
Fixed the issue encountered during POS Invoice consolidation. When a POS Invoice has a Tax Type set to "On Previous Row Amount" or "On Previous Row Total," which sets a Row Reference on the Original invoice, the system incorrectly passes the Reference Row for the "Actual" Tax Type during consolidation.