### PR TITLE
fix(trial-balance-simple): ignore cancelled gl and add company filter

### DIFF
--- a/erpnext/accounts/report/trial_balance_simple/trial_balance_simple.json
+++ b/erpnext/accounts/report/trial_balance_simple/trial_balance_simple.json
@@ -4,15 +4,25 @@
  "disabled": 0, 
  "docstatus": 0, 
  "doctype": "Report", 
+ "filters": [
+  {
+   "fieldname": "company",
+   "fieldtype": "Link",
+   "label": "Company",
+   "mandatory": 1,
+   "options": "Company",
+   "wildcard_filter": 0
+  }
+ ],
  "idx": 0, 
  "is_standard": "Yes", 
- "modified": "2019-01-17 17:20:42.374958", 
+ "modified": "2025-08-28 19:06:54.273322",
  "modified_by": "Administrator", 
  "module": "Accounts", 
  "name": "Trial Balance (Simple)", 
  "owner": "Administrator", 
  "prepared_report": 0, 
- "query": "select fiscal_year as \"Fiscal Year:Data:80\",\n\tcompany as \"Company:Data:220\",\n\tposting_date as \"Posting Date:Date:100\",\n\taccount as \"Account:Data:380\",\n\tsum(debit) as \"Debit:Currency:140\",\n\tsum(credit) as \"Credit:Currency:140\",\n\tfinance_book as \"Finance Book:Link/Finance Book:140\"\nfrom `tabGL Entry`\ngroup by fiscal_year, company, posting_date, account\norder by fiscal_year, company, posting_date, account", 
+ "query": "select fiscal_year as \"Fiscal Year:Data:80\",\n\tcompany as \"Company:Data:220\",\n\tposting_date as \"Posting Date:Date:100\",\n\taccount as \"Account:Data:380\",\n\tsum(debit) as \"Debit:Currency:140\",\n\tsum(credit) as \"Credit:Currency:140\",\n\tfinance_book as \"Finance Book:Link/Finance Book:140\"\nfrom `tabGL Entry`\nwhere is_cancelled = 0 and company = %(company)s\ngroup by fiscal_year, company, posting_date, account\norder by fiscal_year, company, posting_date, account",
  "ref_doctype": "GL Entry", 
  "report_name": "Trial Balance (Simple)", 
  "report_type": "Query Report", 


### PR DESCRIPTION
Issue: Trial Balance Simple Includes cancelled GL

Ref: [47372](https://support.frappe.io/helpdesk/tickets/47372)

<img width="1862" height="760" alt="image" src="https://github.com/user-attachments/assets/dcf36e60-0b75-49de-aa96-c320bb063560" />


**Backport Needed: Version-15**