### PR TITLE
fix(general-ledger): include cost_center and project in opening balance calculation

### DIFF
--- a/erpnext/accounts/report/general_ledger/general_ledger.py
+++ b/erpnext/accounts/report/general_ledger/general_ledger.py
@@ -286,6 +286,8 @@ def get_conditions(filters):
 	if not (
 		filters.get("account")
 		or filters.get("party")
+		or filters.get("cost_center")
+		or filters.get("project")
 		or filters.get("categorize_by") in ["Categorize by Account", "Categorize by Party"]
 	):
 		if not ignore_is_opening:


### PR DESCRIPTION
## Description
When filtering the General Ledger report by **cost_center** or **project** (without an account or party filter), the opening balance incorrectly shows as **0**.

## Root Cause
In `get_conditions()`, the logic that determines whether to fetch entries before `from_date` only checks for `account`, `party`, and `categorize_by` filters:

```python
if not (
    filters.get("account")
    or filters.get("party")
    or filters.get("categorize_by") in [...]
):
    conditions.append("posting_date >= from_date")  # Excludes historical entries
```

When filtering by `cost_center` alone, this condition is triggered, and entries before `from_date` are excluded — making it impossible to calculate the opening balance.

## Solution
Add `cost_center` and `project` to the condition check, consistent with how `account` and `party` already work:

```python
if not (
    filters.get("account")
    or filters.get("party")
    or filters.get("cost_center")  # Added
    or filters.get("project")      # Added
    or filters.get("categorize_by") in [...]
):
```

## Example
- **Filter:** cost_center = "Sales Dept", from_date = 2025-02-01
- **Before:** Opening balance = 0 (entries before Feb 1 not fetched)
- **After:** Opening balance = correct sum of all prior entries for "Sales Dept"

## Testing
Manually tested with:
1. Create GL entries for a cost center on different dates
2. Run GL report filtered by that cost center with from_date after some entries
3. Verify opening balance reflects entries before from_date

Fixes #48026

---
Please backport to `version-16-hotfix` and `version-15-hotfix`