### PR TITLE
fix: use current_tax_amount value for base_total_taxes_and_charges

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -1873,7 +1873,7 @@ class PaymentEntry(AccountsController):
 				else:
 					self.total_taxes_and_charges += current_tax_amount
 
-			self.base_total_taxes_and_charges += tax.base_tax_amount
+			self.base_total_taxes_and_charges += current_tax_amount
 
 		if self.get("taxes"):
 			self.paid_amount_after_tax = self.get("taxes")[-1].base_total


### PR DESCRIPTION
**Issue :**

Incorrect amount showing in bank clearance when **TDS** gets deducted for the payment entry


**Ref :** [#53067](https://support.frappe.io/helpdesk/tickets/53067) , [#53174](https://support.frappe.io/helpdesk/tickets/53174) , [#53680](https://support.frappe.io/helpdesk/tickets/53680)


**Before :**


https://github.com/user-attachments/assets/dc9cfbbb-9b8a-427f-b69f-c7754c825697



**After :**


https://github.com/user-attachments/assets/0d6338b7-eb8e-4007-ba2c-751d433da138



**Backport needed: v15**

