### PR TITLE
fix: add other charges in total

### DIFF
--- a/erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py
+++ b/erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py
@@ -105,7 +105,7 @@ def _execute(filters=None, additional_table_columns=None, additional_conditions=
 			{
 				"total_tax": total_tax,
 				"total_other_charges": total_other_charges,
-				"total": d.base_net_amount + total_tax,
+				"total": d.base_net_amount + total_tax + total_other_charges,
 				"currency": company_currency,
 			}
 		)


### PR DESCRIPTION
**Issue:**
In Item-wise sales report, other charges were not included in the total column.

**Ref:**  [#57167](https://support.frappe.io/helpdesk/tickets/57167)

**Before:**
![WhatsApp Image 2026-01-14 at 1 22 24 PM](https://github.com/user-attachments/assets/f9b5006f-b4a0-4249-90fd-105bc899c328)


**After:**
<img width="1808" height="957" alt="image" src="https://github.com/user-attachments/assets/578bdf4c-926b-4fd8-bfd6-a1b5b7b6cca4" />

Backport needed for 15