### PR TITLE
chore: update sales_data from site_info

### DIFF
--- a/erpnext/tests/test_activation.py
+++ b/erpnext/tests/test_activation.py
@@ -5,5 +5,6 @@ from erpnext.utilities.activation import get_level
 
 class TestActivation(IntegrationTestCase):
 	def test_activation(self):
-		levels = get_level()
+		site_info = {"activation": {"activation_level": 0, "sales_data": []}}
+		levels = get_level(site_info)
 		self.assertTrue(levels)

--- a/erpnext/utilities/__init__.py
+++ b/erpnext/utilities/__init__.py
@@ -37,7 +37,7 @@ def get_site_info(site_info):
 	if company:
 		domain = frappe.get_cached_value("Company", cstr(company), "domain")
 
-	return {"company": company, "domain": domain, "activation": get_level()}
+	return {"company": company, "domain": domain, "activation": get_level(site_info)}
 
 
 @contextmanager

--- a/erpnext/utilities/activation.py
+++ b/erpnext/utilities/activation.py
@@ -9,9 +9,9 @@ from frappe.core.doctype.installed_applications.installed_applications import ge
 import erpnext
 
 
-def get_level():
-	activation_level = 0
-	sales_data = []
+def get_level(site_info):
+	activation_level = site_info.get("activation", {}).get("activation_level", 0)
+	sales_data = site_info.get("activation", {}).get("sales_data", [])
 	min_count = 0
 	doctypes = {
 		"Asset": 5,


### PR DESCRIPTION
1. Apps like Learning, CRM, Helpdesk, etc, will now also track the count of doctypes for FC Site Analytics.
2. This change will ensure apps don't override each other's data.