### PR TITLE
fix(sales analytics): add curve filter

### DIFF
--- a/erpnext/selling/report/sales_analytics/sales_analytics.js
+++ b/erpnext/selling/report/sales_analytics/sales_analytics.js
@@ -74,6 +74,18 @@ frappe.query_reports["Sales Analytics"] = {
 			reqd: 1,
 		},
 		{
+			fieldname: "curves",
+			label: __("Curves"),
+			fieldtype: "Select",
+			options: [
+				{ value: "all", label: __("All") },
+				{ value: "non-zeros", label: __("Non-Zeros") },
+				{ value: "total", label: __("Total Only") },
+			],
+			default: "all",
+			reqd: 1,
+		},
+		{
 			fieldname: "show_aggregate_value_from_subsidiary_companies",
 			label: __("Show Aggregate Value from Subsidiary Companies"),
 			fieldtype: "Check",


### PR DESCRIPTION
Issue:
Sales Analytics report chart data is not displayed.

Ref: [#57165](https://support.frappe.io/helpdesk/tickets/57165)

no-docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Curves" filter to Sales Analytics with options: Select, All, Non‑Zeros, Total Only.
  * Line chart now builds and displays per-entity series when applicable, and can aggregate into a single "Total" series.
  * "Non‑Zeros" hides series with all-zero values; numeric value handling improved for consistent chart display.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->