### PR TITLE
fix: first and last name in supplier quick entry

### DIFF
--- a/erpnext/public/js/utils/contact_address_quick_entry.js
+++ b/erpnext/public/js/utils/contact_address_quick_entry.js
@@ -44,13 +44,13 @@ frappe.ui.form.ContactAddressQuickEntryForm = class ContactAddressQuickEntryForm
 				label: __("First Name"),
 				fieldname: "map_to_first_name",
 				fieldtype: "Data",
-				depends_on: "eval:doc.customer_type=='Company'",
+				depends_on: "eval:doc.customer_type=='Company' || doc.supplier_type=='Company'",
 			},
 			{
 				label: __("Last Name"),
 				fieldname: "map_to_last_name",
 				fieldtype: "Data",
-				depends_on: "eval:doc.customer_type=='Company'",
+				depends_on: "eval:doc.customer_type=='Company' || doc.supplier_type=='Company'",
 			},
 
 			{


### PR DESCRIPTION
Issue: First and last name fields are available in customer quick entry, but not in supplier quick entry.

<img width="612" height="562" alt="image" src="https://github.com/user-attachments/assets/b0b88ed8-3d23-4485-8a42-3c84c020fbc9" />
