### PR TITLE
fix(stock): use purchase UOM in Supplier Quotation items

### DIFF
--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -421,9 +421,10 @@ def get_basic_details(args, item, overwrite_warehouse=True):
 	if not args.get("uom"):
 		if args.get("doctype") in sales_doctypes:
 			args.uom = item.sales_uom if item.sales_uom else item.stock_uom
-		elif (args.get("doctype") in ["Purchase Order", "Purchase Receipt", "Purchase Invoice"]) or (
-			args.get("doctype") == "Material Request" and args.get("material_request_type") == "Purchase"
-		):
+		elif (
+			args.get("doctype")
+			in ["Purchase Order", "Purchase Receipt", "Purchase Invoice", "Supplier Quotation"]
+		) or (args.get("doctype") == "Material Request" and args.get("material_request_type") == "Purchase"):
 			args.uom = item.purchase_uom if item.purchase_uom else item.stock_uom
 		else:
 			args.uom = item.stock_uom


### PR DESCRIPTION
Backport of PR [#51999](https://github.com/frappe/erpnext/pull/51999) to Version-15

Ticket Ref :[#58134](https://support.frappe.io/helpdesk/tickets/58134)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Supplier Quotation documents now correctly use the purchase unit of measure, consistent with other purchase document types. This ensures uniform unit of measure handling across all purchase-related documents.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->