### PR TITLE
fix: child item picker picking all items when creating PI from PR

### DIFF
--- a/erpnext/buying/doctype/purchase_order/purchase_order.js
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.js
@@ -627,6 +627,9 @@ erpnext.buying.PurchaseOrderController = class PurchaseOrderController extends (
 						docstatus: 1,
 						status: ["not in", ["Stopped", "Expired"]],
 					},
+					allow_child_item_selection: true,
+					child_fieldname: "items",
+					child_columns: ["item_code", "item_name", "qty", "rate", "amount"],
 				});
 			},
 			__("Get Items From")

--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
@@ -1421,8 +1421,8 @@ def make_purchase_invoice(source_name, target_doc=None, args=None):
 				"postprocess": update_item,
 				"filter": lambda d: (
 					get_pending_qty(d)[0] <= 0 if not doc.get("is_return") else get_pending_qty(d)[0] > 0
-				)
-				and select_item(d),
+				),
+				"condition": select_item,
 			},
 			"Purchase Taxes and Charges": {
 				"doctype": "Purchase Taxes and Charges",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * You can now select specific items from a Supplier Quotation when creating a Purchase Order, with a clear item picker showing item code, name, qty, rate, and amount.
  * Supports mapping multiple selected items into the Purchase Order in one step.
  * Taxes and totals are automatically recalculated after item selection.
* Improvements
  * More precise item filtering during document mappings (e.g., to Purchase Invoice), ensuring only chosen and pending-quantity items are included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->