### PR TITLE
fix: handle negative inventory check (#48558)

### DIFF
--- a/erpnext/stock/doctype/item/item.json
+++ b/erpnext/stock/doctype/item/item.json
@@ -318,6 +318,7 @@
    "fieldname": "shelf_life_in_days",
    "fieldtype": "Int",
    "label": "Shelf Life In Days",
+   "non_negative": 1,
    "mandatory_depends_on": "eval:doc.has_batch_no && doc.has_expiry_date"
   },
   {
@@ -355,6 +356,7 @@
    "fieldname": "warranty_period",
    "fieldtype": "Data",
    "label": "Warranty Period (in days)",
+   "non_negative": 1,
    "oldfieldname": "warranty_period",
    "oldfieldtype": "Data"
   },
@@ -362,7 +364,8 @@
    "depends_on": "is_stock_item",
    "fieldname": "weight_per_unit",
    "fieldtype": "Float",
-   "label": "Weight Per Unit"
+   "label": "Weight Per Unit",
+   "non_negative": 1
   },
   {
    "depends_on": "eval:doc.is_stock_item",
@@ -534,13 +537,15 @@
    "fieldname": "min_order_qty",
    "fieldtype": "Float",
    "label": "Minimum Order Qty",
+   "non_negative": 1,
    "oldfieldname": "min_order_qty",
    "oldfieldtype": "Currency"
   },
   {
    "fieldname": "safety_stock",
    "fieldtype": "Float",
-   "label": "Safety Stock"
+   "label": "Safety Stock",
+   "non_negative": 1
   },
   {
    "fieldname": "purchase_details_cb",
@@ -551,6 +556,7 @@
    "fieldname": "lead_time_days",
    "fieldtype": "Int",
    "label": "Lead Time in days",
+   "non_negative": 1,
    "oldfieldname": "lead_time_days",
    "oldfieldtype": "Int"
   },
@@ -558,6 +564,7 @@
    "fieldname": "last_purchase_rate",
    "fieldtype": "Float",
    "label": "Last Purchase Rate",
+   "non_negative": 1,
    "no_copy": 1,
    "oldfieldname": "last_purchase_rate",
    "oldfieldtype": "Currency",

--- a/erpnext/stock/doctype/item/item.json
+++ b/erpnext/stock/doctype/item/item.json
@@ -318,8 +318,8 @@
    "fieldname": "shelf_life_in_days",
    "fieldtype": "Int",
    "label": "Shelf Life In Days",
-   "non_negative": 1,
-   "mandatory_depends_on": "eval:doc.has_batch_no && doc.has_expiry_date"
+   "mandatory_depends_on": "eval:doc.has_batch_no && doc.has_expiry_date",
+   "non_negative": 1
   },
   {
    "default": "2099-12-31",
@@ -356,7 +356,6 @@
    "fieldname": "warranty_period",
    "fieldtype": "Data",
    "label": "Warranty Period (in days)",
-   "non_negative": 1,
    "oldfieldname": "warranty_period",
    "oldfieldtype": "Data"
   },
@@ -564,8 +563,8 @@
    "fieldname": "last_purchase_rate",
    "fieldtype": "Float",
    "label": "Last Purchase Rate",
-   "non_negative": 1,
    "no_copy": 1,
+   "non_negative": 1,
    "oldfieldname": "last_purchase_rate",
    "oldfieldtype": "Currency",
    "read_only": 1
@@ -896,7 +895,7 @@
  "image_field": "image",
  "links": [],
  "make_attachments_public": 1,
- "modified": "2025-02-03 23:43:57.253667",
+ "modified": "2025-08-08 14:58:48.674193",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Item",
@@ -961,6 +960,7 @@
   }
  ],
  "quick_entry": 1,
+ "row_format": "Dynamic",
  "search_fields": "item_name,description,item_group,customer_code",
  "show_name_in_global_search": 1,
  "show_preview_popup": 1,

--- a/erpnext/stock/doctype/item/item.py
+++ b/erpnext/stock/doctype/item/item.py
@@ -59,8 +59,6 @@ class Item(Document):
 	from typing import TYPE_CHECKING
 
 	if TYPE_CHECKING:
