### PR TITLE
fix: use yearly_opening_wdv for WDV depreciation fiscal year detection

### DIFF
--- a/erpnext/assets/doctype/asset_depreciation_schedule/asset_depreciation_schedule.py
+++ b/erpnext/assets/doctype/asset_depreciation_schedule/asset_depreciation_schedule.py
@@ -863,6 +863,7 @@ def get_wdv_or_dd_depr_amount(
 		asset,
 		fb_row,
 		depreciable_value,
+		yearly_opening_wdv,
 		schedule_idx,
 		prev_depreciation_amount,
 		has_wdv_or_dd_non_yearly_pro_rata,
@@ -875,6 +876,7 @@ def get_default_wdv_or_dd_depr_amount(
 	asset,
 	fb_row,
 	depreciable_value,
+	yearly_opening_wdv,
 	schedule_idx,
 	prev_depreciation_amount,
 	has_wdv_or_dd_non_yearly_pro_rata,
@@ -886,6 +888,7 @@ def get_default_wdv_or_dd_depr_amount(
 			asset,
 			fb_row,
 			depreciable_value,
+			yearly_opening_wdv,
 			schedule_idx,
 			prev_depreciation_amount,
 			has_wdv_or_dd_non_yearly_pro_rata,
@@ -896,6 +899,7 @@ def get_default_wdv_or_dd_depr_amount(
 			asset,
 			fb_row,
 			depreciable_value,
+			yearly_opening_wdv,
 			schedule_idx,
 			prev_depreciation_amount,
 			has_wdv_or_dd_non_yearly_pro_rata,
@@ -904,10 +908,35 @@ def get_default_wdv_or_dd_depr_amount(
 		)
 
 
+def _is_fiscal_year_start(depreciable_value, yearly_opening_wdv, schedule_idx):
+	"""
+	Detect if current depreciation period is at a fiscal year boundary.
+
+	The caller (_make_depr_schedule) resets yearly_opening_wdv = value_after_depreciation
+	whenever schedule_date crosses fiscal year end. At fiscal year start, both values
+	will be equal (within tolerance). Mid-year, yearly_opening_wdv > depreciable_value
+	as the asset value has depreciated.
+
+	Args:
+	        depreciable_value: Current asset value
+	        yearly_opening_wdv: Asset value at start of current fiscal year
+	        schedule_idx: Current period index (0-based)
+
+	Returns:
+	        bool: True if at fiscal year start, False otherwise
+	"""
+	if schedule_idx == 0:
+		return True
+
+	# Use tolerance for floating point comparison
+	return abs(flt(yearly_opening_wdv) - flt(depreciable_value)) < 0.01
+
+
 def _get_default_wdv_or_dd_depr_amount(
 	asset,
 	fb_row,
 	depreciable_value,
+	yearly_opening_wdv,
 	schedule_idx,
 	prev_depreciation_amount,
 	has_wdv_or_dd_non_yearly_pro_rata,
@@ -916,21 +945,25 @@ def _get_default_wdv_or_dd_depr_amount(
 	if cint(fb_row.frequency_of_depreciation) == 12:
 		return flt(depreciable_value) * (flt(fb_row.rate_of_depreciation) / 100)
 	else:
+		# Detect fiscal year start by comparing yearly_opening_wdv with depreciable_value
+		# The caller resets yearly_opening_wdv = value_after_depreciation at fiscal year boundary
+		is_fiscal_year_start = _is_fiscal_year_start(depreciable_value, yearly_opening_wdv, schedule_idx)
+
 		if has_wdv_or_dd_non_yearly_pro_rata:
 			if schedule_idx == 0:
 				return flt(depreciable_value) * (flt(fb_row.rate_of_depreciation) / 100)
-			elif schedule_idx % (12 / cint(fb_row.frequency_of_depreciation)) == 1:
+			elif is_fiscal_year_start:
 				return (
-					flt(depreciable_value)
+					flt(yearly_opening_wdv)
 					* flt(fb_row.frequency_of_depreciation)
 					* (flt(fb_row.rate_of_depreciation) / 1200)
 				)
 			else:
 				return prev_depreciation_amount
 		else:
-			if schedule_idx % (12 / cint(fb_row.frequency_of_depreciation)) == 0:
+			if is_fiscal_year_start:
 				return (
-					flt(depreciable_value)
+					flt(yearly_opening_wdv)
 					* flt(fb_row.frequency_of_depreciation)
 					* (flt(fb_row.rate_of_depreciation) / 1200)
 				)
@@ -942,23 +975,27 @@ def _get_daily_prorata_based_default_wdv_or_dd_depr_amount(
 	asset,
 	fb_row,
 	depreciable_value,
+	yearly_opening_wdv,
 	schedule_idx,
 	prev_depreciation_amount,
 	has_wdv_or_dd_non_yearly_pro_rata,
 	asset_depr_schedule,
 	prev_per_day_depr,
 ):
-	if has_wdv_or_dd_non_yearly_pro_rata:  # If applicable days for ther first month is less than full month
+	# Detect fiscal year start by comparing yearly_opening_wdv with depreciable_value
+	is_fiscal_year_start = _is_fiscal_year_start(depreciable_value, yearly_opening_wdv, schedule_idx)
+
+	if has_wdv_or_dd_non_yearly_pro_rata:  # If applicable days for the first month is less than full month
 		if schedule_idx == 0:
 			return flt(depreciable_value) * (flt(fb_row.rate_of_depreciation) / 100), None
 
-		elif schedule_idx % (12 / cint(fb_row.frequency_of_depreciation)) == 1:  # Year changes
-			return get_monthly_depr_amount(fb_row, schedule_idx, depreciable_value)
+		elif is_fiscal_year_start:
+			return get_monthly_depr_amount(fb_row, schedule_idx, yearly_opening_wdv)
 		else:
 			return get_monthly_depr_amount_based_on_prev_per_day_depr(fb_row, schedule_idx, prev_per_day_depr)
 	else:
-		if schedule_idx % (12 / cint(fb_row.frequency_of_depreciation)) == 0:  # year changes
-			return get_monthly_depr_amount(fb_row, schedule_idx, depreciable_value)
+		if is_fiscal_year_start:
+			return get_monthly_depr_amount(fb_row, schedule_idx, yearly_opening_wdv)
 		else:
 			return get_monthly_depr_amount_based_on_prev_per_day_depr(fb_row, schedule_idx, prev_per_day_depr)
 

--- a/erpnext/assets/doctype/asset_depreciation_schedule/asset_depreciation_schedule.py
+++ b/erpnext/assets/doctype/asset_depreciation_schedule/asset_depreciation_schedule.py
@@ -989,7 +989,9 @@ def _get_daily_prorata_based_default_wdv_or_dd_depr_amount(
 		if schedule_idx == 0:
 			return flt(depreciable_value) * (flt(fb_row.rate_of_depreciation) / 100), None
 
-		elif is_fiscal_year_start:
+		elif is_fiscal_year_start or prev_per_day_depr is None:
+			# Recalculate at fiscal year boundary or when per_day_depr not yet established
+			# (prev_per_day_depr is None after first pro-rated period)
 			return get_monthly_depr_amount(fb_row, schedule_idx, yearly_opening_wdv)
 		else:
 			return get_monthly_depr_amount_based_on_prev_per_day_depr(fb_row, schedule_idx, prev_per_day_depr)


### PR DESCRIPTION
## Summary

Fixes WDV/DD depreciation calculation for migrated assets where the schedule_idx modulo arithmetic fails to detect actual fiscal year boundaries.

## Problem

The depreciation recalculation was using `schedule_idx % (12 / frequency) == 1` to detect year changes. This fails for migrated assets with `opening_number_of_booked_depreciations > 0` because the schedule index doesn't align with actual fiscal year boundaries.

## Solution

- Pass `yearly_opening_wdv` through to calculation functions (it was already calculated correctly but ignored)
- Add `_is_fiscal_year_start()` helper to detect fiscal year boundaries by comparing `yearly_opening_wdv` with `depreciable_value`
- Use `yearly_opening_wdv` for recalculation at fiscal year start

The caller (`_make_depr_schedule`) already correctly tracks fiscal year boundaries using `get_fiscal_year()` and resets `yearly_opening_wdv` at each boundary. This fix properly utilizes that value.

## Test Plan

- [x] Verified Python syntax compiles correctly
- [ ] Test with existing asset (no migration) - should work as before
- [ ] Test with migrated asset - depreciation should now recalculate at actual fiscal year start (April for Apr-Mar fiscal year) instead of arbitrary month

Fixes #51115

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Asset depreciation now correctly handles fiscal-year boundaries by using the opening-year value when a new fiscal year starts.
  * Depreciation calculations (including prorata/monthly paths) have been adjusted to apply the correct starting value at year changes, producing more accurate per-period and accumulated depreciation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->