### PR TITLE
refactor: use translated value of set default in Opportunity

### DIFF
--- a/erpnext/crm/doctype/opportunity/opportunity.js
+++ b/erpnext/crm/doctype/opportunity/opportunity.js
@@ -284,6 +284,9 @@ erpnext.crm.Opportunity = class Opportunity extends frappe.ui.form.Controller {
 			this.frm.set_value("currency", frappe.defaults.get_user_default("Currency"));
 		}
 
+		if (this.frm.is_new() && this.frm.doc.opportunity_type === undefined) {
+			this.frm.doc.opportunity_type = __("Sales");
+		}
 		this.setup_queries();
 	}
 

--- a/erpnext/crm/doctype/opportunity/opportunity.json
+++ b/erpnext/crm/doctype/opportunity/opportunity.json
@@ -157,7 +157,6 @@
    "no_copy": 1
   },
   {
-   "default": "Sales",
    "fieldname": "opportunity_type",
    "fieldtype": "Link",
    "in_list_view": 1,
@@ -657,7 +656,7 @@
  "icon": "fa fa-info-sign",
  "idx": 195,
  "links": [],
- "modified": "2025-06-26 11:16:13.665866",
+ "modified": "2025-08-11 13:35:39.476016",
  "modified_by": "Administrator",
  "module": "CRM",
  "name": "Opportunity",

--- a/erpnext/crm/doctype/opportunity/opportunity.py
+++ b/erpnext/crm/doctype/opportunity/opportunity.py
@@ -128,6 +128,7 @@ class Opportunity(TransactionBase, CRMNote):
 				link_communications(self.opportunity_from, self.party_name, self)
 
 	def validate(self):
+		self.set_opportunity_type()
 		self.make_new_lead_if_required()
 		self.validate_item_details()
 		self.validate_uom_is_integer("uom", "qty")
@@ -151,6 +152,10 @@ class Opportunity(TransactionBase, CRMNote):
 					self.set(field, value)
 				except Exception:
 					continue
+
+	def set_opportunity_type(self):
+		if self.is_new() and not self.opportunity_type:
+			self.opportunity_type = _("Sales")
 
 	def set_exchange_rate(self):
 		company_currency = frappe.get_cached_value("Company", self.company, "default_currency")


### PR DESCRIPTION
develop port of https://github.com/frappe/erpnext/pull/48715

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - New Opportunities now reliably default to the “Sales” opportunity type when not specified, ensuring consistency across all creation methods.
  - Prevents empty or undefined opportunity types, reducing errors in filters, reports, and related workflows.
  - Defaulting occurs earlier during record creation for smoother setup and more predictable behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->