### PR TITLE
fix(stock): prevent serial number reuse in manufacturing after delivery

### DIFF
--- a/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py
+++ b/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py
@@ -73,8 +73,7 @@ class SerialandBatchBundle(Document):
 		item_group: DF.Link | None
 		item_name: DF.Data | None
 		naming_series: DF.Literal["", "SABB-.########"]
-		posting_date: DF.Date | None
-		posting_time: DF.Time | None
+		posting_datetime: DF.Datetime | None
 		returned_against: DF.Data | None
 		total_amount: DF.Float
 		total_qty: DF.Float
@@ -119,8 +118,8 @@ class SerialandBatchBundle(Document):
 		self.allow_existing_serial_nos()
 		if not self.flags.ignore_validate_serial_batch or frappe.in_test:
 			self.validate_serial_nos_duplicate()
-			self.check_future_entries_exists()
 
+		self.check_future_entries_exists()
 		self.set_is_outward()
 		self.calculate_total_qty()
 		self.set_warehouse()
@@ -229,7 +228,7 @@ class SerialandBatchBundle(Document):
 			return
 
 		if self.voucher_type == "Stock Reconciliation":
-			serial_nos = self.get_serial_nos_for_validate()
+			serial_nos, batches = self.get_serial_nos_for_validate()
 		else:
 			serial_nos = [d.serial_no for d in self.entries if d.serial_no]
 
@@ -252,8 +251,7 @@ class SerialandBatchBundle(Document):
 			kwargs.update(
 				{
 					"voucher_no": self.voucher_no,
-					"posting_date": self.posting_date,
-					"posting_time": self.posting_time,
+					"posting_datetime": self.posting_datetime,
 				}
 			)
 
@@ -288,11 +286,30 @@ class SerialandBatchBundle(Document):
 			return
 
 		serial_nos = [d.serial_no for d in self.entries if d.serial_no]
+
+		# Check if this is a return transaction
+		# Returns legitimately reuse serial numbers that were delivered
+		is_return = self.is_return_transaction()
+		
+		if not is_return:
+			# For non-return transactions, prevent reuse of delivered serial numbers
+			deliver_serials = frappe.get_all(
+				"Serial No",
+				filters={"name": ("in", serial_nos), "status": "Delivered"},
+				pluck="name",
+			)
+			if deliver_serials:
+				for serial_no in deliver_serials:
+					self.throw_error_message(
+						f"Serial No {bold(serial_no)} is already delivered and cannot be reused. "
+						f"Serial numbers must be unique per item.",
+						SerialNoDuplicateError,
+					)
+
 		kwargs = frappe._dict(
 			{
 				"item_code": self.item_code,
-				"posting_date": self.posting_date,
-				"posting_time": self.posting_time,
+				"posting_datetime": self.posting_datetime,
 				"serial_nos": serial_nos,
 				"check_serial_nos": True,
 			}
@@ -312,10 +329,42 @@ class SerialandBatchBundle(Document):
 					SerialNoDuplicateError,
 				)
 
+	def is_return_transaction(self):
+		"""
+		Check if this is a return transaction.
+		Return transactions legitimately reuse serial numbers.
+		"""
+		# Check if returned_against field is set
+		if self.returned_against:
+			return True
+		
+		# Check if parent voucher is a return
+		if self.voucher_type in [
+			"Delivery Note",
+			"Sales Invoice",
+			"Purchase Invoice",
+			"Purchase Receipt",
+			"POS Invoice",
+			"Subcontracting Receipt",
+		]:
+			try:
+				voucher_details = frappe.db.get_value(
+					self.voucher_type, 
+					self.voucher_no, 
+					["is_return", "return_against"], 
+					as_dict=True
+				)
+				if voucher_details and voucher_details.get("is_return"):
+					return True
+			except Exception:
+				pass
+		
+		return False
+
 	def throw_error_message(self, message, exception=frappe.ValidationError):
 		frappe.throw(_(message), exception, title=_("Error"))
 
-	def set_incoming_rate(self, parent=None, row=None, save=False, allow_negative_stock=False):
+	def set_incoming_rate(self, parent=None, row=None, save=False, allow_negative_stock=False, prev_sle=None):
 		if self.type_of_transaction not in ["Inward", "Outward"] or self.voucher_type in [
 			"Installation Note",
 			"Job Card",
@@ -325,15 +374,15 @@ class SerialandBatchBundle(Document):
 			return
 
 		if return_against := self.get_return_against(parent=parent):
-			self.set_valuation_rate_for_return_entry(return_against, row, save)
+			self.set_valuation_rate_for_return_entry(return_against, row, save, prev_sle=prev_sle)
 		elif self.type_of_transaction == "Outward":
 			self.set_incoming_rate_for_outward_transaction(
 				row, save, allow_negative_stock=allow_negative_stock
 			)
 		else:
-			self.set_incoming_rate_for_inward_transaction(row, save)
+			self.set_incoming_rate_for_inward_transaction(row, save, prev_sle=prev_sle)
 
-	def set_valuation_rate_for_return_entry(self, return_against, row, save=False):
+	def set_valuation_rate_for_return_entry(self, return_against, row, save=False, prev_sle=None):
 		if valuation_details := self.get_valuation_rate_for_return_entry(return_against):
 			for row in self.entries:
 				if valuation_details:
@@ -365,7 +414,7 @@ class SerialandBatchBundle(Document):
 					)
 
 		elif self.type_of_transaction == "Inward":
