### PR TITLE
fix: mark navbar item as translatable

### DIFF
--- a/erpnext/setup/install.py
+++ b/erpnext/setup/install.py
@@ -204,7 +204,7 @@ def add_standard_navbar_items():
 			"is_standard": 1,
 		},
 		{
-			"item_label": "Report an Issue",
+			"item_label": _("Report an Issue"),
 			"item_type": "Route",
 			"route": "https://github.com/frappe/erpnext/issues",
 			"is_standard": 1,


### PR DESCRIPTION
This pull request makes a minor improvement to the navigation bar items by ensuring that the "Report an Issue" label is translatable.

Backported via https://github.com/frappe/erpnext/pull/50539