### PR TITLE
fix(budget):  fiscal year assignment and approver role in budget

### DIFF
--- a/erpnext/accounts/doctype/budget/budget.py
+++ b/erpnext/accounts/doctype/budget/budget.py
@@ -145,8 +145,10 @@ def validate_expense_against_budget(args, expense_amount=0):
 	if not frappe.db.count("Budget", cache=True):
 		return
 
-	if args.get("company") and not args.fiscal_year:
+	if not args.fiscal_year:
 		args.fiscal_year = get_fiscal_year(args.get("posting_date"), company=args.get("company"))[0]
+
+	if args.get("company"):
 		frappe.flags.exception_approver_role = frappe.get_cached_value(
 			"Company", args.get("company"), "exception_budget_approver_role"
 		)


### PR DESCRIPTION
**Ref:** [47251](https://support.frappe.io/helpdesk/tickets/47251)

**Issue:**
`exception_budget_approver_role ` was only set if fiscal_year was missing, causing errors when it was already set.

**Fix:**

Calculate fiscal_year separately if missing.

Set `exception_budget_approver_role `independently whenever a company is provided.

**Before:**

<img width="1793" height="922" alt="image" src="https://github.com/user-attachments/assets/fe2c7a09-aa39-4e88-85f3-bd22bff9887a" />

<img width="1787" height="552" alt="image" src="https://github.com/user-attachments/assets/56e77147-8574-40a2-a94a-38feca4627b2" />

<img width="1797" height="902" alt="image" src="https://github.com/user-attachments/assets/051000c2-8a88-4fa3-98eb-94f3ebec8dd3" />

**After:**

<img width="1812" height="938" alt="image" src="https://github.com/user-attachments/assets/9bffa9e9-8807-489d-a214-1f33db9609c7" />



**Backport needed v15**