### PR TITLE
fix: Calculate WO disassemble quantities from Manufacturing STE

### DIFF
--- a/erpnext/manufacturing/doctype/work_order/test_work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/test_work_order.py
@@ -2627,14 +2627,14 @@ class TestWorkOrder(IntegrationTestCase):
 		se_for_material_transfer.save()
 		se_for_material_transfer.submit()
 
-		# First Manufacture Entry - 3 units
+		# First Manufacture Entry - 3 units, with 6 units of additional_rm
 		se_manufacture1 = frappe.get_doc(make_stock_entry(wo.name, "Manufacture", 3))
 		# Additional RM
 		se_manufacture1.append(
 			"items",
 			{
 				"item_code": additional_rm,
-				"qty": 3,  # 1 per unit
+				"qty": 6,  # 2 per unit
 				"s_warehouse": wo.wip_warehouse,
 				"is_finished_item": 0,
 			},
@@ -2642,14 +2642,14 @@ class TestWorkOrder(IntegrationTestCase):
 		se_manufacture1.save()
 		se_manufacture1.submit()
 
-		# Second Manufacture Entry - 7 units
+		# Second Manufacture Entry - 7 units, with 14 units of additional_rm
 		se_manufacture2 = frappe.get_doc(make_stock_entry(wo.name, "Manufacture", 7))
 		# AAdditional RM
 		se_manufacture2.append(
 			"items",
 			{
 				"item_code": additional_rm,
-				"qty": 7,  # 1 per unit
+				"qty": 14,  # 2 per unit
 				"s_warehouse": wo.wip_warehouse,
 				"is_finished_item": 0,
 			},
@@ -2686,9 +2686,10 @@ class TestWorkOrder(IntegrationTestCase):
 			f"Additional raw material {additional_rm} not found in disassembly",
 		)
 
-		# intentional full reversal as not part of BOM
-		# eg: dies or consumables used during manufacturing
-		expected_additional_rm_qty = 3 + 7
+		# Over our 2 Work Orders, we've made 10 finished items.  We've used 20 units
+		# of the additional RM.  We are disassembling 4 items.  So, we should expect
+		# to see 4/10 of the 20 units used, which equals 8 units of the additional RM.
+		expected_additional_rm_qty = 8
 		self.assertAlmostEqual(
 			additional_rm_row.qty,
 			expected_additional_rm_qty,

--- a/erpnext/manufacturing/doctype/work_order/test_work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/test_work_order.py
@@ -2686,7 +2686,7 @@ class TestWorkOrder(IntegrationTestCase):
 			f"Additional raw material {additional_rm} not found in disassembly",
 		)
 
-		# Over our 2 Work Orders, we've made 10 finished items.  We've used 20 units
+		# Over our 2 Manufacture entries, we've made 10 finished items.  We've used 20 units
 		# of the additional RM.  We are disassembling 4 items.  So, we should expect
 		# to see 4/10 of the 20 units used, which equals 8 units of the additional RM.
 		expected_additional_rm_qty = 8

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -2247,14 +2247,12 @@ class StockEntry(StockController, SubcontractingInwardController):
 		items = self.get_items_from_manufacture_entry()
 
 		s_warehouse = frappe.db.get_value("Work Order", self.work_order, "fg_warehouse")
-
-		items_dict = get_bom_items_as_dict(
-			self.bom_no,
-			self.company,
-			self.fg_completed_qty,
-			fetch_exploded=self.use_multi_level_bom,
-			fetch_qty_in_stock_uom=False,
-		)
+		wo_produced_qty = flt(frappe.db.get_value("Work Order", self.work_order, "produced_qty"))
+		if wo_produced_qty <= 0:
+			frappe.throw(_("Work Order {0} has no produced qty").format(self.work_order))
+		disassemble_qty = flt(self.fg_completed_qty)
+		if disassemble_qty <= 0:
+			frappe.throw(_("Disassemble Qty cannot be less than or equal to 0."))
 
 		for row in items:
 			child_row = self.append("items", {})
@@ -2262,11 +2260,7 @@ class StockEntry(StockController, SubcontractingInwardController):
 				if value is not None:
 					child_row.set(field, value)
 
-			# update qty and amount from BOM items
-			bom_items = items_dict.get(row.item_code)
-			if bom_items:
-				child_row.qty = bom_items.get("qty", child_row.qty)
-				child_row.amount = bom_items.get("amount", child_row.amount)
+			child_row.qty = (flt(child_row.qty) / wo_produced_qty) * disassemble_qty
 
 			if row.is_finished_item:
 				child_row.qty = self.fg_completed_qty
@@ -2274,6 +2268,9 @@ class StockEntry(StockController, SubcontractingInwardController):
 			child_row.s_warehouse = (self.from_warehouse or s_warehouse) if row.is_finished_item else ""
 			child_row.t_warehouse = row.s_warehouse
 			child_row.is_finished_item = 0 if row.is_finished_item else 1
+
+		self.set_transfer_qty()
+		self.calculate_rate_and_amount()
 
 	def _add_items_for_disassembly_from_bom(self):
 		if not self.bom_no or not self.fg_completed_qty:

--- a/erpnext/stock/doctype/stock_entry/test_stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/test_stock_entry.py
@@ -2280,9 +2280,7 @@ class TestStockEntry(IntegrationTestCase):
 		se.save()
 		se.submit()
 
-
 	def test_disassemble_entry_with_wo(self):
-
 		from erpnext.manufacturing.doctype.production_plan.test_production_plan import make_bom
 		from erpnext.manufacturing.doctype.work_order.work_order import (
 			make_stock_entry as _make_stock_entry,

--- a/erpnext/stock/doctype/stock_entry/test_stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/test_stock_entry.py
@@ -2349,7 +2349,7 @@ class TestStockEntry(IntegrationTestCase):
 
 		se = make_stock_entry(purpose="Disassemble", do_not_save=True)
 		se.work_order = work_order.name
-		# We are going to dissasemble a quarter of what we made.
+		# We are going to disassemble a quarter of what we made.
 		se.fg_completed_qty = QTY_TO_MADE / 4
 		se.get_items()
 

--- a/erpnext/stock/doctype/stock_entry/test_stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/test_stock_entry.py
@@ -2295,10 +2295,18 @@ class TestStockEntry(IntegrationTestCase):
 
 		# Create items.  1 finished good, 4 raw mats.
 		fg_item = make_item("_Disassemble Mobile", properties={"is_stock_item": 1}).name
-		rm_item1 = make_item("_Disassemble Temper Glass", properties={"is_stock_item": 1, "valuation_rate": 1}).name
-		rm_item2 = make_item("_Disassemble Battery", properties={"is_stock_item": 1, "valuation_rate": 1}).name
-		rm_item3 = make_item("_Disassemble Speaker", properties={"is_stock_item": 1, "valuation_rate": 1}).name
-		rm_item4 = make_item("_Disassemble Alternative Battery", properties={"is_stock_item": 1, "valuation_rate": 1}).name
+		rm_item1 = make_item(
+			"_Disassemble Temper Glass", properties={"is_stock_item": 1, "valuation_rate": 1}
+		).name
+		rm_item2 = make_item(
+			"_Disassemble Battery", properties={"is_stock_item": 1, "valuation_rate": 1}
+		).name
+		rm_item3 = make_item(
+			"_Disassemble Speaker", properties={"is_stock_item": 1, "valuation_rate": 1}
+		).name
+		rm_item4 = make_item(
+			"_Disassemble Alternative Battery", properties={"is_stock_item": 1, "valuation_rate": 1}
+		).name
 
 		# Create BOM for finished good, using first 3 raw mats.
 		bom_no = make_bom(item=fg_item, raw_materials=[rm_item1, rm_item2, rm_item3]).name
@@ -2330,9 +2338,7 @@ class TestStockEntry(IntegrationTestCase):
 
 		# Create a "Manufacture" Stock Entry for Work Order.
 		stock_entry = _make_stock_entry(work_order.name, "Manufacture", QTY_TO_MADE)
-		ste = frappe.new_doc("Stock Entry").update(
-			stock_entry
-		)
+		ste = frappe.new_doc("Stock Entry").update(stock_entry)
 
 		for i in ste.items:
 			# If _Disassemble Temper Glass, adjust qty needed to triple
@@ -2381,7 +2387,6 @@ class TestStockEntry(IntegrationTestCase):
 		self.assertFalse(rm_item2_in_se)
 		self.assertTrue(rm_item3_in_se)
 		self.assertTrue(rm_item4_in_se)
-
 
 	def test_disassemble_entry_without_wo(self):
 		from erpnext.manufacturing.doctype.production_plan.test_production_plan import make_bom

--- a/erpnext/stock/doctype/stock_entry/test_stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/test_stock_entry.py
@@ -2317,7 +2317,6 @@ class TestStockEntry(IntegrationTestCase):
 				"skip_transfer": 1,
 				"source_warehouse": TEST_WAREHOUSE,
 				"target_warehouse": TEST_WAREHOUSE,
-				"produced_qty": QTY_TO_MADE
 			}
 		)
 		work_order.insert()
