### PR TITLE
feat(payment gateway account): add company

### DIFF
--- a/erpnext/accounts/doctype/payment_gateway_account/payment_gateway_account.js
+++ b/erpnext/accounts/doctype/payment_gateway_account/payment_gateway_account.js
@@ -8,4 +8,14 @@ frappe.ui.form.on("Payment Gateway Account", {
 			frm.set_df_property("payment_gateway", "read_only", 1);
 		}
 	},
+
+	setup(frm) {
+		frm.set_query("payment_account", function () {
+			return {
+				filters: {
+					company: frm.doc.company,
+				},
+			};
+		});
+	},
 });

--- a/erpnext/accounts/doctype/payment_gateway_account/payment_gateway_account.json
+++ b/erpnext/accounts/doctype/payment_gateway_account/payment_gateway_account.json
@@ -7,6 +7,7 @@
  "field_order": [
   "payment_gateway",
   "payment_channel",
+  "company",
   "is_default",
   "column_break_4",
   "payment_account",
@@ -71,11 +72,21 @@
    "fieldtype": "Select",
    "label": "Payment Channel",
    "options": "\nEmail\nPhone\nOther"
+  },
+  {
+   "fieldname": "company",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Company",
+   "options": "Company",
+   "print_hide": 1,
+   "remember_last_selected_value": 1,
+   "reqd": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-03-29 18:53:09.836254",
+ "modified": "2025-07-14 16:49:55.210352",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Payment Gateway Account",
@@ -94,6 +105,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": []

--- a/erpnext/accounts/doctype/payment_gateway_account/payment_gateway_account.py
+++ b/erpnext/accounts/doctype/payment_gateway_account/payment_gateway_account.py
@@ -36,13 +36,15 @@ class PaymentGatewayAccount(Document):
 
 	def update_default_payment_gateway(self):
 		if self.is_default:
-			frappe.db.sql(
-				"""update `tabPayment Gateway Account` set is_default = 0
-				where is_default = 1 """
+			frappe.db.set_value(
+				"Payment Gateway Account",
+				{"is_default": 1, "name": ["!=", self.name], "company": self.company},
+				"is_default",
+				0,
 			)
 
 	def set_as_default_if_not_set(self):
-		if not frappe.db.get_value(
-			"Payment Gateway Account", {"is_default": 1, "name": ("!=", self.name)}, "name"
+		if not frappe.db.exists(
+			"Payment Gateway Account", {"is_default": 1, "name": ("!=", self.name), "company": self.company}
 		):
 			self.is_default = 1

--- a/erpnext/accounts/doctype/payment_gateway_account/payment_gateway_account.py
+++ b/erpnext/accounts/doctype/payment_gateway_account/payment_gateway_account.py
@@ -15,6 +15,7 @@ class PaymentGatewayAccount(Document):
 	if TYPE_CHECKING:
 		from frappe.types import DF
 
+		company: DF.Link
 		currency: DF.ReadOnly | None
 		is_default: DF.Check
 		message: DF.SmallText | None
@@ -24,7 +25,8 @@ class PaymentGatewayAccount(Document):
 	# end: auto-generated types
 
 	def autoname(self):
-		self.name = self.payment_gateway + " - " + self.currency
+		abbr = frappe.db.get_value("Company", self.company, "abbr")
+		self.name = self.payment_gateway + " - " + abbr
 
 	def validate(self):
 		self.currency = frappe.get_cached_value("Account", self.payment_account, "account_currency")

--- a/erpnext/accounts/doctype/payment_gateway_account/payment_gateway_account.py
+++ b/erpnext/accounts/doctype/payment_gateway_account/payment_gateway_account.py
@@ -26,7 +26,7 @@ class PaymentGatewayAccount(Document):
 
 	def autoname(self):
 		abbr = frappe.db.get_value("Company", self.company, "abbr")
-		self.name = self.payment_gateway + " - " + abbr
+		self.name = self.payment_gateway + " - " + self.currency + " - " + abbr
 
 	def validate(self):
 		self.currency = frappe.get_cached_value("Account", self.payment_account, "account_currency")

--- a/erpnext/accounts/doctype/payment_request/payment_request.js
+++ b/erpnext/accounts/doctype/payment_request/payment_request.js
@@ -9,6 +9,14 @@ frappe.ui.form.on("Payment Request", {
 				query: "erpnext.setup.doctype.party_type.party_type.get_party_type",
 			};
 		});
+
+		frm.set_query("payment_gateway_account", function () {
+			return {
+				filters: {
+					company: frm.doc.company,
+				},
+			};
+		});
 	},
 });
 

