### PR TITLE
fix: Set paid amount automatically only if return entry validated and has negative grand total

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -228,6 +228,11 @@ class AccountsController(TransactionBase):
 
 		self.validate_date_with_fiscal_year()
 		self.validate_party_accounts()
+		if self.doctype in ["Sales Invoice", "Purchase Invoice"]:
+			if self.is_return:
+				self.validate_qty()
+			else:
+				self.validate_deferred_start_and_end_date()
 
 		self.validate_inter_company_reference()
 		# validate inter  company transaction rate
@@ -278,11 +283,6 @@ class AccountsController(TransactionBase):
 				self.set_advances()
 
 			self.set_advance_gain_or_loss()
-
-			if self.is_return:
-				self.validate_qty()
-			else:
-				self.validate_deferred_start_and_end_date()
 
 			self.validate_deferred_income_expense_account()
 			self.set_inter_company_account()

--- a/erpnext/public/js/controllers/taxes_and_totals.js
+++ b/erpnext/public/js/controllers/taxes_and_totals.js
@@ -78,6 +78,7 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 		if (
 			this.frm.doc.doctype === "Purchase Invoice" &&
 			this.frm.doc.is_return &&
+			this.frm.doc.grand_total < 0 &&
 			this.frm.doc.grand_total > this.frm.doc.paid_amount
 		) {
 			this.frm.doc.paid_amount = flt(this.frm.doc.grand_total, precision("grand_total"));


### PR DESCRIPTION
Problem:
- In a Return purchase invoice or debit note, the paid amount was getting set incorrectly when the users were setting the item qty as positive, This eventually leading to incorrect outstanding amount.
Fix:
- Set paid amount automatically only if return entry validated and has negative grand total

Linked support issue: https://support.frappe.io/helpdesk/tickets/42089