### PR TITLE
fix: fixed-actual-qty-becomes-zero-save-and-submit

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry.js
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.js
@@ -228,6 +228,19 @@ frappe.ui.form.on("Stock Entry", {
 	refresh: function (frm) {
 		frm.trigger("get_items_from_transit_entry");
 
+		// Refresh actual_qty for Material Receipt items (both draft and submitted)
+		if (frm.doc.purpose === "Material Receipt" && frm.doc.items?.length) {
+			frappe.after_ajax(() => {
+				setTimeout(() => {
+					frm.doc.items.forEach((row) => {
+						if (row.item_code && row.t_warehouse) {
+							frm.events.fetch_actual_qty_for_material_receipt(frm, row);
+						}
+					});
+				}, 100);
+			});
+		}
+
 		if (!frm.doc.docstatus && !frm.doc.subcontracting_inward_order) {
 			frm.trigger("validate_purpose_consumption");
 			frm.add_custom_button(
@@ -643,6 +656,39 @@ frappe.ui.form.on("Stock Entry", {
 				},
 			});
 		}
+	},
+
+	fetch_actual_qty_for_material_receipt: function (frm, row) {
+		if (!row.item_code || !row.t_warehouse) return;
+
+		frappe.call({
+			method: "erpnext.stock.doctype.stock_entry.stock_entry.get_warehouse_details",
+			args: {
+				args: {
+					item_code: row.item_code,
+					warehouse: row.t_warehouse,
+					transfer_qty: row.transfer_qty,
+					serial_and_batch_bundle: row.serial_and_batch_bundle,
+					qty: row.transfer_qty,
+					posting_date: frm.doc.posting_date,
+					posting_time: frm.doc.posting_time,
+					company: frm.doc.company,
+					voucher_type: frm.doc.doctype,
+					voucher_no: row.name,
+					allow_zero_valuation: 1,
+				},
+			},
+			callback: function (r) {
+				if (!r.exc && r.message && r.message.actual_qty !== undefined) {
+					// Directly update the row without triggering form dirty state
+					row.actual_qty = r.message.actual_qty || 0;
+					// Only refresh the field if form is already loaded
+					if (frm.fields_dict.items && frm.fields_dict.items.grid) {
+						frm.fields_dict.items.grid.refresh_field("actual_qty");
+					}
+				}
+			},
+		});
 	},
 
 	show_bom_custom_button: function (frm) {

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -200,7 +200,10 @@ class StockEntry(StockController, SubcontractingInwardController):
 
 	def onload(self):
 		for item in self.get("items"):
-			item.update(get_bin_details(item.item_code, item.s_warehouse))
+			# For Material Receipt, use t_warehouse; for others, use s_warehouse
+			warehouse = item.t_warehouse if self.purpose == "Material Receipt" else item.s_warehouse
+			if warehouse:
+				item.update(get_bin_details(item.item_code, warehouse))
 
 	def before_insert(self):
 		if self.subcontracting_order and frappe.get_cached_value(

--- a/erpnext/stock/serial_batch_bundle.py
+++ b/erpnext/stock/serial_batch_bundle.py
@@ -1519,18 +1519,24 @@ def get_batchwise_qty(voucher_type, voucher_no):
 	if not bundles:
 		return
 
-	batches = frappe.get_all(
-		"Serial and Batch Entry",
-		filters={"parent": ("in", bundles), "batch_no": ("is", "set")},
-		fields=["batch_no", {"SUM": "qty", "as": "qty"}],
-		group_by="batch_no",
-		as_list=1,
-	)
+	# Use query builder for aggregation
+	entry_table = frappe.qb.DocType("Serial and Batch Entry")
+	
+	batches = (
+		frappe.qb.from_(entry_table)
+		.select(entry_table.batch_no, Sum(entry_table.qty).as_("qty"))
+		.where(
+			(entry_table.parent.isin(bundles))
+			& (entry_table.batch_no.isnotnull())
+		)
+		.groupby(entry_table.batch_no)
+	).run(as_dict=True)
 
 	if not batches:
 		return frappe._dict({})
 
-	return frappe._dict(batches)
+	# Convert to dict format: {batch_no: qty}
+	return frappe._dict([(b.batch_no, b.qty) for b in batches])
 
 
 def get_serial_batch_list_from_item(item):


### PR DESCRIPTION
<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/erpnext/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->

While creating Material Receipt, after choosing Item from the dropdown and Target Warehouse, "actual_qty" is fetched which is getting fetched without any error.
As soon as you save the form value of "actual_qty" changes to 0 even though it has value in the DB.

Summary of Changes
1. stock_entry.py - Fixed actual_qty for Material Receipt on form load
Location: onload() method (lines 201-206)
Problem: For Material Receipt, items use t_warehouse (target), but the code only checked s_warehouse (source), so actual_qty wasn't populated.

2. stock_entry.js - Fixed actual_qty resetting to 0 after save/submit
Location: Multiple changes in the JavaScript file
Problem: actual_qty reset to 0 after saving or submitting Material Receipt entries because it wasn't re-fetched.
**Solution A** - Added refresh logic in refresh()
**Solution B** - Added fetch_actual_qty_for_material_receipt() helper function fetch_actual_qty_for_material_receipt
**Impact**:
actual_qty is fetched when the form loads (draft and submitted)
Updates don't mark the form as dirty
Works for both draft and submitted states

3. serial_batch_bundle.py - Fixed AttributeError during Stock Entry submission
Location: get_batchwise_qty() function (lines 1513-1539)
Problem: frappe.get_all() was called with a dict in the fields parameter for aggregation ({"SUM": "qty", "as": "qty"}), which isn't supported. sanitize_fields() expects strings, so calling .lower() on the dict raised AttributeError: 'dict' object has no attribute 'lower'.
Solution: Replaced with query builder for aggregation:
def get_batchwise_qty(voucher_type, voucher_no):
    bundles = frappe.get_all(
        "Serial and Batch Bundle",
        filters={"voucher_no": voucher_no, "voucher_type": voucher_type, "docstatus": (">", 0)},
        pluck="name",
    )
    if not bundles:
        return

    # Use query builder for aggregation
    entry_table = frappe.qb.DocType("Serial and Batch Entry")
    
    batches = (
        frappe.qb.from_(entry_table)
        .select(entry_table.batch_no, Sum(entry_table.qty).as_("qty"))
        .where(
            (entry_table.parent.isin(bundles))
            & (entry_table.batch_no.isnotnull())
        )
        .groupby(entry_table.batch_no)
    ).run(as_dict=True)

    if not batches:
        return frappe._dict({})

    # Convert to dict format: {batch_no: qty}
    return frappe._dict([(b.batch_no, b.qty) for b in batches])
    Impact:
Submission no longer errors
Batch quantity aggregation works correctly
Uses the proper query builder pattern

Technical Details
Why these changes were needed:
Material Receipt uses t_warehouse (target) instead of s_warehouse (source), so the original code didn't fetch stock for the correct warehouse.
actual_qty is a calculated field, not stored. It must be re-fetched after save/submit to display correctly.
frappe.get_all() doesn't support dict-based aggregation syntax. Use the query builder (frappe.qb) for aggregations like SUM().
