### PR TITLE
fix(work order): prevent status mismatch due to float precision

### DIFF
--- a/erpnext/manufacturing/doctype/work_order/work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/work_order.py
@@ -1326,14 +1326,14 @@ class WorkOrder(Document):
 
 		for d in self.get("operations"):
 			precision = d.precision("completed_qty")
-			qty = flt(d.completed_qty, precision) + flt(d.process_loss_qty, precision)
+			qty = flt(flt(d.completed_qty, precision) + flt(d.process_loss_qty, precision), precision)
 			if not qty:
 				d.status = "Pending"
-			elif flt(qty) < flt(self.qty):
+			elif qty < flt(self.qty, precision):
 				d.status = "Work in Progress"
-			elif flt(qty) == flt(self.qty):
+			elif qty == flt(self.qty, precision):
 				d.status = "Completed"
-			elif flt(qty) <= max_allowed_qty_for_wo:
+			elif qty <= flt(max_allowed_qty_for_wo, precision):
 				d.status = "Completed"
 			else:
 				frappe.throw(_("Completed Qty cannot be greater than 'Qty to Manufacture'"))


### PR DESCRIPTION
**Issue :**

While updating the operation status in a **Work Order**, summing `completed_qty` and `process_loss_qty` resulted in an incorrectly precise value (e.g., 0.30000000000000004 instead of 0.3). This float precision mismatch causes a validation error (Completed Qty cannot be greater than 'Qty to Manufacture') while submitting the document


**Ref :** [#54916](https://support.frappe.io/helpdesk/my-tickets/54916)

**Before :**

https://github.com/user-attachments/assets/0157887b-64ac-489d-b678-c377b55e6b6d




**After :**



https://github.com/user-attachments/assets/5a265c58-e3f4-48fc-9fa8-02e3aa242e17


**Backport Needed : v15**

