### PR TITLE
fix: error when trying to edit quantity of top most FG in bom creator

### DIFF
--- a/erpnext/public/js/bom_configurator/bom_configurator.bundle.js
+++ b/erpnext/public/js/bom_configurator/bom_configurator.bundle.js
@@ -417,7 +417,7 @@ class BOMConfigurator {
 						doctype: doctype,
 						docname: docname,
 						qty: data.qty,
-						parent: node.data.parent_id,
+						parent: node.data.parent_id ? node.data.parent_id : this.frm.doc.name,
 					},
 					callback: (r) => {
 						node.data.qty = data.qty;


### PR DESCRIPTION
Reference support ticket [44460](https://support.frappe.io/helpdesk/tickets/44460)

Issue exists only on v15