### PR TITLE
Fix warehouse source reference in production report

### DIFF
--- a/erpnext/manufacturing/report/production_planning_report/production_planning_report.py
+++ b/erpnext/manufacturing/report/production_planning_report/production_planning_report.py
@@ -113,6 +113,12 @@ class ProductionPlanReport:
 		self.orders = query.run(as_dict=True)
 
 	def get_raw_materials(self):
+		"""Retrieve raw materials and source warehouses for production orders.
+	
+	    This method collects BOM or Work Order items depending on the selected
+	    filter and updates `self.raw_materials_dict`, `self.warehouses`,
+	    and `self.item_codes` accordingly.
+	    """
 		if not self.orders:
 			return
 		self.warehouses = [d.warehouse for d in self.orders]

--- a/erpnext/manufacturing/report/production_planning_report/production_planning_report.py
+++ b/erpnext/manufacturing/report/production_planning_report/production_planning_report.py
@@ -135,7 +135,7 @@ class ProductionPlanReport:
 				)
 				or []
 			)
-			self.warehouses.extend([d.source_warehouse for d in raw_materials])
+			self.warehouses.extend([d.warehouse for d in raw_materials])
 
 		else:
 			bom_nos = []


### PR DESCRIPTION
in Production Planning Report

The raw materials retrieval function (`get_raw_materials`) in the production report was incorrectly referencing `d.source_warehouse` after aliasing `source_warehouse as warehouse` in the query result.

