### PR TITLE
feat: add item_name column to Material Request dialog in Purchase Order

### DIFF
--- a/erpnext/buying/doctype/purchase_order/purchase_order.js
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.js
@@ -606,7 +606,7 @@ erpnext.buying.PurchaseOrderController = class PurchaseOrderController extends (
 					},
 					allow_child_item_selection: true,
 					child_fieldname: "items",
-					child_columns: ["item_code", "qty", "ordered_qty"],
+					child_columns: ["item_code", "item_name", "qty", "ordered_qty"],
 				});
 			},
 			__("Get Items From")


### PR DESCRIPTION
Added **item_name** to child_columns in **Get Items From > Material Request** selection dialog in **PO** to improve UX as each time the end user has to check the item code in item master for its item name

**Backport Needed: Version-15**

**Before change:**

<img width="1912" height="1013" alt="Screenshot 2025-08-09 at 12 43 23 AM" src="https://github.com/user-attachments/assets/8749a6ca-56af-4faf-9cdd-544f40826d4c" />

**After change:**

<img width="1914" height="1007" alt="Screenshot 2025-08-09 at 12 54 10 AM" src="https://github.com/user-attachments/assets/c3639ac7-78dd-4f3c-ae64-576daada66e6" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Item Name" as a visible column in the item selection dialog when mapping items from a Material Request to a Purchase Order, making it easier to identify items during selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->