### PR TITLE
fix: provide missing company in report records that require reference to Company:company:default_currency (Backport #48926)

### DIFF
--- a/erpnext/accounts/report/payment_ledger/payment_ledger.py
+++ b/erpnext/accounts/report/payment_ledger/payment_ledger.py
@@ -78,6 +78,7 @@ class PaymentLedger:
 					against_voucher_no="Outstanding:",
 					amount=total,
 					currency=voucher_data[0].currency,
+					company=voucher_data[0].company,
 				)
 
 				if self.filters.include_account_currency:

--- a/erpnext/accounts/report/payment_ledger/payment_ledger.py
+++ b/erpnext/accounts/report/payment_ledger/payment_ledger.py
@@ -46,6 +46,7 @@ class PaymentLedger:
 						against_voucher_no=ple.against_voucher_no,
 						amount=ple.amount,
 						currency=ple.account_currency,
+						company=ple.company,
 					)
 
 					if self.filters.include_account_currency:

--- a/erpnext/accounts/report/payment_ledger/payment_ledger.py
+++ b/erpnext/accounts/report/payment_ledger/payment_ledger.py
@@ -87,7 +87,12 @@ class PaymentLedger:
 				voucher_data.append(entry)
 
 				# empty row
-				voucher_data.append(frappe._dict())
+				voucher_data.append(
+					frappe._dict(
+						currency=voucher_data[0].currency,
+						company=voucher_data[0].company,
+					)
+				)
 				self.data.extend(voucher_data)
 
 	def build_conditions(self):


### PR DESCRIPTION
Backport: https://github.com/frappe/erpnext/pull/48926

Only payment_ledger is modified because before the version-15 query rewrite of non_billied_report the company data was already getting fetched.