### PR TITLE
fix: test case

### DIFF
--- a/erpnext/controllers/selling_controller.py
+++ b/erpnext/controllers/selling_controller.py
@@ -839,7 +839,7 @@ class SellingController(StockController):
 					sre_doc = frappe.get_doc("Stock Reservation Entry", sre)
 
 					qty_can_be_deliver = 0
-					if sre_doc.reservation_based_on == "Serial and Batch" and item.serial_and_batch_bundle:
+					if sre_doc.reservation_based_on == "Serial and Batch":
 						sbb = frappe.get_doc("Serial and Batch Bundle", item.serial_and_batch_bundle)
 						if sre_doc.has_serial_no:
 							delivered_serial_nos = [d.serial_no for d in sbb.entries]

--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -1100,7 +1100,13 @@ def make_delivery_note(source_name, target_doc=None, kwargs=None):
 				dn_item.qty = flt(sre.reserved_qty) / flt(dn_item.get("conversion_factor", 1))
 				dn_item.warehouse = sre.warehouse
 
-				if sre.reservation_based_on == "Serial and Batch" and (sre.has_serial_no or sre.has_batch_no):
+				use_serial_batch_fields = frappe.get_single_value("Stock Settings", "use_serial_batch_fields")
+
+				if (
+					not use_serial_batch_fields
+					and sre.reservation_based_on == "Serial and Batch"
+					and (sre.has_serial_no or sre.has_batch_no)
+				):
 					dn_item.serial_and_batch_bundle = get_ssb_bundle_for_voucher(sre)
 
 				target_doc.append("items", dn_item)

--- a/erpnext/stock/doctype/delivery_note/delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.py
@@ -444,8 +444,6 @@ class DeliveryNote(SellingController):
 		self.update_prevdoc_status()
 		self.update_billing_status()
 
-		self.update_stock_reservation_entries()
-
 		if not self.is_return:
 			self.check_credit_limit()
 		elif self.issue_credit_note:
@@ -457,6 +455,8 @@ class DeliveryNote(SellingController):
 
 			self.make_bundle_for_sales_purchase_return(table_name)
 			self.make_bundle_using_old_serial_batch_fields(table_name)
+
+		self.update_stock_reservation_entries()
 
 		# Updating stock ledger should always be called after updating prevdoc status,
 		# because updating reserved qty in bin depends upon updated delivered qty in SO

--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -202,6 +202,9 @@ def update_stock(ctx, out, doc=None):
 				"item_code": ctx.item_code,
 				"warehouse": ctx.warehouse,
 				"based_on": frappe.get_single_value("Stock Settings", "pick_serial_and_batch_based_on"),
+				"sabb_voucher_no": doc.get("name"),
+				"sabb_voucher_detail_no": ctx.child_docname,
+				"sabb_voucher_type": ctx.doctype,
 			}
 		)
 


