### PR TITLE
fix(stock): ignore pos reserved batches for stock levels

### DIFF
--- a/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py
+++ b/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py
@@ -2689,7 +2689,10 @@ def get_auto_batch_nos(kwargs):
 
 	available_batches = get_available_batches(kwargs)
 	stock_ledgers_batches = get_stock_ledgers_batches(kwargs)
-	pos_invoice_batches = get_reserved_batches_for_pos(kwargs)
+
+	pos_invoice_batches = frappe._dict()
+	if not kwargs.for_stock_levels:
+		pos_invoice_batches = get_reserved_batches_for_pos(kwargs)
 
 	sre_reserved_batches = frappe._dict()
 	if not kwargs.ignore_reserved_stock:


### PR DESCRIPTION
**Issue:**
1. The system includes POS reserved quantity when calculating available batch quantity. This causes a "Negative Batch Quantity" error when creating a POS Closing Entry.
2. The above behavior also leads to quantity mismatches between the Stock Ledger/Batch-wise Balance History reports and the actual quantities shown in the Batch master.

**Ref:** [#59057](https://support.frappe.io/helpdesk/tickets/59057)

**Before:**

https://github.com/user-attachments/assets/eadda788-8862-47b2-ad3c-8889e781400b

**After:**

https://github.com/user-attachments/assets/744cf1a3-e2ad-46a9-a738-b99e2afd1dfe

**Backport Needed for v15 & v16**