### PR TITLE
fix: NoneType object error on POS

### DIFF
--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -202,7 +202,7 @@ def update_stock(ctx, out, doc=None):
 				"item_code": ctx.item_code,
 				"warehouse": ctx.warehouse,
 				"based_on": frappe.get_single_value("Stock Settings", "pick_serial_and_batch_based_on"),
-				"sabb_voucher_no": doc.get("name"),
+				"sabb_voucher_no": ctx.name,
 				"sabb_voucher_detail_no": ctx.child_docname,
 				"sabb_voucher_type": ctx.doctype,
 			}


### PR DESCRIPTION
**Issue:** When adding item with POS Settings `invoice_type` configured to `POS Invoice` , `NoneType` object error raised from `update_stock` in `get_item_details.py`.

**Ref Screenshot:**

![Screenshot from 2025-07-02 18-11-14](https://github.com/user-attachments/assets/2dde37f0-3828-40a2-9a96-fe1b27127f7f)
