### PR TITLE
refactor: creation of purchase order from sales order

### DIFF
--- a/erpnext/public/js/controllers/buying.js
+++ b/erpnext/public/js/controllers/buying.js
@@ -176,9 +176,14 @@ erpnext.buying = {
 					callback: (r) => {
 						if (!r.message) return;
 
-						this.frm.set_value("billing_address", r.message.primary_address || "");
+						if (!this.frm.doc.billing_address) {
+							this.frm.set_value("billing_address", r.message.primary_address || "");
+						}
 
-						if (frappe.meta.has_field(this.frm.doc.doctype, "shipping_address")) {
+						if (
+							frappe.meta.has_field(this.frm.doc.doctype, "shipping_address") &&
+							!this.frm.doc.shipping_address
+						) {
 							this.frm.set_value("shipping_address", r.message.shipping_address || "");
 						}
 					},

--- a/erpnext/public/js/controllers/buying.js
+++ b/erpnext/public/js/controllers/buying.js
@@ -176,14 +176,9 @@ erpnext.buying = {
 					callback: (r) => {
 						if (!r.message) return;
 
-						if (!this.frm.doc.billing_address) {
-							this.frm.set_value("billing_address", r.message.primary_address || "");
-						}
+						this.frm.set_value("billing_address", r.message.primary_address || "");
 
-						if (
-							frappe.meta.has_field(this.frm.doc.doctype, "shipping_address") &&
-							!this.frm.doc.shipping_address
-						) {
+						if (frappe.meta.has_field(this.frm.doc.doctype, "shipping_address")) {
 							this.frm.set_value("shipping_address", r.message.shipping_address || "");
 						}
 					},

--- a/erpnext/selling/doctype/sales_order/sales_order.js
+++ b/erpnext/selling/doctype/sales_order/sales_order.js
@@ -1585,12 +1585,6 @@ erpnext.selling.SalesOrderController = class SalesOrderController extends erpnex
 			size: "large",
 			fields: [
 				{
-					fieldtype: "Check",
-					label: __("Against Default Supplier"),
-					fieldname: "against_default_supplier",
-					default: 0,
-				},
-				{
 					fieldname: "items_for_po",
 					fieldtype: "Table",
 					label: __("Select Items"),
@@ -1625,10 +1619,11 @@ erpnext.selling.SalesOrderController = class SalesOrderController extends erpnex
 							in_list_view: 1,
 						},
 						{
-							fieldtype: "Data",
+							fieldtype: "Link",
 							fieldname: "supplier",
 							label: __("Supplier"),
-							read_only: 1,
+							reqd: 1,
+							options: "Supplier",
 							in_list_view: 1,
 						},
 					],
@@ -1647,13 +1642,17 @@ erpnext.selling.SalesOrderController = class SalesOrderController extends erpnex
 					});
 				}
 
-				dialog.hide();
+				if (selected_items.some((item) => !item.supplier)) {
+					frappe.throw({
+						message: "Supplier is required for all selected Items",
+						title: __("Supplier Required"),
+						indicator: "blue",
+					});
+				}
 
-				var method = args.against_default_supplier
-					? "make_purchase_order_for_default_supplier"
-					: "make_purchase_order";
+				dialog.hide();
 				return frappe.call({
-					method: "erpnext.selling.doctype.sales_order.sales_order." + method,
+					method: "erpnext.selling.doctype.sales_order.sales_order.make_purchase_order",
 					freeze_message: __("Creating Purchase Order ..."),
 					args: {
 						source_name: me.frm.doc.name,
@@ -1662,9 +1661,9 @@ erpnext.selling.SalesOrderController = class SalesOrderController extends erpnex
 					freeze: true,
 					callback: function (r) {
 						if (!r.exc) {
-							if (!args.against_default_supplier) {
-								frappe.model.sync(r.message);
-								frappe.set_route("Form", r.message.doctype, r.message.name);
+							if (r.message.length == 1) {
+								frappe.model.sync(r.message[0]);
+								frappe.set_route("Form", r.message[0].doctype, r.message[0].name);
 							} else {
 								frappe.route_options = {
 									sales_order: me.frm.doc.name,
@@ -1677,37 +1676,25 @@ erpnext.selling.SalesOrderController = class SalesOrderController extends erpnex
 			},
 		});
 
-		dialog.fields_dict["against_default_supplier"].df.onchange = () => set_po_items_data(dialog);
-
 		function set_po_items_data(dialog) {
-			var against_default_supplier = dialog.get_value("against_default_supplier");
-			var items_for_po = dialog.get_value("items_for_po");
+			let po_items = [];
+			me.frm.doc.items.forEach((d) => {
+				let ordered_qty = me.get_ordered_qty(d, me.frm.doc);
+				let pending_qty = (flt(d.stock_qty) - ordered_qty) / flt(d.conversion_factor);
+				if (pending_qty > 0) {
+					po_items.push({
+						name: d.name,
+						item_name: d.item_name,
+						item_code: d.item_code,
+						pending_qty: pending_qty,
+						uom: d.uom,
+						supplier: d.supplier,
+					});
+				}
+			});
 
-			if (against_default_supplier) {
-				let items_with_supplier = items_for_po.filter((item) => item.supplier);
-
-				dialog.fields_dict["items_for_po"].df.data = items_with_supplier;
-				dialog.get_field("items_for_po").refresh();
-			} else {
-				let po_items = [];
-				me.frm.doc.items.forEach((d) => {
-					let ordered_qty = me.get_ordered_qty(d, me.frm.doc);
-					let pending_qty = (flt(d.stock_qty) - ordered_qty) / flt(d.conversion_factor);
-					if (pending_qty > 0) {
-						po_items.push({
-							name: d.name,
-							item_name: d.item_name,
-							item_code: d.item_code,
-							pending_qty: pending_qty,
-							uom: d.uom,
-							supplier: d.supplier,
-						});
-					}
-				});
-
-				dialog.fields_dict["items_for_po"].df.data = po_items;
-				dialog.get_field("items_for_po").refresh();
-			}
+			dialog.fields_dict["items_for_po"].df.data = po_items;
+			dialog.get_field("items_for_po").refresh();
 		}
 
 		set_po_items_data(dialog);

--- a/erpnext/selling/doctype/sales_order/sales_order.js
+++ b/erpnext/selling/doctype/sales_order/sales_order.js
@@ -1588,6 +1588,8 @@ erpnext.selling.SalesOrderController = class SalesOrderController extends erpnex
 					fieldname: "items_for_po",
 					fieldtype: "Table",
 					label: __("Select Items"),
+					cannot_add_rows: true,
+					cannot_delete_rows: true,
 					fields: [
 						{
 							fieldtype: "Data",
@@ -1698,7 +1700,6 @@ erpnext.selling.SalesOrderController = class SalesOrderController extends erpnex
 		}
 
 		set_po_items_data(dialog);
-		dialog.get_field("items_for_po").grid.only_sortable();
 		dialog.get_field("items_for_po").refresh();
 		dialog.wrapper.find(".grid-heading-row .grid-row-check").click();
 		dialog.show();

--- a/erpnext/selling/doctype/sales_order/sales_order.js
+++ b/erpnext/selling/doctype/sales_order/sales_order.js
@@ -1585,6 +1585,28 @@ erpnext.selling.SalesOrderController = class SalesOrderController extends erpnex
 			size: "large",
 			fields: [
 				{
+					fieldname: "set_supplier",
+					fieldtype: "Link",
+					label: __("Set Supplier"),
+					options: "Supplier",
+					onchange: function () {
+						let supplier = dialog.get_value("set_supplier");
+						let items_table = dialog.fields_dict.items_for_po.grid;
+						let selected_items = items_table.get_selected_children();
+
+						selected_items.forEach((item) => {
+							item.supplier = supplier;
+							items_table.refresh();
+						});
+					},
+				},
+				{
+					fieldtype: "Column Break",
+				},
+				{
+					fieldtype: "Section Break",
+				},
+				{
 					fieldname: "items_for_po",
 					fieldtype: "Table",
 					label: __("Select Items"),

--- a/erpnext/selling/doctype/sales_order/sales_order.js
+++ b/erpnext/selling/doctype/sales_order/sales_order.js
@@ -1644,7 +1644,7 @@ erpnext.selling.SalesOrderController = class SalesOrderController extends erpnex
 
 				if (selected_items.some((item) => !item.supplier)) {
 					frappe.throw({
-						message: "Supplier is required for all selected Items",
+						message: __("Supplier is required for all selected Items"),
 						title: __("Supplier Required"),
 						indicator: "blue",
 					});

--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -1682,7 +1682,7 @@ def make_purchase_order(source_name, selected_items=None, target_doc=None):
 						"margin_rate_or_amount",
 					],
 					"postprocess": update_item,
-					"condition": lambda doc: filter_items(doc, supplier),
+					"condition": lambda doc, s=supplier: filter_items(doc, s),
 				},
 				"Packed Item": {
 					"doctype": "Purchase Order Item",

--- a/erpnext/selling/doctype/sales_order/test_sales_order.py
+++ b/erpnext/selling/doctype/sales_order/test_sales_order.py
@@ -1038,7 +1038,7 @@ class TestSalesOrder(AccountsTestMixin, IntegrationTestCase):
 	def test_drop_shipping(self):
 		from erpnext.buying.doctype.purchase_order.purchase_order import update_status
 		from erpnext.selling.doctype.sales_order.sales_order import (
-			make_purchase_order_for_default_supplier,
+			make_purchase_order,
 		)
 		from erpnext.selling.doctype.sales_order.sales_order import update_status as so_update_status
 
@@ -1071,7 +1071,7 @@ class TestSalesOrder(AccountsTestMixin, IntegrationTestCase):
 		so = make_sales_order(item_list=so_items, do_not_submit=True)
 		so.submit()
 
-		po = make_purchase_order_for_default_supplier(so.name, selected_items=[so_items[0]])[0]
+		po = make_purchase_order(so.name, selected_items=[so_items[0]])[0]
 		po.submit()
 
 		dn = create_dn_against_so(so.name, delivered_qty=2)
@@ -1129,7 +1129,7 @@ class TestSalesOrder(AccountsTestMixin, IntegrationTestCase):
 
 	def test_drop_shipping_partial_order(self):
 		from erpnext.selling.doctype.sales_order.sales_order import (
-			make_purchase_order_for_default_supplier,
+			make_purchase_order,
 		)
 		from erpnext.selling.doctype.sales_order.sales_order import update_status as so_update_status
 
@@ -1165,7 +1165,7 @@ class TestSalesOrder(AccountsTestMixin, IntegrationTestCase):
 		so.submit()
 
 		# create po for only one item
-		po1 = make_purchase_order_for_default_supplier(so.name, selected_items=[so_items[0]])[0]
+		po1 = make_purchase_order(so.name, selected_items=[so_items[0]])[0]
 		po1.submit()
 
 		self.assertEqual(so.customer, po1.customer)
@@ -1175,7 +1175,7 @@ class TestSalesOrder(AccountsTestMixin, IntegrationTestCase):
 		self.assertEqual(len(po1.items), 1)
 
 		# create po for remaining item
-		po2 = make_purchase_order_for_default_supplier(so.name, selected_items=[so_items[1]])[0]
+		po2 = make_purchase_order(so.name, selected_items=[so_items[1]])[0]
 		po2.submit()
 
 		# teardown
@@ -1189,7 +1189,7 @@ class TestSalesOrder(AccountsTestMixin, IntegrationTestCase):
 	def test_drop_shipping_full_for_default_suppliers(self):
 		"""Test if multiple POs are generated in one go against different default suppliers."""
 		from erpnext.selling.doctype.sales_order.sales_order import (
-			make_purchase_order_for_default_supplier,
+			make_purchase_order,
 		)
 
 		if not frappe.db.exists("Item", "_Test Item for Drop Shipping 1"):
@@ -1221,7 +1221,7 @@ class TestSalesOrder(AccountsTestMixin, IntegrationTestCase):
 		so = make_sales_order(item_list=so_items, do_not_submit=True)
 		so.submit()
 
-		purchase_orders = make_purchase_order_for_default_supplier(so.name, selected_items=so_items)
+		purchase_orders = make_purchase_order(so.name, selected_items=so_items)
 
 		self.assertEqual(len(purchase_orders), 2)
 		self.assertEqual(purchase_orders[0].supplier, "_Test Supplier")
@@ -1253,7 +1253,7 @@ class TestSalesOrder(AccountsTestMixin, IntegrationTestCase):
 
 		so = make_sales_order(item_list=so_items)
 
-		purchase_order = make_purchase_order(so.name, selected_items=so_items)
+		purchase_order = make_purchase_order(so.name, selected_items=so_items)[0]
 
 		self.assertEqual(purchase_order.items[0].item_code, "_Test Bundle Item 1")
 		self.assertEqual(purchase_order.items[1].item_code, "_Test Bundle Item 2")
@@ -1283,7 +1283,7 @@ class TestSalesOrder(AccountsTestMixin, IntegrationTestCase):
 
 		so = make_sales_order(item_list=so_items)
 
-		purchase_order = make_purchase_order(so.name, selected_items=so_items)
+		purchase_order = make_purchase_order(so.name, selected_items=so_items)[0]
 		purchase_order.supplier = "_Test Supplier"
 		purchase_order.set_warehouse = "_Test Warehouse - _TC"
 		purchase_order.save()
@@ -2559,7 +2559,7 @@ class TestSalesOrder(AccountsTestMixin, IntegrationTestCase):
 		)
 		so.submit()
 
-		po = make_purchase_order(so.name, selected_items=so.items)
+		po = make_purchase_order(so.name, selected_items=so.items)[0]
 		po.supplier = "_Test Supplier"
 		po.items[0].rate = 100
 		po.submit()


### PR DESCRIPTION
When creating Purchase Order from Sales Order, the supplier field was ignored and all items were added to a single PO with no supplier. Now the entire dialog is refactored and separate POs are made for each supplier.

This also fixes an issue where supplier/customer address was not being retained when creating PO from SO.