### PR TITLE
fix(payment entry): update currency symbol

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.js
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.js
@@ -400,6 +400,16 @@ frappe.ui.form.on("Payment Entry", {
 		);
 
 		frm.refresh_fields();
+
+		const party_currency =
+			frm.doc.payment_type === "Receive" ? "paid_from_account_currency" : "paid_to_account_currency";
+
+		var reference_grid = frm.fields_dict["references"].grid;
+		["total_amount", "outstanding_amount", "allocated_amount"].forEach((fieldname) => {
+			reference_grid.update_docfield_property(fieldname, "options", party_currency);
+		});
+
+		reference_grid.refresh();
 	},
 
 	show_general_ledger: function (frm) {


### PR DESCRIPTION
**Issue:**  In Payment Entry, when a payment involves a foreign currency, the system fails to update the currency symbol in the Reference table. Instead company's default currency symbol is being shown

**Ref:** [57810](https://support.frappe.io/helpdesk/tickets/57810)

**Before:**
<img width="1427" height="802" alt="Screenshot 2026-01-21 at 14 22 17" src="https://github.com/user-attachments/assets/469040a7-8841-4022-a44a-de114ba7f478" />

**After:**
<img width="1430" height="804" alt="Screenshot 2026-01-21 at 14 18 06" src="https://github.com/user-attachments/assets/d6102ac7-0258-478b-9467-c0f6b8780a02" />


**Backport Needed v15**
