### PR TITLE
feat: Allowing closing individual items in sales order

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -2826,7 +2826,10 @@ def get_reference_details(
 				)
 				exchange_rate = 1
 			else:
-				total_amount = ref_doc.get("rounded_total") or ref_doc.get("grand_total")
+				if reference_doctype in ["Sales Order"]:
+					total_amount = ref_doc.get_sales_order_amounts()[0]
+				else:
+					total_amount = ref_doc.get("rounded_total") or ref_doc.get("grand_total")
 		if not exchange_rate:
 			# Get the exchange rate from the original ref doc
 			# or get it based on the posting date of the ref doc.
@@ -2896,6 +2899,9 @@ def get_payment_entry(
 	grand_total, outstanding_amount = set_grand_total_and_outstanding_amount(
 		party_amount, dt, party_account_currency, doc
 	)
+	if dt == "Sales Order":
+		if party_account_currency == doc.company_currency:
+			grand_total, outstanding_amount = doc.get_sales_order_amounts(party_account_handling=True)
 
 	# bank or cash
 	bank = get_bank_cash_account(doc, bank_account)

--- a/erpnext/accounts/doctype/payment_request/payment_request.py
+++ b/erpnext/accounts/doctype/payment_request/payment_request.py
@@ -811,11 +811,16 @@ def get_amount(ref_doc, payment_account=None):
 
 	dt = ref_doc.doctype
 	if dt in ["Sales Order", "Purchase Order"]:
+		party_handling = True
 		advance_amount = flt(ref_doc.advance_paid)
 		if ref_doc.party_account_currency != ref_doc.currency:
 			advance_amount = flt(flt(ref_doc.advance_paid) / ref_doc.conversion_rate)
+			party_handling = False
 
-		grand_total = (flt(ref_doc.rounded_total) or flt(ref_doc.grand_total)) - advance_amount
+		if dt == "Sales Order":
+			grand_total = ref_doc.get_sales_order_amounts(party_handling)[0] - advance_amount
+		else:
+			grand_total = (flt(ref_doc.rounded_total) or flt(ref_doc.grand_total)) - advance_amount
 
 	elif dt in ["Sales Invoice", "Purchase Invoice"]:
 		if (

--- a/erpnext/manufacturing/doctype/production_plan/production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.py
@@ -367,7 +367,7 @@ class ProductionPlan(Document):
 				(so_item.parent.isin(so_list))
 				& (so_item.docstatus == 1)
 				& ((so_item.stock_qty - so_item.stock_reserved_qty) > so_item.work_order_qty)
-				& ((so_item.is_closed == 0) | (so_item.is_closed.isnull()))
+				& (so_item.is_closed == 0)
 			)
 		)
 
@@ -432,7 +432,7 @@ class ProductionPlan(Document):
 						.where((bom.item == pi.item_code) & (bom.is_active == 1))
 					)
 				)
-				& ((so_item.is_closed == 0) | (so_item.is_closed.isnull()))
+				& (so_item.is_closed == 0)
 			)
 		)
 
@@ -1545,7 +1545,7 @@ def get_sales_orders(self):
 			& (so.status.notin(["Stopped", "Closed"]))
 			& (so.company == self.company)
 			& (so_item.qty > so_item.production_plan_qty)
-			& ((so_item.is_closed == 0) | (so_item.is_closed.isnull()))
+			& (so_item.is_closed == 0)
 		)
 	)
 

--- a/erpnext/manufacturing/doctype/production_plan/production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.py
@@ -367,6 +367,7 @@ class ProductionPlan(Document):
 				(so_item.parent.isin(so_list))
 				& (so_item.docstatus == 1)
 				& ((so_item.stock_qty - so_item.stock_reserved_qty) > so_item.work_order_qty)
+				& ((so_item.is_closed == 0) | (so_item.is_closed.isnull()))
 			)
 		)
 
@@ -431,6 +432,7 @@ class ProductionPlan(Document):
 						.where((bom.item == pi.item_code) & (bom.is_active == 1))
 					)
 				)
+				& ((so_item.is_closed == 0) | (so_item.is_closed.isnull()))
 			)
 		)
 
@@ -1543,6 +1545,7 @@ def get_sales_orders(self):
 			& (so.status.notin(["Stopped", "Closed"]))
 			& (so.company == self.company)
 			& (so_item.qty > so_item.production_plan_qty)
+			& ((so_item.is_closed == 0) | (so_item.is_closed.isnull()))
 		)
 	)
 

