### PR TITLE
fix(tds): always update item taxable value

### DIFF
--- a/erpnext/accounts/doctype/tax_withholding_category/test_tax_withholding_category.py
+++ b/erpnext/accounts/doctype/tax_withholding_category/test_tax_withholding_category.py
@@ -1214,8 +1214,6 @@ class TestTaxWithholdingCategory(IntegrationTestCase):
 		# First invoice - below threshold, should be under withheld
 		pi = create_purchase_invoice(supplier="Test TDS Supplier6", rate=4000, do_not_save=True)
 		pi.apply_tds = 1
-		pi.tax_withholding_category = "Test Multi Invoice Category"
-		pi.save()
 		pi.submit()
 		invoices.append(pi)
 
@@ -1478,7 +1476,6 @@ class TestTaxWithholdingCategory(IntegrationTestCase):
 
 		pi = create_purchase_invoice(supplier="Test TDS Supplier6", rate=12000, do_not_save=True)
 		pi.apply_tds = 1
-		pi.tax_withholding_category = "Test Multi Invoice Category"
 		advances = pi.get_advance_entries()
 		pi.append(
 			"advances",
@@ -2096,7 +2093,6 @@ class TestTaxWithholdingCategory(IntegrationTestCase):
 		# Create purchase invoice that settles the payment entry
 		pi = create_purchase_invoice(supplier="Test TDS Supplier6", rate=8000, do_not_save=True)
 		pi.apply_tds = 1
-		pi.tax_withholding_category = "Test Multi Invoice Category"
 		advances = pi.get_advance_entries()
 		pi.append(
 			"advances",
@@ -2719,7 +2715,6 @@ class TestTaxWithholdingCategory(IntegrationTestCase):
 		# Create purchase invoice with manual override
 		pi = create_purchase_invoice(supplier="Test TDS Supplier6", rate=20000, do_not_save=True)
 		pi.apply_tds = 1
-		pi.tax_withholding_category = "Test Multi Invoice Category"
 		pi.ignore_tax_withholding_threshold = 1
 		pi.save()
 
@@ -2749,7 +2744,6 @@ class TestTaxWithholdingCategory(IntegrationTestCase):
 
 		# Step 2: Create Purchase Invoice with partial adjustment and manual rate change
 		pi = create_purchase_invoice(supplier="Test TDS Supplier8", rate=80000, do_not_save=True)
-		pi.tax_withholding_category = "Test Multi Invoice Category"
 		pi.override_tax_withholding_entries = 1  # Enable manual override
 		pi.tax_withholding_entries = []
 
@@ -2790,6 +2784,7 @@ class TestTaxWithholdingCategory(IntegrationTestCase):
 		)
 
 		pi.save()
+		pi.reload()
 		pi.submit()
 
 		# Step 3: Verify the tax withholding entries
@@ -2870,7 +2865,6 @@ class TestTaxWithholdingCategory(IntegrationTestCase):
 
 		# Step 2: Create Purchase Invoice with partial adjustment and manual rate change
 		pi = create_purchase_invoice(supplier="Test TDS Supplier8", rate=80000, do_not_save=True)
-		pi.tax_withholding_category = "Test Multi Invoice Category"
 		pi.override_tax_withholding_entries = 1  # Enable manual override
 		pi.tax_withholding_entries = []
 
@@ -2911,6 +2905,7 @@ class TestTaxWithholdingCategory(IntegrationTestCase):
 		)
 
 		pi.save()
+		pi.reload()
 		pi.submit()
 
 		# Step 3: Verify the tax withholding entries
@@ -2993,7 +2988,6 @@ class TestTaxWithholdingCategory(IntegrationTestCase):
 		self.validate_tax_withholding_entries("Payment Entry", pe.name, pe_expected)
 
 		pi = create_purchase_invoice(supplier="Test TDS Supplier8", rate=50000, do_not_save=True)
-		pi.tax_withholding_category = "Test Multi Invoice Category"
 		pi.override_tax_withholding_entries = 1
 		pi.tax_withholding_entries = []
 

