### PR TITLE
fix(budget variance report): check budget dimensions

### DIFF
--- a/erpnext/accounts/report/budget_variance_report/budget_variance_report.py
+++ b/erpnext/accounts/report/budget_variance_report/budget_variance_report.py
@@ -18,6 +18,8 @@ def execute(filters=None):
 		dimensions = filters.get("budget_against_filter")
 	else:
 		dimensions = get_budget_dimensions(filters)
+	if not dimensions:
+		return columns, [], None, None
 
 	budget_records = get_budget_records(filters, dimensions)
 	budget_map = build_budget_map(budget_records, filters)


### PR DESCRIPTION
**Issue:**
An error occurs when loading the budget variance report filtered by project if no project is present.

**Ref:**[#57621](https://support.frappe.io/helpdesk/tickets/57621)

**Budget Variance Report :**

![photo_6298363171160395323_y](https://github.com/user-attachments/assets/1b38c222-dacc-43ea-89b5-6308584dab58)



