### PR TITLE
perf: create Pricing Rule from Customer and Supplier

### DIFF
--- a/erpnext/accounts/doctype/pricing_rule/pricing_rule.py
+++ b/erpnext/accounts/doctype/pricing_rule/pricing_rule.py
@@ -703,17 +703,6 @@ def set_transaction_type(args):
 
 
 @frappe.whitelist()
-def make_pricing_rule(doctype, docname):
-	doc = frappe.new_doc("Pricing Rule")
-	doc.applicable_for = doctype
-	doc.set(frappe.scrub(doctype), docname)
-	doc.selling = 1 if doctype == "Customer" else 0
-	doc.buying = 1 if doctype == "Supplier" else 0
-
-	return doc
-
-
-@frappe.whitelist()
 @frappe.validate_and_sanitize_search_inputs
 def get_item_uoms(doctype, txt, searchfield, start, page_len, filters):
 	items = [filters.get("value")]

--- a/erpnext/buying/doctype/supplier/supplier.js
+++ b/erpnext/buying/doctype/supplier/supplier.js
@@ -67,7 +67,7 @@ frappe.ui.form.on("Supplier", {
 
 		frm.make_methods = {
 			"Bank Account": () => erpnext.utils.make_bank_account(frm.doc.doctype, frm.doc.name),
-			"Pricing Rule": () => erpnext.utils.make_pricing_rule(frm.doc.doctype, frm.doc.name),
+			"Pricing Rule": () => frm.trigger("make_pricing_rule"),
 		};
 	},
 
@@ -120,7 +120,7 @@ frappe.ui.form.on("Supplier", {
 			frm.add_custom_button(
 				__("Pricing Rule"),
 				function () {
-					erpnext.utils.make_pricing_rule(frm.doc.doctype, frm.doc.name);
+					frm.trigger("make_pricing_rule");
 				},
 				__("Create")
 			);
@@ -229,5 +229,12 @@ frappe.ui.form.on("Supplier", {
 			primary_action_label: __("Create Link"),
 		});
 		dialog.show();
+	},
+	make_pricing_rule: function (frm) {
+		frappe.new_doc("Pricing Rule", {
+			applicable_for: "Supplier",
+			supplier: frm.doc.name,
+			buying: 1,
+		});
 	},
 });

--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -293,20 +293,6 @@ $.extend(erpnext.utils, {
 		});
 	},
 
-	make_pricing_rule: function (doctype, docname) {
-		frappe.call({
-			method: "erpnext.accounts.doctype.pricing_rule.pricing_rule.make_pricing_rule",
-			args: {
-				doctype: doctype,
-				docname: docname,
-			},
-			callback: function (r) {
-				var doclist = frappe.model.sync(r.message);
-				frappe.set_route("Form", doclist[0].doctype, doclist[0].name);
-			},
-		});
-	},
-
 	/**
 	 * Checks if the first row of a given child table is empty
 	 * @param child_table - Child table Doctype

--- a/erpnext/selling/doctype/customer/customer.js
+++ b/erpnext/selling/doctype/customer/customer.js
@@ -32,7 +32,7 @@ frappe.ui.form.on("Customer", {
 					method: "erpnext.selling.doctype.customer.customer.make_payment_entry",
 					frm: frm,
 				}),
-			"Pricing Rule": () => erpnext.utils.make_pricing_rule(frm.doc.doctype, frm.doc.name),
+			"Pricing Rule": () => frm.trigger("make_pricing_rule"),
 			"Bank Account": () => erpnext.utils.make_bank_account(frm.doc.doctype, frm.doc.name),
 		};
 
@@ -263,5 +263,12 @@ frappe.ui.form.on("Customer", {
 			primary_action_label: __("Create Link"),
 		});
 		dialog.show();
+	},
+	make_pricing_rule: function (frm) {
+		frappe.new_doc("Pricing Rule", {
+			applicable_for: "Customer",
+			customer: frm.doc.name,
+			selling: 1,
+		});
 	},
 });


### PR DESCRIPTION
This pull request refactors how **Pricing Rule** documents are created from the **Supplier** and **Customer** forms. Instead of using a server-side method and asynchronous call, the creation is now handled directly on the client side using `frappe.new_doc`, which simplifies the code and improves responsiveness. The change removes the old utility function and server-side endpoint, and updates relevant form triggers and button actions.

In case you want to backport this later, please exclude the commit that removes the utils (7bc5080).

Migration guide: https://github.com/frappe/erpnext/wiki/Migration-Guide-To-ERPNext-Version-16#new-pricing-rule-via-api