### PR TITLE
feat: Add designation field to Lead Details report

### DIFF
--- a/erpnext/crm/report/lead_details/lead_details.py
+++ b/erpnext/crm/report/lead_details/lead_details.py
@@ -22,7 +22,9 @@ def get_columns():
 			"width": 150,
 		},
 		{"label": _("Lead Name"), "fieldname": "lead_name", "fieldtype": "Data", "width": 120},
-		{"fieldname": "status", "label": _("Status"), "fieldtype": "Data", "width": 100},
+{"label": _("Designation"), "fieldname": "designation", "fieldtype": "Data", "width": 120},
+{"fieldname": "status", "label": _("Status"), "fieldtype": "Data", "width": 100},
+
 		{
 			"fieldname": "lead_owner",
 			"label": _("Lead Owner"),
@@ -84,6 +86,7 @@ def get_data(filters):
 		.select(
 			lead.name,
 			lead.lead_name,
+			lead.designation,
 			lead.status,
 			lead.lead_owner,
 			lead.territory,


### PR DESCRIPTION
### Details of the change

This pull request adds the **Designation** field to the **Lead Details Report**.
Previously, users could not view a lead’s designation directly in the report, which required opening individual Lead records.
This change improves usability by making the designation information available directly in the report view.

### What problem does this solve?

- Allows users to quickly view the designation of leads from the report itself.
- Reduces the need to open individual Lead documents.
- Improves reporting completeness and usability.

### Screenshots / GIFs

Not included, as this is a small report enhancement and local testing could not be performed due to environment constraints.

closes #47120