### PR TITLE
fix: Batch ordering based on the method mentioned in settings

### DIFF
--- a/erpnext/stock/doctype/batch/batch.py
+++ b/erpnext/stock/doctype/batch/batch.py
@@ -239,6 +239,7 @@ def get_batch_qty(
 		get_auto_batch_nos,
 	)
 
+	stock_settings = frappe.get_cached_doc("Stock Settings")
 	batchwise_qty = defaultdict(float)
 	kwargs = frappe._dict(
 		{
@@ -247,6 +248,7 @@ def get_batch_qty(
 			"posting_date": posting_date,
 			"posting_time": posting_time,
 			"batch_no": batch_no,
+			"based_on": stock_settings.pick_serial_and_batch_based_on,
 			"ignore_voucher_nos": ignore_voucher_nos,
 			"for_stock_levels": for_stock_levels,
 			"consider_negative_batches": consider_negative_batches,

--- a/erpnext/stock/doctype/batch/batch.py
+++ b/erpnext/stock/doctype/batch/batch.py
@@ -239,7 +239,7 @@ def get_batch_qty(
 		get_auto_batch_nos,
 	)
 
-	stock_settings = frappe.get_cached_doc("Stock Settings")
+	based_on = frappe.get_single_value("Stock Settings", "pick_serial_and_batch_based_on")
 	batchwise_qty = defaultdict(float)
 	kwargs = frappe._dict(
 		{
@@ -248,7 +248,7 @@ def get_batch_qty(
 			"posting_date": posting_date,
 			"posting_time": posting_time,
 			"batch_no": batch_no,
-			"based_on": stock_settings.pick_serial_and_batch_based_on,
+			"based_on": based_on,
 			"ignore_voucher_nos": ignore_voucher_nos,
 			"for_stock_levels": for_stock_levels,
 			"consider_negative_batches": consider_negative_batches,

--- a/erpnext/stock/doctype/batch/batch.py
+++ b/erpnext/stock/doctype/batch/batch.py
@@ -239,7 +239,6 @@ def get_batch_qty(
 		get_auto_batch_nos,
 	)
 
-	based_on = frappe.get_single_value("Stock Settings", "pick_serial_and_batch_based_on")
 	batchwise_qty = defaultdict(float)
 	kwargs = frappe._dict(
 		{
@@ -248,7 +247,7 @@ def get_batch_qty(
 			"posting_date": posting_date,
 			"posting_time": posting_time,
 			"batch_no": batch_no,
-			"based_on": based_on,
+			"based_on": frappe.get_single_value("Stock Settings", "pick_serial_and_batch_based_on"),
 			"ignore_voucher_nos": ignore_voucher_nos,
 			"for_stock_levels": for_stock_levels,
 			"consider_negative_batches": consider_negative_batches,


### PR DESCRIPTION
Previously, the batch selection during transactions did not consistently respect the batch ordering method configured in Stock Settings (e.g., FIFO, LIFO, or Expiry Date).

This fix ensures that batches are now fetched and ordered according to the method defined in Stock Settings → Batch Selection Method.

`no-docs`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Batch quantity calculations now respect the Stock Settings option "Pick Serial and Batch Based On."
  * Batch selection and quantities in transactions and reports will align with your configured preference.
  * Behavior is applied across relevant workflows without requiring any user action or changes to integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->