### PR TITLE
fix: filter sales team to show only active individual salespersons

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
@@ -798,6 +798,15 @@ frappe.ui.form.on("Sales Invoice", {
 				},
 			};
 		});
+
+		frm.set_query("sales_person", "sales_team", function () {
+			return {
+				filters: {
+					is_group: 0,
+					enabled: 1,
+				},
+			};
+		});
 	},
 	onload: function (frm) {
 		frm.redemption_conversion_factor = null;

--- a/erpnext/selling/doctype/sales_order/sales_order.js
+++ b/erpnext/selling/doctype/sales_order/sales_order.js
@@ -44,6 +44,15 @@ frappe.ui.form.on("Sales Order", {
 			};
 		});
 
+		frm.set_query("sales_person", "sales_team", function () {
+			return {
+				filters: {
+					is_group: 0,
+					enabled: 1,
+				},
+			};
+		});
+
 		frm.set_df_property("packed_items", "cannot_add_rows", true);
 		frm.set_df_property("packed_items", "cannot_delete_rows", true);
 	},


### PR DESCRIPTION
Closes #49997

<img width="1366" height="621" alt="image" src="https://github.com/user-attachments/assets/53e3a021-d917-4edb-815f-da13037055ce" />

`no-docs`