### PR TITLE
fix(job-card): only require sub_operation when pending operations exist

### DIFF
--- a/erpnext/manufacturing/doctype/job_card/job_card.js
+++ b/erpnext/manufacturing/doctype/job_card/job_card.js
@@ -349,19 +349,19 @@ frappe.ui.form.on("Job Card", {
 			},
 		];
 
-		if (frm.doc.sub_operations?.length) {
+		let pending_sub_operations = (frm.doc.sub_operations || []).filter(
+			(d) => d.status === "Pending"
+		);
+		if (pending_sub_operations.length) {
 			fields.push({
 				fieldtype: "Link",
 				label: __("Sub Operation"),
 				fieldname: "sub_operation",
 				options: "Operation",
 				get_query() {
-					let non_completed_operations = frm.doc.sub_operations.filter(
-						(d) => d.status === "Pending"
-					);
 					return {
 						filters: {
-							name: ["in", non_completed_operations.map((d) => d.sub_operation)],
+							name: ["in", pending_sub_operations.map((d) => d.sub_operation)],
 						},
 					};
 				},


### PR DESCRIPTION
## Description
When completing a Job Card that has sub_operations, the completion dialog shows a mandatory **Sub Operation** field. However, if all sub_operations have already been completed, this field has no valid options but is still required, preventing users from completing the Job Card.

## Steps to Reproduce
1. Create a Job Card with sub_operations
2. Complete all sub_operations (status = 'Complete')
3. Try to complete the Job Card
4. ❌ Error: 'Sub Operation: This field is mandatory'

## Root Cause
The code checked if `sub_operations` array has any items, then added a mandatory field. But the `get_query` filtered to only show 'Pending' operations, creating a mismatch.

```javascript
// Before: adds mandatory field if ANY sub_operations exist
if (frm.doc.sub_operations?.length) {
    fields.push({ reqd: 1, ... });
}
```

## Solution
Filter for pending operations first, then only add the mandatory field if there are actually pending operations available.

```javascript
// After: adds mandatory field only if PENDING sub_operations exist
let pending_sub_operations = (frm.doc.sub_operations || []).filter(
    (d) => d.status === 'Pending'
);
if (pending_sub_operations.length) {
    fields.push({ reqd: 1, ... });
}
```

Fixes #52472

---
Please backport to `version-16-hotfix`