### PR TITLE
fix(bom): add validation to avoid duplicate raw material

### DIFF
--- a/erpnext/manufacturing/doctype/bom/bom.py
+++ b/erpnext/manufacturing/doctype/bom/bom.py
@@ -16,6 +16,7 @@ from frappe.utils import cint, cstr, flt, get_link_to_form, parse_json, today
 from frappe.website.website_generator import WebsiteGenerator
 
 import erpnext
+from erpnext.projects.doctype.activity_cost.activity_cost import DuplicationError
 from erpnext.setup.utils import get_exchange_rate
 from erpnext.stock.doctype.item.item import get_item_details
 from erpnext.stock.get_item_details import ItemDetailsCtx, get_conversion_factor, get_price_list_rate
@@ -293,10 +294,10 @@ class BOM(WebsiteGenerator):
 				frappe.throw(
 					_("Row #{0}: Duplicate entry in Item {1}").format(
 						frappe.bold(row.idx), frappe.bold(row.item_code)
-					)
+					),
+					DuplicationError,
 				)
-			else:
-				item_list.append(row.item_code)
+			item_list.append(row.item_code)
 
 	def set_default_uom(self):
 		if not self.get("items"):

--- a/erpnext/manufacturing/doctype/bom/bom.py
+++ b/erpnext/manufacturing/doctype/bom/bom.py
@@ -3,7 +3,7 @@
 
 import functools
 import re
-from collections import deque
+from collections import defaultdict, deque
 from operator import itemgetter
 
 import frappe
@@ -288,16 +288,16 @@ class BOM(WebsiteGenerator):
 		self.validate_duplicate_item()
 
 	def validate_duplicate_item(self):
-		item_list = []
+		item_dict = defaultdict(list)
 		for row in self.items:
-			if row.item_code in item_list:
+			if row.operation in item_dict[row.item_code]:
 				frappe.throw(
 					_("Row #{0}: Duplicate entry in Item {1}").format(
 						frappe.bold(row.idx), frappe.bold(row.item_code)
 					),
 					DuplicationError,
 				)
-			item_list.append(row.item_code)
+			item_dict[row.item_code].append(row.operation)
 
 	def set_default_uom(self):
 		if not self.get("items"):

--- a/erpnext/manufacturing/doctype/bom/bom.py
+++ b/erpnext/manufacturing/doctype/bom/bom.py
@@ -284,6 +284,19 @@ class BOM(WebsiteGenerator):
 		self.set_process_loss_qty()
 		self.validate_scrap_items()
 		self.set_default_uom()
+		self.validate_duplicate_item()
+
+	def validate_duplicate_item(self):
+		item_list = []
+		for row in self.items:
+			if row.item_code in item_list:
+				frappe.throw(
+					_("Row #{0}: Duplicate entry in Item {1}").format(
+						frappe.bold(row.idx), frappe.bold(row.item_code)
+					)
+				)
+			else:
+				item_list.append(row.item_code)
 
 	def set_default_uom(self):
 		if not self.get("items"):

--- a/erpnext/manufacturing/doctype/bom/test_bom.py
+++ b/erpnext/manufacturing/doctype/bom/test_bom.py
@@ -432,6 +432,23 @@ class TestBOM(IntegrationTestCase):
 		self.assertRaises(DuplicationError, bom.save)
 
 	@timeout
+	def test_bom_duplicate_item_with_operation(self):
+		from erpnext.manufacturing.doctype.operation.test_operation import make_operation
+
+		item = make_item(properties={"is_stock_item": 1}).name
+
+		op1 = make_operation(operation="Assembly")
+
+		bom = frappe.new_doc("BOM")
+		bom.item = item
+		bom.with_operation = 1
+
+		bom.append("items", frappe._dict(item_code=item, operation=op1.name))
+		bom.append("items", frappe._dict(item_code=item, operation=op1.name))
+
+		self.assertRaises(DuplicationError, bom.save)
+
+	@timeout
 	def test_bom_with_process_loss_item(self):
 		fg_item_non_whole, fg_item_whole, bom_item = create_process_loss_bom_items()
 

--- a/erpnext/manufacturing/doctype/bom/test_bom.py
+++ b/erpnext/manufacturing/doctype/bom/test_bom.py
@@ -441,7 +441,7 @@ class TestBOM(IntegrationTestCase):
 
 		bom = frappe.new_doc("BOM")
 		bom.item = item
-		bom.with_operation = 1
+		bom.with_operations = 1
 
 		bom.append("items", frappe._dict(item_code=item, operation=op1.name))
 		bom.append("items", frappe._dict(item_code=item, operation=op1.name))

--- a/erpnext/manufacturing/doctype/bom/test_bom.py
+++ b/erpnext/manufacturing/doctype/bom/test_bom.py
@@ -16,6 +16,7 @@ from erpnext.manufacturing.doctype.bom.bom import BOMRecursionError, item_query,
 from erpnext.manufacturing.doctype.bom_update_log.test_bom_update_log import (
 	update_cost_in_all_boms_in_test,
 )
