### PR TITLE
fix(pricing rule): pricing rule not applied correctly

### DIFF
--- a/erpnext/accounts/doctype/pricing_rule/test_pricing_rule.py
+++ b/erpnext/accounts/doctype/pricing_rule/test_pricing_rule.py
@@ -1521,6 +1521,55 @@ class TestPricingRule(IntegrationTestCase):
 		debit_note.delete()
 		pi.cancel()
 
+	def test_item_group_rule_with_multiple_rules_present(self):
+		frappe.delete_doc_if_exists("Pricing Rule", "_Test Pricing Rule for Item Group")
+		frappe.delete_doc_if_exists("Pricing Rule", "_Test Pricing Rule")
+
+		pr1_dict = {
+			"doctype": "Pricing Rule",
+			"title": "_Test Pricing Rule",
+			"apply_on": "Item Code",
+			"items": [
+				{
+					"item_code": "_Test Item",
+				}
+			],
+			"selling": 1,
+			"currency": "INR",
+			"discount_percentage": 10,
+			"margin_type": "Percentage",
+			"rate_or_discount": "Discount Percentage",
+			"min_qty": 10,
+			"max_qty": 15,
+			"company": "_Test Company",
+		}
+		pr1 = frappe.get_doc(pr1_dict)
+		pr1.insert()
+
+		pr2_dict = {
+			"doctype": "Pricing Rule",
+			"title": "_Test discount on item group",
+			"apply_on": "Item Group",
+			"item_groups": [
+				{
+					"item_group": "All Item Groups",
+				}
+			],
+			"selling": 1,
+			"currency": "INR",
+			"discount_percentage": 5,
+			"margin_type": "Percentage",
+			"rate_or_discount": "Discount Percentage",
+			"min_qty": 5,
+			"max_qty": 10,
+			"company": "_Test Company",
+		}
+		pr2 = frappe.get_doc(pr2_dict)
+		pr2.insert()
+
+		so = make_sales_order(item_code="_Test Item", qty=6)
+		self.assertEqual(so.pricing_rules[0].pricing_rule, pr2.name)
+
 
 EXTRA_TEST_RECORD_DEPENDENCIES = ["UTM Campaign"]
 

