### PR TITLE
fix: retain shipping address in doc

### DIFF
--- a/erpnext/public/js/controllers/buying.js
+++ b/erpnext/public/js/controllers/buying.js
@@ -177,7 +177,10 @@ erpnext.buying = {
 						this.frm.set_value("billing_address", r.message.primary_address || "");
 
 						if (!frappe.meta.has_field(this.frm.doc.doctype, "shipping_address")) return;
-						this.frm.set_value("shipping_address", r.message.shipping_address || "");
+						this.frm.set_value(
+							"shipping_address",
+							r.message.shipping_address || this.frm.doc.shipping_address || ""
+						);
 					},
 				});
 				erpnext.utils.set_letter_head(this.frm);


### PR DESCRIPTION
Issue: When making a Purchase Order from a Sales Order using drop shipping, the shipping address is not getting carried.

Ref: [#49716](https://support.frappe.io/helpdesk/tickets/49716)


Backport needed: v15