### PR TITLE
fix: NoneType error on applying presentation_currency filter on financial statements and trial balance report

### DIFF
--- a/erpnext/accounts/report/utils.py
+++ b/erpnext/accounts/report/utils.py
@@ -118,7 +118,7 @@ def convert_to_presentation_currency(gl_entries, currency_info, filters=None):
 			len(account_currencies) == 1
 			and account_currency == presentation_currency
 			and not exchange_gain_or_loss
-		) and not filters.get("show_amount_in_company_currency"):
+		) and not (filters and filters.get("show_amount_in_company_currency")):
 			entry["debit"] = debit_in_account_currency
 			entry["credit"] = credit_in_account_currency
 		else:


### PR DESCRIPTION
Fixed the NoneType Server Error which occurred when the `presentation_currency` filter is applied and `presentation_currency == account_currency` where `account_currency` belongs to GL Entries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability by preventing errors when certain filters are missing in reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->