### PR TITLE
fix: restore missing account number for Indirect Expenses in standard COA with Numbers

### DIFF
--- a/erpnext/accounts/doctype/account/account_tree.js
+++ b/erpnext/accounts/doctype/account/account_tree.js
@@ -161,6 +161,14 @@ frappe.treeview_settings["Account"] = {
 			description: __("Optional. This setting will be used to filter in various transactions."),
 		},
 		{
+			fieldtype: "Link",
+			fieldname: "account_category",
+			label: __("Account Category"),
+			options: frappe.get_meta("Account").fields.filter((d) => d.fieldname == "account_category")[0]
+				.options,
+			description: __("Used with Financial Report Template."),
+		},
+		{
 			fieldtype: "Float",
 			fieldname: "tax_rate",
 			label: __("Tax Rate"),

--- a/erpnext/accounts/doctype/account/account_tree.js
+++ b/erpnext/accounts/doctype/account/account_tree.js
@@ -161,14 +161,6 @@ frappe.treeview_settings["Account"] = {
 			description: __("Optional. This setting will be used to filter in various transactions."),
 		},
 		{
-			fieldtype: "Link",
-			fieldname: "account_category",
-			label: __("Account Category"),
-			options: frappe.get_meta("Account").fields.filter((d) => d.fieldname == "account_category")[0]
-				.options,
-			description: __("Used with Financial Report Template."),
-		},
-		{
 			fieldtype: "Float",
 			fieldname: "tax_rate",
 			label: __("Tax Rate"),

--- a/erpnext/accounts/doctype/account/chart_of_accounts/verified/standard_chart_of_accounts_with_account_number.py
+++ b/erpnext/accounts/doctype/account/chart_of_accounts/verified/standard_chart_of_accounts_with_account_number.py
@@ -228,6 +228,7 @@ def get():
 				},
 				_("Impairment"): {"account_number": "5224", "account_category": "Operating Expenses"},
 				_("Tax Expense"): {"account_number": "5225", "account_category": "Tax Expense"},
+				"account_number": "5200",
 			},
 			"root_type": "Expense",
 			"account_number": "5000",

--- a/erpnext/accounts/doctype/account/chart_of_accounts/verified/standard_chart_of_accounts_with_account_number.py
+++ b/erpnext/accounts/doctype/account/chart_of_accounts/verified/standard_chart_of_accounts_with_account_number.py
@@ -228,7 +228,6 @@ def get():
 				},
 				_("Impairment"): {"account_number": "5224", "account_category": "Operating Expenses"},
 				_("Tax Expense"): {"account_number": "5225", "account_category": "Tax Expense"},
-				"account_number": "5200",
 			},
 			"root_type": "Expense",
 			"account_number": "5000",


### PR DESCRIPTION
The Indirect Expenses parent account in standard_chart_of_accounts_with_account_number.py was missing.