### PR TITLE
fix: Update Qty on Bin doctype

### DIFF
--- a/erpnext/stock/doctype/bin/bin.py
+++ b/erpnext/stock/doctype/bin/bin.py
@@ -239,6 +239,11 @@ def on_doctype_update():
 
 
 def get_bin_details(bin_name):
+	bin_details = frappe.get_doc("Bin", bin_name)
+	if bin_details:
+		# recalculate qty for the latest values
+		bin_details.recalculate_qty()
+
 	return frappe.db.get_value(
 		"Bin",
 		bin_name,


### PR DESCRIPTION
This issue relate to this forum [Is there a bug in Bin](https://discuss.frappe.io/t/is-there-a-bug-in-bin/137215)

In my step to this issue following
1. on Bin doctype item below has actual Qty 150
![Selection_515](https://github.com/user-attachments/assets/8015bbbb-73bd-4e45-bea6-b20666bc3222)

2. Create **purchase receipt** for receive **item 10 unit** into warehosue **051 - Mega - P** and click Submit
![Selection_516](https://github.com/user-attachments/assets/866d463e-a117-41dd-80f3-7ece616d45ff)

3. Refresh bin doctype, on actual qty it should display 160 but it still 150 and I have to click **Recalculate Bin Qty**
![Selection_517](https://github.com/user-attachments/assets/32fee05a-7e4a-4dcf-90d4-241009fa42c3)

So IMHO we should recalculate qty first before update Qty
or have any suggestion to fix this issue?
