### PR TITLE
fix(stock): remove is_return condition on pos batch qty calculation

### DIFF
--- a/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py
+++ b/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py
@@ -2596,11 +2596,11 @@ def get_reserved_batches_for_pos(kwargs) -> dict:
 
 		key = (row.batch_no, row.warehouse)
 		if key in pos_batches:
-			pos_batches[key]["qty"] -= row.qty * -1 if row.is_return else row.qty
+			pos_batches[key]["qty"] += row.qty * -1
 		else:
 			pos_batches[key] = frappe._dict(
 				{
-					"qty": (row.qty * -1 if not row.is_return else row.qty),
+					"qty": row.qty * -1,
 					"warehouse": row.warehouse,
 				}
 			)


### PR DESCRIPTION
**Issue:** When recalculating the batch qty, system populated with discrepancy between batch balance qty and stock ledger wise balance for same batch.

**Ref: [57403](https://support.frappe.io/helpdesk/tickets/57403)**

**Solution:** Removing `is_return` check condition on pos reserved batch qty calculation solved the issue.

**To Replicate the Issue:**
- Create one pos invoice for 2 qty and return it before consolidating.
- Check the batch qty where system sums up the both invoice qty and populates a negative balance -4 qty, which is incorrect. It needs to sum up the positive and negative value and the expected balance should be 0. 

**Before:**

<img width="1571" height="963" alt="image" src="https://github.com/user-attachments/assets/1478d34c-0175-4e57-a212-959606a2f100" />


**After:**

<img width="3418" height="1848" alt="image" src="https://github.com/user-attachments/assets/32bd2b33-45bf-4d5f-8a75-5b1f7c6e1b03" />

**Backport Needed: v16, v15**

