### PR TITLE
feat: show all items checkbox in item shortage report

### DIFF
--- a/erpnext/stock/report/item_shortage_report/item_shortage_report.js
+++ b/erpnext/stock/report/item_shortage_report/item_shortage_report.js
@@ -19,8 +19,17 @@ frappe.query_reports["Item Shortage Report"] = {
 			options: "Warehouse",
 			width: "100",
 			get_data: function (txt) {
-				return frappe.db.get_link_options("Warehouse", txt);
+				return frappe.db.get_link_options("Warehouse", txt, {
+					is_group: 0,
+					company: frappe.query_report.get_filter_value("company"),
+				});
 			},
+		},
+		{
+			fieldname: "show_all",
+			label: __("Show All Items"),
+			fieldtype: "Check",
+			default: 0,
 		},
 	],
 };

--- a/erpnext/stock/report/item_shortage_report/item_shortage_report.py
+++ b/erpnext/stock/report/item_shortage_report/item_shortage_report.py
@@ -40,12 +40,7 @@ def get_data(filters):
 			item.item_name,
 			item.description,
 		)
-		.where(
-			(item.disabled == 0)
-			& (bin.projected_qty < 0)
-			& (wh.name == bin.warehouse)
-			& (bin.item_code == item.name)
-		)
+		.where((item.disabled == 0) & (wh.name == bin.warehouse) & (bin.item_code == item.name))
 		.orderby(bin.projected_qty)
 	)
 
@@ -54,6 +49,9 @@ def get_data(filters):
 
 	if filters.get("company"):
 		query = query.where(wh.company == filters.get("company"))
+
+	if not filters.get("show_all"):
+		query = query.where(bin.projected_qty < 0)
 
 	return query.run(as_dict=True)
 


### PR DESCRIPTION
Item Shortage report now has an option to show all items as "shortage" may mean different things/values for different use cases/people

`no-docs`