### PR TITLE
fix: pos opening and closing validation

### DIFF
--- a/erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.json
+++ b/erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.json
@@ -74,6 +74,7 @@
    "label": "User Details"
   },
   {
+   "fetch_from": "pos_opening_entry.company",
    "fetch_if_empty": 1,
    "fieldname": "company",
    "fieldtype": "Link",
@@ -103,6 +104,7 @@
    "fieldtype": "Link",
    "label": "Cashier",
    "options": "User",
+   "read_only": 1,
    "reqd": 1
   },
   {
@@ -259,7 +261,7 @@
    "link_fieldname": "pos_closing_entry"
   }
  ],
- "modified": "2025-06-06 12:00:31.955176",
+ "modified": "2025-06-14 02:38:14.962291",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "POS Closing Entry",

--- a/erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.py
+++ b/erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.py
@@ -243,9 +243,9 @@ class POSClosingEntry(StatusUpdater):
 	def check_pce_is_cancellable(self):
 		if frappe.db.exists("POS Opening Entry", {"pos_profile": self.pos_profile, "status": "Open"}):
 			frappe.throw(
-				title=_("POS Opening Entry Exists"),
+				title=_("Cannot cancel POS Closing Entry"),
 				msg=_(
-					"{0} is already opened. Close the POS or Cancel already existing POS Opening Entry to cancel this POS Closing Entry."
+					"POS Profile - {0} is currently open. Please close the POS or cancel the existing POS Opening Entry before cancelling this POS Closing Entry."
 				).format(frappe.bold(self.pos_profile)),
 			)
 

--- a/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
+++ b/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
@@ -373,18 +373,6 @@ class POSInvoice(SalesInvoice):
 						_("Payment related to {0} is not completed").format(pay.mode_of_payment)
 					)
 
-	def validate_pos_opening_entry(self):
-		opening_entries = frappe.get_list(
-			"POS Opening Entry", filters={"pos_profile": self.pos_profile, "status": "Open", "docstatus": 1}
-		)
-		if len(opening_entries) == 0:
-			frappe.throw(
-				title=_("POS Opening Entry Missing"),
-				msg=_("No open POS Opening Entry found for POS Profile {0}.").format(
-					frappe.bold(self.pos_profile)
-				),
-			)
-
 	def validate_stock_availablility(self):
 		if self.is_return:
 			return

--- a/erpnext/accounts/doctype/pos_opening_entry/pos_opening_entry.py
+++ b/erpnext/accounts/doctype/pos_opening_entry/pos_opening_entry.py
@@ -56,15 +56,15 @@ class POSOpeningEntry(StatusUpdater):
 			frappe.throw(
 				title=_("POS Opening Entry Exists"),
 				msg=_(
-					"{0} is already opened. Close the POS or Cancel already existing POS Opening Entry to create a new POS Opening Entry."
+					"{0} is open. Close the POS or cancel the existing POS Opening Entry to create a new POS Opening Entry."
 				).format(frappe.bold(self.pos_profile)),
 			)
 
 	def check_user_already_assigned(self):
 		if frappe.db.exists("POS Opening Entry", {"user": self.user, "status": "Open"}):
 			frappe.throw(
-				title=_("Cashier Already Assigned"),
-				msg=_("Cashier is already assigned to a POS."),
+				title=_("Cannot Assign Cashier"),
+				msg=_("Cashier is currently assigned to another POS."),
 			)
 
 	def validate_payment_method_account(self):

--- a/erpnext/accounts/doctype/pos_opening_entry/test_pos_opening_entry.py
+++ b/erpnext/accounts/doctype/pos_opening_entry/test_pos_opening_entry.py
@@ -58,8 +58,8 @@ class TestPOSOpeningEntry(IntegrationTestCase):
 		cashier_user = create_user("test_cashier@example.com", "Accounts Manager", "Sales Manager")
 		frappe.set_user(cashier_user.name)
 
-		pos_profile = make_pos_profile(name="_Test POS Profile 2")
-		opening_entry_2 = create_opening_entry(pos_profile, cashier_user.name)
+		pos_profile2 = make_pos_profile(name="_Test POS Profile 2")
+		opening_entry_2 = create_opening_entry(pos_profile2, cashier_user.name)
 
 		self.assertEqual(opening_entry_2.status, "Open")
 		self.assertEqual(opening_entry_2.user, cashier_user.name)
@@ -73,6 +73,15 @@ class TestPOSOpeningEntry(IntegrationTestCase):
 
 		with self.assertRaises(frappe.ValidationError):
 			create_opening_entry(pos_profile, cashier_user.name)
