### PR TITLE
fix: show company-details popup only for the targeted print format/letterhead

### DIFF
--- a/erpnext/public/js/print.js
+++ b/erpnext/public/js/print.js
@@ -1,6 +1,16 @@
 let beforePrintHandled = false;
 
 frappe.realtime.on("sales_invoice_before_print", (data) => {
+	let print_format = $('input[data-fieldname="print_format"]').val();
+	let letterhead = $('input[data-fieldname="letterhead"]').val();
+
+	let allowed_print_formats = ["Sales Invoice Standard", "Sales Invoice with Item Image"];
+	let allowed_letterheads = ["Company Letterhead", "Company Letterhead - Grey"];
+
+	if (!allowed_print_formats.includes(print_format) && !allowed_letterheads.includes(letterhead)) {
+		return;
+	}
+
 	const route = frappe.get_route();
 
 	if (!beforePrintHandled && route[0] === "print" && route[1] === "Sales Invoice") {


### PR DESCRIPTION
Issue:
- The company details popup appeared for all print formats and letterheads whenever company details were missing. This caused unnecessary interruptions when users used other formats.

_Before_

https://github.com/user-attachments/assets/26594241-4c45-493e-aec8-7c3f1e4e66ab

_After_

https://github.com/user-attachments/assets/11bcb996-c0f3-41d8-b87b-34abd449e97e

