### PR TITLE
fix: add missing translation for Internal/Inter Company Sales Order button label

### DIFF
--- a/erpnext/buying/doctype/purchase_order/purchase_order.js
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.js
@@ -480,9 +480,10 @@ erpnext.buying.PurchaseOrderController = class PurchaseOrderController extends (
 						let internal = me.frm.doc.is_internal_supplier;
 						if (internal) {
 							let button_label =
-								me.frm.doc.company === me.frm.doc.represents_company
-									? "Internal Sales Order"
-									: "Inter Company Sales Order";
+							me.frm.doc.company === me.frm.doc.represents_company
+								? __("Internal Sales Order")
+								: __("Inter Company Sales Order");
+
 
 							me.frm.add_custom_button(
 								button_label,


### PR DESCRIPTION
This PR wraps the "Internal Sales Order" and "Inter Company Sales Order" button labels with the __() translation function, ensuring proper localization support in multi-language environments.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The Internal/Inter Company Sales Order button label now respects user language settings, displaying translated text where available.
  * Improves consistency and clarity for multilingual users without changing button behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->