### PR TITLE
fix(stock): add stock recon opening stock condition

### DIFF
--- a/erpnext/stock/report/stock_balance/stock_balance.py
+++ b/erpnext/stock/report/stock_balance/stock_balance.py
@@ -282,7 +282,11 @@ class StockBalanceReport:
 		for field in self.inventory_dimensions:
 			qty_dict[field] = entry.get(field)
 
-		if entry.voucher_type == "Stock Reconciliation" and (not entry.batch_no or entry.serial_no):
+		if (
+			entry.voucher_type == "Stock Reconciliation"
+			and frappe.get_cached_value(entry.voucher_type, entry.voucher_no, "purpose") != "Opening Stock"
+			and (not entry.batch_no or entry.serial_no)
+		):
 			qty_diff = flt(entry.qty_after_transaction) - flt(qty_dict.bal_qty)
 		else:
 			qty_diff = flt(entry.actual_qty)


### PR DESCRIPTION
**Issue:** Currently, system is not considering the dimension wise opening stock, which causing balance qty discrepancy in _Stock Balance Report_.

**Ref: [57318](https://support.frappe.io/helpdesk/tickets/57318)** , https://github.com/frappe/erpnext/issues/51932

**Steps To Replicate:**
 - Create a Inventory Dimension as `Plant`, Add two dimensions Plant A and Plant B.
 -  Create a Stock Reconciliation with purpose of **Opening Stock** for both dimensions.
 - Check the Stock Balance Report with `Show Dimension Wise Stock` checked. System will show the Plant B opening qty as total balance qty of that specific Item and warehouse.

**Solution:** Ignore, stock recon calculation for opening entries, and consider the actual qty.

**Before:**

https://github.com/user-attachments/assets/938accc7-4b53-4866-96fd-e984f3c91230


**After:**

https://github.com/user-attachments/assets/4cfcd12e-330b-4efd-8727-0ed247d1205b



**Backport Needed: v16, v15**