### PR TITLE
Update payment_entry.py

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -2713,10 +2713,9 @@ def get_party_details(company, party_type, party, date, cost_center=None):
 
 @frappe.whitelist()
 def get_account_details(account, date, cost_center=None):
-	frappe.has_permission("Payment Entry", throw=True)
 
 	# to check if the passed account is accessible under reference doctype Payment Entry
-	account_list = frappe.get_list("Account", {"name": account}, reference_doctype="Payment Entry", limit=1)
+	account_list = frappe.get_all("Account", {"name": account}, reference_doctype="Payment Entry", limit=1)
 
 	# There might be some user permissions which will allow account under certain doctypes
 	# except for Payment Entry, only in such case we should throw permission error


### PR DESCRIPTION
when using frappe.get_list or pe.insert(ignore_permissions=True), internal validations still trigger permission checks on the Account doctype, causing:
```
frappe.exceptions.PermissionError
```

Even with ignore_permissions=True set on the Payment Entry insert, the validate method internally calls get_account_details, which uses frappe.get_list—this still enforces standard permission rules.

