### PR TITLE
fix: fetch fieldname in accounting dimension filter

### DIFF
--- a/erpnext/accounts/doctype/accounting_dimension_filter/accounting_dimension_filter.json
+++ b/erpnext/accounts/doctype/accounting_dimension_filter/accounting_dimension_filter.json
@@ -7,6 +7,7 @@
  "engine": "InnoDB",
  "field_order": [
   "accounting_dimension",
+  "fieldname",
   "disabled",
   "column_break_2",
   "company",
@@ -90,11 +91,17 @@
    "fieldname": "apply_restriction_on_values",
    "fieldtype": "Check",
    "label": "Apply restriction on dimension values"
+  },
+  {
+   "fieldname": "fieldname",
+   "fieldtype": "Data",
+   "hidden": 1,
+   "label": "Fieldname"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-03-27 13:05:57.199186",
+ "modified": "2025-08-08 14:13:22.203011",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Accounting Dimension Filter",
@@ -139,6 +146,7 @@
   }
  ],
  "quick_entry": 1,
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],

--- a/erpnext/accounts/doctype/accounting_dimension_filter/accounting_dimension_filter.py
+++ b/erpnext/accounts/doctype/accounting_dimension_filter/accounting_dimension_filter.py
@@ -38,7 +38,8 @@ class AccountingDimensionFilter(Document):
 	def validate(self):
 		self.fieldname = frappe.db.get_value(
 			"Accounting Dimension", {"document_type": self.accounting_dimension}, "fieldname"
-		)
+		) or frappe.scrub(self.accounting_dimension)  # scrub to handle default accounting dimension
+
 		self.validate_applicable_accounts()
 
 	def validate_applicable_accounts(self):

--- a/erpnext/accounts/doctype/accounting_dimension_filter/accounting_dimension_filter.py
+++ b/erpnext/accounts/doctype/accounting_dimension_filter/accounting_dimension_filter.py
@@ -17,17 +17,16 @@ class AccountingDimensionFilter(Document):
 		from frappe.types import DF
 
 		from erpnext.accounts.doctype.allowed_dimension.allowed_dimension import AllowedDimension
-		from erpnext.accounts.doctype.applicable_on_account.applicable_on_account import (
-			ApplicableOnAccount,
-		)
+		from erpnext.accounts.doctype.applicable_on_account.applicable_on_account import ApplicableOnAccount
 
-		accounting_dimension: DF.Literal
+		accounting_dimension: DF.Literal[None]
 		accounts: DF.Table[ApplicableOnAccount]
 		allow_or_restrict: DF.Literal["Allow", "Restrict"]
 		apply_restriction_on_values: DF.Check
 		company: DF.Link
 		dimensions: DF.Table[AllowedDimension]
 		disabled: DF.Check
+		fieldname: DF.Data | None
 	# end: auto-generated types
 
 	def before_save(self):
@@ -37,6 +36,9 @@ class AccountingDimensionFilter(Document):
 			self.set("dimensions", [])
 
 	def validate(self):
+		self.fieldname = frappe.db.get_value(
+			"Accounting Dimension", {"document_type": self.accounting_dimension}, "fieldname"
+		)
 		self.validate_applicable_accounts()
 
 	def validate_applicable_accounts(self):
