### PR TITLE
feat(stock): allow updating items after submit for Purchase Material Requests

### DIFF
--- a/erpnext/stock/doctype/material_request/material_request.js
+++ b/erpnext/stock/doctype/material_request/material_request.js
@@ -656,3 +656,179 @@ function set_schedule_date(frm) {
 		);
 	}
 }
+// frappe.ui.form.on("Material Request", {
+// 	refresh(frm) {
+// 		if (
+// 			frm.doc.docstatus === 1 &&
+// 			frm.doc.material_request_type === "Purchase" &&
+// 			flt(frm.doc.per_ordered) < 100 &&
+// 			frm.doc.status !== "Stopped"
+// 		) {
+// 			// Add button ONLY once
+// 			if (!frm.custom_buttons || !frm.custom_buttons[__("Update Items")]) {
+// 				frm.add_custom_button(
+// 					__("Update Items"),
+// 					() => open_update_items_dialog(frm)
+// 				).addClass("btn-primary");
+// 			}
+// 		}
+// 	},
+// });
+
+
+
+// function open_update_items_dialog(frm) {
+// 	const table_data = frm.doc.items.map((d) => ({
+// 		docname: d.name,
+// 		item_code: d.item_code,
+// 		qty: flt(d.qty),
+// 		completed_qty: flt(d.ordered_qty),
+// 		uom: d.uom,
+// 		conversion_factor: d.conversion_factor,
+// 		rate: d.rate,
+// 		warehouse: d.warehouse,
+// 		schedule_date: d.schedule_date,
+// 	}));
+
+// 	const dialog = new frappe.ui.Dialog({
+// 		title: __("Update Material Request Items"),
+// 		size: "extra-large",
+// 		fields: [
+// 			{
+// 				fieldname: "items_table",
+// 				fieldtype: "Table",
+// 				label: __("Items"),
+// 				in_place_edit: false,
+// 				data: table_data,
+// 				get_data: () => table_data,
+// 				fields: [
+// 					{
+// 						fieldtype: "Data",
+// 						fieldname: "docname",
+// 						hidden: 1,
+// 						read_only: 1,
+// 					},
+// 					{
+// 						fieldtype: "Link",
+// 						fieldname: "item_code",
+// 						label: __("Item Code"),
+// 						options: "Item",
+// 						in_list_view: 1,
+// 						reqd: 1,
+// 						get_query() {
+// 							return {
+// 								query: "erpnext.controllers.queries.item_query",
+// 								filters: { is_purchase_item: 1 },
+// 							};
+// 						},
+// 					},
+// 					{
+// 						fieldtype: "Float",
+// 						fieldname: "qty",
+// 						label: __("Qty"),
+// 						in_list_view: 1,
+// 						reqd: 1,
+// 					},
+// 					{
+// 						fieldtype: "Float",
+// 						fieldname: "completed_qty",
+// 						label: __("Completed Qty"),
+// 						read_only: 1,
+// 					},
+// 					{
+// 						fieldtype: "Link",
+// 						fieldname: "uom",
+// 						label: __("UOM"),
+// 						options: "UOM",
+// 						in_list_view: 1,
+// 						reqd: 1,
+// 						onchange() {
+// 							const me = this;
+
+// 							if (!me.doc.item_code || !me.value) return;
+
+// 							frappe.call({
+// 								method:
+// 									"erpnext.stock.get_item_details.get_conversion_factor",
+// 								args: {
+// 									item_code: me.doc.item_code,
+// 									uom: me.value,
+// 								},
+// 								callback(r) {
+// 									if (!r.exc && r.message) {
+// 										me.doc.conversion_factor =
+// 											r.message.conversion_factor;
+// 										dialog.fields_dict.items_table.grid.refresh();
+// 									}
+// 								},
+// 							});
+// 						},
+// 					},
+// 					{
+// 						fieldtype: "Float",
+// 						fieldname: "conversion_factor",
+// 						label: __("Conversion Factor"),
+// 						in_list_view: 1,
+// 						read_only: 1,
+// 					},
+// 					{
+// 						fieldtype: "Currency",
+// 						fieldname: "rate",
+// 						label: __("Rate"),
+// 					},
+// 					{
+// 						fieldtype: "Link",
+// 						fieldname: "warehouse",
+// 						label: __("Warehouse"),
+// 						options: "Warehouse",
+// 						in_list_view: 1,
+// 						reqd: 1,
+// 					},
+// 					{
+// 						fieldtype: "Date",
+// 						fieldname: "schedule_date",
+// 						label: __("Required By"),
+// 						in_list_view: 1,
+// 						reqd: 1,
+// 					},
+// 				],
+// 			},
+// 		],
+
+// 		primary_action_label: __("Apply"),
+// 		primary_action() {
+// 			const values = dialog.get_values();
+// 			if (!values) return;
+
+// 			const trans_items = values.items_table
+// 				.filter((d) => !!d.item_code)
+// 				.map((d) => ({
+// 					docname: d.docname,
+// 					item_code: d.item_code,
+// 					qty: flt(d.qty),
+// 					uom: d.uom,
+// 					rate: d.rate,
+// 					conversion_factor: flt(d.conversion_factor) || 1,
+// 					warehouse: d.warehouse,
+// 					schedule_date: d.schedule_date,
+// 				}));
+
+// 			frappe.call({
+// 				method:
+// 					"erpnext.stock.doctype.material_request.material_request.update_items_after_submit",
+// 				freeze: true,
+// 				freeze_message: __("Updating Material Request..."),
+// 				args: {
+// 					mr_name: frm.doc.name,
+// 					trans_items: trans_items,
+// 				},
+// 				callback() {
+// 					frm.reload_doc();
+// 					dialog.hide();
+// 				},
+// 			});
+// 		},
+// 	});
+
+// 	dialog.show();
+// }

