### PR TITLE
fix(accounts): assign batch number and serial number for free item 

### DIFF
--- a/erpnext/accounts/doctype/pos_invoice/test_pos_invoice.py
+++ b/erpnext/accounts/doctype/pos_invoice/test_pos_invoice.py
@@ -1150,6 +1150,176 @@ class TestPOSInvoice(IntegrationTestCase):
 
 		frappe.set_user("test@example.com")
 
+	def test_pos_item_with_batch_no_and_pricing_rule(self):
+		from erpnext.accounts.doctype.pricing_rule.test_pricing_rule import make_pricing_rule
+
+		item = "_Test Item with Batch No and Pricing Rule"
+		make_item(
+			item,
+			{
+				"is_stock_item": 1,
+				"has_batch_no": 1,
+				"create_new_batch": 1,
+				"batch_number_series": "BATCH-.#####",
+			},
+		)
+		make_purchase_receipt(
+			item_code=item, warehouse="_Test Warehouse - _TC", qty=10, rate=500, use_serial_batch_fields=1
+		)
+
+		pr = make_pricing_rule(
+			title="5+1",
+			apply_on="Item Code",
+			item_code=item,
+			selling=1,
+			price_or_product_discount="Product",
+			free_item=item,
+			free_qty=1,
+		)
+		pr.round_free_qty = 1
+		pr.is_recursive = 1
+		pr.recurse_for = 5
+		pr.save()
+
+		pos_inv = create_pos_invoice(
+			update_stock=1, item_code=item, qty=6, rate=500, do_not_submit=1, use_serial_batch_fields=1
+		)
+		pos_inv.payments = []
+		pos_inv.append("payments", {"mode_of_payment": "Cash", "amount": 3000})
+		pos_inv.save()
+		pos_inv.submit()
+		pos_inv.reload()
+
+		self.assertEqual(len(pos_inv.items), 2)
+		self.assertIsNotNone(pos_inv.items[0].serial_and_batch_bundle)
+		self.assertIsNotNone(pos_inv.items[1].serial_and_batch_bundle)
+		serial_batch_nos1 = frappe.get_doc(
+			"Serial and Batch Bundle", pos_inv.items[0].serial_and_batch_bundle
+		)
+		serial_batch_nos2 = frappe.get_doc(
+			"Serial and Batch Bundle", pos_inv.items[1].serial_and_batch_bundle
+		)
+		batch_qty1 = abs(serial_batch_nos1.entries[0].qty)
+		batch_qty2 = abs(serial_batch_nos2.entries[0].qty)
+		self.assertEqual(abs(pos_inv.items[0].qty), batch_qty1)
+		self.assertEqual(abs(pos_inv.items[1].qty), batch_qty2)
+
+		pos_return = make_sales_return(pos_inv.name)
+		pos_return.insert()
+		pos_return.submit()
+		self.assertIsNotNone(pos_return.items[0].serial_and_batch_bundle)
+		self.assertIsNotNone(pos_return.items[1].serial_and_batch_bundle)
+		return_bundle1 = frappe.get_doc(
+			"Serial and Batch Bundle", pos_return.items[0].serial_and_batch_bundle
+		)
+		return_bundle2 = frappe.get_doc(
+			"Serial and Batch Bundle", pos_return.items[1].serial_and_batch_bundle
+		)
+		self.assertEqual(abs(pos_return.items[0].qty), abs(return_bundle1.entries[0].qty))
+		self.assertEqual(abs(pos_return.items[1].qty), abs(return_bundle2.entries[0].qty))
+
+	def test_pos_item_with_serial_no_and_pricing_rule(self):
+		import frappe
+
+		from erpnext.accounts.doctype.pricing_rule.test_pricing_rule import make_pricing_rule
+
+		item = "_Test Item with Serial No and Pricing Rule"
+		make_item(
+			item,
+			{
+				"is_stock_item": 1,
+				"has_serial_no": 1,
+				"serial_no_series": "SERIAL-.#####",
+			},
+		)
+		make_purchase_receipt(
+			item_code=item, warehouse="_Test Warehouse - _TC", qty=10, rate=500, use_serial_batch_fields=1
+		)
+
+		pr = make_pricing_rule(
+			title="5+1",
+			apply_on="Item Code",
+			item_code=item,
+			selling=1,
+			price_or_product_discount="Product",
+			free_item=item,
+			free_qty=1,
+		)
+		pr.round_free_qty = 1
+		pr.is_recursive = 1
+		pr.recurse_for = 5
+		pr.save()
+
+		pos_inv = create_pos_invoice(
+			update_stock=1, item_code=item, qty=6, rate=500, do_not_submit=1, use_serial_batch_fields=1
+		)
+
+		# Assign serial numbers to the free item (pricing rule auto-adds free item
+		# but serial numbers are auto-fetched only via POS UI, not backend)
+		from erpnext.stock.doctype.serial_no.serial_no import get_serial_nos_for_outward
+
+		for row in pos_inv.items:
+			if row.is_free_item and not row.serial_no:
+				# Collect serial nos already used by other items in the invoice
+				used_serial_nos = []
+				for other_row in pos_inv.items:
+					if other_row.serial_no and other_row.name != row.name:
+						used_serial_nos.extend(other_row.serial_no.split("\n"))
+
+				available_serial_nos = get_serial_nos_for_outward(
+					frappe._dict(
+						{
+							"item_code": row.item_code,
+							"warehouse": row.warehouse or "_Test Warehouse - _TC",
+							"qty": abs(row.stock_qty or row.qty),
+							"based_on": frappe.get_single_value(
+								"Stock Settings", "pick_serial_and_batch_based_on"
+							),
+							"ignore_serial_nos": used_serial_nos,
+						}
+					)
+				)
+				row.serial_no = "\n".join(available_serial_nos[: abs(int(row.qty))])
+				if not row.warehouse:
+					row.warehouse = "_Test Warehouse - _TC"
+
+		pos_inv.payments = []
+		pos_inv.append("payments", {"mode_of_payment": "Cash", "amount": 3000})
+		pos_inv.save()
+		pos_inv.submit()
+		pos_inv.reload()
+
+		self.assertEqual(len(pos_inv.items), 2)
+		self.assertIsNotNone(pos_inv.items[0].serial_and_batch_bundle)
+		self.assertIsNotNone(pos_inv.items[1].serial_and_batch_bundle)
+		serial_batch_nos1 = frappe.get_doc(
+			"Serial and Batch Bundle", pos_inv.items[0].serial_and_batch_bundle
+		)
+		serial_batch_nos2 = frappe.get_doc(
+			"Serial and Batch Bundle", pos_inv.items[1].serial_and_batch_bundle
+		)
+		# For serial number items, each entry has qty=1 (one per serial number)
+		bundle_qty1 = abs(sum(e.qty for e in serial_batch_nos1.entries))
+		bundle_qty2 = abs(sum(e.qty for e in serial_batch_nos2.entries))
+		self.assertEqual(abs(pos_inv.items[0].qty), bundle_qty1)
+		self.assertEqual(abs(pos_inv.items[1].qty), bundle_qty2)
+
+		pos_return = make_sales_return(pos_inv.name)
+		pos_return.insert()
+		pos_return.submit()
+		self.assertIsNotNone(pos_return.items[0].serial_and_batch_bundle)
+		self.assertIsNotNone(pos_return.items[1].serial_and_batch_bundle)
+		return_bundle1 = frappe.get_doc(
+			"Serial and Batch Bundle", pos_return.items[0].serial_and_batch_bundle
+		)
+		return_bundle2 = frappe.get_doc(
+			"Serial and Batch Bundle", pos_return.items[1].serial_and_batch_bundle
+		)
+		return_qty1 = abs(sum(e.qty for e in return_bundle1.entries))
+		return_qty2 = abs(sum(e.qty for e in return_bundle2.entries))
+		self.assertEqual(abs(pos_return.items[0].qty), return_qty1)
+		self.assertEqual(abs(pos_return.items[1].qty), return_qty2)
+
 
 def create_pos_invoice(**args):
 	args = frappe._dict(args)