### PR DESCRIPTION
```
ERROR  test_stock_reservation_against_sales_order (erpnext.stock.doctype.stock_reservation_entry.test_stock_reservation_entry.TestStockReservationEntry.test_stock_reservation_against_sales_order)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.12.10/x64/lib/python3.12/contextlib.py", line 81, in inner
    return func(*args, **kwds)
           ^^^^^^^^^^^^^^^^^^^
    args = (<erpnext.stock.doctype.stock_reservation_entry.test_stock_reservation_entry.TestStockReservationEntry testMethod=test_stock_reservation_against_sales_order>,)
    func = <function TestStockReservationEntry.test_stock_reservation_against_sales_order at 0x7ff1aa24d760>
    kwds = {}
    self = <contextlib._GeneratorContextManager object at 0x7ff1ab6eeb40>
  File "/home/runner/frappe-bench/apps/erpnext/erpnext/stock/doctype/stock_reservation_entry/test_stock_reservation_entry.py", line 356, in test_stock_reservation_against_sales_order
    dn2.submit()
    dn1 = <DeliveryNote: doctype=Delivery Note MAT-DN-2025-00002 docstatus=1>
    dn2 = <DeliveryNote: doctype=Delivery Note MAT-DN-2025-00003 docstatus=1>
    item = <DeliveryNoteItem: doctype=Delivery Note Item up97uhufvv docstatus=1 parent=MAT-DN-2025-00003>
    item_code = '4a97b42ce0d1f44c'
    item_list = [{'item_code': '[564](https://github.com/frappe/erpnext/actions/runs/15749702946/job/44392461163?pr=48131#step:13:565)3812eaae7cc74', 'warehouse': '_Test Warehouse - _TC', 'qty': 84, 'uom': 'Nos', 'rate': 260, 'doctype': 'Sales Order Item'}, {'item_code': 'b51e95d12f99dce1', 'warehouse': '_Test Warehouse - _TC', 'qty': 99, 'uom': 'Nos', 'rate': 43, 'doctype': 'Sales Order Item'}, {'item_code': 'dc77bd3bb57ef08e', 'warehouse': '_Test Warehouse - _TC', 'qty': 58, 'uom': 'Nos', 'rate': 263, 'doctype': 'Sales Order Item'}, {'item_code': '4a97b42ce0d1f44c', 'warehouse': '_Test Warehouse - _TC', 'qty': 91, 'uom': 'Nos', 'rate': 252, 'doctype': 'Sales Order Item'}]
    items_details = {'5643812eaae7cc74': <Item: doctype=Item 5643812eaae7cc74>, 'b51e95d12f99dce1': <Item: doctype=Item b51e95d12f99dce1>, 'dc77bd3bb57ef08e': <Item: doctype=Item dc77bd3bb57ef08e>, '4a97b42ce0d1f44c': <Item: doctype=Item 4a97b42ce0d1f44c>}
    properties = <Item: doctype=Item 4a97b42ce0d1f44c>
    reserved_qty = 91.0
    reserved_qty_details = {'ulu6n2q1ch': 84.0, 'ulu9jvqpho': 58.0, 'ulue6sjmqi': 91.0, 'ulug213dt0': 99.0}
    se = <StockEntry: doctype=Stock Entry MAT-STE-2025-00014 docstatus=2>
    self = <erpnext.stock.doctype.stock_reservation_entry.test_stock_reservation_entry.TestStockReservationEntry testMethod=test_stock_reservation_against_sales_order>
    so = <SalesOrder: doctype=Sales Order SAL-ORD-2025-00005 docstatus=1>
    sre_details = {'delivered_qty': 6.0, 'status': 'Partially Delivered'}
  File "/home/runner/frappe-bench/apps/frappe/frappe/utils/typing_validations.py", line 32, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
    apply_condition = <function whitelist.<locals>.innerfn.<locals>.<lambda> at 0x7ff1b6b7d4e0>
    args = (<DeliveryNote: doctype=Delivery Note MAT-DN-2025-00003 docstatus=1>,)
    func = <function Document.submit at 0x7ff1b6b7d440>
    kwargs = {}
File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 1494, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
                              ^^^^^^^^^^^^^^^^^^^^^^^^^
    add_to_return_value = <function Document.hook.<locals>.add_to_return_value at 0x7ff1aa1e9620>
    args = ()
    fn = <function Document.run_method.<locals>.fn at 0x7ff1aa1ca8e0>
    hooks = ()
    kwargs = {}
    method = 'on_submit'
    self = <DeliveryNote: doctype=Delivery Note MAT-DN-2025-00003 docstatus=1>
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 1124, in fn
    return method_object(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    args = ()
    kwargs = {}
    method = 'on_submit'
    method_object = <bound method DeliveryNote.on_submit of <DeliveryNote: doctype=Delivery Note MAT-DN-2025-00003 docstatus=1>>
    self = <DeliveryNote: doctype=Delivery Note MAT-DN-2025-00003 docstatus=1>
  File "/home/runner/frappe-bench/apps/erpnext/erpnext/stock/doctype/delivery_note/delivery_note.py", line 459, in on_submit
    self.make_bundle_using_old_serial_batch_fields(table_name)
    self = <DeliveryNote: doctype=Delivery Note MAT-DN-2025-00003 docstatus=1>
    table_name = 'items'
  File "/home/runner/frappe-bench/apps/erpnext/erpnext/controllers/stock_controller.py", line 277, in make_bundle_using_old_serial_batch_fields
    self.create_serial_batch_bundle(bundle_details, row)
    bundle_details = {'item_code': 'b51e95d12f99dce1', 'posting_date': datetime.date(2025, 6, 19), 'posting_time': datetime.timedelta(seconds=3549, microseconds=995481), 'voucher_type': 'Delivery Note', 'voucher_no': 'MAT-DN-2025-00003', 'voucher_detail_no': 'up9cgs3b0v', 'company': '_Test Company', 'is_rejected': False, 'use_serial_batch_fields': 1, 'via_landed_cost_voucher': False, 'do_not_submit': True, 'qty': 99.0, 'type_of_transaction': 'Outward', 'warehouse': '_Test Warehouse - _TC', 'batches': None, 'serial_nos': ['SRSI-00316', 'SRSI-00317', 'SRSI-00318', 'SRSI-00319', 'SRSI-00320'], 'batch_no': None}
    parent_details = {}
    row = <DeliveryNoteItem: doctype=Delivery Note Item up9cgs3b0v docstatus=1 parent=MAT-DN-2025-00003>
    self = <DeliveryNote: doctype=Delivery Note MAT-DN-2025-00003 docstatus=1>
    table_name = 'items'
    via_landed_cost_voucher = False
  File "/home/runner/frappe-bench/apps/erpnext/erpnext/controllers/stock_controller.py", line 486, in create_serial_batch_bundle
    sn_doc = SerialBatchCreation(bundle_details).make_serial_and_batch_bundle()
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    SerialBatchCreation = <class 'erpnext.stock.serial_batch_bundle.SerialBatchCreation'>
    bundle_details = {'item_code': 'b51e95d12f99dce1', 'posting_date': datetime.date(2025, 6, 19), 'posting_time': datetime.timedelta(seconds=3549, microseconds=995481), 'voucher_type': 'Delivery Note', 'voucher_no': 'MAT-DN-2025-00003', 'voucher_detail_no': 'up9cgs3b0v', 'company': '_Test Company', 'is_rejected': False, 'use_serial_batch_fields': 1, 'via_landed_cost_voucher': False, 'do_not_submit': True, 'qty': 99.0, 'type_of_transaction': 'Outward', 'warehouse': '_Test Warehouse - _TC', 'batches': None, 'serial_nos': ['SRSI-00316', 'SRSI-00317', 'SRSI-00318', 'SRSI-00319', 'SRSI-00320'], 'batch_no': None}
    row = <DeliveryNoteItem: doctype=Delivery Note Item up9cgs3b0v docstatus=1 parent=MAT-DN-2025-00003>
    self = <DeliveryNote: doctype=Delivery Note MAT-DN-2025-00003 docstatus=1>
  File "/home/runner/frappe-bench/apps/erpnext/erpnext/stock/serial_batch_bundle.py", line 1029, in make_serial_and_batch_bundle
    self.validate_qty(doc)
    doc = <SerialandBatchBundle: doctype=Serial and Batch Bundle c[637](https://github.com/frappe/erpnext/actions/runs/15749702946/job/44392461163?pr=48131#step:13:638)fa65336590876d25>
    key = 'actual_qty'
    self = <erpnext.stock.serial_batch_bundle.SerialBatchCreation object at 0x7ff1ab438b00>
    valid_columns = ['name', 'owner', 'creation', 'modified', 'modified_by', 'docstatus', 'idx', 'naming_series', 'company', 'item_name', 'has_serial_no', 'has_batch_no', 'item_code', 'warehouse', 'type_of_transaction', 'total_qty', 'item_group', 'avg_rate', 'total_amount', 'voucher_type', 'voucher_no', 'voucher_detail_no', 'posting_date', 'posting_time', 'returned_against', 'is_cancelled', 'is_packed', 'is_rejected', 'amended_from']
    value = 99.0
  File "/home/runner/frappe-bench/apps/erpnext/erpnext/stock/serial_batch_bundle.py", line 1064, in validate_qty
    frappe.throw(msg, title=_("Insufficient Stock"))
    doc = <SerialandBatchBundle: doctype=Serial and Batch Bundle c637fa65336590876d25>
    msg = 'For the item <strong>b51e95d12f99dce1</strong>, the Available qty <strong>5.0</strong> is less than the Required Qty <strong>99.0</strong> in the warehouse <strong>_Test Warehouse - _TC</strong>. Please add sufficient qty in the warehouse.'
    precision = 3
    required_qty = 99.0
    self = <erpnext.stock.serial_batch_bundle.SerialBatchCreation object at 0x7ff1ab438b00>
    total_qty = 5.0
  File "/home/runner/frappe-bench/apps/frappe/frappe/utils/messages.py", line 145, in throw
    msgprint(
    as_list = False
    exc = <class 'frappe.exceptions.ValidationError'>
    is_minimizable = False
    msg = 'For the item <strong>b51e95d12f99dce1</strong>, the Available qty <strong>5.0</strong> is less than the Required Qty <strong>99.0</strong> in the warehouse <strong>_Test Warehouse - _TC</strong>. Please add sufficient qty in the warehouse.'
    primary_action = None
    title = 'Insufficient Stock'
    wide = False
  File "/home/runner/frappe-bench/apps/frappe/frappe/utils/messages.py", line 106, in msgprint
    _raise_exception()
    _raise_exception = <function msgprint.<locals>._raise_exception at 0x7ff1aa5ce340>
    alert = False
    as_list = False
    as_table = False
    indicator = 'red'
    inspect = <module 'inspect' from '/opt/hostedtoolcache/Python/3.12.10/x64/lib/python3.12/inspect.py'>
    is_minimizable = False
    msg = 'For the item <strong>b51e95d12f99dce1</strong>, the Available qty <strong>5.0</strong> is less than the Required Qty <strong>99.0</strong> in the warehouse <strong>_Test Warehouse - _TC</strong>. Please add sufficient qty in the warehouse.'
    out = {'message': 'For the item <strong>b51e95d12f99dce1</strong>, the Available qty <strong>5.0</strong> is less than the Required Qty <strong>99.0</strong> in the warehouse <strong>_Test Warehouse - _TC</strong>. Please add sufficient qty in the warehouse.', 'title': 'Insufficient Stock', 'indicator': 'red', 'raise_exception': 1, '__frappe_exc_id': '6375412afb2315adb9a4fe20d85fe6a82d3069b5efccbd1465c3c349'}
    primary_action = None
    raise_exception = <class 'frappe.exceptions.ValidationError'>
    realtime = False
    title = 'Insufficient Stock'
    wide = False
  File "/home/runner/frappe-bench/apps/frappe/frappe/utils/messages.py", line 57, in _raise_exception
    raise exc
    exc = ValidationError('For the item <strong>b51e95d12f99dce1</strong>, the Available qty <strong>5.0</strong> is less than the Required Qty <strong>99.0</strong> in the warehouse <strong>_Test Warehouse - _TC</strong>. Please add sufficient qty in the warehouse.')
    inspect = <module 'inspect' from '/opt/hostedtoolcache/Python/3.12.10/x64/lib/python3.12/inspect.py'>
    msg = 'For the item <strong>b51e95d12f99dce1</strong>, the Available qty <strong>5.0</strong> is less than the Required Qty <strong>99.0</strong> in the warehouse <strong>_Test Warehouse - _TC</strong>. Please add sufficient qty in the warehouse.'
    out = {'message': 'For the item <strong>b51e95d12f99dce1</strong>, the Available qty <strong>5.0</strong> is less than the Required Qty <strong>99.0</strong> in the warehouse <strong>_Test Warehouse - _TC</strong>. Please add sufficient qty in the warehouse.', 'title': 'Insufficient Stock', 'indicator': 'red', 'raise_exception': 1, '__frappe_exc_id': '6375412afb2315adb9a4fe20d85fe6a82d3069b5efccbd1465c3c349'}
    raise_exception = <class 'frappe.exceptions.ValidationError'>
frappe.exceptions.ValidationError: For the item <strong>b51e95d12f99dce1</strong>, the Available qty <strong>5.0</strong> is less than the Required Qty <strong>99.0</strong> in the warehouse <strong>_Test Warehouse - _TC</strong>. Please add sufficient qty in the warehouse.
```