### PR TITLE
feat: add subject field to project

### DIFF
--- a/erpnext/projects/doctype/project/project.js
+++ b/erpnext/projects/doctype/project/project.js
@@ -202,6 +202,12 @@ frappe.ui.form.on("Project", {
 				});
 		});
 	},
+
+	collect_progress: function (frm) {
+		if (frm.doc.collect_progress && !frm.doc.subject) {
+			frm.set_value("subject", `For project ${frm.doc.name}, update your status`);
+		}
+	},
 });
 
 function open_form(frm, doctype, child_doctype, parentfield) {

--- a/erpnext/projects/doctype/project/project.js
+++ b/erpnext/projects/doctype/project/project.js
@@ -205,7 +205,7 @@ frappe.ui.form.on("Project", {
 
 	collect_progress: function (frm) {
 		if (frm.doc.collect_progress && !frm.doc.subject) {
-			frm.set_value("subject", `For project ${frm.doc.name}, update your status`);
+			frm.set_value("subject", __("For project {0}, update your status", [frm.doc.name]));
 		}
 	},
 });

--- a/erpnext/projects/doctype/project/project.json
+++ b/erpnext/projects/doctype/project/project.json
@@ -62,6 +62,7 @@
   "day_to_send",
   "weekly_time_to_send",
   "column_break_45",
+  "subject",
   "message"
  ],
  "fields": [
@@ -447,6 +448,13 @@
    "print_hide": 1,
    "reqd": 1,
    "set_only_once": 1
+  },
+  {
+   "depends_on": "collect_progress",
+   "fieldname": "subject",
+   "fieldtype": "Data",
+   "label": "Subject",
+   "mandatory_depends_on": "collect_progress"
   }
  ],
  "icon": "fa fa-puzzle-piece",
@@ -454,7 +462,7 @@
  "index_web_pages_for_search": 1,
  "links": [],
  "max_attachments": 4,
- "modified": "2024-04-24 10:56:16.001032",
+ "modified": "2025-07-03 10:54:30.444139",
  "modified_by": "Administrator",
  "module": "Projects",
  "name": "Project",
@@ -501,6 +509,7 @@
   }
  ],
  "quick_entry": 1,
+ "row_format": "Dynamic",
  "search_fields": "project_name,customer, status, priority, is_active",
  "show_name_in_global_search": 1,
  "sort_field": "creation",

--- a/erpnext/projects/doctype/project/project.py
+++ b/erpnext/projects/doctype/project/project.py
@@ -62,6 +62,7 @@ class Project(Document):
 		sales_order: DF.Link | None
 		second_email: DF.Time | None
 		status: DF.Literal["Open", "Completed", "Cancelled"]
+		subject: DF.Data | None
 		to_time: DF.Time | None
 		total_billable_amount: DF.Currency
 		total_billed_amount: DF.Currency
@@ -606,8 +607,6 @@ def send_project_update_email_to_users(project):
 		}
 	).insert()
 
-	subject = "For project %s, update your status" % (project)
-
 	incoming_email_account = frappe.db.get_value(
 		"Email Account", dict(enable_incoming=1, default_incoming=1), "email_id"
 	)
@@ -615,7 +614,7 @@ def send_project_update_email_to_users(project):
 	frappe.sendmail(
 		recipients=get_users_email(doc),
 		message=doc.message,
-		subject=_(subject),
+		subject=_(doc.subject),
 		reference_doctype=project_update.doctype,
 		reference_name=project_update.name,
 		reply_to=incoming_email_account,

--- a/erpnext/projects/doctype/project/project.py
+++ b/erpnext/projects/doctype/project/project.py
@@ -614,7 +614,7 @@ def send_project_update_email_to_users(project):
 	frappe.sendmail(
 		recipients=get_users_email(doc),
 		message=doc.message,
-		subject=_(doc.subject),
+		subject=doc.subject,
 		reference_doctype=project_update.doctype,
 		reference_name=project_update.name,
 		reply_to=incoming_email_account,


### PR DESCRIPTION
Reference support ticket [42563](https://support.frappe.io/helpdesk/tickets/42563)

Subject field of the email was hardcoded, moved logic to fetch from new `subject` field