### PR TITLE
fix: correct sle voucher_type comparison in get_ref_doctype

### DIFF
--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -1303,7 +1303,7 @@ class update_entries_after:
 				else:
 					if sle.voucher_type in ("Delivery Note", "Sales Invoice"):
 						ref_doctype = "Packed Item"
-					elif sle == "Subcontracting Receipt":
+					elif sle.voucher_type == "Subcontracting Receipt":
 						ref_doctype = "Subcontracting Receipt Supplied Item"
 					else:
 						ref_doctype = "Purchase Receipt Item Supplied"


### PR DESCRIPTION
## Problem

In `get_ref_doctype`, the condition was comparing the entire `sle` object (a Stock Ledger Entry dict) against the string `"Subcontracting Receipt"`:

Since `sle` is a dict/object and not a string, this comparison always evaluates to `False`. As a result, `ref_doctype` is never set to `"Subcontracting Receipt Supplied Item"` and incorrectly falls through to `"Purchase Receipt Item Supplied"` for Subcontracting Receipts.

## Fix

Access the correct attribute on the `sle` object:

- -elif sle == "Subcontracting Receipt":
+ +elif sle.voucher_type == "Subcontracting Receipt":

## Before Fix

elif sle == "Subcontracting Receipt":  # sle is a dict, not a string
    ref_doctype = "Subcontracting Receipt Supplied Item"

❌ sle == "Subcontracting Receipt" → always False
❌ ref_doctype → falls through to "Purchase Receipt Item Supplied" (wrong)

## After Fix

elif sle.voucher_type == "Subcontracting Receipt":  # correctly accesses the attribute
    ref_doctype = "Subcontracting Receipt Supplied Item"

✅ sle.voucher_type == "Subcontracting Receipt" → evaluates correctly
✅ ref_doctype → "Subcontracting Receipt Supplied Item" (correct)

## Impact

Without this fix, stock ledger entries for Subcontracting Receipts resolve to the wrong
`ref_doctype`, which can cause incorrect inventory valuation or item linkage for
subcontracting workflows.