### PR TITLE
fix(delivery note): avoid carrying si_detail on return delivery note

### DIFF
--- a/erpnext/controllers/sales_and_purchase_return.py
+++ b/erpnext/controllers/sales_and_purchase_return.py
@@ -596,7 +596,6 @@ def make_return_doc(doctype: str, source_name: str, target_doc=None, return_agai
 			target_doc.against_sales_order = source_doc.against_sales_order
 			target_doc.against_sales_invoice = source_doc.against_sales_invoice
 			target_doc.so_detail = source_doc.so_detail
-			target_doc.si_detail = source_doc.si_detail
 			target_doc.expense_account = source_doc.expense_account
 			target_doc.dn_detail = source_doc.name
 			if default_warehouse_for_sales_return:

--- a/erpnext/stock/doctype/delivery_note/delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.py
@@ -387,11 +387,12 @@ class DeliveryNote(SellingController):
 		)
 
 	def validate_sales_invoice_references(self):
-		fields = ["against_sales_invoice"]
-		if not self.is_return:
-			fields.append("si_detail")
+		if self.is_return:
+			return
 
-		self._validate_dependent_item_fields(fields, _("References to Sales Invoices are Incomplete"))
+		self._validate_dependent_item_fields(
+			["against_sales_invoice", "si_detail"], _("References to Sales Invoices are Incomplete")
+		)
 
 	def _validate_dependent_item_fields(self, fields: list[str], error_title: str):
 		errors = []

--- a/erpnext/stock/doctype/delivery_note/delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.py
@@ -383,29 +383,34 @@ class DeliveryNote(SellingController):
 
 	def validate_sales_order_references(self):
 		self._validate_dependent_item_fields(
-			"against_sales_order", "so_detail", _("References to Sales Orders are Incomplete")
+			["against_sales_order", "so_detail"], _("References to Sales Orders are Incomplete")
 		)
 
 	def validate_sales_invoice_references(self):
-		self._validate_dependent_item_fields(
-			"against_sales_invoice", "si_detail", _("References to Sales Invoices are Incomplete")
-		)
+		fields = ["against_sales_invoice"]
+		if not self.is_return:
+			fields.append("si_detail")
 
-	def _validate_dependent_item_fields(self, field_a: str, field_b: str, error_title: str):
+		self._validate_dependent_item_fields(fields, _("References to Sales Invoices are Incomplete"))
+
+	def _validate_dependent_item_fields(self, fields: list[str], error_title: str):
 		errors = []
 		for item in self.items:
-			missing_label = None
-			if item.get(field_a) and not item.get(field_b):
-				missing_label = item.meta.get_label(field_b)
-			elif item.get(field_b) and not item.get(field_a):
-				missing_label = item.meta.get_label(field_a)
+			present_fields = [f for f in fields if item.get(f)]
+			missing_fields = set(fields) - set(present_fields)
 
-			if missing_label and missing_label != "No Label":
-				errors.append(
-					_("The field {0} in row {1} is not set").format(
-						frappe.bold(_(missing_label)), frappe.bold(item.idx)
+			if not present_fields or not missing_fields:
+				continue
+
+			for field in missing_fields:
+				missing_label = item.meta.get_label(field)
+				if missing_label and missing_label != "No Label":
+					errors.append(
+						_("The field {0} in row {1} is not set").format(
+							frappe.bold(_(missing_label)),
+							frappe.bold(item.idx),
+						)
 					)
-				)
 
 		if errors:
 			frappe.throw("<br>".join(errors), title=error_title)

--- a/erpnext/stock/doctype/delivery_note/delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.py
@@ -659,7 +659,7 @@ class DeliveryNote(SellingController):
 	def update_billing_status(self, update_modified=True):
 		updated_delivery_notes = [self.name]
 		for d in self.get("items"):
-			if d.si_detail and not d.so_detail:
+			if d.si_detail and d.against_sales_invoice:
 				d.db_set("billed_amt", d.amount, update_modified=update_modified)
 			elif d.so_detail:
 				updated_delivery_notes += update_billed_amount_based_on_so(d.so_detail, update_modified)


### PR DESCRIPTION
**Issue:** When creating a Return Delivery Note against a fully billed Delivery Note, the Per Billed field in the Return Delivery Note is set to 100%, even though no Credit Note has been created against it.

**Ref:** [58819](https://support.frappe.io/helpdesk/tickets/58819)

**Steps to Reproduce:**
1) Create a **Delivery Note**.
2) Create a **Sales Invoice** against the **Delivery Note** and submit it.
3) Create a **Return Delivery Note** against the previously created Delivery Note.
4) Observe the `Per Billed` field being set to 100 even without a **Credit Note** against the return.

**Before:**

https://github.com/user-attachments/assets/09518666-e40c-4327-a45c-cf488778cdd2

**After:**

https://github.com/user-attachments/assets/f1707e41-1352-4682-8c52-f046393f49a7

**Backport Needed v15**