### PR TITLE
fix: check is_rejected attribute

### DIFF
--- a/erpnext/stock/serial_batch_bundle.py
+++ b/erpnext/stock/serial_batch_bundle.py
@@ -1247,7 +1247,7 @@ class SerialBatchCreation:
 	def create_batch(self):
 		from erpnext.stock.doctype.batch.batch import make_batch
 
-		if self.is_rejected:
+		if hasattr(self, "is_rejected") and self.is_rejected:
 			bundle = frappe.db.get_value(
 				"Serial and Batch Bundle",
 				{


### PR DESCRIPTION
**Issue:** Attribute error when creating Sales Return for Delivery Note with packed items.

**Ref: [50177](https://support.frappe.io/helpdesk/tickets/50177?view=VIEW-HD+Ticket-819)**

<img width="1920" height="932" alt="image" src="https://github.com/user-attachments/assets/ef282fa1-2a37-4ba1-9fba-eec107f6959d" />

**Backport Needed: v15**