### PR TITLE
fix: not able to set operation in work order

### DIFF
--- a/erpnext/manufacturing/doctype/work_order/work_order.js
+++ b/erpnext/manufacturing/doctype/work_order/work_order.js
@@ -244,7 +244,13 @@ frappe.ui.form.on("Work Order", {
 	},
 
 	toggle_items_editable(frm) {
-		frm.toggle_enable("required_items", frm.doc.__onload?.allow_editing_items === 1 ? 1 : 0);
+		if (!frm.doc.__onload?.allow_editing_items) {
+			frm.set_df_property("required_items", "cannot_delete_rows", true);
+			frm.set_df_property("required_items", "cannot_add_rows", true);
+			frm.fields_dict["required_items"].grid.update_docfield_property("item_code", "read_only", 1);
+			frm.fields_dict["required_items"].grid.update_docfield_property("required_qty", "read_only", 1);
+			frm.fields_dict["required_items"].grid.refresh();
+		}
 	},
 
 	hide_reserve_stock_button(frm) {

--- a/erpnext/manufacturing/doctype/work_order_item/work_order_item.json
+++ b/erpnext/manufacturing/doctype/work_order_item/work_order_item.json
@@ -160,7 +160,8 @@
    "fieldname": "stock_uom",
    "fieldtype": "Link",
    "label": "Stock UOM",
-   "options": "UOM"
+   "options": "UOM",
+   "read_only": 1
   },
   {
    "fieldname": "section_break_idhr",
@@ -206,7 +207,7 @@
  "grid_page_length": 50,
  "istable": 1,
  "links": [],
- "modified": "2025-10-12 14:27:16.721532",
+ "modified": "2025-12-02 11:16:05.081613",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "Work Order Item",


### PR DESCRIPTION
**Issue**
When "Allow Editing of Items and Quantities in Work Order" has disabled in the Manufacturing Settings, the required items table gets read only due to which user won't be able to select the operation manually in the work order