### PR TITLE
chore: correct description for `consider_party_ledger_amount` in Tax Withholding Category

### DIFF
--- a/erpnext/accounts/doctype/tax_withholding_category/tax_withholding_category.json
+++ b/erpnext/accounts/doctype/tax_withholding_category/tax_withholding_category.json
@@ -61,7 +61,7 @@
   },
   {
    "default": "0",
-   "description": "Even invoices with apply tax withholding unchecked will be considered for checking cumulative threshold breach",
+   "description": "Only payment entries with apply tax withholding unchecked will be considered for checking cumulative threshold breach",
    "fieldname": "consider_party_ledger_amount",
    "fieldtype": "Check",
    "label": "Consider Entire Party Ledger Amount"
@@ -83,10 +83,11 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-03-27 13:10:52.531436",
+ "modified": "2025-07-30 07:13:51.785735",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Tax Withholding Category",
+ "naming_rule": "Set by user",
  "owner": "Administrator",
  "permissions": [
   {
@@ -126,6 +127,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],


### PR DESCRIPTION
When "Consider Entire Party Ledger Amount" is checked, then only payments are considered.

<img width="1554" height="461" alt="image" src="https://github.com/user-attachments/assets/db30b6ce-6965-4053-baf8-a557232a321e" />
