### PR TITLE
fix: prevent double-counting of advance payments in Supplier Ledger (#49076)

### DIFF
--- a/erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py
+++ b/erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py
@@ -6,7 +6,7 @@ import frappe
 from frappe import _, qb, scrub
 from frappe.query_builder import Criterion, Tuple
 from frappe.query_builder.functions import IfNull
-from frappe.utils import getdate, nowdate
+from frappe.utils import getdate, nowdate, flt
 from frappe.utils.nestedset import get_descendants_of
 from pypika.terms import LiteralValue
 
@@ -307,8 +307,8 @@ class PartyLedgerSummaryReport:
 				or row.closing_balance  # Fixed typo from closing_amount to closing_balance
 			):
 				adjustments = self.party_adjustment_details.get(party, {})
-				# Fix double counting by subtracting already-allocated advances
     
+				# Fix double counting by subtracting already-allocated advances
 				total_party_adjustment = sum(
 					flt(amount) for amount in adjustments.values()
 				)

--- a/erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py
+++ b/erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py
@@ -306,12 +306,15 @@ class PartyLedgerSummaryReport:
 				or row.return_amount
 				or row.closing_balance  # Fixed typo from closing_amount to closing_balance
 			):
+				adjustments = self.party_adjustment_details.get(party, {})
+				# Fix double counting by subtracting already-allocated advances
+    
 				total_party_adjustment = sum(
-					amount for amount in self.party_adjustment_details.get(party, {}).values()
+					flt(amount) for amount in adjustments.values()
 				)
 				row.paid_amount -= total_party_adjustment
 
-				adjustments = self.party_adjustment_details.get(party, {})
+				# Add breakdown columns
 				for account in self.party_adjustment_accounts:
 					row["adj_" + scrub(account)] = adjustments.get(account, 0)
 


### PR DESCRIPTION
**What this PR does:**
Correctly separates advance allocations and prevents them from being added again to paid_amount

Adds breakdown of advance payments by account using party_adjustment_details

Ensures proper treatment of:

Return invoices

Entries against return invoices

Normal invoices and payments

Improves performance slightly by reducing repeated dictionary lookups

**Explain the details for making this change. What existing problem does the pull request solve**

The bug (#49076) caused confusion in reporting because the ledger totals did not match actual advance allocations. This PR ensures accurate balances are reported for suppliers by eliminating redundant counting of payments already adjusted against invoices.


