### PR TITLE
fix: remove remarks if show_remarks is unchecked

### DIFF
--- a/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.html
+++ b/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.html
@@ -34,13 +34,13 @@
 		<thead>
 			<tr>
 				<th style="width: 12%">{{ _("Date") }}</th>
-				<th style="width: 15%">{{ _("Reference") }}</th>
-				{% if filters.show_remarks %}
-					<th style="width: 25%">{{ _("Remarks") }}</th>
-				{% endif %}
+				<th style="width: 20%">{{ _("Reference") }}</th>
 				<th style="width: 15%">{{ _("Debit") }}</th>
 				<th style="width: 15%">{{ _("Credit") }}</th>
 				<th style="width: 18%">{{ _("Balance (Dr - Cr)") }}</th>
+				{% if filters.show_remarks %}
+				<th style="width: 20%">{{ _("Remarks") }}</th>
+				{% endif %}
 			</tr>
 		</thead>
 		<tbody>
@@ -50,65 +50,50 @@
 				<td>{{ frappe.format(row.posting_date, 'Date') }}</td>
 				<td>{{ row.voucher_type }}
 					<br>{{ row.voucher_no }}
-					{% if not filters.show_remarks %}
-						{% if not (filters.party or filters.account) %}
-							<br>{{ row.party or row.account }}
-						{% endif %}
-						{% if row.remarks %}
-							<br>{{ _("Remarks:") }} {{ row.remarks }}
-						{% endif %}
-						{% if row.bill_no %}
-							<br>{{ _("Supplier Invoice No") }}: {{ row.bill_no }}
-						{% endif %}
-					{% endif %}
-				</td>
-
-				{% if filters.show_remarks %}
-				<td>
 					{% if not (filters.party or filters.account) %}
-						{{ row.party or row.account }}<br>
+						{{ row.party or row.account }}
+						<br>
 					{% endif %}
-					{% if row.remarks %}
-						{{ _("Remarks:") }} {{ row.remarks }}<br>
-					{% endif %}
-
 					{% if row.bill_no %}
 						{{ _("Supplier Invoice No") }}: {{ row.bill_no }}
 					{% endif %}
-				</td>
-				{% endif %}
-
-				<td style="text-align: right">
-					{{ frappe.utils.fmt_money(row.debit, currency=filters.presentation_currency) }}
-				</td>
-				<td style="text-align: right">
-					{{ frappe.utils.fmt_money(row.credit, currency=filters.presentation_currency) }}
-				</td>
-
+					</td>
+					<td style="text-align: right">
+						{{ frappe.utils.fmt_money(row.debit, currency=filters.presentation_currency) }}</td>
+					<td style="text-align: right">
+						{{ frappe.utils.fmt_money(row.credit, currency=filters.presentation_currency) }}</td>
+					<td style="text-align: right">
+						{{ frappe.utils.fmt_money(row.balance, currency=filters.presentation_currency) }}
+					</td>
+					{% if filters.show_remarks %}
+					<td>
+						{% if row.remarks  %}
+							{{ _("Remarks:") }} {{ row.remarks }}
+						{% endif %}
+					</td>
+					{% endif %}
 			{% else %}
 				<td></td>
 				<td>
-					{% if filters.show_remarks %}
-					{% else %}
-						<b>{{ frappe.format(row.account, {fieldtype: "Link"}) or "&nbsp;" }}</b>
-					{% endif %}
-				</td>
-
-				{% if filters.show_remarks %}
-				<td>
 					<b>{{ frappe.format(row.account, {fieldtype: "Link"}) or "&nbsp;" }}</b>
 				</td>
-				{% endif %}
 				<td style="text-align: right">
 					{{ row.get('account', '') and frappe.utils.fmt_money(row.debit, currency=filters.presentation_currency) }}
 				</td>
 				<td style="text-align: right">
 					{{ row.get('account', '') and frappe.utils.fmt_money(row.credit, currency=filters.presentation_currency) }}
 				</td>
-			{% endif %}
 				<td style="text-align: right">
 					{{ frappe.utils.fmt_money(row.balance, currency=filters.presentation_currency) }}
 				</td>
+				{% if filters.show_remarks %}
+				<td>
+					{% if row.remarks  %}
+						{{ _("Remarks:") }} {{ row.remarks }}
+					{% endif %}
+				</td>
+				{% endif %}
+			{% endif %}
 			</tr>
 		{% endfor %}
 		</tbody>

--- a/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.html
+++ b/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.html
@@ -35,7 +35,9 @@
 			<tr>
 				<th style="width: 12%">{{ _("Date") }}</th>
 				<th style="width: 15%">{{ _("Reference") }}</th>
-				<th style="width: 25%">{{ _("Remarks") }}</th>
+				{% if filters.show_remarks %}
+					<th style="width: 25%">{{ _("Remarks") }}</th>
+				{% endif %}
 				<th style="width: 15%">{{ _("Debit") }}</th>
 				<th style="width: 15%">{{ _("Credit") }}</th>
 				<th style="width: 18%">{{ _("Balance (Dr - Cr)") }}</th>
