### PR TITLE
fix(repost item valuation): reorder function call

### DIFF
--- a/erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.js
+++ b/erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.js
@@ -132,4 +132,19 @@ frappe.ui.form.on("Repost Item Valuation", {
 			},
 		});
 	},
+
+	voucher_type: function (frm) {
+		console.log(frm.doc);
+		frm.trigger("set_company_on_transaction");
+	},
+
+	voucher_no: function (frm) {
+		frm.trigger("set_company_on_transaction");
+	},
+
+	set_company_on_transaction(frm) {
+		if (frm.doc.voucher_no && frm.doc.voucher_no) {
+			frm.call("set_company");
+		}
+	},
 });

--- a/erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.js
+++ b/erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.js
@@ -134,7 +134,6 @@ frappe.ui.form.on("Repost Item Valuation", {
 	},
 
 	voucher_type: function (frm) {
-		console.log(frm.doc);
 		frm.trigger("set_company_on_transaction");
 	},
 

--- a/erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.py
+++ b/erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.py
@@ -70,10 +70,10 @@ class RepostItemValuation(Document):
 		)
 
 	def validate(self):
+		self.set_company()
 		self.validate_period_closing_voucher()
 		self.set_status(write=False)
 		self.reset_field_values()
-		self.set_company()
 		self.validate_accounts_freeze()
 		self.reset_recreate_stock_ledgers()
 
@@ -162,6 +162,7 @@ class RepostItemValuation(Document):
 	def on_trash(self):
 		self.clear_attachment()
 
+	@frappe.whitelist()
 	def set_company(self):
 		if self.based_on == "Transaction":
 			self.company = frappe.get_cached_value(self.voucher_type, self.voucher_no, "company")


### PR DESCRIPTION
Issue: When creating a Repost Item Valuation during Asset Capitalization, if the default company has a PCV and the Asset Capitalization is created for a different company within the same period as the PCV, Repost Item Valuation throws an error.

Ref: [47332](https://support.frappe.io/helpdesk/tickets/47332)
