### PR TITLE
fix: prevent auto-setting payment amount if set_grand_total_to_default_mop is disabled

### DIFF
--- a/erpnext/public/js/controllers/taxes_and_totals.js
+++ b/erpnext/public/js/controllers/taxes_and_totals.js
@@ -946,8 +946,12 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 	set_default_payment(total_amount_to_pay, update_paid_amount) {
 		var me = this;
 		var payment_status = true;
-		const set_payment = flt(this.frm.doc.paid_amount) || cint(this.frm.set_default_payment);
-		if(this.frm.doc.is_pos && set_payment && (update_paid_amount===undefined || update_paid_amount)) {
+
+		if (
+			this.frm.doc.is_pos
+			&& cint(this.frm.set_default_payment)
+			&& (update_paid_amount===undefined || update_paid_amount)
+		) {
 			$.each(this.frm.doc['payments'] || [], function(index, data) {
 				if(data.default && payment_status && total_amount_to_pay > 0) {
 					let base_amount, amount;


### PR DESCRIPTION
Fixes the issue to prevent auto-setting the payment amount for the default payment method in cases where the paid amount for an invoice is already set, despite the POS Profile configuration `set_grand_total_to_default_mop` being disabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Default payment now applies even when the paid amount is zero (when enabled), ensuring expected POS behavior.
  - More accurate calculations for payments in multi-currency scenarios using the correct conversion logic.
  - Ensures only the primary default payment row is filled and other rows are cleared when a payment exists.
  - More consistent handling when updating the paid amount, reducing unexpected overwrites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->