### PR TITLE
fix: consider consumed qty while validating component qty

### DIFF
--- a/erpnext/manufacturing/doctype/work_order/test_work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/test_work_order.py
@@ -2825,6 +2825,58 @@ class TestWorkOrder(IntegrationTestCase):
 
 		frappe.db.set_single_value("Manufacturing Settings", "validate_components_quantities_per_bom", 0)
 
+	def test_include_consumed_qty_in_component_qty_validation(self):
+		from erpnext.stock.doctype.stock_entry.stock_entry import NotEnoughQuantityConsumedError
+
+		frappe.db.set_single_value("Manufacturing Settings", "validate_components_quantities_per_bom", 1)
+		frappe.db.set_single_value("Manufacturing Settings", "material_consumption", 1)
+
+		fg_item = "Test FG Item For Component Validation 2"
+		source_warehouse = "Stores - _TC"
+		raw_materials = ["Test Component Validation RM Item 21", "Test Component Validation RM Item 22"]
+
+		make_item(fg_item, {"is_stock_item": 1})
+		for item in raw_materials:
+			make_item(item, {"is_stock_item": 1})
+			test_stock_entry.make_stock_entry(item=item, target=source_warehouse, qty=10, basic_rate=100)
+
+		make_bom(item=fg_item, source_warehouse=source_warehouse, raw_materials=raw_materials)
+
+		wo = make_wo_order_test_record(
+			item=fg_item,
+			qty=10,
+			source_warehouse=source_warehouse,
+		)
+
+		transfer_entry = frappe.get_doc(make_stock_entry(wo.name, "Material Transfer for Manufacture", 10))
+		transfer_entry.save().submit()
+
+		manufacture_entry1 = frappe.get_doc(make_stock_entry(wo.name, "Manufacture", 5))
+		manufacture_entry1.save().submit()
+
+		consumption_entry = frappe.get_doc(
+			make_stock_entry(wo.name, "Material Consumption for Manufacture", 2)
+		)
+		consumption_entry.save().submit()
+
+		manufacture_entry2 = frappe.get_doc(make_stock_entry(wo.name, "Manufacture", 5))
+		manufacture_entry2.save()
+
+		manufacture_entry2.remove(manufacture_entry2.items[0])
+		self.assertRaises(NotEnoughQuantityConsumedError, manufacture_entry2.save)
+		manufacture_entry2.reload()
+
+		for row in manufacture_entry2.items:
+			if not row.s_warehouse:
+				continue
+
+			self.assertEqual(row.qty, 3)
+
+		manufacture_entry2.save().submit()
+
+		frappe.db.set_single_value("Manufacturing Settings", "validate_components_quantities_per_bom", 0)
+		frappe.db.set_single_value("Manufacturing Settings", "material_consumption", 0)
+
 	def test_components_as_per_bom_for_manufacture_entry(self):
 		frappe.db.set_single_value("Manufacturing Settings", "backflush_raw_materials_based_on", "BOM")
 		frappe.db.set_single_value("Manufacturing Settings", "validate_components_quantities_per_bom", 1)

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -910,37 +910,141 @@ class StockEntry(StockController, SubcontractingInwardController):
 					title=_("Insufficient Stock"),
 				)
 
-	def validate_component_and_quantities(self):
-		if self.purpose not in ["Manufacture", "Material Transfer for Manufacture"]:
-			return
-
-		if not frappe.db.get_single_value("Manufacturing Settings", "validate_components_quantities_per_bom"):
-			return
-
-		if not self.fg_completed_qty:
+	def validate_component_and_quantities(self) -> None:
+		if not self._should_validate_component_quantities():
 			return
 
 		raw_materials = self.get_bom_raw_materials(self.fg_completed_qty)
-
+		item_list = list(raw_materials.keys())
 		precision = frappe.get_precision("Stock Entry Detail", "qty")
