### PR TITLE
fix: add template_name to posting_date

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -1216,6 +1216,8 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 						party:
 							me.frm.doc.doctype == "Sales Invoice" ? me.frm.doc.customer : me.frm.doc.supplier,
 						company: me.frm.doc.company,
+						template_name: me.frm.doc.payment_terms_template,
+
 					},
 					callback: function (r, rt) {
 						if (r.message) {


### PR DESCRIPTION
**Issue:**
Payment Due Date got recalculated

Ref: [#50949](https://github.com/frappe/erpnext/issues/50949)

**Description:**
while editing the Invoice Date on a Sales Invoice with a Payment Terms Template that differs from the customer's default does not accurately recalculate the Payment Due Date.

**Steps to Reproduce**

1.Create two Payment Terms Templates:
       1 Week - Days after invoice = 7
       2 Weeks - Days after invoice = 14
2.Assign template 2 Weeks to a Customer.
3.Create a Sales Invoice for that Customer with  Date - 01.01.2026 and Payment Terms Template 1 Week
4.Save
5.Edit the Sales Invoice: change Date - 10.01.2026

**Before**

https://github.com/user-attachments/assets/236824a9-4a7b-4d71-b749-4f5a553da007

**After**

https://github.com/user-attachments/assets/4db4b5a6-c2f4-4060-a5c6-7f3f8dd9a585




