### PR TITLE
fix(barcode scanner): validate warehouse on default

### DIFF
--- a/erpnext/public/js/utils/barcode_scanner.js
+++ b/erpnext/public/js/utils/barcode_scanner.js
@@ -459,7 +459,7 @@ erpnext.utils.BarcodeScanner = class BarcodeScanner {
 			const item_scanned = row.has_item_scanned;
 
 			let warehouse_match = true;
-			if (has_warehouse_field) {
+			if (has_warehouse_field && default_warehouse) {
 				if (warehouse) {
 					warehouse_match = row[warehouse_field] === warehouse;
 				} else {


### PR DESCRIPTION
Issue: For Material Transfer, scanning the same item with a barcode always adds a new row instead of updating the existing row quantity.

Ref: [47111](https://support.frappe.io/helpdesk/tickets/47111)

Before :

https://github.com/user-attachments/assets/a70ef478-e1ac-4cb2-8856-db3070a22315

After:

https://github.com/user-attachments/assets/e93127e6-d8c4-4667-b62e-9d44fbedd826


Backport needed: v15