### PR TITLE
feat(selling-settings): add checkbox to fetch payemnt term from quotation

### DIFF
--- a/erpnext/selling/doctype/quotation/quotation.py
+++ b/erpnext/selling/doctype/quotation/quotation.py
@@ -7,7 +7,7 @@ import json
 import frappe
 from frappe import _
 from frappe.model.mapper import get_mapped_doc
-from frappe.utils import flt, getdate, nowdate
+from frappe.utils import cint, flt, getdate, nowdate
 
 from erpnext.controllers.selling_controller import SellingController
 
@@ -459,12 +459,18 @@ def _make_sales_order(source_name, target_doc=None, ignore_permissions=False, ar
 			},
 			"Sales Taxes and Charges": {"doctype": "Sales Taxes and Charges", "reset_value": True},
 			"Sales Team": {"doctype": "Sales Team", "add_if_empty": True},
-			"Payment Schedule": {"doctype": "Payment Schedule", "add_if_empty": True},
 		},
 		target_doc,
 		set_missing_values,
 		ignore_permissions=ignore_permissions,
 	)
+
+	automatically_fetch_payment_terms = cint(
+		frappe.get_single_value("Selling Settings", "automatically_fetch_payment_terms_from_quotation")
+	)
+
+	if automatically_fetch_payment_terms:
+		doclist.set_payment_schedule()
 
 	return doclist
 

--- a/erpnext/selling/doctype/selling_settings/selling_settings.json
+++ b/erpnext/selling/doctype/selling_settings/selling_settings.json
@@ -33,6 +33,7 @@
   "allow_multiple_items",
   "allow_against_multiple_purchase_orders",
   "allow_sales_order_creation_for_expired_quotation",
+  "automatically_fetch_payment_terms_from_quotation",
   "dont_reserve_sales_order_qty_on_sales_return",
   "hide_tax_id",
   "enable_discount_accounting",
@@ -288,6 +289,12 @@
    "fieldname": "use_legacy_js_reactivity",
    "fieldtype": "Check",
    "label": "Use Legacy (Client side) Reactivity"
+  },
+  {
+   "default": "0",
+   "fieldname": "automatically_fetch_payment_terms_from_quotation",
+   "fieldtype": "Check",
+   "label": "Automatically Fetch Payment Terms from Quotation"
   }
  ],
  "grid_page_length": 50,
@@ -296,7 +303,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-12-17 16:08:48.865885",
+ "modified": "2025-12-30 12:22:27.836801",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Selling Settings",

--- a/erpnext/selling/doctype/selling_settings/selling_settings.py
+++ b/erpnext/selling/doctype/selling_settings/selling_settings.py
@@ -27,6 +27,7 @@ class SellingSettings(Document):
 		allow_sales_order_creation_for_expired_quotation: DF.Check
 		allow_zero_qty_in_quotation: DF.Check
 		allow_zero_qty_in_sales_order: DF.Check
+		automatically_fetch_payment_terms_from_quotation: DF.Check
 		blanket_order_allowance: DF.Float
 		cust_master_name: DF.Literal["Customer Name", "Naming Series", "Auto Name"]
 		customer_group: DF.Link | None


### PR DESCRIPTION
Issue:

The Payment Date is directly carried forward from the Quotation into the Sales Order, which is causing a mismatch, as the payment date should ideally be set or recalculated at the Sales Order stage.

Ref: [56378](https://support.frappe.io/helpdesk/tickets/56378)


Backport Needed: Version-15