### PR TITLE
fix: coa reset root_type on unchecking is_group on new_node

### DIFF
--- a/erpnext/accounts/doctype/account/account_tree.js
+++ b/erpnext/accounts/doctype/account/account_tree.js
@@ -139,6 +139,11 @@ frappe.treeview_settings["Account"] = {
 			description: __(
 				"Further accounts can be made under Groups, but entries can be made against non-Groups"
 			),
+			onchange: function () {
+				if (!this.value) {
+					this.layout.set_value("root_type", "");
+				}
+			},
 		},
 		{
 			fieldtype: "Select",


### PR DESCRIPTION
Issue: On the Chart of Accounts, if a user tries to create a new Account under Company, which should be a Group Account. However, while adding an Account using `New`, if a user checks `is_group` and selects a `root_type` and unchecks `is_group`, it doesn't clear the selection on `root_type`. So, it enables users to create a non-group account directly under the Company.


https://github.com/user-attachments/assets/2fce8902-9d39-4c67-b4e0-c7560e6ab7b9

Fixed:

https://github.com/user-attachments/assets/8109ce9d-6711-47dc-b2ad-46fdc14bfe68