### PR TITLE
fix(pick list): make warehouse editable

### DIFF
--- a/erpnext/stock/doctype/pick_list/pick_list.js
+++ b/erpnext/stock/doctype/pick_list/pick_list.js
@@ -21,6 +21,14 @@ frappe.ui.form.on("Pick List", {
 			"Stock Entry": "Stock Entry",
 		};
 
+		frm.set_query("warehouse", "locations", () => {
+			return {
+				filters: {
+					company: frm.doc.company,
+				},
+			};
+		});
+
 		frm.set_query("parent_warehouse", () => {
 			return {
 				filters: {
@@ -91,6 +99,15 @@ frappe.ui.form.on("Pick List", {
 			});
 		}
 	},
+
+	pick_manually: function (frm) {
+		frm.fields_dict.locations.grid.update_docfield_property(
+			"warehouse",
+			"read_only",
+			!frm.doc.pick_manually
+		);
+	},
+
 	get_item_locations: (frm) => {
 		// Button on the form
 		frm.events.set_item_locations(frm, false);

--- a/erpnext/stock/doctype/pick_list/pick_list.json
+++ b/erpnext/stock/doctype/pick_list/pick_list.json
@@ -201,7 +201,7 @@
   },
   {
    "default": "0",
-   "description": "If enabled then system won't override the picked qty / batches / serial numbers.",
+   "description": "If enabled then system won't override the picked qty / batches / serial numbers / warehouse.",
    "fieldname": "pick_manually",
    "fieldtype": "Check",
    "label": "Pick Manually"
@@ -247,7 +247,7 @@
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2025-05-31 19:18:30.860044",
+ "modified": "2025-07-23 08:34:32.099673",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Pick List",


### PR DESCRIPTION
Issue: When trying to create a Pick List manually, the Warehouse field in the Item Locations table is not editable.

Pick List:

<img width="1792" height="1120" alt="Screenshot 2025-07-22 at 12 52 12 PM" src="https://github.com/user-attachments/assets/401c922c-31ef-4ce9-91c1-bad98d24ed01" />

resolves[#48108 ](https://github.com/frappe/erpnext/issues/48108)

Backport needed: v15