### PR TITLE
fix: pick list qty does not reset when pick list is cancelled

### DIFF
--- a/erpnext/stock/doctype/pick_list/pick_list.py
+++ b/erpnext/stock/doctype/pick_list/pick_list.py
@@ -400,7 +400,7 @@ class PickList(TransactionBase):
 		picked_items = get_picked_items_qty(packed_items, contains_packed_items=True)
 		self.validate_picked_qty(picked_items)
 
-		doc_updates = {}
+		doc_updates = {item: {"picked_qty": 0} for item in set(packed_items)}
 		for d in picked_items:
 			doc_updates[d.product_bundle_item] = {"picked_qty": flt(d.picked_qty)}
 
@@ -411,7 +411,7 @@ class PickList(TransactionBase):
 		picked_items = get_picked_items_qty(so_items)
 		self.validate_picked_qty(picked_items)
 
-		doc_updates = {}
+		doc_updates = {item: {"picked_qty": 0} for item in set(so_items)}
 		for d in picked_items:
 			doc_updates[d.sales_order_item] = {"picked_qty": flt(d.picked_qty)}
 


### PR DESCRIPTION
1. Create Sales Order
2. Create Pick List from Sales Order
3. Cancel Pick List
4. Go back to Sales Order
5. Create -> Pick List option is missing because picked_qty was never reset to 0