### PR TITLE
fix: get already billed amount from current doc instead of database

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
@@ -3380,6 +3380,7 @@ class TestSalesInvoice(ERPNextTestSuite):
 		si.posting_date = getdate()
 		si.submit()
 
+	@IntegrationTestCase.change_settings("Accounts Settings", {"over_billing_allowance": 0})
 	def test_over_billing_case_against_delivery_note(self):
 		"""
 		Test a case where duplicating the item with qty = 1 in the invoice
@@ -3387,24 +3388,23 @@ class TestSalesInvoice(ERPNextTestSuite):
 		"""
 		from erpnext.stock.doctype.delivery_note.test_delivery_note import create_delivery_note
 
-		over_billing_allowance = frappe.db.get_single_value("Accounts Settings", "over_billing_allowance")
-		frappe.db.set_single_value("Accounts Settings", "over_billing_allowance", 0)
-
 		dn = create_delivery_note()
 		dn.submit()
 
 		si = make_sales_invoice(dn.name)
-		# make a copy of first item and add it to invoice
 		item_copy = frappe.copy_doc(si.items[0])
+		si.save()
+
+		si.items = []  # Clear existing items
 		si.append("items", item_copy)
 		si.save()
 
+		si.append("items", item_copy)
 		with self.assertRaises(frappe.ValidationError) as err:
-			si.submit()
+			si.save()
 
 		self.assertTrue("cannot overbill" in str(err.exception).lower())
-
-		frappe.db.set_single_value("Accounts Settings", "over_billing_allowance", over_billing_allowance)
+		dn.cancel()
 
 	@IntegrationTestCase.change_settings(
 		"Accounts Settings",


### PR DESCRIPTION
Issue: If a sales invoice is saved with ref in the item row, incorrect overbilling validation is raised again when saving the doc because the already billed amount for the doc is fetched from the database, where old rows are stored.


Steps to replicate:
- Create a Delivery Note with an item with 10 qty.
- Create a Sales Invoice from the delivery note for 7 qty and save
- Remove the row and again fetch the items from the delivery note and save.

An error will be raised because old rows will also be included for the calculation of the already billed total.

Note: Also refactored code for validating all items in one call.

Before:
![image](https://github.com/user-attachments/assets/dbe7c645-4fa7-4f88-813a-bfd74acc0944)

After:
![image](https://github.com/user-attachments/assets/fa0550b1-f394-4ddd-a776-cfc84f302292)



Frappe Support Issue: https://support.frappe.io/app/hd-ticket/39705