### PR TITLE
fix: remove mandatory in LCV items description

### DIFF
--- a/erpnext/stock/doctype/landed_cost_item/landed_cost_item.json
+++ b/erpnext/stock/doctype/landed_cost_item/landed_cost_item.json
@@ -42,7 +42,6 @@
    "oldfieldtype": "Data",
    "print_width": "300px",
    "read_only": 1,
-   "reqd": 1,
    "width": "120px"
   },
   {
@@ -145,7 +144,7 @@
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-06-11 08:53:38.096761",
+ "modified": "",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Landed Cost Item",

--- a/erpnext/stock/doctype/landed_cost_item/landed_cost_item.py
+++ b/erpnext/stock/doctype/landed_cost_item/landed_cost_item.py
@@ -17,7 +17,7 @@ class LandedCostItem(Document):
 		amount: DF.Currency
 		applicable_charges: DF.Currency
 		cost_center: DF.Link | None
-		description: DF.TextEditor
+		description: DF.TextEditor | None
 		is_fixed_asset: DF.Check
 		item_code: DF.Link
 		parent: DF.Data


### PR DESCRIPTION
Issue : description field is mandatory for items table in LCV, even though it is not in Purchase Receipt Item nor in item master.

Fix : Remove mandatory for description in the LCV items table.

Before :

<img width="1912" height="1011" alt="Screenshot from 2025-10-08 12-19-03" src="https://github.com/user-attachments/assets/48ce5098-8b9d-4aff-a1b3-db20e23537e0" />



After :

<img width="1912" height="1011" alt="Screenshot from 2025-10-08 12-28-41" src="https://github.com/user-attachments/assets/6b490f40-4107-4401-8066-589161f41456" />


Backport needed : V14 , V15
