### PR TITLE
fix: double barcode issue

### DIFF
--- a/erpnext/stock/doctype/stock_reconciliation_item/stock_reconciliation_item.json
+++ b/erpnext/stock/doctype/stock_reconciliation_item/stock_reconciliation_item.json
@@ -14,6 +14,7 @@
   "column_break_6",
   "warehouse",
   "qty",
+  "stock_uom",
   "valuation_rate",
   "amount",
   "allow_zero_valuation_rate",
@@ -85,6 +86,16 @@
    "fieldtype": "Float",
    "in_list_view": 1,
    "label": "Quantity"
+  },
+  {
+   "columns": 2,
+   "fetch_from": "item_code.stock_uom",
+   "fieldname": "stock_uom",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Stock UOM",
+   "options": "UOM",
+   "read_only": 1
   },
   {
    "columns": 2,

--- a/erpnext/stock/doctype/stock_reconciliation_item/stock_reconciliation_item.py
+++ b/erpnext/stock/doctype/stock_reconciliation_item/stock_reconciliation_item.py
@@ -36,6 +36,7 @@ class StockReconciliationItem(Document):
 		reconcile_all_serial_batch: DF.Check
 		serial_and_batch_bundle: DF.Link | None
 		serial_no: DF.LongText | None
+		stock_uom: DF.Link | None
 		use_serial_batch_fields: DF.Check
 		valuation_rate: DF.Currency
 		warehouse: DF.Link


### PR DESCRIPTION
fixes #50218

backport of #47299 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Stock UOM" column to Stock Reconciliation Item list view. The field displays the stock unit of measure for each item and is automatically populated based on the item selection.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->