### PR TITLE
fix(purchase_receipt): add internal_and_external_links field to show …

### DIFF
--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt_dashboard.py
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt_dashboard.py
@@ -18,6 +18,9 @@ def get_data():
 			"Purchase Order": ["items", "purchase_order"],
 			"Project": ["items", "project"],
 		},
+		"internal_and_external_links": {
+			"Purchase Invoice": ["items", "purchase_invoice"],
+		},
 		"transactions": [
 			{
 				"label": _("Related"),


### PR DESCRIPTION
Issue:
When a Purchase Receipt is created by referencing a Purchase Invoice, the internal connection to the Purchase Invoice is not reflected in the Purchase Receipt’s connections view. As a result, the connected Purchase Invoice count is not displayed under internal transactions.

Ref: [51991](https://support.frappe.io/helpdesk/tickets/51991)

<img width="1300" height="617" alt="after" src="https://github.com/user-attachments/assets/9094b2fb-f869-4eec-9b15-486f2256c45f" />


Backport needed - version 15

