### PR TITLE
fix: handle all searchfields in items

### DIFF
--- a/erpnext/stock/report/stock_balance/stock_balance.js
+++ b/erpnext/stock/report/stock_balance/stock_balance.js
@@ -61,10 +61,10 @@ frappe.query_reports["Stock Balance"] = {
 					},
 				});
 
-				data = data.map(({ name, description }) => {
+				data = data.map(({ name, ...rest }) => {
 					return {
 						value: name,
-						description: description,
+						description: Object.values(rest),
 					};
 				});
 

--- a/erpnext/stock/report/stock_ledger/stock_ledger.js
+++ b/erpnext/stock/report/stock_ledger/stock_ledger.js
@@ -56,11 +56,10 @@ frappe.query_reports["Stock Ledger"] = {
 						as_dict: 1,
 					},
 				});
-
-				data = data.map(({ name, description }) => {
+				data = data.map(({ name, ...rest }) => {
 					return {
 						value: name,
-						description: description,
+						description: Object.values(rest),
 					};
 				});
 


### PR DESCRIPTION
Issue: Item MultiSelectList shows `undefined` in Stock Ledger and Stock Balance when the description search field is missing.

Ref: [#46059](https://support.frappe.io/helpdesk/tickets/46059)

Before:

<img width="1792" height="1120" alt="Screenshot 2025-08-15 at 10 04 07 AM" src="https://github.com/user-attachments/assets/e754a27a-f175-48e0-8748-a8c79656e726" />

After:

<img width="1792" height="1120" alt="Screenshot 2025-08-15 at 10 02 02 AM" src="https://github.com/user-attachments/assets/95339c7d-5c6d-4b9d-9222-8aedc82e775e" />


Backport needed: v15

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Stock Balance report: Item filter suggestions now show multiple item details (replacing the single description), providing richer context when selecting items.
  - Stock Ledger report: Item filter suggestions display additional item attributes alongside the item name for clearer identification.
  - Consistent item suggestion behavior across both reports, presenting a richer, multi-field description in the dropdown to aid quick selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->