### PR TITLE
fix(stock): handle missing item_code in get_batch_based_item_price

### DIFF
--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -1154,7 +1154,9 @@ def get_item_price(
 
 
 @frappe.whitelist()
-def get_batch_based_item_price(pctx: ItemPriceCtx | dict | str, item_code) -> float:
+def get_batch_based_item_price(pctx: ItemPriceCtx | dict | str, item_code=None) -> float:
+	if not item_code:
+		return 0.0
 	pctx = parse_json(pctx)
 
 	item_price = get_item_price(pctx, item_code, force_batch_no=True)


### PR DESCRIPTION
**Issue:** 
When an item has both Batch Number and Serial Number enabled, scanning or pasting the Serial Number in the Barcode field while creating a Sales Invoice results in a server error.

**Fixes:** https://github.com/frappe/erpnext/issues/52189

**Before:**

[Before(52189).webm](https://github.com/user-attachments/assets/4a490f81-7124-4838-99dc-716a4bfbd6e0)


**After:**

[After(52189).webm](https://github.com/user-attachments/assets/b22203c7-cd81-4a4d-9748-86331b52db12)
