### PR TITLE
fix: corrected the status for sales order as maintenance type

### DIFF
--- a/erpnext/controllers/status_updater.py
+++ b/erpnext/controllers/status_updater.py
@@ -43,15 +43,15 @@ status_map = {
 		["Draft", None],
 		[
 			"To Deliver and Bill",
-			"eval:self.per_delivered < 100 and self.per_billed < 100 and self.docstatus == 1",
+			"eval:self.per_delivered < 100 and self.per_billed < 100 and self.docstatus == 1 and self.order_type != 'Maintenance'",
 		],
 		[
 			"To Bill",
-			"eval:(self.per_delivered >= 100 or self.skip_delivery_note) and self.per_billed < 100 and self.docstatus == 1",
+			"eval:(self.per_delivered >= 100 or self.skip_delivery_note or self.order_type == 'Maintenance') and self.per_billed < 100 and self.docstatus == 1",
 		],
 		[
 			"To Deliver",
-			"eval:self.per_delivered < 100 and self.per_billed >= 100 and self.docstatus == 1 and not self.skip_delivery_note",
+			"eval:self.per_delivered < 100 and self.per_billed >= 100 and self.docstatus == 1 and not self.skip_delivery_note and self.order_type != 'Maintenance'",
 		],
 		[
 			"To Pay",
@@ -59,7 +59,7 @@ status_map = {
 		],
 		[
 			"Completed",
-			"eval:(self.per_delivered >= 100 or self.skip_delivery_note) and self.per_billed >= 100 and self.docstatus == 1",
+			"eval:(self.per_delivered >= 100 or self.skip_delivery_note or self.order_type == 'Maintenance') and self.per_billed >= 100 and self.docstatus == 1",
 		],
 		["Cancelled", "eval:self.docstatus==2"],
 		["Closed", "eval:self.status=='Closed' and self.docstatus != 2"],

--- a/erpnext/selling/doctype/sales_order/sales_order_list.js
+++ b/erpnext/selling/doctype/sales_order/sales_order_list.js
@@ -13,17 +13,18 @@ frappe.listview_settings["Sales Order"] = {
 		"skip_delivery_note",
 	],
 	get_indicator: function (doc) {
-		if (doc.status === "Closed") {
-			// Closed
-			return [__("Closed"), "green", "status,=,Closed"];
-		} else if (doc.status === "On Hold") {
-			// on hold
-			return [__("On Hold"), "orange", "status,=,On Hold"];
-		} else if (doc.status === "Completed") {
-			return [__("Completed"), "green", "status,=,Completed"];
-		} else if (doc.advance_payment_status === "Requested") {
-			return [__("To Pay"), "gray", "advance_payment_status,=,Requested"];
-		} else if (!doc.skip_delivery_note && flt(doc.per_delivered) < 100) {
+		const color_map = {
+			Closed: "green",
+			"On Hold": "orange",
+			Completed: "green",
+			"To Pay": "gray",
+			"To Bill": "orange",
+			"To Deliver": "orange",
+			"To Deliver and Bill": "orange",
+			Cancelled: "red",
+		};
+
+		if (!doc.skip_delivery_note && flt(doc.per_delivered) < 100) {
 			if (frappe.datetime.get_diff(doc.delivery_date) < 0) {
 				// not delivered & overdue
 				return [
@@ -31,33 +32,11 @@ frappe.listview_settings["Sales Order"] = {
 					"red",
 					"per_delivered,<,100|delivery_date,<,Today|status,!=,Closed|docstatus,=,1",
 				];
-			} else if (flt(doc.grand_total) === 0) {
-				// not delivered (zeroount order)
-				return [
-					__("To Deliver"),
-					"orange",
-					"per_delivered,<,100|grand_total,=,0|status,!=,Closed|docstatus,=,1",
-				];
-			} else if (flt(doc.per_billed) < 100) {
-				// not delivered & not billed
-				return [
-					__("To Deliver and Bill"),
-					"orange",
-					"per_delivered,<,100|per_billed,<,100|status,!=,Closed",
-				];
-			} else {
-				// not billed
-				return [__("To Deliver"), "orange", "per_delivered,<,100|per_billed,=,100|status,!=,Closed"];
 			}
-		} else if (
-			flt(doc.per_delivered) === 100 &&
-			flt(doc.grand_total) !== 0 &&
-			flt(doc.per_billed) < 100
-		) {
-			// to bill
-			return [__("To Bill"), "orange", "per_delivered,=,100|per_billed,<,100|status,!=,Closed"];
-		} else if (doc.skip_delivery_note && flt(doc.per_billed) < 100) {
-			return [__("To Bill"), "orange", "per_billed,<,100|status,!=,Closed"];
+		}
+
+		if (doc.status in color_map) {
+			return [__(doc.status), color_map[doc.status]];
 		}
 	},
 	onload: function (listview) {

--- a/erpnext/selling/doctype/sales_order/test_sales_order.py
+++ b/erpnext/selling/doctype/sales_order/test_sales_order.py
@@ -57,6 +57,24 @@ class TestSalesOrder(AccountsTestMixin, IntegrationTestCase):
 		frappe.db.rollback()
 		frappe.set_user("Administrator")
 
+	def test_sales_order_status_for_maintenance_order(self):
+		so = make_sales_order(
+			item_code="_Test Item",
+			qty=1,
+			rate=100,
+			order_type="Maintenance",
+			do_not_submit=True,
+		)
+		so.submit()
+		self.assertEqual(so.status, "To Bill")
+
+		si = make_sales_invoice(so.name)
+		si.insert()
+		si.submit()
+
+		so.reload()
+		self.assertEqual(so.status, "Completed")
+
 	def test_sales_order_with_negative_rate(self):
 		"""
 		Test if negative rate is allowed in Sales Order via doc submission and update items
@@ -2649,6 +2667,7 @@ def make_sales_order(**args):
 	so.currency = args.currency or "INR"
 	so.po_no = args.po_no or ""
 	so.is_subcontracted = args.is_subcontracted or 0
+	so.order_type = args.order_type or "Sales"
 	if args.selling_price_list:
 		so.selling_price_list = args.selling_price_list
 


### PR DESCRIPTION
This is the fix for the support ticket - https://support.frappe.io/helpdesk/tickets/56775 

In case of the maintenance order type in sales order the status of the doctype was not reflecting correctly. By default the status now will be To Bill and and once sales invoice is created we will update it to Completed. 


`no-docs`