### PR TITLE
fix: prevent negative scrap quantity in Job Card (#48545)

### DIFF
--- a/erpnext/manufacturing/doctype/job_card_scrap_item/job_card_scrap_item.json
+++ b/erpnext/manufacturing/doctype/job_card_scrap_item/job_card_scrap_item.json
@@ -51,6 +51,7 @@
    "fieldtype": "Float",
    "in_list_view": 1,
    "label": "Qty",
+   "non_negative": 1,
    "reqd": 1
   },
   {


### PR DESCRIPTION
### Description

Fixed validation issue in **Job Card** where negative scrap quantities were incorrectly allowed in the scrap items tab.

### Issue Fixed

- **#48545**: Negative Scrap Quantity in Job Card is possible 

### Changes Made

- Added `non_negative: 1` constraint to the following field:
  - `scrap_qty` in **Job Card Scrap** (prevents negative scrap quantity)

### Issues

Fixes #48545


### Testing

- [X] Tested adding negative scrap quantity in Job Card (Validation Works)  
- [X] Verified positive values still save successfully  
- [X] Confirmed error message appears appropriately 

[jobcard-negative-scrapItem-Qty-fix.webm](https://github.com/user-attachments/assets/bf56dac8-9c9a-4d46-96c4-adc7181d2c97)
