### PR TITLE
fix: avoid duplicate taxes and charges rows in payment entry

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.js
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.js
@@ -1450,16 +1450,15 @@ frappe.ui.form.on("Payment Entry", {
 			callback: function (r) {
 				if (!r.exc && r.message) {
 					// set taxes table
-					if (r.message) {
-						for (let tax of r.message) {
-							if (tax.charge_type === "On Net Total") {
-								tax.charge_type = "On Paid Amount";
-							}
-							frm.add_child("taxes", tax);
+					let taxes = r.message;
+					taxes.forEach((tax) => {
+						if (tax.charge_type === "On Net Total") {
+							tax.charge_type = "On Paid Amount";
 						}
-						frm.events.apply_taxes(frm);
-						frm.events.set_unallocated_amount(frm);
-					}
+					});
+					frm.set_value("taxes", taxes);
+					frm.events.apply_taxes(frm);
+					frm.events.set_unallocated_amount(frm);
 				}
 			},
 		});


### PR DESCRIPTION
**Issue**

When selecting or changing a Taxes and Charges template in Payment Entry, the tax rows are appended to the existing table instead of replacing them.
This results in duplicate rows in the Taxes and Charges table.

**Fix**

Instead of appending tax rows using frm.add_child, the Taxes and Charges table is now replaced entirely using frm.set_value("taxes", taxes).
This ensures that previously applied tax rows are cleared before applying the new template.

**Closes:** [52174](https://github.com/frappe/erpnext/issues/52174)

**before:**

[Screencast from 2026-01-29 11-54-21.webm](https://github.com/user-attachments/assets/ef39689b-a5fc-4bf7-a6b0-f5f9ec44cf48)

**after:**

[Screencast from 2026-01-29 13-10-51.webm](https://github.com/user-attachments/assets/875c3267-0af2-4597-bb73-42a2f269d2c1)


**Backport needed v15**
