### PR TITLE
fix(asset): handle partial asset sales by splitting remaining quantity

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -33,6 +33,7 @@ from erpnext.accounts.utils import (
 	get_account_currency,
 	update_voucher_outstanding,
 )
+from erpnext.assets.doctype.asset.asset import split_asset
 from erpnext.assets.doctype.asset.depreciation import (
 	depreciate_asset,
 	get_gl_entries_on_asset_disposal,
@@ -467,6 +468,8 @@ class SalesInvoice(SellingController):
 			self.validate_standalone_serial_nos_customer()
 			self.update_stock_reservation_entries()
 			self.update_stock_ledger()
+
+		self.split_asset_based_on_sale_qty()
 
 		self.process_asset_depreciation()
 
@@ -1357,6 +1360,41 @@ class SalesInvoice(SellingController):
 				and frappe.db.get_value("Delivery Note", d.delivery_note, "docstatus", cache=True) != 1
 			):
 				throw(_("Delivery Note {0} is not submitted").format(d.delivery_note))
+
+	def split_asset_based_on_sale_qty(self):
+		asset_qty_map = self.get_asset_qty()
+		for asset, qty in asset_qty_map.items():
+			remaining_qty = qty["actual_qty"] - qty["sale_qty"]
+			if remaining_qty > 0:
+				split_asset(asset, remaining_qty)
+
+	def get_asset_qty(self):
+		asset_qty_map = {}
+
+		assets = {row.asset for row in self.items if row.is_fixed_asset and row.asset}
+		if not assets or self.is_return:
+			return asset_qty_map
+
+		asset_actual_qty = dict(
+			frappe.db.get_all(
+				"Asset",
+				{"name": ["in", list(assets)]},
+				["name", "asset_quantity"],
+				as_list=True,
+			)
+		)
+		for row in self.items:
+			if row.is_fixed_asset and row.asset:
+				actual_qty = asset_actual_qty.get(row.asset)
+				asset_qty_map.setdefault(
+					row.asset,
+					{
+						"sale_qty": flt(row.qty),
+						"actual_qty": flt(actual_qty),
+					},
+				)
+
+		return asset_qty_map
 
 	def process_asset_depreciation(self):
 		if (self.is_return and self.docstatus == 2) or (not self.is_return and self.docstatus == 1):

--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -1083,7 +1083,7 @@ def get_asset_naming_series():
 
 
 @frappe.whitelist()
-def make_sales_invoice(asset, item_code, company, serial_no=None, posting_date=None):
+def make_sales_invoice(asset, item_code, company, sell_qty, serial_no=None):
 	asset_doc = frappe.get_doc("Asset", asset)
 	si = frappe.new_doc("Sales Invoice")
 	si.company = company
@@ -1098,7 +1098,7 @@ def make_sales_invoice(asset, item_code, company, serial_no=None, posting_date=N
 			"income_account": disposal_account,
 			"serial_no": serial_no,
 			"cost_center": depreciation_cost_center,
-			"qty": 1,
+			"qty": sell_qty,
 		},
 	)
 

--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -482,6 +482,9 @@ class Asset(AccountsController):
 			frappe.throw(_("Available-for-use Date should be after purchase date"))
 
 	def validate_linked_purchase_documents(self):
+		if self.flags.is_split_asset:
+			return
+
 		for fieldname, doctype in [
 			("purchase_receipt", "Purchase Receipt"),
 			("purchase_invoice", "Purchase Invoice"),
@@ -1378,6 +1381,7 @@ def process_asset_split(existing_asset, split_qty, splitted_asset=None, is_new_a
 	scaling_factor = flt(split_qty) / flt(existing_asset.asset_quantity)
 	new_asset = frappe.copy_doc(existing_asset) if is_new_asset else splitted_asset
 	asset_doc = new_asset if is_new_asset else existing_asset
+	asset_doc.flags.is_split_asset = True
 
 	set_split_asset_values(asset_doc, scaling_factor, split_qty, existing_asset, is_new_asset)
 	log_asset_activity(existing_asset, asset_doc, splitted_asset, is_new_asset)

--- a/erpnext/assets/doctype/asset/test_asset.py
+++ b/erpnext/assets/doctype/asset/test_asset.py
@@ -734,7 +734,7 @@ class TestAsset(AssetSetup):
 			asset_depr_schedule_before_sale.depreciation_schedule[0].get("depreciation_amount"), 83333.33
 		)
 
-		# make a partial sales againt the asset
+		# make a partial sales against the asset
 		si = make_sales_invoice(
 			asset=asset.name, item_code="Macbook Pro", company="_Test Company", sell_qty=5
 		)
@@ -776,7 +776,6 @@ class TestAsset(AssetSetup):
 			location=asset_location,
 			supplier="_Test Supplier",
 		)
