### PR TITLE
fix: handle NoneType object error for packed_items

### DIFF
--- a/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py
+++ b/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py
@@ -1390,12 +1390,14 @@ class SerialandBatchBundle(Document):
 
 		so_name, so_detail_no = frappe.db.get_value(
 			"Delivery Note Item", self.voucher_detail_no, ["against_sales_order", "so_detail"]
-		)
+		) or [None, None]
 
 		if so_name and so_detail_no:
 			sre_names = get_sre_against_so_for_dn(so_name, so_detail_no)
 
 			return sre_names
+
+		return None
 
 
 @frappe.whitelist()


### PR DESCRIPTION
**Issue:** Nonetype object error when creating DN for product bundle item.

**Ref: [53076](https://support.frappe.io/helpdesk/tickets/53076)**

**Before:**

[nonetype-issue.webm](https://github.com/user-attachments/assets/7a7f04d4-7c4f-4118-997a-6f006a04c012)


**After:**

[nonetype-fixed.webm](https://github.com/user-attachments/assets/304f2f89-0827-4055-bc68-56997dbdabc2)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced reliability in serial and batch bundle operations to prevent potential processing errors during data retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->