### PR TITLE
fix(selling-workspace-sidebar): changed order of pos profile

### DIFF
--- a/erpnext/workspace_sidebar/selling.json
+++ b/erpnext/workspace_sidebar/selling.json
@@ -94,6 +94,17 @@
    "collapsible": 1,
    "indent": 0,
    "keep_closed": 0,
+   "label": "POS Profile",
+   "link_to": "POS Profile",
+   "link_type": "DocType",
+   "show_arrow": 0,
+   "type": "Link"
+  },
+  {
+   "child": 1,
+   "collapsible": 1,
+   "indent": 0,
+   "keep_closed": 0,
    "label": "POS Invoice",
    "link_to": "POS Invoice",
    "link_type": "DocType",
@@ -118,17 +129,6 @@
    "keep_closed": 0,
    "label": "POS Closing Entry",
    "link_to": "POS Closing Entry",
-   "link_type": "DocType",
-   "show_arrow": 0,
-   "type": "Link"
-  },
-  {
-   "child": 1,
-   "collapsible": 1,
-   "indent": 0,
-   "keep_closed": 0,
-   "label": "POS Profile",
-   "link_to": "POS Profile",
    "link_type": "DocType",
    "show_arrow": 0,
    "type": "Link"
@@ -687,7 +687,7 @@
    "type": "Link"
   }
  ],
- "modified": "2026-01-10 00:06:13.103140",
+ "modified": "2026-02-16 23:48:24.611112",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Selling",


### PR DESCRIPTION
Moved `POS Profile` Item right below to POS on Selling Workspace Sidebar, as POS Profile is an important DocType used both in `Sales Invoice` and `POS Invoice`.
