### PR TITLE
fix: disable asset repair when status is fully depreciated

### DIFF
--- a/erpnext/assets/doctype/asset/asset.js
+++ b/erpnext/assets/doctype/asset/asset.js
@@ -117,14 +117,6 @@ frappe.ui.form.on("Asset", {
 				);
 
 				frm.add_custom_button(
-					__("Repair Asset"),
-					function () {
-						frm.trigger("create_asset_repair");
-					},
-					__("Manage")
-				);
-
-				frm.add_custom_button(
 					__("Split Asset"),
 					function () {
 						frm.trigger("split_asset");
@@ -152,6 +144,14 @@ frappe.ui.form.on("Asset", {
 					__("Adjust Asset Value"),
 					function () {
 						frm.trigger("create_asset_value_adjustment");
+					},
+					__("Manage")
+				);
+
+				frm.add_custom_button(
+					__("Repair Asset"),
+					function () {
+						frm.trigger("create_asset_repair");
 					},
 					__("Manage")
 				);


### PR DESCRIPTION
**Issue:**
When the asset is fully depreciated, the "Asset Repair" button is still visible in the Manage dropdown.

**Before:**
<img width="1799" height="940" alt="image" src="https://github.com/user-attachments/assets/b9a7d4af-57dc-442b-a002-004f450e7b07" />

**After:**
<img width="1800" height="942" alt="image" src="https://github.com/user-attachments/assets/5ffa0bf5-c54a-456f-af53-e324c8bbc4fb" />

Backport needed for v15 and v16