### PR TITLE
fix(asset): remove purchase links for composite and existing assets

### DIFF
--- a/erpnext/assets/doctype/asset/asset.js
+++ b/erpnext/assets/doctype/asset/asset.js
@@ -471,16 +471,21 @@ frappe.ui.form.on("Asset", {
 	},
 
 	is_existing_asset: function (frm) {
+		if (frm.doc.is_existing_asset) {
+			frm.set_value("purchase_receipt", "");
+			frm.set_value("purchase_invoice", "");
+		}
 		frm.trigger("toggle_reference_doc");
 	},
 
 	is_composite_asset: function (frm) {
 		if (frm.doc.is_composite_asset) {
 			frm.set_value("net_purchase_amount", 0);
+			frm.set_value("purchase_receipt", "");
+			frm.set_value("purchase_invoice", "");
 		} else {
 			frm.set_df_property("net_purchase_amount", "read_only", 0);
 		}
-
 		frm.trigger("toggle_reference_doc");
 	},
 


### PR DESCRIPTION
**Issue:**
Purchase links are not getting unlink even if we enable the is_existing_asset checkbox.

**Before:**

[Screencast from 08-01-26 04:45:08 PM IST.webm](https://github.com/user-attachments/assets/30f7297d-ac08-455d-b0f0-3339d6f94f60)

**After:**

[Screencast from 08-01-26 04:52:13 PM IST.webm](https://github.com/user-attachments/assets/c4013dcd-82f4-4ba8-8542-042dccdccb8b)

**backport Needed for v15**