### PR TITLE
fix: include Sales Invoice in SABB validation for packed items

### DIFF
--- a/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py
+++ b/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py
@@ -146,7 +146,7 @@ class SerialandBatchBundle(Document):
 				)
 
 		elif not frappe.db.exists("Stock Ledger Entry", {"voucher_detail_no": self.voucher_detail_no}):
-			if self.voucher_type == "Delivery Note" and frappe.db.exists(
+			if self.voucher_type in ["Delivery Note", "Sales Invoice"] and frappe.db.exists(
 				"Packed Item", self.voucher_detail_no
 			):
 				return


### PR DESCRIPTION
Reference support ticket [45545](https://support.frappe.io/helpdesk/tickets/45545)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation to support both "Delivery Note" and "Sales Invoice" voucher types when checking for related packed items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->