### PR TITLE
feat(pos): allow warehouse change configuration

### DIFF
--- a/erpnext/accounts/doctype/pos_profile/pos_profile.json
+++ b/erpnext/accounts/doctype/pos_profile/pos_profile.json
@@ -63,6 +63,8 @@
   "allow_rate_change",
   "column_break_hwfg",
   "allow_discount_change",
+  "column_break_egpi",
+  "allow_warehouse_change",
   "section_break_15",
   "applicable_for_users",
   "section_break_23",
@@ -542,6 +544,16 @@
   {
    "fieldname": "column_break_hwfg",
    "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "column_break_egpi",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "fieldname": "allow_warehouse_change",
+   "fieldtype": "Check",
+   "label": "Allow User to Edit Warehouse"
   }
  ],
  "grid_page_length": 50,
@@ -570,7 +582,7 @@
    "link_fieldname": "pos_profile"
   }
  ],
- "modified": "2026-02-05 03:38:13.216277",
+ "modified": "2026-02-05 04:36:40.757162",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "POS Profile",

--- a/erpnext/accounts/doctype/pos_profile/pos_profile.py
+++ b/erpnext/accounts/doctype/pos_profile/pos_profile.py
@@ -34,6 +34,7 @@ class POSProfile(Document):
 		allow_discount_change: DF.Check
 		allow_partial_payment: DF.Check
 		allow_rate_change: DF.Check
+		allow_warehouse_change: DF.Check
 		applicable_for_users: DF.Table[POSProfileUser]
 		apply_discount_on: DF.Literal["Grand Total", "Net Total"]
 		auto_add_item_to_cart: DF.Check

--- a/erpnext/selling/page/point_of_sale/pos_item_details.js
+++ b/erpnext/selling/page/point_of_sale/pos_item_details.js
@@ -5,6 +5,7 @@ erpnext.PointOfSale.ItemDetails = class {
 		this.hide_images = settings.hide_images;
 		this.allow_rate_change = settings.allow_rate_change;
 		this.allow_discount_change = settings.allow_discount_change;
+		this.allow_warehouse_change = settings.allow_warehouse_change;
 		this.current_item = {};
 		this.frm_doctype = settings.frm_doctype;
 
@@ -287,6 +288,7 @@ erpnext.PointOfSale.ItemDetails = class {
 					filters: { company: this.events.get_frm().doc.company, is_group: 0 },
 				};
 			};
+			this.warehouse_control.df.read_only = !this.allow_warehouse_change;
 			this.warehouse_control.refresh();
 		}
 


### PR DESCRIPTION
Introduced a configuration on the POS Profile that allows users to edit the warehouse field in the POS Item Details View. 

Screenshot:

<img width="2840" height="1184" alt="image" src="https://github.com/user-attachments/assets/a5a99a30-fc02-4fd8-9125-e98d2fa660f7" />


<!-- no-docs -->