--- a/erpnext/stock/doctype/material_request/material_request.js
+++ b/erpnext/stock/doctype/material_request/material_request.js
@@ -656,179 +656,184 @@ function set_schedule_date(frm) {
 		);
 	}
 }
-// frappe.ui.form.on("Material Request", {
-// 	refresh(frm) {
-// 		if (
-// 			frm.doc.docstatus === 1 &&
-// 			frm.doc.material_request_type === "Purchase" &&
-// 			flt(frm.doc.per_ordered) < 100 &&
-// 			frm.doc.status !== "Stopped"
-// 		) {
-// 			// Add button ONLY once
-// 			if (!frm.custom_buttons || !frm.custom_buttons[__("Update Items")]) {
-// 				frm.add_custom_button(
-// 					__("Update Items"),
-// 					() => open_update_items_dialog(frm)
-// 				).addClass("btn-primary");
-// 			}
-// 		}
-// 	},
-// });
+frappe.ui.form.on("Material Request", {
+	refresh(frm) {
+		if (
+			frm.doc.docstatus === 1 &&
+			frm.doc.material_request_type === "Purchase" &&
+			flt(frm.doc.per_ordered) < 100 &&
+			frm.doc.status !== "Stopped"
+		) {
+			// Add button ONLY once
+			if (!frm.custom_buttons || !frm.custom_buttons[__("Update Items")]) {
+				frm.add_custom_button(
+					__("Update Items"),
+					() => open_update_items_dialog(frm)
+				).addClass("btn-primary");
+			}
+		}
+	},
+});
 
 
 
