### PR TITLE
fix(payment_entry): clearance date in amended form

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -195,9 +195,14 @@ class PaymentEntry(AccountsController):
 		PaymentTaxWithholding(self).on_validate()
 		self.set_status()
 		self.set_total_in_words()
+		self.check_amended_form()
 
 	def before_save(self):
 		self.set_matched_unset_payment_requests_to_response()
+
+	def check_amended_form(self):
+		if self.amended_from:
+			self.clearance_date = None
 
 	def on_submit(self):
 		if self.difference_amount:


### PR DESCRIPTION
**Issue:**
After cancelling a reconciled payment entry and amending it, the system considers this new payment entry as already reconciled but the bank transaction used to reconcile this payment entry is unreconciled.

**Ref:**[#57264](https://support.frappe.io/helpdesk/tickets/57264)

**Steps To Reproduce:**

1. Perform bank reconciliation on a payment entry and match it with a related bank transaction
2. Cancel this payment entry and amend it.
3. Submit the new payment entry.

