### PR TITLE
fix(general_ledger): add translation for accounting dimension

### DIFF
--- a/erpnext/accounts/report/general_ledger/general_ledger.py
+++ b/erpnext/accounts/report/general_ledger/general_ledger.py
@@ -546,6 +546,13 @@ def get_accountwise_gle(filters, accounting_dimensions, gl_entries, gle_map):
 		gle.remarks = _(gle.remarks)
 		gle.party_type = _(gle.party_type)
 
+		if filters.get("include_dimensions"):
+			dimensions = [*accounting_dimensions, "cost_center", "project"]
+
+			for dimension in dimensions:
+				if val := gle.get(dimension):
+					gle[dimension] = _(val)
+
 		if gle.posting_date < from_date or (cstr(gle.is_opening) == "Yes" and not show_opening_entries):
 			if not group_by_voucher_consolidated:
 				update_value_in_dict(gle_map[group_by_value].totals, "opening", gle)

--- a/erpnext/accounts/report/general_ledger/general_ledger.py
+++ b/erpnext/accounts/report/general_ledger/general_ledger.py
@@ -546,13 +546,6 @@ def get_accountwise_gle(filters, accounting_dimensions, gl_entries, gle_map):
 		gle.remarks = _(gle.remarks)
 		gle.party_type = _(gle.party_type)
 
-		if filters.get("include_dimensions"):
-			dimensions = [*accounting_dimensions, "cost_center", "project"]
-
-			for dimension in dimensions:
-				if val := gle.get(dimension):
-					gle[dimension] = _(val)
-
 		if gle.posting_date < from_date or (cstr(gle.is_opening) == "Yes" and not show_opening_entries):
 			if not group_by_voucher_consolidated:
 				update_value_in_dict(gle_map[group_by_value].totals, "opening", gle)
@@ -594,6 +587,13 @@ def get_accountwise_gle(filters, accounting_dimensions, gl_entries, gle_map):
 					consolidated_gle.setdefault(key, gle)
 				else:
 					update_value_in_dict(consolidated_gle, key, gle)
+
+		if filters.get("include_dimensions"):
+			dimensions = [*accounting_dimensions, "cost_center", "project"]
+
+			for dimension in dimensions:
+				if val := gle.get(dimension):
+					gle[dimension] = _(val)
 
 	for value in consolidated_gle.values():
 		update_value_in_dict(totals, "total", value)


### PR DESCRIPTION
Issue: In GL report transaltion is not working for accounting dimension.

Ref: [52804](https://support.frappe.io/helpdesk/tickets/52804)

**Steps to Replicate the issue:**

- Translate “Shareholder” → “Corpus” using Translation tool.
- Create a custom Doctype named Sub Account Head.
- Add a field named sub_account_head.
- Set naming rule to use the value of sub_account_head.
- Create a sales invoice and select “Corpus” (previously translated from “Shareholder”).
- Click view -> Accounting Ledger

**Before:**

<img width="1882" height="727" alt="image" src="https://github.com/user-attachments/assets/431f1853-7795-4de3-886e-ffae8cc79110" />


**After:**

<img width="1879" height="753" alt="image" src="https://github.com/user-attachments/assets/da89b8bf-d9a3-4292-88f1-ce84fc4a96bf" />


**Backport Needed: Version-15**

