### PR TITLE
fix(accounts): filter accounts by company in get_accounts_with_children

### DIFF
--- a/erpnext/accounts/report/general_ledger/general_ledger.py
+++ b/erpnext/accounts/report/general_ledger/general_ledger.py
@@ -369,12 +369,13 @@ def get_accounts_with_children(accounts, company=None):
 		return
 
 	doctype = frappe.qb.DocType("Account")
-	accounts_data = (
-		frappe.qb.from_(doctype)
-		.select(doctype.lft, doctype.rgt)
-		.where(doctype.name.isin(accounts))
-		.run(as_dict=True)
-	)
+	query = frappe.qb.from_(doctype).select(doctype.lft, doctype.rgt).where(doctype.name.isin(accounts))
+
+	# Filter by company in the initial lookup as well for defense-in-depth
+	if company:
+		query = query.where(doctype.company == company)
+
+	accounts_data = query.run(as_dict=True)
 
 	conditions = []
 	for account in accounts_data:

--- a/erpnext/accounts/report/general_ledger/general_ledger.py
+++ b/erpnext/accounts/report/general_ledger/general_ledger.py
@@ -227,7 +227,7 @@ def get_conditions(filters):
 	ignore_is_opening = frappe.get_single_value("Accounts Settings", "ignore_is_opening_check_for_reporting")
 
 	if filters.get("account"):
-		filters.account = get_accounts_with_children(filters.account)
+		filters.account = get_accounts_with_children(filters.account, filters.get("company"))
 		if filters.account:
 			conditions.append("account in %(account)s")
 
@@ -361,7 +361,7 @@ def get_party_name_map():
 	return party_map
 
 
-def get_accounts_with_children(accounts):
+def get_accounts_with_children(accounts, company=None):
 	if not isinstance(accounts, list):
 		accounts = [d.strip() for d in accounts.strip().split(",") if d]
 
@@ -380,7 +380,14 @@ def get_accounts_with_children(accounts):
 	for account in accounts_data:
 		conditions.append((doctype.lft >= account.lft) & (doctype.rgt <= account.rgt))
 
-	return frappe.qb.from_(doctype).select(doctype.name).where(Criterion.any(conditions)).run(pluck=True)
+	query = frappe.qb.from_(doctype).select(doctype.name).where(Criterion.any(conditions))
+
+	# Filter by company to avoid returning accounts from other companies
+	# Each company has its own account tree with independent lft/rgt numbering
+	if company:
+		query = query.where(doctype.company == company)
+
+	return query.run(pluck=True)
 
 
 def set_bill_no(gl_entries):

--- a/erpnext/accounts/report/trial_balance_for_party/trial_balance_for_party.py
+++ b/erpnext/accounts/report/trial_balance_for_party/trial_balance_for_party.py
@@ -40,7 +40,7 @@ def get_data(filters, show_party_name):
 
 	account_filter = []
 	if filters.get("account"):
-		account_filter = get_accounts_with_children(filters.get("account"))
+		account_filter = get_accounts_with_children(filters.get("account"), filters.get("company"))
 
 	company_currency = frappe.get_cached_value("Company", filters.company, "default_currency")
 	opening_balances = get_opening_balances(filters, account_filter)


### PR DESCRIPTION
## Description

When querying child accounts using `lft/rgt` for account filtering in General Ledger and Trial Balance for Party reports, the function was not filtering by company.

Since each company has its own account tree with independent `lft/rgt` numbering, this caused accounts from other companies (with overlapping `lft/rgt` ranges) to be incorrectly included when users had permissions for multiple companies.

### Root Cause
The `get_accounts_with_children()` function queries accounts using the nested set pattern (`lft >= X AND rgt <= Y`) but doesn't filter by company. In a multi-company setup:

- Company A: `Sales - A` with `lft=10, rgt=20`
- Company B: `Expenses - B` with `lft=10, rgt=20` (same range, different tree)

When user selects `Sales - A`, the query returns accounts from BOTH companies, effectively ignoring the account filter.

### Fix
Add an optional `company` parameter to `get_accounts_with_children()` and filter the query to only return accounts from the specified company.

## References
Fixes #52458

## Testing
1. Create two companies with overlapping chart of accounts
2. Give a user permission to both companies
3. Run General Ledger report, select Company A, select a specific Account
4. Verify that only the selected account (and its children) are shown, not accounts from Company B