### PR TITLE
fix: disallow posting date of purchase receipt and invoice before PO transaction date

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
@@ -259,6 +259,7 @@ class PurchaseInvoice(BuyingController):
 			self.is_opening = "No"
 
 		self.validate_posting_time()
+		self.validate_posting_date_with_po()
 
 		super().validate()
 

--- a/erpnext/controllers/buying_controller.py
+++ b/erpnext/controllers/buying_controller.py
@@ -80,6 +80,21 @@ class BuyingController(SubcontractingController):
 				),
 			)
 
+	def validate_posting_date_with_po(self):
+		po_list = []
+		for item in self.items:
+			if item.purchase_order and item.purchase_order not in po_list:
+				po_list.append(item.purchase_order)
+
+		for po in po_list:
+			po_posting_date = frappe.get_value("Purchase Order", po, "transaction_date")
+			if getdate(po_posting_date) > getdate(self.posting_date):
+				frappe.throw(
+					_("Posting Date {0} cannot be before Purchase Order Posting Date {1}").format(
+						frappe.bold(self.posting_date), frappe.bold(po_posting_date)
+					)
+				)
+
 	def create_package_for_transfer(self) -> None:
 		"""Create serial and batch package for Sourece Warehouse in case of inter transfer."""
 

--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
@@ -235,6 +235,7 @@ class PurchaseReceipt(BuyingController):
 
 	def validate(self):
 		self.validate_posting_time()
+		self.validate_posting_date_with_po()
 		super().validate()
 
 		if self._action != "submit":


### PR DESCRIPTION
Reference support ticket [41475](https://support.frappe.io/helpdesk/tickets/41475)

Users will no longer be allowed to set posting/transaction date of Purchase Receipt and/or Purchase Invoice before the Purchase Order date.