### PR TITLE
fix(accounts): correct date in Journal Auditing Voucher print format

### DIFF
--- a/erpnext/accounts/print_format/journal_auditing_voucher/journal_auditing_voucher.html
+++ b/erpnext/accounts/print_format/journal_auditing_voucher/journal_auditing_voucher.html
@@ -17,7 +17,7 @@
             </div>
             <div class="col-xs-6">
                 <table>
-                    <tr><td><strong>Date: </strong></td><td>{{  frappe.utils.format_date(doc.creation)  }}</td></tr>
+                    <tr><td><strong>Date: </strong></td><td>{{  frappe.utils.format_date(doc.posting_date)  }}</td></tr>
                 </table>
             </div>
     </div>


### PR DESCRIPTION
### What does this PR do?

The Journal Auditing Voucher print format was using `doc.creation`
instead of `doc.posting_date`, which caused a mismatch between the
date shown in the Journal Entry UI and the printed document.

This change updates the print format to use `posting_date`,
ensuring consistency with the accounting date shown in the UI.

Closes #51987

### Screenshots/GIFs

Not applicable. This is a small print format fix.