### PR TITLE
style: format controllers with prettier

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,8 +32,6 @@ repos:
                 cypress/.*|
                 .*node_modules.*|
                 .*boilerplate.*|
-                erpnext/public/js/controllers/.*|
-                erpnext/templates/pages/order.js|
                 erpnext/templates/includes/.*
             )$
 

--- a/erpnext/public/js/controllers/accounts.js
+++ b/erpnext/public/js/controllers/accounts.js
@@ -5,61 +5,69 @@
 frappe.provide("erpnext.taxes");
 
 erpnext.accounts.taxes = {
-	setup_tax_validations: function(doctype) {
+	setup_tax_validations: function (doctype) {
 		let me = this;
 		frappe.ui.form.on(doctype, {
-			setup: function(frm) {
+			setup: function (frm) {
 				// set conditional display for rate column in taxes
-				$(frm.wrapper).on('grid-row-render', function(e, grid_row) {
-					if(['Sales Taxes and Charges', 'Purchase Taxes and Charges'].includes(grid_row.doc.doctype)) {
+				$(frm.wrapper).on("grid-row-render", function (e, grid_row) {
+					if (
+						["Sales Taxes and Charges", "Purchase Taxes and Charges"].includes(
+							grid_row.doc.doctype
+						)
+					) {
 						me.set_conditional_mandatory_rate_or_amount(grid_row);
 					}
 				});
 			},
-			onload: function(frm) {
-				if(frm.get_field("taxes")) {
-					frm.set_query("account_head", "taxes", function(doc) {
-						if(frm.cscript.tax_table == "Sales Taxes and Charges") {
+			onload: function (frm) {
+				if (frm.get_field("taxes")) {
+					frm.set_query("account_head", "taxes", function (doc) {
+						if (frm.cscript.tax_table == "Sales Taxes and Charges") {
 							var account_type = ["Tax", "Chargeable", "Expense Account"];
 						} else {
-							var account_type = ["Tax", "Chargeable", "Income Account", "Expenses Included In Valuation"];
+							var account_type = [
+								"Tax",
+								"Chargeable",
+								"Income Account",
+								"Expenses Included In Valuation",
+							];
 						}
 
 						return {
 							query: "erpnext.controllers.queries.tax_account_query",
 							filters: {
-								"account_type": account_type,
-								"company": doc.company,
-							}
-						}
+								account_type: account_type,
+								company: doc.company,
+							},
+						};
 					});
-					frm.set_query("cost_center", "taxes", function(doc) {
+					frm.set_query("cost_center", "taxes", function (doc) {
 						return {
 							filters: {
-								"company": doc.company,
-								"is_group": 0
-							}
+								company: doc.company,
+								is_group: 0,
+							},
 						};
 					});
 				}
 			},
-			validate: function(frm) {
+			validate: function (frm) {
 				// neither is absolutely mandatory
-				if(frm.get_docfield("taxes")) {
+				if (frm.get_docfield("taxes")) {
 					frm.get_docfield("taxes", "rate").reqd = 0;
 					frm.get_docfield("taxes", "tax_amount").reqd = 0;
 				}
-
 			},
-			taxes_on_form_rendered: function(frm) {
+			taxes_on_form_rendered: function (frm) {
 				me.set_conditional_mandatory_rate_or_amount(frm.open_grid_row());
 			},
 		});
 	},
 
-	set_conditional_mandatory_rate_or_amount: function(grid_row) {
-		if(grid_row) {
-			if(grid_row.doc.charge_type==="Actual") {
+	set_conditional_mandatory_rate_or_amount: function (grid_row) {
+		if (grid_row) {
+			if (grid_row.doc.charge_type === "Actual") {
 				grid_row.toggle_editable("tax_amount", true);
 				grid_row.toggle_reqd("tax_amount", true);
 				grid_row.toggle_editable("rate", false);
@@ -73,31 +81,45 @@ erpnext.accounts.taxes = {
 		}
 	},
 
-	validate_taxes_and_charges: function(cdt, cdn) {
+	validate_taxes_and_charges: function (cdt, cdn) {
 		let d = locals[cdt][cdn];
 		let msg = "";
 
 		if (d.account_head && !d.description) {
 			// set description from account head
-			d.description = d.account_head.split(' - ').slice(0, -1).join(' - ');
+			d.description = d.account_head.split(" - ").slice(0, -1).join(" - ");
 		}
 
 		if (!d.charge_type && (d.row_id || d.rate || d.tax_amount)) {
 			msg = __("Please select Charge Type first");
 			d.row_id = "";
 			d.rate = d.tax_amount = 0.0;
-		} else if ((d.charge_type == 'Actual' || d.charge_type == 'On Net Total' || d.charge_type == 'On Paid Amount') && d.row_id) {
-			msg = __("Can refer row only if the charge type is 'On Previous Row Amount' or 'Previous Row Total'");
+		} else if (
+			(d.charge_type == "Actual" ||
+				d.charge_type == "On Net Total" ||
+				d.charge_type == "On Paid Amount") &&
+			d.row_id
+		) {
+			msg = __(
+				"Can refer row only if the charge type is 'On Previous Row Amount' or 'Previous Row Total'"
+			);
 			d.row_id = "";
-		} else if ((d.charge_type == 'On Previous Row Amount' || d.charge_type == 'On Previous Row Total') && d.row_id) {
+		} else if (
+			(d.charge_type == "On Previous Row Amount" || d.charge_type == "On Previous Row Total") &&
+			d.row_id
+		) {
 			if (d.idx == 1) {
-				msg = __("Cannot select charge type as 'On Previous Row Amount' or 'On Previous Row Total' for first row");
-				d.charge_type = '';
+				msg = __(
+					"Cannot select charge type as 'On Previous Row Amount' or 'On Previous Row Total' for first row"
+				);
+				d.charge_type = "";
 			} else if (!d.row_id) {
 				msg = __("Please specify a valid Row ID for row {0} in table {1}", [d.idx, __(d.doctype)]);
 				d.row_id = "";
 			} else if (d.row_id && d.row_id >= d.idx) {
-				msg = __("Cannot refer row number greater than or equal to current row number for this Charge type");
+				msg = __(
+					"Cannot refer row number greater than or equal to current row number for this Charge type"
+				);
 				d.row_id = "";
 			}
 		}
@@ -106,13 +128,12 @@ erpnext.accounts.taxes = {
 			refresh_field("taxes");
 			frappe.throw(msg);
 		}
-
 	},
 
-	setup_tax_filters: function(doctype) {
+	setup_tax_filters: function (doctype) {
 		let me = this;
 		frappe.ui.form.on(doctype, {
-			account_head: function(frm, cdt, cdn) {
+			account_head: function (frm, cdt, cdn) {
 				let d = locals[cdt][cdn];
 
 				if (d.docstatus == 1) {
@@ -120,150 +141,157 @@ erpnext.accounts.taxes = {
 					return;
 				}
 
-				if(!d.charge_type && d.account_head){
+				if (!d.charge_type && d.account_head) {
 					frappe.msgprint(__("Please select Charge Type first"));
 					frappe.model.set_value(cdt, cdn, "account_head", "");
 				} else if (d.account_head) {
 					frappe.call({
-						type:"GET",
+						type: "GET",
 						method: "erpnext.controllers.accounts_controller.get_tax_rate",
-						args: {"account_head":d.account_head},
-						callback: function(r) {
-							if (d.charge_type!=="Actual") {
+						args: { account_head: d.account_head },
+						callback: function (r) {
+							if (d.charge_type !== "Actual") {
 								frappe.model.set_value(cdt, cdn, "rate", r.message.tax_rate || 0);
 							}
 							frappe.model.set_value(cdt, cdn, "description", r.message.account_name);
-						}
-					})
+						},
+					});
 				}
 			},
-			row_id: function(frm, cdt, cdn) {
+			row_id: function (frm, cdt, cdn) {
 				me.validate_taxes_and_charges(cdt, cdn);
 			},
-			rate: function(frm, cdt, cdn) {
+			rate: function (frm, cdt, cdn) {
 				me.validate_taxes_and_charges(cdt, cdn);
 			},
-			tax_amount: function(frm, cdt, cdn) {
+			tax_amount: function (frm, cdt, cdn) {
 				me.validate_taxes_and_charges(cdt, cdn);
 			},
-			charge_type: function(frm, cdt, cdn) {
+			charge_type: function (frm, cdt, cdn) {
 				me.validate_taxes_and_charges(cdt, cdn);
 				let open_form = frm.open_grid_row();
-				if(open_form) {
+				if (open_form) {
 					me.set_conditional_mandatory_rate_or_amount(open_form);
 				} else {
 					// apply in current row
-					me.set_conditional_mandatory_rate_or_amount(frm.get_field('taxes').grid.get_row(cdn));
+					me.set_conditional_mandatory_rate_or_amount(frm.get_field("taxes").grid.get_row(cdn));
 				}
 			},
-			included_in_print_rate: function(frm, cdt, cdn) {
+			included_in_print_rate: function (frm, cdt, cdn) {
 				let tax = frappe.get_doc(cdt, cdn);
 				try {
 					me.validate_taxes_and_charges(cdt, cdn);
 					me.validate_inclusive_tax(tax, frm);
-				} catch(e) {
+				} catch (e) {
 					tax.included_in_print_rate = 0;
 					refresh_field("included_in_print_rate", tax.name, tax.parentfield);
 					throw e;
 				}
-			}
+			},
 		});
 	},
 
-	validate_inclusive_tax: function(tax, frm) {
+	validate_inclusive_tax: function (tax, frm) {
 		this.frm = this.frm || frm;
-		let actual_type_error = function() {
-			var msg = __("Actual type tax cannot be included in Item rate in row {0}", [tax.idx])
+		let actual_type_error = function () {
+			var msg = __("Actual type tax cannot be included in Item rate in row {0}", [tax.idx]);
 			frappe.throw(msg);
 		};
 
-		let on_previous_row_error = function(row_range) {
-			var msg = __("For row {0} in {1}. To include {2} in Item rate, rows {3} must also be included",
-				[tax.idx, __(tax.doctype), tax.charge_type, row_range])
+		let on_previous_row_error = function (row_range) {
+			var msg = __("For row {0} in {1}. To include {2} in Item rate, rows {3} must also be included", [
+				tax.idx,
+				__(tax.doctype),
+				tax.charge_type,
+				row_range,
+			]);
 			frappe.throw(msg);
 		};
 
-		if(cint(tax.included_in_print_rate)) {
-			if(tax.charge_type == "Actual") {
+		if (cint(tax.included_in_print_rate)) {
+			if (tax.charge_type == "Actual") {
 				// inclusive tax cannot be of type Actual
 				actual_type_error();
-			} else if (tax.charge_type == "On Previous Row Amount" && this.frm &&
+			} else if (
+				tax.charge_type == "On Previous Row Amount" &&
+				this.frm &&
 				!cint(this.frm.doc["taxes"][tax.row_id - 1].included_in_print_rate)
 			) {
 				// referred row should also be an inclusive tax
 				on_previous_row_error(tax.row_id);
 			} else if (tax.charge_type == "On Previous Row Total" && this.frm) {
-				var taxes_not_included = $.map(this.frm.doc["taxes"].slice(0, tax.row_id),
-					function(t) { return cint(t.included_in_print_rate) ? null : t; });
-				if(taxes_not_included.length > 0) {
+				var taxes_not_included = $.map(this.frm.doc["taxes"].slice(0, tax.row_id), function (t) {
+					return cint(t.included_in_print_rate) ? null : t;
+				});
+				if (taxes_not_included.length > 0) {
 					// all rows above this tax should be inclusive
 					on_previous_row_error(tax.row_id == 1 ? "1" : "1 - " + tax.row_id);
 				}
-			} else if(tax.category == "Valuation") {
+			} else if (tax.category == "Valuation") {
 				frappe.throw(__("Valuation type charges can not marked as Inclusive"));
 			}
 		}
-	}
-}
+	},
+};
 
 erpnext.accounts.payment_triggers = {
-	setup: function(doctype) {
+	setup: function (doctype) {
 		frappe.ui.form.on(doctype, {
 			allocate_advances_automatically(frm) {
-				frm.trigger('fetch_advances');
+				frm.trigger("fetch_advances");
 			},
 
 			only_include_allocated_payments(frm) {
-				frm.trigger('fetch_advances');
+				frm.trigger("fetch_advances");
 			},
 
 			fetch_advances(frm) {
-				if(frm.doc.allocate_advances_automatically) {
+				if (frm.doc.allocate_advances_automatically) {
 					frappe.call({
 						doc: frm.doc,
 						method: "set_advances",
-						callback: function(r, rt) {
+						callback: function (r, rt) {
 							refresh_field("advances");
-						}
-					})
+						},
+					});
 				}
-			}
+			},
 		});
 	},
-}
+};
 
 erpnext.accounts.pos = {
-	setup: function(doctype) {
+	setup: function (doctype) {
 		frappe.ui.form.on(doctype, {
-			mode_of_payment: function(frm, cdt, cdn) {
+			mode_of_payment: function (frm, cdt, cdn) {
 				var d = locals[cdt][cdn];
-				get_payment_mode_account(frm, d.mode_of_payment, function(account){
-					frappe.model.set_value(cdt, cdn, 'account', account)
-				})
-			}
+				get_payment_mode_account(frm, d.mode_of_payment, function (account) {
+					frappe.model.set_value(cdt, cdn, "account", account);
+				});
+			},
 		});
 	},
 
-	get_payment_mode_account: function(frm, mode_of_payment, callback) {
-		if(!frm.doc.company) {
-			frappe.throw({message:__("Please select a Company first."), title: __("Mandatory")});
+	get_payment_mode_account: function (frm, mode_of_payment, callback) {
+		if (!frm.doc.company) {
+			frappe.throw({ message: __("Please select a Company first."), title: __("Mandatory") });
 		}
 
-		if(!mode_of_payment) {
+		if (!mode_of_payment) {
 			return;
 		}
 
-		return  frappe.call({
+		return frappe.call({
 			method: "erpnext.accounts.doctype.sales_invoice.sales_invoice.get_bank_cash_account",
 			args: {
-				"mode_of_payment": mode_of_payment,
-				"company": frm.doc.company
+				mode_of_payment: mode_of_payment,
+				company: frm.doc.company,
 			},
-			callback: function(r, rt) {
-				if(r.message) {
-					callback(r.message.account)
+			callback: function (r, rt) {
+				if (r.message) {
+					callback(r.message.account);
 				}
-			}
+			},
 		});
-	}
-}
+	},
+};

--- a/erpnext/public/js/controllers/buying.js
+++ b/erpnext/public/js/controllers/buying.js
@@ -5,7 +5,7 @@ frappe.provide("erpnext.buying");
 // cur_frm.add_fetch('project', 'cost_center', 'cost_center');
 
 erpnext.buying = {
-	setup_buying_controller: function() {
+	setup_buying_controller: function () {
 		erpnext.buying.BuyingController = class BuyingController extends erpnext.TransactionController {
 			setup() {
 				super.setup();
@@ -17,11 +17,11 @@ erpnext.buying = {
 				this.setup_queries(doc, cdt, cdn);
 				super.onload();
 
-				this.frm.set_query('shipping_rule', function() {
+				this.frm.set_query("shipping_rule", function () {
 					return {
 						filters: {
-							"shipping_rule_type": "Buying"
-						}
+							shipping_rule_type: "Buying",
+						},
 					};
 				});
 
@@ -33,29 +33,28 @@ erpnext.buying = {
 					};
 				});
 
-				if (this.frm.doc.__islocal
-					&& frappe.meta.has_field(this.frm.doc.doctype, "disable_rounded_total")) {
-
-						var df = frappe.meta.get_docfield(this.frm.doc.doctype, "disable_rounded_total");
-						var disable = cint(df.default) || cint(frappe.sys_defaults.disable_rounded_total);
-						this.frm.set_value("disable_rounded_total", disable);
+				if (
+					this.frm.doc.__islocal &&
+					frappe.meta.has_field(this.frm.doc.doctype, "disable_rounded_total")
+				) {
+					var df = frappe.meta.get_docfield(this.frm.doc.doctype, "disable_rounded_total");
+					var disable = cint(df.default) || cint(frappe.sys_defaults.disable_rounded_total);
+					this.frm.set_value("disable_rounded_total", disable);
 				}
 
-
 				// no idea where me is coming from
-				if(this.frm.get_field('shipping_address')) {
+				if (this.frm.get_field("shipping_address")) {
 					this.frm.set_query("shipping_address", () => {
-						if(this.frm.doc.customer) {
+						if (this.frm.doc.customer) {
 							return {
-								query: 'frappe.contacts.doctype.address.address.address_query',
-								filters: { link_doctype: 'Customer', link_name: this.frm.doc.customer }
+								query: "frappe.contacts.doctype.address.address.address_query",
+								filters: { link_doctype: "Customer", link_name: this.frm.doc.customer },
 							};
-						} else
-							return erpnext.queries.company_address_query(this.frm.doc)
+						} else return erpnext.queries.company_address_query(this.frm.doc);
 					});
 				}
 
-				if(this.frm.get_field('dispatch_address')) {
+				if (this.frm.get_field("dispatch_address")) {
 					this.frm.set_query("dispatch_address", () => {
 						return erpnext.queries.address_query(this.frm.doc);
 					});
@@ -65,76 +64,77 @@ erpnext.buying = {
 			setup_queries(doc, cdt, cdn) {
 				var me = this;
 
-				if(this.frm.fields_dict.buying_price_list) {
-					this.frm.set_query("buying_price_list", function() {
-						return{
-							filters: { 'buying': 1 }
-						}
+				if (this.frm.fields_dict.buying_price_list) {
+					this.frm.set_query("buying_price_list", function () {
+						return {
+							filters: { buying: 1 },
+						};
 					});
 				}
 
-				if(this.frm.fields_dict.tc_name) {
-					this.frm.set_query("tc_name", function() {
-						return{
-							filters: { 'buying': 1 }
-						}
+				if (this.frm.fields_dict.tc_name) {
+					this.frm.set_query("tc_name", function () {
+						return {
+							filters: { buying: 1 },
+						};
 					});
 				}
 
-				me.frm.set_query('supplier', erpnext.queries.supplier);
-				me.frm.set_query('contact_person', erpnext.queries.contact_query);
-				me.frm.set_query('supplier_address', erpnext.queries.address_query);
+				me.frm.set_query("supplier", erpnext.queries.supplier);
+				me.frm.set_query("contact_person", erpnext.queries.contact_query);
+				me.frm.set_query("supplier_address", erpnext.queries.address_query);
 
-				me.frm.set_query('billing_address', erpnext.queries.company_address_query);
+				me.frm.set_query("billing_address", erpnext.queries.company_address_query);
 				erpnext.accounts.dimensions.setup_dimension_filters(me.frm, me.frm.doctype);
 
-				this.frm.set_query("item_code", "items", function() {
+				this.frm.set_query("item_code", "items", function () {
 					if (me.frm.doc.is_subcontracted) {
-						var filters = {'supplier': me.frm.doc.supplier};
+						var filters = { supplier: me.frm.doc.supplier };
 						if (me.frm.doc.is_old_subcontracting_flow) {
 							filters["is_sub_contracted_item"] = 1;
-						}
-						else {
+						} else {
 							filters["is_stock_item"] = 0;
 						}
 
-						return{
+						return {
 							query: "erpnext.controllers.queries.item_query",
-							filters: filters
-						}
-					}
-					else {
-						return{
+							filters: filters,
+						};
+					} else {
+						return {
 							query: "erpnext.controllers.queries.item_query",
-							filters: { 'supplier': me.frm.doc.supplier, 'is_purchase_item': 1, 'has_variants': 0}
-						}
+							filters: { supplier: me.frm.doc.supplier, is_purchase_item: 1, has_variants: 0 },
+						};
 					}
 				});
 
-
-				this.frm.set_query("manufacturer", "items", function(doc, cdt, cdn) {
+				this.frm.set_query("manufacturer", "items", function (doc, cdt, cdn) {
 					const row = locals[cdt][cdn];
 					return {
 						query: "erpnext.controllers.queries.item_manufacturer_query",
-						filters:{ 'item_code': row.item_code }
-					}
+						filters: { item_code: row.item_code },
+					};
 				});
 
-				if(this.frm.fields_dict["items"].grid.get_field('item_code')) {
-					this.frm.set_query("item_tax_template", "items", function(doc, cdt, cdn) {
-						return me.set_query_for_item_tax_template(doc, cdt, cdn)
+				if (this.frm.fields_dict["items"].grid.get_field("item_code")) {
+					this.frm.set_query("item_tax_template", "items", function (doc, cdt, cdn) {
+						return me.set_query_for_item_tax_template(doc, cdt, cdn);
 					});
 				}
 			}
 
 			refresh(doc) {
-				frappe.dynamic_link = {doc: this.frm.doc, fieldname: 'supplier', doctype: 'Supplier'};
+				frappe.dynamic_link = { doc: this.frm.doc, fieldname: "supplier", doctype: "Supplier" };
 
-				this.frm.toggle_display("supplier_name",
-					(this.frm.doc.supplier_name && this.frm.doc.supplier_name!==this.frm.doc.supplier));
+				this.frm.toggle_display(
+					"supplier_name",
+					this.frm.doc.supplier_name && this.frm.doc.supplier_name !== this.frm.doc.supplier
+				);
 
-				if(this.frm.doc.docstatus==0 &&
-					(this.frm.doctype==="Purchase Order" || this.frm.doctype==="Material Request")) {
+				if (
+					this.frm.doc.docstatus == 0 &&
+					(this.frm.doctype === "Purchase Order" || this.frm.doctype === "Material Request")
+				) {
 					this.set_from_product_bundle();
 				}
 
@@ -143,45 +143,53 @@ erpnext.buying = {
 			}
 
 			toggle_subcontracting_fields() {
-				if (['Purchase Receipt', 'Purchase Invoice'].includes(this.frm.doc.doctype)) {
-					this.frm.fields_dict.supplied_items.grid.update_docfield_property('consumed_qty',
-						'read_only', this.frm.doc.__onload && this.frm.doc.__onload.backflush_based_on === 'BOM');
+				if (["Purchase Receipt", "Purchase Invoice"].includes(this.frm.doc.doctype)) {
+					this.frm.fields_dict.supplied_items.grid.update_docfield_property(
+						"consumed_qty",
+						"read_only",
+						this.frm.doc.__onload && this.frm.doc.__onload.backflush_based_on === "BOM"
+					);
 
-					this.frm.set_df_property('supplied_items', 'cannot_add_rows', 1);
-					this.frm.set_df_property('supplied_items', 'cannot_delete_rows', 1);
+					this.frm.set_df_property("supplied_items", "cannot_add_rows", 1);
+					this.frm.set_df_property("supplied_items", "cannot_delete_rows", 1);
 				}
 			}
 
 			supplier() {
 				var me = this;
-				erpnext.utils.get_party_details(this.frm, null, null, function(){
+				erpnext.utils.get_party_details(this.frm, null, null, function () {
 					me.apply_price_list();
 				});
 			}
 
-			company(){
-				if(!frappe.meta.has_field(this.frm.doc.doctype, "billing_address")) return;
+			company() {
+				if (!frappe.meta.has_field(this.frm.doc.doctype, "billing_address")) return;
 
 				frappe.call({
 					method: "erpnext.setup.doctype.company.company.get_billing_shipping_address",
 					args: {
 						name: this.frm.doc.company,
-						billing_address:this.frm.doc.billing_address,
-						shipping_address: this.frm.doc.shipping_address
+						billing_address: this.frm.doc.billing_address,
+						shipping_address: this.frm.doc.shipping_address,
 					},
 					callback: (r) => {
 						this.frm.set_value("billing_address", r.message.primary_address || "");
 
-						if(!frappe.meta.has_field(this.frm.doc.doctype, "shipping_address")) return;
+						if (!frappe.meta.has_field(this.frm.doc.doctype, "shipping_address")) return;
 						this.frm.set_value("shipping_address", r.message.shipping_address || "");
 					},
 				});
-				erpnext.utils.set_letter_head(this.frm)
+				erpnext.utils.set_letter_head(this.frm);
 			}
 
 			supplier_address() {
 				erpnext.utils.get_address_display(this.frm);
-				erpnext.utils.set_taxes_from_address(this.frm, "supplier_address", "supplier_address", "supplier_address");
+				erpnext.utils.set_taxes_from_address(
+					this.frm,
+					"supplier_address",
+					"supplier_address",
+					"supplier_address"
+				);
 			}
 
 			buying_price_list() {
@@ -201,24 +209,33 @@ erpnext.buying = {
 			}
 
 			qty(doc, cdt, cdn) {
-				if ((doc.doctype == "Purchase Receipt") || (doc.doctype == "Purchase Invoice" && doc.update_stock)) {
-					this.calculate_received_qty(doc, cdt, cdn)
+				if (
+					doc.doctype == "Purchase Receipt" ||
+					(doc.doctype == "Purchase Invoice" && doc.update_stock)
+				) {
+					this.calculate_received_qty(doc, cdt, cdn);
 				}
 				super.qty(doc, cdt, cdn);
 			}
 
 			rejected_qty(doc, cdt, cdn) {
-				this.calculate_received_qty(doc, cdt, cdn)
+				this.calculate_received_qty(doc, cdt, cdn);
 			}
 
-			calculate_received_qty(doc, cdt, cdn){
+			calculate_received_qty(doc, cdt, cdn) {
 				var item = frappe.get_doc(cdt, cdn);
 				frappe.model.round_floats_in(item, ["qty", "rejected_qty"]);
 
-				if(!doc.is_return && this.validate_negative_quantity(cdt, cdn, item, ["qty", "rejected_qty"])){ return }
+				if (
+					!doc.is_return &&
+					this.validate_negative_quantity(cdt, cdn, item, ["qty", "rejected_qty"])
+				) {
+					return;
+				}
 
 				let received_qty = flt(item.qty + item.rejected_qty, precision("received_qty", item));
-				let received_stock_qty = flt(item.conversion_factor, precision("conversion_factor", item)) * flt(received_qty);
+				let received_stock_qty =
+					flt(item.conversion_factor, precision("conversion_factor", item)) * flt(received_qty);
 
 				frappe.model.set_value(cdt, cdn, "received_qty", received_qty);
 				frappe.model.set_value(cdt, cdn, "received_stock_qty", received_stock_qty);
@@ -228,24 +245,32 @@ erpnext.buying = {
 				super.batch_no(doc, cdt, cdn);
 			}
 
-			validate_negative_quantity(cdt, cdn, item, fieldnames){
-				if(!item || !fieldnames) { return }
+			validate_negative_quantity(cdt, cdn, item, fieldnames) {
+				if (!item || !fieldnames) {
+					return;
+				}
 
 				var is_negative_qty = false;
-				for(var i = 0; i<fieldnames.length; i++) {
-					if(item[fieldnames[i]] < 0){
-						frappe.msgprint(__("Row #{0}: {1} can not be negative for item {2}", [item.idx,__(frappe.meta.get_label(cdt, fieldnames[i], cdn)), item.item_code]));
+				for (var i = 0; i < fieldnames.length; i++) {
+					if (item[fieldnames[i]] < 0) {
+						frappe.msgprint(
+							__("Row #{0}: {1} can not be negative for item {2}", [
+								item.idx,
+								__(frappe.meta.get_label(cdt, fieldnames[i], cdn)),
+								item.item_code,
+							])
+						);
 						is_negative_qty = true;
 						break;
 					}
 				}
 
-				return is_negative_qty
+				return is_negative_qty;
 			}
 
 			warehouse(doc, cdt, cdn) {
 				var item = frappe.get_doc(cdt, cdn);
-				if(item.item_code && item.warehouse) {
+				if (item.item_code && item.warehouse) {
 					return this.frm.call({
 						method: "erpnext.stock.get_item_details.get_bin_details",
 						child: item,
@@ -253,22 +278,21 @@ erpnext.buying = {
 							item_code: item.item_code,
 							warehouse: item.warehouse,
 							company: doc.company,
-							include_child_warehouses: true
-						}
+							include_child_warehouses: true,
+						},
 					});
 				}
 			}
 
 			project(doc, cdt, cdn) {
 				var item = frappe.get_doc(cdt, cdn);
-				if(item.project) {
-					$.each(this.frm.doc["items"] || [],
-						function(i, other_item) {
-							if(!other_item.project) {
-								other_item.project = item.project;
-								refresh_field("project", other_item.name, other_item.parentfield);
-							}
-						});
+				if (item.project) {
+					$.each(this.frm.doc["items"] || [], function (i, other_item) {
+						if (!other_item.project) {
+							other_item.project = item.project;
+							refresh_field("project", other_item.name, other_item.parentfield);
+						}
+					});
 				}
 			}
 
@@ -281,7 +305,7 @@ erpnext.buying = {
 
 			category(doc, cdt, cdn) {
 				// should be the category field of tax table
-				if(cdt != doc.doctype) {
+				if (cdt != doc.doctype) {
 					this.calculate_taxes_and_totals();
 				}
 			}
@@ -291,26 +315,42 @@ erpnext.buying = {
 
 			set_from_product_bundle() {
 				var me = this;
-				this.frm.add_custom_button(__("Product Bundle"), function() {
-					erpnext.buying.get_items_from_product_bundle(me.frm);
-				}, __("Get Items From"));
+				this.frm.add_custom_button(
+					__("Product Bundle"),
+					function () {
+						erpnext.buying.get_items_from_product_bundle(me.frm);
+					},
+					__("Get Items From")
+				);
 			}
 
-			shipping_address(){
+			shipping_address() {
 				var me = this;
-				erpnext.utils.get_address_display(this.frm, "shipping_address",
-					"shipping_address_display", true);
+				erpnext.utils.get_address_display(
+					this.frm,
+					"shipping_address",
+					"shipping_address_display",
+					true
+				);
 			}
 
-			dispatch_address(){
+			dispatch_address() {
 				var me = this;
-				erpnext.utils.get_address_display(this.frm, "dispatch_address",
-					"dispatch_address_display", true);
+				erpnext.utils.get_address_display(
+					this.frm,
+					"dispatch_address",
+					"dispatch_address_display",
+					true
+				);
 			}
 
 			billing_address() {
-				erpnext.utils.get_address_display(this.frm, "billing_address",
-					"billing_address_display", true);
+				erpnext.utils.get_address_display(
+					this.frm,
+					"billing_address",
+					"billing_address_display",
+					true
+				);
 			}
 
 			tc_name() {
@@ -320,37 +360,43 @@ erpnext.buying = {
 			update_auto_repeat_reference(doc) {
 				if (doc.auto_repeat) {
 					frappe.call({
-						method:"frappe.automation.doctype.auto_repeat.auto_repeat.update_reference",
-						args:{
+						method: "frappe.automation.doctype.auto_repeat.auto_repeat.update_reference",
+						args: {
 							docname: doc.auto_repeat,
-							reference:doc.name
+							reference: doc.name,
 						},
-						callback: function(r){
-							if (r.message=="success") {
-								frappe.show_alert({message:__("Auto repeat document updated"), indicator:'green'});
+						callback: function (r) {
+							if (r.message == "success") {
+								frappe.show_alert({
+									message: __("Auto repeat document updated"),
+									indicator: "green",
+								});
 							} else {
-								frappe.show_alert({message:__("An error occurred during the update process"), indicator:'red'});
+								frappe.show_alert({
+									message: __("An error occurred during the update process"),
+									indicator: "red",
+								});
 							}
-						}
-					})
+						},
+					});
 				}
 			}
 
 			manufacturer(doc, cdt, cdn) {
 				const row = locals[cdt][cdn];
 
-				if(row.manufacturer) {
+				if (row.manufacturer) {
 					frappe.call({
 						method: "erpnext.stock.doctype.item_manufacturer.item_manufacturer.get_item_manufacturer_part_no",
 						args: {
-							'item_code': row.item_code,
-							'manufacturer': row.manufacturer
+							item_code: row.item_code,
+							manufacturer: row.manufacturer,
 						},
-						callback: function(r) {
+						callback: function (r) {
 							if (r.message) {
-								frappe.model.set_value(cdt, cdn, 'manufacturer_part_no', r.message);
+								frappe.model.set_value(cdt, cdn, "manufacturer_part_no", r.message);
 							}
-						}
+						},
 					});
 				}
 			}
@@ -359,19 +405,22 @@ erpnext.buying = {
 				const row = locals[cdt][cdn];
 
 				if (row.manufacturer_part_no) {
-					frappe.model.get_value('Item Manufacturer',
+					frappe.model.get_value(
+						"Item Manufacturer",
 						{
-							'item_code': row.item_code,
-							'manufacturer': row.manufacturer,
-							'manufacturer_part_no': row.manufacturer_part_no
+							item_code: row.item_code,
+							manufacturer: row.manufacturer,
+							manufacturer_part_no: row.manufacturer_part_no,
 						},
-						'name',
-						function(data) {
+						"name",
+						function (data) {
 							if (!data) {
 								let msg = {
-									message: __("Manufacturer Part Number <b>{0}</b> is invalid", [row.manufacturer_part_no]),
-									title: __("Invalid Part Number")
-								}
+									message: __("Manufacturer Part Number <b>{0}</b> is invalid", [
+										row.manufacturer_part_no,
+									]),
+									title: __("Invalid Part Number"),
+								};
 								frappe.throw(msg);
 							}
 						}
@@ -384,40 +433,42 @@ erpnext.buying = {
 				let me = this;
 				let fields = ["has_batch_no", "has_serial_no"];
 
-				frappe.db.get_value("Item", item.item_code, fields)
-					.then((r) => {
-						if (r.message && (r.message.has_batch_no || r.message.has_serial_no)) {
-							fields.forEach((field) => {
-								item[field] = r.message[field];
-							});
+				frappe.db.get_value("Item", item.item_code, fields).then((r) => {
+					if (r.message && (r.message.has_batch_no || r.message.has_serial_no)) {
+						fields.forEach((field) => {
+							item[field] = r.message[field];
+						});
 
-							item.type_of_transaction = item.qty > 0 ? "Inward" : "Outward";
-							item.is_rejected = false;
+						item.type_of_transaction = item.qty > 0 ? "Inward" : "Outward";
+						item.is_rejected = false;
 
-							new erpnext.SerialBatchPackageSelector(
-								me.frm, item, (r) => {
-									if (r) {
-										let qty = Math.abs(r.total_qty);
-										if (doc.is_return) {
-											qty = qty * -1;
-										}
-
-										let update_values = {
-											"serial_and_batch_bundle": r.name,
-											"use_serial_batch_fields": 0,
-											"qty": qty / flt(item.conversion_factor || 1, precision("conversion_factor", item))
-										}
-
-										if (r.warehouse) {
-											update_values["warehouse"] = r.warehouse;
-										}
-
-										frappe.model.set_value(item.doctype, item.name, update_values);
-									}
+						new erpnext.SerialBatchPackageSelector(me.frm, item, (r) => {
+							if (r) {
+								let qty = Math.abs(r.total_qty);
+								if (doc.is_return) {
+									qty = qty * -1;
 								}
-							);
-						}
-					});
+
+								let update_values = {
+									serial_and_batch_bundle: r.name,
+									use_serial_batch_fields: 0,
+									qty:
+										qty /
+										flt(
+											item.conversion_factor || 1,
+											precision("conversion_factor", item)
+										),
+								};
+
+								if (r.warehouse) {
+									update_values["warehouse"] = r.warehouse;
+								}
+
+								frappe.model.set_value(item.doctype, item.name, update_values);
+							}
+						});
+					}
+				});
 			}
 
 			add_serial_batch_for_rejected_qty(doc, cdt, cdn) {
@@ -425,142 +476,147 @@ erpnext.buying = {
 				let me = this;
 				let fields = ["has_batch_no", "has_serial_no"];
 
-				frappe.db.get_value("Item", item.item_code, fields)
-					.then((r) => {
-						if (r.message && (r.message.has_batch_no || r.message.has_serial_no)) {
-							fields.forEach((field) => {
-								item[field] = r.message[field];
-							});
+				frappe.db.get_value("Item", item.item_code, fields).then((r) => {
+					if (r.message && (r.message.has_batch_no || r.message.has_serial_no)) {
+						fields.forEach((field) => {
+							item[field] = r.message[field];
+						});
 
-							item.type_of_transaction = !doc.is_return > 0 ? "Inward" : "Outward";
-							item.is_rejected = true;
+						item.type_of_transaction = !doc.is_return > 0 ? "Inward" : "Outward";
+						item.is_rejected = true;
 
-							new erpnext.SerialBatchPackageSelector(
-								me.frm, item, (r) => {
-									if (r) {
-										let qty = Math.abs(r.total_qty);
-										if (doc.is_return) {
-											qty = qty * -1;
-										}
-
-										let update_values = {
-											"rejected_serial_and_batch_bundle": r.name,
-											"use_serial_batch_fields": 0,
-											"rejected_qty": qty / flt(item.conversion_factor || 1, precision("conversion_factor", item))
-										}
-
-										if (r.warehouse) {
-											update_values["rejected_warehouse"] = r.warehouse;
-										}
-
-										frappe.model.set_value(item.doctype, item.name, update_values);
-									}
+						new erpnext.SerialBatchPackageSelector(me.frm, item, (r) => {
+							if (r) {
+								let qty = Math.abs(r.total_qty);
+								if (doc.is_return) {
+									qty = qty * -1;
 								}
-							);
-						}
-					});
+
+								let update_values = {
+									rejected_serial_and_batch_bundle: r.name,
+									use_serial_batch_fields: 0,
+									rejected_qty:
+										qty /
+										flt(
+											item.conversion_factor || 1,
+											precision("conversion_factor", item)
+										),
+								};
+
+								if (r.warehouse) {
+									update_values["rejected_warehouse"] = r.warehouse;
+								}
+
+								frappe.model.set_value(item.doctype, item.name, update_values);
+							}
+						});
+					}
+				});
 			}
 		};
-	}
-}
+	},
+};
 
-erpnext.buying.link_to_mrs = function(frm) {
+erpnext.buying.link_to_mrs = function (frm) {
 	frappe.call({
 		method: "erpnext.buying.utils.get_linked_material_requests",
-		args:{
-			items: frm.doc.items.map((item) => item.item_code)
+		args: {
+			items: frm.doc.items.map((item) => item.item_code),
 		},
-		callback: function(r) {
+		callback: function (r) {
 			if (!r.message || r.message.length == 0) {
 				frappe.throw({
 					message: __("No pending Material Requests found to link for the given items."),
-					title: __("Note")
+					title: __("Note"),
 				});
 			}
 
 			var item_length = frm.doc.items.length;
 			for (let item of frm.doc.items) {
 				var qty = item.qty;
-				(r.message[0] || []).forEach(function(d) {
-					if (d.qty > 0 && qty > 0 && item.item_code == d.item_code && !item.material_request_item)
-					{
+				(r.message[0] || []).forEach(function (d) {
+					if (
+						d.qty > 0 &&
+						qty > 0 &&
+						item.item_code == d.item_code &&
+						!item.material_request_item
+					) {
 						item.material_request = d.mr_name;
 						item.material_request_item = d.mr_item;
 						var my_qty = Math.min(qty, d.qty);
 						qty = qty - my_qty;
 						d.qty = d.qty - my_qty;
-						item.stock_qty = my_qty*item.conversion_factor;
+						item.stock_qty = my_qty * item.conversion_factor;
 						item.qty = my_qty;
 
-						frappe.msgprint("Assigning " + d.mr_name + " to " + d.item_code + " (row " + item.idx + ")");
-						if (qty > 0)
-						{
+						frappe.msgprint(
+							"Assigning " + d.mr_name + " to " + d.item_code + " (row " + item.idx + ")"
+						);
+						if (qty > 0) {
 							frappe.msgprint("Splitting " + qty + " units of " + d.item_code);
 							var newrow = frappe.model.add_child(frm.doc, item.doctype, "items");
 							item_length++;
 
-							for (var key in item)
-							{
+							for (var key in item) {
 								newrow[key] = item[key];
 							}
 
 							newrow.idx = item_length;
-							newrow["stock_qty"] = newrow.conversion_factor*qty;
+							newrow["stock_qty"] = newrow.conversion_factor * qty;
 							newrow["qty"] = qty;
 
 							newrow["material_request"] = "";
 							newrow["material_request_item"] = "";
-
 						}
 					}
 				});
 			}
 			refresh_field("items");
-		}
+		},
 	});
-}
+};
 
-erpnext.buying.get_default_bom = function(frm) {
-	$.each(frm.doc["items"] || [], function(i, d) {
+erpnext.buying.get_default_bom = function (frm) {
+	$.each(frm.doc["items"] || [], function (i, d) {
 		if (d.item_code && d.bom === "") {
 			return frappe.call({
 				type: "GET",
 				method: "erpnext.stock.get_item_details.get_default_bom",
 				args: {
-					"item_code": d.item_code,
+					item_code: d.item_code,
 				},
-				callback: function(r) {
-					if(r) {
+				callback: function (r) {
+					if (r) {
 						frappe.model.set_value(d.doctype, d.name, "bom", r.message);
 					}
-				}
-			})
+				},
+			});
 		}
 	});
-}
+};
 
-erpnext.buying.get_items_from_product_bundle = function(frm) {
+erpnext.buying.get_items_from_product_bundle = function (frm) {
 	var dialog = new frappe.ui.Dialog({
 		title: __("Get Items from Product Bundle"),
 		fields: [
 			{
-				"fieldtype": "Link",
-				"label": __("Product Bundle"),
-				"fieldname": "product_bundle",
-				"options":"Product Bundle",
-				"reqd": 1
+				fieldtype: "Link",
+				label: __("Product Bundle"),
+				fieldname: "product_bundle",
+				options: "Product Bundle",
+				reqd: 1,
 			},
 			{
-				"fieldtype": "Currency",
-				"label": __("Quantity"),
-				"fieldname": "quantity",
-				"reqd": 1,
-				"default": 1
-			}
+				fieldtype: "Currency",
+				label: __("Quantity"),
+				fieldname: "quantity",
+				reqd: 1,
+				default: 1,
+			},
 		],
-		primary_action_label: 'Get Items',
-		primary_action(args){
-			if(!args) return;
+		primary_action_label: "Get Items",
+		primary_action(args) {
+			if (!args) return;
 			dialog.hide();
 			return frappe.call({
 				type: "GET",
@@ -581,44 +637,44 @@ erpnext.buying.get_items_from_product_bundle = function(frm) {
 						is_subcontracted: frm.doc.is_subcontracted,
 						transaction_date: frm.doc.transaction_date || frm.doc.posting_date,
 						ignore_pricing_rule: frm.doc.ignore_pricing_rule,
-						doctype: frm.doc.doctype
+						doctype: frm.doc.doctype,
 					},
 				},
 				freeze: true,
-				callback: function(r) {
-					const first_row_is_empty = function(child_table){
-						if($.isArray(child_table) && child_table.length > 0) {
+				callback: function (r) {
+					const first_row_is_empty = function (child_table) {
+						if ($.isArray(child_table) && child_table.length > 0) {
 							return !child_table[0].item_code;
 						}
 						return false;
 					};
 
-					const remove_empty_first_row = function(frm){
-					if (first_row_is_empty(frm.doc.items)){
-						frm.doc.items = frm.doc.items.splice(1);
+					const remove_empty_first_row = function (frm) {
+						if (first_row_is_empty(frm.doc.items)) {
+							frm.doc.items = frm.doc.items.splice(1);
 						}
 					};
 
-					if(!r.exc && r.message) {
+					if (!r.exc && r.message) {
 						remove_empty_first_row(frm);
-						for (var i=0; i< r.message.length; i++) {
+						for (var i = 0; i < r.message.length; i++) {
 							var d = frm.add_child("items");
 							var item = r.message[i];
-							for (var key in  item) {
+							for (var key in item) {
 								if (!is_null(item[key]) && key !== "doctype") {
 									d[key] = item[key];
 								}
 							}
-							if(frappe.meta.get_docfield(d.doctype, "price_list_rate", d.name)) {
+							if (frappe.meta.get_docfield(d.doctype, "price_list_rate", d.name)) {
 								frm.script_manager.trigger("price_list_rate", d.doctype, d.name);
 							}
 						}
 						frm.refresh_field("items");
 					}
-				}
-			})
-		}
+				},
+			});
+		},
 	});
 
 	dialog.show();
-}
+};

--- a/erpnext/public/js/controllers/stock_controller.js
+++ b/erpnext/public/js/controllers/stock_controller.js
@@ -11,13 +11,13 @@ erpnext.stock.StockController = class StockController extends frappe.ui.form.Con
 		}
 	}
 
-	barcode(doc, cdt, cdn)  {
+	barcode(doc, cdt, cdn) {
 		let row = locals[cdt][cdn];
 		if (row.barcode) {
 			erpnext.stock.utils.set_item_details_using_barcode(this.frm, row, (r) => {
 				frappe.model.set_value(cdt, cdn, {
-					"item_code": r.message.item_code,
-					"qty": 1,
+					item_code: r.message.item_code,
+					qty: 1,
 				});
 			});
 		}
@@ -25,74 +25,81 @@ erpnext.stock.StockController = class StockController extends frappe.ui.form.Con
 
 	setup_warehouse_query() {
 		var me = this;
-		erpnext.queries.setup_queries(this.frm, "Warehouse", function() {
+		erpnext.queries.setup_queries(this.frm, "Warehouse", function () {
 			return erpnext.queries.warehouse(me.frm.doc);
 		});
 	}
 
 	setup_posting_date_time_check() {
 		// make posting date default and read only unless explictly checked
-		frappe.ui.form.on(this.frm.doctype, 'set_posting_date_and_time_read_only', function(frm) {
-			if(frm.doc.docstatus == 0 && frm.doc.set_posting_time) {
-				frm.set_df_property('posting_date', 'read_only', 0);
-				frm.set_df_property('posting_time', 'read_only', 0);
+		frappe.ui.form.on(this.frm.doctype, "set_posting_date_and_time_read_only", function (frm) {
+			if (frm.doc.docstatus == 0 && frm.doc.set_posting_time) {
+				frm.set_df_property("posting_date", "read_only", 0);
+				frm.set_df_property("posting_time", "read_only", 0);
 			} else {
-				frm.set_df_property('posting_date', 'read_only', 1);
-				frm.set_df_property('posting_time', 'read_only', 1);
+				frm.set_df_property("posting_date", "read_only", 1);
+				frm.set_df_property("posting_time", "read_only", 1);
 			}
-		})
-
-		frappe.ui.form.on(this.frm.doctype, 'set_posting_time', function(frm) {
-			frm.trigger('set_posting_date_and_time_read_only');
 		});
 
-		frappe.ui.form.on(this.frm.doctype, 'refresh', function(frm) {
+		frappe.ui.form.on(this.frm.doctype, "set_posting_time", function (frm) {
+			frm.trigger("set_posting_date_and_time_read_only");
+		});
+
+		frappe.ui.form.on(this.frm.doctype, "refresh", function (frm) {
 			// set default posting date / time
-			if(frm.doc.docstatus==0) {
-				if(!frm.doc.posting_date) {
-					frm.set_value('posting_date', frappe.datetime.nowdate());
+			if (frm.doc.docstatus == 0) {
+				if (!frm.doc.posting_date) {
+					frm.set_value("posting_date", frappe.datetime.nowdate());
 				}
-				if(!frm.doc.posting_time) {
-					frm.set_value('posting_time', frappe.datetime.now_time());
+				if (!frm.doc.posting_time) {
+					frm.set_value("posting_time", frappe.datetime.now_time());
 				}
-				frm.trigger('set_posting_date_and_time_read_only');
+				frm.trigger("set_posting_date_and_time_read_only");
 			}
 		});
 	}
 
 	show_stock_ledger() {
 		var me = this;
-		if(this.frm.doc.docstatus > 0) {
-			cur_frm.add_custom_button(__("Stock Ledger"), function() {
-				frappe.route_options = {
-					voucher_no: me.frm.doc.name,
-					from_date: me.frm.doc.posting_date,
-					to_date: moment(me.frm.doc.modified).format('YYYY-MM-DD'),
-					company: me.frm.doc.company,
-					show_cancelled_entries: me.frm.doc.docstatus === 2,
-					ignore_prepared_report: true
-				};
-				frappe.set_route("query-report", "Stock Ledger");
-			}, __("View"));
+		if (this.frm.doc.docstatus > 0) {
+			cur_frm.add_custom_button(
+				__("Stock Ledger"),
+				function () {
+					frappe.route_options = {
+						voucher_no: me.frm.doc.name,
+						from_date: me.frm.doc.posting_date,
+						to_date: moment(me.frm.doc.modified).format("YYYY-MM-DD"),
+						company: me.frm.doc.company,
+						show_cancelled_entries: me.frm.doc.docstatus === 2,
+						ignore_prepared_report: true,
+					};
+					frappe.set_route("query-report", "Stock Ledger");
+				},
+				__("View")
+			);
 		}
-
 	}
 
 	show_general_ledger() {
 		let me = this;
-		if(this.frm.doc.docstatus > 0) {
-			cur_frm.add_custom_button(__('Accounting Ledger'), function() {
-				frappe.route_options = {
-					voucher_no: me.frm.doc.name,
-					from_date: me.frm.doc.posting_date,
-					to_date: moment(me.frm.doc.modified).format('YYYY-MM-DD'),
-					company: me.frm.doc.company,
-					categorize_by: "Categorize by Voucher (Consolidated)",
-					show_cancelled_entries: me.frm.doc.docstatus === 2,
-					ignore_prepared_report: true
-				};
-				frappe.set_route("query-report", "General Ledger");
-			}, __("View"));
+		if (this.frm.doc.docstatus > 0) {
+			cur_frm.add_custom_button(
+				__("Accounting Ledger"),
+				function () {
+					frappe.route_options = {
+						voucher_no: me.frm.doc.name,
+						from_date: me.frm.doc.posting_date,
+						to_date: moment(me.frm.doc.modified).format("YYYY-MM-DD"),
+						company: me.frm.doc.company,
+						categorize_by: "Categorize by Voucher (Consolidated)",
+						show_cancelled_entries: me.frm.doc.docstatus === 2,
+						ignore_prepared_report: true,
+					};
+					frappe.set_route("query-report", "General Ledger");
+				},
+				__("View")
+			);
 		}
 	}
 };

--- a/erpnext/public/js/controllers/taxes_and_totals.js
+++ b/erpnext/public/js/controllers/taxes_and_totals.js
@@ -13,22 +13,22 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 			effective_item_rate = item.blanket_order_rate;
 		}
 		if (item.margin_type == "Percentage") {
-			item.rate_with_margin = flt(effective_item_rate)
-				+ flt(effective_item_rate) * ( flt(item.margin_rate_or_amount) / 100);
+			item.rate_with_margin =
+				flt(effective_item_rate) + flt(effective_item_rate) * (flt(item.margin_rate_or_amount) / 100);
 		} else {
 			item.rate_with_margin = flt(effective_item_rate) + flt(item.margin_rate_or_amount);
 		}
 		item.base_rate_with_margin = flt(item.rate_with_margin) * flt(this.frm.doc.conversion_rate);
 
-		item_rate = flt(item.rate_with_margin , precision("rate", item));
+		item_rate = flt(item.rate_with_margin, precision("rate", item));
 
 		if (item.discount_percentage && !item.discount_amount) {
-			item.discount_amount = flt(item.rate_with_margin) * flt(item.discount_percentage) / 100;
+			item.discount_amount = (flt(item.rate_with_margin) * flt(item.discount_percentage)) / 100;
 		}
 
 		if (item.discount_amount > 0) {
-			item_rate = flt((item.rate_with_margin) - (item.discount_amount), precision('rate', item));
-			item.discount_percentage = 100 * flt(item.discount_amount) / flt(item.rate_with_margin);
+			item_rate = flt(item.rate_with_margin - item.discount_amount, precision("rate", item));
+			item.discount_percentage = (100 * flt(item.discount_amount)) / flt(item.rate_with_margin);
 		}
 
 		frappe.model.set_value(item.doctype, item.name, "rate", item_rate);
@@ -52,17 +52,17 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 
 		// Advance calculation applicable to Sales/Purchase Invoice
 		if (
-			["Sales Invoice", "POS Invoice", "Purchase Invoice"].includes(this.frm.doc.doctype)
-			&& this.frm.doc.docstatus < 2
-			&& !this.frm.doc.is_return
+			["Sales Invoice", "POS Invoice", "Purchase Invoice"].includes(this.frm.doc.doctype) &&
+			this.frm.doc.docstatus < 2 &&
+			!this.frm.doc.is_return
 		) {
 			this.calculate_total_advance(update_paid_amount);
 		}
 
 		if (
-			["Sales Invoice", "POS Invoice"].includes(this.frm.doc.doctype)
-			&& this.frm.doc.is_pos
-			&& this.frm.doc.is_return
+			["Sales Invoice", "POS Invoice"].includes(this.frm.doc.doctype) &&
+			this.frm.doc.is_pos &&
+			this.frm.doc.is_return
 		) {
 			await this.set_total_amount_to_default_mop();
 			this.calculate_paid_amount();
@@ -76,9 +76,9 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 
 		// Update paid amount on return/debit note creation
 		if (
-			this.frm.doc.doctype === "Purchase Invoice"
-			&& this.frm.doc.is_return
-			&& (this.frm.doc.grand_total > this.frm.doc.paid_amount)
+			this.frm.doc.doctype === "Purchase Invoice" &&
+			this.frm.doc.is_return &&
+			this.frm.doc.grand_total > this.frm.doc.paid_amount
 		) {
 			this.frm.doc.paid_amount = flt(this.frm.doc.grand_total, precision("grand_total"));
 		}
@@ -109,17 +109,26 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 	}
 
 	validate_conversion_rate() {
-		this.frm.doc.conversion_rate = flt(this.frm.doc.conversion_rate, (cur_frm) ? precision("conversion_rate") : 9);
-		var conversion_rate_label = frappe.meta.get_label(this.frm.doc.doctype, "conversion_rate",
-			this.frm.doc.name);
+		this.frm.doc.conversion_rate = flt(
+			this.frm.doc.conversion_rate,
+			cur_frm ? precision("conversion_rate") : 9
+		);
+		var conversion_rate_label = frappe.meta.get_label(
+			this.frm.doc.doctype,
+			"conversion_rate",
+			this.frm.doc.name
+		);
 		var company_currency = this.get_company_currency();
 
-		if(!this.frm.doc.conversion_rate) {
-			if(this.frm.doc.currency == company_currency) {
+		if (!this.frm.doc.conversion_rate) {
+			if (this.frm.doc.currency == company_currency) {
 				this.frm.set_value("conversion_rate", 1);
 			} else {
-				const subs =  [conversion_rate_label, this.frm.doc.currency, company_currency];
-				const err_message = __('{0} is mandatory. Maybe Currency Exchange record is not created for {1} to {2}', subs);
+				const subs = [conversion_rate_label, this.frm.doc.currency, company_currency];
+				const err_message = __(
+					"{0} is mandatory. Maybe Currency Exchange record is not created for {1} to {2}",
+					subs
+				);
 				frappe.throw(err_message);
 			}
 		}
@@ -135,12 +144,11 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 
 				if (!(me.frm.doc.is_return || me.frm.doc.is_debit_note)) {
 					item.net_amount = item.amount = flt(item.rate * item.qty, precision("amount", item));
-				}
-				else {
+				} else {
 					// allow for '0' qty on Credit/Debit notes
 					let qty = flt(item.qty);
 					if (!qty) {
-						qty = (me.frm.doc.is_debit_note ? 1 : -1);
+						qty = me.frm.doc.is_debit_note ? 1 : -1;
 						if (me.frm.doc.doctype !== "Purchase Receipt" && me.frm.doc.is_return === 1) {
 							// In case of Purchase Receipt, qty can be 0 if all items are rejected
 							qty = flt(item.qty);
@@ -153,35 +161,53 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 				item.item_tax_amount = 0.0;
 				item.total_weight = flt(item.weight_per_unit * item.stock_qty);
 
-				me.set_in_company_currency(item, ["price_list_rate", "rate", "amount", "net_rate", "net_amount"]);
+				me.set_in_company_currency(item, [
+					"price_list_rate",
+					"rate",
+					"amount",
+					"net_rate",
+					"net_amount",
+				]);
 			}
 		}
 	}
 
 	set_in_company_currency(doc, fields) {
 		var me = this;
-		$.each(fields, function(i, f) {
-			doc["base_"+f] = flt(flt(doc[f], precision(f, doc)) * me.frm.doc.conversion_rate, precision("base_" + f, doc));
+		$.each(fields, function (i, f) {
+			doc["base_" + f] = flt(
+				flt(doc[f], precision(f, doc)) * me.frm.doc.conversion_rate,
+				precision("base_" + f, doc)
+			);
 		});
 	}
 
 	initialize_taxes() {
 		var me = this;
 
-		$.each(this.frm.doc["taxes"] || [], function(i, tax) {
+		$.each(this.frm.doc["taxes"] || [], function (i, tax) {
 			if (!tax.dont_recompute_tax) {
 				tax.item_wise_tax_detail = {};
 			}
-			var tax_fields = ["total", "tax_amount_after_discount_amount",
-				"tax_amount_for_current_item", "grand_total_for_current_item",
-				"tax_fraction_for_current_item", "grand_total_fraction_for_current_item"];
+			var tax_fields = [
+				"total",
+				"tax_amount_after_discount_amount",
+				"tax_amount_for_current_item",
+				"grand_total_for_current_item",
+				"tax_fraction_for_current_item",
+				"grand_total_fraction_for_current_item",
+			];
 
-			if (cstr(tax.charge_type) != "Actual" &&
-				!(me.discount_amount_applied && me.frm.doc.apply_discount_on=="Grand Total")) {
+			if (
+				cstr(tax.charge_type) != "Actual" &&
+				!(me.discount_amount_applied && me.frm.doc.apply_discount_on == "Grand Total")
+			) {
 				tax_fields.push("tax_amount");
 			}
 
-			$.each(tax_fields, function(i, fieldname) { tax[fieldname] = 0.0; });
+			$.each(tax_fields, function (i, fieldname) {
+				tax[fieldname] = 0.0;
+			});
 
 			if (!this.discount_amount_applied) {
 				erpnext.accounts.taxes.validate_taxes_and_charges(tax.doctype, tax.name);
@@ -197,24 +223,24 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 
 		if (me.frm.doc.company) {
 			frappe.call({
-				"method": "erpnext.controllers.taxes_and_totals.get_round_off_applicable_accounts",
-				"args": {
-					"company": me.frm.doc.company,
-					"account_list": frappe.flags.round_off_applicable_accounts
+				method: "erpnext.controllers.taxes_and_totals.get_round_off_applicable_accounts",
+				args: {
+					company: me.frm.doc.company,
+					account_list: frappe.flags.round_off_applicable_accounts,
 				},
 				callback(r) {
 					if (r.message) {
 						frappe.flags.round_off_applicable_accounts.push(...r.message);
 					}
-				}
+				},
 			});
 		}
 
 		frappe.call({
 			method: "erpnext.controllers.taxes_and_totals.get_rounding_tax_settings",
-			callback: function(r) {
+			callback: function (r) {
 				frappe.flags.round_off_settings = r.message;
-			}
+			},
 		});
 	}
 
@@ -222,25 +248,25 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 		var me = this;
 
 		var has_inclusive_tax = false;
-		$.each(me.frm.doc["taxes"] || [], function(i, row) {
-			if(cint(row.included_in_print_rate)) has_inclusive_tax = true;
+		$.each(me.frm.doc["taxes"] || [], function (i, row) {
+			if (cint(row.included_in_print_rate)) has_inclusive_tax = true;
 		});
-		if(has_inclusive_tax==false) return;
+		if (has_inclusive_tax == false) return;
 
-		$.each(this.frm.doc.items || [], function(n, item) {
+		$.each(this.frm.doc.items || [], function (n, item) {
 			var item_tax_map = me._load_item_tax_rate(item.item_tax_rate);
 			var cumulated_tax_fraction = 0.0;
 			var total_inclusive_tax_amount_per_qty = 0;
-			$.each(me.frm.doc["taxes"] || [], function(i, tax) {
+			$.each(me.frm.doc["taxes"] || [], function (i, tax) {
 				var current_tax_fraction = me.get_current_tax_fraction(tax, item_tax_map);
 				tax.tax_fraction_for_current_item = current_tax_fraction[0];
 				var inclusive_tax_amount_per_qty = current_tax_fraction[1];
 
-				if(i==0) {
+				if (i == 0) {
 					tax.grand_total_fraction_for_current_item = 1 + tax.tax_fraction_for_current_item;
 				} else {
 					tax.grand_total_fraction_for_current_item =
-						me.frm.doc["taxes"][i-1].grand_total_fraction_for_current_item +
+						me.frm.doc["taxes"][i - 1].grand_total_fraction_for_current_item +
 						tax.tax_fraction_for_current_item;
 				}
 
@@ -248,7 +274,11 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 				total_inclusive_tax_amount_per_qty += inclusive_tax_amount_per_qty * flt(item.qty);
 			});
 
-			if(!me.discount_amount_applied && item.qty && (total_inclusive_tax_amount_per_qty || cumulated_tax_fraction)) {
+			if (
+				!me.discount_amount_applied &&
+				item.qty &&
+				(total_inclusive_tax_amount_per_qty || cumulated_tax_fraction)
+			) {
 				var amount = flt(item.amount) - total_inclusive_tax_amount_per_qty;
 				item.net_amount = flt(amount / (1 + cumulated_tax_fraction), precision("net_amount", item));
 				item.net_rate = item.qty ? flt(item.net_amount / item.qty, precision("net_rate", item)) : 0;
@@ -264,25 +294,25 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 		var current_tax_fraction = 0.0;
 		var inclusive_tax_amount_per_qty = 0;
 
-		if(cint(tax.included_in_print_rate)) {
+		if (cint(tax.included_in_print_rate)) {
 			var tax_rate = this._get_tax_rate(tax, item_tax_map);
 
-			if(tax.charge_type == "On Net Total") {
-				current_tax_fraction = (tax_rate / 100.0);
-
-			} else if(tax.charge_type == "On Previous Row Amount") {
-				current_tax_fraction = (tax_rate / 100.0) *
+			if (tax.charge_type == "On Net Total") {
+				current_tax_fraction = tax_rate / 100.0;
+			} else if (tax.charge_type == "On Previous Row Amount") {
+				current_tax_fraction =
+					(tax_rate / 100.0) *
 					this.frm.doc["taxes"][cint(tax.row_id) - 1].tax_fraction_for_current_item;
-
-			} else if(tax.charge_type == "On Previous Row Total") {
-				current_tax_fraction = (tax_rate / 100.0) *
+			} else if (tax.charge_type == "On Previous Row Total") {
+				current_tax_fraction =
+					(tax_rate / 100.0) *
 					this.frm.doc["taxes"][cint(tax.row_id) - 1].grand_total_fraction_for_current_item;
 			} else if (tax.charge_type == "On Item Quantity") {
 				inclusive_tax_amount_per_qty = flt(tax_rate);
 			}
 		}
 
-		if(tax.add_deduct_tax && tax.add_deduct_tax == "Deduct") {
+		if (tax.add_deduct_tax && tax.add_deduct_tax == "Deduct") {
 			current_tax_fraction *= -1;
 			inclusive_tax_amount_per_qty *= -1;
 		}
@@ -290,15 +320,21 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 	}
 
 	_get_tax_rate(tax, item_tax_map) {
-		return (Object.keys(item_tax_map).indexOf(tax.account_head) != -1) ?
-			flt(item_tax_map[tax.account_head], precision("rate", tax)) : tax.rate;
+		return Object.keys(item_tax_map).indexOf(tax.account_head) != -1
+			? flt(item_tax_map[tax.account_head], precision("rate", tax))
+			: tax.rate;
 	}
 
 	calculate_net_total() {
 		var me = this;
-		this.frm.doc.total_qty = this.frm.doc.total = this.frm.doc.base_total = this.frm.doc.net_total = this.frm.doc.base_net_total = 0.0;
+		this.frm.doc.total_qty =
+			this.frm.doc.total =
+			this.frm.doc.base_total =
+			this.frm.doc.net_total =
+			this.frm.doc.base_net_total =
+				0.0;
 
-		$.each(this.frm._items || [], function(i, item) {
+		$.each(this.frm._items || [], function (i, item) {
 			me.frm.doc.total += item.amount;
 			me.frm.doc.total_qty += item.qty;
 			me.frm.doc.base_total += item.base_amount;
@@ -325,12 +361,12 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 		let me = this;
 
 		if (item_tax_map && cint(frappe.defaults.get_default("add_taxes_from_item_tax_template"))) {
-			if (typeof (item_tax_map) == "string") {
+			if (typeof item_tax_map == "string") {
 				item_tax_map = JSON.parse(item_tax_map);
 			}
 
-			$.each(item_tax_map, function(tax, rate) {
-				let found = (me.frm.doc.taxes || []).find(d => d.account_head === tax);
+			$.each(item_tax_map, function (tax, rate) {
+				let found = (me.frm.doc.taxes || []).find((d) => d.account_head === tax);
 				if (!found) {
 					let child = frappe.model.add_child(me.frm.doc, "taxes");
 					child.charge_type = "On Net Total";
@@ -350,15 +386,15 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 		var actual_tax_dict = {};
 
 		// maintain actual tax rate based on idx
-		$.each(doc.taxes, function(i, tax) {
+		$.each(doc.taxes, function (i, tax) {
 			if (tax.charge_type == "Actual") {
 				actual_tax_dict[tax.idx] = flt(tax.tax_amount, precision("tax_amount", tax));
 			}
 		});
 
-		$.each(this.frm._items || [], function(n, item) {
+		$.each(this.frm._items || [], function (n, item) {
 			var item_tax_map = me._load_item_tax_rate(item.item_tax_rate);
-			$.each(doc.taxes, function(i, tax) {
+			$.each(doc.taxes, function (i, tax) {
 				// tax_amount represents the amount of tax for the current step
 				var current_tax_amount = me.get_current_tax_amount(item, tax, item_tax_map);
 				if (frappe.flags.round_row_wise_tax) {
@@ -374,8 +410,10 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 				}
 
 				// accumulate tax amount into tax.tax_amount
-				if (tax.charge_type != "Actual" &&
-					!(me.discount_amount_applied && me.frm.doc.apply_discount_on=="Grand Total")) {
+				if (
+					tax.charge_type != "Actual" &&
+					!(me.discount_amount_applied && me.frm.doc.apply_discount_on == "Grand Total")
+				) {
 					tax.tax_amount += current_tax_amount;
 				}
 
@@ -387,32 +425,39 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 				tax.tax_amount_after_discount_amount += current_tax_amount;
 
 				// for buying
-				if(tax.category) {
+				if (tax.category) {
 					// if just for valuation, do not add the tax amount in total
 					// hence, setting it as 0 for further steps
-					current_tax_amount = (tax.category == "Valuation") ? 0.0 : current_tax_amount;
+					current_tax_amount = tax.category == "Valuation" ? 0.0 : current_tax_amount;
 
-					current_tax_amount *= (tax.add_deduct_tax == "Deduct") ? -1.0 : 1.0;
+					current_tax_amount *= tax.add_deduct_tax == "Deduct" ? -1.0 : 1.0;
 				}
 
 				// note: grand_total_for_current_item contains the contribution of
 				// item's amount, previously applied tax and the current tax on that item
-				if(i==0) {
+				if (i == 0) {
 					tax.grand_total_for_current_item = flt(item.net_amount + current_tax_amount);
 				} else {
-					tax.grand_total_for_current_item =
-						flt(me.frm.doc["taxes"][i-1].grand_total_for_current_item + current_tax_amount);
+					tax.grand_total_for_current_item = flt(
+						me.frm.doc["taxes"][i - 1].grand_total_for_current_item + current_tax_amount
+					);
 				}
 			});
 		});
 
 		const discount_amount_applied = this.discount_amount_applied;
-		if (doc.apply_discount_on === "Grand Total" && (discount_amount_applied || doc.discount_amount || doc.additional_discount_percentage)) {
+		if (
+			doc.apply_discount_on === "Grand Total" &&
+			(discount_amount_applied || doc.discount_amount || doc.additional_discount_percentage)
+		) {
 			const tax_amount_precision = precision("tax_amount", doc.taxes[0]);
 
 			for (const [i, tax] of doc.taxes.entries()) {
 				if (discount_amount_applied)
-					tax.tax_amount_after_discount_amount = flt(tax.tax_amount_after_discount_amount, tax_amount_precision);
+					tax.tax_amount_after_discount_amount = flt(
+						tax.tax_amount_after_discount_amount,
+						tax_amount_precision
+					);
 
 				this.set_cumulative_total(i, tax);
 			}
@@ -421,14 +466,17 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 				this.grand_total_for_distributing_discount = doc.taxes[doc.taxes.length - 1].total;
 			} else {
 				this.grand_total_diff = flt(
-					this.grand_total_for_distributing_discount - doc.discount_amount - doc.taxes[doc.taxes.length - 1].total, precision("grand_total"));
+					this.grand_total_for_distributing_discount -
+						doc.discount_amount -
+						doc.taxes[doc.taxes.length - 1].total,
+					precision("grand_total")
+				);
 			}
 		}
 
 		for (const [i, tax] of doc.taxes.entries()) {
 			me.round_off_totals(tax);
-			me.set_in_company_currency(tax,
-				["tax_amount", "tax_amount_after_discount_amount"]);
+			me.set_in_company_currency(tax, ["tax_amount", "tax_amount_after_discount_amount"]);
 
 			me.round_off_base_values(tax);
 
@@ -441,16 +489,18 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 
 	set_cumulative_total(row_idx, tax) {
 		var tax_amount = tax.tax_amount_after_discount_amount;
-		if (tax.category == 'Valuation') {
+		if (tax.category == "Valuation") {
 			tax_amount = 0;
 		}
 
-		if (tax.add_deduct_tax == "Deduct") { tax_amount = -1*tax_amount; }
+		if (tax.add_deduct_tax == "Deduct") {
+			tax_amount = -1 * tax_amount;
+		}
 
-		if(row_idx==0) {
+		if (row_idx == 0) {
 			tax.total = flt(this.frm.doc.net_total + tax_amount, precision("total", tax));
 		} else {
-			tax.total = flt(this.frm.doc["taxes"][row_idx-1].total + tax_amount, precision("total", tax));
+			tax.total = flt(this.frm.doc["taxes"][row_idx - 1].total + tax_amount, precision("total", tax));
 		}
 	}
 
@@ -464,35 +514,38 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 		var current_net_amount = 0.0;
 
 		// To set row_id by default as previous row.
-		if(["On Previous Row Amount", "On Previous Row Total"].includes(tax.charge_type)) {
+		if (["On Previous Row Amount", "On Previous Row Total"].includes(tax.charge_type)) {
 			if (tax.idx === 1) {
 				frappe.throw(
-					__("Cannot select charge type as 'On Previous Row Amount' or 'On Previous Row Total' for first row"));
+					__(
+						"Cannot select charge type as 'On Previous Row Amount' or 'On Previous Row Total' for first row"
+					)
+				);
 			}
 			if (!tax.row_id) {
 				tax.row_id = tax.idx - 1;
 			}
 		}
-		if(tax.charge_type == "Actual") {
-			current_net_amount = item.net_amount
+		if (tax.charge_type == "Actual") {
+			current_net_amount = item.net_amount;
 			// distribute the tax amount proportionally to each item row
 			var actual = flt(tax.tax_amount, precision("tax_amount", tax));
-			current_tax_amount = this.frm.doc.net_total ?
-				((item.net_amount / this.frm.doc.net_total) * actual) : 0.0;
-
-		} else if(tax.charge_type == "On Net Total") {
+			current_tax_amount = this.frm.doc.net_total
+				? (item.net_amount / this.frm.doc.net_total) * actual
+				: 0.0;
+		} else if (tax.charge_type == "On Net Total") {
 			if (tax.account_head in item_tax_map) {
-				current_net_amount = item.net_amount
-			};
+				current_net_amount = item.net_amount;
+			}
 			current_tax_amount = (tax_rate / 100.0) * item.net_amount;
-		} else if(tax.charge_type == "On Previous Row Amount") {
-			current_net_amount = this.frm.doc["taxes"][cint(tax.row_id) - 1].tax_amount_for_current_item
-			current_tax_amount = (tax_rate / 100.0) *
-				this.frm.doc["taxes"][cint(tax.row_id) - 1].tax_amount_for_current_item;
-		} else if(tax.charge_type == "On Previous Row Total") {
-			current_net_amount = this.frm.doc["taxes"][cint(tax.row_id) - 1].grand_total_for_current_item
-			current_tax_amount = (tax_rate / 100.0) *
-				this.frm.doc["taxes"][cint(tax.row_id) - 1].grand_total_for_current_item;
+		} else if (tax.charge_type == "On Previous Row Amount") {
+			current_net_amount = this.frm.doc["taxes"][cint(tax.row_id) - 1].tax_amount_for_current_item;
+			current_tax_amount =
+				(tax_rate / 100.0) * this.frm.doc["taxes"][cint(tax.row_id) - 1].tax_amount_for_current_item;
+		} else if (tax.charge_type == "On Previous Row Total") {
+			current_net_amount = this.frm.doc["taxes"][cint(tax.row_id) - 1].grand_total_for_current_item;
+			current_tax_amount =
+				(tax_rate / 100.0) * this.frm.doc["taxes"][cint(tax.row_id) - 1].grand_total_for_current_item;
 		} else if (tax.charge_type == "On Item Quantity") {
 			// don't sum current net amount due to the field being a currency field
 			current_tax_amount = tax_rate * item.qty;
@@ -510,7 +563,7 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 		let tax_detail = tax.item_wise_tax_detail;
 		let key = item.item_code || item.item_name;
 
-		if(typeof (tax_detail) == "string") {
+		if (typeof tax_detail == "string") {
 			tax.item_wise_tax_detail = JSON.parse(tax.item_wise_tax_detail);
 			tax_detail = tax.item_wise_tax_detail;
 		}
@@ -538,27 +591,30 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 
 	round_off_totals(tax) {
 		if (frappe.flags.round_off_applicable_accounts.includes(tax.account_head)) {
-			tax.tax_amount= Math.round(tax.tax_amount);
+			tax.tax_amount = Math.round(tax.tax_amount);
 			tax.tax_amount_after_discount_amount = Math.round(tax.tax_amount_after_discount_amount);
 		}
 
 		tax.tax_amount = flt(tax.tax_amount, precision("tax_amount", tax));
-		tax.tax_amount_after_discount_amount = flt(tax.tax_amount_after_discount_amount, precision("tax_amount", tax));
+		tax.tax_amount_after_discount_amount = flt(
+			tax.tax_amount_after_discount_amount,
+			precision("tax_amount", tax)
+		);
 	}
 
 	round_off_base_values(tax) {
 		if (frappe.flags.round_off_applicable_accounts.includes(tax.account_head)) {
-			tax.base_tax_amount= Math.round(tax.base_tax_amount);
+			tax.base_tax_amount = Math.round(tax.base_tax_amount);
 			tax.base_tax_amount_after_discount_amount = Math.round(tax.base_tax_amount_after_discount_amount);
 		}
 	}
 
 	/**
-	* @deprecated Use adjust_grand_total_for_inclusive_tax instead.
-	*/
+	 * @deprecated Use adjust_grand_total_for_inclusive_tax instead.
+	 */
 	manipulate_grand_total_for_inclusive_tax() {
 		// for backward compatablility - if in case used by an external application
-		this.adjust_grand_total_for_inclusive_tax()
+		this.adjust_grand_total_for_inclusive_tax();
 	}
 
 	adjust_grand_total_for_inclusive_tax() {
@@ -567,30 +623,33 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 		// if any inclusive taxes and diff
 		if (this.frm.doc["taxes"] && this.frm.doc["taxes"].length) {
 			var any_inclusive_tax = false;
-			$.each(this.frm.doc.taxes || [], function(i, d) {
-				if(cint(d.included_in_print_rate)) any_inclusive_tax = true;
+			$.each(this.frm.doc.taxes || [], function (i, d) {
+				if (cint(d.included_in_print_rate)) any_inclusive_tax = true;
 			});
 			if (any_inclusive_tax) {
 				var last_tax = me.frm.doc["taxes"].slice(-1)[0];
-				var non_inclusive_tax_amount = frappe.utils.sum($.map(this.frm.doc.taxes || [],
-					function(d) {
-						if(!d.included_in_print_rate) {
-							let tax_amount = d.category === "Valuation" ? 0 : d.tax_amount_after_discount_amount;
+				var non_inclusive_tax_amount = frappe.utils.sum(
+					$.map(this.frm.doc.taxes || [], function (d) {
+						if (!d.included_in_print_rate) {
+							let tax_amount =
+								d.category === "Valuation" ? 0 : d.tax_amount_after_discount_amount;
 							if (d.add_deduct_tax === "Deduct") tax_amount *= -1;
 							return tax_amount;
 						}
-					}
-				));
-				var diff = me.frm.doc.total + non_inclusive_tax_amount
-					- flt(last_tax.total, precision("grand_total"));
+					})
+				);
+				var diff =
+					me.frm.doc.total +
+					non_inclusive_tax_amount -
+					flt(last_tax.total, precision("grand_total"));
 
-				if(me.discount_amount_applied && me.frm.doc.discount_amount) {
+				if (me.discount_amount_applied && me.frm.doc.discount_amount) {
 					diff -= flt(me.frm.doc.discount_amount);
 				}
 
 				diff = flt(diff, precision("rounding_adjustment"));
 
-				if ( diff && Math.abs(diff) <= (5.0 / Math.pow(10, precision("tax_amount", last_tax))) ) {
+				if (diff && Math.abs(diff) <= 5.0 / Math.pow(10, precision("tax_amount", last_tax))) {
 					me.grand_total_diff = diff;
 				}
 			}
@@ -603,40 +662,56 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 		const tax_count = this.frm.doc.taxes?.length;
 		const grand_total_diff = this.grand_total_diff || 0;
 
-		this.frm.doc.grand_total = flt(tax_count
-			? this.frm.doc["taxes"][tax_count - 1].total + grand_total_diff
-			: this.frm.doc.net_total);
+		this.frm.doc.grand_total = flt(
+			tax_count ? this.frm.doc["taxes"][tax_count - 1].total + grand_total_diff : this.frm.doc.net_total
+		);
 
-		if(["Quotation", "Sales Order", "Delivery Note", "Sales Invoice", "POS Invoice"].includes(this.frm.doc.doctype)) {
-			this.frm.doc.base_grand_total = (this.frm.doc.total_taxes_and_charges) ?
-				flt(this.frm.doc.grand_total * this.frm.doc.conversion_rate) : this.frm.doc.base_net_total;
+		if (
+			["Quotation", "Sales Order", "Delivery Note", "Sales Invoice", "POS Invoice"].includes(
+				this.frm.doc.doctype
+			)
+		) {
+			this.frm.doc.base_grand_total = this.frm.doc.total_taxes_and_charges
+				? flt(this.frm.doc.grand_total * this.frm.doc.conversion_rate)
+				: this.frm.doc.base_net_total;
 		} else {
 			// other charges added/deducted
 			this.frm.doc.taxes_and_charges_added = this.frm.doc.taxes_and_charges_deducted = 0.0;
-			if(tax_count) {
-				$.each(this.frm.doc["taxes"] || [], function(i, tax) {
+			if (tax_count) {
+				$.each(this.frm.doc["taxes"] || [], function (i, tax) {
 					if (["Valuation and Total", "Total"].includes(tax.category)) {
-						if(tax.add_deduct_tax == "Add") {
+						if (tax.add_deduct_tax == "Add") {
 							me.frm.doc.taxes_and_charges_added += flt(tax.tax_amount_after_discount_amount);
 						} else {
-							me.frm.doc.taxes_and_charges_deducted += flt(tax.tax_amount_after_discount_amount);
+							me.frm.doc.taxes_and_charges_deducted += flt(
+								tax.tax_amount_after_discount_amount
+							);
 						}
 					}
 				});
 
-				frappe.model.round_floats_in(this.frm.doc,
-					["taxes_and_charges_added", "taxes_and_charges_deducted"]);
+				frappe.model.round_floats_in(this.frm.doc, [
+					"taxes_and_charges_added",
+					"taxes_and_charges_deducted",
+				]);
 			}
 
-			this.frm.doc.base_grand_total = flt((this.frm.doc.taxes_and_charges_added || this.frm.doc.taxes_and_charges_deducted) ?
-				flt(this.frm.doc.grand_total * this.frm.doc.conversion_rate) : this.frm.doc.base_net_total);
+			this.frm.doc.base_grand_total = flt(
+				this.frm.doc.taxes_and_charges_added || this.frm.doc.taxes_and_charges_deducted
+					? flt(this.frm.doc.grand_total * this.frm.doc.conversion_rate)
+					: this.frm.doc.base_net_total
+			);
 
-			this.set_in_company_currency(this.frm.doc,
-				["taxes_and_charges_added", "taxes_and_charges_deducted"]);
+			this.set_in_company_currency(this.frm.doc, [
+				"taxes_and_charges_added",
+				"taxes_and_charges_deducted",
+			]);
 		}
 
-		this.frm.doc.total_taxes_and_charges = flt(this.frm.doc.grand_total - this.frm.doc.net_total
-			- grand_total_diff, precision("total_taxes_and_charges"));
+		this.frm.doc.total_taxes_and_charges = flt(
+			this.frm.doc.grand_total - this.frm.doc.net_total - grand_total_diff,
+			precision("total_taxes_and_charges")
+		);
 
 		this.set_in_company_currency(this.frm.doc, ["total_taxes_and_charges"]);
 
@@ -649,7 +724,7 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 
 	set_rounded_total() {
 		var disable_rounded_total = 0;
-		if(frappe.meta.get_docfield(this.frm.doc.doctype, "disable_rounded_total", this.frm.doc.name)) {
+		if (frappe.meta.get_docfield(this.frm.doc.doctype, "disable_rounded_total", this.frm.doc.name)) {
 			disable_rounded_total = this.frm.doc.disable_rounded_total;
 		} else if (frappe.sys_defaults.disable_rounded_total) {
 			disable_rounded_total = frappe.sys_defaults.disable_rounded_total;
@@ -662,11 +737,16 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 			return;
 		}
 
-		if(frappe.meta.get_docfield(this.frm.doc.doctype, "rounded_total", this.frm.doc.name)) {
-			this.frm.doc.rounded_total = round_based_on_smallest_currency_fraction(this.frm.doc.grand_total,
-				this.frm.doc.currency, precision("rounded_total"));
-			this.frm.doc.rounding_adjustment = flt(this.frm.doc.rounded_total - this.frm.doc.grand_total,
-				precision("rounding_adjustment"));
+		if (frappe.meta.get_docfield(this.frm.doc.doctype, "rounded_total", this.frm.doc.name)) {
+			this.frm.doc.rounded_total = round_based_on_smallest_currency_fraction(
+				this.frm.doc.grand_total,
+				this.frm.doc.currency,
+				precision("rounded_total")
+			);
+			this.frm.doc.rounding_adjustment = flt(
+				this.frm.doc.rounded_total - this.frm.doc.grand_total,
+				precision("rounding_adjustment")
+			);
 
 			this.set_in_company_currency(this.frm.doc, ["rounding_adjustment", "rounded_total"]);
 		}
@@ -676,24 +756,34 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 		this.frm.doc.base_in_words = this.frm.doc.in_words = "";
 		let items = this.frm.doc.items;
 
-		if(items && items.length) {
-			if(!frappe.meta.get_docfield(items[0].doctype, "item_tax_amount", this.frm.doctype)) {
-				$.each(items || [], function(i, item) {
+		if (items && items.length) {
+			if (!frappe.meta.get_docfield(items[0].doctype, "item_tax_amount", this.frm.doctype)) {
+				$.each(items || [], function (i, item) {
 					delete item["item_tax_amount"];
 				});
 			}
 		}
 
-		if(this.frm.doc["taxes"] && this.frm.doc["taxes"].length) {
-			var temporary_fields = ["tax_amount_for_current_item", "grand_total_for_current_item",
-				"tax_fraction_for_current_item", "grand_total_fraction_for_current_item"];
+		if (this.frm.doc["taxes"] && this.frm.doc["taxes"].length) {
+			var temporary_fields = [
+				"tax_amount_for_current_item",
+				"grand_total_for_current_item",
+				"tax_fraction_for_current_item",
+				"grand_total_fraction_for_current_item",
+			];
 
-			if(!frappe.meta.get_docfield(this.frm.doc["taxes"][0].doctype, "tax_amount_after_discount_amount", this.frm.doctype)) {
+			if (
+				!frappe.meta.get_docfield(
+					this.frm.doc["taxes"][0].doctype,
+					"tax_amount_after_discount_amount",
+					this.frm.doctype
+				)
+			) {
 				temporary_fields.push("tax_amount_after_discount_amount");
 			}
 
-			$.each(this.frm.doc["taxes"] || [], function(i, tax) {
-				$.each(temporary_fields, function(i, fieldname) {
+			$.each(this.frm.doc["taxes"] || [], function (i, tax) {
+				$.each(temporary_fields, function (i, fieldname) {
 					delete tax[fieldname];
 				});
 
@@ -705,9 +795,13 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 	}
 
 	set_discount_amount() {
-		if(this.frm.doc.additional_discount_percentage) {
-			this.frm.doc.discount_amount = flt(flt(this.frm.doc[frappe.scrub(this.frm.doc.apply_discount_on)])
-				* this.frm.doc.additional_discount_percentage / 100, precision("discount_amount"));
+		if (this.frm.doc.additional_discount_percentage) {
+			this.frm.doc.discount_amount = flt(
+				(flt(this.frm.doc[frappe.scrub(this.frm.doc.apply_discount_on)]) *
+					this.frm.doc.additional_discount_percentage) /
+					100,
+				precision("discount_amount")
+			);
 		}
 	}
 
@@ -717,13 +811,17 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 		this.frm.doc.base_discount_amount = 0.0;
 
 		if (this.frm.doc.discount_amount) {
-			if(!this.frm.doc.apply_discount_on)
-				frappe.throw(__("Please select Apply Discount On"));
+			if (!this.frm.doc.apply_discount_on) frappe.throw(__("Please select Apply Discount On"));
 
-			this.frm.doc.base_discount_amount = flt(this.frm.doc.discount_amount * this.frm.doc.conversion_rate,
-				precision("base_discount_amount"));
+			this.frm.doc.base_discount_amount = flt(
+				this.frm.doc.discount_amount * this.frm.doc.conversion_rate,
+				precision("base_discount_amount")
+			);
 
-			if (this.frm.doc.apply_discount_on == "Grand Total" && this.frm.doc.is_cash_or_non_trade_discount) {
+			if (
+				this.frm.doc.apply_discount_on == "Grand Total" &&
+				this.frm.doc.is_cash_or_non_trade_discount
+			) {
 				return;
 			}
 
@@ -733,11 +831,12 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 
 			// calculate item amount after Discount Amount
 			if (total_for_discount_amount) {
-				$.each(this.frm._items || [], function(i, item) {
-					distributed_amount = flt(me.frm.doc.discount_amount) * item.net_amount / total_for_discount_amount;
+				$.each(this.frm._items || [], function (i, item) {
+					distributed_amount =
+						(flt(me.frm.doc.discount_amount) * item.net_amount) / total_for_discount_amount;
 
 					const adjusted_net_amount = item.net_amount - distributed_amount;
-					expected_net_total += adjusted_net_amount
+					expected_net_total += adjusted_net_amount;
 					item.net_amount = flt(adjusted_net_amount, precision("net_amount", item));
 					net_total += item.net_amount;
 
@@ -745,10 +844,15 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 					// assignment to rounding_difference is intentional
 					const rounding_difference = flt(expected_net_total - net_total, precision("net_total"));
 					if (rounding_difference) {
-						item.net_amount = flt(item.net_amount + rounding_difference, precision("net_amount", item));
+						item.net_amount = flt(
+							item.net_amount + rounding_difference,
+							precision("net_amount", item)
+						);
 						net_total += rounding_difference;
 					}
-					item.net_rate = item.qty ? flt(item.net_amount / item.qty, precision("net_rate", item)) : 0;
+					item.net_rate = item.qty
+						? flt(item.net_amount / item.qty, precision("net_rate", item))
+						: 0;
 					me.set_in_company_currency(item, ["net_rate", "net_amount"]);
 				});
 
@@ -761,8 +865,7 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 	get_total_for_discount_amount() {
 		const doc = this.frm.doc;
 
-		if (doc.apply_discount_on == "Net Total" || !doc.taxes?.length)
-			return doc.net_total;
+		if (doc.apply_discount_on == "Net Total" || !doc.taxes?.length) return doc.net_total;
 
 		let total_actual_tax = 0.0;
 		let actual_taxes_dict = {};
@@ -773,11 +876,11 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 
 			actual_taxes_dict[tax.idx] = {
 				tax_amount: tax_amount,
-				cumulative_total: total_actual_tax
+				cumulative_total: total_actual_tax,
 			};
 		}
 
-		doc.taxes.forEach(tax => {
+		doc.taxes.forEach((tax) => {
 			if (["Actual", "On Item Quantity"].includes(tax.charge_type)) {
 				update_actual_taxes_dict(tax, tax.tax_amount);
 				return;
@@ -788,17 +891,22 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 
 			// if charge type is 'On Previous Row Amount', calculate tax on previous row amount
 			// else (On Previous Row Total) calculate tax on cumulative total
-			const base_tax_amount = tax.charge_type == "On Previous Row Amount" ? base_row["tax_amount"]: base_row["cumulative_total"];
-			update_actual_taxes_dict(tax, base_tax_amount * tax.rate / 100);
+			const base_tax_amount =
+				tax.charge_type == "On Previous Row Amount"
+					? base_row["tax_amount"]
+					: base_row["cumulative_total"];
+			update_actual_taxes_dict(tax, (base_tax_amount * tax.rate) / 100);
 		});
 
 		return (this.grand_total_for_distributing_discount || doc.grand_total) - total_actual_tax;
 	}
 
 	calculate_total_advance(update_paid_amount) {
-		var total_allocated_amount = frappe.utils.sum($.map(this.frm.doc["advances"] || [], function(adv) {
-			return flt(adv.allocated_amount, precision("allocated_amount", adv));
-		}));
+		var total_allocated_amount = frappe.utils.sum(
+			$.map(this.frm.doc["advances"] || [], function (adv) {
+				return flt(adv.allocated_amount, precision("allocated_amount", adv));
+			})
+		);
 		this.frm.doc.total_advance = flt(total_allocated_amount, precision("total_advance"));
 
 		if (this.frm.doc.write_off_outstanding_amount_automatically) {
@@ -810,7 +918,7 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 	}
 
 	is_internal_invoice() {
-		if (['Sales Invoice', 'Purchase Invoice'].includes(this.frm.doc.doctype)) {
+		if (["Sales Invoice", "Purchase Invoice"].includes(this.frm.doc.doctype)) {
 			if (this.frm.doc.company === this.frm.doc.represents_company) {
 				return true;
 			}
@@ -822,25 +930,28 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 		// NOTE:
 		// paid_amount and write_off_amount is only for POS/Loyalty Point Redemption Invoice
 		// total_advance is only for non POS Invoice
-		if(["Sales Invoice", "POS Invoice"].includes(this.frm.doc.doctype) && this.frm.doc.is_return){
+		if (["Sales Invoice", "POS Invoice"].includes(this.frm.doc.doctype) && this.frm.doc.is_return) {
 			this.calculate_paid_amount();
 		}
 
-		if (this.frm.doc.is_return || (this.frm.doc.docstatus > 0) || this.is_internal_invoice()) return;
+		if (this.frm.doc.is_return || this.frm.doc.docstatus > 0 || this.is_internal_invoice()) return;
 
 		frappe.model.round_floats_in(this.frm.doc, ["grand_total", "total_advance", "write_off_amount"]);
 
-		if(["Sales Invoice", "POS Invoice", "Purchase Invoice"].includes(this.frm.doc.doctype)) {
+		if (["Sales Invoice", "POS Invoice", "Purchase Invoice"].includes(this.frm.doc.doctype)) {
 			let grand_total = this.frm.doc.rounded_total || this.frm.doc.grand_total;
 			let base_grand_total = this.frm.doc.base_rounded_total || this.frm.doc.base_grand_total;
 
-			if(this.frm.doc.party_account_currency == this.frm.doc.currency) {
-				var total_amount_to_pay = flt((grand_total - this.frm.doc.total_advance
-					- this.frm.doc.write_off_amount), precision("grand_total"));
+			if (this.frm.doc.party_account_currency == this.frm.doc.currency) {
+				var total_amount_to_pay = flt(
+					grand_total - this.frm.doc.total_advance - this.frm.doc.write_off_amount,
+					precision("grand_total")
+				);
 			} else {
 				var total_amount_to_pay = flt(
-					(flt(base_grand_total, precision("base_grand_total"))
-						- this.frm.doc.total_advance - this.frm.doc.base_write_off_amount),
+					flt(base_grand_total, precision("base_grand_total")) -
+						this.frm.doc.total_advance -
+						this.frm.doc.base_write_off_amount,
 					precision("base_grand_total")
 				);
 			}
@@ -848,24 +959,34 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 			frappe.model.round_floats_in(this.frm.doc, ["paid_amount"]);
 			this.set_in_company_currency(this.frm.doc, ["paid_amount"]);
 
-			if(this.frm.refresh_field){
+			if (this.frm.refresh_field) {
 				this.frm.refresh_field("paid_amount");
 				this.frm.refresh_field("base_paid_amount");
 			}
 
-			if(["Sales Invoice", "POS Invoice"].includes(this.frm.doc.doctype)) {
-				let total_amount_for_payment = (this.frm.doc.redeem_loyalty_points && this.frm.doc.loyalty_amount)
-					? flt(total_amount_to_pay - this.frm.doc.loyalty_amount, precision("base_grand_total"))
-					: total_amount_to_pay;
+			if (["Sales Invoice", "POS Invoice"].includes(this.frm.doc.doctype)) {
+				let total_amount_for_payment =
+					this.frm.doc.redeem_loyalty_points && this.frm.doc.loyalty_amount
+						? flt(
+								total_amount_to_pay - this.frm.doc.loyalty_amount,
+								precision("base_grand_total")
+						  )
+						: total_amount_to_pay;
 				this.set_default_payment(total_amount_for_payment, update_paid_amount);
 				this.calculate_paid_amount();
 			}
 			this.calculate_change_amount();
 
-			var paid_amount = (this.frm.doc.party_account_currency == this.frm.doc.currency) ?
-				this.frm.doc.paid_amount : this.frm.doc.base_paid_amount;
-			this.frm.doc.outstanding_amount =  flt(total_amount_to_pay - flt(paid_amount) +
-				flt(this.frm.doc.change_amount * this.frm.doc.conversion_rate), precision("outstanding_amount"));
+			var paid_amount =
+				this.frm.doc.party_account_currency == this.frm.doc.currency
+					? this.frm.doc.paid_amount
+					: this.frm.doc.base_paid_amount;
+			this.frm.doc.outstanding_amount = flt(
+				total_amount_to_pay -
+					flt(paid_amount) +
+					flt(this.frm.doc.change_amount * this.frm.doc.conversion_rate),
+				precision("outstanding_amount")
+			);
 		}
 	}
 
@@ -880,13 +1001,9 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 			);
 		} else {
 			var total_amount_to_pay = flt(
-				(
-					flt(
-						base_grand_total,
-						precision("base_grand_total")
-					)
-					- this.frm.doc.total_advance - this.frm.doc.base_write_off_amount
-				),
+				flt(base_grand_total, precision("base_grand_total")) -
+					this.frm.doc.total_advance -
+					this.frm.doc.base_write_off_amount,
 				precision("base_grand_total")
 			);
 		}
@@ -898,8 +1015,8 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 		*/
 
 		let payment_amount = 0;
-		this.frm.doc.payments.forEach(payment => {
-			payment_amount += payment.amount
+		this.frm.doc.payments.forEach((payment) => {
+			payment_amount += payment.amount;
 		});
 
 		if (payment_amount == total_amount_to_pay) {
@@ -911,16 +1028,16 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 		it should set the return to that mode of payment only.
 		*/
 
-		if(this.frm.doc.return_against){
-			let {message : return_against_mop } = await frappe.call({
-				method: 'erpnext.controllers.sales_and_purchase_return.get_payment_data',
+		if (this.frm.doc.return_against) {
+			let { message: return_against_mop } = await frappe.call({
+				method: "erpnext.controllers.sales_and_purchase_return.get_payment_data",
 				args: {
-					invoice: this.frm.doc.return_against
-				}
+					invoice: this.frm.doc.return_against,
+				},
 			});
 
 			if (return_against_mop.length === 1) {
-				this.frm.doc.payments.forEach(payment => {
+				this.frm.doc.payments.forEach((payment) => {
 					if (payment.mode_of_payment == return_against_mop[0].mode_of_payment) {
 						payment.amount = total_amount_to_pay;
 					} else {
@@ -932,11 +1049,11 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 			}
 		}
 
-		this.frm.doc.payments.find(payment => {
+		this.frm.doc.payments.find((payment) => {
 			if (payment.default) {
 				payment.amount = total_amount_to_pay;
 			} else {
-				payment.amount = 0
+				payment.amount = 0;
 			}
 		});
 
@@ -948,30 +1065,35 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 		var payment_status = true;
 
 		if (
-			this.frm.doc.is_pos
-			&& cint(this.frm.set_default_payment)
-			&& (update_paid_amount===undefined || update_paid_amount)
+			this.frm.doc.is_pos &&
+			cint(this.frm.set_default_payment) &&
+			(update_paid_amount === undefined || update_paid_amount)
 		) {
-			$.each(this.frm.doc['payments'] || [], function(index, data) {
-				if(data.default && payment_status && total_amount_to_pay > 0) {
+			$.each(this.frm.doc["payments"] || [], function (index, data) {
+				if (data.default && payment_status && total_amount_to_pay > 0) {
 					let base_amount, amount;
 
 					if (me.frm.doc.party_account_currency == me.frm.doc.currency) {
 						// if customer/supplier currency is same as company currency
 						// total_amount_to_pay is already in customer/supplier currency
 						// so base_amount has to be calculated using total_amount_to_pay
-						base_amount = flt(total_amount_to_pay * me.frm.doc.conversion_rate, precision("base_amount", data));
+						base_amount = flt(
+							total_amount_to_pay * me.frm.doc.conversion_rate,
+							precision("base_amount", data)
+						);
 						amount = flt(total_amount_to_pay, precision("amount", data));
 					} else {
 						base_amount = flt(total_amount_to_pay, precision("base_amount", data));
-						amount = flt(total_amount_to_pay / me.frm.doc.conversion_rate, precision("amount", data));
+						amount = flt(
+							total_amount_to_pay / me.frm.doc.conversion_rate,
+							precision("amount", data)
+						);
 					}
 
 					frappe.model.set_value(data.doctype, data.name, "base_amount", base_amount);
 					frappe.model.set_value(data.doctype, data.name, "amount", amount);
 					payment_status = false;
-
-				} else if(me.frm.doc.paid_amount) {
+				} else if (me.frm.doc.paid_amount) {
 					frappe.model.set_value(data.doctype, data.name, "amount", 0.0);
 				}
 			});
@@ -982,56 +1104,74 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 		var me = this;
 		var paid_amount = 0.0;
 		var base_paid_amount = 0.0;
-		if(this.frm.doc.is_pos) {
-			$.each(this.frm.doc['payments'] || [], function(index, data){
-				data.base_amount = flt(data.amount * me.frm.doc.conversion_rate, precision("base_amount", data));
+		if (this.frm.doc.is_pos) {
+			$.each(this.frm.doc["payments"] || [], function (index, data) {
+				data.base_amount = flt(
+					data.amount * me.frm.doc.conversion_rate,
+					precision("base_amount", data)
+				);
 				paid_amount += data.amount;
 				base_paid_amount += data.base_amount;
 			});
-		} else if(!this.frm.doc.is_return){
+		} else if (!this.frm.doc.is_return) {
 			this.frm.doc.payments = [];
 		}
 		if (this.frm.doc.redeem_loyalty_points && this.frm.doc.loyalty_amount) {
 			base_paid_amount += this.frm.doc.loyalty_amount;
-			paid_amount += flt(this.frm.doc.loyalty_amount / me.frm.doc.conversion_rate, precision("paid_amount"));
+			paid_amount += flt(
+				this.frm.doc.loyalty_amount / me.frm.doc.conversion_rate,
+				precision("paid_amount")
+			);
 		}
 
-		this.frm.set_value('paid_amount', flt(paid_amount, precision("paid_amount")));
-		this.frm.set_value('base_paid_amount', flt(base_paid_amount, precision("base_paid_amount")));
+		this.frm.set_value("paid_amount", flt(paid_amount, precision("paid_amount")));
+		this.frm.set_value("base_paid_amount", flt(base_paid_amount, precision("base_paid_amount")));
 	}
 
-	calculate_change_amount(){
+	calculate_change_amount() {
 		this.frm.doc.change_amount = 0.0;
 		this.frm.doc.base_change_amount = 0.0;
-		if(["Sales Invoice", "POS Invoice"].includes(this.frm.doc.doctype)
-			&& this.frm.doc.paid_amount > this.frm.doc.grand_total && !this.frm.doc.is_return) {
-
-			var payment_types = $.map(this.frm.doc.payments, function(d) { return d.type; });
-			if (in_list(payment_types, 'Cash')) {
+		if (
+			["Sales Invoice", "POS Invoice"].includes(this.frm.doc.doctype) &&
+			this.frm.doc.paid_amount > this.frm.doc.grand_total &&
+			!this.frm.doc.is_return
+		) {
+			var payment_types = $.map(this.frm.doc.payments, function (d) {
+				return d.type;
+			});
+			if (in_list(payment_types, "Cash")) {
 				var grand_total = this.frm.doc.rounded_total || this.frm.doc.grand_total;
 				var base_grand_total = this.frm.doc.base_rounded_total || this.frm.doc.base_grand_total;
 
-				this.frm.doc.change_amount = flt(this.frm.doc.paid_amount - grand_total,
-					precision("change_amount"));
+				this.frm.doc.change_amount = flt(
+					this.frm.doc.paid_amount - grand_total,
+					precision("change_amount")
+				);
 
-				this.frm.doc.base_change_amount = flt(this.frm.doc.base_paid_amount -
-					base_grand_total, precision("base_change_amount"));
+				this.frm.doc.base_change_amount = flt(
+					this.frm.doc.base_paid_amount - base_grand_total,
+					precision("base_change_amount")
+				);
 			}
 		}
 	}
 
 	calculate_write_off_amount() {
-		if(this.frm.doc.write_off_outstanding_amount_automatically) {
-			this.frm.doc.write_off_amount = flt(this.frm.doc.outstanding_amount, precision("write_off_amount"));
-			this.frm.doc.base_write_off_amount = flt(this.frm.doc.write_off_amount * this.frm.doc.conversion_rate,
-				precision("base_write_off_amount"));
+		if (this.frm.doc.write_off_outstanding_amount_automatically) {
+			this.frm.doc.write_off_amount = flt(
+				this.frm.doc.outstanding_amount,
+				precision("write_off_amount")
+			);
+			this.frm.doc.base_write_off_amount = flt(
+				this.frm.doc.write_off_amount * this.frm.doc.conversion_rate,
+				precision("base_write_off_amount")
+			);
 
 			this.calculate_outstanding_amount(false);
 		}
-
 	}
 
 	filtered_items() {
-		return this.frm.doc.items.filter(item => !item["is_alternative"]);
+		return this.frm.doc.items.filter((item) => !item["is_alternative"]);
 	}
 };

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -1,7 +1,6 @@
 // Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 // License: GNU General Public License v3. See license.txt
 
-
 erpnext.TransactionController = class TransactionController extends erpnext.taxes_and_totals {
 	setup() {
 		super.setup();
@@ -12,32 +11,36 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 		this.frm.ignore_doctypes_on_cancel_all = ["Serial and Batch Bundle"];
 
 		frappe.flags.hide_serial_batch_dialog = true;
-		frappe.ui.form.on(this.frm.doctype + " Item", "rate", function(frm, cdt, cdn) {
+		frappe.ui.form.on(this.frm.doctype + " Item", "rate", function (frm, cdt, cdn) {
 			var item = frappe.get_doc(cdt, cdn);
-			var has_margin_field = frappe.meta.has_field(cdt, 'margin_type');
+			var has_margin_field = frappe.meta.has_field(cdt, "margin_type");
 
 			frappe.model.round_floats_in(item, ["rate", "price_list_rate"]);
 
-			if(item.price_list_rate && !item.blanket_order_rate) {
-				if(item.rate > item.price_list_rate && has_margin_field) {
+			if (item.price_list_rate && !item.blanket_order_rate) {
+				if (item.rate > item.price_list_rate && has_margin_field) {
 					// if rate is greater than price_list_rate, set margin
 					// or set discount
 					item.discount_percentage = 0;
-					item.margin_type = 'Amount';
-					item.margin_rate_or_amount = flt(item.rate - item.price_list_rate,
-						precision("margin_rate_or_amount", item));
+					item.margin_type = "Amount";
+					item.margin_rate_or_amount = flt(
+						item.rate - item.price_list_rate,
+						precision("margin_rate_or_amount", item)
+					);
 					item.rate_with_margin = item.rate;
 				} else {
-					item.discount_percentage = flt((1 - item.rate / item.price_list_rate) * 100.0,
-						precision("discount_percentage", item));
+					item.discount_percentage = flt(
+						(1 - item.rate / item.price_list_rate) * 100.0,
+						precision("discount_percentage", item)
+					);
 					item.discount_amount = flt(item.price_list_rate) - flt(item.rate);
-					item.margin_type = '';
+					item.margin_type = "";
 					item.margin_rate_or_amount = 0;
 					item.rate_with_margin = 0;
 				}
 			} else {
 				item.discount_percentage = 0.0;
-				item.margin_type = '';
+				item.margin_type = "";
 				item.margin_rate_or_amount = 0;
 				item.rate_with_margin = 0;
 			}
@@ -60,64 +63,65 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 							posting_date: frm.doc.posting_date,
 							bill_date: frm.doc.bill_date,
 							transaction_date: frm.doc.transaction_date,
-						}
+						},
 					},
-					callback: function(r) {
+					callback: function (r) {
 						const item_tax_template = r.message;
-						frappe.model.set_value(cdt, cdn, 'item_tax_template', item_tax_template);
-					}
+						frappe.model.set_value(cdt, cdn, "item_tax_template", item_tax_template);
+					},
 				});
 			}
 		});
 
-		frappe.ui.form.on(this.frm.cscript.tax_table, "rate", function(frm, cdt, cdn) {
+		frappe.ui.form.on(this.frm.cscript.tax_table, "rate", function (frm, cdt, cdn) {
 			cur_frm.cscript.calculate_taxes_and_totals();
 		});
 
-		frappe.ui.form.on(this.frm.cscript.tax_table, "tax_amount", function(frm, cdt, cdn) {
+		frappe.ui.form.on(this.frm.cscript.tax_table, "tax_amount", function (frm, cdt, cdn) {
 			cur_frm.cscript.calculate_taxes_and_totals();
 		});
 
-		frappe.ui.form.on(this.frm.cscript.tax_table, "row_id", function(frm, cdt, cdn) {
+		frappe.ui.form.on(this.frm.cscript.tax_table, "row_id", function (frm, cdt, cdn) {
 			cur_frm.cscript.calculate_taxes_and_totals();
 		});
 
-		frappe.ui.form.on(this.frm.cscript.tax_table, "included_in_print_rate", function(frm, cdt, cdn) {
+		frappe.ui.form.on(this.frm.cscript.tax_table, "included_in_print_rate", function (frm, cdt, cdn) {
 			cur_frm.cscript.set_dynamic_labels();
 			cur_frm.cscript.calculate_taxes_and_totals();
 		});
 
-		frappe.ui.form.on(this.frm.doctype, "apply_discount_on", function(frm) {
-			if(frm.doc.additional_discount_percentage) {
+		frappe.ui.form.on(this.frm.doctype, "apply_discount_on", function (frm) {
+			if (frm.doc.additional_discount_percentage) {
 				frm.trigger("additional_discount_percentage");
 			} else {
 				cur_frm.cscript.calculate_taxes_and_totals();
 			}
 		});
 
-		frappe.ui.form.on(this.frm.doctype, "additional_discount_percentage", function(frm) {
-			if(!frm.doc.apply_discount_on) {
+		frappe.ui.form.on(this.frm.doctype, "additional_discount_percentage", function (frm) {
+			if (!frm.doc.apply_discount_on) {
 				frappe.msgprint(__("Please set 'Apply Additional Discount On'"));
 				return;
 			}
 
 			frm.via_discount_percentage = true;
 
-			if(frm.doc.additional_discount_percentage && frm.doc.discount_amount) {
+			if (frm.doc.additional_discount_percentage && frm.doc.discount_amount) {
 				// Reset discount amount and net / grand total
 				frm.doc.discount_amount = 0;
 				frm.cscript.calculate_taxes_and_totals();
 			}
 
 			var total = flt(frm.doc[frappe.model.scrub(frm.doc.apply_discount_on)]);
-			var discount_amount = flt(total*flt(frm.doc.additional_discount_percentage) / 100,
-				precision("discount_amount"));
+			var discount_amount = flt(
+				(total * flt(frm.doc.additional_discount_percentage)) / 100,
+				precision("discount_amount")
+			);
 
-			frm.set_value("discount_amount", discount_amount)
-				.then(() => delete frm.via_discount_percentage);
+			frm.set_value("discount_amount", discount_amount).then(() => delete frm.via_discount_percentage);
 		});
 
-		frappe.ui.form.on(this.frm.doctype, "discount_amount", function(frm) {
+		frappe.ui.form.on(this.frm.doctype, "discount_amount", function (frm) {
 			frm.cscript.set_dynamic_labels();
 
 			if (!frm.via_discount_percentage) {
@@ -128,7 +132,7 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 		});
 
 		frappe.ui.form.on(this.frm.doctype + " Item", {
-			items_add: function(frm, cdt, cdn) {
+			items_add: function (frm, cdt, cdn) {
 				var item = frappe.get_doc(cdt, cdn);
 				if (!item.warehouse && frm.doc.set_warehouse) {
 					item.warehouse = frm.doc.set_warehouse;
@@ -142,133 +146,132 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 					item.from_warehouse = frm.doc.set_from_warehouse;
 				}
 
-				if (item.docstatus === 0
-					&& frappe.meta.has_field(item.doctype, "use_serial_batch_fields")
-					&& cint(frappe.user_defaults?.use_serial_batch_fields) === 1
+				if (
+					item.docstatus === 0 &&
+					frappe.meta.has_field(item.doctype, "use_serial_batch_fields") &&
+					cint(frappe.user_defaults?.use_serial_batch_fields) === 1
 				) {
 					frappe.model.set_value(item.doctype, item.name, "use_serial_batch_fields", 1);
 				}
 
-				erpnext.accounts.dimensions.copy_dimension_from_first_row(frm, cdt, cdn, 'items');
-			}
+				erpnext.accounts.dimensions.copy_dimension_from_first_row(frm, cdt, cdn, "items");
+			},
 		});
 
-		if(this.frm.fields_dict["items"].grid.get_field('serial_and_batch_bundle')) {
-			this.frm.set_query("serial_and_batch_bundle", "items", function(doc, cdt, cdn) {
+		if (this.frm.fields_dict["items"].grid.get_field("serial_and_batch_bundle")) {
+			this.frm.set_query("serial_and_batch_bundle", "items", function (doc, cdt, cdn) {
 				let item_row = locals[cdt][cdn];
 				return {
 					filters: {
-						'item_code': item_row.item_code,
-						'voucher_type': doc.doctype,
-						'voucher_no': ["in", [doc.name, ""]],
-						'is_cancelled': 0,
-					}
-				}
+						item_code: item_row.item_code,
+						voucher_type: doc.doctype,
+						voucher_no: ["in", [doc.name, ""]],
+						is_cancelled: 0,
+					},
+				};
 			});
 		}
 
-		if(this.frm.fields_dict['items'].grid.get_field('batch_no')) {
-			this.frm.set_query('batch_no', 'items', function(doc, cdt, cdn) {
+		if (this.frm.fields_dict["items"].grid.get_field("batch_no")) {
+			this.frm.set_query("batch_no", "items", function (doc, cdt, cdn) {
 				return me.set_query_for_batch(doc, cdt, cdn);
 			});
 		}
 
 		if (this.frm.fields_dict["items"].grid.get_field("uom")) {
-			this.frm.set_query("uom", "items", function(doc, cdt, cdn) {
+			this.frm.set_query("uom", "items", function (doc, cdt, cdn) {
 				let row = locals[cdt][cdn];
 
 				return {
 					query: "erpnext.controllers.queries.get_item_uom_query",
 					filters: {
-						"item_code": row.item_code
-					}
+						item_code: row.item_code,
+					},
 				};
 			});
 		}
 
-		if(
-			this.frm.docstatus < 2
-			&& this.frm.fields_dict["payment_terms_template"]
-			&& this.frm.fields_dict["payment_schedule"]
-			&& this.frm.doc.payment_terms_template
-			&& !this.frm.doc.payment_schedule.length
-		){
+		if (
+			this.frm.docstatus < 2 &&
+			this.frm.fields_dict["payment_terms_template"] &&
+			this.frm.fields_dict["payment_schedule"] &&
+			this.frm.doc.payment_terms_template &&
+			!this.frm.doc.payment_schedule.length
+		) {
 			this.frm.trigger("payment_terms_template");
 		}
 
-		if(this.frm.fields_dict["taxes"]) {
+		if (this.frm.fields_dict["taxes"]) {
 			this["taxes_remove"] = this.calculate_taxes_and_totals;
 		}
 
-		if(this.frm.fields_dict["items"]) {
+		if (this.frm.fields_dict["items"]) {
 			this["items_remove"] = this.process_item_removal;
 		}
 
-		if(this.frm.fields_dict["recurring_print_format"]) {
-			this.frm.set_query("recurring_print_format", function(doc) {
-				return{
-					filters: [
-						['Print Format', 'doc_type', '=', cur_frm.doctype],
-					]
+		if (this.frm.fields_dict["recurring_print_format"]) {
+			this.frm.set_query("recurring_print_format", function (doc) {
+				return {
+					filters: [["Print Format", "doc_type", "=", cur_frm.doctype]],
 				};
 			});
 		}
 
-		if(this.frm.fields_dict["return_against"]) {
-			this.frm.set_query("return_against", function(doc) {
+		if (this.frm.fields_dict["return_against"]) {
+			this.frm.set_query("return_against", function (doc) {
 				var filters = {
-					"docstatus": 1,
-					"is_return": 0,
-					"company": doc.company
+					docstatus: 1,
+					is_return: 0,
+					company: doc.company,
 				};
 				if (me.frm.fields_dict["customer"] && doc.customer) filters["customer"] = doc.customer;
 				if (me.frm.fields_dict["supplier"] && doc.supplier) filters["supplier"] = doc.supplier;
 
 				return {
-					filters: filters
+					filters: filters,
 				};
 			});
 		}
 
 		if (this.frm.fields_dict["items"].grid.get_field("expense_account")) {
-			this.frm.set_query("expense_account", "items", function(doc) {
+			this.frm.set_query("expense_account", "items", function (doc) {
 				return {
 					filters: {
-						"company": doc.company,
-						"report_type": "Profit and Loss",
-						"is_group": 0
-					}
+						company: doc.company,
+						report_type: "Profit and Loss",
+						is_group: 0,
+					},
 				};
 			});
 		}
 
-		if(frappe.meta.get_docfield(this.frm.doc.doctype, "pricing_rules")) {
-			this.frm.set_indicator_formatter('pricing_rule', function(doc) {
-				return (doc.rule_applied) ? "green" : "red";
+		if (frappe.meta.get_docfield(this.frm.doc.doctype, "pricing_rules")) {
+			this.frm.set_indicator_formatter("pricing_rule", function (doc) {
+				return doc.rule_applied ? "green" : "red";
 			});
 		}
 
-		if (this.frm.fields_dict["items"].grid.get_field('blanket_order')) {
-			this.frm.set_query("blanket_order", "items", function(doc, cdt, cdn) {
+		if (this.frm.fields_dict["items"].grid.get_field("blanket_order")) {
+			this.frm.set_query("blanket_order", "items", function (doc, cdt, cdn) {
 				var item = locals[cdt][cdn];
 				return {
 					query: "erpnext.controllers.queries.get_blanket_orders",
 					filters: {
-						"company": doc.company,
-						"blanket_order_type": doc.doctype === "Sales Order" ? "Selling" : "Purchasing",
-						"item": item.item_code
-					}
-				}
+						company: doc.company,
+						blanket_order_type: doc.doctype === "Sales Order" ? "Selling" : "Purchasing",
+						item: item.item_code,
+					},
+				};
 			});
 		}
 
 		if (this.frm.fields_dict.taxes_and_charges) {
-			this.frm.set_query("taxes_and_charges", function() {
+			this.frm.set_query("taxes_and_charges", function () {
 				return {
 					filters: [
-						['company', '=', me.frm.doc.company],
-						['docstatus', '!=', 2]
-					]
+						["company", "=", me.frm.doc.company],
+						["docstatus", "!=", 2],
+					],
 				};
 			});
 		}
@@ -285,65 +288,74 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 
 	set_fields_onload_for_line_item() {
 		if (this.frm.is_new() && this.frm.doc?.items) {
-			this.frm.doc.items.forEach(item => {
-				if (item.docstatus === 0
-					&& frappe.meta.has_field(item.doctype, "use_serial_batch_fields")
-					&& cint(frappe.user_defaults?.use_serial_batch_fields) === 1
+			this.frm.doc.items.forEach((item) => {
+				if (
+					item.docstatus === 0 &&
+					frappe.meta.has_field(item.doctype, "use_serial_batch_fields") &&
+					cint(frappe.user_defaults?.use_serial_batch_fields) === 1
 				) {
 					frappe.model.set_value(item.doctype, item.name, "use_serial_batch_fields", 1);
 				}
-			})
+			});
 		}
 	}
 
 	toggle_enable_for_stock_uom(field) {
 		frappe.call({
-			method: 'erpnext.stock.doctype.stock_settings.stock_settings.get_enable_stock_uom_editing',
+			method: "erpnext.stock.doctype.stock_settings.stock_settings.get_enable_stock_uom_editing",
 			callback: (r) => {
 				if (r.message) {
 					var value = r.message[field];
 					this.frm.fields_dict["items"].grid.toggle_enable("stock_qty", value);
 				}
-			}
+			},
 		});
 	}
 
 	onload() {
 		var me = this;
 
-		if(this.frm.doc.__islocal) {
+		if (this.frm.doc.__islocal) {
 			var currency = frappe.defaults.get_user_default("currency");
 
 			let set_value = (fieldname, value) => {
-				if(me.frm.fields_dict[fieldname] && !me.frm.doc[fieldname]) {
+				if (me.frm.fields_dict[fieldname] && !me.frm.doc[fieldname]) {
 					return me.frm.set_value(fieldname, value);
 				}
 			};
 
-			this.frm.trigger('set_default_internal_warehouse');
+			this.frm.trigger("set_default_internal_warehouse");
 
 			return frappe.run_serially([
-				() => set_value('currency', currency),
-				() => set_value('price_list_currency', currency),
-				() => set_value('status', 'Draft'),
-				() => set_value('is_subcontracted', 0),
+				() => set_value("currency", currency),
+				() => set_value("price_list_currency", currency),
+				() => set_value("status", "Draft"),
+				() => set_value("is_subcontracted", 0),
 				() => {
-					if(this.frm.doc.company && !this.frm.doc.amended_from) {
+					if (this.frm.doc.company && !this.frm.doc.amended_from) {
 						this.frm.trigger("company");
 					}
-				}
+				},
 			]);
 		}
 	}
 
 	is_return() {
-		if(!this.frm.doc.is_return && this.frm.doc.return_against) {
-			this.frm.set_value('return_against', '');
+		if (!this.frm.doc.is_return && this.frm.doc.return_against) {
+			this.frm.set_value("return_against", "");
 		}
 	}
 
 	setup_quality_inspection() {
-		if(!["Delivery Note", "Sales Invoice", "Purchase Receipt", "Purchase Invoice", "Subcontracting Receipt"].includes(this.frm.doc.doctype)) {
+		if (
+			![
+				"Delivery Note",
+				"Sales Invoice",
+				"Purchase Receipt",
+				"Purchase Invoice",
+				"Subcontracting Receipt",
+			].includes(this.frm.doc.doctype)
+		) {
 			return;
 		}
 
@@ -353,34 +365,43 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 		}
 
 		const me = this;
-		if (!this.frm.is_new()
-			&& (this.frm.doc.docstatus === 0 || this.frm.doc.__onload?.allow_to_make_qc_after_submission)
-			&& frappe.model.can_create("Quality Inspection")
-			&& show_qc_button) {
-			this.frm.add_custom_button(__("Quality Inspection(s)"), () => {
-				me.make_quality_inspection();
-			}, __("Create"));
+		if (
+			!this.frm.is_new() &&
+			(this.frm.doc.docstatus === 0 || this.frm.doc.__onload?.allow_to_make_qc_after_submission) &&
+			frappe.model.can_create("Quality Inspection") &&
+			show_qc_button
+		) {
+			this.frm.add_custom_button(
+				__("Quality Inspection(s)"),
+				() => {
+					me.make_quality_inspection();
+				},
+				__("Create")
+			);
 		}
 
-		const inspection_type = ["Purchase Receipt", "Purchase Invoice", "Subcontracting Receipt"].includes(this.frm.doc.doctype)
-			? "Incoming" : "Outgoing";
+		const inspection_type = ["Purchase Receipt", "Purchase Invoice", "Subcontracting Receipt"].includes(
+			this.frm.doc.doctype
+		)
+			? "Incoming"
+			: "Outgoing";
 
 		let quality_inspection_field = this.frm.get_docfield("items", "quality_inspection");
-		quality_inspection_field.get_route_options_for_new_doc = function(row) {
-			if(me.frm.is_new()) return {};
+		quality_inspection_field.get_route_options_for_new_doc = function (row) {
+			if (me.frm.is_new()) return {};
 			return {
-				"inspection_type": inspection_type,
-				"reference_type": me.frm.doc.doctype,
-				"reference_name": me.frm.doc.name,
-				"child_row_reference": row.doc.name,
-				"item_code": row.doc.item_code,
-				"description": row.doc.description,
-				"item_serial_no": row.doc.serial_no ? row.doc.serial_no.split("\n")[0] : null,
-				"batch_no": row.doc.batch_no
-			}
-		}
+				inspection_type: inspection_type,
+				reference_type: me.frm.doc.doctype,
+				reference_name: me.frm.doc.name,
+				child_row_reference: row.doc.name,
+				item_code: row.doc.item_code,
+				description: row.doc.description,
+				item_serial_no: row.doc.serial_no ? row.doc.serial_no.split("\n")[0] : null,
+				batch_no: row.doc.batch_no,
+			};
+		};
 
-		this.frm.set_query("quality_inspection", "items", function(doc, cdt, cdn) {
+		this.frm.set_query("quality_inspection", "items", function (doc, cdt, cdn) {
 			let d = locals[cdt][cdn];
 			return {
 				filters: {
@@ -388,46 +409,55 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 					inspection_type: inspection_type,
 					reference_name: doc.name,
 					item_code: d.item_code,
-					child_row_reference : d.name
-				}
-			}
+					child_row_reference: d.name,
+				},
+			};
 		});
 	}
 
 	make_payment_request() {
 		let me = this;
-		const payment_request_type = (['Sales Order', 'Sales Invoice'].includes(this.frm.doc.doctype))
-			? "Inward" : "Outward";
+		const payment_request_type = ["Sales Order", "Sales Invoice"].includes(this.frm.doc.doctype)
+			? "Inward"
+			: "Outward";
 
 		frappe.call({
-			method:"erpnext.accounts.doctype.payment_request.payment_request.make_payment_request",
+			method: "erpnext.accounts.doctype.payment_request.payment_request.make_payment_request",
 			args: {
 				dt: me.frm.doc.doctype,
 				dn: me.frm.doc.name,
 				recipient_id: me.frm.doc.contact_email,
 				payment_request_type: payment_request_type,
-				party_type: payment_request_type == 'Outward' ? "Supplier" : "Customer",
-				party: payment_request_type == 'Outward' ? me.frm.doc.supplier : me.frm.doc.customer,
-				party_name:payment_request_type == 'Outward' ? me.frm.doc.supplier_name : me.frm.doc.customer_name
+				party_type: payment_request_type == "Outward" ? "Supplier" : "Customer",
+				party: payment_request_type == "Outward" ? me.frm.doc.supplier : me.frm.doc.customer,
+				party_name:
+					payment_request_type == "Outward" ? me.frm.doc.supplier_name : me.frm.doc.customer_name,
 			},
-			callback: function(r) {
-				if(!r.exc){
+			callback: function (r) {
+				if (!r.exc) {
 					frappe.model.sync(r.message);
 					frappe.set_route("Form", r.message.doctype, r.message.name);
 				}
-			}
-		})
+			},
+		});
 	}
 
 	onload_post_render() {
-		if(this.frm.doc.__islocal && !(this.frm.doc.taxes || []).length
-			&& !this.frm.doc.__onload?.load_after_mapping) {
+		if (
+			this.frm.doc.__islocal &&
+			!(this.frm.doc.taxes || []).length &&
+			!this.frm.doc.__onload?.load_after_mapping
+		) {
 			frappe.after_ajax(() => this.apply_default_taxes());
-		} else if(this.frm.doc.__islocal && this.frm.doc.company && this.frm.doc["items"]
-			&& !this.frm.doc.is_pos) {
+		} else if (
+			this.frm.doc.__islocal &&
+			this.frm.doc.company &&
+			this.frm.doc["items"] &&
+			!this.frm.doc.is_pos
+		) {
 			frappe.after_ajax(() => this.calculate_taxes_and_totals());
 		}
-		if(frappe.meta.get_docfield(this.frm.doc.doctype + " Item", "item_code")) {
+		if (frappe.meta.get_docfield(this.frm.doc.doctype + " Item", "item_code")) {
 			this.setup_item_selector();
 			this.frm.get_field("items").grid.set_multiple_add("item_code", "qty");
 		}
@@ -447,26 +477,26 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 	set_route_options_for_new_doc() {
 		// While creating the batch from the link field, copy item from line item to batch form
 
-		if(this.frm.fields_dict['items'].grid.get_field('batch_no')) {
-			let batch_no_field = this.frm.get_docfield('items', 'batch_no');
+		if (this.frm.fields_dict["items"].grid.get_field("batch_no")) {
+			let batch_no_field = this.frm.get_docfield("items", "batch_no");
 			if (batch_no_field) {
-				batch_no_field.get_route_options_for_new_doc = function(row) {
+				batch_no_field.get_route_options_for_new_doc = function (row) {
 					return {
-						'item': row.doc.item_code
-					}
+						item: row.doc.item_code,
+					};
 				};
 			}
 		}
 
 		// While creating the SABB from the link field, copy item, doctype from line item to SABB form
-		if(this.frm.fields_dict['items'].grid.get_field('serial_and_batch_bundle')) {
-			let sbb_field = this.frm.get_docfield('items', 'serial_and_batch_bundle');
+		if (this.frm.fields_dict["items"].grid.get_field("serial_and_batch_bundle")) {
+			let sbb_field = this.frm.get_docfield("items", "serial_and_batch_bundle");
 			if (sbb_field) {
 				sbb_field.get_route_options_for_new_doc = (row) => {
 					return {
-						"item_code": row.doc.item_code,
-						"voucher_type": this.frm.doc.doctype,
-					}
+						item_code: row.doc.item_code,
+						voucher_type: this.frm.doc.doctype,
+					};
 				};
 			}
 		}
@@ -477,28 +507,30 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 		this.barcode_scanner.process_scan();
 	}
 
-	barcode(doc, cdt, cdn)  {
+	barcode(doc, cdt, cdn) {
 		let row = locals[cdt][cdn];
 		if (row.barcode) {
 			erpnext.stock.utils.set_item_details_using_barcode(this.frm, row, (r) => {
 				frappe.model.set_value(cdt, cdn, {
-					"item_code": r.message.item_code,
-					"qty": 1,
+					item_code: r.message.item_code,
+					qty: 1,
 				});
 			});
 		}
 	}
 
-	validate_has_items () {
+	validate_has_items() {
 		let table = this.frm.doc.items;
-		this.frm.has_items = (table && table.length
-			&& table[0].qty && table[0].item_code);
+		this.frm.has_items = table && table.length && table[0].qty && table[0].item_code;
 	}
 
 	apply_default_taxes() {
 		var me = this;
-		var taxes_and_charges_field = frappe.meta.get_docfield(me.frm.doc.doctype, "taxes_and_charges",
-			me.frm.doc.name);
+		var taxes_and_charges_field = frappe.meta.get_docfield(
+			me.frm.doc.doctype,
+			"taxes_and_charges",
+			me.frm.doc.name
+		);
 
 		if (!this.frm.doc.taxes_and_charges && this.frm.doc.taxes && this.frm.doc.taxes.length > 0) {
 			return;
@@ -508,40 +540,46 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 			return frappe.call({
 				method: "erpnext.controllers.accounts_controller.get_default_taxes_and_charges",
 				args: {
-					"master_doctype": taxes_and_charges_field.options,
-					"tax_template": me.frm.doc.taxes_and_charges || "",
-					"company": me.frm.doc.company
+					master_doctype: taxes_and_charges_field.options,
+					tax_template: me.frm.doc.taxes_and_charges || "",
+					company: me.frm.doc.company,
 				},
 				debounce: 2000,
-				callback: function(r) {
-					if(!r.exc && r.message) {
+				callback: function (r) {
+					if (!r.exc && r.message) {
 						frappe.run_serially([
 							() => {
 								// directly set in doc, so as not to call triggers
-								if(r.message.taxes_and_charges) {
+								if (r.message.taxes_and_charges) {
 									me.frm.doc.taxes_and_charges = r.message.taxes_and_charges;
 								}
 
 								// set taxes table
-								if(r.message.taxes) {
+								if (r.message.taxes) {
 									me.frm.set_value("taxes", r.message.taxes);
 								}
 							},
 							() => me.set_dynamic_labels(),
-							() => me.calculate_taxes_and_totals()
+							() => me.calculate_taxes_and_totals(),
 						]);
 					}
-				}
+				},
 			});
 		}
 	}
 
 	setup_sms() {
 		var me = this;
-		let blacklist = ['Purchase Invoice', 'BOM'];
-		if(frappe.boot.sms_gateway_enabled && this.frm.doc.docstatus===1 && !["Lost", "Stopped", "Closed"].includes(this.frm.doc.status)
-			&& !blacklist.includes(this.frm.doctype)) {
-			this.frm.page.add_menu_item(__('Send SMS'), function() { me.send_sms(); });
+		let blacklist = ["Purchase Invoice", "BOM"];
+		if (
+			frappe.boot.sms_gateway_enabled &&
+			this.frm.doc.docstatus === 1 &&
+			!["Lost", "Stopped", "Closed"].includes(this.frm.doc.status) &&
+			!blacklist.includes(this.frm.doctype)
+		) {
+			this.frm.page.add_menu_item(__("Send SMS"), function () {
+				me.send_sms();
+			});
 		}
 	}
 
@@ -558,13 +596,13 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 				doc: doc,
 				method: "process_item_selection",
 				args: {
-					item_idx: item.idx
+					item_idx: item.idx,
 				},
-				callback: function(r) {
-					if(!r.exc) {
+				callback: function (r) {
+					if (!r.exc) {
 						me.frm.refresh_fields();
 					}
-				}
+				},
 			});
 		} else {
 			me.process_item_selection(doc, cdt, cdn);
@@ -574,18 +612,17 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 	process_item_selection(doc, cdt, cdn) {
 		var item = frappe.get_doc(cdt, cdn);
 		var me = this;
-		var update_stock = 0, show_batch_dialog = 0;
+		var update_stock = 0,
+			show_batch_dialog = 0;
 
 		item.weight_per_unit = 0;
-		item.weight_uom = '';
+		item.weight_uom = "";
 		item.conversion_factor = 0;
 
-		if(['Sales Invoice', 'Purchase Invoice'].includes(this.frm.doc.doctype)) {
+		if (["Sales Invoice", "Purchase Invoice"].includes(this.frm.doc.doctype)) {
 			update_stock = cint(me.frm.doc.update_stock);
 			show_batch_dialog = update_stock;
-
-		} else if((this.frm.doc.doctype === 'Purchase Receipt') ||
-			  this.frm.doc.doctype === 'Delivery Note') {
+		} else if (this.frm.doc.doctype === "Purchase Receipt" || this.frm.doc.doctype === "Delivery Note") {
 			show_batch_dialog = 1;
 		}
 
@@ -595,12 +632,11 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 
 		item.barcode = null;
 
-
-		if(item.item_code || item.serial_no) {
-			if(!this.validate_company_and_party()) {
+		if (item.item_code || item.serial_no) {
+			if (!this.validate_company_and_party()) {
 				this.frm.fields_dict["items"].grid.grid_rows[item.idx - 1].remove();
 			} else {
-				item.pricing_rules = ''
+				item.pricing_rules = "";
 				return this.frm.call({
 					method: "erpnext.stock.get_item_details.get_item_details",
 					child: item,
@@ -643,7 +679,7 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 							weight_uom: item.weight_uom,
 							manufacturer: item.manufacturer,
 							stock_uom: item.stock_uom,
-							pos_profile: cint(me.frm.doc.is_pos) ? me.frm.doc.pos_profile : '',
+							pos_profile: cint(me.frm.doc.is_pos) ? me.frm.doc.pos_profile : "",
 							cost_center: item.cost_center,
 							tax_category: me.frm.doc.tax_category,
 							item_tax_template: item.item_tax_template,
@@ -652,18 +688,19 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 							is_old_subcontracting_flow: me.frm.doc.is_old_subcontracting_flow,
 							use_serial_batch_fields: item.use_serial_batch_fields,
 							serial_and_batch_bundle: item.serial_and_batch_bundle,
-						}
+						},
 					},
 
-					callback: function(r) {
-						if(!r.exc) {
+					callback: function (r) {
+						if (!r.exc) {
 							frappe.run_serially([
 								() => {
-									if (item.docstatus === 0
-									    && frappe.meta.has_field(item.doctype, "use_serial_batch_fields")
-									    && !item.use_serial_batch_fields
-									    && cint(frappe.user_defaults?.use_serial_batch_fields) === 1
-									   ) {
+									if (
+										item.docstatus === 0 &&
+										frappe.meta.has_field(item.doctype, "use_serial_batch_fields") &&
+										!item.use_serial_batch_fields &&
+										cint(frappe.user_defaults?.use_serial_batch_fields) === 1
+									) {
 										item["use_serial_batch_fields"] = 1;
 									}
 								},
@@ -676,12 +713,23 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 								},
 								async () => {
 									// for internal customer instead of pricing rule directly apply valuation rate on item
-									const fetch_valuation_rate_for_internal_transactions = await frappe.db.get_single_value(
-										"Accounts Settings", "fetch_valuation_rate_for_internal_transaction"
-									);
-									if ((me.frm.doc.is_internal_customer || me.frm.doc.is_internal_supplier) && fetch_valuation_rate_for_internal_transactions) {
-										me.get_incoming_rate(item, me.frm.posting_date, me.frm.posting_time,
-												     me.frm.doc.doctype, me.frm.doc.company);
+									const fetch_valuation_rate_for_internal_transactions =
+										await frappe.db.get_single_value(
+											"Accounts Settings",
+											"fetch_valuation_rate_for_internal_transaction"
+										);
+									if (
+										(me.frm.doc.is_internal_customer ||
+											me.frm.doc.is_internal_supplier) &&
+										fetch_valuation_rate_for_internal_transactions
+									) {
+										me.get_incoming_rate(
+											item,
+											me.frm.posting_date,
+											me.frm.posting_time,
+											me.frm.doc.doctype,
+											me.frm.doc.company
+										);
 									} else {
 										me.frm.script_manager.trigger("price_list_rate", cdt, cdn);
 									}
@@ -694,31 +742,45 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 								() => me.toggle_conversion_factor(item),
 								() => {
 									if (show_batch_dialog && !frappe.flags.trigger_from_barcode_scanner)
-										return frappe.db.get_value("Item", item.item_code, ["has_batch_no", "has_serial_no"])
-										.then((r) => {
-											if (r.message &&
-											    (r.message.has_batch_no || r.message.has_serial_no)) {
-												frappe.flags.hide_serial_batch_dialog = false;
-											} else {
-												show_batch_dialog = false;
-											}
-										});
+										return frappe.db
+											.get_value("Item", item.item_code, [
+												"has_batch_no",
+												"has_serial_no",
+											])
+											.then((r) => {
+												if (
+													r.message &&
+													(r.message.has_batch_no || r.message.has_serial_no)
+												) {
+													frappe.flags.hide_serial_batch_dialog = false;
+												} else {
+													show_batch_dialog = false;
+												}
+											});
 								},
 								() => {
 									// check if batch serial selector is disabled or not
 									if (show_batch_dialog && !frappe.flags.hide_serial_batch_dialog)
-										return frappe.db.get_single_value('Stock Settings', 'disable_serial_no_and_batch_selector')
-										.then((value) => {
-											if (value) {
-												frappe.flags.hide_serial_batch_dialog = true;
-											}
-										});
+										return frappe.db
+											.get_single_value(
+												"Stock Settings",
+												"disable_serial_no_and_batch_selector"
+											)
+											.then((value) => {
+												if (value) {
+													frappe.flags.hide_serial_batch_dialog = true;
+												}
+											});
 								},
 								() => {
-									if(show_batch_dialog && !frappe.flags.hide_serial_batch_dialog && !frappe.flags.dialog_set) {
+									if (
+										show_batch_dialog &&
+										!frappe.flags.hide_serial_batch_dialog &&
+										!frappe.flags.dialog_set
+									) {
 										var d = locals[cdt][cdn];
-										$.each(r.message, function(k, v) {
-											if(!d[k]) d[k] = v;
+										$.each(r.message, function (k, v) {
+											if (!d[k]) d[k] = v;
 										});
 
 										if (d.has_batch_no && d.has_serial_no) {
@@ -726,12 +788,22 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 										}
 
 										frappe.flags.dialog_set = true;
-										erpnext.show_serial_batch_selector(me.frm, d, (item) => {
-											me.frm.script_manager.trigger('qty', item.doctype, item.name);
-											if (!me.frm.doc.set_warehouse)
-												me.frm.script_manager.trigger('warehouse', item.doctype, item.name);
-											me.apply_price_list(item, true);
-										}, undefined, !frappe.flags.hide_serial_batch_dialog);
+										erpnext.show_serial_batch_selector(
+											me.frm,
+											d,
+											(item) => {
+												me.frm.script_manager.trigger("qty", item.doctype, item.name);
+												if (!me.frm.doc.set_warehouse)
+													me.frm.script_manager.trigger(
+														"warehouse",
+														item.doctype,
+														item.name
+													);
+												me.apply_price_list(item, true);
+											},
+											undefined,
+											!frappe.flags.hide_serial_batch_dialog
+										);
 									} else {
 										frappe.flags.dialog_set = false;
 									}
@@ -741,32 +813,45 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 								() => {
 									if (item.apply_rule_on_other_items) {
 										let key = item.name;
-										me.apply_rule_on_other_items({key: item});
+										me.apply_rule_on_other_items({ key: item });
 									}
 								},
 								() => {
 									var company_currency = me.get_company_currency();
 									me.update_item_grid_labels(company_currency);
-								}
+								},
 							]);
 						}
-					}
+					},
 				});
 			}
 		}
 	}
-
 
 	price_list_rate(doc, cdt, cdn) {
 		var item = frappe.get_doc(cdt, cdn);
 		frappe.model.round_floats_in(item, ["price_list_rate", "discount_percentage"]);
 
 		// check if child doctype is Sales Order Item/Quotation Item and calculate the rate
-		if (in_list(["Quotation Item", "Sales Order Item", "Delivery Note Item", "Sales Invoice Item", "POS Invoice Item", "Purchase Invoice Item", "Purchase Order Item", "Purchase Receipt Item"]), cdt)
+		if (
+			(in_list([
+				"Quotation Item",
+				"Sales Order Item",
+				"Delivery Note Item",
+				"Sales Invoice Item",
+				"POS Invoice Item",
+				"Purchase Invoice Item",
+				"Purchase Order Item",
+				"Purchase Receipt Item",
+			]),
+			cdt)
+		)
 			this.apply_pricing_rule_on_item(item);
 		else
-			item.rate = flt(item.price_list_rate * (1 - item.discount_percentage / 100.0),
-				precision("rate", item));
+			item.rate = flt(
+				item.price_list_rate * (1 - item.discount_percentage / 100.0),
+				precision("rate", item)
+			);
 
 		this.calculate_taxes_and_totals();
 	}
@@ -792,28 +877,27 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 	}
 
 	get_incoming_rate(item, posting_date, posting_time, voucher_type, company) {
-
 		let item_args = {
-			'item_code': item.item_code,
-			'warehouse': in_list('Purchase Receipt', 'Purchase Invoice') ? item.from_warehouse : item.warehouse,
-			'posting_date': posting_date,
-			'posting_time': posting_time,
-			'qty': item.qty * item.conversion_factor,
-			'serial_no': item.serial_no,
-			'batch_no': item.batch_no,
-			'voucher_type': voucher_type,
-			'company': company,
-			'allow_zero_valuation_rate': item.allow_zero_valuation_rate
-		}
+			item_code: item.item_code,
+			warehouse: in_list("Purchase Receipt", "Purchase Invoice") ? item.from_warehouse : item.warehouse,
+			posting_date: posting_date,
+			posting_time: posting_time,
+			qty: item.qty * item.conversion_factor,
+			serial_no: item.serial_no,
+			batch_no: item.batch_no,
+			voucher_type: voucher_type,
+			company: company,
+			allow_zero_valuation_rate: item.allow_zero_valuation_rate,
+		};
 
 		frappe.call({
-			method: 'erpnext.stock.utils.get_incoming_rate',
+			method: "erpnext.stock.utils.get_incoming_rate",
 			args: {
-				args: item_args
+				args: item_args,
 			},
-			callback: function(r) {
-				frappe.model.set_value(item.doctype, item.name, 'rate', r.message * item.conversion_factor);
-			}
+			callback: function (r) {
+				frappe.model.set_value(item.doctype, item.name, "rate", r.message * item.conversion_factor);
+			},
 		});
 	}
 
@@ -821,21 +905,20 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 		var me = this;
 		var item = frappe.get_doc(cdt, cdn);
 
-		if (item && item.doctype === 'Purchase Receipt Item Supplied') {
+		if (item && item.doctype === "Purchase Receipt Item Supplied") {
 			return;
 		}
 
 		if (item.serial_no) {
-			item.use_serial_batch_fields = 1
+			item.use_serial_batch_fields = 1;
 		}
 
 		if (item && item.serial_no) {
 			if (!item.item_code) {
 				this.frm.trigger("item_code", cdt, cdn);
-			}
-			else {
+			} else {
 				// Replace all occurences of comma with line feed
-				item.serial_no = item.serial_no.replace(/,/g, '\n');
+				item.serial_no = item.serial_no.replace(/,/g, "\n");
 				item.conversion_factor = item.conversion_factor || 1;
 				refresh_field("serial_no", item.name, item.parentfield);
 				if (!doc.is_return) {
@@ -848,8 +931,10 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 	}
 
 	on_submit() {
-		if (["Purchase Invoice", "Sales Invoice"].includes(this.frm.doc.doctype)
-			&& !this.frm.doc.update_stock) {
+		if (
+			["Purchase Invoice", "Sales Invoice"].includes(this.frm.doc.doctype) &&
+			!this.frm.doc.update_stock
+		) {
 			return;
 		}
 
@@ -859,7 +944,7 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 	refresh_serial_batch_bundle_field() {
 		frappe.route_hooks.after_submit = (frm_obj) => {
 			frm_obj.reload_doc();
-		}
+		};
 	}
 
 	update_qty(cdt, cdn) {
@@ -872,14 +957,18 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 				valid_serial_nos.push(serialnos[i]);
 			}
 		}
-		frappe.model.set_value(item.doctype, item.name,
-			"qty", valid_serial_nos.length / item.conversion_factor);
+		frappe.model.set_value(
+			item.doctype,
+			item.name,
+			"qty",
+			valid_serial_nos.length / item.conversion_factor
+		);
 		frappe.model.set_value(item.doctype, item.name, "stock_qty", valid_serial_nos.length);
 	}
 
 	async validate() {
 		await this.calculate_taxes_and_totals(false);
-		await this.confirm_posting_date_change()
+		await this.confirm_posting_date_change();
 	}
 
 	async confirm_posting_date_change() {
@@ -888,8 +977,9 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 		if (frappe.datetime.get_today() == this.frm.doc.posting_date) return;
 
 		let is_confirmation_reqd = await frappe.db.get_single_value(
-			'Accounts Settings', 'confirm_before_resetting_posting_date'
-		)
+			"Accounts Settings",
+			"confirm_before_resetting_posting_date"
+		);
 
 		if (!is_confirmation_reqd) return;
 
@@ -909,34 +999,54 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 	}
 
 	update_stock() {
-		this.frm.trigger('set_default_internal_warehouse');
+		this.frm.trigger("set_default_internal_warehouse");
 	}
 
 	set_default_internal_warehouse() {
 		let me = this;
-		if ((this.frm.doc.doctype === 'Sales Invoice' && me.frm.doc.update_stock)
-			|| this.frm.doc.doctype == 'Delivery Note') {
-			if (this.frm.doc.is_internal_customer && this.frm.doc.company === this.frm.doc.represents_company) {
-				frappe.db.get_value('Company', this.frm.doc.company, 'default_in_transit_warehouse', function(value) {
-					me.frm.set_value('set_target_warehouse', value.default_in_transit_warehouse);
-				});
+		if (
+			(this.frm.doc.doctype === "Sales Invoice" && me.frm.doc.update_stock) ||
+			this.frm.doc.doctype == "Delivery Note"
+		) {
+			if (
+				this.frm.doc.is_internal_customer &&
+				this.frm.doc.company === this.frm.doc.represents_company
+			) {
+				frappe.db.get_value(
+					"Company",
+					this.frm.doc.company,
+					"default_in_transit_warehouse",
+					function (value) {
+						me.frm.set_value("set_target_warehouse", value.default_in_transit_warehouse);
+					}
+				);
 			}
 		}
 
-		if ((this.frm.doc.doctype === 'Purchase Invoice' && me.frm.doc.update_stock)
-			|| this.frm.doc.doctype == 'Purchase Receipt') {
-			if (this.frm.doc.is_internal_supplier && this.frm.doc.company === this.frm.doc.represents_company) {
-				frappe.db.get_value('Company', this.frm.doc.company, 'default_in_transit_warehouse', function(value) {
-					me.frm.set_value('set_from_warehouse', value.default_in_transit_warehouse);
-				});
+		if (
+			(this.frm.doc.doctype === "Purchase Invoice" && me.frm.doc.update_stock) ||
+			this.frm.doc.doctype == "Purchase Receipt"
+		) {
+			if (
+				this.frm.doc.is_internal_supplier &&
+				this.frm.doc.company === this.frm.doc.represents_company
+			) {
+				frappe.db.get_value(
+					"Company",
+					this.frm.doc.company,
+					"default_in_transit_warehouse",
+					function (value) {
+						me.frm.set_value("set_from_warehouse", value.default_in_transit_warehouse);
+					}
+				);
 			}
 		}
 	}
 
 	company() {
 		var me = this;
-		var set_pricing = function() {
-			if(me.frm.doc.company && me.frm.fields_dict.currency) {
+		var set_pricing = function () {
+			if (me.frm.doc.company && me.frm.fields_dict.currency) {
 				frappe.run_serially([
 					() => get_party_currency(),
 					() => me.update_item_tax_map(),
@@ -946,19 +1056,17 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 					() => set_letter_head(),
 				]);
 			}
-		}
+		};
 
-		var get_party_currency = function() {
+		var get_party_currency = function () {
 			if (me.is_a_mapped_document() || me.frm.doc.__onload?.load_after_mapping) {
 				return;
 			}
 
 			var party_type, party_name;
-			if( me.frm.doc.doctype == "Quotation" && me.frm.doc.quotation_to == "Customer"){
-				party_type = "Customer",
-				party_name = me.frm.doc.party_name
-			}
-			else{
+			if (me.frm.doc.doctype == "Quotation" && me.frm.doc.quotation_to == "Customer") {
+				(party_type = "Customer"), (party_name = me.frm.doc.party_name);
+			} else {
 				party_type = frappe.meta.has_field(me.frm.doc.doctype, "customer") ? "Customer" : "Supplier";
 				party_name = me.frm.doc[party_type.toLowerCase()];
 			}
@@ -974,14 +1082,14 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 						if (r.message) {
 							set_currency(r.message.default_currency);
 						}
-					}
-				})
+					},
+				});
 			} else {
 				set_currency();
 			}
-		}
+		};
 
-		var set_currency = function(party_default_currency) {
+		var set_currency = function (party_default_currency) {
 			var company_currency = me.get_company_currency();
 			var currency = party_default_currency || company_currency;
 			if (me.frm.doc.currency != currency) {
@@ -992,57 +1100,63 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 				me.frm.set_value("conversion_rate", 1.0);
 			}
 			if (me.frm.doc.price_list_currency == company_currency) {
-				me.frm.set_value('plc_conversion_rate', 1.0);
+				me.frm.set_value("plc_conversion_rate", 1.0);
 			}
 
 			me.frm.script_manager.trigger("currency");
-		}
+		};
 
-		var set_terms = function() {
+		var set_terms = function () {
 			if (frappe.meta.has_field(me.frm.doc.doctype, "tc_name") && !me.frm.doc.tc_name) {
 				var company_doc = frappe.get_doc(":Company", me.frm.doc.company);
 				var selling_doctypes = ["Quotation", "Sales Order", "Delivery Note", "Sales Invoice"];
-				var company_terms_fieldname = selling_doctypes.includes(me.frm.doc.doctype) ? "default_selling_terms" : "default_buying_terms";
+				var company_terms_fieldname = selling_doctypes.includes(me.frm.doc.doctype)
+					? "default_selling_terms"
+					: "default_buying_terms";
 				if (company_doc && company_doc[company_terms_fieldname]) {
 					me.frm.set_value("tc_name", company_doc[company_terms_fieldname]);
 				}
 			}
-		}
+		};
 
-		var set_letter_head = function() {
-			if(me.frm.fields_dict.letter_head) {
+		var set_letter_head = function () {
+			if (me.frm.fields_dict.letter_head) {
 				var company_doc = frappe.get_doc(":Company", me.frm.doc.company);
 				if (company_doc && company_doc.default_letter_head) {
 					me.frm.set_value("letter_head", company_doc.default_letter_head);
 				}
 			}
-		}
+		};
 
-		var set_party_account = function(set_pricing) {
+		var set_party_account = function (set_pricing) {
 			if (["Sales Invoice", "Purchase Invoice"].includes(me.frm.doc.doctype)) {
-				if(me.frm.doc.doctype=="Sales Invoice") {
+				if (me.frm.doc.doctype == "Sales Invoice") {
 					var party_type = "Customer";
-					var party_account_field = 'debit_to';
+					var party_account_field = "debit_to";
 				} else {
 					var party_type = "Supplier";
-					var party_account_field = 'credit_to';
+					var party_account_field = "credit_to";
 				}
 
 				var party = me.frm.doc[frappe.model.scrub(party_type)];
-				if(party && me.frm.doc.company && (!me.frm.doc.__onload?.load_after_mapping || !me.frm.doc[party_account_field])) {
+				if (
+					party &&
+					me.frm.doc.company &&
+					(!me.frm.doc.__onload?.load_after_mapping || !me.frm.doc[party_account_field])
+				) {
 					return frappe.call({
 						method: "erpnext.accounts.party.get_party_account",
 						args: {
 							company: me.frm.doc.company,
 							party_type: party_type,
-							party: party
+							party: party,
 						},
-						callback: function(r) {
-							if(!r.exc && r.message) {
+						callback: function (r) {
+							if (!r.exc && r.message) {
 								me.frm.set_value(party_account_field, r.message);
 								set_pricing();
 							}
-						}
+						},
 					});
 				} else {
 					set_pricing();
@@ -1050,24 +1164,24 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 			} else {
 				set_pricing();
 			}
+		};
 
-		}
+		if (
+			frappe.meta.get_docfield(this.frm.doctype, "shipping_address") &&
+			["Purchase Order", "Purchase Receipt", "Purchase Invoice"].includes(this.frm.doctype)
+		) {
+			let is_drop_ship = me.frm.doc.items.some((item) => item.delivered_by_supplier);
 
-		if (frappe.meta.get_docfield(this.frm.doctype, "shipping_address") &&
-			['Purchase Order', 'Purchase Receipt', 'Purchase Invoice'].includes(this.frm.doctype)) {
-				let is_drop_ship = me.frm.doc.items.some(item => item.delivered_by_supplier);
-
-				if (!is_drop_ship) {
-					erpnext.utils.get_shipping_address(this.frm, function() {
-						set_party_account(set_pricing);
-					});
-				}
-
+			if (!is_drop_ship) {
+				erpnext.utils.get_shipping_address(this.frm, function () {
+					set_party_account(set_pricing);
+				});
+			}
 		} else {
 			set_party_account(set_pricing);
 		}
 
-		if(this.frm.doc.company) {
+		if (this.frm.doc.company) {
 			erpnext.last_selected_company = this.frm.doc.company;
 		}
 	}
@@ -1084,26 +1198,29 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 		if (this.frm.doc.posting_date) {
 			this.frm.posting_date = this.frm.doc.posting_date;
 
-			if ((this.frm.doc.doctype == "Sales Invoice" && this.frm.doc.customer) ||
-				(this.frm.doc.doctype == "Purchase Invoice" && this.frm.doc.supplier)) {
+			if (
+				(this.frm.doc.doctype == "Sales Invoice" && this.frm.doc.customer) ||
+				(this.frm.doc.doctype == "Purchase Invoice" && this.frm.doc.supplier)
+			) {
 				return frappe.call({
 					method: "erpnext.accounts.party.get_due_date",
 					args: {
-						"posting_date": me.frm.doc.posting_date,
-						"party_type": me.frm.doc.doctype == "Sales Invoice" ? "Customer" : "Supplier",
-						"bill_date": me.frm.doc.bill_date,
-						"party": me.frm.doc.doctype == "Sales Invoice" ? me.frm.doc.customer : me.frm.doc.supplier,
-						"company": me.frm.doc.company
+						posting_date: me.frm.doc.posting_date,
+						party_type: me.frm.doc.doctype == "Sales Invoice" ? "Customer" : "Supplier",
+						bill_date: me.frm.doc.bill_date,
+						party:
+							me.frm.doc.doctype == "Sales Invoice" ? me.frm.doc.customer : me.frm.doc.supplier,
+						company: me.frm.doc.company,
 					},
-					callback: function(r, rt) {
-						if(r.message) {
+					callback: function (r, rt) {
+						if (r.message) {
 							me.frm.doc.due_date = r.message;
 							refresh_field("due_date");
 							frappe.ui.form.trigger(me.frm.doc.doctype, "currency");
 							me.recalculate_terms();
 						}
-					}
-				})
+					},
+				});
 			} else {
 				frappe.ui.form.trigger(me.frm.doc.doctype, "currency");
 			}
@@ -1120,20 +1237,17 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 		}
 
 		// if there is only one row in payment schedule child table, set its due date as the due date
-		if (doc.payment_schedule.length == 1){
+		if (doc.payment_schedule.length == 1) {
 			doc.payment_schedule[0].due_date = doc.due_date;
 			this.frm.refresh_field("payment_schedule");
-			return
+			return;
 		}
 
 		if (
 			doc.due_date &&
 			!this.frm.updating_party_details &&
 			!doc.is_pos &&
-			(
-				doc.payment_terms_template ||
-				doc.payment_schedule?.length
-			)
+			(doc.payment_terms_template || doc.payment_schedule?.length)
 		) {
 			const to_clear = [];
 			if (doc.payment_terms_template) {
@@ -1147,10 +1261,7 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 			frappe.confirm(
 				__(
 					"For the new {0} to take effect, would you like to clear the current {1}?",
-					[
-						__(frappe.meta.get_label(cdt, "due_date")),
-						frappe.utils.comma_and(to_clear)
-					],
+					[__(frappe.meta.get_label(cdt, "due_date")), frappe.utils.comma_and(to_clear)],
 					"Clear payment terms template and/or payment schedule when due date is changed"
 				),
 				() => {
@@ -1172,18 +1283,18 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 			this.payment_terms_template();
 		} else if (doc.payment_schedule) {
 			const me = this;
-			doc.payment_schedule.forEach(
-				function(term) {
-					if (term.payment_term) {
-						me.payment_term(doc, term.doctype, term.name);
-					} else {
-						frappe.model.set_value(
-							term.doctype, term.name, 'due_date',
-							doc.posting_date || doc.transaction_date
-						);
-					}
+			doc.payment_schedule.forEach(function (term) {
+				if (term.payment_term) {
+					me.payment_term(doc, term.doctype, term.name);
+				} else {
+					frappe.model.set_value(
+						term.doctype,
+						term.name,
+						"due_date",
+						doc.posting_date || doc.transaction_date
+					);
 				}
-			);
+			});
 		}
 	}
 
@@ -1198,27 +1309,34 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 	currency() {
 		// The transaction date be either transaction_date (from orders) or posting_date (from invoices)
 		let transaction_date = this.frm.doc.transaction_date || this.frm.doc.posting_date;
-		let inter_company_reference = this.frm.doc.inter_company_order_reference || this.frm.doc.inter_company_invoice_reference;
+		let inter_company_reference =
+			this.frm.doc.inter_company_order_reference || this.frm.doc.inter_company_invoice_reference;
 
 		let me = this;
 		this.set_dynamic_labels();
 		let company_currency = this.get_company_currency();
 		// Added `load_after_mapping` to determine if document is loading after mapping from another doc
-		if(this.frm.doc.currency && this.frm.doc.currency !== company_currency
-				&& (!this.frm.doc.__onload?.load_after_mapping || inter_company_reference)) {
-
-			this.get_exchange_rate(transaction_date, this.frm.doc.currency, company_currency,
-				function(exchange_rate) {
-					if(exchange_rate != me.frm.doc.conversion_rate) {
+		if (
+			this.frm.doc.currency &&
+			this.frm.doc.currency !== company_currency &&
+			(!this.frm.doc.__onload?.load_after_mapping || inter_company_reference)
+		) {
+			this.get_exchange_rate(
+				transaction_date,
+				this.frm.doc.currency,
+				company_currency,
+				function (exchange_rate) {
+					if (exchange_rate != me.frm.doc.conversion_rate) {
 						me.set_margin_amount_based_on_currency(exchange_rate);
 						me.set_actual_charges_based_on_currency(exchange_rate);
 						me.frm.set_value("conversion_rate", exchange_rate);
 					}
-				});
+				}
+			);
 		} else {
 			// company currency and doc currency is same
 			// this will prevent unnecessary conversion rate triggers
-			if(this.frm.doc.currency === this.get_company_currency()) {
+			if (this.frm.doc.currency === this.get_company_currency()) {
 				this.frm.set_value("conversion_rate", 1.0);
 			} else {
 				this.conversion_rate();
@@ -1228,21 +1346,22 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 
 	conversion_rate() {
 		const me = this.frm;
-		if(this.frm.doc.currency === this.get_company_currency()) {
+		if (this.frm.doc.currency === this.get_company_currency()) {
 			this.frm.set_value("conversion_rate", 1.0);
 		}
-		if(this.frm.doc.currency === this.frm.doc.price_list_currency &&
-			this.frm.doc.plc_conversion_rate !== this.frm.doc.conversion_rate) {
+		if (
+			this.frm.doc.currency === this.frm.doc.price_list_currency &&
+			this.frm.doc.plc_conversion_rate !== this.frm.doc.conversion_rate
+		) {
 			this.frm.set_value("plc_conversion_rate", this.frm.doc.conversion_rate);
 		}
 
-		if(flt(this.frm.doc.conversion_rate)>0.0) {
-			if(this.frm.doc.__onload?.load_after_mapping) {
+		if (flt(this.frm.doc.conversion_rate) > 0.0) {
+			if (this.frm.doc.__onload?.load_after_mapping) {
 				this.calculate_taxes_and_totals();
-			} else if (!this.in_apply_price_list){
+			} else if (!this.in_apply_price_list) {
 				this.apply_price_list();
 			}
-
 		}
 		// Make read only if Accounts Settings doesn't allow stale rates
 		this.frm.set_df_property("conversion_rate", "read_only", erpnext.stale_rate_allowed() ? 0 : 1);
@@ -1250,7 +1369,7 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 
 	apply_discount_on_item(doc, cdt, cdn, field) {
 		var item = frappe.get_doc(cdt, cdn);
-		if(item && !item.price_list_rate) {
+		if (item && !item.price_list_rate) {
 			item[field] = 0.0;
 		} else {
 			this.price_list_rate(doc, cdt, cdn);
@@ -1260,24 +1379,41 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 
 	shipping_rule() {
 		var me = this;
-		if(this.frm.doc.shipping_rule) {
-			return this.frm.call({
-				doc: this.frm.doc,
-				method: "apply_shipping_rule",
-				callback: function(r) {
-					me._calculate_taxes_and_totals();
-				}
-			}).fail(() => this.frm.set_value('shipping_rule', ''));
+		if (this.frm.doc.shipping_rule) {
+			return this.frm
+				.call({
+					doc: this.frm.doc,
+					method: "apply_shipping_rule",
+					callback: function (r) {
+						me._calculate_taxes_and_totals();
+					},
+				})
+				.fail(() => this.frm.set_value("shipping_rule", ""));
 		}
 	}
 
 	set_margin_amount_based_on_currency(exchange_rate) {
-		if (in_list(["Quotation", "Sales Order", "Delivery Note", "Sales Invoice", "Purchase Invoice", "Purchase Order", "Purchase Receipt"]), this.frm.doc.doctype) {
+		if (
+			(in_list([
+				"Quotation",
+				"Sales Order",
+				"Delivery Note",
+				"Sales Invoice",
+				"Purchase Invoice",
+				"Purchase Order",
+				"Purchase Receipt",
+			]),
+			this.frm.doc.doctype)
+		) {
 			var me = this;
-			$.each(this.frm.doc.items || [], function(i, d) {
-				if(d.margin_type == "Amount") {
-					frappe.model.set_value(d.doctype, d.name, "margin_rate_or_amount",
-						flt(d.margin_rate_or_amount) / flt(exchange_rate));
+			$.each(this.frm.doc.items || [], function (i, d) {
+				if (d.margin_type == "Amount") {
+					frappe.model.set_value(
+						d.doctype,
+						d.name,
+						"margin_rate_or_amount",
+						flt(d.margin_rate_or_amount) / flt(exchange_rate)
+					);
 				}
 			});
 		}
@@ -1285,10 +1421,14 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 
 	set_actual_charges_based_on_currency(exchange_rate) {
 		var me = this;
-		$.each(this.frm.doc.taxes || [], function(i, d) {
-			if(d.charge_type == "Actual") {
-				frappe.model.set_value(d.doctype, d.name, "tax_amount",
-					flt(d.base_tax_amount) / flt(exchange_rate));
+		$.each(this.frm.doc.taxes || [], function (i, d) {
+			if (d.charge_type == "Actual") {
+				frappe.model.set_value(
+					d.doctype,
+					d.name,
+					"tax_amount",
+					flt(d.base_tax_amount) / flt(exchange_rate)
+				);
 			}
 		});
 	}
@@ -1297,8 +1437,7 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 		var args;
 		if (["Quotation", "Sales Order", "Delivery Note", "Sales Invoice"].includes(this.frm.doctype)) {
 			args = "for_selling";
-		}
-		else if (["Purchase Order", "Purchase Receipt", "Purchase Invoice"].includes(this.frm.doctype)) {
+		} else if (["Purchase Order", "Purchase Receipt", "Purchase Invoice"].includes(this.frm.doctype)) {
 			args = "for_buying";
 		}
 
@@ -1309,43 +1448,52 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 				transaction_date: transaction_date,
 				from_currency: from_currency,
 				to_currency: to_currency,
-				args: args
+				args: args,
 			},
 			freeze: true,
 			freeze_message: __("Fetching exchange rates ..."),
-			callback: function(r) {
+			callback: function (r) {
 				callback(flt(r.message));
-			}
+			},
 		});
 	}
 
 	price_list_currency() {
-		var me=this;
+		var me = this;
 		this.set_dynamic_labels();
 
 		var company_currency = this.get_company_currency();
 		// Added `load_after_mapping` to determine if document is loading after mapping from another doc
-		if(this.frm.doc.price_list_currency !== company_currency  &&
-				!this.frm.doc.__onload?.load_after_mapping) {
-			this.get_exchange_rate(this.frm.doc.posting_date, this.frm.doc.price_list_currency, company_currency,
-				function(exchange_rate) {
+		if (
+			this.frm.doc.price_list_currency !== company_currency &&
+			!this.frm.doc.__onload?.load_after_mapping
+		) {
+			this.get_exchange_rate(
+				this.frm.doc.posting_date,
+				this.frm.doc.price_list_currency,
+				company_currency,
+				function (exchange_rate) {
 					me.frm.set_value("plc_conversion_rate", exchange_rate);
-				});
+				}
+			);
 		} else {
 			this.plc_conversion_rate();
 		}
 	}
 
 	plc_conversion_rate() {
-		if(this.frm.doc.price_list_currency === this.get_company_currency()) {
+		if (this.frm.doc.price_list_currency === this.get_company_currency()) {
 			this.frm.set_value("plc_conversion_rate", 1.0);
-		} else if(this.frm.doc.price_list_currency === this.frm.doc.currency
-			&& this.frm.doc.plc_conversion_rate && cint(this.frm.doc.plc_conversion_rate) != 1 &&
-			cint(this.frm.doc.plc_conversion_rate) != cint(this.frm.doc.conversion_rate)) {
+		} else if (
+			this.frm.doc.price_list_currency === this.frm.doc.currency &&
+			this.frm.doc.plc_conversion_rate &&
+			cint(this.frm.doc.plc_conversion_rate) != 1 &&
+			cint(this.frm.doc.plc_conversion_rate) != cint(this.frm.doc.conversion_rate)
+		) {
 			this.frm.set_value("conversion_rate", this.frm.doc.plc_conversion_rate);
 		}
 
-		if(!this.in_apply_price_list) {
+		if (!this.in_apply_price_list) {
 			this.apply_price_list(null, true);
 		}
 	}
@@ -1353,46 +1501,45 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 	uom(doc, cdt, cdn) {
 		var me = this;
 		var item = frappe.get_doc(cdt, cdn);
-		item.pricing_rules = ''
-		if(item.item_code && item.uom) {
+		item.pricing_rules = "";
+		if (item.item_code && item.uom) {
 			return this.frm.call({
 				method: "erpnext.stock.get_item_details.get_conversion_factor",
 				args: {
 					item_code: item.item_code,
-					uom: item.uom
+					uom: item.uom,
 				},
-				callback: function(r) {
-					if(!r.exc) {
-						frappe.model.set_value(cdt, cdn, 'conversion_factor', r.message.conversion_factor);
+				callback: function (r) {
+					if (!r.exc) {
+						frappe.model.set_value(cdt, cdn, "conversion_factor", r.message.conversion_factor);
 						me.apply_price_list(item, true);
 					}
-				}
+				},
 			});
 		}
 		me.calculate_stock_uom_rate(doc, cdt, cdn);
 	}
 
 	conversion_factor(doc, cdt, cdn, dont_fetch_price_list_rate) {
-		if(frappe.meta.get_docfield(cdt, "stock_qty", cdn)) {
+		if (frappe.meta.get_docfield(cdt, "stock_qty", cdn)) {
 			var item = frappe.get_doc(cdt, cdn);
 			frappe.model.round_floats_in(item, ["qty", "conversion_factor"]);
 			item.stock_qty = flt(item.qty * item.conversion_factor, precision("stock_qty", item));
 			refresh_field("stock_qty", item.name, item.parentfield);
 			this.toggle_conversion_factor(item);
 
-			if(doc.doctype != "Material Request") {
+			if (doc.doctype != "Material Request") {
 				item.total_weight = flt(item.stock_qty * item.weight_per_unit);
 				refresh_field("total_weight", item.name, item.parentfield);
 				this.calculate_net_weight();
 			}
 
 			// for handling customization not to fetch price list rate
-			if(frappe.flags.dont_fetch_price_list_rate) {
-				return
+			if (frappe.flags.dont_fetch_price_list_rate) {
+				return;
 			}
 
-			if (!dont_fetch_price_list_rate &&
-				frappe.meta.has_field(doc.doctype, "price_list_currency")) {
+			if (!dont_fetch_price_list_rate && frappe.meta.has_field(doc.doctype, "price_list_currency")) {
 				this.apply_price_list(item, true);
 			}
 			this.calculate_stock_uom_rate(doc, cdt, cdn);
@@ -1411,16 +1558,14 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 		const mappped_fields = mapped_item_field_map[this.frm.doc.doctype] || [];
 
 		if (item) {
-			return mappped_fields
-				.map((field) => item[field])
-				.filter(Boolean).length > 0;
+			return mappped_fields.map((field) => item[field]).filter(Boolean).length > 0;
 		} else if (this.frm.doc?.items) {
 			let first_row = this.frm.doc.items[0];
 			if (!first_row) {
-				return false
-			};
+				return false;
+			}
 
-			let mapped_rows = mappped_fields.filter(d => first_row[d])
+			let mapped_rows = mappped_fields.filter((d) => first_row[d]);
 
 			return mapped_rows?.length > 0;
 		}
@@ -1428,9 +1573,15 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 
 	toggle_conversion_factor(item) {
 		// toggle read only property for conversion factor field if the uom and stock uom are same
-		if(this.frm.get_field('items').grid.fields_map.conversion_factor) {
-			this.frm.fields_dict.items.grid.toggle_enable("conversion_factor",
-				((item.uom != item.stock_uom) && !frappe.meta.get_docfield(cur_frm.fields_dict.items.grid.doctype, "conversion_factor").read_only)? true: false);
+		if (this.frm.get_field("items").grid.fields_map.conversion_factor) {
+			this.frm.fields_dict.items.grid.toggle_enable(
+				"conversion_factor",
+				item.uom != item.stock_uom &&
+					!frappe.meta.get_docfield(cur_frm.fields_dict.items.grid.doctype, "conversion_factor")
+						.read_only
+					? true
+					: false
+			);
 		}
 	}
 
@@ -1443,11 +1594,11 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 				() => this.conversion_factor(doc, cdt, cdn, true),
 				() => this.apply_price_list(item, true), //reapply price list before applying pricing rule
 				() => this.calculate_stock_uom_rate(doc, cdt, cdn),
-				() => this.apply_pricing_rule(item, true)
+				() => this.apply_pricing_rule(item, true),
 			]);
 		} else {
-			this.conversion_factor(doc, cdt, cdn, true)
-			this.calculate_taxes_and_totals()
+			this.conversion_factor(doc, cdt, cdn, true);
+			this.calculate_taxes_and_totals();
 		}
 	}
 
@@ -1472,12 +1623,12 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 	service_stop_date(frm, cdt, cdn) {
 		var child = locals[cdt][cdn];
 
-		if(child.service_stop_date) {
+		if (child.service_stop_date) {
 			let start_date = Date.parse(child.service_start_date);
 			let end_date = Date.parse(child.service_end_date);
 			let stop_date = Date.parse(child.service_stop_date);
 
-			if(stop_date < start_date) {
+			if (stop_date < start_date) {
 				frappe.model.set_value(cdt, cdn, "service_stop_date", "");
 				frappe.throw(__("Service Stop Date cannot be before Service Start Date"));
 			} else if (stop_date > end_date) {
@@ -1490,14 +1641,14 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 	service_start_date(frm, cdt, cdn) {
 		var child = locals[cdt][cdn];
 
-		if(child.service_start_date) {
+		if (child.service_start_date) {
 			frappe.call({
-				"method": "erpnext.stock.get_item_details.calculate_service_end_date",
-				args: {ctx: child},
-				callback: function(r) {
+				method: "erpnext.stock.get_item_details.calculate_service_end_date",
+				args: { ctx: child },
+				callback: function (r) {
 					frappe.model.set_value(cdt, cdn, "service_end_date", r.message.service_end_date);
-				}
-			})
+				},
+			});
 		}
 	}
 
@@ -1506,12 +1657,12 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 		this.frm.trigger("calculate_net_weight");
 	}
 
-	calculate_net_weight(){
+	calculate_net_weight() {
 		/* Calculate Total Net Weight then further applied shipping rule to calculate shipping charges.*/
 		var me = this;
-		this.frm.doc.total_net_weight= 0.0;
+		this.frm.doc.total_net_weight = 0.0;
 
-		$.each(this.frm.doc["items"] || [], function(i, item) {
+		$.each(this.frm.doc["items"] || [], function (i, item) {
 			me.frm.doc.total_net_weight += flt(item.total_weight);
 		});
 		refresh_field("total_net_weight");
@@ -1520,8 +1671,10 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 
 	set_dynamic_labels() {
 		// What TODO? should we make price list system non-mandatory?
-		this.frm.toggle_reqd("plc_conversion_rate",
-			!!(this.frm.doc.price_list_name && this.frm.doc.price_list_currency));
+		this.frm.toggle_reqd(
+			"plc_conversion_rate",
+			!!(this.frm.doc.price_list_name && this.frm.doc.price_list_currency)
+		);
 
 		var company_currency = this.get_company_currency();
 		this.change_form_labels(company_currency);
@@ -1532,50 +1685,114 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 	change_form_labels(company_currency) {
 		let me = this;
 
-		this.frm.set_currency_labels(["base_total", "base_net_total", "base_total_taxes_and_charges",
-			"base_discount_amount", "base_grand_total", "base_rounded_total", "base_in_words",
-			"base_taxes_and_charges_added", "base_taxes_and_charges_deducted", "total_amount_to_pay",
-			"base_paid_amount", "base_write_off_amount", "base_change_amount", "base_operating_cost",
-			"base_raw_material_cost", "base_total_cost", "base_scrap_material_cost",
-			"base_rounding_adjustment"], company_currency);
+		this.frm.set_currency_labels(
+			[
+				"base_total",
+				"base_net_total",
+				"base_total_taxes_and_charges",
+				"base_discount_amount",
+				"base_grand_total",
+				"base_rounded_total",
+				"base_in_words",
+				"base_taxes_and_charges_added",
+				"base_taxes_and_charges_deducted",
+				"total_amount_to_pay",
+				"base_paid_amount",
+				"base_write_off_amount",
+				"base_change_amount",
+				"base_operating_cost",
+				"base_raw_material_cost",
+				"base_total_cost",
+				"base_scrap_material_cost",
+				"base_rounding_adjustment",
+			],
+			company_currency
+		);
 
-		this.frm.set_currency_labels(["total", "net_total", "total_taxes_and_charges", "discount_amount",
-			"grand_total", "taxes_and_charges_added", "taxes_and_charges_deducted","tax_withholding_net_total",
-			"rounded_total", "in_words", "paid_amount", "write_off_amount", "operating_cost",
-			"scrap_material_cost", "rounding_adjustment", "raw_material_cost",
-			"total_cost"], this.frm.doc.currency);
+		this.frm.set_currency_labels(
+			[
+				"total",
+				"net_total",
+				"total_taxes_and_charges",
+				"discount_amount",
+				"grand_total",
+				"taxes_and_charges_added",
+				"taxes_and_charges_deducted",
+				"tax_withholding_net_total",
+				"rounded_total",
+				"in_words",
+				"paid_amount",
+				"write_off_amount",
+				"operating_cost",
+				"scrap_material_cost",
+				"rounding_adjustment",
+				"raw_material_cost",
+				"total_cost",
+			],
+			this.frm.doc.currency
+		);
 
-		this.frm.set_currency_labels(["outstanding_amount", "total_advance"],
-			this.frm.doc.party_account_currency);
+		this.frm.set_currency_labels(
+			["outstanding_amount", "total_advance"],
+			this.frm.doc.party_account_currency
+		);
 
-		this.frm.set_df_property("conversion_rate", "description", "1 " + this.frm.doc.currency
-			+ " = [?] " + company_currency);
+		this.frm.set_df_property(
+			"conversion_rate",
+			"description",
+			"1 " + this.frm.doc.currency + " = [?] " + company_currency
+		);
 
-		if(this.frm.doc.price_list_currency && this.frm.doc.price_list_currency!=company_currency) {
-			this.frm.set_df_property("plc_conversion_rate", "description", "1 "
-				+ this.frm.doc.price_list_currency + " = [?] " + company_currency);
+		if (this.frm.doc.price_list_currency && this.frm.doc.price_list_currency != company_currency) {
+			this.frm.set_df_property(
+				"plc_conversion_rate",
+				"description",
+				"1 " + this.frm.doc.price_list_currency + " = [?] " + company_currency
+			);
 		}
 
 		// toggle fields
-		this.frm.toggle_display(["conversion_rate", "base_total", "base_net_total", "base_tax_withholding_net_total",
-			"base_total_taxes_and_charges", "base_taxes_and_charges_added", "base_taxes_and_charges_deducted",
-			"base_grand_total", "base_rounded_total", "base_in_words", "base_discount_amount",
-			"base_paid_amount", "base_write_off_amount", "base_operating_cost", "base_raw_material_cost",
-			"base_total_cost", "base_scrap_material_cost", "base_rounding_adjustment"],
-		this.frm.doc.currency != company_currency);
+		this.frm.toggle_display(
+			[
+				"conversion_rate",
+				"base_total",
+				"base_net_total",
+				"base_tax_withholding_net_total",
+				"base_total_taxes_and_charges",
+				"base_taxes_and_charges_added",
+				"base_taxes_and_charges_deducted",
+				"base_grand_total",
+				"base_rounded_total",
+				"base_in_words",
+				"base_discount_amount",
+				"base_paid_amount",
+				"base_write_off_amount",
+				"base_operating_cost",
+				"base_raw_material_cost",
+				"base_total_cost",
+				"base_scrap_material_cost",
+				"base_rounding_adjustment",
+			],
+			this.frm.doc.currency != company_currency
+		);
 
-		this.frm.toggle_display(["plc_conversion_rate", "price_list_currency"],
-			this.frm.doc.price_list_currency != company_currency);
+		this.frm.toggle_display(
+			["plc_conversion_rate", "price_list_currency"],
+			this.frm.doc.price_list_currency != company_currency
+		);
 
-		let show = cint(this.frm.doc.discount_amount) ||
-				((this.frm.doc.taxes || []).filter(function(d) {return d.included_in_print_rate===1}).length);
+		let show =
+			cint(this.frm.doc.discount_amount) ||
+			(this.frm.doc.taxes || []).filter(function (d) {
+				return d.included_in_print_rate === 1;
+			}).length;
 
-		if(this.frm.doc.doctype && frappe.meta.get_docfield(this.frm.doc.doctype, "net_total")) {
+		if (this.frm.doc.doctype && frappe.meta.get_docfield(this.frm.doc.doctype, "net_total")) {
 			this.frm.toggle_display("net_total", show);
 		}
 
-		if(this.frm.doc.doctype && frappe.meta.get_docfield(this.frm.doc.doctype, "base_net_total")) {
-			this.frm.toggle_display("base_net_total", (show && (me.frm.doc.currency != company_currency)));
+		if (this.frm.doc.doctype && frappe.meta.get_docfield(this.frm.doc.doctype, "base_net_total")) {
+			this.frm.toggle_display("base_net_total", show && me.frm.doc.currency != company_currency);
 		}
 	}
 
@@ -1587,12 +1804,20 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 		this.toggle_item_grid_columns(company_currency);
 
 		if (this.frm.doc.operations && this.frm.doc.operations.length > 0) {
-			this.frm.set_currency_labels(["operating_cost", "hour_rate"], this.frm.doc.currency, "operations");
-			this.frm.set_currency_labels(["base_operating_cost", "base_hour_rate"], company_currency, "operations");
+			this.frm.set_currency_labels(
+				["operating_cost", "hour_rate"],
+				this.frm.doc.currency,
+				"operations"
+			);
+			this.frm.set_currency_labels(
+				["base_operating_cost", "base_hour_rate"],
+				company_currency,
+				"operations"
+			);
 
 			var item_grid = this.frm.fields_dict["operations"].grid;
-			$.each(["base_operating_cost", "base_hour_rate"], function(i, fname) {
-				if(frappe.meta.get_docfield(item_grid.doctype, fname))
+			$.each(["base_operating_cost", "base_hour_rate"], function (i, fname) {
+				if (frappe.meta.get_docfield(item_grid.doctype, fname))
 					item_grid.set_column_disp(fname, me.frm.doc.currency != company_currency);
 			});
 		}
@@ -1602,48 +1827,82 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 			this.frm.set_currency_labels(["base_rate", "base_amount"], company_currency, "scrap_items");
 
 			var item_grid = this.frm.fields_dict["scrap_items"].grid;
-			$.each(["base_rate", "base_amount"], function(i, fname) {
-				if(frappe.meta.get_docfield(item_grid.doctype, fname))
+			$.each(["base_rate", "base_amount"], function (i, fname) {
+				if (frappe.meta.get_docfield(item_grid.doctype, fname))
 					item_grid.set_column_disp(fname, me.frm.doc.currency != company_currency);
 			});
 		}
 
 		if (this.frm.doc.taxes && this.frm.doc.taxes.length > 0) {
-			this.frm.set_currency_labels(["tax_amount", "total", "tax_amount_after_discount"], this.frm.doc.currency, "taxes");
+			this.frm.set_currency_labels(
+				["tax_amount", "total", "tax_amount_after_discount"],
+				this.frm.doc.currency,
+				"taxes"
+			);
 
-			this.frm.set_currency_labels(["base_tax_amount", "base_total", "base_tax_amount_after_discount"], company_currency, "taxes");
+			this.frm.set_currency_labels(
+				["base_tax_amount", "base_total", "base_tax_amount_after_discount"],
+				company_currency,
+				"taxes"
+			);
 		}
 
 		if (this.frm.doc.advances && this.frm.doc.advances.length > 0) {
-			this.frm.set_currency_labels(["advance_amount", "allocated_amount"],
-				this.frm.doc.party_account_currency, "advances");
+			this.frm.set_currency_labels(
+				["advance_amount", "allocated_amount"],
+				this.frm.doc.party_account_currency,
+				"advances"
+			);
 		}
 
 		this.update_payment_schedule_grid_labels(company_currency);
 	}
 
 	update_item_grid_labels(company_currency) {
-		this.frm.set_currency_labels([
-			"base_rate", "base_net_rate", "base_price_list_rate",
-			"base_amount", "base_net_amount", "base_rate_with_margin"
-		], company_currency, "items");
+		this.frm.set_currency_labels(
+			[
+				"base_rate",
+				"base_net_rate",
+				"base_price_list_rate",
+				"base_amount",
+				"base_net_amount",
+				"base_rate_with_margin",
+			],
+			company_currency,
+			"items"
+		);
 
-		this.frm.set_currency_labels([
-			"rate", "net_rate", "price_list_rate", "amount",
-			"net_amount", "stock_uom_rate", "rate_with_margin"
-		], this.frm.doc.currency, "items");
+		this.frm.set_currency_labels(
+			[
+				"rate",
+				"net_rate",
+				"price_list_rate",
+				"amount",
+				"net_amount",
+				"stock_uom_rate",
+				"rate_with_margin",
+			],
+			this.frm.doc.currency,
+			"items"
+		);
 	}
 
 	update_payment_schedule_grid_labels(company_currency) {
 		const me = this;
 		if (this.frm.doc.payment_schedule && this.frm.doc.payment_schedule.length > 0) {
-			this.frm.set_currency_labels(["base_payment_amount", "base_outstanding", "base_paid_amount"],
-				company_currency, "payment_schedule");
-			this.frm.set_currency_labels(["payment_amount", "outstanding", "paid_amount"],
-				this.frm.doc.currency, "payment_schedule");
+			this.frm.set_currency_labels(
+				["base_payment_amount", "base_outstanding", "base_paid_amount"],
+				company_currency,
+				"payment_schedule"
+			);
+			this.frm.set_currency_labels(
+				["payment_amount", "outstanding", "paid_amount"],
+				this.frm.doc.currency,
+				"payment_schedule"
+			);
 
 			var schedule_grid = this.frm.fields_dict["payment_schedule"].grid;
-			$.each(["base_payment_amount", "base_outstanding", "base_paid_amount"], function(i, fname) {
+			$.each(["base_payment_amount", "base_outstanding", "base_paid_amount"], function (i, fname) {
 				if (frappe.meta.get_docfield(schedule_grid.doctype, fname))
 					schedule_grid.set_column_disp(fname, me.frm.doc.currency != company_currency);
 			});
@@ -1654,7 +1913,7 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 		let row = locals[cdt][cdn];
 
 		if (row.batch_no) {
-			row.use_serial_batch_fields = 1
+			row.use_serial_batch_fields = 1;
 		}
 
 		if (row.batch_no) {
@@ -1668,15 +1927,15 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 					pctx: params,
 					item_code: row.item_code,
 				},
-				callback: function(r) {
+				callback: function (r) {
 					if (!r.exc && r.message) {
 						row.price_list_rate = r.message;
 						row.rate = r.message;
 						refresh_field("rate", row.name, row.parentfield);
 						refresh_field("price_list_rate", row.name, row.parentfield);
 					}
-				}
-			})
+				},
+			});
 		}
 	}
 
@@ -1684,22 +1943,27 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 		const me = this;
 		// toggle columns
 		var item_grid = this.frm.fields_dict["items"].grid;
-		$.each(["base_rate", "base_price_list_rate", "base_amount", "base_rate_with_margin"], function(i, fname) {
-			if(frappe.meta.get_docfield(item_grid.doctype, fname))
-				item_grid.set_column_disp(fname, me.frm.doc.currency != company_currency);
+		$.each(
+			["base_rate", "base_price_list_rate", "base_amount", "base_rate_with_margin"],
+			function (i, fname) {
+				if (frappe.meta.get_docfield(item_grid.doctype, fname))
+					item_grid.set_column_disp(fname, me.frm.doc.currency != company_currency);
+			}
+		);
+
+		var show =
+			cint(this.frm.doc.discount_amount) ||
+			(this.frm.doc.taxes || []).filter(function (d) {
+				return d.included_in_print_rate === 1;
+			}).length;
+
+		$.each(["net_rate", "net_amount"], function (i, fname) {
+			if (frappe.meta.get_docfield(item_grid.doctype, fname)) item_grid.set_column_disp(fname, show);
 		});
 
-		var show = (cint(this.frm.doc.discount_amount)) ||
-			((this.frm.doc.taxes || []).filter(function(d) {return d.included_in_print_rate===1}).length);
-
-		$.each(["net_rate", "net_amount"], function(i, fname) {
-			if(frappe.meta.get_docfield(item_grid.doctype, fname))
-				item_grid.set_column_disp(fname, show);
-		});
-
-		$.each(["base_net_rate", "base_net_amount"], function(i, fname) {
-			if(frappe.meta.get_docfield(item_grid.doctype, fname))
-				item_grid.set_column_disp(fname, (show && (me.frm.doc.currency != company_currency)));
+		$.each(["base_net_rate", "base_net_amount"], function (i, fname) {
+			if (frappe.meta.get_docfield(item_grid.doctype, fname))
+				item_grid.set_column_disp(fname, show && me.frm.doc.currency != company_currency);
 		});
 	}
 
@@ -1716,41 +1980,41 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 	}
 
 	ignore_pricing_rule() {
-		if(this.frm.doc.ignore_pricing_rule) {
+		if (this.frm.doc.ignore_pricing_rule) {
 			let me = this;
 			let item_list = [];
 
-			$.each(this.frm.doc["items"] || [], function(i, d) {
+			$.each(this.frm.doc["items"] || [], function (i, d) {
 				if (d.item_code) {
 					if (d.is_free_item) {
 						// Simply remove free items
 						me.frm.get_field("items").grid.grid_rows[i].remove();
 					} else {
 						item_list.push({
-							"doctype": d.doctype,
-							"name": d.name,
-							"item_code": d.item_code,
-							"pricing_rules": d.pricing_rules,
-							"parenttype": d.parenttype,
-							"parent": d.parent,
-							"price_list_rate": d.price_list_rate
-						})
+							doctype: d.doctype,
+							name: d.name,
+							item_code: d.item_code,
+							pricing_rules: d.pricing_rules,
+							parenttype: d.parenttype,
+							parent: d.parent,
+							price_list_rate: d.price_list_rate,
+						});
 					}
 				}
 			});
 			return this.frm.call({
 				method: "erpnext.accounts.doctype.pricing_rule.pricing_rule.remove_pricing_rules",
 				args: { item_list: item_list },
-				callback: function(r) {
+				callback: function (r) {
 					if (!r.exc && r.message) {
-						r.message.forEach(row_item => {
+						r.message.forEach((row_item) => {
 							me.remove_pricing_rule(row_item);
 						});
 						me._set_values_for_item_list(r.message);
 						me.calculate_taxes_and_totals();
-						if(me.frm.doc.apply_discount_on) me.frm.trigger("apply_discount_on");
+						if (me.frm.doc.apply_discount_on) me.frm.trigger("apply_discount_on");
 					}
-				}
+				},
 			});
 		} else {
 			this.apply_pricing_rule();
@@ -1760,31 +2024,31 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 	remove_pricing_rule_for_item(item) {
 		// capture pricing rule before removing it to delete free items
 		let removed_pricing_rule = item.pricing_rules;
-		if (item.pricing_rules){
+		if (item.pricing_rules) {
 			let me = this;
 			return this.frm.call({
 				method: "erpnext.accounts.doctype.pricing_rule.pricing_rule.remove_pricing_rule_for_item",
 				args: {
 					pricing_rules: item.pricing_rules,
 					item_details: {
-						"doctype": item.doctype,
-						"name": item.name,
-						"item_code": item.item_code,
-						"pricing_rules": item.pricing_rules,
-						"parenttype": item.parenttype,
-						"parent": item.parent,
-						"price_list_rate": item.price_list_rate
+						doctype: item.doctype,
+						name: item.name,
+						item_code: item.item_code,
+						pricing_rules: item.pricing_rules,
+						parenttype: item.parenttype,
+						parent: item.parent,
+						price_list_rate: item.price_list_rate,
 					},
 					item_code: item.item_code,
 					rate: item.price_list_rate,
 				},
-				callback: function(r) {
+				callback: function (r) {
 					if (!r.exc && r.message) {
 						me.remove_pricing_rule(r.message, removed_pricing_rule, item.name);
 						me.calculate_taxes_and_totals();
-						if(me.frm.doc.apply_discount_on) me.frm.trigger("apply_discount_on");
+						if (me.frm.doc.apply_discount_on) me.frm.trigger("apply_discount_on");
 					}
-				}
+				},
 			});
 		}
 	}
@@ -1807,79 +2071,92 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 
 		return this.frm.call({
 			method: "erpnext.accounts.doctype.pricing_rule.pricing_rule.apply_pricing_rule",
-			args: {	args: args, doc: me.frm.doc },
-			callback: function(r) {
+			args: { args: args, doc: me.frm.doc },
+			callback: function (r) {
 				if (!r.exc && r.message) {
 					me._set_values_for_item_list(r.message);
-					if(item) me.set_gross_profit(item);
-					if (me.frm.doc.apply_discount_on) me.frm.trigger("apply_discount_on")
+					if (item) me.set_gross_profit(item);
+					if (me.frm.doc.apply_discount_on) me.frm.trigger("apply_discount_on");
 				}
-			}
+			},
 		});
 	}
 
 	_get_args(item) {
 		var me = this;
 		return {
-			"items": this._get_item_list(item),
-			"customer": me.frm.doc.customer || me.frm.doc.party_name,
-			"quotation_to": me.frm.doc.quotation_to,
-			"customer_group": me.frm.doc.customer_group,
-			"territory": me.frm.doc.territory,
-			"supplier": me.frm.doc.supplier,
-			"supplier_group": me.frm.doc.supplier_group,
-			"currency": me.frm.doc.currency,
-			"conversion_rate": me.frm.doc.conversion_rate,
-			"price_list": me.frm.doc.selling_price_list || me.frm.doc.buying_price_list,
-			"price_list_currency": me.frm.doc.price_list_currency,
-			"plc_conversion_rate": me.frm.doc.plc_conversion_rate,
-			"company": me.frm.doc.company,
-			"transaction_date": me.frm.doc.transaction_date || me.frm.doc.posting_date,
-			"campaign": me.frm.doc.campaign,
-			"sales_partner": me.frm.doc.sales_partner,
-			"ignore_pricing_rule": me.frm.doc.ignore_pricing_rule,
-			"doctype": me.frm.doc.doctype,
-			"name": me.frm.doc.name,
-			"is_return": cint(me.frm.doc.is_return),
-			"update_stock": ['Sales Invoice', 'Purchase Invoice'].includes(me.frm.doc.doctype) ? cint(me.frm.doc.update_stock) : 0,
-			"conversion_factor": me.frm.doc.conversion_factor,
-			"pos_profile": me.frm.doc.doctype == 'Sales Invoice' ? me.frm.doc.pos_profile : '',
-			"coupon_code": me.frm.doc.coupon_code,
-			"is_internal_supplier": me.frm.doc.is_internal_supplier,
-			"is_internal_customer": me.frm.doc.is_internal_customer,
+			items: this._get_item_list(item),
+			customer: me.frm.doc.customer || me.frm.doc.party_name,
+			quotation_to: me.frm.doc.quotation_to,
+			customer_group: me.frm.doc.customer_group,
+			territory: me.frm.doc.territory,
+			supplier: me.frm.doc.supplier,
+			supplier_group: me.frm.doc.supplier_group,
+			currency: me.frm.doc.currency,
+			conversion_rate: me.frm.doc.conversion_rate,
+			price_list: me.frm.doc.selling_price_list || me.frm.doc.buying_price_list,
+			price_list_currency: me.frm.doc.price_list_currency,
+			plc_conversion_rate: me.frm.doc.plc_conversion_rate,
+			company: me.frm.doc.company,
+			transaction_date: me.frm.doc.transaction_date || me.frm.doc.posting_date,
+			campaign: me.frm.doc.campaign,
+			sales_partner: me.frm.doc.sales_partner,
+			ignore_pricing_rule: me.frm.doc.ignore_pricing_rule,
+			doctype: me.frm.doc.doctype,
+			name: me.frm.doc.name,
+			is_return: cint(me.frm.doc.is_return),
+			update_stock: ["Sales Invoice", "Purchase Invoice"].includes(me.frm.doc.doctype)
+				? cint(me.frm.doc.update_stock)
+				: 0,
+			conversion_factor: me.frm.doc.conversion_factor,
+			pos_profile: me.frm.doc.doctype == "Sales Invoice" ? me.frm.doc.pos_profile : "",
+			coupon_code: me.frm.doc.coupon_code,
+			is_internal_supplier: me.frm.doc.is_internal_supplier,
+			is_internal_customer: me.frm.doc.is_internal_customer,
 		};
 	}
 
 	_get_item_list(item) {
 		var item_list = [];
-		var append_item = function(d) {
+		var append_item = function (d) {
 			if (d.item_code) {
 				item_list.push({
-					"doctype": d.doctype,
-					"name": d.name,
-					"child_docname": d.name,
-					"item_code": d.item_code,
-					"item_group": d.item_group,
-					"brand": d.brand,
-					"qty": d.qty,
-					"stock_qty": d.stock_qty,
-					"uom": d.uom,
-					"stock_uom": d.stock_uom,
-					"parenttype": d.parenttype,
-					"parent": d.parent,
-					"pricing_rules": d.pricing_rules,
-					"is_free_item": d.is_free_item,
-					"warehouse": d.warehouse,
-					"serial_no": d.serial_no,
-					"batch_no": d.batch_no,
-					"price_list_rate": d.price_list_rate,
-					"conversion_factor": d.conversion_factor || 1.0,
-					"discount_percentage" : d.discount_percentage,
-					"discount_amount" : d.discount_amount,
+					doctype: d.doctype,
+					name: d.name,
+					child_docname: d.name,
+					item_code: d.item_code,
+					item_group: d.item_group,
+					brand: d.brand,
+					qty: d.qty,
+					stock_qty: d.stock_qty,
+					uom: d.uom,
+					stock_uom: d.stock_uom,
+					parenttype: d.parenttype,
+					parent: d.parent,
+					pricing_rules: d.pricing_rules,
+					is_free_item: d.is_free_item,
+					warehouse: d.warehouse,
+					serial_no: d.serial_no,
+					batch_no: d.batch_no,
+					price_list_rate: d.price_list_rate,
+					conversion_factor: d.conversion_factor || 1.0,
+					discount_percentage: d.discount_percentage,
+					discount_amount: d.discount_amount,
 				});
 
 				// if doctype is Quotation Item / Sales Order Iten then add Margin Type and rate in item_list
-				if (in_list(["Quotation Item", "Sales Order Item", "Delivery Note Item", "Sales Invoice Item",  "Purchase Invoice Item", "Purchase Order Item", "Purchase Receipt Item"]), d.doctype) {
+				if (
+					(in_list([
+						"Quotation Item",
+						"Sales Order Item",
+						"Delivery Note Item",
+						"Sales Invoice Item",
+						"Purchase Invoice Item",
+						"Purchase Order Item",
+						"Purchase Receipt Item",
+					]),
+					d.doctype)
+				) {
 					item_list[0]["margin_type"] = d.margin_type;
 					item_list[0]["margin_rate_or_amount"] = d.margin_rate_or_amount;
 				}
@@ -1889,7 +2166,7 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 		if (item) {
 			append_item(item);
 		} else {
-			$.each(this.frm.doc["items"] || [], function(i, d) {
+			$.each(this.frm.doc["items"] || [], function (i, d) {
 				append_item(d);
 			});
 		}
@@ -1913,7 +2190,10 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 					}
 
 					if (key !== "free_item_data") {
-						if (child.apply_rule_on_other_items && JSON.parse(child.apply_rule_on_other_items).length) {
+						if (
+							child.apply_rule_on_other_items &&
+							JSON.parse(child.apply_rule_on_other_items).length
+						) {
 							if (!in_list(JSON.parse(child.apply_rule_on_other_items), child.item_code)) {
 								continue;
 							}
@@ -1924,10 +2204,10 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 				}
 			}
 
-			frappe.model.round_floats_in(
-				frappe.get_doc(child.doctype, child.name),
-				["price_list_rate", "discount_percentage"],
-			);
+			frappe.model.round_floats_in(frappe.get_doc(child.doctype, child.name), [
+				"price_list_rate",
+				"discount_percentage",
+			]);
 
 			// if pricing rule set as blank from an existing value, apply price_list
 			if (!this.frm.doc.ignore_pricing_rule && existing_pricing_rule && !child.pricing_rules) {
@@ -1953,16 +2233,19 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 		const me = this;
 		const fields = ["pricing_rules"];
 
-		for(var k in args) {
+		for (var k in args) {
 			let data = args[k];
 
 			if (data && data.apply_rule_on_other_items && JSON.parse(data.apply_rule_on_other_items)) {
-				fields.push(frappe.scrub(data.pricing_rule_for))
-				me.frm.doc.items.forEach(d => {
+				fields.push(frappe.scrub(data.pricing_rule_for));
+				me.frm.doc.items.forEach((d) => {
 					if (JSON.parse(data.apply_rule_on_other_items).includes(d[data.apply_rule_on])) {
-						for(var k in data) {
-
-							if (in_list(fields, k) && data[k] && (data.price_or_product_discount === 'Price' || k === 'pricing_rules')) {
+						for (var k in data) {
+							if (
+								in_list(fields, k) &&
+								data[k] &&
+								(data.price_or_product_discount === "Price" || k === "pricing_rules")
+							) {
 								frappe.model.set_value(d.doctype, d.name, k, data[k]);
 							}
 						}
@@ -1973,23 +2256,27 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 	}
 
 	apply_product_discount(args) {
-		const items = this.frm.doc.items.filter(d => (d.is_free_item)) || [];
+		const items = this.frm.doc.items.filter((d) => d.is_free_item) || [];
 
-		const exist_items = items.map(row => { return {item_code: row.item_code, pricing_rules: row.pricing_rules};});
+		const exist_items = items.map((row) => {
+			return { item_code: row.item_code, pricing_rules: row.pricing_rules };
+		});
 
-		args.free_item_data.forEach(async pr_row => {
+		args.free_item_data.forEach(async (pr_row) => {
 			let row_to_modify = {};
 
 			// If there are no free items, or if the current free item doesn't exist in the table, add it
-			if (!items || !exist_items.filter(e_row => {
-				return e_row.item_code == pr_row.item_code && e_row.pricing_rules == pr_row.pricing_rules;
-			}).length) {
-				row_to_modify = frappe.model.add_child(this.frm.doc,
-					this.frm.doc.doctype + ' Item', 'items');
-
-			} else if(items) {
-				row_to_modify = items.filter(d => (d.item_code === pr_row.item_code
-					&& d.pricing_rules === pr_row.pricing_rules))[0];
+			if (
+				!items ||
+				!exist_items.filter((e_row) => {
+					return e_row.item_code == pr_row.item_code && e_row.pricing_rules == pr_row.pricing_rules;
+				}).length
+			) {
+				row_to_modify = frappe.model.add_child(this.frm.doc, this.frm.doc.doctype + " Item", "items");
+			} else if (items) {
+				row_to_modify = items.filter(
+					(d) => d.item_code === pr_row.item_code && d.pricing_rules === pr_row.pricing_rules
+				)[0];
 			}
 
 			for (let key in pr_row) {
@@ -2003,18 +2290,20 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 				}
 			}
 
-			this.frm.script_manager.copy_from_first_row("items", row_to_modify, ["expense_account", "income_account"]);
+			this.frm.script_manager.copy_from_first_row("items", row_to_modify, [
+				"expense_account",
+				"income_account",
+			]);
 		});
 
 		// free_item_data is a temporary variable
-		args.free_item_data = '';
-		refresh_field('items');
+		args.free_item_data = "";
+		refresh_field("items");
 	}
 
 	apply_price_list(item, reset_plc_conversion) {
 		// We need to reset plc_conversion_rate sometimes because the call to
 		// `erpnext.stock.get_item_details.apply_price_list` is sensitive to its value
-
 
 		if (this.frm.doc.doctype === "Material Request") {
 			return;
@@ -2033,81 +2322,102 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 		if (me.in_apply_price_list == true) return;
 
 		me.in_apply_price_list = true;
-		return this.frm.call({
-			method: "erpnext.stock.get_item_details.apply_price_list",
-			args: {	ctx: args, doc: me.frm.doc },
-			callback: function(r) {
-				if (!r.exc) {
-					frappe.run_serially([
-						() => {
-							if (r.message.parent.price_list_currency)
-								me.frm.set_value("price_list_currency", r.message.parent.price_list_currency);
-						},
-						() => {
-							if (r.message.parent.plc_conversion_rate)
-								me.frm.set_value("plc_conversion_rate", r.message.parent.plc_conversion_rate);
-						},
-						() => {
-							if(args.items.length) {
-								me._set_values_for_item_list(r.message.children);
-								$.each(r.message.children || [], function(i, d) {
-									me.apply_discount_on_item(d, d.doctype, d.name, 'discount_percentage');
-								});
-							}
-						},
-						() => { me.in_apply_price_list = false; }
-					]);
-
-				} else {
-					me.in_apply_price_list = false;
-				}
-			}
-		}).always(() => {
-			me.in_apply_price_list = false;
-		});
+		return this.frm
+			.call({
+				method: "erpnext.stock.get_item_details.apply_price_list",
+				args: { ctx: args, doc: me.frm.doc },
+				callback: function (r) {
+					if (!r.exc) {
+						frappe.run_serially([
+							() => {
+								if (r.message.parent.price_list_currency)
+									me.frm.set_value(
+										"price_list_currency",
+										r.message.parent.price_list_currency
+									);
+							},
+							() => {
+								if (r.message.parent.plc_conversion_rate)
+									me.frm.set_value(
+										"plc_conversion_rate",
+										r.message.parent.plc_conversion_rate
+									);
+							},
+							() => {
+								if (args.items.length) {
+									me._set_values_for_item_list(r.message.children);
+									$.each(r.message.children || [], function (i, d) {
+										me.apply_discount_on_item(
+											d,
+											d.doctype,
+											d.name,
+											"discount_percentage"
+										);
+									});
+								}
+							},
+							() => {
+								me.in_apply_price_list = false;
+							},
+						]);
+					} else {
+						me.in_apply_price_list = false;
+					}
+				},
+			})
+			.always(() => {
+				me.in_apply_price_list = false;
+			});
 	}
 
 	remove_pricing_rule(item, removed_pricing_rule, row_name) {
 		let me = this;
-		const fields = ["discount_percentage",
-			"discount_amount", "margin_rate_or_amount", "rate_with_margin"];
+		const fields = [
+			"discount_percentage",
+			"discount_amount",
+			"margin_rate_or_amount",
+			"rate_with_margin",
+		];
 
 		if (!item) {
 			return;
 		}
 
-		if(item.remove_free_item) {
+		if (item.remove_free_item) {
 			let items = [];
 
-			me.frm.doc.items.forEach(d => {
+			me.frm.doc.items.forEach((d) => {
 				// if same item was added as free item through a different pricing rule, keep it
-				if(d.item_code != item.remove_free_item || !d.is_free_item || !removed_pricing_rule?.includes(d.pricing_rules)) {
+				if (
+					d.item_code != item.remove_free_item ||
+					!d.is_free_item ||
+					!removed_pricing_rule?.includes(d.pricing_rules)
+				) {
 					items.push(d);
 				}
 			});
 
 			me.frm.doc.items = items;
-			refresh_field('items');
-		} else if(item.applied_on_items && item.apply_on) {
-			const applied_on_items = item.applied_on_items.split(',');
-			me.frm.doc.items.forEach(row => {
-				if(applied_on_items.includes(row[item.apply_on])) {
-					fields.forEach(f => {
+			refresh_field("items");
+		} else if (item.applied_on_items && item.apply_on) {
+			const applied_on_items = item.applied_on_items.split(",");
+			me.frm.doc.items.forEach((row) => {
+				if (applied_on_items.includes(row[item.apply_on])) {
+					fields.forEach((f) => {
 						row[f] = 0;
 					});
 
-					["pricing_rules", "margin_type"].forEach(field => {
+					["pricing_rules", "margin_type"].forEach((field) => {
 						if (row[field]) {
-							row[field] = '';
+							row[field] = "";
 						}
-					})
+					});
 				}
 			});
 
 			me.trigger_price_list_rate();
-		}
-		else if(!item.is_free_item && row_name){
-			me.frm.doc.items.forEach(d => {
+		} else if (!item.is_free_item && row_name) {
+			me.frm.doc.items.forEach((d) => {
 				if (d.name != row_name) return;
 
 				Object.assign(d, item);
@@ -2116,12 +2426,11 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 	}
 
 	trigger_price_list_rate() {
-		var me  = this;
+		var me = this;
 
-		this.frm.doc.items.forEach(child_row => {
-			me.frm.script_manager.trigger("price_list_rate",
-				child_row.doctype, child_row.name);
-		})
+		this.frm.doc.items.forEach((child_row) => {
+			me.frm.script_manager.trigger("price_list_rate", child_row.doctype, child_row.name);
+		});
 	}
 
 	validate_company_and_party() {
@@ -2132,12 +2441,19 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 			return valid;
 		}
 
-		$.each(["company", "customer"], function(i, fieldname) {
-			if(frappe.meta.has_field(me.frm.doc.doctype, fieldname) &&  !["Purchase Order","Purchase Invoice"].includes(me.frm.doc.doctype)) {
+		$.each(["company", "customer"], function (i, fieldname) {
+			if (
+				frappe.meta.has_field(me.frm.doc.doctype, fieldname) &&
+				!["Purchase Order", "Purchase Invoice"].includes(me.frm.doc.doctype)
+			) {
 				if (!me.frm.doc[fieldname]) {
-					frappe.msgprint(__("Please specify") + ": " +
-						__(frappe.meta.get_label(me.frm.doc.doctype, fieldname, me.frm.doc.name)) +
-						". " + __("It is needed to fetch Item Details."));
+					frappe.msgprint(
+						__("Please specify") +
+							": " +
+							__(frappe.meta.get_label(me.frm.doc.doctype, fieldname, me.frm.doc.name)) +
+							". " +
+							__("It is needed to fetch Item Details.")
+					);
 					valid = false;
 				}
 			}
@@ -2148,8 +2464,8 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 	get_terms() {
 		var me = this;
 
-		erpnext.utils.get_terms(this.frm.doc.tc_name, this.frm.doc, function(r) {
-			if(!r.exc) {
+		erpnext.utils.get_terms(this.frm.doc.tc_name, this.frm.doc, function (r) {
+			if (!r.exc) {
 				me.frm.set_value("terms", r.message);
 			}
 		});
@@ -2157,17 +2473,20 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 
 	taxes_and_charges() {
 		var me = this;
-		if(this.frm.doc.taxes_and_charges) {
+		if (this.frm.doc.taxes_and_charges) {
 			return this.frm.call({
 				method: "erpnext.controllers.accounts_controller.get_taxes_and_charges",
 				args: {
-					"master_doctype": frappe.meta.get_docfield(this.frm.doc.doctype, "taxes_and_charges",
-						this.frm.doc.name).options,
-					"master_name": this.frm.doc.taxes_and_charges
+					master_doctype: frappe.meta.get_docfield(
+						this.frm.doc.doctype,
+						"taxes_and_charges",
+						this.frm.doc.name
+					).options,
+					master_name: this.frm.doc.taxes_and_charges,
 				},
-				callback: function(r) {
-					if(!r.exc) {
-						if(me.frm.doc.shipping_rule && me.frm.doc.taxes) {
+				callback: function (r) {
+					if (!r.exc) {
+						if (me.frm.doc.shipping_rule && me.frm.doc.taxes) {
 							for (let tax of r.message) {
 								me.frm.add_child("taxes", tax);
 							}
@@ -2178,14 +2497,14 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 							me.calculate_taxes_and_totals();
 						}
 					}
-				}
+				},
 			});
 		}
 	}
 
 	tax_category() {
 		var me = this;
-		if(me.frm.updating_party_details) return;
+		if (me.frm.updating_party_details) return;
 
 		frappe.run_serially([
 			() => this.update_item_tax_map(),
@@ -2201,7 +2520,7 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 
 		if (me.frm.doc.is_return && me.frm.doc.return_against) return;
 
-		$.each(this.frm.doc.items || [], function(i, item) {
+		$.each(this.frm.doc.items || [], function (i, item) {
 			if (item.item_code) {
 				// Use combination of name and item code in case same item is added multiple times
 				item_codes.push([item.item_code, item.name]);
@@ -2218,44 +2537,48 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 					tax_category: cstr(me.frm.doc.tax_category),
 					item_codes: item_codes,
 					item_rates: item_rates,
-					item_tax_templates: item_tax_templates
+					item_tax_templates: item_tax_templates,
 				},
-				callback: function(r) {
+				callback: function (r) {
 					if (!r.exc) {
-						$.each(me.frm.doc.items || [], function(i, item) {
-							if (item.name && r.message.hasOwnProperty(item.name) && r.message[item.name].item_tax_template) {
+						$.each(me.frm.doc.items || [], function (i, item) {
+							if (
+								item.name &&
+								r.message.hasOwnProperty(item.name) &&
+								r.message[item.name].item_tax_template
+							) {
 								item.item_tax_template = r.message[item.name].item_tax_template;
 								item.item_tax_rate = r.message[item.name].item_tax_rate;
 								me.add_taxes_from_item_tax_template(item.item_tax_rate);
 							}
 						});
 					}
-				}
+				},
 			});
 		}
 	}
 
 	item_tax_template(doc, cdt, cdn) {
 		var me = this;
-		if(me.frm.updating_party_details) return;
+		if (me.frm.updating_party_details) return;
 
 		var item = frappe.get_doc(cdt, cdn);
 
-		if(item.item_tax_template) {
+		if (item.item_tax_template) {
 			return this.frm.call({
 				method: "erpnext.stock.get_item_details.get_item_tax_map",
 				args: {
 					doc: me.frm.doc,
 					tax_template: item.item_tax_template,
-					as_json: true
+					as_json: true,
 				},
-				callback: function(r) {
-					if(!r.exc) {
+				callback: function (r) {
+					if (!r.exc) {
 						item.item_tax_rate = r.message;
 						me.add_taxes_from_item_tax_template(item.item_tax_rate);
 						me.calculate_taxes_and_totals();
 					}
-				}
+				},
 			});
 		} else {
 			item.item_tax_rate = "{}";
@@ -2263,27 +2586,33 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 		}
 	}
 
-
 	is_recurring() {
 		// set default values for recurring documents
-		if(this.frm.doc.is_recurring && this.frm.doc.__islocal) {
+		if (this.frm.doc.is_recurring && this.frm.doc.__islocal) {
 			frappe.msgprint(__("Please set recurring after saving"));
-			this.frm.set_value('is_recurring', 0);
+			this.frm.set_value("is_recurring", 0);
 			return;
 		}
 
-		if(this.frm.doc.is_recurring) {
-			if(!this.frm.doc.recurring_id) {
-				this.frm.set_value('recurring_id', this.frm.doc.name);
+		if (this.frm.doc.is_recurring) {
+			if (!this.frm.doc.recurring_id) {
+				this.frm.set_value("recurring_id", this.frm.doc.name);
 			}
 
-			var owner_email = this.frm.doc.owner=="Administrator"
-				? frappe.user_info("Administrator").email
-				: this.frm.doc.owner;
+			var owner_email =
+				this.frm.doc.owner == "Administrator"
+					? frappe.user_info("Administrator").email
+					: this.frm.doc.owner;
 
-			this.frm.doc.notification_email_address = $.map([cstr(owner_email),
-				cstr(this.frm.doc.contact_email)], function(v) { return v || null; }).join(", ");
-			this.frm.doc.repeat_on_day_of_month = frappe.datetime.str_to_obj(this.frm.doc.posting_date).getDate();
+			this.frm.doc.notification_email_address = $.map(
+				[cstr(owner_email), cstr(this.frm.doc.contact_email)],
+				function (v) {
+					return v || null;
+				}
+			).join(", ");
+			this.frm.doc.repeat_on_day_of_month = frappe.datetime
+				.str_to_obj(this.frm.doc.posting_date)
+				.getDate();
 		}
 
 		refresh_many(["notification_email_address", "repeat_on_day_of_month"]);
@@ -2291,16 +2620,14 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 
 	from_date() {
 		// set to_date
-		if(this.frm.doc.from_date) {
-			var recurring_type_map = {'Monthly': 1, 'Quarterly': 3, 'Half-yearly': 6,
-				'Yearly': 12};
+		if (this.frm.doc.from_date) {
+			var recurring_type_map = { Monthly: 1, Quarterly: 3, "Half-yearly": 6, Yearly: 12 };
 
 			var months = recurring_type_map[this.frm.doc.recurring_type];
-			if(months) {
-				var to_date = frappe.datetime.add_months(this.frm.doc.from_date,
-					months);
+			if (months) {
+				var to_date = frappe.datetime.add_months(this.frm.doc.from_date, months);
 				this.frm.doc.to_date = frappe.datetime.add_days(to_date, -1);
-				refresh_field('to_date');
+				refresh_field("to_date");
 			}
 		}
 	}
@@ -2308,7 +2635,7 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 	set_gross_profit(item) {
 		if (["Sales Order", "Quotation"].includes(this.frm.doc.doctype) && item.valuation_rate) {
 			var rate = flt(item.rate) * flt(this.frm.doc.conversion_rate || 1);
-			item.gross_profit = flt(((rate - item.valuation_rate) * item.stock_qty), precision("amount", item));
+			item.gross_profit = flt((rate - item.valuation_rate) * item.stock_qty, precision("amount", item));
 		}
 	}
 
@@ -2322,22 +2649,22 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 	}
 
 	get_advances() {
-		if(!this.frm.is_return) {
+		if (!this.frm.is_return) {
 			var me = this;
 			return this.frm.call({
 				method: "set_advances",
 				doc: this.frm.doc,
-				callback: function(r, rt) {
+				callback: function (r, rt) {
 					refresh_field("advances");
 					me.frm.dirty();
-				}
-			})
+				},
+			});
 		}
 	}
 
 	make_payment_entry() {
 		let via_journal_entry = this.frm.doc.__onload && this.frm.doc.__onload.make_payment_via_journal_entry;
-		if(this.has_discount_in_schedule() && !via_journal_entry) {
+		if (this.has_discount_in_schedule() && !via_journal_entry) {
 			// If early payment discount is applied, ask user for reference date
 			this.prompt_user_for_reference_date();
 		} else {
@@ -2347,34 +2674,36 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 
 	make_mapped_payment_entry(args) {
 		var me = this;
-		args = args || { "dt": this.frm.doc.doctype, "dn": this.frm.doc.name };
+		args = args || { dt: this.frm.doc.doctype, dn: this.frm.doc.name };
 		return frappe.call({
 			method: me.get_method_for_payment(),
 			args: args,
-			callback: function(r) {
+			callback: function (r) {
 				var doclist = frappe.model.sync(r.message);
 				frappe.set_route("Form", doclist[0].doctype, doclist[0].name);
-			}
+			},
 		});
 	}
 
-	prompt_user_for_reference_date(){
+	prompt_user_for_reference_date() {
 		let me = this;
-		frappe.prompt({
-			label: __("Cheque/Reference Date"),
-			fieldname: "reference_date",
-			fieldtype: "Date",
-			reqd: 1,
-		}, (values) => {
-			let args = {
-				"dt": me.frm.doc.doctype,
-				"dn": me.frm.doc.name,
-				"reference_date": values.reference_date
-			}
-			me.make_mapped_payment_entry(args);
-		},
-		__("Reference Date for Early Payment Discount"),
-		__("Continue")
+		frappe.prompt(
+			{
+				label: __("Cheque/Reference Date"),
+				fieldname: "reference_date",
+				fieldtype: "Date",
+				reqd: 1,
+			},
+			(values) => {
+				let args = {
+					dt: me.frm.doc.doctype,
+					dn: me.frm.doc.name,
+					reference_date: values.reference_date,
+				};
+				me.make_mapped_payment_entry(args);
+			},
+			__("Reference Date for Early Payment Discount"),
+			__("Continue")
 		);
 	}
 
@@ -2384,9 +2713,9 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 			this.frm.doctype
 		);
 		let has_payment_schedule = this.frm.doc.payment_schedule && this.frm.doc.payment_schedule.length;
-		if(!is_eligible || !has_payment_schedule) return false;
+		if (!is_eligible || !has_payment_schedule) return false;
 
-		let has_discount = this.frm.doc.payment_schedule.some(row => row.discount);
+		let has_discount = this.frm.doc.payment_schedule.some((row) => row.discount);
 		return has_discount;
 	}
 
@@ -2407,79 +2736,82 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 					{
 						fieldtype: "Data",
 						fieldname: "docname",
-						hidden: true
+						hidden: true,
 					},
 					{
 						fieldtype: "Read Only",
 						fieldname: "item_code",
 						label: __("Item Code"),
-						in_list_view: true
+						in_list_view: true,
 					},
 					{
 						fieldtype: "Read Only",
 						fieldname: "item_name",
 						label: __("Item Name"),
-						in_list_view: true
+						in_list_view: true,
 					},
 					{
 						fieldtype: "Float",
 						fieldname: "qty",
 						label: __("Accepted Quantity"),
 						in_list_view: true,
-						read_only: true
+						read_only: true,
 					},
 					{
 						fieldtype: "Float",
 						fieldname: "sample_size",
 						label: __("Sample Size"),
 						reqd: true,
-						in_list_view: true
+						in_list_view: true,
 					},
 					{
 						fieldtype: "Data",
 						fieldname: "description",
 						label: __("Description"),
-						hidden: true
+						hidden: true,
 					},
 					{
 						fieldtype: "Data",
 						fieldname: "serial_no",
 						label: __("Serial No"),
-						hidden: true
+						hidden: true,
 					},
 					{
 						fieldtype: "Data",
 						fieldname: "batch_no",
 						label: __("Batch No"),
-						hidden: true
+						hidden: true,
 					},
 					{
 						fieldtype: "Data",
 						fieldname: "child_row_reference",
 						label: __("Child Row Reference"),
-						hidden: true
-					}
-				]
-			}
+						hidden: true,
+					},
+				],
+			},
 		];
 
 		const me = this;
-		const inspection_type = ["Purchase Receipt", "Purchase Invoice", "Subcontracting Receipt"].includes(this.frm.doc.doctype)
-			? "Incoming" : "Outgoing";
+		const inspection_type = ["Purchase Receipt", "Purchase Invoice", "Subcontracting Receipt"].includes(
+			this.frm.doc.doctype
+		)
+			? "Incoming"
+			: "Outgoing";
 		const dialog = new frappe.ui.Dialog({
 			title: __("Select Items for Quality Inspection"),
 			size: "extra-large",
 			fields: fields,
 			primary_action: function () {
 				const data = dialog.get_values();
-				const selected_data = data.items.filter(item => item?.__checked == 1 );
+				const selected_data = data.items.filter((item) => item?.__checked == 1);
 				frappe.call({
 					method: "erpnext.controllers.stock_controller.make_quality_inspections",
 					args: {
 						doctype: me.frm.doc.doctype,
 						docname: me.frm.doc.name,
 						items: selected_data,
-						inspection_type: inspection_type
+						inspection_type: inspection_type,
 					},
 					freeze: true,
 					callback: function (r) {
@@ -2488,39 +2820,39 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 								frappe.set_route("Form", "Quality Inspection", r.message[0]);
 							} else {
 								frappe.route_options = {
-									"reference_type": me.frm.doc.doctype,
-									"reference_name": me.frm.doc.name
+									reference_type: me.frm.doc.doctype,
+									reference_name: me.frm.doc.name,
 								};
 								frappe.set_route("List", "Quality Inspection");
 							}
 						}
 						dialog.hide();
-					}
+					},
 				});
 			},
-			primary_action_label: __("Create")
+			primary_action_label: __("Create"),
 		});
 
 		frappe.call({
 			method: "erpnext.controllers.stock_controller.check_item_quality_inspection",
 			args: {
 				doctype: this.frm.doc.doctype,
-				items: this.frm.doc.items
+				items: this.frm.doc.items,
 			},
 			freeze: true,
 			callback: function (r) {
-				r.message.forEach(item => {
+				r.message.forEach((item) => {
 					if (me.has_inspection_required(item)) {
 						let dialog_items = dialog.fields_dict.items;
 						dialog_items.df.data.push({
-							"item_code": item.item_code,
-							"item_name": item.item_name,
-							"qty": item.qty,
-							"description": item.description,
-							"serial_no": item.serial_no,
-							"batch_no": item.batch_no,
-							"sample_size": item.sample_quantity,
-							"child_row_reference": item.name,
+							item_code: item.item_code,
+							item_name: item.item_name,
+							qty: item.qty,
+							description: item.description,
+							serial_no: item.serial_no,
+							batch_no: item.batch_no,
+							sample_size: item.sample_quantity,
+							child_row_reference: item.name,
 						});
 						dialog_items.grid.refresh();
 					}
@@ -2528,16 +2860,18 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 
 				data = dialog.fields_dict.items.df.data;
 				if (!data.length) {
-					frappe.msgprint(__("All items in this document already have a linked Quality Inspection."));
+					frappe.msgprint(
+						__("All items in this document already have a linked Quality Inspection.")
+					);
 				} else {
 					dialog.show();
 				}
-			}
+			},
 		});
 	}
 
 	has_inspection_required(item) {
-		if (this.frm.doc.doctype === "Stock Entry" && this.frm.doc.purpose == "Manufacture" ) {
+		if (this.frm.doc.doctype === "Stock Entry" && this.frm.doc.purpose == "Manufacture") {
 			if (item.is_finished_item && !item.quality_inspection) {
 				return true;
 			}
@@ -2548,15 +2882,17 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 
 	get_method_for_payment() {
 		let method = "erpnext.accounts.doctype.payment_entry.payment_entry.get_payment_entry";
-		if(this.frm.doc.__onload && this.frm.doc.__onload.make_payment_via_journal_entry){
-			if(['Sales Invoice', 'Purchase Invoice'].includes( this.frm.doc.doctype)){
-				method = "erpnext.accounts.doctype.journal_entry.journal_entry.get_payment_entry_against_invoice";
-			}else {
-				method= "erpnext.accounts.doctype.journal_entry.journal_entry.get_payment_entry_against_order";
+		if (this.frm.doc.__onload && this.frm.doc.__onload.make_payment_via_journal_entry) {
+			if (["Sales Invoice", "Purchase Invoice"].includes(this.frm.doc.doctype)) {
+				method =
+					"erpnext.accounts.doctype.journal_entry.journal_entry.get_payment_entry_against_invoice";
+			} else {
+				method =
+					"erpnext.accounts.doctype.journal_entry.journal_entry.get_payment_entry_against_order";
 			}
 		}
 
-		return method
+		return method;
 	}
 
 	set_query_for_batch(doc, cdt, cdn) {
@@ -2565,18 +2901,20 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 		var me = this;
 		var item = frappe.get_doc(cdt, cdn);
 
-		if(!item.item_code) {
+		if (!item.item_code) {
 			frappe.throw(__("Please enter Item Code to get batch no"));
-		} else if (doc.doctype == "Purchase Receipt" ||
-			(doc.doctype == "Purchase Invoice" && doc.update_stock)) {
+		} else if (
+			doc.doctype == "Purchase Receipt" ||
+			(doc.doctype == "Purchase Invoice" && doc.update_stock)
+		) {
 			return {
-				filters: {'item': item.item_code}
-			}
+				filters: { item: item.item_code },
+			};
 		} else {
 			let filters = {
-				'item_code': item.item_code,
-				'posting_date': me.frm.doc.posting_date || frappe.datetime.nowdate(),
-			}
+				item_code: item.item_code,
+				posting_date: me.frm.doc.posting_date || frappe.datetime.nowdate(),
+			};
 
 			if (doc.is_return) {
 				filters["is_return"] = 1;
@@ -2588,39 +2926,37 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 			if (item.warehouse) filters["warehouse"] = item.warehouse;
 
 			return {
-				query : "erpnext.controllers.queries.get_batch_no",
-				filters: filters
-			}
+				query: "erpnext.controllers.queries.get_batch_no",
+				filters: filters,
+			};
 		}
 	}
 
 	set_query_for_item_tax_template(doc, cdt, cdn) {
 		var item = frappe.get_doc(cdt, cdn);
-		if(!item.item_code) {
-			return doc.company ? {filters: {company: doc.company}} : {};
+		if (!item.item_code) {
+			return doc.company ? { filters: { company: doc.company } } : {};
 		} else {
 			let filters = {
-				'item_code': item.item_code,
-				'valid_from': ["<=", doc.transaction_date || doc.bill_date || doc.posting_date],
-				'item_group': item.item_group,
-				"base_net_rate": item.base_net_rate,
-			}
+				item_code: item.item_code,
+				valid_from: ["<=", doc.transaction_date || doc.bill_date || doc.posting_date],
+				item_group: item.item_group,
+				base_net_rate: item.base_net_rate,
+			};
 
-			if (doc.tax_category)
-				filters['tax_category'] = doc.tax_category;
-			if (doc.company)
-				filters['company'] = doc.company;
+			if (doc.tax_category) filters["tax_category"] = doc.tax_category;
+			if (doc.company) filters["company"] = doc.company;
 			return {
 				query: "erpnext.controllers.queries.get_tax_template",
-				filters: filters
-			}
+				filters: filters,
+			};
 		}
 	}
 
 	payment_terms_template() {
 		var me = this;
 		const doc = this.frm.doc;
-		if(doc.payment_terms_template && doc.doctype !== 'Delivery Note' && !doc.is_return) {
+		if (doc.payment_terms_template && doc.doctype !== "Delivery Note" && !doc.is_return) {
 			var posting_date = doc.posting_date || doc.transaction_date;
 			frappe.call({
 				method: "erpnext.controllers.accounts_controller.get_payment_terms",
@@ -2629,23 +2965,23 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 					posting_date: posting_date,
 					grand_total: doc.rounded_total || doc.grand_total,
 					base_grand_total: doc.base_rounded_total || doc.base_grand_total,
-					bill_date: doc.bill_date
+					bill_date: doc.bill_date,
 				},
-				callback: function(r) {
-					if(r.message && !r.exc) {
+				callback: function (r) {
+					if (r.message && !r.exc) {
 						me.frm.set_value("payment_schedule", r.message);
 						const company_currency = me.get_company_currency();
 						me.update_payment_schedule_grid_labels(company_currency);
 					}
-				}
-			})
+				},
+			});
 		}
 	}
 
 	payment_term(doc, cdt, cdn) {
 		const me = this;
 		var row = locals[cdt][cdn];
-		if(row.payment_term) {
+		if (row.payment_term) {
 			frappe.call({
 				method: "erpnext.controllers.accounts_controller.get_payment_term_details",
 				args: {
@@ -2653,61 +2989,71 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 					bill_date: this.frm.doc.bill_date,
 					posting_date: this.frm.doc.posting_date || this.frm.doc.transaction_date,
 					grand_total: this.frm.doc.rounded_total || this.frm.doc.grand_total,
-					base_grand_total: this.frm.doc.base_rounded_total || this.frm.doc.base_grand_total
+					base_grand_total: this.frm.doc.base_rounded_total || this.frm.doc.base_grand_total,
 				},
-				callback: function(r) {
-					if(r.message && !r.exc) {
+				callback: function (r) {
+					if (r.message && !r.exc) {
 						for (var d in r.message) {
 							frappe.model.set_value(cdt, cdn, d, r.message[d]);
 							const company_currency = me.get_company_currency();
 							me.update_payment_schedule_grid_labels(company_currency);
 						}
 					}
-				}
-			})
+				},
+			});
 		}
 	}
 
 	against_blanket_order(doc, cdt, cdn) {
 		var item = locals[cdt][cdn];
-		if(!item.against_blanket_order) {
+		if (!item.against_blanket_order) {
 			frappe.model.set_value(this.frm.doctype + " Item", item.name, "blanket_order", null);
-			frappe.model.set_value(this.frm.doctype + " Item", item.name, "blanket_order_rate", 0.00);
+			frappe.model.set_value(this.frm.doctype + " Item", item.name, "blanket_order_rate", 0.0);
 		}
 	}
 
 	blanket_order(doc, cdt, cdn) {
 		var me = this;
 		var item = locals[cdt][cdn];
-		if (item.blanket_order && (item.parenttype=="Sales Order" || item.parenttype=="Purchase Order")) {
+		if (item.blanket_order && (item.parenttype == "Sales Order" || item.parenttype == "Purchase Order")) {
 			frappe.call({
 				method: "erpnext.stock.get_item_details.get_blanket_order_details",
 				args: {
-					ctx:{
+					ctx: {
 						item_code: item.item_code,
 						customer: doc.customer,
 						supplier: doc.supplier,
 						company: doc.company,
 						transaction_date: doc.transaction_date,
-						blanket_order: item.blanket_order
-					}
+						blanket_order: item.blanket_order,
+					},
 				},
-				callback: function(r) {
+				callback: function (r) {
 					if (!r.message) {
 						frappe.throw(__("Invalid Blanket Order for the selected Customer and Item"));
 					} else {
 						frappe.run_serially([
-							() => frappe.model.set_value(cdt, cdn, "blanket_order_rate", r.message.blanket_order_rate),
-							() => me.frm.script_manager.trigger("price_list_rate", cdt, cdn)
+							() =>
+								frappe.model.set_value(
+									cdt,
+									cdn,
+									"blanket_order_rate",
+									r.message.blanket_order_rate
+								),
+							() => me.frm.script_manager.trigger("price_list_rate", cdt, cdn),
 						]);
 					}
-				}
-			})
+				},
+			});
 		}
 	}
 
 	set_reserve_warehouse() {
-		this.autofill_warehouse(this.frm.doc.supplied_items, "reserve_warehouse", this.frm.doc.set_reserve_warehouse);
+		this.autofill_warehouse(
+			this.frm.doc.supplied_items,
+			"reserve_warehouse",
+			this.frm.doc.set_reserve_warehouse
+		);
 	}
 
 	set_warehouse() {
@@ -2725,7 +3071,7 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 	autofill_warehouse(child_table, warehouse_field, warehouse) {
 		if (warehouse && child_table && child_table.length) {
 			let doctype = child_table[0].doctype;
-			$.each(child_table || [], function(i, item) {
+			$.each(child_table || [], function (i, item) {
 				frappe.model.set_value(doctype, item.name, warehouse_field, warehouse);
 			});
 		}
@@ -2736,11 +3082,11 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 			// reset pricing rules if coupon code is set or is unset
 			const _ignore_pricing_rule = this.frm.doc.ignore_pricing_rule;
 			return frappe.run_serially([
-				() => this.frm.doc.ignore_pricing_rule=1,
-				() => this.frm.trigger('ignore_pricing_rule'),
-				() => this.frm.doc.ignore_pricing_rule=_ignore_pricing_rule,
-				() => this.frm.trigger('apply_pricing_rule'),
-				() => this.frm._last_coupon_code = this.frm.doc.coupon_code
+				() => (this.frm.doc.ignore_pricing_rule = 1),
+				() => this.frm.trigger("ignore_pricing_rule"),
+				() => (this.frm.doc.ignore_pricing_rule = _ignore_pricing_rule),
+				() => this.frm.trigger("apply_pricing_rule"),
+				() => (this.frm._last_coupon_code = this.frm.doc.coupon_code),
 			]);
 		}
 	}
@@ -2766,13 +3112,17 @@ erpnext.show_serial_batch_selector = function (frm, item_row, callback, on_close
 				warehouse = item_row.s_warehouse;
 			}
 
-			if (in_list([
-					"Material Transfer",
-					"Send to Subcontractor",
-					"Material Issue",
-					"Material Consumption for Manufacture",
-					"Material Transfer for Manufacture"
-				], frm.doc.purpose)
+			if (
+				in_list(
+					[
+						"Material Transfer",
+						"Send to Subcontractor",
+						"Material Issue",
+						"Material Consumption for Manufacture",
+						"Material Transfer for Manufacture",
+					],
+					frm.doc.purpose
+				)
 			) {
 				warehouse_field = "s_warehouse";
 			} else {
@@ -2801,9 +3151,9 @@ erpnext.show_serial_batch_selector = function (frm, item_row, callback, on_close
 	new erpnext.SerialBatchPackageSelector(frm, item_row, (r) => {
 		if (r) {
 			let update_values = {
-				"serial_and_batch_bundle": r.name,
-				"qty": Math.abs(r.total_qty)
-			}
+				serial_and_batch_bundle: r.name,
+				qty: Math.abs(r.total_qty),
+			};
 
 			if (r.warehouse) {
 				update_values[warehouse_field] = r.warehouse;
@@ -2812,11 +3162,11 @@ erpnext.show_serial_batch_selector = function (frm, item_row, callback, on_close
 			frappe.model.set_value(item_row.doctype, item_row.name, update_values);
 		}
 	});
-}
+};
 
-erpnext.apply_putaway_rule = (frm, purpose=null) => {
+erpnext.apply_putaway_rule = (frm, purpose = null) => {
 	if (!frm.doc.company) {
-		frappe.throw({message: __("Please select a Company first."), title: __("Mandatory")});
+		frappe.throw({ message: __("Please select a Company first."), title: __("Mandatory") });
 	}
 	if (!frm.doc.items.length) return;
 
@@ -2827,13 +3177,13 @@ erpnext.apply_putaway_rule = (frm, purpose=null) => {
 			items: frm.doc.items,
 			company: frm.doc.company,
 			sync: true,
-			purpose: purpose
+			purpose: purpose,
 		},
 		callback: (result) => {
 			if (!result.exc && result.message) {
 				frm.clear_table("items");
 
-				let items =  result.message;
+				let items = result.message;
 				items.forEach((row) => {
 					delete row["name"]; // dont overwrite name from server side
 					let child = frm.add_child("items");
@@ -2842,7 +3192,7 @@ erpnext.apply_putaway_rule = (frm, purpose=null) => {
 				});
 				frm.get_field("items").grid.refresh();
 			}
-		}
+		},
 	});
 };
 
@@ -2850,7 +3200,9 @@ erpnext.set_unit_price_items_note = (frm) => {
 	if (frm.doc.has_unit_price_items && !frm.is_new()) {
 		// Remove existing note
 		const $note = $(frm.layout.wrapper.find(".unit-price-items-note"));
-		if ($note.length) { $note.parent().remove(); }
+		if ($note.length) {
+			$note.parent().remove();
+		}
 
 		frm.layout.show_message(
 			`<div class="unit-price-items-note">


### PR DESCRIPTION
Controllers were excluded from prettier because they used to include jinja template sytax. This is gone since https://github.com/frappe/erpnext/pull/36147, so we can continue in style.

`erpnext/templates/pages/order.js` was excluded from prettier, but no longer exists, so I removed that as well.

@coderabbitai ignore
