### PR TITLE
fix: set use_serial_batch_fields when creating PR from PO

### DIFF
--- a/erpnext/buying/doctype/purchase_order/purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.py
@@ -744,6 +744,7 @@ def close_or_unclose_purchase_orders(names, status):
 def set_missing_values(source, target):
 	target.run_method("set_missing_values")
 	target.run_method("calculate_taxes_and_totals")
+	target.run_method("set_use_serial_batch_fields")
 
 
 @frappe.whitelist()


### PR DESCRIPTION
**Issue:** When creating Purchase Receipt from Purchase Order `use_serial_batch_fields` is unchecked.

**Ref:** [45578](https://support.frappe.io/helpdesk/tickets/45578)

**Before:**

[use_serial_batch_fields_issue.webm](https://github.com/user-attachments/assets/82550f60-d895-4c29-892b-18a841d80c9c)

**After:**

[use_serial_batch_fields_solved.webm](https://github.com/user-attachments/assets/7bad85f8-90bb-47df-b488-bf585a9bf4a7)

**Backport needed: v15**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved handling of serial number and batch tracking fields during purchase order processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->