### PR TITLE
fix(pos): reapply set warehouse during cart update

### DIFF
--- a/erpnext/selling/page/point_of_sale/pos_controller.js
+++ b/erpnext/selling/page/point_of_sale/pos_controller.js
@@ -651,6 +651,9 @@ erpnext.PointOfSale.Controller = class {
 
 	async on_cart_update(args) {
 		frappe.dom.freeze();
+		if (this.frm.doc.set_warehouse !== this.settings.warehouse) {
+			this.frm.set_value("set_warehouse", this.settings.warehouse);
+		}
 		let item_row = undefined;
 		try {
 			let { field, value, item } = args;


### PR DESCRIPTION
Issue: Warehouse is being cleared on the company set when strict permissions are applied, despite having access to the POS Profile and Warehouse.

Ref: [#54147](https://support.frappe.io/helpdesk/tickets/54147)

FYR:


https://github.com/user-attachments/assets/303173f5-b564-481f-a0a6-b4f49a07c276


