### PR TITLE
fix: correct uom reflecting in sales order when fetching from..

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -555,10 +555,11 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 
 		var item = frappe.get_doc(cdt, cdn);
 		var update_stock = 0, show_batch_dialog = 0;
-
 		item.weight_per_unit = 0;
 		item.weight_uom = '';
-		item.uom = null // make UOM blank to update the existing UOM when item changes
+		if(!item.barcode){
+			item.uom = null // make UOM blank to update the existing UOM when item changes
+		}
 		item.conversion_factor = 0;
 
 		if(['Sales Invoice', 'Purchase Invoice'].includes(this.frm.doc.doctype)) {
@@ -573,6 +574,7 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 		if (show_batch_dialog && item.use_serial_batch_fields === 1) {
 			show_batch_dialog = 0;
 		}
+
 
 		item.barcode = null;
 

--- a/erpnext/public/js/utils/barcode_scanner.js
+++ b/erpnext/public/js/utils/barcode_scanner.js
@@ -404,6 +404,8 @@ erpnext.utils.BarcodeScanner = class BarcodeScanner {
 	async set_barcode(row, barcode) {
 		if (barcode && frappe.meta.has_field(row.doctype, this.barcode_field)) {
 			await frappe.model.set_value(row.doctype, row.name, this.barcode_field, barcode);
+		} else {
+			row.barcode = barcode;
 		}
 	}
 


### PR DESCRIPTION
This fixes: https://github.com/frappe/erpnext/issues/51381

The uom was not correctly reflecting incase of fetching item from barcode in sales order, this fixes it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Unit of Measure (UOM) handling to preserve existing values when items have barcodes
  * Enhanced barcode assignment for transaction types that don't have dedicated barcode fields

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->