### PR TITLE
fix: fetch defaults based on precedence

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py
@@ -23,6 +23,7 @@ from erpnext.projects.doctype.project.test_project import make_project
 from erpnext.stock.doctype.item.test_item import create_item
 from erpnext.stock.doctype.material_request.material_request import make_purchase_order
 from erpnext.stock.doctype.material_request.test_material_request import make_material_request
+from erpnext.stock.doctype.price_list.test_price_list import create_price_list_for_default_check
 from erpnext.stock.doctype.purchase_receipt.purchase_receipt import (
 	make_purchase_invoice as create_purchase_invoice_from_receipt,
 )
@@ -2966,6 +2967,24 @@ class TestPurchaseInvoice(IntegrationTestCase, StockTestMixin):
 
 		pr = make_purchase_receipt_from_pi(pi.name)
 		self.assertFalse(pr.items)
+
+	def test_check_default_price_list_in_purchase_invoice(self):
+		pi = frappe.new_doc("Purchase Invoice")
+		supplier = create_supplier(
+			supplier_name="_test_supplier_with_price_list", default_currency="INR", supplier_type="Company"
+		)
+		pi.supplier = supplier.name
+		price_list = create_price_list_for_default_check(
+			self, price_list_name="_test Default Price List in PI"
+		)
+		price_list_name = price_list.name
+		frappe.db.set_value("Supplier", pi.supplier, "default_price_list", price_list_name)
+		pi.posting_date = today()
+		item = create_item("_Test Item for Default Price List in PI")
+		pi.append("items", {"item_code": item.name, "qty": 2, "rate": 100})
+		pi.set_missing_values()
+		pi.insert(ignore_if_duplicate=True)
+		self.assertEqual(pi.buying_price_list, "_test Default Price List in PI")
 
 
 def set_advance_flag(company, flag, default_account):

--- a/erpnext/controllers/buying_controller.py
+++ b/erpnext/controllers/buying_controller.py
@@ -205,10 +205,19 @@ class BuyingController(SubcontractingController):
 					row.discount_amount = 0.0
 					row.margin_rate_or_amount = 0.0
 
+	def check_buying_price_list(self):
+		if self.doctype in ["Purchase Order", "Purchase Receipt", "Purchase Invoice"] :
+			if self.supplier:
+				buying_price_list = frappe.db.get_value("Supplier",self.supplier,"default_price_list")
+
+				if buying_price_list and frappe.db.get_value("Price List", buying_price_list, "buying"):
+					self.buying_price_list = buying_price_list
+
 	def set_missing_values(self, for_validate=False):
 		super().set_missing_values(for_validate)
 
 		self.set_supplier_from_item_default()
+		self.check_buying_price_list()
 		self.set_price_list_currency("Buying")
 
 		# set contact and address details for supplier, if they are not mentioned

--- a/erpnext/controllers/buying_controller.py
+++ b/erpnext/controllers/buying_controller.py
@@ -206,12 +206,16 @@ class BuyingController(SubcontractingController):
 					row.margin_rate_or_amount = 0.0
 
 	def check_buying_price_list(self):
-		if self.doctype in ["Purchase Order", "Purchase Receipt", "Purchase Invoice"] :
+		if self.doctype in ["Purchase Order", "Purchase Receipt", "Purchase Invoice"]:
 			if self.supplier:
-				buying_price_list = frappe.db.get_value("Supplier",self.supplier,"default_price_list")
+				buying_price_list = frappe.db.get_value("Supplier", self.supplier, "default_price_list")
 
 				if buying_price_list and frappe.db.get_value("Price List", buying_price_list, "buying"):
-					self.buying_price_list = buying_price_list
+					default_buying_price_list = frappe.db.get_single_value(
+						"Buying Settings", "buying_price_list"
+					)
+					if not self.buying_price_list or self.buying_price_list == default_buying_price_list:
+						self.buying_price_list = buying_price_list
 
 	def set_missing_values(self, for_validate=False):
 		super().set_missing_values(for_validate)

