### PR TITLE
fix: add advance taxes and charges in accounting dimension doctypes

### DIFF
--- a/erpnext/hooks.py
+++ b/erpnext/hooks.py
@@ -539,6 +539,7 @@ accounting_dimension_doctypes = [
 	"Stock Entry Detail",
 	"Payment Entry Deduction",
 	"Sales Taxes and Charges",
+	"Advance Taxes and Charges",
 	"Purchase Taxes and Charges",
 	"Shipping Rule",
 	"Landed Cost Item",


### PR DESCRIPTION
**Issue:**
Department Accounting Dimension not appearing in Payment Entry -Advance Taxes and Charges Template child table.

**Ref:**[#57468](https://support.frappe.io/helpdesk/tickets/57468)
            [#51782](https://github.com/frappe/erpnext/issues/51782)

**Before:**
<img width="2652" height="1102" alt="image" src="https://github.com/user-attachments/assets/a038d11d-b101-4fce-973a-53e36d60cc47" />

**After:**
<img width="1906" height="841" alt="image" src="https://github.com/user-attachments/assets/b6ceeead-5bfb-4797-8eba-5d1177a71864" />

Backport needed:v15
