### PR TITLE
revert: do not set pay_to_recd_from to None

### DIFF
--- a/erpnext/accounts/doctype/journal_entry/journal_entry.py
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.py
@@ -1145,9 +1145,7 @@ class JournalEntry(AccountsController):
 
 	def set_print_format_fields(self):
 		bank_amount = party_amount = total_amount = 0.0
-		currency = (
-			bank_account_currency
-		) = party_account_currency = pay_to_recd_from = self.pay_to_recd_from = None
+		currency = bank_account_currency = party_account_currency = pay_to_recd_from = None
 		party_type = None
 		for d in self.get("accounts"):
 			if d.party_type in ["Customer", "Supplier"] and d.party:

--- a/erpnext/accounts/doctype/journal_entry/test_journal_entry.py
+++ b/erpnext/accounts/doctype/journal_entry/test_journal_entry.py
@@ -579,6 +579,18 @@ class TestJournalEntry(IntegrationTestCase):
 		]
 		self.assertEqual(expected, actual)
 
+	def test_pay_to_recd_from(self):
+		jv = make_journal_entry("_Test Cash - _TC", "_Test Bank - _TC", 100, save=False)
+		jv.pay_to_recd_from = "_Test Receiver"
+		jv.save()
+		self.assertEqual(jv.pay_to_recd_from, "_Test Receiver")
+
+		jv.pay_to_recd_from = "_Test Receiver 2"
+		jv.save()
+		jv.submit()
+
+		self.assertEqual(jv.pay_to_recd_from, "_Test Receiver 2")
+
 
 def make_journal_entry(
 	account1,


### PR DESCRIPTION
Issue: The Journal Entry pay_to_recd_from does not update when it's changed .

Ref: [#44293](https://support.frappe.io/helpdesk/tickets/44293)

Reverting:  [#48402 ](https://github.com/frappe/erpnext/pull/48402)

Before:

https://github.com/user-attachments/assets/9699a0b1-21cb-410d-8905-033bed54138a

After:

https://github.com/user-attachments/assets/eaa8e8aa-2b86-41b7-971c-f2f403455655

Backport needed: v15
