### PR TITLE
fix(email campaign): send emails using bcc

### DIFF
--- a/erpnext/crm/doctype/email_campaign/email_campaign.py
+++ b/erpnext/crm/doctype/email_campaign/email_campaign.py
@@ -123,7 +123,7 @@ def send_mail(entry, email_campaign):
 		subject=frappe.render_template(email_template.get("subject"), context),
 		content=frappe.render_template(email_template.response_, context),
 		sender=sender,
-		recipients=recipient_list,
+		bcc=recipient_list,
 		communication_medium="Email",
 		sent_or_received="Sent",
 		send_email=True,


### PR DESCRIPTION
Fixed the issue where Email Campaigns were using recipients to send out emails, which exposed all the other emails addresses that are part of that Email Campaign.

Support Ticket: [#54148](https://support.frappe.io/helpdesk/tickets/54148)

Depends upon: frappe/frappe#34946