### PR TITLE
chore: add default value for posting_time field in subcontracting receipt

### DIFF
--- a/erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.json
+++ b/erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.json
@@ -152,6 +152,7 @@
    "width": "100px"
   },
   {
+   "default": "Now",
    "description": "Time at which materials were received",
    "fieldname": "posting_time",
    "fieldtype": "Time",


### PR DESCRIPTION
- https://github.com/frappe/erpnext/pull/48951
- https://github.com/frappe/frappe/pull/33515

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Subcontracting Receipt now auto-fills Posting Time with the current time when creating a new record, reducing manual entry.
  * Users can still adjust the Posting Time before submission to fit their needs.
  * Improves speed and consistency when recording receipts created without an explicit time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->