### PR TITLE
fix: add contact name field to party quick entry form

### DIFF
--- a/erpnext/public/js/utils/contact_address_quick_entry.js
+++ b/erpnext/public/js/utils/contact_address_quick_entry.js
@@ -73,6 +73,11 @@ frappe.ui.form.ContactAddressQuickEntryForm = class ContactAddressQuickEntryForm
 				collapsible: 1,
 			},
 			{
+				label: __("Contact Name"),
+				fieldname: "contact_name",
+				fieldtype: "Data",
+			},
+			{
 				label: __("Address Line 1"),
 				fieldname: "address_line1",
 				fieldtype: "Data",

--- a/erpnext/selling/doctype/customer/customer.py
+++ b/erpnext/selling/doctype/customer/customer.py
@@ -730,7 +730,17 @@ def make_contact(args, is_primary_contact=1):
 	party_type = args.customer_type if args.doctype == "Customer" else args.supplier_type
 	party_name_key = "customer_name" if args.doctype == "Customer" else "supplier_name"
 
-	if party_type == "Individual":
+	if contact_name := args.get("contact_name"):
+		first, middle, last = parse_full_name(contact_name)
+		values.update(
+			{
+				"first_name": first,
+				"middle_name": middle,
+				"last_name": last,
+			}
+		)
+
+	elif party_type == "Individual":
 		first, middle, last = parse_full_name(args.get(party_name_key))
 		values.update(
 			{


### PR DESCRIPTION
Issue: The Contact name was automatically set incorrectly based on the party name.

<img width="618" height="872" alt="image" src="https://github.com/user-attachments/assets/88935462-484c-4f6d-9b21-04916e040dfa" />


Frappe Support Issue: https://support.frappe.io/app/hd-ticket/53105