### PR TITLE
fix(taxes_and_totals): apply conversion_rate to taxable_amount in get_itemised_tax

### DIFF
--- a/erpnext/controllers/taxes_and_totals.py
+++ b/erpnext/controllers/taxes_and_totals.py
@@ -1289,7 +1289,8 @@ def get_itemised_tax(doc, with_tax_account=False):
 		)
 
 		tax_info.tax_amount += flt(row.amount, precision)
-		tax_info.taxable_amount += flt(row.taxable_amount, precision)
+		conversion_rate = doc.conversion_rate or 1
+		tax_info.taxable_amount += flt(row.taxable_amount / conversion_rate, precision)
 
 		if with_tax_account:
 			tax_info.tax_account = tax.account_head


### PR DESCRIPTION
**Issue:** In multi-currency transactions, when tax is applied, the Tax Breakup table shows amounts in base currency instead of the transaction currency.

**Ref:** [#60940](https://support.frappe.io/helpdesk/tickets/60940)

**Before:**

<img width="1880" height="950" alt="Screenshot from 2026-02-24 14-09-34" src="https://github.com/user-attachments/assets/b293e6b0-3796-4fd8-9a60-01b6b0a8af19" />

**After:**

<img width="1880" height="950" alt="Screenshot from 2026-02-24 14-09-06" src="https://github.com/user-attachments/assets/703dab61-e326-428e-9c3a-5eacf753dec2" />

