### PR TITLE
fix: update subcontracted_quantity with set_value

### DIFF
--- a/erpnext/subcontracting/doctype/subcontracting_order/subcontracting_order.py
+++ b/erpnext/subcontracting/doctype/subcontracting_order/subcontracting_order.py
@@ -257,13 +257,13 @@ class SubcontractingOrder(SubcontractingController):
 					si.purchase_order_item,
 					["qty", "subcontracted_quantity", "fg_item_qty"],
 				)
-				available_qty = qty - subcontracted_quantity
+				available_qty = flt(qty) - flt(subcontracted_quantity)
 
 				if available_qty == 0:
 					continue
 
 				si.qty = available_qty
-				conversion_factor = qty / fg_item_qty
+				conversion_factor = flt(qty) / flt(fg_item_qty)
 				si.fg_item_qty = flt(
 					available_qty / conversion_factor, frappe.get_precision("Purchase Order Item", "qty")
 				)
@@ -342,8 +342,10 @@ class SubcontractingOrder(SubcontractingController):
 
 	def update_subcontracted_quantity_in_po(self, cancel=False):
 		for service_item in self.service_items:
-			subcontracted_quantity = frappe.db.get_value(
-				"Purchase Order Item", service_item.purchase_order_item, "subcontracted_quantity"
+			subcontracted_quantity = flt(
+				frappe.db.get_value(
+					"Purchase Order Item", service_item.purchase_order_item, "subcontracted_quantity"
+				)
 			)
 
 			subcontracted_quantity = (

--- a/erpnext/subcontracting/doctype/subcontracting_order/subcontracting_order.py
+++ b/erpnext/subcontracting/doctype/subcontracting_order/subcontracting_order.py
@@ -252,14 +252,18 @@ class SubcontractingOrder(SubcontractingController):
 			if si.fg_item:
 				item = frappe.get_doc("Item", si.fg_item)
 
-				po_item = frappe.get_doc("Purchase Order Item", si.purchase_order_item)
-				available_qty = po_item.qty - po_item.subcontracted_quantity
+				qty, subcontracted_quantity, fg_item_qty = frappe.db.get_value(
+					"Purchase Order Item",
+					si.purchase_order_item,
+					["qty", "subcontracted_quantity", "fg_item_qty"],
+				)
+				available_qty = qty - subcontracted_quantity
 
 				if available_qty == 0:
 					continue
 
 				si.qty = available_qty
-				conversion_factor = po_item.qty / po_item.fg_item_qty
+				conversion_factor = qty / fg_item_qty
 				si.fg_item_qty = flt(
 					available_qty / conversion_factor, frappe.get_precision("Purchase Order Item", "qty")
 				)

--- a/erpnext/subcontracting/doctype/subcontracting_order/subcontracting_order.py
+++ b/erpnext/subcontracting/doctype/subcontracting_order/subcontracting_order.py
@@ -338,13 +338,22 @@ class SubcontractingOrder(SubcontractingController):
 
 	def update_subcontracted_quantity_in_po(self, cancel=False):
 		for service_item in self.service_items:
-			doc = frappe.get_doc("Purchase Order Item", service_item.purchase_order_item)
-			doc.subcontracted_quantity = (
-				(doc.subcontracted_quantity + service_item.qty)
-				if not cancel
-				else (doc.subcontracted_quantity - service_item.qty)
+			subcontracted_quantity = frappe.db.get_value(
+				"Purchase Order Item", service_item.purchase_order_item, "subcontracted_quantity"
 			)
-			doc.save()
+
+			subcontracted_quantity = (
+				(subcontracted_quantity + service_item.qty)
+				if not cancel
+				else (subcontracted_quantity - service_item.qty)
+			)
+
+			frappe.db.set_value(
+				"Purchase Order Item",
+				service_item.purchase_order_item,
+				"subcontracted_quantity",
+				subcontracted_quantity,
+			)
 
 
 @frappe.whitelist()


### PR DESCRIPTION
**Issue:** When the user didn't have permission to submit the Purchase Order, they got a permission error while submitting the Subcontracting Order, as it was updating the subcontracted_quantity in the Purchase Order Item.

**ref:** [48131](https://support.frappe.io/helpdesk/tickets/48131)

**Before:**

https://github.com/user-attachments/assets/4fde8718-1518-45c6-9b22-b0bb35c23c02

**After:**

https://github.com/user-attachments/assets/61c5c05d-1f36-4c4c-8485-5d91e3d0cfc3

**Backport needed for V15**