### PR TITLE
fix(asset): handle None in depreciation value

### DIFF
--- a/erpnext/assets/doctype/asset_depreciation_schedule/asset_depreciation_schedule.py
+++ b/erpnext/assets/doctype/asset_depreciation_schedule/asset_depreciation_schedule.py
@@ -456,7 +456,7 @@ class AssetDepreciationSchedule(Document):
 				continue
 			depreciation_amount = flt(depreciation_amount, asset_doc.precision("gross_purchase_amount"))
 			value_after_depreciation = flt(
-				value_after_depreciation - flt(depreciation_amount),
+				flt(value_after_depreciation) - flt(depreciation_amount),
 				asset_doc.precision("gross_purchase_amount"),
 			)
 


### PR DESCRIPTION
Issue: When cancelling the Asset Value Adjustment `Nonetype` error occurs

Ref: [47297](https://support.frappe.io/helpdesk/tickets/47297)

 Asset Value Adjustment:

<img width="1792" height="1120" alt="Screenshot 2025-08-26 at 1 36 57 PM" src="https://github.com/user-attachments/assets/7dc82660-f837-4bfa-b94a-a091172d0e02" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy and consistency of asset depreciation calculations to prevent type/rounding-related discrepancies.
  * Ensures correct value-after-depreciation figures in schedules, aligning with system precision settings.
  * Reduces occasional mismatches between depreciation schedules, reports, and book values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->