### PR TITLE
fix(accounts): assign batch number to free item added by pricing rule…

### DIFF
--- a/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
+++ b/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
@@ -19,6 +19,7 @@ from erpnext.accounts.doctype.sales_invoice.sales_invoice import (
 from erpnext.accounts.party import get_due_date, get_party_account
 from erpnext.controllers.queries import item_query as _item_query
 from erpnext.controllers.sales_and_purchase_return import get_sales_invoice_item_from_consolidated_invoice
+from erpnext.stock.doctype.serial_and_batch_bundle.serial_and_batch_bundle import combine_datetime
 from erpnext.stock.doctype.serial_no.serial_no import get_serial_nos
 from erpnext.stock.stock_ledger import is_negative_stock_allowed
 
@@ -250,7 +251,29 @@ class POSInvoice(SalesInvoice):
 		self.set_status(update=True)
 		self.make_bundle_for_sales_purchase_return()
 		for table_name in ["items", "packed_items"]:
+			if not self.get(table_name):
+				continue
 			self.make_bundle_using_old_serial_batch_fields(table_name)
+			for row in self.get(table_name):
+				if not row.item_code:
+					continue
+				if row.get("serial_and_batch_bundle") or row.get("rejected_serial_and_batch_bundle"):
+					continue
+				if not self.is_serial_batch_item(row.item_code):
+					continue
+
+				bundle_details = {
+					"item_code": row.get("rm_item_code") or row.item_code,
+					"posting_datetime": combine_datetime(self.posting_date, self.posting_time),
+					"voucher_type": self.doctype,
+					"voucher_no": self.name,
+					"voucher_detail_no": row.name,
+					"company": self.company,
+					"is_rejected": 1 if row.get("rejected_warehouse") else 0,
+					"use_serial_batch_fields": row.get("use_serial_batch_fields"),
+				}
+				self.update_bundle_details(bundle_details, table_name, row)
+				self.create_serial_batch_bundle(bundle_details, row)
 			self.submit_serial_batch_bundle(table_name)
 
 		if self.coupon_code:

--- a/erpnext/accounts/doctype/pos_invoice/test_pos_invoice.py
+++ b/erpnext/accounts/doctype/pos_invoice/test_pos_invoice.py
@@ -1150,6 +1150,66 @@ class TestPOSInvoice(IntegrationTestCase):
 
 		frappe.set_user("test@example.com")
 
+	def make_pos_item_contain_batch_or_serial_no_with_pricing_rule(self):
+		from erpnext.accounts.doctype.pricing_rule.test_pricing_rule import make_pricing_rule
+
+		item = "_Test Item with Serial No and Pricing Rule"
+		make_item(
+			item,
+			{
+				"is_stock_item": 1,
+				"has_batch_no": 1,
+				"auto_create_batch_nos": 1,
+				"batch_number_series": "BATCH-.#####",
+			},
+		)
+		make_purchase_receipt(item_code=item, warehouse="_Test Warehouse - _TC", qty=1, rate=500)
+
+		pr = make_pricing_rule(
+			title="5+1",
+			apply_on="Item Code",
+			items=[{"item_code": item}],
+			selling=1,
+			price_or_product_discount="Product",
+			free_item=item,
+			free_qty=1,
+			round_free_qty=1,
+			is_recursive=1,
+			recurse_for=5,
+		)
+		pr.save()
+
+		pos_inv = create_pos_invoice(
+			update_stock=1, items=[{"item_code": item, "qty": 6, "rate": 500}], do_not_save=0
+		)
+		self.assertEqual(len(pos_inv.items), 2)
+		self.assertIsNotNone(pos_inv.items[0].serial_and_batch_bundle)
+		self.assertIsNotNone(pos_inv.items[1].serial_and_batch_bundle)
+		serial_batch_nos1 = frappe.get_doc(
+			"Serial and Batch Bundle", pos_inv.items[0].serial_and_batch_bundle
+		)
+		serial_batch_nos2 = frappe.get_doc(
+			"Serial and Batch Bundle", pos_inv.items[1].serial_and_batch_bundle
+		)
+		batch_qty1 = abs(serial_batch_nos1.entries[0].qty)
+		batch_qty2 = abs(serial_batch_nos2.entries[0].qty)
+		self.assertEqual(abs(pos_inv.items[0].qty), batch_qty1)
+		self.assertEqual(abs(pos_inv.items[1].qty), batch_qty2)
+
+		pos_return = make_sales_return(pos_inv.name)
+		pos_return.insert()
+		pos_return.submit()
+		self.assertIsNotNone(pos_return.items[0].serial_and_batch_bundle)
+		self.assertIsNotNone(pos_return.items[1].serial_and_batch_bundle)
+		return_bundle1 = frappe.get_doc(
+			"Serial and Batch Bundle", pos_return.items[0].serial_and_batch_bundle
+		)
+		return_bundle2 = frappe.get_doc(
+			"Serial and Batch Bundle", pos_return.items[1].serial_and_batch_bundle
+		)
+		self.assertEqual(abs(pos_return.items[0].qty), abs(return_bundle1.entries[0].qty))
+		self.assertEqual(abs(pos_return.items[1].qty), abs(return_bundle2.entries[0].qty))
+
 
 def create_pos_invoice(**args):
 	args = frappe._dict(args)


### PR DESCRIPTION
**Issue:** Missing Batch No on free POS item causes return failure.

**Fix:**[#59197](https://support.frappe.io/helpdesk/tickets/59197)

**Description:**
POS Invoice return fails because the free item added by a pricing rule does not have a Batch/Serial Number. The free item should also have a Batch/Serial Number assigned so that the return can proceed normally.


**Step to Reproduce :**
1. Create batch-tracked item.
2. Create pricing rule: Buy 5 Get 1 free.
3. In POS, add 5 qty and select Batch No.
4. Free item is auto-added without Batch No.
5. Submit POS Invoice.
6. Try to return the invoice.

**Actual Behaviour :**
Return fails with error: **No Serial / Batches are available for return.**

**Expected Behaviour :**
Free item should have Batch No assigned, and return should work normally.

**Before :**

[Screencast from 05-02-26 06:29:17 PM IST.webm](https://github.com/user-attachments/assets/207f8027-cb0f-486f-aa79-da809fd8a0d6)

**After :**

[Screencast from 05-02-26 06:27:15 PM IST.webm](https://github.com/user-attachments/assets/3b25d366-de66-498a-a01f-d34511bf27ac)

Backport Needed For V16 and V15
