### PR TITLE
fix: Item Tax Template rate is ignored — both backend and frontend in…(issue 48211)

### DIFF
--- a/erpnext/public/js/controllers/taxes_and_totals.js
+++ b/erpnext/public/js/controllers/taxes_and_totals.js
@@ -335,7 +335,7 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 					let child = frappe.model.add_child(me.frm.doc, "taxes");
 					child.charge_type = "On Net Total";
 					child.account_head = tax;
-					child.rate = 0;
+					child.rate = rate;
 					child.set_by_item_tax_template = true;
 				}
 			});

--- a/erpnext/utilities/transaction_base.py
+++ b/erpnext/utilities/transaction_base.py
@@ -361,7 +361,7 @@ class TransactionBase(StatusUpdater):
 			for tax_head, _rate in item_tax_template.items():
 				found = [x for x in self.taxes if x.account_head == tax_head]
 				if not found:
-					self.append("taxes", {"charge_type": "On Net Total", "account_head": tax_head, "rate": 0})
+					self.append("taxes", {"charge_type": "On Net Total", "account_head": tax_head, "rate": _rate})
 
 	def set_rate_based_on_price_list(self, item_obj: object, item_details: dict) -> None:
 		if item_obj.price_list_rate and item_obj.discount_percentage:


### PR DESCRIPTION
### Description
When an Item has a predefined Item Tax Template, and it is added to a Sales Order, ERPNext correctly adds the related tax account_head into the Sales Order’s taxes list. However, the corresponding tax rate is always set to 0, even though the correct rate exists in item_tax_rate, which is present in the document data passed from the frontend.

### ✅ Expected Behavior
The tax rate defined in the item's tax template (and found in item_tax_rate) should be used to populate the rate field in the taxes list of the Sales Order.

### 🐛 Related Frontend Bug: Tax rate hardcoded as 0 in JS controller
In addition to the server-side issue, there's also a similar bug in the frontend code:

**File:** erpnext/public/js/controllers/taxes_and_totals.js
**Function:** add_taxes_from_item_tax_template