### PR TITLE
fix: feat: multiple changes related to subcontracting inward

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -1297,7 +1297,7 @@ class SalesInvoice(SellingController):
 							item.idx,
 							item.stock_qty,
 							item.stock_uom,
-							frappe.bold(item.item_code),
+							get_link_to_form("Item", item.item_code),
 							frappe.bold(max_qty),
 						)
 					)

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -3939,8 +3939,8 @@ def update_child_qty_rate(parent_doctype, trans_items, parent_doctype_name, chil
 		if parent.is_subcontracted and not parent.can_update_items():
 			frappe.throw(
 				_(
-					"Items cannot be updated as Subcontracting Inward Order is created against the Sales Order {0}."
-				).format(frappe.bold(parent.name))
+					"Items cannot be updated as Subcontracting Inward Order(s) exist against this Subcontracted Sales Order."
+				)
 			)
 		parent.validate_selling_price()
 		parent.validate_for_duplicate_items()

--- a/erpnext/controllers/subcontracting_controller.py
+++ b/erpnext/controllers/subcontracting_controller.py
@@ -156,7 +156,7 @@ class SubcontractingController(StockController):
 				frappe.throw(
 					_(
 						"Row {0}: Delivery Warehouse cannot be same as Customer Warehouse for Item {1}."
-					).format(item.idx, frappe.bold(item.item_name))
+					).format(item.idx, get_link_to_form("Item", item.item_code))
 				)
 
 			if not item.get("is_scrap_item"):
@@ -664,6 +664,8 @@ class SubcontractingController(StockController):
 
 	def __add_supplied_or_received_item(self, item_row, bom_item, qty):
 		bom_item.conversion_factor = item_row.conversion_factor
+		if self.subcontract_data.order_doctype == "Subcontracting Inward Order":
+			bom_item.pop("rate")
 		rm_obj = self.append(self.raw_material_table, bom_item)
 		if rm_obj.get("qty"):
 			# Qty field not exists

--- a/erpnext/manufacturing/doctype/work_order/work_order.js
+++ b/erpnext/manufacturing/doctype/work_order/work_order.js
@@ -652,7 +652,11 @@ frappe.ui.form.on("Work Order Item", {
 							required_qty: row.required_qty || 1,
 							item_name: r.message.item_name,
 							description: r.message.description,
-							source_warehouse: r.message.default_warehouse,
+							source_warehouse:
+								r.message.is_customer_provided_item &&
+								frm.doc.subcontracting_inward_order_item
+									? frm.doc.source_warehouse
+									: r.message.default_warehouse,
 							allow_alternative_item: r.message.allow_alternative_item,
 							include_item_in_manufacturing: r.message.include_item_in_manufacturing,
 						});

