### PR TITLE
fix(stock entry): calculate transferred quantity using transfer_qty

### DIFF
--- a/erpnext/stock/doctype/material_request/test_material_request.py
+++ b/erpnext/stock/doctype/material_request/test_material_request.py
@@ -1138,7 +1138,8 @@ def make_material_request(**args):
 	mr = frappe.new_doc("Material Request")
 	mr.material_request_type = args.material_request_type or "Purchase"
 	mr.company = args.company or "_Test Company"
-	mr.customer = args.customer or "_Test Customer"
+	if mr.material_request_type == "Customer Provided":
+		mr.customer = args.customer or "_Test Customer"
 	mr.append(
 		"items",
 		{
@@ -1147,6 +1148,7 @@ def make_material_request(**args):
 			"uom": args.uom or "_Test UOM",
 			"conversion_factor": args.conversion_factor or 1,
 			"schedule_date": args.schedule_date or today(),
+			"from_warehouse": args.from_warehouse,
 			"warehouse": args.warehouse or "_Test Warehouse - _TC",
 			"cost_center": args.cost_center or "_Test Cost Center - _TC",
 		},

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -3238,7 +3238,7 @@ class StockEntry(StockController, SubcontractingInwardController):
 				stock_entries_child_list.append(d.ste_detail)
 				transferred_qty = frappe.get_all(
 					"Stock Entry Detail",
-					fields=[{"SUM": "qty", "as": "qty"}],
+					fields=[{"SUM": "transfer_qty", "as": "qty"}],
 					filters={
 						"against_stock_entry": d.against_stock_entry,
 						"ste_detail": d.ste_detail,


### PR DESCRIPTION
**Issue:** When creating a Material Request for Material Transfer with the item using a different UOM other than the item's stock UOM, the system fails to use the UOM conversion applied qty(transfer_qty) to update the transferred_qty in the Stock Entry. So the Material Request stuck in "In Transit" status even after the transfer is fully completed.

**Ref:**  [57022](https://support.frappe.io/helpdesk/tickets/57022)

**Steps to Reproduce:**
**Step 1:** Create Material Request (Material Transfer)
- Qty = 1, UOM: Box (1 Box = 12 Nos).

**Step 2:** Create In Transit Stock Entry (Source → In-Transit)
**Step 3:** Create End Transit Stock Entry (In-Transit → Target)
**Step 4:** Observe Material Request's transfer status still showing "In-Transit" instead of "Completed"

Before:

https://github.com/user-attachments/assets/1f23ec17-8a59-4e06-bf5e-a19e0e0bac25

<img width="1426" height="836" alt="Screenshot 2026-01-11 at 17 54 56" src="https://github.com/user-attachments/assets/aa281be8-88db-4b8f-9d01-3d1599a4bf6f" />


After:

https://github.com/user-attachments/assets/48b3b17f-a0da-418f-abbf-f5364f6e7e5a

<img width="1429" height="811" alt="Screenshot 2026-01-11 at 17 55 54" src="https://github.com/user-attachments/assets/98ab3d53-7c49-4a31-9f87-a7d291b31119" />

