### PR TITLE
fix: duplicate account number (Indonesia COA)

### DIFF
--- a/erpnext/accounts/doctype/account/chart_of_accounts/verified/id_chart_of_accounts.json
+++ b/erpnext/accounts/doctype/account/chart_of_accounts/verified/id_chart_of_accounts.json
@@ -33,6 +33,17 @@
                         }, 
                         "account_number": "1151.000"
                     }, 
+                    "Pajak Dibayar di Muka": {
+                        "PPN Masukan": {
+                            "account_number": "1152.001",
+                            "account_type": "Tax"
+                        },
+                        "PPh 23 Dibayar di Muka": {
+                            "account_number": "1152.002",
+                            "account_type": "Tax"
+                        },
+                        "account_number": "1152.000"
+                    },
                     "account_number": "1150.000"
                 }, 
                 "Kas": {
@@ -96,17 +107,6 @@
                         "account_number": "1132.000"
                     }, 
                     "account_number": "1130.000"
-                },
-                "Pajak Dibayar di Muka": {
-                    "PPN Masukan": {
-                        "account_number": "1151.001", 
-                        "account_type": "Tax"
-                    },
-                    "PPh 23 Dibayar di Muka": {
-                        "account_number": "1152.001", 
-                        "account_type": "Tax"
-                    }, 
-                    "account_number": "1150.000"
                 },
                 "account_number": "1100.000"
                 


### PR DESCRIPTION
**In version 15**,
Accounts (Pajak Dibayar di Muka) with duplicate numbers do not appear:
<img width="1295" height="650" alt="capture_260126_160624" src="https://github.com/user-attachments/assets/bbd3148e-a206-448b-8ece-7d4a49bde4ea" />

After fixed:
<img width="1293" height="624" alt="capture_260126_161547" src="https://github.com/user-attachments/assets/ae89bde1-dc8d-4ebf-b5be-5002604f62ff" />


**In version 16**,
Failed to create new company during and after setup wizard:
<img width="1287" height="415" alt="capture_260126_162859" src="https://github.com/user-attachments/assets/a19a1039-a1a3-4cfb-9a49-ec00f4699077" />

After fixed:
<img width="1269" height="832" alt="capture_260126_162310" src="https://github.com/user-attachments/assets/a7247eaf-de39-4a4b-a142-0a7bc985dd23" />