### PR TITLE
fix: reset billing and shipping address when company changes

### DIFF
--- a/erpnext/public/js/controllers/buying.js
+++ b/erpnext/public/js/controllers/buying.js
@@ -174,15 +174,13 @@ erpnext.buying = {
 						shipping_address: this.frm.doc.shipping_address,
 					},
 					callback: (r) => {
-						if (!this.frm.doc.billing_address)
-							this.frm.set_value("billing_address", r.message.primary_address || "");
+						if (!r.message) return;
 
-						if (
-							!frappe.meta.has_field(this.frm.doc.doctype, "shipping_address") ||
-							this.frm.doc.shipping_address
-						)
-							return;
-						this.frm.set_value("shipping_address", r.message.shipping_address || "");
+						this.frm.set_value("billing_address", r.message.primary_address || "");
+
+						if (frappe.meta.has_field(this.frm.doc.doctype, "shipping_address")) {
+							this.frm.set_value("shipping_address", r.message.shipping_address || "");
+						}
 					},
 				});
 				erpnext.utils.set_letter_head(this.frm);


### PR DESCRIPTION
**Issue :** When the company is changed, the existing billing and shipping addresses are retained even when the new company has no linked addresses.

**Ref :** [#52293](https://support.frappe.io/helpdesk/tickets/52293)

**Before :** 


https://github.com/user-attachments/assets/b9b934cd-00b7-4a16-8373-33388a468900



**After :** 


https://github.com/user-attachments/assets/8b4c155f-e039-42cd-ab12-f2b12b9302f9



**Backport needed: v15**