### PR TITLE
fix: valuation for batch items

### DIFF
--- a/erpnext/stock/serial_batch_bundle.py
+++ b/erpnext/stock/serial_batch_bundle.py
@@ -804,12 +804,15 @@ class BatchNoValuation(DeprecatedBatchNoValuation):
 			self.non_batchwise_valuation_batches = self.batches
 			return
 
-		batches = frappe.get_all(
-			"Batch", filters={"name": ("in", self.batches), "use_batchwise_valuation": 1}, fields=["name"]
-		)
+		if get_valuation_method(self.sle.item_code) == "FIFO":
+			self.batchwise_valuation_batches = self.batches
+		else:
+			batches = frappe.get_all(
+				"Batch", filters={"name": ("in", self.batches), "use_batchwise_valuation": 1}, fields=["name"]
+			)
 
-		for batch in batches:
-			self.batchwise_valuation_batches.append(batch.name)
+			for batch in batches:
+				self.batchwise_valuation_batches.append(batch.name)
 
 		self.non_batchwise_valuation_batches = list(set(self.batches) - set(self.batchwise_valuation_batches))
 


### PR DESCRIPTION
If the valuation method is FIFO, then calculate the valuation based on the average rate.