### PR TITLE
chore: upgrade Plaid version

### DIFF
--- a/erpnext/accounts/doctype/bank_account/bank_account.js
+++ b/erpnext/accounts/doctype/bank_account/bank_account.js
@@ -40,6 +40,15 @@ frappe.ui.form.on("Bank Account", {
 					}
 				);
 			});
+
+			frappe.call({
+				method: "get_bank_balance",
+				doc: frm.doc,
+				callback: function (r) {
+					frm.doc.account_balance = r.message;
+					frm.refresh_field("account_balance");
+				},
+			});
 		}
 	},
 

--- a/erpnext/accounts/doctype/bank_account/bank_account.json
+++ b/erpnext/accounts/doctype/bank_account/bank_account.json
@@ -9,9 +9,11 @@
  "field_order": [
   "account_name",
   "account",
+  "account_currency",
   "bank",
   "account_type",
   "account_subtype",
+  "account_balance",
   "column_break_7",
   "disabled",
   "is_default",
@@ -207,6 +209,21 @@
    "fieldname": "disabled",
    "fieldtype": "Check",
    "label": "Disabled"
+  },
+  {
+   "fetch_from": "account.account_currency",
+   "fieldname": "account_balance",
+   "fieldtype": "Currency",
+   "label": "Account Balance ",
+   "options": "account_currency",
+   "read_only": 1
+  },
+  {
+   "fieldname": "account_currency",
+   "fieldtype": "Link",
+   "label": "Company Account Currency",
+   "options": "Currency",
+   "read_only": 1
   }
  ],
  "grid_page_length": 50,
@@ -252,7 +269,7 @@
    "link_fieldname": "default_bank_account"
   }
  ],
- "modified": "2025-08-29 12:32:01.081687",
+ "modified": "2025-11-21 19:37:58.110513",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Bank Account",

--- a/erpnext/accounts/doctype/bank_account/bank_account.py
+++ b/erpnext/accounts/doctype/bank_account/bank_account.py
@@ -9,7 +9,9 @@ from frappe.contacts.address_and_contact import (
 	load_address_and_contact,
 )
 from frappe.model.document import Document
-from frappe.utils import comma_and, get_link_to_form
+from frappe.utils import comma_and, flt, get_link_to_form
+
+from erpnext.erpnext_integrations.doctype.plaid_settings.plaid_settings import get_account_details
 
 
 class BankAccount(Document):
@@ -22,6 +24,8 @@ class BankAccount(Document):
 		from frappe.types import DF
 
 		account: DF.Link | None
+		account_balance: DF.Currency
+		account_currency: DF.Link | None
 		account_name: DF.Data
 		account_subtype: DF.Link | None
 		account_type: DF.Link | None
@@ -86,6 +90,19 @@ class BankAccount(Document):
 				"is_default",
 				0,
 			)
+
+	@frappe.whitelist()
+	def get_bank_balance(self):
+		if self.bank:
+			plaid_access_token = frappe.get_value("Bank", self.bank, "plaid_access_token")
+			if plaid_access_token:
+				account_details = get_account_details(
+					account_id=self.integration_id, access_token=plaid_access_token
+				)
+				balance = (
+					account_details["balances"]["available"] or account_details["balances"]["current"] or 0
+				)
+				return flt(balance, self.precision("account_balance"))
 
 
 def get_party_bank_account(party_type, party):

--- a/erpnext/erpnext_integrations/doctype/plaid_settings/plaid_connector.py
+++ b/erpnext/erpnext_integrations/doctype/plaid_settings/plaid_connector.py
@@ -2,10 +2,16 @@
 # For license information, please see license.txt
 
 import frappe
-import plaid
-import requests
 from frappe import _
-from plaid.errors import APIError, InvalidRequestError, ItemError
+from frappe.utils import getdate
+from plaid.api import plaid_api
+from plaid.exceptions import ApiException
+
+PLAID_ENV_URLS = {
+	"sandbox": "https://sandbox.plaid.com",
+	"development": "https://development.plaid.com",
+	"production": "https://production.plaid.com",
+}
 
 
 class PlaidConnector:
