### PR TITLE
fix(pos): include Product Bundle components in reserved qty to preven…

### DIFF
--- a/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
+++ b/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
@@ -411,9 +411,9 @@ class POSInvoice(SalesInvoice):
 					)
 				elif is_stock_item and flt(available_stock) < flt(d.stock_qty):
 					frappe.throw(
-						_(
-							"Row #{}: Stock quantity not enough for Item Code: {} under warehouse {}. Available quantity {}."
-						).format(d.idx, item_code, warehouse, available_stock),
+						_("Row #{}: Stock quantity not enough for Item Code: {} under warehouse {}.").format(
+							d.idx, item_code, warehouse
+						),
 						title=_("Item Unavailable"),
 					)
 

--- a/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
+++ b/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
@@ -906,8 +906,7 @@ def get_pos_reserved_qty(item_code, warehouse):
 	pinv_item_reserved_qty = get_pos_reserved_qty_from_table("POS Invoice Item", item_code, warehouse)
 	packed_item_reserved_qty = get_pos_reserved_qty_from_table("Packed Item", item_code, warehouse)
 
-	reserved_qty = flt(pinv_item_reserved_qty[0].stock_qty) if pinv_item_reserved_qty else 0
-	reserved_qty += flt(packed_item_reserved_qty[0].stock_qty) if packed_item_reserved_qty else 0
+	reserved_qty = pinv_item_reserved_qty + packed_item_reserved_qty
 
 	return reserved_qty
 
@@ -932,7 +931,7 @@ def get_pos_reserved_qty_from_table(child_table, item_code, warehouse):
 
 	qty_column = "qty" if child_table == "Packed Item" else "stock_qty"
 
-	stock_qty = (
+	reserved_qty = (
 		frappe.qb.from_(p_inv)
 		.from_(p_item)
 		.select(Sum(p_item[qty_column]).as_("stock_qty"))
@@ -945,7 +944,7 @@ def get_pos_reserved_qty_from_table(child_table, item_code, warehouse):
 		)
 	).run(as_dict=True)
 
-	return stock_qty
+	return flt(reserved_qty[0].stock_qty) if reserved_qty else 0
 
 
 @frappe.whitelist()

--- a/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
+++ b/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
@@ -217,6 +217,7 @@ class POSInvoice(SalesInvoice):
 		self.validate_loyalty_transaction()
 		self.validate_company_with_pos_company()
 		self.validate_full_payment()
+		self.update_packing_list()
 		if self.coupon_code:
 			from erpnext.accounts.doctype.pricing_rule.utils import validate_coupon_code
 

--- a/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
+++ b/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
@@ -907,6 +907,7 @@ def get_pos_reserved_qty(item_code, warehouse):
 
 	return direct_reserved + bundle_reserved
 
+
 def get_direct_pos_reserved_qty(item_code, warehouse):
 	"""Reserved qty for the item from direct lines in submitted POS Invoices (matching warehouse)."""
 
@@ -925,6 +926,7 @@ def get_direct_pos_reserved_qty(item_code, warehouse):
 		)
 	).run(as_dict=True)
 	return flt(reserved_qty[0].stock_qty) if reserved_qty else 0
+
 
 def get_bundle_pos_reserved_qty(item_code, warehouse):
 	"""Reserved qty for the item as a component of Product Bundles in submitted POS Invoices (matching warehouse)."""
@@ -945,12 +947,13 @@ def get_bundle_pos_reserved_qty(item_code, warehouse):
 			& (IfNull(p_inv.consolidated_invoice, "") == "")
 			& (p_item.docstatus == 1)
 			& (p_item.warehouse == warehouse)
-			& (pb.name == p_item.item_code)      # POS item is a bundle
-			& (pb_item.parent == pb.name)        # Bundle items
-			& (pb_item.item_code == item_code)   # This specific item
+			& (pb.name == p_item.item_code)  # POS item is a bundle
+			& (pb_item.parent == pb.name)  # Bundle items
+			& (pb_item.item_code == item_code)  # This specific item
 		)
 	).run(as_dict=True)
 	return flt(bundle_reserved[0].stock_qty) if bundle_reserved else 0
+
 
 @frappe.whitelist()
 def make_sales_return(source_name, target_doc=None):

--- a/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
+++ b/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
@@ -867,7 +867,6 @@ def get_bundle_availability(bundle_item_code, warehouse):
 	bundle_bin_qty = 1000000
 	for item in product_bundle.items:
 		item_bin_qty = get_bin_qty(item.item_code, warehouse)
-		item_pos_reserved_qty = get_pos_reserved_qty(item.item_code, warehouse)
 
 		max_available_bundles = item_bin_qty / item.qty
 		if bundle_bin_qty > max_available_bundles and frappe.get_value(


### PR DESCRIPTION
## POS: Fix real-time stock for Product Bundle components to prevent overselling
Fixes: #49021

### Summary
When selling Product Bundles in POS, the available stock for the component items wasn’t reflected in real time. This allowed POS sessions to oversell items used in bundles and then hit negative stock on closing.

This PR centralizes POS “reserved” quantity logic and includes bundles in the reservation.

Prevents double-counting of reservations when computing how many bundles can be sold.

## Root cause
`get_pos_reserved_qty` only accounted for direct item lines in submitted POS Invoices. It ignored quantities reserved through Product Bundles.

In `get_bundle_availability` we subtracted pos_reserved_qty again at the item level, which led to underestimation (double subtraction) and inconsistent availability between items and bundles.


### Broke down the logic into two smaller functions

`get_direct_pos_reserved_qty(item_code, warehouse)`: existing behavior (direct item lines in submitted POS Invoices).

`get_bundle_pos_reserved_qty(item_code, warehouse)`: new aggregation that multiplies POS Invoice Item.stock_qty (for the bundle) by each Product Bundle Item.qty to compute the reserved quantity of component items.

get_pos_reserved_qty now returns direct_reserved + bundle_reserved.

### Before

POS shows component items as available even after multiple bundle sales.

Bundle availability was undertesting due to double subtraction, causing giving an error when trying to sell bundles even is enough components items where available.

Closing POS could fail with negative stock.

### After

Component reservations from submitted POS Invoices (both direct and via bundles) are reflected.

Bundle availability is computed without double subtracting reservations.

Eliminates overselling scenarios reproduced in #49021.

### Notes & Compatibility:
No schema changes.

Doesn’t alter valuation; only the reservation/availability logic seen by POS.

### Testing
Create items A (qty 5) and B (qty 5).

Create bundle “Combo”: 1×A, 2×B.

Open POS.

Submit a POS Invoice for 1×Combo.

Before (bug): Session 2 still shows A:5, B:5 and allows selling beyond component stock.

After (fix): Session 2 reflects A and B reserved via the bundle sale; attempting to oversell is blocked. Bundle availability matches component constraints.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Improvements
  - POS availability now distinguishes direct-sale reservations from bundle-component reservations; per-item gating uses raw bin stock for clearer limits.
  - Bundle caps refined so checkout limits reflect component stock after accounting for bundle reservations.
  - Packing lists are updated during validation to keep checkout data current.

- Bug Fixes
  - Aggregated reservation checks reduce overselling and improve real-time availability.

- Documentation
  - Added descriptive docstrings for the new reservation aggregation logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->