### PR TITLE
fix: Reset Raw Materials Table button not working

### DIFF
--- a/erpnext/controllers/subcontracting_controller.py
+++ b/erpnext/controllers/subcontracting_controller.py
@@ -202,6 +202,9 @@ class SubcontractingController(StockController):
 			self.set(self.raw_material_table, [])
 			return
 
+		if not self.get(self.raw_material_table):
+			return
+
 		item_dict = self.__get_data_before_save()
 		if not item_dict:
 			return True
@@ -656,6 +659,9 @@ class SubcontractingController(StockController):
 	def set_batch_for_supplied_items(self):
 		from erpnext.stock.doctype.serial_no.serial_no import get_serial_nos_for_outward
 		from erpnext.stock.get_item_details import get_filtered_serial_nos
+
+		if self.is_return:
+			return
 
 		for row in self.supplied_items:
 			item_details = frappe.get_cached_value(

--- a/erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.js
+++ b/erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.js
@@ -336,6 +336,10 @@ frappe.ui.form.on("Subcontracting Receipt", {
 
 	reset_raw_materials_table: (frm) => {
 		frm.clear_table("supplied_items");
+		frm.doc.__unsaved = true;
+		if (!frm.doc.set_posting_time) {
+			frm.set_value("posting_time", frappe.datetime.now_time());
+		}
 
 		frm.call({
 			method: "reset_raw_materials",

--- a/erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.json
+++ b/erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.json
@@ -649,6 +649,7 @@
    "label": "Raw Materials Actions"
   },
   {
+   "description": "Click this button if you encounter a negative stock error for a serial or batch item. The system will fetch the available serials or batches automatically.",
    "fieldname": "reset_raw_materials_table",
    "fieldtype": "Button",
    "label": "Reset Raw Materials Table"
@@ -678,7 +679,7 @@
  "in_create": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-12-06 15:24:38.384232",
+ "modified": "2025-10-08 21:43:27.065640",
  "modified_by": "Administrator",
  "module": "Subcontracting",
  "name": "Subcontracting Receipt",
@@ -739,6 +740,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "search_fields": "status, posting_date, supplier",
  "show_name_in_global_search": 1,
  "sort_field": "creation",


### PR DESCRIPTION
Reset Raw Materials Table button not working in the subcontracting receipt