### PR TITLE
fix(pricing-rule): correct depends_on condition for brand and item group child tables

### DIFF
--- a/erpnext/accounts/doctype/pricing_rule_brand/pricing_rule_brand.json
+++ b/erpnext/accounts/doctype/pricing_rule_brand/pricing_rule_brand.json
@@ -10,7 +10,7 @@
  ],
  "fields": [
   {
-   "depends_on": "eval:parent.apply_on == 'Item Code'",
+   "depends_on": "eval:parent.apply_on == 'Brand'",
    "fieldname": "brand",
    "fieldtype": "Link",
    "in_list_view": 1,
@@ -28,12 +28,13 @@
  ],
  "istable": 1,
  "links": [],
- "modified": "2024-03-27 13:10:17.857046",
+ "modified": "2026-02-12 18:16:21.174354",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Pricing Rule Brand",
  "owner": "Administrator",
  "permissions": [],
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],

--- a/erpnext/accounts/doctype/pricing_rule_item_group/pricing_rule_item_group.json
+++ b/erpnext/accounts/doctype/pricing_rule_item_group/pricing_rule_item_group.json
@@ -10,7 +10,7 @@
  ],
  "fields": [
   {
-   "depends_on": "eval:parent.apply_on == 'Item Code'",
+   "depends_on": "eval:parent.apply_on == 'Item Group'",
    "fieldname": "item_group",
    "fieldtype": "Link",
    "in_list_view": 1,
@@ -28,12 +28,13 @@
  ],
  "istable": 1,
  "links": [],
- "modified": "2024-03-27 13:10:18.221095",
+ "modified": "2026-02-12 18:16:01.729051",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Pricing Rule Item Group",
  "owner": "Administrator",
  "permissions": [],
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],


### PR DESCRIPTION
**Issue:** The depends_on condition in Pricing Rule child tables was incorrect. Brand and Item Group fields were shown for the wrong apply_on value, causing improper field visibility.

**Fix:** Updated the depends_on conditions to match the correct apply_on values and added dynamic row format for proper rendering.

**closes:** [52615](https://github.com/frappe/erpnext/issues/52615)


**before:**

[Screencast from 2026-02-13 12-11-07.webm](https://github.com/user-attachments/assets/14d7e14a-5f3e-4adb-b91e-b77bbd33ae3d)

**after:**

[Screencast from 2026-02-13 12-09-27.webm](https://github.com/user-attachments/assets/405656d3-3267-411b-aef2-f26536180d8b)