--- a/erpnext/manufacturing/doctype/work_order/work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/work_order.py
@@ -2447,6 +2447,7 @@ def query_sales_order(doctype: str, txt: str, searchfield: str, start: int, page
 		fields=["name"],
 		filters=[
 			["Sales Order", "docstatus", "=", 1],
+			["Sales Order", "status", "!=", "Closed"],
 		],
 		or_filters=[
 			["Sales Order Item", "item_code", "=", filters.get("production_item")],

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -461,6 +461,7 @@ erpnext.patches.v16_0.add_accounting_dimensions_to_journal_template_accounts
 erpnext.patches.v16_0.set_post_change_gl_entries_on_pos_settings
 erpnext.patches.v15_0.create_accounting_dimensions_in_advance_taxes_and_charges
 execute:frappe.delete_doc_if_exists("Workspace Sidebar", "Opening & Closing")
+erpnext.patches.v16_0.update_sales_order_item_status
 erpnext.patches.v16_0.migrate_transaction_deletion_task_flags_to_status # 2
 erpnext.patches.v16_0.set_ordered_qty_in_quotation_item
 erpnext.patches.v16_0.update_company_custom_field_in_bin

--- a/erpnext/patches/v16_0/update_sales_order_item_status.py
+++ b/erpnext/patches/v16_0/update_sales_order_item_status.py
@@ -12,7 +12,7 @@ def execute():
 		).set(sales_order_item.is_closed, 1).where(
 			(sales_order.name == sales_order_item.parent)
 			& (sales_order.status == "Closed")
-			& (sales_order_item.is_closed == 0)
+			& ((sales_order_item.is_closed == 0) | sales_order_item.is_closed.isnull())
 		).run()
 	finally:
 		frappe.db.auto_commit_on_many_writes = 0

--- a/erpnext/patches/v16_0/update_sales_order_item_status.py
+++ b/erpnext/patches/v16_0/update_sales_order_item_status.py
@@ -1,0 +1,18 @@
+import frappe
+
+
+def execute():
+	frappe.db.auto_commit_on_many_writes = 1
+	sales_order = frappe.qb.DocType("Sales Order")
+	sales_order_item = frappe.qb.DocType("Sales Order Item")
+
+	try:
+		frappe.qb.update(sales_order_item).join(sales_order).on(
+			sales_order.name == sales_order_item.parent
+		).set(sales_order_item.is_closed, 1).where(
+			(sales_order.name == sales_order_item.parent)
+			& (sales_order.status == "Closed")
+			& (sales_order_item.is_closed == 0)
+		).run()
+	finally:
+		frappe.db.auto_commit_on_many_writes = 0

--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -610,23 +610,31 @@ erpnext.utils.update_child_items = function (opts) {
 	const has_reserved_stock = opts.has_reserved_stock ? true : false;
 	const get_precision = (fieldname) => child_meta.fields.find((f) => f.fieldname == fieldname).precision;
 
-	this.data = frm.doc[opts.child_docname].map((d) => {
-		return {
-			docname: d.name,
-			name: d.name,
-			item_code: d.item_code,
-			item_name: d.item_name,
-			delivery_date: d.delivery_date,
-			schedule_date: d.schedule_date,
-			conversion_factor: d.conversion_factor,
-			qty: d.qty,
-			rate: d.rate,
-			uom: d.uom,
-			fg_item: d.fg_item,
-			fg_item_qty: d.fg_item_qty,
-			description: d.description,
-		};
-	});
+	const is_sales_order = frm.doc.doctype === "Sales Order";
+	this.data = frm.doc[opts.child_docname]
+		.filter((d) => {
+			if (is_sales_order) {
+				return !d.is_closed;
+			}
+			return true;
+		})
+		.map((d) => {
+			return {
+				docname: d.name,
+				name: d.name,
+				item_code: d.item_code,
+				item_name: d.item_name,
+				delivery_date: d.delivery_date,
+				schedule_date: d.schedule_date,
+				conversion_factor: d.conversion_factor,
+				qty: d.qty,
+				rate: d.rate,
+				uom: d.uom,
+				fg_item: d.fg_item,
+				fg_item_qty: d.fg_item_qty,
+				description: d.description,
+			};
+		});
 
 	const fields = [
 		{

--- a/erpnext/selling/doctype/sales_order/sales_order.js
+++ b/erpnext/selling/doctype/sales_order/sales_order.js
@@ -28,6 +28,8 @@ frappe.ui.form.on("Sales Order", {
 				color = "yellow";
 			} else if (doc.stock_qty <= doc.delivered_qty) {
 				color = "green";
+			} else if (doc.is_closed) {
+				color = "grey";
 			} else {
 				color = "orange";
 			}
@@ -996,6 +998,18 @@ erpnext.selling.SalesOrderController = class SalesOrderController extends erpnex
 								() => this.close_sales_order(),
 								__("Status")
 							);
+
+							this.frm.add_custom_button(
+								__("Close selected items"),
+								() => this.close_selected_items(),
+								__("Status")
+							);
+
+							this.frm.add_custom_button(
+								__("Re-open selected items"),
+								() => this.reopen_selected_items(),
+								__("Status")
+							);
 						}
 					}
 
@@ -1717,7 +1731,7 @@ erpnext.selling.SalesOrderController = class SalesOrderController extends erpnex
 			me.frm.doc.items.forEach((d) => {
 				let ordered_qty = me.get_ordered_qty(d, me.frm.doc);
 				let pending_qty = (flt(d.stock_qty) - ordered_qty) / flt(d.conversion_factor);
-				if (pending_qty > 0) {
+				if (pending_qty > 0 && !d.is_closed) {
 					po_items.push({
 						name: d.name,
 						item_name: d.item_name,
@@ -1787,6 +1801,178 @@ erpnext.selling.SalesOrderController = class SalesOrderController extends erpnex
 		});
 		d.show();
 	}
+	reopen_selected_items() {
+		var me = this;
+		this.data = this.frm.doc.items
+			.filter((d) => d.is_closed)
+			.map((d) => {
+				return {
+					docname: d.name,
+					item_code: d.item_code,
+					qty: d.qty,
+					is_close: d.is_closed,
+					delivered_qty: d.delivered_qty,
+				};
+			});
+		const reopen_item_fields = [
+			{
+				fieldtype: "Link",
+				fieldname: "item_code",
+				options: "Item",
+				in_list_view: 1,
+				read_only: 1,
+			},
+			{
+				fieldtype: "Float",
+				fieldname: "qty",
+				read_only: 1,
+				in_list_view: 1,
+				label: __("Qty"),
+			},
+		];
+		var d = new frappe.ui.Dialog({
+			title: __("Re-open Selected Items"),
+			size: "large",
+			fields: [
+				{
+					fieldname: "reopen_items",
+					fieldtype: "Table",
+					label: __("Items"),
+					cannot_add_rows: true,
+					in_place_edit: true,
+					fields: reopen_item_fields,
+					data: this.data,
+					get_data: () => {
+						return this.data;
+					},
+				},
+			],
+			primary_action_label: __("Re-open"),
+			primary_action: function () {
+				let values = d.get_values();
+
+				let selected_items = (values.reopen_items || []).filter((row) => row.__checked);
+				if (!selected_items.length) {
+					frappe.msgprint(__("Please select one item to re-open"));
+					return;
+				}
+				frappe.call({
+					method: "erpnext.selling.doctype.sales_order.sales_order.close_or_reopen_selected_items",
+					args: { sales_order: me.frm.doc.name, selected_items: selected_items, status: "Re-open" },
+					callback: (r) => {
+						if (!r.exc) {
+							d.hide();
+							me.frm.reload_doc();
+							frappe.show_alert({
+								message: __("Selected items re-opened"),
+								indicator: "green",
+							});
+						}
+					},
+				});
+			},
+		});
+
+		d.show();
+	}
+
+	close_selected_items() {
+		var me = this;
+		this.data = this.frm.doc.items
+			.filter((d) => d.qty > flt(d.delivered_qty) && !d.is_closed)
+			.map((d) => {
+				return {
+					docname: d.name,
+					item_code: d.item_code,
+					qty: d.qty,
+					is_close: d.is_closed,
+					delivered_qty: d.delivered_qty,
+				};
+			});
+		const close_item_fields = [
+			{
+				fieldtype: "Link",
+				fieldname: "item_code",
+				options: "Item",
+				in_list_view: 1,
+				read_only: 1,
+			},
+			{
+				fieldtype: "Float",
+				fieldname: "qty",
+				read_only: 1,
+				in_list_view: 1,
+				label: __("Qty"),
+			},
+		];
+		var d = new frappe.ui.Dialog({
+			title: __("Close Selected Items"),
+			size: "large",
+			fields: [
+				{
+					fieldname: "select_all",
+					fieldtype: "Check",
+					label: __("Select all items"),
+					default: 1,
+					onchange: function () {
+						const table_field = d.get_field("close_items");
+						table_field.df.hidden = this.get_value();
+						table_field.refresh();
+					},
+				},
+				{
+					fieldname: "close_items",
+					fieldtype: "Table",
+					label: __("Items"),
+					cannot_add_rows: true,
+					in_place_edit: true,
+					fields: close_item_fields,
+					data: this.data,
+					hidden: true,
+					get_data: () => {
+						return this.data;
+					},
+				},
+			],
+			primary_action_label: __("Close"),
+			primary_action: function () {
+				let values = d.get_values();
+
+				if (values.select_all) {
+					me.close_sales_order();
+					d.hide();
+					return;
+				}
+				let selected_items = (values.close_items || []).filter((row) => row.__checked);
+				if (selected_items.length == me.data.length) {
+					me.close_sales_order();
+					d.hide();
+					return;
+				}
+				if (!selected_items.length) {
+					frappe.msgprint(__("Please select one item to close"));
+					return;
+				}
+				frappe.call({
+					method: "erpnext.selling.doctype.sales_order.sales_order.close_or_reopen_selected_items",
+					args: { sales_order: me.frm.doc.name, selected_items: selected_items, status: "Close" },
+					callback: (r) => {
+						if (!r.exc) {
+							d.hide();
+							me.frm.reload_doc();
+							frappe.show_alert({
+								message: __("Selected items closed"),
+								indicator: "green",
+							});
+						}
+					},
+				});
+			},
+		});
+
+		d.show();
+	}
+
 	close_sales_order() {
 		this.frm.cscript.update_status("Close", "Closed");
 	}

--- a/erpnext/selling/doctype/sales_order/sales_order.js
+++ b/erpnext/selling/doctype/sales_order/sales_order.js
@@ -1810,7 +1810,7 @@ erpnext.selling.SalesOrderController = class SalesOrderController extends erpnex
 					docname: d.name,
 					item_code: d.item_code,
 					qty: d.qty,
-					is_close: d.is_closed,
+					is_closed: d.is_closed,
 					delivered_qty: d.delivered_qty,
 				};
 			});
@@ -1885,7 +1885,7 @@ erpnext.selling.SalesOrderController = class SalesOrderController extends erpnex
 					docname: d.name,
 					item_code: d.item_code,
 					qty: d.qty,
-					is_close: d.is_closed,
+					is_closed: d.is_closed,
 					delivered_qty: d.delivered_qty,
 				};
 			});

