### PR TITLE
fix: add missing translation function for company default error message

### DIFF
--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -1146,7 +1146,7 @@ def get_company_default(company, fieldname, ignore_validation=False):
 	if not ignore_validation and not value:
 		throw(
 			_("Please set default {0} in Company {1}").format(
-				frappe.get_meta("Company").get_label(fieldname), company
+				_(frappe.get_meta("Company").get_label(fieldname)), company
 			)
 		)
 


### PR DESCRIPTION
### Before
<img width="877" height="188" alt="image" src="https://github.com/user-attachments/assets/a904340f-4468-473c-812a-6d33d1eed5b1" />

### After
<img width="876" height="200" alt="image" src="https://github.com/user-attachments/assets/ab34c398-bade-4c79-af5d-935dca5ed047" />
