### PR TITLE
fix(map_current_doc): prevent mutation of query args in get_query

### DIFF
--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -989,7 +989,7 @@ erpnext.utils.map_current_doc = function (opts) {
 	}
 
 	if (query_args.filters || query_args.query) {
-		opts.get_query = () => query_args;
+		opts.get_query = () => JSON.parse(JSON.stringify(query_args));
 	}
 
 	if (opts.source_doctype) {


### PR DESCRIPTION
**Issue**:
`get_query()` returns the same `query_args` object by reference.

When filters are added or removed in the dialog, this object is mutated in-place.
Because of this, removing a filter from the UI does not remove it from the actual query args.

As a result, stale filters are still sent in subsequent search queries.

This change fixes the issue by cloning the query args before using them, so each search works with an isolated copy and no state leaks between filter changes.

**Before:**

https://github.com/user-attachments/assets/19514244-ac2c-4ce4-90d6-8018c32410cf


**After:**

https://github.com/user-attachments/assets/a0e87e1e-b505-400a-a979-4e7ddecf7f91

