### PR TITLE
fix: add company filter for default warehouse for sales return

### DIFF
--- a/erpnext/setup/doctype/company/company.js
+++ b/erpnext/setup/doctype/company/company.js
@@ -53,6 +53,15 @@ frappe.ui.form.on("Company", {
 				},
 			};
 		});
+
+		frm.set_query("default_warehouse_for_sales_return", function () {
+			return {
+				filters: {
+					company: frm.doc.name,
+					is_group: 0,
+				},
+			};
+		});
 	},
 
 	company_name: function (frm) {


### PR DESCRIPTION
**Issue :**

When selecting the Default Warehouse for Sales Return in the Company doctype, the field currently displays all warehouses across companies, allowing users to select a warehouse belonging to another company.

**Before :**

<img width="1919" height="920" alt="Before" src="https://github.com/user-attachments/assets/b7ee0d46-395f-4b85-b33e-37621614cc0b" />


**After :**

<img width="1919" height="910" alt="After" src="https://github.com/user-attachments/assets/39ee69fe-f81e-4531-a02d-b8c6587594ee" />


**Backport needed: v15**

 
 