### PR TITLE
fix: expense_account query override in Purchase Receipt

### DIFF
--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.js
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.js
@@ -17,13 +17,6 @@ frappe.ui.form.on("Purchase Receipt", {
 			"Landed Cost Voucher": "Landed Cost Voucher",
 		};
 
-		frm.set_query("expense_account", "items", function () {
-			return {
-				query: "erpnext.controllers.queries.get_expense_account",
-				filters: { company: frm.doc.company },
-			};
-		});
-
 		frm.set_query("wip_composite_asset", "items", function () {
 			return {
 				filters: { is_composite_asset: 1, docstatus: 0 },
@@ -171,6 +164,16 @@ erpnext.stock.PurchaseReceiptController = class PurchaseReceiptController extend
 		this.setup_accounting_dimension_triggers();
 		this.setup_posting_date_time_check();
 		super.setup(doc);
+
+		this.frm.set_query("expense_account", "items", () => {
+			return {
+				query: "erpnext.controllers.queries.get_expense_account",
+				filters: {
+					company: this.frm.doc.company,
+					disabled: 0,
+				},
+			};
+		});
 	}
 
 	refresh() {


### PR DESCRIPTION
The `expense_account` query in Purchase Receipt Items was overridden during controller setup, so it never executed. Setting the query inside the controller setup fixes the issue.

Check the recording

https://github.com/user-attachments/assets/325ad2a1-23a9-4d4d-80b9-27c17cb896e7

