### PR TITLE
fix: add selling price validation on update item

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -3985,6 +3985,7 @@ def update_child_qty_rate(parent_doctype, trans_items, parent_doctype_name, chil
 						).format(frappe.bold(parent.name))
 					)
 	else:  # Sales Order
+		parent.validate_selling_price()
 		parent.validate_for_duplicate_items()
 		parent.validate_warehouse()
 		parent.update_reserved_qty()


### PR DESCRIPTION
Issue: Selling Price validation is not happening on update item in sales order.

Ref: [42927](https://support.frappe.io/helpdesk/tickets/42927)

Before:

[Screencast from 04-07-25 08:30:34 PM IST.webm](https://github.com/user-attachments/assets/f4ba7dc3-67c8-4bc2-b966-4bca85828c99)

After:

[Screencast from 04-07-25 08:31:38 PM IST.webm](https://github.com/user-attachments/assets/fe4304b0-d43b-4524-97e9-b990f92f0ab6)


**Backport Needed: Version-15**