### PR TITLE
fix: set asset status as fully depreciated

### DIFF
--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -795,6 +795,8 @@ class Asset(AccountsController):
 						status = "Fully Depreciated"
 					elif flt(value_after_depreciation) < flt(self.net_purchase_amount):
 						status = "Partially Depreciated"
+				elif self.is_fully_depreciated:
+					status = "Fully Depreciated"
 		elif self.docstatus == 2:
 			status = "Cancelled"
 		return status

--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -788,10 +788,7 @@ class Asset(AccountsController):
 					].expected_value_after_useful_life
 					value_after_depreciation = self.finance_books[idx].value_after_depreciation
 
-					if (
-						flt(value_after_depreciation) <= expected_value_after_useful_life
-						or self.is_fully_depreciated
-					):
+					if flt(value_after_depreciation) <= expected_value_after_useful_life:
 						status = "Fully Depreciated"
 					elif flt(value_after_depreciation) < flt(self.net_purchase_amount):
 						status = "Partially Depreciated"

--- a/erpnext/assets/doctype/asset/test_asset.py
+++ b/erpnext/assets/doctype/asset/test_asset.py
@@ -823,6 +823,12 @@ class TestAsset(AssetSetup):
 
 		frappe.db.set_value("Item", asset_item, "is_grouped_asset", 0)
 
+	def test_is_fully_depreciated_asset_status(self):
+		asset = create_asset(item_code="Macbook Pro", do_not_save=1)
+		asset.is_fully_depreciated = 1
+		asset.save().submit()
+		self.assertEqual(asset.status, "Fully Depreciated")
+
 
 class TestDepreciationMethods(AssetSetup):
 	@classmethod


### PR DESCRIPTION
**Issue:**
Asset status is not updated to Fully Depreciated even when is_fully_depreciated is checked

Steps to Reproduce:
1. Create an asset with `is_full_depreciated` checked
2. Observe the asset status set as "Submitted` instead of "Fully Depreciated"

Before

[Screencast from 2026-02-03 11-17-22.webm](https://github.com/user-attachments/assets/92119cf7-8689-4e83-aaa6-bf724e5e10c3)

After

[Screencast from 2026-02-03 11-44-39.webm](https://github.com/user-attachments/assets/263b0130-85b5-4594-b943-98d967ba4f12)

