### PR TITLE
feat: add price list field to material request

### DIFF
--- a/erpnext/public/js/controllers/buying.js
+++ b/erpnext/public/js/controllers/buying.js
@@ -581,7 +581,8 @@ erpnext.buying.get_items_from_product_bundle = function(frm) {
 						transaction_date: frm.doc.transaction_date || frm.doc.posting_date,
 						ignore_pricing_rule: frm.doc.ignore_pricing_rule,
 						doctype: frm.doc.doctype
-					}
+					},
+					price_list: frm.doc.price_list,
 				},
 				freeze: true,
 				callback: function(r) {

--- a/erpnext/stock/doctype/material_request/material_request.js
+++ b/erpnext/stock/doctype/material_request/material_request.js
@@ -42,6 +42,15 @@ frappe.ui.form.on("Material Request", {
 				},
 			};
 		});
+
+		frm.set_query("price_list", () => {
+			return {
+				filters: {
+					buying: 1,
+					enabled: 1,
+				},
+			};
+		});
 	},
 
 	schedule_date(frm) {
@@ -78,6 +87,7 @@ frappe.ui.form.on("Material Request", {
 		});
 
 		erpnext.accounts.dimensions.setup_dimension_filters(frm, frm.doctype);
+		frm.doc.price_list = frappe.defaults.get_default("buying_price_list");
 	},
 
 	company: function (frm) {
@@ -259,7 +269,7 @@ frappe.ui.form.on("Material Request", {
 					from_warehouse: item.from_warehouse,
 					warehouse: item.warehouse,
 					doctype: frm.doc.doctype,
-					buying_price_list: frappe.defaults.get_default("buying_price_list"),
+					buying_price_list: frm.doc.price_list,
 					currency: frappe.defaults.get_default("Currency"),
 					name: frm.doc.name,
 					qty: item.qty || 1,

--- a/erpnext/stock/doctype/material_request/material_request.json
+++ b/erpnext/stock/doctype/material_request/material_request.json
@@ -16,6 +16,7 @@
   "column_break_2",
   "transaction_date",
   "schedule_date",
+  "price_list",
   "amended_from",
   "warehouse_section",
   "scan_barcode",
@@ -351,13 +352,19 @@
   {
    "fieldname": "column_break_13",
    "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "price_list",
+   "fieldtype": "Link",
+   "label": "Price List",
+   "options": "Price List"
   }
  ],
  "icon": "fa fa-ticket",
  "idx": 70,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-12-16 12:46:02.262167",
+ "modified": "2025-07-07 13:15:28.615984",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Material Request",
@@ -424,6 +431,7 @@
   }
  ],
  "quick_entry": 1,
+ "row_format": "Dynamic",
  "search_fields": "status,transaction_date",
  "show_name_in_global_search": 1,
  "sort_field": "creation",

--- a/erpnext/stock/doctype/material_request/material_request.py
+++ b/erpnext/stock/doctype/material_request/material_request.py
@@ -8,6 +8,7 @@
 import json
 
 import frappe
+import frappe.defaults
 from frappe import _, msgprint
 from frappe.model.mapper import get_mapped_doc
 from frappe.query_builder.functions import Sum
@@ -53,6 +54,7 @@ class MaterialRequest(BuyingController):
 		naming_series: DF.Literal["MAT-MR-.YYYY.-"]
 		per_ordered: DF.Percent
 		per_received: DF.Percent
+		price_list: DF.Link | None
 		scan_barcode: DF.Data | None
 		schedule_date: DF.Date | None
 		select_print_heading: DF.Link | None
@@ -160,6 +162,9 @@ class MaterialRequest(BuyingController):
 		self.reset_default_field_value("set_from_warehouse", "items", "from_warehouse")
 
 		self.validate_pp_qty()
+
+		if not self.price_list:
+			self.price_list = frappe.defaults.get_defaults().buying_price_list
 
 	def validate_pp_qty(self):
 		items_from_pp = [item for item in self.items if item.material_request_plan_item]

--- a/erpnext/stock/doctype/packed_item/packed_item.py
+++ b/erpnext/stock/doctype/packed_item/packed_item.py
@@ -349,9 +349,8 @@ def on_doctype_update():
 
 
 @frappe.whitelist()
-def get_items_from_product_bundle(row):
+def get_items_from_product_bundle(row, price_list):
 	row, items = ItemDetailsCtx(json.loads(row)), []
-	defaults = frappe.defaults.get_defaults()
 
 	bundled_items = get_product_bundle_items(row["item_code"])
 	for item in bundled_items:
@@ -360,8 +359,8 @@ def get_items_from_product_bundle(row):
 				"item_code": item.item_code,
 				"qty": flt(row["quantity"]) * flt(item.qty),
 				"conversion_rate": 1,
-				"price_list": defaults.buying_price_list,
-				"currency": defaults.currency,
+				"price_list": price_list,
+				"currency": frappe.defaults.get_defaults().currency,
 			}
 		)
 		items.append(get_item_details(row))


### PR DESCRIPTION
Reference support ticket [42648](https://support.frappe.io/helpdesk/tickets/42648)

Users will now have an option to select buying price list when creating material requests.