### PR TITLE
fix(transaction): recalculate tax and total when quantity changes

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -1437,6 +1437,7 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 			]);
 		} else {
 			this.conversion_factor(doc, cdt, cdn, true)
+			this.calculate_taxes_and_totals()
 		}
 	}
 


### PR DESCRIPTION
**Ref:**  [43530](https://support.frappe.io/helpdesk/tickets/43530)

**Issue:** Tax and total amounts were not updating when the item quantity changed in a transaction.

**Steps to Reproduce:**
- Create a Sales Order.
- Submit the order.
- Create a Sales Invoice from the submitted Sales Order.
- In the Sales Invoice, change the quantity of the item.
- Observe that the amount, tax, and total do not update automatically.

**Fix:** Trigger tax and total recalculation whenever the quantity is modified.

**Before:**

<img width="1423" height="892" alt="before_fix" src="https://github.com/user-attachments/assets/5875e87b-e40f-4049-aa20-2c60e4da2aa1" />


**After:**

<img width="1423" height="893" alt="after_fix" src="https://github.com/user-attachments/assets/96b0bd55-bc03-4cb5-92b0-21dd8c1a4e7f" />


**Backport needed v15**
