### PR TITLE
feat(sales_order, purchase_order): add bulk close and reopen actions in list view

### DIFF
--- a/erpnext/buying/doctype/purchase_order/purchase_order_list.js
+++ b/erpnext/buying/doctype/purchase_order/purchase_order_list.js
@@ -51,11 +51,11 @@ frappe.listview_settings["Purchase Order"] = {
 	onload: function (listview) {
 		var method = "erpnext.buying.doctype.purchase_order.purchase_order.close_or_unclose_purchase_orders";
 
-		listview.page.add_menu_item(__("Close"), function () {
+		listview.page.add_action_item(__("Close"), function () {
 			listview.call_for_selected_items(method, { status: "Closed" });
 		});
 
-		listview.page.add_menu_item(__("Reopen"), function () {
+		listview.page.add_action_item(__("Reopen"), function () {
 			listview.call_for_selected_items(method, { status: "Submitted" });
 		});
 

--- a/erpnext/selling/doctype/sales_order/sales_order_list.js
+++ b/erpnext/selling/doctype/sales_order/sales_order_list.js
@@ -63,11 +63,11 @@ frappe.listview_settings["Sales Order"] = {
 	onload: function (listview) {
 		var method = "erpnext.selling.doctype.sales_order.sales_order.close_or_unclose_sales_orders";
 
-		listview.page.add_menu_item(__("Close"), function () {
+		listview.page.add_action_item(__("Close"), function () {
 			listview.call_for_selected_items(method, { status: "Closed" });
 		});
 
-		listview.page.add_menu_item(__("Re-open"), function () {
+		listview.page.add_action_item(__("Re-open"), function () {
 			listview.call_for_selected_items(method, { status: "Submitted" });
 		});
 


### PR DESCRIPTION
added the action for close and reopen of bulk entries from the list view 

<img width="1905" height="581" alt="Screenshot 2025-12-08 at 5 29 21 PM" src="https://github.com/user-attachments/assets/a1695ee9-6ca0-4cd9-beb6-9da3cb493a54" />

REF: #[49740](https://github.com/frappe/erpnext/issues/49740) 

no-docs