### PR TITLE
fix: validate budget after cost center allocation

### DIFF
--- a/erpnext/accounts/general_ledger.py
+++ b/erpnext/accounts/general_ledger.py
@@ -210,18 +210,19 @@ def distribute_gl_based_on_cost_center_allocation(gl_map, precision=None, from_r
 	for d in gl_map:
 		cost_center = d.get("cost_center")
 
+		cost_center_allocation = get_cost_center_allocation_data(
+			gl_map[0]["company"], gl_map[0]["posting_date"], cost_center
+		)
+
+		if not cost_center_allocation:
+			new_gl_map.append(d)
+			continue
+
 		# Validate budget against main cost center
 		if not from_repost:
 			validate_expense_against_budget(
 				d, expense_amount=flt(d.debit, precision) - flt(d.credit, precision)
 			)
-
-		cost_center_allocation = get_cost_center_allocation_data(
-			gl_map[0]["company"], gl_map[0]["posting_date"], cost_center
-		)
-		if not cost_center_allocation:
-			new_gl_map.append(d)
-			continue
 
 		if d.account == round_off_account:
 			d.cost_center = cost_center_allocation[0][0]
@@ -426,7 +427,11 @@ def make_entry(args, adv_adj, update_outstanding, from_repost=False):
 	gle.flags.notify_update = False
 	gle.submit()
 
-	if not from_repost and gle.voucher_type != "Period Closing Voucher":
+	if (
+		not from_repost
+		and gle.voucher_type != "Period Closing Voucher"
+		and (gle.is_cancelled == 0 or gle.voucher_type == "Journal Entry")
+	):
 		validate_expense_against_budget(args)
 
 


### PR DESCRIPTION
Budget validation error was showing multiple time because of incorrect call and codition.
Also updated the condition to prevent validation from running when a document is being cancelled.

_Before_
<img width="570" height="795" alt="Screenshot 2025-12-10 at 11 25 14 PM" src="https://github.com/user-attachments/assets/3375103e-dbd2-497e-af1b-fd9b657b4a69" />

_After_
<img width="1416" height="531" alt="Screenshot 2025-12-12 at 1 47 28 PM" src="https://github.com/user-attachments/assets/02d1afd8-ed95-473d-9e5f-0aec87c458c2" />

