### PR TITLE
perf(stock): fix N+1 queries in Stock Ledger and Stock Projected Qty reports

### DIFF
--- a/erpnext/stock/report/stock_ledger/stock_ledger.py
+++ b/erpnext/stock/report/stock_ledger/stock_ledger.py
@@ -619,12 +619,29 @@ def get_opening_balance(filters, columns, sl_entries):
 		}
 	)
 
+	# Batch fetch all Stock Reconciliation purposes to avoid N+1 queries
+	sr_vouchers = [
+		sle.voucher_no
+		for sle in sl_entries
+		if sle.get("voucher_type") == "Stock Reconciliation" and sle.posting_date == filters.from_date
+	]
+
+	opening_stock_vouchers = set()
+	if sr_vouchers:
+		opening_stock_vouchers = set(
+			frappe.get_all(
+				"Stock Reconciliation",
+				filters={"name": ("in", sr_vouchers), "purpose": "Opening Stock"},
+				pluck="name",
+			)
+		)
+
 	# check if any SLEs are actually Opening Stock Reconciliation
 	for sle in list(sl_entries):
 		if (
 			sle.get("voucher_type") == "Stock Reconciliation"
 			and sle.posting_date == filters.from_date
-			and frappe.db.get_value("Stock Reconciliation", sle.voucher_no, "purpose") == "Opening Stock"
+			and sle.voucher_no in opening_stock_vouchers
 		):
 			last_entry = sle
 			sl_entries.remove(sle)

--- a/erpnext/stock/report/stock_projected_qty/stock_projected_qty.py
+++ b/erpnext/stock/report/stock_projected_qty/stock_projected_qty.py
@@ -27,7 +27,8 @@ def execute(filters=None):
 		item_groups.append(filters.item_group)
 		item_groups.extend(get_descendants_of("Item Group", filters.item_group))
 
-	warehouse_company = {}
+	# Batch fetch warehouse companies to avoid N+1 queries
+	warehouse_company = get_warehouse_company_map(bin_list)
 	data = []
 	conversion_factors = []
 	for bin in bin_list:
@@ -38,9 +39,7 @@ def execute(filters=None):
 			continue
 
 		# item = item_map.setdefault(bin.item_code, get_item(bin.item_code))
-		company = warehouse_company.setdefault(
-			bin.warehouse, frappe.db.get_value("Warehouse", bin.warehouse, "company")
-		)
+		company = warehouse_company.get(bin.warehouse)
 
 		if filters.brand and filters.brand != item.brand:
 			continue
@@ -229,6 +228,23 @@ def get_columns():
 			"convertible": "qty",
 		},
 	]
+
+
+def get_warehouse_company_map(bin_list):
+	"""Batch fetch warehouse companies to avoid N+1 queries."""
+	if not bin_list:
+		return {}
+
+	warehouses = list({bin.warehouse for bin in bin_list})
+	if not warehouses:
+		return {}
+
+	wh = frappe.qb.DocType("Warehouse")
+	warehouse_data = (
+		frappe.qb.from_(wh).select(wh.name, wh.company).where(wh.name.isin(warehouses)).run(as_dict=True)
+	)
+
+	return {d.name: d.company for d in warehouse_data}
 
 
 def get_bin_list(filters):


### PR DESCRIPTION
## Summary
This PR fixes N+1 query performance issues in two stock reports.

## Problem

### Stock Ledger Report (`stock_ledger.py`)
In `get_opening_balance()`, for each Stock Reconciliation entry matching the from_date, the code was making a separate database call:

```python
# Before (N queries)
for sle in list(sl_entries):
    if (sle.get('voucher_type') == 'Stock Reconciliation'
        and sle.posting_date == filters.from_date
        and frappe.db.get_value('Stock Reconciliation', sle.voucher_no, 'purpose') == 'Opening Stock'):
```

### Stock Projected Qty Report (`stock_projected_qty.py`)
The loop was calling `frappe.db.get_value()` for each unique warehouse to get its company:

```python
# Before (N queries for N unique warehouses)
for bin in bin_list:
    company = warehouse_company.setdefault(
        bin.warehouse, frappe.db.get_value('Warehouse', bin.warehouse, 'company')
    )
```

## Solution

### Stock Ledger Report
Batch fetch all Stock Reconciliation purposes in a single query before the loop:

```python
# After (1 query)
sr_vouchers = [sle.voucher_no for sle in sl_entries 
               if sle.get('voucher_type') == 'Stock Reconciliation' 
               and sle.posting_date == filters.from_date]
opening_stock_vouchers = set(frappe.get_all('Stock Reconciliation',
    filters={'name': ('in', sr_vouchers), 'purpose': 'Opening Stock'}, pluck='name'))
```

### Stock Projected Qty Report
Pre-fetch all warehouse companies in a single batch query:

```python
# After (1 query)
def get_warehouse_company_map(bin_list):
    warehouses = list({bin.warehouse for bin in bin_list})
    wh = frappe.qb.DocType('Warehouse')
    warehouse_data = frappe.qb.from_(wh).select(wh.name, wh.company).where(wh.name.isin(warehouses)).run(as_dict=True)
    return {d.name: d.company for d in warehouse_data}
```

## Performance Impact

| Report | Before | After |
|--------|--------|-------|
| Stock Ledger | N queries (N = Stock Reconciliation entries on from_date) | 1 query |
| Stock Projected Qty | N queries (N = unique warehouses) | 1 query |

For a database with 100 unique warehouses, the Stock Projected Qty report now makes 1 query instead of 100.

## Testing
- No behavioral changes - only performance optimization
- Tested locally to ensure reports return correct data