### PR TITLE
fix(purchase invoice): filter only enabled account

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js
@@ -37,7 +37,6 @@ erpnext.accounts.PurchaseInvoice = class PurchaseInvoice extends erpnext.buying.
 				query: "erpnext.controllers.queries.get_expense_account",
 				filters: {
 					company: doc.company,
-					disabled: 0,
 				},
 			};
 		});

--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js
@@ -37,6 +37,7 @@ erpnext.accounts.PurchaseInvoice = class PurchaseInvoice extends erpnext.buying.
 				query: "erpnext.controllers.queries.get_expense_account",
 				filters: {
 					company: doc.company,
+					disabled: 0,
 				},
 			};
 		});

--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js
@@ -35,7 +35,10 @@ erpnext.accounts.PurchaseInvoice = class PurchaseInvoice extends erpnext.buying.
 		this.frm.set_query("expense_account", "items", function () {
 			return {
 				query: "erpnext.controllers.queries.get_expense_account",
-				filters: { company: doc.company },
+				filters: {
+					company: doc.company,
+					disabled: 0,
+				},
 			};
 		});
 	}

--- a/erpnext/controllers/queries.py
+++ b/erpnext/controllers/queries.py
@@ -700,6 +700,7 @@ def get_expense_account(doctype, txt, searchfield, start, page_len, filters):
 	condition = ""
 	if filters.get("company"):
 		condition += "and tabAccount.company = %(company)s"
+	condition += f"and tabAccount.disabled = {filters.get('disabled', 0)}"
 
 	return frappe.db.sql(
 		f"""select tabAccount.name from `tabAccount`

--- a/erpnext/controllers/queries.py
+++ b/erpnext/controllers/queries.py
@@ -700,14 +700,13 @@ def get_expense_account(doctype, txt, searchfield, start, page_len, filters):
 	condition = ""
 	if filters.get("company"):
 		condition += "and tabAccount.company = %(company)s"
-	condition += f"and tabAccount.disabled = {filters.get('disabled', 0)}"
 
 	return frappe.db.sql(
 		f"""select tabAccount.name from `tabAccount`
 		where (tabAccount.report_type = "Profit and Loss"
 				or tabAccount.account_type in ("Expense Account", "Fixed Asset", "Temporary", "Asset Received But Not Billed", "Capital Work in Progress"))
 			and tabAccount.is_group=0
-			and tabAccount.docstatus!=2
+		    and tabAccount.disabled = 0
 			and tabAccount.{searchfield} LIKE %(txt)s
 			{condition} {get_match_cond(doctype)}""",
 		{"company": filters.get("company", ""), "txt": "%" + txt + "%"},


### PR DESCRIPTION
**Issue:**

In Purchase Invoice, the Expense Head field in the item row displays disabled accounts, which should not be listed.

**Before:**

[before_issue](https://github.com/user-attachments/assets/d4214b9e-76a7-4427-9004-6a9675283648)


**After:**

[after_fix](https://github.com/user-attachments/assets/79d9aa3b-1266-4122-9c0b-254132864f9c)


**Resolves:** #48716

**Backport needed: v14, v15**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the selection of expense accounts in Purchase Invoice items by ensuring only enabled accounts are available for selection.
  * Updated filters so that disabled accounts are excluded from the expense account dropdown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->