### PR TITLE
fix(stock): Correct warehouse matching in barcode scanner

### DIFF
--- a/erpnext/public/js/utils/barcode_scanner.js
+++ b/erpnext/public/js/utils/barcode_scanner.js
@@ -460,7 +460,7 @@ erpnext.utils.BarcodeScanner = class BarcodeScanner {
 				if (warehouse) {
 					warehouse_match = row[warehouse_field] === warehouse;
 				} else {
-					warehouse_match = !row[warehouse_field];
+					warehouse_match = true;
 				}
 			}
 


### PR DESCRIPTION
This code is executed when no specific warehouse has been scanned beforehand, which is the standard procedure for a Pick List. The line warehouse_match = !row[warehouse_field]; incorrectly requires the warehouse field in the item row to be empty to get a match.

In a Pick List, every item row always has a warehouse assigned. Therefore, row[warehouse_field] is never empty, the condition !row[warehouse_field] is always false, the warehouse_match fails, and the scanner never finds a valid row to update.