### PR TITLE
fix: patch to set invoice_type on POS Settings

### DIFF
--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -433,3 +433,4 @@ erpnext.patches.v15_0.remove_sales_partner_from_consolidated_sales_invoice
 erpnext.patches.v15_0.update_uae_zero_rated_fetch
 erpnext.patches.v15_0.add_company_payment_gateway_account
 erpnext.patches.v16_0.update_serial_no_reference_name
+erpnext.patches.v16_0.set_invoice_type_in_pos_settings

--- a/erpnext/patches/v16_0/set_invoice_type_in_pos_settings.py
+++ b/erpnext/patches/v16_0/set_invoice_type_in_pos_settings.py
@@ -1,0 +1,6 @@
+import frappe
+
+
+def execute():
+	if not frappe.db.get_single_value("POS Settings", "invoice_type"):
+		frappe.db.set_single_value("POS Settings", "invoice_type", "POS Invoice")


### PR DESCRIPTION
Patch to set `invoice_type` on POS Settings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures POS “Invoice Type” is correctly initialized after an update, improving consistency between Sales Invoice and POS Invoice flows.

* **Chores**
  * Adds a post-update step that automatically sets POS “Invoice Type” to match Accounts settings and existing POS sales, reducing manual adjustments after upgrades.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->