### PR TITLE
fix(accounts-receivable): ensure report data with party account currency

### DIFF
--- a/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
+++ b/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
@@ -666,7 +666,16 @@ class ReceivablePayableReport:
 		invoiced = d.base_payment_amount
 		paid_amount = d.base_paid_amount
 
-		if company_currency == d.party_account_currency or self.filters.get("in_party_currency"):
+		in_party_currency = self.filters.get("in_party_currency")
+		# company, billing, and party account currencies are the same
+		if company_currency == d.currency and company_currency == d.party_account_currency:
+			in_party_currency = False
+
+		# When filtered by party currency and the billing currency not matches the party account currency
+		if in_party_currency and d.currency != d.party_account_currency:
+			in_party_currency = False
+
+		if in_party_currency:
 			invoiced = d.payment_amount
 			paid_amount = d.paid_amount
 

--- a/erpnext/accounts/test/accounts_mixin.py
+++ b/erpnext/accounts/test/accounts_mixin.py
@@ -5,7 +5,9 @@ from erpnext.stock.doctype.item.test_item import create_item
 
 
 class AccountsTestMixin:
-	def create_customer(self, customer_name="_Test Customer", currency=None):
+	def create_customer(
+		self, customer_name="_Test Customer", currency=None, default_account=None, company=None
+	):
 		if not frappe.db.exists("Customer", customer_name):
 			customer = frappe.new_doc("Customer")
 			customer.customer_name = customer_name
@@ -13,9 +15,28 @@ class AccountsTestMixin:
 
 			if currency:
 				customer.default_currency = currency
+			if company and default_account:
+				customer.append(
+					"accounts",
+					{
+						"company": company,
+						"account": default_account,
+					},
+				)
 			customer.save()
 			self.customer = customer.name
 		else:
+			if company and default_account:
+				customer = frappe.get_doc("Customer", customer_name)
+				customer.accounts = []
+				customer.append(
+					"accounts",
+					{
+						"company": company,
+						"account": default_account,
+					},
+				)
+				customer.save()
 			self.customer = customer_name
 
 	def create_supplier(self, supplier_name="_Test Supplier", currency=None):


### PR DESCRIPTION
**Ref:** [50616](https://support.frappe.io/helpdesk/tickets/50616)

**Issue:** The Account Receivable report displayed incorrect amounts when the `in_party_currency ` filter was enabled.

**Fix:** Updated the `in_party_currency `filter logic to apply the party account currency correctly and added test cases to ensure the correct report data.

**Before:** 

https://github.com/user-attachments/assets/1cfde844-5222-4a8b-972f-1e68d037595a

**After:**

https://github.com/user-attachments/assets/51a4dc17-cfa1-45e9-965a-09819d7ae5bd


**Backport Needed: v15**