### PR TITLE
fix: include empty values in user permission

### DIFF
--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -27,6 +27,7 @@ from frappe.utils import (
 	nowdate,
 )
 from pypika import Order
+from pypika.functions import Coalesce
 from pypika.terms import ExistsCriterion
 
 import erpnext
@@ -2385,6 +2386,8 @@ def sync_auto_reconcile_config(auto_reconciliation_job_trigger: int = 15):
 def build_qb_match_conditions(doctype, user=None) -> list:
 	match_filters = build_match_conditions(doctype, user, False)
 	criterion = []
+	apply_strict_user_permissions = frappe.get_system_settings("apply_strict_user_permissions")
+
 	if match_filters:
 		from frappe import qb
 
@@ -2393,6 +2396,12 @@ def build_qb_match_conditions(doctype, user=None) -> list:
 		for filter in match_filters:
 			for d, names in filter.items():
 				fieldname = d.lower().replace(" ", "_")
-				criterion.append(_dt[fieldname].isin(names))
+				field = _dt[fieldname]
+
+				cond = field.isin(names)
+				if not apply_strict_user_permissions:
+					cond = (Coalesce(field, "") == "") | field.isin(names)
+
+				criterion.append(cond)
 
 	return criterion


### PR DESCRIPTION
Issue: Empty values are not included in the user permission check on reports.

Ref: [44850](https://support.frappe.io/helpdesk/tickets/44850)

Before:

https://github.com/user-attachments/assets/541d15f8-0980-4759-9728-9d5f1b6a4244





After:


https://github.com/user-attachments/assets/874915b1-ec1b-44fc-8c4c-731dd20824b5







**Backport needed: Version-15, Version-14**