### PR TITLE
chore: rename stock qty label

### DIFF
--- a/erpnext/stock/doctype/pick_list_item/pick_list_item.json
+++ b/erpnext/stock/doctype/pick_list_item/pick_list_item.json
@@ -124,7 +124,7 @@
    "fieldname": "stock_qty",
    "fieldtype": "Float",
    "in_list_view": 1,
-   "label": "Stock Qty",
+   "label": "Qty (in Stock UOM)",
    "read_only": 1
   },
   {
@@ -252,7 +252,7 @@
  ],
  "istable": 1,
  "links": [],
- "modified": "2025-05-31 19:57:43.531298",
+ "modified": "2025-09-20 17:25:01.139613",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Pick List Item",


### PR DESCRIPTION
The field label **Stock Qty** creates UX Issue on _Pick List Item_. As It's purpose is to show the qty in stock UOM. So, renamed it to **Qty (in Stock UOM)** 

**Ref:** [49065](https://support.frappe.io/helpdesk/tickets/49065)

**Before:** 
<img width="410" height="122" alt="image" src="https://github.com/user-attachments/assets/76e9518e-03cd-4c64-b675-be225d0987f3" />

**After:**
<img width="410" height="122" alt="image" src="https://github.com/user-attachments/assets/b0a00f4e-8d18-4ac3-83ab-dfa9d38fb2f7" />

**Backport Needed: v15**
