### PR TITLE
refactor(pos): set/reset grand total to default mode of payment

### DIFF
--- a/erpnext/selling/page/point_of_sale/pos_payment.js
+++ b/erpnext/selling/page/point_of_sale/pos_payment.js
@@ -450,10 +450,11 @@ erpnext.PointOfSale.Payment = class {
 	}
 
 	render_payment_section() {
+		this.grand_total_to_default_mop();
 		this.render_payment_mode_dom();
 		this.make_invoice_field_dialog();
 		this.update_totals_section();
-		this.set_grand_total_to_default_mop();
+		this.focus_on_default_mop();
 	}
 
 	after_render() {
@@ -495,6 +496,17 @@ erpnext.PointOfSale.Payment = class {
 			});
 			this[`remark_control`].set_value("");
 		}
+	}
+
+	grand_total_to_default_mop() {
+		if (this.set_gt_to_default_mop) return;
+		const doc = this.events.get_frm().doc;
+		const payments = doc.payments;
+		payments.forEach((p) => {
+			if (p.default) {
+				frappe.model.set_value(p.doctype, p.name, "amount", 0);
+			}
+		});
 	}
 
 	render_payment_mode_dom() {
@@ -557,6 +569,7 @@ erpnext.PointOfSale.Payment = class {
 	}
 
 	focus_on_default_mop() {
+		if (!this.set_gt_to_default_mop) return;
 		const doc = this.events.get_frm().doc;
 		const payments = doc.payments;
 		payments.forEach((p) => {
@@ -709,12 +722,6 @@ erpnext.PointOfSale.Payment = class {
 			.replace(/[^\p{L}\p{N}_-]/gu, "")
 			.replace(/^[^_a-zA-Z\p{L}]+/u, "")
 			.toLowerCase();
-	}
-
-	set_grand_total_to_default_mop() {
-		if (this.set_gt_to_default_mop) {
-			this.focus_on_default_mop();
-		}
 	}
 
 	validate_reqd_invoice_fields() {


### PR DESCRIPTION
Refactored the code to reset the amount on the default Mode of Payment at the POS (depends on POS Profile configuration) instead of taxes_and_totals.js. (refer to https://github.com/frappe/erpnext/pull/48964)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of payment amounts for default payment modes in the Point of Sale, ensuring amounts are reset to zero when appropriate and focusing on default payment modes only when relevant.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->