### PR TITLE
fix: update payment request outstanding on unreconciliation

### DIFF
--- a/erpnext/accounts/doctype/payment_request/payment_request.py
+++ b/erpnext/accounts/doctype/payment_request/payment_request.py
@@ -826,8 +826,7 @@ def update_payment_requests_as_per_pe_references(references=None, cancel=False):
 	if not references:
 		return
 
-	precision = references[0].precision("allocated_amount")
-
+	precision = frappe.get_precision("Payment Entry Reference", "allocated_amount")
 	referenced_payment_requests = frappe.get_all(
 		"Payment Request",
 		filters={"name": ["in", {row.payment_request for row in references if row.payment_request}]},

--- a/erpnext/accounts/doctype/payment_request/test_payment_request.py
+++ b/erpnext/accounts/doctype/payment_request/test_payment_request.py
@@ -813,3 +813,27 @@ class TestPaymentRequest(IntegrationTestCase):
 		pi.load_from_db()
 		pr = make_payment_request(dt="Purchase Invoice", dn=pi.name, mute_email=1)
 		self.assertEqual(pr.grand_total, pi.outstanding_amount)
+
+	def test_payment_request_on_unreconcile(self):
+		pi = make_purchase_invoice(currency="INR", qty=1, rate=500)
+		pi.submit()
+
+		pr = make_payment_request(dt="Purchase Invoice", dn=pi.name, mute_email=1)
+		self.assertEqual(pr.grand_total, pi.outstanding_amount)
+
+		pe = pr.create_payment_entry()
+		unreconcile = frappe.get_doc(
+			{
+				"doctype": "Unreconcile Payment",
+				"company": pe.company,
+				"voucher_type": pe.doctype,
+				"voucher_no": pe.name,
+			}
+		)
+		unreconcile.add_references()
+		unreconcile.submit()
+
+		pi.load_from_db()
+		pr.load_from_db()
+
+		self.assertEqual(pr.grand_total, pi.outstanding_amount)

--- a/erpnext/accounts/doctype/payment_request/test_payment_request.py
+++ b/erpnext/accounts/doctype/payment_request/test_payment_request.py
@@ -818,7 +818,13 @@ class TestPaymentRequest(IntegrationTestCase):
 		pi = make_purchase_invoice(currency="INR", qty=1, rate=500)
 		pi.submit()
 
-		pr = make_payment_request(dt="Purchase Invoice", dn=pi.name, mute_email=1)
+		pr = make_payment_request(
+			dt=pi.doctype,
+			dn=pi.name,
+			mute_email=1,
+			submit_doc=True,
+			return_doc=True,
+		)
 		self.assertEqual(pr.grand_total, pi.outstanding_amount)
 
 		pe = pr.create_payment_entry()


### PR DESCRIPTION
Issue: On unreconciliation of payment entry, where the payment request is set, the outstanding amount inthe Payment Request is not updating.

Steps to replicate:
- Create a Purchase invoice
- Create a payment request against it.
- Create the payment entry against the payment request.
- Unreconcile the payment entry.

The outstanding amount in the payment request will not get updated after unreconciliation.

Frappe Support Issue: https://support.frappe.io/app/hd-ticket/41005