### PR TITLE
fix(trial_balance): remove hardcoded precision for currency values

### DIFF
--- a/erpnext/accounts/report/trial_balance/trial_balance.py
+++ b/erpnext/accounts/report/trial_balance/trial_balance.py
@@ -447,7 +447,7 @@ def prepare_data(accounts, filters, parent_children_map, company_currency):
 		}
 
 		for key in value_fields:
-			row[key] = flt(d.get(key, 0.0), 3)
+			row[key] = flt(d.get(key, 0.0))
 
 			if abs(row[key]) >= get_zero_cutoff(company_currency):
 				# ignore zero values


### PR DESCRIPTION
Issue: When system is set to use 4-decimal precision for currency value in transactions, the Trial Balance and General Ledger  values didn't match as expected.

Ref: [55227](https://support.frappe.io/helpdesk/tickets/55227)

Before:

<img width="1436" height="387" alt="Screenshot 2025-12-11 at 15 36 10" src="https://github.com/user-attachments/assets/99317a21-a60e-4bde-9dcd-74b6706afa0b" />
<img width="1434" height="390" alt="Screenshot 2025-12-11 at 15 39 40" src="https://github.com/user-attachments/assets/b0912e2c-cd5a-4a0d-b360-d224be3dabad" />

After:

<img width="1433" height="483" alt="Screenshot 2025-12-11 at 15 41 33" src="https://github.com/user-attachments/assets/de8a6c8d-1fcb-4c11-a6e1-a93b9a047225" />


Backport Needed v15