### PR TITLE
perf: check PCV (smaller) table before checking GL Entries

### DIFF
--- a/erpnext/accounts/doctype/period_closing_voucher/period_closing_voucher.py
+++ b/erpnext/accounts/doctype/period_closing_voucher/period_closing_voucher.py
@@ -75,6 +75,17 @@ class PeriodClosingVoucher(AccountsController):
 			return
 
 		previous_fiscal_year_start_date = previous_fiscal_year[0][1]
+		previous_fiscal_year_closed = frappe.db.exists(
+			"Period Closing Voucher",
+			{
+				"period_end_date": ("between", [previous_fiscal_year_start_date, last_year_closing]),
+				"docstatus": 1,
+				"company": self.company,
+			},
+		)
+		if previous_fiscal_year_closed:
+			return
+
 		gle_exists_in_previous_year = frappe.db.exists(
 			"GL Entry",
 			{
@@ -86,16 +97,7 @@ class PeriodClosingVoucher(AccountsController):
 		if not gle_exists_in_previous_year:
 			return
 
-		previous_fiscal_year_closed = frappe.db.exists(
-			"Period Closing Voucher",
-			{
-				"period_end_date": ("between", [previous_fiscal_year_start_date, last_year_closing]),
-				"docstatus": 1,
-				"company": self.company,
-			},
-		)
-		if not previous_fiscal_year_closed:
-			frappe.throw(_("Previous Year is not closed, please close it first"))
+		frappe.throw(_("Previous Year is not closed, please close it first"))
 
 	def block_if_future_closing_voucher_exists(self):
 		future_closing_voucher = self.get_future_closing_voucher()


### PR DESCRIPTION
Issue:  Request timeout issue while creating Period Closing Voucher.

`SELECT name FROM tabGL Entry WHERE posting_date BETWEEN '2024-04-01' AND '2025-03-31' AND company='Test Company' AND is_cancelled=0 LIMIT 1` 

The query is taking more than 200 seconds to execute on larger databases. It is from the db.exisits check.

Solution: If the Period Closing Voucher exists (cheaper DB call), the query to check the existence of GL Entry can be skipped.

Ref: [47028](https://support.frappe.io/helpdesk/tickets/47028)

Backport needed: v15