### PR TITLE
fix: update dunning status based on credit notes

### DIFF
--- a/erpnext/accounts/doctype/dunning/dunning.py
+++ b/erpnext/accounts/doctype/dunning/dunning.py
@@ -208,21 +208,12 @@ def resolve_dunning_for_credit_note(doc, state):
 	Check if dunning should be resolved when a credit note is issued against a Sales Invoice.
 	Only process if update_outstanding_for_self is False (credit note is being applied against the original invoice).
 	"""
-	if not doc.is_return or doc.get("update_outstanding_for_self"):
+	if not doc.is_return or doc.get("update_outstanding_for_self") or not doc.get("return_against"):
 		return
 
-	if not doc.get("return_against"):
-		return
+	state = "Resolved" if doc.docstatus == 2 else "Unresolved"
 
-	original_invoice = doc.return_against
-	if doc.docstatus == 1:
-		state = "Unresolved"
-	elif doc.docstatus == 2:
-		state = "Resolved"
-	else:
-		return
-
-	dunnings = get_linked_dunnings_as_per_state(original_invoice, state)
+	dunnings = get_linked_dunnings_as_per_state(doc.return_against, state)
 
 	for dunning in dunnings:
 		resolve = True

--- a/erpnext/accounts/doctype/dunning/test_dunning.py
+++ b/erpnext/accounts/doctype/dunning/test_dunning.py
@@ -139,7 +139,7 @@ class TestDunning(IntegrationTestCase):
 		self.assertEqual(sales_invoice.status, "Overdue")
 		self.assertEqual(dunning.status, "Unresolved")
 
-	def test_dunning_resolution_with_credit_note(self):
+	def test_dunning_resolution_from_credit_note(self):
 		"""
 		Test that dunning is resolved when a credit note is issued against the original invoice.
 		"""

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -200,9 +200,9 @@ class PaymentEntry(AccountsController):
 		if self.difference_amount:
 			frappe.throw(_("Difference Amount must be zero"))
 		self.update_payment_requests()
+		self.update_payment_schedule()
 		self.make_gl_entries()
 		self.update_outstanding_amounts()
-		self.update_payment_schedule()
 		self.set_status()
 
 	def validate_for_repost(self):
@@ -303,10 +303,10 @@ class PaymentEntry(AccountsController):
 		)
 		super().on_cancel()
 		self.update_payment_requests(cancel=True)
+		self.update_payment_schedule(cancel=1)
 		self.make_gl_entries(cancel=1)
 		self.update_outstanding_amounts()
 		self.delink_advance_entry_references()
-		self.update_payment_schedule(cancel=1)
 		self.set_status()
 
 	def update_payment_requests(self, cancel=False):

--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -1940,6 +1940,8 @@ def create_payment_ledger_entry(
 
 
 def update_voucher_outstanding(voucher_type, voucher_no, account, party_type, party):
+	from erpnext.accounts.doctype.dunning.dunning import update_linked_dunnings
+
 	if not voucher_type or not voucher_no:
 		return
 
@@ -1969,6 +1971,7 @@ def update_voucher_outstanding(voucher_type, voucher_no, account, party_type, pa
 
 	outstanding = voucher_outstanding[0]
 	ref_doc = frappe.get_lazy_doc(voucher_type, voucher_no)
+	previous_outstanding_amount = ref_doc.outstanding_amount
 	outstanding_amount = flt(
 		outstanding["outstanding_in_account_currency"], ref_doc.precision("outstanding_amount")
 	)
@@ -1982,6 +1985,7 @@ def update_voucher_outstanding(voucher_type, voucher_no, account, party_type, pa
 		outstanding_amount,
 	)
 
+	update_linked_dunnings(ref_doc, previous_outstanding_amount)
 	ref_doc.set_status(update=True)
 	ref_doc.notify_update()
 

--- a/erpnext/hooks.py
+++ b/erpnext/hooks.py
@@ -359,8 +359,12 @@ doc_events = {
 		"on_submit": [
 			"erpnext.regional.create_transaction_log",
 			"erpnext.regional.italy.utils.sales_invoice_on_submit",
+			"erpnext.accounts.doctype.dunning.dunning.resolve_dunning_for_credit_note",
 		],
-		"on_cancel": ["erpnext.regional.italy.utils.sales_invoice_on_cancel"],
+		"on_cancel": [
+			"erpnext.regional.italy.utils.sales_invoice_on_cancel",
+			"erpnext.accounts.doctype.dunning.dunning.resolve_dunning_for_credit_note",
+		],
 		"on_trash": "erpnext.regional.check_deletion_permission",
 	},
 	"Purchase Invoice": {

--- a/erpnext/hooks.py
+++ b/erpnext/hooks.py
@@ -359,11 +359,9 @@ doc_events = {
 		"on_submit": [
 			"erpnext.regional.create_transaction_log",
 			"erpnext.regional.italy.utils.sales_invoice_on_submit",
-			"erpnext.accounts.doctype.dunning.dunning.resolve_dunnings",
 		],
 		"on_cancel": [
 			"erpnext.regional.italy.utils.sales_invoice_on_cancel",
-			"erpnext.accounts.doctype.dunning.dunning.resolve_dunnings",
 		],
 		"on_trash": "erpnext.regional.check_deletion_permission",
 	},
@@ -376,9 +374,7 @@ doc_events = {
 	"Payment Entry": {
 		"on_submit": [
 			"erpnext.regional.create_transaction_log",
-			"erpnext.accounts.doctype.dunning.dunning.resolve_dunnings",
 		],
-		"on_cancel": ["erpnext.accounts.doctype.dunning.dunning.resolve_dunnings"],
 		"on_trash": "erpnext.regional.check_deletion_permission",
 	},
 	"Address": {

--- a/erpnext/hooks.py
+++ b/erpnext/hooks.py
@@ -359,11 +359,11 @@ doc_events = {
 		"on_submit": [
 			"erpnext.regional.create_transaction_log",
 			"erpnext.regional.italy.utils.sales_invoice_on_submit",
-			"erpnext.accounts.doctype.dunning.dunning.resolve_dunning_for_credit_note",
+			"erpnext.accounts.doctype.dunning.dunning.resolve_dunnings",
 		],
 		"on_cancel": [
 			"erpnext.regional.italy.utils.sales_invoice_on_cancel",
-			"erpnext.accounts.doctype.dunning.dunning.resolve_dunning_for_credit_note",
+			"erpnext.accounts.doctype.dunning.dunning.resolve_dunnings",
 		],
 		"on_trash": "erpnext.regional.check_deletion_permission",
 	},
@@ -376,9 +376,9 @@ doc_events = {
 	"Payment Entry": {
 		"on_submit": [
 			"erpnext.regional.create_transaction_log",
-			"erpnext.accounts.doctype.dunning.dunning.resolve_dunning",
+			"erpnext.accounts.doctype.dunning.dunning.resolve_dunnings",
 		],
-		"on_cancel": ["erpnext.accounts.doctype.dunning.dunning.resolve_dunning"],
+		"on_cancel": ["erpnext.accounts.doctype.dunning.dunning.resolve_dunnings"],
 		"on_trash": "erpnext.regional.check_deletion_permission",
 	},
 	"Address": {

--- a/erpnext/stock/doctype/inventory_dimension/test_inventory_dimension.py
+++ b/erpnext/stock/doctype/inventory_dimension/test_inventory_dimension.py
@@ -667,13 +667,13 @@ def prepare_data_for_internal_transfer():
 	company = "_Test Company with perpetual inventory"
 
 	customer = create_internal_customer(
-		"_Test Internal Customer 3",
+		"_Test Internal Customer 2",
 		company,
 		company,
 	)
 
 	supplier = create_internal_supplier(
-		"_Test Internal Supplier 3",
+		"_Test Internal Supplier 2",
 		company,
 		company,
 	)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Dunning status now auto-updates when an invoice's outstanding amount changes (payments, invoice submit/cancel, and invoice-linked credit notes).

- Bug Fixes
  - More accurate dunning resolution by aggregating outstanding amounts across linked documents and avoiding redundant status updates.
  - Consistent status transitions on cancellation; no change persisted if status remains the same.

- Tests
  - Added tests for invoice-linked vs. standalone credit note interactions, including submit and cancel flows.

- Chores
  - Adjusted payment schedule update timing to ensure consistent posting/order during submit/cancel.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->