### PR TITLE
fix: add is_group filter for warehouse

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.js
+++ b/erpnext/selling/doctype/sales_order/sales_order.js
@@ -181,14 +181,20 @@ frappe.ui.form.on("Sales Order", {
 		}
 		erpnext.queries.setup_queries(frm, "Warehouse", function () {
 			return {
-				filters: [["Warehouse", "company", "in", ["", cstr(frm.doc.company)]]],
+				filters: [
+					["Warehouse", "company", "in", ["", cstr(frm.doc.company)]],
+					["Warehouse", "is_group", "=", 0],
+				],
 			};
 		});
 
 		frm.set_query("warehouse", "items", function (doc, cdt, cdn) {
 			let row = locals[cdt][cdn];
 			let query = {
-				filters: [["Warehouse", "company", "in", ["", cstr(frm.doc.company)]]],
+				filters: [
+					["Warehouse", "company", "in", ["", cstr(frm.doc.company)]],
+					["Warehouse", "is_group", "=", 0],
+				],
 			};
 			if (row.item_code) {
 				query.query = "erpnext.controllers.queries.warehouse_query";


### PR DESCRIPTION
Issue: 
In the Sales Order, the "Is Group Warehouse = No" filter is not applied, whereas it is available in the Delivery Note and Sales Invoice. Ideally, this filter should also be applied in the Sales Order

Ref: [41746](https://support.frappe.io/helpdesk/tickets/41746)

Before:

[before js change.webm](https://github.com/user-attachments/assets/bea918ec-61f4-4263-a2bb-54033b3986a1)

After:

[after js change.webm](https://github.com/user-attachments/assets/3da474b5-60e0-480c-8358-0eb8db5e6591)

Backport Needed: Version-15
