### PR TITLE
fix: standalone credit/debit notes should not fetch any serial or bat…

### DIFF
--- a/erpnext/public/js/utils/serial_no_batch_selector.js
+++ b/erpnext/public/js/utils/serial_no_batch_selector.js
@@ -709,7 +709,7 @@ erpnext.SerialBatchPackageSelector = class SerialNoBatchBundleUpdate {
 	}
 
 	render_data() {
-		if (this.bundle || this.frm.doc.is_return) {
+		if (this.bundle || (this.frm.doc.is_return && this.frm.doc.return_against)) {
 			frappe
 				.call({
 					method: "erpnext.stock.doctype.serial_and_batch_bundle.serial_and_batch_bundle.get_serial_batch_ledgers",


### PR DESCRIPTION
When you create a standalone debit or credit note with update stock checked and a batch item, clicking on pick serial/batch (serial batch selector) will give you the selector with many serial or batches prefilled which should not be the case, it should be empty.