### PR TITLE
fix: resolve bundle item into line item if againt default supplier ch…

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -1397,11 +1397,7 @@ def make_purchase_order_for_default_supplier(source_name, selected_items=None, t
 	suppliers = [item.get("supplier") for item in selected_items if item.get("supplier")]
 	suppliers = list(dict.fromkeys(suppliers))  # remove duplicates while preserving order
 
-	items_to_map = [
-		item.get("item_code")
-		for item in selected_items
-		if item.get("item_code") and item.get("delivered_by_supplier")
-	]
+	items_to_map = [item.get("item_code") for item in selected_items if item.get("item_code")]
 	items_to_map = list(set(items_to_map))
 
 	if not suppliers:

--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -1391,10 +1391,17 @@ def make_purchase_order_for_default_supplier(source_name, selected_items=None, t
 		target.stock_qty = flt(source.stock_qty) - flt(source.ordered_qty)
 		target.project = source_parent.project
 
+	def update_item_for_packed_item(source, target, source_parent):
+		target.qty = flt(source.qty) - flt(source.ordered_qty)
+
 	suppliers = [item.get("supplier") for item in selected_items if item.get("supplier")]
 	suppliers = list(dict.fromkeys(suppliers))  # remove duplicates while preserving order
 
-	items_to_map = [item.get("item_code") for item in selected_items if item.get("item_code")]
+	items_to_map = [
+		item.get("item_code")
+		for item in selected_items
+		if item.get("item_code") and item.get("delivered_by_supplier")
+	]
 	items_to_map = list(set(items_to_map))
 
 	if not suppliers:
@@ -1444,13 +1451,35 @@ def make_purchase_order_for_default_supplier(source_name, selected_items=None, t
 					"condition": lambda doc: doc.ordered_qty < doc.stock_qty
 					and doc.supplier == supplier
 					and doc.item_code in items_to_map
-					and doc.delivered_by_supplier == 1,
+					and not is_product_bundle(doc.item_code),
+				},
+				"Packed Item": {
+					"doctype": "Purchase Order Item",
+					"field_map": [
+						["name", "sales_order_packed_item"],
+						["parent", "sales_order"],
+						["uom", "uom"],
+						["conversion_factor", "conversion_factor"],
+						["parent_item", "product_bundle"],
+						["rate", "rate"],
+					],
+					"field_no_map": [
+						"price_list_rate",
+						"item_tax_template",
+						"discount_percentage",
+						"discount_amount",
+						"supplier",
+						"pricing_rules",
+					],
+					"postprocess": update_item_for_packed_item,
+					"condition": lambda doc: doc.parent_item in items_to_map,
 				},
 			},
 			target_doc,
 			set_missing_values,
 		)
 
+		set_delivery_date(doc.items, source_name)
 		doc.insert()
 		frappe.db.commit()
 		purchase_orders.append(doc)
@@ -1466,9 +1495,7 @@ def make_purchase_order(source_name, selected_items=None, target_doc=None):
 	if isinstance(selected_items, str):
 		selected_items = json.loads(selected_items)
 
-	items_to_map = [
-		item.get("item_code") for item in selected_items if item.get("item_code") and item.get("item_code")
-	]
+	items_to_map = [item.get("item_code") for item in selected_items if item.get("item_code")]
 	items_to_map = list(set(items_to_map))
 
 	def is_drop_ship_order(target):

--- a/erpnext/stock/doctype/packed_item/packed_item.json
+++ b/erpnext/stock/doctype/packed_item/packed_item.json
@@ -23,6 +23,7 @@
   "use_serial_batch_fields",
   "column_break_11",
   "serial_and_batch_bundle",
+  "delivered_by_supplier",
   "section_break_bgys",
   "serial_no",
   "column_break_qlha",
@@ -290,18 +291,26 @@
   {
    "fieldname": "column_break_qlha",
    "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "fieldname": "delivered_by_supplier",
+   "fieldtype": "Check",
+   "label": "Supplier delivers to Customer",
+   "read_only": 1
   }
  ],
  "idx": 1,
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-02-18 13:06:02.789654",
+ "modified": "2025-07-09 19:12:45.850219",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Packed Item",
  "owner": "Administrator",
  "permissions": [],
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],

--- a/erpnext/stock/doctype/packed_item/packed_item.py
+++ b/erpnext/stock/doctype/packed_item/packed_item.py
@@ -27,6 +27,7 @@ class PackedItem(Document):
 		actual_qty: DF.Float
 		batch_no: DF.Link | None
 		conversion_factor: DF.Float
+		delivered_by_supplier: DF.Check
 		description: DF.TextEditor | None
 		incoming_rate: DF.Currency
 		item_code: DF.Link | None
@@ -218,6 +219,7 @@ def update_packed_item_basic_data(main_item_row, pi_row, packing_item, item_data
 	pi_row.uom = item_data.stock_uom
 	pi_row.qty = flt(packing_item.qty) * flt(main_item_row.stock_qty)
 	pi_row.conversion_factor = main_item_row.conversion_factor
+	pi_row.delivered_by_supplier = main_item_row.get("delivered_by_supplier")
 
 	if not pi_row.description:
 		pi_row.description = packing_item.get("description")


### PR DESCRIPTION
Issue:

- The packed items from the product bundle were added to the Purchase Order as individual line items. In the mapping process, the information that they are delivered by the supplier was lost. That is, the checkbox Delivered By Supplier is not getting set for the resolved bundle items.

- If Against Default Supplier is enabled in the dialog for creating a Purchase Order from a Sales Order, the bundle items are not getting resolved into line items.

Ref: [42514](https://support.frappe.io/helpdesk/tickets/42514)

Before:

[Screencast from 09-07-25 07:38:27 PM IST.webm](https://github.com/user-attachments/assets/a950f397-ad88-4f31-92ab-bd8144b45948)

After:

[Screencast from 09-07-25 07:40:14 PM IST.webm](https://github.com/user-attachments/assets/c042f193-9c35-4a1f-bda6-1cc5169545b4)




**Backport Needed: Version-15**