### PR TITLE
fix: status in MR (material transfer) when using transit stock entries

### DIFF
--- a/erpnext/stock/doctype/material_request/material_request.json
+++ b/erpnext/stock/doctype/material_request/material_request.json
@@ -307,6 +307,7 @@
    "fieldname": "transfer_status",
    "fieldtype": "Select",
    "label": "Transfer Status",
+   "no_copy": 1,
    "options": "\nNot Started\nIn Transit\nCompleted",
    "read_only": 1
   },
@@ -364,7 +365,7 @@
  "idx": 70,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-07-11 21:03:26.588307",
+ "modified": "2025-07-28 15:13:49.000037",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Material Request",

--- a/erpnext/stock/doctype/material_request/material_request.py
+++ b/erpnext/stock/doctype/material_request/material_request.py
@@ -38,6 +38,7 @@ class MaterialRequest(BuyingController):
 		from erpnext.stock.doctype.material_request_item.material_request_item import MaterialRequestItem
 
 		amended_from: DF.Link | None
+		buying_price_list: DF.Link | None
 		company: DF.Link
 		customer: DF.Link | None
 		items: DF.Table[MaterialRequestItem]
@@ -54,7 +55,6 @@ class MaterialRequest(BuyingController):
 		naming_series: DF.Literal["MAT-MR-.YYYY.-"]
 		per_ordered: DF.Percent
 		per_received: DF.Percent
-		price_list: DF.Link | None
 		scan_barcode: DF.Data | None
 		schedule_date: DF.Date | None
 		select_print_heading: DF.Link | None

--- a/erpnext/stock/doctype/material_request/material_request_list.js
+++ b/erpnext/stock/doctype/material_request/material_request_list.js
@@ -10,7 +10,11 @@ frappe.listview_settings["Material Request"] = {
 			} else if (doc.transfer_status == "In Transit") {
 				return [__("In Transit"), "yellow", "transfer_status,=,In Transit"];
 			} else if (doc.transfer_status == "Completed") {
-				return [__("Completed"), "green", "transfer_status,=,Completed"];
+				if (doc.status == "Transferred") {
+					return [__("Completed"), "green", "transfer_status,=,Completed"];
+				} else {
+					return [__("Partially Received"), "yellow", "per_ordered,<,100"];
+				}
 			}
 		} else if (doc.docstatus == 1 && flt(doc.per_ordered, precision) == 0) {
 			return [__("Pending"), "orange", "per_ordered,=,0|docstatus,=,1"];


### PR DESCRIPTION
Reference support ticket [44120](https://support.frappe.io/helpdesk/tickets/44120)