### PR TITLE
fix(stock): remove item image to avoid setting the image of previous item

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry.js
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.js
@@ -944,6 +944,9 @@ frappe.ui.form.on("Stock Entry Detail", {
 
 	item_code(frm, cdt, cdn) {
 		var d = locals[cdt][cdn];
+		// since some items may not have image, so empty the image field to avoid setting the image of previous item
+		d.image = "";
+
 		if (d.item_code) {
 			var args = {
 				item_code: d.item_code,


### PR DESCRIPTION
**Issue:**
Wrong Item image is showing in stock entry line item.

**Ref:** [#56241](https://support.frappe.io/helpdesk/tickets/56241?view=VIEW-HD+Ticket-850)

**Before:**

https://github.com/user-attachments/assets/7f693fa9-4fab-4a3d-af9d-2a4f8bfe3875

**After:**

https://github.com/user-attachments/assets/ba8d4478-6124-48ca-b7a4-1c9193117f9a

**Backport Needed for v15**