### PR TITLE
fix(journal-entry): update party type for equity account

### DIFF
--- a/erpnext/accounts/doctype/journal_entry/journal_entry.py
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.py
@@ -1705,6 +1705,8 @@ def get_account_details_and_party_type(account, date, company, debit=None, credi
 		party_type = "Customer"
 	elif account_details.account_type == "Payable":
 		party_type = "Supplier"
+	elif account_details.account_type == "Equity":
+		party_type = "Shareholder"
 	else:
 		party_type = ""
 


### PR DESCRIPTION


Issue: The Party type in Journal account is not filtered  for Equity Account

Before:


[Screencast from 29-09-25 01:56:45 PM IST.webm](https://github.com/user-attachments/assets/36bb685d-5f20-4be8-9c28-8796baee8a3d)


After:


[Screencast from 29-09-25 01:58:17 PM IST.webm](https://github.com/user-attachments/assets/668b2612-e753-45fc-b469-6f7941c7f0b0)



**Backport needed: v15**