### PR TITLE
fix: sales partner on pos invoice

### DIFF
--- a/erpnext/accounts/doctype/pos_invoice/pos_invoice.json
+++ b/erpnext/accounts/doctype/pos_invoice/pos_invoice.json
@@ -1416,6 +1416,8 @@
    "width": "50%"
   },
   {
+   "fetch_from": "sales_partner.commission_rate",
+   "fetch_if_empty": 1,
    "fieldname": "commission_rate",
    "fieldtype": "Float",
    "label": "Commission Rate (%)",
@@ -1573,7 +1575,7 @@
  "icon": "fa fa-file-text",
  "is_submittable": 1,
  "links": [],
- "modified": "2025-06-24 12:13:28.242649",
+ "modified": "2025-07-17 16:51:40.886083",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "POS Invoice",

--- a/erpnext/accounts/doctype/pos_invoice_merge_log/pos_invoice_merge_log.py
+++ b/erpnext/accounts/doctype/pos_invoice_merge_log/pos_invoice_merge_log.py
@@ -338,6 +338,11 @@ class POSInvoiceMergeLog(Document):
 			invoice.flags.ignore_pos_profile = True
 			invoice.pos_profile = ""
 
+		# Unset Commission Section
+		invoice.set("sales_partner", None)
+		invoice.set("commission_rate", 0)
+		invoice.set("total_commission", 0)
+
 		return invoice
 
 	def get_new_sales_invoice(self):

--- a/erpnext/accounts/report/sales_partners_commission/sales_partners_commission.json
+++ b/erpnext/accounts/report/sales_partners_commission/sales_partners_commission.json
@@ -1,21 +1,22 @@
 {
  "add_total_row": 0,
+ "add_translate_data": 0,
  "columns": [],
  "creation": "2013-05-06 12:28:23",
- "disable_prepared_report": 0,
  "disabled": 0,
  "docstatus": 0,
  "doctype": "Report",
  "filters": [],
- "idx": 3,
+ "idx": 6,
  "is_standard": "Yes",
- "modified": "2021-10-06 06:26:07.881340",
+ "letterhead": null,
+ "modified": "2025-07-17 16:47:20.596297",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Sales Partners Commission",
  "owner": "Administrator",
  "prepared_report": 0,
- "query": "SELECT\n    sales_partner as \"Sales Partner:Link/Sales Partner:220\",\n\tsum(base_net_total) as \"Invoiced Amount (Excl. Tax):Currency:220\",\n\tsum(amount_eligible_for_commission) as \"Amount Eligible for Commission:Currency:220\",\n\tsum(total_commission) as \"Total Commission:Currency:170\",\n\tsum(total_commission)*100/sum(amount_eligible_for_commission) as \"Average Commission Rate:Percent:220\"\nFROM\n\t`tabSales Invoice`\nWHERE\n\tdocstatus = 1 and ifnull(base_net_total, 0) > 0 and ifnull(total_commission, 0) > 0\nGROUP BY\n\tsales_partner\nORDER BY\n\t\"Total Commission:Currency:120\"",
+ "query": "SELECT\n   sales_partner as \"Sales Partner:Link / Sales Partner:220\",\n   sum(base_net_total) as \"Invoiced Amount (Excl. Tax):Currency:220\",\n   sum(amount_eligible_for_commission) as \"Amount Eligible for Commission:Currency:220\",\n   sum(total_commission) as \"Total Commission:Currency:170\",\n   sum(total_commission)*100 / sum(amount_eligible_for_commission) as \"Average Commission Rate:Percent:220\"\nFROM\n   (\n      SELECT\n         sales_partner,\n         base_net_total,\n         total_commission,\n         amount_eligible_for_commission\n      FROM\n         `tabSales Invoice` \n      WHERE\n         docstatus = 1\n         AND NOT (is_consolidated = 1 AND is_created_using_pos = 0)\n         AND IFNULL(base_net_total, 0) > 0\n         AND IFNULL(total_commission, 0) > 0\n\n      UNION ALL\n\n      SELECT\n         sales_partner,\n         base_net_total,\n         total_commission,\n         amount_eligible_for_commission\n      FROM\n         `tabPOS Invoice`\n      WHERE\n         docstatus = 1\n         AND IFNULL(base_net_total, 0) > 0\n         AND IFNULL(total_commission, 0) > 0\n   ) AS sub\nGROUP BY\n   sales_partner\nORDER BY\n   \"Total Commission:Currency:120\"",
  "ref_doctype": "Sales Invoice",
  "report_name": "Sales Partners Commission",
  "report_type": "Query Report",
@@ -26,5 +27,6 @@
   {
    "role": "Accounts User"
   }
- ]
+ ],
+ "timeout": 0
 }

