### PR TITLE
fix(stock): update target field attribute

### DIFF
--- a/erpnext/stock/doctype/inventory_dimension/inventory_dimension.py
+++ b/erpnext/stock/doctype/inventory_dimension/inventory_dimension.py
@@ -139,7 +139,7 @@ class InventoryDimension(Document):
 			self.source_fieldname = scrub(self.dimension_name)
 
 		if not self.target_fieldname:
-			self.target_fieldname = scrub(self.reference_document)
+			self.target_fieldname = scrub(self.dimension_name)
 
 	def on_update(self):
 		self.add_custom_fields()

--- a/erpnext/stock/doctype/inventory_dimension/test_inventory_dimension.py
+++ b/erpnext/stock/doctype/inventory_dimension/test_inventory_dimension.py
@@ -116,12 +116,12 @@ class TestInventoryDimension(IntegrationTestCase):
 		inward.load_from_db()
 
 		sle_data = frappe.db.get_value(
-			"Stock Ledger Entry", {"voucher_no": inward.name}, ["shelf", "warehouse"], as_dict=1
+			"Stock Ledger Entry", {"voucher_no": inward.name}, ["to_shelf", "warehouse"], as_dict=1
 		)
 
 		self.assertEqual(inward.items[0].to_shelf, "Shelf 1")
 		self.assertEqual(sle_data.warehouse, warehouse)
-		self.assertEqual(sle_data.shelf, "Shelf 1")
+		self.assertEqual(sle_data.to_shelf, "Shelf 1")
 
 		outward = make_stock_entry(
 			item_code=item_code,


### PR DESCRIPTION
**Issue:** Stock Reconciliation is not allowed for the same Item and Warehouse when Inventory Dimensions differ (e.g., Plant-A ,Plant-B).

**Step to Reproduce :**
1. Create an Inventory Dimension as ID-Plant for the custom Doctype Plant
2. Create two plants as Plant A and Plant B
3. Create a new item with maintain stock
4.  Create a stock reconciliation with the purpose of opening Stock, add two item rows for the same item with different quantities and dimensions (Item1 has Plant-A and Item2 has Plant-B).

**Description:**
While creating the inventory dimension (ID-Plant) it set the target fieldname as (Reference document). After that, in stock reconciliation for item-1 is plant-A and item-2 is Plant-B the system refers to the reference document("Plant") so it does not allowing .

The expected behaviour is system should allow reconciliation for same item and warehouse with different inventory dimensions.

**Solution:** Changing target_fieldname (reference document to dimension_name) resolved the issue.


**Before :**

[Screencast from 03-02-26 04:15:49 PM IST.webm](https://github.com/user-attachments/assets/f08fd2c0-326b-45b8-87ec-badfc648fc36)

**After :**

[Screencast from 03-02-26 04:14:07 PM IST.webm](https://github.com/user-attachments/assets/52012cac-5fe1-4b3b-abe9-9404f7084fb2)


Backport Needed : V15 and V16