### PR TITLE
fix: exclude cancelled repost accounting ledgers in the removal of references

### DIFF
--- a/erpnext/__init__.py
+++ b/erpnext/__init__.py
@@ -4,7 +4,7 @@ import inspect
 import frappe
 from frappe.utils.user import is_website_user
 
-__version__ = "15.93.0"
+__version__ = "15.93.1"
 
 
 def get_default_company(user=None):

--- a/erpnext/__init__.py
+++ b/erpnext/__init__.py
@@ -4,7 +4,7 @@ import inspect
 import frappe
 from frappe.utils.user import is_website_user
 
-__version__ = "15.92.5"
+__version__ = "15.93.0"
 
 
 def get_default_company(user=None):

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -429,7 +429,7 @@ class AccountsController(TransactionBase):
 			rows = (
 				frappe.qb.from_(dt)
 				.select(dt.name, dt.parent, dt.parenttype)
-				.where((dt.voucher_type == self.doctype) & (dt.voucher_no == self.name))
+				.where((dt.voucher_type == self.doctype) & (dt.voucher_no == self.name) & (dt.docstatus != 2))
 				.run(as_dict=True)
 			)
 


### PR DESCRIPTION
Exclude cancelled repost accounting ledgers in  _remove_references_in_repost_doctypes, due to this cannot delete the invoices.

repost_doc.save() - saving cancelled document!!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 15.93.1

* **Bug Fixes**
  * Enhanced reconciliation processes to exclude cancelled documents from reprocessing, ensuring only active records are affected by account updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->