### PR TITLE
fix: show better errors when unpacking from `frappe.get_cached_value()` fails

### DIFF
--- a/erpnext/accounts/doctype/account/account.py
+++ b/erpnext/accounts/doctype/account/account.py
@@ -236,9 +236,12 @@ class Account(NestedSet):
 			if not descendants:
 				return
 			parent_acc_name_map = {}
-			parent_acc_name, parent_acc_number = frappe.get_cached_value(
+			result = frappe.get_cached_value(
 				"Account", self.parent_account, ["account_name", "account_number"]
 			)
+			if result is None:
+				frappe.throw(_("Parent Account does not exist"), frappe.DoesNotExistError)
+			parent_acc_name, parent_acc_number = result
 			filters = {
 				"company": ["in", descendants],
 				"account_name": parent_acc_name,
@@ -487,9 +490,13 @@ def get_account_currency(account):
 		return
 
 	def generator():
-		account_currency, company = frappe.get_cached_value(
-			"Account", account, ["account_currency", "company"]
-		)
+		result = frappe.get_cached_value("Account", account, ["account_currency", "company"])
+
+		if result is None:
+			frappe.throw(_("Account does not exist"), frappe.DoesNotExistError)
+
+		account_currency, company = result
+
 		if not account_currency:
 			account_currency = frappe.get_cached_value("Company", company, "default_currency")
 

--- a/erpnext/accounts/doctype/account/account.py
+++ b/erpnext/accounts/doctype/account/account.py
@@ -493,7 +493,7 @@ def get_account_currency(account):
 		result = frappe.get_cached_value("Account", account, ["account_currency", "company"])
 
 		if result is None:
-			frappe.throw(_("Account does not exist"), frappe.DoesNotExistError)
+			frappe.throw(_("Account {0} does not exist").format(account), frappe.DoesNotExistError)
 
 		account_currency, company = result
 

--- a/erpnext/accounts/doctype/account/account.py
+++ b/erpnext/accounts/doctype/account/account.py
@@ -236,11 +236,17 @@ class Account(NestedSet):
 			if not descendants:
 				return
 			parent_acc_name_map = {}
+
 			result = frappe.get_cached_value(
 				"Account", self.parent_account, ["account_name", "account_number"]
 			)
+
 			if result is None:
-				frappe.throw(_("Parent Account does not exist"), frappe.DoesNotExistError)
+				frappe.throw(
+					_("Parent Account {0} does not exist").format(self.parent_account),
+					frappe.DoesNotExistError,
+				)
+
 			parent_acc_name, parent_acc_number = result
 			filters = {
 				"company": ["in", descendants],

--- a/erpnext/accounts/doctype/account_closing_balance/account_closing_balance.py
+++ b/erpnext/accounts/doctype/account_closing_balance/account_closing_balance.py
@@ -154,9 +154,13 @@ def get_previous_closing_entries(company, closing_date, accounting_dimensions):
 
 
 def set_amount_in_reporting_currency(cle, company, closing_date):
-	default_currency, reporting_currency = frappe.get_cached_value(
-		"Company", company, ["default_currency", "reporting_currency"]
-	)
+
+	result = frappe.get_cached_value("Company", company, ["default_currency", "reporting_currency"])
+
+	if result is None:
+		frappe.throw(_("Company does not exist"), frappe.DoesNotExistError)
+
+	default_currency, reporting_currency = result
 
 	reporting_currency_exchange_rate = get_exchange_rate(default_currency, reporting_currency, closing_date)
 	if not reporting_currency_exchange_rate:

--- a/erpnext/accounts/doctype/account_closing_balance/account_closing_balance.py
+++ b/erpnext/accounts/doctype/account_closing_balance/account_closing_balance.py
@@ -154,11 +154,10 @@ def get_previous_closing_entries(company, closing_date, accounting_dimensions):
 
 
 def set_amount_in_reporting_currency(cle, company, closing_date):
-
 	result = frappe.get_cached_value("Company", company, ["default_currency", "reporting_currency"])
 
 	if result is None:
-		frappe.throw(_("Company does not exist"), frappe.DoesNotExistError)
+		frappe.throw(_("Company {0} does not exist").format(company), frappe.DoesNotExistError)
 
 	default_currency, reporting_currency = result
 

--- a/erpnext/accounts/doctype/chart_of_accounts_importer/chart_of_accounts_importer.py
+++ b/erpnext/accounts/doctype/chart_of_accounts_importer/chart_of_accounts_importer.py
@@ -57,7 +57,7 @@ def validate_columns(data):
 
 
 @frappe.whitelist()
-def validate_company(company):
+def validate_company(company: str):
 	parent_company, allow_account_creation_against_child_company = frappe.get_cached_value(
 		"Company", company, ["parent_company", "allow_account_creation_against_child_company"]
 	) or (None, None)
@@ -240,7 +240,7 @@ def build_forest(data):
 	error_messages = []
 
 	for i in data:
-		(search
+		(
 			account_name,
 			parent_account,
 			account_number,

--- a/erpnext/accounts/doctype/chart_of_accounts_importer/chart_of_accounts_importer.py
+++ b/erpnext/accounts/doctype/chart_of_accounts_importer/chart_of_accounts_importer.py
@@ -57,10 +57,11 @@ def validate_columns(data):
 
 
 @frappe.whitelist()
-def validate_company(company: str):
+def validate_company(company):
+
 	parent_company, allow_account_creation_against_child_company = frappe.get_cached_value(
 		"Company", company, ["parent_company", "allow_account_creation_against_child_company"]
-	)
+	) or (None, None)
 
 	if parent_company and (not allow_account_creation_against_child_company):
 		msg = _("{} is a child company.").format(frappe.bold(company)) + " "
@@ -240,7 +241,7 @@ def build_forest(data):
 	error_messages = []
 
 	for i in data:
-		(
+		(search
 			account_name,
 			parent_account,
 			account_number,

--- a/erpnext/accounts/doctype/chart_of_accounts_importer/chart_of_accounts_importer.py
+++ b/erpnext/accounts/doctype/chart_of_accounts_importer/chart_of_accounts_importer.py
@@ -58,7 +58,6 @@ def validate_columns(data):
 
 @frappe.whitelist()
 def validate_company(company):
-
 	parent_company, allow_account_creation_against_child_company = frappe.get_cached_value(
 		"Company", company, ["parent_company", "allow_account_creation_against_child_company"]
 	) or (None, None)

--- a/erpnext/accounts/doctype/exchange_rate_revaluation/exchange_rate_revaluation.py
+++ b/erpnext/accounts/doctype/exchange_rate_revaluation/exchange_rate_revaluation.py
@@ -628,7 +628,7 @@ def get_account_details(
 	result = frappe.get_cached_value("Account", account, ["account_currency", "account_type"])
 
 	if result is None:
-		frappe.throw(_("Account does not exist"), frappe.DoesNotExistError)
+		frappe.throw(_("Account {0} does not exist").format(account), frappe.DoesNotExistError)
 
 	account_currency, account_type = result
 

--- a/erpnext/accounts/doctype/exchange_rate_revaluation/exchange_rate_revaluation.py
+++ b/erpnext/accounts/doctype/exchange_rate_revaluation/exchange_rate_revaluation.py
@@ -625,9 +625,12 @@ def get_account_details(
 	if not (company and posting_date):
 		frappe.throw(_("Company and Posting Date is mandatory"))
 
-	account_currency, account_type = frappe.get_cached_value(
-		"Account", account, ["account_currency", "account_type"]
-	)
+	result = frappe.get_cached_value("Account", account, ["account_currency", "account_type"])
+
+	if result is None:
+		frappe.throw(_("Account does not exist"), frappe.DoesNotExistError)
+
+	account_currency, account_type = result
 
 	if account_type in ["Receivable", "Payable"] and not (party_type and party):
 		frappe.throw(_("Party Type and Party is mandatory for {0} account").format(account_type))

--- a/erpnext/accounts/doctype/gl_entry/gl_entry.py
+++ b/erpnext/accounts/doctype/gl_entry/gl_entry.py
@@ -299,9 +299,13 @@ class GLEntry(Document):
 			validate_party_gle_currency(self.party_type, self.party, self.company, self.account_currency)
 
 	def set_amount_in_reporting_currency(self):
-		default_currency, reporting_currency = frappe.get_cached_value(
-			"Company", self.company, ["default_currency", "reporting_currency"]
-		)
+
+		result = frappe.get_cached_value("Company", self.company, ["default_currency", "reporting_currency"])
+
+		if result is None:
+			frappe.throw(_("Company  does not exist"), frappe.DoesNotExistError)
+
+		default_currency, reporting_currency = result
 		transaction_date = self.transaction_date or self.posting_date
 		self.reporting_currency_exchange_rate = get_exchange_rate(
 			default_currency, reporting_currency, transaction_date

--- a/erpnext/accounts/doctype/gl_entry/gl_entry.py
+++ b/erpnext/accounts/doctype/gl_entry/gl_entry.py
@@ -234,6 +234,9 @@ class GLEntry(Document):
 			"Account", self.account, fieldname=["is_group", "docstatus", "company"], as_dict=True
 		)
 
+		if account is None:
+			frappe.throw(_("Account {0} does not exist").format(self.account), frappe.DoesNotExistError)
+
 		if account.is_group == 1:
 			frappe.throw(
 				_(
@@ -257,7 +260,14 @@ class GLEntry(Document):
 		if not self.cost_center or self.is_cancelled:
 			return
 
-		is_group, company = frappe.get_cached_value("Cost Center", self.cost_center, ["is_group", "company"])
+		result = frappe.get_cached_value("Cost Center", self.cost_center, ["is_group", "company"])
+
+		if result is None:
+			frappe.throw(
+				_("Cost Center {0} does not exist").format(self.cost_center), frappe.DoesNotExistError
+			)
+
+		is_group, company = result
 
 		if company != self.company:
 			frappe.throw(
@@ -303,7 +313,7 @@ class GLEntry(Document):
 		result = frappe.get_cached_value("Company", self.company, ["default_currency", "reporting_currency"])
 
 		if result is None:
-			frappe.throw(_("Company  does not exist"), frappe.DoesNotExistError)
+			frappe.throw(_("Company does not exist"), frappe.DoesNotExistError)
 
 		default_currency, reporting_currency = result
 		transaction_date = self.transaction_date or self.posting_date

--- a/erpnext/accounts/doctype/gl_entry/gl_entry.py
+++ b/erpnext/accounts/doctype/gl_entry/gl_entry.py
@@ -309,11 +309,10 @@ class GLEntry(Document):
 			validate_party_gle_currency(self.party_type, self.party, self.company, self.account_currency)
 
 	def set_amount_in_reporting_currency(self):
-
 		result = frappe.get_cached_value("Company", self.company, ["default_currency", "reporting_currency"])
 
 		if result is None:
-			frappe.throw(_("Company does not exist"), frappe.DoesNotExistError)
+			frappe.throw(_("Company {0} does not exist").format(self.company), frappe.DoesNotExistError)
 
 		default_currency, reporting_currency = result
 		transaction_date = self.transaction_date or self.posting_date

--- a/erpnext/accounts/doctype/item_tax_template/item_tax_template.py
+++ b/erpnext/accounts/doctype/item_tax_template/item_tax_template.py
@@ -40,8 +40,10 @@ class ItemTaxTemplate(Document):
 		for d in self.get("taxes"):
 			if d.tax_type:
 				result = frappe.get_cached_value("Account", d.tax_type, ["account_type", "company"])
+
 				if result is None:
 					frappe.throw(_("Account {0} does not exist").format(d.tax_type), frappe.DoesNotExistError)
+
 				account_type, account_company = result
 
 				if account_company != self.company:

--- a/erpnext/accounts/doctype/item_tax_template/item_tax_template.py
+++ b/erpnext/accounts/doctype/item_tax_template/item_tax_template.py
@@ -39,9 +39,10 @@ class ItemTaxTemplate(Document):
 		check_list = []
 		for d in self.get("taxes"):
 			if d.tax_type:
-				account_type, account_company = frappe.get_cached_value(
-					"Account", d.tax_type, ["account_type", "company"]
-				)
+				result = frappe.get_cached_value("Account", d.tax_type, ["account_type", "company"])
+				if result is None:
+					frappe.throw(_("Account does not exist"), frappe.DoesNotExistError)
+				account_type, account_company = result
 
 				if account_company != self.company:
 					frappe.throw(

--- a/erpnext/accounts/doctype/item_tax_template/item_tax_template.py
+++ b/erpnext/accounts/doctype/item_tax_template/item_tax_template.py
@@ -41,7 +41,7 @@ class ItemTaxTemplate(Document):
 			if d.tax_type:
 				result = frappe.get_cached_value("Account", d.tax_type, ["account_type", "company"])
 				if result is None:
-					frappe.throw(_("Account does not exist"), frappe.DoesNotExistError)
+					frappe.throw(_("Account {0} does not exist").format(d.tax_type), frappe.DoesNotExistError)
 				account_type, account_company = result
 
 				if account_company != self.company:

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -728,9 +728,12 @@ class PaymentEntry(AccountsController):
 				continue
 
 			if d.reference_doctype in ("Sales Invoice", "Purchase Invoice"):
-				outstanding_amount, is_return = frappe.get_cached_value(
+				result = frappe.get_cached_value(
 					d.reference_doctype, d.reference_name, ["outstanding_amount", "is_return"]
 				)
+				if result is None:
+					frappe.throw(_(f"{d.reference_doctype} does not exist"), frappe.DoesNotExistError)
+				outstanding_amount, is_return = result
 				if outstanding_amount <= 0 and not is_return:
 					no_oustanding_refs.setdefault(d.reference_doctype, []).append(d)
 

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -732,7 +732,9 @@ class PaymentEntry(AccountsController):
 					d.reference_doctype, d.reference_name, ["outstanding_amount", "is_return"]
 				)
 				if result is None:
-					frappe.throw(_(f"{d.reference_doctype} does not exist"), frappe.DoesNotExistError)
+					frappe.throw(
+						_("{0} does not exist").format(d.reference_doctype), frappe.DoesNotExistError
+					)
 				outstanding_amount, is_return = result
 				if outstanding_amount <= 0 and not is_return:
 					no_oustanding_refs.setdefault(d.reference_doctype, []).append(d)

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -731,11 +731,15 @@ class PaymentEntry(AccountsController):
 				result = frappe.get_cached_value(
 					d.reference_doctype, d.reference_name, ["outstanding_amount", "is_return"]
 				)
+
 				if result is None:
 					frappe.throw(
-						_("{0} does not exist").format(d.reference_doctype), frappe.DoesNotExistError
+						_("{0} {1} does not exist").format(d.reference_doctype, d.reference_name),
+						frappe.DoesNotExistError,
 					)
+
 				outstanding_amount, is_return = result
+
 				if outstanding_amount <= 0 and not is_return:
 					no_oustanding_refs.setdefault(d.reference_doctype, []).append(d)
 

--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
@@ -246,8 +246,10 @@ class PurchaseInvoice(BuyingController):
 			result = frappe.get_cached_value(
 				"Supplier", self.supplier, ["tax_withholding_category", "tax_withholding_group"]
 			)
+
 			if result is None:
-				frappe.throw(_("Supplier does not exist"), frappe.DoesNotExistError)
+				frappe.throw(_("Supplier {0} does not exist").format(self.supplier), frappe.DoesNotExistError)
+
 			tax_withholding_category, tax_withholding_group = result
 			self.set_onload("apply_tds", tax_withholding_category or tax_withholding_group)
 
@@ -360,9 +362,12 @@ class PurchaseInvoice(BuyingController):
 			result = frappe.get_cached_value(
 				"Supplier", self.supplier, ["tax_withholding_category", "tax_withholding_group"]
 			)
+
 			if result is None:
-				frappe.throw(_("Supplier does not exist"), frappe.DoesNotExistError)
+				frappe.throw(_("Supplier {0} does not exist").format(self.supplier), frappe.DoesNotExistError)
+
 			tax_withholding_category, tax_withholding_group = result
+
 			if not for_validate:
 				if tax_withholding_category or tax_withholding_group:
 					self.apply_tds = 1

--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
@@ -243,9 +243,12 @@ class PurchaseInvoice(BuyingController):
 	def onload(self):
 		super().onload()
 		if self.supplier:
-			tax_withholding_category, tax_withholding_group = frappe.get_cached_value(
+			result = frappe.get_cached_value(
 				"Supplier", self.supplier, ["tax_withholding_category", "tax_withholding_group"]
 			)
+			if result is None:
+				frappe.throw(_("Suppplier does not exist"), frappe.DoesNotExistError)
+			tax_withholding_category, tax_withholding_group = result
 			self.set_onload("apply_tds", tax_withholding_category or tax_withholding_group)
 
 		if self.is_new():
@@ -354,9 +357,12 @@ class PurchaseInvoice(BuyingController):
 			)
 
 		if self.supplier:
-			tax_withholding_category, tax_withholding_group = frappe.get_cached_value(
+			result = frappe.get_cached_value(
 				"Supplier", self.supplier, ["tax_withholding_category", "tax_withholding_group"]
 			)
+			if result is None:
+				frappe.throw(_("Supplier does not exist"), frappe.DoesNotExistError)
+			tax_withholding_category, tax_withholding_group = result
 			if not for_validate:
 				if tax_withholding_category or tax_withholding_group:
 					self.apply_tds = 1

--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
@@ -247,7 +247,7 @@ class PurchaseInvoice(BuyingController):
 				"Supplier", self.supplier, ["tax_withholding_category", "tax_withholding_group"]
 			)
 			if result is None:
-				frappe.throw(_("Suppplier does not exist"), frappe.DoesNotExistError)
+				frappe.throw(_("Supplier does not exist"), frappe.DoesNotExistError)
 			tax_withholding_category, tax_withholding_group = result
 			self.set_onload("apply_tds", tax_withholding_category or tax_withholding_group)
 

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -294,8 +294,10 @@ class SalesInvoice(SellingController):
 			result = frappe.get_cached_value(
 				"Customer", self.customer, ["tax_withholding_category", "tax_withholding_group"]
 			)
+
 			if result is None:
-				frappe.throw(_("Customer does not exist"), frappe.DoesNotExistError)
+				frappe.throw(_("Customer {0} does not exist").format(self.customer), frappe.DoesNotExistError)
+
 			tax_withholding_category, tax_withholding_group = result
 			self.set_onload("apply_tds", tax_withholding_category or tax_withholding_group)
 

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -291,9 +291,12 @@ class SalesInvoice(SellingController):
 	def onload(self):
 		super().onload()
 		if self.customer:
-			tax_withholding_category, tax_withholding_group = frappe.get_cached_value(
+			result = frappe.get_cached_value(
 				"Customer", self.customer, ["tax_withholding_category", "tax_withholding_group"]
 			)
+			if result is None:
+				frappe.throw(_("Customer does not exist"), frappe.DoesNotExistError)
+			tax_withholding_category, tax_withholding_group = result
 			self.set_onload("apply_tds", tax_withholding_category or tax_withholding_group)
 
 	def validate(self):
@@ -2474,10 +2477,12 @@ def make_delivery_note(source_name: str, target_doc: Document | None = None):
 					"cost_center": "cost_center",
 				},
 				"postprocess": update_item,
-				"condition": lambda doc: doc.delivered_by_supplier != 1
-				and not doc.scio_detail
-				and not doc.dn_detail
-				and doc.qty - doc.delivered_qty > 0,
+				"condition": lambda doc: (
+					doc.delivered_by_supplier != 1
+					and not doc.scio_detail
+					and not doc.dn_detail
+					and doc.qty - doc.delivered_qty > 0
+				),
 			},
 			"Sales Taxes and Charges": {"doctype": "Sales Taxes and Charges", "reset_value": True},
 			"Sales Team": {

--- a/erpnext/accounts/doctype/subscription/subscription.py
+++ b/erpnext/accounts/doctype/subscription/subscription.py
@@ -414,9 +414,12 @@ class Subscription(Document):
 			invoice.customer = self.party
 		else:
 			invoice.supplier = self.party
-			tax_withholding_category, tax_withholding_group = frappe.get_cached_value(
+			result=frappe.get_cached_value(
 				"Supplier", self.party, ["tax_withholding_category", "tax_withholding_group"]
 			)
+			if result is None:
+				frappe.throw(_("Supplier does not exist"), frappe.DoesNotExistError)
+			tax_withholding_category, tax_withholding_group = result
 			if tax_withholding_category or tax_withholding_group:
 				invoice.apply_tds = 1
 

--- a/erpnext/accounts/doctype/subscription/subscription.py
+++ b/erpnext/accounts/doctype/subscription/subscription.py
@@ -414,11 +414,14 @@ class Subscription(Document):
 			invoice.customer = self.party
 		else:
 			invoice.supplier = self.party
-			result=frappe.get_cached_value(
+
+			result = frappe.get_cached_value(
 				"Supplier", self.party, ["tax_withholding_category", "tax_withholding_group"]
 			)
+
 			if result is None:
-				frappe.throw(_("Supplier does not exist"), frappe.DoesNotExistError)
+				frappe.throw(_("Supplier {0} does not exist").format(self.party), frappe.DoesNotExistError)
+
 			tax_withholding_category, tax_withholding_group = result
 			if tax_withholding_category or tax_withholding_group:
 				invoice.apply_tds = 1

--- a/erpnext/accounts/general_ledger.py
+++ b/erpnext/accounts/general_ledger.py
@@ -201,9 +201,13 @@ def process_gl_map(gl_map, merge_entries=True, precision=None, from_repost=False
 
 
 def distribute_gl_based_on_cost_center_allocation(gl_map, precision=None, from_repost=False):
-	round_off_account, default_currency = frappe.get_cached_value(
-		"Company", gl_map[0].company, ["round_off_account", "default_currency"]
-	)
+
+	result = frappe.get_cached_value("Company", gl_map[0].company, ["round_off_account", "default_currency"])
+
+	if result is None:
+		frappe.throw(_("Company does not exist"), frappe.DoesNotExistError)
+
+	round_off_account, default_currency = result
 	if not precision:
 		precision = get_field_precision(
 			frappe.get_meta("GL Entry").get_field("debit"),
@@ -312,12 +316,14 @@ def merge_similar_entries(gl_map, precision=None):
 
 	# filter zero debit and credit entries
 	merged_gl_map = filter(
-		lambda x: flt(x.debit, precision) != 0
-		or flt(x.credit, precision) != 0
-		or (
-			x.voucher_type == "Journal Entry"
-			and frappe.get_cached_value("Journal Entry", x.voucher_no, "voucher_type")
-			== "Exchange Gain Or Loss"
+		lambda x: (
+			flt(x.debit, precision) != 0
+			or flt(x.credit, precision) != 0
+			or (
+				x.voucher_type == "Journal Entry"
+				and frappe.get_cached_value("Journal Entry", x.voucher_no, "voucher_type")
+				== "Exchange Gain Or Loss"
+			)
 		),
 		merged_gl_map,
 	)
@@ -645,7 +651,7 @@ def update_accounting_dimensions(round_off_gle):
 def get_round_off_account_and_cost_center(company, voucher_type, voucher_no, use_company_default=False):
 	round_off_account, round_off_cost_center, round_off_for_opening = frappe.get_cached_value(
 		"Company", company, ["round_off_account", "round_off_cost_center", "round_off_for_opening"]
-	) or [None, None, None]
+	) or (None, None, None)
 
 	# Use expense account as fallback
 	if not round_off_account:

--- a/erpnext/accounts/general_ledger.py
+++ b/erpnext/accounts/general_ledger.py
@@ -201,11 +201,10 @@ def process_gl_map(gl_map, merge_entries=True, precision=None, from_repost=False
 
 
 def distribute_gl_based_on_cost_center_allocation(gl_map, precision=None, from_repost=False):
-
 	result = frappe.get_cached_value("Company", gl_map[0].company, ["round_off_account", "default_currency"])
 
 	if result is None:
-		frappe.throw(_("Company does not exist"), frappe.DoesNotExistError)
+		frappe.throw(_("Company {0} does not exist").format(gl_map[0].company), frappe.DoesNotExistError)
 
 	round_off_account, default_currency = result
 	if not precision:

--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -1259,7 +1259,7 @@ def get_outstanding_invoices(
 	if account:
 		root_type, account_type = frappe.get_cached_value(
 			"Account", account[0], ["root_type", "account_type"]
-		)
+		) or (None, None)
 		party_account_type = "Receivable" if root_type == "Asset" else "Payable"
 		party_account_type = account_type or party_account_type
 	else:

--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -1250,9 +1250,14 @@ def make_journal_entry(asset_name: str):
 		depreciation_expense_account,
 	) = get_depreciation_accounts(asset.asset_category, asset.company)
 
-	depreciation_cost_center, depreciation_series = frappe.get_cached_value(
+	result = frappe.get_cached_value(
 		"Company", asset.company, ["depreciation_cost_center", "series_for_depreciation_entry"]
 	)
+
+	if result is None:
+		frappe.throw(_("Asset company does not exist"), frappe.DoesNotExistError)
+
+	depreciation_cost_center, depreciation_series = result
 	depreciation_cost_center = asset.cost_center or depreciation_cost_center
 
 	je = frappe.new_doc("Journal Entry")

--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -1255,7 +1255,7 @@ def make_journal_entry(asset_name: str):
 	)
 
 	if result is None:
-		frappe.throw(_("Asset company does not exist"), frappe.DoesNotExistError)
+		frappe.throw(_("Company {0} does not exist").format(asset.company), frappe.DoesNotExistError)
 
 	depreciation_cost_center, depreciation_series = result
 	depreciation_cost_center = asset.cost_center or depreciation_cost_center

--- a/erpnext/assets/doctype/asset/depreciation.py
+++ b/erpnext/assets/doctype/asset/depreciation.py
@@ -139,9 +139,12 @@ def get_credit_debit_accounts_for_asset(asset_category, company):
 
 
 def get_depreciation_cost_center_and_series(asset):
-	depreciation_cost_center, depreciation_series = frappe.get_cached_value(
+	result = frappe.get_cached_value(
 		"Company", asset.company, ["depreciation_cost_center", "series_for_depreciation_entry"]
 	)
+	if result is None:
+		frappe.throw(_("Company does not exist"), frappe.DoesNotExistError)
+	depreciation_cost_center, depreciation_series = result
 	depreciation_cost_center = asset.cost_center or depreciation_cost_center
 	return depreciation_cost_center, depreciation_series
 
@@ -152,9 +155,12 @@ def get_depr_cost_center_and_series():
 	res = {}
 
 	for company_name in company_names:
-		depreciation_cost_center, depreciation_series = frappe.get_cached_value(
+		result = frappe.get_cached_value(
 			"Company", company_name, ["depreciation_cost_center", "series_for_depreciation_entry"]
 		)
+		if result is None:
+			frappe.throw(_("Company does not exist"), frappe.DoesNotExistError)
+		depreciation_cost_center, depreciation_series = result
 		res.setdefault(company_name, (depreciation_cost_center, depreciation_series))
 
 	return res
@@ -773,10 +779,13 @@ def get_profit_gl_entries(
 
 
 @frappe.whitelist()
-def get_disposal_account_and_cost_center(company: str):
-	disposal_account, depreciation_cost_center = frappe.get_cached_value(
+def get_disposal_account_and_cost_center(company):
+	result=frappe.get_cached_value(
 		"Company", company, ["disposal_account", "depreciation_cost_center"]
 	)
+	if result is None:
+		frappe.throw(_("Company does not exist"), frappe.DoesNotExistError)
+	disposal_account, depreciation_cost_center = result
 
 	if not disposal_account:
 		frappe.throw(_("Please set 'Gain/Loss Account on Asset Disposal' in Company {0}").format(company))

--- a/erpnext/assets/doctype/asset/depreciation.py
+++ b/erpnext/assets/doctype/asset/depreciation.py
@@ -742,6 +742,9 @@ def get_depreciation_accounts(asset_category, company):
 			"Company", company, ["accumulated_depreciation_account", "depreciation_expense_account"]
 		)
 
+		if accounts is None:
+			frappe.throw(_("Company does not exist"), frappe.DoesNotExistError)
+
 		if not accumulated_depreciation_account:
 			accumulated_depreciation_account = accounts[0]
 		if not depreciation_expense_account:
@@ -780,9 +783,7 @@ def get_profit_gl_entries(
 
 @frappe.whitelist()
 def get_disposal_account_and_cost_center(company):
-	result=frappe.get_cached_value(
-		"Company", company, ["disposal_account", "depreciation_cost_center"]
-	)
+	result = frappe.get_cached_value("Company", company, ["disposal_account", "depreciation_cost_center"])
 	if result is None:
 		frappe.throw(_("Company does not exist"), frappe.DoesNotExistError)
 	disposal_account, depreciation_cost_center = result

--- a/erpnext/assets/doctype/asset/depreciation.py
+++ b/erpnext/assets/doctype/asset/depreciation.py
@@ -142,8 +142,10 @@ def get_depreciation_cost_center_and_series(asset):
 	result = frappe.get_cached_value(
 		"Company", asset.company, ["depreciation_cost_center", "series_for_depreciation_entry"]
 	)
+
 	if result is None:
-		frappe.throw(_("Company does not exist"), frappe.DoesNotExistError)
+		frappe.throw(_("Company {0} does not exist").format(asset.company), frappe.DoesNotExistError)
+
 	depreciation_cost_center, depreciation_series = result
 	depreciation_cost_center = asset.cost_center or depreciation_cost_center
 	return depreciation_cost_center, depreciation_series
@@ -158,8 +160,10 @@ def get_depr_cost_center_and_series():
 		result = frappe.get_cached_value(
 			"Company", company_name, ["depreciation_cost_center", "series_for_depreciation_entry"]
 		)
+
 		if result is None:
-			frappe.throw(_("Company does not exist"), frappe.DoesNotExistError)
+			frappe.throw(_("Company {0} does not exist").format(company_name), frappe.DoesNotExistError)
+
 		depreciation_cost_center, depreciation_series = result
 		res.setdefault(company_name, (depreciation_cost_center, depreciation_series))
 
@@ -743,7 +747,7 @@ def get_depreciation_accounts(asset_category, company):
 		)
 
 		if accounts is None:
-			frappe.throw(_("Company does not exist"), frappe.DoesNotExistError)
+			frappe.throw(_("Company {0} does not exist").format(company), frappe.DoesNotExistError)
 
 		if not accumulated_depreciation_account:
 			accumulated_depreciation_account = accounts[0]
@@ -784,8 +788,10 @@ def get_profit_gl_entries(
 @frappe.whitelist()
 def get_disposal_account_and_cost_center(company):
 	result = frappe.get_cached_value("Company", company, ["disposal_account", "depreciation_cost_center"])
+
 	if result is None:
-		frappe.throw(_("Company does not exist"), frappe.DoesNotExistError)
+		frappe.throw(_("Company {0} does not exist").format(company), frappe.DoesNotExistError)
+
 	disposal_account, depreciation_cost_center = result
 
 	if not disposal_account:

--- a/erpnext/assets/doctype/asset_value_adjustment/asset_value_adjustment.py
+++ b/erpnext/assets/doctype/asset_value_adjustment/asset_value_adjustment.py
@@ -94,8 +94,10 @@ class AssetValueAdjustment(Document):
 		result = frappe.get_cached_value(
 			"Company", asset.company, ["depreciation_cost_center", "series_for_depreciation_entry"]
 		)
+
 		if result is None:
-			frappe.throw(_("Company does not exist"), frappe.DoesNotExistError)
+			frappe.throw(_("Company {0} does not exist").format(asset.company), frappe.DoesNotExistError)
+
 		depreciation_cost_center, depreciation_series = result
 
 		je = frappe.new_doc("Journal Entry")

--- a/erpnext/assets/doctype/asset_value_adjustment/asset_value_adjustment.py
+++ b/erpnext/assets/doctype/asset_value_adjustment/asset_value_adjustment.py
@@ -91,9 +91,12 @@ class AssetValueAdjustment(Document):
 			depreciation_expense_account,
 		) = get_depreciation_accounts(asset.asset_category, asset.company)
 
-		depreciation_cost_center, depreciation_series = frappe.get_cached_value(
+		result = frappe.get_cached_value(
 			"Company", asset.company, ["depreciation_cost_center", "series_for_depreciation_entry"]
 		)
+		if result is None:
+			frappe.throw(_("Company does not exist"), frappe.DoesNotExistError)
+		depreciation_cost_center, depreciation_series = result
 
 		je = frappe.new_doc("Journal Entry")
 		je.voucher_type = "Journal Entry"

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -844,9 +844,12 @@ class AccountsController(TransactionBase):
 			)
 
 	def validate_line_items(self, ref_dt, ref_dn_field, ref_link_field):
-		action, role_allowed_to_override = frappe.get_cached_value(
+		result=frappe.get_cached_value(
 			"Accounts Settings", "None", ["maintain_same_rate_action", "role_to_override_stop_action"]
 		)
+		if result is None:
+			frappe.throw(_("Value does not exist"), frappe.DoesNotExistError)
+		action, role_allowed_to_override = result
 
 		reference_names = [d.get(ref_link_field) for d in self.get("items") if d.get(ref_link_field)]
 		reference_details = self.get_reference_details(reference_names, ref_dt + " Item")

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -844,12 +844,9 @@ class AccountsController(TransactionBase):
 			)
 
 	def validate_line_items(self, ref_dt, ref_dn_field, ref_link_field):
-		result=frappe.get_cached_value(
+		action, role_allowed_to_override = frappe.get_cached_value(
 			"Accounts Settings", "None", ["maintain_same_rate_action", "role_to_override_stop_action"]
 		)
-		if result is None:
-			frappe.throw(_("Value does not exist"), frappe.DoesNotExistError)
-		action, role_allowed_to_override = result
 
 		reference_names = [d.get(ref_link_field) for d in self.get("items") if d.get(ref_link_field)]
 		reference_details = self.get_reference_details(reference_names, ref_dt + " Item")

--- a/erpnext/controllers/selling_controller.py
+++ b/erpnext/controllers/selling_controller.py
@@ -318,9 +318,12 @@ class SellingController(StockController):
 		for item in self.items:
 			if not item.item_code or item.is_free_item:
 				continue
+
 			result = frappe.get_cached_value("Item", item.item_code, ("last_purchase_rate", "is_stock_item"))
+
 			if result is None:
-				frappe.throw(_("Item does not exist"), frappe.DoesNotExistError)
+				frappe.throw(_("Item {0} does not exist").format(item.item_code), frappe.DoesNotExistError)
+
 			last_purchase_rate, is_stock_item = result
 
 			last_purchase_rate_in_sales_uom = flt(

--- a/erpnext/controllers/selling_controller.py
+++ b/erpnext/controllers/selling_controller.py
@@ -318,10 +318,10 @@ class SellingController(StockController):
 		for item in self.items:
 			if not item.item_code or item.is_free_item:
 				continue
-
-			last_purchase_rate, is_stock_item = frappe.get_cached_value(
-				"Item", item.item_code, ("last_purchase_rate", "is_stock_item")
-			)
+			result = frappe.get_cached_value("Item", item.item_code, ("last_purchase_rate", "is_stock_item"))
+			if result is None:
+				frappe.throw(_("Item does not exist"), frappe.DoesNotExistError)
+			last_purchase_rate, is_stock_item = result
 
 			last_purchase_rate_in_sales_uom = flt(
 				last_purchase_rate * (item.conversion_factor or 1), item.precision("base_net_rate")

--- a/erpnext/controllers/status_updater.py
+++ b/erpnext/controllers/status_updater.py
@@ -738,7 +738,7 @@ def get_allowance_for(
 
 	qty_allowance, over_billing_allowance = frappe.get_cached_value(
 		"Item", item_code, ["over_delivery_receipt_allowance", "over_billing_allowance"]
-	)
+	) or (None, None)
 
 	if qty_or_amount == "qty" and not qty_allowance:
 		if global_qty_allowance is None:

--- a/erpnext/controllers/trends.py
+++ b/erpnext/controllers/trends.py
@@ -85,8 +85,10 @@ def get_data(filters, conditions):
 	result = frappe.get_cached_value(
 		"Fiscal Year", filters.get("fiscal_year"), ["year_start_date", "year_end_date"]
 	)
+
 	if result is None:
 		frappe.throw(_("Fiscal Year does not exist"), frappe.DoesNotExistError)
+
 	year_start_date, year_end_date = result
 
 	if filters.get("group_by"):
@@ -314,8 +316,10 @@ def get_period_date_ranges(
 
 	if not year_start_date:
 		result = frappe.get_cached_value("Fiscal Year", fiscal_year, ["year_start_date", "year_end_date"])
+
 		if result is None:
-			frappe.throw(_("Fiscal Year does not exist"), frappe.DoesNotExistError)
+			frappe.throw(_("Fiscal Year {0} does not exist").format(fiscal_year), frappe.DoesNotExistError)
+
 		year_start_date, year_end_date = result
 
 	increment = {"Monthly": 1, "Quarterly": 3, "Half-Yearly": 6, "Yearly": 12}.get(period)

--- a/erpnext/controllers/trends.py
+++ b/erpnext/controllers/trends.py
@@ -82,9 +82,12 @@ def get_data(filters, conditions):
 	if conditions.get("trans") == "Quotation" and filters.get("group_by") == "Customer":
 		cond += " and t1.quotation_to = 'Customer'"
 
-	year_start_date, year_end_date = frappe.get_cached_value(
+	result = frappe.get_cached_value(
 		"Fiscal Year", filters.get("fiscal_year"), ["year_start_date", "year_end_date"]
 	)
+	if result is None:
+		frappe.throw(_("Fiscal Year does not exist"), frappe.DoesNotExistError)
+	year_start_date, year_end_date = result
 
 	if filters.get("group_by"):
 		sel_col = ""
@@ -310,9 +313,10 @@ def get_period_date_ranges(
 	from dateutil.relativedelta import relativedelta
 
 	if not year_start_date:
-		year_start_date, year_end_date = frappe.get_cached_value(
-			"Fiscal Year", fiscal_year, ["year_start_date", "year_end_date"]
-		)
+		result = frappe.get_cached_value("Fiscal Year", fiscal_year, ["year_start_date", "year_end_date"])
+		if result is None:
+			frappe.throw(_("Fiscal Year does not exist"), frappe.DoesNotExistError)
+		year_start_date, year_end_date = result
 
 	increment = {"Monthly": 1, "Quarterly": 3, "Half-Yearly": 6, "Yearly": 12}.get(period)
 

--- a/erpnext/manufacturing/doctype/work_order/work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/work_order.py
@@ -2436,8 +2436,8 @@ def get_default_warehouse(company):
 
 	wip, fg, scrap = frappe.get_cached_value(
 		"Company", company, ["default_wip_warehouse", "default_fg_warehouse", "default_scrap_warehouse"]
-	) or (None, None)
-	
+	) or (None, None, None)
+
 	return {
 		"wip_warehouse": wip,
 		"fg_warehouse": fg,

--- a/erpnext/manufacturing/doctype/work_order/work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/work_order.py
@@ -2432,10 +2432,12 @@ def make_stock_entry(
 
 
 @frappe.whitelist()
-def get_default_warehouse(company: str):
+def get_default_warehouse(company):
+
 	wip, fg, scrap = frappe.get_cached_value(
 		"Company", company, ["default_wip_warehouse", "default_fg_warehouse", "default_scrap_warehouse"]
-	)
+	) or (None, None)
+	
 	return {
 		"wip_warehouse": wip,
 		"fg_warehouse": fg,

--- a/erpnext/manufacturing/doctype/work_order/work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/work_order.py
@@ -2433,7 +2433,6 @@ def make_stock_entry(
 
 @frappe.whitelist()
 def get_default_warehouse(company):
-
 	wip, fg, scrap = frappe.get_cached_value(
 		"Company", company, ["default_wip_warehouse", "default_fg_warehouse", "default_scrap_warehouse"]
 	) or (None, None, None)

--- a/erpnext/regional/united_arab_emirates/utils.py
+++ b/erpnext/regional/united_arab_emirates/utils.py
@@ -63,9 +63,12 @@ def get_account_currency(account):
 		return
 
 	def generator():
-		account_currency, company = frappe.get_cached_value(
+		result=frappe.get_cached_value(
 			"Account", account, ["account_currency", "company"]
 		)
+		if result is None:
+			frappe.throw(_("Account does not exist"), frappe.DoesNotExistError)
+		account_currency, company = result
 		if not account_currency:
 			account_currency = frappe.get_cached_value("Company", company, "default_currency")
 

--- a/erpnext/regional/united_arab_emirates/utils.py
+++ b/erpnext/regional/united_arab_emirates/utils.py
@@ -63,12 +63,13 @@ def get_account_currency(account):
 		return
 
 	def generator():
-		result=frappe.get_cached_value(
-			"Account", account, ["account_currency", "company"]
-		)
+		result = frappe.get_cached_value("Account", account, ["account_currency", "company"])
+
 		if result is None:
-			frappe.throw(_("Account does not exist"), frappe.DoesNotExistError)
+			frappe.throw(_("Account {0} does not exist").format(account), frappe.DoesNotExistError)
+
 		account_currency, company = result
+
 		if not account_currency:
 			account_currency = frappe.get_cached_value("Company", company, "default_currency")
 

--- a/erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py
+++ b/erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py
@@ -1629,11 +1629,14 @@ def create_stock_reservation_entries_for_so_items(
 					item.idx, frappe.bold(item.item_code)
 				)
 			)
+
 		result = frappe.get_cached_value(
 			"Item", item.item_code, ["is_stock_item", "has_serial_no", "has_batch_no"]
 		)
+
 		if result is None:
-			frappe.throw(_("Item does not exist"), frappe.DoesNotExistError)
+			frappe.throw(_("Item {0} does not exist").format(item.item_code), frappe.DoesNotExistError)
+
 		is_stock_item, has_serial_no, has_batch_no = result
 
 		# Skip if Non-Stock Item.

--- a/erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py
+++ b/erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py
@@ -1629,10 +1629,12 @@ def create_stock_reservation_entries_for_so_items(
 					item.idx, frappe.bold(item.item_code)
 				)
 			)
-
-		is_stock_item, has_serial_no, has_batch_no = frappe.get_cached_value(
+		result = frappe.get_cached_value(
 			"Item", item.item_code, ["is_stock_item", "has_serial_no", "has_batch_no"]
-		) or (None, None, None)
+		)
+		if result is None:
+			frappe.throw(_("Item does not exist"), frappe.DoesNotExistError)
+		is_stock_item, has_serial_no, has_batch_no = result
 
 		# Skip if Non-Stock Item.
 		if not is_stock_item:

--- a/erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py
+++ b/erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py
@@ -1632,7 +1632,7 @@ def create_stock_reservation_entries_for_so_items(
 
 		is_stock_item, has_serial_no, has_batch_no = frappe.get_cached_value(
 			"Item", item.item_code, ["is_stock_item", "has_serial_no", "has_batch_no"]
-		)
+		) or (None, None, None)
 
 		# Skip if Non-Stock Item.
 		if not is_stock_item:

--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -767,12 +767,16 @@ def _get_item_tax_template(
 	taxes_with_no_validity = []
 
 	for tax in taxes:
-		result=frappe.get_cached_value(
-			"Item Tax Template", tax.item_tax_template, ["disabled", "company"]
-		)
+		result = frappe.get_cached_value("Item Tax Template", tax.item_tax_template, ["disabled", "company"])
+
 		if result is None:
-			frappe.throw(_("Item Tax Template does not exist"), frappe.DoesNotExistError)
+			frappe.throw(
+				_("Item Tax Template {0} does not exist").format(tax.item_tax_template),
+				frappe.DoesNotExistError,
+			)
+
 		disabled, tax_company = result
+
 		if not disabled and tax_company == ctx["company"]:
 			if tax.valid_from or tax.maximum_net_rate:
 				# In purchase Invoice first preference will be given to supplier invoice date

--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -767,9 +767,12 @@ def _get_item_tax_template(
 	taxes_with_no_validity = []
 
 	for tax in taxes:
-		disabled, tax_company = frappe.get_cached_value(
+		result=frappe.get_cached_value(
 			"Item Tax Template", tax.item_tax_template, ["disabled", "company"]
 		)
+		if result is None:
+			frappe.throw(_("Item Tax Template does not exist"), frappe.DoesNotExistError)
+		disabled, tax_company = result
 		if not disabled and tax_company == ctx["company"]:
 			if tax.valid_from or tax.maximum_net_rate:
 				# In purchase Invoice first preference will be given to supplier invoice date

--- a/erpnext/utilities/transaction_base.py
+++ b/erpnext/utilities/transaction_base.py
@@ -91,13 +91,19 @@ class TransactionBase(StatusUpdater):
 		buying_doctypes = ["Purchase Order", "Purchase Invoice", "Purchase Receipt"]
 
 		if self.doctype in buying_doctypes:
-			action, role_allowed_to_override = frappe.get_cached_value(
+			result=frappe.get_cached_value(
 				"Buying Settings", "None", ["maintain_same_rate_action", "role_to_override_stop_action"]
 			)
+			if result is None:
+				frappe.throw(_("Buying Settings does not exist"), frappe.DoesNotExistError)
+			action, role_allowed_to_override = result
 		else:
-			action, role_allowed_to_override = frappe.get_cached_value(
+			result=frappe.get_cached_value(
 				"Selling Settings", "None", ["maintain_same_rate_action", "role_to_override_stop_action"]
 			)
+			if result is None:
+				frappe.throw(_("Selling Settings does not exist"), frappe.DoesNotExistError)
+			action, role_allowed_to_override = result
 
 		stop_actions = []
 		for ref_dt, ref_dn_field, ref_link_field in ref_details:

--- a/erpnext/utilities/transaction_base.py
+++ b/erpnext/utilities/transaction_base.py
@@ -91,19 +91,14 @@ class TransactionBase(StatusUpdater):
 		buying_doctypes = ["Purchase Order", "Purchase Invoice", "Purchase Receipt"]
 
 		if self.doctype in buying_doctypes:
-			result=frappe.get_cached_value(
+			action, role_allowed_to_override = frappe.get_cached_value(
 				"Buying Settings", "None", ["maintain_same_rate_action", "role_to_override_stop_action"]
 			)
-			if result is None:
-				frappe.throw(_("Buying Settings does not exist"), frappe.DoesNotExistError)
-			action, role_allowed_to_override = result
+
 		else:
-			result=frappe.get_cached_value(
+			action, role_allowed_to_override = frappe.get_cached_value(
 				"Selling Settings", "None", ["maintain_same_rate_action", "role_to_override_stop_action"]
 			)
-			if result is None:
-				frappe.throw(_("Selling Settings does not exist"), frappe.DoesNotExistError)
-			action, role_allowed_to_override = result
 
 		stop_actions = []
 		for ref_dt, ref_dn_field, ref_link_field in ref_details:


### PR DESCRIPTION
**frappe.get_cached_value() returns NoneType when DoesNotExistError is thrown by get_cached_doc().**

```
def get_cached_value(doctype: str, name: str, fieldname: str = "name", as_dict: bool = False) -> Any:
  try:
    doc = get_cached_doc(doctype, name)
  except DoesNotExistError:
    clear_last_message()
    return
```


**Earlier while using frappe.get_cached_value(), there was no checking done on the return value before unpacking, if the returned value is a NoneType or not. this may cause NoneType not iterable error.**

```
@frappe.whitelist(allow_guest=True)
def get_period_date_ranges(period, fiscal_year=None, year_start_date=None):
  from dateutil.relativedelta import relativedelta

  if not year_start_date:
    year_start_date, year_end_date = frappe.get_cached_value(
      "Fiscal Year", fiscal_year, ["year_start_date", "year_end_date"]
    )

  increment = {"Monthly": 1, "Quarterly": 3, "Half-Yearly": 6, "Yearly": 12}.get(period)

```

**To solve this, checks like below are added:**

```
result = ...
if result is None:
    frappe.throw(_("Fiscal year does not exist"), frappe.DoesNotExistError)

year_start_date, year_end_date = result
```
 **or 
 
 A tuple of (None,None,...) is assigned in case the value is NoneType.**

 ```
round_off_account, round_off_cost_center, round_off_for_opening = frappe.get_cached_value(
    "Company", company, ["round_off_account", "round_off_cost_center", "round_off_for_opening"]
  ) or (None, None, None)
```