### PR TITLE
fix: arrange Company Name and Abbreviation fields side by side

### DIFF
--- a/erpnext/setup/doctype/company/company.json
+++ b/erpnext/setup/doctype/company/company.json
@@ -910,4 +910,4 @@
  "sort_order": "ASC",
  "states": [],
  "track_changes": 1
-
+}

--- a/erpnext/setup/doctype/company/company.json
+++ b/erpnext/setup/doctype/company/company.json
@@ -838,7 +838,7 @@
    "options": "Advance Payment Date\nOldest Of Invoice Or Advance\nReconciliation Date"
   }
  ],
-"icon": "fa fa-building",
+ "icon": "fa fa-building",
  "idx": 1,
  "image_field": "company_logo",
  "is_tree": 1,
@@ -910,4 +910,4 @@
  "sort_order": "ASC",
  "states": [],
  "track_changes": 1
-}
+

--- a/erpnext/setup/doctype/company/company.json
+++ b/erpnext/setup/doctype/company/company.json
@@ -126,6 +126,7 @@
    "oldfieldtype": "Section Break"
   },
   {
+   "columns": 6,
    "fieldname": "company_name",
    "fieldtype": "Data",
    "label": "Company",
@@ -135,6 +136,7 @@
    "unique": 1
   },
   {
+   "columns": 6,
    "fieldname": "abbr",
    "fieldtype": "Data",
    "label": "Abbr",
@@ -834,73 +836,6 @@
    "fieldtype": "Select",
    "label": "Reconciliation Takes Effect On",
    "options": "Advance Payment Date\nOldest Of Invoice Or Advance\nReconciliation Date"
-  }
- ],
- "icon": "fa fa-building",
- "idx": 1,
- "image_field": "company_logo",
- "is_tree": 1,
- "links": [],
- "modified": "2025-01-09 20:12:25.471544",
- "modified_by": "Administrator",
- "module": "Setup",
- "name": "Company",
- "naming_rule": "By fieldname",
- "nsm_parent_field": "parent_company",
- "owner": "Administrator",
- "permissions": [
-  {
-   "create": 1,
-   "delete": 1,
-   "email": 1,
-   "print": 1,
-   "read": 1,
-   "report": 1,
-   "role": "System Manager",
-   "share": 1,
-   "write": 1
-  },
-  {
-   "email": 1,
-   "print": 1,
-   "read": 1,
-   "role": "Accounts User"
-  },
-  {
-   "read": 1,
-   "role": "Employee"
-  },
-  {
-   "read": 1,
-   "role": "Sales User"
-  },
-  {
-   "read": 1,
-   "role": "Purchase User"
-  },
-  {
-   "read": 1,
-   "role": "Stock User"
-  },
-  {
-   "read": 1,
-   "role": "Projects User"
-  },
-  {
-   "create": 1,
-   "delete": 1,
-   "email": 1,
-   "export": 1,
-   "print": 1,
-   "read": 1,
-   "report": 1,
-   "role": "Accounts Manager",
-   "share": 1,
-   "write": 1
-  },
-  {
-   "role": "Auditor",
-   "select": 1
   }
  ],
  "show_name_in_global_search": 1,

--- a/erpnext/setup/doctype/company/company.json
+++ b/erpnext/setup/doctype/company/company.json
@@ -838,6 +838,73 @@
    "options": "Advance Payment Date\nOldest Of Invoice Or Advance\nReconciliation Date"
   }
  ],
+"icon": "fa fa-building",
+ "idx": 1,
+ "image_field": "company_logo",
+ "is_tree": 1,
+ "links": [],
+ "modified": "2025-01-09 20:12:25.471544",
+ "modified_by": "Administrator",
+ "module": "Setup",
+ "name": "Company",
+ "naming_rule": "By fieldname",
+ "nsm_parent_field": "parent_company",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "email": 1,
+   "print": 1,
+   "read": 1,
+   "role": "Accounts User"
+  },
+  {
+   "read": 1,
+   "role": "Employee"
+  },
+  {
+   "read": 1,
+   "role": "Sales User"
+  },
+  {
+   "read": 1,
+   "role": "Purchase User"
+  },
+  {
+   "read": 1,
+   "role": "Stock User"
+  },
+  {
+   "read": 1,
+   "role": "Projects User"
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Accounts Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "role": "Auditor",
+   "select": 1
+  }
+ ],
  "show_name_in_global_search": 1,
  "sort_field": "creation",
  "sort_order": "ASC",


### PR DESCRIPTION
This PR addresses issue #49135 by improving the field layout organization in the Company DocType form.

**Changes:**
- Added `"columns": 6` property to `company_name` field
- Added `"columns": 6` property to `abbr` field

**Impact:**
- Company Name and Company Abbreviation fields now display side by side
- Improved user experience during company setup and form editing
- Better utilization of horizontal space in the form layout

**Testing:**
- Verified field layout changes in Company DocType JSON definition
- Fields will display in 2-column layout using Frappe's 12-column grid system

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Style
  - Company form layout improved: Company Name and Abbreviation now appear side-by-side in a two-column arrangement for a cleaner, more balanced view.
  - Enhances readability and reduces scrolling on wider screens, speeding data entry and improving visual consistency across the form.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->