### PR TITLE
fix: do not execute patch if no advance doctypes

### DIFF
--- a/erpnext/patches/v15_0/create_advance_payment_ledger_records.py
+++ b/erpnext/patches/v15_0/create_advance_payment_ledger_records.py
@@ -32,6 +32,10 @@ def execute():
 	"""
 	frappe.db.truncate(DOCTYPE)
 	advance_doctpyes = get_advance_payment_doctypes()
+
+	if not advance_doctpyes:
+		return
+
 	make_advance_ledger_entries_for_payment_entries(advance_doctpyes)
 	make_advance_ledger_entries_for_journal_entries(advance_doctpyes)
 


### PR DESCRIPTION
backport to v-15 not required as it is included here: https://github.com/frappe/erpnext/pull/48896