### PR TITLE
feat(stock): allow updating items after submit for Purchase Material …

### DIFF
--- a/erpnext/stock/doctype/material_request/material_request.js
+++ b/erpnext/stock/doctype/material_request/material_request.js
@@ -656,3 +656,115 @@ function set_schedule_date(frm) {
 		);
 	}
 }
+frappe.ui.form.on("Material Request", {
+    refresh(frm) {
+        if (
+            frm.doc.docstatus === 1 &&
+            frm.doc.material_request_type === "Purchase" &&
+            flt(frm.doc.per_ordered) < 100 &&
+            frm.doc.status !== "Stopped"
+        ) {
+            frm.remove_custom_button(__("Update Items"));
+
+            frm.add_custom_button(
+                __("Update Items"),
+                () => open_update_items_dialog(frm)
+            ).addClass("btn-primary");
+        }
+    }
+});
+
+function open_update_items_dialog(frm) {
+    const table_data = frm.doc.items.map((d) => ({
+        docname: d.name,
+        item_code: d.item_code,
+        qty: flt(d.qty),
+        completed_qty: flt(d.ordered_qty),
+        uom: d.uom,
+        conversion_factor: flt(d.conversion_factor) || 1,
+        rate: d.rate,
+        warehouse: d.warehouse,
+        schedule_date: d.schedule_date
+    }));
+
+    const dialog = new frappe.ui.Dialog({
+        title: __("Update Material Request Items"),
+        size: "extra-large",
+        fields: [
+            {
+                fieldname: "items_table",
+                fieldtype: "Table",
+                label: __("Items"),
+                cannot_add_rows: false,
+                cannot_delete_rows: false,
+                data: table_data,
+                fields: [
+                    { fieldtype: "Data", fieldname: "docname", hidden: 1 },
+                    {
+                        fieldtype: "Link",
+                        fieldname: "item_code",
+                        label: __("Item Code"),
+                        options: "Item",
+                        in_list_view: 1,
+                        reqd: 1
+                    },
+                    { fieldtype: "Float", fieldname: "qty", label: __("Qty"), in_list_view: 1, reqd: 1 },
+                    {
+                        fieldtype: "Link",
+                        fieldname: "uom",
+                        label: __("UOM"),
+                        options: "UOM",
+                        in_list_view: 1,
+                        reqd: 1,
+                        onchange() {
+                            const row = this.doc;
+                            if (!row.item_code || !this.value) return;
+
+                            frappe.call({
+                                method: "erpnext.stock.get_item_details.get_conversion_factor",
+                                args: { item_code: row.item_code, uom: this.value },
+                                callback(r) {
+                                    if (r.message) {
+                                        row.conversion_factor = flt(r.message.conversion_factor) || 1;
+                                        dialog.fields_dict.items_table.grid.refresh();
+                                    }
+                                }
+                            });
+                        }
+                    },
+                    {
+                        fieldtype: "Float",
+                        fieldname: "conversion_factor",
+                        label: __("Factor"),
+                        in_list_view: 1,
+                        read_only: 0
+                    },
+                    { fieldtype: "Link", fieldname: "warehouse", label: __("Warehouse"), options: "Warehouse", in_list_view: 1, reqd: 1 },
+                    { fieldtype: "Date", fieldname: "schedule_date", label: __("Required By"), in_list_view: 1, reqd: 1 }
+                ]
+            }
+        ],
+        primary_action_label: __("Apply Updates"),
+        primary_action() {
+            const values = dialog.get_values();
+            if (!values) return;
+
+            frappe.call({
+                method: "erpnext.stock.doctype.material_request.material_request.update_items_after_submit",
+                freeze: true,
+                args: {
+                    material_request: frm.doc.name,
+                    items: values.items_table
+                },
+                callback() {
+                    frm.reload_doc();
+                    dialog.hide();
+                    frappe.show_alert({message: __("Items Updated"), indicator: "green"});
+                }
+            });
+        }
+    });
+
+    dialog.show();
+    dialog.fields_dict.items_table.grid.refresh();
+}

--- a/erpnext/stock/doctype/material_request/material_request.py
+++ b/erpnext/stock/doctype/material_request/material_request.py
@@ -878,3 +878,114 @@ def make_in_transit_stock_entry(source_name, in_transit_warehouse):
 		row.t_warehouse = in_transit_warehouse
 
 	return ste_doc
