### PR TITLE
fix: remove incorrect validation from email digest throwing spurious error

### DIFF
--- a/erpnext/setup/doctype/email_digest/email_digest.py
+++ b/erpnext/setup/doctype/email_digest/email_digest.py
@@ -162,8 +162,6 @@ class EmailDigest(Document):
 				context.purchase_order_list,
 				context.purchase_orders_items_overdue_list,
 			) = self.get_purchase_orders_items_overdue_list()
-			if not context.purchase_order_list:
-				frappe.throw(_("No items to be received are overdue"))
 
 		if not context:
 			return None


### PR DESCRIPTION
This PR fixes a bug that prevents email digests from being sent out if the box is checked for "Purchase Orders Items Overdue" AND there happen to be no purchase order items overdue at the time the digest is sent. The validation has been removed instead of ammended because it serves no purpose (as far as I can tell). This change conforms "Purchase Orders Items Overdue" to the way the other items are coded in the report such as notifications, projects, etc. 

After this change is made, it is possible again for email digests to be sent when "Purchase Orders Items Overdue" is checked in both scenarios: (1) if there are purchase order items overdue:

<img width="683" height="756" alt="Screenshot 2026-01-18 085337" src="https://github.com/user-attachments/assets/cb0a9cfd-07f1-48cd-996e-7aa04cabd3b9" />

and (2) if there are not:

<img width="695" height="761" alt="Screenshot 2026-01-18 085459" src="https://github.com/user-attachments/assets/719304d0-9325-445c-9de0-c586cc8c83ad" />

Closes https://github.com/frappe/erpnext/issues/51825