### PR TITLE
fix(barcode_scanner): set serial and batch before item to prevent FIFO override

### DIFF
--- a/erpnext/public/js/utils/barcode_scanner.js
+++ b/erpnext/public/js/utils/barcode_scanner.js
@@ -138,15 +138,15 @@ erpnext.utils.BarcodeScanner = class BarcodeScanner {
 
 			frappe.run_serially([
 				() => this.set_selector_trigger_flag(data),
-				() =>
-					this.set_item(row, item_code, barcode, batch_no, serial_no).then((qty) => {
-						this.show_scan_message(row.idx, !is_new_row, qty);
-					}),
 				() => this.set_barcode_uom(row, uom),
 				() => this.set_serial_no(row, serial_no),
 				() => this.set_batch_no(row, batch_no),
 				() => this.set_barcode(row, barcode),
 				() => this.set_warehouse(row),
+				() =>
+					this.set_item(row, item_code, barcode, batch_no, serial_no).then((qty) => {
+						this.show_scan_message(row.idx, !is_new_row, qty);
+					}),
 				() => this.clean_up(),
 				() => this.revert_selector_flag(),
 				() => resolve(row),


### PR DESCRIPTION
**Issue :**

When `Auto Create Serial and Batch Bundle for Outward` is enabled in Stock Settings, scanning a single serial number in the Scan Barcode field of a direct Delivery Note incorrectly increments the quantity to 2 and pulls an extra serial number via FIFO.

**Ref :** [#53932](https://support.frappe.io/helpdesk/tickets/53932)

**Before :**


https://github.com/user-attachments/assets/1087d578-1b51-4408-8da1-896a83f01753



**After :**


https://github.com/user-attachments/assets/bb5155ae-61c6-40d9-8afb-66bfd5a0f611



**Backport needed:** v15