### PR TITLE
fix(stock): clear serial batch bundle when using serial fields

### DIFF
--- a/erpnext/controllers/stock_controller.py
+++ b/erpnext/controllers/stock_controller.py
@@ -206,15 +206,24 @@ class StockController(AccountsController):
 		if self.get("_action") == "update_after_submit":
 			return
 
-		# To handle test cases
-		if frappe.flags.in_test and frappe.flags.use_serial_and_batch_fields:
-			return
-
 		if not table_name:
 			table_name = "items"
 
 		if self.doctype == "Asset Capitalization":
 			table_name = "stock_items"
+
+		# To handle test cases: skip auto bundle creation only when none is needed
+		if frappe.flags.in_test and frappe.flags.use_serial_and_batch_fields:
+			needs_bundle = any(
+				(
+					row.get("use_serial_batch_fields")
+					and not row.get("serial_and_batch_bundle")
+					and (row.serial_no or row.batch_no or row.get("rejected_serial_no"))
+				)
+				for row in self.get(table_name)
+			)
+			if not needs_bundle:
+				return
 
 		parent_details = frappe._dict()
 		if table_name == "packed_items":

--- a/erpnext/stock/doctype/delivery_note/delivery_note.js
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.js
@@ -130,7 +130,23 @@ frappe.ui.form.on("Delivery Note Item", {
 		var d = locals[dt][dn];
 		frm.update_in_all_rows("items", "expense_account", d.expense_account);
 	},
+	use_serial_batch_fields: function (frm, dt, dn) {
+		erpnext.stock.delivery_note.clear_bundle_if_using_serial_fields(dt, dn);
+	},
+	serial_no: function (frm, dt, dn) {
+		erpnext.stock.delivery_note.clear_bundle_if_using_serial_fields(dt, dn);
+	},
+	batch_no: function (frm, dt, dn) {
+		erpnext.stock.delivery_note.clear_bundle_if_using_serial_fields(dt, dn);
+	},
 });
+
+erpnext.stock.delivery_note.clear_bundle_if_using_serial_fields = function (dt, dn) {
+	var d = locals[dt][dn];
+	if (d && d.use_serial_batch_fields && d.serial_and_batch_bundle) {
+		frappe.model.set_value(dt, dn, "serial_and_batch_bundle", null);
+	}
+};
 
 erpnext.stock.DeliveryNoteController = class DeliveryNoteController extends (
 	erpnext.selling.SellingController

--- a/erpnext/stock/doctype/delivery_note/delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.py
@@ -261,7 +261,7 @@ class DeliveryNote(SellingController):
 					where item_code = %s and warehouse = %s""",
 					(d.item_code, d.warehouse),
 				)
-				d.actual_qty = actual_qty and flt(actual_qty[0][0]) or 0
+				d.actual_qty = (actual_qty and flt(actual_qty[0][0])) or 0
 
 	def so_required(self):
 		"""check in manage account if sales order required or not"""
@@ -283,6 +283,7 @@ class DeliveryNote(SellingController):
 		self.validate_uom_is_integer("uom", "qty")
 		self.validate_with_previous_doc()
 		self.set_serial_and_batch_bundle_from_pick_list()
+		self.normalize_serial_and_batch_fields()
 
 		from erpnext.stock.doctype.packed_item.packed_item import make_packing_list
 
@@ -294,6 +295,11 @@ class DeliveryNote(SellingController):
 
 		self.validate_against_stock_reservation_entries()
 		self.reset_default_field_value("set_warehouse", "items", "warehouse")
+
+	def normalize_serial_and_batch_fields(self):
+		for d in self.get("items"):
+			if d.get("use_serial_batch_fields") and d.get("serial_and_batch_bundle"):
+				d.serial_and_batch_bundle = None
 
 	def validate_with_previous_doc(self):
 		super().validate_with_previous_doc(
@@ -782,7 +788,7 @@ def update_billed_amount_based_on_so(so_detail, update_modified=True):
 		)
 		.run()
 	)
-	billed_against_so = billed_against_so and billed_against_so[0][0] or 0
+	billed_against_so = (billed_against_so and billed_against_so[0][0]) or 0
 
 	# Get all Delivery Note Item rows against the Sales Order Item row
 	dn = frappe.qb.DocType("Delivery Note").as_("dn")
@@ -817,7 +823,7 @@ def update_billed_amount_based_on_so(so_detail, update_modified=True):
 				where dn_detail=%s and docstatus=1""",
 				dnd.name,
 			)
