### PR TITLE
fix(accounts): allow default bank account per company

### DIFF
--- a/erpnext/accounts/doctype/bank_account/bank_account.py
+++ b/erpnext/accounts/doctype/bank_account/bank_account.py
@@ -109,6 +109,7 @@ class BankAccount(Document):
 					"party_type": self.party_type,
 					"party": self.party,
 					"is_company_account": self.is_company_account,
+					"company": self.company,
 					"is_default": 1,
 					"disabled": 0,
 				},


### PR DESCRIPTION
<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/erpnext/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

If we need to set up one default bank account per company, we cannot do that since setting any one company's bank account as default marks the other's as not default. This PR changes the logic so that the default is reset only on other accounts belonging to the same company.
