### PR TITLE
fix: correct in_list usage causing item rate issues in Supplier Quotation Item

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -757,13 +757,14 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 	price_list_rate(doc, cdt, cdn) {
 		var item = frappe.get_doc(cdt, cdn);
 		frappe.model.round_floats_in(item, ["price_list_rate", "discount_percentage"]);
-
+		
 		// check if child doctype is Sales Order Item/Quotation Item and calculate the rate
-		if (in_list(["Quotation Item", "Sales Order Item", "Delivery Note Item", "Sales Invoice Item", "POS Invoice Item", "Purchase Invoice Item", "Purchase Order Item", "Purchase Receipt Item"]), cdt)
+		if(in_list(["Quotation Item", "Sales Order Item", "Delivery Note Item", "Sales Invoice Item", "POS Invoice Item", "Purchase Invoice Item", "Purchase Order Item", "Purchase Receipt Item"], cdt)){
 			this.apply_pricing_rule_on_item(item);
-		else
+		} else {
 			item.rate = flt(item.price_list_rate * (1 - item.discount_percentage / 100.0),
 				precision("rate", item));
+		}
 
 		this.calculate_taxes_and_totals();
 	}

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -759,13 +759,13 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 		frappe.model.round_floats_in(item, ["price_list_rate", "discount_percentage"]);
 		
 		// check if child doctype is Sales Order Item/Quotation Item and calculate the rate
-		if(in_list(["Quotation Item", "Sales Order Item", "Delivery Note Item", "Sales Invoice Item", "POS Invoice Item", "Purchase Invoice Item", "Purchase Order Item", "Purchase Receipt Item"], cdt)){
+		if (in_list(["Quotation Item", "Sales Order Item", "Delivery Note Item", "Sales Invoice Item", "POS Invoice Item", "Purchase Invoice Item", "Purchase Order Item", "Purchase Receipt Item"], cdt)){
 			this.apply_pricing_rule_on_item(item);
 		} else {
 			item.rate = flt(item.price_list_rate * (1 - item.discount_percentage / 100.0),
 				precision("rate", item));
 		}
-
+		
 		this.calculate_taxes_and_totals();
 	}
 


### PR DESCRIPTION
Issue: #48592

Caused by

- https://github.com/frappe/erpnext/pull/24685
- https://github.com/frappe/erpnext/commit/ed42afc5e8ff50a31eae2736f2351ffa4771ff14#diff-d243a364bcb9beb99023ffabc45910291efeb15f16a9979abb782a3cad1f106c


Fixed improper usage of the `in_list` function, which was missing the second argument (`cdt`). This caused conditionals checking the doctype to fail silently.

``` js
if (in_list(["Quotation Item", "Sales Order Item", "Delivery Note Item", "Sales Invoice Item", "POS Invoice Item", "Purchase Invoice Item", "Purchase Order Item", "Purchase Receipt Item"]), cdt)
```
``` js
function in_list(list, item) {
	return list.includes(item);
}
```

As a result, item-level logic in Supplier Quotation Item (such as setting Rate, Amount, and etc.) did not execute properly when selecting an Item Code.

This fix restores correct behavior: selecting an Item Code now updates the Rate and related fields as expected.