### PR TITLE
feat: leave item description empty

### DIFF
--- a/erpnext/stock/doctype/item/item.py
+++ b/erpnext/stock/doctype/item/item.py
@@ -184,9 +184,6 @@ class Item(Document):
 		if not self.item_name:
 			self.item_name = self.item_code
 
-		if not strip_html(cstr(self.description)).strip():
-			self.description = self.item_name
-
 		self.validate_uom()
 		self.validate_description()
 		self.add_default_uom_in_conversion_factor_table()

--- a/erpnext/stock/doctype/item/test_item.py
+++ b/erpnext/stock/doctype/item/test_item.py
@@ -811,13 +811,6 @@ class TestItem(IntegrationTestCase):
 		self.assertTrue(get_data(warehouse="_Test Warehouse - _TC"))
 		self.assertTrue(get_data(item_group="All Item Groups"))
 
-	def test_empty_description(self):
-		item = make_item(properties={"description": "<p></p>"})
-		self.assertEqual(item.description, item.item_name)
-		item.description = ""
-		item.save()
-		self.assertEqual(item.description, item.item_name)
-
 	def test_item_type_field_change(self):
 		"""Check if critical fields like `is_stock_item`, `has_batch_no` are not changed if transactions exist."""
 		from erpnext.accounts.doctype.purchase_invoice.test_purchase_invoice import make_purchase_invoice

--- a/erpnext/subcontracting/doctype/subcontracting_order_item/subcontracting_order_item.json
+++ b/erpnext/subcontracting/doctype/subcontracting_order_item/subcontracting_order_item.json
@@ -114,7 +114,6 @@
    "fieldtype": "Text Editor",
    "label": "Description",
    "print_width": "300px",
-   "reqd": 1,
    "width": "300px"
   },
   {
@@ -415,7 +414,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-03-02 17:05:28.386492",
+ "modified": "2025-08-10 22:37:39.863628",
  "modified_by": "Administrator",
  "module": "Subcontracting",
  "name": "Subcontracting Order Item",

--- a/erpnext/subcontracting/doctype/subcontracting_order_item/subcontracting_order_item.py
+++ b/erpnext/subcontracting/doctype/subcontracting_order_item/subcontracting_order_item.py
@@ -19,7 +19,7 @@ class SubcontractingOrderItem(Document):
 		bom: DF.Link
 		conversion_factor: DF.Float
 		cost_center: DF.Link | None
-		description: DF.TextEditor
+		description: DF.TextEditor | None
 		expected_delivery_date: DF.Date | None
 		expense_account: DF.Link | None
 		image: DF.Attach | None


### PR DESCRIPTION
### Problem
An item description cannot be left empty. The item name is automatically copied in on save. 
Items (E.g. consumables) don't always have or need a description. This is a problem when a user wants to print both the item name and description since it creates duplicate values in both columns.

Besides the description is not a mandatory field so there is no reason to force a value especially with hardcoded logic.

![no-description](https://github.com/user-attachments/assets/44a8e28a-ba95-4b22-b15c-dfea9da25db8)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated item validation logic so that the description field is no longer automatically set to the item name when left empty.
* **Bug Fixes**
  * Removed requirement for description in subcontracting order items, allowing it to be optional.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->