### PR TITLE
fix: validate available stock with multiple dimensions

### DIFF
--- a/erpnext/stock/doctype/inventory_dimension/test_inventory_dimension.py
+++ b/erpnext/stock/doctype/inventory_dimension/test_inventory_dimension.py
@@ -3,7 +3,7 @@
 
 import frappe
 from frappe.custom.doctype.custom_field.custom_field import create_custom_field
-from frappe.tests import IntegrationTestCase
+from frappe.tests import IntegrationTestCase, change_settings
 from frappe.utils import nowdate, nowtime
 
 from erpnext.stock.doctype.delivery_note.test_delivery_note import create_delivery_note
@@ -497,6 +497,57 @@ class TestInventoryDimension(IntegrationTestCase):
 
 		self.assertEqual(site_name, "Site 1")
 
+	@change_settings("Stock Settings", {"allow_negative_stock": 0})
+	def test_validate_negative_stock_with_multiple_dimension(self):
+		item_code = "Test Negative Multi Inventory Dimension Item"
+		create_item(item_code)
+
+		create_inventory_dimension(
+			apply_to_all_doctypes=1,
+			dimension_name="Inv Site",
+			reference_document="Inv Site",
+			document_type="Inv Site",
+			validate_negative_stock=1,
+		)
+
+		create_inventory_dimension(
+			apply_to_all_doctypes=1,
+			dimension_name="Rack",
+			reference_document="Rack",
+			document_type="Rack",
+			validate_negative_stock=1,
+		)
+
+		pr_doc = make_purchase_receipt(qty=30, do_not_submit=True)
+		pr_doc.items[0].inv_site = "Site 1"
+		pr_doc.items[0].rack = "Rack 1"
+		pr_doc.save()
+		pr_doc.submit()
+
+		pr_doc = make_purchase_receipt(qty=15, do_not_submit=True)
+		pr_doc.items[0].inv_site = "Site 1"
+		pr_doc.items[0].rack = "Rack 2"
+		pr_doc.save()
+		pr_doc.submit()
+
+		pr_doc = make_purchase_receipt(qty=30, do_not_submit=True)
+		pr_doc.items[0].inv_site = "Site 2"
+		pr_doc.items[0].rack = "Rack 1"
+		pr_doc.save()
+		pr_doc.submit()
+
+		pr_doc = make_purchase_receipt(qty=25, do_not_submit=True)
+		pr_doc.items[0].inv_site = "Site 2"
+		pr_doc.items[0].rack = "Rack 2"
+		pr_doc.save()
+		pr_doc.submit()
+
+		dn_doc = create_delivery_note(qty=35, do_not_submit=True)
+		dn_doc.items[0].inv_site = "Site 2"
+		dn_doc.items[0].rack = "Rack 1"
+		dn_doc.save()
+		self.assertRaises(InventoryDimensionNegativeStockError, dn_doc.submit)
+
 
 def get_voucher_sl_entries(voucher_no, fields):
 	return frappe.get_all(
@@ -586,7 +637,7 @@ def prepare_test_data():
 			}
 		).insert(ignore_permissions=True)
 
-	for rack in ["Rack 1"]:
+	for rack in ["Rack 1", "Rack 2"]:
 		if not frappe.db.exists("Rack", rack):
 			frappe.get_doc({"doctype": "Rack", "rack_name": rack}).insert(ignore_permissions=True)
 

--- a/erpnext/stock/doctype/inventory_dimension/test_inventory_dimension.py
+++ b/erpnext/stock/doctype/inventory_dimension/test_inventory_dimension.py
@@ -502,21 +502,23 @@ class TestInventoryDimension(IntegrationTestCase):
 		item_code = "Test Negative Multi Inventory Dimension Item"
 		create_item(item_code)
 
-		create_inventory_dimension(
+		inv_dimension_1 = create_inventory_dimension(
 			apply_to_all_doctypes=1,
 			dimension_name="Inv Site",
 			reference_document="Inv Site",
 			document_type="Inv Site",
 			validate_negative_stock=1,
 		)
+		inv_dimension_1.db_set("validate_negative_stock", 1)
 
-		create_inventory_dimension(
+		inv_dimension_2 = create_inventory_dimension(
 			apply_to_all_doctypes=1,
 			dimension_name="Rack",
 			reference_document="Rack",
 			document_type="Rack",
 			validate_negative_stock=1,
 		)
+		inv_dimension_2.db_set("validate_negative_stock", 1)
 
 		pr_doc = make_purchase_receipt(qty=30, do_not_submit=True)
 		pr_doc.items[0].inv_site = "Site 1"

--- a/erpnext/stock/doctype/inventory_dimension/test_inventory_dimension.py
+++ b/erpnext/stock/doctype/inventory_dimension/test_inventory_dimension.py
@@ -520,31 +520,31 @@ class TestInventoryDimension(IntegrationTestCase):
 		)
 		inv_dimension_2.db_set("validate_negative_stock", 1)
 
-		pr_doc = make_purchase_receipt(qty=30, do_not_submit=True)
+		pr_doc = make_purchase_receipt(item_code=item_code, qty=30, do_not_submit=True)
 		pr_doc.items[0].inv_site = "Site 1"
 		pr_doc.items[0].rack = "Rack 1"
 		pr_doc.save()
 		pr_doc.submit()
 
-		pr_doc = make_purchase_receipt(qty=15, do_not_submit=True)
+		pr_doc = make_purchase_receipt(item_code=item_code, qty=15, do_not_submit=True)
 		pr_doc.items[0].inv_site = "Site 1"
 		pr_doc.items[0].rack = "Rack 2"
 		pr_doc.save()
 		pr_doc.submit()
 
-		pr_doc = make_purchase_receipt(qty=30, do_not_submit=True)
+		pr_doc = make_purchase_receipt(item_code=item_code, qty=30, do_not_submit=True)
 		pr_doc.items[0].inv_site = "Site 2"
 		pr_doc.items[0].rack = "Rack 1"
 		pr_doc.save()
 		pr_doc.submit()
 
-		pr_doc = make_purchase_receipt(qty=25, do_not_submit=True)
+		pr_doc = make_purchase_receipt(item_code=item_code, qty=25, do_not_submit=True)
 		pr_doc.items[0].inv_site = "Site 2"
 		pr_doc.items[0].rack = "Rack 2"
 		pr_doc.save()
 		pr_doc.submit()
 
-		dn_doc = create_delivery_note(qty=35, do_not_submit=True)
+		dn_doc = create_delivery_note(item_code=item_code, qty=35, do_not_submit=True)
 		dn_doc.items[0].inv_site = "Site 2"
 		dn_doc.items[0].rack = "Rack 1"
 		dn_doc.save()


### PR DESCRIPTION
**Issue:**
When a transaction involves multiple inventory dimensions, the system validates available quantity one dimension at a time. As a result, transactions may be allowed to proceed even when the overall quantity is not actually available for the full set of dimensions, causing stock balances to go negative.

**ref:** [54673](https://support.frappe.io/helpdesk/tickets/54673)

**Before:**

https://github.com/user-attachments/assets/e6bc9b95-2166-431c-a3b7-fdb0f35fb1fc


**After:**

https://github.com/user-attachments/assets/3d74f0bb-a2aa-47ca-a1fc-d7f44d9cf90a



**Backport needed for v15**