### PR TITLE
fix: skip 'Bank Account' creation on setup

### DIFF
--- a/erpnext/setup/demo.py
+++ b/erpnext/setup/demo.py
@@ -75,7 +75,7 @@ def create_demo_company():
 	frappe.db.set_single_value("Global Defaults", "demo_company", new_company.name)
 	frappe.db.set_default("company", new_company.name)
 
-	bank_account = create_bank_account({"company_name": new_company.name})
+	bank_account = create_bank_account({"company_name": new_company.name}, demo=True)
 	frappe.db.set_value("Company", new_company.name, "default_bank_account", bank_account.name)
 
 	return new_company.name

--- a/erpnext/setup/setup_wizard/operations/install_fixtures.py
+++ b/erpnext/setup/setup_wizard/operations/install_fixtures.py
@@ -522,7 +522,7 @@ def create_bank_account(args, demo=False):
 	if not args.get("bank_account"):
 		if not demo:
 			return
-		args["bank_account"] = _("Bank Account")
+		args["bank_account"] = _("Demo Bank Account")
 
 	company_name = args.get("company_name")
 	bank_account_group = frappe.db.get_value(

--- a/erpnext/setup/setup_wizard/operations/install_fixtures.py
+++ b/erpnext/setup/setup_wizard/operations/install_fixtures.py
@@ -518,8 +518,10 @@ def update_stock_settings():
 	stock_settings.save()
 
 
-def create_bank_account(args):
+def create_bank_account(args, demo=False):
 	if not args.get("bank_account"):
+		if not demo:
+			return
 		args["bank_account"] = _("Bank Account")
 
 	company_name = args.get("company_name")


### PR DESCRIPTION
Added a fix to skip the child 'Bank Account' creation (see image) on setup completion.

<img width="1080" height="486" alt="image" src="https://github.com/user-attachments/assets/765e2f60-8c80-450a-b613-d99e4a190902" />