--- a/erpnext/accounts/doctype/payment_request/payment_request.py
+++ b/erpnext/accounts/doctype/payment_request/payment_request.py
@@ -534,7 +534,8 @@ def make_payment_request(**args):
 		frappe.throw(_("Payment Requests cannot be created against: {0}").format(frappe.bold(args.dt)))
 
 	ref_doc = args.ref_doc or frappe.get_doc(args.dt, args.dn)
-
+	if not args.get("company"):
+		args.company = ref_doc.company
 	gateway_account = get_gateway_details(args) or frappe._dict()
 
 	grand_total = get_amount(ref_doc, gateway_account.get("payment_account"))
@@ -781,7 +782,7 @@ def get_gateway_details(args):  # nosemgrep
 	"""
 	Return gateway and payment account of default payment gateway
 	"""
-	gateway_account = args.get("payment_gateway_account", {"is_default": 1})
+	gateway_account = args.get("payment_gateway_account", {"is_default": 1, "company": args.company})
 	return get_payment_gateway_account(gateway_account)
 
 

--- a/erpnext/accounts/doctype/payment_request/test_payment_request.py
+++ b/erpnext/accounts/doctype/payment_request/test_payment_request.py
@@ -34,12 +34,14 @@ payment_method = [
 		"payment_gateway": "_Test Gateway",
 		"payment_account": "_Test Bank - _TC",
 		"currency": "INR",
+		"company": "_Test Company",
 	},
 	{
 		"doctype": "Payment Gateway Account",
 		"payment_gateway": "_Test Gateway",
 		"payment_account": "_Test Bank USD - _TC",
 		"currency": "USD",
+		"company": "_Test Company",
 	},
 	{
 		"doctype": "Payment Gateway Account",
@@ -47,6 +49,7 @@ payment_method = [
 		"payment_account": "_Test Bank USD - _TC",
 		"payment_channel": "Other",
 		"currency": "USD",
+		"company": "_Test Company",
 	},
 	{
 		"doctype": "Payment Gateway Account",
@@ -54,6 +57,7 @@ payment_method = [
 		"payment_account": "_Test Bank USD - _TC",
 		"payment_channel": "Phone",
 		"currency": "USD",
+		"company": "_Test Company",
 	},
 ]
 
@@ -67,7 +71,11 @@ class TestPaymentRequest(IntegrationTestCase):
 		for method in payment_method:
 			if not frappe.db.get_value(
 				"Payment Gateway Account",
-				{"payment_gateway": method["payment_gateway"], "currency": method["currency"]},
+				{
+					"payment_gateway": method["payment_gateway"],
+					"currency": method["currency"],
+					"company": method["company"],
+				},
 				"name",
 			):
 				frappe.get_doc(method).insert(ignore_permissions=True)
@@ -103,7 +111,7 @@ class TestPaymentRequest(IntegrationTestCase):
 			dt="Sales Order",
 			dn=so_inr.name,
 			recipient_id="saurabh@erpnext.com",
-			payment_gateway_account="_Test Gateway - INR",
+			payment_gateway_account="_Test Gateway - INR - _TC",
 		)
 
 		self.assertEqual(pr.reference_doctype, "Sales Order")
