### PR TITLE
fix: consider table multiselect in delete transaction

### DIFF
--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -465,3 +465,4 @@ erpnext.patches.v16_0.set_ordered_qty_in_quotation_item
 erpnext.patches.v16_0.update_company_custom_field_in_bin
 erpnext.patches.v15_0.replace_http_with_https_in_sales_partner
 erpnext.patches.v16_0.migrate_asset_type_checkboxes_to_select
+erpnext.patches.v15_0.delete_quotation_lost_record_detail

--- a/erpnext/patches/v15_0/delete_quotation_lost_record_detail.py
+++ b/erpnext/patches/v15_0/delete_quotation_lost_record_detail.py
@@ -1,0 +1,11 @@
+import frappe
+from frappe.query_builder import DocType
+
+
+def execute():
+	qlr = DocType("Quotation Lost Reason Detail")
+	quotation = DocType("Quotation")
+
+	sub_query = frappe.qb.from_(quotation).select(quotation.name)
+	query = frappe.qb.from_(qlr).delete().where(qlr.parent.notin(sub_query))
+	query.run()

--- a/erpnext/setup/doctype/transaction_deletion_record/transaction_deletion_record.py
+++ b/erpnext/setup/doctype/transaction_deletion_record/transaction_deletion_record.py
@@ -317,7 +317,9 @@ class TransactionDeletionRecord(Document):
 		        list: List of child table DocType names (Table field options)
 		"""
 		return frappe.get_all(
-			"DocField", filters={"parent": doctype_name, "fieldtype": "Table"}, pluck="options"
+			"DocField",
+			filters={"parent": doctype_name, "fieldtype": ["in", ["Table", "Table MultiSelect"]]},
+			pluck="options",
 		)
 
 	def _get_to_delete_row_infos(self, doctype_name, company_field=None, company=None):


### PR DESCRIPTION
**Issue:**
 While deleting the company's transaction via Delete Transaction, the Quotation Lost Reason Detail Doctype is still linked to the Quotation that was marked as lost.

**Ref:** [#57220](https://support.frappe.io/helpdesk/tickets/57220)

**Before:**
<img width="1797" height="956" alt="image" src="https://github.com/user-attachments/assets/23c11596-ce1c-4241-a91a-5bd8e0cbbdcb" />


**After:**
<img width="1803" height="950" alt="image" src="https://github.com/user-attachments/assets/ee3ed056-c067-4399-ad0c-e08702813207" />
