### PR TITLE
feat(Supplier): remove create buttons

### DIFF
--- a/erpnext/buying/doctype/supplier/supplier.js
+++ b/erpnext/buying/doctype/supplier/supplier.js
@@ -109,10 +109,6 @@ frappe.ui.form.on("Supplier", {
 				__("View")
 			);
 
-			frm.add_custom_button(__("Bank Account"), () => frm.make_methods["Bank Account"](), __("Create"));
-
-			frm.add_custom_button(__("Pricing Rule"), () => frm.make_methods["Pricing Rule"](), __("Create"));
-
 			frm.add_custom_button(
 				__("Get Supplier Group Details"),
 				function () {


### PR DESCRIPTION
It seems arbitrary to only offer "Create" buttons for **Bank Account** and **Pricing Rule**.

When a user wants to create anything else from the Supplier, they waste one click to discover that it's not possible. Better go straight to the Connections tab and create the desired record there.

> no-docs