### PR TITLE
fix: prevent pi status from changing on asset repair

### DIFF
--- a/erpnext/assets/doctype/asset_repair/asset_repair.py
+++ b/erpnext/assets/doctype/asset_repair/asset_repair.py
@@ -305,7 +305,6 @@ class AssetRepair(AccountsController):
 					"cost_center": self.cost_center,
 					"posting_date": self.completion_date,
 					"against_voucher_type": "Purchase Invoice",
-					"against_voucher": self.purchase_invoice,
 					"company": self.company,
 				},
 				item=self,


### PR DESCRIPTION
Issue:
When an Asset Repair is submitted with an unpaid Purchase Invoice and "Capitalize Repair Cost" enabled, the PI status changes to Paid incorrectly.

Ref: [#53133](https://support.frappe.io/helpdesk/tickets/53133)

Steps to Reproduce:

1. Create an Asset and a Purchase Invoice for a non-stock item without making any payment.
2. Create an Asset Repair for the Asset, set the Purchase Invoice, enable "Capitalize Repair Cost", and submit it.
3. Check the Purchase Invoice the status wrongly changes to Paid.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated GL entry generation for asset repair operations to adjust how repair cost transactions are recorded and referenced in the accounting system.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->