### PR TITLE
fix: 'NoneType' object has no attribute 'get' in get_item_details.py

### DIFF
--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -202,7 +202,7 @@ def update_stock(ctx, out, doc=None):
 				"item_code": ctx.item_code,
 				"warehouse": ctx.warehouse,
 				"based_on": frappe.get_single_value("Stock Settings", "pick_serial_and_batch_based_on"),
-				"sabb_voucher_no": doc.get("name"),
+				"sabb_voucher_no": doc.get("name") if doc else None,
 				"sabb_voucher_detail_no": ctx.child_docname,
 				"sabb_voucher_type": ctx.doctype,
 			}


### PR DESCRIPTION
Doc here is a variable that may be null.
<img width="856" height="520" alt="image" src="https://github.com/user-attachments/assets/d9bdc3b3-e61e-4e91-ab3e-d6a362d61f25" />

So it must have a validation before run a .get in doc variable.