### PR TITLE
fix: added 'Asset Capitalization' to excluded voucher types in return…

### DIFF
--- a/erpnext/stock/doctype/serial_no/serial_no.py
+++ b/erpnext/stock/doctype/serial_no/serial_no.py
@@ -374,7 +374,7 @@ def validate_serial_no(sle, item_det):
 
 					if (
 						sr.delivery_document_no
-						and sle.voucher_type not in ["Stock Entry", "Stock Reconciliation"]
+						and sle.voucher_type not in ["Stock Entry", "Stock Reconciliation", "Asset Capitalization"]
 						and sle.voucher_type == sr.delivery_document_type
 					):
 						return_against = frappe.db.get_value(


### PR DESCRIPTION

When creating an Asset Capitalization document for an item that is enabled with both Serial No and Batch No, if the user selects a Serial No that has already been marked as "**Delivered**", the system throws the following error: