### PR TITLE
fix: view ledger button of company on chart of accounts

### DIFF
--- a/erpnext/accounts/doctype/account/account_tree.js
+++ b/erpnext/accounts/doctype/account/account_tree.js
@@ -275,12 +275,14 @@ frappe.treeview_settings["Account"] = {
 			label: __("View Ledger"),
 			click: function (node, btn) {
 				frappe.route_options = {
-					account: node.label,
 					from_date: erpnext.utils.get_fiscal_year(frappe.datetime.get_today(), true)[1],
 					to_date: erpnext.utils.get_fiscal_year(frappe.datetime.get_today(), true)[2],
 					company:
 						frappe.treeview_settings["Account"].treeview.page.fields_dict.company.get_value(),
 				};
+				if (node.parent_label) {
+					frappe.route_options["account"] = node.label;
+				}
 				frappe.set_route("query-report", "General Ledger");
 			},
 			btnClass: "hidden-xs",


### PR DESCRIPTION
Resolved the issue where clicking on the `View Ledger` button of the Company on the Chart of Accounts was opening the General Ledger Report with the account set to the Company Name, causing the error shown in the video.

https://github.com/user-attachments/assets/dab3a174-3846-4e43-92e3-63942fba723a

