### PR TITLE
fix: payment entry clear party type

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.js
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.js
@@ -330,7 +330,7 @@ frappe.ui.form.on('Payment Entry', {
 	payment_type: function(frm) {
 		set_default_party_type(frm);
 		if(frm.doc.payment_type == "Internal Transfer") {
-			$.each(["party", "party_balance", "paid_from", "paid_to",
+			$.each(["party", "party_type", "party_balance", "paid_from", "paid_to",
 				"references", "total_allocated_amount"], function(i, field) {
 				frm.set_value(field, null);
 			});


### PR DESCRIPTION
<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/erpnext/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->

### Base branch
- version-14-hotfix

### Summary
- Fixes a client-side bug where switching `payment_type` from “Pay” to “Internal Transfer” leaves `party_type` as “Supplier”, causing submit to fail with “Supplier None not found”.
- Clears `party_type` along with other fields when `payment_type == "Internal Transfer"`.

### Problem
- When creating a Payment Entry:
  1) Set `payment_type` = Pay
  2) Switch `payment_type` = Internal Transfer
  3) Select two different bank accounts for `paid_from` and `paid_to`
  4) Complete required fields, Save, Submit
- Error: “Supplier None not found”

### Root cause
- The `payment_type` handler did not clear `party_type` when switching to Internal Transfer, so it retained “Supplier” from the earlier “Pay” state.

### Fix
- In `erpnext/accounts/doctype/payment_entry/payment_entry.js`, update the `payment_type` handler to also clear `party_type` when `payment_type == "Internal Transfer"`:
  - Array now includes `"party_type"` alongside `"party"`, `"paid_from"`, `"paid_to"`, `"references"`, `"total_allocated_amount"`.

### Affected versions
- ERPNext v14.88.2 (Frappe v14.96.14). Newer versions already include this behavior.

### How I tested
- Reproduced the steps above before the change to observe the error.
- After the change, repeated the steps; no error on submit, and the document saves and submits successfully.

### Screenshots/GIFs
- Not UI-visible; behavior change is clearing a field. If needed, I can attach a short GIF demonstrating the flow without the error.

### Business logic/validations
- No server-side logic altered. This change prevents an incorrect client-side state; server-side validations remain unchanged.

### Documentation
- Not applicable. No user-facing settings or behavior changes beyond fixing incorrect state.

### Additional notes
- This is a backport-only fix for v14; newer branches already clear `party_type`. Please keep this PR on `version-14-hotfix`.

If there’s an existing issue to auto-close, add:
- closes #49276


