### PR TITLE
fix: use posting_date instead of bill_date from purchase invoice

### DIFF
--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -1212,7 +1212,7 @@ def get_values_from_purchase_doc(purchase_doc_name, item_code, doctype):
 
 	return {
 		"company": purchase_doc.company,
-		"purchase_date": purchase_doc.get("bill_date") or purchase_doc.get("posting_date"),
+		"purchase_date": purchase_doc.get("posting_date"),
 		"net_purchase_amount": flt(first_item.base_net_amount),
 		"asset_quantity": first_item.qty,
 		"cost_center": first_item.cost_center or purchase_doc.get("cost_center"),


### PR DESCRIPTION
Issue: During asset creation if the purchase Invoice is linked, system sets `Supplier Invoice Date` as the `Purchase Date` instead of `Posting Date`.

Ref: [54340](https://support.frappe.io/helpdesk/tickets/54340)

Backport Needed: Version-15