### PR TITLE
fix: payment recalculation logic in case of date update through list view

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
@@ -112,40 +112,31 @@ class TestSalesInvoice(ERPNextTestSuite):
 	def tearDownClass(self):
 		unlink_payment_on_cancel_of_invoice(0)
 
-	def test_payment_date_recalculate(self):
+	def test_payment_date_recalculation(self):
 		posting_date = getdate()
 		new_posting_date = add_days(posting_date, 5)
+		payment_term = frappe.new_doc("Payment Term")
+		payment_term.payment_term_name = "Test Term 2 Days"
+		payment_term.invoice_portion = 100
+		payment_term.credit_days = 2
+		payment_term.save()
 
-		payment_term = frappe.get_doc(
-			{
-				"doctype": "Payment Term",
-				"payment_term_name": "Test Term 2 Days",
-				"invoice_portion": 100,
-				"credit_days": 2,
-			}
-		).insert()
-
-		ptt = frappe.get_doc(
-			{
-				"doctype": "Payment Terms Template",
-				"template_name": "Test Template Recalc",
-				"terms": [{"payment_term": payment_term.name, "invoice_portion": 100, "credit_days": 2}],
-			}
-		).insert()
+		payment_term_template = frappe.new_doc("Payment Terms Template")
+		payment_term_template.template_name = "Test Template Recalc"
+		payment_term_template.append(
+			"terms", {"payment_term": payment_term.name, "invoice_portion": 100, "credit_days": 2}
+		)
+		payment_term_template.save()
 
 		si = create_sales_invoice(do_not_save=1)
+		si.set_posting_time = 1
 		si.posting_date = posting_date
-		si.payment_terms_template = ptt.name
-		si.set_missing_values()
-		si.set_payment_schedule()
-		si.set_due_date()
-		si.insert()
-
+		si.payment_terms_template = payment_term_template.name
+		si.save()
 		self.assertEqual(si.payment_schedule[0].due_date, add_days(posting_date, 2))
 
-		si = frappe.get_doc("Sales Invoice", si.name)
-
-		recalculate_payment_due_date(new_posting_date, si.payment_schedule)
+		si.update({"posting_date": new_posting_date})
+		si.save()
 
 		self.assertEqual(si.payment_schedule[0].due_date, add_days(new_posting_date, 2))
 

--- a/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
@@ -27,7 +27,11 @@ from erpnext.assets.doctype.asset.test_asset import create_asset, create_asset_d
 from erpnext.assets.doctype.asset_depreciation_schedule.asset_depreciation_schedule import (
 	get_depr_schedule,
 )
-from erpnext.controllers.accounts_controller import InvalidQtyError, update_invoice_status
+from erpnext.controllers.accounts_controller import (
+	InvalidQtyError,
+	recalculate_payment_due_date,
+	update_invoice_status,
+)
 from erpnext.controllers.taxes_and_totals import get_itemised_tax_breakup_data
 from erpnext.exceptions import InvalidAccountCurrency, InvalidCurrency
 from erpnext.selling.doctype.customer.test_customer import get_customer_dict
@@ -107,6 +111,43 @@ class TestSalesInvoice(ERPNextTestSuite):
 	@classmethod
 	def tearDownClass(self):
 		unlink_payment_on_cancel_of_invoice(0)
+
+	def test_payment_date_recalculate(self):
+		posting_date = getdate()
+		new_posting_date = add_days(posting_date, 5)
+
+		payment_term = frappe.get_doc(
+			{
+				"doctype": "Payment Term",
+				"payment_term_name": "Test Term 2 Days",
+				"invoice_portion": 100,
+				"credit_days": 2,
+			}
+		).insert()
+
+		ptt = frappe.get_doc(
+			{
+				"doctype": "Payment Terms Template",
+				"template_name": "Test Template Recalc",
+				"terms": [{"payment_term": payment_term.name, "invoice_portion": 100, "credit_days": 2}],
+			}
+		).insert()
+
+		si = create_sales_invoice(do_not_save=1)
+		si.posting_date = posting_date
+		si.payment_terms_template = ptt.name
+		si.set_missing_values()
+		si.set_payment_schedule()
+		si.set_due_date()
+		si.insert()
+
+		self.assertEqual(si.payment_schedule[0].due_date, add_days(posting_date, 2))
+
+		si = frappe.get_doc("Sales Invoice", si.name)
+
+		recalculate_payment_due_date(new_posting_date, si.payment_schedule)
+
+		self.assertEqual(si.payment_schedule[0].due_date, add_days(new_posting_date, 2))
 
 	def test_sales_invoice_qty(self):
 		si = create_sales_invoice(qty=0, do_not_save=True)

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -658,8 +658,8 @@ class AccountsController(TransactionBase):
 			return
 
 		self.validate_payment_schedule_dates()
