### PR TITLE
fix: dont validate account type while creating journal entry for employee party type

### DIFF
--- a/erpnext/accounts/doctype/journal_entry/journal_entry.py
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.py
@@ -654,7 +654,8 @@ class JournalEntry(AccountsController):
 				elif (
 					d.party_type
 					and frappe.db.get_value("Party Type", d.party_type, "account_type") != account_type
-					and (not self.flags.ignore_party_account_validation)
+					and d.party_type
+					!= "Employee"  # making an excpetion for employee since they can be both payable and receivable
 				):
 					frappe.throw(
 						_("Row {0}: Account {1} and Party Type {2} have different account types").format(


### PR DESCRIPTION
Since they can be both payable and receivable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where journal entries involving "Employee" party types would incorrectly trigger account type validation errors. "Employee" party types are now properly exempted from this validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->