### PR TITLE
fix: show warehouse for the selected company

### DIFF
--- a/erpnext/stock/doctype/material_request/material_request.js
+++ b/erpnext/stock/doctype/material_request/material_request.js
@@ -324,6 +324,9 @@ frappe.ui.form.on("Material Request", {
 	},
 
 	get_items_from_bom: function (frm) {
+		if (!frm.doc.company) {
+			frappe.throw(__("Please select company"));
+		}
 		var d = new frappe.ui.Dialog({
 			title: __("Get Items from BOM"),
 			fields: [
@@ -343,6 +346,9 @@ frappe.ui.form.on("Material Request", {
 					label: __("For Warehouse"),
 					options: "Warehouse",
 					reqd: 1,
+					get_query: function () {
+						return { filters: { company: frm.doc.company } };
+					},
 				},
 				{ fieldname: "qty", fieldtype: "Float", label: __("Quantity"), reqd: 1, default: 1 },
 				{


### PR DESCRIPTION
Issue: While creating a Material Request using 'Get Items from Bill of Materials', the system displays warehouses from all companies, regardless of the company selected in the Material Request


Before:

[before_issue](https://github.com/user-attachments/assets/dfd30b3e-7703-4ad5-b7dd-e62460b46afb)


After:

[after_fix](https://github.com/user-attachments/assets/ecb8f753-5097-46cc-b2fe-625e019366a9)

resolves: [#48474 ](https://github.com/frappe/erpnext/issues/48474)

**Backport needed: v15**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Bug Fixes
  * Prevented opening the BOM item picker without a company: users must select a company before fetching items from BOM in Material Request, avoiding incorrect context and data integrity.
  * Improved accuracy of warehouse selection in the BOM dialog: the "For Warehouse" field now filters options by the selected company, reducing mismatches and errors and ensuring correct company-specific data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->