### PR TITLE
fix(subcontract): ignore BOM qty validation for alternative items

### DIFF
--- a/erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py
+++ b/erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py
@@ -571,6 +571,12 @@ class SubcontractingReceipt(SubcontractingController):
 
 		for row in self.items:
 			precision = row.precision("qty")
+
+			# if allow alternative item, ignore the validation as per BOM required qty
+			is_allow_alternative_item = frappe.db.get_value("BOM", row.bom, "allow_alternative_item")
+			if is_allow_alternative_item:
+				continue
+
 			for bom_item in self._get_materials_from_bom(
 				row.item_code, row.bom, row.get("include_exploded_items")
 			):


### PR DESCRIPTION
**Issue:** Unable to consume the alternative items in Subcontracting Receipt.

**Reference Issue: https://github.com/frappe/erpnext/issues/51089**

