### PR TITLE
fix(bank reconciliation tool): carry bank account to payment entry

### DIFF
--- a/erpnext/accounts/doctype/bank_reconciliation_tool/bank_reconciliation_tool.py
+++ b/erpnext/accounts/doctype/bank_reconciliation_tool/bank_reconciliation_tool.py
@@ -345,7 +345,9 @@ def create_payment_entry_bts(
 	pe.mode_of_payment = mode_of_payment
 	pe.project = project
 	pe.cost_center = cost_center
-	pe.bank_account = company_bank_account
+
+	if company_bank_account:
+		pe.bank_account = company_bank_account
 
 	pe.validate()
 

--- a/erpnext/accounts/doctype/bank_reconciliation_tool/bank_reconciliation_tool.py
+++ b/erpnext/accounts/doctype/bank_reconciliation_tool/bank_reconciliation_tool.py
@@ -304,6 +304,7 @@ def create_payment_entry_bts(
 	project=None,
 	cost_center=None,
 	allow_edit=None,
+	company_bank_account=None,
 ):
 	# Create a new payment entry based on the bank transaction
 	bank_transaction = frappe.db.get_values(
@@ -344,6 +345,7 @@ def create_payment_entry_bts(
 	pe.mode_of_payment = mode_of_payment
 	pe.project = project
 	pe.cost_center = cost_center
+	pe.bank_account = company_bank_account
 
 	pe.validate()
 

--- a/erpnext/public/js/bank_reconciliation_tool/dialog_manager.js
+++ b/erpnext/public/js/bank_reconciliation_tool/dialog_manager.js
@@ -526,7 +526,7 @@ erpnext.accounts.bank_reconciliation.DialogManager = class DialogManager {
 				mode_of_payment: values.mode_of_payment,
 				project: values.project,
 				cost_center: values.cost_center,
-				company_bank_account: values?.company_bank_account || this?.bank_account,
+				company_bank_account: values?.bank_account || this?.bank_account,
 			},
 			callback: (response) => {
 				const alert_string = __("Bank Transaction {0} added as Payment Entry", [
@@ -598,7 +598,7 @@ erpnext.accounts.bank_reconciliation.DialogManager = class DialogManager {
 					project: values.project,
 					cost_center: values.cost_center,
 					allow_edit: true,
-					company_bank_account: values?.company_bank_account || this?.bank_account,
+					company_bank_account: values?.bank_account || this?.bank_account,
 				},
 				callback: (r) => {
 					const doc = frappe.model.sync(r.message);

--- a/erpnext/public/js/bank_reconciliation_tool/dialog_manager.js
+++ b/erpnext/public/js/bank_reconciliation_tool/dialog_manager.js
@@ -362,6 +362,21 @@ erpnext.accounts.bank_reconciliation.DialogManager = class DialogManager {
 					"eval:doc.action=='Create Voucher' && doc.document_type=='Payment Entry'",
 			},
 			{
+				fieldname: "bank_account",
+				fieldtype: "Link",
+				label: "Company Bank Account",
+				options: "Bank Account",
+				depends_on: "eval:doc.party",
+				get_query: function () {
+					return {
+						filters: {
+							is_company_account: 1,
+							company: this.company,
+						},
+					};
+				},
+			},
+			{
 				fieldname: "project",
 				fieldtype: "Link",
 				label: "Project",
@@ -511,6 +526,7 @@ erpnext.accounts.bank_reconciliation.DialogManager = class DialogManager {
 				mode_of_payment: values.mode_of_payment,
 				project: values.project,
 				cost_center: values.cost_center,
+				company_bank_account: values?.company_bank_account || this?.bank_account,
 			},
 			callback: (response) => {
 				const alert_string = __("Bank Transaction {0} added as Payment Entry", [
@@ -582,6 +598,7 @@ erpnext.accounts.bank_reconciliation.DialogManager = class DialogManager {
 					project: values.project,
 					cost_center: values.cost_center,
 					allow_edit: true,
+					company_bank_account: values?.company_bank_account || this?.bank_account,
 				},
 				callback: (r) => {
 					const doc = frappe.model.sync(r.message);


### PR DESCRIPTION
Issue:
When using the Bank Reconciliation Tool to create a new Payment Entry, the selected Company Bank Account is not carried over to the Payment Entry.

Ref: [#56124](https://support.frappe.io/helpdesk/tickets/56124)

Steps to Reproduce:
1. Go to the Bank Reconciliation Tool.
2. Fetch the unreconciled bank transactions.
3. For any transaction, use the Actions menu and choose `Create Voucher` and Document type `Payment Entry`.
4. Submit the voucher, go to the PE created notice that in the `Payment Entry` in the company bank account, the bank account is not carried over.

Before:


https://github.com/user-attachments/assets/873aabd0-f073-4db6-b496-7843a5c7e9d1



After:

https://github.com/user-attachments/assets/39bcc67d-6fbb-4fd5-9a27-ae5570e8dc86

Backport needed:v15

