### PR TITLE
fix(stock entry): set expense account from company for manufacture

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -2262,6 +2262,9 @@ class StockEntry(StockController):
 			# in case of BOM
 			to_warehouse = item.get("default_warehouse")
 
+		expense_account = item.get("expense_account")
+		if self.purpose == "Manufacture" or not expense_account:
+			expense_account = frappe.get_cached_value("Company", self.company, "stock_adjustment_account")
 		args = {
 			"to_warehouse": to_warehouse,
 			"from_warehouse": "",
@@ -2269,7 +2272,7 @@ class StockEntry(StockController):
 			"item_name": item.item_name,
 			"description": item.description,
 			"stock_uom": item.stock_uom,
-			"expense_account": item.get("expense_account"),
+			"expense_account": expense_account,
 			"cost_center": item.get("buying_cost_center"),
 			"is_finished_item": 1,
 		}

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -2263,7 +2263,7 @@ class StockEntry(StockController):
 			to_warehouse = item.get("default_warehouse")
 
 		expense_account = item.get("expense_account")
-		if self.purpose == "Manufacture" or not expense_account:
+		if not expense_account:
 			expense_account = frappe.get_cached_value("Company", self.company, "stock_adjustment_account")
 		args = {
 			"to_warehouse": to_warehouse,


### PR DESCRIPTION
Issue: When making a manufacturing entry, it fetches the default expense account from the Item defaults  as a different account

Ref: [#48292](https://support.frappe.io/helpdesk/tickets/48292)

Before:

<img width="1792" height="1120" alt="Screenshot 2025-09-26 at 12 30 14 PM" src="https://github.com/user-attachments/assets/54e31a39-2143-41c4-a48d-5eadf854b0ba" />

After

<img width="1792" height="1120" alt="Screenshot 2025-09-26 at 12 29 30 PM" src="https://github.com/user-attachments/assets/68841572-8124-4c2f-afb7-d6ca22a72d62" />




Backport needed: v15