### PR TITLE
fix: add editable payment amount as input

### DIFF
--- a/erpnext/selling/page/point_of_sale/pos_payment.js
+++ b/erpnext/selling/page/point_of_sale/pos_payment.js
@@ -211,20 +211,15 @@ erpnext.PointOfSale.Payment = class {
 			} else {
 				// clicked one is not selected then select it
 				mode_clicked.addClass("border-primary");
-
-				me.selected_mode = me[`${mode}_control`];
+				mode_clicked.find(".mode-of-payment-control").css("display", "flex");
+				me.$payment_modes.find(`.${mode}-amount`).css("display", "none");
 				const mode_clicked_amount = mode_clicked.find(`.${mode}-amount`).get(0);
-				if (!mode_clicked_amount.innerHTML) {
-					mode_clicked_amount.innerHTML = format_currency(0, me.events.get_frm().doc.currency);
+				if (!mode_clicked_amount.innerText) {
+					mode_clicked_amount.innerText = format_currency(0, me.events.get_frm().doc.currency);
 				}
+				me.selected_mode = me[`${mode}_control`];
+				me.selected_mode && me.selected_mode.$input.get(0).focus();
 				me.auto_set_remaining_amount();
-			}
-		});
-
-		// change payment amount for selected mode on key press from keyboard
-		$(document).on("keydown", function (e) {
-			if (me.selected_mode) {
-				me.on_numpad_clicked(e.key, false);
 			}
 		});
 


### PR DESCRIPTION
**Issue:**
On Payment page, User can use the on screen keypad to edit the amount, but it’s not obvious to the user.

**Ref:**[#59195](https://support.frappe.io/helpdesk/tickets/59195)


**Before:**


https://github.com/user-attachments/assets/ba3e5a11-bd27-4215-90e7-ddee931ac13d


**After:**

https://github.com/user-attachments/assets/e250c07b-f1cb-4a37-90d8-ad17c7513e92


