### PR TITLE
fix: add company filters to project

### DIFF
--- a/erpnext/accounts/doctype/journal_entry/journal_entry.js
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.js
@@ -43,6 +43,20 @@ frappe.ui.form.on("Journal Entry", {
 				},
 			};
 		});
+
+		frm.set_query("project", "accounts", function (doc, cdt, cdn) {
+			let row = frappe.get_doc(cdt, cdn);
+			let filters = {
+				company: doc.company,
+			};
+			if (row.party_type == "Customer") {
+				filters.customer = row.party;
+			}
+			return {
+				query: "erpnext.controllers.queries.get_project_name",
+				filters,
+			};
+		});
 	},
 
 	get_balance_for_periodic_accounting(frm) {

--- a/erpnext/stock/doctype/stock_entry/stock_entry.js
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.js
@@ -138,6 +138,24 @@ frappe.ui.form.on("Stock Entry", {
 			};
 		});
 
+		frm.set_query("project", "items", function (doc) {
+			return {
+				query: "erpnext.controllers.queries.get_project_name",
+				filters: {
+					company: doc.company,
+				},
+			};
+		});
+
+		frm.set_query("project", function (doc) {
+			return {
+				query: "erpnext.controllers.queries.get_project_name",
+				filters: {
+					company: doc.company,
+				},
+			};
+		});
+
 		frm.add_fetch("bom_no", "inspection_required", "inspection_required");
 		erpnext.accounts.dimensions.setup_dimension_filters(frm, frm.doctype);
 


### PR DESCRIPTION
**Issue:**
In the Stock Entry and Journal Entry doctype, all the projects are shown irrespective of the Company.

**Before:**

https://github.com/user-attachments/assets/254a3d4e-f6e6-43ae-931f-3b72517e2426

**After:**

https://github.com/user-attachments/assets/4c060fcc-dcdf-4b86-87e4-31735bf2dc2a

Backport needed for v15