### PR TITLE
Allow following calendar months for yearly subscription models

### DIFF
--- a/erpnext/accounts/doctype/subscription/subscription.json
+++ b/erpnext/accounts/doctype/subscription/subscription.json
@@ -195,7 +195,7 @@
   },
   {
    "default": "0",
-   "description": "If this is checked subsequent new invoices will be created on calendar  month and quarter start dates irrespective of current invoice start date",
+   "description": "If this is checked subsequent new invoices will be created on calendar month, quarter or year start dates irrespective of current invoice start date",
    "fieldname": "follow_calendar_months",
    "fieldtype": "Check",
    "label": "Follow Calendar Months",

--- a/erpnext/accounts/doctype/subscription/subscription.py
+++ b/erpnext/accounts/doctype/subscription/subscription.py
@@ -364,12 +364,19 @@ class Subscription(Document):
 			return
 
 		billing_info = self.get_billing_cycle_and_interval()
+		billing_interval = billing_info[0]["billing_interval"]
 
-		if not self.end_date:
-			frappe.throw(_("Subscription End Date is mandatory to follow calendar months"))
+		if billing_interval in ["Day", "Week"] and not self.end_date:
+			frappe.throw(
+				_(
+					"Subscription End Date is mandatory to follow calendar months when billing interval is {0}"
+				).format(billing_interval)
+			)
 
-		if billing_info[0]["billing_interval"] != "Month":
-			frappe.throw(_("Billing Interval in Subscription Plan must be Month to follow calendar months"))
+		if billing_interval not in ["Month", "Year"]:
+			frappe.throw(
+				_("Billing Interval in Subscription Plan must be Month or Year to follow calendar months")
+			)
 
 	def generate_invoice(
 		self,

--- a/erpnext/accounts/doctype/subscription/subscription.py
+++ b/erpnext/accounts/doctype/subscription/subscription.py
@@ -151,13 +151,22 @@ class Subscription(Document):
 				_current_invoice_end = get_last_day(date)
 
 			if self.follow_calendar_months:
-				# Sets the end date
-				# eg if date is 17-Feb-2022, the invoice will be generated per month ie
-				# the invoice will be created from 17 Feb to 28 Feb
+				# Get the billing interval and count
 				billing_info = self.get_billing_cycle_and_interval()
+				billing_interval = billing_info[0]["billing_interval"]
 				billing_interval_count = billing_info[0]["billing_interval_count"]
-				_end = add_months(getdate(date), billing_interval_count - 1)
-				_current_invoice_end = get_last_day(_end)
+
+				# Calculate end date based on billing interval
+				if billing_interval == "Month":
+					# For monthly, get the last day of the month
+					_end = add_months(getdate(date), billing_interval_count - 1)
+					_current_invoice_end = get_last_day(_end)
+				else:  # billing_interval == "Year"
+					current_date = getdate(date)
+					# First, add the appropriate number of years
+					if billing_interval_count > 1:
+						current_date = add_to_date(current_date, years=billing_interval_count - 1)
+					_current_invoice_end = get_last_day(f"{current_date.year}-12-01")
 
 			if self.end_date and getdate(_current_invoice_end) > getdate(self.end_date):
 				_current_invoice_end = self.end_date


### PR DESCRIPTION
I wanted to be able to create yearly memberships tied to open-ended subscriptions that follow the calendar year, and the description of the functionality in erpnext implied this should be possible. 
It didn't work because of validation errors and missing logic.

In the current codebase, there is a check for the existence of a subscription end date when "follow calendar months" is enabled. It complains about the absence of a subscription end date when you create a subscription on a yearly billing cycle.
This exception seems unintentional and I cannot think of a valid use case where you'd want to require a predefined subscription end date with yearly subscriptions but not monthly/quarterly. As such, I am submitting this fix (which otherwise leaves the validation check in place).

I tried to create a PR before but it was rather incomplete (my apologies) and when I tried to update it today things truly went sideways, so I closed that PR and am now submitting this hopefully cleaner one. Thank you for your patience and interest.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Yearly subscriptions now align to calendar years when “Follow Calendar Months” is enabled (e.g., periods end on Dec 31).
  - Subsequent billing periods automatically align to calendar months/years.

- Bug Fixes
  - Corrected end-date calculation for yearly plans when following the calendar.
  - Validation now correctly restricts calendar-following to monthly or yearly intervals.

- Documentation
  - Updated “Follow Calendar Months” description to include year start dates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->