### PR TITLE
fix: operation field is incorrectly hidden

### DIFF
--- a/erpnext/manufacturing/doctype/work_order/work_order.js
+++ b/erpnext/manufacturing/doctype/work_order/work_order.js
@@ -240,11 +240,6 @@ frappe.ui.form.on("Work Order", {
 		frm.trigger("add_custom_button_to_return_components");
 		frm.trigger("allow_alternative_item");
 		frm.trigger("hide_reserve_stock_button");
-		frm.trigger("toggle_items_editable");
-	},
-
-	toggle_items_editable(frm) {
-		frm.toggle_enable("required_items", frm.doc.__onload?.allow_editing_items === 1 ? 1 : 0);
 	},
 
 	hide_reserve_stock_button(frm) {

--- a/erpnext/manufacturing/doctype/work_order/work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/work_order.py
@@ -151,7 +151,6 @@ class WorkOrder(Document):
 
 	def onload(self):
 		ms = frappe.get_doc("Manufacturing Settings")
-		self.set_onload("allow_editing_items", ms.allow_editing_of_items_and_quantities_in_work_order)
 		self.set_onload("material_consumption", ms.material_consumption)
 		self.set_onload("backflush_raw_materials_based_on", ms.backflush_raw_materials_based_on)
 		self.set_onload("overproduction_percentage", ms.overproduction_percentage_for_work_order)


### PR DESCRIPTION
When `allow_editing_of_items_and_quantities_in_work_order` is enabled in `Manufacturing Settings`, the table was made read only which caused fields to become incorrectly hidden (like Operation).

By removing it, the table can be edited however it will instead now be reset instead of point-blank read-only.