-		pr.submit()
 
 		asset = frappe.db.get_value("Asset", {"purchase_receipt": pr.name, "docstatus": 0}, "name")
 		asset_doc = frappe.get_doc("Asset", asset)

--- a/erpnext/assets/doctype/asset/test_asset.py
+++ b/erpnext/assets/doctype/asset/test_asset.py
@@ -330,7 +330,9 @@ class TestAsset(AssetSetup):
 
 		post_depreciation_entries(date=add_months(purchase_date, 2))
 
-		si = make_sales_invoice(asset=asset.name, item_code="Macbook Pro", company="_Test Company")
+		si = make_sales_invoice(
+			asset=asset.name, item_code="Macbook Pro", company="_Test Company", sell_qty=asset.asset_quantity
+		)
 		si.customer = "_Test Customer"
 		si.due_date = date
 		si.get("items")[0].rate = 25000
@@ -458,7 +460,9 @@ class TestAsset(AssetSetup):
 
 		post_depreciation_entries(date="2021-01-01")
 
-		si = make_sales_invoice(asset=asset.name, item_code="Macbook Pro", company="_Test Company")
+		si = make_sales_invoice(
+			asset=asset.name, item_code="Macbook Pro", company="_Test Company", sell_qty=asset.asset_quantity
+		)
 		si.customer = "_Test Customer"
 		si.due_date = nowdate()
 		si.get("items")[0].rate = 25000

--- a/erpnext/assets/doctype/asset/test_asset.py
+++ b/erpnext/assets/doctype/asset/test_asset.py
@@ -702,6 +702,129 @@ class TestAsset(AssetSetup):
 		frappe.db.set_value("Asset Category Account", name, "capital_work_in_progress_account", cwip_acc)
 		frappe.db.get_value("Company", "_Test Company", "capital_work_in_progress_account", cwip_acc)
 
