### PR TITLE
fix: task actual hours calculation correction post timesheet update after submit

### DIFF
--- a/erpnext/projects/doctype/timesheet/timesheet.py
+++ b/erpnext/projects/doctype/timesheet/timesheet.py
@@ -76,6 +76,10 @@ class Timesheet(Document):
 	def on_discard(self):
 		self.db_set("status", "Cancelled")
 
+	def on_update_after_submit(self):
+		self.validate_mandatory_fields()
+		self.update_task_and_project()
+
 	def calculate_hours(self):
 		for row in self.time_logs:
 			if row.to_time and row.from_time:


### PR DESCRIPTION
The following fixes: https://github.com/frappe/erpnext/issues/51382, it allows the actual hours to be recalculated in a scenario where the user has enabled "allow on submit" option for timesheet. 

`no-docs`