### PR TITLE
refactor: remove unused import

### DIFF
--- a/erpnext/setup/install.py
+++ b/erpnext/setup/install.py
@@ -7,7 +7,6 @@ import os
 import frappe
 from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
 from frappe.desk.page.setup_wizard.setup_wizard import add_all_roles_to
-from frappe.utils import cint
 
 from erpnext.setup.doctype.incoterm.incoterm import create_incoterms
 from erpnext.setup.utils import identity as _


### PR DESCRIPTION
This pull request makes a small change to the import statements in `erpnext/setup/install.py`, removing an unused import of `cint` to clean up the code.

Backport not needed, it's already removed in v15.