### PR TITLE
feat: show item name in update items dialog for sales and purchase order

### DIFF
--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -733,6 +733,7 @@ erpnext.utils.update_child_items = function (opts) {
 			fieldname: "item_name",
 			label: __("Item Name"),
 			read_only: 1,
+			in_list_view: 1,
 		},
 		{
 			fieldtype: "Link",
@@ -784,7 +785,7 @@ erpnext.utils.update_child_items = function (opts) {
 	];
 
 	if (frm.doc.doctype == "Sales Order" || frm.doc.doctype == "Purchase Order") {
-		fields.splice(2, 0, {
+		fields.splice(3, 0, {
 			fieldtype: "Date",
 			fieldname: frm.doc.doctype == "Sales Order" ? "delivery_date" : "schedule_date",
 			in_list_view: 1,
@@ -792,7 +793,7 @@ erpnext.utils.update_child_items = function (opts) {
 			default: frm.doc.doctype == "Sales Order" ? frm.doc.delivery_date : frm.doc.schedule_date,
 			reqd: 1,
 		});
-		fields.splice(3, 0, {
+		fields.splice(4, 0, {
 			fieldtype: "Float",
 			fieldname: "conversion_factor",
 			label: __("Conversion Factor"),


### PR DESCRIPTION
**Issue:**  When updating items in a Purchase or Sales Order, the Update Items popup currently displays only the Item Code in the list view making it difficult for users to identify the items.

**Solution:** Enabled In List View for Item Name field. which enables the user to identify the items easily.

Ref : [#49830](https://github.com/frappe/erpnext/issues/49830)


**Before:**

<img width="1919" height="997" alt="Before" src="https://github.com/user-attachments/assets/a9e92a9d-22c6-4782-8bc6-ec19f9532cc5" />

**After:**

<img width="1919" height="1005" alt="After" src="https://github.com/user-attachments/assets/2794a0ec-e7c9-4383-8820-09a901599b40" />

**Backport Needed:** version-15