### PR TITLE
fix(stock): validate use_serial_batch_fields with serial and batch va…

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -1094,7 +1094,7 @@ class StockEntry(StockController):
 		already_picked_serial_nos = []
 
 		for row in self.items:
-			if row.use_serial_batch_fields:
+			if row.use_serial_batch_fields and (row.serial_no or row.batch_no):
 				continue
 
 			if not row.s_warehouse:


### PR DESCRIPTION
**Issue:**
Incorrect distribution of additional costs in material transfer entries

**Ref: [45657](https://support.frappe.io/helpdesk/tickets/45657)**

**Description:**
 - When a user creates a material transfer with `use_serial_batch_fields` checked but without specifying values for batch_no or serial_no,
 - The stock entry gets submitted with the `valuation_rate` not accounting for the additional costs.
 - As a result, the accounting ledger records the additional costs as a difference amount, leading to inaccuracies in financial reports.

**Solution:**
Add validation to ensure that batch_no and serial_no are provided when `use_serial_batch_fields` is checked. This will enforce the creation of serial and batch bundles for outward entries without incorrectly setting the outward entry rate as the valuation_rate in the voucher detail row.

**Before:**

[additional costs distribution issue.webm](https://github.com/user-attachments/assets/1898e0e7-0a3a-403f-84e9-47fab4a1c42b)

**After:**

[additional costs distribution solved.webm](https://github.com/user-attachments/assets/2f16c39b-4a4d-4c47-bd92-7c9932fa424e)


**Backport Needed: v15**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected handling of items requiring serial/batch tracking in outward stock entries. Items marked for serial/batch tracking without provided serial or batch numbers are no longer skipped and now flow through the serial/batch processing.
  * Improves accuracy of stock movement, traceability, and validation feedback by ensuring these items are processed consistently instead of being silently ignored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->