### PR TITLE
fix: allow non-stock items while updating items

### DIFF
--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -646,7 +646,11 @@ erpnext.utils.update_child_items = function (opts) {
 			get_query: function () {
 				let filters;
 				if (frm.doc.doctype == "Sales Order") {
-					filters = { is_sales_item: 1, is_stock_item: !frm.doc.is_subcontracted };
+					if (frm.doc.is_subcontracted) {
+						filters = { is_sales_item: 1, is_stock_item: 0 };
+					} else {
+						filters = { is_sales_item: 1 };
+					}
 				} else if (frm.doc.doctype == "Purchase Order") {
 					if (frm.doc.is_subcontracted) {
 						if (frm.doc.is_old_subcontracting_flow) {


### PR DESCRIPTION
**Issue**:
The item filters are applied in Sales Order- Update Items (after Submit), causing non-stock service items to not appear during Update Items.


**Before:**
<img width="1918" height="1013" alt="image" src="https://github.com/user-attachments/assets/434574b9-1531-43f8-bf38-bc7fa719665f" />



**After:**

<img width="1629" height="670" alt="image" src="https://github.com/user-attachments/assets/38428a6b-cf4b-4e12-88ab-23f7f885b252" />
