### PR TITLE
perf: Only check transaction deletion record once during req/job

### DIFF
--- a/erpnext/setup/doctype/transaction_deletion_record/transaction_deletion_record.py
+++ b/erpnext/setup/doctype/transaction_deletion_record/transaction_deletion_record.py
@@ -9,6 +9,7 @@ from frappe.desk.notifications import clear_notifications
 from frappe.model.document import Document
 from frappe.utils import cint, comma_and, create_batch, get_link_to_form
 from frappe.utils.background_jobs import get_job, is_job_enqueued
+from frappe.utils.caching import request_cache
 
 LEDGER_ENTRY_DOCTYPES = frozenset(
 	(
@@ -482,6 +483,7 @@ def get_doctypes_to_be_ignored():
 
 
 @frappe.whitelist()
+@request_cache
 def is_deletion_doc_running(company: str | None = None, err_msg: str | None = None):
 	if not company:
 		return


### PR DESCRIPTION
2 queries for each insert + submit of GL/SL/PLE can be avoided with this. 

https://github.com/frappe/erpnext/blob/8d723d3da63594dff643c1372124f4875e9a7d55/erpnext/hooks.py#L326-L330