### PR TITLE
feat: run parallel reposting

### DIFF
--- a/erpnext/hooks.py
+++ b/erpnext/hooks.py
@@ -411,7 +411,9 @@ scheduler_events = {
 		"0/15 * * * *": [
 			"erpnext.manufacturing.doctype.bom_update_log.bom_update_log.resume_bom_cost_update_jobs",
 		],
-		"0/30 * * * *": [],
+		"0/30 * * * *": [
+			"erpnext.stock.doctype.repost_item_valuation.repost_item_valuation.run_parallel_reposting",
+		],
 		# Hourly but offset by 30 minutes
 		"30 * * * *": [
 			"erpnext.accounts.doctype.gl_entry.gl_entry.rename_gle_sle_docs",

--- a/erpnext/stock/doctype/stock_reposting_settings/stock_reposting_settings.json
+++ b/erpnext/stock/doctype/stock_reposting_settings/stock_reposting_settings.json
@@ -13,6 +13,8 @@
   "end_time",
   "limits_dont_apply_on",
   "item_based_reposting",
+  "enable_parallel_reposting",
+  "no_of_parallel_reposting",
   "errors_notification_section",
   "notify_reposting_error_to_role"
  ],
@@ -65,12 +67,25 @@
    "fieldname": "errors_notification_section",
    "fieldtype": "Section Break",
    "label": "Errors Notification"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval: doc.item_based_reposting",
+   "fieldname": "enable_parallel_reposting",
+   "fieldtype": "Check",
+   "label": "Enable Parallel Reposting"
+  },
+  {
+   "default": "4",
+   "fieldname": "no_of_parallel_reposting",
+   "fieldtype": "Int",
+   "label": "No of Parallel Reposting (Per Item)"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-07-08 11:27:46.659056",
+ "modified": "2025-12-10 17:45:56.597514",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Stock Reposting Settings",

--- a/erpnext/stock/doctype/stock_reposting_settings/stock_reposting_settings.py
+++ b/erpnext/stock/doctype/stock_reposting_settings/stock_reposting_settings.py
@@ -16,18 +16,30 @@ class StockRepostingSettings(Document):
 	if TYPE_CHECKING:
 		from frappe.types import DF
 
+		enable_parallel_reposting: DF.Check
 		end_time: DF.Time | None
 		item_based_reposting: DF.Check
 		limit_reposting_timeslot: DF.Check
 		limits_dont_apply_on: DF.Literal[
 			"", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"
 		]
+		no_of_parallel_reposting: DF.Int
 		notify_reposting_error_to_role: DF.Link | None
 		start_time: DF.Time | None
 	# end: auto-generated types
 
 	def validate(self):
 		self.set_minimum_reposting_time_slot()
+
+	def before_save(self):
+		self.reset_parallel_reposting_settings()
+
+	def reset_parallel_reposting_settings(self):
+		if not self.item_based_reposting and self.enable_parallel_reposting:
+			self.enable_parallel_reposting = 0
+
+		if self.enable_parallel_reposting and not self.no_of_parallel_reposting:
+			self.no_of_parallel_reposting = 4
 
 	def set_minimum_reposting_time_slot(self):
 		"""Ensure that timeslot for reposting is at least 12 hours."""


### PR DESCRIPTION
By default, the system uses a single worker to execute reposting, but users can configure it to use multiple workers if they are using item-based reposting.

<img width="535" height="324" alt="Screenshot 2025-12-10 at 5 46 17 PM" src="https://github.com/user-attachments/assets/927c8a94-295d-42f2-8d0a-ecb457e9bc2d" />

docs https://docs.frappe.io/erpnext/user/manual/en/stock-reposting-settings#enable-parallel-reposting