### PR TITLE
perf: optimize account balance data fetching for Chart Of Accounts

### DIFF
--- a/erpnext/accounts/doctype/account/account_tree.js
+++ b/erpnext/accounts/doctype/account/account_tree.js
@@ -53,59 +53,53 @@ frappe.treeview_settings["Account"] = {
 	root_label: "Accounts",
 	get_tree_nodes: "erpnext.accounts.utils.get_children",
 	on_get_node: function (nodes, deep = false) {
-		if (frappe.boot.user.can_read.indexOf("GL Entry") == -1) return;
+		const render_balances = () => {
+			for (let account of cur_tree.account_balance_data) {
+				const node = cur_tree.nodes && cur_tree.nodes[account.value];
+				if (!node || node.is_root) continue;
 
-		let accounts = [];
-		if (deep) {
-			// in case of `get_all_nodes`
-			accounts = nodes.reduce((acc, node) => [...acc, ...node.data], []);
-		} else {
-			accounts = nodes;
-		}
+				// show Dr if positive since balance is calculated as debit - credit else show Cr
+				const balance = account.balance_in_account_currency || account.balance;
+				const dr_or_cr = balance > 0 ? __("Dr") : __("Cr");
+				const format = (value, currency) => format_currency(Math.abs(value), currency);
 
-		frappe.db.get_single_value("Accounts Settings", "show_balance_in_coa").then((value) => {
-			if (value) {
-				const get_balances = frappe.call({
-					method: "erpnext.accounts.utils.get_account_balances",
-					args: {
-						accounts: accounts,
-						company: cur_tree.args.company,
-						include_default_fb_balances: true,
-					},
-				});
-
-				get_balances.then((r) => {
-					if (!r.message || r.message.length == 0) return;
-
-					for (let account of r.message) {
-						const node = cur_tree.nodes && cur_tree.nodes[account.value];
-						if (!node || node.is_root) continue;
-
-						// show Dr if positive since balance is calculated as debit - credit else show Cr
-						const balance = account.balance_in_account_currency || account.balance;
-						const dr_or_cr = balance > 0 ? __("Dr") : __("Cr");
-						const format = (value, currency) => format_currency(Math.abs(value), currency);
-
-						if (account.balance !== undefined) {
-							node.parent && node.parent.find(".balance-area").remove();
-							$(
-								'<span class="balance-area pull-right">' +
-									(account.balance_in_account_currency
-										? format(
-												account.balance_in_account_currency,
-												account.account_currency
-										  ) + " / "
-										: "") +
-									format(account.balance, account.company_currency) +
-									" " +
-									dr_or_cr +
-									"</span>"
-							).insertBefore(node.$ul);
-						}
-					}
-				});
+				if (account.balance !== undefined) {
+					node.parent && node.parent.find(".balance-area").remove();
+					$(
+						'<span class="balance-area pull-right">' +
+							(account.account_currency != account.company_currency
+								? format(account.balance_in_account_currency, account.account_currency) +
+								  " / "
+								: "") +
+							format(account.balance, account.company_currency) +
+							" " +
+							dr_or_cr +
+							"</span>"
+					).insertBefore(node.$ul);
+				}
 			}
-		});
+		};
+
+		if (frappe.boot.user.can_read.indexOf("GL Entry") == -1) return;
+		if (!cur_tree.account_balance_data) {
+			frappe.db.get_single_value("Accounts Settings", "show_balance_in_coa").then((value) => {
+				if (value) {
+					const get_balances = frappe.call({
+						method: "erpnext.accounts.utils.get_account_balances_beta",
+						args: {
+							company: cur_tree.args.company,
+							include_default_fb_balances: true,
+						},
+					});
+
+					get_balances.then((r) => {
+						if (!r.message || r.message.length == 0) return;
+						cur_tree.account_balance_data = r.message || [];
+						render_balances();
+					});
+				}
+			});
+		} else render_balances();
 	},
 	add_tree_node: "erpnext.accounts.utils.add_ac",
 	menu_items: [

--- a/erpnext/accounts/doctype/account/account_tree.js
+++ b/erpnext/accounts/doctype/account/account_tree.js
@@ -99,7 +99,10 @@ frappe.treeview_settings["Account"] = {
 					});
 				}
 			});
