### PR TITLE
fix: update value after depreciation when asset splitting

### DIFF
--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -1215,6 +1215,10 @@ def update_existing_asset(asset, remaining_qty, new_asset_name):
 	opening_accumulated_depreciation = flt(
 		(asset.opening_accumulated_depreciation * remaining_qty) / asset.asset_quantity
 	)
+	value_after_depreciation = flt(
+		(asset.value_after_depreciation * remaining_qty) / asset.asset_quantity,
+		asset.precision("gross_purchase_amount"),
+	)
 
 	frappe.db.set_value(
 		"Asset",
@@ -1222,6 +1226,7 @@ def update_existing_asset(asset, remaining_qty, new_asset_name):
 		{
 			"opening_accumulated_depreciation": opening_accumulated_depreciation,
 			"gross_purchase_amount": remaining_gross_purchase_amount,
+			"value_after_depreciation": value_after_depreciation,
 			"asset_quantity": remaining_qty,
 		},
 	)
@@ -1283,6 +1288,9 @@ def create_new_asset_after_split(asset, split_qty):
 	new_asset.opening_accumulated_depreciation = opening_accumulated_depreciation
 	new_asset.asset_quantity = split_qty
 	new_asset.split_from = asset.name
+	new_asset.value_after_depreciation = flt(
+		(asset.value_after_depreciation * split_qty) / asset.asset_quantity, asset.precision("gross_purchase_amount")
+	)
 
 	for row in new_asset.get("finance_books"):
 		row.value_after_depreciation = flt((row.value_after_depreciation * split_qty) / asset.asset_quantity)

--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -1289,7 +1289,8 @@ def create_new_asset_after_split(asset, split_qty):
 	new_asset.asset_quantity = split_qty
 	new_asset.split_from = asset.name
 	new_asset.value_after_depreciation = flt(
-		(asset.value_after_depreciation * split_qty) / asset.asset_quantity, asset.precision("gross_purchase_amount")
+		(asset.value_after_depreciation * split_qty) / asset.asset_quantity,
+		asset.precision("gross_purchase_amount"),
 	)
 
 	for row in new_asset.get("finance_books"):

--- a/erpnext/assets/doctype/asset/test_asset.py
+++ b/erpnext/assets/doctype/asset/test_asset.py
@@ -1707,6 +1707,9 @@ def create_asset(**args):
 			"is_composite_asset": args.is_composite_asset or 0,
 			"asset_quantity": args.get("asset_quantity") or 1,
 			"depr_entry_posting_status": args.depr_entry_posting_status or "",
+			"value_after_depreciation": (
+				(args.gross_purchase_amount or 100000) - (args.opening_accumulated_depreciation or 0)
+			),
 		}
 	)
 

--- a/erpnext/assets/doctype/asset/test_asset.py
+++ b/erpnext/assets/doctype/asset/test_asset.py
@@ -487,7 +487,6 @@ class TestAsset(AssetSetup):
 		self.assertEqual(new_asset.gross_purchase_amount, 24000)
 		self.assertEqual(new_asset.opening_accumulated_depreciation, 4000)
 		self.assertEqual(new_asset.split_from, asset.name)
-		self.assertEqual(new_asset.value_after_depreciation, 16000)
 		self.assertEqual(depr_schedule_of_new_asset[0].depreciation_amount, 4000)
 		self.assertEqual(depr_schedule_of_new_asset[1].depreciation_amount, 4000)
 
@@ -1707,9 +1706,6 @@ def create_asset(**args):
 			"is_composite_asset": args.is_composite_asset or 0,
 			"asset_quantity": args.get("asset_quantity") or 1,
 			"depr_entry_posting_status": args.depr_entry_posting_status or "",
-			"value_after_depreciation": (
-				(args.gross_purchase_amount or 100000) - (args.opening_accumulated_depreciation or 0)
-			),
 		}
 	)
 

--- a/erpnext/assets/doctype/asset/test_asset.py
+++ b/erpnext/assets/doctype/asset/test_asset.py
@@ -487,6 +487,7 @@ class TestAsset(AssetSetup):
 		self.assertEqual(new_asset.gross_purchase_amount, 24000)
 		self.assertEqual(new_asset.opening_accumulated_depreciation, 4000)
 		self.assertEqual(new_asset.split_from, asset.name)
+		self.assertEqual(new_asset.value_after_depreciation, 16000)
 		self.assertEqual(depr_schedule_of_new_asset[0].depreciation_amount, 4000)
 		self.assertEqual(depr_schedule_of_new_asset[1].depreciation_amount, 4000)
 


### PR DESCRIPTION
While splitting a grouped asset, all values were updating correctly except for the Value After Depreciation. This incorrect update led to inconsistencies in subsequent asset-related transactions.

Internal support issue: https://support.frappe.io/helpdesk/tickets/43436