### PR TITLE
fix: do not fetch disabled item tax template

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -2944,6 +2944,7 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 				valid_from: ["<=", doc.transaction_date || doc.bill_date || doc.posting_date],
 				item_group: item.item_group,
 				base_net_rate: item.base_net_rate,
+				disabled: 0,
 			};
 
 			if (doc.tax_category) filters["tax_category"] = doc.tax_category;

--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -740,8 +740,10 @@ def _get_item_tax_template(
 	taxes_with_no_validity = []
 
 	for tax in taxes:
-		tax_company = frappe.get_cached_value("Item Tax Template", tax.item_tax_template, "company")
-		if tax_company == ctx["company"]:
+		disabled, tax_company = frappe.get_cached_value(
+			"Item Tax Template", tax.item_tax_template, ["disabled", "company"]
+		)
+		if not disabled and tax_company == ctx["company"]:
 			if tax.valid_from or tax.maximum_net_rate:
 				# In purchase Invoice first preference will be given to supplier invoice date
 				# if supplier date is not present then posting date


### PR DESCRIPTION
Issue: User can use a disabled Item Tax Template in a transaction.


Frappe Support Issue: https://support.frappe.io/app/hd-ticket/49204