### PR TITLE
fix(asset capitalization): update asset values using db_set

### DIFF
--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -669,7 +669,10 @@ class Asset(AccountsController):
 	def get_status(self):
 		"""Returns status based on whether it is draft, submitted, scrapped or depreciated"""
 		if self.docstatus == 0:
-			status = "Draft"
+			if self.is_composite_asset:
+				status = "Work In Progress"
+			else:
+				status = "Draft"
 		elif self.docstatus == 1:
 			status = "Submitted"
 

--- a/erpnext/assets/doctype/asset_capitalization/asset_capitalization.py
+++ b/erpnext/assets/doctype/asset_capitalization/asset_capitalization.py
@@ -613,13 +613,19 @@ class AssetCapitalization(StockController):
 		if self.docstatus == 2:
 			gross_purchase_amount = asset_doc.gross_purchase_amount - total_target_asset_value
 			purchase_amount = asset_doc.purchase_amount - total_target_asset_value
-			asset_doc.db_set("total_asset_cost", asset_doc.total_asset_cost - total_target_asset_value)
+			total_asset_cost = asset_doc.total_asset_cost - total_target_asset_value
 		else:
 			gross_purchase_amount = asset_doc.gross_purchase_amount + total_target_asset_value
 			purchase_amount = asset_doc.purchase_amount + total_target_asset_value
+			total_asset_cost = asset_doc.total_asset_cost + total_target_asset_value
 
-		asset_doc.db_set("gross_purchase_amount", gross_purchase_amount)
-		asset_doc.db_set("purchase_amount", purchase_amount)
+		asset_doc.db_set(
+			{
+				"gross_purchase_amount": gross_purchase_amount,
+				"purchase_amount": purchase_amount,
+				"total_asset_cost": total_asset_cost,
+			}
+		)
 
 		frappe.msgprint(
 			_("Asset {0} has been updated. Please set the depreciation details if any and submit it.").format(

--- a/erpnext/assets/doctype/asset_capitalization/asset_capitalization.py
+++ b/erpnext/assets/doctype/asset_capitalization/asset_capitalization.py
@@ -611,14 +611,15 @@ class AssetCapitalization(StockController):
 
 		asset_doc = frappe.get_doc("Asset", self.target_asset)
 		if self.docstatus == 2:
-			asset_doc.gross_purchase_amount -= total_target_asset_value
-			asset_doc.purchase_amount -= total_target_asset_value
+			gross_purchase_amount = asset_doc.gross_purchase_amount - total_target_asset_value
+			purchase_amount = asset_doc.purchase_amount - total_target_asset_value
+			asset_doc.db_set("total_asset_cost", asset_doc.total_asset_cost - total_target_asset_value)
 		else:
-			asset_doc.gross_purchase_amount += total_target_asset_value
-			asset_doc.purchase_amount += total_target_asset_value
-		asset_doc.set_status("Work In Progress")
-		asset_doc.flags.ignore_validate = True
-		asset_doc.save()
+			gross_purchase_amount = asset_doc.gross_purchase_amount + total_target_asset_value
+			purchase_amount = asset_doc.purchase_amount + total_target_asset_value
+
+		asset_doc.db_set("gross_purchase_amount", gross_purchase_amount)
+		asset_doc.db_set("purchase_amount", purchase_amount)
 
 		frappe.msgprint(
 			_("Asset {0} has been updated. Please set the depreciation details if any and submit it.").format(


### PR DESCRIPTION
**Issue:** Unable to cancel the composite Asset when an Asset Capitalization has been posted against it.

**Ref:** [58096](https://support.frappe.io/helpdesk/tickets/58096?)

**Steps to reproduce:**
1) Create a **Composite Asset**.
2) Capitalize the asset using **Asset Capitalization**.
3) Submit the Asset document.
4) Attempt to cancel the **Asset** document.

**Before:**

https://github.com/user-attachments/assets/ca0512ea-9134-4274-bd09-cb34a72d1830


**After:**

https://github.com/user-attachments/assets/35af4f55-7b96-43b6-82a0-3301ae164292



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Composite assets now show "Work In Progress" when in draft, instead of "Draft".
  * Asset capitalization updates now write cost totals more reliably, ensuring changes persist correctly and user feedback remains consistent.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->