### PR TITLE
fix: remove mandatory item description in LCV

### DIFF
--- a/erpnext/stock/doctype/landed_cost_item/landed_cost_item.json
+++ b/erpnext/stock/doctype/landed_cost_item/landed_cost_item.json
@@ -42,7 +42,6 @@
    "oldfieldtype": "Data",
    "print_width": "300px",
    "read_only": 1,
-   "reqd": 1,
    "width": "120px"
   },
   {
@@ -145,7 +144,7 @@
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-06-11 08:53:38.096761",
+ "modified": "2025-09-03 17:42:13.644861",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Landed Cost Item",

--- a/erpnext/stock/doctype/landed_cost_item/landed_cost_item.py
+++ b/erpnext/stock/doctype/landed_cost_item/landed_cost_item.py
@@ -27,7 +27,9 @@ class LandedCostItem(Document):
 		qty: DF.Float
 		rate: DF.Currency
 		receipt_document: DF.DynamicLink | None
-		receipt_document_type: DF.Literal["Purchase Invoice", "Purchase Receipt", "Stock Entry", "Subcontracting Receipt"]
+		receipt_document_type: DF.Literal[
+			"Purchase Invoice", "Purchase Receipt", "Stock Entry", "Subcontracting Receipt"
+		]
 		stock_entry_item: DF.Data | None
 	# end: auto-generated types
 

--- a/erpnext/stock/doctype/landed_cost_item/landed_cost_item.py
+++ b/erpnext/stock/doctype/landed_cost_item/landed_cost_item.py
@@ -17,7 +17,7 @@ class LandedCostItem(Document):
 		amount: DF.Currency
 		applicable_charges: DF.Currency
 		cost_center: DF.Link | None
-		description: DF.TextEditor
+		description: DF.TextEditor | None
 		is_fixed_asset: DF.Check
 		item_code: DF.Link
 		parent: DF.Data
@@ -27,9 +27,7 @@ class LandedCostItem(Document):
 		qty: DF.Float
 		rate: DF.Currency
 		receipt_document: DF.DynamicLink | None
-		receipt_document_type: DF.Literal[
-			"Purchase Invoice", "Purchase Receipt", "Stock Entry", "Subcontracting Receipt"
-		]
+		receipt_document_type: DF.Literal["Purchase Invoice", "Purchase Receipt", "Stock Entry", "Subcontracting Receipt"]
 		stock_entry_item: DF.Data | None
 	# end: auto-generated types
 


### PR DESCRIPTION
Issue : description field is mandatory for items table in LCV, even though it is not in Purchase Receipt Item nor in item master.

Fix : Remove mandatory for description in the LCV items table.

Before :

<img width="1825" height="957" alt="Screenshot from 2025-10-01 11-34-20" src="https://github.com/user-attachments/assets/0dcdefd7-ebea-4f4d-96ca-3e473ec4916b" />



After :

<img width="1199" height="637" alt="Screenshot from 2025-10-01 11-35-06" src="https://github.com/user-attachments/assets/336f278e-7b1a-4c24-ba84-475e3e446a73" />

Backport needed : V14 , V15
