### PR TITLE
fix: current qty for batch in stock reco

### DIFF
--- a/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py
+++ b/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py
@@ -1473,6 +1473,7 @@ def get_stock_balance_for(
 				posting_time=posting_time,
 				for_stock_levels=True,
 				consider_negative_batches=True,
+				do_not_check_future_batches=True,
 			)
 			or 0
 		)


### PR DESCRIPTION
**Issue**

Incorrect batch current qty for backdated stock reco

**Solution**

Do not consider transactions after the posting date for batch qty calculation



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Stock Reconciliation now excludes future-dated batches when calculating batch quantities. Users may see corrected quantities and valuations during reconciliation for batched items, improving accuracy in reports and adjustments. No changes to user-facing workflows or settings are required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->