### PR TITLE
fix: filter to validate existing item in Party Specific Item

### DIFF
--- a/erpnext/selling/doctype/party_specific_item/party_specific_item.py
+++ b/erpnext/selling/doctype/party_specific_item/party_specific_item.py
@@ -23,13 +23,13 @@ class PartySpecificItem(Document):
 
 	def validate(self):
 		exists = frappe.db.exists(
+			"Party Specific Item",
 			{
-				"doctype": "Party Specific Item",
 				"party_type": self.party_type,
 				"party": self.party,
 				"restrict_based_on": self.restrict_based_on,
-				"based_on": self.based_on_value,
-			}
+				"based_on_value": self.based_on_value,
+			},
 		)
 		if exists:
 			frappe.throw(_("This item filter has already been applied for the {0}").format(self.party_type))


### PR DESCRIPTION
## Reason
- Items with same filters can be created multiple times in Party Specific item instead of existing record checked in validate function

## Changes Done
- Update the fieldname `based_on` to `based_on_value` as it is in doctype and remove doctype outside the filter

`no-docs`

Closes: #48074