### PR TITLE
feat: track purchases in accounting and configure item / item group / brand wise COGS

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
@@ -884,6 +884,7 @@ class PurchaseInvoice(BuyingController):
 		self.make_write_off_gl_entry(gl_entries)
 		self.make_gle_for_rounding_adjustment(gl_entries)
 		self.set_transaction_currency_and_rate_in_gl_map(gl_entries)
+		self.set_gl_entry_for_purchase_expense(gl_entries)
 		return gl_entries
 
 	def check_asset_cwip_enabled(self):

--- a/erpnext/setup/doctype/company/company.js
+++ b/erpnext/setup/doctype/company/company.js
@@ -278,6 +278,8 @@ erpnext.company.setup_queries = function (frm) {
 			["depreciation_expense_account", { root_type: "Expense", account_type: "Depreciation" }],
 			["disposal_account", { report_type: "Profit and Loss" }],
 			["default_inventory_account", { account_type: "Stock" }],
+			["purchase_expense_account", { root_type: "Expense" }],
+			["purchase_expense_contra_account", { root_type: "Expense" }],
 			["cost_center", {}],
 			["round_off_cost_center", {}],
 			["depreciation_cost_center", {}],

--- a/erpnext/setup/doctype/company/company.json
+++ b/erpnext/setup/doctype/company/company.json
@@ -106,6 +106,10 @@
   "default_warehouse_for_sales_return",
   "credit_limit",
   "transactions_annual_history",
+  "purchase_expense_section",
+  "purchase_expense_account",
+  "column_break_ereg",
+  "purchase_expense_contra_account",
   "stock_tab",
   "auto_accounting_for_stock_settings",
   "enable_perpetual_inventory",
@@ -844,6 +848,27 @@
    "options": "Currency",
    "print_hide": 1,
    "read_only": 1
+  },
+  {
+   "fieldname": "purchase_expense_section",
+   "fieldtype": "Section Break",
+   "label": "Purchase Expense"
+  },
+  {
+   "fieldname": "column_break_ereg",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "purchase_expense_account",
+   "fieldtype": "Link",
+   "label": "Purchase Expense Account",
+   "options": "Account"
+  },
+  {
+   "fieldname": "purchase_expense_contra_account",
+   "fieldtype": "Link",
+   "label": "Purchase Expense Contra Account",
+   "options": "Account"
   }
  ],
  "icon": "fa fa-building",
@@ -851,7 +876,7 @@
  "image_field": "company_logo",
  "is_tree": 1,
  "links": [],
- "modified": "2025-08-25 18:34:03.602046",
+ "modified": "2025-10-01 17:34:10.971627",
  "modified_by": "Administrator",
  "module": "Setup",
  "name": "Company",

--- a/erpnext/setup/doctype/company/company.py
+++ b/erpnext/setup/doctype/company/company.py
@@ -86,6 +86,8 @@ class Company(NestedSet):
 		parent_company: DF.Link | None
 		payment_terms: DF.Link | None
 		phone_no: DF.Data | None
+		purchase_expense_account: DF.Link | None
+		purchase_expense_contra_account: DF.Link | None
 		reconcile_on_advance_payment_date: DF.Check
 		reconciliation_takes_effect_on: DF.Literal[
 			"Advance Payment Date", "Oldest Of Invoice Or Advance", "Reconciliation Date"

--- a/erpnext/stock/doctype/item/item.js
+++ b/erpnext/stock/doctype/item/item.js
@@ -488,6 +488,21 @@ $.extend(erpnext.item, {
 				},
 			};
 		});
