### PR TITLE
fix: do not hide primary-action for composite asset

### DIFF
--- a/erpnext/assets/doctype/asset/asset.js
+++ b/erpnext/assets/doctype/asset/asset.js
@@ -80,6 +80,12 @@ frappe.ui.form.on("Asset", {
 		}
 	},
 
+	before_submit: function (frm) {
+		if (frm.doc.is_composite_asset && !frm.has_active_capitalization) {
+			frappe.throw(__("Please capitalize this asset before submitting."));
+		}
+	},
+
 	refresh: function (frm) {
 		frappe.ui.form.trigger("Asset", "is_existing_asset");
 		frm.toggle_display("next_depreciation_date", frm.doc.docstatus < 1);
@@ -197,8 +203,7 @@ frappe.ui.form.on("Asset", {
 					},
 					callback: function (r) {
 						if (!r.message) {
-							$(".primary-action").prop("hidden", true);
-							$(".form-message").text(__("Capitalize this asset to confirm"));
+							$(".form-message").text(__("Capitalize this asset before submitting."));
 
 							frm.add_custom_button(__("Capitalize Asset"), function () {
 								frm.trigger("create_asset_capitalization");
@@ -538,7 +543,6 @@ frappe.ui.form.on("Asset", {
 			callback: function (r) {
 				var doclist = frappe.model.sync(r.message);
 				frappe.set_route("Form", doclist[0].doctype, doclist[0].name);
-				$(".primary-action").prop("hidden", false);
 			},
 		});
 	},

--- a/erpnext/assets/doctype/asset/asset.js
+++ b/erpnext/assets/doctype/asset/asset.js
@@ -202,6 +202,8 @@ frappe.ui.form.on("Asset", {
 						asset: frm.doc.name,
 					},
 					callback: function (r) {
+						frm.has_active_capitalization = r.message;
+
 						if (!r.message) {
 							$(".form-message").text(__("Capitalize this asset before submitting."));
 
@@ -475,7 +477,6 @@ frappe.ui.form.on("Asset", {
 	is_composite_asset: function (frm) {
 		if (frm.doc.is_composite_asset) {
 			frm.set_value("net_purchase_amount", 0);
-			frm.set_df_property("net_purchase_amount", "read_only", 1);
 		} else {
 			frm.set_df_property("net_purchase_amount", "read_only", 0);
 		}

--- a/erpnext/assets/doctype/asset/asset.json
+++ b/erpnext/assets/doctype/asset/asset.json
@@ -556,7 +556,8 @@
    "fieldtype": "Currency",
    "label": "Net Purchase Amount",
    "mandatory_depends_on": "eval:(!doc.is_composite_asset || doc.docstatus==1)",
-   "options": "Company:company:default_currency"
+   "options": "Company:company:default_currency",
+   "read_only_depends_on": "eval: doc.is_composite_asset"
   }
  ],
  "idx": 72,
@@ -600,7 +601,7 @@
    "link_fieldname": "target_asset"
   }
  ],
- "modified": "2025-11-04 22:39:00.817405",
+ "modified": "2025-12-18 16:36:40.904246",
  "modified_by": "Administrator",
  "module": "Assets",
  "name": "Asset",

--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -243,6 +243,10 @@ class Asset(AccountsController):
 		self.validate_expected_value_after_useful_life()
 		self.set_total_booked_depreciations()
 
+	def before_submit(self):
+		if self.is_composite_asset and not has_active_capitalization(self.name):
+			frappe.throw(_("Please capitalize this asset before submitting."))
+
 	def on_submit(self):
 		self.validate_in_use_date()
 		self.make_asset_movement()


### PR DESCRIPTION
This change was required because earlier, when an asset was marked as a composite asset without any capitalization, the primary buttons were hidden on the client side. As a result, once the asset was saved, it was not possible to update any details even though the asset was still in draft.
Additionally, this approach had issues where the hidden state was not reset on page change, causing the primary buttons to remain hidden even for assets that were not composite.


https://github.com/user-attachments/assets/f1f5457a-c9f8-4af4-9b00-fda96fa50cee

So hiding the primary button is not the right solution. The better approach is to add a validation, which is what has been done in this fix.

https://github.com/user-attachments/assets/279b3e98-20af-4cc1-9e80-b7079ef86075
