### PR TITLE
fix: improve permission handling for party link creation

### DIFF
--- a/erpnext/accounts/doctype/party_link/party_link.py
+++ b/erpnext/accounts/doctype/party_link/party_link.py
@@ -74,6 +74,6 @@ def create_party_link(primary_role, primary_party, secondary_party):
 	party_link.secondary_role = "Customer" if primary_role == "Supplier" else "Supplier"
 	party_link.secondary_party = secondary_party
 
-	party_link.save(ignore_permissions=True)
+	party_link.save()
 
 	return party_link

--- a/erpnext/buying/doctype/supplier/supplier.js
+++ b/erpnext/buying/doctype/supplier/supplier.js
@@ -133,7 +133,10 @@ frappe.ui.form.on("Supplier", {
 				__("Actions")
 			);
 
-			if (cint(frappe.defaults.get_default("enable_common_party_accounting"))) {
+			if (
+				cint(frappe.defaults.get_default("enable_common_party_accounting")) &&
+				frappe.model.can_create("Party Link")
+			) {
 				frm.add_custom_button(
 					__("Link with Customer"),
 					function () {

--- a/erpnext/selling/doctype/customer/customer.js
+++ b/erpnext/selling/doctype/customer/customer.js
@@ -190,7 +190,10 @@ frappe.ui.form.on("Customer", {
 				__("Actions")
 			);
 
-			if (cint(frappe.defaults.get_default("enable_common_party_accounting"))) {
+			if (
+				cint(frappe.defaults.get_default("enable_common_party_accounting")) &&
+				frappe.model.can_create("Party Link")
+			) {
 				frm.add_custom_button(
 					__("Link with Supplier"),
 					function () {


### PR DESCRIPTION
Currently, Party Links can be created without proper permissions.

This PR removes the use of `ignore_permissions=True` and adds a permission check for the Party Link Custom Button in Supplier and Customer.