### PR TITLE
fix: negative stock issue for higher precision

### DIFF
--- a/erpnext/stock/doctype/delivery_note/test_delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/test_delivery_note.py
@@ -2789,6 +2789,23 @@ class TestDeliveryNote(IntegrationTestCase):
 						serial_batch_map[row.item_code].batch_no_valuation[entry.batch_no],
 					)
 
+	def test_negative_stock_with_higher_precision(self):
+		original_flt_precision = frappe.db.get_default("float_precision")
+		frappe.db.set_single_value("System Settings", "float_precision", 7)
+
+		item_code = make_item(
+			"Test Negative Stock High Precision Item", properties={"is_stock_item": 1, "valuation_rate": 1}
+		).name
+		dn = create_delivery_note(
+			item_code=item_code,
+			qty=0.0000010,
+			do_not_submit=True,
+		)
+
+		self.assertRaises(frappe.ValidationError, dn.submit)
+
+		frappe.db.set_single_value("System Settings", "float_precision", original_flt_precision)
+
 
 def create_delivery_note(**args):
 	dn = frappe.new_doc("Delivery Note")

--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -1176,7 +1176,11 @@ class update_entries_after:
 		diff = self.wh_data.qty_after_transaction + flt(sle.actual_qty) - flt(self.reserved_stock)
 		diff = flt(diff, self.flt_precision)  # respect system precision
 
-		if diff < 0 and abs(diff) > 0.0001:
+		diff_threshold = 0.0001
+		if self.flt_precision > 4:
+			diff_threshold = 10 ** (-1 * self.flt_precision)
+
+		if diff < 0 and abs(diff) > diff_threshold:
 			# negative stock!
 			exc = sle.copy().update({"diff": diff})
 			self.exceptions.setdefault(sle.warehouse, []).append(exc)


### PR DESCRIPTION
Steps to replicate the issue

1. Set float precision as 7 in the System Settings
2. Make sure Allow Negative Stock has disabled in the Stock Settings
3. Make a delivery note for item A against which stock does not exists and set the qty as 0.0000010 
4. Now try to submit the stock entry
5. System allows you to submit the stock entry even though stock has not available
<img width="1196" height="320" alt="Screenshot 2026-01-08 at 1 33 04 PM" src="https://github.com/user-attachments/assets/6f0825fb-969f-4c0a-9cc1-0cac83ae3b74" />

**After Fix**
<img width="671" height="300" alt="Screenshot 2026-01-08 at 1 37 46 PM" src="https://github.com/user-attachments/assets/9c0d5712-c77d-49bb-ad57-1dd1a436d10c" />



