### PR TITLE
fix: update task actual time when timesheet is modified after submit

### DIFF
--- a/erpnext/projects/doctype/timesheet/timesheet.py
+++ b/erpnext/projects/doctype/timesheet/timesheet.py
@@ -147,6 +147,10 @@ class Timesheet(Document):
 	def on_submit(self):
 		self.validate_mandatory_fields()
 		self.update_task_and_project()
+	
+	def on_update_after_submit(self):
+		self.update_task_and_project()
+
 
 	def validate_mandatory_fields(self):
 		for data in self.time_logs:


### PR DESCRIPTION
**Description:**
This PR fixes an issue where the actual_time of a Task was not updating correctly when a submitted Timesheet is modified.

**Changes:**

Enabled allow_on_submit for Timesheet to allow modifications after submission.

Updated Timesheet logic to correctly update the associated Task’s actual_time whenever time logs are added or modified post-submission.

Ensures Task actual hours remain consistent without affecting other Timesheet functionality.

**Testing:**

Ran erpnext.projects.doctype.timesheet.test_timesheet test suite.

Verified that the Task's actual_time updates correctly when modifying a submitted Timesheet.

Confirmed no impact on new Timesheet creation, billing, or time overlap validation.

**Attachment**

[Screencast from 20-12-25 07:39:31 PM IST.webm](https://github.com/user-attachments/assets/b50b37d7-400f-40aa-aae3-0de3bae3eb56)
