### PR TITLE
fix: don't recalculate stock_qty with conversion_factor

### DIFF
--- a/erpnext/controllers/sales_and_purchase_return.py
+++ b/erpnext/controllers/sales_and_purchase_return.py
@@ -202,7 +202,11 @@ def validate_quantity(doc, key, args, ref, valid_items, already_returned_items):
 			current_stock_qty = args.get(column)
 		elif args.get("return_qty_from_rejected_warehouse"):
 			reference_qty = ref.get("rejected_qty") * ref.get("conversion_factor", 1.0)
-			current_stock_qty = args.get(column) * args.get("conversion_factor", 1.0)
+			current_stock_qty = (
+				args.get(column) * args.get("conversion_factor", 1.0)
+				if column != "stock_qty"
+				else args.get(column)
+			)
 		else:
 			reference_qty = ref.get(column) * ref.get("conversion_factor", 1.0)
 			current_stock_qty = args.get(column) * args.get("conversion_factor", 1.0)


### PR DESCRIPTION
**Issue:** Unable to return purchase receipt qty from rejected warehouse with conversion factor value.

**Ref:** [49604](https://support.frappe.io/helpdesk/tickets/49604?view=VIEW-HD+Ticket-646)

**Before:**

[Screencast from 29-09-25 10:20:23 PM IST.webm](https://github.com/user-attachments/assets/2b9bc5a6-841d-411d-9033-a41c2e21505b)

**After:**

[Screencast from 29-09-25 10:21:54 PM IST.webm](https://github.com/user-attachments/assets/4406df73-7581-4215-87cf-1e2945805a34)

**Backport Needed: v15**