### PR TITLE
Update opportunity.json

### DIFF
--- a/erpnext/crm/doctype/opportunity/opportunity.json
+++ b/erpnext/crm/doctype/opportunity/opportunity.json
@@ -152,7 +152,6 @@
    "no_copy": 1
   },
   {
-   "default": "Sales",
    "fieldname": "opportunity_type",
    "fieldtype": "Link",
    "in_list_view": 1,


### PR DESCRIPTION
removing "Sales" as default from Opportunity Type as this is causes errors in non-english setups.

when selecting "German" on the setup wizard of ERPNext is will create these Opportunity Types
<img width="1078" height="628" alt="image" src="https://github.com/user-attachments/assets/c2cef5e7-4bfc-41a8-b390-4bc5c90dae3d" />

As "Sales" is not one of them setting the default value "Sales" in Opportunity Doctype will break.

Workaround:
Add record names "Sales" in Opportunity Types manually.
