### PR TITLE
feat: Improve party field handling in bank reconciliation dialog

### DIFF
--- a/erpnext/public/js/bank_reconciliation_tool/dialog_manager.js
+++ b/erpnext/public/js/bank_reconciliation_tool/dialog_manager.js
@@ -47,6 +47,10 @@ erpnext.accounts.bank_reconciliation.DialogManager = class DialogManager {
 			callback: (r) => {
 				if (r.message) {
 					this.bank_transaction = r.message;
+					this.original_party_details = {
+						party_type: this.bank_transaction.party_type,
+						party: this.bank_transaction.party,
+					};
 					r.message.payment_entry = 1;
 					r.message.journal_entry = 1;
 					this.dialog.set_values(r.message);
@@ -336,6 +340,34 @@ erpnext.accounts.bank_reconciliation.DialogManager = class DialogManager {
 							company: this.company,
 						},
 					};
+				},
+				onchange: () => {
+					const values = this.dialog.get_values();
+					if (values && values.second_account) {
+						frappe.db.get_value("Account", values.second_account, "account_type").then((r) => {
+							if (r && r.message) {
+								const is_party_account = ["Receivable", "Payable"].includes(
+									r.message.account_type
+								);
+
+								if (is_party_account) {
+									if (this.original_party_details) {
+										this.dialog.set_value(
+											"party_type",
+											this.original_party_details.party_type
+										);
+										this.dialog.set_value("party", this.original_party_details.party);
+									}
+								} else {
+									this.dialog.set_value("party_type", "");
+									this.dialog.set_value("party", "");
+								}
+							}
+						});
+					} else {
+						this.dialog.set_value("party_type", "");
+						this.dialog.set_value("party", "");
+					}
 				},
 			},
 			{

--- a/erpnext/public/js/bank_reconciliation_tool/dialog_manager.js
+++ b/erpnext/public/js/bank_reconciliation_tool/dialog_manager.js
@@ -55,6 +55,10 @@ erpnext.accounts.bank_reconciliation.DialogManager = class DialogManager {
 					r.message.journal_entry = 1;
 					this.dialog.set_values(r.message);
 					this.copy_data_to_voucher();
+					const values = this.dialog.get_values();
+					if (values.action == "Create Voucher" && values.document_type == "Journal Entry") {
+						this._handle_party_for_account();
+					}
 					this.dialog.show();
 				}
 			},
@@ -170,6 +174,35 @@ erpnext.accounts.bank_reconciliation.DialogManager = class DialogManager {
 		}
 	}
 
+	_handle_party_for_account() {
+		const values = this.dialog.get_values();
+		if (values && values.second_account) {
+			frappe.db.get_value("Account", values.second_account, "account_type").then((r) => {
+				if (r && r.message) {
+					const is_party_account = ["Receivable", "Payable"].includes(
+						r.message.account_type
+					);
+
+					if (is_party_account) {
+						if (this.original_party_details) {
+							this.dialog.set_value(
+								"party_type",
+								this.original_party_details.party_type
+							);
+							this.dialog.set_value("party", this.original_party_details.party);
+						}
+					} else {
+						this.dialog.set_value("party_type", "");
+						this.dialog.set_value("party", "");
+					}
+				}
+			});
+		} else {
+			this.dialog.set_value("party_type", "");
+			this.dialog.set_value("party", "");
+		}
+	}
+
 	make_dialog() {
 		const me = this;
 		me.selected_payment = null;
@@ -193,6 +226,12 @@ erpnext.accounts.bank_reconciliation.DialogManager = class DialogManager {
 				options: `Payment Entry\nJournal Entry`,
 				default: "Payment Entry",
 				depends_on: "eval:doc.action=='Create Voucher'",
+				onchange: () => {
+					const values = this.dialog.get_values();
+					if (values.document_type == "Journal Entry") {
+						this._handle_party_for_account();
+					}
+				},
 			},
 			{
 				fieldtype: "Section Break",
@@ -342,32 +381,7 @@ erpnext.accounts.bank_reconciliation.DialogManager = class DialogManager {
 					};
 				},
 				onchange: () => {
-					const values = this.dialog.get_values();
-					if (values && values.second_account) {
-						frappe.db.get_value("Account", values.second_account, "account_type").then((r) => {
-							if (r && r.message) {
-								const is_party_account = ["Receivable", "Payable"].includes(
-									r.message.account_type
-								);
-
-								if (is_party_account) {
-									if (this.original_party_details) {
-										this.dialog.set_value(
-											"party_type",
-											this.original_party_details.party_type
-										);
-										this.dialog.set_value("party", this.original_party_details.party);
-									}
-								} else {
-									this.dialog.set_value("party_type", "");
-									this.dialog.set_value("party", "");
-								}
-							}
-						});
-					} else {
-						this.dialog.set_value("party_type", "");
-						this.dialog.set_value("party", "");
-					}
+					this._handle_party_for_account();
 				},
 			},
 			{


### PR DESCRIPTION
When using the Bank Reconciliation Tool, transactions are often automatically assigned a `Party`
and `Party Type` based on matching rules. For example, a transaction with "Stripe" in the
description is frequently mapped to the "Stripe" Supplier.

This is helpful for standard payments but creates a usability issue for internal transfers, such as
moving funds from a Stripe account to a company bank account. In this case, the user needs to
create a Journal Entry between two non-party accounts (e.g., two `Bank` type accounts). However,
the pre-filled `Party` and `Party Type` fields cause a validation error, forcing the user to
manually clear them before they can proceed.

This PR resolves this by adding intelligent handling for the `Party` and `Party Type` fields within
the "Create Voucher" dialog:

1.  When the user selects an `Account` for a new Journal Entry, the system checks the account's
type.
2.  If the selected account is **not** a "Receivable" or "Payable" account, the `Party` and `Party
Type` fields are automatically cleared.
3.  If the user then selects a "Receivable" or "Payable" account, the original, auto-matched party
details are restored.

This change streamlines the process of reconciling internal transfers, preventing unnecessary
validation errors and removing the need for manual intervention.

Closes #48463