### PR TITLE
feat: add show zero value filter in profit and loss and balance sheet

### DIFF
--- a/erpnext/accounts/report/balance_sheet/balance_sheet.js
+++ b/erpnext/accounts/report/balance_sheet/balance_sheet.js
@@ -5,30 +5,35 @@ frappe.query_reports["Balance Sheet"] = $.extend({}, erpnext.financial_statement
 
 erpnext.utils.add_dimensions("Balance Sheet", 10);
 
-frappe.query_reports["Balance Sheet"]["filters"].push({
-	fieldname: "selected_view",
-	label: __("Select View"),
-	fieldtype: "Select",
-	options: [
-		{ value: "Report", label: __("Report View") },
-		{ value: "Growth", label: __("Growth View") },
-	],
-	default: "Report",
-	reqd: 1,
-});
-
-frappe.query_reports["Balance Sheet"]["filters"].push({
-	fieldname: "accumulated_values",
-	label: __("Accumulated Values"),
-	fieldtype: "Check",
-	default: 1,
-});
-
-frappe.query_reports["Balance Sheet"]["filters"].push({
-	fieldname: "include_default_book_entries",
-	label: __("Include Default FB Entries"),
-	fieldtype: "Check",
-	default: 1,
-});
+frappe.query_reports["Balance Sheet"]["filters"].push(
+	{
+		fieldname: "selected_view",
+		label: __("Select View"),
+		fieldtype: "Select",
+		options: [
+			{ value: "Report", label: __("Report View") },
+			{ value: "Growth", label: __("Growth View") },
+		],
+		default: "Report",
+		reqd: 1,
+	},
+	{
+		fieldname: "accumulated_values",
+		label: __("Accumulated Values"),
+		fieldtype: "Check",
+		default: 1,
+	},
+	{
+		fieldname: "include_default_book_entries",
+		label: __("Include Default FB Entries"),
+		fieldtype: "Check",
+		default: 1,
+	},
+	{
+		fieldname: "show_zero_values",
+		label: __("Show zero values"),
+		fieldtype: "Check",
+	}
+);
 
 frappe.query_reports["Balance Sheet"]["export_hidden_cols"] = true;

--- a/erpnext/accounts/report/financial_statements.py
+++ b/erpnext/accounts/report/financial_statements.py
@@ -212,7 +212,7 @@ def get_data(
 		company_currency,
 		accumulated_values=filters.accumulated_values,
 	)
-	out = filter_out_zero_value_rows(out, parent_children_map)
+	out = filter_out_zero_value_rows(out, parent_children_map, filters.show_zero_values)
 
 	if out and total:
 		add_total_row(out, root_type, balance_must_be, period_list, company_currency)

--- a/erpnext/accounts/report/profit_and_loss_statement/profit_and_loss_statement.js
+++ b/erpnext/accounts/report/profit_and_loss_statement/profit_and_loss_statement.js
@@ -5,31 +5,36 @@ frappe.query_reports["Profit and Loss Statement"] = $.extend({}, erpnext.financi
 
 erpnext.utils.add_dimensions("Profit and Loss Statement", 10);
 
-frappe.query_reports["Profit and Loss Statement"]["filters"].push({
-	fieldname: "selected_view",
-	label: __("Select View"),
-	fieldtype: "Select",
-	options: [
-		{ value: "Report", label: __("Report View") },
-		{ value: "Growth", label: __("Growth View") },
-		{ value: "Margin", label: __("Margin View") },
-	],
-	default: "Report",
-	reqd: 1,
-});
-
-frappe.query_reports["Profit and Loss Statement"]["filters"].push({
-	fieldname: "accumulated_values",
-	label: __("Accumulated Values"),
-	fieldtype: "Check",
-	default: 1,
-});
-
-frappe.query_reports["Profit and Loss Statement"]["filters"].push({
-	fieldname: "include_default_book_entries",
-	label: __("Include Default FB Entries"),
-	fieldtype: "Check",
-	default: 1,
-});
+frappe.query_reports["Profit and Loss Statement"]["filters"].push(
+	{
+		fieldname: "selected_view",
+		label: __("Select View"),
+		fieldtype: "Select",
+		options: [
+			{ value: "Report", label: __("Report View") },
+			{ value: "Growth", label: __("Growth View") },
+			{ value: "Margin", label: __("Margin View") },
+		],
+		default: "Report",
+		reqd: 1,
+	},
+	{
+		fieldname: "accumulated_values",
+		label: __("Accumulated Values"),
+		fieldtype: "Check",
+		default: 1,
+	},
+	{
+		fieldname: "include_default_book_entries",
+		label: __("Include Default FB Entries"),
+		fieldtype: "Check",
+		default: 1,
+	},
+	{
+		fieldname: "show_zero_values",
+		label: __("Show zero values"),
+		fieldtype: "Check",
+	}
+);
 
 frappe.query_reports["Profit and Loss Statement"]["export_hidden_cols"] = true;


### PR DESCRIPTION
Issue: added show zero value filter in profit and loss and balance sheet


Ref: [#49341](https://support.frappe.io/helpdesk/tickets/49341)

Balance Sheet:


https://github.com/user-attachments/assets/125f799e-edfd-460d-b1a0-8293d891b876


Profit and Loss:


https://github.com/user-attachments/assets/7f88fdfc-38ed-4988-b4e9-696027781897


Backport needed: v15

no-docs