### PR TITLE
refactor: standardize cost_center updation across transactions

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js
@@ -579,17 +579,6 @@ cur_frm.fields_dict["items"].grid.get_field("cost_center").get_query = function 
 	};
 };
 
-cur_frm.cscript.cost_center = function (doc, cdt, cdn) {
-	var d = locals[cdt][cdn];
-	if (d.cost_center) {
-		var cl = doc.items || [];
-		for (var i = 0; i < cl.length; i++) {
-			if (!cl[i].cost_center) cl[i].cost_center = d.cost_center;
-		}
-	}
-	refresh_field("items");
-};
-
 cur_frm.fields_dict["items"].grid.get_field("project").get_query = function (doc, cdt, cdn) {
 	return {
 		filters: [["Project", "status", "not in", "Completed, Cancelled"]],

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
@@ -618,10 +618,6 @@ cur_frm.cscript.expense_account = function (doc, cdt, cdn) {
 	erpnext.utils.copy_value_in_all_rows(doc, cdt, cdn, "items", "expense_account");
 };
 
-cur_frm.cscript.cost_center = function (doc, cdt, cdn) {
-	erpnext.utils.copy_value_in_all_rows(doc, cdt, cdn, "items", "cost_center");
-};
-
 frappe.ui.form.on("Sales Invoice", {
 	setup: function (frm) {
 		frm.add_fetch("customer", "tax_id", "tax_id");

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -1241,12 +1241,8 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 		this.frm.refresh_field("payment_schedule");
 	}
 
-	cost_center(doc) {
-		this.frm.doc.items.forEach((item) => {
-			item.cost_center = doc.cost_center;
-		});
-
-		this.frm.refresh_field("items");
+	cost_center(doc, cdt, cdn) {
+		erpnext.utils.copy_value_in_all_rows(doc, cdt, cdn, "items", "cost_center");
 	}
 
 	due_date(doc, cdt, cdn) {

--- a/erpnext/stock/doctype/delivery_note/delivery_note.js
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.js
@@ -130,10 +130,6 @@ frappe.ui.form.on("Delivery Note Item", {
 		var d = locals[dt][dn];
 		frm.update_in_all_rows("items", "expense_account", d.expense_account);
 	},
-	cost_center: function (frm, dt, dn) {
-		var d = locals[dt][dn];
-		frm.update_in_all_rows("items", "cost_center", d.cost_center);
-	},
 });
 
 erpnext.stock.DeliveryNoteController = class DeliveryNoteController extends (


### PR DESCRIPTION
**Issue:** Unable to set Cost Center in Material Request Item. The same issue appears in the Items table of Purchase Receipt, Purchase Order and Sales Order. When the Cost Center is updated in the item row. The system sets the header level  cost_center to its item table even though the value is null.

If the user try to set the cost center in the item table its getting removed due to the existing logic causing confusion on the UX side

Reference: [55366](https://support.frappe.io/helpdesk/tickets/55366)

**Steps to reproduce:**
1) Create a new Material Request.
2) Set an  Item Code.
3) Try to set the Cost Center in the item row.

**Expected Behaviour:**
1) The system should allow the user to set a Cost Center for each individual line item.
2) When a Cost Center is chosen at the parent level, the system should populate the Cost Center for any line items where the value is missing.

**Before:**

https://github.com/user-attachments/assets/3e9990ef-69e1-4681-bd0a-29ce79561905

**After:**

https://github.com/user-attachments/assets/fd87f259-3f9d-4cb8-b4b1-76e1a9b9bea1

Backport Needed v15

