### PR TITLE
fix: sync paid and received amount

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.js
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.js
@@ -824,7 +824,7 @@ frappe.ui.form.on("Payment Entry", {
 	paid_amount: function (frm) {
 		frm.set_value("base_paid_amount", flt(frm.doc.paid_amount) * flt(frm.doc.source_exchange_rate));
 		let company_currency = frappe.get_doc(":Company", frm.doc.company).default_currency;
-		if (!frm.doc.received_amount) {
+		if (frm.doc.paid_amount) {
 			if (frm.doc.paid_from_account_currency == frm.doc.paid_to_account_currency) {
 				frm.set_value("received_amount", frm.doc.paid_amount);
 			} else if (company_currency == frm.doc.paid_to_account_currency) {
@@ -845,7 +845,7 @@ frappe.ui.form.on("Payment Entry", {
 			flt(frm.doc.received_amount) * flt(frm.doc.target_exchange_rate)
 		);
 
-		if (!frm.doc.paid_amount) {
+		if (frm.doc.received_amount) {
 			if (frm.doc.paid_from_account_currency == frm.doc.paid_to_account_currency) {
 				frm.set_value("paid_amount", frm.doc.received_amount);
 				if (frm.doc.target_exchange_rate) {


### PR DESCRIPTION
Issue:
While making Payment Entry to Import Supplier, the Total Outstanding is 1000 USD, and as per the currency exchange, it is fetching 90610 Rs. in the Paid Amount field,

Now, if I change the Received Amount to 300 USD, the Paid amount field value should show up as 27183 Rs.

Ref:[#60280](https://support.frappe.io/helpdesk/tickets/60280)