### PR TITLE
fix: update salvage value after value adjustment

### DIFF
--- a/erpnext/assets/doctype/asset_value_adjustment/asset_value_adjustment.py
+++ b/erpnext/assets/doctype/asset_value_adjustment/asset_value_adjustment.py
@@ -180,12 +180,21 @@ class AssetValueAdjustment(Document):
 		if asset.calculate_depreciation:
 			for row in asset.finance_books:
 				if cstr(row.finance_book) == cstr(self.finance_book):
-					row.value_after_depreciation += flt(difference_amount)
+					salvage_value_adjustment = (
+						self.get_adjusted_salvage_value_amount(row, difference_amount) or 0
+					)
+					row.expected_value_after_useful_life += salvage_value_adjustment
+					row.value_after_depreciation = row.value_after_depreciation + flt(difference_amount)
 					row.db_update()
 
 		asset.value_after_depreciation += flt(difference_amount)
 		asset.db_update()
 		return asset
+
+	def get_adjusted_salvage_value_amount(self, row, difference_amount):
+		if row.expected_value_after_useful_life:
+			salvage_value_adjustment = (difference_amount * row.salvage_value_percentage) / 100
+			return flt(salvage_value_adjustment)
 
 	def get_adjustment_note(self):
 		if self.docstatus == 1:

--- a/erpnext/assets/doctype/asset_value_adjustment/test_asset_value_adjustment.py
+++ b/erpnext/assets/doctype/asset_value_adjustment/test_asset_value_adjustment.py
@@ -299,6 +299,43 @@ class TestAssetValueAdjustment(IntegrationTestCase):
 		asset_doc.load_from_db()
 		self.assertEqual(asset_doc.finance_books[0].value_after_depreciation, 40000.0)
 
+	def test_expected_value_after_useful_life(self):
+		pr = make_purchase_receipt(item_code="Macbook Pro", qty=1, rate=100000.0, location="Test Location")
+
+		asset_name = frappe.db.get_value("Asset", {"purchase_receipt": pr.name}, "name")
+		asset_doc = frappe.get_doc("Asset", asset_name)
+		asset_doc.calculate_depreciation = 1
+		asset_doc.available_for_use_date = "2023-01-15"
+		asset_doc.purchase_date = "2023-01-15"
+
+		asset_doc.append(
+			"finance_books",
+			{
+				"expected_value_after_useful_life": 5000,
+				"salvage_value_percentage": 5,
+				"depreciation_method": "Straight Line",
+				"total_number_of_depreciations": 12,
+				"frequency_of_depreciation": 1,
+				"depreciation_start_date": "2023-01-31",
+			},
+		)
+		asset_doc.submit()
+		self.assertEqual(asset_doc.finance_books[0].expected_value_after_useful_life, 5000.0)
+
+		current_asset_value = get_asset_value_after_depreciation(asset_doc.name)
+		adj_doc = make_asset_value_adjustment(
+			asset=asset_doc.name,
+			current_asset_value=current_asset_value,
+			new_asset_value=40000,
+			date="2023-08-21",
+		)
+		adj_doc.submit()
+		difference_amount = adj_doc.new_asset_value - adj_doc.current_asset_value
+		self.assertEqual(difference_amount, -60000)
+		asset_doc.load_from_db()
+		self.assertEqual(asset_doc.finance_books[0].value_after_depreciation, 40000.0)
+		self.assertEqual(asset_doc.finance_books[0].expected_value_after_useful_life, 2000.0)
+
 
 def make_asset_value_adjustment(**args):
 	args = frappe._dict(args)


### PR DESCRIPTION
Issue
When an asset value adjustment entry is created to increase the asset's value (for example, from ₹100 to ₹150), the expected value after useful life was not getting updated. It continued to use the original asset value to calculate salvage value, which resulted in incorrect data.

Fix
The logic has been updated to calculate the salvage value based on the adjusted asset value. For example, if the salvage percentage is 10%, it will now correctly calculate 10% of ₹150 (adjusted value) instead of the original ₹100.

Internal support ticket: https://support.frappe.io/helpdesk/tickets/41203