@@ -2346,6 +2345,7 @@ class TestStockEntry(IntegrationTestCase):
 		ste.insert()
 		ste.submit()
 		work_order.reload()
+		self.assertEqual(work_order.produced_qty, QTY_TO_MADE)
 
 		se = make_stock_entry(purpose="Disassemble", do_not_save=True)
 		se.work_order = work_order.name

--- a/erpnext/stock/doctype/stock_entry/test_stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/test_stock_entry.py
@@ -2300,7 +2300,7 @@ class TestStockEntry(IntegrationTestCase):
 		rm_item3 = make_item("_Disassemble Speaker", properties={"is_stock_item": 1, "valuation_rate": 1}).name
 		rm_item4 = make_item("_Disassemble Alternative Battery", properties={"is_stock_item": 1, "valuation_rate": 1}).name
 
-		# Create BOM for finished good, using only first 2 raw mats.
+		# Create BOM for finished good, using first 3 raw mats.
 		bom_no = make_bom(item=fg_item, raw_materials=[rm_item1, rm_item2, rm_item3]).name
 
 		# Create a Work Order for finished good.  We want to make 20
@@ -2353,13 +2353,21 @@ class TestStockEntry(IntegrationTestCase):
 		se.fg_completed_qty = QTY_TO_MADE / 4
 		se.get_items()
 
