### PR TITLE
Bom duplicate item validation

### DIFF
--- a/erpnext/manufacturing/doctype/bom/bom.py
+++ b/erpnext/manufacturing/doctype/bom/bom.py
@@ -281,6 +281,7 @@ class BOM(WebsiteGenerator):
 		self.set_process_loss_qty()
 		self.validate_scrap_items()
 		self.set_default_uom()
+		self.validate_duplicate_items()
 
 	def set_default_uom(self):
 		if not self.get("items"):
@@ -298,6 +299,22 @@ class BOM(WebsiteGenerator):
 		for row in self.get("items"):
 			if row.stock_uom != item_wise_uom.get(row.item_code):
 				row.stock_uom = item_wise_uom.get(row.item_code)
+
+	def validate_duplicate_items(self):
+		unique_items = set()
+
+		for row in self.items:
+			identifier = row.item_code
+
+			if identifier in unique_items:
+				frappe.throw(
+					_("At row {0}: Item {1} entered multiple times.").format(
+						row.idx, frappe.bold(row.item_code)
+					),
+					title=_("Duplicate Item Found"),
+				)
+			else:
+				unique_items.add(identifier)
 
 	def get_context(self, context):
 		context.parents = [{"name": "boms", "title": _("All BOMs")}]

--- a/erpnext/manufacturing/doctype/bom_creator/bom_creator.py
+++ b/erpnext/manufacturing/doctype/bom_creator/bom_creator.py
@@ -78,6 +78,8 @@ class BOMCreator(Document):
 		self.validate_items()
 
 	def validate_items(self):
+		unique_items = set()
+
 		for row in self.items:
 			if row.is_expandable and row.item_code == self.item_code:
 				frappe.throw(_("Item {0} cannot be added as a sub-assembly of itself").format(row.item_code))
@@ -93,6 +95,14 @@ class BOMCreator(Document):
 					_("At row {0}: Parent Row No cannot be set for item {1}").format(row.idx, row.item_code),
 					title=_("Remove Parent Row No in Items Table"),
 				)
+
+			if row.item_code in unique_items:
+				frappe.throw(
+					_("At row {0}: Item {1} already added.").format(row.idx, frappe.bold(row.item_code)),
+					title=_("Duplicate Item Found"),
+				)
+			else:
+				unique_items.add(row.item_code)
 
 	def set_status(self, save=False):
 		self.status = {


### PR DESCRIPTION
Implement validation to detect and prevent duplicate items in both the Bill of Materials (BOM) and BOM Creator. Each item should appear only once within the BOM items table to ensure accuracy in material planning and costing.
https://github.com/frappe/erpnext/issues/48006