### PR TITLE
fix(asset movement): clear custodian if not present

### DIFF
--- a/erpnext/assets/doctype/asset_movement/asset_movement.py
+++ b/erpnext/assets/doctype/asset_movement/asset_movement.py
@@ -5,7 +5,7 @@
 import frappe
 from frappe import _
 from frappe.model.document import Document
-from frappe.utils import get_link_to_form
+from frappe.utils import cstr, get_link_to_form
 
 from erpnext.assets.doctype.asset_activity.asset_activity import add_asset_activity
 
@@ -143,8 +143,8 @@ class AssetMovement(Document):
 	def update_asset_location_and_custodian(self, asset_id, location, employee):
 		asset = frappe.get_doc("Asset", asset_id)
 
-		if employee and employee != asset.custodian:
-			frappe.db.set_value("Asset", asset_id, "custodian", employee)
+		if cstr(employee) != asset.custodian:
+			frappe.db.set_value("Asset", asset_id, "custodian", cstr(employee))
 		if location and location != asset.location:
 			frappe.db.set_value("Asset", asset_id, "location", location)
 


### PR DESCRIPTION
**Issue**
  
When an asset is first assigned to an employee and later an Asset Movement is created with the purpose `Receipt` to move it to a different location, the Custodian field is set to None. However, when submitting the Asset Movement, the previous custodian remains instead of being cleared. As a result, if the same asset is later issued to another employee through a new Asset Movement, the old custodian information is still displayed.


Ref: [50380](https://support.frappe.io/helpdesk/tickets/50380)

Before:


https://github.com/user-attachments/assets/186a10d2-c82f-4011-b9a6-546e3992a640



After:



https://github.com/user-attachments/assets/735b2864-9eb5-43da-9830-5718dd389ea5








Backport needed: v15