### PR TITLE
fix(gross profit): remove customer name from columns

### DIFF
--- a/erpnext/accounts/report/gross_profit/gross_profit.py
+++ b/erpnext/accounts/report/gross_profit/gross_profit.py
@@ -233,9 +233,12 @@ def get_data_when_not_grouped_by_invoice(gross_profit_data, filters, group_wise_
 
 	# removing customer_name from group columns
 	customer_master_name = frappe.db.get_single_value("Selling Settings", "cust_master_name")
+	supplier_master_name = frappe.db.get_single_value("Buying Settings", "supp_master_name")
 
-	if "customer_name" in group_columns and customer_master_name == "Customer Name":
-		group_columns.remove("customer_name")
+	if "customer_name" in group_columns and (
+		supplier_master_name == "Supplier Name" and customer_master_name == "Customer Name"
+	):
+		group_columns = [col for col in group_columns if col != "customer_name"]
 
 	for src in gross_profit_data.grouped_data:
 		total_base_amount += src.base_amount or 0.00

--- a/erpnext/accounts/report/gross_profit/gross_profit.py
+++ b/erpnext/accounts/report/gross_profit/gross_profit.py
@@ -231,6 +231,12 @@ def get_data_when_not_grouped_by_invoice(gross_profit_data, filters, group_wise_
 
 	group_columns = group_wise_columns.get(scrub(filters.group_by))
 
+	# removing customer_name from group columns
+	customer_master_name = frappe.db.get_single_value("Selling Settings", "cust_master_name")
+
+	if "customer_name" in group_columns and customer_master_name == "Customer Name":
+		group_columns.remove("customer_name")
+
 	for src in gross_profit_data.grouped_data:
 		total_base_amount += src.base_amount or 0.00
 		total_buying_amount += src.buying_amount or 0.00


### PR DESCRIPTION
Issue: When the Gross Profit report is generated for Customer and Customer Group, it shows correctly for Customer Group, but shows incorrect results for Customer if the Customer Naming By in Selling Settings is set to Customer Name.

Ref: [#51379](https://support.frappe.io/helpdesk/tickets/51379)

Before:

<img width="1792" height="1120" alt="Screenshot 2025-10-27 at 11 08 55 AM" src="https://github.com/user-attachments/assets/bb92c01a-d868-4bea-81f2-c28dd9e0fc24" />


After:

<img width="1792" height="1120" alt="Screenshot 2025-10-27 at 11 10 12 AM" src="https://github.com/user-attachments/assets/7186f224-04d8-497e-807b-88b7b76c11d1" />


Backport needed: v15