+
+	def test_user_assignment_to_multiple_pos_profile(self):
+		test_user, pos_profile = self.init_user_and_profile()
+		opening_entry_1 = create_opening_entry(pos_profile, test_user.name)
+		self.assertEqual(opening_entry_1.user, test_user.name)
+
+		pos_profile2 = make_pos_profile(name="_Test POS Profile 2")
+		with self.assertRaises(frappe.ValidationError):
+			create_opening_entry(pos_profile2, test_user.name)
 
 	def test_cancel_pos_opening_entry_without_invoices(self):
 		test_user, pos_profile = self.init_user_and_profile()

--- a/erpnext/accounts/doctype/pos_opening_entry/test_pos_opening_entry.py
+++ b/erpnext/accounts/doctype/pos_opening_entry/test_pos_opening_entry.py
@@ -3,14 +3,98 @@
 import unittest
 
 import frappe
+from frappe.core.doctype.user_permission.test_user_permission import create_user
 from frappe.tests import IntegrationTestCase
+
+from erpnext.accounts.doctype.pos_invoice.test_pos_invoice import create_pos_invoice
+from erpnext.accounts.doctype.pos_profile.test_pos_profile import make_pos_profile
+from erpnext.stock.doctype.stock_entry.test_stock_entry import make_stock_entry
 
 
 class TestPOSOpeningEntry(IntegrationTestCase):
-	pass
+	@classmethod
+	def setUpClass(cls):
+		frappe.db.sql("delete from `tabPOS Opening Entry`")
+		cls.enterClassContext(cls.change_settings("POS Settings", {"invoice_type": "POS Invoice"}))
+
+	@classmethod
+	def tearDownClass(cls):
+		frappe.db.sql("delete from `tabPOS Opening Entry`")
+
+	def setUp(self):
+		# Make stock available for POS Sales
+		frappe.db.sql("delete from `tabPOS Opening Entry`")
+		make_stock_entry(target="_Test Warehouse - _TC", qty=2, basic_rate=100)
+		from erpnext.accounts.doctype.pos_closing_entry.test_pos_closing_entry import init_user_and_profile
+
+		self.init_user_and_profile = init_user_and_profile
+
+	def tearDown(self):
+		frappe.set_user("Administrator")
+		frappe.db.sql("delete from `tabPOS Profile`")
+
+	def test_pos_opening_entry(self):
+		test_user, pos_profile = self.init_user_and_profile()
+		opening_entry = create_opening_entry(pos_profile, test_user.name)
+
+		self.assertEqual(opening_entry.status, "Open")
+		self.assertNotEqual(opening_entry.docstatus, 0)
+
+	def test_multiple_pos_opening_entries_for_same_pos_profile(self):
+		test_user, pos_profile = self.init_user_and_profile()
+		opening_entry = create_opening_entry(pos_profile, test_user.name)
+
+		self.assertEqual(opening_entry.status, "Open")
+		with self.assertRaises(frappe.ValidationError):
+			create_opening_entry(pos_profile, test_user.name)
+
+	def test_multiple_pos_opening_entry_for_multiple_pos_profiles(self):
+		test_user, pos_profile = self.init_user_and_profile()
+		opening_entry_1 = create_opening_entry(pos_profile, test_user.name)
+
+		self.assertEqual(opening_entry_1.status, "Open")
+		self.assertEqual(opening_entry_1.user, test_user.name)
+
+		cashier_user = create_user("test_cashier@example.com", "Accounts Manager", "Sales Manager")
+		frappe.set_user(cashier_user.name)
+
+		pos_profile = make_pos_profile(name="_Test POS Profile 2")
+		opening_entry_2 = create_opening_entry(pos_profile, cashier_user.name)
+
+		self.assertEqual(opening_entry_2.status, "Open")
+		self.assertEqual(opening_entry_2.user, cashier_user.name)
+
+	def test_multiple_pos_opening_entry_for_same_pos_profile_by_multiple_user(self):
+		test_user, pos_profile = self.init_user_and_profile()
+		cashier_user = create_user("test_cashier@example.com", "Accounts Manager", "Sales Manager")
+
+		opening_entry = create_opening_entry(pos_profile, test_user.name)
+		self.assertEqual(opening_entry.status, "Open")
+
+		with self.assertRaises(frappe.ValidationError):
+			create_opening_entry(pos_profile, cashier_user.name)
+
+	def test_cancel_pos_opening_entry_without_invoices(self):
+		test_user, pos_profile = self.init_user_and_profile()
+		opening_entry = create_opening_entry(pos_profile, test_user.name, get_obj=True)
+
+		opening_entry.cancel()
+		self.assertEqual(opening_entry.status, "Cancelled")
+		self.assertNotEqual(opening_entry.docstatus, 1)
+
+	def test_cancel_pos_opening_entry_with_invoice(self):
+		test_user, pos_profile = self.init_user_and_profile()
+		opening_entry = create_opening_entry(pos_profile, test_user.name, get_obj=True)
+
+		pos_inv1 = create_pos_invoice(pos_profile=pos_profile.name, rate=100, do_not_save=1)
+		pos_inv1.append("payments", {"mode_of_payment": "Cash", "account": "Cash - _TC", "amount": 100})
+		pos_inv1.save()
+		pos_inv1.submit()
+
+		self.assertRaises(frappe.ValidationError, opening_entry.cancel)
 
 
-def create_opening_entry(pos_profile, user):
+def create_opening_entry(pos_profile, user, get_obj=False):
 	entry = frappe.new_doc("POS Opening Entry")
 	entry.pos_profile = pos_profile.name
 	entry.user = user
