### PR TITLE
feat(stock): add company field to Bin with migration patch

### DIFF
--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -461,3 +461,4 @@ erpnext.patches.v15_0.create_accounting_dimensions_in_advance_taxes_and_charges
 execute:frappe.delete_doc_if_exists("Workspace Sidebar", "Opening & Closing")
 erpnext.patches.v16_0.migrate_transaction_deletion_task_flags_to_status # 2
 erpnext.patches.v16_0.set_ordered_qty_in_quotation_item
+erpnext.patches.v16_0.update_company_custom_field_in_bin

--- a/erpnext/patches/v16_0/update_company_custom_field_in_bin.py
+++ b/erpnext/patches/v16_0/update_company_custom_field_in_bin.py
@@ -1,0 +1,14 @@
+import frappe
+
+
+def execute():
+	frappe.reload_doc("stock", "doctype", "bin")
+
+	frappe.db.sql(
+		"""
+        UPDATE `tabBin` b
+        INNER JOIN `tabWarehouse` w ON b.warehouse = w.name
+        SET b.company = w.company
+        WHERE b.company IS NULL OR b.company = ''
+    """
+	)

--- a/erpnext/stock/doctype/bin/bin.json
+++ b/erpnext/stock/doctype/bin/bin.json
@@ -22,6 +22,7 @@
   "reserved_stock",
   "section_break_pmrs",
   "stock_uom",
+  "company",
   "column_break_0slj",
   "valuation_rate",
   "stock_value"
@@ -133,6 +134,14 @@
    "read_only": 1
   },
   {
+   "fetch_from": "warehouse.company",
+   "fieldname": "company",
+   "fieldtype": "Link",
+   "label": "Company",
+   "options": "Company",
+   "read_only": 1
+  },
+  {
    "fieldname": "valuation_rate",
    "fieldtype": "Float",
    "label": "Valuation Rate",
@@ -186,7 +195,7 @@
  "idx": 1,
  "in_create": 1,
  "links": [],
- "modified": "2024-03-27 13:06:39.414036",
+ "modified": "2026-02-01 08:11:46.824913",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Bin",
@@ -231,6 +240,7 @@
   }
  ],
  "quick_entry": 1,
+ "row_format": "Dynamic",
  "search_fields": "item_code,warehouse",
  "sort_field": "creation",
  "sort_order": "ASC",

--- a/erpnext/stock/doctype/bin/bin.py
+++ b/erpnext/stock/doctype/bin/bin.py
@@ -19,6 +19,7 @@ class Bin(Document):
 		from frappe.types import DF
 
 		actual_qty: DF.Float
+		company: DF.Link | None
 		indented_qty: DF.Float
 		item_code: DF.Link
 		ordered_qty: DF.Float


### PR DESCRIPTION
**Issue:** There is no option in the BIN to see the company name as it it created based on the warehouse with its relevant company.

**Feat:** #52216 

Description: Earlier, the Bin DocType did not have a Company field. A Company field has now been added to determine the company associated with the stock through its warehouse.

**Before:** 

![Before(52216)](https://github.com/user-attachments/assets/bc46b349-4595-47f4-b6da-96f1be5907a7)


**After:**

<img width="1127" height="644" alt="After(52216)" src="https://github.com/user-attachments/assets/bd9926d9-e59b-4dca-9e29-180a1d513816" />


Backport needed v15 and v16