### PR TITLE
Removing Newsletter from Settings Workspace

### DIFF
--- a/erpnext/setup/workspace/settings/settings.json
+++ b/erpnext/setup/workspace/settings/settings.json
@@ -134,17 +134,6 @@
    "dependencies": "",
    "hidden": 0,
    "is_query_report": 0,
-   "label": "Newsletter",
-   "link_count": 0,
-   "link_to": "Newsletter",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "dependencies": "",
-   "hidden": 0,
-   "is_query_report": 0,
    "label": "Notification Settings",
    "link_count": 0,
    "link_to": "Notification Settings",


### PR DESCRIPTION
Since Newsletter is now a separate app from Frappe because of this PR: https://github.com/frappe/frappe/pull/32971, I think it would be appropriate to remove it from the Settings Workspace in ERPNext.

If you only install Frappe + ERPNext, it looks like this:

<img width="1920" height="934" alt="Screenshot 2025-08-25 at 11 11 42 AM" src="https://github.com/user-attachments/assets/72454d93-343b-41f9-a9ac-2e4aec11ea5c" />

With the 'Settings' section left blank.
