### PR TITLE
fix(task): calculate end date if not available

### DIFF
--- a/erpnext/projects/doctype/task/task.py
+++ b/erpnext/projects/doctype/task/task.py
@@ -98,7 +98,7 @@ class Task(NestedSet):
 		self.validate_parent_project_dates()
 
 	def set_default_end_date_if_missing(self):
-		if self.exp_start_date and self.expected_time:
+		if self.exp_start_date and self.expected_time and not self.exp_end_date:
 			self.exp_end_date = add_to_date(self.exp_start_date, hours=self.expected_time)
 
 	def validate_parent_expected_end_date(self):

--- a/erpnext/projects/doctype/task/test_task.py
+++ b/erpnext/projects/doctype/task/test_task.py
@@ -158,6 +158,12 @@ class TestTask(ERPNextTestSuite):
 
 		self.assertRaises(ParentIsGroupError, child_task.save)
 
+	def test_expected_end_date(self):
+		task = create_task("Testing End Date", add_days(nowdate(), 1), add_days(nowdate(), 5))
+		task.expected_time = 72
+		task.save()
+		self.assertEqual(getdate(task.exp_end_date), getdate(add_days(nowdate(), 5)))
+
 
 def create_task(
 	subject,


### PR DESCRIPTION
**Issue**:
The Expected end date of a Task gets recalculated based on the expected time, even if the expected end date is set manually.

**Ref**: #51200

**Before**:

[Screencast from 2025-12-19 22-36-35.webm](https://github.com/user-attachments/assets/ada6256f-1697-4214-8735-e7e0941ede58)


**After**:

[Screencast from 2025-12-19 22-34-57.webm](https://github.com/user-attachments/assets/a66bb472-7ad6-4f40-892a-b915a9cce087)
