### PR TITLE
feat: update item button addition for quotation

### DIFF
--- a/erpnext/buying/doctype/supplier_quotation/supplier_quotation.js
+++ b/erpnext/buying/doctype/supplier_quotation/supplier_quotation.js
@@ -32,6 +32,13 @@ erpnext.buying.SupplierQuotationController = class SupplierQuotationController e
 				this.make_purchase_order.bind(this),
 				__("Create")
 			);
+			this.frm.add_custom_button(__("Update Items"), () => {
+				erpnext.utils.update_child_items({
+					frm: this.frm,
+					child_docname: "items",
+					cannot_add_row: false,
+				});
+			});
 			this.frm.page.set_inner_btn_group_as_primary(__("Create"));
 			this.frm.add_custom_button(__("Quotation"), this.make_quotation.bind(this), __("Create"));
 		} else if (this.frm.doc.docstatus === 0) {

--- a/erpnext/buying/doctype/supplier_quotation/supplier_quotation.py
+++ b/erpnext/buying/doctype/supplier_quotation/supplier_quotation.py
@@ -347,3 +347,15 @@ def set_expired_status():
 		""",
 		(nowdate()),
 	)
+
+
+def get_purchased_items(supplier_quotation: str):
+	return frappe._dict(
+		frappe.get_all(
+			"Purchase Order Item",
+			filters={"supplier_quotation": supplier_quotation, "docstatus": 1},
+			fields=["supplier_quotation_item", {"SUM": "qty"}],
+			group_by="supplier_quotation_item",
+			as_list=1,
+		)
+	)

--- a/erpnext/buying/doctype/supplier_quotation/test_supplier_quotation.py
+++ b/erpnext/buying/doctype/supplier_quotation/test_supplier_quotation.py
@@ -2,15 +2,113 @@
 # License: GNU General Public License v3. See license.txt
 
 
+import json
+
 import frappe
 from frappe.tests import IntegrationTestCase, change_settings
 from frappe.utils import add_days, today
 
 from erpnext.buying.doctype.supplier_quotation.supplier_quotation import make_purchase_order
-from erpnext.controllers.accounts_controller import InvalidQtyError
+from erpnext.controllers.accounts_controller import InvalidQtyError, update_child_qty_rate
 
 
 class TestPurchaseOrder(IntegrationTestCase):
+	def test_update_child_supplier_quotation_add_item(self):
+		sq = frappe.copy_doc(self.globalTestRecords["Supplier Quotation"][0])
+		sq.submit()
+
+		trans_item = json.dumps(
+			[
+				{
+					"item_code": sq.items[0].item_code,
+					"rate": sq.items[0].rate,
+					"qty": 5,
+					"docname": sq.items[0].name,
+				},
+				{
+					"item_code": "_Test Item 2",
+					"rate": 300,
+					"qty": 3,
+				},
+			]
+		)
+		update_child_qty_rate("Supplier Quotation", trans_item, sq.name)
+		sq.reload()
+		self.assertEqual(sq.get("items")[0].qty, 5)
+		self.assertEqual(sq.get("items")[1].rate, 300)
+
+	def test_update_supplier_quotation_child_rate_disallow(self):
+		sq = frappe.copy_doc(self.globalTestRecords["Supplier Quotation"][0])
+		sq.submit()
+		trans_item = json.dumps(
+			[
+				{
+					"item_code": sq.items[0].item_code,
+					"rate": 300,
+					"qty": sq.items[0].qty,
+					"docname": sq.items[0].name,
+				},
+			]
+		)
+		self.assertRaises(
+			frappe.ValidationError, update_child_qty_rate, "Supplier Quotation", trans_item, sq.name
+		)
+
+	def test_update_supplier_quotation_child_remove_item(self):
+		sq = frappe.copy_doc(self.globalTestRecords["Supplier Quotation"][0])
+		sq.submit()
+		po = make_purchase_order(sq.name)
+
+		trans_item = json.dumps(
+			[
+				{
+					"item_code": sq.items[0].item_code,
+					"rate": sq.items[0].rate,
+					"qty": sq.items[0].qty,
+					"docname": sq.items[0].name,
+				},
+				{
+					"item_code": "_Test Item 2",
+					"rate": 300,
+					"qty": 3,
+				},
+			]
+		)
+		po.get("items")[0].schedule_date = add_days(today(), 1)
+		update_child_qty_rate("Supplier Quotation", trans_item, sq.name)
+		po.submit()
+		sq.reload()
+
+		trans_item = json.dumps(
+			[
+				{
+					"item_code": "_Test Item 2",
+					"rate": 300,
+					"qty": 3,
+				}
+			]
+		)
+
+		# check if item having purchase order can be removed
+		self.assertRaises(
+			frappe.LinkExistsError, update_child_qty_rate, "Supplier Quotation", trans_item, sq.name
+		)
+
+		trans_item = json.dumps(
+			[
+				{
+					"item_code": sq.items[0].item_code,
+					"rate": sq.items[0].rate,
+					"qty": sq.items[0].qty,
+					"docname": sq.items[0].name,
+				}
+			]
+		)
+
+		update_child_qty_rate("Supplier Quotation", trans_item, sq.name)
+		sq.reload()
+		# self.assertEqual(len(sq.get("items")),1)
+
 	def test_supplier_quotation_qty(self):
 		sq = frappe.copy_doc(self.globalTestRecords["Supplier Quotation"][0])
 		sq.items[0].qty = 0

--- a/erpnext/buying/doctype/supplier_quotation/test_supplier_quotation.py
+++ b/erpnext/buying/doctype/supplier_quotation/test_supplier_quotation.py
@@ -89,10 +89,12 @@ class TestPurchaseOrder(IntegrationTestCase):
 			]
 		)
 
+		frappe.db.savepoint("before_cancel")
 		# check if item having purchase order can be removed
 		self.assertRaises(
 			frappe.LinkExistsError, update_child_qty_rate, "Supplier Quotation", trans_item, sq.name
 		)
+		frappe.db.rollback(save_point="before_cancel")
 
 		trans_item = json.dumps(
 			[
@@ -107,7 +109,7 @@ class TestPurchaseOrder(IntegrationTestCase):
 
 		update_child_qty_rate("Supplier Quotation", trans_item, sq.name)
 		sq.reload()
-		# self.assertEqual(len(sq.get("items")),1)
+		self.assertEqual(len(sq.get("items")), 1)
 
 	def test_supplier_quotation_qty(self):
 		sq = frappe.copy_doc(self.globalTestRecords["Supplier Quotation"][0])

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -3704,7 +3704,7 @@ def set_order_defaults(parent_doctype, parent_doctype_name, child_doctype, child
 	return child_item
 
 
-def validate_child_on_delete(row, parent):
+def validate_child_on_delete(row, parent, ordered_item=None):
 	"""Check if partially transacted item (row) is being deleted."""
 	if parent.doctype == "Sales Order":
 		if flt(row.delivered_qty):
@@ -3732,13 +3732,17 @@ def validate_child_on_delete(row, parent):
 				row.idx, row.item_code
 			)
 		)
-
-	if flt(row.billed_amt):
-		frappe.throw(
-			_("Row #{0}: Cannot delete item {1} which has already been billed.").format(
-				row.idx, row.item_code
+	if parent.doctype in ["Purchase Order", "Sales Order"]:
+		if flt(row.billed_amt):
+			frappe.throw(
+				_("Row #{0}: Cannot delete item {1} which has already been billed.").format(
+					row.idx, row.item_code
+				)
 			)
-		)
+
+	if parent.doctype == "Quotation":
+		if ordered_item.get(row.name):
+			frappe.throw(_("Cannot delete an item which has been ordered"))
 
 
 def update_bin_on_delete(row, doctype):
@@ -3764,7 +3768,7 @@ def update_bin_on_delete(row, doctype):
 		update_bin_qty(row.item_code, row.warehouse, qty_dict)
 
 
-def validate_and_delete_children(parent, data) -> bool:
+def validate_and_delete_children(parent, data, ordered_item=None) -> bool:
 	deleted_children = []
 	updated_item_names = [d.get("docname") for d in data]
 	for item in parent.items:
@@ -3772,7 +3776,7 @@ def validate_and_delete_children(parent, data) -> bool:
 			deleted_children.append(item)
 
 	for d in deleted_children:
-		validate_child_on_delete(d, parent)
+		validate_child_on_delete(d, parent, ordered_item)
 		d.cancel()
 		d.delete()
 
@@ -3781,16 +3785,18 @@ def validate_and_delete_children(parent, data) -> bool:
 
 	# need to update ordered qty in Material Request first
 	# bin uses Material Request Items to recalculate & update
-	parent.update_prevdoc_status()
-
-	for d in deleted_children:
-		update_bin_on_delete(d, parent.doctype)
+	if parent.doctype != "Quotation":
+		parent.update_prevdoc_status()
+		for d in deleted_children:
+			update_bin_on_delete(d, parent.doctype)
 
 	return bool(deleted_children)
 
 
 @frappe.whitelist()
 def update_child_qty_rate(parent_doctype, trans_items, parent_doctype_name, child_docname="items"):
+	from erpnext.selling.doctype.quotation.quotation import get_ordered_items
+
 	def check_doc_permissions(doc, perm_type="create"):
 		try:
 			doc.check_permission(perm_type)
@@ -3829,7 +3835,7 @@ def update_child_qty_rate(parent_doctype, trans_items, parent_doctype_name, chil
 			)
 
 	def get_new_child_item(item_row):
-		child_doctype = "Sales Order Item" if parent_doctype == "Sales Order" else "Purchase Order Item"
+		child_doctype = parent_doctype + " Item"
 		return set_order_defaults(parent_doctype, parent_doctype_name, child_doctype, child_docname, item_row)
 
 	def is_allowed_zero_qty():
@@ -3853,6 +3859,15 @@ def update_child_qty_rate(parent_doctype, trans_items, parent_doctype_name, chil
 
 		if parent_doctype == "Purchase Order" and flt(new_data.get("qty")) < flt(child_item.received_qty):
 			frappe.throw(_("Cannot set quantity less than received quantity"))
+
+		if parent_doctype == "Quotation":
+			if not ordered_items:
+				return
+
+			qty_to_check = ordered_items.get(child_item.name)
+			if qty_to_check:
+				if flt(new_data.get("qty")) < qty_to_check:
+					frappe.throw(_("Cannot reduce quantity than ordered quantity"))
 
 	def should_update_supplied_items(doc) -> bool:
 		"""Subcontracted PO can allow following changes *after submit*:
@@ -3896,7 +3911,6 @@ def update_child_qty_rate(parent_doctype, trans_items, parent_doctype_name, chil
 			frappe.throw(_("Finished Good Item {0} Qty can not be zero").format(new_data["fg_item"]))
 
 	data = json.loads(trans_items)
-
 	any_qty_changed = False  # updated to true if any item's qty changes
 	items_added_or_removed = False  # updated to true if any new item is added or removed
 	any_conversion_factor_changed = False
@@ -3904,7 +3918,13 @@ def update_child_qty_rate(parent_doctype, trans_items, parent_doctype_name, chil
 	parent = frappe.get_doc(parent_doctype, parent_doctype_name)
 
 	check_doc_permissions(parent, "write")
-	_removed_items = validate_and_delete_children(parent, data)
+
+	if parent_doctype in ["Quotation", "Supplier Quotation"]:
+		ordered_items = get_ordered_items(parent.name)
+		_removed_items = validate_and_delete_children(parent, data, ordered_items)
+	else:
+		_removed_items = validate_and_delete_children(parent, data)
+
 	items_added_or_removed |= _removed_items
 
 	for d in data:
@@ -3944,7 +3964,9 @@ def update_child_qty_rate(parent_doctype, trans_items, parent_doctype_name, chil
 			conversion_factor_unchanged = prev_con_fac == new_con_fac
 			any_conversion_factor_changed |= not conversion_factor_unchanged
 			date_unchanged = (
-				prev_date == getdate(new_date) if prev_date and new_date else False
+				(prev_date == getdate(new_date) if prev_date and new_date else False)
+				if parent_doctype != "Quotation"
+				else None
 			)  # in case of delivery note etc
 			if (
 				rate_unchanged
@@ -3957,6 +3979,10 @@ def update_child_qty_rate(parent_doctype, trans_items, parent_doctype_name, chil
 				continue
 
 		validate_quantity(child_item, d)
+		if parent_doctype == "Quotation":
+			if not rate_unchanged:
+				frappe.throw(_("Rates cannot be modified for quoted items"))
+
 		if flt(child_item.get("qty")) != flt(d.get("qty")):
 			any_qty_changed = True
 
@@ -3980,18 +4006,21 @@ def update_child_qty_rate(parent_doctype, trans_items, parent_doctype_name, chil
 		rate_unchanged = prev_rate == new_rate
 		if not rate_unchanged and not child_item.get("qty") and is_allowed_zero_qty():
 			frappe.throw(_("Rate of '{}' items cannot be changed").format(frappe.bold(_("Unit Price"))))
-
 		# Amount cannot be lesser than billed amount, except for negative amounts
 		row_rate = flt(d.get("rate"), rate_precision)
-		amount_below_billed_amt = flt(child_item.billed_amt, rate_precision) > flt(
-			row_rate * flt(d.get("qty"), qty_precision), rate_precision
-		)
-		if amount_below_billed_amt and row_rate > 0.0:
-			frappe.throw(
-				_(
-					"Row #{0}: Cannot set Rate if the billed amount is greater than the amount for Item {1}."
-				).format(child_item.idx, child_item.item_code)
+
+		if parent_doctype in ["Purchase Order", "Sales Order"]:
+			amount_below_billed_amt = flt(child_item.billed_amt, rate_precision) > flt(
+				row_rate * flt(d.get("qty"), qty_precision), rate_precision
 			)
+			if amount_below_billed_amt and row_rate > 0.0:
+				frappe.throw(
+					_(
+						"Row #{0}: Cannot set Rate if the billed amount is greater than the amount for Item {1}."
+					).format(child_item.idx, child_item.item_code)
+				)
+			else:
+				child_item.rate = row_rate
 		else:
 			child_item.rate = row_rate
 
@@ -4019,26 +4048,27 @@ def update_child_qty_rate(parent_doctype, trans_items, parent_doctype_name, chil
 		if d.get("bom_no") and parent_doctype == "Sales Order":
 			child_item.bom_no = d.get("bom_no")
 
-		if flt(child_item.price_list_rate):
-			if flt(child_item.rate) > flt(child_item.price_list_rate):
-				#  if rate is greater than price_list_rate, set margin
-				#  or set discount
-				child_item.discount_percentage = 0
-				child_item.margin_type = "Amount"
-				child_item.margin_rate_or_amount = flt(
-					child_item.rate - child_item.price_list_rate,
-					child_item.precision("margin_rate_or_amount"),
-				)
-				child_item.rate_with_margin = child_item.rate
-			else:
-				child_item.discount_percentage = flt(
-					(1 - flt(child_item.rate) / flt(child_item.price_list_rate)) * 100.0,
-					child_item.precision("discount_percentage"),
-				)
-				child_item.discount_amount = flt(child_item.price_list_rate) - flt(child_item.rate)
-				child_item.margin_type = ""
-				child_item.margin_rate_or_amount = 0
-				child_item.rate_with_margin = 0
+		if parent_doctype in ["Sales Order", "Purchase Order"]:
+			if flt(child_item.price_list_rate):
+				if flt(child_item.rate) > flt(child_item.price_list_rate):
+					#  if rate is greater than price_list_rate, set margin
+					#  or set discount
+					child_item.discount_percentage = 0
+					child_item.margin_type = "Amount"
+					child_item.margin_rate_or_amount = flt(
+						child_item.rate - child_item.price_list_rate,
+						child_item.precision("margin_rate_or_amount"),
+					)
+					child_item.rate_with_margin = child_item.rate
+				else:
+					child_item.discount_percentage = flt(
+						(1 - flt(child_item.rate) / flt(child_item.price_list_rate)) * 100.0,
+						child_item.precision("discount_percentage"),
+					)
+					child_item.discount_amount = flt(child_item.price_list_rate) - flt(child_item.rate)
+					child_item.margin_type = ""
+					child_item.margin_rate_or_amount = 0
+					child_item.rate_with_margin = 0
 
 		child_item.flags.ignore_validate_update_after_submit = True
 		if new_child_flag:
@@ -4066,7 +4096,7 @@ def update_child_qty_rate(parent_doctype, trans_items, parent_doctype_name, chil
 		parent.validate_budget()
 		if parent.is_against_so():
 			parent.update_status_updater()
-	else:
+	elif parent_doctype == "Sales Order":
 		parent.check_credit_limit()
 
 	# reset index of child table
@@ -4099,7 +4129,7 @@ def update_child_qty_rate(parent_doctype, trans_items, parent_doctype_name, chil
 							"Items cannot be updated as Subcontracting Order is created against the Purchase Order {0}."
 						).format(frappe.bold(parent.name))
 					)
-	else:  # Sales Order
+	elif parent_doctype == "Sales Order":  # Sales Order
 		if parent.is_subcontracted and not parent.can_update_items():
 			frappe.throw(
 				_(
@@ -4117,9 +4147,10 @@ def update_child_qty_rate(parent_doctype, trans_items, parent_doctype_name, chil
 	parent.reload()
 	validate_workflow_conditions(parent)
 
-	parent.update_blanket_order()
-	parent.update_billing_percentage()
-	parent.set_status()
+	if parent_doctype in ["Purchase Order", "Sales Order"]:
+		parent.update_blanket_order()
+		parent.update_billing_percentage()
+		parent.set_status()
 
 	parent.validate_uom_is_integer("uom", "qty")
 	parent.validate_uom_is_integer("stock_uom", "stock_qty")

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -3686,7 +3686,7 @@ def set_order_defaults(parent_doctype, parent_doctype_name, child_doctype, child
 	conversion_factor = flt(get_conversion_factor(item.item_code, child_item.uom).get("conversion_factor"))
 	child_item.conversion_factor = flt(trans_item.get("conversion_factor")) or conversion_factor
 
-	if child_doctype == "Purchase Order Item":
+	if child_doctype in ["Purchase Order Item", "Supplier Quotation Item"]:
 		# Initialized value will update in parent validation
 		child_item.base_rate = 1
 		child_item.base_amount = 1
@@ -3785,7 +3785,7 @@ def validate_and_delete_children(parent, data, ordered_item=None) -> bool:
 
 	# need to update ordered qty in Material Request first
 	# bin uses Material Request Items to recalculate & update
-	if parent.doctype != "Quotation":
+	if parent.doctype not in ["Quotation", "Supplier Quotation"]:
 		parent.update_prevdoc_status()
 		for d in deleted_children:
 			update_bin_on_delete(d, parent.doctype)
@@ -3795,6 +3795,7 @@ def validate_and_delete_children(parent, data, ordered_item=None) -> bool:
 
 @frappe.whitelist()
 def update_child_qty_rate(parent_doctype, trans_items, parent_doctype_name, child_docname="items"):
+	from erpnext.buying.doctype.supplier_quotation.supplier_quotation import get_purchased_items
 	from erpnext.selling.doctype.quotation.quotation import get_ordered_items
 
 	def check_doc_permissions(doc, perm_type="create"):
@@ -3860,14 +3861,20 @@ def update_child_qty_rate(parent_doctype, trans_items, parent_doctype_name, chil
 		if parent_doctype == "Purchase Order" and flt(new_data.get("qty")) < flt(child_item.received_qty):
 			frappe.throw(_("Cannot set quantity less than received quantity"))
 
-		if parent_doctype == "Quotation":
-			if not ordered_items:
+		if parent_doctype in ["Quotation", "Supplier Quotation"]:
+			if (parent_doctype == "Quotation" and not ordered_items) or (
+				parent_doctype == "Supplier Quotation" and not purchased_items
+			):
 				return
 
-			qty_to_check = ordered_items.get(child_item.name)
+			qty_to_check = (
+				ordered_items.get(child_item.name)
+				if parent_doctype == "Quotation"
+				else purchased_items.get(child_item.name)
+			)
 			if qty_to_check:
 				if flt(new_data.get("qty")) < qty_to_check:
-					frappe.throw(_("Cannot reduce quantity than ordered quantity"))
+					frappe.throw(_("Cannot reduce quantity than ordered or purchased quantity"))
 
 	def should_update_supplied_items(doc) -> bool:
 		"""Subcontracted PO can allow following changes *after submit*:
@@ -3919,9 +3926,12 @@ def update_child_qty_rate(parent_doctype, trans_items, parent_doctype_name, chil
 
 	check_doc_permissions(parent, "write")
 
-	if parent_doctype in ["Quotation", "Supplier Quotation"]:
+	if parent_doctype == "Quotation":
 		ordered_items = get_ordered_items(parent.name)
 		_removed_items = validate_and_delete_children(parent, data, ordered_items)
+	elif parent_doctype == "Supplier Quotation":
+		purchased_items = get_purchased_items(parent.name)
+		_removed_items = validate_and_delete_children(parent, data, purchased_items)
 	else:
 		_removed_items = validate_and_delete_children(parent, data)
 
@@ -3965,7 +3975,7 @@ def update_child_qty_rate(parent_doctype, trans_items, parent_doctype_name, chil
 			any_conversion_factor_changed |= not conversion_factor_unchanged
 			date_unchanged = (
 				(prev_date == getdate(new_date) if prev_date and new_date else False)
-				if parent_doctype != "Quotation"
+				if parent_doctype not in ["Quotation", "Supplier Quotation"]
 				else None
 			)  # in case of delivery note etc
 			if (
@@ -3979,7 +3989,7 @@ def update_child_qty_rate(parent_doctype, trans_items, parent_doctype_name, chil
 				continue
 
 		validate_quantity(child_item, d)
-		if parent_doctype == "Quotation":
+		if parent_doctype in ["Quotation", "Supplier Quotation"]:
 			if not rate_unchanged:
 				frappe.throw(_("Rates cannot be modified for quoted items"))
 
@@ -4090,7 +4100,8 @@ def update_child_qty_rate(parent_doctype, trans_items, parent_doctype_name, chil
 		parent.doctype, parent.company, parent.base_grand_total
 	)
 
-	parent.set_payment_schedule()
+	if parent_doctype != "Supplier Quotation":
+		parent.set_payment_schedule()
 	if parent_doctype == "Purchase Order":
 		parent.validate_minimum_order_qty()
 		parent.validate_budget()

--- a/erpnext/selling/doctype/quotation/quotation.js
+++ b/erpnext/selling/doctype/quotation/quotation.js
@@ -123,6 +123,13 @@ erpnext.selling.QuotationController = class QuotationController extends erpnext.
 					frappe.datetime.get_diff(doc.valid_till, frappe.datetime.get_today()) >= 0)
 			) {
 				this.frm.add_custom_button(__("Sales Order"), () => this.make_sales_order(), __("Create"));
+				this.frm.add_custom_button(__("Update Items"), () => {
+					erpnext.utils.update_child_items({
+						frm: this.frm,
+						child_docname: "items",
+						cannot_add_row: false,
+					});
+				});
 			}
 
 			if (doc.status !== "Ordered" && this.frm.has_perm("write")) {

--- a/erpnext/selling/doctype/quotation/quotation.py
+++ b/erpnext/selling/doctype/quotation/quotation.py
@@ -612,6 +612,7 @@ def handle_mandatory_error(e, customer, lead_name):
 	frappe.throw(message, title=_("Mandatory Missing"))
 
 
+@frappe.whitelist()
 def get_ordered_items(quotation: str):
 	"""
 	Returns a dict of ordered items with their total qty based on quotation row name.

--- a/erpnext/selling/doctype/quotation/test_quotation.py
+++ b/erpnext/selling/doctype/quotation/test_quotation.py
@@ -15,7 +15,7 @@ EXTRA_TEST_RECORD_DEPENDENCIES = ["Product Bundle"]
 
 
 class TestQuotation(IntegrationTestCase):
-	def test_update_child_add_new_item(self):
+	def test_update_child_quotation_add_item(self):
 		from erpnext.stock.doctype.item.test_item import make_item
 
 		item_1 = make_item("_Test Item")

--- a/erpnext/selling/doctype/quotation/test_quotation.py
+++ b/erpnext/selling/doctype/quotation/test_quotation.py
@@ -1,17 +1,114 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: GNU General Public License v3. See license.txt
 
+import json
+
 import frappe
 from frappe.tests import IntegrationTestCase, change_settings
 from frappe.utils import add_days, add_months, flt, getdate, nowdate
 
-from erpnext.controllers.accounts_controller import InvalidQtyError
+from erpnext.controllers.accounts_controller import InvalidQtyError, update_child_qty_rate
+from erpnext.selling.doctype.quotation.quotation import make_sales_order
 from erpnext.setup.utils import get_exchange_rate
 
 EXTRA_TEST_RECORD_DEPENDENCIES = ["Product Bundle"]
 
 
 class TestQuotation(IntegrationTestCase):
+	def test_update_child_add_new_item(self):
+		from erpnext.stock.doctype.item.test_item import make_item
+
+		item_1 = make_item("_Test Item")
+		item_2 = make_item("_Test Item 1")
+
+		item_list = [
+			{"item_code": item_1.item_code, "warehouse": "", "qty": 10, "rate": 300},
+			{"item_code": item_2.item_code, "warehouse": "", "qty": 5, "rate": 400},
+		]
+
+		qo = make_quotation(item_list=item_list)
+		first_item = qo.get("items")[0]
+		second_item = qo.get("items")[1]
+		trans_item = json.dumps(
+			[
+				{
+					"item_code": first_item.item_code,
+					"rate": first_item.rate,
+					"qty": 11,
+					"docname": first_item.name,
+				},
+				{
+					"item_code": second_item.item_code,
+					"rate": second_item.rate,
+					"qty": second_item.qty,
+					"docname": second_item.name,
+				},
+				{"item_code": "_Test Item 2", "rate": 100, "qty": 7},
+			]
+		)
+
+		update_child_qty_rate("Quotation", trans_item, qo.name)
+		qo.reload()
+		self.assertEqual(qo.get("items")[0].qty, 11)
+		self.assertEqual(qo.get("items")[-1].rate, 100)
+
+	def test_update_child_disallow_rate_change(self):
+		qo = make_quotation(qty=4)
+		trans_item = json.dumps(
+			[
+				{
+					"item_code": qo.items[0].item_code,
+					"rate": 5000,
+					"qty": qo.items[0].qty,
+					"docname": qo.items[0].name,
+				}
+			]
+		)
+		self.assertRaises(frappe.ValidationError, update_child_qty_rate, "Quotation", trans_item, qo.name)
+
+	def test_update_child_removing_item(self):
+		qo = make_quotation(qty=10)
+		sales_order = make_sales_order(qo.name)
+		sales_order.delivery_date = nowdate()
+
+		trans_item = json.dumps(
+			[
+				{
+					"item_code": qo.items[0].item_code,
+					"rate": qo.items[0].rate,
+					"qty": qo.items[0].qty,
+					"docname": qo.items[0].name,
+				},
+				{"item_code": "_Test Item 2", "rate": 100, "qty": 7},
+			]
+		)
+
+		update_child_qty_rate("Quotation", trans_item, qo.name)
+		sales_order.submit()
+		qo.reload()
+		self.assertEqual(qo.status, "Partially Ordered")
+
+		trans_item = json.dumps([{"item_code": "_Test Item 2", "rate": 100, "qty": 7}])
+
+		# check if items having a sales order can be removed
+		self.assertRaises(frappe.ValidationError, update_child_qty_rate, "Quotation", trans_item, qo.name)
+
+		trans_item = json.dumps(
+			[
+				{
+					"item_code": qo.items[0].item_code,
+					"rate": qo.items[0].rate,
+					"qty": qo.items[0].qty,
+					"docname": qo.items[0].name,
+				}
+			]
+		)
+
+		# remove item with no sales order
+		update_child_qty_rate("Quotation", trans_item, qo.name)
+		qo.reload()
+		self.assertEqual(len(qo.get("items")), 1)
+
 	def test_quotation_qty(self):
 		qo = make_quotation(qty=0, do_not_save=True)
 		with self.assertRaises(InvalidQtyError):


### PR DESCRIPTION
The following Code, adds an update item button to the Quotation and Supplier Quotation doctype just like the one present in Sales order and Purchase order. 
It fixes https://github.com/frappe/erpnext/issues/49518

It allows the following things: 
1. Updating the quantity (Increase or decrease if no sales/purchase order present against that item) 
2. Increasing the quantity, if sales/purchase order already present against that item and Quotation is not in ordered state
3. Adding new items to the quotation/supplier quotation after it has been submitted 

The following validations are present: 
1. Rate cannot be updated 
2. Deleting an item that has a sales/purchase order present against it
3. Reducing quantity of an item that has a sales/purchase order present against it

`no-docs`