### PR TITLE
feat(accounts): retain filters when switching between financial statements

### DIFF
--- a/erpnext/public/js/financial_statements.js
+++ b/erpnext/public/js/financial_statements.js
@@ -345,7 +345,6 @@ erpnext.financial_statements = {
 					from_fiscal_year: filters.from_fiscal_year,
 					to_fiscal_year: filters.to_fiscal_year,
 					periodicity: filters.periodicity,
-					presentation_currency: filters.presentation_currency,
 					cost_center: filters.cost_center,
 					project: filters.project,
 				});

--- a/erpnext/public/js/financial_statements.js
+++ b/erpnext/public/js/financial_statements.js
@@ -305,17 +305,50 @@ erpnext.financial_statements = {
 
 			report.page.add_custom_menu_item(views_menu, __("Balance Sheet"), function () {
 				var filters = report.get_values();
-				frappe.set_route("query-report", "Balance Sheet", { company: filters.company });
+				frappe.set_route("query-report", "Balance Sheet", {
+					company: filters.company,
+					filter_based_on: filters.filter_based_on,
+					period_start_date: filters.period_start_date,
+					period_end_date: filters.period_end_date,
+					from_fiscal_year: filters.from_fiscal_year,
+					to_fiscal_year: filters.to_fiscal_year,
+					periodicity: filters.periodicity,
+					presentation_currency: filters.presentation_currency,
+					cost_center: filters.cost_center,
+					project: filters.project,
+				});
 			});
 
 			report.page.add_custom_menu_item(views_menu, __("Profit and Loss"), function () {
 				var filters = report.get_values();
-				frappe.set_route("query-report", "Profit and Loss Statement", { company: filters.company });
+				frappe.set_route("query-report", "Profit and Loss Statement", {
+					company: filters.company,
+					filter_based_on: filters.filter_based_on,
+					period_start_date: filters.period_start_date,
+					period_end_date: filters.period_end_date,
+					from_fiscal_year: filters.from_fiscal_year,
+					to_fiscal_year: filters.to_fiscal_year,
+					periodicity: filters.periodicity,
+					presentation_currency: filters.presentation_currency,
+					cost_center: filters.cost_center,
+					project: filters.project,
+				});
 			});
 
 			report.page.add_custom_menu_item(views_menu, __("Cash Flow Statement"), function () {
 				var filters = report.get_values();
-				frappe.set_route("query-report", "Cash Flow", { company: filters.company });
+				frappe.set_route("query-report", "Cash Flow", {
+					company: filters.company,
+					filter_based_on: filters.filter_based_on,
+					period_start_date: filters.period_start_date,
+					period_end_date: filters.period_end_date,
+					from_fiscal_year: filters.from_fiscal_year,
+					to_fiscal_year: filters.to_fiscal_year,
+					periodicity: filters.periodicity,
+					presentation_currency: filters.presentation_currency,
+					cost_center: filters.cost_center,
+					project: filters.project,
+				});
 			});
 		}
 	},


### PR DESCRIPTION
<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/erpnext/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

Earlier, filters were not retained when switching between financial statements - leading to terrible UX.

> Explain the **details** for making this change. What existing problem does the pull request solve?

Example: A user opens the Profit and Loss Statement and sets the fiscal year, periodicity etc. Now when the user wants to view the balance sheet, they have the option to toggle between financial statements - and in most cases, the user wants to see data for the same period/cost center/project etc. However, ERPNext used to only retain the company value in the filter and the user would have to set the filters again. Now, the filters are retained - this is better UX IMO.

> Screenshots/GIFs

**Earlier:**

https://github.com/user-attachments/assets/5334fb67-f7f8-4173-b44d-c135b65ed1ea


**After this change:**

https://github.com/user-attachments/assets/a7924f2b-5904-4a47-9695-e4d55ff8ce16



<!-- Add images/recordings to better visualize the change: expected/current behviour -->