-			billed_amt_agianst_dn = billed_amt_agianst_dn and billed_amt_agianst_dn[0][0] or 0
+			billed_amt_agianst_dn = (billed_amt_agianst_dn and billed_amt_agianst_dn[0][0]) or 0
 
 		# Distribute billed amount directly against SO between DNs based on FIFO
 		if billed_against_so and billed_amt_agianst_dn < dnd.amount:

--- a/erpnext/stock/doctype/delivery_note/delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.py
@@ -297,8 +297,13 @@ class DeliveryNote(SellingController):
 		self.reset_default_field_value("set_warehouse", "items", "warehouse")
 
 	def normalize_serial_and_batch_fields(self):
+		"""Clear bundle link when serial/batch fields are used for this row."""
 		for d in self.get("items"):
-			if d.get("use_serial_batch_fields") and d.get("serial_and_batch_bundle"):
+			if (
+				d.get("use_serial_batch_fields")
+				and d.get("serial_and_batch_bundle")
+				and (d.get("serial_no") or d.get("batch_no"))
+			):
 				d.serial_and_batch_bundle = None
 
 	def validate_with_previous_doc(self):

--- a/erpnext/stock/doctype/delivery_note/test_delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/test_delivery_note.py
@@ -24,7 +24,10 @@ from erpnext.stock.doctype.delivery_note.delivery_note import (
 	make_sales_invoice,
 )
 from erpnext.stock.doctype.item.test_item import make_item
