### PR TITLE
refactor: default to '0'  for standalone cr note and better label

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
@@ -1576,12 +1576,13 @@
    "options": "Supplier Group"
   },
   {
-   "default": "1",
+   "default": "0",
    "depends_on": "eval: doc.is_return && doc.return_against",
-   "description": "Debit Note will update it's own outstanding amount, even if 'Return Against' is specified.",
+   "description": "Check this box if the customer has already paid the original invoice. This will record the return as a separate amount owed to the customer rather than reducing their existing unpaid balance.",
    "fieldname": "update_outstanding_for_self",
    "fieldtype": "Check",
-   "label": "Update Outstanding for Self"
+   "label": "Independent Debit Note",
+   "show_description_on_click": 1
   },
   {
    "fieldname": "sender",
@@ -1689,7 +1690,7 @@
  "idx": 204,
  "is_submittable": 1,
  "links": [],
- "modified": "2026-02-23 13:23:57.269770",
+ "modified": "2026-02-25 16:57:35.047695",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Purchase Invoice",

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.json
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.json
@@ -2114,14 +2114,15 @@
    "options": "Coupon Code"
   },
   {
-   "default": "1",
+   "default": "0",
    "depends_on": "eval: doc.is_return && doc.return_against",
-   "description": "Credit Note will update it's own outstanding amount, even if 'Return Against' is specified.",
+   "description": "Check this box if the customer has already paid the original invoice. This will record the return as a separate amount owed to the customer rather than reducing their existing unpaid balance.",
    "fieldname": "update_outstanding_for_self",
    "fieldtype": "Check",
-   "label": "Update Outstanding for Self",
+   "label": "Independent Credit Note",
    "no_copy": 1,
-   "print_hide": 1
+   "print_hide": 1,
+   "show_description_on_click": 1
   },
   {
    "fieldname": "column_break_imbx",
@@ -2330,7 +2331,7 @@
    "link_fieldname": "consolidated_invoice"
   }
  ],
- "modified": "2026-02-23 13:29:00.301842",
+ "modified": "2026-02-25 16:51:16.360446",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Sales Invoice",

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -184,19 +184,9 @@ class AccountsController(TransactionBase):
 			against_voucher_outstanding = frappe.get_value(
 				self.doctype, self.return_against, "outstanding_amount"
 			)
-			document_type = "Credit Note" if self.doctype == "Sales Invoice" else "Debit Note"
 
 			msg = ""
-			if self.get("update_outstanding_for_self"):
-				msg = _(
-					"We can see {0} is made against {1}. If you want {1}'s outstanding to be updated, uncheck the '{2}' checkbox."
-				).format(
-					frappe.bold(document_type),
-					get_link_to_form(self.doctype, self.get("return_against")),
-					frappe.bold(_("Update Outstanding for Self")),
-				)
-
-			elif not self.update_outstanding_for_self and (
+			if not self.update_outstanding_for_self and (
 				abs(flt(self.rounded_total) or flt(self.grand_total)) > flt(against_voucher_outstanding)
 			):
 				self.update_outstanding_for_self = 1


### PR DESCRIPTION
1. Cr / Dr Note made against parent invoice will by default be reconciled against the parent - opt-in is better than opt-out
2. Better label

todo:
 - [ ] update popup description as well

<img width="2095" height="521" alt="Screenshot from 2026-02-19 12-15-17" src="https://github.com/user-attachments/assets/e59a5387-0cd2-4a61-9516-6cc61a086379" />

