### PR TITLE
fix: auto commit if too many writes reached

### DIFF
--- a/erpnext/patches/v15_0/set_company_on_pos_inv_merge_log.py
+++ b/erpnext/patches/v15_0/set_company_on_pos_inv_merge_log.py
@@ -6,6 +6,7 @@ def execute():
 		"POS Invoice Merge Log", {"docstatus": 1}, ["name", "pos_closing_entry"]
 	)
 
+	frappe.db.auto_commit_on_many_writes = 1
 	for log in pos_invoice_merge_logs:
 		if log.pos_closing_entry and frappe.db.exists("POS Closing Entry", log.pos_closing_entry):
 			company = frappe.db.get_value("POS Closing Entry", log.pos_closing_entry, "company")

--- a/erpnext/patches/v15_0/set_company_on_pos_inv_merge_log.py
+++ b/erpnext/patches/v15_0/set_company_on_pos_inv_merge_log.py
@@ -11,3 +11,5 @@ def execute():
 		if log.pos_closing_entry and frappe.db.exists("POS Closing Entry", log.pos_closing_entry):
 			company = frappe.db.get_value("POS Closing Entry", log.pos_closing_entry, "company")
 			frappe.db.set_value("POS Invoice Merge Log", log.name, "company", company)
+
+	frappe.db.auto_commit_on_many_writes = 0


### PR DESCRIPTION
**Issue:** The patch is failing due to too many db changes in single action. Set the auto_commit_on_many_writes flag to 1.

**Ref:** [48980](https://support.frappe.io/helpdesk/tickets/48980) 

**Backport Needed: v15**