### PR TITLE
fix: Prevent saving negative quantity in BOM

### DIFF
--- a/erpnext/manufacturing/doctype/bom/bom.json
+++ b/erpnext/manufacturing/doctype/bom/bom.json
@@ -134,6 +134,7 @@
    "fieldname": "quantity",
    "fieldtype": "Float",
    "label": "Quantity",
+   "non_negative": 1,
    "oldfieldname": "quantity",
    "oldfieldtype": "Currency",
    "reqd": 1
@@ -663,7 +664,7 @@
  "image_field": "image",
  "is_submittable": 1,
  "links": [],
- "modified": "2024-06-03 16:24:47.518411",
+ "modified": "2025-06-16 16:13:22.497695",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "BOM",
@@ -696,6 +697,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "search_fields": "item, item_name",
  "show_name_in_global_search": 1,
  "sort_field": "creation",


### PR DESCRIPTION
## Reason
- In BOM, the system allows saving the negative values in quantity field.

## Changes done:
- Enable non negative property in quantity field to prevent saving negative values.

## Screenshot
![image](https://github.com/user-attachments/assets/79c6ef47-6276-4c4f-ab61-fa363bc2d3dc)

`no-docs`