### PR TITLE
fix(project template): clear subject when task is empty

### DIFF
--- a/erpnext/projects/doctype/project_template/project_template.js
+++ b/erpnext/projects/doctype/project_template/project_template.js
@@ -19,6 +19,13 @@ frappe.ui.form.on("Project Template", {
 frappe.ui.form.on("Project Template Task", {
 	task: function (frm, cdt, cdn) {
 		var row = locals[cdt][cdn];
+
+		if (!row.task) {
+			row.subject = null;
+			refresh_field("tasks");
+			return;
+		}
+
 		frappe.db.get_value("Task", row.task, "subject", (value) => {
 			row.subject = value.subject;
 			refresh_field("tasks");

--- a/erpnext/projects/doctype/task/task.json
+++ b/erpnext/projects/doctype/task/task.json
@@ -368,6 +368,7 @@
    "options": "User"
   },
   {
+   "allow_in_quick_entry": 1,
    "default": "0",
    "fieldname": "is_template",
    "fieldtype": "Check",
@@ -404,11 +405,11 @@
  "is_tree": 1,
  "links": [],
  "max_attachments": 5,
- "modified": "2025-10-16 08:39:12.214577",
+ "modified": "2026-02-05 09:58:38.052875",
  "modified_by": "Administrator",
  "module": "Projects",
  "name": "Task",
- "naming_rule": "Expression (old style)",
+ "naming_rule": "Expression",
  "nsm_parent_field": "parent_task",
  "owner": "Administrator",
  "permissions": [
@@ -425,6 +426,7 @@
   }
  ],
  "quick_entry": 1,
+ "row_format": "Dynamic",
  "search_fields": "subject",
  "show_name_in_global_search": 1,
  "show_preview_popup": 1,


### PR DESCRIPTION
Issue:
When a Task is created from a Project Template without enabling **Is Template**, the task is not set correctly, but the subject gets populated incorrectly.

Ref: [#58945](https://support.frappe.io/helpdesk/tickets/58945)

Steps to Reproduce:
- Create a Task from a Project Template without enabling **Is Template**
- Notice that the Task is not set correctly, and the subject is filled incorrectly

Added **Is Template** field to be visible in Quick Entry for better usability

Backport needed:v16