### PR TITLE
fix: company creation for Italy country

### DIFF
--- a/erpnext/regional/italy/setup.py
+++ b/erpnext/regional/italy/setup.py
@@ -231,22 +231,6 @@ def make_custom_fields(update=True):
 				description=_("Set this if the customer is a Public Administration company."),
 				depends_on='eval:doc.customer_type=="Company"',
 			),
-			dict(
-				fieldname="first_name",
-				label="First Name",
-				fieldtype="Data",
-				insert_after="salutation",
-				print_hide=1,
-				depends_on='eval:doc.customer_type!="Company"',
-			),
-			dict(
-				fieldname="last_name",
-				label="Last Name",
-				fieldtype="Data",
-				insert_after="first_name",
-				print_hide=1,
-				depends_on='eval:doc.customer_type!="Company"',
-			),
 		],
 		"Mode of Payment": [
 			dict(


### PR DESCRIPTION
The company creation for Italy country was failing due to custom column addition of existing columns like first_name and last_name in customer doctype, it fixes https://github.com/frappe/erpnext/issues/51233

`no-docs`