### PR TITLE
fix: incorrect current qty calculation for the batch

### DIFF
--- a/erpnext/stock/doctype/batch/batch.py
+++ b/erpnext/stock/doctype/batch/batch.py
@@ -218,6 +218,7 @@ def get_batch_qty(
 	batch_no=None,
 	warehouse=None,
 	item_code=None,
+	creation=None,
 	posting_date=None,
 	posting_time=None,
 	ignore_voucher_nos=None,
@@ -244,6 +245,7 @@ def get_batch_qty(
 		{
 			"item_code": item_code,
 			"warehouse": warehouse,
+			"creation": creation,
 			"posting_date": posting_date,
 			"posting_time": posting_time,
 			"batch_no": batch_no,

--- a/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py
+++ b/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py
@@ -2419,6 +2419,16 @@ def get_available_batches(kwargs):
 			kwargs.posting_date, kwargs.posting_time
 		)
 
+		if kwargs.get("creation"):
+			timestamp_condition = stock_ledger_entry.posting_datetime < get_combine_datetime(
+				kwargs.posting_date, kwargs.posting_time
+			)
+
+			timestamp_condition |= (
+				stock_ledger_entry.posting_datetime
+				== get_combine_datetime(kwargs.posting_date, kwargs.posting_time)
+			) & (stock_ledger_entry.creation < kwargs.creation)
+
 		query = query.where(timestamp_condition)
 
 	for field in ["warehouse", "item_code"]:
@@ -2660,6 +2670,16 @@ def get_stock_ledgers_for_serial_nos(kwargs):
 			kwargs.posting_date, kwargs.posting_time
 		)
 
+		if kwargs.get("creation"):
+			timestamp_condition = stock_ledger_entry.posting_datetime < get_combine_datetime(
+				kwargs.posting_date, kwargs.posting_time
+			)
+
+			timestamp_condition |= (
+				stock_ledger_entry.posting_datetime
+				== get_combine_datetime(kwargs.posting_date, kwargs.posting_time)
+			) & (stock_ledger_entry.creation < kwargs.creation)
+
 		query = query.where(timestamp_condition)
 
 	for field in ["warehouse", "item_code", "serial_no"]:
@@ -2717,6 +2737,16 @@ def get_stock_ledgers_batches(kwargs):
 		timestamp_condition = stock_ledger_entry.posting_datetime <= get_combine_datetime(
 			kwargs.posting_date, kwargs.posting_time
 		)
+
+		if kwargs.get("creation"):
+			timestamp_condition = stock_ledger_entry.posting_datetime < get_combine_datetime(
+				kwargs.posting_date, kwargs.posting_time
+			)
+
+			timestamp_condition |= (
+				stock_ledger_entry.posting_datetime
+				== get_combine_datetime(kwargs.posting_date, kwargs.posting_time)
+			) & (stock_ledger_entry.creation < kwargs.creation)
 
 		query = query.where(timestamp_condition)
 

--- a/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py
+++ b/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py
@@ -5,7 +5,7 @@
 import frappe
 from frappe import _, bold, json, msgprint
 from frappe.query_builder.functions import CombineDatetime, Sum
-from frappe.utils import add_to_date, cint, cstr, flt, get_datetime
+from frappe.utils import add_to_date, cint, cstr, flt, get_datetime, now
 
 import erpnext
 from erpnext.accounts.utils import get_company_default
@@ -1029,7 +1029,7 @@ class StockReconciliation(StockController):
 			val_rate = 0.0
 			current_qty = 0.0
 			if row.current_serial_and_batch_bundle:
-				current_qty = self.get_current_qty_for_serial_or_batch(row)
+				current_qty = self.get_current_qty_for_serial_or_batch(row, sle_creation)
 			elif row.serial_no:
 				item_dict = get_stock_balance_for(
 					row.item_code,
@@ -1138,17 +1138,17 @@ class StockReconciliation(StockController):
 
 		return allow_negative_stock
 
-	def get_current_qty_for_serial_or_batch(self, row):
+	def get_current_qty_for_serial_or_batch(self, row, sle_creation):
 		doc = frappe.get_doc("Serial and Batch Bundle", row.current_serial_and_batch_bundle)
 		current_qty = 0.0
 		if doc.has_serial_no:
-			current_qty = self.get_current_qty_for_serial_nos(doc)
+			current_qty = self.get_current_qty_for_serial_nos(doc, sle_creation)
 		elif doc.has_batch_no:
-			current_qty = self.get_current_qty_for_batch_nos(doc)
+			current_qty = self.get_current_qty_for_batch_nos(doc, sle_creation)
 
 		return abs(current_qty)
 
-	def get_current_qty_for_serial_nos(self, doc):
+	def get_current_qty_for_serial_nos(self, doc, sle_creation):
 		serial_nos_details = get_available_serial_nos(
 			frappe._dict(
 				{
@@ -1156,6 +1156,7 @@ class StockReconciliation(StockController):
 					"warehouse": doc.warehouse,
 					"posting_date": self.posting_date,
 					"posting_time": self.posting_time,
+					"creation": sle_creation,
 					"voucher_no": self.name,
 					"ignore_warehouse": 1,
 				}
@@ -1185,7 +1186,7 @@ class StockReconciliation(StockController):
 
 		return current_qty
 
-	def get_current_qty_for_batch_nos(self, doc):
+	def get_current_qty_for_batch_nos(self, doc, sle_creation):
 		current_qty = 0.0
 		precision = doc.entries[0].precision("qty")
 		for d in doc.entries:
@@ -1193,6 +1194,7 @@ class StockReconciliation(StockController):
 				get_batch_qty(
 					d.batch_no,
 					doc.warehouse,
+					creation=sle_creation,
 					posting_date=doc.posting_date,
 					posting_time=doc.posting_time,
 					ignore_voucher_nos=[doc.voucher_no],
@@ -1489,6 +1491,7 @@ def get_stock_balance_for(
 						"company": company,
 						"posting_date": posting_date,
 						"posting_time": posting_time,
+						"creation": row.get("creation") if row and row.get("creation") else now(),
 					}
 				)
 			)


### PR DESCRIPTION
Multiple stock reconciliations with same item code, warehouse, posting data, posting time and batch causing incorrect qty calculation 