+		rm_item1_in_se = False
+		rm_item2_in_se = False
+		rm_item3_in_se = False
 		rm_item4_in_se = False
+
 		for i in se.items:
 			if i.item_code == rm_item1:
+				rm_item1_in_se = True
 				self.assertEqual(i.qty, OVERRIDE_AMOUNT / 4)
 				self.assertEqual(i.transfer_qty, OVERRIDE_AMOUNT / 4)
 				self.assertEqual(i.amount, 100 * (OVERRIDE_AMOUNT / 4))
+			if i.item_code == rm_item2:
+				rm_item2_in_se = True
 			if i.item_code == rm_item3:
+				rm_item3_in_se = True
 				self.assertEqual(i.qty, (QTY_TO_MADE / 4))
 				self.assertEqual(i.transfer_qty, (QTY_TO_MADE / 4))
 				self.assertEqual(i.amount, 20 * (QTY_TO_MADE / 4))
@@ -2369,6 +2377,9 @@ class TestStockEntry(IntegrationTestCase):
 				self.assertEqual(i.transfer_qty, QTY_TO_MADE / 4)
 				self.assertEqual(i.amount, 20 * (QTY_TO_MADE / 4))
 
+		self.assertTrue(rm_item1_in_se)
+		self.assertFalse(rm_item2_in_se)
+		self.assertTrue(rm_item3_in_se)
 		self.assertTrue(rm_item4_in_se)
 
 

--- a/erpnext/stock/doctype/stock_entry/test_stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/test_stock_entry.py
@@ -2328,6 +2328,13 @@ class TestStockEntry(IntegrationTestCase):
 		work_order.insert()
 		work_order.submit()
 
+		se = make_stock_entry(purpose="Disassemble", do_not_save=True)
+		se.work_order = work_order.name
+		# We are going to disassemble 4.  An error should be raised as we've not,
+		# at this point, produced anything.
+		se.fg_completed_qty = 4
+		self.assertRaises(frappe.ValidationError, se.get_items)
+
 		# Add some stock for the raw mats.
 		make_stock_entry(item_code=rm_item1, target=TEST_WAREHOUSE, qty=60, basic_rate=100)
 		make_stock_entry(item_code=rm_item2, target=TEST_WAREHOUSE, qty=60, basic_rate=20)
@@ -2353,38 +2360,36 @@ class TestStockEntry(IntegrationTestCase):
 
 		se = make_stock_entry(purpose="Disassemble", do_not_save=True)
 		se.work_order = work_order.name
