### PR TITLE
fix: linter; dont change doc after DB update

### DIFF
--- a/erpnext/selling/doctype/selling_settings/selling_settings.py
+++ b/erpnext/selling/doctype/selling_settings/selling_settings.py
@@ -70,15 +70,15 @@ class SellingSettings(Document):
 		)
 
 	def toggle_hide_tax_id(self):
-		self.hide_tax_id = cint(self.hide_tax_id)
+		_hide_tax_id = cint(self.hide_tax_id)
 
 		# Make property setters to hide tax_id fields
 		for doctype in ("Sales Order", "Sales Invoice", "Delivery Note"):
 			make_property_setter(
-				doctype, "tax_id", "hidden", self.hide_tax_id, "Check", validate_fields_for_doctype=False
+				doctype, "tax_id", "hidden", _hide_tax_id, "Check", validate_fields_for_doctype=False
 			)
 			make_property_setter(
-				doctype, "tax_id", "print_hide", self.hide_tax_id, "Check", validate_fields_for_doctype=False
+				doctype, "tax_id", "print_hide", _hide_tax_id, "Check", validate_fields_for_doctype=False
 			)
 
 	def toggle_editable_rate_for_bundle_items(self):


### PR DESCRIPTION
This fix was part of https://github.com/frappe/erpnext/pull/44293, but should be backported independently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified how Selling Settings applies the “Hide Tax ID” preference across Sales Order, Sales Invoice, and Delivery Note by using a single computed value when updating form properties. No change to functionality; existing visibility settings continue to work as before. Improves consistency and reduces risk of mismatched field visibility internally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->