### PR TITLE
fix: ignore links in Dunning patch

### DIFF
--- a/erpnext/patches/v14_0/single_to_multi_dunning.py
+++ b/erpnext/patches/v14_0/single_to_multi_dunning.py
@@ -48,6 +48,7 @@ def execute():
 		dunning.validate()
 
 		dunning.flags.ignore_validate_update_after_submit = True
+		dunning.flags.ignore_links = True
 		dunning.save()
 
 		# Reverse entries only if dunning is submitted and not resolved


### PR DESCRIPTION
When migrating old **Dunnings** to the new data structure, we may need to set links to cancelled **Sales Invoices** (previously on the parent, now on the child row level). By setting `doc.flags.ignore_links = True`, we prevent `frappe.exceptions.CancelledLinkError` during migration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved failures during Dunning document migration by adjusting validation behavior during save, preventing link-related errors.
  - Improves reliability of the Dunning patch, ensuring smoother upgrades with fewer interruptions and retries.
  - Users upgrading should experience more consistent patch execution without errors caused by linked records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->