### PR TITLE
fix: Fetching incorrect incoming rate in the sales invoice return case

### DIFF
--- a/erpnext/controllers/selling_controller.py
+++ b/erpnext/controllers/selling_controller.py
@@ -525,11 +525,7 @@ class SellingController(StockController):
 				# Get incoming rate based on original item cost based on valuation method
 				qty = flt(d.get("stock_qty") or d.get("actual_qty") or d.get("qty"))
 
-				if (
-					not d.incoming_rate
-					or self.is_internal_transfer()
-					or (get_valuation_method(d.item_code) == "Moving Average" and self.get("is_return"))
-				):
+				if (not d.incoming_rate and not self.get("return_against")) or self.is_internal_transfer():
 					d.incoming_rate = get_incoming_rate(
 						{
 							"item_code": d.item_code,


### PR DESCRIPTION
Issue: Fetching incorrect incoming rate in the sales invoice return when the valuation method is set to "Moving Average".

Scenario: If we have item stock in multiple warehouses and create a sales invoice with updated stock, selecting a specific warehouse, the incoming rate is applied according to that warehouse. However, when we process a sales invoice return, if we select a different warehouse (only in the existing stock movement warehouse) than the one used in the original invoice, the system incorrectly applies the incoming rate based on the new warehouse rather than the original return invoice, which is incorrect.

Before Fix:

[before_fix.webm](https://github.com/user-attachments/assets/c0babc58-9512-41e8-b449-0a6c154b8c53)

After Fix:

[after_fix.webm](https://github.com/user-attachments/assets/5af0f336-76cb-4acd-841b-e962db769ac1)
