### PR TITLE
fix(journal-entry): prevent submit failure due to double background queuing

### DIFF
--- a/erpnext/accounts/doctype/journal_entry/journal_entry.py
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.py
@@ -179,7 +179,7 @@ class JournalEntry(AccountsController):
 		validate_docs_for_deferred_accounting([self.name], [])
 
 	def submit(self):
-		if len(self.accounts) > 100:
+		if len(self.accounts) > 100 and not self.meta.queue_in_background:
 			queue_submission(self, "_submit")
 		else:
 			return self._submit()


### PR DESCRIPTION
Don't Queue Journal Entry Submit in Submission Queue if already **Queue in Background** enabled for Journal Entry


**Before:**



https://github.com/user-attachments/assets/914b3dcf-55cf-4f3e-ac6c-17c901e90e03


**After:**



https://github.com/user-attachments/assets/f92a804f-a115-4a06-86b8-09f282576669

