### PR TITLE
feat: stock balance and stock ledger report with multi-select items and warehouses

### DIFF
--- a/erpnext/stock/doctype/purchase_receipt/test_purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/test_purchase_receipt.py
@@ -3693,7 +3693,7 @@ class TestPurchaseReceipt(IntegrationTestCase):
 
 		columns, data = execute(
 			filters=frappe._dict(
-				{"item_code": item_code, "warehouse": pr.items[0].warehouse, "company": pr.company}
+				{"item_code": [item_code], "warehouse": [pr.items[0].warehouse], "company": pr.company}
 			)
 		)
 

--- a/erpnext/stock/doctype/warehouse/warehouse.py
+++ b/erpnext/stock/doctype/warehouse/warehouse.py
@@ -280,7 +280,7 @@ def apply_warehouse_filter(query, sle, filters):
 	for condition in range_conditions[1:]:
 		combined_condition = combined_condition | condition
 
-	child_query = child_query.where(combined_condition & (warehouse_table.name == sle.warehouse))
+	child_query = child_query.where(combined_condition).where(warehouse_table.name == sle.warehouse)
 
 	query = query.where(ExistsCriterion(child_query))
 

--- a/erpnext/stock/report/stock_balance/stock_balance.js
+++ b/erpnext/stock/report/stock_balance/stock_balance.js
@@ -36,38 +36,37 @@ frappe.query_reports["Stock Balance"] = {
 		},
 		{
 			fieldname: "item_code",
-			label: __("Item"),
-			fieldtype: "Link",
+			label: __("Items"),
+			fieldtype: "MultiSelectList",
 			width: "80",
 			options: "Item",
-			get_query: function () {
+			get_data: function (txt) {
 				let item_group = frappe.query_report.get_filter_value("item_group");
 
-				return {
-					query: "erpnext.controllers.queries.item_query",
-					filters: {
-						...(item_group && { item_group }),
-						is_stock_item: 1,
-					},
+				let filters = {
+					...(item_group && { item_group }),
+					is_stock_item: 1,
 				};
+
+				return frappe.db.get_link_options("Item", txt, filters);
 			},
 		},
 		{
 			fieldname: "warehouse",
-			label: __("Warehouse"),
-			fieldtype: "Link",
+			label: __("Warehouses"),
+			fieldtype: "MultiSelectList",
 			width: "80",
 			options: "Warehouse",
-			get_query: () => {
+			get_data: (txt) => {
 				let warehouse_type = frappe.query_report.get_filter_value("warehouse_type");
 				let company = frappe.query_report.get_filter_value("company");
 
-				return {
-					filters: {
-						...(warehouse_type && { warehouse_type }),
-						...(company && { company }),
-					},
+				let filters = {
+					...(warehouse_type && { warehouse_type }),
+					...(company && { company }),
 				};
+
+				return frappe.db.get_link_options("Warehouse", txt, filters);
 			},
 		},
 		{

--- a/erpnext/stock/report/stock_balance/stock_balance.js
+++ b/erpnext/stock/report/stock_balance/stock_balance.js
@@ -40,7 +40,7 @@ frappe.query_reports["Stock Balance"] = {
 			fieldtype: "MultiSelectList",
 			width: "80",
 			options: "Item",
-			get_data: function (txt) {
+			get_data: async function (txt) {
 				let item_group = frappe.query_report.get_filter_value("item_group");
 
 				let filters = {
@@ -48,7 +48,27 @@ frappe.query_reports["Stock Balance"] = {
 					is_stock_item: 1,
 				};
 
-				return frappe.db.get_link_options("Item", txt, filters);
+				let { message: data } = await frappe.call({
+					method: "erpnext.controllers.queries.item_query",
+					args: {
+						doctype: "Item",
+						txt: txt,
+						searchfield: "name",
+						start: 0,
+						page_len: 10,
+						filters: filters,
+						as_dict: 1,
+					},
+				});
+
+				data = data.map(({ name, description }) => {
+					return {
+						value: name,
+						description: description,
+					};
+				});
+
+				return data || [];
 			},
 		},
 		{

--- a/erpnext/stock/report/stock_balance/stock_balance.py
+++ b/erpnext/stock/report/stock_balance/stock_balance.py
@@ -8,11 +8,9 @@ from typing import Any, TypedDict
 
 import frappe
 from frappe import _
-from frappe.query_builder import Order
 from frappe.query_builder.functions import Coalesce
 from frappe.utils import add_days, cint, date_diff, flt, getdate
 from frappe.utils.nestedset import get_descendants_of
-from pypika.terms import ExistsCriterion
 
 import erpnext
 from erpnext.stock.doctype.inventory_dimension.inventory_dimension import get_inventory_dimensions

--- a/erpnext/stock/report/stock_balance/stock_balance.py
+++ b/erpnext/stock/report/stock_balance/stock_balance.py
@@ -360,28 +360,8 @@ class StockBalanceReport:
 	def apply_warehouse_filters(self, query, sle) -> str:
 		warehouse_table = frappe.qb.DocType("Warehouse")
 
-		if warehouses := self.filters.get("warehouse"):
-			warehouse_range = frappe.get_all(
-				"Warehouse",
-				filters={
-					"name": ("in", warehouses),
-				},
-				fields=["lft", "rgt"],
-				as_list=True,
-			)
-
-			child_query = frappe.qb.from_(warehouse_table).select(warehouse_table.name)
-
-			range_conditions = [
-				(warehouse_table.lft >= lft) & (warehouse_table.rgt <= rgt) for lft, rgt in warehouse_range
-			]
-
-			combined_condition = range_conditions[0]
-			for condition in range_conditions[1:]:
-				combined_condition = combined_condition | condition
-
-			child_query = child_query.where(combined_condition & (warehouse_table.name == sle.warehouse))
-			query = query.where(ExistsCriterion(child_query))
+		if self.filters.get("warehouse"):
+			apply_warehouse_filter(query, sle, self.filters)
 
 		elif warehouse_type := self.filters.get("warehouse_type"):
 			query = (

--- a/erpnext/stock/report/stock_balance/stock_balance.py
+++ b/erpnext/stock/report/stock_balance/stock_balance.py
@@ -361,7 +361,7 @@ class StockBalanceReport:
 		warehouse_table = frappe.qb.DocType("Warehouse")
 
 		if self.filters.get("warehouse"):
-			apply_warehouse_filter(query, sle, self.filters)
+			query = apply_warehouse_filter(query, sle, self.filters)
 
 		elif warehouse_type := self.filters.get("warehouse_type"):
 			query = (

--- a/erpnext/stock/report/stock_balance/test_stock_balance.py
+++ b/erpnext/stock/report/stock_balance/test_stock_balance.py
@@ -23,7 +23,7 @@ class TestStockBalance(IntegrationTestCase):
 		self.filters = _dict(
 			{
 				"company": "_Test Company",
-				"item_code": self.item.name,
+				"item_code": [self.item.name],
 				"from_date": "2020-01-01",
 				"to_date": str(today()),
 			}
@@ -165,6 +165,6 @@ class TestStockBalance(IntegrationTestCase):
 		variant.save()
 
 		self.generate_stock_ledger(variant.name, [_dict(qty=5, rate=10)])
-		rows = stock_balance(self.filters.update({"show_variant_attributes": 1, "item_code": variant.name}))
+		rows = stock_balance(self.filters.update({"show_variant_attributes": 1, "item_code": [variant.name]}))
 		self.assertPartialDictEq(attributes, rows[0])
 		self.assertInvariants(rows)

--- a/erpnext/stock/report/stock_ledger/stock_ledger.js
+++ b/erpnext/stock/report/stock_ledger/stock_ledger.js
@@ -27,25 +27,24 @@ frappe.query_reports["Stock Ledger"] = {
 		},
 		{
 			fieldname: "warehouse",
-			label: __("Warehouse"),
-			fieldtype: "Link",
+			label: __("Warehouses"),
+			fieldtype: "MultiSelectList",
 			options: "Warehouse",
-			get_query: function () {
+			get_data: function (txt) {
 				const company = frappe.query_report.get_filter_value("company");
-				return {
-					filters: { company: company },
-				};
+
+				return frappe.db.get_link_options("Warehouse", txt, {
+					company: company,
+				});
 			},
 		},
 		{
 			fieldname: "item_code",
-			label: __("Item"),
-			fieldtype: "Link",
+			label: __("Items"),
+			fieldtype: "MultiSelectList",
 			options: "Item",
-			get_query: function () {
-				return {
-					query: "erpnext.controllers.queries.item_query",
-				};
+			get_data: function (txt) {
+				return frappe.db.get_link_options("Item", txt, {});
 			},
 		},
 		{

--- a/erpnext/stock/report/stock_ledger/stock_ledger.js
+++ b/erpnext/stock/report/stock_ledger/stock_ledger.js
@@ -43,8 +43,28 @@ frappe.query_reports["Stock Ledger"] = {
 			label: __("Items"),
 			fieldtype: "MultiSelectList",
 			options: "Item",
-			get_data: function (txt) {
-				return frappe.db.get_link_options("Item", txt, {});
+			get_data: async function (txt) {
+				let { message: data } = await frappe.call({
+					method: "erpnext.controllers.queries.item_query",
+					args: {
+						doctype: "Item",
+						txt: txt,
+						searchfield: "name",
+						start: 0,
+						page_len: 10,
+						filters: {},
+						as_dict: 1,
+					},
+				});
+
+				data = data.map(({ name, description }) => {
+					return {
+						value: name,
+						description: description,
+					};
+				});
+
+				return data || [];
 			},
 		},
 		{

--- a/erpnext/stock/report/stock_ledger/stock_ledger.py
+++ b/erpnext/stock/report/stock_ledger/stock_ledger.py
@@ -637,6 +637,9 @@ def get_opening_balance(filters, columns, sl_entries):
 
 
 def get_warehouse_condition(warehouses):
+	if not warehouses:
+		return ""
+
 	if isinstance(warehouses, str):
 		warehouses = [warehouses]
 
@@ -653,14 +656,14 @@ def get_warehouse_condition(warehouses):
 		return ""
 
 	alias = "wh"
-	condtions = []
+	conditions = []
 	for lft, rgt in warehouse_range:
-		condtions.append(f"({alias}.lft >= {lft} and {alias}.rgt <= {rgt})")
+		conditions.append(f"({alias}.lft >= {lft} and {alias}.rgt <= {rgt})")
 
-	condtions = " or ".join(condtions)
+	conditions = " or ".join(conditions)
 
 	return f" exists (select name from `tabWarehouse` {alias} \
-		where ({condtions}) and warehouse = {alias}.name)"
+		where ({conditions}) and warehouse = {alias}.name)"
 
 
 def get_item_group_condition(item_group, item_table=None):

--- a/erpnext/stock/report/stock_ledger/stock_ledger.py
+++ b/erpnext/stock/report/stock_ledger/stock_ledger.py
@@ -540,8 +540,8 @@ def get_opening_balance_from_batch(filters, columns, sl_entries):
 	}
 
 	for fields in ["item_code", "warehouse"]:
-		value = filters.get(fields)
-		query_filters[fields] = ("in", value)
+		if value := filters.get(fields):
+			query_filters[fields] = ("in", value)
 
 	opening_data = frappe.get_all(
 		"Stock Ledger Entry",

--- a/erpnext/stock/report/stock_ledger/test_stock_ledger_report.py
+++ b/erpnext/stock/report/stock_ledger/test_stock_ledger_report.py
@@ -17,7 +17,7 @@ class TestStockLedgerReeport(IntegrationTestCase):
 			company="_Test Company",
 			from_date=today(),
 			to_date=add_days(today(), 30),
-			item_code="_Test Stock Report Serial Item",
+			item_code=["_Test Stock Report Serial Item"],
 		)
 
 	def tearDown(self) -> None:

--- a/erpnext/stock/report/test_reports.py
+++ b/erpnext/stock/report/test_reports.py
@@ -18,8 +18,15 @@ batch = get_random("Batch")
 REPORT_FILTER_TEST_CASES: list[tuple[ReportName, ReportFilters]] = [
 	("Stock Ledger", {"_optional": True}),
 	("Stock Ledger", {"batch_no": batch}),
-	("Stock Ledger", {"item_code": "_Test Item", "warehouse": "_Test Warehouse - _TC"}),
-	("Stock Balance", {"_optional": True}),
+	("Stock Ledger", {"item_code": ["_Test Item"], "warehouse": ["_Test Warehouse - _TC"]}),
+	(
+		"Stock Balance",
+		{
+			"item_code": ["_Test Item"],
+			"warehouse": ["_Test Warehouse - _TC"],
+			"item_group": "_Test Item Group",
+		},
+	),
 	("Stock Projected Qty", {"_optional": True}),
 	("Batch-Wise Balance History", {}),
 	("Itemwise Recommended Reorder Level", {"item_group": "All Item Groups"}),

--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -57,12 +57,12 @@ def make_sl_entries(sl_entries, allow_negative_stock=False, via_landed_cost_vouc
 	"""Create SL entries from SL entry dicts
 
 	args:
-	        - allow_negative_stock: disable negative stock valiations if true
-	        - via_landed_cost_voucher: landed cost voucher cancels and reposts
-	        entries of purchase document. This flag is used to identify if
-	        cancellation and repost is happening via landed cost voucher, in
-	        such cases certain validations need to be ignored (like negative
-	                        stock)
+	                - allow_negative_stock: disable negative stock valiations if true
+	                - via_landed_cost_voucher: landed cost voucher cancels and reposts
+	                entries of purchase document. This flag is used to identify if
+	                cancellation and repost is happening via landed cost voucher, in
+	                such cases certain validations need to be ignored (like negative
+	                                                stock)
 	"""
 	from erpnext.controllers.stock_controller import future_sle_exists
 
@@ -527,12 +527,12 @@ class update_entries_after:
 
 	:param args: args as dict
 
-	        args = {
-	                "item_code": "ABC",
-	                "warehouse": "XYZ",
-	                "posting_date": "2012-12-12",
-	                "posting_time": "12:00"
-	        }
+	                args = {
+	                                "item_code": "ABC",
+	                                "warehouse": "XYZ",
+	                                "posting_date": "2012-12-12",
+	                                "posting_time": "12:00"
+	                }
 	"""
 
 	def __init__(
@@ -603,15 +603,15 @@ class update_entries_after:
 		:Data Structure:
 
 		self.data = {
-		        warehouse1: {
-		                'previus_sle': {},
-		                'qty_after_transaction': 10,
-		                'valuation_rate': 100,
-		                'stock_value': 1000,
-		                'prev_stock_value': 1000,
-		                'stock_queue': '[[10, 100]]',
-		                'stock_value_difference': 1000
-		        }
+		                warehouse1: {
+		                                'previus_sle': {},
+		                                'qty_after_transaction': 10,
+		                                'valuation_rate': 100,
+		                                'stock_value': 1000,
+		                                'prev_stock_value': 1000,
+		                                'stock_queue': '[[10, 100]]',
+		                                'stock_value_difference': 1000
+		                }
 		}
 
 		"""
@@ -1656,11 +1656,11 @@ def get_previous_sle(args, for_update=False, extra_cond=None):
 	is called from various transaction like stock entry, reco etc
 
 	args = {
-	        "item_code": "ABC",
-	        "warehouse": "XYZ",
-	        "posting_date": "2012-12-12",
-	        "posting_time": "12:00",
-	        "sle": "name of reference Stock Ledger Entry"
+	                "item_code": "ABC" or ["ABC", "XYZ"],
+	                "warehouse": "XYZ" or ["XYZ", "ABC"],
+	                "posting_date": "2012-12-12",
+	                "posting_time": "12:00",
+	                "sle": "name of reference Stock Ledger Entry"
 	}
 	"""
 	args["name"] = args.get("sle", None) or ""
@@ -1682,8 +1682,20 @@ def get_stock_ledger_entries(
 ):
 	"""get stock ledger entries filtered by specific posting datetime conditions"""
 	conditions = f" and posting_datetime {operator} %(posting_datetime)s"
-	if previous_sle.get("warehouse"):
-		conditions += " and warehouse = %(warehouse)s"
+
+	if item_code := previous_sle.get("item_code"):
+		if isinstance(item_code, list | tuple):
+			conditions += " and item_code in %(item_code)s"
+		else:
+			conditions += " and item_code = %(item_code)s"
+
+	if warehouse := previous_sle.get("warehouse"):
+		if isinstance(warehouse, list | tuple):
+			conditions += " and warehouse in %(warehouse)s"
+
+		else:
+			conditions += " and warehouse = %(warehouse)s"
+
 	elif previous_sle.get("warehouse_condition"):
 		conditions += " and " + previous_sle.get("warehouse_condition")
 
@@ -1726,8 +1738,7 @@ def get_stock_ledger_entries(
 		"""
 		select *, posting_datetime as "timestamp"
 		from `tabStock Ledger Entry`
-		where item_code = %(item_code)s
-		and is_cancelled = 0
+		where is_cancelled = 0
 		{conditions}
 		order by posting_datetime {order}, creation {order}
 		{limit} {for_update}""".format(

--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -57,12 +57,12 @@ def make_sl_entries(sl_entries, allow_negative_stock=False, via_landed_cost_vouc
 	"""Create SL entries from SL entry dicts
 
 	args:
-	                - allow_negative_stock: disable negative stock valiations if true
-	                - via_landed_cost_voucher: landed cost voucher cancels and reposts
-	                entries of purchase document. This flag is used to identify if
-	                cancellation and repost is happening via landed cost voucher, in
-	                such cases certain validations need to be ignored (like negative
-	                                                stock)
+	        - allow_negative_stock: disable negative stock valiations if true
+	        - via_landed_cost_voucher: landed cost voucher cancels and reposts
+	        entries of purchase document. This flag is used to identify if
+	        cancellation and repost is happening via landed cost voucher, in
+	        such cases certain validations need to be ignored (like negative
+	                        stock)
 	"""
 	from erpnext.controllers.stock_controller import future_sle_exists
 
@@ -527,12 +527,12 @@ class update_entries_after:
 
 	:param args: args as dict
 
-	                args = {
-	                                "item_code": "ABC",
-	                                "warehouse": "XYZ",
-	                                "posting_date": "2012-12-12",
-	                                "posting_time": "12:00"
-	                }
+	        args = {
+	                "item_code": "ABC",
+	                "warehouse": "XYZ",
+	                "posting_date": "2012-12-12",
+	                "posting_time": "12:00"
+	        }
 	"""
 
 	def __init__(
@@ -603,15 +603,15 @@ class update_entries_after:
 		:Data Structure:
 
 		self.data = {
-		                warehouse1: {
-		                                'previus_sle': {},
-		                                'qty_after_transaction': 10,
-		                                'valuation_rate': 100,
-		                                'stock_value': 1000,
-		                                'prev_stock_value': 1000,
-		                                'stock_queue': '[[10, 100]]',
-		                                'stock_value_difference': 1000
-		                }
+		        warehouse1: {
+		                'previus_sle': {},
+		                'qty_after_transaction': 10,
+		                'valuation_rate': 100,
+		                'stock_value': 1000,
+		                'prev_stock_value': 1000,
+		                'stock_queue': '[[10, 100]]',
+		                'stock_value_difference': 1000
+		        }
 		}
 
 		"""
@@ -1656,11 +1656,11 @@ def get_previous_sle(args, for_update=False, extra_cond=None):
 	is called from various transaction like stock entry, reco etc
 
 	args = {
-	                "item_code": "ABC" or ["ABC", "XYZ"],
-	                "warehouse": "XYZ" or ["XYZ", "ABC"],
-	                "posting_date": "2012-12-12",
-	                "posting_time": "12:00",
-	                "sle": "name of reference Stock Ledger Entry"
+	        "item_code": "ABC",
+	        "warehouse": "XYZ",
+	        "posting_date": "2012-12-12",
+	        "posting_time": "12:00",
+	        "sle": "name of reference Stock Ledger Entry"
 	}
 	"""
 	args["name"] = args.get("sle", None) or ""


### PR DESCRIPTION
- Previously, in Stock Balance and Stock Ledger reports users could only filter by a single Item or Warehouse at a time. This limitation made it tedious to compare stock movements across multiple items or warehouse locations.

- This PR transforms the filters for item_code and warehouse into MultiSelectList field. Users can now select multiple items and multiple warehouses at once, enabling more flexible reporting.

<img width="1453" height="444" alt="image" src="https://github.com/user-attachments/assets/04b489ca-bad3-4450-bbe3-20ed2a16cf98" />

<img width="1856" height="438" alt="image" src="https://github.com/user-attachments/assets/fbef33dc-3ada-4533-b468-c66f035ee7a8" />


### Usecases:

1. Multi-Item Stock Overview
2. Consolidated Stock Ledger Across Warehouses
3. Batch Item and Location Analysis

`no-docs`: as this just enhances the filter functionality