### PR TITLE
fix: collapsible filters on accounts receivable and accounts payables reports

### DIFF
--- a/erpnext/accounts/report/accounts_payable/accounts_payable.js
+++ b/erpnext/accounts/report/accounts_payable/accounts_payable.js
@@ -151,6 +151,8 @@ frappe.query_reports["Accounts Payable"] = {
 			fieldtype: "Check",
 		},
 	],
+	collapsible_filters: true,
+	seperate_check_filters: true,
 
 	formatter: function (value, row, column, data, default_formatter) {
 		value = default_formatter(value, row, column, data);

--- a/erpnext/accounts/report/accounts_payable/accounts_payable.js
+++ b/erpnext/accounts/report/accounts_payable/accounts_payable.js
@@ -152,7 +152,7 @@ frappe.query_reports["Accounts Payable"] = {
 		},
 	],
 	collapsible_filters: true,
-	seperate_check_filters: true,
+	separate_check_filters: true,
 
 	formatter: function (value, row, column, data, default_formatter) {
 		value = default_formatter(value, row, column, data);

--- a/erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js
+++ b/erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js
@@ -109,7 +109,7 @@ frappe.query_reports["Accounts Payable Summary"] = {
 		},
 	],
 	collapsible_filters: true,
-	seperate_check_filters: true,
+	separate_check_filters: true,
 
 	onload: function (report) {
 		report.page.add_inner_button(__("Accounts Payable"), function () {

--- a/erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js
+++ b/erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js
@@ -108,6 +108,8 @@ frappe.query_reports["Accounts Payable Summary"] = {
 			fieldtype: "Check",
 		},
 	],
+	collapsible_filters: true,
+	seperate_check_filters: true,
 
 	onload: function (report) {
 		report.page.add_inner_button(__("Accounts Payable"), function () {

--- a/erpnext/accounts/report/accounts_receivable/accounts_receivable.js
+++ b/erpnext/accounts/report/accounts_receivable/accounts_receivable.js
@@ -179,7 +179,7 @@ frappe.query_reports["Accounts Receivable"] = {
 		},
 	],
 	collapsible_filters: true,
-	seperate_check_filters: true,
+	separate_check_filters: true,
 
 	formatter: function (value, row, column, data, default_formatter) {
 		value = default_formatter(value, row, column, data);

--- a/erpnext/accounts/report/accounts_receivable/accounts_receivable.js
+++ b/erpnext/accounts/report/accounts_receivable/accounts_receivable.js
@@ -178,6 +178,8 @@ frappe.query_reports["Accounts Receivable"] = {
 			fieldtype: "Check",
 		},
 	],
+	collapsible_filters: true,
+	seperate_check_filters: true,
 
 	formatter: function (value, row, column, data, default_formatter) {
 		value = default_formatter(value, row, column, data);

--- a/erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js
+++ b/erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js
@@ -132,7 +132,7 @@ frappe.query_reports["Accounts Receivable Summary"] = {
 		},
 	],
 	collapsible_filters: true,
-	seperate_check_filters: true,
+	separate_check_filters: true,
 
 	onload: function (report) {
 		report.page.add_inner_button(__("Accounts Receivable"), function () {

--- a/erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js
+++ b/erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js
@@ -131,6 +131,8 @@ frappe.query_reports["Accounts Receivable Summary"] = {
 			fieldtype: "Check",
 		},
 	],
+	collapsible_filters: true,
+	seperate_check_filters: true,
 
 	onload: function (report) {
 		report.page.add_inner_button(__("Accounts Receivable"), function () {

--- a/erpnext/accounts/report/general_ledger/general_ledger.js
+++ b/erpnext/accounts/report/general_ledger/general_ledger.js
@@ -224,7 +224,7 @@ frappe.query_reports["General Ledger"] = {
 		},
 	],
 	collapsible_filters: true,
-	seperate_check_filters: true,
+	separate_check_filters: true,
 };
 
 erpnext.utils.add_dimensions("General Ledger", 15);


### PR DESCRIPTION
Enabled collapsible filters on Accounts Receivable and Accounts Payable Reports.