### PR TITLE
fix: correct get linked payments type hint in bank reconcilliation tool

### DIFF
--- a/erpnext/accounts/doctype/bank_reconciliation_tool/bank_reconciliation_tool.py
+++ b/erpnext/accounts/doctype/bank_reconciliation_tool/bank_reconciliation_tool.py
@@ -492,7 +492,7 @@ def reconcile_vouchers(bank_transaction_name: str, vouchers: str):
 @frappe.whitelist()
 def get_linked_payments(
 	bank_transaction_name: str,
-	document_types: list[str] | None = None,
+	document_types: str | list[str] | None = None,
 	from_date: str | date | None = None,
 	to_date: str | date | None = None,
 	filter_by_reference_date: bool | None = None,


### PR DESCRIPTION
ref #52732 

<img width="478" height="121" alt="Screenshot 2026-02-26 at 2 16 04 AM" src="https://github.com/user-attachments/assets/ac5268d8-c917-42d7-9947-3bb63189aafb" />

breaks the existing function 