### PR TITLE
bugfix: wrong general ledger on exchange gain or loss journal entry

### DIFF
--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -2248,7 +2248,7 @@ def create_gain_loss_journal(
 			"reference_type": ref2_dt,
 			"reference_name": ref2_dn,
 			"reference_detail_no": ref2_detail_no,
-			reverse_dr_or_cr + "_in_account_currency": 0,
+			reverse_dr_or_cr + "_in_account_currency": abs(exc_gain_loss),
 			reverse_dr_or_cr: abs(exc_gain_loss),
 		}
 	)


### PR DESCRIPTION
Bug observed in **ERPNext: v15.70.2 (version-15)**

Steps to reproduce:

- create a purchase invoice, dated in one month, using a currency different from the company currency (e.g. CHF, company currency EUR). Submit the invoice.

<img width="1191" height="104" alt="grafik" src="https://github.com/user-attachments/assets/c0d4d545-8864-45f6-a886-a7fb4771f70b" />

- create a payment entry, in a later month (different exchange rate).

<img width="1203" height="76" alt="grafik" src="https://github.com/user-attachments/assets/1d23caf4-6dc6-46e4-bce5-48bb35536b2b" />

- submit. the system will create an exchange gain/loss journal entry.

<img width="1142" height="77" alt="grafik" src="https://github.com/user-attachments/assets/85fe71a0-dd4a-42cd-850b-a3098c81436d" />

- observe the general ledger for the exchange gain/loss account: the amount is not correctly reflected (because it is only in company currency, but not account corrency

<img width="1169" height="577" alt="grafik" src="https://github.com/user-attachments/assets/8e5b9370-24b7-4f9b-9923-8e858437d4bf" />

Correct behaviour: an expense account must be in company currency, hence, both debit/credit and debit_in_account currency or credit_in_account_currency must be booked accordingly.

Proof for the bugfix: row 20 is without the bugfix, row 19 with the bugfix:

<img width="1214" height="106" alt="grafik" src="https://github.com/user-attachments/assets/67733422-818d-4d37-a2c0-2ec9c68c940f" />


This is covered in this bugfix-PR.