### PR TITLE
fix(sales-order): update quotation status while cancelling sales order

### DIFF
--- a/erpnext/selling/doctype/quotation/test_quotation.py
+++ b/erpnext/selling/doctype/quotation/test_quotation.py
@@ -1002,7 +1002,6 @@ class TestQuotation(IntegrationTestCase):
 
 	def test_quotation_status(self):
 		quotation = make_quotation()
-		quotation.submit()
 
 		so1 = make_sales_order(quotation.name)
 		so1.delivery_date = nowdate()

--- a/erpnext/selling/doctype/quotation/test_quotation.py
+++ b/erpnext/selling/doctype/quotation/test_quotation.py
@@ -1000,6 +1000,32 @@ class TestQuotation(IntegrationTestCase):
 		so1.submit()
 		self.assertRaises(frappe.ValidationError, so2.submit)
 
+	def test_quotation_status(self):
+		quotation = make_quotation()
+		quotation.submit()
+
+		so1 = make_sales_order(quotation.name)
+		so1.delivery_date = nowdate()
+		so1.submit()
+		quotation.reload()
+		self.assertEqual(quotation.status, "Ordered")
+		so1.cancel()
+
+		quotation.reload()
+		self.assertEqual(quotation.status, "Open")
+
+		so2 = make_sales_order(quotation.name)
+		so2.delivery_date = nowdate()
+		so2.items[0].qty = 1
+		so2.submit()
+		quotation.reload()
+		self.assertEqual(quotation.status, "Partially Ordered")
+
+		so2.cancel()
+
+		quotation.reload()
+		self.assertEqual(quotation.status, "Open")
+
 
 def enable_calculate_bundle_price(enable=1):
 	selling_settings = frappe.get_doc("Selling Settings")

--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -531,7 +531,7 @@ class SalesOrder(SellingController):
 			"Unreconcile Payment Entries",
 		)
 		super().on_cancel()
-
+		super().update_prevdoc_status()
 		# Cannot cancel closed SO
 		if self.status == "Closed":
 			frappe.throw(_("Closed order cannot be cancelled. Unclose to cancel."))


### PR DESCRIPTION
**Issue:**
When a Sales Order is created against a Quotation, the Quotation status has not been updated when the sales order is canceled.

**Ref:** [60480](https://support.frappe.io/helpdesk/tickets/60480)

**Before:**

https://github.com/user-attachments/assets/4006a416-21c6-48da-87ed-f66d2a94745a


**After:**

https://github.com/user-attachments/assets/eae66d66-2624-408e-9a72-a9f768cf512b





