### PR TITLE
feat(account): add Tax Exempt option on Tax Category

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
@@ -479,7 +479,7 @@ class TestSalesInvoice(ERPNextTestSuite):
 		)
 		si.insert()
 
-		# Item 1: 3 × 200 = 600, Item 2: 2 × 350 = 700, Total = 1300
+		# Item 1: 3 x 200 = 600, Item 2: 2 x 350 = 700, Total = 1300
 		self.assertEqual(si.items[0].net_amount, 600)
 		self.assertEqual(si.items[1].net_amount, 700)
 		self.assertEqual(si.net_total, 1300)
@@ -515,6 +515,30 @@ class TestSalesInvoice(ERPNextTestSuite):
 
 		tax_gl = [e for e in gl_entries if e.account == "_Test Account Service Tax - _TC"]
 		self.assertEqual(len(tax_gl), 0, "Tax-exempt invoice should not have GL entries for tax account")
+
+	def test_tax_exempt_actual_charge_type(self):
+		"""Tax-exempt category with Actual charge type: tax amount must be zero."""
+		tax_category = frappe.get_doc(
+			{"doctype": "Tax Category", "title": "_Test Tax Exempt", "is_tax_exempt": 1}
+		).insert()
+
+		si = create_sales_invoice(qty=2, rate=500, do_not_save=True)
+		si.tax_category = tax_category.name
+		si.append(
+			"taxes",
+			{
+				"charge_type": "Actual",
+				"account_head": "_Test Account Service Tax - _TC",
+				"cost_center": "_Test Cost Center - _TC",
+				"description": "Service Tax",
+				"tax_amount": 150,
+			},
+		)
+		si.insert()
+
+		self.assertEqual(si.net_total, 1000)
+		self.assertEqual(si.taxes[0].tax_amount, 0)
+		self.assertEqual(si.grand_total, 1000)
 
 	def test_sales_invoice_discount_amount(self):
 		si = frappe.copy_doc(self.globalTestRecords["Sales Invoice"][3])

--- a/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
@@ -392,6 +392,130 @@ class TestSalesInvoice(ERPNextTestSuite):
 		self.assertEqual(si.net_total, 3859.65)
 		self.assertEqual(si.grand_total, 4900.00)
 