-		} else render_balances();
+		} else {
+			// render_balances();
+			setTimeout(render_balances, 0);
+		}
 	},
 	add_tree_node: "erpnext.accounts.utils.add_ac",
 	menu_items: [

--- a/erpnext/accounts/doctype/account/account_tree.js
+++ b/erpnext/accounts/doctype/account/account_tree.js
@@ -52,7 +52,7 @@ frappe.treeview_settings["Account"] = {
 	],
 	root_label: "Accounts",
 	get_tree_nodes: "erpnext.accounts.utils.get_children",
-	on_get_node: function (nodes, deep = false) {
+	on_node_render: function (node, deep) {
 		const render_balances = () => {
 			for (let account of cur_tree.account_balance_data) {
 				const node = cur_tree.nodes && cur_tree.nodes[account.value];
@@ -84,24 +84,22 @@ frappe.treeview_settings["Account"] = {
 		if (!cur_tree.account_balance_data) {
 			frappe.db.get_single_value("Accounts Settings", "show_balance_in_coa").then((value) => {
 				if (value) {
-					const get_balances = frappe.call({
-						method: "erpnext.accounts.utils.get_account_balances_beta",
+					frappe.call({
+						method: "erpnext.accounts.utils.get_account_balances_coa",
 						args: {
 							company: cur_tree.args.company,
 							include_default_fb_balances: true,
 						},
-					});
-
-					get_balances.then((r) => {
-						if (!r.message || r.message.length == 0) return;
-						cur_tree.account_balance_data = r.message || [];
-						render_balances();
+						callback: function (r) {
+							if (!r.message || r.message.length === 0) return;
+							cur_tree.account_balance_data = r.message || [];
+							render_balances();
+						},
 					});
 				}
 			});
 		} else {
-			// render_balances();
-			setTimeout(render_balances, 0);
+			render_balances();
 		}
 	},
 	add_tree_node: "erpnext.accounts.utils.add_ac",

--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -341,6 +341,16 @@ def get_balance_on(
 		else:
 			select_field = "sum(round(debit, %s)) - sum(round(credit, %s))"
 
+		print(
+			frappe.db.sql(
+				"""
+			SELECT {}
+			FROM `tabGL Entry` gle
+			WHERE {}""".format(select_field, " and ".join(cond)),
+				(precision, precision),
+				run=False,
+			)
+		)
 		bal = frappe.db.sql(
 			"""
 			SELECT {}
@@ -1412,6 +1422,77 @@ def get_account_balances(
 			)
 
 	return accounts
+
+
+@frappe.whitelist()
+def get_account_balances_beta(company: str, include_default_fb_balances: bool = False):
+	company_currency = frappe.get_cached_value("Company", company, "default_currency")
+
+	Account = DocType("Account")
+	account_list = (
+		frappe.qb.from_(Account)
+		.select(Account.name, Account.parent_account, Account.account_currency)
+		.where(Account.company == company)
+		.orderby(Account.lft)
+		.run(as_dict=True)
+	)
+
+	account_balances_cc = {account.get("name"): 0 for account in account_list}
+
+	account_balances_ac = {account.get("name"): 0 for account in account_list}
+
+	GLEntry = DocType("GL Entry")
+	precision = get_currency_precision()
+	get_ledger_balances_query = (
+		frappe.qb.from_(GLEntry)
+		.select(
+			GLEntry.account,
+			(Sum(Round(GLEntry.debit, precision)) - Sum(Round(GLEntry.credit, precision))).as_("balance"),
+			(
+				Sum(Round(GLEntry.debit_in_account_currency, precision))
+				- Sum(Round(GLEntry.credit_in_account_currency, precision))
+			).as_("balance_in_account_currency"),
+		)
+		.groupby(GLEntry.account)
+	)
+
+	condition_list = [GLEntry.company == company, GLEntry.is_cancelled == 0]
+
+	default_finance_book = None
+
+	if include_default_fb_balances:
+		default_finance_book = frappe.get_cached_value("Company", company, "default_finance_book")
+
+	if default_finance_book:
+		condition_list.append(GLEntry.finance_book == default_finance_book)
+
+	for condition in condition_list:
+		get_ledger_balances_query = get_ledger_balances_query.where(condition)
+
+	ledger_balances = get_ledger_balances_query.run(as_dict=True)
+
+	for ledger_entry in ledger_balances:
+		account_balances_cc[ledger_entry.get("account")] = ledger_entry.get("balance")
+		account_balances_ac[ledger_entry.get("account")] = ledger_entry.get("balance_in_account_currency")
+
+	for account in reversed(account_list):
+		parent = account.get("parent_account")
+		if parent:
+			account_balances_cc[parent] += account_balances_cc.get(account.get("name"))
+			account_balances_ac[parent] += account_balances_ac.get(account.get("name"))
+
+	accounts_data = [
+		{
+			"value": account.get("name"),
+			"company_currency": company_currency,
+			"balance": account_balances_cc.get(account.get("name")),
+			"account_currency": account.get("account_currency"),
+			"balance_in_account_currency": account_balances_ac.get(account.get("name")),
+		}
+		for account in account_list
+	]
+
+	return accounts_data
 
 
 def create_payment_gateway_account(gateway, payment_channel="Email", company=None):

--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -1415,7 +1415,7 @@ def get_account_balances(
 
 
 @frappe.whitelist()
-def get_account_balances_beta(company: str, include_default_fb_balances: bool = False):
+def get_account_balances_coa(company: str, include_default_fb_balances: bool = False):
 	company_currency = frappe.get_cached_value("Company", company, "default_currency")
 
 	Account = DocType("Account")
@@ -1454,7 +1454,9 @@ def get_account_balances_beta(company: str, include_default_fb_balances: bool = 
 		default_finance_book = frappe.get_cached_value("Company", company, "default_finance_book")
 
 	if default_finance_book:
-		condition_list.append(GLEntry.finance_book == default_finance_book)
+		condition_list.append(
+			(GLEntry.finance_book == default_finance_book) | (GLEntry.finance_book.isnull())
+		)
 
 	for condition in condition_list:
 		get_ledger_balances_query = get_ledger_balances_query.where(condition)

--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -1469,7 +1469,6 @@ def get_account_balances_beta(company: str, include_default_fb_balances: bool = 
 		parent = account.get("parent_account")
 		if parent:
 			account_balances_cc[parent] += account_balances_cc.get(account.get("name"))
-			account_balances_ac[parent] += account_balances_ac.get(account.get("name"))
 
 	accounts_data = [
 		{

--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -341,16 +341,6 @@ def get_balance_on(
 		else:
 			select_field = "sum(round(debit, %s)) - sum(round(credit, %s))"
 
-		print(
-			frappe.db.sql(
-				"""
-			SELECT {}
-			FROM `tabGL Entry` gle
-			WHERE {}""".format(select_field, " and ".join(cond)),
-				(precision, precision),
-				run=False,
-			)
-		)
 		bal = frappe.db.sql(
 			"""
 			SELECT {}


### PR DESCRIPTION
Context: The site has ~1.5 million GL entries and 82 accounts (group and ledger)
Suppose N = number of records in GL Entry table, K = number of records in GL Entry table for a particular ledger account, A = number of records in Account table then, 

Before:

https://github.com/user-attachments/assets/d00848f4-f9db-44b1-9736-c2de7288cb80

Cons of the current implementation:
1. Executed seperate db queries for each individual account even though most of the data overlaps
best case: 5 accounts i.e. ~5 db calls and ~12 secs
worst case: for all accounts i.e. ~82 db calls/ ~60 secs and additional db queries if account and company currency differ for any account

Query time complexity
for ledger accounts ->  O(N) or O(K), if index is properly maintained
for group accounts -> O(N x A), since it runs a nested select statement

2. On load fetches balances for the accounts visible by default and on subsequent expansion fetches the remaining balances and on expand/collapse all it refetched the balance data again


After:

https://github.com/user-attachments/assets/c52e209f-3d69-4dec-afc0-a71a3e73a066

Pros: Fetch entire balance data at once in a single db query ~6 secs, cache at the client-side and  display balances as and when required. No extra db calls even if account and company currency differ

Query time complexity: O(N)

Depends on frappe/frappe#37779
Closes #51953