### PR TITLE
fix: rate comparison in stock reco

### DIFF
--- a/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py
+++ b/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py
@@ -524,7 +524,7 @@ class StockReconciliation(StockController):
 
 			float_precision = frappe.db.get_default("float_precision") or 3
 			item_dict["rate"] = flt(item_dict.get("rate"), float_precision)
-			item.valuation_rate = flt(item.valuation_rate, float_precision)
+			item.valuation_rate = flt(item.valuation_rate, float_precision) if item.valuation_rate else None
 			if (
 				(item.qty is None or item.qty == item_dict.get("qty"))
 				and (item.valuation_rate is None or item.valuation_rate == item_dict.get("rate"))

--- a/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py
+++ b/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py
@@ -522,6 +522,9 @@ class StockReconciliation(StockController):
 				if abs(difference_amount) > 0:
 					return True
 
+			float_precision = frappe.db.get_default("float_precision") or 3
+			item_dict["rate"] = flt(item_dict.get("rate"), float_precision)
+			item.valuation_rate = flt(item.valuation_rate, float_precision)
 			if (
 				(item.qty is None or item.qty == item_dict.get("qty"))
 				and (item.valuation_rate is None or item.valuation_rate == item_dict.get("rate"))


### PR DESCRIPTION
When fetching rates, apply precision so that the rates are correctly compared.