### PR TITLE
fix(quotation): update currency on duplicate

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -953,8 +953,15 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 				return;
 			}
 
-			var party_type = frappe.meta.has_field(me.frm.doc.doctype, "customer") ? "Customer" : "Supplier";
-			var party_name = me.frm.doc[party_type.toLowerCase()];
+			var party_type, party_name;
+			if( me.frm.doc.doctype == "Quotation" && me.frm.doc.quotation_to == "Customer"){
+				party_type = "Customer",
+				party_name = me.frm.doc.party_name
+			}
+			else{
+				party_type = frappe.meta.has_field(me.frm.doc.doctype, "customer") ? "Customer" : "Supplier";
+				party_name = me.frm.doc[party_type.toLowerCase()];
+			}
 			if (party_name) {
 				frappe.call({
 					method: "frappe.client.get_value",


### PR DESCRIPTION
Issue: Quotation exchange rate not updating on **USD** customer duplication

Ref: [#46129](https://support.frappe.io/helpdesk/tickets/46129)

Before:

https://github.com/user-attachments/assets/db401965-7364-4593-969a-dabd696a294c

After: 

https://github.com/user-attachments/assets/4ecf5bbb-412b-471d-bac3-8b509c77f207

Backport needed: v15

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Corrected default currency selection for Quotations addressed to Customers. The system now uses the specified customer as the party when determining currency.
  - Improved consistency of party and currency resolution across related transaction flows, reducing mismatches.
  - Maintains existing fallbacks (e.g., company currency) when no party currency is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->