### PR TITLE
fix: setup wizard load chart of accounts and fiscal year on change of country

### DIFF
--- a/erpnext/public/js/setup_wizard.js
+++ b/erpnext/public/js/setup_wizard.js
@@ -61,9 +61,13 @@ erpnext.setup.slides_settings = [
 
 		onload: function (slide) {
 			this.bind_events(slide);
-			this.load_chart_of_accounts(slide);
-			this.set_fy_dates(slide);
 		},
+
+		before_show: function () {
+			this.load_chart_of_accounts(this);
+			this.set_fy_dates(this);
+		},
+
 		validate: function () {
 			if (!this.validate_fy_dates()) {
 				return false;


### PR DESCRIPTION
Issue: If a user selects the wrong country in Slide 1 of the Setup Wizard and realizes this on Slide 2, they have to reload the page to choose the correct Chart of Accounts on the second Slide as the Options won't fetch on Country change in Slide 1.

https://github.com/user-attachments/assets/75f7f1e6-2dd4-450e-b0e1-edc8443cfe6f

Fix:

https://github.com/user-attachments/assets/6c93f4fe-83aa-4d9f-9877-e9a36f38a3b8

