### PR TITLE
fix(manufacturing): get items for disassembly order

### DIFF
--- a/erpnext/manufacturing/doctype/work_order/work_order.js
+++ b/erpnext/manufacturing/doctype/work_order/work_order.js
@@ -439,6 +439,10 @@ frappe.ui.form.on("Work Order", {
 		erpnext.work_order
 			.show_prompt_for_qty_input(frm, "Disassemble")
 			.then((data) => {
+				if (flt(data.qty) <= 0) {
+					frappe.msgprint(__("Disassemble Qty cannot be less than or equal to <b>0</b>."));
+					return;
+				}
 				return frappe.xcall("erpnext.manufacturing.doctype.work_order.work_order.make_stock_entry", {
 					work_order_id: frm.doc.name,
 					purpose: "Disassemble",

--- a/erpnext/manufacturing/doctype/work_order/work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/work_order.py
@@ -2349,7 +2349,7 @@ def make_stock_entry(
 
 	stock_entry.set_stock_entry_type()
 	stock_entry.is_additional_transfer_entry = is_additional_transfer_entry
-	stock_entry.get_items(qty, work_order.production_item)
+	stock_entry.get_items()
 
 	if purpose != "Disassemble":
 		stock_entry.set_serial_no_batch_for_finished_good()

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -2152,7 +2152,7 @@ class StockEntry(StockController, SubcontractingInwardController):
 					},
 				)
 
-	def get_items_for_disassembly(self, disassemble_qty, production_item):
+	def get_items_for_disassembly(self):
 		"""Get items for Disassembly Order"""
 
 		if not self.work_order:
@@ -2165,7 +2165,7 @@ class StockEntry(StockController, SubcontractingInwardController):
 		items_dict = get_bom_items_as_dict(
 			self.bom_no,
 			self.company,
-			disassemble_qty,
+			self.fg_completed_qty,
 			fetch_exploded=self.use_multi_level_bom,
 			fetch_qty_in_stock_uom=False,
 		)
@@ -2182,8 +2182,8 @@ class StockEntry(StockController, SubcontractingInwardController):
 				child_row.qty = bom_items.get("qty", child_row.qty)
 				child_row.amount = bom_items.get("amount", child_row.amount)
 
-			if row.item_code == production_item:
-				child_row.qty = disassemble_qty
+			if row.is_finished_item:
+				child_row.qty = self.fg_completed_qty
 
 			child_row.s_warehouse = (self.from_warehouse or s_warehouse) if row.is_finished_item else ""
 			child_row.t_warehouse = row.s_warehouse
@@ -2219,12 +2219,12 @@ class StockEntry(StockController, SubcontractingInwardController):
 		)
 
 	@frappe.whitelist()
-	def get_items(self, qty=None, production_item=None):
+	def get_items(self):
 		self.set("items", [])
 		self.validate_work_order()
 
-		if self.purpose == "Disassemble" and qty is not None:
-			return self.get_items_for_disassembly(qty, production_item)
+		if self.purpose == "Disassemble":
+			return self.get_items_for_disassembly()
 
 		if not self.posting_date or not self.posting_time:
 			frappe.throw(_("Posting date and posting time is mandatory"))


### PR DESCRIPTION
**Issue:**
The Items are not fetching when we click the "Get Items" button in the Disassembly Stock Entry.

**Ref:** [#55096](https://support.frappe.io/helpdesk/tickets/55096)

**Before:**

https://github.com/user-attachments/assets/8f3dc40a-2651-4aac-8ca8-16da94792a72

**After:**


https://github.com/user-attachments/assets/f74c859b-a641-4940-bcdd-0ded55e99b01

Backport Needed for v14 & v15
