### PR TITLE
fix(stock): ignore current voucher in reserved stock validation

### DIFF
--- a/erpnext/stock/doctype/delivery_note/delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.py
@@ -523,7 +523,7 @@ class DeliveryNote(SellingController):
 		reserved_stocks = self.get_reserved_stock_details()
 
 		for row in self.items:
-			if reserved_stocks.get((row.item_code, row.warehouse)) > 0:
+			if flt(reserved_stocks.get((row.item_code, row.warehouse))) > 0:
 				args = frappe._dict(
 					{
 						"item_code": row.item_code,

--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -2235,6 +2235,10 @@ def get_future_sle_with_negative_batch_qty(sle_args):
 
 
 def validate_reserved_stock(kwargs):
+	# ignore current voucher when validating the reserved stock
+	if not kwargs.ignore_voucher_nos and kwargs.voucher_no:
+		kwargs.ignore_voucher_nos = [kwargs.voucher_no]
+
 	if kwargs.serial_no:
 		validate_reserved_serial_nos(kwargs)
 


### PR DESCRIPTION
**Issue:** Negative Stock Error while doing transfer entry for item with partially reserved stock.

**Fix:** Passing the current voucher no to ignore when fetching available quantity from ledgers.

**Steps to Replicate:**

(Make sure Stock Reservation is enabled in Stock Settings)
1) Create a New Item. Enable Batch
2) Create a Stock Entry of type Material Receipt for the new item with 8 qty
3) Create a New Sales Order with the New item and set the Qty as 3. Save & submit the sales order
4) Create a Pick List from Sales Order and Pick the batch created from the Stock entry. Submit the Pick List
5) From Pick List, Reserve the Stock.
6) Create a New Stock Entry to transfer the remaining 5 stock
7) Select Stock Entry type as Material Transfer and select target warehouse and Pick the batch
8) Enter Qty as 5 (8-3 = 5) and submit the stock entry. System will throw a Reserved Stock for Batch error.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced reserved stock validation to handle edge cases and ensure accurate calculations during stock operations and delivery note processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->