### PR TITLE
fix: dont show certain fields based on permissions

### DIFF
--- a/erpnext/stock/doctype/item/item.js
+++ b/erpnext/stock/doctype/item/item.js
@@ -116,6 +116,11 @@ frappe.ui.form.on("Item", {
 				},
 				__("View")
 			);
+
+			frm.toggle_display(
+				["opening_stock"],
+				frappe.model.can_create("Stock Entry") && frappe.model.can_write("Stock Entry")
+			);
 		}
 
 		if (frm.doc.is_fixed_asset) {
@@ -239,6 +244,8 @@ frappe.ui.form.on("Item", {
 				},
 			};
 		});
+
+		frm.toggle_display(["standard_rate"], frappe.model.can_create("Item Price"));
 	},
 
 	validate: function (frm) {


### PR DESCRIPTION
`Opening Stock` and `Standard Selling Rate` fields will now be shown only if user has the relevant permissions

fixes #51694