### PR TITLE
fix: format workstation link correctly

### DIFF
--- a/erpnext/public/js/templates/visual_plant_floor_template.html
+++ b/erpnext/public/js/templates/visual_plant_floor_template.html
@@ -5,7 +5,7 @@
 				<span class="workstation-status-title" style="font-size:10px">{{row.status}}</span>
 			</span>
 		</div>
-		<div class="workstation-image {{row.workstation_off}}" onclick="location.href='{{row.workstation_link}}'">
+		<div class="workstation-image {{row.workstation_off}}" onclick="location.href='{{ frappe.utils.get_form_link('Workstation', row.name)}}'">
 			<div class="workstation-image-container flex items-center justify-center h-32 border-b-grey text-6xl text-grey-100">
 				{% if(row.status_image) { %}
 					<img class="workstation-image-cls" src="{{row.status_image}}">


### PR DESCRIPTION
Video

https://github.com/user-attachments/assets/23de8f04-0378-47e5-9f18-dad41c42413c


Closes https://github.com/frappe/frappe/issues/32332

`no-docs`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed navigation from Visual Plant Floor: clicking a workstation image now consistently opens the correct Workstation record via the standard in-app route, preventing broken or outdated links.
  * Improves compatibility with role-based access and deep links, with no visual changes to the template.
  * Users should experience smoother, more predictable behavior when drilling into details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->