### PR TITLE
fix(stock): ignore packing slip while cancelling the sales invoice

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
@@ -44,6 +44,7 @@ erpnext.accounts.SalesInvoiceController = class SalesInvoiceController extends (
 			"Unreconcile Payment Entries",
 			"Serial and Batch Bundle",
 			"Bank Transaction",
+			"Packing Slip",
 		];
 
 		if (!this.frm.doc.__islocal && !this.frm.doc.customer && this.frm.doc.debit_to) {


### PR DESCRIPTION
**Issue:**
Sales Invoice cancellation fails when it is linked to a Packing Slip (via Delivery Note). During Sales Invoice cancellation, the Cancel All flow attempts to cancel both **Delivery Note** and **Packing Slip**, Since the Delivery Note on_cancel also cancels the Packing Slip, the system tries to cancel the Packing Slip twice, which throws an error and prevents the Sales Invoice from being cancelled.

**Ref:** [#57038](https://support.frappe.io/helpdesk/tickets/57038)

**Before:**

https://github.com/user-attachments/assets/58afa7b9-4384-4d12-b699-b088b59b5b33

**After:**

https://github.com/user-attachments/assets/ec4b0553-32ed-4cb8-9da9-67b20864c33f

**Backport Needed for v16 & v15**