### PR TITLE
fix: recalculate taxes when item tax template changes after discount

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
@@ -2979,7 +2979,7 @@ class TestSalesInvoice(ERPNextTestSuite):
 
 		item.save()
 
-		si = create_sales_invoice(item="T Shirt Tax Recalc", rate=700, do_not_save=True)
+		si = create_sales_invoice(item=item.name, rate=700, do_not_save=True)
 		si.append(
 			"taxes",
 			{
@@ -3001,7 +3001,6 @@ class TestSalesInvoice(ERPNextTestSuite):
 		# Verify template changed to 10%
 		self.assertEqual(si.items[0].item_tax_template, "_Test Account Excise Duty @ 10 - _TC")
 
-		# Submit and verify GL entries balance
 		si.submit()
 
 	@IntegrationTestCase.change_settings("Selling Settings", {"enable_discount_accounting": 1})

--- a/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
@@ -2951,6 +2951,59 @@ class TestSalesInvoice(ERPNextTestSuite):
 		self.assertEqual(sales_invoice.items[0].item_tax_template, "_Test Account Excise Duty @ 10 - _TC")
 		self.assertEqual(sales_invoice.items[0].item_tax_rate, item_tax_map)
 
+	def test_item_tax_template_change_with_grand_total_discount(self):
+		"""
+		Test that when item tax template changes due to discount on Grand Total,
+		the tax calculations are consistent.
+		"""
+		item = create_item("Test Item With Multiple Tax Templates")
+
+		item.set("taxes", [])
+		item.append(
+			"taxes",
+			{
+				"item_tax_template": "_Test Account Excise Duty @ 10 - _TC",
+				"minimum_net_rate": 0,
+				"maximum_net_rate": 500,
+			},
+		)
+
+		item.append(
+			"taxes",
+			{
+				"item_tax_template": "_Test Account Excise Duty @ 12 - _TC",
+				"minimum_net_rate": 501,
+				"maximum_net_rate": 1000,
+			},
+		)
+
+		item.save()
+
+		si = create_sales_invoice(item="T Shirt Tax Recalc", rate=700, do_not_save=True)
+		si.append(
+			"taxes",
+			{
+				"charge_type": "On Net Total",
+				"account_head": "_Test Account Excise Duty - _TC",
+				"cost_center": "_Test Cost Center - _TC",
+				"description": "Excise Duty",
+				"rate": 0,
+			},
+		)
+		si.insert()
+
+		self.assertEqual(si.items[0].item_tax_template, "_Test Account Excise Duty @ 12 - _TC")
+
+		si.apply_discount_on = "Grand Total"
+		si.discount_amount = 300
+		si.save()
+
+		# Verify template changed to 10%
+		self.assertEqual(si.items[0].item_tax_template, "_Test Account Excise Duty @ 10 - _TC")
+
+		# Submit and verify GL entries balance
+		si.submit()
+
 	@IntegrationTestCase.change_settings("Selling Settings", {"enable_discount_accounting": 1})
 	def test_sales_invoice_with_discount_accounting_enabled(self):
 		discount_account = create_account(

--- a/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
@@ -3000,6 +3000,8 @@ class TestSalesInvoice(ERPNextTestSuite):
 
 		# Verify template changed to 10%
 		self.assertEqual(si.items[0].item_tax_template, "_Test Account Excise Duty @ 10 - _TC")
+		self.assertEqual(si.taxes[0].tax_amount, 70)  # 10% of 700
+		self.assertEqual(si.grand_total, 470)  # 700 + 70 - 300
 
 		si.submit()
 

--- a/erpnext/controllers/taxes_and_totals.py
+++ b/erpnext/controllers/taxes_and_totals.py
@@ -39,19 +39,27 @@ class calculate_taxes_and_totals:
 		items = list(filter(lambda item: not item.get("is_alternative"), self.doc.get("items")))
 		return items
 
-	def calculate(self, skip_tax_template_validation=False):
+	def calculate(self, validate_tax_template=True):
 		if not len(self.doc.items):
 			return
 
 		self.discount_amount_applied = False
+		self._has_tax_template_changed = False
+		self._validate_tax_template = validate_tax_template
+
 		self._calculate()
 
 		if self.doc.meta.get_field("discount_amount"):
 			self.set_discount_amount()
 			self.apply_discount_amount()
 
-		if not skip_tax_template_validation and self.validate_item_tax_template():
-			return self.calculate(skip_tax_template_validation=True)
+		if (
+			validate_tax_template
+			and self._has_tax_template_changed
+			and self.doc.apply_discount_on == "Grand Total"
+			and self.doc.get("discount_amount")
+		):
+			return self.calculate(validate_tax_template=False)
 
 		# Update grand total as per cash and non trade discount
 		if self.doc.apply_discount_on == "Grand Total" and self.doc.get("is_cash_or_non_trade_discount"):
@@ -71,6 +79,7 @@ class calculate_taxes_and_totals:
 	def _calculate(self):
 		self.validate_conversion_rate()
 		self.calculate_item_values()
+		self.validate_item_tax_template()
 		self.update_item_tax_map()
 		self.initialize_taxes()
 		self.determine_exclusive_rate()
@@ -81,10 +90,11 @@ class calculate_taxes_and_totals:
 		self.calculate_total_net_weight()
 
 	def validate_item_tax_template(self):
-		if self.doc.get("is_return") and self.doc.get("return_against"):
-			return False
+		if not self._validate_tax_template:
+			return
 
-		has_template_changed = False
+		if self.doc.get("is_return") and self.doc.get("return_against"):
+			return
 
 		for item in self.doc.items:
 			if item.item_code and item.get("item_tax_template"):
@@ -125,9 +135,10 @@ class calculate_taxes_and_totals:
 								item.idx, frappe.bold(item.item_code)
 							)
 						)
-						has_template_changed = True
 
-		return has_template_changed
+						# Set flag to trigger recalculation after discount
+						if self.discount_amount_applied:
+							self._has_tax_template_changed = True
 
 	def update_item_tax_map(self):
 		for item in self.doc.items:

--- a/erpnext/controllers/taxes_and_totals.py
+++ b/erpnext/controllers/taxes_and_totals.py
@@ -39,7 +39,7 @@ class calculate_taxes_and_totals:
 		items = list(filter(lambda item: not item.get("is_alternative"), self.doc.get("items")))
 		return items
 
-	def calculate(self):
+	def calculate(self, skip_tax_template_validation=False):
 		if not len(self.doc.items):
 			return
 
@@ -49,6 +49,9 @@ class calculate_taxes_and_totals:
 		if self.doc.meta.get_field("discount_amount"):
 			self.set_discount_amount()
 			self.apply_discount_amount()
+
+		if not skip_tax_template_validation and self.validate_item_tax_template():
+			return self.calculate(skip_tax_template_validation=True)
 
 		# Update grand total as per cash and non trade discount
 		if self.doc.apply_discount_on == "Grand Total" and self.doc.get("is_cash_or_non_trade_discount"):
@@ -68,7 +71,6 @@ class calculate_taxes_and_totals:
 	def _calculate(self):
 		self.validate_conversion_rate()
 		self.calculate_item_values()
-		self.validate_item_tax_template()
 		self.update_item_tax_map()
 		self.initialize_taxes()
 		self.determine_exclusive_rate()
@@ -80,7 +82,9 @@ class calculate_taxes_and_totals:
 
 	def validate_item_tax_template(self):
 		if self.doc.get("is_return") and self.doc.get("return_against"):
-			return
+			return False
+
+		has_template_changed = False
 
 		for item in self.doc.items:
 			if item.item_code and item.get("item_tax_template"):
@@ -121,6 +125,9 @@ class calculate_taxes_and_totals:
 								item.idx, frappe.bold(item.item_code)
 							)
 						)
