### PR TITLE
fix(accounting-dimension): System-generated round-off GL entries fail to set the accounting dimension

### DIFF
--- a/erpnext/accounts/doctype/gl_entry/gl_entry.py
+++ b/erpnext/accounts/doctype/gl_entry/gl_entry.py
@@ -193,7 +193,6 @@ class GLEntry(Document):
 				account_type == "Profit and Loss"
 				and self.company == dimension.company
 				and dimension.mandatory_for_pl
-				and not dimension.disabled
 				and not self.is_cancelled
 			):
 				if not self.get(dimension.fieldname):
@@ -207,7 +206,6 @@ class GLEntry(Document):
 				account_type == "Balance Sheet"
 				and self.company == dimension.company
 				and dimension.mandatory_for_bs
-				and not dimension.disabled
 				and not self.is_cancelled
 			):
 				if not self.get(dimension.fieldname):

--- a/erpnext/accounts/doctype/payment_ledger_entry/payment_ledger_entry.py
+++ b/erpnext/accounts/doctype/payment_ledger_entry/payment_ledger_entry.py
@@ -131,7 +131,6 @@ class PaymentLedgerEntry(Document):
 				account_type == "Profit and Loss"
 				and self.company == dimension.company
 				and dimension.mandatory_for_pl
-				and not dimension.disabled
 			):
 				if not self.get(dimension.fieldname):
 					frappe.throw(
@@ -144,7 +143,6 @@ class PaymentLedgerEntry(Document):
 				account_type == "Balance Sheet"
 				and self.company == dimension.company
 				and dimension.mandatory_for_bs
-				and not dimension.disabled
 			):
 				if not self.get(dimension.fieldname):
 					frappe.throw(

--- a/erpnext/accounts/general_ledger.py
+++ b/erpnext/accounts/general_ledger.py
@@ -626,10 +626,14 @@ def update_accounting_dimensions(round_off_gle):
 		for dimension in dimensions:
 			round_off_gle[dimension] = dimension_values.get(dimension)
 	else:
+		report_type = frappe.get_cached_value("Account", round_off_gle.account, "report_type")
 		for dimension in get_checks_for_pl_and_bs_accounts():
 			if (
 				round_off_gle.company == dimension.company
-				and dimension.mandatory_for_pl
+				and (
+					(report_type == "Profit and Loss" and dimension.mandatory_for_pl)
+					or (report_type == "Balance Sheet" and dimension.mandatory_for_bs)
+				)
 				and dimension.default_dimension
 			):
 				round_off_gle[dimension.fieldname] = dimension.default_dimension

--- a/erpnext/accounts/general_ledger.py
+++ b/erpnext/accounts/general_ledger.py
@@ -14,6 +14,7 @@ from frappe.utils.dashboard import cache_source
 import erpnext
 from erpnext.accounts.doctype.accounting_dimension.accounting_dimension import (
 	get_accounting_dimensions,
+	get_checks_for_pl_and_bs_accounts,
 )
 from erpnext.accounts.doctype.accounting_dimension_filter.accounting_dimension_filter import (
 	get_dimension_filter_map,
@@ -624,6 +625,14 @@ def update_accounting_dimensions(round_off_gle):
 
 		for dimension in dimensions:
 			round_off_gle[dimension] = dimension_values.get(dimension)
+	else:
+		for dimension in get_checks_for_pl_and_bs_accounts():
+			if (
+				round_off_gle.company == dimension.company
+				and dimension.mandatory_for_pl
+				and dimension.default_dimension
+			):
+				round_off_gle[dimension.fieldname] = dimension.default_dimension
 
 
 def get_round_off_account_and_cost_center(company, voucher_type, voucher_no, use_company_default=False):


### PR DESCRIPTION
**Issue:** 

System-generated round-off GL entries fail to set the accounting dimension when a cost center allocation is assigned in a JV, preventing users from submitting the journal entry.

Removed the Disable condition, which has already handled in the fetch.

Ref: [55554](https://support.frappe.io/helpdesk/tickets/55554)

**Steps to reproduce:**

- Create an Accounting Dimension for Branch Doctype.
- Set it as mandatory for Profit and Loss for Company X.
- Create a Cost Center Allocation for the default cost center in the Company master, similar to the attached image.
- Create a Journal Entry for Company X with an expense account for the amount shown in the attached image.
- On Save and Submit, an error appears related to the Round Off Account, which is set by the system.

**Accounting Dimension:**

<img width="1635" height="334" alt="image" src="https://github.com/user-attachments/assets/dfc01413-f346-45b6-ae71-c1895401acf6" />


**Cost Center Allocation:**

<img width="1631" height="934" alt="image" src="https://github.com/user-attachments/assets/573b710e-f0e9-4c3a-aae6-f4c6ae61f88f" />


Before:

<img width="1630" height="923" alt="image" src="https://github.com/user-attachments/assets/3c2d611d-2e73-4594-aafd-1d73ed723d72" />

After:

<img width="1636" height="768" alt="image" src="https://github.com/user-attachments/assets/9a9f8a87-3090-4901-89fe-dcaaae664034" />

<img width="1632" height="916" alt="image" src="https://github.com/user-attachments/assets/2fab5a28-37bb-4f62-88ab-71a4e1b72921" />


**Backport Needed: Version-15**