### PR TITLE
fix(sales invoice): 100% additional discount gl issue with discount accounting

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -1625,7 +1625,11 @@ class SalesInvoice(SellingController):
 		)
 
 		for item in self.get("items"):
-			if flt(item.base_net_amount, item.precision("base_net_amount")) or item.is_fixed_asset:
+			if (
+				flt(item.base_net_amount, item.precision("base_net_amount"))
+				or item.is_fixed_asset
+				or enable_discount_accounting
+			):
 				# Do not book income for transfer within same company
 				if self.is_internal_transfer():
 					continue


### PR DESCRIPTION
Fixed the issue with the Sales Invoice, where if a 100% additional discount was added with Discount Accounting Enabled, an error of "Incorrect number of GL Entries found" was encountered.