### PR TITLE
 Fix: Product Bundle Purchase Order Creation Logic

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.js
+++ b/erpnext/selling/doctype/sales_order/sales_order.js
@@ -1325,15 +1325,8 @@ erpnext.selling.SalesOrderController = class SalesOrderController extends erpnex
 			// calculate ordered qty based on packed items in case of product bundle
 			let packed_items = so.packed_items.filter((pi) => pi.parent_detail_docname == item.name);
 			if (packed_items && packed_items.length) {
-				// Check if ALL packed items are fully ordered
-				let all_packed_items_ordered = packed_items.every((pi) => flt(pi.ordered_qty) >= flt(pi.qty));
-				if (all_packed_items_ordered) {
-					// If all packed items are fully ordered, the bundle is fully ordered
-					ordered_qty = item.stock_qty;
-				} else {
-					// If any packed item is not fully ordered, bundle is not ordered
-					ordered_qty = 0;
-				}
+				const all_packed_items_ordered = packed_items.every((pi) => flt(pi.ordered_qty) >= flt(pi.qty));
+				ordered_qty = all_packed_items_ordered ? item.stock_qty : 0;
 			}
 		}
 		return ordered_qty;

--- a/erpnext/selling/doctype/sales_order/sales_order.js
+++ b/erpnext/selling/doctype/sales_order/sales_order.js
@@ -1170,7 +1170,8 @@ erpnext.selling.SalesOrderController = class SalesOrderController extends erpnex
 
 	make_purchase_order() {
 		let pending_items = this.frm.doc.items.some((item) => {
-			let pending_qty = flt(item.stock_qty) - flt(item.ordered_qty);
+			let ordered_qty = this.get_ordered_qty(item, this.frm.doc);
+			let pending_qty = flt(item.stock_qty) - ordered_qty;
 			return pending_qty > 0;
 		});
 		if (!pending_items) {
@@ -1324,8 +1325,15 @@ erpnext.selling.SalesOrderController = class SalesOrderController extends erpnex
 			// calculate ordered qty based on packed items in case of product bundle
 			let packed_items = so.packed_items.filter((pi) => pi.parent_detail_docname == item.name);
 			if (packed_items && packed_items.length) {
-				ordered_qty = packed_items.reduce((sum, pi) => sum + flt(pi.ordered_qty), 0);
-				ordered_qty = ordered_qty / packed_items.length;
+				// Check if ALL packed items are fully ordered
+				let all_packed_items_ordered = packed_items.every((pi) => flt(pi.ordered_qty) >= flt(pi.qty));
+				if (all_packed_items_ordered) {
+					// If all packed items are fully ordered, the bundle is fully ordered
+					ordered_qty = item.stock_qty;
+				} else {
+					// If any packed item is not fully ordered, bundle is not ordered
+					ordered_qty = 0;
+				}
 			}
 		}
 		return ordered_qty;

--- a/erpnext/selling/doctype/sales_order/sales_order.js
+++ b/erpnext/selling/doctype/sales_order/sales_order.js
@@ -1170,8 +1170,7 @@ erpnext.selling.SalesOrderController = class SalesOrderController extends erpnex
 
 	make_purchase_order() {
 		let pending_items = this.frm.doc.items.some((item) => {
-			let ordered_qty = this.get_ordered_qty(item, this.frm.doc);
-			let pending_qty = flt(item.stock_qty) - ordered_qty;
+			const pending_qty = flt(item.stock_qty) - this.get_ordered_qty(item, this.frm.doc);
 			return pending_qty > 0;
 		});
 		if (!pending_items) {
@@ -1325,7 +1324,9 @@ erpnext.selling.SalesOrderController = class SalesOrderController extends erpnex
 			// calculate ordered qty based on packed items in case of product bundle
 			let packed_items = so.packed_items.filter((pi) => pi.parent_detail_docname == item.name);
 			if (packed_items && packed_items.length) {
-				const all_packed_items_ordered = packed_items.every((pi) => flt(pi.ordered_qty) >= flt(pi.qty));
+				const all_packed_items_ordered = packed_items.every(
+					(pi) => flt(pi.ordered_qty) >= flt(pi.qty)
+				);
 				ordered_qty = all_packed_items_ordered ? item.stock_qty : 0;
 			}
 		}

--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -1454,7 +1454,8 @@ def make_purchase_order_for_default_supplier(source_name, selected_items=None, t
 						"pricing_rules",
 					],
 					"postprocess": update_item_for_packed_item,
-					"condition": lambda doc: doc.parent_item in items_to_map,
+					"condition": lambda doc: doc.parent_item in items_to_map
+					and flt(doc.ordered_qty) < flt(doc.qty),
 				},
 			},
 			target_doc,
@@ -1592,7 +1593,8 @@ def make_purchase_order(source_name, selected_items=None, target_doc=None):
 					"pricing_rules",
 				],
 				"postprocess": update_item_for_packed_item,
-				"condition": lambda doc: doc.parent_item in items_to_map,
+				"condition": lambda doc: doc.parent_item in items_to_map
+				and flt(doc.ordered_qty) < flt(doc.qty),
 			},
 		},
 		target_doc,


### PR DESCRIPTION
## Problem

When creating Purchase Orders from Sales Orders containing product bundles, the system incorrectly marked bundles as "fully ordered" even when only some packed items were ordered. This prevented users from creating additional Purchase Orders for remaining packed items.

[Before-fix_create_purchase_order_from_sales_order.webm](https://github.com/user-attachments/assets/f325b771-f259-4320-abbe-d966832a5106)


## Root Cause

1. **JavaScript**: `get_ordered_qty()` method averaged `ordered_qty` across packed items instead of checking completion status
2. **Python**: Server-side mapping included fully ordered packed items (qty = 0) in new Purchase Orders

## Solution

### `sales_order.js` Changes

1. **Fixed `get_ordered_qty()` method**: Changed from averaging logic to binary completion check
   - Returns `stock_qty` only when ALL packed items are fully ordered
   - Returns `0` when ANY packed item has pending quantity

2. **Fixed validation consistency**: Updated `make_purchase_order()` initial validation to use `get_ordered_qty()` method instead of raw `ordered_qty` field

### `sales_order.py` Changes

Updated packed item mapping condition in both `make_purchase_order()` and `make_purchase_order_for_default_supplier()`:

```python
# Before
"condition": lambda doc: doc.parent_item in items_to_map,

# After  
"condition": lambda doc: doc.parent_item in items_to_map and flt(doc.ordered_qty) < flt(doc.qty),
```

## Impact

- ✅ Product bundles remain available until ALL packed items are fully ordered
- ✅ Multiple Purchase Orders can be created for the same bundle
- ✅ Clean Purchase Orders without zero-quantity items
- ✅ Backward compatible with existing Sales Order/Purchase Order workflows
- ✅ No impact on regular (non-bundle) items

[After-fix_create_purchase_order_from_sales_order..webm](https://github.com/user-attachments/assets/cf40fa7d-ce8e-43a7-9c1b-0c2106d9823e)


## Testing

Verified with product bundles containing multiple packed items across partial and complete ordering scenarios.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected pending quantity calculation in Sales Orders for Purchase Order creation, including accurate handling of packed/bundled items.
  * Fully ordered packed items are now treated as complete, preventing them from being considered for further ordering.
  * Prevents mapping items with no remaining quantity, reducing duplicate or zero-quantity lines in Purchase Orders.
  * Improves consistency and clarity of item eligibility during Purchase Order creation, minimizing over-ordering and mismatches between ordered and required quantities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->