-		for item_code, details in raw_materials.items():
-			if matched_item := self.get_matched_items(item_code):
-				if flt(details.get("qty"), precision) != flt(matched_item.qty, precision):
-					frappe.throw(
-						_("For the item {0}, the quantity should be {1} according to the BOM {2}.").format(
-							frappe.bold(item_code),
-							flt(details.get("qty")),
-							get_link_to_form("BOM", self.bom_no),
-						),
-						title=_("Incorrect Component Quantity"),
-					)
-			else:
+
+		total_consumed_rm = self.get_total_consumed_qty_for_wo(item_list)
+		already_manufactured_fg = self.get_total_manufactured_fg_qty_for_wo()
+
+		for item_code, bom_details in raw_materials.items():
+			self._validate_item_quantity(
+				item_code=item_code,
+				bom_details=bom_details,
+				total_consumed_rm=total_consumed_rm,
+				already_manufactured_fg=already_manufactured_fg,
+				precision=precision,
+			)
+
+	def _should_validate_component_quantities(self) -> bool:
+		if self.purpose not in ["Manufacture", "Material Transfer for Manufacture"]:
+			return False
+
+		if not frappe.db.get_single_value("Manufacturing Settings", "validate_components_quantities_per_bom"):
+			return False
+
+		return bool(self.fg_completed_qty)
+
+	def _validate_item_quantity(
+		self, item_code, bom_details, total_consumed_rm, already_manufactured_fg, precision
+	) -> None:
+		required_qty = flt(bom_details.get("qty"))
+		matched_item = self.get_matched_items(item_code)
+
+		if self.purpose == "Manufacture" and self.work_order:
+			current_entry_rm_qty = flt(matched_item.qty) if matched_item else 0.0
+			consumed_rm_upto_now = flt(total_consumed_rm.get(item_code, 0.0)) + current_entry_rm_qty
+
+			rm_per_fg = flt(required_qty) / flt(self.fg_completed_qty) if self.fg_completed_qty else 0.0
+			total_fg_after = flt(already_manufactured_fg) + flt(self.fg_completed_qty)
+			required_rm_total = flt(rm_per_fg * total_fg_after)
+
+			if flt(consumed_rm_upto_now, precision) != flt(required_rm_total, precision):
 				frappe.throw(
-					_("According to the BOM {0}, the Item '{1}' is missing in the stock entry.").format(
-						get_link_to_form("BOM", self.bom_no), frappe.bold(item_code)
+					_(
+						"For the Work Order {0}.<br/>"
+						"Item {1}, consumed qty must match BOM requirement."
+						"Required {2} for total manufactured qty {3}, but consumed is {4}."
+					).format(
+						frappe.bold(self.work_order),
+						frappe.bold(item_code),
+						frappe.bold(flt(required_rm_total, precision)),
+						frappe.bold(flt(total_fg_after, precision)),
+						frappe.bold(flt(consumed_rm_upto_now, precision)),
 					),
-					title=_("Missing Item"),
+					title=_("Incorrect Component Quantity"),
 				)
+
+			return
+
+		if matched_item:
+			if flt(required_qty, precision) != flt(matched_item.qty, precision):
+				frappe.throw(
+					_("For the item {0}, the quantity should be {1} according to the BOM {2}.").format(
+						frappe.bold(item_code),
+						flt(required_qty),
+						get_link_to_form("BOM", self.bom_no),
+					),
+					title=_("Incorrect Component Quantity"),
+				)
+		else:
+			frappe.throw(
+				_("According to the BOM {0}, the Item '{1}' is missing in the stock entry.").format(
+					get_link_to_form("BOM", self.bom_no),
+					frappe.bold(item_code),
+				),
+				title=_("Missing Item"),
+			)
+
+	def get_total_consumed_qty_for_wo(self, item_list) -> dict[str, float]:
+		StockEntry = frappe.qb.DocType("Stock Entry")
+		StockEntryDetail = frappe.qb.DocType("Stock Entry Detail")
+
+		effective_item = (
+			frappe.qb.terms.Case()
+			.when(
+				(StockEntryDetail.original_item.isnull()) | (StockEntryDetail.original_item == ""),
+				StockEntryDetail.item_code,
+			)
+			.else_(StockEntryDetail.original_item)
+			.as_("effective_item")
+		)
+
+		consumed_qty = Sum(
+			frappe.qb.terms.Case()
+			.when(
+				(StockEntry.purpose.isin(["Material Consumption for Manufacture", "Manufacture"]))
+				& (StockEntryDetail.is_finished_item == 0),
+				StockEntryDetail.qty,
+			)
+			.else_(0)
+		)
+
+		result = (
+			frappe.qb.from_(StockEntry)
+			.join(StockEntryDetail)
+			.on(StockEntry.name == StockEntryDetail.parent)
+			.select(effective_item.as_("effective_item"), consumed_qty.as_("consumed_qty"))
+			.where(
+				(effective_item.isin(item_list))
+				& (StockEntry.work_order == self.work_order)
+				& (StockEntry.docstatus == 1)
+			)
+			.groupby(effective_item)
+			.run(as_dict=True)
+		)
+
+		return {row.effective_item: flt(row.consumed_qty) for row in result}
+
+	def get_total_manufactured_fg_qty_for_wo(self) -> float:
+		StockEntry = frappe.qb.DocType("Stock Entry")
+
+		result = (
+			frappe.qb.from_(StockEntry)
+			.select(Sum(StockEntry.fg_completed_qty))
+			.where(
+				(StockEntry.work_order == self.work_order)
+				& (StockEntry.docstatus == 1)
+				& (StockEntry.purpose == "Manufacture")
+			)
+			.run()
+		)
+
+		return flt(result[0][0]) if result else 0.0
 
 	def validate_same_source_target_warehouse_during_material_transfer(self):
 		"""

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -78,6 +78,10 @@ class MaxSampleAlreadyRetainedError(frappe.ValidationError):
 	pass
 
 
+class NotEnoughQuantityConsumedError(frappe.ValidationError):
+	pass
+
+
 from erpnext.controllers.stock_controller import StockController
 from erpnext.controllers.subcontracting_inward_controller import SubcontractingInwardController
 
@@ -966,6 +970,7 @@ class StockEntry(StockController, SubcontractingInwardController):
 						frappe.bold(flt(total_fg_after, precision)),
 						frappe.bold(flt(consumed_rm_upto_now, precision)),
 					),
+					exc=NotEnoughQuantityConsumedError,
 					title=_("Incorrect Component Quantity"),
 				)
 


### PR DESCRIPTION
**Issue:**
The system not considering the consumed qty of the raw materials while validating the component qty.

**Ref:** [#57262](https://support.frappe.io/helpdesk/tickets/57262)

**Before:**

https://github.com/user-attachments/assets/384f67c0-883f-4f77-a053-1196a3c62c33

**After:**

https://github.com/user-attachments/assets/1407c98d-8c98-4f2a-983f-30b8447503e7

**Backport Needed for v15 & v16**