### PR TITLE
fix: do not hide primary-action for composite asset

### DIFF
--- a/erpnext/assets/doctype/asset/asset.js
+++ b/erpnext/assets/doctype/asset/asset.js
@@ -80,6 +80,12 @@ frappe.ui.form.on("Asset", {
 		}
 	},
 
+	before_submit: function (frm) {
+		if (frm.doc.is_composite_asset && !frm.has_active_capitalization) {
+			frappe.throw(__("Please capitalize this asset before submitting."));
+		}
+	},
+
 	refresh: function (frm) {
 		frappe.ui.form.trigger("Asset", "is_existing_asset");
 		frm.toggle_display("next_depreciation_date", frm.doc.docstatus < 1);
@@ -200,9 +206,10 @@ frappe.ui.form.on("Asset", {
 						asset: frm.doc.name,
 					},
 					callback: function (r) {
+						frm.has_active_capitalization = r.message;
+
 						if (!r.message) {
-							$(".primary-action").prop("hidden", true);
-							$(".form-message").text(__("Capitalize this asset to confirm"));
+							$(".form-message").text(__("Capitalize this asset before submitting."));
 
 							frm.add_custom_button(__("Capitalize Asset"), function () {
 								frm.trigger("create_asset_capitalization");
@@ -474,7 +481,6 @@ frappe.ui.form.on("Asset", {
 	is_composite_asset: function (frm) {
 		if (frm.doc.is_composite_asset) {
 			frm.set_value("gross_purchase_amount", 0);
-			frm.set_df_property("gross_purchase_amount", "read_only", 1);
 		} else {
 			frm.set_df_property("gross_purchase_amount", "read_only", 0);
 		}
@@ -542,7 +548,6 @@ frappe.ui.form.on("Asset", {
 			callback: function (r) {
 				var doclist = frappe.model.sync(r.message);
 				frappe.set_route("Form", doclist[0].doctype, doclist[0].name);
-				$(".primary-action").prop("hidden", false);
 			},
 		});
 	},

--- a/erpnext/assets/doctype/asset/asset.json
+++ b/erpnext/assets/doctype/asset/asset.json
@@ -229,7 +229,8 @@
    "fieldtype": "Currency",
    "label": "Net Purchase Amount",
    "mandatory_depends_on": "eval:(!doc.is_composite_asset || doc.docstatus==1)",
-   "options": "Company:company:default_currency"
+   "options": "Company:company:default_currency",
+   "read_only_depends_on": "eval: doc.is_composite_asset"
   },
   {
    "fieldname": "available_for_use_date",
@@ -596,7 +597,7 @@
    "link_fieldname": "target_asset"
   }
  ],
- "modified": "2025-11-17 18:01:51.417942",
+ "modified": "2025-12-23 16:01:10.195932",
  "modified_by": "Administrator",
  "module": "Assets",
  "name": "Asset",

--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -69,7 +69,6 @@ class Asset(AccountsController):
 		default_finance_book: DF.Link | None
 		department: DF.Link | None
 		depr_entry_posting_status: DF.Literal["", "Successful", "Failed"]
-		depreciation_completed: DF.Check
 		depreciation_method: DF.Literal["", "Straight Line", "Double Declining Balance", "Manual"]
 		disposal_date: DF.Date | None
 		finance_books: DF.Table[AssetFinanceBook]
@@ -158,6 +157,10 @@ class Asset(AccountsController):
 	def before_save(self):
 		self.total_asset_cost = self.gross_purchase_amount + self.additional_asset_cost
 		self.status = self.get_status()
+
+	def before_submit(self):
+		if self.is_composite_asset and not has_active_capitalization(self.name):
+			frappe.throw(_("Please capitalize this asset before submitting."))
 
 	def on_submit(self):
 		self.validate_in_use_date()


### PR DESCRIPTION
Backport PR of https://github.com/frappe/erpnext/pull/51205

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation requiring composite assets to have active capitalization before submission.

* **Bug Fixes**
  * Improved capitalization prompts for clearer user guidance.
  * Updated field read-only behavior: Net Purchase Amount now conditionally locked based on asset type.
  * Restored gross_purchase_amount field editability for composite assets.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->