### PR TITLE
feat: supplier invoice date in opening invoice creation tool

### DIFF
--- a/erpnext/accounts/doctype/opening_invoice_creation_tool/opening_invoice_creation_tool.py
+++ b/erpnext/accounts/doctype/opening_invoice_creation_tool/opening_invoice_creation_tool.py
@@ -214,6 +214,9 @@ class OpeningInvoiceCreationTool(Document):
 			}
 		)
 
+		if self.invoice_type == "Purchase" and row.supplier_invoice_date:
+			invoice.update({"bill_date": row.supplier_invoice_date})
+
 		accounting_dimension = get_accounting_dimensions()
 		for dimension in accounting_dimension:
 			invoice.update({dimension: self.get(dimension) or item.get(dimension)})

--- a/erpnext/accounts/doctype/opening_invoice_creation_tool_item/opening_invoice_creation_tool_item.json
+++ b/erpnext/accounts/doctype/opening_invoice_creation_tool_item/opening_invoice_creation_tool_item.json
@@ -12,6 +12,7 @@
   "column_break_3",
   "posting_date",
   "due_date",
+  "supplier_invoice_date",
   "section_break_5",
   "item_name",
   "outstanding_amount",
@@ -111,17 +112,24 @@
    "fieldname": "invoice_number",
    "fieldtype": "Data",
    "label": "Invoice Number"
+  },
+  {
+   "depends_on": "eval: parent.invoice_type == \"Purchase\"",
+   "fieldname": "supplier_invoice_date",
+   "fieldtype": "Date",
+   "label": "Supplier Invoice Date"
   }
  ],
  "istable": 1,
  "links": [],
- "modified": "2024-03-27 13:10:06.703006",
+ "modified": "2025-12-01 16:18:07.997594",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Opening Invoice Creation Tool Item",
  "owner": "Administrator",
  "permissions": [],
  "quick_entry": 1,
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],

--- a/erpnext/accounts/doctype/opening_invoice_creation_tool_item/opening_invoice_creation_tool_item.py
+++ b/erpnext/accounts/doctype/opening_invoice_creation_tool_item/opening_invoice_creation_tool_item.py
@@ -26,6 +26,7 @@ class OpeningInvoiceCreationToolItem(Document):
 		party_type: DF.Link | None
 		posting_date: DF.Date | None
 		qty: DF.Data | None
+		supplier_invoice_date: DF.Date | None
 		temporary_opening_account: DF.Link | None
 	# end: auto-generated types
 


### PR DESCRIPTION
<img width="915" height="352" alt="Screenshot 2025-12-01 at 5 57 18 PM" src="https://github.com/user-attachments/assets/1efe44e3-6969-4f2c-80f8-07f2dd7c4dd4" />

closes: https://github.com/frappe/erpnext/issues/41585


`no-docs`