### PR TITLE
fix: Use correct Attachments folder in code list import

### DIFF
--- a/erpnext/edi/doctype/code_list/code_list_import.py
+++ b/erpnext/edi/doctype/code_list/code_list_import.py
@@ -60,7 +60,7 @@ def import_genericode():
 			"doctype": "File",
 			"attached_to_doctype": "Code List",
 			"attached_to_name": code_list.name,
-			"folder": "Home/Attachments",
+			"folder": frappe.db.get_value("File", {"is_attachments_folder": 1}),
 			"file_name": frappe.local.uploaded_filename,
 			"file_url": frappe.local.uploaded_file_url,
 			"is_private": 1,


### PR DESCRIPTION
I believe that `Home/Attachments` is still translated in old installs of ERPNext, right?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the assignment of imported Code List files to ensure they are placed in the correct attachments folder based on current system settings, rather than a fixed folder path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->