### PR TITLE
fix(subscription): add cancellation and date validation

### DIFF
--- a/erpnext/accounts/doctype/subscription/subscription.py
+++ b/erpnext/accounts/doctype/subscription/subscription.py
@@ -223,7 +223,11 @@ class Subscription(Document):
 		"""
 		if self.is_trialling():
 			self.status = "Trialing"
-		elif self.status == "Active" and self.end_date and getdate(posting_date) > getdate(self.end_date):
+		elif (
+			not self.has_outstanding_invoice()
+			and self.end_date
+			and getdate(posting_date) > getdate(self.end_date)
+		):
 			self.status = "Completed"
 		elif self.is_past_grace_period():
 			self.status = self.get_status_for_past_grace_period()

--- a/erpnext/accounts/doctype/subscription/subscription.py
+++ b/erpnext/accounts/doctype/subscription/subscription.py
@@ -561,6 +561,17 @@ class Subscription(Document):
 			self.current_invoice_start, self.current_invoice_end
 		) and self.can_generate_new_invoice(posting_date):
 			self.generate_invoice(posting_date=posting_date)
+			if self.end_date:
+				next_start = add_days(self.current_invoice_end, 1)
+
+				if getdate(next_start) > getdate(self.end_date):
+					if self.cancel_at_period_end:
+						self.cancel_subscription()
+					else:
+						self.set_subscription_status(posting_date=posting_date)
+
+					self.save()
+					return
 			self.update_subscription_period(add_days(self.current_invoice_end, 1))
 		elif posting_date and getdate(posting_date) > getdate(self.current_invoice_end):
 			self.update_subscription_period()


### PR DESCRIPTION
Prevents subscription periods from extending past the end date and handles cancellation correctly at period end.
