### PR TITLE
fix: handle partial dn against reserved stock

### DIFF
--- a/erpnext/stock/doctype/delivery_note/delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.py
@@ -17,6 +17,7 @@ from frappe.utils import cint, flt
 from erpnext.accounts.party import get_due_date
 from erpnext.controllers.accounts_controller import get_taxes_and_charges, merge_taxes
 from erpnext.controllers.selling_controller import SellingController
+from erpnext.stock.stock_ledger import validate_reserved_stock
 
 form_grid_templates = {"items": "templates/form_grid/item_grid.html"}
 
@@ -471,6 +472,10 @@ class DeliveryNote(SellingController):
 			self.make_bundle_using_old_serial_batch_fields(table_name)
 
 		self.validate_standalone_serial_nos_customer()
+
+		if not self.is_return:
+			self.validate_reserved_stock()
+
 		self.update_stock_reservation_entries()
 
 		# Updating stock ledger should always be called after updating prevdoc status,
@@ -507,6 +512,39 @@ class DeliveryNote(SellingController):
 		)
 
 		self.delete_auto_created_batches()
+
+	def validate_reserved_stock(self):
+		from erpnext.stock.doctype.stock_reservation_entry.stock_reservation_entry import (
+			get_sre_against_so_for_dn,
+		)
+
+		for row in self.items:
+			reserved_stock = frappe.db.get_value(
+				"Bin", {"item_code": row.item_code, "warehouse": row.warehouse}, "reserved_stock"
+			)
+			if reserved_stock > 0:
+				args = frappe._dict(
+					{
+						"item_code": row.item_code,
+						"warehouse": row.warehouse,
+						"batch_nos": [row.batch_no] if row.batch_no else [],
+						"serial_nos": row.serial_no.split("\n") if row.serial_no else [],
+						"serial_and_batch_bundle": row.serial_and_batch_bundle,
+						"voucher_type": self.doctype,
+						"voucher_no": self.name,
+						"voucher_detail_no": row.name,
+						"actual_qty": row.qty * -1,
+						"posting_date": self.posting_date,
+						"posting_time": self.posting_time,
+					}
+				)
+
+				if row.against_sales_order and row.so_detail:
+					args.ignore_voucher_nos = get_sre_against_so_for_dn(
+						row.against_sales_order, row.so_detail
+					)
+
+				validate_reserved_stock(args)
 
 	def validate_against_stock_reservation_entries(self):
 		"""Validates if Stock Reservation Entries are available for the Sales Order Item reference."""

--- a/erpnext/stock/doctype/delivery_note/test_delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/test_delivery_note.py
@@ -40,7 +40,7 @@ from erpnext.stock.doctype.stock_reconciliation.test_stock_reconciliation import
 	create_stock_reconciliation,
 	set_valuation_method,
 )
-from erpnext.stock.doctype.warehouse.test_warehouse import get_warehouse
+from erpnext.stock.doctype.warehouse.test_warehouse import create_warehouse, get_warehouse
 from erpnext.stock.stock_ledger import get_previous_sle
 
 
@@ -2786,6 +2786,77 @@ class TestDeliveryNote(IntegrationTestCase):
 						entry.incoming_rate,
 						serial_batch_map[row.item_code].batch_no_valuation[entry.batch_no],
 					)
+
+	@IntegrationTestCase.change_settings(
+		"Stock Settings", {"allow_negative_stock": 0, "enable_stock_reservation": 1}
+	)
+	def test_partial_delivery_note_against_reserved_stock(self):
+		from erpnext.stock.doctype.stock_reservation_entry.stock_reservation_entry import (
+			get_stock_reservation_entries_for_voucher,
+		)
+
+		# create batch item
+		batch_item = make_item(
+			"_Test Batch Item For DN Reserve Check",
+			{
+				"is_stock_item": 1,
+				"has_batch_no": 1,
+				"create_new_batch": 1,
+				"batch_number_series": "TBDNR.#####",
+			},
+		)
+		serial_item = make_item(
+			"_Test Serial Item For DN Reserve Check",
+			{
+				"is_stock_item": 1,
+				"has_serial_no": 1,
+				"serial_no_series": "TSNDNR.#####",
+			},
+		)
+
+		company = "_Test Company"
+
+		warehouse = create_warehouse("Test Partial DN Reserved Stock", company=company)
+		customer = "_Test Customer"
+
+		items = [batch_item.name, serial_item.name]
+
+		for idx, item in enumerate(items):
+			# make inward entry for batch item
+			se = make_stock_entry(item_code=item, purpose="Material Receipt", qty=10, to_warehouse=warehouse)
+			sabb = se.items[0].serial_and_batch_bundle
+
+			batch_no = get_batch_from_bundle(sabb) if not idx else None
+			serial_nos = get_serial_nos_from_bundle(sabb) if idx else None
+
+			# make sales order and reserve the quantites against the so
+			so = make_sales_order(item_code=item, qty=10, rate=100, customer=customer, warehouse=warehouse)
+			so.submit()
+			so.create_stock_reservation_entries()
+			so.reload()
+
+			# create a delivery note with partial quantity from resreved quantity
+			dn = create_dn_against_so(so=so.name, delivered_qty=5, do_not_submit=True)
+			dn.items[0].use_serial_batch_fields = 1
+			if batch_no:
+				dn.items[0].batch_no = batch_no
+			else:
+				dn.items[0].serial_no = "\n".join(serial_nos[:5])
+
+			dn.save()
+			dn.submit()
+
+			against_sales_order = dn.items[0].against_sales_order
+			so_detail = dn.items[0].so_detail
+
+			sre_details = get_stock_reservation_entries_for_voucher(
+				so.doctype, against_sales_order, so_detail, ["reserved_qty", "delivered_qty", "status"]
+			)
+
+			# check partially delivered reserved stock
+			self.assertEqual(sre_details[0].status, "Partially Delivered")
+			self.assertEqual(sre_details[0].reserved_qty, so.items[0].qty)
+			self.assertEqual(sre_details[0].delivered_qty, dn.items[0].qty)
 
 
 def create_delivery_note(**args):

