### PR TITLE
fix(stock): include subcontracting order qty while calculating the bin qty

### DIFF
--- a/erpnext/subcontracting/doctype/subcontracting_order/subcontracting_order.py
+++ b/erpnext/subcontracting/doctype/subcontracting_order/subcontracting_order.py
@@ -12,7 +12,7 @@ from erpnext.stock.doctype.stock_reservation_entry.stock_reservation_entry impor
 	StockReservation,
 	has_reserved_stock,
 )
-from erpnext.stock.stock_balance import update_bin_qty
+from erpnext.stock.stock_balance import get_ordered_qty, update_bin_qty
 from erpnext.stock.utils import get_bin
 
 
@@ -234,30 +234,7 @@ class SubcontractingOrder(SubcontractingController):
 			):
 				item_wh_list.append([item.item_code, item.warehouse])
 		for item_code, warehouse in item_wh_list:
-			update_bin_qty(item_code, warehouse, {"ordered_qty": self.get_ordered_qty(item_code, warehouse)})
-
-	@staticmethod
-	def get_ordered_qty(item_code, warehouse):
-		table = frappe.qb.DocType("Subcontracting Order")
-		child = frappe.qb.DocType("Subcontracting Order Item")
-
-		query = (
-			frappe.qb.from_(table)
-			.inner_join(child)
-			.on(table.name == child.parent)
-			.select((child.qty - child.received_qty) * child.conversion_factor)
-			.where(
-				(table.docstatus == 1)
-				& (child.item_code == item_code)
-				& (child.warehouse == warehouse)
-				& (child.qty > child.received_qty)
-				& (table.status != "Completed")
-			)
-		)
-
-		query = query.run()
-
-		return flt(query[0][0]) if query else 0
+			update_bin_qty(item_code, warehouse, {"ordered_qty": get_ordered_qty(item_code, warehouse)})
 
 	def update_reserved_qty_for_subcontracting(self, sco_item_rows=None):
 		for item in self.supplied_items:


### PR DESCRIPTION
**Issue:**
Ordered Qty shown in Bin does not include outstanding quantities from Subcontracting Orders. The calculation currently considers only pending Purchase Orders.

**Ref:** [#58787](https://support.frappe.io/helpdesk/tickets/58787)

**Before:**

https://github.com/user-attachments/assets/4d0ec4da-2737-4646-9c19-76f9bbec9ab2

**After:**

https://github.com/user-attachments/assets/af45a8ad-f23d-4078-bf99-aefde2b7d895

**Backport Needed for v15 & v16**