### PR TITLE
fix: validate asset movement transaction date

### DIFF
--- a/erpnext/assets/doctype/asset_movement/asset_movement.py
+++ b/erpnext/assets/doctype/asset_movement/asset_movement.py
@@ -5,7 +5,7 @@
 import frappe
 from frappe import _
 from frappe.model.document import Document
-from frappe.utils import cstr, get_link_to_form
+from frappe.utils import cstr, get_datetime, get_link_to_form
 
 from erpnext.assets.doctype.asset_activity.asset_activity import add_asset_activity
 
@@ -34,6 +34,7 @@ class AssetMovement(Document):
 		for d in self.assets:
 			self.validate_asset(d)
 			self.validate_movement(d)
+			self.validate_transaction_date(d)
 
 	def validate_asset(self, d):
 		status, company = frappe.db.get_value("Asset", d.asset, ["status", "company"])
@@ -50,6 +51,26 @@ class AssetMovement(Document):
 			self.validate_location(d)
 		else:
 			self.validate_employee(d)
+
+	def validate_transaction_date(self, d):
+		previous_movement_date = frappe.db.sql(
+			"""
+			SELECT MAX(am.transaction_date)
+			FROM `tabAsset Movement` am
+			INNER JOIN `tabAsset Movement Item` ami ON am.name = ami.parent
+			WHERE
+				ami.asset=%s AND
+				am.company=%s AND
+				am.docstatus=1
+				AND am.name!=%s
+		""",
+			(d.asset, self.company, self.name),
+		)[0][0]
+
+		if previous_movement_date and get_datetime(previous_movement_date) > get_datetime(
+			self.transaction_date
+		):
+			frappe.throw("Transaction date can't be before previous asset movement date")
 
 	def validate_location_and_employee(self, d):
 		self.validate_location(d)

--- a/erpnext/assets/doctype/asset_movement/asset_movement.py
+++ b/erpnext/assets/doctype/asset_movement/asset_movement.py
@@ -62,7 +62,7 @@ class AssetMovement(Document):
 		if previous_movement_date and get_datetime(previous_movement_date) > get_datetime(
 			self.transaction_date
 		):
-			frappe.throw("Transaction date can't be earlier than previous movement date")
+			frappe.throw(_("Transaction date can't be earlier than previous movement date"))
 
 	def validate_location_and_employee(self, d):
 		self.validate_location(d)

--- a/erpnext/assets/doctype/asset_movement/asset_movement.py
+++ b/erpnext/assets/doctype/asset_movement/asset_movement.py
@@ -53,24 +53,16 @@ class AssetMovement(Document):
 			self.validate_employee(d)
 
 	def validate_transaction_date(self, d):
-		previous_movement_date = frappe.db.sql(
-			"""
-			SELECT MAX(am.transaction_date)
-			FROM `tabAsset Movement` am
-			INNER JOIN `tabAsset Movement Item` ami ON am.name = ami.parent
-			WHERE
-				ami.asset=%s AND
-				am.company=%s AND
-				am.docstatus=1
-				AND am.name!=%s
-		""",
-			(d.asset, self.company, self.name),
-		)[0][0]
-
+		previous_movement_date = frappe.db.get_value(
+			"Asset Movement",
+			[["Asset Movement Item", "asset", "=", d.asset], ["docstatus", "=", 1]],
+			"transaction_date",
+			order_by="transaction_date desc",
+		)
 		if previous_movement_date and get_datetime(previous_movement_date) > get_datetime(
 			self.transaction_date
 		):
-			frappe.throw("Transaction date can't be before previous asset movement date")
+			frappe.throw("Transaction date can't be earlier than previous movement date")
 
 	def validate_location_and_employee(self, d):
 		self.validate_location(d)

--- a/erpnext/assets/doctype/asset_movement/test_asset_movement.py
+++ b/erpnext/assets/doctype/asset_movement/test_asset_movement.py
@@ -150,6 +150,9 @@ class TestAssetMovement(IntegrationTestCase):
 		asset = create_asset(item_code="Macbook Pro", do_not_save=1)
 		asset.save().submit()
 
+		if not frappe.db.exists("Location", "Test Location 2"):
+			frappe.get_doc({"doctype": "Location", "location_name": "Test Location 2"}).insert()
+
 		asset_creation_date = frappe.db.get_value(
 			"Asset Movement",
 			[["Asset Movement Item", "asset", "=", asset.name], ["docstatus", "=", 1]],

--- a/erpnext/assets/doctype/asset_movement/test_asset_movement.py
+++ b/erpnext/assets/doctype/asset_movement/test_asset_movement.py
@@ -3,9 +3,9 @@
 
 import frappe
 from frappe.tests import IntegrationTestCase
-from frappe.utils import now
+from frappe.utils import add_days, now
 
-from erpnext.assets.doctype.asset.test_asset import create_asset_data
+from erpnext.assets.doctype.asset.test_asset import create_asset, create_asset_data
 from erpnext.setup.doctype.employee.test_employee import make_employee
 from erpnext.stock.doctype.purchase_receipt.test_purchase_receipt import make_purchase_receipt
 
@@ -146,6 +146,30 @@ class TestAssetMovement(IntegrationTestCase):
 		movement1.cancel()
 		self.assertEqual(frappe.db.get_value("Asset", asset.name, "location"), "Test Location")
 
+	def test_movement_transaction_date(self):
+		asset = create_asset(item_code="Macbook Pro", do_not_save=1)
+		asset.save().submit()
+
+		asset_creation_date = frappe.db.get_value(
+			"Asset Movement",
+			[["Asset Movement Item", "asset", "=", asset.name], ["docstatus", "=", 1]],
+			"transaction_date",
+		)
+		asset_movement = create_asset_movement(
+			purpose="Transfer",
+			company=asset.company,
+			assets=[
+				{
+					"asset": asset.name,
+					"source_location": "Test Location",
+					"target_location": "Test Location 2",
+				}
+			],
+			transaction_date=add_days(asset_creation_date, -1),
+			do_not_save=True,
+		)
+		self.assertRaises(frappe.ValidationError, asset_movement.save)
+
 
 def create_asset_movement(**args):
 	args = frappe._dict(args)
@@ -164,9 +188,10 @@ def create_asset_movement(**args):
 			"reference_name": args.reference_name,
 		}
 	)
-
-	movement.insert()
-	movement.submit()
+	if not args.do_not_save:
+		movement.insert(ignore_if_duplicate=True)
+		if not args.do_not_submit:
+			movement.submit()
 
 	return movement
 


### PR DESCRIPTION
Issue:
In the current system, Asset Movement does not validate transaction date, which is earlier than previous movement of the same asset

Ref : [55590](https://support.frappe.io/helpdesk/tickets/55590)

Steps to reproduce:
1.  Create an Asset and note the Asset Movement transaction date generated during asset creation.
2.  Create a new Asset Movement with purpose set to “Receipt" and assign it to an employee.
3.  Set the transaction_date of this Asset Movement to a date earlier than the previous Asset Movement’s transaction date.
4.  Submit the Asset Movement.
5.  Observe that the Custodian field on the Asset document remains empty, even though the asset has been issued.

Before

[Screencast from 2026-02-03 17-12-04.webm](https://github.com/user-attachments/assets/66852bcc-da3d-48ce-a70f-1b227d107bbd)

After

[Screencast from 2026-02-03 17-25-24.webm](https://github.com/user-attachments/assets/fe347e94-cd64-4ef0-bf19-cda68df090c6)

