### PR TITLE
fix(production plan): filter sales orders by item

### DIFF
--- a/erpnext/manufacturing/doctype/production_plan/production_plan.js
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.js
@@ -34,6 +34,7 @@ frappe.ui.form.on("Production Plan", {
 				query: "erpnext.manufacturing.doctype.production_plan.production_plan.sales_order_query",
 				filters: {
 					company: frm.doc.company,
+					item_code: frm.doc.item_code,
 				},
 			};
 		});

--- a/erpnext/manufacturing/doctype/production_plan/production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.py
@@ -2080,6 +2080,9 @@ def sales_order_query(doctype=None, txt=None, searchfield=None, start=None, page
 	if filters.get("sales_orders"):
 		query = query.where(so_table.name.isin(filters.get("sales_orders")))
 
+	if filters.get("item_code"):
+		query = query.where(table.item_code == filters.get("item_code"))
+
 	if txt:
 		query = query.where(table.parent.like(f"%{txt}%"))
 


### PR DESCRIPTION
Issue: When selecting Sales Orders in Production Plan with a specific Item Code, Sales Orders that already have a Production Plan for that Item are also being shown.

Ref: [#47585](https://support.frappe.io/helpdesk/tickets/47585)

Before:

https://github.com/user-attachments/assets/d2179d46-fb23-442b-9beb-a4f75b568d2c

After:

https://github.com/user-attachments/assets/e7446422-b670-41fa-bcb9-68e9b00996be

Backport needed: v15