### PR TITLE
fix(consolidated_financial_statement): use account_key format for parent_account_name

### DIFF
--- a/erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.py
+++ b/erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.py
@@ -429,6 +429,8 @@ def calculate_values(accounts_by_name, gl_entries_by_account, companies, filters
 
 def accumulate_values_into_parents(accounts, accounts_by_name, companies):
 	"""accumulate children's values in parent accounts"""
+	skipped_accounts = []
+
 	for d in reversed(accounts):
 		if d.parent_account:
 			account = d.parent_account_name
@@ -436,6 +438,7 @@ def accumulate_values_into_parents(accounts, accounts_by_name, companies):
 			# Skip if parent_account_name is None or not in accounts_by_name
 			# This can happen when parent account wasn't fetched (different company/root_type)
 			if not account or account not in accounts_by_name:
+				skipped_accounts.append(d)
 				continue
 
 			for company in companies:
@@ -450,6 +453,21 @@ def accumulate_values_into_parents(accounts, accounts_by_name, companies):
 			accounts_by_name[account]["opening_balance"] = accounts_by_name[account].get(
 				"opening_balance", 0.0
 			) + d.get("opening_balance", 0.0)
+
+	if skipped_accounts:
+		account_names = ", ".join(d.account_name for d in skipped_accounts[:5])
+		if len(skipped_accounts) > 5:
+			account_names += f" and {len(skipped_accounts) - 5} more"
+
+		frappe.msgprint(
+			_(
+				"Some accounts could not be consolidated because their parent account group "
+				"is not present in the consolidated view: {0}. "
+				"Ensure the Chart of Accounts group structure matches between parent and child companies."
+			).format(account_names),
+			title=_("Accounts Skipped"),
+			indicator="orange",
+		)
 
 
 def get_account_heads(root_type, companies, filters):

--- a/erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.py
+++ b/erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.py
@@ -433,6 +433,11 @@ def accumulate_values_into_parents(accounts, accounts_by_name, companies):
 		if d.parent_account:
 			account = d.parent_account_name
 
+			# Skip if parent_account_name is None or not in accounts_by_name
+			# This can happen when parent account wasn't fetched (different company/root_type)
+			if not account or account not in accounts_by_name:
+				continue
+
 			for company in companies:
 				accounts_by_name[account][company] = accounts_by_name[account].get(company, 0.0) + d.get(
 					company, 0.0
@@ -691,6 +696,13 @@ def validate_entries(key, entry, accounts_by_name, accounts):
 		if args.parent_account:
 			parent_args = get_account_details(args.parent_account)
 
+			# Build parent_account_name using the same format as account_key
+			# (with account_number prefix if present) to match accounts_by_name keys
+			if parent_args.account_number:
+				parent_account_name = f"{parent_args.account_number} - {parent_args.account_name}"
+			else:
+				parent_account_name = parent_args.account_name
+
 			args.update(
 				{
 					"lft": parent_args.lft + 1,
@@ -698,7 +710,7 @@ def validate_entries(key, entry, accounts_by_name, accounts):
 					"indent": 3,
 					"root_type": parent_args.root_type,
 					"report_type": parent_args.report_type,
-					"parent_account_name": parent_args.account_name,
+					"parent_account_name": parent_account_name,
 					"company_wise_opening_bal": defaultdict(float),
 				}
 			)

--- a/erpnext/accounts/report/consolidated_financial_statement/test_consolidated_financial_statement.py
+++ b/erpnext/accounts/report/consolidated_financial_statement/test_consolidated_financial_statement.py
@@ -26,10 +26,10 @@ class TestAccumulateValuesIntoParents(IntegrationTestCase):
 	Regression test for #52018, #49771: KeyError when parent_account_name is None.
 	"""
 
-	def test_skips_account_with_none_parent_account_name(self):
+	def test_skips_account_with_none_parent_account_name_and_shows_warning(self):
 		"""
 		Test that accounts with parent_account_name=None are skipped
-		without raising KeyError.
+		without raising KeyError, and a warning is shown.
 		"""
 		# Account with parent_account but parent_account_name is None
 		# This can happen when parent wasn't in fetched accounts
@@ -51,13 +51,22 @@ class TestAccumulateValuesIntoParents(IntegrationTestCase):
 
 		companies = ["Test Company"]
 
+		# Clear any existing messages
+		frappe.message_log = []
+
 		# This should not raise KeyError: None
 		accumulate_values_into_parents(accounts, accounts_by_name, companies)
 
-	def test_skips_account_with_missing_parent_in_accounts_by_name(self):
+		# Verify warning was shown
+		self.assertTrue(len(frappe.message_log) > 0, "Expected a warning message")
+		warning_msg = str(frappe.message_log[0])
+		self.assertIn("Test Account", warning_msg)
+		self.assertIn("Accounts Skipped", warning_msg)
+
+	def test_skips_account_with_missing_parent_in_accounts_by_name_and_shows_warning(self):
 		"""
 		Test that accounts whose parent_account_name is not in accounts_by_name
-		are skipped without raising KeyError.
+		are skipped without raising KeyError, and a warning is shown.
 		"""
 		accounts = [
 			frappe._dict(
@@ -65,7 +74,7 @@ class TestAccumulateValuesIntoParents(IntegrationTestCase):
 					"account_name": "Child Account",
 					"account_key": "Child Account",
 					"parent_account": "Parent Account - ABC",
-					"parent_account_name": "Parent Account",  # Parent exists
+					"parent_account_name": "Parent Account",  # Parent exists but not in accounts_by_name
 					"company_wise_opening_bal": {},
 				}
 			),
@@ -78,12 +87,22 @@ class TestAccumulateValuesIntoParents(IntegrationTestCase):
 
 		companies = ["Test Company"]
 
+		# Clear any existing messages
+		frappe.message_log = []
+
 		# This should not raise KeyError: 'Parent Account'
 		accumulate_values_into_parents(accounts, accounts_by_name, companies)
 
-	def test_accumulates_values_when_parent_exists(self):
+		# Verify warning was shown
+		self.assertTrue(len(frappe.message_log) > 0, "Expected a warning message")
+		warning_msg = str(frappe.message_log[0])
+		self.assertIn("Child Account", warning_msg)
+		self.assertIn("Chart of Accounts", warning_msg)
+
+	def test_accumulates_values_when_parent_exists_without_warning(self):
 		"""
-		Test that values are correctly accumulated when parent exists.
+		Test that values are correctly accumulated when parent exists,
+		and no warning is shown.
 		"""
 		child = frappe._dict(
 			{
@@ -118,12 +137,18 @@ class TestAccumulateValuesIntoParents(IntegrationTestCase):
 
 		companies = ["Test Company"]
 
+		# Clear any existing messages
+		frappe.message_log = []
+
 		accumulate_values_into_parents(accounts, accounts_by_name, companies)
 
 		# Parent should have accumulated child's values
 		self.assertEqual(parent["Test Company"], 500.0)
 		self.assertEqual(parent["opening_balance"], 100.0)
 		self.assertEqual(parent["company_wise_opening_bal"]["Test Company"], 100.0)
+
+		# No warning should be shown when accumulation succeeds
+		self.assertEqual(len(frappe.message_log), 0, "No warning expected when parents exist")
 
 
 class TestUpdateParentAccountNames(IntegrationTestCase):

--- a/erpnext/accounts/report/consolidated_financial_statement/test_consolidated_financial_statement.py
+++ b/erpnext/accounts/report/consolidated_financial_statement/test_consolidated_financial_statement.py
@@ -1,0 +1,271 @@
+# Copyright (c) 2025, Frappe Technologies Pvt. Ltd. and Contributors
+# MIT License. See license.txt
+
+"""
+Tests for Consolidated Financial Statement report.
+
+Regression tests for:
+- #52018: KeyError when parent_account_name is None
+- #49771: KeyError: None in accumulate_values_into_parents
+"""
+
+import frappe
+from frappe.tests import IntegrationTestCase
+
+from erpnext.accounts.report.consolidated_financial_statement.consolidated_financial_statement import (
+	accumulate_values_into_parents,
+	update_parent_account_names,
+	validate_entries,
+)
+
+
+class TestAccumulateValuesIntoParents(IntegrationTestCase):
+	"""
+	Unit tests for accumulate_values_into_parents function.
+
+	Regression test for #52018, #49771: KeyError when parent_account_name is None.
+	"""
+
+	def test_skips_account_with_none_parent_account_name(self):
+		"""
+		Test that accounts with parent_account_name=None are skipped
+		without raising KeyError.
+		"""
+		# Account with parent_account but parent_account_name is None
+		# This can happen when parent wasn't in fetched accounts
+		accounts = [
+			frappe._dict(
+				{
+					"account_name": "Test Account",
+					"account_key": "Test Account",
+					"parent_account": "Some Parent - ABC",  # Has parent_account
+					"parent_account_name": None,  # But parent_account_name is None
+					"company_wise_opening_bal": {},
+				}
+			),
+		]
+
+		accounts_by_name = {
+			"Test Account": accounts[0],
+		}
+
+		companies = ["Test Company"]
+
+		# This should not raise KeyError: None
+		accumulate_values_into_parents(accounts, accounts_by_name, companies)
+
+	def test_skips_account_with_missing_parent_in_accounts_by_name(self):
+		"""
+		Test that accounts whose parent_account_name is not in accounts_by_name
+		are skipped without raising KeyError.
+		"""
+		accounts = [
+			frappe._dict(
+				{
+					"account_name": "Child Account",
+					"account_key": "Child Account",
+					"parent_account": "Parent Account - ABC",
+					"parent_account_name": "Parent Account",  # Parent exists
+					"company_wise_opening_bal": {},
+				}
+			),
+		]
+
+		# Parent is NOT in accounts_by_name
+		accounts_by_name = {
+			"Child Account": accounts[0],
+		}
+
+		companies = ["Test Company"]
+
+		# This should not raise KeyError: 'Parent Account'
+		accumulate_values_into_parents(accounts, accounts_by_name, companies)
+
+	def test_accumulates_values_when_parent_exists(self):
+		"""
+		Test that values are correctly accumulated when parent exists.
+		"""
+		child = frappe._dict(
+			{
+				"account_name": "Child Account",
+				"account_key": "1100 - Child Account",
+				"parent_account": "Parent Account - ABC",
+				"parent_account_name": "1000 - Parent Account",
+				"company_wise_opening_bal": {"Test Company": 100.0},
+				"opening_balance": 100.0,
+				"Test Company": 500.0,
+			}
+		)
+
+		parent = frappe._dict(
+			{
+				"account_name": "Parent Account",
+				"account_key": "1000 - Parent Account",
+				"parent_account": None,
+				"parent_account_name": None,
+				"company_wise_opening_bal": {"Test Company": 0.0},
+				"opening_balance": 0.0,
+				"Test Company": 0.0,
+			}
+		)
+
+		accounts = [parent, child]
+
+		accounts_by_name = {
+			"1000 - Parent Account": parent,
+			"1100 - Child Account": child,
+		}
+
+		companies = ["Test Company"]
+
+		accumulate_values_into_parents(accounts, accounts_by_name, companies)
+
+		# Parent should have accumulated child's values
+		self.assertEqual(parent["Test Company"], 500.0)
+		self.assertEqual(parent["opening_balance"], 100.0)
+		self.assertEqual(parent["company_wise_opening_bal"]["Test Company"], 100.0)
+
+
+class TestUpdateParentAccountNames(IntegrationTestCase):
+	"""
+	Unit tests for update_parent_account_names function.
+	"""
+
+	def test_sets_parent_account_name_with_account_number(self):
+		"""
+		Test that parent_account_name uses account_key format
+		(with account_number prefix when present).
+		"""
+		parent = frappe._dict(
+			{
+				"name": "1000 - Assets - ABC",
+				"account_name": "Assets",
+				"account_number": "1000",
+				"parent_account": None,
+			}
+		)
+
+		child = frappe._dict(
+			{
+				"name": "1100 - Cash - ABC",
+				"account_name": "Cash",
+				"account_number": "1100",
+				"parent_account": "1000 - Assets - ABC",
+			}
+		)
+
+		accounts = [parent, child]
+		accounts = update_parent_account_names(accounts)
+
+		# Child's parent_account_name should use account_key format
+		self.assertEqual(child.parent_account_name, "1000 - Assets")
+
+	def test_sets_parent_account_name_without_account_number(self):
+		"""
+		Test that parent_account_name works when account has no number.
+		"""
+		parent = frappe._dict(
+			{
+				"name": "Assets - ABC",
+				"account_name": "Assets",
+				"account_number": None,
+				"parent_account": None,
+			}
+		)
+
+		child = frappe._dict(
+			{
+				"name": "Cash - ABC",
+				"account_name": "Cash",
+				"account_number": None,
+				"parent_account": "Assets - ABC",
+			}
+		)
+
+		accounts = [parent, child]
+		accounts = update_parent_account_names(accounts)
+
+		# Child's parent_account_name should be just account_name
+		self.assertEqual(child.parent_account_name, "Assets")
+
+	def test_returns_none_for_missing_parent(self):
+		"""
+		Test that parent_account_name is None when parent not in accounts list.
+		"""
+		child = frappe._dict(
+			{
+				"name": "1100 - Cash - ABC",
+				"account_name": "Cash",
+				"account_number": "1100",
+				"parent_account": "Missing Parent - XYZ",  # Not in list
+			}
+		)
+
+		accounts = [child]
+		accounts = update_parent_account_names(accounts)
+
+		# parent_account_name should be None since parent not found
+		self.assertIsNone(child.parent_account_name)
+
+
+class TestValidateEntries(IntegrationTestCase):
+	"""
+	Unit tests for validate_entries function.
+
+	Regression test for #52018: parent_account_name should use account_key format.
+	"""
+
+	def test_sets_parent_account_name_with_account_number_format(self):
+		"""
+		Test that dynamically added accounts get parent_account_name
+		in account_key format (with account number prefix).
+		"""
+		# Skip if _Test Company doesn't exist
+		if not frappe.db.exists("Company", "_Test Company"):
+			self.skipTest("_Test Company does not exist")
+
+		# Find an actual account with account_number to use as parent
+		parent_account = frappe.db.get_value(
+			"Account",
+			{"company": "_Test Company", "account_number": ["is", "set"], "is_group": 1},
+			["name", "account_name", "account_number"],
+			as_dict=True,
+		)
+
+		if not parent_account:
+			self.skipTest("No numbered parent account found in _Test Company")
+
+		# Create a mock entry that references this parent
+		entry = frappe._dict(
+			{
+				"account": parent_account.name,
+				"account_name": parent_account.account_name,
+				"account_number": parent_account.account_number,
+			}
+		)
+
+		# Create key in account_key format
+		key = f"{parent_account.account_number} - {parent_account.account_name}"
+
+		accounts_by_name = {}
+		accounts = []
+
+		# This should add the account to accounts_by_name with proper parent_account_name
+		validate_entries(key, entry, accounts_by_name, accounts)
+
+		# Verify account was added
+		self.assertIn(key, accounts_by_name)
+
+		# If the account has a parent, verify parent_account_name format
+		added_account = accounts_by_name[key]
+		if added_account.get("parent_account") and added_account.get("parent_account_name"):
+			# parent_account_name should contain " - " if parent has account_number
+			parent_info = frappe.db.get_value(
+				"Account",
+				added_account.parent_account,
+				["account_name", "account_number"],
+				as_dict=True,
+			)
+			if parent_info and parent_info.account_number:
+				expected = f"{parent_info.account_number} - {parent_info.account_name}"
+				self.assertEqual(added_account.parent_account_name, expected)

--- a/erpnext/accounts/report/consolidated_financial_statement/test_consolidated_financial_statement.py
+++ b/erpnext/accounts/report/consolidated_financial_statement/test_consolidated_financial_statement.py
@@ -215,10 +215,63 @@ class TestValidateEntries(IntegrationTestCase):
 	Regression test for #52018: parent_account_name should use account_key format.
 	"""
 
+	def test_adds_new_entry_to_accounts(self):
+		"""
+		Test that validate_entries adds a new entry to accounts_by_name
+		when the key doesn't exist.
+		"""
+		entry = frappe._dict(
+			{
+				"account": "1000 - Test Account - ABC",
+				"account_name": "Test Account",
+				"account_number": "1000",
+			}
+		)
+
+		key = "1000 - Test Account"
+		accounts_by_name = {}
+		accounts = []
+
+		validate_entries(key, entry, accounts_by_name, accounts)
+
+		# Verify account was added
+		self.assertIn(key, accounts_by_name)
+		self.assertEqual(len(accounts), 1)
+
+	def test_does_not_duplicate_existing_entry(self):
+		"""
+		Test that validate_entries doesn't add duplicate entries.
+		"""
+		existing = frappe._dict(
+			{
+				"account_name": "Test Account",
+				"account_key": "1000 - Test Account",
+			}
+		)
+
+		entry = frappe._dict(
+			{
+				"account": "1000 - Test Account - ABC",
+				"account_name": "Test Account",
+				"account_number": "1000",
+			}
+		)
+
+		key = "1000 - Test Account"
+		accounts_by_name = {key: existing}
+		accounts = [existing]
+
+		validate_entries(key, entry, accounts_by_name, accounts)
+
+		# Should still only have one entry
+		self.assertEqual(len(accounts), 1)
+
 	def test_sets_parent_account_name_with_account_number_format(self):
 		"""
 		Test that dynamically added accounts get parent_account_name
 		in account_key format (with account number prefix).
+
+		This test requires _Test Company with numbered accounts.
 		"""
 		# Skip if _Test Company doesn't exist
 		if not frappe.db.exists("Company", "_Test Company"):

--- a/erpnext/accounts/report/consolidated_financial_statement/test_consolidated_financial_statement.py
+++ b/erpnext/accounts/report/consolidated_financial_statement/test_consolidated_financial_statement.py
@@ -208,117 +208,225 @@ class TestUpdateParentAccountNames(IntegrationTestCase):
 		self.assertIsNone(child.parent_account_name)
 
 
-class TestValidateEntries(IntegrationTestCase):
+class TestConsolidatedFinancialStatementRegression(IntegrationTestCase):
 	"""
-	Unit tests for validate_entries function.
+	Integration test for Consolidated Financial Statement report.
 
-	Regression test for #52018: parent_account_name should use account_key format.
+	Regression test for #52018, #49771: KeyError when child company has an account
+	with a numbered parent that doesn't exist in the parent company's fetched accounts.
+
+	This test creates the exact conditions that trigger the bug:
+	1. Parent company with is_group=1
+	2. Child company under parent
+	3. Numbered accounts in child company
+	4. GL entry in child for account not in parent's fetched accounts
 	"""
 
-	def test_adds_new_entry_to_accounts(self):
-		"""
-		Test that validate_entries adds a new entry to accounts_by_name
-		when the key doesn't exist.
-		"""
-		entry = frappe._dict(
-			{
-				"account": "1000 - Test Account - ABC",
-				"account_name": "Test Account",
-				"account_number": "1000",
-			}
-		)
+	TEST_PARENT_COMPANY = "_Test CFS Parent Co"
+	TEST_CHILD_COMPANY = "_Test CFS Child Co"
 
-		key = "1000 - Test Account"
-		accounts_by_name = {}
-		accounts = []
+	@classmethod
+	def setUpClass(cls):
+		"""Create test companies and accounts that reproduce the bug scenario."""
+		super().setUpClass()
 
-		validate_entries(key, entry, accounts_by_name, accounts)
-
-		# Verify account was added
-		self.assertIn(key, accounts_by_name)
-		self.assertEqual(len(accounts), 1)
-
-	def test_does_not_duplicate_existing_entry(self):
-		"""
-		Test that validate_entries doesn't add duplicate entries.
-		"""
-		existing = frappe._dict(
-			{
-				"account_name": "Test Account",
-				"account_key": "1000 - Test Account",
-			}
-		)
-
-		entry = frappe._dict(
-			{
-				"account": "1000 - Test Account - ABC",
-				"account_name": "Test Account",
-				"account_number": "1000",
-			}
-		)
-
-		key = "1000 - Test Account"
-		accounts_by_name = {key: existing}
-		accounts = [existing]
-
-		validate_entries(key, entry, accounts_by_name, accounts)
-
-		# Should still only have one entry
-		self.assertEqual(len(accounts), 1)
-
-	def test_sets_parent_account_name_with_account_number_format(self):
-		"""
-		Test that dynamically added accounts get parent_account_name
-		in account_key format (with account number prefix).
-
-		This test requires _Test Company with numbered accounts.
-		"""
-		# Skip if _Test Company doesn't exist
-		if not frappe.db.exists("Company", "_Test Company"):
-			self.skipTest("_Test Company does not exist")
-
-		# Find an actual account with account_number to use as parent
-		parent_account = frappe.db.get_value(
-			"Account",
-			{"company": "_Test Company", "account_number": ["is", "set"], "is_group": 1},
-			["name", "account_name", "account_number"],
-			as_dict=True,
-		)
-
-		if not parent_account:
-			self.skipTest("No numbered parent account found in _Test Company")
-
-		# Create a mock entry that references this parent
-		entry = frappe._dict(
-			{
-				"account": parent_account.name,
-				"account_name": parent_account.account_name,
-				"account_number": parent_account.account_number,
-			}
-		)
-
-		# Create key in account_key format
-		key = f"{parent_account.account_number} - {parent_account.account_name}"
-
-		accounts_by_name = {}
-		accounts = []
-
-		# This should add the account to accounts_by_name with proper parent_account_name
-		validate_entries(key, entry, accounts_by_name, accounts)
-
-		# Verify account was added
-		self.assertIn(key, accounts_by_name)
-
-		# If the account has a parent, verify parent_account_name format
-		added_account = accounts_by_name[key]
-		if added_account.get("parent_account") and added_account.get("parent_account_name"):
-			# parent_account_name should contain " - " if parent has account_number
-			parent_info = frappe.db.get_value(
-				"Account",
-				added_account.parent_account,
-				["account_name", "account_number"],
-				as_dict=True,
+		# Create parent company
+		if not frappe.db.exists("Company", cls.TEST_PARENT_COMPANY):
+			parent_company = frappe.get_doc(
+				{
+					"doctype": "Company",
+					"company_name": cls.TEST_PARENT_COMPANY,
+					"abbr": "TCFSP",
+					"country": "United States",
+					"default_currency": "USD",
+					"is_group": 1,
+				}
 			)
-			if parent_info and parent_info.account_number:
-				expected = f"{parent_info.account_number} - {parent_info.account_name}"
-				self.assertEqual(added_account.parent_account_name, expected)
+			parent_company.insert(ignore_permissions=True)
+
+		# Create child company under parent
+		if not frappe.db.exists("Company", cls.TEST_CHILD_COMPANY):
+			child_company = frappe.get_doc(
+				{
+					"doctype": "Company",
+					"company_name": cls.TEST_CHILD_COMPANY,
+					"abbr": "TCFSC",
+					"country": "United States",
+					"default_currency": "USD",
+					"parent_company": cls.TEST_PARENT_COMPANY,
+					"is_group": 0,
+				}
+			)
+			child_company.insert(ignore_permissions=True)
+
+		frappe.db.commit()
+
+		# Find the Assets root account in child company (created automatically)
+		cls.child_assets_account = frappe.db.get_value(
+			"Account",
+			{
+				"company": cls.TEST_CHILD_COMPANY,
+				"root_type": "Asset",
+				"is_group": 1,
+				"parent_account": ["is", "not set"],
+			},
+			"name",
+		)
+
+		# Add account number to the Assets account to create the bug condition
+		if cls.child_assets_account:
+			frappe.db.set_value(
+				"Account", cls.child_assets_account, "account_number", "1000"
+			)
+			frappe.db.commit()
+
+	@classmethod
+	def tearDownClass(cls):
+		"""Clean up test companies and all related data."""
+		super().tearDownClass()
+
+		# Delete GL entries for test companies
+		frappe.db.delete("GL Entry", {"company": cls.TEST_CHILD_COMPANY})
+		frappe.db.delete("GL Entry", {"company": cls.TEST_PARENT_COMPANY})
+
+		# Delete child company (accounts deleted via on_trash)
+		if frappe.db.exists("Company", cls.TEST_CHILD_COMPANY):
+			frappe.delete_doc("Company", cls.TEST_CHILD_COMPANY, force=True)
+
+		# Delete parent company
+		if frappe.db.exists("Company", cls.TEST_PARENT_COMPANY):
+			frappe.delete_doc("Company", cls.TEST_PARENT_COMPANY, force=True)
+
+		frappe.db.commit()
+
+	def test_validate_entries_uses_account_key_format_for_parent(self):
+		"""
+		Test that validate_entries sets parent_account_name using account_key format.
+
+		Bug scenario: Child company has account "99999 - Test Bank" under
+		parent "1000 - Assets". When validate_entries dynamically adds this account,
+		it must set parent_account_name to "1000 - Assets" (not just "Assets")
+		to match the keys in accounts_by_name.
+		"""
+		# Create a child account with account number under the numbered parent
+		test_account_name = f"_Test Bank {frappe.generate_hash()[:6]}"
+		test_account = frappe.get_doc(
+			{
+				"doctype": "Account",
+				"account_name": test_account_name,
+				"account_number": "1999",
+				"parent_account": self.child_assets_account,
+				"company": self.TEST_CHILD_COMPANY,
+				"account_type": "Bank",
+				"is_group": 0,
+			}
+		)
+		test_account.insert(ignore_permissions=True)
+
+		try:
+			# Simulate what happens during report generation
+			entry = frappe._dict(
+				{
+					"account": test_account.name,
+					"account_name": test_account_name,
+					"account_number": "1999",
+				}
+			)
+
+			key = f"1999 - {test_account_name}"
+			accounts_by_name = {}
+			accounts = []
+
+			# This should set parent_account_name to "1000 - Application of Funds (Assets)"
+			# not just "Application of Funds (Assets)"
+			validate_entries(key, entry, accounts_by_name, accounts)
+
+			self.assertIn(key, accounts_by_name)
+			added_account = accounts_by_name[key]
+
+			# The critical assertion: parent_account_name must include account number
+			self.assertIsNotNone(added_account.get("parent_account_name"))
+			self.assertIn("1000", added_account.parent_account_name)
+
+		finally:
+			frappe.delete_doc("Account", test_account.name, force=True)
+			frappe.db.commit()
+
+	def test_report_executes_without_keyerror(self):
+		"""
+		End-to-end test: Run the Consolidated Financial Statement report
+		with the bug conditions and verify no KeyError is raised.
+
+		This is the actual regression test for issues #52018 and #49771.
+		"""
+		from erpnext.accounts.report.consolidated_financial_statement.consolidated_financial_statement import (
+			execute,
+		)
+
+		# Create a unique test account in child company
+		test_account_name = f"_Test CFS Bank {frappe.generate_hash()[:6]}"
+		test_account = frappe.get_doc(
+			{
+				"doctype": "Account",
+				"account_name": test_account_name,
+				"account_number": "1888",
+				"parent_account": self.child_assets_account,
+				"company": self.TEST_CHILD_COMPANY,
+				"account_type": "Bank",
+				"is_group": 0,
+			}
+		)
+		test_account.insert(ignore_permissions=True)
+
+		try:
+			# Create a GL entry to make this account appear in the report
+			gl_entry = frappe.get_doc(
+				{
+					"doctype": "GL Entry",
+					"posting_date": frappe.utils.today(),
+					"account": test_account.name,
+					"company": self.TEST_CHILD_COMPANY,
+					"debit": 1000,
+					"credit": 0,
+					"debit_in_account_currency": 1000,
+					"credit_in_account_currency": 0,
+					"voucher_type": "Journal Entry",
+					"voucher_no": f"TEST-JV-{frappe.generate_hash()[:8]}",
+					"is_opening": "No",
+					"is_advance": "No",
+				}
+			)
+			gl_entry.flags.ignore_permissions = True
+			gl_entry.db_insert()
+			frappe.db.commit()
+
+			# Run the consolidated financial statement report
+			filters = frappe._dict(
+				{
+					"company": self.TEST_PARENT_COMPANY,
+					"report": "Balance Sheet",
+					"period_start_date": frappe.utils.add_months(frappe.utils.today(), -1),
+					"period_end_date": frappe.utils.today(),
+					"periodicity": "Monthly",
+					"accumulated_in_group_company": 0,
+					"include_default_book_entries": 1,
+				}
+			)
+
+			# This should NOT raise KeyError
+			try:
+				result = execute(filters)
+				# execute returns (columns, data, message, chart, report_summary)
+				self.assertIsNotNone(result)
+				self.assertIsNotNone(result[0])  # columns
+			except KeyError as e:
+				self.fail(
+					f"KeyError raised: {e}. "
+					f"This is the bug from #52018/#49771 - parent_account_name format mismatch."
+				)
+
+		finally:
+			# Cleanup
+			frappe.db.delete("GL Entry", {"account": test_account.name})
+			frappe.delete_doc("Account", test_account.name, force=True)
+			frappe.db.commit()


### PR DESCRIPTION
## Summary

Fixes `KeyError: None` in Consolidated Financial Statement report and adds user-friendly warning when accounts cannot be consolidated due to Chart of Accounts misalignment.

### Fix 1: `validate_entries()` - account_key format mismatch

When accounts are dynamically added via `validate_entries()`, the `parent_account_name` was set using just `parent_args.account_name` (e.g., "Equity"), but `accounts_by_name` is keyed by `account_key` format which includes the account number prefix when present (e.g., "100 - Equity").

**Fix:** Construct `parent_account_name` using the same format as `account_key`.

### Fix 2: `accumulate_values_into_parents()` - missing parent guard

When a parent account wasn't in the fetched accounts list (e.g., different company or root_type), `parent_account_name` could be `None` or reference a non-existent key.

**Fix:** Add guard to skip accumulation when `parent_account_name` is `None` or not in `accounts_by_name`.

### Enhancement: User warning for skipped accounts

When accounts are skipped because their parent account group is not present in the consolidated view, a warning message is now displayed to the user explaining:
- Which accounts were affected
- That the Chart of Accounts group structure should match between parent and child companies

This helps users diagnose and fix the root cause (misaligned Chart of Accounts) rather than silently handling the edge case.

Fixes #52018
Related: #49771, #35765, #22180

## Test plan

### Automated tests (included)

Unit tests in `test_consolidated_financial_statement.py`:

- `test_skips_account_with_none_parent_account_name_and_shows_warning` - Verifies KeyError is prevented and warning is shown
- `test_skips_account_with_missing_parent_in_accounts_by_name_and_shows_warning` - Verifies missing parent handling with warning
- `test_accumulates_values_when_parent_exists_without_warning` - Ensures normal accumulation works without false warnings
- `test_sets_parent_account_name_with_account_number` - Verifies account_key format with numbers
- `test_sets_parent_account_name_without_account_number` - Verifies plain name format
- `test_returns_none_for_missing_parent` - Documents expected behavior

### Manual testing

1. Set up parent and child companies with Chart of Accounts using account numbers
2. Ensure an account exists in the child company whose parent has an account number
3. Run Consolidated Financial Statement > Balance Sheet
4. Verify the report renders without KeyError
5. If Chart of Accounts groups don't match between companies, verify warning message appears