### PR TITLE
refactor: remove custom sql function in AR SQL procedure approach

### DIFF
--- a/erpnext/accounts/doctype/accounts_settings/accounts_settings.py
+++ b/erpnext/accounts/doctype/accounts_settings/accounts_settings.py
@@ -152,6 +152,5 @@ class AccountsSettings(Document):
 	def drop_ar_sql_procedures(self):
 		from erpnext.accounts.report.accounts_receivable.accounts_receivable import InitSQLProceduresForAR
 
-		frappe.db.sql(f"drop function if exists {InitSQLProceduresForAR.genkey_function_name}")
 		frappe.db.sql(f"drop procedure if exists {InitSQLProceduresForAR.init_procedure_name}")
 		frappe.db.sql(f"drop procedure if exists {InitSQLProceduresForAR.allocate_procedure_name}")


### PR DESCRIPTION
In a production setup where DB binary logging is enabled, custom SQL functions cannot be created.
```
This function has none of DETERMINISTIC, NO SQL, or READS SQL DATA in its declaration and binary logging is enabled
```

So dropping it from SQL procedure based Receivable report refactor (https://github.com/frappe/erpnext/pull/47892).
