### PR TITLE
fix(Timesheet): don't use billing_hours for costing amount

### DIFF
--- a/erpnext/projects/doctype/timesheet/timesheet.py
+++ b/erpnext/projects/doctype/timesheet/timesheet.py
@@ -285,7 +285,7 @@ class Timesheet(Document):
 			if data.activity_type or data.is_billable:
 				rate = get_activity_cost(self.employee, data.activity_type)
 				hours = data.billing_hours or 0
-				costing_hours = data.billing_hours or data.hours or 0
+				costing_hours = data.hours or 0
 				if rate:
 					data.billing_rate = (
 						flt(rate.get("billing_rate")) if flt(data.billing_rate) == 0 else data.billing_rate


### PR DESCRIPTION
Hotfix of the following develop-fix: https://github.com/frappe/erpnext/pull/50394 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated timesheet costing calculations to use standard hours for cost determination, ensuring consistent costing behavior across timesheet entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->