### PR TITLE
 refactor: process subscriptions in batch wise

### DIFF
--- a/erpnext/accounts/doctype/subscription/subscription.py
+++ b/erpnext/accounts/doctype/subscription/subscription.py
@@ -756,18 +756,14 @@ def get_prorata_factor(
 	return diff / plan_days
 
 
-def process_all(subscription: str | None = None, posting_date: DateTimeLikeObject | None = None) -> None:
+def process_all(subscription: list, posting_date: DateTimeLikeObject | None = None) -> None:
 	"""
 	Task to updates the status of all `Subscription` apart from those that are cancelled
 	"""
-	filters = {"status": ("!=", "Cancelled")}
 
-	if subscription:
-		filters["name"] = subscription
-
-	for subscription in frappe.get_all("Subscription", filters, pluck="name"):
+	for subscription_name in subscription:
 		try:
-			subscription = frappe.get_doc("Subscription", subscription)
+			subscription = frappe.get_doc("Subscription", subscription_name)
 			subscription.process(posting_date)
 			frappe.db.commit()
 		except frappe.ValidationError:


### PR DESCRIPTION
Issue: Background job timed out when there are too many subscriptions to process.

Ref: [#44349](https://support.frappe.io/helpdesk/tickets/44349), [#42775](https://support.frappe.io/helpdesk/tickets/42775)

Solution: Process subscriptions in batches of 500.

Backport needed: v15

no-docs



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved subscription processing by batching and asynchronously handling multiple subscriptions, enhancing performance and scalability for large numbers of subscriptions.

* **Bug Fixes**
  * Resolved issues related to processing cancelled subscriptions by ensuring they are excluded from batch operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->