### PR TITLE
fix: financial ratios translation and pdf export error

### DIFF
--- a/erpnext/accounts/report/financial_ratios/financial_ratios.js
+++ b/erpnext/accounts/report/financial_ratios/financial_ratios.js
@@ -52,7 +52,7 @@ frappe.query_reports["Financial Ratios"] = {
 		},
 	],
 	formatter: function (value, row, column, data, default_formatter) {
-		let heading_ratios = ["Liquidity Ratios", "Solvency Ratios", "Turnover Ratios"];
+		let heading_ratios = [__("Liquidity Ratios"), __("Solvency Ratios"), __("Turnover Ratios")];
 
 		if (heading_ratios.includes(value)) {
 			value = $(`<span>${value}</span>`);
@@ -60,7 +60,7 @@ frappe.query_reports["Financial Ratios"] = {
 			value = $value.wrap("<p></p>").parent().html();
 		}
 
-		if (heading_ratios.includes(row[1].content) && column.fieldtype == "Float") {
+		if (heading_ratios.includes(row[1]?.content) && column.fieldtype == "Float") {
 			column.fieldtype = "Data";
 		}
 

--- a/erpnext/accounts/report/financial_ratios/financial_ratios.py
+++ b/erpnext/accounts/report/financial_ratios/financial_ratios.py
@@ -147,9 +147,9 @@ def get_gl_data(filters, period_list, years):
 
 def add_liquidity_ratios(data, years, current_asset, current_liability, quick_asset):
 	precision = frappe.db.get_single_value("System Settings", "float_precision")
-	data.append({"ratio": "Liquidity Ratios"})
+	data.append({"ratio": _("Liquidity Ratios")})
 
-	ratio_data = [["Current Ratio", current_asset], ["Quick Ratio", quick_asset]]
+	ratio_data = [[_("Current Ratio"), current_asset], [_("Quick Ratio"), quick_asset]]
 
 	for d in ratio_data:
 		row = {
@@ -165,13 +165,13 @@ def add_solvency_ratios(
 	data, years, total_asset, total_liability, net_sales, cogs, total_income, total_expense
 ):
 	precision = frappe.db.get_single_value("System Settings", "float_precision")
-	data.append({"ratio": "Solvency Ratios"})
+	data.append({"ratio": _("Solvency Ratios"}))
 
-	debt_equity_ratio = {"ratio": "Debt Equity Ratio"}
-	gross_profit_ratio = {"ratio": "Gross Profit Ratio"}
-	net_profit_ratio = {"ratio": "Net Profit Ratio"}
-	return_on_asset_ratio = {"ratio": "Return on Asset Ratio"}
-	return_on_equity_ratio = {"ratio": "Return on Equity Ratio"}
+	debt_equity_ratio = {"ratio": _("Debt Equity Ratio")}
+	gross_profit_ratio = {"ratio": _("Gross Profit Ratio")}
+	net_profit_ratio = {"ratio": _("Net Profit Ratio")}
+	return_on_asset_ratio = {"ratio": _("Return on Asset Ratio")}
+	return_on_equity_ratio = {"ratio": _("Return on Equity Ratio")}
 
 	for year in years:
 		profit_after_tax = flt(total_income.get(year)) + flt(total_expense.get(year))
@@ -195,7 +195,7 @@ def add_solvency_ratios(
 
 def add_turnover_ratios(data, years, period_list, filters, total_asset, net_sales, cogs, direct_expense):
 	precision = frappe.db.get_single_value("System Settings", "float_precision")
-	data.append({"ratio": "Turnover Ratios"})
+	data.append({"ratio": _("Turnover Ratios")})
 
 	avg_data = {}
 	for d in ["Receivable", "Payable", "Stock"]:
@@ -208,10 +208,10 @@ def add_turnover_ratios(data, years, period_list, filters, total_asset, net_sale
 	)
 
 	ratio_data = [
-		["Fixed Asset Turnover Ratio", net_sales, total_asset],
-		["Debtor Turnover Ratio", net_sales, avg_debtors],
-		["Creditor Turnover Ratio", direct_expense, avg_creditors],
-		["Inventory Turnover Ratio", cogs, avg_stock],
+		[_("Fixed Asset Turnover Ratio"), net_sales, total_asset],
+		[_("Debtor Turnover Ratio"), net_sales, avg_debtors],
+		[_("Creditor Turnover Ratio"), direct_expense, avg_creditors],
+		[_("Inventory Turnover Ratio"), cogs, avg_stock],
 	]
 	for ratio in ratio_data:
 		row = {

--- a/erpnext/accounts/report/financial_ratios/financial_ratios.py
+++ b/erpnext/accounts/report/financial_ratios/financial_ratios.py
@@ -165,7 +165,7 @@ def add_solvency_ratios(
 	data, years, total_asset, total_liability, net_sales, cogs, total_income, total_expense
 ):
 	precision = frappe.db.get_single_value("System Settings", "float_precision")
-	data.append({"ratio": _("Solvency Ratios"}))
+	data.append({"ratio": _("Solvency Ratios")})
 
 	debt_equity_ratio = {"ratio": _("Debt Equity Ratio")}
 	gross_profit_ratio = {"ratio": _("Gross Profit Ratio")}

--- a/erpnext/locale/es.po
+++ b/erpnext/locale/es.po
@@ -19618,6 +19618,62 @@ msgstr ""
 msgid "End Year"
 msgstr "Fin de año"
 
+#: erpnext/accounts/report/financial_ratios/financial_ratios.js:58
+msgid "Liquidity Ratios"
+msgstr "Ratios de Liquidez"
+
+#: erpnext/accounts/report/financial_ratios/financial_ratios.js:58
+msgid "Solvency Ratios"
+msgstr "Ratios de Solvencia"
+
+#: erpnext/accounts/report/financial_ratios/financial_ratios.js:58
+msgid "Turnover Ratios"
+msgstr "Ratios de Rotación"
+
+#: erpnext/accounts/report/financial_ratios/financial_ratios.py:152
+msgid "Current Ratio"
+msgstr "Ratio de Liquidez Corriente"
+
+#: erpnext/accounts/report/financial_ratios/financial_ratios.py:152
+msgid "Quick Ratio"
+msgstr "Ratio de Liquidez Inmediata"
+
+#: erpnext/accounts/report/financial_ratios/financial_ratios.py:170
+msgid "Debt Equity Ratio"
+msgstr "Ratio Deuda-Patrimonio"
+
+#: erpnext/accounts/report/financial_ratios/financial_ratios.py:171
+msgid "Gross Profit Ratio"
+msgstr "Ratio de Margen Bruto"
+
+#: erpnext/accounts/report/financial_ratios/financial_ratios.py:172
+msgid "Net Profit Ratio"
+msgstr "Ratio de Margen Neto"
+
+#: erpnext/accounts/report/financial_ratios/financial_ratios.py:173
+msgid "Return on Asset Ratio"
+msgstr "Ratio de Rentabilidad sobre Activos"
+
+#: erpnext/accounts/report/financial_ratios/financial_ratios.py:174
+msgid "Return on Equity Ratio"
+msgstr "Ratio de Rentabilidad sobre Patrimonio"
+
+#: erpnext/accounts/report/financial_ratios/financial_ratios.py:211
+msgid "Fixed Asset Turnover Ratio"
+msgstr "Ratio de Rotación de Activos Fijos"
+
+#: erpnext/accounts/report/financial_ratios/financial_ratios.py:212
+msgid "Debtor Turnover Ratio"
+msgstr "Ratio de Rotación de Deudores"
+
+#: erpnext/accounts/report/financial_ratios/financial_ratios.py:213
+msgid "Creditor Turnover Ratio"
+msgstr "Ratio de Rotación de Acreedores"
+
+#: erpnext/accounts/report/financial_ratios/financial_ratios.py:214
+msgid "Inventory Turnover Ratio"
+msgstr "Ratio de Rotación de Inventario"
+
 #: erpnext/accounts/report/financial_statements.py:133
 msgid "End Year cannot be before Start Year"
 msgstr "Año de finalización no puede ser anterior al Año de Inicio"

--- a/erpnext/locale/es.po
+++ b/erpnext/locale/es.po
@@ -19618,62 +19618,6 @@ msgstr ""
 msgid "End Year"
 msgstr "Fin de año"
 
-#: erpnext/accounts/report/financial_ratios/financial_ratios.js:58
-msgid "Liquidity Ratios"
-msgstr "Ratios de Liquidez"
-
-#: erpnext/accounts/report/financial_ratios/financial_ratios.js:58
-msgid "Solvency Ratios"
-msgstr "Ratios de Solvencia"
-
-#: erpnext/accounts/report/financial_ratios/financial_ratios.js:58
-msgid "Turnover Ratios"
-msgstr "Ratios de Rotación"
-
-#: erpnext/accounts/report/financial_ratios/financial_ratios.py:152
-msgid "Current Ratio"
-msgstr "Ratio de Liquidez Corriente"
-
-#: erpnext/accounts/report/financial_ratios/financial_ratios.py:152
-msgid "Quick Ratio"
-msgstr "Ratio de Liquidez Inmediata"
-
-#: erpnext/accounts/report/financial_ratios/financial_ratios.py:170
-msgid "Debt Equity Ratio"
-msgstr "Ratio Deuda-Patrimonio"
-
-#: erpnext/accounts/report/financial_ratios/financial_ratios.py:171
-msgid "Gross Profit Ratio"
-msgstr "Ratio de Margen Bruto"
-
-#: erpnext/accounts/report/financial_ratios/financial_ratios.py:172
-msgid "Net Profit Ratio"
-msgstr "Ratio de Margen Neto"
-
-#: erpnext/accounts/report/financial_ratios/financial_ratios.py:173
-msgid "Return on Asset Ratio"
-msgstr "Ratio de Rentabilidad sobre Activos"
-
-#: erpnext/accounts/report/financial_ratios/financial_ratios.py:174
-msgid "Return on Equity Ratio"
-msgstr "Ratio de Rentabilidad sobre Patrimonio"
-
-#: erpnext/accounts/report/financial_ratios/financial_ratios.py:211
-msgid "Fixed Asset Turnover Ratio"
-msgstr "Ratio de Rotación de Activos Fijos"
-
-#: erpnext/accounts/report/financial_ratios/financial_ratios.py:212
-msgid "Debtor Turnover Ratio"
-msgstr "Ratio de Rotación de Deudores"
-
-#: erpnext/accounts/report/financial_ratios/financial_ratios.py:213
-msgid "Creditor Turnover Ratio"
-msgstr "Ratio de Rotación de Acreedores"
-
-#: erpnext/accounts/report/financial_ratios/financial_ratios.py:214
-msgid "Inventory Turnover Ratio"
-msgstr "Ratio de Rotación de Inventario"
-
 #: erpnext/accounts/report/financial_statements.py:133
 msgid "End Year cannot be before Start Year"
 msgstr "Año de finalización no puede ser anterior al Año de Inicio"


### PR DESCRIPTION
## Fix Financial Ratios Translation and PDF Export Error

### Changes Made:

- Added translation functions in Python file.
- Fixed JavaScript formatter function
- Added optional chaining operator (?.) to prevent PDF export error: 
```js
financial_ratios.js:62 Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'content')
    at Object.formatter (financial_ratios.js:62:38)
    at Object.format (query_report.js:1362:35)
    at eval (eval at <anonymous> (microtemplate.js:88:36), <anonymous>:60:166)
    at Object.render (microtemplate.js:104:42)
    at Object.render_template (microtemplate.js:119:16)
    at QueryReport.pdf_report (query_report.js:1526:26)
    at query_report.js:1806:32
    at print_utils.js:82:4
    at Dialog.<anonymous> (messages.js:104:4)
    at HTMLButtonElement.<anonymous> (dialog.js:209:20)
```

