### PR TITLE
fix(pick list): update warehouse property on refresh

### DIFF
--- a/erpnext/stock/doctype/pick_list/pick_list.js
+++ b/erpnext/stock/doctype/pick_list/pick_list.js
@@ -100,7 +100,11 @@ frappe.ui.form.on("Pick List", {
 		}
 	},
 
-	pick_manually: function (frm) {
+	pick_manually: (frm) => {
+		frm.trigger("update_warehouse_property");
+	},
+
+	update_warehouse_property: (frm) => {
 		frm.fields_dict.locations.grid.update_docfield_property(
 			"warehouse",
 			"read_only",
@@ -114,6 +118,7 @@ frappe.ui.form.on("Pick List", {
 	},
 	refresh: (frm) => {
 		frm.trigger("add_get_items_button");
+		frm.trigger("update_warehouse_property");
 		if (frm.doc.docstatus === 1) {
 			const status_completed = frm.doc.status === "Completed";
 			frm.set_df_property("locations", "allow_on_submit", status_completed ? 0 : 1);


### PR DESCRIPTION
Issue: In Pick List draft records, the warehouse field is not editable even when Pick Manually is checked.

Before:

https://github.com/user-attachments/assets/01982759-ebaf-4e13-a90e-4306b1d53c7c

After:

https://github.com/user-attachments/assets/fabed0ed-93d3-49e7-a09c-f3c51554d12e

Backport needed: v15

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * In Pick List locations, the Warehouse field now automatically switches to editable when “Pick Manually” is enabled and returns to read-only when disabled.
  * The Warehouse field’s state updates instantly when toggling “Pick Manually,” removing the need for manual refreshes.
  * The editability state is preserved and correctly restored on form refresh, ensuring consistent behavior across sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->