### PR TITLE
feat: account name and number columns on financial statements report on export

### DIFF
--- a/erpnext/accounts/report/balance_sheet/balance_sheet.js
+++ b/erpnext/accounts/report/balance_sheet/balance_sheet.js
@@ -30,3 +30,5 @@ frappe.query_reports["Balance Sheet"]["filters"].push({
 	fieldtype: "Check",
 	default: 1,
 });
+
+frappe.query_reports["Balance Sheet"]["export_hidden_cols"] = true;

--- a/erpnext/accounts/report/financial_statements.py
+++ b/erpnext/accounts/report/financial_statements.py
@@ -295,6 +295,8 @@ def prepare_data(accounts, balance_must_be, period_list, company_currency, accum
 				"account_name": (
 					f"{_(d.account_number)} - {_(d.account_name)}" if d.account_number else _(d.account_name)
 				),
+				"acc_name": d.account_name,
+				"acc_number": d.account_number,
 			}
 		)
 		for period in period_list:
@@ -650,6 +652,25 @@ def get_columns(periodicity, period_list, accumulated_values=1, company=None, ca
 			"width": 300,
 		}
 	]
+	if not cash_flow:
+		columns.extend(
+			[
+				{
+					"fieldname": "acc_name",
+					"label": _("Account Name"),
+					"fieldtype": "Data",
+					"width": 250,
+					"hidden": 1,
+				},
+				{
+					"fieldname": "acc_number",
+					"label": _("Account Number"),
+					"fieldtype": "Data",
+					"width": 120,
+					"hidden": 1,
+				},
+			]
+		)
 	if company:
 		columns.append(
 			{

--- a/erpnext/accounts/report/profit_and_loss_statement/profit_and_loss_statement.js
+++ b/erpnext/accounts/report/profit_and_loss_statement/profit_and_loss_statement.js
@@ -31,3 +31,5 @@ frappe.query_reports["Profit and Loss Statement"]["filters"].push({
 	fieldtype: "Check",
 	default: 1,
 });
+
+frappe.query_reports["Profit and Loss Statement"]["export_hidden_cols"] = true;

--- a/erpnext/accounts/report/profit_and_loss_statement/test_profit_and_loss_statement.py
+++ b/erpnext/accounts/report/profit_and_loss_statement/test_profit_and_loss_statement.py
@@ -142,7 +142,7 @@ class TestProfitAndLossStatement(AccountsTestMixin, IntegrationTestCase):
 			accumulated_values=False,
 		)
 		result = execute(filters)
-		columns = [result[0][2], result[0][3]]
+		columns = [result[0][4], result[0][5]]
 		expected = {
 			"account": income_acc,
 			columns[0].get("fieldname"): 450.0,
@@ -163,7 +163,7 @@ class TestProfitAndLossStatement(AccountsTestMixin, IntegrationTestCase):
 			columns[1].get("fieldname"): 570.0,
 		}
 		result = execute(filters)
-		columns = [result[0][2], result[0][3]]
+		columns = [result[0][4], result[0][5]]
 		actual = [x for x in result[1] if x.get("account") == income_acc]
 		self.assertEqual(len(actual), 1)
 		actual = actual[0]

--- a/erpnext/accounts/report/trial_balance/trial_balance.js
+++ b/erpnext/accounts/report/trial_balance/trial_balance.js
@@ -122,6 +122,7 @@ frappe.query_reports["Trial Balance"] = {
 	tree: true,
 	name_field: "account",
 	parent_field: "parent_account",
+	export_hidden_cols: true,
 	initial_depth: 3,
 };
 

--- a/erpnext/accounts/report/trial_balance/trial_balance.py
+++ b/erpnext/accounts/report/trial_balance/trial_balance.py
@@ -402,6 +402,8 @@ def prepare_data(accounts, filters, parent_children_map, company_currency):
 			"to_date": filters.to_date,
 			"currency": company_currency,
 			"is_group_account": d.is_group,
+			"acc_name": d.account_name,
+			"acc_number": d.account_number,
 			"account_name": (
 				f"{d.account_number} - {d.account_name}" if d.account_number else d.account_name
 			),
@@ -435,6 +437,20 @@ def get_columns():
 			"fieldtype": "Link",
 			"options": "Account",
 			"width": 300,
+		},
+		{
+			"fieldname": "acc_name",
+			"label": _("Account Name"),
+			"fieldtype": "Data",
+			"hidden": 1,
+			"width": 250,
+		},
+		{
+			"fieldname": "acc_number",
+			"label": _("Account Number"),
+			"fieldtype": "Data",
+			"hidden": 1,
+			"width": 120,
 		},
 		{
 			"fieldname": "currency",


### PR DESCRIPTION
Separate columns for Account Name and Account Number can be added to the export of the Trial Balance Report, Balance Sheet Report, and Profit and Loss Statement. To add columns, enable the `Include hidden columns` on the Export Dialog.

<img width="1218" height="644" alt="image" src="https://github.com/user-attachments/assets/e89e8f19-62a9-415c-9f91-5c76937136f0" />


<!-- no-docs -->