### PR TITLE
fix: incorrect pending qty when creating PI from PO and PI rates differ from PO

### DIFF
--- a/erpnext/buying/doctype/purchase_order/purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.py
@@ -831,11 +831,19 @@ def get_mapped_purchase_invoice(source_name, target_doc=None, ignore_permissions
 		target.credit_to = get_party_account("Supplier", source.supplier, source.company)
 
 	def update_item(obj, target, source_parent):
-		target.amount = flt(obj.amount) - flt(obj.billed_amt)
-		target.base_amount = target.amount * flt(source_parent.conversion_rate)
-		target.qty = (
-			target.amount / flt(obj.rate) if (flt(obj.rate) and flt(obj.billed_amt)) else flt(obj.qty)
-		)
+		def get_billed_qty(po_item_name):
+			from frappe.query_builder.functions import Sum
+
+			table = frappe.qb.DocType("Purchase Invoice Item")
+			query = (
+				frappe.qb.from_(table)
+				.select(Sum(table.qty).as_("qty"))
+				.where((table.docstatus == 1) & (table.po_detail == po_item_name))
+			)
+			return query.run(pluck="qty")[0] or 0
+
+		billed_qty = flt(get_billed_qty(obj.name))
+		target.qty = flt(obj.qty) - billed_qty
 
 		item = get_item_defaults(target.item_code, source_parent.company)
 		item_group = get_item_group_defaults(target.item_code, source_parent.company)

--- a/erpnext/buying/doctype/purchase_order/test_purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/test_purchase_order.py
@@ -1320,6 +1320,25 @@ class TestPurchaseOrder(IntegrationTestCase):
 		self.assertFalse(po.per_billed)
 		self.assertEqual(po.status, "To Receive and Bill")
 
+	@IntegrationTestCase.change_settings("Buying Settings", {"maintain_same_rate": 0})
+	def test_purchase_invoice_creation_with_partial_qty(self):
+		po = create_purchase_order(qty=100, rate=10)
+
+		pi = make_pi_from_po(po.name)
+		pi.items[0].qty = 42
+		pi.items[0].rate = 7.5
+		pi.submit()
+
+		pi = make_pi_from_po(po.name)
+		self.assertEqual(pi.items[0].qty, 58)
+		self.assertEqual(pi.items[0].rate, 10)
+		pi.items[0].qty = 8
+		pi.items[0].rate = 5
+		pi.submit()
+
+		pi = make_pi_from_po(po.name)
+		self.assertEqual(pi.items[0].qty, 50)
+
 
 def create_po_for_sc_testing():
 	from erpnext.controllers.tests.test_subcontracting_controller import (


### PR DESCRIPTION
Reference support ticket [41207](https://support.frappe.io/helpdesk/tickets/41207)

When creating Purchase Invoice from Purchase Order, the pending quantity was being calculated through the billed amount field. This created problems when rate in partial Purchase Invoice was different from rate in Purchase Order causing the pending quantity calculated to be incorrect.