### PR TITLE
fix: prevent duplicate reverse Journal Entry

### DIFF
--- a/erpnext/accounts/doctype/journal_entry/journal_entry.py
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.py
@@ -1796,6 +1796,14 @@ def make_inter_company_journal_entry(name, voucher_type, company):
 
 @frappe.whitelist()
 def make_reverse_journal_entry(source_name, target_doc=None):
+	existing_reverse = frappe.db.exists("Journal Entry", {"reversal_of": source_name, "docstatus": 1})
+	if existing_reverse:
+		frappe.throw(
+			_("A Reverse Journal Entry {0} already exists for this Journal Entry.").format(
+				get_link_to_form("Journal Entry", existing_reverse)
+			)
+		)
+
 	from frappe.model.mapper import get_mapped_doc
 
 	def post_process(source, target):


### PR DESCRIPTION
closes #49101

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents creating duplicate Reverse Journal Entries by checking for an existing reversal and stopping the action.
  * Displays a clear, translated message with a direct link to the existing entry for quick access.
  * Improves user experience when attempting to reverse the same Journal Entry multiple times, safeguarding data integrity without altering normal reversal behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->