### PR TITLE
fix(subscription): add grace period status while invoice in grace period

### DIFF
--- a/erpnext/accounts/doctype/subscription/subscription.json
+++ b/erpnext/accounts/doctype/subscription/subscription.json
@@ -51,7 +51,7 @@
    "fieldtype": "Select",
    "label": "Status",
    "no_copy": 1,
-   "options": "\nTrialing\nActive\nPast Due Date\nCancelled\nUnpaid\nCompleted",
+   "options": "\nTrialing\nActive\nGrace Period\nCancelled\nUnpaid\nCompleted",
    "read_only": 1
   },
   {
@@ -267,7 +267,7 @@
    "link_fieldname": "subscription"
   }
  ],
- "modified": "2024-03-27 13:10:47.578120",
+ "modified": "2025-12-23 19:42:52.036034",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Subscription",
@@ -311,6 +311,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],

--- a/erpnext/accounts/doctype/subscription/subscription.py
+++ b/erpnext/accounts/doctype/subscription/subscription.py
@@ -77,7 +77,7 @@ class Subscription(Document):
 		purchase_tax_template: DF.Link | None
 		sales_tax_template: DF.Link | None
 		start_date: DF.Date | None
-		status: DF.Literal["", "Trialing", "Active", "Past Due Date", "Cancelled", "Unpaid", "Completed"]
+		status: DF.Literal["", "Trialing", "Active", "Grace Period", "Cancelled", "Unpaid", "Completed"]
 		submit_invoice: DF.Check
 		trial_period_end: DF.Date | None
 		trial_period_start: DF.Date | None
@@ -229,7 +229,7 @@ class Subscription(Document):
 			self.status = self.get_status_for_past_grace_period()
 			self.cancelation_date = getdate(posting_date) if self.status == "Cancelled" else None
 		elif self.current_invoice_is_past_due() and not self.is_past_grace_period():
-			self.status = "Past Due Date"
+			self.status = "Grace Period"
 		elif not self.has_outstanding_invoice():
 			self.status = "Active"
 

--- a/erpnext/accounts/doctype/subscription/test_subscription.py
+++ b/erpnext/accounts/doctype/subscription/test_subscription.py
@@ -144,17 +144,17 @@ class TestSubscription(IntegrationTestCase):
 		subscription = create_subscription(start_date=add_days(nowdate(), -1000))
 
 		subscription.process(posting_date=subscription.current_invoice_end)  # generate first invoice
-		self.assertEqual(subscription.status, "Past Due Date")
+		self.assertEqual(subscription.status, "Grace Period")
 
 		subscription.process()
-		# Grace period is 1000 days so status should remain as Past Due Date
-		self.assertEqual(subscription.status, "Past Due Date")
+		# Grace period is 1000 days so status should remain as Grace Period
+		self.assertEqual(subscription.status, "Grace Period")
 
 		subscription.process()
-		self.assertEqual(subscription.status, "Past Due Date")
+		self.assertEqual(subscription.status, "Grace Period")
 
 		subscription.process()
-		self.assertEqual(subscription.status, "Past Due Date")
+		self.assertEqual(subscription.status, "Grace Period")
 
 		settings.grace_period = grace_period
 		settings.save()


### PR DESCRIPTION
Added a status called "Grace Period" so that when the invoice is past due, the subscription will display "Grace Period" if there is a grace period set in the settings instead of the past due date status.
<img width="1450" height="836" alt="Screenshot 2025-12-23 at 8 02 44 PM" src="https://github.com/user-attachments/assets/039dd6c5-f206-4329-954c-0d3c2043d6e2" />
