### PR TITLE
fix(asset): remove references  for composite and existing assets

### DIFF
--- a/erpnext/assets/doctype/asset/asset.js
+++ b/erpnext/assets/doctype/asset/asset.js
@@ -237,6 +237,8 @@ frappe.ui.form.on("Asset", {
 		} else if (frm.doc.is_existing_asset || frm.doc.is_composite_asset) {
 			frm.toggle_reqd("purchase_receipt", 0);
 			frm.toggle_reqd("purchase_invoice", 0);
+			frm.set_value("purchase_receipt", "");
+			frm.set_value("purchase_invoice", "");
 		} else if (frm.doc.purchase_receipt) {
 			// if purchase receipt link is set then set PI disabled
 			frm.toggle_reqd("purchase_invoice", 0);
@@ -480,7 +482,6 @@ frappe.ui.form.on("Asset", {
 		} else {
 			frm.set_df_property("net_purchase_amount", "read_only", 0);
 		}
-
 		frm.trigger("toggle_reference_doc");
 	},
 


### PR DESCRIPTION
**Issue:**
Purchase links are not getting unlink even if we enable the is_existing_asset checkbox.

**Before:**

[Screencast from 08-01-26 04:45:08 PM IST.webm](https://github.com/user-attachments/assets/30f7297d-ac08-455d-b0f0-3339d6f94f60)

**After:**

[Screencast from 08-01-26 04:52:13 PM IST.webm](https://github.com/user-attachments/assets/c4013dcd-82f4-4ba8-8542-042dccdccb8b)

**backport Needed for v15**