### PR TITLE
fix(material request): set default buying price list if not exists

### DIFF
--- a/erpnext/stock/doctype/material_request/material_request.js
+++ b/erpnext/stock/doctype/material_request/material_request.js
@@ -87,7 +87,9 @@ frappe.ui.form.on("Material Request", {
 		});
 
 		erpnext.accounts.dimensions.setup_dimension_filters(frm, frm.doctype);
-		frm.doc.buying_price_list = frappe.defaults.get_default("buying_price_list");
+		if (!frm.doc.buying_price_list) {
+			frm.doc.buying_price_list = frappe.defaults.get_default("buying_price_list");
+		}
 	},
 
 	company: function (frm) {


### PR DESCRIPTION
Issue: The default buying price list is being set in the Material Request even when a different price list is already selected.

Ref: [#52202](https://support.frappe.io/helpdesk/tickets/52202)
Backport needed: v15