### PR TITLE
fix: Add Landed Cost Voucher Amount in Internal Purchase Receipt

### DIFF
--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -825,7 +825,6 @@ class update_entries_after:
 			if not self.validate_negative_stock(sle):
 				self.wh_data.qty_after_transaction += flt(sle.actual_qty)
 				return
-
 		# Get dynamic incoming/outgoing rate
 		if not self.args.get("sle_id"):
 			self.get_dynamic_incoming_outgoing_rate(sle)

--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -2326,6 +2326,7 @@ def get_incoming_rate_for_inter_company_transfer(sle) -> float:
 	For inter company transfer, incoming rate is the average of the outgoing rate
 	"""
 	rate = 0.0
+	lcv_rate = 0.0
 
 	field = "delivery_note_item" if sle.voucher_type == "Purchase Receipt" else "sales_invoice_item"
 
@@ -2340,7 +2341,15 @@ def get_incoming_rate_for_inter_company_transfer(sle) -> float:
 			"incoming_rate",
 		)
 
-	return rate
+	# add lcv amount in incoming_rate
+	lcv_amount = frappe.db.get_value(
+		f"{sle.voucher_type} Item", sle.voucher_detail_no, "landed_cost_voucher_amount"
+	)
+
+	if lcv_amount:
+		lcv_rate = flt(lcv_amount / abs(sle.actual_qty))
+
+	return rate + lcv_rate
 
 
 def is_internal_transfer(sle):


### PR DESCRIPTION
**Issue:** When reposting a Internal Purchase Receipt with Landed Cost Voucher, system updates incorrect Incoming Rate which hasn't considered the Landed Cost Voucher amount, and causes incorrect accounting entries too.

**Ref: [53613](https://support.frappe.io/helpdesk/tickets/53613)**

**Steps To Replicate:**
- Create an Internal Transfer Entry. (DN -> PR for customer and supplier representing the same company)
- Create a LCV against the Internal Purchase Receipt.
- Repost the Internal Purchase Receipt Voucher and check the Stock Ledger and General Ledger Report.

**Solution:** Consider and add the Landed Cost Voucher rate for Internal Transfer entries.

**Before:**


https://github.com/user-attachments/assets/77c9efcc-b4e1-47fc-85bf-d685b562695f


**After:**


https://github.com/user-attachments/assets/23f9c668-d6dc-494a-944e-f680e874cb6f




**Backport Needed: v16, v15**