### PR TITLE
chore: resolve conflicts

### DIFF
--- a/erpnext/manufacturing/doctype/production_plan/production_plan.js
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.js
@@ -154,17 +154,10 @@ frappe.ui.form.on("Production Plan", {
 					has_create_buttons = true;
 				}
 			}
-<<<<<<< HEAD
-=======
 
 			if (has_create_buttons && frm.doc.status !== "Closed") {
 				frm.page.set_inner_btn_group_as_primary(__("Create"));
 			}
->>>>>>> 0948358bb3 (fix: prevent empty Create dropdown when In Process)
-		}
-
-		if (frm.doc.status !== "Closed") {
-			frm.page.set_inner_btn_group_as_primary(__("Create"));
 		}
 		frm.trigger("material_requirement");
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The Create button is now highlighted as the primary action only when creation options are actually available and the production plan is not Closed. This prevents the button from appearing actionable when no actions can be taken, improving clarity and reducing user confusion.
  * Ensures more consistent primary action behavior across production plan states for a cleaner, more intuitive workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->