### PR TITLE
fix: set delivery date if missing

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -787,7 +787,8 @@ class SalesOrder(SellingController):
 
 		if self.delivery_date:
 			for item in self.items:
-				item.delivery_date = self.delivery_date
+				if not item.delivery_date:
+					item.delivery_date = self.delivery_date
 
 
 def get_unreserved_qty(item: object, reserved_qty_details: dict) -> float:


### PR DESCRIPTION
Issue: Unable to change the delivery date in the sales order child table, upon saving it is being updated by the parent's delivery date

Before:

https://github.com/user-attachments/assets/62079050-0c9c-444a-8548-1dde2ea3ac53

After:

https://github.com/user-attachments/assets/25097f61-f2c4-4870-916f-c8a93d53959f

Backport needed: v15

