### PR TITLE
fix: price list arg type error

### DIFF
--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -1459,7 +1459,7 @@ def get_batch_qty(batch_no, warehouse, item_code):
 
 @frappe.whitelist()
 @erpnext.normalize_ctx_input(ItemDetailsCtx)
-def apply_price_list(ctx: ItemDetailsCtx, as_doc=False, doc=None):
+def apply_price_list(ctx, as_doc=False, doc=None):
 	"""Apply pricelist on a document-like dict object and return as
 	{'parent': dict, 'children': list}
 


### PR DESCRIPTION
Open any buying or selling DocType and see the console, you will see this

```
Traceback (most recent call last):
  File "apps/frappe/frappe/utils/typing_validations.py", line 160, in transform_parameter_types
    current_arg_value_after = TypeAdapter(current_arg_type).validate_python(current_arg_value)
  File "env/lib/python3.14/site-packages/pydantic/type_adapter.py", line 441, in validate_python
    return self.validator.validate_python(
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        object,
        ^^^^^^^
    ...<6 lines>...
        by_name=by_name,
        ^^^^^^^^^^^^^^^^
    )
    ^
pydantic_core._pydantic_core.ValidationError: 1 validation error for is-instance[_dict]
  Input should be an instance of _dict [type=is_instance_of, input_value='{"items":[],"currency":"...s_internal_customer":0}', input_type=str]
    For further information visit https://errors.pydantic.dev/2.12/v/is_instance_of

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "apps/frappe/frappe/app.py", line 121, in application
    response = frappe.api.handle(request)
  File "apps/frappe/frappe/api/__init__.py", line 63, in handle
    data = endpoint(**arguments)
  File "apps/frappe/frappe/api/v1.py", line 40, in handle_rpc_call
    return frappe.handler.handle()
           ~~~~~~~~~~~~~~~~~~~~~^^
  File "apps/frappe/frappe/handler.py", line 52, in handle
    data = execute_cmd(cmd)
  File "apps/frappe/frappe/handler.py", line 85, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
           ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/__init__.py", line 1127, in call
    return fn(*args, **newargs)
  File "apps/frappe/frappe/utils/typing_validations.py", line 34, in wrapper
    args, kwargs = transform_parameter_types(func, args, kwargs)
                   ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/utils/typing_validations.py", line 162, in transform_parameter_types
    raise_type_error(func, current_arg, current_arg_type, current_arg_value, current_exception=e)
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/utils/typing_validations.py", line 73, in raise_type_error
    raise FrappeTypeError(
    ...<2 lines>...
    ) from current_exception
frappe.exceptions.FrappeTypeError: Argument 'ctx' in 'erpnext.stock.get_item_details.apply_price_list' should be of type 'frappe.types.frappedict._dict' but got 'str' instead.
request.js:478:15
```