### PR TITLE
fix(profit and loss statement): incorrect total calculation

### DIFF
--- a/erpnext/accounts/report/financial_statements.py
+++ b/erpnext/accounts/report/financial_statements.py
@@ -325,18 +325,24 @@ def prepare_data(accounts, balance_must_be, period_list, company_currency, accum
 
 
 def filter_out_zero_value_rows(data, parent_children_map, show_zero_values=False):
+	def get_all_parents(account, parent_children_map):
+		for parent, children in parent_children_map.items():
+			for child in children:
+				if child["name"] == account and parent:
+					accounts_to_show.add(parent)
+					get_all_parents(parent, parent_children_map)
+
 	data_with_value = []
+	accounts_to_show = set()
+
 	for d in data:
 		if show_zero_values or d.get("has_value"):
+			accounts_to_show.add(d.get("account"))
+			get_all_parents(d.get("account"), parent_children_map)
+
+	for d in data:
+		if d.get("account") in accounts_to_show:
 			data_with_value.append(d)
-		else:
-			# show group with zero balance, if there are balances against child
-			children = [child.name for child in parent_children_map.get(d.get("account")) or []]
-			if children:
-				for row in data:
-					if row.get("account") in children and row.get("has_value"):
-						data_with_value.append(d)
-						break
 
 	return data_with_value
 


### PR DESCRIPTION
Issue: The Profit and Loss statement was showing incorrect totals because parent accounts were not being fetched correctly.

Ref: [#48699](https://support.frappe.io/helpdesk/tickets/48699)

Before:

<img width="1792" height="1120" alt="Screenshot 2025-09-19 at 7 38 49 PM" src="https://github.com/user-attachments/assets/694f0be6-50d5-4bb1-bba7-1173017c30de" />

After:

<img width="1792" height="1120" alt="Screenshot 2025-09-19 at 7 39 17 PM" src="https://github.com/user-attachments/assets/c953cb23-77d7-4d67-8ea2-487762d7f323" />

Backport needed: v15