### PR TITLE
feat: Adding Item name in update item dialog box

### DIFF
--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -735,6 +735,7 @@ erpnext.utils.update_child_items = function (opts) {
 			fieldname: "item_name",
 			label: __("Item Name"),
 			read_only: 1,
+			in_list_view: 1,
 		},
 		{
 			fieldtype: "Link",
@@ -792,7 +793,7 @@ erpnext.utils.update_child_items = function (opts) {
 	];
 
 	if (frm.doc.doctype == "Sales Order" || frm.doc.doctype == "Purchase Order") {
-		fields.splice(2, 0, {
+		fields.splice(3, 0, {
 			fieldtype: "Date",
 			fieldname: frm.doc.doctype == "Sales Order" ? "delivery_date" : "schedule_date",
 			in_list_view: 1,
@@ -800,7 +801,7 @@ erpnext.utils.update_child_items = function (opts) {
 			default: frm.doc.doctype == "Sales Order" ? frm.doc.delivery_date : frm.doc.schedule_date,
 			reqd: 1,
 		});
-		fields.splice(3, 0, {
+		fields.splice(4, 0, {
 			fieldtype: "Float",
 			fieldname: "conversion_factor",
 			label: __("Conversion Factor"),


### PR DESCRIPTION
This is with reference to https://github.com/frappe/erpnext/issues/49830, we add item name in update item dialog box for all doctypes applicable (Sales Order, Purchase Order, Quotation, Supplier Quotation) 


`no-docs`
