### PR TITLE
fix: set rate as incoming_rate for stand-alone credit note

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -465,6 +465,7 @@ class SalesInvoice(SellingController):
 				self.make_bundle_using_old_serial_batch_fields(table_name)
 
 			self.validate_standalone_serial_nos_customer()
+			self.validate_standalone_incoming_rate()
 			self.update_stock_reservation_entries()
 			self.update_stock_ledger()
 

--- a/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
@@ -4691,6 +4691,71 @@ class TestSalesInvoice(ERPNextTestSuite):
 
 		doc.db_set("do_not_use_batchwise_valuation", original_value)
 
+	@change_settings("Selling Settings", {"set_incoming_rate_as_invoice_rate": 1})
+	def test_standalone_credit_note_incoming_rate(self):
+		item_code = "_Test Item for Credit Note Incoming Rate"
+		make_item_for_si(
+			item_code,
+			{
+				"is_stock_item": 1,
+				"has_batch_no": 1,
+				"create_new_batch": 1,
+				"batch_number_series": "BATCH-TCNIR.####",
+			},
+		)
+
+		si = create_sales_invoice(
+			item=item_code,
+			qty=-2,
+			rate=120,
+			is_return=1,
+			update_stock=1,
+		)
+
+		stock_ledger_entry = frappe.db.get_value(
+			"Stock Ledger Entry",
+			{
+				"voucher_type": "Sales Invoice",
+				"voucher_no": si.name,
+				"item_code": item_code,
+				"warehouse": "_Test Warehouse - _TC",
+			},
+			["incoming_rate", "valuation_rate", "actual_qty as qty", "stock_value_difference"],
+			as_dict=True,
+		)
+
+		self.assertEqual(stock_ledger_entry.incoming_rate, 120)
+		self.assertEqual(stock_ledger_entry.valuation_rate, 120)
+		self.assertEqual(stock_ledger_entry.qty, 2.0)
+		self.assertEqual(stock_ledger_entry.stock_value_difference, 240)
+
+	@change_settings("Selling Settings", {"set_incoming_rate_as_invoice_rate": 0})
+	def test_standalone_credit_note_zero_incoming_rate_validation(self):
+		from erpnext.controllers.selling_controller import StandaloneZeroIncomingRateError
+
+		item_code = "_Test Item for Credit Note Zero Incoming Rate"
+		make_item_for_si(
+			item_code,
+			{
+				"is_stock_item": 1,
+				"has_batch_no": 1,
+				"create_new_batch": 1,
+				"batch_number_series": "BATCH-TCNZIR.####",
+			},
+		)
+
+		si = create_sales_invoice(
+			item=item_code,
+			qty=-2,
+			rate=120,
+			is_return=1,
+			update_stock=1,
+			do_not_submit=1,
+			allow_zero_valuation_rate=0,
+		)
+
+		self.assertRaises(StandaloneZeroIncomingRateError, si.submit)
+
 
 def make_item_for_si(item_code, properties=None):
 	from erpnext.stock.doctype.item.test_item import make_item

--- a/erpnext/controllers/sales_and_purchase_return.py
+++ b/erpnext/controllers/sales_and_purchase_return.py
@@ -724,7 +724,17 @@ def get_rate_for_return(
 				raise_error_if_no_rate=False,
 			)
 
-	if not rate and voucher_type in ["Sales Invoice", "Delivery Note"]:
+	set_incoming_rate_as_invoice_rate = frappe.db.get_single_value(
+		"Selling Settings", "set_incoming_rate_as_invoice_rate"
+	)
+
+	if (
+		not rate
+		and set_incoming_rate_as_invoice_rate
+		and not return_against
+		and voucher_type in ["Sales Invoice", "Delivery Note"]
+	):
+		# set incoming rate same as invoice rate for standalone credit note
 		details = frappe.db.get_value(
 			voucher_type + " Item", voucher_detail_no, ["rate", "allow_zero_valuation_rate"], as_dict=1
 		)

--- a/erpnext/controllers/selling_controller.py
+++ b/erpnext/controllers/selling_controller.py
@@ -15,7 +15,7 @@ from erpnext.stock.get_item_details import get_bin_details, get_conversion_facto
 from erpnext.stock.utils import get_combine_datetime, get_incoming_rate, get_valuation_method
 
 
-class StandaloneIncomingRateError(frappe.ValidationError):
+class StandaloneZeroIncomingRateError(frappe.ValidationError):
 	pass
 
 
@@ -1033,7 +1033,7 @@ class SellingController(StockController):
 
 	def validate_standalone_incoming_rate(self):
 		"""
-		Validate the standalone credit note incoming rate as per the selling settings
+		Validate the standalone credit note zero incoming rate as per the selling settings.
 		"""
 		if self.doctype not in ("Delivery Note", "Sales Invoice"):
 			return
