### PR TITLE
fix: skip auto-cancel of depreciation for components during asset capitalization

### DIFF
--- a/erpnext/assets/doctype/asset/depreciation.py
+++ b/erpnext/assets/doctype/asset/depreciation.py
@@ -507,7 +507,8 @@ def depreciate_asset(asset_doc, date, notes):
 	make_depreciation_entry_for_all_asset_depr_schedules(asset_doc, date)
 
 	asset_doc.reload()
-	cancel_depreciation_entries(asset_doc, date)
+	if not frappe.flags.is_composite_component:
+		cancel_depreciation_entries(asset_doc, date)
 
 
 @erpnext.allow_regional

--- a/erpnext/assets/doctype/asset_capitalization/asset_capitalization.py
+++ b/erpnext/assets/doctype/asset_capitalization/asset_capitalization.py
@@ -492,6 +492,7 @@ class AssetCapitalization(StockController):
 			asset = frappe.get_doc("Asset", item.asset)
 
 			if asset.calculate_depreciation:
+				frappe.flags.is_composite_component = True
 				notes = _(
 					"This schedule was created when Asset {0} was consumed through Asset Capitalization {1}."
 				).format(
@@ -499,6 +500,7 @@ class AssetCapitalization(StockController):
 					get_link_to_form(self.doctype, self.get("name")),
 				)
 				depreciate_asset(asset, self.posting_date, notes)
+				frappe.flags.is_composite_component = False
 				asset.reload()
 
 			fixed_asset_gl_entries = get_gl_entries_on_asset_disposal(

--- a/erpnext/assets/doctype/asset_capitalization/asset_capitalization.py
+++ b/erpnext/assets/doctype/asset_capitalization/asset_capitalization.py
@@ -493,15 +493,17 @@ class AssetCapitalization(StockController):
 
 			if asset.calculate_depreciation:
 				frappe.flags.is_composite_component = True
-				notes = _(
-					"This schedule was created when Asset {0} was consumed through Asset Capitalization {1}."
-				).format(
-					get_link_to_form(asset.doctype, asset.name),
-					get_link_to_form(self.doctype, self.get("name")),
-				)
-				depreciate_asset(asset, self.posting_date, notes)
-				frappe.flags.is_composite_component = False
-				asset.reload()
+				try:
+					notes = _(
+						"This schedule was created when Asset {0} was consumed through Asset Capitalization {1}."
+					).format(
+						get_link_to_form(asset.doctype, asset.name),
+						get_link_to_form(self.doctype, self.get("name")),
+					)
+					depreciate_asset(asset, self.posting_date, notes)
+					asset.reload()
+				finally:
+					frappe.flags.is_composite_component = False
 
 			fixed_asset_gl_entries = get_gl_entries_on_asset_disposal(
 				asset,


### PR DESCRIPTION
The issue occurs because ERPNext was auto-cancelling depreciation for a component asset during capitalization. This was happening because the system considered this process as disposal or scrapping of the asset.

As per the Income Tax Act (India), the asset should not be depreciated in the financial year in which it is sold or scrapped.

In this case, the asset was not actually disposed or scrapped, so depreciation should have been allowed for the days it was used, and the remaining depreciation should continue on the new composite asset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents unintended cancellation of depreciation for composite asset components during capitalization.
  * Ensures temporary processing state is always cleared even if errors occur, avoiding lingering side effects.
  * Improves accuracy of ledger entries and reliability of asset capitalization and depreciation workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->