### PR TITLE
fix: Bug: get_product_discount_rule raises AttributeError when doc is None in recursive pricing rule scenario (Issue #48055)

### DIFF
--- a/erpnext/accounts/doctype/pricing_rule/utils.py
+++ b/erpnext/accounts/doctype/pricing_rule/utils.py
@@ -658,7 +658,7 @@ def get_product_discount_rule(pricing_rule, item_details, args=None, doc=None):
 				if not row.is_free_item
 				and row.item_code == args.item_code
 				and row.pricing_rules == args.pricing_rules
-			]
+			] if doc and doc.get('items') else [0]
 		)
 		transaction_qty = transaction_qty - pricing_rule.apply_recursion_over
 		if transaction_qty and transaction_qty > 0:


### PR DESCRIPTION
When using a pricing rule with recursive is true, and trying to add item which has pricing rule then an error occured. But is_recursive property is setted as false then it run properly. the problem is that 
**def get_product_discount_rule(pricing_rule, item_details, args=None, doc=None):** method in **erpnext/erpnext/accounts/doctype/pricing_rule/utils.py** file has called **doc** parameter which can be nullable. but in this method on line 657 doc parameter is used without checking that is it none or not. so error occur here. Fixed and changed code some little
```python
transaction_qty = sum(
            [
                row.qty
                for row in doc.items
                if not row.is_free_item
                and row.item_code == args.item_code
                and row.pricing_rules == args.pricing_rules
            ] if doc and doc.get('items') else [0]
        )
```
added this code **if doc and doc.get('items') else [0]** on line 661