### PR TITLE
fix: pos minor issues

### DIFF
--- a/erpnext/selling/page/point_of_sale/pos_controller.js
+++ b/erpnext/selling/page/point_of_sale/pos_controller.js
@@ -526,9 +526,7 @@ erpnext.PointOfSale.Controller = class {
 							() => this.make_invoice_frm(doc.doctype),
 							() => this.make_return_invoice(doc),
 							() => this.cart.load_invoice(),
-							() => this.item_selector.toggle_component(true),
-							() => this.item_selector.resize_selector(false),
-							() => this.item_details.toggle_component(false),
+							() => this.toggle_components(true),
 							() => frappe.dom.unfreeze(),
 						]);
 					});
@@ -541,9 +539,7 @@ erpnext.PointOfSale.Controller = class {
 						() => this.frm.refresh(name),
 						() => this.frm.call("reset_mode_of_payments"),
 						() => this.cart.load_invoice(),
-						() => this.item_selector.toggle_component(true),
-						() => this.item_selector.resize_selector(false),
-						() => this.item_details.toggle_component(false),
+						() => this.toggle_components(true),
 					]);
 				},
 				delete_order: (doctype, name) => {

--- a/erpnext/selling/page/point_of_sale/pos_item_cart.js
+++ b/erpnext/selling/page/point_of_sale/pos_item_cart.js
@@ -558,14 +558,8 @@ erpnext.PointOfSale.ItemCart = class {
 			const taxes_html = taxes
 				.map((t) => {
 					if (t.tax_amount_after_discount_amount == 0.0) return;
-					// if tax rate is 0, don't print it.
-					const description = /[0-9]+/.test(t.description)
-						? t.description
-						: t.rate != 0
-						? `${t.description} @ ${t.rate}%`
-						: t.description;
 					return `<div class="tax-row">
-					<div class="tax-label">${description}</div>
+					<div class="tax-label">${t.description}</div>
 					<div class="tax-value">${format_currency(t.tax_amount_after_discount_amount, currency)}</div>
 				</div>`;
 				})

--- a/erpnext/selling/page/point_of_sale/pos_item_selector.js
+++ b/erpnext/selling/page/point_of_sale/pos_item_selector.js
@@ -367,28 +367,6 @@ erpnext.PointOfSale.ItemSelector = class {
 		this.set_search_value("");
 	}
 
-	resize_selector(minimize) {
-		minimize
-			? this.$component
-					.find(".filter-section")
-					.css("grid-template-columns", "repeat(1, minmax(0, 1fr))")
-			: this.$component
-					.find(".filter-section")
-					.css("grid-template-columns", "repeat(12, minmax(0, 1fr))");
-
-		minimize
-			? this.$component.find(".search-field").css("margin", "var(--margin-sm) 0px")
-			: this.$component.find(".search-field").css("margin", "0px var(--margin-sm)");
-
-		minimize
-			? this.$component.css("grid-column", "span 2 / span 2")
-			: this.$component.css("grid-column", "span 6 / span 6");
-
-		minimize
-			? this.$items_container.css("grid-template-columns", "repeat(1, minmax(0, 1fr))")
-			: this.$items_container.css("grid-template-columns", "repeat(4, minmax(0, 1fr))");
-	}
-
 	toggle_component(show) {
 		this.set_search_value("");
 		this.$component.css("display", show ? "flex" : "none");

--- a/erpnext/selling/page/point_of_sale/pos_past_order_summary.js
+++ b/erpnext/selling/page/point_of_sale/pos_past_order_summary.js
@@ -160,15 +160,9 @@ erpnext.PointOfSale.PastOrderSummary = class {
 
 		let taxes_html = doc.taxes
 			.map((t) => {
-				// if tax rate is 0, don't print it.
-				const description = /[0-9]+/.test(t.description)
-					? t.description
-					: t.rate != 0
-					? `${t.description} @ ${t.rate}%`
-					: t.description;
 				return `
 				<div class="tax-row">
-					<div class="tax-label">${description}</div>
+					<div class="tax-label">${t.description}</div>
 					<div class="tax-value">${format_currency(t.tax_amount_after_discount_amount, doc.currency)}</div>
 				</div>
 			`;


### PR DESCRIPTION
Changes include:
- Removed Tax Rate from POS Item Cart and POS Recent Order Summary, as different Items can have different Item Tax Templates from the Tax Rate set on Sales Taxes and Charges.
- Toggle Components on Load Invoices for Return Invoice and Edit Invoice.