--- a/erpnext/selling/report/sales_partner_commission_summary/sales_partner_commission_summary.js
+++ b/erpnext/selling/report/sales_partner_commission_summary/sales_partner_commission_summary.js
@@ -13,7 +13,7 @@ frappe.query_reports["Sales Partner Commission Summary"] = {
 			fieldname: "doctype",
 			label: __("Document Type"),
 			fieldtype: "Select",
-			options: "Sales Order\nDelivery Note\nSales Invoice",
+			options: "Sales Order\nDelivery Note\nSales Invoice\nPOS Invoice",
 			default: "Sales Order",
 		},
 		{

--- a/erpnext/selling/report/sales_partner_commission_summary/sales_partner_commission_summary.py
+++ b/erpnext/selling/report/sales_partner_commission_summary/sales_partner_commission_summary.py
@@ -106,4 +106,7 @@ def get_conditions(filters, date_field):
 	if filters.get("to_date"):
 		conditions += f" and {date_field} <= %(to_date)s"
 
+	if filters.get("doctype") == "Sales Invoice":
+		conditions += " and not (is_consolidated = 1 and is_created_using_pos = 0)"
+
 	return conditions

--- a/erpnext/selling/report/sales_partner_target_variance_based_on_item_group/item_group_wise_sales_target_variance.py
+++ b/erpnext/selling/report/sales_partner_target_variance_based_on_item_group/item_group_wise_sales_target_variance.py
@@ -248,6 +248,9 @@ def get_actual_data(filters, sales_users_or_territory_data, date_field, sales_fi
 		net_amount = child_doc.base_net_amount
 		sales_field_col = parent_doc[sales_field]
 
+	if filters.get("doctype") == "Sales Invoice":
+		query = query.where(~((parent_doc.is_consolidated == 0) & (parent_doc.is_created_using_pos == 1)))
+
 	query = query.select(
 		child_doc.item_group,
 		parent_doc[date_field],

--- a/erpnext/selling/report/sales_partner_target_variance_based_on_item_group/sales_partner_target_variance_based_on_item_group.js
+++ b/erpnext/selling/report/sales_partner_target_variance_based_on_item_group/sales_partner_target_variance_based_on_item_group.js
@@ -21,7 +21,7 @@ frappe.query_reports["Sales Partner Target Variance based on Item Group"] = {
 			fieldname: "doctype",
 			label: __("Document Type"),
 			fieldtype: "Select",
-			options: "Sales Order\nDelivery Note\nSales Invoice",
+			options: "Sales Order\nDelivery Note\nSales Invoice\nPOS Invoice",
 			default: "Sales Order",
 		},
 		{

--- a/erpnext/selling/report/sales_partner_transaction_summary/sales_partner_transaction_summary.js
+++ b/erpnext/selling/report/sales_partner_transaction_summary/sales_partner_transaction_summary.js
@@ -13,7 +13,7 @@ frappe.query_reports["Sales Partner Transaction Summary"] = {
 			fieldname: "doctype",
 			label: __("Document Type"),
 			fieldtype: "Select",
-			options: "Sales Order\nDelivery Note\nSales Invoice",
+			options: "Sales Order\nDelivery Note\nSales Invoice\nPOS Invoice",
 			default: "Sales Order",
 		},
 		{

--- a/erpnext/selling/report/sales_partner_transaction_summary/sales_partner_transaction_summary.py
+++ b/erpnext/selling/report/sales_partner_transaction_summary/sales_partner_transaction_summary.py
@@ -137,6 +137,9 @@ def get_conditions(filters, date_field):
 	if filters.get("brand"):
 		conditions += " and dt_item.brand = %(brand)s"
 
+	if filters.get("doctype") == "Sales Invoice":
+		conditions += " and not (is_consolidated = 1 and is_created_using_pos = 0)"
+
 	if filters.get("item_group"):
 		lft, rgt = frappe.get_cached_value("Item Group", filters.get("item_group"), ["lft", "rgt"])
 


### PR DESCRIPTION
Changes include:
- Fixed fetching of Commission Rate on POS Invoice from Sales Partner DocType if `commission_rate` is not set.
- Fixed the query for Sales Partner Commission to calculate separately for POS Invoice and Sales Invoice.
- Added POS Invoice option for Sales Partner Commission Summary, Sales Partner Transaction Summary, and Sales Partner Target Variance Based on Item Group.
- Fixed the query for Sales Invoice DocType in `Sales Partner` related Reports.
- Unset the Sales Partner, Commission Rate, and Total Commission on Consolidated Sales Invoice.