### PR TITLE
fix: enhance SalesOrderController setup method to call super.setup

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.js
+++ b/erpnext/selling/doctype/sales_order/sales_order.js
@@ -917,8 +917,9 @@ frappe.ui.form.on("Sales Order Item", {
 });
 
 erpnext.selling.SalesOrderController = class SalesOrderController extends erpnext.selling.SellingController {
-	setup() {
+	setup(doc) {
 		this.setup_accounting_dimension_triggers();
+		super.setup(doc);
 	}
 	onload(doc, dt, dn) {
 		super.onload(doc, dt, dn);


### PR DESCRIPTION
regression: https://github.com/frappe/erpnext/pull/50621

Traceback
```
TypeError: can't access property "includes", frappe.flags.round_off_applicable_accounts is undefined
    round_off_totals taxes_and_totals.js:526
    calculate_taxes taxes_and_totals.js:429
    _calculate_taxes_and_totals taxes_and_totals.js:106
    calculate_taxes_and_totals taxes_and_totals.js:39
    validate transaction.js:881
    o script_manager.js:106
    trigger script_manager.js:136
    promise callback*frappe.run_serially/< dom.js:262
    run_serially dom.js:260
    trigger script_manager.js:141
    validate_and_save form.js:808
    promise callback*frappe.run_serially/< dom.js:262
    run_serially dom.js:260
    validate_and_save form.js:807
    save form.js:746
    save form.js:743
    Save toolbar.js:718
    set_action page.js:306
    jQuery 2
    Async* <anonymous code>:1
    apply <anonymous code>:1
    jQuery 6
    set_action page.js:305
    set_primary_action page.js:320
    set_page_actions toolbar.js:735
    set_primary_action toolbar.js:648
    add_update_button_on_dirty toolbar.js:750
    jQuery 6
form.js:794:13

```

Frappe Support Issue: https://support.frappe.io/helpdesk/tickets/54258?view=VIEW-HD+Ticket-771