### PR TITLE
fix: validate account type of depreciation account

### DIFF
--- a/erpnext/accounts/doctype/journal_entry/journal_entry.py
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.py
@@ -326,10 +326,15 @@ class JournalEntry(AccountsController):
 
 	def validate_depr_account_and_depr_entry_voucher_type(self):
 		for d in self.get("accounts"):
+			root_type = frappe.get_cached_value("Account", d.account, "root_type")
 			if (
 				d.reference_type == "Asset"
 				and d.reference_name
-				and (d.account_type == "Depreciation" or self.voucher_type == "Depreciation Entry")
+				and (
+					d.account_type == "Depreciation"
+					or self.voucher_type == "Depreciation Entry"
+					or root_type == "Expense"
+				)
 				and d.debit
 			):
 				if d.account_type != "Depreciation":
@@ -340,7 +345,7 @@ class JournalEntry(AccountsController):
 						_("Journal Entry type should be set as Depreciation Entry for asset depreciation")
 					)
 
-				if frappe.get_cached_value("Account", d.account, "root_type") != "Expense":
+				if root_type != "Expense":
 					frappe.throw(_("Account {0} should be of type Expense").format(d.account))
 
 	def validate_stock_accounts(self):

--- a/erpnext/accounts/doctype/journal_entry/journal_entry.py
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.py
@@ -326,26 +326,13 @@ class JournalEntry(AccountsController):
 
 	def validate_depr_account_and_depr_entry_voucher_type(self):
 		for d in self.get("accounts"):
-			root_type = frappe.get_cached_value("Account", d.account, "root_type")
-			if (
-				d.reference_type == "Asset"
-				and d.reference_name
-				and (
-					d.account_type == "Depreciation"
-					or self.voucher_type == "Depreciation Entry"
-					or root_type == "Expense"
-				)
-				and d.debit
-			):
-				if d.account_type != "Depreciation":
-					frappe.throw(_("Account {0} should be of type Depreciation").format(d.account))
-
+			if d.account_type == "Depreciation":
 				if self.voucher_type != "Depreciation Entry":
 					frappe.throw(
 						_("Journal Entry type should be set as Depreciation Entry for asset depreciation")
 					)
 
-				if root_type != "Expense":
+				if frappe.get_cached_value("Account", d.account, "root_type") != "Expense":
 					frappe.throw(_("Account {0} should be of type Expense").format(d.account))
 
 	def validate_stock_accounts(self):
@@ -466,7 +453,7 @@ class JournalEntry(AccountsController):
 			if (
 				d.reference_type == "Asset"
 				and d.reference_name
-				and d.account_type == "Depreciation"
+				and frappe.get_cached_value("Account", d.account, "root_type") == "Expense"
 				and d.debit
 			):
 				asset = frappe.get_cached_doc("Asset", d.reference_name)

--- a/erpnext/accounts/doctype/journal_entry/journal_entry.py
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.py
@@ -326,7 +326,15 @@ class JournalEntry(AccountsController):
 
 	def validate_depr_account_and_depr_entry_voucher_type(self):
 		for d in self.get("accounts"):
-			if d.account_type == "Depreciation":
+			if (
+				d.reference_type == "Asset"
+				and d.reference_name
+				and (d.account_type == "Depreciation" or self.voucher_type == "Depreciation Entry")
+				and d.debit
+			):
+				if d.account_type != "Depreciation":
+					frappe.throw(_("Account {0} should be of type Depreciation").format(d.account))
+
 				if self.voucher_type != "Depreciation Entry":
 					frappe.throw(
 						_("Journal Entry type should be set as Depreciation Entry for asset depreciation")


### PR DESCRIPTION
Previously, depreciation was creating a Journal Entry even when the account type was incorrect, and it only failed later while linking the entry due to the correct validation. Now, the validation is added at the time of Journal Entry creation itself.

https://github.com/user-attachments/assets/956d8a39-13ef-4af9-8ea0-1eb951fe821b

