### PR TITLE
fix(subscription): include days before

### DIFF
--- a/erpnext/accounts/doctype/subscription/subscription.py
+++ b/erpnext/accounts/doctype/subscription/subscription.py
@@ -483,12 +483,10 @@ class Subscription(Document):
 
 		return invoice
 
-	def get_items_from_plans(self, plans: list[dict[str, str]], prorate: bool | None = None) -> list[dict]:
+	def get_items_from_plans(self, plans: list[dict[str, str]], prorate: int = 0) -> list[dict]:
 		"""
 		Returns the `Item`s linked to `Subscription Plan`
 		"""
-		if prorate is None:
-			prorate = False
 
 		prorate_factor = 1
 		if prorate:

--- a/erpnext/accounts/doctype/subscription/test_subscription.py
+++ b/erpnext/accounts/doctype/subscription/test_subscription.py
@@ -8,6 +8,7 @@ from frappe.utils.data import (
 	add_days,
 	add_months,
 	add_to_date,
+	add_years,
 	cint,
 	date_diff,
 	flt,
@@ -554,6 +555,33 @@ class TestSubscription(IntegrationTestCase):
 		subscription.force_fetch_subscription_updates()
 		subscription.reload()
 		self.assertEqual(len(subscription.invoices), 0)
+
+	def test_invoice_generation_days_before_subscription_period_with_prorate(self):
+		settings = frappe.get_single("Subscription Settings")
+		settings.prorate = 1
+		settings.save()
+
+		create_plan(
+			plan_name="_Test Plan Name 5",
+			cost=1000,
+			billing_interval="Year",
+			billing_interval_count=1,
+			currency="INR",
+		)
+
+		start_date = add_days(nowdate(), 2)
+
+		subscription = create_subscription(
+			start_date=start_date,
+			party_type="Supplier",
+			party="_Test Supplier",
+			generate_invoice_at="Days before the current subscription period",
+			generate_new_invoices_past_due_date=1,
+			number_of_days=2,
+			plans=[{"plan": "_Test Plan Name 5", "qty": 1}],
+		)
+		subscription.process(nowdate())
+		self.assertEqual(len(subscription.invoices), 1)
 
 
 def make_plans():


### PR DESCRIPTION
Issue: Subscription invoice not generated for `Days before the current subscription period` when prorate is **enabled** in subscription settings, the system calculates prorate incorrectly


Ref: [#48965](https://support.frappe.io/helpdesk/tickets/48965)

Subscription:

<img width="1792" height="1120" alt="Screenshot 2025-09-19 at 7 27 53 PM" src="https://github.com/user-attachments/assets/3e821127-189d-4abf-a729-6fbeec2c0a9c" />


Backport needed: v15