### PR TITLE
fix(asset capitalization): update total_asset_cost on asset capitalisation submission

### DIFF
--- a/erpnext/assets/doctype/asset_capitalization/asset_capitalization.py
+++ b/erpnext/assets/doctype/asset_capitalization/asset_capitalization.py
@@ -573,13 +573,19 @@ class AssetCapitalization(StockController):
 		if self.docstatus == 2:
 			net_purchase_amount = asset_doc.net_purchase_amount - total_target_asset_value
 			purchase_amount = asset_doc.purchase_amount - total_target_asset_value
-			asset_doc.db_set("total_asset_cost", asset_doc.total_asset_cost - total_target_asset_value)
+			total_asset_cost = asset_doc.total_asset_cost - total_target_asset_value
 		else:
 			net_purchase_amount = asset_doc.net_purchase_amount + total_target_asset_value
 			purchase_amount = asset_doc.purchase_amount + total_target_asset_value
+			total_asset_cost = asset_doc.total_asset_cost + total_target_asset_value
 
-		asset_doc.db_set("net_purchase_amount", net_purchase_amount)
-		asset_doc.db_set("purchase_amount", purchase_amount)
+		asset_doc.db_set(
+			{
+				"net_purchase_amount": net_purchase_amount,
+				"purchase_amount": purchase_amount,
+				"total_asset_cost": total_asset_cost,
+			}
+		)
 
 		frappe.msgprint(
 			_("Asset {0} has been updated. Please set the depreciation details if any and submit it.").format(


### PR DESCRIPTION
Issue: Upon asset capitalization submission, the system fails to update the **total_asset_cost** field in the Asset document.

Steps to reproduce:

1) Create a **Composite Asset.**
2) Capitalize the asset using **Asset Capitalization**.
3) Submit the Asset document.
4) Observe that **total_asset_cost** in the Asset document remains 0.

Before:

https://github.com/user-attachments/assets/1f3f9b5d-9232-40fa-b672-bb62764c52f6

After:

https://github.com/user-attachments/assets/ab308295-15d4-4eef-90b6-bb832c28382f


