### PR TITLE
feat: Display Item Name in items table shown while creating Work order from Sales Order

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.js
+++ b/erpnext/selling/doctype/sales_order/sales_order.js
@@ -834,6 +834,12 @@ erpnext.selling.SalesOrderController = class SalesOrderController extends erpnex
 									in_list_view: 1,
 								},
 								{
+									fieldtype: "Read Only",
+									fieldname: "item_name",
+									label: __("Item Name"),
+									in_list_view: 1,
+								},
+								{
 									fieldtype: "Link",
 									fieldname: "bom",
 									options: "BOM",

--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -1852,6 +1852,7 @@ def get_work_order_items(sales_order, for_raw_material_request=0):
 						dict(
 							name=i.name,
 							item_code=i.item_code,
+							item_name=i.item_name,
 							description=i.description,
 							bom=bom or "",
 							warehouse=i.warehouse,


### PR DESCRIPTION
## Reason
- When a work order is created from sales order, the items table shown in dialog doesn't show item name which makes difficulty for user to identify which item it is.

## Changes
- Get the item name also from the items table of sales order in items to be shown in dialog box for which work order will be created

![image](https://github.com/user-attachments/assets/8e038a23-7129-4f6a-bc10-4f07d418f8a4)

`no-docs`

Closes: #41602
