### PR TITLE
fix: show create purchase receipt button in purchase invoice only when update stock is not checked

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js
@@ -656,7 +656,7 @@ frappe.ui.form.on("Purchase Invoice", {
 	},
 
 	add_custom_buttons: function (frm) {
-		if (frm.doc.docstatus == 1 && frm.doc.per_received < 100) {
+		if (frm.doc.docstatus == 1 && frm.doc.per_received < 100 && frm.doc.update_stock == 0) {
 			frm.add_custom_button(
 				__("Purchase Receipt"),
 				() => {


### PR DESCRIPTION
Closes #49253

> Please provide enough information so that others can review your pull request:
- `Create Purchase Receipt` button remains visible after submitting a Purchase Invoice with `Update Stock` enabled.
- The button is unnecessary since the stock is updated automatically in this case and also Purchase Receipt is not required
- If a Purchase Receipt is created from this point,  it updates stocks, and the button stays visible, creating an invalid loop.

> Explain the **details** for making this change. What existing problem does the pull request solve?
- As `Purchase Receipt` is not required when `Purchase Invoice` is submitted with update stock
- 
- The `Create Purchase Receipt` button is only shown when `Update Stock` is unchecked.

> Screenshots/GIFs
 When `Update Stock` is checked
<img width="1632" height="759" alt="image" src="https://github.com/user-attachments/assets/821852c2-4189-4991-8002-26ed7cd02255" />
When `Update Stock` is unchecked
<img width="1746" height="787" alt="image" src="https://github.com/user-attachments/assets/ae7ee5d9-6057-402d-84d4-9f8d2eb64dfc" />

**The same can be fixed in version-15**




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * "Create Purchase Receipt" button on Purchase Invoice now only appears when the invoice is submitted, items aren’t fully received, and stock update is disabled; existing "View Purchase Receipt" and "Landed Cost Voucher" actions unchanged.
* **Enhancements**
  * Landed Cost Voucher now displays the Total Vendor Invoices Cost labeled in the company's default currency for clearer financial context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->