### PR TITLE
fix(accounts-payable-summary): add Show GL Balance check similar to A…

### DIFF
--- a/erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js
+++ b/erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js
@@ -102,6 +102,11 @@ frappe.query_reports["Accounts Payable Summary"] = {
 			label: __("Revaluation Journals"),
 			fieldtype: "Check",
 		},
+		{
+			fieldname: "show_gl_balance",
+			label: __("Show GL Balance"),
+			fieldtype: "Check",
+		},
 	],
 
 	onload: function (report) {


### PR DESCRIPTION
Added the Show GL Balance option to the Accounts Payable Summary report, similar to the implementation in the Accounts Receivable Summary report.
<img width="1680" height="389" alt="Screenshot 2025-11-28 at 5 37 35 PM" src="https://github.com/user-attachments/assets/e2099411-c390-4ee3-9bb6-f70fdd227ce1" />
