### PR TITLE
fix: Disallow due date to be before the posting date in Quotation

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -2707,7 +2707,9 @@ class AccountsController(TransactionBase):
 
 		for d in self.get("payment_schedule"):
 			d.validate_from_to_dates("discount_date", "due_date")
-			if self.doctype == "Sales Order" and getdate(d.due_date) < getdate(self.transaction_date):
+			if self.doctype in ["Sales Order", "Quotation"] and getdate(d.due_date) < getdate(
+				self.transaction_date
+			):
 				frappe.throw(
 					_("Row {0}: Due Date in the Payment Terms table cannot be before Posting Date").format(
 						d.idx

--- a/erpnext/selling/doctype/quotation/test_quotation.py
+++ b/erpnext/selling/doctype/quotation/test_quotation.py
@@ -52,6 +52,11 @@ class TestQuotation(IntegrationTestCase):
 		self.assertEqual(qo.get("items")[0].qty, 11)
 		self.assertEqual(qo.get("items")[-1].rate, 100)
 
+	def test_disallow_due_date_before_transaction_date(self):
+		qo = make_quotation(qty=3, do_not_submit=1)
+		qo.payment_schedule[0].due_date = add_days(qo.transaction_date, -2)
+		self.assertRaises(frappe.ValidationError, qo.save)
+
 	def test_update_child_disallow_rate_change(self):
 		qo = make_quotation(qty=4)
 		trans_item = json.dumps(


### PR DESCRIPTION
In the current working, we were permitting the user to give a due date which was before the posting date in Quotation, which is not permitted in Sales order. To avoid the issues for advance due date that would occur when sales order gets created from quotation, validation is added for quotation as well. It fixes https://github.com/frappe/erpnext/issues/42873.

`no-docs`
