### PR TITLE
fix: trends report total mismatch with group by filters

### DIFF
--- a/erpnext/accounts/report/purchase_invoice_trends/purchase_invoice_trends.json
+++ b/erpnext/accounts/report/purchase_invoice_trends/purchase_invoice_trends.json
@@ -1,32 +1,37 @@
 {
- "add_total_row": 1, 
- "apply_user_permissions": 1, 
- "creation": "2013-06-13 18:46:55", 
- "disabled": 0, 
- "docstatus": 0, 
- "doctype": "Report", 
- "idx": 3, 
- "is_standard": "Yes", 
- "modified": "2018-02-21 01:28:31.261299", 
- "modified_by": "Administrator", 
- "module": "Accounts", 
- "name": "Purchase Invoice Trends", 
- "owner": "Administrator", 
- "ref_doctype": "Purchase Invoice", 
- "report_name": "Purchase Invoice Trends", 
- "report_type": "Script Report", 
+ "add_total_row": 0,
+ "add_translate_data": 0,
+ "columns": [],
+ "creation": "2013-06-13 18:46:55",
+ "disabled": 0,
+ "docstatus": 0,
+ "doctype": "Report",
+ "filters": [],
+ "idx": 3,
+ "is_standard": "Yes",
+ "letterhead": null,
+ "modified": "2025-11-05 11:55:49.950442",
+ "modified_by": "Administrator",
+ "module": "Accounts",
+ "name": "Purchase Invoice Trends",
+ "owner": "Administrator",
+ "prepared_report": 0,
+ "ref_doctype": "Purchase Invoice",
+ "report_name": "Purchase Invoice Trends",
+ "report_type": "Script Report",
  "roles": [
   {
    "role": "Accounts User"
-  }, 
+  },
   {
    "role": "Purchase User"
-  }, 
+  },
   {
    "role": "Accounts Manager"
-  }, 
+  },
   {
    "role": "Auditor"
   }
- ]
+ ],
+ "timeout": 0
 }

--- a/erpnext/accounts/report/sales_invoice_trends/sales_invoice_trends.json
+++ b/erpnext/accounts/report/sales_invoice_trends/sales_invoice_trends.json
@@ -1,26 +1,31 @@
 {
- "add_total_row": 1, 
- "apply_user_permissions": 1, 
- "creation": "2013-06-13 18:44:21", 
- "disabled": 0, 
- "docstatus": 0, 
- "doctype": "Report", 
- "idx": 3, 
- "is_standard": "Yes", 
- "modified": "2018-02-21 01:28:03.622485", 
- "modified_by": "Administrator", 
- "module": "Accounts", 
- "name": "Sales Invoice Trends", 
- "owner": "Administrator", 
- "ref_doctype": "Sales Invoice", 
- "report_name": "Sales Invoice Trends", 
- "report_type": "Script Report", 
+ "add_total_row": 0,
+ "add_translate_data": 0,
+ "columns": [],
+ "creation": "2013-06-13 18:44:21",
+ "disabled": 0,
+ "docstatus": 0,
+ "doctype": "Report",
+ "filters": [],
+ "idx": 3,
+ "is_standard": "Yes",
+ "letterhead": null,
+ "modified": "2025-11-05 11:55:50.070651",
+ "modified_by": "Administrator",
+ "module": "Accounts",
+ "name": "Sales Invoice Trends",
+ "owner": "Administrator",
+ "prepared_report": 0,
+ "ref_doctype": "Sales Invoice",
+ "report_name": "Sales Invoice Trends",
+ "report_type": "Script Report",
  "roles": [
   {
    "role": "Accounts Manager"
-  }, 
+  },
   {
    "role": "Accounts User"
   }
- ]
+ ],
+ "timeout": 0
 }

--- a/erpnext/buying/report/purchase_order_trends/purchase_order_trends.json
+++ b/erpnext/buying/report/purchase_order_trends/purchase_order_trends.json
@@ -1,29 +1,34 @@
 {
- "add_total_row": 1, 
- "apply_user_permissions": 1, 
- "creation": "2013-06-13 18:45:01", 
- "disabled": 0, 
- "docstatus": 0, 
- "doctype": "Report", 
- "idx": 3, 
- "is_standard": "Yes", 
- "modified": "2018-02-21 01:28:37.416562", 
- "modified_by": "Administrator", 
- "module": "Buying", 
- "name": "Purchase Order Trends", 
- "owner": "Administrator", 
- "ref_doctype": "Purchase Order", 
- "report_name": "Purchase Order Trends", 
- "report_type": "Script Report", 
+ "add_total_row": 0,
+ "add_translate_data": 0,
+ "columns": [],
+ "creation": "2013-06-13 18:45:01",
+ "disabled": 0,
+ "docstatus": 0,
+ "doctype": "Report",
+ "filters": [],
+ "idx": 3,
+ "is_standard": "Yes",
+ "letterhead": null,
+ "modified": "2025-11-05 11:55:50.058154",
+ "modified_by": "Administrator",
+ "module": "Buying",
+ "name": "Purchase Order Trends",
+ "owner": "Administrator",
+ "prepared_report": 0,
+ "ref_doctype": "Purchase Order",
+ "report_name": "Purchase Order Trends",
+ "report_type": "Script Report",
  "roles": [
   {
    "role": "Stock User"
-  }, 
+  },
   {
    "role": "Purchase Manager"
-  }, 
+  },
   {
    "role": "Purchase User"
   }
