### PR TITLE
fix: add base_tax_withholding_net_total to tax withholding report

### DIFF
--- a/erpnext/accounts/report/tax_withholding_details/tax_withholding_details.py
+++ b/erpnext/accounts/report/tax_withholding_details/tax_withholding_details.py
@@ -51,7 +51,7 @@ def get_result(filters, tds_docs, tds_accounts, tax_category_map, journal_entry_
 	entries = {}
 	for name, details in gle_map.items():
 		for entry in details:
-			tax_amount, total_amount, grand_total, base_total = 0, 0, 0, 0
+			tax_amount, total_amount, grand_total, base_total, base_tax_withholding_net_total = 0, 0, 0, 0, 0
 			tax_withholding_category, rate = None, None
 			bill_no, bill_date = "", ""
 			party = entry.party or entry.against
@@ -93,12 +93,16 @@ def get_result(filters, tds_docs, tds_accounts, tax_category_map, journal_entry_
 
 					grand_total = values[1]
 					base_total = values[2]
+					base_tax_withholding_net_total = total_amount
 
 					if voucher_type == "Purchase Invoice":
+						base_tax_withholding_net_total = values[0]
 						bill_no = values[3]
 						bill_date = values[4]
+
 			else:
 				total_amount += entry.credit
+				base_tax_withholding_net_total = total_amount
 
 			if tax_amount:
 				if party_map.get(party, {}).get("party_type") == "Supplier":
@@ -125,6 +129,7 @@ def get_result(filters, tds_docs, tds_accounts, tax_category_map, journal_entry_
 						"rate": rate,
 						"total_amount": total_amount,
 						"grand_total": grand_total,
+						"base_tax_withholding_net_total": base_tax_withholding_net_total,
 						"base_total": base_total,
 						"tax_amount": tax_amount,
 						"transaction_date": posting_date,
@@ -250,6 +255,12 @@ def get_columns(filters):
 				"fieldname": "rate",
 				"fieldtype": "Percent",
 				"width": 60,
+			},
+			{
+				"label": _("Tax Withholding Net Total"),
+				"fieldname": "base_tax_withholding_net_total",
+				"fieldtype": "Float",
+				"width": 150,
 			},
 			{
 				"label": _("Taxable Amount"),

--- a/erpnext/accounts/report/tax_withholding_details/tax_withholding_details.py
+++ b/erpnext/accounts/report/tax_withholding_details/tax_withholding_details.py
@@ -252,14 +252,8 @@ def get_columns(filters):
 				"width": 60,
 			},
 			{
-				"label": _("Total Amount"),
+				"label": _("Taxable Amount"),
 				"fieldname": "total_amount",
-				"fieldtype": "Float",
-				"width": 120,
-			},
-			{
-				"label": _("Base Total"),
-				"fieldname": "base_total",
 				"fieldtype": "Float",
 				"width": 120,
 			},
@@ -270,10 +264,16 @@ def get_columns(filters):
 				"width": 120,
 			},
 			{
-				"label": _("Grand Total"),
+				"label": _("Grand Total (Company Currency)"),
+				"fieldname": "base_total",
+				"fieldtype": "Float",
+				"width": 150,
+			},
+			{
+				"label": _("Grand Total (Transaction Currency)"),
 				"fieldname": "grand_total",
 				"fieldtype": "Float",
-				"width": 120,
+				"width": 170,
 			},
 			{"label": _("Transaction Type"), "fieldname": "transaction_type", "width": 130},
 			{

--- a/erpnext/accounts/report/tax_withholding_details/tax_withholding_details.py
+++ b/erpnext/accounts/report/tax_withholding_details/tax_withholding_details.py
@@ -83,6 +83,7 @@ def get_result(filters, tds_docs, tds_accounts, tax_category_map, journal_entry_
 					# back calculate total amount from rate and tax_amount
 					base_total = min(flt(tax_amount / (rate / 100), precision=precision), values[0])
 					total_amount = grand_total = base_total
+					base_tax_withholding_net_total = total_amount
 
 				else:
 					if tax_amount and rate:

--- a/erpnext/accounts/report/tax_withholding_details/test_tax_withholding_details.py
+++ b/erpnext/accounts/report/tax_withholding_details/test_tax_withholding_details.py
@@ -35,9 +35,9 @@ class TestTaxWithholdingDetails(AccountsTestMixin, FrappeTestCase):
 		result = execute(filters)[1]
 		expected_values = [
 			# Check for JV totals using back calculation logic
-			[jv.name, "TCS", 0.075, -10000.0, -7.5, -10000.0],
-			[pe.name, "TCS", 0.075, 2550, 0.53, 2550.53],
-			[si.name, "TCS", 0.075, 1000, 0.52, 1000.52],
+			[jv.name, "TCS", 0.075, -10000.0, -10000.0, -7.5, -10000.0],
+			[pe.name, "TCS", 0.075, 2550, 2550, 0.53, 2550.53],
+			[si.name, "TCS", 0.075, 1000, 1000, 0.52, 1000.52],
 		]
 		self.check_expected_values(result, expected_values)
 
@@ -55,8 +55,8 @@ class TestTaxWithholdingDetails(AccountsTestMixin, FrappeTestCase):
 			frappe._dict(company="_Test Company", party_type="Supplier", from_date=today(), to_date=today())
 		)[1]
 		expected_values = [
-			[inv_1.name, "TDS - 1", 10, 5000, 500, 5500],
-			[inv_2.name, "TDS - 2", 20, 5000, 1000, 6000],
+			[inv_1.name, "TDS - 1", 10, 5000, 5000, 500, 5500],
+			[inv_2.name, "TDS - 2", 20, 5000, 5000, 1000, 6000],
 		]
 		self.check_expected_values(result, expected_values)
 
@@ -107,8 +107,8 @@ class TestTaxWithholdingDetails(AccountsTestMixin, FrappeTestCase):
 		)[1]
 
 		expected_values = [
-			[inv_1.name, "TDS - 3", 10.0, 5000, 500, 4500],
-			[inv_2.name, "TDS - 3", 20.0, 5000, 1000, 4000],
+			[inv_1.name, "TDS - 3", 10.0, 5000, 5000, 500, 4500],
+			[inv_2.name, "TDS - 3", 20.0, 5000, 5000, 1000, 4000],
 		]
 		self.check_expected_values(result, expected_values)
 
@@ -120,6 +120,7 @@ class TestTaxWithholdingDetails(AccountsTestMixin, FrappeTestCase):
 				voucher.ref_no,
 				voucher.section_code,
 				voucher.rate,
+				voucher.base_tax_withholding_net_total,
 				voucher.base_total,
 				voucher.tax_amount,
 				voucher.grand_total,

--- a/erpnext/accounts/report/tax_withholding_details/test_tax_withholding_details.py
+++ b/erpnext/accounts/report/tax_withholding_details/test_tax_withholding_details.py
@@ -36,8 +36,8 @@ class TestTaxWithholdingDetails(AccountsTestMixin, FrappeTestCase):
 		expected_values = [
 			# Check for JV totals using back calculation logic
 			[jv.name, "TCS", 0.075, -10000.0, -10000.0, -7.5, -10000.0],
-			[pe.name, "TCS", 0.075, 2550, 2550, 0.53, 2550.53],
-			[si.name, "TCS", 0.075, 1000, 1000, 0.52, 1000.52],
+			[pe.name, "TCS", 0.075, 706.67, 2550.0, 0.53, 2550.53],
+			[si.name, "TCS", 0.075, 693.33, 1000.0, 0.52, 1000.52],
 		]
 		self.check_expected_values(result, expected_values)
 

--- a/erpnext/accounts/report/tds_computation_summary/tds_computation_summary.py
+++ b/erpnext/accounts/report/tds_computation_summary/tds_computation_summary.py
@@ -128,7 +128,7 @@ def get_columns(filters):
 				"width": 120,
 			},
 			{
-				"label": _("Total Amount"),
+				"label": _("Total Taxable Amount"),
 				"fieldname": "total_amount",
 				"fieldtype": "Float",
 				"width": 120,


### PR DESCRIPTION
Manual Backport: https://github.com/frappe/erpnext/pull/52593


- Renamed "Total Amount" → "Taxable Amount" for clarity
- Clarified grand total columns: "Grand Total (Company Currency)" and "Grand Total (Transaction Currency)" to distinguish between base_total and grand_total
- Reordered columns: "Tax Amount" now appears immediately after "Taxable Amount" for better logical flow
Adjusted column widths for longer labels


- Added base_tax_withholding_net_total column in Tax Withholding Details Report.
- For Purchase, it will be set from the doc, and for other doctypes, it will be as perthe  calculated `base_total`

Before:
<img width="1348" height="392" alt="image" src="https://github.com/user-attachments/assets/68e5f353-12f2-4340-9967-12741eaf3fec" />


After:
<img width="1401" height="374" alt="image" src="https://github.com/user-attachments/assets/883cc6eb-6c97-46e3-a673-69ffa4e6e063" />




Frappe Support Issue: https://support.frappe.io/desk/hd-ticket/55617

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tax withholding details report adds a new taxable/net metric and includes it in row and aggregate totals.
  * Report columns reorganized: renamed/mapped fields and separate grand totals for company and transaction currencies.
  * TDS computation report header clarified to "Total Taxable Amount".
* **Tests**
  * Updated tests and expectations to include the new taxable/net column.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->