### PR TITLE
fix: make labels in error message translatable

### DIFF
--- a/erpnext/accounts/doctype/accounts_settings/accounts_settings.py
+++ b/erpnext/accounts/doctype/accounts_settings/accounts_settings.py
@@ -149,8 +149,8 @@ class AccountsSettings(Document):
 		if self.add_taxes_from_item_tax_template and self.add_taxes_from_taxes_and_charges_template:
 			frappe.throw(
 				_("You cannot enable both the settings '{0}' and '{1}'.").format(
-					frappe.bold(self.meta.get_label("add_taxes_from_item_tax_template")),
-					frappe.bold(self.meta.get_label("add_taxes_from_taxes_and_charges_template")),
+					frappe.bold(_(self.meta.get_label("add_taxes_from_item_tax_template"))),
+					frappe.bold(_(self.meta.get_label("add_taxes_from_taxes_and_charges_template"))),
 				),
 				title=_("Auto Tax Settings Error"),
 			)

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -639,7 +639,7 @@ class PaymentEntry(AccountsController):
 	def validate_mandatory(self):
 		for field in ("paid_amount", "received_amount", "source_exchange_rate", "target_exchange_rate"):
 			if not self.get(field):
-				frappe.throw(_("{0} is mandatory").format(self.meta.get_label(field)))
+				frappe.throw(_("{0} is mandatory").format(_(self.meta.get_label(field))))
 
 	def validate_reference_documents(self):
 		valid_reference_doctypes = self.get_valid_reference_doctypes()

--- a/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py
+++ b/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py
@@ -589,7 +589,7 @@ class PaymentReconciliation(Document):
 	def check_mandatory_to_fetch(self):
 		for fieldname in ["company", "party_type", "party", "receivable_payable_account"]:
 			if not self.get(fieldname):
-				frappe.throw(_("Please select {0} first").format(self.meta.get_label(fieldname)))
+				frappe.throw(_("Please select {0} first").format(_(self.meta.get_label(fieldname))))
 
 	def validate_entries(self):
 		if not self.get("invoices"):

--- a/erpnext/accounts/doctype/pricing_rule/pricing_rule.py
+++ b/erpnext/accounts/doctype/pricing_rule/pricing_rule.py
@@ -169,7 +169,7 @@ class PricingRule(Document):
 
 		tocheck = frappe.scrub(self.get("applicable_for", ""))
 		if tocheck and not self.get(tocheck):
-			throw(_("{0} is required").format(self.meta.get_label(tocheck)), frappe.MandatoryError)
+			throw(_("{0} is required").format(_(self.meta.get_label(tocheck))), frappe.MandatoryError)
 
 		if self.apply_rule_on_other:
 			o_field = "other_" + frappe.scrub(self.apply_rule_on_other)

--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -179,7 +179,7 @@ def validate_fiscal_year(date, fiscal_year, company, label="Date", doc=None):
 		if doc:
 			doc.fiscal_year = years[0]
 		else:
-			throw(_("{0} '{1}' not in Fiscal Year {2}").format(label, formatdate(date), fiscal_year))
+			throw(_("{0} '{1}' not in Fiscal Year {2}").format(_(label), formatdate(date), fiscal_year))
 
 
 @frappe.whitelist()

--- a/erpnext/manufacturing/doctype/bom/bom.py
+++ b/erpnext/manufacturing/doctype/bom/bom.py
@@ -1037,7 +1037,7 @@ class BOM(WebsiteGenerator):
 			self.transfer_material_against = "Work Order"
 		if not self.transfer_material_against and not self.is_new():
 			frappe.throw(
-				_("Setting {} is required").format(self.meta.get_label("transfer_material_against")),
+				_("Setting {0} is required").format(_(self.meta.get_label("transfer_material_against"))),
 				title=_("Missing value"),
 			)
 

--- a/erpnext/manufacturing/doctype/work_order/work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/work_order.py
@@ -461,7 +461,7 @@ class WorkOrder(Document):
 			if qty > completed_qty:
 				frappe.throw(
 					_("{0} ({1}) cannot be greater than planned quantity ({2}) in Work Order {3}").format(
-						self.meta.get_label(fieldname), qty, completed_qty, self.name
+						_(self.meta.get_label(fieldname)), qty, completed_qty, self.name
 					),
 					StockOverProductionError,
 				)
