### PR TITLE
fix: handle flt conversion for prev_ordered_qty

### DIFF
--- a/erpnext/buying/doctype/purchase_order/purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.py
@@ -669,9 +669,8 @@ class PurchaseOrder(BuyingController):
 		if not self.is_against_so():
 			return
 		for item in removed_items:
-			prev_ordered_qty = (
+			prev_ordered_qty = flt(
 				frappe.get_cached_value("Sales Order Item", item.get("sales_order_item"), "ordered_qty")
-				or 0.0
 			)
 
 			frappe.db.set_value(


### PR DESCRIPTION
**Issue:** Unsupported operand error when removing items using update items button in Purchase Order.

**Ref: [50073](https://support.frappe.io/helpdesk/tickets/50647?view=VIEW-HD+Ticket-850)**

[Screencast from 14-10-25 01:42:06 PM IST.webm](https://github.com/user-attachments/assets/97a1933f-879b-42db-9b6e-9a70e89b782e)


**Backport Needed: v14, v15**