### PR TITLE
fix(asset): prevent creating assets beyond purchased quantity

### DIFF
--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -453,7 +453,7 @@ class Asset(AccountsController):
 		existing_asset_qty = (
 			frappe.qb.from_(Asset)
 			.select(IfNull(Sum(Asset.asset_quantity), 0))
-			.where((Asset.item_code == self.item_code) & (Asset.name != self.name))
+			.where((Asset.item_code == self.item_code) & (Asset.name != self.name) & (Asset.docstatus != 2))
 			.where(asset_filter)
 		).run()[0][0]
 


### PR DESCRIPTION
Adds validation to prevent creating more Asset records than the purchased quantity in linked Purchase Receipt/Invoice.

<img width="1401" height="805" alt="Screenshot 2025-12-05 at 3 06 36 PM" src="https://github.com/user-attachments/assets/992db078-346c-41f8-a543-859d288e5fff" />


Closes: https://github.com/frappe/erpnext/issues/40851