### PR TITLE
fix: ignore reserved batches from total available batches

### DIFF
--- a/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py
+++ b/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py
@@ -2297,7 +2297,11 @@ def get_auto_batch_nos(kwargs):
 
 	stock_ledgers_batches = get_stock_ledgers_batches(kwargs)
 	pos_invoice_batches = get_reserved_batches_for_pos(kwargs)
-	sre_reserved_batches = get_reserved_batches_for_sre(kwargs)
+
+	sre_reserved_batches = frappe._dict()
+	if not kwargs.ignore_reserved_stock:
+		sre_reserved_batches = get_reserved_batches_for_sre(kwargs)
+
 	picked_batches = frappe._dict()
 	if kwargs.get("is_pick_list"):
 		picked_batches = get_picked_batches(kwargs)

--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -2313,6 +2313,7 @@ def validate_reserved_batch_nos(kwargs):
 					"posting_date": kwargs.posting_date,
 					"posting_time": kwargs.posting_time,
 					"ignore_voucher_nos": kwargs.ignore_voucher_nos,
+					"ignore_reserved_stock": True,
 				}
 			)
 		)


### PR DESCRIPTION
**Issue:** Unable to Issue/transfer the balance unreserved stock for the batch item with a partial stock reservation entry.

**Fix:** Ignore the reserved stock inclusion when fetching the total available batches.

**Before:**

https://github.com/user-attachments/assets/456ac254-6e9e-4ea7-8c06-39015baaedc0

**After:**

[SRE-Stock-Transfer-Fixed.webm](https://github.com/user-attachments/assets/65f01408-6082-4506-b4f9-0810f4e29f9f)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation for reserved stock with batch items. The system now correctly prevents material issues that conflict with existing stock reservations, ensuring reserved batches are properly accounted for during inventory operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->