### PR TITLE
fix(accounts): prevent redundant stock updates from invoices

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js
@@ -77,6 +77,12 @@ erpnext.accounts.PurchaseInvoice = class PurchaseInvoice extends erpnext.buying.
 	refresh(doc) {
 		const me = this;
 		super.refresh();
+		// Hide update stock field if has purchase receipts
+		let has_purchase_receipt = (this.frm.doc.items || []).some((item) => item.purchase_receipt);
+		let can_update_stock = !has_purchase_receipt;
+
+		this.frm.set_df_property("update_stock", "read_only", !can_update_stock);
+		this.frm.toggle_display("update_stock", can_update_stock);
 
 		hide_fields(this.frm.doc);
 		// Show / Hide button

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
@@ -1129,9 +1129,12 @@ frappe.ui.form.on("Sales Invoice", {
 		if (frm.doc.is_debit_note) {
 			frm.set_df_property("return_against", "label", __("Adjustment Against"));
 		}
+		// Hide update stock field if has subcontracted items or linked delivery notes
+		let has_delivery_note = (frm.doc.items || []).some((item) => item.delivery_note);
+		let can_update_stock = !frm.doc.has_subcontracted && !has_delivery_note;
 
-		frm.set_df_property("update_stock", "read_only", frm.doc.has_subcontracted);
-		frm.toggle_display("update_stock", !frm.doc.has_subcontracted);
+		frm.set_df_property("update_stock", "read_only", !can_update_stock);
+		frm.toggle_display("update_stock", can_update_stock);
 	},
 });
 


### PR DESCRIPTION
**Ref** : #52358 

**Issue :** When invoices are created from stock-impacting documents, the Update Stock checkbox is still visible/shown.

In the selling flow, stock is reduced at Delivery Note stage. When a Sales Invoice is created from a Delivery Note, stock movement has already occurred, so Update Stock should not be allowed on the invoice to avoid duplicate stock impact.For direct Sales Invoices (not created from Delivery Note), Update Stock must remain available so that stock can be reduced from the invoice itself.
Stock is already updated at Purchase Receipt stage. When a Purchase Invoice is created from a Purchase Receipt, Update Stock should not be allowed on the invoice.

**Steps to reproduce:**
   1.Create a Stock Item with available quantity.
   2.Create a Delivery Note for the item and submit it.
→ Stock is reduced at this stage.
   3.From the Delivery Note, click Create → Sales Invoice.
   4.Observed behavior , Update stock checkbox is still visible.


**Before:**

[Screencast from 04-02-26 04:31:24 PM IST.webm](https://github.com/user-attachments/assets/26e39582-2dc8-46ee-9fdf-ace187112020)

**After:**

[Screencast from 04-02-26 04:32:53 PM IST.webm](https://github.com/user-attachments/assets/b937b1f4-baa0-4342-a25f-445ac4709976)


**Bacport needed:** v15 and v16
