### PR TITLE
fix: ledger preview in accounting transactions

### DIFF
--- a/erpnext/public/js/utils/ledger_preview.js
+++ b/erpnext/public/js/utils/ledger_preview.js
@@ -74,7 +74,7 @@ erpnext.accounts.ledger_preview = {
 					},
 				],
 			});
-
+			dialog.$wrapper.find(".section-body").css("max-width", "100%");
 			setTimeout(function () {
 				me.get_datatable(columns, data, dialog.get_field(fieldname).wrapper);
 			}, 200);


### PR DESCRIPTION
-Closes: #52327 

>Description of fix

The standard form layout restricts width (via --page-max-width), so override the default section max-width constraint on the Ledger Preview dialog to allow the data table to utilize the full screen width.
<img width="1920" height="1200" alt="code" src="https://github.com/user-attachments/assets/6290bb4a-3ef5-4aed-9a06-aa69e636386c" />

>Screenshots

Before:
<img width="1921" height="1014" alt="before" src="https://github.com/user-attachments/assets/c96e70c8-b0d1-4219-97ec-fd736fd30544" />

After:
<img width="1921" height="1014" alt="after" src="https://github.com/user-attachments/assets/592325df-f85d-4a05-90da-f5878b3ac9f1" />
