### PR TITLE
fix: sanitize address display by stripping HTML tags using html2text

### DIFF
--- a/erpnext/public/js/utils/party.js
+++ b/erpnext/public/js/utils/party.js
@@ -156,7 +156,7 @@ erpnext.utils.get_address_display = function (frm, address_field, display_field,
 			args: { address_dict: frm.doc[address_field] },
 			callback: function (r) {
 				if (r.message) {
-					frm.set_value(display_field, r.message);
+					frm.set_value(display_field, frappe.utils.html2text(r.message));
 				}
 			},
 		});

--- a/erpnext/public/js/utils/sales_common.js
+++ b/erpnext/public/js/utils/sales_common.js
@@ -410,7 +410,10 @@ erpnext.sales_common = {
 						args: { address_dict: this.frm.doc.company_address },
 						callback: function (r) {
 							if (r.message) {
-								me.frm.set_value("company_address_display", r.message);
+								me.frm.set_value(
+									"company_address_display",
+									frappe.utils.html2text(r.message)
+								);
 							}
 						},
 					});

--- a/erpnext/selling/doctype/customer/customer.js
+++ b/erpnext/selling/doctype/customer/customer.js
@@ -116,7 +116,7 @@ frappe.ui.form.on("Customer", {
 					address_dict: frm.doc.customer_primary_address,
 				},
 				callback: function (r) {
-					frm.set_value("primary_address", r.message);
+					frm.set_value("primary_address", frappe.utils.html2text(r.message));
 				},
 			});
 		}

--- a/erpnext/stock/doctype/delivery_trip/delivery_trip.js
+++ b/erpnext/stock/doctype/delivery_trip/delivery_trip.js
@@ -208,7 +208,12 @@ frappe.ui.form.on("Delivery Stop", {
 				args: { address_dict: row.address },
 				callback: function (r) {
 					if (r.message) {
-						frappe.model.set_value(cdt, cdn, "customer_address", r.message);
+						frappe.model.set_value(
+							cdt,
+							cdn,
+							"customer_address",
+							frappe.utils.html2text(r.message)
+						);
 					}
 				},
 			});


### PR DESCRIPTION
**Issue :** 
Primary Address shows line break html tags on Customer master "Address & Contact" tab

Fixed : [#50951](https://github.com/frappe/erpnext/issues/50951)

**Before :** 

<img width="1366" height="700" alt="image" src="https://github.com/user-attachments/assets/a5786a38-4941-47c9-b359-0177a96643ce" />

**After :**

<img width="1366" height="700" alt="image" src="https://github.com/user-attachments/assets/1d8c77d3-3c1f-4c7d-bf40-c0f9177e97f1" />
