### PR TITLE
fix(asset): prorata daily depr amount calculation

### DIFF
--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -1571,11 +1571,9 @@ def get_straight_line_or_manual_depr_amount(asset, row, schedule_idx, number_of_
 
 			return daily_depr_amount * (date_diff(to_date, from_date) + 1)
 		else:
-			return (
-				flt(asset.gross_purchase_amount)
-				- flt(asset.opening_accumulated_depreciation)
-				- flt(row.expected_value_after_useful_life)
-			) / flt(row.total_number_of_depreciations - asset.number_of_depreciations_booked)
+			return (flt(asset.gross_purchase_amount) - flt(row.expected_value_after_useful_life)) / flt(
+				row.total_number_of_depreciations
+			)
 
 
 def get_shift_depr_amount(asset, row, schedule_idx):

--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -1532,11 +1532,7 @@ def get_straight_line_or_manual_depr_amount(asset, row, schedule_idx, number_of_
 	# if the Depreciation Schedule is being prepared for the first time
 	else:
 		if row.daily_prorata_based:
-			amount = (
-				flt(asset.gross_purchase_amount)
-				- flt(asset.opening_accumulated_depreciation)
-				- flt(row.expected_value_after_useful_life)
-			)
+			amount = flt(asset.gross_purchase_amount) - flt(row.expected_value_after_useful_life)
 			total_days = (
 				date_diff(
 					get_last_day(
@@ -1548,7 +1544,11 @@ def get_straight_line_or_manual_depr_amount(asset, row, schedule_idx, number_of_
 					),
 					add_days(
 						get_last_day(
-							add_months(row.depreciation_start_date, -1 * row.frequency_of_depreciation)
+							add_months(
+								row.depreciation_start_date,
+								(row.frequency_of_depreciation * (asset.number_of_depreciations_booked + 1))
+								* -1,
+							),
 						),
 						1,
 					),

--- a/erpnext/assets/doctype/asset/test_asset.py
+++ b/erpnext/assets/doctype/asset/test_asset.py
@@ -660,7 +660,7 @@ class TestDepreciationMethods(AssetSetup):
 			available_for_use_date="2030-06-06",
 			is_existing_asset=1,
 			number_of_depreciations_booked=2,
-			opening_accumulated_depreciation=47095.89,
+			opening_accumulated_depreciation=47178.08,
 			expected_value_after_useful_life=10000,
 			depreciation_start_date="2032-12-31",
 			total_number_of_depreciations=3,
@@ -668,7 +668,7 @@ class TestDepreciationMethods(AssetSetup):
 		)
 
 		self.assertEqual(asset.status, "Draft")
-		expected_schedules = [["2032-12-31", 42904.11, 90000.0]]
+		expected_schedules = [["2032-12-31", 30000.0, 77178.08], ["2033-06-06", 12821.92, 90000.0]]
 		schedules = [
 			[cstr(d.schedule_date), flt(d.depreciation_amount, 2), d.accumulated_depreciation_amount]
 			for d in asset.get("schedules")


### PR DESCRIPTION
Issue: When an asset is created with both Opening Accumulated Depreciation and Number of Depreciations Booked, and if the asset requires prorata depreciation with depreciation method as Straight Line, the system calculates an unexpected per-day depreciation amount. This affects the depreciation amount of each schedules.

Ref: [54615](https://support.frappe.io/helpdesk/tickets/54615)

Asset Config:
<img width="2206" height="1474" alt="image" src="https://github.com/user-attachments/assets/1a8dff33-1085-4956-a085-e65139da311a" />

Before:
<img width="1048" height="1202" alt="image" src="https://github.com/user-attachments/assets/95a190db-bd70-4b04-9b33-ea998eb960af" />

After:
<img width="1048" height="1202" alt="Screenshot 2025-12-08 at 14 11 40" src="https://github.com/user-attachments/assets/afee9400-f284-41af-ae1e-6e9e74d7fcb9" />

Supporting Calculation:
<img width="1048" height="1202" alt="Screenshot 2025-12-08 at 14 16 32" src="https://github.com/user-attachments/assets/9a8da1f2-5eed-4bb2-a1db-8f412aca3bf2" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed depreciation calculations to avoid double-counting opening accumulated depreciation in first and final prorated entries; corrected date-offset logic so first-entry booking aligns with actual booking counts.
* **Tests**
  * Updated expected depreciation schedule to reflect split prorated entries and revised opening accumulated depreciation in tests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->