### PR TITLE
fix(stock): handle serial and batch nos for disassemble stock entry

### DIFF
--- a/erpnext/stock/serial_batch_bundle.py
+++ b/erpnext/stock/serial_batch_bundle.py
@@ -1070,12 +1070,22 @@ class SerialBatchCreation:
 		for d in remove_list:
 			package.remove(d)
 
-	def make_serial_and_batch_bundle(self):
+	def make_serial_and_batch_bundle(
+		self, serial_nos=None, batch_nos=None
+	):  # passing None instead of [] due to ruff linter error B006
+		serial_nos = serial_nos or []
+		batch_nos = batch_nos or []
+
 		doc = frappe.new_doc("Serial and Batch Bundle")
 		valid_columns = doc.meta.get_valid_columns()
 		for key, value in self.__dict__.items():
 			if key in valid_columns:
 				doc.set(key, value)
+
+		if serial_nos:
+			self.serial_nos = serial_nos
+		if batch_nos:
+			self.batches = batch_nos
 
 		if self.type_of_transaction == "Outward":
 			self.set_auto_serial_batch_entries_for_outward()


### PR DESCRIPTION
**Issue:**
"**Unexpected keyword argument**" Error When Submitting Disassembly Stock Entry with Serial and Batch Bundle Item

**Ref:** [#55096](https://support.frappe.io/helpdesk/tickets/55096#activity)

**Before:**

https://github.com/user-attachments/assets/770f44f6-1dea-45b1-b8bb-9a81f904f414

**After:**

https://github.com/user-attachments/assets/e0244a2e-6365-48a6-a848-e469a223e5da

**Backport Needed for v15**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Serial and batch numbers can now be pre-supplied during bundle creation.
  * Inward transactions now include enhanced automatic serial and batch entry handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->