### PR TITLE
fix: show country name for United States in address template

### DIFF
--- a/erpnext/regional/address_template/templates/united_states.html
+++ b/erpnext/regional/address_template/templates/united_states.html
@@ -1,4 +1,4 @@
 {{ address_line1 }}<br>
 {% if address_line2 %}{{ address_line2 }}<br>{% endif -%}
 {{ city }}, {% if state %}{{ state }}{% endif -%}{% if pincode %} {{ pincode }}{% endif -%}<br>
-{% if country != "United States" %}{{ country }}{% endif -%}
+{{ country }}


### PR DESCRIPTION
<p data-start="208" data-end="383"><strong data-start="208" data-end="218">Issue:</strong><br data-start="218" data-end="221">
The country name <strong data-start="238" data-end="257">"United States"</strong> was not being displayed in the address format because the United States address template had the following conditional check:</p>
<pre class="overflow-visible!" data-start="384" data-end="457"><div class="contain-inline-size rounded-2xl relative bg-token-sidebar-surface-primary"><div class="sticky top-9"><div class="absolute end-0 bottom-0 flex h-9 items-center pe-2"><div class="bg-token-bg-elevated-secondary text-token-text-secondary flex items-center gap-4 rounded-sm px-2 font-sans text-xs"></div></div></div><div class="overflow-y-auto p-4" dir="ltr"><code class="whitespace-pre! language-jinja"><span>{% if country != "United States" %}{{ country }}{% endif -%}
</span></code></div></div></pre>
<p data-start="458" data-end="618">This caused the country name to be omitted, leading to inconsistent behavior compared to other countries like India, where the country name is shown by default.</p>
<hr data-start="620" data-end="623">
<p data-start="625" data-end="758"><strong data-start="625" data-end="633">Fix:</strong><br data-start="633" data-end="636">
Updated the <strong data-start="648" data-end="682">United States address template</strong> to <strong data-start="686" data-end="721">always display the country name</strong> by removing the conditional check.</p>
<p data-start="760" data-end="781"><strong data-start="760" data-end="781">Updated Template:</strong></p>
<pre class="overflow-visible!" data-start="782" data-end="986"><div class="contain-inline-size rounded-2xl relative bg-token-sidebar-surface-primary"><div class="sticky top-9"><div class="absolute end-0 bottom-0 flex h-9 items-center pe-2"><div class="bg-token-bg-elevated-secondary text-token-text-secondary flex items-center gap-4 rounded-sm px-2 font-sans text-xs"></div></div></div><div class="overflow-y-auto p-4" dir="ltr"><code class="whitespace-pre! language-jinja"><span>{{ address_line1 }}&lt;br&gt;
{% if address_line2 %}{{ address_line2 }}&lt;br&gt;{% endif -%}
{{ city }}, {% if state %}{{ state }}{% endif -%}{% if pincode %} {{ pincode }}{% endif -%}&lt;br&gt;
{{ country }}
</span></code></div></div></pre>
<hr data-start="988" data-end="991">
<p data-start="993" data-end="1011"><strong data-start="993" data-end="1009">Screenshots:</strong></p>
<div class="_tableContainer_1rjym_1"><div tabindex="-1" class="_tableWrapper_1rjym_13 group flex w-fit flex-col-reverse">
Before (Bug)
<img width="1227" height="727" alt="Screenshot from 2025-08-31 11-11-42" src="https://github.com/user-attachments/assets/b741d63a-b6f3-4dfd-a06f-ef7c185262c9" />

<img width="1227" height="727" alt="Screenshot from 2025-08-31 11-11-49" src="https://github.com/user-attachments/assets/5ae92c69-65c2-4b93-9c3e-f5cf9c90e836" />

After (Fix)
<img width="1275" height="656" alt="Screenshot from 2025-08-31 11-16-59" src="https://github.com/user-attachments/assets/771792b1-4bd5-475c-ad04-5f823fb1f57a" />

</div></div>
<hr data-start="1156" data-end="1159">
<p data-start="1161" data-end="1174"><strong data-start="1161" data-end="1172">Impact:</strong></p>
<ul data-start="1175" data-end="1353">
<li data-start="1175" data-end="1308">
<p data-start="1177" data-end="1308">Addresses in the United States now display the country name consistently, improving clarity for documents, invoices, and reports.</p>
</li>
<li data-start="1309" data-end="1353">
<p data-start="1311" data-end="1353">No impact on other countries or templates.</p></li></ul>