### PR TITLE
fix: handle html email template separately in RFQ to avoid jinja cont…

### DIFF
--- a/erpnext/buying/doctype/request_for_quotation/request_for_quotation.js
+++ b/erpnext/buying/doctype/request_for_quotation/request_for_quotation.js
@@ -250,10 +250,17 @@ frappe.ui.form.on("Request for Quotation", {
 					"subject",
 				])
 				.then((r) => {
-					frm.set_value(
-						"message_for_supplier",
-						r.message.use_html ? r.message.response_html : r.message.response
-					);
+					if (r.message.use_html) {
+						frm.set_value({
+							mfs_html: r.message.response_html,
+							use_html: 1,
+						});
+					} else {
+						frm.set_value({
+							message_for_supplier: r.message.response,
+							use_html: 0,
+						});
+					}
 					frm.set_value("subject", r.message.subject);
 				});
 		}

--- a/erpnext/buying/doctype/request_for_quotation/request_for_quotation.json
+++ b/erpnext/buying/doctype/request_for_quotation/request_for_quotation.json
@@ -31,7 +31,9 @@
   "send_document_print",
   "sec_break_email_2",
   "subject",
+  "use_html",
   "message_for_supplier",
+  "mfs_html",
   "terms_section_break",
   "incoterm",
   "named_place",
@@ -142,12 +144,13 @@
   {
    "allow_on_submit": 1,
    "default": "Please supply the specified items at the best possible rates",
+   "depends_on": "eval:doc.use_html == 0",
    "fieldname": "message_for_supplier",
    "fieldtype": "Text Editor",
    "in_list_view": 1,
    "label": "Message for Supplier",
-   "print_hide": 1,
-   "reqd": 1
+   "mandatory_depends_on": "eval:doc.use_html == 0",
+   "print_hide": 1
   },
   {
    "collapsible": 1,
@@ -324,6 +327,22 @@
    "label": "Subject",
    "not_nullable": 1,
    "reqd": 1
+  },
+  {
+   "allow_on_submit": 1,
+   "depends_on": "eval:doc.use_html == 1",
+   "fieldname": "mfs_html",
+   "fieldtype": "Code",
+   "label": "Message for Supplier",
+   "mandatory_depends_on": "eval:doc.use_html == 1",
+   "print_hide": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "use_html",
+   "fieldtype": "Check",
+   "hidden": 1,
+   "label": "Use HTML"
   }
  ],
  "grid_page_length": 50,
@@ -331,7 +350,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2026-01-06 10:31:08.747043",
+ "modified": "2026-03-01 23:38:48.079274",
  "modified_by": "Administrator",
  "module": "Buying",
  "name": "Request for Quotation",

--- a/erpnext/buying/doctype/request_for_quotation/request_for_quotation.py
+++ b/erpnext/buying/doctype/request_for_quotation/request_for_quotation.py
@@ -48,7 +48,8 @@ class RequestforQuotation(BuyingController):
 		incoterm: DF.Link | None
 		items: DF.Table[RequestforQuotationItem]
 		letter_head: DF.Link | None
-		message_for_supplier: DF.TextEditor
+		message_for_supplier: DF.TextEditor | None
+		mfs_html: DF.Code | None
 		named_place: DF.Data | None
 		naming_series: DF.Literal["PUR-RFQ-.YYYY.-"]
 		opportunity: DF.Link | None
@@ -62,6 +63,7 @@ class RequestforQuotation(BuyingController):
 		tc_name: DF.Link | None
 		terms: DF.TextEditor | None
 		transaction_date: DF.Date
+		use_html: DF.Check
 		vendor: DF.Link | None
 	# end: auto-generated types
 
@@ -101,8 +103,16 @@ class RequestforQuotation(BuyingController):
 				["use_html", "response", "response_html", "subject"],
 				as_dict=True,
 			)
-			if not self.message_for_supplier:
-				self.message_for_supplier = data.response_html if data.use_html else data.response
+
+			self.use_html = data.use_html
+
+			if data.use_html:
+				if not self.mfs_html:
+					self.mfs_html = data.response_html
+			else:
+				if not self.message_for_supplier:
+					self.message_for_supplier = data.response
+
 			if not self.subject:
 				self.subject = data.subject
 
@@ -305,7 +315,10 @@ class RequestforQuotation(BuyingController):
 		else:
 			sender = frappe.session.user not in STANDARD_USERS and frappe.session.user or None
 
-		rendered_message = frappe.render_template(self.message_for_supplier, doc_args)
+		message_template = self.mfs_html if self.use_html else self.message_for_supplier
+		# nosemgrep: frappe-semgrep-rules.rules.security.frappe-ssti
+		rendered_message = frappe.render_template(message_template, doc_args)
+
 		subject_source = (
 			self.subject
 			or frappe.get_value("Email Template", self.email_template, "subject")


### PR DESCRIPTION
**Issue :**

When creating a Request for Quotation using an Email Template that contains Jinja variables like `loopcounter`, rendering fails with:

`jinja2.exceptions.UndefinedError: 'loopcounter' is undefined`

This happens because RFQ always stores the template content in `message_for_supplier` (Text Editor field), even when the Email Template is marked as `use_html`.

HTML templates may contain Jinja constructs that are not compatible with the Text Editor content or get altered before rendering, causing template rendering errors.

Steps to reproduce:
1. Create an Email Template with use_html enabled
2. Use a jinja for loop inside the table tag
3. Select template in Request for Quotation
4. Click Preview Email



**Ref :** [#60692](https://support.frappe.io/helpdesk/tickets/60692?view=VIEW-HD+Ticket-850) , [#61065](https://support.frappe.io/helpdesk/tickets/61065?view=VIEW-HD+Ticket-850)



**Before :**


<img width="1919" height="962" alt="image" src="https://github.com/user-attachments/assets/ec0a5092-68d4-4d78-b6c5-22b2ace50980" />


**After :**

<img width="1919" height="971" alt="image" src="https://github.com/user-attachments/assets/a62745b0-1229-4018-9e81-0b7e0a95ad47" />


**Backport Needed for v15 & v16** 