### PR TITLE
fix: show amount for exchange gain or loss account

### DIFF
--- a/erpnext/accounts/report/general_ledger/general_ledger.py
+++ b/erpnext/accounts/report/general_ledger/general_ledger.py
@@ -210,7 +210,7 @@ def get_gl_entries(filters, accounting_dimensions):
 	)
 
 	if filters.get("presentation_currency"):
-		return convert_to_presentation_currency(gl_entries, currency_map)
+		return convert_to_presentation_currency(gl_entries, currency_map, filters)
 	else:
 		return gl_entries
 

--- a/erpnext/accounts/report/utils.py
+++ b/erpnext/accounts/report/utils.py
@@ -101,7 +101,7 @@ def convert_to_presentation_currency(gl_entries, currency_info, filters=None):
 	account_currencies = list(set(entry["account_currency"] for entry in gl_entries))
 	exchange_gain_or_loss = False
 
-	if filters:
+	if filters and isinstance(filters.get("account"), list):
 		account_filter = filters.get("account")
 		gain_loss_account = frappe.db.get_value("Company", filters.company, "exchange_gain_loss_account")
 

--- a/erpnext/accounts/report/utils.py
+++ b/erpnext/accounts/report/utils.py
@@ -86,7 +86,7 @@ def get_rate_as_at(date, from_currency, to_currency):
 	return rate
 
 
-def convert_to_presentation_currency(gl_entries, currency_info):
+def convert_to_presentation_currency(gl_entries, currency_info, filters=None):
 	"""
 	Take a list of GL Entries and change the 'debit' and 'credit' values to currencies
 	in `currency_info`.
@@ -99,6 +99,13 @@ def convert_to_presentation_currency(gl_entries, currency_info):
 	company_currency = currency_info["company_currency"]
 
 	account_currencies = list(set(entry["account_currency"] for entry in gl_entries))
+	exchange_gain_or_loss = False
+
+	if filters:
+		account_filter = filters.get("account")
+		gain_loss_account = frappe.db.get_value("Company", filters.company, "exchange_gain_loss_account")
+
+		exchange_gain_or_loss = len(account_filter) == 1 and account_filter[0] == gain_loss_account
 
 	for entry in gl_entries:
 		debit = flt(entry["debit"])
@@ -107,7 +114,11 @@ def convert_to_presentation_currency(gl_entries, currency_info):
 		credit_in_account_currency = flt(entry["credit_in_account_currency"])
 		account_currency = entry["account_currency"]
 
-		if len(account_currencies) == 1 and account_currency == presentation_currency:
+		if (
+			len(account_currencies) == 1
+			and account_currency == presentation_currency
+			and not exchange_gain_or_loss
+		):
 			entry["debit"] = debit_in_account_currency
 			entry["credit"] = credit_in_account_currency
 		else:


### PR DESCRIPTION
Issue: For a system posted exchange gain/loss entry the debit_in_account_curreny or credit_in_account_currency field won't be filled, so when we filter that particular account in GL the debit credit showing as 0.

Ref: [44622](https://support.frappe.io/helpdesk/tickets/44622), [41369](https://support.frappe.io/helpdesk/tickets/41369), [44340](https://support.frappe.io/helpdesk/tickets/44340)

Before:

<img width="1808" height="478" alt="image" src="https://github.com/user-attachments/assets/118789ed-4045-4677-9624-7fb4c9009fc2" />


After:

<img width="1808" height="519" alt="image" src="https://github.com/user-attachments/assets/6b8caa95-3339-4f25-afa2-5f7358491336" />



**Backport Needed: Version-15, Version-14**

no-docs