### PR TITLE
fix(stock): exclude disabled batches from Pick List item locations

### DIFF
--- a/erpnext/stock/doctype/pick_list/pick_list.py
+++ b/erpnext/stock/doctype/pick_list/pick_list.py
@@ -76,6 +76,7 @@ class PickList(TransactionBase):
 
 	def validate(self):
 		self.validate_expired_batches()
+		self.validate_disabled_batches()
 		self.validate_for_qty()
 		self.validate_stock_qty()
 		self.check_serial_no_status()
@@ -248,6 +249,30 @@ class PickList(TransactionBase):
 				frappe.throw(
 					_("The following batches are expired, please restock them: <br> {0}").format(msg),
 					title=_("Expired Batches"),
+				)
+    
+	def validate_disabled_batches(self):
+		# Validates if any picked batches are disabled
+		batches = []
+		for row in self.get("locations"):
+			if row.get("batch_no") and row.get("picked_qty"):
+				batches.append(row.batch_no)
+
+		if batches:
+			batch = frappe.qb.DocType("Batch")
+			query = (
+				frappe.qb.from_(batch)
+				.select(batch.name)
+				.where((batch.name.isin(batches)) & (batch.disabled == 1))
+			)
+
+			disabled_batches = query.run(as_dict=True)
+			if disabled_batches:
+				msg = "<ul>" + "".join(f"<li>{batch.name}</li>" for batch in disabled_batches) + "</ul>"
+
+				frappe.throw(
+					_("The following batches are disabled, please restock with active batches: <br> {0}").format(msg),
+					title=_("Disabled Batches"),
 				)
 
 	def make_bundle_using_old_serial_batch_fields(self):
@@ -1142,11 +1167,19 @@ def get_available_item_locations_for_batched_item(
 		)
 	)
 
+  # Fetch all disabled batches for the item to filter them out efficiently
+	disabled_batched = set(frappe.get_all("Batch", filters={"item_code": item_code, "disabled": 1}, pluck="name"))
+  
+  
 	warehouse_wise_batches = frappe._dict()
 	rejected_warehouses = get_rejected_warehouses()
 
 	for d in data:
 		if not consider_rejected_warehouses and rejected_warehouses and d.warehouse in rejected_warehouses:
+			continue
+ 
+		# skip disabled batches
+		if d.batch_no in disabled_batched:
 			continue
 
 		if d.warehouse not in warehouse_wise_batches:

--- a/erpnext/stock/doctype/pick_list/test_pick_list.py
+++ b/erpnext/stock/doctype/pick_list/test_pick_list.py
@@ -1485,3 +1485,123 @@ class TestPickList(FrappeTestCase):
 		pick_list.cancel()
 		sales_order.cancel()
 		stock_entry.cancel()
