### PR TITLE
fix(accounts): Clear cached currency values to prevent incorrect base…

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -323,6 +323,9 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 
 	onload() {
 		var me = this;
+		// Reset cached currency state to avoid incorrect base currency fields and labels
+		this._last_currency = null;
+		this._last_price_list_currency = null;
 
 		if (this.frm.doc.__islocal) {
 			var currency = frappe.defaults.get_user_default("currency");
@@ -1719,9 +1722,6 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 		) {
 			return;
 		}
-
-		this._last_currency = this.frm.doc.currency;
-		this._last_price_list_currency = this.frm.doc.price_list_currency;
 
 		this.change_form_labels(company_currency);
 		this.change_grid_labels(company_currency);


### PR DESCRIPTION
**Ref :** #52328 

**Issue:**
When creating a Credit Note / Return from a Sales Invoice, the form sometimes renders in an incorrect currency state:Base currency fields become visible even though the invoice is not multi-currency.Currency labels fall back to “Company Currency” instead of the actual currency.

**Before:**

[Screencast from 03-02-26 03:34:20 PM IST.webm](https://github.com/user-attachments/assets/16ef26b3-6dd4-4e15-ad8b-248a2d2e976d)


**After:**

[Screencast from 03-02-26 03:35:40 PM IST.webm](https://github.com/user-attachments/assets/9332c949-6610-476d-805f-e6fd2be22240)


**Bacport needed: v16**
