### PR TITLE
fix: failing patch

### DIFF
--- a/erpnext/patches/v15_0/patch_missing_buying_price_list_in_material_request.py
+++ b/erpnext/patches/v15_0/patch_missing_buying_price_list_in_material_request.py
@@ -9,10 +9,9 @@ def execute():
 		docs = frappe.get_all(
 			"Material Request", filters={"buying_price_list": ["is", "not set"], "docstatus": 1}, pluck="name"
 		)
-		old_limit = frappe.db.MAX_WRITES_PER_TRANSACTION
-		frappe.db.MAX_WRITES_PER_TRANSACTION *= 4
+		frappe.db.auto_commit_on_many_writes = 1
 		try:
 			for doc in docs:
 				frappe.db.set_value("Material Request", doc, "buying_price_list", default_buying_price_list)
 		finally:
-			frappe.db.MAX_WRITES_PER_TRANSACTION = old_limit
+			frappe.db.auto_commit_on_many_writes = 0


### PR DESCRIPTION
Fixes an issue in patch `patch_missing_buying_price_list_in_material_request.py` where if number of Material Request documents is too large, `frappe.exceptions.TooManyWrites` error is thrown.