### PR TITLE
fix: add validation for draft PR/PI in Asset

### DIFF
--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -120,13 +120,13 @@ class Asset(AccountsController):
 	def validate(self):
 		self.validate_category()
 		self.validate_precision()
+		self.validate_linked_purchase_docs()
 		self.set_purchase_doc_row_item()
 		self.validate_asset_values()
 		self.validate_asset_and_reference()
 		self.validate_item()
 		self.validate_cost_center()
 		self.set_missing_values()
-		self.validate_linked_purchase_docs()
 		self.validate_gross_and_purchase_amount()
 		self.validate_finance_books()
 		self.total_asset_cost = self.gross_purchase_amount + self.additional_asset_cost


### PR DESCRIPTION
closes #49074

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Assets now enforce that any linked purchase receipt or invoice must be submitted before the asset can be saved.
  * When a linked purchase document is still a draft, users are prompted to submit it before saving the asset, preventing incomplete linkage and ensuring data consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->