### PR TITLE
perf: optimize company monthly sales query using date range

### DIFF
--- a/erpnext/setup/doctype/company/company.py
+++ b/erpnext/setup/doctype/company/company.py
@@ -11,7 +11,7 @@ from frappe.cache_manager import clear_defaults_cache
 from frappe.contacts.address_and_contact import load_address_and_contact
 from frappe.custom.doctype.property_setter.property_setter import make_property_setter
 from frappe.desk.page.setup_wizard.setup_wizard import make_records
-from frappe.utils import cint, formatdate, get_link_to_form, get_timestamp, today
+from frappe.utils import add_months, cint, formatdate, get_first_day, get_link_to_form, get_timestamp, today
 from frappe.utils.nestedset import NestedSet, rebuild_tree
 
 from erpnext.accounts.doctype.account.account import get_account_currency
@@ -734,27 +734,29 @@ def install_country_fixtures(company, country):
 
 
 def update_company_current_month_sales(company):
-	current_month_year = formatdate(today(), "MM-yyyy")
+	from_date = get_first_day(today())
+	to_date = get_first_day(add_months(from_date, 1))
 
 	results = frappe.db.sql(
-		f"""
-		SELECT
-			SUM(base_grand_total) AS total,
-			DATE_FORMAT(`posting_date`, '%m-%Y') AS month_year
-		FROM
-			`tabSales Invoice`
-		WHERE
-			DATE_FORMAT(`posting_date`, '%m-%Y') = '{current_month_year}'
-			AND docstatus = 1
-			AND company = {frappe.db.escape(company)}
-		GROUP BY
-			month_year
-	""",
+		"""
+        SELECT
+            SUM(base_grand_total) AS total,
+            DATE_FORMAT(posting_date, '%%m-%%Y') AS month_year
+        FROM
+            `tabSales Invoice`
+        WHERE
+            posting_date >= %s
+            AND posting_date < %s
+            AND docstatus = 1
+            AND company = %s
+        GROUP BY
+            month_year
+        """,
+		(from_date, to_date, company),
 		as_dict=True,
 	)
 
 	monthly_total = results[0]["total"] if len(results) > 0 else 0
-
 	frappe.db.set_value("Company", company, "total_monthly_sales", monthly_total)
 
 

--- a/erpnext/setup/doctype/company/company.py
+++ b/erpnext/setup/doctype/company/company.py
@@ -739,19 +739,19 @@ def update_company_current_month_sales(company):
 
 	results = frappe.db.sql(
 		"""
-        SELECT
-            SUM(base_grand_total) AS total,
-            DATE_FORMAT(posting_date, '%%m-%%Y') AS month_year
-        FROM
-            `tabSales Invoice`
-        WHERE
-            posting_date >= %s
-            AND posting_date < %s
-            AND docstatus = 1
-            AND company = %s
-        GROUP BY
-            month_year
-        """,
+		SELECT
+			SUM(base_grand_total) AS total,
+			DATE_FORMAT(posting_date, '%%m-%%Y') AS month_year
+		FROM
+			`tabSales Invoice`
+		WHERE
+			posting_date >= %s
+			AND posting_date < %s
+			AND docstatus = 1
+			AND company = %s
+		GROUP BY
+			month_year
+		""",
 		(from_date, to_date, company),
 		as_dict=True,
 	)


### PR DESCRIPTION
Summary
Optimized update_company_current_month_sales function by replacing DATE_FORMAT() in WHERE clause with direct date range comparison.

Changes
- Replaced DATE_FORMAT(posting_date, '%m-%Y') = 'MM-YYYY' with date range filtering
- Used parameterized queries instead of string formatting
- Added proper date range calculation using get_first_day() and add_months

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect month-to-month sales totals by switching to robust date-range filtering, preventing sales from being misattributed across month boundaries.
  * Improved reliability and security of the sales query so company totals for the current month are calculated accurately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->