### PR TITLE
fix: refactor commision_rate from data to float

### DIFF
--- a/erpnext/setup/doctype/sales_person/sales_person.json
+++ b/erpnext/setup/doctype/sales_person/sales_person.json
@@ -54,7 +54,7 @@
   },
   {
    "fieldname": "commission_rate",
-   "fieldtype": "Data",
+   "fieldtype": "Float",
    "label": "Commission Rate",
    "print_hide": 1
   },
@@ -145,7 +145,7 @@
  "idx": 1,
  "is_tree": 1,
  "links": [],
- "modified": "2024-03-27 13:10:37.891377",
+ "modified": "2026-02-09 11:27:00.072511",
  "modified_by": "Administrator",
  "module": "Setup",
  "name": "Sales Person",
@@ -179,6 +179,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "search_fields": "parent_sales_person",
  "show_name_in_global_search": 1,
  "sort_field": "creation",

--- a/erpnext/setup/doctype/sales_person/sales_person.py
+++ b/erpnext/setup/doctype/sales_person/sales_person.py
@@ -27,7 +27,7 @@ class SalesPerson(NestedSet):
 
 		from erpnext.setup.doctype.target_detail.target_detail import TargetDetail
 
-		commission_rate: DF.Data | None
+		commission_rate: DF.Float | None
 		department: DF.Link | None
 		employee: DF.Link | None
 		enabled: DF.Check


### PR DESCRIPTION
**Issue:**

Sales Person's "Commission Rate" field is Data (text field). Users can enter 0,05 or 0.5 and each creates vastly different commission calculations, especially in Turkish locale where comma is the decimal separator.

When Data field converts to Float for calculations, locale-specific parsing creates inconsistent results:
1. 0,025 (with comma) → Parsed as 25 (comma treated as thousands separator) → Results in 25% 
2. 0.25 (with period) → Parsed correctly as 0.25 → Results in correct 0.25% commission

**To Do:**

- [ ] To add patch for the change


**Ref:**[#59301](https://support.frappe.io/helpdesk/tickets/59301)