@@ -14,76 +20,131 @@ class PlaidConnector:
 		self.settings = frappe.get_single("Plaid Settings")
 		self.products = ["transactions"]
 		self.client_name = frappe.local.site
-		self.client = plaid.Client(
-			client_id=self.settings.plaid_client_id,
-			secret=self.settings.get_password("plaid_secret"),
-			environment=self.settings.plaid_env,
-			api_version="2020-09-14",
+		self.client = self.get_client()
+
+	def get_client(self):
+		from plaid import ApiClient
+		from plaid.configuration import Configuration
+
+		config = Configuration(
+			host=PLAID_ENV_URLS.get(self.settings.plaid_env),
+			api_key={
+				"clientId": self.settings.plaid_client_id,
+				"secret": self.settings.get_password("plaid_secret"),
+			},
 		)
+		client = ApiClient(config)
+		return plaid_api.PlaidApi(client)
 
 	def get_access_token(self, public_token):
+		from plaid.model.item_public_token_exchange_request import ItemPublicTokenExchangeRequest
+
 		if public_token is None:
 			frappe.log_error("Plaid: Public token is missing")
-		response = self.client.Item.public_token.exchange(public_token)
-		access_token = response["access_token"]
-		return access_token
+
+		request = ItemPublicTokenExchangeRequest(public_token=public_token)
+
+		try:
+			response = self.client.item_public_token_exchange(request)
+			return response.access_token
+		except ApiException as e:
+			frappe.log_error("Plaid Token Exchange Error", e)
+			frappe.msgprint(_("Failed to exchange public token Check Error Log for more details"))
 
 	def get_token_request(self, update_mode=False):
+		from plaid.model.country_code import CountryCode
+		from plaid.model.link_token_create_request import LinkTokenCreateRequest
+		from plaid.model.link_token_create_request_user import LinkTokenCreateRequestUser
+		from plaid.model.products import Products
+
 		country_codes = (
-			["US", "CA", "FR", "IE", "NL", "ES", "GB"]
+			[
+				CountryCode("US"),
+				CountryCode("CA"),
+				CountryCode("FR"),
+				CountryCode("IE"),
+				CountryCode("NL"),
+				CountryCode("ES"),
+				CountryCode("GB"),
+			]
 			if self.settings.enable_european_access
-			else ["US", "CA"]
+			else [CountryCode("US"), CountryCode("CA")]
 		)
-		args = {
-			"client_name": self.client_name,
-			# only allow Plaid-supported languages and countries (LAST: Sep-19-2020)
-			"language": frappe.local.lang if frappe.local.lang in ["en", "fr", "es", "nl"] else "en",
-			"country_codes": country_codes,
-			"user": {"client_user_id": frappe.generate_hash(frappe.session.user, length=32)},
-		}
+
+		user = LinkTokenCreateRequestUser(client_user_id=frappe.generate_hash(frappe.session.user, length=32))
+		request = LinkTokenCreateRequest(
+			user=user,
+			client_name=self.client_name,
+			language=frappe.local.lang if frappe.local.lang in ["en", "fr", "es", "nl"] else "en",
+			country_codes=country_codes,
+			products=[Products("transactions")] if not update_mode else None,
+		)
 
 		if update_mode:
-			args["access_token"] = self.access_token
-		else:
-			args.update(
-				{
-					"client_id": self.settings.plaid_client_id,
-					"secret": self.settings.plaid_secret,
-					"products": self.products,
-				}
-			)
+			request.access_token = self.access_token
 
-		return args
+		return request
 
 	def get_link_token(self, update_mode=False):
 		token_request = self.get_token_request(update_mode)
 
 		try:
-			response = self.client.LinkToken.create(token_request)
-		except InvalidRequestError:
-			frappe.log_error("Plaid: Invalid request error")
-			frappe.msgprint(_("Please check your Plaid client ID and secret values"))
-		except APIError as e:
-			frappe.log_error("Plaid: Authentication error")
-			frappe.throw(_(str(e)), title=_("Authentication Failed"))
-		else:
-			return response["link_token"]
+			response = self.client.link_token_create(token_request)
+			return response.link_token
+		except ApiException as e:
+			frappe.log_error("Plaid API Exception Error", e)
+			frappe.msgprint(_("Plaid request Failed Check Error Log for more details."))
+		except Exception as e:
+			frappe.log_error("Plaid Link Token Error", e)
+			frappe.msgprint(_("Failed to generate Plaid Link Token Check Error Log for more details"))
 
 	def get_transactions(self, start_date, end_date, account_id=None):
-		kwargs = dict(access_token=self.access_token, start_date=start_date, end_date=end_date)
-		if account_id:
-			kwargs.update(dict(account_ids=[account_id]))
+		from plaid.model.transactions_get_request import TransactionsGetRequest
+		from plaid.model.transactions_get_request_options import TransactionsGetRequestOptions
+
+		len_trans = 0
+
+		def get_request_data(offset=None):
+			kwargs = TransactionsGetRequestOptions()
+			if account_id:
+				kwargs.account_ids = [account_id]
+			if offset:
+				kwargs.offset = offset
+
+			return TransactionsGetRequest(
+				access_token=self.access_token,
+				start_date=getdate(start_date),
+				end_date=getdate(end_date),
+				options=kwargs,
+			)
 
 		try:
-			response = self.client.Transactions.get(**kwargs)
-			transactions = response["transactions"]
-			while len(transactions) < response["total_transactions"]:
-				response = self.client.Transactions.get(
-					self.access_token, start_date=start_date, end_date=end_date, offset=len(transactions)
-				)
-				transactions.extend(response["transactions"])
+			request = get_request_data()
+			response = self.client.transactions_get(request)
+			transactions = response.transactions
+			len_trans += len(transactions)
+			while len(transactions) < response.total_transactions:
+				request = get_request_data(offset=len(transactions))
+				next_response = self.client.transactions_get(request)
+				transactions.extend(next_response.transactions)
 			return transactions
-		except ItemError as e:
-			raise e
-		except Exception:
-			frappe.log_error("Plaid: Transactions sync error")
+		except ApiException as e:
+			frappe.log_error("Plaid Transactions Error", e)
+
+	def get_bank_details(self, access_token, account_id=None):
+		from plaid.model.accounts_balance_get_request import AccountsBalanceGetRequest
+
+		request = AccountsBalanceGetRequest(access_token=access_token)
+		try:
+			result = self.client.accounts_balance_get(request)
+
+			accounts_map = frappe._dict()
+
+			for acc in result.get("accounts", []):
+				if account_id and acc["account_id"] == account_id:
+					return acc
+				accounts_map[acc["account_id"]] = acc
+			return accounts_map
+		except Exception as e:
+			frappe.log_error("Plaid Account Balance Error", e)
+			frappe.msgprint(_("Failed to fetch account balace from plaid Check Error Log for more details"))

--- a/erpnext/erpnext_integrations/doctype/plaid_settings/plaid_settings.py
+++ b/erpnext/erpnext_integrations/doctype/plaid_settings/plaid_settings.py
@@ -7,8 +7,7 @@ import frappe
 from frappe import _
 from frappe.desk.doctype.tag.tag import add_tag
 from frappe.model.document import Document
-from frappe.utils import add_months, formatdate, getdate, sbool, today
-from plaid.errors import ItemError
+from frappe.utils import add_months, getdate, sbool, today
 
 from erpnext.erpnext_integrations.doctype.plaid_settings.plaid_connector import PlaidConnector
 
@@ -79,12 +78,29 @@ def add_institution(token, response):
 
 
 @frappe.whitelist()
+def get_account_details(account_id=None, token=None, access_token=None):
+	plaid = PlaidConnector()
+
+	if access_token:
+		final_token = access_token
+	elif token:
+		final_token = plaid.get_access_token(token)
+	else:
+		frappe.throw(_("Missing access_token or public_token"))
+
+	return plaid.get_bank_details(access_token=final_token, account_id=account_id)
+
+
+@frappe.whitelist()
 def add_bank_accounts(response, bank, company):
 	try:
 		response = json.loads(response)
 	except TypeError:
 		pass
-
+	access_token = frappe.db.get_value(
+		"Bank", {"bank_name": response["institution"]["name"]}, "plaid_access_token"
+	)
+	banck_details = get_account_details(access_token=access_token)
 	if isinstance(bank, str):
 		bank = json.loads(bank)
 	result = []
@@ -100,6 +116,7 @@ def add_bank_accounts(response, bank, company):
 		)
 
 	for account in response["accounts"]:
