### PR TITLE
fix: ensure fresh `grand_total_diff` is used for each calculation

### DIFF
--- a/erpnext/controllers/taxes_and_totals.py
+++ b/erpnext/controllers/taxes_and_totals.py
@@ -398,6 +398,9 @@ class calculate_taxes_and_totals:
 			self._calculate()
 
 	def calculate_taxes(self):
+		# reset value from earlier calculations
+		self.grand_total_diff = 0
+
 		doc = self.doc
 		if not doc.get("taxes"):
 			return
@@ -684,7 +687,7 @@ class calculate_taxes_and_totals:
 				self.grand_total_diff = 0
 
 	def calculate_totals(self):
-		grand_total_diff = getattr(self, "grand_total_diff", 0)
+		grand_total_diff = self.grand_total_diff
 
 		if self.doc.get("taxes"):
 			self.doc.grand_total = flt(self.doc.get("taxes")[-1].total) + grand_total_diff

--- a/erpnext/public/js/controllers/taxes_and_totals.js
+++ b/erpnext/public/js/controllers/taxes_and_totals.js
@@ -380,6 +380,9 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 	}
 
 	calculate_taxes() {
+		// reset value from earlier calculations
+		this.grand_total_diff = 0;
+
 		const doc = this.frm.doc;
 		if (!doc.taxes?.length) return;
 
@@ -617,6 +620,8 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 
 				if (diff && Math.abs(diff) <= 5.0 / Math.pow(10, precision("tax_amount", last_tax))) {
 					me.grand_total_diff = diff;
+				} else {
+					me.grand_total_diff = 0;
 				}
 			}
 		}
@@ -626,7 +631,7 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 		// Changing sequence can cause rounding_adjustmentng issue and on-screen discrepency
 		const me = this;
 		const tax_count = this.frm.doc.taxes?.length;
-		const grand_total_diff = this.grand_total_diff || 0;
+		const grand_total_diff = this.grand_total_diff;
 
 		this.frm.doc.grand_total = flt(
 			tax_count ? this.frm.doc["taxes"][tax_count - 1].total + grand_total_diff : this.frm.doc.net_total


### PR DESCRIPTION
### before

- user changes some qty / rate
- leads to grand total diff
- correct grand total set
- user changes some qty / rate again
- no new grand total diff but earlier value used
- leads to incorrect grand total and subsequent calculations ❌ 

### after

- grand total diff is reset on each run, so no stale values are ever used

note: this was working fine in the backend, but the frontend didn't have [this code](https://github.com/sagarvora/erpnext/blob/fresh-gt-dff/erpnext/public/js/controllers/taxes_and_totals.js#L623-L624). that led to a `change_amount` being set in frontend, which was not reset in the backend.