### PR TITLE
feat: hooks for formatting link fields

### DIFF
--- a/erpnext/hooks.py
+++ b/erpnext/hooks.py
@@ -665,8 +665,4 @@ export_python_type_annotations = True
 
 fields_for_group_similar_items = ["qty", "amount"]
 
-link_formatters = {
-	"Item": "item_name",
-	"Employee": "employee_name",
-	"Project": "project_name"
-}
+link_formatters = {"Item": "item_name", "Employee": "employee_name", "Project": "project_name"}

--- a/erpnext/hooks.py
+++ b/erpnext/hooks.py
@@ -664,3 +664,9 @@ default_log_clearing_doctypes = {
 export_python_type_annotations = True
 
 fields_for_group_similar_items = ["qty", "amount"]
+
+link_formatters = {
+	"Item": "item_name",
+	"Employee": "employee_name",
+	"Project": "project_name"
+}

--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -1060,17 +1060,11 @@ erpnext.utils.map_current_doc = function (opts) {
 	}
 };
 
-frappe.form.link_formatters["Item"] = function (value, doc, df) {
-	return add_link_title(value, doc, df, "item_name");
-};
-
-frappe.form.link_formatters["Employee"] = function (value, doc, df) {
-	return add_link_title(value, doc, df, "employee_name");
-};
-
-frappe.form.link_formatters["Project"] = function (value, doc, df) {
-	return add_link_title(value, doc, df, "project_name");
-};
+Object.entries(frappe.boot.link_formatters).forEach(([doctype, fieldname]) => {
+	frappe.form.link_formatters[doctype] = function (value, doc, df) {
+		return add_link_title(value, doc, df, fieldname);
+	};
+});
 
 /**
  * Add a title to a link value based on the provided document and field information.
@@ -1081,6 +1075,7 @@ frappe.form.link_formatters["Project"] = function (value, doc, df) {
  * @param {string} title_field - The field name for the title.
  * @returns {string} - The link value with the added title.
  */
+
 function add_link_title(value, doc, df, title_field) {
 	if (doc && value && doc[title_field] && doc[title_field] !== value && doc[df.fieldname] === value) {
 		return value + ": " + doc[title_field];

--- a/erpnext/startup/boot.py
+++ b/erpnext/startup/boot.py
@@ -63,6 +63,7 @@ def boot_session(bootinfo):
 			bootinfo.current_fiscal_year = fiscal_year[0]
 
 		bootinfo.sysdefaults.demo_company = frappe.db.get_single_value("Global Defaults", "demo_company")
+		bootinfo.link_formatters = frappe.get_hooks("link_formatters")
 
 
 def update_page_info(bootinfo):


### PR DESCRIPTION
I'm using hooks instead of hardcoding the link formatting, as I believe this approach provides better flexibility for developers. However, I'm not sure if this change will be acceptable. I'm open to modifying the logic to better align with the framework's standards if needed.

`no-docs`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved link display formatting for "Item", "Employee", and "Project" records, showing more descriptive names in links throughout the application.

* **Refactor**
  * Streamlined link formatting setup to automatically apply descriptive titles based on system configuration, enhancing maintainability and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->