### PR TITLE
feat(accounting-period): add role-based bypass for accounting period restrictions

### DIFF
--- a/erpnext/accounts/doctype/accounting_period/accounting_period.json
+++ b/erpnext/accounts/doctype/accounting_period/accounting_period.json
@@ -12,6 +12,7 @@
   "column_break_4",
   "company",
   "disabled",
+  "exempted_role",
   "section_break_7",
   "closed_documents"
  ],
@@ -67,10 +68,18 @@
    "label": "Closed Documents",
    "options": "Closed Document",
    "reqd": 1
+  },
+  {
+   "description": "Role allowed to bypass period restrictions.",
+   "fieldname": "exempted_role",
+   "fieldtype": "Link",
+   "label": "Exempted Role",
+   "link_filters": "[[\"Role\",\"disabled\",\"=\",0]]",
+   "options": "Role"
   }
  ],
  "links": [],
- "modified": "2025-10-06 15:00:15.568067",
+ "modified": "2025-12-01 16:53:44.631299",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Accounting Period",


### PR DESCRIPTION
Added an exempted role field in the Accounting Period, so if the role is given, that role can bypass the restriction of the Accounting Period.
<img width="1452" height="948" alt="Screenshot 2025-12-01 at 5 35 23 PM" src="https://github.com/user-attachments/assets/39308f14-6930-4247-896d-acddaa2249bd" />

no-docs