### PR TITLE
fix: set default_currency in accounts during child company creation

### DIFF
--- a/erpnext/accounts/doctype/account/chart_of_accounts/chart_of_accounts.py
+++ b/erpnext/accounts/doctype/account/chart_of_accounts/chart_of_accounts.py
@@ -18,6 +18,7 @@ def create_charts(
 		accounts = []
 
 		def _import_accounts(children, parent, root_type, root_account=False):
+			nonlocal custom_chart
 			for account_name, child in children.items():
 				if root_account:
 					root_type = child.get("root_type")
@@ -55,7 +56,8 @@ def create_charts(
 							"account_number": account_number,
 							"account_type": child.get("account_type"),
 							"account_currency": child.get("account_currency")
-							or frappe.get_cached_value("Company", company, "default_currency"),
+							if custom_chart
+							else frappe.get_cached_value("Company", company, "default_currency"),
 							"tax_rate": child.get("tax_rate"),
 						}
 					)


### PR DESCRIPTION
Fixed the issue where currency in all the accounts of the child company was incorrectly set to the parent company's `default_currency` during child company creation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of account currency assignment when importing charts of accounts, ensuring that custom chart data is used correctly without unintended fallback to the company's default currency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->