### PR TITLE
fix: disallowing overlapping time logs in allow on submit mode

### DIFF
--- a/erpnext/projects/doctype/timesheet/test_timesheet.py
+++ b/erpnext/projects/doctype/timesheet/test_timesheet.py
@@ -172,6 +172,21 @@ class TestTimesheet(ERPNextTestSuite):
 		settings.ignore_employee_time_overlap = 1
 		settings.save()
 		timesheet.save()  # should not throw an error
+		timesheet.submit()  # should not throw an error
+		settings.ignore_employee_time_overlap = 0
+		settings.save()
+
+		timesheet.append(
+			"time_logs",
+			{
+				"billable": 1,
+				"activity_type": "_Test Activity Type",
+				"from_time": now_datetime(),
+				"to_time": now_datetime() + datetime.timedelta(hours=3),
+				"company": "_Test Company",
+			},
+		)
+		self.assertRaises(frappe.ValidationError, timesheet.submit)
 
 		settings.ignore_employee_time_overlap = initial_setting
 		settings.save()

--- a/erpnext/projects/doctype/timesheet/timesheet.py
+++ b/erpnext/projects/doctype/timesheet/timesheet.py
@@ -79,6 +79,7 @@ class Timesheet(Document):
 	def on_update_after_submit(self):
 		self.validate_mandatory_fields()
 		self.update_task_and_project()
+		self.validate_time_logs()
 
 	def calculate_hours(self):
 		for row in self.time_logs:


### PR DESCRIPTION
This fixes https://github.com/frappe/erpnext/issues/51383

In case of time sheet being in allow on submit mode, it still validates for overlapping entry in time logs.


`no-docs`