### PR TITLE
fix: prevent negative Hourly Rate and Operation Time in BOM operations

### DIFF
--- a/erpnext/manufacturing/doctype/bom/bom.js
+++ b/erpnext/manufacturing/doctype/bom/bom.js
@@ -914,6 +914,16 @@ frappe.ui.form.on("BOM Operation", {
 });
 
 frappe.ui.form.on("BOM", {
+	validate(frm) {
+		frm.doc.operations.forEach((d) => {
+			if (flt(d.hour_rate) < 0) {
+				frappe.throw(__("Hourly Rate cannot be negative"));
+			}
+			if (flt(d.time_in_mins) < 0) {
+				frappe.throw(__("Operation Time cannot be negative"));
+			}
+		});
+	},
 	_prompt_for_raw_materials(frm, row) {
 		let fields = frm.events.get_fields_for_prompt(frm, row);
 		frm._bom_rm_dialog = new frappe.ui.Dialog({


### PR DESCRIPTION
## Description

This PR fixes a bug where negative values for Hourly Rate and Operation Time were being accepted in the BOM operations. Validation is now added in the `validate` hook to throw an error if these values are negative.

## Related Issues

Fixes: #48662


## Steps to Test

1. Go to the BOM form
2. Tick "With operations"
3. Add an operation with a negative Hourly Rate or negative Operation Time
4. Try to save the BOM

### Expected:
System should throw an error and prevent submission.

### Actual (Before Fix):
System was accepting negative values.

## Checklist

- [x] I have tested these changes
- [x] I have commented my code where needed
- [x] The title of my pull request is clear and descriptive
