### PR TITLE
refactor: `Fiscal Year` cleanup

### DIFF
--- a/erpnext/accounts/doctype/fiscal_year/fiscal_year.py
+++ b/erpnext/accounts/doctype/fiscal_year/fiscal_year.py
@@ -4,7 +4,7 @@
 
 import frappe
 from dateutil.relativedelta import relativedelta
-from frappe import _
+from frappe import _, cint
 from frappe.model.document import Document
 from frappe.utils import add_days, add_years, cstr, getdate
 
@@ -89,15 +89,25 @@ class FiscalYear(Document):
 					)
 
 
-@frappe.whitelist()
 def auto_create_fiscal_year():
-	for d in frappe.db.sql(
-		"""select name from `tabFiscal Year` where year_end_date = date_add(current_date, interval 3 day)"""
-	):
+	fy = frappe.qb.DocType("Fiscal Year")
+
+	# Skipped auto-creating Short Year, as it has very rare use case.
+	# Reference: https://www.irs.gov/businesses/small-businesses-self-employed/tax-years (US)
+	follow_up_date = add_days(getdate(), days=3)
+	fiscal_year = (
+		frappe.qb.from_(fy)
+		.select(fy.name)
+		.where((fy.year_end_date == follow_up_date) & (fy.is_short_year == 0))
+		.run()
+	)
+
+	for d in fiscal_year:
 		try:
 			current_fy = frappe.get_doc("Fiscal Year", d[0])
 
-			new_fy = frappe.copy_doc(current_fy, ignore_no_copy=False)
+			new_fy = frappe.new_doc("Fiscal Year")
+			new_fy.disabled = cint(current_fy.disabled)
 
 			new_fy.year_start_date = add_days(current_fy.year_end_date, 1)
 			new_fy.year_end_date = add_years(current_fy.year_end_date, 1)
@@ -105,6 +115,10 @@ def auto_create_fiscal_year():
 			start_year = cstr(new_fy.year_start_date.year)
 			end_year = cstr(new_fy.year_end_date.year)
 			new_fy.year = start_year if start_year == end_year else (start_year + "-" + end_year)
+
+			for row in current_fy.companies:
+				new_fy.append("companies", {"company": row.company})
+
 			new_fy.auto_created = 1
 
 			new_fy.insert(ignore_permissions=True)

--- a/erpnext/accounts/doctype/fiscal_year/fiscal_year.py
+++ b/erpnext/accounts/doctype/fiscal_year/fiscal_year.py
@@ -33,24 +33,6 @@ class FiscalYear(Document):
 		self.validate_dates()
 		self.validate_overlap()
 
-		if not self.is_new():
-			year_start_end_dates = frappe.db.sql(
-				"""select year_start_date, year_end_date
-				from `tabFiscal Year` where name=%s""",
-				(self.name),
-			)
-
-			if year_start_end_dates:
-				if (
-					getdate(self.year_start_date) != year_start_end_dates[0][0]
-					or getdate(self.year_end_date) != year_start_end_dates[0][1]
-				):
-					frappe.throw(
-						_(
-							"Cannot change Fiscal Year Start Date and Fiscal Year End Date once the Fiscal Year is saved."
-						)
-					)
-
 	def validate_dates(self):
 		self.validate_from_to_dates("year_start_date", "year_end_date")
 		if self.is_short_year:
@@ -66,28 +48,20 @@ class FiscalYear(Document):
 				frappe.exceptions.InvalidDates,
 			)
 
-	def on_update(self):
-		check_duplicate_fiscal_year(self)
-		frappe.cache().delete_value("fiscal_years")
-
-	def on_trash(self):
-		frappe.cache().delete_value("fiscal_years")
-
 	def validate_overlap(self):
