### PR TITLE
fix(repost item valuation): validate voucher type in transaction

### DIFF
--- a/erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.js
+++ b/erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.js
@@ -142,7 +142,7 @@ frappe.ui.form.on("Repost Item Valuation", {
 	},
 
 	set_company_on_transaction(frm) {
-		if (frm.doc.voucher_no && frm.doc.voucher_no) {
+		if (frm.doc.voucher_no && frm.doc.voucher_type) {
 			frm.call("set_company");
 		}
 	},


### PR DESCRIPTION
Issue: `set_company_on_transaction` was checking `voucher_no` twice 

follow-up[#49376](https://github.com/frappe/erpnext/pull/49376)

Backport needed: v15