### PR TITLE
fix: set missing due date in Purchase Invoice and POS Invoice

### DIFF
--- a/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
+++ b/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
@@ -717,7 +717,13 @@ class POSInvoice(SalesInvoice):
 				"Account", self.debit_to, "account_currency"
 			)
 		if not self.due_date and self.customer:
-			self.due_date = get_due_date(self.posting_date, "Customer", self.customer, self.company)
+			self.due_date = get_due_date(
+				self.posting_date,
+				"Customer",
+				self.customer,
+				self.company,
+				template_name=self.payment_terms_template,
+			)
 
 		super(SalesInvoice, self).set_missing_values(for_validate)
 

--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
@@ -343,7 +343,12 @@ class PurchaseInvoice(BuyingController):
 			)
 		if not self.due_date:
 			self.due_date = get_due_date(
-				self.posting_date, "Supplier", self.supplier, self.company, self.bill_date
+				self.posting_date,
+				"Supplier",
+				self.supplier,
+				self.company,
+				self.bill_date,
+				template_name=self.payment_terms_template,
 			)
 
 		tds_category = frappe.db.get_value("Supplier", self.supplier, "tax_withholding_category")


### PR DESCRIPTION
Original issue: **Auto Repeat** on **Purchase Invoice** fails because the _Due Date_ does not match the selected _Payment Terms Template_.

<details>
<summary>Stack trace</summary>

