### PR TITLE
feat: add company links to Email Account and Communication

### DIFF
--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -261,6 +261,7 @@ execute:frappe.rename_doc("Report", "TDS Payable Monthly", "Tax Withholding Deta
 erpnext.patches.v14_0.update_proprietorship_to_individual
 erpnext.patches.v15_0.rename_subcontracting_fields
 erpnext.patches.v15_0.unset_incorrect_additional_discount_percentage
+erpnext.patches.v16_0.create_company_custom_fields
 
 [post_model_sync]
 erpnext.patches.v15_0.create_asset_depreciation_schedules_from_assets

--- a/erpnext/patches/v16_0/create_company_custom_fields.py
+++ b/erpnext/patches/v16_0/create_company_custom_fields.py
@@ -1,5 +1,4 @@
-from erpnext.setup.install import create_company_custom_fields
-
-
 def execute():
+	from erpnext.setup.install import create_company_custom_fields
+
 	create_company_custom_fields()

--- a/erpnext/patches/v16_0/create_company_custom_fields.py
+++ b/erpnext/patches/v16_0/create_company_custom_fields.py
@@ -2,4 +2,5 @@ from erpnext.setup.install import create_custom_company_links
 
 
 def execute():
+	"""Add link fields to Company in Email Account and Communication."""
 	create_custom_company_links()

--- a/erpnext/patches/v16_0/create_company_custom_fields.py
+++ b/erpnext/patches/v16_0/create_company_custom_fields.py
@@ -1,4 +1,5 @@
-def execute():
-	from erpnext.setup.install import create_company_custom_fields
+from erpnext.setup.install import create_custom_company_links
 
-	create_company_custom_fields()
+
+def execute():
+	create_custom_company_links()

--- a/erpnext/patches/v16_0/create_company_custom_fields.py
+++ b/erpnext/patches/v16_0/create_company_custom_fields.py
@@ -1,0 +1,5 @@
+from erpnext.setup.install import create_company_custom_fields
+
+
+def execute():
+	create_company_custom_fields()

--- a/erpnext/setup/install.py
+++ b/erpnext/setup/install.py
@@ -141,6 +141,12 @@ def create_default_success_action():
 
 
 def create_custom_company_links():
+	"""Add link fields to Company in Email Account and Communication.
+
+	These DocTypes are provided by the Frappe Framework but need to be associated
+	with a company in ERPNext to allow for multitenancy. I.e. one company should
+	not be able to access emails and communications from another company.
+	"""
 	create_custom_fields(
 		{
 			"Email Account": [

--- a/erpnext/setup/install.py
+++ b/erpnext/setup/install.py
@@ -160,6 +160,7 @@ def create_company_custom_fields():
 					"options": "Company",
 					"insert_after": "email_account",
 					"fetch_from": "email_account.company",
+					"read_only": 1,
 				},
 			],
 		},

--- a/erpnext/setup/install.py
+++ b/erpnext/setup/install.py
@@ -23,6 +23,7 @@ def after_install():
 	set_single_defaults()
 	create_print_setting_custom_fields()
 	create_marketgin_campagin_custom_fields()
+	create_company_custom_fields()
 	add_all_roles_to("Administrator")
 	create_default_success_action()
 	create_incoterms()
@@ -137,6 +138,32 @@ def create_default_success_action():
 		if not frappe.db.exists("Success Action", success_action.get("ref_doctype")):
 			doc = frappe.get_doc(success_action)
 			doc.insert(ignore_permissions=True)
+
+
+def create_company_custom_fields():
+	create_custom_fields(
+		{
+			"Email Account": [
+				{
+					"label": _("Company"),
+					"fieldname": "company",
+					"fieldtype": "Link",
+					"options": "Company",
+					"insert_after": "email_id",
+				},
+			],
+			"Communication": [
+				{
+					"label": _("Company"),
+					"fieldname": "company",
+					"fieldtype": "Link",
+					"options": "Company",
+					"insert_after": "email_account",
+					"fetch_from": "email_account.company",
+				},
+			],
+		},
+	)
 
 
 def add_company_to_session_defaults():

--- a/erpnext/setup/install.py
+++ b/erpnext/setup/install.py
@@ -23,7 +23,7 @@ def after_install():
 	set_single_defaults()
 	create_print_setting_custom_fields()
 	create_marketgin_campagin_custom_fields()
-	create_company_custom_fields()
+	create_custom_company_links()
 	add_all_roles_to("Administrator")
 	create_default_success_action()
 	create_incoterms()
@@ -140,7 +140,7 @@ def create_default_success_action():
 			doc.insert(ignore_permissions=True)
 
 
-def create_company_custom_fields():
+def create_custom_company_links():
 	create_custom_fields(
 		{
 			"Email Account": [

--- a/erpnext/support/doctype/issue/issue.json
+++ b/erpnext/support/doctype/issue/issue.json
@@ -233,6 +233,8 @@
    "options": "Project"
   },
   {
+   "fetch_from": "email_account.company",
+   "fetch_if_empty": 1,
    "fieldname": "company",
    "fieldtype": "Link",
    "label": "Company",
@@ -391,7 +393,7 @@
  "icon": "fa fa-ticket",
  "idx": 7,
  "links": [],
- "modified": "2025-02-18 21:18:52.797745",
+ "modified": "2025-09-25 11:10:53.556731",
  "modified_by": "Administrator",
  "module": "Support",
  "name": "Issue",
@@ -411,6 +413,8 @@
   }
  ],
  "quick_entry": 1,
+ "recipient_account_field": "email_account",
+ "row_format": "Dynamic",
  "search_fields": "status,customer,subject,raised_by",
  "sender_field": "raised_by",
  "sort_field": "creation",

--- a/erpnext/support/doctype/issue/issue.json
+++ b/erpnext/support/doctype/issue/issue.json
@@ -413,8 +413,6 @@
   }
  ],
  "quick_entry": 1,
- "recipient_account_field": "email_account",
- "row_format": "Dynamic",
  "search_fields": "status,customer,subject,raised_by",
  "sender_field": "raised_by",
  "sort_field": "creation",


### PR DESCRIPTION
Resolves https://github.com/frappe/erpnext/issues/49713

- Adds _company_ fields to the **Email Account** and **Communication**
- Adds a `fetch_from` property to _company_ in **Issue** and **Communication**
- In **Issue** the `fetch_if_empty` property is also set for backwards compatibility

Intended effects:
In multi company setup Email Accounts can be assigned to a Company, allowing access restriction for Issues, Communication and Attachments from incoming Emails

Tested locally:
- [x] New fields and fetch_from works on existing Site
- [x] New fields and fetch_from is added on new Site

Ref: ABI-25

> no-docs