### PR TITLE
fix: Fixed SLA resolution by calculation

### DIFF
--- a/erpnext/support/doctype/service_level_agreement/service_level_agreement.py
+++ b/erpnext/support/doctype/service_level_agreement/service_level_agreement.py
@@ -888,6 +888,11 @@ def set_response_by(doc, start_date_time, priority):
 
 def set_resolution_by(doc, start_date_time, priority):
 	if doc.meta.has_field("sla_resolution_by"):
+		if doc.meta.has_field("total_hold_time") and doc.get("total_hold_time"):
+			start_date_time = add_to_date(
+				start_date_time, seconds=round(doc.get("total_hold_time")), as_datetime=True
+			)
+
 		doc.sla_resolution_by = get_expected_time_for(
 			parameter="resolution", service_level=priority, start_date_time=start_date_time
 		)


### PR DESCRIPTION
**Fix: SLA resolution by date time calculation with hold time**
This PR addresses an issue where the Resolution Time calculation incorrectly included hold time, leading to a total resolution duration that could exceed the defined SLA working hours or days.

The logic has been updated to account for hold time before calculating the Resolution By datetime. This ensures that the final Resolution By datetime remains accurate and in line with SLA settings.

SLA Configurations
<img width="1120" height="793" alt="image" src="https://github.com/user-attachments/assets/555b14be-c875-40c5-bf40-a8b555fc0c7c" />
Before
<img width="1277" height="650" alt="image" src="https://github.com/user-attachments/assets/f7a92c69-6beb-40e1-bc84-94391a31df35" />
After
<img width="1244" height="594" alt="image" src="https://github.com/user-attachments/assets/da844caa-ef5c-4873-a672-9ecc55b92401" />