+	def test_tax_exempt_exclusive_tax(self):
+		"""Tax-exempt category with exclusive taxes: tax amount must be zero,
+		grand total must equal net total (item rate unchanged)."""
+		tax_category = frappe.get_doc(
+			{"doctype": "Tax Category", "title": "_Test Tax Exempt", "is_tax_exempt": 1}
+		).insert()
+
+		si = create_sales_invoice(qty=2, rate=500, do_not_save=True)
+		si.tax_category = tax_category.name
+		si.append(
+			"taxes",
+			{
+				"charge_type": "On Net Total",
+				"account_head": "_Test Account Service Tax - _TC",
+				"cost_center": "_Test Cost Center - _TC",
+				"description": "Service Tax",
+				"rate": 14,
+			},
+		)
+		si.insert()
+
+		# Rate stays as-is, tax is zero
+		self.assertEqual(si.items[0].net_amount, 1000)
+		self.assertEqual(si.net_total, 1000)
+		self.assertEqual(si.taxes[0].tax_amount, 0)
+		self.assertEqual(si.grand_total, 1000)
+
+	def test_tax_exempt_inclusive_tax(self):
+		"""Tax-exempt category with inclusive taxes: tax should be backed out from
+		the price so the customer pays the net amount."""
+		tax_category = frappe.get_doc(
+			{"doctype": "Tax Category", "title": "_Test Tax Exempt", "is_tax_exempt": 1}
+		).insert()
+
+		si = create_sales_invoice(qty=1, rate=1000, do_not_save=True)
+		si.tax_category = tax_category.name
+		si.append(
+			"taxes",
+			{
+				"charge_type": "On Net Total",
+				"account_head": "_Test Account Service Tax - _TC",
+				"cost_center": "_Test Cost Center - _TC",
+				"description": "Service Tax",
+				"rate": 10,
+				"included_in_print_rate": 1,
+			},
+		)
+		si.insert()
+
+		# 1000 / 1.10 = 909.09 net, tax backed out then zeroed
+		self.assertEqual(si.items[0].net_amount, 909.09)
+		self.assertEqual(si.net_total, 909.09)
+		self.assertEqual(si.taxes[0].tax_amount, 0)
+		self.assertEqual(si.grand_total, 909.09)
+
+	def test_tax_exempt_exclusive_tax_multiple_items(self):
+		"""Tax-exempt with exclusive taxes and multiple items."""
+		tax_category = frappe.get_doc(
+			{"doctype": "Tax Category", "title": "_Test Tax Exempt", "is_tax_exempt": 1}
+		).insert()
+
+		si = create_sales_invoice(qty=3, rate=200, do_not_save=True)
+		si.tax_category = tax_category.name
+		si.append(
+			"items",
+			{
+				"item_code": "_Test Item",
+				"warehouse": "_Test Warehouse - _TC",
+				"qty": 2,
+				"rate": 350,
+				"income_account": "Sales - _TC",
+				"expense_account": "Cost of Goods Sold - _TC",
+				"cost_center": "_Test Cost Center - _TC",
+			},
+		)
+		si.append(
+			"taxes",
+			{
+				"charge_type": "On Net Total",
+				"account_head": "_Test Account Service Tax - _TC",
+				"cost_center": "_Test Cost Center - _TC",
+				"description": "Service Tax",
+				"rate": 14,
+			},
+		)
+		si.insert()
+
+		# Item 1: 3 × 200 = 600, Item 2: 2 × 350 = 700, Total = 1300
+		self.assertEqual(si.items[0].net_amount, 600)
+		self.assertEqual(si.items[1].net_amount, 700)
+		self.assertEqual(si.net_total, 1300)
+		self.assertEqual(si.taxes[0].tax_amount, 0)
+		self.assertEqual(si.grand_total, 1300)
+
+	def test_tax_exempt_no_gl_entries_for_tax(self):
+		"""Tax-exempt invoices must not create GL entries for tax accounts."""
+		tax_category = frappe.get_doc(
+			{"doctype": "Tax Category", "title": "_Test Tax Exempt", "is_tax_exempt": 1}
+		).insert()
+
+		si = create_sales_invoice(qty=1, rate=500, do_not_save=True)
+		si.tax_category = tax_category.name
+		si.append(
+			"taxes",
+			{
+				"charge_type": "On Net Total",
+				"account_head": "_Test Account Service Tax - _TC",
+				"cost_center": "_Test Cost Center - _TC",
+				"description": "Service Tax",
+				"rate": 10,
+			},
+		)
+		si.insert()
+		si.submit()
+
+		gl_entries = frappe.db.get_all(
+			"GL Entry",
+			filters={"voucher_no": si.name, "is_cancelled": 0},
+			fields=["account", "debit", "credit"],
+		)
+
+		tax_gl = [e for e in gl_entries if e.account == "_Test Account Service Tax - _TC"]
+		self.assertEqual(len(tax_gl), 0, "Tax-exempt invoice should not have GL entries for tax account")
+
 	def test_sales_invoice_discount_amount(self):
 		si = frappe.copy_doc(self.globalTestRecords["Sales Invoice"][3])
 		si.discount_amount = 104.94

--- a/erpnext/accounts/doctype/tax_category/tax_category.json
+++ b/erpnext/accounts/doctype/tax_category/tax_category.json
@@ -8,7 +8,8 @@
  "engine": "InnoDB",
  "field_order": [
   "title",
-  "disabled"
+  "disabled",
+  "is_tax_exempt"
  ],
  "fields": [
   {
@@ -25,6 +26,13 @@
    "fieldname": "disabled",
    "fieldtype": "Check",
    "label": "Disabled"
+  },
+  {
+   "default": "0",
+   "description": "Customers with this tax category are exempt from taxes. Tax amounts will be zero with no GL entries for tax accounts. For tax-inclusive pricing, tax will be backed out from the price so the customer pays the net amount.",
+   "fieldname": "is_tax_exempt",
+   "fieldtype": "Check",
+   "label": "Is Tax Exempt"
   }
  ],
  "index_web_pages_for_search": 1,

--- a/erpnext/controllers/taxes_and_totals.py
+++ b/erpnext/controllers/taxes_and_totals.py
@@ -436,8 +436,10 @@ class calculate_taxes_and_totals:
 
 		# Zero out Actual tax amounts for tax-exempt categories
 		if self._is_tax_exempt:
