### PR TITLE
fix: update outstanding amount on payment reconcillation

### DIFF
--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -522,7 +522,8 @@ def reconcile_against_document(
 					skip_ref_details_update_for_pe=skip_ref_details_update_for_pe,
 					dimensions_dict=dimensions_dict,
 				)
-
+				if referenced_row.get("outstanding_amount"):
+					referenced_row.outstanding_amount -= flt(entry.allocated_amount)
 		doc.save(ignore_permissions=True)
 		# re-submit advance entry
 		doc = frappe.get_doc(entry.voucher_type, entry.voucher_no)


### PR DESCRIPTION
Issue: Outstanding amount was not updated in the Payment Entry after payment reconciliation.

Ref: [#43729](https://support.frappe.io/helpdesk/tickets/43729)

Before:

https://github.com/user-attachments/assets/c799f756-9992-4ff4-bf96-bc199239bfe3

After:

https://github.com/user-attachments/assets/cd1d6715-dbe2-45e2-ae66-e81b229b9fb9

Backport needed: v15

