### PR TITLE
Update Posting Date Logic for Exchange Gain/Loss in Payment Reconciliation

### DIFF
--- a/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.js
+++ b/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.js
@@ -318,7 +318,8 @@ erpnext.accounts.PaymentReconciliationController = class PaymentReconciliationCo
 					},
 					{
 						fieldtype: "HTML",
-						options: "<b> New Journal Entry will be posted for the difference amount </b>",
+						options:
+							"<b> New Journal Entry will be posted for the difference amount. The Posting Date can be changed. </b>",
 					},
 				],
 				primary_action: () => {

--- a/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py
+++ b/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py
@@ -453,7 +453,11 @@ class PaymentReconciliation(Document):
 				res.difference_amount = self.get_difference_amount(pay, inv, res["allocated_amount"])
 				res.difference_account = default_exchange_gain_loss_account
 				res.exchange_rate = inv.get("exchange_rate")
-				res.update({"gain_loss_posting_date": pay.get("posting_date")})
+				payment_date = pay.get("posting_date")
+				invoice_date = inv.get("invoice_date")
+				latest_date = max(payment_date, invoice_date)
+
+				res.update({"gain_loss_posting_date": latest_date})
 				if not pay.get("is_advance"):
 					if exc_gain_loss_posting_date == "Invoice":
 						res.update({"gain_loss_posting_date": inv.get("invoice_date")})
@@ -466,7 +470,6 @@ class PaymentReconciliation(Document):
 				elif inv.get("outstanding_amount") == 0:
 					entries.append(res)
 					continue
-
 			else:
 				break
 


### PR DESCRIPTION
This PR addresses the logic and UI behavior for setting the Posting Date during payment reconciliation involving exchange gain/loss entries.

**Changes Made**:
- Logic Update:
Modified the default behavior to set the Posting Date as the latest of either the Sales Invoice date or the Payment Entry date, ensuring accurate journal entry timing.
- UI Enhancement:
Added a note in the reconciliation dialog stating:
```"The Posting Date can be changed."```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added option to post exchange gain/loss on the Reconciliation Date.
  - Default posting date for exchange gain/loss now uses the later of the payment or invoice date (still honors the "Invoice" setting).

- **Documentation**
  - Clarified dialog text: the Posting Date for the resulting Journal Entry can be changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->