### PR TITLE
fix: Project/Task calculation of cost

### DIFF
--- a/erpnext/projects/doctype/project/project.py
+++ b/erpnext/projects/doctype/project/project.py
@@ -282,6 +282,8 @@ class Project(Document):
 				Min(TimesheetDetail.from_time).as_("start_date"),
 				Max(TimesheetDetail.to_time).as_("end_date"),
 				Sum(TimesheetDetail.hours).as_("time"),
+				Sum(TimesheetDetail.base_costing_amount).as_("base_costing_amount"),
+				Sum(TimesheetDetail.base_billing_amount).as_("base_billing_amount"),
 			)
 			.where((TimesheetDetail.project == self.name) & (TimesheetDetail.docstatus == 1))
 		).run(as_dict=True)[0]
@@ -289,8 +291,8 @@ class Project(Document):
 		self.actual_start_date = from_time_sheet.start_date
 		self.actual_end_date = from_time_sheet.end_date
 
-		self.total_costing_amount = from_time_sheet.costing_amount
-		self.total_billable_amount = from_time_sheet.billing_amount
+		self.total_costing_amount = from_time_sheet.base_costing_amount
+		self.total_billable_amount = from_time_sheet.base_billing_amount
 		self.actual_time = from_time_sheet.time
 
 		self.update_purchase_costing()

--- a/erpnext/projects/doctype/project/test_project.py
+++ b/erpnext/projects/doctype/project/test_project.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: GNU General Public License v3. See license.txt
 
-
 import frappe
 from frappe.tests import IntegrationTestCase
 from frappe.utils import add_days, getdate, nowdate
@@ -25,8 +24,8 @@ class TestProject(ERPNextTestSuite):
 		from erpnext.projects.doctype.timesheet.test_timesheet import make_timesheet
 		from erpnext.setup.doctype.employee.test_employee import make_employee
 
-		project_name = "Test Project costing"
-		employee = make_employee("test_employee_6@salary.com")
+		project_name = "Test Project Costing"
+		employee = make_employee("employee@frappe.io")
 		project = make_project({"project_name": project_name})
 		timesheet = make_timesheet(
 			employee=employee,

--- a/erpnext/projects/doctype/project/test_project.py
+++ b/erpnext/projects/doctype/project/test_project.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: GNU General Public License v3. See license.txt
 
+
 import frappe
 from frappe.tests import IntegrationTestCase
 from frappe.utils import add_days, getdate, nowdate
@@ -19,6 +20,26 @@ class TestProject(ERPNextTestSuite):
 	def setUpClass(cls):
 		super().setUpClass()
 		cls.make_projects()
+
+	def test_project_total_costing_and_billing_amount(self):
+		from erpnext.projects.doctype.timesheet.test_timesheet import make_timesheet
+		from erpnext.setup.doctype.employee.test_employee import make_employee
+
+		project_name = "Test Project costing"
+		employee = make_employee("test_employee_6@salary.com")
+		project = make_project({"project_name": project_name})
+		timesheet = make_timesheet(
+			employee=employee,
+			is_billable=1,
+			currency="USD",
+			project=project.name,
+			simulate=True,
+			exchange_rate=80,
+		)
+		timesheet.reload()
+		project.reload()
+		self.assertEqual(project.total_costing_amount, 3200)
+		self.assertEqual(project.total_billable_amount, 8000)
 
 	def test_project_with_template_having_no_parent_and_depend_tasks(self):
 		project_name = "Test Project with Template - No Parent and Dependend Tasks"

--- a/erpnext/projects/doctype/task/test_task.py
+++ b/erpnext/projects/doctype/task/test_task.py
@@ -1,6 +1,5 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: GNU General Public License v3. See license.txt
-import unittest
 
 import frappe
 from frappe.tests import IntegrationTestCase
@@ -21,10 +20,10 @@ class TestTask(ERPNextTestSuite):
 		from erpnext.projects.doctype.timesheet.test_timesheet import make_timesheet
 		from erpnext.setup.doctype.employee.test_employee import make_employee
 
-		project_name = "Test Project costing"
-		employee = make_employee("test_employee_6@salary.com")
+		project_name = "Test Project Costing"
+		employee = make_employee("employee@frappe.io")
 		project = make_project({"project_name": project_name})
-		task = create_task("_Test task 1")
+		task = create_task("_Test Task 1")
 		task.project = project.name
 		task.save()
 		timesheet = make_timesheet(

--- a/erpnext/projects/doctype/task/test_task.py
+++ b/erpnext/projects/doctype/task/test_task.py
@@ -16,6 +16,32 @@ class TestTask(ERPNextTestSuite):
 		super().setUpClass()
 		cls.make_projects()
 
+	def test_task_total_costing_and_billing_amount(self):
+		from erpnext.projects.doctype.project.test_project import make_project
+		from erpnext.projects.doctype.timesheet.test_timesheet import make_timesheet
+		from erpnext.setup.doctype.employee.test_employee import make_employee
+
+		project_name = "Test Project costing"
+		employee = make_employee("test_employee_6@salary.com")
+		project = make_project({"project_name": project_name})
+		task = create_task("_Test task 1")
+		task.project = project.name
+		task.save()
+		timesheet = make_timesheet(
+			employee=employee,
+			is_billable=1,
+			currency="USD",
+			project=project.name,
+			simulate=True,
+			exchange_rate=80,
+			task=task.name,
+		)
+		timesheet.reload()
+		project.reload()
+		task.reload()
+		self.assertEqual(task.total_costing_amount, 3200)
+		self.assertEqual(task.total_billing_amount, 8000)
+
 	def test_circular_reference(self):
 		task1 = create_task("_Test Task 1", add_days(nowdate(), -15), add_days(nowdate(), -10))
 		task2 = create_task("_Test Task 2", add_days(nowdate(), 11), add_days(nowdate(), 15), task1.name)

--- a/erpnext/projects/doctype/timesheet/test_timesheet.py
+++ b/erpnext/projects/doctype/timesheet/test_timesheet.py
@@ -216,11 +216,14 @@ def make_timesheet(
 	project=None,
 	task=None,
 	company=None,
+	currency=None,
+	exchange_rate=None,
 ):
 	update_activity_type(activity_type)
 	timesheet = frappe.new_doc("Timesheet")
 	timesheet.employee = employee
 	timesheet.company = company or "_Test Company"
+	timesheet.exchange_rate = exchange_rate
 	timesheet_detail = timesheet.append("time_logs", {})
 	timesheet_detail.is_billable = is_billable
 	timesheet_detail.activity_type = activity_type
@@ -229,6 +232,7 @@ def make_timesheet(
 	timesheet_detail.to_time = timesheet_detail.from_time + datetime.timedelta(hours=timesheet_detail.hours)
 	timesheet_detail.project = project
 	timesheet_detail.task = task
+	timesheet_detail.currency = currency
 
 	for data in timesheet.get("time_logs"):
 		if simulate:


### PR DESCRIPTION
The following code fixes https://github.com/frappe/erpnext/issues/50390 and https://github.com/frappe/erpnext/issues/35421

In the Project and task doctype, the total costing amount and total billable amount were reflecting based on transaction currency instead of base currency. This was originally providing incorrect cost calculation when the timesheet uses different currencies. 


`no-docs`