### PR TITLE
fix: set first_response_time on set_first_response

### DIFF
--- a/erpnext/support/doctype/issue/issue.py
+++ b/erpnext/support/doctype/issue/issue.py
@@ -310,7 +310,7 @@ def is_first_response(issue):
 
 
 def calculate_first_response_time(issue, first_responded_on):
-	issue_creation_date = issue.service_level_agreement_creation or issue.creation
+	issue_creation_date = get_datetime(issue.service_level_agreement_creation or issue.creation)
 	issue_creation_time = get_time_in_seconds(issue_creation_date)
 	first_responded_on_in_seconds = get_time_in_seconds(first_responded_on)
 	support_hours = frappe.get_cached_doc(

--- a/erpnext/support/doctype/service_level_agreement/service_level_agreement.py
+++ b/erpnext/support/doctype/service_level_agreement/service_level_agreement.py
@@ -25,7 +25,7 @@ from frappe.utils.caching import redis_cache
 from frappe.utils.nestedset import get_ancestors_of
 from frappe.utils.safe_exec import get_safe_globals
 
-from erpnext.support.doctype.issue.issue import get_holidays
+from erpnext.support.doctype.issue.issue import calculate_first_response_time, get_holidays
 
 
 class ServiceLevelAgreement(Document):
@@ -552,6 +552,8 @@ def handle_status_change(doc, apply_sla_for_resolution):
 	def set_first_response():
 		if doc.meta.has_field("first_responded_on") and not doc.get("first_responded_on"):
 			doc.first_responded_on = now_time
+			if doc.meta.has_field("first_response_time"):
+				doc.first_response_time = calculate_first_response_time(doc, doc.first_responded_on)
 			if get_datetime(doc.get("first_responded_on")) > get_datetime(doc.get("response_by")):
 				record_assigned_users_on_failure(doc)
 


### PR DESCRIPTION
Changes include:
- The `set_first_response` function now sets both `first_response_time` and `first_responded_on`, whereas previously only `first_responded_on` was set. This will not result in overwriting the `first_responded_on` field if an email was sent for an `Issue`, as the communication logic only checks for the availability of `first_response_time`.

Support Ticket: [#47836](https://support.frappe.io/helpdesk/tickets/47836)