- ]
+ ],
+ "timeout": 0
 }

--- a/erpnext/controllers/trends.py
+++ b/erpnext/controllers/trends.py
@@ -191,6 +191,9 @@ def get_data(filters, conditions):
 					des[j + inc] = row1[0][j]
 
 				data.append(des)
+
+		total_row = calculate_total_row(data1, conditions["columns"])
+		data.append(total_row)
 	else:
 		data = frappe.db.sql(
 			""" select {} from `tab{}` t1, `tab{} Item` t2 {}
@@ -214,7 +217,30 @@ def get_data(filters, conditions):
 			as_list=1,
 		)
 
+		total_row = calculate_total_row(data, conditions["columns"])
+		data.append(total_row)
+
 	return data
+
+
+def calculate_total_row(data, columns):
+	def wrap_in_quotes(label):
+		return f"'{label}'"
+
+	total_values = {}
+	for i, col in enumerate(columns):
+		if "Float" in col or "Currency/currency" in col:
+			total_values[i] = 0
+
+	for row in data:
+		for i in total_values.keys():
+			total_values[i] += row[i] if row[i] is not None else 0
+
+	total_row = [wrap_in_quotes(_("Total"))]
+	for i in range(1, len(columns)):
+		total_row.append(total_values.get(i, None))
+
+	return total_row
 
 
 def get_mon(dt):

--- a/erpnext/selling/report/quotation_trends/quotation_trends.json
+++ b/erpnext/selling/report/quotation_trends/quotation_trends.json
@@ -1,32 +1,37 @@
 {
- "add_total_row": 1, 
- "apply_user_permissions": 1, 
- "creation": "2013-06-07 16:01:16", 
- "disabled": 0, 
- "docstatus": 0, 
- "doctype": "Report", 
- "idx": 3, 
- "is_standard": "Yes", 
- "modified": "2018-02-21 01:28:14.928929", 
- "modified_by": "Administrator", 
- "module": "Selling", 
- "name": "Quotation Trends", 
- "owner": "Administrator", 
- "ref_doctype": "Quotation", 
- "report_name": "Quotation Trends", 
- "report_type": "Script Report", 
+ "add_total_row": 0,
+ "add_translate_data": 0,
+ "columns": [],
+ "creation": "2013-06-07 16:01:16",
+ "disabled": 0,
+ "docstatus": 0,
+ "doctype": "Report",
+ "filters": [],
+ "idx": 3,
+ "is_standard": "Yes",
+ "letterhead": null,
+ "modified": "2025-11-05 11:55:50.127020",
+ "modified_by": "Administrator",
+ "module": "Selling",
+ "name": "Quotation Trends",
+ "owner": "Administrator",
+ "prepared_report": 0,
+ "ref_doctype": "Quotation",
+ "report_name": "Quotation Trends",
+ "report_type": "Script Report",
  "roles": [
   {
    "role": "Sales User"
-  }, 
+  },
   {
    "role": "Sales Manager"
-  }, 
+  },
   {
    "role": "Maintenance Manager"
-  }, 
+  },
   {
    "role": "Maintenance User"
   }
- ]
+ ],
+ "timeout": 0
 }

--- a/erpnext/selling/report/sales_order_trends/sales_order_trends.json
+++ b/erpnext/selling/report/sales_order_trends/sales_order_trends.json
@@ -1,35 +1,40 @@
 {
- "add_total_row": 1, 
- "apply_user_permissions": 1, 
- "creation": "2013-06-13 18:43:30", 
- "disabled": 0, 
- "docstatus": 0, 
- "doctype": "Report", 
- "idx": 3, 
- "is_standard": "Yes", 
- "modified": "2018-02-20 08:05:46.191588", 
- "modified_by": "Administrator", 
- "module": "Selling", 
- "name": "Sales Order Trends", 
- "owner": "Administrator", 
- "ref_doctype": "Sales Order", 
- "report_name": "Sales Order Trends", 
- "report_type": "Script Report", 
+ "add_total_row": 0,
+ "add_translate_data": 0,
+ "columns": [],
+ "creation": "2013-06-13 18:43:30",
+ "disabled": 0,
+ "docstatus": 0,
+ "doctype": "Report",
+ "filters": [],
+ "idx": 3,
+ "is_standard": "Yes",
+ "letterhead": null,
+ "modified": "2025-11-05 11:55:50.096303",
+ "modified_by": "Administrator",
+ "module": "Selling",
+ "name": "Sales Order Trends",
+ "owner": "Administrator",
+ "prepared_report": 0,
+ "ref_doctype": "Sales Order",
+ "report_name": "Sales Order Trends",
+ "report_type": "Script Report",
  "roles": [
   {
    "role": "Sales User"
-  }, 
+  },
   {
    "role": "Sales Manager"
-  }, 
+  },
   {
    "role": "Maintenance User"
-  }, 
+  },
   {
    "role": "Accounts User"
-  }, 
+  },
   {
    "role": "Stock User"
   }
- ]
+ ],
+ "timeout": 0
 }

--- a/erpnext/stock/report/delivery_note_trends/delivery_note_trends.json
+++ b/erpnext/stock/report/delivery_note_trends/delivery_note_trends.json
@@ -1,32 +1,37 @@
 {
- "add_total_row": 1, 
- "apply_user_permissions": 1, 
- "creation": "2013-06-13 18:42:11", 
- "disabled": 0, 
- "docstatus": 0, 
- "doctype": "Report", 
- "idx": 3, 
- "is_standard": "Yes", 
- "modified": "2018-02-21 01:28:47.049042", 
- "modified_by": "Administrator", 
- "module": "Stock", 
- "name": "Delivery Note Trends", 
- "owner": "Administrator", 
- "ref_doctype": "Delivery Note", 
- "report_name": "Delivery Note Trends", 
- "report_type": "Script Report", 
+ "add_total_row": 0,
+ "add_translate_data": 0,
+ "columns": [],
+ "creation": "2013-06-13 18:42:11",
+ "disabled": 0,
+ "docstatus": 0,
+ "doctype": "Report",
+ "filters": [],
+ "idx": 3,
+ "is_standard": "Yes",
+ "letterhead": null,
+ "modified": "2025-11-05 11:55:50.114173",
+ "modified_by": "Administrator",
+ "module": "Stock",
+ "name": "Delivery Note Trends",
+ "owner": "Administrator",
+ "prepared_report": 0,
+ "ref_doctype": "Delivery Note",
+ "report_name": "Delivery Note Trends",
+ "report_type": "Script Report",
  "roles": [
   {
    "role": "Stock User"
-  }, 
+  },
   {
    "role": "Stock Manager"
-  }, 
+  },
   {
    "role": "Sales User"
-  }, 
+  },
   {
    "role": "Accounts User"
   }
- ]
+ ],
+ "timeout": 0
 }

--- a/erpnext/stock/report/purchase_receipt_trends/purchase_receipt_trends.json
+++ b/erpnext/stock/report/purchase_receipt_trends/purchase_receipt_trends.json
@@ -1,32 +1,37 @@
 {
- "add_total_row": 1, 
- "apply_user_permissions": 1, 
- "creation": "2013-06-13 18:45:44", 
- "disabled": 0, 
- "docstatus": 0, 
- "doctype": "Report", 
- "idx": 3, 
- "is_standard": "Yes", 
- "modified": "2018-02-21 01:28:22.682161", 
- "modified_by": "Administrator", 
- "module": "Stock", 
- "name": "Purchase Receipt Trends", 
- "owner": "Administrator", 
- "ref_doctype": "Purchase Receipt", 
- "report_name": "Purchase Receipt Trends", 
- "report_type": "Script Report", 
+ "add_total_row": 0,
+ "add_translate_data": 0,
+ "columns": [],
+ "creation": "2013-06-13 18:45:44",
+ "disabled": 0,
+ "docstatus": 0,
+ "doctype": "Report",
+ "filters": [],
+ "idx": 3,
+ "is_standard": "Yes",
+ "letterhead": null,
+ "modified": "2025-11-05 11:55:49.983683",
+ "modified_by": "Administrator",
+ "module": "Stock",
+ "name": "Purchase Receipt Trends",
+ "owner": "Administrator",
+ "prepared_report": 0,
+ "ref_doctype": "Purchase Receipt",
+ "report_name": "Purchase Receipt Trends",
+ "report_type": "Script Report",
  "roles": [
   {
    "role": "Stock Manager"
-  }, 
+  },
   {
    "role": "Stock User"
-  }, 
+  },
   {
    "role": "Purchase User"
-  }, 
+  },
   {
    "role": "Accounts User"
   }
- ]
+ ],
+ "timeout": 0
 }


### PR DESCRIPTION
Resolved the issue with the various trends report, where if a group-by filter is applied, an incorrect total was calculated, as the reports were using `add_total_row`. 

Closes: #33287 