### PR TITLE
fix: use default buying price list when price list is falsy

### DIFF
--- a/erpnext/stock/doctype/material_request/material_request.js
+++ b/erpnext/stock/doctype/material_request/material_request.js
@@ -269,7 +269,9 @@ frappe.ui.form.on("Material Request", {
 					from_warehouse: item.from_warehouse,
 					warehouse: item.warehouse,
 					doctype: frm.doc.doctype,
-					buying_price_list: frm.doc.price_list,
+					buying_price_list: frm.doc.price_list
+						? frm.doc.price_list
+						: frappe.defaults.get_default("buying_price_list"),
 					currency: frappe.defaults.get_default("Currency"),
 					name: frm.doc.name,
 					qty: item.qty || 1,


### PR DESCRIPTION
Uses the default buying price list to get item data in Material Request when Price List is falsy.