### PR TITLE
perf: prevent duplicate reposting for the same item

### DIFF
--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -756,7 +756,8 @@ class update_entries_after:
 				self.distinct_item_warehouses[key] = val
 				self.new_items_found = True
 			elif (
-				dependant_sle.actual_qty > 0
+				self.via_landed_cost_voucher
+				and dependant_sle.actual_qty > 0
 				and dependant_sle.voucher_type == "Stock Entry"
 				and is_transfer_stock_entry(dependant_sle.voucher_no)
 			):


### PR DESCRIPTION
Original Issue:

- Create a Purchase Receipt for a quantity of 1 with a rate of 100 in Warehouse A.
- Create a Stock Transfer entry from Warehouse A to Warehouse B (valuation rate: 100).
- Create a Stock Transfer entry from Warehouse B back to Warehouse A (valuation rate: 100).
- Create a Landed Cost Voucher against the Purchase Receipt created in step 1 with a rate of 20.
- After completing reposting, the valuation rate in the stock entry created in step 3 for Warehouse A remained 100.

To fix this, reposting was triggered again for stock transfer transactions. But, this has caused a performance issue because the same vouchers were being reposted multiple times, even when users were not creating a Landed Cost Voucher.

Solution:

Repost stock transfer entries only when the reposting is created against a Landed Cost Voucher.