### PR TITLE
fix: allow sequence ID edit in BOM if routing is not set

### DIFF
--- a/erpnext/manufacturing/doctype/bom_operation/bom_operation.json
+++ b/erpnext/manufacturing/doctype/bom_operation/bom_operation.json
@@ -146,7 +146,7 @@
    "label": "Batch Size"
   },
   {
-   "depends_on": "eval:doc.parenttype == \"Routing\"",
+   "depends_on": "eval:doc.parenttype == \"Routing\" || !parent.routing",
    "description": "If you want to run operations in parallel, keep the same sequence ID for them.",
    "fieldname": "sequence_id",
    "fieldtype": "Int",
@@ -297,7 +297,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-01-01 17:15:59.806874",
+ "modified": "2026-02-17 15:33:28.495850",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "BOM Operation",


### PR DESCRIPTION
Sequence ID in operations table in BOM could not be edited. Now they can be edited only if routing is not present