### PR TITLE
fix(financial reports): set fiscal year associated with the default company

### DIFF
--- a/erpnext/startup/boot.py
+++ b/erpnext/startup/boot.py
@@ -3,7 +3,10 @@
 
 
 import frappe
+from frappe.defaults import get_user_default
 from frappe.utils import cint
+
+from erpnext.accounts.utils import get_fiscal_years
 
 
 def boot_session(bootinfo):
@@ -53,6 +56,11 @@ def boot_session(bootinfo):
 		)
 
 		party_account_types = frappe.db.sql(""" select name, ifnull(account_type, '') from `tabParty Type`""")
+		fiscal_year = get_fiscal_years(
+			frappe.utils.nowdate(), company=get_user_default("company"), boolean=True
+		)
+		if fiscal_year:
+			bootinfo.current_fiscal_year = fiscal_year[0]
 		bootinfo.party_account_types = frappe._dict(party_account_types)
 
 		bootinfo.sysdefaults.demo_company = frappe.db.get_single_value("Global Defaults", "demo_company")


### PR DESCRIPTION
Issue:
Fiscal year is not being fetched according to the company selected in the report.

Ref: [#52938](https://support.frappe.io/helpdesk/tickets/52938)

Steps to Reproduce:

1. Create two companies: Test_Company_1 and Test_Company_2.
2. For Test_Company_1, create a fiscal year APR 1 to MAR 31.  For Test_Company_2, create a fiscal year JUN 1 to MAY 31. 
3. Set the session default company as Test_Company_1.
4. Load any financial report (Trial Balance, Profit and Loss) for Test_Company_1. The report throws an error.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized fiscal year lookups to reduce unnecessary API calls and improve performance for fiscal year-related operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->