### PR TITLE
fix(pricing rule): cumulative for product slab

### DIFF
--- a/erpnext/accounts/doctype/pricing_rule/utils.py
+++ b/erpnext/accounts/doctype/pricing_rule/utils.py
@@ -642,12 +642,12 @@ def get_product_discount_rule(pricing_rule, item_details, args=None, doc=None):
 			)
 		)
 
-	qty = pricing_rule.free_qty or flt(1)
+	qty = pricing_rule.free_qty or 1
 
 	if pricing_rule.is_cumulative:
 		items = [args.get(frappe.scrub(pricing_rule.get("apply_on")))]
 		data = get_qty_amount_data_for_cumulative(pricing_rule, doc, items, free_item=True)
-		if data[0]:
+		if data and data[0]:
 			qty -= data[0]
 
 	if pricing_rule.is_recursive:

--- a/erpnext/accounts/doctype/pricing_rule/utils.py
+++ b/erpnext/accounts/doctype/pricing_rule/utils.py
@@ -498,7 +498,7 @@ def get_qty_and_rate_for_other_item(doc, pr_doc, pricing_rules, row_item):
 				return pricing_rules
 
 
-def get_qty_amount_data_for_cumulative(pr_doc, doc, items=None):
+def get_qty_amount_data_for_cumulative(pr_doc, doc, items=None, free_item=False):
 	if items is None:
 		items = []
 	sum_qty, sum_amt = [0, 0]
@@ -511,36 +511,25 @@ def get_qty_amount_data_for_cumulative(pr_doc, doc, items=None):
 	child_doctype = f"{doctype} Item"
 	apply_on = frappe.scrub(pr_doc.get("apply_on"))
 
-	values = [pr_doc.valid_from, pr_doc.valid_upto]
-	condition = ""
-
+	parent = frappe.qb.DocType(doctype)
+	child = frappe.qb.DocType(child_doctype)
+	query = (
+		frappe.qb.from_(child)
+		.join(parent)
+		.on(child.parent == parent.name)
+		.select(child.stock_qty, child.amount)
+		.where(parent[date_field].between(pr_doc.valid_from, pr_doc.valid_upto))
+		.where(parent.docstatus == 1)
+		.where(child.is_free_item == free_item)
+	)
 	if pr_doc.warehouse:
 		warehouses = get_child_warehouses(pr_doc.warehouse)
-
-		condition += """ and `tab{child_doc}`.warehouse in ({warehouses})
-			""".format(child_doc=child_doctype, warehouses=",".join(["%s"] * len(warehouses)))
-
-		values.extend(warehouses)
+		query = query.where(child.warehouse.isin(warehouses))
 
 	if items:
-		condition += " and `tab{child_doc}`.{apply_on} in ({items})".format(
-			child_doc=child_doctype, apply_on=apply_on, items=",".join(["%s"] * len(items))
-		)
+		query = query.where(child[apply_on].isin(items))
 
-		values.extend(items)
-
-	data_set = frappe.db.sql(
-		f""" SELECT `tab{child_doctype}`.stock_qty,
-			`tab{child_doctype}`.amount
-		FROM `tab{child_doctype}`, `tab{doctype}`
-		WHERE
-			`tab{child_doctype}`.parent = `tab{doctype}`.name and `tab{doctype}`.{date_field}
-			between %s and %s and `tab{doctype}`.docstatus = 1
-			{condition} group by `tab{child_doctype}`.name
-	""",
-		tuple(values),
-		as_dict=1,
-	)
+	data_set = query.run(as_dict=True)
 
 	for data in data_set:
 		sum_qty += data.get("stock_qty")
@@ -653,7 +642,14 @@ def get_product_discount_rule(pricing_rule, item_details, args=None, doc=None):
 			)
 		)
 
-	qty = pricing_rule.free_qty or 1
+	qty = pricing_rule.free_qty or flt(1)
+
+	if pricing_rule.is_cumulative:
+		items = [args.get(frappe.scrub(pricing_rule.get("apply_on")))]
+		data = get_qty_amount_data_for_cumulative(pricing_rule, doc, items, free_item=True)
+		if data[0]:
+			qty -= data[0]
+
 	if pricing_rule.is_recursive:
 		transaction_qty = sum(
 			[

--- a/erpnext/accounts/doctype/promotional_scheme/test_promotional_scheme.py
+++ b/erpnext/accounts/doctype/promotional_scheme/test_promotional_scheme.py
@@ -4,6 +4,7 @@ import unittest
 
 import frappe
 from frappe.tests import IntegrationTestCase
+from frappe.utils import nowdate
 
 from erpnext.accounts.doctype.promotional_scheme.promotional_scheme import TransactionExists
 from erpnext.selling.doctype.sales_order.test_sales_order import make_sales_order
@@ -172,6 +173,50 @@ class TestPromotionalScheme(IntegrationTestCase):
 		)
 		ps.mixed_conditions = True
 		self.assertRaises(frappe.ValidationError, ps.save)
+
+	def test_cumulative_product_discount_slabs(self):
+		ps = make_promotional_scheme(applicable_for="Customer", customer="_Test Customer 1")
+		ps.is_cumulative = True
+		ps.valid_from = ps.valid_upto = nowdate()
+		ps.set("price_discount_slabs", [])
+		ps.set("items", [])
+		ps.set(
+			"items",
+			[
+				{
+					"item_code": "_Test Item 2",
+				}
+			],
+		)
+		ps.set(
+			"product_discount_slabs",
+			[
+				{
+					"rule_description": "Test1",
+					"min_qty": 500,
+					"max_qty": 500,
+					"same_item": True,
+					"free_qty": 50,
+				},
+				{
+					"rule_description": "Test2",
+					"min_qty": 1000,
+					"max_qty": 1000,
+					"same_item": True,
+					"free_qty": 120,
+				},
+			],
+		)
+		ps.save()
+
+		so1 = make_sales_order(customer="_Test Customer 1", item_code="_Test Item 2", qty=500)
+		self.assertEqual(so1.items[1].qty, 50)
+
+		so2 = make_sales_order(customer="_Test Customer 1", item_code="_Test Item 2", qty=500)
+		self.assertEqual(so2.items[1].qty, 70)
+
+		so1.reload().cancel().delete()
+		so2.reload().cancel().delete()
 
 
 def make_promotional_scheme(**args):


### PR DESCRIPTION
Issue:  When a promotion scheme is cumulative and has multiple product discount slabs, the product discount is not calculated correctly.

Ref: [46833](https://support.frappe.io/helpdesk/tickets/46833)

Before :


https://github.com/user-attachments/assets/1b81758a-0414-4c7f-aa53-e0f6f79b77b7

After:


https://github.com/user-attachments/assets/b7be1b5e-9272-4b0b-adb0-86e71e3f9315


Backport needed: v15