### PR TITLE
fix: log changes made to accounts settings

### DIFF
--- a/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
+++ b/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
@@ -691,7 +691,7 @@
   }
  ],
  "grid_page_length": 50,
- "hide_toolbar": 1,
+ "hide_toolbar": 0,
  "icon": "icon-cog",
  "idx": 1,
  "index_web_pages_for_search": 1,


### PR DESCRIPTION
**fix**: This PR is a direct resolution to **Ticket #60075** wherein the issue is that any changes made to accounts settings were not being logged. This PR fixes that so any changes now made in accounts settings are logged. 

This issue only exists in V16, perfectly logged in V15.

**Before**:
<img width="2392" height="1430" alt="image" src="https://github.com/user-attachments/assets/a61b23c1-808f-4594-bb78-c91261e6581e" />


**After**:
<img width="2880" height="1638" alt="image" src="https://github.com/user-attachments/assets/5ef90feb-79b3-4387-a2be-4e2c3a228077" />
