### PR TITLE
fix: avoid auto_repeat on duplicate

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.json
+++ b/erpnext/selling/doctype/sales_order/sales_order.json
@@ -1434,6 +1434,7 @@
    "hide_days": 1,
    "hide_seconds": 1,
    "label": "Auto Repeat",
+   "no_copy": 1,
    "options": "Auto Repeat"
   },
   {
@@ -1687,7 +1688,7 @@
  "idx": 105,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-03-03 16:49:00.676927",
+ "modified": "2025-07-28 12:14:29.760988",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Sales Order",


### PR DESCRIPTION
**Issue:**

While duplicating a Sales Order which has an Auto Repeat, the Auto Repeat field is copied over to the duplicated document.

**Before:**

[before_issue](https://github.com/user-attachments/assets/ed2bd717-2b1f-4592-87a2-b7f9abbbf5a9)


**After:**

[after_fix](https://github.com/user-attachments/assets/c6938cf4-cbb9-40ae-a2be-e6d5be738086)


**resolves:** #48768 


**Backport needed: v15**



