### PR TITLE
fix: prevent creation of root accounts in account tree view

### DIFF
--- a/erpnext/accounts/doctype/account/account_tree.js
+++ b/erpnext/accounts/doctype/account/account_tree.js
@@ -236,6 +236,10 @@ frappe.treeview_settings["Account"] = {
 							root_company,
 						]);
 					} else {
+						const node = treeview.tree.get_selected_node();
+						if (node.is_root) {
+							frappe.throw(__("Cannot create root account."));
+						}
 						treeview.new_node();
 					}
 				},
@@ -254,7 +258,8 @@ frappe.treeview_settings["Account"] = {
 					].treeview.page.fields_dict.root_company.get_value() ||
 						frappe.flags.ignore_root_company_validation) &&
 					node.expandable &&
-					!node.hide_add
+					!node.hide_add &&
+					!node.is_root
 				);
 			},
 			click: function () {


### PR DESCRIPTION
Issue: Root Account cannot be created from ui.Users get different errors.

Before:
![image](https://github.com/user-attachments/assets/9c499de2-4f8d-4d8c-819e-f095dbc532b5)

![image](https://github.com/user-attachments/assets/f8cab9b0-2ffa-469e-9614-c61129e2c9f6)





After:
![image](https://github.com/user-attachments/assets/2c8b39c5-9159-47f0-9ce2-4c76c3ee725a)


![image](https://github.com/user-attachments/assets/90513111-9740-4971-973b-666be52a1275)


Closes: https://github.com/frappe/erpnext/issues/48257
