### PR TITLE
fix: available qty not fetched on selection of batch

### DIFF
--- a/erpnext/public/js/utils/serial_no_batch_selector.js
+++ b/erpnext/public/js/utils/serial_no_batch_selector.js
@@ -381,7 +381,7 @@ erpnext.SerialNoBatchSelector = class SerialNoBatchSelector {
 								query: "erpnext.controllers.queries.get_batch_no",
 							};
 						},
-						onchange: function () {
+						change: function () {
 							const batch_no = this.get_value();
 							if (!batch_no) {
 								this.grid_row.on_grid_fields_dict.available_qty.set_value(0);


### PR DESCRIPTION
**Issue**

Qty not fetching from second row

https://github.com/user-attachments/assets/454940d2-c173-4fc9-ba0a-a4748ef7bfcd


**After Fix**

https://github.com/user-attachments/assets/82727592-5efb-4136-a936-3fb80af26645





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved batch selector handling to prevent unnecessary processing when batch number is empty.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->