### PR TITLE
fix(stock): correct warehouse mapping for material issue

### DIFF
--- a/erpnext/stock/doctype/material_request/material_request.py
+++ b/erpnext/stock/doctype/material_request/material_request.py
@@ -777,6 +777,9 @@ def make_stock_entry(source_name, target_doc=None):
 		target.purpose = source.material_request_type
 		target.from_warehouse = source.set_from_warehouse
 		target.to_warehouse = source.set_warehouse
+		if source.material_request_type == "Material Issue":
+			target.from_warehouse = source.set_warehouse
+			target.to_warehouse = None
 
 		if source.job_card:
 			target.purpose = "Material Transfer for Manufacture"

--- a/erpnext/stock/doctype/material_request/test_material_request.py
+++ b/erpnext/stock/doctype/material_request/test_material_request.py
@@ -1017,15 +1017,27 @@ class TestMaterialRequest(IntegrationTestCase):
 		import json
 
 		from erpnext.stock.doctype.pick_list.pick_list import create_stock_entry
+		from erpnext.stock.doctype.stock_entry.stock_entry_utils import make_stock_entry
 
-		mr = make_material_request(material_request_type="Material Transfer")
+		new_item = create_item("_Test Pick List Item", is_stock_item=1)
+		item_code = new_item.name
+
+		make_stock_entry(
+			item_code=item_code,
+			target="_Test Warehouse - _TC",
+			qty=10,
+			do_not_save=False,
+			do_not_submit=False,
+		)
+
+		mr = make_material_request(item_code=item_code, material_request_type="Material Transfer")
 		pl = create_pick_list(mr.name)
 		pl.save()
 		pl.locations[0].qty = 5
 		pl.locations[0].stock_qty = 5
 		pl.submit()
 
-		to_warehouse = create_warehouse("Test To Warehouse")
+		to_warehouse = create_warehouse("_Test Warehouse - _TC")
 
 		se_data = create_stock_entry(json.dumps(pl.as_dict()))
 		se = frappe.get_doc(se_data)
@@ -1044,6 +1056,15 @@ class TestMaterialRequest(IntegrationTestCase):
 
 	def test_mr_pick_list_qty_validation(self):
 		"""Test for checking pick list qty validation from Material Request"""
+		from erpnext.stock.doctype.stock_entry.stock_entry_utils import make_stock_entry
+
+		make_stock_entry(
+			item_code="_Test Item",
+			target="_Test Warehouse - _TC",
+			qty=10,
+			do_not_save=False,
+			do_not_submit=False,
+		)
 
 		mr = make_material_request(material_request_type="Material Transfer")
 		pl = create_pick_list(mr.name)

--- a/erpnext/stock/doctype/material_request/test_material_request.py
+++ b/erpnext/stock/doctype/material_request/test_material_request.py
@@ -1104,6 +1104,19 @@ class TestMaterialRequest(IntegrationTestCase):
 
 		self.assertRaises(frappe.ValidationError, end_transit_2.submit)
 
+	def test_make_stock_entry_material_issue_warehouse_mapping(self):
+		"""Test to ensure while making stock entry from material request of type Material Issue, warehouse is mapped correctly"""
+		mr = make_material_request(material_request_type="Material Issue", do_not_submit=True)
+		mr.set_warehouse = "_Test Warehouse - _TC"
+		mr.save()
+		mr.submit()
+
+		se = make_stock_entry(mr.name)
+		self.assertEqual(se.from_warehouse, "_Test Warehouse - _TC")
+		self.assertIsNone(se.to_warehouse)
+		se.save()
+		se.submit()
+
 
 def get_in_transit_warehouse(company):
 	if not frappe.db.exists("Warehouse Type", "Transit"):


### PR DESCRIPTION
**Issue:** When creating a Stock Entry from a Material Request with purpose Material Issue, the system incorrectly maps the From Warehouse to the Target Warehouse instead of only setting it as the Source Warehouse

**Fix:** [#59242](https://support.frappe.io/helpdesk/tickets/59242)

**Step to Reproduce :**
1. Create a Material Request with type Material Issue.
2. Set From Warehouse = **(Stores)** and submit.
3. Click Create → Stock Entry

**Actual Behavior :**
**Stores** warehouse is populated in the Target Warehouse field.

**Expected behavior:**
**Stores** warehouse should populate only the Source Warehouse, not the Target Warehouse.

**Before :**

[Screencast from 08-02-26 10:37:22 AM IST.webm](https://github.com/user-attachments/assets/04abe9d1-211b-4c35-8770-9b0f18ac7620)

**After:**

[Screencast from 08-02-26 10:49:06 AM IST.webm](https://github.com/user-attachments/assets/6fbc4bc5-f355-4735-80e5-b99dd94297f6)

**Backport Needed For V16 and V15**
