### PR TITLE
fix: obtaining bom_no in add_items

### DIFF
--- a/erpnext/manufacturing/doctype/production_plan/production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.py
@@ -496,7 +496,7 @@ class ProductionPlan(Document):
 
 			item_details = get_item_details(data.item_code, throw=False)
 			if self.combine_items:
-				bom_no = item_details.bom_no
+				bom_no = item_details.get("bom_no")
 				if data.get("bom_no"):
 					bom_no = data.get("bom_no")
 


### PR DESCRIPTION
When creating a new Production Plan, in cases where "Consolidate Sales Order Items" is checked (which maps to the combine_items field), an AttributeError can occur on line 499 as the item_details variable is a dictionary. This PR updates this line to access the bom_no key correctly.