### PR TITLE
fix: unable to cancel PO if unreconciliation is done

### DIFF
--- a/erpnext/buying/doctype/purchase_order/purchase_order.js
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.js
@@ -12,7 +12,6 @@ erpnext.buying.setup_buying_controller();
 
 frappe.ui.form.on("Purchase Order", {
 	setup: function (frm) {
-		frm.ignore_doctypes_on_cancel_all = ["Unreconcile Payment", "Unreconcile Payment Entries"];
 		if (frm.doc.is_old_subcontracting_flow) {
 			frm.set_query("reserve_warehouse", "supplied_items", function () {
 				return {
@@ -154,6 +153,10 @@ frappe.ui.form.on("Purchase Order", {
 	},
 
 	onload: function (frm) {
+		var ignore_list = ["Unreconcile Payment", "Unreconcile Payment Entries"];
+		frm.ignore_doctypes_on_cancel_all = Object.hasOwn(frm, "ignore_doctypes_on_cancel_all")
+			? frm.ignore_doctypes_on_cancel_all.concat(ignore_list)
+			: ignore_list;
 		set_schedule_date(frm);
 		if (!frm.doc.transaction_date) {
 			frm.set_value("transaction_date", frappe.datetime.get_today());


### PR DESCRIPTION
frm.ignore_doctypes_on_cancel_all is overridden upon clicking 'Cancel'