### PR TITLE
fix: provide missing `company` in report records that require reference to `Company:company:default_currency`

### DIFF
--- a/erpnext/accounts/report/non_billed_report.py
+++ b/erpnext/accounts/report/non_billed_report.py
@@ -46,6 +46,7 @@ def get_ordered_to_be_billed_data(args, filters=None):
 			child_doctype.item_name,
 			child_doctype.description,
 			project_field,
+			doctype.company,
 		)
 		.where(
 			(doctype.docstatus == 1)

--- a/erpnext/accounts/report/payment_ledger/payment_ledger.py
+++ b/erpnext/accounts/report/payment_ledger/payment_ledger.py
@@ -78,6 +78,7 @@ class PaymentLedger:
 					against_voucher_no="Outstanding:",
 					amount=total,
 					currency=voucher_data[0].currency,
+					company=voucher_data[0].company,
 				)
 
 				if self.filters.include_account_currency:

--- a/erpnext/accounts/report/payment_ledger/payment_ledger.py
+++ b/erpnext/accounts/report/payment_ledger/payment_ledger.py
@@ -130,7 +130,6 @@ class PaymentLedger:
 		)
 
 	def get_columns(self):
-		company_currency = frappe.get_cached_value("Company", self.filters.get("company"), "default_currency")
 		options = None
 		self.columns.append(
 			dict(
@@ -195,7 +194,7 @@ class PaymentLedger:
 				label=_("Amount"),
 				fieldname="amount",
 				fieldtype="Currency",
-				options=company_currency,
+				options="Company:company:default_currency",
 				width="100",
 			)
 		)

--- a/erpnext/accounts/report/payment_ledger/payment_ledger.py
+++ b/erpnext/accounts/report/payment_ledger/payment_ledger.py
@@ -46,6 +46,7 @@ class PaymentLedger:
 						against_voucher_no=ple.against_voucher_no,
 						amount=ple.amount,
 						currency=ple.account_currency,
+						company=ple.company,
 					)
 
 					if self.filters.include_account_currency:

--- a/erpnext/accounts/report/payment_ledger/payment_ledger.py
+++ b/erpnext/accounts/report/payment_ledger/payment_ledger.py
@@ -87,7 +87,12 @@ class PaymentLedger:
 				voucher_data.append(entry)
 
 				# empty row
-				voucher_data.append(frappe._dict())
+				voucher_data.append(
+					frappe._dict(
+						currency=voucher_data[0].currency,
+						company=voucher_data[0].company,
+					)
+				)
 				self.data.extend(voucher_data)
 
 	def build_conditions(self):


### PR DESCRIPTION
This PR reverses the changes made in https://github.com/frappe/erpnext/pull/42458 because as far as I can understand putting a currency name in the `options` key doesn't actually force Frappe currency formatter to use that currency. Instead Frappe tries to read the currency from the record using the `options` value as the record key lookup.

Verified the following reports:
- [x] available_serial_no   ( already referenced )
- [x] deliverd_items_to_be_billed
- [x] general_and_payment_ledger_comparison   ( already referenced )
- [x] payment_ledger
- [x] pos_register ( already referenced )
- [x] received_items_to_be_billed ( same as deliverd_items_to_be_billed )
- [x] fixed_asset_register ( already referenced )
- [x] purchase_order_analysis
- [x] sales_order_analysis ( already referenced )
- [x] stock_balance ( already referenced )
- [x] stock_ledger ( already referenced )

Please backport to `version-15`, `version-14` (https://github.com/frappe/erpnext/pull/48927)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Payment ledger and non-billed reports now display the company information for each entry.

* **Improvements**
  * The payment ledger report dynamically sets the currency for the "Amount" column based on the company, improving accuracy for multi-company setups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->