### PR TITLE
fix(stock): NoneType object error on stock entry

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -2340,9 +2340,12 @@ class StockEntry(StockController):
 					"Work Order", self.work_order, "allow_alternative_item"
 				)
 
-			skip_transfer, from_wip_warehouse = frappe.get_value(
-				"Work Order", self.work_order, ["skip_transfer", "from_wip_warehouse"]
+			skip_transfer, from_wip_warehouse = (
+				frappe.get_value("Work Order", self.work_order, ["skip_transfer", "from_wip_warehouse"])
+				if self.work_order
+				else [None, None]
 			)
+
 			item.from_warehouse = (
 				frappe.get_value(
 					"Work Order Item",


### PR DESCRIPTION
**Issue:** Unable to create _Stock Entry Manufacture_ entry from BOM. When user clicks `Get Items` button, the system throws a `NoneType` object error.

**Ref:** [48949](https://support.frappe.io/helpdesk/tickets/48949)

**Before:**
<img width="2880" height="1340" alt="image" src="https://github.com/user-attachments/assets/3e0eb642-6e69-43b4-83c4-db3f56696be1" />


**After:**
 
[Screencast from 18-09-25 04:34:17 PM IST.webm](https://github.com/user-attachments/assets/3bb02b30-43c9-4753-93e6-ab014cafcbb6)

**Backport Needed: v15**