### PR TITLE
fix: re-calculate outstanding / write-off amount during submission

### DIFF
--- a/erpnext/controllers/taxes_and_totals.py
+++ b/erpnext/controllers/taxes_and_totals.py
@@ -944,12 +944,11 @@ class calculate_taxes_and_totals:
 					)
 				)
 
-			if self.doc.docstatus.is_draft():
-				if self.doc.get("write_off_outstanding_amount_automatically"):
-					self.doc.write_off_amount = 0
+			if self.doc.get("write_off_outstanding_amount_automatically"):
+				self.doc.write_off_amount = 0
 
-				self.calculate_outstanding_amount()
-				self.calculate_write_off_amount()
+			self.calculate_outstanding_amount()
+			self.calculate_write_off_amount()
 
 	def is_internal_invoice(self):
 		"""


### PR DESCRIPTION
backend logic should always get executed:
 - frontend logic may be flawed
 - people may call `inv.submit()` directly instead of `inv.save()` first


follow up to https://github.com/frappe/erpnext/pull/51051

---

this is a really old guard added in https://github.com/frappe/erpnext/commit/8bb6e530c7b0eb44fdf988b8e7f3ed25f592593b