### PR TITLE
fix: correct exchange gain loss in ppr

### DIFF
--- a/erpnext/accounts/doctype/process_payment_reconciliation/process_payment_reconciliation.py
+++ b/erpnext/accounts/doctype/process_payment_reconciliation/process_payment_reconciliation.py
@@ -413,7 +413,7 @@ def reconcile(doc: None | str = None) -> None:
 						pr.append("allocation", x)
 
 					# reconcile
-					pr.reconcile_allocations(skip_ref_details_update_for_pe=True)
+					pr.reconcile_allocations()
 
 					# If Payment Entry, update details only for newly linked references
 					# This is for performance


### PR DESCRIPTION
Issue:
Process Payment Reconciliation (PPR) calculates incorrect Exchange Gain/Loss.

References: [#51192](https://support.frappe.io/helpdesk/tickets/51192),  [#54324](https://support.frappe.io/helpdesk/tickets/54324)

 Steps to Reproduce
1. Enable `Allow multi-currency invoices against single party account`.
2. Create a `Purchase Invoice` for USD Exchange Rate 100 Rate 10 USD  Qty 1 Total 10 USD and 1,000 INR  and submit the invoice and credit to the Company Currency Account.
4. Create a `Payment Entry` for the same supplier and the same INR account for `1,000 INR`.
6. Create a `Process Payment Reconciliation (PPR)`.
7. PPR incorrectly recalculates the exchange rate by applying the invoice rate again 100, treating 1,000 INR as 100,000, creating a wrong Exchange Gain/Loss of 99,000 INR.


**PPR**


https://github.com/user-attachments/assets/6412ce4b-218c-4663-88dd-cf078a28d6e4

Backport needed:v15



