### PR TITLE
fix: add is_group filter for supplier_group and warehouse fields

### DIFF
--- a/erpnext/buying/doctype/supplier/supplier.js
+++ b/erpnext/buying/doctype/supplier/supplier.js
@@ -135,14 +135,6 @@ frappe.ui.form.on("Supplier", {
 			// indicators
 			erpnext.utils.set_party_dashboard_indicators(frm);
 		}
-
-		frm.set_query("supplier_group", () => {
-			return {
-				filters: {
-					is_group: 0,
-				},
-			};
-		});
 	},
 	get_supplier_group_details: function (frm) {
 		frappe.call({

--- a/erpnext/buying/doctype/supplier/supplier.json
+++ b/erpnext/buying/doctype/supplier/supplier.json
@@ -167,6 +167,7 @@
    "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "Supplier Group",
+   "link_filters": "[[\"Supplier Group\",\"is_group\",\"=\",0]]",
    "oldfieldname": "supplier_type",
    "oldfieldtype": "Link",
    "options": "Supplier Group"
@@ -503,7 +504,7 @@
    "link_fieldname": "party"
   }
  ],
- "modified": "2026-02-02 12:36:51.566439",
+ "modified": "2026-02-06 12:58:01.398824",
  "modified_by": "Administrator",
  "module": "Buying",
  "name": "Supplier",

--- a/erpnext/stock/doctype/material_request/material_request.js
+++ b/erpnext/stock/doctype/material_request/material_request.js
@@ -30,7 +30,10 @@ frappe.ui.form.on("Material Request", {
 
 		frm.set_query("from_warehouse", "items", function (doc) {
 			return {
-				filters: { company: doc.company },
+				filters: {
+					company: doc.company,
+					is_group: 0,
+				},
 			};
 		});
 
@@ -70,19 +73,28 @@ frappe.ui.form.on("Material Request", {
 
 		frm.set_query("warehouse", "items", function (doc) {
 			return {
-				filters: { company: doc.company },
+				filters: {
+					company: doc.company,
+					is_group: 0,
+				},
 			};
 		});
 
 		frm.set_query("set_warehouse", function (doc) {
 			return {
-				filters: { company: doc.company },
+				filters: {
+					company: doc.company,
+					is_group: 0,
+				},
 			};
 		});
 
 		frm.set_query("set_from_warehouse", function (doc) {
 			return {
-				filters: { company: doc.company },
+				filters: {
+					company: doc.company,
+					is_group: 0,
+				},
 			};
 		});
 


### PR DESCRIPTION
**Issue:**
1. The `Is Group = 0` filter is not applied to the Supplier Group field in the Supplier Quick Entry.
2. The `Is Group = 0` filter should be applied to the Warehouse fields in the Material Request.

**Ref:** [#59190](https://support.frappe.io/helpdesk/tickets/59190)

**Before:**

https://github.com/user-attachments/assets/49e65010-d5dc-4cc6-ac3e-31c5b6f3f2dd

**After:**

https://github.com/user-attachments/assets/b05ab33a-4325-4eea-8143-9fb33e72b082

**Backport Needed for v15 & v16**