### PR TITLE
fix: check for auto reserve serial/batch before auto reserving

### DIFF
--- a/erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py
+++ b/erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py
@@ -255,6 +255,8 @@ class StockReservationEntry(Document):
 			not self.from_voucher_type
 			and (self.get("_action") == "submit")
 			and (self.has_serial_no or self.has_batch_no)
+			and frappe.get_single_value("Stock Settings", "auto_reserve_serial_and_batch")
+			and not self.get("bypass_auto_reserve_serial_and_batch")
 		):
 			from erpnext.stock.doctype.batch.batch import get_available_batches
 			from erpnext.stock.doctype.serial_no.serial_no import get_serial_nos_for_outward


### PR DESCRIPTION
1. Value of Stock Setting `auto_reserve_serial_and_batch` will now be checked before auto reserving.
2. It is now also possible to set `bypass_auto_reserve_serial_and_batch` to the SRE object incase one wants to ignore the setting. Note that it is **NOT** a DocField but a mere variable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Auto-reservation of serials/batches now respects global Stock Settings and a document-level bypass option. Auto-reserve runs on submit only when the global flag is enabled and the document isn’t set to bypass, preventing unintended reservations and bringing consistency across transactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->