### PR TITLE
"fix: prevent UOM from updating incorrectly while scanning barcode"

### DIFF
--- a/erpnext/public/js/utils/barcode_scanner.js
+++ b/erpnext/public/js/utils/barcode_scanner.js
@@ -138,7 +138,6 @@ erpnext.utils.BarcodeScanner = class BarcodeScanner {
 
 			frappe.run_serially([
 				() => this.set_selector_trigger_flag(data),
-				() => this.set_barcode_uom(row, uom),
 				() => this.set_serial_no(row, serial_no),
 				() => this.set_batch_no(row, batch_no),
 				() => this.set_barcode(row, barcode),
@@ -148,6 +147,7 @@ erpnext.utils.BarcodeScanner = class BarcodeScanner {
 						this.show_scan_message(row.idx, !is_new_row, qty);
 					}),
 				() => this.clean_up(),
+				() => this.set_barcode_uom(row, uom),				
 				() => this.revert_selector_flag(),
 				() => resolve(row),
 			]);


### PR DESCRIPTION
**Issue**: In the Material Request and Stock Entry, while scanning the barcode, the UOM updates wrongly in items child table

**Fix:** #51765

**Description:**
While scanning the barcode in Material request and Stock Entry the UOM in the items table updates the system default value(Nos) and that was fixed to fetch Item UOM and updates properly.

Fixed the barcode scanning logic to ensure the correct UOM associated with the scanned barcode is applied.
Ensured consistent behavior across Material Request and Stock Entry.

**Before :**


https://github.com/user-attachments/assets/b743ddb7-9047-4e33-9854-9d5da1f14028

**After :**


https://github.com/user-attachments/assets/b3cfb027-35fc-47a5-b607-82cb90b03c41


