### PR TITLE
fix: get_conversion_factor return 0 if uom conversion factor not found

### DIFF
--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -1344,7 +1344,7 @@ def get_conversion_factor(item_code, uom):
 	if not conversion_factor:
 		conversion_factor = get_uom_conv_factor(uom, item.stock_uom)
 
-	return {"conversion_factor": conversion_factor or 1.0}
+	return {"conversion_factor": conversion_factor or 0}
 
 
 @frappe.whitelist()


### PR DESCRIPTION
`get_conversion_factor` should return 0 if the UOM Conversion Factor for the Item is not found.