### PR TITLE
fix: `update_stock` behaviour on selling invoices

### DIFF
--- a/erpnext/accounts/doctype/pos_invoice/pos_invoice.json
+++ b/erpnext/accounts/doctype/pos_invoice/pos_invoice.json
@@ -60,7 +60,6 @@
   "sec_warehouse",
   "set_warehouse",
   "items_section",
-  "update_stock",
   "scan_barcode",
   "last_scanned_warehouse",
   "items",
@@ -574,7 +573,6 @@
    "label": "Warehouse"
   },
   {
-   "depends_on": "update_stock",
    "fieldname": "set_warehouse",
    "fieldtype": "Link",
    "label": "Source Warehouse",
@@ -587,15 +585,6 @@
    "label": "Items",
    "oldfieldtype": "Section Break",
    "options": "fa fa-shopping-cart"
-  },
-  {
-   "default": "0",
-   "fieldname": "update_stock",
-   "fieldtype": "Check",
-   "label": "Update Stock",
-   "oldfieldname": "update_stock",
-   "oldfieldtype": "Check",
-   "print_hide": 1
   },
   {
    "fieldname": "scan_barcode",
@@ -1582,7 +1571,7 @@
  "icon": "fa fa-file-text",
  "is_submittable": 1,
  "links": [],
- "modified": "2025-08-04 22:22:31.471752",
+ "modified": "2026-02-22 04:18:50.691218",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "POS Invoice",
@@ -1627,6 +1616,7 @@
    "role": "All"
   }
  ],
+ "row_format": "Dynamic",
  "search_fields": "posting_date, due_date, customer, base_grand_total, outstanding_amount",
  "show_name_in_global_search": 1,
  "sort_field": "modified",

--- a/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
+++ b/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
@@ -183,7 +183,6 @@ class POSInvoice(SalesInvoice):
 		total_taxes_and_charges: DF.Currency
 		update_billed_amount_in_delivery_note: DF.Check
 		update_billed_amount_in_sales_order: DF.Check
-		update_stock: DF.Check
 		write_off_account: DF.Link | None
 		write_off_amount: DF.Currency
 		write_off_cost_center: DF.Link | None
@@ -652,7 +651,6 @@ class POSInvoice(SalesInvoice):
 				"tax_category",
 				"ignore_pricing_rule",
 				"company_address",
-				"update_stock",
 			):
 				if not for_validate:
 					self.set(fieldname, profile.get(fieldname))

--- a/erpnext/accounts/doctype/pos_invoice/test_pos_invoice.py
+++ b/erpnext/accounts/doctype/pos_invoice/test_pos_invoice.py
@@ -1101,7 +1101,6 @@ def create_pos_invoice(**args):
 
 	pos_inv = frappe.new_doc("POS Invoice")
 	pos_inv.update(args)
-	pos_inv.update_stock = 1
 	pos_inv.is_pos = 1
 	pos_inv.pos_profile = args.pos_profile or pos_profile.name
 

--- a/erpnext/accounts/doctype/pos_invoice_merge_log/pos_invoice_merge_log.py
+++ b/erpnext/accounts/doctype/pos_invoice_merge_log/pos_invoice_merge_log.py
@@ -146,6 +146,7 @@ class POSInvoiceMergeLog(Document):
 
 		sales_invoice.is_consolidated = 1
 		sales_invoice.set_posting_time = 1
+		sales_invoice.update_stock = 1
 
 		if not sales_invoice.posting_date:
 			sales_invoice.posting_date = getdate(self.posting_date)
@@ -174,6 +175,7 @@ class POSInvoiceMergeLog(Document):
 
 			credit_note.is_consolidated = 1
 			credit_note.set_posting_time = 1
+			credit_note.update_stock = 1
 			credit_note.posting_date = getdate(self.posting_date)
 			credit_note.posting_time = get_time(self.posting_time)
 			# TODO: return could be against multiple sales invoice which could also have been consolidated?

--- a/erpnext/accounts/doctype/pos_profile/pos_profile.json
+++ b/erpnext/accounts/doctype/pos_profile/pos_profile.json
@@ -25,7 +25,6 @@
   "validate_stock_on_save",
   "print_receipt_on_order_complete",
   "column_break_16",
-  "update_stock",
   "ignore_pricing_rule",
   "allow_rate_change",
   "allow_discount_change",
@@ -297,7 +296,6 @@
    "options": "Print Format"
   },
   {
-   "depends_on": "update_stock",
    "fieldname": "warehouse",
    "fieldtype": "Link",
    "label": "Warehouse",
@@ -311,14 +309,6 @@
    "fieldname": "ignore_pricing_rule",
    "fieldtype": "Check",
    "label": "Ignore Pricing Rule"
-  },
-  {
-   "default": "1",
-   "fieldname": "update_stock",
-   "fieldtype": "Check",
-   "hidden": 1,
-   "label": "Update Stock",
-   "read_only": 1
   },
   {
    "default": "0",
@@ -432,7 +422,7 @@
    "link_fieldname": "pos_profile"
   }
  ],
- "modified": "2025-04-14 15:58:20.497426",
+ "modified": "2026-02-22 04:17:03.308876",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "POS Profile",

--- a/erpnext/accounts/doctype/pos_profile/pos_profile.py
+++ b/erpnext/accounts/doctype/pos_profile/pos_profile.py
@@ -61,7 +61,6 @@ class POSProfile(Document):
 		tax_category: DF.Link | None
 		taxes_and_charges: DF.Link | None
 		tc_name: DF.Link | None
-		update_stock: DF.Check
 		validate_stock_on_save: DF.Check
 		warehouse: DF.Link
 		write_off_account: DF.Link

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -854,9 +854,6 @@ class SalesInvoice(SellingController):
 			if selling_price_list:
 				self.set("selling_price_list", selling_price_list)
 
-			if not for_validate:
-				self.update_stock = cint(pos.get("update_stock"))
-
 			# set pos values in items
 			for item in self.get("items"):
 				if item.get("item_code"):
@@ -1097,7 +1094,9 @@ class SalesInvoice(SellingController):
 			d.projected_qty = bin and flt(bin[0]["projected_qty"]) or 0
 
 	def update_packing_list(self):
-		if cint(self.update_stock) == 1:
+		if self.doctype == "POS Invoice" or (
+			self.doctype == "Sales Invoice" and cint(self.update_stock) == 1
+		):
 			from erpnext.stock.doctype.packed_item.packed_item import make_packing_list
 
 			make_packing_list(self)


### PR DESCRIPTION
Removed `update_stock` field from `POS Invoice` and `POS Profile` as Stock Ledger is hit during consolidation of POS Invoices. 

This also affects the `Sales Invoice`. If a `Sales Invoice` included Payment, it used to automatically fetch the value of `update_stock` from the `POS Profile` where it was enabled, and hidden. The previous behaviour was not ideal from a UX POV. Instead, users should get the option to enable or disable `update_stock`, as selecting `POS Profile` on `Sales Invoice` should fetch accounting details and Payment Mode details.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Removed the "Update Stock" configuration from POS Invoice and POS Profile interfaces.
  * POS Invoice layout now uses dynamic row formatting.

* **Bug Fixes / Behavior Changes**
  * Consolidated sales invoices created via merge now enable stock updates automatically.
  * Packing list generation adjusted: POS Invoices always generate packing lists when applicable; Sales Invoices generate them only when stock updates are enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->