### PR TITLE
fix: group item wise tax details by tax row

### DIFF
--- a/erpnext/regional/italy/utils.py
+++ b/erpnext/regional/italy/utils.py
@@ -142,7 +142,14 @@ def download_zip(files, output_filename):
 
 def get_invoice_summary(items, taxes, item_wise_tax_details):
 	summary_data = frappe._dict()
-	taxes_wise_tax_details = {d.tax_row: d for d in item_wise_tax_details}
+	taxes_wise_tax_details = {}
+
+	for d in item_wise_tax_details:
+		if d.tax_row not in taxes_wise_tax_details:
+			taxes_wise_tax_details[d.tax_row] = []
+
+		taxes_wise_tax_details[d.tax_row].append(d)
+
 	for tax in taxes:
 		# Include only VAT charges.
 		if tax.charge_type == "Actual":


### PR DESCRIPTION
Issue:
Unable to submit a Sales Invoice for a company with the Italy region due to incorrect iteration over Item Wise Tax Detail records during submission.

Ref: [#57729](https://support.frappe.io/helpdesk/tickets/57729)

TraceBack:

```
Traceback (most recent call last):
  File "apps/frappe/frappe/app.py", line 121, in application
    response = frappe.api.handle(request)
  File "apps/frappe/frappe/api/__init__.py", line 63, in handle
    data = endpoint(**arguments)
  File "apps/frappe/frappe/api/v1.py", line 40, in handle_rpc_call
    return frappe.handler.handle()
           ~~~~~~~~~~~~~~~~~~~~~^^
  File "apps/frappe/frappe/handler.py", line 53, in handle
    data = execute_cmd(cmd)
  File "apps/frappe/frappe/handler.py", line 86, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
           ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/__init__.py", line 1124, in call
    return fn(*args, **newargs)
  File "apps/frappe/frappe/utils/typing_validations.py", line 36, in wrapper
    return func(*args, **kwargs)
  File "apps/frappe/frappe/desk/form/save.py", line 41, in savedocs
    doc.submit()
    ~~~~~~~~~~^^
  File "apps/frappe/frappe/utils/typing_validations.py", line 36, in wrapper
    return func(*args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 1270, in submit
    return self._submit()
           ~~~~~~~~~~~~^^
  File "apps/frappe/frappe/model/document.py", line 1251, in _submit
    return self.save()
           ~~~~~~~~~^^
  File "apps/frappe/frappe/model/document.py", line 518, in save
    return self._save(*args, **kwargs)
           ~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/model/document.py", line 572, in _save
    self.run_post_save_methods()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "apps/frappe/frappe/model/document.py", line 1378, in run_post_save_methods
    self.run_method("on_submit")
    ~~~~~~~~~~~~~~~^^^^^^^^^^^^^
  File "apps/frappe/frappe/model/document.py", line 1181, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 1578, in composer
    return composed(self, method, *args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 1560, in runner
    add_to_return_value(self, f(self, method, *args, **kwargs))
                              ~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/erpnext/erpnext/regional/italy/utils.py", line 321, in sales_invoice_on_submit
    prepare_and_attach_invoice(doc)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^
  File "apps/erpnext/erpnext/regional/italy/utils.py", line 327, in prepare_and_attach_invoice
    invoice = prepare_invoice(doc, progressive_number)
  File "apps/erpnext/erpnext/regional/italy/utils.py", line 82, in prepare_invoice
    tax_data = get_invoice_summary(invoice.e_invoice_items, invoice.taxes, invoice.item_wise_tax_details)
  File "apps/erpnext/erpnext/regional/italy/utils.py", line 157, in get_invoice_summary
    for row in taxes_wise_tax_details.get(tax.name) or []:
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: 'ItemWiseTaxDetail' object is not iterable

(anonymous) @ request.js:476Understand this error

```