--- a/erpnext/accounts/doctype/tax_withholding_entry/tax_withholding_entry.py
+++ b/erpnext/accounts/doctype/tax_withholding_entry/tax_withholding_entry.py
@@ -377,30 +377,23 @@ class TaxWithholdingController:
 		return category_names
 
 	def calculate(self):
-		# Always get category details first for account mapping
 		self.category_details = self._get_category_details()
+
+		self._update_taxable_amounts()
 
 		if not self.doc.override_tax_withholding_entries:
 			self._generate_withholding_entries()
 
-		# Final processing - entry status and tax_update
 		self._process_withholding_entries()
 
 	def _generate_withholding_entries(self):
-		# Clear existing entries
 		self.doc.tax_withholding_entries = []
 
-		# Calculate taxable amounts for each category
-		self._update_taxable_amounts()
-
-		# Apply threshold rules
 		self._evaluate_thresholds()
 
-		# Generate entries for each category
 		for category in self.category_details.values():
 			self.entries += self._create_entries_for_category(category)
 
-		# Add all generated entries to the document
 		self.doc.extend("tax_withholding_entries", self.entries)
 
 	def _create_entries_for_category(self, category):


### PR DESCRIPTION
Issue: If tds entries were overridden, then the item's taxable amount was not set.
```
Traceback (most recent call last):
  File "apps/frappe/frappe/app.py", line 121, in application
    response = frappe.api.handle(request)
  File "apps/frappe/frappe/api/__init__.py", line 63, in handle
    data = endpoint(**arguments)
  File "apps/frappe/frappe/api/v1.py", line 40, in handle_rpc_call
    return frappe.handler.handle()
           ~~~~~~~~~~~~~~~~~~~~~^^
  File "apps/frappe/frappe/handler.py", line 53, in handle
    data = execute_cmd(cmd)
  File "apps/frappe/frappe/handler.py", line 86, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
           ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/__init__.py", line 1124, in call
    return fn(*args, **newargs)
  File "apps/frappe/frappe/utils/typing_validations.py", line 36, in wrapper
    return func(*args, **kwargs)
  File "apps/frappe/frappe/desk/form/save.py", line 43, in savedocs
    doc.save()
    ~~~~~~~~^^
  File "apps/frappe/frappe/model/document.py", line 518, in save
    return self._save(*args, **kwargs)
           ~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/model/document.py", line 554, in _save
    self.run_before_save_methods()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "apps/frappe/frappe/model/document.py", line 1332, in run_before_save_methods
    self.run_method("validate")
    ~~~~~~~~~~~~~~~^^^^^^^^^^^^
  File "apps/frappe/frappe/model/document.py", line 1181, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 1578, in composer
    return composed(self, method, *args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 1556, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
                              ~~^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/model/document.py", line 1178, in fn
    return method_object(*args, **kwargs)
  File "apps/erpnext/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py", line 302, in validate
    PurchaseTaxWithholding(self).on_validate()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "apps/erpnext/erpnext/accounts/doctype/tax_withholding_entry/tax_withholding_entry.py", line 1114, in on_validate
    self.calculate()
    ~~~~~~~~~~~~~~^^
  File "apps/erpnext/erpnext/accounts/doctype/tax_withholding_entry/tax_withholding_entry.py", line 387, in calculate
    self._process_withholding_entries()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "apps/erpnext/erpnext/accounts/doctype/tax_withholding_entry/tax_withholding_entry.py", line 1072, in _process_withholding_entries
    self.update_tax_rows()
    ~~~~~~~~~~~~~~~~~~~~^^
  File "apps/erpnext/erpnext/accounts/doctype/tax_withholding_entry/tax_withholding_entry.py", line 735, in update_tax_rows
    self._set_item_wise_tax_for_tds(
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
    	tax_row, account_head, category_withholding_map, for_update=for_update
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "apps/erpnext/erpnext/accounts/doctype/tax_withholding_entry/tax_withholding_entry.py", line 782, in _set_item_wise_tax_for_tds
    category_totals.get(item.tax_withholding_category, 0) + item_taxable
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~
TypeError: unsupported operand type(s) for +: 'int' and 'NoneType'

```

Frappe Support Issue: https://support.frappe.io/helpdesk/tickets/56528
