### PR TITLE
refactor: get advance payment doctypes from hooks

### DIFF
--- a/erpnext/accounts/doctype/account/chart_of_accounts/verified/standard_chart_of_accounts.py
+++ b/erpnext/accounts/doctype/account/chart_of_accounts/verified/standard_chart_of_accounts.py
@@ -13,7 +13,7 @@ def get():
 				_("Bank Accounts"): {"account_type": "Bank", "is_group": 1},
 				_("Cash In Hand"): {_("Cash"): {"account_type": "Cash"}, "account_type": "Cash"},
 				_("Loans and Advances (Assets)"): {
-					_("Employee Advances"): {},
+					_("Employee Advances"): {"account_type": "Payable"},
 				},
 				_("Securities and Deposits"): {_("Earnest Money"): {}},
 				_("Stock Assets"): {

--- a/erpnext/accounts/doctype/account/chart_of_accounts/verified/standard_chart_of_accounts_with_account_number.py
+++ b/erpnext/accounts/doctype/account/chart_of_accounts/verified/standard_chart_of_accounts_with_account_number.py
@@ -20,7 +20,7 @@ def get():
 					"account_number": "1100",
 				},
 				_("Loans and Advances (Assets)"): {
-					_("Employee Advances"): {"account_number": "1610"},
+					_("Employee Advances"): {"account_number": "1610", "account_type": "Payable"},
 					"account_number": "1600",
 				},
 				_("Securities and Deposits"): {

--- a/erpnext/accounts/doctype/advance_payment_ledger_entry/advance_payment_ledger_entry.py
+++ b/erpnext/accounts/doctype/advance_payment_ledger_entry/advance_payment_ledger_entry.py
@@ -4,7 +4,7 @@
 import frappe
 from frappe.model.document import Document
 
-from erpnext.accounts.utils import update_voucher_outstanding
+from erpnext.accounts.utils import get_advance_payment_doctypes, update_voucher_outstanding
 
 
 class AdvancePaymentLedgerEntry(Document):
@@ -29,7 +29,7 @@ class AdvancePaymentLedgerEntry(Document):
 
 	def on_update(self):
 		if (
-			self.against_voucher_type in ["Purchase Order", "Sales Order"]
+			self.against_voucher_type in get_advance_payment_doctypes()
 			and self.flags.update_outstanding == "Yes"
 			and not frappe.flags.is_reverse_depr_entry
 		):

--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -481,7 +481,6 @@ def reconcile_against_document(
 			reconciled_entries[(row.voucher_type, row.voucher_no)] = []
 
 		reconciled_entries[(row.voucher_type, row.voucher_no)].append(row)
-
 	for key, entries in reconciled_entries.items():
 		voucher_type, voucher_no = key
 
@@ -1835,6 +1834,7 @@ def get_payment_ledger_entries(gl_entries, cancel=0):
 
 		dr_or_cr = 0
 		account_type = None
+
 		for gle in gl_entries:
 			if gle.account in receivable_or_payable_accounts:
 				account_type = get_account_type(gle.account)
@@ -1939,7 +1939,8 @@ def update_voucher_outstanding(voucher_type, voucher_no, account, party_type, pa
 	if not voucher_type or not voucher_no:
 		return
 
-	if voucher_type in ["Purchase Order", "Sales Order"]:
+	# todo use get advanced dotypes hooks
+	if voucher_type in get_advance_payment_doctypes():
 		ref_doc = frappe.get_lazy_doc(voucher_type, voucher_no)
 		ref_doc.set_total_advance_paid()
 		return

--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -1939,7 +1939,6 @@ def update_voucher_outstanding(voucher_type, voucher_no, account, party_type, pa
 	if not voucher_type or not voucher_no:
 		return
 
-	# todo use get advanced dotypes hooks
 	if voucher_type in get_advance_payment_doctypes():
 		ref_doc = frappe.get_lazy_doc(voucher_type, voucher_no)
 		ref_doc.set_total_advance_paid()


### PR DESCRIPTION
- Use advance payment docypes as specifed in hooks.py instead of hardcoding advanced doctyes so that things are compatible with other apps.
- Set account type for employee advance account in standard COA since the creation of advanced payment ledger entries now depends on account type condition

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the classification of "Employee Advances" in the chart of accounts by explicitly setting its account type to "Payable".

* **Refactor**
  * Improved how advance payment voucher types are determined, making the system more flexible and maintainable.

* **Style**
  * Minor formatting adjustments for improved code readability (no impact on user-facing features).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->