### PR TITLE
fix(trial balance party): add check for parties with zero credit and debit

### DIFF
--- a/erpnext/accounts/report/trial_balance_for_party/trial_balance_for_party.js
+++ b/erpnext/accounts/report/trial_balance_for_party/trial_balance_for_party.js
@@ -81,5 +81,11 @@ frappe.query_reports["Trial Balance for Party"] = {
 			label: __("Show zero values"),
 			fieldtype: "Check",
 		},
+		{
+			fieldname: "exclude_zero_balance_parties",
+			label: __("Exclude Zero Balance Parties"),
+			fieldtype: "Check",
+			default: 1,
+		},
 	],
 };

--- a/erpnext/accounts/report/trial_balance_for_party/trial_balance_for_party.py
+++ b/erpnext/accounts/report/trial_balance_for_party/trial_balance_for_party.py
@@ -75,20 +75,20 @@ def get_data(filters, show_party_name):
 		closing_debit, closing_credit = toggle_debit_credit(opening_debit + debit, opening_credit + credit)
 		row.update({"closing_debit": closing_debit, "closing_credit": closing_credit})
 
-		# totals
-		for col in total_row:
-			total_row[col] += row.get(col)
-
 		row.update({"currency": company_currency})
 
 		has_value = False
 		if opening_debit or opening_credit or debit or credit or closing_debit or closing_credit:
 			has_value = True
+		# Exclude zero balance parties if filter is set
+		if filters.get("exclude_zero_balance_parties") and not closing_debit and not closing_credit:
+			continue
 
 		if cint(filters.show_zero_values) or has_value:
 			data.append(row)
-
-	# Add total row
+			# totals
+			for col in total_row:
+				total_row[col] += row.get(col)
 
 	total_row.update({"party": "'" + _("Totals") + "'", "currency": company_currency})
 	data.append(total_row)


### PR DESCRIPTION
Add a check "Exclude Zero Balance Parties" in the trial balance party report to filter out the rows with zero closing debit/credit.

<img width="1198" height="351" alt="Screenshot 2026-01-01 at 4 39 44 AM" src="https://github.com/user-attachments/assets/67feca33-3780-40b3-a94a-79c3d835511e" />