--- a/erpnext/controllers/selling_controller.py
+++ b/erpnext/controllers/selling_controller.py
@@ -106,8 +106,17 @@ class SellingController(StockController):
 							title=_("Serial No Already Assigned"),
 						)
 
+	def check_selling_price_list(self):
+		if self.doctype in ["Sales Order", "Delivery Note", "Sales Invoice", "Quotation"]:
+			if self.customer:
+				selling_price_list = frappe.db.get_value("Customer",self.customer,"default_price_list")
+
+				if selling_price_list and frappe.db.get_value("Price List", selling_price_list, "selling"):
+					self.selling_price_list = selling_price_list
+
 	def set_missing_values(self, for_validate=False):
 		super().set_missing_values(for_validate)
+		self.check_selling_price_list()
 
 		# set contact and address details for customer, if they are not mentioned
 		self.set_missing_lead_customer_details(for_validate=for_validate)

--- a/erpnext/controllers/selling_controller.py
+++ b/erpnext/controllers/selling_controller.py
@@ -107,12 +107,16 @@ class SellingController(StockController):
 						)
 
 	def check_selling_price_list(self):
-		if self.doctype in ["Sales Order", "Delivery Note", "Sales Invoice", "Quotation"]:
+		if self.doctype in ["Sales Order", "Delivery Note", "Sales Invoice"]:
 			if self.customer:
-				selling_price_list = frappe.db.get_value("Customer",self.customer,"default_price_list")
+				selling_price_list = frappe.db.get_value("Customer", self.customer, "default_price_list")
 
 				if selling_price_list and frappe.db.get_value("Price List", selling_price_list, "selling"):
-					self.selling_price_list = selling_price_list
+					default_selling_price_list = frappe.get_single_value(
+						"Selling Settings", "selling_price_list"
+					)
+					if not self.selling_price_list or self.selling_price_list == default_selling_price_list:
+						self.selling_price_list = selling_price_list
 
 	def set_missing_values(self, for_validate=False):
 		super().set_missing_values(for_validate)

--- a/erpnext/stock/doctype/price_list/test_price_list.py
+++ b/erpnext/stock/doctype/price_list/test_price_list.py
@@ -2,3 +2,23 @@
 # License: GNU General Public License v3. See license.txt
 
 
+import frappe
+from frappe.tests import IntegrationTestCase
+
+
+class TestPriceList(IntegrationTestCase):
+	pass
+
+
+def create_price_list_for_default_check(self, price_list_name, currency="INR", is_default=0):
+	price_list = frappe.get_doc(
+		{
+			"doctype": "Price List",
+			"price_list_name": price_list_name,
+			"currency": currency,
+			"buying": 1,
+			"is_default": is_default,
+		}
+	)
+	price_list.insert()
+	return price_list


### PR DESCRIPTION
**Issue:** 
 
When creating documents programmatically using frappe.new_doc(), global defaults from settings (e.g., Buying Settings) are applied immediately during document creation. This prevents doc.set_missing_values() from applying more specific defaults (e.g., from Supplier master) because the values are no longer "missing."

In Purchase Invoice when the Supplier have default price list. And when we use doc.set_missing_values() ,  The priority takes Buying setting default price list (buying_price_list ) over Supplier Default.

This creates a precedence inversion where general defaults (Buying Settings) take priority over specific defaults (Supplier master), which is counterintuitive and inconsistent with the expected behavior.

Fixes:https://github.com/frappe/erpnext/issues/51442

**Before:**

[Screencast from 12-01-26 04:15:41 PM ISTbefore.webm](https://github.com/user-attachments/assets/0627142c-1851-4a12-b036-93bf30856cf1)

**After:**

[Screencast from 12-01-26 04:21:28 PM ISTafter.webm](https://github.com/user-attachments/assets/f376f810-aea3-413b-bdc5-2507170e9b47)

**Backport needed v15, v16**  
 