+						has_template_changed = True
+
+		return has_template_changed
 
 	def update_item_tax_map(self):
 		for item in self.doc.items:

--- a/erpnext/controllers/taxes_and_totals.py
+++ b/erpnext/controllers/taxes_and_totals.py
@@ -131,7 +131,6 @@ class calculate_taxes_and_totals:
 							)
 						)
 
-						# Set flag to trigger recalculation after discount
 						if self.discount_amount_applied:
 							self._has_tax_template_changed = True
 

--- a/erpnext/controllers/taxes_and_totals.py
+++ b/erpnext/controllers/taxes_and_totals.py
@@ -39,13 +39,13 @@ class calculate_taxes_and_totals:
 		items = list(filter(lambda item: not item.get("is_alternative"), self.doc.get("items")))
 		return items
 
-	def calculate(self, validate_tax_template=True):
+	def calculate(self, ignore_tax_template_validation=False):
 		if not len(self.doc.items):
 			return
 
 		self.discount_amount_applied = False
-		self._has_tax_template_changed = False
-		self._validate_tax_template = validate_tax_template
+		self.need_recomputation = False
+		self.ignore_tax_template_validation = ignore_tax_template_validation
 
 		self._calculate()
 
@@ -53,8 +53,8 @@ class calculate_taxes_and_totals:
 			self.set_discount_amount()
 			self.apply_discount_amount()
 
