### PR TITLE
fix: preserve address if present

### DIFF
--- a/erpnext/public/js/controllers/buying.js
+++ b/erpnext/public/js/controllers/buying.js
@@ -174,13 +174,15 @@ erpnext.buying = {
 						shipping_address: this.frm.doc.shipping_address,
 					},
 					callback: (r) => {
-						this.frm.set_value("billing_address", r.message.primary_address || "");
+						if (!this.frm.doc.billing_address)
+							this.frm.set_value("billing_address", r.message.primary_address || "");
 
-						if (!frappe.meta.has_field(this.frm.doc.doctype, "shipping_address")) return;
-						this.frm.set_value(
-							"shipping_address",
-							r.message.shipping_address || this.frm.doc.shipping_address || ""
-						);
+						if (
+							!frappe.meta.has_field(this.frm.doc.doctype, "shipping_address") ||
+							this.frm.doc.shipping_address
+						)
+							return;
+						this.frm.set_value("shipping_address", r.message.shipping_address || "");
 					},
 				});
 				erpnext.utils.set_letter_head(this.frm);

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -1170,7 +1170,8 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 
 		if (
 			frappe.meta.get_docfield(this.frm.doctype, "shipping_address") &&
-			["Purchase Order", "Purchase Receipt", "Purchase Invoice"].includes(this.frm.doctype)
+			["Purchase Order", "Purchase Receipt", "Purchase Invoice"].includes(this.frm.doctype) &&
+			!this.frm.doc.shipping_address
 		) {
 			let is_drop_ship = me.frm.doc.items.some((item) => item.delivered_by_supplier);
 


### PR DESCRIPTION
**Issue**
  
There’s an issue when a company has a preferred shipping and billing address, and a Purchase Order is created using a different shipping address. When the Purchase Receipt is created from that Purchase Order, the shipping address correctly remains the same as in the Purchase Order. However, when a Purchase Invoice is created from the Purchase Receipt, the billing address automatically changes back to the company’s preferred billing address instead of retaining the one used in the Purchase Order.

Ref: [50181](https://support.frappe.io/helpdesk/tickets/50181)

Before:


https://github.com/user-attachments/assets/5cc2c2aa-f13e-4446-945e-b4591ed709bf

After:


https://github.com/user-attachments/assets/6e3aea14-7e57-4a1e-b18a-6b890f0cdf20







Backport needed: v15