### PR TITLE
fix: update uom when item changes

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -438,6 +438,7 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 
 		item.weight_per_unit = 0;
 		item.weight_uom = '';
+		item.uom = null // make UOM blank to update the existing UOM when item changes
 		item.conversion_factor = 0;
 
 		if(['Sales Invoice'].includes(this.frm.doc.doctype)) {


### PR DESCRIPTION
**Issue:** Default UOM is not updating in the line item row when the user changes the item code.

**Ref :**  [#52987](https://support.frappe.io/helpdesk/tickets/52987)

**Before :**


https://github.com/user-attachments/assets/6de75e1e-bf33-47f3-aabb-c6ada57db2ad



**After :**


https://github.com/user-attachments/assets/5c95f590-25b2-42e3-b495-b0985ac4062d



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Unit of Measure (UOM) not updating properly when changing an item in transactions. The UOM now correctly resets when a new item is selected, allowing the appropriate unit to be assigned automatically.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->