### PR TITLE
fix: use gain_loss_posting_date instead of today

### DIFF
--- a/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py
+++ b/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py
@@ -826,7 +826,7 @@ def reconcile_dr_cr_note(dr_cr_notes, company, active_dimensions=None):
 
 			create_gain_loss_journal(
 				company,
-				today(),
+				inv.difference_posting_date,
 				inv.party_type,
 				inv.party,
 				inv.account,


### PR DESCRIPTION
Issue: When payment reconciliation is done for a debit or credit note, the Journal Entry for exchange gain/loss uses the current date instead of the gain_loss_posting_date  posting date.

Ref: [#41692](https://support.frappe.io/helpdesk/tickets/41692)

Before:

https://github.com/user-attachments/assets/61d71858-9d25-4d16-9429-ac21f05b96c3

After:

https://github.com/user-attachments/assets/f3e4a09e-58db-44b2-94be-fa60c5481d5c

Backport needed: v15
