### PR TITLE
fix: do not fetch sub-assembly in PP

### DIFF
--- a/erpnext/manufacturing/doctype/bom_explosion_item/bom_explosion_item.json
+++ b/erpnext/manufacturing/doctype/bom_explosion_item/bom_explosion_item.json
@@ -25,7 +25,8 @@
   "stock_uom",
   "amount",
   "include_item_in_manufacturing",
-  "sourced_by_supplier"
+  "sourced_by_supplier",
+  "is_sub_assembly_item"
  ],
  "fields": [
   {
@@ -165,19 +166,28 @@
    "fieldtype": "Check",
    "label": "Sourced by Supplier",
    "read_only": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "is_sub_assembly_item",
+   "fieldtype": "Check",
+   "label": "Is Sub Assembly Item",
+   "no_copy": 1,
+   "read_only": 1
   }
  ],
  "idx": 1,
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-03-27 13:06:40.935882",
+ "modified": "2025-08-12 20:02:32.694836",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "BOM Explosion Item",
  "naming_rule": "Random",
  "owner": "Administrator",
  "permissions": [],
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],

--- a/erpnext/manufacturing/doctype/bom_explosion_item/bom_explosion_item.py
+++ b/erpnext/manufacturing/doctype/bom_explosion_item/bom_explosion_item.py
@@ -18,6 +18,7 @@ class BOMExplosionItem(Document):
 		description: DF.TextEditor | None
 		image: DF.Attach | None
 		include_item_in_manufacturing: DF.Check
+		is_sub_assembly_item: DF.Check
 		item_code: DF.Link | None
 		item_name: DF.Data | None
 		operation: DF.Link | None

--- a/erpnext/manufacturing/doctype/bom_item/bom_item.json
+++ b/erpnext/manufacturing/doctype/bom_item/bom_item.json
@@ -41,7 +41,8 @@
   "include_item_in_manufacturing",
   "original_item",
   "column_break_33",
-  "sourced_by_supplier"
+  "sourced_by_supplier",
+  "is_sub_assembly_item"
  ],
  "fields": [
   {
@@ -300,18 +301,27 @@
    "fieldname": "operation_row_id",
    "fieldtype": "Int",
    "label": "Operation ID"
+  },
+  {
+   "default": "0",
+   "fieldname": "is_sub_assembly_item",
+   "fieldtype": "Check",
+   "label": "Is Sub Assembly Item",
+   "no_copy": 1,
+   "read_only": 1
   }
  ],
  "idx": 1,
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-03-27 13:08:41.079752",
+ "modified": "2025-08-12 20:01:59.532613",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "BOM Item",
  "owner": "Administrator",
  "permissions": [],
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": []

--- a/erpnext/manufacturing/doctype/bom_item/bom_item.py
+++ b/erpnext/manufacturing/doctype/bom_item/bom_item.py
@@ -26,6 +26,7 @@ class BOMItem(Document):
 		image: DF.Attach | None
 		include_item_in_manufacturing: DF.Check
 		is_stock_item: DF.Check
+		is_sub_assembly_item: DF.Check
 		item_code: DF.Link
 		item_name: DF.Data | None
 		operation: DF.Link | None

--- a/erpnext/manufacturing/doctype/bom_operation/bom_operation.json
+++ b/erpnext/manufacturing/doctype/bom_operation/bom_operation.json
@@ -43,6 +43,7 @@
  ],
  "fields": [
   {
+   "columns": 2,
    "fieldname": "operation",
    "fieldtype": "Link",
    "in_list_view": 1,
@@ -53,9 +54,11 @@
    "reqd": 1
   },
   {
+   "columns": 2,
    "depends_on": "eval:!doc.workstation_type",
    "fieldname": "workstation",
    "fieldtype": "Link",
+   "in_list_view": 1,
    "label": "Workstation",
    "oldfieldname": "workstation",
    "oldfieldtype": "Link",
@@ -83,7 +86,7 @@
    "precision": "2"
   },
   {
-   "columns": 1,
+   "columns": 3,
    "description": "In minutes",
    "fetch_from": "operation.total_operation_time",
    "fetch_if_empty": 1,
@@ -191,7 +194,7 @@
    "label": "Set Operating Cost Based On BOM Quantity"
   },
   {
-   "columns": 1,
+   "columns": 3,
    "fieldname": "workstation_type",
    "fieldtype": "Link",
    "in_list_view": 1,
@@ -199,26 +202,31 @@
    "options": "Workstation Type"
   },
   {
+   "columns": 3,
+   "depends_on": "eval:parent.track_semi_finished_goods === 1",
    "fieldname": "finished_good",
    "fieldtype": "Link",
    "in_list_view": 1,
-   "label": "Finished Goods / Semi Finished Goods Item",
+   "label": "FG / Semi FG Item",
    "options": "Item"
   },
   {
-   "columns": 1,
+   "columns": 2,
+   "depends_on": "eval:parent.track_semi_finished_goods === 1",
    "fieldname": "bom_no",
    "fieldtype": "Link",
+   "in_list_view": 1,
    "label": "BOM No",
    "options": "BOM"
   },
   {
-   "columns": 1,
+   "columns": 2,
    "default": "1",
+   "depends_on": "eval:parent.track_semi_finished_goods === 1",
    "fieldname": "finished_good_qty",
    "fieldtype": "Float",
    "in_list_view": 1,
-   "label": "Finished Goods Qty"
+   "label": "Qty to Produce"
   },
   {
    "default": "0",
@@ -264,7 +272,7 @@
    "label": "Is Subcontracted"
   },
   {
-   "depends_on": "eval:!doc.bom_no",
+   "depends_on": "eval:!doc.bom_no && parent.track_semi_finished_goods === 1",
    "fieldname": "add_raw_materials",
    "fieldtype": "Button",
    "label": "Add Raw Materials"
@@ -287,7 +295,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-07-31 16:17:47.287117",
+ "modified": "2025-08-12 19:27:20.682797",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "BOM Operation",

--- a/erpnext/manufacturing/doctype/production_plan/production_plan.json
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.json
@@ -425,7 +425,6 @@
    "fieldname": "sub_assembly_warehouse",
    "fieldtype": "Link",
    "label": "Sub Assembly Warehouse",
-   "mandatory_depends_on": "eval:doc.skip_available_sub_assembly_item === 1",
    "options": "Warehouse"
   },
   {
@@ -446,7 +445,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-05-09 18:55:45.500257",
+ "modified": "2025-08-12 19:48:09.302503",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "Production Plan",


### PR DESCRIPTION
Do not fetch sub-assembly in PP if Track Semi Finished Goods enabled in the respective BOM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added “Track Semi-Finished Goods” support in BOM with dynamic field enable/disable in operations.
  * Introduced an indicator for Sub Assembly items across BOM and exploded views.

* Enhancements
  * “Add Raw Materials” dialog now pre-fills items for the selected operation.
  * Planning and explosion flows exclude sub-assembly items where appropriate, improving accuracy.
  * Updated labels and list visibility in operations for clarity; adjusted button availability based on context.
  * Relaxed mandatory rule for Sub Assembly Warehouse in Production Plan.
  * Added user guidance when semi-finished tracking prevents sub-assembly use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->