### PR TITLE
fix: link purchase invoice and receipt items to asset

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
@@ -1081,7 +1081,11 @@ class PurchaseInvoice(BuyingController):
 	def update_gross_purchase_amount_for_linked_assets(self, item):
 		assets = frappe.db.get_all(
 			"Asset",
-			filters={"purchase_invoice": self.name, "item_code": item.item_code},
+			filters={
+				"purchase_invoice": self.name,
+				"item_code": item.item_code,
+				"purchase_invoice_item": ("in", [item.name, ""]),
+			},
 			fields=["name", "asset_quantity"],
 		)
 		for asset in assets:

--- a/erpnext/assets/doctype/asset/asset.js
+++ b/erpnext/assets/doctype/asset/asset.js
@@ -586,6 +586,11 @@ frappe.ui.form.on("Asset", {
 			if (item.asset_location) {
 				frm.set_value("location", item.asset_location);
 			}
+			if (doctype === "Purchase Receipt") {
+				frm.set_value("purchase_receipt_item", item.purchase_receipt_item);
+			} else {
+				frm.set_value("purchase_invoice_item", item.purchase_invoice_item);
+			}
 		});
 	},
 

--- a/erpnext/assets/doctype/asset/asset.json
+++ b/erpnext/assets/doctype/asset/asset.json
@@ -33,7 +33,9 @@
   "dimension_col_break",
   "purchase_details_section",
   "purchase_receipt",
+  "purchase_receipt_item",
   "purchase_invoice",
+  "purchase_invoice_item",
   "available_for_use_date",
   "total_asset_cost",
   "additional_asset_cost",
@@ -550,6 +552,19 @@
    "label": "Additional Asset Cost",
    "options": "Company:company:default_currency",
    "read_only": 1
+  },
+  {
+   "fieldname": "purchase_receipt_item",
+   "fieldtype": "Data",
+   "hidden": 1,
+   "label": "Purchase Receipt Item"
+  },
+  {
+   "fieldname": "purchase_invoice_item",
+   "fieldtype": "Data",
+   "hidden": 1,
+   "label": "Purchase Invoice Item",
+   "options": "Purchase Invoice Item"
   }
  ],
  "idx": 72,
@@ -583,7 +598,7 @@
    "link_fieldname": "target_asset"
   }
  ],
- "modified": "2025-05-20 00:44:06.229177",
+ "modified": "2025-10-16 17:53:12.734384",
  "modified_by": "Administrator",
  "module": "Assets",
  "name": "Asset",

--- a/erpnext/controllers/buying_controller.py
+++ b/erpnext/controllers/buying_controller.py
@@ -753,6 +753,8 @@ class BuyingController(SubcontractingController):
 				"asset_quantity": asset_quantity,
 				"purchase_receipt": self.name if self.doctype == "Purchase Receipt" else None,
 				"purchase_invoice": self.name if self.doctype == "Purchase Invoice" else None,
+				"purchase_receipt_item": row.name if self.doctype == "Purchase Receipt" else None,
+				"purchase_invoice_item": row.name if self.doctype == "Purchase Invoice" else None,
 				"cost_center": row.cost_center,
 			}
 		)

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -377,3 +377,4 @@ execute:frappe.db.set_single_value("Accounts Settings", "receivable_payable_fetc
 erpnext.patches.v14_0.set_update_price_list_based_on
 erpnext.patches.v14_0.rename_group_by_to_categorize_by_in_custom_reports
 erpnext.patches.v14_0.update_full_name_in_contract
+erpnext.patches.v14_0.link_purchase_item_to_asset_doc

--- a/erpnext/patches/v14_0/link_purchase_item_to_asset_doc.py
+++ b/erpnext/patches/v14_0/link_purchase_item_to_asset_doc.py
@@ -1,0 +1,74 @@
+import frappe
+
+
+def execute():
+	if frappe.db.has_column("Asset", "purchase_invoice_item") and frappe.db.has_column(
+		"Asset", "purchase_receipt_item"
+	):
+		# Get all assets with their related Purchase Invoice and Purchase Receipt
+		assets = frappe.get_all(
+			"Asset",
+			filters={"docstatus": 0},
+			fields=[
+				"name",
+				"item_code",
+				"purchase_invoice",
+				"purchase_receipt",
+				"gross_purchase_amount",
+				"asset_quantity",
+				"purchase_invoice_item",
+				"purchase_receipt_item",
+			],
+		)
+
+		for asset in assets:
+			# Get Purchase Invoice Items
+			if asset.purchase_invoice and not asset.purchase_invoice_item:
+				purchase_invoice_item = get_linked_item(
+					"Purchase Invoice Item",
+					asset.purchase_invoice,
+					asset.item_code,
+					asset.gross_purchase_amount,
+					asset.asset_quantity,
+				)
+				frappe.db.set_value("Asset", asset.name, "purchase_invoice_item", purchase_invoice_item)
+
+			# Get Purchase Receipt Items
+			if asset.purchase_receipt and not asset.purchase_receipt_item:
+				purchase_receipt_item = get_linked_item(
+					"Purchase Receipt Item",
+					asset.purchase_receipt,
+					asset.item_code,
+					asset.gross_purchase_amount,
+					asset.asset_quantity,
+				)
+				frappe.db.set_value("Asset", asset.name, "purchase_receipt_item", purchase_receipt_item)
+
+
+def get_linked_item(doctype, parent, item_code, amount, quantity):
+	items = frappe.get_all(
+		doctype,
+		filters={
+			"parenttype": doctype.replace(" Item", ""),
+			"parent": parent,
+			"item_code": item_code,
+		},
+		fields=["name", "rate", "amount", "qty", "landed_cost_voucher_amount"],
+	)
+	if len(items) == 1:
+		# If only one item exists, return it directly
+		return items[0].name
+
+	for item in items:
+		landed_cost = item.get("landed_cost_voucher_amount", 0)
+		# Check if the asset is grouped
+		if quantity > 1:
+			if item.amount + landed_cost == amount and item.qty == quantity:
+				return item.name
+			elif item.qty == quantity:
+				return item.name
+		else:
+			if item.rate + (landed_cost / item.qty) == amount:
+				return item.name
+
+	return items[0].name if items else None

--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
@@ -714,7 +714,11 @@ class PurchaseReceipt(BuyingController):
 	def update_assets(self, item, valuation_rate):
 		assets = frappe.db.get_all(
 			"Asset",
-			filters={"purchase_receipt": self.name, "item_code": item.item_code},
+			filters={
+				"purchase_receipt": self.name,
+				"item_code": item.item_code,
+				"purchase_receipt_item": ("in", [item.name, ""]),
+			},
 			fields=["name", "asset_quantity"],
 		)
 


### PR DESCRIPTION
Issue: When a Purchase Receipt is created for an asset item, and the same item (same item code but different item name) is added in multiple rows with different rates, assets are created correctly on submission. However, when a Landed Cost Voucher is made for that Purchase Receipt, all the created assets get updated to the same value.

Ref:[#51019](https://support.frappe.io/helpdesk/tickets/51019)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Assets now link to specific purchase document line items, enabling enhanced tracking of asset origins from Purchase Receipts and Purchase Invoices.

* **Chores**
  * Automatic data migration populates asset records with source purchase document item references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->