### PR TITLE
fix: budget naming series

### DIFF
--- a/erpnext/accounts/doctype/budget/budget.json
+++ b/erpnext/accounts/doctype/budget/budget.json
@@ -7,10 +7,10 @@
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
+  "naming_series",
   "budget_against",
   "company",
   "cost_center",
-  "naming_series",
   "project",
   "fiscal_year",
   "column_break_3",
@@ -199,12 +199,12 @@
   },
   {
    "fieldname": "naming_series",
-   "fieldtype": "Data",
-   "hidden": 1,
+   "fieldtype": "Select",
    "label": "Series",
    "no_copy": 1,
+   "options": "BUDGET-.YYYY.-",
    "print_hide": 1,
-   "read_only": 1,
+   "reqd": 1,
    "set_only_once": 1
   },
   {
@@ -238,7 +238,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-05-22 13:46:28.510566",
+ "modified": "2025-06-16 15:57:13.114981",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Budget",

--- a/erpnext/accounts/doctype/budget/budget.py
+++ b/erpnext/accounts/doctype/budget/budget.py
@@ -51,7 +51,7 @@ class Budget(Document):
 		cost_center: DF.Link | None
 		fiscal_year: DF.Link
 		monthly_distribution: DF.Link | None
-		naming_series: DF.Data | None
+		naming_series: DF.Literal["BUDGET-.YYYY.-"]
 		project: DF.Link | None
 	# end: auto-generated types
 
@@ -138,9 +138,6 @@ class Budget(Document):
 			or self.applicable_on_booking_actual_expenses
 		):
 			self.applicable_on_booking_actual_expenses = 1
-
-	def before_naming(self):
-		self.naming_series = f"{{{frappe.scrub(self.budget_against)}}}./.{self.fiscal_year}/.###"
 
 
 def validate_expense_against_budget(args, expense_amount=0):


### PR DESCRIPTION
Removed hard-coded naming series for Budget DocType.

Fixes: #47833 