### PR TITLE
fix: default item cost center from parent when empty

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -1261,8 +1261,15 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 		this.frm.refresh_field("payment_schedule");
 	}
 
-	cost_center(doc, cdt, cdn) {
-		erpnext.utils.copy_value_in_all_rows(doc, cdt, cdn, "items", "cost_center");
+	cost_center(doc) {
+		const parent_cc = doc.cost_center;
+		if (!parent_cc) return;
+
+		(doc.items || []).forEach((row) => {
+			if (!row.cost_center) {
+				frappe.model.set_value(row.doctype, row.name, "cost_center", parent_cc);
+			}
+		});
 	}
 
 	due_date(doc, cdt, cdn) {


### PR DESCRIPTION
**Issue**:
The Default Cost Center set in Session Defaults is correctly applied to the invoice header but not applied to item rows in both Sales Invoice and Purchase Invoice.
Instead, item rows fall back to the Company Default Cost Center, causing inconsistency.

**Ref:**[#58469](https://support.frappe.io/helpdesk/tickets/58469)

**Before**:



<img width="1734" height="942" alt="image" src="https://github.com/user-attachments/assets/d8abc858-e3ef-4e0d-a16f-e294b97f92dd" />

<img width="1693" height="986" alt="image" src="https://github.com/user-attachments/assets/863a4483-04df-4298-8790-2cf9b5e2ef57" />


**After**:

<img width="1600" height="776" alt="image" src="https://github.com/user-attachments/assets/c93124f0-77d1-43ca-bdf8-dfc47f4e5419" />

<img width="1912" height="862" alt="image" src="https://github.com/user-attachments/assets/12ffacaf-81c3-4379-9c8d-6d622e9e806d" />



