### PR TITLE
feat: Link Supplier group permission in Purchase order

### DIFF
--- a/erpnext/buying/doctype/purchase_order/purchase_order.json
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.json
@@ -103,6 +103,7 @@
   "section_addresses",
   "supplier_address",
   "address_display",
+  "supplier_group",
   "col_break_address",
   "contact_person",
   "contact_display",
@@ -1273,6 +1274,14 @@
    "read_only": 1
   },
   {
+   "fieldname": "supplier_group",
+   "fieldtype": "Link",
+   "hidden": 1,
+   "label": "Supplier Group",
+   "options": "Supplier Group",
+   "print_hide": 1
+  },
+  {
    "depends_on": "eval: doc.last_scanned_warehouse",
    "fieldname": "last_scanned_warehouse",
    "fieldtype": "Data",
@@ -1300,7 +1309,7 @@
  "idx": 105,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-08-28 11:00:56.635116",
+ "modified": "2025-09-28 11:00:56.635116",
  "modified_by": "Administrator",
  "module": "Buying",
  "name": "Purchase Order",


### PR DESCRIPTION
### Reason
All purchaser are able to see all the purchase order even if Supplier Group permission is added, (purchase order is not included in the supplier group permission)

### Changes
- Added supplier group as link field which links the permission based on supplier group for all purchase order

Closes: #48219

`no-docs`