### PR TITLE
perf: speed up chart of accounts creation using template

### DIFF
--- a/erpnext/accounts/doctype/account/account.py
+++ b/erpnext/accounts/doctype/account/account.py
@@ -107,6 +107,7 @@ class Account(NestedSet):
 	def validate(self):
 		if frappe.local.flags.allow_unverified_charts:
 			return
+		self.flags.account_creation_using_charts = hasattr(frappe.local, "chart_accounts")
 		self.validate_parent()
 		self.validate_parent_child_account_type()
 		self.validate_root_details()
@@ -131,15 +132,28 @@ class Account(NestedSet):
 				"Direct Expense",
 				"Indirect Expense",
 			]:
-				parent_account_type = frappe.db.get_value("Account", self.parent_account, ["account_type"])
+				parent_account_type = (
+					frappe.db.get_value("Account", self.parent_account, ["account_type"])
+					if not self.flags.account_creation_using_charts
+					else self._get_account_from_charts_accounts(
+						self.parent_account, fields=["account_type"]
+					).get("account_type")
+				)
 				if parent_account_type == self.account_type:
 					throw(_("Only Parent can be of type {0}").format(self.account_type))
 
 	def validate_parent(self):
 		"""Fetch Parent Details and validate parent account"""
 		if self.parent_account:
