### PR TITLE
fix: stock ageing report

### DIFF
--- a/erpnext/stock/report/stock_ageing/stock_ageing.py
+++ b/erpnext/stock/report/stock_ageing/stock_ageing.py
@@ -275,6 +275,7 @@ class FIFOSlots:
 					else:
 						serial_nos = get_serial_nos_from_bundle(d.serial_and_batch_bundle) or []
 
+				serial_nos = self.uppercase_serial_nos(serial_nos)
 				if d.actual_qty > 0:
 					self.__compute_incoming_stock(d, fifo_queue, transferred_item_key, serial_nos)
 				else:
@@ -290,6 +291,10 @@ class FIFOSlots:
 			self.item_details = self.__aggregate_details_by_item(self.item_details)
 
 		return self.item_details
+
+	def uppercase_serial_nos(self, serial_nos):
+		"Convert serial nos to uppercase for uniformity."
+		return [sn.upper() for sn in serial_nos]
 
 	def __init_key_stores(self, row: dict) -> tuple:
 		"Initialise keys and FIFO Queue."


### PR DESCRIPTION
Due to the same serial number appearing in both uppercase and lowercase in different stock ledger entries created before the SABB feature, the Stock Ageing Report is showing an incorrect available quantity. This is because the Python is case-sensitive and serial no field was denormalized before SABB feature.

<img width="554" height="218" alt="Screenshot 2025-12-12 at 5 36 41 PM" src="https://github.com/user-attachments/assets/ae3c410d-e410-43bb-a123-c1ae6f9034d6" />
<img width="1325" height="355" alt="Screenshot 2025-12-12 at 5 33 56 PM" src="https://github.com/user-attachments/assets/02811552-9157-4d6a-9008-8fef65d9f93e" />


**After Fix**

<img width="1321" height="284" alt="Screenshot 2025-12-12 at 5 41 31 PM" src="https://github.com/user-attachments/assets/16934a71-7ee5-4609-99a6-16f2cd3f56c3" />



