### PR TITLE
fix: modify all SRE queries to consider new Closed status

### DIFF
--- a/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py
+++ b/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py
@@ -2180,8 +2180,7 @@ def get_reserved_batches_for_sre(kwargs) -> dict:
 		.where(
 			(sre.docstatus == 1)
 			& (sre.item_code == kwargs.item_code)
-			& (sre.reserved_qty >= sre.delivered_qty)
-			& (sre.status.notin(["Delivered", "Cancelled"]))
+			& (sre.delivered_qty < sre.reserved_qty)
 			& (sre.reservation_based_on == "Serial and Batch")
 		)
 		.groupby(sb_entry.batch_no, sre.warehouse)


### PR DESCRIPTION
The new Stock Transfer Reservation feature added the "Closed" status for the Stock Reservation Entry DocType but all earlier queries manually checked for status using `sre.status.notin(["Delivered", "Cancelled"])`.

This PR replaces that condition with `sre.delivered_qty < sre.reserved_qty` which I feel is a better approach because it not only fixes the "Closed" status issue but also foolproofs for new possible statuses in the future.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy in calculating and displaying reserved and available stock quantities by refining the logic for handling delivered and reserved quantities.
  * Enhanced consistency in status updates for stock reservations, ensuring that status reflects the latest reserved and delivered quantities.

* **Refactor**
  * Streamlined the logic used to filter and update stock reservation entries for better reliability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->