### PR TITLE
fix(manufacturing): remove delete query of job card & batch and serial no 

### DIFF
--- a/erpnext/manufacturing/doctype/routing/test_routing.py
+++ b/erpnext/manufacturing/doctype/routing/test_routing.py
@@ -56,7 +56,6 @@ class TestRouting(IntegrationTestCase):
 				self.assertEqual(job_card_doc.total_completed_qty, 10)
 
 		wo_doc.cancel()
-		wo_doc.delete()
 
 	def test_update_bom_operation_time(self):
 		"""Update cost shouldn't update routing times."""

--- a/erpnext/manufacturing/doctype/work_order/work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/work_order.py
@@ -780,7 +780,6 @@ class WorkOrder(Document):
 		self.db_set("status", "Cancelled")
 
 		self.on_close_or_cancel()
-		self.delete_job_card()
 
 	def on_close_or_cancel(self):
 		if self.production_plan and frappe.db.exists(
@@ -1375,10 +1374,6 @@ class WorkOrder(Document):
 	def set_lead_time(self):
 		if self.actual_start_date and self.actual_end_date:
 			self.lead_time = flt(time_diff_in_hours(self.actual_end_date, self.actual_start_date) * 60)
-
-	def delete_job_card(self):
-		for d in frappe.get_all("Job Card", ["name"], {"work_order": self.name}):
-			frappe.delete_doc("Job Card", d.name)
 
 	def validate_production_item(self):
 		if frappe.get_cached_value("Item", self.production_item, "has_variants"):

--- a/erpnext/manufacturing/doctype/work_order/work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/work_order.py
@@ -794,7 +794,6 @@ class WorkOrder(Document):
 		self.update_planned_qty()
 		self.update_ordered_qty()
 		self.update_reserved_qty_for_production()
-		self.delete_auto_created_batch_and_serial_no()
 
 		if self.reserve_stock:
 			self.update_stock_reservation()
@@ -925,13 +924,6 @@ class WorkOrder(Document):
 					}
 				)
 			)
-
-	def delete_auto_created_batch_and_serial_no(self):
-		for row in frappe.get_all("Serial No", filters={"work_order": self.name}):
-			frappe.delete_doc("Serial No", row.name)
-
-		for row in frappe.get_all("Batch", filters={"reference_name": self.name}):
-			frappe.delete_doc("Batch", row.name)
 
 	def make_serial_nos(self, args):
 		item_details = frappe.get_cached_value(


### PR DESCRIPTION
**Issue:**
1. When closing a Work Order, the system attempts to delete the associated serial and batch records, even though they may already be linked to Serial and Batch Bundles.
2. Similarly, when cancelling a Work Order, the system attempts to delete Job Cards that might already been submitted.

**Ref:** [#60420](https://support.frappe.io/helpdesk/tickets/60420)

**Backport Needed for v15 & v16**