### PR TITLE
fix: calculate discount_amount for correct UI display

### DIFF
--- a/erpnext/accounts/doctype/pricing_rule/pricing_rule.py
+++ b/erpnext/accounts/doctype/pricing_rule/pricing_rule.py
@@ -615,6 +615,10 @@ def apply_price_discount_rule(pricing_rule, item_details, args):
 				item_details.setdefault(field, 0)
 
 			item_details[field] += pricing_rule.get(field, 0) if pricing_rule else args.get(field, 0)
+	if args.get("price_list_rate") and item_details.get("discount_percentage") is not None:
+		item_details["discount_amount"] = flt(
+			(flt(item_details.discount_percentage) / 100) * flt(args.price_list_rate)
+		)
 
 
 @frappe.whitelist()


### PR DESCRIPTION
Issue: Incorrect Discount Display on UI (Correct After Save) When Multiple Pricing Rules Apply

Previously, discount values were not showing correctly in the grid when a new item was added.
This PR resolves the issue so that the correct discount values appear immediately.

# Before
![before_full_low](https://github.com/user-attachments/assets/1b4cd5de-a089-412c-b0c1-0c6d2c9a5716)
# After
![Recording 2025-10-02 223600_low](https://github.com/user-attachments/assets/bf1ec85d-a1d2-4a4b-a282-455ef1b2b0c1)

Closes: #49564
