### PR TITLE
fix(deferred revenue): validate service stop date

### DIFF
--- a/erpnext/accounts/deferred_revenue.py
+++ b/erpnext/accounts/deferred_revenue.py
@@ -46,7 +46,8 @@ def validate_service_stop_date(doc):
 		if (
 			old_stop_dates
 			and old_stop_dates.get(item.name)
-			and item.service_stop_date != old_stop_dates.get(item.name)
+			and item.service_stop_date
+			and getdate(item.service_stop_date) != getdate(old_stop_dates.get(item.name))
 		):
 			frappe.throw(_("Cannot change Service Stop Date for item in row {0}").format(item.idx))
 


### PR DESCRIPTION
Issue:

When creating a Purchase Invoice for an item with `Enable Deferred Expense` checked and a `12`-month service period, if the service start date is `11/10/2025`, the service end date is 1`1/10/2026`, and the service stop date is `11/07/2026`, the system throws an error on submission `Cannot change Service Stop Date for item` 

This happens even though the stop_dates value is the same. 

The issue occurs because the comparison is made between a string and a date object, causing the validation to fail incorrectly.

Ref: [#50599](https://support.frappe.io/helpdesk/tickets/50599)

Before:

https://github.com/user-attachments/assets/7addfb78-594a-46f5-b08d-95720b841f15

After:


https://github.com/user-attachments/assets/74c68cb2-e181-4d7d-baa1-6b1c4708d5c0

Backport needed: v15
