### PR TITLE
feat: add show_amount_in_company_currency in gl report

### DIFF
--- a/erpnext/accounts/report/general_ledger/general_ledger.js
+++ b/erpnext/accounts/report/general_ledger/general_ledger.js
@@ -198,6 +198,11 @@ frappe.query_reports["General Ledger"] = {
 			fieldtype: "Check",
 		},
 		{
+			fieldname: "show_amount_in_company_currency",
+			label: __("Show Credit / Debit in Company Currency"),
+			fieldtype: "Check",
+		},
+		{
 			fieldname: "add_values_in_transaction_currency",
 			label: __("Add Columns in Transaction Currency"),
 			fieldtype: "Check",

--- a/erpnext/accounts/report/general_ledger/general_ledger.py
+++ b/erpnext/accounts/report/general_ledger/general_ledger.py
@@ -627,6 +627,18 @@ def get_columns(filters):
 		company = filters.get("company") or get_default_company()
 		filters["presentation_currency"] = currency = get_company_currency(company)
 
+	company_currency = get_company_currency(filters.get("company") or get_default_company())
+
+	if (
+		filters.get("show_amount_in_company_currency")
+		and filters["presentation_currency"] != company_currency
+	):
+		frappe.throw(
+			_(
+				f'Presentation Currency cannot be {frappe.bold(filters["presentation_currency"])} , When {frappe.bold("Show Credit / Debit in Company Currency")} is enabled.'
+			)
+		)
+
 	columns = [
 		{
 			"label": _("GL Entry"),

--- a/erpnext/accounts/report/utils.py
+++ b/erpnext/accounts/report/utils.py
@@ -118,7 +118,7 @@ def convert_to_presentation_currency(gl_entries, currency_info, filters=None):
 			len(account_currencies) == 1
 			and account_currency == presentation_currency
 			and not exchange_gain_or_loss
-		):
+		) and not filters.get("show_amount_in_company_currency"):
 			entry["debit"] = debit_in_account_currency
 			entry["credit"] = credit_in_account_currency
 		else:


### PR DESCRIPTION
Issue: When a group account or multiple exchange gain/loss account selected the  amount didn't show in the general ledger report

Ref: [41369](https://support.frappe.io/helpdesk/tickets/41369), [44778](https://support.frappe.io/helpdesk/tickets/44778), [44953](https://support.frappe.io/helpdesk/tickets/44953), [44742](https://support.frappe.io/helpdesk/tickets/44742)




[Screencast from 28-07-25 02:01:49 PM IST.webm](https://github.com/user-attachments/assets/42085cce-c71d-4eca-909b-9e8750a86746)





**Backport Needed: Version-15, Version-14**

no-docs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new filter, "Show Credit / Debit in Company Currency," to the General Ledger report, allowing users to toggle credit and debit amounts in the company currency.

* **Bug Fixes**
  * Improved validation to ensure that when the new filter is enabled, the presentation currency matches the company's base currency.
  * Adjusted currency conversion logic to respect the new filter, preventing unintended conversions when company currency display is selected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->