### PR TITLE
refactor: make checkboxes opt out

### DIFF
--- a/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
+++ b/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
@@ -98,7 +98,7 @@
   "payment_request_settings",
   "create_pr_in_draft_status",
   "budget_settings",
-  "use_new_budget_controller"
+  "use_legacy_budget_controller"
  ],
  "fields": [
   {
@@ -600,12 +600,6 @@
   },
   {
    "default": "1",
-   "fieldname": "use_new_budget_controller",
-   "fieldtype": "Check",
-   "label": "Use New Budget Controller"
-  },
-  {
-   "default": "1",
    "description": "If enabled, user will be alerted before resetting posting date to current date in relevant transactions",
    "fieldname": "confirm_before_resetting_posting_date",
    "fieldtype": "Check",
@@ -651,6 +645,12 @@
    "fieldname": "fetch_valuation_rate_for_internal_transaction",
    "fieldtype": "Check",
    "label": "Fetch Valuation Rate for Internal Transaction"
+  },
+  {
+   "default": "0",
+   "fieldname": "use_legacy_budget_controller",
+   "fieldtype": "Check",
+   "label": "Use Legacy Budget Controller"
   }
  ],
  "grid_page_length": 50,
@@ -659,7 +659,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-07-18 13:56:47.192437",
+ "modified": "2025-09-24 16:08:08.515254",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Accounts Settings",

--- a/erpnext/accounts/doctype/accounts_settings/accounts_settings.py
+++ b/erpnext/accounts/doctype/accounts_settings/accounts_settings.py
@@ -74,7 +74,7 @@ class AccountsSettings(Document):
 		submit_journal_entries: DF.Check
 		unlink_advance_payment_on_cancelation_of_order: DF.Check
 		unlink_payment_on_cancellation_of_invoice: DF.Check
-		use_new_budget_controller: DF.Check
+		use_legacy_budget_controller: DF.Check
 	# end: auto-generated types
 
 	def validate(self):

--- a/erpnext/accounts/general_ledger.py
+++ b/erpnext/accounts/general_ledger.py
@@ -35,7 +35,7 @@ def make_gl_entries(
 ):
 	if gl_map:
 		if (
-			frappe.get_single_value("Accounts Settings", "use_new_budget_controller")
+			not cint(frappe.get_single_value("Accounts Settings", "use_legacy_budget_controller"))
 			and gl_map[0].voucher_type != "Period Closing Voucher"
 		):
 			bud_val = BudgetValidation(gl_map=gl_map)

--- a/erpnext/controllers/buying_controller.py
+++ b/erpnext/controllers/buying_controller.py
@@ -875,7 +875,7 @@ class BuyingController(SubcontractingController):
 			self.update_fixed_asset(field, delete_asset=True)
 
 	def validate_budget(self):
-		if frappe.get_single_value("Accounts Settings", "use_new_budget_controller"):
+		if not frappe.get_single_value("Accounts Settings", "use_legacy_budget_controller"):
 			from erpnext.controllers.budget_controller import BudgetValidation
 
 			val = BudgetValidation(doc=self)

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -592,7 +592,7 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 		frappe.flags.dialog_set = false;
 
 		// Experimental: This will be removed once stability is achieved.
-		if (frappe.boot.sysdefaults.use_server_side_reactivity) {
+		if (!frappe.boot.sysdefaults.use_legacy_js_reactivity) {
 			var item = frappe.get_doc(cdt, cdn);
 			frappe.call({
 				doc: doc,

--- a/erpnext/selling/doctype/selling_settings/selling_settings.json
+++ b/erpnext/selling/doctype/selling_settings/selling_settings.json
@@ -38,7 +38,7 @@
   "allow_zero_qty_in_quotation",
   "allow_zero_qty_in_sales_order",
   "experimental_section",
-  "use_server_side_reactivity"
+  "use_legacy_js_reactivity"
  ],
  "fields": [
   {
@@ -219,12 +219,6 @@
    "label": "Experimental"
   },
   {
-   "default": "1",
-   "fieldname": "use_server_side_reactivity",
-   "fieldtype": "Check",
-   "label": "Use Server Side Reactivity"
-  },
-  {
    "default": "0",
    "description": "Allows users to submit Sales Orders with zero quantity. Useful when rates are fixed but the quantities are not. Eg. Rate Contracts.",
    "fieldname": "allow_zero_qty_in_sales_order",
@@ -243,6 +237,12 @@
    "fieldname": "fallback_to_default_price_list",
    "fieldtype": "Check",
    "label": "Use Prices from Default Price List as Fallback"
+  },
+  {
+   "default": "0",
+   "fieldname": "use_legacy_js_reactivity",
+   "fieldtype": "Check",
+   "label": "Use Legacy (Client side) Reactivity"
   }
  ],
  "grid_page_length": 50,
@@ -251,7 +251,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-09-23 21:10:14.826653",
+ "modified": "2025-09-24 16:08:48.865885",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Selling Settings",

--- a/erpnext/selling/doctype/selling_settings/selling_settings.py
+++ b/erpnext/selling/doctype/selling_settings/selling_settings.py
@@ -44,7 +44,7 @@ class SellingSettings(Document):
 		selling_price_list: DF.Link | None
 		so_required: DF.Literal["No", "Yes"]
 		territory: DF.Link | None
-		use_server_side_reactivity: DF.Check
+		use_legacy_js_reactivity: DF.Check
 		validate_selling_price: DF.Check
 	# end: auto-generated types
 

--- a/erpnext/startup/boot.py
+++ b/erpnext/startup/boot.py
@@ -17,8 +17,8 @@ def boot_session(bootinfo):
 
 		bootinfo.sysdefaults.territory = frappe.get_single_value("Selling Settings", "territory")
 		bootinfo.sysdefaults.customer_group = frappe.get_single_value("Selling Settings", "customer_group")
-		bootinfo.sysdefaults.use_server_side_reactivity = frappe.get_single_value(
-			"Selling Settings", "use_server_side_reactivity"
+		bootinfo.sysdefaults.use_legacy_js_reactivity = cint(
+			frappe.get_single_value("Selling Settings", "use_legacy_js_reactivity")
 		)
 		bootinfo.sysdefaults.allow_stale = cint(frappe.get_single_value("Accounts Settings", "allow_stale"))
 		bootinfo.sysdefaults.over_billing_allowance = frappe.get_single_value(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added “Use Legacy Budget Controller” in Accounts Settings. Budget validation now switches between new and legacy flows based on this setting.
  - Added “Use Legacy (Client side) Reactivity” in Selling Settings to choose client-side or server-side item updates.

- Refactor
  - Replaced prior “new budget controller” and “server-side reactivity” toggles with legacy-oriented flags, updating validation and item processing paths accordingly.
  - Boot defaults updated to reflect the new reactivity setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->