### PR TITLE
fix: attribute error because of missing margin_type field in Supplier Quotation

### DIFF
--- a/erpnext/buying/doctype/supplier_quotation_item/supplier_quotation_item.json
+++ b/erpnext/buying/doctype/supplier_quotation_item/supplier_quotation_item.json
@@ -30,11 +30,15 @@
   "stock_qty",
   "sec_break_price_list",
   "price_list_rate",
+  "base_price_list_rate",
+  "discount_and_margin_section",
+  "margin_type",
+  "margin_rate_or_amount",
+  "rate_with_margin",
+  "col_break_6",
   "discount_percentage",
   "discount_amount",
   "distributed_discount_amount",
-  "col_break_price_list",
-  "base_price_list_rate",
   "sec_break1",
   "rate",
   "amount",
@@ -532,10 +536,6 @@
    "fieldtype": "Section Break"
   },
   {
-   "fieldname": "col_break_price_list",
-   "fieldtype": "Column Break"
-  },
-  {
    "collapsible": 1,
    "fieldname": "ad_sec_break",
    "fieldtype": "Section Break",
@@ -572,19 +572,55 @@
    "fieldtype": "Currency",
    "label": "Distributed Discount Amount",
    "options": "currency"
+  },
+  {
+   "depends_on": "price_list_rate",
+   "fieldname": "margin_type",
+   "fieldtype": "Select",
+   "label": "Margin Type",
+   "options": "\nPercentage\nAmount",
+   "print_hide": 1
+  },
+  {
+   "depends_on": "eval:doc.margin_type && doc.price_list_rate",
+   "fieldname": "margin_rate_or_amount",
+   "fieldtype": "Float",
+   "label": "Margin Rate or Amount",
+   "print_hide": 1
+  },
+  {
+   "collapsible": 1,
+   "collapsible_depends_on": "eval: doc.margin_type || doc.discount_amount || doc.distributed_discount_amount",
+   "fieldname": "discount_and_margin_section",
+   "fieldtype": "Section Break",
+   "label": "Discount and Margin"
+  },
+  {
+   "depends_on": "eval:doc.margin_type && doc.price_list_rate && doc.margin_rate_or_amount",
+   "fieldname": "rate_with_margin",
+   "fieldtype": "Currency",
+   "label": "Rate With Margin",
+   "options": "currency",
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "col_break_6",
+   "fieldtype": "Column Break"
   }
  ],
  "idx": 1,
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-06-02 06:22:17.864822",
+ "modified": "2025-06-17 12:05:52.441645",
  "modified_by": "Administrator",
  "module": "Buying",
  "name": "Supplier Quotation Item",
  "naming_rule": "Random",
  "owner": "Administrator",
  "permissions": [],
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],

--- a/erpnext/buying/doctype/supplier_quotation_item/supplier_quotation_item.py
+++ b/erpnext/buying/doctype/supplier_quotation_item/supplier_quotation_item.py
@@ -38,6 +38,8 @@ class SupplierQuotationItem(Document):
 		lead_time_days: DF.Int
 		manufacturer: DF.Link | None
 		manufacturer_part_no: DF.Data | None
+		margin_rate_or_amount: DF.Float
+		margin_type: DF.Literal["", "Percentage", "Amount"]
 		material_request: DF.Link | None
 		material_request_item: DF.Data | None
 		net_amount: DF.Currency
@@ -52,6 +54,7 @@ class SupplierQuotationItem(Document):
 		project: DF.Link | None
 		qty: DF.Float
 		rate: DF.Currency
+		rate_with_margin: DF.Currency
 		request_for_quotation: DF.Link | None
 		request_for_quotation_item: DF.Data | None
 		sales_order: DF.Link | None


### PR DESCRIPTION
## Reason
- While creating supplier quotation when user try to fill items table, an attribute error occurs

## Changes done
- Added margin related fields as these fields are checked while setting items rate and discounts.
- Fields added are:
  - margin type
  - margin rate or amount
  - rate with margin
  
 - Closes: #47420