### PR TITLE
Feat: Add Title Field Support for Batch across Reports and Serial/Batch Selector

### DIFF
--- a/erpnext/controllers/queries.py
+++ b/erpnext/controllers/queries.py
@@ -442,7 +442,7 @@ def get_filterd_batches(data):
 		if batch_data[0] not in batches:
 			batches[batch_data[0]] = list(batch_data)
 		else:
-			batches[batch_data[0]][1] += batch_data[1]
+			batches[batch_data[0]][2] += batch_data[2]
 
 	filterd_batch = []
 	for _batch, batch_data in batches.items():

--- a/erpnext/controllers/queries.py
+++ b/erpnext/controllers/queries.py
@@ -400,10 +400,11 @@ def get_batch_no(doctype, txt, searchfield, start, page_len, filters):
 	doctype = "Batch"
 	meta = frappe.get_meta(doctype, cached=True)
 	searchfields = meta.get_search_fields()
+	title_field = meta.get_title_field()
 	page_len = 300
 
-	batches = get_batches_from_stock_ledger_entries(searchfields, txt, filters, start, page_len)
-	batches.extend(get_batches_from_serial_and_batch_bundle(searchfields, txt, filters, start, page_len))
+	batches = get_batches_from_stock_ledger_entries(searchfields, title_field, txt, filters, start, page_len)
+	batches.extend(get_batches_from_serial_and_batch_bundle(searchfields, title_field, txt, filters, start, page_len))
 
 	filtered_batches = get_filterd_batches(batches)
 
@@ -443,13 +444,13 @@ def get_filterd_batches(data):
 
 	filterd_batch = []
 	for _batch, batch_data in batches.items():
-		if batch_data[1] > 0:
+		if batch_data[2] > 0:
 			filterd_batch.append(tuple(batch_data))
 
 	return filterd_batch
 
 
-def get_batches_from_stock_ledger_entries(searchfields, txt, filters, start=0, page_len=100):
+def get_batches_from_stock_ledger_entries(searchfields, title_field, txt, filters, start=0, page_len=100):
 	stock_ledger_entry = frappe.qb.DocType("Stock Ledger Entry")
 	batch_table = frappe.qb.DocType("Batch")
 
