### PR TITLE
fix(repost accounting ledger): prevent preview generation when no vouchers are selected

### DIFF
--- a/erpnext/accounts/doctype/repost_accounting_ledger/repost_accounting_ledger.py
+++ b/erpnext/accounts/doctype/repost_accounting_ledger/repost_accounting_ledger.py
@@ -115,6 +115,10 @@ class RepostAccountingLedger(Document):
 	def generate_preview(self):
 		from erpnext.accounts.report.general_ledger.general_ledger import get_columns as get_gl_columns
 
+		if not self.vouchers:
+			frappe.msgprint(_("Add vouchers to generate preview."))
+			return
+
 		gl_columns = []
 		gl_data = []
 


### PR DESCRIPTION
Fixed the issue where an error was encountered on clicking the "Show Preview" button on the Repost Accounting Ledger without selecting any vouchers.

Before:

<img width="1514" height="666" alt="image" src="https://github.com/user-attachments/assets/58b758ce-5dc9-4d11-95a5-3c59277fd1cb" />

After:

<img width="1250" height="314" alt="image" src="https://github.com/user-attachments/assets/4e088846-9e88-49cd-a758-bb93c002d773" />
