### PR TITLE
fix: run sync auto reconcile config with force

### DIFF
--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -397,7 +397,7 @@ erpnext.patches.v15_0.update_cc_in_process_statement_of_accounts
 erpnext.patches.v15_0.refactor_closing_stock_balance #5
 erpnext.patches.v15_0.update_asset_status_to_work_in_progress
 erpnext.patches.v15_0.rename_manufacturing_settings_field
-erpnext.patches.v15_0.sync_auto_reconcile_config
+erpnext.patches.v15_0.sync_auto_reconcile_config #2025-08-26
 execute:frappe.db.set_single_value("Accounts Settings", "exchange_gain_loss_posting_date", "Payment")
 erpnext.patches.v14_0.disable_add_row_in_gross_profit
 erpnext.patches.v14_0.update_posting_datetime

--- a/erpnext/patches/v15_0/sync_auto_reconcile_config.py
+++ b/erpnext/patches/v15_0/sync_auto_reconcile_config.py
@@ -11,7 +11,7 @@ def execute():
 	frappe.db.set_single_value("Accounts Settings", "reconciliation_queue_size", 5)
 
 	# Create Scheduler Event record if it doesn't exist
-	if frappe.reload_doc("core", "doctype", "scheduler_event"):
+	if frappe.reload_doc("core", "doctype", "scheduler_event", force=True):
 		method = "erpnext.accounts.doctype.process_payment_reconciliation.process_payment_reconciliation.trigger_reconciliation_for_queued_docs"
 		if not frappe.db.get_all(
 			"Scheduler Event", {"scheduled_against": "Process Payment Reconciliation", "method": method}


### PR DESCRIPTION
Issue: Changes in `reload_doc` cause the patch to fail, which leads to an error when triggering Auto Reconcile Payments.

Ref: [46969](https://support.frappe.io/helpdesk/tickets/46969)

Backport needed: v15