### PR TITLE
fix: unsaved status on opening gain loss journal

### DIFF
--- a/erpnext/accounts/doctype/journal_entry/journal_entry.js
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.js
@@ -126,9 +126,11 @@ frappe.ui.form.on("Journal Entry", {
 
 		erpnext.accounts.unreconcile_payment.add_unreconcile_btn(frm);
 
-		$.each(frm.doc.accounts || [], function (i, row) {
-			erpnext.journal_entry.set_exchange_rate(frm, row.doctype, row.name);
-		});
+		if (frm.doc.voucher_type !== "Exchange Gain Or Loss") {
+			$.each(frm.doc.accounts || [], function (i, row) {
+				erpnext.journal_entry.set_exchange_rate(frm, row.doctype, row.name);
+			});
+		}
 	},
 	before_save: function (frm) {
 		if (frm.doc.docstatus == 0 && !frm.doc.is_system_generated) {


### PR DESCRIPTION
<img width="1084" height="321" alt="Screenshot from 2026-01-06 17-40-16" src="https://github.com/user-attachments/assets/5fdff53e-4b62-4ba3-b280-0ddb94f588f9" />

Debit and Credit will always differ with Debit In Account Currency  and Credit In Account Currency for Exchange Gain Or Loss journals. This is by design.