### PR TITLE
fix: remove default conversion factor in purchase invoice item

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice_item/purchase_invoice_item.json
+++ b/erpnext/accounts/doctype/purchase_invoice_item/purchase_invoice_item.json
@@ -228,7 +228,6 @@
    "reqd": 1
   },
   {
-   "default": "1",
    "depends_on": "eval:doc.uom != doc.stock_uom",
    "fieldname": "conversion_factor",
    "fieldtype": "Float",
@@ -985,7 +984,7 @@
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-10-14 13:00:54.441511",
+ "modified": "2025-12-13 14:10:02.379392",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Purchase Invoice Item",


### PR DESCRIPTION
**Issue:**
When creating a new Purchase Invoice for an Item where the `Default Purchase Unit of Measure` is different from the `Default Unit of Measure`, the Conversion Factor is not updated correctly.  

Ref: [#49650](https://support.frappe.io/helpdesk/tickets/49650)

**Steps to Reproduce:**

1. Create an Item where `Default Unit of Measure` is`Nos` `Default Purchase Unit of Measure` is `Pack` `Conversion Factor` for `Pack` is `12`

2. Create a Purchase Invoice for this Item.

3. Notice that the Conversion Factor is incorrectly set to `1` instead of `12`.
