### PR TITLE
chore: do not show stock details if update stock is disabled

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice_item/purchase_invoice_item.json
+++ b/erpnext/accounts/doctype/purchase_invoice_item/purchase_invoice_item.json
@@ -52,6 +52,7 @@
   "stock_uom_rate",
   "is_free_item",
   "apply_tds",
+  "allow_zero_valuation_rate",
   "section_break_22",
   "net_rate",
   "net_amount",
@@ -97,7 +98,6 @@
   "service_start_date",
   "service_end_date",
   "reference",
-  "allow_zero_valuation_rate",
   "item_tax_rate",
   "bom",
   "include_exploded_items",
@@ -420,6 +420,7 @@
    "options": "UOM"
   },
   {
+   "depends_on": "eval:parent.update_stock",
    "fieldname": "warehouse_section",
    "fieldtype": "Section Break",
    "label": "Warehouse"
@@ -800,7 +801,7 @@
    "read_only": 1
   },
   {
-   "depends_on": "eval:parent.is_internal_supplier && parent.update_stock",
+   "depends_on": "eval:parent.is_internal_supplier",
    "fieldname": "from_warehouse",
    "fieldtype": "Link",
    "ignore_user_permissions": 1,
@@ -896,7 +897,7 @@
    "label": "Consider for Tax Withholding"
   },
   {
-   "depends_on": "eval:parent.update_stock == 1 && (doc.use_serial_batch_fields === 0 || doc.docstatus === 1)",
+   "depends_on": "eval:doc.use_serial_batch_fields === 0 || doc.docstatus === 1",
    "fieldname": "serial_and_batch_bundle",
    "fieldtype": "Link",
    "label": "Serial and Batch Bundle",
@@ -906,7 +907,7 @@
    "search_index": 1
   },
   {
-   "depends_on": "eval:parent.update_stock == 1 && (doc.use_serial_batch_fields === 0 || doc.docstatus === 1)",
+   "depends_on": "eval:doc.use_serial_batch_fields === 0 || doc.docstatus === 1",
    "fieldname": "rejected_serial_and_batch_bundle",
    "fieldtype": "Link",
    "label": "Rejected Serial and Batch Bundle",
@@ -922,7 +923,7 @@
    "options": "Asset"
   },
   {
-   "depends_on": "eval:parent.update_stock === 1 && (doc.use_serial_batch_fields === 0 || doc.docstatus === 1)",
+   "depends_on": "eval:doc.use_serial_batch_fields === 0 || doc.docstatus === 1",
    "fieldname": "add_serial_batch_bundle",
    "fieldtype": "Button",
    "label": "Add Serial / Batch No"
@@ -992,7 +993,7 @@
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-12-13 14:10:02.379392",
+ "modified": "2026-02-15 20:52:20.097603",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Purchase Invoice Item",

--- a/erpnext/accounts/doctype/purchase_invoice_item/purchase_invoice_item.json
+++ b/erpnext/accounts/doctype/purchase_invoice_item/purchase_invoice_item.json
@@ -448,7 +448,6 @@
    "print_hide": 1
   },
   {
-   "depends_on": "eval:!doc.is_fixed_asset && doc.use_serial_batch_fields === 1 && parent.update_stock === 1",
    "fieldname": "batch_no",
    "fieldtype": "Link",
    "label": "Batch No",
@@ -460,14 +459,12 @@
    "fieldtype": "Column Break"
   },
   {
-   "depends_on": "eval:!doc.is_fixed_asset && doc.use_serial_batch_fields === 1 && parent.update_stock === 1",
    "fieldname": "serial_no",
    "fieldtype": "Text",
    "label": "Serial No",
    "no_copy": 1
   },
   {
-   "depends_on": "eval:!doc.is_fixed_asset && doc.use_serial_batch_fields === 1 && parent.update_stock === 1",
    "fieldname": "rejected_serial_no",
    "fieldtype": "Text",
    "label": "Rejected Serial No",
@@ -578,6 +575,7 @@
   },
   {
    "default": "0",
+   "depends_on": "eval:parent.update_stock",
    "fieldname": "allow_zero_valuation_rate",
    "fieldtype": "Check",
    "label": "Allow Zero Valuation Rate",
@@ -923,7 +921,7 @@
    "options": "Asset"
   },
   {
-   "depends_on": "eval:doc.use_serial_batch_fields === 0 || doc.docstatus === 1",
+   "depends_on": "eval:doc.use_serial_batch_fields === 0 && doc.docstatus === 0",
    "fieldname": "add_serial_batch_bundle",
    "fieldtype": "Button",
    "label": "Add Serial / Batch No"
@@ -993,7 +991,7 @@
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-02-15 20:52:20.097603",
+ "modified": "2026-02-15 21:07:49.455930",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Purchase Invoice Item",

--- a/erpnext/accounts/doctype/sales_invoice_item/sales_invoice_item.json
+++ b/erpnext/accounts/doctype/sales_invoice_item/sales_invoice_item.json
@@ -614,7 +614,6 @@
    "options": "Quality Inspection"
   },
   {
-   "depends_on": "eval: doc.use_serial_batch_fields === 1 && parent.update_stock === 1",
    "fieldname": "batch_no",
    "fieldtype": "Link",
    "label": "Batch No",
@@ -627,6 +626,7 @@
   },
   {
    "default": "0",
+   "depends_on": "eval:parent.update_stock",
    "fieldname": "allow_zero_valuation_rate",
    "fieldtype": "Check",
    "label": "Allow Zero Valuation Rate",
@@ -634,7 +634,6 @@
    "print_hide": 1
   },
   {
-   "depends_on": "eval: doc.use_serial_batch_fields === 1 && parent.update_stock === 1",
    "fieldname": "serial_no",
    "fieldtype": "Text",
    "label": "Serial No",
@@ -917,6 +916,7 @@
    "search_index": 1
   },
   {
+   "depends_on": "eval:doc.use_serial_batch_fields === 0 && doc.docstatus === 0",
    "fieldname": "pick_serial_and_batch",
    "fieldtype": "Button",
    "label": "Pick Serial / Batch No"
@@ -1009,7 +1009,7 @@
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-02-15 20:50:18.580088",
+ "modified": "2026-02-15 21:08:57.341638",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Sales Invoice Item",

--- a/erpnext/accounts/doctype/sales_invoice_item/sales_invoice_item.json
+++ b/erpnext/accounts/doctype/sales_invoice_item/sales_invoice_item.json
@@ -52,6 +52,7 @@
   "is_free_item",
   "apply_tds",
   "grant_commission",
+  "allow_zero_valuation_rate",
   "section_break_21",
   "net_rate",
   "net_amount",
@@ -88,7 +89,6 @@
   "serial_and_batch_bundle",
   "use_serial_batch_fields",
   "col_break5",
-  "allow_zero_valuation_rate",
   "incoming_rate",
   "item_tax_rate",
   "actual_batch_qty",
@@ -580,6 +580,7 @@
   {
    "collapsible": 1,
    "collapsible_depends_on": "eval:doc.serial_no || doc.batch_no",
+   "depends_on": "eval:parent.update_stock",
    "fieldname": "warehouse_and_reference",
    "fieldtype": "Section Break",
    "label": "Stock Details"
@@ -595,7 +596,7 @@
    "print_hide": 1
   },
   {
-   "depends_on": "eval: parent.is_internal_customer && parent.update_stock",
+   "depends_on": "eval: parent.is_internal_customer",
    "fieldname": "target_warehouse",
    "fieldtype": "Link",
    "hidden": 1,
@@ -906,7 +907,7 @@
    "read_only": 1
   },
   {
-   "depends_on": "eval:parent.update_stock == 1 && (doc.use_serial_batch_fields === 0 || doc.docstatus === 1)",
+   "depends_on": "eval:doc.use_serial_batch_fields === 0 || doc.docstatus === 1",
    "fieldname": "serial_and_batch_bundle",
    "fieldtype": "Link",
    "label": "Serial and Batch Bundle",
@@ -916,7 +917,6 @@
    "search_index": 1
   },
   {
-   "depends_on": "eval:parent.update_stock === 1",
    "fieldname": "pick_serial_and_batch",
    "fieldtype": "Button",
    "label": "Pick Serial / Batch No"
@@ -1009,7 +1009,7 @@
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-02-02 16:46:12.597972",
+ "modified": "2026-02-15 20:50:18.580088",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Sales Invoice Item",


### PR DESCRIPTION
1. Moved `Allow Zero Valuation Rate` to the rate section
2. The entire `Stock Details` section will not be shown if `Update Stock` on parent is unchecked
3. Serial Batch Selector button will not be shown if using serial batch fields