### PR TITLE
feat: Add Party GL Balance in Purchase & Sales Documents When Creating

### DIFF
--- a/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
+++ b/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
@@ -40,6 +40,8 @@
   "show_taxes_as_table_in_print",
   "column_break_12",
   "show_payment_schedule_in_print",
+  "balance_view_settings_section",
+  "show_gl_balance_in_document",
   "item_price_settings_section",
   "maintain_same_internal_transaction_rate",
   "fetch_valuation_rate_for_internal_transaction",
@@ -99,7 +101,8 @@
   "payment_request_settings",
   "create_pr_in_draft_status",
   "budget_settings",
-  "use_legacy_budget_controller"
+  "use_legacy_budget_controller",
+  "column_break_xrnd"
  ],
  "fields": [
   {
@@ -658,6 +661,17 @@
    "fieldname": "use_legacy_controller_for_pcv",
    "fieldtype": "Check",
    "label": "Use Legacy Controller For Period Closing Voucher"
+  },
+  {
+   "default": "0",
+   "fieldname": "show_gl_balance_in_document",
+   "fieldtype": "Check",
+   "label": "Show GL Balance in Document"
+  },
+  {
+   "fieldname": "balance_view_settings_section",
+   "fieldtype": "Section Break",
+   "label": "Balance View Settings"
   }
  ],
  "grid_page_length": 50,
@@ -666,7 +680,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-10-20 14:06:08.870427",
+ "modified": "2025-11-22 11:42:23.968318",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Accounts Settings",

--- a/erpnext/accounts/doctype/accounts_settings/accounts_settings.py
+++ b/erpnext/accounts/doctype/accounts_settings/accounts_settings.py
@@ -67,6 +67,7 @@ class AccountsSettings(Document):
 		role_to_override_stop_action: DF.Link | None
 		round_row_wise_tax: DF.Check
 		show_balance_in_coa: DF.Check
+		show_gl_balance_in_document: DF.Check
 		show_inclusive_tax_in_print: DF.Check
 		show_payment_schedule_in_print: DF.Check
 		show_taxes_as_table_in_print: DF.Check

--- a/erpnext/public/js/controllers/buying.js
+++ b/erpnext/public/js/controllers/buying.js
@@ -138,6 +138,8 @@ erpnext.buying = {
 					this.set_from_product_bundle();
 				}
 
+				erpnext.utils.get_party_gl_balance(this.frm);
+
 				this.toggle_subcontracting_fields();
 				super.refresh();
 			}
@@ -160,6 +162,7 @@ erpnext.buying = {
 				erpnext.utils.get_party_details(this.frm, null, null, function () {
 					me.apply_price_list();
 				});
+				erpnext.utils.get_party_gl_balance(this.frm);
 			}
 
 			company() {

--- a/erpnext/public/js/utils/party.js
+++ b/erpnext/public/js/utils/party.js
@@ -124,6 +124,64 @@ erpnext.utils.get_party_details = function (frm, method, args, callback) {
 	});
 };
 
+erpnext.utils.get_party_gl_balance = function (frm) {
+	frappe.db.get_single_value("Accounts Settings", "show_gl_balance_in_document").then((value) => {
+		if (!value) {
+			return
+		}
+	});
+
+	let args = {};
+
+	if (in_list(SALES_DOCTYPES, frm.doc.doctype)) {
+			args = {
+				party: frm.doc.customer || frm.doc.party_name,
+				party_type: "Customer",
+			};
+		}
+
+		if (in_list(PURCHASE_DOCTYPES, frm.doc.doctype)) {
+			args = {
+				party: frm.doc.supplier,
+				party_type: "Supplier",
+			};
+		}
+
+	party_field = args.doctype == "Quotation" ? "party_name" : args.party_type == "Customer" ? "customer" : "supplier"
+
+	if(args.party && frm.doc.docstatus == 0) {
+		frappe.call({
+			method: "erpnext.accounts.utils.get_balance_on",
+			args: {
+				company: frm.doc.company,
+				party_type: args.party_type,
+				party: args.party,
+			},
+			callback: function(r) {
+				if (r.message) {
+					let balance = r.message;
+
+					if(balance == 0) {
+						frm.set_df_property(party_field, "description", "");
+						return
+					}
+					let color = balance <= 0 ? "green" : "red";
+					let html = `<b>Current GL Balance:</b>
+						<span style="color:${color}; font-weight:bold;">
+							${format_currency(balance, frm.doc.currency || "INR")}
+						</span>`;
+
+					frm.set_df_property(party_field, "description", html);
+				} else {
+					frm.set_df_property(party_field, "description", "");
+				}
+			}
+		});
+	} else {
+		frm.set_df_property(party_field, "description", "");
+	}
+}
+
 erpnext.utils.add_item = function (frm) {
 	if (frm.is_new()) {
 		var prev_route = frappe.get_prev_route();

--- a/erpnext/public/js/utils/sales_common.js
+++ b/erpnext/public/js/utils/sales_common.js
@@ -112,6 +112,8 @@ erpnext.sales_common = {
 					this.frm.doc.customer_name && this.frm.doc.customer_name !== this.frm.doc.customer
 				);
 
+				erpnext.utils.get_party_gl_balance(this.frm);
+
 				this.toggle_editable_price_list_rate();
 				this.change_warehouse_labels_for_return();
 			}
@@ -170,6 +172,7 @@ erpnext.sales_common = {
 				erpnext.utils.get_party_details(this.frm, null, null, function () {
 					me.apply_price_list();
 				});
+				erpnext.utils.get_party_gl_balance(this.frm);
 			}
 
 			customer_address() {


### PR DESCRIPTION
This PR introduces an optional feature to automatically display the
current Customer/Supplier ledger balance (Receivable/Payable) directly
inside transaction forms such as Sales Invoice, Sales Order, Delivery Note,
Purchase Invoice, Purchase Order, and Purchase Receipt.

### Why this is needed
Users currently need to manually navigate to Customer/Supplier Ledger
or AR/AP reports to verify outstanding balances while creating
transactions. This breaks workflow efficiency and increases the risk
of incorrect entries.

### What this PR adds

1. New option in **Accounts Settings**:
   - "Show Party Ledger Balance in Transactions"
   - When enabled, ERPNext will:
     • Fetch current balance using existing `get_balance_on`
     • Display it under Customer/Supplier field

2. Applies to the following doctypes:
   • Sales Invoice  
   • Sales Order  
   • Delivery Note  
   • Purchase Invoice  
   • Purchase Order  
   • Purchase Receipt  

3. Fully client-side + server-side integration ensuring:
   - Fast fetch
   - Minimal DB load
   - No UI blocking
   - Configurable behavior via Accounts Settings

### How it works
A small JS controller enhancement listens to Customer/Supplier selection.
It triggers a server-side method that returns current ledger balance
based on company and party. The result is rendered below the
field with conditional color formatting with real time balance.

### Screenshots
<img width="1178" height="749" alt="Screenshot 2025-11-22 at 12 18 42" src="https://github.com/user-attachments/assets/9d9bd60b-f0cd-4c02-8de0-c75fe4674a35" />

<img width="1157" height="790" alt="Screenshot 2025-11-22 at 12 17 52" src="https://github.com/user-attachments/assets/594f77a5-33a0-4eb4-bb9a-474816760717" />
