### PR TITLE
fix: update uom when item changes

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -558,6 +558,7 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 
 		item.weight_per_unit = 0;
 		item.weight_uom = '';
+		item.uom = null // make UOM blank to update the existing UOM when item changes
 		item.conversion_factor = 0;
 
 		if(['Sales Invoice', 'Purchase Invoice'].includes(this.frm.doc.doctype)) {


### PR DESCRIPTION
**Issue:** Default UOM is not updating in the line item row when the user changes the item code. 

**Ref: [51321](https://support.frappe.io/helpdesk/tickets/51321) , [52987](https://support.frappe.io/helpdesk/tickets/52987)**

**Before:**

https://github.com/user-attachments/assets/81fd0d4f-dd84-4ae8-8691-ce5911ee5d34

**After:**

https://github.com/user-attachments/assets/29cfef7a-a0ab-4c9b-9211-26cb4ccf640e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the unit of measure (UOM) was not properly cleared when changing the item in a transaction line item. The UOM will now reset appropriately when a new item is selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->