### PR TITLE
fix(bulk transaction process): skip records creation if original records are marked 'On Hold' or 'Closed'

### DIFF
--- a/erpnext/utilities/bulk_transaction.py
+++ b/erpnext/utilities/bulk_transaction.py
@@ -19,9 +19,30 @@ def transaction_processing(data, from_doctype, to_doctype, args=None):
 	if isinstance(args, str):
 		args = frappe._dict(json.loads(args))
 
+	skipped_records = [d for d in deserialized_data if d.get("status") in ("On Hold", "Closed")]
+
+	deserialized_data = [d for d in deserialized_data if d.get("status") not in ("On Hold", "Closed")]
+
 	length_of_data = len(deserialized_data)
 
-	frappe.msgprint(_("Started a background job to create {1} {0}").format(to_doctype, length_of_data))
+	skipped_msg = ""
+
+	if skipped_records:
+		skipped_msg = _("{0} creation for the following records will be skipped.").format(to_doctype)
+
+		skipped_msg += (
+			"<br><br><ul>"
+			+ "".join(_("<li>{}</li>").format(frappe.bold(row.get("name"))) for row in skipped_records)
+			+ "</ul>"
+		)
+
+	if not length_of_data:
+		frappe.msgprint(skipped_msg)
+		return
+
+	frappe.msgprint(
+		_("Started a background job to create {1} {0}. {2}").format(to_doctype, length_of_data, skipped_msg)
+	)
 	frappe.enqueue(
 		job,
 		deserialized_data=deserialized_data,


### PR DESCRIPTION
Skip creating bulk transactions when the source documents are marked On Hold or Closed, preventing unintended processing.

<img width="1216" height="434" alt="image" src="https://github.com/user-attachments/assets/b47165d6-ad13-4f99-8130-090f72dc35c7" />

