### PR TITLE
feat: select child item when creating one document from another

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js
@@ -165,6 +165,9 @@ erpnext.accounts.PurchaseInvoice = class PurchaseInvoice extends erpnext.buying.
 							per_billed: ["<", 99.99],
 							company: me.frm.doc.company,
 						},
+						allow_child_item_selection: true,
+						child_fieldname: "items",
+						child_columns: ["item_code", "item_name", "qty", "amount", "billed_amt"],
 					});
 				},
 				__("Get Items From")
@@ -187,6 +190,9 @@ erpnext.accounts.PurchaseInvoice = class PurchaseInvoice extends erpnext.buying.
 							company: me.frm.doc.company,
 							is_return: 0,
 						},
+						allow_child_item_selection: true,
+						child_fieldname: "items",
+						child_columns: ["item_code", "item_name", "qty", "amount", "billed_amt"],
 					});
 				},
 				__("Get Items From")

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
@@ -265,6 +265,9 @@ erpnext.accounts.SalesInvoiceController = class SalesInvoiceController extends (
 						per_billed: ["<", 99.99],
 						company: me.frm.doc.company,
 					},
+					allow_child_item_selection: true,
+					child_fieldname: "items",
+					child_columns: ["item_code", "item_name", "qty", "amount", "billed_amt"],
 				});
 			},
 			__("Get Items From")
@@ -294,6 +297,9 @@ erpnext.accounts.SalesInvoiceController = class SalesInvoiceController extends (
 						status: ["!=", "Lost"],
 						company: me.frm.doc.company,
 					},
+					allow_child_item_selection: true,
+					child_fieldname: "items",
+					child_columns: ["item_code", "item_name", "qty", "rate", "amount"],
 				});
 			},
 			__("Get Items From")
@@ -325,6 +331,9 @@ erpnext.accounts.SalesInvoiceController = class SalesInvoiceController extends (
 							filters: filters,
 						};
 					},
+					allow_child_item_selection: true,
+					child_fieldname: "items",
+					child_columns: ["item_code", "item_name", "qty", "amount", "billed_amt"],
 				});
 			},
 			__("Get Items From")

--- a/erpnext/selling/doctype/quotation/quotation.py
+++ b/erpnext/selling/doctype/quotation/quotation.py
@@ -2,6 +2,8 @@
 # License: GNU General Public License v3. See license.txt
 
 
+import json
+
 import frappe
 from frappe import _
 from frappe.model.mapper import get_mapped_doc
@@ -348,7 +350,7 @@ def get_list_context(context=None):
 
 
 @frappe.whitelist()
-def make_sales_order(source_name: str, target_doc=None):
+def make_sales_order(source_name: str, target_doc=None, args=None):
 	if not frappe.db.get_singles_value(
 		"Selling Settings", "allow_sales_order_creation_for_expired_quotation"
 	):
@@ -360,10 +362,15 @@ def make_sales_order(source_name: str, target_doc=None):
 		):
 			frappe.throw(_("Validity period of this quotation has ended."))
 
-	return _make_sales_order(source_name, target_doc)
+	return _make_sales_order(source_name, target_doc, args=args)
 
 
-def _make_sales_order(source_name, target_doc=None, ignore_permissions=False):
+def _make_sales_order(source_name, target_doc=None, ignore_permissions=False, args=None):
+	if args is None:
+		args = {}
+	if isinstance(args, str):
+		args = json.loads(args)
+
 	customer = _make_customer(source_name, ignore_permissions)
 	ordered_items = get_ordered_items(source_name)
 
@@ -431,6 +438,11 @@ def _make_sales_order(source_name, target_doc=None, ignore_permissions=False):
 		# Simple row
 		return True
 
+	def select_item(d):
+		filtered_items = args.get("filtered_children", [])
+		child_filter = d.name in filtered_items if filtered_items else True
+		return child_filter
+
 	doclist = get_mapped_doc(
 		"Quotation",
 		source_name,
@@ -440,7 +452,7 @@ def _make_sales_order(source_name, target_doc=None, ignore_permissions=False):
 				"doctype": "Sales Order Item",
 				"field_map": {"parent": "prevdoc_docname", "name": "quotation_item"},
 				"postprocess": update_item,
-				"condition": can_map_row,
+				"condition": lambda d: can_map_row(d) and select_item(d),
 			},
 			"Sales Taxes and Charges": {"doctype": "Sales Taxes and Charges", "reset_value": True},
 			"Sales Team": {"doctype": "Sales Team", "add_if_empty": True},
@@ -477,11 +489,16 @@ def set_expired_status():
 
 
 @frappe.whitelist()
