### PR TITLE
Fix: Set Zero Rate for Standalone Credit Note with Expired Batch

### DIFF
--- a/erpnext/selling/doctype/selling_settings/selling_settings.json
+++ b/erpnext/selling/doctype/selling_settings/selling_settings.json
@@ -39,6 +39,7 @@
   "enable_cutoff_date_on_bulk_delivery_note_creation",
   "allow_zero_qty_in_quotation",
   "allow_zero_qty_in_sales_order",
+  "set_zero_rate_for_expired_batch",
   "experimental_section",
   "use_legacy_js_reactivity",
   "subcontracting_inward_tab",
@@ -289,6 +290,13 @@
    "fieldname": "use_legacy_js_reactivity",
    "fieldtype": "Check",
    "label": "Use Legacy (Client side) Reactivity"
+  },
+  {
+   "default": "0",
+   "description": "If enabled, system will set incoming rate as zero for stand-alone credit notes with expired batch item.",
+   "fieldname": "set_zero_rate_for_expired_batch",
+   "fieldtype": "Check",
+   "label": "Set Incoming Rate as Zero for Expired Batch"
   }
  ],
  "grid_page_length": 50,
@@ -298,7 +306,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2026-01-21 17:28:37.027837",
+ "modified": "2026-01-23 00:04:33.105916",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Selling Settings",

--- a/erpnext/selling/doctype/selling_settings/selling_settings.py
+++ b/erpnext/selling/doctype/selling_settings/selling_settings.py
@@ -44,6 +44,7 @@ class SellingSettings(Document):
 		role_to_override_stop_action: DF.Link | None
 		sales_update_frequency: DF.Literal["Monthly", "Each Transaction", "Daily"]
 		selling_price_list: DF.Link | None
+		set_zero_rate_for_expired: DF.Check
 		so_required: DF.Literal["No", "Yes"]
 		territory: DF.Link | None
 		use_legacy_js_reactivity: DF.Check

--- a/erpnext/selling/doctype/selling_settings/selling_settings.py
+++ b/erpnext/selling/doctype/selling_settings/selling_settings.py
@@ -44,7 +44,7 @@ class SellingSettings(Document):
 		role_to_override_stop_action: DF.Link | None
 		sales_update_frequency: DF.Literal["Monthly", "Each Transaction", "Daily"]
 		selling_price_list: DF.Link | None
-		set_zero_rate_for_expired: DF.Check
+		set_zero_rate_for_expired_batch: DF.Check
 		so_required: DF.Literal["No", "Yes"]
 		territory: DF.Link | None
 		use_legacy_js_reactivity: DF.Check


### PR DESCRIPTION
**Issue:** While creating standalone credit note for expired batch, system is fetching batch valuation rate as it's and updating the stock ledger, which should not be a default constant behaviour as some customers maintain the expired batch in separate expiry warehouse and they won't re-use it again.

**Ref: [57015](https://support.frappe.io/helpdesk/tickets/57015)**

**Solution:** Added a checkbox `Set Incoming Rate as Zero for Expired Batch` in Selling Settings. When it's enabled the system will set zero as valuation rate for stand-alone credit notes with expired batches (default it's disabled).

<img width="1707" height="919" alt="Screenshot 2026-01-23 at 2 37 20 AM" src="https://github.com/user-attachments/assets/8628ae10-0be2-42da-bbdd-7755c9f569f8" />


**Before:**

https://github.com/user-attachments/assets/2e960ab7-4469-437c-ba48-0ce316fdbb55



**After:**


https://github.com/user-attachments/assets/b049352e-abbc-4805-b6d9-6771a851cae8


**Backport Needed:** v16, v15
