### PR TITLE
feat: add calculate_ageing_with option in summary reports

### DIFF
--- a/erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js
+++ b/erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js
@@ -24,6 +24,13 @@ frappe.query_reports["Accounts Payable Summary"] = {
 			default: "Due Date",
 		},
 		{
+			fieldname: "calculate_ageing_with",
+			label: __("Calculate Ageing With"),
+			fieldtype: "Select",
+			options: "Report Date\nToday Date",
+			default: "Report Date",
+		},
+		{
 			fieldname: "range",
 			label: __("Ageing Range"),
 			fieldtype: "Data",

--- a/erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js
+++ b/erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js
@@ -24,6 +24,13 @@ frappe.query_reports["Accounts Receivable Summary"] = {
 			default: "Due Date",
 		},
 		{
+			fieldname: "calculate_ageing_with",
+			label: __("Calculate Ageing With"),
+			fieldtype: "Select",
+			options: "Report Date\nToday Date",
+			default: "Report Date",
+		},
+		{
 			fieldname: "range",
 			label: __("Ageing Range"),
 			fieldtype: "Data",


### PR DESCRIPTION
Issue: Accounts Payable Summary showing wrong data

Ref: [43414](https://support.frappe.io/helpdesk/tickets/43414)

<img width="1860" height="973" alt="image" src="https://github.com/user-attachments/assets/e3875793-49c2-4fd0-b30a-4e33ba882f15" />


<img width="1863" height="973" alt="image" src="https://github.com/user-attachments/assets/fbf0973d-74fa-4723-adf9-da7e4472a17a" />



<img width="1860" height="973" alt="image" src="https://github.com/user-attachments/assets/e929ab59-4e05-4ef3-be3a-346474c671af" />



**Backport Needed: Version-15**