### PR TITLE
fix: ensure layout has Bootstrap row and column

### DIFF
--- a/erpnext/selling/page/sales_funnel/sales_funnel.css
+++ b/erpnext/selling/page/sales_funnel/sales_funnel.css
@@ -1,4 +1,4 @@
 .funnel-wrapper {
-	margin: 15px;
+	margin: 40px;
 	width: 100%;
 }

--- a/erpnext/selling/page/sales_funnel/sales_funnel.css
+++ b/erpnext/selling/page/sales_funnel/sales_funnel.css
@@ -1,4 +1,4 @@
 .funnel-wrapper {
-	margin: 40px;
-	width: 100%;
+    width: calc(100% - 30px);
+    margin-left: 30px;
 }

--- a/erpnext/selling/page/sales_funnel/sales_funnel.js
+++ b/erpnext/selling/page/sales_funnel/sales_funnel.js
@@ -8,6 +8,9 @@ frappe.pages["sales-funnel"].on_page_load = function (wrapper) {
 		single_column: true,
 	});
 
+	$(wrapper).find(".layout-main").addClass("row");
+	$(wrapper).find(".layout-main-section-wrapper").addClass("col-md-12");
+
 	wrapper.sales_funnel = new erpnext.SalesFunnel(wrapper);
 
 	frappe.breadcrumbs.add("Selling");


### PR DESCRIPTION
**Issue:**
The Sales Funnel is not displaying in its usual position.

**Ref:**[#59793](https://support.frappe.io/helpdesk/tickets/59793)

**Before:**
<img width="720" height="171" alt="image" src="https://github.com/user-attachments/assets/ad716bff-0a82-436f-8b05-413b6e98539b" />

**After:**
![WhatsApp Image 2026-02-12 at 4 09 39 PM](https://github.com/user-attachments/assets/b88829c4-3ce8-4628-b2df-ec7d19912b98)

Backport Needed v16
