### PR TITLE
 fix: allow creation of root accounts in account tree view 

### DIFF
--- a/erpnext/accounts/doctype/account/account.py
+++ b/erpnext/accounts/doctype/account/account.py
@@ -167,7 +167,7 @@ class Account(NestedSet):
 			if par.root_type:
 				self.root_type = par.root_type
 
-		if self.is_group:
+		if cint(self.is_group):
 			db_value = self.get_doc_before_save()
 			if db_value:
 				if self.report_type != db_value.report_type:
@@ -259,7 +259,7 @@ class Account(NestedSet):
 
 		if self.check_gle_exists():
 			throw(_("Account with existing transaction cannot be converted to ledger"))
-		elif self.is_group:
+		elif cint(self.is_group):
 			if self.account_type and not self.flags.exclude_account_type_check:
 				throw(_("Cannot covert to Group because Account Type is selected."))
 		elif self.check_if_child_exists():

--- a/erpnext/accounts/doctype/account/account.py
+++ b/erpnext/accounts/doctype/account/account.py
@@ -210,7 +210,7 @@ class Account(NestedSet):
 		if doc_before_save and not doc_before_save.parent_account:
 			throw(_("Root cannot be edited."), RootNotEditable)
 
-		if not self.parent_account and not self.is_group:
+		if not self.parent_account and not cint(self.is_group):
 			throw(_("The root account {0} must be a group").format(frappe.bold(self.name)))
 
 	def validate_root_company_and_sync_account_to_children(self):

--- a/erpnext/accounts/doctype/account/account_tree.js
+++ b/erpnext/accounts/doctype/account/account_tree.js
@@ -236,10 +236,6 @@ frappe.treeview_settings["Account"] = {
 							root_company,
 						]);
 					} else {
-						const node = treeview.tree.get_selected_node();
-						if (node.is_root) {
-							frappe.throw(__("Cannot create root account."));
-						}
 						treeview.new_node();
 					}
 				},
@@ -258,8 +254,7 @@ frappe.treeview_settings["Account"] = {
 					].treeview.page.fields_dict.root_company.get_value() ||
 						frappe.flags.ignore_root_company_validation) &&
 					node.expandable &&
-					!node.hide_add &&
-					!node.is_root
+					!node.hide_add
 				);
 			},
 			click: function () {


### PR DESCRIPTION
revert: https://github.com/frappe/erpnext/pull/48435
The fix was incorrect. Root account creation is allowed from the charts of accounts.

The problem was an incorrect validation message.
Root Account should always be a group account.
But due to an incorrect condition check, an error for missing root type was thrown.

Issue: 0 being passed as a string.

Steps to replicate:
- Open Charts of Accounts
- Create an account by directly clicking "New".

<img width="1858" height="204" alt="image" src="https://github.com/user-attachments/assets/0371e003-05f7-4df5-9bce-a2e04d0feae2" />





Before: 
<img width="797" height="163" alt="image" src="https://github.com/user-attachments/assets/a7d394ad-5834-4c6d-9dd7-63171298706b" />


After:
<img width="685" height="157" alt="image" src="https://github.com/user-attachments/assets/3c93e6d5-a521-4a60-a4f0-06b12215fe38" />



Frappe Support Issue: https://support.frappe.io/app/hd-ticket/45994
Closes: https://github.com/frappe/erpnext/issues/48257

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Create a new root account directly from the Accounts tree.
  - Add child accounts under the root node for easier hierarchy management.
  - Toolbar actions are now available at the root level for a smoother workflow.

- Bug Fixes
  - More consistent validation of root account “Group” status (handles non-boolean values), reducing unexpected errors and enforcing root account rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->