### PR TITLE
fix: do not recalculate depreciation on sale invoice cancellation for fully depreciated asset

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -1370,8 +1370,9 @@ class SalesInvoice(SellingController):
 						)
 						asset.db_set("disposal_date", None)
 						add_asset_activity(asset.name, _("Asset returned"))
+						asset_status = asset.get_status()
 
-						if asset.calculate_depreciation:
+						if asset.calculate_depreciation and not asset_status == "Fully Depreciated":
 							posting_date = (
 								frappe.db.get_value("Sales Invoice", self.return_against, "posting_date")
 								if self.is_return

--- a/erpnext/assets/doctype/asset/test_asset.py
+++ b/erpnext/assets/doctype/asset/test_asset.py
@@ -346,6 +346,33 @@ class TestAsset(AssetSetup):
 		si.cancel()
 		self.assertEqual(frappe.db.get_value("Asset", asset.name, "status"), "Partially Depreciated")
 
+	def test_asset_status_after_sales_invoice_cancel(self):
+		from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_sales_invoice
+
+		asset = create_asset(
+			calculate_depreciation=1,
+			available_for_use_date="2020-04-01",
+			purchase_date="2020-04-01",
+			expected_value_after_useful_life=0,
+			total_number_of_depreciations=5,
+			opening_number_of_booked_depreciations=2,
+			frequency_of_depreciation=12,
+			depreciation_start_date="2023-03-31",
+			opening_accumulated_depreciation=24000,
+			gross_purchase_amount=60000,
+			submit=1,
+		)
+
+		si = create_sales_invoice(
+			item_code="Macbook Pro", asset=asset.name, qty=1, rate=40000, posting_date=getdate("2023-05-23")
+		)
+		asset.load_from_db()
+		self.assertEqual(frappe.db.get_value("Asset", asset.name, "status"), "Sold")
+
+		si.cancel()
+		asset.load_from_db()
+		self.assertEqual(frappe.db.get_value("Asset", asset.name, "status"), "Partially Depreciated")
+
 	def test_gle_made_by_asset_sale_for_existing_asset(self):
 		from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_sales_invoice
 


### PR DESCRIPTION
When a Sales Invoice linked to an Asset is canceled, the system was recalculating depreciation even for Assets that were already fully depreciated. This behavior was leading to duplicate depreciation entries.

In the given screenshot, double entries were created for the same date:

<img width="1066" height="553" alt="Screenshot 2025-07-31 at 12 07 16 PM" src="https://github.com/user-attachments/assets/9967a1e8-0316-43f5-8bba-b34cb8d906b8" />

**This PR introduces a check to prevent recalculation of depreciation for fully depreciated Assets.**