### PR TITLE
fix(customer): add customer group filters

### DIFF
--- a/erpnext/selling/doctype/customer/customer.json
+++ b/erpnext/selling/doctype/customer/customer.json
@@ -183,6 +183,7 @@
    "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "Customer Group",
+   "link_filters": "[[\"Customer Group\", \"is_group\", \"=\", 0]]",
    "oldfieldname": "customer_group",
    "oldfieldtype": "Link",
    "options": "Customer Group",
@@ -625,7 +626,7 @@
    "link_fieldname": "party"
   }
  ],
- "modified": "2026-01-16 15:56:05.967663",
+ "modified": "2026-01-21 17:23:42.151114",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Customer",

--- a/erpnext/selling/doctype/selling_settings/selling_settings.json
+++ b/erpnext/selling/doctype/selling_settings/selling_settings.json
@@ -61,6 +61,7 @@
    "fieldtype": "Link",
    "in_list_view": 1,
    "label": "Default Customer Group",
+   "link_filters": "[[\"Customer Group\", \"is_group\", \"=\", 0]]",
    "options": "Customer Group"
   },
   {
@@ -297,7 +298,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2026-01-02 18:17:05.734945",
+ "modified": "2026-01-21 17:28:37.027837",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Selling Settings",


### PR DESCRIPTION
**Issue:**
When the Customer Group field is made mandatory in the Customer doctype, creating a customer via Quick Entry does not filter out group (Is Group) customer groups.

**Ref:** [#58002](https://support.frappe.io/helpdesk/tickets/58002)

**FYR**

<img width="1758" height="942" alt="image" src="https://github.com/user-attachments/assets/60ee33e9-b3dd-429f-b154-219ffee5bed1" />
