### PR TITLE
fix(process statement of accounts): use date instead of formatted date

### DIFF
--- a/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.py
+++ b/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.py
@@ -550,7 +550,7 @@ def send_auto_email():
 	selected = frappe.get_list(
 		"Process Statement Of Accounts",
 		filters={"enable_auto_email": 1},
-		or_filters={"to_date": format_date(today()), "posting_date": format_date(today())},
+		or_filters={"to_date": today(), "posting_date": today()},
 	)
 	for entry in selected:
 		send_emails(entry.name, from_scheduler=True)


### PR DESCRIPTION
Issue: Auto email in Process Statement of Accounts fails due to use of `format_date` in filters.

Ref: [#45910](https://support.frappe.io/helpdesk/tickets/45910)

Process Statement Of Accounts:

<img width="1792" height="1120" alt="Screenshot 2025-08-11 at 12 22 41 PM" src="https://github.com/user-attachments/assets/e5084081-dfa5-4e6c-a66f-7aa0530855dd" />
 

Backport needed: v15

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of auto-sent Statement of Accounts by correcting date filtering in scheduled emails. Ensures records are selected using proper date values, reducing missed or wrongly included statements and making scheduling more reliable.
  * Prevents inconsistencies caused by string-formatted dates, aligning behavior across locales and time zones.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->