@@ -117,7 +125,7 @@ class TestPaymentRequest(IntegrationTestCase):
 			dt="Sales Invoice",
 			dn=si_usd.name,
 			recipient_id="saurabh@erpnext.com",
-			payment_gateway_account="_Test Gateway - USD",
+			payment_gateway_account="_Test Gateway - USD - _TC",
 		)
 
 		self.assertEqual(pr.reference_doctype, "Sales Invoice")
@@ -130,7 +138,7 @@ class TestPaymentRequest(IntegrationTestCase):
 		pr = make_payment_request(
 			dt="Sales Order",
 			dn=so.name,
-			payment_gateway_account="_Test Gateway Other - USD",
+			payment_gateway_account="_Test Gateway Other - USD - _TC",
 			submit_doc=True,
 			return_doc=True,
 		)
@@ -145,7 +153,7 @@ class TestPaymentRequest(IntegrationTestCase):
 		pr = make_payment_request(
 			dt="Sales Order",
 			dn=so.name,
-			payment_gateway_account="_Test Gateway - USD",  # email channel
+			payment_gateway_account="_Test Gateway - USD - _TC",  # email channel
 			submit_doc=False,
 			return_doc=True,
 		)
@@ -163,7 +171,7 @@ class TestPaymentRequest(IntegrationTestCase):
 		pr = make_payment_request(
 			dt="Sales Order",
 			dn=so.name,
-			payment_gateway_account="_Test Gateway Phone - USD",
+			payment_gateway_account="_Test Gateway Phone - USD - _TC",
 			submit_doc=True,
 			return_doc=True,
 		)
@@ -180,7 +188,7 @@ class TestPaymentRequest(IntegrationTestCase):
 		pr = make_payment_request(
 			dt="Sales Order",
 			dn=so.name,
-			payment_gateway_account="_Test Gateway - USD",  # email channel
+			payment_gateway_account="_Test Gateway - USD - _TC",  # email channel
 			submit_doc=True,
 			return_doc=True,
 		)
@@ -201,7 +209,7 @@ class TestPaymentRequest(IntegrationTestCase):
 		pr = make_payment_request(
 			dt="Sales Order",
 			dn=so.name,
-			payment_gateway_account="_Test Gateway - USD",  # email channel
+			payment_gateway_account="_Test Gateway - USD - _TC",  # email channel
 			make_sales_invoice=True,
 			mute_email=True,
 			submit_doc=True,
@@ -232,7 +240,7 @@ class TestPaymentRequest(IntegrationTestCase):
 			party="_Test Supplier USD",
 			recipient_id="user@example.com",
 			mute_email=1,
-			payment_gateway_account="_Test Gateway - USD",
+			payment_gateway_account="_Test Gateway - USD - _TC",
 			submit_doc=1,
 			return_doc=1,
 		)
@@ -257,7 +265,7 @@ class TestPaymentRequest(IntegrationTestCase):
 			dn=purchase_invoice.name,
 			recipient_id="user@example.com",
 			mute_email=1,
-			payment_gateway_account="_Test Gateway - USD",
+			payment_gateway_account="_Test Gateway - USD - _TC",
 			return_doc=1,
 		)
 
@@ -276,7 +284,7 @@ class TestPaymentRequest(IntegrationTestCase):
 			dn=purchase_invoice.name,
 			recipient_id="user@example.com",
 			mute_email=1,
-			payment_gateway_account="_Test Gateway - USD",
+			payment_gateway_account="_Test Gateway - USD - _TC",
 			return_doc=1,
 		)
 
@@ -300,7 +308,7 @@ class TestPaymentRequest(IntegrationTestCase):
 			dn=so_inr.name,
 			recipient_id="saurabh@erpnext.com",
 			mute_email=1,
-			payment_gateway_account="_Test Gateway - INR",
+			payment_gateway_account="_Test Gateway - INR - _TC",
 			submit_doc=1,
 			return_doc=1,
 		)
