### PR TITLE
fix: mr item quantity validation against so over-receipt allowance

### DIFF
--- a/erpnext/stock/doctype/material_request/material_request.py
+++ b/erpnext/stock/doctype/material_request/material_request.py
@@ -83,6 +83,21 @@ class MaterialRequest(BuyingController):
 		work_order: DF.Link | None
 	# end: auto-generated types
 
+	def __init__(self, *args, **kwargs):
+		super().__init__(*args, **kwargs)
+		self.status_updater = [
+			{
+				"source_dt": "Material Request Item",
+				"target_dt": "Sales Order Item",
+				"target_field": "ordered_qty",
+				"target_parent_dt": "Sales Order",
+				"target_parent_field": "",
+				"join_field": "sales_order_item",
+				"target_ref_field": "stock_qty",
+				"source_field": "stock_qty",
+			}
+		]
+
 	def check_if_already_pulled(self):
 		pass
 
@@ -206,10 +221,10 @@ class MaterialRequest(BuyingController):
 	def on_submit(self):
 		self.update_requested_qty_in_production_plan()
 		self.update_requested_qty()
-		if self.material_request_type == "Purchase" and frappe.db.exists(
-			"Budget", {"applicable_on_material_request": 1, "docstatus": 1}
-		):
-			self.validate_budget()
+		if self.material_request_type == "Purchase":
+			self.update_prevdoc_status()
+			if frappe.db.exists("Budget", {"applicable_on_material_request": 1, "docstatus": 1}):
+				self.validate_budget()
 
 	def before_save(self):
 		self.set_status(update=True)

--- a/erpnext/stock/doctype/material_request/test_material_request.py
+++ b/erpnext/stock/doctype/material_request/test_material_request.py
@@ -933,6 +933,18 @@ class TestMaterialRequest(IntegrationTestCase):
 		self.assertEqual(mr.per_ordered, 100)
 		self.assertEqual(mr.status, "Ordered")
 
+	def test_material_request_qty_over_sales_order_limit(self):
+		from erpnext.controllers.status_updater import OverAllowanceError
+		from erpnext.selling.doctype.sales_order.test_sales_order import make_sales_order
+
+		so = make_sales_order()
+		mr = make_material_request(qty=100, do_not_submit=True)
+		mr.items[0].sales_order = so.name
+		mr.items[0].sales_order_item = so.items[0].name
+		mr.save()
+
+		self.assertRaises(OverAllowanceError, mr.submit)
+
 
 def get_in_transit_warehouse(company):
 	if not frappe.db.exists("Warehouse Type", "Transit"):


### PR DESCRIPTION
**Issue :**  

When a Material Request is linked to a Sales Order, it currently doesn’t check whether the requested quantity exceeds the Sales Order quantity plus the allowed over-receipt limit. As a result, users can create Material Requests for more items than permitted, which causes mismatches between the Sales Order and Material Request quantities.

**Ref :**  [#52332](https://support.frappe.io/helpdesk/tickets/52332)

**Before :**


https://github.com/user-attachments/assets/ed5b582b-e64c-49a3-91de-1b436f28c6ca




**After :**


https://github.com/user-attachments/assets/7e51584b-4f4c-46a8-ad02-3f76340fe6cd






**Backport needed: v15**