### PR TITLE
fix: remove incorrect validation from email digest throwing spurious error (backport #51827)

### DIFF
--- a/erpnext/setup/doctype/email_digest/email_digest.py
+++ b/erpnext/setup/doctype/email_digest/email_digest.py
@@ -162,8 +162,6 @@ class EmailDigest(Document):
 				context.purchase_order_list,
 				context.purchase_orders_items_overdue_list,
 			) = self.get_purchase_orders_items_overdue_list()
-			if not context.purchase_order_list:
-				frappe.throw(_("No items to be received are overdue"))
 
 		if not context:
 			return None


### PR DESCRIPTION
Manual backport #51827 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where email digests would fail to generate when there were no overdue purchase orders, enabling successful digest generation regardless of purchase order status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->