-// function open_update_items_dialog(frm) {
-// 	const table_data = frm.doc.items.map((d) => ({
-// 		docname: d.name,
-// 		item_code: d.item_code,
-// 		qty: flt(d.qty),
-// 		completed_qty: flt(d.ordered_qty),
-// 		uom: d.uom,
-// 		conversion_factor: d.conversion_factor,
-// 		rate: d.rate,
-// 		warehouse: d.warehouse,
-// 		schedule_date: d.schedule_date,
-// 	}));
+function open_update_items_dialog(frm) {
+	const table_data = frm.doc.items.map((d) => ({
+		docname: d.name,
+		item_code: d.item_code,
+		qty: flt(d.qty),
+		completed_qty: flt(d.ordered_qty),
+		uom: d.uom,
+		conversion_factor: d.conversion_factor,
+		rate: d.rate,
+		warehouse: d.warehouse,
+		schedule_date: d.schedule_date,
+	}));
 
-// 	const dialog = new frappe.ui.Dialog({
-// 		title: __("Update Material Request Items"),
-// 		size: "extra-large",
-// 		fields: [
-// 			{
-// 				fieldname: "items_table",
-// 				fieldtype: "Table",
-// 				label: __("Items"),
-// 				in_place_edit: false,
-// 				data: table_data,
-// 				get_data: () => table_data,
-// 				fields: [
-// 					{
-// 						fieldtype: "Data",
-// 						fieldname: "docname",
-// 						hidden: 1,
-// 						read_only: 1,
-// 					},
-// 					{
-// 						fieldtype: "Link",
-// 						fieldname: "item_code",
-// 						label: __("Item Code"),
-// 						options: "Item",
-// 						in_list_view: 1,
-// 						reqd: 1,
-// 						get_query() {
-// 							return {
-// 								query: "erpnext.controllers.queries.item_query",
-// 								filters: { is_purchase_item: 1 },
-// 							};
-// 						},
-// 					},
-// 					{
-// 						fieldtype: "Float",
-// 						fieldname: "qty",
-// 						label: __("Qty"),
-// 						in_list_view: 1,
-// 						reqd: 1,
-// 					},
-// 					{
-// 						fieldtype: "Float",
-// 						fieldname: "completed_qty",
-// 						label: __("Completed Qty"),
-// 						read_only: 1,
-// 					},
-// 					{
-// 						fieldtype: "Link",
-// 						fieldname: "uom",
-// 						label: __("UOM"),
-// 						options: "UOM",
-// 						in_list_view: 1,
-// 						reqd: 1,
-// 						onchange() {
-// 							const me = this;
+	const dialog = new frappe.ui.Dialog({
+		title: __("Update Material Request Items"),
+		size: "extra-large",
+		fields: [
+			{
+				fieldname: "items_table",
+				fieldtype: "Table",
+				label: __("Items"),
+				in_place_edit: false,
+				data: table_data,
+				get_data: () => table_data,
+				fields: [
+					{
+						fieldtype: "Data",
+						fieldname: "docname",
+						hidden: 1,
+						read_only: 1,
+					},
+					{
+						fieldtype: "Link",
+						fieldname: "item_code",
+						label: __("Item Code"),
+						options: "Item",
+						in_list_view: 1,
+						reqd: 1,
+						get_query() {
+							return {
+								query: "erpnext.controllers.queries.item_query",
+								filters: { is_purchase_item: 1 },
+							};
+						},
+					},
+					{
+						fieldtype: "Float",
+						fieldname: "qty",
+						label: __("Qty"),
+						in_list_view: 1,
+						reqd: 1,
+					},
+					{
+						fieldtype: "Float",
+						fieldname: "completed_qty",
+						label: __("Completed Qty"),
+						read_only: 1,
+					},
+					{
+						fieldtype: "Link",
+						fieldname: "uom",
+						label: __("UOM"),
+						options: "UOM",
+						in_list_view: 1,
+						reqd: 1,
+						onchange() {
+							const me = this;
 
-// 							if (!me.doc.item_code || !me.value) return;
+							if (!me.doc.item_code || !me.value) return;
 
-// 							frappe.call({
-// 								method:
-// 									"erpnext.stock.get_item_details.get_conversion_factor",
-// 								args: {
-// 									item_code: me.doc.item_code,
-// 									uom: me.value,
-// 								},
-// 								callback(r) {
-// 									if (!r.exc && r.message) {
-// 										me.doc.conversion_factor =
-// 											r.message.conversion_factor;
-// 										dialog.fields_dict.items_table.grid.refresh();
-// 									}
-// 								},
-// 							});
-// 						},
-// 					},
-// 					{
-// 						fieldtype: "Float",
-// 						fieldname: "conversion_factor",
-// 						label: __("Conversion Factor"),
-// 						in_list_view: 1,
-// 						read_only: 1,
-// 					},
-// 					{
-// 						fieldtype: "Currency",
-// 						fieldname: "rate",
-// 						label: __("Rate"),
-// 					},
-// 					{
-// 						fieldtype: "Link",
-// 						fieldname: "warehouse",
-// 						label: __("Warehouse"),
-// 						options: "Warehouse",
-// 						in_list_view: 1,
-// 						reqd: 1,
-// 					},
-// 					{
-// 						fieldtype: "Date",
-// 						fieldname: "schedule_date",
-// 						label: __("Required By"),
-// 						in_list_view: 1,
-// 						reqd: 1,
-// 					},
-// 				],
-// 			},
-// 		],
+							frappe.call({
+								method:
+									"erpnext.stock.get_item_details.get_conversion_factor",
+								args: {
+									item_code: me.doc.item_code,
+									uom: me.value,
+								},
+								callback(r) {
+									if (!r.exc && r.message) {
+										me.doc.conversion_factor =
+											r.message.conversion_factor;
+										dialog.fields_dict.items_table.grid.refresh();
+									}
+								},
+							});
+						},
+					},
+					{
+						fieldtype: "Float",
+						fieldname: "conversion_factor",
+						label: __("Conversion Factor"),
+						in_list_view: 1,
+						read_only: 1,
+					},
+					{
+						fieldtype: "Currency",
+						fieldname: "rate",
+						label: __("Rate"),
+					},
+					{
+						fieldtype: "Link",
+						fieldname: "warehouse",
+						label: __("Warehouse"),
+						options: "Warehouse",
+						in_list_view: 1,
+						reqd: 1,
+					},
+					{
+						fieldtype: "Date",
+						fieldname: "schedule_date",
+						label: __("Required By"),
+						in_list_view: 1,
+						reqd: 1,
+					},
+				],
+			},
+		],
 
-// 		primary_action_label: __("Apply"),
-// 		primary_action() {
-// 			const values = dialog.get_values();
-// 			if (!values) return;
+		primary_action_label: __("Apply"),
+		primary_action() {
+			const values = dialog.get_values();
+			if (!values) return;
 
-// 			const trans_items = values.items_table
-// 				.filter((d) => !!d.item_code)
-// 				.map((d) => ({
-// 					docname: d.docname,
-// 					item_code: d.item_code,
-// 					qty: flt(d.qty),
-// 					uom: d.uom,
-// 					rate: d.rate,
-// 					conversion_factor: flt(d.conversion_factor) || 1,
-// 					warehouse: d.warehouse,
-// 					schedule_date: d.schedule_date,
-// 				}));
+			const trans_items = values.items_table
+				.filter((d) => !!d.item_code)
+				.map((d) => ({
+					docname: d.docname,
+					item_code: d.item_code,
+					qty: flt(d.qty),
+					uom: d.uom,
+					rate: d.rate,
+					conversion_factor: flt(d.conversion_factor) || 1,
+					warehouse: d.warehouse,
+					schedule_date: d.schedule_date,
+				}));
 
-// 			frappe.call({
-// 				method:
-// 					"erpnext.stock.doctype.material_request.material_request.update_items_after_submit",
-// 				freeze: true,
-// 				freeze_message: __("Updating Material Request..."),
-// 				args: {
-// 					mr_name: frm.doc.name,
-// 					trans_items: trans_items,
-// 				},
-// 				callback() {
-// 					frm.reload_doc();
-// 					dialog.hide();
-// 				},
-// 			});
-// 		},
-// 	});
+			frappe.call({
+				method:
+					"erpnext.stock.doctype.material_request.material_request.update_items_after_submit",
+				freeze: true,
+				freeze_message: __("Updating Material Request..."),
+				args: {
+					mr_name: frm.doc.name,
+					trans_items: trans_items,
+				},
+				callback() {
+					frm.reload_doc();
+					dialog.hide();
+				},
+			});
+		},
+	});
 
-// 	dialog.show();
-// }
+	dialog.show();
+}
+
+
+
+
+

