### PR TITLE
fix: ensure cache is cleared on fiscal year update and trash

### DIFF
--- a/erpnext/accounts/doctype/fiscal_year/fiscal_year.py
+++ b/erpnext/accounts/doctype/fiscal_year/fiscal_year.py
@@ -33,6 +33,12 @@ class FiscalYear(Document):
 		self.validate_dates()
 		self.validate_overlap()
 
+	def on_update(self):
+		frappe.cache().delete_key("fiscal_years")
+
+	def on_trash(self):
+		frappe.cache().delete_key("fiscal_years")
+
 	def validate_dates(self):
 		self.validate_from_to_dates("year_start_date", "year_end_date")
 		if self.is_short_year:


### PR DESCRIPTION
Issue: incorrect fiscal year data, even after the fiscal year is created, because the cache was not updated.
regression: https://github.com/frappe/erpnext/pull/52842


Failing IC Test: https://github.com/resilient-tech/india-compliance/actions/runs/22399449482/job/64841686006?pr=4036


