### PR TITLE
fix: server error on opportunity summary by sales stage report

### DIFF
--- a/erpnext/crm/report/opportunity_summary_by_sales_stage/opportunity_summary_by_sales_stage.py
+++ b/erpnext/crm/report/opportunity_summary_by_sales_stage/opportunity_summary_by_sales_stage.py
@@ -153,7 +153,12 @@ class OpportunitySummaryBySalesStage:
 			}[self.filters.get("based_on")]
 
 			if self.filters.get("based_on") == "Opportunity Owner":
-				if d.get(based_on) == "[]" or d.get(based_on) is None or d.get(based_on) == "Not Assigned":
+				if (
+					d.get(based_on) == "[]"
+					or d.get(based_on) is None
+					or d.get(based_on) == "Not Assigned"
+					or d.get(based_on) == ""
+				):
 					assignments = ["Not Assigned"]
 				else:
 					assignments = json.loads(d.get(based_on))


### PR DESCRIPTION
Fixed the issue where users get Server Error if they select "Opportunity Owner" on the `based_on` filter on the Opportunity Summary by Sales Stage Report.

<img width="2028" height="544" alt="image" src="https://github.com/user-attachments/assets/437fe001-8065-492f-b36c-1ab969c1899d" />


Fixes support ticket [#45201](https://support.frappe.io/helpdesk/tickets/45201)