### PR TITLE
fix: skip receivable/payable account validation in payroll entry if party is not available

### DIFF
--- a/erpnext/accounts/doctype/gl_entry/gl_entry.py
+++ b/erpnext/accounts/doctype/gl_entry/gl_entry.py
@@ -131,18 +131,19 @@ class GLEntry(Document):
 
 		if not self.is_cancelled and not (self.party_type and self.party):
 			account_type = frappe.get_cached_value("Account", self.account, "account_type")
-			if account_type == "Receivable":
-				frappe.throw(
-					_("{0} {1}: Customer is required against Receivable account {2}").format(
-						self.voucher_type, self.voucher_no, self.account
+			if not frappe.flags.skip_receivable_payable_account_validation:
+				if account_type == "Receivable":
+					frappe.throw(
+						_("{0} {1}: Customer is required against Receivable account {2}").format(
+							self.voucher_type, self.voucher_no, self.account
+						)
 					)
-				)
-			elif account_type == "Payable":
-				frappe.throw(
-					_("{0} {1}: Supplier is required against Payable account {2}").format(
-						self.voucher_type, self.voucher_no, self.account
+				elif account_type == "Payable":
+					frappe.throw(
+						_("{0} {1}: Supplier is required against Payable account {2}").format(
+							self.voucher_type, self.voucher_no, self.account
+						)
 					)
-				)
 
 		# Zero value transaction is not allowed
 		if not (

--- a/erpnext/accounts/doctype/gl_entry/gl_entry.py
+++ b/erpnext/accounts/doctype/gl_entry/gl_entry.py
@@ -131,7 +131,9 @@ class GLEntry(Document):
 
 		if not self.is_cancelled and not (self.party_type and self.party):
 			account_type = frappe.get_cached_value("Account", self.account, "account_type")
-			if not frappe.flags.skip_receivable_payable_account_validation:
+			
+			# skipping validation for payroll entry creation in case party is not required
+			if not frappe.flags.party_not_required_for_receivable_payable:
 				if account_type == "Receivable":
 					frappe.throw(
 						_("{0} {1}: Customer is required against Receivable account {2}").format(

--- a/erpnext/accounts/doctype/gl_entry/gl_entry.py
+++ b/erpnext/accounts/doctype/gl_entry/gl_entry.py
@@ -131,7 +131,6 @@ class GLEntry(Document):
 
 		if not self.is_cancelled and not (self.party_type and self.party):
 			account_type = frappe.get_cached_value("Account", self.account, "account_type")
-			
 			# skipping validation for payroll entry creation in case party is not required
 			if not frappe.flags.party_not_required_for_receivable_payable:
 				if account_type == "Receivable":

--- a/erpnext/accounts/doctype/journal_entry/journal_entry.py
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.py
@@ -646,7 +646,7 @@ class JournalEntry(AccountsController):
 			account_type = frappe.get_cached_value("Account", d.account, "account_type")
 
 			# skipping validation for payroll entry creation
-			skip_validation = frappe.flags.skip_receivable_payable_account_validation
+			skip_validation = frappe.flags.party_not_required_for_receivable_payable
 			if account_type in ["Receivable", "Payable"]:
 				if not (d.party_type and d.party) and not skip_validation:
 					frappe.throw(

--- a/erpnext/accounts/doctype/journal_entry/journal_entry.py
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.py
@@ -644,8 +644,11 @@ class JournalEntry(AccountsController):
 	def validate_party(self):
 		for d in self.get("accounts"):
 			account_type = frappe.get_cached_value("Account", d.account, "account_type")
+
+			# skipping validation for payroll entry creation
+			skip_validation = frappe.flags.skip_receivable_payable_account_validation
 			if account_type in ["Receivable", "Payable"]:
-				if not (d.party_type and d.party):
+				if not (d.party_type and d.party) and not skip_validation:
 					frappe.throw(
 						_(
 							"Row {0}: Party Type and Party is required for Receivable / Payable account {1}"


### PR DESCRIPTION
## Reason
- Payroll Entry submission currently requires Journal and GL Entry creation, which includes validation of Party and Party Type. However, this validation is not applicable to Payroll Entries and should be bypassed.

payroll PR to add flag: https://github.com/frappe/hrms/pull/3564

`no-docs`