### PR TITLE
Fix the global default distance setting for non English systems in version V16

### DIFF
--- a/erpnext/setup/doctype/global_defaults/global_defaults.js
+++ b/erpnext/setup/doctype/global_defaults/global_defaults.js
@@ -17,7 +17,7 @@ frappe.ui.form.on("Global Defaults", {
 			method: "frappe.client.get_list",
 			args: {
 				doctype: "UOM Conversion Factor",
-				filters: { category: __("Length") },
+				filters: { category: "Length" },
 				fields: ["to_uom"],
 				limit_page_length: 500,
 			},


### PR DESCRIPTION
This bug is not unique to Chinese, but can be triggered in all non English environments - French will be translated as "Longueur", German as "L ä nge", Japanese as "long さ", none of which can find the "Length" in the database.