-		existing_fiscal_years = frappe.db.sql(
-			"""select name from `tabFiscal Year`
-			where (
-				(%(year_start_date)s between year_start_date and year_end_date)
-				or (%(year_end_date)s between year_start_date and year_end_date)
-				or (year_start_date between %(year_start_date)s and %(year_end_date)s)
-				or (year_end_date between %(year_start_date)s and %(year_end_date)s)
-			) and name!=%(name)s""",
-			{
-				"year_start_date": self.year_start_date,
-				"year_end_date": self.year_end_date,
-				"name": self.name or "No Name",
-			},
-			as_dict=True,
+		fy = frappe.qb.DocType("Fiscal Year")
+
+		name = self.name or self.year
+
+		existing_fiscal_years = (
+			frappe.qb.from_(fy)
+			.select(fy.name)
+			.where(
+				(fy.year_start_date <= self.year_end_date)
+				& (fy.year_end_date >= self.year_start_date)
+				& (fy.name != name)
+			)
+			.run(as_dict=True)
 		)
 
 		if existing_fiscal_years:
@@ -110,26 +84,9 @@ class FiscalYear(Document):
 					frappe.throw(
 						_(
 							"Year start date or end date is overlapping with {0}. To avoid please set company"
-						).format(existing.name),
+						).format(frappe.get_desk_link("Fiscal Year", existing.name, open_in_new_tab=True)),
 						frappe.NameError,
 					)
-
-
-@frappe.whitelist()
-def check_duplicate_fiscal_year(doc):
-	year_start_end_dates = frappe.db.sql(
-		"""select name, year_start_date, year_end_date from `tabFiscal Year` where name!=%s""",
-		(doc.name),
-	)
-	for fiscal_year, ysd, yed in year_start_end_dates:
-		if (getdate(doc.year_start_date) == ysd and getdate(doc.year_end_date) == yed) and (
-			not frappe.in_test
-		):
-			frappe.throw(
-				_(
-					"Fiscal Year Start Date and Fiscal Year End Date are already set in Fiscal Year {0}"
-				).format(fiscal_year)
-			)
 
 
 @frappe.whitelist()

--- a/erpnext/accounts/doctype/fiscal_year_company/fiscal_year_company.json
+++ b/erpnext/accounts/doctype/fiscal_year_company/fiscal_year_company.json
@@ -15,18 +15,20 @@
    "ignore_user_permissions": 1,
    "in_list_view": 1,
    "label": "Company",
-   "options": "Company"
+   "options": "Company",
+   "reqd": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-03-27 13:09:44.659251",
+ "modified": "2026-02-20 23:02:26.193606",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Fiscal Year Company",
  "owner": "Administrator",
  "permissions": [],
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],

--- a/erpnext/accounts/doctype/fiscal_year_company/fiscal_year_company.py
+++ b/erpnext/accounts/doctype/fiscal_year_company/fiscal_year_company.py
@@ -14,7 +14,7 @@ class FiscalYearCompany(Document):
 	if TYPE_CHECKING:
 		from frappe.types import DF
 
-		company: DF.Link | None
+		company: DF.Link
 		parent: DF.Data
 		parentfield: DF.Data
 		parenttype: DF.Data

--- a/erpnext/accounts/notification/notification_for_new_fiscal_year/notification_for_new_fiscal_year.html
+++ b/erpnext/accounts/notification/notification_for_new_fiscal_year/notification_for_new_fiscal_year.html
@@ -1,3 +1,43 @@
-<h3>{{ _("Fiscal Year") }}</h3>
+<h4>{{ _("New Fiscal Year - {0}").format(doc.name) }}</h4>
 
-<p>{{ _("New fiscal year created :- ") }} {{ doc.name }}</p>
+<p>{{ _("A new fiscal year has been automatically created.") }}</p>
+
+<p>{{ _("Fiscal Year Details") }}</p>
+
+<table style="margin-bottom: 1rem; width: 70%">
+    <tr>
+        <td style="font-weight:bold; width: 40%">{{ _("Year Name") }}</td>
+        <td>{{ doc.name }}</td>
+    </tr>
+    <tr>
+        <td style="font-weight:bold; width: 40%">{{ _("Start Date") }}</td>
+        <td>{{ frappe.format_value(doc.year_start_date) }}</td>
+    </tr>
+    <tr>
+        <td style="font-weight:bold; width: 40%">{{ _("End Date") }}</td>
+        <td>{{ frappe.format_value(doc.year_end_date) }}</td>
+    </tr>
+    {% if doc.companies|length > 0 %}
+    <tr>
+        <td style="vertical-align: top; font-weight: bold; width: 40%" rowspan="{{ doc.companies|length }}">
+        {% if doc.companies|length < 2 %}
+            {{ _("Company") }}
+        {% else %}
+            {{ _("Companies") }}
+        {% endif %}
+        </td>
+        <td>{{ doc.companies[0].company }}</td>
+    </tr>
+    {% for idx in range(1, doc.companies|length) %}
+    <tr>
+        <td>{{ doc.companies[idx].company }}</td>
+    </tr>
+    {% endfor %}
+    {% endif %}
+</table>
+
+{% if doc.disabled %}
+<p>{{ _("The fiscal year has been automatically created in a Disabled state to maintain consistency with the previous fiscal year's status.") }}</p>
+{% endif %}
+
+<p>{{ _("Please review the {0} configuration and complete any required financial setup activities.").format(frappe.utils.get_link_to_form("Fiscal Year", doc.name, frappe.bold("Fiscal Year"))) }}</p>

