### PR TITLE
fix(stock): resolve quantity issue when adding items via barcode scan

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -518,7 +518,7 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 
 	barcode(doc, cdt, cdn) {
 		let row = locals[cdt][cdn];
-		if (row.barcode) {
+		if (row.barcode && !frappe.flags.trigger_from_barcode_scanner) {
 			erpnext.stock.utils.set_item_details_using_barcode(this.frm, row, (r) => {
 				frappe.model.set_value(cdt, cdn, {
 					item_code: r.message.item_code,


### PR DESCRIPTION
Issue: When an item contains multiple barcodes, scanning a different barcode for the same item in a Sales Invoice does not increment the quantity on the second scan.

Ref:[#57170](https://support.frappe.io/helpdesk/tickets/57170)

Description:
When an Item is configured with multiple barcodes, scanning different barcodes for the same Item in a Sales Invoice leads to inconsistent behavior.

If the Item is added using one barcode and then scanned again using another barcode belonging to the same Item, the system displays the message “Quantity increased by 1”, but the quantity in the item child table is not updated correctly.

Before:


https://github.com/user-attachments/assets/75490d42-01d5-48d8-b184-3dfa0a9d2c75

After:


https://github.com/user-attachments/assets/fe7c18ac-e567-4760-b980-91e7e1b2d614

Backport Needed: V16 and V15


