### PR TITLE
fix(regional): rename duplicate Customer fields in Italy setup

### DIFF
--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -427,3 +427,4 @@ erpnext.patches.v15_0.toggle_legacy_controller_for_period_closing
 execute:frappe.db.set_single_value("Accounts Settings", "show_party_balance", 1)
 execute:frappe.db.set_single_value("Accounts Settings", "show_account_balance", 1)
 erpnext.patches.v16_0.update_currency_exchange_settings_for_frankfurter
+erpnext.patches.v15_0.rename_italy_customer_name_fields

--- a/erpnext/patches/v15_0/rename_italy_customer_name_fields.py
+++ b/erpnext/patches/v15_0/rename_italy_customer_name_fields.py
@@ -1,0 +1,60 @@
+import frappe
+
+
+def execute():
+	"""Rename Italy regional custom fields to avoid conflict with standard Customer fields.
+
+	The Italy regional setup created custom fields 'first_name' and 'last_name' on Customer
+	which conflict with the standard read-only fields that fetch from customer_primary_contact.
+	This patch renames them to 'italy_customer_first_name' and 'italy_customer_last_name'.
+	"""
+	# Check if old fields exist and are the Italy regional ones
+	old_first_name_exists = frappe.db.exists("Custom Field", "Customer-first_name")
+	old_last_name_exists = frappe.db.exists("Custom Field", "Customer-last_name")
+
+	is_italy_first_name = False
+	is_italy_last_name = False
+
+	if old_first_name_exists:
+		field_doc = frappe.get_doc("Custom Field", "Customer-first_name")
+		is_italy_first_name = field_doc.depends_on and "customer_type" in field_doc.depends_on
+
+	if old_last_name_exists:
+		field_doc = frappe.get_doc("Custom Field", "Customer-last_name")
+		is_italy_last_name = field_doc.depends_on and "customer_type" in field_doc.depends_on
+
+	# If neither field is the Italy regional one, nothing to do
+	if not is_italy_first_name and not is_italy_last_name:
+		return
+
+	# Step 1: Delete old Custom Field documents FIRST (to avoid duplicate field validation error)
+	if is_italy_first_name:
+		frappe.delete_doc("Custom Field", "Customer-first_name", force=True)
+
+	if is_italy_last_name:
+		frappe.delete_doc("Custom Field", "Customer-last_name", force=True)
+
+	# Step 2: Create the new fields
+	from erpnext.regional.italy.setup import make_custom_fields
+	make_custom_fields(update=True)
+
+	# Step 3: Migrate data from old columns to new columns (if old columns still exist in DB)
+	if is_italy_first_name and frappe.db.has_column("Customer", "first_name"):
+		frappe.db.sql("""
+			UPDATE `tabCustomer`
+			SET italy_customer_first_name = first_name
+			WHERE first_name IS NOT NULL AND first_name != ''
+			AND (italy_customer_first_name IS NULL OR italy_customer_first_name = '')
+		""")
+		# Drop old column
+		frappe.db.sql_ddl("ALTER TABLE `tabCustomer` DROP COLUMN `first_name`")
+
+	if is_italy_last_name and frappe.db.has_column("Customer", "last_name"):
+		frappe.db.sql("""
+			UPDATE `tabCustomer`
+			SET italy_customer_last_name = last_name
+			WHERE last_name IS NOT NULL AND last_name != ''
+			AND (italy_customer_last_name IS NULL OR italy_customer_last_name = '')
+		""")
+		# Drop old column
+		frappe.db.sql_ddl("ALTER TABLE `tabCustomer` DROP COLUMN `last_name`")

--- a/erpnext/regional/italy/e-invoice.xml
+++ b/erpnext/regional/italy/e-invoice.xml
@@ -97,8 +97,8 @@
         {%- if doc.customer_data.customer_type == "Individual" %}
           <CodiceFiscale>{{ doc.customer_data.fiscal_code }}</CodiceFiscale>
           <Anagrafica>
-            <Nome>{{ doc.customer_data.first_name }}</Nome>
-            <Cognome>{{ doc.customer_data.last_name }}</Cognome>
+            <Nome>{{ doc.customer_data.italy_customer_first_name }}</Nome>
+            <Cognome>{{ doc.customer_data.italy_customer_last_name }}</Cognome>
           </Anagrafica>
         {%- else %}
           <IdFiscaleIVA>

--- a/erpnext/regional/italy/setup.py
+++ b/erpnext/regional/italy/setup.py
@@ -232,7 +232,7 @@ def make_custom_fields(update=True):
 				depends_on='eval:doc.customer_type=="Company"',
 			),
 			dict(
-				fieldname="first_name",
+				fieldname="italy_customer_first_name",
 				label="First Name",
 				fieldtype="Data",
 				insert_after="salutation",
@@ -240,10 +240,10 @@ def make_custom_fields(update=True):
 				depends_on='eval:doc.customer_type!="Company"',
 			),
 			dict(
-				fieldname="last_name",
+				fieldname="italy_customer_last_name",
 				label="Last Name",
 				fieldtype="Data",
-				insert_after="first_name",
+				insert_after="italy_customer_first_name",
 				print_hide=1,
 				depends_on='eval:doc.customer_type!="Company"',
 			),


### PR DESCRIPTION
The Italy regional setup created custom fields `first_name` and `last_name` on Customer which conflict with the standard read-only fields that fetch from `customer_primary_contact`. This prevented any third-party app from adding custom fields to Customer on Italian installations.

Renamed the fields to:
- `first_name` → `italy_customer_first_name`
- `last_name` → `italy_customer_last_name`

Also includes a migration patch to:
1. Preserve existing data by copying to new fields
2. Remove the old duplicate custom fields and columns

Fixes #50915

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/erpnext/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->
