### PR TITLE
fix: modify query to fetch valid return qty

### DIFF
--- a/erpnext/stock/doctype/delivery_note/delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.py
@@ -793,13 +793,15 @@ def get_returned_qty_map(delivery_note):
 	"""returns a map: {so_detail: returned_qty}"""
 	returned_qty_map = frappe._dict(
 		frappe.db.sql(
-			"""select dn_item.dn_detail, abs(dn_item.qty) as qty
-		from `tabDelivery Note Item` dn_item, `tabDelivery Note` dn
-		where dn.name = dn_item.parent
-			and dn.docstatus = 1
-			and dn.is_return = 1
-			and dn.return_against = %s
-	""",
+			"""select dn_item.dn_detail, sum(abs(dn_item.qty)) as qty
+			from `tabDelivery Note Item` dn_item, `tabDelivery Note` dn
+			where dn.name = dn_item.parent
+				and dn.docstatus = 1
+				and dn.is_return = 1
+				and dn.return_against = %s
+				and dn_item.qty <= 0
+				group by dn_item.item_code
+		""",
 			delivery_note,
 		)
 	)

--- a/erpnext/stock/doctype/delivery_note/test_delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/test_delivery_note.py
@@ -6,8 +6,7 @@ import json
 from collections import defaultdict
 
 import frappe
-from frappe.tests import change_settings
-from frappe.tests.utils import FrappeTestCase
+from frappe.tests.utils import FrappeTestCase, change_settings
 from frappe.utils import add_days, cstr, flt, getdate, nowdate, nowtime, today
 
 from erpnext.accounts.doctype.account.test_account import get_inventory_account

--- a/erpnext/stock/doctype/delivery_note/test_delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/test_delivery_note.py
@@ -6,6 +6,7 @@ import json
 from collections import defaultdict
 
 import frappe
+from frappe.tests import change_settings
 from frappe.tests.utils import FrappeTestCase
 from frappe.utils import add_days, cstr, flt, getdate, nowdate, nowtime, today
 
@@ -1021,6 +1022,30 @@ class TestDeliveryNote(FrappeTestCase):
 		self.assertEqual(dn2.get("items")[0].billed_amt, 300)
 		self.assertEqual(dn2.per_billed, 100)
 		self.assertEqual(dn2.status, "Completed")
+
+	@change_settings("Accounts Settings", {"delete_linked_ledger_entries": True})
+	def test_sales_invoice_qty_after_return(self):
+		from erpnext.stock.doctype.delivery_note.delivery_note import make_sales_return
+
+		dn = create_delivery_note(qty=10)
+
+		dnr1 = make_sales_return(dn.name)
+		dnr1.get("items")[0].qty = -3
+		dnr1.save().submit()
+
+		dnr2 = make_sales_return(dn.name)
+		dnr2.get("items")[0].qty = -2
+		dnr2.save().submit()
+
+		si = make_sales_invoice(dn.name)
+		si.save().submit()
+
+		self.assertEqual(si.get("items")[0].qty, 5)
+
+		si.reload().cancel().delete()
+		dnr1.reload().cancel().delete()
+		dnr2.reload().cancel().delete()
+		dn.reload().cancel().delete()
 
 	def test_dn_billing_status_case3(self):
 		# SO -> DN1 -> SI and SO -> SI and SO -> DN2


### PR DESCRIPTION
Issue: When two different credit notes are created with the same item for a Delivery Note, and the user tries to create a Sales Invoice against that Delivery Note, the quantity is shown incorrectly.

Ref: [#40010](https://support.frappe.io/helpdesk/tickets/40010)

Before:

https://github.com/user-attachments/assets/412b860f-be4f-4662-835f-348fe0059bc6

After:

https://github.com/user-attachments/assets/2b350aa1-751d-421e-9633-16d76f56775d
