### PR TITLE
fix(mode of payment): use valid syntax

### DIFF
--- a/erpnext/accounts/doctype/mode_of_payment/mode_of_payment.js
+++ b/erpnext/accounts/doctype/mode_of_payment/mode_of_payment.js
@@ -7,7 +7,7 @@ frappe.ui.form.on("Mode of Payment", {
 			let d = locals[cdt][cdn];
 			return {
 				filters: [
-					["Account", "account_type", "in", "Bank, Cash, Receivable"],
+					["Account", "account_type", "in", ["Bank", "Cash", "Receivable"]],
 					["Account", "is_group", "=", 0],
 					["Account", "company", "=", d.company],
 				],


### PR DESCRIPTION
**Issue:**
While selecting a Cash Account in the Mode of Payment, the account does not appear in the list, even though the cash account has already been created in the system. 

**Ref:** [#56825](https://support.frappe.io/helpdesk/tickets/56825)

**Before:**

<img width="944" height="648" alt="Before" src="https://github.com/user-attachments/assets/e8377c16-765c-45e3-9844-f32f7dea383e" />

**After:**
<img width="1795" height="926" alt="After" src="https://github.com/user-attachments/assets/df944303-ecc6-4818-9fea-e1f7df9d53a3" />


