### PR TITLE
refactor: simplify expression

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -3088,9 +3088,7 @@ def set_balance_in_account_currency(
 			_("Account: {0} with currency: {1} can not be selected").format(gl_dict.account, account_currency)
 		)
 
-	gl_dict["account_currency"] = (
-		company_currency if account_currency == company_currency else account_currency
-	)
+	gl_dict["account_currency"] = account_currency
 
 	# set debit/credit in account currency if not provided
 	if flt(gl_dict.debit) and not flt(gl_dict.debit_in_account_currency):


### PR DESCRIPTION
I'd say this is true:

```python
(a if a == b else b) == b
```

Then this is also true:

```python
(company_currency if account_currency == company_currency else account_currency) == account_currency
```

So, we can replace the left side with the much shorter right side.