### PR TITLE
fix: missed refactoring code

### DIFF
--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -1932,9 +1932,6 @@ def get_valuation_rate(
 
 	# Get moving average rate of a specific batch number
 	if warehouse and serial_and_batch_bundle:
-		sabb = frappe.db.get_value(
-			"Serial and Batch Bundle", serial_and_batch_bundle, ["posting_date", "posting_time"], as_dict=True
-		)
 		batch_obj = BatchNoValuation(
 			sle=frappe._dict(
 				{
@@ -1942,7 +1939,9 @@ def get_valuation_rate(
 					"warehouse": warehouse,
 					"actual_qty": -1,
 					"serial_and_batch_bundle": serial_and_batch_bundle,
-					"posting_datetime": get_combine_datetime(sabb.posting_date, sabb.posting_time),
+					"posting_datetime": frappe.get_value(
+						"Serial and Batch Bundle", serial_and_batch_bundle, "posting_datetime"
+					),
 				}
 			)
 		)


### PR DESCRIPTION
When manually selecting batches when receiving materials through `Material Receipt` Stock Entry, this error was being thrown.

<img width="1642" height="1154" alt="CleanShot 2025-10-28 at 13 47 18@2x" src="https://github.com/user-attachments/assets/9f036ccf-3657-4098-aad1-3041e012687b" />

Related to changes made in #49710 