### PR TITLE
fix: automatically append taxes if taxes_and_charges is set in Buying controller

### DIFF
--- a/erpnext/controllers/buying_controller.py
+++ b/erpnext/controllers/buying_controller.py
@@ -15,6 +15,7 @@ from erpnext.accounts.doctype.accounting_dimension.accounting_dimension import g
 from erpnext.accounts.doctype.budget.budget import validate_expense_against_budget
 from erpnext.accounts.party import get_party_details
 from erpnext.buying.utils import update_last_purchase_rate, validate_for_items
+from erpnext.controllers.accounts_controller import get_taxes_and_charges
 from erpnext.controllers.sales_and_purchase_return import get_rate_for_return
 from erpnext.controllers.subcontracting_controller import SubcontractingController
 from erpnext.stock.get_item_details import get_conversion_factor, get_item_defaults
@@ -215,6 +216,12 @@ class BuyingController(SubcontractingController):
 			)
 
 		self.set_missing_item_details(for_validate)
+
+		if self.meta.get_field("taxes"):
+			if self.get("taxes_and_charges") and not self.get("taxes") and not for_validate:
+				taxes = get_taxes_and_charges("Purchase Taxes and Charges Template", self.taxes_and_charges)
+				for tax in taxes:
+					self.append("taxes", tax)
 
 	def set_supplier_from_item_default(self):
 		if self.meta.get_field("supplier") and not self.supplier:


### PR DESCRIPTION
Issue: While creating a supplier quotation from a request for quotation, taxes are not populating, even though the taxes and charges template is set.

Steps to replicate:
- Create a tax rule for the supplier.
- Create a Request for Quotation for the supplier.
- Create Supplier quotation from RFQ.

The taxes and charges template will be set, but taxes will be empty.

closes: https://github.com/frappe/erpnext/issues/49610
continued:https://github.com/frappe/erpnext/pull/49755