### PR TITLE
refactor: add supplier filter in buying

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js
@@ -71,14 +71,6 @@ erpnext.accounts.PurchaseInvoice = class PurchaseInvoice extends erpnext.buying.
 		if (this.frm.doc.supplier && this.frm.doc.__islocal) {
 			this.frm.trigger("supplier");
 		}
-
-		this.frm.set_query("supplier", function () {
-			return {
-				filters: {
-					is_transporter: 0,
-				},
-			};
-		});
 	}
 
 	refresh(doc) {

--- a/erpnext/buying/doctype/purchase_order/purchase_order.js
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.js
@@ -502,17 +502,6 @@ erpnext.buying.PurchaseOrderController = class PurchaseOrderController extends (
 		}
 	}
 
-	onload() {
-		super.onload();
-		this.frm.set_query("supplier", function () {
-			return {
-				filters: {
-					is_transporter: 0,
-				},
-			};
-		});
-	}
-
 	get_items_from_open_material_requests() {
 		erpnext.utils.map_current_doc({
 			method: "erpnext.stock.doctype.material_request.material_request.make_purchase_order_based_on_supplier",

--- a/erpnext/public/js/controllers/buying.js
+++ b/erpnext/public/js/controllers/buying.js
@@ -17,6 +17,16 @@ erpnext.buying = {
 				this.setup_queries(doc, cdt, cdn);
 				super.onload();
 
+				if (["Purchase Order", "Purchase Receipt", "Purchase Invoice"].includes(this.frm.doctype)) {
+					this.frm.set_query("supplier", function () {
+						return {
+							filters: {
+								is_transporter: 0,
+							},
+						};
+					});
+				}
+
 				this.frm.set_query("shipping_rule", function () {
 					return {
 						filters: {

--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.js
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.js
@@ -199,17 +199,6 @@ erpnext.stock.PurchaseReceiptController = class PurchaseReceiptController extend
 		super.setup(doc);
 	}
 
-	onload() {
-		super.onload();
-		this.frm.set_query("supplier", function () {
-			return {
-				filters: {
-					is_transporter: 0,
-				},
-			};
-		});
-	}
-
 	refresh() {
 		var me = this;
 		super.refresh();


### PR DESCRIPTION
**Issue:**
The transporter filter applied for the supplier is currently handled across all three doctypes (PI, PO, and PR), which are inherited under the Buying Controller.

**Refactored Solution:**
Following the DRY principle, the filter query has been moved into the Buying class, with the necessary doctype-specific conditions included.


<img width="1679" height="895" alt="image" src="https://github.com/user-attachments/assets/91b5047d-626a-4fdb-91d2-78538af816c9" />


**Backport Needed: v15**

