### PR TITLE
Feat/shipment default contact

### DIFF
--- a/erpnext/stock/doctype/delivery_note/delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.py
@@ -7,6 +7,7 @@ import json
 import frappe
 from frappe import _
 from frappe.contacts.doctype.address.address import get_company_address
+from frappe.contacts.doctype.contact.contact import get_default_contact
 from frappe.desk.notifications import clear_doctype_notifications
 from frappe.model.mapper import get_mapped_doc
 from frappe.model.utils import get_fetch_values
@@ -1104,10 +1105,12 @@ def make_shipment(source_name, target_doc=None):
 		target.pickup_contact_person = frappe.session.user
 
 		if source.contact_person:
+			contact_person = source.contact_person or get_default_contact("Customer", source.customer)
 			contact = frappe.db.get_value(
-				"Contact", source.contact_person, ["email_id", "phone", "mobile_no"], as_dict=1
+				"Contact", contact_person, ["email_id", "phone", "mobile_no"], as_dict=1
 			)
-			delivery_contact_display = f"{source.contact_display}"
+
+			delivery_contact_display = f"{source.contact_display or contact_person or ''}"
 			if contact:
 				if contact.email_id:
 					delivery_contact_display += "<br>" + contact.email_id
@@ -1115,7 +1118,7 @@ def make_shipment(source_name, target_doc=None):
 					delivery_contact_display += "<br>" + contact.phone
 				if contact.mobile_no and not contact.phone:
 					delivery_contact_display += "<br>" + contact.mobile_no
-			target.delivery_contact = delivery_contact_display
+			target.delivery_contact = contact_person
 
 		if source.shipping_address_name:
 			target.delivery_address_name = source.shipping_address_name

--- a/erpnext/stock/doctype/delivery_note/delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.py
@@ -1104,13 +1104,13 @@ def make_shipment(source_name, target_doc=None):
 		# As we are using session user details in the pickup_contact then pickup_contact_person will be session user
 		target.pickup_contact_person = frappe.session.user
 
-		if source.contact_person:
-			contact_person = source.contact_person or get_default_contact("Customer", source.customer)
+		contact_person = source.contact_person or get_default_contact("Customer", source.customer)
+		if contact_person:
 			contact = frappe.db.get_value(
 				"Contact", contact_person, ["email_id", "phone", "mobile_no"], as_dict=1
 			)
 
-			delivery_contact_display = f"{source.contact_display or contact_person or ''}"
+			delivery_contact_display = source.contact_display or contact_person or ""
 			if contact:
 				if contact.email_id:
 					delivery_contact_display += "<br>" + contact.email_id
@@ -1118,7 +1118,9 @@ def make_shipment(source_name, target_doc=None):
 					delivery_contact_display += "<br>" + contact.phone
 				if contact.mobile_no and not contact.phone:
 					delivery_contact_display += "<br>" + contact.mobile_no
-			target.delivery_contact = contact_person
+
+			target.delivery_contact_name = contact_person
+			target.delivery_contact = delivery_contact_display
 
 		if source.shipping_address_name:
 			target.delivery_address_name = source.shipping_address_name

--- a/erpnext/stock/doctype/delivery_note/delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.py
@@ -1111,7 +1111,7 @@ def make_shipment(source_name, target_doc=None):
 			)
 
 			delivery_contact_display = source.contact_display or contact_person or ""
-			if contact:
+			if contact and not source.contact_display:
 				if contact.email_id:
 					delivery_contact_display += "<br>" + contact.email_id
 				if contact.phone:
@@ -1120,6 +1120,8 @@ def make_shipment(source_name, target_doc=None):
 					delivery_contact_display += "<br>" + contact.mobile_no
 
 			target.delivery_contact_name = contact_person
+			if contact and contact.email_id and not target.delivery_contact_email:
+				target.delivery_contact_email = contact.email_id
 			target.delivery_contact = delivery_contact_display
 
 		if source.shipping_address_name:


### PR DESCRIPTION
Resolves #XXXX ### Please provide enough information so that others can review your pull request:

**Explain the details for making this change. What existing problem does the pull request solve?**

Currently, when generating a `Shipment` from a `Delivery Note` using the `get_mapped_doc` utility, the `contact_person` field is mapped directly from the source document. If the Delivery Note does not have a contact explicitly defined, the resulting Shipment is created with an empty contact field, even if the underlying Customer has a Default Contact configured in the system.

This creates a discrepancy in the UI and requires manual intervention to clear and re-select the customer to trigger the client-side fetch mechanism.

**The Solution:**
This PR introduces a server-side fallback mechanism during the mapping process. By leveraging a `postprocess` function, the system now checks if the target `Shipment` has a `customer` but lacks a `contact_person`. If so, it automatically fetches and assigns the Customer's Default Contact using `get_default_contact`. 

This ensures data integrity for logistics, prevents dispatching delays due to missing communication details, and strictly adheres to the guideline of keeping business logic on the server-side.

**After (Expected Behavior - Default contact is automatically loaded):**
### Checklist:
- [x] My code follows the style guidelines of this project (passed `bench lint`)
- [x] I have performed a self-review of my own code
- [x] All business logic and validations are on the server-side