### PR TITLE
fix: check for target warehouse on internal return

### DIFF
--- a/erpnext/controllers/sales_and_purchase_return.py
+++ b/erpnext/controllers/sales_and_purchase_return.py
@@ -1004,7 +1004,7 @@ def filter_serial_batches(parent_doc, data, row, warehouse_field=None, qty_field
 
 	elif data.batches:
 		for batch_no, batch_qty in data.batches.items():
-			if parent_doc.get("is_internal_customer"):
+			if parent_doc.get("is_internal_customer") and parent_doc.get("target_warehouse"):
 				batch_qty = batch_qty * -1
 
 			if batch_qty <= 0:
@@ -1062,7 +1062,7 @@ def make_serial_batch_bundle_for_return(data, child_doc, parent_doc, warehouse_f
 		qty_field = "stock_qty"
 
 	warehouse = child_doc.get(warehouse_field)
-	if parent_doc.get("is_internal_customer"):
+	if parent_doc.get("is_internal_customer") and child_doc.get("target_warehouse"):
 		warehouse = child_doc.get("target_warehouse")
 		type_of_transaction = "Outward"
 


### PR DESCRIPTION
**Issue:** Unable to submit the return delivery note for the internal customer with the item with the batch
**ref:** [44106](https://support.frappe.io/helpdesk/tickets/44106)

<img width="1861" height="646" alt="image" src="https://github.com/user-attachments/assets/a318e3e9-9f58-4d7d-bcd0-1b63bc4940e7" />


**Before:**


**After:**

https://github.com/user-attachments/assets/cd6b8f0b-c96a-4418-b6b9-35e74a1f5a03


**Backport needed for V15**