### PR TITLE
feat: reallocate so po reference in pe

### DIFF
--- a/erpnext/accounts/doctype/unreconcile_payment/test_unreconcile_payment.py
+++ b/erpnext/accounts/doctype/unreconcile_payment/test_unreconcile_payment.py
@@ -5,10 +5,14 @@ import frappe
 from frappe.tests import IntegrationTestCase
 from frappe.utils import today
 
+from erpnext.accounts.doctype.payment_entry.payment_entry import get_payment_entry
 from erpnext.accounts.doctype.payment_entry.test_payment_entry import create_payment_entry
 from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_sales_invoice
 from erpnext.accounts.party import get_party_account
 from erpnext.accounts.test.accounts_mixin import AccountsTestMixin
+from erpnext.buying.doctype.purchase_order.purchase_order import (
+	make_purchase_invoice as make_pi_from_po,
+)
 from erpnext.buying.doctype.purchase_order.test_purchase_order import create_purchase_order
 from erpnext.selling.doctype.sales_order.sales_order import make_sales_invoice
 from erpnext.selling.doctype.sales_order.test_sales_order import make_sales_order
@@ -483,7 +487,7 @@ class TestUnreconcilePayment(AccountsTestMixin, IntegrationTestCase):
 		# after unreconcilaition advance paid will be reduced
 		# Assert 'Advance Paid'
 		so.reload()
-		self.assertEqual(so.advance_paid, 0)
+		self.assertEqual(so.advance_paid, 1000)  # still same as it is not unreconciled from SO
 
 		self.disable_advance_as_liability()
 
@@ -539,3 +543,82 @@ class TestUnreconcilePayment(AccountsTestMixin, IntegrationTestCase):
 
 		po.reload()
 		self.assertEqual(po.advance_paid, 0)
+
+	def test_reallocate_purchase_order_reference_on_unreconcile(self):
+		po_doc = create_purchase_order()
+
+		# Create Payment Entry linked to the PO (advance payment)
+		pe = get_payment_entry("Purchase Order", po_doc.name, bank_account="_Test Bank - _TC")
+		pe.reference_no = "1"
+		pe.reference_date = today()
+		pe.paid_from_account_currency = po_doc.currency
+		pe.paid_to_account_currency = po_doc.currency
+		pe.source_exchange_rate = 1
+		pe.target_exchange_rate = 1
+		pe.paid_amount = po_doc.grand_total
+		pe.save(ignore_permissions=True)
+		pe.submit()
+
+		# Check PE initially references the PO
+		self.assertEqual(pe.references[0].reference_doctype, "Purchase Order")
+		self.assertEqual(pe.references[0].reference_name, po_doc.name)
+
+		# Create Purchase Invoice from PO and allocate advance
+		pi = make_pi_from_po(po_doc.name)
+		pi.allocate_advances_automatically = 1
+		pi.only_include_allocated_payments = 1
+		pi.submit()
+
+		pe.reload()
+
+		# After allocation, PE should reference the Purchase Invoice
+		self.assertEqual(pe.references[0].reference_doctype, "Purchase Invoice")
+		self.assertEqual(pe.references[0].reference_name, pi.name)
+
+		pi.reload()
+		# Cancel invoice to simulate unreconciliation
+		pi.cancel()
+		pe.reload()
+
+		# After unreconciliation, PE should reallocate reference back to PO
+		self.assertEqual(pe.references[0].reference_doctype, "Purchase Order")
+		self.assertEqual(pe.references[0].reference_name, po_doc.name)
+
+	def test_reallocate_sales_order_reference_on_unreconcile(self):
+		so = self.create_sales_order()
+		pe = self.create_payment_entry()
+		pe.paid_amount = 1000
+		pe.append(
+			"references",
+			{"reference_doctype": so.doctype, "reference_name": so.name, "allocated_amount": 1000},
+		)
+		pe.save().submit()
+
+		# Assert 'Advance Paid'
+		so.reload()
+		self.assertEqual(so.advance_paid, 1000)
+
+		# Check PE initially references the SO
+		self.assertEqual(pe.references[0].reference_doctype, "Sales Order")
+		self.assertEqual(pe.references[0].reference_name, so.name)
+
+		# Create Sales Invoice from PO and allocate advance
+		si = make_sales_invoice(so.name)
+		si.allocate_advances_automatically = 1
+		si.only_include_allocated_payments = 1
+		si.submit()
+
+		pe.reload()
+
+		# After allocation, PE should reference the Sales Invoice
+		self.assertEqual(pe.references[0].reference_doctype, "Sales Invoice")
+		self.assertEqual(pe.references[0].reference_name, si.name)
+
+		si.reload()
+		# Cancel invoice to simulate unreconciliation
+		si.cancel()
+		pe.reload()
+
+		# After unreconciliation, PE should reallocate reference back to SO
+		self.assertEqual(pe.references[0].reference_doctype, "Sales Order")
+		self.assertEqual(pe.references[0].reference_name, so.name)

