### PR TITLE
feat(stock): add ability to update items in submitted Material Requests

### DIFF
--- a/erpnext/stock/doctype/material_request/material_request.js
+++ b/erpnext/stock/doctype/material_request/material_request.js
@@ -670,6 +670,7 @@ function set_schedule_date(frm) {
 	}
 }
 
+
 function prevent_past_schedule_dates(frm) {
 	if (frm.doc.transaction_date) {
 		frm.fields_dict["schedule_date"].datepicker.update({
@@ -677,3 +678,96 @@ function prevent_past_schedule_dates(frm) {
 		});
 	}
 }
+
+frappe.ui.form.on("Material Request", {
+	make_custom_buttons: function(frm) {
+		if (frm.doc.docstatus === 1 && 
+			frm.doc.material_request_type === "Purchase" && 
+			flt(frm.doc.per_ordered) < 100 && 
+			frm.doc.status !== "Stopped") {
+			
+			frm.add_custom_button(
+				__("Update Items"),
+				() => open_update_items_dialog(frm)
+			).addClass("btn-primary");
+		}
+	}
+});
+
+function open_update_items_dialog(frm) {
+	const table_data = frm.doc.items.map((d) => ({
+		docname: d.name,
+		item_code: d.item_code,
+		qty: flt(d.qty),
+		completed_qty: flt(d.ordered_qty),
+		uom: d.uom,
+		conversion_factor: flt(d.conversion_factor) || 1,
+		rate: d.rate,
+		warehouse: d.warehouse,
+		schedule_date: d.schedule_date
+	}));
+
+	const dialog = new frappe.ui.Dialog({
+		title: __("Update Material Request Items"),
+		size: "extra-large",
+		fields: [
+			{
+				fieldname: "items_table",
+				fieldtype: "Table",
+				label: __("Items"),
+				data: table_data,
+				get_status: (row) => (row && row.docname) ? "Read Only" : "Write",
+				fields: [
+					{ fieldtype: "Data", fieldname: "docname", hidden: 1 },
+					{ fieldtype: "Link", fieldname: "item_code", label: __("Item Code"), options: "Item", in_list_view: 1},
+					{ fieldtype: "Float", fieldname: "qty", label: __("Qty"), in_list_view: 1, reqd: 1 },
+					{ fieldtype: "Link", fieldname: "warehouse", label: __("Warehouse"), options: "Warehouse", in_list_view: 1,reqd:1 },
+					{ fieldtype: "Date", fieldname: "schedule_date", label: __("Required By"), in_list_view: 1 , reqd: 1},
+					{ fieldtype: "Float", fieldname: "completed_qty", label: __("Ordered Qty"), read_only: 1 },
+					{
+						fieldtype: "Link",
+						fieldname: "uom",
+						label: __("UOM"),
+						options: "UOM",
+						in_list_view: 1,
+						onchange() {
+							const row = this.doc;
+							if (!row.item_code || !this.value) return;
+							frappe.call({
+								method: "erpnext.stock.get_item_details.get_conversion_factor",
+								args: { item_code: row.item_code, uom: this.value },
+								callback(r) {
+									if (r.message) {
+										row.conversion_factor = flt(r.message.conversion_factor) || 1;
+										dialog.fields_dict.items_table.grid.refresh();
+									}
+								}
+							});
+						}
+					},
+					{ fieldtype: "Float", fieldname: "conversion_factor", label: __("Factor"),  },	
+					{ fieldtype: "Float", fieldname: "completed_qty", label: __("Ordered Qty"), read_only: 1 },
+				]
+			}
+		],
+		primary_action_label: __("Update"),
+		primary_action() {
+			const values = dialog.get_values();
+			if (!values) return;
+
+			frappe.call({
+				method: "erpnext.stock.doctype.material_request.material_request.update_items_after_submit",
+				freeze: true,
+				args: { material_request: frm.doc.name, trans_items: values.items_table },
+				callback(r) {
+					if (r.exc) return;
+					frm.reload_doc();
+					dialog.hide();
+					frappe.show_alert({message: __("Items Updated"), indicator: "green"});
+				}
+			});
+		}
+	});
+	dialog.show();
+}
+

--- a/erpnext/stock/doctype/material_request/material_request.js
+++ b/erpnext/stock/doctype/material_request/material_request.js
@@ -716,7 +716,7 @@ function open_update_items_dialog(frm) {
 				fieldtype: "Table",
 				label: __("Items"),
 				data: table_data,
-				get_status: (row) => (row && row.docname) ? "Read Only" : "Write",
+				get_status: (row) => (row && row.docname) ? "Read Only": "Write",
 				fields: [
 					{ fieldtype: "Data", fieldname: "docname", hidden: 1 },
 					{ fieldtype: "Link", fieldname: "item_code", label: __("Item Code"), options: "Item", in_list_view: 1,read_only_depends_on: "eval:doc.docname"},
@@ -745,7 +745,7 @@ function open_update_items_dialog(frm) {
 							});
 						}
 					},
