### PR TITLE
fix: ignore translations from frappe

### DIFF
--- a/erpnext/hooks.py
+++ b/erpnext/hooks.py
@@ -663,3 +663,8 @@ default_log_clearing_doctypes = {
 export_python_type_annotations = True
 
 fields_for_group_similar_items = ["qty", "amount"]
+
+# Translation
+# ------------
+# List of apps whose translatable strings should be excluded from this app's translations.
+ignore_translatable_strings_from = ["frappe"]


### PR DESCRIPTION
Don't write translatable strings into ERPNext's `.pot`-file for messages that are already specified in the Frappe Framework. If a translatable string exists there, we don't want to override it with our own.

This should reduce our translation file by ~8,000 lines (13%).

Depends on https://github.com/frappe/frappe/pull/34544