### PR TITLE
fix(Job Card): apply precision to total time in minutes

### DIFF
--- a/erpnext/manufacturing/doctype/job_card/job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/job_card.py
@@ -263,13 +263,16 @@ class JobCard(Document):
 					)
 
 				if d.from_time and d.to_time:
-					d.time_in_mins = time_diff_in_hours(d.to_time, d.from_time) * 60
+					d.time_in_mins = flt(
+						time_diff_in_hours(d.to_time, d.from_time) * 60, d.precision("time_in_mins")
+					)
 					self.total_time_in_mins += d.time_in_mins
 
 				if d.completed_qty and not self.sub_operations:
 					self.total_completed_qty += d.completed_qty
 
 			self.total_completed_qty = flt(self.total_completed_qty, self.precision("total_completed_qty"))
+			self.total_time_in_mins = flt(self.total_time_in_mins, self.precision("total_time_in_mins"))
 
 			if save and self.docstatus == 1:
 				self.db_set(

--- a/erpnext/manufacturing/doctype/job_card/job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/job_card.py
@@ -644,21 +644,21 @@ class JobCard(Document):
 				op_row.completed_qty += flt(time_log.completed_qty)
 
 		for row in self.sub_operations:
-			operation_deatils = operation_wise_completed_time.get(row.sub_operation)
-			if operation_deatils:
+			operation_details = operation_wise_completed_time.get(row.sub_operation)
+			if operation_details:
 				if row.status != "Complete":
-					row.status = operation_deatils.status
+					row.status = operation_details.status
 
-				completed_time = flt(operation_deatils.completed_time, row.precision("completed_time"))
-				if operation_deatils.employee:
+				completed_time = flt(operation_details.completed_time, row.precision("completed_time"))
+				if operation_details.employee:
 					completed_time = flt(
-						operation_deatils.completed_time / len(set(operation_deatils.employee)),
+						operation_details.completed_time / len(set(operation_details.employee)),
 						row.precision("completed_time"),
 					)
 
-					if operation_deatils.completed_qty:
+					if operation_details.completed_qty:
 						row.completed_qty = flt(
-							operation_deatils.completed_qty / len(set(operation_deatils.employee)),
+							operation_details.completed_qty / len(set(operation_details.employee)),
 							row.precision("completed_qty"),
 						)
 

--- a/erpnext/manufacturing/doctype/job_card/job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/job_card.py
@@ -649,17 +649,27 @@ class JobCard(Document):
 				if row.status != "Complete":
 					row.status = operation_deatils.status
 
-				row.completed_time = operation_deatils.completed_time
+				completed_time = flt(operation_deatils.completed_time, row.precision("completed_time"))
 				if operation_deatils.employee:
-					row.completed_time = row.completed_time / len(set(operation_deatils.employee))
+					completed_time = flt(
+						operation_deatils.completed_time / len(set(operation_deatils.employee)),
+						row.precision("completed_time"),
+					)
 
 					if operation_deatils.completed_qty:
-						row.completed_qty = operation_deatils.completed_qty / len(
-							set(operation_deatils.employee)
+						row.completed_qty = flt(
+							operation_deatils.completed_qty / len(set(operation_deatils.employee)),
+							row.precision("completed_qty"),
 						)
+
+				# Only update completed_time if value actually changed.
+				# completed_time is a Data (string) field, so compare as floats
+				if flt(row.completed_time) != completed_time:
+					row.completed_time = completed_time
 			else:
 				row.status = "Pending"
-				row.completed_time = 0.0
+				if flt(row.completed_time) != 0.0:
+					row.completed_time = 0.0
 				row.completed_qty = 0.0
 
 	def update_time_logs(self, row):


### PR DESCRIPTION
This pull request introduces improvements to the calculation and precision handling of time and quantity fields in the `Job Card` doctype, ensuring consistency and accuracy in manufacturing job tracking. The most important changes focus on using the `flt()` function for precision and updating values only when necessary.

Precision and calculation improvements:

* Updated the calculation of `time_in_mins` and `total_time_in_mins` in the `validate_time_logs` method to use the `flt()` function with field-specific precision, ensuring more accurate and consistent values.
* Modified the calculation of `completed_time` and `completed_qty` in the `update_sub_operation_status` method to use the `flt()` function with the appropriate precision for each field, improving consistency for sub-operation tracking.

Logic and update optimizations:

* Added logic to update `completed_time` only if the value actually changed, preventing unnecessary writes and ensuring the field is only updated when needed.

Screenshot of original issue:

<img width="770" height="259" alt="Bildschirmfoto 2025-11-26 um 12 10 23" src="https://github.com/user-attachments/assets/78f71b82-1741-4eff-9338-560fa556be08" />
