### PR TITLE
fix: validate sabb autocreation when disabled

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -1213,7 +1213,9 @@ class StockEntry(StockController, SubcontractingInwardController):
 				).update_serial_and_batch_entries(
 					serial_nos=serial_nos.get(row.name), batch_nos=batch_nos.get(row.name)
 				)
-			elif not row.serial_and_batch_bundle:
+			elif not row.serial_and_batch_bundle and frappe.get_single_value(
+				"Stock Settings", "auto_create_serial_and_batch_bundle_for_outward"
+			):
 				bundle_doc = SerialBatchCreation(
 					{
 						"item_code": row.item_code,

--- a/erpnext/stock/serial_batch_bundle.py
+++ b/erpnext/stock/serial_batch_bundle.py
@@ -268,7 +268,7 @@ class SerialBatchBundle:
 			and not self.sle.serial_and_batch_bundle
 			and self.item_details.has_batch_no == 1
 			and (
-				self.item_details.create_new_batch
+				(self.item_details.create_new_batch and self.sle.actual_qty > 0)
 				or (
 					frappe.get_single_value(
 						"Stock Settings", "auto_create_serial_and_batch_bundle_for_outward"


### PR DESCRIPTION
**Issue:** Despite `Auto Create Serial and Batch Bundle For Outward` is unchecked in stock settings, the system created bundle for outward entry and picked batch automatically without manual intervention.

**Ref: [52693](https://support.frappe.io/helpdesk/tickets/52693)**


**Before:**

[sabb-creation-issue.webm](https://github.com/user-attachments/assets/51216736-3223-48b0-b28d-1520aa93ca4b)


**After:**

[sabb-creation-fixed.webm](https://github.com/user-attachments/assets/2826c01e-64e1-494d-84ac-d01752dd9ae4)


**Backport Needed: v15**