### PR TITLE
fix(manufacturing): refactor production analytics report

### DIFF
--- a/erpnext/manufacturing/report/production_analytics/production_analytics.py
+++ b/erpnext/manufacturing/report/production_analytics/production_analytics.py
@@ -8,6 +8,8 @@ from frappe.utils import getdate, today
 
 from erpnext.stock.report.stock_analytics.stock_analytics import get_period, get_period_date_ranges
 
+WORK_ORDER_STATUS_LIST = ["Not Started", "Overdue", "Pending", "Completed", "Closed", "Stopped"]
+
 
 def execute(filters=None):
 	columns = get_columns(filters)
@@ -16,119 +18,97 @@ def execute(filters=None):
 
 
 def get_columns(filters):
-	columns = [{"label": _("Status"), "fieldname": "Status", "fieldtype": "Data", "width": 140}]
-
+	columns = [{"label": _("Status"), "fieldname": "status", "fieldtype": "Data", "width": 140}]
 	ranges = get_period_date_ranges(filters)
 
 	for _dummy, end_date in ranges:
 		period = get_period(end_date, filters)
-
 		columns.append({"label": _(period), "fieldname": scrub(period), "fieldtype": "Float", "width": 120})
 
 	return columns
 
 
-def get_periodic_data(filters, entry):
-	periodic_data = {
-		"Not Started": {},
-		"Overdue": {},
-		"Pending": {},
-		"Completed": {},
-		"Closed": {},
-		"Stopped": {},
-	}
+def get_work_orders(filters):
+	from_date = filters.get("from_date")
+	to_date = filters.get("to_date")
 
-	ranges = get_period_date_ranges(filters)
+	WorkOrder = frappe.qb.DocType("Work Order")
 
-	for from_date, end_date in ranges:
-		period = get_period(end_date, filters)
-		for d in entry:
-			if getdate(from_date) <= getdate(d.creation) <= getdate(end_date) and d.status not in [
-				"Draft",
-				"Submitted",
-				"Completed",
-				"Cancelled",
-			]:
-				if d.status in ["Not Started", "Closed", "Stopped"]:
-					periodic_data = update_periodic_data(periodic_data, d.status, period)
-				elif getdate(today()) > getdate(d.planned_end_date):
-					periodic_data = update_periodic_data(periodic_data, "Overdue", period)
-				elif getdate(today()) < getdate(d.planned_end_date):
-					periodic_data = update_periodic_data(periodic_data, "Pending", period)
-
-			if (
-				getdate(from_date) <= getdate(d.actual_end_date) <= getdate(end_date)
-				and d.status == "Completed"
-			):
-				periodic_data = update_periodic_data(periodic_data, "Completed", period)
-
-	return periodic_data
-
-
-def update_periodic_data(periodic_data, status, period):
-	if periodic_data.get(status).get(period):
-		periodic_data[status][period] += 1
-	else:
-		periodic_data[status][period] = 1
-
-	return periodic_data
+	return (
+		frappe.qb.from_(WorkOrder)
+		.select(WorkOrder.creation, WorkOrder.actual_end_date, WorkOrder.planned_end_date, WorkOrder.status)
+		.where(
+			(WorkOrder.docstatus == 1)
+			& (WorkOrder.company == filters.get("company"))
+			& (
+				(WorkOrder.creation.between(from_date, to_date))
+				| (WorkOrder.actual_end_date.between(from_date, to_date))
+			)
+		)
+		.run(as_dict=True)
+	)
 
 
 def get_data(filters, columns):
-	data = []
-	entry = frappe.get_all(
-		"Work Order",
-		fields=[
-			"creation",
-			"actual_end_date",
-			"planned_end_date",
-			"status",
-		],
-		filters={"docstatus": 1, "company": filters["company"]},
-	)
+	ranges = build_ranges(filters)
+	period_labels = [pd for _fd, _td, pd in ranges]
+	periodic_data = {status: {pd: 0 for pd in period_labels} for status in WORK_ORDER_STATUS_LIST}
+	entries = get_work_orders(filters)
 
-	periodic_data = get_periodic_data(filters, entry)
+	for d in entries:
+		if d.status == "Completed":
+			if not d.actual_end_date:
+				continue
 
