### PR TITLE
fix(ledger-summary-report): show party group and territory

### DIFF
--- a/erpnext/accounts/report/customer_ledger_summary/test_customer_ledger_summary.py
+++ b/erpnext/accounts/report/customer_ledger_summary/test_customer_ledger_summary.py
@@ -186,6 +186,8 @@ class TestCustomerLedgerSummary(AccountsTestMixin, IntegrationTestCase):
 		expected = {
 			"party": "_Test Customer",
 			"customer_name": "_Test Customer",
+			"customer_group": "_Test Customer Group",
+			"territory": "_Test Territory",
 			"party_name": "_Test Customer",
 			"opening_balance": 0,
 			"invoiced_amount": 100.0,
@@ -213,6 +215,8 @@ class TestCustomerLedgerSummary(AccountsTestMixin, IntegrationTestCase):
 		expected = {
 			"party": "_Test Customer",
 			"customer_name": "_Test Customer",
+			"customer_group": "_Test Customer Group",
+			"territory": "_Test Territory",
 			"party_name": "_Test Customer",
 			"opening_balance": 0,
 			"invoiced_amount": 100.0,


### PR DESCRIPTION
Issue: Not able to add supplier group as it is already present as hidden field.

Ref: [51950](https://support.frappe.io/helpdesk/tickets/51950)

<img width="1882" height="729" alt="image" src="https://github.com/user-attachments/assets/a9339e04-84ce-40b8-93bb-5470dea59bcc" />

<img width="1877" height="838" alt="image" src="https://github.com/user-attachments/assets/4511484b-fbe2-4595-8e9a-ee589d67eb03" />


**Backport Needed: Version-15**