### PR TITLE
fix(stock): remove limit filter while fetching batch and bin

### DIFF
--- a/erpnext/stock/doctype/pick_list/pick_list.py
+++ b/erpnext/stock/doctype/pick_list/pick_list.py
@@ -686,18 +686,14 @@ def get_available_item_locations(
 		locations = get_available_item_locations_for_batched_item(
 			item_code,
 			from_warehouses,
-			required_qty,
 			company,
-			total_picked_qty,
 			consider_rejected_warehouses=consider_rejected_warehouses,
 		)
 	else:
 		locations = get_available_item_locations_for_other_item(
 			item_code,
 			from_warehouses,
-			required_qty,
 			company,
-			total_picked_qty,
 			consider_rejected_warehouses=consider_rejected_warehouses,
 		)
 
@@ -790,9 +786,7 @@ def get_available_item_locations_for_serialized_item(
 def get_available_item_locations_for_batched_item(
 	item_code,
 	from_warehouses,
-	required_qty,
 	company,
-	total_picked_qty=0,
 	consider_rejected_warehouses=False,
 ):
 	sle = frappe.qb.DocType("Stock Ledger Entry")
@@ -813,7 +807,6 @@ def get_available_item_locations_for_batched_item(
 		.groupby(sle.warehouse, sle.batch_no, sle.item_code)
 		.having(Sum(sle.actual_qty) > 0)
 		.orderby(IfNull(batch.expiry_date, "2200-01-01"), batch.creation, sle.batch_no, sle.warehouse)
-		.limit(ceil(required_qty + total_picked_qty))
 	)
 
 	if from_warehouses:
@@ -838,7 +831,6 @@ def get_available_item_locations_for_serial_and_batched_item(
 	locations = get_available_item_locations_for_batched_item(
 		item_code,
 		from_warehouses,
-		required_qty,
 		company,
 		consider_rejected_warehouses=consider_rejected_warehouses,
 	)
@@ -872,9 +864,7 @@ def get_available_item_locations_for_serial_and_batched_item(
 def get_available_item_locations_for_other_item(
 	item_code,
 	from_warehouses,
-	required_qty,
 	company,
-	total_picked_qty=0,
 	consider_rejected_warehouses=False,
 ):
 	bin = frappe.qb.DocType("Bin")
@@ -883,7 +873,6 @@ def get_available_item_locations_for_other_item(
 		.select(bin.warehouse, bin.actual_qty.as_("qty"))
 		.where((bin.item_code == item_code) & (bin.actual_qty > 0))
 		.orderby(bin.creation)
-		.limit(ceil(required_qty + total_picked_qty))
 	)
 
 	if from_warehouses:


### PR DESCRIPTION
**Issue:**
The system throws the error "The Item is Picked in another Pick List" while creating a Pick List, even though there is enough unpicked quantity remaining from the Sales Order.

**Ref:** [#57368](https://support.frappe.io/helpdesk/tickets/57368)

**Before:**

https://github.com/user-attachments/assets/dd32b651-2611-4f64-81fd-5f0489c6676c

**After:**

https://github.com/user-attachments/assets/7e0fa224-c546-4175-9061-492926eb98f7



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal pick list item location retrieval logic for improved code maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->