### PR TITLE
fix: use sales_order from data instead of doc

### DIFF
--- a/erpnext/manufacturing/doctype/production_plan/production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.py
@@ -1714,7 +1714,7 @@ def get_items_for_material_requests(doc, warehouses=None, get_parent_warehouse_d
 				}
 			)
 
-		sales_order = doc.get("sales_order")
+		sales_order = data.get("sales_order")
 
 		for item_code, details in item_details.items():
 			so_item_details.setdefault(sales_order, frappe._dict())


### PR DESCRIPTION
**Issue:**  When fetching Raw Materials Sales Order is not referenced as per the FG Item.

**Ref:** [49394](https://support.frappe.io/helpdesk/tickets/49394?view=VIEW-HD+Ticket-646)

**Before:**

[Screencast from 28-09-25 10:50:57 PM IST.webm](https://github.com/user-attachments/assets/f2c99c48-5be1-4dbc-b9ce-26d41e0d0a00)

**After:**

[Screencast from 28-09-25 10:51:34 PM IST.webm](https://github.com/user-attachments/assets/fb7683a6-5f52-47e4-bd63-17fa0acc4e82)

**Backport Needed: v15** 