### PR TITLE
fix: autofill warehouse for packed items

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -3131,10 +3131,16 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 
 	set_warehouse() {
 		this.autofill_warehouse(this.frm.doc.items, "warehouse", this.frm.doc.set_warehouse);
+		this.autofill_warehouse(this.frm.doc.packed_items, "warehouse", this.frm.doc.set_warehouse);
 	}
 
 	set_target_warehouse() {
 		this.autofill_warehouse(this.frm.doc.items, "target_warehouse", this.frm.doc.set_target_warehouse);
+		this.autofill_warehouse(
+			this.frm.doc.packed_items,
+			"target_warehouse",
+			this.frm.doc.set_target_warehouse
+		);
 	}
 
 	set_from_warehouse() {


### PR DESCRIPTION
**Issue:**
When updating the Warehouse field at the parent level (e.g., in a Delivery Note, Sales Invoice), the system does not automatically update the warehouse to the corresponding packed items in the Packed Items child table.

**Expected Behavior:**
Changing the warehouse on the parent item/row should automatically update the warehouse for all associated packed items.

**Ref:** [#57963](https://support.frappe.io/helpdesk/tickets/57963)

**Before:**

https://github.com/user-attachments/assets/005945a5-b377-4e86-8ca0-4fa44511a1e5

**After:**

https://github.com/user-attachments/assets/92fa87ab-2fb9-4535-8121-57c983151bfc


**Backport Needed for v16 & v15**