### PR TITLE
fix: system was allowing credit notes with serial numbers for any customer

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -475,6 +475,7 @@ class SalesInvoice(SellingController):
 				self.make_bundle_for_sales_purchase_return(table_name)
 				self.make_bundle_using_old_serial_batch_fields(table_name)
 
+			self.validate_standalone_serial_nos_customer()
 			self.update_stock_reservation_entries()
 			self.update_stock_ledger()
 

--- a/erpnext/controllers/sales_and_purchase_return.py
+++ b/erpnext/controllers/sales_and_purchase_return.py
@@ -38,6 +38,17 @@ def validate_return_against(doc):
 
 		party_type = "customer" if doc.doctype in ("Sales Invoice", "Delivery Note") else "supplier"
 
+		if ref_doc.get(party_type) != doc.get(party_type):
+			frappe.throw(
+				_("The {0} {1} does not match with the {0} {2} in the {3} {4}").format(
+					doc.meta.get_label(party_type),
+					doc.get(party_type),
+					ref_doc.get(party_type),
+					ref_doc.doctype,
+					ref_doc.name,
+				)
+			)
+
 		if (
 			ref_doc.company == doc.company
 			and ref_doc.get(party_type) == doc.get(party_type)

--- a/erpnext/controllers/selling_controller.py
+++ b/erpnext/controllers/selling_controller.py
@@ -61,6 +61,35 @@ class SellingController(StockController):
 			if self.get(table_field):
 				self.set_serial_and_batch_bundle(table_field)
 
+	def validate_standalone_serial_nos_customer(self):
+		if not self.is_return or self.return_against:
+			return
+
+		if self.doctype in ["Sales Invoice", "Delivery Note"]:
+			bundle_ids = [d.serial_and_batch_bundle for d in self.get("items") if d.serial_and_batch_bundle]
+			if not bundle_ids:
+				return
+
+			serial_nos = frappe.get_all(
+				"Serial and Batch Entry",
+				filters={"parent": ("in", bundle_ids)},
+				pluck="serial_no",
+			)
+
+			if serial_nos := frappe.get_all(
+				"Serial No",
+				filters={"name": ("in", serial_nos), "customer": ("is", "set")},
+				fields=["name", "customer"],
+			):
+				for sn in serial_nos:
+					if sn.customer and sn.customer != self.customer:
+						frappe.throw(
+							_(
+								"Serial No {0} is already assigned to customer {1}. Can only be returned against the customer {1}"
+							).format(frappe.bold(sn.name), frappe.bold(sn.customer)),
+							title=_("Serial No Already Assigned"),
+						)
+
 	def set_missing_values(self, for_validate=False):
 		super().set_missing_values(for_validate)
 

--- a/erpnext/stock/doctype/delivery_note/delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.py
@@ -466,6 +466,7 @@ class DeliveryNote(SellingController):
 			self.make_bundle_for_sales_purchase_return(table_name)
 			self.make_bundle_using_old_serial_batch_fields(table_name)
 
+		self.validate_standalone_serial_nos_customer()
 		self.update_stock_reservation_entries()
 
 		# Updating stock ledger should always be called after updating prevdoc status,

--- a/erpnext/stock/doctype/serial_no/serial_no.json
+++ b/erpnext/stock/doctype/serial_no/serial_no.json
@@ -15,6 +15,7 @@
   "batch_no",
   "warehouse",
   "purchase_rate",
+  "customer",
   "column_break1",
   "status",
   "item_name",
@@ -267,12 +268,21 @@
    "label": "Creation Document No",
    "no_copy": 1,
    "read_only": 1
+  },
+  {
+   "fieldname": "customer",
+   "fieldtype": "Link",
+   "label": "Customer",
+   "no_copy": 1,
+   "options": "Customer",
+   "print_hide": 1,
+   "read_only": 1
   }
  ],
  "icon": "fa fa-barcode",
  "idx": 1,
  "links": [],
- "modified": "2025-01-15 15:22:49.873889",
+ "modified": "2025-07-15 13:36:21.938700",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Serial No",
@@ -310,6 +320,7 @@
    "role": "Stock User"
   }
  ],
+ "row_format": "Dynamic",
  "search_fields": "item_code",
  "show_name_in_global_search": 1,
  "sort_field": "creation",

--- a/erpnext/stock/doctype/serial_no/serial_no.py
+++ b/erpnext/stock/doctype/serial_no/serial_no.py
@@ -40,6 +40,7 @@ class SerialNo(StockController):
 		batch_no: DF.Link | None
 		brand: DF.Link | None
 		company: DF.Link
+		customer: DF.Link | None
 		description: DF.Text | None
 		employee: DF.Link | None
 		item_code: DF.Link

--- a/erpnext/stock/serial_batch_bundle.py
+++ b/erpnext/stock/serial_batch_bundle.py
@@ -409,6 +409,10 @@ class SerialBatchBundle:
 				]:
 					status = "Consumed"
 
+		customer = None
+		if sle.voucher_type in ["Sales Invoice", "Delivery Note"] and sle.actual_qty < 0:
+			customer = frappe.get_cached_value(sle.voucher_type, sle.voucher_no, "customer")
+
 		sn_table = frappe.qb.DocType("Serial No")
 
 		query = (
@@ -419,10 +423,11 @@ class SerialBatchBundle:
 				"Active"
 				if warehouse
 				else status
-				if (sn_table.purchase_document_no != sle.voucher_no and sle.is_cancelled != 1)
+				if (sn_table.purchase_document_no != sle.voucher_no or sle.is_cancelled != 1)
 				else "Inactive",
 			)
 			.set(sn_table.company, sle.company)
+			.set(sn_table.customer, customer)
 			.where(sn_table.name.isin(serial_nos))
 		)
 


### PR DESCRIPTION
**Issue**

- Create the sales invoice for Customer A with serial no SN-0001 and enable update stock
- Create the standalone credit note for Customer B with serial no SN-0001
- System will allow to make the credit note for Customer B which should not allow


**After Fix**


Added validation to prevent the creation of a credit note against a different customer.

<img width="767" height="243" alt="image" src="https://github.com/user-attachments/assets/1afee050-e139-43dc-9ca9-f6c092545e39" />



While fixing the issue, we found another problem where the system was allowing the creation of a credit note (non-standalone) against a different customer. We have addressed this by adding a validation.

<img width="782" height="289" alt="image" src="https://github.com/user-attachments/assets/1b5ea627-1ab1-4238-8e7b-8a3492e2c2b9" />


Fixed https://github.com/frappe/erpnext/issues/48590