### PR TITLE
fix: handle None in last_valuation_rate check

### DIFF
--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -1927,7 +1927,7 @@ def get_valuation_rate(
 		)
 
 		last_valuation_rate = query.run()
-		if last_valuation_rate:
+		if last_valuation_rate and last_valuation_rate[0][0] is not None:
 			return flt(last_valuation_rate[0][0])
 
 	# Get moving average rate of a specific batch number


### PR DESCRIPTION
**Issue:** When creating a _Manufacture Entry_ without raw materials for a batch item, the valuation rate was incorrectly set to zero. This caused miscalculations in the _Stock Ledger_.

**Cause:** The `last_valuation_rate` check passed even when the query result contained a nested tuple with a None value. This led to the valuation rate being set to zero unintentionally.

**Solution:** The condition now explicitly checks for `None` in the query result. The valuation rate is returned only if it has a valid numeric value (including zero).

**Ref: [52253](https://support.frappe.io/helpdesk/tickets/52253)**

**Before:**

[Screencast from 01-11-25 06:13:40 PM IST.webm](https://github.com/user-attachments/assets/fd85f9f9-ad72-4d2b-9ee8-410a7fe79c05)


**After:**

[Screencast from 01-11-25 06:19:38 PM IST.webm](https://github.com/user-attachments/assets/1da3c8c1-04d4-4442-98c5-00981b8f0ea1)



**Backport Needed: v15**