### PR TITLE
fix: check warehouse account before accessing

### DIFF
--- a/erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py
+++ b/erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py
@@ -599,7 +599,7 @@ class SubcontractingReceipt(SubcontractingController):
 
 		for item in self.items:
 			if flt(item.rate) and flt(item.qty):
-				if warehouse_account.get(item.warehouse):
+				if warehouse_account and warehouse_account.get(item.warehouse):
 					stock_value_diff = frappe.db.get_value(
 						"Stock Ledger Entry",
 						{


### PR DESCRIPTION
**Issue:** `NoneType` object error while previewing GL Entries for _Subcontracting Receipt_ in _Repost Accounting Ledger_

**Ref: [52573](https://support.frappe.io/helpdesk/tickets/52573)**

**Before:**

[Screencast from 07-11-25 03:43:29 PM IST.webm](https://github.com/user-attachments/assets/bbb9d047-c3d6-423e-b53f-f120118eead7)


**After:**

[Screencast from 07-11-25 03:43:09 PM IST.webm](https://github.com/user-attachments/assets/27d93d85-7e2d-439f-8f81-026623009f80)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue in Subcontracting Receipt where General Ledger entries could fail when warehouse account information was missing. GL entries now only process when valid warehouse account mapping is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->