@@ -1177,7 +1177,7 @@ class WorkOrder(Document):
 			self.transfer_material_against = "Work Order"
 		if not self.transfer_material_against:
 			frappe.throw(
-				_("Setting {} is required").format(self.meta.get_label("transfer_material_against")),
+				_("Setting {0} is required").format(_(self.meta.get_label("transfer_material_against"))),
 				title=_("Missing value"),
 			)
 

--- a/erpnext/setup/doctype/email_digest/email_digest.py
+++ b/erpnext/setup/doctype/email_digest/email_digest.py
@@ -395,7 +395,7 @@ class EmailDigest(Document):
 
 		label = get_link_to_report(
 			"General Ledger",
-			self.meta.get_label("income"),
+			_(self.meta.get_label("income")),
 			filters={
 				"from_date": self.future_from_date,
 				"to_date": self.future_to_date,
@@ -427,7 +427,7 @@ class EmailDigest(Document):
 			filters = {"currency": self.currency}
 			label = get_link_to_report(
 				"Profit and Loss Statement",
-				label=self.meta.get_label(root_type + "_year_to_date"),
+				label=_(self.meta.get_label(root_type + "_year_to_date")),
 				filters=filters,
 			)
 
@@ -435,7 +435,7 @@ class EmailDigest(Document):
 			filters = {"currency": self.currency}
 			label = get_link_to_report(
 				"Profit and Loss Statement",
-				label=self.meta.get_label(root_type + "_year_to_date"),
+				label=_(self.meta.get_label(root_type + "_year_to_date")),
 				filters=filters,
 			)
 
@@ -466,7 +466,7 @@ class EmailDigest(Document):
 
 		label = get_link_to_report(
 			"General Ledger",
-			self.meta.get_label("expenses_booked"),
+			_(self.meta.get_label("expenses_booked")),
 			filters={
 				"company": self.company,
 				"from_date": self.future_from_date,
@@ -500,7 +500,7 @@ class EmailDigest(Document):
 
 		label = get_link_to_report(
 			"Sales Order",
-			label=self.meta.get_label("sales_orders_to_bill"),
+			label=_(self.meta.get_label("sales_orders_to_bill")),
 			report_type="Report Builder",
 			doctype="Sales Order",
 			filters={
@@ -526,7 +526,7 @@ class EmailDigest(Document):
 
 		label = get_link_to_report(
 			"Sales Order",
-			label=self.meta.get_label("sales_orders_to_deliver"),
+			label=_(self.meta.get_label("sales_orders_to_deliver")),
 			report_type="Report Builder",
 			doctype="Sales Order",
 			filters={
@@ -552,7 +552,7 @@ class EmailDigest(Document):
 
 		label = get_link_to_report(
 			"Purchase Order",
-			label=self.meta.get_label("purchase_orders_to_receive"),
+			label=_(self.meta.get_label("purchase_orders_to_receive")),
 			report_type="Report Builder",
 			doctype="Purchase Order",
 			filters={
@@ -578,7 +578,7 @@ class EmailDigest(Document):
 
 		label = get_link_to_report(
 			"Purchase Order",
-			label=self.meta.get_label("purchase_orders_to_bill"),
+			label=_(self.meta.get_label("purchase_orders_to_bill")),
 			report_type="Report Builder",
 			doctype="Purchase Order",
 			filters={
@@ -630,7 +630,7 @@ class EmailDigest(Document):
 					"company": self.company,
 				}
 				label = get_link_to_report(
-					"Account Balance", label=self.meta.get_label(fieldname), filters=filters
+					"Account Balance", label=_(self.meta.get_label(fieldname)), filters=filters
 				)
 			else:
 				filters = {
@@ -640,7 +640,7 @@ class EmailDigest(Document):
 					"company": self.company,
 				}
 				label = get_link_to_report(
-					"Account Balance", label=self.meta.get_label(fieldname), filters=filters
+					"Account Balance", label=_(self.meta.get_label(fieldname)), filters=filters
 				)
 
 			return {"label": label, "value": balance, "last_value": prev_balance}
@@ -648,17 +648,17 @@ class EmailDigest(Document):
 			if account_type == "Payable":
 				label = get_link_to_report(
 					"Accounts Payable",
-					label=self.meta.get_label(fieldname),
+					label=_(self.meta.get_label(fieldname)),
 					filters={"report_date": self.future_to_date, "company": self.company},
 				)
 			elif account_type == "Receivable":
 				label = get_link_to_report(
 					"Accounts Receivable",
-					label=self.meta.get_label(fieldname),
+					label=_(self.meta.get_label(fieldname)),
 					filters={"report_date": self.future_to_date, "company": self.company},
 				)
 			else:
-				label = self.meta.get_label(fieldname)
+				label = _(self.meta.get_label(fieldname))
 
 			return {"label": label, "value": balance, "last_value": prev_balance, "count": count}
 
@@ -748,7 +748,7 @@ class EmailDigest(Document):
 
 		label = get_link_to_report(
 			"Quotation",
-			label=self.meta.get_label(fieldname),
+			label=_(self.meta.get_label(fieldname)),
 			report_type="Report Builder",
 			doctype="Quotation",
 			filters={
@@ -779,7 +779,7 @@ class EmailDigest(Document):
 
 		label = get_link_to_report(
 			doc_type,
-			label=self.meta.get_label(fieldname),
+			label=_(self.meta.get_label(fieldname)),
 			report_type="Report Builder",
 			filters=filters,
 			doctype=doc_type,

--- a/erpnext/stock/doctype/item/item.py
+++ b/erpnext/stock/doctype/item/item.py
@@ -638,7 +638,7 @@ class Item(Document):
 
 		if new_properties != [cstr(self.get(field)) for field in field_list]:
 			msg = _("To merge, following properties must be same for both items")
-			msg += ": \n" + ", ".join([self.meta.get_label(fld) for fld in field_list])
+			msg += ": \n" + ", ".join([_(self.meta.get_label(fld)) for fld in field_list])
 			frappe.throw(msg, title=_("Cannot Merge"), exc=DataValidationError)
 
 	def validate_duplicate_product_bundles_before_merge(self, old_name, new_name):
@@ -977,7 +977,7 @@ class Item(Document):
 			return
 
 		if linked_doc := self._get_linked_submitted_documents(changed_fields):
-			changed_field_labels = [frappe.bold(self.meta.get_label(f)) for f in changed_fields]
+			changed_field_labels = [frappe.bold(_(self.meta.get_label(f))) for f in changed_fields]
 			msg = _(
 				"As there are existing submitted transactions against item {0}, you can not change the value of {1}."
 			).format(self.name, ", ".join(changed_field_labels))

--- a/erpnext/stock/doctype/stock_ledger_entry/stock_ledger_entry.py
+++ b/erpnext/stock/doctype/stock_ledger_entry/stock_ledger_entry.py
@@ -192,7 +192,7 @@ class StockLedgerEntry(Document):
 		mandatory = ["warehouse", "posting_date", "voucher_type", "voucher_no", "company"]
 		for k in mandatory:
 			if not self.get(k):
-				frappe.throw(_("{0} is required").format(self.meta.get_label(k)))
+				frappe.throw(_("{0} is required").format(_(self.meta.get_label(k))))
 
 		if self.voucher_type != "Stock Reconciliation" and not self.actual_qty:
 			frappe.throw(_("Actual Qty is mandatory"))

--- a/erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py
+++ b/erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py
@@ -210,7 +210,7 @@ class StockReservationEntry(Document):
 		]
 		for d in mandatory:
 			if not self.get(d):
-				msg = _("{0} is required").format(self.meta.get_label(d))
+				msg = _("{0} is required").format(_(self.meta.get_label(d)))
 				frappe.throw(msg)
 
 	def validate_group_warehouse(self) -> None:


### PR DESCRIPTION
`self.meta.get_label` returns an untranslated label. We need to translate it before formatting it into the otherwise translated error message.