### PR TITLE
fix: validate is_group for parent task

### DIFF
--- a/erpnext/projects/doctype/task/task.py
+++ b/erpnext/projects/doctype/task/task.py
@@ -163,15 +163,21 @@ class Task(NestedSet):
 	def validate_parent_template_task(self):
 		if self.parent_task:
 			if not frappe.db.get_value("Task", self.parent_task, "is_template"):
-				parent_task_format = f"""<a href="/app/task/{self.parent_task}">{self.parent_task}</a>"""
-				frappe.throw(_("Parent Task {0} is not a Template Task").format(parent_task_format))
+				frappe.throw(
+					_("Parent Task {0} is not a Template Task").format(
+						get_link_to_form("Task", self.parent_task)
+					)
+				)
 
 	def validate_depends_on_tasks(self):
 		if self.depends_on:
 			for task in self.depends_on:
 				if not frappe.db.get_value("Task", task.task, "is_template"):
-					dependent_task_format = f"""<a href="/app/task/{task.task}">{task.task}</a>"""
-					frappe.throw(_("Dependent Task {0} is not a Template Task").format(dependent_task_format))
+					frappe.throw(
+						_("Dependent Task {0} is not a Template Task").format(
+							get_link_to_form("Task", task.task)
+						)
+					)
 
 	def validate_completed_on(self):
 		if self.completed_on and getdate(self.completed_on) > getdate():
@@ -180,9 +186,11 @@ class Task(NestedSet):
 	def validate_parent_is_group(self):
 		if self.parent_task:
 			if not frappe.db.get_value("Task", self.parent_task, "is_group"):
-				parent_task_format = f"""<a href="/app/task/{self.parent_task}">{self.parent_task}</a>"""
 				frappe.throw(
-					_("Parent Task {0} must be a Group Task").format(parent_task_format), ParentIsGroupError
+					_("Parent Task {0} must be a Group Task").format(
+						get_link_to_form("Task", self.parent_task)
+					),
+					ParentIsGroupError,
 				)
 
 	def update_depends_on(self):

--- a/erpnext/projects/doctype/task/test_task.py
+++ b/erpnext/projects/doctype/task/test_task.py
@@ -6,7 +6,7 @@ import frappe
 from frappe.tests import IntegrationTestCase
 from frappe.utils import add_days, getdate, nowdate
 
-from erpnext.projects.doctype.task.task import CircularReferenceError
+from erpnext.projects.doctype.task.task import CircularReferenceError, ParentIsGroupError
 from erpnext.tests.utils import ERPNextTestSuite
 
 
@@ -118,6 +118,20 @@ class TestTask(ERPNextTestSuite):
 		set_tasks_as_overdue()
 
 		self.assertEqual(frappe.db.get_value("Task", task.name, "status"), "Overdue")
+
+	def test_parent_task_must_be_group(self):
+		parent_task = create_task(
+			subject="_Test Parent Task Non Group",
+			is_group=0,
+		)
+
+		child_task = create_task(
+			subject="_Test Child Task",
+			parent_task=parent_task.name,
+			save=False,
+		)
+
+		self.assertRaises(ParentIsGroupError, child_task.save)
 
 
 def create_task(


### PR DESCRIPTION
**Issue :** No validation takes place when a non-group task gets linked with another task as a parent task, causing an invalid task hierarchy

**Ref :** [#52064](https://support.frappe.io/helpdesk/tickets/52064)

**Before :** 


https://github.com/user-attachments/assets/b0591d36-6c51-4b0e-9341-aca62382f22f



**After :**


https://github.com/user-attachments/assets/e929eb3f-5135-444b-87a6-b08e6e49ae70


**Backport needed: v15**



