### PR TITLE
fix(account): Edit depends_on of item group, brand field on apply rule table in pricing rule doctype

### DIFF
--- a/erpnext/accounts/doctype/pricing_rule_brand/pricing_rule_brand.json
+++ b/erpnext/accounts/doctype/pricing_rule_brand/pricing_rule_brand.json
@@ -10,7 +10,7 @@
  ],
  "fields": [
   {
-   "depends_on": "eval:parent.apply_on == 'Item Code'",
+   "depends_on": "eval:parent.apply_on == 'Brand'",
    "fieldname": "brand",
    "fieldtype": "Link",
    "in_list_view": 1,
@@ -28,12 +28,13 @@
  ],
  "istable": 1,
  "links": [],
- "modified": "2024-03-27 13:10:17.857046",
+ "modified": "2026-02-12 12:17:10.503355",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Pricing Rule Brand",
  "owner": "Administrator",
  "permissions": [],
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],

--- a/erpnext/accounts/doctype/pricing_rule_item_group/pricing_rule_item_group.json
+++ b/erpnext/accounts/doctype/pricing_rule_item_group/pricing_rule_item_group.json
@@ -10,7 +10,7 @@
  ],
  "fields": [
   {
-   "depends_on": "eval:parent.apply_on == 'Item Code'",
+   "depends_on": "eval:parent.apply_on == 'Item Group'",
    "fieldname": "item_group",
    "fieldtype": "Link",
    "in_list_view": 1,
@@ -28,12 +28,13 @@
  ],
  "istable": 1,
  "links": [],
- "modified": "2024-03-27 13:10:18.221095",
+ "modified": "2026-02-12 12:14:04.413342",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Pricing Rule Item Group",
  "owner": "Administrator",
  "permissions": [],
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],


### PR DESCRIPTION
This change updates the depends_on expressions for the Brand and Item Group fields in the Apply Rule child tables of the Pricing Rule doctype to ensure the correct dependency logic based on the selected "Apply On" value.

**Specifically:**

✅ In Pricing Rule Brand, the depends_on for the brand field now uses:
<img width="579" height="117" alt="Screenshot from 2026-02-12 12-23-56" src="https://github.com/user-attachments/assets/f9c50748-fe80-4628-bfe9-61c09afdeb68" />

✅ In Pricing Rule Item Group, the depends_on for the item_group field now uses:
<img width="579" height="117" alt="Screenshot from 2026-02-12 12-24-54" src="https://github.com/user-attachments/assets/8a7e2311-be99-4010-9137-1308287d461f" />

This ensures that the Brand and Item Group fields are only shown when Apply On has the correct type selected, fixing incorrect dependency expressions for the pricing rule child tables.

<img width="1423" height="558" alt="image" src="https://github.com/user-attachments/assets/a5ccca44-4080-4377-a93e-aab37ed53cf0" />
