### PR TITLE
fix: populate contact details when creating quotation from customer

### DIFF
--- a/erpnext/selling/doctype/customer/customer.py
+++ b/erpnext/selling/doctype/customer/customer.py
@@ -511,7 +511,22 @@ def _set_missing_values(source, target):
 		target.customer_address = address[0].parent
 
 	if contact:
-		target.contact_person = contact[0].parent
+		contact_name = contact[0].parent
+		target.contact_person = contact_name
+
+		contact_details = frappe.db.get_value(
+			"Contact",
+			contact_name,
+			["full_name", "mobile_no", "email_id"],
+			as_dict=True
+		)
+		if contact_details:
+			if hasattr(target, "contact_display"):
+				target.contact_display = contact_details.full_name
+			if hasattr(target, "contact_mobile"):
+				target.contact_mobile = contact_details.mobile_no
+			if hasattr(target, "contact_email"):
+				target.contact_email = contact_details.email_id
 
 
 @frappe.whitelist()


### PR DESCRIPTION
## Details

When creating a Quotation from a Customer, the `contact_person` field was being set, but the related contact details (`contact_display`, `contact_mobile`, `contact_email`) were not being populated. This required users to manually unset and set the contact_person to populate these fields even though the information was already available in the system.

This PR adds logic to fetch and populate these contact fields automatically from the Contact doctype when a contact_person is selected.

**Note:** This fix only addresses the obvious bug in the Quotation flow.

However, there is a problem in other doctypes (Sales Order, Sales Invoice, Delivery Note, etc.) where the behavior is currently not at all implemented. Namely, the contact_person is not set at all.
Additionally, the "selection" of which contact person is set is a bit random to me.

**Consideration:** This could and should probably be implemented using "fetch from" fields in the doctype definition rather than programmatic assignment. It looks to me that this is very old code, so it is possible that that was not available back then. IMHO this would make the solution more maintainable and consistent across all related doctypes. Since I am not sure of the implication such a change would have, I will leave this decision to the core team.

Backport to v15 would be great