--- a/erpnext/selling/doctype/sales_order/sales_order.js
+++ b/erpnext/selling/doctype/sales_order/sales_order.js
@@ -981,13 +981,13 @@ erpnext.selling.SalesOrderController = class SalesOrderController extends erpnex
 
 							this.frm.add_custom_button(
 								__("Close items"),
-								() => this.close_selected_items(),
+								() => this.close_or_reopen_selected_items("Closed"),
 								__("Status")
 							);
 
 							this.frm.add_custom_button(
 								__("Re-open items"),
-								() => this.reopen_selected_items(),
+								() => this.close_or_reopen_selected_items("Re-open"),
 								__("Status")
 							);
 						}
@@ -1781,10 +1781,11 @@ erpnext.selling.SalesOrderController = class SalesOrderController extends erpnex
 		});
 		d.show();
 	}
-	reopen_selected_items() {
+
+	close_or_reopen_selected_items(status) {
 		var me = this;
 		this.data = this.frm.doc.items
-			.filter((d) => d.is_closed)
+			.filter((d) => (status === "Closed" ? d.qty > flt(d.delivered_qty) && !d.is_closed : d.is_closed))
 			.map((d) => {
 				return {
 					docname: d.name,
@@ -1792,13 +1793,18 @@ erpnext.selling.SalesOrderController = class SalesOrderController extends erpnex
 					qty: d.qty,
 					is_closed: d.is_closed,
 					delivered_qty: d.delivered_qty,
+					__checked: 1,
 				};
 			});
 		if (!this.data.length) {
-			frappe.msgprint(__("No closed items to re-open"));
+			frappe.msgprint(
+				status === "Closed"
+					? __("No items available to close")
+					: __("No closed items available to re-open")
+			);
 			return;
 		}
-		const reopen_item_fields = [
+		const item_fields = [
 			{
 				fieldtype: "Link",
 				fieldname: "item_code",
@@ -1815,141 +1821,65 @@ erpnext.selling.SalesOrderController = class SalesOrderController extends erpnex
 			},
 		];
 		var d = new frappe.ui.Dialog({
-			title: __("Re-open Selected Items"),
+			title: status === "Closed" ? __("Close Selected Items") : __("Re-open Selected Items"),
 			size: "large",
 			fields: [
 				{
-					fieldname: "reopen_items",
+					fieldname: "items",
 					fieldtype: "Table",
 					label: __("Items"),
 					cannot_add_rows: true,
 					in_place_edit: true,
-					fields: reopen_item_fields,
+					fields: item_fields,
 					data: this.data,
 					get_data: () => {
 						return this.data;
 					},
 				},
 			],
-			primary_action_label: __("Re-open"),
-			primary_action: function () {
-				let values = d.get_values();
-
-				let selected_items = (values.reopen_items || []).filter((row) => row.__checked);
-				if (!selected_items.length) {
-					frappe.msgprint(__("Please select at least one item to re-open"));
-					return;
-				}
-				frappe.call({
-					method: "erpnext.selling.doctype.sales_order.sales_order.close_or_reopen_selected_items",
-					args: { sales_order: me.frm.doc.name, selected_items: selected_items, status: "Re-open" },
-					callback: (r) => {
-						if (!r.exc) {
-							d.hide();
-							me.frm.reload_doc();
-							frappe.show_alert({
-								message: __("Selected items re-opened"),
-								indicator: "green",
-							});
-						}
-					},
-				});
-			},
-		});
-
-		d.show();
-	}
-
-	close_selected_items() {
-		var me = this;
-		this.data = this.frm.doc.items
-			.filter((d) => d.qty > flt(d.delivered_qty) && !d.is_closed)
-			.map((d) => {
-				return {
-					docname: d.name,
-					item_code: d.item_code,
-					qty: d.qty,
-					is_closed: d.is_closed,
-					delivered_qty: d.delivered_qty,
-				};
-			});
-		if (!this.data.length) {
-			frappe.msgprint(__("No items available to close"));
-			return;
-		}
-		const close_item_fields = [
-			{
-				fieldtype: "Link",
-				fieldname: "item_code",
-				options: "Item",
-				in_list_view: 1,
-				read_only: 1,
-			},
-			{
-				fieldtype: "Float",
-				fieldname: "qty",
-				read_only: 1,
-				in_list_view: 1,
-				label: __("Qty"),
-			},
-		];
-		var d = new frappe.ui.Dialog({
-			title: __("Close Selected Items"),
-			size: "large",
-			fields: [
-				{
-					fieldname: "select_all",
-					fieldtype: "Check",
-					label: __("Select all items"),
-					default: 1,
-					onchange: function () {
-						const table_field = d.get_field("close_items");
-						table_field.df.hidden = this.get_value();
-						table_field.refresh();
-					},
-				},
-				{
-					fieldname: "close_items",
-					fieldtype: "Table",
-					label: __("Items"),
-					cannot_add_rows: true,
-					in_place_edit: true,
-					fields: close_item_fields,
-					data: this.data,
-					hidden: true,
-					get_data: () => {
-						return this.data;
-					},
-				},
-			],
-			primary_action_label: __("Close"),
+			primary_action_label: status === "Closed" ? __("Close") : __("Re-open"),
 			primary_action: function () {
 				let values = d.get_values();
 
 				if (values.select_all) {
-					me.close_sales_order();
+					if (status === "Closed") {
+						me.close_sales_order();
+					} else {
+						me.reopen_sales_order();
+					}
 					d.hide();
 					return;
 				}
-				let selected_items = (values.close_items || []).filter((row) => row.__checked);
+				let selected_items = (values.items || []).filter((row) => row.__checked);
 				if (selected_items.length == me.data.length) {
-					me.close_sales_order();
+					if (status === "Close") {
+						me.close_sales_order();
+					} else {
+						me.reopen_sales_order();
+					}
 					d.hide();
 					return;
 				}
 				if (!selected_items.length) {
-					frappe.msgprint(__("Please select at least one item to close"));
+					frappe.msgprint(
+						status === "Closed"
+							? __("Please select at least one item to close")
+							: __("Please select at least one item to re-open")
+					);
 					return;
 				}
 				frappe.call({
 					method: "erpnext.selling.doctype.sales_order.sales_order.close_or_reopen_selected_items",
-					args: { sales_order: me.frm.doc.name, selected_items: selected_items, status: "Close" },
+					args: { sales_order: me.frm.doc.name, selected_items: selected_items, status: status },
 					callback: (r) => {
 						if (!r.exc) {
 							d.hide();
 							me.frm.reload_doc();
 							frappe.show_alert({
-								message: __("Selected items closed"),
+								message:
+									status === "Close"
+										? __("Selected items closed")
+										: __("Selected items re-opened"),
 								indicator: "green",
 							});
 						}
@@ -1963,6 +1893,9 @@ erpnext.selling.SalesOrderController = class SalesOrderController extends erpnex
 
 	close_sales_order() {
 		this.frm.cscript.update_status("Close", "Closed");
+	}
+	reopen_sales_order() {
+		this.frm.cscript.update_status("Re-open", "Draft");
 	}
 	update_status(label, status) {
 		var doc = this.frm.doc;

--- a/erpnext/selling/doctype/sales_order/sales_order.js
+++ b/erpnext/selling/doctype/sales_order/sales_order.js
@@ -29,7 +29,7 @@ frappe.ui.form.on("Sales Order", {
 			} else if (doc.stock_qty <= doc.delivered_qty) {
 				color = "green";
 			} else if (doc.is_closed) {
-				color = "grey";
+				color = "red";
 			} else {
 				color = "orange";
 			}
@@ -959,20 +959,6 @@ erpnext.selling.SalesOrderController = class SalesOrderController extends erpnex
 						},
 						__("Status")
 					);
-
-					if (flt(doc.per_delivered) < 100 || flt(doc.per_billed) < 100) {
-						// close
-						this.frm.add_custom_button(__("Close"), () => this.close_sales_order(), __("Status"));
-					}
-				} else if (doc.status === "Closed") {
-					// un-close
-					this.frm.add_custom_button(
-						__("Re-open"),
-						function () {
-							me.frm.cscript.update_status("Re-open", "Draft");
-						},
-						__("Status")
-					);
 				}
 			}
 			if (doc.status !== "Closed") {
@@ -992,21 +978,15 @@ erpnext.selling.SalesOrderController = class SalesOrderController extends erpnex
 								() => this.hold_sales_order(),
 								__("Status")
 							);
-							// close
-							this.frm.add_custom_button(
-								__("Close"),
-								() => this.close_sales_order(),
-								__("Status")
-							);
 
 							this.frm.add_custom_button(
-								__("Close selected items"),
+								__("Close items"),
 								() => this.close_selected_items(),
 								__("Status")
 							);
 
 							this.frm.add_custom_button(
-								__("Re-open selected items"),
+								__("Re-open items"),
 								() => this.reopen_selected_items(),
 								__("Status")
 							);

--- a/erpnext/selling/doctype/sales_order/sales_order.js
+++ b/erpnext/selling/doctype/sales_order/sales_order.js
@@ -1814,6 +1814,10 @@ erpnext.selling.SalesOrderController = class SalesOrderController extends erpnex
 					delivered_qty: d.delivered_qty,
 				};
 			});
+		if (!this.data.length) {
+			frappe.msgprint(__("No closed items to re-open"));
+			return;
+		}
 		const reopen_item_fields = [
 			{
 				fieldtype: "Link",
@@ -1853,7 +1857,7 @@ erpnext.selling.SalesOrderController = class SalesOrderController extends erpnex
 
 				let selected_items = (values.reopen_items || []).filter((row) => row.__checked);
 				if (!selected_items.length) {
-					frappe.msgprint(__("Please select one item to re-open"));
+					frappe.msgprint(__("Please select at least one item to re-open"));
 					return;
 				}
 				frappe.call({
@@ -1889,6 +1893,10 @@ erpnext.selling.SalesOrderController = class SalesOrderController extends erpnex
 					delivered_qty: d.delivered_qty,
 				};
 			});
+		if (!this.data.length) {
+			frappe.msgprint(__("No items available to close"));
+			return;
+		}
 		const close_item_fields = [
 			{
 				fieldtype: "Link",
@@ -1950,7 +1958,7 @@ erpnext.selling.SalesOrderController = class SalesOrderController extends erpnex
 					return;
 				}
 				if (!selected_items.length) {
-					frappe.msgprint(__("Please select one item to close"));
+					frappe.msgprint(__("Please select at least one item to close"));
 					return;
 				}
 				frappe.call({

--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -1482,15 +1482,13 @@ def make_sales_invoice(
 				},
 				"postprocess": update_item,
 				"condition": lambda doc: (
-					True
-					if is_unit_price_row(doc)
-					else (
-						doc.qty
-						and (doc.base_amount == 0 or abs(doc.billed_amt) < abs(doc.amount))
-						and not doc.is_closed
+					(
+						is_unit_price_row(doc)
+						or (doc.qty and (doc.base_amount == 0 or abs(doc.billed_amt) < abs(doc.amount)))
 					)
-				)
-				and select_item(doc),
+					and not doc.is_closed
+					and select_item(doc)
+				),
 			},
 			"Sales Taxes and Charges": {
 				"doctype": "Sales Taxes and Charges",

--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -2175,15 +2175,16 @@ def close_or_reopen_selected_items(sales_order, status, selected_items=None, all
 		items = {i["docname"] for i in selected_items}
 
 	for row in so.items:
+		print(status)
 		if not all_items_closed and row.name not in items:
 			continue
 
-		if status == "Close":
+		if status == "Closed":
 			if row.delivered_qty and row.qty == row.delivered_qty and not all_items_closed:
 				frappe.throw(_("Item cannot be closed as it is already delivered"))
 
 			row.is_closed = 1
-		elif status == "Re-open":
+		elif status == "Re-open" or status == "Submitted":
 			if so.docstatus == 1:
 				so.check_credit_limit()
 			row.is_closed = 0

--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -2015,6 +2015,7 @@ def get_work_order_items(sales_order: str, for_raw_material_request: int = 0):
 				"Product Bundle", {"new_item_code": ["in", item_codes], "disabled": 0}, ["new_item_code"]
 			)
 		]
+		so_items_is_closed_map = {item.name: item.is_closed for item in so.items}
 
 		overproduction_percentage_for_sales_order = (
 			frappe.get_single_value("Manufacturing Settings", "overproduction_percentage_for_sales_order")
@@ -2022,8 +2023,12 @@ def get_work_order_items(sales_order: str, for_raw_material_request: int = 0):
 		)
 		for table in [so.items, so.packed_items]:
 			for i in table:
-				if getattr(i, "is_closed", 0):
-					continue
+				if table == so.packed_items:
+					if so_items_is_closed_map.get(i.parent_detail_docname):
+						continue
+				else:
+					if getattr(i, "is_closed", 0):
+						continue
 
 				bom = get_default_bom(i.item_code)
 				stock_qty = i.qty if i.doctype == "Packed Item" else i.stock_qty
@@ -2141,6 +2146,9 @@ def get_mapped_subcontracting_inward_order(source_name, target_doc=None):
 
 @frappe.whitelist()
 def close_or_reopen_selected_items(sales_order, status, selected_items=None, all_items_closed=False):
+	if not frappe.has_permission("Sales Order", "write"):
+		frappe.throw(_("Not permitted"), frappe.PermissionError)
+
 	items = []
 	so = frappe.get_doc("Sales Order", sales_order)
 
@@ -2167,7 +2175,7 @@ def close_or_reopen_selected_items(sales_order, status, selected_items=None, all
 			row.is_closed = 0
 
 	so.save()
-	if len(items) > 0:
+	if items:
 		so.update_reserved_qty(items)
 	else:
 		so.update_reserved_qty()

--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -222,7 +222,6 @@ class SalesOrder(SellingController):
 
 	def can_update_items(self) -> bool:
 		result = True
-
 		if self.is_subcontracted:
 			if frappe.db.exists("Subcontracting Inward Order", {"sales_order": self.name, "docstatus": 1}):
 				result = False
@@ -603,7 +602,12 @@ class SalesOrder(SellingController):
 		# Limit should be checked after the 'Hold/Closed' status is reset.
 		if status == "Draft" and self.docstatus == 1:
 			self.check_credit_limit()
-		self.update_reserved_qty()
+			close_or_reopen_selected_items(self.name, "Re-open", all_items_closed=True)
+
+		if status == "Closed":
+			close_or_reopen_selected_items(self.name, "Close", all_items_closed=True)
+		else:
+			self.update_reserved_qty()
 		self.update_subcontracting_order_status()
 		self.notify_update()
 		clear_doctype_notifications(self)
@@ -1114,7 +1118,8 @@ def make_material_request(source_name: str, target_doc: str | Document | None = 
 				"condition": lambda item: not frappe.db.exists(
 					"Product Bundle", {"name": item.item_code, "disabled": 0}
 				)
-				and get_remaining_qty(item) > 0,
+				and get_remaining_qty(item) > 0
+				and not item.is_closed,
 				"postprocess": update_item,
 			},
 		},
@@ -1232,8 +1237,10 @@ def make_delivery_note(
 				return False
 
 		return (
-			(abs(doc.delivered_qty) < abs(doc.qty)) or is_unit_price_row(doc)
-		) and doc.delivered_by_supplier != 1
+			((abs(doc.delivered_qty) < abs(doc.qty)) or is_unit_price_row(doc))
+			and doc.delivered_by_supplier != 1
+			and not doc.is_closed
+		)
 
 	def update_item(source, target, source_parent):
 		target.base_amount = (flt(source.qty) - flt(source.delivered_qty)) * flt(source.base_rate)
@@ -1477,7 +1484,11 @@ def make_sales_invoice(
 				"condition": lambda doc: (
 					True
 					if is_unit_price_row(doc)
-					else (doc.qty and (doc.base_amount == 0 or abs(doc.billed_amt) < abs(doc.amount)))
+					else (
+						doc.qty
+						and (doc.base_amount == 0 or abs(doc.billed_amt) < abs(doc.amount))
+						and not doc.is_closed
+					)
 				)
 				and select_item(doc),
 			},
@@ -1928,6 +1939,7 @@ def create_pick_list(source_name: str, target_doc: str | Document | None = None)
 			abs(item.delivered_qty) < abs(item.qty)
 			and item.delivered_by_supplier != 1
 			and not is_product_bundle(item.item_code)
+			and not item.is_closed
 		)
 
 	# Don't allow a Pick List to be created against a Sales Order that has reserved stock.
@@ -2010,6 +2022,9 @@ def get_work_order_items(sales_order: str, for_raw_material_request: int = 0):
 		)
 		for table in [so.items, so.packed_items]:
 			for i in table:
+				if getattr(i, "is_closed", 0):
+					continue
+
 				bom = get_default_bom(i.item_code)
 				stock_qty = i.qty if i.doctype == "Packed Item" else i.stock_qty
 
@@ -2122,3 +2137,46 @@ def get_mapped_subcontracting_inward_order(source_name, target_doc=None):
 	)
 
 	return target_doc
+
+
+@frappe.whitelist()
+def close_or_reopen_selected_items(sales_order, status, selected_items=None, all_items_closed=False):
+	items = []
+	so = frappe.get_doc("Sales Order", sales_order)
+
+	# check if subcontracted so exists against the SO
+	if not so.can_update_items():
+		frappe.throw(_("Cannot close items in a subcontracted Sales Order"))
+
+	if not all_items_closed:
+		selected_items = parse_json(selected_items)
+		items = {i["docname"] for i in selected_items}
+
+	for row in so.items:
+		if not all_items_closed and row.name not in items:
+			continue
+
+		if status == "Close":
+			if row.delivered_qty and row.qty == row.delivered_qty and not all_items_closed:
+				frappe.throw(_("Item cannot be closed as it is already delivered"))
+
+			row.is_closed = 1
+		elif status == "Re-open":
+			if so.docstatus == 1:
+				so.check_credit_limit()
+			row.is_closed = 0
+
+	so.save()
+	if len(items) > 0:
+		so.update_reserved_qty(items)
+	else:
+		so.update_reserved_qty()
+
+	if not all_items_closed and all(d.is_closed for d in so.items):
+		so.status = "Closed"
+		so.set_status(update=True, status="Closed")
+		so.update_subcontracting_order_status()
+		so.notify_update()
+		clear_doctype_notifications(so)
+
+	return True

--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -836,6 +836,22 @@ class SalesOrder(SellingController):
 
 		return False
 
+	def get_sales_order_amounts(self, party_account_handling=False):
+		if party_account_handling:
+			grand_total = self.base_rounded_total or self.base_grand_total
+		else:
+			grand_total = self.rounded_total or self.grand_total
+
+		for item in self.get("items"):
+			if item.is_closed == 1:
+				if party_account_handling:
+					grand_total -= item.base_amount
+				else:
+					grand_total -= item.amount
+
+		outstanding_amount = grand_total - self.advance_paid
+		return grand_total, outstanding_amount
+
 	@frappe.whitelist()
 	def create_stock_reservation_entries(
 		self,

--- a/erpnext/selling/doctype/sales_order/test_sales_order.py
+++ b/erpnext/selling/doctype/sales_order/test_sales_order.py
@@ -103,7 +103,7 @@ class TestSalesOrder(AccountsTestMixin, IntegrationTestCase):
 			frappe.ValidationError,
 			close_or_reopen_selected_items,
 			so.name,
-			"Close",
+			"Closed",
 			json.dumps([{"docname": so.items[0].name}]),
 		)
 
@@ -116,7 +116,7 @@ class TestSalesOrder(AccountsTestMixin, IntegrationTestCase):
 			)[0].reserved_qty,
 			3,
 		)
-		close_or_reopen_selected_items(so.name, "Close", json.dumps([{"docname": so.items[1].name}]))
+		close_or_reopen_selected_items(so.name, "Closed", json.dumps([{"docname": so.items[1].name}]))
 		so.reload()
 		self.assertEqual(
 			frappe.get_all(

--- a/erpnext/selling/doctype/sales_order/test_sales_order.py
+++ b/erpnext/selling/doctype/sales_order/test_sales_order.py
@@ -22,6 +22,7 @@ from erpnext.manufacturing.doctype.blanket_order.test_blanket_order import make_
 from erpnext.selling.doctype.product_bundle.test_product_bundle import make_product_bundle
 from erpnext.selling.doctype.sales_order.sales_order import (
 	WarehouseRequired,
+	close_or_reopen_selected_items,
 	create_pick_list,
 	make_delivery_note,
 	make_material_request,
@@ -56,6 +57,114 @@ class TestSalesOrder(AccountsTestMixin, IntegrationTestCase):
 	def tearDown(self):
 		frappe.db.rollback()
 		frappe.set_user("Administrator")
+
+	def test_sales_order_item_level_closing(self):
+		warehouse = "_Test Warehouse - _TC"
+
+		item_1 = make_item("_Test SO Item Level Closing 1", {"is_stock_item": 1})
+		item_2 = make_item("_Test SO Item Level Closing 2", {"is_stock_item": 1})
+		item_3 = make_item("_Test SO Item Level Closing 3", {"is_stock_item": 1})
+
+		make_stock_entry(item_code=item_1.item_code, target=warehouse, qty=10, rate=100)
+		make_stock_entry(item_code=item_2.item_code, target=warehouse, qty=10, rate=100)
+		make_stock_entry(item_code=item_3.item_code, target=warehouse, qty=10, rate=100)
+
+		so = make_sales_order(
+			item_list=[
+				{
+					"item_code": item_1.item_code,
+					"qty": 2,
+					"rate": 100,
+					"warehouse": warehouse,
+				},
+				{
+					"item_code": item_2.item_code,
+					"qty": 3,
+					"rate": 100,
+					"warehouse": warehouse,
+				},
+				{
+					"item_code": item_3.item_code,
+					"qty": 4,
+					"rate": 100,
+					"warehouse": warehouse,
+				},
+			],
+			do_not_submit=True,
+		)
+		so.submit()
+		dn = make_delivery_note(so.name, kwargs={"filtered_children": [so.items[0].name]})
+		dn.submit()
+
+		so.reload()
+		self.assertEqual(so.items[0].delivered_qty, 2)
+
+		self.assertRaises(
+			frappe.ValidationError,
+			close_or_reopen_selected_items,
+			so.name,
+			"Close",
+			json.dumps([{"docname": so.items[0].name}]),
+		)
+
+		# checking for item reserved qty before and after closing
+		self.assertEqual(
+			frappe.get_all(
+				"Bin",
+				filters={"item_code": so.items[1].item_code, "warehouse": so.items[1].warehouse},
+				fields=["reserved_qty"],
+			)[0].reserved_qty,
+			3,
+		)
+		close_or_reopen_selected_items(so.name, "Close", json.dumps([{"docname": so.items[1].name}]))
+		so.reload()
+		self.assertEqual(
+			frappe.get_all(
+				"Bin",
+				filters={"item_code": so.items[1].item_code, "warehouse": so.items[1].warehouse},
+				fields=["reserved_qty"],
+			)[0].reserved_qty,
+			0,
+		)
+
+		# updating closed item
+		self.assertRaises(
+			frappe.ValidationError,
+			update_child_qty_rate,
+			"Sales Order",
+			json.dumps(
+				[
+					{
+						"item_code": so.items[1].item_code,
+						"rate": so.items[1].rate,
+						"qty": 5,
+						"docname": so.items[1].name,
+					}
+				]
+			),
+			so.name,
+		)
+
+		# creating pick list for remaining items
+		pick_list = create_pick_list(so.name)
+		pick_list.submit()
+		self.assertEqual(len(pick_list.locations), 1)
+		# reopening closed item
+		close_or_reopen_selected_items(
+			so.name,
+			"Re-open",
+			json.dumps([{"docname": so.items[1].name}]),
+		)
+
+		so.reload()
+		self.assertEqual(
+			frappe.get_all(
+				"Bin",
+				filters={"item_code": so.items[1].item_code, "warehouse": so.items[1].warehouse},
+				fields=["reserved_qty"],
+			)[0].reserved_qty,
+			3,
+		)
 
 	def test_sales_order_skip_delivery_note(self):
 		so = make_sales_order(do_not_submit=True)

--- a/erpnext/selling/doctype/sales_order_item/sales_order_item.json
+++ b/erpnext/selling/doctype/sales_order_item/sales_order_item.json
@@ -14,6 +14,7 @@
   "ensure_delivery_based_on_produced_serial_no",
   "is_stock_item",
   "reserve_stock",
+  "is_closed",
   "col_break1",
   "delivery_date",
   "item_name",
@@ -1010,6 +1011,14 @@
    "fieldtype": "Float",
    "label": "Finished Good Qty",
    "mandatory_depends_on": "eval:parent.is_subcontracted"
+  },
+  {
+   "allow_on_submit": 1,
+   "default": "0",
+   "fieldname": "is_closed",
+   "fieldtype": "Check",
+   "label": "Is Closed",
+   "read_only": 1
   }
  ],
  "grid_page_length": 50,

--- a/erpnext/selling/doctype/sales_order_item/sales_order_item.py
+++ b/erpnext/selling/doctype/sales_order_item/sales_order_item.py
@@ -47,6 +47,7 @@ class SalesOrderItem(Document):
 		grant_commission: DF.Check
 		gross_profit: DF.Currency
 		image: DF.Attach | None
+		is_closed: DF.Check
 		is_free_item: DF.Check
 		is_stock_item: DF.Check
 		item_code: DF.Link

--- a/erpnext/selling/report/item_wise_sales_history/item_wise_sales_history.py
+++ b/erpnext/selling/report/item_wise_sales_history/item_wise_sales_history.py
@@ -124,6 +124,12 @@ def get_columns(filters):
 			"options": "Currency",
 			"hidden": 1,
 		},
+		{
+			"label": _("Is Closed"),
+			"fieldtype": "Check",
+			"fieldname": "is_closed",
+			"width": 80,
+		},
 	]
 
 
@@ -159,6 +165,7 @@ def get_data(filters):
 			"delivered_quantity": flt(record.get("delivered_qty")),
 			"billed_amount": flt(record.get("billed_amt")),
 			"company": record.get("company"),
+			"is_closed": record.get("is_closed"),
 		}
 		row["currency"] = frappe.get_cached_value("Company", row["company"], "default_currency")
 		data.append(row)
