### PR TITLE
fix: add docstatus condition to get_sales_invoice_item function

### DIFF
--- a/erpnext/accounts/doctype/pos_invoice_merge_log/pos_invoice_merge_log.py
+++ b/erpnext/accounts/doctype/pos_invoice_merge_log/pos_invoice_merge_log.py
@@ -697,6 +697,7 @@ def get_sales_invoice_item(return_against_pos_invoice, pos_invoice_item):
 				& (SalesInvoice.is_return == 0)
 				& (SalesInvoiceItem.pos_invoice == return_against_pos_invoice)
 				& (SalesInvoiceItem.pos_invoice_item == pos_invoice_item)
+				& (SalesInvoice.docstatus == 1)
 			)
 		)
 


### PR DESCRIPTION
fix: add docstatus=1 filter to get_sales_invoice_item

- Ensure only submitted sales invoice items are fetched
- Prevent fetching cancelled/draft invoice items

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Sales Invoice item lookup to only match submitted invoices, preventing unfinalized transactions from being incorrectly included in merge operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->