### PR TITLE
fix(Bank Transaction)!: make transaction ID non-unique

### DIFF
--- a/erpnext/accounts/doctype/bank_transaction/bank_transaction.json
+++ b/erpnext/accounts/doctype/bank_transaction/bank_transaction.json
@@ -123,8 +123,7 @@
    "fieldname": "transaction_id",
    "fieldtype": "Data",
    "label": "Transaction ID",
-   "read_only": 1,
-   "unique": 1
+   "read_only": 1
   },
   {
    "allow_on_submit": 1,
@@ -239,7 +238,7 @@
  "grid_page_length": 50,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-09-26 17:06:29.207673",
+ "modified": "2025-10-23 17:32:58.514807",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Bank Transaction",


### PR DESCRIPTION
The _Transaction ID_ in **Bank Transaction** cannot be unique, since:

1) Transaction IDs are not guaranteed to be unique across Bank Accounts or Banks
2) We can have batch transactions, where each subtransaction shall be recorded in ERPNext but they all share the same  ID. (We added a custom _Subtransaction ID_ for this.)

I'd prefer backporting this to v15, since we should have a supported major version that allows unconstrained import of bank transactions.

Also, adding a custom unique constraint is much easier than removing a core one.