### PR TITLE
fix(pos): removed white space from the bottom of pos screen

### DIFF
--- a/erpnext/public/scss/point-of-sale.scss
+++ b/erpnext/public/scss/point-of-sale.scss
@@ -6,8 +6,8 @@
 
 	section {
 		min-height: 30rem;
-		height: calc(100vh - 125px);
-		max-height: calc(100vh - 125px);
+		height: calc(100vh - 5rem);
+		max-height: calc(100vh - 5rem);
 	}
 
 	.frappe-control {


### PR DESCRIPTION
Removed the whitespace from the bottom of the POS Screen for v16.

Before:

<img width="2940" height="1670" alt="image" src="https://github.com/user-attachments/assets/9743490a-ae20-479a-a7dd-a2e1ea804e5e" />

After:

<img width="2940" height="1674" alt="image" src="https://github.com/user-attachments/assets/b0adb65b-576f-41a4-aa76-487eeedf326d" />
