### PR TITLE
fix: swap warehouse labels for return entry

### DIFF
--- a/erpnext/public/js/utils/sales_common.js
+++ b/erpnext/public/js/utils/sales_common.js
@@ -113,6 +113,7 @@ erpnext.sales_common = {
 				);
 
 				this.toggle_editable_price_list_rate();
+				this.change_warehouse_labels_for_return();
 			}
 
 			company() {
@@ -503,6 +504,33 @@ erpnext.sales_common = {
 			coupon_code() {
 				this.frm.set_value("discount_amount", 0);
 				this.frm.set_value("additional_discount_percentage", 0);
+			}
+
+			is_return() {
+				let reset = !this.frm.doc.is_return;
+				this.change_warehouse_labels_for_return(reset);
+			}
+
+			change_warehouse_labels_for_return(reset) {
+				// swap source and target warehouse labels for return
+				let source_warehouse_label = __("Source Warehouse");
+				let target_warehouse_label = __("Set Target Warehouse");
+
+				if (this.frm.doc.doctype == "Delivery Note") {
+					source_warehouse_label = __("Set Source Warehouse");
+				}
+
+				if (reset) {
+					// reset to original labels
+					this.frm.set_df_property("set_warehouse", "label", source_warehouse_label);
+					this.frm.set_df_property("set_target_warehouse", "label", target_warehouse_label);
+					return;
+				}
+
+				if (this.frm.doc.is_return) {
+					this.frm.set_df_property("set_warehouse", "label", target_warehouse_label);
+					this.frm.set_df_property("set_target_warehouse", "label", source_warehouse_label);
+				}
 			}
 		};
 	},


### PR DESCRIPTION
**Issue:** 
Since our backend system handles source and target warehouse values for return entries the same way as the original entry, the warehouse labels caused confusion for users.

**Solution:** 
The system now dynamically changes the labels when it’s a return entry to improve the customer experience.

**Ref: [50647](support.frappe.io/helpdesk/tickets/50647?view=VIEW-HD+Ticket-850)**
 
[Screencast from 14-10-25 12:18:43 PM IST.webm](https://github.com/user-attachments/assets/1995777a-59a7-4e0a-ac77-087fdc818d17)

**Backport Needed: v15**