@@ -1053,13 +1053,17 @@ class SellingController(StockController):
 			):
 				throw(
 					_(
-						"""The incoming rate should not be zero for standalone credit note. If you want to set the invoice rate as incoming rate.
-						Kindly enable {0} in {1}"""
+						"""Row #{0}: Incoming Rate for item {1} is zero, you can set the rate manually in {2} field.<br><br>
+						Alternatively, if you want system to set Incoming Rate same as Invoice Rate for standalone credit note.<br>
+						Kindly enable {3} in {4}"""
 					).format(
+						bold(row.idx),
+						bold(row.item_name),
+						bold(row.meta.get_label("incoming_rate")),
 						bold(_("Set the Incoming Rate Same as the Invoice Rate")),
 						get_link_to_form("Selling Settings", "Selling Settings"),
 					),
-					StandaloneIncomingRateError,
+					StandaloneZeroIncomingRateError,
 				)
 
 

--- a/erpnext/controllers/selling_controller.py
+++ b/erpnext/controllers/selling_controller.py
@@ -15,6 +15,10 @@ from erpnext.stock.get_item_details import get_bin_details, get_conversion_facto
 from erpnext.stock.utils import get_combine_datetime, get_incoming_rate, get_valuation_method
 
 
+class StandaloneIncomingRateError(frappe.ValidationError):
+	pass
+
+
 class SellingController(StockController):
 	def __setup__(self):
 		self.flags.ignore_permlevel_for_fields = ["selling_price_list", "price_list_currency"]
@@ -536,6 +540,7 @@ class SellingController(StockController):
 		allow_at_arms_length_price = frappe.get_cached_value(
 			"Stock Settings", None, "allow_internal_transfer_at_arms_length_price"
 		)
+
 		items = self.get("items") + (self.get("packed_items") or [])
 		for d in items:
 			if not frappe.get_cached_value("Item", d.item_code, "is_stock_item"):
@@ -591,13 +596,19 @@ class SellingController(StockController):
 						self.doctype, self.name, d.item_code, self.return_against, item_row=d
 					)
 
+				set_incoming_rate_as_invoice_rate = frappe.db.get_single_value(
+					"Selling Settings", "set_incoming_rate_as_invoice_rate"
+				)
+
 				if (
-					self.get("is_return")
+					set_incoming_rate_as_invoice_rate
+					and self.get("is_return")
 					and not d.incoming_rate
 					and not self.get("return_against")
 					and not self.is_internal_transfer()
 					and not d.get("allow_zero_valuation_rate")
 				):
+					# set incoming rate same as invoice rate for standalone credit note
 					d.incoming_rate = d.rate
 
 				# For internal transfers use incoming rate as the valuation rate
@@ -1019,6 +1030,37 @@ class SellingController(StockController):
 					sre_doc.update_reserved_stock_in_bin()
 
 					qty_to_undelivered -= qty_can_be_undelivered
+
+	def validate_standalone_incoming_rate(self):
+		"""
+		Validate the standalone credit note incoming rate as per the selling settings
+		"""
+		if self.doctype not in ("Delivery Note", "Sales Invoice"):
+			return
+
+		if not self.is_return or self.return_against:
+			return
+
+		set_incoming_rate_as_invoice_rate = frappe.db.get_single_value(
+			"Selling Settings", "set_incoming_rate_as_invoice_rate"
+		)
+
+		for row in self.get("items"):
+			if (
+				not set_incoming_rate_as_invoice_rate
+				and row.incoming_rate == 0
+				and not row.allow_zero_valuation_rate
+			):
+				throw(
+					_(
+						"""The incoming rate should not be zero for standalone credit note. If you want to set the invoice rate as incoming rate.
+						Kindly enable {0} in {1}"""
+					).format(
+						bold(_("Set the Incoming Rate Same as the Invoice Rate")),
+						get_link_to_form("Selling Settings", "Selling Settings"),
+					),
+					StandaloneIncomingRateError,
+				)
 
 
 def set_default_income_account_for_item(obj):

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -456,3 +456,5 @@ erpnext.patches.v16_0.update_tax_withholding_field_in_payment_entry
 erpnext.patches.v16_0.migrate_tax_withholding_data
 erpnext.patches.v16_0.update_corrected_cancelled_status
 erpnext.patches.v16_0.fix_barcode_typo
+erpnext.patches.v15_0.enable_set_incoming_rate_as_invoice_rate
+

--- a/erpnext/patches/v15_0/enable_set_incoming_rate_as_invoice_rate.py
+++ b/erpnext/patches/v15_0/enable_set_incoming_rate_as_invoice_rate.py
@@ -1,0 +1,5 @@
+import frappe
+
+
+def execute():
+	frappe.db.set_single_value("Selling Settings", "set_incoming_rate_as_invoice_rate", 1)

