### PR TITLE
fix(Bank Transaction)!: make company mandatory

### DIFF
--- a/erpnext/accounts/doctype/bank_transaction/bank_transaction.json
+++ b/erpnext/accounts/doctype/bank_transaction/bank_transaction.json
@@ -83,7 +83,7 @@
    "in_standard_filter": 1,
    "label": "Company",
    "options": "Company",
-   "read_only": 1
+   "reqd": 1
   },
   {
    "fieldname": "section_break_4",
@@ -239,7 +239,7 @@
  "grid_page_length": 50,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-09-26 17:06:29.207673",
+ "modified": "2025-10-10 12:46:41.835513",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Bank Transaction",

--- a/erpnext/accounts/doctype/bank_transaction/bank_transaction.py
+++ b/erpnext/accounts/doctype/bank_transaction/bank_transaction.py
@@ -27,7 +27,7 @@ class BankTransaction(Document):
 		bank_party_account_number: DF.Data | None
 		bank_party_iban: DF.Data | None
 		bank_party_name: DF.Data | None
-		company: DF.Link | None
+		company: DF.Link
 		currency: DF.Link | None
 		date: DF.Date | None
 		deposit: DF.Currency
@@ -48,8 +48,17 @@ class BankTransaction(Document):
 		self.update_allocated_amount()
 
 	def validate(self):
+		self.validate_company()
 		self.validate_duplicate_references()
 		self.validate_currency()
+
+	def validate_company(self):
+		if (
+			self.company
+			and self.bank_account
+			and frappe.get_cached_value("Bank Account", self.bank_account, "company") != self.company
+		):
+			frappe.throw(_("Bank Account company does not match with the Bank Transaction company."))
 
 	def validate_currency(self):
 		"""


### PR DESCRIPTION
So far, _Bank Account_ and _Company_ have been optional in **Bank Transaction**. I know there are use-cases for leaving the _Bank Account_ empty. But, IMO, a **Bank Transaction** should at the very least belong to a specific company. 