### PR TITLE
fix: set company before creating asset movement to avoid permission error

### DIFF
--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -463,6 +463,7 @@ class Asset(AccountsController):
 				"asset_name": self.asset_name,
 				"target_location": self.location,
 				"to_employee": self.custodian,
+				"company": self.company,
 			}
 		]
 		asset_movement = frappe.get_doc(


### PR DESCRIPTION
**Issue Description:** while submitting an Asset the user is facing an issue because the company is not being passed in the Asset Movement child table. Ideally, it should be passed.

Please backport the fix to version-14 as well.

<img width="791" height="389" alt="Screenshot from 2025-11-05 16-54-37" src="https://github.com/user-attachments/assets/81671a59-8443-477b-9849-0889318ed42b" />
