### PR TITLE
fix(lead): made the create and action menu visible for lead doctype

### DIFF
--- a/erpnext/crm/doctype/lead/lead.js
+++ b/erpnext/crm/doctype/lead/lead.js
@@ -239,6 +239,7 @@ erpnext.LeadController = class LeadController extends frappe.ui.form.Controller 
 		crm_activities.refresh();
 	}
 };
-if (this.frm) {
-	extend_cscript(this.frm.cscript, new erpnext.LeadController({ frm: this.frm }));
+
+if (cur_frm) {
+	extend_cscript(cur_frm.cscript, new erpnext.LeadController({ frm: cur_frm }));
 }


### PR DESCRIPTION
Fixed the issue with Lead DocType where the Create and Action menus were not visible.

Closes: #50435