### PR TITLE
fix: add validation for cancelled reposting entries

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -364,6 +364,24 @@ class AccountsController(TransactionBase):
 
 		for _doctype in repost_doctypes:
 			dt = frappe.qb.DocType(_doctype)
+
+			cancelled_entries = (
+				frappe.qb.from_(dt)
+				.select(dt.parent, dt.parenttype)
+				.where((dt.voucher_type == self.doctype) & (dt.voucher_no == self.name) & (dt.docstatus == 2))
+				.run(as_dict=True)
+			)
+
+			if cancelled_entries:
+				entries = "<br>".join([get_link_to_form(d.parenttype, d.parent) for d in cancelled_entries])
+
+				frappe.throw(
+					_(
+						"The following cancelled repost entries exist for <b>{0}</b>:<br><br>{1}<br><br>"
+						"Kindly delete these entries before continuing."
+					).format(self.name, entries)
+				)
+
 			rows = (
 				frappe.qb.from_(dt)
 				.select(dt.name, dt.parent, dt.parenttype)


### PR DESCRIPTION
Issue: Upon Invoice deletion, with cancelled repost entries getting an error for updation.

Ref: [53866](https://support.frappe.io/helpdesk/tickets/53866)

**Steps to reproduce:**

- Create and submit a Sales Invoice.
- Create a Repost Accounting Ledger entry for this invoice.
- Cancel the repost entry.
- Cancel the original invoice.
- Attempt to delete the invoice → system throws a browser error, user didn't get the proper error message.

Before:

<img width="1660" height="924" alt="image" src="https://github.com/user-attachments/assets/af20fc9a-45e6-4510-860d-aa2674add770" />

After:

<img width="1691" height="927" alt="image" src="https://github.com/user-attachments/assets/6823cde1-43f3-4314-b64b-8ba4c417e1fc" />


**Backport needed: Version-15**