### PR TITLE
fix: Add company validation to company related fields in Process Statement Of Accounts

### DIFF
--- a/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.js
+++ b/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.js
@@ -54,6 +54,9 @@ frappe.ui.form.on("Process Statement Of Accounts", {
 			};
 		});
 		frm.set_query("account", function () {
+			if (!frm.doc.company) {
+				frappe.throw(__("Please set Company"));
+			}
 			return {
 				filters: {
 					company: frm.doc.company,
@@ -61,6 +64,9 @@ frappe.ui.form.on("Process Statement Of Accounts", {
 			};
 		});
 		frm.set_query("cost_center", function () {
+			if (!frm.doc.company) {
+				frappe.throw(__("Please set Company"));
+			}
 			return {
 				filters: {
 					company: frm.doc.company,
@@ -68,6 +74,9 @@ frappe.ui.form.on("Process Statement Of Accounts", {
 			};
 		});
 		frm.set_query("project", function () {
+			if (!frm.doc.company) {
+				frappe.throw(__("Please set Company"));
+			}
 			return {
 				filters: {
 					company: frm.doc.company,
@@ -78,6 +87,11 @@ frappe.ui.form.on("Process Statement Of Accounts", {
 			frm.set_value("from_date", frappe.datetime.add_months(frappe.datetime.get_today(), -1));
 			frm.set_value("to_date", frappe.datetime.get_today());
 		}
+	},
+	company: function (frm) {
+		frm.set_value("account", "");
+		frm.set_value("cost_center", "");
+		frm.set_value("project", "");
 	},
 	report: function (frm) {
 		let filters = {


### PR DESCRIPTION
 Add company validation to account, cost centre, and project fields in Process Statement Of Accounts.

- On change of company, empty fields.
- On selection of the field, if the company is not set, then throw an error.
- Backend validation for company-related fields.

![image](https://github.com/user-attachments/assets/ace30b9f-9994-4a97-815d-9f7ac5c66aca)

![image](https://github.com/user-attachments/assets/cf20f4e6-62a4-4c61-a843-ff88733f55d7)



Closes: https://github.com/frappe/erpnext/issues/48264
Closes: https://github.com/frappe/erpnext/issues/48256
