### PR TITLE
Feat allow to transfer additional materials 

### DIFF
--- a/erpnext/manufacturing/doctype/manufacturing_settings/manufacturing_settings.json
+++ b/erpnext/manufacturing/doctype/manufacturing_settings/manufacturing_settings.json
@@ -24,6 +24,9 @@
   "overproduction_percentage_for_sales_order",
   "column_break_16",
   "overproduction_percentage_for_work_order",
+  "section_break_xhtl",
+  "transfer_extra_materials_percentage",
+  "column_break_kemp",
   "job_card_section",
   "add_corrective_operation_cost_in_finished_good_valuation",
   "enforce_time_logs",
@@ -243,13 +246,28 @@
    "fieldname": "enforce_time_logs",
    "fieldtype": "Check",
    "label": "Enforce Time Logs"
+  },
+  {
+   "fieldname": "section_break_xhtl",
+   "fieldtype": "Section Break",
+   "label": "Extra Material Transfer"
+  },
+  {
+   "fieldname": "column_break_kemp",
+   "fieldtype": "Column Break"
+  },
+  {
+   "description": "The user will be able to transfer additional materials from the store to the Work in Progress (WIP) warehouse.",
+   "fieldname": "transfer_extra_materials_percentage",
+   "fieldtype": "Percent",
+   "label": "Transfer Extra Raw Materials to WIP (%)"
   }
  ],
  "icon": "icon-wrench",
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-05-16 11:23:16.916512",
+ "modified": "2025-09-08 19:48:31.726126",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "Manufacturing Settings",

--- a/erpnext/manufacturing/doctype/manufacturing_settings/manufacturing_settings.py
+++ b/erpnext/manufacturing/doctype/manufacturing_settings/manufacturing_settings.py
@@ -35,6 +35,7 @@ class ManufacturingSettings(Document):
 		overproduction_percentage_for_sales_order: DF.Percent
 		overproduction_percentage_for_work_order: DF.Percent
 		set_op_cost_and_scrap_from_sub_assemblies: DF.Check
+		transfer_extra_materials_percentage: DF.Percent
 		update_bom_costs_automatically: DF.Check
 		validate_components_quantities_per_bom: DF.Check
 	# end: auto-generated types

--- a/erpnext/manufacturing/doctype/work_order/test_work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/test_work_order.py
@@ -3005,6 +3005,36 @@ class TestWorkOrder(IntegrationTestCase):
 			wo.operations[3].planned_start_time, add_to_date(wo.operations[1].planned_end_time, minutes=10)
 		)
 
+	def test_allow_additional_material_transfer(self):
+		from erpnext.stock.doctype.stock_entry.test_stock_entry import (
+			make_stock_entry as make_stock_entry_test_record,
+		)
+
+		frappe.db.set_single_value("Manufacturing Settings", "transfer_extra_materials_percentage", 50)
+		wo_order = make_wo_order_test_record(planned_start_date=now(), qty=2)
+		for row in wo_order.required_items:
+			make_stock_entry_test_record(
+				item_code=row.item_code,
+				target=row.source_warehouse,
+				qty=row.required_qty * 2,
+				basic_rate=100,
+			)
+
+		stock_entry = frappe.get_doc(make_stock_entry(wo_order.name, "Material Transfer for Manufacture", 2))
+		stock_entry.insert()
+		stock_entry.submit()
+
+		wo_order.reload()
+		self.assertEqual(wo_order.material_transferred_for_manufacturing, 2)
+
+		stock_entry = frappe.get_doc(make_stock_entry(wo_order.name, "Material Transfer for Manufacture", 1))
+		stock_entry.insert()
+		stock_entry.submit()
+
+		wo_order.reload()
+		self.assertEqual(wo_order.material_transferred_for_manufacturing, 3)
+		frappe.db.set_single_value("Manufacturing Settings", "transfer_extra_materials_percentage", 0)
+
 
 def make_stock_in_entries_and_get_batches(rm_item, source_warehouse, wip_warehouse):
 	from erpnext.stock.doctype.stock_entry.test_stock_entry import (

--- a/erpnext/manufacturing/doctype/work_order/work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/work_order.py
@@ -149,6 +149,7 @@ class WorkOrder(Document):
 		self.set_onload("material_consumption", ms.material_consumption)
 		self.set_onload("backflush_raw_materials_based_on", ms.backflush_raw_materials_based_on)
 		self.set_onload("overproduction_percentage", ms.overproduction_percentage_for_work_order)
+		self.set_onload("transfer_extra_materials_percentage", ms.transfer_extra_materials_percentage)
 		self.set_onload("show_create_job_card_button", self.show_create_job_card_button())
 		self.set_onload(
 			"enable_stock_reservation",
@@ -484,6 +485,13 @@ class WorkOrder(Document):
 				continue
 
 			qty = self.get_transferred_or_manufactured_qty(purpose)
+
+			if not allowance_percentage and purpose == "Material Transfer for Manufacture":
+				allowance_percentage = flt(
+					frappe.db.get_single_value(
+						"Manufacturing Settings", "transfer_extra_materials_percentage"
+					)
+				)
 
 			completed_qty = self.qty + (allowance_percentage / 100 * self.qty)
 			if qty > completed_qty:


### PR DESCRIPTION
**Use Case**

The Transfer Materials button is not showing because all required materials have already been transferred, but the user wants to transfer additional materials since some are damaged.

<img width="1382" height="664" alt="Screenshot 2025-09-08 at 6 54 50 PM" src="https://github.com/user-attachments/assets/2c47492b-9b3f-4efb-895e-f62d911a0d11" />


**Solution**

Added a provision to define the percentage for 'Transfer Extra Raw Materials to WIP (%)' in Manufacturing Settings.

<img width="1082" height="502" alt="Screenshot 2025-09-08 at 7 48 51 PM" src="https://github.com/user-attachments/assets/f6a982f8-aa3d-4596-afe1-0e12044af3db" />


Once the user sets the 'Transfer Extra Raw Materials to WIP (%)' in Manufacturing Settings, they can transfer additional materials from the store to WIP against the work order.

<img width="1385" height="681" alt="Screenshot 2025-09-08 at 7 15 43 PM" src="https://github.com/user-attachments/assets/8da30e2c-e230-4d36-9bcd-46b3c0f4f613" />


Fixed https://github.com/orgs/frappe/projects/102/views/5?pane=issue&itemId=123716184&issue=frappe%7Cerpnext%7C47372

Docs https://docs.frappe.io/erpnext/user/manual/en/work-order#42-transfer-addtional-materials