### PR TITLE
ci: disable coderabbit status comment

### DIFF
--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -3,3 +3,4 @@ reviews:
     ignore_title_keywords:
       - "sync translations"
       - "update POT file"
+  review_status: false

--- a/.github/workflows/patch.yml
+++ b/.github/workflows/patch.yml
@@ -8,6 +8,9 @@ on:
       - '**.md'
       - '**.html'
       - '**.csv'
+      - 'crowdin.yml'
+      - '.coderabbit.yml'
+      - '.mergify.yml'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/server-tests-mariadb.yml
+++ b/.github/workflows/server-tests-mariadb.yml
@@ -9,6 +9,9 @@ on:
       - '**.css'
       - '**.md'
       - '**.html'
+      - 'crowdin.yml'
+      - '.coderabbit.yml'
+      - '.mergify.yml'
   schedule:
     # Run everday at midnight UTC / 5:30 IST
     - cron: "0 0 * * *"

--- a/.github/workflows/server-tests-postgres.yml
+++ b/.github/workflows/server-tests-postgres.yml
@@ -6,6 +6,9 @@ on:
       - '**.js'
       - '**.md'
       - '**.html'
+      - 'crowdin.yml'
+      - '.coderabbit.yml'
+      - '.mergify.yml'
     types: [opened, labelled, synchronize, reopened]
 
 concurrency:


### PR DESCRIPTION
Disables this kind of comment: https://github.com/frappe/erpnext/pull/49152#issuecomment-3184835491


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted automated review configuration to add a new review flag while preserving existing ignore-keyword rules.
  * Updated CI workflow triggers so changes limited to automation/config files are ignored by certain test and patch workflows.
  * No user-facing feature changes; operational updates to reduce unnecessary CI runs and stabilize review behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->