@@ -322,7 +330,7 @@ class TestPaymentRequest(IntegrationTestCase):
 			dn=si_usd.name,
 			recipient_id="saurabh@erpnext.com",
 			mute_email=1,
-			payment_gateway_account="_Test Gateway - USD",
+			payment_gateway_account="_Test Gateway - USD - _TC",
 			submit_doc=1,
 			return_doc=1,
 		)
@@ -366,7 +374,7 @@ class TestPaymentRequest(IntegrationTestCase):
 			dn=si_usd.name,
 			recipient_id="saurabh@erpnext.com",
 			mute_email=1,
-			payment_gateway_account="_Test Gateway - USD",
+			payment_gateway_account="_Test Gateway - USD - _TC",
 			submit_doc=1,
 			return_doc=1,
 		)

--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -1357,6 +1357,7 @@ def create_payment_gateway_account(gateway, payment_channel="Email", company=Non
 				"payment_account": bank_account.name,
 				"currency": bank_account.account_currency,
 				"payment_channel": payment_channel,
+				"company": company,
 			}
 		).insert(ignore_permissions=True, ignore_if_duplicate=True)
 

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -428,3 +428,4 @@ erpnext.patches.v15_0.set_company_on_pos_inv_merge_log
 erpnext.patches.v15_0.rename_price_list_to_buying_price_list
 erpnext.patches.v15_0.patch_missing_buying_price_list_in_material_request
 erpnext.patches.v15_0.remove_sales_partner_from_consolidated_sales_invoice
+erpnext.patches.v15_0.add_company_payment_gateway_account

--- a/erpnext/patches/v15_0/add_company_payment_gateway_account.py
+++ b/erpnext/patches/v15_0/add_company_payment_gateway_account.py
@@ -1,0 +1,7 @@
+import frappe
+
+
+def execute():
+	for pgc in frappe.get_list("Payment Gateway Account", fields=["name", "payment_account"]):
+		company = frappe.db.get_value("Account", pgc.payment_account, "company")
+		frappe.db.set_value("Payment Gateway Account", pgc.name, "company", company)

--- a/erpnext/patches/v15_0/add_company_payment_gateway_account.py
+++ b/erpnext/patches/v15_0/add_company_payment_gateway_account.py
@@ -2,6 +2,6 @@ import frappe
 
 
 def execute():
-	for pgc in frappe.get_list("Payment Gateway Account", fields=["name", "payment_account"]):
-		company = frappe.db.get_value("Account", pgc.payment_account, "company")
-		frappe.db.set_value("Payment Gateway Account", pgc.name, "company", company)
+	for gateway_account in frappe.get_list("Payment Gateway Account", fields=["name", "payment_account"]):
+		company = frappe.db.get_value("Account", gateway_account.payment_account, "company")
+		frappe.db.set_value("Payment Gateway Account", gateway_account.name, "company", company)


### PR DESCRIPTION
Issue: When I have two companies and a Stripe payment gateway account set up for Company A, if I create a Sales Invoice for Company B and make a Payment Request, the system still shows Company A's Stripe payment gateway account.

Ref: [#43518](https://support.frappe.io/helpdesk/tickets/43518)

Image:

<img width="1792" height="996" alt="Screenshot 2025-07-14 at 6 21 13 PM" src="https://github.com/user-attachments/assets/265ab148-8f6b-423d-92ae-2156b6e58068" />


Backport needed: v15

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a required "Company" field to Payment Gateway Accounts, ensuring each account is associated with a specific company.
  * Payment Gateway Account selection in forms is now filtered by the selected company.
  * Payment Gateway Account naming now includes the company abbreviation for clarity.

* **Bug Fixes**
  * Default payment gateway accounts are now managed per company, preventing conflicts across companies.

* **Chores**
  * Existing Payment Gateway Accounts are automatically updated to include company information.
  * Test data and related logic updated to reflect new company-specific requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->