+	def test_partial_asset_sale(self):
+		date = nowdate()
+		purchase_date = add_months(get_first_day(date), -2)
+		depreciation_start_date = add_months(get_last_day(date), -2)
+
+		# create an asset
+		asset = create_asset(
+			item_code="Macbook Pro",
+			is_existing_asset=1,
+			calculate_depreciation=1,
+			available_for_use_date=purchase_date,
+			purchase_date=purchase_date,
+			depreciation_start_date=depreciation_start_date,
+			net_purchase_amount=1000000.0,
+			purchase_amount=1000000.0,
+			asset_quantity=10,
+			total_number_of_depreciations=12,
+			frequency_of_depreciation=1,
+			submit=1,
+		)
+		asset_depr_schedule_before_sale = get_asset_depr_schedule_doc(asset.name, "Active")
+		post_depreciation_entries(date)
+		asset.reload()
+
+		# check asset values before sale
+		self.assertEqual(asset.asset_quantity, 10)
+		self.assertEqual(asset.net_purchase_amount, 1000000)
+		self.assertEqual(asset.status, "Partially Depreciated")
+		self.assertEqual(
+			asset_depr_schedule_before_sale.depreciation_schedule[0].get("depreciation_amount"), 83333.33
+		)
+
+		# make a partial sales againt the asset
+		si = make_sales_invoice(
+			asset=asset.name, item_code="Macbook Pro", company="_Test Company", sell_qty=5
+		)
+		si.customer = "_Test Customer"
+		si.due_date = date
+		si.get("items")[0].rate = 25000
+		si.insert()
+		si.submit()
+
+		asset.reload()
+		asset_depr_schedule_after_sale = get_asset_depr_schedule_doc(asset.name, "Active")
+
+		# check asset values after sales
+		self.assertEqual(asset.asset_quantity, 5)
+		self.assertEqual(asset.net_purchase_amount, 500000)
+		self.assertEqual(asset.status, "Sold")
+		self.assertEqual(
+			asset_depr_schedule_after_sale.depreciation_schedule[0].get("depreciation_amount"), 41666.66
+		)
+
+	def test_asset_splitting_for_non_existing_asset(self):
+		date = nowdate()
+		purchase_date = add_months(get_first_day(date), -2)
+		depreciation_start_date = add_months(get_last_day(date), -2)
+
+		asset_qty = 10
+		asset_rate = 100000.0
+		asset_item = "Macbook Pro"
+		asset_location = "Test Location"
+
+		frappe.db.set_value("Item", asset_item, "is_grouped_asset", 1)
+
+		# Inward asset via Purchase Receipt
+		pr = make_purchase_receipt(
+			item_code="Macbook Pro",
+			posting_date=purchase_date,
+			qty=asset_qty,
+			rate=asset_rate,
+			location=asset_location,
+			supplier="_Test Supplier",
+		)
+		pr.submit()
+
+		asset = frappe.db.get_value("Asset", {"purchase_receipt": pr.name, "docstatus": 0}, "name")
+		asset_doc = frappe.get_doc("Asset", asset)
+		asset_doc.calculate_depreciation = 1
+		asset_doc.available_for_use_date = purchase_date
+		asset_doc.location = asset_location
+		asset_doc.append(
+			"finance_books",
+			{
+				"expected_value_after_useful_life": 0,
+				"depreciation_method": "Straight Line",
+				"total_number_of_depreciations": 12,
+				"frequency_of_depreciation": 1,
+				"depreciation_start_date": depreciation_start_date,
+			},
+		)
+		asset_doc.submit()
+
+		# check asset values before splitting
+		asset_depr_schedule_before_splitting = get_asset_depr_schedule_doc(asset_doc.name, "Active")
+		self.assertEqual(asset_doc.asset_quantity, 10)
+		self.assertEqual(asset_doc.net_purchase_amount, 1000000)
+		self.assertEqual(
+			asset_depr_schedule_before_splitting.depreciation_schedule[0].get("depreciation_amount"), 83333.33
+		)
+
+		# initate asset split
+		new_asset = split_asset(asset_doc.name, 5)
+		asset_doc.reload()
+		asset_depr_schedule_after_sale = get_asset_depr_schedule_doc(asset_doc.name, "Active")
+		new_asset_depr_schedule = get_asset_depr_schedule_doc(new_asset.name, "Active")
+
+		# check asset values after splitting
+		self.assertEqual(asset_doc.asset_quantity, 5)
+		self.assertEqual(asset_doc.net_purchase_amount, 500000)
+		self.assertEqual(
+			asset_depr_schedule_after_sale.depreciation_schedule[0].get("depreciation_amount"), 41666.66
+		)
+
+		# check new asset values after splitting
+		self.assertEqual(asset_doc.asset_quantity, 5)
+		self.assertEqual(asset_doc.net_purchase_amount, 500000)
+		self.assertEqual(
+			new_asset_depr_schedule.depreciation_schedule[0].get("depreciation_amount"), 41666.66
+		)
+
+		frappe.db.set_value("Item", asset_item, "is_grouped_asset", 0)
+
 
 class TestDepreciationMethods(AssetSetup):
 	def test_schedule_for_straight_line_method(self):
@@ -1694,59 +1817,6 @@ class TestDepreciationBasics(AssetSetup):
 
 		pr.submit()
 		self.assertTrue(get_gl_entries("Purchase Receipt", pr.name))
