### PR TITLE
POS fix item initial load

### DIFF
--- a/erpnext/selling/page/point_of_sale/point_of_sale.py
+++ b/erpnext/selling/page/point_of_sale/point_of_sale.py
@@ -129,7 +129,7 @@ def get_parent_item_group():
 
 
 @frappe.whitelist()
-def get_items(start, page_length, price_list, item_group, pos_profile, search_term=""):
+def get_items(start=0, page_length=20, price_list="", item_group="", pos_profile="", search_term=""):
 	warehouse, hide_unavailable_items = frappe.db.get_value(
 		"POS Profile", pos_profile, ["warehouse", "hide_unavailable_items"]
 	)


### PR DESCRIPTION
The POS has error everytime the page load.
Then the item is not appear in the list until item groups manually selected.