### PR TITLE
fix(project): add missing counter to project update naming series

### DIFF
--- a/erpnext/projects/doctype/project/project.py
+++ b/erpnext/projects/doctype/project/project.py
@@ -603,7 +603,7 @@ def send_project_update_email_to_users(project):
 			"sent": 0,
 			"date": today(),
 			"time": nowtime(),
-			"naming_series": "UPDATE-.project.-.YY.MM.DD.-",
+			"naming_series": "UPDATE-.project.-.YY.MM.DD.-.####",
 		}
 	).insert()
 


### PR DESCRIPTION
Issue:
When a Project is created with Collect Progress enabled, during Project Update creation, the naming series is set incorrectly.

Ref: [#57888](https://support.frappe.io/helpdesk/tickets/57888)

Backport needed:v16, v15