### PR TITLE
fix(pricing_rule): handle dict type when checking coupon_code_based

### DIFF
--- a/erpnext/accounts/doctype/pricing_rule/pricing_rule.py
+++ b/erpnext/accounts/doctype/pricing_rule/pricing_rule.py
@@ -452,7 +452,7 @@ def get_pricing_rule_for_item(args, doc=None, for_validate=False):
 					get_pricing_rule_items(pricing_rule, other_items=fetch_other_item) or []
 				)
 
-			if pricing_rule.coupon_code_based == 1:
+			if pricing_rule.get("coupon_code_based") == 1:
 				if not args.coupon_code:
 					continue
 				coupon_code = frappe.db.get_value(


### PR DESCRIPTION
`no-docs`

closes #49674