### PR TITLE
fix:Once a row is in edit mode within the Dialog's Table field, the E…

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.js
+++ b/erpnext/selling/doctype/sales_order/sales_order.js
@@ -1325,10 +1325,44 @@ erpnext.selling.SalesOrderController = class SalesOrderController extends erpnex
 		}
 
 		set_po_items_data(dialog);
-		dialog.get_field("items_for_po").grid.only_sortable();
-		dialog.get_field("items_for_po").refresh();
-		dialog.wrapper.find(".grid-heading-row .grid-row-check").click();
-		dialog.show();
+        let grid = dialog.get_field("items_for_po").grid;
+
+     // 1. Enable editing but hide Add/Delete buttons
+        grid.static_rows = false; 
+        grid.cannot_add_rows = true;    // Removes the "Add Row" button
+        grid.cannot_delete_rows = true; 
+
+    // 2. Ensure fields are editable
+        grid.docfields.forEach(df => {
+            df.read_only = 0;
+        });
+
+        grid.wrapper.on("mousedown", ".grid-row", function (e) {
+    // Don't interfere if clicking an input, checkbox, or the edit pencil
+        if ($(e.target).is('input, textarea, select, .grid-row-check, .btn-open-row')) {
+                   return;
+        }
+
+        e.preventDefault();
+        e.stopImmediatePropagation();
+
+        let idx = $(this).data("idx") - 1;
+        let row = grid.grid_rows[idx];
+
+    // Force close any currently open row form
+        if (grid.grid_form) {
+             grid.grid_form.hide();
+             grid.grid_form = null;
+        }
+
+        // Force open the clicked row's form
+         if (row) {
+              grid.open_grid_row(row);
+        } 
+    });
+        grid.refresh();
+        dialog.get_field("items_for_po").refresh();
+        dialog.show();
 	}
 
 	get_ordered_qty(item, so) {


### PR DESCRIPTION
### Description
This PR improves the user experience when switching between grid rows in the "Select Items" dialog (Sales Order to Purchase Order flow). It allows users to click a new row to expand it while automatically collapsing the previous one, preventing the UI from locking.

### Related Issue
Fixes frappe/frappe#35502

Before:

https://github.com/user-attachments/assets/99d60183-af54-45fc-a453-45509809fa01

After:

[Kooha-2026-01-02-13-14-01.webm](https://github.com/user-attachments/assets/aa5ba56a-7f4f-4fe5-a81d-445febd9df08)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Purchase Order items now support inline editing—click any row to edit details directly.
  * Redesigned interaction model with interactive row-level editing capabilities.

* **Changes**
  * Row addition and deletion controls removed from the items interface for a streamlined workflow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->