### PR TITLE
fix: broken reference to removed 'use_new_budget_controller' field in accounts settings

### DIFF
--- a/erpnext/accounts/doctype/budget/budget.js
+++ b/erpnext/accounts/doctype/budget/budget.js
@@ -25,7 +25,7 @@ frappe.ui.form.on("Budget", {
 		erpnext.accounts.dimensions.setup_dimension_filters(frm, frm.doctype);
 		frappe.db.get_single_value("Accounts Settings", "use_legacy_budget_controller").then((value) => {
 			if (value) {
-				frm.get_field("contro1l_action_for_cumulative_expense_section").hide();
+				frm.get_field("control_action_for_cumulative_expense_section").hide();
 			}
 		});
 	},

--- a/erpnext/accounts/doctype/budget/budget.js
+++ b/erpnext/accounts/doctype/budget/budget.js
@@ -23,7 +23,7 @@ frappe.ui.form.on("Budget", {
 		});
 
 		erpnext.accounts.dimensions.setup_dimension_filters(frm, frm.doctype);
-		frappe.db.get_single_value("Accounts Settings", "use_new_budget_controller").then((value) => {
+		frappe.db.get_single_value("Accounts Settings", "use_legacy_budget_controller").then((value) => {
 			if (!value) {
 				frm.get_field("control_action_for_cumulative_expense_section").hide();
 			}

--- a/erpnext/accounts/doctype/budget/budget.js
+++ b/erpnext/accounts/doctype/budget/budget.js
@@ -24,8 +24,8 @@ frappe.ui.form.on("Budget", {
 
 		erpnext.accounts.dimensions.setup_dimension_filters(frm, frm.doctype);
 		frappe.db.get_single_value("Accounts Settings", "use_legacy_budget_controller").then((value) => {
-			if (!value) {
-				frm.get_field("control_action_for_cumulative_expense_section").hide();
+			if (value) {
+				frm.get_field("contro1l_action_for_cumulative_expense_section").hide();
 			}
 		});
 	},

--- a/erpnext/accounts/doctype/budget/test_budget.py
+++ b/erpnext/accounts/doctype/budget/test_budget.py
@@ -24,7 +24,7 @@ class TestBudget(ERPNextTestSuite):
 		cls.make_projects()
 
 	def setUp(self):
-		frappe.db.set_single_value("Accounts Settings", "use_legacy_budget_controller", True)
+		frappe.db.set_single_value("Accounts Settings", "use_legacy_budget_controller", False)
 
 	def test_monthly_budget_crossed_ignore(self):
 		set_total_expense_zero(nowdate(), "cost_center")

--- a/erpnext/accounts/doctype/budget/test_budget.py
+++ b/erpnext/accounts/doctype/budget/test_budget.py
@@ -24,7 +24,7 @@ class TestBudget(ERPNextTestSuite):
 		cls.make_projects()
 
 	def setUp(self):
-		frappe.db.set_single_value("Accounts Settings", "use_new_budget_controller", True)
+		frappe.db.set_single_value("Accounts Settings", "use_legacy_budget_controller", True)
 
 	def test_monthly_budget_crossed_ignore(self):
 		set_total_expense_zero(nowdate(), "cost_center")

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -413,7 +413,7 @@ execute:frappe.db.set_single_value("Accounts Settings", "receivable_payable_fetc
 erpnext.patches.v14_0.set_update_price_list_based_on
 erpnext.patches.v15_0.update_journal_entry_type
 erpnext.patches.v15_0.set_grand_total_to_default_mop
-execute:frappe.db.set_single_value("Accounts Settings", "use_new_budget_controller", True)
+execute:frappe.db.set_single_value("Accounts Settings", "use_legacy_budget_controller", False)
 erpnext.patches.v15_0.set_cancelled_status_to_cancelled_pos_invoice
 erpnext.patches.v15_0.rename_group_by_to_categorize_by_in_custom_reports
 erpnext.patches.v15_0.remove_agriculture_roles


### PR DESCRIPTION
<img width="848" height="379" alt="Screenshot 2025-10-03 at 4 30 58 PM" src="https://github.com/user-attachments/assets/47735435-a06c-42f1-b02e-c86eb50c629d" />