+from erpnext.projects.doctype.activity_cost.activity_cost import DuplicationError
 from erpnext.stock.doctype.item.test_item import make_item
 from erpnext.stock.doctype.stock_reconciliation.test_stock_reconciliation import (
 	create_stock_reconciliation,
@@ -418,6 +419,17 @@ class TestBOM(IntegrationTestCase):
 		with self.assertRaises(BOMRecursionError):
 			bom1.save()
 			bom2.save()
+
+	@timeout
+	def test_bom_duplicate_item(self):
+		item = make_item(properties={"is_stock_item": 1}).name
+
+		bom = frappe.new_doc("BOM")
+		bom.item = item
+		bom.append("items", frappe._dict(item_code=item))
+		bom.append("items", frappe._dict(item_code=item))
+
+		self.assertRaises(DuplicationError, bom.save)
 
 	@timeout
 	def test_bom_with_process_loss_item(self):

--- a/erpnext/manufacturing/doctype/bom_creator/bom_creator.py
+++ b/erpnext/manufacturing/doctype/bom_creator/bom_creator.py
@@ -80,6 +80,7 @@ class BOMCreator(Document):
 		self.validate_items()
 
 	def validate_items(self):
+		dict_items = {}
 		for row in self.items:
 			if row.is_expandable and row.item_code == self.item_code:
 				frappe.throw(_("Item {0} cannot be added as a sub-assembly of itself").format(row.item_code))
@@ -95,6 +96,19 @@ class BOMCreator(Document):
 					_("At row {0}: Parent Row No cannot be set for item {1}").format(row.idx, row.item_code),
 					title=_("Remove Parent Row No in Items Table"),
 				)
+
+			if row.fg_item not in dict_items:
+				dict_items[row.fg_item] = []
+
+			if row.item_code in dict_items[row.fg_item]:
+				frappe.throw(
+					_("Row #{0}: Duplicate entry in Item {1} under {2}").format(
+						frappe.bold(row.idx), frappe.bold(row.item_code), frappe.bold(row.fg_item)
+					)
+				)
+
+			else:
+				dict_items[row.fg_item].append(row.item_code)
 
 	def set_status(self, save=False):
 		self.status = {

--- a/erpnext/manufacturing/doctype/bom_creator/bom_creator.py
+++ b/erpnext/manufacturing/doctype/bom_creator/bom_creator.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2023, Frappe Technologies Pvt. Ltd. and contributors
 # For license information, please see license.txt
 
-from collections import OrderedDict
+from collections import OrderedDict, defaultdict
 
 import frappe
 from frappe import _
@@ -10,6 +10,7 @@ from frappe.utils import cint, flt, sbool
 from pypika.terms import ValueWrapper
 
 from erpnext.manufacturing.doctype.bom.bom import get_bom_item_rate
+from erpnext.projects.doctype.activity_cost.activity_cost import DuplicationError
 
 BOM_FIELDS = [
 	"company",
@@ -80,7 +81,7 @@ class BOMCreator(Document):
 		self.validate_items()
 
 	def validate_items(self):
-		dict_items = {}
+		dict_items = defaultdict(list)
 		for row in self.items:
 			if row.is_expandable and row.item_code == self.item_code:
 				frappe.throw(_("Item {0} cannot be added as a sub-assembly of itself").format(row.item_code))
@@ -97,18 +98,14 @@ class BOMCreator(Document):
 					title=_("Remove Parent Row No in Items Table"),
 				)
 
-			if row.fg_item not in dict_items:
-				dict_items[row.fg_item] = []
-
 			if row.item_code in dict_items[row.fg_item]:
 				frappe.throw(
 					_("Row #{0}: Duplicate entry in Item {1} under {2}").format(
 						frappe.bold(row.idx), frappe.bold(row.item_code), frappe.bold(row.fg_item)
-					)
+					),
+					DuplicationError,
 				)
-
-			else:
-				dict_items[row.fg_item].append(row.item_code)
+			dict_items[row.fg_item].append(row.item_code)
 
 	def set_status(self, save=False):
 		self.status = {

--- a/erpnext/manufacturing/doctype/bom_creator/test_bom_creator.py
+++ b/erpnext/manufacturing/doctype/bom_creator/test_bom_creator.py
@@ -10,6 +10,8 @@ from erpnext.manufacturing.doctype.bom_creator.bom_creator import (
 	add_item,
 	add_sub_assembly,
 )
+from erpnext.projects.doctype.activity_cost.activity_cost import DuplicationError
+from erpnext.stock.doctype.item.item import get_item_details
 from erpnext.stock.doctype.item.test_item import make_item
 
 
@@ -115,6 +117,48 @@ class TestBOMCreator(IntegrationTestCase):
 				self.assertEqual(row.fg_reference_id, doc.name)
 
 		self.assertEqual(doc.raw_material_cost, fg_valuation_rate)
+
+	def test_bom_duplicate_raw_material(self):
+		final_product = "Bicycle"
+		make_item(
+			final_product,
+			{
+				"item_group": "Raw Material",
+				"stock_uom": "Nos",
+			},
+		)
+
+		doc = make_bom_creator(
+			name="Bicycle Test",
+			company="_Test Company",
+			item_code=final_product,
+			qty=1,
+			rm_cosy_as_per="Valuation Rate",
+			currency="INR",
+			plc_conversion_rate=1,
+			conversion_rate=1,
+		)
+
+		ls_item = ["Pedal Assembly", "Pedal Assembly"]
+
+		for item in ls_item:
+			item_info = get_item_details(item)
+
+			doc.append(
+				"items",
+				{
+					"parent": doc.name,
+					"fg_item": final_product,
+					"fg_reference_id": doc.name,
+					"item_code": item,
+					"qty": 2,
+					"uom": item_info.stock_uom,
+					"stock_uom": item_info.stock_uom,
+					"conversion_factor": 1,
+				},
+			)
+
+		self.assertRaises(DuplicationError, doc.save)
 
 	def test_convert_to_sub_assembly(self):
 		final_product = "Bicycle"


### PR DESCRIPTION
**Issue:**

Duplicate items are being allowed in BOM and BOM Creator.

**fixes:** #48006

**Before**:
<img width="1783" height="820" alt="image" src="https://github.com/user-attachments/assets/0abc125b-1966-4864-a17d-5ca44444e772" />


**After**:
<img width="1799" height="793" alt="image" src="https://github.com/user-attachments/assets/8068fc34-0919-43d0-b7e2-43498cd80b8f" />
