### PR TITLE
fix(stock): pass company to avoid document naming rule issue in QI

### DIFF
--- a/erpnext/controllers/stock_controller.py
+++ b/erpnext/controllers/stock_controller.py
@@ -2087,7 +2087,9 @@ def check_item_quality_inspection(doctype: str, items: str | list[dict]):
 
 
 @frappe.whitelist()
-def make_quality_inspections(doctype: str, docname: str, items: str | list, inspection_type: str):
+def make_quality_inspections(
+	company: str, doctype: str, docname: str, items: str | list, inspection_type: str
+):
 	if isinstance(items, str):
 		items = json.loads(items)
 
@@ -2106,6 +2108,7 @@ def make_quality_inspections(doctype: str, docname: str, items: str | list, insp
 
 		quality_inspection = frappe.get_doc(
 			{
+				"company": company,
 				"doctype": "Quality Inspection",
 				"inspection_type": inspection_type,
 				"inspected_by": frappe.session.user,

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -2961,6 +2961,7 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 				frappe.call({
 					method: "erpnext.controllers.stock_controller.make_quality_inspections",
 					args: {
+						company: me.frm.doc.company,
 						doctype: me.frm.doc.doctype,
 						docname: me.frm.doc.name,
 						items: selected_data,

--- a/erpnext/stock/doctype/quality_inspection/test_quality_inspection.py
+++ b/erpnext/stock/doctype/quality_inspection/test_quality_inspection.py
@@ -142,7 +142,9 @@ class TestQualityInspection(IntegrationTestCase):
 			inspection_type = "Outgoing"
 		for item in dn.items:
 			item.sample_size = item.qty
-		quality_inspections = make_quality_inspections(dn.doctype, dn.name, dn.items, inspection_type)
+		quality_inspections = make_quality_inspections(
+			dn.company, dn.doctype, dn.name, dn.items, inspection_type
+		)
 		self.assertEqual(len(dn.items), len(quality_inspections))
 
 		# cleanup

--- a/erpnext/stock/doctype/stock_entry/test_stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/test_stock_entry.py
@@ -2410,6 +2410,54 @@ class TestStockEntry(IntegrationTestCase):
 		frappe.get_doc(_make_stock_entry(work_order.name, "Material Consumption for Manufacture", 5)).submit()
 		frappe.get_doc(_make_stock_entry(work_order.name, "Manufacture", 5)).submit()
 
+	def test_qi_creation_with_naming_rule_company_condition(self):
+		"""
+		Unit test case to check the document naming rule with company condition
+		For Quality Inspection, when created from Stock Entry.
+		"""
+		from erpnext.accounts.report.trial_balance.test_trial_balance import create_company
+		from erpnext.controllers.stock_controller import make_quality_inspections
+		from erpnext.stock.doctype.warehouse.test_warehouse import create_warehouse
+
+		# create a separate company to handle document naming rule with company condition
+		qc_company = create_company(company_name="Test Quality Company")
+
+		# create document naming rule based on that for Quality Inspection Doctype
+		qc_naming_rule = frappe.new_doc(
+			"Document Naming Rule", document_type="Quality Inspection", prefix="NQC.-ST-", prefix_digits=5
+		)
+		qc_naming_rule.append("conditions", {"field": "company", "condition": "=", "value": qc_company})
+		qc_naming_rule.save()
+
+		warehouse = create_warehouse(warehouse_name="Test QI Warehouse", company=qc_company)
+		item = create_item(
+			item_code="Test QI DNR Item",
+			is_stock_item=1,
+		)
+
+		# create inward stock entry
+		stock_entry = make_stock_entry(
+			item_code=item.item_code,
+			target=warehouse,
+			qty=10,
+			basic_rate=100,
+			inspection_required=True,
+			do_not_submit=True,
+		)
+
+		# create QI from Stock Entry and check the naming series generated.
+		qi = make_quality_inspections(
+			stock_entry.company,
+			stock_entry.doctype,
+			stock_entry.name,
+			stock_entry.as_dict().get("items"),
+			"Incoming",
+		)
+		self.assertEqual(qi[0], "NQC-ST-00001")
+
+		# delete naming rule
+		frappe.delete_doc("Document Naming Rule", qc_naming_rule.name)
+
 
 def make_serialized_item(self, **args):
 	args = frappe._dict(args)


### PR DESCRIPTION
When a Document Naming Rule is configured in QI with a condition based on the company, the system was not passing the company value properly. As a result, the naming rule condition was skipped and the document name was generated using the default series.

This fix ensures that the company is passed correctly so that the configured Document Naming Rule is evaluated and applied as expected.

Ref: [60057](https://support.frappe.io/helpdesk/tickets/60057)

Before:

https://github.com/user-attachments/assets/b1da7ff1-090e-4294-a2f5-b2632bc055f4


After:

https://github.com/user-attachments/assets/e7e9b894-5a66-4c10-b43d-59a24fb5718b

