### PR TITLE
fix: handle zero rate actual taxes in calculate_taxes_and_totals

### DIFF
--- a/erpnext/controllers/taxes_and_totals.py
+++ b/erpnext/controllers/taxes_and_totals.py
@@ -505,8 +505,9 @@ class calculate_taxes_and_totals:
 
 		for idx, d in enumerate(self.doc._item_wise_tax_details):
 			tax = d.get("tax")
-			if not tax:
+			if not tax or (tax.get("charge_type") == "Actual" and d.rate == 0):
 				continue
+
 			tax._total_tax_breakup += d.amount or 0
 			tax._last_row_idx = idx
 


### PR DESCRIPTION
Issue: Raises invalid error for Tax Rows with `Actual` (say charges).

do not validate taxes row with charge_type as "Actual".