### PR TITLE
Fix: PaymentEntryReference AttributeError in Payment Entry Cancellation

### DIFF
--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -798,26 +798,22 @@ def get_reconciliation_effect_date(reference, company, posting_date):
 		reconcile_on = posting_date
 	elif reconciliation_takes_effect_on == "Oldest Of Invoice Or Advance":
 		date_field = "posting_date"
-		
-		# Handle both PaymentEntryReference objects and reconciliation objects
-		if hasattr(reference, 'against_voucher_type'):
 
+		# Handle both PaymentEntryReference objects and reconciliation objects
+		if hasattr(reference, "against_voucher_type"):
 			voucher_type = reference.against_voucher_type
 			voucher_no = reference.against_voucher
-		elif hasattr(reference, 'reference_doctype'):
-
+		elif hasattr(reference, "reference_doctype"):
 			voucher_type = reference.reference_doctype
 			voucher_no = reference.reference_name
 		else:
 			# Fallback
 			reconcile_on = posting_date
 			return reconcile_on
-		
+
 		if voucher_type in ["Sales Order", "Purchase Order"]:
 			date_field = "transaction_date"
-		reconcile_on = frappe.db.get_value(
-			voucher_type, voucher_no, date_field
-		)
+		reconcile_on = frappe.db.get_value(voucher_type, voucher_no, date_field)
 		if getdate(reconcile_on) < getdate(posting_date):
 			reconcile_on = posting_date
 	elif reconciliation_takes_effect_on == "Reconciliation Date":

--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -791,14 +791,32 @@ def get_reconciliation_effect_date(reference, company, posting_date):
 		"Company", company, "reconciliation_takes_effect_on"
 	)
 
+	# initializing reconcile_on with a default value
+	reconcile_on = posting_date
+
 	if reconciliation_takes_effect_on == "Advance Payment Date":
 		reconcile_on = posting_date
 	elif reconciliation_takes_effect_on == "Oldest Of Invoice Or Advance":
 		date_field = "posting_date"
-		if reference.against_voucher_type in ["Sales Order", "Purchase Order"]:
+		
+		# Handle both PaymentEntryReference objects and reconciliation objects
+		if hasattr(reference, 'against_voucher_type'):
+
+			voucher_type = reference.against_voucher_type
+			voucher_no = reference.against_voucher
+		elif hasattr(reference, 'reference_doctype'):
+
+			voucher_type = reference.reference_doctype
+			voucher_no = reference.reference_name
+		else:
+			# Fallback
+			reconcile_on = posting_date
+			return reconcile_on
+		
+		if voucher_type in ["Sales Order", "Purchase Order"]:
 			date_field = "transaction_date"
 		reconcile_on = frappe.db.get_value(
-			reference.against_voucher_type, reference.against_voucher, date_field
+			voucher_type, voucher_no, date_field
 		)
 		if getdate(reconcile_on) < getdate(posting_date):
 			reconcile_on = posting_date


### PR DESCRIPTION
# PR: Fix PaymentEntryReference AttributeError in Payment Entry Cancellation

## Issue Description
**GitHub Issue**: [#48739](https://github.com/frappe/erpnext/issues/48739)

**Error**: `AttributeError: 'PaymentEntryReference' object has no attribute 'against_voucher_type'`

**Trigger**: Canceling Payment Entries with references to Sales Orders or Purchase Orders

**Impact**: Users cannot cancel Payment Entries, breaking core ERPNext functionality

## Root Cause
The `get_reconciliation_effect_date()` function in `erpnext/accounts/utils.py` was designed to handle reconciliation objects with `against_voucher_type` and `against_voucher` attributes. However, when called from Payment Entry cancellation, it receives `PaymentEntryReference` objects with `reference_doctype` and `reference_name` attributes instead.

## Solution
Modified `get_reconciliation_effect_date()` function to handle both object types:

1. **Object Type Detection**: Uses `hasattr()` to check available attributes
2. **Attribute Mapping**: Maps `reference_doctype` → `voucher_type` and `reference_name` → `voucher_no`
3. **Graceful Fallback**: Returns posting_date if object type is unknown
4. **Variable Initialization**: Prevents UnboundLocalError


## Files Changed
- `erpnext/accounts/utils.py` - Modified `get_reconciliation_effect_date()` function

## Deployment Notes
- Safe to deploy immediately
- No database migrations required
- No configuration changes needed
- Monitor Payment Entry cancellation success rates post-deployment 