### PR TITLE
Update Active Employee Filter in Job Card and Time Log

### DIFF
--- a/erpnext/manufacturing/doctype/job_card/job_card.js
+++ b/erpnext/manufacturing/doctype/job_card/job_card.js
@@ -30,6 +30,21 @@ frappe.ui.form.on("Job Card", {
 				return doc.status === "Complete" ? "green" : "orange";
 			}
 		});
+		
+		frm.set_query("employee", () => ({
+			filters: {
+				status: "Active"
+			}
+		}));
+
+		frm.set_query("employee", "time_logs", function (doc, cdt, cdn) {
+			const row = locals[cdt][cdn];
+			return {
+				filters: {
+					status: "Active"
+				}
+			};
+		});	
 	},
 
 	make_fields_read_only(frm) {

--- a/erpnext/manufacturing/doctype/job_card/job_card.js
+++ b/erpnext/manufacturing/doctype/job_card/job_card.js
@@ -30,21 +30,21 @@ frappe.ui.form.on("Job Card", {
 				return doc.status === "Complete" ? "green" : "orange";
 			}
 		});
-		
+
 		frm.set_query("employee", () => ({
 			filters: {
-				status: "Active"
-			}
+				status: "Active",
+			},
 		}));
 
 		frm.set_query("employee", "time_logs", function (doc, cdt, cdn) {
 			const row = locals[cdt][cdn];
 			return {
 				filters: {
-					status: "Active"
-				}
+					status: "Active",
+				},
 			};
-		});	
+		});
 	},
 
 	make_fields_read_only(frm) {


### PR DESCRIPTION
This PR fixes Issue #48301 by applying an active employee filter in the Job Card form.
The employee field in the main Job Card now only allows selection of employees with status = "Active".
The employee field inside the Time Log child table is also filtered to show only active employees.
This ensures that only currently active employees can be assigned to manufacturing tasks.