### PR TITLE
fix: unintended backported depends_on expression

### DIFF
--- a/erpnext/manufacturing/doctype/bom/bom.json
+++ b/erpnext/manufacturing/doctype/bom/bom.json
@@ -591,7 +591,6 @@
   },
   {
    "default": "0",
-   "depends_on": "eval:doc.track_semi_finished_goods === 0",
    "fieldname": "fg_based_operating_cost",
    "fieldtype": "Check",
    "label": "Finished Goods based Operating Cost"


### PR DESCRIPTION
**Issue:** The `Finished Goods based Operating Cost` check is not present in BOM, which was previously there in version-15.

**Fix:** Removed unintended `depend_on` expression which was backported mistakenly from https://github.com/frappe/erpnext/pull/50264

**Before:**

<img width="1409" height="547" alt="image" src="https://github.com/user-attachments/assets/e46074fb-9df5-430a-a96d-ca46f165c530" />

**After:**

<img width="1409" height="547" alt="Screenshot from 2025-11-14 18-51-40" src="https://github.com/user-attachments/assets/4b2649ad-adb1-45d2-9908-fc72b57fb268" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The FG Based Operating Cost field in Bill of Materials is now always visible and accessible in the form, regardless of other settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->