### PR TITLE
fix: project accounting dimension and gl posting date column width

### DIFF
--- a/erpnext/accounts/doctype/advance_taxes_and_charges/advance_taxes_and_charges.json
+++ b/erpnext/accounts/doctype/advance_taxes_and_charges/advance_taxes_and_charges.json
@@ -17,6 +17,7 @@
   "accounting_dimensions_section",
   "cost_center",
   "dimension_col_break",
+  "project",
   "section_break_8",
   "rate",
   "section_break_9",
@@ -94,6 +95,13 @@
   {
    "fieldname": "dimension_col_break",
    "fieldtype": "Column Break"
+  },
+  {
+    "allow_on_submit": 1,
+    "fieldname": "project",
+    "fieldtype": "Link",
+    "label": "Project",
+    "options": "Project"
   },
   {
    "fieldname": "section_break_8",

--- a/erpnext/accounts/doctype/loyalty_program/loyalty_program.json
+++ b/erpnext/accounts/doctype/loyalty_program/loyalty_program.json
@@ -147,7 +147,6 @@
    "fieldtype": "Column Break"
   },
   {
-    "allow_on_submit": 1,
     "fieldname": "project",
     "fieldtype": "Link",
     "label": "Project",

--- a/erpnext/accounts/doctype/loyalty_program/loyalty_program.json
+++ b/erpnext/accounts/doctype/loyalty_program/loyalty_program.json
@@ -25,6 +25,7 @@
   "accounting_dimensions_section",
   "cost_center",
   "dimension_col_break",
+  "project",
   "help_section",
   "loyalty_program_help"
  ],
@@ -144,6 +145,13 @@
   {
    "fieldname": "dimension_col_break",
    "fieldtype": "Column Break"
+  },
+  {
+    "allow_on_submit": 1,
+    "fieldname": "project",
+    "fieldtype": "Link",
+    "label": "Project",
+    "options": "Project"
   }
  ],
  "links": [],

--- a/erpnext/accounts/doctype/opening_invoice_creation_tool/opening_invoice_creation_tool.json
+++ b/erpnext/accounts/doctype/opening_invoice_creation_tool/opening_invoice_creation_tool.json
@@ -65,7 +65,6 @@
    "options": "Cost Center"
   },
   {
-    "allow_on_submit": 1,
     "fieldname": "project",
     "fieldtype": "Link",
     "label": "Project",

--- a/erpnext/accounts/doctype/opening_invoice_creation_tool/opening_invoice_creation_tool.json
+++ b/erpnext/accounts/doctype/opening_invoice_creation_tool/opening_invoice_creation_tool.json
@@ -14,6 +14,7 @@
   "accounting_dimensions_section",
   "cost_center",
   "dimension_col_break",
+  "project",
   "section_break_4",
   "invoices"
  ],
@@ -62,6 +63,13 @@
    "fieldtype": "Link",
    "label": "Cost Center",
    "options": "Cost Center"
