### PR TITLE
fix: mark role profile names as translatable

### DIFF
--- a/erpnext/setup/install.py
+++ b/erpnext/setup/install.py
@@ -313,26 +313,26 @@ def create_letter_head():
 
 
 DEFAULT_ROLE_PROFILES = {
-	"Inventory": [
+	_("Inventory"): [
 		"Stock User",
 		"Stock Manager",
 		"Item Manager",
 	],
-	"Manufacturing": [
+	_("Manufacturing"): [
 		"Stock User",
 		"Manufacturing User",
 		"Manufacturing Manager",
 	],
-	"Accounts": [
+	_("Accounts"): [
 		"Accounts User",
 		"Accounts Manager",
 	],
-	"Sales": [
+	_("Sales"): [
 		"Sales User",
 		"Stock User",
 		"Sales Manager",
 	],
-	"Purchase": [
+	_("Purchase"): [
 		"Item Manager",
 		"Stock User",
 		"Purchase User",


### PR DESCRIPTION
The desired effect depends on https://github.com/frappe/frappe/pull/34709. Merging it first is still fine, since this dummy translation function (`identity`) does not change anything, apart from the strings being extracted to translation files.

The v15 backport depends on https://github.com/frappe/erpnext/pull/50539.