### PR TITLE
fix: skip Asset Capitalization in return check

### DIFF
--- a/erpnext/stock/doctype/serial_no/serial_no.py
+++ b/erpnext/stock/doctype/serial_no/serial_no.py
@@ -374,7 +374,8 @@ def validate_serial_no(sle, item_det):
 
 					if (
 						sr.delivery_document_no
-						and sle.voucher_type not in ["Stock Entry", "Stock Reconciliation"]
+						and sle.voucher_type
+						not in ["Stock Entry", "Stock Reconciliation", "Asset Capitalization"]
 						and sle.voucher_type == sr.delivery_document_type
 					):
 						return_against = frappe.db.get_value(


### PR DESCRIPTION
**Issue:** When creating an Asset Capitalization document for an item that is enabled with both Serial No and Batch No, if the user selects a Serial No that has already been marked as "Delivered", the system throws the following error:

<img width="1366" height="768" alt="Media(2)" src="https://github.com/user-attachments/assets/2db8e8d7-2d6f-4541-bad4-4afbef38eeec" />
<img width="1366" height="768" alt="Media(3)" src="https://github.com/user-attachments/assets/f90b115f-ae91-4f2e-92dd-e18c22134c60" />
<img width="1366" height="768" alt="Media(4)" src="https://github.com/user-attachments/assets/328e018d-c922-407e-8bf1-0c8efb91c339" />