+
+	def test_disabled_batch_validation(self):
+    # Create a batched item
+		item = make_item(
+			"Test Disabled Batch Item",
+			properties={
+				"is_stock_item": 1,
+				"has_batch_no": 1,
+				"create_new_batch": 1,
+				"batch_number_series": "TDB-.####"
+			}
+		).name
+
+		warehouse = "_Test Warehouse - _TC"
+
+		# Create an active batch
+		active_batch = frappe.get_doc({
+			"doctype": "Batch",
+			"item": item,
+			"batch_id": "TDB-ACTIVE-0001",
+			"disabled": 0
+		}).insert()
+
+		# Create a disabled batch
+		disabled_batch = frappe.get_doc({
+			"doctype": "Batch",
+			"item": item,
+			"batch_id": "TDB-DISABLED-0002",
+			"disabled": 1
+		}).insert()
+
+		# Add stock for both batches using individual stock entries
+		# This ensures we have proper serial_and_batch_bundle references
+		se1 = make_stock_entry(
+			item=item,
+			to_warehouse=warehouse,
+			qty=5,
+			basic_rate=100,
+			batches=frappe._dict({active_batch.batch_id: 5})
+		)
+
+		se2 = make_stock_entry(
+			item=item,
+			to_warehouse=warehouse,
+			qty=5,
+			basic_rate=100,
+			batches=frappe._dict({disabled_batch.batch_id: 5})
+		)
+
+    # Create a Sales Order
+		so = make_sales_order(item_code=item, qty=5, rate=100, warehouse=warehouse)
+
+    # Test 1: Verify disabled batches are excluded during auto-population
+		pl = create_pick_list(so.name)
+		pl.set_item_locations()
+		pl.save()
+
+    # Should only pick from active batch
+		self.assertEqual(len(pl.locations), 1)
+		self.assertEqual(pl.locations[0].batch_no, active_batch.batch_id)
+		self.assertNotEqual(pl.locations[0].batch_no, disabled_batch.batch_id)
+
+    # Test 2: Verify validation error when a disabled batch is manually added
+		pl_manual = frappe.get_doc({
+			"doctype": "Pick List",
+			"company": "_Test Company",
+			"customer": "_Test Customer",
+			"items_based_on": "Sales Order",
+			"purpose": "Delivery",
+			"locations": [
+				{
+					"item_code": item,
+					"qty": 5,
+					"stock_qty": 5,
+					"conversion_factor": 1,
+					"batch_no": disabled_batch.batch_id,
+					"sales_order": so.name,
+					"sales_order_item": so.items[0].name,
+					"warehouse": warehouse
+				}
+			]
+		})
+
+    # This should raise a ValidationError
+		with self.assertRaises(frappe.exceptions.ValidationError):
+			pl_manual.submit()
+
+    # Test 3: Test pick list with only disabled batch stock (edge case)
+    # Consume all active batch stock first
+		consume_se = make_stock_entry(
+			item=item,
+			from_warehouse=warehouse,
+			qty=5,
+			basic_rate=100,
+			batches=frappe._dict({active_batch.batch_id: 5})
+		)
+
+    # Now try to create pick list - should have no locations since only disabled batch remains
+		so2 = make_sales_order(item_code=item, qty=3, rate=100, warehouse=warehouse)
+		pl_no_stock = create_pick_list(so2.name)
+		pl_no_stock.set_item_locations()
+
+    # Should have no locations since disabled batch stock shouldn't be picked
+		self.assertEqual(len(pl_no_stock.locations), 0)
+
+    # Cleanup
+		try:
+			if pl.docstatus == 1:
+				pl.cancel()
+			if pl_manual.docstatus == 1:
+				pl_manual.cancel()
+			so.cancel()
+			so2.cancel()
+			se1.cancel()
+			se2.cancel()
+			consume_se.cancel()
+			active_batch.delete()
+			disabled_batch.delete()
+		except Exception:
+			pass


### PR DESCRIPTION
## Summary

Previously, Pick List auto-population could include **disabled batches**.  
This change ensures that **only active batches** are considered when fetching item locations.  

### Key improvements:
- Disabled batches are excluded in auto-population.
- Validation error raised when manually adding a disabled batch.
- Edge case handled when only disabled batches exist.

---

## Description

This PR ensures that disabled batches are never included when auto-populating Pick List item locations.  
Previously, even disabled batches could be suggested if they had stock, potentially leading to incorrect fulfillment.

---

## Changes Introduced
- Updated Pick List item location fetching logic to **skip disabled batches**.
- Added comprehensive tests to verify:
  1. Disabled batches are excluded during auto-population.
  2. Validation error is raised when a disabled batch is manually assigned.
  3. Edge case handling when only disabled batch stock exists (no locations returned).

---

## Why This Change is Needed
Disabled batches should not be picked for fulfilling orders.  
This prevents operational errors, maintains stock integrity, and aligns with expected batch management behavior.

---

## Test Coverage
**Unit test:** `test_disabled_batch_validation`  
Covers:
- Normal scenario with both active and disabled batches.
- Manual assignment of disabled batch (expecting validation error).
- No available stock except disabled batches (expecting no locations).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Clear validation message when attempting to use disabled batches in Pick Lists, guiding users to restock with active batches.
- Bug Fixes
  - Auto-populated locations now exclude disabled batches.
  - Submitting a Pick List with disabled batches is blocked with a detailed error listing affected batches.
  - If only disabled stock exists, no locations are suggested.
  - Minor performance improvement by skipping disabled batches earlier in processing.
- Tests
  - Added tests covering auto-population, manual validation errors, and edge cases with only disabled stock.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->