### PR TITLE
fix: warning message to avoid serial no series overlap issue

### DIFF
--- a/erpnext/stock/serial_batch_bundle.py
+++ b/erpnext/stock/serial_batch_bundle.py
@@ -1432,7 +1432,18 @@ class SerialBatchCreation:
 				"batch_no",
 			]
 
-			frappe.db.bulk_insert("Serial No", fields=fields, values=set(serial_nos_details))
+			try:
+				frappe.db.bulk_insert("Serial No", fields=fields, values=set(serial_nos_details))
+			except Exception as e:
+				if e and len(e.args) > 1 and "Duplicate" in e.args[1]:
+					frappe.throw(
+						_(
+							"A naming series conflict occurred while creating serial numbers. Please change the naming series for the item {0}."
+						).format(bold(self.item_code)),
+						title=_("Duplicate Serial Number Error"),
+					)
+				else:
+					raise e
 
 		obj.update_counter(current_value)
 


### PR DESCRIPTION

<img width="891" height="467" alt="Screenshot 2025-12-08 at 1 45 28 PM" src="https://github.com/user-attachments/assets/6d27abf2-d326-4d71-9bd0-11bf84ea77de" />


Fixed https://github.com/frappe/erpnext/issues/50829