### PR TITLE
fix(Accounts Payable Summary): add a missing translate function

### DIFF
--- a/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
+++ b/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
@@ -1268,7 +1268,7 @@ class ReceivablePayableReport:
 	def setup_ageing_columns(self):
 		# for charts
 		self.ageing_column_labels = []
-		ranges = [*self.ranges, "Above"]
+		ranges = [*self.ranges, _("Above")]
 
 		prev_range_value = 0
 		for idx, curr_range_value in enumerate(ranges):

--- a/erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py
+++ b/erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py
@@ -171,7 +171,7 @@ class AccountsReceivableSummary(ReceivablePayableReport):
 			self.add_column(_("Difference"), fieldname="diff")
 
 		self.setup_ageing_columns()
-		self.add_column(label="Total Amount Due", fieldname="total_due")
+		self.add_column(label=_("Total Amount Due"), fieldname="total_due")
 
 		if self.filters.show_future_payments:
 			self.add_column(label=_("Future Payment Amount"), fieldname="future_amount")


### PR DESCRIPTION
in **Report** `Accounts Payable Summary`

### Before
<img width="1405" height="226" alt="Before" src="https://github.com/user-attachments/assets/0663e976-0e14-4365-8bde-28a23c14fb1b" />

### After
<img width="1426" height="243" alt="After" src="https://github.com/user-attachments/assets/e981b368-c1e9-4d48-9db2-ffafa7b9131e" />

backport version-15-hotfix

