### PR TITLE
feat: optional fixed outgoing email for RfQ

### DIFF
--- a/erpnext/buying/doctype/buying_settings/buying_settings.json
+++ b/erpnext/buying/doctype/buying_settings/buying_settings.json
@@ -268,6 +268,7 @@
    "fieldname": "fixed_email",
    "fieldtype": "Link",
    "label": "Fixed Outgoing Email Account",
+   "link_filters": "[[\"Email Account\",\"enable_outgoing\",\"=\",1]]",
    "options": "Email Account"
   }
  ],
@@ -277,7 +278,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-08-20 21:15:21.401305",
+ "modified": "2025-08-20 22:13:38.506889",
  "modified_by": "Administrator",
  "module": "Buying",
  "name": "Buying Settings",

--- a/erpnext/buying/doctype/buying_settings/buying_settings.json
+++ b/erpnext/buying/doctype/buying_settings/buying_settings.json
@@ -39,7 +39,9 @@
   "section_break_xcug",
   "auto_create_subcontracting_order",
   "column_break_izrr",
-  "auto_create_purchase_receipt"
+  "auto_create_purchase_receipt",
+  "request_for_quotation_tab",
+  "fixed_email"
  ],
  "fields": [
   {
@@ -255,6 +257,18 @@
    "fieldname": "set_valuation_rate_for_rejected_materials",
    "fieldtype": "Check",
    "label": "Set Valuation Rate for Rejected Materials"
+  },
+  {
+   "fieldname": "request_for_quotation_tab",
+   "fieldtype": "Tab Break",
+   "label": "Request for Quotation"
+  },
+  {
+   "description": "If set, the system does not use the user's Email or the standard outgoing Email account for sending request for quotations.",
+   "fieldname": "fixed_email",
+   "fieldtype": "Link",
+   "label": "Fixed Outgoing Email Account",
+   "options": "Email Account"
   }
  ],
  "grid_page_length": 50,
@@ -263,7 +277,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-05-16 15:56:38.321369",
+ "modified": "2025-08-20 21:15:21.401305",
  "modified_by": "Administrator",
  "module": "Buying",
  "name": "Buying Settings",

--- a/erpnext/buying/doctype/buying_settings/buying_settings.py
+++ b/erpnext/buying/doctype/buying_settings/buying_settings.py
@@ -23,13 +23,12 @@ class BuyingSettings(Document):
 		allow_zero_qty_in_supplier_quotation: DF.Check
 		auto_create_purchase_receipt: DF.Check
 		auto_create_subcontracting_order: DF.Check
-		backflush_raw_materials_of_subcontract_based_on: DF.Literal[
-			"BOM", "Material Transferred for Subcontract"
-		]
+		backflush_raw_materials_of_subcontract_based_on: DF.Literal["BOM", "Material Transferred for Subcontract"]
 		bill_for_rejected_quantity_in_purchase_invoice: DF.Check
 		blanket_order_allowance: DF.Float
 		buying_price_list: DF.Link | None
 		disable_last_purchase_rate: DF.Check
+		fixed_email: DF.Link | None
 		maintain_same_rate: DF.Check
 		maintain_same_rate_action: DF.Literal["Stop", "Warn"]
 		over_transfer_allowance: DF.Float

--- a/erpnext/buying/doctype/buying_settings/buying_settings.py
+++ b/erpnext/buying/doctype/buying_settings/buying_settings.py
@@ -23,7 +23,9 @@ class BuyingSettings(Document):
 		allow_zero_qty_in_supplier_quotation: DF.Check
 		auto_create_purchase_receipt: DF.Check
 		auto_create_subcontracting_order: DF.Check
-		backflush_raw_materials_of_subcontract_based_on: DF.Literal["BOM", "Material Transferred for Subcontract"]
+		backflush_raw_materials_of_subcontract_based_on: DF.Literal[
+			"BOM", "Material Transferred for Subcontract"
+		]
 		bill_for_rejected_quantity_in_purchase_invoice: DF.Check
 		blanket_order_allowance: DF.Float
 		buying_price_list: DF.Link | None

--- a/erpnext/buying/doctype/buying_settings/buying_settings.py
+++ b/erpnext/buying/doctype/buying_settings/buying_settings.py
@@ -23,9 +23,7 @@ class BuyingSettings(Document):
 		allow_zero_qty_in_supplier_quotation: DF.Check
 		auto_create_purchase_receipt: DF.Check
 		auto_create_subcontracting_order: DF.Check
-		backflush_raw_materials_of_subcontract_based_on: DF.Literal[
-			"BOM", "Material Transferred for Subcontract"
-		]
+		backflush_raw_materials_of_subcontract_based_on: DF.Literal["BOM", "Material Transferred for Subcontract"]
 		bill_for_rejected_quantity_in_purchase_invoice: DF.Check
 		blanket_order_allowance: DF.Float
 		buying_price_list: DF.Link | None

--- a/erpnext/buying/doctype/request_for_quotation/request_for_quotation.py
+++ b/erpnext/buying/doctype/request_for_quotation/request_for_quotation.py
@@ -289,7 +289,11 @@ class RequestforQuotation(BuyingController):
 		email_template = frappe.get_doc("Email Template", self.email_template)
 		message = frappe.render_template(email_template.response_, doc_args)
 		subject = frappe.render_template(email_template.subject, doc_args)
-		sender = frappe.session.user not in STANDARD_USERS and frappe.session.user or None
+		fixed_procurement_email = frappe.db.get_single_value("Buying Settings", "fixed_email")
+		if fixed_procurement_email:
+			sender = frappe.db.get_value("Email Account", fixed_procurement_email, "email_id")
+		else:
+			sender = frappe.session.user not in STANDARD_USERS and frappe.session.user or None
 
 		if preview:
 			return {"message": message, "subject": subject}


### PR DESCRIPTION
This PR introduces the option to send Request for Quotations (RfQs) using a fixed email address.

Added functionality to configure a static sender email address for all RfQ communications. The option is in "Buying Settings". If left blank, no changes are made to the existing workflow.

This allows organizations to use functional/shared mailboxes (e.g., procurement@frappe.io) instead of individual user accounts.

Please backport to v15

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a “Request for Quotation” tab in Buying Settings for easier configuration.
  - Introduced a “Fixed Outgoing Email Account” option to control the sender address for RFQ emails.
  - When configured, RFQ emails will be sent from the selected email account, ensuring consistent outbound communication.
  - If not configured, the system continues using the existing behavior (current user or the standard outgoing email account).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->