### PR TITLE
fix: Payment Terms auto-fetched in Sales Invoice Without enabling the (automatically_fetch_payment_terms) in Account settings 

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -1399,7 +1399,6 @@ def make_sales_invoice(source_name, target_doc=None, ignore_permissions=False, a
 				"doctype": "Sales Invoice",
 				"field_map": {
 					"party_account_currency": "party_account_currency",
-					"payment_terms_template": "payment_terms_template",
 				},
 				"field_no_map": ["payment_terms_template"],
 				"validation": {"docstatus": ["=", 1]},


### PR DESCRIPTION
**Issue**  **Reference :** [50133](https://github.com/frappe/erpnext/issues/50133)


**Issue Description :**  Payment Terms auto-fetched in Sales Invoice Without enabling the (automatically_fetch_payment_terms) in Account settings


**before :**

[payment_terms_before.webm](https://github.com/user-attachments/assets/9a6e3a0b-510d-405b-a3e4-5068fcd34179)

**after :**

[Screencast from 27-10-25 09:15:35 AM IST.webm](https://github.com/user-attachments/assets/562ae946-c3a9-4575-ae3a-0f8164ba772e)
