### PR TITLE
fix(RFQ): render email templates for preview and sending

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -60,7 +60,7 @@ body:
       description: Share exact version number of Frappe and ERPNext you are using.
       placeholder: |
         Frappe version -
-        ERPNext Verion -
+        ERPNext version -
     validations:
       required: true
 

--- a/erpnext/buying/doctype/request_for_quotation/request_for_quotation.py
+++ b/erpnext/buying/doctype/request_for_quotation/request_for_quotation.py
@@ -304,12 +304,17 @@ class RequestforQuotation(BuyingController):
 		else:
 			sender = frappe.session.user not in STANDARD_USERS and frappe.session.user or None
 
+		rendered_message = frappe.render_template(self.message_for_supplier, doc_args)
+		subject_source = (
+			self.subject
+			or frappe.get_value("Email Template", self.email_template, "subject")
+			or _("Request for Quotation")
+		)
+		rendered_subject = frappe.render_template(subject_source, doc_args)
 		if preview:
 			return {
-				"message": self.message_for_supplier,
-				"subject": self.subject
-				or frappe.get_value("Email Template", self.email_template, "subject")
-				or _("Request for Quotation"),
+				"message": rendered_message,
+				"subject": rendered_subject,
 			}
 
 		attachments = []
@@ -333,10 +338,8 @@ class RequestforQuotation(BuyingController):
 		self.send_email(
 			data,
 			sender,
-			self.subject
-			or frappe.get_value("Email Template", self.email_template, "subject")
-			or _("Request for Quotation"),
-			self.message_for_supplier,
+			rendered_subject,
+			rendered_message,
 			attachments,
 		)
 


### PR DESCRIPTION
**fix(RFQ)**: This PR is a direct resolution of issue #52091 for wherein the RFQ feature emails were sent raw. This PR resolves that by first rendering the `subject` and the `message` thus allowing the correct preview and appropriately rendered mail to be sent to respective user. 


**Before**:

<img width="2880" height="1072" alt="image" src="https://github.com/user-attachments/assets/d92653cb-fae8-47f5-8ffb-a3af4f2ce0c1" />

**After**:

Preview:
<img width="2880" height="1072" alt="image" src="https://github.com/user-attachments/assets/a0fb72d4-73cb-4b14-9db8-192a8fa63878" />

Email:
<img width="1444" height="434" alt="image" src="https://github.com/user-attachments/assets/2ea11f00-4949-43c6-a381-771674bbecaf" />


closes #52091