### PR TITLE
fix: skip empty dimension values in exchange gain loss

### DIFF
--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -500,7 +500,8 @@ def _build_dimensions_dict_for_exc_gain_loss(
 	dimensions_dict = frappe._dict()
 	if entry and active_dimensions:
 		for dim in active_dimensions:
-			dimensions_dict[dim.fieldname] = entry.get(dim.fieldname)
+			if entry_dimension := entry.get(dim.fieldname):
+				dimensions_dict[dim.fieldname] = entry_dimension
 	return dimensions_dict
 
 


### PR DESCRIPTION
Issue:
Unable to perform Payment Reconciliation when creating the Exchange Gain/Loss Journal Entry. If the corresponding payment does not have a Cost Center set, the system throws an `Accounting Dimension Required` error.

This error occurs even when a default Cost Center is configured at the Company level.

Ref: [#60621](https://support.frappe.io/helpdesk/tickets/60621)

Steps to Reproduce:

1. Create a Purchase Invoice for a USD supplier, Exchange rate: 50, Amount: 10 USD, Base amount: 500

2. Create a Journal Entry for the same supplier, Exchange rate: 100, Amount: 10 USD, Base amount: 1000 do NOT set any accounting dimensions (like Cost Center).

3. Go to Payment Reconciliation and try to reconcile the Purchase Invoice and the Journal Entry.

Error:

<img width="632" height="212" alt="image" src="https://github.com/user-attachments/assets/0d9e942e-e31a-4c92-8dcd-86910dec849e" />


Backport needed: v16, v15