### PR TITLE
Revert "fix: use checkout@v2 instead of v4"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Entire Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           persist-credentials: false


### PR DESCRIPTION
This reverts commit c9d69d9629c67cfae33a3570bc915939cc664e50.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release pipeline to use the latest repository checkout action, improving CI reliability and compatibility.
  * No changes to application behavior; end-users will not see any differences.
  * Release processes and schedules remain unaffected.
  * No action required from users or administrators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->