### PR TITLE
fix: back calcalute total amount from rate and tax_amount in tax withholding details report

### DIFF
--- a/erpnext/accounts/report/tax_withholding_details/tax_withholding_details.py
+++ b/erpnext/accounts/report/tax_withholding_details/tax_withholding_details.py
@@ -80,13 +80,13 @@ def get_result(filters, tds_docs, tds_accounts, tax_category_map, journal_entry_
 
 			if values:
 				if voucher_type == "Journal Entry" and tax_amount and rate:
-					# back calcalute total amount from rate and tax_amount
+					# back calculate total amount from rate and tax_amount
 					base_total = min(flt(tax_amount / (rate / 100), precision=precision), values[0])
 					total_amount = grand_total = base_total
 
 				else:
 					if tax_amount and rate:
-						# back calcalute total amount from rate and tax_amount
+						# back calculate total amount from rate and tax_amount
 						total_amount = flt((tax_amount * 100) / rate, precision=precision)
 					else:
 						total_amount = values[0]

--- a/erpnext/accounts/report/tax_withholding_details/tax_withholding_details.py
+++ b/erpnext/accounts/report/tax_withholding_details/tax_withholding_details.py
@@ -72,17 +72,28 @@ def get_result(filters, tds_docs, tds_accounts, tax_category_map, journal_entry_
 					tax_withholding_category = party_map.get(party, {}).get("tax_withholding_category")
 
 				rate = get_tax_withholding_rates(tax_rate_map.get(tax_withholding_category, []), posting_date)
-			if net_total_map.get((voucher_type, name)):
+
+			values = net_total_map.get((voucher_type, name))
+
+			if values:
 				if voucher_type == "Journal Entry" and tax_amount and rate:
 					# back calcalute total amount from rate and tax_amount
-					base_total = min(tax_amount / (rate / 100), net_total_map.get((voucher_type, name))[0])
+					base_total = min(tax_amount / (rate / 100), values[0])
 					total_amount = grand_total = base_total
-				elif voucher_type == "Purchase Invoice":
-					total_amount, grand_total, base_total, bill_no, bill_date = net_total_map.get(
-						(voucher_type, name)
-					)
+
 				else:
-					total_amount, grand_total, base_total = net_total_map.get((voucher_type, name))
+					if tax_amount and rate:
+						# back calcalute total amount from rate and tax_amount
+						total_amount = (tax_amount * 100) / rate
+					else:
+						total_amount = values[0]
+
+					grand_total = values[1]
+					base_total = values[2]
+
+					if voucher_type == "Purchase Invoice":
+						bill_no = values[3]
+						bill_date = values[4]
 			else:
 				total_amount += entry.credit
 

--- a/erpnext/accounts/report/tax_withholding_details/tax_withholding_details.py
+++ b/erpnext/accounts/report/tax_withholding_details/tax_withholding_details.py
@@ -4,7 +4,9 @@
 
 import frappe
 from frappe import _
-from frappe.utils import getdate
+from frappe.utils import flt, getdate
+
+from erpnext.accounts.utils import get_currency_precision
 
 
 def execute(filters=None):
@@ -43,6 +45,7 @@ def get_result(filters, tds_docs, tds_accounts, tax_category_map, journal_entry_
 	party_map = get_party_pan_map(filters.get("party_type"))
 	tax_rate_map = get_tax_rate_map(filters)
 	gle_map = get_gle_map(tds_docs)
+	precision = get_currency_precision()
 
 	out = []
 	entries = {}
@@ -78,13 +81,13 @@ def get_result(filters, tds_docs, tds_accounts, tax_category_map, journal_entry_
 			if values:
 				if voucher_type == "Journal Entry" and tax_amount and rate:
 					# back calcalute total amount from rate and tax_amount
-					base_total = min(tax_amount / (rate / 100), values[0])
+					base_total = min(flt(tax_amount / (rate / 100), precision=precision), values[0])
 					total_amount = grand_total = base_total
 
 				else:
 					if tax_amount and rate:
 						# back calcalute total amount from rate and tax_amount
-						total_amount = (tax_amount * 100) / rate
+						total_amount = flt((tax_amount * 100) / rate, precision=precision)
 					else:
 						total_amount = values[0]
 


### PR DESCRIPTION
Issue: When TDS is deducted in the advance payment and adjusted in the invoice, the grand total in tax withholding details report is incorrect.

Steps to Replicate the issue:
-Create a supplier with Tax Withholding Category and rate as 0.1%.
-Create payment entry for payment of amount 500000, with Apply Tax Withholding Amount ticked and TDS deducted.
-Create a purchase invoice of 10,00,000 with TDS and advance payments allocated.

In payment entry, TDS will be deducted 500; in the invoice, also TDS will be deducted 500, but the report will show the total amount as 1500000 and TDS deduction as 1000.



Before:
<img width="1868" height="349" alt="image" src="https://github.com/user-attachments/assets/fabaf9a7-0949-4eb7-9a97-600c58503b9a" />


After: 
<img width="1727" height="336" alt="image" src="https://github.com/user-attachments/assets/75d8c7ef-0fa9-43ec-85f8-446af30cb0ad" />


Before:
<img width="1888" height="412" alt="image" src="https://github.com/user-attachments/assets/be97a621-1d95-4800-8004-a77f0a8da2ff" />


After:
<img width="1800" height="365" alt="image" src="https://github.com/user-attachments/assets/c3338230-9e0e-4533-83f7-2aca4b2f055e" />


Frappe Support Issue: https://support.frappe.io/app/hd-ticket/52645