+
+
+@frappe.whitelist()
+def update_items_after_submit(material_request, items):
+	"""
+	Update items of a submitted Purchase Material Request
+	when it is partially ordered.
+	"""
+
+	if not material_request:
+		frappe.throw(_("Material Request is required"))
+
+	if isinstance(items, str):
+		items = frappe.parse_json(items)
+
+	if not items:
+		frappe.throw(_("No items provided for update"))
+
+	material_request_doc = frappe.get_doc(
+		"Material Request", material_request
+	)
+
+	material_request_doc.check_permission("write")
+
+	if material_request_doc.docstatus != 1:
+		frappe.throw(_("Material Request must be submitted"))
+
+	if material_request_doc.material_request_type != "Purchase":
+		frappe.throw(
+			_("Only Purchase type Material Requests can be updated")
+		)
+
+	if flt(material_request_doc.per_ordered) >= 100:
+		frappe.throw(
+			_("Cannot update a fully ordered Material Request")
+		)
+
+	if material_request_doc.status == "Stopped":
+		frappe.throw(_("Cannot update a stopped Material Request"))
+
+	
+	material_request_doc.flags.ignore_validate_update_after_submit = True
+
+
+	existing_items_by_name = {
+		item.name: item for item in material_request_doc.items
+	}
+
+	incoming_item_names = {
+		row.get("docname")
+		for row in items
+		if row.get("docname")
+	}
+
+	for row_name, row in existing_items_by_name.items():
+		if row_name not in incoming_item_names:
+			if flt(row.ordered_qty) > 0:
+				frappe.throw(
+					_(
+						"Cannot delete Item {0} because it has completed quantity"
+					).format(row.item_code)
+				)
+			material_request_doc.remove(row)
+
+	
+	for item_data in items:
+		if not item_data.get("item_code"):
+			continue
+
+		if (
+			item_data.get("docname")
+			and item_data.get("docname") in existing_items_by_name
+		):
+			child = existing_items_by_name[item_data.get("docname")]
+		else:
+			child = material_request_doc.append("items", {})
+			item_doc = frappe.get_cached_doc(
+				"Item", item_data.get("item_code")
+			)
+
+			child.item_code = item_doc.name
+			child.item_name = item_doc.item_name
+			child.description = item_doc.description
+			child.stock_uom = item_doc.stock_uom
+
+		qty = flt(item_data.get("qty"))
+		conversion_factor = flt(item_data.get("conversion_factor")) or 1
+		stock_qty = qty * conversion_factor
+
+		if flt(child.ordered_qty) and stock_qty <= flt(
+			child.ordered_qty
+		):
+			frappe.throw(
+				_(
+					"Updated Qty must be greater than Completed Qty for Item {0}"
+				).format(child.item_code)
+			)
+
+		child.qty = qty
+		child.uom = item_data.get("uom")
+		child.rate = flt(item_data.get("rate"))
+		child.conversion_factor = conversion_factor
+		child.stock_qty = stock_qty
+		child.warehouse = item_data.get("warehouse")
+		child.schedule_date = item_data.get("schedule_date")
+
+	
+	material_request_doc.save()
+	material_request_doc.update_requested_qty()
+
+	return material_request_doc.name


### PR DESCRIPTION
Problem
In real-world purchase workflows, a Material Request is often created for a larger
quantity, while Purchase Orders are raised partially based on availability,
budget, or supplier constraints.

Example:

A Material Request is submitted for 100 units
A Purchase Order is created for 50 units
The Material Request moves to a Partially Ordered state
At this stage, users may need to update the remaining quantity or related details
such as warehouse, UOM, rate, or required date. However, ERPNext currently does not
provide a standard way to update item details on a submitted, partially ordered
Purchase-type Material Request. Users are forced to cancel and recreate the
Material Request even when only the remaining quantity needs adjustment.

Solution
This PR introduces a controlled Update Items action for submitted
Purchase-type Material Requests that are not fully ordered.

Key Points
Allows updating remaining quantity, UOM, rate, warehouse, and required date
Prevents reducing quantity below the already ordered (completed) quantity
Disallows unsafe row deletion
Ensures all validations are enforced on the server side
Updates items safely without affecting existing Purchase Orders
Scope
Material Request (Purchase)
Client-side dialogue
[Screencast from 2026-01-05 22-08-31.webm](https://github.com/user-attachments/assets/0e6b5c30-317e-429e-a278-065a605b4545)
for item updates
Server-side validation and persistence
Backward Compatibility
This change does not impact existing workflows.
The feature is available only via an explicit UI action and applies
only to partially ordered Purchase-type Material Requests.
[Screencast from 2026-01-05 22-08-31.webm](https://github.com/user-attachments/assets/a7835d70-8915-4a89-8f94-303d7147ca3f)