+		banck_detail = banck_details.get(account["id"])
 		acc_type = frappe.db.get_value("Bank Account Type", account["type"])
 		if not acc_type:
 			add_account_type(account["type"])
@@ -113,34 +130,43 @@ def add_bank_accounts(response, bank, company):
 
 		if not existing_bank_account:
 			try:
-				gl_account = frappe.get_doc(
-					{
-						"doctype": "Account",
-						"account_name": account["name"] + " - " + response["institution"]["name"],
-						"parent_account": parent_gl_account[0].name,
-						"account_type": "Bank",
-						"company": company,
-					}
-				)
-				gl_account.insert(ignore_if_duplicate=True)
+				Currency = banck_detail["balances"]["iso_currency_code"]
+				if frappe.db.exists("Currency", Currency):
+					if frappe.db.get_value("Currency", Currency, "enabled"):
+						gl_account = frappe.get_doc(
+							{
+								"doctype": "Account",
+								"account_name": account["name"] + " - " + response["institution"]["name"],
+								"parent_account": parent_gl_account[0].name,
+								"account_type": "Bank",
+								"company": company,
+								"account_currency": Currency,
+							}
+						)
+						gl_account.insert(ignore_if_duplicate=True)
 
-				new_account = frappe.get_doc(
-					{
-						"doctype": "Bank Account",
-						"bank": bank["bank_name"],
-						"account": gl_account.name,
-						"account_name": account["name"],
-						"account_type": account.get("type", ""),
-						"account_subtype": account.get("subtype", ""),
-						"mask": account.get("mask", ""),
-						"integration_id": account["id"],
-						"is_company_account": 1,
-						"company": company,
-					}
-				)
-				new_account.insert()
+						new_account = frappe.get_doc(
+							{
+								"doctype": "Bank Account",
+								"bank": bank["bank_name"],
+								"account": gl_account.name,
+								"account_currency": Currency,
+								"account_name": account["name"],
+								"account_type": account.get("type", ""),
+								"account_subtype": account.get("subtype", ""),
+								"mask": account.get("mask", ""),
+								"integration_id": account["id"],
+								"is_company_account": 1,
+								"company": company,
+							}
+						)
+						new_account.insert()
 