--- a/erpnext/accounts/doctype/pricing_rule/utils.py
+++ b/erpnext/accounts/doctype/pricing_rule/utils.py
@@ -644,9 +644,11 @@ def get_applied_pricing_rules(pricing_rules):
 
 
 def get_product_discount_rule(pricing_rule, item_details, args=None, doc=None):
+	if args is None:
+		args = frappe._dict()
 	free_item = pricing_rule.free_item
 	if pricing_rule.same_item and pricing_rule.get("apply_on") != "Transaction":
-		free_item = item_details.item_code or args.item_code
+		free_item = item_details.item_code or args.get("item_code")
 
 	if not free_item:
 		frappe.throw(
@@ -656,14 +658,14 @@ def get_product_discount_rule(pricing_rule, item_details, args=None, doc=None):
 		)
 
 	qty = pricing_rule.free_qty or 1
-	if pricing_rule.is_recursive:
+	if pricing_rule.is_recursive and doc:
 		transaction_qty = sum(
 			[
 				row.qty
 				for row in doc.items
 				if not row.is_free_item
-				and row.item_code == args.item_code
-				and row.pricing_rules == args.pricing_rules
+				and row.item_code == args.get("item_code")
+				and row.pricing_rules == args.get("pricing_rules")
 			]
 		)
 		transaction_qty = transaction_qty - pricing_rule.apply_recursion_over

