### PR TITLE
fix(material-request): get remaining qty on partial transaction with product bundle

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -1030,17 +1030,20 @@ def make_material_request(source_name, target_doc=None):
 
 	def get_remaining_packed_item_qty(so_item):
 		delivered_qty = frappe.db.get_value(
-			"Sales Order Item", {"docstatus": 1, "name": so_item.parent_detail_docname}, ["delivered_qty"]
+			"Sales Order Item", {"name": so_item.parent_detail_docname}, ["delivered_qty"]
 		)
 
-		bundle_item_qty = frappe.db.get_value("Product Bundle Item", {"parent": so_item.parent_item}, ["qty"])
+		bundle_item_qty = frappe.db.get_value(
+			"Product Bundle Item", {"parent": so_item.parent_item, "item_code": so_item.item_code}, ["qty"]
+		)
 
 		return flt(
 			(
 				flt(so_item.qty)
 				- flt(requested_item_qty.get(so_item.name, {}).get("qty"))
 				- max(
-					flt(delivered_qty) - flt(requested_item_qty.get(so_item.name, {}).get("received_qty")),
+					flt(delivered_qty) * flt(bundle_item_qty)
+					- flt(requested_item_qty.get(so_item.name, {}).get("received_qty")),
 					0,
 				)
 			)

--- a/erpnext/stock/doctype/material_request/test_material_request.py
+++ b/erpnext/stock/doctype/material_request/test_material_request.py
@@ -1011,7 +1011,7 @@ class TestMaterialRequest(IntegrationTestCase):
 		mr = make_material_request(so.name)
 
 		self.assertEqual(mr.items[0].qty, 5)
-		self.assertEqual(mr.items[0].qty, 5)
+		self.assertEqual(mr.items[1].qty, 5)
 
 	def test_pending_qty_in_pick_list(self):
 		"""Test for pick list mapped doc qty from partially received Material Request Transfer"""

--- a/erpnext/stock/doctype/material_request/test_material_request.py
+++ b/erpnext/stock/doctype/material_request/test_material_request.py
@@ -973,6 +973,46 @@ class TestMaterialRequest(IntegrationTestCase):
 
 		self.assertRaises(OverAllowanceError, mr.submit)
 
+	def test_get_remaining_qty_from_sales_order(self):
+		from frappe.utils import add_to_date, today
+
+		from erpnext.selling.doctype.product_bundle.test_product_bundle import make_product_bundle
+		from erpnext.selling.doctype.sales_order.sales_order import make_material_request
+		from erpnext.selling.doctype.sales_order.test_sales_order import make_sales_order
+
+		sub_item_a = "_Test Bundle ItemA"
+		create_item(sub_item_a, is_customer_provided_item=1, customer="_Test Customer", is_purchase_item=0)
+
+		sub_item_b = "_Test Bundle ItemB"
+		create_item(sub_item_b, is_customer_provided_item=1, customer="_Test Customer", is_purchase_item=0)
+
+		bundle_item = "_Test Bundle"
+		create_item(
+			bundle_item,
+			is_stock_item=0,
+			is_customer_provided_item=1,
+			customer="_Test Customer",
+			is_purchase_item=0,
+		)
+
+		pb = make_product_bundle(parent=bundle_item, items=[sub_item_a, sub_item_b])
+		pb.submit()
+
+		so = make_sales_order(item_code=bundle_item)
+		so.submit()
+
+		mr = make_material_request(so.name)
+		mr.schedule_date = add_to_date(today(), days=1, as_string=True)
+		mr.get("items")[0].qty = 5
+		mr.get("items")[1].qty = 5
+		mr.insert()
+		mr.submit()
+
+		mr = make_material_request(so.name)
+
+		self.assertEqual(mr.items[0].qty, 5)
+		self.assertEqual(mr.items[0].qty, 5)
+
 	def test_pending_qty_in_pick_list(self):
 		"""Test for pick list mapped doc qty from partially received Material Request Transfer"""
 		import json

--- a/erpnext/stock/doctype/material_request/test_material_request.py
+++ b/erpnext/stock/doctype/material_request/test_material_request.py
@@ -995,8 +995,7 @@ class TestMaterialRequest(IntegrationTestCase):
 			is_purchase_item=0,
 		)
 
-		pb = make_product_bundle(parent=bundle_item, items=[sub_item_a, sub_item_b])
-		pb.submit()
+		make_product_bundle(parent=bundle_item, items=[sub_item_a, sub_item_b])
 
 		so = make_sales_order(item_code=bundle_item)
 		so.submit()

--- a/erpnext/stock/doctype/material_request_item/material_request_item.json
+++ b/erpnext/stock/doctype/material_request_item/material_request_item.json
@@ -56,6 +56,7 @@
   "lead_time_date",
   "sales_order",
   "sales_order_item",
+  "packed_item",
   "col_break4",
   "production_plan",
   "material_request_plan_item",
@@ -528,6 +529,16 @@
    "no_copy": 1,
    "non_negative": 1,
    "read_only": 1
+  },
+  {
+   "fieldname": "packed_item",
+   "fieldtype": "Data",
+   "hidden": 1,
+   "label": "Packed Item",
+   "no_copy": 1,
+   "print_hide": 1,
+   "read_only": 1,
+   "search_index": 1
   }
  ],
  "idx": 1,

--- a/erpnext/stock/doctype/material_request_item/material_request_item.py
+++ b/erpnext/stock/doctype/material_request_item/material_request_item.py
@@ -37,6 +37,7 @@ class MaterialRequestItem(Document):
 		material_request_plan_item: DF.Data | None
 		min_order_qty: DF.Float
 		ordered_qty: DF.Float
+		packed_item: DF.Data | None
 		page_break: DF.Check
 		parent: DF.Data
 		parentfield: DF.Data


### PR DESCRIPTION
**Issue**:

A Material Request is created for a partial quantity against the Sales Order for bundle items. When a new Material Request is created, the remaining quantity is not fetched from the Sales Order.

**fixes**: #43329 

**Before**:

[Screencast from 2025-12-17 13-47-41.webm](https://github.com/user-attachments/assets/da3a3c71-8543-4183-a111-672a468a2d7b)

**After**:

[Screencast from 2025-12-17 13-25-05.webm](https://github.com/user-attachments/assets/fa095a69-8f03-47ae-9039-2ea344796deb)

Backport needed for v15
