### PR TITLE
fix(perf): applying consistent index to fetch gl entries for financial statements

### DIFF
--- a/erpnext/accounts/report/financial_statements.py
+++ b/erpnext/accounts/report/financial_statements.py
@@ -530,6 +530,7 @@ def get_accounting_entries(
 		query = query.select(gl_entry.posting_date, gl_entry.is_opening, gl_entry.fiscal_year)
 		query = query.where(gl_entry.is_cancelled == 0)
 		query = query.where(gl_entry.posting_date <= to_date)
+		query = query.force_index("posting_date_company_index")
 
 		if ignore_opening_entries and not ignore_is_opening:
 			query = query.where(gl_entry.is_opening == "No")


### PR DESCRIPTION
Applied force index on `posting_date_company_index` for GL Entries to `get_accounting_entries` for various financial statements. This will make sure that a consistent index is used to fetch accounting entries from the DB.

Fixes support ticket [47409](https://support.frappe.io/helpdesk/tickets/47409).

Background: While investigating the support ticket, it was observed that the DB was not using a consistent index to fetch GL Entries for different timeframes, resulting in ConnectionLost Error.