### PR TITLE
fix: delivered qty in reservation entry

### DIFF
--- a/erpnext/manufacturing/doctype/work_order/work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/work_order.py
@@ -1336,6 +1336,9 @@ class WorkOrder(Document):
 			self.set_available_qty()
 
 	def update_transferred_qty_for_required_items(self):
+		if self.skip_transfer:
+			return
+
 		ste = frappe.qb.DocType("Stock Entry")
 		ste_child = frappe.qb.DocType("Stock Entry Detail")
 

--- a/erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py
+++ b/erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py
@@ -613,10 +613,10 @@ class StockReservationEntry(Document):
 				data = row_wise_serial_batch[row]
 
 				if entry.serial_no in data.serial_nos:
-					entry.delivered_qty = 1
+					entry.delivered_qty = flt(1)
 
 				elif entry.batch_no in data.batch_nos:
-					entry.delivered_qty = data.batch_nos[entry.batch_no]
+					entry.delivered_qty = flt(data.batch_nos[entry.batch_no])
 
 			entry.db_update()
 


### PR DESCRIPTION
If the work order has skip transfer enabled, then the delivered quantity in the reservation entry is set to zero.