### PR TITLE
fix(Common Code): fetch canonical URI from Code List

### DIFF
--- a/erpnext/edi/doctype/common_code/common_code.json
+++ b/erpnext/edi/doctype/common_code/common_code.json
@@ -6,6 +6,7 @@
  "engine": "InnoDB",
  "field_order": [
   "code_list",
+  "canonical_uri",
   "title",
   "common_code",
   "description",
@@ -71,10 +72,17 @@
    "in_list_view": 1,
    "label": "Description",
    "max_height": "60px"
+  },
+  {
+   "fetch_from": "code_list.canonical_uri",
+   "fieldname": "canonical_uri",
+   "fieldtype": "Data",
+   "label": "Canonical URI"
   }
  ],
+ "grid_page_length": 50,
  "links": [],
- "modified": "2024-11-06 07:46:17.175687",
+ "modified": "2025-10-04 17:22:28.176155",
  "modified_by": "Administrator",
  "module": "EDI",
  "name": "Common Code",
@@ -94,6 +102,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "search_fields": "common_code,description",
  "show_title_field_in_link": 1,
  "sort_field": "creation",

--- a/erpnext/edi/doctype/common_code/common_code.py
+++ b/erpnext/edi/doctype/common_code/common_code.py
@@ -22,6 +22,7 @@ class CommonCode(Document):
 
 		additional_data: DF.Code | None
 		applies_to: DF.Table[DynamicLink]
+		canonical_uri: DF.Data | None
 		code_list: DF.Link
 		common_code: DF.Data
 		description: DF.SmallText | None


### PR DESCRIPTION
Useful for filtering relevant codes, e.g. setting a query on a link field that allows codes from different code lists (technically the same, but different publishers and versions).
