### PR TITLE
fix: Correct "Addresses" in Portal

### DIFF
--- a/erpnext/hooks.py
+++ b/erpnext/hooks.py
@@ -270,7 +270,7 @@ standard_portal_menu_items = [
 		"role": "Customer",
 	},
 	{"title": "Issues", "route": "/issues", "reference_doctype": "Issue", "role": "Customer"},
-	{"title": "Addresses", "route": "/addresses", "reference_doctype": "Address"},
+	{"title": "Addresses", "route": "/address", "reference_doctype": "Address", "role": "Customer"},
 	{
 		"title": "Timesheets",
 		"route": "/timesheets",

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -466,3 +466,4 @@ erpnext.patches.v16_0.update_company_custom_field_in_bin
 erpnext.patches.v15_0.replace_http_with_https_in_sales_partner
 erpnext.patches.v16_0.migrate_asset_type_checkboxes_to_select
 erpnext.patches.v15_0.delete_quotation_lost_record_detail
+erpnext.patches.v16_0.delete_invalid_address_portal_menu_item

--- a/erpnext/patches/v16_0/delete_invalid_address_portal_menu_item.py
+++ b/erpnext/patches/v16_0/delete_invalid_address_portal_menu_item.py
@@ -1,6 +1,6 @@
 import frappe
 
-# Ammending the incorrect route in hooks.py leaves the incorrect entry in the database, it needs to be removed manually.
+# Amending the incorrect route in hooks.py leaves the incorrect entry in the database, it needs to be removed manually.
 
 
 def execute():
@@ -17,5 +17,4 @@ def execute():
 	)
 
 	for ipmi in incorrect_portal_menu_item:
-		doc = frappe.get_doc("Portal Menu Item", ipmi.name)
-		doc.delete(doc)
+		frappe.delete_doc("Portal Menu Item", ipmi.name, force=True)

--- a/erpnext/patches/v16_0/delete_invalid_address_portal_menu_item.py
+++ b/erpnext/patches/v16_0/delete_invalid_address_portal_menu_item.py
@@ -1,9 +1,18 @@
 import frappe
 
-# Amending the incorrect route in hooks.py leaves the incorrect entry in the database, it needs to be removed manually.
-
 
 def execute():
