### PR TITLE
feat: add inclusion type and party group

### DIFF
--- a/erpnext/controllers/queries.py
+++ b/erpnext/controllers/queries.py
@@ -208,11 +208,9 @@ def item_query(doctype, txt, searchfield, start, page_len, filters, as_dict=Fals
 	searchfields = " or ".join([field + " like %(txt)s" for field in searchfields])
 
 	if filters and isinstance(filters, dict):
-		if filters.get("customer") or filters.get("supplier"):
+		if party := filters.get("customer") or filters.get("supplier"):
 			party_doctype = "Customer" if filters.get("customer") else "Supplier"
-			group_type = "customer_group" if party_doctype == "Customer" else "supplier_group"
-			party = filters.get("customer") or filters.get("supplier")
-			party_group = frappe.get_value(party_doctype, party, group_type)
+			party_group = frappe.get_value(party_doctype, party, f"{party_doctype.lower()}_group")
 
 			party_list = [party]
 			if party_group:

--- a/erpnext/controllers/queries.py
+++ b/erpnext/controllers/queries.py
@@ -209,24 +209,45 @@ def item_query(doctype, txt, searchfield, start, page_len, filters, as_dict=Fals
 
 	if filters and isinstance(filters, dict):
 		if filters.get("customer") or filters.get("supplier"):
+			party_doctype = "Customer" if filters.get("customer") else "Supplier"
+			group_type = "customer_group" if party_doctype == "Customer" else "supplier_group"
 			party = filters.get("customer") or filters.get("supplier")
+			party_group = frappe.get_value(party_doctype, party, group_type)
+
+			party_list = [party]
+			if party_group:
+				party_list.append(party_group)
+
+			type_list = []
+			if party_doctype == "Customer":
+				type_list.extend(["Customer", "Customer Group"])
+			elif party_doctype == "Supplier":
+				type_list.extend(["Supplier", "Supplier Group"])
+
 			item_rules_list = frappe.get_all(
 				"Party Specific Item",
-				filters={"party": party},
-				fields=["restrict_based_on", "based_on_value"],
+				filters=[["party", "in", party_list], ["party_type", "in", type_list]],
+				fields=["restrict_based_on", "based_on_value", "inclusion_type"],
 			)
 
-			filters_dict = {}
+			include_filters = defaultdict(list)
+			exclude_filters = defaultdict(list)
+
 			for rule in item_rules_list:
 				if rule["restrict_based_on"] == "Item":
 					rule["restrict_based_on"] = "name"
-				filters_dict[rule.restrict_based_on] = []
 
-			for rule in item_rules_list:
-				filters_dict[rule.restrict_based_on].append(rule.based_on_value)
+				if rule.get("inclusion_type", "Inclusive") == "Exclusive":
+					exclude_filters[rule.restrict_based_on].append(rule.based_on_value)
+				else:
+					include_filters[rule.restrict_based_on].append(rule.based_on_value)
 
-			for filter in filters_dict:
-				filters[scrub(filter)] = ["in", filters_dict[filter]]
+			for key, values in include_filters.items():
+				filters[scrub(key)] = ["in", values]
+
+			for key, values in exclude_filters.items():
+				if key not in include_filters:
+					filters[scrub(key)] = ["not in", values]
 
 			if filters.get("customer"):
 				del filters["customer"]

--- a/erpnext/selling/doctype/party_specific_item/party_specific_item.json
+++ b/erpnext/selling/doctype/party_specific_item/party_specific_item.json
@@ -10,22 +10,23 @@
   "party",
   "column_break_3",
   "restrict_based_on",
-  "based_on_value"
+  "based_on_value",
+  "inclusion_type"
  ],
  "fields": [
   {
    "fieldname": "party_type",
    "fieldtype": "Select",
    "in_list_view": 1,
-   "label": "Party Type",
-   "options": "Customer\nSupplier",
+   "label": "Party Type / Group",
+   "options": "Customer\nCustomer Group\nSupplier\nSupplier Group",
    "reqd": 1
   },
   {
    "fieldname": "party",
    "fieldtype": "Dynamic Link",
    "in_list_view": 1,
-   "label": "Party Name",
+   "label": "Party Name / Group",
    "options": "party_type",
    "reqd": 1
   },
@@ -48,11 +49,20 @@
    "label": "Based On Value",
    "options": "restrict_based_on",
    "reqd": 1
+  },
+  {
+   "default": "Inclusive",
+   "fieldname": "inclusion_type",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "label": "Inclusion Type",
+   "options": "Inclusive\nExclusive",
+   "reqd": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-03-27 13:10:08.752476",
+ "modified": "2026-01-09 20:46:56.483071",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Party Specific Item",
@@ -71,6 +81,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],

--- a/erpnext/selling/doctype/party_specific_item/party_specific_item.py
+++ b/erpnext/selling/doctype/party_specific_item/party_specific_item.py
@@ -16,8 +16,9 @@ class PartySpecificItem(Document):
 		from frappe.types import DF
 
 		based_on_value: DF.DynamicLink
+		inclusion_type: DF.Literal["Inclusive", "Exclusive"]
 		party: DF.DynamicLink
-		party_type: DF.Literal["Customer", "Supplier"]
+		party_type: DF.Literal["Customer", "Customer Group", "Supplier", "Supplier Group"]
 		restrict_based_on: DF.Literal["Item", "Item Group", "Brand"]
 	# end: auto-generated types
 
@@ -29,6 +30,7 @@ class PartySpecificItem(Document):
 				"party": self.party,
 				"restrict_based_on": self.restrict_based_on,
 				"based_on_value": self.based_on_value,
+				"name": ["!=", self.name],
 			},
 		)
 		if exists:

--- a/erpnext/selling/doctype/party_specific_item/party_specific_item.py
+++ b/erpnext/selling/doctype/party_specific_item/party_specific_item.py
@@ -23,15 +23,29 @@ class PartySpecificItem(Document):
 	# end: auto-generated types
 
 	def validate(self):
+		party_type = [self.party_type]
+		party = [self.party]
+
+		if self.party_type in ["Customer", "Supplier"]:
+			if party_group := frappe.get_value(
+				self.party_type, self.party, f"{self.party_type.lower()}_group"
+			):
+				party.append(party_group)
+				party_type.append(f"{self.party_type} Group")
+
 		exists = frappe.db.exists(
 			"Party Specific Item",
 			{
-				"party_type": self.party_type,
-				"party": self.party,
+				"party_type": ["in", party_type],
+				"party": ["in", party],
 				"restrict_based_on": self.restrict_based_on,
 				"based_on_value": self.based_on_value,
 				"name": ["!=", self.name],
 			},
 		)
 		if exists:
-			frappe.throw(_("This item filter has already been applied for the {0}").format(self.party_type))
+			frappe.throw(
+				_("This item filter has already been applied in {0}").format(
+					frappe.utils.get_link_to_form("Party Specific Item", exists)
+				)
+			)


### PR DESCRIPTION
**Description:**
In the Party Specific Item Doctype, the customer and supplier groups were introduced to manage groups of customers or suppliers with similar rules.

The Inclusion Type field was added to control how the item rules can be applied:
- Inclusive → The items specified in this doctype are allowed for the specific Party/Group.
- Exclusive → All items are allowed by default, except the item defined in this doctype.

**fixes:** #45221 #49795 #38757


https://github.com/user-attachments/assets/dd4ae893-d22a-4ca4-8b09-4a66edcc2b24



Backport needed for 15