### PR TITLE
fix: missing depr_series causing error on jv creation

### DIFF
--- a/erpnext/assets/doctype/asset/depreciation.py
+++ b/erpnext/assets/doctype/asset/depreciation.py
@@ -246,7 +246,9 @@ def _make_journal_entry_for_depreciation(
 
 def setup_journal_entry_metadata(je, depr_schedule_doc, depr_series, depr_schedule, asset):
 	je.voucher_type = "Depreciation Entry"
-	je.naming_series = depr_series
+	if depr_series:
+		je.naming_series = depr_series
+
 	je.posting_date = depr_schedule.schedule_date
 	je.company = asset.company
 	je.finance_book = depr_schedule_doc.finance_book


### PR DESCRIPTION
Asset Depreciation Naming Series is not a mandatory field in company.
Scrapping an asset creates a JV and if this series is not set, it will throw an error saying naming series in mandatory.

This PR check if that field is populated and only if it is, then proceeds to set the naming series.