### PR TITLE
fix(accounts): prevent duplicate credit notes from return DN (#51608)

### DIFF
--- a/erpnext/stock/doctype/delivery_note/delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.py
@@ -852,7 +852,7 @@ def make_sales_invoice(source_name, target_doc=None, args=None):
 
 	def set_missing_values(source, target):
 		if source.is_return and source.return_against:
-			# Find original Sales Invoice
+			#Sales Invoice Items linked to the Delivery Note
 			invoices = frappe.get_all(
 				"Sales Invoice Item",
 				filters={
@@ -862,22 +862,31 @@ def make_sales_invoice(source_name, target_doc=None, args=None):
 				fields=["parent", "name", "item_code"]
 			)
 
-			original_invoice = None
 			item_map = {}
+			original_invoices = set()
 
 			for row in invoices:
-				# Pick the original invoice
 				if not frappe.db.get_value("Sales Invoice", row.parent, "is_return"):
-					original_invoice = row.parent
+					original_invoices.add(row.parent)
 					item_map.setdefault(row.item_code, []).append(row.name)
 
-
-			if not original_invoice:
+			if not original_invoices:
 				frappe.throw(
 					_("Could not determine original Sales Invoice for this return."),
 					frappe.ValidationError,
 				)
 
+			if len(original_invoices) > 1:
+				frappe.throw(
+					_(
+						"Cannot create a single Credit Note for a Delivery Note "
+						"invoiced by multiple Sales Invoices. "
+						"Please return each invoice separately."
+					),
+					frappe.ValidationError,
+				)
+
+			original_invoice = next(iter(original_invoices))
 			target.return_against = original_invoice
 
 			for item in target.items:

--- a/erpnext/stock/doctype/delivery_note/delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.py
@@ -851,6 +851,32 @@ def make_sales_invoice(source_name, target_doc=None, args=None):
 	invoiced_qty_map = get_invoiced_qty_map(source_name)
 
 	def set_missing_values(source, target):
+		if source.is_return and source.return_against:
+			#Find original Sales Invoice
+			invoices = frappe.get_all(
+				"Sales Invoice Item",
+				filters={
+					"delivery_note": source.return_against,
+					"docstatus": 1
+				},
+				fields=["parent", "name", "item_code"]
+			)
+
+			original_invoice = None
+			item_map = {}
+
+			for row in invoices:
+				if not frappe.db.get_value("Sales Invoice", row.parent, "is_return"):
+					original_invoice = row.parent
+					item_map.setdefault(row.item_code, []).append(row.name)
+
+			if original_invoice:
+				target.return_against = original_invoice
+
+
+				for item in target.items:
+					if item.item_code in item_map:
+						item.sales_invoice_item = item_map[item.item_code][0]
 		target.run_method("set_missing_values")
 		target.run_method("set_po_nos")
 

--- a/erpnext/stock/doctype/delivery_note/delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.py
@@ -852,7 +852,7 @@ def make_sales_invoice(source_name, target_doc=None, args=None):
 
 	def set_missing_values(source, target):
 		if source.is_return and source.return_against:
-			#Find original Sales Invoice
+			# Find original Sales Invoice
 			invoices = frappe.get_all(
 				"Sales Invoice Item",
 				filters={
@@ -866,17 +866,23 @@ def make_sales_invoice(source_name, target_doc=None, args=None):
 			item_map = {}
 
 			for row in invoices:
+				# Pick the original invoice
 				if not frappe.db.get_value("Sales Invoice", row.parent, "is_return"):
 					original_invoice = row.parent
 					item_map.setdefault(row.item_code, []).append(row.name)
 
-			if original_invoice:
-				target.return_against = original_invoice
 
+			if not original_invoice:
+				frappe.throw(
+					_("Could not determine original Sales Invoice for this return."),
+					frappe.ValidationError,
+				)
 
-				for item in target.items:
-					if item.item_code in item_map:
-						item.sales_invoice_item = item_map[item.item_code][0]
+			target.return_against = original_invoice
+
+			for item in target.items:
+				if item.item_code in item_map and item_map[item.item_code]:
+					item.sales_invoice_item = item_map[item.item_code].pop(0)
 		target.run_method("set_missing_values")
 		target.run_method("set_po_nos")
 

--- a/erpnext/stock/doctype/delivery_note/delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.py
@@ -852,7 +852,7 @@ def make_sales_invoice(source_name, target_doc=None, args=None):
 
 	def set_missing_values(source, target):
 		if source.is_return and source.return_against:
-			#Sales Invoice Items linked to the Delivery Note
+			# Sales Invoice Items linked to the Delivery Note
 			invoices = frappe.get_all(
 				"Sales Invoice Item",
 				filters={
@@ -870,28 +870,13 @@ def make_sales_invoice(source_name, target_doc=None, args=None):
 					original_invoices.add(row.parent)
 					item_map.setdefault(row.item_code, []).append(row.name)
 
-			if not original_invoices:
-				frappe.throw(
-					_("Could not determine original Sales Invoice for this return."),
-					frappe.ValidationError,
-				)
+			if len(original_invoices) == 1:
+				original_invoice = next(iter(original_invoices))
+				target.return_against = original_invoice
 
-			if len(original_invoices) > 1:
-				frappe.throw(
-					_(
-						"Cannot create a single Credit Note for a Delivery Note "
-						"invoiced by multiple Sales Invoices. "
-						"Please return each invoice separately."
-					),
-					frappe.ValidationError,
-				)
-
-			original_invoice = next(iter(original_invoices))
-			target.return_against = original_invoice
-
-			for item in target.items:
-				if item.item_code in item_map and item_map[item.item_code]:
-					item.sales_invoice_item = item_map[item.item_code].pop(0)
+				for item in target.items:
+					if item.item_code in item_map and item_map[item.item_code]:
+						item.sales_invoice_item = item_map[item.item_code].pop(0)
 		target.run_method("set_missing_values")
 		target.run_method("set_po_nos")
 

--- a/erpnext/stock/doctype/delivery_note/test_delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/test_delivery_note.py
@@ -2877,7 +2877,7 @@ class TestDeliveryNote(IntegrationTestCase):
 		frappe.clear_cache()
 
 		dn = create_delivery_note(qty=10, rate=100)
-		dn.submit()
+
 
 		si = make_sales_invoice(dn.name)
 		si.save()
@@ -2898,7 +2898,7 @@ class TestDeliveryNote(IntegrationTestCase):
 			return_against=dn.name,
 			qty=-10
 		)
-		dn_return.submit()
+
 
 		# Second Credit Note
 		cn2 = make_sales_invoice(dn_return.name)

--- a/erpnext/stock/doctype/delivery_note/test_delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/test_delivery_note.py
@@ -2911,7 +2911,7 @@ class TestDeliveryNote(IntegrationTestCase):
 			self.assertTrue(item.sales_invoice_item)
 
 		with self.assertRaises(StockOverReturnError):
-			cn2.save()
+			cn2.submit()
 
 
 def create_delivery_note(**args):

--- a/erpnext/stock/doctype/delivery_note/test_delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/test_delivery_note.py
@@ -2864,6 +2864,55 @@ class TestDeliveryNote(IntegrationTestCase):
 		for entry in sabb.entries:
 			self.assertEqual(entry.incoming_rate, 200)
 
+	def test_return_dn_blocks_duplicate_credit_note_submission(self):
+
+		from erpnext.stock.doctype.delivery_note.delivery_note import make_sales_invoice
+		from erpnext.controllers.sales_and_purchase_return import (
+			make_return_doc,
+			StockOverReturnError,
+		)
+
+		# Setup
+		frappe.db.set_single_value("Accounts Settings", "allow_over_billing", 0)
+		frappe.clear_cache()
+
+		dn = create_delivery_note(qty=10, rate=100)
+		dn.submit()
+
+		si = make_sales_invoice(dn.name)
+		si.save()
+		si.submit()
+
+		# First Credit Note
+		cn1 = make_return_doc("Sales Invoice", si.name)
+		cn1.save()
+		cn1.submit()
+
+		# Simulate reconciliation
+		si.db_set("outstanding_amount", 0)
+		si.reload()
+
+		# Return Delivery Note
+		dn_return = create_delivery_note(
+			is_return=1,
+			return_against=dn.name,
+			qty=-10
+		)
+		dn_return.submit()
+
+		# Second Credit Note
+		cn2 = make_sales_invoice(dn_return.name)
+
+		# Header linkage
+		self.assertEqual(cn2.return_against, si.name)
+
+		# Item linkage
+		for item in cn2.items:
+			self.assertTrue(item.sales_invoice_item)
+
+		with self.assertRaises(StockOverReturnError):
+			cn2.save()
+
 
 def create_delivery_note(**args):
 	dn = frappe.new_doc("Delivery Note")


### PR DESCRIPTION
This PR fixes Issue #51608 where creating a Credit Note from a Return Delivery Note did not correctly link returned item rows to the original Sales Invoice.

Because sales_invoice_item was not mapped, return quantity validation (validate_return_qty) was skipped, allowing users to submit duplicate refunds for the same invoice.

Root Cause: During Credit Note creation from a Return Delivery Note:

return_against was not reliably set to the original Sales Invoice.

Item rows were not linked to the corresponding Sales Invoice Item rows.

As a result, ERPNext could not detect previously returned quantities.

Fix:

Updated set_missing_values in erpnext/stock/doctype/delivery_note/delivery_note.py to:

Identify the original Sales Invoice.

Map returned items to their corresponding sales_invoice_item rows.

This ensures validate_return_qty is executed correctly and prevents over-return and duplicate refunds.

Tests:

Added regression test test_return_dn_blocks_duplicate_credit_note_submission in erpnext/stock/doctype/delivery_note/test_delivery_note.py.

Test validates:

Header linkage via return_against.

Item row linkage via sales_invoice_item.

Blocking of duplicate returns (ValidationError raised).

Closes: #51608