### PR TITLE
fix: ensure the company address belongs to the selected company

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -303,6 +303,7 @@ class AccountsController(TransactionBase):
 		self.set_default_letter_head()
 		self.validate_company_in_accounting_dimension()
 		self.validate_party_address_and_contact()
+		self.validate_company_address()
 
 	def set_default_letter_head(self):
 		if hasattr(self, "letter_head") and not self.letter_head:
@@ -474,7 +475,6 @@ class AccountsController(TransactionBase):
 
 	def validate_party_address_and_contact(self):
 		party_type, party = self.get_party()
-
 		if not (party_type and party):
 			return
 
@@ -2328,6 +2328,29 @@ class AccountsController(TransactionBase):
 
 		return party_type, party
 
+	def get_company_address(self):
+		field = None
+		if self.doctype in ("Quotation", "Sales Order", "Delivery Note", "Sales Invoice"):
+			field = "company_address"
+
+		elif self.doctype in (
+			"Supplier Quotation",
+			"Purchase Order",
+			"Purchase Receipt",
+			"Purchase Invoice",
+		):
+			field = "billing_address"
+
+		elif self.meta.get_field("customer"):
+			field = "company_address"
+
+		elif self.meta.get_field("supplier"):
+			field = "billing_address"
+
+		address = self.get(field.lower()) if field else None
+
+		return address
+
 	def validate_currency(self):
 		if self.get("currency"):
 			party_type, party = self.get_party()
@@ -2932,6 +2955,19 @@ class AccountsController(TransactionBase):
 		for x in gl_entries:
 			x["transaction_currency"] = self.currency
 			x["transaction_exchange_rate"] = self.get("conversion_rate") or 1
+
+	def validate_company_address(self):
+		company_address = self.get_company_address()
+		if company_address and not frappe.db.exists(
+			{
+				"doctype": "Dynamic Link",
+				"parent": company_address,
+				"parenttype": "Address",
+				"link_doctype": "Company",
+				"link_name": self.company,
+			}
+		):
+			frappe.throw("The selected Company Address does not belong to the selected Company.")
 
 
 @frappe.whitelist()

--- a/erpnext/controllers/tests/test_accounts_controller.py
+++ b/erpnext/controllers/tests/test_accounts_controller.py
@@ -2228,6 +2228,12 @@ class TestAccountsController(IntegrationTestCase):
 		supplier_shipping.append("links", {"link_doctype": "Supplier", "link_name": "_Test Supplier"})
 		supplier_shipping.save()
 
+		company_address = make_address(
+			address_title="test", address_type="Billing", address_line1="100", city="Mumbai"
+		)
+		company_address.append("links", {"link_doctype": "User", "link_name": "Administrator"})
+		company_address.save()
+
 		si = create_sales_invoice(do_not_save=True)
 		si.customer_address = supplier_billing.name
 		self.assertRaises(frappe.ValidationError, si.save)
@@ -2245,6 +2251,26 @@ class TestAccountsController(IntegrationTestCase):
 		self.assertRaises(frappe.ValidationError, pi.save)
 		pi.supplier_address = supplier_shipping.name
 		pi.save()
+
+		from erpnext.selling.doctype.sales_order.test_sales_order import make_sales_order
+
+		so = make_sales_order(do_not_save=True)
+		so.company_address = company_address.name
+		self.assertRaises(frappe.ValidationError, so.save)
+
+		si = create_sales_invoice(do_not_save=True)
+		si.company_address = company_address.name
+		self.assertRaises(frappe.ValidationError, si.save)
+
+		pi = make_purchase_invoice(do_not_save=True)
+		pi.billing_address = company_address.name
+		self.assertRaises(frappe.ValidationError, pi.save)
+
+		from erpnext.buying.doctype.purchase_order.test_purchase_order import create_purchase_order
+
+		po = create_purchase_order(do_not_save=True)
+		po.billing_address = company_address.name
+		self.assertRaises(frappe.ValidationError, po.save)
 
 	def test_party_contact(self):
 		from frappe.contacts.doctype.contact.test_contact import create_contact


### PR DESCRIPTION
**REF**: [48385](https://github.com/frappe/erpnext/issues/48385)

**issue:** Creating a Sales order/Quotation/Purchase Order that has address different from selected company



**fix:** Added a validation to ensure that the selected Company Address is linked to the same Company


**before:**

[Before_validation.webm](https://github.com/user-attachments/assets/f34f5728-67a2-4bfe-93f3-9bdb607027fc)



**after:**

[After_validation.webm](https://github.com/user-attachments/assets/f390c981-762f-4f8c-8b32-d4bb70ea9a86)
