### PR TITLE
fix: stop creating transaction logs

### DIFF
--- a/erpnext/hooks.py
+++ b/erpnext/hooks.py
@@ -357,7 +357,6 @@ doc_events = {
 	},
 	"Sales Invoice": {
 		"on_submit": [
-			"erpnext.regional.create_transaction_log",
 			"erpnext.regional.italy.utils.sales_invoice_on_submit",
 		],
 		"on_cancel": [
@@ -372,9 +371,6 @@ doc_events = {
 		]
 	},
 	"Payment Entry": {
-		"on_submit": [
-			"erpnext.regional.create_transaction_log",
-		],
 		"on_trash": "erpnext.regional.check_deletion_permission",
 	},
 	"Address": {

--- a/erpnext/regional/__init__.py
+++ b/erpnext/regional/__init__.py
@@ -12,27 +12,3 @@ def check_deletion_permission(doc, method):
 	region = get_region(doc.company)
 	if region in ["Nepal"] and doc.docstatus != 0:
 		frappe.throw(_("Deletion is not permitted for country {0}").format(region))
-
-
-def create_transaction_log(doc, method):
-	"""
-	Appends the transaction to a chain of hashed logs for legal resons.
-	Called on submit of Sales Invoice and Payment Entry.
-	"""
-	if frappe.conf.get("disable_transaction_log", False):
-		return
-
-	region = get_region()
-	if region not in ["Germany"]:
-		return
-
-	data = str(doc.as_dict())
-
-	frappe.get_doc(
-		{
-			"doctype": "Transaction Log",
-			"reference_doctype": doc.doctype,
-			"document_name": doc.name,
-			"data": data,
-		}
-	).insert(ignore_permissions=True)


### PR DESCRIPTION
Creation of **Transaction Logs** was enabled for Germany only, but it's not really needed here. At least I haven't come across that requirement again in the six years since enabling this feature.

Refer also: https://github.com/frappe/erpnext/pull/49342

The use for France has already been moved to scopen-coop/erpnext_france.

Migration Guide: https://github.com/frappe/erpnext/wiki/Migration-Guide-To-ERPNext-Version-16