### PR TITLE
fix: pos customer selection on new order

### DIFF
--- a/erpnext/selling/page/point_of_sale/pos_controller.js
+++ b/erpnext/selling/page/point_of_sale/pos_controller.js
@@ -581,6 +581,7 @@ erpnext.PointOfSale.Controller = class {
 		this.cart.toggle_component(show);
 		this.cart.toggle_numpad(!show);
 		this.cart.toggle_checkout_btn(show);
+		this.cart.enable_customer_selection();
 		this.item_selector.toggle_component(show);
 
 		// do not show item details or payment if recent order is toggled off


### PR DESCRIPTION
Resolved the issue where users were unable to reselect the Customers on the POS on New Order.

[Support Ticket](https://support.frappe.io/helpdesk/tickets/43762)