### PR TITLE
fix: handle partial dn against reserved stock

### DIFF
--- a/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py
+++ b/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py
@@ -253,6 +253,9 @@ class SerialandBatchBundle(Document):
 				}
 			)
 
+		if self.voucher_type == "Delivery Note":
+			kwargs["ignore_voucher_nos"] = self.get_sre_against_dn()
+
 		available_serial_nos = get_available_serial_nos(frappe._dict(kwargs))
 
 		serial_no_warehouse = {}
@@ -1379,6 +1382,20 @@ class SerialandBatchBundle(Document):
 		frappe.qb.from_(SBBE).delete().where(SBBE.parent == self.name).run()
 
 		self.set("entries", [])
+
+	def get_sre_against_dn(self):
+		from erpnext.stock.doctype.stock_reservation_entry.stock_reservation_entry import (
+			get_sre_against_so_for_dn,
+		)
+
+		so_name, so_detail_no = frappe.db.get_value(
+			"Delivery Note Item", self.voucher_detail_no, ["against_sales_order", "so_detail"]
+		)
+
+		if so_name and so_detail_no:
+			sre_names = get_sre_against_so_for_dn(so_name, so_detail_no)
+
+			return sre_names
 
 
 @frappe.whitelist()


### PR DESCRIPTION
**Issue:** Unable to create a partial delivery note against reserved stock for the same sales order.

**Ref: [52102](https://support.frappe.io/helpdesk/tickets/52103)**

**Steps to Replicate:**
(Make sure Stock Reservation enable in Stock Settings)
1) Create a New Item. Enable Batch
2) Create a Stock Entry of type Material Receipt for the new item with 10 qty
3) Create a New Sales Order with the New item and set the Qty as 10. Save & submit the sales order
4) Create a Pick List from Sales Order and Pick the batch created from the Stock entry. Submit the Pick List
5) From Pick List, Reserve the Stock.
6) From Pick List create a Delivery Note
7) Now the Delivery Note has 10 qty, Change it to 7 qty(Only partial qty) and try to submit the Delivery Note.

**Fixes:** Ignored current DN referenced sales order reservation entry while validating batch and serial quantities.

**Before:**

[partial dn against reserved stock issue.webm](https://github.com/user-attachments/assets/8d761deb-d5cc-4eed-a379-7aecde531f9e)



**After:**

[partial dn against resreved stock solution.webm](https://github.com/user-attachments/assets/16ea6f27-5165-4983-ba61-727027bab31c)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Delivery Notes now validate reserved stock on submit and cancel, including improved handling for batch/serial items and honoring related Sales Order / Delivery Note reservations.

* **Bug Fixes**
  * Reservation checks refined to avoid false conflicts and to properly exclude already-related reservation entries during validation.

* **Tests**
  * Added/expanded test coverage for partial deliveries against reserved stock covering batch and serial scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->