### PR TITLE
feat: show party name in reports

### DIFF
--- a/erpnext/accounts/report/general_ledger/general_ledger.py
+++ b/erpnext/accounts/report/general_ledger/general_ledger.py
@@ -209,6 +209,12 @@ def get_gl_entries(filters, accounting_dimensions):
 		as_dict=1,
 	)
 
+	party_name_map = get_party_name_map()
+
+	for gl_entry in gl_entries:
+		if gl_entry.party_type and gl_entry.party:
+			gl_entry.party_name = party_name_map.get(gl_entry.party_type, {}).get(gl_entry.party)
+
 	if filters.get("presentation_currency"):
 		return convert_to_presentation_currency(gl_entries, currency_map, filters)
 	else:
@@ -339,6 +345,17 @@ def get_conditions(filters):
 						conditions.append(f"{dimension.fieldname} in %({dimension.fieldname})s")
 
 	return "and {}".format(" and ".join(conditions)) if conditions else ""
+
+
+def get_party_name_map():
+	party_map = {}
+
+	customers = frappe.get_all("Customer", fields=["name", "customer_name"])
+	party_map["Customer"] = {c.name: c.customer_name for c in customers}
+
+	suppliers = frappe.get_all("Supplier", fields=["name", "supplier_name"])
+	party_map["Supplier"] = {s.name: s.supplier_name for s in suppliers}
+	return party_map
 
 
 def get_accounts_with_children(accounts):

--- a/erpnext/accounts/report/general_ledger/general_ledger.py
+++ b/erpnext/accounts/report/general_ledger/general_ledger.py
@@ -711,6 +711,19 @@ def get_columns(filters):
 		{"label": _("Party"), "fieldname": "party", "width": 100},
 	]
 
+	supplier_master_name = frappe.db.get_single_value("Buying Settings", "supp_master_name")
+	customer_master_name = frappe.db.get_single_value("Selling Settings", "cust_master_name")
+
+	if supplier_master_name != "Supplier Name" or customer_master_name != "Customer Name":
+		columns.append(
+			{
+				"label": _("Party Name"),
+				"fieldname": "party_name",
+				"fieldtype": "Data",
+				"width": 150,
+			}
+		)
+
 	if filters.get("include_dimensions"):
 		columns.append({"label": _("Project"), "options": "Project", "fieldname": "project", "width": 100})
 

--- a/erpnext/accounts/report/general_ledger/general_ledger.py
+++ b/erpnext/accounts/report/general_ledger/general_ledger.py
@@ -355,6 +355,9 @@ def get_party_name_map():
 
 	suppliers = frappe.get_all("Supplier", fields=["name", "supplier_name"])
 	party_map["Supplier"] = {s.name: s.supplier_name for s in suppliers}
+
+	employees = frappe.get_all("Employee", fields=["name", "employee_name"])
+	party_map["Employee"] = {e.name: e.employee_name for e in employees}
 	return party_map
 
 

--- a/erpnext/accounts/report/gross_profit/gross_profit.py
+++ b/erpnext/accounts/report/gross_profit/gross_profit.py
@@ -255,6 +255,7 @@ def get_columns(group_wise_columns, filters):
 
 	supplier_master_name = frappe.db.get_single_value("Buying Settings", "supp_master_name")
 	customer_master_name = frappe.db.get_single_value("Selling Settings", "cust_master_name")
