### PR TITLE
fix: update asset value after revaluation cancellation

### DIFF
--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -249,14 +249,11 @@ class Asset(AccountsController):
 			frappe.throw(_("Purchase Invoice cannot be made against an existing asset {0}").format(self.name))
 
 	def prepare_depreciation_data(self):
+		self.value_after_depreciation = flt(self.gross_purchase_amount) - flt(
+			self.opening_accumulated_depreciation
+		)
 		if self.calculate_depreciation:
-			self.value_after_depreciation = 0
 			self.set_depreciation_rate()
-		else:
-			self.finance_books = []
-			self.value_after_depreciation = flt(self.gross_purchase_amount) - flt(
-				self.opening_accumulated_depreciation
-			)
 
 	def validate_item(self):
 		item = frappe.get_cached_value(

--- a/erpnext/assets/doctype/asset/test_asset.py
+++ b/erpnext/assets/doctype/asset/test_asset.py
@@ -1492,7 +1492,6 @@ class TestDepreciationBasics(AssetSetup):
 		)
 
 		self.assertSequenceEqual(gle, expected_gle)
-		self.assertEqual(asset.get("value_after_depreciation"), 0)
 
 	def test_expected_value_change(self):
 		"""

--- a/erpnext/assets/doctype/asset_value_adjustment/test_asset_value_adjustment.py
+++ b/erpnext/assets/doctype/asset_value_adjustment/test_asset_value_adjustment.py
@@ -267,7 +267,6 @@ class TestAssetValueAdjustment(unittest.TestCase):
 		asset_doc.calculate_depreciation = 1
 		asset_doc.available_for_use_date = "2023-01-15"
 		asset_doc.purchase_date = "2023-01-15"
-		asset_doc.value_after_depreciation = 54000.0
 
 		asset_doc.append(
 			"finance_books",
@@ -283,13 +282,13 @@ class TestAssetValueAdjustment(unittest.TestCase):
 
 		adj_doc = make_asset_value_adjustment(
 			asset=asset_doc.name,
-			current_asset_value=54000,
+			current_asset_value=120000.0,
 			new_asset_value=50000.0,
 			date="2023-08-21",
 		)
 		adj_doc.submit()
 		difference_amount = adj_doc.new_asset_value - adj_doc.current_asset_value
-		self.assertEqual(difference_amount, -4000)
+		self.assertEqual(difference_amount, -70000)
 		asset_doc.load_from_db()
 		self.assertEqual(asset_doc.value_after_depreciation, 50000.0)
 

--- a/erpnext/assets/doctype/asset_value_adjustment/test_asset_value_adjustment.py
+++ b/erpnext/assets/doctype/asset_value_adjustment/test_asset_value_adjustment.py
@@ -267,6 +267,7 @@ class TestAssetValueAdjustment(unittest.TestCase):
 		asset_doc.calculate_depreciation = 1
 		asset_doc.available_for_use_date = "2023-01-15"
 		asset_doc.purchase_date = "2023-01-15"
+		asset_doc.value_after_depreciation = 54000.0
 
 		asset_doc.append(
 			"finance_books",


### PR DESCRIPTION
Fixed inconsistent updates in Asset Value Adjustment during revaluation submission and cancellation.
Earlier, the same logic was used for both actions, which sometimes updated only partial fields—working for submission but failing for cancellation, or vice versa.
This refactor ensures all asset values and related finance book fields update correctly in both scenarios, with tests updated accordingly.