### PR TITLE
fix: finance books issue when asset splitting

### DIFF
--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -1303,7 +1303,6 @@ def create_new_asset_after_split(asset, split_qty):
 		)
 
 	new_asset.insert()
-	print(".............")
 	add_asset_activity(
 		new_asset.name,
 		_("Asset created after being split from Asset {0}").format(get_link_to_form("Asset", asset.name)),

--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -314,6 +314,9 @@ class Asset(AccountsController):
 				)
 
 	def set_missing_values(self):
+		if not self.calculate_depreciation:
+			return
+
 		if not self.asset_category:
 			self.asset_category = frappe.get_cached_value("Item", self.item_code, "asset_category")
 
@@ -1300,7 +1303,7 @@ def create_new_asset_after_split(asset, split_qty):
 		)
 
 	new_asset.insert()
-
+	print(".............")
 	add_asset_activity(
 		new_asset.name,
 		_("Asset created after being split from Asset {0}").format(get_link_to_form("Asset", asset.name)),

--- a/erpnext/assets/doctype/asset/test_asset.py
+++ b/erpnext/assets/doctype/asset/test_asset.py
@@ -445,6 +445,27 @@ class TestAsset(AssetSetup):
 
 		self.assertEqual(frappe.db.get_value("Asset", asset.name, "status"), "Sold")
 
+	def test_asset_splitting_without_depreciation(self):
+		asset = create_asset(
+			calculate_depreciation=0,
+			asset_quantity=10,
+			available_for_use_date="2020-01-01",
+			purchase_date="2020-01-01",
+			gross_purchase_amount=120000,
+			submit=1,
+		)
+
+		self.assertEqual(asset.asset_quantity, 10)
+		self.assertEqual(asset.gross_purchase_amount, 120000)
+
+		new_asset = split_asset(asset.name, 2)
+		asset.load_from_db()
+		self.assertEqual(asset.asset_quantity, 8)
+		self.assertEqual(asset.gross_purchase_amount, 96000)
+
+		self.assertEqual(new_asset.asset_quantity, 2)
+		self.assertEqual(new_asset.gross_purchase_amount, 24000)
+
 	def test_asset_splitting(self):
 		asset = create_asset(
 			calculate_depreciation=1,


### PR DESCRIPTION
Previously, when creating or updating an Asset, the system was automatically adding a missing finance book row by fetching data from the Asset Category, even if the "Calculate Depreciation" checkbox was unchecked.

This PR fixes the issue by ensuring that finance book rows are only added when depreciation calculation is enabled.