### PR TITLE
fix: fallback expense account and cost center in subcontracting receipt

### DIFF
--- a/erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py
+++ b/erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py
@@ -639,11 +639,11 @@ class SubcontractingReceipt(SubcontractingController):
 							self.add_gl_entry(
 								gl_entries=gl_entries,
 								account=supplier_warehouse_account,
-								cost_center=rm_item.cost_center,
+								cost_center=rm_item.cost_center or item.cost_center,
 								debit=0.0,
 								credit=flt(rm_item.amount),
 								remarks=remarks,
-								against_account=rm_item.expense_account,
+								against_account=rm_item.expense_account or item.expense_account,
 								account_currency=get_account_currency(supplier_warehouse_account),
 								project=item.project,
 								item=item,
@@ -651,8 +651,8 @@ class SubcontractingReceipt(SubcontractingController):
 							# Expense Account (Debit)
 							self.add_gl_entry(
 								gl_entries=gl_entries,
-								account=rm_item.expense_account,
-								cost_center=rm_item.cost_center,
+								account=rm_item.expense_account or item.expense_account,
+								cost_center=rm_item.cost_center or item.cost_center,
 								debit=flt(rm_item.amount),
 								credit=0.0,
 								remarks=remarks,


### PR DESCRIPTION
Reference support ticket [41233](https://support.frappe.io/helpdesk/tickets/41233)