### PR TITLE
fix: Pass uom field name to update existing item qty

### DIFF
--- a/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.js
+++ b/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.js
@@ -7,7 +7,10 @@ frappe.provide("erpnext.accounts.dimensions");
 frappe.ui.form.on("Stock Reconciliation", {
 	setup(frm) {
 		frm.ignore_doctypes_on_cancel_all = ["Serial and Batch Bundle"];
-		frm.barcode_scanner = new erpnext.utils.BarcodeScanner({ frm });
+		frm.barcode_scanner = new erpnext.utils.BarcodeScanner({
+			frm: frm,
+			uom_field: "stock_uom",
+		});
 	},
 
 	onload: function (frm) {


### PR DESCRIPTION
**Issue:** When scanning a barcode in Stock Reconciliation, the system adds a new row for the same item instead of increasing the quantity in the existing item row. This causes a poor UX.

**Fix:** The system was matching the item row using the default UOM field (uom), while in this case, the field used was stock_uom. To fix this, the uom field was explicitly passed when initializing the BarcodeScanner, ensuring correct item row matching and quantity updates.

**Ref: [51626](https://support.frappe.io/helpdesk/tickets/51626)**

**Before:**

[stock-recon-barcode-scan.issue.webm](https://github.com/user-attachments/assets/3895d12d-8935-473d-afb2-ace0553166c1)

**After:**

[stock-recon-barcode-scan-fixed.webm](https://github.com/user-attachments/assets/5e87ffef-b57e-4fcd-be9c-763e18b63d4a)

**Backport Needed: v15**