### PR TITLE
fix: table render issue on pop-up edit

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.js
+++ b/erpnext/selling/doctype/sales_order/sales_order.js
@@ -1223,6 +1223,7 @@ erpnext.selling.SalesOrderController = class SalesOrderController extends erpnex
 							read_only: 1,
 							fieldname: "uom",
 							label: __("UOM"),
+							options: "UOM",
 							in_list_view: 1,
 						},
 						{
@@ -1296,7 +1297,6 @@ erpnext.selling.SalesOrderController = class SalesOrderController extends erpnex
 					let pending_qty = (flt(d.stock_qty) - ordered_qty) / flt(d.conversion_factor);
 					if (pending_qty > 0) {
 						po_items.push({
-							doctype: "Sales Order Item",
 							name: d.name,
 							item_name: d.item_name,
 							item_code: d.item_code,


### PR DESCRIPTION
Issue: popup click expand not working

Ref: [45961](https://support.frappe.io/helpdesk/tickets/45961)

Before:

<img width="1855" height="826" alt="image" src="https://github.com/user-attachments/assets/e13a0a35-cd26-44c7-a27f-ef681e78d5ac" />


After:

<img width="1858" height="638" alt="image" src="https://github.com/user-attachments/assets/b7e600c0-3772-4107-8de9-14f65498ae6b" />



**Backport needed: Version-15**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - In the Select Items dialog when creating a Purchase Order from a Sales Order, the UOM field is now a searchable link to existing UOMs, making it easier to pick the correct unit of measure and reducing entry errors.
  - Streamlined the item selection experience in the dialog for smoother, more consistent PO creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->