### PR TITLE
fix(sales-order): disallow address edits after sales order is submitted

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.json
+++ b/erpnext/selling/doctype/sales_order/sales_order.json
@@ -349,7 +349,6 @@
    "options": "fa fa-bullhorn"
   },
   {
-   "allow_on_submit": 1,
    "fieldname": "customer_address",
    "fieldtype": "Link",
    "hide_days": 1,
@@ -430,7 +429,6 @@
    "width": "50%"
   },
   {
-   "allow_on_submit": 1,
    "fieldname": "shipping_address_name",
    "fieldtype": "Link",
    "hide_days": 1,


### PR DESCRIPTION
**Ref:**  [43620](https://support.frappe.io/helpdesk/tickets/43620)

**Issue**
> [PR #13747](https://github.com/frappe/erpnext/pull/13747) allowed editing the Address after submission, which was useful when the address was missing or needed correction.
> 
> Later, [PR #16377](https://github.com/frappe/erpnext/pull/16377) introduced automatic Tax Category selection based on the selected Address. As a result, changing the Address after submission can update the Tax Category and trigger recalculation of the tax table, causing unexpected tax changes in already submitted Sales Orders.

**Fix:** 
> This PR disables editing the Address field on submitted Sales Orders to prevent tax values from being recalculated and overwritten after submission.

**Backport needed v15**

`no-docs`
