### PR TITLE
feat(asset): make asset depreciation failure notification role configurable

### DIFF
--- a/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
+++ b/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
@@ -73,7 +73,7 @@
   "calculate_depr_using_total_days",
   "column_break_gjcc",
   "book_asset_depreciation_entry_automatically",
-  "role_used_for_depreciation_failure",
+  "role_to_notify_on_depreciation_failure",
   "closing_settings_tab",
   "period_closing_settings_section",
   "acc_frozen_upto",
@@ -661,10 +661,10 @@
    "label": "Use Legacy Controller For Period Closing Voucher"
   },
   {
-   "description": "Users with this role will be notified if the asset depreciation fails",
-   "fieldname": "role_used_for_depreciation_failure",
+   "description": "Users with this role will be notified if the asset depreciation gets failed",
+   "fieldname": "role_to_notify_on_depreciation_failure",
    "fieldtype": "Link",
-   "label": "Role used for Depreciation Failure",
+   "label": "Role to Notify on Depreciation Failure",
    "options": "Role"
   }
  ],
@@ -674,7 +674,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-11-24 23:36:21.829372",
+ "modified": "2025-12-03 20:42:13.238050",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Accounts Settings",

--- a/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
+++ b/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
@@ -661,7 +661,7 @@
    "label": "Use Legacy Controller For Period Closing Voucher"
   },
   {
-   "description": "Users with this role will be notified if the asset depreciation gets failed",
+   "description": "Users with this role will be notified if the asset depreciation fails",
    "fieldname": "role_used_for_depreciation_failure",
    "fieldtype": "Link",
    "label": "Role used for Depreciation Failure",

--- a/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
+++ b/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
@@ -73,6 +73,7 @@
   "calculate_depr_using_total_days",
   "column_break_gjcc",
   "book_asset_depreciation_entry_automatically",
+  "role_used_for_depreciation_failure",
   "closing_settings_tab",
   "period_closing_settings_section",
   "acc_frozen_upto",
@@ -658,6 +659,13 @@
    "fieldname": "use_legacy_controller_for_pcv",
    "fieldtype": "Check",
    "label": "Use Legacy Controller For Period Closing Voucher"
+  },
+  {
+   "description": "Users with this role will be notified if the asset depreciation gets failed",
+   "fieldname": "role_used_for_depreciation_failure",
+   "fieldtype": "Link",
+   "label": "Role used for Depreciation Failure",
+   "options": "Role"
   }
  ],
  "grid_page_length": 50,
@@ -666,7 +674,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-10-20 14:06:08.870427",
+ "modified": "2025-11-24 23:36:21.829372",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Accounts Settings",

--- a/erpnext/accounts/doctype/accounts_settings/accounts_settings.py
+++ b/erpnext/accounts/doctype/accounts_settings/accounts_settings.py
@@ -64,8 +64,8 @@ class AccountsSettings(Document):
 		receivable_payable_remarks_length: DF.Int
 		reconciliation_queue_size: DF.Int
 		role_allowed_to_over_bill: DF.Link | None
+		role_to_notify_on_depreciation_failure: DF.Link | None
 		role_to_override_stop_action: DF.Link | None
-		role_used_for_depreciation_failure: DF.Link | None
 		round_row_wise_tax: DF.Check
 		show_balance_in_coa: DF.Check
 		show_inclusive_tax_in_print: DF.Check

--- a/erpnext/accounts/doctype/accounts_settings/accounts_settings.py
+++ b/erpnext/accounts/doctype/accounts_settings/accounts_settings.py
@@ -65,6 +65,7 @@ class AccountsSettings(Document):
 		reconciliation_queue_size: DF.Int
 		role_allowed_to_over_bill: DF.Link | None
 		role_to_override_stop_action: DF.Link | None
+		role_used_for_depreciation_failure: DF.Link | None
 		round_row_wise_tax: DF.Check
 		show_balance_in_coa: DF.Check
 		show_inclusive_tax_in_print: DF.Check

--- a/erpnext/assets/doctype/asset/depreciation.py
+++ b/erpnext/assets/doctype/asset/depreciation.py
@@ -307,7 +307,7 @@ def set_depr_entry_posting_status_for_failed_assets(failed_asset_names):
 
 
 def notify_depr_entry_posting_error(failed_asset_names, error_log_names):
-	user_role = frappe.db.get_single_value("Accounts Settings", "role_used_for_depreciation_failure")
+	user_role = frappe.db.get_single_value("Accounts Settings", "role_to_notify_on_depreciation_failure")
 	recipients = get_users_with_role(user_role or "Accounts Manager")
 
 	if not recipients:

--- a/erpnext/assets/doctype/asset/depreciation.py
+++ b/erpnext/assets/doctype/asset/depreciation.py
@@ -307,7 +307,8 @@ def set_depr_entry_posting_status_for_failed_assets(failed_asset_names):
 
 
 def notify_depr_entry_posting_error(failed_asset_names, error_log_names):
-	recipients = get_users_with_role("Accounts Manager")
+	user_role = frappe.db.get_single_value("Accounts Settings", "role_used_for_depreciation_failure")
+	recipients = get_users_with_role(user_role or "Accounts Manager")
 
 	if not recipients:
 		recipients = get_users_with_role("System Manager")


### PR DESCRIPTION
**Issue**:
When asset depreciation fails, it sends a notification to the Account Manager by default.

 fixes: #48878

**Solution**:
Added a field in Accounts Settings to configure the role

<img width="1853" height="390" alt="image" src="https://github.com/user-attachments/assets/a5511fc9-4b4c-419f-ab26-03a0959a4cae" />


no-docs