### PR TITLE
feat: implement automatic line item creation in Sales Invoices based …

### DIFF
--- a/erpnext/projects/doctype/activity_type/activity_type.json
+++ b/erpnext/projects/doctype/activity_type/activity_type.json
@@ -12,7 +12,9 @@
   "costing_rate",
   "column_break_3",
   "billing_rate",
-  "disabled"
+  "disabled",
+  "section_break_1",
+  "item"
  ],
  "fields": [
   {
@@ -42,6 +44,18 @@
    "fieldname": "disabled",
    "fieldtype": "Check",
    "label": "Disabled"
+  },
+  {
+   "fieldname": "section_break_1",
+   "fieldtype": "Section Break",
+   "label": "Item Mapping"
+  },
+  {
+   "description": "Link this Activity Type to an Item for automatic line item creation in Sales Invoices",
+   "fieldname": "item",
+   "fieldtype": "Link",
+   "label": "Item",
+   "options": "Item"
   }
  ],
  "icon": "icon-flag",

--- a/erpnext/projects/doctype/activity_type/activity_type.py
+++ b/erpnext/projects/doctype/activity_type/activity_type.py
@@ -18,6 +18,7 @@ class ActivityType(Document):
 		billing_rate: DF.Currency
 		costing_rate: DF.Currency
 		disabled: DF.Check
+		item: DF.Link | None
 	# end: auto-generated types
 
 	pass

--- a/erpnext/selling/doctype/selling_settings/selling_settings.json
+++ b/erpnext/selling/doctype/selling_settings/selling_settings.json
@@ -36,6 +36,7 @@
   "enable_cutoff_date_on_bulk_delivery_note_creation",
   "allow_zero_qty_in_quotation",
   "allow_zero_qty_in_sales_order",
+  "sum_similar_timesheets_in_sales_invoice",
   "experimental_section",
   "use_server_side_reactivity"
  ],
@@ -236,6 +237,13 @@
    "fieldname": "allow_zero_qty_in_quotation",
    "fieldtype": "Check",
    "label": "Allow Quotation with Zero Quantity"
+  },
+  {
+   "default": "0",
+   "description": "When enabled, similar timesheets (same rate and Item) will be combined into one line item in Sales Invoices",
+   "fieldname": "sum_similar_timesheets_in_sales_invoice",
+   "fieldtype": "Check",
+   "label": "Sum Similar Timesheets in Sales Invoice"
   }
  ],
  "grid_page_length": 50,


### PR DESCRIPTION
# Time Tracking and Invoicing Integration

This feature allows automatic creation of Sales Invoice line items based on Timesheet data and Activity Type mappings.

## Features

### 1. Activity Type to Item Mapping
- Add a new "Item" field to Activity Type doctype
- Link Activity Types to corresponding Items for automatic line item creation
- Configure in: **Projects > Activity Type**

### 2. Automatic Line Item Creation
When fetching Timesheets into a Sales Invoice:
- If Activity Types have Item mappings, line items are automatically created
- Hours are used as quantity, billing rate as item rate
- Works for both manual timesheet fetching and project-based auto-fetch

### 3. Timesheet Grouping Options
New setting in **Selling Settings**:
- **"Sum Similar Timesheets in Sales Invoice"**: Groups timesheets with same Item and rate into single line items
- Respects existing **"Allow Item to be Added Multiple Times"** setting

## Usage

### Setup
1. **Configure Activity Types**:
   - Go to Projects > Activity Type
   - For each Activity Type, set the corresponding Item in the "Item Mapping" section
   - Ensure the linked Items are marked as Sales Items

2. **Configure Settings** (Optional):
   - Go to Selling Settings
   - Enable "Sum Similar Timesheets in Sales Invoice" to group similar entries
   - "Allow Item to be Added Multiple Times" controls whether duplicate items can be added

### Creating Sales Invoices from Timesheets

#### Method 1: From Timesheet
1. Open a submitted Timesheet with billable hours
2. Click "Create Sales Invoice"
3. Leave "Item Code" blank to use automatic mapping
4. Line items will be created automatically based on Activity Type mappings

#### Method 2: From Sales Invoice
1. Create a new Sales Invoice
2. Click "Get Items From" > "Timesheet"
3. Select date range and project
4. Leave "Item Code" blank for automatic mapping
5. Line items and timesheet entries will be created automatically

#### Method 3: Project Auto-fetch
1. Enable "Fetch Timesheet in Sales Invoice" in Projects Settings
2. Create Sales Invoice with a Project
3. Line items will be automatically created for unbilled timesheets

## Examples

### Example 1: Simple Mapping
- Activity Type: "Development" → Item: "Software Development Services"
- Timesheet: 8 hours of "Development" at $100/hour
- Result: Line item with 8 Hours @ $100/hour of "Software Development Services"

### Example 2: Grouped Timesheets (Sum Similar enabled)
- Multiple timesheets with "Development" activity at same rate
- Result: Single line item with total hours for "Software Development Services"

### Example 3: Mixed Activities
- Timesheet with multiple activities mapped to different items
- Result: Multiple line items, one for each mapped activity type

## Benefits

1. **Automated Workflow**: Eliminates manual line item creation
2. **Consistency**: Ensures correct items are used for specific activities
3. **Flexibility**: Supports both grouped and individual item creation
4. **Integration**: Works with existing timesheet and project workflows
5. **Customization**: Respects existing settings for item handling

## Technical Notes

- Line items use "Hour" as default UOM
- Item rates are calculated from timesheet billing amounts
- Only billable timesheet entries are processed
- Existing manual item addition still works alongside automatic creation
- Activity Types without Item mappings are still added to timesheet table but don't create line items
