### PR TITLE
fix: calculate net profit amount from root accounts

### DIFF
--- a/erpnext/accounts/report/gross_and_net_profit_report/gross_and_net_profit_report.py
+++ b/erpnext/accounts/report/gross_and_net_profit_report/gross_and_net_profit_report.py
@@ -54,14 +54,14 @@ def execute(filters=None):
 	gross_income = get_revenue(income, period_list)
 	gross_expense = get_revenue(expense, period_list)
 
-	if len(gross_income) == 0 and len(gross_expense) == 0:
-		data.append(
-			{
-				"account_name": "'" + _("Nothing is included in gross") + "'",
-				"account": "'" + _("Nothing is included in gross") + "'",
-			}
-		)
-		return columns, data
+	# if len(gross_income) == 0 and len(gross_expense) == 0:
+	# 	data.append(
+	# 		{
+	# 			"account_name": "'" + _("Nothing is included in gross") + "'",
+	# 			"account": "'" + _("Nothing is included in gross") + "'",
+	# 		}
+	# 	)
+	# 	return columns, data
 
 	# to avoid error eg: gross_income[0] : list index out of range
 	if not gross_income:
@@ -112,7 +112,7 @@ def execute(filters=None):
 	)
 	data.append({})
 	data.append(net_profit)
-
+	print(data)
 	return columns, data
 
 
@@ -219,24 +219,18 @@ def get_net_profit(
 
 	has_value = False
 
+	gross_income_roots = [row for row in (gross_income or []) if not flt(row.get("indent"))]
+	non_gross_income_roots = [row for row in (non_gross_income or []) if not flt(row.get("indent"))]
+	gross_expense_roots = [row for row in (gross_expense or []) if not flt(row.get("indent"))]
+	non_gross_expense_roots = [row for row in (non_gross_expense or []) if not flt(row.get("indent"))]
+
 	for period in period_list:
 		key = period if consolidated else period.key
 
-		gross_income_for_period = sum(
-			flt(row.get(key, 0)) for row in (gross_income or []) if flt(row.get("indent")) == 0.0
-		)
-
-		non_gross_income_for_period = sum(
-			flt(row.get(key, 0)) for row in (non_gross_income or []) if flt(row.get("indent")) == 0.0
-		)
-
-		gross_expense_for_period = sum(
-			flt(row.get(key, 0)) for row in (gross_expense or []) if flt(row.get("indent")) == 0.0
-		)
-
-		non_gross_expense_for_period = sum(
-			flt(row.get(key, 0)) for row in (non_gross_expense or []) if flt(row.get("indent")) == 0.0
-		)
+		gross_income_for_period = sum(flt(row.get(key, 0)) for row in gross_income_roots)
+		non_gross_income_for_period = sum(flt(row.get(key, 0)) for row in non_gross_income_roots)
+		gross_expense_for_period = sum(flt(row.get(key, 0)) for row in gross_expense_roots)
+		non_gross_expense_for_period = sum(flt(row.get(key, 0)) for row in non_gross_expense_roots)
 
 		total_income = gross_income_for_period + non_gross_income_for_period
 		total_expense = gross_expense_for_period + non_gross_expense_for_period

--- a/erpnext/accounts/report/gross_and_net_profit_report/gross_and_net_profit_report.py
+++ b/erpnext/accounts/report/gross_and_net_profit_report/gross_and_net_profit_report.py
@@ -54,14 +54,14 @@ def execute(filters=None):
 	gross_income = get_revenue(income, period_list)
 	gross_expense = get_revenue(expense, period_list)
 
-	# if len(gross_income) == 0 and len(gross_expense) == 0:
-	# 	data.append(
-	# 		{
-	# 			"account_name": "'" + _("Nothing is included in gross") + "'",
-	# 			"account": "'" + _("Nothing is included in gross") + "'",
-	# 		}
-	# 	)
-	# 	return columns, data
+	if len(gross_income) == 0 and len(gross_expense) == 0:
+		data.append(
+			{
+				"account_name": "'" + _("Nothing is included in gross") + "'",
+				"account": "'" + _("Nothing is included in gross") + "'",
+			}
+		)
+		return columns, data
 
 	# to avoid error eg: gross_income[0] : list index out of range
 	if not gross_income:

--- a/erpnext/accounts/report/gross_and_net_profit_report/gross_and_net_profit_report.py
+++ b/erpnext/accounts/report/gross_and_net_profit_report/gross_and_net_profit_report.py
@@ -112,7 +112,6 @@ def execute(filters=None):
 	)
 	data.append({})
 	data.append(net_profit)
-	print(data)
 	return columns, data
 
 

--- a/erpnext/accounts/report/gross_and_net_profit_report/gross_and_net_profit_report.py
+++ b/erpnext/accounts/report/gross_and_net_profit_report/gross_and_net_profit_report.py
@@ -221,11 +221,22 @@ def get_net_profit(
 
 	for period in period_list:
 		key = period if consolidated else period.key
-		gross_income_for_period = flt(gross_income[0].get(key, 0)) if gross_income else 0
-		non_gross_income_for_period = flt(non_gross_income[0].get(key, 0)) if non_gross_income else 0
 
-		gross_expense_for_period = flt(gross_expense[0].get(key, 0)) if gross_expense else 0
-		non_gross_expense_for_period = flt(non_gross_expense[0].get(key, 0)) if non_gross_expense else 0
+		gross_income_for_period = sum(
+			flt(row.get(key, 0)) for row in (gross_income or []) if flt(row.get("indent")) == 0.0
+		)
+
+		non_gross_income_for_period = sum(
+			flt(row.get(key, 0)) for row in (non_gross_income or []) if flt(row.get("indent")) == 0.0
+		)
+
+		gross_expense_for_period = sum(
+			flt(row.get(key, 0)) for row in (gross_expense or []) if flt(row.get("indent")) == 0.0
+		)
+
+		non_gross_expense_for_period = sum(
+			flt(row.get(key, 0)) for row in (non_gross_expense or []) if flt(row.get("indent")) == 0.0
+		)
 
 		total_income = gross_income_for_period + non_gross_income_for_period
 		total_expense = gross_expense_for_period + non_gross_expense_for_period


### PR DESCRIPTION
**Issue:** Net Profit value in the Gross and Net Profit Report shows incorrect value because total income and expense amounts are calculated using only the zero-indexed row.
This leads a discrepancy, when the Net Profit value is compared with the Profit and Loss Statement, especially when multiple root-level accounts exist.

**Ref:** [56322](https://support.frappe.io/helpdesk/tickets/56322)

**Solution:** Calculate  income and expense totals by summing all root-level accounts.

Before:

<img width="1337" height="419" alt="Screenshot 2026-01-05 at 14 21 14" src="https://github.com/user-attachments/assets/53d9fa33-027a-48d7-86a2-81b4b89479bb" />

After:

<img width="1298" height="584" alt="Screenshot 2026-01-05 at 14 17 32" src="https://github.com/user-attachments/assets/308392dc-96bd-4513-acd8-1e38bedf2b99" />

Bacport Needed v15