### PR TITLE
fix: show asset value as revaluation amount or gross purchase amount

### DIFF
--- a/erpnext/assets/report/fixed_asset_register/fixed_asset_register.py
+++ b/erpnext/assets/report/fixed_asset_register/fixed_asset_register.py
@@ -268,6 +268,7 @@ def get_asset_depreciation_amount_map(filters, finance_book):
 		.where(gle.account == IfNull(aca.depreciation_expense_account, company.depreciation_expense_account))
 		.where(gle.debit != 0)
 		.where(gle.is_cancelled == 0)
+		.where(gle.is_opening == "No")
 		.where(company.name == filters.company)
 		.where(asset.docstatus == 1)
 	)


### PR DESCRIPTION
Issue: Asset value is showing incorrectly in the `Fixed Asset Register report` if paid via JV.

Steps to reproduce:

- Create an Asset with` is existing asset` enabled.
- Pay the Asset via JV for the gross purchase amount mapping the asset for the `Fixed Asset Account`
- Check `Finance Asset Register Report` asset value

Ref: [49614]( https://support.frappe.io/helpdesk/tickets/49614)

Before:

<img width="1658" height="860" alt="image" src="https://github.com/user-attachments/assets/573fd4a8-f2d9-4a8e-bf72-64bd2ee1cb47" />


After:

<img width="1659" height="851" alt="image" src="https://github.com/user-attachments/assets/5f1dd54f-f31c-4970-ab36-a90d9db9e740" />



**Backport Needed: Version-15**