### PR TITLE
fix: change fieldtype from link to data for document_type in producti…

### DIFF
--- a/erpnext/manufacturing/report/production_plan_summary/production_plan_summary.py
+++ b/erpnext/manufacturing/report/production_plan_summary/production_plan_summary.py
@@ -160,10 +160,9 @@ def get_column(filters):
 		},
 		{
 			"label": _("Document Type"),
-			"fieldtype": "Link",
+			"fieldtype": "Data",
 			"fieldname": "document_type",
 			"width": 150,
-			"options": "DocType",
 		},
 		{
 			"label": _("Document Name"),


### PR DESCRIPTION
**Issue :**

When a normal user tries to access Production Plan Summary report, a permission error occurs because the **Document Type** column is defined as a Link field pointing to the **DocType** doctype.

Since only users with the **System Manager** role  or Administrator user have read access to the DocType doctype, other users are unable to load the report.


**Ref :** [#51054](https://support.frappe.io/helpdesk/tickets/51054)


**Backport needed: v15**