--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -1024,6 +1024,20 @@ def convert_to_list(result):
 def remove_ref_doc_link_from_pe(
 	ref_type: str | None = None, ref_no: str | None = None, payment_name: str | None = None
 ):
+	order_type = "Sales Order" if ref_type == "Sales Invoice" else "Purchase Order"
+	order_refs = []
+
+	# fetch all linked SO/PO from invoice items
+	if ref_type in ["Sales Invoice", "Purchase Invoice"]:
+		order_refs = frappe.get_all(
+			ref_type + " Item",
+			filters={
+				"parent": ref_no,
+				frappe.scrub(order_type): ["not in", ["", None]],
+			},
+			pluck=frappe.scrub(order_type),
+		)
+
 	per = qb.DocType("Payment Entry Reference")
 	pay = qb.DocType("Payment Entry")
 
@@ -1049,10 +1063,13 @@ def remove_ref_doc_link_from_pe(
 
 	linked_pe = set()
 	row_names = set()
-
+	advance_row_names = set()
 	for row in reference_rows:
 		linked_pe.add(row.parent)
-		row_names.add(row.name)
+		if order_refs and row.advance_voucher_type == order_type and row.advance_voucher_no in order_refs:
+			advance_row_names.add(row.name)
+		else:
+			row_names.add(row.name)
 
 	from erpnext.accounts.doctype.payment_request.payment_request import (
 		update_payment_requests_as_per_pe_references,
@@ -1062,15 +1079,31 @@ def remove_ref_doc_link_from_pe(
 	update_payment_requests_as_per_pe_references(reference_rows, cancel=True)
 
 	# Update allocated amounts and modified fields in one go
-	(
-		qb.update(per)
-		.set(per.allocated_amount, 0)
-		.set(per.modified, now())
-		.set(per.modified_by, frappe.session.user)
-		.where(per.name.isin(row_names))
-		.where(per.parenttype == "Payment Entry")
-		.run()
-	)
+	if row_names:
+		(
+			qb.update(per)
+			.set(per.allocated_amount, 0)
+			.set(per.modified, now())
+			.set(per.modified_by, frappe.session.user)
+			.where(per.name.isin(row_names))
+			.where(per.parenttype == "Payment Entry")
+			.run()
+		)
+
+	# if order reference found retain the link
+	if advance_row_names and order_refs:
+		(
+			qb.update(per)
+			.set(per.reference_doctype, order_type)
+			.set(per.reference_name, order_refs[0])
+			.set(per.advance_voucher_type, None)
+			.set(per.advance_voucher_no, None)
+			.set(per.modified, now())
+			.set(per.modified_by, frappe.session.user)
+			.where(per.name.isin(advance_row_names))
+			.where(per.parenttype == "Payment Entry")
+			.run()
+		)
 
 	for pe in linked_pe:
 		try:


### PR DESCRIPTION
**Ref:** [43285](https://support.frappe.io/helpdesk/tickets/43285)

**Issue:**

- When an advance Payment Entry is allocated to a Sales or Purchase Invoice, unreconciling the invoice causes the Payment Entry to lose its original Sales Order or Purchase Order reference.

**Fix:**

- Ensure that on unreconciliation, the Payment Entry restores the original SO/PO reference, maintaining proper traceability between orders, invoices, and payments.

### Steps to Reproduce

1. **Create a Purchase or Sales Order**
2. **Create a Payment Entry against the Order**
3. **Create an Invoice from the Order**
4. **Cancel (Unreconcile) the Invoice**
6. **Observe the issue**
   * Before the fix, the PE would **lose the original PO/SO reference**.
   * After applying the fix, the PE `reference_doctype` and `reference_name` should be **restored back to the original PO/SO reference**, maintaining traceability.

**Before:**

https://github.com/user-attachments/assets/cfe67dac-a627-41c7-9be6-23e4208cdba2

**After:**

https://github.com/user-attachments/assets/004dd194-6e3b-48d6-8fa3-54f4bb669438


**Backport Needed V15**