### PR TITLE
fix: update filters on period closing voucher

### DIFF
--- a/erpnext/accounts/doctype/period_closing_voucher/period_closing_voucher.js
+++ b/erpnext/accounts/doctype/period_closing_voucher/period_closing_voucher.js
@@ -13,9 +13,9 @@ frappe.ui.form.on("Period Closing Voucher", {
 			return {
 				filters: [
 					["Account", "company", "=", frm.doc.company],
-					["Account", "is_group", "=", "0"],
+					["Account", "is_group", "=", 0],
 					["Account", "freeze_account", "=", "No"],
-					["Account", "root_type", "in", "Liability, Equity"],
+					["Account", "root_type", "in", ["Liability", "Equity"]],
 				],
 			};
 		});


### PR DESCRIPTION
**Issue:**
In the Period Closing Voucher, Equity accounts were not filtered in the Closing Account Head field.

**fixes:**#51465

**Before:**

https://github.com/user-attachments/assets/a127510c-f851-418b-ab04-f87dfc4676af

**After:**

https://github.com/user-attachments/assets/74618622-558d-4b70-9098-8f5f77f86251

Backport needed for v15, v14