### PR TITLE
fix: hide target_qty field from the capitalization

### DIFF
--- a/erpnext/assets/doctype/asset_capitalization/asset_capitalization.json
+++ b/erpnext/assets/doctype/asset_capitalization/asset_capitalization.json
@@ -177,6 +177,7 @@
    "default": "1",
    "fieldname": "target_qty",
    "fieldtype": "Float",
+   "hidden": 1,
    "label": "Target Qty"
   },
   {
@@ -290,10 +291,10 @@
    "options": "Cost Center"
   },
   {
-    "fieldname": "project",
-    "fieldtype": "Link",
-    "label": "Project",
-    "options": "Project"
+   "fieldname": "project",
+   "fieldtype": "Link",
+   "label": "Project",
+   "options": "Project"
   },
   {
    "fieldname": "dimension_col_break",
@@ -324,7 +325,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-01-08 13:14:33.008458",
+ "modified": "2026-01-13 17:25:01.352568",
  "modified_by": "Administrator",
  "module": "Assets",
  "name": "Asset Capitalization",
@@ -362,6 +363,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": [],

--- a/erpnext/assets/doctype/asset_capitalization/asset_capitalization.py
+++ b/erpnext/assets/doctype/asset_capitalization/asset_capitalization.py
@@ -54,10 +54,17 @@ class AssetCapitalization(StockController):
 	from typing import TYPE_CHECKING
 
 	if TYPE_CHECKING:
-		from erpnext.assets.doctype.asset_capitalization_asset_item.asset_capitalization_asset_item import AssetCapitalizationAssetItem
-		from erpnext.assets.doctype.asset_capitalization_service_item.asset_capitalization_service_item import AssetCapitalizationServiceItem
-		from erpnext.assets.doctype.asset_capitalization_stock_item.asset_capitalization_stock_item import AssetCapitalizationStockItem
 		from frappe.types import DF
+
+		from erpnext.assets.doctype.asset_capitalization_asset_item.asset_capitalization_asset_item import (
+			AssetCapitalizationAssetItem,
+		)
+		from erpnext.assets.doctype.asset_capitalization_service_item.asset_capitalization_service_item import (
+			AssetCapitalizationServiceItem,
+		)
+		from erpnext.assets.doctype.asset_capitalization_stock_item.asset_capitalization_stock_item import (
+			AssetCapitalizationStockItem,
+		)
 
 		amended_from: DF.Link | None
 		asset_items: DF.Table[AssetCapitalizationAssetItem]

--- a/erpnext/assets/doctype/asset_capitalization/asset_capitalization.py
+++ b/erpnext/assets/doctype/asset_capitalization/asset_capitalization.py
@@ -54,17 +54,10 @@ class AssetCapitalization(StockController):
 	from typing import TYPE_CHECKING
 
 	if TYPE_CHECKING:
+		from erpnext.assets.doctype.asset_capitalization_asset_item.asset_capitalization_asset_item import AssetCapitalizationAssetItem
+		from erpnext.assets.doctype.asset_capitalization_service_item.asset_capitalization_service_item import AssetCapitalizationServiceItem
+		from erpnext.assets.doctype.asset_capitalization_stock_item.asset_capitalization_stock_item import AssetCapitalizationStockItem
 		from frappe.types import DF
-
-		from erpnext.assets.doctype.asset_capitalization_asset_item.asset_capitalization_asset_item import (
-			AssetCapitalizationAssetItem,
-		)
-		from erpnext.assets.doctype.asset_capitalization_service_item.asset_capitalization_service_item import (
-			AssetCapitalizationServiceItem,
-		)
-		from erpnext.assets.doctype.asset_capitalization_stock_item.asset_capitalization_stock_item import (
-			AssetCapitalizationStockItem,
-		)
 
 		amended_from: DF.Link | None
 		asset_items: DF.Table[AssetCapitalizationAssetItem]
@@ -76,6 +69,7 @@ class AssetCapitalization(StockController):
 		naming_series: DF.Literal["ACC-ASC-.YYYY.-"]
 		posting_date: DF.Date
 		posting_time: DF.Time
+		project: DF.Link | None
 		service_items: DF.Table[AssetCapitalizationServiceItem]
 		service_items_total: DF.Currency
 		set_posting_time: DF.Check


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced Asset Capitalization form structure with dynamic row formatting for improved layout and usability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->