### PR TITLE
fix: product bundle child item quantity should be a positive number

### DIFF
--- a/erpnext/selling/doctype/product_bundle/product_bundle.py
+++ b/erpnext/selling/doctype/product_bundle/product_bundle.py
@@ -32,6 +32,7 @@ class ProductBundle(Document):
 	def validate(self):
 		self.validate_main_item()
 		self.validate_child_items()
+		self.validate_child_items_qty_non_zero()
 		from erpnext.utilities.transaction_base import validate_uom_is_integer
 
 		validate_uom_is_integer(self, "uom", "qty")
@@ -85,6 +86,15 @@ class ProductBundle(Document):
 				frappe.throw(
 					_(
 						"Row #{0}: Child Item should not be a Product Bundle. Please remove Item {1} and Save"
+					).format(item.idx, frappe.bold(item.item_code))
+				)
+
+	def validate_child_items_qty_non_zero(self):
+		for item in self.items:
+			if item.qty <= 0:
+				frappe.throw(
+					_(
+						"Row #{0}: Quantity cannot be a non-positive number. Please increase the quantity or remove the Item {1}"
 					).format(item.idx, frappe.bold(item.item_code))
 				)
 


### PR DESCRIPTION
Added a validation to check that the quantity of Child Items is a positive number in the Product Bundle.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents saving Product Bundles with zero or negative quantities for child items.
  * Displays a clear validation error highlighting the exact row and item code when a non-positive quantity is entered.
  * Ensures consistent validation during form entry and data import, improving data integrity and reducing downstream issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->