### PR TITLE
fix: incorrect status of SRE during transfer

### DIFF
--- a/erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py
+++ b/erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py
@@ -1337,7 +1337,9 @@ class StockReservation:
 				.set(doctype.delivered_qty, doctype.delivered_qty + delivered_qty)
 				.set(
 					doctype.status,
-					Case().when((doctype.reserved_qty == doctype.delivered_qty), "Closed").else_("Reserved"),
+					Case()
+					.when((doctype.reserved_qty == doctype.delivered_qty), "Closed")
+					.else_("Partially Delivered"),
 				)
 				.where(doctype.name == name)
 			)


### PR DESCRIPTION
When transferring Stock Reservation Entry from one document to another, the status set should be `Partially Delivered` and not `Reserved` in case of partial transfer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Stock Reservation status now reflects delivery progress more accurately.
  * Entries with partial delivery will show “Partially Delivered” instead of “Reserved.”
  * Fully delivered reservations automatically move to “Closed.”

* **Enhancements**
  * Improved clarity in list views, reports, and filters by distinguishing partial deliveries from untouched reservations.
  * Helps users track fulfillment progress and take appropriate follow-up actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->