### PR TITLE
perf: subcontracting receipt creation using data import

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry.json
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.json
@@ -165,7 +165,8 @@
    "fieldname": "subcontracting_order",
    "fieldtype": "Link",
    "label": "Subcontracting Order",
-   "options": "Subcontracting Order"
+   "options": "Subcontracting Order",
+   "search_index": 1
   },
   {
    "depends_on": "eval:doc.purpose==\"Sales Return\"",
@@ -697,7 +698,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-08-13 19:05:42.386955",
+ "modified": "2025-07-20 15:16:00.287680",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Stock Entry",
@@ -763,6 +764,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "search_fields": "posting_date, from_warehouse, to_warehouse, purpose, remarks",
  "show_name_in_global_search": 1,
  "sort_field": "creation",


### PR DESCRIPTION
**Before Fix**

System has taken 318 Seconds to submit 71 subcontracting receipts which has 1800 raw materials

<img width="912" height="727" alt="Screenshot 2025-07-19 at 9 56 26 PM" src="https://github.com/user-attachments/assets/1b49ac31-f6c4-4f82-a729-a6c2494b90e1" />



**After Fix**
System has taken 175 Seconds to submit 71 subcontracting receipts which has 1800 raw materials
<img width="848" height="719" alt="Screenshot 2025-07-20 at 3 36 43 PM" src="https://github.com/user-attachments/assets/1ecd063f-0ffb-47c4-a99a-11f632fb580e" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved accuracy of reserved quantity calculations for subcontracting orders by considering actual materials transferred.
  * Enhanced search capabilities for the "subcontracting_order" field in Stock Entry records.

* **Bug Fixes**
  * Reserved quantities in stock bins now reflect the latest state of materials transferred for each raw material item in subcontracting workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->