### PR TITLE
fix: use valuation_rate from item master if no bin is present

### DIFF
--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -1564,7 +1564,7 @@ def get_valuation_rate(item_code, company, warehouse=None):
 
 		return frappe.db.get_value(
 			"Bin", {"item_code": item_code, "warehouse": warehouse}, ["valuation_rate"], as_dict=True
-		) or {"valuation_rate": 0}
+		) or {"valuation_rate": item.get("valuation_rate") or 0}
 
 	elif not item.get("is_stock_item"):
 		pi_item = frappe.qb.DocType("Purchase Invoice Item")


### PR DESCRIPTION
Issue: The Valuation rate is not set in the Quotation for newly created items, even when the item master has a valuation rate.

Explanation: If a new item is created with a valuation rate of 1000, no Bin record is generated for it. When creating a Quotation for that item, the valuation rate is shown as 0 because there is no Bin entry.

Ref: [#49320](https://support.frappe.io/helpdesk/tickets/49320)

Before:

<img width="1792" height="1120" alt="Screenshot 2025-09-26 at 1 43 53 PM" src="https://github.com/user-attachments/assets/397a5bb4-f29f-411f-ac46-da46ecca1eb8" />


After:

<img width="1792" height="1120" alt="Screenshot 2025-09-26 at 1 38 20 PM" src="https://github.com/user-attachments/assets/a7fd222f-3723-4f1e-be1b-842fadf47ab0" />





Backport needed: v15