### PR TITLE
revert: do not save when set email campaign status

### DIFF
--- a/erpnext/crm/doctype/email_campaign/email_campaign.py
+++ b/erpnext/crm/doctype/email_campaign/email_campaign.py
@@ -144,4 +144,3 @@ def set_email_campaign_status():
 	for entry in email_campaigns:
 		email_campaign = frappe.get_doc("Email Campaign", entry.name)
 		email_campaign.update_status()
-		email_campaign.save()


### PR DESCRIPTION
Issue: Email Campaign status is not updating

Reason : The status is updated using db.set, and calling save again triggers validation, which leads to an error.

reverting: [#39776](https://github.com/frappe/erpnext/pull/39776)

Before:

https://github.com/user-attachments/assets/4dce1b1e-b846-4a97-b36c-aca5bd07f722

After:

https://github.com/user-attachments/assets/a28472a8-e9c7-43d6-ab41-d114f2c63ce7

no-docs
