### PR TITLE
fix: remove allow_on_submit for pick list items

### DIFF
--- a/erpnext/stock/doctype/pick_list/pick_list.js
+++ b/erpnext/stock/doctype/pick_list/pick_list.js
@@ -121,7 +121,6 @@ frappe.ui.form.on("Pick List", {
 		frm.trigger("update_warehouse_property");
 		if (frm.doc.docstatus === 1) {
 			const status_completed = frm.doc.status === "Completed";
-			frm.set_df_property("locations", "allow_on_submit", status_completed ? 0 : 1);
 
 			if (!status_completed) {
 				frm.add_custom_button(__("Update Current Stock"), () =>

--- a/erpnext/stock/doctype/pick_list/pick_list.json
+++ b/erpnext/stock/doctype/pick_list/pick_list.json
@@ -77,7 +77,6 @@
    "options": "Work Order"
   },
   {
-   "allow_on_submit": 1,
    "fieldname": "locations",
    "fieldtype": "Table",
    "label": "Item Locations",
@@ -247,7 +246,7 @@
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2025-07-23 08:34:32.099673",
+ "modified": "2025-10-03 18:36:52.282355",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Pick List",


### PR DESCRIPTION
**Issue:** allow_on_submit enabled for Pick List Locations table, leads to data inconsistencies.

**Ref: [49125](https://support.frappe.io/helpdesk/tickets/49125?view=VIEW-HD+Ticket-646)**

**Before:**

[Screencast from 03-10-25 06:48:48 PM IST.webm](https://github.com/user-attachments/assets/0faf3a6e-43b8-4082-aa45-10220944eab2)

**After:**

[Screencast from 03-10-25 06:47:29 PM IST.webm](https://github.com/user-attachments/assets/b864d50e-73e9-4bb8-9697-9144ebd04c03)

**Backport Needed: v15**