### PR TITLE
refactor: rename and patch gross purchase amount field

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
@@ -1229,7 +1229,7 @@ class PurchaseInvoice(BuyingController):
 						)
 
 			if item.is_fixed_asset and item.landed_cost_voucher_amount:
-				self.update_gross_purchase_amount_for_linked_assets(item)
+				self.update_net_purchase_amount_for_linked_assets(item)
 
 	def get_provisional_accounts(self):
 		self.provisional_accounts = frappe._dict()
@@ -1291,7 +1291,7 @@ class PurchaseInvoice(BuyingController):
 					),
 				)
 
-	def update_gross_purchase_amount_for_linked_assets(self, item):
+	def update_net_purchase_amount_for_linked_assets(self, item):
 		assets = frappe.db.get_all(
 			"Asset",
 			filters={
@@ -1307,7 +1307,7 @@ class PurchaseInvoice(BuyingController):
 				"Asset",
 				asset.name,
 				{
-					"gross_purchase_amount": purchase_amount,
+					"net_purchase_amount": purchase_amount,
 					"purchase_amount": purchase_amount,
 				},
 			)

--- a/erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.py
+++ b/erpnext/accounts/report/asset_depreciation_ledger/asset_depreciation_ledger.py
@@ -103,7 +103,7 @@ def get_data(filters):
 					"depreciation_amount": d.debit,
 					"depreciation_date": d.posting_date,
 					"value_after_depreciation": (
-						flt(row.gross_purchase_amount) - flt(row.accumulated_depreciation_amount)
+						flt(row.net_purchase_amount) - flt(row.accumulated_depreciation_amount)
 					),
 					"depreciation_entry": d.voucher_no,
 				}
@@ -119,7 +119,7 @@ def get_assets_details(assets):
 
 	fields = [
 		"name as asset",
-		"gross_purchase_amount",
+		"net_purchase_amount",
 		"opening_accumulated_depreciation",
 		"asset_category",
 		"status",
@@ -151,7 +151,7 @@ def get_columns():
 		},
 		{
 			"label": _("Purchase Amount"),
-			"fieldname": "gross_purchase_amount",
+			"fieldname": "net_purchase_amount",
 			"fieldtype": "Currency",
 			"width": 120,
 		},

--- a/erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py
+++ b/erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py
@@ -87,7 +87,7 @@ def get_asset_categories_for_grouped_by_category(filters):
 		SELECT a.asset_category,
 			   ifnull(sum(case when a.purchase_date < %(from_date)s then
 							   case when ifnull(a.disposal_date, 0) = 0 or a.disposal_date >= %(from_date)s then
-									a.gross_purchase_amount
+									a.net_purchase_amount
 							   else
 									0
 							   end
@@ -95,7 +95,7 @@ def get_asset_categories_for_grouped_by_category(filters):
 								0
 						   end), 0) as value_as_on_from_date,
 			   ifnull(sum(case when a.purchase_date >= %(from_date)s then
-			   						a.gross_purchase_amount
+			   						a.net_purchase_amount
 			   				   else
 			   				   		0
 			   				   end), 0) as value_of_new_purchase,
@@ -103,7 +103,7 @@ def get_asset_categories_for_grouped_by_category(filters):
 			   						and a.disposal_date >= %(from_date)s
 			   						and a.disposal_date <= %(to_date)s then
 							   case when a.status = "Sold" then
-							   		a.gross_purchase_amount
+							   		a.net_purchase_amount
 							   else
 							   		0
 							   end
@@ -114,7 +114,7 @@ def get_asset_categories_for_grouped_by_category(filters):
 			   						and a.disposal_date >= %(from_date)s
 			   						and a.disposal_date <= %(to_date)s then
 							   case when a.status = "Scrapped" then
-							   		a.gross_purchase_amount
+							   		a.net_purchase_amount
 							   else
 							   		0
 							   end
@@ -125,7 +125,7 @@ def get_asset_categories_for_grouped_by_category(filters):
 			   						and a.disposal_date >= %(from_date)s
 			   						and a.disposal_date <= %(to_date)s then
 							   case when a.status = "Capitalized" then
-							   		a.gross_purchase_amount
+							   		a.net_purchase_amount
 							   else
 							   		0
 							   end
@@ -357,7 +357,7 @@ def get_asset_details_for_grouped_by_category(filters):
 		SELECT a.name,
 			   ifnull(sum(case when a.purchase_date < %(from_date)s then
 							   case when ifnull(a.disposal_date, 0) = 0 or a.disposal_date >= %(from_date)s then
-									a.gross_purchase_amount
+									a.net_purchase_amount
 							   else
 									0
 							   end
@@ -365,7 +365,7 @@ def get_asset_details_for_grouped_by_category(filters):
 								0
 						   end), 0) as value_as_on_from_date,
 			   ifnull(sum(case when a.purchase_date >= %(from_date)s then
-			   						a.gross_purchase_amount
+			   						a.net_purchase_amount
 			   				   else
 			   				   		0
 			   				   end), 0) as value_of_new_purchase,
@@ -373,7 +373,7 @@ def get_asset_details_for_grouped_by_category(filters):
 			   						and a.disposal_date >= %(from_date)s
 			   						and a.disposal_date <= %(to_date)s then
 							   case when a.status = "Sold" then
-							   		a.gross_purchase_amount
+							   		a.net_purchase_amount
 							   else
 							   		0
 							   end
@@ -384,7 +384,7 @@ def get_asset_details_for_grouped_by_category(filters):
 			   						and a.disposal_date >= %(from_date)s
 			   						and a.disposal_date <= %(to_date)s then
 							   case when a.status = "Scrapped" then
-							   		a.gross_purchase_amount
+							   		a.net_purchase_amount
 							   else
 							   		0
 							   end
@@ -395,7 +395,7 @@ def get_asset_details_for_grouped_by_category(filters):
 			   						and a.disposal_date >= %(from_date)s
 			   						and a.disposal_date <= %(to_date)s then
 							   case when a.status = "Capitalized" then
-							   		a.gross_purchase_amount
+							   		a.net_purchase_amount
 							   else
 							   		0
 							   end

