### PR TITLE
fix: incorrect error thrown when updating rate of 0 qty PO

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -3934,7 +3934,7 @@ def update_child_qty_rate(parent_doctype, trans_items, parent_doctype_name, chil
 
 		prev_rate, new_rate = flt(child_item.get("rate")), flt(d.get("rate"))
 		rate_unchanged = prev_rate == new_rate
-		if not rate_unchanged and not child_item.get("qty") and is_allowed_zero_qty():
+		if not rate_unchanged and not child_item.get("qty") and not is_allowed_zero_qty():
 			frappe.throw(_("Rate of '{}' items cannot be changed").format(frappe.bold(_("Unit Price"))))
 
 		# Amount cannot be lesser than billed amount, except for negative amounts


### PR DESCRIPTION
fixes #49668

ref #49673 @ruthra-kumar @KerollesFathy 

<img width="608" height="141" alt="image" src="https://github.com/user-attachments/assets/ff5deda7-8a97-48f3-be57-fbda3b9fb284" />