### PR TITLE
fix: Update pick list locations quantity

### DIFF
--- a/erpnext/stock/doctype/material_request/material_request.py
+++ b/erpnext/stock/doctype/material_request/material_request.py
@@ -902,6 +902,16 @@ def raise_work_orders(material_request):
 
 @frappe.whitelist()
 def create_pick_list(source_name, target_doc=None):
+	def update_item(obj, target, source_parent):
+		qty = (
+			flt(flt(obj.stock_qty) - flt(obj.ordered_qty)) / target.conversion_factor
+			if flt(obj.stock_qty) > flt(obj.ordered_qty)
+			else 0
+		)
+		target.qty = qty
+		target.stock_qty = qty * obj.conversion_factor
+		target.conversion_factor = obj.conversion_factor
+
 	doc = get_mapped_doc(
 		"Material Request",
 		source_name,
@@ -914,6 +924,11 @@ def create_pick_list(source_name, target_doc=None):
 			"Material Request Item": {
 				"doctype": "Pick List Item",
 				"field_map": {"name": "material_request_item", "stock_qty": "stock_qty"},
+				"postprocess": update_item,
+				"condition": lambda doc: (
+					flt(doc.ordered_qty, doc.precision("ordered_qty"))
+					< flt(doc.stock_qty, doc.precision("ordered_qty"))
+				),
 			},
 		},
 		target_doc,

--- a/erpnext/stock/doctype/material_request/test_material_request.py
+++ b/erpnext/stock/doctype/material_request/test_material_request.py
@@ -13,6 +13,7 @@ from frappe.utils import flt, today
 from erpnext.controllers.accounts_controller import InvalidQtyError
 from erpnext.stock.doctype.item.test_item import create_item
 from erpnext.stock.doctype.material_request.material_request import (
+	create_pick_list,
 	make_in_transit_stock_entry,
 	make_purchase_order,
 	make_stock_entry,
@@ -944,6 +945,36 @@ class TestMaterialRequest(IntegrationTestCase):
 		mr.save()
 
 		self.assertRaises(OverAllowanceError, mr.submit)
+
+	def test_pending_qty_in_pick_list(self):
+		"""Test for pick list mapped doc qty from partially received Material Request Transfer"""
+		import json
+
+		from erpnext.stock.doctype.pick_list.pick_list import create_stock_entry
+
+		mr = make_material_request(material_request_type="Material Transfer")
+		pl = create_pick_list(mr.name)
+		pl.save()
+		pl.locations[0].qty = 5
+		pl.locations[0].stock_qty = 5
+		pl.submit()
+
+		to_warehouse = create_warehouse("Test To Warehouse")
+
+		se_data = create_stock_entry(json.dumps(pl.as_dict()))
+		se = frappe.get_doc(se_data)
+		se.items[0].t_warehouse = to_warehouse
+		se.save()
+		se.submit()
+
+		pl.load_from_db()
+		self.assertEqual(pl.locations[0].picked_qty, se.items[0].qty)
+
+		mr.load_from_db()
+		self.assertEqual(mr.status, "Partially Received")
+
+		pl_for_pending = create_pick_list(mr.name)
+		self.assertEqual(pl_for_pending.locations[0].qty, 5)
 
 
 def get_in_transit_warehouse(company):

--- a/erpnext/stock/doctype/pick_list/pick_list.py
+++ b/erpnext/stock/doctype/pick_list/pick_list.py
@@ -1552,8 +1552,8 @@ def update_stock_entry_items_with_no_reference(pick_list, stock_entry):
 def update_common_item_properties(item, location):
 	item.item_code = location.item_code
 	item.s_warehouse = location.warehouse
-	item.qty = location.picked_qty * location.conversion_factor
 	item.transfer_qty = location.picked_qty
+	item.qty = location.qty
 	item.uom = location.uom
 	item.conversion_factor = location.conversion_factor
 	item.stock_uom = location.stock_uom


### PR DESCRIPTION
**Issue:** When creating a _Pick List_ against the partially picked _Material Request_, system is not calculating and passing the balance required quantity  from MR.

**Fix:** System will update the qty when creating _Pick List_ from _MR_ as per the formula **(Qty - Completed Qty)** and only considers items if the balance quantity is above zero.

**Ref: [50973](https://support.frappe.io/helpdesk/tickets/50973)**

**Before:**

[Screencast from 21-10-25 08:24:46 PM IST.webm](https://github.com/user-attachments/assets/fdd90af2-c6b5-4cbf-b1d2-2484ce2cdd24)

**After:**

[Screencast from 21-10-25 08:23:07 PM IST.webm](https://github.com/user-attachments/assets/d0c93ab7-ec6e-48fd-a46d-57fe5c814135)



While debugging the main issue, I identified an additional problem related to _Transfer Entry_ creation from the _Pick List_ and fixed it in the following commit:

Commit: f5860f2
Fix: Handled transfer quantity for multi-UOM items when creating a transfer from a pick list.

**Backport Needed: v15**


  