### PR TITLE
fix: pos recent order display customer code and name

### DIFF
--- a/erpnext/public/scss/point-of-sale.scss
+++ b/erpnext/public/scss/point-of-sale.scss
@@ -1105,21 +1105,31 @@
 						justify-content: flex-end;
 						padding-right: var(--padding-sm);
 
-						> .customer-name {
-							font-size: var(--text-2xl);
-							font-weight: 700;
-						}
+						> .customer-section {
+							margin-bottom: auto;
 
-						> .customer-email {
-							font-size: var(--text-md);
-							font-weight: 500;
+							> .customer-name {
+								font-size: var(--text-2xl);
+								font-weight: 700;
+							}
+
+							> .customer-code {
+								font-size: var(--text-xs);
+								font-weight: 500;
+								color: var(--text-light);
+							}
+
+							> .customer-email {
+								font-size: var(--text-md);
+								font-weight: 500;
+							}
 						}
 
 						> .cashier {
 							font-size: var(--text-md);
 							font-weight: 500;
 							color: var(--gray-600);
-							margin-top: auto;
+							margin-top: var(--margin-md);
 						}
 					}
 
@@ -1127,7 +1137,6 @@
 						display: flex;
 						flex-direction: column;
 						align-items: flex-end;
-						justify-content: space-between;
 
 						> .paid-amount {
 							font-size: var(--text-2xl);

--- a/erpnext/selling/page/point_of_sale/point_of_sale.py
+++ b/erpnext/selling/page/point_of_sale/point_of_sale.py
@@ -338,7 +338,7 @@ def create_opening_voucher(pos_profile, company, balance_details):
 
 @frappe.whitelist()
 def get_past_order_list(search_term, status, limit=20):
-	fields = ["name", "grand_total", "currency", "customer", "posting_time", "posting_date"]
+	fields = ["name", "grand_total", "currency", "customer", "customer_name", "posting_time", "posting_date"]
 	invoice_list = []
 
 	if search_term and status:

--- a/erpnext/selling/page/point_of_sale/pos_past_order_list.js
+++ b/erpnext/selling/page/point_of_sale/pos_past_order_list.js
@@ -114,7 +114,7 @@ erpnext.PointOfSale.PastOrderList = class {
 						<svg class="mr-2" width="12" height="12" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1" stroke-linecap="round" stroke-linejoin="round">
 							<path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/>
 						</svg>
-						${frappe.ellipsis(invoice.customer, 20)}
+						${frappe.ellipsis(invoice.customer_name, 20)}
 					</div>
 					<div class="invoice-name">${invoice.name}</div>
 				</div>

--- a/erpnext/selling/page/point_of_sale/pos_past_order_summary.js
+++ b/erpnext/selling/page/point_of_sale/pos_past_order_summary.js
@@ -73,6 +73,7 @@ erpnext.PointOfSale.PastOrderSummary = class {
 	get_upper_section_html(doc) {
 		const { status } = doc;
 		let indicator_color = "";
+		const is_customer_naming_by_customer_name = frappe.sys_defaults.cust_master_name !== "Customer Name";
 
 		["Paid", "Consolidated"].includes(status) && (indicator_color = "green");
 		["Partly Paid", "Overdue"].includes(status) && (indicator_color = "yellow");
@@ -80,8 +81,11 @@ erpnext.PointOfSale.PastOrderSummary = class {
 		["Credit Note Issued", "Return"].includes(status) && (indicator_color = "grey");
 
 		return `<div class="left-section">
-					<div class="customer-name">${doc.customer}</div>
-					<div class="customer-email">${this.customer_email}</div>
+					<div class="customer-section">
+						<div class="customer-name">${doc.customer_name}</div>
+						${is_customer_naming_by_customer_name ? `<div class="customer-code">${doc.customer}</div>` : ""}
+						<div class="customer-email">${this.customer_email}</div>
+					</div>
 					<div class="cashier">${__("Sold by")}: ${doc.owner}</div>
 				</div>
 				<div class="right-section">


### PR DESCRIPTION
Changes include:
- Display `customer.name` and `customer.customer_name` on the POS Recent Order List and the POS Recent Order Summary if the Customer Naming setting is not set to "Customer Name" on Selling Settings.
	
	Screenshots:

	![image](https://github.com/user-attachments/assets/664e1537-f798-4941-bf21-5e00b8c6ce0e)

	![image](https://github.com/user-attachments/assets/2a0652e3-9398-4430-af95-5130ee36bfd8)

