### PR TITLE
fix(process statement of accounts): make date fields mandatory

### DIFF
--- a/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.json
+++ b/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.json
@@ -78,18 +78,18 @@
    "reqd": 1
   },
   {
-   "depends_on": "eval:(doc.enable_auto_email == 0 && doc.report == 'General Ledger');",
+   "depends_on": "eval:(!doc.enable_auto_email && doc.report == 'General Ledger');",
    "fieldname": "from_date",
    "fieldtype": "Date",
    "label": "From Date",
-   "mandatory_depends_on": "eval:doc.frequency == '';"
+   "mandatory_depends_on": "eval:(!doc.enable_auto_email && doc.report == \"General Ledger\") "
   },
   {
-   "depends_on": "eval:(doc.enable_auto_email == 0 && doc.report == 'General Ledger');",
+   "depends_on": "eval:(!doc.enable_auto_email && doc.report == 'General Ledger');",
    "fieldname": "to_date",
    "fieldtype": "Date",
    "label": "To Date",
-   "mandatory_depends_on": "eval:doc.frequency == '';"
+   "mandatory_depends_on": "eval:(!doc.enable_auto_email && doc.report == \"General Ledger\") "
   },
   {
    "fieldname": "cost_center",
@@ -330,7 +330,8 @@
    "depends_on": "eval:(doc.report == 'Accounts Receivable');",
    "fieldname": "posting_date",
    "fieldtype": "Date",
-   "label": "Posting Date"
+   "label": "Posting Date",
+   "mandatory_depends_on": "eval:(doc.report == 'Accounts Receivable');"
   },
   {
    "depends_on": "eval: (doc.report == 'Accounts Receivable');",
@@ -400,7 +401,7 @@
   }
  ],
  "links": [],
- "modified": "2025-07-08 16:52:12.602384",
+ "modified": "2025-08-04 18:21:12.603623",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Process Statement Of Accounts",


### PR DESCRIPTION
Issue: Error occurs while sending email because the date is missing.

Ref: [#45707](https://support.frappe.io/helpdesk/tickets/45707)

Before:

https://github.com/user-attachments/assets/156e4f4d-203d-4631-9740-1d3ab0de8701

After:

https://github.com/user-attachments/assets/cbfe3d9b-6612-4a97-8258-3a70cbb96022


Backport needed: v15

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved the logic controlling field visibility and mandatory status for date fields in statement of accounts reports, ensuring more consistent and accurate behavior based on selected options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->