### PR TITLE
fix: modify all remaining SRE queries to consider new Closed status

### DIFF
--- a/erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py
+++ b/erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py
@@ -1425,7 +1425,7 @@ class StockReservation:
 			)
 			.where(
 				(sre.docstatus == 1)
-				& (sre.status.notin(["Delivered", "Cancelled", "Draft", "Closed"]))
+				& (sre.delivered_qty < sre.reserved_qty)
 				& (sre.voucher_type == doctype)
 				& (sre.voucher_no.isin(docnames))
 			)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Stock reservations now rely on remaining quantities instead of status, ensuring partially delivered items correctly keep outstanding reservations.
  * Prevents premature release or unintended retention of reservations for delivered or cancelled items.
  * Improves accuracy of stock availability shown during submission of sales-related documents.
  * Reduces edge cases where reservations appeared closed despite pending quantities, leading to more reliable delivery planning and fulfillment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->