### PR TITLE
fix(material-request): update customer provided status

### DIFF
--- a/erpnext/controllers/status_updater.py
+++ b/erpnext/controllers/status_updater.py
@@ -130,7 +130,7 @@ status_map = {
 		],
 		[
 			"Received",
-			"eval:self.status != 'Stopped' and self.per_received == 100 and self.docstatus == 1 and self.material_request_type == 'Purchase'",
+			"eval:self.status != 'Stopped' and self.docstatus == 1 and ((self.per_received == 100 and self.material_request_type == 'Purchase') or (self.per_ordered == 100 and self.material_request_type == 'Customer Provided'))",
 		],
 		[
 			"Partially Received",
@@ -138,11 +138,11 @@ status_map = {
 		],
 		[
 			"Partially Received",
-			"eval:self.status != 'Stopped' and self.per_ordered < 100 and self.per_ordered > 0 and self.docstatus == 1 and self.material_request_type == 'Material Transfer'",
+			"eval:self.status != 'Stopped' and self.per_ordered < 100 and self.per_ordered > 0 and self.docstatus == 1 and self.material_request_type in ['Material Transfer', 'Customer Provided']",
 		],
 		[
 			"Partially Ordered",
-			"eval:self.status != 'Stopped' and self.per_ordered < 100 and self.per_ordered > 0 and self.docstatus == 1 and self.material_request_type != 'Material Transfer'",
+			"eval:self.status != 'Stopped' and self.per_ordered < 100 and self.per_ordered > 0 and self.docstatus == 1 and self.material_request_type not in ['Material Transfer', 'Customer Provided']",
 		],
 	],
 	"POS Opening Entry": [

--- a/erpnext/stock/doctype/material_request/material_request_list.js
+++ b/erpnext/stock/doctype/material_request/material_request_list.js
@@ -21,7 +21,8 @@ frappe.listview_settings["Material Request"] = {
 		} else if (
 			doc.docstatus == 1 &&
 			flt(doc.per_ordered, precision) < 100 &&
-			doc.material_request_type == "Material Transfer"
+			(doc.material_request_type == "Material Transfer" ||
+				doc.material_request_type == "Customer Provided")
 		) {
 			return [__("Partially Received"), "yellow", "per_ordered,<,100"];
 		} else if (doc.docstatus == 1 && flt(doc.per_ordered, precision) < 100) {

--- a/erpnext/stock/doctype/material_request/test_material_request.py
+++ b/erpnext/stock/doctype/material_request/test_material_request.py
@@ -934,6 +934,33 @@ class TestMaterialRequest(IntegrationTestCase):
 		self.assertEqual(mr.per_ordered, 100)
 		self.assertEqual(mr.status, "Ordered")
 
+	def test_customer_provided_received_status(self):
+		create_item("CUST-0989", is_customer_provided_item=1, customer="_Test Customer", is_purchase_item=0)
+
+		mr = make_material_request(item_code="CUST-0989", material_request_type="Customer Provided")
+		se = make_stock_entry(mr.name)
+		se.insert()
+		se.submit()
+
+		mr.reload()
+
+		self.assertEqual(mr.per_ordered, 100)
+		self.assertEqual(mr.status, "Received")
+
+	def test_customer_provided_partially_received_status(self):
+		create_item("CUST-0990", is_customer_provided_item=1, customer="_Test Customer", is_purchase_item=0)
+
+		mr = make_material_request(item_code="CUST-0990", qty=10, material_request_type="Customer Provided")
+		se = make_stock_entry(mr.name)
+		se.get("items")[0].qty = 5
+		se.insert()
+		se.submit()
+
+		mr.reload()
+
+		self.assertEqual(mr.per_ordered, 50)
+		self.assertEqual(mr.status, "Partially Received")
+
 	def test_material_request_qty_over_sales_order_limit(self):
 		from erpnext.controllers.status_updater import OverAllowanceError
 		from erpnext.selling.doctype.sales_order.test_sales_order import make_sales_order


### PR DESCRIPTION
**Issue:**
When the Material Request is created with type Customer Provided and a stock entry is made against it. The status field didn't get updated properly.

**fixes:** #49462

**Before**
<img width="1358" height="288" alt="image" src="https://github.com/user-attachments/assets/2774b958-3633-4b44-b218-b754d2eaafea" />

**After**
<img width="1482" height="325" alt="image" src="https://github.com/user-attachments/assets/56a8851b-fd66-4fd3-a342-54610ad2bcf1" />
