### PR TITLE
feat: add default-age-range in accounts settings

### DIFF
--- a/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
+++ b/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
@@ -91,6 +91,7 @@
   "receivable_payable_remarks_length",
   "accounts_receivable_payable_tuning_section",
   "receivable_payable_fetch_method",
+  "default_ageing_range",
   "column_break_ntmi",
   "drop_ar_procedures",
   "legacy_section",
@@ -649,6 +650,12 @@
    "fieldtype": "Link",
    "label": "Role to Notify on Depreciation Failure",
    "options": "Role"
+  },
+  {
+   "default": "30, 60, 90, 120",
+   "fieldname": "default_ageing_range",
+   "fieldtype": "Data",
+   "label": "Default Ageing Range"
   }
  ],
  "grid_page_length": 50,
@@ -657,7 +664,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-12-03 20:42:13.238050",
+ "modified": "2025-12-26 19:46:55.093717",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Accounts Settings",

--- a/erpnext/accounts/doctype/accounts_settings/accounts_settings.py
+++ b/erpnext/accounts/doctype/accounts_settings/accounts_settings.py
@@ -40,6 +40,7 @@ class AccountsSettings(Document):
 		confirm_before_resetting_posting_date: DF.Check
 		create_pr_in_draft_status: DF.Check
 		credit_controller: DF.Link | None
+		default_ageing_range: DF.Data | None
 		delete_linked_ledger_entries: DF.Check
 		determine_address_tax_category_from: DF.Literal["Billing Address", "Shipping Address"]
 		enable_common_party_accounting: DF.Check

--- a/erpnext/accounts/report/accounts_payable/accounts_payable.js
+++ b/erpnext/accounts/report/accounts_payable/accounts_payable.js
@@ -166,11 +166,9 @@ frappe.query_reports["Accounts Payable"] = {
 			frappe.set_route("query-report", "Accounts Payable Summary", { company: filters.company });
 		});
 
-		frappe.db.get_single_value("Accounts Settings", "default_ageing_range").then((value) => {
-			if (value) {
-				report.set_filter_value("range", value);
-			}
-		});
+		if (frappe.boot.sysdefaults.default_ageing_range) {
+			report.set_filter_value("range", frappe.boot.sysdefaults.default_ageing_range);
+		}
 	},
 };
 

--- a/erpnext/accounts/report/accounts_payable/accounts_payable.js
+++ b/erpnext/accounts/report/accounts_payable/accounts_payable.js
@@ -165,6 +165,12 @@ frappe.query_reports["Accounts Payable"] = {
 			var filters = report.get_values();
 			frappe.set_route("query-report", "Accounts Payable Summary", { company: filters.company });
 		});
+
+		frappe.db.get_single_value("Accounts Settings", "default_ageing_range").then((value) => {
+			if (value) {
+				report.set_filter_value("range", value);
+			}
+		});
 	},
 };
 

--- a/erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js
+++ b/erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js
@@ -35,6 +35,13 @@ frappe.query_reports["Accounts Payable Summary"] = {
 			label: __("Ageing Range"),
 			fieldtype: "Data",
 			default: "30, 60, 90, 120",
+			onload: function (report) {
+				frappe.db.get_single_value("Accounts Settings", "range").then((value) => {
+					if (value) {
+						report.set_filter_value("range", value);
+					}
+				});
+			},
 		},
 		{
 			fieldname: "finance_book",
@@ -113,6 +120,12 @@ frappe.query_reports["Accounts Payable Summary"] = {
 		report.page.add_inner_button(__("Accounts Payable"), function () {
 			var filters = report.get_values();
 			frappe.set_route("query-report", "Accounts Payable", { company: filters.company });
+		});
+
+		frappe.db.get_single_value("Accounts Settings", "default_ageing_range").then((value) => {
+			if (value) {
+				report.set_filter_value("range", value);
+			}
 		});
 	},
 };

--- a/erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js
+++ b/erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js
@@ -115,11 +115,9 @@ frappe.query_reports["Accounts Payable Summary"] = {
 			frappe.set_route("query-report", "Accounts Payable", { company: filters.company });
 		});
 
