### PR TITLE
fix(shipment): user contact validation to use full name

### DIFF
--- a/erpnext/stock/doctype/shipment/shipment.js
+++ b/erpnext/stock/doctype/shipment/shipment.js
@@ -261,9 +261,9 @@ frappe.ui.form.on("Shipment", {
 		frappe.db.get_value(
 			"User",
 			{ name: frappe.session.user },
-			["full_name", "last_name", "email", "phone", "mobile_no"],
+			["full_name", "email", "phone", "mobile_no"],
 			(r) => {
-				if (!(r.last_name && r.email && (r.phone || r.mobile_no))) {
+				if (!(r.full_name && r.email && (r.phone || r.mobile_no))) {
 					if (delivery_type == "Delivery") {
 						frm.set_value("delivery_company", "");
 						frm.set_value("delivery_contact", "");
@@ -272,9 +272,9 @@ frappe.ui.form.on("Shipment", {
 						frm.set_value("pickup_contact", "");
 					}
 					frappe.throw(
-						__("Last Name, Email or Phone/Mobile of the user are mandatory to continue.") +
+						__("Full Name, Email or Phone/Mobile of the user are mandatory to continue.") +
 							"</br>" +
-							__("Please first set Last Name, Email and Phone for the user") +
+							__("Please first set Full Name, Email and Phone for the user") +
 							` <a href="/app/user/${frappe.session.user}">${frappe.session.user}</a>`
 					);
 				}


### PR DESCRIPTION
**Issue**: Shipment enforces last name for user contact validation inconsistently.

**Fix:** #52034 

**Description:**
While creating a Shipment, ERPNext enforces that the logged-in user must have Last Name, Email, and Phone/Mobile set before allowing the document to proceed.

**Before:**

<img width="1883" height="985" alt="before" src="https://github.com/user-attachments/assets/6f09d3f1-9a41-4944-a3c3-7a0bee36c973" />


**After:**

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/c731e3cd-44c2-4a73-af4a-6dd2eac0d27e" />
