### PR TITLE
fix(point-of-sale): render payment methods only when payment component is visible

### DIFF
--- a/erpnext/selling/page/point_of_sale/pos_payment.js
+++ b/erpnext/selling/page/point_of_sale/pos_payment.js
@@ -502,6 +502,10 @@ erpnext.PointOfSale.Payment = class {
 		const payments = doc.payments;
 		const currency = doc.currency;
 
+		if (!this.$payment_modes.is(":visible")) {
+			return;
+		}
+
 		this.$payment_modes.html(
 			`${payments
 				.map((p, i) => {
@@ -678,6 +682,10 @@ erpnext.PointOfSale.Payment = class {
 		const change = doc.change_amount || remaining <= 0 ? -1 * remaining : undefined;
 		const currency = doc.currency;
 		const label = doc.paid_amount > grand_total ? __("Change Amount") : __("Remaining Amount");
+
+		if (!this.$totals.is(":visible")) {
+			return;
+		}
 
 		this.$totals.html(
 			`<div class="col">


### PR DESCRIPTION
`render_payment_method_dom` and `update_totals_section` will get executed every time the "Paid Amount" field gets updated. If a Pricing Rule is applied to any item, it updates the Paid Amount even when none of the Payment Methods have been rendered, causing the POS Screen to freeze. 

Added a fix to `render_payment_mode_dom` and `update_totals_section` to execute only when the components are visible.

Support Ticket: [#51018](https://support.frappe.io/helpdesk/tickets/51018)