### PR TITLE
fix(quotation): ignore zero ordered_qty

### DIFF
--- a/erpnext/selling/doctype/quotation/quotation.py
+++ b/erpnext/selling/doctype/quotation/quotation.py
@@ -621,6 +621,9 @@ def handle_mandatory_error(e, customer, lead_name):
 def get_ordered_items(quotation: str):
 	return frappe._dict(
 		frappe.get_all(
-			"Quotation Item", {"docstatus": 1, "parent": quotation}, ["name", "ordered_qty"], as_list=True
+			"Quotation Item",
+			{"docstatus": 1, "parent": quotation, "ordered_qty": (">", 0)},
+			["name", "ordered_qty"],
+			as_list=True,
 		)
 	)


### PR DESCRIPTION
Issue:
Unable to mark a Quotation as `Lost` when no Sales Order has been created from the Quotation.

Ref: [#59450](https://support.frappe.io/helpdesk/tickets/59450), [#59625](https://support.frappe.io/helpdesk/tickets/59625)

Steps to Reproduce:

1. Create a Quotation.
2. Create a Quotation Lost reason.
3. Mark the Quotation as Lost and try to save it.

Before:


https://github.com/user-attachments/assets/06828b6f-0679-4ac6-8367-021e3a9d37e0



After:


https://github.com/user-attachments/assets/be701884-2feb-48f8-85d7-102c4086bb9d



Backport needed:v16, v15