### PR TITLE
fix(accounts_controller): make return message translatable

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -187,9 +187,8 @@ class AccountsController(TransactionBase):
 
 			msg = ""
 			if self.get("update_outstanding_for_self"):
-				msg = (
-					"We can see {0} is made against {1}. If you want {1}'s outstanding to be updated, "
-					"uncheck '{2}' checkbox. <br><br>Or"
+				msg = _(
+					"We can see {0} is made against {1}. If you want {1}'s outstanding to be updated, uncheck the '{2}' checkbox."
 				).format(
 					frappe.bold(document_type),
 					get_link_to_form(self.doctype, self.get("return_against")),
@@ -200,8 +199,8 @@ class AccountsController(TransactionBase):
 				abs(flt(self.rounded_total) or flt(self.grand_total)) > flt(against_voucher_outstanding)
 			):
 				self.update_outstanding_for_self = 1
-				msg = (
-					"The outstanding amount {} in {} is lesser than {}. Updating the outstanding to this invoice. <br><br>And"
+				msg = _(
+					"The outstanding amount {0} in {1} is lesser than {2}. Updating the outstanding to this invoice."
 				).format(
 					against_voucher_outstanding,
 					get_link_to_form(self.doctype, self.get("return_against")),
@@ -209,11 +208,11 @@ class AccountsController(TransactionBase):
 				)
 
 			if msg:
-				msg += " you can use {} tool to reconcile against {} later.".format(
+				msg += "<br><br>" + _("You can use {0} to reconcile against {1} later.").format(
 					get_link_to_form("Payment Reconciliation"),
 					get_link_to_form(self.doctype, self.get("return_against")),
 				)
-				frappe.msgprint(_(msg))
+				frappe.msgprint(msg)
 
 	def validate(self):
 		if not self.get("is_return") and not self.get("is_debit_note"):


### PR DESCRIPTION
This PR ensures user-facing messages for return transactions are translatable.

Introduced via #46631

FYI @Bhavan23 