### PR TITLE
fix(asset depreciations and balances): showing opening entries

### DIFF
--- a/erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py
+++ b/erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py
@@ -273,6 +273,7 @@ def get_asset_value_adjustment_map_by_category(filters):
 			AND a.company = %(company)s
 			AND a.purchase_date <= %(to_date)s
 			AND gle.account = aca.fixed_asset_account
+			AND gle.is_opening = 'No'
 		GROUP BY a.asset_category
 	""",
 		{"from_date": filters.from_date, "to_date": filters.to_date, "company": filters.company},
@@ -543,6 +544,7 @@ def get_asset_value_adjustment_map(filters):
 			AND a.company = %(company)s
 			AND a.purchase_date <= %(to_date)s
 			AND gle.account = aca.fixed_asset_account
+			AND gle.is_opening = 'No'
 		GROUP BY a.name
 	""",
 		{"from_date": filters.from_date, "to_date": filters.to_date, "company": filters.company},


### PR DESCRIPTION
Issue:
When an existing asset is created with a value of ₹1000, and an opening journal entry of ₹1000 is also made against the Fixed Asset account, the Asset Depreciations and Balances incorrectly show the opening entries too.

Ref: [#49614](https://support.frappe.io/helpdesk/tickets/49614)

Before:

<img width="1792" height="1120" alt="Screenshot 2025-10-24 at 6 27 26 PM" src="https://github.com/user-attachments/assets/2a0fb79e-6760-4e58-a07c-e931e0227084" />

After:

<img width="1792" height="1120" alt="Screenshot 2025-10-24 at 6 27 32 PM" src="https://github.com/user-attachments/assets/62fe82e5-7813-419e-88f2-5d17f4bc1fe0" />


Backport needed: v15
