### PR TITLE
feat: add accounts filters in accounts payable/receivable summary report

### DIFF
--- a/erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js
+++ b/erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js
@@ -84,6 +84,22 @@ frappe.query_reports["Accounts Payable Summary"] = {
 			},
 		},
 		{
+			fieldname: "party_account",
+			label: __("Payable Account"),
+			fieldtype: "Link",
+			options: "Account",
+			get_query: () => {
+				var company = frappe.query_report.get_filter_value("company");
+				return {
+					filters: {
+						company: company,
+						account_type: "Payable",
+						is_group: 0,
+					},
+				};
+			},
+		},
+		{
 			fieldname: "payment_terms_template",
 			label: __("Payment Terms Template"),
 			fieldtype: "Link",

--- a/erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js
+++ b/erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js
@@ -84,6 +84,22 @@ frappe.query_reports["Accounts Receivable Summary"] = {
 			},
 		},
 		{
+			fieldname: "party_account",
+			label: __("Receivable Account"),
+			fieldtype: "Link",
+			options: "Account",
+			get_query: () => {
+				var company = frappe.query_report.get_filter_value("company");
+				return {
+					filters: {
+						company: company,
+						account_type: "Receivable",
+						is_group: 0,
+					},
+				};
+			},
+		},
+		{
 			fieldname: "customer_group",
 			label: __("Customer Group"),
 			fieldtype: "Link",


### PR DESCRIPTION
**Issue:**
Unable to get Payable/ Receivable summary for a specific account.

**Solution:**
Added a account filter in Payable/ Receivable reports

**Before:**

[before_issue](https://github.com/user-attachments/assets/03f58fe6-dabd-4d8b-bcd3-7e98f26866be)

**After:**

[after_fix](https://github.com/user-attachments/assets/f64b663f-75e9-4e49-b384-919842972519)


**Backport needed: v15**

   