### PR TITLE
fix: change float types in payment entry reference table to currency

### DIFF
--- a/erpnext/accounts/doctype/payment_entry_reference/payment_entry_reference.json
+++ b/erpnext/accounts/doctype/payment_entry_reference/payment_entry_reference.json
@@ -70,7 +70,7 @@
   {
    "columns": 2,
    "fieldname": "total_amount",
-   "fieldtype": "Float",
+   "fieldtype": "Currency",
    "in_list_view": 1,
    "label": "Grand Total",
    "print_hide": 1,
@@ -79,7 +79,7 @@
   {
    "columns": 2,
    "fieldname": "outstanding_amount",
-   "fieldtype": "Float",
+   "fieldtype": "Currency",
    "in_list_view": 1,
    "label": "Outstanding",
    "read_only": 1
@@ -87,7 +87,7 @@
   {
    "columns": 2,
    "fieldname": "allocated_amount",
-   "fieldtype": "Float",
+   "fieldtype": "Currency",
    "in_list_view": 1,
    "label": "Allocated"
   },
@@ -176,7 +176,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-12-08 13:57:30.098239",
+ "modified": "2026-01-05 14:18:03.286224",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Payment Entry Reference",

--- a/erpnext/accounts/doctype/payment_entry_reference/payment_entry_reference.py
+++ b/erpnext/accounts/doctype/payment_entry_reference/payment_entry_reference.py
@@ -18,12 +18,12 @@ class PaymentEntryReference(Document):
 		account_type: DF.Data | None
 		advance_voucher_no: DF.DynamicLink | None
 		advance_voucher_type: DF.Link | None
-		allocated_amount: DF.Float
+		allocated_amount: DF.Currency
 		bill_no: DF.Data | None
 		due_date: DF.Date | None
 		exchange_gain_loss: DF.Currency
 		exchange_rate: DF.Float
-		outstanding_amount: DF.Float
+		outstanding_amount: DF.Currency
 		parent: DF.Data
 		parentfield: DF.Data
 		parenttype: DF.Data
@@ -34,7 +34,7 @@ class PaymentEntryReference(Document):
 		reconcile_effect_on: DF.Date | None
 		reference_doctype: DF.Link
 		reference_name: DF.DynamicLink
-		total_amount: DF.Float
+		total_amount: DF.Currency
 	# end: auto-generated types
 
 	@property


### PR DESCRIPTION
Almost all the numbers in the payment entry doctype are currency as they should be. However, in the Payment References table, for some reason they are floats. This is inconsistent and an eyesore. All numbers referring to money should be currency field type. If for some reason, someone wants to change the number of significant digits in that table, they can customize the "payment entry reference" form, but the default should be consistent for all money amounts on the "payment entry" form.

Closes https://github.com/frappe/erpnext/issues/51527

PLEASE Backport to version-15

### Before: 
<img width="1138" height="1248" alt="Payment-Entry-Before" src="https://github.com/user-attachments/assets/7cc861f9-0771-4164-9142-2774149158d3" />

### After:
<img width="1174" height="1195" alt="Payment-Entry-After" src="https://github.com/user-attachments/assets/abfa1b23-64e7-4d50-8e52-e5f39b5f11e1" />

