### PR TITLE
fix: item code not showing in report view

### DIFF
--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -1070,7 +1070,7 @@ frappe.form.link_formatters["Project"] = function (value, doc, df) {
  */
 function add_link_title(value, doc, df, title_field) {
 	if (doc.doctype != df.parent) {
-		return "";
+		return value;
 	} else if (
 		doc &&
 		value &&


### PR DESCRIPTION
[fixes issue](https://github.com/frappe/frappe/issues/36507)

**Problem**                                                                                    
  Item Code from child table (like Sales Order Item) shows empty in Report View.                
                                                                                                
**Cause**                                                                                      
                                                                                             
  aac39b2671 returns "" to prevent wrong item_name.                                             
  But returning just item_code (value) is enough - no wrong name attached.  
                                                                                                
**Fix**                                                                                        
  Return the actual value instead of empty string.                                              
                                                                                                
**How to Test**                                                                             
  1. Open Sales Order list                                                                      
  2. Switch to Report View                                                                      
  3. Click Pick Columns → add Item Code from Sales Order Item                                   
  4. Item Code now shows correctly 

**Before**
<img width="1472" height="426" alt="image" src="https://github.com/user-attachments/assets/07164d20-90e3-4ad2-8b0d-c4f668ca23d7" />


**After**
<img width="1472" height="426" alt="image" src="https://github.com/user-attachments/assets/a78f4409-011b-4285-a244-d59ec580e706" />                            
