### PR TITLE
fix: serial no reserved error when reservation is transferred

### DIFF
--- a/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py
+++ b/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py
@@ -2074,8 +2074,7 @@ def get_reserved_serial_nos_for_sre(kwargs) -> list:
 		.where(
 			(sre.docstatus == 1)
 			& (sre.item_code == kwargs.item_code)
-			& (sre.reserved_qty >= sre.delivered_qty)
-			& (sre.status.notin(["Delivered", "Cancelled"]))
+			& (sre.delivered_qty < sre.reserved_qty)
 			& (sre.reservation_based_on == "Serial and Batch")
 		)
 	)


### PR DESCRIPTION
Serial No reserved using Stock Reservation Transfer could not be used in any further transaction

Steps to replicate:
1. Create Production Plan and Reserve Stock for Raw Material Item which has serial/batch
2. Create work order from Production Plan and reserve stock at work order level as well
3. Try transferring the raw material from source to WIP, you will get an error that raw material is reserved against Production Plan