### PR TITLE
fix: add Stock Entry link to Asset Repair doctype.

### DIFF
--- a/erpnext/assets/doctype/asset_repair/asset_repair.json
+++ b/erpnext/assets/doctype/asset_repair/asset_repair.json
@@ -260,8 +260,13 @@
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
- "links": [],
- "modified": "2025-11-04 23:06:43.644846",
+ "links": [
+  {
+   "link_doctype": "Stock Entry",
+   "link_fieldname": "asset_repair"
+  }
+ ],
+ "modified": "2025-11-28 13:04:34.921098",
  "modified_by": "Administrator",
  "module": "Assets",
  "name": "Asset Repair",


### PR DESCRIPTION
Before:
<img width="1889" height="234" alt="image" src="https://github.com/user-attachments/assets/78017a90-a120-40dd-92be-0ee45a7e3b8e" />

After: 
<img width="1912" height="311" alt="image" src="https://github.com/user-attachments/assets/26edfc8d-f859-4ec1-9a8e-6e602e2ab13d" />


closes: https://github.com/frappe/erpnext/issues/50324 (Alternative solution)
closes: https://github.com/frappe/erpnext/issues/48854