### PR TITLE
fix: hide update stock checkbox if sales invoice (created from delivery note/contains items from delivery note)

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
@@ -1132,6 +1132,13 @@ frappe.ui.form.on("Sales Invoice", {
 
 		frm.set_df_property("update_stock", "read_only", frm.doc.has_subcontracted);
 		frm.toggle_display("update_stock", !frm.doc.has_subcontracted);
+		toggle_update_stock(frm);
+	},
+});
+
+frappe.ui.form.on("Sales Invoice Item", {
+	items_remove(frm) {
+		toggle_update_stock(frm);
 	},
 });
 
@@ -1198,3 +1205,9 @@ var select_loyalty_program = function (frm, loyalty_programs) {
 
 	dialog.show();
 };
+
+function toggle_update_stock(frm) {
+	const dn_exists = (frm.doc.items || []).some((row) => row.delivery_note);
+	frm.set_df_property("update_stock", "hidden", dn_exists);
+	if (dn_exists) frm.set_value("update_stock", 0);
+}

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.json
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.json
@@ -2306,7 +2306,7 @@
    "link_fieldname": "consolidated_invoice"
   }
  ],
- "modified": "2026-02-03 14:09:44.347133",
+ "modified": "2026-02-03 21:52:16.045815",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Sales Invoice",


### PR DESCRIPTION


https://github.com/user-attachments/assets/1cb6e699-9833-4b2f-b050-3a5721c2b425



