### PR TITLE
fix: Reduce asset value on asset capitalization cancelation

### DIFF
--- a/erpnext/assets/doctype/asset_capitalization/asset_capitalization.py
+++ b/erpnext/assets/doctype/asset_capitalization/asset_capitalization.py
@@ -139,6 +139,7 @@ class AssetCapitalization(StockController):
 		self.make_gl_entries()
 		self.repost_future_sle_and_gle()
 		self.restore_consumed_asset_items()
+		self.update_target_asset()
 
 	def set_title(self):
 		self.title = self.target_asset_name or self.target_item_name or self.target_item_code
@@ -607,8 +608,12 @@ class AssetCapitalization(StockController):
 		total_target_asset_value = flt(self.total_value, self.precision("total_value"))
 
 		asset_doc = frappe.get_doc("Asset", self.target_asset)
-		asset_doc.gross_purchase_amount += total_target_asset_value
-		asset_doc.purchase_amount += total_target_asset_value
+		if self.docstatus == 2:
+			asset_doc.gross_purchase_amount -= total_target_asset_value
+			asset_doc.purchase_amount -= total_target_asset_value
+		else:
+			asset_doc.gross_purchase_amount += total_target_asset_value
+			asset_doc.purchase_amount += total_target_asset_value
 		asset_doc.set_status("Work In Progress")
 		asset_doc.flags.ignore_validate = True
 		asset_doc.save()


### PR DESCRIPTION
Fixes https://github.com/frappe/erpnext/issues/50849:

The gross_purchase_amount and the purchase_amount of the asset are increased. But on cancel of the Asset Capitalization, the two values are not decreased anymore, leaving the asset with wrong values and possibly unable to submit if the "unhidden" gross_purchase_amount* is edited manually.

The develop-branch has this issue already addressed: https://github.com/frappe/erpnext/commit/a121c30b56dc9649ddac225389496470a0709a31

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced asset capitalization cancellation workflow to properly adjust target asset values. When a capitalization transaction is cancelled, the asset's purchase amounts are now correctly reversed to accurately reflect the cancellation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->