### PR TITLE
feat(account settings): add checkbox to show balances in payment entry

### DIFF
--- a/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
+++ b/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
@@ -56,6 +56,9 @@
   "reconciliation_queue_size",
   "column_break_resa",
   "exchange_gain_loss_posting_date",
+  "payment_entry_settings",
+  "show_account_balance",
+  "show_party_balance",
   "invoicing_settings_tab",
   "accounts_transactions_settings_section",
   "over_billing_allowance",
@@ -95,7 +98,8 @@
   "legacy_section",
   "ignore_is_opening_check_for_reporting",
   "payment_request_settings",
-  "create_pr_in_draft_status"
+  "create_pr_in_draft_status",
+  "column_break_xrnd"
  ],
  "fields": [
   {
@@ -636,6 +640,23 @@
    "fieldname": "use_legacy_controller_for_pcv",
    "fieldtype": "Check",
    "label": "Use Legacy Controller For Period Closing Voucher"
+  },
+  {
+   "fieldname": "payment_entry_settings",
+   "fieldtype": "Section Break",
+   "label": "Payment Entry Settings"
+  },
+  {
+   "default": "0",
+   "fieldname": "show_account_balance",
+   "fieldtype": "Check",
+   "label": "Show Account Balance"
+  },
+  {
+   "default": "0",
+   "fieldname": "show_party_balance",
+   "fieldtype": "Check",
+   "label": "Show Party Balance"
   }
  ],
  "icon": "icon-cog",
@@ -643,7 +664,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-10-20 14:06:08.870427",
+ "modified": "2025-11-06 17:48:07.682837",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Accounts Settings",
@@ -668,6 +689,7 @@
   }
  ],
  "quick_entry": 1,
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "ASC",
  "states": [],

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -424,3 +424,5 @@ erpnext.patches.v15_0.update_uae_zero_rated_fetch
 erpnext.patches.v15_0.update_fieldname_in_accounting_dimension_filter
 erpnext.patches.v15_0.set_asset_status_if_not_already_set
 erpnext.patches.v15_0.toggle_legacy_controller_for_period_closing
+execute:frappe.db.set_single_value("Accounts Settings", "show_party_balance", 1)
+execute:frappe.db.set_single_value("Accounts Settings", "show_account_balance", 1)


### PR DESCRIPTION
Feature: A checkbox has been introduced to show the balance of the party and the account in the Payment Entry.

Ref: [#52753](https://support.frappe.io/helpdesk/tickets/52753)

Accouts Settings:

<img width="1792" height="1120" alt="Screenshot 2025-11-06 at 6 02 27 PM" src="https://github.com/user-attachments/assets/3a2395cd-e4ff-44f4-9dc1-4c98372728e4" />

no-docs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added toggleable options in Accounts Settings to control visibility of account and party balance information displayed in Payment Entry.

* **Chores**
  * Updated default settings configuration to enable balance information display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->