### PR TITLE
feat: validating asset scrap date (backport #43093)

### DIFF
--- a/erpnext/assets/doctype/asset/asset.js
+++ b/erpnext/assets/doctype/asset/asset.js
@@ -790,17 +790,41 @@ frappe.ui.form.on("Asset Finance Book", {
 });
 
 erpnext.asset.scrap_asset = function (frm) {
-	frappe.confirm(__("Do you really want to scrap this asset?"), function () {
-		frappe.call({
-			args: {
-				asset_name: frm.doc.name,
+	var scrap_dialog = new frappe.ui.Dialog({
+		title: __("Enter date to scrap asset"),
+		fields: [
+			{
+				label: __("Select the date"),
+				fieldname: "scrap_date",
+				fieldtype: "Date",
+				reqd: 1,
 			},
+<<<<<<< HEAD
 			method: "erpnext.assets.doctype.asset.depreciation.scrap_asset",
 			callback: function (r) {
 				cur_frm.reload_doc();
 			},
 		});
+=======
+		],
+		size: "medium",
+		primary_action_label: "Submit",
+		primary_action(values) {
+			frappe.call({
+				args: {
+					asset_name: frm.doc.name,
+					scrap_date: values.scrap_date,
+				},
+				method: "erpnext.assets.doctype.asset.depreciation.scrap_asset",
+				callback: function (r) {
+					frm.reload_doc();
+					scrap_dialog.hide();
+				},
+			});
+		},
+>>>>>>> e07bc5af41 (feat: validating asset scrap date (#43093))
 	});
+	scrap_dialog.show();
 };
 
 erpnext.asset.restore_asset = function (frm) {

--- a/erpnext/assets/doctype/asset/asset.js
+++ b/erpnext/assets/doctype/asset/asset.js
@@ -799,13 +799,6 @@ erpnext.asset.scrap_asset = function (frm) {
 				fieldtype: "Date",
 				reqd: 1,
 			},
-<<<<<<< HEAD
-			method: "erpnext.assets.doctype.asset.depreciation.scrap_asset",
-			callback: function (r) {
-				cur_frm.reload_doc();
-			},
-		});
-=======
 		],
 		size: "medium",
 		primary_action_label: "Submit",
@@ -822,7 +815,6 @@ erpnext.asset.scrap_asset = function (frm) {
 				},
 			});
 		},
->>>>>>> e07bc5af41 (feat: validating asset scrap date (#43093))
 	});
 	scrap_dialog.show();
 };

--- a/erpnext/assets/doctype/asset/depreciation.py
+++ b/erpnext/assets/doctype/asset/depreciation.py
@@ -394,7 +394,7 @@ def get_comma_separated_links(names, doctype):
 
 
 @frappe.whitelist()
-def scrap_asset(asset_name):
+def scrap_asset(asset_name, scrap_date=None):
 	asset = frappe.get_doc("Asset", asset_name)
 
 	if asset.docstatus != 1:
@@ -402,7 +402,11 @@ def scrap_asset(asset_name):
 	elif asset.status in ("Cancelled", "Sold", "Scrapped", "Capitalized"):
 		frappe.throw(_("Asset {0} cannot be scrapped, as it is already {1}").format(asset.name, asset.status))
 
-	date = today()
+	today_date = getdate(today())
+	date = getdate(scrap_date) or today_date
+	purchase_date = getdate(asset.purchase_date)
+
+	validate_scrap_date(date, today_date, purchase_date, asset.calculate_depreciation, asset_name)
 
 	notes = _("This schedule was created when Asset {0} was scrapped.").format(
 		get_link_to_form(asset.doctype, asset.name)
@@ -434,6 +438,36 @@ def scrap_asset(asset_name):
 	add_asset_activity(asset_name, _("Asset scrapped"))
 
 	frappe.msgprint(_("Asset scrapped via Journal Entry {0}").format(je.name))
+
+
+def validate_scrap_date(scrap_date, today_date, purchase_date, calculate_depreciation, asset_name):
+	if scrap_date > today_date:
+		frappe.throw(_("Future date is not allowed"))
+	elif scrap_date < purchase_date:
+		frappe.throw(_("Scrap date cannot be before purchase date"))
+
+	if calculate_depreciation:
+		asset_depreciation_schedules = frappe.db.get_all(
+			"Asset Depreciation Schedule", filters={"asset": asset_name, "docstatus": 1}, fields=["name"]
+		)
+
+		for depreciation_schedule in asset_depreciation_schedules:
+			last_booked_depreciation_date = frappe.db.get_value(
+				"Depreciation Schedule",
+				{
+					"parent": depreciation_schedule["name"],
+					"docstatus": 1,
+					"journal_entry": ["!=", ""],
+				},
+				"schedule_date",
+				order_by="schedule_date desc",
+			)
+			if (
+				last_booked_depreciation_date
+				and scrap_date < last_booked_depreciation_date
+				and scrap_date > purchase_date
+			):
+				frappe.throw(_("Asset cannot be scrapped before the last depreciation entry."))
 
 
 @frappe.whitelist()


### PR DESCRIPTION
## Background/Context

1. When we select Asset Scrapping, the system by default takes the current date and scraps the asset as on the date
2. In case the company wants to scrap their asset with backdated effect, then that cannot be achieved in the present system as there is no option to select the scrap date anywhere.
3. Also, there is no restriction on scrapping the asset even if depreciation entries are posted

## Solution Summary

1. If a user wants to scrap an asset, then the system will ask for a scrapping date (as shown in the below screenshot).
2. According to the date entered by the user, the asset will be scrapped on that date with back dated effect.
4. The scrapping date cannot be before the purchase date or it cannot be after the current date. Also, If the depreciation entries are passed, asset can only be scrap after the last depreciation date and not before it. In such cases depreciation entry needs to be manually cancelled first and then scrapping can be possible.


![image](https://github.com/user-attachments/assets/dbcbf069-1eba-4082-86f8-b40ed0a5bcfd)

#no-docs<hr>This is an automatic backport of pull request #43093 done by [Mergify](https://mergify.com).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added Advance Payment Ledger Entry.
  - New verified Charts of Accounts: Australia, Switzerland, Turkey; significant updates to Brazil, Canada (FR), Germany, France, India; added Hungary metadata.
  - Account form/tree improvements: editable account number/company, new account types/options; public chart fetch.

- Improvements
  - Bank Reconciliation: multi-currency, smarter matching/allocation/status; Bank Clearance supports POS payments; enhanced clearance updates.
  - Bank Statement Import: server-side logs, export, and custom delimiters.
  - Accounts Settings: immutable ledger toggle, new tax options, auto-reconcile scheduling/validation; action to drop AR procedures.

- Documentation
  - Updated Frappe School link in README.

- CI/Chores
  - Release workflow updates, new skip-release-notes label, and cache upgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->