### PR TITLE
fix: logo was not visible because of wrong fieldname

### DIFF
--- a/erpnext/accounts/letterhead/company_letterhead.html
+++ b/erpnext/accounts/letterhead/company_letterhead.html
@@ -56,8 +56,11 @@
 		<tr>
 			<td class="logo-cell" style="vertical-align: middle !important">
 				<div class="logo-container">
-					{% set company_logo = frappe.db.get_value("Company", doc.company, "logo_for_printing") %} {% if
-					company_logo %}
+					{% set company_logo = frappe.db.get_value("Company", doc.company, "company_logo") %} 
+					{% if not company_logo and "india_compliance" not in frappe.get_installed_apps() %}
+					{% set company_logo = frappe.db.get_value("Company", doc.company, "logo_for_printing") %}
+					{% endif %}
+					{% if company_logo %}
 					<img src="{{ frappe.utils.get_url(company_logo) }}" alt="Company Logo" />
 					{% endif %}
 				</div>

--- a/erpnext/accounts/letterhead/company_letterhead.html
+++ b/erpnext/accounts/letterhead/company_letterhead.html
@@ -56,7 +56,7 @@
 		<tr>
 			<td class="logo-cell" style="vertical-align: middle !important">
 				<div class="logo-container">
-					{% set company_logo = frappe.db.get_value("Company", doc.company, "company_logo") %} {% if
+					{% set company_logo = frappe.db.get_value("Company", doc.company, "logo_for_printing") %} {% if
 					company_logo %}
 					<img src="{{ frappe.utils.get_url(company_logo) }}" alt="Company Logo" />
 					{% endif %}

--- a/erpnext/accounts/letterhead/company_letterhead_grey.html
+++ b/erpnext/accounts/letterhead/company_letterhead_grey.html
@@ -74,7 +74,7 @@
 	<tbody>
 		<tr>
 			<td class="logo-address">
-				{% set company_logo = frappe.db.get_value("Company", doc.company, "company_logo") %} {% if
+				{% set company_logo = frappe.db.get_value("Company", doc.company, "logo_for_printing") %} {% if
 				company_logo %}
 				<div class="logo">
 					<img src="{{ frappe.utils.get_url(company_logo) }}" />

--- a/erpnext/accounts/letterhead/company_letterhead_grey.html
+++ b/erpnext/accounts/letterhead/company_letterhead_grey.html
@@ -74,8 +74,11 @@
 	<tbody>
 		<tr>
 			<td class="logo-address">
-				{% set company_logo = frappe.db.get_value("Company", doc.company, "logo_for_printing") %} {% if
-				company_logo %}
+				{% set company_logo = frappe.db.get_value("Company", doc.company, "company_logo") %} 
+				{% if not company_logo and "india_compliance" not in frappe.get_installed_apps() %}
+				{% set company_logo = frappe.db.get_value("Company", doc.company, "logo_for_printing") %}
+				{% endif %}
+				{% if company_logo %}
 				<div class="logo">
 					<img src="{{ frappe.utils.get_url(company_logo) }}" />
 				</div>


### PR DESCRIPTION
In the Company doctype, ERPNext now provides a field called logo_for_printing to upload the company logo intended for print formats.

However, in the following letterhead templates, the field company_logo is still being used:

erpnext/accounts/letterhead/company_letterhead.html (line 59)

erpnext/accounts/letterhead/company_letterhead_grey.html (line 77)

Because of this mismatch, the logo does not appear in the print view of documents such as Sales Orders and Purchase Orders, which rely on these letterhead templates.

The field reference in the templates should be updated from company_logo to logo_for_printing to ensure the logo displays correctly in print formats.