### PR TITLE
fix: fetch correct values from payment references

### DIFF
--- a/erpnext/accounts/doctype/payment_request/payment_request.py
+++ b/erpnext/accounts/doctype/payment_request/payment_request.py
@@ -378,6 +378,7 @@ class PaymentRequest(Document):
 			bank_amount=bank_amount,
 			created_from_payment_request=True,
 		)
+		payment_entry.set_missing_ref_details(force=True)
 
 		payment_entry.update(
 			{
@@ -955,6 +956,7 @@ def resend_payment_email(docname: str):
 @frappe.whitelist()
 def make_payment_entry(docname: str):
 	doc = frappe.get_doc("Payment Request", docname)
+
 	return doc.create_payment_entry(submit=False).as_dict()
 
 


### PR DESCRIPTION
**Issue:**
Invoice shows an outstanding balance of 500 and a Payment Request for 400 was submitted to settle the payment. 
and clicks Create Payment Entry from that Payment Request to make the payment. At that time, in the Payment Entry form, under the Payment References table, the Grand Total should show the invoice amount 500.00, but instead it shows only the paid amount from the Payment Request 400. 

**Ref:**[#59516](https://support.frappe.io/helpdesk/tickets/59516)


