### PR TITLE
fix: don't consider phantom item in additional costs in stock entry

### DIFF
--- a/erpnext/manufacturing/doctype/bom/bom.py
+++ b/erpnext/manufacturing/doctype/bom/bom.py
@@ -1493,7 +1493,7 @@ def add_non_stock_items_cost(stock_entry, work_order, expense_account, job_card=
 	items = {}
 	for d in bom.get(table):
 		# Phantom item is exploded, so its cost is considered via its components
-		if d.is_phantom_item:
+		if d.get("is_phantom_item"):
 			continue
 
 		items.setdefault(d.item_code, d.amount)

--- a/erpnext/manufacturing/doctype/bom/bom.py
+++ b/erpnext/manufacturing/doctype/bom/bom.py
@@ -1492,6 +1492,10 @@ def add_non_stock_items_cost(stock_entry, work_order, expense_account, job_card=
 
 	items = {}
 	for d in bom.get(table):
+		# Phantom item is exploded, so its cost is considered via its components
+		if d.is_phantom_item:
+			continue
+
 		items.setdefault(d.item_code, d.amount)
 
 	non_stock_items = frappe.get_all(

--- a/erpnext/manufacturing/doctype/work_order/test_work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/test_work_order.py
@@ -3275,6 +3275,8 @@ class TestWorkOrder(IntegrationTestCase):
 		"""Test that phantom BOMs are not added to additional costs,
 		but regular non-stock items in the FG BOM are added."""
 
+		from erpnext.stock.doctype.item.test_item import make_item
+
 		# Create items:
 		# - FG Item (stock item)
 		# - Phantom sub-assembly (non-stock item to be phantom)
@@ -3399,12 +3401,19 @@ class TestWorkOrder(IntegrationTestCase):
 		fg_bom.insert()
 		fg_bom.submit()
 
-		# Ensure stock for regular RM
+		# Ensure stock
 		test_stock_entry.make_stock_entry(
 			item_code=regular_rm,
 			target="_Test Warehouse - _TC",
 			qty=10,
 			basic_rate=100,
+		)
+
+		test_stock_entry.make_stock_entry(
+			item_code=phantom_rm,
+			target="_Test Warehouse - _TC",
+			qty=10,
+			basic_rate=200,
 		)
 
 		# Create work order


### PR DESCRIPTION
## Steps to replicate the issue

- Create a Phantom BOM with RM
- Create a FG BOM using Phantom Item, and Packing Material (non-stock items)
- Create a Work Order -> Transfer RM -> Finish Manufacturing

On finish, Phantom item was considered in additional costs leading to duplicate costing. Ideally only other non-stock items like packing material should be considered.

### Before

https://github.com/user-attachments/assets/4c6fbbd8-517b-4def-a8b3-f5b54ea4c598

### After

https://github.com/user-attachments/assets/2248aaa8-2e4c-437f-b724-ff43b5c88dfe

