### PR TITLE
fix(bank statement import): return blank template instead of template with 5 records on download template

### DIFF
--- a/erpnext/accounts/doctype/bank_statement_import/bank_statement_import.js
+++ b/erpnext/accounts/doctype/bank_statement_import/bank_statement_import.js
@@ -252,7 +252,7 @@ frappe.ui.form.on("Bank Statement Import", {
 
 		open_url_post(method, {
 			doctype: "Bank Transaction",
-			export_records: "5_records",
+			export_records: "blank_template",
 			export_fields: {
 				"Bank Transaction": [
 					"date",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Downloading a bank statement import template now provides a blank template without sample records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->