### PR TITLE
fix: pos adding item multiple times on applying item group filter

### DIFF
--- a/erpnext/selling/page/point_of_sale/pos_item_selector.js
+++ b/erpnext/selling/page/point_of_sale/pos_item_selector.js
@@ -345,7 +345,10 @@ erpnext.PointOfSale.ItemSelector = class {
 				const items = this.search_index[selling_price_list][search_term];
 				this.items = items;
 				this.render_item_list(items);
-				this.auto_add_item && this.items.length == 1 && this.add_filtered_item_to_cart();
+				this.auto_add_item &&
+					this.search_field.$input[0].value &&
+					this.items.length == 1 &&
+					this.add_filtered_item_to_cart();
 				return;
 			}
 		}
@@ -358,7 +361,10 @@ erpnext.PointOfSale.ItemSelector = class {
 			}
 			this.items = items;
 			this.render_item_list(items);
-			this.auto_add_item && this.items.length == 1 && this.add_filtered_item_to_cart();
+			this.auto_add_item &&
+				this.search_field.$input[0].value &&
+				this.items.length == 1 &&
+				this.add_filtered_item_to_cart();
 		});
 	}
 


### PR DESCRIPTION
Resolved the issue where if an Item Group has only one Item, then applying Item Group Filter on POS Item Selector would result in adding that item in the cart continuously.
