### PR TITLE
fix: resolve sql error on dimension-wise accounts balance report

### DIFF
--- a/erpnext/accounts/report/dimension_wise_accounts_balance_report/dimension_wise_accounts_balance_report.py
+++ b/erpnext/accounts/report/dimension_wise_accounts_balance_report/dimension_wise_accounts_balance_report.py
@@ -179,7 +179,7 @@ def accumulate_values_into_parents(accounts, accounts_by_name, dimension_list):
 def get_condition(dimension):
 	conditions = []
 
-	conditions.append(f"{frappe.scrub(dimension)} in %(dimensions)s")
+	conditions.append(f"{frappe.scrub(dimension)} in (%(dimensions)s)")
 
 	return " and {}".format(" and ".join(conditions)) if conditions else ""
 


### PR DESCRIPTION
Resolved SQL Syntax error on the Dimension-wise Accounts Balance Report.