### PR TITLE
fix: clear advances table when credit note is created from sales invoice

### DIFF
--- a/erpnext/controllers/sales_and_purchase_return.py
+++ b/erpnext/controllers/sales_and_purchase_return.py
@@ -443,6 +443,7 @@ def make_return_doc(doctype: str, source_name: str, target_doc=None, return_agai
 		doc.is_return = 1
 		doc.ignore_pricing_rule = 1
 		doc.pricing_rules = []
+		doc.advances = []
 		doc.return_against = source.name
 		doc.set_warehouse = ""
 		if doctype == "Sales Invoice" or doctype == "POS Invoice":


### PR DESCRIPTION
**Issue**: [#49519](https://github.com/frappe/erpnext/issues/49519)

**Description:** When making a return/ credit note from a sales invoice, the advances are being fetched, which disallows the form from being saved.

<img width="1301" height="627" alt="image" src="https://github.com/user-attachments/assets/8c3dc874-3a7a-45d2-aced-c9189a2b425f" />

<img width="1301" height="627" alt="Screenshot from 2026-01-09 14-21-49" src="https://github.com/user-attachments/assets/1c9979ea-6945-4c6a-b37b-9315e7cd6d09" />


Backport needed in v15



