### PR TITLE
fix(stock-entry): prevent default warehouse from overriding parent warehouse

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry.js
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.js
@@ -1382,8 +1382,8 @@ erpnext.stock.StockEntry = class StockEntry extends erpnext.stock.StockControlle
 			this.frm.script_manager.copy_from_first_row("items", row, ["expense_account", "cost_center"]);
 		}
 
-		if (!row.s_warehouse) row.s_warehouse = this.frm.doc.from_warehouse;
-		if (!row.t_warehouse) row.t_warehouse = this.frm.doc.to_warehouse;
+		if (this.frm.doc.from_warehouse) row.s_warehouse = this.frm.doc.from_warehouse;
+		if (this.frm.doc.to_warehouse) row.t_warehouse = this.frm.doc.to_warehouse;
 
 		if (cint(frappe.user_defaults?.use_serial_batch_fields)) {
 			frappe.model.set_value(row.doctype, row.name, "use_serial_batch_fields", 1);


### PR DESCRIPTION
**Issue :**

When a user has permissions for two warehouses and one of them is marked as the default, the Stock Entry form applies the default warehouse to all warehouse fields. Even if the user selects different Source and Target Warehouses in the parent document, the system still replaces the child item row values with the default warehouse from User Permissions.

**Ref :** [#52430](https://support.frappe.io/helpdesk/tickets/52430)


**Before :**


https://github.com/user-attachments/assets/d5e4feb7-6418-45ff-b69f-ab625e9d2263




**After :**


https://github.com/user-attachments/assets/9c809c08-a377-4551-8e9b-6097e0302ba1





**Backport Needed : v15**