### PR TITLE
fix: pos product bundle and repack

### DIFF
--- a/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
+++ b/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
@@ -868,10 +868,8 @@ def get_bundle_availability(bundle_item_code, warehouse):
 	bundle_bin_qty = 1000000
 	for item in product_bundle.items:
 		item_bin_qty = get_bin_qty(item.item_code, warehouse)
-		item_pos_reserved_qty = get_pos_reserved_qty(item.item_code, warehouse)
-		available_qty = item_bin_qty - item_pos_reserved_qty
 
-		max_available_bundles = available_qty / item.qty
+		max_available_bundles = item_bin_qty / item.qty
 		if bundle_bin_qty > max_available_bundles and frappe.get_value(
 			"Item", item.item_code, "is_stock_item"
 		):

--- a/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
+++ b/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
@@ -411,9 +411,9 @@ class POSInvoice(SalesInvoice):
 					)
 				elif is_stock_item and flt(available_stock) < flt(d.stock_qty):
 					frappe.throw(
-						_(
-							"Row #{}: Stock quantity not enough for Item Code: {} under warehouse {}. Available quantity {}."
-						).format(d.idx, item_code, warehouse, available_stock),
+						_("Row #{}: Stock quantity not enough for Item Code: {} under warehouse {}.").format(
+							d.idx, item_code, warehouse
+						),
 						title=_("Item Unavailable"),
 					)
 

--- a/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
+++ b/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
@@ -213,6 +213,7 @@ class POSInvoice(SalesInvoice):
 		self.validate_return_items_qty()
 		self.set_status()
 		self.validate_pos()
+		self.update_packing_list()
 		self.validate_payment_amount()
 		self.validate_loyalty_transaction()
 		self.validate_company_with_pos_company()
@@ -893,13 +894,25 @@ def get_bin_qty(item_code, warehouse):
 
 
 def get_pos_reserved_qty(item_code, warehouse):
-	p_inv = frappe.qb.DocType("POS Invoice")
-	p_item = frappe.qb.DocType("POS Invoice Item")
+	pinv_item_reserved_qty = reserved_stock_qty_sql("POS Invoice Item", item_code, warehouse)
+	packed_item_reserved_qty = reserved_stock_qty_sql("Packed Item", item_code, warehouse)
 
-	reserved_qty = (
+	reserved_qty = flt(pinv_item_reserved_qty[0].stock_qty) if pinv_item_reserved_qty else 0
+	reserved_qty += flt(packed_item_reserved_qty[0].stock_qty) if packed_item_reserved_qty else 0
+
+	return reserved_qty
+
+
+def reserved_stock_qty_sql(child_table, item_code, warehouse):
+	p_inv = frappe.qb.DocType("POS Invoice")
+	p_item = frappe.qb.DocType(child_table)
+
+	qty_column = "qty" if child_table == "Packed Item" else "stock_qty"
+
+	stock_qty = (
 		frappe.qb.from_(p_inv)
 		.from_(p_item)
-		.select(Sum(p_item.stock_qty).as_("stock_qty"))
+		.select(Sum(p_item[qty_column]).as_("stock_qty"))
 		.where(
 			(p_inv.name == p_item.parent)
 			& (IfNull(p_inv.consolidated_invoice, "") == "")
@@ -909,7 +922,7 @@ def get_pos_reserved_qty(item_code, warehouse):
 		)
 	).run(as_dict=True)
 
-	return flt(reserved_qty[0].stock_qty) if reserved_qty else 0
+	return stock_qty
 
 
 @frappe.whitelist()


### PR DESCRIPTION
Fixed the issue with Product Bundle and Repacked Items on the POS Invoice, including reserved quantity calculation for unconsolidated POS Invoices.

However, this PR does not resolve the issue with Serial and Batch Selection of Packed Items on POS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * POS reserved stock now aggregates reservations from both invoice and packed items for more accurate availability.

* **Improvements**
  * Validation now refreshes packing lists during POS validation to keep quantities in sync.
  * Bundle availability now computes limits per item before subtracting POS reservations, improving bundle stock accuracy.
  * Reserved stock totals apply item- and warehouse-specific filters.

* **Bug Fixes**
  * Stock shortage messages no longer expose raw available quantities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->