### PR TITLE
fix(item): avoid inheriting item defaults from identically named items

### DIFF
--- a/erpnext/stock/doctype/item/item.py
+++ b/erpnext/stock/doctype/item/item.py
@@ -724,7 +724,10 @@ class Item(Document):
 
 		item_defaults = frappe.db.get_values(
 			"Item Default",
-			{"parent": self.item_group},
+			{
+				"parent": self.item_group,
+				"parenttype": "Item Group",
+			},
 			[
 				"company",
 				"default_warehouse",


### PR DESCRIPTION
## Summary
- restrict Item Group default lookup to parenttype Item Group so identically named Items no longer add duplicate defaults
- quick entry succeeds again on ERPNext 15.77.0

Closes https://github.com/frappe/erpnext/issues/49570

## Testing
- not run (manual quick entry recommended)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures only item-group-specific defaults are applied when updating items from a group.
  * Prevents accidental mixing of defaults from other record types.
  * Improves accuracy of default values during item creation and updates derived from groups.
  * Reduces unexpected configurations and increases consistency in stock and account defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->