### PR TITLE
fix: handle duplicate description in item-wise report (backport #50979)

### DIFF
--- a/erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py
+++ b/erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py
@@ -5,7 +5,6 @@
 import frappe
 from frappe import _
 from frappe.utils import flt
-from pypika import Order
 
 import erpnext
 from erpnext.accounts.report.item_wise_sales_register.item_wise_sales_register import (
@@ -16,7 +15,7 @@ from erpnext.accounts.report.item_wise_sales_register.item_wise_sales_register i
 	get_group_by_and_display_fields,
 	get_tax_accounts,
 )
-from erpnext.accounts.report.utils import get_query_columns, get_values_for_columns
+from erpnext.accounts.report.utils import get_values_for_columns
 
 
 def execute(filters=None):
@@ -40,16 +39,6 @@ def _execute(filters=None, additional_table_columns=None):
 			doctype="Purchase Invoice",
 			tax_doctype="Purchase Taxes and Charges",
 		)
-
-		scrubbed_tax_fields = {}
-
-		for tax in tax_columns:
-			scrubbed_tax_fields.update(
-				{
-					tax + " Rate": frappe.scrub(tax + " Rate"),
-					tax + " Amount": frappe.scrub(tax + " Amount"),
-				}
-			)
 
 	po_pr_map = get_purchase_receipts_against_purchase_order(item_list)
 
@@ -100,8 +89,8 @@ def _execute(filters=None, additional_table_columns=None):
 			item_tax = itemised_tax.get(d.name, {}).get(tax, {})
 			row.update(
 				{
-					scrubbed_tax_fields[tax + " Rate"]: item_tax.get("tax_rate", 0),
-					scrubbed_tax_fields[tax + " Amount"]: item_tax.get("tax_amount", 0),
+					f"{tax}_rate": item_tax.get("tax_rate", 0),
+					f"{tax}_amount": item_tax.get("tax_amount", 0),
 				}
 			)
 			total_tax += flt(item_tax.get("tax_amount"))


### PR DESCRIPTION
Manual backport: https://github.com/frappe/erpnext/pull/50979
Issue: Tax descriptions with different capitalizations (e.g., 'OUTPUT CGST' vs 'Output CGST') were creating duplicate columns in Item Wise Sales and Purchase Register reports, causing incorrect tax calculations and overridden amounts.

Create a 2 Sales Invoices with items
- Add taxes with descriptions:
- Invoice 1: "Freight" @ 9%
- Invoice 2: "FREIGHT" @ 9% (note different capitalisation)
- Go to Accounts → Reports → Item Wise Sales Register
- Run a report for the invoice date range
- Observe: Duplicate tax columns appear, and amounts are incorrect.

Before:
<img width="1438" height="579" alt="image" src="https://github.com/user-attachments/assets/37003f3a-e82a-4f97-9117-b9d7e5ca91b4" />

After:
<img width="1388" height="503" alt="image" src="https://github.com/user-attachments/assets/aeb0a407-2635-4ea2-8952-d75fd893d89a" />


Note: Removed unused imports.

Support Issue: https://support.frappe.io/desk/hd-ticket/55095

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced consistency in tax field handling across accounting reports
  * Improved stability of tax column naming conventions
  * Optimized internal data structure processing for tax-related features

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->