### PR TITLE
fix: preview stock ledger for manual serial and batch values

### DIFF
--- a/erpnext/controllers/stock_controller.py
+++ b/erpnext/controllers/stock_controller.py
@@ -1653,7 +1653,9 @@ def get_stock_ledger_preview(doc, filters):
 
 	if doc.get("update_stock") or doc.doctype in ("Purchase Receipt", "Delivery Note", "Stock Entry"):
 		doc.docstatus = 1
+		doc.make_bundle_using_old_serial_batch_fields()
 		doc.update_stock_ledger()
+
 		columns = get_sl_columns(filters)
 		sl_entries = get_sl_entries_for_preview(doc.doctype, doc.name, fields)
 


### PR DESCRIPTION
**Issue:** Unable to preview Stock Ledger report in the Purchase Receipt and other inward entries with manual serial and batch numbers.

**Ref: [50163](https://support.frappe.io/helpdesk/tickets/50163?view=VIEW-HD+Ticket-850)**

**Before:**

[Screencast from 14-10-25 05:15:16 PM IST.webm](https://github.com/user-attachments/assets/88c7d488-bf87-4c56-9d9b-e72bd23b298b)

**After:**

[Screencast from 14-10-25 05:15:50 PM IST.webm](https://github.com/user-attachments/assets/07e7e2c8-c1bd-4e48-9cf8-2af6956e8665)


**Backport Needed: v15**