### PR TITLE
fix(sales invoice): fetch tax id from customer

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.json
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.json
@@ -275,6 +275,7 @@
    "read_only": 1
   },
   {
+   "fetch_from": "customer.tax_id",
    "fieldname": "tax_id",
    "fieldtype": "Data",
    "hide_days": 1,
@@ -2241,7 +2242,7 @@
    "link_fieldname": "consolidated_invoice"
   }
  ],
- "modified": "2025-08-04 19:20:28.732039",
+ "modified": "2025-09-09 14:48:59.472826",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Sales Invoice",


### PR DESCRIPTION
Issue: When creating a Sales Invoice from the backend, the customer's tax_id is not getting fetched and displayed.

Ref: [#47986](https://support.frappe.io/helpdesk/tickets/47986), [#48245](https://support.frappe.io/helpdesk/tickets/48245)


