### PR TITLE
fix: do not split round off when there is a cost center allocation

### DIFF
--- a/erpnext/accounts/general_ledger.py
+++ b/erpnext/accounts/general_ledger.py
@@ -196,6 +196,15 @@ def process_gl_map(gl_map, merge_entries=True, precision=None, from_repost=False
 
 
 def distribute_gl_based_on_cost_center_allocation(gl_map, precision=None, from_repost=False):
+	round_off_account, default_currency = frappe.get_cached_value(
+		"Company", gl_map[0].company, ["round_off_account", "default_currency"]
+	)
+	if not precision:
+		precision = get_field_precision(
+			frappe.get_meta("GL Entry").get_field("debit"),
+			currency=default_currency,
+		)
+
 	new_gl_map = []
 	for d in gl_map:
 		cost_center = d.get("cost_center")
@@ -210,6 +219,11 @@ def distribute_gl_based_on_cost_center_allocation(gl_map, precision=None, from_r
 			gl_map[0]["company"], gl_map[0]["posting_date"], cost_center
 		)
 		if not cost_center_allocation:
+			new_gl_map.append(d)
+			continue
+
+		if d.account == round_off_account:
+			d.cost_center = cost_center_allocation[0][0]
 			new_gl_map.append(d)
 			continue
 


### PR DESCRIPTION
**Issue:** GL Entries are getting posted with debit-credit difference with Cost Center Allocation, when Rounding Method is `Commercial Rounding` 

ref: [41663](https://support.frappe.io/helpdesk/tickets/41663)

**Before:**

https://github.com/user-attachments/assets/3e33ae42-5bdc-4c3a-a6c6-a722fb80d1de


**After:**

https://github.com/user-attachments/assets/f6c6df12-1e86-4244-b40f-5875d2c6b411



**Backport needed for v14 and v15**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of round-off account entries to ensure correct cost center assignment during general ledger distribution.
* **Tests**
  * Added a test to verify that debit and credit amounts remain balanced when using commercial rounding with cost center allocations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->