### PR TITLE
fix: process statement of accounts

### DIFF
--- a/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.html
+++ b/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.html
@@ -13,7 +13,7 @@
 		</div>
 		{% endif %}
 	</div>
-	<h2 class="text-center">{{ _("STATEMENT OF ACCOUNTS") }}</h2>
+	<h2 class="text-center">{{ _("GENERAL LEDGER") }}</h2>
 	<div>
 		{% if filters.party[0] == filters.party_name[0] %}
 			<h5 style="float: left;">{{ _("Customer: ") }} <b>{{ filters.party_name[0] }}</b></h5>

--- a/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.json
+++ b/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.json
@@ -70,7 +70,7 @@
    "fieldname": "frequency",
    "fieldtype": "Select",
    "label": "Frequency",
-   "options": "Weekly\nMonthly\nQuarterly"
+   "options": "Daily\nWeekly\nBiweekly\nMonthly\nQuarterly"
   },
   {
    "fieldname": "company",
@@ -417,7 +417,7 @@
   }
  ],
  "links": [],
- "modified": "2025-10-07 11:17:05.444394",
+ "modified": "2025-10-07 12:19:20.719898",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Process Statement Of Accounts",

--- a/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.json
+++ b/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.json
@@ -1,5 +1,6 @@
 {
  "actions": [],
+ "allow_rename": 1,
  "autoname": "Prompt",
  "creation": "2020-05-22 16:46:18.712954",
  "doctype": "DocType",
@@ -416,7 +417,7 @@
   }
  ],
  "links": [],
- "modified": "2025-09-03 14:24:43.608565",
+ "modified": "2025-10-07 11:17:05.444394",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Process Statement Of Accounts",

--- a/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.py
+++ b/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.py
@@ -8,7 +8,7 @@ import frappe
 from frappe import _
 from frappe.desk.reportview import get_match_cond
 from frappe.model.document import Document
-from frappe.utils import add_days, add_months, format_date, getdate, today
+from frappe.utils import add_days, add_months, add_to_date, format_date, getdate, today
 from frappe.utils.jinja import validate_template
 from frappe.utils.pdf import get_pdf
 from frappe.www.printview import get_print_style
@@ -55,7 +55,7 @@ class ProcessStatementOfAccounts(Document):
 		enable_auto_email: DF.Check
 		filter_duration: DF.Int
 		finance_book: DF.Link | None
-		frequency: DF.Literal["Weekly", "Monthly", "Quarterly"]
+		frequency: DF.Literal["Daily", "Weekly", "Biweekly", "Monthly", "Quarterly"]
 		from_date: DF.Date | None
 		ignore_cr_dr_notes: DF.Check
 		ignore_exchange_rate_revaluation_journals: DF.Check
@@ -555,8 +555,9 @@ def send_emails(document_name, from_scheduler=False, posting_date=None):
 
 		if doc.enable_auto_email and from_scheduler:
 			new_to_date = getdate(posting_date or today())
-			if doc.frequency == "Weekly":
-				new_to_date = add_days(new_to_date, 7)
+			if doc.frequency in ("Daily", "Weekly", "Biweekly"):
+				frequency = {"Daily": 1, "Weekly": 7, "Biweekly": 14}
+				new_to_date = add_days(new_to_date, frequency[doc.frequency])
 			else:
 				new_to_date = add_months(new_to_date, 1 if doc.frequency == "Monthly" else 3)
 			new_from_date = add_months(new_to_date, -1 * doc.filter_duration)

--- a/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html
+++ b/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html
@@ -23,7 +23,7 @@
 	{% endif %}
 </div>
 
-<h2 class="text-center" style="margin-top:0">{{ _(report.report_name) }}</h2>
+<h2 class="text-center" style="margin-top:0">{{ _("STATEMENT OF ACCOUNTS") }}</h2>
 <h4 class="text-center">
 	{{ filters.customer_name }}
 </h4>


### PR DESCRIPTION
Changes include:

- Renaming of the Process Statement of Accounts documents is allowed.

<img width="2420" height="788" alt="image" src="https://github.com/user-attachments/assets/d5dc30e2-1eab-430f-8996-8f76c2219fc9" />

- Added "Daily" and "Biweekly" frequency for "Enable Auto Email".

<img width="908" height="670" alt="image" src="https://github.com/user-attachments/assets/0752fa3a-11b5-4bf4-89cf-4f15d299277b" />

- Updated the headings of the reports. The General Ledger Report now has the heading "General Ledger," while the "Accounts Receivable" report has been renamed to "Statement of Accounts."