### PR TITLE
fix: add doctype parameter to lead details for correct company details

### DIFF
--- a/erpnext/controllers/selling_controller.py
+++ b/erpnext/controllers/selling_controller.py
@@ -141,6 +141,7 @@ class SellingController(StockController):
 					lead,
 					posting_date=self.get("transaction_date") or self.get("posting_date"),
 					company=self.company,
+					doctype=self.doctype,
 				)
 			)
 

--- a/erpnext/crm/doctype/lead/lead.py
+++ b/erpnext/crm/doctype/lead/lead.py
@@ -442,7 +442,7 @@ def _set_missing_values(source, target):
 
 
 @frappe.whitelist()
-def get_lead_details(lead, posting_date=None, company=None):
+def get_lead_details(lead, posting_date=None, company=None, doctype=None):
 	if not lead:
 		return {}
 
@@ -464,7 +464,7 @@ def get_lead_details(lead, posting_date=None, company=None):
 		}
 	)
 
-	set_address_details(out, lead, "Lead", company=company)
+	set_address_details(out, lead, "Lead", doctype=doctype, company=company)
 
 	taxes_and_charges = set_taxes(
 		None,

--- a/erpnext/selling/doctype/quotation/quotation.js
+++ b/erpnext/selling/doctype/quotation/quotation.js
@@ -252,6 +252,7 @@ erpnext.selling.QuotationController = class QuotationController extends erpnext.
 				lead: this.frm.doc.party_name,
 				posting_date: this.frm.doc.transaction_date,
 				company: this.frm.doc.company,
+				doctype: this.frm.doc.doctype,
 			},
 			callback: function (r) {
 				if (r.message) {


### PR DESCRIPTION
Issue: Correct tax details were not fetched when the quotation was created from a lead.Even though the company address was fetched, the fields (fetch from were not fetched) because they were only fetched for the Sales Doctype, and the doctype was not being passed.Due to which regional code(India Compliance App) is not fetching taxes.

Steps to replicate:
- Install India Compliance App.
- Create a Lead
- Create a Quotation from the lead

Taxes should have been automatically fetched, but were not fetched because the company's GSTIN was not fetched.

Before:

https://github.com/user-attachments/assets/bb874c64-5fa5-4394-99a1-746ac2fca322


After:


https://github.com/user-attachments/assets/baa824f7-d3cd-4f61-815a-604220a5fb7b


Frappe Support Issue: https://support.frappe.io/app/hd-ticket/52864