-
-	def test_partial_asset_sale_for_existing_asset(self):
-		date = nowdate()
-		purchase_date = add_months(get_first_day(date), -2)
-		depreciation_start_date = add_months(get_last_day(date), -2)
-
-		# create an asset
-		asset = create_asset(
-			item_code="Macbook Pro",
-			is_existing_asset=1,
-			calculate_depreciation=1,
-			available_for_use_date=purchase_date,
-			purchase_date=purchase_date,
-			depreciation_start_date=depreciation_start_date,
-			net_purchase_amount=1000000,
-			purchase_amount=1000000,
-			asset_quantity=10,
-			total_number_of_depreciations=12,
-			frequency_of_depreciation=1,
-			submit=1,
-		)
-		asset_depr_schedule_before_sale = get_asset_depr_schedule_doc(asset.name, "Active")
-		post_depreciation_entries(date)
-		asset.reload()
-
-		# check asset values before sale
-		self.assertEqual(asset.asset_quantity, 10)
-		self.assertEqual(asset.net_purchase_amount, 1000000)
-		self.assertEqual(asset.status, "Partially Depreciated")
-		self.assertEqual(
-			asset_depr_schedule_before_sale.depreciation_schedule[0].get("depreciation_amount"), 83333.33
-		)
-
-		# make a partial sales againt the asset
-		si = make_sales_invoice(
-			asset=asset.name, item_code="Macbook Pro", company="_Test Company", sell_qty=5
-		)
-		si.customer = "_Test Customer"
-		si.due_date = date
-		si.get("items")[0].rate = 25000
-		si.insert()
-		si.submit()
-
-		asset.reload()
-		asset_depr_schedule_after_sale = get_asset_depr_schedule_doc(asset.name, "Active")
-
-		# check asset values after sales
-		self.assertEqual(asset.asset_quantity, 5)
-		self.assertEqual(asset.net_purchase_amount, 500000)
-		self.assertEqual(asset.status, "Sold")
-		self.assertEqual(
-			asset_depr_schedule_after_sale.depreciation_schedule[0].get("depreciation_amount"), 41666.66
-		)
 
 
 def get_gl_entries(doctype, docname):

--- a/erpnext/assets/doctype/asset/test_asset.py
+++ b/erpnext/assets/doctype/asset/test_asset.py
@@ -817,8 +817,8 @@ class TestAsset(AssetSetup):
 		)
 
 		# check new asset values after splitting
-		self.assertEqual(asset_doc.asset_quantity, 5)
-		self.assertEqual(asset_doc.net_purchase_amount, 500000)
+		self.assertEqual(new_asset.asset_quantity, 5)
+		self.assertEqual(new_asset.net_purchase_amount, 500000)
 		self.assertEqual(
 			new_asset_depr_schedule.depreciation_schedule[0].get("depreciation_amount"), 41666.66
 		)

--- a/erpnext/assets/doctype/asset_repair/test_asset_repair.py
+++ b/erpnext/assets/doctype/asset_repair/test_asset_repair.py
@@ -51,7 +51,9 @@ class TestAssetRepair(IntegrationTestCase):
 			submit=1,
 		)
 
-		si = make_sales_invoice(asset=asset.name, item_code="Macbook Pro", company="_Test Company")
+		si = make_sales_invoice(
+			asset=asset.name, item_code="Macbook Pro", company="_Test Company", sell_qty=asset.asset_quantity
+		)
 		si.customer = "_Test Customer"
 		si.due_date = date
 		si.get("items")[0].rate = 25000


### PR DESCRIPTION
**Issue:** 
    - **Case 1:** When an asset is sold partially, the system incorrectly marks the entire asset as Sold and calculates depreciation up to the sale date for the total asset quantity instead of only the sold quantity.
    - **Case 2:** System doesn't allows to split the asset when the asset is created by linking a purchase document

**Solution:** 
    - **Case 1:**  When a partial sale is detected, the system can splits the asset so the remaining quantity is moved to a new asset. Depreciation to be calculated during sales can only be applied for sold quantity, and the remaining asset retains its depreciation schedule.
    - **Case 2:**  Bypassing  the linked purchase validation during asset split with a flag

**Before:**

https://github.com/user-attachments/assets/cd341730-898c-4b63-83e0-22ed705886f3


**After:**

https://github.com/user-attachments/assets/1502f377-b762-4872-abbd-bf6796802225


