### PR TITLE
fix: Workspace sidebar links for Debit/Credit Notes

### DIFF
--- a/erpnext/workspace_sidebar/accounting.json
+++ b/erpnext/workspace_sidebar/accounting.json
@@ -67,7 +67,7 @@
   {
    "child": 1,
    "collapsible": 1,
-   "filters": "",
+   "filters": "[[\"Sales Invoice\",\"is_return\",\"=\",1]]",
    "icon": "",
    "indent": 0,
    "keep_closed": 0,
@@ -126,6 +126,7 @@
   {
    "child": 1,
    "collapsible": 1,
+   "filters": "[[\"Purchase Invoice\",\"is_return\",\"=\",1]]",
    "indent": 0,
    "keep_closed": 0,
    "label": "Debit Note",
@@ -570,7 +571,7 @@
    "type": "Link"
   }
  ],
- "modified": "2026-01-02 18:07:04.450536",
+ "modified": "2026-01-08 15:04:31.767795",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Accounting",


### PR DESCRIPTION
Now, it will open filtered list view only for returned Purchase/Sales Invoices.