### PR TITLE
fix(payment gateway account): remove payment gateway field

### DIFF
--- a/erpnext/accounts/doctype/payment_gateway_account/payment_gateway_account.json
+++ b/erpnext/accounts/doctype/payment_gateway_account/payment_gateway_account.json
@@ -5,7 +5,6 @@
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
-  "payment_gateway",
   "payment_channel",
   "company",
   "is_default",
@@ -17,14 +16,6 @@
   "message_examples"
  ],
  "fields": [
-  {
-   "fieldname": "payment_gateway",
-   "fieldtype": "Link",
-   "in_list_view": 1,
-   "label": "Payment Gateway",
-   "options": "Payment Gateway",
-   "reqd": 1
-  },
   {
    "default": "0",
    "fieldname": "is_default",
@@ -86,7 +77,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-07-14 16:49:55.210352",
+ "modified": "2025-11-21 15:18:14.428224",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Payment Gateway Account",

--- a/erpnext/accounts/doctype/payment_gateway_account/payment_gateway_account.py
+++ b/erpnext/accounts/doctype/payment_gateway_account/payment_gateway_account.py
@@ -20,8 +20,7 @@ class PaymentGatewayAccount(Document):
 		is_default: DF.Check
 		message: DF.SmallText | None
 		payment_account: DF.Link
-		payment_channel: DF.Literal["", "Email", "Phone"]
-		payment_gateway: DF.Link
+		payment_channel: DF.Literal["", "Email", "Phone", "Other"]
 	# end: auto-generated types
 
 	def autoname(self):

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -449,3 +449,4 @@ erpnext.patches.v16_0.set_company_wise_warehouses
 erpnext.patches.v16_0.set_valuation_method_on_companies
 erpnext.patches.v15_0.migrate_old_item_wise_tax_detail_data_to_table
 erpnext.patches.v16_0.migrate_budget_records_to_new_structure
+erpnext.patches.v16_0.create_payment_gateway_account_custom_fields

--- a/erpnext/patches/v16_0/create_payment_gateway_account_custom_fields.py
+++ b/erpnext/patches/v16_0/create_payment_gateway_account_custom_fields.py
@@ -1,0 +1,22 @@
+import frappe
+from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
+
+
+def execute():
+	if frappe.db.exists("Installed Application", {"app_name": "payments"}):
+		create_custom_fields(
+			{
+				"Payment Gateway Account": [
+					{
+						"fieldname": "payment_gateway",
+						"fieldtype": "Link",
+						"in_list_view": 1,
+						"label": "Payment Gateway",
+						"options": "Payment Gateway",
+						"reqd": 1,
+					}
+				]
+			}
+		)
+
+		frappe.clear_cache(doctype="Payment Gateway Account")


### PR DESCRIPTION
Removed the `payment_gateway` field from the Payment Gateway Account DocType. Added a patch to add the `payment_gateway` custom field if the payments app is already installed.

Closes: #45220
Ref: frappe/payments#185