### PR TITLE
fix: allow team members to add employees as event participants despite User permission restrictions

### DIFF
--- a/erpnext/hooks.py
+++ b/erpnext/hooks.py
@@ -285,6 +285,12 @@ sounds = [
 
 has_upload_permission = {"Employee": "erpnext.setup.doctype.employee.employee.has_upload_permission"}
 
+# Add custom permission for Event doctype to allow adding employees as participants
+has_permission = {"Event": "erpnext.setup.doctype.employee.employee.has_event_permission"}
+
+# Add custom permission for Event Participants to bypass user permissions for employees
+has_permission.update({"Event Participants": "erpnext.setup.doctype.employee.employee.has_event_participant_permission"})
+
 has_website_permission = {
 	"Sales Order": "erpnext.controllers.website_list_for_contact.has_website_permission",
 	"Quotation": "erpnext.controllers.website_list_for_contact.has_website_permission",

--- a/erpnext/public/js/event.js
+++ b/erpnext/public/js/event.js
@@ -12,6 +12,17 @@ frappe.ui.form.on("Event", {
 			};
 		});
 
+		// Custom query for Employee selection to bypass user permissions
+		frm.set_query("reference_docname", "event_participants", function () {
+			let reference_doctype = frm.get_selected_value("reference_doctype");
+			if (reference_doctype === "Employee") {
+				return {
+					query: "erpnext.setup.doctype.employee.employee.get_employees_for_event_participants",
+					filters: {},
+				};
+			}
+		});
+
 		frm.add_custom_button(
 			__("Add Leads"),
 			function () {
@@ -39,7 +50,8 @@ frappe.ui.form.on("Event", {
 		frm.add_custom_button(
 			__("Add Employees"),
 			function () {
-				new frappe.desk.eventParticipants(frm, "Employee");
+				// Custom employee selection that bypasses permissions
+				frm.trigger("add_employees_as_participants");
 			},
 			__("Add Participants")
 		);
@@ -51,5 +63,51 @@ frappe.ui.form.on("Event", {
 			},
 			__("Add Participants")
 		);
+	},
+
+	add_employees_as_participants: function (frm) {
+		// Custom method to add employees as participants
+		frappe.call({
+			method: "erpnext.setup.doctype.employee.employee.get_employees_for_event_participants",
+			args: {
+				doctype: "Employee",
+				txt: "",
+				searchfield: "name",
+				start: 0,
+				page_len: 50,
+				filters: {},
+			},
+			callback: function (r) {
+				if (r.message) {
+					let options = r.message.map(function (emp) {
+						return {
+							label: emp[1],
+							value: emp[0],
+						};
+					});
+
+					frappe.prompt(
+						{
+							fieldtype: "Select",
+							label: __("Select Employee"),
+							fieldname: "employee",
+							options: options,
+							reqd: 1,
+						},
+						function (data) {
+							if (data.employee) {
+								frm.add_child("event_participants", {
+									reference_doctype: "Employee",
+									reference_docname: data.employee,
+								});
+								frm.refresh_field("event_participants");
+							}
+						},
+						__("Add Employee"),
+						__("Add")
+					);
+				}
+			},
+		});
 	},
 });


### PR DESCRIPTION
### Problem

- Team members with restricted User Permissions on the Employee doctype cannot add employees as participants in calendar events, preventing collaboration and event scheduling.

fix: #49056

### Solution
Added custom permission functions that bypass Employee read permissions specifically for event participants while maintaining security.

### Changes Made

**1. `erpnext/hooks.py`**
- Added custom permission hooks for Event and Event Participants doctypes

**2. `erpnext/setup/doctype/employee/employee.py`**
- `has_event_permission()`: Allows Event access with restricted Employee permissions
- `has_event_participant_permission()`: Allows adding employees as participants
- `get_employees_for_event_participants()`: Custom query bypassing User Permissions
- `add_employee_to_event()`: Direct method to add employees to events

**3. `erpnext/public/js/event.js`**
- Updated employee selection to use a custom permission-bypassing query
- Custom "Add Employees" button functionality

### Security
- Users still need Event permissions to create/edit events
- Only bypasses Employee read permissions for event participants
- Standard Employee permissions remain intact for other operations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced event management by allowing employees to be added as event participants, even if users have limited permissions on employee records.
  * Added a new workflow for selecting and adding employees to events, including a prompt with a selectable list of employees.

* **Bug Fixes**
  * Improved permission handling to ensure users with event access can manage employee participants without being restricted by employee record permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->