@@ -23,5 +107,8 @@ def create_opening_entry(pos_profile, user):
 
 	entry.set("balance_details", balance_details)
 	entry.submit()
+
+	if get_obj:
+		return entry
 
 	return entry.as_dict()

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -1135,16 +1135,16 @@ class SalesInvoice(SellingController):
 			)
 		if len(opening_entries) > 1:
 			frappe.throw(
-				title=_("Too Many POS Opening Entry"),
+				title=_("Multiple POS Opening Entry"),
 				msg=_(
-					"Too Many POS Opening Entry exists for same POS Profile. Cancel or close them before proceeding."
-				),
+					"POS Profile - {0} has multiple open POS Opening Entries. Please close or cancel the existing entries before proceeding."
+				).format(self.pos_profile),
 			)
 		if frappe.utils.get_date_str(opening_entries[0].get("period_start_date")) != frappe.utils.today():
 			frappe.throw(
 				title=_("Outdated POS Opening Entry"),
 				msg=_(
-					"Current Open POS Opening Entry - {0} is outdated. Please close the POS and create a new Opening Entry."
+					"POS Opening Entry - {0} is outdated. Please close the POS and create a new POS Opening Entry."
 				).format(opening_entries[0].get("name")),
 			)
 

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -423,3 +423,4 @@ erpnext.patches.v15_0.update_pick_list_fields
 execute:frappe.db.set_single_value("Accounts Settings", "confirm_before_resetting_posting_date", 1)
 erpnext.patches.v15_0.rename_pos_closing_entry_fields #2025-06-13
 erpnext.patches.v15_0.update_pegged_currencies
+erpnext.patches.v15_0.set_status_cancelled_on_cancelled_pos_opening_entry_and_pos_closing_entry

--- a/erpnext/patches/v15_0/set_status_cancelled_on_cancelled_pos_opening_entry_and_pos_closing_entry.py
+++ b/erpnext/patches/v15_0/set_status_cancelled_on_cancelled_pos_opening_entry_and_pos_closing_entry.py
@@ -1,0 +1,14 @@
+import frappe
+from frappe.query_builder import DocType
+
+
+def execute():
+	POSOpeningEntry = DocType("POS Opening Entry")
+	POSClosingEntry = DocType("POS Closing Entry")
+
+	frappe.qb.update(POSOpeningEntry).set(POSOpeningEntry.status, "Cancelled").where(
+		POSOpeningEntry.docstatus == 2
+	).run()
+	frappe.qb.update(POSClosingEntry).set(POSClosingEntry.status, "Cancelled").where(
+		POSClosingEntry.docstatus == 2
+	).run()

--- a/erpnext/selling/page/point_of_sale/pos_controller.js
+++ b/erpnext/selling/page/point_of_sale/pos_controller.js
@@ -207,7 +207,7 @@ erpnext.PointOfSale.Controller = class {
 			frappe.msgprint({
 				title: __("Outdated POS Opening Entry"),
 				message: __(
-					"Current POS Opening Entry is outdated. Close the Existing and create a new Opening Entry."
+					"The current POS opening entry is outdated. Please close it and create a new one."
 				),
 				indicator: "yellow",
 			});


### PR DESCRIPTION
Changes Include:
- POS Opening Entry validity is only till midnight of the Period Start Date. For an outdated POS Opening Entry, the POS will display a Dialog mentioning that the current POS Opening Entry is outdated.
- POS Opening Entry can be cancelled only if there are no unconsolidated invoices.
- POS Closing Entry can be cancelled only if there are no open POS Opening Entries for that particular POS Profile.
- POS Invoice / Sales Invoice won't be allowed to create if there is more than one POS Opening Entry present for a POS Profile.
- Added Test Cases for POS Opening Entry.
- Added patch to set Status `Cancelled` for Cancelled POS Opening Entries and POS Closing Entries.