### PR TITLE
fix(postgres): validate against period closing using MAX(period_end_date)

### DIFF
--- a/erpnext/accounts/general_ledger.py
+++ b/erpnext/accounts/general_ledger.py
@@ -809,17 +809,14 @@ def validate_against_pcv(is_opening, posting_date, company):
 
 	pcv = frappe.qb.DocType("Period Closing Voucher")
 
-	# Some installs use period_end_date; others may only have posting_date.
-	meta = frappe.get_meta("Period Closing Voucher")
-	date_field = "period_end_date" if meta.has_field("period_end_date") else "posting_date"
-	date_col = getattr(pcv, date_field)
-
 	last_pcv_date = (
-		frappe.qb.from_(pcv).select(Max(date_col)).where((pcv.docstatus == 1) & (pcv.company == company))
+		frappe.qb.from_(pcv)
+		.select(Max(pcv.period_end_date))
+		.where((pcv.docstatus == 1) & (pcv.company == company))
 	).run(pluck=True)[0]
 
 	if last_pcv_date and getdate(posting_date) <= getdate(last_pcv_date):
-		message = _("Books have been closed till the period ending on {0}").format(formatdate(last_pcv_date))
+		message = _("Books have been closed till the period ending on {0}.").format(formatdate(last_pcv_date))
 		message += "</br >"
 		message += _("You cannot create/amend any accounting entries till this date.")
 		frappe.throw(message, title=_("Period Closed"))

--- a/erpnext/accounts/general_ledger.py
+++ b/erpnext/accounts/general_ledger.py
@@ -804,9 +804,19 @@ def validate_against_pcv(is_opening, posting_date, company):
 			title=_("Invalid Opening Entry"),
 		)
 
-	last_pcv_date = frappe.db.get_value(
-		"Period Closing Voucher", {"docstatus": 1, "company": company}, "max(period_end_date)"
-	)
+	# Local import so you don't have to touch file-level imports
+	from frappe.query_builder.functions import Max
+
+	pcv = frappe.qb.DocType("Period Closing Voucher")
+
+	# Some installs use period_end_date; others may only have posting_date.
+	meta = frappe.get_meta("Period Closing Voucher")
+	date_field = "period_end_date" if meta.has_field("period_end_date") else "posting_date"
+	date_col = getattr(pcv, date_field)
+
+	last_pcv_date = (
+		frappe.qb.from_(pcv).select(Max(date_col)).where((pcv.docstatus == 1) & (pcv.company == company))
+	).run(pluck=True)[0]
 
 	if last_pcv_date and getdate(posting_date) <= getdate(last_pcv_date):
 		message = _("Books have been closed till the period ending on {0}").format(formatdate(last_pcv_date))


### PR DESCRIPTION
### Summary

Fix Postgres failure in `validate_against_pcv` by avoiding aggregate queries that introduce non-aggregated ordering.

### Problem

Submitting accounting entries on Postgres can fail during `validate_against_pcv` when computing the latest Period Closing Voucher date, due to strict GROUP BY / ORDER BY rules.

### Fix

Compute the latest closing date using Query Builder:

- select `MAX(period_end_date)` for submitted vouchers (`docstatus == 1`) for the company
- no ordering or grouping side-effects

This is portable and avoids DB-specific behavior in aggregate lookups.

### Tests

- `pre-commit run --all-files` ✅
- Manual: Sales Invoice submit proceeds past PCV validation on Postgres.


### Additional note
@ruthra-kumar trying again with a smaller edit against version-15-hotfix. The cherry pick read "1 file changed, 13 insertions(+), 3 deletions(-)"


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Period Closing Voucher validation: the system now more reliably determines the most recent closing date, reducing false rejections of entries due to incorrect date comparisons.
  * Minor clarification to the validation error message text for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->