### PR TITLE
fix: set status to Draft for auto-created assets from Purchase Receipt

### DIFF
--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -129,6 +129,8 @@ class Asset(AccountsController):
 		self.set_missing_values()
 		self.validate_gross_and_purchase_amount()
 		self.validate_finance_books()
+
+	def before_save(self):
 		self.total_asset_cost = self.net_purchase_amount + self.additional_asset_cost
 		self.status = self.get_status()
 

--- a/erpnext/controllers/buying_controller.py
+++ b/erpnext/controllers/buying_controller.py
@@ -1048,6 +1048,7 @@ class BuyingController(SubcontractingController):
 				"asset_category": item_data.get("asset_category"),
 				"location": row.asset_location,
 				"company": self.company,
+				"status": "Draft",
 				"supplier": self.supplier,
 				"purchase_date": self.posting_date,
 				"calculate_depreciation": 0,

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -442,3 +442,4 @@ erpnext.patches.v16_0.set_posting_datetime_for_sabb_and_drop_indexes
 erpnext.patches.v16_0.update_serial_no_reference_name
 erpnext.patches.v16_0.rename_subcontracted_quantity
 erpnext.patches.v16_0.add_new_stock_entry_types
+erpnext.patches.v15_0.set_asset_status_if_not_already_set

--- a/erpnext/patches/v15_0/set_asset_status_if_not_already_set.py
+++ b/erpnext/patches/v15_0/set_asset_status_if_not_already_set.py
@@ -1,0 +1,13 @@
+import frappe
+from frappe.query_builder import DocType
+
+
+def execute():
+	Asset = DocType("Asset")
+
+	query = (
+		frappe.qb.update(Asset)
+		.set(Asset.status, "Draft")
+		.where((Asset.docstatus == 0) & ((Asset.status.isnull()) | (Asset.status == "")))
+	)
+	query.run()


### PR DESCRIPTION
1. Ensures that newly auto-created assets from Purchase Receipts have their status set to "Draft" on creation.
2. Added a patch to update existing assets with docstatus = 0 and empty status to "Draft".

Internal support ticket: [Ref](https://support.frappe.io/helpdesk/tickets/51402)