### PR TITLE
fix: resolve sql syntax on accounting dimension

### DIFF
--- a/erpnext/accounts/report/dimension_wise_accounts_balance_report/dimension_wise_accounts_balance_report.py
+++ b/erpnext/accounts/report/dimension_wise_accounts_balance_report/dimension_wise_accounts_balance_report.py
@@ -86,7 +86,7 @@ def set_gl_entries_by_account(dimension_list, filters, account, gl_entries_by_ac
 		"finance_book": cstr(filters.get("finance_book")),
 	}
 
-	gl_filters["dimensions"] = set(dimension_list)
+	gl_filters["dimensions"] = tuple(set(dimension_list))
 
 	if filters.get("include_default_book_entries"):
 		gl_filters["company_fb"] = frappe.get_cached_value("Company", filters.company, "default_finance_book")
@@ -179,7 +179,7 @@ def accumulate_values_into_parents(accounts, accounts_by_name, dimension_list):
 def get_condition(dimension):
 	conditions = []
 
-	conditions.append(f"{frappe.scrub(dimension)} in (%(dimensions)s)")
+	conditions.append(f"{frappe.scrub(dimension)} in %(dimensions)s")
 
 	return " and {}".format(" and ".join(conditions)) if conditions else ""
 


### PR DESCRIPTION
Issue: Error in 'Dimension-wise Accounts Balance Report'

Ref: [44538](https://support.frappe.io/helpdesk/tickets/44538)

Before:

**Veriosn-15**

<img width="1346" height="811" alt="image" src="https://github.com/user-attachments/assets/1222bc2e-e057-45c5-8a89-efed63676146" />


**Develop (data not fetching for if multiple accounting dimensions are present )**

<img width="1864" height="623" alt="image" src="https://github.com/user-attachments/assets/dfb637f3-c71c-43f7-886c-714a3a48b22a" />

<img width="779" height="148" alt="image" src="https://github.com/user-attachments/assets/86628fee-802b-4fa0-87df-8464553095a8" />



After:

**Version-15**

<img width="1379" height="635" alt="image" src="https://github.com/user-attachments/assets/89abd164-9cf1-4127-99bf-111ab31265e0" />


**Develop**

<img width="1862" height="972" alt="image" src="https://github.com/user-attachments/assets/b36357d8-e2cf-4da2-ba45-6b86107b1dc1" />


<img width="630" height="151" alt="image" src="https://github.com/user-attachments/assets/68d001d6-65b3-4b3c-a062-32504322b272" />


**Backport needed: Version-15**