### PR TITLE
fix(bom): validate process loss percentage to prevent negative values

### DIFF
--- a/erpnext/manufacturing/doctype/bom/bom.py
+++ b/erpnext/manufacturing/doctype/bom/bom.py
@@ -1079,7 +1079,7 @@ class BOM(WebsiteGenerator):
 		return BOMTree(self.name)
 
 	def set_process_loss_qty(self):
-		if self.process_loss_percentage < 0:
+		if flt(self.process_loss_percentage) < 0:
 			frappe.throw(_("Process Loss Percentage cannot be negative"))
 
 		if self.process_loss_percentage:

--- a/erpnext/manufacturing/doctype/bom/bom.py
+++ b/erpnext/manufacturing/doctype/bom/bom.py
@@ -1079,6 +1079,9 @@ class BOM(WebsiteGenerator):
 		return BOMTree(self.name)
 
 	def set_process_loss_qty(self):
+		if self.process_loss_percentage < 0:
+			frappe.throw(_("Process Loss Percentage cannot be negative"))
+
 		if self.process_loss_percentage:
 			self.process_loss_qty = flt(self.quantity) * flt(self.process_loss_percentage) / 100
 


### PR DESCRIPTION
Fixes: #48521 
Backport: version-15

---
https://github.com/user-attachments/assets/a8460d51-a8fb-4d57-b466-921c8b685a91




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to prevent negative values for process loss percentage in BOM. An error will be shown if a negative value is entered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->