@@ -47,26 +49,56 @@
 			{% if(row.posting_date) %}
 				<td>{{ frappe.format(row.posting_date, 'Date') }}</td>
 				<td>{{ row.voucher_type }}
-					<br>{{ row.voucher_no }}</td>
+					<br>{{ row.voucher_no }}
+					{% if not filters.show_remarks %}
+						{% if not (filters.party or filters.account) %}
+							<br>{{ row.party or row.account }}
+						{% endif %}
+						{% if row.remarks %}
+							<br>{{ _("Remarks:") }} {{ row.remarks }}
+						{% endif %}
+						{% if row.bill_no %}
+							<br>{{ _("Supplier Invoice No") }}: {{ row.bill_no }}
+						{% endif %}
+					{% endif %}
+				</td>
+
+				{% if filters.show_remarks %}
 				<td>
-					{% if not (filters.party or filters.account)  %}
-						{{ row.party or row.account }}
-						<br>
+					{% if not (filters.party or filters.account) %}
+						{{ row.party or row.account }}<br>
+					{% endif %}
+					{% if row.remarks %}
+						{{ _("Remarks:") }} {{ row.remarks }}<br>
 					{% endif %}
 
-					<br>{{ _("Remarks:") }} {{ row.remarks }}
 					{% if row.bill_no %}
-						<br>{{ _("Supplier Invoice No") }}: {{ row.bill_no }}
+						{{ _("Supplier Invoice No") }}: {{ row.bill_no }}
 					{% endif %}
-					</td>
-					<td style="text-align: right">
-						{{ frappe.utils.fmt_money(row.debit, currency=filters.presentation_currency) }}</td>
-					<td style="text-align: right">
-						{{ frappe.utils.fmt_money(row.credit, currency=filters.presentation_currency) }}</td>
+				</td>
+				{% endif %}
+
+				<td style="text-align: right">
+					{{ frappe.utils.fmt_money(row.debit, currency=filters.presentation_currency) }}
+				</td>
+				<td style="text-align: right">
+					{{ frappe.utils.fmt_money(row.credit, currency=filters.presentation_currency) }}
+				</td>
+
 			{% else %}
 				<td></td>
-				<td></td>
-				<td><b>{{ frappe.format(row.account, {fieldtype: "Link"}) or "&nbsp;" }}</b></td>
+				<td>
+					{% if filters.show_remarks %}
+					{% else %}
+						<b>{{ frappe.format(row.account, {fieldtype: "Link"}) or "&nbsp;" }}</b>
+					{% endif %}
+				</td>
+
+				{% if filters.show_remarks %}
+				<td>
+					<b>{{ frappe.format(row.account, {fieldtype: "Link"}) or "&nbsp;" }}</b>
+				</td>
+				{% endif %}
 				<td style="text-align: right">
 					{{ row.get('account', '') and frappe.utils.fmt_money(row.debit, currency=filters.presentation_currency) }}
 				</td>

--- a/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html
+++ b/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html
@@ -327,8 +327,7 @@
 		{% endfor %}
 		<td></td>
 		<td></td>
-		<td></td>
-		{% if not(filters.show_future_payments) and filters.show_remarks %}
+		{% if (filters.show_future_payments) or filters.show_remarks %}
 			<td></td>
 		{% endif %}
 		{% if not(filters.show_future_payments) %}

--- a/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html
+++ b/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html
@@ -159,7 +159,7 @@
 				{% else %}
 					<th style="width: 24%">{{ _("Reference") }}</th>
 				{% endif %}
-				{% if not(filters.show_future_payments) %}
+				{% if not(filters.show_future_payments) and filters.show_remarks %}
 					<th style="width: 20%">
 					{% if (filters.customer or filters.supplier or filters.customer_name) %}
 						{{ _("Remarks") }}
@@ -228,7 +228,7 @@
 					<td>{{ data[i]["sales_person"] }}</td>
 					{% endif %}
 
-					{% if not (filters.show_future_payments) %}
+					{% if not (filters.show_future_payments) and filters.show_remarks %}
 					<td>
 						{% if(not(filters.customer or filters.supplier or filters.customer_name)) %}
 							{{ data[i]["party"] }}
@@ -328,6 +328,9 @@
 		<td></td>
 		<td></td>
 		<td></td>
+		{% if not(filters.show_future_payments) and filters.show_remarks %}
+			<td></td>
+		{% endif %}
 		{% if not(filters.show_future_payments) %}
 			<td></td>
 			<td style="text-align: right"><b>{{ frappe.utils.fmt_money(data|sum(attribute="invoiced"), currency=data[0]["currency"]) }}</b></td>


### PR DESCRIPTION
**Issue:**

When show_remarks is disabled, the remarks column is still visible.

**Ref :** [48519](https://support.frappe.io/helpdesk/tickets/48519)


**Before:**

[Screencast from 18-09-25 10:22:27 AM IST.webm](https://github.com/user-attachments/assets/4ba152c0-7808-4a9e-acae-e916e7e1fbc0)


**After :**

[Screencast from 18-09-25 10:17:23 AM IST.webm](https://github.com/user-attachments/assets/aaa193a8-843b-459f-9f73-1bc760b88649)



**Backport Needed: V15**

