### PR TITLE
refactor: single table for better performance

### DIFF
--- a/erpnext/controllers/stock_controller.py
+++ b/erpnext/controllers/stock_controller.py
@@ -921,12 +921,22 @@ class StockController(AccountsController):
 						"Serial and Batch Bundle", row.serial_and_batch_bundle, {"is_cancelled": 1}
 					)
 
+					frappe.db.set_value(
+						"Serial and Batch Entry", {"parent": row.serial_and_batch_bundle}, {"is_cancelled": 1}
+					)
+
 				if update_values:
 					row.db_set(update_values)
 
 				if table_name == "items" and row.get("rejected_serial_and_batch_bundle"):
 					frappe.db.set_value(
 						"Serial and Batch Bundle", row.rejected_serial_and_batch_bundle, {"is_cancelled": 1}
+					)
+
+					frappe.db.set_value(
+						"Serial and Batch Entry",
+						{"parent": row.rejected_serial_and_batch_bundle},
+						{"is_cancelled": 1},
 					)
 
 					row.db_set("rejected_serial_and_batch_bundle", None)
@@ -2310,6 +2320,7 @@ def make_bundle_for_material_transfer(**kwargs):
 		row.voucher_no = bundle_doc.voucher_no
 		row.voucher_detail_no = bundle_doc.voucher_detail_no
 		row.type_of_transaction = bundle_doc.type_of_transaction
+		row.item_code = bundle_doc.item_code
 
 	bundle_doc.set_incoming_rate()
 	bundle_doc.calculate_qty_and_amount()

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -443,7 +443,7 @@ erpnext.patches.v16_0.rename_subcontracted_quantity
 erpnext.patches.v16_0.add_new_stock_entry_types
 erpnext.patches.v15_0.set_asset_status_if_not_already_set
 erpnext.patches.v15_0.toggle_legacy_controller_for_period_closing
-erpnext.patches.v16_0.update_serial_batch_entries
+erpnext.patches.v16_0.update_serial_batch_entries #11-01-2026 10:00:00
 erpnext.patches.v16_0.set_company_wise_warehouses
 erpnext.patches.v16_0.set_valuation_method_on_companies
 erpnext.patches.v15_0.migrate_old_item_wise_tax_detail_data_to_table

--- a/erpnext/patches/v16_0/update_serial_batch_entries.py
+++ b/erpnext/patches/v16_0/update_serial_batch_entries.py
@@ -11,7 +11,9 @@ def execute():
 					SABE.voucher_type = SABB.voucher_type,
 					SABE.voucher_no = SABB.voucher_no,
 					SABE.voucher_detail_no = SABB.voucher_detail_no,
-					SABE.type_of_transaction = SABB.type_of_transaction
+					SABE.type_of_transaction = SABB.type_of_transaction,
+					SABE.is_cancelled = SABB.is_cancelled,
+					SABE.item_code = SABB.item_code
 				WHERE SABE.parent = SABB.name
 			"""
 		)

--- a/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py
+++ b/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py
@@ -139,6 +139,7 @@ class SerialandBatchBundle(Document):
 			self.set_incoming_rate()
 
 		self.calculate_qty_and_amount()
+		self.set_child_details()
 
 	def validate_serial_no_status(self):
 		serial_nos = [d.serial_no for d in self.entries if d.serial_no]
@@ -1342,7 +1343,17 @@ class SerialandBatchBundle(Document):
 		self.set_source_document_no()
 
 	def on_submit(self):
+		self.validate_docstatus()
 		self.validate_serial_nos_inventory()
+
+	def validate_docstatus(self):
+		for row in self.entries:
+			if row.docstatus != 1:
+				frappe.throw(
+					_("At Row {0}: In Serial and Batch Bundle {1} must have docstatus as 1 and not 0").format(
+						bold(row.idx), bold(self.name)
+					)
+				)
 
 	def set_child_details(self):
 		for row in self.entries:
@@ -1353,6 +1364,7 @@ class SerialandBatchBundle(Document):
 				"voucher_no",
 				"voucher_detail_no",
 				"type_of_transaction",
+				"item_code",
 			]:
 				if not row.get(field) or row.get(field) != self.get(field):
 					row.set(field, self.get(field))

--- a/erpnext/stock/doctype/serial_and_batch_entry/serial_and_batch_entry.json
+++ b/erpnext/stock/doctype/serial_and_batch_entry/serial_and_batch_entry.json
@@ -7,6 +7,7 @@
  "field_order": [
   "serial_no",
   "batch_no",
+  "item_code",
   "column_break_2",
   "qty",
   "warehouse",
@@ -22,6 +23,7 @@
   "reference_for_reservation",
   "voucher_type",
   "voucher_no",
+  "is_cancelled",
   "column_break_eykr",
   "posting_datetime",
   "type_of_transaction",
@@ -146,24 +148,28 @@
    "fieldname": "posting_datetime",
    "fieldtype": "Datetime",
    "label": "Posting Datetime",
+   "no_copy": 1,
    "read_only": 1
   },
   {
    "fieldname": "voucher_type",
    "fieldtype": "Data",
    "label": "Voucher Type",
+   "no_copy": 1,
    "read_only": 1
   },
   {
    "fieldname": "voucher_no",
    "fieldtype": "Data",
    "label": "Voucher No",
+   "no_copy": 1,
    "read_only": 1
   },
   {
    "fieldname": "voucher_detail_no",
    "fieldtype": "Data",
    "label": "Voucher Detail No",
+   "no_copy": 1,
    "read_only": 1,
    "search_index": 1
   },
@@ -171,18 +177,35 @@
    "fieldname": "type_of_transaction",
    "fieldtype": "Data",
    "label": "Type of Transaction",
+   "no_copy": 1,
    "read_only": 1,
    "search_index": 1
   },
   {
    "fieldname": "column_break_eykr",
    "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "fieldname": "is_cancelled",
+   "fieldtype": "Check",
+   "label": "Is Cancelled",
+   "no_copy": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "item_code",
+   "fieldtype": "Link",
+   "label": "Item Code",
+   "no_copy": 1,
+   "options": "Item",
+   "read_only": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-11-09 23:28:35.191959",
+ "modified": "2026-01-11 11:05:10.789054",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Serial and Batch Entry",

--- a/erpnext/stock/doctype/serial_and_batch_entry/serial_and_batch_entry.py
+++ b/erpnext/stock/doctype/serial_and_batch_entry/serial_and_batch_entry.py
@@ -17,7 +17,9 @@ class SerialandBatchEntry(Document):
 		batch_no: DF.Link | None
 		delivered_qty: DF.Float
 		incoming_rate: DF.Float
+		is_cancelled: DF.Check
 		is_outward: DF.Check
+		item_code: DF.Link | None
 		outgoing_rate: DF.Float
 		parent: DF.Data
 		parentfield: DF.Data


### PR DESCRIPTION
Join between serial and batch bundle and serial an batch entry is slow, so from v16 will be using only serial an batch entry table to fetch the valuation rate for better performance