### PR TITLE
chore: fix flaky test in Tax Withholding Details

### DIFF
--- a/erpnext/accounts/doctype/budget/test_budget.py
+++ b/erpnext/accounts/doctype/budget/test_budget.py
@@ -113,6 +113,10 @@ class TestBudget(ERPNextTestSuite):
 		frappe.db.set_value("Budget", budget.name, "action_if_accumulated_monthly_budget_exceeded", "Stop")
 		frappe.db.set_value("Budget", budget.name, "fiscal_year", fiscal_year)
 
+		accumulated_limit = get_accumulated_monthly_budget(
+			budget.monthly_distribution, nowdate(), budget.fiscal_year, budget.accounts[0].budget_amount
+		)
+
 		mr = frappe.get_doc(
 			{
 				"doctype": "Material Request",
@@ -126,7 +130,7 @@ class TestBudget(ERPNextTestSuite):
 						"uom": "_Test UOM",
 						"warehouse": "_Test Warehouse - _TC",
 						"schedule_date": nowdate(),
-						"rate": 100000,
+						"rate": accumulated_limit + 1,
 						"expense_account": "_Test Account Cost for Goods Sold - _TC",
 						"cost_center": "_Test Cost Center - _TC",
 					}

--- a/erpnext/accounts/report/tax_withholding_details/tax_withholding_details.py
+++ b/erpnext/accounts/report/tax_withholding_details/tax_withholding_details.py
@@ -121,7 +121,7 @@ def get_result(filters, tds_docs, tds_accounts, tax_category_map, journal_entry_
 				)
 				out.append(row)
 
-	out.sort(key=lambda x: x["section_code"])
+	out.sort(key=lambda x: (x["section_code"], x["transaction_date"]))
 
 	return out
 

--- a/erpnext/accounts/report/tax_withholding_details/test_tax_withholding_details.py
+++ b/erpnext/accounts/report/tax_withholding_details/test_tax_withholding_details.py
@@ -67,11 +67,12 @@ class TestTaxWithholdingDetails(AccountsTestMixin, IntegrationTestCase):
 		mid_year = add_to_date(fiscal_year[1], months=6)
 		tds_doc = frappe.get_doc("Tax Withholding Category", "TDS - 3")
 		tds_doc.rates[0].to_date = mid_year
+		from_date = add_to_date(mid_year, days=1)
 		tds_doc.append(
 			"rates",
 			{
 				"tax_withholding_rate": 20,
-				"from_date": add_to_date(mid_year, days=1),
+				"from_date": from_date,
 				"to_date": fiscal_year[2],
 				"single_threshold": 1,
 				"cumulative_threshold": 1,
@@ -80,18 +81,19 @@ class TestTaxWithholdingDetails(AccountsTestMixin, IntegrationTestCase):
 
 		tds_doc.save()
 
-		inv_1 = make_purchase_invoice(rate=1000, do_not_submit=True)
+		inv_1 = make_purchase_invoice(
+			rate=1000, posting_date=add_to_date(fiscal_year[1], days=1), do_not_save=True, do_not_submit=True
+		)
+		inv_1.set_posting_time = 1
 		inv_1.apply_tds = 1
-		inv_1.tax_withholding_category = "TDS - 3"
+		inv_1.tax_withholding_category = tds_doc.name
+		inv_1.save()
 		inv_1.submit()
 
-		inv_2 = make_purchase_invoice(
-			rate=1000, do_not_submit=True, posting_date=add_to_date(mid_year, days=1), do_not_save=True
-		)
+		inv_2 = make_purchase_invoice(rate=1000, posting_date=from_date, do_not_save=True, do_not_submit=True)
 		inv_2.set_posting_time = 1
-
-		inv_1.apply_tds = 1
-		inv_2.tax_withholding_category = "TDS - 3"
+		inv_2.apply_tds = 1
+		inv_2.tax_withholding_category = tds_doc.name
 		inv_2.save()
 		inv_2.submit()
 


### PR DESCRIPTION
Reasons for failing Test:

1. Date Issue: posting date was not defined so rate was getting applied as per today's date
2. Order Issue: result was not sorted by date so now result is sorted by section code and date.


```
Traceback (most recent call last):
  File "/home/runner/frappe-bench/apps/erpnext/erpnext/accounts/report/tax_withholding_details/test_tax_withholding_details.py", line 111, in test_date_filters_in_multiple_tax_withholding_rules
    self.check_expected_values(result, expected_values)
    expected_values = [['ACC-PINV-2025-00003', 'TDS - 3', 10.0, 5000, 500, 4500], ['ACC-PINV-2025-00004', 'TDS - 3', 20.0, 5000, 1000, 4000]]
    fiscal_year = ('2025', datetime.date(2025, 1, 1), datetime.date(2025, 12, 31))
    inv_1 = <PurchaseInvoice: doctype=Purchase Invoice ACC-PINV-2025-00003 docstatus=1>
    inv_2 = <PurchaseInvoice: doctype=Purchase Invoice ACC-PINV-2025-00004 docstatus=1>
    mid_year = datetime.date(2025, 7, 1)
    result = [{'pan': None, 'party': '_Test Supplier', 'section_code': 'TDS - 3', 'entity_type': 'Company', 'rate': 20.0, 'total_amount': 5000.0, 'grand_total': 4000.0, 'base_total': 5000.0, 'tax_amount': 1000.0, 'transaction_date': datetime.date(2025, 7, 3), 'transaction_type': 'Purchase Invoice', 'ref_no': 'ACC-PINV-2025-00003', 'supplier_invoice_no': None, 'supplier_invoice_date': None}]
    self = <erpnext.accounts.report.tax_withholding_details.test_tax_withholding_details.TestTaxWithholdingDetails testMethod=test_date_filters_in_multiple_tax_withholding_rules>
    tds_doc = <TaxWithholdingCategory: doctype=Tax Withholding Category TDS - 3>
  File "/home/runner/frappe-bench/apps/erpnext/erpnext/accounts/report/tax_withholding_details/test_tax_withholding_details.py", line 125, in check_expected_values
    self.assertSequenceEqual(voucher_actual_values, voucher_expected_values)
    expected_values = [['ACC-PINV-2025-00003', 'TDS - 3', 10.0, 5000, 500, 4500], ['ACC-PINV-2025-00004', 'TDS - 3', 20.0, 5000, 1000, 4000]]
    i = 0
    result = [{'pan': None, 'party': '_Test Supplier', 'section_code': 'TDS - 3', 'entity_type': 'Company', 'rate': 20.0, 'total_amount': 5000.0, 'grand_total': 4000.0, 'base_total': 5000.0, 'tax_amount': 1000.0, 'transaction_date': datetime.date(2025, 7, 3), 'transaction_type': 'Purchase Invoice', 'ref_no': 'ACC-PINV-2025-00003', 'supplier_invoice_no': None, 'supplier_invoice_date': None}]
    self = <erpnext.accounts.report.tax_withholding_details.test_tax_withholding_details.TestTaxWithholdingDetails testMethod=test_date_filters_in_multiple_tax_withholding_rules>
    voucher = {'pan': None, 'party': '_Test Supplier', 'section_code': 'TDS - 3', 'entity_type': 'Company', 'rate': 20.0, 'total_amount': 5000.0, 'grand_total': 4000.0, 'base_total': 5000.0, 'tax_amount': 1000.0, 'transaction_date': datetime.date(2025, 7, 3), 'transaction_type': 'Purchase Invoice', 'ref_no': 'ACC-PINV-2025-00003', 'supplier_invoice_no': None, 'supplier_invoice_date': None}
    voucher_actual_values = ('ACC-PINV-2025-00003', 'TDS - 3', 20.0, 5000.0, 1000.0, 4000.0)
    voucher_expected_values = ['ACC-PINV-2025-00003', 'TDS - 3', 10.0, 5000, 500, 4500]
AssertionError: Sequences differ: ('ACC-PINV-2025-00003', 'TDS - 3', 20.0, 5000.0, 1000.0, 4000.0) != ['ACC-PINV-2025-00003', 'TDS - 3', 10.0, 5000, 500, 4500]

First differing element 2:
20.0
10.0

- ('ACC-PINV-2025-00003', 'TDS - 3', 20.0, 5000.0, 1000.0, 4000.0)
? ^                                  ^         ^   ^  ^^^^^^^^^^^^

+ ['ACC-PINV-2025-00003', 'TDS - 3', 10.0, 5000, 500, 4500]
? ^                                  ^         ^^^^   ^^  ^
```

```
Traceback (most recent call last):
  File "/home/runner/frappe-bench/apps/erpnext/erpnext/accounts/report/tax_withholding_details/test_tax_withholding_details.py", line 113, in test_date_filters_in_multiple_tax_withholding_rules
    self.check_expected_values(result, expected_values)
    expected_values = [['ACC-PINV-2025-00003', 'TDS - 3', 10.0, 5000, 500, 4500], ['ACC-PINV-2025-00004', 'TDS - 3', 20.0, 5000, 1000, 4000]]
    fiscal_year = ('2025', datetime.date(2025, 1, 1), datetime.date(2025, 12, 31))
    from_date = datetime.date(2025, 7, 2)
    inv_1 = <PurchaseInvoice: doctype=Purchase Invoice ACC-PINV-2025-00003 docstatus=1>
    inv_2 = <PurchaseInvoice: doctype=Purchase Invoice ACC-PINV-2025-00004 docstatus=1>
    mid_year = datetime.date(2025, 7, 1)
    result = [{'pan': None, 'party': '_Test Supplier', 'section_code': 'TDS - 3', 'entity_type': 'Company', 'rate': 20.0, 'total_amount': 5000.0, 'grand_total': 4000.0, 'base_total': 5000.0, 'tax_amount': 1000.0, 'transaction_date': datetime.date(2025, 7, 2), 'transaction_type': 'Purchase Invoice', 'ref_no': 'ACC-PINV-2025-00004', 'supplier_invoice_no': None, 'supplier_invoice_date': None}, {'pan': None, 'party': '_Test Supplier', 'section_code': 'TDS - 3', 'entity_type': 'Company', 'rate': 10.0, 'total_amount': 5000.0, 'grand_total': 4500.0, 'base_total': 5000.0, 'tax_amount': 500.0, 'transaction_date': datetime.date(2025, 1, 2), 'transaction_type': 'Purchase Invoice', 'ref_no': 'ACC-PINV-2025-00003', 'supplier_invoice_no': None, 'supplier_invoice_date': None}]
    self = <erpnext.accounts.report.tax_withholding_details.test_tax_withholding_details.TestTaxWithholdingDetails testMethod=test_date_filters_in_multiple_tax_withholding_rules>
    tds_doc = <TaxWithholdingCategory: doctype=Tax Withholding Category TDS - 3>
  File "/home/runner/frappe-bench/apps/erpnext/erpnext/accounts/report/tax_withholding_details/test_tax_withholding_details.py", line 127, in check_expected_values
    self.assertSequenceEqual(voucher_actual_values, voucher_expected_values)
    expected_values = [['ACC-PINV-2025-00003', 'TDS - 3', 10.0, 5000, 500, 4500], ['ACC-PINV-2025-00004', 'TDS - 3', 20.0, 5000, 1000, 4000]]
    i = 0
    result = [{'pan': None, 'party': '_Test Supplier', 'section_code': 'TDS - 3', 'entity_type': 'Company', 'rate': 20.0, 'total_amount': 5000.0, 'grand_total': 4000.0, 'base_total': 5000.0, 'tax_amount': 1000.0, 'transaction_date': datetime.date(2025, 7, 2), 'transaction_type': 'Purchase Invoice', 'ref_no': 'ACC-PINV-2025-00004', 'supplier_invoice_no': None, 'supplier_invoice_date': None}, {'pan': None, 'party': '_Test Supplier', 'section_code': 'TDS - 3', 'entity_type': 'Company', 'rate': 10.0, 'total_amount': 5000.0, 'grand_total': 4500.0, 'base_total': 5000.0, 'tax_amount': 500.0, 'transaction_date': datetime.date(2025, 1, 2), 'transaction_type': 'Purchase Invoice', 'ref_no': 'ACC-PINV-2025-00003', 'supplier_invoice_no': None, 'supplier_invoice_date': None}]
    self = <erpnext.accounts.report.tax_withholding_details.test_tax_withholding_details.TestTaxWithholdingDetails testMethod=test_date_filters_in_multiple_tax_withholding_rules>
    voucher = {'pan': None, 'party': '_Test Supplier', 'section_code': 'TDS - 3', 'entity_type': 'Company', 'rate': 20.0, 'total_amount': 5000.0, 'grand_total': 4000.0, 'base_total': 5000.0, 'tax_amount': 1000.0, 'transaction_date': datetime.date(2025, 7, 2), 'transaction_type': 'Purchase Invoice', 'ref_no': 'ACC-PINV-2025-00004', 'supplier_invoice_no': None, 'supplier_invoice_date': None}
    voucher_actual_values = ('ACC-PINV-2025-00004', 'TDS - 3', 20.0, 5000.0, 1000.0, 4000.0)
    voucher_expected_values = ['ACC-PINV-2025-00003', 'TDS - 3', 10.0, 5000, 500, 4500]
AssertionError: Sequences differ: ('ACC-PINV-2025-00004', 'TDS - 3', 20.0, 5000.0, 1000.0, 4000.0) != ['ACC-PINV-2025-00003', 'TDS - 3', 10.0, 5000, 500, 4500]

First differing element 0:
'ACC-PINV-2025-00004'
'ACC-PINV-2025-00003'

- ('ACC-PINV-2025-00004', 'TDS - 3', 20.0, 5000.0, 1000.0, 4000.0)
? ^                   ^              ^         ^   ^  ^^^^^^^^^^^^

+ ['ACC-PINV-2025-00003', 'TDS - 3', 10.0, 5000, 500, 4500]
? ^                   ^              ^         ^^^^   ^^  ^


Tests: 546, Failing: 1, Errors: 0
```