### PR TITLE
fix: wrap inter-company order button labels in __() for translation

### DIFF
--- a/erpnext/buying/doctype/purchase_order/purchase_order.js
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.js
@@ -481,8 +481,8 @@ erpnext.buying.PurchaseOrderController = class PurchaseOrderController extends (
 						if (internal) {
 							let button_label =
 								me.frm.doc.company === me.frm.doc.represents_company
-									? "Internal Sales Order"
-									: "Inter Company Sales Order";
+									? __("Internal Sales Order")
+									: __("Inter Company Sales Order");
 
 							me.frm.add_custom_button(
 								button_label,

--- a/erpnext/selling/doctype/sales_order/sales_order.js
+++ b/erpnext/selling/doctype/sales_order/sales_order.js
@@ -738,8 +738,8 @@ erpnext.selling.SalesOrderController = class SalesOrderController extends erpnex
 						if (internal) {
 							let button_label =
 								me.frm.doc.company === me.frm.doc.represents_company
-									? "Internal Purchase Order"
-									: "Inter Company Purchase Order";
+									? __("Internal Purchase Order")
+									: __("Inter Company Purchase Order");
 
 							me.frm.add_custom_button(
 								button_label,


### PR DESCRIPTION
Fixes frappe/erpnext#47519

- Wrapped both Purchase Order and Sales Order inter-company button labels in __().
- Verified by switching languages—buttons now translate correctly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Button labels in Purchasing and Sales now support translation based on the user’s language. Specifically, the actions for creating Internal vs Inter Company orders display localized text in both Purchase Order and Sales Order screens. This improves clarity for non-English users and aligns labels with selected locale. No changes to workflows or behavior—only the visible button text is now localized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->