### PR TITLE
Replace deprecated cache handling

### DIFF
--- a/erpnext/accounts/doctype/fiscal_year/fiscal_year.py
+++ b/erpnext/accounts/doctype/fiscal_year/fiscal_year.py
@@ -68,10 +68,10 @@ class FiscalYear(Document):
 
 	def on_update(self):
 		check_duplicate_fiscal_year(self)
-		frappe.cache().delete_value("fiscal_years")
+		frappe.cache().delete_key("fiscal_years")
 
 	def on_trash(self):
-		frappe.cache().delete_value("fiscal_years")
+		frappe.cache().delete_key("fiscal_years")
 
 	def validate_overlap(self):
 		existing_fiscal_years = frappe.db.sql(


### PR DESCRIPTION
Replace deprecated `delete_value` with `delete_key` in fiscal_year.py for cache handling.

closes #48163