### PR TITLE
fix: delete advance ledger entries  while reconciling payment entry

### DIFF
--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -547,6 +547,7 @@ def reconcile_against_document(
 				doc.make_advance_gl_entries(entry=row)
 		else:
 			_delete_pl_entries(voucher_type, voucher_no)
+			_delete_adv_pl_entries(voucher_type, voucher_no)
 			gl_map = doc.build_gl_map()
 			# Make sure there is no overallocation
 			from erpnext.accounts.general_ledger import process_debit_credit_difference

--- a/erpnext/buying/doctype/purchase_order/test_purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/test_purchase_order.py
@@ -1330,6 +1330,54 @@ class TestPurchaseOrder(IntegrationTestCase):
 		pi = make_pi_from_po(po.name)
 		self.assertEqual(pi.items[0].qty, 50)
 
+	def test_multiple_advances_againt_purchase_order_are_allocated_across_partial_purchase_invoices(self):
+		# step - 1: create PO
+		po = create_purchase_order(qty=10, rate=10)
+		po.save(ignore_permissions=True).submit()
+
+		# step - 2: create first partial advance payment
+		pe1 = get_payment_entry("Purchase Order", po.name, bank_account="_Test Bank - _TC")
+		pe1.reference_no = "1"
+		pe1.reference_date = nowdate()
+		pe1.paid_amount = 50
+		pe1.references[0].allocated_amount = 50
+		pe1.save(ignore_permissions=True).submit()
+
+		# check first advance paid agaist PO
+		po.reload()
+		self.assertEqual(po.advance_paid, 50)
+
+		# step - 3: create first PI for partial qty and allocate first advance
+		pi_1 = make_pi_from_po(po.name)
+		pi_1.update_stock = 1
+		pi_1.allocate_advances_automatically = 1
+		pi_1.items[0].qty = 5
+		pi_1.save(ignore_permissions=True).submit()
+
+		# step - 4: create second advance payment for remaining
+		pe2 = get_payment_entry("Purchase Order", po.name, bank_account="_Test Bank - _TC")
+		pe2.reference_no = "2"
+		pe2.reference_date = nowdate()
+		pe2.paid_amount = 50
+		pe2.references[0].allocated_amount = 50
+		pe2.save(ignore_permissions=True).submit()
+
+		# check second advance paid agaist PO
+		po.reload()
+		self.assertEqual(po.advance_paid, 100)
+
+		# step - 5: create second PI for remaining qty and allocate second advance
+		pi_2 = make_pi_from_po(po.name)
+		pi_2.update_stock = 1
+		pi_2.allocate_advances_automatically = 1
+		pi_2.save(ignore_permissions=True).submit()
+
+		# check PO and PI status
+		po.reload()
+		self.assertEqual(pi_1.status, "Paid")
+		self.assertEqual(pi_2.status, "Paid")
+		self.assertEqual(po.status, "Completed")
+
 
 def create_po_for_sc_testing():
 	from erpnext.controllers.tests.test_subcontracting_controller import (

--- a/erpnext/buying/doctype/purchase_order/test_purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/test_purchase_order.py
@@ -1330,10 +1330,9 @@ class TestPurchaseOrder(IntegrationTestCase):
 		pi = make_pi_from_po(po.name)
 		self.assertEqual(pi.items[0].qty, 50)
 
-	def test_multiple_advances_againt_purchase_order_are_allocated_across_partial_purchase_invoices(self):
+	def test_multiple_advances_against_purchase_order_are_allocated_across_partial_purchase_invoices(self):
 		# step - 1: create PO
 		po = create_purchase_order(qty=10, rate=10)
-		po.save(ignore_permissions=True).submit()
 
 		# step - 2: create first partial advance payment
 		pe1 = get_payment_entry("Purchase Order", po.name, bank_account="_Test Bank - _TC")
@@ -1374,6 +1373,8 @@ class TestPurchaseOrder(IntegrationTestCase):
 
 		# check PO and PI status
 		po.reload()
+		pi_1.reload()
+		pi_2.reload()
 		self.assertEqual(pi_1.status, "Paid")
 		self.assertEqual(pi_2.status, "Paid")
 		self.assertEqual(po.status, "Completed")

--- a/erpnext/buying/doctype/purchase_order/test_purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/test_purchase_order.py
@@ -1342,7 +1342,7 @@ class TestPurchaseOrder(IntegrationTestCase):
 		pe1.references[0].allocated_amount = 50
 		pe1.save(ignore_permissions=True).submit()
 
-		# check first advance paid agaist PO
+		# check first advance paid against PO
 		po.reload()
 		self.assertEqual(po.advance_paid, 50)
 
@@ -1361,7 +1361,7 @@ class TestPurchaseOrder(IntegrationTestCase):
 		pe2.references[0].allocated_amount = 50
 		pe2.save(ignore_permissions=True).submit()
 
-		# check second advance paid agaist PO
+		# check second advance paid against PO
 		po.reload()
 		self.assertEqual(po.advance_paid, 100)
 


### PR DESCRIPTION
**Issue:** When an advance payment is made against a Purchase Order, a partial Purchase Invoice is created and the advance amount from the first advance is allocated. However, after making a second advance against the same PO, the system calculates an incorrect advance_paid amount in the PO. The calculated value does not reflects the actual paid amount.

Ref: [49313](https://support.frappe.io/helpdesk/tickets/49313)

**Steps to Reproduce**
1) Create a Purchase Order with Quantity 10, Rate 10, and Total Amount 100.
2) Create a Payment Entry against the Purchase Order with Paid Amount 50.
3) Create a Purchase Invoice from the Purchase Order for Quantity 5 and allocate the advance.
4) Create another Payment Entry against the same Purchase Order with Paid Amount 50.
5) Observe that after submitting the second payment entry, the Advance Paid amount in the Purchase Order shows incorrect value.

**Before:** 

https://github.com/user-attachments/assets/693b8131-1013-41bf-b14a-5fdd686a7f3f

**After:**

https://github.com/user-attachments/assets/11177387-7c80-44aa-8d3c-2f605a175c3d