### PR TITLE
fix(asset value adjustment): skip cancelling revaluation journal entry if already cancelled

### DIFF
--- a/erpnext/accounts/doctype/journal_entry/journal_entry.py
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.py
@@ -185,7 +185,7 @@ class JournalEntry(AccountsController):
 			return self._submit()
 
 	def before_cancel(self):
-		pass
+		self.has_asset_adjustment_entry()
 
 	def cancel(self):
 		if len(self.accounts) > 100:
@@ -308,7 +308,6 @@ class JournalEntry(AccountsController):
 		)
 		self.make_gl_entries(1)
 		JournalTaxWithholding(self).on_cancel()
-		self.has_asset_adjustment_entry()
 		self.unlink_advance_entry_reference()
 		self.unlink_asset_reference()
 		self.unlink_inter_company_jv()

--- a/erpnext/accounts/doctype/journal_entry/journal_entry.py
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.py
@@ -555,11 +555,12 @@ class JournalEntry(AccountsController):
 			frappe.db.set_value("Journal Entry", self.name, "inter_company_journal_entry_reference", "")
 
 	def unlink_asset_adjustment_entry(self):
-		frappe.db.sql(
-			""" update `tabAsset Value Adjustment`
-			set journal_entry = null where journal_entry = %s""",
-			self.name,
-		)
+		AssetValueAdjustment = frappe.qb.DocType("Asset Value Adjustment")
+		(
+			frappe.qb.update(AssetValueAdjustment)
+			.set(AssetValueAdjustment.journal_entry, None)
+			.where(AssetValueAdjustment.journal_entry == self.name)
+		).run()
 
 	def validate_party(self):
 		for d in self.get("accounts"):

--- a/erpnext/accounts/doctype/journal_entry/journal_entry.py
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.py
@@ -184,6 +184,9 @@ class JournalEntry(AccountsController):
 		else:
 			return self._submit()
 
+	def before_cancel(self):
+		pass
+
 	def cancel(self):
 		if len(self.accounts) > 100:
 			queue_submission(self, "_cancel")
@@ -305,6 +308,7 @@ class JournalEntry(AccountsController):
 		)
 		self.make_gl_entries(1)
 		JournalTaxWithholding(self).on_cancel()
+		self.has_asset_adjustment_entry()
 		self.unlink_advance_entry_reference()
 		self.unlink_asset_reference()
 		self.unlink_inter_company_jv()
@@ -553,6 +557,20 @@ class JournalEntry(AccountsController):
 				"",
 			)
 			frappe.db.set_value("Journal Entry", self.name, "inter_company_journal_entry_reference", "")
+
+	def has_asset_adjustment_entry(self):
+		if self.flags.get("via_asset_value_adjustment"):
+			return
+
+		asset_value_adjustment = frappe.db.get_value(
+			"Asset Value Adjustment", {"docstatus": 1, "journal_entry": self.name}, "name"
+		)
+		if asset_value_adjustment:
+			frappe.throw(
+				_(
+					"Cannot cancel this document as it is linked with the submitted Asset Value Adjustment <b>{0}</b>. Please cancel the Asset Value Adjustment to continue."
+				).format(frappe.utils.get_link_to_form("Asset Value Adjustment", asset_value_adjustment))
+			)
 
 	def unlink_asset_adjustment_entry(self):
 		AssetValueAdjustment = frappe.qb.DocType("Asset Value Adjustment")

--- a/erpnext/assets/doctype/asset_value_adjustment/asset_value_adjustment.py
+++ b/erpnext/assets/doctype/asset_value_adjustment/asset_value_adjustment.py
@@ -74,7 +74,7 @@ class AssetValueAdjustment(Document):
 		)
 
 	def on_cancel(self):
-		frappe.get_doc("Journal Entry", self.journal_entry).cancel()
+		self.cancel_asset_revaluation_entry()
 		self.update_asset()
 		add_asset_activity(
 			self.asset,
@@ -166,6 +166,14 @@ class AssetValueAdjustment(Document):
 
 			if dimension.get("mandatory_for_pl"):
 				debit_entry.update({dimension["fieldname"]: dimension_value})
+
+	def cancel_asset_revaluation_entry(self):
+		if not self.journal_entry:
+			return
+
+		revaluation_entry = frappe.get_doc("Journal Entry", self.journal_entry)
+		if revaluation_entry.docstatus == 1:
+			revaluation_entry.cancel()
 
 	def update_asset(self):
 		asset = self.update_asset_value_after_depreciation()

--- a/erpnext/assets/doctype/asset_value_adjustment/asset_value_adjustment.py
+++ b/erpnext/assets/doctype/asset_value_adjustment/asset_value_adjustment.py
@@ -175,6 +175,7 @@ class AssetValueAdjustment(Document):
 		if revaluation_entry.docstatus == 1:
 			# Ignore permissions to match Journal Entry submission behavior
 			revaluation_entry.flags.ignore_permissions = True
+			revaluation_entry.flags.via_asset_value_adjustment = True
 			revaluation_entry.cancel()
 
 	def update_asset(self):

--- a/erpnext/assets/doctype/asset_value_adjustment/asset_value_adjustment.py
+++ b/erpnext/assets/doctype/asset_value_adjustment/asset_value_adjustment.py
@@ -173,6 +173,8 @@ class AssetValueAdjustment(Document):
 
 		revaluation_entry = frappe.get_doc("Journal Entry", self.journal_entry)
 		if revaluation_entry.docstatus == 1:
+			# Ignore permissions to match Journal Entry submission behavior
+			revaluation_entry.flags.ignore_permissions = True
 			revaluation_entry.cancel()
 
 	def update_asset(self):


### PR DESCRIPTION
**Issue:** When an Asset Value Adjustment is posted, and the related Revaluation Journal Entry is manually cancelled, the system does not allow the Asset Value Adjustment to be cancelled afterwards.

**Ref:** [56819](https://support.frappe.io/helpdesk/tickets/56819)

**Steps to reproduce:**
**Step 1:** Create an Asset Value Adjustment for an asset.
**Step 2:** Submit the Asset Value Adjustment, which triggers the posting of a Revaluation Journal Entry.
**Step 3:** Manually cancel the posted Revaluation Journal Entry.
**Step 4:** Attempt to cancel the original Asset Value Adjustment.

**Before:**

https://github.com/user-attachments/assets/40db2496-494d-436e-a94e-d275fb02e756

**After:**

https://github.com/user-attachments/assets/6aae4a62-cf92-4688-a16d-64e12a256f57

**Backport Needed v15**

