### PR TITLE
feat: add support for printing batch and serial number barcodes with global print customization

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -112,6 +112,9 @@ class AccountsController(TransactionBase):
 		if taxes_field and taxes_field.fieldtype == "Table":
 			print_setting_fields += ["print_taxes_with_zero_amount"]
 
+		if self.docstatus == 1 and self.doctype in ["Purchase Receipt", "Stock Entry", "Delivery Note", "Purchase Invoice", "Sales Invoice"]:
+			print_setting_fields += ["print_batch_no_barcodes", "print_serial_no_barcodes"]
+
 		return print_setting_fields
 
 	@property

--- a/erpnext/controllers/print_settings.py
+++ b/erpnext/controllers/print_settings.py
@@ -28,6 +28,20 @@ def set_print_templates_for_item_table(doc, settings):
 		] = "templates/print_formats/includes/item_table_description.html"
 		doc.flags.format_columns = format_columns
 
+	if settings.print_batch_no_barcodes:
+		doc.print_templates = {
+			"items": "templates/print_formats/includes/batch_no_barcodes.html",
+		}
+
+	if settings.print_serial_no_barcodes:
+		doc.print_templates = {
+			"items": "templates/print_formats/includes/serial_no_barcodes.html"
+		}
+
+	if settings.print_batch_no_barcodes and settings.print_serial_no_barcodes:
+		doc.print_templates = {
+			"items": "templates/print_formats/includes/serial_and_batch_no_barcodes.html"
+		}
 
 def set_print_templates_for_taxes(doc, settings):
 	doc.flags.show_inclusive_tax_in_print = doc.is_inclusive_tax()

--- a/erpnext/controllers/print_settings.py
+++ b/erpnext/controllers/print_settings.py
@@ -33,12 +33,12 @@ def set_print_templates_for_item_table(doc, settings):
 			"items": "templates/print_formats/includes/batch_no_barcodes.html",
 		}
 
-	if settings.print_serial_no_barcodes:
+	elif settings.print_serial_no_barcodes:
 		doc.print_templates = {
 			"items": "templates/print_formats/includes/serial_no_barcodes.html"
 		}
 
-	if settings.print_batch_no_barcodes and settings.print_serial_no_barcodes:
+	elif settings.print_batch_no_barcodes and settings.print_serial_no_barcodes:
 		doc.print_templates = {
 			"items": "templates/print_formats/includes/serial_and_batch_no_barcodes.html"
 		}

--- a/erpnext/setup/install.py
+++ b/erpnext/setup/install.py
@@ -114,6 +114,20 @@ def create_print_setting_custom_fields():
 					"default": "0",
 					"insert_after": "allow_print_for_cancelled",
 				},
+				{
+					"label": _("Print Batch No barcodes"),
+					"fieldname": "print_batch_no_barcodes",
+					"fieldtype": "Check",
+					"default": "0",
+					"insert_after": "print_uom_after_quantity",
+				},
+				{
+					"label": _("Print Serial No barcodes"),
+					"fieldname": "print_serial_no_barcodes",
+					"fieldtype": "Check",
+					"default": "0",
+					"insert_after": "print_batch_no_barcodes",
+				},
 			]
 		}
 	)

--- a/erpnext/stock/doctype/stock_settings/stock_settings.json
+++ b/erpnext/stock/doctype/stock_settings/stock_settings.json
@@ -53,6 +53,16 @@
   "use_naming_series",
   "column_break_wslv",
   "naming_series_prefix",
+  "serial_and_batch_number_barcode_print_settings_section",
+  "print_serial_or_batch_number_for_barcode",
+  "print_item_name_for_barcode",
+  "print_item_cost_for_barcode",
+  "print_font_for_barcode",
+  "print_font_size_for_barcode",
+  "column_break_lbdm",
+  "print_height_for_barcode",
+  "print_width_for_barcode",
+  "print_barcode_color",
   "stock_reservation_tab",
   "enable_stock_reservation",
   "auto_reserve_stock",
@@ -546,6 +556,67 @@
    "fieldname": "validate_material_transfer_warehouses",
    "fieldtype": "Check",
    "label": "Validate Material Transfer Warehouses"