--- a/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py
+++ b/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py
@@ -257,6 +257,9 @@ class SerialandBatchBundle(Document):
 				}
 			)
 
+		if self.voucher_type == "Delivery Note":
+			kwargs["ignore_voucher_nos"] = self.get_sre_against_dn()
+
 		available_serial_nos = get_available_serial_nos(frappe._dict(kwargs))
 
 		serial_no_warehouse = {}
@@ -1414,6 +1417,20 @@ class SerialandBatchBundle(Document):
 		frappe.qb.from_(SBBE).delete().where(SBBE.parent == self.name).run()
 
 		self.set("entries", [])
+
+	def get_sre_against_dn(self):
+		from erpnext.stock.doctype.stock_reservation_entry.stock_reservation_entry import (
+			get_sre_against_so_for_dn,
+		)
+
+		so_name, so_detail_no = frappe.db.get_value(
+			"Delivery Note Item", self.voucher_detail_no, ["against_sales_order", "so_detail"]
+		)
+
+		if so_name and so_detail_no:
+			sre_names = get_sre_against_so_for_dn(so_name, so_detail_no)
+
+			return sre_names
 
 
 @frappe.whitelist()

--- a/erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py
+++ b/erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py
@@ -919,7 +919,7 @@ def get_sre_reserved_qty_for_voucher_detail_no(
 
 
 def get_sre_reserved_serial_nos_details(
-	item_code: str, warehouse: str, serial_nos: list | None = None
+	item_code: str, warehouse: str, serial_nos: list | None = None, ignore_voucher_nos: list | None = None
 ) -> dict:
 	"""Returns a dict of `Serial No` reserved in Stock Reservation Entry. The dict is like {serial_no: sre_name, ...}"""
 
@@ -946,7 +946,9 @@ def get_sre_reserved_serial_nos_details(
 	return frappe._dict(query.run())
 
 
-def get_sre_reserved_batch_nos_details(item_code: str, warehouse: str, batch_nos: list | None = None) -> dict:
+def get_sre_reserved_batch_nos_details(
+	item_code: str, warehouse: str, batch_nos: list | None = None, ignore_voucher_nos: list | None = None
+) -> dict:
 	"""Returns a dict of `Batch Qty` reserved in Stock Reservation Entry. The dict is like {batch_no: qty, ...}"""
 
 	sre = frappe.qb.DocType("Stock Reservation Entry")
@@ -973,6 +975,9 @@ def get_sre_reserved_batch_nos_details(item_code: str, warehouse: str, batch_nos
 
 	if batch_nos:
 		query = query.where(sb_entry.batch_no.isin(batch_nos))
+
+	if ignore_voucher_nos:
+		query = query.where(sre.name.notin(ignore_voucher_nos))
 
 	return frappe._dict(query.run())
 
@@ -1859,3 +1864,24 @@ def update_serial_batch_delivered_qty(row, name, is_cancelled=False):
 			)
 
 		query.run()
+
+
+@frappe.request_cache
+def get_sre_against_so_for_dn(so_name: str, so_detail_no: str) -> list[str]:
+	"""Returns list of Stock Reservation Entries against Delivery Note with Sales Order Reference."""
+
+	sre = frappe.qb.DocType("Stock Reservation Entry")
+	query = (
+		frappe.qb.from_(sre)
+		.select(sre.name)
+		.where(
+			(sre.docstatus == 1)
+			& (sre.voucher_type == "Sales Order")
+			& (sre.voucher_no == so_name)
+			& (sre.voucher_detail_no == so_detail_no)
+		)
+	)
+
+	result = query.run(as_list=True)
+
+	return result[0] if result else []

--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -2248,6 +2248,30 @@ def get_future_sle_with_negative_batch_qty(sle_args):
 
 
 def validate_reserved_stock(kwargs):
+	if kwargs.serial_no:
+		validate_reserved_serial_nos(kwargs)
+
+	elif kwargs.batch_no:
+		validate_reserved_batch_nos(kwargs)
+
+	elif kwargs.serial_and_batch_bundle:
+		sbb_entries = frappe.db.get_all(
+			"Serial and Batch Entry",
+			{
+				"parenttype": "Serial and Batch Bundle",
+				"parent": kwargs.serial_and_batch_bundle,
+				"docstatus": 1,
+			},
+			["batch_no", "serial_no"],
+		)
+
+		if serial_nos := [entry.serial_no for entry in sbb_entries if entry.serial_no]:
+			kwargs.serial_nos = serial_nos
+			validate_reserved_serial_nos(kwargs)
+		elif batch_nos := [entry.batch_no for entry in sbb_entries if entry.batch_no]:
+			kwargs.batch_nos = batch_nos
+			validate_reserved_batch_nos(kwargs)
+
 	# Qty based validation for non-serial-batch items OR SRE with Reservation Based On Qty.
 	precision = cint(frappe.db.get_default("float_precision")) or 2
 	balance_qty = get_stock_balance(kwargs.item_code, kwargs.warehouse)
@@ -2264,9 +2288,13 @@ def validate_reserved_stock(kwargs):
 		frappe.throw(msg, title=_("Reserved Stock"))
 
 
-def validate_reserved_serial_nos(item_code, warehouse, serial_nos):
-	if reserved_serial_nos_details := get_sre_reserved_serial_nos_details(item_code, warehouse, serial_nos):
-		if common_serial_nos := list(set(serial_nos).intersection(set(reserved_serial_nos_details.keys()))):
+def validate_reserved_serial_nos(kwargs):
+	if reserved_serial_nos_details := get_sre_reserved_serial_nos_details(
+		kwargs.item_code, kwargs.warehouse, kwargs.serial_nos, kwargs.ignore_voucher_nos
+	):
+		if common_serial_nos := list(
+			set(kwargs.serial_nos).intersection(set(reserved_serial_nos_details.keys()))
+		):
 			msg = _(
 				"Serial Nos are reserved in Stock Reservation Entries, you need to unreserve them before proceeding."
 			)
@@ -2280,21 +2308,25 @@ def validate_reserved_serial_nos(item_code, warehouse, serial_nos):
 			frappe.throw(msg, title=_("Reserved Serial No."))
 
 
-def validate_reserved_batch_nos(item_code, warehouse, batch_nos):
-	if reserved_batches_map := get_sre_reserved_batch_nos_details(item_code, warehouse, batch_nos):
+def validate_reserved_batch_nos(kwargs):
+	if reserved_batches_map := get_sre_reserved_batch_nos_details(
+		kwargs.item_code, kwargs.warehouse, kwargs.batch_nos, kwargs.ignore_voucher_nos
+	):
 		available_batches = get_auto_batch_nos(
 			frappe._dict(
 				{
-					"item_code": item_code,
-					"warehouse": warehouse,
-					"posting_datetime": get_combine_datetime(nowdate(), nowtime()),
+					"item_code": kwargs.item_code,
+					"warehouse": kwargs.warehouse,
+					"posting_date": kwargs.posting_date,
+					"posting_time": kwargs.posting_time,
+					"ignore_voucher_nos": kwargs.ignore_voucher_nos,
 				}
 			)
 		)
 		available_batches_map = {row.batch_no: row.qty for row in available_batches}
 		precision = cint(frappe.db.get_default("float_precision")) or 2
 
-		for batch_no in batch_nos:
+		for batch_no in kwargs.batch_nos:
 			diff = flt(
 				available_batches_map.get(batch_no, 0) - reserved_batches_map.get(batch_no, 0), precision
 			)
@@ -2302,7 +2334,7 @@ def validate_reserved_batch_nos(item_code, warehouse, batch_nos):
 				msg = _("{0} units of {1} needed in {2} on {3} {4} to complete this transaction.").format(
 					abs(diff),
 					frappe.get_desk_link("Batch", batch_no),
-					frappe.get_desk_link("Warehouse", warehouse),
+					frappe.get_desk_link("Warehouse", kwargs.warehouse),
 					nowdate(),
 					nowtime(),
 				)


### PR DESCRIPTION
**Issue:** Unable to create a partial delivery note against reserved stock for the same sales order.

**Steps to Replicate:**
(Make sure Stock Reservation enable in Stock Settings)
1) Create a New Item. Enable Batch
2) Create a Stock Entry of type Material Receipt for the new item with 10 qty
3) Create a New Sales Order with the New item and set the Qty as 10. Save & submit the sales order
4) Create a Pick List from Sales Order and Pick the batch created from the Stock entry. Submit the Pick List
5) From Pick List, Reserve the Stock.
6) From Pick List create a Delivery Note
7) Now the Delivery Note has 10 qty, Change it to 7 qty(Only partial qty) and try to submit the Delivery Note.

**Fixes:** Ignored current DN referenced sales order reservation entry while validating batch and serial quantities.

**Before:**

[partial dn against reserved stock issue.webm](https://github.com/user-attachments/assets/8d761deb-d5cc-4eed-a379-7aecde531f9e)



**After:**

[partial dn against resreved stock solution.webm](https://github.com/user-attachments/assets/16ea6f27-5165-4983-ba61-727027bab31c)


**Backport Needed: v15**