### PR TITLE
feat: set options for IBAN fields

### DIFF
--- a/erpnext/accounts/doctype/bank_account/bank_account.json
+++ b/erpnext/accounts/doctype/bank_account/bank_account.json
@@ -132,7 +132,8 @@
    "fieldtype": "Data",
    "in_list_view": 1,
    "label": "IBAN",
-   "length": 30
+   "length": 30,
+   "options": "IBAN"
   },
   {
    "fieldname": "column_break_12",
@@ -208,6 +209,7 @@
    "label": "Disabled"
   }
  ],
+ "grid_page_length": 50,
  "links": [
   {
    "group": "Transactions",
@@ -250,7 +252,7 @@
    "link_fieldname": "default_bank_account"
   }
  ],
- "modified": "2024-10-30 09:41:14.113414",
+ "modified": "2025-08-26 23:29:24.984767",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Bank Account",
@@ -282,6 +284,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "search_fields": "bank,account",
  "sort_field": "creation",
  "sort_order": "DESC",

--- a/erpnext/accounts/doctype/bank_account/bank_account.json
+++ b/erpnext/accounts/doctype/bank_account/bank_account.json
@@ -132,7 +132,7 @@
    "fieldtype": "Data",
    "in_list_view": 1,
    "label": "IBAN",
-   "length": 30,
+   "length": 34,
    "options": "IBAN"
   },
   {
@@ -252,7 +252,7 @@
    "link_fieldname": "default_bank_account"
   }
  ],
- "modified": "2025-08-26 23:29:24.984767",
+ "modified": "2025-08-29 12:32:01.081687",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Bank Account",

--- a/erpnext/accounts/doctype/bank_account/bank_account.py
+++ b/erpnext/accounts/doctype/bank_account/bank_account.py
@@ -52,7 +52,6 @@ class BankAccount(Document):
 
 	def validate(self):
 		self.validate_company()
-		self.validate_iban()
 		self.validate_account()
 		self.update_default_bank_account()
 
@@ -71,35 +70,6 @@ class BankAccount(Document):
 	def validate_company(self):
 		if self.is_company_account and not self.company:
 			frappe.throw(_("Company is mandatory for company account"))
-
-	def validate_iban(self):
-		"""
-		Algorithm: https://en.wikipedia.org/wiki/International_Bank_Account_Number#Validating_the_IBAN
-		"""
-		# IBAN field is optional
-		if not self.iban:
-			return
-
-		def encode_char(c):
-			# Position in the alphabet (A=1, B=2, ...) plus nine
-			return str(9 + ord(c) - 64)
-
-		# remove whitespaces, upper case to get the right number from ord()
-		iban = "".join(self.iban.split(" ")).upper()
-
-		# Move country code and checksum from the start to the end
-		flipped = iban[4:] + iban[:4]
-
-		# Encode characters as numbers
-		encoded = [encode_char(c) if ord(c) >= 65 and ord(c) <= 90 else c for c in flipped]
-
-		try:
-			to_check = int("".join(encoded))
-		except ValueError:
-			frappe.throw(_("IBAN is not valid"))
-
-		if to_check % 97 != 1:
-			frappe.throw(_("IBAN is not valid"))
 
 	def update_default_bank_account(self):
 		if self.is_default and not self.disabled:

--- a/erpnext/accounts/doctype/bank_account/test_bank_account.py
+++ b/erpnext/accounts/doctype/bank_account/test_bank_account.py
@@ -8,38 +8,4 @@ from frappe.tests import IntegrationTestCase
 
 
 class TestBankAccount(IntegrationTestCase):
-	def test_validate_iban(self):
-		valid_ibans = [
-			"GB82 WEST 1234 5698 7654 32",
-			"DE91 1000 0000 0123 4567 89",
-			"FR76 3000 6000 0112 3456 7890 189",
-		]
-
-		invalid_ibans = [
-			# wrong checksum (3rd place)
-			"GB72 WEST 1234 5698 7654 32",
-			"DE81 1000 0000 0123 4567 89",
-			"FR66 3000 6000 0112 3456 7890 189",
-		]
-
-		bank_account = frappe.get_doc({"doctype": "Bank Account"})
-
-		try:
-			bank_account.validate_iban()
-		except AttributeError:
-			msg = "BankAccount.validate_iban() failed for empty IBAN"
-			self.fail(msg=msg)
-
-		for iban in valid_ibans:
-			bank_account.iban = iban
-			try:
-				bank_account.validate_iban()
-			except ValidationError:
-				msg = f"BankAccount.validate_iban() failed for valid IBAN {iban}"
-				self.fail(msg=msg)
-
-		for not_iban in invalid_ibans:
-			bank_account.iban = not_iban
-			msg = f"BankAccount.validate_iban() accepted invalid IBAN {not_iban}"
-			with self.assertRaises(ValidationError, msg=msg):
-				bank_account.validate_iban()
+	pass

