### PR TITLE
fix: fetch item tax template after setting `base_net_rate`

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -42,6 +42,10 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 			}
 			item.base_rate_with_margin = item.rate_with_margin * flt(frm.doc.conversion_rate);
 
+			cur_frm.cscript.set_gross_profit(item);
+			cur_frm.cscript.calculate_taxes_and_totals();
+			cur_frm.cscript.calculate_stock_uom_rate(frm, cdt, cdn);
+
 			if (item.item_code && item.rate) {
 				frappe.call({
 					method: "erpnext.stock.get_item_details.get_item_tax_template",
@@ -63,10 +67,6 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 					}
 				});
 			}
-
-			cur_frm.cscript.set_gross_profit(item);
-			cur_frm.cscript.calculate_taxes_and_totals();
-			cur_frm.cscript.calculate_stock_uom_rate(frm, cdt, cdn);
 		});
 
 		frappe.ui.form.on(this.frm.cscript.tax_table, "rate", function(frm, cdt, cdn) {


### PR DESCRIPTION
Issue: Incorrect Item Tax Template is being fetched because previous base_net_rate is passed in args.





![image](https://github.com/user-attachments/assets/6c5b083e-7e6b-4b70-b439-dec2fac947e8)

Before:

https://github.com/user-attachments/assets/c3e4bd23-8215-459a-a7d9-25dd9db8ae36

After:

https://github.com/user-attachments/assets/9e606450-386c-4db6-b20d-e8f832148c85

Frappe Support Issue: https://support.frappe.io/app/hd-ticket/41524



