### PR TITLE
fix: correct sales order item deletion message for MR and PO linkage

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -3748,7 +3748,7 @@ def validate_child_on_delete(row, parent, ordered_item=None):
 			)
 		if flt(row.ordered_qty):
 			frappe.throw(
-				_("Row #{0}: Cannot delete item {1} which is assigned to customer's purchase order.").format(
+				_("Row #{0}: Cannot delete item {1} which is already ordered against this Sales Order.").format(
 					row.idx, row.item_code
 				)
 			)


### PR DESCRIPTION
Issue: Sales Order Item deletion message incorrect for MR and PO linkage

Ref: [#56421](https://support.frappe.io/helpdesk/tickets/56421)

Description:
When deleting an item from a Sales Order that is already linked to a Material Request or Purchase Order, the validation error message incorrectly indicates that the item is linked only to a Purchase Order.
To address this, the validation message has been updated to correctly mention both Material Request and Purchase Order, ensuring the user receives accurate information when attempting to delete such items.

Before:


https://github.com/user-attachments/assets/460254cb-b5e3-4c24-83bc-e14ce1f2ab1f

After:


https://github.com/user-attachments/assets/6d9ddccb-2ae5-4708-bbc2-a35674472c3b