+
+		let fields = ["purchase_expense_account", "purchase_expense_contra_account", "default_cogs_account"];
+
+		fields.forEach((field) => {
+			frm.set_query(field, "item_defaults", (doc, cdt, cdn) => {
+				let row = locals[cdt][cdn];
+				return {
+					filters: {
+						company: row.company,
+						root_type: "Expense",
+						is_group: 0,
+					},
+				};
+			});
+		});
 	},
 
 	make_dashboard: function (frm) {

--- a/erpnext/stock/doctype/item/item.json
+++ b/erpnext/stock/doctype/item/item.json
@@ -16,20 +16,22 @@
   "item_name",
   "item_group",
   "stock_uom",
+  "opening_stock",
+  "valuation_rate",
+  "standard_rate",
   "column_break0",
   "disabled",
   "allow_alternative_item",
   "is_stock_item",
   "has_variants",
-  "opening_stock",
-  "valuation_rate",
-  "standard_rate",
   "is_fixed_asset",
   "auto_create_assets",
   "is_grouped_asset",
   "asset_category",
   "asset_naming_series",
+  "section_break_znra",
   "over_delivery_receipt_allowance",
+  "column_break_wugd",
   "over_billing_allowance",
   "image",
   "section_break_11",
@@ -63,6 +65,8 @@
   "column_break_37",
   "has_serial_no",
   "serial_no_series",
+  "defaults_tab",
+  "item_defaults",
   "variants_section",
   "variant_of",
   "variant_based_on",
@@ -74,8 +78,6 @@
   "column_break_9s9o",
   "enable_deferred_revenue",
   "no_of_months",
-  "section_break_avcp",
-  "item_defaults",
   "purchasing_tab",
   "purchase_uom",
   "min_order_qty",
@@ -888,10 +890,6 @@
    "fieldtype": "Column Break"
   },
   {
-   "fieldname": "section_break_avcp",
-   "fieldtype": "Section Break"
-  },
-  {
    "collapsible": 1,
    "fieldname": "deferred_accounting_section",
    "fieldtype": "Section Break",
@@ -936,6 +934,19 @@
    "fieldname": "production_capacity",
    "fieldtype": "Int",
    "label": "Production Capacity"
+  },
+  {
+   "fieldname": "defaults_tab",
+   "fieldtype": "Tab Break",
+   "label": "Defaults"
+  },
+  {
+   "fieldname": "section_break_znra",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "column_break_wugd",
+   "fieldtype": "Column Break"
   }
  ],
  "icon": "fa fa-tag",
@@ -943,7 +954,7 @@
  "image_field": "image",
  "links": [],
  "make_attachments_public": 1,
- "modified": "2025-08-14 23:35:56.293048",
+ "modified": "2025-10-01 16:58:40.946604",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Item",

--- a/erpnext/stock/doctype/item/test_item.py
+++ b/erpnext/stock/doctype/item/test_item.py
@@ -305,6 +305,7 @@ class TestItem(IntegrationTestCase):
 						"company": "_Test Company",
 						"default_warehouse": "_Test Warehouse 2 - _TC",  # no override
 						"expense_account": "_Test Account Stock Expenses - _TC",  # override brand default
+						"default_cogs_account": "_Test Account Cost for Goods Sold - _TC",  # override brand default
 						"buying_cost_center": "_Test Write Off Cost Center - _TC",  # override item group default
 					}
 				],
@@ -315,7 +316,7 @@ class TestItem(IntegrationTestCase):
 			"item_code": "Test Item With Defaults",
 			"warehouse": "_Test Warehouse 2 - _TC",  # from item
 			"income_account": "_Test Account Sales - _TC",  # from brand
-			"expense_account": "_Test Account Stock Expenses - _TC",  # from item
+			"expense_account": "_Test Account Cost for Goods Sold - _TC",  # from item
 			"cost_center": "_Test Cost Center 2 - _TC",  # from item group
 		}
 		sales_item_details = get_item_details(

--- a/erpnext/stock/doctype/item_default/item_default.json
+++ b/erpnext/stock/doctype/item_default/item_default.json
@@ -16,10 +16,15 @@
   "column_break_8",
   "expense_account",
   "default_provisional_account",
+  "column_break_cpif",
+  "purchase_expense_account",
+  "purchase_expense_contra_account",
   "selling_defaults",
   "selling_cost_center",
   "column_break_12",
   "income_account",
+  "cost_of_good_sold_section",
+  "default_cogs_account",
   "deferred_accounting_defaults_section",
   "deferred_expense_account",
   "column_break_kwad",
@@ -111,7 +116,7 @@
   {
    "fieldname": "default_provisional_account",
    "fieldtype": "Link",
-   "label": "Default Provisional Account",
+   "label": "Default Provisional Account (Service)",
    "options": "Account"
   },
   {
@@ -136,17 +141,45 @@
   {
    "fieldname": "column_break_kwad",
    "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "column_break_cpif",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "cost_of_good_sold_section",
+   "fieldtype": "Section Break",
+   "label": "Cost of Goods Sold"
+  },
+  {
+   "fieldname": "default_cogs_account",
+   "fieldtype": "Link",
+   "label": "Default COGS Account",
+   "options": "Account"
+  },
+  {
+   "fieldname": "purchase_expense_account",
+   "fieldtype": "Link",
+   "label": "Purchase Expense Account",
+   "options": "Account"
+  },
+  {
+   "fieldname": "purchase_expense_contra_account",
+   "fieldtype": "Link",
+   "label": "Purchase Expense Contra Account",
+   "options": "Account"
   }
  ],
  "istable": 1,
  "links": [],
- "modified": "2025-03-17 13:46:09.719105",
+ "modified": "2025-10-01 19:17:33.687836",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Item Default",
  "owner": "Administrator",
  "permissions": [],
  "quick_entry": 1,
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],