```python
ar = frappe.get_doc("Auto Repeat", "AUT-AR-00001")
assert ar.reference_doctype == "Purchase Invoice"
ar.make_new_document()

File apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py:244, in AutoRepeat.make_new_document(self)
    238 self.update_doc(new_doc, reference_doc)
    239 new_doc.flags.updater_reference = {
    240         "doctype": self.doctype,
    241         "docname": self.name,
    242         "label": _("via Auto Repeat"),
    243 }
--> 244 new_doc.insert(ignore_permissions=True)
    246 if self.submit_on_creation:
    247         new_doc.submit()

File apps/frappe/frappe/model/document.py:309, in Document.insert(self, ignore_permissions, ignore_links, ignore_if_duplicate, ignore_mandatory, set_name, set_child_names)
    306 self.validate_higher_perm_levels()
    308 self.flags.in_insert = True
--> 309 self.run_before_save_methods()
    310 self._validate()
    311 self.set_docstatus()

File apps/frappe/frappe/model/document.py:1136, in Document.run_before_save_methods(self)
   1133         return
   1135 if self._action == "save":
-> 1136         self.run_method("validate")
   1137         self.run_method("before_save")
   1138 elif self._action == "submit":

File apps/frappe/frappe/model/document.py:1007, in Document.run_method(self, method, *args, **kwargs)
   1004                 return method_object(*args, **kwargs)
   1006 fn.__name__ = str(method)
-> 1007 out = Document.hook(fn)(self, *args, **kwargs)
   1009 self.run_notifications(method)
   1010 run_webhooks(self, method)

File apps/frappe/frappe/model/document.py:1367, in Document.hook.<locals>.composer(self, *args, **kwargs)
   1364         hooks.append(frappe.get_attr(handler))
   1366 composed = compose(f, *hooks)
-> 1367 return composed(self, method, *args, **kwargs)

File apps/frappe/frappe/model/document.py:1349, in Document.hook.<locals>.compose.<locals>.runner(self, method, *args, **kwargs)
   1348 def runner(self, method, *args, **kwargs):
-> 1349         add_to_return_value(self, fn(self, *args, **kwargs))
   1350         for f in hooks:
   1351                 add_to_return_value(self, f(self, method, *args, **kwargs))

File apps/frappe/frappe/model/document.py:1004, in Document.run_method.<locals>.fn(self, *args, **kwargs)
   1001 # Cannot have a field with same name as method
   1002 # If method found in __dict__, expect it to be callable
   1003 if method in self.__dict__ or callable(method_object):
-> 1004         return method_object(*args, **kwargs)

File apps/erpnext/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py:264, in PurchaseInvoice.validate(self)
    260         self.is_opening = "No"
    262 self.validate_posting_time()
--> 264 super().validate()
    266 if not self.is_return:
    267         self.po_required()

File apps/erpnext/erpnext/controllers/buying_controller.py:33, in BuyingController.validate(self)
     30 def validate(self):
     31         self.set_rate_for_standalone_debit_note()
---> 33         super().validate()
     34         if getattr(self, "supplier", None) and not self.supplier_name:
     35                 self.supplier_name = frappe.db.get_value("Supplier", self.supplier, "supplier_name")

File apps/erpnext/erpnext/controllers/subcontracting_controller.py:56, in SubcontractingController.validate(self)
     54         self.create_raw_materials_supplied()
     55 else:
---> 56         super().validate()

File apps/erpnext/erpnext/controllers/stock_controller.py:52, in StockController.validate(self)
     51 def validate(self):
---> 52         super().validate()
     54         if self.docstatus == 0:
     55                 for table_name in ["items", "packed_items", "supplied_items"]:

File apps/erpnext/erpnext/controllers/accounts_controller.py:261, in AccountsController.validate(self)
    257                 self.validate_value("base_grand_total", ">=", 0)
    259         validate_return(self)
--> 261 self.validate_all_documents_schedule()
    263 self.validate_party()
    264 self.validate_currency()

File apps/erpnext/erpnext/controllers/accounts_controller.py:606, in AccountsController.validate_all_documents_schedule(self)
    604 def validate_all_documents_schedule(self):
    605         if self.doctype in ("Sales Invoice", "Purchase Invoice"):
--> 606                 self.validate_invoice_documents_schedule()
    607         elif self.doctype in ("Quotation", "Purchase Order", "Sales Order"):
    608                 self.validate_non_invoice_documents_schedule()

File apps/erpnext/erpnext/controllers/accounts_controller.py:596, in AccountsController.validate_invoice_documents_schedule(self)
    594 if not self.get("ignore_default_payment_terms_template"):
    595         self.validate_payment_schedule_amount()
--> 596         self.validate_due_date()
    597 self.validate_advance_entries()

File apps/erpnext/erpnext/controllers/accounts_controller.py:876, in AccountsController.validate_due_date(self)
    874         validate_due_date(posting_date, self.due_date, None, self.payment_terms_template, self.doctype)
    875 elif self.doctype == "Purchase Invoice":
--> 876         validate_due_date(
    877                 posting_date, self.due_date, self.bill_date, self.payment_terms_template, self.doctype
    878         )

File apps/erpnext/erpnext/accounts/party.py:672, in validate_due_date(posting_date, due_date, bill_date, template_name, doctype)
    670         frappe.throw(_("Due Date cannot be before Posting / Supplier Invoice Date"))
    671 else:
--> 672         validate_due_date_with_template(posting_date, due_date, bill_date, template_name, doctype)

File apps/erpnext/erpnext/accounts/party.py:695, in validate_due_date_with_template(posting_date, due_date, bill_date, template_name, doctype)
    688         msgprint(
    689                 _("Note: Due Date exceeds allowed {0} credit days by {1} day(s)").format(
    690                         party_type, date_diff(due_date, default_due_date)
    691                 )
    692         )
    694 else:
--> 695         frappe.throw(_("Due / Reference Date cannot be after {0}").format(formatdate(default_due_date)))

File apps/frappe/frappe/__init__.py:609, in throw(msg, exc, title, is_minimizable, wide, as_list, primary_action)
    590 def throw(
    591         msg: str,
    592         exc: type[Exception] | Exception = ValidationError,
   (...)
    597         primary_action=None,
    598 ) -> None:
    599         """Throw execption and show message (`msgprint`).
    600 
    601         :param msg: Message.
   (...)
    607         :param primary_action: [optional] Bind a primary server/client side action.
    608         """
--> 609         msgprint(
    610                 msg,
    611                 raise_exception=exc,
    612                 title=title,
    613                 indicator="red",
    614                 is_minimizable=is_minimizable,
    615                 wide=wide,
    616                 as_list=as_list,
    617                 primary_action=primary_action,
    618         )

File apps/frappe/frappe/__init__.py:574, in msgprint(msg, title, raise_exception, as_table, as_list, indicator, alert, primary_action, is_minimizable, wide, realtime)
    572 else:
    573         message_log.append(out)
--> 574 _raise_exception()

File apps/frappe/frappe/__init__.py:525, in msgprint.<locals>._raise_exception()
    523 if out.__frappe_exc_id:
    524         exc.__frappe_exc_id = out.__frappe_exc_id
--> 525 raise exc

ValidationError: Due / Reference Date cannot be after 05.10.2025
```

</details>

Analysis: _Due Date_ is marked as _No Copy_, but `set_missing_values` still adds it. Here the selected _Payment Terms Template_ was not being considered, so the resulting date was incorrect. `validate_due_date_with_template` later catches that.

Fix: Take into account the selected _Payment Terms Template_ when setting the missing _Due Date_ in **Purchase Invoice** (and **POS Invoice**, which seems to suffer from the same problem).