### PR TITLE
fix: add doctype fieldname in condition

### DIFF
--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -2,6 +2,7 @@
 # License: GNU General Public License v3. See license.txt
 
 
+from collections import defaultdict
 from json import loads
 from typing import TYPE_CHECKING, Optional
 
@@ -2386,25 +2387,37 @@ def sync_auto_reconcile_config(auto_reconciliation_job_trigger: int = 15):
 		).save()
 
 
+def get_link_fields_grouped_by_option(doctype):
+	meta = frappe.get_meta(doctype)
+	link_fields_map = defaultdict(list)
+
+	for df in meta.fields:
+		if df.fieldtype == "Link" and df.options and not df.ignore_user_permissions:
+			link_fields_map[df.options].append(df.fieldname)
+
+	return link_fields_map
+
+
 def build_qb_match_conditions(doctype, user=None) -> list:
 	match_filters = build_match_conditions(doctype, user, False)
+	link_fields_map = get_link_fields_grouped_by_option(doctype)
 	criterion = []
 	apply_strict_user_permissions = frappe.get_system_settings("apply_strict_user_permissions")
 
 	if match_filters:
-		from frappe import qb
-
 		_dt = qb.DocType(doctype)
 
 		for filter in match_filters:
-			for d, names in filter.items():
-				fieldname = d.lower().replace(" ", "_")
-				field = _dt[fieldname]
+			for link_option, allowed_values in filter.items():
+				fieldnames = link_fields_map.get(link_option, [])
 
-				cond = field.isin(names)
-				if not apply_strict_user_permissions:
-					cond = (Coalesce(field, "") == "") | field.isin(names)
+				for fieldname in fieldnames:
+					field = _dt[fieldname]
+					cond = field.isin(allowed_values)
 
-				criterion.append(cond)
+					if not apply_strict_user_permissions:
+						cond = (Coalesce(field, "") == "") | cond
+
+					criterion.append(cond)
 
 	return criterion


### PR DESCRIPTION
Issue: OperationalError in “Accounts Payable” report when the user’s Currency permissions are restricted.

Ref: [44935](https://support.frappe.io/helpdesk/tickets/44935)

Before:

<img width="1866" height="932" alt="image" src="https://github.com/user-attachments/assets/cb684eac-1bc9-47cc-bdb0-e0c889e30ab1" />

After:

<img width="1865" height="934" alt="image" src="https://github.com/user-attachments/assets/1e223b31-34e1-4a1d-acc1-ef6ac9a84caa" />




**Backport needed: Version-15, Version-14**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved handling of user permissions by supporting multiple linked fields per filter option when generating query conditions.

* **Bug Fixes**
  * Enhanced accuracy in applying user permission filters across all relevant linked fields, reducing the chance of missing permissions on certain fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->