### PR TITLE
fix: flag on journal entry to ignore party account type validation if required

### DIFF
--- a/erpnext/accounts/doctype/journal_entry/journal_entry.py
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.py
@@ -654,6 +654,7 @@ class JournalEntry(AccountsController):
 				elif (
 					d.party_type
 					and frappe.db.get_value("Party Type", d.party_type, "account_type") != account_type
+					and (not self.flags.ignore_party_account_validation)
 				):
 					frappe.throw(
 						_("Row {0}: Account {1} and Party Type {2} have different account types").format(


### PR DESCRIPTION
For party types like employee they could be payable as in expense claim or receivable as in employee advance for them the account type and party account type could be different.

So introduced this flag to ignore that validation when creating employee advance.
Works with frappe/hrms@9061fd3fc31c2ab5cc00149d7ca92081a53a0bb4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved journal entry validation to better handle cases where party-account type checks should be bypassed under certain conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->