+	"""
+	Amending the incorrect route in hooks.py leaves
+	the incorrect entry to /addresses in the database
+	and in the Portal Settings which needs to be
+	removed manually.
+
+	This patch deletes the incorrect entry so that
+	only the correct entry with route /address
+	remains in the database and Portal Settings.
+	"""
+
 	incorrect_portal_menu_item = frappe.get_all(
 		"Portal Menu Item",
 		filters={

--- a/erpnext/patches/v16_0/delete_invalid_address_portal_menu_item.py
+++ b/erpnext/patches/v16_0/delete_invalid_address_portal_menu_item.py
@@ -1,0 +1,21 @@
+import frappe
+
+# Ammending the incorrect route in hooks.py leaves the incorrect entry in the database, it needs to be removed manually.
+
+
+def execute():
+	incorrect_portal_menu_item = frappe.get_all(
+		"Portal Menu Item",
+		filters={
+			"title": "Addresses",
+			"enabled": 1,
+			"route": "/addresses",
+			"reference_doctype": "Address",
+			"role": None,
+		},
+		fields=["name"],
+	)
+
+	for ipmi in incorrect_portal_menu_item:
+		doc = frappe.get_doc("Portal Menu Item", ipmi.name)
+		doc.delete(doc)

--- a/erpnext/utilities/web_form/addresses/addresses.json
+++ b/erpnext/utilities/web_form/addresses/addresses.json
@@ -1,13 +1,10 @@
 {
- "accept_payment": 0,
  "allow_comments": 0,
  "allow_delete": 0,
  "allow_edit": 1,
  "allow_incomplete": 0,
  "allow_multiple": 1,
  "allow_print": 0,
- "amount": 0.0,
- "amount_based_on_field": 0,
  "anonymous": 0,
  "apply_document_permissions": 1,
  "condition_json": "[]",
@@ -15,13 +12,15 @@
  "doc_type": "Address",
  "docstatus": 0,
  "doctype": "Web Form",
+ "hide_footer": 0,
+ "hide_navbar": 0,
  "idx": 0,
  "is_standard": 1,
  "list_columns": [],
  "list_title": "",
  "login_required": 1,
  "max_attachment_size": 0,
- "modified": "2025-10-27 21:05:21.125639",
+ "modified": "2026-02-16 16:34:00.586969",
  "modified_by": "Administrator",
  "module": "Utilities",
  "name": "addresses",
@@ -31,7 +30,7 @@
  "show_attachments": 0,
  "show_list": 1,
  "show_sidebar": 0,
- "success_url": "/addresses",
+ "success_url": "/address",
  "title": "Address",
  "web_form_fields": [
   {
@@ -85,17 +84,17 @@
    "show_in_filter": 0
   },
   {
-    "allow_read_on_all_link_options": 0,
-    "fieldname": "pincode",
-    "fieldtype": "Data",
-    "hidden": 0,
-    "label": "Postal Code",
-    "max_length": 0,
-    "max_value": 0,
-    "read_only": 0,
-    "reqd": 0,
-    "show_in_filter": 0
-   },
+   "allow_read_on_all_link_options": 0,
+   "fieldname": "pincode",
+   "fieldtype": "Data",
+   "hidden": 0,
+   "label": "Postal Code",
+   "max_length": 0,
+   "max_value": 0,
+   "read_only": 0,
+   "reqd": 0,
+   "show_in_filter": 0
+  },
   {
    "allow_read_on_all_link_options": 0,
    "fieldname": "city",
@@ -120,7 +119,6 @@
    "reqd": 0,
    "show_in_filter": 0
   },
-  
   {
    "allow_read_on_all_link_options": 1,
    "fieldname": "country",


### PR DESCRIPTION
This PR fixes bugs that prevent the "Addresses" Portal Menu Item from functioning. 

The basic approach was to:
1. Correct the URL for Addresses in the hooks.py standard_portal_menu_items section
2. Correct the success_url in the Addresses web form
3. Create a patch to remove the old, incorrect entry from the database because only correcting hooks.py leaves the old one in the tabPortal Menu Items table to cause problems

### Before:
<img width="1080" height="552" alt="before-1" src="https://github.com/user-attachments/assets/38672502-6641-491b-9a90-56b33b427783" />
<img width="1286" height="670" alt="before-2" src="https://github.com/user-attachments/assets/c210da11-8d22-473f-9677-897e934ae491" />
<img width="1288" height="672" alt="before-3" src="https://github.com/user-attachments/assets/a1c982cb-90ab-43e9-a621-8d111d987146" />

### After:
<img width="1076" height="548" alt="after-1" src="https://github.com/user-attachments/assets/8a5ae468-b2fb-48af-b954-370d4f5e565b" />
<img width="1080" height="548" alt="after-2" src="https://github.com/user-attachments/assets/0a85e577-f23f-4221-9d65-e1d6dfde1cb4" />
<img width="1078" height="552" alt="after-3" src="https://github.com/user-attachments/assets/f8f9c36a-6b00-4de9-b1e5-966db715221c" />
<img width="1090" height="746" alt="after-4" src="https://github.com/user-attachments/assets/9cc497c0-ac72-478f-b181-09c6599ef9e4" />
<img width="1144" height="1030" alt="after-5" src="https://github.com/user-attachments/assets/7d48fdde-54d4-4a2d-b601-ac3842e8a9b1" />
<img width="1164" height="778" alt="after-6" src="https://github.com/user-attachments/assets/28e7d1d4-3c67-4bb1-99c4-bb71bca24b0a" />

Closes #52710 