### PR TITLE
fix: restore customer field

### DIFF
--- a/erpnext/controllers/subcontracting_controller.py
+++ b/erpnext/controllers/subcontracting_controller.py
@@ -1297,10 +1297,10 @@ def get_pending_subcontracted_quantity(doctype, name):
 	)
 	query = (
 		frappe.qb.from_(table)
-		.select(table.name, table.qty, table.subcontracted_qty)
+		.select(table.name, table.stock_qty, table.subcontracted_qty)
 		.where(table.parent == name)
 	)
-	return {item.name: item.qty - item.subcontracted_qty for item in query.run(as_dict=True)}
+	return {item.name: item.stock_qty - item.subcontracted_qty for item in query.run(as_dict=True)}
 
 
 @frappe.whitelist()

--- a/erpnext/stock/doctype/item/item.json
+++ b/erpnext/stock/doctype/item/item.json
@@ -87,6 +87,7 @@
   "lead_time_days",
   "last_purchase_rate",
   "is_customer_provided_item",
+  "customer",
   "supplier_details",
   "delivered_by_supplier",
   "column_break2",
@@ -205,11 +206,9 @@
   },
   {
    "default": "0",
-   "depends_on": "eval:!doc.is_customer_provided_item",
    "fieldname": "allow_alternative_item",
    "fieldtype": "Check",
-   "label": "Allow Alternative Item",
-   "read_only_depends_on": "eval:doc.is_customer_provided_item"
+   "label": "Allow Alternative Item"
   },
   {
    "allow_in_quick_entry": 1,
@@ -587,6 +586,13 @@
    "label": "Is Customer Provided Item"
   },
   {
+   "depends_on": "eval:doc.is_customer_provided_item",
+   "fieldname": "customer",
+   "fieldtype": "Link",
+   "label": "Customer",
+   "options": "Customer"
+  },
+  {
    "collapsible": 1,
    "depends_on": "eval:!doc.is_fixed_asset",
    "fieldname": "supplier_details",
@@ -947,7 +953,7 @@
  "image_field": "image",
  "links": [],
  "make_attachments_public": 1,
- "modified": "2025-10-12 16:58:40.946604",
+ "modified": "2025-10-13 16:58:40.946604",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Item",

--- a/erpnext/stock/doctype/item/item.py
+++ b/erpnext/stock/doctype/item/item.py
@@ -82,6 +82,7 @@ class Item(Document):
 		country_of_origin: DF.Link | None
 		create_new_batch: DF.Check
 		cumulative_time: DF.Int
+		customer: DF.Link | None
 		customer_code: DF.SmallText | None
 		customer_items: DF.Table[ItemCustomerDetail]
 		customs_tariff_number: DF.Link | None
@@ -966,7 +967,6 @@ class Item(Document):
 
 		restricted_fields = (
 			"has_serial_no",
-			"is_customer_provided_item",
 			"is_stock_item",
 			"valuation_method",
 			"has_batch_no",

--- a/erpnext/stock/doctype/warehouse/warehouse.js
+++ b/erpnext/stock/doctype/warehouse/warehouse.js
@@ -84,6 +84,10 @@ frappe.ui.form.on("Warehouse", {
 		}
 
 		frm.toggle_enable(["is_group", "company"], false);
+
+		if (frm.doc.customer) {
+			frm.set_df_property("customer", "read_only", frm.doc.__onload.stock_exists);
+		}
 	},
 });
 

--- a/erpnext/stock/doctype/warehouse/warehouse.py
+++ b/erpnext/stock/doctype/warehouse/warehouse.py
@@ -59,13 +59,13 @@ class Warehouse(NestedSet):
 		self.name = self.warehouse_name
 
 	def onload(self):
-		"""load account name for General Ledger Report"""
 		if self.company and cint(frappe.db.get_value("Company", self.company, "enable_perpetual_inventory")):
 			account = self.account or get_warehouse_account(self)
 
 			if account:
 				self.set_onload("account", account)
 		load_address_and_contact(self)
+		self.set_onload("stock_exists", self.check_if_sle_exists(non_cancelled_only=True))
 
 	def validate(self):
 		self.warn_about_multiple_warehouse_account()
@@ -151,8 +151,11 @@ class Warehouse(NestedSet):
 				indicator="orange",
 			)
 
-	def check_if_sle_exists(self):
-		return frappe.db.exists("Stock Ledger Entry", {"warehouse": self.name})
+	def check_if_sle_exists(self, non_cancelled_only=False):
+		filters = {"warehouse": self.name}
+		if non_cancelled_only:
+			filters["is_cancelled"] = 0
+		return frappe.db.exists("Stock Ledger Entry", filters)
 
 	def check_if_child_exists(self):
 		return frappe.db.exists("Warehouse", {"parent_warehouse": self.name})

--- a/erpnext/subcontracting/doctype/subcontracting_inward_order/subcontracting_inward_order.js
+++ b/erpnext/subcontracting/doctype/subcontracting_inward_order/subcontracting_inward_order.js
@@ -55,6 +55,7 @@ frappe.ui.form.on("Subcontracting Inward Order", {
 					is_rejected_warehouse: 0,
 					company: frm.doc.company,
 					disabled: 0,
+					customer: ["is", "not set"],
 				},
 			};
 		});
@@ -66,6 +67,7 @@ frappe.ui.form.on("Subcontracting Inward Order", {
 					is_rejected_warehouse: 0,
 					company: frm.doc.company,
 					disabled: 0,
+					customer: ["is", "not set"],
 				},
 			};
 		});

--- a/erpnext/subcontracting/doctype/subcontracting_inward_order/subcontracting_inward_order.py
+++ b/erpnext/subcontracting/doctype/subcontracting_inward_order/subcontracting_inward_order.py
@@ -165,13 +165,13 @@ class SubcontractingInwardOrder(SubcontractingController):
 				item = frappe.get_doc("Item", si.fg_item)
 
 				so_item = frappe.get_doc("Sales Order Item", si.sales_order_item)
-				available_qty = so_item.qty - so_item.subcontracted_qty
+				available_qty = so_item.stock_qty - so_item.subcontracted_qty
 
 				if available_qty == 0:
 					continue
 
-				si.qty = available_qty
-				conversion_factor = so_item.qty / so_item.fg_item_qty
+				si.required_qty = available_qty
+				conversion_factor = so_item.stock_qty / so_item.fg_item_qty
 				si.fg_item_qty = flt(
 					available_qty / conversion_factor, frappe.get_precision("Sales Order Item", "qty")
 				)


### PR DESCRIPTION
1. Restore `customer` field in `Item` removed by #47728
2. fixes a bug related to conversion factor/UOM in subcontracting flows
3. System will no longer allow the user to change the `customer` field of `Warehouse` if SLE exists for that warehouse
4. Delivery warehouse cannot be a customer warehouse

`no-docs`