### PR TITLE
fix: hide total row in general ledger report

### DIFF
--- a/erpnext/accounts/report/general_ledger/general_ledger.json
+++ b/erpnext/accounts/report/general_ledger/general_ledger.json
@@ -1,5 +1,5 @@
 {
- "add_total_row": 1,
+ "add_total_row": 0,
  "add_translate_data": 0,
  "columns": [],
  "creation": "2013-12-06 13:22:23",
@@ -10,7 +10,7 @@
  "idx": 3,
  "is_standard": "Yes",
  "letterhead": null,
- "modified": "2025-08-13 12:47:27.645023",
+ "modified": "2025-11-05 15:47:59.597853",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "General Ledger",


### PR DESCRIPTION
**Issue :**  General Ledger report currently displays a total row at the bottom, which is unnecessary and may cause confusion when reviewing ledger entries

**Ref :** [#52595](https://support.frappe.io/helpdesk/tickets/52595)

**Before :** 


<img width="1919" height="960" alt="Before" src="https://github.com/user-attachments/assets/2d912caa-cc86-4313-89ce-a961c1d99ae3" />



**After :** 


<img width="1919" height="971" alt="After" src="https://github.com/user-attachments/assets/c8193a1b-ce47-4499-88b0-f7aa76d72145" />




**Backport needed: v15**