-from erpnext.stock.doctype.purchase_receipt.test_purchase_receipt import get_gl_entries
+from erpnext.stock.doctype.purchase_receipt.test_purchase_receipt import (
+	get_gl_entries,
+	make_purchase_receipt,
+)
 from erpnext.stock.doctype.serial_and_batch_bundle.test_serial_and_batch_bundle import (
 	get_batch_from_bundle,
 	get_serial_nos_from_bundle,
@@ -286,6 +289,51 @@ class TestDeliveryNote(FrappeTestCase):
 		for serial_no in returned_serial_nos2:
 			self.assertTrue(serial_no in serial_nos)
 			self.assertFalse(serial_no in returned_serial_nos1)
+
+	def test_clear_serial_and_batch_bundle_when_using_serial_fields(self):
+		serial_item_code = "Serial Bundle Clear Test Item"
+		make_item(
+			serial_item_code,
+			{
+				"has_serial_no": 1,
+				"serial_no_series": "SBBCLR-.#####",
+				"is_stock_item": 1,
+			},
+		)
+
+		pr = make_purchase_receipt(
+			item_code=serial_item_code, warehouse="_Test Warehouse - _TC", qty=1, rate=100
+		)
+		serial_no = get_serial_nos_from_bundle(pr.items[0].serial_and_batch_bundle)[0]
+
+		dn = create_delivery_note(
+			item_code=serial_item_code,
+			warehouse="_Test Warehouse - _TC",
+			qty=1,
+			rate=150,
+			serial_no=serial_no,
+			use_serial_batch_fields=1,
+			do_not_save=True,
+		)
+		dn.items[0].serial_and_batch_bundle = make_serial_batch_bundle(
+			frappe._dict(
+				{
+					"item_code": serial_item_code,
+					"warehouse": "_Test Warehouse - _TC",
+					"qty": -1,
+					"voucher_type": "Delivery Note",
+					"serial_nos": [serial_no],
+					"posting_date": dn.posting_date,
+					"posting_time": dn.posting_time,
+					"type_of_transaction": "Outward",
+					"do_not_submit": True,
+				}
+			)
+		).name
+		dn.insert()
+		dn.load_from_db()
+
+		self.assertFalse(dn.items[0].serial_and_batch_bundle)
 
 	def test_sales_return_for_non_bundled_items_partial(self):
 		company = frappe.db.get_value("Warehouse", "Stores - TCP1", "company")
@@ -688,7 +736,7 @@ class TestDeliveryNote(FrappeTestCase):
 		self.assertEqual(actual_qty, 35)
 
 		# Check incoming rate for return entry
-		incoming_rate, stock_value_difference = frappe.db.get_value(
+		incoming_rate, _stock_value_difference = frappe.db.get_value(
 			"Stock Ledger Entry",
 			{"voucher_type": "Delivery Note", "voucher_no": dn1.name},
 			["incoming_rate", "stock_value_difference"],


### PR DESCRIPTION
This pull request introduces improvements to the handling of serial and batch fields in Delivery Notes, ensuring that the `serial_and_batch_bundle` field is cleared when serial/batch fields are used, and adds corresponding backend normalization and frontend triggers. It also includes minor code cleanups and a new test to verify this behavior.

**Serial and Batch Bundle Handling Improvements:**

* Added a new method `normalize_serial_and_batch_fields` in `delivery_note.py` to clear the `serial_and_batch_bundle` field for items using serial/batch fields, and invoked it during validation. [[1]](diffhunk://#diff-ef460e80f74de1df918fc36660ebf720ccf959b918a948d07f5d7e4043d961d9R286) [[2]](diffhunk://#diff-ef460e80f74de1df918fc36660ebf720ccf959b918a948d07f5d7e4043d961d9R299-R303)
* Updated the Delivery Note Item JavaScript controller to call a new helper function that clears the bundle when relevant fields (`use_serial_batch_fields`, `serial_no`, `batch_no`) are changed.
* Introduced the backend function `erpnext.stock.delivery_note.clear_bundle_if_using_serial_fields` for clearing the bundle if serial/batch fields are used.

**Testing Enhancements:**

* Added a new test `test_clear_serial_and_batch_bundle_when_using_serial_fields` to verify that the bundle is cleared appropriately when serial fields are used.

**Code Quality Improvements:**

* Refactored several Python lines to use more idiomatic expressions for conditional assignments. [[1]](diffhunk://#diff-ef460e80f74de1df918fc36660ebf720ccf959b918a948d07f5d7e4043d961d9L264-R264) [[2]](diffhunk://#diff-ef460e80f74de1df918fc36660ebf720ccf959b918a948d07f5d7e4043d961d9L785-R791) [[3]](diffhunk://#diff-ef460e80f74de1df918fc36660ebf720ccf959b918a948d07f5d7e4043d961d9L820-R826)
* Minor variable renaming in a test to clarify intent.
* Added missing imports to support new tests.

<!-- Add images/recordings to better visualize the change: expected/current behviour -->
<img width="596" height="167" alt="image" src="https://github.com/user-attachments/assets/fb712925-d5cd-489b-b24f-2ef051e2b128" />

<img width="966" height="539" alt="image" src="https://github.com/user-attachments/assets/91c9df5a-0b47-4e89-bf41-14d9c481186c" />


<img width="991" height="220" alt="image" src="https://github.com/user-attachments/assets/d3b1e423-8612-48fd-879f-7ba6718a26e6" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Delivery Notes now auto-clear linked serial/batch bundles when serial/batch fields are used to prevent stale links.

* **Bug Fixes**
  * Safer quantity and billed-amount calculations to avoid errors when query results are empty.
  * Validation tightened to normalize serial/batch fields during processing.
  * Improved handling of test-mode bundle creation so it runs only when bundling is needed.

* **Tests**
  * Added tests covering serial/batch bundle clearing and related flows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->