### PR TITLE
refactor: global defaults

### DIFF
--- a/erpnext/setup/doctype/global_defaults/global_defaults.py
+++ b/erpnext/setup/doctype/global_defaults/global_defaults.py
@@ -85,9 +85,6 @@ class GlobalDefaults(Document):
 				"Check",
 				validate_fields_for_doctype=False,
 			)
-			make_property_setter(
-				doctype, "base_rounded_total", "print_hide", 1, "Check", validate_fields_for_doctype=False
-			)
 
 			make_property_setter(
 				doctype,
@@ -97,6 +94,7 @@ class GlobalDefaults(Document):
 				"Check",
 				validate_fields_for_doctype=False,
 			)
+
 			make_property_setter(
 				doctype,
 				"rounded_total",

--- a/erpnext/setup/doctype/global_defaults/global_defaults.py
+++ b/erpnext/setup/doctype/global_defaults/global_defaults.py
@@ -75,15 +75,13 @@ class GlobalDefaults(Document):
 		return frappe.defaults.get_defaults()
 
 	def toggle_rounded_total(self):
-		self.disable_rounded_total = cint(self.disable_rounded_total)
-
 		# Make property setters to hide rounded total fields
 		for doctype in ROUNDED_TOTAL_DOCTYPES:
 			make_property_setter(
 				doctype,
 				"base_rounded_total",
 				"hidden",
-				self.disable_rounded_total,
+				cint(self.disable_rounded_total),
 				"Check",
 				validate_fields_for_doctype=False,
 			)
@@ -95,7 +93,7 @@ class GlobalDefaults(Document):
 				doctype,
 				"rounded_total",
 				"hidden",
-				self.disable_rounded_total,
+				cint(self.disable_rounded_total),
 				"Check",
 				validate_fields_for_doctype=False,
 			)
@@ -103,7 +101,7 @@ class GlobalDefaults(Document):
 				doctype,
 				"rounded_total",
 				"print_hide",
-				self.disable_rounded_total,
+				cint(self.disable_rounded_total),
 				"Check",
 				validate_fields_for_doctype=False,
 			)
@@ -118,15 +116,13 @@ class GlobalDefaults(Document):
 			)
 
 	def toggle_in_words(self):
-		self.disable_in_words = cint(self.disable_in_words)
-
 		# Make property setters to hide in words fields
 		for doctype in ROUNDED_TOTAL_DOCTYPES:
 			make_property_setter(
 				doctype,
 				"in_words",
 				"hidden",
-				self.disable_in_words,
+				cint(self.disable_in_words),
 				"Check",
 				validate_fields_for_doctype=False,
 			)
@@ -134,7 +130,7 @@ class GlobalDefaults(Document):
 				doctype,
 				"in_words",
 				"print_hide",
-				self.disable_in_words,
+				cint(self.disable_in_words),
 				"Check",
 				validate_fields_for_doctype=False,
 			)

--- a/erpnext/setup/doctype/global_defaults/global_defaults.py
+++ b/erpnext/setup/doctype/global_defaults/global_defaults.py
@@ -3,6 +3,7 @@
 
 
 """Global Defaults"""
+
 import frappe
 import frappe.defaults
 from frappe.custom.doctype.property_setter.property_setter import make_property_setter
@@ -18,6 +19,18 @@ keydict = {
 	"disable_rounded_total": "disable_rounded_total",
 	"disable_in_words": "disable_in_words",
 }
+
+ROUNDED_TOTAL_DOCTYPES = (
+	"Quotation",
+	"Sales Order",
+	"POS Invoice",
+	"Sales Invoice",
+	"Delivery Note",
+	"Supplier Quotation",
+	"Purchase Order",
+	"Purchase Invoice",
+	"Purchase Receipt",
+)
 
 from frappe.model.document import Document
 
@@ -53,6 +66,7 @@ class GlobalDefaults(Document):
 
 		self.toggle_rounded_total()
 		self.toggle_in_words()
+		self.set_disable_rounded_total_on_pos_profiles()
 
 		frappe.clear_cache()
 
@@ -64,16 +78,7 @@ class GlobalDefaults(Document):
 		self.disable_rounded_total = cint(self.disable_rounded_total)
 
 		# Make property setters to hide rounded total fields
-		for doctype in (
-			"Quotation",
-			"Sales Order",
-			"Sales Invoice",
-			"Delivery Note",
-			"Supplier Quotation",
-			"Purchase Order",
-			"Purchase Invoice",
-			"Purchase Receipt",
-		):
+		for doctype in ROUNDED_TOTAL_DOCTYPES:
 			make_property_setter(
 				doctype,
 				"base_rounded_total",
@@ -116,16 +121,7 @@ class GlobalDefaults(Document):
 		self.disable_in_words = cint(self.disable_in_words)
 
 		# Make property setters to hide in words fields
-		for doctype in (
-			"Quotation",
-			"Sales Order",
-			"Sales Invoice",
-			"Delivery Note",
-			"Supplier Quotation",
-			"Purchase Order",
-			"Purchase Invoice",
-			"Purchase Receipt",
-		):
+		for doctype in ROUNDED_TOTAL_DOCTYPES:
 			make_property_setter(
 				doctype,
 				"in_words",
@@ -142,3 +138,10 @@ class GlobalDefaults(Document):
 				"Check",
 				validate_fields_for_doctype=False,
 			)
+
+	def set_disable_rounded_total_on_pos_profiles(self):
+		POSProfile = frappe.qb.DocType("POS Profile")
+
+		frappe.qb.update(POSProfile).set(
+			POSProfile.disable_rounded_total, cint(self.disable_rounded_total)
+		).run()


### PR DESCRIPTION
Changes include:
- Set `disable_rounded_total` on POS Profile, on update.
- Refactored to comply with semgrep rules.
- Removed `make_property_setter` for `base_rounded_total`, as the property is already set on DocType, and that function was not making any change at all 🤷🤷🤷🤷