### PR TITLE
fix(currency exchange settings): added backward compatibility for frankfurter api

### DIFF
--- a/erpnext/accounts/doctype/currency_exchange_settings/currency_exchange_settings.js
+++ b/erpnext/accounts/doctype/currency_exchange_settings/currency_exchange_settings.js
@@ -19,7 +19,7 @@ frappe.ui.form.on("Currency Exchange Settings", {
 							to: "{to_currency}",
 						};
 						add_param(frm, r.message, params, result);
-					} else if (frm.doc.service_provider == "frankfurter.dev") {
+					} else if (["frankfurter.app", "frankfurter.dev"].includes(frm.doc.service_provider)) {
 						let result = ["rates", "{to_currency}"];
 						let params = {
 							base: "{from_currency}",

--- a/erpnext/accounts/doctype/currency_exchange_settings/currency_exchange_settings.py
+++ b/erpnext/accounts/doctype/currency_exchange_settings/currency_exchange_settings.py
@@ -60,7 +60,7 @@ class CurrencyExchangeSettings(Document):
 			self.append("req_params", {"key": "date", "value": "{transaction_date}"})
 			self.append("req_params", {"key": "from", "value": "{from_currency}"})
 			self.append("req_params", {"key": "to", "value": "{to_currency}"})
-		elif self.service_provider == "frankfurter.dev":
+		elif self.service_provider in ("frankfurter.dev", "frankfurter.app"):
 			self.set("result_key", [])
 			self.set("req_params", [])
 
@@ -105,9 +105,11 @@ class CurrencyExchangeSettings(Document):
 
 @frappe.whitelist()
 def get_api_endpoint(service_provider: str | None = None, use_http: bool = False):
-	if service_provider and service_provider in ["exchangerate.host", "frankfurter.dev"]:
+	if service_provider and service_provider in ["exchangerate.host", "frankfurter.dev", "frankfurter.app"]:
 		if service_provider == "exchangerate.host":
 			api = "api.exchangerate.host/convert"
+		elif service_provider == "frankfurter.app":
+			api = "api.frankfurter.app/{transaction_date}"
 		elif service_provider == "frankfurter.dev":
 			api = "api.frankfurter.dev/v1/{transaction_date}"
 

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -449,6 +449,6 @@ erpnext.patches.v16_0.set_company_wise_warehouses
 erpnext.patches.v16_0.set_valuation_method_on_companies
 erpnext.patches.v15_0.migrate_old_item_wise_tax_detail_data_to_table
 erpnext.patches.v16_0.migrate_budget_records_to_new_structure
-erpnext.patches.v16_0.update_currency_exchange_settings_for_frankfurter
+erpnext.patches.v16_0.update_currency_exchange_settings_for_frankfurter #2025-12-11
 erpnext.patches.v16_0.migrate_account_freezing_settings_to_company
 erpnext.patches.v16_0.populate_budget_distribution_total

--- a/erpnext/patches/v16_0/update_currency_exchange_settings_for_frankfurter.py
+++ b/erpnext/patches/v16_0/update_currency_exchange_settings_for_frankfurter.py
@@ -2,8 +2,13 @@ import frappe
 
 
 def execute():
+	settings_meta = frappe.get_meta("Currency Exchange Settings")
 	settings = frappe.get_doc("Currency Exchange Settings")
-	if settings.service_provider != "frankfurter.app":
+
+	if (
+		"frankfurter.dev" not in settings_meta.get_options("service_provider").split("\n")
+		or settings.service_provider != "frankfurter.app"
+	):
 		return
 
 	settings.service_provider = "frankfurter.dev"


### PR DESCRIPTION
Added backward compatibility for frankfurter.app endpoint. Also fixed the patch, which will now make sure that "frankfurter.dev" Option exists on `service_provider`.