### PR TITLE
fix(journal-entry): allow copy account currency when duplicating JV

### DIFF
--- a/erpnext/accounts/doctype/journal_entry_account/journal_entry_account.json
+++ b/erpnext/accounts/doctype/journal_entry_account/journal_entry_account.json
@@ -106,7 +106,6 @@
    "fieldname": "account_currency",
    "fieldtype": "Link",
    "label": "Account Currency",
-   "no_copy": 1,
    "options": "Currency",
    "print_hide": 1,
    "read_only": 1
@@ -287,7 +286,7 @@
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-10-20 17:46:47.344089",
+ "modified": "2025-10-27 13:48:32.805100",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Journal Entry Account",


### PR DESCRIPTION
**Ref:** [50754](https://support.frappe.io/helpdesk/tickets/50754)

**Issue:** Account currency value was incorrectly copied to the duplicate JV when no_copy was enabled.

**Fix:** Set the `no_copy` property of the `account_currency` field to 0 to ensure its value is copied to duplicated records.

**Before:**

https://github.com/user-attachments/assets/a3e31d7c-60b4-487d-a0a8-aaaae08016c6


**After:**

https://github.com/user-attachments/assets/d3e48f64-5eb3-4f1f-a5d5-e12a88dee5c0


Backport needed: v15
