### PR TITLE
feat(stock): allow updating items in submitted Purchase Material Requests

### DIFF
--- a/erpnext/stock/doctype/material_request/material-request.md
+++ b/erpnext/stock/doctype/material_request/material-request.md
@@ -1,0 +1,25 @@
+### Problem
+Once a Purchase Material Request is partially ordered, users cannot update the
+remaining quantity, UOM, warehouse, or schedule date. This forces cancellation
+and recreation of Material Requests, breaking workflow continuity.
+
+### Solution
+Introduces a controlled **Update Items** action for submitted Purchase Material
+Requests that are not fully ordered.
+
+### Key Features
+- Allows updating qty, UOM, rate, warehouse, and schedule date
+- Prevents reducing quantity below completed (ordered) quantity
+- Disallows deletion of rows with completed quantity
+- Enforces permission and document state checks
+- Updates Bin → Indented Qty to keep inventory consistent
+
+### Scope
+- Material Request (Purchase)
+- Client-side dialog for controlled updates
+- Server-side validation and persistence
+- Unit tests added
+- Documentation added
+
+### Backward Compatibility
+No impact on existing workflows. Feature is opt-in via UI action.

--- a/erpnext/stock/doctype/material_request/material_request.js
+++ b/erpnext/stock/doctype/material_request/material_request.js
@@ -669,8 +669,6 @@ function set_schedule_date(frm) {
 		);
 	}
 }
