### PR TITLE
fix(stock entry): use fg item expense account for direct manufacturing entry

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -577,6 +577,7 @@ class StockEntry(StockController, SubcontractingInwardController):
 						"project": self.project,
 						"uom": item.uom,
 						"s_warehouse": item.s_warehouse,
+						"is_finished_item": item.is_finished_item,
 					}
 				),
 				for_update=True,
@@ -608,6 +609,9 @@ class StockEntry(StockController, SubcontractingInwardController):
 
 			if self.purpose == "Subcontracting Delivery":
 				item.expense_account = frappe.get_value("Company", self.company, "default_expense_account")
+
+			if self.purpose == "Manufacture":
+				item.set("expense_account", item_details.get("expense_account"))
 
 	def validate_fg_completed_qty(self):
 		if self.purpose != "Manufacture":
@@ -2078,7 +2082,9 @@ class StockEntry(StockController, SubcontractingInwardController):
 		if self.purpose == "Material Issue":
 			ret["expense_account"] = item.get("expense_account") or item_group_defaults.get("expense_account")
 
-		if self.purpose == "Manufacture" or not ret.get("expense_account"):
+		if (self.purpose == "Manufacture" and not args.get("is_finished_item")) or not ret.get(
+			"expense_account"
+		):
 			ret["expense_account"] = frappe.get_cached_value(
 				"Company", self.company, "stock_adjustment_account"
 			)

--- a/erpnext/stock/doctype/stock_entry/test_stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/test_stock_entry.py
@@ -1261,6 +1261,7 @@ class TestStockEntry(IntegrationTestCase):
 				frappe._dict(item_code="_Test FG Item", qty=4, t_warehouse="_Test Warehouse 1 - _TC"),
 			],
 		)
+		frappe.db.set_value("Company", "_Test Company", "stock_adjustment_account", "Stock Adjustment - _TC")
 		# SE must have atleast one FG
 		self.assertRaises(FinishedGoodError, se.save)
 
@@ -1277,6 +1278,9 @@ class TestStockEntry(IntegrationTestCase):
 		self.assertEqual(se.items[1].basic_rate, flt(se.items[0].basic_rate / 4))
 		self.assertEqual(se.value_difference, 0.0)
 		self.assertEqual(se.total_incoming_value, se.total_outgoing_value)
+
+		self.assertEqual(se.items[0].expense_account, "Stock Adjustment - _TC")
+		self.assertEqual(se.items[1].expense_account, "_Test Account Cost for Goods Sold - _TC")
 
 	@IntegrationTestCase.change_settings("Stock Settings", {"allow_negative_stock": 0})
 	def test_future_negative_sle(self):


### PR DESCRIPTION
**Issue :**

When creating a Manufacturing Stock Entry directly (without a Work Order), the Finished Good (FG) item currently picks the Company’s `Stock Adjustment Account` as the expense/difference account.

However, if a default expense account is defined in the Item master, the system should consider and use that account for the  FG item, similar to how it behaves when the Manufacturing Entry is created from a **Work Order**.

**Ref :** [#51248](https://support.frappe.io/helpdesk/tickets/51284)


**Before :** 


https://github.com/user-attachments/assets/4a9a9784-3ae1-4322-a7fa-582485e64945



**After :** 


https://github.com/user-attachments/assets/5c6db00b-f3e3-4209-a22f-664cfff2842e


**Backport needed: v15**