### PR TITLE
fix(pos): order pos invoices by timestamp

### DIFF
--- a/erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.py
+++ b/erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.py
@@ -161,6 +161,8 @@ def get_pos_invoices(start, end, pos_profile, user):
 		`tabPOS Invoice`
 	where
 		owner = %s and docstatus = 1 and pos_profile = %s and ifnull(consolidated_invoice,'') = ''
+	order by
+		timestamp
 	""",
 		(user, pos_profile),
 		as_dict=1,


### PR DESCRIPTION
**Issue:**
Negative stock error occurs when submitting a *POS Closing Entry* even though sufficient stock is available.

**Ref: [51587](https://support.frappe.io/helpdesk/tickets/51587)**

**Steps to Reproduce:**
1. Create POS Invoices for the same customer, item, and warehouse using the total available quantity (stock balance becomes zero).  
2. Create an Inward Entry for the same item and warehouse. Then, complete another POS Invoice for the same customer as before.  
3. Create a POS Invoice for a different item for the same customer, but with a posting date and time **before** the Inward Entry.  
4. When submitting the POS Closing Entry, the system consolidates POS Invoices by customer and sets the posting time to that of the **last POS Invoice**, resulting in a negative stock error.

**Solution:**
Added ordering by timestamp when fetching POS Invoices in the *POS Closing Entry*, ensuring invoices are processed in chronological order and preventing negative stock errors.

**Beore:**

[Screencast from 30-10-25 06:12:35 PM IST.webm](https://github.com/user-attachments/assets/4fa732d9-a3db-4661-9725-2fc56586baf1)

**After:**

<img width="1917" height="939" alt="Screenshot from 2025-10-30 18-13-51" src="https://github.com/user-attachments/assets/4fdbd850-a961-400e-aaa6-7090e3472810" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved POS closing entry process by ensuring invoices are retrieved in a consistent, deterministic order, enhancing the reliability and predictability of closing operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->