### PR TITLE
fix(payment entry): clear party_name for internal transfer

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.js
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.js
@@ -427,7 +427,15 @@ frappe.ui.form.on("Payment Entry", {
 
 		if (frm.doc.payment_type == "Internal Transfer") {
 			$.each(
-				["party", "party_type", "paid_from", "paid_to", "references", "total_allocated_amount"],
+				[
+					"party",
+					"party_type",
+					"paid_from",
+					"paid_to",
+					"references",
+					"total_allocated_amount",
+					"party_name",
+				],
 				function (i, field) {
 					frm.set_value(field, null);
 				}


### PR DESCRIPTION
Issue:
The Party Name is not getting cleared when the `Payment Type` is changed to Internal Transfer in the `Payment Entry`


Ref: [#56081](https://support.frappe.io/helpdesk/tickets/56081)

Backport needed:v15
