### PR TITLE
fix(buying): make item name editable in request for quotation

### DIFF
--- a/erpnext/buying/doctype/request_for_quotation_item/request_for_quotation_item.json
+++ b/erpnext/buying/doctype/request_for_quotation_item/request_for_quotation_item.json
@@ -63,7 +63,6 @@
    "fieldtype": "Column Break"
   },
   {
-   "fetch_from": "item_code.item_name",
    "fieldname": "item_name",
    "fieldtype": "Data",
    "in_global_search": 1,


### PR DESCRIPTION
Issue: In Request for Quotation, the Item Name field was not editable.

Fix : [#58854](https://support.frappe.io/helpdesk/tickets/58854)

Description :

In the Request for Quotation document, the Item Name field was not editable while saving the document. This behavior has now been fixed, and the Item Name field is editable as expected.

Before :

[Screencast from 31-01-26 02:10:40 PM IST.webm](https://github.com/user-attachments/assets/5e1382b5-226f-41d9-bfd3-a0d1e6b5ece6)


After :

[Screencast from 31-01-26 02:08:20 PM IST.webm](https://github.com/user-attachments/assets/a5635d5d-d5b7-4a24-b197-51d5c37abbae)

Backport Needed : V16