### PR TITLE
Fix/Support 50220

### DIFF
--- a/erpnext/manufacturing/doctype/production_plan/production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.py
@@ -1927,7 +1927,7 @@ def get_reserved_qty_for_production_plan(item_code, warehouse):
 		frappe.qb.from_(table)
 		.inner_join(child)
 		.on(table.name == child.parent)
-		.select(Sum(child.required_bom_qty))
+		.select(Sum(child.quantity))
 		.where(
 			(table.docstatus == 1)
 			& (child.item_code == item_code)

--- a/erpnext/manufacturing/doctype/production_plan/production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.py
@@ -965,6 +965,7 @@ class ProductionPlan(Document):
 					if material_request_type == "Material Transfer"
 					else None,
 					"qty": item.quantity - item.requested_qty,
+					"uom": item.uom,
 					"schedule_date": schedule_date,
 					"warehouse": item.warehouse,
 					"sales_order": item.sales_order,
@@ -1927,7 +1928,7 @@ def get_reserved_qty_for_production_plan(item_code, warehouse):
 		frappe.qb.from_(table)
 		.inner_join(child)
 		.on(table.name == child.parent)
-		.select(Sum(child.quantity))
+		.select(Sum(child.quantity * child.conversion_factor))
 		.where(
 			(table.docstatus == 1)
 			& (child.item_code == item_code)

--- a/erpnext/manufacturing/doctype/production_plan/test_production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/test_production_plan.py
@@ -1256,7 +1256,6 @@ class TestProductionPlan(IntegrationTestCase):
 		after_qty = flt(frappe.db.get_value("Bin", bin_name, "reserved_qty_for_production_plan"))
 
 		self.assertEqual(after_qty, before_qty)
-
 		completed_plans = get_non_completed_production_plans()
 		for plan in plans:
 			self.assertFalse(plan in completed_plans)


### PR DESCRIPTION
**Issue:** When consuming raw materials in a production plan, the system updates the `reserved_qty` and `projected_qty` based on the BOM required quantity. This causes a mismatch in future production plan calculations.

**Steps to Reproduce:**
- Create a production plan and fetch the raw materials.
- Split the required quantity among three different material request types for the same item.
- The required quantity as per the BOM is 100, but you split it into three separate rows.
- When the production plan is submitted, the system updates the projected and reserved quantity as the sum of the BOM required quantities — resulting in 300 instead of 100.

**Ref: [50220](https://support.frappe.io/helpdesk/tickets/50220?view=VIEW-HD+Ticket-850)**

**Backport Needed: v15**