### PR TITLE
fix: correct spelling of Payment Reconciliation in Accounting

### DIFF
--- a/erpnext/workspace_sidebar/invoicing.json
+++ b/erpnext/workspace_sidebar/invoicing.json
@@ -219,7 +219,7 @@
    "collapsible": 1,
    "indent": 0,
    "keep_closed": 0,
-   "label": "Payment Reconciliaition",
+   "label": "Payment Reconciliation",
    "link_to": "Payment Reconciliation",
    "link_type": "DocType",
    "show_arrow": 0,


### PR DESCRIPTION
Issue:
Spelling issue in the Payment Reconciliation (left menu) under Accounting

Before:
<img width="1800" height="957" alt="Screenshot from 2026-01-12 14-41-54" src="https://github.com/user-attachments/assets/2513848f-fe80-4f0a-89ad-1f2087dc3735" />

After:
<img width="1800" height="957" alt="Screenshot from 2026-01-12 14-45-16" src="https://github.com/user-attachments/assets/5bfdafbc-8386-4ede-b2d0-0137bbb4d9d4" />

Backport needed for v16



