### PR TITLE
fix: warning message if the batch has incorrect qty

### DIFF
--- a/erpnext/stock/serial_batch_bundle.py
+++ b/erpnext/stock/serial_batch_bundle.py
@@ -1389,11 +1389,12 @@ def get_batch_current_qty(batch):
 
 
 def throw_negative_batch_validation(batch_no, qty):
-	frappe.throw(
-		_("The Batch {0} has negative quantity {1}. Please correct the quantity.").format(
-			bold(batch_no), bold(qty)
-		),
-		title=_("Negative Batch Quantity"),
+	frappe.msgprint(
+		_(
+			"The Batch {0} has negative batch quantity {1}. To fix this, go to the batch and click on Recalculate Batch Qty. If the issue still persists, create an inward entry."
+		).format(bold(get_link_to_form("Batch", batch_no)), bold(qty)),
+		title=_("Warning!"),
+		indicator="orange",
 	)
 
 


### PR DESCRIPTION
Instead of error show the warning message if the batch has incorrect qty

<img width="737" height="341" alt="Screenshot 2025-10-07 at 9 47 50 AM" src="https://github.com/user-attachments/assets/62e2d123-6f76-4fc6-a88c-aa036afcdd89" />
