### PR TITLE
fix(payment entry): fetch gain loss account from company boot

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.js
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.js
@@ -1277,15 +1277,14 @@ frappe.ui.form.on("Payment Entry", {
 		let row = (frm.doc.deductions || []).find((t) => t.is_exchange_gain_loss);
 
 		if (!row) {
-			const response = await get_company_defaults(frm.doc.company);
-
+			const company_defaults = frappe.get_doc(":Company", frm.doc.company);
 			const account =
-				response.message?.[account_fieldname] ||
+				company_defaults?.[account_fieldname] ||
 				(await prompt_for_missing_account(frm, account_fieldname));
 
 			row = frm.add_child("deductions");
 			row.account = account;
-			row.cost_center = response.message?.cost_center;
+			row.cost_center = company_defaults?.cost_center;
 			row.is_exchange_gain_loss = 1;
 		}
 

--- a/erpnext/startup/boot.py
+++ b/erpnext/startup/boot.py
@@ -49,7 +49,7 @@ def boot_session(bootinfo):
 
 		bootinfo.docs += frappe.db.sql(
 			"""select name, default_currency, cost_center, default_selling_terms, default_buying_terms,
-			default_letter_head, default_bank_account, enable_perpetual_inventory, country from `tabCompany`""",
+			default_letter_head, default_bank_account, enable_perpetual_inventory, country, exchange_gain_loss_account from `tabCompany`""",
 			as_dict=1,
 			update={"doctype": ":Company"},
 		)


### PR DESCRIPTION
**Issue :**
Incorrect difference amount is calculated while creating a Payment Entry (PE), causing a glitch in the form before saving.

Ref:  [#54454](https://support.frappe.io/helpdesk/tickets/54454)

**Description  :**
When creating a Payment Entry for an Invoice whose currency differs from the Company currency, changing Account Paid From(for Purchase Invoices) or Account Paid To (for Sales Invoices) results in an incorrect calculation of the difference amount on the client side.  
The backend recalculates correctly on save, but the UI shows the wrong value during form entry.

**Steps to Reproduce :**  
1. Create a Company with `USD` as the default currency.  
2. Create a `Purchase Invoice (PI)` for a `UGX` supplier under the `USD company` using an exchange rate of `0.0003`.  
3. Create a `Payment Entry` for that PI and change `Account Paid From` to a UGX account.  
4. Observe that the calculated difference amount is incorrect (e.g., `-0.06`).

**PE**

https://github.com/user-attachments/assets/d86784fd-7543-4dba-8d9b-53750cee4d2b

Backport needed:v15
