### PR TITLE
fix(postgres): fix v15 migration failures on Postgres

### DIFF
--- a/erpnext/accounts/doctype/repost_accounting_ledger/repost_accounting_ledger.py
+++ b/erpnext/accounts/doctype/repost_accounting_ledger/repost_accounting_ledger.py
@@ -235,7 +235,6 @@ def get_allowed_types_from_settings(child_doc: bool = False):
 	return result
 
 
-
 def get_child_docs(doc: list) -> list:
 	child_doc = []
 	doc = get_child_tables_of_doctypes(doc)
@@ -306,4 +305,3 @@ def get_repost_allowed_types(doctype, txt, searchfield, start, page_len, filters
 
 	allowed_types = list(dict.fromkeys(allowed_types))
 	return [[dt] for dt in allowed_types]
-

--- a/erpnext/accounts/doctype/repost_accounting_ledger/repost_accounting_ledger.py
+++ b/erpnext/accounts/doctype/repost_accounting_ledger/repost_accounting_ledger.py
@@ -215,18 +215,25 @@ def start_repost(account_repost_doc=str) -> None:
 
 
 def get_allowed_types_from_settings(child_doc: bool = False):
-	repost_docs = [
-		x.document_type
-		for x in frappe.db.get_all(
-			"Repost Allowed Types", filters={"allowed": True}, fields=["distinct(document_type)"]
-		)
-	]
+	# Avoid DISTINCT(...) here: Frappe applies a default ORDER BY which breaks on Postgres
+	# when used with SELECT DISTINCT.
+	repost_docs = frappe.db.get_all(
+		"Repost Allowed Types",
+		filters={"allowed": True},
+		pluck="document_type",
+	)
+
+	# De-dupe while preserving order (first occurrence wins)
+	repost_docs = list(dict.fromkeys(repost_docs))
 	result = repost_docs
 
 	if repost_docs and child_doc:
 		result.extend(get_child_docs(repost_docs))
+		# Keep uniqueness after extending
+		result = list(dict.fromkeys(result))
 
 	return result
+
 
 
 def get_child_docs(doc: list) -> list:
@@ -291,8 +298,12 @@ def get_repost_allowed_types(doctype, txt, searchfield, start, page_len, filters
 	if txt:
 		filters.update({"document_type": ("like", f"%{txt}%")})
 
-	if allowed_types := frappe.db.get_all(
-		"Repost Allowed Types", filters=filters, fields=["distinct(document_type)"], as_list=1
-	):
-		return allowed_types
-	return []
+	allowed_types = frappe.db.get_all(
+		"Repost Allowed Types",
+		filters=filters,
+		pluck="document_type",
+	)
+
+	allowed_types = list(dict.fromkeys(allowed_types))
+	return [[dt] for dt in allowed_types]
+

--- a/erpnext/patches/v15_0/update_pick_list_fields.py
+++ b/erpnext/patches/v15_0/update_pick_list_fields.py
@@ -8,12 +8,25 @@ def execute():
 
 
 def update_delivery_note():
-	DN = frappe.qb.DocType("Delivery Note")
-	DNI = frappe.qb.DocType("Delivery Note Item")
+	# Postgres doesn't support UPDATE ... JOIN. Use UPDATE ... FROM instead.
+	frappe.db.multisql(
+		{
+			"mariadb": """
+				UPDATE `tabDelivery Note Item` dni
+				JOIN `tabDelivery Note` dn ON dn.`name` = dni.`parent`
+				SET dni.`against_pick_list` = dn.`pick_list`
+				WHERE COALESCE(dn.`pick_list`, '') <> ''
+			""",
+			"postgres": """
+				UPDATE "tabDelivery Note Item" dni
+				SET against_pick_list = dn.pick_list
+				FROM "tabDelivery Note" dn
+				WHERE dn.name = dni.parent
+				  AND COALESCE(dn.pick_list, '') <> ''
+			""",
+		}
+	)
 
-	frappe.qb.update(DNI).join(DN).on(DN.name == DNI.parent).set(DNI.against_pick_list, DN.pick_list).where(
-		IfNull(DN.pick_list, "") != ""
-	).run()
 
 
 def update_pick_list_items():

--- a/erpnext/patches/v15_0/update_pick_list_fields.py
+++ b/erpnext/patches/v15_0/update_pick_list_fields.py
@@ -28,7 +28,6 @@ def update_delivery_note():
 	)
 
 
-
 def update_pick_list_items():
 	PL = frappe.qb.DocType("Pick List")
 	PLI = frappe.qb.DocType("Pick List Item")


### PR DESCRIPTION
### Summary

Fix two PostgreSQL-specific failures encountered during `bench --site iliad.local migrate` on ERPNext v15.

### Reproduction

- DB: PostgreSQL
- Run: `bench --site iliad.local migrate`

### Fix 1: `update_pick_list_fields` fails on Postgres (`UPDATE ... JOIN`)

- Patch: `erpnext.patches.v15_0.update_pick_list_fields`
- Error: `psycopg2.errors.SyntaxError: syntax error at or near "JOIN"`
- Cause: MariaDB-style `UPDATE <table> JOIN <table>` is not supported on Postgres
- Change: use `frappe.db.multisql`:
  - MariaDB: keep existing `UPDATE ... JOIN`
  - Postgres: equivalent `UPDATE ... SET ... FROM ... WHERE ...`

### Fix 2: `allow_on_submit_dimensions_for_repostable_doctypes` fails on Postgres (DISTINCT + ordering)

- Patch: `erpnext.patches.v15_0.allow_on_submit_dimensions_for_repostable_doctypes`
- Call chain: `get_allowed_types_from_settings(child_doc=True)` in
  `erpnext/accounts/doctype/repost_accounting_ledger/repost_accounting_ledger.py`
- Error: `psycopg2.errors.InvalidColumnReference: for SELECT DISTINCT, ORDER BY expressions must appear in select list`
- Cause: `fields=["distinct(document_type)"]` generates a `SELECT DISTINCT ...` query which conflicts with ordering rules on Postgres
- Change: replace `distinct(document_type)` with `pluck="document_type"` and de-duplicate results in Python while preserving order

### Notes

- Scope is limited to migration code paths
- MariaDB behavior unchanged
- Target branch: `version-15-hotfix`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved retrieval and deduplication of document types eligible for reposting, preserving original order when expanding child document types.
  * Rewrote the delivery note pick-list synchronization to use a more direct, database-specific update approach for reliable propagation to line items.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->