### PR TITLE
fix(sales invoice): Calculate sales team contribution on update after submit

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -877,6 +877,7 @@ class SalesInvoice(SellingController):
 				data.sales_invoice = sales_invoice
 
 	def on_update_after_submit(self):
+		self.calculate_contribution()
 		fields_to_check = [
 			"additional_discount_account",
 			"cash_bank_account",


### PR DESCRIPTION
In a subimtted Sales Invoice, if you update the Sales Team table by adding a salesperson or changing the contribution of the salespeople listed, the check for 100% contribution is no longer performed, nor is the check for inactive salespeople. It is therefore possible to add several salespeople, each with a contribution of 100% (or only 10% or even 400%), and save the changes.

Note that this operation is correctly performed on_update_after_submit in Sales Orders, but not in Sales Invoices.