+		# We are going to disassemble zero, an error should be raised.
+		se.fg_completed_qty = 0
+		self.assertRaises(frappe.ValidationError, se.get_items)
+
+		se = make_stock_entry(purpose="Disassemble", do_not_save=True)
+		se.work_order = work_order.name
 		# We are going to disassemble a quarter of what we made.
 		se.fg_completed_qty = QTY_TO_MADE / 4
 		se.get_items()
 
-		rm_item1_in_se = False
-		rm_item2_in_se = False
-		rm_item3_in_se = False
-		rm_item4_in_se = False
+		item_codes = {row.item_code for row in se.items}
+
+		self.assertIn(rm_item1, item_codes)
+		self.assertNotIn(rm_item2, item_codes)
+		self.assertIn(rm_item3, item_codes)
+		self.assertIn(rm_item4, item_codes)
 
 		for i in se.items:
 			if i.item_code == rm_item1:
-				rm_item1_in_se = True
 				self.assertEqual(i.qty, OVERRIDE_AMOUNT / 4)
 				self.assertEqual(i.transfer_qty, OVERRIDE_AMOUNT / 4)
 				self.assertEqual(i.amount, 100 * (OVERRIDE_AMOUNT / 4))
-			if i.item_code == rm_item2:
-				rm_item2_in_se = True
 			if i.item_code == rm_item3:
-				rm_item3_in_se = True
 				self.assertEqual(i.qty, (QTY_TO_MADE / 4))
 				self.assertEqual(i.transfer_qty, (QTY_TO_MADE / 4))
 				self.assertEqual(i.amount, 20 * (QTY_TO_MADE / 4))
 			if i.item_code == rm_item4:
-				rm_item4_in_se = True
 				self.assertEqual(i.qty, QTY_TO_MADE / 4)
 				self.assertEqual(i.transfer_qty, QTY_TO_MADE / 4)
 				self.assertEqual(i.amount, 20 * (QTY_TO_MADE / 4))
-
-		self.assertTrue(rm_item1_in_se)
-		self.assertFalse(rm_item2_in_se)
-		self.assertTrue(rm_item3_in_se)
-		self.assertTrue(rm_item4_in_se)
 
 	def test_disassemble_entry_without_wo(self):
 		from erpnext.manufacturing.doctype.production_plan.test_production_plan import make_bom

--- a/erpnext/stock/doctype/stock_entry/test_stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/test_stock_entry.py
@@ -2280,6 +2280,98 @@ class TestStockEntry(IntegrationTestCase):
 		se.save()
 		se.submit()
 
