### PR TITLE
fix: use company default currency in amount_eligible_for_commission

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.json
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.json
@@ -1997,6 +1997,7 @@
    "fieldname": "amount_eligible_for_commission",
    "fieldtype": "Currency",
    "label": "Amount Eligible for Commission",
+   "options": "Company:company:default_currency",
    "read_only": 1
   },
   {
@@ -2231,7 +2232,7 @@
    "link_fieldname": "consolidated_invoice"
   }
  ],
- "modified": "2025-03-17 19:32:31.809658",
+ "modified": "2025-06-26 14:06:56.773552",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Sales Invoice",


### PR DESCRIPTION
Issue: Wrong Currency For Amount Eligible for Commission

Ref: [ #41980](https://support.frappe.io/helpdesk/tickets/41980)

Before:

https://github.com/user-attachments/assets/7e7d246c-da86-4c64-a4db-7b0ce9519e20

After:


https://github.com/user-attachments/assets/43803baa-7ae0-47e1-89b7-5d6242938aee

Backport needed: v15
