### PR TITLE
feat: Allow Editing of Items and Quantities in Work Order

### DIFF
--- a/erpnext/manufacturing/doctype/manufacturing_settings/manufacturing_settings.json
+++ b/erpnext/manufacturing/doctype/manufacturing_settings/manufacturing_settings.json
@@ -15,6 +15,7 @@
   "bom_section",
   "update_bom_costs_automatically",
   "column_break_lhyt",
+  "allow_editing_of_items_and_quantities_in_work_order",
   "section_break_6",
   "default_wip_warehouse",
   "default_fg_warehouse",
@@ -261,13 +262,20 @@
    "fieldname": "transfer_extra_materials_percentage",
    "fieldtype": "Percent",
    "label": "Transfer Extra Raw Materials to WIP (%)"
+  },
+  {
+   "default": "0",
+   "description": "If enabled, the system will allow users to edit the raw materials and their quantities in the Work Order. The system will not reset the quantities as per the BOM, if the user has changed them.",
+   "fieldname": "allow_editing_of_items_and_quantities_in_work_order",
+   "fieldtype": "Check",
+   "label": "Allow Editing of Items and Quantities in Work Order"
   }
  ],
  "icon": "icon-wrench",
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-09-08 19:48:31.726126",
+ "modified": "2025-11-07 14:52:56.241459",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "Manufacturing Settings",

--- a/erpnext/manufacturing/doctype/manufacturing_settings/manufacturing_settings.py
+++ b/erpnext/manufacturing/doctype/manufacturing_settings/manufacturing_settings.py
@@ -18,6 +18,7 @@ class ManufacturingSettings(Document):
 		from frappe.types import DF
 
 		add_corrective_operation_cost_in_finished_good_valuation: DF.Check
+		allow_editing_of_items_and_quantities_in_work_order: DF.Check
 		allow_overtime: DF.Check
 		allow_production_on_holidays: DF.Check
 		backflush_raw_materials_based_on: DF.Literal["BOM", "Material Transferred for Manufacture"]

--- a/erpnext/manufacturing/doctype/work_order/work_order.js
+++ b/erpnext/manufacturing/doctype/work_order/work_order.js
@@ -239,6 +239,11 @@ frappe.ui.form.on("Work Order", {
 		frm.trigger("add_custom_button_to_return_components");
 		frm.trigger("allow_alternative_item");
 		frm.trigger("hide_reserve_stock_button");
+		frm.trigger("toggle_items_editable");
+	},
+
+	toggle_items_editable(frm) {
+		frm.toggle_enable("required_items", frm.doc.__onload?.allow_editing_items === 1 ? 1 : 0);
 	},
 
 	hide_reserve_stock_button(frm) {

--- a/erpnext/manufacturing/doctype/work_order/work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/work_order.py
@@ -151,6 +151,7 @@ class WorkOrder(Document):
 
 	def onload(self):
 		ms = frappe.get_doc("Manufacturing Settings")
+		self.set_onload("allow_editing_items", ms.allow_editing_of_items_and_quantities_in_work_order)
 		self.set_onload("material_consumption", ms.material_consumption)
 		self.set_onload("backflush_raw_materials_based_on", ms.backflush_raw_materials_based_on)
 		self.set_onload("overproduction_percentage", ms.overproduction_percentage_for_work_order)
@@ -205,7 +206,11 @@ class WorkOrder(Document):
 
 		validate_uom_is_integer(self, "stock_uom", ["required_qty"])
 
-		self.set_required_items(reset_only_qty=len(self.get("required_items")))
+		if not len(self.get("required_items")) or not frappe.db.get_single_value(
+			"Manufacturing Settings", "allow_editing_of_items_and_quantities_in_work_order"
+		):
+			self.set_required_items(reset_only_qty=len(self.get("required_items")))
+
 		self.enable_auto_reserve_stock()
 		self.validate_operations_sequence()
 		self.validate_subcontracting_inward_order()


### PR DESCRIPTION
<img width="1115" height="643" alt="Screenshot 2025-11-07 at 3 25 52 PM" src="https://github.com/user-attachments/assets/cf018634-75fd-41ec-8350-de6b29502d55" />


Fixed https://github.com/frappe/erpnext/issues/47790

Docs https://docs.frappe.io/erpnext/user/manual/en/manufacturing-settings#4-allow-editing-of-items-and-quantities-in-work-order