### PR TITLE
feat: add make methods for Bank Account

### DIFF
--- a/erpnext/buying/doctype/supplier/supplier.js
+++ b/erpnext/buying/doctype/supplier/supplier.js
@@ -64,6 +64,10 @@ frappe.ui.form.on("Supplier", {
 				},
 			};
 		});
+
+		frm.make_methods = {
+			"Bank Account": () => erpnext.utils.make_bank_account(frm.doc.doctype, frm.doc.name),
+		};
 	},
 
 	refresh: function (frm) {

--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -213,17 +213,9 @@ $.extend(erpnext.utils, {
 	},
 
 	make_bank_account: function (doctype, docname) {
-		frappe.call({
-			method: "erpnext.accounts.doctype.bank_account.bank_account.make_bank_account",
-			args: {
-				doctype: doctype,
-				docname: docname,
-			},
-			freeze: true,
-			callback: function (r) {
-				var doclist = frappe.model.sync(r.message);
-				frappe.set_route("Form", doclist[0].doctype, doclist[0].name);
-			},
+		frappe.new_doc("Bank Account", {
+			party_type: doctype,
+			party: docname,
 		});
 	},
 

--- a/erpnext/selling/doctype/customer/customer.js
+++ b/erpnext/selling/doctype/customer/customer.js
@@ -33,6 +33,7 @@ frappe.ui.form.on("Customer", {
 					frm: frm,
 				}),
 			"Pricing Rule": () => erpnext.utils.make_pricing_rule(frm.doc.doctype, frm.doc.name),
+			"Bank Account": () => erpnext.utils.make_bank_account(frm.doc.doctype, frm.doc.name),
 		};
 
 		frm.add_fetch("lead_name", "company_name", "customer_name");

--- a/erpnext/setup/doctype/employee/employee.js
+++ b/erpnext/setup/doctype/employee/employee.js
@@ -21,6 +21,12 @@ erpnext.setup.EmployeeController = class EmployeeController extends frappe.ui.fo
 };
 
 frappe.ui.form.on("Employee", {
+	setup: function (frm) {
+		frm.make_methods = {
+			"Bank Account": () => erpnext.utils.make_bank_account(frm.doc.doctype, frm.doc.name),
+		};
+	},
+
 	onload: function (frm) {
 		frm.set_query("department", function () {
 			return {


### PR DESCRIPTION
Auto-fill _Party Type_ and _Party_ when creating a **Bank Account** from **Customer**, **Supplier** or **Employee** dashboard.

https://github.com/user-attachments/assets/083b2bd9-b2d5-4c02-9459-c9f10b27eea2

Refactored `erpnext.utils.make_bank_account` to create the **Bank Account** directly instead of making a useless roundtrip to the server.

Todo:

- [x] Remove `erpnext.accounts.doctype.bank_account.bank_account.make_bank_account` in a separate PR without backports #49001

> no-docs
