### PR TITLE
fix: stock settings save issue

### DIFF
--- a/erpnext/stock/doctype/stock_settings/stock_settings.py
+++ b/erpnext/stock/doctype/stock_settings/stock_settings.py
@@ -121,7 +121,11 @@ class StockSettings(Document):
 				)
 
 	def cant_change_valuation_method(self):
-		previous_valuation_method = self.get_doc_before_save().get("valuation_method")
+		doc_before_save = self.get_doc_before_save()
+		if not doc_before_save:
+			return
+
+		previous_valuation_method = doc_before_save.get("valuation_method")
 
 		if previous_valuation_method and previous_valuation_method != self.valuation_method:
 			# check if there are any stock ledger entries against items


### PR DESCRIPTION
```
  File "apps/erpnext/erpnext/setup/setup_wizard/operations/install_fixtures.py", line 478, in install_defaults
    update_stock_settings()
  File "apps/erpnext/erpnext/setup/setup_wizard/operations/install_fixtures.py", line 509, in update_stock_settings
    stock_settings.save()
  File "apps/frappe/frappe/model/document.py", line 483, in save
    return self._save(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/model/document.py", line 505, in _save
    return self.insert()
           ^^^^^^^^^^^^^
  File "apps/frappe/frappe/model/document.py", line 413, in insert
    self.run_before_save_methods()
  File "apps/frappe/frappe/model/document.py", line 1278, in run_before_save_methods
    self.run_method("validate")
  File "apps/frappe/frappe/model/document.py", line 1127, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/model/document.py", line 1518, in composer
    return composed(self, method, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/model/document.py", line 1496, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
                              ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/model/document.py", line 1124, in fn
    return method_object(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/erpnext/erpnext/stock/doctype/stock_settings/stock_settings.py", line 105, in validate
    self.cant_change_valuation_method()
  File "apps/erpnext/erpnext/stock/doctype/stock_settings/stock_settings.py", line 124, in cant_change_valuation_method
    previous_valuation_method = self.get_doc_before_save().get("valuation_method")
                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'get'
```