### PR TITLE
fix: incorrect condition for setting party account on change of company

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -1017,7 +1017,7 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 				}
 
 				var party = me.frm.doc[frappe.model.scrub(party_type)];
-				if(party && me.frm.doc.company && !me.frm.doc.__onload?.load_after_mapping && !me.frm.doc.get(party_account_field)) {
+				if(party && me.frm.doc.company && (!me.frm.doc.__onload?.load_after_mapping || !me.frm.doc.get(party_account_field))) {
 					return frappe.call({
 						method: "erpnext.accounts.party.get_party_account",
 						args: {


### PR DESCRIPTION
regression: https://github.com/frappe/erpnext/pull/48098


Check the party field condition only if the document is being created from a mapped document.