### PR TITLE
fix: provide better translation for workstation off

### DIFF
--- a/erpnext/manufacturing/doctype/workstation/workstation.json
+++ b/erpnext/manufacturing/doctype/workstation/workstation.json
@@ -146,7 +146,7 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Status",
-   "options": "Production\nOff\nIdle\nProblem\nMaintenance\nSetup"
+   "options": "Production\nTurnedOff\nIdle\nProblem\nMaintenance\nSetup"
   },
   {
    "fieldname": "column_break_glcv",
@@ -223,7 +223,7 @@
  "idx": 1,
  "image_field": "on_status_image",
  "links": [],
- "modified": "2025-08-19 12:07:05.374386",
+ "modified": "2025-09-06 09:00:09.129371",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "Workstation",


### PR DESCRIPTION
Change string to be able to correctly translate in other languages
Off has different meaning in Frappe vs Erpnext