### PR TITLE
fix: use maintenance_status filter for indicators

### DIFF
--- a/erpnext/assets/doctype/asset_maintenance_log/asset_maintenance_log_list.js
+++ b/erpnext/assets/doctype/asset_maintenance_log/asset_maintenance_log_list.js
@@ -3,13 +3,13 @@ frappe.listview_settings["Asset Maintenance Log"] = {
 	has_indicator_for_draft: 1,
 	get_indicator: function (doc) {
 		if (doc.maintenance_status == "Planned") {
-			return [__(doc.maintenance_status), "orange", "status,=," + doc.maintenance_status];
+			return [__(doc.maintenance_status), "orange", "maintenance_status,=," + doc.maintenance_status];
 		} else if (doc.maintenance_status == "Completed") {
-			return [__(doc.maintenance_status), "green", "status,=," + doc.maintenance_status];
+			return [__(doc.maintenance_status), "green", "maintenance_status,=," + doc.maintenance_status];
 		} else if (doc.maintenance_status == "Cancelled") {
-			return [__(doc.maintenance_status), "red", "status,=," + doc.maintenance_status];
+			return [__(doc.maintenance_status), "red", "maintenance_status,=," + doc.maintenance_status];
 		} else if (doc.maintenance_status == "Overdue") {
-			return [__(doc.maintenance_status), "red", "status,=," + doc.maintenance_status];
+			return [__(doc.maintenance_status), "red", "maintenance_status,=," + doc.maintenance_status];
 		}
 	},
 };


### PR DESCRIPTION
Getting this error when switching to report view.

<img width="1092" height="411" alt="Screenshot 2025-08-05 at 2 41 20 PM" src="https://github.com/user-attachments/assets/7cb9907e-e2a4-4440-9e13-ed2b4793cd83" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the filter for maintenance status indicators to ensure accurate filtering by status in the asset maintenance log list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->