@@ -71,7 +73,7 @@ def get_dimension_filter_map():
 			"""
 			SELECT
 				a.applicable_on_account, d.dimension_value, p.accounting_dimension,
-				p.allow_or_restrict, a.is_mandatory
+				p.allow_or_restrict, p.fieldname, a.is_mandatory
 			FROM
 				`tabApplicable On Account` a,
 				`tabAccounting Dimension Filter` p
@@ -86,8 +88,6 @@ def get_dimension_filter_map():
 		dimension_filter_map = {}
 
 		for f in filters:
-			f.fieldname = scrub(f.accounting_dimension)
-
 			build_map(
 				dimension_filter_map,
 				f.fieldname,

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -434,3 +434,4 @@ erpnext.patches.v15_0.update_uae_zero_rated_fetch
 erpnext.patches.v15_0.add_company_payment_gateway_account
 erpnext.patches.v16_0.update_serial_no_reference_name
 erpnext.patches.v16_0.set_invoice_type_in_pos_settings
+erpnext.patches.v15_0.update_fieldname_in_accounting_dimension_filter

--- a/erpnext/patches/v15_0/update_fieldname_in_accounting_dimension_filter.py
+++ b/erpnext/patches/v15_0/update_fieldname_in_accounting_dimension_filter.py
@@ -1,0 +1,23 @@
+import frappe
+from frappe.query_builder import DocType
+
+
+def execute():
+	ADF = DocType("Accounting Dimension Filter")
+	AD = DocType("Accounting Dimension")
+
+	accounting_dimension_filter = (
+		frappe.qb.from_(ADF)
+		.join(AD)
+		.on(AD.document_type == ADF.accounting_dimension)
+		.select(ADF.name, AD.fieldname)
+	).run(as_dict=True)
+
+	for doc in accounting_dimension_filter:
+		frappe.db.set_value(
+			"Accounting Dimension Filter",
+			doc.name,
+			"fieldname",
+			doc.fieldname,
+			update_modified=False,
+		)

--- a/erpnext/patches/v15_0/update_fieldname_in_accounting_dimension_filter.py
+++ b/erpnext/patches/v15_0/update_fieldname_in_accounting_dimension_filter.py
@@ -3,6 +3,7 @@ from frappe.query_builder import DocType
 
 
 def execute():
+	default_accounting_dimension()
 	ADF = DocType("Accounting Dimension Filter")
 	AD = DocType("Accounting Dimension")
 
@@ -19,5 +20,16 @@ def execute():
 			doc.name,
 			"fieldname",
 			doc.fieldname,
+			update_modified=False,
+		)
+
+
+def default_accounting_dimension():
+	for accounting_dimension in ["Cost Center", "Project"]:
+		frappe.db.set_value(
+			"Accounting Dimension Filter",
+			{"accounting_dimension": accounting_dimension},
+			"fieldname",
+			frappe.scrub(accounting_dimension),
 			update_modified=False,
 		)

--- a/erpnext/patches/v15_0/update_fieldname_in_accounting_dimension_filter.py
+++ b/erpnext/patches/v15_0/update_fieldname_in_accounting_dimension_filter.py
@@ -11,25 +11,26 @@ def execute():
 		frappe.qb.from_(ADF)
 		.join(AD)
 		.on(AD.document_type == ADF.accounting_dimension)
-		.select(ADF.name, AD.fieldname)
+		.select(ADF.name, AD.fieldname, ADF.accounting_dimension)
 	).run(as_dict=True)
 
 	for doc in accounting_dimension_filter:
+		value = doc.fieldname or frappe.scrub(doc.accounting_dimension)
 		frappe.db.set_value(
 			"Accounting Dimension Filter",
 			doc.name,
 			"fieldname",
-			doc.fieldname,
+			value,
 			update_modified=False,
 		)
 
 
 def default_accounting_dimension():
-	for accounting_dimension in ["Cost Center", "Project"]:
-		frappe.db.set_value(
-			"Accounting Dimension Filter",
-			{"accounting_dimension": accounting_dimension},
-			"fieldname",
-			frappe.scrub(accounting_dimension),
-			update_modified=False,
+	ADF = DocType("Accounting Dimension Filter")
+	for dim in ("Cost Center", "Project"):
+		(
+			frappe.qb.update(ADF)
+			.set(ADF.fieldname, frappe.scrub(dim))
+			.where(ADF.accounting_dimension == dim)
+			.run()
 		)


### PR DESCRIPTION
Issue: Error using Accounting Dimension Filter while fieldname and document type name is different

Ref: [45932](https://support.frappe.io/helpdesk/tickets/45932)

<img width="1813" height="747" alt="image" src="https://github.com/user-attachments/assets/fbba362d-ef92-491e-b2f3-3b9c38f04c92" />

<img width="1808" height="780" alt="image" src="https://github.com/user-attachments/assets/1d62bbb6-61b4-493c-9530-e4aa2cb2ab2d" />

<img width="1855" height="896" alt="image" src="https://github.com/user-attachments/assets/3f8ab3d1-43c8-4053-8b1a-d8a02ece85e3" />


**Backport Needed: Version-15**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixes mismatches in Accounting Dimension filters by using the stored dimension key, ensuring filters apply correctly across setups.

* **Improvements**
  * Enables dynamic row rendering for Accounting Dimension Filter rows for smoother form interaction.

* **Chores**
  * Adds an automatic background migration to populate missing dimension field names; no user action required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->