### PR TITLE
fix: set posting time during restore

### DIFF
--- a/erpnext/utilities/transaction_base.py
+++ b/erpnext/utilities/transaction_base.py
@@ -19,8 +19,8 @@ class UOMMustBeIntegerError(frappe.ValidationError):
 
 class TransactionBase(StatusUpdater):
 	def validate_posting_time(self):
-		# set Edit Posting Date and Time to 1 while data import
-		if frappe.flags.in_import and self.posting_date:
+		# set Edit Posting Date and Time to 1 while data import and restore
+		if (frappe.flags.in_import or self.flags.from_restore) and self.posting_date:
 			self.set_posting_time = 1
 
 		if not getattr(self, "set_posting_time", None):


### PR DESCRIPTION
Issue:

When an invoice is created on older date and later deleted, restoring it on the current date throws a validation error.

Ref: [#55735](https://support.frappe.io/helpdesk/tickets/55735), 

Part of: [#35363](https://github.com/frappe/frappe/pull/35363)

Steps to replicate the issue:

1. Create an invoice with a date, and a due date is set as 1/12/25 without enabling `Edit Posting Date and Time`
2. Save the invoice and delete it
3. Restore the deleted document. It throws a validation error

Deleted Document:

<img width="1792" height="1120" alt="image" src="https://github.com/user-attachments/assets/7aa84c1c-ec13-48c3-ab9b-a0fe0f9b6a56" />


