### PR TITLE
fix(bom): pass company warehouse filter

### DIFF
--- a/erpnext/manufacturing/doctype/bom/bom.js
+++ b/erpnext/manufacturing/doctype/bom/bom.js
@@ -92,6 +92,10 @@ frappe.ui.form.on("BOM", {
 			};
 		});
 
+		frm.events.set_company_filters(frm, "project");
+		frm.events.set_company_filters(frm, "default_source_warehouse");
+		frm.events.set_company_filters(frm, "default_target_warehouse");
+
 		frm.trigger("toggle_fields_for_semi_finished_goods");
 	},
 
@@ -102,6 +106,16 @@ frappe.ui.form.on("BOM", {
 				title: __("Mandatory"),
 			});
 		}
+	},
+
+	set_company_filters: function (frm, fieldname) {
+		frm.set_query(fieldname, () => {
+			return {
+				filters: {
+					company: frm.doc.company,
+				},
+			};
+		});
 	},
 
 	track_semi_finished_goods(frm) {


### PR DESCRIPTION
Issue : 
The `Default Source Warehouse`, `Default Target Warehouse` and `Project` field is not filtered based on company

Before:

<img width="1280" height="800" alt="image" src="https://github.com/user-attachments/assets/bd900fee-1add-4723-97e4-abc212740d45" />

After:

<img width="1634" height="963" alt="image" src="https://github.com/user-attachments/assets/522b12c2-2772-42ed-8d75-c5a5fb8bfa3c" />
 
backport needed for v15 and v16