### PR TITLE
fix(accounts): validate target warehouse account mapping for internal…

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
@@ -4695,6 +4695,42 @@ class TestSalesInvoice(ERPNextTestSuite):
 
 		doc.db_set("do_not_use_batchwise_valuation", original_value)
 
+	def test_internal_si_missing_target_warehouse_account_validation(self):
+		from erpnext.stock.doctype.warehouse.test_warehouse import create_warehouse
+
+		company = "_Test Company with perpetual inventory"
+		customer = "_Test Internal Customer 2"
+
+		# Create a warehouse without an account link (no accounting settings); test setup ensures no default mapping
+		git_wh = create_warehouse("_Test Temp GIT No Account", company=company)
+
+		# Ensure there is stock at source to allow update_stock flow to proceed until GL stage
+		make_stock_entry(target="Stores - TCP1", company=company, qty=1, basic_rate=100)
+
+		si = create_sales_invoice(
+			company=company,
+			customer=customer,
+			debit_to="Debtors - TCP1",
+			warehouse="Stores - TCP1",
+			income_account="Sales - TCP1",
+			expense_account="Cost of Goods Sold - TCP1",
+			cost_center="Main - TCP1",
+			currency="INR",
+			do_not_save=1,
+		)
+
+		si.update_stock = 1
+		si.items[0].target_warehouse = git_wh
+		add_taxes(si)
+		si.save()
+
+		# Submitting should fail with user-facing missing account message, not raw 'Account is required'
+		with self.assertRaises(frappe.ValidationError) as ctx:
+			si.submit()
+
+		self.assertIn("Warehouse", str(ctx.exception))
+		self.assertIn("not linked to any account", str(ctx.exception))
+
 
 def make_item_for_si(item_code, properties=None):
 	from erpnext.stock.doctype.item.test_item import make_item

--- a/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
@@ -4702,7 +4702,7 @@ class TestSalesInvoice(ERPNextTestSuite):
 		customer = "_Test Internal Customer 2"
 
 		# Create a warehouse without an account link (no accounting settings); test setup ensures no default mapping
-		git_wh = create_warehouse("_Test Temp GIT No Account", company=company)
+		git_wh = create_warehouse("_Test Temp GIT No Account", company=company, properties={"account": None})
 
 		# Ensure there is stock at source to allow update_stock flow to proceed until GL stage
 		make_stock_entry(target="Stores - TCP1", company=company, qty=1, basic_rate=100)

--- a/erpnext/controllers/stock_controller.py
+++ b/erpnext/controllers/stock_controller.py
@@ -601,9 +601,17 @@ class StockController(AccountsController):
 						self.check_expense_account(item_row)
 
 						# expense account/ target_warehouse / source_warehouse
+						expense_account = None
 						if item_row.get("target_warehouse"):
 							warehouse = item_row.get("target_warehouse")
-							expense_account = warehouse_account[warehouse]["account"]
+							# Ensure target warehouse has an account mapping
+							if warehouse_account.get(warehouse):
+								expense_account = warehouse_account[warehouse]["account"]
+							else:
+								if warehouse not in warehouse_with_no_account:
+									warehouse_with_no_account.append(warehouse)
+								# Skip creating GL entries for this SLE row; error will be thrown later
+								continue
 						else:
 							expense_account = item_row.expense_account
 
@@ -649,9 +657,20 @@ class StockController(AccountsController):
 			if abs(sle_rounding_diff) > (1.0 / (10**precision)) and self.is_internal_transfer():
 				warehouse_asset_account = ""
 				if self.get("is_internal_customer"):
-					warehouse_asset_account = warehouse_account[item_row.get("target_warehouse")]["account"]
+					_target_wh = item_row.get("target_warehouse")
+					if not _target_wh or not warehouse_account.get(_target_wh):
+						if _target_wh and _target_wh not in warehouse_with_no_account:
+							warehouse_with_no_account.append(_target_wh)
+						# Cannot proceed with rounding entries without a target warehouse account
+						continue
+					warehouse_asset_account = warehouse_account[_target_wh]["account"]
 				elif self.get("is_internal_supplier"):
-					warehouse_asset_account = warehouse_account[item_row.get("warehouse")]["account"]
+					_source_wh = item_row.get("warehouse")
+					if not _source_wh or not warehouse_account.get(_source_wh):
+						if _source_wh and _source_wh not in warehouse_with_no_account:
+							warehouse_with_no_account.append(_source_wh)
+						continue
+					warehouse_asset_account = warehouse_account[_source_wh]["account"]
 
 				expense_account = frappe.get_cached_value("Company", self.company, "default_expense_account")
 				if not expense_account:


### PR DESCRIPTION
fix(accounts): validate target warehouse account mapping for internal SI update_stock to avoid 'Account is required'; add regression test

Fixes: #34834

<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/erpnext/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

## Problem
When submitting a Sales Invoice for an internal customer with Update Stock enabled, the system could fail with a cryptic "Account is required" error. This occurred when the target warehouse lacked an account mapping, causing GL entries to be created without a valid account field.

## Root Cause
In `controllers/stock_controller.py`, the `get_gl_entries()` method would attempt to create GL entries for stock transfers without validating that the target warehouse had an associated account. For internal transfers with `update_stock=1`, this resulted in GL entries with empty `account` fields, which failed validation during submission.

## Solution
- **Validate warehouse account mappings** before constructing GL entries in `StockController.get_gl_entries()`
- **Skip GL entry creation** for warehouses without account mappings and collect them for user-facing error reporting
- **Guard internal transfer rounding GL** to only proceed when warehouse account mappings exist
- **Surface clear validation errors** instead of generic "Account is required" messages

## Changes Made
1. **`controllers/stock_controller.py`**:
   - Added validation for `target_warehouse` account mapping before creating GL entries
   - Enhanced internal transfer rounding logic to check warehouse account existence
   - Improved error collection for missing warehouse accounts

2. **`accounts/doctype/sales_invoice/test_sales_invoice.py`**:
   - Added regression test `test_internal_si_missing_target_warehouse_account_validation`
   - Tests internal customer SI with Update Stock and target warehouse lacking account mapping
   - Verifies user-facing warehouse account error is raised instead of generic GL validation error

## Testing
- All existing tests pass
- New regression test validates the fix
- Manual testing confirms proper error messages for missing warehouse accounts

## Impact
- **Before**: Internal SI with missing warehouse account mapping failed with "Account is required"
- **After**: Clear error message: "Warehouse {name} is not linked to any account, please mention the account in the warehouse record or set default inventory account in company {company}"

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->

**Before (Error):**