+  },
+  {
+    "allow_on_submit": 1,
+    "fieldname": "project",
+    "fieldtype": "Link",
+    "label": "Project",
+    "options": "Project"
   },
   {
    "collapsible": 1,

--- a/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.json
+++ b/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.json
@@ -28,6 +28,7 @@
   "accounting_dimensions_section",
   "cost_center",
   "dimension_col_break",
+  "project",
   "sec_break1",
   "invoice_name",
   "invoices",
@@ -193,6 +194,13 @@
    "fieldtype": "Link",
    "label": "Cost Center",
    "options": "Cost Center"
+  },
+  {
+    "allow_on_submit": 1,
+    "fieldname": "project",
+    "fieldtype": "Link",
+    "label": "Project",
+    "options": "Project"
   },
   {
    "depends_on": "eval:doc.party",

--- a/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.json
+++ b/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.json
@@ -196,7 +196,6 @@
    "options": "Cost Center"
   },
   {
-    "allow_on_submit": 1,
     "fieldname": "project",
     "fieldtype": "Link",
     "label": "Project",

--- a/erpnext/accounts/doctype/purchase_taxes_and_charges/purchase_taxes_and_charges.json
+++ b/erpnext/accounts/doctype/purchase_taxes_and_charges/purchase_taxes_and_charges.json
@@ -23,6 +23,7 @@
   "accounting_dimensions_section",
   "cost_center",
   "dimension_col_break",
+  "project",
   "section_break_9",
   "account_currency",
   "net_amount",
@@ -213,6 +214,13 @@
   {
    "fieldname": "dimension_col_break",
    "fieldtype": "Column Break"
+  },
+  {
+    "allow_on_submit": 1,
+    "fieldname": "project",
+    "fieldtype": "Link",
+    "label": "Project",
+    "options": "Project"
   },
   {
    "default": "0",

--- a/erpnext/accounts/doctype/sales_taxes_and_charges/sales_taxes_and_charges.json
+++ b/erpnext/accounts/doctype/sales_taxes_and_charges/sales_taxes_and_charges.json
@@ -17,6 +17,7 @@
   "accounting_dimensions_section",
   "cost_center",
   "dimension_col_break",
+  "project",
   "section_break_8",
   "rate",
   "section_break_9",
@@ -190,6 +191,13 @@
   {
    "fieldname": "dimension_col_break",
    "fieldtype": "Column Break"
+  },
+  {
+    "allow_on_submit": 1,
+    "fieldname": "project",
+    "fieldtype": "Link",
+    "label": "Project",
+    "options": "Project"
   },
   {
    "default": "0",

--- a/erpnext/accounts/doctype/shipping_rule/shipping_rule.json
+++ b/erpnext/accounts/doctype/shipping_rule/shipping_rule.json
@@ -141,7 +141,6 @@
    "fieldtype": "Column Break"
   },
   {
-    "allow_on_submit": 1,
     "fieldname": "project",
     "fieldtype": "Link",
     "label": "Project",

--- a/erpnext/accounts/doctype/shipping_rule/shipping_rule.json
+++ b/erpnext/accounts/doctype/shipping_rule/shipping_rule.json
@@ -18,6 +18,7 @@
   "accounting_dimensions_section",
   "cost_center",
   "dimension_col_break",
+  "project",
   "shipping_amount_section",
   "calculate_based_on",
   "column_break_8",
@@ -138,6 +139,13 @@
   {
    "fieldname": "dimension_col_break",
    "fieldtype": "Column Break"
+  },
+  {
+    "allow_on_submit": 1,
+    "fieldname": "project",
+    "fieldtype": "Link",
+    "label": "Project",
+    "options": "Project"
   }
  ],
  "icon": "fa fa-truck",

--- a/erpnext/accounts/report/general_ledger/general_ledger.py
+++ b/erpnext/accounts/report/general_ledger/general_ledger.py
@@ -667,7 +667,7 @@ def get_columns(filters):
 			"options": "GL Entry",
 			"hidden": 1,
 		},
-		{"label": _("Posting Date"), "fieldname": "posting_date", "fieldtype": "Date", "width": 100},
+		{"label": _("Posting Date"), "fieldname": "posting_date", "fieldtype": "Date", "width": 110},
 		{
 			"label": _("Account"),
 			"fieldname": "account",

--- a/erpnext/accounts/report/general_ledger/general_ledger.py
+++ b/erpnext/accounts/report/general_ledger/general_ledger.py
@@ -667,7 +667,7 @@ def get_columns(filters):
 			"options": "GL Entry",
 			"hidden": 1,
 		},
-		{"label": _("Posting Date"), "fieldname": "posting_date", "fieldtype": "Date", "width": 110},
+		{"label": _("Posting Date"), "fieldname": "posting_date", "fieldtype": "Date", "width": 120},
 		{
 			"label": _("Account"),
 			"fieldname": "account",

--- a/erpnext/assets/doctype/asset_capitalization/asset_capitalization.json
+++ b/erpnext/assets/doctype/asset_capitalization/asset_capitalization.json
@@ -277,7 +277,6 @@
    "options": "Cost Center"
   },
   {
-    "allow_on_submit": 1,
     "fieldname": "project",
     "fieldtype": "Link",
     "label": "Project",

--- a/erpnext/assets/doctype/asset_capitalization/asset_capitalization.json
+++ b/erpnext/assets/doctype/asset_capitalization/asset_capitalization.json
@@ -41,6 +41,7 @@
   "accounting_dimensions_section",
   "cost_center",
   "dimension_col_break",
+  "project",
   "target_fixed_asset_account"
  ],
  "fields": [
@@ -274,6 +275,13 @@
    "fieldtype": "Link",
    "label": "Cost Center",
    "options": "Cost Center"
+  },
+  {
+    "allow_on_submit": 1,
+    "fieldname": "project",
+    "fieldtype": "Link",
+    "label": "Project",
+    "options": "Project"
   },
   {
    "fieldname": "dimension_col_break",

--- a/erpnext/assets/doctype/asset_capitalization_asset_item/asset_capitalization_asset_item.json
+++ b/erpnext/assets/doctype/asset_capitalization_asset_item/asset_capitalization_asset_item.json
@@ -18,6 +18,7 @@
   "accounting_dimensions_section",
   "cost_center",
   "dimension_col_break",
+  "project",
   "fixed_asset_account"
  ],
  "fields": [
@@ -97,6 +98,13 @@
   {
    "fieldname": "dimension_col_break",
    "fieldtype": "Column Break"
+  },
+  {
+    "allow_on_submit": 1,
+    "fieldname": "project",
+    "fieldtype": "Link",
+    "label": "Project",
+    "options": "Project"
   },
   {
    "fieldname": "finance_book",


### PR DESCRIPTION
Issue: 

- Inconsistency of Project Accounting Dimension across the system.
- The Posting Date is not fully visible in the GL Report.

Ref: [48420](https://support.frappe.io/helpdesk/tickets/48420), [48726](https://support.frappe.io/helpdesk/tickets/48726)

<img width="1855" height="694" alt="image" src="https://github.com/user-attachments/assets/79f74b34-6c35-4018-a64d-78824b768d67" />


**Backport Needed: Version-15, Version-14**