### PR TITLE
fix: add option to disable Transaction Log

### DIFF
--- a/erpnext/regional/__init__.py
+++ b/erpnext/regional/__init__.py
@@ -19,6 +19,9 @@ def create_transaction_log(doc, method):
 	Appends the transaction to a chain of hashed logs for legal resons.
 	Called on submit of Sales Invoice and Payment Entry.
 	"""
+	if frappe.conf.get("disable_transaction_log", False):
+		return
+
 	region = get_region()
 	if region not in ["Germany"]:
 		return


### PR DESCRIPTION
**Transaction Log** attempts to store the entire **Sales Invoice** as JSON in a "Long Text" field. For some extreme use cases (e.g. several thousand line items) this can exceed the DB's `max_packet_size`.

This non-breaking change allows to disable **Transaction Log**  when it's not  needed, to avoid such problems.

Docs: https://docs.frappe.io/framework/user/en/basics/site_config

> [!NOTE]
> IMO, we should remove **Transaction Log** entirely on `develop` (in a future PR). This feature fails to satisfy the regulations it was supposed to (KassenSichV). Enabled for Germany in #19198. Extracted into app for France in #37229.