### PR TITLE
perf: avoid unnecessary set_dynamic_labels updates

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -1679,6 +1679,17 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 		);
 
 		var company_currency = this.get_company_currency();
+
+		if (
+			this._last_company_currency === company_currency &&
+			this._last_price_list_currency === this.frm.doc.price_list_currency
+		) {
+			return;
+		}
+
+		this._last_company_currency = company_currency;
+		this._last_price_list_currency = this.frm.doc.price_list_currency;
+
 		this.change_form_labels(company_currency);
 		this.change_grid_labels(company_currency);
 		this.frm.refresh_fields();


### PR DESCRIPTION
Skip updating UI if currencies are unchanged since the last call.

Issue: #49847 