### PR TITLE
fix(purchase order): get party type based on supplier field

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -1069,7 +1069,7 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 			if (me.frm.doc.doctype == "Quotation" && me.frm.doc.quotation_to == "Customer") {
 				(party_type = "Customer"), (party_name = me.frm.doc.party_name);
 			} else {
-				party_type = frappe.meta.has_field(me.frm.doc.doctype, "customer") ? "Customer" : "Supplier";
+				party_type = frappe.meta.has_field(me.frm.doc.doctype, "supplier") ? "Supplier" : "Customer";
 				party_name = me.frm.doc[party_type.toLowerCase()];
 			}
 			if (party_name) {


### PR DESCRIPTION
**Issue:**
Party Currency changed to company currency while duplicating the forex PO

**ref:** [48810](https://support.frappe.io/helpdesk/tickets/48810)

**Solution:**
As the PO has a customer field for Drop Shipping, the party currency for the duplicated PO is fetched from the Customer. So I validated it with the supplier field instead of the customer

**Note:**
As the superclass's onload didn't get invoked [here](https://github.com/frappe/erpnext/blame/7e63f1d2208935e6d4ee2a8e7220d6c7d63ef440/erpnext/buying/doctype/purchase_order/purchase_order.js#L505), the issue is non-reproducible in the `develop` branch, and I raised a PR #49643 for it. However, the issue is reproducible in v15.

**Before:**

https://github.com/user-attachments/assets/c0570b93-dea2-4ee6-bf7b-18c9ca9eb9ec



**After:**

https://github.com/user-attachments/assets/0f54e884-546a-4fe1-aedf-eccb0ee3d50c



**Backport needed for v15**