### PR TITLE
fix: update type hint for party parameter to allow None in get_party_details and set_taxes functions

### DIFF
--- a/erpnext/accounts/doctype/tax_rule/tax_rule.py
+++ b/erpnext/accounts/doctype/tax_rule/tax_rule.py
@@ -135,7 +135,7 @@ class TaxRule(Document):
 
 
 @frappe.whitelist()
-def get_party_details(party: str, party_type: str, args: dict | None = None):
+def get_party_details(party: str | None, party_type: str, args: dict | None = None):
 	out = {}
 	billing_address, shipping_address = None, None
 	if args:

--- a/erpnext/accounts/party.py
+++ b/erpnext/accounts/party.py
@@ -719,7 +719,7 @@ def get_address_tax_category(
 
 @frappe.whitelist()
 def set_taxes(
-	party: str,
+	party: str | None,
 	party_type: str,
 	posting_date: str | date | None,
 	company: str | None,


### PR DESCRIPTION
Issue: lead doctype uses set_taxes without party.
Ref: https://github.com/frappe/erpnext/pull/52910
https://github.com/frappe/erpnext/blob/7ef187b1eb34313d82e9b08abf261f002f627f3d/erpnext/crm/doctype/lead/lead.py#L469-L479