--- a/erpnext/selling/doctype/selling_settings/selling_settings.json
+++ b/erpnext/selling/doctype/selling_settings/selling_settings.json
@@ -39,6 +39,7 @@
   "enable_cutoff_date_on_bulk_delivery_note_creation",
   "allow_zero_qty_in_quotation",
   "allow_zero_qty_in_sales_order",
+  "set_incoming_rate_as_invoice_rate",
   "experimental_section",
   "use_legacy_js_reactivity",
   "subcontracting_inward_tab",
@@ -288,6 +289,13 @@
    "fieldname": "use_legacy_js_reactivity",
    "fieldtype": "Check",
    "label": "Use Legacy (Client side) Reactivity"
+  },
+  {
+   "default": "1",
+   "description": "if enabled, system will set the incoming rate same as the invoice rate for standalone credit notes.",
+   "fieldname": "set_incoming_rate_as_invoice_rate",
+   "fieldtype": "Check",
+   "label": "Set the Incoming Rate Same as the Invoice Rate"
   }
  ],
  "grid_page_length": 50,
@@ -296,7 +304,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-12-17 16:08:48.865885",
+ "modified": "2026-01-06 19:15:36.892618",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Selling Settings",

--- a/erpnext/selling/doctype/selling_settings/selling_settings.py
+++ b/erpnext/selling/doctype/selling_settings/selling_settings.py
@@ -44,6 +44,7 @@ class SellingSettings(Document):
 		role_to_override_stop_action: DF.Link | None
 		sales_update_frequency: DF.Literal["Monthly", "Each Transaction", "Daily"]
 		selling_price_list: DF.Link | None
+		set_incoming_rate_as_invoice_rate: DF.Check
 		so_required: DF.Literal["No", "Yes"]
 		territory: DF.Link | None
 		use_legacy_js_reactivity: DF.Check

--- a/erpnext/stock/doctype/delivery_note/delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.py
@@ -475,6 +475,7 @@ class DeliveryNote(SellingController):
 			self.make_bundle_using_old_serial_batch_fields(table_name)
 
 		self.validate_standalone_serial_nos_customer()
+		self.validate_standalone_incoming_rate()
 		self.update_stock_reservation_entries()
 
 		# Updating stock ledger should always be called after updating prevdoc status,

--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -649,7 +649,6 @@ class update_entries_after:
 			while i < len(entries_to_fix):
 				sle = entries_to_fix[i]
 				i += 1
-
 				self.process_sle(sle)
 				self.update_bin_data(sle)
 
@@ -1225,7 +1224,28 @@ class update_entries_after:
 					get_rate_for_return,  # don't move this import to top
 				)
 
+				set_incoming_rate_as_invoice_rate = frappe.db.get_single_value(
+					"Selling Settings", "set_incoming_rate_as_invoice_rate"
+				)
+
+				return_against = frappe.get_cached_value(sle.voucher_type, sle.voucher_no, "return_against")
+
 				if (
+					set_incoming_rate_as_invoice_rate
+					and not return_against
+					and sle.voucher_type in ["Delivery Note", "Sales Invoice"]
+				):
+					# set incoming rate same as invoice rate for standalone credit note
+					rate = get_rate_for_return(
+						sle.voucher_type,
+						sle.voucher_no,
+						sle.item_code,
+						voucher_detail_no=sle.voucher_detail_no,
+						return_against=return_against,
+						sle=sle,
+					)
+
+				elif (
 					self.valuation_method == "Moving Average"
 					and not sle.get("serial_no")
 					and not sle.get("batch_no")


### PR DESCRIPTION
**Issue:** The system currently allows a zero incoming rate for standalone Credit Notes. This can lead to stock value discrepancies in subsequent inventory transactions.

**Fix:** A new setting, **Set the Incoming Rate Same as the Invoice Rate**, has been added to _Selling Settings_ and is enabled by default.

When this setting is enabled, the system will automatically set the `incoming_rate` equal to the invoice rate only if the incoming rate is zero. This acts as a fallback mechanism when:
 - the actual valuation rate is unavailable, and
 - no incoming rate has been manually entered.

When the setting is disabled, the system will not allow a zero incoming rate, unless `allow_zero_valuation_rate` is explicitly enabled.

**FYR**
<img width="1710" height="919" alt="Screenshot 2026-01-06 at 6 17 35 PM" src="https://github.com/user-attachments/assets/e19b7ab1-5250-45ba-9d89-67ed24961224" />


**Before:**

https://github.com/user-attachments/assets/0c5061a3-6f06-46c3-a59a-0a724279a50e


**After:**

https://github.com/user-attachments/assets/9e92efea-c74a-4198-9bff-2406801da8fb


**Backport Needed: v15**