### PR TITLE
fix: too many writes on patch run

### DIFF
--- a/erpnext/patches/v15_0/patch_missing_buying_price_list_in_material_request.py
+++ b/erpnext/patches/v15_0/patch_missing_buying_price_list_in_material_request.py
@@ -9,5 +9,8 @@ def execute():
 		docs = frappe.get_all(
 			"Material Request", filters={"buying_price_list": ["is", "not set"], "docstatus": 1}, pluck="name"
 		)
+		old_limit = frappe.db.MAX_WRITES_PER_TRANSACTION
+		frappe.db.MAX_WRITES_PER_TRANSACTION *= 4
 		for doc in docs:
 			frappe.db.set_value("Material Request", doc, "buying_price_list", default_buying_price_list)
+		frappe.db.MAX_WRITES_PER_TRANSACTION = old_limit

--- a/erpnext/patches/v15_0/patch_missing_buying_price_list_in_material_request.py
+++ b/erpnext/patches/v15_0/patch_missing_buying_price_list_in_material_request.py
@@ -11,6 +11,8 @@ def execute():
 		)
 		old_limit = frappe.db.MAX_WRITES_PER_TRANSACTION
 		frappe.db.MAX_WRITES_PER_TRANSACTION *= 4
-		for doc in docs:
-			frappe.db.set_value("Material Request", doc, "buying_price_list", default_buying_price_list)
-		frappe.db.MAX_WRITES_PER_TRANSACTION = old_limit
+		try:
+			for doc in docs:
+				frappe.db.set_value("Material Request", doc, "buying_price_list", default_buying_price_list)
+		finally:
+			frappe.db.MAX_WRITES_PER_TRANSACTION = old_limit


### PR DESCRIPTION
If user had more than 2L material requests, the patch failed with `TooManyWrites` exception