### PR TITLE
fix: profit and loss report chart not shown properly

### DIFF
--- a/erpnext/accounts/report/profit_and_loss_statement/profit_and_loss_statement.py
+++ b/erpnext/accounts/report/profit_and_loss_statement/profit_and_loss_statement.py
@@ -159,11 +159,11 @@ def get_net_profit_loss(income, expense, period_list, company, currency=None, co
 
 
 def get_chart_data(filters, columns, income, expense, net_profit_loss, currency):
-	labels = [d.get("label") for d in columns[4:]]
+	labels = [d.get("label") for d in columns[2:]]
 
 	income_data, expense_data, net_profit = [], [], []
 
-	for p in columns[4:]:
+	for p in columns[2:]:
 		if income:
 			income_data.append(income[-2].get(p.get("fieldname")))
 		if expense:


### PR DESCRIPTION
- Closes: #52510

### **Profit and loss report chart not shown properly due to incorrect slicing of list returned by `get_columns()`.**

**Reason why it works in v16 and doesn't work properly in v15.**
- Inside the `get_columns()` in v15, there are 2 dicts that are appended to the columns list and after which the code is dynamically generating another dicts to append in the list. 
- In `get_chart_data()`, to just get the dynamically generated dicts, they are slicing the list generated from `get_columns()` by `[2:]`.
- In v16, the number of dicts appended before the dynamically generated dicts was increased to 4. To accommodate this change, the slicing in `get_chart_data()` was done by `[4:]`.
- The problem occurred when this change of slicing the list by `[4:]` was backported to v15 also. Due to this, 2 dicts that are dynamically generated and are used to show chart data are not included. So when the list contained only 4 dicts, the result of slicing becomes empty, which results in the chart not being shown.
- Also even if the chart is shown, it won't be able to include the whole data as the first two dynamically generated dicts are always removed by slicing the list `[4:]`.

**Change made to solve this:**  
-  Reduced the slicing in v15 from `[4:]` to `[2:]`. 