### PR TITLE
fix: skip asset capitalization

### DIFF
--- a/erpnext/stock/doctype/serial_no/serial_no.py
+++ b/erpnext/stock/doctype/serial_no/serial_no.py
@@ -406,7 +406,7 @@ def validate_serial_no(sle, item_det):
 
 					if (
 						sr.delivery_document_no
-						and sle.voucher_type not in ["Stock Entry", "Stock Reconciliation"]
+						and sle.voucher_type not in ["Stock Entry", "Stock Reconciliation", "Asset Capitalization"]
 						and sle.voucher_type == sr.delivery_document_type
 					):
 						return_against = frappe.db.get_value(


### PR DESCRIPTION
getting an error while selecting already capitalize serial no

<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/cb2ef89d-e5e6-4c91-ad99-19b54f8de031" />


<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/3607619d-d11a-4060-b436-29940477a5e1" />

<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/adafac7d-e974-4935-8140-a166465c1ab4" />

