### PR TITLE
fix: populate doctypes to be ignored table in validate

### DIFF
--- a/erpnext/setup/doctype/transaction_deletion_record/transaction_deletion_record.py
+++ b/erpnext/setup/doctype/transaction_deletion_record/transaction_deletion_record.py
@@ -165,6 +165,8 @@ class TransactionDeletionRecord(Document):
 
 	def validate(self):
 		frappe.only_for("System Manager")
+		if not self.doctypes_to_be_ignored:
+			self.populate_doctypes_to_be_ignored_table()
 		self.validate_to_delete_list()
 
 	def validate_to_delete_list(self):


### PR DESCRIPTION
Issue: The Delete Transaction from the company master option is deleting the ignored doctypes master data as well.

Ref: [60077](https://support.frappe.io/helpdesk/tickets/60077)

Regression: [50592](https://github.com/frappe/erpnext/pull/50592)

https://github.com/frappe/erpnext/blob/8b2a9710190a108022da0375ecf19f99504a4ba8/erpnext/setup/doctype/company/company.py#L1095


Backport Needed: V16