### PR TITLE
fix: prevent expired or future pricing rules from applying on submit

### DIFF
--- a/erpnext/accounts/doctype/pricing_rule/pricing_rule.py
+++ b/erpnext/accounts/doctype/pricing_rule/pricing_rule.py
@@ -10,7 +10,7 @@ import re
 import frappe
 from frappe import _, throw
 from frappe.model.document import Document
-from frappe.utils import cint, flt
+from frappe.utils import cint, flt, getdate
 
 apply_on_dict = {"Item Code": "items", "Item Group": "item_groups", "Brand": "brands"}
 
@@ -451,6 +451,13 @@ def get_pricing_rule_for_item(args, doc=None, for_validate=False):
 				pricing_rule.apply_rule_on_other_items = (
 					get_pricing_rule_items(pricing_rule, other_items=fetch_other_item) or []
 				)
+
+			posting_date = args.get("posting_date") or args.get("transaction_date")
+			if posting_date:
+				if pricing_rule.get("valid_from") and pricing_rule.get("valid_from") > getdate(posting_date):
+					continue
+				if pricing_rule.get("valid_upto") and pricing_rule.get("valid_upto") < getdate(posting_date):
+					continue
 
 			if pricing_rule.get("coupon_code_based") == 1:
 				if not args.coupon_code:


### PR DESCRIPTION
Issue: ERPNext appears to apply pricing rules even if they're expired

Previously, pricing rules with valid date ranges outside of the selected date for sales invoice were applying discounts. This pull request adds date checks in the pricing rule application logic to prevent pricing rules outside date scope to apply discounts. This ensures the pricing rule is not applied on submission of sales invoices. To note is that a UI bug still exists due to missing `posting_date` and `transaction_date` values before submission.

- First check: Skip pricing rules that have a valid start date after the `posting_date`.

- Second check: Skip pricing rules that have a valid end date before the `posting_date`.

`transaction_date` is used as fallback in place of a missing `posting_date` in the checks.

# Showcase
The following showcase demonstrates the behavior of a 5% expired pricing rule before and after the date checks were added.
## Setup
In the following show case a pricing rule of 5 % with an expired date where setup as follows:
<img width="1917" height="904" alt="upper_Screenshot 2025-10-17 231414" src="https://github.com/user-attachments/assets/3d3b4e79-81ce-49ce-aee1-4b907f37c271" />
<img width="1916" height="908" alt="below_Screenshot 2025-10-17 231454" src="https://github.com/user-attachments/assets/e0379077-edc5-4c42-930d-a4876bde1116" />

## Before
![before2_Recording 2025-10-18 114035](https://github.com/user-attachments/assets/84450d73-0a1c-407d-971a-5791e1f965dd)

## After
![after2Recording 2025-10-18 114333](https://github.com/user-attachments/assets/ac46fb3e-7b61-4432-8518-a10b0456c87c)

Closes: #50122
