### PR TITLE
fix(Timesheet): don't use billing_hours for costing amount calculation

### DIFF
--- a/erpnext/projects/doctype/timesheet_detail/timesheet_detail.py
+++ b/erpnext/projects/doctype/timesheet_detail/timesheet_detail.py
@@ -88,7 +88,7 @@ class TimesheetDetail(Document):
 		)
 
 		self.billing_amount = self.billing_rate * (self.billing_hours or 0)
-		self.costing_amount = self.costing_rate * (self.billing_hours or self.hours or 0)
+		self.costing_amount = self.costing_rate * (self.hours or 0)
 
 	def validate_dates(self):
 		"""Validate that to_time is not before from_time."""


### PR DESCRIPTION
## Problem
In **Timesheet Detail**:
_Costing Amount_ should not be calculated with _Billing Hours_, but with actual _Hours_.

Problematic scenario: An employee spent 4 hours on a task. Due to goodwill only 3 hours are billed. Then the actual costs still incurred for 4 hours, not for 3 hours.


V15-Hotfix: 
https://github.com/frappe/erpnext/pull/50394
Backport wouldn't be possible due to refactored code in develop.