### PR TITLE
fix(production plan): add company filter to sub assembly warehouse

### DIFF
--- a/erpnext/manufacturing/doctype/production_plan/production_plan.js
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.js
@@ -47,6 +47,14 @@ frappe.ui.form.on("Production Plan", {
 			};
 		});
 
+		frm.set_query("sub_assembly_warehouse", function (doc) {
+			return {
+				filters: {
+					company: doc.company,
+				},
+			};
+		});
+
 		frm.set_query("material_request", "material_requests", function () {
 			return {
 				filters: {


### PR DESCRIPTION
Issue: In Production Plan, the Sub Assembly Warehouse is not filtered by the selected company.

Before:

https://github.com/user-attachments/assets/ff7ab739-eb1e-44a4-b123-773753a0c7e3

After:

https://github.com/user-attachments/assets/3faf01f0-67e4-4e7a-a649-4f83282bb8df

resolves[#48295 ](https://github.com/frappe/erpnext/issues/48295)

Backport needed: v15