### PR TITLE
fix: fixed translation on inter sales and purchase buttons

### DIFF
--- a/erpnext/buying/doctype/purchase_order/purchase_order.js
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.js
@@ -464,8 +464,8 @@ erpnext.buying.PurchaseOrderController = class PurchaseOrderController extends (
 						if (internal) {
 							let button_label =
 								me.frm.doc.company === me.frm.doc.represents_company
-									? "Internal Sales Order"
-									: "Inter Company Sales Order";
+										? __("Internal Sales Order")
+										: __("Inter Company Sales Order");
 
 							me.frm.add_custom_button(
 								button_label,

--- a/erpnext/selling/doctype/sales_order/sales_order.js
+++ b/erpnext/selling/doctype/sales_order/sales_order.js
@@ -732,8 +732,8 @@ erpnext.selling.SalesOrderController = class SalesOrderController extends erpnex
 						if (internal) {
 							let button_label =
 								me.frm.doc.company === me.frm.doc.represents_company
-									? "Internal Purchase Order"
-									: "Inter Company Purchase Order";
+									? __("Internal Purchase Order")
+									: __("Inter Company Purchase Order");
 
 							me.frm.add_custom_button(
 								button_label,


### PR DESCRIPTION
> Please provide enough information so that others can review your pull request:

Buttons for Internal Sales Orders/Internal Purchase Orders and Inter Company Sales Order/Inter Company Purchase Order were missing translations because strings were missing function: __()

> Explain the details for making this change. What existing problem does the pull request solve?

Fixes issue #47519 

