### PR TITLE
fix(manufacturing): set pick list purpose while creating it from work order

### DIFF
--- a/erpnext/manufacturing/doctype/work_order/work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/work_order.py
@@ -2685,6 +2685,7 @@ def create_pick_list(source_name, target_doc=None, for_qty=None):
 		target_doc,
 	)
 
+	doc.purpose = "Material Transfer for Manufacture"
 	doc.for_qty = for_qty
 
 	doc.set_item_locations()


### PR DESCRIPTION
**Issue:**
1. Instead of using the default Pick List purpose, the system should automatically set the appropriate purpose "Material Transfer for Manufacture" when creating a Pick List from a Work Order.
2. The system should remove the Work Order reference from the Pick List and the Stock Entry when it is not needed.

**Ref:** [#59774](https://support.frappe.io/helpdesk/tickets/59774)

**Before:**

https://github.com/user-attachments/assets/5e7ca953-9cf4-423d-b076-6b1e4aa87562

**After:**

https://github.com/user-attachments/assets/62e1af07-aabf-4994-818f-80405e346423

**Backport Needed for v15 & v16**