### PR TITLE
fix: backflush based on for job card

### DIFF
--- a/erpnext/manufacturing/doctype/job_card_item/job_card_item.json
+++ b/erpnext/manufacturing/doctype/job_card_item/job_card_item.json
@@ -17,6 +17,7 @@
   "required_qty",
   "column_break_9",
   "transferred_qty",
+  "consumed_qty",
   "allow_alternative_item"
  ],
  "fields": [
@@ -100,18 +101,26 @@
    "no_copy": 1,
    "print_hide": 1,
    "read_only": 1
+  },
+  {
+   "fieldname": "consumed_qty",
+   "fieldtype": "Float",
+   "label": "Consumed Qty",
+   "no_copy": 1,
+   "read_only": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-03-27 13:09:56.943741",
+ "modified": "2025-12-04 14:30:19.472294",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "Job Card Item",
  "owner": "Administrator",
  "permissions": [],
  "quick_entry": 1,
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],

--- a/erpnext/manufacturing/doctype/job_card_item/job_card_item.py
+++ b/erpnext/manufacturing/doctype/job_card_item/job_card_item.py
@@ -15,6 +15,7 @@ class JobCardItem(Document):
 		from frappe.types import DF
 
 		allow_alternative_item: DF.Check
+		consumed_qty: DF.Float
 		description: DF.Text | None
 		item_code: DF.Link | None
 		item_group: DF.Link | None

--- a/erpnext/stock/doctype/stock_entry/stock_entry.js
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.js
@@ -162,6 +162,11 @@ frappe.ui.form.on("Stock Entry", {
 				};
 			});
 		}
+
+		if (frm.doc.job_card && frm.doc.purpose === "Manufacture") {
+			frm.set_df_property("fg_completed_qty", "read_only", 1);
+			frm.set_df_property("get_items", "hidden", 1);
+		}
 	},
 
 	setup_quality_inspection: function (frm) {

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -1920,6 +1920,7 @@ class StockEntry(StockController, SubcontractingInwardController):
 				job_doc.set_transferred_qty(update_status=True)
 				job_doc.set_transferred_qty_in_job_card_item(self)
 			else:
+				job_doc.set_consumed_qty_in_job_card_item(self)
 				job_doc.set_manufactured_qty()
 
 		if self.work_order:


### PR DESCRIPTION
If backflushing is based on the Material Transfer, then when you make a Manufacture Stock Entry against the Job Card, it should consume the quantities as per the transfer.