### PR TITLE
fix: unhide book_advance_payments_in_separate_party_account check fie…

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.json
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.json
@@ -701,7 +701,6 @@
    "fetch_from": "company.book_advance_payments_in_separate_party_account",
    "fieldname": "book_advance_payments_in_separate_party_account",
    "fieldtype": "Check",
-   "hidden": 1,
    "label": "Book Advance Payments in Separate Party Account",
    "no_copy": 1,
    "read_only": 1
@@ -793,7 +792,7 @@
    "table_fieldname": "payment_entries"
   }
  ],
- "modified": "2025-12-18 13:56:40.206038",
+ "modified": "2026-02-03 16:08:49.800381",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Payment Entry",


### PR DESCRIPTION
closes #52136 

<img width="1249" height="285" alt="Screenshot 2026-02-03 at 4 12 48 PM" src="https://github.com/user-attachments/assets/a888a57d-6906-49d0-bc39-db6cdf7f6c11" />

json  snippet of the field
<img width="704" height="204" alt="Screenshot 2026-02-03 at 4 13 21 PM" src="https://github.com/user-attachments/assets/60a4e762-6a2f-4181-bfde-26a9429fee86" />
