### PR TITLE
feat(payments): Add PaymentController v2 gateway support

### DIFF
--- a/erpnext/accounts/doctype/payment_request/payment_request.py
+++ b/erpnext/accounts/doctype/payment_request/payment_request.py
@@ -36,6 +36,27 @@ def _get_payment_gateway_controller(*args, **kwargs):
 	return get_payment_gateway_controller(*args, **kwargs)
 
 
+def _is_v2_gateway(payment_gateway):
+	"""Check if a payment gateway implements the new PaymentController interface.
+
+	Delegates to payments.utils.is_v2_gateway() which centralizes the v2 detection logic.
+	Returns False if payments app is not installed, doesn't have v2 support, or if
+	any error occurs during detection (to prevent submission failures).
+	"""
+	try:
+		with payment_app_import_guard():
+			from payments.utils import is_v2_gateway
+		return is_v2_gateway(payment_gateway)
+	except frappe.ValidationError:
+		# payments app not installed - fall back to v1
+		return False
+	except Exception as e:
+		# Catch-all for any other errors (database errors, misconfigured gateways, etc.)
+		# to prevent submission failures - fall back to v1 flow
+		frappe.logger().warning(f"Error detecting v2 gateway for '{payment_gateway}': {e}", exc_info=True)
+		return False
+
+
 class PaymentRequest(Document):
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
@@ -227,17 +248,159 @@ class PaymentRequest(Document):
 		elif self.payment_request_type == "Inward":
 			self.status = "Requested"
 
-		if self.payment_request_type == "Inward":
-			if self.payment_channel == "Phone":
+		if self.payment_request_type == "Inward" and self.payment_gateway:
+			if _is_v2_gateway(self.payment_gateway):
+				# New PaymentController flow (v2 gateways)
+				self._process_v2_gateway()
+			elif self.payment_channel == "Phone":
+				# Legacy v1 phone payment - phone payments do not generate email/link
+				# communications as the payment is initiated directly via phone channel
 				self.request_phone_payment()
+				return
 			else:
+				# Legacy v1 URL payment
 				self.set_payment_request_url()
-				if not (self.mute_email or self.flags.mute_email):
-					self.send_email()
-					self.make_communication_entry()
+
+			if not (self.mute_email or self.flags.mute_email):
+				self.send_email()
+				self.make_communication_entry()
 
 	def on_submit(self):
 		self.update_reference_advance_payment_status()
+
+	def _process_v2_gateway(self):
+		"""Process payment using the new PaymentController interface (v2 gateways)."""
+		tx_data = self.get_tx_data()
+		with payment_app_import_guard():
+			from payments.controllers import PaymentController
+
+			try:
+				_controller, psl_name = PaymentController.initiate(tx_data, self.payment_gateway)
+			except Exception as e:
+				# Log full exception for debugging, show generic message to user
+				frappe.log_error(
+					title=_("Payment Initialization Failed"),
+					message=f"Gateway: {self.payment_gateway}, Error: {e}\n{frappe.get_traceback()}",
+				)
+				frappe.throw(
+					_("Failed to initiate payment with {0}. Please try again or contact support.").format(
+						self.payment_gateway
+					),
+					title=_("Payment Initialization Failed"),
+				)
+			if not psl_name:
+				frappe.throw(
+					_("Payment gateway {0} failed to create a payment session").format(self.payment_gateway),
+					title=_("Payment Initialization Failed"),
+				)
+			self.payment_url = PaymentController.get_payment_url(psl_name)
+			# Store PSL reference for debugging and reconciliation
+			# (payment_session_log field added by payments app as custom field)
+			if hasattr(self, "payment_session_log"):
+				self.payment_session_log = psl_name
+
+	def get_tx_data(self):
+		"""Prepare standardized transaction data for PaymentController.
+
+		This method creates the tx_data dict expected by PaymentController.initiate().
+		Must match the TxData dataclass fields from payments.types.
+
+		Note on reference fields:
+		    reference_doctype/reference_docname point to this Payment Request (the wrapper),
+		    not the underlying business document (Sales Invoice, etc.). This is intentional
+		    because Payment Request handles callbacks, reconciliation, and status updates.
+		    The business document reference is available via self.reference_doctype/reference_name.
+		"""
+		payer_contact, payer_address = self._get_party_contact_and_address()
+
+		return frappe._dict(
+			{
+				"amount": self.get_request_amount(),
+				"currency": self.currency,
+				"reference_doctype": self.doctype,
+				"reference_docname": self.name,
+				"payer_contact": payer_contact,
+				"payer_address": payer_address,
+				"loyalty_points": None,
+				"discount_amount": None,
+			}
+		)
+
+	def _get_party_contact_and_address(self):
+		"""Get primary contact and address for the party, with only payment-relevant fields.
+
+		Returns minimal data needed for payment processing to avoid exposing
+		unnecessary PII to the payment gateway layer.
+		"""
+		if not (self.party_type and self.party):
+			return {}, {}
+
+		# Map party type to field names for primary contact/address
+		field_map = {
+			"Customer": ("customer_primary_contact", "customer_primary_address"),
+			"Supplier": ("supplier_primary_contact", "supplier_primary_address"),
+		}
+		if self.party_type not in field_map:
+			return {}, {}
+
+		contact_field, address_field = field_map[self.party_type]
+
+		# Fetch only the primary contact/address names from party (single query)
+		party_data = frappe.get_value(
+			self.party_type, self.party, [contact_field, address_field], as_dict=True
+		)
+		if not party_data:
+			return {}, {}
+
+		payer_contact = self._get_contact_fields(party_data.get(contact_field))
+		payer_address = self._get_address_fields(party_data.get(address_field))
+
+		return payer_contact, payer_address
+
+	def _get_contact_fields(self, contact_name):
+		"""Extract payment-relevant fields from a Contact."""
+		if not contact_name:
+			return {}
+
+		contact = frappe.get_value(
+			"Contact",
+			contact_name,
+			["first_name", "last_name", "email_id", "phone", "mobile_no"],
+			as_dict=True,
+		)
+		if not contact:
+			return {}
+
+		return {
+			"first_name": contact.first_name or "",
+			"last_name": contact.last_name or "",
+			"email_id": contact.email_id or "",
+			"email": contact.email_id or "",  # Alias for gateway compatibility
+			"phone": contact.phone or contact.mobile_no or "",
+		}
+
+	def _get_address_fields(self, address_name):
+		"""Extract payment-relevant fields from an Address."""
+		if not address_name:
+			return {}
+
+		address = frappe.get_value(
+			"Address",
+			address_name,
+			["address_line1", "address_line2", "city", "state", "pincode", "country"],
+			as_dict=True,
+		)
+		if not address:
+			return {}
+
+		return {
+			"address_line1": address.address_line1 or "",
+			"address_line2": address.address_line2 or "",
+			"city": address.city or "",
+			"state": address.state or "",
+			"pincode": address.pincode or "",
+			"country": address.country or "",
+		}
 
 	def request_phone_payment(self):
 		controller = _get_payment_gateway_controller(self.payment_gateway)
