### PR TITLE
fix: incorrect pending qty when creating sales invoice from sales order

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -1176,6 +1176,17 @@ def make_sales_invoice(source_name, target_doc=None, ignore_permissions=False, a
 		target.debit_to = get_party_account("Customer", source.customer, source.company)
 
 	def update_item(source, target, source_parent):
+		def get_billed_qty(so_item_name):
+			from frappe.query_builder.functions import Sum
+
+			table = frappe.qb.DocType("Sales Invoice Item")
+			query = (
+				frappe.qb.from_(table)
+				.select(Sum(table.qty).as_("qty"))
+				.where((table.docstatus == 1) & (table.so_detail == so_item_name))
+			)
+			return query.run(pluck="qty")[0] or 0
+
 		if source_parent.has_unit_price_items:
 			# 0 Amount rows (as seen in Unit Price Items) should be mapped as it is
 			pending_amount = flt(source.amount) - flt(source.billed_amt)
@@ -1185,8 +1196,8 @@ def make_sales_invoice(source_name, target_doc=None, ignore_permissions=False, a
 
 		target.base_amount = target.amount * flt(source_parent.conversion_rate)
 		target.qty = (
-			target.amount / flt(source.rate)
-			if (source.rate and source.billed_amt)
+			source.qty - get_billed_qty(source.name)
+			if (source.qty and source.billed_amt)
 			else (source.qty if is_unit_price_row(source) else source.qty - source.returned_qty)
 		)
 

--- a/erpnext/selling/doctype/sales_order/test_sales_order.py
+++ b/erpnext/selling/doctype/sales_order/test_sales_order.py
@@ -2572,7 +2572,6 @@ class TestSalesOrder(AccountsTestMixin, IntegrationTestCase):
 		so = make_sales_order(qty=30, rate=100)
 
 		si1 = make_sales_invoice(so.name)
-		si1.update_stock = 1
 		si1.get("items")[0].qty = 10
 		si1.insert()
 		si1.submit()

--- a/erpnext/selling/doctype/sales_order/test_sales_order.py
+++ b/erpnext/selling/doctype/sales_order/test_sales_order.py
@@ -2568,6 +2568,31 @@ class TestSalesOrder(AccountsTestMixin, IntegrationTestCase):
 		po.submit()
 		self.assertEqual(po.taxes[0].tax_amount, 2)
 
+	def test_pending_quantity_after_update_item_during_invoice_creation(self):
+		so = make_sales_order(qty=30, rate=100)
+
+		si1 = make_sales_invoice(so.name)
+		si1.update_stock = 1
+		si1.get("items")[0].qty = 10
+		si1.insert()
+		si1.submit()
+
+		first_item_of_so = so.get("items")[0]
+		trans_item = json.dumps(
+			[
+				{
+					"item_code": first_item_of_so.item_code,
+					"rate": 1000,
+					"qty": first_item_of_so.qty,
+					"docname": first_item_of_so.name,
+				},
+			]
+		)
+		update_child_qty_rate("Sales Order", trans_item, so.name)
+
+		si2 = make_sales_invoice(so.name)
+		self.assertEqual(si2.items[0].qty, 20)
+
 
 def automatically_fetch_payment_terms(enable=1):
 	accounts_settings = frappe.get_doc("Accounts Settings")


### PR DESCRIPTION
Issue: When creating a Sales Invoice from a Sales Order, the item quantity is not set correctly.

Before:

https://github.com/user-attachments/assets/4c0b11bc-6fc7-4fc8-af88-93b71fa68836

After:

https://github.com/user-attachments/assets/3e3ea727-1465-4ab4-9789-8d5998736c87

resolves[#47470 ](https://github.com/frappe/erpnext/issues/47470)

Backport needed: v15