### PR TITLE
 feat(task): update progress on parent task

### DIFF
--- a/erpnext/projects/doctype/task/task.js
+++ b/erpnext/projects/doctype/task/task.js
@@ -60,7 +60,7 @@ frappe.ui.form.on("Task", {
 	},
 
 	project: function (frm) {
-		if (frm.doc.parent_task && frm.doc.project !== "") {
+		if (frm.doc.parent_task && frm.doc.project) {
 			frappe.db.get_value("Task", frm.doc.parent_task, "project").then((r) => {
 				if (r.message && r.message.project !== frm.doc.project) {
 					frm.set_value("parent_task", "");

--- a/erpnext/projects/doctype/task/task.js
+++ b/erpnext/projects/doctype/task/task.js
@@ -58,14 +58,4 @@ frappe.ui.form.on("Task", {
 	validate: function (frm) {
 		frm.doc.project && frappe.model.remove_from_locals("Project", frm.doc.project);
 	},
-
-	project: function (frm) {
-		if (frm.doc.parent_task && frm.doc.project) {
-			frappe.db.get_value("Task", frm.doc.parent_task, "project").then((r) => {
-				if (r.message && r.message.project !== frm.doc.project) {
-					frm.set_value("parent_task", "");
-				}
-			});
-		}
-	},
 });

--- a/erpnext/projects/doctype/task/task.js
+++ b/erpnext/projects/doctype/task/task.js
@@ -58,4 +58,14 @@ frappe.ui.form.on("Task", {
 	validate: function (frm) {
 		frm.doc.project && frappe.model.remove_from_locals("Project", frm.doc.project);
 	},
+
+	project: function (frm) {
+		if (frm.doc.parent_task && frm.doc.project !== "") {
+			frappe.db.get_value("Task", frm.doc.parent_task, "project").then((r) => {
+				if (r.message && r.message.project !== frm.doc.project) {
+					frm.set_value("parent_task", "");
+				}
+			});
+		}
+	},
 });

--- a/erpnext/projects/doctype/task/task.json
+++ b/erpnext/projects/doctype/task/task.json
@@ -194,7 +194,8 @@
    "fieldname": "progress",
    "fieldtype": "Percent",
    "label": "% Progress",
-   "no_copy": 1
+   "no_copy": 1,
+   "read_only_depends_on": "eval:doc.is_group == 1"
   },
   {
    "default": "0",
@@ -423,7 +424,7 @@
  "is_tree": 1,
  "links": [],
  "max_attachments": 5,
- "modified": "2026-03-04 11:47:10.454548",
+ "modified": "2025-12-29 21:27:02.120525",
  "modified_by": "Administrator",
  "module": "Projects",
  "name": "Task",

--- a/erpnext/projects/doctype/task/task.json
+++ b/erpnext/projects/doctype/task/task.json
@@ -424,7 +424,7 @@
  "is_tree": 1,
  "links": [],
  "max_attachments": 5,
- "modified": "2025-12-29 21:27:02.120525",
+ "modified": "2026-03-25 15:07:02.120525",
  "modified_by": "Administrator",
  "module": "Projects",
  "name": "Task",

--- a/erpnext/projects/doctype/task/task.py
+++ b/erpnext/projects/doctype/task/task.py
@@ -176,7 +176,9 @@ class Task(NestedSet):
 			frappe.qb.from_(Task).select(Avg(Task.progress)).where(Task.parent_task == parent_task)
 		).run()[0][0] or 0
 
-		frappe.db.set_value("Task", parent_task, "progress", avg_progress)
+		doc = frappe.get_doc("Task", parent_task)
+		doc.progress = avg_progress
+		doc.save()
 
 	def validate_dependencies_for_template_task(self):
 		if self.is_template:

--- a/erpnext/projects/doctype/task/task.py
+++ b/erpnext/projects/doctype/task/task.py
@@ -322,6 +322,8 @@ class Task(NestedSet):
 			return True
 
 	def populate_depends_on(self):
+		TaskDependsOn = frappe.qb.DocType("Task Depends On")
+
 		if self.parent_task:
 			parent = frappe.get_doc("Task", self.parent_task)
 			if self.name not in [row.task for row in parent.depends_on]:
@@ -329,6 +331,16 @@ class Task(NestedSet):
 					"depends_on", {"doctype": "Task Depends On", "task": self.name, "subject": self.subject}
 				)
 				parent.save()
+
+		doc_before_save = self.get_doc_before_save()
+		if (
+			doc_before_save
+			and doc_before_save.parent_task
+			and doc_before_save.parent_task != self.parent_task
+		):
+			frappe.qb.from_(TaskDependsOn).delete().where(
+				(TaskDependsOn.parent == doc_before_save.parent_task) & (TaskDependsOn.task == self.name)
+			).run()
 
 	def on_trash(self):
 		if check_if_child_exists(self.name):

--- a/erpnext/projects/doctype/task/task.py
+++ b/erpnext/projects/doctype/task/task.py
@@ -90,6 +90,7 @@ class Task(NestedSet):
 		self.validate_completed_on()
 		self.set_default_end_date_if_missing()
 		self.validate_parent_is_group()
+		self.validate_parent_task_project()
 
 	def validate_dates(self):
 		self.validate_from_to_dates("exp_start_date", "exp_end_date")
@@ -217,6 +218,12 @@ class Task(NestedSet):
 					),
 					ParentIsGroupError,
 				)
+
+	def validate_parent_task_project(self):
+		if self.parent_task and self.project:
+			parent_proj = frappe.get_value("Task", self.parent_task, "project")
+			if self.project != parent_proj:
+				self.parent_task = ""
 
 	def update_depends_on(self):
 		depends_on_tasks = ""

--- a/erpnext/projects/doctype/task/task.py
+++ b/erpnext/projects/doctype/task/task.py
@@ -8,7 +8,7 @@ import frappe
 from frappe import _, throw
 from frappe.desk.form.assign_to import clear, close_all_assignments
 from frappe.model.mapper import get_mapped_doc
-from frappe.query_builder.functions import Max, Min, Sum
+from frappe.query_builder.functions import Avg, Max, Min, Sum
 from frappe.utils import add_days, add_to_date, cstr, date_diff, flt, get_link_to_form, getdate, today
 from frappe.utils.data import format_date
 from frappe.utils.nestedset import NestedSet
@@ -158,6 +158,26 @@ class Task(NestedSet):
 		if self.status == "Completed":
 			self.progress = 100
 
+	def update_parent_progress(self):
+		doc_before_save = self.get_doc_before_save()
+		if (
+			doc_before_save
+			and doc_before_save.parent_task
+			and doc_before_save.parent_task != self.parent_task
+		):
+			self.set_parent_progress(doc_before_save.parent_task)
+
+		if self.parent_task:
+			self.set_parent_progress(self.parent_task)
+
+	def set_parent_progress(self, parent_task):
+		Task = frappe.qb.DocType("Task")
+		avg_progress = (
+			frappe.qb.from_(Task).select(Avg(Task.progress)).where(Task.parent_task == parent_task)
+		).run()[0][0] or 0
+
+		frappe.db.set_value("Task", parent_task, "progress", avg_progress)
+
 	def validate_dependencies_for_template_task(self):
 		if self.is_template:
 			self.validate_parent_template_task()
@@ -213,6 +233,7 @@ class Task(NestedSet):
 		self.update_project()
 		self.unassign_todo()
 		self.populate_depends_on()
+		self.update_parent_progress()
 
 	def unassign_todo(self):
 		if self.status == "Completed":

--- a/erpnext/projects/doctype/task/test_task.py
+++ b/erpnext/projects/doctype/task/test_task.py
@@ -178,6 +178,27 @@ class TestTask(ERPNextTestSuite):
 		task.save()
 		self.assertEqual(getdate(task.exp_end_date), getdate(add_days(nowdate(), 5)))
 
+	def test_prev_parent_depends_on(self):
+		parent_task1 = create_task(
+			subject="_Test Parent Task 1",
+			is_group=1,
+		)
+
+		parent_task2 = create_task(
+			subject="_Test Parent Task 2",
+			is_group=1,
+		)
+
+		child_task = create_task(subject="_Test Child Task", parent_task=parent_task1.name, save=True)
+
+		child_task.parent_task = parent_task2.name
+		child_task.save()
+
+		parent_task1.reload()
+		parent_task2.reload()
+		self.assertEqual(parent_task1.depends_on, [])
+		self.assertEqual(parent_task2.depends_on[0].task, child_task.name)
+
 
 def create_task(
 	subject,

--- a/erpnext/projects/doctype/task/test_task.py
+++ b/erpnext/projects/doctype/task/test_task.py
@@ -152,6 +152,26 @@ class TestTask(ERPNextTestSuite):
 
 		self.assertRaises(ParentIsGroupError, child_task.save)
 
+	def test_parent_task_progress(self):
+		parent_task = create_task(
+			subject="_Test Parent Task",
+			is_group=1,
+		)
+
+		child_task1 = create_task(subject="_Test Child Task1", parent_task=parent_task.name, save=False)
+		child_task1.progress = 30
+		child_task1.save()
+
+		parent_task.reload()
+		self.assertEqual(parent_task.progress, 30)
+
+		child_task2 = create_task(subject="_Test Child Task2", parent_task=parent_task.name, save=False)
+		child_task2.progress = 50
+		child_task2.save()
+
+		parent_task.reload()
+		self.assertEqual(parent_task.progress, 40)
+
 	def test_expected_end_date(self):
 		task = create_task("Testing End Date", add_days(nowdate(), 1), add_days(nowdate(), 5))
 		task.expected_time = 72


### PR DESCRIPTION
**Issue:**

1. When child tasks are updated with their progress percentage, the parent task's progress is not automatically recalculated based on its children's progress.
**fixes:** #47267

2. When the child task is updated with the new parent task, the depends on reference is not removed from the previous parent task of the child task. 

3. The user created task T3, associated with project P1 and parent task PT1. If the project is changed to Project P2, the parent task PT1 is still linked to the task T3 
(Note: After this, Task T3 is assigned to Project P2, but the parent task PT1 is assigned to the P1)

**Solution**

1.  Calculated the child task's average progress and set it on the parent task.
2. Deleted the Depends on reference in the parent task when the parent task is removed from the child task.
3. Unlinked the parent task field if a new project(not linked with the parent task) is assigned to the child task.

Backport needed for v15, v16