### PR TITLE
fix: performance of the reposting

### DIFF
--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -724,6 +724,13 @@ class update_entries_after:
 			{"item_code": self.item_code, "warehouse": self.args.warehouse}
 		)
 
+		key = (self.item_code, self.args.warehouse)
+		if key in self.distinct_item_warehouses and self.distinct_item_warehouses[key].get(
+			"transfer_entry_to_repost"
+		):
+			# only repost stock entries
+			args["filter_voucher_type"] = "Stock Entry"
+
 		return list(self.get_sle_after_datetime(args))
 
 	def get_dependent_entries_to_fix(self, entries_to_fix, sle):
@@ -757,8 +764,10 @@ class update_entries_after:
 			if getdate(existing_sle.get("posting_date")) > getdate(dependant_sle.posting_date):
 				self.distinct_item_warehouses[key] = val
 				self.new_items_found = True
-			elif dependant_sle.voucher_type == "Stock Entry" and is_transfer_stock_entry(
-				dependant_sle.voucher_no
+			elif (
+				dependant_sle.actual_qty > 0
+				and dependant_sle.voucher_type == "Stock Entry"
+				and is_transfer_stock_entry(dependant_sle.voucher_no)
 			):
 				if self.distinct_item_warehouses[key].get("transfer_entry_to_repost"):
 					return
@@ -1853,6 +1862,9 @@ def get_stock_ledger_entries(
 
 	if operator in (">", "<=") and previous_sle.get("name"):
 		conditions += " and name!=%(name)s"
+
+	if previous_sle.get("filter_voucher_type"):
+		conditions += " and voucher_type = %(filter_voucher_type)s"
 
 	if extra_cond:
 		conditions += f"{extra_cond}"


### PR DESCRIPTION
Case

- For Item A, a Purchase Receipt was created for 10 qty at a rate of 100 in Warehouse A.
- Transferred 10 qty from Warehouse A to Warehouse B.
- Transferred 10 qty from Warehouse B to Warehouse A.
- Transferred 10 qty from Warehouse A to Warehouse B.
- The user then created an LCV against the Purchase Receipt created in Step 1.
- After the LCV is posted, the system performs reposting of Item A for both Warehouse A and Warehouse B.

Earlier Design

While reposting the transaction created in Step 3, the system was not picking up the correct valuation rate for Warehouse A. At that time, the valuation rate of Warehouse B had not yet been updated. Since this was a transfer entry, the target warehouse valuation depended on the source warehouse valuation.

To address this issue, we started reposting entries for Warehouse A again after the reposting of B. However, this increased the number of reposting operations, leading to slower reposting performance.

Solution

Only repost the single entry created in Step 3 for Warehouse A, and avoid reposting subsequent transactions.