### PR TITLE
feat: default letterhead and print format

### DIFF
--- a/erpnext/accounts/doctype/process_statement_of_accounts/test_process_statement_of_accounts.py
+++ b/erpnext/accounts/doctype/process_statement_of_accounts/test_process_statement_of_accounts.py
@@ -18,7 +18,18 @@ class TestProcessStatementOfAccounts(AccountsTestMixin, IntegrationTestCase):
 	@classmethod
 	def setUpClass(cls):
 		super().setUpClass()
+		letterhead = frappe.get_doc("Letter Head", "Company Letterhead - Grey")
+		letterhead.is_default = 0
+		letterhead.save()
 		cls.enterClassContext(cls.change_settings("Selling Settings", validate_selling_price=0))
+
+	@classmethod
+	def tearDownClass(cls):
+		super().tearDownClass()
+		letterhead = frappe.get_doc("Letter Head", "Company Letterhead - Grey")
+		letterhead.is_default = 1
+		letterhead.save()
+		frappe.db.commit()  # nosemgrep
 
 	def setUp(self):
 		self.create_company()

--- a/erpnext/setup/install.py
+++ b/erpnext/setup/install.py
@@ -35,6 +35,7 @@ def after_install():
 	update_roles()
 	make_default_operations()
 	update_pegged_currencies()
+	set_default_print_formats()
 	create_letter_head()
 	frappe.db.commit()
 
@@ -301,6 +302,31 @@ def update_pegged_currencies():
 	doc.save()
 
 
+def set_default_print_formats():
+	default_map = {
+		"Sales Order": "Sales Order with Item Image",
+		"Sales Invoice": "Sales Invoice with Item Image",
+		"Delivery Note": "Delivery Note with Item Image",
+		"Purchase Order": "Purchase Order with Item Image",
+		"Purchase Invoice": "Purchase Invoice with Item Image",
+		"POS Invoice": "POS Invoice with Item Image",
+	}
+
+	for doctype, print_format in default_map.items():
+		if frappe.get_meta(doctype).default_print_format:
+			continue
+
+		frappe.make_property_setter(
+			{
+				"doctype": doctype,
+				"doctype_or_field": "DocType",
+				"property": "default_print_format",
+				"value": print_format,
+			},
+			validate_fields_for_doctype=False,
+		)
+
+
 def create_letter_head():
 	base_path = frappe.get_app_path("erpnext", "accounts", "letterhead")
 
@@ -318,6 +344,7 @@ def create_letter_head():
 					"letter_head_name": name,
 					"source": "HTML",
 					"content": content,
+					"is_default": 1 if name == "Company Letterhead - Grey" else 0,
 				}
 			)
 			doc.insert(ignore_permissions=True)

--- a/erpnext/setup/install.py
+++ b/erpnext/setup/install.py
@@ -345,7 +345,7 @@ def create_letter_head():
 					"letter_head_name": name,
 					"source": "HTML",
 					"content": content,
-					"is_default": 1 if name == "Company Letterhead - Grey" else 0,
+					"is_default": 1 if name == "Company Letterhead" else 0,
 				}
 			)
 			doc.insert(ignore_permissions=True)

--- a/erpnext/setup/install.py
+++ b/erpnext/setup/install.py
@@ -322,6 +322,7 @@ def set_default_print_formats():
 				"doctype_or_field": "DocType",
 				"property": "default_print_format",
 				"value": print_format,
+				"property_type": "Link",
 			},
 			validate_fields_for_doctype=False,
 		)

--- a/erpnext/setup/install.py
+++ b/erpnext/setup/install.py
@@ -316,6 +316,9 @@ def set_default_print_formats():
 		if frappe.get_meta(doctype).default_print_format:
 			continue
 
+		if not frappe.db.exists("Print Format", print_format):
+			continue
+
 		frappe.make_property_setter(
 			{
 				"doctype": doctype,
@@ -345,7 +348,7 @@ def create_letter_head():
 					"letter_head_name": name,
 					"source": "HTML",
 					"content": content,
-					"is_default": 1 if name == "Company Letterhead" else 0,
+					"is_default": 1 if name == "Company Letterhead - Grey" else 0,
 				}
 			)
 			doc.insert(ignore_permissions=True)


### PR DESCRIPTION
#### TL;DR
This PR sets default print formats for key selling and buying documents during installation and ensures a default letterhead is created and configured properly.

---


#### 1. Default Print Formats on Install

Adds `set_default_print_formats()` in `after_install()` to set default print formats (only if not already configured) for:

- Sales Order  
- Sales Invoice  
- Delivery Note  
- Purchase Order  
- Purchase Invoice  
- POS Invoice  

#### 2. Default Letterhead Configuration

Updates `create_letter_head()` to:

- Create standard letterheads if they do not exist
- Set **"Company Letterhead - Grey"** as the default on fresh install

no-docs