@@ -384,9 +547,7 @@ class PaymentRequest(Document):
 				"mode_of_payment": self.mode_of_payment,
 				"reference_no": self.name,  # to prevent validation error
 				"reference_date": nowdate(),
-				"remarks": "Payment Entry against {} {} via Payment Request {}".format(
-					self.reference_doctype, self.reference_name, self.name
-				),
+				"remarks": f"Payment Entry against {self.reference_doctype} {self.reference_name} via Payment Request {self.name}",
 			}
 		)
 

--- a/erpnext/accounts/doctype/payment_request/test_payment_request.py
+++ b/erpnext/accounts/doctype/payment_request/test_payment_request.py
@@ -3,7 +3,8 @@
 
 import json
 import re
-from unittest.mock import patch
+import sys
+from unittest.mock import MagicMock, patch
 
 import frappe
 from frappe.utils import add_days, nowdate
@@ -974,3 +975,1012 @@ class TestPaymentRequest(ERPNextTestSuite):
 				return_doc=True,
 				schedules=schedules,
 			)
+
+
+class TestPaymentRequestV2Gateway(ERPNextTestSuite):
+	"""Tests for PaymentController v2 gateway integration."""
+
+	def setUp(self):
+		"""Set up payment gateway fixtures for flow tests."""
+		for payment_gateway in payment_gateways:
+			if not frappe.db.get_value("Payment Gateway", payment_gateway["gateway"], "name"):
+				frappe.get_doc(payment_gateway).insert(ignore_permissions=True)
+		for method in payment_method:
+			if not frappe.db.get_value(
+				"Payment Gateway Account",
+				{"payment_gateway": method["payment_gateway"], "currency": method["currency"]},
+				"name",
+			):
+				frappe.get_doc(method).insert(ignore_permissions=True)
+
+	def _mock_payments_modules(self, is_v2_gateway_return_value):
+		"""Helper to mock both payments and payments.utils modules.
+
+		Python requires the parent module to be in sys.modules before importing
+		a child module. This helper ensures both are mocked properly.
+		"""
+		mock_payments = MagicMock()
+		mock_utils = MagicMock()
+		mock_utils.is_v2_gateway = MagicMock(return_value=is_v2_gateway_return_value)
+		mock_payments.utils = mock_utils
+		return {"payments": mock_payments, "payments.utils": mock_utils}, mock_utils
+
+	def test_is_v2_gateway_returns_false_for_none(self):
+		"""_is_v2_gateway returns False for None input."""
+		from erpnext.accounts.doctype.payment_request.payment_request import _is_v2_gateway
+
+		# Mock returns True, but is_v2_gateway(None) in payments.utils returns False
+		modules, mock_utils = self._mock_payments_modules(False)
+
+		with patch.dict(sys.modules, modules):
+			result = _is_v2_gateway(None)
+			self.assertFalse(result)
+			mock_utils.is_v2_gateway.assert_called_once_with(None)
+
+	def test_is_v2_gateway_returns_false_for_empty_string(self):
+		"""_is_v2_gateway returns False for empty string input."""
+		from erpnext.accounts.doctype.payment_request.payment_request import _is_v2_gateway
+
+		modules, mock_utils = self._mock_payments_modules(False)
+
+		with patch.dict(sys.modules, modules):
+			result = _is_v2_gateway("")
+			self.assertFalse(result)
+			mock_utils.is_v2_gateway.assert_called_once_with("")
+
+	def test_is_v2_gateway_returns_false_for_nonexistent_gateway(self):
+		"""_is_v2_gateway returns False for nonexistent gateway."""
+		from erpnext.accounts.doctype.payment_request.payment_request import _is_v2_gateway
+
+		modules, mock_utils = self._mock_payments_modules(False)
+
+		with patch.dict(sys.modules, modules):
+			result = _is_v2_gateway("NonExistentGateway12345")
+			self.assertFalse(result)
+			mock_utils.is_v2_gateway.assert_called_once_with("NonExistentGateway12345")
+
+	def test_is_v2_gateway_delegates_to_payments_util(self):
+		"""_is_v2_gateway delegates to payments.utils.is_v2_gateway."""
+		from erpnext.accounts.doctype.payment_request.payment_request import _is_v2_gateway
+
+		modules, mock_utils = self._mock_payments_modules(True)
+
+		with patch.dict(sys.modules, modules):
+			result = _is_v2_gateway("_Test Gateway")
+			self.assertTrue(result)
+			mock_utils.is_v2_gateway.assert_called_once_with("_Test Gateway")
+
+	def test_is_v2_gateway_returns_false_when_payments_util_returns_false(self):
+		"""_is_v2_gateway returns False when payments.utils.is_v2_gateway returns False."""
+		from erpnext.accounts.doctype.payment_request.payment_request import _is_v2_gateway
+
+		modules, _ = self._mock_payments_modules(False)
+
+		with patch.dict(sys.modules, modules):
+			result = _is_v2_gateway("_Test Gateway")
+			self.assertFalse(result)
+
+	def test_is_v2_gateway_catches_unexpected_exceptions(self):
+		"""_is_v2_gateway catches unexpected exceptions and returns False."""
+		from erpnext.accounts.doctype.payment_request.payment_request import _is_v2_gateway
+
+		mock_payments = MagicMock()
+		mock_utils = MagicMock()
+		mock_utils.is_v2_gateway = MagicMock(side_effect=RuntimeError("Unexpected error"))
+		mock_payments.utils = mock_utils
+		modules = {"payments": mock_payments, "payments.utils": mock_utils}
+
+		with patch.dict(sys.modules, modules):
+			# Should not raise, should return False
+			result = _is_v2_gateway("_Test Gateway")
+			self.assertFalse(result)
+
+	def test_get_tx_data_returns_required_fields(self):
+		"""get_tx_data returns all fields required by TxData."""
+		so = make_sales_order(currency="INR")
+
+		# Use make_payment_request to properly populate all mandatory fields
+		pr = make_payment_request(
+			dt="Sales Order",
+			dn=so.name,
+			recipient_id="test@example.com",
+			mute_email=True,
+			submit_doc=False,
+			return_doc=True,
+		)
+
+		tx_data = pr.get_tx_data()
+
+		# Verify all required TxData fields are present
+		self.assertIn("amount", tx_data)
+		self.assertIn("currency", tx_data)
+		self.assertIn("reference_doctype", tx_data)
+		self.assertIn("reference_docname", tx_data)
+		self.assertIn("payer_contact", tx_data)
+		self.assertIn("payer_address", tx_data)
+		self.assertIn("loyalty_points", tx_data)
+		self.assertIn("discount_amount", tx_data)
+
+		# Verify values - amount should come from get_request_amount()
+		self.assertEqual(tx_data.amount, pr.get_request_amount())
+		self.assertEqual(tx_data.currency, "INR")
+		self.assertEqual(tx_data.reference_doctype, "Payment Request")
+		self.assertEqual(tx_data.reference_docname, pr.name)
+
+	def test_get_tx_data_uses_request_amount_not_grand_total(self):
+		"""get_tx_data should use get_request_amount() to support partial payments."""
+		so = make_sales_order(currency="INR", qty=1, rate=1000)
+
+		# Use make_payment_request to properly populate all mandatory fields
+		pr = make_payment_request(
+			dt="Sales Order",
+			dn=so.name,
+			recipient_id="test@example.com",
+			mute_email=True,
+			submit_doc=False,
+			return_doc=True,
+		)
+
+		# Mock get_request_amount to return a partial amount
+		with patch.object(pr, "get_request_amount", return_value=500.0):
+			tx_data = pr.get_tx_data()
+			# Amount should be the partial request amount, not grand_total
+			self.assertEqual(tx_data.amount, 500.0)
+			self.assertNotEqual(tx_data.amount, pr.grand_total)
+
+	def test_get_party_contact_and_address_returns_whitelisted_fields_only(self):
+		"""_get_party_contact_and_address should only return payment-relevant fields."""
+		# Create a customer with contact and address to ensure assertions run
+		customer = frappe.get_doc("Customer", "_Test Customer")
+
+		# Create or get test contact
+		contact_name = f"_Test Contact for {customer.name}"
+		if not frappe.db.exists("Contact", contact_name):
+			test_contact = frappe.get_doc(
+				{
+					"doctype": "Contact",
+					"first_name": "Test",
+					"last_name": "Contact",
+					"email_id": "test.contact@example.com",
+					"phone": "+1234567890",
+				}
+			)
+			test_contact.insert(ignore_permissions=True)
+			contact_name = test_contact.name
+
+		# Create or get test address
+		address_name = f"_Test Address for {customer.name}"
+		if not frappe.db.exists("Address", {"address_title": address_name}):
+			test_address = frappe.get_doc(
+				{
+					"doctype": "Address",
+					"address_title": address_name,
+					"address_type": "Billing",
+					"address_line1": "123 Test Street",
+					"city": "Test City",
+					"country": "United States",
+				}
+			)
+			test_address.insert(ignore_permissions=True)
+			address_name = test_address.name
+
+		# Link contact and address to customer
+		customer.customer_primary_contact = contact_name
+		customer.customer_primary_address = address_name
+		customer.save(ignore_permissions=True)
+
+		pr = frappe.new_doc("Payment Request")
+		pr.party_type = "Customer"
+		pr.party = customer.name
+
+		contact, address = pr._get_party_contact_and_address()
+
+		# Assertions should always run now that we've ensured contact/address exist
+		self.assertTrue(contact, "Contact should be returned")
+		allowed_contact_fields = {"first_name", "last_name", "email_id", "email", "phone"}
+		self.assertTrue(set(contact.keys()).issubset(allowed_contact_fields))
+		# Verify internal/sensitive fields are NOT present
+		self.assertNotIn("owner", contact)
+		self.assertNotIn("creation", contact)
+		self.assertNotIn("modified", contact)
+		self.assertNotIn("doctype", contact)
+
+		self.assertTrue(address, "Address should be returned")
+		allowed_address_fields = {"address_line1", "address_line2", "city", "state", "pincode", "country"}
+		self.assertTrue(set(address.keys()).issubset(allowed_address_fields))
+		# Verify internal/sensitive fields are NOT present
+		self.assertNotIn("owner", address)
+		self.assertNotIn("creation", address)
+		self.assertNotIn("modified", address)
+		self.assertNotIn("doctype", address)
+
+	def test_get_party_contact_and_address_handles_missing_party(self):
+		"""_get_party_contact_and_address returns empty dicts for missing party."""
+		pr = frappe.new_doc("Payment Request")
+		pr.party_type = None
+		pr.party = None
+
+		contact, address = pr._get_party_contact_and_address()
+
+		self.assertEqual(contact, {})
+		self.assertEqual(address, {})
+
+	def test_get_party_contact_and_address_handles_deleted_party(self):
+		"""_get_party_contact_and_address handles deleted party gracefully."""
+		pr = frappe.new_doc("Payment Request")
+		pr.party_type = "Customer"
+		pr.party = "NonExistentCustomer12345"
+
+		contact, address = pr._get_party_contact_and_address()
+
+		self.assertEqual(contact, {})
+		self.assertEqual(address, {})
+
+	def test_v2_gateway_uses_process_v2_gateway(self):
+		"""v2 gateways should use _process_v2_gateway flow, not legacy flow."""
+		so = make_sales_order(currency="INR")
+
+		with patch(
+			"erpnext.accounts.doctype.payment_request.payment_request._is_v2_gateway",
+			return_value=True,
+		):
+			with patch(
+				"erpnext.accounts.doctype.payment_request.payment_request.PaymentRequest._process_v2_gateway"
+			) as mock_process_v2:
+				with patch(
+					"erpnext.accounts.doctype.payment_request.payment_request.PaymentRequest.set_payment_request_url"
+				) as mock_set_url:
+					with patch(
+						"erpnext.accounts.doctype.payment_request.payment_request.PaymentRequest.send_email"
+					):
+						make_payment_request(
+							dt="Sales Order",
+							dn=so.name,
+							recipient_id="test@example.com",
+							payment_gateway_account="_Test Gateway - INR - _TC",
+							mute_email=True,
+							submit_doc=True,
+							return_doc=True,
+						)
+
+						# v2 flow should be called
+						mock_process_v2.assert_called_once()
+						# Legacy flow should NOT be called
+						mock_set_url.assert_not_called()
+
+	def test_v1_gateway_uses_legacy_flow(self):
+		"""v1 gateways should use set_payment_request_url flow, not v2 flow."""
+		so = make_sales_order(currency="INR")
+
+		with patch(
+			"erpnext.accounts.doctype.payment_request.payment_request._is_v2_gateway",
+			return_value=False,
+		):
+			with patch(
+				"erpnext.accounts.doctype.payment_request.payment_request.PaymentRequest.set_payment_request_url"
+			) as mock_set_url:
+				with patch(
+					"erpnext.accounts.doctype.payment_request.payment_request.PaymentRequest._process_v2_gateway"
+				) as mock_process_v2:
+					with patch(
+						"erpnext.accounts.doctype.payment_request.payment_request.PaymentRequest.get_payment_url",
+						return_value=PAYMENT_URL,
+					):
+						with patch(
+							"erpnext.accounts.doctype.payment_request.payment_request._get_payment_gateway_controller"
+						):
+							with patch(
+								"erpnext.accounts.doctype.payment_request.payment_request.PaymentRequest.send_email"
+							):
+								make_payment_request(
+									dt="Sales Order",
+									dn=so.name,
+									recipient_id="test@example.com",
+									payment_gateway_account="_Test Gateway - INR - _TC",
+									mute_email=True,
+									submit_doc=True,
+									return_doc=True,
+								)
+
+								# Legacy flow should be called
+								mock_set_url.assert_called_once()
+								# v2 flow should NOT be called
+								mock_process_v2.assert_not_called()
+
+	# ============================================================================
+	# Codecov Gap Tests
+	# ============================================================================
+
+	def test_is_v2_gateway_returns_false_when_payments_not_installed(self):
+		"""_is_v2_gateway returns False when payments app raises ValidationError."""
+		from erpnext.accounts.doctype.payment_request.payment_request import _is_v2_gateway
+
+		# Simulate payments app not installed (ValidationError from import guard)
+		with patch(
+			"erpnext.accounts.doctype.payment_request.payment_request.payment_app_import_guard",
+			side_effect=frappe.ValidationError("Payments app not installed"),
+		):
+			result = _is_v2_gateway("_Test Gateway")
+			self.assertFalse(result)
+
+	def test_process_v2_gateway_handles_initiate_failure(self):
+		"""_process_v2_gateway shows user-friendly error on initiate failure."""
+		so = make_sales_order(currency="INR")
+
+		pr = make_payment_request(
+			dt="Sales Order",
+			dn=so.name,
+			recipient_id="test@example.com",
+			payment_gateway_account="_Test Gateway - INR - _TC",
+			mute_email=True,
+			submit_doc=False,
+			return_doc=True,
+		)
+		# Ensure payment_gateway is set (make_payment_request may not populate it)
+		pr.payment_gateway = "_Test Gateway"
+
+		# Mock PaymentController to raise an exception
+		mock_controller = MagicMock()
+		mock_controller.initiate = MagicMock(side_effect=Exception("Gateway connection failed"))
+
+		with patch("erpnext.accounts.doctype.payment_request.payment_request.payment_app_import_guard"):
+			with patch.dict(
+				sys.modules,
+				{
+					"payments": MagicMock(),
+					"payments.controllers": MagicMock(PaymentController=mock_controller),
+				},
+			):
+				with self.assertRaises(frappe.ValidationError) as context:
+					pr._process_v2_gateway()
+
+				self.assertIn("Failed to initiate payment", str(context.exception))
+				self.assertIn("_Test Gateway", str(context.exception))
+
+	def test_process_v2_gateway_handles_none_psl(self):
+		"""_process_v2_gateway throws when PaymentController returns None PSL."""
+		so = make_sales_order(currency="INR")
+
+		pr = make_payment_request(
+			dt="Sales Order",
+			dn=so.name,
+			recipient_id="test@example.com",
+			payment_gateway_account="_Test Gateway - INR - _TC",
+			mute_email=True,
+			submit_doc=False,
+			return_doc=True,
+		)
+
+		# Mock PaymentController.initiate to return (controller, None)
+		mock_controller_class = MagicMock()
+		mock_controller_class.initiate = MagicMock(return_value=(MagicMock(), None))
+
+		with patch("erpnext.accounts.doctype.payment_request.payment_request.payment_app_import_guard"):
+			with patch.dict(
+				sys.modules,
+				{
+					"payments": MagicMock(),
+					"payments.controllers": MagicMock(PaymentController=mock_controller_class),
+				},
+			):
+				with self.assertRaises(frappe.ValidationError) as context:
+					pr._process_v2_gateway()
+
+				self.assertIn("failed to create a payment session", str(context.exception))
+
+	def test_process_v2_gateway_sets_payment_session_log(self):
+		"""_process_v2_gateway sets payment_session_log field when it exists."""
+		so = make_sales_order(currency="INR")
+
+		pr = make_payment_request(
+			dt="Sales Order",
+			dn=so.name,
+			recipient_id="test@example.com",
+			payment_gateway_account="_Test Gateway - INR - _TC",
+			mute_email=True,
+			submit_doc=False,
+			return_doc=True,
+		)
+
+		# Add payment_session_log attribute to simulate custom field
+		pr.payment_session_log = None
+
+		mock_controller_class = MagicMock()
+		mock_controller_class.initiate = MagicMock(return_value=(MagicMock(), "PSL-00001"))
+		mock_controller_class.get_payment_url = MagicMock(return_value="https://pay.example.com/xyz")
+
+		with patch("erpnext.accounts.doctype.payment_request.payment_request.payment_app_import_guard"):
+			with patch.dict(
+				sys.modules,
+				{
+					"payments": MagicMock(),
+					"payments.controllers": MagicMock(PaymentController=mock_controller_class),
+				},
+			):
+				pr._process_v2_gateway()
+
+				self.assertEqual(pr.payment_session_log, "PSL-00001")
+				self.assertEqual(pr.payment_url, "https://pay.example.com/xyz")
+
+	def test_get_party_contact_and_address_supplier(self):
+		"""_get_party_contact_and_address works for Supplier party type."""
+		# Get or create test supplier
+		supplier_name = "_Test Supplier"
+		if not frappe.db.exists("Supplier", supplier_name):
+			frappe.get_doc(
+				{
+					"doctype": "Supplier",
+					"supplier_name": supplier_name,
+					"supplier_group": "All Supplier Groups",
+				}
+			).insert(ignore_permissions=True)
+
+		supplier = frappe.get_doc("Supplier", supplier_name)
+		original_contact = supplier.supplier_primary_contact
+		original_address = supplier.supplier_primary_address
+
+		# Create test contact for supplier (always recreate to ensure known state)
+		contact_name = "_Test PR Supplier Contact"
+		if frappe.db.exists("Contact", contact_name):
+			frappe.delete_doc("Contact", contact_name, force=True)
+
+		test_contact = frappe.get_doc(
+			{
+				"doctype": "Contact",
+				"first_name": "SupplierTest",
+				"last_name": "Contact",
+				# Email and phone are set via child tables in Frappe
+				"email_ids": [{"email_id": "supplier.test@example.com", "is_primary": 1}],
+				"phone_nos": [{"phone": "+9876543210", "is_primary_phone": 1}],
+			}
+		)
+		test_contact.insert(ignore_permissions=True)
+
+		# Create test address for supplier (always recreate to ensure known state)
+		address_title = "_Test PR Supplier Address"
+		existing_address = frappe.db.get_value("Address", {"address_title": address_title}, "name")
+		if existing_address:
+			frappe.delete_doc("Address", existing_address, force=True)
+
+		test_address = frappe.get_doc(
+			{
+				"doctype": "Address",
+				"address_title": address_title,
+				"address_type": "Billing",
+				"address_line1": "456 Supplier Street",
+				"city": "Supplier City",
+				"country": "United States",
+			}
+		)
+		test_address.insert(ignore_permissions=True)
+
+		try:
+			# Link contact and address to supplier
+			supplier.db_set("supplier_primary_contact", test_contact.name, update_modified=False)
+			supplier.db_set("supplier_primary_address", test_address.name, update_modified=False)
+
+			pr = frappe.new_doc("Payment Request")
+			pr.party_type = "Supplier"
+			pr.party = supplier.name
+
+			contact, address = pr._get_party_contact_and_address()
+
+			self.assertTrue(contact, "Contact should be returned for Supplier")
+			self.assertEqual(contact.get("first_name"), "SupplierTest")
+			self.assertEqual(contact.get("email_id"), "supplier.test@example.com")
+
+			self.assertTrue(address, "Address should be returned for Supplier")
+			self.assertEqual(address.get("address_line1"), "456 Supplier Street")
+			self.assertEqual(address.get("city"), "Supplier City")
+		finally:
+			# Restore original values
+			supplier.db_set("supplier_primary_contact", original_contact, update_modified=False)
+			supplier.db_set("supplier_primary_address", original_address, update_modified=False)
+			frappe.delete_doc("Contact", test_contact.name, force=True)
+			frappe.delete_doc("Address", test_address.name, force=True)
+
+	def test_get_party_contact_and_address_unsupported_party_type(self):
+		"""_get_party_contact_and_address returns empty dicts for unsupported party types."""
+		pr = frappe.new_doc("Payment Request")
+		pr.party_type = "Lead"  # Not in field_map (only Customer/Supplier supported)
+		pr.party = "some-lead-name"
+
+		# Mock the party lookup to avoid DoesNotExistError for Lead
+		with patch.object(frappe, "get_doc", return_value=MagicMock()):
+			contact, address = pr._get_party_contact_and_address()
+
+		self.assertEqual(contact, {})
+		self.assertEqual(address, {})
+
+	def test_get_party_contact_and_address_deleted_contact(self):
+		"""_get_party_contact_and_address handles deleted contact gracefully."""
+		customer = frappe.get_doc("Customer", "_Test Customer")
+
+		# Set a nonexistent contact name
+		original_contact = customer.customer_primary_contact
+		customer.db_set("customer_primary_contact", "NonExistentContact12345", update_modified=False)
+
+		try:
+			pr = frappe.new_doc("Payment Request")
+			pr.party_type = "Customer"
+			pr.party = customer.name
+
+			contact, _address = pr._get_party_contact_and_address()
+
+			# Should return empty dict for contact, not raise
+			self.assertEqual(contact, {})
+		finally:
+			# Restore original contact
+			customer.db_set("customer_primary_contact", original_contact, update_modified=False)
+
+	def test_get_party_contact_and_address_deleted_address(self):
+		"""_get_party_contact_and_address handles deleted address gracefully."""
+		customer = frappe.get_doc("Customer", "_Test Customer")
+
+		# Set a nonexistent address name
+		original_address = customer.customer_primary_address
+		customer.db_set("customer_primary_address", "NonExistentAddress12345", update_modified=False)
+
+		try:
+			pr = frappe.new_doc("Payment Request")
+			pr.party_type = "Customer"
+			pr.party = customer.name
+
+			_contact, address = pr._get_party_contact_and_address()
+
+			# Should return empty dict for address, not raise
+			self.assertEqual(address, {})
+		finally:
+			# Restore original address
+			customer.db_set("customer_primary_address", original_address, update_modified=False)
+
+	# ============================================================================
+	# before_submit Flow Gap Tests
+	# ============================================================================
+
+	def test_v2_gateway_sends_email_when_not_muted(self):
+		"""v2 gateways should send email when mute_email is False."""
+		so = make_sales_order(currency="INR")
+
+		with patch(
+			"erpnext.accounts.doctype.payment_request.payment_request._is_v2_gateway",
+			return_value=True,
+		):
+			with patch(
+				"erpnext.accounts.doctype.payment_request.payment_request.PaymentRequest._process_v2_gateway"
+			):
+				with patch(
+					"erpnext.accounts.doctype.payment_request.payment_request.PaymentRequest.send_email"
+				) as mock_send_email:
+					with patch(
+						"erpnext.accounts.doctype.payment_request.payment_request.PaymentRequest.make_communication_entry"
+					) as mock_make_comm:
+						make_payment_request(
+							dt="Sales Order",
+							dn=so.name,
+							recipient_id="test@example.com",
+							payment_gateway_account="_Test Gateway - INR - _TC",
+							mute_email=False,  # Email should be sent
+							submit_doc=True,
+							return_doc=True,
+						)
+
+						mock_send_email.assert_called_once()
+						mock_make_comm.assert_called_once()
+
+	def test_v1_phone_payment_skips_email(self):
+		"""Phone payment channel should skip email sending entirely."""
+		so = make_sales_order(currency="INR")
+
+		with patch(
+			"erpnext.accounts.doctype.payment_request.payment_request._is_v2_gateway",
+			return_value=False,
+		):
+			with patch(
+				"erpnext.accounts.doctype.payment_request.payment_request.PaymentRequest.request_phone_payment"
+			) as mock_phone:
+				with patch(
+					"erpnext.accounts.doctype.payment_request.payment_request.PaymentRequest.send_email"
+				) as mock_send_email:
+					with patch(
+						"erpnext.accounts.doctype.payment_request.payment_request.PaymentRequest.make_communication_entry"
+					) as mock_make_comm:
+						pr = make_payment_request(
+							dt="Sales Order",
+							dn=so.name,
+							recipient_id="test@example.com",
+							payment_gateway_account="_Test Gateway - INR - _TC",
+							mute_email=False,
+							submit_doc=False,
+							return_doc=True,
+						)
+						pr.payment_channel = "Phone"
+						pr.submit()
+
+						# Phone payment should be called
+						mock_phone.assert_called_once()
+						# Email should NOT be sent for phone payments
+						mock_send_email.assert_not_called()
+						mock_make_comm.assert_not_called()
+
+	def test_no_payment_gateway_skips_payment_processing(self):
+		"""Payment request without gateway should skip all payment processing."""
+		so = make_sales_order(currency="INR")
+
+		with patch("erpnext.accounts.doctype.payment_request.payment_request._is_v2_gateway") as mock_is_v2:
+			with patch(
+				"erpnext.accounts.doctype.payment_request.payment_request.PaymentRequest._process_v2_gateway"
+			) as mock_v2:
+				with patch(
+					"erpnext.accounts.doctype.payment_request.payment_request.PaymentRequest.set_payment_request_url"
+				) as mock_v1:
+					pr = make_payment_request(
+						dt="Sales Order",
+						dn=so.name,
+						recipient_id="test@example.com",
+						mute_email=True,
+						submit_doc=False,
+						return_doc=True,
+					)
+					# Clear the payment gateway
+					pr.payment_gateway = None
+					pr.payment_gateway_account = None
+					pr.submit()
+
+					# Neither v1 nor v2 flow should be called
+					mock_is_v2.assert_not_called()
+					mock_v2.assert_not_called()
+					mock_v1.assert_not_called()
+
+	def test_outward_payment_request_skips_gateway_processing(self):
+		"""Outward payment requests should not trigger v1/v2 gateway flows."""
+		po = create_purchase_order()
+
+		with patch("erpnext.accounts.doctype.payment_request.payment_request._is_v2_gateway") as mock_is_v2:
+			with patch(
+				"erpnext.accounts.doctype.payment_request.payment_request.PaymentRequest._process_v2_gateway"
+			) as mock_v2:
+				with patch(
+					"erpnext.accounts.doctype.payment_request.payment_request.PaymentRequest.set_payment_request_url"
+				) as mock_v1:
+					pr = make_payment_request(
+						dt="Purchase Order",
+						dn=po.name,
+						recipient_id="test@example.com",
+						mute_email=True,
+						submit_doc=True,
+						return_doc=True,
+					)
+
+					# Outward requests should not call gateway processing
+					mock_is_v2.assert_not_called()
+					mock_v2.assert_not_called()
+					mock_v1.assert_not_called()
+					self.assertEqual(pr.payment_request_type, "Outward")
+					self.assertEqual(pr.status, "Initiated")
+
+	def test_flags_mute_email_suppresses_communication(self):
+		"""flags.mute_email should suppress email even when mute_email field is False."""
+		so = make_sales_order(currency="INR")
+
+		with patch(
+			"erpnext.accounts.doctype.payment_request.payment_request._is_v2_gateway",
+			return_value=True,
+		):
+			with patch(
+				"erpnext.accounts.doctype.payment_request.payment_request.PaymentRequest._process_v2_gateway"
+			):
+				with patch(
+					"erpnext.accounts.doctype.payment_request.payment_request.PaymentRequest.send_email"
+				) as mock_send_email:
+					pr = make_payment_request(
+						dt="Sales Order",
+						dn=so.name,
+						recipient_id="test@example.com",
+						payment_gateway_account="_Test Gateway - INR - _TC",
+						mute_email=False,  # Field says don't mute
+						submit_doc=False,
+						return_doc=True,
+					)
+					pr.flags.mute_email = True  # But flag says mute
+					pr.submit()
+
+					# Email should NOT be sent because of flags.mute_email
+					mock_send_email.assert_not_called()
+
+	# ============================================================================
+	# _get_party_contact_and_address Edge Case Tests
+	# ============================================================================
+
+	def test_contact_uses_mobile_no_fallback(self):
+		"""Contact with mobile_no but no phone should use mobile_no as fallback."""
+		customer = frappe.get_doc("Customer", "_Test Customer")
+
+		# Create contact with only mobile_no (via phone_nos child table)
+		contact_name = "_Test Contact Mobile Only"
+		if frappe.db.exists("Contact", contact_name):
+			frappe.delete_doc("Contact", contact_name, force=True)
+
+		test_contact = frappe.get_doc(
+			{
+				"doctype": "Contact",
+				"first_name": "Mobile",
+				"last_name": "Only",
+				"email_id": "mobile.only@example.com",
+				# Phone numbers in Frappe are set via the phone_nos child table
+				# is_primary_mobile_no sets the mobile_no field, is_primary_phone sets phone
+				"phone_nos": [{"phone": "+1999888777", "is_primary_mobile_no": 1}],
+			}
+		)
+		test_contact.insert(ignore_permissions=True)
+
+		original_contact = customer.customer_primary_contact
+		customer.db_set("customer_primary_contact", test_contact.name, update_modified=False)
+
+		try:
+			pr = frappe.new_doc("Payment Request")
+			pr.party_type = "Customer"
+			pr.party = customer.name
+
+			contact, _ = pr._get_party_contact_and_address()
+
+			# Should fall back to mobile_no since phone is empty
+			self.assertEqual(contact.get("phone"), "+1999888777")
+		finally:
+			customer.db_set("customer_primary_contact", original_contact, update_modified=False)
+			frappe.delete_doc("Contact", test_contact.name, force=True)
+
+	def test_contact_with_no_email_returns_empty_string(self):
+		"""Contact without email_id should return empty string, not None."""
+		customer = frappe.get_doc("Customer", "_Test Customer")
+
+		# Create contact without email
+		contact_name = "_Test Contact No Email"
+		if frappe.db.exists("Contact", contact_name):
+			frappe.delete_doc("Contact", contact_name, force=True)
+
+		test_contact = frappe.get_doc(
+			{
+				"doctype": "Contact",
+				"first_name": "No",
+				"last_name": "Email",
+				"email_id": "",  # No email
+				"phone": "+1234567890",
+			}
+		)
+		test_contact.insert(ignore_permissions=True)
+
+		original_contact = customer.customer_primary_contact
+		customer.db_set("customer_primary_contact", test_contact.name, update_modified=False)
+
+		try:
+			pr = frappe.new_doc("Payment Request")
+			pr.party_type = "Customer"
+			pr.party = customer.name
+
+			contact, _ = pr._get_party_contact_and_address()
+
+			# Should be empty string, not None
+			self.assertEqual(contact.get("email_id"), "")
+			self.assertEqual(contact.get("email"), "")
+			self.assertIsNotNone(contact.get("email_id"))
+		finally:
+			customer.db_set("customer_primary_contact", original_contact, update_modified=False)
+			frappe.delete_doc("Contact", test_contact.name, force=True)
+
+	def test_address_with_missing_optional_fields(self):
+		"""Address missing optional fields should return empty strings."""
+		customer = frappe.get_doc("Customer", "_Test Customer")
+
+		# Create minimal address
+		address_title = "_Test Minimal Address"
+		existing = frappe.db.get_value("Address", {"address_title": address_title}, "name")
+		if existing:
+			frappe.delete_doc("Address", existing, force=True)
+
+		test_address = frappe.get_doc(
+			{
+				"doctype": "Address",
+				"address_title": address_title,
+				"address_type": "Billing",
+				"address_line1": "123 Main St",
+				# No address_line2, state, pincode
+				"city": "Test City",
+				"country": "United States",
+			}
+		)
+		test_address.insert(ignore_permissions=True)
+
+		original_address = customer.customer_primary_address
+		customer.db_set("customer_primary_address", test_address.name, update_modified=False)
+
+		try:
+			pr = frappe.new_doc("Payment Request")
+			pr.party_type = "Customer"
+			pr.party = customer.name
+
+			_, address = pr._get_party_contact_and_address()
+
+			# Optional fields should be empty strings, not None
+			self.assertEqual(address.get("address_line2"), "")
+			self.assertEqual(address.get("state"), "")
+			self.assertEqual(address.get("pincode"), "")
+			# Required fields should have values
+			self.assertEqual(address.get("address_line1"), "123 Main St")
+			self.assertEqual(address.get("city"), "Test City")
+		finally:
+			customer.db_set("customer_primary_address", original_address, update_modified=False)
+			frappe.delete_doc("Address", test_address.name, force=True)
+
+	def test_customer_without_primary_contact(self):
+		"""Customer without primary_contact set should return empty contact dict."""
+		customer = frappe.get_doc("Customer", "_Test Customer")
+
+		original_contact = customer.customer_primary_contact
+		customer.db_set("customer_primary_contact", None, update_modified=False)
+
+		try:
+			pr = frappe.new_doc("Payment Request")
+			pr.party_type = "Customer"
+			pr.party = customer.name
+
+			contact, _ = pr._get_party_contact_and_address()
+
+			self.assertEqual(contact, {})
+		finally:
+			customer.db_set("customer_primary_contact", original_contact, update_modified=False)
+
+	def test_customer_without_primary_address(self):
+		"""Customer without primary_address set should return empty address dict."""
+		customer = frappe.get_doc("Customer", "_Test Customer")
+
+		original_address = customer.customer_primary_address
+		customer.db_set("customer_primary_address", None, update_modified=False)
+
+		try:
+			pr = frappe.new_doc("Payment Request")
+			pr.party_type = "Customer"
+			pr.party = customer.name
+
+			_, address = pr._get_party_contact_and_address()
+
+			self.assertEqual(address, {})
+		finally:
+			customer.db_set("customer_primary_address", original_address, update_modified=False)
+
+	# ============================================================================
+	# get_tx_data Edge Case Tests
+	# ============================================================================
+
+	def test_get_tx_data_multi_currency(self):
+		"""get_tx_data handles multi-currency payment requests correctly."""
+		# Create USD sales order
+		so = make_sales_order(currency="USD", qty=1, rate=100)
+
+		pr = make_payment_request(
+			dt="Sales Order",
+			dn=so.name,
+			recipient_id="test@example.com",
+			payment_gateway_account="_Test Gateway - USD - _TC",
+			mute_email=True,
+			submit_doc=False,
+			return_doc=True,
+		)
+
+		tx_data = pr.get_tx_data()
+
+		self.assertEqual(tx_data.currency, "USD")
+		self.assertGreater(tx_data.amount, 0)
+
+	def test_get_tx_data_without_party(self):
+		"""get_tx_data returns empty contact/address when party is not set."""
+		so = make_sales_order(currency="INR")
+
+		pr = make_payment_request(
+			dt="Sales Order",
+			dn=so.name,
+			recipient_id="test@example.com",
+			mute_email=True,
+			submit_doc=False,
+			return_doc=True,
+		)
+		# Clear party info
+		pr.party_type = None
+		pr.party = None
+
+		tx_data = pr.get_tx_data()
+
+		self.assertEqual(tx_data.payer_contact, {})
+		self.assertEqual(tx_data.payer_address, {})
+
+	def test_get_tx_data_loyalty_and_discount_are_none(self):
+		"""get_tx_data sets loyalty_points and discount_amount to None."""
+		so = make_sales_order(currency="INR")
+
+		pr = make_payment_request(
+			dt="Sales Order",
+			dn=so.name,
+			recipient_id="test@example.com",
+			mute_email=True,
+			submit_doc=False,
+			return_doc=True,
+		)
+
+		tx_data = pr.get_tx_data()
+
+		# These are explicitly set to None as per current implementation
+		self.assertIsNone(tx_data.loyalty_points)
+		self.assertIsNone(tx_data.discount_amount)
+
+	# ============================================================================
+	# _process_v2_gateway Success Path Tests
+	# ============================================================================
+
+	def test_process_v2_gateway_sets_payment_url(self):
+		"""_process_v2_gateway sets payment_url from PaymentController."""
+		so = make_sales_order(currency="INR")
+
+		pr = make_payment_request(
+			dt="Sales Order",
+			dn=so.name,
+			recipient_id="test@example.com",
+			payment_gateway_account="_Test Gateway - INR - _TC",
+			mute_email=True,
+			submit_doc=False,
+			return_doc=True,
+		)
+
+		expected_url = "https://gateway.example.com/pay/session123"
+		mock_controller_class = MagicMock()
+		mock_controller_class.initiate = MagicMock(return_value=(MagicMock(), "PSL-00001"))
+		mock_controller_class.get_payment_url = MagicMock(return_value=expected_url)
+
+		with patch("erpnext.accounts.doctype.payment_request.payment_request.payment_app_import_guard"):
+			with patch.dict(
+				sys.modules,
+				{
+					"payments": MagicMock(),
+					"payments.controllers": MagicMock(PaymentController=mock_controller_class),
+				},
+			):
+				pr._process_v2_gateway()
+
+				self.assertEqual(pr.payment_url, expected_url)
+				mock_controller_class.get_payment_url.assert_called_once_with("PSL-00001")
+
+	def test_process_v2_gateway_logs_error_on_failure(self):
+		"""_process_v2_gateway logs error with frappe.log_error on initiate failure."""
+		so = make_sales_order(currency="INR")
+
+		pr = make_payment_request(
+			dt="Sales Order",
+			dn=so.name,
+			recipient_id="test@example.com",
+			payment_gateway_account="_Test Gateway - INR - _TC",
+			mute_email=True,
+			submit_doc=False,
+			return_doc=True,
+		)
+		# Ensure payment_gateway is set (make_payment_request may not populate it)
+		pr.payment_gateway = "_Test Gateway"
+
+		mock_controller_class = MagicMock()
+		mock_controller_class.initiate = MagicMock(side_effect=Exception("API timeout"))
+
+		with patch("erpnext.accounts.doctype.payment_request.payment_request.payment_app_import_guard"):
+			with patch.dict(
+				sys.modules,
+				{
+					"payments": MagicMock(),
+					"payments.controllers": MagicMock(PaymentController=mock_controller_class),
+				},
+			):
+				with patch("frappe.log_error") as mock_log_error:
+					with self.assertRaises(frappe.ValidationError):
+						pr._process_v2_gateway()
+
+					# Verify error was logged
+					mock_log_error.assert_called_once()
+					call_kwargs = mock_log_error.call_args
+					self.assertIn("Payment Initialization Failed", str(call_kwargs))
+					self.assertIn("_Test Gateway", str(call_kwargs))


