### PR TITLE
fix(stock): remove hardcoded letter_head from report

### DIFF
--- a/erpnext/stock/report/incorrect_serial_and_batch_bundle/incorrect_serial_and_batch_bundle.json
+++ b/erpnext/stock/report/incorrect_serial_and_batch_bundle/incorrect_serial_and_batch_bundle.json
@@ -9,7 +9,7 @@
  "idx": 0,
  "is_standard": "Yes",
  "json": "{}",
- "letter_head": "Test",
+ "letter_head": null,
  "letterhead": null,
  "modified": "2025-02-03 15:39:47.613040",
  "modified_by": "Administrator",


### PR DESCRIPTION
## Description
The **Incorrect Serial and Batch Bundle** report has a hardcoded `letter_head` value of `"Test"`, which prevents users from deleting any Letter Head named "Test" due to Frappe's link existence check.

## Error
```
frappe.exceptions.LinkExistsError: Cannot delete or cancel because 
Letter Head 'Test' is linked with Report 'Incorrect Serial and Batch Bundle'
```

## Root Cause
Introduced in commit 7e24395 - the report JSON was exported with a specific letter_head value from a development environment.

## Solution
Set `letter_head` to `null` instead of `"Test"`. Standard reports should not reference specific Letter Head names as they may not exist in all installations.

## Change
```diff
- "letter_head": "Test",
+ "letter_head": null,
```

Fixes #52569

---
Please backport to `version-16-hotfix`