### PR TITLE
fix(accounts):enable allow_on_submit for accounting dimensions in repost settings allowed doctypes

### DIFF
--- a/erpnext/accounts/doctype/accounting_dimension/accounting_dimension.py
+++ b/erpnext/accounts/doctype/accounting_dimension/accounting_dimension.py
@@ -111,17 +111,15 @@ class AccountingDimension(Document):
 def make_dimension_in_accounting_doctypes(doc, doclist=None):
 	if not doclist:
 		doclist = get_doctypes_with_dimensions()
-
 	doc_count = len(get_accounting_dimensions())
 	count = 0
-	repostable_doctypes = get_allowed_types_from_settings()
+	repostable_doctypes = get_allowed_types_from_settings(child_doc=True)
 
 	for doctype in doclist:
 		if (doc_count + 1) % 2 == 0:
 			insert_after_field = "dimension_col_break"
 		else:
 			insert_after_field = "accounting_dimensions_section"
-
 		df = {
 			"fieldname": doc.fieldname,
 			"label": doc.label,

--- a/erpnext/accounts/doctype/repost_accounting_ledger_settings/repost_accounting_ledger_settings.py
+++ b/erpnext/accounts/doctype/repost_accounting_ledger_settings/repost_accounting_ledger_settings.py
@@ -1,8 +1,13 @@
 # Copyright (c) 2023, Frappe Technologies Pvt. Ltd. and contributors
 # For license information, please see license.txt
 
-# import frappe
+import frappe
 from frappe.model.document import Document
+
+from erpnext.accounts.doctype.accounting_dimension.accounting_dimension import (
+	get_accounting_dimensions,
+)
+from erpnext.accounts.doctype.repost_accounting_ledger.repost_accounting_ledger import get_child_docs
 
 
 class RepostAccountingLedgerSettings(Document):
@@ -17,6 +22,24 @@ class RepostAccountingLedgerSettings(Document):
 		from erpnext.accounts.doctype.repost_allowed_types.repost_allowed_types import RepostAllowedTypes
 
 		allowed_types: DF.Table[RepostAllowedTypes]
-	# end: auto-generated types
 
-	pass
+	# end: auto-generated types
+	def validate(self):
+		self.update_property_for_accounting_dimension()
+
+	def update_property_for_accounting_dimension(self):
+		doctypes = [entry.document_type for entry in self.allowed_types if entry.allowed]
+		if not doctypes:
+			return
+		doctypes += get_child_docs(doctypes)
+
+		set_allow_on_submit_for_dimension_fields(doctypes)
+
+
+def set_allow_on_submit_for_dimension_fields(doctypes):
+	for dt in doctypes:
+		meta = frappe.get_meta(dt)
+		for dimension in get_accounting_dimensions():
+			df = meta.get_field(dimension)
+			if df and not df.allow_on_submit:
+				frappe.db.set_value("Custom Field", dt + "-" + dimension, "allow_on_submit", 1)

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -357,7 +357,7 @@ execute:frappe.db.set_single_value("Buying Settings", "project_update_frequency"
 execute:frappe.db.set_default("date_format", frappe.db.get_single_value("System Settings", "date_format"))
 erpnext.patches.v14_0.update_total_asset_cost_field
 erpnext.patches.v15_0.create_advance_payment_status
-erpnext.patches.v15_0.allow_on_submit_dimensions_for_repostable_doctypes
+erpnext.patches.v15_0.allow_on_submit_dimensions_for_repostable_doctypes #2025-06-19
 erpnext.patches.v14_0.create_accounting_dimensions_in_reconciliation_tool
 erpnext.patches.v14_0.update_flag_for_return_invoices #2024-03-22
 erpnext.patches.v15_0.create_accounting_dimensions_in_payment_request

--- a/erpnext/patches/v15_0/allow_on_submit_dimensions_for_repostable_doctypes.py
+++ b/erpnext/patches/v15_0/allow_on_submit_dimensions_for_repostable_doctypes.py
@@ -9,6 +9,6 @@ from erpnext.accounts.doctype.repost_accounting_ledger.repost_accounting_ledger 
 
 
 def execute():
-	for dt in get_allowed_types_from_settings():
+	for dt in get_allowed_types_from_settings(child_doc=True):
 		for dimension in get_accounting_dimensions():
 			frappe.db.set_value("Custom Field", dt + "-" + dimension, "allow_on_submit", 1)


### PR DESCRIPTION
Issue: When fetching doctypes from the Repost Settings to set the df property for accounting dimension fields, the child doctypes are not being fetched.


Ref: [#38574](https://support.frappe.io/helpdesk/tickets/38574), [#40549](https://support.frappe.io/helpdesk/tickets/40549)

Before:


https://github.com/user-attachments/assets/4d0517cf-6616-4214-af82-63515ab56112

After:


https://github.com/user-attachments/assets/34f10414-1d4c-402c-aeec-dca4d36fad2f

Backport needed: v15

resolves[#44085](https://github.com/frappe/erpnext/issues/44085#event-16279196288),  [#48106](https://github.com/frappe/erpnext/issues/48106)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved handling of accounting dimensions by ensuring that both main and child document types have the "allow on submit" property enabled for relevant fields in repostable doctypes.

* **Chores**
  * Updated internal settings and validation processes to automatically apply configuration changes for accounting dimensions.
  * Added a date comment to the patch log for better traceability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->