### PR TITLE
fix(exchange rate revaluation): add check for gain_loss

### DIFF
--- a/erpnext/accounts/doctype/exchange_rate_revaluation/exchange_rate_revaluation.py
+++ b/erpnext/accounts/doctype/exchange_rate_revaluation/exchange_rate_revaluation.py
@@ -134,7 +134,8 @@ class ExchangeRateRevaluation(Document):
 		accounts = self.get_accounts_data()
 		if accounts:
 			for acc in accounts:
-				self.append("accounts", acc)
+				if acc.get("gain_loss"):
+					self.append("accounts", acc)
 
 	@frappe.whitelist()
 	def get_accounts_data(self):

--- a/erpnext/setup/doctype/company/company.json
+++ b/erpnext/setup/doctype/company/company.json
@@ -750,6 +750,7 @@
   },
   {
    "default": "0",
+   "description": "Upon enabling this, the JV will be submitted for a different exchange rate.",
    "fieldname": "submit_err_jv",
    "fieldtype": "Check",
    "label": "Submit ERR Journals?"
@@ -841,7 +842,7 @@
  "image_field": "company_logo",
  "is_tree": 1,
  "links": [],
- "modified": "2025-01-09 20:12:25.471544",
+ "modified": "2025-08-25 18:34:03.602046",
  "modified_by": "Administrator",
  "module": "Setup",
  "name": "Company",
@@ -903,6 +904,7 @@
    "select": 1
   }
  ],
+ "row_format": "Dynamic",
  "show_name_in_global_search": 1,
  "sort_field": "creation",
  "sort_order": "ASC",


### PR DESCRIPTION
Issue: When Exchange Rate Revaluation (EER) runs automatically, if a company has all accounts where `gain_loss = 0`, System throws an error message. Because of this, the process for other companies also gets stopped, even though they may have valid revaluations.

Ref: [47273](https://support.frappe.io/helpdesk/tickets/47273)

Backport needed: v15