### PR TITLE
feat: filter to display trial balance report without group account

### DIFF
--- a/erpnext/accounts/report/trial_balance/trial_balance.js
+++ b/erpnext/accounts/report/trial_balance/trial_balance.js
@@ -111,6 +111,12 @@ frappe.query_reports["Trial Balance"] = {
 			fieldtype: "Check",
 			default: 1,
 		},
+		{
+			fieldname: "show_group_accounts",
+			label: __("Show Group Accounts"),
+			fieldtype: "Check",
+			default: 1,
+		},
 	],
 	formatter: erpnext.financial_statements.formatter,
 	tree: true,


### PR DESCRIPTION
Added a filter, `Show Group Accounts`, on the Trial Balance Report. If the filter is unchecked, the Trial Balance Report will exclude Group Accounts. 

Trial Balance Report Filter
	
![image](https://github.com/user-attachments/assets/4c89221a-ae93-4f15-a62f-c46d30862df4)

Trial Balance Report excluding Group Accounts
	
![image](https://github.com/user-attachments/assets/6c8b8a7c-6f4f-457b-9b04-9491b675dfd5)

<!-- no-docs -->