-def make_sales_invoice(source_name, target_doc=None):
-	return _make_sales_invoice(source_name, target_doc)
+def make_sales_invoice(source_name, target_doc=None, args=None):
+	return _make_sales_invoice(source_name, target_doc, args=args)
 
 
-def _make_sales_invoice(source_name, target_doc=None, ignore_permissions=False):
+def _make_sales_invoice(source_name, target_doc=None, ignore_permissions=False, args=None):
+	if args is None:
+		args = {}
+	if isinstance(args, str):
+		args = json.loads(args)
+
 	customer = _make_customer(source_name, ignore_permissions)
 
 	def set_missing_values(source, target):
@@ -497,6 +514,11 @@ def _make_sales_invoice(source_name, target_doc=None, ignore_permissions=False):
 		target.cost_center = None
 		target.stock_qty = flt(obj.qty) * flt(obj.conversion_factor)
 
+	def select_item(d):
+		filtered_items = args.get("filtered_children", [])
+		child_filter = d.name in filtered_items if filtered_items else True
+		return child_filter
+
 	doclist = get_mapped_doc(
 		"Quotation",
 		source_name,
@@ -505,7 +527,7 @@ def _make_sales_invoice(source_name, target_doc=None, ignore_permissions=False):
 			"Quotation Item": {
 				"doctype": "Sales Invoice Item",
 				"postprocess": update_item,
-				"condition": lambda row: not row.is_alternative,
+				"condition": lambda row: not row.is_alternative and select_item(row),
 			},
 			"Sales Taxes and Charges": {"doctype": "Sales Taxes and Charges", "reset_value": True},
 			"Sales Team": {"doctype": "Sales Team", "add_if_empty": True},

--- a/erpnext/selling/doctype/sales_order/sales_order.js
+++ b/erpnext/selling/doctype/sales_order/sales_order.js
@@ -793,6 +793,9 @@ erpnext.selling.SalesOrderController = class SalesOrderController extends erpnex
 							docstatus: 1,
 							status: ["!=", "Lost"],
 						},
+						allow_child_item_selection: true,
+						child_fieldname: "items",
+						child_columns: ["item_code", "item_name", "qty", "rate", "amount"],
 					});
 				},
 				__("Get Items From")

--- a/erpnext/stock/doctype/delivery_note/delivery_note.js
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.js
@@ -182,6 +182,9 @@ erpnext.stock.DeliveryNoteController = class DeliveryNoteController extends (
 							company: me.frm.doc.company,
 							project: me.frm.doc.project || undefined,
 						},
+						allow_child_item_selection: true,
+						child_fieldname: "items",
+						child_columns: ["item_code", "item_name", "qty", "delivered_qty"],
 					});
 				},
 				__("Get Items From")
@@ -231,6 +234,9 @@ erpnext.stock.DeliveryNoteController = class DeliveryNoteController extends (
 						},
 						get_query_method: "erpnext.stock.doctype.pick_list.pick_list.get_pick_list_query",
 						size: "extra-large",
+						allow_child_item_selection: true,
+						child_fieldname: "locations",
+						child_columns: ["item_code", "item_name", "stock_qty", "delivered_qty"],
 					});
 				},
 				__("Get Items From")

--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.js
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.js
@@ -150,7 +150,11 @@ frappe.ui.form.on("Purchase Receipt", {
 							docstatus: 1,
 							per_received: ["<", 100],
 							company: frm.doc.company,
+							update_stock: 0,
 						},
+						allow_child_item_selection: true,
+						child_fieldname: "items",
+						child_columns: ["item_code", "item_name", "qty", "received_qty"],
 					});
 				},
 				__("Get Items From")
@@ -265,6 +269,9 @@ erpnext.stock.PurchaseReceiptController = class PurchaseReceiptController extend
 								per_received: ["<", 99.99],
 								company: me.frm.doc.company,
 							},
+							allow_child_item_selection: true,
+							child_fieldname: "items",
+							child_columns: ["item_code", "item_name", "qty", "received_qty"],
 						});
 					},
 					__("Get Items From")


### PR DESCRIPTION
fixes #49113

User can now select specific child items when creating one document from another. These documents include:
1. Creation of Purchase Invoice from Purchase Order and Purchase Receipt
2. Creation of Sales Invoice from Delivery Note, Sales Order and Quotation
3. Creation of Sales Order from Quotation
4. Creation of Purchase Receipt from Purchase Order and Purchase Invoice
5. Creation of Delivery Note from Sales Order and Pick List

Previously this functionality was limited only to create Purchase Order from Material Request

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Select specific item rows when creating documents from related ones (PO, PI, PR, SO, Quotation, Delivery Note, Pick List).
  * Selection dialogs show configurable columns (item code, name, qty, rate/amount, billed/received).

* **Enhancements**
  * Conversions now respect your selected child items for precise partial transfers.
  * Purchase Receipt creation fills additional item values (stock qty and amounts) for clearer totals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->