### PR TITLE
feat: horizontal report view

### DIFF
--- a/erpnext/accounts/report/balance_sheet/balance_sheet.js
+++ b/erpnext/accounts/report/balance_sheet/balance_sheet.js
@@ -25,6 +25,10 @@ frappe.query_reports["Balance Sheet"]["filters"].push({
 	default: ["Vertical"],
 	reqd: 1,
 	depends_on: "eval:doc.selected_view == 'Report'",
+	on_change: function () {
+		frappe.query_report.export_dialog = undefined;
+		frappe.query_report.refresh();
+	},
 });
 
 frappe.query_reports["Balance Sheet"]["filters"].push({

--- a/erpnext/accounts/report/balance_sheet/balance_sheet.js
+++ b/erpnext/accounts/report/balance_sheet/balance_sheet.js
@@ -15,6 +15,22 @@ frappe.query_reports["Balance Sheet"]["filters"].push({
 	],
 	default: "Report",
 	reqd: 1,
+
+	on_change: function () {
+		let filter_based_on = frappe.query_reports.get_filter_value("selected_view");
+		frappe.query_reports.toggle_filter_display("report_view", filter_based_on === "Report");
+		frappe.query_reports.refresh();
+	},
+});
+
+frappe.query_reports["Balance Sheet"]["filters"].push({
+	fieldname: "report_view",
+	label: __("Report View"),
+	fieldtype: "Select",
+	options: ["Horizontal", "Vertical"],
+	default: ["Vertical"],
+	reqd: 1,
+	depends_on: "eval:doc.selected_view == 'Report'",
 });
 
 frappe.query_reports["Balance Sheet"]["filters"].push({

--- a/erpnext/accounts/report/balance_sheet/balance_sheet.js
+++ b/erpnext/accounts/report/balance_sheet/balance_sheet.js
@@ -15,12 +15,6 @@ frappe.query_reports["Balance Sheet"]["filters"].push({
 	],
 	default: "Report",
 	reqd: 1,
-
-	on_change: function () {
-		let filter_based_on = frappe.query_reports.get_filter_value("selected_view");
-		frappe.query_reports.toggle_filter_display("report_view", filter_based_on === "Report");
-		frappe.query_reports.refresh();
-	},
 });
 
 frappe.query_reports["Balance Sheet"]["filters"].push({

--- a/erpnext/accounts/report/balance_sheet/balance_sheet.py
+++ b/erpnext/accounts/report/balance_sheet/balance_sheet.py
@@ -199,7 +199,8 @@ def prepare_horizontal_balance_sheet(
 	filters,
 	currency,
 ):
-	sections_data = {"asset": asset or [], "liability": liability or [], "equity": equity or []}
+	merged_liability = (liability or []) + (equity or [])
+	sections_data = {"asset": asset or [], "liability": merged_liability, "equity": []}
 
 	formatted_data = get_formatted_data(sections_data, period_list)
 	extra_rows = []
@@ -234,7 +235,7 @@ def prepare_horizontal_balance_sheet(
 		period_list,
 		filters.accumulated_values,
 		filters.company,
-		sections=("asset", "liability", "equity"),
+		sections=("asset", "liability"),
 	)
 
 	return formatted_data, columns

--- a/erpnext/accounts/report/balance_sheet/balance_sheet.py
+++ b/erpnext/accounts/report/balance_sheet/balance_sheet.py
@@ -8,11 +8,11 @@ from frappe.utils import cint, flt
 
 from erpnext.accounts.report.financial_statements import (
 	compute_growth_view_data,
-	formated_data,
 	get_all_columns,
 	get_columns,
 	get_data,
 	get_filtered_list_for_consolidated_report,
+	get_formatted_data,
 	get_period_list,
 )
 
@@ -72,7 +72,7 @@ def execute(filters=None):
 	asset = asset or []
 	liability = liability or []
 	equity = equity or []
-	new_data = formated_data({"asset": asset, "liability": liability, "equity": equity}, period_list)
+	new_data = get_formatted_data({"asset": asset, "liability": liability, "equity": equity}, period_list)
 	data = []
 	data.extend(asset or [])
 	data.extend(liability or [])

--- a/erpnext/accounts/report/balance_sheet/balance_sheet.py
+++ b/erpnext/accounts/report/balance_sheet/balance_sheet.py
@@ -8,6 +8,8 @@ from frappe.utils import cint, flt
 
 from erpnext.accounts.report.financial_statements import (
 	compute_growth_view_data,
+	formated_data,
+	get_all_columns,
 	get_columns,
 	get_data,
 	get_filtered_list_for_consolidated_report,
@@ -67,7 +69,10 @@ def execute(filters=None):
 	)
 
 	message, opening_balance = check_opening_balance(asset, liability, equity)
-
+	asset = asset or []
+	liability = liability or []
+	equity = equity or []
+	new_data = formated_data({"asset": asset, "liability": liability, "equity": equity}, period_list)
 	data = []
 	data.extend(asset or [])
 	data.extend(liability or [])
@@ -92,9 +97,17 @@ def execute(filters=None):
 	if total_credit:
 		data.append(total_credit)
 
-	columns = get_columns(
-		filters.periodicity, period_list, filters.accumulated_values, company=filters.company
-	)
+	if filters.report_view == "Horizontal":
+		columns = get_all_columns(
+			filters.periodicity,
+			period_list,
+			filters.accumulated_values,
+			filters.company,
+			sections=("asset", "liability", "equity"),
+		)
+		data = new_data
+	else:
+		columns = get_columns(filters.periodicity, period_list, filters.accumulated_values, filters.company)
 
 	chart = get_chart_data(filters, columns, asset, liability, equity, currency)
 

--- a/erpnext/accounts/report/balance_sheet/balance_sheet.py
+++ b/erpnext/accounts/report/balance_sheet/balance_sheet.py
@@ -69,10 +69,6 @@ def execute(filters=None):
 	)
 
 	message, opening_balance = check_opening_balance(asset, liability, equity)
-	asset = asset or []
-	liability = liability or []
-	equity = equity or []
-	new_data = get_formatted_data({"asset": asset, "liability": liability, "equity": equity}, period_list)
 	data = []
 	data.extend(asset or [])
 	data.extend(liability or [])
@@ -98,14 +94,17 @@ def execute(filters=None):
 		data.append(total_credit)
 
 	if filters.report_view == "Horizontal":
-		columns = get_all_columns(
-			filters.periodicity,
+		data, columns = prepare_horizontal_balance_sheet(
+			asset,
+			liability,
+			equity,
+			provisional_profit_loss,
+			total_credit,
+			opening_balance,
 			period_list,
-			filters.accumulated_values,
-			filters.company,
-			sections=("asset", "liability", "equity"),
+			filters,
+			currency,
 		)
-		data = new_data
 	else:
 		columns = get_columns(filters.periodicity, period_list, filters.accumulated_values, filters.company)
 
@@ -187,6 +186,79 @@ def check_opening_balance(asset, liability, equity):
 	if opening_balance:
 		return _("Previous Financial Year is not closed"), opening_balance
 	return None, None
+
+
+def prepare_horizontal_balance_sheet(
+	asset,
+	liability,
+	equity,
+	provisional_profit_loss,
+	total_credit,
+	opening_balance,
+	period_list,
+	filters,
+	currency,
+):
+	sections_data = {"asset": asset or [], "liability": liability or [], "equity": equity or []}
+
+	formatted_data = get_formatted_data(sections_data, period_list)
+	extra_rows = []
+
+	if opening_balance and round(opening_balance, 2) != 0:
+		extra_rows.append(
+			create_asset_row(
+				_("Unclosed Fiscal Years Profit / Loss (Credit)"), opening_balance, period_list, currency
+			)
+		)
+		if provisional_profit_loss:
+			for key in provisional_profit_loss.keys():
+				if key not in ["account", "total", "warn_if_negative", "currency"]:
+					provisional_profit_loss[key] -= opening_balance
+
+	if provisional_profit_loss:
+		extra_rows.append(
+			create_asset_row(
+				_("Provisional Profit / Loss"), provisional_profit_loss.get("total"), period_list, currency
+			)
+		)
+
+	if total_credit:
+		extra_rows.append(
+			create_asset_row(_("Total Credit"), total_credit.get("total"), period_list, currency)
+		)
+
+	formatted_data.extend(extra_rows)
+
+	columns = get_all_columns(
+		filters.periodicity,
+		period_list,
+		filters.accumulated_values,
+		filters.company,
+		sections=("asset", "liability", "equity"),
+	)
+
+	return formatted_data, columns
+
+
+def create_asset_row(label, amount, period_list, currency):
+	row = frappe._dict({})
+	row["asset_account"] = label
+	row["asset_currency"] = currency
+	row["asset_indent"] = ""
+
+	if period_list:
+		first_period = period_list[0].key
+		row[f"asset_{first_period}"] = amount if amount is not None else ""
+		for period in period_list[1:]:
+			row[f"asset_{period.key}"] = ""
+
+	for section in ["liability", "equity"]:
+		row[f"{section}_account"] = ""
+		row[f"{section}_currency"] = ""
+		row[f"{section}_indent"] = ""
+		for period in period_list:
+			row[f"{section}_{period.key}"] = ""
+	return row
 
 
 def get_report_summary(

--- a/erpnext/accounts/report/financial_statements.py
+++ b/erpnext/accounts/report/financial_statements.py
@@ -706,6 +706,88 @@ def get_columns(periodicity, period_list, accumulated_values=1, company=None, ca
 	return columns
 
 
+def get_all_columns(
+	periodicity, period_list, accumulated_values=1, company=None, sections=("expense", "income")
+):
+	columns = []
+
+	for section in sections:
+		columns.append(
+			{
+				"fieldname": f"{section}_account",
+				"label": _(section.capitalize()),
+				"fieldtype": "Link",
+				"options": "Account",
+				"width": 300,
+			}
+		)
+
+		if company:
+			columns.append(
+				{
+					"fieldname": f"{section}_currency",
+					"label": _("Currency"),
+					"fieldtype": "Link",
+					"options": "Currency",
+					"hidden": 1,
+				}
+			)
+
+		for period in period_list:
+			key_name = f"{section}_{cstr(period.key)}"
+			columns.append(
+				{
+					"fieldname": key_name,
+					"label": period.label,
+					"fieldtype": "Currency",
+					"options": "currency",
+					"width": 150,
+				}
+			)
+
+	if periodicity != "Yearly" and not accumulated_values:
+		columns.append(
+			{
+				"fieldname": "total",
+				"label": _("Total"),
+				"fieldtype": "Currency",
+				"width": 150,
+				"options": "currency",
+			}
+		)
+
+	return columns
+
+
+def formated_data(sections_data, period_list):
+	new_data = []
+	max_len = max(len(v) for v in sections_data.values())
+
+	for i in range(max_len):
+		row = {}
+		for section, data in sections_data.items():
+			if i < len(data):
+				indent_level = cint(data[i].get("indent", 0))
+				row.update(create_section_data(section, period_list, data[i], indent_level))
+			else:
+				row.update(create_section_data(section, period_list, None, 0))
+		new_data.append(row)
+
+	return new_data
+
+
+def create_section_data(section, period_list, record, indent_level):
+	row = {}
+	for period in period_list:
+		key_name = f"{section}_{cstr(period.key)}"
+		row[key_name] = record.get(period.key) if record else ""
+
+	row[f"{section}_account"] = record["account"] if record else ""
+	row[f"{section}_currency"] = record["currency"] if record else ""
+	row[f"{section}_indent"] = indent_level
+	return row
+
+
 def get_filtered_list_for_consolidated_report(filters, period_list):
 	filtered_summary_list = []
 	for period in period_list:

--- a/erpnext/accounts/report/financial_statements.py
+++ b/erpnext/accounts/report/financial_statements.py
@@ -759,7 +759,7 @@ def get_all_columns(
 	return columns
 
 
-def formated_data(sections_data, period_list):
+def get_formatted_data(sections_data, period_list):
 	new_data = []
 	max_len = max(len(v) for v in sections_data.values())
 

--- a/erpnext/accounts/report/profit_and_loss_statement/profit_and_loss_statement.js
+++ b/erpnext/accounts/report/profit_and_loss_statement/profit_and_loss_statement.js
@@ -16,8 +16,22 @@ frappe.query_reports["Profit and Loss Statement"]["filters"].push({
 	],
 	default: "Report",
 	reqd: 1,
+	on_change: function () {
+		let filter_based_on = frappe.query_reports.get_filter_value("selected_view");
+		frappe.query_reports.toggle_filter_display("report_view", filter_based_on === "Report");
+		frappe.query_reports.refresh();
+	},
 });
 
+frappe.query_reports["Profit and Loss Statement"]["filters"].push({
+	fieldname: "report_view",
+	label: __("Report View"),
+	fieldtype: "Select",
+	options: ["Horizontal", "Vertical"],
+	default: ["Vertical"],
+	reqd: 1,
+	depends_on: "eval:doc.selected_view == 'Report'",
+});
 frappe.query_reports["Profit and Loss Statement"]["filters"].push({
 	fieldname: "accumulated_values",
 	label: __("Accumulated Values"),

--- a/erpnext/accounts/report/profit_and_loss_statement/profit_and_loss_statement.js
+++ b/erpnext/accounts/report/profit_and_loss_statement/profit_and_loss_statement.js
@@ -26,6 +26,11 @@ frappe.query_reports["Profit and Loss Statement"]["filters"].push({
 	default: ["Vertical"],
 	reqd: 1,
 	depends_on: "eval:doc.selected_view == 'Report'",
+	on_change: function () {
+		frappe.query_report.export_dialog = undefined;
+
+		frappe.query_report.refresh();
+	},
 });
 frappe.query_reports["Profit and Loss Statement"]["filters"].push({
 	fieldname: "accumulated_values",

--- a/erpnext/accounts/report/profit_and_loss_statement/profit_and_loss_statement.js
+++ b/erpnext/accounts/report/profit_and_loss_statement/profit_and_loss_statement.js
@@ -16,11 +16,6 @@ frappe.query_reports["Profit and Loss Statement"]["filters"].push({
 	],
 	default: "Report",
 	reqd: 1,
-	on_change: function () {
-		let filter_based_on = frappe.query_reports.get_filter_value("selected_view");
-		frappe.query_reports.toggle_filter_display("report_view", filter_based_on === "Report");
-		frappe.query_reports.refresh();
-	},
 });
 
 frappe.query_reports["Profit and Loss Statement"]["filters"].push({

--- a/erpnext/accounts/report/profit_and_loss_statement/profit_and_loss_statement.py
+++ b/erpnext/accounts/report/profit_and_loss_statement/profit_and_loss_statement.py
@@ -4,16 +4,16 @@
 
 import frappe
 from frappe import _
-from frappe.utils import flt
+from frappe.utils import cstr, flt
 
 from erpnext.accounts.report.financial_statements import (
 	compute_growth_view_data,
 	compute_margin_view_data,
-	formated_data,
 	get_all_columns,
 	get_columns,
 	get_data,
 	get_filtered_list_for_consolidated_report,
+	get_formatted_data,
 	get_period_list,
 )
 
@@ -52,7 +52,6 @@ def execute(filters=None):
 	net_profit_loss = get_net_profit_loss(
 		income, expense, period_list, filters.company, filters.presentation_currency
 	)
-	new_data = formated_data({"income": income, "expense": expense}, period_list)
 	data = []
 	data.extend(income or [])
 	data.extend(expense or [])
@@ -60,14 +59,7 @@ def execute(filters=None):
 		data.append(net_profit_loss)
 
 	if filters.report_view == "Horizontal":
-		columns = get_all_columns(
-			filters.periodicity,
-			period_list,
-			filters.accumulated_values,
-			filters.company,
-			sections=("expense", "income"),
-		)
-		data = new_data
+		data, columns = prepare_horizontal_view(income, expense, net_profit_loss, period_list, filters)
 	else:
 		columns = get_columns(filters.periodicity, period_list, filters.accumulated_values, filters.company)
 	currency = filters.presentation_currency or frappe.get_cached_value(
@@ -86,6 +78,34 @@ def execute(filters=None):
 		compute_margin_view_data(data, period_list, filters.accumulated_values)
 
 	return columns, data, None, chart, report_summary, primitive_summary
+
+
+def prepare_horizontal_view(income, expense, net_profit_loss, period_list, filters):
+	sections_data = {"expense": expense or [], "income": income or []}
+	formatted_data = get_formatted_data(sections_data, period_list)
+
+	if net_profit_loss:
+		net_row = frappe._dict({})
+		net_row["income_account"] = net_profit_loss["account"]
+		net_row["expense_account"] = net_profit_loss["account"]
+		net_row["income_indent"] = ""
+		net_row["expense_indent"] = ""
+
+		for period in period_list:
+			net_row[f"income_{period.key}"] = net_profit_loss[period.key]
+			net_row[f"expense_{period.key}"] = net_profit_loss[period.key]
+
+		formatted_data.append(net_row)
+
+	columns = get_all_columns(
+		filters.periodicity,
+		period_list,
+		filters.accumulated_values,
+		filters.company,
+		sections=("expense", "income"),
+	)
+
+	return formatted_data, columns
 
 
 def get_report_summary(

--- a/erpnext/accounts/report/profit_and_loss_statement/profit_and_loss_statement.py
+++ b/erpnext/accounts/report/profit_and_loss_statement/profit_and_loss_statement.py
@@ -9,6 +9,8 @@ from frappe.utils import flt
 from erpnext.accounts.report.financial_statements import (
 	compute_growth_view_data,
 	compute_margin_view_data,
+	formated_data,
+	get_all_columns,
 	get_columns,
 	get_data,
 	get_filtered_list_for_consolidated_report,
@@ -50,15 +52,24 @@ def execute(filters=None):
 	net_profit_loss = get_net_profit_loss(
 		income, expense, period_list, filters.company, filters.presentation_currency
 	)
-
+	new_data = formated_data({"income": income, "expense": expense}, period_list)
 	data = []
 	data.extend(income or [])
 	data.extend(expense or [])
 	if net_profit_loss:
 		data.append(net_profit_loss)
 
-	columns = get_columns(filters.periodicity, period_list, filters.accumulated_values, filters.company)
-
+	if filters.report_view == "Horizontal":
+		columns = get_all_columns(
+			filters.periodicity,
+			period_list,
+			filters.accumulated_values,
+			filters.company,
+			sections=("expense", "income"),
+		)
+		data = new_data
+	else:
+		columns = get_columns(filters.periodicity, period_list, filters.accumulated_values, filters.company)
 	currency = filters.presentation_currency or frappe.get_cached_value(
 		"Company", filters.company, "default_currency"
 	)

--- a/erpnext/public/js/financial_statements.js
+++ b/erpnext/public/js/financial_statements.js
@@ -44,6 +44,71 @@ erpnext.financial_statements = {
 		if (data && column.fieldname == this.name_field) {
 			// first column
 			value = data.section_name || data.account_name || value;
+		}
+		if (frappe.query_report.get_filter_value("report_view") === "Horizontal") {
+			const get_section_from_field = (fieldname) => {
+				if (!fieldname) return null;
+				if (fieldname.endsWith("_account")) return fieldname.slice(0, -"_account".length);
+				if (fieldname.endsWith("_currency")) return fieldname.slice(0, -"_currency".length);
+				const i = fieldname.indexOf("_");
+				return i > 0 ? fieldname.slice(0, i) : null;
+			};
+
+			const section = get_section_from_field(column.fieldname);
+			const indent_field = section ? `${section}_indent` : null;
+			const indent_raw = indent_field ? data[indent_field] : undefined;
+			const indent_level = indent_raw === undefined ? null : parseInt(indent_raw, 10) || 0;
+
+			let $value;
+			let display_value = value;
+
+			if (column.fieldname && column.fieldname.endsWith("_account")) {
+				if (
+					indent_level !== null &&
+					indent_level > 0 &&
+					!(typeof display_value === "string" && display_value.startsWith("&nbsp;"))
+				) {
+					display_value = "&nbsp;".repeat(indent_level * 3) + display_value;
+				}
+				$value = $(`<span>${display_value}</span>`);
+			} else {
+				if (column.fieldtype === "Currency") {
+					const currency =
+						(section && data[`${section}_currency`]) ||
+						data.currency ||
+						frappe.defaults.get_default("currency");
+
+					const raw_value = data[column.fieldname];
+					if (raw_value !== undefined && raw_value !== null && raw_value !== "") {
+						display_value = frappe.format(raw_value, {
+							fieldtype: "Currency",
+							options: currency,
+						});
+					} else {
+						display_value = "";
+					}
+				}
+				$value = $(`<span>${display_value}</span>`);
+			}
+
+			if (indent_level === 0) {
+				if (typeof display_value === "string") {
+					display_value = display_value.replace(/^'(.*)'$/, "$1");
+				}
+				$value = $(`<span style="font-weight: bold;">${display_value}</span>`);
+			}
+
+			const raw_value_for_warn = data[column.fieldname];
+			if (data.warn_if_negative && typeof raw_value_for_warn === "number" && raw_value_for_warn < 0) {
+				$value.addClass("text-danger");
+			}
+
+			value = $value.wrap("<p></p>").parent().html();
+			return value;
+		}
+
+		if (data && column.fieldname == "account") {
+			value = data.account_name || value;
 
 			if (filter && filter?.text && filter?.type == "contains") {
 				if (!value.toLowerCase().includes(filter.text)) {


### PR DESCRIPTION
### Background  
Financial statements like **Profit and Loss** and **Balance Sheet** were difficult to read in their existing vertical layout.  
Users often faced readability issues when comparing figures across multiple periods, especially for reports with many columns.  

### Changes Introduced  
- Added a new **Report View filter** in financial statements.  
- The filter provides two options:  
  - **Vertical View** (existing format)  
  - **Horizontal View** (new format)  
- The **Horizontal View** arranges data in a wider, structured layout, making it easier to compare values across accounts and periods.  
- Improved spacing and detail visibility for better readability.  

### Benefits  
- Users can now easily switch between **Horizontal and Vertical views** without leaving the report.  
- Makes financial statements more flexible and user-friendly.  
- Helps businesses analyze financial data more efficiently.  


https://github.com/user-attachments/assets/baadc653-21fa-4636-b51c-28280d079f99



