### PR TITLE
fix(stock): ignore reserved stock while calculating batch qty

### DIFF
--- a/erpnext/stock/doctype/batch/batch.py
+++ b/erpnext/stock/doctype/batch/batch.py
@@ -159,8 +159,13 @@ class Batch(Document):
 	@frappe.whitelist()
 	def recalculate_batch_qty(self):
 		batches = get_batch_qty(
-			batch_no=self.name, item_code=self.item, for_stock_levels=True, consider_negative_batches=True
+			batch_no=self.name,
+			item_code=self.item,
+			for_stock_levels=True,
+			consider_negative_batches=True,
+			ignore_reserved_stock=True,
 		)
+
 		batch_qty = 0.0
 		if batches:
 			for row in batches:
@@ -241,6 +246,7 @@ def get_batch_qty(
 	for_stock_levels=False,
 	consider_negative_batches=False,
 	do_not_check_future_batches=False,
+	ignore_reserved_stock=False,
 ):
 	"""Returns batch actual qty if warehouse is passed,
 	        or returns dict of qty by warehouse if warehouse is None
@@ -269,6 +275,7 @@ def get_batch_qty(
 			"for_stock_levels": for_stock_levels,
 			"consider_negative_batches": consider_negative_batches,
 			"do_not_check_future_batches": do_not_check_future_batches,
+			"ignore_reserved_stock": ignore_reserved_stock,
 		}
 	)
 

--- a/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py
+++ b/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py
@@ -2495,7 +2495,11 @@ def get_auto_batch_nos(kwargs):
 	available_batches = get_available_batches(kwargs)
 	stock_ledgers_batches = get_stock_ledgers_batches(kwargs)
 	pos_invoice_batches = get_reserved_batches_for_pos(kwargs)
-	sre_reserved_batches = get_reserved_batches_for_sre(kwargs)
+
+	sre_reserved_batches = frappe._dict()
+	if not kwargs.ignore_reserved_stock:
+		sre_reserved_batches = get_reserved_batches_for_sre(kwargs)
+
 	if kwargs.against_sales_order and only_consider_batches:
 		kwargs.batch_no = kwargs.warehouse = None
 


### PR DESCRIPTION
**Issue:**
Considering the reserved stock while calculating the batch qty.

**Ref:** [#55832](https://support.frappe.io/helpdesk/tickets/55832)

**Before:**

https://github.com/user-attachments/assets/2f8551cd-a92e-46c8-b9fb-6afaeabac4ba

**After:**

https://github.com/user-attachments/assets/261ffb71-9a78-45d7-9113-3134131e912a
