### PR TITLE
test: use valid IBANs in party matching test case

### DIFF
--- a/erpnext/accounts/doctype/bank_transaction/test_auto_match_party.py
+++ b/erpnext/accounts/doctype/bank_transaction/test_auto_match_party.py
@@ -7,6 +7,9 @@ from frappe.utils import nowdate
 
 from erpnext.accounts.doctype.bank_transaction.test_bank_transaction import create_bank_account
 
+IBAN_1 = "DE02000000003716541159"
+IBAN_2 = "DE02500105170137075030"
+
 
 class TestAutoMatchParty(IntegrationTestCase):
 	@classmethod
@@ -22,24 +25,24 @@ class TestAutoMatchParty(IntegrationTestCase):
 		frappe.db.set_single_value("Accounts Settings", "enable_fuzzy_matching", 0)
 
 	def test_match_by_account_number(self):
-		create_supplier_for_match(account_no="000000003716541159")
+		create_supplier_for_match(account_no=IBAN_1[11:])
 		doc = create_bank_transaction(
 			withdrawal=1200,
 			transaction_id="562213b0ca1bf838dab8f2c6a39bbc3b",
-			account_no="000000003716541159",
-			iban="DE02000000003716541159",
+			account_no=IBAN_1[11:],
+			iban=IBAN_1,
 		)
 
 		self.assertEqual(doc.party_type, "Supplier")
 		self.assertEqual(doc.party, "John Doe & Co.")
 
 	def test_match_by_iban(self):
-		create_supplier_for_match(iban="DE02000000003716541159")
+		create_supplier_for_match(iban=IBAN_1)
 		doc = create_bank_transaction(
 			withdrawal=1200,
 			transaction_id="c5455a224602afaa51592a9d9250600d",
-			account_no="000000003716541159",
-			iban="DE02000000003716541159",
+			account_no=IBAN_1[11:],
+			iban=IBAN_1,
 		)
 
 		self.assertEqual(doc.party_type, "Supplier")
@@ -51,7 +54,7 @@ class TestAutoMatchParty(IntegrationTestCase):
 			withdrawal=1200,
 			transaction_id="1f6f661f347ff7b1ea588665f473adb1",
 			party_name="Ella Jackson",
-			iban="DE04000000003716545346",
+			iban=IBAN_2,
 		)
 		self.assertEqual(doc.party_type, "Supplier")
 		self.assertEqual(doc.party, "Jackson Ella W.")


### PR DESCRIPTION
Resolves https://github.com/frappe/frappe/pull/33812#issuecomment-3244910464

https://github.com/frappe/erpnext/actions/runs/17401423284/job/49395262401?pr=49425

```
======================================================================
 ERROR  test_match_by_party_name (erpnext.accounts.doctype.bank_transaction.test_auto_match_party.TestAutoMatchParty.test_match_by_party_name)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/runner/frappe-bench/apps/erpnext/erpnext/accounts/doctype/bank_transaction/test_auto_match_party.py", line 50, in test_match_by_party_name
    doc = create_bank_transaction(
          ^^^^^^^^^^^^^^^^^^^^^^^^
    self = <erpnext.accounts.doctype.bank_transaction.test_auto_match_party.TestAutoMatchParty testMethod=test_match_by_party_name>
  File "/home/runner/frappe-bench/apps/erpnext/erpnext/accounts/doctype/bank_transaction/test_auto_match_party.py", line 147, in create_bank_transaction
    doc.insert()
    account_no = None
    deposit = 0
    description = None
    doc = <BankTransaction: doctype=Bank Transaction ACC-BTN-2025-00004>
    iban = 'DE04000000003716545346'
    party_name = 'Ella Jackson'
    transaction_id = '1f6f661f347ff7b1ea588665f473adb1'
    withdrawal = 1200
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 416, in insert
    self._validate()
    ignore_if_duplicate = False
    ignore_links = None
    ignore_mandatory = None
    ignore_permissions = None
    self = <BankTransaction: doctype=Bank Transaction ACC-BTN-2025-00004>
    set_child_names = True
    set_name = None
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 744, in _validate
    self._validate_data_fields()
    self = <BankTransaction: doctype=Bank Transaction ACC-BTN-2025-00004>
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/base_document.py", line 1036, in _validate_data_fields
    validate_iban(data, throw=True)
    data = 'DE04000000003716545346'
    data_field = <DataDocField: bank_party_iban parent=Bank Transaction>
    data_field_options = 'IBAN'
    old_fieldtype = None
    self = <BankTransaction: doctype=Bank Transaction ACC-BTN-2025-00004>
    split_emails = <function split_emails at 0x7f47bc8c6700>
    validate_email_address = <function validate_email_address at 0x7f47bc8c6660>
    validate_iban = <function validate_iban at 0x7f47bc8c6840>
    validate_name = <function validate_name at 0x7f47bc8c65c0>
    validate_phone_number = <function validate_phone_number at 0x7f47bc8c6520>
    validate_phone_number_with_country_code = <function validate_phone_number_with_country_code at 0x7f47bc8c6480>
    validate_url = <function validate_url at 0x7f47bc8c67a0>
  File "/home/runner/frappe-bench/apps/frappe/frappe/utils/__init__.py", line 269, in validate_iban
    frappe.throw(frappe._("'{0}' is not a valid IBAN").format(frappe.bold(iban)))
    _ = <function _ at 0x7f47bc9191c0>
    iban = 'DE04000000003716545346'
    throw = True
    valid = False
  File "/home/runner/frappe-bench/apps/frappe/frappe/utils/messages.py", line 145, in throw
    msgprint(
    as_list = False
    exc = <class 'frappe.exceptions.ValidationError'>
    is_minimizable = False
    msg = "'<strong>DE04000000003716545346</strong>' is not a valid IBAN"
    primary_action = None
    title = None
    wide = False
  File "/home/runner/frappe-bench/apps/frappe/frappe/utils/messages.py", line 106, in msgprint
    _raise_exception()
    _raise_exception = <function msgprint.<locals>._raise_exception at 0x7f47af5f0540>
    alert = False
    as_list = False
    as_table = False
    indicator = 'red'
    inspect = <module 'inspect' from '/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/inspect.py'>
    is_minimizable = False
    msg = "'<strong>DE04000000003716545346</strong>' is not a valid IBAN"
    out = {'message': "'<strong>DE04000000003716545346</strong>' is not a valid IBAN", 'title': 'Message', 'indicator': 'red', 'raise_exception': 1, '__frappe_exc_id': 'c8c003bc39d762d44cdf29921c99579b15f13997b2407466a8a600c7'}
    primary_action = None
    raise_exception = <class 'frappe.exceptions.ValidationError'>
    realtime = False
    title = None
    wide = False
  File "/home/runner/frappe-bench/apps/frappe/frappe/utils/messages.py", line 57, in _raise_exception
    raise exc
    exc = ValidationError("'<strong>DE04000000003716545346</strong>' is not a valid IBAN")
    inspect = <module 'inspect' from '/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/inspect.py'>
    msg = "'<strong>DE04000000003716545346</strong>' is not a valid IBAN"
    out = {'message': "'<strong>DE04000000003716545346</strong>' is not a valid IBAN", 'title': 'Message', 'indicator': 'red', 'raise_exception': 1, '__frappe_exc_id': 'c8c003bc39d762d44cdf29921c99579b15f13997b2407466a8a600c7'}
    raise_exception = <class 'frappe.exceptions.ValidationError'>
frappe.exceptions.ValidationError: '<strong>DE04000000003716545346</strong>' is not a valid IBAN
```