### PR TITLE
fix(stock): prevent excess stock reservation

### DIFF
--- a/erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py
+++ b/erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py
@@ -709,6 +709,7 @@ def get_available_qty_to_reserve(
 				& (sre.warehouse == warehouse)
 				& (sre.delivered_qty < sre.reserved_qty)
 			)
+			.for_update()
 		)
 
 		if ignore_sre:


### PR DESCRIPTION
**Issue:**
Allowing excess stock reservation while the simultaneous creation of stock reservation entry.

**Ref:** [55276](https://support.frappe.io/helpdesk/tickets/55276)

**Before:**

https://github.com/user-attachments/assets/ca6b8bd6-29ae-4951-a950-a40195749b5d

**After:**

https://github.com/user-attachments/assets/65041ef1-5604-47ee-8e5c-3a74eff15bff

**Backport Needed for v15**