### PR TITLE
Validate Product Bundle Negative Stock in POS Invoice

### DIFF
--- a/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
+++ b/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
@@ -23,6 +23,10 @@ from erpnext.stock.doctype.serial_no.serial_no import get_serial_nos
 from erpnext.stock.stock_ledger import is_negative_stock_allowed
 
 
+class ProductBundleStockValidationError(frappe.ValidationError):
+	pass
+
+
 class POSInvoice(SalesInvoice):
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
@@ -434,6 +438,7 @@ class POSInvoice(SalesInvoice):
 								"<br>".join(error_msgs),
 							),
 							title=_("Insufficient Stock for Product Bundle Items"),
+							exc=ProductBundleStockValidationError,
 						)
 
 				else:


### PR DESCRIPTION
**Issue:**
1. While trying to submit the POS Invoice, it is throwing a negative stock error even though the ‘Allow Negative Stock’ checkbox is enabled.

 2. Addresses the UX gaps by surfacing packed item details in negative error popups.
 
Ref: [54016](https://support.frappe.io/helpdesk/tickets/54016?view=VIEW-HD+Ticket-887)

**Before:**

https://github.com/user-attachments/assets/df71c4b0-af0f-4036-912b-a1de626a8dad

**After:**

https://github.com/user-attachments/assets/1e27ccc4-f8b2-4c3a-8580-98ef717a22f0

Backport Needed for v15