### PR TITLE
fix(postgres): use LIMIT/OFFSET in item_query

### DIFF
--- a/erpnext/controllers/queries.py
+++ b/erpnext/controllers/queries.py
@@ -257,7 +257,7 @@ def item_query(doctype, txt, searchfield, start, page_len, filters, as_dict=Fals
 			if(locate(%(_txt)s, item_name), locate(%(_txt)s, item_name), 99999),
 			idx desc,
 			name, item_name
-		limit %(start)s, %(page_len)s """.format(
+		limit %(page_len)s OFFSET %(start)s """.format(
 			columns=columns,
 			scond=searchfields,
 			fcond=get_filters_cond(doctype, filters, conditions).replace("%", "%%"),


### PR DESCRIPTION
### Summary

Fix Postgres crash in `erpnext.controllers.queries.item_query` caused by MySQL-style pagination (`LIMIT start, page_len`).

### Problem

On Postgres, link-field search for Items (e.g. Sales Invoice → Item field autocomplete) can fail with:

```

psycopg2.errors.SyntaxError: LIMIT #,# syntax is not supported
HINT: Use separate LIMIT and OFFSET clauses.

```

Root cause: `item_query` uses `LIMIT %(start)s, %(page_len)s` which is valid in MariaDB/MySQL but invalid in Postgres.

### Fix

Switch pagination in `item_query` to the portable form:

- from: `LIMIT %(start)s, %(page_len)s`
- to:   `LIMIT %(page_len)s OFFSET %(start)s`

This syntax is supported by both Postgres and MariaDB/MySQL.

### Why this change

- Restores Item search/autocomplete functionality on Postgres
- Keeps behavior unchanged on MariaDB/MySQL (portable SQL)
- Minimal surface area: single-line change in `erpnext/controllers/queries.py`

### Tests

- `pre-commit run --all-files` ✅
- Manual: Sales Invoice → Item field search no longer errors on Postgres

### Notes

No business logic changes; server-side query only.


