### PR TITLE
fix: add validation to reject empty readings

### DIFF
--- a/erpnext/stock/doctype/quality_inspection/quality_inspection.py
+++ b/erpnext/stock/doctype/quality_inspection/quality_inspection.py
@@ -283,9 +283,11 @@ class QualityInspection(Document):
 
 	def min_max_criteria_passed(self, reading):
 		"""Determine whether all readings fall in the acceptable range."""
+		has_reading = False
 		for i in range(1, 11):
 			reading_value = reading.get("reading_" + str(i))
 			if reading_value is not None and reading_value.strip():
+				has_reading = True
 				result = (
 					flt(reading.get("min_value"))
 					<= parse_float(reading_value)
@@ -293,7 +295,7 @@ class QualityInspection(Document):
 				)
 				if not result:
 					return False
-		return True
+		return has_reading
 
 	def set_status_based_on_acceptance_formula(self, reading):
 		if not reading.acceptance_formula:

--- a/erpnext/stock/doctype/quality_inspection/test_quality_inspection.py
+++ b/erpnext/stock/doctype/quality_inspection/test_quality_inspection.py
@@ -292,7 +292,7 @@ def create_quality_inspection(**args):
 
 	if not args.readings:
 		create_quality_inspection_parameter("Size")
-		readings = {"specification": "Size", "min_value": 0, "max_value": 10}
+		readings = {"specification": "Size", "min_value": 0, "max_value": 10, "reading_1": "5"}
 		if args.status == "Rejected":
 			readings["reading_1"] = "12"  # status is auto set in child on save
 	else:


### PR DESCRIPTION
**Issue :** When performing a numeric quality inspection, the system currently marks the result as **Accepted** even when no reading values are entered in the readings table

**Ref :**  [#52577](https://support.frappe.io/helpdesk/tickets/52577)

**Before :**


https://github.com/user-attachments/assets/c939dea9-bc93-44cb-9e03-9b4a0a733edb




**After :**



https://github.com/user-attachments/assets/a5cdf2ab-de53-438b-b106-08f67e2d58f4



**Backport needed: v15**

