### PR TITLE
refactor!: remove whitelisted method `make_bank_account`

### DIFF
--- a/erpnext/accounts/doctype/bank_account/bank_account.py
+++ b/erpnext/accounts/doctype/bank_account/bank_account.py
@@ -118,15 +118,6 @@ class BankAccount(Document):
 			)
 
 
-@frappe.whitelist()
-def make_bank_account(doctype, docname):
-	doc = frappe.new_doc("Bank Account")
-	doc.party_type = doctype
-	doc.party = docname
-
-	return doc
-
-
 def get_party_bank_account(party_type, party):
 	return frappe.db.get_value(
 		"Bank Account",


### PR DESCRIPTION
Has no uses after calls have been removed in #49000

Todo:

- [x] Update migration guide https://github.com/frappe/erpnext/wiki/Migration-Guide-To-ERPNext-Version-16#new-party-bank-account-via-api

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Removed an obsolete public/internal API for creating bank account records and cleaned up access paths. This is an internal change with no impact on user-facing features or workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->