### PR TITLE
fix: update total weight

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -4079,6 +4079,10 @@ def update_child_qty_rate(parent_doctype, trans_items, parent_doctype_name, chil
 				flt(d.get("conversion_factor"), conv_fac_precision) or conversion_factor
 			)
 
+		if child_item.meta.get_field("total_weight"):
+			item_details = parent.fetch_item_details(child_item)
+			parent.conversion_factor(child_item, item_details)
+
 		if d.get("delivery_date") and parent_doctype == "Sales Order":
 			child_item.delivery_date = d.get("delivery_date")
 

--- a/erpnext/utilities/transaction_base.py
+++ b/erpnext/utilities/transaction_base.py
@@ -410,7 +410,7 @@ class TransactionBase(StatusUpdater):
 			)
 
 			if self.doctype != "Material Request":
-				item_obj.total_weight = flt(item_obj.stock_qty * item_obj.weight_per_unit)
+				item_obj.total_weight = flt(item_obj.stock_qty * flt(item_obj.weight_per_unit))
 				self.calculate_net_weight()
 
 			# TODO: for handling customization not to fetch price list rate


### PR DESCRIPTION
**Issue :** When updating item quantities in a submitted Sales Order using the Update Items button, the Total Net Weight field does not recalculate based on the new quantity.

**fix:** [#59534](https://support.frappe.io/helpdesk/tickets/59534)

**Steps to Reproduce**

1. Create a Sales Order with an Item that has a Weight Per Unit set in the Item master.
2. Set the quantity to 
3. Save and Submit the Sales Order.
4. Click on Update Items.
5. Change the quantity from 2 → 4.

**Description :**

The Total Net Weight field in Sales Order is not recalculated when item quantities are modified using the Update Items button after submission. Although the item quantity gets updated correctly, the net weight value continues to display the old calculated weight instead of reflecting the new quantity.

**Before :**

[Screencast from 06-02-26 05:29:42 PM IST.webm](https://github.com/user-attachments/assets/449a96b3-1363-44f4-8bd2-5f3d5ec46bb6)

**After :**

[Screencast from 06-02-26 05:30:55 PM IST.webm](https://github.com/user-attachments/assets/0856be81-7ade-4629-b53a-5ada04270805)

**Backport Needed For V16 and V15**