--- a/erpnext/stock/doctype/material_request/material_request.py
+++ b/erpnext/stock/doctype/material_request/material_request.py
@@ -881,18 +881,6 @@ def make_in_transit_stock_entry(source_name, in_transit_warehouse):
 
 
 @frappe.whitelist()
-def make_in_transit_stock_entry(source_name, in_transit_warehouse):
-	ste_doc = make_stock_entry(source_name)
-	ste_doc.add_to_transit = 1
-	ste_doc.to_warehouse = in_transit_warehouse
-
-	for row in ste_doc.items:
-		row.t_warehouse = in_transit_warehouse
-
-	return ste_doc
-
-
-@frappe.whitelist()
 def update_items_after_submit(mr_name=None, trans_items=None):
 	if not mr_name:
 		frappe.throw(_("Material Request name is required"))

--- a/erpnext/stock/doctype/material_request/material_request.py
+++ b/erpnext/stock/doctype/material_request/material_request.py
@@ -878,3 +878,89 @@ def make_in_transit_stock_entry(source_name, in_transit_warehouse):
 		row.t_warehouse = in_transit_warehouse
 
 	return ste_doc
+
+
+@frappe.whitelist()
+def make_in_transit_stock_entry(source_name, in_transit_warehouse):
+	ste_doc = make_stock_entry(source_name)
+	ste_doc.add_to_transit = 1
+	ste_doc.to_warehouse = in_transit_warehouse
+
+	for row in ste_doc.items:
+		row.t_warehouse = in_transit_warehouse
+
+	return ste_doc
+
+
+@frappe.whitelist()
+def update_items_after_submit(mr_name=None, trans_items=None):
+	if not mr_name:
+		frappe.throw(_("Material Request name is required"))
+
+	if isinstance(trans_items, str):
+		trans_items = frappe.parse_json(trans_items)
+
+	mr = frappe.get_doc("Material Request", mr_name)
+
+	# allow update after submit
+	mr.flags.ignore_validate_update_after_submit = True
+	mr.flags.ignore_validate = True
+	mr.flags.ignore_mandatory = True
+
+	existing_rows = {d.name: d for d in mr.items}
+	incoming_rows = {d.get("docname") for d in trans_items if d.get("docname")}
+
+	# DELETE removed rows
+	for rowname, row in existing_rows.items():
+		if rowname not in incoming_rows:
+			if flt(row.ordered_qty) > 0:
+				frappe.throw(
+					_("Cannot delete Item {0} because Completed Qty exists").format(row.item_code)
+				)
+			mr.remove(row)
+
+	# ADD / UPDATE rows
+	for d in trans_items:
+		if not d.get("item_code"):
+			continue
+
+		if d.get("docname") and d.get("docname") in existing_rows:
+			child = existing_rows[d.get("docname")]
+		else:
+			child = mr.append("items", {})
+
+		qty = flt(d.get("qty"))
+		conversion_factor = flt(d.get("conversion_factor")) or 1
+		stock_qty = qty * conversion_factor
+
+		if flt(child.ordered_qty) and stock_qty <= flt(child.ordered_qty):
+			frappe.throw(
+				_("Updated Qty must be greater than Completed Qty for Item {0}")
+				.format(d.get("item_code"))
+			)
+
+		child.item_code = d.get("item_code")
+		child.qty = qty
+		child.uom = d.get("uom")
+		child.rate = flt(d.get("rate"))
+		child.conversion_factor = conversion_factor
+		child.stock_qty = stock_qty
+		child.warehouse = d.get("warehouse")
+		child.schedule_date = d.get("schedule_date")
+
+	# SAVE ONCE (VERY IMPORTANT)
+	mr.save(ignore_permissions=True)
+
+
+
+
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
### Problem