+
 	column_map = frappe._dict(
 		{
 			"parent": {

--- a/erpnext/accounts/report/gross_profit/gross_profit.py
+++ b/erpnext/accounts/report/gross_profit/gross_profit.py
@@ -33,6 +33,7 @@ def execute(filters=None):
 				"invoice_or_item",
 				"customer",
 				"customer_group",
+				"customer_name",
 				"posting_date",
 				"item_code",
 				"item_name",
@@ -95,6 +96,7 @@ def execute(filters=None):
 			"customer": [
 				"customer",
 				"customer_group",
+				"customer_name",
 				"qty",
 				"base_rate",
 				"buying_rate",
@@ -250,6 +252,9 @@ def get_data_when_not_grouped_by_invoice(gross_profit_data, filters, group_wise_
 
 def get_columns(group_wise_columns, filters):
 	columns = []
+
+	supplier_master_name = frappe.db.get_single_value("Buying Settings", "supp_master_name")
+	customer_master_name = frappe.db.get_single_value("Selling Settings", "cust_master_name")
 	column_map = frappe._dict(
 		{
 			"parent": {
@@ -395,6 +400,12 @@ def get_columns(group_wise_columns, filters):
 				"options": "Customer Group",
 				"width": 100,
 			},
+			"customer_name": {
+				"label": _("Customer Name"),
+				"fieldname": "customer_name",
+				"fieldtype": "Data",
+				"width": 150,
+			},
 			"territory": {
 				"label": _("Territory"),
 				"fieldname": "territory",
@@ -419,6 +430,10 @@ def get_columns(group_wise_columns, filters):
 	)
 
 	for col in group_wise_columns.get(scrub(filters.group_by)):
+		if col == "customer_name" and (
+			supplier_master_name == "Supplier Name" and customer_master_name == "Customer Name"
+		):
+			continue
 		columns.append(column_map.get(col))
 
 	columns.append(
@@ -440,6 +455,7 @@ def get_column_names():
 			"invoice_or_item": "sales_invoice",
 			"customer": "customer",
 			"customer_group": "customer_group",
+			"customer_name": "customer_name",
 			"posting_date": "posting_date",
 			"item_code": "item_code",
 			"item_name": "item_name",
@@ -905,7 +921,7 @@ class GrossProfitGenerator:
 				`tabSales Invoice Item`.parenttype, `tabSales Invoice Item`.parent,
 				`tabSales Invoice`.posting_date, `tabSales Invoice`.posting_time,
 				`tabSales Invoice`.project, `tabSales Invoice`.update_stock,
-				`tabSales Invoice`.customer, `tabSales Invoice`.customer_group,
+				`tabSales Invoice`.customer, `tabSales Invoice`.customer_group, `tabSales Invoice`.customer_name,
 				`tabSales Invoice`.territory, `tabSales Invoice Item`.item_code,
 				`tabSales Invoice`.base_net_total as "invoice_base_net_total",
 				`tabSales Invoice Item`.item_name, `tabSales Invoice Item`.description,
@@ -1003,6 +1019,7 @@ class GrossProfitGenerator:
 				"update_stock": row.update_stock,
 				"customer": row.customer,
 				"customer_group": row.customer_group,
+				"customer_name": row.customer_name,
 				"item_code": None,
 				"item_name": None,
 				"description": None,
@@ -1032,6 +1049,7 @@ class GrossProfitGenerator:
 				"project": row.project,
 				"customer": row.customer,
 				"customer_group": row.customer_group,
+				"customer_name": row.customer_name,
 				"item_code": item.item_code,
 				"item_name": item.item_name,
 				"description": item.description,


### PR DESCRIPTION
Currently, both the General Ledger and Gross Profit reports only display the Party Code, making it harder for users to quickly identify parties.

- This PR enhances both reports by displaying Party Name alongside the Party Code for easier identification.
- Updated both General Ledger and Gross Profit reports to include a Party Name column (conditionally displayed based on selling and buying settings).

Closes https://github.com/frappe/erpnext/issues/35373

**General Ledger Report without `Party Name` column**

<img width="1239" height="345" alt="Screenshot 2025-07-30 at 5 26 15 PM" src="https://github.com/user-attachments/assets/66c8bdb0-7175-4f75-855b-5952464e83bc" />

**General Ledger Report with `Party Name` column**

<img width="1249" height="683" alt="Screenshot 2025-07-30 at 5 24 23 PM" src="https://github.com/user-attachments/assets/530ad459-fd4e-4945-9a1b-a84ee43a6a2a" />

**Gross Profit Report without `Customer Name` column**
<img width="1249" height="498" alt="Screenshot 2025-07-30 at 5 27 22 PM" src="https://github.com/user-attachments/assets/d6874bc7-483b-4117-b5ef-02401d829a87" />

**Gross Profit Report with `Customer Name` column**
<img width="1250" height="511" alt="Screenshot 2025-07-30 at 5 27 50 PM" src="https://github.com/user-attachments/assets/2095a1d3-e2fa-4399-8640-e94d2ffccd04" />

no-docs



Fixes #35373 