### PR TITLE
fix(journal entry): use submission_queue to perform submit and cancel actions for rows over 100

### DIFF
--- a/erpnext/accounts/doctype/journal_entry/journal_entry.py
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.py
@@ -6,6 +6,7 @@ import json
 
 import frappe
 from frappe import _, msgprint, scrub
+from frappe.core.doctype.submission_queue.submission_queue import queue_submission
 from frappe.utils import comma_and, cstr, flt, fmt_money, formatdate, get_link_to_form, nowdate
 
 import erpnext
@@ -179,15 +180,13 @@ class JournalEntry(AccountsController):
 
 	def submit(self):
 		if len(self.accounts) > 100:
-			msgprint(_("The task has been enqueued as a background job."), alert=True)
-			self.queue_action("submit", timeout=4600)
+			queue_submission(self, "_submit")
 		else:
 			return self._submit()
 
 	def cancel(self):
 		if len(self.accounts) > 100:
-			msgprint(_("The task has been enqueued as a background job."), alert=True)
-			self.queue_action("cancel", timeout=4600)
+			queue_submission(self, "_cancel")
 		else:
 			return self._cancel()
 


### PR DESCRIPTION
Issue: When a journal entry with more than 100 rows is updated after submission with accounting dimension values, then the system fails to repost the related GL entries.

Ref: [55575](https://support.frappe.io/helpdesk/tickets/55575)

Before:

https://github.com/user-attachments/assets/eb752894-1b02-47a4-b94d-f3f2560b7a8f

After:

https://github.com/user-attachments/assets/66464c49-21a8-4f55-9bcc-3397b0127b10


