### PR TITLE
fix(accounts): correct base grand total and rounded total mismatch

### DIFF
--- a/erpnext/public/js/controllers/taxes_and_totals.js
+++ b/erpnext/public/js/controllers/taxes_and_totals.js
@@ -637,6 +637,12 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 			tax_count ? this.frm.doc["taxes"][tax_count - 1].total + grand_total_diff : this.frm.doc.net_total
 		);
 
+		// total taxes and charges is calculated before adjusting base grand total
+		this.frm.doc.total_taxes_and_charges = flt(
+			this.frm.doc.grand_total - this.frm.doc.net_total - grand_total_diff,
+			precision("total_taxes_and_charges")
+		);
+
 		if (
 			["Quotation", "Sales Order", "Delivery Note", "Sales Invoice", "POS Invoice"].includes(
 				this.frm.doc.doctype
@@ -678,11 +684,6 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 				"taxes_and_charges_deducted",
 			]);
 		}
-
-		this.frm.doc.total_taxes_and_charges = flt(
-			this.frm.doc.grand_total - this.frm.doc.net_total - grand_total_diff,
-			precision("total_taxes_and_charges")
-		);
 
 		this.set_in_company_currency(this.frm.doc, ["total_taxes_and_charges"]);
 


### PR DESCRIPTION
**Issue Reference :** [51718](https://github.com/frappe/erpnext/issues/51718)

**Issue :** Base Grand Total and Base Rounded Total Values Mismatch

**steps to reproduce issue**
          1) create a customer with USD currency
          2) create a currency exchange with exchange rate 89.7
          3) add a precision 2 in system setting
          4) create a sales order with two items
          5) add a taxs and charges

**Fix :** Corrected calculation order in JS to prevent base grand total and base rounded total mismatch.


**before:**

[Screencast from 2026-01-14 11-13-14.webm](https://github.com/user-attachments/assets/2d8932bc-e232-44c1-b3a0-6a0559c20c9d)

**after:**

[Screencast from 2026-01-14 11-10-55.webm](https://github.com/user-attachments/assets/151cb858-21b9-40a3-b148-2889311c56ab)

**Backport needed v15**
