### PR TITLE
fix: not able to save material request

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -1138,6 +1138,10 @@ class AccountsController(TransactionBase):
 			return True
 
 	def set_taxes_and_charges(self):
+		if self.doctype == "Material Request":
+			# Material Request does not have taxes
+			return
+
 		if self.get("taxes") or self.get("is_pos"):
 			return
 


### PR DESCRIPTION
<img width="1016" alt="Screenshot 2025-06-27 at 4 06 08 PM" src="https://github.com/user-attachments/assets/d79c26e6-6d7a-48f8-b641-dfdc6211d605" />


```
  File "apps/erpnext/erpnext/controllers/buying_controller.py", line 33, in validate
    super().validate()
  File "apps/erpnext/erpnext/controllers/subcontracting_controller.py", line 56, in validate
    super().validate()
  File "apps/erpnext/erpnext/controllers/stock_controller.py", line 52, in validate
    super().validate()
  File "apps/erpnext/erpnext/controllers/accounts_controller.py", line 248, in validate
    self.set_taxes_and_charges()
  File "apps/erpnext/erpnext/controllers/accounts_controller.py", line 1147, in set_taxes_and_charges
    self.append_taxes_from_item_tax_template()
  File "apps/erpnext/erpnext/controllers/accounts_controller.py", line 1169, in append_taxes_from_item_tax_template
    row = self.get_tax_row(account_head)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/erpnext/erpnext/controllers/accounts_controller.py", line 1186, in get_tax_row
    for row in self.taxes:
               ^^^^^^^^^^
AttributeError: 'MaterialRequest' object has no attribute 'taxes'
```