### PR TITLE
refactor(pos): disable grand total to default mode of payment

### DIFF
--- a/erpnext/selling/page/point_of_sale/pos_controller.js
+++ b/erpnext/selling/page/point_of_sale/pos_controller.js
@@ -421,6 +421,7 @@ erpnext.PointOfSale.Controller = class {
 	init_payments() {
 		this.payment = new erpnext.PointOfSale.Payment({
 			wrapper: this.$components_wrapper,
+			settings: this.settings,
 			events: {
 				get_frm: () => this.frm || {},
 


### PR DESCRIPTION
Refactored the code to reset the amount on the default Mode of Payment at the POS (depends on POS Profile configuration) instead of `taxes_and_totals.js`. (refer to https://github.com/frappe/erpnext/pull/48965)

Also removed the unnecessary API call to fetch POS Profile configuration.