### PR TITLE
fix: handle undefined bank_transaction_mapping in quick entry

### DIFF
--- a/erpnext/accounts/doctype/bank/bank.js
+++ b/erpnext/accounts/doctype/bank/bank.js
@@ -113,7 +113,7 @@ erpnext.integrations.refreshPlaidLink = class refreshPlaidLink {
 				"There was an issue connecting to Plaid's authentication server. Check browser console for more information"
 			)
 		);
-		console.log(error);
+		console.error(error);
 	}
 
 	plaid_success(token, response) {

--- a/erpnext/accounts/doctype/bank/bank.js
+++ b/erpnext/accounts/doctype/bank/bank.js
@@ -34,11 +34,11 @@ let add_fields_to_mapping_table = function (frm) {
 		});
 	});
 
-	frm.fields_dict.bank_transaction_mapping.grid.update_docfield_property(
-		"bank_transaction_field",
-		"options",
-		options
-	);
+	const grid = frm.fields_dict.bank_transaction_mapping?.grid;
+
+	if (grid) {
+		grid.update_docfield_property("bank_transaction_field", "options", options);
+	}
 };
 
 erpnext.integrations.refreshPlaidLink = class refreshPlaidLink {

--- a/erpnext/accounts/doctype/bank/bank.js
+++ b/erpnext/accounts/doctype/bank/bank.js
@@ -3,9 +3,6 @@
 frappe.provide("erpnext.integrations");
 
 frappe.ui.form.on("Bank", {
-	onload: function (frm) {
-		add_fields_to_mapping_table(frm);
-	},
 	refresh: function (frm) {
 		add_fields_to_mapping_table(frm);
 		frm.toggle_display(["address_html", "contact_html"], !frm.doc.__islocal);


### PR DESCRIPTION
## Traceback

```bash
Uncaught (in promise) TypeError: frm.fields_dict.bank_transaction_mapping is undefined
    add_fields_to_mapping_table bank__js:46
    refresh bank__js:16
    _handler script_manager.js:30
    runner script_manager.js:109
    trigger script_manager.js:127
    promise callback*frappe.run_serially/< dom.js:273
    run_serially dom.js:271
    trigger script_manager.js:141
    render_dialog quick_entry.js:167
    setup quick_entry.js:47
    with_doctype model.js:217
    setup quick_entry.js:42
    setup quick_entry.js:41
    make_quick_entry quick_entry.js:25
    new_doc create_new.js:380
    with_doctype model.js:217
    new_doc create_new.js:375
    new_doc create_new.js:371
    make_new_doc list_view.js:318
    set_primary_action list_view.js:294
    set_action page.js:318
    jQuery 2
form.bundle.I3XO3IGP.js line 3680 > Function:46:2

```

### Error


https://github.com/user-attachments/assets/ba8aef7e-3fc8-495a-bcee-1f2f0ba42247



> [!NOTE]
> Backport to V-16 and V-15 