-			for idx in actual_tax_dict:
-				actual_tax_dict[idx] = 0
+			for tax in doc.taxes:
+				if tax.charge_type == "Actual":
+					tax.tax_amount = 0
+					actual_tax_dict[tax.idx] = 0
 
 		for n, item in enumerate(self._items):
 			item_tax_map = self._load_item_tax_rate(item.item_tax_rate)

--- a/erpnext/controllers/taxes_and_totals.py
+++ b/erpnext/controllers/taxes_and_totals.py
@@ -346,22 +346,9 @@ class calculate_taxes_and_totals:
 		if not item.get("item_code"):
 			return {}
 
-		item_doc = frappe.get_cached_doc("Item", item.item_code)
-		company = self.doc.get("company")
-		exempt_category = self.doc.get("tax_category")
-
-		for row in item_doc.get("taxes", []):
-			if row.tax_category == exempt_category:
-				continue
-			template = frappe.get_cached_doc("Item Tax Template", row.item_tax_template)
-			rates = {}
-			for d in template.taxes:
-				if frappe.get_cached_value("Account", d.tax_type, "company") == company:
-					rates[d.tax_type] = d.tax_rate
-			if rates:
-				return rates
-
-		return {}
+		return _get_non_exempt_rates_for_item(
+			item.item_code, self.doc.get("tax_category"), self.doc.get("company")
+		)
 
 	def _load_item_tax_rate(self, item_tax_rate):
 		return json.loads(item_tax_rate) if item_tax_rate else {}
@@ -446,6 +433,11 @@ class calculate_taxes_and_totals:
 				if tax.charge_type == "Actual"
 			]
 		)
+
+		# Zero out Actual tax amounts for tax-exempt categories
+		if self._is_tax_exempt:
+			for idx in actual_tax_dict:
+				actual_tax_dict[idx] = 0
 
 		for n, item in enumerate(self._items):
 			item_tax_map = self._load_item_tax_rate(item.item_tax_rate)
@@ -1310,24 +1302,31 @@ def get_rounded_tax_amount(itemised_tax, precision):
 				row["tax_amount"] = flt(row["tax_amount"], precision)
 
 
+def _get_non_exempt_rates_for_item(item_code: str, tax_category: str, company: str) -> dict:
+	"""Return non-exempt tax rates for a single item, skipping the given exempt category."""
+	item_doc = frappe.get_cached_doc("Item", item_code)
+	for row in item_doc.get("taxes", []):
+		if row.tax_category == tax_category:
+			continue
+		template = frappe.get_cached_doc("Item Tax Template", row.item_tax_template)
+		rates = {}
+		for d in template.taxes:
+			if frappe.get_cached_value("Account", d.tax_type, "company") == company:
+				rates[d.tax_type] = d.tax_rate
+		if rates:
+			return rates
+	return {}
+
+
 @frappe.whitelist()
-def get_non_exempt_tax_rates(item_codes, tax_category, company):
+def get_non_exempt_tax_rates(item_codes: str | list, tax_category: str, company: str):
 	"""Get non-exempt tax rates for items, used by JS for backing out inclusive prices."""
 	item_codes = json.loads(item_codes) if isinstance(item_codes, str) else item_codes
 	result = {}
 	for item_code in item_codes:
-		item_doc = frappe.get_cached_doc("Item", item_code)
-		for row in item_doc.get("taxes", []):
-			if row.tax_category == tax_category:
-				continue
-			template = frappe.get_cached_doc("Item Tax Template", row.item_tax_template)
-			rates = {}
-			for d in template.taxes:
-				if frappe.get_cached_value("Account", d.tax_type, "company") == company:
-					rates[d.tax_type] = d.tax_rate
-			if rates:
-				result[item_code] = rates
-				break
+		rates = _get_non_exempt_rates_for_item(item_code, tax_category, company)
+		if rates:
+			result[item_code] = rates
 	return result
 
 

--- a/erpnext/controllers/taxes_and_totals.py
+++ b/erpnext/controllers/taxes_and_totals.py
@@ -290,6 +290,11 @@ class calculate_taxes_and_totals:
 
 		for item in self.doc.items:
 			item_tax_map = self._load_item_tax_rate(item.item_tax_rate)
