### PR TITLE
fix: fetch all entries when finance_book and include_default_book_ent…

### DIFF
--- a/erpnext/accounts/report/financial_statements.py
+++ b/erpnext/accounts/report/financial_statements.py
@@ -626,10 +626,8 @@ def apply_additional_conditions(doctype, query, from_date, ignore_closing_entrie
 				| (gl_entry.finance_book.isnull())
 			)
 		else:
-			query = query.where(
-				(gl_entry.finance_book.isin([cstr(filters.finance_book), ""]))
-				| (gl_entry.finance_book.isnull())
-			)
+			if filters.finance_book:
+				query = query.where(gl_entry.finance_book == cstr(filters.finance_book))
 
 	if accounting_dimensions:
 		for dimension in accounting_dimensions:

--- a/erpnext/accounts/report/trial_balance/trial_balance.py
+++ b/erpnext/accounts/report/trial_balance/trial_balance.py
@@ -249,7 +249,6 @@ def get_opening_balance(
 		.where((closing_balance.company == filters.company) & (closing_balance.account.isin(accounts)))
 		.groupby(closing_balance.account)
 	)
-
 	if not ignore_reporting_currency:
 		opening_balance = opening_balance.select(
 			Sum(closing_balance.debit_in_reporting_currency).as_("debit_in_reporting_currency"),
@@ -309,16 +308,15 @@ def get_opening_balance(
 				frappe.throw(
 					_("To use a different finance book, please uncheck 'Include Default FB Entries'")
 				)
-
 			opening_balance = opening_balance.where(
 				(closing_balance.finance_book.isin([cstr(filters.finance_book), cstr(company_fb), ""]))
 				| (closing_balance.finance_book.isnull())
 			)
 		else:
-			opening_balance = opening_balance.where(
-				(closing_balance.finance_book.isin([cstr(filters.finance_book), ""]))
-				| (closing_balance.finance_book.isnull())
-			)
+			if filters.finance_book:
+				opening_balance = opening_balance.where(
+					closing_balance.finance_book == cstr(filters.finance_book)
+				)
 
 	if accounting_dimensions:
 		for dimension in accounting_dimensions:


### PR DESCRIPTION
**Issue**:
If you create two depreciations ,one with a Finance Book and another without a Finance Book and then check the Trial Balance report:
1. If you do not select a Finance Book in the report filter, the system shows only the value without the Finance Book depreciation.
2. If you select a Finance Book, the system shows both the values (with and without the Finance Book).

**Ref**:[#60386](https://support.frappe.io/helpdesk/tickets/60386)