### PR TITLE
fix: Add handling for Sales Invoice Item quantity field

### DIFF
--- a/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py
+++ b/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py
@@ -1026,7 +1026,7 @@ class SerialandBatchBundle(Document):
 			qty_field = "consumed_qty"
 		elif row.get("doctype") == "Stock Entry Detail":
 			qty_field = "transfer_qty"
-		elif row.get("doctype") == "Sales Invoice Item":
+		elif row.get("doctype") in ["Sales Invoice Item", "Purchase Invoice Item"]:
 			qty_field = "stock_qty"
 
 		return qty_field

--- a/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py
+++ b/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py
@@ -1026,6 +1026,8 @@ class SerialandBatchBundle(Document):
 			qty_field = "consumed_qty"
 		elif row.get("doctype") == "Stock Entry Detail":
 			qty_field = "transfer_qty"
+		elif row.get("doctype") == "Sales Invoice Item":
+			qty_field = "stock_qty"
 
 		return qty_field
 


### PR DESCRIPTION
`no-docs`

qty choose from the wrong field when using the conversion.