### PR TITLE
fix(period closing voucher): add title to error log

### DIFF
--- a/erpnext/accounts/doctype/period_closing_voucher/period_closing_voucher.py
+++ b/erpnext/accounts/doctype/period_closing_voucher/period_closing_voucher.py
@@ -475,10 +475,7 @@ def process_gl_and_closing_entries(doc):
 		frappe.db.set_value(doc.doctype, doc.name, "gle_processing_status", "Completed")
 	except Exception as e:
 		frappe.db.rollback()
-		frappe.log_error(
-			title=_("Period Closing Voucher {0} GL Entry Processing Failed").format(doc.name),
-			message=frappe.get_traceback(),
-		)
+		frappe.log_error(title=_("Period Closing Voucher {0} GL Entry Processing Failed").format(doc.name))
 		frappe.db.set_value(
 			doc.doctype,
 			doc.name,
@@ -499,8 +496,7 @@ def process_cancellation(voucher_type, voucher_no):
 	except Exception as e:
 		frappe.db.rollback()
 		frappe.log_error(
-			title=_("Period Closing Voucher {0} GL Entry Cancellation Failed").format(voucher_no),
-			message=frappe.get_traceback(),
+			title=_("Period Closing Voucher {0} GL Entry Cancellation Failed").format(voucher_no)
 		)
 		frappe.db.set_value(
 			voucher_type,

--- a/erpnext/accounts/doctype/period_closing_voucher/period_closing_voucher.py
+++ b/erpnext/accounts/doctype/period_closing_voucher/period_closing_voucher.py
@@ -475,8 +475,18 @@ def process_gl_and_closing_entries(doc):
 		frappe.db.set_value(doc.doctype, doc.name, "gle_processing_status", "Completed")
 	except Exception as e:
 		frappe.db.rollback()
-		frappe.log_error(e)
-		frappe.db.set_value(doc.doctype, doc.name, "gle_processing_status", "Failed")
+		frappe.log_error(
+			title=_("Period Closing Voucher {0} GL Entry Processing Failed").format(doc.name),
+			message=frappe.get_traceback(),
+		)
+		frappe.db.set_value(
+			doc.doctype,
+			doc.name,
+			{
+				"error_message": str(e),
+				"gle_processing_status": "Failed",
+			},
+		)
 
 
 def process_cancellation(voucher_type, voucher_no):
@@ -488,8 +498,18 @@ def process_cancellation(voucher_type, voucher_no):
 		frappe.db.set_value("Period Closing Voucher", voucher_no, "gle_processing_status", "Completed")
 	except Exception as e:
 		frappe.db.rollback()
-		frappe.log_error(e)
-		frappe.db.set_value("Period Closing Voucher", voucher_no, "gle_processing_status", "Failed")
+		frappe.log_error(
+			title=_("Period Closing Voucher {0} GL Entry Cancellation Failed").format(voucher_no),
+			message=frappe.get_traceback(),
+		)
+		frappe.db.set_value(
+			voucher_type,
+			voucher_no,
+			{
+				"error_message": str(e),
+				"gle_processing_status": "Failed",
+			},
+		)
 
 
 def delete_closing_entries(voucher_no):


### PR DESCRIPTION
**Issue :**

While logging the error in period closing voucher , currently the system attempted to create an Error Log, but failed due to field length limitation (140 characters).


**Ref :** [#53148](https://support.frappe.io/helpdesk/tickets/53148)

**Fix :**

- Add title for the log error.
- Update the error message to the respective field.



**Backport needed: v15**