--- a/erpnext/accounts/doctype/pricing_rule/utils.py
+++ b/erpnext/accounts/doctype/pricing_rule/utils.py
@@ -686,6 +686,7 @@ def get_product_discount_rule(pricing_rule, item_details, args=None, doc=None):
 		"is_free_item": 1,
 		"warehouse": args.get("warehouse") or None,
 		"batch_no": args.get("batch_no") or None,
+		"use_serial_batch_fields": 1,
 	}
 
 	item_data = frappe.get_cached_value(

--- a/erpnext/accounts/doctype/pricing_rule/utils.py
+++ b/erpnext/accounts/doctype/pricing_rule/utils.py
@@ -682,6 +682,8 @@ def get_product_discount_rule(pricing_rule, item_details, args=None, doc=None):
 		"rate": pricing_rule.free_item_rate or 0,
 		"price_list_rate": pricing_rule.free_item_rate or 0,
 		"is_free_item": 1,
+		"warehouse": args.get("warehouse") or None,
+		"batch_no": args.get("batch_no") or None,
 	}
 
 	item_data = frappe.get_cached_value(

--- a/erpnext/selling/page/point_of_sale/pos_item_details.js
+++ b/erpnext/selling/page/point_of_sale/pos_item_details.js
@@ -8,6 +8,7 @@ erpnext.PointOfSale.ItemDetails = class {
 		this.allow_warehouse_change = settings.allow_warehouse_change;
 		this.current_item = {};
 		this.frm_doctype = settings.frm_doctype;
+		this.added_serial_nos = [];
 
 		this.init_component();
 	}
@@ -206,7 +207,7 @@ erpnext.PointOfSale.ItemDetails = class {
 			"actual_qty",
 			"price_list_rate",
 		];
-		if (item.has_serial_no || item.serial_no) fields.push("serial_no");
+		if (item.has_serial_no || item.serial_no || item.is_free_item) fields.push("serial_no");
 		if (item.has_batch_no || item.batch_no) fields.push("batch_no");
 		return fields;
 	}
