### PR TITLE
fix(bank clearance): use base total taxes and charges if exists

### DIFF
--- a/erpnext/accounts/doctype/bank_clearance/bank_clearance.py
+++ b/erpnext/accounts/doctype/bank_clearance/bank_clearance.py
@@ -183,8 +183,8 @@ def get_payment_entries_for_bank_clearance(
 			select
 				"Payment Entry" as payment_document, name as payment_entry,
 				reference_no as cheque_number, reference_date as cheque_date,
-				if(paid_from=%(account)s, paid_amount + total_taxes_and_charges, 0) as credit,
-				if(paid_from=%(account)s, 0, received_amount + total_taxes_and_charges) as debit,
+				if(paid_from=%(account)s, paid_amount + ifnull(base_total_taxes_and_charges, total_taxes_and_charges), 0) as credit,
+				if(paid_from=%(account)s, 0, received_amount + ifnull(base_total_taxes_and_charges, total_taxes_and_charges)) as debit,
 				posting_date, ifnull(party,if(paid_from=%(account)s,paid_to,paid_from)) as against_account, clearance_date,
 				if(paid_to=%(account)s, paid_to_account_currency, paid_from_account_currency) as account_currency
 			from `tabPayment Entry`

--- a/erpnext/accounts/doctype/bank_clearance/bank_clearance.py
+++ b/erpnext/accounts/doctype/bank_clearance/bank_clearance.py
@@ -157,6 +157,7 @@ def get_payment_entries_for_bank_clearance(
 	condition = ""
 	if not include_reconciled_entries:
 		condition = "and (clearance_date IS NULL or clearance_date='0000-00-00')"
+		pe_condition = "and (pe.clearance_date IS NULL or pe.clearance_date='0000-00-00')"
 
 	journal_entries = frappe.db.sql(
 		f"""
@@ -181,19 +182,20 @@ def get_payment_entries_for_bank_clearance(
 	payment_entries = frappe.db.sql(
 		f"""
 			select
-				"Payment Entry" as payment_document, name as payment_entry,
-				reference_no as cheque_number, reference_date as cheque_date,
-				if(paid_from=%(account)s, paid_amount + ifnull(base_total_taxes_and_charges, total_taxes_and_charges), 0) as credit,
-				if(paid_from=%(account)s, 0, received_amount + ifnull(base_total_taxes_and_charges, total_taxes_and_charges)) as debit,
-				posting_date, ifnull(party,if(paid_from=%(account)s,paid_to,paid_from)) as against_account, clearance_date,
-				if(paid_to=%(account)s, paid_to_account_currency, paid_from_account_currency) as account_currency
-			from `tabPayment Entry`
+				"Payment Entry" as payment_document, pe.name as payment_entry,
+				pe.reference_no as cheque_number, pe.reference_date as cheque_date,
+				if(pe.paid_from=%(account)s, pe.paid_amount + if(pe.payment_type = 'Pay' and c.default_currency = pe.paid_from_account_currency, pe.base_total_taxes_and_charges, pe.total_taxes_and_charges) , 0) as credit,
+				if(pe.paid_from=%(account)s, 0, pe.received_amount + pe.total_taxes_and_charges) as debit,
+				pe.posting_date, ifnull(pe.party,if(pe.paid_from=%(account)s,pe.paid_to,pe.paid_from)) as against_account, clearance_date,
+				if(pe.paid_to=%(account)s, pe.paid_to_account_currency, pe.paid_from_account_currency) as account_currency
+			from `tabPayment Entry` as pe
+			join `tabCompany` c on c.name = pe.company
 			where
-				(paid_from=%(account)s or paid_to=%(account)s) and docstatus=1
-				and posting_date >= %(from)s and posting_date <= %(to)s
-				{condition}
+				(pe.paid_from=%(account)s or pe.paid_to=%(account)s) and pe.docstatus=1
+				and pe.posting_date >= %(from)s and pe.posting_date <= %(to)s
+				{pe_condition}
 			order by
-				posting_date ASC, name DESC
+				pe.posting_date ASC, pe.name DESC
 		""",
 		{
 			"account": account,

--- a/erpnext/accounts/doctype/bank_clearance/bank_clearance.py
+++ b/erpnext/accounts/doctype/bank_clearance/bank_clearance.py
@@ -155,6 +155,7 @@ def get_payment_entries_for_bank_clearance(
 	entries = []
 
 	condition = ""
+	pe_condition = ""
 	if not include_reconciled_entries:
 		condition = "and (clearance_date IS NULL or clearance_date='0000-00-00')"
 		pe_condition = "and (pe.clearance_date IS NULL or pe.clearance_date='0000-00-00')"
@@ -186,7 +187,7 @@ def get_payment_entries_for_bank_clearance(
 				pe.reference_no as cheque_number, pe.reference_date as cheque_date,
 				if(pe.paid_from=%(account)s, pe.paid_amount + if(pe.payment_type = 'Pay' and c.default_currency = pe.paid_from_account_currency, pe.base_total_taxes_and_charges, pe.total_taxes_and_charges) , 0) as credit,
 				if(pe.paid_from=%(account)s, 0, pe.received_amount + pe.total_taxes_and_charges) as debit,
-				pe.posting_date, ifnull(pe.party,if(pe.paid_from=%(account)s,pe.paid_to,pe.paid_from)) as against_account, clearance_date,
+				pe.posting_date, ifnull(pe.party,if(pe.paid_from=%(account)s,pe.paid_to,pe.paid_from)) as against_account, pe.clearance_date,
 				if(pe.paid_to=%(account)s, pe.paid_to_account_currency, pe.paid_from_account_currency) as account_currency
 			from `tabPayment Entry` as pe
 			join `tabCompany` c on c.name = pe.company


### PR DESCRIPTION
Issue: During Bank Clearance, if a payment entry is in a different currency and includes taxes, the tax amount is fetched incorrectly.

Ref: [#48007](https://support.frappe.io/helpdesk/tickets/48007)

Before:

https://github.com/user-attachments/assets/408e95a0-3db4-41d2-89bf-42451be06377

After:

https://github.com/user-attachments/assets/f970c5cc-67dc-4a41-8932-18bf80632166

Backport needed: v15