### PR TITLE
fix: add default scrap warehouse in wo

### DIFF
--- a/erpnext/manufacturing/doctype/production_plan/production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.py
@@ -775,6 +775,7 @@ class ProductionPlan(Document):
 			work_order_data = {
 				"wip_warehouse": default_warehouses.get("wip_warehouse"),
 				"fg_warehouse": default_warehouses.get("fg_warehouse"),
+				"scrap_warehouse": default_warehouses.get("scrap_warehouse"),
 				"company": self.get("company"),
 			}
 
@@ -1909,7 +1910,7 @@ def get_sub_assembly_items(
 
 
 def set_default_warehouses(row, default_warehouses):
-	for field in ["wip_warehouse", "fg_warehouse"]:
+	for field in ["wip_warehouse", "fg_warehouse", "scrap_warehouse"]:
 		if not row.get(field):
 			row[field] = default_warehouses.get(field)
 


### PR DESCRIPTION
**Issue:** When creating Work Order from Production Plan default scrap warehouse is not fetching.

**Ref:** [49718](https://support.frappe.io/helpdesk/tickets/49718?view=VIEW-HD+Ticket-646)

**Before:**

[Screencast from 02-10-25 03:36:36 PM IST.webm](https://github.com/user-attachments/assets/dd3ae2ea-2de2-472e-8fe1-e24576c00da8)


**After:**

[Screencast from 02-10-25 03:37:18 PM IST.webm](https://github.com/user-attachments/assets/8df4b3e1-098c-4729-9989-050ff402fbed)



**Backport Needed: v15**