### PR TITLE
fix(financial statement): wrap match_conditions

### DIFF
--- a/erpnext/accounts/report/financial_statements.py
+++ b/erpnext/accounts/report/financial_statements.py
@@ -18,7 +18,7 @@ from erpnext.accounts.doctype.accounting_dimension.accounting_dimension import (
 	get_dimension_with_children,
 )
 from erpnext.accounts.report.utils import convert_to_presentation_currency, get_currency
-from erpnext.accounts.utils import get_fiscal_year, get_zero_cutoff
+from erpnext.accounts.utils import build_qb_match_conditions, get_fiscal_year, get_zero_cutoff
 
 
 def get_period_list(
@@ -564,18 +564,16 @@ def get_accounting_entries(
 		account_filter_query = get_account_filter_query(root_lft, root_rgt, root_type, gl_entry)
 		query = query.where(ExistsCriterion(account_filter_query))
 
-	from frappe.desk.reportview import build_match_conditions
-
-	query, params = query.walk()
-	match_conditions = build_match_conditions(doctype)
+	match_conditions = build_qb_match_conditions(doctype)
 
 	if match_conditions:
-		query += " AND (" + match_conditions + ")"
+		for condition in match_conditions:
+			query = query.where(condition)
 
 	if group_by_account:
-		query += " GROUP BY `account`"
+		query = query.groupby(gl_entry.account)
 
-	return frappe.db.sql(query, params, as_dict=True)
+	return query.run(as_dict=True)
 
 
 def get_account_filter_query(root_lft, root_rgt, root_type, gl_entry):

--- a/erpnext/accounts/report/financial_statements.py
+++ b/erpnext/accounts/report/financial_statements.py
@@ -570,7 +570,7 @@ def get_accounting_entries(
 	match_conditions = build_match_conditions(doctype)
 
 	if match_conditions:
-		query += "and" + match_conditions
+		query += " AND (" + match_conditions + ")"
 
 	if group_by_account:
 		query += " GROUP BY `account`"


### PR DESCRIPTION
Issue: Unable to load the financial report due to an SQL syntax error.

Ref: [#59325](https://support.frappe.io/helpdesk/tickets/59325)

Steps:

1. Create a new user and add a User Permission for Company. Grant the required roles and permissions to the user.
2. Impersonate the user and try to load the Balance Sheet report.


Traceback:

```
Traceback with variables (most recent call last):
  File "apps/frappe/frappe/desk/query_report.py", line 231, in run
    result = generate_report_result(report, filters, user, custom_columns, is_tree, parent_field)
      report_name = 'Balance Sheet'
      filters = '{"company":"Aerele (Demo)","filter_based_on":"Fiscal Year","period_start_date":"2025-04-01","period_end_date":"2026-03-31","from_fiscal_year":"2025-2026","to_fiscal_year":"2025-2026","periodicity":"Yearly","cost_center":[],"project":[],"show_account_details":"Summary","selected_view":"Report","accumulated_values":1,"include_default_book_entries":1}'
      user = 'ravi@aerele.in'
      ignore_prepared_report = 'false'
      custom_columns = None
      is_tree = 'true'
      parent_field = 'parent_account'
      are_default_filters = 'false'
      js_filters = '[{"fieldname":"company","fieldtype":"Link","options":"Company"},{"fieldname":"finance_book","fieldtype":"Link","options":"Finance Book"},{"fieldname":"from_fiscal_year","fieldtype":"Link","options":"Fiscal Year"},{"fieldname":"to_fiscal_year","fieldtype":"Link","options":"Fiscal Year"},{"fieldname":"report_template","fieldtype":"Link","options":"Financial Report Template"}]'
      report = Report (Balance Sheet)
      result = None
  File "apps/frappe/frappe/__init__.py", line 486, in wrapper_fn
    retval = fn(*args, **get_newargs(fn, kwargs))
      args = (Report (Balance Sheet), '{"company":"Aerele (Demo)","filter_based_on":"Fiscal Year","period_start_date":"2025-04-01","period_end_date":"2026-03-31","from_fiscal_year":"2025-2026","to_fiscal_year":"2025-2026","periodicity":"Yearly","cost_center":[],"project":[],"show_account_details":"Summary","selected_view":"Report","accumulated_values":1,"include_default_book_entries":1}', 'ravi@aerele.in', None, 'true', 'parent_account')
      kwargs = {}
      switched_connection = False
      fn = <function generate_report_result at 0x107fe8250>
  File "apps/frappe/frappe/desk/query_report.py", line 86, in generate_report_result
    res = get_report_result(report, filters) or []
      report = Report (Balance Sheet)
      filters = {'company': 'Aerele (Demo)', 'filter_based_on': 'Fiscal Year', 'period_start_date': '2025-04-01', 'period_end_date': '2026-03-31', 'from_fiscal_year': '2025-2026', 'to_fiscal_year': '2025-2026', 'periodicity': 'Yearly', 'cost_center': [], 'project': [], 'show_account_details': 'Summary', 'selected_view': 'Report', 'accumulated_values': 1, 'include_default_book_entries': 1}
      user = 'ravi@aerele.in'
      custom_columns = None
      is_tree = 'true'
      parent_field = 'parent_account'
  File "apps/frappe/frappe/desk/query_report.py", line 67, in get_report_result
    res = report.execute_script_report(filters)
      report = Report (Balance Sheet)
      filters = {'company': 'Aerele (Demo)', 'filter_based_on': 'Fiscal Year', 'period_start_date': '2025-04-01', 'period_end_date': '2026-03-31', 'from_fiscal_year': '2025-2026', 'to_fiscal_year': '2025-2026', 'periodicity': 'Yearly', 'cost_center': [], 'project': [], 'show_account_details': 'Summary', 'selected_view': 'Report', 'accumulated_values': 1, 'include_default_book_entries': 1}
      res = None
  File "apps/frappe/frappe/core/doctype/report/report.py", line 182, in execute_script_report
    res = self.execute_module(filters)
      self = Report (Balance Sheet)
      filters = {'company': 'Aerele (Demo)', 'filter_based_on': 'Fiscal Year', 'period_start_date': '2025-04-01', 'period_end_date': '2026-03-31', 'from_fiscal_year': '2025-2026', 'to_fiscal_year': '2025-2026', 'periodicity': 'Yearly', 'cost_center': [], 'project': [], 'show_account_details': 'Summary', 'selected_view': 'Report', 'accumulated_values': 1, 'include_default_book_entries': 1}
      threshold = 15
      start_time = 2026-02-05 09:33:01.736401
      prepared_report_watcher = <Timer(Thread-14, stopped daemon 123145635500032)>
  File "apps/frappe/frappe/core/doctype/report/report.py", line 198, in execute_module
    return frappe.get_attr(method_name)(frappe._dict(filters))
      self = Report (Balance Sheet)
      filters = {'company': 'Aerele (Demo)', 'filter_based_on': 'Fiscal Year', 'period_start_date': '2025-04-01', 'period_end_date': '2026-03-31', 'from_fiscal_year': '2025-2026', 'to_fiscal_year': '2025-2026', 'periodicity': 'Yearly', 'cost_center': [], 'project': [], 'show_account_details': 'Summary', 'selected_view': 'Report', 'accumulated_values': 1, 'include_default_book_entries': 1}
      module = 'Accounts'
      method_name = 'erpnext.accounts.report.balance_sheet.balance_sheet.execute'
  File "apps/erpnext/erpnext/accounts/report/balance_sheet/balance_sheet.py", line 41, in execute
    asset = get_data(
      filters = {'company': 'Aerele (Demo)', 'filter_based_on': 'Fiscal Year', 'period_start_date': datetime.date(2025, 4, 1), 'period_end_date': '2026-03-31', 'from_fiscal_year': '2025-2026', 'to_fiscal_year': '2025-2026', 'periodicity': 'Yearly', 'cost_center': [], 'project': [], 'show_account_details': 'Summary', 'selected_view': 'Report', 'accumulated_values': 1, 'include_default_book_entries': 1}
      period_list = [frappe.types.frappedict._dict{'from_date': 2025-04-01, 'to_date': 2026-03-31, 'to_date_fiscal_year': '2025-2026', 'from_date_fiscal_year_start_date': 2025-04-01, 'key': 'mar_2026', 'label': '2025-2026', 'year_start_date': 2025-04-01, 'year_end_date': 2026-03-31}]
      currency = 'INR'
  File "apps/erpnext/erpnext/accounts/report/financial_statements.py", line 188, in get_data
    set_gl_entries_by_account(
      company = 'Aerele (Demo)'
      root_type = 'Asset'
      balance_must_be = 'Debit'
      period_list = [frappe.types.frappedict._dict{'from_date': 2025-04-01, 'to_date': 2026-03-31, 'to_date_fiscal_year': '2025-2026', 'from_date_fiscal_year_start_date': 2025-04-01, 'key': 'mar_2026', 'label': '2025-2026', 'year_start_date': 2025-04-01, 'year_end_date': 2026-03-31}]
      filters = {'company': 'Aerele (Demo)', 'filter_based_on': 'Fiscal Year', 'period_start_date': datetime.date(2025, 4, 1), 'period_end_date': '2026-03-31', 'from_fiscal_year': '2025-2026', 'to_fiscal_year': '2025-2026', 'periodicity': 'Yearly', 'cost_center': [], 'project': [], 'show_account_details': 'Summary', 'selected_view': 'Report', 'accumulated_values': 1, 'include_default_book_entries': 1}
      accumulated_values = 1
      only_current_fiscal_year = False
      ignore_closing_entries = False
      ignore_accumulated_values_for_fy = False
      total = True
      accounts = [frappe.types.frappedict._dict{'name': 'Application of Funds (Assets) - AD', 'account_number': '', 'parent_account': None, 'lft': 107, 'rgt': 158, 'root_type': 'Asset', 'report_type': 'Balance Sheet', 'account_name': 'Application of Funds (Assets)', 'include_in_gross': 0, 'account_type': '', 'is_group': 1, 'indent': 0}, frappe.types.frappedict._dict{'name': 'Current Assets - AD', 'account_number': '', 'parent_account': 'Application of Funds (Assets) - AD', 'lft': 108, 'rgt': 135, 'root_type': 'Asset', 'report_type': 'Balance Sheet', 'account_name': 'Current Assets', 'include_in_gross': 0, 'account_type': '', 'is_group': 1, 'indent': 1}, frappe.types.frappedict._dict{'name': 'Accounts Rece...ict{'name': 'Temporary Opening - AD', 'account_number': '', 'parent_account': 'Temporary Accounts - AD', 'lft': 155, 'rgt': 156, 'root_type': 'Asset', 'report_type': 'Balance Sheet', 'account_name': 'Temporary Opening', 'include_in_gross': 0, 'account_type': 'Temporary', 'is_group': 0, 'indent': 2}]
      accounts_by_name = {'Application of Funds (Assets) - AD': {'name': 'Application of Funds (Assets) - AD', 'account_number': '', 'parent_account': None, 'lft': 107, 'rgt': 158, 'root_type': 'Asset', 'report_type': 'Balance Sheet', 'account_name': 'Application of Funds (Assets)', 'include_in_gross': 0, 'account_type': '', 'is_group': 1, 'indent': 0}, 'Current Assets - AD': {'name': 'Current Assets - AD', 'account_number': '', 'parent_account': 'Application of Funds (Assets) - AD', 'lft': 108, 'rgt': 135, 'root_type': 'Asset', 'report_type': 'Balance Sheet', 'account_name': 'Current Assets', 'include_in_gross': 0, 'account_type': '', 'is_group': 1, 'indent': 1}, 'Accounts Receivable - AD': {'name': 'Accounts Recei...': {'name': 'Temporary Opening - AD', 'account_number': '', 'parent_account': 'Temporary Accounts - AD', 'lft': 155, 'rgt': 156, 'root_type': 'Asset', 'report_type': 'Balance Sheet', 'account_name': 'Temporary Opening', 'include_in_gross': 0, 'account_type': 'Temporary', 'is_group': 0, 'indent': 2}}
      parent_children_map = {None: [{'name': 'Application of Funds (Assets) - AD', 'account_number': '', 'parent_account': None, 'lft': 107, 'rgt': 158, 'root_type': 'Asset', 'report_type': 'Balance Sheet', 'account_name': 'Application of Funds (Assets)', 'include_in_gross': 0, 'account_type': '', 'is_group': 1, 'indent': 0}], 'Application of Funds (Assets) - AD': [{'name': 'Current Assets - AD', 'account_number': '', 'parent_account': 'Application of Funds (Assets) - AD', 'lft': 108, 'rgt': 135, 'root_type': 'Asset', 'report_type': 'Balance Sheet', 'account_name': 'Current Assets', 'include_in_gross': 0, 'account_type': '', 'is_group': 1, 'indent': 1}, {'name': 'Fixed Assets - AD', 'account_number': '', 'parent_accoun... [{'name': 'Temporary Opening - AD', 'account_number': '', 'parent_account': 'Temporary Accounts - AD', 'lft': 155, 'rgt': 156, 'root_type': 'Asset', 'report_type': 'Balance Sheet', 'account_name': 'Temporary Opening', 'include_in_gross': 0, 'account_type': 'Temporary', 'is_group': 0, 'indent': 2}]}
      company_currency = 'INR'
      gl_entries_by_account = {}
      root = {'lft': 1, 'rgt': 48}
  File "apps/erpnext/erpnext/accounts/report/financial_statements.py", line 482, in set_gl_entries_by_account
    gl_entries += get_accounting_entries(
      company = 'Aerele (Demo)'
      from_date = None
      to_date = 2026-03-31
      filters = {'company': 'Aerele (Demo)', 'filter_based_on': 'Fiscal Year', 'period_start_date': datetime.date(2025, 4, 1), 'period_end_date': '2026-03-31', 'from_fiscal_year': '2025-2026', 'to_fiscal_year': '2025-2026', 'periodicity': 'Yearly', 'cost_center': [], 'project': [], 'show_account_details': 'Summary', 'selected_view': 'Report', 'accumulated_values': 1, 'include_default_book_entries': 1}
      gl_entries_by_account = {}
      root_lft = 1
      root_rgt = 48
      root_type = 'Asset'
      ignore_closing_entries = False
      ignore_opening_entries = False
      group_by_account = False
      ignore_reporting_currency = True
      gl_entries = []
      ignore_closing_balances = 0
      last_period_closing_voucher = []
  File "apps/erpnext/erpnext/accounts/report/financial_statements.py", line 578, in get_accounting_entries
    return frappe.db.sql(query, params, as_dict=True)
      doctype = 'GL Entry'
      from_date = None
      to_date = 2026-03-31
      filters = {'company': 'Aerele (Demo)', 'filter_based_on': 'Fiscal Year', 'period_start_date': datetime.date(2025, 4, 1), 'period_end_date': '2026-03-31', 'from_fiscal_year': '2025-2026', 'to_fiscal_year': '2025-2026', 'periodicity': 'Yearly', 'cost_center': [], 'project': [], 'show_account_details': 'Summary', 'selected_view': 'Report', 'accumulated_values': 1, 'include_default_book_entries': 1}
      root_lft = 1
      root_rgt = 48
      root_type = 'Asset'
      ignore_closing_entries = False
      period_closing_voucher = None
      ignore_opening_entries = False
      group_by_account = False
      ignore_reporting_currency = True
      gl_entry = "tabGL Entry"
      query = 'SELECT `account`,`debit`,`credit`,`debit_in_account_currency`,`credit_in_account_currency`,`account_currency`,`posting_date`,`is_opening`,`fiscal_year` FROM `tabGL Entry` FORCE INDEX (`posting_date_company_index`) WHERE `company`=%(param1)s AND `is_cancelled`=0 AND `posting_date`<='2026-03-31' AND (`finance_book` IN (%(param2)s,%(param3)s,%(param4)s) OR `finance_book` IS NULL) AND EXISTS (SELECT `tabAccount`.`name` FROM `tabAccount` WHERE `tabAccount`.`name`=`tabGL Entry`.`account` AND `tabAccount`.`is_group`=0 AND `tabAccount`.`lft`>=1 AND `tabAccount`.`rgt`<=48 AND `tabAccount`.`root_type`=%(param5)s)andIFNULL(`tabGL Entry`.`company`,'')='' OR `tabGL Entry`.`company` IN ('Aerele (Demo)')'
      ignore_is_opening = 0
      account_filter_query = SELECT `tabAccount`.`name` FROM `tabAccount` WHERE `tabAccount`.`name`=`tabGL Entry`.`account` AND `tabAccount`.`is_group`=0 AND `tabAccount`.`lft`>=1 AND `tabAccount`.`rgt`<=48 AND `tabAccount`.`root_type`='Asset'
      build_match_conditions = <function build_match_conditions at 0x104a13480>
      params = {'param1': 'Aerele (Demo)', 'param2': '', 'param3': '', 'param4': '', 'param5': 'Asset'}
      match_conditions = 'IFNULL(`tabGL Entry`.`company`,'')='' OR `tabGL Entry`.`company` IN ('Aerele (Demo)')'
  File "apps/frappe/frappe/database/database.py", line 272, in sql
    self.execute_query(query, values)
      self = frappe.database.mariadb.mysqlclient.MariaDBDatabase(after_commit=frappe.utils.CallbackManager(-), after_rollback=frappe.utils.CallbackManager(-), auto_commit_on_many_writes=0, before_commit=frappe.utils.CallbackManager(-), before_rollback=frappe.utils.CallbackManager(-), cur_db_name='_33a1d31da9c0beb1', db_type='mariadb', host='127.0.0.1', last_query='SELECT `share_name` FROM `tabDocShare` WHERE `read`=1 AND `share_doctype`='GL Entry' AND (`user`='ravi@aerele.in' OR `everyone`=1)', logger=<Logger database-no_ic (WARNING)>, password='tRIhV6a0uEvKiEdH', port=3306, socket=None, transaction_writes=0, type_map={'Currency': ('decimal', '21,9'), 'Int': ('int', '11'), 'Long Int': ('bigint', '20')...'), 'Color': ('varchar', 140), 'Barcode': ('longtext', ''), 'Geolocation': ('longtext', ''), 'Duration': ('decimal', '21,9'), 'Icon': ('varchar', 140), 'Phone': ('varchar', 140), 'Autocomplete': ('varchar', 140), 'JSON': ('json', '')}, user='_33a1d31da9c0beb1', value_cache=collections.defaultdict{})
      query = 'SELECT `account`,`debit`,`credit`,`debit_in_account_currency`,`credit_in_account_currency`,`account_currency`,`posting_date`,`is_opening`,`fiscal_year` FROM `tabGL Entry` FORCE INDEX (`posting_date_company_index`) WHERE `company`=%(param1)s AND `is_cancelled`=0 AND `posting_date`<='2026-03-31' AND (`finance_book` IN (%(param2)s,%(param3)s,%(param4)s) OR `finance_book` IS NULL) AND EXISTS (SELECT `tabAccount`.`name` FROM `tabAccount` WHERE `tabAccount`.`name`=`tabGL Entry`.`account` AND `tabAccount`.`is_group`=0 AND `tabAccount`.`lft`>=1 AND `tabAccount`.`rgt`<=48 AND `tabAccount`.`root_type`=%(param5)s)andcoalesce(`tabGL Entry`.`company`,'')='' OR `tabGL Entry`.`company` IN ('Aerele (Demo)')'
      values = {'param1': 'Aerele (Demo)', 'param2': '', 'param3': '', 'param4': '', 'param5': 'Asset'}
      as_dict = True
      as_list = 0
      debug = False
      ignore_ddl = 0
      auto_commit = 0
      update = None
      explain = False
      run = True
      pluck = False
      as_iterator = False
      query_type = 'select'
      trace_id = None
  File "apps/frappe/frappe/database/database.py", line 372, in execute_query
    return self._cursor.execute(query, values)
      self = frappe.database.mariadb.mysqlclient.MariaDBDatabase(after_commit=frappe.utils.CallbackManager(-), after_rollback=frappe.utils.CallbackManager(-), auto_commit_on_many_writes=0, before_commit=frappe.utils.CallbackManager(-), before_rollback=frappe.utils.CallbackManager(-), cur_db_name='_33a1d31da9c0beb1', db_type='mariadb', host='127.0.0.1', last_query='SELECT `share_name` FROM `tabDocShare` WHERE `read`=1 AND `share_doctype`='GL Entry' AND (`user`='ravi@aerele.in' OR `everyone`=1)', logger=<Logger database-no_ic (WARNING)>, password='tRIhV6a0uEvKiEdH', port=3306, socket=None, transaction_writes=0, type_map={'Currency': ('decimal', '21,9'), 'Int': ('int', '11'), 'Long Int': ('bigint', '20')...'), 'Color': ('varchar', 140), 'Barcode': ('longtext', ''), 'Geolocation': ('longtext', ''), 'Duration': ('decimal', '21,9'), 'Icon': ('varchar', 140), 'Phone': ('varchar', 140), 'Autocomplete': ('varchar', 140), 'JSON': ('json', '')}, user='_33a1d31da9c0beb1', value_cache=collections.defaultdict{})
      query = 'SELECT `account`,`debit`,`credit`,`debit_in_account_currency`,`credit_in_account_currency`,`account_currency`,`posting_date`,`is_opening`,`fiscal_year` FROM `tabGL Entry` FORCE INDEX (`posting_date_company_index`) WHERE `company`=%(param1)s AND `is_cancelled`=0 AND `posting_date`<='2026-03-31' AND (`finance_book` IN (%(param2)s,%(param3)s,%(param4)s) OR `finance_book` IS NULL) AND EXISTS (SELECT `tabAccount`.`name` FROM `tabAccount` WHERE `tabAccount`.`name`=`tabGL Entry`.`account` AND `tabAccount`.`is_group`=0 AND `tabAccount`.`lft`>=1 AND `tabAccount`.`rgt`<=48 AND `tabAccount`.`root_type`=%(param5)s)andcoalesce(`tabGL Entry`.`company`,'')='' OR `tabGL Entry`.`company` IN ('Aerele (Demo)')'
      values = {'param1': 'Aerele (Demo)', 'param2': '', 'param3': '', 'param4': '', 'param5': 'Asset'}
  File "env/lib/python3.14/site-packages/MySQLdb/cursors.py", line 179, in execute
    res = self._query(mogrified_query)
      self = MySQLdb.cursors.Cursor(arraysize=1, description=None, description_flags=None, lastrowid=None, rowcount=None, rownumber=None)
      query = 'SELECT `account`,`debit`,`credit`,`debit_in_account_currency`,`credit_in_account_currency`,`account_currency`,`posting_date`,`is_opening`,`fiscal_year` FROM `tabGL Entry` FORCE INDEX (`posting_date_company_index`) WHERE `company`=%(param1)s AND `is_cancelled`=0 AND `posting_date`<='2026-03-31' AND (`finance_book` IN (%(param2)s,%(param3)s,%(param4)s) OR `finance_book` IS NULL) AND EXISTS (SELECT `tabAccount`.`name` FROM `tabAccount` WHERE `tabAccount`.`name`=`tabGL Entry`.`account` AND `tabAccount`.`is_group`=0 AND `tabAccount`.`lft`>=1 AND `tabAccount`.`rgt`<=48 AND `tabAccount`.`root_type`=%(param5)s)andcoalesce(`tabGL Entry`.`company`,'')='' OR `tabGL Entry`.`company` IN ('Aerele (Demo)')'
      args = {'param1': 'Aerele (Demo)', 'param2': '', 'param3': '', 'param4': '', 'param5': 'Asset'}
      mogrified_query = b"SELECT `account`,`debit`,`credit`,`debit_in_account_currency`,`credit_in_account_currency`,`account_currency`,`posting_date`,`is_opening`,`fiscal_year` FROM `tabGL Entry` FORCE INDEX (`posting_date_company_index`) WHERE `company`='Aerele (Demo)' AND `is_cancelled`=0 AND `posting_date`<='2026-03-31' AND (`finance_book` IN ('','','') OR `finance_book` IS NULL) AND EXISTS (SELECT `tabAccount`.`name` FROM `tabAccount` WHERE `tabAccount`.`name`=`tabGL Entry`.`account` AND `tabAccount`.`is_group`=0 AND `tabAccount`.`lft`>=1 AND `tabAccount`.`rgt`<=48 AND `tabAccount`.`root_type`='Asset')andcoalesce(`tabGL Entry`.`company`,'')='' OR `tabGL Entry`.`company` IN ('Aerele (Demo)')"
  File "env/lib/python3.14/site-packages/MySQLdb/cursors.py", line 330, in _query
    db.query(q)
      self = MySQLdb.cursors.Cursor(arraysize=1, description=None, description_flags=None, lastrowid=None, rowcount=None, rownumber=None)
      q = b"SELECT `account`,`debit`,`credit`,`debit_in_account_currency`,`credit_in_account_currency`,`account_currency`,`posting_date`,`is_opening`,`fiscal_year` FROM `tabGL Entry` FORCE INDEX (`posting_date_company_index`) WHERE `company`='Aerele (Demo)' AND `is_cancelled`=0 AND `posting_date`<='2026-03-31' AND (`finance_book` IN ('','','') OR `finance_book` IS NULL) AND EXISTS (SELECT `tabAccount`.`name` FROM `tabAccount` WHERE `tabAccount`.`name`=`tabGL Entry`.`account` AND `tabAccount`.`is_group`=0 AND `tabAccount`.`lft`>=1 AND `tabAccount`.`rgt`<=48 AND `tabAccount`.`root_type`='Asset')andcoalesce(`tabGL Entry`.`company`,'')='' OR `tabGL Entry`.`company` IN ('Aerele (Demo)')"
      db = <_mysql.connection open to '127.0.0.1' at 0x7fab81941020>
  File "env/lib/python3.14/site-packages/MySQLdb/connections.py", line 280, in query
    _mysql.connection.query(self, query)
      self = <_mysql.connection open to '127.0.0.1' at 0x7fab81941020>
      query = b"SELECT `account`,`debit`,`credit`,`debit_in_account_currency`,`credit_in_account_currency`,`account_currency`,`posting_date`,`is_opening`,`fiscal_year` FROM `tabGL Entry` FORCE INDEX (`posting_date_company_index`) WHERE `company`='Aerele (Demo)' AND `is_cancelled`=0 AND `posting_date`<='2026-03-31' AND (`finance_book` IN ('','','') OR `finance_book` IS NULL) AND EXISTS (SELECT `tabAccount`.`name` FROM `tabAccount` WHERE `tabAccount`.`name`=`tabGL Entry`.`account` AND `tabAccount`.`is_group`=0 AND `tabAccount`.`lft`>=1 AND `tabAccount`.`rgt`<=48 AND `tabAccount`.`root_type`='Asset')andcoalesce(`tabGL Entry`.`company`,'')='' OR `tabGL Entry`.`company` IN ('Aerele (Demo)')"
MySQLdb.ProgrammingError: (1064, "You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'andcoalesce(`tabGL Entry`.`company`,'')='' OR `tabGL Entry`.`company` IN ('Ae...' at line 1")
```

Backport needed:v16