### PR TITLE
fix(stock-entry): fetch empty batch for finished item

### DIFF
--- a/erpnext/public/js/utils/serial_no_batch_selector.js
+++ b/erpnext/public/js/utils/serial_no_batch_selector.js
@@ -457,7 +457,8 @@ erpnext.SerialBatchPackageSelector = class SerialNoBatchBundleUpdate {
 							(["Purchase Receipt", "Purchase Invoice"].includes(this.frm.doc.doctype) &&
 								!this.frm.doc.is_return) ||
 							(this.frm.doc.doctype === "Stock Entry" &&
-								this.frm.doc.purpose === "Material Receipt")
+								(this.frm.doc.purpose === "Material Receipt" ||
+									(this.frm.doc.purpose === "Manufacture" && this.item.is_finished_item)))
 						) {
 							is_inward = true;
 						}


### PR DESCRIPTION
**Issue:**
The batch selector didn't fetch the empty batch for the finished item in the manufacturing stock entry.

**ref:** [50395](https://support.frappe.io/helpdesk/tickets/50395)


Before:

https://github.com/user-attachments/assets/68d2d6a1-2be5-41d2-9396-e47f382021a5

After:

https://github.com/user-attachments/assets/57d5fb03-13a7-4703-a791-22f994b2fdf7


Backport needed for v15