@@ -207,6 +214,7 @@ def get_sales_order_details(company_list, filters):
 			db_so_item.base_amount,
 			db_so_item.delivered_qty,
 			(db_so_item.billed_amt * db_so.conversion_rate).as_("billed_amt"),
+			db_so_item.is_closed,
 		)
 		.where(db_so.docstatus == 1)
 		.where(db_so.company.isin(tuple(company_list)))

--- a/erpnext/selling/report/sales_order_analysis/sales_order_analysis.py
+++ b/erpnext/selling/report/sales_order_analysis/sales_order_analysis.py
@@ -78,7 +78,8 @@ def get_data(conditions, filters):
 			(soi.base_amount - (soi.billed_amt * IFNULL(so.conversion_rate, 1))) as pending_amount,
 			soi.warehouse as warehouse,
 			so.company, soi.name,
-			soi.description as description
+			soi.description as description,
+			soi.is_closed
 		FROM
 			`tabSales Order` so,
 			`tabSales Order Item` soi
@@ -325,6 +326,12 @@ def get_columns(filters):
 				"fieldname": "time_taken_to_deliver",
 				"fieldtype": "Duration",
 				"width": 100,
+			},
+			{
+				"label": _("Is Closed"),
+				"fieldname": "is_closed",
+				"fieldtype": "Check",
+				"width": 80,
 			},
 		]
 	)

--- a/erpnext/stock/stock_balance.py
+++ b/erpnext/stock/stock_balance.py
@@ -138,7 +138,7 @@ def get_reserved_qty(item_code, warehouse):
 				and (so_item.delivered_by_supplier is null or so_item.delivered_by_supplier = 0)
 				and exists(select * from `tabSales Order` so
 					where so.name = so_item.parent and so.docstatus = 1
-					and so.status not in ('On Hold', 'Closed')))
+					and so_item.is_closed=0 and so.status not in ('On Hold', 'Closed')))
 			) tab
 		where
 			so_item_qty >= so_item_delivered_qty


### PR DESCRIPTION
This adds the feature: https://github.com/frappe/erpnext/issues/39030

By this feature we now allow the items to be closed at individual level in sales order. It ensures the following things:
1. Ensuring closed items do not reflect in other doctype that get created from sales order 
2. Updating close items is not permitted 
3. We can Re-open individual items as well 


`no-docs`