### PR TITLE
feat: consolidated trial balance report

### DIFF
--- a/erpnext/accounts/report/trial_balance/trial_balance.js
+++ b/erpnext/accounts/report/trial_balance/trial_balance.js
@@ -10,6 +10,13 @@ frappe.query_reports["Trial Balance"] = {
 			options: "Company",
 			default: frappe.defaults.get_user_default("Company"),
 			reqd: 1,
+			on_change: function (query_report) {
+				frappe.db.get_value("Company", this.value, "is_group").then((r) => {
+					const is_group = r.message.is_group;
+					query_report.toggle_filter_display("consolidated_trial_balance", !is_group);
+					query_report.set_filter_value("consolidated_trial_balance", is_group);
+				});
+			},
 		},
 		{
 			fieldname: "fiscal_year",
@@ -116,6 +123,12 @@ frappe.query_reports["Trial Balance"] = {
 			label: __("Show Group Accounts"),
 			fieldtype: "Check",
 			default: 1,
+		},
+		{
+			fieldname: "consolidated_trial_balance",
+			label: __("Consolidated Trial Balance"),
+			fieldtype: "Check",
+			default: 0,
 		},
 	],
 	formatter: erpnext.financial_statements.formatter,

--- a/erpnext/accounts/report/trial_balance/trial_balance.py
+++ b/erpnext/accounts/report/trial_balance/trial_balance.py
@@ -81,6 +81,12 @@ def validate_filters(filters):
 		)
 		filters.to_date = filters.year_end_date
 
+	is_group_company = frappe.get_cached_value("Company", filters.company, "is_group")
+	if not is_group_company and filters.get("consolidated_trial_balance"):
+		frappe.msgprint(_("Consolidated Trial Balance can be generated only for a Group Company."))
+
+		filters.consolidated_trial_balance = 0
+
 
 def get_data(filters):
 	accounts = frappe.db.sql(


### PR DESCRIPTION
Consolidated Trial Balance Report for a Company having subsidiary companies.

Changes include:
- Added a filter, named `Consolidated Trial Balance`, which will be visible for Group Company.
- Child Company can have a different `default_currency` than `parent_company`. However, the report will be generated for `parent_company`'s `default_currency` or selected `parent_currency`.

Demo:

https://github.com/user-attachments/assets/57de9287-69bf-44b6-9288-cc270e51daa4


<!-- no-docs -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Consolidated Trial Balance" checkbox filter to the Trial Balance report, which appears when a group company is selected.
  * Enabled consolidated trial balance reporting, allowing users to view combined trial balances for parent and subsidiary companies in a single report.

* **Enhancements**
  * The report now automatically updates the availability of the consolidated view based on the selected company.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->