### PR TITLE
fix: prevent precision errors in  discount distribution with inclusive tax

### DIFF
--- a/erpnext/controllers/taxes_and_totals.py
+++ b/erpnext/controllers/taxes_and_totals.py
@@ -671,6 +671,11 @@ class calculate_taxes_and_totals:
 			else:
 				self.grand_total_diff = 0
 
+			# Apply rounding adjustment to grand_total_for_distributing_discount
+			# to prevent precision errors during discount distribution
+			if hasattr(self, "grand_total_for_distributing_discount") and not self.discount_amount_applied:
+				self.grand_total_for_distributing_discount += self.grand_total_diff
+
 	def calculate_totals(self):
 		grand_total_diff = self.grand_total_diff
 

--- a/erpnext/controllers/tests/test_distributed_discount.py
+++ b/erpnext/controllers/tests/test_distributed_discount.py
@@ -59,3 +59,41 @@ class TestTaxesAndTotals(AccountsTestMixin, IntegrationTestCase):
 		self.assertEqual(so.total, 1500)
 		self.assertAlmostEqual(so.net_total, 1272.73, places=2)
 		self.assertEqual(so.grand_total, 1400)
+
+	def test_100_percent_discount_with_inclusive_tax(self):
+		"""Test that 100% discount with inclusive taxes results in zero net_total"""
+		so = make_sales_order(do_not_save=1)
+		so.apply_discount_on = "Grand Total"
+		so.items[0].qty = 2
+		so.items[0].rate = 1300
+		so.append(
+			"taxes",
+			{
+				"charge_type": "On Net Total",
+				"account_head": "_Test Account VAT - _TC",
+				"cost_center": "_Test Cost Center - _TC",
+				"description": "Account VAT",
+				"included_in_print_rate": True,
+				"rate": 9,
+			},
+		)
+		so.append(
+			"taxes",
+			{
+				"charge_type": "On Net Total",
+				"account_head": "_Test Account Service Tax - _TC",
+				"cost_center": "_Test Cost Center - _TC",
+				"description": "Account Service Tax",
+				"included_in_print_rate": True,
+				"rate": 9,
+			},
+		)
+		so.save()
+
+		# Apply 100% discount
+		so.discount_amount = 2600
+		calculate_taxes_and_totals(so)
+
+		# net_total should be exactly 0, not 0.01
+		self.assertEqual(so.net_total, 0)
+		self.assertEqual(so.grand_total, 0)

--- a/erpnext/public/js/controllers/taxes_and_totals.js
+++ b/erpnext/public/js/controllers/taxes_and_totals.js
@@ -623,6 +623,12 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 				} else {
 					me.grand_total_diff = 0;
 				}
+
+				// Apply rounding adjustment to grand_total_for_distributing_discount
+				// to prevent precision errors during discount distribution
+				if (me.grand_total_for_distributing_discount && !me.discount_amount_applied) {
+					me.grand_total_for_distributing_discount += me.grand_total_diff;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Issue:
When applying a 100% discount on Grand Total with tax-inclusive pricing (e.g., GST), `net_total` becomes `0.01` instead of `0`, causing validation errors during GL entry submission.

Steps to replicate:

- change system settings:
  - float precision: 2
  - currency precision: 2
- 2 items @ ₹1,300 each = ₹2,600
- SGST 9% + CGST 9% (included in print rate)
- Apply 100% discount (₹2,600)
- **Expected**: `net_total` = 0
- **Actual**: `net_total` = 0.01

When `adjust_grand_total_for_inclusive_tax()` calculates rounding adjustments for inclusive taxes, it computes a `grand_total_diff` value (e.g., -0.01) to account for rounding discrepancies. However, this adjustment was **not** being applied to `grand_total_for_distributing_discount`, which is the base value used for discount distribution calculations.


closes: https://github.com/frappe/erpnext/issues/52001