### PR TITLE
fix: Include Employee party type in Receivable and Payable account filters

### DIFF
--- a/erpnext/setup/doctype/party_type/party_type.py
+++ b/erpnext/setup/doctype/party_type/party_type.py
@@ -26,13 +26,31 @@ class PartyType(Document):
 @frappe.validate_and_sanitize_search_inputs
 def get_party_type(doctype, txt, searchfield, start, page_len, filters):
 	cond = ""
+	account_type = None
+
 	if filters and filters.get("account"):
 		account_type = frappe.db.get_value("Account", filters.get("account"), "account_type")
-		cond = "and account_type = '%s'" % account_type
+		if account_type:
+			cond = "and account_type = %(account_type)s"
 
-	return frappe.db.sql(
+	# Build parameters dictionary
+	params = {"txt": "%" + txt + "%", "start": start, "page_len": page_len}
+	if account_type:
+		params["account_type"] = account_type
+
+	result = frappe.db.sql(
 		f"""select name from `tabParty Type`
-			where `{searchfield}` LIKE %(txt)s {cond}
-			order by name limit %(page_len)s offset %(start)s""",
-		{"txt": "%" + txt + "%", "start": start, "page_len": page_len},
+        where `{searchfield}` LIKE %(txt)s {cond}
+        order by name limit %(page_len)s offset %(start)s""",
+		params,
 	)
+
+	# Convert to list and append Employee if not already present
+	result = list(result) if result else []
+
+	# Only append Employee for Receivable or Payable account types
+	if account_type in ["Receivable", "Payable"]:
+		if not any(row[0] == "Employee" for row in result):
+			result.append(("Employee",))  # Using tuple format like SQL returns
+
+	return result


### PR DESCRIPTION
## Issue

Recent update in PR [[#49044]) (fix: flag on journal entry to ignore party account type validation if required - backport [[#49042](https://github.com/frappe/erpnext/pull/49042)](https://github.com/frappe/erpnext/pull/49042)) removed validation for `account_type == "Employee"`, but this created a practical problem with Employee party type filtering.

### The Problem:
- Employees can have both **Receivable** accounts (for Employee Advances) and **Payable** accounts (for Payroll Payable)
- Current party type filtering only shows party types that exactly match the account's `account_type`
- **Critical Issue**: Users **cannot select** "Employee" party type if the Party Type's `account_type` doesn't match the selected Account's `account_type`
- This means "Employee" party type is completely unavailable in Journal Entry dropdowns when account types are mismatched
- Users would need to manually change Party Type's `account_type` or Account's `account_type` for each transaction, which is impractical

### Business Scenario:
1. **Employee Advances** → Employee should appear in Receivable account transactions
2. **Payroll Payables** → Employee should appear in Payable account transactions
3. **Current Limitation** → Employee party type is filtered out from both scenarios if the Employee's `account_type` doesn't match the selected Account's `account_type`
<img width="1307" height="500" alt="Screenshot from 2025-08-10 16-22-35" src="https://github.com/user-attachments/assets/c534955f-2fae-43c7-aeb8-0e1502a0deea" />
<img width="1307" height="587" alt="Screenshot from 2025-08-10 16-23-03" src="https://github.com/user-attachments/assets/da955692-8e2b-41db-9ecd-a679a7601cf1" />
<img width="1307" height="587" alt="Screenshot from 2025-08-10 16-23-20" src="https://github.com/user-attachments/assets/e02cddf1-d8cc-407e-b016-a86ad4c24fba" />
<img width="1307" height="643" alt="Screenshot from 2025-08-10 16-24-47" src="https://github.com/user-attachments/assets/da82caee-b9eb-4f1b-9a7c-919cf8fc9095" />
<img width="1307" height="712" alt="Screenshot from 2025-08-10 16-25-03" src="https://github.com/user-attachments/assets/908840bb-92e1-41a6-ad4b-0f0918536b34" />

## Solution

Modified the party type filtering function to automatically include "Employee" party type for both Receivable and Payable account types, making it practically usable without requiring constant configuration changes.

<img width="1307" height="712" alt="Screenshot from 2025-08-10 16-28-49" src="https://github.com/user-attachments/assets/93a20054-0732-4fe7-b950-c6ae87e581cc" />


## Changes Made

- **`get_party_type()`**: Enhanced the search function to include "Employee" in dropdown results for both Receivable and Payable accounts

---

**Related:** This complements the validation flag introduced in PR [[#49044](https://github.com/frappe/erpnext/pull/49044)](https://github.com/frappe/erpnext/pull/49044) by making Employee party type selection practical without constant manual configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - “Employee” now appears as a selectable party when using Receivable or Payable account contexts.

- Bug Fixes
  - Prevents duplicate “Employee” entries in party selection.
  - Ensures the party list returns an empty list when no matches.
  - Improves reliability and consistency of account-filtered party searches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->