### PR TITLE
fix: add condition for name

### DIFF
--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -2482,6 +2482,10 @@ def build_qb_match_conditions(doctype, user=None) -> list:
 		for filter in match_filters:
 			for link_option, allowed_values in filter.items():
 				fieldnames = link_fields_map.get(link_option, [])
+				cond = None
+
+				if link_option == doctype:
+					cond = _dt["name"].isin(allowed_values)
 
 				for fieldname in fieldnames:
 					field = _dt[fieldname]
@@ -2490,6 +2494,7 @@ def build_qb_match_conditions(doctype, user=None) -> list:
 					if not apply_strict_user_permissions:
 						cond = (Coalesce(field, "") == "") | cond
 
+				if cond:
 					criterion.append(cond)
 
 	return criterion

--- a/erpnext/setup/doctype/employee/test_employee.py
+++ b/erpnext/setup/doctype/employee/test_employee.py
@@ -4,9 +4,11 @@ import unittest
 
 import frappe
 import frappe.utils
+from frappe.query_builder import Criterion
 from frappe.tests import IntegrationTestCase
 
 import erpnext
+from erpnext.accounts.utils import build_qb_match_conditions
 from erpnext.setup.doctype.employee.employee import InactiveEmployeeStatusError
 
 
@@ -31,6 +33,32 @@ class TestEmployee(IntegrationTestCase):
 		employee_doc.user_id = ""
 		employee_doc.save()
 		self.assertTrue("Employee" not in frappe.get_roles(user))
+
+	def test_employee_user_permission(self):
+		employee1 = make_employee("employee_1_test@company.com", create_user_permission=1)
+		employee2 = make_employee("employee_2_test@company.com", create_user_permission=1)
+		make_employee("employee_3_test@company.com", create_user_permission=1)
+
+		employee1_doc = frappe.get_doc("Employee", employee1)
+		employee2_doc = frappe.get_doc("Employee", employee2)
+
+		employee2_doc.reload()
+		employee2_doc.reports_to = employee1_doc.name
+		employee2_doc.save()
+
+		frappe.set_user(employee1_doc.user_id)
+
+		Employee = frappe.qb.DocType("Employee")
+		qb_employee_list = (
+			frappe.qb.from_(Employee)
+			.select(Employee.name)
+			.where(Criterion.all(build_qb_match_conditions("Employee")))
+			.orderby(Employee.Name)
+		).run(pluck=Employee.name)
+		employee_list = frappe.db.get_list("Employee", pluck="name", order_by="name")
+
+		self.assertEqual(qb_employee_list, employee_list)
+		frappe.set_user("Administrator")
 
 	def tearDown(self):
 		frappe.db.rollback()


### PR DESCRIPTION
**Issue:** The function `build_qb_match_conditions` didn't add the name condition for master doctypes like Employee

**Before:**

<img width="1588" height="583" alt="image" src="https://github.com/user-attachments/assets/61ce26e2-6c69-4764-b540-e678f214fa10" />


**After:**

<img width="1609" height="372" alt="image" src="https://github.com/user-attachments/assets/7bb23e3c-a41d-411e-bd1a-4ff047d21244" />


**Backport needed for v15 & v14**