### PR TITLE
fix: prevent dispatch address copying on drop ship

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -1408,7 +1408,6 @@ def make_purchase_order_for_default_supplier(source_name, selected_items=None, t
 			{
 				"Sales Order": {
 					"doctype": "Purchase Order",
-					"field_map": {"dispatch_address_name": "dispatch_address"},
 					"field_no_map": [
 						"address_display",
 						"contact_display",
@@ -1417,6 +1416,7 @@ def make_purchase_order_for_default_supplier(source_name, selected_items=None, t
 						"contact_person",
 						"taxes_and_charges",
 						"shipping_address",
+						"dispatch_address",
 					],
 					"validation": {"docstatus": ["=", 1]},
 				},
@@ -1549,7 +1549,6 @@ def make_purchase_order(source_name, selected_items=None, target_doc=None):
 		{
 			"Sales Order": {
 				"doctype": "Purchase Order",
-				"field_map": {"dispatch_address_name": "dispatch_address"},
 				"field_no_map": [
 					"address_display",
 					"contact_display",
@@ -1558,6 +1557,7 @@ def make_purchase_order(source_name, selected_items=None, target_doc=None):
 					"contact_person",
 					"taxes_and_charges",
 					"shipping_address",
+					"dispatch_address",
 				],
 				"validation": {"docstatus": ["=", 1]},
 			},


### PR DESCRIPTION
**Issue:**
When creating a Drop Ship Purchase Order from a Sales Order,  the `Dispatch Address` is incorrectly copied from the Sales Order.

Ref: [#55365](https://support.frappe.io/helpdesk/tickets/55365)

**Steps to Reproduce:**

1. Create a shipping address for `Company` and `Customer`, and enable `Preferred Shipping Address`.
2. Create a `Sales Order`, enable `Supplier delivers to Customer` on the item, and set both `Shipping Address` and `Dispatch Address`.
3. Create `Purchase Order` from  `Sales Order`.
4. Notice that the PO the  Dispatch Address is copied from the Sales Order.

**Before :**

https://github.com/user-attachments/assets/ce645069-6b04-4b04-b4e0-0c8f28121fe1


**After :**


https://github.com/user-attachments/assets/aa2f22fb-44f1-4f0a-bd01-c7281e302ec9




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Internal adjustment to field mapping used when converting Sales Orders to Purchase Orders to simplify mapping logic.
  * No changes to user-facing behavior, UI, or exported interfaces.
  * No action required from users; data and workflows remain unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->