### PR TITLE
feat(Journal Entry Account): add Bank Transaction as Reference Type

### DIFF
--- a/erpnext/accounts/doctype/bank_transaction/bank_transaction.py
+++ b/erpnext/accounts/doctype/bank_transaction/bank_transaction.py
@@ -139,6 +139,8 @@ class BankTransaction(Document):
 		self.set_status()
 
 	def on_cancel(self):
+		self.ignore_linked_doctypes = ["GL Entry"]
+
 		for payment_entry in self.payment_entries:
 			self.delink_payment_entry(payment_entry)
 

--- a/erpnext/accounts/doctype/journal_entry_account/journal_entry_account.json
+++ b/erpnext/accounts/doctype/journal_entry_account/journal_entry_account.json
@@ -185,7 +185,7 @@
    "fieldtype": "Select",
    "label": "Reference Type",
    "no_copy": 1,
-   "options": "\nSales Invoice\nPurchase Invoice\nJournal Entry\nSales Order\nPurchase Order\nExpense Claim\nAsset\nLoan\nPayroll Entry\nEmployee Advance\nExchange Rate Revaluation\nInvoice Discounting\nFees\nFull and Final Statement\nPayment Entry",
+   "options": "\nSales Invoice\nPurchase Invoice\nJournal Entry\nSales Order\nPurchase Order\nExpense Claim\nAsset\nLoan\nPayroll Entry\nEmployee Advance\nExchange Rate Revaluation\nInvoice Discounting\nFees\nFull and Final Statement\nPayment Entry\nBank Transaction",
    "search_index": 1
   },
   {
@@ -294,7 +294,7 @@
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-11-27 12:23:33.157655",
+ "modified": "2026-02-18 01:02:50.100225",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Journal Entry Account",

--- a/erpnext/accounts/doctype/journal_entry_account/journal_entry_account.json
+++ b/erpnext/accounts/doctype/journal_entry_account/journal_entry_account.json
@@ -197,7 +197,7 @@
    "search_index": 1
   },
   {
-   "depends_on": "eval:doc.reference_type&&!in_list(doc.reference_type, ['Expense Claim', 'Asset', 'Employee Loan', 'Employee Advance'])",
+   "depends_on": "eval:doc.reference_type&&!in_list(doc.reference_type, ['Expense Claim', 'Asset', 'Employee Loan', 'Employee Advance', 'Bank Transaction'])",
    "fieldname": "reference_due_date",
    "fieldtype": "Date",
    "label": "Reference Due Date",
@@ -293,7 +293,7 @@
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-02-18 01:02:50.100225",
+ "modified": "2026-02-19 17:01:22.642454",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Journal Entry Account",

--- a/erpnext/accounts/doctype/journal_entry_account/journal_entry_account.py
+++ b/erpnext/accounts/doctype/journal_entry_account/journal_entry_account.py
@@ -55,6 +55,7 @@ class JournalEntryAccount(Document):
 			"Fees",
 			"Full and Final Statement",
 			"Payment Entry",
+			"Bank Transaction",
 		]
 		user_remark: DF.SmallText | None
 	# end: auto-generated types

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -412,6 +412,7 @@ erpnext.patches.v15_0.rename_group_by_to_categorize_by
 execute:frappe.db.set_single_value("Accounts Settings", "receivable_payable_fetch_method", "Buffered Cursor")
 erpnext.patches.v14_0.set_update_price_list_based_on
 erpnext.patches.v15_0.update_journal_entry_type
+erpnext.patches.v15_0.add_bank_transaction_as_journal_entry_reference
 erpnext.patches.v15_0.set_grand_total_to_default_mop
 execute:frappe.db.set_single_value("Accounts Settings", "use_legacy_budget_controller", False)
 erpnext.patches.v15_0.set_cancelled_status_to_cancelled_pos_invoice

--- a/erpnext/patches/v15_0/add_bank_transaction_as_journal_entry_reference.py
+++ b/erpnext/patches/v15_0/add_bank_transaction_as_journal_entry_reference.py
@@ -1,0 +1,29 @@
+import frappe
+
+
+def execute():
+	"""Append Bank Transaction in custom reference_type options."""
+	new_reference_type = "Bank Transaction"
+	property_setters = frappe.get_all(
+		"Property Setter",
+		filters={
+			"doc_type": "Journal Entry Account",
+			"field_name": "reference_type",
+			"property": "options",
+		},
+		pluck="name",
+	)
+
+	for property_setter in property_setters:
+		existing_value = frappe.db.get_value("Property Setter", property_setter, "value") or ""
+		options = [option.strip() for option in existing_value.split("\n")]
+		if new_reference_type in options:
+			continue
+
+		options.append(new_reference_type)
+		frappe.db.set_value(
+			"Property Setter",
+			property_setter,
+			"value",
+			"\n".join(options),
+		)

--- a/erpnext/patches/v15_0/add_bank_transaction_as_journal_entry_reference.py
+++ b/erpnext/patches/v15_0/add_bank_transaction_as_journal_entry_reference.py
@@ -16,7 +16,11 @@ def execute():
 
 	for property_setter in property_setters:
 		existing_value = frappe.db.get_value("Property Setter", property_setter, "value") or ""
-		options = [option.strip() for option in existing_value.split("\n")]
+
+		raw_options = [option.strip() for option in existing_value.split("\n")]
+		# Preserve a single leading blank (for the empty select option) but drop spurious trailing blanks
+		options = raw_options[:1] + [o for o in raw_options[1:] if o]
+
 		if new_reference_type in options:
 			continue
 


### PR DESCRIPTION
When creating a **Journal Entry** for a **Bank Transaction** (as part of bank reconciliation), it would be useful to link the **Bank Transaction** as a reference. This way it shows up as "proof" in GL and the **Journal Entry** is automatically canceled along with the **Bank Transaction**.

> no-docs