### PR TITLE
fix: validation for inventory account in the warehouse

### DIFF
--- a/erpnext/stock/doctype/warehouse/warehouse.py
+++ b/erpnext/stock/doctype/warehouse/warehouse.py
@@ -64,10 +64,23 @@ class Warehouse(NestedSet):
 
 			if account:
 				self.set_onload("account", account)
+
 		load_address_and_contact(self)
 
 	def validate(self):
 		self.warn_about_multiple_warehouse_account()
+		self.validate_warehouse_account()
+
+	def validate_warehouse_account(self):
+		return
+		if self.flags.ignore_mandatory:
+			return
+
+		if self.company and not frappe.db.get_value("Company", self.company, "enable_perpetual_inventory"):
+			return
+
+		if not self.account and self.company:
+			get_warehouse_account(self, skip_random=True)
 
 	def on_update(self):
 		self.update_nsm_model()


### PR DESCRIPTION
If not account set in the warehouse or in the company system will throw the validation 

<img width="1219" height="295" alt="Screenshot 2025-08-07 at 11 00 35 AM" src="https://github.com/user-attachments/assets/07843887-f4df-4ead-8d55-c055c02f472b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved validation for warehouse accounts when perpetual inventory is enabled, ensuring accounts are set or validated automatically.

* **Enhancements**
  * Error messages for missing warehouse accounts now highlight warehouse and company names for better clarity.
  * Warehouse account assignment logic now considers the earliest created valid stock account if none is directly set.

* **Refactor**
  * Simplified warehouse loading process for improved maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->