### PR TITLE
fix(tds): correct tax logic for customer

### DIFF
--- a/erpnext/accounts/doctype/tax_withholding_category/test_tax_withholding_category.py
+++ b/erpnext/accounts/doctype/tax_withholding_category/test_tax_withholding_category.py
@@ -415,7 +415,6 @@ class TestTaxWithholdingCategory(IntegrationTestCase):
 					"cost_center": "Main - _TC",
 					"tax_amount": 500,
 					"description": "Test",
-					"add_deduct_tax": "Add",
 				},
 			)
 			pi.save()
@@ -506,7 +505,6 @@ class TestTaxWithholdingCategory(IntegrationTestCase):
 					"cost_center": "Main - _TC",
 					"tax_amount": 200,
 					"description": "Test Gross Tax",
-					"add_deduct_tax": "Add",
 				},
 			)
 			si.save()
@@ -541,10 +539,10 @@ class TestTaxWithholdingCategory(IntegrationTestCase):
 				"cost_center": "Main - _TC",
 				"tax_amount": 400,
 				"description": "Test Gross Tax",
-				"add_deduct_tax": "Add",
 			},
 		)
 		si.save()
+		si.reload()
 		si.submit()
 		invoices.append(si)
 		# For amount before threshold (first 8000 + VAT): TCS entry with amount zero
@@ -594,7 +592,6 @@ class TestTaxWithholdingCategory(IntegrationTestCase):
 				"cost_center": "Main - _TC",
 				"tax_amount": 500,
 				"description": "VAT added to test TDS calculation on gross amount",
-				"add_deduct_tax": "Add",
 			},
 		)
 		si.save()
@@ -1024,7 +1021,6 @@ class TestTaxWithholdingCategory(IntegrationTestCase):
 				"cost_center": "Main - _TC",
 				"tax_amount": 1000,
 				"description": "VAT added to test TDS calculation on gross amount",
-				"add_deduct_tax": "Add",
 			},
 		)
 		pi.save()
@@ -1162,7 +1158,6 @@ class TestTaxWithholdingCategory(IntegrationTestCase):
 				"cost_center": "Main - _TC",
 				"tax_amount": 8000,
 				"description": "Test",
-				"add_deduct_tax": "Add",
 			},
 		)
 

--- a/erpnext/accounts/doctype/tax_withholding_entry/tax_withholding_entry.py
+++ b/erpnext/accounts/doctype/tax_withholding_entry/tax_withholding_entry.py
@@ -715,6 +715,10 @@ class TaxWithholdingController:
 		existing_taxes = {row.account_head: row for row in self.doc.taxes if row.is_tax_withholding_account}
 		precision = self.doc.precision("tax_amount", "taxes")
 		conversion_rate = self.get_conversion_rate()
+		add_deduct_tax = "Deduct"
+
+		if self.party_type == "Customer":
+			add_deduct_tax = "Add"
 
 		for account_head, base_amount in account_amount_map.items():
 			tax_amount = flt(base_amount / conversion_rate, precision)
@@ -731,6 +735,7 @@ class TaxWithholdingController:
 				tax_row = self._create_tax_row(account_head, tax_amount)
 				for_update = False
 
+			tax_row.add_deduct_tax = add_deduct_tax
 			# Set item-wise tax breakup for this tax row
 			self._set_item_wise_tax_for_tds(
 				tax_row, account_head, category_withholding_map, for_update=for_update
@@ -750,7 +755,6 @@ class TaxWithholdingController:
 				"account_head": account_head,
 				"description": account_head,
 				"cost_center": cost_center,
-				"add_deduct_tax": "Deduct",
 				"tax_amount": tax_amount,
 				"dont_recompute_tax": 1,
 			},
@@ -814,12 +818,14 @@ class TaxWithholdingController:
 			else:
 				item_tax_amount = 0
 
+			multiplier = -1 if tax_row.add_deduct_tax == "Deduct" else 1
+
 			self.doc._item_wise_tax_details.append(
 				frappe._dict(
 					item=item,
 					tax=tax_row,
 					rate=category.tax_rate,
-					amount=item_tax_amount * -1,  # Negative because it's a deduction
+					amount=item_tax_amount * multiplier,
 					taxable_amount=item_base_taxable,
 				)
 			)


### PR DESCRIPTION
The Issue
- On first save: New tax row is created → add_deduct_tax is set correctly
- Doc reloads from UI (after save)
- On submit: The existing tax row is fetched from existing_taxes (database)

Problem: The existing tax row not have correct add_deduct_tax because it is not present in Sales Taxes and Charges causing error to be raised.
