### PR TITLE
fix: precision issue for Sales Incoming Rate

### DIFF
--- a/erpnext/controllers/buying_controller.py
+++ b/erpnext/controllers/buying_controller.py
@@ -527,13 +527,12 @@ class BuyingController(SubcontractingController):
 					raise_error_if_no_rate=False,
 				)
 
-				d.sales_incoming_rate = flt(outgoing_rate * (d.conversion_factor or 1), d.precision("rate"))
+				d.sales_incoming_rate = flt(outgoing_rate * (d.conversion_factor or 1))
 			else:
 				field = "incoming_rate" if self.get("is_internal_supplier") else "rate"
 				d.sales_incoming_rate = flt(
 					frappe.db.get_value(ref_doctype, d.get(frappe.scrub(ref_doctype)), field)
-					* (d.conversion_factor or 1),
-					d.precision("rate"),
+					* (d.conversion_factor or 1)
 				)
 
 	def validate_for_subcontracting(self):


### PR DESCRIPTION
For inter-transfer transactions, the rate differs between the delivery note and the purchase receipt due to a precision issue.

Delivery Note

<img width="847" height="108" alt="Screenshot 2025-07-17 at 3 12 09 PM" src="https://github.com/user-attachments/assets/a10dfc73-4144-47da-ab7f-db8e08e2081d" />



Purchase Receipt
<img width="820" height="101" alt="Screenshot 2025-07-17 at 3 12 14 PM" src="https://github.com/user-attachments/assets/86a4288b-cff6-4b9f-89e2-613bac8dde33" />