-			self.set_incoming_rate_for_inward_transaction(row, save)
+			self.set_incoming_rate_for_inward_transaction(row, save, prev_sle=prev_sle)
 
 	def validate_returned_serial_batch_no(self, return_against, row, original_inv_details):
 		if frappe.flags.through_repost_item_valuation:
@@ -533,7 +582,11 @@ class SerialandBatchBundle(Document):
 
 			if save:
 				d.db_set(
-					{"incoming_rate": d.incoming_rate, "stock_value_difference": d.stock_value_difference}
+					{
+						"incoming_rate": d.incoming_rate,
+						"stock_value_difference": d.stock_value_difference,
+						"stock_queue": d.get("stock_queue"),
+					}
 				)
 
 	def validate_negative_batch(self, batch_no, available_qty):
@@ -560,8 +613,7 @@ class SerialandBatchBundle(Document):
 	def get_sle_for_outward_transaction(self):
 		sle = frappe._dict(
 			{
-				"posting_date": self.posting_date,
-				"posting_time": self.posting_time,
+				"posting_datetime": self.posting_datetime,
 				"item_code": self.item_code,
 				"warehouse": self.warehouse,
 				"serial_and_batch_bundle": self.name,
@@ -610,7 +662,11 @@ class SerialandBatchBundle(Document):
 
 		return return_against
 
-	def set_incoming_rate_for_inward_transaction(self, row=None, save=False):
+	def set_incoming_rate_for_inward_transaction(self, row=None, save=False, prev_sle=None):
+		from erpnext.stock.utils import get_valuation_method
+
+		valuation_method = get_valuation_method(self.item_code)
+
 		valuation_field = "valuation_rate"
 		if self.voucher_type in ["Sales Invoice", "Delivery Note", "Quotation"]:
 			valuation_field = "incoming_rate"
@@ -634,19 +690,42 @@ class SerialandBatchBundle(Document):
 		if not rate and self.voucher_detail_no and self.voucher_no:
 			rate = frappe.db.get_value(child_table, self.voucher_detail_no, valuation_field)
 
+		stock_queue = []
+		batches = []
+		if prev_sle and prev_sle.stock_queue:
+			batches = frappe.get_all(
+				"Batch",
+				filters={
+					"name": ("in", [d.batch_no for d in self.entries if d.batch_no]),
+					"use_batchwise_valuation": 0,
+				},
+				pluck="name",
+			)
+
+			if batches and valuation_method == "FIFO":
+				stock_queue = parse_json(prev_sle.stock_queue)
+
 		for d in self.entries:
 			if self.is_rejected:
 				rate = 0.0
-			elif (d.incoming_rate == rate) and d.qty and d.stock_value_difference:
+			elif (d.incoming_rate == rate) and not stock_queue and d.qty and d.stock_value_difference:
 				continue
 
 			d.incoming_rate = flt(rate)
 			if d.qty:
 				d.stock_value_difference = flt(d.qty) * d.incoming_rate
 
+			if stock_queue and valuation_method == "FIFO" and d.batch_no in batches:
+				stock_queue.append([d.qty, d.incoming_rate])
+				d.stock_queue = json.dumps(stock_queue)
+
 			if save:
 				d.db_set(
-					{"incoming_rate": d.incoming_rate, "stock_value_difference": d.stock_value_difference}
+					{
+						"incoming_rate": d.incoming_rate,
+						"stock_value_difference": d.stock_value_difference,
+						"stock_queue": d.get("stock_queue"),
+					}
 				)
 
 	def set_serial_and_batch_values(self, parent, row, qty_field=None):
@@ -662,11 +741,10 @@ class SerialandBatchBundle(Document):
 		if not self.voucher_detail_no or self.voucher_detail_no != row.name:
 			values_to_set["voucher_detail_no"] = row.name
 
-		if parent.get("posting_date") and (not self.posting_date or self.posting_date != parent.posting_date):
-			values_to_set["posting_date"] = parent.posting_date or today()
-
-		if parent.get("posting_time") and (not self.posting_time or self.posting_time != parent.posting_time):
-			values_to_set["posting_time"] = parent.posting_time
+		if parent.get("posting_date") and parent.get("posting_time"):
+			posting_datetime = combine_datetime(parent.posting_date, parent.posting_time)
+			if not self.posting_datetime or self.posting_datetime != posting_datetime:
+				values_to_set["posting_datetime"] = posting_datetime
 
 		if parent.doctype in [
 			"Delivery Note",
@@ -720,23 +798,28 @@ class SerialandBatchBundle(Document):
 		if self.flags and self.flags.via_landed_cost_voucher:
 			return
 
-		if not self.has_serial_no:
-			return
+		serial_nos = []
+		batches = []
 
 		if self.voucher_type == "Stock Reconciliation":
-			serial_nos = self.get_serial_nos_for_validate(is_cancelled=is_cancelled)
+			serial_nos, batches = self.get_serial_nos_for_validate(is_cancelled=is_cancelled)
 		else:
+			batches = [d.batch_no for d in self.entries if d.batch_no]
+
+		if (
+			self.voucher_type != "Stock Reconciliation"
+			and not self.flags.ignore_validate_serial_batch
+			and self.has_serial_no
+		):
 			serial_nos = [d.serial_no for d in self.entries if d.serial_no]
 
-		if not serial_nos:
+		if self.has_batch_no and not self.has_serial_no and not batches:
 			return
 
 		parent = frappe.qb.DocType("Serial and Batch Bundle")
 		child = frappe.qb.DocType("Serial and Batch Entry")
 
-		timestamp_condition = CombineDatetime(parent.posting_date, parent.posting_time) > CombineDatetime(
-			self.posting_date, self.posting_time
-		)
+		timestamp_condition = parent.posting_datetime > self.posting_datetime
 
 		future_entries = (
 			frappe.qb.from_(parent)
@@ -744,65 +827,119 @@ class SerialandBatchBundle(Document):
 			.on(parent.name == child.parent)
 			.select(
 				child.serial_no,
+				child.batch_no,
 				parent.voucher_type,
 				parent.voucher_no,
 			)
 			.where(
-				(child.serial_no.isin(serial_nos))
-				& (child.parent != self.name)
+				(child.parent != self.name)
 				& (parent.item_code == self.item_code)
 				& (parent.docstatus == 1)
 				& (parent.is_cancelled == 0)
 				& (parent.type_of_transaction.isin(["Inward", "Outward"]))
 			)
 			.where(timestamp_condition)
-		).run(as_dict=True)
+		)
+
+		if self.has_batch_no and not self.has_serial_no:
+			future_entries = future_entries.where(parent.voucher_type == "Stock Reconciliation")
+
+		if serial_nos:
+			future_entries = future_entries.where(
+				(child.serial_no.isin(serial_nos))
+				| ((parent.warehouse == self.warehouse) & (parent.voucher_type == "Stock Reconciliation"))
+			)
+		elif self.has_serial_no:
+			future_entries = future_entries.where(
+				(parent.warehouse == self.warehouse) & (parent.voucher_type == "Stock Reconciliation")
+			)
+		elif batches:
+			future_entries = future_entries.where(
+				(child.batch_no.isin(batches)) & (parent.warehouse == self.warehouse)
+			)
+
+		future_entries = future_entries.run(as_dict=True)
 
 		if future_entries:
-			msg = """The serial nos has been used in the future
-				transactions so you need to cancel them first.
-				The list of serial nos and their respective
-				transactions are as below."""
+			if self.has_serial_no:
+				title = "Serial No Exists In Future Transaction(s)"
+			else:
+				title = "Batches Exists In Future Transaction(s)"
+
+			msg = """Since the stock reconciliation exists
+				for future dates, cancel it first. For Serial/Batch,
+				if you want to make a backdated transaction,
+				avoid using stock reconciliation.
+				For more details about the transaction,
+				please refer to the list below.
+			"""
 
 			msg += "<br><br><ul>"
 
 			for d in future_entries:
-				msg += f"<li>{d.serial_no} in {get_link_to_form(d.voucher_type, d.voucher_no)}</li>"
+				if self.has_serial_no:
+					msg += f"<li>{d.serial_no} in {get_link_to_form(d.voucher_type, d.voucher_no)}</li>"
+				else:
+					msg += f"<li>{d.batch_no} in {get_link_to_form(d.voucher_type, d.voucher_no)}</li>"
 			msg += "</li></ul>"
-
-			title = "Serial No Exists In Future Transaction(s)"
 
 			frappe.throw(_(msg), title=_(title), exc=SerialNoExistsInFutureTransactionError)
 
 	def get_serial_nos_for_validate(self, is_cancelled=False):
 		serial_nos = [d.serial_no for d in self.entries if d.serial_no]
-		skip_serial_nos = self.get_skip_serial_nos_for_stock_reconciliation(is_cancelled=is_cancelled)
-		serial_nos = list(set(sorted(serial_nos)) - set(sorted(skip_serial_nos)))
+		batches = [d.batch_no for d in self.entries if d.batch_no]
 
-		return serial_nos
+		skip_serial_nos, skip_batches = self.get_skip_serial_nos_for_stock_reconciliation(
+			is_cancelled=is_cancelled
+		)
+
+		serial_nos = list(set(sorted(serial_nos)) - set(sorted(skip_serial_nos)))
+		batch_nos = list(set(sorted(batches)) - set(sorted(skip_batches)))
+
+		return serial_nos, batch_nos
 
 	def get_skip_serial_nos_for_stock_reconciliation(self, is_cancelled=False):
 		data = get_stock_reco_details(self.voucher_detail_no)
+
 		if not data:
-			return []
+			return [], []
+
+		current_serial_nos = set()
+		serial_nos = set()
+		current_batches = set()
+		batches = set()
 
 		if data.current_serial_no:
 			current_serial_nos = set(parse_serial_nos(data.current_serial_no))
 			serial_nos = set(parse_serial_nos(data.serial_no)) if data.serial_no else set([])
-			return list(serial_nos.intersection(current_serial_nos))
+			return list(serial_nos.intersection(current_serial_nos)), []
+
+		elif data.batch_no and data.current_qty == data.qty:
+			return [], [data.batch_no]
+
 		elif data.current_serial_and_batch_bundle:
-			current_serial_nos = set(get_serial_nos_from_bundle(data.current_serial_and_batch_bundle))
+			if self.has_serial_no:
+				current_serial_nos = set(get_serial_nos_from_bundle(data.current_serial_and_batch_bundle))
+			else:
+				current_batches = set(get_batches_from_bundle(data.current_serial_and_batch_bundle))
+
 			if is_cancelled:
-				return current_serial_nos
+				return list(current_serial_nos), list(current_batches)
 
-			serial_nos = (
-				set(get_serial_nos_from_bundle(data.serial_and_batch_bundle))
-				if data.serial_and_batch_bundle
-				else set([])
+			if self.has_serial_no:
+				serial_nos = (
+					set(get_serial_nos_from_bundle(data.serial_and_batch_bundle))
+					if data.serial_and_batch_bundle
+					else set([])
+				)
+			elif self.has_batch_no and data.serial_and_batch_bundle:
+				batches = set(get_batches_from_bundle(data.serial_and_batch_bundle))
+
+			return list(serial_nos.intersection(current_serial_nos)), list(
+				batches.intersection(current_batches)
 			)
-			return list(serial_nos.intersection(current_serial_nos))
 
-		return []
+		return [], []
 
 	def reset_qty(self, row, qty_field=None):
 		qty_field = self.get_qty_field(row, qty_field=qty_field)
@@ -1190,7 +1327,7 @@ class SerialandBatchBundle(Document):
 				frappe.qb.update(sn_table)
 				.set(sn_table.reference_doctype, self.voucher_type)
 				.set(sn_table.reference_name, self.voucher_no)
-				.set(sn_table.posting_date, self.posting_date)
+				.set(sn_table.posting_date, getdate(self.posting_datetime))
 				.where((sn_table.name.isin(serial_nos)) & (sn_table.reference_name.isnull()))
 			).run()
 
@@ -1639,6 +1776,8 @@ def create_serial_batch_no_ledgers(
 	if parent_doc.get("doctype") == "Stock Entry":
 		warehouse = warehouse or child_row.s_warehouse or child_row.t_warehouse
 
+	posting_datetime = combine_datetime(parent_doc.get("posting_date"), parent_doc.get("posting_time"))
+
 	doc = frappe.get_doc(
 		{
 			"doctype": "Serial and Batch Bundle",
@@ -1647,8 +1786,7 @@ def create_serial_batch_no_ledgers(
 			"warehouse": warehouse,
 			"is_rejected": child_row.is_rejected,
 			"type_of_transaction": type_of_transaction,
-			"posting_date": parent_doc.get("posting_date"),
-			"posting_time": parent_doc.get("posting_time"),
+			"posting_datetime": posting_datetime,
 			"company": parent_doc.get("company"),
 		}
 	)
@@ -1682,6 +1820,12 @@ def create_serial_batch_no_ledgers(
 	frappe.msgprint(_("Serial and Batch Bundle created"), alert=True)
 
 	return doc
+
+
+def combine_datetime(date, time=None):
+	from erpnext.stock.utils import get_combine_datetime
+
+	return get_combine_datetime(date, time)
 
 
 def get_batch(item_code):
@@ -1727,8 +1871,8 @@ def get_type_of_transaction(parent_doc, child_row):
 def update_serial_batch_no_ledgers(bundle, entries, child_row, parent_doc, warehouse=None) -> object:
 	doc = frappe.get_doc("Serial and Batch Bundle", bundle)
 	doc.voucher_detail_no = child_row.name
-	doc.posting_date = parent_doc.posting_date
-	doc.posting_time = parent_doc.posting_time
+	doc.posting_datetime = combine_datetime(parent_doc.get("posting_date"), parent_doc.get("posting_time"))
+
 	doc.warehouse = warehouse or doc.warehouse
 	doc.set("entries", [])
 
@@ -1835,6 +1979,9 @@ def get_available_serial_nos(kwargs):
 	elif kwargs.based_on == "Expiry":
 		order_by = "amc_expiry_date asc"
 
+	if not kwargs.get("posting_datetime") and kwargs.get("posting_date"):
+		kwargs["posting_datetime"] = combine_datetime(kwargs.get("posting_date"), kwargs.get("posting_time"))
+
 	filters = {"item_code": kwargs.item_code}
 
 	# ignore_warehouse is used for backdated stock transactions
@@ -1844,28 +1991,57 @@ def get_available_serial_nos(kwargs):
 		if kwargs.warehouse:
 			filters["warehouse"] = kwargs.warehouse
 
-	# Since SLEs are not present against Reserved Stock [POS invoices, SRE], need to ignore reserved serial nos.
-	ignore_serial_nos, consider_serial_nos = get_reserved_serial_nos(kwargs)
+	reserved_entries = get_reserved_serial_nos_for_sre(kwargs)
 
-	if consider_serial_nos:
-		filters["name"] = ("in", consider_serial_nos)
+	ignore_serial_nos = []
+	if reserved_entries:
+		if kwargs.get("sabb_voucher_type") == "Delivery Note" and kwargs.get("against_sales_order"):
+			reserved_voucher_details = [kwargs.get("against_sales_order")]
+		else:
+			reserved_voucher_details = get_reserved_voucher_details(kwargs)
+
+		# Check if serial nos are reserved for the current voucher then fetch only those serial nos
+		if reserved_serial_nos := get_reserved_serial_nos_for_voucher(
+			kwargs, reserved_entries, reserved_voucher_details
+		):
+			filters["name"] = ("in", reserved_serial_nos)
+			return frappe.get_all(
+				"Serial No",
+				fields=fields,
+				filters=filters,
+				limit=cint(kwargs.qty) or 10000000,
+				order_by=order_by,
+			)
+
+		# Check if serial nos are reserved for other vouchers then ignore those serial nos
+		elif ignore_reserved_serial_nos := get_other_doc_reserved_serials(
+			kwargs, reserved_entries, reserved_voucher_details
+		):
+			ignore_serial_nos.extend(ignore_reserved_serial_nos)
+
+	if reserved_for_pos := get_reserved_serial_nos_for_pos(kwargs):
+		ignore_serial_nos.extend(reserved_for_pos)
 
 	# To ignore serial nos in the same record for the draft state
 	if kwargs.get("ignore_serial_nos"):
 		ignore_serial_nos.extend(kwargs.get("ignore_serial_nos"))
 
-	if kwargs.get("posting_date"):
-		if kwargs.get("posting_time") is None:
-			kwargs.posting_time = nowtime()
-
+	ignore_serial_nos = list(set(ignore_serial_nos))
+	if kwargs.get("posting_datetime"):
 		time_based_serial_nos = get_serial_nos_based_on_posting_date(kwargs, ignore_serial_nos)
 
 		if not time_based_serial_nos:
 			return []
 
+		for sn in ignore_serial_nos:
+			if sn in time_based_serial_nos:
+				time_based_serial_nos.remove(sn)
+
 		filters["name"] = ("in", time_based_serial_nos)
 	elif ignore_serial_nos:
 		filters["name"] = ("not in", ignore_serial_nos)
+	elif kwargs.get("serial_nos"):
+		filters["name"] = ("in", kwargs.get("serial_nos"))
 
 	if kwargs.get("batches"):
 		batches = get_non_expired_batches(kwargs.get("batches"))
@@ -1951,46 +2127,6 @@ def get_bundle_wise_serial_nos(data, kwargs):
 			bundle_wise_serial_nos[d.parent].append(d.serial_no)
 
 	return bundle_wise_serial_nos
-
-
-def get_reserved_serial_nos(kwargs) -> list:
-	"""Returns a list of `Serial No` reserved in POS Invoice and Stock Reservation Entry."""
-
-	ignore_serial_nos = []
-	consider_serial_nos = []
-
-	# Extend the list by serial nos reserved in POS Invoice
-	ignore_serial_nos.extend(get_reserved_serial_nos_for_pos(kwargs))
-
-	reserved_entries = get_reserved_serial_nos_for_sre(kwargs)
-	if not reserved_entries:
-		return ignore_serial_nos, consider_serial_nos
-
-	if kwargs.get("sabb_voucher_type") == "Delivery Note" and kwargs.get("against_sales_order"):
-		reserved_voucher_details = [kwargs.get("against_sales_order")]
-	else:
-		reserved_voucher_details = get_reserved_voucher_details(kwargs)
-
-	serial_nos = []
-	for entry in reserved_entries:
-		if entry.voucher_no in reserved_voucher_details:
-			consider_serial_nos.append(entry.serial_no)
-			continue
-
-		if kwargs.get("serial_nos") and entry.serial_no in kwargs.get("serial_nos"):
-			frappe.throw(
-				_(
-					"The Serial No {0} is reserved against the {1} {2} and cannot be used for any other transaction."
-				).format(bold(entry.serial_no), entry.voucher_type, bold(entry.voucher_no)),
-				title=_("Serial No Reserved"),
-			)
-
-		serial_nos.append(entry.serial_no)
-
-	# Extend the list by serial nos reserved via SRE
-	ignore_serial_nos.extend(serial_nos)
-
-	return ignore_serial_nos, consider_serial_nos
 
 
 def get_reserved_voucher_details(kwargs):
@@ -2100,6 +2236,38 @@ def get_reserved_serial_nos_for_pos(kwargs):
 	return list(ignore_serial_nos_counter - returned_serial_nos_counter)
 
 
+def get_reserved_serial_nos_for_voucher(kwargs, reserved_entries, reserved_voucher_details):
+	serial_nos = []
+	if not kwargs.get("pick_reserved_items"):
+		return serial_nos
+
+	for entry in reserved_entries:
+		if entry.voucher_no in reserved_voucher_details:
+			serial_nos.append(entry.serial_no)
+			continue
+
+		if kwargs.get("serial_nos") and entry.serial_no in kwargs.get("serial_nos"):
+			frappe.throw(
+				_(
+					"The Serial No {0} is reserved against the {1} {2} and cannot be used for any other transaction."
+				).format(bold(entry.serial_no), entry.voucher_type, bold(entry.voucher_no)),
+				title=_("Serial No Reserved"),
+			)
+
+	return serial_nos
+
+
+def get_other_doc_reserved_serials(kwargs, reserved_entries, reserved_voucher_details):
+	serial_nos = []
+	for entry in reserved_entries:
+		if entry.voucher_no in reserved_voucher_details:
+			continue
+
+		serial_nos.append(entry.serial_no)
+
+	return serial_nos
+
+
 def get_reserved_serial_nos_for_sre(kwargs) -> list:
 	"""Returns a list of `Serial No` reserved in Stock Reservation Entry."""
 
@@ -2121,6 +2289,7 @@ def get_reserved_serial_nos_for_sre(kwargs) -> list:
 			& (sb_entry.delivered_qty < sb_entry.qty)
 			& (sre.reservation_based_on == "Serial and Batch")
 		)
+		.orderby(sb_entry.idx)
 	)
 
 	if kwargs.warehouse:
@@ -2257,11 +2426,13 @@ def get_auto_batch_nos(kwargs):
 			kwargs.batch_no = batches
 			kwargs.warehouse = warehouses
 
+	if not kwargs.get("posting_datetime") and kwargs.get("posting_date"):
+		kwargs["posting_datetime"] = combine_datetime(kwargs.get("posting_date"), kwargs.get("posting_time"))
+
 	available_batches = get_available_batches(kwargs)
 	stock_ledgers_batches = get_stock_ledgers_batches(kwargs)
 	pos_invoice_batches = get_reserved_batches_for_pos(kwargs)
 	sre_reserved_batches = get_reserved_batches_for_sre(kwargs)
-
 	if kwargs.against_sales_order and only_consider_batches:
 		kwargs.batch_no = kwargs.warehouse = None
 
@@ -2281,7 +2452,7 @@ def get_auto_batch_nos(kwargs):
 	if kwargs.based_on == "Expiry":
 		available_batches = sorted(available_batches, key=lambda x: (x.expiry_date or getdate("9999-12-31")))
 
-	if not kwargs.get("do_not_check_future_batches") and available_batches and kwargs.get("posting_date"):
+	if not kwargs.get("do_not_check_future_batches") and available_batches and kwargs.get("posting_datetime"):
 		filter_zero_near_batches(available_batches, kwargs)
 
 	if not kwargs.consider_negative_batches:
@@ -2318,8 +2489,7 @@ def get_batches_to_be_considered(sales_order_name):
 def filter_zero_near_batches(available_batches, kwargs):
 	kwargs.batch_no = [d.batch_no for d in available_batches]
 
-	del kwargs["posting_date"]
-	del kwargs["posting_time"]
+	del kwargs["posting_datetime"]
 
 	kwargs.do_not_check_future_batches = 1
 	available_batches_in_future = get_auto_batch_nos(kwargs)
@@ -2385,8 +2555,6 @@ def update_available_batches(available_batches, *reserved_batches) -> None:
 
 
 def get_available_batches(kwargs):
-	from erpnext.stock.utils import get_combine_datetime
-
 	stock_ledger_entry = frappe.qb.DocType("Stock Ledger Entry")
 	batch_ledger = frappe.qb.DocType("Serial and Batch Entry")
 	batch_table = frappe.qb.DocType("Batch")
@@ -2411,13 +2579,15 @@ def get_available_batches(kwargs):
 	if not kwargs.get("for_stock_levels"):
 		query = query.where((batch_table.expiry_date >= today()) | (batch_table.expiry_date.isnull()))
 
-	if kwargs.get("posting_date"):
-		if kwargs.get("posting_time") is None:
-			kwargs.posting_time = nowtime()
+	if kwargs.get("posting_datetime"):
+		timestamp_condition = stock_ledger_entry.posting_datetime <= kwargs.posting_datetime
 
-		timestamp_condition = stock_ledger_entry.posting_datetime <= get_combine_datetime(
-			kwargs.posting_date, kwargs.posting_time
-		)
+		if kwargs.get("creation"):
+			timestamp_condition = stock_ledger_entry.posting_datetime < kwargs.posting_datetime
+
+			timestamp_condition |= (stock_ledger_entry.posting_datetime == kwargs.posting_datetime) & (
+				stock_ledger_entry.creation < kwargs.creation
+			)
 
 		query = query.where(timestamp_condition)
 
@@ -2597,15 +2767,14 @@ def get_ledgers_from_serial_batch_bundle(**kwargs) -> list[frappe._dict]:
 			serial_batch_table.incoming_rate,
 			bundle_table.voucher_detail_no,
 			bundle_table.voucher_no,
-			bundle_table.posting_date,
-			bundle_table.posting_time,
+			bundle_table.posting_datetime,
 		)
 		.where(
 			(bundle_table.docstatus == 1)
 			& (bundle_table.is_cancelled == 0)
 			& (bundle_table.type_of_transaction.isin(["Inward", "Outward"]))
 		)
-		.orderby(bundle_table.posting_date, bundle_table.posting_time)
+		.orderby(bundle_table.posting_datetime)
 	)
 
 	for key, val in kwargs.items():
@@ -2623,7 +2792,7 @@ def get_ledgers_from_serial_batch_bundle(**kwargs) -> list[frappe._dict]:
 				query = query.where(bundle_table[key].isin(val))
 			else:
 				query = query.where(bundle_table[key] == val)
-		elif key in ["posting_date", "posting_time"]:
+		elif key in ["posting_datetime"]:
 			query = query.where(bundle_table[key] >= val)
 		else:
 			if isinstance(val, list):
@@ -2635,8 +2804,6 @@ def get_ledgers_from_serial_batch_bundle(**kwargs) -> list[frappe._dict]:
 
 
 def get_stock_ledgers_for_serial_nos(kwargs):
-	from erpnext.stock.utils import get_combine_datetime
-
 	stock_ledger_entry = frappe.qb.DocType("Stock Ledger Entry")
 
 	query = (
@@ -2652,13 +2819,15 @@ def get_stock_ledgers_for_serial_nos(kwargs):
 		.orderby(stock_ledger_entry.creation)
 	)
 
-	if kwargs.get("posting_date"):
-		if kwargs.get("posting_time") is None:
-			kwargs.posting_time = nowtime()
+	if kwargs.get("posting_datetime"):
+		timestamp_condition = stock_ledger_entry.posting_datetime <= kwargs.posting_datetime
 
-		timestamp_condition = stock_ledger_entry.posting_datetime <= get_combine_datetime(
-			kwargs.posting_date, kwargs.posting_time
-		)
+		if kwargs.get("creation"):
+			timestamp_condition = stock_ledger_entry.posting_datetime < kwargs.posting_datetime
+
+			timestamp_condition |= (stock_ledger_entry.posting_datetime == kwargs.posting_datetime) & (
+				stock_ledger_entry.creation < kwargs.creation
+			)
 
 		query = query.where(timestamp_condition)
 
@@ -2678,8 +2847,6 @@ def get_stock_ledgers_for_serial_nos(kwargs):
 
 
 def get_stock_ledgers_batches(kwargs):
-	from erpnext.stock.utils import get_combine_datetime
-
 	stock_ledger_entry = frappe.qb.DocType("Stock Ledger Entry")
 	batch_table = frappe.qb.DocType("Batch")
 
@@ -2710,13 +2877,15 @@ def get_stock_ledgers_batches(kwargs):
 	if not kwargs.get("for_stock_levels"):
 		query = query.where((batch_table.expiry_date >= today()) | (batch_table.expiry_date.isnull()))
 
-	if kwargs.get("posting_date"):
-		if kwargs.get("posting_time") is None:
-			kwargs.posting_time = nowtime()
+	if kwargs.get("posting_datetime"):
+		timestamp_condition = stock_ledger_entry.posting_datetime <= kwargs.posting_datetime
 
-		timestamp_condition = stock_ledger_entry.posting_datetime <= get_combine_datetime(
-			kwargs.posting_date, kwargs.posting_time
-		)
+		if kwargs.get("creation"):
+			timestamp_condition = stock_ledger_entry.posting_datetime < kwargs.posting_datetime
+
+			timestamp_condition |= (stock_ledger_entry.posting_datetime == kwargs.posting_datetime) & (
+				stock_ledger_entry.creation < kwargs.creation
+			)
 
 		query = query.where(timestamp_condition)
 
@@ -2793,6 +2962,18 @@ def get_stock_reco_details(voucher_detail_no):
 	return frappe.db.get_value(
 		"Stock Reconciliation Item",
 		voucher_detail_no,
-		["current_serial_no", "serial_no", "serial_and_batch_bundle", "current_serial_and_batch_bundle"],
+		[
+			"current_serial_no",
+			"serial_no",
+			"serial_and_batch_bundle",
+			"current_serial_and_batch_bundle",
+			"batch_no",
+			"qty",
+			"current_qty",
+		],
 		as_dict=True,
 	)
+
+
+def on_doctype_update():
+	frappe.db.add_index("Serial and Batch Bundle", ["item_code", "warehouse", "posting_datetime", "creation"])

--- a/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py
+++ b/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py
@@ -290,7 +290,7 @@ class SerialandBatchBundle(Document):
 		# Check if this is a return transaction
 		# Returns legitimately reuse serial numbers that were delivered
 		is_return = self.is_return_transaction()
-		
+
 		if not is_return:
 			# For non-return transactions, prevent reuse of delivered serial numbers
 			deliver_serials = frappe.get_all(
@@ -337,7 +337,7 @@ class SerialandBatchBundle(Document):
 		# Check if returned_against field is set
 		if self.returned_against:
 			return True
-		
+
 		# Check if parent voucher is a return
 		if self.voucher_type in [
 			"Delivery Note",
@@ -349,16 +349,13 @@ class SerialandBatchBundle(Document):
 		]:
 			try:
 				voucher_details = frappe.db.get_value(
-					self.voucher_type, 
-					self.voucher_no, 
-					["is_return", "return_against"], 
-					as_dict=True
+					self.voucher_type, self.voucher_no, ["is_return", "return_against"], as_dict=True
 				)
 				if voucher_details and voucher_details.get("is_return"):
 					return True
 			except Exception:
 				pass
-		
+
 		return False
 
 	def throw_error_message(self, message, exception=frappe.ValidationError):

--- a/erpnext/stock/doctype/serial_and_batch_bundle/test_serial_and_batch_bundle.py
+++ b/erpnext/stock/doctype/serial_and_batch_bundle/test_serial_and_batch_bundle.py
@@ -906,6 +906,95 @@ class TestSerialandBatchBundle(IntegrationTestCase):
 		self.assertTrue(bundle_doc.docstatus == 0)
 		self.assertRaises(frappe.ValidationError, bundle_doc.submit)
 
+	def test_delivered_serial_no_reuse_blocked(self):
+		from erpnext.stock.doctype.serial_and_batch_bundle.serial_and_batch_bundle import (
+			SerialNoDuplicateError,
+		)
+
+		item_code = make_item(
+			"Test Delivered Serial Reuse",
+			properties={"has_serial_no": 1, "serial_no_series": "TEST-DSR-.####", "is_stock_item": 1},
+		).name
+
+		serial_no = "TEST-DSR-0001"
+		if not frappe.db.exists("Serial No", serial_no):
+			sn_doc = frappe.get_doc(
+				{
+					"doctype": "Serial No",
+					"serial_no": serial_no,
+					"item_code": item_code,
+					"status": "Delivered",
+				}
+			)
+			sn_doc.insert(ignore_permissions=True)
+		else:
+			frappe.db.set_value("Serial No", serial_no, "status", "Delivered")
+			make_serial_batch_bundle(
+				{
+					"item_code": item_code,
+					"warehouse": "_Test Warehouse - _TC",
+					"voucher_type": "Stock Entry",
+					"posting_date": today(),
+					"posting_time": nowtime(),
+					"qty": 1,
+					"rate": 100,
+					"serial_nos": [serial_no],
+					"type_of_transaction": "Inward",
+					"do_not_submit": True,
+				}
+			)
+
+		self.assertIn("already delivered", str(context.exception).lower())
+
+		frappe.db.rollback()
+
+	def test_return_transaction_allows_delivered_serial(self):
+		from erpnext.stock.doctype.delivery_note.test_delivery_note import create_delivery_note
+
+		item_code = make_item(
+			"Test Return Serial Reuse",
+			properties={"has_serial_no": 1, "serial_no_series": "TEST-RSR-.####", "is_stock_item": 1},
+		).name
+
+		serial_no = "TEST-RSR-0001"
+		if not frappe.db.exists("Serial No", serial_no):
+			sn_doc = frappe.get_doc(
+				{
+					"doctype": "Serial No",
+					"serial_no": serial_no,
+					"item_code": item_code,
+				}
+			)
+			sn_doc.insert(ignore_permissions=True)
+
+		se = make_stock_entry(
+			item_code=item_code,
+			target="_Test Warehouse - _TC",
+			qty=1,
+			rate=100,
+			serial_no=[serial_no],
+		)
+
+		dn = create_delivery_note(
+			item_code=item_code, qty=1, rate=100, warehouse="_Test Warehouse - _TC", serial_no=[serial_no]
+		)
+
+		self.assertEqual(frappe.db.get_value("Serial No", serial_no, "status"), "Delivered")
+
+		return_dn = create_delivery_note(
+			item_code=item_code,
+			qty=-1,
+			rate=100,
+			warehouse="_Test Warehouse - _TC",
+			serial_no=[serial_no],
+			is_return=1,
+			return_against=dn.name,
+		)
+
+		self.assertTrue(return_dn.name)
+
+		frappe.db.rollback()
+
 
 def get_batch_from_bundle(bundle):
 	from erpnext.stock.serial_batch_bundle import get_batch_nos

--- a/erpnext/stock/doctype/serial_and_batch_bundle/test_serial_and_batch_bundle.py
+++ b/erpnext/stock/doctype/serial_and_batch_bundle/test_serial_and_batch_bundle.py
@@ -929,6 +929,8 @@ class TestSerialandBatchBundle(IntegrationTestCase):
 			sn_doc.insert(ignore_permissions=True)
 		else:
 			frappe.db.set_value("Serial No", serial_no, "status", "Delivered")
+
+		with self.assertRaises(SerialNoDuplicateError) as context:
 			make_serial_batch_bundle(
 				{
 					"item_code": item_code,
@@ -967,7 +969,7 @@ class TestSerialandBatchBundle(IntegrationTestCase):
 			)
 			sn_doc.insert(ignore_permissions=True)
 
-		se = make_stock_entry(
+		make_stock_entry(
 			item_code=item_code,
 			target="_Test Warehouse - _TC",
 			qty=1,


### PR DESCRIPTION
Closes #49520

### Description

This PR fixes a bug where serial numbers that have already been delivered can be reused in manufacturing (Stock Entry with "Manufacture" purpose). This causes data loss as the original serial number information gets overwritten, and the delivered item loses its serial number assignment.

### Problem

When creating a Stock Entry for manufacturing with the "Manufacture" purpose, we were not validating whether serial numbers in the incoming bundle had already been delivered. 

### Solution

Added validation in `validate_serial_nos_duplicate()` method to:

1. Check if serial numbers in incoming/outgoing bundles have already been delivered
2. Allow return transactions to legitimately reuse delivered serial numbers by checking:
   - The `returned_against` field on the bundle
   - The `is_return` flag on the parent voucher 
3. Raise `SerialNoDuplicateError` if a delivered serial number is being reused in a non-return transaction

### Changes Made
**Files Modified:**
- `erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py`
  - Enhanced `validate_serial_nos_duplicate()` to check for delivered serial numbers
  - Added new `is_return_transaction()` method to properly identify return transactions

**Tests Added:**
- `test_delivered_serial_no_reuse_blocked()` - Verifies that delivered serial numbers cannot be reused
- `test_return_transaction_allows_delivered_serial()` - Verifies that return transactions can legitimately use delivered serial numbers

### Screencast

Before:
[screencast_before.webm](https://github.com/user-attachments/assets/9657e7e7-e16c-4924-99e8-ccdf47b28427)

After:
[screencast_after.webm](https://github.com/user-attachments/assets/04393b55-37d3-4502-bd38-5938b36a5ef5)
