### PR TITLE
fix: Resend Payment Email button not showing on Payment Request

### DIFF
--- a/erpnext/accounts/doctype/payment_request/payment_request.js
+++ b/erpnext/accounts/doctype/payment_request/payment_request.js
@@ -40,7 +40,7 @@ frappe.ui.form.on("Payment Request", "refresh", function (frm) {
 	if (
 		frm.doc.payment_request_type == "Inward" &&
 		frm.doc.payment_channel !== "Phone" &&
-		!["Initiated", "Paid"].includes(frm.doc.status) &&
+		["Initiated", "Paid"].includes(frm.doc.status) &&
 		!frm.doc.__islocal &&
 		frm.doc.docstatus == 1
 	) {


### PR DESCRIPTION
This PR resolves the issue reported in https://github.com/frappe/erpnext/issues/47771
.

The Resend Payment Email functionality already exists. The issue was caused by incorrect conditional logic that inverted the status check.

Previously, the condition used a negated check:

!["Initiated", "Paid"].includes(frm.doc.status)

This caused the resend action to appear when the Payment Request was in invalid states.

The logic has been corrected to explicitly allow valid states by removing the negation:

["Initiated", "Paid"].includes(frm.doc.status)

No new functionality is added. This change only fixes the condition so the resend action is shown in the correct scenarios and aligns with the intended payment flow.

P.S. Please Backport to version-15 if approved. Thanks!