### PR TITLE
fix: add delivery note link field in  non_standard_fieldnames for pick list

### DIFF
--- a/erpnext/stock/doctype/pick_list/pick_list_dashboard.py
+++ b/erpnext/stock/doctype/pick_list/pick_list_dashboard.py
@@ -3,6 +3,7 @@ def get_data():
 		"fieldname": "pick_list",
 		"non_standard_fieldnames": {
 			"Stock Reservation Entry": "from_voucher_no",
+			"Delivery Note": "against_pick_list",
 		},
 		"internal_links": {
 			"Sales Order": ["locations", "sales_order"],


### PR DESCRIPTION
**Issue :**

When creating a Pick List, the system attempts to fetch linked Delivery Notes. Due to missing mapping in non_standard_fieldnames, it incorrectly searches for `Delivery Note.pick_list`, which does not exist.

**Unknown column **pick_list** in Delivery Note**


**Before :**


<img width="1919" height="756" alt="Before" src="https://github.com/user-attachments/assets/5fd93ee7-e3e3-48c7-b171-205bbd59a9dc" />


**After :**


![After](https://github.com/user-attachments/assets/a558449a-ff2b-42a5-a951-524874fdc541)


