### PR TITLE
fix: add is_group filter in task for timesheet

### DIFF
--- a/erpnext/projects/doctype/timesheet/timesheet.js
+++ b/erpnext/projects/doctype/timesheet/timesheet.js
@@ -21,6 +21,7 @@ frappe.ui.form.on("Timesheet", {
 				filters: {
 					project: child.project,
 					status: ["!=", "Cancelled"],
+					is_group: 0,
 				},
 			};
 		};


### PR DESCRIPTION
Issue : Group tasks were listed in the Task dropdown in Timesheet doctype

Ref: [#52398](https://support.frappe.io/helpdesk/tickets/52398)

Before:

<img width="1919" height="951" alt="Before" src="https://github.com/user-attachments/assets/0b07d216-ac8a-4776-a745-6ccaa67a5458" />

After:

<img width="1919" height="941" alt="After" src="https://github.com/user-attachments/assets/8018b9f2-b796-4e0a-a28f-f01c4c31d2ac" />



Backport needed: v15
