### PR TITLE
fix: convert NaN to numerical

### DIFF
--- a/erpnext/public/js/bank_reconciliation_tool/number_card.js
+++ b/erpnext/public/js/bank_reconciliation_tool/number_card.js
@@ -26,7 +26,7 @@ erpnext.accounts.bank_reconciliation.NumberCardManager = class NumberCardManager
 				currency: this.currency,
 			},
 			{
-				value: this.bank_statement_closing_balance - this.cleared_balance,
+				value: flt(this.bank_statement_closing_balance) - flt(this.cleared_balance),
 				label: __("Difference"),
 				datatype: "Currency",
 				currency: this.currency,


### PR DESCRIPTION
### before

<img width="2251" height="358" alt="image" src="https://github.com/user-attachments/assets/84541c50-9411-49b0-a066-3fa48f20e386" />

### after

<img width="2244" height="349" alt="image" src="https://github.com/user-attachments/assets/50181cf6-0919-4adc-90df-7be51fe372fd" />

backport version-15-hotfix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the calculation of the “Difference” metric in the Bank Reconciliation number card to ensure accurate values.
  * Ensures the displayed amount reflects the correct numeric computation across varying input formats.
  * Visual presentation and labels remain unchanged.
  * Status color behavior for the “Difference” card is unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->