### PR TITLE
perf: multiple performance fixes in `get_item_warehouse`

### DIFF
--- a/erpnext/setup/doctype/brand/brand.py
+++ b/erpnext/setup/doctype/brand/brand.py
@@ -35,7 +35,7 @@ def get_brand_defaults(item, company):
 
 		for d in brand.brand_defaults or []:
 			if d.company == company:
-				row = copy.deepcopy(d.as_dict())
+				row = d.as_dict(no_private_properties=True)
 				row.pop("name")
 				return row
 

--- a/erpnext/setup/doctype/item_group/item_group.py
+++ b/erpnext/setup/doctype/item_group/item_group.py
@@ -90,7 +90,7 @@ def get_item_group_defaults(item, company):
 
 	for d in item_group.item_group_defaults or []:
 		if d.company == company:
-			row = copy.deepcopy(d.as_dict())
+			row = d.as_dict(no_private_properties=True)
 			row.pop("name")
 			return row
 

--- a/erpnext/stock/doctype/item/item.py
+++ b/erpnext/stock/doctype/item/item.py
@@ -1277,7 +1277,7 @@ def get_item_defaults(item_code, company):
 
 	for d in item.item_defaults:
 		if d.company == company:
-			row = copy.deepcopy(d.as_dict())
+			row = d.as_dict(no_private_properties=True)
 			row.pop("name")
 			out.update(row)
 	return out

--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -585,20 +585,12 @@ def get_item_warehouse_(ctx: ItemDetailsCtx, item, overwrite_warehouse, defaults
 			or ctx.warehouse
 		)
 
-		if not warehouse:
-			defaults = frappe.defaults.get_defaults() or {}
-			warehouse_exists = frappe.db.exists(
-				"Warehouse", {"name": defaults.default_warehouse, "company": ctx.company}
-			)
-			if defaults.get("default_warehouse") and warehouse_exists:
-				warehouse = defaults.default_warehouse
-
 	else:
 		warehouse = ctx.warehouse
 
 	if not warehouse:
 		default_warehouse = frappe.get_single_value("Stock Settings", "default_warehouse")
-		if frappe.db.get_value("Warehouse", default_warehouse, "company") == ctx.company:
+		if frappe.get_cached_value("Warehouse", default_warehouse, "company") == ctx.company:
 			return default_warehouse
 
 	return warehouse

--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -590,7 +590,10 @@ def get_item_warehouse_(ctx: ItemDetailsCtx, item, overwrite_warehouse, defaults
 
 	if not warehouse:
 		default_warehouse = frappe.get_single_value("Stock Settings", "default_warehouse")
-		if frappe.get_cached_value("Warehouse", default_warehouse, "company") == ctx.company:
+		if (
+			default_warehouse
+			and frappe.get_cached_value("Warehouse", default_warehouse, "company") == ctx.company
+		):
 			return default_warehouse
 
 	return warehouse


### PR DESCRIPTION
[perf: remove unnecessary branching and use cache in get_item_warehouse](https://github.com/frappe/erpnext/commit/e11cadca585fa89712ab1d17e4be85226b290d8a)


[perf: remove unecessary calls to deepcopy](https://github.com/frappe/erpnext/commit/8b75993d3a37755cc81b1a6cda55d1fc588a49a1)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Default warehouse selection is now company-validated and more reliable, preventing unintended assignments from global defaults.

- Refactor
  - Defaults for items, brands, and item groups now omit internal/private fields, producing cleaner default values.
  - Warehouse resolution uses a cached, validated lookup, reducing queries and improving responsiveness when retrieving item details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->