### PR TITLE
fix: add validation for exchange gain/loss entries

### DIFF
--- a/erpnext/accounts/report/general_ledger/general_ledger.py
+++ b/erpnext/accounts/report/general_ledger/general_ledger.py
@@ -200,8 +200,7 @@ def get_gl_entries(filters, accounting_dimensions):
 			voucher_type, voucher_subtype, voucher_no, {dimension_fields}
 			cost_center, project, {transaction_currency_fields}
 			against_voucher_type, against_voucher, account_currency,
-			against, is_opening, creation {select_fields},
-			transaction_currency
+			against, is_opening, creation {select_fields}
 		from `tabGL Entry`
 		where company=%(company)s {get_conditions(filters)}
 		{order_by_statement}

--- a/erpnext/accounts/report/utils.py
+++ b/erpnext/accounts/report/utils.py
@@ -101,7 +101,6 @@ def convert_to_presentation_currency(gl_entries, currency_info):
 	account_currencies = list(set(entry["account_currency"] for entry in gl_entries))
 
 	for entry in gl_entries:
-		transaction_currency = entry.get("transaction_currency")
 		debit = flt(entry["debit"])
 		credit = flt(entry["credit"])
 		debit_in_account_currency = flt(entry["debit_in_account_currency"])
@@ -111,7 +110,7 @@ def convert_to_presentation_currency(gl_entries, currency_info):
 		if (
 			len(account_currencies) == 1
 			and account_currency == presentation_currency
-			and (transaction_currency is None or account_currency == transaction_currency)
+			and (debit_in_account_currency or credit_in_account_currency)
 		):
 			entry["debit"] = debit_in_account_currency
 			entry["credit"] = credit_in_account_currency


### PR DESCRIPTION
Issue: For a system posted exchange gain/loss entry the debit_in_account_curreny or credit_in_account_currency field won't be filled so when we filter that particular account in GL the debit credit showing as 0.

Ref: [#40683](https://support.frappe.io/helpdesk/tickets/40683)

Before:

https://github.com/user-attachments/assets/5a576c57-bd36-443e-b77c-198dfb20ec6c

After:

https://github.com/user-attachments/assets/0f882732-c448-4828-bb3a-e8085e962e75



Backport Needed: version-15