### PR TITLE
fix: extend quotation filters to exclude 'Ordered' quotations in 'Get Items From' on Sales Order

### DIFF
--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -721,6 +721,7 @@ erpnext.utils.update_child_items = function (opts) {
 									item_name: item_name,
 									bom_no: bom_no,
 								});
+								row.item_name = r.message.item_name;
 								dialog.fields_dict.trans_items.grid.refresh();
 							}
 						}
@@ -784,7 +785,7 @@ erpnext.utils.update_child_items = function (opts) {
 	];
 
 	if (frm.doc.doctype == "Sales Order" || frm.doc.doctype == "Purchase Order") {
-		fields.splice(2, 0, {
+		fields.splice(3, 0, {
 			fieldtype: "Date",
 			fieldname: frm.doc.doctype == "Sales Order" ? "delivery_date" : "schedule_date",
 			in_list_view: 1,
@@ -792,13 +793,21 @@ erpnext.utils.update_child_items = function (opts) {
 			default: frm.doc.doctype == "Sales Order" ? frm.doc.delivery_date : frm.doc.schedule_date,
 			reqd: 1,
 		});
-		fields.splice(3, 0, {
+		fields.splice(4, 0, {
 			fieldtype: "Float",
 			fieldname: "conversion_factor",
 			label: __("Conversion Factor"),
 			precision: get_precision("conversion_factor"),
 		});
 	}
+	fields.splice(2, 0, {
+		fieldtype: "Data",
+		fieldname: "item_name",
+		read_only: 1,
+		in_list_view: 1,
+		fetch_from : "item_code.item_name",
+		label: __("Item Name")
+	});
 
 	if (
 		frm.doc.doctype == "Purchase Order" &&

--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -721,7 +721,6 @@ erpnext.utils.update_child_items = function (opts) {
 									item_name: item_name,
 									bom_no: bom_no,
 								});
-								row.item_name = r.message.item_name;
 								dialog.fields_dict.trans_items.grid.refresh();
 							}
 						}
@@ -785,7 +784,7 @@ erpnext.utils.update_child_items = function (opts) {
 	];
 
 	if (frm.doc.doctype == "Sales Order" || frm.doc.doctype == "Purchase Order") {
-		fields.splice(3, 0, {
+		fields.splice(2, 0, {
 			fieldtype: "Date",
 			fieldname: frm.doc.doctype == "Sales Order" ? "delivery_date" : "schedule_date",
 			in_list_view: 1,
@@ -793,21 +792,13 @@ erpnext.utils.update_child_items = function (opts) {
 			default: frm.doc.doctype == "Sales Order" ? frm.doc.delivery_date : frm.doc.schedule_date,
 			reqd: 1,
 		});
-		fields.splice(4, 0, {
+		fields.splice(3, 0, {
 			fieldtype: "Float",
 			fieldname: "conversion_factor",
 			label: __("Conversion Factor"),
 			precision: get_precision("conversion_factor"),
 		});
 	}
-	fields.splice(2, 0, {
-		fieldtype: "Data",
-		fieldname: "item_name",
-		read_only: 1,
-		in_list_view: 1,
-		fetch_from : "item_code.item_name",
-		label: __("Item Name")
-	});
 
 	if (
 		frm.doc.doctype == "Purchase Order" &&

--- a/erpnext/selling/doctype/sales_order/sales_order.js
+++ b/erpnext/selling/doctype/sales_order/sales_order.js
@@ -1011,7 +1011,7 @@ erpnext.selling.SalesOrderController = class SalesOrderController extends erpnex
 						get_query_filters: {
 							company: me.frm.doc.company,
 							docstatus: 1,
-							status: ["!=", "Lost"],
+							status: ["not in", ["Lost", "Ordered"]],
 						},
 						allow_child_item_selection: true,
 						child_fieldname: "items",


### PR DESCRIPTION
Previously, When select the 'Get Items From' - Quotation in sales order it list full quotation except Lost status. But no need already ordered quotation list . 

feat : add this feature ,  remove the ordered quotation from listing the quotation in sales order get items from
no-docs
