### PR TITLE
fix(stock): fetching rate of batch items in POS

### DIFF
--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -233,7 +233,7 @@ def update_stock(ctx, out, doc=None):
 
 			for batch_no, batch_qty in batches.items():
 				rate = get_batch_based_item_price(
-					{"price_list": doc.get("selling_price_list"), "uom": out.uom, "batch_no": batch_no},
+					{"price_list": ctx.get("selling_price_list"), "uom": out.uom, "batch_no": batch_no},
 					out.item_code,
 				)
 				if batch_qty >= qty:


### PR DESCRIPTION
**Issue :** The rate was not fetched for batch items in POS Invoice when Update Stock was enabled.
Adding such an item resulted in an AttributeError (NoneType)

**Step to Reproduce:**
1. Create an Item with Batch No enabled
2. Create a Pricing Rule for the item
3. Open POS Invoice.
4. Enable Update Stock

**Description:**
In POS Invoice, when the Update Stock checkbox is enabled and a batch item is added, the system throws an AttributeError due to incorrect handling of a None value in the code.

This has been corrected by properly handling the missing context, which avoids the error and ensures that the rate is now fetched correctly for batch items.

**Actual Result :**
POS throws an AttributeError and fails to add the item

**Expected Result :**
The rate should be fetched correctly based on the pricing rule.

**Before :**

[Screencast from 05-02-26 03:41:01 PM IST.webm](https://github.com/user-attachments/assets/b07c9a12-89c4-48cd-8be5-238a706bc539)


**After :**

[Screencast from 05-02-26 03:41:53 PM IST.webm](https://github.com/user-attachments/assets/c6f1fa86-cb4d-42a6-925b-f6a0b1208e8f)

Backport Needed for V16