### PR TITLE
chore: set employee advanced account type to Receivable in standard COA

### DIFF
--- a/erpnext/accounts/doctype/account/chart_of_accounts/verified/standard_chart_of_accounts.py
+++ b/erpnext/accounts/doctype/account/chart_of_accounts/verified/standard_chart_of_accounts.py
@@ -13,7 +13,7 @@ def get():
 				_("Bank Accounts"): {"account_type": "Bank", "is_group": 1},
 				_("Cash In Hand"): {_("Cash"): {"account_type": "Cash"}, "account_type": "Cash"},
 				_("Loans and Advances (Assets)"): {
-					_("Employee Advances"): {"account_type": "Payable"},
+					_("Employee Advances"): {"account_type": "Receivable"},
 				},
 				_("Securities and Deposits"): {_("Earnest Money"): {}},
 				_("Stock Assets"): {

--- a/erpnext/accounts/doctype/account/chart_of_accounts/verified/standard_chart_of_accounts_with_account_number.py
+++ b/erpnext/accounts/doctype/account/chart_of_accounts/verified/standard_chart_of_accounts_with_account_number.py
@@ -20,7 +20,7 @@ def get():
 					"account_number": "1100",
 				},
 				_("Loans and Advances (Assets)"): {
-					_("Employee Advances"): {"account_number": "1610", "account_type": "Payable"},
+					_("Employee Advances"): {"account_number": "1610", "account_type": "Receivable"},
 					"account_number": "1600",
 				},
 				_("Securities and Deposits"): {


### PR DESCRIPTION
It was set from no type to incorrectly Payable to now correctly Receivable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated the classification of "Employee Advances" from "Payable" to "Receivable" in the standard chart of accounts, improving account categorization in financial reports.
  * Enhanced the process for setting default receivable and payable accounts in company setup for more accurate account selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->