### PR TITLE
fix: remove defunct payment gateway links from ERPNext Integrations workspace

### DIFF
--- a/erpnext/erpnext_integrations/workspace/erpnext_integrations/erpnext_integrations.json
+++ b/erpnext/erpnext_integrations/workspace/erpnext_integrations/erpnext_integrations.json
@@ -188,29 +188,9 @@
    "hidden": 0,
    "is_query_report": 0,
    "label": "Payments",
-   "link_count": 3,
+   "link_count": 1,
    "onboard": 0,
    "type": "Card Break"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "GoCardless Settings",
-   "link_count": 0,
-   "link_to": "GoCardless Settings",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
-  },
-  {
-   "hidden": 0,
-   "is_query_report": 0,
-   "label": "Mpesa Settings",
-   "link_count": 0,
-   "link_to": "Mpesa Settings",
-   "link_type": "DocType",
-   "onboard": 0,
-   "type": "Link"
   },
   {
    "hidden": 0,


### PR DESCRIPTION
## Description

Removes broken links to "Mpesa Settings" and "GoCardless Settings" DocTypes that were removed in v15.0 but workspace was not updated accordingly.

## Problem

- Users see defunct links in ERPNext Integrations workspace Payments section
- Clicking these links results in errors since the DocTypes no longer exist  
- Creates confusion and poor user experience

## Root Cause

- DocTypes were properly removed via patch `erpnext/patches/v15_0/delete_payment_gateway_doctypes.py`
- Workspace configuration was not updated in the same cleanup

## Solution

- Removed GoCardless Settings link from workspace
- Removed Mpesa Settings link from workspace  
- Updated Payments card `link_count` from 3 to 1
- Only Plaid Settings remains in Payments section

## Testing

Verified that:
- JSON structure is valid
- Payments section now only shows Plaid Settings
- No more broken links in ERPNext Integrations workspace

## Impact

- Low risk - Only removes broken links
- Improves UX - Eliminates user confusion 
- Maintains consistency - Aligns workspace with actual available DocTypes

Fixes #49352

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Streamlined the ERPNext Integrations workspace for a cleaner experience.
  - Payments card now displays a single link, reducing visual clutter and focusing navigation.
  - Removed shortcuts to GoCardless Settings and Mpesa Settings from the workspace links.
  - Users may now access these settings through their respective modules or search, rather than from the Payments card.
  - Improves clarity and reduces noise for users who do not use these specific payment integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->