+
+	def test_disassemble_entry_with_wo(self):
+
+		from erpnext.manufacturing.doctype.production_plan.test_production_plan import make_bom
+		from erpnext.manufacturing.doctype.work_order.work_order import (
+			make_stock_entry as _make_stock_entry,
+		)
+
+		TEST_WAREHOUSE = "_Test Warehouse - _TC"
+		TEST_UOM = "_Test UOM"
+		QTY_TO_MADE = 20
+		OVERRIDE_AMOUNT = 60
+
+		# Create items.  1 finished good, 4 raw mats.
+		fg_item = make_item("_Disassemble Mobile", properties={"is_stock_item": 1}).name
+		rm_item1 = make_item("_Disassemble Temper Glass", properties={"is_stock_item": 1, "valuation_rate": 1}).name
+		rm_item2 = make_item("_Disassemble Battery", properties={"is_stock_item": 1, "valuation_rate": 1}).name
+		rm_item3 = make_item("_Disassemble Speaker", properties={"is_stock_item": 1, "valuation_rate": 1}).name
+		rm_item4 = make_item("_Disassemble Alternative Battery", properties={"is_stock_item": 1, "valuation_rate": 1}).name
+
+		# Create BOM for finished good, using only first 2 raw mats.
+		bom_no = make_bom(item=fg_item, raw_materials=[rm_item1, rm_item2, rm_item3]).name
+
+		# Create a Work Order for finished good.  We want to make 20
+		work_order = frappe.new_doc("Work Order")
+		work_order.update(
+			{
+				"company": "_Test Company",
+				"fg_warehouse": TEST_WAREHOUSE,
+				"production_item": fg_item,
+				"bom_no": bom_no,
+				"qty": QTY_TO_MADE,
+				"stock_uom": TEST_UOM,
+				"additional_operating_cost": 1000,
+				"skip_transfer": 1,
+				"source_warehouse": TEST_WAREHOUSE,
+				"target_warehouse": TEST_WAREHOUSE,
+				"produced_qty": QTY_TO_MADE
+			}
+		)
+		work_order.insert()
+		work_order.submit()
+
+		# Add some stock for the raw mats.
+		make_stock_entry(item_code=rm_item1, target=TEST_WAREHOUSE, qty=60, basic_rate=100)
+		make_stock_entry(item_code=rm_item2, target=TEST_WAREHOUSE, qty=60, basic_rate=20)
+		make_stock_entry(item_code=rm_item3, target=TEST_WAREHOUSE, qty=60, basic_rate=20)
+		make_stock_entry(item_code=rm_item4, target=TEST_WAREHOUSE, qty=60, basic_rate=20)
+
+		# Create a "Manufacture" Stock Entry for Work Order.
+		stock_entry = _make_stock_entry(work_order.name, "Manufacture", QTY_TO_MADE)
+		ste = frappe.new_doc("Stock Entry").update(
+			stock_entry
+		)
+
+		for i in ste.items:
+			# If _Disassemble Temper Glass, adjust qty needed to triple
+			if i.item_code == rm_item1:
+				i.qty = OVERRIDE_AMOUNT
+			# If _Disassemble Battery, change item to _Disassemble Alternative Battery
+			elif i.item_code == rm_item2:
+				i.item_code = rm_item4
+
+		ste.insert()
+		ste.submit()
+		work_order.reload()
+
+		se = make_stock_entry(purpose="Disassemble", do_not_save=True)
+		se.work_order = work_order.name
+		# We are going to dissasemble a quarter of what we made.
+		se.fg_completed_qty = QTY_TO_MADE / 4
+		se.get_items()
+
+		rm_item4_in_se = False
+		for i in se.items:
+			if i.item_code == rm_item1:
+				self.assertEqual(i.qty, OVERRIDE_AMOUNT / 4)
+				self.assertEqual(i.transfer_qty, OVERRIDE_AMOUNT / 4)
+				self.assertEqual(i.amount, 100 * (OVERRIDE_AMOUNT / 4))
+			if i.item_code == rm_item3:
+				self.assertEqual(i.qty, (QTY_TO_MADE / 4))
+				self.assertEqual(i.transfer_qty, (QTY_TO_MADE / 4))
+				self.assertEqual(i.amount, 20 * (QTY_TO_MADE / 4))
+			if i.item_code == rm_item4:
+				rm_item4_in_se = True
+				self.assertEqual(i.qty, QTY_TO_MADE / 4)
+				self.assertEqual(i.transfer_qty, QTY_TO_MADE / 4)
+				self.assertEqual(i.amount, 20 * (QTY_TO_MADE / 4))
+
+		self.assertTrue(rm_item4_in_se)
+
+
 	def test_disassemble_entry_without_wo(self):
 		from erpnext.manufacturing.doctype.production_plan.test_production_plan import make_bom
 


### PR DESCRIPTION
## Fix: Disassembly should reverse Manufacture Stock Entry, not BOM  

**Applies to:** v16 (develop) and v15

### Background

When a **Work Order** is completed, users have the option to **Disassemble** it.

The intended behaviour of disassembly is to reverse the stock movements created by the related **"Manufacture" Stock Entry**.

### Problem

Currently, the disassembly process generates the reversed Stock Entry based on the **BOM** instead of the actual **Manufacture Stock Entry** created for the Work Order.

This leads to incorrect stock reversals when the original Manufacture Stock Entry has been modified. Such modifications may include:

- Adding or replacing items  
- Adjusting quantities on individual lines  
- Any other manual corrections made during production  

Since the BOM may not reflect these real-world changes, generating the disassembly entry from it can result in:

- Incorrect raw material returns  
- Incorrect finished goods reversal  
- Inconsistent stock balances  

### Root Cause

Disassembly logic references the BOM structure rather than the actual submitted Manufacture Stock Entry linked to the Work Order.

### Solution

The Disassemble process has been updated to:

- Reference the associated **Manufacture Stock Entry**
- Generate the reversal based on the exact items and quantities that were actually consumed and produced

This ensures:

- Accurate stock reversal  
- Consistency with real manufacturing adjustments  
- Reliable inventory valuation