### PR TITLE
fix(acc): thai fiscal year

### DIFF
--- a/erpnext/public/js/setup_wizard.js
+++ b/erpnext/public/js/setup_wizard.js
@@ -264,6 +264,5 @@ erpnext.setup.fiscal_years = {
 	Pakistan: ["07-01", "06-30"],
 	Singapore: ["04-01", "03-31"],
 	"South Africa": ["03-01", "02-28"],
-	Thailand: ["10-01", "09-30"],
 	"United Kingdom": ["04-01", "03-31"],
 };


### PR DESCRIPTION
On setup wizard, Fiscal Year for Thailand has always been incorrect.
It should be the default one. (1st Jan - 31st Dec).

(I don't think no one care enough to make a pull request but it's always been wrong.)

Sorry I couldn't find the source from government site.

Source 1: https://en.wikipedia.org/wiki/Fiscal_year
Quote:
In [Thailand](https://en.wikipedia.org/wiki/Thailand), the government's fiscal year (FY) is 1 October to 30 September of the following year. For individual taxpayers it is the calendar year, 1 January to 31 December.

Source 2: https://thailand.acclime.com/guides/accounting-introduction/
Quote:
By default, the financial year-end for companies registered in Thailand is 31 December.

Source 3: https://belaws.com/thailand/annual-closing-thailand/
Quote:
In Thailand, most companies close their financial year on December 31st

Source 4: https://www.itax.in.th/pedia/%E0%B8%9B%E0%B8%B5%E0%B8%A0%E0%B8%B2%E0%B8%A9%E0%B8%B5
Quote:
โดยปกติรอบระยะเวลาบัญชีจะมีระยะเวลา 12 เดือน และมักจะเริ่มนับตามปีปฎิทินตั้งแต่วันที่ 1 มกราคม – 31 ธันวาคม ของปีนั้นๆ
(Normally, an accounting period lasts 12 months, and it usually follows the calendar year, starting from January 1 to December 31 of that year.)

<img width="1325" height="1504" alt="image" src="https://github.com/user-attachments/assets/245fede8-af9a-4363-ade7-5fb27e1a909f" />
