### PR TITLE
fix(test): flaky budget test case

### DIFF
--- a/erpnext/accounts/doctype/budget/test_budget.py
+++ b/erpnext/accounts/doctype/budget/test_budget.py
@@ -113,6 +113,10 @@ class TestBudget(ERPNextTestSuite):
 		frappe.db.set_value("Budget", budget.name, "action_if_accumulated_monthly_budget_exceeded", "Stop")
 		frappe.db.set_value("Budget", budget.name, "fiscal_year", fiscal_year)
 
+		accumulated_limit = get_accumulated_monthly_budget(
+			budget.monthly_distribution, nowdate(), budget.fiscal_year, budget.accounts[0].budget_amount
+		)
+
 		mr = frappe.get_doc(
 			{
 				"doctype": "Material Request",
@@ -126,7 +130,7 @@ class TestBudget(ERPNextTestSuite):
 						"uom": "_Test UOM",
 						"warehouse": "_Test Warehouse - _TC",
 						"schedule_date": nowdate(),
-						"rate": 100000,
+						"rate": accumulated_limit + 1,
 						"expense_account": "_Test Account Cost for Goods Sold - _TC",
 						"cost_center": "_Test Cost Center - _TC",
 					}


### PR DESCRIPTION
```
======================================================================
 FAIL  test_monthly_budget_crossed_for_mr (erpnext.accounts.doctype.budget.test_budget.TestBudget.test_monthly_budget_crossed_for_mr)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/runner/frappe-bench/apps/erpnext/erpnext/accounts/doctype/budget/test_budget.py", line 139, in test_monthly_budget_crossed_for_mr
    self.assertRaises(BudgetError, mr.submit)
    budget = <Budget: doctype=Budget BUDGET-2025-00006 docstatus=1>
    fiscal_year = '2025'
    mr = <MaterialRequest: doctype=Material Request MAT-MR-2025-00001 docstatus=1>
    self = <erpnext.accounts.doctype.budget.test_budget.TestBudget testMethod=test_monthly_budget_crossed_for_mr>
AssertionError: BudgetError not raised by submit
```