### PR TITLE
fix: prevent rows from being added to sub_assembly_items and mr_items

### DIFF
--- a/erpnext/manufacturing/doctype/production_plan/production_plan.js
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.js
@@ -24,8 +24,8 @@ frappe.ui.form.on("Production Plan", {
 			"Material Request": "Material Request",
 		};
 
-		frm.set_df_property("sub_assembly_items", "cannot_delete_rows", true);
-		frm.set_df_property("mr_items", "cannot_delete_rows", true);
+		frm.set_df_property("sub_assembly_items", "cannot_add_rows", true);
+		frm.set_df_property("mr_items", "cannot_add_rows", true);
 	},
 
 	setup_queries(frm) {


### PR DESCRIPTION
The child tables had delete rows disabled but still allowed to add rows 