### PR TITLE
fix(stock): use purchase UOM in Supplier Quotation items

### DIFF
--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -437,8 +437,10 @@ def get_basic_details(ctx: ItemDetailsCtx, item, overwrite_warehouse=True) -> It
 	if not ctx.uom:
 		if ctx.doctype in sales_doctypes:
 			ctx.uom = item.sales_uom if item.sales_uom else item.stock_uom
-		elif (ctx.doctype in ["Purchase Order", "Purchase Receipt", "Purchase Invoice"]) or (
-			ctx.doctype == "Material Request" and ctx.material_request_type == "Purchase"
+		elif (
+			(ctx.doctype in ["Purchase Order", "Purchase Receipt", "Purchase Invoice"])
+			or (ctx.doctype == "Material Request" and ctx.material_request_type == "Purchase")
+			or (ctx.doctype == "Supplier Quotation")
 		):
 			ctx.uom = item.purchase_uom if item.purchase_uom else item.stock_uom
 		else:


### PR DESCRIPTION
Issue: In Supplier Quotation, the Item table was incorrectly fetching the Stock UOM instead of the Purchase UOM.

fix:[#58134](https://support.frappe.io/helpdesk/tickets/58134?view=VIEW-HD+Ticket-850)

Description:
Previously, when selecting an item in the Supplier Quotation, the system populated the Stock UOM by default.
This behavior was incorrect for purchasing documents.

The logic has now been corrected so that the Purchase UOM configured for the item is fetched and used in Supplier Quotation items.

Before:

[Before uom.webm](https://github.com/user-attachments/assets/620022fa-ffe5-40ac-82c1-f0b727032b17)

After:

[after uom.webm](https://github.com/user-attachments/assets/3b2c3a7a-26f7-4d84-98ca-43294f084daf)

Backport Needed : V15 and V16