### PR TITLE
fix(work_order): update returned qty on work order

### DIFF
--- a/erpnext/manufacturing/doctype/work_order/work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/work_order.py
@@ -557,7 +557,7 @@ class WorkOrder(Document):
 			if status != self.status:
 				self.db_set("status", status)
 
-			self.update_required_items()
+		self.update_required_items()
 
 		return status or self.status
 


### PR DESCRIPTION
Issue: Returned quantity is not updating in a closed Work Order

Ref: [60562](https://support.frappe.io/helpdesk/tickets/60562)

Description :  
In the Work Order, the quantity has been partially transferred for finished goods. For example, out of 10 quantity, 6 quantities have been completed, and the Work Order status was manually set to Closed. After creating a return entry, the returned quantity is not updating in the Required Items table of the Work Order.

Before:

[Screencast from 23-02-26 01:45:20 PM IST.webm](https://github.com/user-attachments/assets/e4f2abc2-63d8-491c-917f-0239cf20fdb6)

After :

[Screencast from 23-02-26 01:42:59 PM IST.webm](https://github.com/user-attachments/assets/98697ff0-2834-48c1-ad80-580e4d8bbfff)

Backport needed For V16 and V15