--- a/erpnext/accounts/doctype/bank_guarantee/bank_guarantee.json
+++ b/erpnext/accounts/doctype/bank_guarantee/bank_guarantee.json
@@ -146,6 +146,7 @@
    "fieldname": "iban",
    "fieldtype": "Data",
    "label": "IBAN",
+   "options": "IBAN",
    "read_only": 1
   },
   {
@@ -214,9 +215,10 @@
    "read_only": 1
   }
  ],
+ "grid_page_length": 50,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-03-27 13:06:37.731207",
+ "modified": "2025-08-29 11:52:33.550847",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Bank Guarantee",
@@ -250,6 +252,7 @@
   }
  ],
  "quick_entry": 1,
+ "row_format": "Dynamic",
  "search_fields": "customer",
  "sort_field": "creation",
  "sort_order": "DESC",

--- a/erpnext/accounts/doctype/bank_transaction/bank_transaction.json
+++ b/erpnext/accounts/doctype/bank_transaction/bank_transaction.json
@@ -223,7 +223,8 @@
   {
    "fieldname": "bank_party_iban",
    "fieldtype": "Data",
-   "label": "Party IBAN (Bank Statement)"
+   "label": "Party IBAN (Bank Statement)",
+   "options": "IBAN"
   },
   {
    "fieldname": "bank_party_account_number",
@@ -238,7 +239,7 @@
  "grid_page_length": 50,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-06-18 17:24:57.044666",
+ "modified": "2025-08-29 11:53:45.908169",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Bank Transaction",

--- a/erpnext/accounts/doctype/payment_request/payment_request.json
+++ b/erpnext/accounts/doctype/payment_request/payment_request.json
@@ -228,7 +228,8 @@
    "fetch_from": "bank_account.iban",
    "fieldname": "iban",
    "fieldtype": "Read Only",
-   "label": "IBAN"
+   "label": "IBAN",
+   "options": "IBAN"
   },
   {
    "fetch_from": "bank_account.branch_code",
@@ -458,11 +459,12 @@
    "label": "Phone Number"
   }
  ],
+ "grid_page_length": 50,
  "in_create": 1,
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-01-04 05:39:32.448857",
+ "modified": "2025-08-29 11:52:48.555415",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Payment Request",
@@ -497,6 +499,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "show_preview_popup": 1,
  "sort_field": "creation",
  "sort_order": "DESC",

--- a/erpnext/setup/doctype/employee/employee.json
+++ b/erpnext/setup/doctype/employee/employee.json
@@ -814,7 +814,8 @@
    "depends_on": "eval:doc.salary_mode == 'Bank'",
    "fieldname": "iban",
    "fieldtype": "Data",
-   "label": "IBAN"
+   "label": "IBAN",
+   "options": "IBAN"
   }
  ],
  "icon": "fa fa-user",
@@ -822,7 +823,7 @@
  "image_field": "image",
  "is_tree": 1,
  "links": [],
- "modified": "2025-07-04 08:29:34.347269",
+ "modified": "2025-08-29 11:52:12.819878",
  "modified_by": "Administrator",
  "module": "Setup",
  "name": "Employee",
@@ -864,6 +865,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "search_fields": "employee_name",
  "show_name_in_global_search": 1,
  "sort_field": "creation",


### PR DESCRIPTION
- Sets options to "IBAN" for the respective Data fields to take advantage of a new formatting [feature provided by the  Frappe Framework](https://github.com/frappe/frappe/pull/33812).
- Adjusts the max length of IBANs in **Bank Account** from 30 to 34 characters as per spec.
- Removes the IBAN validation logic from **Bank Account**, since this will be handled by the Framework in a standardized way.

To do:

- [x] Wait for https://github.com/frappe/frappe/pull/33841

> no-docs