### PR TITLE
fix: ignore Department doctype

### DIFF
--- a/erpnext/setup/doctype/transaction_deletion_record/transaction_deletion_record.py
+++ b/erpnext/setup/doctype/transaction_deletion_record/transaction_deletion_record.py
@@ -475,6 +475,7 @@ def get_doctypes_to_be_ignored():
 		"Item Default",
 		"Customer",
 		"Supplier",
+		"Department",
 	]
 
 	doctypes_to_be_ignored.extend(frappe.get_hooks("company_data_to_be_ignored") or [])


### PR DESCRIPTION
**Issue:** Department records were getting deleted when deleting company transactions.
**Ref:** [52532](https://support.frappe.io/helpdesk/tickets/52532)

**Solution:** Added the Department DocType to doctypes_to_be_ignored

<img width="1871" height="960" alt="after" src="https://github.com/user-attachments/assets/4fde7e62-bee6-4cb5-9aa5-df7feef1f8ed" />

**Backport Needed:** version-15