### PR TITLE
fix: hide is_cumulative for apply_on is set to Transaction

### DIFF
--- a/erpnext/accounts/doctype/pricing_rule/pricing_rule.json
+++ b/erpnext/accounts/doctype/pricing_rule/pricing_rule.json
@@ -174,6 +174,7 @@
   },
   {
    "default": "0",
+   "depends_on": "eval:doc.apply_on != 'Transaction'",
    "fieldname": "is_cumulative",
    "fieldtype": "Check",
    "label": "Is Cumulative"
@@ -656,7 +657,7 @@
  "icon": "fa fa-gift",
  "idx": 1,
  "links": [],
- "modified": "2025-02-17 18:15:39.824639",
+ "modified": "2025-08-20 11:40:07.096854",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Pricing Rule",

--- a/erpnext/accounts/doctype/promotional_scheme/promotional_scheme.json
+++ b/erpnext/accounts/doctype/promotional_scheme/promotional_scheme.json
@@ -93,12 +93,14 @@
   },
   {
    "default": "0",
+   "depends_on": "eval:doc.apply_on != 'Transaction'",
    "fieldname": "mixed_conditions",
    "fieldtype": "Check",
    "label": "Mixed Conditions"
   },
   {
    "default": "0",
+   "depends_on": "eval:doc.apply_on != 'Transaction'",
    "fieldname": "is_cumulative",
    "fieldtype": "Check",
    "label": "Is Cumulative"
@@ -278,7 +280,7 @@
   }
  ],
  "links": [],
- "modified": "2024-03-27 13:10:22.103686",
+ "modified": "2025-08-20 11:48:23.231081",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Promotional Scheme",


### PR DESCRIPTION
Issue: `is cumulative` functionality is not handled for the `apply_on` type `Transaction`.

Ref: [46472](https://support.frappe.io/helpdesk/tickets/46472)

Before:

<img width="1878" height="588" alt="before_depends_on" src="https://github.com/user-attachments/assets/71d92c12-5b2e-4862-aaa3-b19f51b4e184" />

After:

<img width="1876" height="598" alt="after_depends_on" src="https://github.com/user-attachments/assets/9abe2bfa-3a2a-4e9d-8c89-59cd9079acbc" />

Backport Needed: Verion-15

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pricing Rule: “Is Cumulative” now only appears when “Apply On” is not set to “Transaction,” streamlining the form.
  * Promotional Scheme: “Mixed Conditions” and “Is Cumulative” are now conditionally shown only when “Apply On” is not “Transaction,” reducing visual clutter and guiding correct configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->