+  },
+  {
+   "fieldname": "serial_and_batch_number_barcode_print_settings_section",
+   "fieldtype": "Section Break",
+   "label": "Serial and batch number barcode print settings"
+  },
+  {
+   "default": "1",
+   "fieldname": "print_serial_or_batch_number_for_barcode",
+   "fieldtype": "Check",
+   "label": "Print serial or batch number for barcode"
+  },
+  {
+   "default": "0",
+   "fieldname": "print_item_name_for_barcode",
+   "fieldtype": "Check",
+   "label": "Print item name for barcode"
+  },
+  {
+   "default": "0",
+   "fieldname": "print_item_cost_for_barcode",
+   "fieldtype": "Check",
+   "label": "Print item cost for barcode"
+  },
+  {
+   "default": "Helvetica",
+   "fieldname": "print_font_for_barcode",
+   "fieldtype": "Select",
+   "label": "Print font for barcode",
+   "options": "Helvetica\nArial\nVerdana\nsans-serif\nTahoma\nTimes\nConsolas"
+  },
+  {
+   "default": "12",
+   "fieldname": "print_font_size_for_barcode",
+   "fieldtype": "Int",
+   "label": "Print font size for barcode",
+   "non_negative": 1
+  },
+  {
+   "fieldname": "column_break_lbdm",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "40",
+   "fieldname": "print_height_for_barcode",
+   "fieldtype": "Int",
+   "label": "Print height for barcode",
+   "non_negative": 1
+  },
+  {
+   "default": "2",
+   "fieldname": "print_width_for_barcode",
+   "fieldtype": "Int",
+   "label": "Print width for barcode",
+   "non_negative": 1
+  },
+  {
+   "default": "#000000",
+   "fieldname": "print_barcode_color",
+   "fieldtype": "Color",
+   "label": "Print color for barcode"
   }
  ],
  "icon": "icon-cog",
@@ -553,7 +624,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-11-11 11:35:39.864923",
+ "modified": "2025-12-01 18:34:41.608303",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Stock Settings",

--- a/erpnext/stock/doctype/stock_settings/stock_settings.py
+++ b/erpnext/stock/doctype/stock_settings/stock_settings.py
@@ -54,6 +54,14 @@ class StockSettings(Document):
 		over_delivery_receipt_allowance: DF.Float
 		over_picking_allowance: DF.Percent
 		pick_serial_and_batch_based_on: DF.Literal["FIFO", "LIFO", "Expiry"]
+		print_barcode_color: DF.Color | None
+		print_font_for_barcode: DF.Literal["Helvetica", "Arial", "Verdana", "sans-serif", "Tahoma", "Times", "Consolas"]
+		print_font_size_for_barcode: DF.Int
+		print_height_for_barcode: DF.Int
+		print_item_cost_for_barcode: DF.Check
+		print_item_name_for_barcode: DF.Check
+		print_serial_or_batch_number_for_barcode: DF.Check
+		print_width_for_barcode: DF.Int
 		reorder_email_notify: DF.Check
 		role_allowed_to_create_edit_back_dated_transactions: DF.Link | None
 		role_allowed_to_over_deliver_receive: DF.Link | None

--- a/erpnext/templates/print_formats/includes/batch_no_barcodes.html
+++ b/erpnext/templates/print_formats/includes/batch_no_barcodes.html
@@ -1,0 +1,78 @@
+{% set stock_settings = frappe.get_doc("Stock Settings") %}
+
+<style>
+  .barcode-text {
+	font-size: {{ stock_settings.print_font_size_for_barcode }}px;
+	color: {{ stock_settings.print_barcode_color }};
+	font-family: {{ stock_settings.print_font_for_barcode }};
+  }
+</style>
+
+<table class="table table-bordered">
+	<tbody>
+		<tr>
+			<th>No</th>
+			<th>Item Name</th>
+			<th>Batch No Barcodes</th>
+		</tr>
+		{%- for row in doc.items -%}
+			<tr>
+				<td>{{ row.idx }}</td>
+				<td>{{ row.item_name }}</td>
+				<td>
+					{% set bundle_data = frappe.get_all(
+						'Serial and Batch Entry',
+						fields=['batch_no'],
+						filters={'parent': row.serial_and_batch_bundle}
+					) %}
+					{% if bundle_data %}
+						{% for d in bundle_data %}
+							{% if d.batch_no %}
+								<div style="text-align:center; margin-bottom: 10px;">
+
+									{% if stock_settings.print_item_name_for_barcode %}
+										<div class="barcode-text" style="font-weight:600;">
+											{{ row.item_name }}
+										</div>
+									{% endif %}
+
+									{% if stock_settings.print_item_cost_for_barcode %}
+										<div class="barcode-text" style="margin-bottom:4px;">
+											{{ row.rate }} {{ doc.currency }}
+										</div>
+									{% endif %}
+
+									<svg class="batch_no"
+										jsbarcode-value="{{ d.batch_no }}"
+										jsbarcode-text=" "
+										jsbarcode-displayValue="false"
+										jsbarcode-width="{{stock_settings.print_width_for_barcode}}"
+										jsbarcode-height="{{stock_settings.print_height_for_barcode}}"
+										jsbarcode-lineColor="{{stock_settings.print_barcode_color}}"
+									>
+									</svg>
+									{% if stock_settings.print_serial_or_batch_number_for_barcode %}
+										<div class="barcode-text" style="margin-top:4px;">
+											{{ d.batch_no }}
+										</div>
+									{% endif %}
+								</div>
+							{% endif %}
+						{% endfor %}
+					{% else %}
+						<div>
+							Serial and batch bundle not found
+						</div>
+					{% endif %}
+				</td>
+			</tr>
+		{%- endfor -%}
+	</tbody>
+</table>
+
+<script src="https://cdn.jsdelivr.net/npm/jsbarcode@3.11.5/dist/JsBarcode.all.min.js"></script>
+<script>
+  document.addEventListener('DOMContentLoaded', function() {
+	JsBarcode('.batch_no').init();
+  });
+</script>

