### PR TITLE
fix(payment reconciliation): added a hint that posting date can be changed on exchange gain/loss reconcile dialog

### DIFF
--- a/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.js
+++ b/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.js
@@ -334,7 +334,9 @@ erpnext.accounts.PaymentReconciliationController = class PaymentReconciliationCo
 					},
 					{
 						fieldtype: "HTML",
-						options: "<b> New Journal Entry will be posted for the difference amount </b>",
+						options: __(
+							"New Journal Entry will be posted for the difference amount. The Posting Date can be modified."
+						).bold(),
 					},
 				],
 				primary_action: () => {


### PR DESCRIPTION
Added explanatory text to the Exchange Gain/Loss Reconcile dialog to inform users that the Posting Date field can be modified before submitting the reconciliation.
<img width="1152" height="409" alt="Screenshot 2025-11-20 at 1 00 54 PM" src="https://github.com/user-attachments/assets/bb7d7e37-b050-4d86-90ee-7ec121220b98" />