### PR DESCRIPTION
## Summary

Adds support for the new `PaymentController` interface from frappe/payments, enabling Payment Request to work with v2 payment gateways while maintaining backward compatibility with existing v1 gateways.

**Related:** [frappe/payments#192](https://github.com/frappe/payments/pull/192)

**Documentation:** [frappe/frappe_io#332](https://github.com/frappe/frappe_io/pull/332)

## Background

This PR is the ERPNext-side integration for the PaymentController architecture introduced in frappe/payments. It builds on the foundation laid by @blaggacao in:
- #40845 (original comprehensive refactor)
- #43085, #43086 (attempted breakdowns)

Rather than refactoring existing Payment Request logic, this PR adds a branch that detects v2 gateways and routes them through `PaymentController.initiate()` while leaving v1 behavior untouched.

## Changes

**Gateway detection:**
- `_is_v2_gateway()` - Thin wrapper around `payments.utils.is_v2_gateway()` with import guard

**New v2 flow methods:**
- `_process_v2_gateway()` - Calls `PaymentController.initiate()` and sets payment URL
- `get_tx_data()` - Prepares transaction data matching the `TxData` interface
- `_get_party_contact_and_address()` - Extracts payer contact/address info

**Modified `before_submit`:**
- Routes to v2 or v1 flow based on gateway type
- Email/communication handling unchanged

## Design Decisions

1. **Delegation to payments app:** Gateway detection logic lives in `payments.utils.is_v2_gateway()` to avoid duplication and ensure consistency.

2. **Request amount:** Uses `get_request_amount()` (not `grand_total`) to support partial payment scenarios, consistent with existing phone payment flow.

3. **Reference semantics:** `tx_data.reference_doctype/docname` points to Payment Request (not the underlying invoice/order) because Payment Request handles callbacks and reconciliation.

4. **Contact/address fields:** Returns only payment-relevant fields rather than full document data.

## Flow

```
Payment Request submitted
         │
         ▼
   Is v2 gateway?
    /         \
  Yes          No
   │            │
   ▼            ▼
_process_v2_   Legacy flow
gateway()      (unchanged)
   │
   ▼
PaymentController.initiate()
   │
   ▼
Payment Session Log created
   │
   ▼
/pay URL set
```

## Dependencies

Requires frappe/payments with `PaymentController` support ([#192](https://github.com/frappe/payments/pull/192)).

Falls back gracefully when payments app lacks v2 support.

## Test Plan

- [ ] `_is_v2_gateway()` returns True for v2 gateways, False for v1
- [ ] v2 gateway creates Payment Session Log via `PaymentController.initiate()`
- [ ] v1 gateways continue working unchanged
- [ ] Partial payment amounts handled correctly
- [ ] Email sending respects `mute_email` flag for both flows