### PR TITLE
fix: create job card for selected operations only

### DIFF
--- a/erpnext/manufacturing/doctype/work_order/work_order.js
+++ b/erpnext/manufacturing/doctype/work_order/work_order.js
@@ -349,13 +349,18 @@ frappe.ui.form.on("Work Order", {
 					return operations_data;
 				},
 			},
-			function (data) {
+			function () {
+				const selected_rows = dialog.fields_dict["operations"].grid.get_selected_children();
+				if (selected_rows.length == 0) {
+					frappe.msgprint(__("Please select atleast one operation to create Job Card"));
+					return;
+				}
 				frappe.call({
 					method: "erpnext.manufacturing.doctype.work_order.work_order.make_job_card",
 					freeze: true,
 					args: {
 						work_order: frm.doc.name,
-						operations: data.operations,
+						operations: selected_rows,
 					},
 					callback: function () {
 						frm.reload_doc();
@@ -366,7 +371,7 @@ frappe.ui.form.on("Work Order", {
 			__("Create")
 		);
 
-		dialog.fields_dict["operations"].grid.wrapper.find(".grid-add-row").hide();
+		dialog.fields_dict["operations"].grid.grid_buttons.hide();
 
 		var pending_qty = 0;
 		frm.doc.operations.forEach((data) => {


### PR DESCRIPTION
    Create job card for only selected operations (rows) only.
    hide add, duplicate & delete row buttons from dialog

[Screencast from 07-24-2025 03:14:27 PM.webm](https://github.com/user-attachments/assets/68f4c963-da5d-4a6e-aa2d-0daf02f2a955)

`no-docs`

closes #48258