### PR TITLE
fix: include credit notes in project gross margin calculation

### DIFF
--- a/erpnext/projects/doctype/project/project.py
+++ b/erpnext/projects/doctype/project/project.py
@@ -308,6 +308,8 @@ class Project(Document):
 		self.gross_margin = flt(self.total_billed_amount) - expense_amount
 		if self.total_billed_amount:
 			self.per_gross_margin = (self.gross_margin / flt(self.total_billed_amount)) * 100
+		else:
+			self.per_gross_margin = 0
 
 	def update_purchase_costing(self):
 		total_purchase_cost = calculate_total_purchase_cost(self.name)


### PR DESCRIPTION
**Issue:**
When a Sales Invoice linked to a Project is later fully credited using a Credit Note, the Project’s Gross Margin % is not updated correctly. 

Ref: [#56920](https://support.frappe.io/helpdesk/tickets/56920)

**Steps to Reproduce:**

1. Create a Project.
2. Create a Sales Invoice and link the Project.
3. Submit the Sales Invoice.
4. Open the Project and check the Gross Margin % (it shows 100%).
5. Create a Credit Note (Sales Invoice Return) against the same Sales Invoice for the full amount.
6. Submit the Credit Note.
7. Open the Project again and check the Gross Margin %.

Backport needed:v15