### PR TITLE
fix: updating base amounts through python for timesheet

### DIFF
--- a/erpnext/projects/doctype/timesheet/test_timesheet.py
+++ b/erpnext/projects/doctype/timesheet/test_timesheet.py
@@ -22,6 +22,15 @@ class TestTimesheet(ERPNextTestSuite):
 	def setUp(self):
 		frappe.db.delete("Timesheet")
 
+	def test_timesheet_base_amount(self):
+		emp = make_employee("test_employee_6@salary.com")
+		timesheet = make_timesheet(emp, simulate=True, is_billable=1)
+
+		self.assertEqual(timesheet.time_logs[0].base_billing_rate, 50)
+		self.assertEqual(timesheet.time_logs[0].base_costing_rate, 20)
+		self.assertEqual(timesheet.time_logs[0].base_billing_amount, 100)
+		self.assertEqual(timesheet.time_logs[0].base_costing_amount, 40)
+
 	def test_timesheet_billing_amount(self):
 		emp = make_employee("test_employee_6@salary.com")
 		timesheet = make_timesheet(emp, simulate=True, is_billable=1)
@@ -241,4 +250,5 @@ def make_timesheet(
 def update_activity_type(activity_type):
 	activity_type = frappe.get_doc("Activity Type", activity_type)
 	activity_type.billing_rate = 50.0
+	activity_type.costing_rate = 20.0
 	activity_type.save(ignore_permissions=True)

--- a/erpnext/projects/doctype/timesheet_detail/timesheet_detail.py
+++ b/erpnext/projects/doctype/timesheet_detail/timesheet_detail.py
@@ -92,6 +92,16 @@ class TimesheetDetail(Document):
 		self.billing_amount = self.billing_rate * (self.billing_hours or 0)
 		self.costing_amount = self.costing_rate * (self.hours or 0)
 
+		exchange_rate = flt(frappe.get_value("Timesheet", self.parent, "exchange_rate")) or 1.0
+		self.base_billing_rate = flt(self.billing_rate * exchange_rate, self.precision("base_billing_rate"))
+		self.base_costing_rate = flt(self.costing_rate * exchange_rate, self.precision("base_costing_rate"))
+		self.base_billing_amount = flt(
+			self.billing_amount * exchange_rate, self.precision("base_billing_amount")
+		)
+		self.base_costing_amount = flt(
+			self.costing_amount * exchange_rate, self.precision("base_costing_amount")
+		)
+
 	def validate_dates(self):
 		"""Validate that to_time is not before from_time."""
 		if self.from_time and self.to_time and time_diff_in_hours(self.to_time, self.from_time) < 0:

--- a/erpnext/projects/doctype/timesheet_detail/timesheet_detail.py
+++ b/erpnext/projects/doctype/timesheet_detail/timesheet_detail.py
@@ -91,6 +91,11 @@ class TimesheetDetail(Document):
 
 		self.billing_amount = self.billing_rate * (self.billing_hours or 0)
 		self.costing_amount = self.costing_rate * (self.hours or 0)
+		exchange_rate = flt(frappe.get_value("Timesheet", self.parent, "exchange_rate")) or 1.0
+		self.base_billing_rate = flt(self.billing_rate) * exchange_rate
+		self.base_costing_rate = flt(self.costing_rate) * exchange_rate
+		self.base_billing_amount = flt(self.billing_amount) * exchange_rate
+		self.base_costing_amount = flt(self.costing_amount) * exchange_rate
 
 	def validate_dates(self):
 		"""Validate that to_time is not before from_time."""

--- a/erpnext/projects/doctype/timesheet_detail/timesheet_detail.py
+++ b/erpnext/projects/doctype/timesheet_detail/timesheet_detail.py
@@ -91,11 +91,6 @@ class TimesheetDetail(Document):
 
 		self.billing_amount = self.billing_rate * (self.billing_hours or 0)
 		self.costing_amount = self.costing_rate * (self.hours or 0)
-		exchange_rate = flt(frappe.get_value("Timesheet", self.parent, "exchange_rate")) or 1.0
-		self.base_billing_rate = flt(self.billing_rate) * exchange_rate
-		self.base_costing_rate = flt(self.costing_rate) * exchange_rate
-		self.base_billing_amount = flt(self.billing_amount) * exchange_rate
-		self.base_costing_amount = flt(self.costing_amount) * exchange_rate
 
 	def validate_dates(self):
 		"""Validate that to_time is not before from_time."""


### PR DESCRIPTION
The following change was made for the request made in this issue -
fixes https://github.com/frappe/erpnext/issues/50389

Currently the base amount fields in Timesheet only got updated through Js, have mapped these through python as well.
The fields mapped are:

1.base_costing_amount
2.base_billing_amount
3. base_costing_rate
4. base_billing_rate

no-docs