### PR TITLE
fix:prevent address fetch when transporter is empty

### DIFF
--- a/erpnext/setup/doctype/driver/driver.js
+++ b/erpnext/setup/doctype/driver/driver.js
@@ -24,10 +24,15 @@ frappe.ui.form.on("Driver", {
 
 	transporter: function (frm, cdt, cdn) {
 		// this assumes that supplier's address has same title as supplier's name
+		if (!frm.doc.transporter) return;
 		frappe.db
-			.get_doc("Address", null, { address_title: frm.doc.transporter })
+			.get_value("Address", { address_title: frm.doc.transporter }, "name")
 			.then((r) => {
-				frappe.model.set_value(cdt, cdn, "address", r.name);
+				if (r && r.message && r.message.name) {
+					frappe.model.set_value(cdt, cdn, "address", r.message.name);
+				} else {
+					frappe.model.set_value(cdt, cdn, "address", "");
+				}
 			})
 			.catch((err) => {
 				console.log(err);


### PR DESCRIPTION
## Feature description
When creating a new Driver, if the user creates a new Transporter (Supplier) directly from the Transporter field, the system throws the following error

      Not found
      Address ({'address_title': ''}) not found
      The resource you are looking for is not available

This happens because the script in driver.js tries to fetch an Address document using an empty address_title, as the transporter field is not yet set when the Supplier is first created.

## Solution description

- A validation check has been added to ensure that the transporter field has a value before attempting to fetch the related Address record
- This prevents unnecessary database calls and avoids the “Address not found” error when a new Supplier is created from within the Driver form.

- Replaced the invalid `frappe.db.get_doc()` call with `frappe.db.get_value()` to correctly fetch the Address linked to the selected Transporter.
- Added a check to ensure the query only runs when a valid Transporter is selected.
- If an Address exists, it’s set on the Driver form; otherwise, the field is cleared.
- This prevents the “Address not found” error when creating a new Supplier (Transporter) from the Driver form and ensures smooth data handling.

Before  fix:

[Screencast from 17-10-25 12:09:56 AM IST.webm](https://github.com/user-attachments/assets/b0fd9799-2c61-4f4d-a637-8a95afc4e1e5)


After  fix:

[Screencast from 17-10-25 12:07:24 AM IST.webm](https://github.com/user-attachments/assets/389d61cd-0c9d-4545-81d3-62565339ceea)

- Creating a new Supplier from the Transporter field in the Driver form no longer throws any errors.
- The Driver form loads smoothly after the Supplier is created.
- Address fetching only happens when a valid transporter value is present.

## Areas affected and ensured

- Driver
- Address
- Supplier


## Is there any existing behavior change of other features due to this code change?
-No

## Was this feature tested on the browsers?
  - Mozilla Firefoxle

