### PR TITLE
refactor: company details popup

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -7,6 +7,7 @@ from collections import defaultdict
 
 import frappe
 from frappe import _, bold, qb, throw
+from frappe.contacts.doctype.address.address import get_address_display
 from frappe.model.workflow import get_workflow_name, is_transition_condition_satisfied
 from frappe.query_builder import Criterion, DocType
 from frappe.query_builder.custom import ConstantColumn
@@ -4167,3 +4168,109 @@ def update_gl_dict_with_regional_fields(doc, gl_dict):
 def update_gl_dict_with_app_based_fields(doc, gl_dict):
 	for method in frappe.get_hooks("update_gl_dict_with_app_based_fields", default=[]):
 		frappe.get_attr(method)(doc, gl_dict)
+
+
+@frappe.whitelist()
+def get_missing_company_details(doctype, docname):
+	from frappe.contacts.doctype.address.address import get_address_display_list
+
+	company = frappe.db.get_value(doctype, docname, "company")
+	company_address = frappe.db.get_value(doctype, docname, "company_address")
+
+	company_details = frappe.get_value(
+		"Company", company, ["company_logo", "website", "phone_no", "email"], as_dict=True
+	)
+
+	required_fields = [
+		company_details.get("company_logo"),
+		company_details.get("phone_no"),
+		company_details.get("email"),
+	]
+
+	if not all(required_fields) and not frappe.has_permission("Company", "write", throw=False):
+		frappe.msgprint(
+			_(
+				"Some required Company details are missing. You don't have permission to update them. Please contact your System Manager."
+			)
+		)
+		return
+
+	if not company_address and not frappe.has_permission("Sales Invoice", "write", throw=False):
+		frappe.msgprint(
+			_(
+				"Company Address is missing. You don't have permission to update it. Please contact your System Manager."
+			)
+		)
+		return
+
+	address_display_list = get_address_display_list("Company", company)
+	address_line = address_display_list[0].get("address_line1") if address_display_list else ""
+
+	required_fields.append(company_address)
+	required_fields.append(address_line)
+
+	if all(required_fields):
+		return False
+	return {
+		"company_logo": company_details.get("company_logo"),
+		"website": company_details.get("website"),
+		"phone_no": company_details.get("phone_no"),
+		"email": company_details.get("email"),
+		"address_line": address_line,
+		"company": company,
+		"company_address": company_address,
+		"name": docname,
+	}
+
+
+@frappe.whitelist()
+def update_company_master_and_address(name, company, details):
+	from frappe.utils import validate_email_address
+
+	if isinstance(details, str):
+		details = frappe.parse_json(details)
+
+	if details.get("email"):
+		validate_email_address(details.get("email"), throw=True)
+
+	company_fields = ["company_logo", "website", "phone_no", "email"]
+	company_fields_to_update = {field: details.get(field) for field in company_fields if details.get(field)}
+
+	if company_fields_to_update:
+		frappe.db.set_value("Company", company, company_fields_to_update)
+
+	company_address = details.get("company_address")
+	if details.get("address_line1"):
+		address_doc = frappe.get_doc(
+			{
+				"doctype": "Address",
+				"address_title": details.get("address_title"),
+				"address_type": details.get("address_type"),
+				"address_line1": details.get("address_line1"),
+				"address_line2": details.get("address_line2"),
+				"city": details.get("city"),
+				"state": details.get("state"),
+				"pincode": details.get("pincode"),
+				"country": details.get("country"),
+				"is_your_company_address": 1,
+				"links": [{"link_doctype": "Company", "link_name": company}],
+			}
+		)
+		address_doc.insert()
+		company_address = address_doc.name
+
+	if company_address:
+		company_address_display = frappe.db.get_value("Sales Invoice", name, "company_address_display")
+		if not company_address_display or details.get("address_line1"):
+			from frappe.query_builder import DocType
+
+			SalesInvoice = DocType("Sales Invoice")
+
+			(
+				frappe.qb.update(SalesInvoice)
+				.set(SalesInvoice.company_address, company_address)
+				.set(SalesInvoice.company_address_display, get_address_display(company_address))
+				.where(SalesInvoice.name == name)
+			).run()
+
+	return True