--- a/erpnext/stock/doctype/item_default/item_default.py
+++ b/erpnext/stock/doctype/item_default/item_default.py
@@ -16,6 +16,7 @@ class ItemDefault(Document):
 
 		buying_cost_center: DF.Link | None
 		company: DF.Link
+		default_cogs_account: DF.Link | None
 		default_discount_account: DF.Link | None
 		default_price_list: DF.Link | None
 		default_provisional_account: DF.Link | None
@@ -28,6 +29,8 @@ class ItemDefault(Document):
 		parent: DF.Data
 		parentfield: DF.Data
 		parenttype: DF.Data
+		purchase_expense_account: DF.Link | None
+		purchase_expense_contra_account: DF.Link | None
 		selling_cost_center: DF.Link | None
 	# end: auto-generated types
 

--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
@@ -479,6 +479,7 @@ class PurchaseReceipt(BuyingController):
 
 		self.make_item_gl_entries(gl_entries, warehouse_account=warehouse_account)
 		self.make_tax_gl_entries(gl_entries, via_landed_cost_voucher)
+		self.set_gl_entry_for_purchase_expense(gl_entries)
 		update_regional_gl_entries(gl_entries, self)
 
 		return process_gl_map(gl_entries, from_repost=frappe.flags.through_repost_item_valuation)

--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -868,6 +868,19 @@ def get_default_income_account(ctx: ItemDetailsCtx, item, item_group, brand):
 
 
 def get_default_expense_account(ctx: ItemDetailsCtx, item, item_group, brand):
+	if ctx.get("doctype") in ["Sales Invoice", "Delivery Note"]:
+		expense_account = (
+			item.get("default_cogs_account")
+			or item_group.get("default_cogs_account")
+			or brand.get("default_cogs_account")
+		)
+
+		if not expense_account:
+			expense_account = frappe.get_cached_value("Company", ctx.company, "default_expense_account")
+
+		if expense_account:
+			return expense_account
+
 	return (
 		item.get("expense_account")
 		or item_group.get("expense_account")


### PR DESCRIPTION
To calculate COGS, the formula in accounting is as follows:

COGS = Opening + Purchases - Closing

Users can easily find the stock opening and closing balances by referring to the stock balance report, but determining the purchases is more difficult. The account Stock Received but Not Billed can help, but it doesn’t work if the user is using Purchase Invoices with ‘Update Stock’.

To address this, we added Purchase Expense Account and Purchase Expense Contra Account fields in the Company and Item Defaults masters. So now, when the user books the purchase receipt and purchase invoice expense account and its contra will get debited and credited with the same amount, which means the final impact is zero, but the user will be able to see the purchase amount in P&L and Trial Balance reports.

<img width="1157" height="594" alt="Screenshot 2025-10-01 at 6 56 13 PM" src="https://github.com/user-attachments/assets/1f650998-f9bc-4bef-bda3-62e1ee55e8e1" />


### The impact of these accounts in the Purchase Receipt


<img width="1157" height="594" alt="Screenshot 2025-10-01 at 6 35 25 PM" src="https://github.com/user-attachments/assets/b924cead-d9ec-4983-b10f-6d569552e8da" />


### Also added the default COGS account in the item default table
<img width="1284" height="693" alt="Screenshot 2025-10-01 at 7 03 36 PM" src="https://github.com/user-attachments/assets/1fd46bcc-25e0-4b36-a12b-23669cef0b3e" />


## GL Impact

<img width="1293" height="502" alt="Screenshot 2025-10-01 at 7 05 29 PM" src="https://github.com/user-attachments/assets/9a7e8b97-ac62-4d36-9e7c-cfa4a85b5a84" />






Fixed https://github.com/frappe/erpnext/issues/49479 
Fixed https://github.com/frappe/erpnext/issues/49472

Docs https://docs.frappe.io/erpnext/track-purchases-in-accounts