### PR TITLE
Added refund handling to supplier ledger report

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -28,10 +28,10 @@ ignore =
     B007,
     B950,
     W191,
-    E124, # closing bracket, irritating while writing QB code
-    E131, # continuation line unaligned for hanging indent
-    E123, # closing bracket does not match indentation of opening bracket's line
-    E101, # ensured by use of black
+    E124, 
+    E131, 
+    E123, 
+    E101, 
 
 max-line-length = 200
 exclude=.github/helper/semgrep_rules

--- a/erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py
+++ b/erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py
@@ -81,7 +81,7 @@ class PartyLedgerSummaryReport:
 		match_conditions = build_match_conditions(party_type)
 
 		if match_conditions:
-			query = query.where(LiteralValue(match_conditions))
+			query = query.where(qb.Expr(match_conditions))
 
 		party_details = query.run(as_dict=True)
 
@@ -330,7 +330,7 @@ class PartyLedgerSummaryReport:
 				# Deducting refund amount from invoiced and paid amount
 				row.net_invoiced_amount = row.invoiced_amount - row.return_amount
 				row.net_paid_amount = row.paid_amount - row.return_amount
-				row.closing_balance = row.invoiced_amount - row.paid_amount
+				row.closing_balance = row.opening_balance + row.net_invoiced_amount - row.net_paid_amount
 
 				adjustments = self.party_adjustment_details.get(party, {})
 				for account in self.party_adjustment_accounts:
@@ -432,14 +432,12 @@ class PartyLedgerSummaryReport:
 
 	def get_return_invoices(self):
 		doctype = "Sales Invoice" if self.filters.party_type == "Customer" else "Purchase Invoice"
-		filters = (
-			{
-				"is_return": 1,
-				"docstatus": 1,
-				"posting_date": ["between", [self.filters.from_date, self.filters.to_date]],
-				f"{scrub(self.filters.party_type)}": ["in", self.parties],
-			},
-		)
+		filters = {
+			"is_return": 1,
+			"docstatus": 1,
+			"posting_date": ["between", [self.filters.from_date, self.filters.to_date]],
+			f"{scrub(self.filters.party_type)}": ["in", self.parties],
+		}
 
 		self.return_invoices = frappe.get_all(doctype, filters=filters, pluck="name")
 
@@ -530,7 +528,7 @@ def get_children(doctype, value):
 	all_children = []
 
 	for d in value:
-		all_children += get_descendants_of(doctype, value)
+		all_children += get_descendants_of(doctype, d)
 		all_children.append(d)
 
 	return list(set(all_children))

--- a/erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py
+++ b/erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py
@@ -195,9 +195,8 @@ class PartyLedgerSummaryReport:
 				"fieldtype": "Currency",
 				"options": "currency",
 				"width": 120,
-			}
+			},
 		]
-
 
 		for account in self.party_adjustment_accounts:
 			columns.append(

--- a/erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py
+++ b/erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py
@@ -176,13 +176,28 @@ class PartyLedgerSummaryReport:
 				"width": 120,
 			},
 			{
-				"label": _(credit_or_debit_note),
+				"label": _("Return Amount"),
 				"fieldname": "return_amount",
 				"fieldtype": "Currency",
 				"options": "currency",
 				"width": 120,
 			},
+			{
+				"label": _("Net Invoiced Amount"),
+				"fieldname": "net_invoiced_amount",
+				"fieldtype": "Currency",
+				"options": "currency",
+				"width": 120,
+			},
+			{
+				"label": _("Net Paid Amount"),
+				"fieldname": "net_paid_amount",
+				"fieldtype": "Currency",
+				"options": "currency",
+				"width": 120,
+			}
 		]
+
 
 		for account in self.party_adjustment_accounts:
 			columns.append(
@@ -265,6 +280,8 @@ class PartyLedgerSummaryReport:
 						"invoiced_amount": 0,
 						"paid_amount": 0,
 						"return_amount": 0,
+						"net_invoiced_amount": 0,
+						"net_paid_amount": 0,
 						"closing_balance": 0,
 						"currency": company_currency,
 					}
@@ -310,6 +327,11 @@ class PartyLedgerSummaryReport:
 					amount for amount in self.party_adjustment_details.get(party, {}).values()
 				)
 				row.paid_amount -= total_party_adjustment
+
+				# Deducting refund amount from invoiced and paid amount
+				row.net_invoiced_amount = row.invoiced_amount - row.return_amount
+				row.net_paid_amount = row.paid_amount - row.return_amount
+				row.closing_balance = row.invoiced_amount - row.paid_amount
 
 				adjustments = self.party_adjustment_details.get(party, {})
 				for account in self.party_adjustment_accounts:

--- a/erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py
+++ b/erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py
@@ -151,7 +151,7 @@ class PartyLedgerSummaryReport:
 				}
 			)
 
-		credit_or_debit_note = "Credit Note" if self.filters.party_type == "Customer" else "Debit Note"
+		# credit_or_debit_note = "Credit Note" if self.filters.party_type == "Customer" else "Debit Note"
 
 		columns += [
 			{


### PR DESCRIPTION
This addresses the issue in Supplier Ledger Summary report, where the refund/return amounts were not properly deducted form the invoice and paid values.

Changes made :
- Added a new column Return Amount to show total refund/return values
- Deducted the refund amount from both the invoiced and paid amounts
- Added two more columns Net Invoiced Amount and Net Paid Amount to show values after refund deduction

![Screenshot from 2025-08-12 22-57-40](https://github.com/user-attachments/assets/94c48d91-bda0-477b-8d15-05fe7c0a221b)

Please refer to issue #49014 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Net Invoiced Amount" and "Net Paid Amount" columns to Customer Ledger Summary, showing invoiced minus returns and paid minus returns per party.
  * Updated closing balance and totals to incorporate the new net amounts for clearer reconciliation.

* **Bug Fixes / UI**
  * Standardized the "Return Amount" column label for consistent display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->