### PR TITLE
39405/update Reconcile Date based on the user selection in the Payment Reconciliation

### DIFF
--- a/erpnext/accounts/doctype/payment_reconciliation_allocation/payment_reconciliation_allocation.json
+++ b/erpnext/accounts/doctype/payment_reconciliation_allocation/payment_reconciliation_allocation.json
@@ -11,6 +11,7 @@
   "column_break_3",
   "invoice_type",
   "invoice_number",
+  "reconcile_date",
   "section_break_6",
   "allocated_amount",
   "unreconciled_amount",
@@ -168,17 +169,25 @@
   {
    "fieldname": "dimension_col_break",
    "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "reconcile_date",
+   "fieldtype": "Date",
+   "in_list_view": 1,
+   "label": "Reconcile Date"
   }
  ],
+ "grid_page_length": 50,
  "is_virtual": 1,
  "istable": 1,
  "links": [],
- "modified": "2023-12-14 13:38:26.104150",
+ "modified": "2025-07-03 10:38:21.000941",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Payment Reconciliation Allocation",
  "owner": "Administrator",
  "permissions": [],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": [],

--- a/erpnext/accounts/doctype/payment_reconciliation_allocation/payment_reconciliation_allocation.py
+++ b/erpnext/accounts/doctype/payment_reconciliation_allocation/payment_reconciliation_allocation.py
@@ -28,6 +28,7 @@ class PaymentReconciliationAllocation(Document):
 		parent: DF.Data
 		parentfield: DF.Data
 		parenttype: DF.Data
+		reconcile_date: DF.Date | None
 		reference_name: DF.DynamicLink
 		reference_row: DF.Data | None
 		reference_type: DF.Link

--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -712,23 +712,10 @@ def update_reference_in_payment_entry(
 	}
 	update_advance_paid = []
 
-	# Update Reconciliation effect date in reference
-	reconciliation_takes_effect_on = frappe.get_cached_value(
-		"Company", payment_entry.company, "reconciliation_takes_effect_on"
-	)
+	# Update Reconciliation effect date in reference from the Payment Reconciliation Tool
+	
 	if payment_entry.book_advance_payments_in_separate_party_account:
-		if reconciliation_takes_effect_on == "Advance Payment Date":
-			reconcile_on = payment_entry.posting_date
-		elif reconciliation_takes_effect_on == "Oldest Of Invoice Or Advance":
-			date_field = "posting_date"
-			if d.against_voucher_type in ["Sales Order", "Purchase Order"]:
-				date_field = "transaction_date"
-			reconcile_on = frappe.db.get_value(d.against_voucher_type, d.against_voucher, date_field)
-
-			if getdate(reconcile_on) < getdate(payment_entry.posting_date):
-				reconcile_on = payment_entry.posting_date
-		elif reconciliation_takes_effect_on == "Reconciliation Date":
-			reconcile_on = nowdate()
+		reconcile_on = d.reconcile_date or nowdate()
 
 		reference_details.update({"reconcile_effect_on": reconcile_on})
 

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -1663,7 +1663,9 @@ class AccountsController(TransactionBase):
 								self.name,
 								arg.get("referenced_row"),
 							):
-								posting_date = arg.get("difference_posting_date") or frappe.db.get_value(
+								# if gain/loss journal is created from payment reconciliation, then use the reconcile date
+								# else use the difference posting date or the posting date of the voucher
+								posting_date = arg.get("reconcile_date") or arg.get("difference_posting_date") or frappe.db.get_value(
 									arg.voucher_type, arg.voucher_no, "posting_date"
 								)
 								je = create_gain_loss_journal(


### PR DESCRIPTION

Enhance the "Allocation" child table in the Payment Reconciliation Doctype by adding a new column: Reconcile Date.

The Reconcile Date will be auto-populated based on the reference type and the "Reconciliation Takes Effect On" setting, as follows:

Reference: Payment Entry

If "Reconciliation Takes Effect On" is set to "Oldest of Invoice or Advance" or "Advance Payment Date":

Set Reconcile Date to the latest of Posting Date of the Payment Entry or Posting Date of the Invoice

If "Reconciliation Takes Effect On" is set to "Reconciliation Date":

Set Reconcile Date to the current date (i.e., today’s date)

Reference: Journal Entry

Set Reconcile Date to the latest Posting Date among the two Journal Entries involved

Users can manually edit the Reconcile Date field directly in the Allocation table.

When the user clicks "Reconcile", the system will use the Reconcile Date values as specified (whether auto-set or manually updated) to finalize the reconciliation.
