### PR TITLE
fix: retail address on drop ship

### DIFF
--- a/erpnext/public/js/controllers/buying.js
+++ b/erpnext/public/js/controllers/buying.js
@@ -165,7 +165,6 @@ erpnext.buying = {
 			company() {
 				super.company();
 				if (!frappe.meta.has_field(this.frm.doc.doctype, "billing_address")) return;
-
 				frappe.call({
 					method: "erpnext.setup.doctype.company.company.get_billing_shipping_address",
 					args: {
@@ -175,11 +174,22 @@ erpnext.buying = {
 					},
 					callback: (r) => {
 						if (!r.message) return;
+						if (this.frm.__onload.is_drop_ship) {
+							!this.frm.doc.billing_address &&
+								this.frm.set_value("billing_address", r.message.primary_address || "");
 
-						this.frm.set_value("billing_address", r.message.primary_address || "");
+							if (
+								frappe.meta.has_field(this.frm.doc.doctype, "shipping_address") &&
+								!this.frm.doc.shipping_address
+							) {
+								this.frm.set_value("shipping_address", r.message.shipping_address || "");
+							}
+						} else {
+							this.frm.set_value("billing_address", r.message.primary_address || "");
 
-						if (frappe.meta.has_field(this.frm.doc.doctype, "shipping_address")) {
-							this.frm.set_value("shipping_address", r.message.shipping_address || "");
+							if (frappe.meta.has_field(this.frm.doc.doctype, "shipping_address")) {
+								this.frm.set_value("shipping_address", r.message.shipping_address || "");
+							}
 						}
 					},
 				});

--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -1603,6 +1603,10 @@ def make_purchase_order_for_default_supplier(source_name, selected_items=None, t
 			target.customer = ""
 			target.customer_name = ""
 
+		if source.company_address:
+			target.billing_address = source.company_address
+			target.billing_address_display = source.company_address_display
+
 		target.run_method("set_missing_values")
 		target.run_method("calculate_taxes_and_totals")
 
@@ -1698,6 +1702,9 @@ def make_purchase_order_for_default_supplier(source_name, selected_items=None, t
 		)
 
 		set_delivery_date(doc.items, source_name)
+		doc.get("__onload").is_drop_ship = (
+			1 if any(item.delivered_by_supplier == 1 for item in doc.items) else 0
+		)
 		doc.insert()
 		frappe.db.commit()
 		purchase_orders.append(doc)
@@ -1751,6 +1758,10 @@ def make_purchase_order(source_name, selected_items=None, target_doc=None):
 			target.customer_contact_email = source.contact_email
 		else:
 			target.customer = target.customer_name = target.shipping_address = None
+
+		if source.company_address:
+			target.billing_address = source.company_address
+			target.billing_address_display = source.company_address_display
 
 		target.run_method("set_missing_values")
 		if not target.taxes:
@@ -1835,10 +1846,9 @@ def make_purchase_order(source_name, selected_items=None, target_doc=None):
 		target_doc,
 		set_missing_values,
 	)
-
+	doc.get("__onload").is_drop_ship = 1 if is_drop_ship_order(doc) else 0
 	set_delivery_date(doc.items, source_name)
 	doc.set_onload("load_after_mapping", False)
-
 	return doc
 
 


### PR DESCRIPTION
Issue: When making a Purchase Order from a Sales Order using drop shipping, the shipping address and the company billing address are not getting carried.

Ref: [#53025](https://support.frappe.io/helpdesk/tickets/53025)

Backport needed: v15