### PR TITLE
fix: include accounting dimensions in stock entries created during asset repair.

### DIFF
--- a/erpnext/assets/doctype/asset_repair/asset_repair.js
+++ b/erpnext/assets/doctype/asset_repair/asset_repair.js
@@ -73,14 +73,7 @@ frappe.ui.form.on("Asset Repair", {
 	},
 
 	refresh: function (frm) {
-		if (frm.doc.docstatus) {
-			frm.add_custom_button(__("View General Ledger"), function () {
-				frappe.route_options = {
-					voucher_no: frm.doc.name,
-				};
-				frappe.set_route("query-report", "General Ledger");
-			});
-		}
+		frm.events.show_general_ledger(frm);
 
 		let sbb_field = frm.get_docfield("stock_items", "serial_and_batch_bundle");
 		if (sbb_field) {
@@ -142,6 +135,26 @@ frappe.ui.form.on("Asset Repair", {
 			});
 		} else {
 			frm.set_value("repair_cost", 0);
+		}
+	},
+
+	show_general_ledger: (frm) => {
+		if (frm.doc.docstatus > 0) {
+			frm.add_custom_button(
+				__("Accounting Ledger"),
+				function () {
+					frappe.route_options = {
+						voucher_no: frm.doc.name,
+						from_date: frm.doc.posting_date,
+						to_date: moment(frm.doc.modified).format("YYYY-MM-DD"),
+						company: frm.doc.company,
+						categorize_by: "",
+						show_cancelled_entries: frm.doc.docstatus === 2,
+					};
+					frappe.set_route("query-report", "General Ledger");
+				},
+				__("View")
+			);
 		}
 	},
 });

--- a/erpnext/assets/doctype/asset_repair/asset_repair.py
+++ b/erpnext/assets/doctype/asset_repair/asset_repair.py
@@ -7,6 +7,9 @@ from frappe.query_builder import DocType
 from frappe.utils import cint, flt, get_link_to_form, getdate, time_diff_in_hours
 
 import erpnext
+from erpnext.accounts.doctype.accounting_dimension.accounting_dimension import (
+	get_accounting_dimensions,
+)
 from erpnext.accounts.general_ledger import make_gl_entries
 from erpnext.assets.doctype.asset.asset import get_asset_account
 from erpnext.assets.doctype.asset_activity.asset_activity import add_asset_activity
@@ -231,6 +234,12 @@ class AssetRepair(AccountsController):
 			}
 		)
 
+		accounting_dimensions = {
+			"cost_center": self.cost_center,
+			"project": self.project,
+			**{dimension: self.get(dimension) for dimension in get_accounting_dimensions()},
+		}
+
 		for stock_item in self.get("stock_items"):
 			self.validate_serial_no(stock_item)
 
@@ -242,8 +251,7 @@ class AssetRepair(AccountsController):
 					"qty": stock_item.consumed_quantity,
 					"basic_rate": stock_item.valuation_rate,
 					"serial_and_batch_bundle": stock_item.serial_and_batch_bundle,
-					"cost_center": self.cost_center,
-					"project": self.project,
+					**accounting_dimensions,
 				},
 			)
 


### PR DESCRIPTION
Issue: 
- Accounting dimensions are not copied in the stock entry created from the asset repair.
- Refactored custom button "View General Ledger" to "View -->  Accounting Ledger" for consistency.


closes: https://github.com/frappe/erpnext/issues/48854