+
+			# For tax-exempt categories, use non-exempt rates for backing out
+			if self._is_tax_exempt:
+				item_tax_map = self._get_non_exempt_tax_rates(item)
+
 			cumulated_tax_fraction = 0
 			total_inclusive_tax_amount_per_qty = 0
 			for i, tax in enumerate(self.doc.get("taxes")):
@@ -323,6 +328,40 @@ class calculate_taxes_and_totals:
 				)
 
 				self._set_in_company_currency(item, ["net_rate", "net_amount"])
+
+	@property
+	def _is_tax_exempt(self):
+		if not hasattr(self, "_tax_exempt_cached"):
+			if self.doc.get("tax_category"):
+				self._tax_exempt_cached = frappe.db.get_value(
+					"Tax Category", self.doc.tax_category, "is_tax_exempt"
+				)
+			else:
+				self._tax_exempt_cached = False
+		return self._tax_exempt_cached
+
+	def _get_non_exempt_tax_rates(self, item):
+		"""Get the non-exempt tax rates from the item's templates for backing out inclusive prices.
+		Falls back to empty dict so _get_tax_rate() uses tax.rate from the row."""
+		if not item.get("item_code"):
+			return {}
+
+		item_doc = frappe.get_cached_doc("Item", item.item_code)
+		company = self.doc.get("company")
+		exempt_category = self.doc.get("tax_category")
+
+		for row in item_doc.get("taxes", []):
+			if row.tax_category == exempt_category:
+				continue
+			template = frappe.get_cached_doc("Item Tax Template", row.item_tax_template)
+			rates = {}
+			for d in template.taxes:
+				if frappe.get_cached_value("Account", d.tax_type, "company") == company:
+					rates[d.tax_type] = d.tax_rate
+			if rates:
+				return rates
+
+		return {}
 
 	def _load_item_tax_rate(self, item_tax_rate):
 		return json.loads(item_tax_rate) if item_tax_rate else {}
@@ -410,6 +449,13 @@ class calculate_taxes_and_totals:
 
 		for n, item in enumerate(self._items):
 			item_tax_map = self._load_item_tax_rate(item.item_tax_rate)
