### PR TITLE
refactor: convert item warehouse based reposting

### DIFF
--- a/erpnext/stock/doctype/stock_reposting_settings/stock_reposting_settings.py
+++ b/erpnext/stock/doctype/stock_reposting_settings/stock_reposting_settings.py
@@ -84,7 +84,7 @@ def get_reposting_entries():
 def get_stock_ledgers(vouchers):
 	return frappe.get_all(
 		"Stock Ledger Entry",
-		fields=["item_code", "warehouse", "posting_date"],
+		fields=["item_code", "warehouse", "posting_date", "posting_time", "posting_datetime"],
 		filters={"voucher_no": ("in", vouchers)},
 	)
 


### PR DESCRIPTION
Previously reposting entries were creating based on Transaction from Stock and Account value comparison report that has changed to Item warehouse based reposting which is faster than Transaction based reposting