### PR TITLE
fix: Bin reserved qty for production for extra material transfer

### DIFF
--- a/erpnext/manufacturing/doctype/work_order/test_work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/test_work_order.py
@@ -3725,6 +3725,53 @@ class TestWorkOrder(IntegrationTestCase):
 		wo = make_wo_order_test_record(item="Top Level Parent")
 		self.assertEqual([item.item_code for item in wo.required_items], expected)
 
+	def test_reserved_qty_for_pp_with_extra_material_transfer(self):
+		from erpnext.stock.doctype.stock_entry.test_stock_entry import (
+			make_stock_entry as make_stock_entry_test_record,
+		)
+
+		rm_item_code = make_item(
+			"_Test Reserved Qty PP Item",
+			{
+				"is_stock_item": 1,
+			},
+		).name
+
+		fg_item_code = make_item(
+			"_Test Reserved Qty PP FG Item",
+			{
+				"is_stock_item": 1,
+			},
+		).name
+
+		make_stock_entry_test_record(
+			item_code=rm_item_code, target="_Test Warehouse - _TC", qty=10, basic_rate=100
+		)
+
+		make_bom(
+			item=fg_item_code,
+			raw_materials=[rm_item_code],
+		)
+
+		wo_order = make_wo_order_test_record(
+			item=fg_item_code,
+			qty=1,
+			source_warehouse="_Test Warehouse - _TC",
+			skip_transfer=0,
+			target_warehouse="_Test Warehouse - _TC",
+		)
+
+		bin1_at_completion = get_bin(rm_item_code, "_Test Warehouse - _TC")
+		self.assertEqual(bin1_at_completion.reserved_qty_for_production, 1)
+
+		s = frappe.get_doc(make_stock_entry(wo_order.name, "Material Transfer for Manufacture", 1))
+		s.items[0].qty += 2  # extra material transfer
+		s.submit()
+
+		bin1_at_completion = get_bin(rm_item_code, "_Test Warehouse - _TC")
+
+		self.assertEqual(bin1_at_completion.reserved_qty_for_production, 0)
+
 
 def get_reserved_entries(voucher_no, warehouse=None):
 	doctype = frappe.qb.DocType("Stock Reservation Entry")

--- a/erpnext/manufacturing/doctype/work_order/work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/work_order.py
@@ -2654,6 +2654,9 @@ def get_reserved_qty_for_production(
 		qty_field = wo_item.required_qty
 	else:
 		qty_field = Case()
+		qty_field = qty_field.when(
+			((wo.skip_transfer == 0) & (wo_item.transferred_qty > wo_item.required_qty)), 0.0
+		)
 		qty_field = qty_field.when(wo.skip_transfer == 0, wo_item.required_qty - wo_item.transferred_qty)
 		qty_field = qty_field.else_(wo_item.required_qty - wo_item.consumed_qty)
 


### PR DESCRIPTION
- Make work order
- System will increase the "reserved_qty_for_production'
- Make material transfer entry and increase the qty 
- System will show the "reserved_qty_for_production" in negative