### PR TITLE
fix: set valid serial no naming series format

### DIFF
--- a/erpnext/stock/doctype/serial_and_batch_bundle/test_serial_and_batch_bundle.py
+++ b/erpnext/stock/doctype/serial_and_batch_bundle/test_serial_and_batch_bundle.py
@@ -610,7 +610,7 @@ class TestSerialandBatchBundle(IntegrationTestCase):
 	def test_serial_no_valuation_for_legacy_ledgers(self):
 		sn_item = make_item(
 			"Test Serial No Valuation for Legacy Ledgers",
-			properties={"has_serial_no": 1, "serial_no_series": "SNN-TSNVL.-#####"},
+			properties={"has_serial_no": 1, "serial_no_series": "SNN-TSNVL-.#####"},
 		).name
 
 		serial_nos = []


### PR DESCRIPTION
**Issue:** There is a typo mistake in test case `test_serial_no_valuation_for_legacy_ledgers` which blocking the newly added `naming_series` validation on framework [33739](https://github.com/frappe/frappe/pull/33739)

Ref PR: [49105](https://github.com/frappe/erpnext/pull/49105) 

**Backport Needed: v15**