### PR TITLE
fix: batch qty for expired batches

### DIFF
--- a/erpnext/stock/doctype/batch/batch.py
+++ b/erpnext/stock/doctype/batch/batch.py
@@ -158,7 +158,7 @@ class Batch(Document):
 
 	@frappe.whitelist()
 	def recalculate_batch_qty(self):
-		batches = get_batch_qty(batch_no=self.name, item_code=self.item)
+		batches = get_batch_qty(batch_no=self.name, item_code=self.item, for_stock_levels=True)
 		batch_qty = 0.0
 		if batches:
 			for row in batches:


### PR DESCRIPTION
Batch qty set as zero on click of Recalculate Batch Qty
<img width="809" height="299" alt="image" src="https://github.com/user-attachments/assets/09cd19e1-5790-4127-aa4e-331d3b6d7135" />
