### PR TITLE
fix: backport Switzerland VAT rates update to version-15

### DIFF
--- a/erpnext/setup/setup_wizard/data/country_wise_tax.json
+++ b/erpnext/setup/setup_wizard/data/country_wise_tax.json
@@ -4844,17 +4844,17 @@
 
 	"Switzerland": {
 		"Switzerland normal VAT": {
-			"account_name": "VAT 7.7%",
-			"tax_rate": 7.70,
+			"account_name": "VAT 8.1%",
+			"tax_rate": 8.10,
 			"default": 1
 		},
 		"Switzerland reduced VAT": {
-			"account_name": "VAT 2.5%",
-			"tax_rate": 2.50
+			"account_name": "VAT 2.6%",
+			"tax_rate": 2.60
 		},
 		"Switzerland lodging VAT": {
-			"account_name": "VAT 3.7%",
-			"tax_rate": 3.70
+			"account_name": "VAT 3.8%",
+			"tax_rate": 3.80
 		}
 	},
 


### PR DESCRIPTION
## Summary

Backport of #42902 from `develop` to `version-15-hotfix`.

Update Swiss VAT rates to reflect the changes that came into effect on **January 1, 2024**.

| Rate Type | Old Rate | New Rate |
|-----------|----------|----------|
| Standard | 7.7% | 8.1% |
| Reduced | 2.5% | 2.6% |
| Accommodation | 3.7% | 3.8% |

## Reference

Official Swiss Federal Tax Administration:
https://www.estv.admin.ch/estv/en/home/value-added-tax/vat-rates-switzerland.html

## Test Plan

- [ ] Create a new company with Switzerland as country
- [ ] Verify that the created tax templates show the correct rates (8.1%, 2.6%, 3.8%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Switzerland VAT rates have been updated: Normal VAT increased to 8.1%, Reduced VAT to 2.6%, and Lodging VAT to 3.8%.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->