### PR TITLE
fix: update item reference in quality inspection

### DIFF
--- a/erpnext/controllers/stock_controller.py
+++ b/erpnext/controllers/stock_controller.py
@@ -1757,8 +1757,9 @@ def make_quality_inspections(doctype, docname, items, inspection_type):
 				"sample_size": flt(item.get("sample_size")),
 				"item_serial_no": item.get("serial_no").split("\n")[0] if item.get("serial_no") else None,
 				"batch_no": item.get("batch_no"),
+				"child_row_reference": item.get("child_row_reference"),
 			}
-		).insert()
+		)
 		quality_inspection.save()
 		inspections.append(quality_inspection.name)
 

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -371,6 +371,7 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 				"inspection_type": inspection_type,
 				"reference_type": me.frm.doc.doctype,
 				"reference_name": me.frm.doc.name,
+				"child_row_reference": row.doc.name,
 				"item_code": row.doc.item_code,
 				"description": row.doc.description,
 				"item_serial_no": row.doc.serial_no ? row.doc.serial_no.split("\n")[0] : null,
@@ -385,7 +386,8 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 					docstatus: ["<", 2],
 					inspection_type: inspection_type,
 					reference_name: doc.name,
-					item_code: d.item_code
+					item_code: d.item_code,
+					child_row_reference : d.name
 				}
 			}
 		});
@@ -2459,12 +2461,13 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 			fields: fields,
 			primary_action: function () {
 				const data = dialog.get_values();
+				const selected_data = data.items.filter(item => item?.__checked == 1 );
 				frappe.call({
 					method: "erpnext.controllers.stock_controller.make_quality_inspections",
 					args: {
 						doctype: me.frm.doc.doctype,
 						docname: me.frm.doc.name,
-						items: data.items,
+						items: selected_data,
 						inspection_type: inspection_type
 					},
 					freeze: true,

--- a/erpnext/stock/doctype/stock_entry/stock_entry.js
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.js
@@ -179,6 +179,7 @@ frappe.ui.form.on("Stock Entry", {
 				inspection_type: "Incoming",
 				reference_type: frm.doc.doctype,
 				reference_name: frm.doc.name,
+				child_row_reference: row.doc.name,
 				item_code: row.doc.item_code,
 				description: row.doc.description,
 				item_serial_no: row.doc.serial_no ? row.doc.serial_no.split("\n")[0] : null,
@@ -194,6 +195,7 @@ frappe.ui.form.on("Stock Entry", {
 				filters: {
 					item_code: d.item_code,
 					reference_name: doc.name,
+					child_row_reference: d.name,
 				},
 			};
 		});


### PR DESCRIPTION
**Issue:**

- When the delivery note contains the same item in multiple rows, the quality inspection of the first item is applied to all rows with the same item. However, when the quality inspection is cancelled, only the reference in the first item is removed, while the other rows still retain the reference.

- When creating a Quality Inspection through the dialog box, it should include only the selected items; however, it currently includes unselected items as well.

- When creating a Quality Inspection through a Delivery Note or Stock Entry, the child_row_reference in the Quality Inspection should be set to the specific item's row name. However, it currently assigns the same Quality Inspection to all occurrences of that item, instead of linking it to the correct row.

- Update the quality_inspection_query to filter with docstatus < 2 so it includes both draft and submitted documents, instead of only submitted ones (docstatus = 1)

- Due to multiple occurrences of the same item in the Delivery Note or Stock Entry, the item_query was returning redundant data which shows the label as **SKU001** .

Ref:  [#41882](https://support.frappe.io/helpdesk/tickets/41882)


**Before:**

https://github.com/user-attachments/assets/8c7f2daa-860d-449e-b2f3-3366b1c81433

**After:**

https://github.com/user-attachments/assets/84d36b99-23b2-4ea6-be65-7dd426abe73b


**Backport needed: Version-15**