--- a/erpnext/accounts/notification/notification_for_new_fiscal_year/notification_for_new_fiscal_year.json
+++ b/erpnext/accounts/notification/notification_for_new_fiscal_year/notification_for_new_fiscal_year.json
@@ -1,7 +1,8 @@
 {
  "attach_print": 0,
  "channel": "Email",
- "condition": "doc.auto_created",
+ "condition": "doc.auto_created == 1",
+ "condition_type": "Python",
  "creation": "2018-04-25 14:19:05.440361",
  "days_in_advance": 0,
  "docstatus": 0,
@@ -11,8 +12,10 @@
  "event": "New",
  "idx": 0,
  "is_standard": 1,
+ "message": "<h4>{{ _(\"New Fiscal Year - {0}\").format(doc.name) }}</h4>\n\n<p>{{ _(\"A new fiscal year has been automatically created.\") }}</p>\n\n<p>{{ _(\"Fiscal Year Details\") }}</p>\n\n<table style=\"margin-bottom: 1rem; width: 70%\">\n    <tr>\n        <td style=\"font-weight:bold; width: 40%\">{{ _(\"Year Name\") }}</td>\n        <td>{{ doc.name }}</td>\n    </tr>\n    <tr>\n        <td style=\"font-weight:bold; width: 40%\">{{ _(\"Start Date\") }}</td>\n        <td>{{ frappe.format_value(doc.year_start_date) }}</td>\n    </tr>\n    <tr>\n        <td style=\"font-weight:bold; width: 40%\">{{ _(\"End Date\") }}</td>\n        <td>{{ frappe.format_value(doc.year_end_date) }}</td>\n    </tr>\n    {% if doc.companies|length > 0 %}\n    <tr>\n        <td style=\"vertical-align: top; font-weight: bold; width: 40%\" rowspan=\"{{ doc.companies|length }}\">\n        {% if doc.companies|length < 2 %}\n            {{ _(\"Company\") }}\n        {% else %}\n            {{ _(\"Companies\") }}\n        {% endif %}\n        </td>\n        <td>{{ doc.companies[0].company }}</td>\n    </tr>\n    {% for idx in range(1, doc.companies|length) %}\n    <tr>\n        <td>{{ doc.companies[idx].company }}</td>\n    </tr>\n    {% endfor %}\n    {% endif %}\n</table>\n\n{% if doc.disabled %}\n<p>{{ _(\"The fiscal year has been automatically created in a Disabled state to maintain consistency with the previous fiscal year's status.\") }}</p>\n{% endif %}\n\n<p>{{ _(\"Please review the {0} configuration and complete any required financial setup activities.\").format(frappe.utils.get_link_to_form(\"Fiscal Year\", doc.name, frappe.bold(\"Fiscal Year\"))) }}</p>",
  "message_type": "HTML",
- "modified": "2023-11-17 08:54:51.532104",
+ "minutes_offset": 0,
+ "modified": "2026-02-21 12:14:54.736795",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Notification for new fiscal year",
@@ -27,5 +30,5 @@
  ],
  "send_system_notification": 0,
  "send_to_all_assignees": 0,
- "subject": "Notification for new fiscal year {{ doc.name }}"
+ "subject": "{{ _(\"New Fiscal Year {0} - Review Required\").format(doc.name) }}"
 }


### PR DESCRIPTION
Changes include:
- Cleaned up Controller Methods, which Framework handles.
- Made the `company` field mandatory on `Fiscal Year Company` as it was allowing to save overlapping Fiscal Year just by adding a row without adding a Company on the "companies" child table.
- Auto-generate Fiscal Year
	- Maintaining a consistent state of the new Fiscal Year compared to the previous one.
	- Disabled creating a new Fiscal Year for short FY, as it has a very rare use case.
	- Better email content for auto-generated `Fiscal Year`.
