### PR TITLE
fix(stock): don't override t_warehouse if no rules found

### DIFF
--- a/erpnext/stock/doctype/putaway_rule/putaway_rule.py
+++ b/erpnext/stock/doctype/putaway_rule/putaway_rule.py
@@ -131,7 +131,12 @@ def apply_putaway_rule(doctype, items, company, sync=None, purpose=None):
 		at_capacity, rules = get_ordered_putaway_rules(item_code, company, source_warehouse=source_warehouse)
 
 		if not rules:
-			warehouse = source_warehouse or item.get("warehouse")
+			warehouse = (
+				(source_warehouse or item.get("warehouse"))
+				if not item.get("t_warehouse")
+				else item.get("t_warehouse")
+			)
+
 			if at_capacity:
 				# rules available, but no free space
 				items_not_accomodated.append([item_code, pending_qty])


### PR DESCRIPTION
**Issue:**
When user creates a material transfer entry with `apply_putaway_rule` checked but no rules created, the system overrides the `t_warehouse` as `s_warehouse` explicitly.

**Ref:** [46795](https://support.frappe.io/helpdesk/tickets/46795) 

**Before:**

[putaway rule warehouse issue.webm](https://github.com/user-attachments/assets/3cf59425-e9b3-4f56-bc5e-72232bcbcea9)

**After:**

[putaway rule warehouse solved.webm](https://github.com/user-attachments/assets/a30bfc05-2b93-4249-b544-d6a454b4b92b)

**Backport Needed: v15**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Putaway now respects the selected target warehouse when no putaway rules exist. The system prioritizes the transaction’s target warehouse before falling back to the source or item warehouse, preventing items from being placed in unintended locations. This improves accuracy and consistency during stock transfers and receipts, aligning warehouse assignment with user choice and reducing manual corrections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->