### PR TITLE
fix(accounts): resolve duplicate account numbers in Indonesian COA

### DIFF
--- a/erpnext/accounts/doctype/account/chart_of_accounts/verified/id_chart_of_accounts.json
+++ b/erpnext/accounts/doctype/account/chart_of_accounts/verified/id_chart_of_accounts.json
@@ -99,14 +99,14 @@
                 },
                 "Pajak Dibayar di Muka": {
                     "PPN Masukan": {
-                        "account_number": "1151.001", 
+                        "account_number": "1181.001",
                         "account_type": "Tax"
                     },
                     "PPh 23 Dibayar di Muka": {
-                        "account_number": "1152.001", 
+                        "account_number": "1182.001",
                         "account_type": "Tax"
-                    }, 
-                    "account_number": "1150.000"
+                    },
+                    "account_number": "1180.000"
                 },
                 "account_number": "1100.000"
                 


### PR DESCRIPTION
## Summary
- Fixed duplicate account numbers in Indonesian Chart of Accounts that caused Setup Wizard to fail
- Renumbered "Pajak Dibayar di Muka" (Prepaid Tax) section from 1150 series to 1180 series to avoid conflict with "Biaya di Bayar di Muka"

## Changes
| Account | Old Number | New Number |
|---------|-----------|-----------|
| Pajak Dibayar di Muka (group) | 1150.000 | 1180.000 |
| PPN Masukan (Input VAT) | 1151.001 | 1181.001 |
| PPh 23 Dibayar di Muka | 1152.001 | 1182.001 |

## Test plan
- [ ] Verify Setup Wizard completes successfully when selecting Indonesia as country
- [ ] Verify Chart of Accounts is created without validation errors
- [ ] Verify account numbers are unique across the Indonesian COA

Fixes #51778
Fixes #51808

