### PR TITLE
fix(buying): add disabled filter for supplier

### DIFF
--- a/erpnext/buying/doctype/request_for_quotation/request_for_quotation.js
+++ b/erpnext/buying/doctype/request_for_quotation/request_for_quotation.js
@@ -551,7 +551,10 @@ erpnext.buying.RequestforQuotationController = class RequestforQuotationControll
 				} else if (args.supplier_group) {
 					frappe.db
 						.get_list("Supplier", {
-							filters: { supplier_group: args.supplier_group },
+							filters: {
+								supplier_group: args.supplier_group,
+								disabled: 0,
+							},
 							limit: 100,
 							order_by: "name",
 						})


### PR DESCRIPTION
**Issue:**
Disabled suppliers are appearing in the suppliers child table when adding the suppliers to a Request for Quotation.

**Ref:** [#55656](https://support.frappe.io/helpdesk/tickets/55656)

**Before:**

<img width="1864" height="972" alt="image" src="https://github.com/user-attachments/assets/0729ac9d-047a-4662-87bb-cdbe6c999d5f" />

**After:**

<img width="1862" height="973" alt="image" src="https://github.com/user-attachments/assets/feb4f37a-e9a9-4f16-a322-ee8ea5b88c5f" />

**Backport Needed for v15**