### PR TITLE
fix(period closing voucher): closing account head debit and debit in account currency should be equal

### DIFF
--- a/erpnext/accounts/doctype/period_closing_voucher/period_closing_voucher.py
+++ b/erpnext/accounts/doctype/period_closing_voucher/period_closing_voucher.py
@@ -210,8 +210,10 @@ class PeriodClosingVoucher(AccountsController):
 		return gl_entry
 
 	def get_gle_for_closing_account(self, dimension_balance, dimensions):
-		balance_in_account_currency = flt(dimension_balance.balance_in_account_currency)
 		balance_in_company_currency = flt(dimension_balance.balance_in_company_currency)
+		debit = balance_in_company_currency if balance_in_company_currency > 0 else 0
+		credit = abs(balance_in_company_currency) if balance_in_company_currency < 0 else 0
+
 		gl_entry = frappe._dict(
 			{
 				"company": self.company,
@@ -220,14 +222,10 @@ class PeriodClosingVoucher(AccountsController):
 				"account_currency": frappe.db.get_value(
 					"Account", self.closing_account_head, "account_currency"
 				),
-				"debit_in_account_currency": balance_in_account_currency
-				if balance_in_account_currency > 0
-				else 0,
-				"debit": balance_in_company_currency if balance_in_company_currency > 0 else 0,
-				"credit_in_account_currency": abs(balance_in_account_currency)
-				if balance_in_account_currency < 0
-				else 0,
-				"credit": abs(balance_in_company_currency) if balance_in_company_currency < 0 else 0,
+				"debit_in_account_currency": debit,
+				"debit": debit,
+				"credit_in_account_currency": credit,
+				"credit": credit,
 				"is_period_closing_voucher_entry": 1,
 				"voucher_type": "Period Closing Voucher",
 				"voucher_no": self.name,


### PR DESCRIPTION
**Issue:**
When the company has an Income/Expense account, upon posting the Period Closing Voucher, the debit/credit and debit_in_account_currency/credit_in_account_currency values are not the same for the closing account head

ref: [43099](https://support.frappe.io/helpdesk/tickets/43099), [42344](https://support.frappe.io/helpdesk/tickets/42344)

**Before:**
<img width="1801" height="722" alt="image" src="https://github.com/user-attachments/assets/fb9550df-4b74-48fc-af82-7265b16e94f0" />


**After:**
<img width="1813" height="773" alt="image" src="https://github.com/user-attachments/assets/82547606-a2ce-4787-85f8-631b875baf39" />


**Backport needed for v15 and v14**