### PR TITLE
fix(sales order): set project at item level from parent

### DIFF
--- a/erpnext/public/js/utils/sales_common.js
+++ b/erpnext/public/js/utils/sales_common.js
@@ -495,7 +495,16 @@ erpnext.sales_common = {
 				}
 			}
 
-			project() {
+			project(doc, cdt, cdn) {
+				var item = frappe.get_doc(cdt, cdn);
+				if (item.project) {
+					$.each(this.frm.doc["items"] || [], function (i, other_item) {
+						if (!other_item.project) {
+							other_item.project = item.project;
+							refresh_field("project", other_item.name, other_item.parentfield);
+						}
+					});
+				}
 				let me = this;
 				if (["Delivery Note", "Sales Invoice", "Sales Order"].includes(this.frm.doc.doctype)) {
 					if (this.frm.doc.project) {

--- a/erpnext/public/js/utils/sales_common.js
+++ b/erpnext/public/js/utils/sales_common.js
@@ -496,12 +496,16 @@ erpnext.sales_common = {
 			}
 
 			project(doc, cdt, cdn) {
-				var item = frappe.get_doc(cdt, cdn);
+				const item = frappe.get_doc(cdt, cdn);
 				if (item.project) {
 					$.each(this.frm.doc["items"] || [], function (i, other_item) {
 						if (!other_item.project) {
-							other_item.project = item.project;
-							refresh_field("project", other_item.name, other_item.parentfield);
+							frappe.model.set_value(
+								other_item.doctype,
+								other_item.name,
+								"project",
+								item.project
+							);
 						}
 					});
 				}

--- a/erpnext/public/js/utils/sales_common.js
+++ b/erpnext/public/js/utils/sales_common.js
@@ -496,18 +496,28 @@ erpnext.sales_common = {
 			}
 
 			project(doc, cdt, cdn) {
-				const item = frappe.get_doc(cdt, cdn);
-				if (item.project) {
-					$.each(this.frm.doc["items"] || [], function (i, other_item) {
-						if (!other_item.project) {
-							frappe.model.set_value(
-								other_item.doctype,
-								other_item.name,
-								"project",
-								item.project
-							);
-						}
-					});
+				if (!cdt || !cdn) {
+					if (this.frm.doc.project) {
+						$.each(this.frm.doc["items"] || [], function (i, item) {
+							if (!item.project) {
+								frappe.model.set_value(item.doctype, item.name, "project", doc.project);
+							}
+						});
+					}
+				} else {
+					const item = frappe.get_doc(cdt, cdn);
+					if (item.project) {
+						$.each(this.frm.doc["items"] || [], function (i, other_item) {
+							if (!other_item.project) {
+								frappe.model.set_value(
+									other_item.doctype,
+									other_item.name,
+									"project",
+									item.project
+								);
+							}
+						});
+					}
 				}
 				let me = this;
 				if (["Delivery Note", "Sales Invoice", "Sales Order"].includes(this.frm.doc.doctype)) {


### PR DESCRIPTION
**Issue:**
In the Sales Order, the Project field in Accounting Dimensions is not set at the item level. If it is present at the parent level.

**Ref:** [#56427](https://support.frappe.io/helpdesk/tickets/56427)

https://github.com/user-attachments/assets/294c3ca3-67ac-4fad-a43d-fc0b1675b0cd



Backport needed for v15