-		frappe.db.get_single_value("Accounts Settings", "default_ageing_range").then((value) => {
-			if (value) {
-				report.set_filter_value("range", value);
-			}
-		});
+		if (frappe.boot.sysdefaults.default_ageing_range) {
+			report.set_filter_value("range", frappe.boot.sysdefaults.default_ageing_range);
+		}
 	},
 };
 

--- a/erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js
+++ b/erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js
@@ -35,13 +35,6 @@ frappe.query_reports["Accounts Payable Summary"] = {
 			label: __("Ageing Range"),
 			fieldtype: "Data",
 			default: "30, 60, 90, 120",
-			onload: function (report) {
-				frappe.db.get_single_value("Accounts Settings", "range").then((value) => {
-					if (value) {
-						report.set_filter_value("range", value);
-					}
-				});
-			},
 		},
 		{
 			fieldname: "finance_book",

--- a/erpnext/accounts/report/accounts_receivable/accounts_receivable.js
+++ b/erpnext/accounts/report/accounts_receivable/accounts_receivable.js
@@ -192,6 +192,12 @@ frappe.query_reports["Accounts Receivable"] = {
 			var filters = report.get_values();
 			frappe.set_route("query-report", "Accounts Receivable Summary", { company: filters.company });
 		});
+
+		frappe.db.get_single_value("Accounts Settings", "default_ageing_range").then((value) => {
+			if (value) {
+				report.set_filter_value("range", value);
+			}
+		});
 	},
 };
 

--- a/erpnext/accounts/report/accounts_receivable/accounts_receivable.js
+++ b/erpnext/accounts/report/accounts_receivable/accounts_receivable.js
@@ -193,11 +193,9 @@ frappe.query_reports["Accounts Receivable"] = {
 			frappe.set_route("query-report", "Accounts Receivable Summary", { company: filters.company });
 		});
 
-		frappe.db.get_single_value("Accounts Settings", "default_ageing_range").then((value) => {
-			if (value) {
-				report.set_filter_value("range", value);
-			}
-		});
+		if (frappe.boot.sysdefaults.default_ageing_range) {
+			report.set_filter_value("range", frappe.boot.sysdefaults.default_ageing_range);
+		}
 	},
 };
 

--- a/erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js
+++ b/erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js
@@ -138,11 +138,9 @@ frappe.query_reports["Accounts Receivable Summary"] = {
 			frappe.set_route("query-report", "Accounts Receivable", { company: filters.company });
 		});
 
-		frappe.db.get_single_value("Accounts Settings", "default_ageing_range").then((value) => {
-			if (value) {
-				report.set_filter_value("range", value);
-			}
-		});
+		if (frappe.boot.sysdefaults.default_ageing_range) {
+			report.set_filter_value("range", frappe.boot.sysdefaults.default_ageing_range);
+		}
 	},
 };
 

--- a/erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js
+++ b/erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js
@@ -137,6 +137,12 @@ frappe.query_reports["Accounts Receivable Summary"] = {
 			var filters = report.get_values();
 			frappe.set_route("query-report", "Accounts Receivable", { company: filters.company });
 		});
+
+		frappe.db.get_single_value("Accounts Settings", "default_ageing_range").then((value) => {
+			if (value) {
+				report.set_filter_value("range", value);
+			}
+		});
 	},
 };
 

--- a/erpnext/startup/boot.py
+++ b/erpnext/startup/boot.py
@@ -63,6 +63,9 @@ def boot_session(bootinfo):
 			bootinfo.current_fiscal_year = fiscal_year[0]
 
 		bootinfo.sysdefaults.demo_company = frappe.db.get_single_value("Global Defaults", "demo_company")
+		bootinfo.sysdefaults.default_ageing_range = frappe.db.get_single_value(
+			"Accounts Settings", "default_ageing_range"
+		)
 
 
 def update_page_info(bootinfo):


### PR DESCRIPTION
**Description:**
Added a Default Age Range field on Accounts Settings to avoid repetitive custom configuration on 
- Accounts Receivable
- Accounts Receivable Summary
- Accounts Payable
- Accounts Payable Summary

**fixes:** #45830

https://github.com/user-attachments/assets/7811fd9b-9c8c-403a-a561-f661d50779b6

Backport needed for v15