### PR TITLE
fix: negative error not throw for backdated entry

### DIFF
--- a/erpnext/stock/doctype/stock_entry/test_stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/test_stock_entry.py
@@ -1317,18 +1317,9 @@ class TestStockEntry(IntegrationTestCase):
 				posting_date="2021-07-02",  # Illegal SE
 				purpose="Material Transfer",
 			),
-			dict(
-				item_code=item_code,
-				qty=2,
-				from_warehouse=warehouse_names[0],
-				to_warehouse=warehouse_names[1],
-				batch_no=batch_no,
-				posting_date="2021-07-02",  # Illegal SE
-				purpose="Material Transfer",
-			),
 		]
 
-		self.assertRaises(frappe.ValidationError, create_stock_entries, sequence_of_entries)
+		self.assertRaises(NegativeStockError, create_stock_entries, sequence_of_entries)
 
 	@IntegrationTestCase.change_settings("Stock Settings", {"allow_negative_stock": 0})
 	def test_future_negative_sle_batch(self):

--- a/erpnext/stock/serial_batch_bundle.py
+++ b/erpnext/stock/serial_batch_bundle.py
@@ -1399,12 +1399,12 @@ def get_batch_current_qty(batch):
 
 
 def throw_negative_batch_validation(batch_no, qty):
-	frappe.msgprint(
+	# This validation is important for backdated stock transactions with batch items
+	frappe.throw(
 		_(
 			"The Batch {0} has negative batch quantity {1}. To fix this, go to the batch and click on Recalculate Batch Qty. If the issue still persists, create an inward entry."
 		).format(bold(get_link_to_form("Batch", batch_no)), bold(qty)),
-		title=_("Warning!"),
-		indicator="orange",
+		title=_("Negative Stock Error"),
 	)
 
 


### PR DESCRIPTION
Negative stock error not throw for backdated batch entry 