### PR TITLE
fix: add date filter for getting return invoice items

### DIFF
--- a/erpnext/accounts/report/gross_profit/gross_profit.py
+++ b/erpnext/accounts/report/gross_profit/gross_profit.py
@@ -677,7 +677,9 @@ class GrossProfitGenerator:
 				si.name = si_item.parent
 				and si.docstatus = 1
 				and si.is_return = 1
+				and si.posting_date between %(from_date)s and %(to_date)s
 		""",
+			{"from_date": self.filters.from_date, "to_date": self.filters.to_date},
 			as_dict=1,
 		)
 

--- a/erpnext/accounts/report/gross_profit/test_gross_profit.py
+++ b/erpnext/accounts/report/gross_profit/test_gross_profit.py
@@ -1,9 +1,9 @@
 import frappe
 from frappe import qb
 from frappe.tests import IntegrationTestCase
-from frappe.utils import flt, nowdate
+from frappe.utils import add_days, flt, get_first_day, get_last_day, nowdate
 
-from erpnext.accounts.doctype.sales_invoice.sales_invoice import make_delivery_note
+from erpnext.accounts.doctype.sales_invoice.sales_invoice import make_delivery_note, make_sales_return
 from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_sales_invoice
 from erpnext.accounts.report.gross_profit.gross_profit import execute
 from erpnext.stock.doctype.delivery_note.delivery_note import make_sales_invoice
@@ -395,7 +395,6 @@ class TestGrossProfit(IntegrationTestCase):
 		"""
 		Item Qty for Sales Invoices with multiple instances of same item go in the -ve. Ideally, the credit noteshould cancel out the invoice items.
 		"""
-		from erpnext.accounts.doctype.sales_invoice.sales_invoice import make_sales_return
 
 		# Invoice with an item added twice
 		sinv = self.create_sales_invoice(qty=1, rate=100, posting_date=nowdate(), do_not_submit=True)
@@ -642,3 +641,42 @@ class TestGrossProfit(IntegrationTestCase):
 		self.assertEqual(total.buying_amount, 0.0)
 		self.assertEqual(total.gross_profit, 100.0)
 		self.assertEqual(total.get("gross_profit_%"), 100.0)
+
+	def test_profit_for_later_period_return(self):
+		month_start_date, month_end_date = get_first_day(nowdate()), get_last_day(nowdate())
+
+		# create sales invoice on month start date
+		sinv = self.create_sales_invoice(qty=1, rate=100, do_not_save=True, do_not_submit=True)
+		sinv.set_posting_time = 1
+		sinv.posting_date = month_start_date
+		sinv.save().submit()
+
+		# create credit note on next month start date
+		cr_note = make_sales_return(sinv.name)
+		cr_note.set_posting_time = 1
+		cr_note.posting_date = add_days(month_end_date, 1)
+		cr_note.save().submit()
+
+		# apply filters for invoiced period
+		filters = frappe._dict(
+			company=self.company, from_date=month_start_date, to_date=month_end_date, group_by="Invoice"
+		)
+
+		_, data = execute(filters=filters)
+		total = data[-1]
+
+		self.assertEqual(total.selling_amount, 100.0)
+		self.assertEqual(total.buying_amount, 0.0)
+		self.assertEqual(total.gross_profit, 100.0)
+		self.assertEqual(total.get("gross_profit_%"), 100.0)
+
+		# extend filters upto returned period
+		filters.update(to_date=add_days(month_end_date, 1))
+
+		_, data = execute(filters=filters)
+		total = data[-1]
+
+		self.assertEqual(total.selling_amount, 0.0)
+		self.assertEqual(total.buying_amount, 0.0)
+		self.assertEqual(total.gross_profit, 0.0)
+		self.assertEqual(total.get("gross_profit_%"), 0.0)


### PR DESCRIPTION
Issue:
When a Sales Invoice return is created against a Sales Invoice in a later period, the Gross Profit report in the period before the return zeros out the gross profit of the original invoice.

Ref: [47708](https://support.frappe.io/helpdesk/tickets/47708)
Closes: #49465 

Before:

https://github.com/user-attachments/assets/5fb09da9-0efa-4829-9429-0ebd2c43dc86

After:

https://github.com/user-attachments/assets/489f3271-db2e-40e1-93ab-f668fd33485a

Backport Needed: V15