### PR TITLE
refactor: remove default value for opportunity type

### DIFF
--- a/erpnext/crm/doctype/opportunity/opportunity.js
+++ b/erpnext/crm/doctype/opportunity/opportunity.js
@@ -284,6 +284,9 @@ erpnext.crm.Opportunity = class Opportunity extends frappe.ui.form.Controller {
 			this.frm.set_value("currency", frappe.defaults.get_user_default("Currency"));
 		}
 
+		if (this.frm.is_new() && this.frm.doc.opportunity_type === undefined) {
+			this.frm.doc.opportunity_type = __("Sales");
+		}
 		this.setup_queries();
 	}
 

--- a/erpnext/crm/doctype/opportunity/opportunity.json
+++ b/erpnext/crm/doctype/opportunity/opportunity.json
@@ -152,7 +152,6 @@
    "no_copy": 1
   },
   {
-   "default": "Sales",
    "fieldname": "opportunity_type",
    "fieldtype": "Link",
    "in_list_view": 1,

--- a/erpnext/crm/doctype/opportunity/opportunity.py
+++ b/erpnext/crm/doctype/opportunity/opportunity.py
@@ -126,6 +126,7 @@ class Opportunity(TransactionBase, CRMNote):
 				link_communications(self.opportunity_from, self.party_name, self)
 
 	def validate(self):
+		self.set_opportunity_type()
 		self.make_new_lead_if_required()
 		self.validate_item_details()
 		self.validate_uom_is_integer("uom", "qty")
@@ -149,6 +150,10 @@ class Opportunity(TransactionBase, CRMNote):
 					self.set(field, value)
 				except Exception:
 					continue
+
+	def set_opportunity_type(self):
+		if self.is_new() and not self.opportunity_type:
+			self.opportunity_type = _("Sales")
 
 	def set_exchange_rate(self):
 		company_currency = frappe.get_cached_value("Company", self.company, "default_currency")


### PR DESCRIPTION
removing "Sales" as default from Opportunity Type as this is causes errors in non-english setups.

when selecting "German" on the setup wizard of ERPNext is will create these Opportunity Types
<img width="1152" height="687" alt="image" src="https://github.com/user-attachments/assets/ae1a5c04-69b6-489c-9bf4-2062a3e9ff2c" />

As "Sales" is not one of them setting the default value "Sales" in Opportunity Doctype will break.

Workaround:
Add record names "Sales" in Opportunity Types manually.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Removed the stored default “Sales” from the Opportunity type configuration.
- Bug Fixes / Behavior
  - New Opportunity creation still auto-selects “Sales” when not set, preserving prior user-facing behavior.
  - Existing records remain unchanged; admins can set a preferred default via customization if desired.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->