### PR TITLE
fix: pos customer selection on new order

### DIFF
--- a/erpnext/selling/page/point_of_sale/pos_controller.js
+++ b/erpnext/selling/page/point_of_sale/pos_controller.js
@@ -502,6 +502,7 @@ erpnext.PointOfSale.Controller = class {
 						() => frappe.dom.freeze(),
 						() => this.make_new_invoice(),
 						() => this.item_selector.toggle_component(true),
+						() => this.cart.enable_customer_selection(),
 						() => frappe.dom.unfreeze(),
 					]);
 				},


### PR DESCRIPTION
Resolved the issue where users were unable to reselect the Customers on the POS on New Order.

[Support Ticket](https://support.frappe.io/helpdesk/tickets/43762)