### PR TITLE
Fix/mr status from wo

### DIFF
--- a/erpnext/controllers/status_updater.py
+++ b/erpnext/controllers/status_updater.py
@@ -116,7 +116,7 @@ status_map = {
 		["Pending", "eval:self.status != 'Stopped' and self.per_ordered == 0 and self.docstatus == 1"],
 		[
 			"Ordered",
-			"eval:self.status != 'Stopped' and self.per_ordered == 100 and self.docstatus == 1 and self.material_request_type == 'Purchase'",
+			"eval:self.status != 'Stopped' and self.per_ordered == 100 and self.docstatus == 1 and self.material_request_type in ['Purchase', 'Manufacture']",
 		],
 		[
 			"Transferred",
@@ -141,10 +141,6 @@ status_map = {
 		[
 			"Partially Ordered",
 			"eval:self.status != 'Stopped' and self.per_ordered < 100 and self.per_ordered > 0 and self.docstatus == 1 and self.material_request_type != 'Material Transfer'",
-		],
-		[
-			"Manufactured",
-			"eval:self.status != 'Stopped' and self.per_ordered == 100 and self.docstatus == 1 and self.material_request_type == 'Manufacture'",
 		],
 	],
 	"POS Opening Entry": [

--- a/erpnext/selling/doctype/sales_order/test_sales_order.py
+++ b/erpnext/selling/doctype/sales_order/test_sales_order.py
@@ -1828,7 +1828,7 @@ class TestSalesOrder(AccountsTestMixin, IntegrationTestCase):
 		wo.reload()
 		so.reload()
 		self.assertEqual(so.items[0].work_order_qty, wo.produced_qty)
-		self.assertEqual(mr.status, "Manufactured")
+		self.assertEqual(mr.status, "Ordered")
 
 	def test_sales_order_with_shipping_rule(self):
 		from erpnext.accounts.doctype.shipping_rule.test_shipping_rule import create_shipping_rule

--- a/erpnext/stock/doctype/material_request/material_request_list.js
+++ b/erpnext/stock/doctype/material_request/material_request_list.js
@@ -35,7 +35,7 @@ frappe.listview_settings["Material Request"] = {
 				return [__("Partially Received"), "yellow", "per_received,<,100"];
 			} else if (doc.material_request_type == "Purchase" && flt(doc.per_received, precision) == 100) {
 				return [__("Received"), "green", "per_received,=,100"];
-			} else if (doc.material_request_type == "Purchase") {
+			} else if (["Purchase", "Manufacture"].includes(doc.material_request_type)) {
 				return [__("Ordered"), "green", "per_ordered,=,100"];
 			} else if (doc.material_request_type == "Material Transfer") {
 				return [__("Transferred"), "green", "per_ordered,=,100"];
@@ -43,8 +43,6 @@ frappe.listview_settings["Material Request"] = {
 				return [__("Issued"), "green", "per_ordered,=,100"];
 			} else if (doc.material_request_type == "Customer Provided") {
 				return [__("Received"), "green", "per_ordered,=,100"];
-			} else if (doc.material_request_type == "Manufacture") {
-				return [__("Manufactured"), "green", "per_ordered,=,100"];
 			}
 		}
 	},

--- a/erpnext/stock/doctype/material_request/test_material_request.py
+++ b/erpnext/stock/doctype/material_request/test_material_request.py
@@ -916,6 +916,23 @@ class TestMaterialRequest(IntegrationTestCase):
 		for perm in permissions:
 			perm.delete()
 
+	def test_manufacture_type_status_over_wo(self):
+		from erpnext.stock.doctype.material_request.material_request import raise_work_orders
+
+		mr = make_material_request(
+			item_code="_Test FG Item", material_request_type="Manufacture", do_not_submit=False
+		)
+
+		work_order = raise_work_orders(mr.name)
+		wo = frappe.get_doc("Work Order", work_order[0])
+		wo.wip_warehouse = "_Test Warehouse 1 - _TC"
+		wo.submit()
+
+		mr.reload()
+
+		self.assertEqual(mr.per_ordered, 100)
+		self.assertEqual(mr.status, "Ordered")
+
 
 def get_in_transit_warehouse(company):
 	if not frappe.db.exists("Warehouse Type", "Transit"):


### PR DESCRIPTION
**Issue:** When WO submitted against manufacture type MR, the status of MR  misleading as `Manufactured`, though the WO is in `In Process` status.

**Ref:** [46337](https://support.frappe.io/helpdesk/tickets/46337)

**Solution:** Since, the MR status don't need to dependent on WO status, the `Manufacture` type MR status can be `Ordered` against WO.

**Before:**

[manufacture mr type status issue.webm](https://github.com/user-attachments/assets/5a2e33ca-9f70-49c0-8d5f-ed0d2876d077)


**After:**

[manufacture mr type status resolved.webm](https://github.com/user-attachments/assets/b5bfefeb-a8a4-413a-a8b9-4ec4f3fab466)

**Backport Needed: v15**



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Material Request statuses unified: “Manufactured” removed; Manufacture requests now show “Ordered” when fully ordered. List indicators updated accordingly.

- Tests
  - Tests updated to expect “Ordered” (not “Manufactured”) after Work Order completion for Manufacture-type requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->