### PR TITLE
fix: validate paid and received amount

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -194,6 +194,8 @@ class PaymentEntry(AccountsController):
 		PaymentTaxWithholding(self).on_validate()
 		self.set_status()
 		self.set_total_in_words()
+		self.validate_paid_and_received_amount()
+		
 
 	def before_save(self):
 		self.set_matched_unset_payment_requests_to_response()
@@ -606,6 +608,14 @@ class PaymentEntry(AccountsController):
 	def validate_payment_type(self):
 		if self.payment_type not in ("Receive", "Pay", "Internal Transfer"):
 			frappe.throw(_("Payment Type must be one of Receive, Pay and Internal Transfer"))
+	
+	def validate_paid_and_received_amount(self):
+		if self.paid_amount and self.received_amount and self.source_exchange_rate and self.target_exchange_rate:
+			converted_paid_amount = flt(self.received_amount) * flt(self.target_exchange_rate)
+			if self.paid_amount != converted_paid_amount:
+				frappe.throw(
+						_("There is a mismatch between Paid and Received amounts.")
+					)
 
 	def validate_party_details(self):
 		if self.party and not frappe.db.exists(self.party_type, self.party):


### PR DESCRIPTION
**Issue**:
While making Payment Entry to Import Supplier, the Total Outstanding is 1000 USD, and as per currency exchange, it is fetching 90610 Rs. in Paid Amount field,

Now, if i change the Received Amount to 300 USD, the Paid amount field value should show up as 27183 Rs.

**Ref**:[#60280](https://support.frappe.io/helpdesk/tickets/60280)