### PR TITLE
fix: fixed asset register showing opening entries

### DIFF
--- a/erpnext/assets/report/fixed_asset_register/fixed_asset_register.py
+++ b/erpnext/assets/report/fixed_asset_register/fixed_asset_register.py
@@ -319,6 +319,7 @@ def get_asset_value_adjustment_map(filters, finance_book):
 		.select(asset.name.as_("asset"), Sum(gle.debit - gle.credit).as_("adjustment_amount"))
 		.where(gle.account == aca.fixed_asset_account)
 		.where(gle.is_cancelled == 0)
+		.where(gle.is_opening == "No")
 		.where(company.name == filters.company)
 		.where(asset.docstatus == 1)
 	)


### PR DESCRIPTION
Issue:
When an existing asset is created with a value of ₹1000, and an opening journal entry of ₹1000 is also made against the Fixed Asset account, the Fixed Asset Register incorrectly shows the total asset value as ₹2000 instead of ₹1000.

Ref: [#49614](https://support.frappe.io/helpdesk/tickets/49614)

Before:

<img width="1792" height="1120" alt="Screenshot 2025-10-09 at 1 59 44 PM" src="https://github.com/user-attachments/assets/f7fe65d1-1e75-45fa-9e6e-84c66398aa98" />

After:

<img width="1792" height="1120" alt="Screenshot 2025-10-09 at 1 59 21 PM" src="https://github.com/user-attachments/assets/efda8a71-c0b9-49ef-af9a-df03e3f14c09" />

Backport needed: v15