-					{ fieldtype: "Float", fieldname: "conversion_factor", label: __("Factor"),  },	
+					{ fieldtype: "Float", fieldname: "conversion_factor", label: __("UMO Conversion Factor")  },	
 					{ fieldtype: "Float", fieldname: "completed_qty", label: __("Ordered Qty"), read_only: 1 },
 				]
 			}

--- a/erpnext/stock/doctype/material_request/material_request.js
+++ b/erpnext/stock/doctype/material_request/material_request.js
@@ -678,14 +678,13 @@ function prevent_past_schedule_dates(frm) {
 		});
 	}
 }
-
 frappe.ui.form.on("Material Request", {
 	make_custom_buttons: function(frm) {
-		if (frm.doc.docstatus === 1 && 
-			frm.doc.material_request_type === "Purchase" && 
-			flt(frm.doc.per_ordered) < 100 && 
+		if (frm.doc.docstatus === 1 &&
+			frm.doc.material_request_type === "Purchase" &&
+			flt(frm.doc.per_ordered) < 100 &&
 			frm.doc.status !== "Stopped") {
-			
+
 			frm.add_custom_button(
 				__("Update Items"),
 				() => open_update_items_dialog(frm)
@@ -695,16 +694,22 @@ frappe.ui.form.on("Material Request", {
 });
 
 function open_update_items_dialog(frm) {
+	const child_meta = frappe.get_meta("Material Request Item");
+	const get_precision = (fieldname) => child_meta.fields.find((f) => f.fieldname == fieldname).precision;
+
+	// Map data exactly like erpnext.utils.update_child_items
 	const table_data = frm.doc.items.map((d) => ({
 		docname: d.name,
+		name: d.name,
 		item_code: d.item_code,
+		item_name: d.item_name,
 		qty: flt(d.qty),
-		completed_qty: flt(d.ordered_qty),
+		ordered_qty: flt(d.ordered_qty),
 		uom: d.uom,
 		conversion_factor: flt(d.conversion_factor) || 1,
-		rate: d.rate,
 		warehouse: d.warehouse,
-		schedule_date: d.schedule_date
+		schedule_date: d.schedule_date,
+		description: d.description
 	}));
 
 	const dialog = new frappe.ui.Dialog({
@@ -712,41 +717,117 @@ function open_update_items_dialog(frm) {
 		size: "extra-large",
 		fields: [
 			{
-				fieldname: "items_table",
+				fieldname: "trans_items",
 				fieldtype: "Table",
 				label: __("Items"),
+				cannot_add_rows: false,
+				in_place_edit: true,
 				data: table_data,
-				get_status: (row) => (row && row.docname) ? "Read Only": "Write",
+				get_status: (row) => (row && row.docname) ? "Read Only" : "Write",
 				fields: [
-					{ fieldtype: "Data", fieldname: "docname", hidden: 1 },
-					{ fieldtype: "Link", fieldname: "item_code", label: __("Item Code"), options: "Item", in_list_view: 1,read_only_depends_on: "eval:doc.docname"},
-					{ fieldtype: "Float", fieldname: "qty", label: __("Qty"), in_list_view: 1, reqd: 1 },
-					{ fieldtype: "Link", fieldname: "warehouse", label: __("Warehouse"), options: "Warehouse", in_list_view: 1,reqd:1 },
-					{ fieldtype: "Date", fieldname: "schedule_date", label: __("Required By"), in_list_view: 1 , reqd: 1},
-					{ fieldtype: "Float", fieldname: "completed_qty", label: __("Ordered Qty"), read_only: 1 },
+					{
+						fieldtype: "Data",
+						fieldname: "docname",
+						hidden: 1
+					},
+					{
+						fieldtype: "Link",
+						fieldname: "item_code",
+						options: "Item",
+						label: __("Item Code"),
+						in_list_view: 1,
+						reqd: 1,
+						onchange: function() {
+							const me = this;
+							if (!this.value) return;
+							frappe.call({
+								method: "erpnext.stock.get_item_details.get_item_details",
+								args: {
+									doc: frm.doc,
+									item_code: this.value,
+									company: frm.doc.company,
+									doctype: frm.doc.doctype,
+									name: frm.doc.name,
+									qty: me.doc.qty || 1
+								},
+								callback: function(r) {
+									if (r.message) {
+										const row = dialog.fields_dict.trans_items.grid.get_row(me.doc.name);
+										if (row) {
+											Object.assign(row.doc, {
+												item_name: r.message.item_name,
+												uom: r.message.uom,
+												conversion_factor: r.message.conversion_factor,
+												description: r.message.description,
+												warehouse: r.message.warehouse || me.doc.warehouse
+											});
+											dialog.fields_dict.trans_items.grid.refresh();
+										}
+									}
+								}
+							});
+						}
+					},
+					{
+						fieldtype: "Data",
+						fieldname: "item_name",
+						label: __("Item Name"),
+						read_only: 1,
+						in_list_view: 1
+					},
+					{
+						fieldtype: "Link",
+						fieldname: "warehouse",
+						label: __("Warehouse"),
+						options: "Warehouse",
+						in_list_view: 1,
+						reqd: 1
+					},
+					{
+						fieldtype: "Float",
+						fieldname: "qty",
+						label: __("Qty"),
+						in_list_view: 1,
+						reqd: 1,
+						precision: get_precision("qty")
+					},
 					{
 						fieldtype: "Link",
 						fieldname: "uom",
 						label: __("UOM"),
 						options: "UOM",
 						in_list_view: 1,
-						onchange() {
-							const row = this.doc;
-							if (!row.item_code || !this.value) return;
+						reqd: 1,
+						onchange: function() {
+							const me = this;
+							if (!me.doc.item_code || !me.value) return;
 							frappe.call({
 								method: "erpnext.stock.get_item_details.get_conversion_factor",
-								args: { item_code: row.item_code, uom: this.value },
-								callback(r) {
+								args: { item_code: me.doc.item_code, uom: me.value },
+								callback: (r) => {
 									if (r.message) {
-										row.conversion_factor = flt(r.message.conversion_factor) || 1;
-										dialog.fields_dict.items_table.grid.refresh();
+										const row = dialog.fields_dict.trans_items.grid.get_row(me.doc.name);
+										row.doc.conversion_factor = r.message.conversion_factor;
+										dialog.fields_dict.trans_items.grid.refresh();
 									}
 								}
 							});
 						}
 					},
-					{ fieldtype: "Float", fieldname: "conversion_factor", label: __("UMO Conversion Factor")  },	
-					{ fieldtype: "Float", fieldname: "completed_qty", label: __("Ordered Qty"), read_only: 1 },
+					{
+						fieldtype: "Date",
+						fieldname: "schedule_date",
+						label: __("Reqd by date"),
+						in_list_view: 1,
+						reqd: 1
+					},
+					{
+						fieldtype: "Float",
+						fieldname: "ordered_qty",
+						label: __("Ordered Qty"),
+						read_only: 1,
+						precision: get_precision("qty")
+					}
 				]
 			}
 		],
@@ -758,16 +839,23 @@ function open_update_items_dialog(frm) {
 			frappe.call({
 				method: "erpnext.stock.doctype.material_request.material_request.update_items_after_submit",
 				freeze: true,
-				args: { material_request: frm.doc.name, trans_items: values.items_table },
+				args: {
+					material_request: frm.doc.name,
+					trans_items: values.trans_items
+				},
 				callback(r) {
-					if (r.exc) return;
-					frm.reload_doc();
-					dialog.hide();
-					frappe.show_alert({message: __("Items Updated"), indicator: "green"});
+					if (!r.exc) {
+						frm.reload_doc();
+						dialog.hide();
+						frappe.show_alert({
+							message: __("Items updated successfully"),
+							indicator: "green"
+						});
+					}
 				}
 			});
 		}
 	});
+
 	dialog.show();
 }
-

--- a/erpnext/stock/doctype/material_request/material_request.js
+++ b/erpnext/stock/doctype/material_request/material_request.js
@@ -719,7 +719,7 @@ function open_update_items_dialog(frm) {
 				get_status: (row) => (row && row.docname) ? "Read Only" : "Write",
 				fields: [
 					{ fieldtype: "Data", fieldname: "docname", hidden: 1 },
-					{ fieldtype: "Link", fieldname: "item_code", label: __("Item Code"), options: "Item", in_list_view: 1},
+					{ fieldtype: "Link", fieldname: "item_code", label: __("Item Code"), options: "Item", in_list_view: 1,read_only_depends_on: "eval:doc.docname"},
 					{ fieldtype: "Float", fieldname: "qty", label: __("Qty"), in_list_view: 1, reqd: 1 },
 					{ fieldtype: "Link", fieldname: "warehouse", label: __("Warehouse"), options: "Warehouse", in_list_view: 1,reqd:1 },
 					{ fieldtype: "Date", fieldname: "schedule_date", label: __("Required By"), in_list_view: 1 , reqd: 1},

--- a/erpnext/stock/doctype/material_request/material_request.md
+++ b/erpnext/stock/doctype/material_request/material_request.md
@@ -1,0 +1,15 @@
+# Updating Items in Submitted Material Request
+
+Users can now update certain fields in a Material Request after it has been submitted, provided they have "Write" permissions.
+
+### Fields that can be updated:
+- **Quantity**: Update the required quantity (cannot be less than already ordered quantity).
+- **Warehouse**: Change the target or source warehouse.
+- **Schedule Date**: Update the expected date for the items.
+- **Add Items**: New items can be appended to the existing request.
+
+### How to use:
+1. Open a **Submitted** Material Request.
+2. Use the "Update Items" button (added via client-side script).
+3. Modify the item rows in the dialog and click "Update".
+4. The system will automatically update requested and completed quantities.

--- a/erpnext/stock/doctype/material_request/material_request.py
+++ b/erpnext/stock/doctype/material_request/material_request.py
@@ -958,10 +958,6 @@ def make_in_transit_stock_entry(source_name, in_transit_warehouse):
 
 	return ste_doc
 
-import json
-import frappe
-from frappe import _
-from frappe.utils import flt
 
 @frappe.whitelist()
 def update_items_after_submit(material_request, trans_items):

--- a/erpnext/stock/doctype/material_request/material_request.py
+++ b/erpnext/stock/doctype/material_request/material_request.py
@@ -958,67 +958,89 @@ def make_in_transit_stock_entry(source_name, in_transit_warehouse):
 
 	return ste_doc
 
+import json
+import frappe
+from frappe import _
+from frappe.utils import flt
 
 @frappe.whitelist()
 def update_items_after_submit(material_request, trans_items):
+	"""
+	Updates quantities and warehouses in a submitted Material Request.
+	Standard: Uses check_permission and ensures proper qty validation.
+	"""
 	data = json.loads(trans_items) if isinstance(trans_items, str) else trans_items
 	doc = frappe.get_doc("Material Request", material_request)
+	
+	# Standard: Check if user has 'Write' permission on the document
 	doc.check_permission("write")
 
 	if doc.docstatus != 1:
-		frappe.throw(_("Material Request must be submitted"))
+		frappe.throw(_("Material Request {0} must be in a Submitted state to update items.").format(material_request))
 
 	any_qty_changed = False
 
 	for d in data:
 		child_item = None
 
-
 		if d.get("docname"):
-			for item in doc.items:
-				if item.name == d.get("docname"):
-					child_item = item
-					break
-
+			# Standard: Use find to locate the specific child row
+			child_item = next((item for item in doc.items if item.name == d.get("docname")), None)
 			if not child_item:
-				frappe.throw(_("Row {0} not found").format(d.get("docname")))
+				frappe.throw(_("Row {0} not found in the current document").format(d.get("docname")))
 		else:
+			# Standard: Adding a new row to a submitted document
 			child_item = doc.append("items", {})
 			child_item.item_code = d.get("item_code")
-
-			item_info = frappe.get_cached_value("Item", child_item.item_code,
+			
+			# Fetch item details properly
+			item_details = frappe.get_cached_value("Item", child_item.item_code, 
 				["item_name", "description", "stock_uom"], as_dict=1)
-			if item_info:
-				child_item.update(item_info)
-
+			
+			if item_details:
+				child_item.item_name = item_details.item_name
+				child_item.description = item_details.description
+				child_item.stock_uom = item_details.stock_uom
+			
 			any_qty_changed = True
 
+		# Calculations
 		new_qty = flt(d.get("qty"))
 		new_cf = flt(d.get("conversion_factor")) or 1.0
 		new_stock_qty = new_qty * new_cf
 
+		# Standard: Validation against already ordered/booked quantities
+		ordered_qty = flt(child_item.ordered_qty)
+		if ordered_qty > 0 and new_stock_qty < ordered_qty:
+			frappe.throw(_("Row {0} ({1}): New Quantity ({2}) cannot be less than Ordered Quantity ({3})")
+				.format(child_item.idx, child_item.item_code, new_stock_qty, ordered_qty))
 
-		if flt(child_item.ordered_qty) > 0 and new_stock_qty < flt(child_item.ordered_qty):
-			frappe.throw(_("Item {0}: Qty cannot be less than Ordered Qty").format(child_item.item_code))
-
+		# Track changes to trigger re-binning/qty updates
 		if child_item.qty != new_qty or child_item.warehouse != d.get("warehouse"):
 			any_qty_changed = True
 
+		# Update child row fields
 		child_item.qty = new_qty
 		child_item.uom = d.get("uom")
 		child_item.conversion_factor = new_cf
 		child_item.stock_qty = new_stock_qty
 		child_item.warehouse = d.get("warehouse")
 		child_item.schedule_date = d.get("schedule_date")
+		
+		# Allow update after submit for this row
 		child_item.flags.ignore_validate_update_after_submit = True
 
+	
 	doc.flags.ignore_validate_update_after_submit = True
 	doc.save()
 
+	
 	if any_qty_changed:
 		doc.update_requested_qty()
 		doc.update_completed_qty()
+		doc.set_status()
+		doc.db_set("status", doc.status)
 
-	doc.set_status()
-	doc.save()
+	doc.add_comment("Edit", _("Updated items via 'Update Items' dialog after submission."))
+
 	return doc.name

--- a/erpnext/stock/doctype/material_request/material_request.py
+++ b/erpnext/stock/doctype/material_request/material_request.py
@@ -957,3 +957,68 @@ def make_in_transit_stock_entry(source_name, in_transit_warehouse):
 		row.t_warehouse = in_transit_warehouse
 
 	return ste_doc
+
+
+@frappe.whitelist()
+def update_items_after_submit(material_request, trans_items):
+	data = json.loads(trans_items) if isinstance(trans_items, str) else trans_items
+	doc = frappe.get_doc("Material Request", material_request)
+	doc.check_permission("write")
+
+	if doc.docstatus != 1:
+		frappe.throw(_("Material Request must be submitted"))
+
+	any_qty_changed = False
+
+	for d in data:
+		child_item = None
+
+
+		if d.get("docname"):
+			for item in doc.items:
+				if item.name == d.get("docname"):
+					child_item = item
+					break
+
+			if not child_item:
+				frappe.throw(_("Row {0} not found").format(d.get("docname")))
+		else:
+			child_item = doc.append("items", {})
+			child_item.item_code = d.get("item_code")
+
+			item_info = frappe.get_cached_value("Item", child_item.item_code,
+				["item_name", "description", "stock_uom"], as_dict=1)
+			if item_info:
+				child_item.update(item_info)
+
+			any_qty_changed = True
+
+		new_qty = flt(d.get("qty"))
+		new_cf = flt(d.get("conversion_factor")) or 1.0
+		new_stock_qty = new_qty * new_cf
+
+
+		if flt(child_item.ordered_qty) > 0 and new_stock_qty < flt(child_item.ordered_qty):
+			frappe.throw(_("Item {0}: Qty cannot be less than Ordered Qty").format(child_item.item_code))
+
+		if child_item.qty != new_qty or child_item.warehouse != d.get("warehouse"):
+			any_qty_changed = True
+
+		child_item.qty = new_qty
+		child_item.uom = d.get("uom")
+		child_item.conversion_factor = new_cf
+		child_item.stock_qty = new_stock_qty
+		child_item.warehouse = d.get("warehouse")
+		child_item.schedule_date = d.get("schedule_date")
+		child_item.flags.ignore_validate_update_after_submit = True
+
+	doc.flags.ignore_validate_update_after_submit = True
+	doc.save()
+
+	if any_qty_changed:
+		doc.update_requested_qty()
+		doc.update_completed_qty()
+
+	doc.set_status()
+	doc.save()
+	return doc.name

--- a/erpnext/stock/doctype/material_request/test_material_request.py
+++ b/erpnext/stock/doctype/material_request/test_material_request.py
@@ -1147,4 +1147,3 @@ def test_update_items_after_submit(self):
 		mr.reload()
 
 		self.assertEqual(mr.items[0].qty, 15)
->>>>>>> Stashed changes

--- a/erpnext/stock/doctype/material_request/test_material_request.py
+++ b/erpnext/stock/doctype/material_request/test_material_request.py
@@ -1125,25 +1125,58 @@ test_dependencies = ["Currency Exchange", "BOM"]
 test_records = frappe.get_test_records("Material Request")
 
 
-def test_update_items_after_submit(self):
-		from erpnext.stock.doctype.material_request.material_request import update_items_after_submit
-		import json
+class TestMaterialRequest(FrappeTestCase):
+	def test_update_items_after_submit(self):
+		"""
+		Test standard logic for updating items in a submitted Material Request.
+		Covers: Existing row update, adding new row, and qty validation.
+		"""
+		from erpnext.stock.doctype.material_request.test_material_request import make_material_request
 
-		mr = make_material_request(qty=10)
+		# 1. Setup: Create and Submit Material Request
+		mr = make_material_request(item_code="_Test Item", qty=10, warehouse="_Test Warehouse - _TC")
 		mr.submit()
 
-	
-		new_items = json.dumps([{
-			"docname": mr.items[0].name,
-			"item_code": mr.items[0].item_code,
-			"qty": 15,
-			"conversion_factor": 1.0,
-			"uom": mr.items[0].uom,
-			"warehouse": mr.items[0].warehouse,
-			"schedule_date": mr.items[0].schedule_date
-		}])
+		# 2. Update existing row (increase qty to 15)
+		updated_items = [
+			{
+				"docname": mr.items[0].name,
+				"item_code": mr.items[0].item_code,
+				"qty": 15,
+				"conversion_factor": 1.0,
+				"uom": "Nos",
+				"warehouse": "_Test Warehouse - _TC",
+				"schedule_date": mr.items[0].schedule_date
+			},
+			{
+				# 3. Add a new row to the submitted document
+				"item_code": "_Test Item Home Desktop 100",
+				"qty": 5,
+				"conversion_factor": 1.0,
+				"uom": "Nos",
+				"warehouse": "_Test Warehouse - _TC",
+				"schedule_date": mr.items[0].schedule_date
+			}
+		]
 
-		update_items_after_submit(mr.name, new_items)
+	
+		update_items_after_submit(mr.name, json.dumps(updated_items))
 		mr.reload()
 
+		
+		self.assertEqual(len(mr.items), 2)
 		self.assertEqual(mr.items[0].qty, 15)
+		self.assertEqual(mr.items[1].item_code, "_Test Item Home Desktop 100")
+		self.assertEqual(mr.items[1].qty, 5)
+
+		# Mock an ordered quantity on the first item
+		frappe.db.set_value("Material Request Item", mr.items[0].name, "ordered_qty", 20)
+		
+		invalid_items = json.dumps([{
+			"docname": mr.items[0].name,
+			"item_code": mr.items[0].item_code,
+			"qty": 10 # This is less than the mocked ordered_qty of 20
+		}])
+
+	
+		self.assertRaises(frappe.ValidationError, update_items_after_submit, mr.name, invalid_items)

--- a/erpnext/stock/doctype/material_request/test_material_request.py
+++ b/erpnext/stock/doctype/material_request/test_material_request.py
@@ -1118,4 +1118,33 @@ def make_material_request(**args):
 	return mr
 
 
+
 EXTRA_TEST_RECORD_DEPENDENCIES = ["Currency Exchange", "BOM"]
+
+test_dependencies = ["Currency Exchange", "BOM"]
+test_records = frappe.get_test_records("Material Request")
+
+
+def test_update_items_after_submit(self):
+		from erpnext.stock.doctype.material_request.material_request import update_items_after_submit
+		import json
+
+		mr = make_material_request(qty=10)
+		mr.submit()
+
+	
+		new_items = json.dumps([{
+			"docname": mr.items[0].name,
+			"item_code": mr.items[0].item_code,
+			"qty": 15,
+			"conversion_factor": 1.0,
+			"uom": mr.items[0].uom,
+			"warehouse": mr.items[0].warehouse,
+			"schedule_date": mr.items[0].schedule_date
+		}])
+
+		update_items_after_submit(mr.name, new_items)
+		mr.reload()
+
+		self.assertEqual(mr.items[0].qty, 15)
+>>>>>>> Stashed changes


### PR DESCRIPTION
This Pull Request introduces a whitelisted server-side function to allow authorized users to update item quantities, target warehouses, and schedule dates on a Submitted Material Request without requiring a full cancel-and-amend cycle.

Details
Method: Implementation of update_items_after_submit in material_request.py.

Logic: Handled both existing row updates via docname and the addition of new rows to a submitted document.

Validation: Added a check to prevent reducing quantity below the already ordered_qty to maintain stock integrity.

Automation: The system automatically triggers update_requested_qty and update_completed_qty upon successful update.

Testing: Added a comprehensive unit test in test_material_request.py to verify the update logic.

Documentation
User documentation has been added to the repository to guide users on using the new "Update Items" dialog.

File Path: erpnext/stock/doctype/material_request/material_request.md

Content: Covers fields available for update and validation rules.

[x] Documentation has been added

[x] All tests pass locally (UI and Unit tests)

[x] PR name follows Conventional Commits
[Screencast from 2026-01-05 22-08-31.webm](https://github.com/user-attachments/assets/b29f4a73-3fdc-4e4f-aee4-ca6d6d5f642d)
