### PR TITLE
refactor: remove `last_scanned_warehouse` field from python

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
@@ -139,7 +139,6 @@ class PurchaseInvoice(BuyingController):
 		is_subcontracted: DF.Check
 		items: DF.Table[PurchaseInvoiceItem]
 		language: DF.Data | None
-		last_scanned_warehouse: DF.Link | None
 		letter_head: DF.Link | None
 		mode_of_payment: DF.Link | None
 		named_place: DF.Data | None

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -147,7 +147,6 @@ class SalesInvoice(SellingController):
 		is_return: DF.Check
 		items: DF.Table[SalesInvoiceItem]
 		language: DF.Link | None
-		last_scanned_warehouse: DF.Link | None
 		letter_head: DF.Link | None
 		loyalty_amount: DF.Currency
 		loyalty_points: DF.Int

--- a/erpnext/buying/doctype/purchase_order/purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.py
@@ -107,7 +107,6 @@ class PurchaseOrder(BuyingController):
 		is_subcontracted: DF.Check
 		items: DF.Table[PurchaseOrderItem]
 		language: DF.Data | None
-		last_scanned_warehouse: DF.Link | None
 		letter_head: DF.Link | None
 		named_place: DF.Data | None
 		naming_series: DF.Literal["PUR-ORD-.YYYY.-"]

--- a/erpnext/selling/doctype/quotation/quotation.py
+++ b/erpnext/selling/doctype/quotation/quotation.py
@@ -74,7 +74,6 @@ class Quotation(SellingController):
 		incoterm: DF.Link | None
 		items: DF.Table[QuotationItem]
 		language: DF.Link | None
-		last_scanned_warehouse: DF.Link | None
 		letter_head: DF.Link | None
 		lost_reasons: DF.TableMultiSelect[QuotationLostReasonDetail]
 		named_place: DF.Data | None

--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -122,7 +122,6 @@ class SalesOrder(SellingController):
 		is_internal_customer: DF.Check
 		items: DF.Table[SalesOrderItem]
 		language: DF.Link | None
-		last_scanned_warehouse: DF.Link | None
 		letter_head: DF.Link | None
 		loyalty_amount: DF.Currency
 		loyalty_points: DF.Int

--- a/erpnext/stock/doctype/delivery_note/delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.py
@@ -87,7 +87,6 @@ class DeliveryNote(SellingController):
 		issue_credit_note: DF.Check
 		items: DF.Table[DeliveryNoteItem]
 		language: DF.Link | None
-		last_scanned_warehouse: DF.Link | None
 		letter_head: DF.Link | None
 		lr_date: DF.Date | None
 		lr_no: DF.Data | None

--- a/erpnext/stock/doctype/material_request/material_request.py
+++ b/erpnext/stock/doctype/material_request/material_request.py
@@ -43,7 +43,6 @@ class MaterialRequest(BuyingController):
 		customer: DF.Link | None
 		items: DF.Table[MaterialRequestItem]
 		job_card: DF.Link | None
-		last_scanned_warehouse: DF.Link | None
 		letter_head: DF.Link | None
 		material_request_type: DF.Literal[
 			"Purchase",

--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
@@ -87,7 +87,6 @@ class PurchaseReceipt(BuyingController):
 		is_subcontracted: DF.Check
 		items: DF.Table[PurchaseReceiptItem]
 		language: DF.Data | None
-		last_scanned_warehouse: DF.Link | None
 		letter_head: DF.Link | None
 		lr_date: DF.Date | None
 		lr_no: DF.Data | None

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -114,7 +114,6 @@ class StockEntry(StockController):
 		is_return: DF.Check
 		items: DF.Table[StockEntryDetail]
 		job_card: DF.Link | None
-		last_scanned_warehouse: DF.Link | None
 		letter_head: DF.Link | None
 		naming_series: DF.Literal["MAT-STE-.YYYY.-"]
 		outgoing_stock_entry: DF.Link | None

--- a/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py
+++ b/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py
@@ -46,7 +46,6 @@ class StockReconciliation(StockController):
 		difference_amount: DF.Currency
 		expense_account: DF.Link | None
 		items: DF.Table[StockReconciliationItem]
-		last_scanned_warehouse: DF.Link | None
 		naming_series: DF.Literal["MAT-RECO-.YYYY.-"]
 		posting_date: DF.Date
 		posting_time: DF.Time


### PR DESCRIPTION
reference PR: #48865

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal type annotations by removing legacy “last scanned warehouse” hints across multiple transaction types. No functional or UI changes.

* **Chores**
  * Reduced static typing surface to simplify maintenance and improve consistency in developer tooling. No impact on runtime behavior or user workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->