### PR TITLE
fix: backport Pull Request #47016 to version-15

### DIFF
--- a/erpnext/hooks.py
+++ b/erpnext/hooks.py
@@ -340,10 +340,7 @@ doc_events = {
 	"User": {
 		"after_insert": "frappe.contacts.doctype.contact.contact.update_contact",
 		"validate": "erpnext.setup.doctype.employee.employee.validate_employee_role",
-		"on_update": [
-			"erpnext.setup.doctype.employee.employee.update_user_permissions",
-			"erpnext.portal.utils.set_default_role",
-		],
+		"on_update": "erpnext.portal.utils.set_default_role",
 	},
 	"Communication": {
 		"on_update": [

--- a/erpnext/setup/doctype/employee/employee.py
+++ b/erpnext/setup/doctype/employee/employee.py
@@ -88,9 +88,6 @@ class Employee(NestedSet):
 		if not self.has_value_changed("user_id") and not self.has_value_changed("create_user_permission"):
 			return
 
-		if not has_permission("User Permission", ptype="write", raise_exception=False):
-			return
-
 		employee_user_permission_exists = frappe.db.exists(
 			"User Permission", {"allow": "Employee", "for_value": self.name, "user": self.user_id}
 		)
@@ -249,16 +246,6 @@ def validate_employee_role(doc, method=None, ignore_emp_check=False):
 			_("User {0}: Removed Employee Self Service role as there is no mapped employee.").format(doc.name)
 		)
 		doc.get("roles").remove(doc.get("roles", {"role": "Employee Self Service"})[0])
-
-
-def update_user_permissions(doc, method):
-	# called via User hook
-	if "Employee" in [d.role for d in doc.get("roles")]:
-		if not has_permission("User Permission", ptype="write", raise_exception=False):
-			return
-		employee = frappe.get_doc("Employee", {"user_id": doc.name})
-		employee.update_user_permissions()
-
 
 def get_employee_email(employee_doc):
 	return (


### PR DESCRIPTION
While linking an existing **User** to an **Employee**, I noticed that if the current user does not have permission to **write** in the `User Permission` Doctype, ERPNext silently continues without any error — even when the `Create User Permission` field is enabled.

<img width="1058" height="320" alt="image" src="https://github.com/user-attachments/assets/65ea56d7-3213-492a-bb5a-3c4a8d15044d" />


As a result, the new Employee record is created without proper permission restrictions, allowing the linked user to see all other employees’ data — including sensitive information — without any **restrictions**.

After investigating the source code, I found the cause in erpnext/setup/doctype/employee/employee.py (v15):
```python
if not has_permission("User Permission", ptype="write", raise_exception=False):
    return
```
This condition prevents Frappe from raising an error when permission is missing, and also not creating the `User Permission`.
I discovered that this issue was already fixed in `develop branch`, but the change was labeled with `defer backport` and never merged into **version-15**.

Also requires a backport of  [#2971](https://github.com/frappe/hrms/pull/2971) for HRMS App

### References

Original **PR**: [#47016](https://github.com/frappe/erpnext/pull/47016) `defer backport`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined the user and employee permission synchronization process to execute directly through the Employee class method, removing an intermediate validation step.
  * Simplified the execution flow for role assignments during user updates, reducing the number of processes executed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->