### PR TITLE
feat: show formatted currency symbol on ledger preview

### DIFF
--- a/erpnext/controllers/stock_controller.py
+++ b/erpnext/controllers/stock_controller.py
@@ -2017,7 +2017,7 @@ def get_gl_entries_for_preview(doctype, docname, fields):
 
 def get_columns(raw_columns, fields):
 	return [
-		{"name": d.get("label"), "editable": False, "width": 110}
+		{"name": d.get("label"), "editable": False, "width": 110, "fieldtype": d.get("fieldtype")}
 		for d in raw_columns
 		if not d.get("hidden") and d.get("fieldname") in fields
 	]

--- a/erpnext/public/js/utils/ledger_preview.js
+++ b/erpnext/public/js/utils/ledger_preview.js
@@ -84,6 +84,14 @@ erpnext.accounts.ledger_preview = {
 	},
 
 	get_datatable(columns, data, wrapper) {
+		columns.forEach((col) => {
+			if (col.fieldtype === "Currency") {
+				col.format = (value) => {
+					return format_currency(value);
+				};
+			}
+		});
+
 		const datatable_options = {
 			columns: columns,
 			data: data,


### PR DESCRIPTION
**Issue:** On Ledger preview, the currency values are formatted.

**Ref:** [59859](https://support.frappe.io/helpdesk/tickets/59859)

**Before:** 

<img width="1428" height="506" alt="Screenshot 2026-02-11 at 17 33 19" src="https://github.com/user-attachments/assets/2f941a3c-48cd-4a35-9a7d-831dce33e1db" />

**After:**

<img width="1431" height="456" alt="Screenshot 2026-02-11 at 17 32 43" src="https://github.com/user-attachments/assets/4bb1fca2-9b13-49bd-93cc-8d10e88fee71" />

**Backport Needed v15 and v16**