### PR TITLE
fix(queries): fix query for multi-db support

### DIFF
--- a/erpnext/assets/doctype/location/location.py
+++ b/erpnext/assets/doctype/location/location.py
@@ -8,6 +8,7 @@ import math
 import frappe
 from frappe.utils import flt
 from frappe.utils.nestedset import NestedSet, update_nsm
+from pypika.functions import Coalesce
 
 EARTH_RADIUS = 6378137
 
@@ -215,18 +216,13 @@ def get_children(doctype, parent=None, location=None, is_root=False):
 	if parent is None or parent == "All Locations":
 		parent = ""
 
-	return frappe.db.sql(
-		f"""
-		select
-			name as value,
-			is_group as expandable
-		from
-			`tabLocation` comp
-		where
-			ifnull(parent_location, "")={frappe.db.escape(parent)}
-		""",
-		as_dict=1,
+	location_tab = frappe.qb.DocType("Location")
+	query = (
+		frappe.qb.from_(location_tab)
+		.select(location_tab.name.as_("value"), location_tab.is_group.as_("expandable"))
+		.where(Coalesce(location_tab.parent_location, "") == parent)
 	)
+	return query.run(as_dict=1)
 
 
 @frappe.whitelist()

--- a/erpnext/controllers/queries.py
+++ b/erpnext/controllers/queries.py
@@ -257,7 +257,7 @@ def item_query(doctype, txt, searchfield, start, page_len, filters, as_dict=Fals
 			if(locate(%(_txt)s, item_name), locate(%(_txt)s, item_name), 99999),
 			idx desc,
 			name, item_name
-		limit %(start)s, %(page_len)s """.format(
+		limit %(page_len)s offset %(start)s """.format(
 			columns=columns,
 			scond=searchfields,
 			fcond=get_filters_cond(doctype, filters, conditions).replace("%", "%%"),


### PR DESCRIPTION
**fix(queries)**: This PR in particular fixes a query that works in MariaDB but breaks in PostgreSQL, so the fix is to refactor the query in a manner that works for both DB's and in turn maintain the original semantics. This PR is part of a long term strategy to provide stable Postgres support in ERPNext as part of a Multi-DB system is related to #24389. Error first spotted in RFQ (Creating a new RFQ).


**Update**: **This PR is (PART 1) of refactoring / fixing queries for future multi-db support (MariaDB / PostgreSQL). Query rewrites will be done in batches (standalone PR's) to avoid overwhelm at 1 merge.**  

**Before**:
```python
Traceback (most recent call last):
...
  File "apps/erpnext/erpnext/controllers/queries.py", line 244, in item_query
    return frappe.db.sql(
           ~~~~~~~~~~~~~^
    	"""select
     ^^^^^^^^^
    ...<28 lines>...
    	as_dict=as_dict,
     ^^^^^^^^^^^^^^^^
    )
    ^
  File "apps/frappe/frappe/database/postgres/database.py", line 234, in sql
    return super().sql(modify_query(query), modify_values(values), *args, **kwargs)
           ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/database/database.py", line 272, in sql
    self.execute_query(query, values)
    ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/database/database.py", line 372, in execute_query
    return self._cursor.execute(query, values)
           ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
psycopg2.errors.SyntaxError: LIMIT #,# syntax is not supported
LINE 16:   limit '0', '10'
           ^
HINT:  Use separate LIMIT and OFFSET clauses.
```

**After**:

Works on both DB's


related to #24389