### PR TITLE
fix: bank account mismatch error on reverse transaction reconciliation

### DIFF
--- a/erpnext/accounts/doctype/bank_transaction/bank_transaction.py
+++ b/erpnext/accounts/doctype/bank_transaction/bank_transaction.py
@@ -373,11 +373,12 @@ def get_clearance_details(transaction, payment_entry, bt_allocations, gl_entries
 			("unallocated_amount", "bank_account"),
 			as_dict=True,
 		)
+		bt_bank_account = frappe.db.get_value("Bank Account", bt.bank_account, "account")
 
-		if bt.bank_account != gl_bank_account:
+		if bt_bank_account != gl_bank_account:
 			frappe.throw(
 				_("Bank Account {} in Bank Transaction {} is not matching with Bank Account {}").format(
-					bt.bank_account, payment_entry.payment_entry, gl_bank_account
+					bt_bank_account, payment_entry.payment_entry, gl_bank_account
 				)
 			)
 


### PR DESCRIPTION
**Issue:**
The user is unable to reverse the Bank Transaction from Bank Reconciliation Tool

**Ref:**[#60385](https://support.frappe.io/helpdesk/tickets/60385)

**Steps To Replicate The Issue:**

1. Go to Bank Reconciliation Tool.
2. Select Bank Account - 5XXXXX- Y Bank
3. Select Time Period 
4. Get Unreconciled Entries
5. Click Actions on any one entry.
6. Select Bank Transactions in Filters.
7. Select the reverse Bank Transaction from the List.
8. Click Submit.
