### PR TITLE
fix(pos): item selector section ui/ux

### DIFF
--- a/erpnext/public/scss/point-of-sale.scss
+++ b/erpnext/public/scss/point-of-sale.scss
@@ -117,6 +117,35 @@
 			overflow-y: scroll;
 			overflow-x: hidden;
 
+			&.item-loading {
+				position: relative;
+				pointer-events: none;
+			}
+
+			&.item-loading::after {
+				content: "";
+				position: absolute;
+				inset: 0;
+				background: repeating-linear-gradient(
+					90deg,
+					#f3f3f3 0px,
+					#f3f3f3 160px,
+					#e9ecef 160px,
+					#e9ecef 320px
+				);
+				animation: skeletonMove 1.1s linear infinite;
+				z-index: 1;
+			}
+
+			@keyframes skeletonMove {
+				from {
+					background-position: 0 0;
+				}
+				to {
+					background-position: 320px 0;
+				}
+			}
+
 			&.items-not-found {
 				display: flex;
 				align-items: center;

--- a/erpnext/public/scss/point-of-sale.scss
+++ b/erpnext/public/scss/point-of-sale.scss
@@ -117,6 +117,13 @@
 			overflow-y: scroll;
 			overflow-x: hidden;
 
+			&.items-not-found {
+				display: flex;
+				align-items: center;
+				justify-content: center;
+				height: 100%;
+			}
+
 			&.show-item-image {
 				grid-template-columns: repeat(4, minmax(0, 1fr));
 				gap: var(--margin-lg);

--- a/erpnext/selling/page/point_of_sale/point_of_sale.py
+++ b/erpnext/selling/page/point_of_sale/point_of_sale.py
@@ -122,11 +122,13 @@ def filter_result_items(result, pos_profile):
 
 
 @frappe.whitelist()
-def get_parent_item_group():
-	# Using get_all to ignore user permission
-	item_group = frappe.get_all("Item Group", {"lft": 1, "is_group": 1}, pluck="name")
-	if item_group:
-		return item_group[0]
+def get_parent_item_group(pos_profile):
+	item_groups = get_item_groups(pos_profile)
+
+	if not item_groups:
+		item_groups = frappe.get_all("Item Group", {"lft": 1, "is_group": 1}, pluck="name")
+
+	return item_groups[0] if item_groups else None
 
 
 @frappe.whitelist()

--- a/erpnext/selling/page/point_of_sale/pos_item_selector.js
+++ b/erpnext/selling/page/point_of_sale/pos_item_selector.js
@@ -10,11 +10,11 @@ erpnext.PointOfSale.ItemSelector = class {
 		this.item_display_class = this.hide_images ? "hide-item-image" : "show-item-image";
 		this.auto_add_item = settings.auto_add_item_to_cart;
 
-		this.get_parent_item_group();
+		this.item_ready_group = this.get_parent_item_group();
 		this.inti_component();
 	}
 
-	async inti_component() {
+	inti_component() {
 		this.prepare_dom();
 		this.make_search_bar();
 		this.load_items_data();
@@ -51,6 +51,8 @@ erpnext.PointOfSale.ItemSelector = class {
 	}
 
 	async load_items_data() {
+		await this.item_ready_group;
+
 		if (!this.price_list) {
 			const res = await frappe.db.get_value("POS Profile", this.pos_profile, "selling_price_list");
 			this.price_list = res.message.selling_price_list;

--- a/erpnext/selling/page/point_of_sale/pos_item_selector.js
+++ b/erpnext/selling/page/point_of_sale/pos_item_selector.js
@@ -231,6 +231,7 @@ erpnext.PointOfSale.ItemSelector = class {
 
 		$(this.item_group_field.awesomplete.ul).css("min-width", "unset");
 
+		this.hide_open_link_btn();
 		this.attach_clear_btn();
 	}
 
@@ -238,6 +239,10 @@ erpnext.PointOfSale.ItemSelector = class {
 		const $filter_label = this.$component.find(".label");
 
 		$filter_label.html(value ? __(value) : __("All Items"));
+	}
+
+	hide_open_link_btn() {
+		$(this.item_group_field.$wrapper.find(".btn-open")).css("display", "none");
 	}
 
 	attach_clear_btn() {
@@ -249,11 +254,23 @@ erpnext.PointOfSale.ItemSelector = class {
 			</span>`
 		);
 
+		this.item_group_field.$wrapper.find(".link-btn").append(
+			`<a class="btn-clear" tabindex="-1" style="display: inline-block;" title="${__("Clear Link")}">
+				${frappe.utils.icon("close", "xs", "es-icon")}
+			</a>`
+		);
+
 		this.$clear_search_btn = this.search_field.$wrapper.find(".link-btn");
+		this.$clear_item_group_btn = this.item_group_field.$wrapper.find(".btn-clear");
 
 		this.$clear_search_btn.on("click", "a", () => {
 			this.set_search_value("");
 			this.search_field.set_focus();
+		});
+
+		this.$clear_item_group_btn.on("click", () => {
+			$(this.item_group_field.$input[0]).val("").trigger("input");
+			this.item_group_field.set_focus();
 		});
 	}
 


### PR DESCRIPTION
Changes include:
- `parent_item_group` is selected now based upon the `item_groups` selected on the POS Profile. 
- Item Group select field:
	- Fixed the awesomplete dropdown width.
		Before:
		
		<img width="552" height="740" alt="image" src="https://github.com/user-attachments/assets/7c1c2fcd-a185-439a-8f39-fadeb64cfa69" />

	  After: 
	 
	  <img width="494" height="754" alt="image" src="https://github.com/user-attachments/assets/4aa3cac0-0fc6-4ab2-8f4d-ffd3ff5ae662" />

	- Item Group Field is now only select, no provision to add new Item Group or Advanced Search.
		Before:

		<img width="516" height="736" alt="image" src="https://github.com/user-attachments/assets/eb067ef3-68df-4df3-a083-be2df8c8399e" />

		After:

		<img width="484" height="740" alt="image" src="https://github.com/user-attachments/assets/f796499b-88b5-4bf6-b381-8f8fdb0e3863" />

	- Onchange of Item Group Field, `label` on Item Selector section changes.
		Screen recording:
		
		https://github.com/user-attachments/assets/a587d2d3-a6d9-41e3-a52c-4af21917f663

- If there are no items, `Items not found` message will be displayed.

	<img width="1706" height="1362" alt="image" src="https://github.com/user-attachments/assets/ef96fcca-f3d7-437d-9d8b-6fd33ab8445b" />

- Animate on loading items on Item Selector.

- Better UX to remove Item Group Field selection and removed the `Open Link` button from the Item Group Field.



