### PR TITLE
Revert "refactor: add supplier filter in buying (backport #50013)"

### DIFF
--- a/erpnext/public/js/controllers/buying.js
+++ b/erpnext/public/js/controllers/buying.js
@@ -17,17 +17,7 @@ erpnext.buying = {
 				this.setup_queries(doc, cdt, cdn);
 				super.onload();
 
-				if (["Purchase Order", "Purchase Receipt", "Purchase Invoice"].includes(this.frm.doctype)) {
-					this.frm.set_query("supplier", function () {
-						return {
-							filters: {
-								is_transporter: 0,
-							},
-						};
-					});
-				}
-
-				this.frm.set_query("shipping_rule", function () {
+				this.frm.set_query('shipping_rule', function() {
 					return {
 						filters: {
 							"shipping_rule_type": "Buying"


### PR DESCRIPTION
Reverts frappe/erpnext#50107

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed supplier filter restrictions in Purchase Order, Purchase Receipt, and Purchase Invoice documents. Previously, transporters could not be selected as suppliers; this restriction has been removed, allowing greater flexibility in supplier selection for purchasing operations.

* **Improvements**
  * Streamlined document initialization process while maintaining complete shipping rule functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->