### PR TITLE
feat: add filters option in print view

### DIFF
--- a/erpnext/accounts/report/accounts_receivable/accounts_receivable.html
+++ b/erpnext/accounts/report/accounts_receivable/accounts_receivable.html
@@ -164,6 +164,12 @@
 				{% } %}
 			</tr>
 		</thead>
+		<div class="show-filters">
+			{% if subtitle %}
+				{{ subtitle }}
+				<hr>
+			{% endif %}
+		</div>
 		<tbody>
 			{% for(var i=0, l=data.length; i<l; i++) { %}
 				<tr>

--- a/erpnext/accounts/report/financial_statements.html
+++ b/erpnext/accounts/report/financial_statements.html
@@ -34,6 +34,12 @@
 	</h5>
 {% } %}
 <hr>
+<div class="show-filters">
+			{% if subtitle %}
+				{{ subtitle }}
+				<hr>
+			{% endif %}
+</div>
 <table class="table table-bordered">
 	<thead>
 		<tr>

--- a/erpnext/accounts/report/general_ledger/general_ledger.html
+++ b/erpnext/accounts/report/general_ledger/general_ledger.html
@@ -75,6 +75,12 @@
 			</b>
 		</div>
 	</div>
+	<div class="show-filters">
+			{% if subtitle %}
+				{{ subtitle }}
+				<hr>
+			{% endif %}
+	</div>
 	<table style="width:100%; font-size: 11px">
 		<thead>
 			<tr class="title-letter-spacing" style="text-align: center; font-weight:bold">


### PR DESCRIPTION
Depend on PR [#34049](https://github.com/frappe/frappe/pull/34049)

**Issue:**
When a report is viewed in print view, the applied filters are always shown by default.

**Solution:**
Added a checkbox in the "Print Settings" dialog box to include filters in the print view

[Screencast from 2025-09-19 14-06-00.webm](https://github.com/user-attachments/assets/29d04cd2-43f3-4156-b3fd-8c65b338482b)






Backport v15