### PR TITLE
Fix: Procurement Tracker - No permission to read Employee #48765

### DIFF
--- a/erpnext/buying/report/procurement_tracker/procurement_tracker.py
+++ b/erpnext/buying/report/procurement_tracker/procurement_tracker.py
@@ -51,7 +51,7 @@ def get_columns(filters):
 		},
 		{
 			"label": _("Requestor"),
-			"options": "Employee",
+			"options": "User",
 			"fieldname": "requestor",
 			"fieldtype": "Link",
 			"width": 140,


### PR DESCRIPTION
### Issues
When I opened the Procurement Tracker report, it showed that I didn't have the permission to access employees, and I didn't intend to create employees in the system.

ref:  #48765 
