### PR TITLE
fix: set mandatory field for pos search fields

### DIFF
--- a/erpnext/accounts/doctype/pos_search_fields/pos_search_fields.json
+++ b/erpnext/accounts/doctype/pos_search_fields/pos_search_fields.json
@@ -19,13 +19,14 @@
    "fieldname": "field",
    "fieldtype": "Select",
    "in_list_view": 1,
-   "label": "Field"
+   "label": "Field",
+   "reqd": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-03-27 13:10:16.969895",
+ "modified": "2025-07-29 18:08:40.323579",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "POS Search Fields",

--- a/erpnext/selling/page/point_of_sale/point_of_sale.py
+++ b/erpnext/selling/page/point_of_sale/point_of_sale.py
@@ -268,6 +268,8 @@ def add_search_fields_condition(search_term):
 	search_fields = frappe.get_all("POS Search Fields", fields=["fieldname"])
 	if search_fields:
 		for field in search_fields:
+			if not field.get("fieldname"):
+				continue
 			condition += " or item.`{}` like {}".format(
 				field["fieldname"], frappe.db.escape("%" + search_term + "%")
 			)


### PR DESCRIPTION
**Issue:**  While adding  pos search fields rows as empty in POS Settings, the point-of-sale page gives an error:
pymysql.err.OperationalError: (1054, "Unknown column 'item.None' in 'WHERE'")
Possible source of error: erpnext (app)

**Resolves:** #48783 

**Before:**

[before_issue](https://github.com/user-attachments/assets/1d197f37-147d-4758-9db7-22d4178e6a3d)

**After:**

[after_fix](https://github.com/user-attachments/assets/19c158c0-09b4-4d3c-8200-08204b42d7fb)


**Backport needed: v15**
