### PR TITLE
fix: dependent changes for frappe/frappe # 36326 - allow guest to view public portal web pages

### DIFF
--- a/erpnext/controllers/website_list_for_contact.py
+++ b/erpnext/controllers/website_list_for_contact.py
@@ -80,7 +80,7 @@ def get_transaction_list(
 
 	filters["docstatus"] = ["<", "2"] if doctype in ["Supplier Quotation", "Purchase Invoice"] else 1
 
-	if (user != "Guest" and is_website_user()) or doctype == "Request for Quotation":
+	if user != "Guest" and is_website_user():
 		parties_doctype = "Request for Quotation Supplier" if doctype == "Request for Quotation" else doctype
 		# find party for this contact
 		customers, suppliers = get_customers_suppliers(parties_doctype, user)

--- a/erpnext/hooks.py
+++ b/erpnext/hooks.py
@@ -270,7 +270,7 @@ standard_portal_menu_items = [
 		"role": "Customer",
 	},
 	{"title": "Issues", "route": "/issues", "reference_doctype": "Issue", "role": "Customer"},
-	{"title": "Addresses", "route": "/addresses", "reference_doctype": "Address"},
+	{"title": "Addresses", "route": "/addresses", "reference_doctype": "Address", "role": "Desk User"},
 	{
 		"title": "Timesheets",
 		"route": "/timesheets",

--- a/erpnext/projects/doctype/timesheet/timesheet.py
+++ b/erpnext/projects/doctype/timesheet/timesheet.py
@@ -570,7 +570,7 @@ def get_list_context(context=None):
 		"show_search": True,
 		"no_breadcrumbs": True,
 		"title": _("Timesheets"),
-		"get_list": get_timesheets_list,
+		# "get_list": get_timesheets_list,
 		"row_template": "templates/includes/timesheet/timesheet_row.html",
 		"list_template": "templates/includes/list/list.html",
 	}


### PR DESCRIPTION
In order to make blogs (and other portal pages meant to be public like help articles) available to unauthenticated users again, two lines had to be removed from frappe/www/portal.py that basically made all portal-related pages like /blog and /kb inaccessible without logging in. 

However, there were a few security issues with the portal that were uncovered by removing those lines from portal.py. Specifically, I discovered that "/rfq" and "/timesheets" were accessible (and "/addresses" had a visible link) to the guest/unauthenticated user- unlike all the other portal menu items. This PR is to correct that deficiency and bring them into conformity with the other portal menu items.

This PR is a dependency for https://github.com/frappe/frappe/pull/36326, so those portal URLs don't get exposed in any installations.

Before:

https://github.com/user-attachments/assets/ed386ca3-0f29-49aa-919d-c7a5b0abd009




After:

https://github.com/user-attachments/assets/28fdaf20-4d44-453e-98a4-a2f8299d0316



Please backport to version-16-hotfix. Thanks!