### PR TITLE
fix: show company currency symbol

### DIFF
--- a/erpnext/selling/doctype/quotation_item/quotation_item.json
+++ b/erpnext/selling/doctype/quotation_item/quotation_item.json
@@ -365,6 +365,7 @@
    "fieldname": "base_net_rate",
    "fieldtype": "Currency",
    "label": "Net Rate (Company Currency)",
+   "options": "Company:company:default_currency",
    "print_hide": 1,
    "read_only": 1
   },
@@ -698,7 +699,7 @@
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-06-12 17:31:47.775890",
+ "modified": "2025-08-26 20:31:47.775890",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Quotation Item",


### PR DESCRIPTION
Issue: The Company currency symbol is not showing properly for base_net_rate in Quotation Items.

Ref: [47331](https://support.frappe.io/helpdesk/tickets/47331)

Before:

<img width="1589" height="634" alt="before_company_currency" src="https://github.com/user-attachments/assets/7db1c654-0a90-462a-8649-105837065665" />

After:

<img width="1185" height="574" alt="After_company_currency" src="https://github.com/user-attachments/assets/8c70614d-7ac3-4aab-b5d6-f802b01322ba" />

Backport needed: v15

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Quotation Item now links “Base Net Rate” to your company’s default currency, ensuring rates are displayed and interpreted in the correct currency by default.
  * Improves consistency across quotations by providing clearer currency context when entering or reviewing item rates, reducing manual checks and minimizing currency-related confusion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->