### PR TITLE
fix: set status in set_missing_values

### DIFF
--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -130,7 +130,6 @@ class Asset(AccountsController):
 		self.validate_gross_and_purchase_amount()
 		self.validate_finance_books()
 		self.total_asset_cost = self.net_purchase_amount + self.additional_asset_cost
-		self.status = self.get_status()
 
 	def create_asset_depreciation_schedule(self):
 		self.set_depr_rate_and_value_after_depreciation()
@@ -332,6 +331,8 @@ class Asset(AccountsController):
 
 		if self.asset_owner == "Company" and not self.asset_owner_company:
 			self.asset_owner_company = self.company
+
+		self.status = self.get_status()
 
 	def validate_finance_books(self):
 		if not self.calculate_depreciation or len(self.finance_books) == 1:


### PR DESCRIPTION
Issue: The status is not set when an asset is auto-created from the Purchase Receipt.

Ref: [50858](https://support.frappe.io/helpdesk/tickets/50858)

Before:

<img width="1877" height="960" alt="before_missing_asset_status" src="https://github.com/user-attachments/assets/26611ba4-043a-4d36-bd19-8fb2c7da57d5" />

After:

<img width="1881" height="970" alt="after_missing_asset_status" src="https://github.com/user-attachments/assets/fda307c2-9f9a-4d2e-9998-9b788bb740e0" />

Backport needed for v15
