### PR TITLE
fix: include return invoice discount in discount validation

### DIFF
--- a/erpnext/controllers/taxes_and_totals.py
+++ b/erpnext/controllers/taxes_and_totals.py
@@ -7,6 +7,7 @@ import json
 import frappe
 from frappe import _, scrub
 from frappe.model.document import Document, bulk_insert
+from frappe.query_builder import functions
 from frappe.utils import cint, flt, round_based_on_smallest_currency_fraction
 
 import erpnext
@@ -775,6 +776,22 @@ class calculate_taxes_and_totals:
 
 		discount_amount = self.doc.discount_amount or 0
 		grand_total = self.doc.grand_total
+
+		if self.doc.get("is_return") and self.doc.get("return_against"):
+			doctype = frappe.qb.DocType(self.doc.doctype)
+
+			result = (
+				frappe.qb.from_(doctype)
+				.select(functions.Sum(doctype.discount_amount).as_("total_return_discount"))
+				.where(
+					(doctype.return_against == self.doc.return_against)
+					& (doctype.is_return == 1)
+					& (doctype.docstatus == 1)
+				)
+			).run(as_dict=True)
+
+			total_return_discount = abs(result[0].get("total_return_discount") or 0)
+			discount_amount += total_return_discount
 
 		# validate that discount amount cannot exceed the total before discount
 		if (


### PR DESCRIPTION
Issue:
The discount amount is calculated incorrectly when multiple partial return invoices (Credit Notes) are created against the same Sales Invoice.

Ref: [#54655](https://support.frappe.io/helpdesk/tickets/54655)

Steps to reproduce:

1. Create a Sales Invoice with Qty 10, Rate 80, the Net Total becomes 8000, Apply an additional discount on the net total of 6000, Save and submit the invoice.

2. Create the first Credit Note against this Sales Invoice, Qty 9, Total 7200, Apply a discount of 5400, Save and submit it.

3. Try to create the second Credit Note for the remaining quantity, but it throws an Invalid Discount Amount.

<img width="584" height="138" alt="image" src="https://github.com/user-attachments/assets/4a334421-f92c-49db-8c11-9a1a951ae199" />

