### PR TITLE
fix: ensure the company address belongs to the selected company

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -303,6 +303,7 @@ class AccountsController(TransactionBase):
 		self.set_default_letter_head()
 		self.validate_company_in_accounting_dimension()
 		self.validate_party_address_and_contact()
+		self.validate_company_address()
 
 	def set_default_letter_head(self):
 		if hasattr(self, "letter_head") and not self.letter_head:
@@ -2328,6 +2329,29 @@ class AccountsController(TransactionBase):
 
 		return party_type, party
 
+	def get_company_address(self):
+		field = None
+		if self.doctype in ("Quotation", "Sales Order", "Delivery Note", "Sales Invoice"):
+			field = "company_address"
+
+		elif self.doctype in (
+			"Supplier Quotation",
+			"Purchase Order",
+			"Purchase Receipt",
+			"Purchase Invoice",
+		):
+			field = "billing_address"
+
+		elif self.meta.get_field("customer"):
+			field = "company_address"
+
+		elif self.meta.get_field("supplier"):
+			field = "billing_address"
+
+		address = self.get(field) if field else None
+
+		return address
+
 	def validate_currency(self):
 		if self.get("currency"):
 			party_type, party = self.get_party()
@@ -2932,6 +2956,24 @@ class AccountsController(TransactionBase):
 		for x in gl_entries:
 			x["transaction_currency"] = self.currency
 			x["transaction_exchange_rate"] = self.get("conversion_rate") or 1
+
+	def validate_company_address(self):
+		company_address = self.get_company_address()
+		if company_address and not frappe.db.exists(
+			"Dynamic Link",
+			{
+				"parent": company_address,
+				"parenttype": "Address",
+				"link_doctype": "Company",
+				"link_name": self.company,
+			},
+		):
+			frappe.throw(
+				_("The selected Company Address {0} does not belong to Company {1}.").format(
+					get_link_to_form("Address", company_address), bold(self.company)
+				),
+				title=_("Invalid Company Address"),
+			)
 
 
 @frappe.whitelist()

--- a/erpnext/controllers/tests/test_accounts_controller.py
+++ b/erpnext/controllers/tests/test_accounts_controller.py
@@ -16,8 +16,12 @@ from erpnext.accounts.doctype.payment_entry.test_payment_entry import create_pay
 from erpnext.accounts.doctype.purchase_invoice.test_purchase_invoice import make_purchase_invoice
 from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_sales_invoice
 from erpnext.accounts.party import get_party_account
-from erpnext.buying.doctype.purchase_order.test_purchase_order import prepare_data_for_internal_transfer
+from erpnext.buying.doctype.purchase_order.test_purchase_order import (
+	create_purchase_order,
+	prepare_data_for_internal_transfer,
+)
 from erpnext.projects.doctype.project.test_project import make_project
+from erpnext.selling.doctype.sales_order.test_sales_order import make_sales_order
 from erpnext.stock.doctype.item.test_item import create_item
 
 
@@ -2227,6 +2231,11 @@ class TestAccountsController(IntegrationTestCase):
 		)
 		supplier_shipping.append("links", {"link_doctype": "Supplier", "link_name": "_Test Supplier"})
 		supplier_shipping.save()
+		company_address = make_address(
+			address_title="test", address_type="Billing", address_line1="100", city="Mumbai"
+		)
+		company_address.append("links", {"link_doctype": "User", "link_name": "Administrator"})
+		company_address.save()
 
 		si = create_sales_invoice(do_not_save=True)
 		si.customer_address = supplier_billing.name
@@ -2245,6 +2254,22 @@ class TestAccountsController(IntegrationTestCase):
 		self.assertRaises(frappe.ValidationError, pi.save)
 		pi.supplier_address = supplier_shipping.name
 		pi.save()
+
+		so = make_sales_order(do_not_save=True)
+		so.company_address = company_address.name
+		self.assertRaises(frappe.ValidationError, so.save)
+
+		si = create_sales_invoice(do_not_save=True)
+		si.company_address = company_address.name
+		self.assertRaises(frappe.ValidationError, si.save)
+
+		pi = make_purchase_invoice(do_not_save=True)
+		pi.billing_address = company_address.name
+		self.assertRaises(frappe.ValidationError, pi.save)
+
+		po = create_purchase_order(do_not_save=True)
+		po.billing_address = company_address.name
+		self.assertRaises(frappe.ValidationError, po.save)
 
 	def test_party_contact(self):
 		from frappe.contacts.doctype.contact.test_contact import create_contact


### PR DESCRIPTION
**Issue**  **Reference :**  [48385](https://github.com/frappe/erpnext/issues/48385)

**Issue Description:** Company Address could be selected even if it was not linked to the selected Company.

**Fix:** Added validation to restrict selection to Company Addresses linked with the selected Company.

**before:**

[Before_validation.webm](https://github.com/user-attachments/assets/b395a21b-9205-47d3-9f0e-8aea8886978f)

**after:**

[After_Validation.webm](https://github.com/user-attachments/assets/96e30cce-cf69-45c0-9f7a-5ac1e8ef57c7)

