### PR TITLE
fix(stock-reconciliation): include inventory dimensions in duplicate validation

### DIFF
--- a/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py
+++ b/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py
@@ -588,6 +588,10 @@ class StockReconciliation(StockController):
 				if row.get(field):
 					key.append(row.get(field))
 
+			for dimension in get_inventory_dimensions():
+				if row.get(dimension.get("fieldname")):
+					key.append(row.get(dimension.get("fieldname")))
+
 			if key in item_warehouse_combinations:
 				self.validation_messages.append(
 					_get_msg(row_num, _("Same item and warehouse combination already entered."))


### PR DESCRIPTION
**Issue:** Inventory Dimensions were not considered in the stock reconciliation opening entry duplicate validation
**ref:** [48884](https://support.frappe.io/helpdesk/tickets/48884)


**Before:**

https://github.com/user-attachments/assets/2361b77c-5952-47a9-94ee-b7e81c9280f1



**After:**

https://github.com/user-attachments/assets/63cc439f-6c0d-44d6-9e54-0231ecf907f0





**Backport needed for v15**