### PR TITLE
fix: manual depreciation update logic

### DIFF
--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -187,13 +187,15 @@ class Asset(AccountsController):
 	def has_depreciation_settings_changed(self, schedule_doc, fb_row):
 		"""Check if depreciation calculation settings have changed"""
 
-		# For non-manual depreciation methods, always check for changes
-		if schedule_doc.depreciation_method != "Manual":
+		if not schedule_doc.get("depreciation_schedule"):
 			return True
 
-		# For manual depreciation, check specific parameters
+		if fb_row.depreciation_method != "Manual":
+			return True
+
 		return (
-			fb_row.total_number_of_depreciations != schedule_doc.total_number_of_depreciations
+			fb_row.depreciation_method != schedule_doc.depreciation_method
+			or fb_row.total_number_of_depreciations != schedule_doc.total_number_of_depreciations
 			or fb_row.frequency_of_depreciation != schedule_doc.frequency_of_depreciation
 			or getdate(fb_row.depreciation_start_date)
 			!= schedule_doc.get("depreciation_schedule")[0].schedule_date

--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -186,7 +186,7 @@ class Asset(AccountsController):
 	def has_depreciation_settings_changed(self, existing_doc, fb_row):
 		"""Check if depreciation calculation settings have changed"""
 
-		if fb_row.depreciation_method != "Manual":
+		if not existing_doc.get("depreciation_schedule") or fb_row.depreciation_method != "Manual":
 			return True
 
 		return (


### PR DESCRIPTION
- Fix schedule regeneration for manual depreciation
- Asset value changes now trigger proper updates
- Prevent unintended reset of manual entries on submission

Issue with the previous approach:

https://github.com/user-attachments/assets/58d8f6d5-6fa2-4df8-88dd-6bafced32bad

