### PR TITLE
fix(bank_account): `is_company_account` related validations

### DIFF
--- a/erpnext/accounts/doctype/bank_account/bank_account.js
+++ b/erpnext/accounts/doctype/bank_account/bank_account.js
@@ -42,8 +42,4 @@ frappe.ui.form.on("Bank Account", {
 			});
 		}
 	},
-
-	is_company_account: function (frm) {
-		frm.set_df_property("account", "reqd", frm.doc.is_company_account);
-	},
 });

--- a/erpnext/accounts/doctype/bank_account/bank_account.json
+++ b/erpnext/accounts/doctype/bank_account/bank_account.json
@@ -52,6 +52,7 @@
    "fieldtype": "Link",
    "in_list_view": 1,
    "label": "Company Account",
+   "mandatory_depends_on": "is_company_account",
    "options": "Account"
   },
   {
@@ -98,6 +99,7 @@
    "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "Company",
+   "mandatory_depends_on": "is_company_account",
    "options": "Company"
   },
   {
@@ -252,7 +254,7 @@
    "link_fieldname": "default_bank_account"
   }
  ],
- "modified": "2025-08-29 12:32:01.081687",
+ "modified": "2026-01-20 00:46:16.633364",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Bank Account",

--- a/erpnext/accounts/doctype/bank_account/bank_account.py
+++ b/erpnext/accounts/doctype/bank_account/bank_account.py
@@ -51,25 +51,29 @@ class BankAccount(Document):
 		delete_contact_and_address("Bank Account", self.name)
 
 	def validate(self):
-		self.validate_company()
-		self.validate_account()
+		self.validate_is_company_account()
 		self.update_default_bank_account()
 
-	def validate_account(self):
-		if self.account:
-			if accounts := frappe.db.get_all(
-				"Bank Account", filters={"account": self.account, "name": ["!=", self.name]}, as_list=1
-			):
-				frappe.throw(
-					_("'{0}' account is already used by {1}. Use another account.").format(
-						frappe.bold(self.account),
-						frappe.bold(comma_and([get_link_to_form(self.doctype, x[0]) for x in accounts])),
-					)
-				)
+	def validate_is_company_account(self):
+		if self.is_company_account:
+			if not self.company:
+				frappe.throw(_("Company is mandatory for company account"))
 
-	def validate_company(self):
-		if self.is_company_account and not self.company:
-			frappe.throw(_("Company is mandatory for company account"))
+			if not self.account:
+				frappe.throw(_("Company Account is mandatory"))
+
+			self.validate_account()
+
+	def validate_account(self):
+		if accounts := frappe.db.get_all(
+			"Bank Account", filters={"account": self.account, "name": ["!=", self.name]}, as_list=1
+		):
+			frappe.throw(
+				_("'{0}' account is already used by {1}. Use another account.").format(
+					frappe.bold(self.account),
+					frappe.bold(comma_and([get_link_to_form(self.doctype, x[0]) for x in accounts])),
+				)
+			)
 
 	def update_default_bank_account(self):
 		if self.is_default and not self.disabled:


### PR DESCRIPTION
Changes include:

- Added validation for `account` if `is_company_account` is enabled on the server side.
- Added `mandatory_depends_on` for `account` and `company` fields on the Bank Account DocType.
- Removed `is_company_account` trigger to make`account` field a mandatory field on the client side.
