### PR TITLE
feat: allow custom script to ignore Authorization rule for items

### DIFF
--- a/erpnext/setup/doctype/authorization_control/authorization_control.py
+++ b/erpnext/setup/doctype/authorization_control/authorization_control.py
@@ -136,12 +136,18 @@ class AuthorizationControl(TransactionBase):
 		if based_on == "Itemwise Discount":
 			if doc_obj:
 				for t in doc_obj.get("items"):
+					if t.name in (frappe.flags.ignore_auth_rule_for_item or []):
+						continue
+
 					self.validate_auth_rule(
 						doctype_name, t.discount_percentage, based_on, add_cond, company, t.item_code
 					)
 		elif based_on == "Item Group wise Discount":
 			if doc_obj:
 				for t in doc_obj.get("items"):
+					if t.name in (frappe.flags.ignore_auth_rule_for_item or []):
+						continue
+
 					self.validate_auth_rule(
 						doctype_name, t.discount_percentage, based_on, add_cond, company, t.item_group
 					)
@@ -156,6 +162,9 @@ class AuthorizationControl(TransactionBase):
 		if doc_obj:
 			price_list_rate, base_rate = 0, 0
 			for d in doc_obj.get("items"):
+				if d.name in (frappe.flags.ignore_auth_rule_for_item or []):
+					continue
+
 				if d.base_rate:
 					price_list_rate += (flt(d.base_price_list_rate) or flt(d.base_rate)) * flt(d.qty)
 					base_rate += flt(d.base_rate) * flt(d.qty)


### PR DESCRIPTION
Objective: Ignore the Authorization Rule validation for specific items.

Created a flag that will be an Array:
frappe.flags.ignore_auth_rule_for_item

This flag will be filled in a server script or custom app.

Cases where it can be used:

Currently, we can have an Authorization Rule for the Sales Order and Sales Invoice, but if I approve it on the Order, I will have to approve it again on the invoice...
In this case, a custom script can be created to validate the items that did not have a change in the discount that had already been approved on the order and bypass it, without the need to approve it again, but if there is an item that had a change, it would request approval.

The Custom App may have a structure that wants to skip this authorization.
Example:

We currently have an app for clinics. When a patient has a Benefits Plan, such as a health plan, the system applies the benefit plan discount and does not allow the application/change of the discount related to the item. In this case, validation of the authorization rule is not necessary.

There are several other cases where this bypass can occur and be applied.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added the ability to exclude selected items from authorization rule checks and related rate calculations. These items are skipped during discount validation and approving authority evaluation, providing more control over approval workflows and ensuring non-applicable items do not trigger unnecessary validations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->