### PR TITLE
fix(profit and loss statement): exclude non period columns

### DIFF
--- a/erpnext/accounts/report/profit_and_loss_statement/profit_and_loss_statement.py
+++ b/erpnext/accounts/report/profit_and_loss_statement/profit_and_loss_statement.py
@@ -163,11 +163,11 @@ def get_net_profit_loss(income, expense, period_list, company, currency=None, co
 
 
 def get_chart_data(filters, columns, income, expense, net_profit_loss, currency):
-	labels = [d.get("label") for d in columns[2:]]
+	labels = [d.get("label") for d in columns[4:]]
 
 	income_data, expense_data, net_profit = [], [], []
 
-	for p in columns[2:]:
+	for p in columns[4:]:
 		if income:
 			income_data.append(income[-2].get(p.get("fieldname")))
 		if expense:


### PR DESCRIPTION
Issue:

Profit and Loss Statement dashboard chart data includes non period columns

Ref: [#58601](https://support.frappe.io/helpdesk/tickets/58601)

**Before :**

<img width="1792" height="1120" alt="Screenshot 2026-02-02 at 12 07 39 PM" src="https://github.com/user-attachments/assets/45ed1dea-d081-42a8-9326-e998968d5516" />

**After :**

<img width="1792" height="1120" alt="Screenshot 2026-02-02 at 12 06 58 PM" src="https://github.com/user-attachments/assets/dd36671a-663a-4f21-9e36-5950f4be02ba" />


Backport needed:v16, v15