### PR TITLE
feat(payment-reconciliation): add posting date field for debit/credit…

### DIFF
--- a/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py
+++ b/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py
@@ -576,6 +576,7 @@ class PaymentReconciliation(Document):
 				"difference_amount": flt(row.get("difference_amount")),
 				"difference_account": row.get("difference_account"),
 				"difference_posting_date": row.get("gain_loss_posting_date"),
+				"debit_or_credit_note_posting_date": row.get("debit_or_credit_note_posting_date"),
 				"cost_center": row.get("cost_center"),
 			}
 		)
@@ -765,7 +766,7 @@ def reconcile_dr_cr_note(dr_cr_notes, company, active_dimensions=None):
 			{
 				"doctype": "Journal Entry",
 				"voucher_type": voucher_type,
-				"posting_date": today(),
+				"posting_date": inv.get("debit_or_credit_note_posting_date") or today(),
 				"company": company,
 				"multi_currency": 1 if inv.currency != company_currency else 0,
 				"accounts": [

--- a/erpnext/accounts/doctype/payment_reconciliation_allocation/payment_reconciliation_allocation.json
+++ b/erpnext/accounts/doctype/payment_reconciliation_allocation/payment_reconciliation_allocation.json
@@ -20,6 +20,7 @@
   "section_break_5",
   "difference_amount",
   "gain_loss_posting_date",
+  "debit_or_credit_note_posting_date",
   "column_break_7",
   "difference_account",
   "exchange_rate",
@@ -168,17 +169,23 @@
   {
    "fieldname": "dimension_col_break",
    "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "debit_or_credit_note_posting_date",
+   "fieldtype": "Date",
+   "label": "Debit / Credit Note Posting Date"
   }
  ],
  "is_virtual": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-03-27 13:10:10.704417",
+ "modified": "2025-08-20 19:12:50.406769",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Payment Reconciliation Allocation",
  "owner": "Administrator",
  "permissions": [],
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],

--- a/erpnext/accounts/doctype/payment_reconciliation_allocation/payment_reconciliation_allocation.py
+++ b/erpnext/accounts/doctype/payment_reconciliation_allocation/payment_reconciliation_allocation.py
@@ -18,6 +18,7 @@ class PaymentReconciliationAllocation(Document):
 		amount: DF.Currency
 		cost_center: DF.Link | None
 		currency: DF.Link | None
+		debit_or_credit_note_posting_date: DF.Date | None
 		difference_account: DF.Link | None
 		difference_amount: DF.Currency
 		exchange_rate: DF.Float


### PR DESCRIPTION
Issue: Auto-created JV posting date set as today()

Ref: [46821](https://support.frappe.io/helpdesk/tickets/46821)

<img width="1158" height="661" alt="image" src="https://github.com/user-attachments/assets/b403cd44-047b-4e5e-a08f-37ac17668dd0" />


**Backport Needed: Version-15**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added “Debit / Credit Note Posting Date” to Payment Reconciliation Allocation (visible after Gain/Loss Posting Date).
  * During payment reconciliation, debit/credit note entries now post on the specified date; if not set, they default to today’s date.

* **Chores**
  * Updated underlying configuration to support the new field without changing existing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->