### PR TITLE
fix: performance issue while submitting the purchase invoice

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
@@ -1225,6 +1225,9 @@ class PurchaseInvoice(BuyingController):
 	def get_provisional_accounts(self):
 		self.provisional_accounts = frappe._dict()
 		linked_purchase_receipts = set([d.purchase_receipt for d in self.items if d.purchase_receipt])
+		if not linked_purchase_receipts:
+			return
+
 		pr_items = frappe.get_all(
 			"Purchase Receipt Item",
 			filters={"parent": ("in", linked_purchase_receipts)},


### PR DESCRIPTION
Fetching provisional accounts is taking time for purchase invoices that are not linked to any purchase receipts.

<img width="1426" height="156" alt="Screenshot 2025-07-16 at 3 18 51 PM" src="https://github.com/user-attachments/assets/fb264005-b3dd-4e52-907d-5f6187f7ad1f" />


Since the Purchase Receipt field is blank in the purchase invoice for single line item, the system is reading all Purchase Receipt items to fetch the provisional accounts. Reading all rows in the purchase receipt item table causing the performance issue 