-	labels = ["Not Started", "Overdue", "Pending", "Completed", "Closed", "Stopped"]
-	chart_data = get_chart_data(periodic_data, columns)
-	ranges = get_period_date_ranges(filters)
+			if period := get_period_for_date(getdate(d.actual_end_date), ranges):
+				periodic_data["Completed"][period] += 1
+			continue
 
-	for label in labels:
-		work = {}
-		work["Status"] = _(label)
-		for _dummy, end_date in ranges:
-			period = get_period(end_date, filters)
-			if periodic_data.get(label).get(period):
-				work[scrub(period)] = periodic_data.get(label).get(period)
+		creation_date = getdate(d.creation)
+		period = get_period_for_date(creation_date, ranges)
+		if not period:
+			continue
+
+		if d.status in ("Not Started", "Closed", "Stopped"):
+			periodic_data[d.status][period] += 1
+		else:
+			if d.planned_end_date and getdate(today()) > getdate(d.planned_end_date):
+				periodic_data["Overdue"][period] += 1
 			else:
-				work[scrub(period)] = 0.0
-		data.append(work)
+				periodic_data["Pending"][period] += 1
 
-	return data, chart_data
+	data = []
+	for status in WORK_ORDER_STATUS_LIST:
+		row = {"status": _(status)}
+		for _fd, _td, pd in ranges:
+			row[scrub(pd)] = periodic_data[status].get(pd, 0)
+		data.append(row)
+
+	chart = get_chart_data(periodic_data, columns)
+	return data, chart
+
+
+def get_period_for_date(date, ranges):
+	for from_date, to_date, period in ranges:
+		if from_date <= date <= to_date:
+			return period
+	return None
+
+
+def build_ranges(filters):
+	ranges = []
+	for from_date, end_date in get_period_date_ranges(filters):
+		period = get_period(end_date, filters)
+		ranges.append((getdate(from_date), getdate(end_date), period))
+	return ranges
 
 
 def get_chart_data(periodic_data, columns):
 	labels = [d.get("label") for d in columns[1:]]
 
-	not_start, overdue, pending, completed, closed, stopped = [], [], [], [], [], []
 	datasets = []
+	for status in WORK_ORDER_STATUS_LIST:
+		values = [periodic_data.get(status, {}).get(label, 0) for label in labels]
+		datasets.append({"name": _(status), "values": values})
 
-	for d in labels:
-		not_start.append(periodic_data.get("Not Started").get(d))
-		overdue.append(periodic_data.get("Overdue").get(d))
-		pending.append(periodic_data.get("Pending").get(d))
-		completed.append(periodic_data.get("Completed").get(d))
-		closed.append(periodic_data.get("Closed").get(d))
-		stopped.append(periodic_data.get("Stopped").get(d))
-
-	datasets.append({"name": _("Not Started"), "values": not_start})
-	datasets.append({"name": _("Overdue"), "values": overdue})
-	datasets.append({"name": _("Pending"), "values": pending})
-	datasets.append({"name": _("Completed"), "values": completed})
-	datasets.append({"name": _("Closed"), "values": closed})
-	datasets.append({"name": _("Stopped"), "values": stopped})
-
-	chart = {"data": {"labels": labels, "datasets": datasets}}
-	chart["type"] = "line"
-
-	return chart
+	return {"data": {"labels": labels, "datasets": datasets}, "type": "line"}


### PR DESCRIPTION
**Issue:**
1. When checking completed work orders, the code applies `get_date()` to `actual_end_date` without first verifying whether `actual_end_date` is set. If `actual_end_date` is `None`, `get_date()` returns the current date, causing work orders to be incorrectly counted as completed in the current month in the Production Analytics report.
2. The same issue applies to `planned_end_date` when checking pending work orders, as `planned_end_date` can be null.
3. Fetching and processing all the work orders without applying date filters.
4. While preparing the chart data, the code loops over localized period labels, but the keys in `periodic_data` are raw (unlocalized) period strings from `build_ranges`. This mismatch can cause all chart values to be 0 in non-English locales where period names are translated.

**Ref:** [#57279](https://support.frappe.io/helpdesk/tickets/57279)

**Before:**

https://github.com/user-attachments/assets/3295c5d3-b3bb-42f9-8aad-438fa97840e7

**After:**

https://github.com/user-attachments/assets/db39231c-0658-4ee1-85c0-7b0d0ed2c416

**Backport Needed for v16 & v15**