-
-
 function prevent_past_schedule_dates(frm) {
 	if (frm.doc.transaction_date) {
 		frm.fields_dict["schedule_date"].datepicker.update({
@@ -680,7 +678,7 @@ function prevent_past_schedule_dates(frm) {
 }
 
 frappe.ui.form.on("Material Request", {
-    // Standard ERPNext practice: Use make_custom_buttons instead of refresh for button logic
+   
     make_custom_buttons: function(frm) {
         if (
             frm.doc.docstatus === 1 &&
@@ -701,9 +699,8 @@ function open_update_items_dialog(frm) {
         docname: d.name,
         item_code: d.item_code,
         qty: flt(d.qty),
-        completed_qty: flt(d.ordered_qty), // Now visible to the user
+        completed_qty: flt(d.ordered_qty),
         uom: d.uom,
-        conversion_factor: flt(d.conversion_factor) || 1,
         rate: d.rate,
         warehouse: d.warehouse,
         schedule_date: d.schedule_date
@@ -759,7 +756,6 @@ function open_update_items_dialog(frm) {
                             });
                         }
                     },
-                    { fieldtype: "Float", fieldname: "conversion_factor", label: __("Conversion Factor"), in_list_view: 1 },
                     { fieldtype: "Link", fieldname: "warehouse", label: __("Warehouse"), options: "Warehouse", in_list_view: 1, reqd: 1 },
                     { fieldtype: "Date", fieldname: "schedule_date", label: __("Required By"), in_list_view: 1, reqd: 1 }
                 ]

--- a/erpnext/stock/doctype/material_request/material_request.js
+++ b/erpnext/stock/doctype/material_request/material_request.js
@@ -676,125 +676,128 @@ function prevent_past_schedule_dates(frm) {
 		});
 	}
 }
-
 frappe.ui.form.on("Material Request", {
-   
-    make_custom_buttons: function(frm) {
-        if (
-            frm.doc.docstatus === 1 &&
-            frm.doc.material_request_type === "Purchase" &&
-            flt(frm.doc.per_ordered) < 100 &&
-            frm.doc.status !== "Stopped"
-        ) {
-            frm.add_custom_button(
-                __("Update Items"),
-                () => open_update_items_dialog(frm)
-            ).addClass("btn-primary");
-        }
-    }
+	refresh(frm) {
+		if (
+			frm.doc.docstatus === 1 &&
+			frm.doc.material_request_type === "Purchase" &&
+			flt(frm.doc.per_ordered) < 100 &&
+			frm.doc.status !== "Stopped"
+		) {
+			frm.add_custom_button(
+				__("Update Items"),
+				() => open_update_items_dialog(frm),
+				__("Actions")
+			);
+		}
+	},
 });
 
 function open_update_items_dialog(frm) {
-    const table_data = frm.doc.items.map((d) => ({
-        docname: d.name,
-        item_code: d.item_code,
-        qty: flt(d.qty),
-        completed_qty: flt(d.ordered_qty),
-        uom: d.uom,
-        rate: d.rate,
-        warehouse: d.warehouse,
-        schedule_date: d.schedule_date
-    }));
+	const table_data = frm.doc.items.map((d) => ({
+		docname: d.name,
+		item_code: d.item_code,
+		qty: flt(d.qty),
+		completed_qty: flt(d.ordered_qty),
+		uom: d.uom,
+		conversion_factor: d.conversion_factor,
+		rate: d.rate,
+		warehouse: d.warehouse,
+		schedule_date: d.schedule_date,
+	}));
 
-    const dialog = new frappe.ui.Dialog({
-        title: __("Update Material Request Items"),
-        size: "extra-large",
-        fields: [
-            {
-                fieldname: "items_table",
-                fieldtype: "Table",
-                label: __("Items"),
-                data: table_data,
-                fields: [
-                    { fieldtype: "Data", fieldname: "docname", hidden: 1 },
-                    {
-                        fieldtype: "Link",
-                        fieldname: "item_code",
-                        label: __("Item Code"),
-                        options: "Item",
-                        in_list_view: 1,
-                        reqd: 1,
-                        read_only: 1 // Read-only for existing rows to prevent mismatched logs
-                    },
-                    { fieldtype: "Float", fieldname: "qty", label: __("Qty"), in_list_view: 1, reqd: 1 },
-                    { 
-                        fieldtype: "Float", 
-                        fieldname: "completed_qty", 
-                        label: __("Completed Qty"), 
-                        in_list_view: 1, 
-                        read_only: 1 
-                    },
-                    {
-                        fieldtype: "Link",
-                        fieldname: "uom",
-                        label: __("UOM"),
-                        options: "UOM",
-                        in_list_view: 1,
-                        reqd: 1,
-                        onchange() {
-                            const row = this.doc;
-                            if (!row.item_code || !this.value) return;
-                            frappe.call({
-                                method: "erpnext.stock.get_item_details.get_conversion_factor",
-                                args: { item_code: row.item_code, uom: this.value },
-                                callback(r) {
-                                    if (r.message) {
-                                        row.conversion_factor = flt(r.message.conversion_factor) || 1;
-                                        dialog.fields_dict.items_table.grid.refresh();
-                                    }
-                                }
-                            });
-                        }
-                    },
-                    { fieldtype: "Link", fieldname: "warehouse", label: __("Warehouse"), options: "Warehouse", in_list_view: 1, reqd: 1 },
-                    { fieldtype: "Date", fieldname: "schedule_date", label: __("Required By"), in_list_view: 1, reqd: 1 }
-                ]
-            }
-        ],
-        primary_action_label: __("Apply Updates"),
-        primary_action() {
-            const values = dialog.get_values();
-            if (!values) return;k
-            const invalid_items = values.items_table.filter(row => {
-                const stock_qty = flt(row.qty) * flt(row.conversion_factor || 1);
-                return row.docname && stock_qty < flt(row.completed_qty);
-            });
+	const dialog = new frappe.ui.Dialog({
+		title: __("Update Material Request Items"),
+		size: "extra-large",
+		fields: [
+			{
+				fieldname: "items_table",
+				fieldtype: "Table",
+				label: __("Items"),
+				data: table_data,
+				get_data: () => table_data,
+				fields: [
+					{ fieldtype: "Data", fieldname: "docname", hidden: 1 },
+					{
+						fieldtype: "Link",
+						fieldname: "item_code",
+						label: __("Item Code"),
+						options: "Item",
+						in_list_view: 1,
+						reqd: 1,
+					},
+					{
+						fieldtype: "Float",
+						fieldname: "qty",
+						label: __("Qty"),
+						in_list_view: 1,
+						reqd: 1,
+					},
+					{
+						fieldtype: "Float",
+						fieldname: "completed_qty",
+						label: __("Completed Qty"),
+						read_only: 1,
+					},
+					{
+						fieldtype: "Link",
+						fieldname: "uom",
+						label: __("UOM"),
+						options: "UOM",
+						in_list_view: 1,
+						reqd: 1,
+					},
+					{
+						fieldtype: "Float",
+						fieldname: "conversion_factor",
+						label: __("Conversion Factor"),
+						read_only: 1,
+					},
+					{
+						fieldtype: "Currency",
+						fieldname: "rate",
+						label: __("Rate"),
+					},
+					{
+						fieldtype: "Link",
+						fieldname: "warehouse",
+						label: __("Warehouse"),
+						options: "Warehouse",
+						in_list_view: 1,
+						reqd: 1,
+					},
+					{
+						fieldtype: "Date",
+						fieldname: "schedule_date",
+						label: __("Required By"),
+						in_list_view: 1,
+						reqd: 1,
+					},
+				],
+			},
+		],
+		primary_action_label: __("Apply"),
+		primary_action() {
+			const values = dialog.get_values();
+			if (!values) return;
 
-            if (invalid_items.length > 0) {
-                frappe.msgprint({
-                    title: __("Invalid Quantity"),
-                    indicator: "red",
-                    message: __("Row {0}: New quantity cannot be less than Completed Quantity ({1})")
-                        .format(invalid_items[0].idx, invalid_items[0].completed_qty)
-                });
-                return;
-            }
+			frappe.call({
+				method:
+					"erpnext.stock.doctype.material_request.material_request.update_items_after_submit",
+				freeze: true,
+				args: {
+					mr_name: frm.doc.name,
+					trans_items: values.items_table,
+				},
+				callback() {
+					frm.reload_doc();
+					dialog.hide();
+				},
+			});
+		},
+	});
 
-            frappe.call({
-                method: "erpnext.stock.doctype.material_request.material_request.update_items_after_submit",
-                freeze: true,
-                args: {
-                    material_request: frm.doc.name,
-                    items: values.items_table
-                },
-                callback() {
-                    frm.reload_doc();
-                    dialog.hide();
-                    frappe.show_alert({message: __("Items Updated"), indicator: "green"});
-                }
-            });
-        }
-    });
-
-    dialog.show();
+	dialog.show();
 }
+
+

--- a/erpnext/stock/doctype/material_request/material_request.js
+++ b/erpnext/stock/doctype/material_request/material_request.js
@@ -680,15 +680,14 @@ function prevent_past_schedule_dates(frm) {
 }
 
 frappe.ui.form.on("Material Request", {
-    refresh(frm) {
+    // Standard ERPNext practice: Use make_custom_buttons instead of refresh for button logic
+    make_custom_buttons: function(frm) {
         if (
             frm.doc.docstatus === 1 &&
             frm.doc.material_request_type === "Purchase" &&
             flt(frm.doc.per_ordered) < 100 &&
             frm.doc.status !== "Stopped"
         ) {
-            frm.remove_custom_button(__("Update Items"));
-
             frm.add_custom_button(
                 __("Update Items"),
                 () => open_update_items_dialog(frm)
@@ -702,7 +701,7 @@ function open_update_items_dialog(frm) {
         docname: d.name,
         item_code: d.item_code,
         qty: flt(d.qty),
-        completed_qty: flt(d.ordered_qty),
+        completed_qty: flt(d.ordered_qty), // Now visible to the user
         uom: d.uom,
         conversion_factor: flt(d.conversion_factor) || 1,
         rate: d.rate,
@@ -718,8 +717,6 @@ function open_update_items_dialog(frm) {
                 fieldname: "items_table",
                 fieldtype: "Table",
                 label: __("Items"),
-                cannot_add_rows: false,
-                cannot_delete_rows: false,
                 data: table_data,
                 fields: [
                     { fieldtype: "Data", fieldname: "docname", hidden: 1 },
@@ -729,9 +726,17 @@ function open_update_items_dialog(frm) {
                         label: __("Item Code"),
                         options: "Item",
                         in_list_view: 1,
-                        reqd: 1
+                        reqd: 1,
+                        read_only: 1 // Read-only for existing rows to prevent mismatched logs
                     },
                     { fieldtype: "Float", fieldname: "qty", label: __("Qty"), in_list_view: 1, reqd: 1 },
+                    { 
+                        fieldtype: "Float", 
+                        fieldname: "completed_qty", 
+                        label: __("Completed Qty"), 
+                        in_list_view: 1, 
+                        read_only: 1 
+                    },
                     {
                         fieldtype: "Link",
                         fieldname: "uom",
@@ -742,7 +747,6 @@ function open_update_items_dialog(frm) {
                         onchange() {
                             const row = this.doc;
                             if (!row.item_code || !this.value) return;
-
                             frappe.call({
                                 method: "erpnext.stock.get_item_details.get_conversion_factor",
                                 args: { item_code: row.item_code, uom: this.value },
@@ -755,13 +759,7 @@ function open_update_items_dialog(frm) {
                             });
                         }
                     },
-                    {
-                        fieldtype: "Float",
-                        fieldname: "conversion_factor",
-                        label: __("Factor"),
-                        in_list_view: 1,
-                        read_only: 0
-                    },
+                    { fieldtype: "Float", fieldname: "conversion_factor", label: __("Conversion Factor"), in_list_view: 1 },
                     { fieldtype: "Link", fieldname: "warehouse", label: __("Warehouse"), options: "Warehouse", in_list_view: 1, reqd: 1 },
                     { fieldtype: "Date", fieldname: "schedule_date", label: __("Required By"), in_list_view: 1, reqd: 1 }
                 ]
@@ -770,7 +768,21 @@ function open_update_items_dialog(frm) {
         primary_action_label: __("Apply Updates"),
         primary_action() {
             const values = dialog.get_values();
-            if (!values) return;
+            if (!values) return;k
+            const invalid_items = values.items_table.filter(row => {
+                const stock_qty = flt(row.qty) * flt(row.conversion_factor || 1);
+                return row.docname && stock_qty < flt(row.completed_qty);
+            });
+
+            if (invalid_items.length > 0) {
+                frappe.msgprint({
+                    title: __("Invalid Quantity"),
+                    indicator: "red",
+                    message: __("Row {0}: New quantity cannot be less than Completed Quantity ({1})")
+                        .format(invalid_items[0].idx, invalid_items[0].completed_qty)
+                });
+                return;
+            }
 
             frappe.call({
                 method: "erpnext.stock.doctype.material_request.material_request.update_items_after_submit",
@@ -789,5 +801,4 @@ function open_update_items_dialog(frm) {
     });
 
     dialog.show();
-    dialog.fields_dict.items_table.grid.refresh();
 }

--- a/erpnext/stock/doctype/material_request/material_request.js
+++ b/erpnext/stock/doctype/material_request/material_request.js
@@ -670,10 +670,124 @@ function set_schedule_date(frm) {
 	}
 }
 
+
 function prevent_past_schedule_dates(frm) {
 	if (frm.doc.transaction_date) {
 		frm.fields_dict["schedule_date"].datepicker.update({
 			minDate: new Date(frm.doc.transaction_date),
 		});
 	}
+}
+
+frappe.ui.form.on("Material Request", {
+    refresh(frm) {
+        if (
+            frm.doc.docstatus === 1 &&
+            frm.doc.material_request_type === "Purchase" &&
+            flt(frm.doc.per_ordered) < 100 &&
+            frm.doc.status !== "Stopped"
+        ) {
+            frm.remove_custom_button(__("Update Items"));
+
+            frm.add_custom_button(
+                __("Update Items"),
+                () => open_update_items_dialog(frm)
+            ).addClass("btn-primary");
+        }
+    }
+});
+
+function open_update_items_dialog(frm) {
+    const table_data = frm.doc.items.map((d) => ({
+        docname: d.name,
+        item_code: d.item_code,
+        qty: flt(d.qty),
+        completed_qty: flt(d.ordered_qty),
+        uom: d.uom,
+        conversion_factor: flt(d.conversion_factor) || 1,
+        rate: d.rate,
+        warehouse: d.warehouse,
+        schedule_date: d.schedule_date
+    }));
+
+    const dialog = new frappe.ui.Dialog({
+        title: __("Update Material Request Items"),
+        size: "extra-large",
+        fields: [
+            {
+                fieldname: "items_table",
+                fieldtype: "Table",
+                label: __("Items"),
+                cannot_add_rows: false,
+                cannot_delete_rows: false,
+                data: table_data,
+                fields: [
+                    { fieldtype: "Data", fieldname: "docname", hidden: 1 },
+                    {
+                        fieldtype: "Link",
+                        fieldname: "item_code",
+                        label: __("Item Code"),
+                        options: "Item",
+                        in_list_view: 1,
+                        reqd: 1
+                    },
+                    { fieldtype: "Float", fieldname: "qty", label: __("Qty"), in_list_view: 1, reqd: 1 },
+                    {
+                        fieldtype: "Link",
+                        fieldname: "uom",
+                        label: __("UOM"),
+                        options: "UOM",
+                        in_list_view: 1,
+                        reqd: 1,
+                        onchange() {
+                            const row = this.doc;
+                            if (!row.item_code || !this.value) return;
+
+                            frappe.call({
+                                method: "erpnext.stock.get_item_details.get_conversion_factor",
+                                args: { item_code: row.item_code, uom: this.value },
+                                callback(r) {
+                                    if (r.message) {
+                                        row.conversion_factor = flt(r.message.conversion_factor) || 1;
+                                        dialog.fields_dict.items_table.grid.refresh();
+                                    }
+                                }
+                            });
+                        }
+                    },
+                    {
+                        fieldtype: "Float",
+                        fieldname: "conversion_factor",
+                        label: __("Factor"),
+                        in_list_view: 1,
+                        read_only: 0
+                    },
+                    { fieldtype: "Link", fieldname: "warehouse", label: __("Warehouse"), options: "Warehouse", in_list_view: 1, reqd: 1 },
+                    { fieldtype: "Date", fieldname: "schedule_date", label: __("Required By"), in_list_view: 1, reqd: 1 }
+                ]
+            }
+        ],
+        primary_action_label: __("Apply Updates"),
+        primary_action() {
+            const values = dialog.get_values();
+            if (!values) return;
+
+            frappe.call({
+                method: "erpnext.stock.doctype.material_request.material_request.update_items_after_submit",
+                freeze: true,
+                args: {
+                    material_request: frm.doc.name,
+                    items: values.items_table
+                },
+                callback() {
+                    frm.reload_doc();
+                    dialog.hide();
+                    frappe.show_alert({message: __("Items Updated"), indicator: "green"});
+                }
+            });
+        }
+    });
+
+    dialog.show();
+    dialog.fields_dict.items_table.grid.refresh();
 }

--- a/erpnext/stock/doctype/material_request/material_request.js
+++ b/erpnext/stock/doctype/material_request/material_request.js
@@ -692,18 +692,17 @@ frappe.ui.form.on("Material Request", {
 		}
 	},
 });
-
 function open_update_items_dialog(frm) {
-	const table_data = frm.doc.items.map((d) => ({
-		docname: d.name,
-		item_code: d.item_code,
-		qty: flt(d.qty),
-		completed_qty: flt(d.ordered_qty),
-		uom: d.uom,
-		conversion_factor: d.conversion_factor,
-		rate: d.rate,
-		warehouse: d.warehouse,
-		schedule_date: d.schedule_date,
+	const items_data = frm.doc.items.map((row) => ({
+		docname: row.name,
+		item_code: row.item_code,
+		qty: flt(row.qty),
+		completed_qty: flt(row.ordered_qty),
+		uom: row.uom,
+		conversion_factor: row.conversion_factor,
+		rate: row.rate,
+		warehouse: row.warehouse,
+		schedule_date: row.schedule_date,
 	}));
 
 	const dialog = new frappe.ui.Dialog({
@@ -711,13 +710,15 @@ function open_update_items_dialog(frm) {
 		size: "extra-large",
 		fields: [
 			{
-				fieldname: "items_table",
+				fieldname: "items",
 				fieldtype: "Table",
 				label: __("Items"),
-				data: table_data,
-				get_data: () => table_data,
+				data: items_data,
+				get_data: () => items_data,
+				in_place_edit: false,
 				fields: [
 					{ fieldtype: "Data", fieldname: "docname", hidden: 1 },
+
 					{
 						fieldtype: "Link",
 						fieldname: "item_code",
@@ -726,6 +727,7 @@ function open_update_items_dialog(frm) {
 						in_list_view: 1,
 						reqd: 1,
 					},
+
 					{
 						fieldtype: "Float",
 						fieldname: "qty",
@@ -733,12 +735,14 @@ function open_update_items_dialog(frm) {
 						in_list_view: 1,
 						reqd: 1,
 					},
+
 					{
 						fieldtype: "Float",
 						fieldname: "completed_qty",
 						label: __("Completed Qty"),
 						read_only: 1,
 					},
+
 					{
 						fieldtype: "Link",
 						fieldname: "uom",
@@ -746,18 +750,45 @@ function open_update_items_dialog(frm) {
 						options: "UOM",
 						in_list_view: 1,
 						reqd: 1,
+
+						onchange() {
+							const row = this.doc;
+							if (!row.item_code || !row.uom) return;
+
+							frappe.call({
+								method:
+									"erpnext.stock.get_item_details.get_conversion_factor",
+								args: {
+									item_code: row.item_code,
+									uom: row.uom,
+								},
+								callback(r) {
+									if (r.message) {
+										row.conversion_factor =
+											r.message.conversion_factor || 1;
+
+										// refresh grid row
+										dialog.fields_dict.items.grid.refresh();
+									}
+								},
+							});
+						},
 					},
+
 					{
 						fieldtype: "Float",
 						fieldname: "conversion_factor",
 						label: __("Conversion Factor"),
 						read_only: 1,
+						in_list_view: 1,
 					},
+
 					{
 						fieldtype: "Currency",
 						fieldname: "rate",
 						label: __("Rate"),
 					},
+
 					{
 						fieldtype: "Link",
 						fieldname: "warehouse",
@@ -766,6 +797,7 @@ function open_update_items_dialog(frm) {
 						in_list_view: 1,
 						reqd: 1,
 					},
+
 					{
 						fieldtype: "Date",
 						fieldname: "schedule_date",
@@ -776,7 +808,9 @@ function open_update_items_dialog(frm) {
 				],
 			},
 		],
+
 		primary_action_label: __("Apply"),
+
 		primary_action() {
 			const values = dialog.get_values();
 			if (!values) return;
@@ -785,9 +819,10 @@ function open_update_items_dialog(frm) {
 				method:
 					"erpnext.stock.doctype.material_request.material_request.update_items_after_submit",
 				freeze: true,
+				freeze_message: __("Updating Material Request…"),
 				args: {
-					mr_name: frm.doc.name,
-					trans_items: values.items_table,
+					material_request: frm.doc.name,
+					items: values.items,
 				},
 				callback() {
 					frm.reload_doc();
@@ -799,5 +834,6 @@ function open_update_items_dialog(frm) {
 
 	dialog.show();
 }
+
 
 

--- a/erpnext/stock/doctype/material_request/material_request.py
+++ b/erpnext/stock/doctype/material_request/material_request.py
@@ -958,113 +958,77 @@ def make_in_transit_stock_entry(source_name, in_transit_warehouse):
 
 	return ste_doc
 
-
 @frappe.whitelist()
 def update_items_after_submit(material_request, items):
-	"""
-	Update items of a submitted Purchase Material Request
-	when it is partially ordered.
-	"""
+    """
+    Update items of a submitted Purchase Material Request when it is partially ordered.
+    """
+    if isinstance(items, str):
+        items = frappe.parse_json(items)
 
-	if not material_request:
-		frappe.throw(_("Material Request is required"))
+    if not items:
+        frappe.throw(_("No items provided for update"))
 
-	if isinstance(items, str):
-		items = frappe.parse_json(items)
+    doc = frappe.get_doc("Material Request", material_request)
+    doc.check_permission("write")
 
-	if not items:
-		frappe.throw(_("No items provided for update"))
+    
+    if doc.docstatus != 1:
+        frappe.throw(_("Material Request must be submitted"))
+    if doc.material_request_type != "Purchase":
+        frappe.throw(_("Only Purchase type Material Requests can be updated"))
+    if flt(doc.per_ordered) >= 100:
+        frappe.throw(_("Cannot update a fully ordered Material Request"))
+    if doc.status == "Stopped":
+        frappe.throw(_("Cannot update a stopped Material Request"))
 
-	material_request_doc = frappe.get_doc(
-		"Material Request", material_request
-	)
+    updated_row_names = [d.get("docname") for d in items if d.get("docname")]
 
-	material_request_doc.check_permission("write")
+    # Remove rows not present in the dialog
+    for row in list(doc.items):
+        if row.name not in updated_row_names:
+            if flt(row.ordered_qty) > 0:
+                frappe.throw(_("Row {0}: Cannot delete item {1} because it is partially ordered")
+                             .format(row.idx, row.item_code))
+            doc.remove(row)
 
-	if material_request_doc.docstatus != 1:
-		frappe.throw(_("Material Request must be submitted"))
+    # Update existing or append new rows
+    for row_data in items:
+        if not row_data.get("item_code"):
+            continue
 
-	if material_request_doc.material_request_type != "Purchase":
-		frappe.throw(
-			_("Only Purchase type Material Requests can be updated")
-		)
+        if row_data.get("docname"):
+            child = doc.get_child_table_row("items", row_data.get("docname"))
+        else:
+            child = doc.append("items", {})
+            child.item_code = row_data.get("item_code")
+            # Fetch item defaults using cached value for performance
+            item_info = frappe.get_cached_value("Item", child.item_code, 
+                ["item_name", "description", "stock_uom"], as_dict=1)
+            if item_info:
+                child.update(item_info)
 
-	if flt(material_request_doc.per_ordered) >= 100:
-		frappe.throw(
-			_("Cannot update a fully ordered Material Request")
-		)
+        # Quantity calculations and validation
+        new_qty = flt(row_data.get("qty"))
+        conversion_factor = flt(row_data.get("conversion_factor")) or 1.0
+        stock_qty = new_qty * conversion_factor
 
-	if material_request_doc.status == "Stopped":
-		frappe.throw(_("Cannot update a stopped Material Request"))
+        if flt(child.ordered_qty) > 0 and stock_qty < flt(child.ordered_qty):
+            frappe.throw(_("Item {0}: Quantity cannot be less than Ordered Quantity ({1})")
+                         .format(child.item_code, child.ordered_qty))
 
-	
-	material_request_doc.flags.ignore_validate_update_after_submit = True
+        child.qty = new_qty
+        child.uom = row_data.get("uom")
+        child.warehouse = row_data.get("warehouse")
+        child.rate = flt(row_data.get("rate"))
+        child.conversion_factor = conversion_factor
+        child.stock_qty = stock_qty
+        child.schedule_date = row_data.get("schedule_date")
 
+   
+    doc.flags.ignore_validate_update_after_submit = True
+    doc.save()
 
-	existing_items_by_name = {
-		item.name: item for item in material_request_doc.items
-	}
+    doc.update_requested_qty()
 
-	incoming_item_names = {
-		row.get("docname")
-		for row in items
-		if row.get("docname")
-	}
-
-	for row_name, row in existing_items_by_name.items():
-		if row_name not in incoming_item_names:
-			if flt(row.ordered_qty) > 0:
-				frappe.throw(
-					_(
-						"Cannot delete Item {0} because it has completed quantity"
-					).format(row.item_code)
-				)
-			material_request_doc.remove(row)
-
-	
-	for item_data in items:
-		if not item_data.get("item_code"):
-			continue
-
-		if (
-			item_data.get("docname")
-			and item_data.get("docname") in existing_items_by_name
-		):
-			child = existing_items_by_name[item_data.get("docname")]
-		else:
-			child = material_request_doc.append("items", {})
-			item_doc = frappe.get_cached_doc(
-				"Item", item_data.get("item_code")
-			)
-
-			child.item_code = item_doc.name
-			child.item_name = item_doc.item_name
-			child.description = item_doc.description
-			child.stock_uom = item_doc.stock_uom
-
-		qty = flt(item_data.get("qty"))
-		conversion_factor = flt(item_data.get("conversion_factor")) or 1
-		stock_qty = qty * conversion_factor
-
-		if flt(child.ordered_qty) and stock_qty <= flt(
-			child.ordered_qty
-		):
-			frappe.throw(
-				_(
-					"Updated Qty must be greater than Completed Qty for Item {0}"
-				).format(child.item_code)
-			)
-
-		child.qty = qty
-		child.uom = item_data.get("uom")
-		child.rate = flt(item_data.get("rate"))
-		child.conversion_factor = conversion_factor
-		child.stock_qty = stock_qty
-		child.warehouse = item_data.get("warehouse")
-		child.schedule_date = item_data.get("schedule_date")
-
-	
-	material_request_doc.save()
-	material_request_doc.update_requested_qty()
-
-	return material_request_doc.name
+    return doc.name

--- a/erpnext/stock/doctype/material_request/material_request.py
+++ b/erpnext/stock/doctype/material_request/material_request.py
@@ -957,3 +957,114 @@ def make_in_transit_stock_entry(source_name, in_transit_warehouse):
 		row.t_warehouse = in_transit_warehouse
 
 	return ste_doc
+
+
+@frappe.whitelist()
+def update_items_after_submit(material_request, items):
+	"""
+	Update items of a submitted Purchase Material Request
+	when it is partially ordered.
+	"""
+
+	if not material_request:
+		frappe.throw(_("Material Request is required"))
+
+	if isinstance(items, str):
+		items = frappe.parse_json(items)
+
+	if not items:
+		frappe.throw(_("No items provided for update"))
+
+	material_request_doc = frappe.get_doc(
+		"Material Request", material_request
+	)
+
+	material_request_doc.check_permission("write")
+
+	if material_request_doc.docstatus != 1:
+		frappe.throw(_("Material Request must be submitted"))
+
+	if material_request_doc.material_request_type != "Purchase":
+		frappe.throw(
+			_("Only Purchase type Material Requests can be updated")
+		)
+
+	if flt(material_request_doc.per_ordered) >= 100:
+		frappe.throw(
+			_("Cannot update a fully ordered Material Request")
+		)
+
+	if material_request_doc.status == "Stopped":
+		frappe.throw(_("Cannot update a stopped Material Request"))
+
+	
+	material_request_doc.flags.ignore_validate_update_after_submit = True
+
+
+	existing_items_by_name = {
+		item.name: item for item in material_request_doc.items
+	}
+
+	incoming_item_names = {
+		row.get("docname")
+		for row in items
+		if row.get("docname")
+	}
+
+	for row_name, row in existing_items_by_name.items():
+		if row_name not in incoming_item_names:
+			if flt(row.ordered_qty) > 0:
+				frappe.throw(
+					_(
+						"Cannot delete Item {0} because it has completed quantity"
+					).format(row.item_code)
+				)
+			material_request_doc.remove(row)
+
+	
+	for item_data in items:
+		if not item_data.get("item_code"):
+			continue
+
+		if (
+			item_data.get("docname")
+			and item_data.get("docname") in existing_items_by_name
+		):
+			child = existing_items_by_name[item_data.get("docname")]
+		else:
+			child = material_request_doc.append("items", {})
+			item_doc = frappe.get_cached_doc(
+				"Item", item_data.get("item_code")
+			)
+
+			child.item_code = item_doc.name
+			child.item_name = item_doc.item_name
+			child.description = item_doc.description
+			child.stock_uom = item_doc.stock_uom
+
+		qty = flt(item_data.get("qty"))
+		conversion_factor = flt(item_data.get("conversion_factor")) or 1
+		stock_qty = qty * conversion_factor
+
+		if flt(child.ordered_qty) and stock_qty <= flt(
+			child.ordered_qty
+		):
+			frappe.throw(
+				_(
+					"Updated Qty must be greater than Completed Qty for Item {0}"
+				).format(child.item_code)
+			)
+
+		child.qty = qty
+		child.uom = item_data.get("uom")
+		child.rate = flt(item_data.get("rate"))
+		child.conversion_factor = conversion_factor
+		child.stock_qty = stock_qty
+		child.warehouse = item_data.get("warehouse")
+		child.schedule_date = item_data.get("schedule_date")
+
+	
+	material_request_doc.save()
+	material_request_doc.update_requested_qty()
+
+	return material_request_doc.name

--- a/erpnext/stock/doctype/material_request/material_request.py
+++ b/erpnext/stock/doctype/material_request/material_request.py
@@ -959,76 +959,85 @@ def make_in_transit_stock_entry(source_name, in_transit_warehouse):
 	return ste_doc
 
 @frappe.whitelist()
-def update_items_after_submit(material_request, items):
-    """
-    Update items of a submitted Purchase Material Request when it is partially ordered.
-    """
-    if isinstance(items, str):
-        items = frappe.parse_json(items)
+def update_items_after_submit(mr_name, trans_items):
+	if not mr_name:
+		frappe.throw(_("Material Request name is required"))
 
-    if not items:
-        frappe.throw(_("No items provided for update"))
+	if isinstance(trans_items, str):
+		trans_items = frappe.parse_json(trans_items)
 
-    doc = frappe.get_doc("Material Request", material_request)
-    doc.check_permission("write")
+	if not trans_items:
+		frappe.throw(_("No items provided for update"))
 
-    
-    if doc.docstatus != 1:
-        frappe.throw(_("Material Request must be submitted"))
-    if doc.material_request_type != "Purchase":
-        frappe.throw(_("Only Purchase type Material Requests can be updated"))
-    if flt(doc.per_ordered) >= 100:
-        frappe.throw(_("Cannot update a fully ordered Material Request"))
-    if doc.status == "Stopped":
-        frappe.throw(_("Cannot update a stopped Material Request"))
+	mr = frappe.get_doc("Material Request", mr_name)
 
-    updated_row_names = [d.get("docname") for d in items if d.get("docname")]
+	# Permission check (MANDATORY)
+	mr.check_permission("write")
 
-    # Remove rows not present in the dialog
-    for row in list(doc.items):
-        if row.name not in updated_row_names:
-            if flt(row.ordered_qty) > 0:
-                frappe.throw(_("Row {0}: Cannot delete item {1} because it is partially ordered")
-                             .format(row.idx, row.item_code))
-            doc.remove(row)
+	# Server-side validation (DO NOT trust UI)
+	if mr.docstatus != 1:
+		frappe.throw(_("Material Request must be submitted"))
 
-    # Update existing or append new rows
-    for row_data in items:
-        if not row_data.get("item_code"):
-            continue
+	if mr.material_request_type != "Purchase":
+		frappe.throw(_("Only Purchase type Material Requests can be updated"))
 
-        if row_data.get("docname"):
-            child = doc.get_child_table_row("items", row_data.get("docname"))
-        else:
-            child = doc.append("items", {})
-            child.item_code = row_data.get("item_code")
-            # Fetch item defaults using cached value for performance
-            item_info = frappe.get_cached_value("Item", child.item_code, 
-                ["item_name", "description", "stock_uom"], as_dict=1)
-            if item_info:
-                child.update(item_info)
+	if flt(mr.per_ordered) >= 100:
+		frappe.throw(_("Cannot update fully ordered Material Request"))
 
-        # Quantity calculations and validation
-        new_qty = flt(row_data.get("qty"))
-        conversion_factor = flt(row_data.get("conversion_factor")) or 1.0
-        stock_qty = new_qty * conversion_factor
+	if mr.status == "Stopped":
+		frappe.throw(_("Cannot update stopped Material Request"))
 
-        if flt(child.ordered_qty) > 0 and stock_qty < flt(child.ordered_qty):
-            frappe.throw(_("Item {0}: Quantity cannot be less than Ordered Quantity ({1})")
-                         .format(child.item_code, child.ordered_qty))
+	mr.flags.ignore_validate_update_after_submit = True
 
-        child.qty = new_qty
-        child.uom = row_data.get("uom")
-        child.warehouse = row_data.get("warehouse")
-        child.rate = flt(row_data.get("rate"))
-        child.conversion_factor = conversion_factor
-        child.stock_qty = stock_qty
-        child.schedule_date = row_data.get("schedule_date")
+	existing_rows = {d.name: d for d in mr.items}
+	incoming_rows = {d.get("docname") for d in trans_items if d.get("docname")}
 
-   
-    doc.flags.ignore_validate_update_after_submit = True
-    doc.save()
+	# Remove deleted rows
+	for rowname, row in existing_rows.items():
+		if rowname not in incoming_rows:
+			if flt(row.ordered_qty) > 0:
+				frappe.throw(
+					_("Cannot delete Item {0} because Completed Qty exists").format(row.item_code)
+				)
+			mr.remove(row)
 
-    doc.update_requested_qty()
+	# Add / Update rows
+	for d in trans_items:
+		if not d.get("item_code"):
+			continue
 
-    return doc.name
+		if d.get("docname") and d.get("docname") in existing_rows:
+			child = existing_rows[d.get("docname")]
+		else:
+			child = mr.append("items", {})
+			item = frappe.get_cached_doc("Item", d.get("item_code"))
+			child.item_code = item.name
+			child.item_name = item.item_name
+			child.description = item.description
+			child.stock_uom = item.stock_uom
+
+		qty = flt(d.get("qty"))
+		conversion_factor = flt(d.get("conversion_factor")) or 1
+		stock_qty = qty * conversion_factor
+
+		if flt(child.ordered_qty) and stock_qty <= flt(child.ordered_qty):
+			frappe.throw(
+				_("Updated Qty must be greater than Completed Qty for Item {0}")
+				.format(child.item_code)
+			)
+
+		child.qty = qty
+		child.uom = d.get("uom")
+		child.rate = flt(d.get("rate"))
+		child.conversion_factor = conversion_factor
+		child.stock_qty = stock_qty
+		child.warehouse = d.get("warehouse")
+		child.schedule_date = d.get("schedule_date")
+
+	# Save once
+	mr.save()
+
+	# Update bin quantities
+	mr.update_requested_qty()
+
+	return mr.name

--- a/erpnext/stock/doctype/material_request/material_request.py
+++ b/erpnext/stock/doctype/material_request/material_request.py
@@ -957,67 +957,79 @@ def make_in_transit_stock_entry(source_name, in_transit_warehouse):
 		row.t_warehouse = in_transit_warehouse
 
 	return ste_doc
-
+	
 @frappe.whitelist()
-def update_items_after_submit(mr_name, trans_items):
-	if not mr_name:
-		frappe.throw(_("Material Request name is required"))
+def update_items_after_submit(material_request, items):
+	"""
+	Update items of a submitted Purchase Material Request
+	when it is partially ordered.
+	"""
 
-	if isinstance(trans_items, str):
-		trans_items = frappe.parse_json(trans_items)
+	if not material_request:
+		frappe.throw(_("Material Request is required"))
 
-	if not trans_items:
+	if isinstance(items, str):
+		items = frappe.parse_json(items)
+
+	if not items:
 		frappe.throw(_("No items provided for update"))
 
-	mr = frappe.get_doc("Material Request", mr_name)
+	material_request_doc = frappe.get_doc("Material Request", material_request)
 
 	# Permission check (MANDATORY)
-	mr.check_permission("write")
+	material_request_doc.check_permission("write")
 
-	# Server-side validation (DO NOT trust UI)
-	if mr.docstatus != 1:
+	# Server-side validations (do not trust UI)
+	if material_request_doc.docstatus != 1:
 		frappe.throw(_("Material Request must be submitted"))
 
-	if mr.material_request_type != "Purchase":
+	if material_request_doc.material_request_type != "Purchase":
 		frappe.throw(_("Only Purchase type Material Requests can be updated"))
 
-	if flt(mr.per_ordered) >= 100:
-		frappe.throw(_("Cannot update fully ordered Material Request"))
+	if flt(material_request_doc.per_ordered) >= 100:
+		frappe.throw(_("Cannot update a fully ordered Material Request"))
 
-	if mr.status == "Stopped":
-		frappe.throw(_("Cannot update stopped Material Request"))
+	if material_request_doc.status == "Stopped":
+		frappe.throw(_("Cannot update a stopped Material Request"))
 
-	mr.flags.ignore_validate_update_after_submit = True
 
-	existing_rows = {d.name: d for d in mr.items}
-	incoming_rows = {d.get("docname") for d in trans_items if d.get("docname")}
+	material_request_doc.flags.ignore_validate_update_after_submit = True
+
+	existing_items_by_name = {
+		item.name: item for item in material_request_doc.items
+	}
+	incoming_item_names = {
+		item.get("docname") for item in items if item.get("docname")
+	}
 
 	# Remove deleted rows
-	for rowname, row in existing_rows.items():
-		if rowname not in incoming_rows:
+	for row_name, row in existing_items_by_name.items():
+		if row_name not in incoming_item_names:
 			if flt(row.ordered_qty) > 0:
 				frappe.throw(
-					_("Cannot delete Item {0} because Completed Qty exists").format(row.item_code)
+					_("Cannot delete Item {0} because it has completed quantity")
+					.format(row.item_code)
 				)
-			mr.remove(row)
+			material_request_doc.remove(row)
 
-	# Add / Update rows
-	for d in trans_items:
-		if not d.get("item_code"):
+	
+	for item_data in items:
+		if not item_data.get("item_code"):
 			continue
 
-		if d.get("docname") and d.get("docname") in existing_rows:
-			child = existing_rows[d.get("docname")]
+		if item_data.get("docname") and item_data.get("docname") in existing_items_by_name:
+			child = existing_items_by_name[item_data.get("docname")]
 		else:
-			child = mr.append("items", {})
-			item = frappe.get_cached_doc("Item", d.get("item_code"))
-			child.item_code = item.name
-			child.item_name = item.item_name
-			child.description = item.description
-			child.stock_uom = item.stock_uom
+			child = material_request_doc.append("items", {})
+			item_doc = frappe.get_cached_doc("Item", item_data.get("item_code"))
 
-		qty = flt(d.get("qty"))
-		conversion_factor = flt(d.get("conversion_factor")) or 1
+			child.item_code = item_doc.name
+			child.item_name = item_doc.item_name
+			child.description = item_doc.description
+			child.stock_uom = item_doc.stock_uom
+
+		qty = flt(item_data.get("qty"))
+		conversion_factor = flt(item_data.get("conversion_factor")) or 1
 		stock_qty = qty * conversion_factor
 
 		if flt(child.ordered_qty) and stock_qty <= flt(child.ordered_qty):
@@ -1027,17 +1039,17 @@ def update_items_after_submit(mr_name, trans_items):
 			)
 
 		child.qty = qty
-		child.uom = d.get("uom")
-		child.rate = flt(d.get("rate"))
+		child.uom = item_data.get("uom")
+		child.rate = flt(item_data.get("rate"))
 		child.conversion_factor = conversion_factor
 		child.stock_qty = stock_qty
-		child.warehouse = d.get("warehouse")
-		child.schedule_date = d.get("schedule_date")
+		child.warehouse = item_data.get("warehouse")
+		child.schedule_date = item_data.get("schedule_date")
 
-	# Save once
-	mr.save()
 
-	# Update bin quantities
-	mr.update_requested_qty()
+	material_request_doc.save()
 
-	return mr.name
+
+	material_request_doc.update_requested_qty()
+
+	return material_request_doc.name


### PR DESCRIPTION
Once a Purchase Material Request is partially ordered, users cannot update the
remaining quantity, UOM, warehouse, or schedule date. This forces cancellation
and recreation of Material Requests, breaking workflow continuity.

### Solution
Introduces a controlled **Update Items** action for submitted Purchase Material
Requests that are not fully ordered.

### Key Features
- Allows updating qty, UOM, rate, warehouse, and schedule date
- Prevents reducing quantity below completed (ordered) quantity
- Disallows deletion of rows with completed quantity
- Enforces permission and document state checks
- Updates Bin → Indented Qty to keep inventory consistent

### Scope
- Material Request (Purchase)
- Client-side dialog for controlled updates
- Server-side validation and persistence
- Unit tests added
- Documentation added

### Backward Compatibility
No impact on existing workflows. Feature is opt-in via UI action.
[Screencast from 2026-01-05 22-08-31.webm](https://github.com/user-attachments/assets/c538a7cf-e766-4f07-9ab1-2dade91f35f5)