### PR TITLE
fix: preserve user-entered exchange rates in ERR journal entries

### DIFF
--- a/erpnext/accounts/doctype/exchange_rate_revaluation/exchange_rate_revaluation.py
+++ b/erpnext/accounts/doctype/exchange_rate_revaluation/exchange_rate_revaluation.py
@@ -485,6 +485,9 @@ class ExchangeRateRevaluation(Document):
 		journal_entry.posting_date = self.posting_date
 		journal_entry.multi_currency = 1
 
+		# Prevent JE from overriding user-entered exchange rates (e.g., rate of 1)
+		journal_entry.flags.ignore_exchange_rate = True
+
 		journal_entry_accounts = []
 		for d in accounts:
 			if not flt(d.get("balance_in_account_currency"), d.precision("balance_in_account_currency")):


### PR DESCRIPTION
## Summary
- Set `ignore_exchange_rate` flag on Journal Entry to prevent user-entered exchange rates from being overridden

Fixes #51109

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where automatic exchange rate adjustments were incorrectly overriding manual revaluation entries during journal entry creation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->