-		self.set_due_date()
 		self.set_payment_schedule()
+		self.set_due_date()
 		if not self.get("ignore_default_payment_terms_template"):
 			self.validate_payment_schedule_amount()
 			self.validate_due_date()
@@ -2567,6 +2567,8 @@ class AccountsController(TransactionBase):
 					base_payment_amount=base_grand_total,
 				)
 				self.append("payment_schedule", data)
+		elif not self.is_new() and self.get_doc_before_save().posting_date != posting_date:
+			recalculate_payment_due_date(posting_date, self.payment_schedule)
 
 		allocate_payment_based_on_payment_terms = frappe.db.get_value(
 			"Payment Terms Template", self.payment_terms_template, "allocate_payment_based_on_payment_terms"
@@ -4359,3 +4361,9 @@ def update_doc_company_address(current_doctype, docname, company_address, detail
 		.set(getattr(DocType, display_field), get_address_display(company_address))
 		.where(DocType.name == docname)
 	).run()
+
+
+def recalculate_payment_due_date(posting_date, payment_schedule):
+	for terms in payment_schedule:
+		terms.due_date = get_due_date(terms, posting_date)
+		print(posting_date)

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -2569,13 +2569,18 @@ class AccountsController(TransactionBase):
 				self.append("payment_schedule", data)
 		elif (not self.is_new()) and posting_date:
 			doc_before_save = self.get_doc_before_save()
-			old_posting_date = (
-				doc_before_save.get("bill_date")
-				or doc_before_save.get("transaction_date")
-				or doc_before_save.get("posting_date")
-			)
-			if getdate(old_posting_date) != getdate(posting_date):
-				recalculate_payment_due_date(posting_date, self.payment_schedule)
+
+			if doc_before_save:
+				old_posting_date = (
+					doc_before_save.get("bill_date")
+					or doc_before_save.get("transaction_date")
+					or doc_before_save.get("posting_date")
+				)
+
+				if getdate(old_posting_date) != getdate(posting_date) and any(
+					[term.payment_term for term in self.payment_schedule]
+				):
+					recalculate_payment_due_date(posting_date, self.payment_schedule)
 
 		allocate_payment_based_on_payment_terms = frappe.db.get_value(
 			"Payment Terms Template", self.payment_terms_template, "allocate_payment_based_on_payment_terms"

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -2567,8 +2567,15 @@ class AccountsController(TransactionBase):
 					base_payment_amount=base_grand_total,
 				)
 				self.append("payment_schedule", data)
-		elif not self.is_new() and self.get_doc_before_save().posting_date != posting_date:
-			recalculate_payment_due_date(posting_date, self.payment_schedule)
+		elif (not self.is_new()) and posting_date:
+			doc_before_save = self.get_doc_before_save()
+			old_posting_date = (
+				doc_before_save.get("bill_date")
+				or doc_before_save.get("transaction_date")
+				or doc_before_save.get("posting_date")
+			)
+			if getdate(old_posting_date) != getdate(posting_date):
+				recalculate_payment_due_date(posting_date, self.payment_schedule)
 
 		allocate_payment_based_on_payment_terms = frappe.db.get_value(
 			"Payment Terms Template", self.payment_terms_template, "allocate_payment_based_on_payment_terms"
@@ -4366,4 +4373,3 @@ def update_doc_company_address(current_doctype, docname, company_address, detail
 def recalculate_payment_due_date(posting_date, payment_schedule):
 	for terms in payment_schedule:
 		terms.due_date = get_due_date(terms, posting_date)
-		print(posting_date)


### PR DESCRIPTION
The following fixes : https://github.com/frappe/erpnext/issues/50949

In the scenario when we try updating the posting date in sales invoice through list view using the edit function, it used to not update the payment due date. This is fixed in this solution.

`no-docs`