### PR TITLE
fix: add company field on POS Invoice Merge Log

### DIFF
--- a/erpnext/accounts/doctype/pos_invoice_merge_log/pos_invoice_merge_log.json
+++ b/erpnext/accounts/doctype/pos_invoice_merge_log/pos_invoice_merge_log.json
@@ -5,6 +5,7 @@
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
+  "company",
   "posting_date",
   "posting_time",
   "merge_invoices_based_on",
@@ -113,12 +114,22 @@
    "label": "Posting Time",
    "no_copy": 1,
    "reqd": 1
+  },
+  {
+   "fieldname": "company",
+   "fieldtype": "Link",
+   "in_standard_filter": 1,
+   "label": "Company",
+   "options": "Company",
+   "print_hide": 1,
+   "remember_last_selected_value": 1,
+   "reqd": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-03-27 13:10:15.620564",
+ "modified": "2025-07-02 17:08:04.747202",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "POS Invoice Merge Log",
@@ -179,6 +190,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],

--- a/erpnext/accounts/doctype/pos_invoice_merge_log/pos_invoice_merge_log.py
+++ b/erpnext/accounts/doctype/pos_invoice_merge_log/pos_invoice_merge_log.py
@@ -29,11 +29,10 @@ class POSInvoiceMergeLog(Document):
 	if TYPE_CHECKING:
 		from frappe.types import DF
 
-		from erpnext.accounts.doctype.pos_invoice_reference.pos_invoice_reference import (
-			POSInvoiceReference,
-		)
+		from erpnext.accounts.doctype.pos_invoice_reference.pos_invoice_reference import POSInvoiceReference
 
 		amended_from: DF.Link | None
+		company: DF.Link
 		consolidated_credit_note: DF.Link | None
 		consolidated_invoice: DF.Link | None
 		customer: DF.Link

--- a/erpnext/accounts/doctype/pos_invoice_merge_log/pos_invoice_merge_log.py
+++ b/erpnext/accounts/doctype/pos_invoice_merge_log/pos_invoice_merge_log.py
@@ -583,6 +583,7 @@ def create_merge_logs(invoice_by_customer, closing_entry=None):
 					merge_log.posting_time = (
 						get_time(closing_entry.get("posting_time")) if closing_entry else nowtime()
 					)
+					merge_log.company = closing_entry.get("company") if closing_entry else None
 					merge_log.customer = customer
 					merge_log.pos_closing_entry = closing_entry.get("name") if closing_entry else None
 					merge_log.set("pos_invoices", _invoices)

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -424,3 +424,4 @@ execute:frappe.db.set_single_value("Accounts Settings", "confirm_before_resettin
 erpnext.patches.v15_0.rename_pos_closing_entry_fields #2025-06-13
 erpnext.patches.v15_0.update_pegged_currencies
 erpnext.patches.v15_0.set_status_cancelled_on_cancelled_pos_opening_entry_and_pos_closing_entry
+erpnext.patches.v15_0.set_company_on_pos_inv_merge_log

--- a/erpnext/patches/v15_0/set_company_on_pos_inv_merge_log.py
+++ b/erpnext/patches/v15_0/set_company_on_pos_inv_merge_log.py
@@ -1,0 +1,12 @@
+import frappe
+
+
+def execute():
+	pos_invoice_merge_logs = frappe.db.get_all(
+		"POS Invoice Merge Log", {"docstatus": 1}, ["name", "pos_closing_entry"]
+	)
+
+	for log in pos_invoice_merge_logs:
+		if log.pos_closing_entry and frappe.db.exists("POS Closing Entry", log.pos_closing_entry):
+			company = frappe.db.get_value("POS Closing Entry", log.pos_closing_entry, "company")
+			frappe.db.set_value("POS Invoice Merge Log", log.name, "company", company)


### PR DESCRIPTION
**Issue:** Unable to delete customer after deleting company transactions.

**Description:** 
- When closing POS Entries from POS Invoices system creates `POS Invoice Merge Log` grouped and linked to Customer.
- Once company transactions has been deleted, user can't able to delete the customer as it's linked on `POS Invoice Merge Log`

**Solution:**
- Added company field on `POS Invoice Merge Log` DocType to include in company transaction deletion process.
- Added patch for updating existing `POS Invoice Merge Log` records company value fetching from `POS Closing Entry`.

**Ref:** [42580](https://support.frappe.io/helpdesk/tickets/42580) 

**Before:**

[pos merge log customer link issue.webm](https://github.com/user-attachments/assets/df6340b9-1117-420f-9438-4423b15cb424)

**After:**

[pos merge log customer link fix.webm](https://github.com/user-attachments/assets/2c44fa02-ad04-42b0-8d4d-499d13f5936c)



When resolving the above issue identified `NoneType` Object error while selecting POS Item Card.

**Issue**
![Screenshot from 2025-07-02 18-11-14](https://github.com/user-attachments/assets/e063aac2-dfbf-4c30-9cb1-336c38eb9eb3)

**Resolved PR**: #48410


**Backport Needed:** v15


