### PR TITLE
fix(payment-recon): add validation for outstanding of dr_cr

### DIFF
--- a/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py
+++ b/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py
@@ -765,6 +765,14 @@ class PaymentReconciliation(Document):
 
 def reconcile_dr_cr_note(dr_cr_notes, company, active_dimensions=None):
 	for inv in dr_cr_notes:
+		if (
+			abs(frappe.db.get_value(inv.voucher_type, inv.voucher_no, "outstanding_amount"))
+			< inv.allocated_amount
+		):
+			frappe.throw(
+				_("{0} has been modified after you pulled it. Please pull it again.").format(inv.voucher_type)
+			)
+
 		voucher_type = "Credit Note" if inv.voucher_type == "Sales Invoice" else "Debit Note"
 
 		reconcile_dr_or_cr = (


### PR DESCRIPTION
**Issue:** JV was created multiple times upon reconciliation of the debit and credit notes.

**Ref:** [54372](https://support.frappe.io/helpdesk/tickets/54372)

**Steps to reproduce:**

- Create a Sales Invoice of ₹1,000 and a separate Sales Return (Credit Note) of ₹500 for the same customer.
- Open Payment Reconciliation for that customer in two separate browser tabs.
- In both tabs, allocate the same two entries (the invoice and the credit note).
- Reconcile one tab first, then reconcile the second tab. The system incorrectly allows the second reconciliation (it should block the second one due to over-allocation).



**Backport Needed: Version-15**