--- a/erpnext/accounts/doctype/pricing_rule/utils.py
+++ b/erpnext/accounts/doctype/pricing_rule/utils.py
@@ -26,7 +26,6 @@ apply_on_table = {"Item Code": "items", "Item Group": "item_groups", "Brand": "b
 
 def get_pricing_rules(args, doc=None):
 	pricing_rules = []
-	pricing_rule = {}
 	values = {}
 	has_multiple_pricing_rule = False
 
@@ -35,17 +34,18 @@ def get_pricing_rules(args, doc=None):
 
 	for apply_on in ["Item Code", "Item Group", "Brand"]:
 		pricing_rules.extend(_get_pricing_rules(apply_on, args, values))
-		if pricing_rules and pricing_rules[0].has_priority:
-			continue
 
 		# check apply_multiple_pricing_rules is enabled
 		if pricing_rules and apply_multiple_pricing_rules(pricing_rules):
 			has_multiple_pricing_rule = True
 
+		if pricing_rules and pricing_rules[0].has_priority:
+			continue
+
 		if pricing_rules and not has_multiple_pricing_rule:
 			# filter pricing rule
 			pricing_rules = filter_pricing_rule_based_on_condition(pricing_rules, doc)
-			if pricing_rule := filter_pricing_rules(args, pricing_rules, doc):
+			if filter_pricing_rules(args, pricing_rules, doc):
 				break
 
 	rules = []
@@ -53,16 +53,19 @@ def get_pricing_rules(args, doc=None):
 	if not pricing_rules:
 		return []
 
+	pricing_rules = filter_pricing_rule_based_on_condition(pricing_rules, doc)
+
 	if has_multiple_pricing_rule:
-		pricing_rules = filter_pricing_rule_based_on_condition(pricing_rules, doc)
 		pricing_rules = sorted_by_priority(pricing_rules, args, doc)
 		for pricing_rule in pricing_rules:
 			if isinstance(pricing_rule, list):
 				rules.extend(pricing_rule)
 			else:
 				rules.append(pricing_rule)
-	elif pricing_rule:
-		rules.append(pricing_rule)
+	else:
+		pricing_rule = filter_pricing_rules(args, pricing_rules, doc)
+		if pricing_rule:
+			rules.append(pricing_rule)
 
 	return rules
 

--- a/erpnext/accounts/doctype/pricing_rule/utils.py
+++ b/erpnext/accounts/doctype/pricing_rule/utils.py
@@ -26,7 +26,9 @@ apply_on_table = {"Item Code": "items", "Item Group": "item_groups", "Brand": "b
 
 def get_pricing_rules(args, doc=None):
 	pricing_rules = []
+	pricing_rule = {}
 	values = {}
+	has_multiple_pricing_rule = False
 
 	if not frappe.db.count("Pricing Rule", cache=True):
 		return
@@ -36,27 +38,31 @@ def get_pricing_rules(args, doc=None):
 		if pricing_rules and pricing_rules[0].has_priority:
 			continue
 
-		if pricing_rules and not apply_multiple_pricing_rules(pricing_rules):
-			break
+		# check apply_multiple_pricing_rules is enabled
+		if pricing_rules and apply_multiple_pricing_rules(pricing_rules):
+			has_multiple_pricing_rule = True
+
+		if pricing_rules and not has_multiple_pricing_rule:
+			# filter pricing rule
+			pricing_rules = filter_pricing_rule_based_on_condition(pricing_rules, doc)
+			if pricing_rule := filter_pricing_rules(args, pricing_rules, doc):
+				break
 
 	rules = []
-
-	pricing_rules = filter_pricing_rule_based_on_condition(pricing_rules, doc)
 
 	if not pricing_rules:
 		return []
 
-	if apply_multiple_pricing_rules(pricing_rules):
+	if has_multiple_pricing_rule:
+		pricing_rules = filter_pricing_rule_based_on_condition(pricing_rules, doc)
 		pricing_rules = sorted_by_priority(pricing_rules, args, doc)
 		for pricing_rule in pricing_rules:
 			if isinstance(pricing_rule, list):
 				rules.extend(pricing_rule)
 			else:
 				rules.append(pricing_rule)
-	else:
-		pricing_rule = filter_pricing_rules(args, pricing_rules, doc)
-		if pricing_rule:
-			rules.append(pricing_rule)
+	elif pricing_rule:
+		rules.append(pricing_rule)
 
 	return rules
 


### PR DESCRIPTION
Issue:
When two pricing rules are created — one for the Item Code (test_item_01) and another for the Item Group (test_item_group_01) — and both have “Apply Multiple Pricing Rules” unchecked, the Item Group pricing rule does not get applied when creating an order for the item (test_item_01), even though it belongs to that group.

Ref: [#50535](https://support.frappe.io/helpdesk/tickets/50535)
fixes #33210

Steps to Reproduce:


1. Create an item `(test_item_01)` with the item group `(test_item_group_01)`.
2. Create two pricing rules for selling, with `Apply Multiple Pricing Rules` unchecked:

- PR1 for the Item Code `test_item_01`, set Min Qty = 20, Max Qty = 50, and Discount Percent = 10%.
- PR2 for the Item Group `test_item_group_01`, set Min Qty = 1, Max Qty = 10, and Discount Percent = 5%.

3.Create a Sales Order for the item `test_item_01` with a quantity of **5**.

4.Notice that the discount percent is not getting applied.  

Before:


https://github.com/user-attachments/assets/56bc4ca7-8631-4469-99a6-e839ccf3c620



After:

https://github.com/user-attachments/assets/5ef3d7d5-add4-45dc-88b5-11bbcda77baf


Backport needed:v15