### PR TITLE
feat: add active employee filter and mandatory selection check

### DIFF
--- a/erpnext/manufacturing/doctype/job_card/job_card.js
+++ b/erpnext/manufacturing/doctype/job_card/job_card.js
@@ -209,8 +209,19 @@ frappe.ui.form.on("Job Card", {
 								label: __("Select Employees"),
 								options: "Job Card Time Log",
 								fieldname: "employees",
+								get_query: () => {
+									return {
+										filters: {
+											status: "Active",
+										},
+									};
+								},
 							},
 							(d) => {
+								if (!d.employees || d.employees.length === 0) {
+									frappe.msgprint(__("Please select at least one Employee"));
+									return;
+								}
 								frm.events.start_timer(frm, from_time, d.employees);
 							},
 							__("Assign Job to Employee")


### PR DESCRIPTION
#49248
When the user submits the popup dialog without selecting an employee, the error is shown as in the video.
[Screencast from 28-08-25 04:02:35 PM IST.webm](https://github.com/user-attachments/assets/f69882f8-6d9f-4420-acc7-78cac0f79249)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * In Job Card, the employee selector now shows only Active employees for “Select Employees.”
  * Prevents starting the timer without any selected employees; users are prompted to select at least one employee before proceeding.
* **UX Improvements**
  * Clear validation message guides users to complete employee selection, reducing errors when starting work timers on Job Cards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->