### PR TITLE
fix: do not auto reserve serial/batch if SRE already has serial/batch set

### DIFF
--- a/erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py
+++ b/erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py
@@ -256,7 +256,7 @@ class StockReservationEntry(Document):
 			and (self.get("_action") == "submit")
 			and (self.has_serial_no or self.has_batch_no)
 			and frappe.get_single_value("Stock Settings", "auto_reserve_serial_and_batch")
-			and not self.get("bypass_auto_reserve_serial_and_batch")
+			and not self.sb_entries
 		):
 			from erpnext.stock.doctype.batch.batch import get_available_batches
 			from erpnext.stock.doctype.serial_no.serial_no import get_serial_nos_for_outward


### PR DESCRIPTION
Removed the previously added `bypass_auto_reserve_serial_batch` variable check. Now if SRE already has serial/batch set then the system will no longer overwrite the serial/batch table.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Auto-reservation of serial/batch items now runs only when no entries exist and the relevant setting is enabled during submission.
  * Removed the previous bypass option; manual or pre-filled entries are preserved and won’t be auto-overridden.
  * No change for documents without serial/batch requirements; behavior remains as before.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->