### PR TITLE
fix: Company currency label is not displayed in Landed Cost Voucher doctype for the field Total Vendor Invoices Cost

### DIFF
--- a/erpnext/stock/doctype/landed_cost_voucher/landed_cost_voucher.js
+++ b/erpnext/stock/doctype/landed_cost_voucher/landed_cost_voucher.js
@@ -62,8 +62,7 @@ erpnext.stock.LandedCostVoucher = class LandedCostVoucher extends erpnext.stock.
 
 		if (this.frm.doc.company) {
 			let company_currency = frappe.get_doc(":Company", this.frm.doc.company).default_currency;
-			this.frm.set_currency_labels(["total_taxes_and_charges"], company_currency);
-			this.frm.set_currency_labels(["total_vendor_invoices_cost"], company_currency);
+			this.frm.set_currency_labels(["total_taxes_and_charges","total_vendor_invoices_cost"], company_currency);
 		}
 	}
 

--- a/erpnext/stock/doctype/landed_cost_voucher/landed_cost_voucher.js
+++ b/erpnext/stock/doctype/landed_cost_voucher/landed_cost_voucher.js
@@ -62,7 +62,10 @@ erpnext.stock.LandedCostVoucher = class LandedCostVoucher extends erpnext.stock.
 
 		if (this.frm.doc.company) {
 			let company_currency = frappe.get_doc(":Company", this.frm.doc.company).default_currency;
-			this.frm.set_currency_labels(["total_taxes_and_charges","total_vendor_invoices_cost"], company_currency);
+			this.frm.set_currency_labels(
+				["total_taxes_and_charges", "total_vendor_invoices_cost"],
+				company_currency
+			);
 		}
 	}
 

--- a/erpnext/stock/doctype/landed_cost_voucher/landed_cost_voucher.js
+++ b/erpnext/stock/doctype/landed_cost_voucher/landed_cost_voucher.js
@@ -63,6 +63,7 @@ erpnext.stock.LandedCostVoucher = class LandedCostVoucher extends erpnext.stock.
 		if (this.frm.doc.company) {
 			let company_currency = frappe.get_doc(":Company", this.frm.doc.company).default_currency;
 			this.frm.set_currency_labels(["total_taxes_and_charges"], company_currency);
+			this.frm.set_currency_labels(["total_vendor_invoices_cost"], company_currency);
 		}
 	}
 

--- a/erpnext/stock/doctype/landed_cost_voucher/landed_cost_voucher.json
+++ b/erpnext/stock/doctype/landed_cost_voucher/landed_cost_voucher.json
@@ -152,6 +152,7 @@
    "fieldname": "total_vendor_invoices_cost",
    "fieldtype": "Currency",
    "label": "Total Vendor Invoices Cost (Company Currency)",
+   "options": "Company:company:default_currency",
    "no_copy": 1,
    "print_hide": 1,
    "read_only": 1


### PR DESCRIPTION
Closes #49288

> Please provide enough information so that others can review your pull request:
- Currently, company currency label is not displayed in Landed Cost Voucher doctype for the field `Total Vendor Invoices Cost`
<img width="1269" height="690" alt="image" src="https://github.com/user-attachments/assets/32412d67-b6d2-41db-a91e-2bd458a44c72" />

> Explain the **details** for making this change. What existing problem does the pull request solve?
- To show current currency label for the `Total Vendor Invoices Cost` in Landed Cost Voucher doctype

> Screenshots/GIFs
<img width="1436" height="498" alt="image" src="https://github.com/user-attachments/assets/d6452eb2-4dcf-4336-88bd-06d630090e93" />

**The same can be fixed in version-15**