### PR TITLE
Feat/party specific item groups

### DIFF
--- a/erpnext/controllers/queries.py
+++ b/erpnext/controllers/queries.py
@@ -6,7 +6,7 @@ import json
 from collections import OrderedDict, defaultdict
 
 import frappe
-from frappe import qb, scrub
+from frappe import _, qb, scrub
 from frappe.desk.reportview import get_filters_cond, get_match_cond
 from frappe.permissions import has_permission
 from frappe.query_builder import Criterion, CustomFunction
@@ -212,34 +212,53 @@ def item_query(doctype, txt, searchfield, start, page_len, filters, as_dict=Fals
 			party = filters.get("customer") or filters.get("supplier")
 			party_doctype = "Customer" if filters.get("customer") else "Supplier"
 			group_field = "customer_group" if party_doctype == "Customer" else "supplier_group"
+
+			if party and not frappe.db.exists(party_doctype, party):
+				frappe.throw(_("Invalid {0}: {1}").format(party_doctype, party))
+
 			group_name = frappe.db.get_value(party_doctype, party, group_field) or None
 
 			parties_to_check = [party]
 			if group_name:
 				parties_to_check.append(group_name)
 
+			party_types = []
+			if filters.get("customer"):
+				party_types.extend(["Customer", "Customer Group"])
+			else:
+				party_types.extend(["Supplier", "Supplier Group"])
+
 			item_rules_list = frappe.get_all(
 				"Party Specific Item",
-				filters={"party": ["in", parties_to_check]},
-				fields=["restrict_based_on", "based_on_value"],
+				filters={
+					"party": ["in", parties_to_check],
+					"party_type": ["in", party_types],
+				},
+				fields=["restrict_based_on", "based_on_value", "inclusion_type"],
 			)
 
-			filters_dict = {}
+			include_filters = {}
+			exclude_filters = {}
 			for rule in item_rules_list:
 				r_based = rule["restrict_based_on"]
 				if r_based == "Item":
 					r_based = "name"
-				if r_based not in filters_dict:
-					filters_dict[r_based] = []
 
-			for rule in item_rules_list:
-				r_based = rule["restrict_based_on"]
-				if r_based == "Item":
-					r_based = "name"
-				filters_dict[r_based].append(rule["based_on_value"])
+				if (rule.get("inclusion_type") or "Inclusive") == "Exclusive":
+					exclude_filters.setdefault(r_based, []).append(rule["based_on_value"])
+				else:
+					include_filters.setdefault(r_based, []).append(rule["based_on_value"])
 
-			for filter in filters_dict:
-				filters[scrub(filter)] = ["in", filters_dict[filter]]
+			for d in (include_filters, exclude_filters):
+				for k, v in list(d.items()):
+					d[k] = list(dict.fromkeys(v))
+
+			for r_based, values in include_filters.items():
+				filters[scrub(r_based)] = ["in", values]
+
+			for r_based, values in exclude_filters.items():
+				if r_based not in include_filters:
+					filters[scrub(r_based)] = ["not in", values]
 
 			if filters.get("customer"):
 				del filters["customer"]

--- a/erpnext/controllers/queries.py
+++ b/erpnext/controllers/queries.py
@@ -210,20 +210,33 @@ def item_query(doctype, txt, searchfield, start, page_len, filters, as_dict=Fals
 	if filters and isinstance(filters, dict):
 		if filters.get("customer") or filters.get("supplier"):
 			party = filters.get("customer") or filters.get("supplier")
+			party_doctype = "Customer" if filters.get("customer") else "Supplier"
+			group_field = "customer_group" if party_doctype == "Customer" else "supplier_group"
+			group_name = frappe.db.get_value(party_doctype, party, group_field) or None
+
+			parties_to_check = [party]
+			if group_name:
+				parties_to_check.append(group_name)
+
 			item_rules_list = frappe.get_all(
 				"Party Specific Item",
-				filters={"party": party},
+				filters={"party": ["in", parties_to_check]},
 				fields=["restrict_based_on", "based_on_value"],
 			)
 
 			filters_dict = {}
 			for rule in item_rules_list:
-				if rule["restrict_based_on"] == "Item":
-					rule["restrict_based_on"] = "name"
-				filters_dict[rule.restrict_based_on] = []
+				r_based = rule["restrict_based_on"]
+				if r_based == "Item":
+					r_based = "name"
+				if r_based not in filters_dict:
+					filters_dict[r_based] = []
 
 			for rule in item_rules_list:
-				filters_dict[rule.restrict_based_on].append(rule.based_on_value)
+				r_based = rule["restrict_based_on"]
+				if r_based == "Item":
+					r_based = "name"
+				filters_dict[r_based].append(rule["based_on_value"])
 
 			for filter in filters_dict:
 				filters[scrub(filter)] = ["in", filters_dict[filter]]
@@ -238,7 +251,6 @@ def item_query(doctype, txt, searchfield, start, page_len, filters, as_dict=Fals
 
 	description_cond = ""
 	if frappe.db.estimate_count(doctype) < 50000:
-		# scan description only if items are less than 50000
 		description_cond = "or tabItem.description LIKE %(txt)s"
 
 	return frappe.db.sql(

--- a/erpnext/selling/doctype/party_specific_item/party_specific_item.json
+++ b/erpnext/selling/doctype/party_specific_item/party_specific_item.json
@@ -8,9 +8,10 @@
  "field_order": [
   "party_type",
   "party",
-  "column_break_3",
+  "column_break_syzu",
   "restrict_based_on",
-  "based_on_value"
+  "based_on_value",
+  "inclusion_type"
  ],
  "fields": [
   {
@@ -38,21 +39,28 @@
    "reqd": 1
   },
   {
-   "fieldname": "column_break_3",
-   "fieldtype": "Column Break"
-  },
-  {
    "fieldname": "based_on_value",
    "fieldtype": "Dynamic Link",
    "in_list_view": 1,
    "label": "Based On Value",
    "options": "restrict_based_on",
    "reqd": 1
+  },
+  {
+   "fieldname": "inclusion_type",
+   "fieldtype": "Select",
+   "label": "Inclusion Type",
+   "options": "Inclusive\nExclusive",
+   "reqd": 1
+  },
+  {
+   "fieldname": "column_break_syzu",
+   "fieldtype": "Column Break"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-10-01 14:52:57.939916",
+ "modified": "2025-10-03 13:31:49.490973",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Party Specific Item",

--- a/erpnext/selling/doctype/party_specific_item/party_specific_item.json
+++ b/erpnext/selling/doctype/party_specific_item/party_specific_item.json
@@ -17,15 +17,15 @@
    "fieldname": "party_type",
    "fieldtype": "Select",
    "in_list_view": 1,
-   "label": "Party Type",
-   "options": "Customer\nSupplier",
+   "label": "Party / Group Type",
+   "options": "Customer\nCustomer Group\nSupplier\nSupplier Group",
    "reqd": 1
   },
   {
    "fieldname": "party",
    "fieldtype": "Dynamic Link",
    "in_list_view": 1,
-   "label": "Party Name",
+   "label": "Party / Group Name",
    "options": "party_type",
    "reqd": 1
   },
@@ -52,7 +52,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-03-27 13:10:08.752476",
+ "modified": "2025-10-01 14:52:57.939916",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Party Specific Item",
@@ -71,6 +71,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],

--- a/erpnext/selling/doctype/party_specific_item/party_specific_item.json
+++ b/erpnext/selling/doctype/party_specific_item/party_specific_item.json
@@ -50,8 +50,7 @@
    "fieldname": "inclusion_type",
    "fieldtype": "Select",
    "label": "Inclusion Type",
-   "options": "Inclusive\nExclusive",
-   "reqd": 1
+   "options": "Inclusive\nExclusive"
   },
   {
    "fieldname": "column_break_syzu",
@@ -60,7 +59,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-10-03 13:31:49.490973",
+ "modified": "2025-10-07 12:52:25.146368",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Party Specific Item",

--- a/erpnext/selling/doctype/party_specific_item/party_specific_item.py
+++ b/erpnext/selling/doctype/party_specific_item/party_specific_item.py
@@ -17,7 +17,7 @@ class PartySpecificItem(Document):
 
 		based_on_value: DF.DynamicLink
 		party: DF.DynamicLink
-		party_type: DF.Literal["Customer", "Supplier"]
+		party_type: DF.Literal["Customer", "Customer Group", "Supplier", "Supplier Group"]
 		restrict_based_on: DF.Literal["Item", "Item Group", "Brand"]
 	# end: auto-generated types
 

--- a/erpnext/selling/doctype/party_specific_item/party_specific_item.py
+++ b/erpnext/selling/doctype/party_specific_item/party_specific_item.py
@@ -16,6 +16,7 @@ class PartySpecificItem(Document):
 		from frappe.types import DF
 
 		based_on_value: DF.DynamicLink
+		inclusion_type: DF.Literal["Inclusive", "Exclusive"]
 		party: DF.DynamicLink
 		party_type: DF.Literal["Customer", "Customer Group", "Supplier", "Supplier Group"]
 		restrict_based_on: DF.Literal["Item", "Item Group", "Brand"]
@@ -29,6 +30,7 @@ class PartySpecificItem(Document):
 				"party": self.party,
 				"restrict_based_on": self.restrict_based_on,
 				"based_on_value": self.based_on_value,
+				"inclusion_type": self.inclusion_type,
 			},
 		)
 		if exists:


### PR DESCRIPTION
**Issue :** The Party Specific Item doctype supports only individual Customers/Suppliers, not Customer or Supplier Groups.
It allows only inclusion rules, making bulk exclusions inefficient.

**Issue Ref : #49795** 

**Before :**

<img width="1333" height="332" alt="before" src="https://github.com/user-attachments/assets/539f87fc-11b2-49f6-bd40-5553bc2f1218" />

**After:**

https://github.com/user-attachments/assets/ee59f06d-92aa-43b6-a741-5f8c31d09e4f



