### PR TITLE
fix(asset): prevent translation function shadowing in make_journal_entry

### DIFF
--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -1108,7 +1108,7 @@ def get_asset_account(account_name, asset=None, asset_category=None, company=Non
 def make_journal_entry(asset_name):
 	asset = frappe.get_doc("Asset", asset_name)
 	(
-		_,
+		fixed_asset_account,
 		accumulated_depreciation_account,
 		depreciation_expense_account,
 	) = get_depreciation_accounts(asset.asset_category, asset.company)


### PR DESCRIPTION
Issue: Error While Creating Depreciation Entry

In this Asset, while clicking on Manage → Create Depreciation Entry getting a server Error.

Ref: [46619](https://support.frappe.io/helpdesk/tickets/46619)

<img width="1036" height="970" alt="image" src="https://github.com/user-attachments/assets/9f2d2b61-45aa-4e9d-983e-1558aad3a003" />



**Backport Needed: Version-15**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated asset depreciation journal entry handling to align with revised account retrieval, improving consistency and maintainability.
* **User Impact**
  * No visible changes to asset or accounting workflows. Existing depreciation entries continue to post as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->