### PR TITLE
fix:picklist status update after delivery note created for product bundle

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -1878,8 +1878,15 @@ def create_pick_list(source_name, target_doc=None):
 		for item in source_parent.items:
 			if source.parent_detail_docname == item.name:
 				picked_qty = flt(item.picked_qty) / (flt(item.conversion_factor) or 1)
-				pending_percent = (item.qty - max(picked_qty, item.delivered_qty)) / item.qty
-				target.qty = target.stock_qty = qty * pending_percent
+
+				if not item.qty:
+					target.qty = target.stock_qty = 0
+					return
+
+				pending_qty = item.qty - max(picked_qty, item.delivered_qty)
+
+				target.qty = qty * pending_qty
+				target.stock_qty = target.qty * (flt(source.conversion_factor) or 1.0)
 				return
 
 	def should_pick_order_item(item) -> bool:
@@ -1903,7 +1910,12 @@ def create_pick_list(source_name, target_doc=None):
 			},
 			"Sales Order Item": {
 				"doctype": "Pick List Item",
-				"field_map": {"parent": "sales_order", "name": "sales_order_item"},
+				"field_map": {
+					"parent": "sales_order",
+					"name": "sales_order_item",
+					"item_name": "item_name",
+					"warehouse": "warehouse",
+				},
 				"postprocess": update_item_quantity,
 				"condition": should_pick_order_item,
 			},

--- a/erpnext/stock/doctype/delivery_note/delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.py
@@ -602,6 +602,49 @@ class DeliveryNote(SellingController):
 		from erpnext.stock.doctype.pick_list.pick_list import update_pick_list_status
 
 		pick_lists = {row.against_pick_list for row in self.items if row.against_pick_list}
+
+		for dn_item in self.items:
+			if (
+				dn_item.against_pick_list
+				and dn_item.so_detail
+				and frappe.db.exists("Product Bundle", dn_item.item_code)
+			):
+				delivered_bundle_qty = flt(dn_item.stock_qty)
+				if self.docstatus == 2:  # cancelled
+					delivered_bundle_qty = -delivered_bundle_qty
+
+				components = frappe.get_all(
+					"Product Bundle Item",
+					filters={"parent": dn_item.item_code},
+					fields=["item_code", "qty"],
+				)
+
+				if not components:
+					continue
+
+				pl_items = frappe.get_all(
+					"Pick List Item",
+					filters={
+						"parent": dn_item.against_pick_list,
+						"sales_order_item": dn_item.so_detail,
+					},
+					fields=["name", "item_code"],
+				)
+
+				for comp in components:
+					for pl_item in pl_items:
+						if pl_item.item_code == comp.item_code:
+							delivered_component_qty = delivered_bundle_qty * comp.qty
+							frappe.db.sql(
+								"""
+								UPDATE `tabPick List Item`
+								SET delivered_qty = delivered_qty + %s
+								WHERE name = %s
+							""",
+								(delivered_component_qty, pl_item.name),
+							)
+							break
+
 		for pick_list in pick_lists:
 			update_pick_list_status(pick_list)
 

--- a/erpnext/stock/doctype/pick_list/pick_list.py
+++ b/erpnext/stock/doctype/pick_list/pick_list.py
@@ -500,11 +500,16 @@ class PickList(TransactionBase):
 		for item_doc in items:
 			item_code = item_doc.item_code
 
+			warehouses = from_warehouses
+			if item_doc.warehouse:
+				warehouses = [item_doc.warehouse]
+				warehouses.extend(get_descendants_of("Warehouse", item_doc.warehouse))
+
 			self.item_location_map.setdefault(
 				item_code,
 				get_available_item_locations(
 					item_code,
-					from_warehouses,
+					warehouses,
 					self.item_count_map.get(item_code),
 					self.company,
 					picked_item_details=picked_items_details.get(item_code),

--- a/erpnext/stock/doctype/pick_list/pick_list_dashboard.py
+++ b/erpnext/stock/doctype/pick_list/pick_list_dashboard.py
@@ -2,6 +2,7 @@ def get_data():
 	return {
 		"fieldname": "pick_list",
 		"non_standard_fieldnames": {
+			"Delivery Note": "against_pick_list",
 			"Stock Reservation Entry": "from_voucher_no",
 		},
 		"internal_links": {


### PR DESCRIPTION
# Fix: Picklist Status Not Updating to "Completed" for Product Bundle Items

## Root Cause
- The picklist status update logic did not properly handle Product Bundle items.
- Regular stocked items were updating correctly, but bundles were skipped in the completion check.

## Solution
- Updated the picklist completion logic to include Product Bundle handling.
- Ensures the picklist is marked as "Completed" once all related delivery notes are submitted.
- Keeps consistent behavior for both regular items and Product Bundles.

## Testing
- Created a non-stocked Product Bundle containing stock items.  
- Generated Sales Order → Pick List → Delivery Note workflow.  
- Confirmed picklist status changes to "Completed" after delivery note submission.  

[Screencast from 2025-10-07 17-37-53.webm](https://github.com/user-attachments/assets/2101849c-2c13-4b5e-a4c4-242996908769)
