### PR TITLE
fix(tax withholding details): avoid voucher duplication

### DIFF
--- a/erpnext/accounts/report/tax_withholding_details/tax_withholding_details.py
+++ b/erpnext/accounts/report/tax_withholding_details/tax_withholding_details.py
@@ -45,6 +45,7 @@ def get_result(filters, tds_docs, tds_accounts, tax_category_map, journal_entry_
 	gle_map = get_gle_map(tds_docs)
 
 	out = []
+	entries = {}
 	for name, details in gle_map.items():
 		for entry in details:
 			tax_amount, total_amount, grand_total, base_total = 0, 0, 0, 0
@@ -119,8 +120,13 @@ def get_result(filters, tds_docs, tds_accounts, tax_category_map, journal_entry_
 						"supplier_invoice_date": bill_date,
 					}
 				)
-				out.append(row)
 
+				key = entry.voucher_no
+				if key in entries:
+					entries[key]["tax_amount"] += tax_amount
+				else:
+					entries[key] = row
+	out = list(entries.values())
 	out.sort(key=lambda x: (x["section_code"], x["transaction_date"]))
 
 	return out


### PR DESCRIPTION
Issue: Voucher duplication occurs when cost center allocations are present.

Ref: [#43275](https://support.frappe.io/helpdesk/tickets/43275)

Before:

<img width="1792" height="1120" alt="Screenshot 2025-08-01 at 5 03 53 PM" src="https://github.com/user-attachments/assets/dbfd7b1a-80b3-4ab7-8c82-30c739d917ff" />

After:

<img width="1792" height="1120" alt="Screenshot 2025-08-01 at 4 56 38 PM" src="https://github.com/user-attachments/assets/08bd8d13-2cf0-4419-96f9-61999d85effb" />



Backport needed: v15


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the tax withholding details report by consolidating entries with the same voucher number and aggregating their tax amounts, resulting in clearer and more concise reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->