### PR TITLE
fix: ensure payment request button only shows for submitted invoices

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js
@@ -130,7 +130,7 @@ erpnext.accounts.PurchaseInvoice = class PurchaseInvoice extends erpnext.buying.
 			}
 		}
 
-		if (doc.outstanding_amount > 0 && !cint(doc.is_return) && !doc.on_hold) {
+		if (doc.docstatus == 1 && doc.outstanding_amount > 0 && !cint(doc.is_return) && !doc.on_hold) {
 			this.frm.add_custom_button(
 				__("Payment Request"),
 				function () {


### PR DESCRIPTION
### Before

<img width="1866" height="492" alt="image_2025-12-08_18-52-25" src="https://github.com/user-attachments/assets/1df5f642-549b-49df-b2f6-c55640f96fbc" />


### After

<img width="1866" height="673" alt="image_2025-12-08_18-51-14" src="https://github.com/user-attachments/assets/78be2866-d3ce-4d88-ad87-570797685b24" />
