### PR TITLE
fix(taxes): correct tax table total for inclusive tax rounding

### DIFF
--- a/erpnext/controllers/taxes_and_totals.py
+++ b/erpnext/controllers/taxes_and_totals.py
@@ -667,7 +667,11 @@ class calculate_taxes_and_totals:
 			diff = flt(diff, self.doc.precision("rounding_adjustment"))
 
 			if diff and abs(diff) <= (5.0 / 10 ** last_tax.precision("tax_amount")):
-				self.grand_total_diff = diff
+				# Adjust last tax row's total to match the expected inclusive amount
+				last_tax.total = flt(last_tax.total + diff, last_tax.precision("total"))
+				# Set grand_total_diff to 0 since we already adjusted last_tax.total
+				# (grand_total is calculated from last_tax.total in calculate_totals)
+				self.grand_total_diff = 0
 			else:
 				self.grand_total_diff = 0
 


### PR DESCRIPTION
## Description
When using **tax-inclusive pricing** with 0 decimal precision, the tax table's total column shows an incorrect value (e.g., 50,001 instead of 50,000) due to accumulated rounding errors.

The `adjust_grand_total_for_inclusive_tax()` function correctly calculates the rounding difference and adjusts the grand total, but the tax table row (`tax.total`) was not being updated to reflect this adjustment.

## Root Cause
Independent rounding of net amount and tax amount causes drift:
- Net: 50,000 / 1.10 = 45,454.55 → rounds to **45,455**
- Tax: 45,455 × 0.10 = 4,545.5 → rounds to **4,546**  
- Total: 45,455 + 4,546 = **50,001** ❌

The grand total was being corrected to 50,000, but the tax table still displayed 50,001, confusing users and preventing invoice submission in some cases.

## Solution
When the inclusive tax adjustment is applied, also update `last_tax.total` to match the corrected value. This ensures users see consistent totals in both the tax table and the document summary.

## Before/After
| | Tax Table Total | Grand Total |
|---|---|---|
| Before | 50,001 | 50,000 |
| After | 50,000 | 50,000 |

## Testing
Tested with:
- Number format: #,###
- Item price: 50,000 (tax inclusive)
- Tax template: 10% included in basic rate

Fixes #52333

---
Please backport to `version-16-hotfix` and `version-15-hotfix`