### PR TITLE
fix(payment-entry): avoid double deduction of outstanding in PE with advance-allocated invoices

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py
@@ -2453,6 +2453,30 @@ class TestPurchaseInvoice(IntegrationTestCase, StockTestMixin):
 				self.assertEqual(row.serial_no, "\n".join(serial_nos[:2]))
 				self.assertEqual(row.rejected_serial_no, serial_nos[2])
 
+	def test_ensure_outstanding_in_pi_and_pe_same_after_advance_allocation(self):
+		"Ensure outstanding amounts in Purchase Invoice (PI) and Payment Entry (PE) remain the same after advance allocation."
+		po = create_purchase_order(rate=1000, qty=1)
+
+		pe = get_payment_entry(dt="Purchase Order", dn=po.name, party_amount=700)
+		pe.save()
+		pe.submit()
+
+		pi = make_pi_from_po(po.name)
+		pi.allocate_advances_automatically = True
+		pi.set_advances()
+		pi.save()
+		pi.submit()
+
+		po.reload()
+		pi.reload()
+		pe.reload()
+
+		self.assertEqual(
+			flt(pi.outstanding_amount),
+			flt(pe.references[0].outstanding_amount, pi.precision("outstanding_amount")),
+			"Outstanding amount in PI and PE doesn't match after advance allocation.",
+		)
+
 	def test_make_pr_and_pi_from_po(self):
 		from erpnext.assets.doctype.asset.test_asset import create_asset_category
 

--- a/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
@@ -2029,6 +2029,78 @@ class TestSalesInvoice(ERPNextTestSuite):
 			flt(si.rounded_total + si.total_advance, si.precision("outstanding_amount")),
 		)
 
+	def test_ensure_outstanding_in_si_and_pe_same_after_advance_allocation(self):
+		"""
+		Ensure outstanding amounts in Sales Invoice (SI) and Payment Entry (PE)
+		remain the same after advance allocation.
+		"""
+		from erpnext.selling.doctype.sales_order.test_sales_order import make_sales_order
+
+		sales_order = make_sales_order(item_code="138-CMS Shoe", qty=1, price_list_rate=500)
+		pe = frappe.get_doc(
+			{
+				"doctype": "Payment Entry",
+				"payment_type": "Receive",
+				"party_type": "Customer",
+				"party": "_Test Customer",
+				"company": "_Test Company",
+				"paid_from_account_currency": "INR",
+				"paid_to_account_currency": "INR",
+				"source_exchange_rate": 1,
+				"target_exchange_rate": 1,
+				"reference_no": "1",
+				"reference_date": nowdate(),
+				"received_amount": 300,
+				"paid_amount": 300,
+				"paid_from": "Debtors - _TC",
+				"paid_to": "_Test Cash - _TC",
+			}
+		)
+		pe.append(
+			"references",
+			{
+				"reference_doctype": "Sales Order",
+				"reference_name": sales_order.name,
+				"total_amount": sales_order.grand_total,
+				"outstanding_amount": sales_order.grand_total,
+				"allocated_amount": 300,
+			},
+		)
+		pe.insert()
+		pe.submit()
+
+		sales_order.reload()
+		self.assertEqual(sales_order.advance_paid, 300)
+
+		si = frappe.copy_doc(self.globalTestRecords["Sales Invoice"][0])
+		si.items[0].sales_order = sales_order.name
+		si.items[0].so_detail = sales_order.get("items")[0].name
+		si.is_pos = 0
+		si.append(
+			"advances",
+			{
+				"doctype": "Sales Invoice Advance",
+				"reference_type": "Payment Entry",
+				"reference_name": pe.name,
+				"reference_row": pe.references[0].name,
+				"advance_amount": 300,
+				"allocated_amount": 300,
+				"remarks": pe.remarks,
+			},
+		)
+		si.insert()
+		si.submit()
+
+		si.reload()
+		pe.reload()
+		sales_order.reload()
+
+		self.assertEqual(
+			flt(si.outstanding_amount),
+			flt(pe.references[0].outstanding_amount, si.precision("outstanding_amount")),
+			"Outstanding amounts in SI and PE doesn't match after advance allocation",
+		)
+
 	def test_multiple_uom_in_selling(self):
 		frappe.db.sql(
 			"""delete from `tabItem Price`

--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -470,10 +470,11 @@ def _build_dimensions_dict_for_exc_gain_loss(
 
 
 def reconcile_against_document(
-	args, skip_ref_details_update_for_pe=False, active_dimensions=None
+	args, skip_ref_details_update_for_pe=False, active_dimensions=None, is_allocated=False
 ):  # nosemgrep
 	"""
 	Cancel PE or JV, Update against document, split if required and resubmit
+	is_allocated:  Ture if the target invoice already has allocated advances. Defaults to False.
 	"""
 	# To optimize making GL Entry for PE or JV with multiple references
 	reconciled_entries = {}
@@ -510,7 +511,8 @@ def reconcile_against_document(
 					skip_ref_details_update_for_pe=skip_ref_details_update_for_pe,
 					dimensions_dict=dimensions_dict,
 				)
-				if referenced_row.get("outstanding_amount"):
+				# avoid double deduction of outstanding amount if already allocated
+				if not is_allocated and referenced_row.get("outstanding_amount"):
 					referenced_row.outstanding_amount -= flt(entry.allocated_amount)
 
 				reposting_rows.append(referenced_row)

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -1854,7 +1854,7 @@ class AccountsController(TransactionBase):
 				for dim in active_dimensions:
 					if self.get(dim.fieldname):
 						x.update({dim.fieldname: self.get(dim.fieldname)})
-			reconcile_against_document(lst, active_dimensions=active_dimensions)
+			reconcile_against_document(lst, active_dimensions=active_dimensions, is_allocated=True)
 
 	def cancel_system_generated_credit_debit_notes(self):
 		# Cancel 'Credit/Debit' Note Journal Entries, if found.


### PR DESCRIPTION
**Ref:** [51148](https://support.frappe.io/helpdesk/tickets/51148)

**Issue:** The Outstanding amount was double-deducted when submitting an invoice with advance allocation in a Payment Entry.

**Fix:** Corrected the outstanding amount calculation in Payment Entry to prevent double deduction during advance reallocation.


Before:

https://github.com/user-attachments/assets/e5eca75b-1d29-4761-a6ad-c82fcd880171

After:

https://github.com/user-attachments/assets/77f227b1-5cd7-4093-9013-8ffcaa9afc1d



Backport Needed: v15
