### PR TITLE
fix: remove read-only property from Sales Invoice Timesheet Table

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.json
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.json
@@ -800,8 +800,7 @@
    "hide_seconds": 1,
    "label": "Time Sheets",
    "options": "Sales Invoice Timesheet",
-   "print_hide": 1,
-   "read_only": 1
+   "print_hide": 1
   },
   {
    "default": "0",
@@ -2331,7 +2330,7 @@
    "link_fieldname": "consolidated_invoice"
   }
  ],
- "modified": "2026-02-25 12:41:57.043459",
+ "modified": "2026-02-28 17:58:56.453076",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Sales Invoice",


### PR DESCRIPTION
In the Sales Invoice, the user is supposed to be able to fetch timesheets into the document. The filters aren't always enough to get exactly the timesheets you need (for example, there is no Customer filter). Therefore, it's always been necessary to be able to delete timesheets that are not related to the Sales Invoice from the table after they've all been brought in.

This ability was lost in https://github.com/frappe/erpnext/pull/52399 when the table somehow got flipped to read-only. I don't see this table being discussed in the PR, so I don't believe it was intentional. It would be really nice to get some better filters for the timesheet import, but until that happens, and even if it does happen, users will always need to be able to delete unrelated timesheets from the Sales Invoice before submit.

This PR restores that ability by removing the read-only attribute from the Sales Invoice Timesheet Table.

Closes #53046 
Please backport version-16-hotfix