### PR TITLE
feat: Adding closing purchase order individually at item level

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -2831,6 +2831,8 @@ def get_reference_details(
 			party_field = "customer" if reference_doctype == "Sales Order" else "supplier"
 			party = ref_doc.get(party_field)
 			account = get_party_account(party_type, party, ref_doc.company)
+			if reference_doctype == "Purchase Order":
+				total_amount, outstanding_amount = ref_doc.get_revised_total_based_on_closed_items()
 	else:
 		# Get the exchange rate based on the posting date of the ref doc.
 		exchange_rate = get_exchange_rate(party_account_currency, company_currency, ref_doc.posting_date)
@@ -2880,7 +2882,8 @@ def get_payment_entry(
 	grand_total, outstanding_amount = set_grand_total_and_outstanding_amount(
 		party_amount, dt, party_account_currency, doc
 	)
-
+	if dt == "Purchase Order":
+		grand_total, outstanding_amount = doc.get_revised_total_based_on_closed_items()
 	# bank or cash
 	bank = get_bank_cash_account(doc, bank_account)
 

--- a/erpnext/accounts/doctype/payment_request/payment_request.py
+++ b/erpnext/accounts/doctype/payment_request/payment_request.py
@@ -815,7 +815,10 @@ def get_amount(ref_doc, payment_account=None):
 		if ref_doc.party_account_currency != ref_doc.currency:
 			advance_amount = flt(flt(ref_doc.advance_paid) / ref_doc.conversion_rate)
 
-		grand_total = (flt(ref_doc.rounded_total) or flt(ref_doc.grand_total)) - advance_amount
+		if dt == "Purchase Order":
+			grand_total = flt(ref_doc.get_revised_total_based_on_closed_items()[0]) - advance_amount
+		else:
+			grand_total = (flt(ref_doc.rounded_total) or flt(ref_doc.grand_total)) - advance_amount
 
 	elif dt in ["Sales Invoice", "Purchase Invoice"]:
 		if (

--- a/erpnext/buying/doctype/purchase_order/purchase_order.js
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.js
@@ -30,6 +30,8 @@ frappe.ui.form.on("Purchase Order", {
 				color = "yellow";
 			} else if (doc.qty <= doc.received_qty) {
 				color = "green";
+			} else if (doc.is_closed) {
+				color = "red";
 			} else {
 				color = "orange";
 			}
@@ -346,9 +348,16 @@ erpnext.buying.PurchaseOrderController = class PurchaseOrderController extends (
 								__("Status")
 							);
 						}
+
 						this.frm.add_custom_button(
-							__("Close"),
-							() => this.close_purchase_order(),
+							__("Close Items"),
+							() => this.close_selected_items(),
+							__("Status")
+						);
+
+						this.frm.add_custom_button(
+							__("Re-open Items"),
+							() => this.reopen_selected_items(),
 							__("Status")
 						);
 					}
@@ -712,9 +721,201 @@ erpnext.buying.PurchaseOrderController = class PurchaseOrderController extends (
 	unclose_purchase_order() {
 		this.frm.cscript.update_status("Re-open", "Submitted");
 	}
-
 	close_purchase_order() {
 		this.frm.cscript.update_status("Close", "Closed");
+	}
+	reopen_selected_items() {
+		var me = this;
+		this.data = this.frm.doc.items
+			.filter((d) => d.is_closed)
+			.map((d) => {
+				return {
+					docname: d.name,
+					item_code: d.item_code,
+					qty: d.qty,
+					received_qty: d.received_qty,
+					is_closed: d.is_closed,
+				};
+			});
+		const reopen_item_fields = [
+			{
+				fieldtype: "Link",
+				fieldname: "item_code",
+				options: "Item",
+				in_list_view: 1,
+				label: "Item Code",
+				read_only: 1,
+			},
+			{
+				fieldtype: "Float",
+				fieldname: "qty",
+				label: "Qty",
+				read_only: 1,
+				in_list_view: 1,
+			},
+		];
+
+		var d = new frappe.ui.Dialog({
+			title: __("Re-open Selected Items"),
+			size: "large",
+			fields: [
+				{
+					fieldname: "select_all",
+					fieldtype: "Check",
+					label: __("Select all items"),
+					default: 1,
+					onchange: function (e) {
+						const table_field = d.get_field("reopen_items");
+						table_field.df.hidden = this.get_value();
+						table_field.refresh();
+					},
+				},
+				{
+					fieldname: "reopen_items",
+					fieldtype: "Table",
+					label: __("Items"),
+					fields: reopen_item_fields,
+					cannot_add_row: true,
+					in_place_edit: true,
+					hidden: true,
+					data: me.data,
+					get_data: function () {
+						return me.data;
+					},
+				},
+			],
+			primary_action_label: __("Re-open"),
+			primary_action: function () {
+				let values = d.get_values();
+
+				if (values.select_all) {
+					me.unclose_purchase_order();
+					d.hide();
+					return;
+				}
+				let selected_items = (values.reopen_items || []).filter((row) => row.__checked);
+				if (!selected_items.length) {
+					frappe.msgprint(__("Please select at least one item to re-open"));
+					return;
+				}
+				frappe.call({
+					method: "erpnext.buying.doctype.purchase_order.purchase_order.close_or_reopen_selected_items",
+					args: {
+						purchase_order: me.frm.doc.name,
+						selected_items: JSON.stringify(selected_items),
+						status: "Re-open",
+					},
+					callback: function (r) {
+						if (!r.exc) {
+							d.hide();
+							me.frm.reload_doc();
+							frappe.show_alert({
+								message: __("Selected items re-opened successfully"),
+								indicator: "green",
+							});
+						}
+					},
+				});
+			},
+		});
+		d.show();
+	}
+	close_selected_items() {
+		var me = this;
+		this.data = this.frm.doc.items
+			.filter((d) => d.qty > flt(d.received_qty) && !d.is_closed)
+			.map((d) => {
+				return {
+					docname: d.name,
+					item_code: d.item_code,
+					qty: d.qty,
+					received_qty: d.received_qty,
+					is_closed: d.is_closed,
+				};
+			});
+		const close_item_fields = [
+			{
+				fieldtype: "Link",
+				fieldname: "item_code",
+				options: "Item",
+				in_list_view: 1,
+				label: "Item Code",
+				read_only: 1,
+			},
+			{
+				fieldtype: "Float",
+				fieldname: "qty",
+				label: "Qty",
+				read_only: 1,
+				in_list_view: 1,
+			},
+		];
+
+		var d = new frappe.ui.Dialog({
+			title: __("Close Selected Items"),
+			size: "large",
+			fields: [
+				{
+					fieldname: "select_all",
+					fieldtype: "Check",
+					label: __("Select all items"),
+					default: 1,
+					onchange: function (e) {
+						const table_field = d.get_field("close_items");
+						table_field.df.hidden = this.get_value();
+						table_field.refresh();
+					},
+				},
+				{
+					fieldname: "close_items",
+					fieldtype: "Table",
+					label: __("Items"),
+					fields: close_item_fields,
+					cannot_add_row: true,
+					in_place_edit: true,
+					data: me.data,
+					hidden: true,
+					get_data: function () {
+						return me.data;
+					},
+				},
+			],
+			primary_action_label: __("Close"),
+			primary_action: function () {
+				let values = d.get_values();
+
+				let selected_items = (values.close_items || []).filter((row) => row.__checked);
+				if (selected_items.length == me.data.length || values.select_all) {
+					me.close_purchase_order();
+					d.hide();
+					return;
+				}
+				if (!selected_items.length) {
+					frappe.msgprint(__("Please select at least one item to close"));
+					return;
+				}
+				console.log(selected_items);
+				frappe.call({
+					method: "erpnext.buying.doctype.purchase_order.purchase_order.close_or_reopen_selected_items",
+					args: {
+						purchase_order: me.frm.doc.name,
+						selected_items: JSON.stringify(selected_items),
+						status: "Closed",
+					},
+					callback: function (r) {
+						if (!r.exc) {
+							d.hide();
+							me.frm.reload_doc();
+							frappe.show_alert({
+								message: __("Selected items closed successfully"),
+								indicator: "green",
+							});
+						}
+					},
+				});
+			},
+		});
+		d.show();
 	}
 
 	delivered_by_supplier() {

--- a/erpnext/buying/doctype/purchase_order/purchase_order.js
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.js
@@ -351,13 +351,13 @@ erpnext.buying.PurchaseOrderController = class PurchaseOrderController extends (
 
 						this.frm.add_custom_button(
 							__("Close Items"),
-							() => this.close_selected_items(),
+							() => this.close_or_reopen_selected_items("Closed"),
 							__("Status")
 						);
 
 						this.frm.add_custom_button(
 							__("Re-open Items"),
-							() => this.reopen_selected_items(),
+							() => this.close_or_reopen_selected_items("Re-open"),
 							__("Status")
 						);
 					}
@@ -724,116 +724,38 @@ erpnext.buying.PurchaseOrderController = class PurchaseOrderController extends (
 	close_purchase_order() {
 		this.frm.cscript.update_status("Close", "Closed");
 	}
-	reopen_selected_items() {
+
+	close_or_reopen_selected_items(status) {
 		var me = this;
-		this.data = this.frm.doc.items
-			.filter((d) => d.is_closed)
-			.map((d) => {
-				return {
-					docname: d.name,
-					item_code: d.item_code,
-					qty: d.qty,
-					received_qty: d.received_qty,
-					is_closed: d.is_closed,
-				};
-			});
-		const reopen_item_fields = [
-			{
-				fieldtype: "Link",
-				fieldname: "item_code",
-				options: "Item",
-				in_list_view: 1,
-				label: "Item Code",
-				read_only: 1,
-			},
-			{
-				fieldtype: "Float",
-				fieldname: "qty",
-				label: "Qty",
-				read_only: 1,
-				in_list_view: 1,
-			},
-		];
-
-		var d = new frappe.ui.Dialog({
-			title: __("Re-open Selected Items"),
-			size: "large",
-			fields: [
-				{
-					fieldname: "select_all",
-					fieldtype: "Check",
-					label: __("Select all items"),
-					default: 1,
-					onchange: function (e) {
-						const table_field = d.get_field("reopen_items");
-						table_field.df.hidden = this.get_value();
-						table_field.refresh();
-					},
-				},
-				{
-					fieldname: "reopen_items",
-					fieldtype: "Table",
-					label: __("Items"),
-					fields: reopen_item_fields,
-					cannot_add_row: true,
-					in_place_edit: true,
-					hidden: true,
-					data: me.data,
-					get_data: function () {
-						return me.data;
-					},
-				},
-			],
-			primary_action_label: __("Re-open"),
-			primary_action: function () {
-				let values = d.get_values();
-
-				if (values.select_all) {
-					me.unclose_purchase_order();
-					d.hide();
-					return;
-				}
-				let selected_items = (values.reopen_items || []).filter((row) => row.__checked);
-				if (!selected_items.length) {
-					frappe.msgprint(__("Please select at least one item to re-open"));
-					return;
-				}
-				frappe.call({
-					method: "erpnext.buying.doctype.purchase_order.purchase_order.close_or_reopen_selected_items",
-					args: {
-						purchase_order: me.frm.doc.name,
-						selected_items: JSON.stringify(selected_items),
-						status: "Re-open",
-					},
-					callback: function (r) {
-						if (!r.exc) {
-							d.hide();
-							me.frm.reload_doc();
-							frappe.show_alert({
-								message: __("Selected items re-opened successfully"),
-								indicator: "green",
-							});
-						}
-					},
+		if (status == "Closed") {
+			this.data = this.frm.doc.items
+				.filter((d) => d.qty > flt(d.received_qty) && !d.is_closed)
+				.map((d) => {
+					return {
+						docname: d.name,
+						item_code: d.item_code,
+						qty: d.qty,
+						received_qty: d.received_qty,
+						is_closed: d.is_closed,
+						__checked: 1,
+					};
 				});
-			},
-		});
-		d.show();
-	}
-	close_selected_items() {
-		var me = this;
-		this.data = this.frm.doc.items
-			.filter((d) => d.qty > flt(d.received_qty) && !d.is_closed)
-			.map((d) => {
-				return {
-					docname: d.name,
-					item_code: d.item_code,
-					qty: d.qty,
-					received_qty: d.received_qty,
-					is_closed: d.is_closed,
-				};
-			});
-		const close_item_fields = [
+		} else if (status == "Re-open") {
+			this.data = this.frm.doc.items
+				.filter((d) => d.is_closed)
+				.map((d) => {
+					return {
+						docname: d.name,
+						item_code: d.item_code,
+						qty: d.qty,
+						received_qty: d.received_qty,
+						is_closed: d.is_closed,
+						__checked: 1,
+					};
+				});
+		}
+
+		const item_fields = [
 			{
 				fieldtype: "Link",
 				fieldname: "item_code",
@@ -852,62 +774,45 @@ erpnext.buying.PurchaseOrderController = class PurchaseOrderController extends (
 		];
 
 		var d = new frappe.ui.Dialog({
-			title: __("Close Selected Items"),
+			title: __("" + status + " Selected Items"),
 			size: "large",
 			fields: [
 				{
-					fieldname: "select_all",
-					fieldtype: "Check",
-					label: __("Select all items"),
-					default: 1,
-					onchange: function (e) {
-						const table_field = d.get_field("close_items");
-						table_field.df.hidden = this.get_value();
-						table_field.refresh();
-					},
-				},
-				{
-					fieldname: "close_items",
+					fieldname: "items",
 					fieldtype: "Table",
 					label: __("Items"),
-					fields: close_item_fields,
+					fields: item_fields,
 					cannot_add_row: true,
 					in_place_edit: true,
 					data: me.data,
-					hidden: true,
 					get_data: function () {
 						return me.data;
 					},
 				},
 			],
-			primary_action_label: __("Close"),
+			primary_action_label: status == "Closed" ? __("Close") : __("Re-open"),
 			primary_action: function () {
 				let values = d.get_values();
+				let selected_items = (values.items || []).filter((row) => row.__checked);
 
-				let selected_items = (values.close_items || []).filter((row) => row.__checked);
-				if (selected_items.length == me.data.length || values.select_all) {
-					me.close_purchase_order();
-					d.hide();
-					return;
-				}
 				if (!selected_items.length) {
-					frappe.msgprint(__("Please select at least one item to close"));
+					frappe.msgprint(__("Please select at least one item to " + status.toLowerCase()));
 					return;
 				}
-				console.log(selected_items);
+
 				frappe.call({
 					method: "erpnext.buying.doctype.purchase_order.purchase_order.close_or_reopen_selected_items",
 					args: {
 						purchase_order: me.frm.doc.name,
 						selected_items: JSON.stringify(selected_items),
-						status: "Closed",
+						status: status,
 					},
 					callback: function (r) {
 						if (!r.exc) {
 							d.hide();
 							me.frm.reload_doc();
 							frappe.show_alert({
-								message: __("Selected items closed successfully"),
+								message: __("Selected items " + status.toLowerCase() + " successfully"),
 								indicator: "green",
 							});
 						}

--- a/erpnext/buying/doctype/purchase_order/purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.py
@@ -1051,7 +1051,7 @@ def close_or_reopen_selected_items(purchase_order, status, selected_items=None, 
 				frappe.throw(_("Cannot close item {0} as it is fully received").format(row.item_code))
 
 			row.is_closed = 1
-		elif status == "Submitted":
+		elif status == "Submitted" or status == "Re-open":
 			row.is_closed = 0
 
 	po.save()

--- a/erpnext/buying/doctype/purchase_order/purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.py
@@ -3,6 +3,7 @@
 
 
 import json
+from urllib.parse import parse_qs
 
 import frappe
 from frappe import _, msgprint
@@ -437,13 +438,18 @@ class PurchaseOrder(BuyingController):
 			)
 
 	def update_status(self, status):
-		self.check_modified_date()
-		self.set_status(update=True, status=status)
-		self.update_requested_qty()
-		self.update_ordered_qty()
-		self.update_reserved_qty_for_subcontract()
-		self.update_subcontracting_order_status()
-		self.update_blanket_order()
+		if status == "Closed":
+			close_or_reopen_selected_items(self.name, status="Closed", all_items_closed=True)
+		elif status in ["Submitted", "Re-open"]:
+			close_or_reopen_selected_items(self.name, status="Re-open", all_items_closed=True)
+		else:
+			self.check_modified_date()
+			self.set_status(update=True, status=status)
+			self.update_requested_qty()
+			self.update_ordered_qty()
+			self.update_reserved_qty_for_subcontract()
+			self.update_subcontracting_order_status()
+			self.update_blanket_order()
 		self.notify_update()
 		clear_doctype_notifications(self)
 
@@ -658,6 +664,13 @@ class PurchaseOrder(BuyingController):
 			if sco:
 				update_sco_status(sco, "Closed" if self.status == "Closed" else None)
 
+	def get_revised_total_based_on_closed_items(self):
+		for item in self.items:
+			if item.is_closed == 1:
+				self.grand_total -= item.amount
+		self.outstanding_amount = self.grand_total - flt(self.advance_paid)
+		return self.grand_total, self.outstanding_amount
+
 
 @frappe.request_cache
 def item_last_purchase_rate(name, conversion_rate, item_code, conversion_factor=1.0):
@@ -760,6 +773,7 @@ def make_purchase_receipt(
 					True if is_unit_price_row(doc) else abs(doc.received_qty) < abs(doc.qty)
 				)
 				and doc.delivered_by_supplier != 1
+				and doc.is_closed != 1
 				and select_item(doc),
 			},
 			"Purchase Taxes and Charges": {"doctype": "Purchase Taxes and Charges", "reset_value": True},
@@ -858,7 +872,8 @@ def get_mapped_purchase_invoice(source_name, target_doc=None, ignore_permissions
 			},
 			"postprocess": update_item,
 			"condition": lambda doc: (doc.base_amount == 0 or abs(doc.billed_amt) < abs(doc.amount))
-			and select_item(doc),
+			and select_item(doc)
+			and doc.is_closed != 1,
 		},
 		"Purchase Taxes and Charges": {"doctype": "Purchase Taxes and Charges", "reset_value": True},
 	}
@@ -1014,3 +1029,48 @@ def get_mapped_subcontracting_order(source_name, target_doc=None):
 	)
 
 	return target_doc
+
+
+@frappe.whitelist()
+def close_or_reopen_selected_items(purchase_order, status, selected_items=None, all_items_closed=False):
+	items = []
+	po = frappe.get_lazy_doc("Purchase Order", purchase_order)
+	po.check_modified_date()
+	if po.is_subcontracted or po.is_old_subcontracting_flow:
+		frappe.throw(_("Cannot Close items for Subcontracted Purchase Order {0}.").format(po.name))
+	if not all_items_closed:
+		selected_items = frappe.parse_json(selected_items)
+		items = {i["docname"]: i for i in selected_items}
+
+	for row in po.items:
+		if not all_items_closed and row.name not in items:
+			continue
+
+		if status == "Closed":
+			if flt(row.received_qty) and flt(row.received_qty) == flt(row.qty) and not all_items_closed:
+				frappe.throw(_("Cannot close item {0} as it is fully received").format(row.item_code))
+
+			row.is_closed = 1
+		elif status == "Submitted":
+			row.is_closed = 0
+
+	po.save()
+	if len(items) > 0:
+		po_item_rows = [frappe.get_doc("Purchase Order Item", item_name) for item_name in items.keys()]
+		po.update_requested_qty(items=po_item_rows)
+		po.update_ordered_qty(po_item_rows=items)
+		po.update_blanket_order(items=po_item_rows)
+	else:
+		po.set_status(update=True, status=status)
+		po.update_requested_qty()
+		po.update_ordered_qty()
+		po.update_reserved_qty_for_subcontract()
+		po.update_subcontracting_order_status()
+		po.update_blanket_order()
+
+	if not all_items_closed and all(d.is_closed for d in po.items):
+		po.db_set("status", "Closed")
+		po.update_reserved_qty_for_subcontract()
+		po.update_subcontracting_order_status()
+		po.notify_update()
+		clear_doctype_notifications(po)

--- a/erpnext/buying/doctype/purchase_order/test_purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/test_purchase_order.py
@@ -12,6 +12,7 @@ from frappe.utils.data import today
 from erpnext.accounts.doctype.payment_entry.payment_entry import get_payment_entry
 from erpnext.accounts.party import get_due_date_from_template
 from erpnext.buying.doctype.purchase_order.purchase_order import (
+	close_or_reopen_selected_items,
 	make_inter_company_sales_order,
 	make_purchase_receipt,
 )
@@ -29,6 +30,101 @@ from erpnext.stock.doctype.purchase_receipt.purchase_receipt import (
 
 
 class TestPurchaseOrder(IntegrationTestCase):
+	def test_close_purchase_order_individually(self):
+		warehouse = "_Test Warehouse - _TC"
+		supplier = "_Test Supplier"
+
+		item_1 = make_item("_Test PO Item Level Closing 1", {"is_stock_item": 1})
+		item_2 = make_item("_Test PO Item Level Closing 2", {"is_stock_item": 1})
+		item_3 = make_item("_Test PO Item Level Closing 3", {"is_stock_item": 1})
+		po = create_purchase_order(
+			supplier=supplier,
+			rm_items=[
+				{
+					"item_code": item_1.item_code,
+					"qty": 2,
+					"rate": 100,
+					"warehouse": warehouse,
+					"schedule_date": add_days(nowdate(), 1),
+				},
+				{
+					"item_code": item_2.item_code,
+					"qty": 3,
+					"rate": 100,
+					"warehouse": warehouse,
+					"schedule_date": add_days(nowdate(), 1),
+				},
+				{
+					"item_code": item_3.item_code,
+					"qty": 4,
+					"rate": 100,
+					"warehouse": warehouse,
+					"schedule_date": add_days(nowdate(), 1),
+				},
+			],
+			do_not_submit=True,
+		)
+		po.submit()
+		pr = make_purchase_receipt(
+			po.name,
+			args={"filtered_children": [po.items[0].name]},
+		)
+		pr.submit()
+		po.reload()
+		self.assertEqual(po.items[0].received_qty, 2)
+		self.assertEqual(
+			frappe.get_all(
+				"Bin",
+				filters={
+					"item_code": po.items[1].item_code,
+					"warehouse": po.items[1].warehouse,
+				},
+				fields=["ordered_qty"],
+			)[0].ordered_qty,
+			3,
+		)
+
+		close_or_reopen_selected_items(
+			po.name,
+			"Closed",
+			json.dumps([{"docname": po.items[1].name}]),
+		)
+
+		po.reload()
+		self.assertEqual(
+			frappe.get_all(
+				"Bin",
+				filters={
+					"item_code": po.items[1].item_code,
+					"warehouse": po.items[1].warehouse,
+				},
+				fields=["ordered_qty"],
+			)[0].ordered_qty,
+			0,
+		)
+
+		pr = make_purchase_receipt(po.name)
+		self.assertEqual(len(pr.get("items")), 1)
+
+		close_or_reopen_selected_items(
+			po.name,
+			"Submitted",
+			json.dumps([{"docname": po.items[1].name}]),
+		)
+
+		po.reload()
+		self.assertEqual(
+			frappe.get_all(
+				"Bin",
+				filters={
+					"item_code": po.items[1].item_code,
+					"warehouse": po.items[1].warehouse,
+				},
+				fields=["ordered_qty"],
+			)[0].ordered_qty,
+			3,
+		)
+
 	def test_purchase_order_qty(self):
 		po = create_purchase_order(qty=1, do_not_save=True)
 

--- a/erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
+++ b/erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
@@ -14,6 +14,7 @@
   "item_name",
   "brand",
   "product_bundle",
+  "is_closed",
   "column_break_4",
   "schedule_date",
   "expected_delivery_date",
@@ -935,6 +936,14 @@
    "no_copy": 1,
    "non_negative": 1,
    "read_only": 1
+  },
+  {
+   "allow_on_submit": 1,
+   "default": "0",
+   "fieldname": "is_closed",
+   "fieldtype": "Check",
+   "label": "Is Closed",
+   "read_only": 1
   }
  ],
  "grid_page_length": 50,
@@ -942,7 +951,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-10-30 16:51:56.761673",
+ "modified": "2026-01-25 12:39:34.079129",
  "modified_by": "Administrator",
  "module": "Buying",
  "name": "Purchase Order Item",

--- a/erpnext/buying/doctype/purchase_order_item/purchase_order_item.py
+++ b/erpnext/buying/doctype/purchase_order_item/purchase_order_item.py
@@ -44,6 +44,7 @@ class PurchaseOrderItem(Document):
 		from_warehouse: DF.Link | None
 		image: DF.Attach | None
 		include_exploded_items: DF.Check
+		is_closed: DF.Check
 		is_fixed_asset: DF.Check
 		is_free_item: DF.Check
 		item_code: DF.Link

--- a/erpnext/controllers/stock_controller.py
+++ b/erpnext/controllers/stock_controller.py
@@ -1454,8 +1454,10 @@ class StockController(AccountsController):
 			else:
 				frappe.msgprint(msg, alert=True, indicator="orange")
 
-	def update_blanket_order(self):
-		blanket_orders = list(set([d.blanket_order for d in self.items if d.blanket_order]))
+	def update_blanket_order(self, items=None):
+		if not items:
+			items = self.items
+		blanket_orders = list(set([d.blanket_order for d in items if d.blanket_order]))
 		for blanket_order in blanket_orders:
 			frappe.get_doc("Blanket Order", blanket_order).update_ordered_qty()
 

--- a/erpnext/controllers/subcontracting_controller.py
+++ b/erpnext/controllers/subcontracting_controller.py
@@ -1321,9 +1321,11 @@ class SubcontractingController(StockController):
 
 		return self._sub_contracted_items
 
-	def update_requested_qty(self):
+	def update_requested_qty(self, items=None):
 		material_request_map = {}
-		for d in self.get("items"):
+		if not items:
+			items = self.get("items")
+		for d in items:
 			if d.material_request_item:
 				material_request_map.setdefault(d.material_request, []).append(d.material_request_item)
 

--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -609,24 +609,32 @@ erpnext.utils.update_child_items = function (opts) {
 	const child_meta = frappe.get_meta(`${frm.doc.doctype} Item`);
 	const has_reserved_stock = opts.has_reserved_stock ? true : false;
 	const get_precision = (fieldname) => child_meta.fields.find((f) => f.fieldname == fieldname).precision;
+	const is_purchase_order = frm.doc.doctype === "Purchase Order";
 
-	this.data = frm.doc[opts.child_docname].map((d) => {
-		return {
-			docname: d.name,
-			name: d.name,
-			item_code: d.item_code,
-			item_name: d.item_name,
-			delivery_date: d.delivery_date,
-			schedule_date: d.schedule_date,
-			conversion_factor: d.conversion_factor,
-			qty: d.qty,
-			rate: d.rate,
-			uom: d.uom,
-			fg_item: d.fg_item,
-			fg_item_qty: d.fg_item_qty,
-			description: d.description,
-		};
-	});
+	this.data = frm.doc[opts.child_docname]
+		.filter((d) => {
+			if (is_purchase_order) {
+				return !d.is_closed;
+			}
+			return true;
+		})
+		.map((d) => {
+			return {
+				docname: d.name,
+				name: d.name,
+				item_code: d.item_code,
+				item_name: d.item_name,
+				delivery_date: d.delivery_date,
+				schedule_date: d.schedule_date,
+				conversion_factor: d.conversion_factor,
+				qty: d.qty,
+				rate: d.rate,
+				uom: d.uom,
+				fg_item: d.fg_item,
+				fg_item_qty: d.fg_item_qty,
+				description: d.description,
+			};
+		});
 
 	const fields = [
 		{

--- a/erpnext/stock/stock_balance.py
+++ b/erpnext/stock/stock_balance.py
@@ -212,6 +212,7 @@ def get_purchase_order_qty(item_code, warehouse):
 			& (PurchaseOrder.status.notin(["Closed", "Delivered"]))
 			& (PurchaseOrder.docstatus == 1)
 			& (Coalesce(PurchaseOrderItem.delivered_by_supplier, 0) == 0)
+			& (Coalesce(PurchaseOrderItem.is_closed, 0) == 0)
 		)
 		.run()
 	)


### PR DESCRIPTION
The following adds the feature of allowing purchase order to be closed at individual level. This covers the following scenario: 

- For items that have been received, they cannot be closed
- For items that are closed can be individually opened as well 
- For the corresponding payment request and entry that gets made from the purchase order reflects the total amount based on open item entries only
- For update items it will only display the open items in Purchase order 

With reference to https://github.com/frappe/erpnext/issues/46766