### PR TITLE
fix: prevent employees from selecting themselves in "Reports To" dropdown (closes #3183)

### DIFF
--- a/erpnext/setup/doctype/employee/employee.js
+++ b/erpnext/setup/doctype/employee/employee.js
@@ -11,7 +11,13 @@ erpnext.setup.EmployeeController = class EmployeeController extends frappe.ui.fo
 			};
 		};
 		this.frm.fields_dict.reports_to.get_query = function (doc, cdt, cdn) {
-			return { query: "erpnext.controllers.queries.employee_query" };
+			// return { query: "erpnext.controllers.queries.employee_query" };
+			return {
+				filters: [
+					["status", "=", "Active"],  // only active employees
+					["name", "!=", doc.name]    // exclude self
+				]
+			};
 		};
 	}
 

--- a/erpnext/setup/doctype/employee/employee.js
+++ b/erpnext/setup/doctype/employee/employee.js
@@ -11,12 +11,12 @@ erpnext.setup.EmployeeController = class EmployeeController extends frappe.ui.fo
 			};
 		};
 		this.frm.fields_dict.reports_to.get_query = function (doc, cdt, cdn) {
-			// return { query: "erpnext.controllers.queries.employee_query" };
 			return {
+				query: "erpnext.controllers.queries.employee_query",
 				filters: [
-					["status", "=", "Active"],  // only active employees
-					["name", "!=", doc.name]    // exclude self
-				]
+					["status", "=", "Active"],
+					["name", "!=", doc.name],
+				],
 			};
 		};
 	}


### PR DESCRIPTION
This PR addresses [#3183](https://github.com/frappe/erpnext/issues/49142) where an employee could see and select their own Employee ID in the "Reports To" field dropdown while creating or editing their profile.

Changes made:

Added a client-side filter to exclude the current employee from the "Reports To" field query.

Ensures that the dropdown only lists other employees, preventing self-report assignments before save-time validation.

Why this matters:
Although server-side validation already prevents saving an employee who reports to themselves, showing the same employee in the dropdown is confusing to users and could cause unnecessary form errors. This PR improves user experience by removing the invalid option upfront.

Testing done:

Created a new employee and verified the "Reports To" dropdown does not include the same Employee ID.

Edited an existing employee and confirmed no self-reference appears.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * "Reports To" picker now only shows active employees and excludes the current employee to prevent self-reporting.
  * Company-level restriction is still noted but not enforced, so company scoping of the picker remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

fixes #49142