### PR TITLE
fix: add cancelled option in status field

### DIFF
--- a/erpnext/assets/doctype/asset/asset.json
+++ b/erpnext/assets/doctype/asset/asset.json
@@ -371,7 +371,6 @@
    "label": "Other Details"
   },
   {
-   "allow_on_submit": 1,
    "default": "Draft",
    "fieldname": "status",
    "fieldtype": "Select",
@@ -379,7 +378,7 @@
    "in_standard_filter": 1,
    "label": "Status",
    "no_copy": 1,
-   "options": "Draft\nSubmitted\nPartially Depreciated\nFully Depreciated\nSold\nScrapped\nIn Maintenance\nOut of Order\nIssue\nReceipt\nCapitalized\nWork In Progress",
+   "options": "Draft\nSubmitted\nCancelled\nPartially Depreciated\nFully Depreciated\nSold\nScrapped\nIn Maintenance\nOut of Order\nIssue\nReceipt\nCapitalized\nWork In Progress",
    "read_only": 1
   },
   {
@@ -597,7 +596,7 @@
    "link_fieldname": "target_asset"
   }
  ],
- "modified": "2025-10-23 22:43:33.634452",
+ "modified": "2025-11-17 18:01:51.417942",
  "modified_by": "Administrator",
  "module": "Assets",
  "name": "Asset",

--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -103,6 +103,7 @@ class Asset(AccountsController):
 		status: DF.Literal[
 			"Draft",
 			"Submitted",
+			"Cancelled",
 			"Partially Depreciated",
 			"Fully Depreciated",
 			"Sold",

--- a/erpnext/assets/doctype/asset_repair/asset_repair.json
+++ b/erpnext/assets/doctype/asset_repair/asset_repair.json
@@ -139,7 +139,7 @@
    "fieldtype": "Link",
    "in_list_view": 1,
    "label": "Asset",
-   "link_filters": "[[\"Asset\",\"status\",\"not in\",[\"Work In Progress\",\"Capitalized\",\"Fully Depreciated\",\"Sold\",\"Scrapped\",null]]]",
+   "link_filters": "[[\"Asset\",\"status\",\"not in\",[\"Work In Progress\",\"Capitalized\",\"Fully Depreciated\",\"Sold\",\"Scrapped\",\"Cancelled\",null]]]",
    "options": "Asset",
    "reqd": 1
   },
@@ -250,7 +250,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-07-29 15:14:34.044564",
+ "modified": "2025-11-17 18:35:54.575265",
  "modified_by": "Administrator",
  "module": "Assets",
  "name": "Asset Repair",

--- a/erpnext/assets/doctype/asset_repair/asset_repair.py
+++ b/erpnext/assets/doctype/asset_repair/asset_repair.py
@@ -60,6 +60,17 @@ class AssetRepair(AccountsController):
 		if self.get("stock_items"):
 			self.set_stock_items_cost()
 		self.calculate_total_repair_cost()
+		self.validate_purchase_invoice_status()
+
+	def validate_purchase_invoice_status(self):
+		if self.purchase_invoice:
+			docstatus = frappe.db.get_value("Purchase Invoice", self.purchase_invoice, "docstatus")
+			if docstatus == 0:
+				frappe.throw(
+					_("{0} is still in Draft. Please submit it before saving the Asset Repair.").format(
+						get_link_to_form("Purchase Invoice", self.purchase_invoice)
+					)
+				)
 
 	def validate_asset(self):
 		if self.asset_doc.status in ("Sold", "Fully Depreciated", "Scrapped"):


### PR DESCRIPTION
**Issue :** Cancelled option is missing from the status filter in the asset doctype

**Ref :**  [#52685](https://support.frappe.io/helpdesk/tickets/52685)


**Before :**


<img width="1502" height="860" alt="Before" src="https://github.com/user-attachments/assets/4cf67be5-7880-4b1f-a313-68eb6379d844" />



**After :**


<img width="1741" height="873" alt="After" src="https://github.com/user-attachments/assets/c78e2151-f62f-4405-9baa-f575a39e99e8" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Cancelled" as an asset status.

* **Changes**
  * Asset status cannot be changed after submission.
  * Asset Repair excludes cancelled assets from selection.

* **Bug Fixes / Validation**
  * Asset Repair now prevents linking a Purchase Invoice that is still in Draft and shows a user-facing error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->