### PR TITLE
fix: clear asset custodian when asset take back from employee without assign to another employee

### DIFF
--- a/erpnext/assets/doctype/asset_movement/asset_movement.py
+++ b/erpnext/assets/doctype/asset_movement/asset_movement.py
@@ -144,6 +144,10 @@ class AssetMovement(Document):
 
 		if employee and employee != asset.custodian:
 			frappe.db.set_value("Asset", asset_id, "custodian", employee)
+
+		elif not employee and asset.custodian:
+			frappe.db.set_value("Asset", asset_id, "custodian", None)
+
 		if location and location != asset.location:
 			frappe.db.set_value("Asset", asset_id, "location", location)
 

--- a/erpnext/assets/doctype/asset_movement/asset_movement.py
+++ b/erpnext/assets/doctype/asset_movement/asset_movement.py
@@ -142,14 +142,18 @@ class AssetMovement(Document):
 	def update_asset_location_and_custodian(self, asset_id, location, employee):
 		asset = frappe.get_doc("Asset", asset_id)
 
+		updates = {}
 		if employee and employee != asset.custodian:
-			frappe.db.set_value("Asset", asset_id, "custodian", employee)
+			updates["custodian"] = employee
 
 		elif not employee and asset.custodian:
-			frappe.db.set_value("Asset", asset_id, "custodian", None)
+			updates["custodian"] = ""
 
 		if location and location != asset.location:
-			frappe.db.set_value("Asset", asset_id, "location", location)
+			updates["location"] = location
+
+		if updates:
+			frappe.db.set_value("Asset", asset_id, updates)
 
 	def log_asset_activity(self, asset_id, location, employee):
 		if location and employee:


### PR DESCRIPTION
Closes: #49502 

----
https://github.com/user-attachments/assets/324bca63-cc8c-4177-9b35-34cbfa459c74



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Asset Movement now clears the asset custodian when no employee is specified, preventing stale custodian data from persisting.
  * Location changes are only applied when different from current, ensuring accurate asset location records.

* **Improvements**
  * Asset updates are applied atomically to reduce redundant updates and improve reliability and performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->