### PR TITLE
fix: COA safer CSV/Excel parsing

### DIFF
--- a/erpnext/accounts/doctype/chart_of_accounts_importer/chart_of_accounts_importer.py
+++ b/erpnext/accounts/doctype/chart_of_accounts_importer/chart_of_accounts_importer.py
@@ -111,51 +111,90 @@ def get_file(file_name):
 
 
 def generate_data_from_csv(file_doc, as_dict=False):
-	"""read csv file and return the generated nested tree"""
+        """read csv file and return the generated nested tree"""
 
-	file_path = file_doc.get_full_path()
+        file_path = file_doc.get_full_path()
+        data = []
 
-	data = []
-	with open(file_path) as in_file:
-		csv_reader = list(csv.reader(in_file))
-		headers = csv_reader[0]
-		del csv_reader[0]  # delete top row and headers row
+        # open with explicit encoding and newline for correct csv parsing (handles BOM)
+        with open(file_path, encoding="utf-8-sig", newline="") as in_file:
+                csv_reader = list(csv.reader(in_file))
+                if not csv_reader:
+                        return data
 
-		for row in csv_reader:
-			if as_dict:
-				data.append({frappe.scrub(header): row[index] for index, header in enumerate(headers)})
-			else:
-				if not row[1] and len(row) > 1:
-					row[1] = row[0]
-					row[3] = row[2]
-				data.append(row)
+                headers = csv_reader[0]
+                rows = csv_reader[1:]
 
-	# convert csv data
-	return data
+                for row in rows:
+                        # skip empty / whitespace-only rows
+                        if not row or all((c or "").strip() == "" for c in row):
+                                continue
+
+                        # pad to 8 columns to be safe downstream
+                        if len(row) < 8:
+                                row += [""] * (8 - len(row))
+
+                        if as_dict:
+                                data.append(
+                                        {
+                                                frappe.scrub(header): (row[index] if index < len(row) else "")
+                                                for index, header in enumerate(headers)
+                                        }
+                                )
+                        else:
+                                # check lengths BEFORE indexing to avoid IndexError
+                                if len(row) > 1 and not row[1]:
+                                        row[1] = row[0]
+                                if len(row) > 3 and not row[3]:
+                                        row[3] = row[2] if len(row) > 2 else ""
+                                data.append(row)
+
+        return data
 
 
 def generate_data_from_excel(file_doc, extension, as_dict=False):
-	content = file_doc.get_content()
+        """read excel file and return the generated nested tree"""
 
-	if extension == "xlsx":
-		rows = read_xlsx_file_from_attached_file(fcontent=content)
-	elif extension == "xls":
-		rows = read_xls_file_from_attached_file(content)
+        content = file_doc.get_content()
 
-	data = []
-	headers = rows[0]
-	del rows[0]
+        if extension == "xlsx":
+                rows = read_xlsx_file_from_attached_file(fcontent=content)
+        elif extension == "xls":
+                rows = read_xls_file_from_attached_file(content)
+        else:
+                return []
 
-	for row in rows:
-		if as_dict:
-			data.append({frappe.scrub(header): row[index] for index, header in enumerate(headers)})
-		else:
-			if not row[1]:
-				row[1] = row[0]
-				row[3] = row[2]
-			data.append(row)
+        data = []
+        if not rows:
+                return data
 
-	return data
+        headers = rows[0]
+        rows = rows[1:]
+
+        for row in rows:
+                # skip empty / whitespace-only rows
+                if not row or all((c or "").strip() == "" for c in row):
+                        continue
+
+                # pad to 8 columns to be safe downstream
+                if len(row) < 8:
+                        row += [""] * (8 - len(row))
+
+                if as_dict:
+                        data.append(
+                                {
+                                        frappe.scrub(header): (row[index] if index < len(row) else "")
+                                        for index, header in enumerate(headers)
+                                }
+                        )
+                else:
+                        if len(row) > 1 and not row[1]:
+                                row[1] = row[0]
+                        if len(row) > 3 and not row[3]:
+                                row[3] = row[2] if len(row) > 2 else ""
+                        data.append(row)
+
+        return data
 
 
 @frappe.whitelist()

--- a/erpnext/accounts/doctype/chart_of_accounts_importer/chart_of_accounts_importer.py
+++ b/erpnext/accounts/doctype/chart_of_accounts_importer/chart_of_accounts_importer.py
@@ -23,6 +23,10 @@ from erpnext.accounts.doctype.account.chart_of_accounts.chart_of_accounts import
 )
 
 
