### PR TITLE
fix: `Trial Balance` and `Consolidated Trial Balance` total row calculation

### DIFF
--- a/erpnext/accounts/report/consolidated_trial_balance/consolidated_trial_balance.js
+++ b/erpnext/accounts/report/consolidated_trial_balance/consolidated_trial_balance.js
@@ -87,6 +87,12 @@ frappe.query_reports["Consolidated Trial Balance"] = {
 			default: 1,
 		},
 		{
+			fieldname: "show_net_values",
+			label: __("Show net values in opening and closing columns"),
+			fieldtype: "Check",
+			default: 1,
+		},
+		{
 			fieldname: "show_group_accounts",
 			label: __("Show Group Accounts"),
 			fieldtype: "Check",

--- a/erpnext/accounts/report/consolidated_trial_balance/consolidated_trial_balance.py
+++ b/erpnext/accounts/report/consolidated_trial_balance/consolidated_trial_balance.py
@@ -14,6 +14,7 @@ from erpnext.accounts.report.financial_statements import (
 )
 from erpnext.accounts.report.trial_balance.trial_balance import (
 	accumulate_values_into_parents,
+	calculate_total_row,
 	calculate_values,
 	get_opening_balances,
 	hide_group_accounts,
@@ -44,7 +45,6 @@ def execute(filters: dict | None = None):
 
 def validate_filters(filters):
 	validate_companies(filters)
-	filters.show_net_values = True
 	tb_validate_filters(filters)
 
 
@@ -99,15 +99,19 @@ def get_data(filters) -> list[list]:
 		tb_data = get_company_wise_tb_data(company_filter, reporting_currency, ignore_reporting_currency)
 		consolidate_trial_balance_data(data, tb_data)
 
-	for d in data:
-		prepare_opening_closing(d)
-
-	total_row = calculate_total_row(data, reporting_currency)
-
-	data.extend([{}, total_row])
+	if filters.get("show_net_values"):
+		prepare_opening_closing_for_ctb(data)
 
 	if not filters.get("show_group_accounts"):
 		data = hide_group_accounts(data)
+
+	total_row = calculate_total_row(
+		data, reporting_currency, show_group_accounts=filters.get("show_group_accounts")
+	)
+
+	calculate_foreign_currency_translation_reserve(total_row, data, filters=filters)
+
+	data.extend([total_row])
 
 	if filters.get("presentation_currency"):
 		update_to_presentation_currency(
@@ -207,10 +211,6 @@ def prepare_companywise_tb_data(accounts, filters, parent_children_map, reportin
 	data = []
 
 	for d in accounts:
-		# Prepare opening closing for group account
-		if parent_children_map.get(d.account) and filters.get("show_net_values"):
-			prepare_opening_closing(d)
-
 		has_value = False
 		row = {
 			"account": d.name,
@@ -242,35 +242,9 @@ def prepare_companywise_tb_data(accounts, filters, parent_children_map, reportin
 	return data
 
 
-def calculate_total_row(data, reporting_currency):
-	total_row = {
-		"account": "'" + _("Total") + "'",
-		"account_name": "'" + _("Total") + "'",
-		"warn_if_negative": True,
-		"opening_debit": 0.0,
-		"opening_credit": 0.0,
-		"debit": 0.0,
-		"credit": 0.0,
-		"closing_debit": 0.0,
-		"closing_credit": 0.0,
-		"parent_account": None,
-		"indent": 0,
-		"has_value": True,
-		"currency": reporting_currency,
-	}
-
-	for d in data:
-		if not d.get("parent_account"):
-			for field in value_fields:
-				total_row[field] += d[field]
-
-	if data:
-		calculate_foreign_currency_translation_reserve(total_row, data)
-
-	return total_row
-
-
-def calculate_foreign_currency_translation_reserve(total_row, data):
+def calculate_foreign_currency_translation_reserve(total_row, data, filters):
+	if not data or not total_row:
+		return
 	opening_dr_cr_diff = total_row["opening_debit"] - total_row["opening_credit"]
 	dr_cr_diff = total_row["debit"] - total_row["credit"]
 
@@ -289,7 +263,7 @@ def calculate_foreign_currency_translation_reserve(total_row, data):
 		"root_type": data[idx].get("root_type"),
 		"account_type": "Equity",
 		"parent_account": data[idx].get("account"),
-		"indent": data[idx].get("indent") + 1,
+		"indent": data[idx].get("indent") + 1 if filters.get("show_group_accounts") else 0,
 		"has_value": True,
 		"currency": total_row.get("currency"),
 	}
@@ -297,7 +271,8 @@ def calculate_foreign_currency_translation_reserve(total_row, data):
 	fctr_row["closing_debit"] = fctr_row["opening_debit"] + fctr_row["debit"]
 	fctr_row["closing_credit"] = fctr_row["opening_credit"] + fctr_row["credit"]
 
-	prepare_opening_closing(fctr_row)
+	if filters.get("show_net_values"):
+		prepare_opening_closing(fctr_row)
 
 	data.insert(idx + 1, fctr_row)
 
@@ -394,6 +369,11 @@ def update_to_presentation_currency(data, from_currency, to_currency, date, igno
 				if d.get(field):
 					d[field] = d[field] * flt(exchange_rate)
 		d.update(currency=to_currency)
+
+
+def prepare_opening_closing_for_ctb(data):
+	for d in data:
+		prepare_opening_closing(d)
 
 
 def get_columns():

--- a/erpnext/accounts/report/trial_balance/trial_balance.py
+++ b/erpnext/accounts/report/trial_balance/trial_balance.py
@@ -390,7 +390,7 @@ def calculate_values(
 			prepare_opening_closing(d)
 
 
-def calculate_total_row(accounts, company_currency):
+def calculate_total_row(data, company_currency, show_group_accounts=True):
 	total_row = {
 		"account": "'" + _("Total") + "'",
 		"account_name": "'" + _("Total") + "'",
@@ -407,10 +407,16 @@ def calculate_total_row(accounts, company_currency):
 		"currency": company_currency,
 	}
 
-	for d in accounts:
-		if not d.parent_account:
-			for field in value_fields:
-				total_row[field] += d[field]
+	def sum_value_fields(row):
+		for field in value_fields:
+			total_row[field] += row[field]
+
+	for d in data:
+		if not show_group_accounts:
+			sum_value_fields(d)
+
+		elif show_group_accounts and not d.get("parent_account"):
+			sum_value_fields(d)
 
 	return total_row
 
@@ -456,10 +462,12 @@ def prepare_data(accounts, filters, parent_children_map, company_currency):
 		row["has_value"] = has_value
 		data.append(row)
 
-	total_row = calculate_total_row(accounts, company_currency)
-
 	if not filters.get("show_group_accounts"):
 		data = hide_group_accounts(data)
+
+	total_row = calculate_total_row(
+		data, company_currency, show_group_accounts=filters.get("show_group_accounts")
+	)
 
 	data.extend([{}, total_row])
 


### PR DESCRIPTION
Fixed the total row calculation for Opening and Closing columns of `Trial Balance` Report with `show_group_accounts` disabled but `show_net_values` filter enabled.

Also fixed the total row calculation of `Consolidated Trial Balance` Report and introduced `show_net_values` filter.
