### PR TITLE
fix(purchase order): re-calculate tax withholding during update items

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -4054,6 +4054,7 @@ def update_child_qty_rate(parent_doctype, trans_items, parent_doctype_name, chil
 
 	parent.set_payment_schedule()
 	if parent_doctype == "Purchase Order":
+		parent.set_tax_withholding()
 		parent.validate_minimum_order_qty()
 		parent.validate_budget()
 		if parent.is_against_so():


### PR DESCRIPTION
**Issue:** When updating item quantity or rate in a Purchase Order, tax withholding is not getting recalculated.

**Ref:** [56786](https://support.frappe.io/helpdesk/tickets/56786)

**Steps to Reproduce:**
1) Create a Purchase Order with a supplier configured for tax withholding
2) Save and submit the Purchase Order.
3) Update the quantity or rate of an item using "Update Items".
4) Observe that the taxes remain unchanged.

Before:

https://github.com/user-attachments/assets/7e28f59c-cde3-4a57-9c73-9938fa12819f

After:

https://github.com/user-attachments/assets/9209da76-6b72-4c71-aaa9-1256771216a6



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
- Tax withholding is now applied during the validation of subcontracted items in Purchase Orders.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->