### PR TITLE
fix: incorrect query filter when selecting primary customer adr

### DIFF
--- a/erpnext/buying/doctype/supplier/supplier.js
+++ b/erpnext/buying/doctype/supplier/supplier.js
@@ -41,18 +41,20 @@ frappe.ui.form.on("Supplier", {
 
 		frm.set_query("supplier_primary_contact", function (doc) {
 			return {
-				query: "erpnext.buying.doctype.supplier.supplier.get_supplier_primary_contact",
+				query: "erpnext.buying.doctype.supplier.supplier.get_supplier_primary",
 				filters: {
 					supplier: doc.name,
+					type: "Contact",
 				},
 			};
 		});
 
 		frm.set_query("supplier_primary_address", function (doc) {
 			return {
-				query: "erpnext.buying.doctype.supplier.supplier.get_supplier_primary_address",
+				query: "erpnext.buying.doctype.supplier.supplier.get_supplier_primary",
 				filters: {
 					supplier: doc.name,
+					type: "Address",
 				},
 			};
 		});

--- a/erpnext/buying/doctype/supplier/supplier.js
+++ b/erpnext/buying/doctype/supplier/supplier.js
@@ -50,9 +50,9 @@ frappe.ui.form.on("Supplier", {
 
 		frm.set_query("supplier_primary_address", function (doc) {
 			return {
+				query: "erpnext.buying.doctype.supplier.supplier.get_supplier_primary_address",
 				filters: {
-					link_doctype: "Supplier",
-					link_name: doc.name,
+					supplier: doc.name,
 				},
 			};
 		});

--- a/erpnext/buying/doctype/supplier/supplier.py
+++ b/erpnext/buying/doctype/supplier/supplier.py
@@ -235,3 +235,23 @@ def get_supplier_primary_contact(doctype, txt, searchfield, start, page_len, fil
 			& (contact.name.like(f"%{txt}%"))
 		)
 	).run(as_dict=False)
+
+
+@frappe.whitelist()
+@frappe.validate_and_sanitize_search_inputs
+def get_supplier_primary_address(doctype, txt, searchfield, start, page_len, filters):
+	supplier = filters.get("supplier")
+	address = frappe.qb.DocType("Address")
+	dynamic_link = frappe.qb.DocType("Dynamic Link")
+
+	return (
+		frappe.qb.from_(address)
+		.join(dynamic_link)
+		.on(address.name == dynamic_link.parent)
+		.select(address.name, address.email_id)
+		.where(
+			(dynamic_link.link_name == supplier)
+			& (dynamic_link.link_doctype == "Supplier")
+			& (address.name.like(f"%{txt}%"))
+		)
+	).run(as_dict=False)

--- a/erpnext/buying/doctype/supplier/supplier.py
+++ b/erpnext/buying/doctype/supplier/supplier.py
@@ -219,39 +219,25 @@ class Supplier(TransactionBase):
 
 @frappe.whitelist()
 @frappe.validate_and_sanitize_search_inputs
-def get_supplier_primary_contact(doctype, txt, searchfield, start, page_len, filters):
+def get_supplier_primary(doctype, txt, searchfield, start, page_len, filters):
 	supplier = filters.get("supplier")
-	contact = frappe.qb.DocType("Contact")
+	type = filters.get("type")
+	type_doctype = frappe.qb.DocType(type)
 	dynamic_link = frappe.qb.DocType("Dynamic Link")
 
-	return (
-		frappe.qb.from_(contact)
+	query = (
+		frappe.qb.from_(type_doctype)
 		.join(dynamic_link)
-		.on(contact.name == dynamic_link.parent)
-		.select(contact.name, contact.email_id)
+		.on(type_doctype.name == dynamic_link.parent)
+		.select(type_doctype.name)
 		.where(
 			(dynamic_link.link_name == supplier)
 			& (dynamic_link.link_doctype == "Supplier")
-			& (contact.name.like(f"%{txt}%"))
+			& (type_doctype.name.like(f"%{txt}%"))
 		)
-	).run(as_dict=False)
+	)
 
+	if type == "Contact":
+		query = query.select(type_doctype.email_id)
 
-@frappe.whitelist()
-@frappe.validate_and_sanitize_search_inputs
-def get_supplier_primary_address(doctype, txt, searchfield, start, page_len, filters):
-	supplier = filters.get("supplier")
-	address = frappe.qb.DocType("Address")
-	dynamic_link = frappe.qb.DocType("Dynamic Link")
-
-	return (
-		frappe.qb.from_(address)
-		.join(dynamic_link)
-		.on(address.name == dynamic_link.parent)
-		.select(address.name)
-		.where(
-			(dynamic_link.link_name == supplier)
-			& (dynamic_link.link_doctype == "Supplier")
-			& (address.name.like(f"%{txt}%"))
-		)
-	).run(as_dict=False)
+	return query.run()

--- a/erpnext/buying/doctype/supplier/supplier.py
+++ b/erpnext/buying/doctype/supplier/supplier.py
@@ -248,7 +248,7 @@ def get_supplier_primary_address(doctype, txt, searchfield, start, page_len, fil
 		frappe.qb.from_(address)
 		.join(dynamic_link)
 		.on(address.name == dynamic_link.parent)
-		.select(address.name, address.email_id)
+		.select(address.name)
 		.where(
 			(dynamic_link.link_name == supplier)
 			& (dynamic_link.link_doctype == "Supplier")

--- a/erpnext/selling/doctype/customer/customer.js
+++ b/erpnext/selling/doctype/customer/customer.js
@@ -80,11 +80,12 @@ frappe.ui.form.on("Customer", {
 				},
 			};
 		});
+
 		frm.set_query("customer_primary_address", function (doc) {
 			return {
+				query: "erpnext.selling.doctype.customer.customer.get_customer_primary_address",
 				filters: {
-					link_doctype: "Customer",
-					link_name: doc.name,
+					customer: doc.name,
 				},
 			};
 		});

--- a/erpnext/selling/doctype/customer/customer.js
+++ b/erpnext/selling/doctype/customer/customer.js
@@ -74,18 +74,20 @@ frappe.ui.form.on("Customer", {
 
 		frm.set_query("customer_primary_contact", function (doc) {
 			return {
-				query: "erpnext.selling.doctype.customer.customer.get_customer_primary_contact",
+				query: "erpnext.selling.doctype.customer.customer.get_customer_primary",
 				filters: {
 					customer: doc.name,
+					type: "Contact",
 				},
 			};
 		});
 
 		frm.set_query("customer_primary_address", function (doc) {
 			return {
-				query: "erpnext.selling.doctype.customer.customer.get_customer_primary_address",
+				query: "erpnext.selling.doctype.customer.customer.get_customer_primary",
 				filters: {
 					customer: doc.name,
+					type: "Address",
 				},
 			};
 		});

--- a/erpnext/selling/doctype/customer/customer.json
+++ b/erpnext/selling/doctype/customer/customer.json
@@ -618,7 +618,7 @@
    "link_fieldname": "party"
   }
  ],
- "modified": "2025-04-27 12:01:29.549008",
+ "modified": "2025-11-25 09:35:56.772949",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Customer",

--- a/erpnext/selling/doctype/customer/customer.py
+++ b/erpnext/selling/doctype/customer/customer.py
@@ -815,40 +815,28 @@ def make_address(args, is_primary_address=1, is_shipping_address=1):
 
 @frappe.whitelist()
 @frappe.validate_and_sanitize_search_inputs
-def get_customer_primary_contact(doctype, txt, searchfield, start, page_len, filters):
+def get_customer_primary(doctype, txt, searchfield, start, page_len, filters):
 	customer = filters.get("customer")
-
-	con = qb.DocType("Contact")
+	type = filters.get("type")
+	type_doctype = qb.DocType(type)
 	dlink = qb.DocType("Dynamic Link")
 
-	return (
-		qb.from_(con)
+	query = (
+		qb.from_(type_doctype)
 		.join(dlink)
-		.on(con.name == dlink.parent)
-		.select(con.name, con.email_id)
-		.where((dlink.link_name == customer) & (con.name.like(f"%{txt}%")))
-		.run()
-	)
-
-
-@frappe.whitelist()
-@frappe.validate_and_sanitize_search_inputs
-def get_customer_primary_address(doctype, txt, searchfield, start, page_len, filters):
-	customer = filters.get("customer")
-
-	addr = qb.DocType("Address")
-	dlink = qb.DocType("Dynamic Link")
-
-	return (
-		qb.from_(addr)
-		.join(dlink)
-		.on(addr.name == dlink.parent)
-		.select(addr.name)
+		.on(type_doctype.name == dlink.parent)
+		.select(type_doctype.name)
 		.where(
-			(dlink.link_name == customer) & (addr.name.like(f"%{txt}%")) & (dlink.link_doctype == "Customer")
+			(dlink.link_name == customer)
+			& (type_doctype.name.like(f"%{txt}%"))
+			& (dlink.link_doctype == "Customer")
 		)
-		.run()
 	)
+
+	if type == "Contact":
+		query = query.select(type_doctype.email_id)
+
+	return query.run()
 
 
 def parse_full_name(full_name: str) -> tuple[str, str | None, str | None]:

--- a/erpnext/selling/doctype/customer/customer.py
+++ b/erpnext/selling/doctype/customer/customer.py
@@ -831,6 +831,26 @@ def get_customer_primary_contact(doctype, txt, searchfield, start, page_len, fil
 	)
 
 
+@frappe.whitelist()
+@frappe.validate_and_sanitize_search_inputs
+def get_customer_primary_address(doctype, txt, searchfield, start, page_len, filters):
+	customer = filters.get("customer")
+
+	addr = qb.DocType("Address")
+	dlink = qb.DocType("Dynamic Link")
+
+	return (
+		qb.from_(addr)
+		.join(dlink)
+		.on(addr.name == dlink.parent)
+		.select(addr.name)
+		.where(
+			(dlink.link_name == customer) & (addr.name.like(f"%{txt}%")) & (dlink.link_doctype == "Customer")
+		)
+		.run(debug=1)
+	)
+
+
 def parse_full_name(full_name: str) -> tuple[str, str | None, str | None]:
 	"""Parse full name into first name, middle name and last name"""
 	names = full_name.split()

--- a/erpnext/selling/doctype/customer/customer.py
+++ b/erpnext/selling/doctype/customer/customer.py
@@ -847,7 +847,7 @@ def get_customer_primary_address(doctype, txt, searchfield, start, page_len, fil
 		.where(
 			(dlink.link_name == customer) & (addr.name.like(f"%{txt}%")) & (dlink.link_doctype == "Customer")
 		)
-		.run(debug=1)
+		.run()
 	)
 
 


### PR DESCRIPTION
When trying to select the customer primary address, a no permission error was being thrown.