### PR TITLE
ci: fix generate POT workflow

### DIFF
--- a/.github/workflows/generate-pot-file.yml
+++ b/.github/workflows/generate-pot-file.yml
@@ -30,6 +30,11 @@ jobs:
           with:
             python-version: "3.14"
 
+        - name: Setup Node
+          uses: actions/setup-node@v6
+          with:
+            node-version: 24
+
         - name: Run script to update POT file
           run: |
             bash ${GITHUB_WORKSPACE}/.github/helper/update_pot_file.sh


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for generating POT files by adding a step to set up Node.js before running the update script. This ensures that Node.js is available in the environment, which may be required by the script or its dependencies.