### PR TITLE
fix(subscription): current invoice start date cannot be greater than subscription end date

### DIFF
--- a/erpnext/accounts/doctype/subscription/subscription.py
+++ b/erpnext/accounts/doctype/subscription/subscription.py
@@ -95,6 +95,10 @@ class Subscription(Document):
 		`current_invoice_start` and the end of the billing period is represented
 		as `current_invoice_end`.
 		"""
+		# Don't update period if the new start date would be after subscription end date
+		if self.end_date and date and getdate(date) > getdate(self.end_date):
+			return
+		
 		self.current_invoice_start = self.get_current_invoice_start(date)
 		self.current_invoice_end = self.get_current_invoice_end(self.current_invoice_start)
 


### PR DESCRIPTION
This fix closes #48941 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved subscription period updates to prevent changes when the new start date is after the subscription's end date, ensuring date ranges remain valid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->