### PR TITLE
fix: construct batch_nos and serial_nos to avoid NoneType error

### DIFF
--- a/erpnext/stock/doctype/stock_reconciliation/test_stock_reconciliation.py
+++ b/erpnext/stock/doctype/stock_reconciliation/test_stock_reconciliation.py
@@ -45,6 +45,7 @@ class TestStockReconciliation(FrappeTestCase, StockTestMixin):
 	def test_reco_for_moving_average(self):
 		self._test_reco_sle_gle("Moving Average")
 
+	@change_settings("Stock Settings", {"allow_negative_stock": 1})
 	def _test_reco_sle_gle(self, valuation_method):
 		item_code = self.make_item(properties={"valuation_method": valuation_method}).name
 

--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -2240,9 +2240,11 @@ def validate_reserved_stock(kwargs):
 		kwargs.ignore_voucher_nos = [kwargs.voucher_no]
 
 	if kwargs.serial_no:
+		kwargs.serial_nos = kwargs.serial_no.split("\n")
 		validate_reserved_serial_nos(kwargs)
 
 	elif kwargs.batch_no:
+		kwargs.batch_nos = [kwargs.batch_no]
 		validate_reserved_batch_nos(kwargs)
 
 	elif kwargs.serial_and_batch_bundle:


### PR DESCRIPTION
**Issue:** `NoneType` object error while validating the reserved stock for inward entry.

**Ref: [53360](https://support.frappe.io/helpdesk/tickets/53360)**

**Before:**

<img width="1920" height="937" alt="Screenshot from 2025-11-15 16-07-14" src="https://github.com/user-attachments/assets/08203c6a-4661-4683-b656-d225b4353126" />

**After:**

<img width="1920" height="937" alt="Screenshot from 2025-11-15 16-10-15" src="https://github.com/user-attachments/assets/543966cd-faa8-444b-8bb6-c3ee6e67a8f5" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Updated test framework to support negative stock allowance scenarios with improved validation coverage.

* **Bug Fixes**
  * Enhanced input processing for serial numbers and batch numbers in stock ledger validation, now properly normalizing multi-line serial number entries and batch references for consistent validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->