### PR TITLE
fix: negative stock for purchase return

### DIFF
--- a/erpnext/stock/deprecated_serial_batch.py
+++ b/erpnext/stock/deprecated_serial_batch.py
@@ -97,7 +97,6 @@ class DeprecatedBatchNoValuation:
 		for ledger in entries:
 			self.stock_value_differece[ledger.batch_no] += flt(ledger.batch_value)
 			self.available_qty[ledger.batch_no] += flt(ledger.batch_qty)
-			self.total_qty[ledger.batch_no] += flt(ledger.batch_qty)
 
 	@deprecated(
 		"erpnext.stock.serial_batch_bundle.BatchNoValuation.get_sle_for_batches",
@@ -269,7 +268,6 @@ class DeprecatedBatchNoValuation:
 		batch_data = query.run(as_dict=True)
 		for d in batch_data:
 			self.available_qty[d.batch_no] += flt(d.batch_qty)
-			self.total_qty[d.batch_no] += flt(d.batch_qty)
 
 		for d in batch_data:
 			if self.available_qty.get(d.batch_no):
@@ -381,7 +379,6 @@ class DeprecatedBatchNoValuation:
 		batch_data = query.run(as_dict=True)
 		for d in batch_data:
 			self.available_qty[d.batch_no] += flt(d.batch_qty)
-			self.total_qty[d.batch_no] += flt(d.batch_qty)
 
 		if not self.last_sle:
 			return


### PR DESCRIPTION
- Make purchase receipt for item A with batch A for 100 qty in warehouse A
- Make purchase receipt for item A with batch B for 100 qty in warehouse A
- Transfer 100 qty from Warehouse A to B of the Batch A
- Make purchase return entry against the first purchase receipt
- System doesn't throw the negative stock error, and allow to make purchase return entry