### PR TITLE
FIX the multiple variant creation logic when using a different language than EN.

### DIFF
--- a/erpnext/stock/doctype/item/item.js
+++ b/erpnext/stock/doctype/item/item.js
@@ -724,16 +724,32 @@ $.extend(erpnext.item, {
 
 		function get_selected_attributes() {
 			let selected_attributes = {};
-			me.multiple_variant_dialog.$wrapper.find(".form-column").each((i, col) => {
-				if (i === 0) return;
-				let attribute_name = $(col).find(".column-label").html().trim();
-				selected_attributes[attribute_name] = [];
-				let checked_opts = $(col).find(".checkbox input");
-				checked_opts.each((i, opt) => {
-					if ($(opt).is(":checked")) {
-						selected_attributes[attribute_name].push($(opt).attr("data-fieldname"));
+			
+			me.multiple_variant_dialog.fields.forEach((field, index) => {
+				if (field.fieldtype === "Column Break") {
+					// Get the original attribute name from the field definition
+					let attribute_name = field.label;
+					selected_attributes[attribute_name] = [];
+					
+					// Find all checkbox fields that belong to this attribute column
+					// by looking for fields that come after this column break
+					for (let i = index + 1; i < me.multiple_variant_dialog.fields.length; i++) {
+						let next_field = me.multiple_variant_dialog.fields[i];
+						
+						// Stop when we hit another column break or section break
+						if (next_field.fieldtype === "Column Break" || next_field.fieldtype === "Section Break") {
+							break;
+						}
+						
+						// If it's a checkbox field (attribute value), check if it's selected
+						if (next_field.fieldtype === "Check") {
+							let field_obj = me.multiple_variant_dialog.fields_dict[next_field.fieldname];
+							if (field_obj && field_obj.get_value()) {
+								selected_attributes[attribute_name].push(next_field.fieldname);
+							}
+						}
 					}
-				});
+				}
 			});
 
 			return selected_attributes;


### PR DESCRIPTION
When trying to create multiple variants, using the dom leads to usage of translated attributes which breaks the variants creation.


## Before FIX:
<img width="625" height="60" alt="{D318A029-D31A-422C-AA57-60B72A05D504}" src="https://github.com/user-attachments/assets/c796bf7e-2b13-41fd-82dd-8fef638a7216" />


Response 417:
`{
    "exception": "frappe.exceptions.ValidationError: Item Code est nécessaire",
    "exc_type": "ValidationError",
    "_exc_source": "erpnext (app)",
    "exc": "[\"Traceback (most recent call last):\\n  File \\\"apps/frappe/frappe/app.py\\\", line 121, in application\\n    response = frappe.api.handle(request)\\n  File \\\"apps/frappe/frappe/api/__init__.py\\\", line 61, in handle\\n    data = endpoint(**arguments)\\n  File \\\"apps/frappe/frappe/api/v1.py\\\", line 36, in handle_rpc_call\\n    return frappe.handler.handle()\\n  File \\\"apps/frappe/frappe/handler.py\\\", line 52, in handle\\n    data = execute_cmd(cmd)\\n  File \\\"apps/frappe/frappe/handler.py\\\", line 85, in execute_cmd\\n    return frappe.call(method, **frappe.form_dict)\\n  File \\\"apps/frappe/frappe/__init__.py\\\", line 1127, in call\\n    return fn(*args, **newargs)\\n  File \\\"apps/frappe/frappe/utils/typing_validations.py\\\", line 36, in wrapper\\n    return func(*args, **kwargs)\\n  File \\\"apps/erpnext/erpnext/controllers/item_variant.py\\\", line 238, in enqueue_multiple_variant_creation\\n    return create_multiple_variants(item, args, use_template_image)\\n  File \\\"apps/erpnext/erpnext/controllers/item_variant.py\\\", line 263, in create_multiple_variants\\n    variant.save()\\n  File \\\"apps/frappe/frappe/model/document.py\\\", line 497, in save\\n    return self._save(*args, **kwargs)\\n  File \\\"apps/frappe/frappe/model/document.py\\\", line 519, in _save\\n    return self.insert()\\n  File \\\"apps/frappe/frappe/model/document.py\\\", line 422, in insert\\n    self.set_new_name(set_name=set_name, set_child_names=set_child_names)\\n  File \\\"apps/frappe/frappe/model/document.py\\\", line 677, in set_new_name\\n    set_new_name(self)\\n  File \\\"apps/frappe/frappe/model/naming.py\\\", line 194, in set_new_name\\n    set_name_from_naming_options(autoname, doc)\\n  File \\\"apps/frappe/frappe/model/naming.py\\\", line 226, in set_name_from_naming_options\\n    frappe.throw(_(\\\"{0} is required\\\").format(doc.meta.get_label(fieldname)))\\n  File \\\"apps/frappe/frappe/utils/messages.py\\\", line 145, in throw\\n    msgprint(\\n  File \\\"apps/frappe/frappe/utils/messages.py\\\", line 106, in msgprint\\n    _raise_exception()\\n  File \\\"apps/frappe/frappe/utils/messages.py\\\", line 57, in _raise_exception\\n    raise exc\\nfrappe.exceptions.ValidationError: Item Code est nécessaire\\n\"]",
    "_server_messages": "[\"{\\\"message\\\":\\\"Item Code est nécessaire\\\",\\\"title\\\":\\\"Message\\\",\\\"indicator\\\":\\\"red\\\",\\\"raise_exception\\\":1,\\\"__frappe_exc_id\\\":\\\"6932f32afa39c7a166a1557a9a5dd9bbd2b6b488379dc526daa705bc\\\"}\"]"
}`


## After FIX
Corrected request:
<img width="606" height="70" alt="{222D31B6-136C-4771-B5FD-5C46CD70C322}" src="https://github.com/user-attachments/assets/f6f41231-6557-48aa-b8ac-5503fec2223e" />
Response 200:
`{"message":8}`


Environment: develop branch + version-15.


There might be a better way to get the mapping of the attributes and their values. Don't hesitate to suggest if you have any ideas.