### PR TITLE
fix(stock-entry): recalculate total incoming and outgoing amounts

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry.js
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.js
@@ -715,6 +715,7 @@ frappe.ui.form.on("Stock Entry", {
 			precision("basic_amount", item)
 		);
 		frm.events.calculate_total_additional_costs(frm);
+		frm.events.recalculate_totals(frm);
 	},
 
 	calculate_total_additional_costs: function (frm) {
@@ -822,6 +823,27 @@ frappe.ui.form.on("Stock Entry", {
 			);
 			refresh_field("process_loss_qty");
 		}
+	},
+
+	recalculate_totals(frm) {
+		let total_incoming = 0;
+		let total_outgoing = 0;
+
+		frm.doc.items.forEach(function (d) {
+			d.amount = flt(d.qty) * flt(d.basic_rate);
+			if (d.t_warehouse) {
+				total_incoming += d.amount;
+			}
+			if (d.s_warehouse) {
+				total_outgoing += d.amount;
+			}
+		});
+
+		frm.set_value("total_incoming_value", total_incoming);
+		frm.set_value("total_outgoing_value", total_outgoing);
+		frm.set_value("value_difference", total_incoming - total_outgoing);
+
+		frm.refresh_field("items");
 	},
 });
 


### PR DESCRIPTION
**REF:** [47357](https://support.frappe.io/helpdesk/tickets/47357)

**issue:** stock_entry totals were not updating correctly. Incoming and outgoing amounts were miscalculated, leading to incorrect stock valuation.

**fix:** Updated the Stock Entry calculations to properly recalculate total incoming and total outgoing amounts whenever quantity or rate changes.

### **before:**
[Screencast from 28-08-25 07_29_34 PM IST.webm](https://github.com/user-attachments/assets/b98d7c45-38e2-4546-a775-162aef5b8427)



### **after:**
[Screencast from 28-08-25 08_06_41 PM IST.webm](https://github.com/user-attachments/assets/e21916a2-530e-4373-983a-030015d3196c)



### backport needed v15