--- a/erpnext/templates/print_formats/includes/serial_and_batch_no_barcodes.html
+++ b/erpnext/templates/print_formats/includes/serial_and_batch_no_barcodes.html
@@ -1,0 +1,119 @@
+{% set stock_settings = frappe.get_doc("Stock Settings") %}
+
+<style>
+  .barcode-text {
+	font-size: {{ stock_settings.print_font_size_for_barcode }}px;
+	color: {{ stock_settings.print_barcode_color }};
+	font-family: {{ stock_settings.print_font_for_barcode }};
+  }
+</style>
+
+<table class="table table-bordered">
+	<tbody>
+		<tr>
+			<th>No</th>
+			<th>Item Name</th>
+			<th>Batch No Barcodes</th>
+			<th>Serial No Barcodes</th>
+		</tr>
+		{%- for row in doc.items -%}
+			<tr>
+				<td>{{ row.idx }}</td>
+				<td>{{ row.item_name }}</td>
+				{% set bundle_data = frappe.get_all(
+					'Serial and Batch Entry',
+					fields=['batch_no','serial_no'],
+					filters={'parent': row.serial_and_batch_bundle}
+				) %}
+				<td>
+					{% if bundle_data %}
+						{% for d in bundle_data %}
+							{% if d.batch_no %}
+								<div style="text-align:center; margin-bottom: 10px;">
+									{% if stock_settings.print_item_name_for_barcode %}
+										<div class="barcode-text" style="font-weight:600;">
+											{{ row.item_name }}
+										</div>
+									{% endif %}
+
+									{% if stock_settings.print_item_cost_for_barcode %}
+										<div class="barcode-text" style="margin-bottom:4px;">
+											{{ row.rate }} {{ doc.currency }}
+										</div>
+									{% endif %}
+
+									<svg class="batch_no"
+										jsbarcode-value="{{ d.batch_no }}"
+										jsbarcode-text=" "
+										jsbarcode-displayValue="false"
+										jsbarcode-width="{{stock_settings.print_width_for_barcode}}"
+										jsbarcode-height="{{stock_settings.print_height_for_barcode}}"
+										jsbarcode-lineColor="{{stock_settings.print_barcode_color}}"
+									>
+									</svg>
+									{% if stock_settings.print_serial_or_batch_number_for_barcode %}
+										<div class="barcode-text" style="margin-top:4px;">
+											{{ d.batch_no }}
+										</div>
+									{% endif %}
+								</div>
+							{% endif %}
+						{% endfor %}
+					{% else %}
+						<div>
+							Serial and batch bundle not found
+						</div>
+					{% endif %}
+				</td>
+				<td>
+					{% if bundle_data %}
+					{% for d in bundle_data %}
+						{% if d.serial_no %}
+							<div style="text-align:center; margin-bottom: 10px;">
+								{% if stock_settings.print_item_name_for_barcode %}
+									<div class="barcode-text" style="font-weight:600;">
+										{{ row.item_name }}
+									</div>
+								{% endif %}
+
+								{% if stock_settings.print_item_cost_for_barcode %}
+									<div class="barcode-text" style="margin-bottom:4px;">
+										{{ row.rate }} {{ doc.currency }}
+									</div>
+								{% endif %}
+
+								<svg class="serial_no"
+									jsbarcode-value="{{ d.serial_no }}"
+									jsbarcode-text=" "
+									jsbarcode-displayValue="false"
+									jsbarcode-width="{{stock_settings.print_width_for_barcode}}"
+									jsbarcode-height="{{stock_settings.print_height_for_barcode}}"
+									jsbarcode-lineColor="{{stock_settings.print_barcode_color}}"
+								>
+								</svg>
+								{% if stock_settings.print_serial_or_batch_number_for_barcode %}
+									<div class="barcode-text" style="margin-top:4px;">
+										{{ d.serial_no }}
+									</div>
+								{% endif %}
+							</div>
+						{% endif %}
+					{% endfor %}
+					{% else %}
+						<div>
+							Serial and batch bundle not found
+						</div>
+					{% endif %}
+				</td>
+			</tr>
+		{%- endfor -%}
+	</tbody>
+</table>
+
+<script src="https://cdn.jsdelivr.net/npm/jsbarcode@3.11.5/dist/JsBarcode.all.min.js"></script>
+<script>
+	document.addEventListener('DOMContentLoaded', function() {
+		JsBarcode('.batch_no').init();
+		JsBarcode('.serial_no').init();
+	});
+</script>

