### PR TITLE
fix(department): add company abbreviation

### DIFF
--- a/erpnext/setup/doctype/department/department.py
+++ b/erpnext/setup/doctype/department/department.py
@@ -32,9 +32,14 @@ class Department(NestedSet):
 	nsm_parent_field = "parent_department"
 
 	def autoname(self):
-		root = get_root_of("Department")
-		if root and self.department_name != root:
-			self.name = get_abbreviated_name(self.department_name, self.company)
+		if self.company:
+			abbr = frappe.get_cached_value("Company", self.company, "abbr")
+			suffix = f" - {abbr}"
+
+			if self.department_name.endswith(suffix):
+				self.name = self.department_name
+			else:
+				self.name = self.department_name + suffix
 		else:
 			self.name = self.department_name
 


### PR DESCRIPTION
**Ref:** [60110](https://support.frappe.io/helpdesk/tickets/60110?view=VIEW-HD+Ticket-781)

**Description:** During the initial setup process, the Department name suffix was not appended with the Company Abbreviation. This occurred because, in the autoname method, the system attempted to fetch the root department while the department tree was still being created and not yet fully stable. At that stage, the root value was returned as None, which prevented the company abbreviation from being appended to the department name.

**Before:**

[Screencast from 2026-02-17 20-51-30.webm](https://github.com/user-attachments/assets/b18fe3ad-43d9-4d60-b719-27b1020c2462)


**After:**

[Screencast from 2026-02-17 20-45-25.webm](https://github.com/user-attachments/assets/d5f74b77-cdd7-4231-a34e-02e475f3b21c)


Backport needed for v-15, v-16