### PR TITLE
fix: Incorrect filters in Voucher Child Table of Land Cost Voucher DocType

### DIFF
--- a/erpnext/stock/doctype/landed_cost_voucher/landed_cost_voucher.js
+++ b/erpnext/stock/doctype/landed_cost_voucher/landed_cost_voucher.js
@@ -5,31 +5,6 @@ frappe.provide("erpnext.stock");
 
 erpnext.landed_cost_taxes_and_charges.setup_triggers("Landed Cost Voucher");
 erpnext.stock.LandedCostVoucher = class LandedCostVoucher extends erpnext.stock.StockController {
-	setup() {
-		var me = this;
-		this.frm.fields_dict.purchase_receipts.grid.get_field("receipt_document").get_query = function (
-			doc,
-			cdt,
-			cdn
-		) {
-			var d = locals[cdt][cdn];
-
-			var filters = [
-				[d.receipt_document_type, "docstatus", "=", "1"],
-				[d.receipt_document_type, "company", "=", me.frm.doc.company],
-			];
-
-			if (d.receipt_document_type == "Purchase Invoice") {
-				filters.push(["Purchase Invoice", "update_stock", "=", "1"]);
-			}
-
-			if (!me.frm.doc.company) frappe.msgprint(__("Please enter company first"));
-			return {
-				filters: filters,
-			};
-		};
-	}
-
 	refresh() {
 		var help_content = `<br><br>
 			<table class="table table-bordered" style="background-color: var(--scrollbar-track-color);">
@@ -158,15 +133,19 @@ frappe.ui.form.on("Landed Cost Voucher", {
 	setup_queries(frm) {
 		frm.set_query("receipt_document", "purchase_receipts", (doc, cdt, cdn) => {
 			var d = locals[cdt][cdn];
-			if (d.receipt_document_type === "Stock Entry") {
-				return {
-					filters: {
-						docstatus: 1,
-						company: frm.doc.company,
-						purpose: ["in", ["Manufacture", "Repack"]],
-					},
-				};
+			var filters = [
+				[d.receipt_document_type, "docstatus", "=", "1"],
+				[d.receipt_document_type, "company", "=", frm.doc.company],
+			];
+
+			if (d.receipt_document_type == "Purchase Invoice") {
+				filters.push(["Purchase Invoice", "update_stock", "=", "1"]);
+			} else if (d.receipt_document_type === "Stock Entry") {
+				filters.push(["Stock Entry", "purpose", "in", ["Manufacture", "Repack"]]);
 			}
+			return {
+				filters: filters,
+			};
 		});
 
 		frm.set_query("vendor_invoice", "vendor_invoices", (doc, cdt, cdn) => {

--- a/erpnext/stock/doctype/landed_cost_voucher/landed_cost_voucher.js
+++ b/erpnext/stock/doctype/landed_cost_voucher/landed_cost_voucher.js
@@ -134,12 +134,12 @@ frappe.ui.form.on("Landed Cost Voucher", {
 		frm.set_query("receipt_document", "purchase_receipts", (doc, cdt, cdn) => {
 			var d = locals[cdt][cdn];
 			var filters = [
-				[d.receipt_document_type, "docstatus", "=", "1"],
+				[d.receipt_document_type, "docstatus", "=", 1],
 				[d.receipt_document_type, "company", "=", frm.doc.company],
 			];
 
-			if (d.receipt_document_type == "Purchase Invoice") {
-				filters.push(["Purchase Invoice", "update_stock", "=", "1"]);
+			if (d.receipt_document_type === "Purchase Invoice") {
+				filters.push(["Purchase Invoice", "update_stock", "=", 1]);
 			} else if (d.receipt_document_type === "Stock Entry") {
 				filters.push(["Stock Entry", "purpose", "in", ["Manufacture", "Repack"]]);
 			}


### PR DESCRIPTION
Closes #49499
> Please provide enough information so that others can review your pull request:
- In Landed Cost Voucher DocTyep, selected company filters are not applied for Purchase Invoice , Purchase Receipt

<img width="1889" height="786" alt="Image" src="https://github.com/user-attachments/assets/f9e85319-9d84-4afd-bb79-9b0ec458467b" />

-  Additionally cancelled documents are also listing 
<img width="1865" height="608" alt="Image" src="https://github.com/user-attachments/assets/c593718d-7929-4bf4-a717-a86387b47ac9" />

> Explain the **details** for making this change. What existing problem does the pull request solve?
- To list the selected company documents and which are not cancelled
- I have removed the StockController setup controller code, because it is redundant and filters are directly applied in the setup controller of the current doc
 
> Screenshots with correct filters
<img width="1580" height="604" alt="image" src="https://github.com/user-attachments/assets/ff1cbc0c-f3b8-4a32-ab3d-70ad516ff2b4" />

