### PR TITLE
fix: skip plc_conversion_rate updation for mapped document

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -1394,7 +1394,8 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 		}
 		if (
 			this.frm.doc.currency === this.frm.doc.price_list_currency &&
-			this.frm.doc.plc_conversion_rate !== this.frm.doc.conversion_rate
+			this.frm.doc.plc_conversion_rate !== this.frm.doc.conversion_rate &&
+			!this.frm.doc.__onload?.load_after_mapping
 		) {
 			this.frm.set_value("plc_conversion_rate", this.frm.doc.conversion_rate);
 		}


### PR DESCRIPTION
**Issue:**  Unable to submit a Purchase Invoice created against a Purchase Receipt when multi-currency is involved, and the Currency Exchange Rate differs from the Price List Exchange Rate. 

When the Supplier Bill Date is updated on the Purchase Invoice, the system sets the Currency Exchange Rate to the Price List Exchange Rate, which alters the item rates. 

Since the `Maintain Same Rate Throughout the Purchase Cycle` option is enabled, the system blocks the submission of Purchase Invoices.

**Ref:** [56828](https://support.frappe.io/helpdesk/tickets/56828)

**Steps to Reproduce:**
**Step 1:** `Enable Maintain Same Rate Throughout the Purchase Cycle` in Buying Settings
**Step 2:** Create a Purchase Receipt for an overseas supplier with different exchange rates.
-    Exchange Rate: 103.200000000,
- Price List Exchange Rate: 103.102500000

**Step 3:** Create a Purchase Invoice against the above Purchase Receipt.
**Step 4:** Update the Supplier Invoice Number and Supplier Invoice Date on the Purchase Invoice.
**Step 5:** Attempt to save and submit the Purchase Invoice.

**Before:**

https://github.com/user-attachments/assets/75db4d0c-bf13-46ae-90f4-ac1d7e7bde0b

**After:**

https://github.com/user-attachments/assets/0103f857-525d-4eea-8827-2befa509c8e7

**Backport Needed V15**