+# expected number of columns in the COA template
+EXPECTED_COLUMNS = 8
+
+
 class ChartofAccountsImporter(Document):
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
@@ -47,7 +51,7 @@ def validate_columns(data):
 
 	no_of_columns = max([len(d) for d in data])
 
-	if no_of_columns != 8:
+	if no_of_columns != EXPECTED_COLUMNS:
 		frappe.throw(
 			_(
 				"Columns are not according to template. Please compare the uploaded file with standard template"
@@ -111,90 +115,86 @@ def get_file(file_name):
 
 
 def generate_data_from_csv(file_doc, as_dict=False):
-        """read csv file and return the generated nested tree"""
+	"""read csv file and return the generated nested tree"""
 
-        file_path = file_doc.get_full_path()
-        data = []
+	file_path = file_doc.get_full_path()
+	data = []
 
-        # open with explicit encoding and newline for correct csv parsing (handles BOM)
-        with open(file_path, encoding="utf-8-sig", newline="") as in_file:
-                csv_reader = list(csv.reader(in_file))
-                if not csv_reader:
-                        return data
+	# open with explicit encoding and newline for correct csv parsing (handles BOM)
+	with open(file_path, encoding="utf-8-sig", newline="") as in_file:
+		csv_reader = csv.reader(in_file)
+		headers = next(csv_reader, None)
+		if not headers:
+			return data
 
-                headers = csv_reader[0]
-                rows = csv_reader[1:]
+		for row in csv_reader:
+			# skip empty / whitespace-only rows
+			if not row or all(cstr(c).strip() == "" for c in row):
+				continue
 
-                for row in rows:
-                        # skip empty / whitespace-only rows
-                        if not row or all((c or "").strip() == "" for c in row):
-                                continue
+			if as_dict:
+				data.append(
+					{
+						frappe.scrub(header): (row[index] if index < len(row) else "")
+						for index, header in enumerate(headers)
+					}
+				)
+				continue
 
-                        # pad to 8 columns to be safe downstream
-                        if len(row) < 8:
-                                row += [""] * (8 - len(row))
+			# list mode: pad to EXPECTED_COLUMNS and backfill safe indices
+			if len(row) < EXPECTED_COLUMNS:
+				row += [""] * (EXPECTED_COLUMNS - len(row))
+			# check lengths BEFORE indexing to avoid IndexError
+			if len(row) > 1 and not cstr(row[1]).strip():
+				row[1] = row[0]
+			if len(row) > 3 and not cstr(row[3]).strip():
+				row[3] = row[2] if len(row) > 2 else ""
+			data.append(row)
 
-                        if as_dict:
-                                data.append(
-                                        {
-                                                frappe.scrub(header): (row[index] if index < len(row) else "")
-                                                for index, header in enumerate(headers)
-                                        }
-                                )
-                        else:
-                                # check lengths BEFORE indexing to avoid IndexError
-                                if len(row) > 1 and not row[1]:
-                                        row[1] = row[0]
-                                if len(row) > 3 and not row[3]:
-                                        row[3] = row[2] if len(row) > 2 else ""
-                                data.append(row)
-
-        return data
+	return data
 
 
 def generate_data_from_excel(file_doc, extension, as_dict=False):
-        """read excel file and return the generated nested tree"""
+	"""read excel file and return the generated nested tree"""
 
-        content = file_doc.get_content()
+	content = file_doc.get_content()
 
-        if extension == "xlsx":
-                rows = read_xlsx_file_from_attached_file(fcontent=content)
-        elif extension == "xls":
-                rows = read_xls_file_from_attached_file(content)
-        else:
-                return []
+	if extension == "xlsx":
+		rows = read_xlsx_file_from_attached_file(fcontent=content)
+	elif extension == "xls":
+		rows = read_xls_file_from_attached_file(content)
+	else:
+		return []
 
-        data = []
-        if not rows:
-                return data
+	data = []
+	if not rows:
+		return data
 
-        headers = rows[0]
-        rows = rows[1:]
+	headers = rows[0]
+	for row in rows[1:]:
+		# skip empty / whitespace-only rows
+		if not row or all(cstr(c).strip() == "" for c in row):
+			continue
 
-        for row in rows:
-                # skip empty / whitespace-only rows
-                if not row or all((c or "").strip() == "" for c in row):
-                        continue
+		if as_dict:
+			data.append(
+				{
+					frappe.scrub(header): (row[index] if index < len(row) else "")
+					for index, header in enumerate(headers)
+				}
+			)
+			continue
 
-                # pad to 8 columns to be safe downstream
-                if len(row) < 8:
-                        row += [""] * (8 - len(row))
+		# list mode: pad to EXPECTED_COLUMNS and backfill safe indices
+		if len(row) < EXPECTED_COLUMNS:
+			row += [""] * (EXPECTED_COLUMNS - len(row))
+		if len(row) > 1 and not cstr(row[1]).strip():
+			row[1] = row[0]
+		if len(row) > 3 and not cstr(row[3]).strip():
+			row[3] = row[2] if len(row) > 2 else ""
+		data.append(row)
 
-                if as_dict:
-                        data.append(
-                                {
-                                        frappe.scrub(header): (row[index] if index < len(row) else "")
-                                        for index, header in enumerate(headers)
-                                }
-                        )
-                else:
-                        if len(row) > 1 and not row[1]:
-                                row[1] = row[0]
-                        if len(row) > 3 and not row[3]:
-                                row[3] = row[2] if len(row) > 2 else ""
-                        data.append(row)
-
-        return data
+	return data
 
 
 @frappe.whitelist()

--- a/erpnext/accounts/doctype/chart_of_accounts_importer/test_chart_of_accounts_importer.py
+++ b/erpnext/accounts/doctype/chart_of_accounts_importer/test_chart_of_accounts_importer.py
@@ -1,9 +1,226 @@
 # Copyright (c) 2019, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-import unittest
+import frappe
+import os
+import tempfile
 
 from frappe.tests import IntegrationTestCase
-
+from frappe.tests.utils import FrappeTestCase
+from erpnext.accounts.doctype.chart_of_accounts_importer.chart_of_accounts_importer import (
+    generate_data_from_csv,
+    generate_data_from_excel,
+)
+# We patch reader functions on the module itself
+from erpnext.accounts.doctype.chart_of_accounts_importer import chart_of_accounts_importer as importer_module
 
 class TestChartofAccountsImporter(IntegrationTestCase):
-	pass
+        pass
+
+
+class TestGenerateDataFromCSV(FrappeTestCase):
+    """Unit tests for pure CSV parsing logic, independent of DB."""
+
+    def _tmp_csv(self, content: str) -> str:
+        f = tempfile.NamedTemporaryFile(delete=False, suffix=".csv", mode="w", encoding="utf-8")
+        try:
+            f.write(content)
+            f.flush()
+            return f.name
+        finally:
+            f.close()
+
+    def _file_stub(self, path: str):
+        return frappe._dict(get_full_path=lambda: path)
+
+    def _cleanup(self, path: str):
+        try:
+            os.remove(path)
+        except Exception:
+            pass
+
+
+    def test_bom_and_empty_rows(self):
+        csv_content = u"\ufeffHeader1,Header2,Header3\nA,,C\n  ,  ,  \nB,D\n"
+        p = self._tmp_csv(csv_content)
+        try:
+            data = generate_data_from_csv(self._file_stub(p), as_dict=False)
+            self.assertEqual(len(data), 2)
+            self.assertEqual(data[0][0], "A")
+            self.assertEqual(data[0][1], "A")
+            self.assertEqual(data[0][2], "C")
+            self.assertEqual(data[0][3], "C")
+            self.assertGreaterEqual(len(data[0]), 8)
+            self.assertEqual(data[1][0], "B")
+            self.assertEqual(data[1][1], "D")
+        finally:
+            self._cleanup(p)
+
+
+    def test_as_dict_mode(self):
+        csv_content = u"\ufeffAccount Name,Account Code,Group?\nCash,,Yes\n"
+        p = self._tmp_csv(csv_content)
+        try:
+            data = generate_data_from_csv(self._file_stub(p), as_dict=True)
+            self.assertIsInstance(data, list)
+            self.assertEqual(len(data), 1)
+            row = data[0]
+
+            # Always present:
+            self.assertEqual(row["account_name"], "Cash")
+            self.assertEqual(row["account_code"], "")
+
+            # Accept either "group" or "group?" depending on frappe.scrub behavior
+            group_val = row.get("group", row.get("group?"))
+            self.assertEqual(group_val, "Yes")
+
+            # Optional: ensure there isn't some unexpected third variant
+            allowed_keys = {"account_name", "account_code", "group", "group?"}
+            self.assertTrue(set(row.keys()).issubset(allowed_keys))
+        finally:
+            self._cleanup(p)
+
+
+    def test_empty_csv(self):
+        p = self._tmp_csv("")
+        try:
+            data = generate_data_from_csv(self._file_stub(p))
+            self.assertEqual(data, [])
+        finally:
+            self._cleanup(p)
+
+
+    def test_headers_only(self):
+        p = self._tmp_csv("Col1,Col2\n")
+        try:
+            data = generate_data_from_csv(self._file_stub(p))
+            self.assertEqual(data, [])
+        finally:
+            self._cleanup(p)
+
+
+    def test_exactly_8_columns(self):
+        headers = ",".join([f"H{i}" for i in range(1, 9)])
+        row = ",".join([f"A{i}" for i in range(1, 9)])
+        p = self._tmp_csv(headers + "\n" + row + "\n")
+        try:
+            data = generate_data_from_csv(self._file_stub(p))
+            self.assertEqual(len(data[0]), 8)
+            self.assertEqual(data[0][0], "A1")
+            self.assertEqual(data[0][7], "A8")
+        finally:
+            self._cleanup(p)
+
+
+    def test_more_than_8_columns(self):
+        headers = ",".join([f"H{i}" for i in range(1, 11)])
+        row = ",".join([f"B{i}" for i in range(1, 11)])
+        p = self._tmp_csv(headers + "\n" + row + "\n")
+        try:
+            data = generate_data_from_csv(self._file_stub(p))
+            self.assertGreaterEqual(len(data[0]), 10)
+            self.assertEqual(data[0][9], "B10")
+        finally:
+            self._cleanup(p)
+
+
+    def test_short_rows_are_padded(self):
+        p = self._tmp_csv("H1,H2,H3\nX,Y\n")
+        try:
+            data = generate_data_from_csv(self._file_stub(p))
+            self.assertEqual(data[0][0], "X")
+            self.assertEqual(data[0][1], "Y")
+            self.assertGreaterEqual(len(data[0]), 8)
+            self.assertTrue(all(c == "" for c in data[0][2:8]))
+        finally:
+            self._cleanup(p)
+
+class TestGenerateDataFromExcel(FrappeTestCase):
+    """Unit tests for Excel parsing, using monkey-patched readers (no real xlsx/xls files)."""
+
+    def setUp(self):
+        # Keep originals so we can restore in tearDown
+        self._orig_read_xlsx = getattr(importer_module, "read_xlsx_file_from_attached_file", None)
+        self._orig_read_xls  = getattr(importer_module, "read_xls_file_from_attached_file", None)
+
+    def tearDown(self):
+        # Restore originals (important to avoid cross-test side effects)
+        if self._orig_read_xlsx is not None:
+            importer_module.read_xlsx_file_from_attached_file = self._orig_read_xlsx
+        if self._orig_read_xls is not None:
+            importer_module.read_xls_file_from_attached_file = self._orig_read_xls
+
+    def _file_stub(self, content: bytes = b""):
+        # Excel path calls file_doc.get_content(); we can return anything since we patch the readers
+        return frappe._dict(get_content=lambda: content)
+
+    def test_excel_as_dict_mode_and_empty_rows(self):
+        # Simulate what the reader would return: first row headers, then data rows
+        rows = [
+            ["Account Name", "Account Code", "Group?" ],
+            ["Cash",         "",             "Yes"    ],
+            ["  ",           "  ",           "   "    ],  # whitespace-only -> should be skipped
+            ["Bank",         "123",          ""       ],
+        ]
+        importer_module.read_xlsx_file_from_attached_file = lambda fcontent: rows
+
+        file_doc = self._file_stub()
+        data = generate_data_from_excel(file_doc, extension="xlsx", as_dict=True)
+        self.assertEqual(len(data), 2)
+
+        # Row 1 (Cash)
+        r0 = data[0]
+        self.assertEqual(r0["account_name"], "Cash")
+        self.assertEqual(r0["account_code"], "")
+        # Accept "group" or "group?" depending on frappe.scrub behavior
+        self.assertEqual(r0.get("group", r0.get("group?")), "Yes")
+
+        # Row 2 (Bank)
+        r1 = data[1]
+        self.assertEqual(r1["account_name"], "Bank")
+        self.assertEqual(r1["account_code"], "123")
+        self.assertFalse(bool(r1.get("group", r1.get("group?"))))
+
+    def test_excel_list_mode_padding_and_safe_indexing(self):
+        rows = [
+            ["H1","H2","H3","H4","H5","H6","H7","H8"],
+            ["A1","",   "A3"],        # short row; row[1] should backfill from row[0]; row[3] from row[2]
+            ["B1","B2"],              # even shorter; safe indexing + padding to >= 8 cols
+        ]
+        importer_module.read_xlsx_file_from_attached_file = lambda fcontent: rows
+
+        file_doc = self._file_stub()
+        data = generate_data_from_excel(file_doc, extension="xlsx", as_dict=False)
+
+        # Row 0: backfills
+        self.assertEqual(data[0][0], "A1")
+        self.assertEqual(data[0][1], "A1")  # backfilled
+        self.assertEqual(data[0][2], "A3")
+        self.assertEqual(data[0][3], "A3")  # backfilled
+        self.assertGreaterEqual(len(data[0]), 8)
+
+        # Row 1: very short, must be padded
+        self.assertEqual(data[1][0], "B1")
+        self.assertEqual(data[1][1], "B2")
+        self.assertGreaterEqual(len(data[1]), 8)
+        self.assertTrue(all(c == "" for c in data[1][2:8]))
+
+    def test_excel_headers_only(self):
+        rows = [["Col1","Col2","Col3"]]  # only headers
+        importer_module.read_xls_file_from_attached_file = lambda content: rows
+
+        file_doc = self._file_stub()
+        data = generate_data_from_excel(file_doc, extension="xls", as_dict=False)
+        self.assertEqual(data, [])
+
+    def test_excel_more_than_8_columns_preserved(self):
+        headers = [f"H{i}" for i in range(1, 11)]  # 10 cols
+        row     = [f"V{i}" for i in range(1, 11)]
+        rows = [headers, row]
+        importer_module.read_xlsx_file_from_attached_file = lambda fcontent: rows
+
+        file_doc = self._file_stub()
+        data = generate_data_from_excel(file_doc, extension="xlsx", as_dict=False)
+        self.assertEqual(len(data), 1)
+        self.assertGreaterEqual(len(data[0]), 10)
+        self.assertEqual(data[0][8],  "V9")
+        self.assertEqual(data[0][9],  "V10")

--- a/erpnext/accounts/doctype/chart_of_accounts_importer/test_chart_of_accounts_importer.py
+++ b/erpnext/accounts/doctype/chart_of_accounts_importer/test_chart_of_accounts_importer.py
@@ -40,7 +40,7 @@ class TestGenerateDataFromCSV(FrappeTestCase):
 
 
     def test_bom_and_empty_rows(self):
-        csv_content = u"\ufeffHeader1,Header2,Header3\nA,,C\n  ,  ,  \nB,D\n"
+        csv_content = "\ufeffHeader1,Header2,Header3\nA,,C\n  ,  ,  \nB,D\n"
         p = self._tmp_csv(csv_content)
         try:
             data = generate_data_from_csv(self._file_stub(p), as_dict=False)
@@ -57,7 +57,7 @@ class TestGenerateDataFromCSV(FrappeTestCase):
 
 
     def test_as_dict_mode(self):
-        csv_content = u"\ufeffAccount Name,Account Code,Group?\nCash,,Yes\n"
+        csv_content = "\ufeffAccount Name,Account Code,Group?\nCash,,Yes\n"
         p = self._tmp_csv(csv_content)
         try:
             data = generate_data_from_csv(self._file_stub(p), as_dict=True)


### PR DESCRIPTION
## Problem
- `generate_data_from_csv` failed on certain CSV files:
  - BOM (`\ufeff`) in headers caused wrong column names.
  - Empty lines or whitespace-only rows raised errors.
  - Shorter rows (<4 cols) caused `IndexError`.
  - Missing values in column 2 or 4 caused unhandled issues.
- `generate_data_from_excel` had similar issues:
  - Empty/whitespace-only rows not skipped.
  - Short rows caused unsafe indexing (`row[1]`, `row[3]`).
  - Behavior inconsistent with CSV importer.
- No direct unit tests existed for these functions, so regressions were easy to miss.

## Fix
- CSV:
  - Open file with `encoding="utf-8-sig", newline=""` to handle BOMs correctly.
  - Skip empty/whitespace-only rows.
  - Pad rows to at least 8 columns (consistent with downstream assumptions).
  - Added safe indexing: only overwrite row[1] or row[3] if indices exist.
  - Support empty CSV (returns empty list instead of raising).
- Excel:
  - Applied same logic as CSV for skipping, padding, and safe indexing.
  - Ensured consistent behavior between CSV and Excel importers.
  - Tests:
  - Added comprehensive unit tests for both CSV and Excel importers.
  - Covered edge cases: BOM headers, empty/whitespace rows, short rows, headers-only, exactly 8 columns, >8 columns.

## Impact
- Backwards compatible: output structure unchanged.
- More resilient against malformed input files (both CSV and Excel).
- Prevents import errors when using Chart of Accounts or other importers.
- Consistent logic across CSV and Excel imports.
- Regression safety via new test coverage.

Closes #43582
