### PR TITLE
fix: don't duplicate default income account to Item

### DIFF
--- a/erpnext/controllers/selling_controller.py
+++ b/erpnext/controllers/selling_controller.py
@@ -1009,12 +1009,11 @@ class SellingController(StockController):
 
 
 def set_default_income_account_for_item(obj):
+	company_default = frappe.get_cached_value("Company", obj.company, "default_income_account")
 	for d in obj.get("items", default=[]):
-		if d.item_code:
-			if getattr(d, "income_account", None) and d.income_account != frappe.db.get_value(
-				"Company", obj.company, "default_income_account"
-			):
-				set_item_default(d.item_code, obj.company, "income_account", d.income_account)
+		income_account = getattr(d, "income_account", None)
+		if d.item_code and income_account and income_account != company_default:
+			set_item_default(d.item_code, obj.company, "income_account", income_account)
 
 
 def get_serial_and_batch_bundle(child, parent, delivery_note_child=None):

--- a/erpnext/controllers/selling_controller.py
+++ b/erpnext/controllers/selling_controller.py
@@ -1009,9 +1009,11 @@ class SellingController(StockController):
 
 
 def set_default_income_account_for_item(obj):
-	for d in obj.get("items"):
+	for d in obj.get("items", default=[]):
 		if d.item_code:
-			if getattr(d, "income_account", None):
+			if getattr(d, "income_account", None) and d.income_account != frappe.db.get_value(
+				"Company", obj.company, "default_income_account"
+			):
 				set_item_default(d.item_code, obj.company, "income_account", d.income_account)
 
 

--- a/erpnext/controllers/selling_controller.py
+++ b/erpnext/controllers/selling_controller.py
@@ -1009,6 +1009,14 @@ class SellingController(StockController):
 
 
 def set_default_income_account_for_item(obj):
+	"""Set income account as default for items in the transaction.
+
+	Updates the item default income account for each item in the transaction
+	if it differs from the company's default income account.
+
+	Args:
+	    obj: Transaction document containing items table with income_account field
+	"""
 	company_default = frappe.get_cached_value("Company", obj.company, "default_income_account")
 	for d in obj.get("items", default=[]):
 		income_account = getattr(d, "income_account", None)


### PR DESCRIPTION
Only store _Default Income Account_ in **Item** if it's different from the **Company**'s  _Default Income Account_.

This retains the "feature" of automatically storing special income accounts while solving the issue of duplicating the company's default account to every item.

Resolves #48231