@@ -219,7 +220,7 @@ erpnext.PointOfSale.ItemDetails = class {
 
 	make_auto_serial_selection_btn(item) {
 		const doc = this.events.get_frm().doc;
-		if (!doc.is_return && (item.has_serial_no || item.serial_no)) {
+		if (!doc.is_return && (item.has_serial_no || item.serial_no || item.is_free_item)) {
 			if (!item.has_batch_no) {
 				this.$form_container.append(`<div class="grid-filler no-select"></div>`);
 			}
@@ -428,6 +429,23 @@ erpnext.PointOfSale.ItemDetails = class {
 			let qty = this.qty_control.get_value();
 			let conversion_factor = this.conversion_factor_control.get_value();
 			let expiry_date = this.item_row.has_batch_no ? this.events.get_frm().doc.posting_date : "";
+			this.added_serial_nos = [];
+
+			if (
+				qty ===
+				this.serial_no_control
+					.get_value()
+					.split(`\n`)
+					.filter((s) => s).length
+			) {
+				return;
+			}
+
+			this.events.get_frm().doc.items.forEach((item) => {
+				if (item.name !== this.name) {
+					this.added_serial_nos.push(...(item.serial_no ? item.serial_no.split(`\n`) : []));
+				}
+			});
 
 			let numbers = frappe.call({
 				method: "erpnext.stock.doctype.serial_no.serial_no.auto_fetch_serial_number",
@@ -438,6 +456,7 @@ erpnext.PointOfSale.ItemDetails = class {
 					batch_nos: this.current_item.batch_no || "",
 					posting_date: expiry_date,
 					for_doctype: this.frm_doctype,
+					exclude_sr_nos: this.added_serial_nos || [],
 				},
 			});
 

--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -233,7 +233,7 @@ def update_stock(ctx, out, doc=None):
 
 			for batch_no, batch_qty in batches.items():
 				rate = get_batch_based_item_price(
-					{"price_list": doc.get("selling_price_list"), "uom": out.uom, "batch_no": batch_no},
+					{"price_list": ctx.get("selling_price_list"), "uom": out.uom, "batch_no": batch_no},
 					out.item_code,
 				)
 				if batch_qty >= qty:
@@ -289,11 +289,12 @@ def get_filtered_serial_nos(serial_nos, doc, table=None):
 	if not table:
 		table = "items"
 
-	for row in doc.get(table):
-		if row.get("serial_no"):
-			for serial_no in get_serial_nos(row.get("serial_no")):
-				if serial_no in serial_nos:
-					serial_nos.remove(serial_no)
+	if doc:
+		for row in doc.get(table):
+			if row.get("serial_no"):
+				for serial_no in get_serial_nos(row.get("serial_no")):
+					if serial_no in serial_nos:
+						serial_nos.remove(serial_no)
 
 	return serial_nos
 


### PR DESCRIPTION
**Issue:** While creating the POS Invoice Return, if an item has an applied pricing rule, the system is throwing an error , No serial or Batch contain for return the Item.

**Ref:**[59197](https://support.frappe.io/helpdesk/tickets/59197)

**Description:**
POS Invoice return fails because the free item added by a pricing rule does not have a Batch/Serial Number. The free item should also have a Batch/Serial Number assigned so that the return can proceed normally.


**Step to Reproduce :**
1. Create batch-tracked item.
2. Create pricing rule: Buy 5 Get 1 free.
3. In POS, add 5 qty and select Batch No.
4. Free item is auto-added without Batch No.
5. Submit POS Invoice.
6. Try to return the invoice.

**Actual Behaviour :**
Return fails with error: **No Serial / Batches are available for return.**

**Expected Behaviour :**
Free item should have Batch No assigned, and return should work normally.

**Before :**

[Screencast from 05-02-26 06:29:17 PM IST.webm](https://github.com/user-attachments/assets/207f8027-cb0f-486f-aa79-da809fd8a0d6)

**After :**

[Screencast from 05-02-26 06:27:15 PM IST.webm](https://github.com/user-attachments/assets/3b25d366-de66-498a-a01f-d34511bf27ac)

while debugging the actual issue resolved the following NoneType object error:


1. When clicking a serialized item, a NoneType error was thrown. This has been fixed in utils.py (Line 659).


<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/c3b11bd2-a912-491d-bde7-249b9467d701" />



2.When selecting a serialized item, another NoneType error occurred. This issue has been fixed in get_item_details.py (Line 292).


<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/653774fb-cf1b-4a45-85e7-94fc0c4dece8" />



3.When clicking a batched item, a NoneType error was thrown. This has been fixed in get_item_details.py (Line 236).


<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/23de0292-37c7-41de-b119-f9f89df9e560" />


4. The main fix is related to batch items. Additionally, serial number handling in POS was improved in pos_item_details.js


[Screencast from 19-02-26 08:57:30 AM IST.webm](https://github.com/user-attachments/assets/25b48305-b250-4cc5-a6e0-02fd1435eb1b)

**Backport Needed For V16 and V15**
