### PR TITLE
chore: added now as default value for the posting time

### DIFF
--- a/erpnext/accounts/doctype/pos_invoice/pos_invoice.json
+++ b/erpnext/accounts/doctype/pos_invoice/pos_invoice.json
@@ -296,6 +296,7 @@
    "search_index": 1
   },
   {
+   "default": "Now",
    "fieldname": "posting_time",
    "fieldtype": "Time",
    "label": "Posting Time",
@@ -1598,7 +1599,7 @@
  "icon": "fa fa-file-text",
  "is_submittable": 1,
  "links": [],
- "modified": "2025-07-18 16:50:30.516162",
+ "modified": "2025-08-04 22:22:31.471752",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "POS Invoice",

--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
@@ -322,6 +322,7 @@
    "search_index": 1
   },
   {
+   "default": "Now",
    "fieldname": "posting_time",
    "fieldtype": "Time",
    "label": "Posting Time",
@@ -1668,7 +1669,7 @@
  "idx": 204,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-07-30 23:16:05.722875",
+ "modified": "2025-08-04 19:19:11.380664",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Purchase Invoice",

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.json
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.json
@@ -373,6 +373,7 @@
    "search_index": 1
   },
   {
+   "default": "Now",
    "fieldname": "posting_time",
    "fieldtype": "Time",
    "hide_days": 1,
@@ -2232,7 +2233,7 @@
    "link_fieldname": "consolidated_invoice"
   }
  ],
- "modified": "2025-06-26 14:06:56.773552",
+ "modified": "2025-08-04 19:20:28.732039",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Sales Invoice",

--- a/erpnext/stock/doctype/delivery_note/delivery_note.json
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.json
@@ -251,6 +251,7 @@
    "width": "100px"
   },
   {
+   "default": "Now",
    "fieldname": "posting_time",
    "fieldtype": "Time",
    "label": "Posting Time",
@@ -1415,7 +1416,7 @@
  "idx": 146,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-01-06 15:02:30.558756",
+ "modified": "2025-08-04 19:20:47.724218",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Delivery Note",
@@ -1506,6 +1507,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "search_fields": "status,customer,customer_name, territory,base_grand_total",
  "show_name_in_global_search": 1,
  "sort_field": "creation",

--- a/erpnext/stock/doctype/delivery_note/delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.py
@@ -96,7 +96,6 @@ class DeliveryNote(SellingController):
 		per_billed: DF.Percent
 		per_installed: DF.Percent
 		per_returned: DF.Percent
-		pick_list: DF.Link | None
 		plc_conversion_rate: DF.Float
 		po_date: DF.Date | None
 		po_no: DF.SmallText | None

--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.json
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.json
@@ -243,6 +243,7 @@
    "width": "100px"
   },
   {
+   "default": "Now",
    "fieldname": "posting_time",
    "fieldtype": "Time",
    "label": "Posting Time",
@@ -1290,7 +1291,7 @@
  "idx": 261,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-04-09 16:52:19.323878",
+ "modified": "2025-08-04 19:18:47.754957",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Purchase Receipt",

--- a/erpnext/stock/doctype/stock_entry/stock_entry.json
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.json
@@ -218,6 +218,7 @@
    "search_index": 1
   },
   {
+   "default": "Now",
    "fieldname": "posting_time",
    "fieldtype": "Time",
    "label": "Posting Time",
@@ -697,7 +698,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-08-13 19:05:42.386955",
+ "modified": "2025-08-04 19:21:03.338958",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Stock Entry",
@@ -763,6 +764,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "search_fields": "posting_date, from_warehouse, to_warehouse, purpose, remarks",
  "show_name_in_global_search": 1,
  "sort_field": "creation",

--- a/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.json
+++ b/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.json
@@ -72,6 +72,7 @@
    "reqd": 1
   },
   {
+   "default": "Now",
    "fieldname": "posting_time",
    "fieldtype": "Time",
    "in_list_view": 1,
@@ -183,7 +184,7 @@
  "idx": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-03-27 13:10:44.699413",
+ "modified": "2025-08-04 19:21:20.179658",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Stock Reconciliation",
@@ -203,6 +204,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "search_fields": "posting_date",
  "show_name_in_global_search": 1,
  "sort_field": "creation",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The "Posting Time" field in Purchase Invoice, Sales Invoice, Delivery Note, Purchase Receipt, Stock Entry, Stock Reconciliation, and POS Invoice now defaults to the current time when creating new documents.
  * "Row Format" has been set to "Dynamic" for Delivery Note, Stock Entry, and Stock Reconciliation, enhancing data handling for these documents.

* **Refactor**
  * Internal field declaration cleanup in Delivery Note (no impact on user-facing features).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->