### PR TITLE
feat(accounts): enable print format selection in Process Statement of Accounts

### DIFF
--- a/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.js
+++ b/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.js
@@ -83,6 +83,16 @@ frappe.ui.form.on("Process Statement Of Accounts", {
 				},
 			};
 		});
+		frm.set_query("print_format", function () {
+			return {
+				filters: {
+					print_format_for: "Report",
+					report: frm.doc.report,
+					disabled: 0,
+					print_format_type: "Jinja",
+				},
+			};
+		});
 		if (frm.doc.__islocal) {
 			frm.set_value("from_date", frappe.datetime.add_months(frappe.datetime.get_today(), -1));
 			frm.set_value("to_date", frappe.datetime.get_today());
@@ -104,6 +114,16 @@ frappe.ui.form.on("Process Statement Of Accounts", {
 		frm.set_query("account", function () {
 			return {
 				filters: filters,
+			};
+		});
+		frm.set_query("print_format", function () {
+			return {
+				filters: {
+					print_format_for: "Report",
+					report: frm.doc.report,
+					disabled: 0,
+					print_format_type: "Jinja",
+				},
 			};
 		});
 	},

--- a/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.json
+++ b/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.json
@@ -38,6 +38,7 @@
   "column_break_17",
   "customers",
   "preferences",
+  "print_format",
   "orientation",
   "include_break",
   "include_ageing",
@@ -406,10 +407,16 @@
    "fieldname": "show_future_payments",
    "fieldtype": "Check",
    "label": "Show Future Payments"
+  },
+  {
+   "fieldname": "print_format",
+   "fieldtype": "Link",
+   "label": "Print Format",
+   "options": "Print Format"
   }
  ],
  "links": [],
- "modified": "2025-08-29 00:20:08.088189",
+ "modified": "2025-09-03 14:24:43.608565",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Process Statement Of Accounts",

--- a/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.py
+++ b/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.py
@@ -67,6 +67,7 @@ class ProcessStatementOfAccounts(Document):
 		pdf_name: DF.Data | None
 		posting_date: DF.Date | None
 		primary_mandatory: DF.Check
+		print_format: DF.Link | None
 		project: DF.TableMultiSelect[PSOAProject]
 		report: DF.Literal["General Ledger", "Accounts Receivable"]
 		sales_partner: DF.Link | None
@@ -108,6 +109,11 @@ class ProcessStatementOfAccounts(Document):
 			if self.start_date and getdate(self.start_date) >= getdate(today()):
 				self.to_date = self.start_date
 				self.from_date = add_months(self.to_date, -1 * self.filter_duration)
+
+		if self.print_format:
+			print_format_type = frappe.db.get_value("Print Format", self.print_format, "print_format_type")
+			if print_format_type != "Jinja":
+				frappe.throw(title=_("Invalid Print Format"), msg=_("Print Format Type should be Jinja."))
 
 	def validate_account(self):
 		if not self.account:
@@ -289,6 +295,10 @@ def get_html(doc, filters, entry, col, res, ageing):
 	# fetching custom print format for Process Statement of Accounts
 	if process_soa_html and process_soa_html.get(doc.report):
 		template_path = process_soa_html[doc.report][-1]
+
+	if doc.print_format:
+		custom_html, custom_css = frappe.db.get_value("Print Format", doc.print_format, ["html", "css"])
+		template_path = f"<style>{custom_css}</style> {custom_html}"
 
 	if doc.letter_head:
 		from frappe.www.printview import get_letter_head

--- a/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.py
+++ b/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.py
@@ -111,9 +111,23 @@ class ProcessStatementOfAccounts(Document):
 				self.from_date = add_months(self.to_date, -1 * self.filter_duration)
 
 		if self.print_format:
-			print_format_type = frappe.db.get_value("Print Format", self.print_format, "print_format_type")
-			if print_format_type != "Jinja":
+			pf = frappe.db.get_value(
+				"Print Format",
+				self.print_format,
+				["print_format_type", "print_format_for", "report", "disabled"],
+				as_dict=True,
+			)
+			if not pf:
+				frappe.throw(title=_("Invalid Print Format"), msg=_("Selected Print Format does not exist."))
+			if pf.print_format_type != "Jinja":
 				frappe.throw(title=_("Invalid Print Format"), msg=_("Print Format Type should be Jinja."))
+			if pf.print_format_for != "Report" or pf.report != self.report or pf.disabled:
+				frappe.throw(
+					title=_("Invalid Print Format"),
+					msg=_(
+						"Print Format must be an enabled Report Print Format matching the selected Report."
+					),
+				)
 
 	def validate_account(self):
 		if not self.account:


### PR DESCRIPTION
Changes Include:

- Users can now select a custom print format for reports in the Process Statement of Accounts. However, only the Jinja `print_format_type` is available for selection.

	<img width="2880" height="1800" alt="image" src="https://github.com/user-attachments/assets/7e1497fa-d460-4acb-879e-ab3fa9391032" />


- If Print Format is not chosen, the default hard-coded template is going to be used.

This update will allow users to customize their print formats for use in the Process Statement of Accounts.

<!-- no-docs -->