### PR TITLE
fix(payment entry): trigger currency on account set

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.js
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.js
@@ -585,6 +585,7 @@ frappe.ui.form.on("Payment Entry", {
 				if (frm.doc.payment_type == "Pay") {
 					frm.events.paid_amount(frm);
 				}
+				frm.events.paid_from_account_currency(frm);
 			}
 		);
 	},
@@ -607,6 +608,7 @@ frappe.ui.form.on("Payment Entry", {
 						frm.events.received_amount(frm);
 					}
 				}
+				frm.events.paid_to_account_currency(frm);
 			}
 		);
 	},


### PR DESCRIPTION
Issue: In internal transfer Payment Entry, when there is no session default and the global default company is used, and the account currency is the same as the default currency, the exchange rate logic is not set.

Ref: [#49318](https://support.frappe.io/helpdesk/tickets/49318)

**Steps to Reproduce:**

1. Create a new Payment Entry for Internal Transfer.
2. Ensure there is no session default company and global default company set.
3. Select account where the account currency = default currency.
4. Try saving it.

**Payment Entry:**

<img width="1792" height="1120" alt="Screenshot 2025-09-25 at 11 32 53 PM" src="https://github.com/user-attachments/assets/76918361-5f09-4042-833e-bfccfe37b910" />


Backport needed: v15