### PR TITLE
fix: add cancelled status option in assest doctype

### DIFF
--- a/erpnext/assets/doctype/asset/asset.json
+++ b/erpnext/assets/doctype/asset/asset.json
@@ -348,7 +348,7 @@
    "in_standard_filter": 1,
    "label": "Status",
    "no_copy": 1,
-   "options": "Draft\nSubmitted\nPartially Depreciated\nFully Depreciated\nSold\nScrapped\nIn Maintenance\nOut of Order\nIssue\nReceipt\nCapitalized\nWork In Progress",
+   "options": "Draft\nSubmitted\nPartially Depreciated\nFully Depreciated\nSold\nScrapped\nIn Maintenance\nOut of Order\nIssue\nReceipt\nCapitalized\nWork In Progress\nCancelled",
    "read_only": 1
   },
   {
@@ -601,7 +601,7 @@
    "link_fieldname": "target_asset"
   }
  ],
- "modified": "2025-05-23 00:53:54.249309",
+ "modified": "2025-11-05 18:38:58.709888",
  "modified_by": "Administrator",
  "module": "Assets",
  "name": "Asset",

--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -110,6 +110,7 @@ class Asset(AccountsController):
 			"Receipt",
 			"Capitalized",
 			"Work In Progress",
+			"Cancelled",
 		]
 		supplier: DF.Link | None
 		total_asset_cost: DF.Currency


### PR DESCRIPTION
**Issue :** Cancelled option is missing from the status filter in the asset doctype

**Ref :**  [#52685](https://support.frappe.io/helpdesk/tickets/52685)

**Before :** 


<img width="1919" height="966" alt="Before" src="https://github.com/user-attachments/assets/8618716e-ba6f-42d5-a1e8-c3f92eeb40ea" />



**After :** 

<img width="1919" height="963" alt="After" src="https://github.com/user-attachments/assets/f721f429-c420-40eb-bcd4-2198394e8186" />





**Backport needed: v15**
