### PR TITLE
fix(pos-closing-entry): filter POS Profile by applicable_for_users child table

### DIFF
--- a/erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.js
+++ b/erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.js
@@ -6,6 +6,7 @@ frappe.ui.form.on("POS Closing Entry", {
 		frm.ignore_doctypes_on_cancel_all = ["POS Invoice Merge Log", "Sales Invoice"];
 		frm.set_query("pos_profile", function (doc) {
 			return {
+				query: "erpnext.accounts.doctype.pos_closing_entry.pos_closing_entry.get_pos_profiles",
 				filters: { user: doc.user },
 			};
 		});

--- a/erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.py
+++ b/erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.py
@@ -441,3 +441,23 @@ def build_invoice_query(invoice_doctype, user, pos_profile, start, end):
 		)
 
 	return query
+
+
+@frappe.whitelist()
+@frappe.validate_and_sanitize_search_inputs
+def get_pos_profiles(doctype: str, txt: str, searchfield: str, start: int, page_len: int, filters: dict):
+	user = filters.get("user")
+	pos_profile_user = DocType("POS Profile User")
+	pos_profile = DocType("POS Profile")
+
+	query = (
+		frappe.qb.from_(pos_profile_user)
+		.inner_join(pos_profile)
+		.on(pos_profile_user.parent == pos_profile.name)
+		.where((pos_profile_user.user == user) & (pos_profile.name.like(f"%{txt}%")))
+		.select(pos_profile.name)
+		.limit(page_len)
+		.offset(start)
+	)
+
+	return query.run(as_list=True)


### PR DESCRIPTION
**Issue:** POS Closing Entry fails to filter POS Profiles by user after upgrading to Frappe v16.

**Fix:** #52126 

**Description:** The POS Closing Entry form was trying to filter POS Profiles using a user field that does not exist in the POS Profile doctype. The user field is actually stored in the POS Profile User child table.

After upgrading to Frappe v16, this incorrect filter started throwing an error and POS Profiles could not be loaded.

This change fixes the query to get POS Profiles from the child table first and then filter the parent POS Profile records using those results. This ensures that only POS Profiles assigned to the selected user are shown and the form works correctly again.

**Before:**

[Before(52126).webm](https://github.com/user-attachments/assets/d3d3b3de-d006-41d3-a428-c906fddfa0fd)


**After:**

[After(52126).webm](https://github.com/user-attachments/assets/a4102397-1c11-46a5-afa9-e6d234730376)


Backport neede V15 and V16.