-				result.append(new_account.name)
+						result.append(new_account.name)
+					else:
+						frappe.throw(_("Currency is Disabled"))
+				else:
+					frappe.throw(_("currency not present"))
 			except frappe.UniqueValidationError:
 				frappe.msgprint(
 					_("Bank account {0} already exists and could not be created again").format(
@@ -184,30 +210,42 @@ def add_bank_accounts(response, bank, company):
 def add_account_type(account_type):
 	try:
 		frappe.get_doc({"doctype": "Bank Account Type", "account_type": account_type}).insert()
-	except Exception:
-		frappe.throw(frappe.get_traceback())
+	except Exception as e:
+		frappe.log_error("Plaid Account Type Error", e)
+		frappe.msgprint(
+			_("An error occurred while adding the Plaid account type Check Error Log For mor details  ")
+		)
 
 
 def add_account_subtype(account_subtype):
 	try:
 		frappe.get_doc({"doctype": "Bank Account Subtype", "account_subtype": account_subtype}).insert()
-	except Exception:
-		frappe.throw(frappe.get_traceback())
+	except Exception as e:
+		frappe.log_error("Plaid Account Subtype Error", e)
+		frappe.msgprint(
+			_("An error occurred while adding the Plaid account subtype Check Error Log For mor details  ")
+		)
 
 
 def sync_transactions(bank, bank_account):
 	"""Sync transactions based on the last integration date as the start date, after sync is completed
 	add the transaction date of the oldest transaction as the last integration date."""
 	last_transaction_date = frappe.db.get_value("Bank Account", bank_account, "last_integration_date")
-	if last_transaction_date:
-		start_date = formatdate(last_transaction_date, "YYYY-MM-dd")
+	plaid_env = frappe.db.get_single_value("Plaid Settings", "plaid_env")
+
+	if plaid_env == "sandbox":
+		start_date = getdate(add_months(today(), -1))
 	else:
-		start_date = formatdate(add_months(today(), -12), "YYYY-MM-dd")
-	end_date = formatdate(today(), "YYYY-MM-dd")
+		last_year_date = getdate(add_months(today(), -12))
+		if last_transaction_date and getdate(last_transaction_date) <= last_year_date:
+			start_date = getdate(last_transaction_date)
+		else:
+			start_date = last_year_date
+	end_date = getdate(today())
 
 	try:
 		transactions = get_transactions(
-			bank=bank, bank_account=bank_account, start_date=start_date, end_date=end_date
+			bank=bank, start_date=start_date, end_date=end_date, bank_account=bank_account
 		)
 
 		result = []
@@ -227,7 +265,7 @@ def sync_transactions(bank, bank_account):
 		frappe.log_error(frappe.get_traceback(), _("Plaid transactions sync error"))
 
 
-def get_transactions(bank, bank_account=None, start_date=None, end_date=None):
+def get_transactions(bank, start_date=None, end_date=None, bank_account=None):
 	access_token = None
 
 	if bank_account:
@@ -243,13 +281,7 @@ def get_transactions(bank, bank_account=None, start_date=None, end_date=None):
 	plaid = PlaidConnector(access_token)
 
 	transactions = []
-	try:
-		transactions = plaid.get_transactions(start_date=start_date, end_date=end_date, account_id=account_id)
-	except ItemError as e:
-		if e.code == "ITEM_LOGIN_REQUIRED":
-			msg = _("There was an error syncing transactions.") + " "
-			msg += _("Please refresh or reset the Plaid linking of the Bank {}.").format(bank) + " "
-			frappe.log_error(message=msg, title=_("Plaid Link Refresh Required"))
+	transactions = plaid.get_transactions(start_date=start_date, end_date=end_date, account_id=account_id)
 
 	return transactions
 
@@ -282,7 +314,7 @@ def new_bank_transaction(transaction):
 			new_transaction = frappe.get_doc(
 				{
 					"doctype": "Bank Transaction",
-					"date": getdate(transaction["date"]),
+					"date": transaction["date"],
 					"bank_account": bank_account,
 					"deposit": deposit,
 					"withdrawal": withdrawal,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
 
     # integration dependencies
     "googlemaps~=4.10.0",
-    "plaid-python~=7.2.1",
+    "plaid-python==37.1.0",
     "python-youtube~=0.9.7",
 
     # Not used directly - required by PyQRCode for PNG generation


### PR DESCRIPTION
Plaid SDK version upgrade from 7.2.1 to 37.1.0

Fixes

- When creating a Company Account for a Plaid linked Bank Account, the system previously created the account using the company's default currency. This has been fixed to ensure the account is created using the currency returned by the Plaid Bank Account (`iso_currency_code`).
- Fixed transaction date handling to ensure correct date parsing and synchronization.

Feature


- Introduced the ability to display Plaid bank account balances in the Bank Account.