-		from frappe.types import DF
-
 		from erpnext.stock.doctype.item_barcode.item_barcode import ItemBarcode
 		from erpnext.stock.doctype.item_customer_detail.item_customer_detail import ItemCustomerDetail
 		from erpnext.stock.doctype.item_default.item_default import ItemDefault
@@ -69,6 +67,7 @@ class Item(Document):
 		from erpnext.stock.doctype.item_tax.item_tax import ItemTax
 		from erpnext.stock.doctype.item_variant_attribute.item_variant_attribute import ItemVariantAttribute
 		from erpnext.stock.doctype.uom_conversion_detail.uom_conversion_detail import UOMConversionDetail
+		from frappe.types import DF
 
 		allow_alternative_item: DF.Check
 		allow_negative_stock: DF.Check
@@ -88,9 +87,7 @@ class Item(Document):
 		default_bom: DF.Link | None
 		default_item_manufacturer: DF.Link | None
 		default_manufacturer_part_no: DF.Data | None
-		default_material_request_type: DF.Literal[
-			"Purchase", "Material Transfer", "Material Issue", "Manufacture", "Customer Provided"
-		]
+		default_material_request_type: DF.Literal["Purchase", "Material Transfer", "Material Issue", "Manufacture", "Customer Provided"]
 		delivered_by_supplier: DF.Check
 		description: DF.TextEditor | None
 		disabled: DF.Check

--- a/erpnext/stock/doctype/item/item.py
+++ b/erpnext/stock/doctype/item/item.py
@@ -59,6 +59,8 @@ class Item(Document):
 	from typing import TYPE_CHECKING
 
 	if TYPE_CHECKING:
+		from frappe.types import DF
+
 		from erpnext.stock.doctype.item_barcode.item_barcode import ItemBarcode
 		from erpnext.stock.doctype.item_customer_detail.item_customer_detail import ItemCustomerDetail
 		from erpnext.stock.doctype.item_default.item_default import ItemDefault
@@ -67,7 +69,6 @@ class Item(Document):
 		from erpnext.stock.doctype.item_tax.item_tax import ItemTax
 		from erpnext.stock.doctype.item_variant_attribute.item_variant_attribute import ItemVariantAttribute
 		from erpnext.stock.doctype.uom_conversion_detail.uom_conversion_detail import UOMConversionDetail
-		from frappe.types import DF
 
 		allow_alternative_item: DF.Check
 		allow_negative_stock: DF.Check
@@ -87,7 +88,9 @@ class Item(Document):
 		default_bom: DF.Link | None
 		default_item_manufacturer: DF.Link | None
 		default_manufacturer_part_no: DF.Data | None
-		default_material_request_type: DF.Literal["Purchase", "Material Transfer", "Material Issue", "Manufacture", "Customer Provided"]
+		default_material_request_type: DF.Literal[
+			"Purchase", "Material Transfer", "Material Issue", "Manufacture", "Customer Provided"
+		]
 		delivered_by_supplier: DF.Check
 		description: DF.TextEditor | None
 		disabled: DF.Check


### PR DESCRIPTION
## Description
Fixed the issue where negative values were allowed in item inventory settings.

## Changes Made
- Added validation("non_negative:1") to prevent negative inventory quantities

## Fields updated with non-negative validation:
- Shelf Life In Days
- Warranty Period (in days)
- Weight Per Unit
- Lead Time in days
- Minimum Order Qty
- Last Purchase Rate
- Safety Stock

## Issue
Fixes #48558

## Testing
- [x] Tested with negative values (shows error)
- [x] Tested with positive values (works correctly)
- [x] Tested with zero values (works correctly)

## Screenshots
<img width="1826" height="912" alt="image" src="https://github.com/user-attachments/assets/9e902010-a041-4528-b703-c9b2417a6109" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Numeric fields such as shelf life, weight per unit, minimum order quantity, safety stock, lead time, and last purchase rate for items now only accept zero or positive values.
* **Other**
  * Improved data formatting and structure for item records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->