### PR TITLE
fix: Added a missing option to the currency field

### DIFF
--- a/erpnext/accounts/doctype/advance_payment_ledger_entry/advance_payment_ledger_entry.json
+++ b/erpnext/accounts/doctype/advance_payment_ledger_entry/advance_payment_ledger_entry.json
@@ -50,6 +50,7 @@
    "fieldname": "amount",
    "fieldtype": "Currency",
    "label": "Amount",
+   "options": "currency",
    "read_only": 1
   },
   {


### PR DESCRIPTION
If the **currency** is not the **company's currency** in the **Advance Payments Ledger Entry** DocType, the correct **Symbol** will not be displayed in the field **Amount**.
### Before
<img width="834" height="236" alt="image" src="https://github.com/user-attachments/assets/f3b49184-e699-416e-bc67-f29a87d7befb" />

### After
<img width="793" height="227" alt="image" src="https://github.com/user-attachments/assets/5ceaf7a1-bb59-49bd-811c-7c6163144c3e" />
