### PR TITLE
fix: precision issue on job card submission

### DIFF
--- a/erpnext/manufacturing/doctype/work_order/work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/work_order.py
@@ -1326,14 +1326,14 @@ class WorkOrder(Document):
 
 		for d in self.get("operations"):
 			precision = d.precision("completed_qty")
-			qty = flt(d.completed_qty, precision) + flt(d.process_loss_qty, precision)
+			qty = flt(flt(d.completed_qty, precision) + flt(d.process_loss_qty, precision), precision)
 			if not qty:
 				d.status = "Pending"
-			elif flt(qty) < flt(self.qty):
+			elif qty < flt(self.qty, precision):
 				d.status = "Work in Progress"
-			elif flt(qty) == flt(self.qty):
+			elif qty == flt(self.qty, precision):
 				d.status = "Completed"
-			elif flt(qty) <= max_allowed_qty_for_wo:
+			elif qty <= flt(max_allowed_qty_for_wo, precision):
 				d.status = "Completed"
 			else:
 				frappe.throw(_("Completed Qty cannot be greater than 'Qty to Manufacture'"))


### PR DESCRIPTION
Issue: precision loss in qty (decimal value greater than 5 digits) was causing an error while trying to submit Job Card
Ref: https://support.frappe.io/helpdesk/my-tickets/54916
Backport needed for v15

Before:
<img width="1920" height="1106" alt="imagea03f1a" src="https://github.com/user-attachments/assets/e1cc2fde-1386-405e-87d8-9e7ea9930587" />

After:
No error