### PR TITLE
fix(payment_entry): add due date to payment reference rows

### DIFF
--- a/erpnext/accounts/doctype/payment_entry_reference/payment_entry_reference.json
+++ b/erpnext/accounts/doctype/payment_entry_reference/payment_entry_reference.json
@@ -38,7 +38,7 @@
    "search_index": 1
   },
   {
-   "columns": 2,
+   "columns": 4,
    "fieldname": "reference_name",
    "fieldtype": "Dynamic Link",
    "in_global_search": 1,
@@ -49,8 +49,10 @@
    "search_index": 1
   },
   {
+   "columns": 2,
    "fieldname": "due_date",
    "fieldtype": "Date",
+   "in_list_view": 1,
    "label": "Due Date",
    "read_only": 1
   },
@@ -174,7 +176,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-07-25 04:32:11.040025",
+ "modified": "2025-12-08 13:57:30.098239",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Payment Entry Reference",


### PR DESCRIPTION
Added the due date in the list view for the child table payment reference in the payment entry.

<img width="1847" height="737" alt="Screenshot 2025-12-08 at 2 19 11 PM" src="https://github.com/user-attachments/assets/8b0b6274-52f3-4713-bda5-811c4ac9d94c" />
