### PR TITLE
fix: SQL operator precedence in Project query customer filter

### DIFF
--- a/erpnext/controllers/queries.py
+++ b/erpnext/controllers/queries.py
@@ -318,7 +318,7 @@ def get_project_name(doctype, txt, searchfield, start, page_len, filters):
 	if filters:
 		if filters.get("customer"):
 			qb_filter_and_conditions.append(
-				(proj.customer == filters.get("customer")) | proj.customer.isnull() | proj.customer == ""
+				(proj.customer == filters.get("customer")) | (proj.customer.isnull()) | (proj.customer == "")
 			)
 
 		if filters.get("company"):


### PR DESCRIPTION
Added explicit parentheses around customer OR conditions in` get_project_name() `to ensure proper grouping with AND filters. Without these parentheses, SQL operator precedence caused the status filter to be bypassed when a customer filter was applied, resulting in completed and cancelled projects appearing in link field dropdowns.

**Before:**
`WHERE customer='X' OR customer IS NULL OR customer='' AND status NOT IN (...)` was interpreted as:
`WHERE customer='X' OR customer IS NULL OR (customer='' AND status NOT IN (...))`

**After:**
`WHERE (customer='X' OR customer IS NULL OR customer='') AND status NOT IN (...`)

Fixes: Completed/cancelled projects showing in Project link fields
Affected: Any doctype using Project link fields with customer filters

<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/erpnext/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->