-			par = frappe.get_cached_value(
-				"Account", self.parent_account, ["name", "is_group", "company"], as_dict=1
+			par = (
+				frappe.get_cached_value(
+					"Account", self.parent_account, ["name", "is_group", "company"], as_dict=1
+				)
+				if not self.flags.account_creation_using_charts
+				else self._get_account_from_charts_accounts(
+					self.parent_account,
+					fields=["name", "is_group", "company"],
+				)
 			)
 			if not par:
 				throw(
@@ -162,8 +176,14 @@ class Account(NestedSet):
 
 	def set_root_and_report_type(self):
 		if self.parent_account:
-			par = frappe.get_cached_value(
-				"Account", self.parent_account, ["report_type", "root_type"], as_dict=1
+			par = (
+				frappe.get_cached_value(
+					"Account", self.parent_account, ["report_type", "root_type"], as_dict=1
+				)
+				if not self.flags.account_creation_using_charts
+				else self._get_account_from_charts_accounts(
+					self.parent_account, fields=["report_type", "root_type"], as_dict=1
+				)
 			)
 
 			if par.report_type:
@@ -350,9 +370,17 @@ class Account(NestedSet):
 			account_number = self.account_number
 
 		if account_number:
-			account_with_same_number = frappe.db.get_value(
-				"Account",
-				{"account_number": account_number, "company": self.company, "name": ["!=", self.name]},
+			account_with_same_number = (
+				frappe.db.get_value(
+					"Account",
+					{"account_number": account_number, "company": self.company, "name": ["!=", self.name]},
+				)
+				if not self.flags.account_creation_using_charts
+				else self._get_account_from_charts_accounts(
+					filters={"account_number": account_number, "company": self.company},
+					fields=["report_type", "root_type"],
+					as_dict=1,
+				)
 			)
 			if account_with_same_number:
 				frappe.throw(
@@ -360,6 +388,33 @@ class Account(NestedSet):
 						account_number, account_with_same_number
 					)
 				)
+
+	def _get_account_from_charts_accounts(
+		self, filters: None | str | dict, fields: None | list[str] = None, as_dict: int = 1
+	) -> None | "Account" | list | frappe._dict:
+		if not self.flags.account_creation_using_charts:
+			return None
+
+		if not filters:
+			return None
+		elif isinstance(filters, str):
+			filters = {"name": filters}
+
+		account = next(
+			(d for d in frappe.local.chart_accounts if all(d.get(k) == v for k, v in filters.items())),
+			None,
+		)
+
+		if account and fields:
+			data = frappe._dict()
+			for d in fields:
+				data[d] = account.get(d)
+
+			if not as_dict:
+				return [data.get(d) for d in fields]
+
+			return data
+		return account
 
 	def create_account_for_child_company(self, parent_acc_name_map, descendants, parent_acc_name):
 		for company in descendants:

--- a/erpnext/accounts/doctype/account/chart_of_accounts/chart_of_accounts.py
+++ b/erpnext/accounts/doctype/account/chart_of_accounts/chart_of_accounts.py
@@ -5,6 +5,7 @@ import json
 import os
 
 import frappe
+from frappe.model.document import bulk_insert
 from frappe.utils import cstr
 from frappe.utils.nestedset import rebuild_tree
 from unidecode import unidecode
@@ -16,6 +17,7 @@ def create_charts(
 	chart = custom_chart or get_chart(chart_template, existing_company)
 	if chart:
 		accounts = []
+		frappe.local.chart_accounts = []
 
 		def _import_accounts(children, parent, root_type, root_account=False):
 			nonlocal custom_chart
@@ -58,20 +60,26 @@ def create_charts(
 					if root_account or frappe.local.flags.allow_unverified_charts:
 						account.flags.ignore_mandatory = True
 
+					account.autoname()
 					account.flags.ignore_permissions = True
 
-					account.insert()
+					account.validate()
+					frappe.local.chart_accounts.append(account)
 
 					accounts.append(account_name_in_db)
 
 					_import_accounts(child, account.name, root_type)
 
-		# Rebuild NestedSet HSM tree for Account Doctype
-		# after all accounts are already inserted.
-		frappe.local.flags.ignore_update_nsm = True
-		_import_accounts(chart, None, None, root_account=True)
-		rebuild_tree("Account")
-		frappe.local.flags.ignore_update_nsm = False
+		try:
+			# Rebuild NestedSet HSM tree for Account Doctype
+			# after all accounts are already inserted.
+			frappe.local.flags.ignore_update_nsm = True
+			_import_accounts(chart, None, None, root_account=True)
+			bulk_insert("Account", frappe.local.chart_accounts, ignore_duplicates=False)
+			rebuild_tree("Account")
+		finally:
+			frappe.local.flags.ignore_update_nsm = False
+			del frappe.local.chart_accounts
 
 
 def add_suffix_if_duplicate(account_name, account_number, accounts):

--- a/erpnext/setup/doctype/company/test_company.py
+++ b/erpnext/setup/doctype/company/test_company.py
@@ -56,7 +56,24 @@ class TestCompany(IntegrationTestCase):
 		frappe.delete_doc("Company", "COA from Existing Company")
 
 	def test_coa_based_on_country_template(self):
+		from erpnext.accounts.doctype.account.chart_of_accounts.chart_of_accounts import create_charts
+
+		def remove_company_accounts(company):
+			Account = frappe.qb.DocType("Account")
+			frappe.qb.from_(Account).delete().where(Account.company == company.name).run()
+
 		countries = ["Canada", "Germany", "France"]
+
+		company = frappe.new_doc("Company")
+		company.company_name = "Lacuna, Inc."
+		company.abbr = random_string(3)
+		company.default_currency = "USD"
+		company.create_chart_of_accounts_based_on = "Standard Template"
+		company.chart_of_accounts = "Standard"
+		company.save()
+		company.reload()
+		self.delete_mode_of_payment(company.name)
+		remove_company_accounts(company)
 
 		for country in countries:
 			templates = get_charts_for_country(country)
@@ -67,14 +84,8 @@ class TestCompany(IntegrationTestCase):
 
 			for template in templates:
 				try:
-					company = frappe.new_doc("Company")
-					company.company_name = template
-					company.abbr = random_string(3)
-					company.default_currency = "USD"
-					company.create_chart_of_accounts_based_on = "Standard Template"
 					company.chart_of_accounts = template
-					company.save()
-
+					create_charts(company.name, company.chart_of_accounts, company.existing_company)
 					account_types = [
 						"Cost of Goods Sold",
 						"Depreciation",
@@ -90,7 +101,7 @@ class TestCompany(IntegrationTestCase):
 					]
 
 					for account_type in account_types:
-						filters = {"company": template, "account_type": account_type}
+						filters = {"company": company.name, "account_type": account_type}
 						if account_type in ["Bank", "Cash"]:
 							filters["is_group"] = 1
 
@@ -99,8 +110,9 @@ class TestCompany(IntegrationTestCase):
 
 						self.assertTrue(has_matching_accounts, msg=error_message)
 				finally:
-					self.delete_mode_of_payment(template)
-					frappe.delete_doc("Company", template)
+					remove_company_accounts(company)
+
+		frappe.delete_doc("Company", company.name)
 
 	def delete_mode_of_payment(self, company):
 		frappe.db.sql(


### PR DESCRIPTION
Before

```bash
Starting test run with parameters: site=test_site, module=erpnext.setup.doctype.company.test_company, verbose=False, tests=('test_coa_based_on_country_template',), force=False, profile=True, failfast=False, skip_before_tests=False, debug=False, selected_categories=[]
View detailed logs (using --verbose): /Users/frappe/frappe-bench/logs/frappe.testing.log

Running 1 integration tests for erpnext

125890529 function calls (122837771 primitive calls) in 89.717 seconds
```

After

```bash
Starting test run with parameters: site=test_site, module=erpnext.setup.doctype.company.test_company, verbose=False, tests=('test_coa_based_on_country_template',), force=False, profile=True, failfast=False, skip_before_tests=False, debug=False, selected_categories=[]
View detailed logs (using --verbose): /Users/frappe/frappe-bench/logs/frappe.testing.log

Running 1 integration tests for erpnext


91128873 function calls (89296571 primitive calls) in 24.643 seconds
```