### PR TITLE
fix: show company currency in asset depreciation schedule

### DIFF
--- a/erpnext/assets/doctype/asset/asset.js
+++ b/erpnext/assets/doctype/asset/asset.js
@@ -270,8 +270,14 @@ frappe.ui.form.on("Asset", {
 			const row = [
 				sch["idx"],
 				frappe.format(sch["schedule_date"], { fieldtype: "Date" }),
-				frappe.format(sch["depreciation_amount"], { fieldtype: "Currency" }),
-				frappe.format(sch["accumulated_depreciation_amount"], { fieldtype: "Currency" }),
+				frappe.format(sch["depreciation_amount"], {
+					fieldtype: "Currency",
+					options: "Company:company:default_currency",
+				}),
+				frappe.format(sch["accumulated_depreciation_amount"], {
+					fieldtype: "Currency",
+					options: "Company:company:default_currency",
+				}),
 				sch["journal_entry"] || "",
 			];
 


### PR DESCRIPTION
Issue: Global default currency was being shown instead of company currency in Asset Depreciation Schedule View

Ref: [55497](https://support.frappe.io/helpdesk/tickets/55497?view=VIEW-HD+Ticket-745)

**Before:**
![before currency change](https://github.com/user-attachments/assets/fdedda9d-3870-478e-9d05-a24912e0341f)

**After:**
![after currency change](https://github.com/user-attachments/assets/b5253b6a-5b85-4777-9e15-52f252712ac1)

Backport need in v15