### PR TITLE
fix: remove mandatory item description in LCV

### DIFF
--- a/erpnext/stock/doctype/landed_cost_item/landed_cost_item.json
+++ b/erpnext/stock/doctype/landed_cost_item/landed_cost_item.json
@@ -42,7 +42,6 @@
    "oldfieldtype": "Data",
    "print_width": "300px",
    "read_only": 1,
-   "reqd": 1,
    "width": "120px"
   },
   {
@@ -145,7 +144,7 @@
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-06-11 08:53:38.096761",
+ "modified": "2025-09-03 17:42:13.644861",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Landed Cost Item",

--- a/erpnext/stock/doctype/landed_cost_item/landed_cost_item.py
+++ b/erpnext/stock/doctype/landed_cost_item/landed_cost_item.py
@@ -17,7 +17,7 @@ class LandedCostItem(Document):
 		amount: DF.Currency
 		applicable_charges: DF.Currency
 		cost_center: DF.Link | None
-		description: DF.TextEditor
+		description: DF.TextEditor | None
 		is_fixed_asset: DF.Check
 		item_code: DF.Link
 		parent: DF.Data
@@ -27,9 +27,7 @@ class LandedCostItem(Document):
 		qty: DF.Float
 		rate: DF.Currency
 		receipt_document: DF.DynamicLink | None
-		receipt_document_type: DF.Literal[
-			"Purchase Invoice", "Purchase Receipt", "Stock Entry", "Subcontracting Receipt"
-		]
+		receipt_document_type: DF.Literal["Purchase Invoice", "Purchase Receipt", "Stock Entry", "Subcontracting Receipt"]
 		stock_entry_item: DF.Data | None
 	# end: auto-generated types
 


### PR DESCRIPTION
**Issue** : description field is mandatory for items table in LCV, even though it is not in Purchase Receipt Item nor in item master.

**Fix** : Remove mandatory for description in the LCV items table.


**Before** :

<img width="1915" height="1016" alt="Screenshot from 2025-09-03 15-25-40" src="https://github.com/user-attachments/assets/87045395-989f-4a3e-bfeb-ff835082449c" />


**After** :

<img width="1915" height="1016" alt="Screenshot from 2025-09-03 15-28-26" src="https://github.com/user-attachments/assets/a54aa2c3-d456-4315-80ab-e7dbdf067d16" />

Backport needed : V14 , V15