### PR TITLE
fix: consider empty string in previous doc validation

### DIFF
--- a/erpnext/utilities/transaction_base.py
+++ b/erpnext/utilities/transaction_base.py
@@ -68,7 +68,7 @@ class TransactionBase(StatusUpdater):
 					frappe.throw(_("Invalid reference {0} {1}").format(reference_doctype, reference_name))
 
 				for field, condition in fields:
-					if prevdoc_values[field] is not None and field not in self.exclude_fields:
+					if prevdoc_values[field] not in [None, ""] and field not in self.exclude_fields:
 						self.validate_value(field, condition, prevdoc_values[field], doc)
 
 	def get_prev_doc_reference_details(self, reference_names, reference_doctype, fields):


### PR DESCRIPTION
Issue: Empty is considered in the previous doc validation

Ref: [42033](https://support.frappe.io/helpdesk/tickets/42033)

Before:

[Screencast from 01-07-25 08:08:09 PM IST.webm](https://github.com/user-attachments/assets/fb1d67d6-d60f-4495-8254-f31bf0d17afc)

After:

[Screencast from 01-07-25 08:11:03 PM IST.webm](https://github.com/user-attachments/assets/a5bd9697-c101-433f-9295-15c83d4c8e04)




Backport Needed: Version-15