### PR TITLE
fix(accounting-dimension): unable to club multiple DN if it's mapped to a different project

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -1021,13 +1021,17 @@ class SalesInvoice(SellingController):
 					"compare_fields": [
 						["customer", "="],
 						["company", "="],
-						["project", "="],
 						["currency", "="],
 					],
 				},
 				"Sales Order Item": {
 					"ref_dn_field": "so_detail",
-					"compare_fields": [["item_code", "="], ["uom", "="], ["conversion_factor", "="]],
+					"compare_fields": [
+						["item_code", "="],
+						["uom", "="],
+						["conversion_factor", "="],
+						["project", "="],
+					],
 					"is_child_table": True,
 					"allow_duplicate_prev_row_id": True,
 				},
@@ -1036,13 +1040,17 @@ class SalesInvoice(SellingController):
 					"compare_fields": [
 						["customer", "="],
 						["company", "="],
-						["project", "="],
 						["currency", "="],
 					],
 				},
 				"Delivery Note Item": {
 					"ref_dn_field": "dn_detail",
-					"compare_fields": [["item_code", "="], ["uom", "="], ["conversion_factor", "="]],
+					"compare_fields": [
+						["item_code", "="],
+						["uom", "="],
+						["conversion_factor", "="],
+						["project", "="],
+					],
 					"is_child_table": True,
 					"allow_duplicate_prev_row_id": True,
 				},

--- a/erpnext/public/js/utils/dimension_tree_filter.js
+++ b/erpnext/public/js/utils/dimension_tree_filter.js
@@ -16,10 +16,6 @@ erpnext.accounts.dimensions = {
 			},
 			callback: function (r) {
 				me.accounting_dimensions = r.message[0];
-				// Ignoring "Project" as it is already handled specifically in Sales Order and Delivery Note
-				me.accounting_dimensions = me.accounting_dimensions.filter((x) => {
-					return x.document_type != "Project";
-				});
 				me.default_dimensions = r.message[1];
 				me.setup_filters(frm, doctype);
 				me.update_dimension(frm, doctype);

--- a/erpnext/public/js/utils/sales_common.js
+++ b/erpnext/public/js/utils/sales_common.js
@@ -495,7 +495,16 @@ erpnext.sales_common = {
 				}
 			}
 
-			project() {
+			project(doc, cdt, cdn) {
+				var item = frappe.get_doc(cdt, cdn);
+				if (item.project) {
+					$.each(this.frm.doc["items"] || [], function (i, other_item) {
+						if (!other_item.project) {
+							other_item.project = item.project;
+							refresh_field("project", other_item.name, other_item.parentfield);
+						}
+					});
+				}
 				let me = this;
 				if (["Delivery Note", "Sales Invoice", "Sales Order"].includes(this.frm.doc.doctype)) {
 					if (this.frm.doc.project) {


### PR DESCRIPTION
Issue: 

- **Incorrect values error pops-up when combining vouchers from multiple projects in one Sales Invoice**
 > If two different Delivery Notes (each linked to a different Project in parent level) are clubbed into a single Sales Invoice, the system shows incorrect values. This appears to be caused by validation rules tied to the Project selected at the parent level. 
 
- **Project not auto-filling at the item level**
 > When a Project is selected at the parent level in a document (e.g., Delivery Note or Sales Invoice), it does not automatically populate in the Project field at the item row level.

- **Project not carried forward to new rows**
> When adding a new row in the Items table, the Project field from the previous row is not automatically copied forward, requiring manual entry each time.

Ref: [55502](https://support.frappe.io/helpdesk/tickets/55502)

Before:

[Screencast from 2025-12-17 17-55-26.webm](https://github.com/user-attachments/assets/835e9ec0-29b5-4386-b4b7-d01570c64d32)

After:

[Screencast from 2025-12-17 18-08-49.webm](https://github.com/user-attachments/assets/4af2907f-9faa-4ad1-9346-066f57eeb48f)

**Backport Needed: Version-15**