--- a/erpnext/templates/print_formats/includes/serial_no_barcodes.html
+++ b/erpnext/templates/print_formats/includes/serial_no_barcodes.html
@@ -1,0 +1,78 @@
+{% set stock_settings = frappe.get_doc("Stock Settings") %}
+
+<style>
+  .barcode-text {
+	font-size: {{ stock_settings.print_font_size_for_barcode }}px;
+	color: {{ stock_settings.print_barcode_color }};
+	font-family: {{ stock_settings.print_font_for_barcode }};
+  }
+</style>
+
+<table class="table table-bordered">
+	<tbody>
+		<tr>
+			<th>No</th>
+			<th>Item Name</th>
+			<th>Serial No Barcodes</th>
+		</tr>
+		{%- for row in doc.items -%}
+			<tr>
+				<td>{{ row.idx }}</td>
+				<td>{{ row.item_name }}</td>
+				<td>
+					{% set bundle_data = frappe.get_all(
+						'Serial and Batch Entry',
+						fields=['serial_no'],
+						filters={'parent': row.serial_and_batch_bundle}
+					) %}
+					{% if bundle_data %}
+						{% for d in bundle_data %}
+							{% if d.serial_no %}
+								<div style="text-align:center; margin-bottom: 10px;">
+
+									{% if stock_settings.print_item_name_for_barcode %}
+										<div class="barcode-text" style="font-weight:600;">
+											{{ row.item_name }}
+										</div>
+									{% endif %}
+
+									{% if stock_settings.print_item_cost_for_barcode %}
+										<div class="barcode-text" style="margin-bottom:4px;">
+											{{ row.rate }} {{ doc.currency }}
+										</div>
+									{% endif %}
+
+									<svg class="serial_no"
+										jsbarcode-value="{{ d.serial_no }}"
+										jsbarcode-text=" "
+										jsbarcode-displayValue="false"
+										jsbarcode-width="{{stock_settings.print_width_for_barcode}}"
+										jsbarcode-height="{{stock_settings.print_height_for_barcode}}"
+										jsbarcode-lineColor="{{stock_settings.print_barcode_color}}"
+									>
+									</svg>
+									{% if stock_settings.print_serial_or_batch_number_for_barcode %}
+										<div class="barcode-text" style="margin-top:4px;">
+											{{ d.serial_no }}
+										</div>
+									{% endif %}
+								</div>
+							{% endif %}
+						{% endfor %}
+					{% else %}
+						<div>
+							Serial and batch bundle not found
+						</div>
+					{% endif %}
+				</td>
+			</tr>
+		{%- endfor -%}
+	</tbody>
+</table>
+
+<script src="https://cdn.jsdelivr.net/npm/jsbarcode@3.11.5/dist/JsBarcode.all.min.js"></script>
+<script>
+  document.addEventListener('DOMContentLoaded', function() {
+	JsBarcode('.serial_no').init();
+  });
+</script>


### PR DESCRIPTION
# feat: add support for printing batch and serial number barcodes with global print customization

This PR adds support for printing barcodes for serial and batch numbers, solving the problem where users previously could not print barcodes without creating their own extensions. Print options are added for the following DocTypes:

- Purchase Receipt  
- Stock Entry  
- Delivery Note  
- Purchase Invoice
- Sales Invoice

The barcodes is generated based on the serial and batch bundle field of the respective doctypes.

Barcodes are generated using the [JsBarcode](https://github.com/lindell/JsBarcode) library. In the Print Format Selector, the barcodes appear empty because Jinja generates placeholders and JsBarcode renders them client-side, but they display correctly in full-page preview and when printing.

### Checklist
- [x] Add barcode printing for Purchase Receipt, Stock Entry, Delivery Note  
- [x] Add global customization settings in stock settings 

### Showcase
![Recording 2025-11-20 102419_print_serial_and_barcodes](https://github.com/user-attachments/assets/cb557152-cb9b-4343-b63d-0a5ed450591c)

![Recording 2025-12-01 191025_customizable_stock_settings](https://github.com/user-attachments/assets/a6f01108-cd5c-45df-8c4f-65dc97060e15)

Refined PR based on feedback from #50654

Closes: #50146