+
+			# For tax-exempt categories, ensure all tax rates are 0
+			if self._is_tax_exempt:
+				for tax_row in doc.taxes:
+					if tax_row.account_head:
+						item_tax_map[tax_row.account_head] = 0
+
 			for i, tax in enumerate(doc.taxes):
 				# tax_amount represents the amount of tax for the current step
 				current_net_amount, current_tax_amount = self.get_current_tax_and_net_amount(
@@ -1262,6 +1308,27 @@ def get_rounded_tax_amount(itemised_tax, precision):
 		for row in taxes.values():
 			if isinstance(row, dict) and isinstance(row["tax_amount"], float):
 				row["tax_amount"] = flt(row["tax_amount"], precision)
+
+
+@frappe.whitelist()
+def get_non_exempt_tax_rates(item_codes, tax_category, company):
+	"""Get non-exempt tax rates for items, used by JS for backing out inclusive prices."""
+	item_codes = json.loads(item_codes) if isinstance(item_codes, str) else item_codes
+	result = {}
+	for item_code in item_codes:
+		item_doc = frappe.get_cached_doc("Item", item_code)
+		for row in item_doc.get("taxes", []):
+			if row.tax_category == tax_category:
+				continue
+			template = frappe.get_cached_doc("Item Tax Template", row.item_tax_template)
+			rates = {}
+			for d in template.taxes:
+				if frappe.get_cached_value("Account", d.tax_type, "company") == company:
+					rates[d.tax_type] = d.tax_rate
+			if rates:
+				result[item_code] = rates
+				break
+	return result
 
 
 @frappe.whitelist()

--- a/erpnext/public/js/controllers/taxes_and_totals.js
+++ b/erpnext/public/js/controllers/taxes_and_totals.js
@@ -101,9 +101,7 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 		let cached = this.frm.doc.__non_exempt_rates || {};
 		let missing = [
 			...new Set(
-				this.frm.doc.items
-					.map((d) => d.item_code)
-					.filter((code) => code && !(code in cached))
+				this.frm.doc.items.map((d) => d.item_code).filter((code) => code && !(code in cached))
 			),
 		];
 		if (!missing.length) return;
@@ -431,8 +429,11 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 
 		// Zero out Actual tax amounts for tax-exempt categories
 		if (me.frm.doc.__is_tax_exempt) {
-			$.each(actual_tax_dict, function (idx) {
-				actual_tax_dict[idx] = 0;
+			$.each(doc.taxes || [], function (i, tax) {
+				if (tax.charge_type == "Actual") {
+					tax.tax_amount = 0;
+					actual_tax_dict[tax.idx] = 0;
+				}
 			});
 		}
 

--- a/erpnext/public/js/controllers/taxes_and_totals.js
+++ b/erpnext/public/js/controllers/taxes_and_totals.js
@@ -257,6 +257,12 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 
 		$.each(this.frm.doc.items || [], function (n, item) {
 			var item_tax_map = me._load_item_tax_rate(item.item_tax_rate);
+
+			// For tax-exempt categories, use non-exempt rates for backing out
+			if (me.frm.doc.__is_tax_exempt) {
+				item_tax_map = (me.frm.doc.__non_exempt_rates || {})[item.item_code] || {};
+			}
+
 			var cumulated_tax_fraction = 0.0;
 			var total_inclusive_tax_amount_per_qty = 0;
 			$.each(me.frm.doc["taxes"] || [], function (i, tax) {
@@ -399,6 +405,16 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 
 		$.each(this.frm._items || [], function (n, item) {
 			var item_tax_map = me._load_item_tax_rate(item.item_tax_rate);
+
+			// For tax-exempt categories, ensure all tax rates are 0
+			if (me.frm.doc.__is_tax_exempt) {
+				$.each(doc.taxes || [], function (i, tax) {
+					if (tax.account_head) {
+						item_tax_map[tax.account_head] = 0;
+					}
+				});
+			}
+
 			$.each(doc.taxes, function (i, tax) {
 				// tax_amount represents the amount of tax for the current step
 				var [current_net_amount, current_tax_amount] = me.get_current_tax_amount(

--- a/erpnext/public/js/controllers/taxes_and_totals.js
+++ b/erpnext/public/js/controllers/taxes_and_totals.js
@@ -107,14 +107,19 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 		];
 		if (!missing.length) return;
 
-		let r = await frappe.call({
-			method: "erpnext.controllers.taxes_and_totals.get_non_exempt_tax_rates",
-			args: {
-				item_codes: missing,
-				tax_category: this.frm.doc.tax_category,
-				company: this.frm.doc.company,
-			},
-		});
+		let r;
+		try {
+			r = await frappe.call({
+				method: "erpnext.controllers.taxes_and_totals.get_non_exempt_tax_rates",
+				args: {
+					item_codes: missing,
+					tax_category: this.frm.doc.tax_category,
+					company: this.frm.doc.company,
+				},
+			});
+		} catch {
+			return;
+		}
 		Object.assign(cached, r.message || {});
 		this.frm.doc[cache_key] = cached;
 	}

--- a/erpnext/public/js/controllers/taxes_and_totals.js
+++ b/erpnext/public/js/controllers/taxes_and_totals.js
@@ -98,7 +98,8 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 	async _refresh_non_exempt_rates_if_needed() {
 		if (!this.frm.doc.__is_tax_exempt || !this.frm.doc.items?.length) return;
 
-		let cached = this.frm.doc.__non_exempt_rates || {};
+		let cache_key = `__non_exempt_rates__${this.frm.doc.tax_category}__${this.frm.doc.company}`;
+		let cached = this.frm.doc[cache_key] || {};
 		let missing = [
 			...new Set(
 				this.frm.doc.items.map((d) => d.item_code).filter((code) => code && !(code in cached))
@@ -115,7 +116,7 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 			},
 		});
 		Object.assign(cached, r.message || {});
-		this.frm.doc.__non_exempt_rates = cached;
+		this.frm.doc[cache_key] = cached;
 	}
 
 	_calculate_taxes_and_totals() {
@@ -284,7 +285,8 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 
 			// For tax-exempt categories, use non-exempt rates for backing out
 			if (me.frm.doc.__is_tax_exempt) {
-				item_tax_map = (me.frm.doc.__non_exempt_rates || {})[item.item_code] || {};
+				let cache_key = `__non_exempt_rates__${me.frm.doc.tax_category}__${me.frm.doc.company}`;
+				item_tax_map = (me.frm.doc[cache_key] || {})[item.item_code] || {};
 			}
 
 			var cumulated_tax_fraction = 0.0;

--- a/erpnext/public/js/controllers/taxes_and_totals.js
+++ b/erpnext/public/js/controllers/taxes_and_totals.js
@@ -35,6 +35,7 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 	}
 
 	async calculate_taxes_and_totals(update_paid_amount) {
+		await this._refresh_non_exempt_rates_if_needed();
 		this.discount_amount_applied = false;
 		this._calculate_taxes_and_totals();
 		this.calculate_discount_amount();
@@ -92,6 +93,31 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 			this.set_discount_amount();
 			this.apply_discount_amount();
 		}
+	}
+
+	async _refresh_non_exempt_rates_if_needed() {
+		if (!this.frm.doc.__is_tax_exempt || !this.frm.doc.items?.length) return;
+
+		let cached = this.frm.doc.__non_exempt_rates || {};
+		let missing = [
+			...new Set(
+				this.frm.doc.items
+					.map((d) => d.item_code)
+					.filter((code) => code && !(code in cached))
+			),
+		];
+		if (!missing.length) return;
+
+		let r = await frappe.call({
+			method: "erpnext.controllers.taxes_and_totals.get_non_exempt_tax_rates",
+			args: {
+				item_codes: missing,
+				tax_category: this.frm.doc.tax_category,
+				company: this.frm.doc.company,
+			},
+		});
+		Object.assign(cached, r.message || {});
+		this.frm.doc.__non_exempt_rates = cached;
 	}
 
 	_calculate_taxes_and_totals() {
@@ -402,6 +428,13 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 				actual_tax_dict[tax.idx] = flt(tax.tax_amount, precision("tax_amount", tax));
 			}
 		});
+
+		// Zero out Actual tax amounts for tax-exempt categories
+		if (me.frm.doc.__is_tax_exempt) {
+			$.each(actual_tax_dict, function (idx) {
+				actual_tax_dict[idx] = 0;
+			});
+		}
 
 		$.each(this.frm._items || [], function (n, item) {
 			var item_tax_map = me._load_item_tax_rate(item.item_tax_rate);

--- a/erpnext/public/js/controllers/taxes_and_totals.js
+++ b/erpnext/public/js/controllers/taxes_and_totals.js
@@ -107,6 +107,11 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 		];
 		if (!missing.length) return;
 
+		// Guard against concurrent calls for the same cache key
+		let in_flight_key = `__non_exempt_rates_fetching__${this.frm.doc.tax_category}__${this.frm.doc.company}`;
+		if (this.frm.doc[in_flight_key]) return;
+		this.frm.doc[in_flight_key] = true;
+
 		let r;
 		try {
 			r = await frappe.call({
@@ -119,6 +124,8 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 			});
 		} catch {
 			return;
+		} finally {
+			delete this.frm.doc[in_flight_key];
 		}
 		Object.assign(cached, r.message || {});
 		this.frm.doc[cache_key] = cached;

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -2664,9 +2664,11 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 			() => {
 				// Cache the is_tax_exempt status for use in tax calculations
 				if (me.frm.doc.tax_category) {
-					return frappe.db.get_value("Tax Category", me.frm.doc.tax_category, "is_tax_exempt").then((r) => {
-						me.frm.doc.__is_tax_exempt = r.message ? r.message.is_tax_exempt : 0;
-					});
+					return frappe.db
+						.get_value("Tax Category", me.frm.doc.tax_category, "is_tax_exempt")
+						.then((r) => {
+							me.frm.doc.__is_tax_exempt = r.message ? r.message.is_tax_exempt : 0;
+						});
 				} else {
 					me.frm.doc.__is_tax_exempt = 0;
 				}

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -2661,6 +2661,35 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 		if (me.frm.updating_party_details) return;
 
 		frappe.run_serially([
+			() => {
+				// Cache the is_tax_exempt status for use in tax calculations
+				if (me.frm.doc.tax_category) {
+					return frappe.db.get_value("Tax Category", me.frm.doc.tax_category, "is_tax_exempt").then((r) => {
+						me.frm.doc.__is_tax_exempt = r.message ? r.message.is_tax_exempt : 0;
+					});
+				} else {
+					me.frm.doc.__is_tax_exempt = 0;
+				}
+			},
+			() => {
+				// Pre-fetch non-exempt tax rates for backing out inclusive prices
+				if (me.frm.doc.__is_tax_exempt && me.frm.doc.items?.length) {
+					let item_codes = [...new Set(me.frm.doc.items.map((d) => d.item_code).filter(Boolean))];
+					if (item_codes.length) {
+						return frappe.call({
+							method: "erpnext.controllers.taxes_and_totals.get_non_exempt_tax_rates",
+							args: {
+								item_codes: item_codes,
+								tax_category: me.frm.doc.tax_category,
+								company: me.frm.doc.company,
+							},
+							callback: (r) => {
+								me.frm.doc.__non_exempt_rates = r.message || {};
+							},
+						});
+					}
+				}
+			},
 			() => this.update_item_tax_map(),
 			() => erpnext.utils.set_taxes(this.frm, "tax_category"),
 		]);

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -1161,6 +1161,10 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 
 	company() {
 		var me = this;
+		// Invalidate all non-exempt rate caches so stale keys don't linger
+		Object.keys(me.frm.doc)
+			.filter((k) => k.startsWith("__non_exempt_rates"))
+			.forEach((k) => delete me.frm.doc[k]);
 		var set_pricing = function () {
 			if (me.frm.doc.company && me.frm.fields_dict.currency) {
 				frappe.run_serially([
@@ -2660,6 +2664,11 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 		var me = this;
 		if (me.frm.updating_party_details) return;
 
+		// Invalidate all non-exempt rate caches so stale keys don't linger
+		Object.keys(me.frm.doc)
+			.filter((k) => k.startsWith("__non_exempt_rates"))
+			.forEach((k) => delete me.frm.doc[k]);
+
 		frappe.run_serially([
 			() => {
 				// Cache the is_tax_exempt status for use in tax calculations
@@ -2686,7 +2695,8 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 								company: me.frm.doc.company,
 							},
 							callback: (r) => {
-								me.frm.doc.__non_exempt_rates = r.message || {};
+								let cache_key = `__non_exempt_rates__${me.frm.doc.tax_category}__${me.frm.doc.company}`;
+								me.frm.doc[cache_key] = r.message || {};
 							},
 						});
 					}


### PR DESCRIPTION
Adds a new **Is Tax Exempt** checkbox on the Tax Category doctype, providing a category-level mechanism to exempt customers from taxes — complementing the existing item-level and template-based approaches.

When a Tax Category is marked as tax-exempt:

- **Exclusive taxes**: tax amounts are zeroed out; the customer pays only the net total
- **Inclusive taxes**: the tax component is backed out from the item price so the customer pays the reduced net amount
- **No GL entries** are created for tax accounts on exempt transactions

This is useful for organizations (e.g. nonprofits, government bodies, resellers) that are fully exempt from certain taxes. Rather than maintaining separate zero-rate Item Tax Templates or Price Lists, users can simply assign the exempt Tax Category to the customer and all tax rows are automatically zeroed during calculation.

## Changes

- **Tax Category**: new `is_tax_exempt` Check field
- **taxes_and_totals.py / .js**: zero tax amounts for exempt categories during `calculate_taxes()`; use non-exempt rates for backing out inclusive prices in `determine_exclusive_rate()`
- **transaction.js**: pre-fetch exempt status and non-exempt rates client-side so the JS tax engine mirrors the Python behavior
- **taxes_and_totals.py**: new whitelisted `get_non_exempt_tax_rates()` endpoint for the client-side fetch
- **test_sales_invoice.py**: four new tests covering exclusive, inclusive, multi-item, and GL entry scenarios

## How to test

- Create a Tax Category with "Is Tax Exempt" checked
- Create a Sales Invoice with exclusive taxes and the exempt category — verify tax amount is 0 and grand total equals net total
- Create a Sales Invoice with inclusive taxes and the exempt category — verify tax is backed out from price and grand total equals the reduced net
- Submit the invoice and verify no GL entries exist for the tax account
- Verify non-exempt invoices are unaffected

no-docs
