### PR TITLE
feat(BOM): improve tree display with item_name and qty

### DIFF
--- a/erpnext/manufacturing/doctype/bom/bom.py
+++ b/erpnext/manufacturing/doctype/bom/bom.py
@@ -1329,7 +1329,7 @@ def get_children(parent=None, is_root=False, **filters):
 
 		bom_items = frappe.get_all(
 			"BOM Item",
-			fields=["item_code", "bom_no as value", "stock_qty"],
+			fields=["item_code", "bom_no as value", "stock_qty", "qty"],
 			filters=[["parent", "=", frappe.form_dict.parent]],
 			order_by="idx",
 		)

--- a/erpnext/manufacturing/doctype/bom/bom_tree.js
+++ b/erpnext/manufacturing/doctype/bom/bom_tree.js
@@ -16,7 +16,12 @@ frappe.treeview_settings["BOM"] = {
 	show_expand_all: false,
 	get_label: function (node) {
 		if (node.data.qty) {
-			return node.data.qty + " x " + node.data.item_code;
+			return `
+			<span style="font-weight: bold;">
+				${node.data.item_code}: ${node.data.item_name}
+			</span>
+			<span> — [${node.data.qty} ${node.data.stock_uom}]</span>
+			`;
 		} else {
 			return node.data.item_code || node.data.value;
 		}

--- a/erpnext/manufacturing/doctype/bom/bom_tree.js
+++ b/erpnext/manufacturing/doctype/bom/bom_tree.js
@@ -16,12 +16,14 @@ frappe.treeview_settings["BOM"] = {
 	show_expand_all: false,
 	get_label: function (node) {
 		if (node.data.qty) {
-			return `
-			<span style="font-weight: bold;">
-				${node.data.item_code}: ${node.data.item_name}
-			</span>
-			<span> — [${node.data.qty} ${node.data.stock_uom}]</span>
-			`;
+			const escape = frappe.utils.escape_html;
+			let label = escape(node.data.item_code);
+			if (node.data.item_name && node.data.item_code !== node.data.item_name) {
+				label += `: ${escape(node.data.item_name)}`;
+			}
+			return `${label} <span class="badge badge-pill badge-light">${node.data.qty} ${escape(
+				__(node.data.stock_uom)
+			)}</span>`;
 		} else {
 			return node.data.item_code || node.data.value;
 		}


### PR DESCRIPTION
# Problem
BOM Tree wasn't easy to make sense of, because _Item Name_ (and _Qty_) was missing.
See here:
![image](https://github.com/user-attachments/assets/8b8ed4f1-f8f3-49ae-97d0-9eac0d5f2fc8)

# Improvement
![Bildschirmfoto 2025-07-09 um 12 30 28](https://github.com/user-attachments/assets/8232feb4-73ed-44a8-b3b2-0149f25734a3)

No negative side effects were detected. All buttons ("Open Item", ...) and images still work fine.
