### PR TITLE
fix: default UOMs by new Stock Entry created by Stock Level section button (when Item is batch or serial)

### DIFF
--- a/erpnext/stock/dashboard/item_dashboard.js
+++ b/erpnext/stock/dashboard/item_dashboard.js
@@ -51,7 +51,7 @@ erpnext.stock.ItemDashboard = class ItemDashboard {
 			let stock_uom = unescape(element.attr("data-stock-uom"));
 
 			if (disable_quick_entry) {
-				open_stock_entry(item, warehouse, entry_type);
+				open_stock_entry(item, warehouse, entry_type, stock_uom);
 			} else {
 				if (action === "Add") {
 					let rate = unescape($(this).attr("data-rate"));
@@ -66,7 +66,7 @@ erpnext.stock.ItemDashboard = class ItemDashboard {
 			}
 		}
 
-		function open_stock_entry(item, warehouse, entry_type) {
+		function open_stock_entry(item, warehouse, entry_type, stock_uom) {
 			frappe.model.with_doctype("Stock Entry", function () {
 				var doc = frappe.model.get_new_doc("Stock Entry");
 				if (entry_type) {
@@ -75,6 +75,9 @@ erpnext.stock.ItemDashboard = class ItemDashboard {
 
 				var row = frappe.model.add_child(doc, "items");
 				row.item_code = item;
+				row.uom = stock_uom;
+				row.stock_uom = stock_uom;
+				row.conversion_factor = 1;
 
 				if (entry_type === "Material Transfer") {
 					row.s_warehouse = warehouse;


### PR DESCRIPTION
Issue:
Default UOM/Stock UOM on stock entry from Item dashboard (stock level section) button Move or Add

Ref: [42326](https://support.frappe.io/helpdesk/tickets/42326)

Before:

https://github.com/user-attachments/assets/d020216e-d948-4690-a97e-f729ee136a35


After:

https://github.com/user-attachments/assets/d9d46c9b-0d2f-4e87-95a6-56b3597e9c50


Note to reviewers :
If merged, please add github label to backport to version-15

