### PR TITLE
fix: handle mode of payment filter

### DIFF
--- a/erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py
+++ b/erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py
@@ -10,7 +10,6 @@ from frappe.utils import cstr, flt
 from frappe.utils.nestedset import get_descendants_of
 from frappe.utils.xlsxutils import handle_html
 from pypika import Order
-from pypika.terms import LiteralValue
 
 from erpnext.accounts.report.sales_register.sales_register import get_mode_of_payments
 from erpnext.accounts.report.utils import get_values_for_columns

--- a/erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py
+++ b/erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py
@@ -345,7 +345,7 @@ def get_columns(additional_table_columns, filters):
 	return columns
 
 
-def apply_conditions(query, si, sii, filters, additional_conditions=None):
+def apply_conditions(query, si, sii, sip, filters, additional_conditions=None):
 	for opts in ("company", "customer"):
 		if filters.get(opts):
 			query = query.where(si[opts] == filters[opts])
@@ -357,12 +357,13 @@ def apply_conditions(query, si, sii, filters, additional_conditions=None):
 		query = query.where(si.posting_date <= filters.get("to_date"))
 
 	if filters.get("mode_of_payment"):
-		if sales_invoice := frappe.db.get_all(
-			"Sales Invoice Payment", {"mode_of_payment": filters.get("mode_of_payment")}, pluck="parent"
-		):
-			query = query.where(si.name.isin(sales_invoice))
-		else:
-			query = query.where(LiteralValue(1) == LiteralValue(0))
+		subquery = (
+			frappe.qb.from_(sip)
+			.select(sip.parent)
+			.where(sip.mode_of_payment == filters.get("mode_of_payment"))
+			.groupby(sip.parent)
+		)
+		query = query.where(si.name.isin(subquery))
 
 	if filters.get("warehouse"):
 		if frappe.db.get_value("Warehouse", filters.get("warehouse"), "is_group"):
@@ -424,6 +425,7 @@ def get_items(filters, additional_query_columns, additional_conditions=None):
 	doctype = "Sales Invoice"
 	si = frappe.qb.DocType("Sales Invoice")
 	sii = frappe.qb.DocType("Sales Invoice Item")
+	sip = frappe.qb.DocType("Sales Invoice Payment")
 	item = frappe.qb.DocType("Item")
 
 	query = (
@@ -488,7 +490,7 @@ def get_items(filters, additional_query_columns, additional_conditions=None):
 	if filters.get("customer_group"):
 		query = query.where(si.customer_group == filters["customer_group"])
 
-	query = apply_conditions(query, si, sii, filters, additional_conditions)
+	query = apply_conditions(query, si, sii, sip, filters, additional_conditions)
 
 	from frappe.desk.reportview import build_match_conditions
 

--- a/erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py
+++ b/erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py
@@ -10,6 +10,7 @@ from frappe.utils import cstr, flt
 from frappe.utils.nestedset import get_descendants_of
 from frappe.utils.xlsxutils import handle_html
 from pypika import Order
+from pypika.terms import LiteralValue
 
 from erpnext.accounts.report.sales_register.sales_register import get_mode_of_payments
 from erpnext.accounts.report.utils import get_values_for_columns
@@ -344,7 +345,7 @@ def get_columns(additional_table_columns, filters):
 	return columns
 
 
-def apply_conditions(query, si, sii, sip, filters, additional_conditions=None):
+def apply_conditions(query, si, sii, filters, additional_conditions=None):
 	for opts in ("company", "customer"):
 		if filters.get(opts):
 			query = query.where(si[opts] == filters[opts])
@@ -356,7 +357,12 @@ def apply_conditions(query, si, sii, sip, filters, additional_conditions=None):
 		query = query.where(si.posting_date <= filters.get("to_date"))
 
 	if filters.get("mode_of_payment"):
-		query = query.where(sip.mode_of_payment == filters.get("mode_of_payment"))
+		if sales_invoice := frappe.db.get_all(
+			"Sales Invoice Payment", {"mode_of_payment": filters.get("mode_of_payment")}, pluck="parent"
+		):
+			query = query.where(si.name.isin(sales_invoice))
+		else:
+			query = query.where(LiteralValue(1) == LiteralValue(0))
 
 	if filters.get("warehouse"):
 		if frappe.db.get_value("Warehouse", filters.get("warehouse"), "is_group"):
@@ -418,15 +424,12 @@ def get_items(filters, additional_query_columns, additional_conditions=None):
 	doctype = "Sales Invoice"
 	si = frappe.qb.DocType("Sales Invoice")
 	sii = frappe.qb.DocType("Sales Invoice Item")
-	sip = frappe.qb.DocType("Sales Invoice Payment")
 	item = frappe.qb.DocType("Item")
 
 	query = (
 		frappe.qb.from_(si)
 		.join(sii)
 		.on(si.name == sii.parent)
-		.left_join(sip)
-		.on(sip.parent == si.name)
 		.left_join(item)
 		.on(sii.item_code == item.name)
 		.select(
@@ -466,7 +469,6 @@ def get_items(filters, additional_query_columns, additional_conditions=None):
 			si.update_stock,
 			sii.uom,
 			sii.qty,
-			sip.mode_of_payment,
 		)
 		.where(si.docstatus == 1)
 		.where(sii.parenttype == doctype)
@@ -486,7 +488,7 @@ def get_items(filters, additional_query_columns, additional_conditions=None):
 	if filters.get("customer_group"):
 		query = query.where(si.customer_group == filters["customer_group"])
 
-	query = apply_conditions(query, si, sii, sip, filters, additional_conditions)
+	query = apply_conditions(query, si, sii, filters, additional_conditions)
 
 	from frappe.desk.reportview import build_match_conditions
 


### PR DESCRIPTION
Issue: Duplicate Invoice Issue in Item-wise Sales Register

Ref: [46184](https://support.frappe.io/helpdesk/tickets/46184), [46201](https://support.frappe.io/helpdesk/tickets/46201)

Before:

<img width="1858" height="970" alt="image" src="https://github.com/user-attachments/assets/115d3ac4-f978-4f0b-85c7-a4b660f4208b" />

<img width="1813" height="765" alt="image" src="https://github.com/user-attachments/assets/d37885b0-3917-4f5e-a8c9-4ff6d83ef984" />


After:

<img width="1862" height="761" alt="image" src="https://github.com/user-attachments/assets/4d6057bc-9e01-4a99-90ed-a68ab6887559" />


**Backport needed: Version-15**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Item-wise Sales Register: Mode of Payment filter now accurately matches invoice payments and returns no results when none exist, preventing misleading entries.

* **Refactor**
  * Query logic streamlined to remove a direct dependency on payment joins; visible fields and report output remain unchanged while reliability and performance are improved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->