### PR TITLE
fix(bank transaction): change reference number to small text

### DIFF
--- a/erpnext/accounts/doctype/bank_transaction/bank_transaction.json
+++ b/erpnext/accounts/doctype/bank_transaction/bank_transaction.json
@@ -116,7 +116,7 @@
   {
    "allow_on_submit": 1,
    "fieldname": "reference_number",
-   "fieldtype": "Data",
+   "fieldtype": "Small Text",
    "label": "Reference Number"
   },
   {
@@ -239,7 +239,7 @@
  "grid_page_length": 50,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-08-29 11:53:45.908169",
+ "modified": "2025-09-26 17:06:29.207673",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Bank Transaction",

--- a/erpnext/accounts/doctype/bank_transaction/bank_transaction.py
+++ b/erpnext/accounts/doctype/bank_transaction/bank_transaction.py
@@ -36,7 +36,7 @@ class BankTransaction(Document):
 		party: DF.DynamicLink | None
 		party_type: DF.Link | None
 		payment_entries: DF.Table[BankTransactionPayments]
-		reference_number: DF.Data | None
+		reference_number: DF.SmallText | None
 		status: DF.Literal["", "Pending", "Settled", "Unreconciled", "Reconciled", "Cancelled"]
 		transaction_id: DF.Data | None
 		transaction_type: DF.Data | None


### PR DESCRIPTION
**Issue:** If the bank transaction doesn’t have a `check_number` or `reference_number`, the system sets the description as the `reference_number`. According to the MT940 standard, the description can be up to 390 characters, but the `reference_number` fieldtype is set to Data, which only allows 140 characters.

**Solution:** Change the `reference_number` fieldtype from Data to Small Text.