### PR TITLE
feat: add Account Category field to Account (Chart of Accounts)

### DIFF
--- a/erpnext/accounts/doctype/account/account_tree.js
+++ b/erpnext/accounts/doctype/account/account_tree.js
@@ -161,6 +161,14 @@ frappe.treeview_settings["Account"] = {
 			description: __("Optional. This setting will be used to filter in various transactions."),
 		},
 		{
+			fieldtype: "Link",
+			fieldname: "account_category",
+			label: __("Account Category"),
+			options: frappe.get_meta("Account").fields.filter((d) => d.fieldname == "account_category")[0]
+				.options,
+			description: __("Optional. Used with Financial Report Template"),
+		},
+		{
 			fieldtype: "Float",
 			fieldname: "tax_rate",
 			label: __("Tax Rate"),

--- a/erpnext/accounts/doctype/account/account_tree.js
+++ b/erpnext/accounts/doctype/account/account_tree.js
@@ -161,6 +161,14 @@ frappe.treeview_settings["Account"] = {
 			description: __("Optional. This setting will be used to filter in various transactions."),
 		},
 		{
+			fieldtype: "Link",
+			fieldname: "account_category",
+			label: __("Account Category"),
+			options: frappe.get_meta("Account").fields.filter((d) => d.fieldname == "account_category")[0]
+				.options,
+			description: __("Used with Financial Report Template."),
+		},
+		{
 			fieldtype: "Float",
 			fieldname: "tax_rate",
 			label: __("Tax Rate"),

--- a/erpnext/accounts/doctype/account/account_tree.js
+++ b/erpnext/accounts/doctype/account/account_tree.js
@@ -161,14 +161,6 @@ frappe.treeview_settings["Account"] = {
 			description: __("Optional. This setting will be used to filter in various transactions."),
 		},
 		{
-			fieldtype: "Link",
-			fieldname: "account_category",
-			label: __("Account Category"),
-			options: frappe.get_meta("Account").fields.filter((d) => d.fieldname == "account_category")[0]
-				.options,
-			description: __("Used with Financial Report Template."),
-		},
-		{
 			fieldtype: "Float",
 			fieldname: "tax_rate",
 			label: __("Tax Rate"),

--- a/erpnext/accounts/doctype/account/chart_of_accounts/verified/standard_chart_of_accounts_with_account_number.py
+++ b/erpnext/accounts/doctype/account/chart_of_accounts/verified/standard_chart_of_accounts_with_account_number.py
@@ -228,6 +228,7 @@ def get():
 				},
 				_("Impairment"): {"account_number": "5224", "account_category": "Operating Expenses"},
 				_("Tax Expense"): {"account_number": "5225", "account_category": "Tax Expense"},
+				"account_number": "5200",
 			},
 			"root_type": "Expense",
 			"account_number": "5000",

--- a/erpnext/accounts/doctype/account/chart_of_accounts/verified/standard_chart_of_accounts_with_account_number.py
+++ b/erpnext/accounts/doctype/account/chart_of_accounts/verified/standard_chart_of_accounts_with_account_number.py
@@ -228,7 +228,6 @@ def get():
 				},
 				_("Impairment"): {"account_number": "5224", "account_category": "Operating Expenses"},
 				_("Tax Expense"): {"account_number": "5225", "account_category": "Tax Expense"},
-				"account_number": "5200",
 			},
 			"root_type": "Expense",
 			"account_number": "5000",


### PR DESCRIPTION
For all the new Financial Report Templates, selecting the Account Category is mandatory. If this field is missed, the report shows the variance message “VARIANCE (Calculated vs Actual – should be zero)”, which confuses end users.

In most cases, users add new ledgers directly from the Account (Chart of Accounts) Tree Dialog, and since the Account Category field is not visible there, they unintentionally skip it. Later they spend time editing each ledger one by one just to update this field.

To avoid this repeated issue, it’s better to show Account Category directly inside the dialog itself so users can select it while creating the ledger.

This PR adds the “Account Category” field to the account tree dialog in account_tree.js, ensuring smoother workflow and fewer missed configurations.

<img width="3876" height="1892" alt="image" src="https://github.com/user-attachments/assets/f5113fef-81e2-4bdc-909c-63a8c904c9cf" />

`no-docs`
