### PR TITLE
fix(item): validate serial and batch naming series

### DIFF
--- a/erpnext/stock/doctype/item/item.py
+++ b/erpnext/stock/doctype/item/item.py
@@ -411,6 +411,15 @@ class Item(Document):
 					)
 				)
 
+			elif series and "#" in series:
+				hash_index = series.find("#")
+				if not hash_index == 0 and series[hash_index - 1] != ".":
+					frappe.throw(
+						_(
+							"Invalid format for {0}. Must have a dot before the number placeholders, e.g., <b>ABCD.#####</b>"
+						).format(frappe.bold(self.meta.get_field(field).label))
+					)
+
 	def check_for_active_boms(self):
 		if self.default_bom:
 			bom_item = frappe.db.get_value("BOM", self.default_bom, "item")

--- a/erpnext/stock/doctype/serial_and_batch_bundle/test_serial_and_batch_bundle.py
+++ b/erpnext/stock/doctype/serial_and_batch_bundle/test_serial_and_batch_bundle.py
@@ -610,7 +610,7 @@ class TestSerialandBatchBundle(IntegrationTestCase):
 	def test_serial_no_valuation_for_legacy_ledgers(self):
 		sn_item = make_item(
 			"Test Serial No Valuation for Legacy Ledgers",
-			properties={"has_serial_no": 1, "serial_no_series": "SNN-TSNVL.-#####"},
+			properties={"has_serial_no": 1, "serial_no_series": "SNN-TSNVL-.#####"},
 		).name
 
 		serial_nos = []


### PR DESCRIPTION
**Issue:** Validate serial and batch naming series to avoid timeout error on stock entry creation.

**Ref:** [46145](https://support.frappe.io/helpdesk/tickets/46145)

**Error Screenshot:**

<img width="1294" height="493" alt="Screenshot from 2025-08-11 23-47-13" src="https://github.com/user-attachments/assets/e82a7176-b0ed-4c86-8a23-7e188cf4faef" />


**Before:**

[validate serial batch naming series issue.webm](https://github.com/user-attachments/assets/c71395cc-7084-4dd7-bb6d-59f3f479ef7f)

**After:**

[validate serial batch naming series fixed.webm](https://github.com/user-attachments/assets/b8acef75-4e21-43eb-9a21-48858e107608)


**Backport Needed:** v15
    


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Clearer validation for naming series in serial and batch configurations, requiring a dot before number placeholders (e.g., ABCD.#####) and providing a descriptive error when misconfigured.
- Bug Fixes
  - Prevents incorrect naming series formats that could lead to inconsistent serial/batch numbers by enforcing the dot-before-# rule.
- Tests
  - Updated test data to follow the new naming series format; no impact on user workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->