### PR TITLE
fix(job-card): Add filter to item_code query for scrap_items to exclude disabled

### DIFF
--- a/erpnext/manufacturing/doctype/job_card/job_card.js
+++ b/erpnext/manufacturing/doctype/job_card/job_card.js
@@ -23,6 +23,14 @@ frappe.ui.form.on("Job Card", {
 			};
 		});
 
+		frm.set_query("item_code", "scrap_items", () => {
+			return {
+				filters: {
+					disabled: 0,
+				},
+			};
+		});
+
 		frm.events.set_company_filters(frm, "source_warehouse");
 		frm.events.set_company_filters(frm, "wip_warehouse");
 		frm.set_query("source_warehouse", "items", () => {


### PR DESCRIPTION
Fixes: #49063 
Backport: version-15

---

https://github.com/user-attachments/assets/c91b4fd3-c7a7-4a9f-bf2d-29d8c059db9d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a filter to the "item_code" field in the scrap items section of the Job Card form, ensuring only active items can be selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->