### PR TITLE
feat(reports): add Designation field to Lead Details and Address/Contact reports

### DIFF
--- a/erpnext/crm/report/lead_details/lead_details.py
+++ b/erpnext/crm/report/lead_details/lead_details.py
@@ -78,16 +78,30 @@ def get_data(filters):
 	dynamic_link_address = frappe.qb.DocType("Dynamic Link").as_("dla")
 	dynamic_link_contact = frappe.qb.DocType("Dynamic Link").as_("dlc")
 
+	# Subquery to get the primary contact's designation for each lead
+	# This avoids Cartesian product when a lead has multiple contacts
+	contact_subquery = (
+		frappe.qb.from_(contact)
+		.join(dynamic_link_contact)
+		.on(contact.name == dynamic_link_contact.parent)
+		.select(contact.designation)
+		.where(dynamic_link_contact.link_name == lead.name)
+		.where(dynamic_link_contact.link_doctype == "Lead")
+		.where(dynamic_link_contact.parenttype == "Contact")
+		.orderby(contact.is_primary_contact, order=frappe.qb.desc)
+		.limit(1)
+	)
+
 	query = (
 		frappe.qb.from_(lead)
 		.left_join(dynamic_link_address)
-		.on((lead.name == dynamic_link_address.link_name) & (dynamic_link_address.parenttype == "Address"))
+		.on(
+			(lead.name == dynamic_link_address.link_name)
+			& (dynamic_link_address.link_doctype == "Lead")
+			& (dynamic_link_address.parenttype == "Address")
+		)
 		.left_join(address)
 		.on(address.name == dynamic_link_address.parent)
-		.left_join(dynamic_link_contact)
-		.on((lead.name == dynamic_link_contact.link_name) & (dynamic_link_contact.parenttype == "Contact"))
-		.left_join(contact)
-		.on(contact.name == dynamic_link_contact.parent)
 		.select(
 			lead.name,
 			lead.lead_name,
@@ -100,7 +114,7 @@ def get_data(filters):
 			lead.phone,
 			lead.owner,
 			lead.company,
-			contact.designation,
+			contact_subquery.as_("designation"),
 			(Concat_ws(", ", address.address_line1, address.address_line2)).as_("address"),
 			address.pincode,
 			address.city,

--- a/erpnext/crm/report/lead_details/lead_details.py
+++ b/erpnext/crm/report/lead_details/lead_details.py
@@ -55,6 +55,7 @@ def get_columns():
 			"options": "Company",
 			"width": 120,
 		},
+		{"label": _("Designation"), "fieldname": "designation", "fieldtype": "Data", "width": 120},
 		{"label": _("Address"), "fieldname": "address", "fieldtype": "Data", "width": 130},
 		{"label": _("Postal Code"), "fieldname": "pincode", "fieldtype": "Data", "width": 90},
 		{"label": _("City"), "fieldname": "city", "fieldtype": "Data", "width": 100},
@@ -73,14 +74,20 @@ def get_columns():
 def get_data(filters):
 	lead = frappe.qb.DocType("Lead")
 	address = frappe.qb.DocType("Address")
-	dynamic_link = frappe.qb.DocType("Dynamic Link")
+	contact = frappe.qb.DocType("Contact")
+	dynamic_link_address = frappe.qb.DocType("Dynamic Link").as_("dla")
+	dynamic_link_contact = frappe.qb.DocType("Dynamic Link").as_("dlc")
 
 	query = (
 		frappe.qb.from_(lead)
-		.left_join(dynamic_link)
-		.on((lead.name == dynamic_link.link_name) & (dynamic_link.parenttype == "Address"))
+		.left_join(dynamic_link_address)
+		.on((lead.name == dynamic_link_address.link_name) & (dynamic_link_address.parenttype == "Address"))
 		.left_join(address)
-		.on(address.name == dynamic_link.parent)
+		.on(address.name == dynamic_link_address.parent)
+		.left_join(dynamic_link_contact)
+		.on((lead.name == dynamic_link_contact.link_name) & (dynamic_link_contact.parenttype == "Contact"))
+		.left_join(contact)
+		.on(contact.name == dynamic_link_contact.parent)
 		.select(
 			lead.name,
 			lead.lead_name,
@@ -93,6 +100,7 @@ def get_data(filters):
 			lead.phone,
 			lead.owner,
 			lead.company,
+			contact.designation,
 			(Concat_ws(", ", address.address_line1, address.address_line2)).as_("address"),
 			address.pincode,
 			address.city,

--- a/erpnext/selling/report/address_and_contacts/address_and_contacts.py
+++ b/erpnext/selling/report/address_and_contacts/address_and_contacts.py
@@ -6,7 +6,7 @@ import frappe
 from frappe import _
 
 field_map = {
-	"Contact": ["name", "first_name", "last_name", "phone", "mobile_no", "email_id", "is_primary_contact"],
+	"Contact": ["name", "first_name", "last_name", "designation", "phone", "mobile_no", "email_id", "is_primary_contact"],
 	"Address": [
 		"name",
 		"address_line1",
@@ -47,6 +47,7 @@ def get_columns(filters):
 		{"label": _("Contact"), "fieldtype": "Link", "options": "Contact", "hidden": 1},
 		"First Name",
 		"Last Name",
+		"Designation",
 		"Phone",
 		"Mobile No",
 		"Email Id",


### PR DESCRIPTION
## Summary
- Added Designation field (from Contact doctype) to Lead Details Report and Address and Contacts Report
- Enables users to see contact designation information directly in reports

## Changes

### Lead Details Report
- Added Contact doctype join via Dynamic Link
- Added "Designation" column between Company and Address columns

### Address and Contacts Report
- Added `designation` to Contact field_map
- Added "Designation" column after "Last Name"

## Test plan
- [ ] Run Lead Details Report and verify Designation column appears with correct data
- [ ] Run Address and Contacts Report and verify Designation column appears with correct data
- [ ] Verify reports work correctly when Contact has no designation set (should show empty)

Fixes #47120
