### PR TITLE
fix: incorrect last sle for no batch wise valuation

### DIFF
--- a/erpnext/stock/deprecated_serial_batch.py
+++ b/erpnext/stock/deprecated_serial_batch.py
@@ -318,6 +318,12 @@ class DeprecatedBatchNoValuation:
 		if self.sle.name:
 			query = query.where(sle.name != self.sle.name)
 
+		if self.sle.serial_and_batch_bundle:
+			query = query.where(
+				(sle.serial_and_batch_bundle != self.sle.serial_and_batch_bundle)
+				| (sle.serial_and_batch_bundle.isnull())
+			)
+
 		data = query.run(as_dict=True)
 
 		return data[0] if data else frappe._dict()


### PR DESCRIPTION
The system was picking an incorrect last SLE for batches where 'Use Batch-wise Valuation' was disabled. Due to the incorrect SLE, the system calculated an incorrect valuation rate, which caused the error: pymysql.err.DataError: (1264, 'Out of range value for column ''stock_value_difference'' at row 1').