### PR TITLE
fix(stock): remove total bar in chart view

### DIFF
--- a/erpnext/stock/report/delivery_note_trends/delivery_note_trends.py
+++ b/erpnext/stock/report/delivery_note_trends/delivery_note_trends.py
@@ -20,6 +20,9 @@ def execute(filters=None):
 
 
 def get_chart_data(data, filters):
+	def wrap_in_quotes(label):
+		return f"'{label}'"
+
 	if not data:
 		return []
 
@@ -36,6 +39,9 @@ def get_chart_data(data, filters):
 		data = data[:10]
 
 	for row in data:
+		if row[0] == wrap_in_quotes(_("Total")):
+			continue
+
 		labels.append(row[0])
 		datapoints.append(row[-1])
 


### PR DESCRIPTION
**Issue:**
The report is displaying an unintended "Total" bar chart, which is not required and is distorting the overall visualization.

**Ref:** [#54915](https://support.frappe.io/helpdesk/tickets/54915)

**Before:**
<img width="1843" height="732" alt="image" src="https://github.com/user-attachments/assets/9e70e115-ec13-4082-94fd-49ee3ecdf289" />

**After:**
<img width="1843" height="732" alt="image" src="https://github.com/user-attachments/assets/ffb4fe78-4f1b-46d9-bd53-0dbb370ac438" />

Backport Needed for v14 & v15.
