### PR TITLE
fix: allow zero valuation rate toast showing even when rate is not 0

### DIFF
--- a/erpnext/controllers/stock_controller.py
+++ b/erpnext/controllers/stock_controller.py
@@ -65,6 +65,8 @@ class StockController(AccountsController):
 		self.validate_internal_transfer()
 		self.validate_putaway_capacity()
 		self.reset_conversion_factor()
+
+	def on_update(self):
 		self.check_zero_rate()
 
 	def reset_conversion_factor(self):

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -302,6 +302,7 @@ class StockEntry(StockController):
 			self.set_material_request_transfer_status("In Transit")
 
 	def on_update(self):
+		super().on_update()
 		self.set_serial_and_batch_bundle()
 
 	def set_job_card_data(self):

--- a/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py
+++ b/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py
@@ -86,6 +86,7 @@ class StockReconciliation(StockController):
 			self.validate_reserved_stock()
 
 	def on_update(self):
+		super().on_update()
 		self.set_serial_and_batch_bundle(ignore_validate=True)
 
 	def validate_inventory_dimension(self):


### PR DESCRIPTION
The newly added Allow Zero Valuation Rate toast added in develop through #48015 is getting triggered even when rate is not 0. This PR fixes it by moving the function from `validate` to `on_update`.

Do not backport!