### PR TITLE
perf: add composite indexes to Advance Payment Ledger Entry

### DIFF
--- a/erpnext/accounts/doctype/advance_payment_ledger_entry/advance_payment_ledger_entry.json
+++ b/erpnext/accounts/doctype/advance_payment_ledger_entry/advance_payment_ledger_entry.json
@@ -82,7 +82,7 @@
  "in_create": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-10-13 13:23:21.205945",
+ "modified": "2025-10-13 15:11:58.300836",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Advance Payment Ledger Entry",
@@ -116,7 +116,6 @@
    "share": 1
   }
  ],
- "read_only": 1,
  "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",

--- a/erpnext/accounts/doctype/advance_payment_ledger_entry/advance_payment_ledger_entry.json
+++ b/erpnext/accounts/doctype/advance_payment_ledger_entry/advance_payment_ledger_entry.json
@@ -82,7 +82,7 @@
  "in_create": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-07-29 11:37:42.678556",
+ "modified": "2025-10-13 13:23:21.205945",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Advance Payment Ledger Entry",
@@ -116,6 +116,7 @@
    "share": 1
   }
  ],
+ "read_only": 1,
  "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",

--- a/erpnext/accounts/doctype/advance_payment_ledger_entry/advance_payment_ledger_entry.py
+++ b/erpnext/accounts/doctype/advance_payment_ledger_entry/advance_payment_ledger_entry.py
@@ -34,3 +34,15 @@ class AdvancePaymentLedgerEntry(Document):
 			and not frappe.flags.is_reverse_depr_entry
 		):
 			update_voucher_outstanding(self.against_voucher_type, self.against_voucher_no, None, None, None)
+
+
+def on_doctype_update():
+	frappe.db.add_index(
+		"Advance Payment Ledger Entry",
+		["against_voucher_type", "against_voucher_no"],
+	)
+
+	frappe.db.add_index(
+		"Advance Payment Ledger Entry",
+		["voucher_type", "voucher_no"],
+	)


### PR DESCRIPTION
Cancellations of documents like Sales Invoice, and Purchase Invoice were triggering slow update queries on the `Advance Payment Ledger Entry`. These queries filter by voucher_type / against_voucher_type and their respective voucher numbers, but the table didn't have suitable indexes to support that.

This PR adds two composite indexes:

- against_voucher_type, against_voucher_no
- voucher_type, voucher_no

With these indexes in place, we avoid full index scans on large datasets.