### PR TITLE
ci: disable Coderabbit on translation PRs

### DIFF
--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -1,0 +1,5 @@
+reviews:
+  auto_review:
+    ignore_title_keywords:
+      - "sync translations"
+      - "update POT file"


### PR DESCRIPTION
Seems like a waste of compute.

- POT files are auto-generated, there's nothing to review.
- Translations are decided on Crowdin, sync PRs are not the right place to question them.

No backports needed, translation sync only happens on `develop` at the moment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated review configuration to reduce noise from routine maintenance updates (e.g., translation syncs and template updates).
  * Improves signal in pull request reviews and streamlines workflows for maintainers.
  * No impact on product functionality, performance, or user interface.
  * Deployment and user experience remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->