In real-world purchase workflows, a Material Request is often created for a larger quantity, while Purchase Orders are raised partially based on availability, budget, or supplier constraints.

Example:
- Material Request is submitted for 100 units
- A Purchase Order is created for  50 units
- Material Request moves to  Partially Ordered

At this stage, the remaining quantity (50 units) often requires changes such as:
- Quantity adjustment
- Warehouse change
- Rate update
- Required date modification

Currently, ERPNext does not provide a standard way to update item details on a submitted, partially ordered PurchaseMaterial Request. Users are forced to cancel and recreate the document even when only the remaining quantity needs correction.

---

### Solution

This PR introduces a controlled 'Update Items' action for submitted Purchase Material Requests that are not fully ordered.

The feature allows users to safely update remaining item details while preserving data integrity and existing workflows.

---

### Key Features

- Adds Update Items action for submitted Purchase Material Requests
- Allows updating:
  - Quantity (remaining only)
  - UOM and conversion factor
  - Rate
  - Warehouse
  - Required date
- Prevents reducing quantity below the completed (ordered) quantity
- Disallows deletion of rows with completed quantity
- All validations and updates handled server-side
- Parent document is saved once to avoid inconsistencies

---

### Scope

- Material Request (Purchase)
- Client-side dialog for item updates
- Server-side validation and persistence logic

---

###
[Screencast from 2026-01-05 22-08-31.webm](https://github.com/user-attachments/assets/ab31a2b6-b61c-4f64-abbd-8d1e9a41cddd)
 Backward Compatibility

No impact on existing workflows.  
The feature is opt-in via UI action and applies only to submitted Purchase Material Requests that are not fully ordered.


