### PR TITLE
refactor: update labels for tax withholding reports columns to improve clarity

### DIFF
--- a/erpnext/accounts/report/tax_withholding_details/tax_withholding_details.py
+++ b/erpnext/accounts/report/tax_withholding_details/tax_withholding_details.py
@@ -154,14 +154,8 @@ def get_columns(filters):
 			"width": 60,
 		},
 		{
-			"label": _("Total Amount"),
+			"label": _("Taxable Amount"),
 			"fieldname": "total_amount",
-			"fieldtype": "Currency",
-			"width": 120,
-		},
-		{
-			"label": _("Base Total"),
-			"fieldname": "base_total",
 			"fieldtype": "Currency",
 			"width": 120,
 		},
@@ -172,10 +166,16 @@ def get_columns(filters):
 			"width": 120,
 		},
 		{
-			"label": _("Grand Total"),
+			"label": _("Grand Total (Company Currency)"),
+			"fieldname": "base_total",
+			"fieldtype": "Currency",
+			"width": 150,
+		},
+		{
+			"label": _("Grand Total (Transaction Currency)"),
 			"fieldname": "grand_total",
 			"fieldtype": "Currency",
-			"width": 120,
+			"width": 170,
 		},
 		{
 			"label": _("Reference Date"),

--- a/erpnext/accounts/report/tds_computation_summary/tds_computation_summary.py
+++ b/erpnext/accounts/report/tds_computation_summary/tds_computation_summary.py
@@ -106,7 +106,7 @@ def get_columns(filters):
 			"width": 120,
 		},
 		{
-			"label": _("Total Amount"),
+			"label": _("Total Taxable Amount"),
 			"fieldname": "total_amount",
 			"fieldtype": "Float",
 			"width": 120,


### PR DESCRIPTION
- Renamed "Total Amount" → "Taxable Amount" for clarity
- Clarified grand total columns: "Grand Total (Company Currency)" and "Grand Total (Transaction Currency)" to distinguish between base_total and grand_total
- Reordered columns: "Tax Amount" now appears immediately after "Taxable Amount" for better logical flow
Adjusted column widths for longer labels

Before:
<img width="1650" height="165" alt="image" src="https://github.com/user-attachments/assets/2d577bbf-206c-4944-9917-7a150bd961c2" />

After: 
<img width="1656" height="159" alt="image" src="https://github.com/user-attachments/assets/690f2b93-c8d6-4c70-a6da-ac4ac8636431" />