-		if validate_tax_template and self._has_tax_template_changed:
-			return self.calculate(validate_tax_template=False)
+		if not ignore_tax_template_validation and self.need_recomputation:
+			return self.calculate(ignore_tax_template_validation=True)
 
 		# Update grand total as per cash and non trade discount
 		if self.doc.apply_discount_on == "Grand Total" and self.doc.get("is_cash_or_non_trade_discount"):
@@ -85,7 +85,7 @@ class calculate_taxes_and_totals:
 		self.calculate_total_net_weight()
 
 	def validate_item_tax_template(self):
-		if not self._validate_tax_template:
+		if self.ignore_tax_template_validation:
 			return
 
 		if self.doc.get("is_return") and self.doc.get("return_against"):
@@ -131,8 +131,9 @@ class calculate_taxes_and_totals:
 							)
 						)
 
-						if self.discount_amount_applied:
-							self._has_tax_template_changed = True
+						# For correct tax_amount calculation re-computation is required
+						if self.discount_amount_applied and self.doc.apply_discount_on == "Grand Total":
+							self.need_recomputation = True
 
 	def update_item_tax_map(self):
 		for item in self.doc.items:

--- a/erpnext/controllers/taxes_and_totals.py
+++ b/erpnext/controllers/taxes_and_totals.py
@@ -53,12 +53,7 @@ class calculate_taxes_and_totals:
 			self.set_discount_amount()
 			self.apply_discount_amount()
 
-		if (
-			validate_tax_template
-			and self._has_tax_template_changed
-			and self.doc.apply_discount_on == "Grand Total"
-			and self.doc.get("discount_amount")
-		):
+		if validate_tax_template and self._has_tax_template_changed:
 			return self.calculate(validate_tax_template=False)
 
 		# Update grand total as per cash and non trade discount


### PR DESCRIPTION
### Issue
When submitting a Sales Invoice with a discount applied on **Grand Total** with item tax template getting changed, the system throws:
ValidationError: Debit and Credit not equal for Sales Invoice #SINV-XXXX

## Steps to Replicate
1. **Create an Item** with multiple tax templates based on net rate:
   | Template | Rate | Min Net Rate | Max Net Rate |
   |----------|------|--------------|--------------|
   | Template A | 10% | 0 | 500 |
   | Template B | 12% | 501 | 1000 |
2. **Create a Sales Invoice:**
   - Add the item with `rate = 700` (falls in Template B range)
   - Add applicable taxes
3. **Apply discount on Grand Total:**
   - Set `apply_discount_on = "Grand Total"`
   - Set `discount_amount = 300` (moves net_rate to ~400, which falls in Template A range)
4. **Save and Submit** the invoice
5. **Result:**
   - **Expected:** Invoice submits successfully
   - **Actual:** `ValidationError: Debit and Credit not equal`

### Root Cause
- The  validate_item_tax_template() function was called inside _calculate(), which runs twice:
1. First pass: Before discount is applied
2. Second pass: After discount is applied (inside apply_discount_amount())


When the discount moved the net_rate into a different template's range:

- The Item Tax Template was updated
- But tax_amount values were preserved from the first calculation (due to discount_amount_applied flag)
- tax_amount_after_discount_amount was calculated with the new template.
- This mismatch caused GL entries to be unbalanced


Frappe Support Issue: https://support.frappe.io/desk/hd-ticket/57287