### PR TITLE
fix(journal-entry): auto-populate bank account when user selects account

### DIFF
--- a/erpnext/accounts/doctype/journal_entry/journal_entry.js
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.js
@@ -720,6 +720,8 @@ $.extend(erpnext.journal_entry, {
 					}
 				},
 			});
+		} else {
+			erpnext.journal_entry.clear_fields(frm, dt, dn);
 		}
 	},
 	set_amount_on_last_row: function (frm, dt, dn) {
@@ -743,5 +745,14 @@ $.extend(erpnext.journal_entry, {
 			}
 		}
 		refresh_field("accounts");
+	},
+	clear_fields: function (frm, dt, dn) {
+		let row = locals[dt][dn];
+
+		row.party_type = null;
+		row.party = null;
+		row.bank_account = null;
+
+		frm.refresh_field("accounts");
 	},
 });

--- a/erpnext/accounts/doctype/journal_entry/journal_entry.py
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.py
@@ -1720,7 +1720,7 @@ def get_account_details_and_party_type(account, date, company, debit=None, credi
 		"account_type": account_details.account_type,
 		"account_currency": account_details.account_currency or company_currency,
 		"bank_account": (
-			frappe.db.get_value("Bank Account", {"account": account, "company": company}, ["name"]) or ""
+			frappe.db.get_value("Bank Account", {"account": account, "company": company}) or None
 		),
 		# The date used to retreive the exchange rate here is the date passed in
 		# as an argument to this function. It is assumed to be the date on which the balance is sought

--- a/erpnext/accounts/doctype/journal_entry/journal_entry.py
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.py
@@ -1719,6 +1719,9 @@ def get_account_details_and_party_type(account, date, company, debit=None, credi
 		"party_type": party_type,
 		"account_type": account_details.account_type,
 		"account_currency": account_details.account_currency or company_currency,
+		"bank_account": (
+			frappe.db.get_value("Bank Account", {"account": account, "company": company}, ["name"]) or ""
+		),
 		# The date used to retreive the exchange rate here is the date passed in
 		# as an argument to this function. It is assumed to be the date on which the balance is sought
 		"exchange_rate": get_exchange_rate(


### PR DESCRIPTION
When a user selects an Account in Journal Entry, the corresponding Bank Account now auto-populates.
<img width="993" height="670" alt="Screenshot 2025-11-25 at 5 37 07 PM" src="https://github.com/user-attachments/assets/85ec1111-d12d-4abb-8ef4-93d253065eb2" />
