### PR TITLE
fix(delivery note): avoid maintaining si_detail on return delivery note

### DIFF
--- a/erpnext/controllers/sales_and_purchase_return.py
+++ b/erpnext/controllers/sales_and_purchase_return.py
@@ -596,7 +596,6 @@ def make_return_doc(doctype: str, source_name: str, target_doc=None, return_agai
 			target_doc.against_sales_order = source_doc.against_sales_order
 			target_doc.against_sales_invoice = source_doc.against_sales_invoice
 			target_doc.so_detail = source_doc.so_detail
-			target_doc.si_detail = source_doc.si_detail
 			target_doc.expense_account = source_doc.expense_account
 			target_doc.dn_detail = source_doc.name
 			if default_warehouse_for_sales_return:

--- a/erpnext/stock/doctype/delivery_note/delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.py
@@ -396,6 +396,9 @@ class DeliveryNote(SellingController):
 		)
 
 	def validate_sales_invoice_references(self):
+		if self.is_return:
+			return
+
 		self._validate_dependent_item_fields(
 			"against_sales_invoice", "si_detail", _("References to Sales Invoices are Incomplete")
 		)
@@ -663,7 +666,7 @@ class DeliveryNote(SellingController):
 	def update_billing_status(self, update_modified=True):
 		updated_delivery_notes = [self.name]
 		for d in self.get("items"):
-			if d.si_detail and not d.so_detail:
+			if d.si_detail and d.against_sales_invoice:
 				d.db_set("billed_amt", d.amount, update_modified=update_modified)
 			elif d.so_detail:
 				updated_delivery_notes += update_billed_amount_based_on_so(d.so_detail, update_modified)

--- a/erpnext/stock/doctype/delivery_note/delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.py
@@ -666,7 +666,7 @@ class DeliveryNote(SellingController):
 	def update_billing_status(self, update_modified=True):
 		updated_delivery_notes = [self.name]
 		for d in self.get("items"):
-			if d.si_detail and d.against_sales_invoice:
+			if d.si_detail and not d.so_detail:
 				d.db_set("billed_amt", d.amount, update_modified=update_modified)
 			elif d.so_detail:
 				updated_delivery_notes += update_billed_amount_based_on_so(d.so_detail, update_modified)


### PR DESCRIPTION
**Issue:** When creating a Return Delivery Note against a fully billed Delivery Note, the Per Billed field in the Return Delivery Note is set to 100%, even though no Credit Note has been created against it.

**Ref:** [58819](https://support.frappe.io/helpdesk/tickets/58819)

**Steps to Reproduce:**
1) Create a **Sales Invoice**.
2) Create a **Delivery Note** against the **Sales Invoice** and submit it.
3) Create a **Return Delivery Note** against the previously created Delivery Note.
4) Observe the `Per Billed` field being set to 100 even without a **Credit Note** against the return.

**Before:**

https://github.com/user-attachments/assets/09518666-e40c-4327-a45c-cf488778cdd2

**After:**

https://github.com/user-attachments/assets/f1707e41-1352-4682-8c52-f046393f49a7

**Backport Needed v15 and v16**