### PR TITLE
fix: prevent deadlock when setting item defaults under high concurrency

### DIFF
--- a/erpnext/stock/doctype/item/item.py
+++ b/erpnext/stock/doctype/item/item.py
@@ -1290,6 +1290,7 @@ def set_item_default(item_code, company, fieldname, value):
 		if d.company == company:
 			if not d.get(fieldname):
 				frappe.db.set_value(d.doctype, d.name, fieldname, value)
+				item.clear_cache()
 			return
 
 	# no row found, add a new row for the company


### PR DESCRIPTION
Flush cache after setting values in item default to avoid multiple write operations and deadlock under high throughput.

This fix allows to flush cache after values in DB are updated. Thus, in upcoming transactions, the cache will have the latest data available, helping us to avoid expensive unnecessary DB write operations.

Closes: https://github.com/frappe/erpnext/issues/49107