### PR TITLE
fix(payment-reco): recalculate amount based on allocated amount

### DIFF
--- a/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.js
+++ b/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.js
@@ -385,6 +385,16 @@ frappe.ui.form.on("Payment Reconciliation Allocation", {
 		// filter payment
 		let payment = frm.doc.payments.filter((x) => x.reference_name == row.reference_name);
 
+		let amount = payment[0].amount;
+		for (const d of frm.doc.allocation) {
+			if (row.reference_name == d.reference_name && amount) {
+				if (d.allocated_amount <= amount) {
+					d.amount = amount;
+					amount -= d.allocated_amount;
+				}
+			}
+		}
+
 		frm.call({
 			doc: frm.doc,
 			method: "calculate_difference_on_allocation_change",


### PR DESCRIPTION
Issue: Amount field not recalculated on manual change of Allocated Amount in Payment Reconciliation Allocation.

Ref: [50978](https://support.frappe.io/helpdesk/tickets/50978)


**Steps to Reproduce:**

- Create 2 invoices with the below grand total.

 **Invoice 1: ₹72,830.00
 Invoice 2: ₹38,892.00**

- Create a Payment: Payment 1 (Amount: ₹109,828.00).

- Go to Payment Reconciliation.
- Click Get Unreconciled Entries.
- Allocate the 2 invoices with 1 payment:

Manually edit allocated amount

**Row 1 - 72,829.00
Row 2 - 36,999.00**

**- (Total: ₹109,828.00 ✓)**

- Click Reconcile → Error occurs.

<img width="1880" height="924" alt="image" src="https://github.com/user-attachments/assets/bad5345f-e4b7-4988-91c7-7e215d1546a7" />


Before:

https://github.com/user-attachments/assets/b8b7c75c-36bf-4ebe-8253-ccba667e661a


After:

https://github.com/user-attachments/assets/40df8cc9-8bb0-4a28-968b-1867f552c419




**Backport Needed: Version-15**