### PR TITLE
fix: adjustment entries for SE and SCR after LCV

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -1660,14 +1660,16 @@ class StockEntry(StockController):
 					)
 
 					account_currency = get_account_currency(item.expense_account)
+
+					# credit amount in negative to knock off the debit entry
 					gl_entries.append(
 						self.get_gl_dict(
 							{
 								"account": item.expense_account,
-								"against": account,
+								"against": warehouse_account.get(item.t_warehouse)["account"],
 								"cost_center": item.cost_center,
-								"debit": credit_amount,
-								"credit": 0.0,
+								"debit": 0.0,
+								"credit": credit_amount * -1,
 								"remarks": _("Accounting Entry for LCV in Stock Entry {0}").format(self.name),
 								"debit_in_account_currency": flt(amount["amount"]),
 								"account_currency": account_currency,

--- a/erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py
+++ b/erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py
@@ -777,12 +777,14 @@ class SubcontractingReceipt(SubcontractingController):
 						)
 
 						account_currency = get_account_currency(item.expense_account)
+
+						# credit amount in negative to knock off the debit entry
 						self.add_gl_entry(
 							gl_entries=gl_entries,
 							account=item.expense_account,
 							cost_center=item.cost_center,
-							debit=credit_amount,
-							credit=0.0,
+							debit=0.0,
+							credit=credit_amount * -1,
 							remarks=remarks,
 							against_account=warehouse_account.get(item.warehouse)["account"],
 							debit_in_account_currency=flt(amount["amount"]),


### PR DESCRIPTION
### Adjustment entries

<img width="987" alt="Screenshot 2025-06-18 at 5 43 01 PM" src="https://github.com/user-attachments/assets/4f335be2-5aa4-47b5-a0bc-247e55b137f9" />

### After fix (removed adjustment entries)
<img width="1009" alt="Screenshot 2025-06-18 at 5 43 11 PM" src="https://github.com/user-attachments/assets/1bdfbd8f-c9df-446a-b84e-579af964c7b5" />

