### PR TITLE
fix: do not reset party account for return doc

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -1017,7 +1017,7 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 				}
 
 				var party = me.frm.doc[frappe.model.scrub(party_type)];
-				if(party && me.frm.doc.company) {
+				if(party && me.frm.doc.company && !me.frm.doc.__onload?.load_after_mapping && !me.frm.doc.get(party_account_field)) {
 					return frappe.call({
 						method: "erpnext.accounts.party.get_party_account",
 						args: {


### PR DESCRIPTION
Issue: Party account getting reset on creating Sales Return from Sales Invoice.

Steps to replicate:
- Create a Sales Invoice with `debit_to` account other than default party account.
- Create a Sales Return from the invoice

Party account will be different from sales invoice .

Before:

https://github.com/user-attachments/assets/d6830a83-0a2f-4827-823e-4d7d9f0e6804

After:

https://github.com/user-attachments/assets/ed0dcebd-e67d-45c6-8d2d-66a668e24539


Frappe Support Issue: https://support.frappe.io/app/hd-ticket/40802
