### PR TITLE
fix: add company filters for warehouse

### DIFF
--- a/erpnext/buying/doctype/supplier_quotation/supplier_quotation.js
+++ b/erpnext/buying/doctype/supplier_quotation/supplier_quotation.js
@@ -16,6 +16,14 @@ erpnext.buying.SupplierQuotationController = class SupplierQuotationController e
 			return !doc.qty && me.frm.doc.has_unit_price_items ? "yellow" : "";
 		});
 
+		this.frm.set_query("warehouse", "items", (doc, cdt, cdn) => {
+			return {
+				filters: {
+					company: doc.company,
+					is_group: 0,
+				},
+			};
+		});
 		super.setup();
 	}
 

--- a/erpnext/selling/doctype/quotation/quotation.js
+++ b/erpnext/selling/doctype/quotation/quotation.js
@@ -36,6 +36,15 @@ frappe.ui.form.on("Quotation", {
 			};
 		});
 
+		frm.set_query("warehouse", "items", (doc, cdt, cdn) => {
+			return {
+				filters: {
+					company: doc.company,
+					is_group: 0,
+				},
+			};
+		});
+
 		frm.set_indicator_formatter("item_code", function (doc) {
 			return !doc.qty && frm.doc.has_unit_price_items ? "yellow" : "";
 		});


### PR DESCRIPTION
**Issue:**
The Warehouse field was not filtered based on the company in Quotation and the Supplier Quotation.

**Before:**
<img width="1799" height="940" alt="image" src="https://github.com/user-attachments/assets/20e38e63-ce7e-400e-94e8-d2b3dc822417" />


**After:**
<img width="1799" height="940" alt="image" src="https://github.com/user-attachments/assets/51bd456d-8a25-4e57-aac3-7d07de92a266" />

Backport needed for v15, v16