### PR TITLE
fix: add undefined check for cur_frm in lead doctype (#48522)

### DIFF
--- a/erpnext/crm/doctype/lead/lead.js
+++ b/erpnext/crm/doctype/lead/lead.js
@@ -2,8 +2,8 @@
 // License: GNU General Public License v3. See license.txt
 
 frappe.provide("erpnext");
-if (cur_frm) {
-cur_frm.email_field = "email_id";
+if (this.frm) {
+	this.frm.email_field = "email_id";
 }
 erpnext.LeadController = class LeadController extends frappe.ui.form.Controller {
 	setup() {
@@ -239,6 +239,6 @@ erpnext.LeadController = class LeadController extends frappe.ui.form.Controller 
 		crm_activities.refresh();
 	}
 };
-if (cur_frm) {
-extend_cscript(cur_frm.cscript, new erpnext.LeadController({ frm: cur_frm }));
+if (this.frm) {
+	extend_cscript(this.frm.cscript, new erpnext.LeadController({ frm: this.frm }));
 }

--- a/erpnext/crm/doctype/lead/lead.js
+++ b/erpnext/crm/doctype/lead/lead.js
@@ -2,8 +2,9 @@
 // License: GNU General Public License v3. See license.txt
 
 frappe.provide("erpnext");
+if (cur_frm) {
 cur_frm.email_field = "email_id";
-
+}
 erpnext.LeadController = class LeadController extends frappe.ui.form.Controller {
 	setup() {
 		this.frm.make_methods = {
@@ -238,5 +239,6 @@ erpnext.LeadController = class LeadController extends frappe.ui.form.Controller 
 		crm_activities.refresh();
 	}
 };
-
+if (cur_frm) {
 extend_cscript(cur_frm.cscript, new erpnext.LeadController({ frm: cur_frm }));
+}


### PR DESCRIPTION
As said in (#48522) if the quick entry is enabled in the lead doctype one can't access neither the entry dialog neither the create lead doctype so this PR provide a possiable solution to avoid that issue by checking if cur_frm is defined before useage (To Avoid Uncaught TypeErrors) 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability by preventing potential errors when certain fields are not available during lead management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->