### PR TITLE
fix: status fully depreciated

### DIFF
--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -647,13 +647,13 @@ class Asset(AccountsController):
 					].expected_value_after_useful_life
 					value_after_depreciation = self.finance_books[idx].value_after_depreciation
 
-					if (
-						flt(value_after_depreciation) <= expected_value_after_useful_life
-						or self.is_fully_depreciated
-					):
-						status = "Fully Depreciated"
-					elif flt(value_after_depreciation) < flt(self.gross_purchase_amount):
-						status = "Partially Depreciated"
+				if (
+					flt(value_after_depreciation) <= expected_value_after_useful_life
+					or self.is_fully_depreciated
+				):
+					status = "Fully Depreciated"
+				elif flt(value_after_depreciation) < flt(self.gross_purchase_amount):
+					status = "Partially Depreciated"
 		elif self.docstatus == 2:
 			status = "Cancelled"
 		return status


### PR DESCRIPTION
Compare to Version 15.0
https://github.com/frappe/erpnext/blob/version-15/erpnext/assets/doctype/asset/asset.py#L629-L642

And this is on develop branch
https://github.com/frappe/erpnext/blob/develop/erpnext/assets/doctype/asset/asset.py#L640-L653

This led to bug when submitting a  fully depreciated asset, and it should change status to **Fully Depreciated**
![Selection_548](https://github.com/user-attachments/assets/20e8d89e-e25f-4dbf-a37e-fab87e8d4b9f)

