### PR TITLE
fix: set cost center in taxes if not set

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -2488,14 +2488,20 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 				},
 				callback: function (r) {
 					if (!r.exc) {
+						let taxes = r.message;
+						taxes.forEach((tax) => {
+							if (me.frm.doc?.cost_center && !tax.cost_center) {
+								tax.cost_center = me.frm.doc.cost_center;
+							}
+						});
 						if (me.frm.doc.shipping_rule && me.frm.doc.taxes) {
-							for (let tax of r.message) {
+							for (let tax of taxes) {
 								me.frm.add_child("taxes", tax);
 							}
 
 							refresh_field("taxes");
 						} else {
-							me.frm.set_value("taxes", r.message);
+							me.frm.set_value("taxes", taxes);
 							me.calculate_taxes_and_totals();
 						}
 					}


### PR DESCRIPTION
Issue: If the Sales Taxes and Charges Template has no cost center, and the company’s Default Cost Center is also not set, the record’s cost center does not get copied to the taxes when the template is used.



Ref: [#49302](https://support.frappe.io/helpdesk/tickets/49302)



Backport needed: v15