### PR TITLE
fix(accounts): reference get_payment_mode_account correctly in Sales Invoice

### DIFF
--- a/erpnext/public/js/controllers/accounts.js
+++ b/erpnext/public/js/controllers/accounts.js
@@ -265,7 +265,7 @@ erpnext.accounts.pos = {
 		frappe.ui.form.on(doctype, {
 			mode_of_payment: function (frm, cdt, cdn) {
 				var d = locals[cdt][cdn];
-				get_payment_mode_account(frm, d.mode_of_payment, function (account) {
+				erpnext.accounts.pos.get_payment_mode_account(frm, d.mode_of_payment, function (account) {
 					frappe.model.set_value(cdt, cdn, "account", account);
 				});
 			},


### PR DESCRIPTION
Closes: #49514 
Backport: version-15

----

https://github.com/user-attachments/assets/8645ffca-c7f5-4ba4-8f2f-7cf846bda02f



