### PR TITLE
fix(bom): price list lookup now considers UOM conversion table

### DIFF
--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -1214,12 +1214,40 @@ def get_price_list_rate_for(ctx: ItemDetailsCtx, item_code):
 			pctx.uom = ctx.get("stock_uom")
 			general_price_list_rate = get_item_price(pctx, item_code, ignore_party=ctx.get("ignore_party"))
 
+		# Try alternative UOMs from the item's UOM conversion table
+		if not general_price_list_rate:
+			item_uoms = frappe.get_all(
+				"UOM Conversion Detail",
+				filters={"parent": item_code, "parenttype": "Item"},
+				fields=["uom", "conversion_factor"],
+			)
+			for uom_row in item_uoms:
+				if uom_row.uom not in [ctx.get("uom"), ctx.get("stock_uom")]:
+					pctx.uom = uom_row.uom
+					alt_price = get_item_price(pctx, item_code, ignore_party=ctx.get("ignore_party"))
+					if alt_price:
+						# Convert the price from the found UOM to the requested UOM
+						requested_uom = ctx.get("uom") or ctx.get("stock_uom")
+						found_uom = uom_row.uom
+						# Get conversion factors relative to stock UOM
+						found_cf = uom_row.conversion_factor  # found_uom to stock_uom
+						requested_cf = ctx.get("conversion_factor") or 1  # requested_uom to stock_uom
+						# Price in found_uom * (found_cf / requested_cf) = Price in requested_uom
+						conversion_multiplier = flt(found_cf) / flt(requested_cf) if requested_cf else 1
+						general_price_list_rate = alt_price
+						# Store the conversion multiplier for later use
+						ctx["_alt_uom_conversion_multiplier"] = conversion_multiplier
+						break
+
 		if general_price_list_rate:
 			item_price_data = general_price_list_rate
 
 	if item_price_data:
 		if item_price_data[0].uom == ctx.get("uom"):
 			return item_price_data[0].price_list_rate
+		elif ctx.get("_alt_uom_conversion_multiplier"):
+			# Apply the alternative UOM conversion
+			return flt(item_price_data[0].price_list_rate * ctx.get("_alt_uom_conversion_multiplier"))
 		elif not ctx.get("price_list_uom_dependant"):
 			return flt(item_price_data[0].price_list_rate * flt(ctx.get("conversion_factor", 1)))
 		else:


### PR DESCRIPTION
## Description
When using 'Price List' as cost configuration in BOM, the system failed to find item prices if the Price List UOM differed from the BOM item UOM, even when both UOMs were properly configured in the item's UOM conversion table.

## Root Cause
`get_price_list_rate_for()` only checked:
1. The requested UOM
2. The stock UOM as fallback

It never searched alternative UOMs from the item's UOM conversion table.

## Solution
Added a fallback mechanism that:
1. After checking the requested UOM and stock UOM, iterates through the item's UOM conversion table
2. Searches for prices with alternative UOMs  
3. Applies the appropriate conversion factor to calculate the correct rate

## Example
If BOM uses UOM 'Gram' and Item Price is set for 'KG' with conversion factor 1000 (1 KG = 1000 grams), the system will now find the KG price and convert it appropriately.

Fixes #52547