### PR TITLE
feat: allow fallback to default selling price list

### DIFF
--- a/erpnext/selling/doctype/selling_settings/selling_settings.json
+++ b/erpnext/selling/doctype/selling_settings/selling_settings.json
@@ -242,7 +242,7 @@
    "default": "0",
    "fieldname": "fallback_to_default_price_list",
    "fieldtype": "Check",
-   "label": "Use prices from Default Price List as Fallback"
+   "label": "Use Prices from Default Price List as Fallback"
   }
  ],
  "grid_page_length": 50,
@@ -251,7 +251,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-09-19 12:07:09.723545",
+ "modified": "2025-09-23 21:10:14.826653",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Selling Settings",

--- a/erpnext/selling/doctype/selling_settings/selling_settings.json
+++ b/erpnext/selling/doctype/selling_settings/selling_settings.json
@@ -17,6 +17,7 @@
   "role_to_override_stop_action",
   "column_break_15",
   "maintain_same_sales_rate",
+  "fallback_to_default_price_list",
   "editable_price_list_rate",
   "validate_selling_price",
   "editable_bundle_item_rates",
@@ -236,6 +237,12 @@
    "fieldname": "allow_zero_qty_in_quotation",
    "fieldtype": "Check",
    "label": "Allow Quotation with Zero Quantity"
+  },
+  {
+   "default": "0",
+   "fieldname": "fallback_to_default_price_list",
+   "fieldtype": "Check",
+   "label": "Use prices from Default Price List as Fallback"
   }
  ],
  "grid_page_length": 50,
@@ -244,7 +251,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-05-06 15:23:14.332971",
+ "modified": "2025-09-19 12:07:09.723545",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Selling Settings",

--- a/erpnext/selling/doctype/selling_settings/selling_settings.py
+++ b/erpnext/selling/doctype/selling_settings/selling_settings.py
@@ -5,6 +5,7 @@
 
 
 import frappe
+from frappe import _
 from frappe.custom.doctype.property_setter.property_setter import make_property_setter
 from frappe.model.document import Document
 from frappe.utils import cint
@@ -71,6 +72,25 @@ class SellingSettings(Document):
 			self.get("cust_master_name") == "Naming Series",
 			hide_name_field=False,
 		)
+
+		self.validate_fallback_to_default_price_list()
+
+	def validate_fallback_to_default_price_list(self):
+		if (
+			self.fallback_to_default_price_list
+			and self.has_value_changed("fallback_to_default_price_list")
+			and frappe.get_single_value("Stock Settings", "auto_insert_price_list_rate_if_missing")
+		):
+			stock_meta = frappe.get_meta("Stock Settings")
+			frappe.msgprint(
+				_(
+					"You have enabled {0} and {1} in {2}. This can lead to prices from the default price list being inserted into the transaction price list."
+				).format(
+					"<i>{}</i>".format(_(self.meta.get_label("fallback_to_default_price_list"))),
+					"<i>{}</i>".format(_(stock_meta.get_label("auto_insert_price_list_rate_if_missing"))),
+					frappe.bold(_("Stock Settings")),
+				)
+			)
 
 	def toggle_hide_tax_id(self):
 		_hide_tax_id = cint(self.hide_tax_id)

--- a/erpnext/selling/doctype/selling_settings/selling_settings.py
+++ b/erpnext/selling/doctype/selling_settings/selling_settings.py
@@ -34,6 +34,7 @@ class SellingSettings(Document):
 		editable_price_list_rate: DF.Check
 		enable_cutoff_date_on_bulk_delivery_note_creation: DF.Check
 		enable_discount_accounting: DF.Check
+		fallback_to_default_price_list: DF.Check
 		hide_tax_id: DF.Check
 		maintain_same_rate_action: DF.Literal["Stop", "Warn"]
 		maintain_same_sales_rate: DF.Check

--- a/erpnext/stock/doctype/stock_settings/stock_settings.py
+++ b/erpnext/stock/doctype/stock_settings/stock_settings.py
@@ -106,6 +106,7 @@ class StockSettings(Document):
 		self.validate_clean_description_html()
 		self.validate_pending_reposts()
 		self.validate_stock_reservation()
+		self.validate_auto_insert_price_list_rate_if_missing()
 		self.change_precision_for_for_sales()
 		self.change_precision_for_purchase()
 
@@ -222,6 +223,23 @@ class StockSettings(Document):
 							frappe.bold(_("Stock Reservation"))
 						)
 					)
+
+	def validate_auto_insert_price_list_rate_if_missing(self):
+		if (
+			self.auto_insert_price_list_rate_if_missing
+			and self.has_value_changed("auto_insert_price_list_rate_if_missing")
+			and frappe.get_single_value("Selling Settings", "fallback_to_default_price_list")
+		):
+			selling_meta = frappe.get_meta("Selling Settings")
+			frappe.msgprint(
+				_(
+					"You have enabled {0} and {1} in {2}. This can lead to prices from the default price list being inserted in the transaction price list."
+				).format(
+					"<i>{}</i>".format(_(self.meta.get_label("auto_insert_price_list_rate_if_missing"))),
+					"<i>{}</i>".format(_(selling_meta.get_label("fallback_to_default_price_list"))),
+					frappe.bold(_("Selling Settings")),
+				)
+			)
 
 	def on_update(self):
 		self.toggle_warehouse_field_for_inter_warehouse_transfer()

--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -118,6 +118,13 @@ def get_item_details(
 
 	out.update(get_price_list_rate(ctx, item))
 
+	if not out.price_list_rate and frappe.get_single_value(
+		"Selling Settings", "fallback_to_default_price_list"
+	):
+		fallback_args = ctx.copy()
+		fallback_args.price_list = frappe.get_single_value("Selling Settings", "selling_price_list")
+		out.update(get_price_list_rate(fallback_args, item))
+
 	ctx.customer = current_customer
 
 	if ctx.customer and cint(ctx.is_pos):


### PR DESCRIPTION
Resolves https://github.com/frappe/erpnext/issues/49569

The feature is backwards compatible, since it introduces an optional setting.

The new setting conflicts with _Auto Insert Item Price If Missing_ in **Stock Settings**. This is mentioned in docs and shown in a message when a user enables both settings.

> If no **Item Price** is found for an item in the **Price List** set in the Transaction, prices from the *Default Price List* will be fetched. Don't use this together with *Auto Insert Item Price If Missing* from **Stock Settings**, since prices from the *Default Price List* can end up in other price lists.

Ref: AIT-6

https://docs.frappe.io/erpnext/user/manual/en/selling-settings?editWiki=1&wikiPagePatch=3ddo30rjev