### PR TITLE
fix: customer_group import from lead to customer

### DIFF
--- a/erpnext/crm/doctype/lead/lead.py
+++ b/erpnext/crm/doctype/lead/lead.py
@@ -327,7 +327,8 @@ def _make_customer(source_name, target_doc=None, ignore_permissions=False):
 			target.customer_type = "Individual"
 			target.customer_name = source.lead_name
 
-		target.customer_group = frappe.db.get_default("Customer Group")
+		if not target.customer_group:
+			target.customer_group = frappe.db.get_default("Customer Group")
 
 		address = get_default_address("Lead", source.name)
 		contact = get_default_contact("Lead", source.name)


### PR DESCRIPTION
In case customization happens and the lead has the field "customer_group", the get_mapped_doc function would fail and be overwritten by the default value.

Please backport to v15