### PR TITLE
test: fix naming series for serial no on test_serial_no_valuation_for_legacy_ledgers

### DIFF
--- a/erpnext/stock/doctype/serial_and_batch_bundle/test_serial_and_batch_bundle.py
+++ b/erpnext/stock/doctype/serial_and_batch_bundle/test_serial_and_batch_bundle.py
@@ -610,7 +610,7 @@ class TestSerialandBatchBundle(IntegrationTestCase):
 	def test_serial_no_valuation_for_legacy_ledgers(self):
 		sn_item = make_item(
 			"Test Serial No Valuation for Legacy Ledgers",
-			properties={"has_serial_no": 1, "serial_no_series": "SNN-TSNVL.-#####"},
+			properties={"has_serial_no": 1, "serial_no_series": "SNN-TSNVL-.#####"},
 		).name
 
 		serial_nos = []


### PR DESCRIPTION
Fixed the naming series for `serial_no` on `test_serial_no_valuation_for_legacy_ledgers`.