### PR TITLE
fix: escape TCS/TDS account names to avoid % format errors

### DIFF
--- a/erpnext/patches/v16_0/migrate_tax_withholding_data.py
+++ b/erpnext/patches/v16_0/migrate_tax_withholding_data.py
@@ -922,6 +922,7 @@ def migrate_sales_invoices(tds_accounts, tax_rate_map, column_cache, party_tax_i
 	# Get Sales Invoices with TCS amounts aggregated
 	# Use conditional sum to aggregate TCS amounts only from TCS accounts
 	tcs_accounts_list = list(all_tcs_accounts)
+	tcs_accounts_list = [frappe.db.escape(acc) for acc in tcs_accounts_list]
 
 	tcs_entries = (
 		frappe.qb.from_(si)


### PR DESCRIPTION
Issue: During execution of the tax withholding data migration, the process fails while aggregating TDS/TCS amounts when the TDS/TCS account names contain percentage (%) characters.


Supporting Screenshot:
<img width="821" height="404" alt="Screenshot 2026-01-28 at 16 39 48" src="https://github.com/user-attachments/assets/4b058447-3ed5-44de-a4df-43b938c27526" />
