### PR TITLE
 fix: Automatically disable expired pricing rules

### DIFF
--- a/erpnext/accounts/doctype/pricing_rule/pricing_rule.py
+++ b/erpnext/accounts/doctype/pricing_rule/pricing_rule.py
@@ -727,3 +727,37 @@ def get_item_uoms(doctype, txt, searchfield, start, page_len, filters):
 		fields=["distinct uom"],
 		as_list=1,
 	)
+
+
+def disable_expired_pricing_rules():
+	"""
+	Scheduled function to automatically disable pricing rules that have expired.
+	This should be run daily via a scheduled job.
+	"""
+	from frappe.utils import today
+
+	expired_rules = frappe.get_all(
+		"Pricing Rule",
+		filters={"valid_upto": ["<", today()], "disable": 0},
+		pluck="name",
+	)
+
+	if not expired_rules:
+		return
+
+	# Bulk update using ORM
+	frappe.db.set_value(
+		"Pricing Rule",
+		{"name": ["in", expired_rules]},
+		"disable",
+		1,
+		update_modified=True,
+	)
+
+	frappe.db.commit()
+
+	frappe.logger().info(
+		f"Auto-disabled {len(expired_rules)} expired pricing rule(s): "
+		f"{', '.join(expired_rules[:5])}"
+		+ (f" and {len(expired_rules) - 5} more" if len(expired_rules) > 5 else "")
+	)

--- a/erpnext/hooks.py
+++ b/erpnext/hooks.py
@@ -461,6 +461,7 @@ scheduler_events = {
 		"erpnext.accounts.utils.auto_create_exchange_rate_revaluation_daily",
 		"erpnext.accounts.utils.run_ledger_health_checks",
 		"erpnext.assets.doctype.asset_maintenance_log.asset_maintenance_log.update_asset_maintenance_log_status",
+		"erpnext.accounts.doctype.pricing_rule.pricing_rule.disable_expired_pricing_rules",
 	],
 	"weekly": [
 		"erpnext.accounts.utils.auto_create_exchange_rate_revaluation_weekly",


### PR DESCRIPTION
 Description:
  ## Summary

  This PR adds automatic disabling of expired pricing rules to prevent them from being
  applied to new transactions.

  ## Problem

  Expired pricing rules (where `valid_upto < today`) could still be manually enabled and
  would be applied to new sales invoices, causing:
  - Unexpected discounts on expired promotions
  - Revenue loss from unintended discounts
  - Customer confusion
  - Inventory/profit margin issues

  ## Solution

  Added a daily scheduled job that automatically disables all expired pricing rules.

  ### Changes Made:

  1. **New function**: `disable_expired_pricing_rules()` in `pricing_rule.py`
     - Finds all active pricing rules with `valid_upto < today`
     - Uses ORM bulk update (`frappe.db.set_value`) for efficiency
     - No loops - single query disables all expired rules
     - Logs disabled rules for audit trail
     - Updates `modified` timestamp automatically

  2. **Scheduled job**: Added to daily scheduler in `hooks.py`
     - Runs once per day automatically
     - Ensures expired promotional schemes stay disabled

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added immutable ledger option with confirmation prompt in Accounts Settings.
  * Implemented multi-currency support for bank reconciliation with automatic exchange rate handling.
  * Introduced auto-reconciliation job trigger with configurable queue size.

* **Improvements**
  * Enhanced bank account validation and default account management.
  * Added advance payment ledger tracking for improved payment visibility.
  * Updated account type options and field labeling for clarity.
  * Improved account clearance date propagation across transactions.

* **Documentation**
  * Updated community forum and documentation links to current platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->