### PR TITLE
fix:add validation for party type

### DIFF
--- a/erpnext/accounts/party.py
+++ b/erpnext/accounts/party.py
@@ -424,6 +424,8 @@ def get_party_account(party_type, party=None, company=None, include_advance=Fals
 	Will first search in party (Customer / Supplier) record, if not found,
 	will search in group (Customer Group / Supplier Group),
 	finally will return default."""
+	if not party_type:
+		frappe.throw(_("Party Type is mandatory"))
 	if not company:
 		frappe.throw(_("Please select a Company"))
 


### PR DESCRIPTION
Issue : AttributeError: 'NoneType' object has no attribute 'lower' error in Bank Reconciliation when editing the full page without selecting a Party Type.

Ref: [#41062](https://support.frappe.io/helpdesk/tickets/41062)

Before:

[Screencast from 16-06-25 06:16:02 PM IST.webm](https://github.com/user-attachments/assets/c7da11e3-1579-4594-ab52-d042f4798056)

After:

[Screencast from 16-06-25 06:18:01 PM IST.webm](https://github.com/user-attachments/assets/5f382801-b2f8-4934-8d15-d6d286d2eceb)

Backport Needed: Version-15