--- a/erpnext/stock/doctype/stock_entry/stock_entry.js
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.js
@@ -151,6 +151,17 @@ frappe.ui.form.on("Stock Entry", {
 		if (!check_should_not_attach_bom_items(frm.doc.bom_no)) {
 			erpnext.accounts.dimensions.update_dimension(frm, frm.doctype);
 		}
+
+		if (frm.doc.purpose == "Receive from Customer") {
+			frm.set_query("against_fg", "items", function () {
+				return {
+					query: "erpnext.controllers.subcontracting_inward_controller.get_fg_reference_names",
+					filters: {
+						parent: frm.doc.subcontracting_inward_order,
+					},
+				};
+			});
+		}
 	},
 
 	setup_quality_inspection: function (frm) {
@@ -853,6 +864,10 @@ frappe.ui.form.on("Stock Entry Detail", {
 		let item = frappe.get_doc(cdt, cdn);
 		if (item.is_finished_item) {
 			frm.events.set_fg_completed_qty(frm);
+		}
+
+		if (frm.doc.purpose === "Receive from Customer") {
+			item.t_warehouse = frm.doc.items.find((item) => item.scio_detail).t_warehouse;
 		}
 	},
 	set_basic_rate_manually(frm, cdt, cdn) {

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -904,10 +904,9 @@ class StockEntry(StockController, SubcontractingInwardController):
 			if d.s_warehouse or d.set_basic_rate_manually:
 				continue
 
-			if d.allow_zero_valuation_rate and self.purpose != "Receive from Customer":
+			if d.allow_zero_valuation_rate and d.basic_rate and self.purpose != "Receive from Customer":
 				d.basic_rate = 0.0
 				items.append(d.item_code)
-
 			elif d.is_finished_item:
 				if self.purpose == "Manufacture":
 					d.basic_rate = self.get_basic_rate_for_manufactured_item(

--- a/erpnext/stock/doctype/stock_entry_detail/stock_entry_detail.json
+++ b/erpnext/stock/doctype/stock_entry_detail/stock_entry_detail.json
@@ -21,6 +21,7 @@
   "is_scrap_item",
   "quality_inspection",
   "subcontracted_item",
+  "against_fg",
   "section_break_8",
   "description",
   "column_break_10",
@@ -113,7 +114,8 @@
    "label": "Target Warehouse",
    "oldfieldname": "t_warehouse",
    "oldfieldtype": "Link",
-   "options": "Warehouse"
+   "options": "Warehouse",
+   "read_only_depends_on": "eval:parent.purpose === \"Receive from Customer\""
   },
   {
    "fieldname": "sec_break1",
@@ -641,6 +643,16 @@
    "print_hide": 1,
    "read_only": 1,
    "search_index": 1
+  },
+  {
+   "depends_on": "eval:parent.purpose === \"Receive from Customer\" && !doc.scio_detail",
+   "fieldname": "against_fg",
+   "fieldtype": "Link",
+   "label": "Against Finished Good",
+   "mandatory_depends_on": "eval:parent.purpose === \"Receive from Customer\" && !doc.scio_detail",
+   "no_copy": 1,
+   "options": "Subcontracting Inward Order Item",
+   "set_only_once": 1
   }
  ],
  "grid_page_length": 50,
@@ -648,7 +660,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-10-14 14:10:38.373099",
+ "modified": "2025-10-16 11:50:50.573443",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Stock Entry Detail",

--- a/erpnext/stock/doctype/stock_entry_detail/stock_entry_detail.py
+++ b/erpnext/stock/doctype/stock_entry_detail/stock_entry_detail.py
@@ -16,6 +16,7 @@ class StockEntryDetail(Document):
 
 		actual_qty: DF.Float
 		additional_cost: DF.Currency
+		against_fg: DF.Link | None
 		against_stock_entry: DF.Link | None
 		allow_alternative_item: DF.Check
 		allow_zero_valuation_rate: DF.Check

--- a/erpnext/subcontracting/doctype/subcontracting_inward_order/subcontracting_inward_order.js
+++ b/erpnext/subcontracting/doctype/subcontracting_inward_order/subcontracting_inward_order.js
@@ -60,6 +60,14 @@ frappe.ui.form.on("Subcontracting Inward Order", {
 			};
 		});
 
+		frm.set_query("bom", "items", () => {
+			return {
+				filters: {
+					is_active: 1,
+				},
+			};
+		});
+
 		frm.set_query("set_delivery_warehouse", () => {
 			return {
 				filters: {

--- a/erpnext/subcontracting/doctype/subcontracting_inward_order/subcontracting_inward_order.py
+++ b/erpnext/subcontracting/doctype/subcontracting_inward_order/subcontracting_inward_order.py
@@ -275,10 +275,13 @@ class SubcontractingInwardOrder(SubcontractingController):
 						d.precision("qty"),
 					)
 					for item in self.get("received_items")
-					if item.reference_name == d.name and item.is_customer_provided_item
+					if item.reference_name == d.name and item.is_customer_provided_item and item.required_qty
 				]
 			)
-			qty = int(qty) if frappe.get_cached_value("UOM", d.stock_uom, "must_be_whole_number") else qty
+			qty = min(
+				int(qty) if frappe.get_cached_value("UOM", d.stock_uom, "must_be_whole_number") else qty,
+				d.qty - d.produced_qty,
+			)
 
 			item_details.update({"qty": qty, "max_producible_qty": qty})
 			item_list.append(item_details)

--- a/erpnext/subcontracting/doctype/subcontracting_inward_order/test_subcontracting_inward_order.py
+++ b/erpnext/subcontracting/doctype/subcontracting_inward_order/test_subcontracting_inward_order.py
@@ -66,6 +66,7 @@ class IntegrationTestSubcontractingInwardOrder(IntegrationTestCase):
 				"transfer_qty": 5,
 				"uom": "Nos",
 				"conversion_factor": 1,
+				"against_fg": scio.items[0].name,
 			},
 		)
 		rm_in.submit()

--- a/erpnext/subcontracting/doctype/subcontracting_inward_order_item/subcontracting_inward_order_item.json
+++ b/erpnext/subcontracting/doctype/subcontracting_inward_order_item/subcontracting_inward_order_item.json
@@ -46,6 +46,7 @@
    "in_global_search": 1,
    "label": "Item Name",
    "print_hide": 1,
+   "read_only": 1,
    "reqd": 1
   },
   {
@@ -185,7 +186,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-10-14 10:29:29.256455",
+ "modified": "2025-10-18 18:04:04.204651",
  "modified_by": "Administrator",
  "module": "Subcontracting",
  "name": "Subcontracting Inward Order Item",

--- a/erpnext/subcontracting/doctype/subcontracting_inward_order_received_item/subcontracting_inward_order_received_item.json
+++ b/erpnext/subcontracting/doctype/subcontracting_inward_order_received_item/subcontracting_inward_order_received_item.json
@@ -22,7 +22,9 @@
   "column_break_16",
   "consumed_qty",
   "work_order_qty",
-  "returned_qty"
+  "returned_qty",
+  "section_break_yhve",
+  "rate"
  ],
  "fields": [
   {
@@ -32,7 +34,8 @@
    "in_list_view": 1,
    "label": "Item Code",
    "options": "Item",
-   "read_only": 1
+   "read_only": 1,
+   "reqd": 1
   },
   {
    "columns": 2,
@@ -70,7 +73,8 @@
    "fieldname": "reference_name",
    "fieldtype": "Data",
    "label": "Reference Name",
-   "read_only": 1
+   "read_only": 1,
+   "reqd": 1
   },
   {
    "fieldname": "section_break_13",
@@ -116,7 +120,6 @@
   },
   {
    "default": "0",
-   "depends_on": "eval:doc.returned_qty",
    "fieldname": "returned_qty",
    "fieldtype": "Float",
    "label": "Returned Qty",
@@ -128,7 +131,7 @@
   {
    "allow_on_submit": 1,
    "default": "0",
-   "depends_on": "eval:doc.work_order_qty",
+   "depends_on": "eval:!(!doc.is_customer_provided_item && doc.is_additional_item)",
    "fieldname": "work_order_qty",
    "fieldtype": "Float",
    "label": "Work Order Qty",
@@ -146,7 +149,6 @@
    "reqd": 1
   },
   {
-   "depends_on": "eval:!doc.is_customer_provided_item",
    "fieldname": "warehouse",
    "fieldtype": "Link",
    "label": "Warehouse",
@@ -166,11 +168,27 @@
   },
   {
    "default": "0",
-   "depends_on": "eval:!doc.bom_detail_no",
    "fieldname": "is_additional_item",
    "fieldtype": "Check",
    "label": "Is Additional Item",
    "read_only": 1
+  },
+  {
+   "depends_on": "eval:doc.is_customer_provided_item",
+   "fieldname": "section_break_yhve",
+   "fieldtype": "Section Break"
+  },
+  {
+   "default": "0",
+   "fieldname": "rate",
+   "fieldtype": "Currency",
+   "label": "Rate",
+   "mandatory_depends_on": "eval:doc.is_customer_provided_item",
+   "no_copy": 1,
+   "non_negative": 1,
+   "options": "Company:company:default_currency",
+   "read_only": 1,
+   "read_only_depends_on": "eval:doc.is_customer_provided_item"
   }
  ],
  "grid_page_length": 50,
@@ -178,7 +196,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-10-14 10:18:58.905093",
+ "modified": "2025-10-21 23:44:18.302327",
  "modified_by": "Administrator",
  "module": "Subcontracting",
  "name": "Subcontracting Inward Order Received Item",

--- a/erpnext/subcontracting/doctype/subcontracting_inward_order_received_item/subcontracting_inward_order_received_item.py
+++ b/erpnext/subcontracting/doctype/subcontracting_inward_order_received_item/subcontracting_inward_order_received_item.py
@@ -19,12 +19,13 @@ class SubcontractingInwardOrderReceivedItem(Document):
 		consumed_qty: DF.Float
 		is_additional_item: DF.Check
 		is_customer_provided_item: DF.Check
-		main_item_code: DF.Link | None
+		main_item_code: DF.Link
 		parent: DF.Data
 		parentfield: DF.Data
 		parenttype: DF.Data
+		rate: DF.Currency
 		received_qty: DF.Float
-		reference_name: DF.Data | None
+		reference_name: DF.Data
 		required_qty: DF.Float
 		returned_qty: DF.Float
 		rm_item_code: DF.Link


### PR DESCRIPTION
1. replace all document references in error messages to now have hyperlinks to that document
2. new rows added to `Receive from Customer` Stock Entries as well as in the `Required Items` table of Work Order will now be autofilled with the customer warehouse from the linked Subcontracting Inward Order if the item is customer provided
3. transfer of items in Stock Entries related to Work Orders created against Subcontracting Inward Orders are now end to end ie. over consumption of customer provided items will not be allowed for mainly 2 reasons. Traceability and to maintain accurate value of stock
4. To receive extra customer provided item codes already not present in the `Required Items` table of the Subcontracting Inward Order, users will now have to specify against which finished good they will be using the raw material using the newly added `against_fg` field
5. Rate of each customer provided item will now be maintained in a new `rate` field of `Subcontracting Inward Order Received Item` child DocType, primarily done for tax compliance purposes
6. various bug and miscellaneous fixes