### PR TITLE
fix: set default user in get_pos_invoices function

### DIFF
--- a/erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.py
+++ b/erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.py
@@ -152,7 +152,9 @@ def get_cashiers(doctype, txt, searchfield, start, page_len, filters):
 
 
 @frappe.whitelist()
-def get_pos_invoices(start, end, pos_profile, user):
+def get_pos_invoices(start, end, pos_profile, user=None):
+	if not user:
+		user = frappe.session.user
 	data = frappe.db.sql(
 		"""
 	select


### PR DESCRIPTION
The POS closing entry UI calls get_pos_invoices without a `user` argument, causing a TypeError. Made `user` optional and fall back to frappe.session.user."
