### PR TITLE
fix: resolve page sales-taxes-and-charges not found err

### DIFF
--- a/erpnext/workspace_sidebar/taxes.json
+++ b/erpnext/workspace_sidebar/taxes.json
@@ -17,7 +17,7 @@
    "indent": 0,
    "keep_closed": 0,
    "label": "Sales Template",
-   "link_to": "Sales Taxes and Charges",
+   "link_to": "Sales Taxes and Charges Template",
    "link_type": "DocType",
    "modified": "2025-11-18 12:17:49.242078",
    "modified_by": "Administrator",


### PR DESCRIPTION
Updated the `link_to` field for the "Sales Template" sidebar item from `"Sales Taxes and Charges"` to `"Sales Taxes and Charges Template"` in `erpnext/workspace_sidebar/taxes.json`, since **Sales Taxes and Charges** is a **child table**.


`no-docs`