### PR TITLE
fix(accounting): ensure proper removal of advance references during u…

### DIFF
--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -964,19 +964,28 @@ def update_accounting_ledgers_after_reference_removal(
 	adv_ple.run()
 
 
-def remove_ref_from_advance_section(ref_doc: object = None):
+def remove_ref_from_advance_section(ref_doc: object = None, payment_name: str | None = None):
 	# TODO: this might need some testing
 	if ref_doc.doctype in ("Sales Invoice", "Purchase Invoice"):
-		ref_doc.set("advances", [])
-		adv_type = qb.DocType(f"{ref_doc.doctype} Advance")
-		qb.from_(adv_type).delete().where(adv_type.parent == ref_doc.name).run()
+		row_names = []
+		for adv in ref_doc.get("advances") or []:
+			if adv.get("reference_name", None) == payment_name:
+				row_names.append(adv.name)
+
+		if not row_names:
+			return
+
+		child_table = (
+			"Sales Invoice Advance" if ref_doc.doctype == "Sales Invoice" else "Purchase Invoice Advance"
+		)
+		frappe.db.delete(child_table, {"name": ("in", row_names)})
 
 
 def unlink_ref_doc_from_payment_entries(ref_doc: object = None, payment_name: str | None = None):
 	remove_ref_doc_link_from_jv(ref_doc.doctype, ref_doc.name, payment_name)
 	remove_ref_doc_link_from_pe(ref_doc.doctype, ref_doc.name, payment_name)
 	update_accounting_ledgers_after_reference_removal(ref_doc.doctype, ref_doc.name, payment_name)
-	remove_ref_from_advance_section(ref_doc)
+	remove_ref_from_advance_section(ref_doc, payment_name)
 
 
 def remove_ref_doc_link_from_jv(
@@ -1043,7 +1052,6 @@ def remove_ref_doc_link_from_pe(
 		query = query.where(per.parent == payment_name)
 
 	reference_rows = query.run(as_dict=True)
-
 	if not reference_rows:
 		return
 


### PR DESCRIPTION
**closes** :  https://github.com/frappe/erpnext/issues/49458

**Problem:**

In the Payment Invoice => Advance Payment section, when unreconciling a payment entry, the entire advances table was being cleared. This caused loss of all advance records instead of just removing the unreconciled entry.

**Video:**

**Before Fix:**

[Screencast from 23-09-25 05:20:37 PM +0530.webm](https://github.com/user-attachments/assets/a2704c0d-4ac0-47e8-b90f-132c4d1177ed)

**After Fix:**

[Screencast from 23-09-25 05:23:11 PM +0530.webm](https://github.com/user-attachments/assets/bc8cfac0-81ce-4686-9820-630eff3bcaf1)



**Backport needed for v15**


