### PR TITLE
fix: "writeoff" and "change amount" for sales invoice to work toggether

### DIFF
--- a/erpnext/controllers/taxes_and_totals.py
+++ b/erpnext/controllers/taxes_and_totals.py
@@ -988,7 +988,7 @@ class calculate_taxes_and_totals:
 			change_amount = 0
 
 			if self.doc.doctype == "Sales Invoice" and not self.doc.get("is_return"):
-				self.calculate_change_amount()
+				self.calculate_change_amount(total_amount_to_pay)
 				change_amount = (
 					self.doc.change_amount
 					if self.doc.party_account_currency == self.doc.currency
@@ -1046,11 +1046,16 @@ class calculate_taxes_and_totals:
 		self.doc.paid_amount = flt(paid_amount, self.doc.precision("paid_amount"))
 		self.doc.base_paid_amount = flt(base_paid_amount, self.doc.precision("base_paid_amount"))
 
-	def calculate_change_amount(self):
+	def calculate_change_amount(self, total_amount_to_pay):
 		self.doc.change_amount = 0.0
 		self.doc.base_change_amount = 0.0
-		grand_total = self.doc.rounded_total or self.doc.grand_total
-		base_grand_total = self.doc.base_rounded_total or self.doc.base_grand_total
+		if self.doc.party_account_currency == self.doc.currency:
+			grand_total = total_amount_to_pay
+		else:
+			grand_total = flt(
+				total_amount_to_pay / flt(self.doc.conversion_rate), self.doc.precision("grand_total")
+			)
+		base_grand_total = total_amount_to_pay
 
 		if (
 			self.doc.doctype == "Sales Invoice"
@@ -1068,11 +1073,12 @@ class calculate_taxes_and_totals:
 
 	def calculate_write_off_amount(self):
 		if self.doc.get("write_off_outstanding_amount_automatically"):
+			# NOTE: outstanding_amount is based on company currency.
 			self.doc.write_off_amount = flt(
-				self.doc.outstanding_amount, self.doc.precision("write_off_amount")
+				self.doc.outstanding_amount / self.doc.conversion_rate, self.doc.precision("write_off_amount")
 			)
 			self.doc.base_write_off_amount = flt(
-				self.doc.write_off_amount * self.doc.conversion_rate,
+				self.doc.outstanding_amount,
 				self.doc.precision("base_write_off_amount"),
 			)
 

--- a/erpnext/controllers/taxes_and_totals.py
+++ b/erpnext/controllers/taxes_and_totals.py
@@ -1074,9 +1074,16 @@ class calculate_taxes_and_totals:
 	def calculate_write_off_amount(self):
 		if self.doc.get("write_off_outstanding_amount_automatically"):
 			# NOTE: outstanding_amount is based on company currency.
-			self.doc.write_off_amount = flt(
-				self.doc.outstanding_amount / self.doc.conversion_rate, self.doc.precision("write_off_amount")
-			)
+			if self.doc.party_account_currency == self.doc.currency:
+				self.doc.write_off_amount = flt(
+					self.doc.outstanding_amount, self.doc.precision("write_off_amount")
+				)
+			else:
+				self.doc.write_off_amount = flt(
+					self.doc.outstanding_amount / self.doc.conversion_rate,
+					self.doc.precision("write_off_amount"),
+				)
+
 			self.doc.base_write_off_amount = flt(
 				self.doc.outstanding_amount,
 				self.doc.precision("base_write_off_amount"),

--- a/erpnext/public/js/controllers/taxes_and_totals.js
+++ b/erpnext/public/js/controllers/taxes_and_totals.js
@@ -1108,8 +1108,12 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 				return d.type;
 			});
 			if (payment_types.includes("Cash")) {
-				var grand_total = this.frm.doc.rounded_total || this.frm.doc.grand_total;
-				var base_grand_total = this.frm.doc.base_rounded_total || this.frm.doc.base_grand_total;
+				var grand_total =
+					this.frm.doc.rounded_total ||
+					this.frm.doc.grand_total - flt(this.frm.doc.write_off_amount);
+				var base_grand_total =
+					this.frm.doc.base_rounded_total ||
+					this.frm.doc.base_grand_total - flt(this.frm.doc.base_write_off_amount);
 
 				this.frm.doc.change_amount = flt(
 					this.frm.doc.paid_amount - grand_total,
@@ -1125,13 +1129,15 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 	}
 
 	calculate_write_off_amount() {
+		// NOTE: outstanding_amount is based on company currency.
 		if (this.frm.doc.write_off_outstanding_amount_automatically) {
 			this.frm.doc.write_off_amount = flt(
-				this.frm.doc.outstanding_amount,
+				this.frm.doc.outstanding_amount / this.frm.doc.conversion_rate,
 				precision("write_off_amount")
 			);
+
 			this.frm.doc.base_write_off_amount = flt(
-				this.frm.doc.write_off_amount * this.frm.doc.conversion_rate,
+				this.frm.doc.outstanding_amount,
 				precision("base_write_off_amount")
 			);
 


### PR DESCRIPTION
Issue: https://github.com/frappe/erpnext/issues/45607

Summary:
1. fix: writeoff and change amout to work toggether.
2. fix: writeoff amount when using multi currency and write_off_outstanding_amount_automatically=1


Details:

1. Currently when a sales invoice is processed with a payment, we have errors in handling the following fields:

- Writeoff
- Change Amount

In previous versions this worked VERY well, I don't know what direction ERPNext is taking, but this has stopped working as it should.


Example:
Sales Invoice: R$ 18.90
Paid Amount: R$ 20
Write off: R$ -0.10
Change amount: R$ 1


Sales Amount - Write Off = Total to be Paid.
18.90 - (-0.1) = R$ 19.00

Paid Amount - Grand Total = Change Amount
R$ 20 - 19 = R$ 1



- **Before my Changes**

https://github.com/user-attachments/assets/22914edc-dc20-4e4e-91e9-688fcf009623


- **After my Changes**

https://github.com/user-attachments/assets/aaea7588-ff84-4eb7-89f4-9e69694852de


2. For check "Write Off Outstanding Amount" multi currency was fixed, The field "self.doc.outstanding_amount" always displays the value in the company's currency, so adjustments were made to ensure that when applying the writeoff, the calculation is done correctly.


https://github.com/user-attachments/assets/c2f7d3af-9f65-4a66-a876-9ee440ef65da






NOTE: If this PR is approved, I will resume the PR that makes this work using the POS.
https://github.com/frappe/erpnext/pull/45963

Issue of anothers persons...
https://github.com/frappe/erpnext/issues/47893

@diptanilsaha 
@nabinhait 
@ruthra-kumar 
