### PR TITLE
fix: change docfield type to render html format

### DIFF
--- a/erpnext/buying/doctype/supplier/supplier.json
+++ b/erpnext/buying/doctype/supplier/supplier.json
@@ -383,7 +383,7 @@
   },
   {
    "fieldname": "primary_address",
-   "fieldtype": "Text",
+   "fieldtype": "Text Editor",
    "label": "Primary Address",
    "read_only": 1
   },
@@ -500,7 +500,7 @@
    "link_fieldname": "party"
   }
  ],
- "modified": "2025-06-29 05:30:50.398653",
+ "modified": "2026-01-16 15:56:31.139206",
  "modified_by": "Administrator",
  "module": "Buying",
  "name": "Supplier",

--- a/erpnext/buying/doctype/supplier/supplier.py
+++ b/erpnext/buying/doctype/supplier/supplier.py
@@ -62,7 +62,7 @@ class Supplier(TransactionBase):
 		portal_users: DF.Table[PortalUser]
 		prevent_pos: DF.Check
 		prevent_rfqs: DF.Check
-		primary_address: DF.Text | None
+		primary_address: DF.TextEditor | None
 		release_date: DF.Date | None
 		represents_company: DF.Link | None
 		supplier_details: DF.Text | None

--- a/erpnext/public/js/utils/party.js
+++ b/erpnext/public/js/utils/party.js
@@ -157,7 +157,7 @@ erpnext.utils.get_address_display = function (frm, address_field, display_field,
 			args: { address_dict: frm.doc[address_field] },
 			callback: function (r) {
 				if (r.message) {
-					frm.set_value(display_field, frappe.utils.html2text(r.message));
+					frm.set_value(display_field, r.message);
 				}
 			},
 		});

--- a/erpnext/selling/doctype/customer/customer.json
+++ b/erpnext/selling/doctype/customer/customer.json
@@ -335,7 +335,7 @@
   },
   {
    "fieldname": "primary_address",
-   "fieldtype": "Text",
+   "fieldtype": "Text Editor",
    "label": "Primary Address",
    "read_only": 1
   },
@@ -625,7 +625,7 @@
    "link_fieldname": "party"
   }
  ],
- "modified": "2025-11-25 09:35:56.772949",
+ "modified": "2026-01-16 15:56:05.967663",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Customer",

--- a/erpnext/selling/doctype/customer/customer.py
+++ b/erpnext/selling/doctype/customer/customer.py
@@ -83,7 +83,7 @@ class Customer(TransactionBase):
 		opportunity_name: DF.Link | None
 		payment_terms: DF.Link | None
 		portal_users: DF.Table[PortalUser]
-		primary_address: DF.Text | None
+		primary_address: DF.TextEditor | None
 		prospect_name: DF.Link | None
 		represents_company: DF.Link | None
 		sales_team: DF.Table[SalesTeam]

--- a/erpnext/stock/doctype/shipment/shipment.json
+++ b/erpnext/stock/doctype/shipment/shipment.json
@@ -115,7 +115,7 @@
   },
   {
    "fieldname": "pickup_address",
-   "fieldtype": "Small Text",
+   "fieldtype": "Text Editor",
    "read_only": 1
   },
   {
@@ -135,7 +135,7 @@
   },
   {
    "fieldname": "pickup_contact",
-   "fieldtype": "Small Text",
+   "fieldtype": "Text Editor",
    "read_only": 1
   },
   {
@@ -193,7 +193,7 @@
   },
   {
    "fieldname": "delivery_address",
-   "fieldtype": "Small Text",
+   "fieldtype": "Text Editor",
    "read_only": 1
   },
   {
@@ -214,7 +214,7 @@
   {
    "depends_on": "eval:doc.delivery_contact_name",
    "fieldname": "delivery_contact",
-   "fieldtype": "Small Text",
+   "fieldtype": "Text Editor",
    "read_only": 1
   },
   {
@@ -441,11 +441,11 @@
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2026-01-07 19:24:23.566312",
+ "modified": "2026-01-16 14:59:28.547953",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Shipment",
- "naming_rule": "Expression (old style)",
+ "naming_rule": "Expression",
  "owner": "Administrator",
  "permissions": [
   {
@@ -477,6 +477,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],

--- a/erpnext/stock/doctype/shipment/shipment.py
+++ b/erpnext/stock/doctype/shipment/shipment.py
@@ -27,10 +27,10 @@ class Shipment(Document):
 		awb_number: DF.Data | None
 		carrier: DF.Data | None
 		carrier_service: DF.Data | None
-		delivery_address: DF.SmallText | None
+		delivery_address: DF.TextEditor | None
 		delivery_address_name: DF.Link
 		delivery_company: DF.Link | None
-		delivery_contact: DF.SmallText | None
+		delivery_contact: DF.TextEditor | None
 		delivery_contact_email: DF.Data | None
 		delivery_contact_name: DF.Link | None
 		delivery_customer: DF.Link | None
@@ -42,10 +42,10 @@ class Shipment(Document):
 		pallets: DF.Literal["No", "Yes"]
 		parcel_template: DF.Link | None
 		pickup: DF.Data | None
-		pickup_address: DF.SmallText | None
+		pickup_address: DF.TextEditor | None
 		pickup_address_name: DF.Link
 		pickup_company: DF.Link | None
-		pickup_contact: DF.SmallText | None
+		pickup_contact: DF.TextEditor | None
 		pickup_contact_email: DF.Data | None
 		pickup_contact_name: DF.Link | None
 		pickup_contact_person: DF.Link | None


### PR DESCRIPTION
**Issue:**
The address field with a "Small Text" type was not rendering the HTML content.

**Ref:** [#57455](https://support.frappe.io/helpdesk/tickets/57455)

**Description:**
The "Small Text" field type was not rendering HTML content due to security reasons. So, the field type has been changed to "Text Editor" field type.

**Before:**

<img width="1798" height="921" alt="image" src="https://github.com/user-attachments/assets/5143889b-eada-4383-92e9-ef3b8f718aba" />

**After:**

<img width="1788" height="802" alt="image" src="https://github.com/user-attachments/assets/1a96116a-8513-4146-84aa-e34a8ed49778" />
