### PR TITLE
fix(manufacturing): consider process loss qty while validating the work order

### DIFF
--- a/erpnext/manufacturing/doctype/work_order/work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/work_order.py
@@ -502,7 +502,7 @@ class WorkOrder(Document):
 	def validate_work_order_against_so(self):
 		# already ordered qty
 		ordered_qty_against_so = frappe.db.sql(
-			"""select sum(qty) from `tabWork Order`
+			"""select sum(qty - process_loss_qty) from `tabWork Order`
 			where production_item = %s and sales_order = %s and docstatus < 2 and status != 'Closed' and name != %s""",
 			(self.production_item, self.sales_order, self.name),
 		)[0][0]

--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -1989,7 +1989,7 @@ def get_work_order_items(sales_order, for_raw_material_request=0):
 				if not for_raw_material_request:
 					total_work_order_qty = flt(
 						qb.from_(wo)
-						.select(Sum(wo.qty))
+						.select(Sum(wo.qty - wo.process_loss_qty))
 						.where(
 							(wo.production_item == i.item_code)
 							& (wo.sales_order == so.name)


### PR DESCRIPTION
**Issue:**  
The system does not allow creating a Work Order for the **process loss quantity** when generating it from a Sales Order.

**Ref:**  [#57390](https://support.frappe.io/helpdesk/tickets/57390)

**Before:**

https://github.com/user-attachments/assets/14bbece9-6e55-4654-a7ad-9afb8e39708c

**After:**

https://github.com/user-attachments/assets/89c74e47-6de3-4916-a693-5843523b87cd

**Backport Needed for v15 & v16**