### PR TITLE
fix: Fix SLA resolution by date time calculation with hold time

### DIFF
--- a/erpnext/support/doctype/service_level_agreement/service_level_agreement.py
+++ b/erpnext/support/doctype/service_level_agreement/service_level_agreement.py
@@ -882,13 +882,14 @@ def set_response_by(doc, start_date_time, priority):
 
 def set_resolution_by(doc, start_date_time, priority):
 	if doc.meta.has_field("sla_resolution_by"):
+		if doc.meta.has_field("total_hold_time") and doc.get("total_hold_time"):
+			start_date_time = add_to_date(
+				start_date_time, seconds=round(doc.get("total_hold_time")), as_datetime=True
+			)
+
 		doc.sla_resolution_by = get_expected_time_for(
 			parameter="resolution", service_level=priority, start_date_time=start_date_time
 		)
-		if doc.meta.has_field("total_hold_time") and doc.get("total_hold_time"):
-			doc.sla_resolution_by = add_to_date(
-				doc.sla_resolution_by, seconds=round(doc.get("total_hold_time"))
-			)
 
 
 def record_assigned_users_on_failure(doc):


### PR DESCRIPTION
**Fix: SLA resolution by date time calculation with hold time**
This PR addresses an issue where the Resolution Time calculation incorrectly included hold time, leading to a total resolution duration that could exceed the defined SLA working hours or days.

The logic has been updated to account for hold time before calculating the Resolution By datetime. This ensures that the final Resolution By datetime remains accurate and in line with SLA settings.

SLA Configurations
<img width="1120" height="793" alt="image" src="https://github.com/user-attachments/assets/2d6f229c-cdfb-4b2d-8f20-2131c4a3a1da" />

Before
<img width="1277" height="650" alt="image" src="https://github.com/user-attachments/assets/6024dabd-79f3-471e-bec5-b869c6c2f568" />

After
<img width="1244" height="594" alt="image" src="https://github.com/user-attachments/assets/ce9e3e71-cf99-47c9-9ad5-b8a91a63d4ff" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected SLA “Resolution By” calculation to properly account for hold/paused time at the start of the timer, improving accuracy of expected resolution deadlines.
  * Eliminates inflated deadlines and inconsistencies by integrating hold duration directly into the computation, ensuring aligned values across tickets, reports, and notifications.
  * Delivers more predictable SLA behavior without requiring configuration changes, applying wherever the SLA resolution deadline is shown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->