### PR TITLE
fix: enhance sub-assembly item handling in raw material request calculations

### DIFF
--- a/erpnext/manufacturing/doctype/production_plan/production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.py
@@ -1624,6 +1624,7 @@ def get_items_for_material_requests(doc, warehouses=None, get_parent_warehouse_d
 	include_safety_stock = doc.get("include_safety_stock")
 
 	so_item_details = frappe._dict()
+	existing_sub_assembly_items = set()
 
 	sub_assembly_items = defaultdict(int)
 	if doc.get("skip_available_sub_assembly_item") and doc.get("sub_assembly_items"):
@@ -1659,7 +1660,7 @@ def get_items_for_material_requests(doc, warehouses=None, get_parent_warehouse_d
 					and doc.get("sub_assembly_items")
 				):
 					item_details = get_raw_materials_of_sub_assembly_items(
-						so_item_details[doc.get("sales_order")].keys() if so_item_details else [],
+						existing_sub_assembly_items,
 						item_details,
 						company,
 						bom_no,
@@ -2044,6 +2045,7 @@ def get_raw_materials_of_sub_assembly_items(
 				sub_assembly_items,
 				planned_qty=planned_qty,
 			)
+			existing_sub_assembly_items.add(item.item_code)
 		else:
 			if not item.conversion_factor and item.purchase_uom:
 				item.conversion_factor = get_uom_conversion_factor(item.item_code, item.purchase_uom)


### PR DESCRIPTION
Regression: https://github.com/frappe/erpnext/pull/46938

## Issue

- Assembly item with same RM was ignored when computing required raw materials
- Sub-assembly item with same RM was also ignored when computing required raw materials

## Reason

Existing sub assembly items was dependent on

https://github.com/frappe/erpnext/blob/f757adc7f76c642f84332ea4daa7df09f196f91f/erpnext/manufacturing/doctype/production_plan/production_plan.py#L1662

This was getting updated in the loop

https://github.com/frappe/erpnext/blob/f757adc7f76c642f84332ea4daa7df09f196f91f/erpnext/manufacturing/doctype/production_plan/production_plan.py#L1721

Because of this it was getting ignored for next item with same RM (assembly or sub-assembly):

https://github.com/frappe/erpnext/blob/f757adc7f76c642f84332ea4daa7df09f196f91f/erpnext/manufacturing/doctype/production_plan/production_plan.py#L2033

## Fix

Created new object for sub-assembly items that have been covered and can be ignored