--- a/erpnext/assets/doctype/asset/asset.js
+++ b/erpnext/assets/doctype/asset/asset.js
@@ -340,7 +340,7 @@ frappe.ui.form.on("Asset", {
 		}
 
 		var x_intervals = [frappe.format(frm.doc.purchase_date, { fieldtype: "Date" })];
-		var asset_values = [frm.doc.gross_purchase_amount];
+		var asset_values = [frm.doc.net_purchase_amount];
 
 		if (frm.doc.calculate_depreciation) {
 			if (frm.doc.opening_accumulated_depreciation) {
@@ -351,8 +351,8 @@ frappe.ui.form.on("Asset", {
 				x_intervals.push(frappe.format(depreciation_date, { fieldtype: "Date" }));
 				asset_values.push(
 					flt(
-						frm.doc.gross_purchase_amount - frm.doc.opening_accumulated_depreciation,
-						precision("gross_purchase_amount")
+						frm.doc.net_purchase_amount - frm.doc.opening_accumulated_depreciation,
+						precision("net_purchase_amount")
 					)
 				);
 			}
@@ -371,8 +371,8 @@ frappe.ui.form.on("Asset", {
 			$.each(asset_depr_schedule_doc.depreciation_schedule || [], function (i, v) {
 				x_intervals.push(frappe.format(v.schedule_date, { fieldtype: "Date" }));
 				var asset_value = flt(
-					frm.doc.gross_purchase_amount - v.accumulated_depreciation_amount,
-					precision("gross_purchase_amount")
+					frm.doc.net_purchase_amount - v.accumulated_depreciation_amount,
+					precision("net_purchase_amount")
 				);
 				if (v.journal_entry) {
 					asset_values.push(asset_value);
@@ -392,8 +392,8 @@ frappe.ui.form.on("Asset", {
 				x_intervals.push(frappe.format(frm.doc.creation.split(" ")[0], { fieldtype: "Date" }));
 				asset_values.push(
 					flt(
-						frm.doc.gross_purchase_amount - frm.doc.opening_accumulated_depreciation,
-						precision("gross_purchase_amount")
+						frm.doc.net_purchase_amount - frm.doc.opening_accumulated_depreciation,
+						precision("net_purchase_amount")
 					)
 				);
 			}
@@ -408,7 +408,7 @@ frappe.ui.form.on("Asset", {
 			$.each(depr_entries || [], function (i, v) {
 				x_intervals.push(frappe.format(v.posting_date, { fieldtype: "Date" }));
 				let last_asset_value = asset_values[asset_values.length - 1];
-				asset_values.push(flt(last_asset_value - v.value, precision("gross_purchase_amount")));
+				asset_values.push(flt(last_asset_value - v.value, precision("net_purchase_amount")));
 			});
 		}
 
@@ -434,7 +434,7 @@ frappe.ui.form.on("Asset", {
 	},
 
 	item_code: function (frm) {
-		if (frm.doc.item_code && frm.doc.calculate_depreciation && frm.doc.gross_purchase_amount) {
+		if (frm.doc.item_code && frm.doc.calculate_depreciation && frm.doc.net_purchase_amount) {
 			frm.trigger("set_finance_book");
 		} else {
 			frm.set_value("finance_books", []);
@@ -447,7 +447,7 @@ frappe.ui.form.on("Asset", {
 			args: {
 				item_code: frm.doc.item_code,
 				asset_category: frm.doc.asset_category,
-				gross_purchase_amount: frm.doc.gross_purchase_amount,
+				net_purchase_amount: frm.doc.net_purchase_amount,
 			},
 			callback: function (r, rt) {
 				if (r.message) {
@@ -463,10 +463,10 @@ frappe.ui.form.on("Asset", {
 
 	is_composite_asset: function (frm) {
 		if (frm.doc.is_composite_asset) {
-			frm.set_value("gross_purchase_amount", 0);
-			frm.set_df_property("gross_purchase_amount", "read_only", 1);
+			frm.set_value("net_purchase_amount", 0);
+			frm.set_df_property("net_purchase_amount", "read_only", 1);
 		} else {
-			frm.set_df_property("gross_purchase_amount", "read_only", 0);
+			frm.set_df_property("net_purchase_amount", "read_only", 0);
 		}
 
 		frm.trigger("toggle_reference_doc");
@@ -592,14 +592,14 @@ frappe.ui.form.on("Asset", {
 
 	calculate_depreciation: function (frm) {
 		frm.toggle_reqd("finance_books", frm.doc.calculate_depreciation);
-		if (frm.doc.item_code && frm.doc.calculate_depreciation && frm.doc.gross_purchase_amount) {
+		if (frm.doc.item_code && frm.doc.calculate_depreciation && frm.doc.net_purchase_amount) {
 			frm.trigger("set_finance_book");
 		} else {
 			frm.set_value("finance_books", []);
 		}
 	},
 
-	gross_purchase_amount: function (frm) {
+	net_purchase_amount: function (frm) {
 		if (frm.doc.finance_books) {
 			frm.doc.finance_books.forEach((d) => {
 				frm.events.set_depreciation_rate(frm, d);
@@ -650,8 +650,8 @@ frappe.ui.form.on("Asset", {
 					let data = r.message;
 					frm.set_value("company", data.company);
 					frm.set_value("purchase_date", data.purchase_date);
-					frm.set_value("gross_purchase_amount", data.gross_purchase_amount);
-					frm.set_value("purchase_amount", data.gross_purchase_amount);
+					frm.set_value("net_purchase_amount", data.net_purchase_amount);
+					frm.set_value("purchase_amount", data.net_purchase_amount);
 					frm.set_value("asset_quantity", data.asset_quantity);
 					frm.set_value("cost_center", data.cost_center);
 					if (data.asset_location) {
@@ -702,7 +702,7 @@ frappe.ui.form.on("Asset", {
 		if (expected_value_after_useful_life_changed) {
 			frappe.flags.from_set_salvage_value_percentage_or_expected_value_after_useful_life = true;
 			const new_salvage_value_percentage = flt(
-				(row.expected_value_after_useful_life * 100) / frm.doc.gross_purchase_amount,
+				(row.expected_value_after_useful_life * 100) / frm.doc.net_purchase_amount,
 				precision("salvage_value_percentage", row)
 			);
 			frappe.model.set_value(
@@ -715,8 +715,8 @@ frappe.ui.form.on("Asset", {
 		} else if (salvage_value_percentage_changed) {
 			frappe.flags.from_set_salvage_value_percentage_or_expected_value_after_useful_life = true;
 			const new_expected_value_after_useful_life = flt(
-				frm.doc.gross_purchase_amount * (row.salvage_value_percentage / 100),
-				precision("gross_purchase_amount")
+				frm.doc.net_purchase_amount * (row.salvage_value_percentage / 100),
+				precision("net_purchase_amount")
 			);
 			frappe.model.set_value(
 				row.doctype,

--- a/erpnext/assets/doctype/asset/asset.json
+++ b/erpnext/assets/doctype/asset/asset.json
@@ -31,7 +31,7 @@
   "purchase_date",
   "available_for_use_date",
   "column_break_23",
-  "gross_purchase_amount",
+  "net_purchase_amount",
   "purchase_amount",
   "asset_quantity",
   "additional_asset_cost",
@@ -225,13 +225,6 @@
    "options": "Journal Entry",
    "print_hide": 1,
    "read_only": 1
-  },
-  {
-   "fieldname": "gross_purchase_amount",
-   "fieldtype": "Currency",
-   "label": "Net Purchase Amount",
-   "mandatory_depends_on": "eval:(!doc.is_composite_asset || doc.docstatus==1)",
-   "options": "Company:company:default_currency"
   },
   {
    "fieldname": "available_for_use_date",
@@ -558,6 +551,13 @@
    "fieldname": "is_composite_component",
    "fieldtype": "Check",
    "label": "Is Composite Component"
+  },
+  {
+   "fieldname": "net_purchase_amount",
+   "fieldtype": "Currency",
+   "label": "Net Purchase Amount",
+   "mandatory_depends_on": "eval:(!doc.is_composite_asset || doc.docstatus==1)",
+   "options": "Company:company:default_currency"
   }
  ],
  "idx": 72,
@@ -601,7 +601,7 @@
    "link_fieldname": "target_asset"
   }
  ],
- "modified": "2025-05-20 13:44:06.229177",
+ "modified": "2025-05-23 00:53:54.249309",
  "modified_by": "Administrator",
  "module": "Assets",
  "name": "Asset",

--- a/erpnext/assets/doctype/asset/asset.json
+++ b/erpnext/assets/doctype/asset/asset.json
@@ -237,7 +237,7 @@
    "fieldname": "calculate_depreciation",
    "fieldtype": "Check",
    "label": "Calculate Depreciation",
-   "read_only_depends_on": "eval:(doc.is_composite_asset && !doc.gross_purchase_amount) || doc.is_composite_component"
+   "read_only_depends_on": "eval:(doc.is_composite_asset && !doc.net_purchase_amount) || doc.is_composite_component"
   },
   {
    "default": "0",

--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -70,7 +70,6 @@ class Asset(AccountsController):
 		disposal_date: DF.Date | None
 		finance_books: DF.Table[AssetFinanceBook]
 		frequency_of_depreciation: DF.Int
-		gross_purchase_amount: DF.Currency
 		image: DF.AttachImage | None
 		insurance_end_date: DF.Date | None
 		insurance_start_date: DF.Date | None
@@ -86,6 +85,7 @@ class Asset(AccountsController):
 		location: DF.Link
 		maintenance_required: DF.Check
 		naming_series: DF.Literal["ACC-ASS-.YYYY.-"]
+		net_purchase_amount: DF.Currency
 		next_depreciation_date: DF.Date | None
 		opening_accumulated_depreciation: DF.Currency
 		opening_number_of_booked_depreciations: DF.Int

--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -129,7 +129,7 @@ class Asset(AccountsController):
 		self.set_missing_values()
 		self.validate_gross_and_purchase_amount()
 		self.validate_finance_books()
-		self.total_asset_cost = self.gross_purchase_amount + self.additional_asset_cost
+		self.total_asset_cost = self.net_purchase_amount + self.additional_asset_cost
 		self.status = self.get_status()
 
 	def create_asset_depreciation_schedule(self):
@@ -159,7 +159,7 @@ class Asset(AccountsController):
 			return
 
 		self.value_after_depreciation = (
-			flt(self.gross_purchase_amount)
+			flt(self.net_purchase_amount)
 			- flt(self.opening_accumulated_depreciation)
 			+ flt(self.additional_asset_cost)
 		)
@@ -224,7 +224,7 @@ class Asset(AccountsController):
 		if self.is_existing_asset or self.is_composite_asset:
 			return
 
-		self.purchase_amount = self.gross_purchase_amount
+		self.purchase_amount = self.net_purchase_amount
 		purchase_doc_type = "Purchase Receipt" if self.purchase_receipt else "Purchase Invoice"
 		purchase_doc = self.purchase_receipt or self.purchase_invoice
 
@@ -244,12 +244,12 @@ class Asset(AccountsController):
 
 		for item in purchase_doc.items:
 			if self.asset_quantity > 1:
-				if item.base_net_amount == self.gross_purchase_amount and item.qty == self.asset_quantity:
+				if item.base_net_amount == self.net_purchase_amount and item.qty == self.asset_quantity:
 					return item.name
 				elif item.qty == self.asset_quantity:
 					return item.name
 			else:
-				if item.base_net_rate == self.gross_purchase_amount and item.qty == self.asset_quantity:
+				if item.base_net_rate == self.net_purchase_amount and item.qty == self.asset_quantity:
 					return item.name
 
 	def validate_asset_and_reference(self):
@@ -327,7 +327,7 @@ class Asset(AccountsController):
 			self.asset_category = frappe.get_cached_value("Item", self.item_code, "asset_category")
 
 		if self.item_code and not self.get("finance_books"):
-			finance_books = get_item_details(self.item_code, self.asset_category, self.gross_purchase_amount)
+			finance_books = get_item_details(self.item_code, self.asset_category, self.net_purchase_amount)
 			self.set("finance_books", finance_books)
 
 		if self.asset_owner == "Company" and not self.asset_owner_company:
@@ -366,10 +366,8 @@ class Asset(AccountsController):
 			)
 
 	def validate_precision(self):
-		if self.gross_purchase_amount:
-			self.gross_purchase_amount = flt(
-				self.gross_purchase_amount, self.precision("gross_purchase_amount")
-			)
+		if self.net_purchase_amount:
+			self.net_purchase_amount = flt(self.net_purchase_amount, self.precision("net_purchase_amount"))
 
 		if self.opening_accumulated_depreciation:
 			self.opening_accumulated_depreciation = flt(
@@ -380,7 +378,7 @@ class Asset(AccountsController):
 		if not self.asset_category:
 			self.asset_category = frappe.get_cached_value("Item", self.item_code, "asset_category")
 
-		if not flt(self.gross_purchase_amount) and not self.is_composite_asset:
+		if not flt(self.net_purchase_amount) and not self.is_composite_asset:
 			frappe.throw(_("Gross Purchase Amount is mandatory"), frappe.MandatoryError)
 
 		if is_cwip_accounting_enabled(self.asset_category):
@@ -440,7 +438,7 @@ class Asset(AccountsController):
 		if self.is_existing_asset:
 			return
 
-		if self.gross_purchase_amount and self.gross_purchase_amount != self.purchase_amount:
+		if self.net_purchase_amount and self.net_purchase_amount != self.purchase_amount:
 			error_message = _(
 				"Gross Purchase Amount should be <b>equal</b> to purchase amount of one single Asset."
 			)
@@ -486,9 +484,9 @@ class Asset(AccountsController):
 
 	def validate_asset_finance_books(self, row):
 		row.expected_value_after_useful_life = flt(
-			row.expected_value_after_useful_life, self.precision("gross_purchase_amount")
+			row.expected_value_after_useful_life, self.precision("net_purchase_amount")
 		)
-		if flt(row.expected_value_after_useful_life) >= flt(self.gross_purchase_amount):
+		if flt(row.expected_value_after_useful_life) >= flt(self.net_purchase_amount):
 			frappe.throw(
 				_("Row {0}: Expected Value After Useful Life must be less than Gross Purchase Amount").format(
 					row.idx
@@ -507,11 +505,11 @@ class Asset(AccountsController):
 
 	def validate_opening_depreciation_values(self, row):
 		row.expected_value_after_useful_life = flt(
-			row.expected_value_after_useful_life, self.precision("gross_purchase_amount")
+			row.expected_value_after_useful_life, self.precision("net_purchase_amount")
 		)
 		depreciable_amount = flt(
-			flt(self.gross_purchase_amount) - flt(row.expected_value_after_useful_life),
-			self.precision("gross_purchase_amount"),
+			flt(self.net_purchase_amount) - flt(row.expected_value_after_useful_life),
+			self.precision("net_purchase_amount"),
 		)
 		if flt(self.opening_accumulated_depreciation) > depreciable_amount:
 			frappe.throw(
@@ -576,8 +574,8 @@ class Asset(AccountsController):
 
 			if accumulated_depreciation_after_full_schedule:
 				asset_value_after_full_schedule = flt(
-					flt(self.gross_purchase_amount) - flt(accumulated_depreciation_after_full_schedule),
-					self.precision("gross_purchase_amount"),
+					flt(self.net_purchase_amount) - flt(accumulated_depreciation_after_full_schedule),
+					self.precision("net_purchase_amount"),
 				)
 
 				if (
@@ -631,7 +629,7 @@ class Asset(AccountsController):
 
 			self.db_set(
 				"value_after_depreciation",
-				(flt(self.gross_purchase_amount) - flt(self.opening_accumulated_depreciation)),
+				(flt(self.net_purchase_amount) - flt(self.opening_accumulated_depreciation)),
 			)
 
 	def set_status(self, status=None):
@@ -668,7 +666,7 @@ class Asset(AccountsController):
 						or self.is_fully_depreciated
 					):
 						status = "Fully Depreciated"
-					elif flt(value_after_depreciation) < flt(self.gross_purchase_amount):
+					elif flt(value_after_depreciation) < flt(self.net_purchase_amount):
 						status = "Partially Depreciated"
 		elif self.docstatus == 2:
 			status = "Cancelled"
@@ -676,16 +674,16 @@ class Asset(AccountsController):
 
 	def get_value_after_depreciation(self, finance_book=None):
 		if not self.calculate_depreciation:
-			return flt(self.value_after_depreciation, self.precision("gross_purchase_amount"))
+			return flt(self.value_after_depreciation, self.precision("net_purchase_amount"))
 
 		if not finance_book:
 			return flt(
-				self.get("finance_books")[0].value_after_depreciation, self.precision("gross_purchase_amount")
+				self.get("finance_books")[0].value_after_depreciation, self.precision("net_purchase_amount")
 			)
 
 		for row in self.get("finance_books"):
 			if finance_book == row.finance_book:
-				return flt(row.value_after_depreciation, self.precision("gross_purchase_amount"))
+				return flt(row.value_after_depreciation, self.precision("net_purchase_amount"))
 
 	def get_default_finance_book_idx(self):
 		if not self.get("default_finance_book") and self.company:
@@ -889,7 +887,7 @@ class Asset(AccountsController):
 		if flt(args.get("value_after_depreciation")):
 			current_asset_value = flt(args.get("value_after_depreciation"))
 		else:
-			current_asset_value = flt(self.gross_purchase_amount) - flt(self.opening_accumulated_depreciation)
+			current_asset_value = flt(self.net_purchase_amount) - flt(self.opening_accumulated_depreciation)
 
 		value = flt(args.get("expected_value_after_useful_life")) / current_asset_value
 
@@ -1058,7 +1056,7 @@ def transfer_asset(args):
 
 
 @frappe.whitelist()
-def get_item_details(item_code, asset_category, gross_purchase_amount):
+def get_item_details(item_code, asset_category, net_purchase_amount):
 	asset_category_doc = frappe.get_cached_doc("Asset Category", asset_category)
 	books = []
 	for d in asset_category_doc.finance_books:
@@ -1071,7 +1069,7 @@ def get_item_details(item_code, asset_category, gross_purchase_amount):
 				"daily_prorata_based": d.daily_prorata_based,
 				"shift_based": d.shift_based,
 				"salvage_value_percentage": d.salvage_value_percentage,
-				"expected_value_after_useful_life": flt(gross_purchase_amount)
+				"expected_value_after_useful_life": flt(net_purchase_amount)
 				* flt(d.salvage_value_percentage / 100),
 				"depreciation_start_date": d.depreciation_start_date or nowdate(),
 				"rate_of_depreciation": d.rate_of_depreciation,
@@ -1211,7 +1209,7 @@ def get_values_from_purchase_doc(purchase_doc_name, item_code, doctype):
 	return {
 		"company": purchase_doc.company,
 		"purchase_date": purchase_doc.get("bill_date") or purchase_doc.get("posting_date"),
-		"gross_purchase_amount": flt(first_item.base_net_amount),
+		"net_purchase_amount": flt(first_item.base_net_amount),
 		"asset_quantity": first_item.qty,
 		"cost_center": first_item.cost_center or purchase_doc.get("cost_center"),
 		"asset_location": first_item.get("asset_location"),
@@ -1266,10 +1264,10 @@ def process_asset_split(existing_asset, split_qty, splitted_asset=None, is_new_a
 
 
 def set_split_asset_values(asset_doc, scaling_factor, split_qty, existing_asset, is_new_asset):
-	asset_doc.gross_purchase_amount = existing_asset.gross_purchase_amount * scaling_factor
-	asset_doc.purchase_amount = existing_asset.gross_purchase_amount
+	asset_doc.net_purchase_amount = existing_asset.net_purchase_amount * scaling_factor
+	asset_doc.purchase_amount = existing_asset.net_purchase_amount
 	asset_doc.additional_asset_cost = existing_asset.additional_asset_cost * scaling_factor
-	asset_doc.total_asset_cost = asset_doc.gross_purchase_amount + asset_doc.additional_asset_cost
+	asset_doc.total_asset_cost = asset_doc.net_purchase_amount + asset_doc.additional_asset_cost
 	asset_doc.opening_accumulated_depreciation = (
 		existing_asset.opening_accumulated_depreciation * scaling_factor
 	)

--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -379,7 +379,7 @@ class Asset(AccountsController):
 			self.asset_category = frappe.get_cached_value("Item", self.item_code, "asset_category")
 
 		if not flt(self.net_purchase_amount) and not self.is_composite_asset:
-			frappe.throw(_("Gross Purchase Amount is mandatory"), frappe.MandatoryError)
+			frappe.throw(_("Net Purchase Amount is mandatory"), frappe.MandatoryError)
 
 		if is_cwip_accounting_enabled(self.asset_category):
 			if (
@@ -440,11 +440,11 @@ class Asset(AccountsController):
 
 		if self.net_purchase_amount and self.net_purchase_amount != self.purchase_amount:
 			error_message = _(
-				"Gross Purchase Amount should be <b>equal</b> to purchase amount of one single Asset."
+				"Net Purchase Amount should be <b>equal</b> to purchase amount of one single Asset."
 			)
 			error_message += "<br>"
 			error_message += _("Please do not book expense of multiple assets against one single Asset.")
-			frappe.throw(error_message, title=_("Invalid Gross Purchase Amount"))
+			frappe.throw(error_message, title=_("Invalid Net Purchase Amount"))
 
 	def make_asset_movement(self):
 		reference_doctype = "Purchase Receipt" if self.purchase_receipt else "Purchase Invoice"
@@ -488,7 +488,7 @@ class Asset(AccountsController):
 		)
 		if flt(row.expected_value_after_useful_life) >= flt(self.net_purchase_amount):
 			frappe.throw(
-				_("Row {0}: Expected Value After Useful Life must be less than Gross Purchase Amount").format(
+				_("Row {0}: Expected Value After Useful Life must be less than Net Purchase Amount").format(
 					row.idx
 				)
 			)

--- a/erpnext/assets/doctype/asset/depreciation.py
+++ b/erpnext/assets/doctype/asset/depreciation.py
@@ -589,8 +589,8 @@ def get_gl_entries_on_asset_regain(
 		asset.get_gl_dict(
 			{
 				"account": fixed_asset_account,
-				"debit_in_account_currency": asset.gross_purchase_amount,
-				"debit": asset.gross_purchase_amount,
+				"debit_in_account_currency": asset.net_purchase_amount,
+				"debit": asset.net_purchase_amount,
 				"cost_center": depreciation_cost_center,
 				"posting_date": date,
 			},
@@ -642,8 +642,8 @@ def get_gl_entries_on_asset_disposal(
 		asset.get_gl_dict(
 			{
 				"account": fixed_asset_account,
-				"credit_in_account_currency": asset.gross_purchase_amount,
-				"credit": asset.gross_purchase_amount,
+				"credit_in_account_currency": asset.net_purchase_amount,
+				"credit": asset.net_purchase_amount,
 				"cost_center": depreciation_cost_center,
 				"posting_date": date,
 			},
@@ -681,7 +681,7 @@ def get_gl_entries_on_asset_disposal(
 
 def get_asset_details(asset, finance_book=None):
 	value_after_depreciation = asset.get_value_after_depreciation(finance_book)
-	accumulated_depr_amount = flt(asset.gross_purchase_amount) - flt(value_after_depreciation)
+	accumulated_depr_amount = flt(asset.net_purchase_amount) - flt(value_after_depreciation)
 
 	fixed_asset_account, accumulated_depr_account, _ = get_depreciation_accounts(
 		asset.asset_category, asset.company
@@ -792,7 +792,7 @@ def get_value_after_depreciation_on_disposal_date(asset, disposal_date, finance_
 	validate_disposal_date(asset_doc.available_for_use_date, getdate(disposal_date), "available for use")
 
 	if asset_doc.available_for_use_date == getdate(disposal_date):
-		return flt(asset_doc.gross_purchase_amount - asset_doc.opening_accumulated_depreciation)
+		return flt(asset_doc.net_purchase_amount - asset_doc.opening_accumulated_depreciation)
 
 	if not asset_doc.calculate_depreciation:
 		return flt(asset_doc.value_after_depreciation)
@@ -813,8 +813,8 @@ def get_value_after_depreciation_on_disposal_date(asset, disposal_date, finance_
 	].accumulated_depreciation_amount
 
 	return flt(
-		flt(asset_doc.gross_purchase_amount) - accumulated_depr_amount,
-		asset_doc.precision("gross_purchase_amount"),
+		flt(asset_doc.net_purchase_amount) - accumulated_depr_amount,
+		asset_doc.precision("net_purchase_amount"),
 	)
 
 

--- a/erpnext/assets/doctype/asset/test_asset.py
+++ b/erpnext/assets/doctype/asset/test_asset.py
@@ -64,9 +64,9 @@ class TestAsset(AssetSetup):
 
 		self.assertEqual(asset.asset_category, "Computers")
 
-	def test_gross_purchase_amount_is_mandatory(self):
+	def test_net_purchase_amount_is_mandatory(self):
 		asset = create_asset(item_code="Macbook Pro", do_not_save=1)
-		asset.gross_purchase_amount = 0
+		asset.net_purchase_amount = 0
 
 		self.assertRaises(frappe.MandatoryError, asset.save)
 
@@ -213,8 +213,8 @@ class TestAsset(AssetSetup):
 		asset.load_from_db()
 
 		accumulated_depr_amount = flt(
-			asset.gross_purchase_amount - asset.finance_books[0].value_after_depreciation,
-			asset.precision("gross_purchase_amount"),
+			asset.net_purchase_amount - asset.finance_books[0].value_after_depreciation,
+			asset.precision("net_purchase_amount"),
 		)
 		self.assertEqual(accumulated_depr_amount, 18000.0)
 
@@ -252,8 +252,8 @@ class TestAsset(AssetSetup):
 		self.assertEqual(first_asset_depr_schedule.status, "Cancelled")
 
 		accumulated_depr_amount = flt(
-			asset.gross_purchase_amount - asset.finance_books[0].value_after_depreciation,
-			asset.precision("gross_purchase_amount"),
+			asset.net_purchase_amount - asset.finance_books[0].value_after_depreciation,
+			asset.precision("net_purchase_amount"),
 		)
 
 		second_asset_depr_schedule.depreciation_amount = 9006.17
@@ -266,10 +266,10 @@ class TestAsset(AssetSetup):
 			date,
 			original_schedule_date=get_last_day(date),
 		)
-		pro_rata_amount = flt(pro_rata_amount, asset.precision("gross_purchase_amount"))
+		pro_rata_amount = flt(pro_rata_amount, asset.precision("net_purchase_amount"))
 		self.assertEqual(
 			accumulated_depr_amount,
-			flt(18000.0 + pro_rata_amount, asset.precision("gross_purchase_amount")),
+			flt(18000.0 + pro_rata_amount, asset.precision("net_purchase_amount")),
 		)
 
 		self.assertEqual(asset.status, "Scrapped")
@@ -278,13 +278,13 @@ class TestAsset(AssetSetup):
 		expected_gle = (
 			(
 				"_Test Accumulated Depreciations - _TC",
-				flt(18000.0 + pro_rata_amount, asset.precision("gross_purchase_amount")),
+				flt(18000.0 + pro_rata_amount, asset.precision("net_purchase_amount")),
 				0.0,
 			),
 			("_Test Fixed Asset - _TC", 0.0, 100000.0),
 			(
 				"_Test Gain/Loss on Asset Disposal - _TC",
-				flt(82000.0 - pro_rata_amount, asset.precision("gross_purchase_amount")),
+				flt(82000.0 - pro_rata_amount, asset.precision("net_purchase_amount")),
 				0.0,
 			),
 		)
@@ -304,8 +304,8 @@ class TestAsset(AssetSetup):
 		self.assertEqual(asset.status, "Partially Depreciated")
 
 		accumulated_depr_amount = flt(
-			asset.gross_purchase_amount - asset.finance_books[0].value_after_depreciation,
-			asset.precision("gross_purchase_amount"),
+			asset.net_purchase_amount - asset.finance_books[0].value_after_depreciation,
+			asset.precision("net_purchase_amount"),
 		)
 		this_month_depr_amount = 9000.0 if is_last_day_of_the_month(date) else 0
 
@@ -347,21 +347,21 @@ class TestAsset(AssetSetup):
 
 		asset.load_from_db()
 		accumulated_depr_amount = flt(
-			asset.gross_purchase_amount - asset.finance_books[0].value_after_depreciation,
-			asset.precision("gross_purchase_amount"),
+			asset.net_purchase_amount - asset.finance_books[0].value_after_depreciation,
+			asset.precision("net_purchase_amount"),
 		)
 		pro_rata_amount = flt(accumulated_depr_amount - 18000)
 
 		expected_gle = (
 			(
 				"_Test Accumulated Depreciations - _TC",
-				flt(accumulated_depr_amount, asset.precision("gross_purchase_amount")),
+				flt(accumulated_depr_amount, asset.precision("net_purchase_amount")),
 				0.0,
 			),
 			("_Test Fixed Asset - _TC", 0.0, 100000.0),
 			(
 				"_Test Gain/Loss on Asset Disposal - _TC",
-				flt(57000.0 - pro_rata_amount, asset.precision("gross_purchase_amount")),
+				flt(57000.0 - pro_rata_amount, asset.precision("net_purchase_amount")),
 				0.0,
 			),
 			("Debtors - _TC", 25000.0, 0.0),
@@ -385,7 +385,7 @@ class TestAsset(AssetSetup):
 			frequency_of_depreciation=12,
 			depreciation_start_date="2023-03-31",
 			opening_accumulated_depreciation=24000,
-			gross_purchase_amount=60000,
+			net_purchase_amount=60000,
 			submit=1,
 		)
 
@@ -483,7 +483,7 @@ class TestAsset(AssetSetup):
 			frequency_of_depreciation=12,
 			depreciation_start_date="2024-03-31",
 			opening_accumulated_depreciation=493.15,
-			gross_purchase_amount=12000,
+			net_purchase_amount=12000,
 			submit=1,
 		)
 
@@ -493,7 +493,7 @@ class TestAsset(AssetSetup):
 		post_depreciation_entries(date="2024-03-31")
 
 		self.assertEqual(asset.asset_quantity, 10)
-		self.assertEqual(asset.gross_purchase_amount, 12000)
+		self.assertEqual(asset.net_purchase_amount, 12000)
 		self.assertEqual(asset.opening_accumulated_depreciation, 493.15)
 
 		new_asset = split_asset(asset.name, 2)
@@ -510,14 +510,14 @@ class TestAsset(AssetSetup):
 		depr_schedule_of_new_asset = first_asset_depr_schedule_of_new_asset.get("depreciation_schedule")
 
 		self.assertEqual(new_asset.asset_quantity, 2)
-		self.assertEqual(new_asset.gross_purchase_amount, 2400)
+		self.assertEqual(new_asset.net_purchase_amount, 2400)
 		self.assertEqual(new_asset.opening_accumulated_depreciation, 98.63)
 		self.assertEqual(new_asset.split_from, asset.name)
 		self.assertEqual(depr_schedule_of_new_asset[0].depreciation_amount, 400)
 		self.assertEqual(depr_schedule_of_new_asset[1].depreciation_amount, 400)
 
 		self.assertEqual(asset.asset_quantity, 8)
-		self.assertEqual(asset.gross_purchase_amount, 9600)
+		self.assertEqual(asset.net_purchase_amount, 9600)
 		self.assertEqual(asset.opening_accumulated_depreciation, 394.52)
 		self.assertEqual(depr_schedule_of_asset[0].depreciation_amount, 1600)
 		self.assertEqual(depr_schedule_of_asset[1].depreciation_amount, 1600)
@@ -603,7 +603,7 @@ class TestAsset(AssetSetup):
 		asset_doc.available_for_use_date = (
 			nowdate() if nowdate() != month_end_date else add_days(nowdate(), -15)
 		)
-		self.assertEqual(asset_doc.gross_purchase_amount, 5250.0)
+		self.assertEqual(asset_doc.net_purchase_amount, 5250.0)
 
 		asset_doc.append(
 			"finance_books",
@@ -732,7 +732,7 @@ class TestDepreciationMethods(AssetSetup):
 			calculate_depreciation=1,
 			available_for_use_date="2023-01-01",
 			purchase_date="2023-01-01",
-			gross_purchase_amount=12000,
+			net_purchase_amount=12000,
 			depreciation_start_date="2023-01-31",
 			total_number_of_depreciations=12,
 			frequency_of_depreciation=1,
@@ -935,7 +935,7 @@ class TestDepreciationMethods(AssetSetup):
 			available_for_use_date="2022-02-15",
 			purchase_date="2022-02-15",
 			depreciation_method="Written Down Value",
-			gross_purchase_amount=10000,
+			net_purchase_amount=10000,
 			expected_value_after_useful_life=5000,
 			depreciation_start_date="2022-02-28",
 			total_number_of_depreciations=5,
@@ -1123,7 +1123,7 @@ class TestDepreciationBasics(AssetSetup):
 		self.assertTrue(depr_schedule_doc.has_pro_rata)
 
 	def test_expected_value_after_useful_life_greater_than_purchase_amount(self):
-		"""Tests if an error is raised when expected_value_after_useful_life(110,000) > gross_purchase_amount(100,000)."""
+		"""Tests if an error is raised when expected_value_after_useful_life(110,000) > net_purchase_amount(100,000)."""
 
 		asset = create_asset(
 			item_code="Macbook Pro",
@@ -1151,7 +1151,7 @@ class TestDepreciationBasics(AssetSetup):
 		self.assertRaises(frappe.ValidationError, asset.save)
 
 	def test_opening_accumulated_depreciation(self):
-		"""Tests if an error is raised when opening_accumulated_depreciation > (gross_purchase_amount - expected_value_after_useful_life)."""
+		"""Tests if an error is raised when opening_accumulated_depreciation > (net_purchase_amount - expected_value_after_useful_life)."""
 
 		asset = create_asset(
 			item_code="Macbook Pro",
@@ -1489,7 +1489,7 @@ class TestDepreciationBasics(AssetSetup):
 			d.accumulated_depreciation_amount for d in get_depr_schedule(asset.name, "Draft")
 		)
 
-		asset_value_after_full_schedule = flt(asset.gross_purchase_amount) - flt(
+		asset_value_after_full_schedule = flt(asset.net_purchase_amount) - flt(
 			accumulated_depreciation_after_full_schedule
 		)
 
@@ -1739,7 +1739,7 @@ def create_asset(**args):
 			"calculate_depreciation": args.calculate_depreciation or 0,
 			"opening_accumulated_depreciation": args.opening_accumulated_depreciation or 0,
 			"opening_number_of_booked_depreciations": args.opening_number_of_booked_depreciations or 0,
-			"gross_purchase_amount": args.gross_purchase_amount or 100000,
+			"net_purchase_amount": args.net_purchase_amount or 100000,
 			"purchase_amount": args.purchase_amount or 100000,
 			"maintenance_required": args.maintenance_required or 0,
 			"warehouse": args.warehouse or "_Test Warehouse - _TC",
@@ -1771,7 +1771,7 @@ def create_asset(**args):
 		)
 
 	if asset.is_composite_asset:
-		asset.gross_purchase_amount = 0
+		asset.net_purchase_amount = 0
 		asset.purchase_amount = 0
 
 	if not args.do_not_save:

--- a/erpnext/assets/doctype/asset_capitalization/asset_capitalization.py
+++ b/erpnext/assets/doctype/asset_capitalization/asset_capitalization.py
@@ -569,14 +569,14 @@ class AssetCapitalization(StockController):
 		asset_doc = frappe.get_doc("Asset", self.target_asset)
 
 		if self.docstatus == 2:
-			gross_purchase_amount = asset_doc.gross_purchase_amount - total_target_asset_value
+			net_purchase_amount = asset_doc.net_purchase_amount - total_target_asset_value
 			purchase_amount = asset_doc.purchase_amount - total_target_asset_value
 			asset_doc.db_set("total_asset_cost", asset_doc.total_asset_cost - total_target_asset_value)
 		else:
-			gross_purchase_amount = asset_doc.gross_purchase_amount + total_target_asset_value
+			net_purchase_amount = asset_doc.net_purchase_amount + total_target_asset_value
 			purchase_amount = asset_doc.purchase_amount + total_target_asset_value
 
-		asset_doc.db_set("gross_purchase_amount", gross_purchase_amount)
+		asset_doc.db_set("net_purchase_amount", net_purchase_amount)
 		asset_doc.db_set("purchase_amount", purchase_amount)
 
 		frappe.msgprint(

--- a/erpnext/assets/doctype/asset_capitalization/test_asset_capitalization.py
+++ b/erpnext/assets/doctype/asset_capitalization/test_asset_capitalization.py
@@ -98,7 +98,7 @@ class TestAssetCapitalization(IntegrationTestCase):
 
 		# Test Target Asset values
 		target_asset = frappe.get_doc("Asset", asset_capitalization.target_asset)
-		self.assertEqual(target_asset.gross_purchase_amount, total_amount)
+		self.assertEqual(target_asset.net_purchase_amount, total_amount)
 		self.assertEqual(target_asset.purchase_amount, total_amount)
 		self.assertEqual(target_asset.status, "Work In Progress")
 
@@ -193,7 +193,7 @@ class TestAssetCapitalization(IntegrationTestCase):
 
 		# Test Target Asset values
 		target_asset = frappe.get_doc("Asset", asset_capitalization.target_asset)
-		self.assertEqual(target_asset.gross_purchase_amount, total_amount)
+		self.assertEqual(target_asset.net_purchase_amount, total_amount)
 		self.assertEqual(target_asset.purchase_amount, total_amount)
 
 		# Test Consumed Asset values
@@ -273,7 +273,7 @@ class TestAssetCapitalization(IntegrationTestCase):
 
 		# Test Target Asset values
 		target_asset = frappe.get_doc("Asset", asset_capitalization.target_asset)
-		self.assertEqual(target_asset.gross_purchase_amount, total_amount)
+		self.assertEqual(target_asset.net_purchase_amount, total_amount)
 		self.assertEqual(target_asset.purchase_amount, total_amount)
 		self.assertEqual(target_asset.status, "Work In Progress")
 
@@ -333,7 +333,7 @@ class TestAssetCapitalization(IntegrationTestCase):
 		self.assertEqual(asset_capitalization.service_items_total, service_amount)
 
 		target_asset = frappe.get_doc("Asset", asset_capitalization.target_asset)
-		self.assertEqual(target_asset.gross_purchase_amount, total_amount)
+		self.assertEqual(target_asset.net_purchase_amount, total_amount)
 		self.assertEqual(target_asset.purchase_amount, total_amount)
 
 		expected_gle = {
@@ -528,8 +528,8 @@ def create_depreciation_asset(**args):
 	asset.purchase_date = args.purchase_date or "2020-01-01"
 	asset.available_for_use_date = args.available_for_use_date or asset.purchase_date
 
-	asset.gross_purchase_amount = args.asset_value or 100000
-	asset.purchase_amount = asset.gross_purchase_amount
+	asset.net_purchase_amount = args.asset_value or 100000
+	asset.purchase_amount = asset.net_purchase_amount
 
 	finance_book = asset.append("finance_books")
 	finance_book.depreciation_start_date = args.depreciation_start_date or "2020-12-31"

--- a/erpnext/assets/doctype/asset_depreciation_schedule/asset_depreciation_schedule.json
+++ b/erpnext/assets/doctype/asset_depreciation_schedule/asset_depreciation_schedule.json
@@ -11,7 +11,7 @@
   "naming_series",
   "company",
   "column_break_2",
-  "gross_purchase_amount",
+  "net_purchase_amount",
   "opening_accumulated_depreciation",
   "opening_number_of_booked_depreciations",
   "finance_book",
@@ -164,15 +164,6 @@
    "read_only": 1
   },
   {
-   "fieldname": "gross_purchase_amount",
-   "fieldtype": "Currency",
-   "hidden": 1,
-   "label": "Gross Purchase Amount",
-   "options": "Company:company:default_currency",
-   "print_hide": 1,
-   "read_only": 1
-  },
-  {
    "fieldname": "opening_number_of_booked_depreciations",
    "fieldtype": "Int",
    "hidden": 1,
@@ -210,12 +201,21 @@
    "fieldtype": "Currency",
    "label": "Value After Depreciation",
    "read_only": 1
+  },
+  {
+   "fieldname": "net_purchase_amount",
+   "fieldtype": "Currency",
+   "hidden": 1,
+   "label": "Net Purchase Amount",
+   "options": "Company:company:default_currency",
+   "print_hide": 1,
+   "read_only": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-12-02 17:54:20.635668",
+ "modified": "2025-05-23 01:17:16.708004",
  "modified_by": "Administrator",
  "module": "Assets",
  "name": "Asset Depreciation Schedule",
@@ -252,6 +252,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": []

--- a/erpnext/assets/doctype/asset_depreciation_schedule/asset_depreciation_schedule.py
+++ b/erpnext/assets/doctype/asset_depreciation_schedule/asset_depreciation_schedule.py
@@ -39,8 +39,8 @@ class AssetDepreciationSchedule(DepreciationScheduleController):
 		finance_book: DF.Link | None
 		finance_book_id: DF.Int
 		frequency_of_depreciation: DF.Int
-		gross_purchase_amount: DF.Currency
 		naming_series: DF.Literal["ACC-ADS-.YYYY.-"]
+		net_purchase_amount: DF.Currency
 		notes: DF.SmallText | None
 		opening_accumulated_depreciation: DF.Currency
 		opening_number_of_booked_depreciations: DF.Int
@@ -149,7 +149,7 @@ class AssetDepreciationSchedule(DepreciationScheduleController):
 		self.opening_number_of_booked_depreciations = (
 			self.asset_doc.opening_number_of_booked_depreciations or 0
 		)
-		self.gross_purchase_amount = self.asset_doc.gross_purchase_amount
+		self.net_purchase_amount = self.asset_doc.net_purchase_amount
 		self.depreciation_method = self.fb_row.depreciation_method
 		self.total_number_of_depreciations = self.fb_row.total_number_of_depreciations
 		self.frequency_of_depreciation = self.fb_row.frequency_of_depreciation

--- a/erpnext/assets/doctype/asset_depreciation_schedule/deppreciation_schedule_controller.py
+++ b/erpnext/assets/doctype/asset_depreciation_schedule/deppreciation_schedule_controller.py
@@ -380,12 +380,12 @@ class DepreciationScheduleController(StraightLineMethod, WDVMethod):
 
 	def validate_depreciation_amount_for_low_value_assets(self):
 		"""
-		If gross purchase amount is too low, then depreciation amount
+		If net purchase amount is too low, then depreciation amount
 		can come zero sometimes based on the frequency and number of depreciations.
 		"""
 		if flt(self.depreciation_amount, self.asset_doc.precision("net_purchase_amount")) <= 0:
 			frappe.throw(
-				_("Gross Purchase Amount {0} cannot be depreciated over {1} cycles.").format(
+				_("Net Purchase Amount {0} cannot be depreciated over {1} cycles.").format(
 					frappe.bold(self.asset_doc.net_purchase_amount),
 					frappe.bold(self.fb_row.total_number_of_depreciations),
 				)

--- a/erpnext/assets/doctype/asset_depreciation_schedule/deppreciation_schedule_controller.py
+++ b/erpnext/assets/doctype/asset_depreciation_schedule/deppreciation_schedule_controller.py
@@ -82,19 +82,19 @@ class DepreciationScheduleController(StraightLineMethod, WDVMethod):
 				self.set_depreciation_amount_for_last_row(row_idx)
 
 			self.depreciation_amount = flt(
-				self.depreciation_amount, self.asset_doc.precision("gross_purchase_amount")
+				self.depreciation_amount, self.asset_doc.precision("net_purchase_amount")
 			)
 			if not self.depreciation_amount:
 				break
 
 			self.pending_depreciation_amount = flt(
 				self.pending_depreciation_amount - self.depreciation_amount,
-				self.asset_doc.precision("gross_purchase_amount"),
+				self.asset_doc.precision("net_purchase_amount"),
 			)
 
 			self.adjust_depr_amount_for_salvage_value(row_idx)
 
-			if flt(self.depreciation_amount, self.asset_doc.precision("gross_purchase_amount")) > 0:
+			if flt(self.depreciation_amount, self.asset_doc.precision("net_purchase_amount")) > 0:
 				self.add_depr_schedule_row(row_idx)
 
 	def initialize_variables(self):
@@ -310,7 +310,7 @@ class DepreciationScheduleController(StraightLineMethod, WDVMethod):
 		)
 
 		self.depreciation_amount = flt(
-			self.depreciation_amount, self.asset_doc.precision("gross_purchase_amount")
+			self.depreciation_amount, self.asset_doc.precision("net_purchase_amount")
 		)
 		if self.depreciation_amount > 0:
 			self.schedule_date = self.disposal_date
@@ -383,10 +383,10 @@ class DepreciationScheduleController(StraightLineMethod, WDVMethod):
 		If gross purchase amount is too low, then depreciation amount
 		can come zero sometimes based on the frequency and number of depreciations.
 		"""
-		if flt(self.depreciation_amount, self.asset_doc.precision("gross_purchase_amount")) <= 0:
+		if flt(self.depreciation_amount, self.asset_doc.precision("net_purchase_amount")) <= 0:
 			frappe.throw(
 				_("Gross Purchase Amount {0} cannot be depreciated over {1} cycles.").format(
-					frappe.bold(self.asset_doc.gross_purchase_amount),
+					frappe.bold(self.asset_doc.net_purchase_amount),
 					frappe.bold(self.fb_row.total_number_of_depreciations),
 				)
 			)

--- a/erpnext/assets/doctype/asset_depreciation_schedule/test_asset_depreciation_schedule.py
+++ b/erpnext/assets/doctype/asset_depreciation_schedule/test_asset_depreciation_schedule.py
@@ -93,7 +93,7 @@ class TestAssetDepreciationSchedule(IntegrationTestCase):
 			depreciation_start_date="2024-07-31",
 			total_number_of_depreciations=24,
 			frequency_of_depreciation=1,
-			gross_purchase_amount=731,
+			net_purchase_amount=731,
 			daily_prorata_based=1,
 		)
 
@@ -133,7 +133,7 @@ class TestAssetDepreciationSchedule(IntegrationTestCase):
 			depreciation_start_date="2024-07-31",
 			total_number_of_depreciations=24,
 			frequency_of_depreciation=1,
-			gross_purchase_amount=731,
+			net_purchase_amount=731,
 		)
 
 		expected_schedules = [
@@ -171,7 +171,7 @@ class TestAssetDepreciationSchedule(IntegrationTestCase):
 			depreciation_start_date="2024-12-31",
 			total_number_of_depreciations=12,
 			frequency_of_depreciation=3,
-			gross_purchase_amount=731,
+			net_purchase_amount=731,
 		)
 
 		expected_schedules = [
@@ -199,7 +199,7 @@ class TestAssetDepreciationSchedule(IntegrationTestCase):
 			calculate_depreciation=1,
 			depreciation_method="Straight Line",
 			daily_prorata_based=1,
-			gross_purchase_amount=1096,
+			net_purchase_amount=1096,
 			available_for_use_date="2020-01-15",
 			depreciation_start_date="2020-01-31",
 			frequency_of_depreciation=1,
@@ -377,7 +377,7 @@ class TestAssetDepreciationSchedule(IntegrationTestCase):
 	def test_depreciation_schedule_after_cancelling_asset_repair(self):
 		asset = create_asset(
 			item_code="Macbook Pro",
-			gross_purchase_amount=500,
+			net_purchase_amount=500,
 			calculate_depreciation=1,
 			depreciation_method="Straight Line",
 			available_for_use_date="2023-01-01",
@@ -457,7 +457,7 @@ class TestAssetDepreciationSchedule(IntegrationTestCase):
 	def test_depreciation_schedule_after_cancelling_asset_repair_for_6_months_frequency(self):
 		asset = create_asset(
 			item_code="Macbook Pro",
-			gross_purchase_amount=500,
+			net_purchase_amount=500,
 			calculate_depreciation=1,
 			depreciation_method="Straight Line",
 			available_for_use_date="2023-01-01",
@@ -522,7 +522,7 @@ class TestAssetDepreciationSchedule(IntegrationTestCase):
 	def test_depreciation_schedule_after_cancelling_asset_repair_for_existing_asset(self):
 		asset = create_asset(
 			item_code="Macbook Pro",
-			gross_purchase_amount=500,
+			net_purchase_amount=500,
 			calculate_depreciation=1,
 			depreciation_method="Straight Line",
 			available_for_use_date="2023-01-15",
@@ -601,7 +601,7 @@ class TestAssetDepreciationSchedule(IntegrationTestCase):
 	def test_wdv_depreciation_schedule_after_cancelling_asset_repair(self):
 		asset = create_asset(
 			item_code="Macbook Pro",
-			gross_purchase_amount=500,
+			net_purchase_amount=500,
 			calculate_depreciation=1,
 			depreciation_method="Written Down Value",
 			available_for_use_date="2023-04-01",
@@ -662,7 +662,7 @@ class TestAssetDepreciationSchedule(IntegrationTestCase):
 	def test_daily_prorata_based_depreciation_schedule_after_cancelling_asset_repair(self):
 		asset = create_asset(
 			item_code="Macbook Pro",
-			gross_purchase_amount=500,
+			net_purchase_amount=500,
 			calculate_depreciation=1,
 			depreciation_method="Straight Line",
 			available_for_use_date="2023-01-01",
@@ -742,7 +742,7 @@ class TestAssetDepreciationSchedule(IntegrationTestCase):
 	def test_depreciation_schedule_after_cancelling_asset_value_adjustent(self):
 		asset = create_asset(
 			item_code="Macbook Pro",
-			gross_purchase_amount=1000,
+			net_purchase_amount=1000,
 			calculate_depreciation=1,
 			depreciation_method="Straight Line",
 			available_for_use_date="2023-01-01",
@@ -844,7 +844,7 @@ class TestAssetDepreciationSchedule(IntegrationTestCase):
 	def test_depreciation_schedule_after_cancelling_asset_value_adjustent_for_existing_asset(self):
 		asset = create_asset(
 			item_code="Macbook Pro",
-			gross_purchase_amount=500,
+			net_purchase_amount=500,
 			calculate_depreciation=1,
 			depreciation_method="Straight Line",
 			available_for_use_date="2023-01-15",
@@ -918,7 +918,7 @@ class TestAssetDepreciationSchedule(IntegrationTestCase):
 	def test_depreciation_schedule_for_parallel_adjustment_and_repair(self):
 		asset = create_asset(
 			item_code="Macbook Pro",
-			gross_purchase_amount=600,
+			net_purchase_amount=600,
 			calculate_depreciation=1,
 			depreciation_method="Straight Line",
 			available_for_use_date="2021-01-01",
@@ -1007,7 +1007,7 @@ class TestAssetDepreciationSchedule(IntegrationTestCase):
 	def test_depreciation_schedule_after_sale_of_asset(self):
 		asset = create_asset(
 			item_code="Macbook Pro",
-			gross_purchase_amount=600,
+			net_purchase_amount=600,
 			calculate_depreciation=1,
 			depreciation_method="Straight Line",
 			available_for_use_date="2021-01-01",
@@ -1085,7 +1085,7 @@ class TestAssetDepreciationSchedule(IntegrationTestCase):
 	def test_depreciation_schedule_after_sale_of_asset_wdv_method(self):
 		asset = create_asset(
 			item_code="Macbook Pro",
-			gross_purchase_amount=500,
+			net_purchase_amount=500,
 			calculate_depreciation=1,
 			depreciation_method="Written Down Value",
 			available_for_use_date="2021-01-01",

--- a/erpnext/assets/doctype/asset_shift_allocation/test_asset_shift_allocation.py
+++ b/erpnext/assets/doctype/asset_shift_allocation/test_asset_shift_allocation.py
@@ -26,7 +26,7 @@ class TestAssetShiftAllocation(IntegrationTestCase):
 			calculate_depreciation=1,
 			available_for_use_date="2023-01-01",
 			purchase_date="2023-01-01",
-			gross_purchase_amount=120000,
+			net_purchase_amount=120000,
 			depreciation_start_date="2023-01-31",
 			total_number_of_depreciations=12,
 			frequency_of_depreciation=1,

--- a/erpnext/assets/report/fixed_asset_register/fixed_asset_register.py
+++ b/erpnext/assets/report/fixed_asset_register/fixed_asset_register.py
@@ -72,7 +72,7 @@ def get_data(filters):
 		"purchase_receipt",
 		"asset_category",
 		"purchase_date",
-		"gross_purchase_amount",
+		"net_purchase_amount",
 		"location",
 		"available_for_use_date",
 		"purchase_invoice",
@@ -87,7 +87,7 @@ def get_data(filters):
 		depreciation_amount = depreciation_amount_map.get(asset.asset_id) or 0.0
 		revaluation_amount = revaluation_amount_map.get(asset.asset_id, 0.0)
 		asset_value = (
-			asset.gross_purchase_amount
+			asset.net_purchase_amount
 			- asset.opening_accumulated_depreciation
 			- depreciation_amount
 			+ revaluation_amount
@@ -101,7 +101,7 @@ def get_data(filters):
 			"cost_center": asset.cost_center,
 			"vendor_name": pr_supplier_map.get(asset.purchase_receipt)
 			or pi_supplier_map.get(asset.purchase_invoice),
-			"gross_purchase_amount": asset.gross_purchase_amount,
+			"net_purchase_amount": asset.net_purchase_amount,
 			"opening_accumulated_depreciation": asset.opening_accumulated_depreciation,
 			"depreciated_amount": depreciation_amount,
 			"available_for_use_date": asset.available_for_use_date,
@@ -370,7 +370,7 @@ def get_group_by_data(
 		a["depreciated_amount"] = depreciation_amount_map.get(a["name"], 0.0)
 		a["revaluation_amount"] = revaluation_amount_map.get(a["name"], 0.0)
 		a["asset_value"] = (
-			a["gross_purchase_amount"]
+			a["net_purchase_amount"]
 			- a["opening_accumulated_depreciation"]
 			- a["depreciated_amount"]
 			+ a["revaluation_amount"]
@@ -435,7 +435,7 @@ def get_columns(filters):
 				"width": 216,
 			},
 			{
-				"label": _("Gross Purchase Amount"),
+				"label": _("Net Purchase Amount"),
 				"fieldname": "net_purchase_amount",
 				"fieldtype": "Currency",
 				"options": "Company:company:default_currency",
@@ -496,7 +496,7 @@ def get_columns(filters):
 			"width": 90,
 		},
 		{
-			"label": _("Gross Purchase Amount"),
+			"label": _("Net Purchase Amount"),
 			"fieldname": "net_purchase_amount",
 			"fieldtype": "Currency",
 			"options": "Company:company:default_currency",

--- a/erpnext/assets/report/fixed_asset_register/fixed_asset_register.py
+++ b/erpnext/assets/report/fixed_asset_register/fixed_asset_register.py
@@ -355,7 +355,7 @@ def get_group_by_data(
 	fields = [
 		group_by,
 		"name",
-		"gross_purchase_amount",
+		"net_purchase_amount",
 		"opening_accumulated_depreciation",
 		"calculate_depreciation",
 	]
@@ -384,7 +384,7 @@ def get_group_by_data(
 			data.append(a)
 		else:
 			for field in (
-				"gross_purchase_amount",
+				"net_purchase_amount",
 				"opening_accumulated_depreciation",
 				"depreciated_amount",
 				"asset_value",
@@ -436,7 +436,7 @@ def get_columns(filters):
 			},
 			{
 				"label": _("Gross Purchase Amount"),
-				"fieldname": "gross_purchase_amount",
+				"fieldname": "net_purchase_amount",
 				"fieldtype": "Currency",
 				"options": "Company:company:default_currency",
 				"width": 250,
@@ -497,7 +497,7 @@ def get_columns(filters):
 		},
 		{
 			"label": _("Gross Purchase Amount"),
-			"fieldname": "gross_purchase_amount",
+			"fieldname": "net_purchase_amount",
 			"fieldtype": "Currency",
 			"options": "Company:company:default_currency",
 			"width": 100,

--- a/erpnext/controllers/buying_controller.py
+++ b/erpnext/controllers/buying_controller.py
@@ -1052,7 +1052,7 @@ class BuyingController(SubcontractingController):
 				"purchase_date": self.posting_date,
 				"calculate_depreciation": 0,
 				"purchase_amount": purchase_amount,
-				"gross_purchase_amount": purchase_amount,
+				"net_purchase_amount": purchase_amount,
 				"asset_quantity": asset_quantity,
 				"purchase_receipt": self.name if self.doctype == "Purchase Receipt" else None,
 				"purchase_invoice": self.name if self.doctype == "Purchase Invoice" else None,

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -263,6 +263,7 @@ erpnext.patches.v15_0.rename_subcontracting_fields
 erpnext.patches.v15_0.unset_incorrect_additional_discount_percentage
 
 [post_model_sync]
+erpnext.patches.v15_0.rename_gross_purchase_amount_to_net_purchase_amount
 erpnext.patches.v15_0.create_asset_depreciation_schedules_from_assets
 execute:frappe.delete_doc_if_exists('Workspace', 'ERPNext Integrations Settings')
 erpnext.patches.v14_0.update_posting_datetime_and_dropped_indexes #22-02-2024

--- a/erpnext/patches/v14_0/update_total_asset_cost_field.py
+++ b/erpnext/patches/v14_0/update_total_asset_cost_field.py
@@ -3,7 +3,7 @@ import frappe
 
 def execute():
 	asset = frappe.qb.DocType("Asset")
-	frappe.qb.update(asset).set(asset.total_asset_cost, asset.gross_purchase_amount).run()
+	frappe.qb.update(asset).set(asset.total_asset_cost, asset.net_purchase_amount).run()
 
 	asset_repair_list = frappe.db.get_all(
 		"Asset Repair",

--- a/erpnext/patches/v15_0/correct_asset_value_if_je_with_workflow.py
+++ b/erpnext/patches/v15_0/correct_asset_value_if_je_with_workflow.py
@@ -35,7 +35,7 @@ def correct_value_for_assets_with_manual_depr_entries():
 		.on(company.name == asset.company)
 		.select(
 			asset.name.as_("asset_name"),
-			asset.gross_purchase_amount.as_("gross_purchase_amount"),
+			asset.net_purchase_amount.as_("net_purchase_amount"),
 			asset.opening_accumulated_depreciation.as_("opening_accumulated_depreciation"),
 			Sum(gle.debit).as_("depr_amount"),
 		)
@@ -51,7 +51,7 @@ def correct_value_for_assets_with_manual_depr_entries():
 		asset_details_and_depr_amount_map.asset_name == asset.name
 	).set(
 		asset.value_after_depreciation,
-		asset_details_and_depr_amount_map.gross_purchase_amount
+		asset_details_and_depr_amount_map.net_purchase_amount
 		- asset_details_and_depr_amount_map.opening_accumulated_depreciation
 		- asset_details_and_depr_amount_map.depr_amount,
 	).run()
@@ -74,7 +74,7 @@ def correct_value_for_assets_with_auto_depr(fb_name=None):
 		.on(company.name == asset.company)
 		.select(
 			asset.name.as_("asset_name"),
-			asset.gross_purchase_amount.as_("gross_purchase_amount"),
+			asset.net_purchase_amount.as_("net_purchase_amount"),
 			asset.opening_accumulated_depreciation.as_("opening_accumulated_depreciation"),
 			Sum(gle.debit).as_("depr_amount"),
 		)
@@ -101,7 +101,7 @@ def correct_value_for_assets_with_auto_depr(fb_name=None):
 		.on(asset_details_and_depr_amount_map.asset_name == afb.parent)
 		.set(
 			afb.value_after_depreciation,
-			asset_details_and_depr_amount_map.gross_purchase_amount
+			asset_details_and_depr_amount_map.net_purchase_amount
 			- asset_details_and_depr_amount_map.opening_accumulated_depreciation
 			- asset_details_and_depr_amount_map.depr_amount,
 		)

--- a/erpnext/patches/v15_0/create_asset_depreciation_schedules_from_assets.py
+++ b/erpnext/patches/v15_0/create_asset_depreciation_schedules_from_assets.py
@@ -48,7 +48,7 @@ def get_asset_finance_books_map():
 			asset.docstatus,
 			asset.name,
 			asset.opening_accumulated_depreciation,
-			asset.gross_purchase_amount,
+			asset.net_purchase_amount,
 			asset.opening_number_of_booked_depreciations,
 		)
 		.where(asset.docstatus < 2)

--- a/erpnext/patches/v15_0/link_purchase_item_to_asset_doc.py
+++ b/erpnext/patches/v15_0/link_purchase_item_to_asset_doc.py
@@ -14,7 +14,7 @@ def execute():
 				"item_code",
 				"purchase_invoice",
 				"purchase_receipt",
-				"gross_purchase_amount",
+				"net_purchase_amount",
 				"asset_quantity",
 				"purchase_invoice_item",
 				"purchase_receipt_item",
@@ -28,7 +28,7 @@ def execute():
 					"Purchase Invoice Item",
 					asset.purchase_invoice,
 					asset.item_code,
-					asset.gross_purchase_amount,
+					asset.net_purchase_amount,
 					asset.asset_quantity,
 				)
 				frappe.db.set_value("Asset", asset.name, "purchase_invoice_item", purchase_invoice_item)
@@ -39,7 +39,7 @@ def execute():
 					"Purchase Receipt Item",
 					asset.purchase_receipt,
 					asset.item_code,
-					asset.gross_purchase_amount,
+					asset.net_purchase_amount,
 					asset.asset_quantity,
 				)
 				frappe.db.set_value("Asset", asset.name, "purchase_receipt_item", purchase_receipt_item)

--- a/erpnext/patches/v15_0/rename_gross_purchase_amount_to_net_purchase_amount.py
+++ b/erpnext/patches/v15_0/rename_gross_purchase_amount_to_net_purchase_amount.py
@@ -1,0 +1,6 @@
+from frappe.model.utils.rename_field import rename_field
+
+
+def execute():
+	rename_field("Asset", "gross_purchase_amount", "net_purchase_amount")
+	rename_field("Asset Depreciation Schedule", "gross_purchase_amount", "net_purchase_amount")

--- a/erpnext/patches/v15_0/update_gpa_and_ndb_for_assdeprsch.py
+++ b/erpnext/patches/v15_0/update_gpa_and_ndb_for_assdeprsch.py
@@ -8,11 +8,11 @@ def execute():
         JOIN `tabAsset`
         ON `tabAsset Depreciation Schedule`.`asset`=`tabAsset`.`name`
         SET
-            `tabAsset Depreciation Schedule`.`gross_purchase_amount`=`tabAsset`.`gross_purchase_amount`,
+            `tabAsset Depreciation Schedule`.`net_purchase_amount`=`tabAsset`.`net_purchase_amount`,
             `tabAsset Depreciation Schedule`.`opening_number_of_booked_depreciations`=`tabAsset`.`opening_number_of_booked_depreciations`
         WHERE
         (
-            `tabAsset Depreciation Schedule`.`gross_purchase_amount`<>`tabAsset`.`gross_purchase_amount`
+            `tabAsset Depreciation Schedule`.`net_purchase_amount`<>`tabAsset`.`net_purchase_amount`
             OR
             `tabAsset Depreciation Schedule`.`opening_number_of_booked_depreciations`<>`tabAsset`.`opening_number_of_booked_depreciations`
         )

--- a/erpnext/stock/doctype/landed_cost_voucher/test_landed_cost_voucher.py
+++ b/erpnext/stock/doctype/landed_cost_voucher/test_landed_cost_voucher.py
@@ -562,7 +562,7 @@ class TestLandedCostVoucher(IntegrationTestCase):
 			self.assertEqual(entry.credit_in_account_currency, amounts[1])
 
 	def test_asset_lcv(self):
-		"Check if LCV for an Asset updates the Assets Gross Purchase Amount correctly."
+		"Check if LCV for an Asset updates the Assets Net Purchase Amount correctly."
 		frappe.db.set_value(
 			"Company", "_Test Company", "capital_work_in_progress_account", "CWIP Account - _TC"
 		)

--- a/erpnext/stock/doctype/landed_cost_voucher/test_landed_cost_voucher.py
+++ b/erpnext/stock/doctype/landed_cost_voucher/test_landed_cost_voucher.py
@@ -591,7 +591,7 @@ class TestLandedCostVoucher(IntegrationTestCase):
 		lcv.submit()
 
 		# lcv updates amount in draft asset
-		self.assertEqual(frappe.db.get_value("Asset", assets[0].name, "gross_purchase_amount"), 50080)
+		self.assertEqual(frappe.db.get_value("Asset", assets[0].name, "net_purchase_amount"), 50080)
 
 		# tear down
 		lcv.cancel()

--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
@@ -931,7 +931,7 @@ class PurchaseReceipt(BuyingController):
 				"Asset",
 				asset.name,
 				{
-					"gross_purchase_amount": purchase_amount,
+					"net_purchase_amount": purchase_amount,
 					"purchase_amount": purchase_amount,
 				},
 			)

--- a/erpnext/stock/doctype/purchase_receipt/test_purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/test_purchase_receipt.py
@@ -829,7 +829,7 @@ class TestPurchaseReceipt(IntegrationTestCase):
 
 		asset = frappe.get_doc("Asset", {"purchase_receipt": pr.name})
 		asset.available_for_use_date = frappe.utils.nowdate()
-		asset.gross_purchase_amount = 50.0
+		asset.net_purchase_amount = 50.0
 		asset.append(
 			"finance_books",
 			{


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Replaced "Gross Purchase Amount" with "Net Purchase Amount" across Asset forms, depreciation schedules, capitalization, purchase flows, and related valuation/depreciation logic.
- Reports
  - Fixed Asset Register, Asset Depreciation Ledger, and Asset Depreciations & Balances now display and aggregate Net Purchase Amount.
- Chores
  - Added a migration to rename fields and update existing records automatically.
- Tests
  - Updated tests to use Net Purchase Amount and validate unchanged depreciation/GL behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->