### PR TITLE
fix: remove item name in get_item_details

### DIFF
--- a/erpnext/stock/doctype/pick_list/pick_list.py
+++ b/erpnext/stock/doctype/pick_list/pick_list.py
@@ -1438,7 +1438,7 @@ def get_pending_work_orders(doctype, txt, searchfield, start, page_length, filte
 
 @frappe.whitelist()
 def get_item_details(item_code, uom=None, warehouse=None, company=None):
-	details = frappe.db.get_value("Item", item_code, ["stock_uom", "name"], as_dict=1)
+	details = frappe.db.get_value("Item", item_code, "stock_uom", as_dict=1)
 	details.uom = uom or details.stock_uom
 	if uom:
 		details.update(get_conversion_factor(item_code, uom))


### PR DESCRIPTION
**Issue:** Pick List Location name was incorrectly updated as the Item Code.

This is a regression from #49684, where `get_item_details` returned `item_name` as name, and this was unknowingly used in the fix.

**Before:**
<img width="1541" height="609" alt="image" src="https://github.com/user-attachments/assets/a3e78d9e-7a6c-4d35-9be0-0510edd2077c" />

**After:**
<img width="1541" height="609" alt="image" src="https://github.com/user-attachments/assets/7ab75c1e-1f38-49e8-b3a3-3a0bef1f54a6" />

**Backport Needed: v15**
