### PR TITLE
fix(Accounts Payable Summary): add a missing translate function (backport #49496)

### DIFF
--- a/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
+++ b/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
@@ -1270,7 +1270,7 @@ class ReceivablePayableReport:
 	def setup_ageing_columns(self):
 		# for charts
 		self.ageing_column_labels = []
-		ranges = [*self.ranges, "Above"]
+		ranges = [*self.ranges, _("Above")]
 
 		prev_range_value = 0
 		for idx, curr_range_value in enumerate(ranges):

--- a/erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py
+++ b/erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py
@@ -171,7 +171,7 @@ class AccountsReceivableSummary(ReceivablePayableReport):
 			self.add_column(_("Difference"), fieldname="diff")
 
 		self.setup_ageing_columns()
-		self.add_column(label="Total Amount Due", fieldname="total_due")
+		self.add_column(label=_("Total Amount Due"), fieldname="total_due")
 
 		if self.filters.show_future_payments:
 			self.add_column(label=_("Future Payment Amount"), fieldname="future_amount")


### PR DESCRIPTION
Backport PR: #49496 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced internationalization in financial reports. The Accounts Receivable report now translates the upper ageing bucket label (“Above”), and the Accounts Receivable Summary report makes the “Total Amount Due” column label translatable. Users will see these labels localized according to their language settings, improving readability and consistency for multilingual teams across both reports without changing underlying report logic or calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->