### PR TITLE
fix(accounts): populate correct fields on GL Entry during discount accounting

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -2005,7 +2005,7 @@ class AccountsController(TransactionBase):
 									discount_amount * self.get("conversion_rate"),
 									item.precision("discount_amount"),
 								),
-								"debit_in_account_currency": flt(
+								"debit_in_transaction_currency": flt(
 									discount_amount, item.precision("discount_amount")
 								),
 								"cost_center": item.cost_center,
@@ -2026,7 +2026,7 @@ class AccountsController(TransactionBase):
 									discount_amount * self.get("conversion_rate"),
 									item.precision("discount_amount"),
 								),
-								"credit_in_account_currency": flt(
+								"credit_in_transaction_currency": flt(
 									discount_amount, item.precision("discount_amount")
 								),
 								"cost_center": item.cost_center,


### PR DESCRIPTION
Fixed the issue where the `debit_in_account_currency` \ `credit_in_account_currency` fields were getting populated instead of the `debit_in_transaction_currency` \ `credit_in_transaction_currency` on GL Entry in Discount Accounting with multi-currency, causing a mismatch in the Trial Balance Report and General Ledger Report.

Support Ticket: [50933](https://support.frappe.io/helpdesk/tickets/50933)