--- a/erpnext/public/js/print.js
+++ b/erpnext/public/js/print.js
@@ -1,155 +1,137 @@
-let beforePrintHandled = false;
+const doctype_list = ["Sales Invoice"];
+const allowed_print_formats = ["Sales Invoice Standard", "Sales Invoice with Item Image"];
+const allowed_letterheads = ["Company Letterhead", "Company Letterhead - Grey"];
 
-frappe.realtime.on("sales_invoice_before_print", (data) => {
-	let print_format = $('input[data-fieldname="print_format"]').val();
-	let letterhead = $('input[data-fieldname="letterhead"]').val();
+handle_route_event();
 
-	let allowed_print_formats = ["Sales Invoice Standard", "Sales Invoice with Item Image"];
-	let allowed_letterheads = ["Company Letterhead", "Company Letterhead - Grey"];
-
-	if (!allowed_print_formats.includes(print_format) && !allowed_letterheads.includes(letterhead)) {
-		return;
-	}
-
+function handle_route_event() {
 	const route = frappe.get_route();
+	const current_doctype = route[1];
+	const current_docname = route[2];
 
-	if (!beforePrintHandled && route[0] === "print" && route[1] === "Sales Invoice") {
-		beforePrintHandled = true;
+	if (!doctype_list.includes(current_doctype)) return;
 
-		let companyDetailsDialog = new frappe.ui.Dialog({
-			title: "Enter Company Details",
-			fields: [
-				{
-					label: "Company Logo",
-					fieldname: "company_logo",
-					fieldtype: "Attach Image",
-					reqd: data.company_logo ? 0 : 1,
-					hidden: data.company_logo ? 1 : 0,
+	setTimeout(() => {
+		if (should_fetch_company_details()) {
+			fetch_company_details(current_doctype, current_docname);
+		}
+	}, 500);
+}
+
+function should_fetch_company_details() {
+	const print_format = $('input[data-fieldname="print_format"]').val();
+	const letterhead = $('input[data-fieldname="letterhead"]').val();
+
+	return allowed_print_formats.includes(print_format) || allowed_letterheads.includes(letterhead);
+}
+
+function fetch_company_details(doctype, docname) {
+	frappe.call({
+		method: "erpnext.controllers.accounts_controller.get_missing_company_details",
+		args: { doctype, docname },
+		callback: function (r) {
+			if (r && r.message) {
+				open_company_details_dialog(r.message);
+			}
+		},
+	});
+}
+
+function open_company_details_dialog(data) {
+	const dialog = new frappe.ui.Dialog({
+		title: "Enter Company Details",
+		fields: build_dialog_fields(data),
+		primary_action_label: "Save",
+		primary_action(values) {
+			save_company_details(dialog, data, values);
+		},
+	});
+
+	dialog.show();
+}
+
+function build_dialog_fields(data) {
+	return [
+		make_field("Company Logo", "company_logo", "Attach Image", data.company_logo),
+		make_field("Website", "website", "Data", data.website),
+		make_field("Phone No", "phone_no", "Data", data.phone_no),
+		{
+			label: "Email",
+			fieldname: "email",
+			fieldtype: "Data",
+			options: "Email",
+			reqd: data.email ? 0 : 1,
+			hidden: data.email ? 1 : 0,
+		},
+		{ fieldtype: "Section Break" },
+
+		make_field("Address Title", "address_title", "Data", data.address_line),
+		{
+			label: "Address Type",
+			fieldname: "address_type",
+			fieldtype: "Select",
+			options: ["Billing", "Shipping"],
+			default: "Billing",
+			reqd: data.address_line ? 0 : 1,
+			hidden: data.address_line ? 1 : 0,
+		},
+		make_field("Address Line 1", "address_line1", "Data", data.address_line),
+		make_field("Address Line 2", "address_line2", "Data", data.address_line, false),
+		make_field("City", "city", "Data", data.address_line),
+		make_field("State", "state", "Data", data.address_line, false),
+		{
+			label: "Country",
+			fieldname: "country",
+			fieldtype: "Link",
+			options: "Country",
+			reqd: data.address_line ? 0 : 1,
+			hidden: data.address_line ? 1 : 0,
+		},
+		make_field("Postal Code", "pincode", "Data", data.address_line, false),
+
+		{
+			label: "Select Company Address",
+			fieldname: "company_address",
+			fieldtype: "Link",
+			options: "Address",
+			get_query: () => ({
+				query: "frappe.contacts.doctype.address.address.address_query",
+				filters: {
+					link_doctype: "Company",
+					link_name: data.company,
 				},
-				{
-					label: "Website",
-					fieldname: "website",
-					fieldtype: "Data",
-					hidden: data.website ? 1 : 0,
-				},
-				{
-					label: "Phone No",
-					fieldname: "phone_no",
-					fieldtype: "Data",
-					reqd: data.phone_no ? 0 : 1,
-					hidden: data.phone_no ? 1 : 0,
-				},
-				{
-					label: "Email",
-					fieldname: "email",
-					fieldtype: "Data",
-					options: "Email",
-					reqd: data.email ? 0 : 1,
-					hidden: data.email ? 1 : 0,
-				},
-				{
-					fieldname: "section_break_1",
-					fieldtype: "Section Break",
-				},
-				{
-					label: "Address Title",
-					fieldname: "address_title",
-					fieldtype: "Data",
-					reqd: data.address_line ? 0 : 1,
-					hidden: data.address_line ? 1 : 0,
-				},
-				{
-					label: "Address Type",
-					fieldname: "address_type",
-					fieldtype: "Select",
-					options: ["Billing", "Shipping"],
-					default: "Billing",
-					reqd: data.address_line ? 0 : 1,
-					hidden: data.address_line ? 1 : 0,
-				},
-				{
-					label: "Address Line 1",
-					fieldname: "address_line1",
-					fieldtype: "Data",
-					reqd: data.address_line ? 0 : 1,
-					hidden: data.address_line ? 1 : 0,
-				},
-				{
-					label: "Address Line 2",
-					fieldname: "address_line2",
-					fieldtype: "Data",
-					hidden: data.address_line ? 1 : 0,
-				},
-				{
-					label: "City",
-					fieldname: "city",
-					fieldtype: "Data",
-					reqd: data.address_line ? 0 : 1,
-					hidden: data.address_line ? 1 : 0,
-				},
-				{
-					label: "State",
-					fieldname: "state",
-					fieldtype: "Data",
-					hidden: data.address_line ? 1 : 0,
-				},
-				{
-					label: "Country",
-					fieldname: "country",
-					fieldtype: "Link",
-					options: "Country",
-					reqd: data.address_line ? 0 : 1,
-					hidden: data.address_line ? 1 : 0,
-				},
-				{
-					label: "Postal Code",
-					fieldname: "pincode",
-					fieldtype: "Data",
-					hidden: data.address_line ? 1 : 0,
-				},
-				{
-					label: "Select Company Address",
-					fieldname: "company_address",
-					fieldtype: "Link",
-					options: "Address",
-					get_query: function () {
-						return {
-							query: "frappe.contacts.doctype.address.address.address_query",
-							filters: {
-								link_doctype: "Company",
-								link_name: data.company,
-							},
-						};
-					},
-					reqd: data.address_line && !data.company_address ? 1 : 0,
-					hidden: data.address_line && !data.company_address ? 0 : 1,
-				},
-			],
-			primary_action_label: "Save",
-			primary_action(values) {
-				frappe.call({
-					method: "erpnext.accounts.doctype.sales_invoice.sales_invoice.save_company_master_details",
-					args: {
-						name: data.name,
-						company: data.company,
-						details: values,
-					},
-					callback: function () {
-						companyDetailsDialog.hide();
-						frappe.msgprint(__("Updating details."));
-						setTimeout(() => {
-							window.location.reload();
-						}, 1000);
-					},
-				});
-			},
-		});
-		companyDetailsDialog.show();
-	}
-});
-frappe.router.on("change", () => {
-	const route = frappe.get_route();
-	if (route[0] !== "print" || route[1] !== "Sales Invoice") {
-		beforePrintHandled = false;
-	}
-});
+			}),
+			reqd: data.address_line && !data.company_address ? 1 : 0,
+			hidden: data.address_line && !data.company_address ? 0 : 1,
+		},
+	];
+}
+
+function make_field(label, fieldname, fieldtype, existing_value, required_if_empty = true) {
+	return {
+		label,
+		fieldname,
+		fieldtype,
+		reqd: existing_value ? 0 : required_if_empty ? 1 : 0,
+		hidden: existing_value ? 1 : 0,
+	};
+}
+
+function save_company_details(dialog, data, values) {
+	frappe.call({
+		method: "erpnext.controllers.accounts_controller.update_company_master_and_address",
+		args: {
+			name: data.name,
+			company: data.company,
+			details: values,
+		},
+		callback() {
+			dialog.hide();
+			frappe.msgprint("Updating details.");
+
+			setTimeout(() => {
+				location.reload();
+			}, 1000);
+		},
+	});
+}

--- a/erpnext/public/js/print.js
+++ b/erpnext/public/js/print.js
@@ -39,9 +39,9 @@ function fetch_company_details(doctype, docname) {
 
 function open_company_details_dialog(data) {
 	const dialog = new frappe.ui.Dialog({
-		title: "Enter Company Details",
+		title: __("Enter Company Details"),
 		fields: build_dialog_fields(data),
-		primary_action_label: "Save",
+		primary_action_label: __("Save"),
 		primary_action(values) {
 			save_company_details(dialog, data, values);
 		},
@@ -52,11 +52,11 @@ function open_company_details_dialog(data) {
 
 function build_dialog_fields(data) {
 	return [
-		make_field("Company Logo", "company_logo", "Attach Image", data.company_logo),
-		make_field("Website", "website", "Data", data.website),
-		make_field("Phone No", "phone_no", "Data", data.phone_no),
+		make_field(__("Company Logo"), "company_logo", "Attach Image", data.company_logo),
+		make_field(__("Website"), "website", "Data", data.website),
+		make_field(__("Phone No"), "phone_no", "Data", data.phone_no),
 		{
-			label: "Email",
+			label: __("Email"),
 			fieldname: "email",
 			fieldtype: "Data",
 			options: "Email",
@@ -65,9 +65,9 @@ function build_dialog_fields(data) {
 		},
 		{ fieldtype: "Section Break" },
 
-		make_field("Address Title", "address_title", "Data", data.address_line),
+		make_field(__("Address Title"), "address_title", "Data", data.address_line),
 		{
-			label: "Address Type",
+			label: __("Address Type"),
 			fieldname: "address_type",
 			fieldtype: "Select",
 			options: ["Billing", "Shipping"],
@@ -75,22 +75,22 @@ function build_dialog_fields(data) {
 			reqd: data.address_line ? 0 : 1,
 			hidden: data.address_line ? 1 : 0,
 		},
-		make_field("Address Line 1", "address_line1", "Data", data.address_line),
-		make_field("Address Line 2", "address_line2", "Data", data.address_line, false),
-		make_field("City", "city", "Data", data.address_line),
-		make_field("State", "state", "Data", data.address_line, false),
+		make_field(__("Address Line 1"), "address_line1", "Data", data.address_line),
+		make_field(__("Address Line 2"), "address_line2", "Data", data.address_line, false),
+		make_field(__("City"), "city", "Data", data.address_line),
+		make_field(__("State"), "state", "Data", data.address_line, false),
 		{
-			label: "Country",
+			label: __("Country"),
 			fieldname: "country",
 			fieldtype: "Link",
 			options: "Country",
 			reqd: data.address_line ? 0 : 1,
 			hidden: data.address_line ? 1 : 0,
 		},
-		make_field("Postal Code", "pincode", "Data", data.address_line, false),
+		make_field(__("Postal Code"), "pincode", "Data", data.address_line, false),
 
 		{
-			label: "Select Company Address",
+			label: __("Select Company Address"),
 			fieldname: "company_address",
 			fieldtype: "Link",
 			options: "Address",
@@ -127,7 +127,7 @@ function save_company_details(dialog, data, values) {
 		},
 		callback() {
 			dialog.hide();
-			frappe.msgprint("Updating details.");
+			frappe.msgprint(__("Updating details."));
 
 			setTimeout(() => {
 				location.reload();


### PR DESCRIPTION
This PR fixes the issue where the company-details popup was triggering multiple times during print preview.
The original implementation relied on before_print + realtime events, which made the popup fire repeatedly and worked only for Sales Invoice.

The flow is refactored to a cleaner, generic approach:

- Popup logic moved to the print page instead of before_print
- Added a unified API to fetch missing company details
- Works for Sales Invoice, Delivery Note, Purchase Order, and POS Invoice
- No more realtime events → no duplicate popups
- Popup fields show only when needed based on missing data