### PR TITLE
fix: use serial and batch bundle to fetch incoming rate

### DIFF
--- a/erpnext/assets/doctype/asset_capitalization/asset_capitalization.js
+++ b/erpnext/assets/doctype/asset_capitalization/asset_capitalization.js
@@ -194,6 +194,13 @@ erpnext.assets.AssetCapitalization = class AssetCapitalization extends erpnext.s
 		}
 	}
 
+	serial_and_batch_bundle(doc, cdt, cdn) {
+		let row = locals[cdt][cdn];
+		if (cdt === "Asset Capitalization Stock Item") {
+			this.get_warehouse_details(row);
+		}
+	}
+
 	asset(doc, cdt, cdn) {
 		var row = frappe.get_doc(cdt, cdn);
 		if (cdt === "Asset Capitalization Asset Item") {
@@ -407,6 +414,7 @@ erpnext.assets.AssetCapitalization = class AssetCapitalization extends erpnext.s
 						voucher_type: me.frm.doc.doctype,
 						voucher_no: me.frm.doc.name,
 						allow_zero_valuation: 1,
+						serial_and_batch_bundle: item.serial_and_batch_bundle,
 					},
 				},
 				callback: function (r) {

--- a/erpnext/assets/doctype/asset_capitalization/asset_capitalization.js
+++ b/erpnext/assets/doctype/asset_capitalization/asset_capitalization.js
@@ -195,7 +195,7 @@ erpnext.assets.AssetCapitalization = class AssetCapitalization extends erpnext.s
 	}
 
 	serial_and_batch_bundle(doc, cdt, cdn) {
-		let row = locals[cdt][cdn];
+		var row = frappe.get_doc(cdt, cdn);
 		if (cdt === "Asset Capitalization Stock Item") {
 			this.get_warehouse_details(row);
 		}

--- a/erpnext/assets/doctype/asset_capitalization/asset_capitalization.py
+++ b/erpnext/assets/doctype/asset_capitalization/asset_capitalization.py
@@ -352,6 +352,7 @@ class AssetCapitalization(StockController):
 				"voucher_no": self.name,
 				"company": self.company,
 				"allow_zero_valuation": cint(item.get("allow_zero_valuation_rate")),
+				"serial_and_batch_bundle": item.serial_and_batch_bundle,
 			}
 		)
 
@@ -723,6 +724,7 @@ def get_consumed_stock_item_details(ctx: ItemDetailsCtx):
 				"company": ctx.company,
 				"serial_no": ctx.serial_no,
 				"batch_no": ctx.batch_no,
+				"serial_and_batch_bundle": ctx.serial_and_batch_bundle,
 			}
 		)
 		out.update(get_warehouse_details(incoming_rate_args))


### PR DESCRIPTION
Issue: When Asset Capitalisation is created by consuming a Stock Item, the system fetches the valuation rate without considering the mentioned Serial and Batch Bundle.
Because of this, the valuation amount becomes incorrect, which causes a Debit and Credit mismatch during GL Entry creation, and the document fails to submit.

Ref: [55430](https://support.frappe.io/helpdesk/tickets/55430?view=VIEW-HD+Ticket-845)

Steps to Reproduce
1) Create an Item with Serial No enabled.
2) Create a Stock Entry:
   - Item Qty: 1, Rate: 156,600, Serial No(Auto Created): S0001
3) Create another Stock Entry for the same item:
   - Item Qty: 1, Rate: 170,600, Serial No(Auto Created): S0002
4) Create a Serial and Batch Bundle for serial number S0001.
5) Create an Asset Capitalisation entry:
   - Add the item in the line item table.
   - Select the Serial and Batch Bundle corresponding to S0001.
6) Observe the valuation rate fetched in the Asset Capitalisation line item.
7) Try submitting the document.

Expected Behaviour:
The system should fetch the valuation_rate associated with that mentioned Serial and Batch Bundle's Serial No

Before:

https://github.com/user-attachments/assets/ccb42e81-7d99-435e-a759-6cb6d825c65d

After:

https://github.com/user-attachments/assets/f57857f1-46e7-4655-a156-3e833a3e9fed


Backport Needed v15
