### PR TITLE
feat: Added description column for update items

### DIFF
--- a/erpnext/buying/doctype/supplier_quotation/test_supplier_quotation.py
+++ b/erpnext/buying/doctype/supplier_quotation/test_supplier_quotation.py
@@ -25,17 +25,14 @@ class TestPurchaseOrder(IntegrationTestCase):
 					"qty": 5,
 					"docname": sq.items[0].name,
 				},
-				{
-					"item_code": "_Test Item 2",
-					"rate": 300,
-					"qty": 3,
-				},
+				{"item_code": "_Test Item 2", "rate": 300, "qty": 3, "description": "test"},
 			]
 		)
 		update_child_qty_rate("Supplier Quotation", trans_item, sq.name)
 		sq.reload()
 		self.assertEqual(sq.get("items")[0].qty, 5)
 		self.assertEqual(sq.get("items")[1].rate, 300)
+		self.assertEqual(sq.get("items")[1].description, "test")
 
 	def test_update_supplier_quotation_child_rate_disallow(self):
 		sq = frappe.copy_doc(self.globalTestRecords["Supplier Quotation"][0])

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -3990,6 +3990,8 @@ def update_child_qty_rate(parent_doctype, trans_items, parent_doctype_name, chil
 			elif parent_doctype == "Purchase Order":
 				prev_date, new_date = child_item.get("schedule_date"), d.get("schedule_date")
 
+			prev_description, new_description = (child_item.get("description"), d.get("description"))
+			description_unchanged = prev_description == new_description
 			rate_unchanged = prev_rate == new_rate
 			qty_unchanged = prev_qty == new_qty
 			fg_qty_unchanged = prev_fg_qty == new_fg_qty
@@ -4008,6 +4010,7 @@ def update_child_qty_rate(parent_doctype, trans_items, parent_doctype_name, chil
 				and conversion_factor_unchanged
 				and uom_unchanged
 				and date_unchanged
+				and description_unchanged
 			):
 				continue
 
@@ -4031,6 +4034,7 @@ def update_child_qty_rate(parent_doctype, trans_items, parent_doctype_name, chil
 				child_item.fg_item = d["fg_item"]
 
 		child_item.qty = flt(d.get("qty"))
+		child_item.description = d.get("description")
 		rate_precision = child_item.precision("rate") or 2
 		conv_fac_precision = child_item.precision("conversion_factor") or 2
 		qty_precision = child_item.precision("qty") or 2

--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -624,6 +624,7 @@ erpnext.utils.update_child_items = function (opts) {
 			uom: d.uom,
 			fg_item: d.fg_item,
 			fg_item_qty: d.fg_item_qty,
+			description: d.description,
 		};
 	});
 
@@ -707,8 +708,8 @@ erpnext.utils.update_child_items = function (opts) {
 								conversion_factor,
 								item_name,
 								bom_no,
+								description,
 							} = r.message;
-
 							const row = dialog.fields_dict.trans_items.df.data.find(
 								(row) => row.name == me.doc.name
 							);
@@ -720,6 +721,7 @@ erpnext.utils.update_child_items = function (opts) {
 									rate: me.doc.rate || rate,
 									item_name: item_name,
 									bom_no: bom_no,
+									description: me.doc.description || description,
 								});
 								dialog.fields_dict.trans_items.grid.refresh();
 							}
@@ -780,6 +782,12 @@ erpnext.utils.update_child_items = function (opts) {
 			in_list_view: 1,
 			label: __("Rate"),
 			precision: get_precision("rate"),
+		},
+		{
+			fieldtype: "Text Editor",
+			fieldname: "description",
+			read_only: 0,
+			label: __("Description"),
 		},
 	];
 

--- a/erpnext/selling/doctype/quotation/test_quotation.py
+++ b/erpnext/selling/doctype/quotation/test_quotation.py
@@ -42,6 +42,7 @@ class TestQuotation(IntegrationTestCase):
 					"rate": second_item.rate,
 					"qty": second_item.qty,
 					"docname": second_item.name,
+					"description": "test",
 				},
 				{"item_code": "_Test Item 2", "rate": 100, "qty": 7},
 			]
@@ -51,6 +52,7 @@ class TestQuotation(IntegrationTestCase):
 		qo.reload()
 		self.assertEqual(qo.get("items")[0].qty, 11)
 		self.assertEqual(qo.get("items")[-1].rate, 100)
+		self.assertEqual(qo.get("items")[1].description, "test")
 
 	def test_disallow_due_date_before_transaction_date(self):
 		qo = make_quotation(qty=3, do_not_submit=1)


### PR DESCRIPTION
This is with reference to the following https://github.com/frappe/erpnext/issues/49518, as requested have added description column which can be updated through update items button in Sales Order, Purchase Order, Quotation and Supplier Quotation doctype. 


`no-docs`