### PR TITLE
fix: accumulate deductions into paid_amount

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -1970,7 +1970,7 @@ class PaymentEntry(AccountsController):
 		precision = self.precision("paid_amount")
 		total_positive_outstanding_including_order = 0
 		total_negative_outstanding = 0
-		paid_amount -= sum(flt(d.amount, precision) for d in self.deductions)
+		paid_amount += sum(flt(d.amount, precision) for d in self.deductions)
 
 		for ref in self.references:
 			reference_outstanding_amount = flt(ref.outstanding_amount)


### PR DESCRIPTION
Please port to `version-14`, and `version-15`

Example creating Payment from Sales Invoice with early payment discount.
### Before PR
The deduction amount is accumulated correctly into the reference allocation when creating a Payment Entry from Sales Invoice
and incorrectly when fetched from Get Outstanding Invoices.

[Screencast from 2025-07-24 03:35:29 PM.webm](https://github.com/user-attachments/assets/3591e6c2-f8fe-41d7-b5e5-0d28ff6753ca)


### After PR
The deduction amount is correctly accumulated into the reference allocation using both scenarios.

[Screencast from 2025-07-24 03:38:35 PM.webm](https://github.com/user-attachments/assets/35ffa619-aeb1-4d65-a172-80ea80d3fb5b)
