### PR TITLE
fix: Payment Terms auto-fetched in Sales Invoice Without enabling the (automatically_fetch_payment_terms) in Account settings  (backport #50149)

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -2580,12 +2580,12 @@ class AccountsController(TransactionBase):
 
 	def get_order_details(self):
 		if self.doctype == "Sales Invoice":
-			po_or_so = self.get("items")[0].get("sales_order")
+			po_or_so = self.get("items") and self.get("items")[0].get("sales_order")
 			po_or_so_doctype = "Sales Order"
 			po_or_so_doctype_name = "sales_order"
 
 		else:
-			po_or_so = self.get("items")[0].get("purchase_order")
+			po_or_so = self.get("items") and self.get("items")[0].get("purchase_order")
 			po_or_so_doctype = "Purchase Order"
 			po_or_so_doctype_name = "purchase_order"
 

--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -1203,7 +1203,6 @@ def make_sales_invoice(source_name, target_doc=None, ignore_permissions=False, a
 				"doctype": "Sales Invoice",
 				"field_map": {
 					"party_account_currency": "party_account_currency",
-					"payment_terms_template": "payment_terms_template",
 				},
 				"field_no_map": ["payment_terms_template"],
 				"validation": {"docstatus": ["=", 1]},

--- a/erpnext/selling/doctype/sales_order/test_sales_order.py
+++ b/erpnext/selling/doctype/sales_order/test_sales_order.py
@@ -232,9 +232,7 @@ class TestSalesOrder(AccountsTestMixin, FrappeTestCase):
 		si1 = make_sales_invoice(so.name)
 		self.assertEqual(len(si1.get("items")), 0)
 
-	@change_settings(
-		"Accounts Settings", {"automatically_fetch_payment_terms": 1}
-	)  # Enable auto fetch
+	@change_settings("Accounts Settings", {"automatically_fetch_payment_terms": 1})  # Enable auto fetch
 	def test_auto_fetch_terms_enable(self):
 		so = make_sales_order(do_not_submit=True)
 
@@ -248,9 +246,7 @@ class TestSalesOrder(AccountsTestMixin, FrappeTestCase):
 		si.insert()
 		si.submit()
 
-	@change_settings(
-		"Accounts Settings", {"automatically_fetch_payment_terms": 0}
-	)  # Disable auto fetch
+	@change_settings("Accounts Settings", {"automatically_fetch_payment_terms": 0})  # Disable auto fetch
 	def test_auto_fetch_terms_disable(self):
 		so = make_sales_order(do_not_submit=True)
 

--- a/erpnext/selling/doctype/sales_order/test_sales_order.py
+++ b/erpnext/selling/doctype/sales_order/test_sales_order.py
@@ -202,7 +202,11 @@ class TestSalesOrder(AccountsTestMixin, FrappeTestCase):
 
 	@change_settings(
 		"Accounts Settings",
-		{"add_taxes_from_item_tax_template": 0, "add_taxes_from_taxes_and_charges_template": 1},
+		{
+			"add_taxes_from_item_tax_template": 0,
+			"add_taxes_from_taxes_and_charges_template": 1,
+			"automatically_fetch_payment_terms": 1,
+		},
 	)
 	def test_make_sales_invoice_with_terms(self):
 		so = make_sales_order(do_not_submit=True)

--- a/erpnext/selling/doctype/sales_order/test_sales_order.py
+++ b/erpnext/selling/doctype/sales_order/test_sales_order.py
@@ -200,10 +200,16 @@ class TestSalesOrder(AccountsTestMixin, FrappeTestCase):
 		so.load_from_db()
 		self.assertEqual(so.per_billed, 0)
 
+<<<<<<< HEAD
 	@change_settings(
 		"Accounts Settings",
 		{"add_taxes_from_item_tax_template": 0, "add_taxes_from_taxes_and_charges_template": 1},
 	)
+=======
+	@IntegrationTestCase.change_settings(
+		"Accounts Settings", {"automatically_fetch_payment_terms": 1}
+	)  # Enable auto fetch
+>>>>>>> cf1d892d60 (fix: Payment Terms auto-fetched in Sales Invoice even when automatically_fetch_payment_terms is disabled)
 	def test_make_sales_invoice_with_terms(self):
 		so = make_sales_order(do_not_submit=True)
 
@@ -231,6 +237,38 @@ class TestSalesOrder(AccountsTestMixin, FrappeTestCase):
 
 		si1 = make_sales_invoice(so.name)
 		self.assertEqual(len(si1.get("items")), 0)
+
+	@IntegrationTestCase.change_settings(
+		"Accounts Settings", {"automatically_fetch_payment_terms": 1}
+	)  # Enable auto fetch
+	def test_auto_fetch_terms_enable(self):
+		so = make_sales_order(do_not_submit=True)
+
+		so.payment_terms_template = "_Test Payment Term Template"
+		so.save()
+		so.submit()
+
+		si = make_sales_invoice(so.name)
+		# Check if payment terms are copied from sales order to sales invoice
+		self.assertTrue(si.payment_terms_template)
+		si.insert()
+		si.submit()
+
+	@IntegrationTestCase.change_settings(
+		"Accounts Settings", {"automatically_fetch_payment_terms": 0}
+	)  # Disable auto fetch
+	def test_auto_fetch_terms_disable(self):
+		so = make_sales_order(do_not_submit=True)
+
+		so.payment_terms_template = "_Test Payment Term Template"
+		so.save()
+		so.submit()
+
+		si = make_sales_invoice(so.name)
+		# Check if payment terms are not copied from sales order to sales invoice
+		self.assertFalse(si.payment_terms_template)
+		si.insert()
+		si.submit()
 
 	def test_update_qty(self):
 		so = make_sales_order()

--- a/erpnext/selling/doctype/sales_order/test_sales_order.py
+++ b/erpnext/selling/doctype/sales_order/test_sales_order.py
@@ -200,16 +200,10 @@ class TestSalesOrder(AccountsTestMixin, FrappeTestCase):
 		so.load_from_db()
 		self.assertEqual(so.per_billed, 0)
 
-<<<<<<< HEAD
 	@change_settings(
 		"Accounts Settings",
 		{"add_taxes_from_item_tax_template": 0, "add_taxes_from_taxes_and_charges_template": 1},
 	)
-=======
-	@IntegrationTestCase.change_settings(
-		"Accounts Settings", {"automatically_fetch_payment_terms": 1}
-	)  # Enable auto fetch
->>>>>>> cf1d892d60 (fix: Payment Terms auto-fetched in Sales Invoice even when automatically_fetch_payment_terms is disabled)
 	def test_make_sales_invoice_with_terms(self):
 		so = make_sales_order(do_not_submit=True)
 
@@ -238,7 +232,7 @@ class TestSalesOrder(AccountsTestMixin, FrappeTestCase):
 		si1 = make_sales_invoice(so.name)
 		self.assertEqual(len(si1.get("items")), 0)
 
-	@IntegrationTestCase.change_settings(
+	@change_settings(
 		"Accounts Settings", {"automatically_fetch_payment_terms": 1}
 	)  # Enable auto fetch
 	def test_auto_fetch_terms_enable(self):
@@ -254,7 +248,7 @@ class TestSalesOrder(AccountsTestMixin, FrappeTestCase):
 		si.insert()
 		si.submit()
 
-	@IntegrationTestCase.change_settings(
+	@change_settings(
 		"Accounts Settings", {"automatically_fetch_payment_terms": 0}
 	)  # Disable auto fetch
 	def test_auto_fetch_terms_disable(self):


### PR DESCRIPTION
**issue**: test_make_sales_invoice_with_terms is failing in PR #[50860](https://github.com/frappe/erpnext/pull/50860)

**backport**: version-15-hotfix


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented errors when retrieving order details from invoices or orders with empty or missing item lists.

* **New Features**
  * Payment terms copying now respects the "automatically fetch payment terms" Accounts Setting: when enabled, templates are populated from Sales Orders to Sales Invoices; when disabled, they are not copied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->