### PR TITLE
fix: remove posting date & time on SRE batch validation

### DIFF
--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -2337,8 +2337,6 @@ def validate_reserved_batch_nos(kwargs):
 				{
 					"item_code": kwargs.item_code,
 					"warehouse": kwargs.warehouse,
-					"posting_date": kwargs.posting_date,
-					"posting_time": kwargs.posting_time,
 					"ignore_voucher_nos": kwargs.ignore_voucher_nos,
 					"ignore_reserved_stock": True,
 				}


### PR DESCRIPTION
**Issue:** Unable to create backdated outward entry for batch item with available qty.

**Ref: [52652](https://support.frappe.io/helpdesk/tickets/52652?view=VIEW-HD+Ticket-003)**

**Solution:** Since, we are not maintaining posting date and time in stock reservation entry, validation for unreserved batch quantity should also follow the same. Removed posting date & time filter while getting available batch quantities. 

**Steps to replicate:**
(Enable Stock Reservation in Stock Settings)

1) Create a new Batch Item

2) Create a new Stock Entry of Type Material Receipt and Select Date as 01-12-25 and enter qty as 300.

3) Create a another new Stock Entry of Type Material Receipt and Select Date as 23-12-25 and enter qty as 300 and select the same batch that created in Previous Stock Entry.

4) Create a Sales Order for 450 qty. Create a Pick List and select the batch created by stock entry. And Reserve the Stock

Now Overall batch balance is 600, Reserved qty on that batch is 450 and available to consume is 150 qty.

5) Now make a back dated Stock Entry of type Material Transfer and select the batch, enter qty as 150.

On submitting this material transfer, system throws error for Stock Reservation. But even after this entry there is enough stock for stock reservation and the stock balance will not go negative.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined batch availability filtering during reserved batch allocation, adjusting how eligible batches are identified in the reservation process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->