### PR TITLE
fix: unknown column error

### DIFF
--- a/erpnext/accounts/doctype/pricing_rule/utils.py
+++ b/erpnext/accounts/doctype/pricing_rule/utils.py
@@ -244,7 +244,7 @@ def get_other_conditions(conditions, values, args):
 			conditions += " and " + group_condition
 
 	date = args.get("transaction_date") or frappe.get_value(
-		args.get("doctype"), args.get("name"), "posting_date"
+		args.get("doctype"), args.get("name"), "posting_date", ignore=True
 	)
 	if date:
 		conditions += """ and %(transaction_date)s between ifnull(`tabPricing Rule`.valid_from, '2000-01-01')


### PR DESCRIPTION
Some documents do not have posting date (for example: BOM) causing unknown column error being thrown

related to #50667