### PR TITLE
fix: duplicate naming issue in contract doctype

### DIFF
--- a/erpnext/crm/doctype/contract/contract.json
+++ b/erpnext/crm/doctype/contract/contract.json
@@ -2,6 +2,7 @@
  "actions": [],
  "allow_import": 1,
  "allow_rename": 1,
+ "autoname": "CON-.YYYY.-.#####",
  "creation": "2018-04-12 06:32:04.582486",
  "doctype": "DocType",
  "editable_grid": 1,
@@ -256,10 +257,11 @@
  "grid_page_length": 50,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-05-23 13:54:03.346537",
+ "modified": "2025-06-19 17:27:19.908421",
  "modified_by": "Administrator",
  "module": "CRM",
  "name": "Contract",
+ "naming_rule": "Expression (old style)",
  "owner": "Administrator",
  "permissions": [
   {
@@ -328,6 +330,7 @@
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],
+ "title_field": "party_name",
  "track_changes": 1,
  "track_seen": 1
 }

--- a/erpnext/crm/doctype/contract/contract.json
+++ b/erpnext/crm/doctype/contract/contract.json
@@ -257,7 +257,7 @@
  "grid_page_length": 50,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-06-19 17:27:19.908421",
+ "modified": "2025-06-19 17:48:45.049007",
  "modified_by": "Administrator",
  "module": "CRM",
  "name": "Contract",
@@ -326,6 +326,7 @@
   }
  ],
  "row_format": "Dynamic",
+ "search_fields": "party_type, party_name, contract_template",
  "show_name_in_global_search": 1,
  "sort_field": "creation",
  "sort_order": "DESC",

--- a/erpnext/crm/doctype/contract/contract.py
+++ b/erpnext/crm/doctype/contract/contract.py
@@ -6,6 +6,7 @@ import frappe
 from frappe import _
 from frappe.model.document import Document
 from frappe.utils import getdate, nowdate
+from frappe.model.naming import append_number_if_name_exists
 
 
 class Contract(Document):
@@ -52,12 +53,7 @@ class Contract(Document):
 		if self.contract_template:
 			name += f" - {self.contract_template} Agreement"
 
-		# If identical, append contract name with the next number in the iteration
-		if frappe.db.exists("Contract", name):
-			count = len(frappe.get_all("Contract", filters={"name": ["like", f"%{name}%"]}))
-			name = f"{name} - {count}"
-
-		self.name = _(name)
+		self.name = append_number_if_name_exists("Contract", name)
 
 	def validate(self):
 		self.set_missing_values()

--- a/erpnext/crm/doctype/contract/contract.py
+++ b/erpnext/crm/doctype/contract/contract.py
@@ -5,7 +5,6 @@
 import frappe
 from frappe import _
 from frappe.model.document import Document
-from frappe.model.naming import append_number_if_name_exists
 from frappe.utils import getdate, nowdate
 
 

--- a/erpnext/crm/doctype/contract/contract.py
+++ b/erpnext/crm/doctype/contract/contract.py
@@ -47,14 +47,6 @@ class Contract(Document):
 		status: DF.Literal["Unsigned", "Active", "Inactive"]
 	# end: auto-generated types
 
-	def autoname(self):
-		name = self.party_name
-
-		if self.contract_template:
-			name += f" - {self.contract_template} Agreement"
-
-		self.name = append_number_if_name_exists("Contract", name)
-
 	def validate(self):
 		self.set_missing_values()
 		self.validate_dates()

--- a/erpnext/crm/doctype/contract/contract.py
+++ b/erpnext/crm/doctype/contract/contract.py
@@ -5,8 +5,8 @@
 import frappe
 from frappe import _
 from frappe.model.document import Document
-from frappe.utils import getdate, nowdate
 from frappe.model.naming import append_number_if_name_exists
+from frappe.utils import getdate, nowdate
 
 
 class Contract(Document):

--- a/erpnext/crm/doctype/contract/test_contract.py
+++ b/erpnext/crm/doctype/contract/test_contract.py
@@ -12,19 +12,6 @@ class TestContract(IntegrationTestCase):
 		frappe.db.sql("delete from `tabContract`")
 		self.contract_doc = get_contract()
 
-	def test_autoname_appends_suffix_for_duplicates(self):
-		contract_1 = self.contract_doc
-		contract_1.insert()
-		self.assertEqual(contract_1.name, "_Test Customer")
-
-		contract_2 = get_contract()
-		contract_2.insert()
-		self.assertEqual(contract_2.name, "_Test Customer-1")
-
-		contract_3 = get_contract()
-		contract_3.insert()
-		self.assertEqual(contract_3.name, "_Test Customer-2")
-
 	def test_validate_start_date_before_end_date(self):
 		self.contract_doc.start_date = nowdate()
 		self.contract_doc.end_date = add_days(nowdate(), -1)

--- a/erpnext/crm/doctype/contract/test_contract.py
+++ b/erpnext/crm/doctype/contract/test_contract.py
@@ -12,6 +12,19 @@ class TestContract(IntegrationTestCase):
 		frappe.db.sql("delete from `tabContract`")
 		self.contract_doc = get_contract()
 
+	def test_autoname_appends_suffix_for_duplicates(self):
+		contract_1 = self.contract_doc
+		contract_1.insert()
+		self.assertEqual(contract_1.name, "_Test Customer")
+
+		contract_2 = get_contract()
+		contract_2.insert()
+		self.assertEqual(contract_2.name, "_Test Customer-1")
+
+		contract_3 = get_contract()
+		contract_3.insert()
+		self.assertEqual(contract_3.name, "_Test Customer-2")
+
 	def test_validate_start_date_before_end_date(self):
 		self.contract_doc.start_date = nowdate()
 		self.contract_doc.end_date = add_days(nowdate(), -1)


### PR DESCRIPTION
Issue:
The custom autoname method in the Contract Doctype generated names based on the count of existing records. However, deleted records were not excluded from this logic, leading to unintended reuse of already-deleted names.

closes: https://github.com/frappe/erpnext/issues/47401