@@ -461,6 +462,7 @@ def get_batches_from_stock_ledger_entries(searchfields, txt, filters, start=0, p
 		.on(batch_table.name == stock_ledger_entry.batch_no)
 		.select(
 			stock_ledger_entry.batch_no,
+			batch_table[title_field],
 			Sum(stock_ledger_entry.actual_qty).as_("qty"),
 		)
 		.where(stock_ledger_entry.is_cancelled == 0)
@@ -499,7 +501,7 @@ def get_batches_from_stock_ledger_entries(searchfields, txt, filters, start=0, p
 	return query.run(as_list=1) or []
 
 
-def get_batches_from_serial_and_batch_bundle(searchfields, txt, filters, start=0, page_len=100):
+def get_batches_from_serial_and_batch_bundle(searchfields, title_field, txt, filters, start=0, page_len=100):
 	bundle = frappe.qb.DocType("Serial and Batch Entry")
 	stock_ledger_entry = frappe.qb.DocType("Stock Ledger Entry")
 	batch_table = frappe.qb.DocType("Batch")
@@ -514,6 +516,7 @@ def get_batches_from_serial_and_batch_bundle(searchfields, txt, filters, start=0
 		.on(batch_table.name == bundle.batch_no)
 		.select(
 			bundle.batch_no,
+			batch_table[title_field],
 			Sum(bundle.qty).as_("qty"),
 		)
 		.where(stock_ledger_entry.is_cancelled == 0)

--- a/erpnext/controllers/queries.py
+++ b/erpnext/controllers/queries.py
@@ -404,7 +404,9 @@ def get_batch_no(doctype, txt, searchfield, start, page_len, filters):
 	page_len = 300
 
 	batches = get_batches_from_stock_ledger_entries(searchfields, title_field, txt, filters, start, page_len)
-	batches.extend(get_batches_from_serial_and_batch_bundle(searchfields, title_field, txt, filters, start, page_len))
+	batches.extend(
+		get_batches_from_serial_and_batch_bundle(searchfields, title_field, txt, filters, start, page_len)
+	)
 
 	filtered_batches = get_filterd_batches(batches)
 
@@ -464,6 +466,7 @@ def get_batches_from_stock_ledger_entries(searchfields, title_field, txt, filter
 			stock_ledger_entry.batch_no,
 			batch_table[title_field],
 			Sum(stock_ledger_entry.actual_qty).as_("qty"),
+			batch_table.stock_uom,
 		)
 		.where(stock_ledger_entry.is_cancelled == 0)
 		.where(
@@ -518,6 +521,7 @@ def get_batches_from_serial_and_batch_bundle(searchfields, title_field, txt, fil
 			bundle.batch_no,
 			batch_table[title_field],
 			Sum(bundle.qty).as_("qty"),
+			batch_table.stock_uom,
 		)
 		.where(stock_ledger_entry.is_cancelled == 0)
 		.where(

--- a/erpnext/public/js/utils/serial_no_batch_selector.js
+++ b/erpnext/public/js/utils/serial_no_batch_selector.js
@@ -547,6 +547,9 @@ erpnext.SerialBatchPackageSelector = class SerialNoBatchBundleUpdate {
 				},
 				callback: (r) => {
 					if (r.message) {
+						r.message.forEach((row) => {
+							frappe.utils.add_link_title("Batch", row.batch_no, row.batch_no_display);
+						});
 						this.dialog.fields_dict.entries.df.data = r.message;
 						this.dialog.fields_dict.entries.grid.refresh();
 					}

--- a/erpnext/stock/doctype/batch/batch.py
+++ b/erpnext/stock/doctype/batch/batch.py
@@ -135,6 +135,8 @@ class Batch(Document):
 		"""Generate unique ID for batch if not specified"""
 
 		if self.batch_id:
+			if frappe.db.exists("Batch", {"batch_id": self.batch_id, "item": self.item}):
+				frappe.throw(f"Batch Number {self.batch_id} already exists for Item {self.item}")
 			return
 
 		create_new_batch, batch_number_series = frappe.db.get_value(

--- a/erpnext/stock/doctype/batch/batch.py
+++ b/erpnext/stock/doctype/batch/batch.py
@@ -114,11 +114,27 @@ class Batch(Document):
 		use_batchwise_valuation: DF.Check
 	# end: auto-generated types
 
-	def autoname(self):
-		"""Generate random ID for batch if not specified"""
+	def before_insert(self):
+		self.set_batch_id()
+
+	def onload(self):
+		self.image = frappe.db.get_value("Item", self.item, "image")
+
+	def after_delete(self):
+		revert_series_if_last(get_batch_naming_series(), self.name)
+
+	def validate(self):
+		self.item_has_batch_enabled()
+		self.set_batchwise_valuation()
+
+	def item_has_batch_enabled(self):
+		if frappe.db.get_value("Item", self.item, "has_batch_no") == 0:
+			frappe.throw(_("The selected item cannot have Batch"))
+
+	def set_batch_id(self):
+		"""Generate unique ID for batch if not specified"""
 
 		if self.batch_id:
-			self.name = self.batch_id
 			return
 
 		create_new_batch, batch_number_series = frappe.db.get_value(
@@ -139,22 +155,6 @@ class Batch(Document):
 			# User might have manually created a batch with next number
 			if frappe.db.exists("Batch", self.batch_id):
 				self.batch_id = None
-
-		self.name = self.batch_id
-
-	def onload(self):
-		self.image = frappe.db.get_value("Item", self.item, "image")
-
-	def after_delete(self):
-		revert_series_if_last(get_batch_naming_series(), self.name)
-
-	def validate(self):
-		self.item_has_batch_enabled()
-		self.set_batchwise_valuation()
-
-	def item_has_batch_enabled(self):
-		if frappe.db.get_value("Item", self.item, "has_batch_no") == 0:
-			frappe.throw(_("The selected item cannot have Batch"))
 
 	@frappe.whitelist()
 	def recalculate_batch_qty(self):

--- a/erpnext/stock/doctype/batch/batch.py
+++ b/erpnext/stock/doctype/batch/batch.py
@@ -136,7 +136,7 @@ class Batch(Document):
 
 		if self.batch_id:
 			if frappe.db.exists("Batch", {"batch_id": self.batch_id, "item": self.item}):
-				frappe.throw(f"Batch Number {self.batch_id} already exists for Item {self.item}")
+				frappe.throw(_(f"Batch Number {self.batch_id} already exists for Item {self.item}"))
 			return
 
 		create_new_batch, batch_number_series = frappe.db.get_value(

--- a/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py
+++ b/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py
@@ -2599,16 +2599,21 @@ def filter_zero_near_batches(available_batches, kwargs):
 
 def get_qty_based_available_batches(available_batches, qty):
 	batches = []
+	title_field = frappe.get_meta("Batch").get_title_field()
+
 	for batch in available_batches:
 		if qty <= 0:
 			break
-
+		
+		batch_display_name = frappe.get_cached_value("Batch", batch.batch_no, title_field)
 		batch_qty = flt(batch.qty)
+
 		if qty > batch_qty:
 			batches.append(
 				frappe._dict(
 					{
 						"batch_no": batch.batch_no,
+						"batch_no_display": batch_display_name,
 						"qty": batch_qty,
 						"warehouse": batch.warehouse,
 					}
@@ -2620,6 +2625,7 @@ def get_qty_based_available_batches(available_batches, qty):
 				frappe._dict(
 					{
 						"batch_no": batch.batch_no,
+						"batch_no_display": batch_display_name,
 						"qty": qty,
 						"warehouse": batch.warehouse,
 					}

--- a/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py
+++ b/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py
@@ -2604,7 +2604,7 @@ def get_qty_based_available_batches(available_batches, qty):
 	for batch in available_batches:
 		if qty <= 0:
 			break
-		
+
 		batch_display_name = frappe.get_cached_value("Batch", batch.batch_no, title_field)
 		batch_qty = flt(batch.qty)
 

--- a/erpnext/stock/report/available_batch_report/available_batch_report.js
+++ b/erpnext/stock/report/available_batch_report/available_batch_report.js
@@ -88,4 +88,15 @@ frappe.query_reports["Available Batch Report"] = {
 			width: "80",
 		},
 	],
+	formatter: function (value, row, column, data, default_formatter) {
+		value = default_formatter(value, row, column, data);
+
+		if (column.fieldname === "batch_no" && data && data["batch_no"]) {
+			value = `<a href="/app/batch/${data["batch_id"]}">${frappe.utils.escape_html(
+				data["batch_no"]
+			)}</a>`;
+		}
+
+		return value;
+	},
 };

--- a/erpnext/stock/report/available_batch_report/available_batch_report.py
+++ b/erpnext/stock/report/available_batch_report/available_batch_report.py
@@ -117,7 +117,7 @@ def get_batchwise_data_from_stock_ledger(filters):
 	query = get_query_based_on_filters(query, batch, table, filters)
 
 	for d in query.run(as_dict=True):
-		key = (d.item_code, d.warehouse, d.batch_no)
+		key = (d.item_code, d.warehouse, d.batch_id)
 		batchwise_data.setdefault(key, d)
 
 	return batchwise_data
@@ -151,7 +151,7 @@ def get_batchwise_data_from_serial_batch_bundle(batchwise_data, filters):
 	query = get_query_based_on_filters(query, batch, table, filters)
 
 	for d in query.run(as_dict=True):
-		key = (d.item_code, d.warehouse, d.batch_no)
+		key = (d.item_code, d.warehouse, d.batch_id)
 		if key in batchwise_data:
 			batchwise_data[key].balance_qty += flt(d.balance_qty)
 		else:

--- a/erpnext/stock/report/batch_item_expiry_status/batch_item_expiry_status.js
+++ b/erpnext/stock/report/batch_item_expiry_status/batch_item_expiry_status.js
@@ -32,4 +32,13 @@ frappe.query_reports["Batch Item Expiry Status"] = {
 			},
 		},
 	],
+	formatter: function (value, row, column, data, default_formatter) {
+		value = default_formatter(value, row, column, data);
+
+		if (column.fieldname === "batch" && data && !!data["batch"]) {
+			value = `<a href="/app/batch/${data["batch_id"]}">${frappe.utils.escape_html(data["batch"])}</a>`;
+		}
+
+		return value;
+	},
 };

--- a/erpnext/stock/report/batch_item_expiry_status/batch_item_expiry_status.py
+++ b/erpnext/stock/report/batch_item_expiry_status/batch_item_expiry_status.py
@@ -29,31 +29,47 @@ def validate_filters(filters):
 
 def get_columns():
 	return [
-		_("Item") + ":Link/Item:150",
-		_("Item Name") + "::150",
-		_("Batch") + ":Link/Batch:150",
-		_("Stock UOM") + ":Link/UOM:100",
-		_("Quantity") + ":Float:100",
-		_("Expires On") + ":Date:100",
-		_("Expiry (In Days)") + ":Int:130",
+		{"label": _("Item"), "fieldname": "item", "fieldtype": "Link", "options": "Item", "width": 150},
+		{"label": _("Item Name"), "fieldname": "item_name", "fieldtype": "Data", "width": 150},
+		{"label": _("Batch"), "fieldname": "batch", "fieldtype": "Link", "options": "Batch", "width": 150},
+		{"label": _("Quantity"), "fieldname": "quantity", "fieldtype": "Float", "width": 100},
+		{
+			"label": _("Stock UOM"),
+			"fieldname": "stock_uom",
+			"fieldtype": "Link",
+			"options": "UOM",
+			"width": 100,
+		},
+		{"label": _("Expires On"), "fieldname": "expires_on", "fieldtype": "Date", "width": 100},
+		{"label": _("Expiry (In Days)"), "fieldname": "expiry_in_days", "fieldtype": "Int", "width": 130},
+		{
+			"label": _("Batch ID"),
+			"fieldname": "batch_id",
+			"fieldtype": "Link",
+			"options": "Batch",
+			"width": 100,
+			"hidden": 1,
+		},
 	]
 
 
 def get_data(filters):
 	data = []
+	title_field = frappe.get_meta("Batch", cached=True).get_title_field()
 
 	for batch in get_batch_details(filters):
 		data.append(
 			[
 				batch.item,
 				batch.item_name,
-				batch.name,
-				batch.stock_uom,
+				batch[title_field],
 				batch.batch_qty,
+				batch.stock_uom,
 				batch.expiry_date,
 				max((batch.expiry_date - frappe.utils.datetime.date.today()).days, 0)
 				if batch.expiry_date
 				else None,
+				batch.name,
 			]
 		)
 
@@ -62,6 +78,7 @@ def get_data(filters):
 
 def get_batch_details(filters):
 	batch = frappe.qb.DocType("Batch")
+	title_field = frappe.get_meta("Batch", cached=True).get_title_field()
 	query = (
 		frappe.qb.from_(batch)
 		.select(
@@ -72,6 +89,7 @@ def get_batch_details(filters):
 			batch.item_name,
 			batch.stock_uom,
 			batch.batch_qty,
+			batch[title_field],
 		)
 		.where(
 			(batch.disabled == 0)

--- a/erpnext/stock/report/batch_wise_balance_history/batch_wise_balance_history.js
+++ b/erpnext/stock/report/batch_wise_balance_history/batch_wise_balance_history.js
@@ -79,8 +79,8 @@ frappe.query_reports["Batch-Wise Balance History"] = {
 		},
 	],
 	formatter: function (value, row, column, data, default_formatter) {
-		if (column.fieldname == "Batch" && data && !!data["Batch"]) {
-			value = data["Batch"];
+		if (column.fieldname == "batch" && data && !!data["batch"]) {
+			value = data["batch"];
 			column.link_onclick =
 				"frappe.query_reports['Batch-Wise Balance History'].set_batch_route_to_stock_ledger(" +
 				JSON.stringify(data) +
@@ -92,7 +92,7 @@ frappe.query_reports["Batch-Wise Balance History"] = {
 	},
 	set_batch_route_to_stock_ledger: function (data) {
 		frappe.route_options = {
-			batch_no: data["Batch"],
+			batch_no: data["batch_id"],
 		};
 
 		frappe.set_route("query-report", "Stock Ledger");

--- a/erpnext/stock/report/batch_wise_balance_history/batch_wise_balance_history.py
+++ b/erpnext/stock/report/batch_wise_balance_history/batch_wise_balance_history.py
@@ -52,7 +52,7 @@ def execute(filters=None):
 								item_map[item]["item_name"],
 								item_map[item]["description"],
 								wh,
-								batch,
+								qty_dict.batch_no,
 								flt(qty_dict.opening_qty, float_precision),
 								flt(qty_dict.in_qty, float_precision),
 								flt(qty_dict.out_qty, float_precision),
@@ -63,6 +63,7 @@ def execute(filters=None):
 								),
 								flt(qty_dict.bal_value, float_precision),
 								item_map[item]["stock_uom"],
+								qty_dict.batch_id,
 							]
 						)
 
@@ -73,18 +74,37 @@ def get_columns(filters):
 	"""return columns based on filters"""
 
 	columns = [
-		_("Item") + ":Link/Item:100",
-		_("Item Name") + "::120",
-		_("Description") + "::90",
-		_("Warehouse") + ":Link/Warehouse:100",
-		_("Batch") + ":Link/Batch:100",
-		_("Opening Qty") + ":Float:90",
-		_("In Qty") + ":Float:80",
-		_("Out Qty") + ":Float:80",
-		_("Balance Qty") + ":Float:120",
-		_("Valuation Rate") + ":Float:120",
-		_("Balance Value") + ":Currency:120",
-		_("UOM") + "::90",
+		{"label": _("Item"), "fieldname": "item", "fieldtype": "Link", "options": "Item", "width": 100},
+		{"label": _("Item Name"), "fieldname": "item_name", "width": 150},
+		{"label": _("Description"), "fieldname": "description", "width": 150},
+		{
+			"label": _("Warehouse"),
+			"fieldname": "warehouse",
+			"fieldtype": "Link",
+			"options": "Warehouse",
+			"width": 100,
+		},
+		{
+			"label": _("Batch"),
+			"fieldname": "batch",
+			"fieldtype": "Link",
+			"options": "Batch",
+			"align": "left",
+			"width": 150,
+		},
+		{"label": _("Opening Qty"), "fieldname": "opening_qty", "fieldtype": "Float", "width": 90},
+		{"label": _("In Qty"), "fieldname": "in_qty", "fieldtype": "Float", "width": 80},
+		{"label": _("Out Qty"), "fieldname": "out_qty", "fieldtype": "Float", "width": 80},
+		{"label": _("Balance Qty"), "fieldname": "bal_qty", "fieldtype": "Float", "width": 90},
+		{"label": _("UOM"), "fieldname": "stock_uom", "width": 90},
+		{
+			"label": _("Batch ID"),
+			"fieldname": "batch_id",
+			"fieldtype": "Link",
+			"options": "Batch",
+			"width": 150,
+			"hidden": 1,
+		},
 	]
 
 	return columns
@@ -129,15 +149,21 @@ def get_stock_ledger_entries_for_batch_no(filters):
 		frappe.throw(_("'To Date' is required"))
 
 	posting_datetime = get_datetime(add_to_date(filters["to_date"], days=1))
+	title_field = frappe.get_meta("Batch", cached=True).get_title_field()
 
 	sle = frappe.qb.DocType("Stock Ledger Entry")
+	batch_table = frappe.qb.DocType("Batch")
+
 	query = (
 		frappe.qb.from_(sle)
+		.inner_join(batch_table)
+		.on(batch_table.name == sle.batch_no)
 		.select(
 			sle.item_code,
 			sle.warehouse,
-			sle.batch_no,
+			sle.batch_no.as_("batch_id"),
 			sle.posting_date,
+			batch_table[title_field].as_("batch_no"),
 			fn.Sum(sle.actual_qty).as_("actual_qty"),
 			fn.Sum(sle.stock_value_difference).as_("stock_value_difference"),
 		)
@@ -174,18 +200,22 @@ def get_stock_ledger_entries_for_batch_no(filters):
 def get_stock_ledger_entries_for_batch_bundle(filters):
 	sle = frappe.qb.DocType("Stock Ledger Entry")
 	batch_package = frappe.qb.DocType("Serial and Batch Entry")
-
+	batch_table = frappe.qb.DocType("Batch")
 	to_date = get_datetime(str(filters.to_date) + " 23:59:59")
+	title_field = frappe.get_meta("Batch", cached=True).get_title_field()
 
 	query = (
 		frappe.qb.from_(sle)
 		.inner_join(batch_package)
 		.on(batch_package.parent == sle.serial_and_batch_bundle)
+		.inner_join(batch_table)
+		.on(batch_table.name == batch_package.batch_no)
 		.select(
 			sle.item_code,
 			sle.warehouse,
-			batch_package.batch_no,
+			batch_package.batch_no.as_("batch_id"),
 			sle.posting_date,
+			batch_table[title_field].as_("batch_no"),
 			fn.Sum(batch_package.qty).as_("actual_qty"),
 			fn.Sum(batch_package.stock_value_difference).as_("stock_value_difference"),
 		)
@@ -233,7 +263,15 @@ def get_item_warehouse_batch_map(filters, float_precision):
 		iwb_map.setdefault(d.item_code, {}).setdefault(d.warehouse, {}).setdefault(
 			d.batch_no,
 			frappe._dict(
-				{"opening_qty": 0.0, "in_qty": 0.0, "out_qty": 0.0, "bal_qty": 0.0, "bal_value": 0.0}
+				{
+					"batch_id": d.batch_id,
+					"batch_no": d.batch_no,
+					"opening_qty": 0.0,
+					"in_qty": 0.0,
+					"out_qty": 0.0,
+					"bal_qty": 0.0,
+					"bal_value": 0.0,
+				}
 			),
 		)
 		qty_dict = iwb_map[d.item_code][d.warehouse][d.batch_no]

--- a/erpnext/stock/report/batch_wise_balance_history/batch_wise_balance_history.py
+++ b/erpnext/stock/report/batch_wise_balance_history/batch_wise_balance_history.py
@@ -57,12 +57,12 @@ def execute(filters=None):
 								flt(qty_dict.in_qty, float_precision),
 								flt(qty_dict.out_qty, float_precision),
 								flt(qty_dict.bal_qty, float_precision),
+								item_map[item]["stock_uom"],
 								flt(
 									(qty_dict.bal_value / qty_dict.bal_qty) if qty_dict.bal_qty else 0,
 									float_precision,
 								),
 								flt(qty_dict.bal_value, float_precision),
-								item_map[item]["stock_uom"],
 								qty_dict.batch_id,
 							]
 						)
@@ -96,7 +96,9 @@ def get_columns(filters):
 		{"label": _("In Qty"), "fieldname": "in_qty", "fieldtype": "Float", "width": 80},
 		{"label": _("Out Qty"), "fieldname": "out_qty", "fieldtype": "Float", "width": 80},
 		{"label": _("Balance Qty"), "fieldname": "bal_qty", "fieldtype": "Float", "width": 90},
-		{"label": _("UOM"), "fieldname": "stock_uom", "width": 90},
+		{"label": _("UOM"), "fieldname": "stock_uom", "width": 60},
+		{"label": _("Valuation Rate"), "fieldname": "val_rate", "fieldtype": "Float", "width": 120},
+		{"label": _("Balance Value"), "fieldname": "bal_val", "fieldtype": "Currency", "width": 140},
 		{
 			"label": _("Batch ID"),
 			"fieldname": "batch_id",

--- a/erpnext/stock/report/serial_and_batch_summary/serial_and_batch_summary.js
+++ b/erpnext/stock/report/serial_and_batch_summary/serial_and_batch_summary.js
@@ -93,4 +93,15 @@ frappe.query_reports["Serial and Batch Summary"] = {
 			},
 		},
 	],
+	formatter: function (value, row, column, data, default_formatter) {
+		value = default_formatter(value, row, column, data);
+
+		if (column.fieldname === "batch_no" && data["batch_no"]) {
+			value = `<a href="/app/batch/${data["batch_id"]}">${frappe.utils.escape_html(
+				data["batch_no"]
+			)}</a>`;
+		}
+
+		return value;
+	},
 };

--- a/erpnext/stock/report/serial_and_batch_summary/serial_and_batch_summary.js
+++ b/erpnext/stock/report/serial_and_batch_summary/serial_and_batch_summary.js
@@ -96,7 +96,7 @@ frappe.query_reports["Serial and Batch Summary"] = {
 	formatter: function (value, row, column, data, default_formatter) {
 		value = default_formatter(value, row, column, data);
 
-		if (column.fieldname === "batch_no" && data["batch_no"]) {
+		if (column.fieldname === "batch_no" && data && data["batch_no"]) {
 			value = `<a href="/app/batch/${data["batch_id"]}">${frappe.utils.escape_html(
 				data["batch_no"]
 			)}</a>`;

--- a/erpnext/stock/report/serial_and_batch_summary/serial_and_batch_summary.py
+++ b/erpnext/stock/report/serial_and_batch_summary/serial_and_batch_summary.py
@@ -45,6 +45,8 @@ def get_data(filters):
 	query = apply_filters(query, filters)
 	query = query.orderby(SerialBatchBundle.posting_datetime)
 
+	return query.run(as_dict=True)
+
 
 def apply_filters(query, filters):
 	SerialBatchBundle = frappe.qb.DocType("Serial and Batch Bundle")

--- a/erpnext/stock/report/serial_and_batch_summary/serial_and_batch_summary.py
+++ b/erpnext/stock/report/serial_and_batch_summary/serial_and_batch_summary.py
@@ -13,58 +13,62 @@ def execute(filters=None):
 
 
 def get_data(filters):
-	filter_conditions = get_filter_conditions(filters)
+	SerialBatchBundle = frappe.qb.DocType("Serial and Batch Bundle")
+	SerialBatchEntry = frappe.qb.DocType("Serial and Batch Entry")
+	Batch = frappe.qb.DocType("Batch")
+	title_field = frappe.get_meta("Batch", cached=True).get_title_field()
 
-	return frappe.get_all(
-		"Serial and Batch Bundle",
-		fields=[
-			"`tabSerial and Batch Bundle`.`voucher_type`",
-			"`tabSerial and Batch Bundle`.`posting_datetime` as posting_date",
-			"`tabSerial and Batch Bundle`.`name`",
-			"`tabSerial and Batch Bundle`.`company`",
-			"`tabSerial and Batch Bundle`.`voucher_no`",
-			"`tabSerial and Batch Bundle`.`item_code`",
-			"`tabSerial and Batch Bundle`.`item_name`",
-			"`tabSerial and Batch Entry`.`serial_no`",
-			"`tabSerial and Batch Entry`.`batch_no`",
-			"`tabSerial and Batch Entry`.`warehouse`",
-			"`tabSerial and Batch Entry`.`incoming_rate`",
-			"`tabSerial and Batch Entry`.`stock_value_difference`",
-			"`tabSerial and Batch Entry`.`qty`",
-		],
-		filters=filter_conditions,
-		order_by="posting_datetime",
+	query = (
+		frappe.qb.from_(SerialBatchBundle)
+		.join(SerialBatchEntry)
+		.on(SerialBatchBundle.name == SerialBatchEntry.parent)
+		.left_join(Batch)
+		.on(SerialBatchEntry.batch_no == Batch.name)
+		.select(
+			SerialBatchBundle.voucher_type,
+			SerialBatchBundle.posting_datetime.as_("posting_date"),
+			SerialBatchBundle.name,
+			SerialBatchBundle.company,
+			SerialBatchBundle.voucher_no,
+			SerialBatchBundle.item_code,
+			SerialBatchBundle.item_name,
+			SerialBatchEntry.serial_no,
+			SerialBatchEntry.batch_no.as_("batch_id"),
+			SerialBatchEntry.warehouse,
+			SerialBatchEntry.incoming_rate,
+			SerialBatchEntry.stock_value_difference,
+			SerialBatchEntry.qty,
+			Batch[title_field].as_("batch_no"),
+		)
 	)
 
+	query = apply_filters(query, filters)
+	query = query.orderby(SerialBatchBundle.posting_datetime)
 
-def get_filter_conditions(filters):
-	filter_conditions = [
-		["Serial and Batch Bundle", "docstatus", "=", 1],
-		["Serial and Batch Bundle", "is_cancelled", "=", 0],
-	]
+
+def apply_filters(query, filters):
+	SerialBatchBundle = frappe.qb.DocType("Serial and Batch Bundle")
+	SerialBatchEntry = frappe.qb.DocType("Serial and Batch Entry")
+
+	query = query.where((SerialBatchBundle.docstatus == 1) & (SerialBatchBundle.is_cancelled == 0))
 
 	for field in ["voucher_type", "voucher_no", "item_code", "warehouse", "company"]:
 		if filters.get(field):
 			if field == "voucher_no":
-				filter_conditions.append(["Serial and Batch Bundle", field, "in", filters.get(field)])
+				query = query.where(SerialBatchBundle.voucher_no.isin(filters[field]))
 			else:
-				filter_conditions.append(["Serial and Batch Bundle", field, "=", filters.get(field)])
+				query = query.where(SerialBatchBundle[field] == filters[field])
 
 	if filters.get("from_date") and filters.get("to_date"):
-		filter_conditions.append(
-			[
-				"Serial and Batch Bundle",
-				"posting_datetime",
-				"between",
-				[filters.get("from_date"), filters.get("to_date")],
-			]
+		query = query.where(
+			SerialBatchBundle.posting_datetime.between(filters["from_date"], filters["to_date"])
 		)
 
 	for field in ["serial_no", "batch_no"]:
 		if filters.get(field):
-			filter_conditions.append(["Serial and Batch Entry", field, "=", filters.get(field)])
+			query = query.where(SerialBatchEntry[field] == filters[field])
 
-	return filter_conditions
+	return query
 
 
 def get_columns(filters, data):
@@ -225,29 +229,59 @@ def get_serial_nos(doctype, txt, searchfield, start, page_len, filters):
 @frappe.whitelist()
 @frappe.validate_and_sanitize_search_inputs
 def get_batch_nos(doctype, txt, searchfield, start, page_len, filters):
-	query_filters = {}
+	Batch = frappe.qb.DocType("Batch")
+	SerialBatchEntry = frappe.qb.DocType("Serial and Batch Entry")
+	meta = frappe.get_meta(doctype, cached=True)
+	title_field = meta.get_title_field()
 
-	if filters.get("voucher_no") and txt:
-		query_filters["batch_no"] = ["like", f"%{txt}%"]
+	conditions = []
 
 	if filters.get("voucher_no"):
-		serial_batch_bundle = frappe.get_cached_value(
-			"Serial and Batch Bundle",
-			{"voucher_no": ("in", filters.get("voucher_no")), "docstatus": 1, "is_cancelled": 0},
-			"name",
+		sbb_filters = {"voucher_no": ("in", filters.get("voucher_no")), "docstatus": 1, "is_cancelled": 0}
+
+		if filters.get("item_code"):
+			sbb_filters["item_code"] = filters.get("item_code")
+
+		serial_batch_bundles = frappe.get_list("Serial and Batch Bundle", filters=sbb_filters, pluck="name")
+
+		if not serial_batch_bundles:
+			return []
+
+		query = (
+			frappe.qb.from_(SerialBatchEntry)
+			.join(Batch)
+			.on(Batch.name == SerialBatchEntry.batch_no)
+			.select(SerialBatchEntry.batch_no, Batch[title_field])
+			.distinct()
 		)
 
-		query_filters["parent"] = serial_batch_bundle
-		if not txt:
-			query_filters["batch_no"] = ("is", "set")
+		conditions.append(SerialBatchEntry.parent.isin(serial_batch_bundles))
 
-		return frappe.get_all(
-			"Serial and Batch Entry", filters=query_filters, fields=["batch_no"], as_list=True
-		)
+		if filters.get("item_code"):
+			conditions.append(Batch.item == filters.get("item_code"))
+
+		if txt:
+			conditions.append(SerialBatchEntry.batch_no.like(f"%{txt}%"))
+		else:
+			conditions.append(SerialBatchEntry.batch_no.isnotnull())
+
+		for condition in conditions:
+			query = query.where(condition)
+
+		return query.run(as_list=True)
 
 	else:
-		if txt:
-			query_filters["name"] = ["like", f"%{txt}%"]
+		if not filters.get("item_code"):
+			return []
 
-		query_filters["item"] = filters.get("item_code")
-		return frappe.get_all("Batch", filters=query_filters, as_list=True)
+		query = frappe.qb.from_(Batch).select(Batch.name, Batch[title_field])
+
+		conditions.append(Batch.item == filters.get("item_code"))
+
+		if txt:
+			conditions.append(Batch.name.like(f"%{txt}%"))
+
+		for condition in conditions:
+			query = query.where(condition)
+
+		return query.run(as_list=True)


### PR DESCRIPTION
Fixes: #31211 and #47581

## Summary

This PR adds Title Field (title_field) support for the Batch DocType across the following areas:

- Serial and Batch Selector
- Serial and Batch Summary Report
- Other batch-related reports

Previously, batch-related features/reports displayed batch.name. With this change, the system now uses the Batch Title Field when configured, falling back to batch.name when it is not. This results in more meaningful and user-friendly batch information throughout the UI.

In addition, this PR updates Batch creation logic so that batch.name is no longer auto-assigned from batch_id. The document name now correctly follows the Batch DocType naming configuration (naming series, prompt, hash, etc.).

## Why This Is Needed

In many implementations, users prefer to use a naming series for Batch documents while displaying a business-relevant batch number (for example, a supplier or manufacturing batch number).

By allowing the batch_id to be configured as the Title Field for Batch:

- Users can reuse the same batch number across different items
- Reports and selectors display readable, meaningful batch numbers

## Backward Compatibility

- No breaking changes: If no title_field is set on Batch, it will fallback to name.

@rohitwaghchaure, please review this PR and let me know if any changes are required.

`no-docs`