### PR TITLE
fix: include cost_center and project upon accounting dimension fetch

### DIFF
--- a/erpnext/accounts/doctype/accounting_dimension/accounting_dimension.py
+++ b/erpnext/accounts/doctype/accounting_dimension/accounting_dimension.py
@@ -309,8 +309,8 @@ def get_dimensions(with_cost_center_and_project=False):
 	if with_cost_center_and_project:
 		dimension_filters.extend(
 			[
-				{"fieldname": "cost_center", "document_type": "Cost Center"},
-				{"fieldname": "project", "document_type": "Project"},
+				frappe._dict({"fieldname": "cost_center", "document_type": "Cost Center"}),
+				frappe._dict({"fieldname": "project", "document_type": "Project"}),
 			]
 		)
 

--- a/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.js
+++ b/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.js
@@ -61,6 +61,22 @@ erpnext.accounts.PaymentReconciliationController = class PaymentReconciliationCo
 				},
 			};
 		});
+		this.frm.set_query("cost_center", "payments", () => {
+			return {
+				filters: {
+					company: this.frm.doc.company,
+					is_group: 0,
+				},
+			};
+		});
+		this.frm.set_query("cost_center", "allocation", () => {
+			return {
+				filters: {
+					company: this.frm.doc.company,
+					is_group: 0,
+				},
+			};
+		});
 	}
 
 	refresh() {

--- a/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py
+++ b/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py
@@ -72,7 +72,7 @@ class PaymentReconciliation(Document):
 		self.common_filter_conditions = []
 		self.accounting_dimension_filter_conditions = []
 		self.ple_posting_date_filter = []
-		self.dimensions = get_dimensions()[0]
+		self.dimensions = get_dimensions(with_cost_center_and_project=True)[0]
 
 	def load_from_db(self):
 		# 'modified' attribute is required for `run_doc_method` to work properly.


### PR DESCRIPTION
**Issue:**

 In company default cost center is not set, upon reconcilation the difference entry is not picking the cost center given in the allocation table.

**Fix:**

- Include the Cost Center and Project in the process.
- Applied Company, Is Group filter for cost center.

Ref: [52189](https://support.frappe.io/helpdesk/tickets/52189)

**Steps to reproduce:**

- Remove Default Cost Center in Company.
- Create SI with 80 Exchange Rate and Payment with 85 Exchange Rate (USD).
- Go to Payment Reco Allocate both the entry set cost center in allocation table and try reconcile .



**Backport Needed: Verison-15**