### PR TITLE
fix: apply grand total to default payment mode in Sales and POS invoices

### DIFF
--- a/erpnext/accounts/doctype/pos_invoice/pos_invoice.js
+++ b/erpnext/accounts/doctype/pos_invoice/pos_invoice.js
@@ -55,6 +55,16 @@ erpnext.selling.POSInvoiceController = class POSInvoiceController extends erpnex
 		});
 
 		erpnext.accounts.dimensions.setup_dimension_filters(this.frm, this.frm.doctype);
+
+		if (this.frm.doc.pos_profile) {
+			frappe.db
+				.get_value("POS Profile", this.frm.doc.pos_profile, "set_grand_total_to_default_mop")
+				.then((r) => {
+					if (!r.exc) {
+						this.frm.set_default_payment = r.message.set_grand_total_to_default_mop;
+					}
+				});
+		}
 	}
 
 	onload_post_render(frm) {
@@ -120,6 +130,7 @@ erpnext.selling.POSInvoiceController = class POSInvoiceController extends erpnex
 						this.frm.meta.default_print_format = r.message.print_format || "";
 						this.frm.doc.campaign = r.message.campaign;
 						this.frm.allow_print_before_pay = r.message.allow_print_before_pay;
+						this.frm.set_default_payment = r.message.set_default_payment;
 					}
 					this.frm.script_manager.trigger("update_stock");
 					this.calculate_taxes_and_totals();

--- a/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
+++ b/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
@@ -732,6 +732,7 @@ class POSInvoice(SalesInvoice):
 				"utm_campaign": profile.get("utm_campaign"),
 				"utm_medium": profile.get("utm_medium"),
 				"allow_print_before_pay": profile.get("allow_print_before_pay"),
+				"set_default_payment": profile.get("set_grand_total_to_default_mop"),
 			}
 
 	@frappe.whitelist()

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
@@ -58,6 +58,13 @@ erpnext.accounts.SalesInvoiceController = class SalesInvoiceController extends (
 
 			me.frm.script_manager.trigger("is_pos");
 			me.frm.refresh_fields();
+			frappe.db
+				.get_value("POS Profile", this.frm.doc.pos_profile, "set_grand_total_to_default_mop")
+				.then((r) => {
+					if (!r.exc) {
+						me.frm.set_default_payment = r.message.set_grand_total_to_default_mop;
+					}
+				});
 		}
 		erpnext.queries.setup_warehouse_query(this.frm);
 	}
@@ -512,8 +519,9 @@ erpnext.accounts.SalesInvoiceController = class SalesInvoiceController extends (
 					},
 					callback: function (r) {
 						if (!r.exc) {
-							if (r.message && r.message.print_format) {
+							if (r.message) {
 								me.frm.pos_print_format = r.message.print_format;
+								me.frm.set_default_payment = r.message.set_default_payment;
 							}
 							me.frm.trigger("update_stock");
 							if (me.frm.doc.taxes_and_charges) {

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -764,6 +764,7 @@ class SalesInvoice(SellingController):
 				"utm_campaign": pos.get("utm_campaign"),
 				"utm_medium": pos.get("utm_medium"),
 				"allow_print_before_pay": pos.get("allow_print_before_pay"),
+				"set_default_payment": pos.get("set_grand_total_to_default_mop", 1),
 			}
 
 	@frappe.whitelist()

--- a/erpnext/public/js/controllers/taxes_and_totals.js
+++ b/erpnext/public/js/controllers/taxes_and_totals.js
@@ -946,8 +946,8 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 	set_default_payment(total_amount_to_pay, update_paid_amount) {
 		var me = this;
 		var payment_status = true;
-		if(this.frm.doc.is_pos && (update_paid_amount===undefined || update_paid_amount)) {
-
+		const set_payment = flt(this.frm.doc.paid_amount) || cint(this.frm.set_default_payment);
+		if(this.frm.doc.is_pos && set_payment && (update_paid_amount===undefined || update_paid_amount)) {
 			$.each(this.frm.doc['payments'] || [], function(index, data) {
 				if(data.default && payment_status && total_amount_to_pay > 0) {
 					let base_amount, amount;

--- a/erpnext/selling/page/point_of_sale/pos_payment.js
+++ b/erpnext/selling/page/point_of_sale/pos_payment.js
@@ -450,7 +450,6 @@ erpnext.PointOfSale.Payment = class {
 	}
 
 	render_payment_section() {
-		this.grand_total_to_default_mop();
 		this.render_payment_mode_dom();
 		this.make_invoice_field_dialog();
 		this.update_totals_section();
@@ -496,17 +495,6 @@ erpnext.PointOfSale.Payment = class {
 			});
 			this[`remark_control`].set_value("");
 		}
-	}
-
-	grand_total_to_default_mop() {
-		if (this.set_gt_to_default_mop) return;
-		const doc = this.events.get_frm().doc;
-		const payments = doc.payments;
-		payments.forEach((p) => {
-			if (p.default) {
-				frappe.model.set_value(p.doctype, p.name, "amount", 0);
-			}
-		});
 	}
 
 	render_payment_mode_dom() {


### PR DESCRIPTION
Fixed the issue with applying the Grand Total to the Default Payment Mode with Sales Invoice and POS Invoice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * POS and Sales Invoice now honor a configurable "default payment" flag coming from POS Profile and server responses.

* **Improvements**
  * Default payment is applied only when enabled or when a paid amount exists, reducing unintended auto-fills.
  * POS payment screen no longer resets payment amounts during rendering, preserving user entries.
  * Printing and payment defaults load more reliably during invoice creation.

* **Bug Fixes**
  * Prevents unexpected default payment when paid amount is zero and no configuration is set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->