### PR TITLE
fix: merge taxes in purchase receipt when get items from multiple purchase invoices

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
@@ -2009,9 +2009,7 @@ def make_purchase_receipt(source_name, target_doc=None, args=None):
 		set_missing_values(target_parent)
 
 	def remove_items_with_zero_qty(target_parent):
-		for row in target_parent.get("items"):
-			if row.get("qty") == 0:
-				target_parent.remove(row)
+		target_parent.items = [row for row in target_parent.get("items") if row.get("qty") != 0]
 
 	def set_missing_values(target):
 		target.run_method("set_missing_values")
@@ -2067,7 +2065,10 @@ def make_purchase_receipt(source_name, target_doc=None, args=None):
 				"postprocess": update_item,
 				"condition": lambda doc: abs(doc.received_qty) < abs(doc.qty) and select_item(doc),
 			},
-			"Purchase Taxes and Charges": {"doctype": "Purchase Taxes and Charges", "reset_value": True},
+			"Purchase Taxes and Charges": {
+				"doctype": "Purchase Taxes and Charges",
+				"reset_value": (args and args.get("merge_taxes")),
+			},
 		},
 		target_doc,
 		post_parent_process,

--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
@@ -36,7 +36,7 @@ from erpnext.accounts.utils import get_account_currency, get_fiscal_year, update
 from erpnext.assets.doctype.asset.asset import is_cwip_accounting_enabled
 from erpnext.assets.doctype.asset_category.asset_category import get_asset_category_account
 from erpnext.buying.utils import check_on_hold_or_closed_status
-from erpnext.controllers.accounts_controller import validate_account_head
+from erpnext.controllers.accounts_controller import merge_taxes, validate_account_head
 from erpnext.controllers.buying_controller import BuyingController
 from erpnext.stock.doctype.purchase_receipt.purchase_receipt import (
 	update_billed_amount_based_on_po,
@@ -2006,14 +2006,17 @@ def make_purchase_receipt(source_name, target_doc=None, args=None):
 
 	def post_parent_process(source_parent, target_parent):
 		remove_items_with_zero_qty(target_parent)
-		set_missing_values(target_parent)
+		set_missing_values(source_parent, target_parent)
 
 	def remove_items_with_zero_qty(target_parent):
 		target_parent.items = [row for row in target_parent.get("items") if row.get("qty") != 0]
 
-	def set_missing_values(target):
-		target.run_method("set_missing_values")
-		target.run_method("calculate_taxes_and_totals")
+	def set_missing_values(source_parent, target_parent):
+		target_parent.run_method("set_missing_values")
+		target_parent.run_method("calculate_taxes_and_totals")
+
+		if args and args.get("merge_taxes"):
+			merge_taxes(source_parent, target_parent)
 
 	def update_item(obj, target, source_parent):
 		from erpnext.controllers.sales_and_purchase_return import get_returned_qty_map_for_row
@@ -2067,7 +2070,8 @@ def make_purchase_receipt(source_name, target_doc=None, args=None):
 			},
 			"Purchase Taxes and Charges": {
 				"doctype": "Purchase Taxes and Charges",
-				"reset_value": (args and args.get("merge_taxes")),
+				"reset_value": not (args and args.get("merge_taxes")),
+				"ignore": args.get("merge_taxes") if args else 0,
 			},
 		},
 		target_doc,

--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
@@ -2013,10 +2013,9 @@ def make_purchase_receipt(source_name, target_doc=None, args=None):
 
 	def set_missing_values(source_parent, target_parent):
 		target_parent.run_method("set_missing_values")
-		target_parent.run_method("calculate_taxes_and_totals")
-
 		if args and args.get("merge_taxes"):
 			merge_taxes(source_parent, target_parent)
+		target_parent.run_method("calculate_taxes_and_totals")
 
 	def update_item(obj, target, source_parent):
 		from erpnext.controllers.sales_and_purchase_return import get_returned_qty_map_for_row

--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
@@ -2005,9 +2005,17 @@ def make_purchase_receipt(source_name, target_doc=None, args=None):
 		args = json.loads(args)
 
 	def post_parent_process(source_parent, target_parent):
+		remove_items_with_zero_qty(target_parent)
+		set_missing_values(target_parent)
+
+	def remove_items_with_zero_qty(target_parent):
 		for row in target_parent.get("items"):
 			if row.get("qty") == 0:
 				target_parent.remove(row)
+
+	def set_missing_values(target):
+		target.run_method("set_missing_values")
+		target.run_method("calculate_taxes_and_totals")
 
 	def update_item(obj, target, source_parent):
 		from erpnext.controllers.sales_and_purchase_return import get_returned_qty_map_for_row
@@ -2059,7 +2067,7 @@ def make_purchase_receipt(source_name, target_doc=None, args=None):
 				"postprocess": update_item,
 				"condition": lambda doc: abs(doc.received_qty) < abs(doc.qty) and select_item(doc),
 			},
-			"Purchase Taxes and Charges": {"doctype": "Purchase Taxes and Charges"},
+			"Purchase Taxes and Charges": {"doctype": "Purchase Taxes and Charges", "reset_value": True},
 		},
 		target_doc,
 		post_parent_process,

--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -993,7 +993,7 @@ erpnext.utils.map_current_doc = function (opts) {
 
 	if (opts.source_doctype) {
 		let data_fields = [];
-		if (["Purchase Receipt", "Delivery Note"].includes(opts.source_doctype)) {
+		if (["Purchase Receipt", "Delivery Note", "Purchase Invoice"].includes(opts.source_doctype)) {
 			let target_meta = frappe.get_meta(cur_frm.doc.doctype);
 			if (target_meta.fields.find((f) => f.fieldname === "taxes")) {
 				data_fields.push({


### PR DESCRIPTION
**Issue:** When a Purchase Receipt is created by pulling items from multiple Purchase Invoices that use the same tax account, the system does not merge the tax rows. Instead, it adds separate tax rows for the same account and the tax amount gets doubled upon save.

Ref: [56269](https://support.frappe.io/helpdesk/tickets/56269)

**Steps to Reproduce:**
1) Create Purchase Invoice 1 for a supplier with taxes mentioned.
2) Create Purchase Invoice 2 for the same supplier using the same tax account.
3) Create a Purchase Receipt and pull items from both Purchase Invoices using "Get items From"
4) Save the Purchase Receipt.
5) Now its noticeable that the Tax rows with the same tax account appear twice and the tax amount is doubled.


**Before:**

https://github.com/user-attachments/assets/87aceeb7-0f6a-4733-876f-2506a3abd899

**After:**

https://github.com/user-attachments/assets/8afe7ce1-63a8-4175-9937-33765af52c32

**Backport needed v15**

