### PR TITLE
fix(gross-profit): apply precision-based rounding to grouped totals

### DIFF
--- a/erpnext/accounts/report/gross_profit/gross_profit.py
+++ b/erpnext/accounts/report/gross_profit/gross_profit.py
@@ -649,7 +649,7 @@ class GrossProfitGenerator:
 						new_row = row
 						self.set_average_based_on_payment_term_portion(new_row, row, invoice_portion)
 					else:
-						new_row.qty += flt(row.qty)
+						new_row.qty = flt((new_row.qty + row.qty), self.float_precision)
 						self.set_average_based_on_payment_term_portion(new_row, row, invoice_portion, True)
 
 				new_row = self.set_average_rate(new_row)
@@ -659,11 +659,17 @@ class GrossProfitGenerator:
 					if i == 0:
 						new_row = row
 					else:
-						new_row.qty += flt(row.qty)
-						new_row.buying_amount += flt(row.buying_amount, self.currency_precision)
-						new_row.base_amount += flt(row.base_amount, self.currency_precision)
+						new_row.qty = flt((new_row.qty + row.qty), self.float_precision)
+						new_row.buying_amount = flt(
+							(new_row.buying_amount + row.buying_amount), self.currency_precision
+						)
+						new_row.base_amount = flt(
+							(new_row.base_amount + row.base_amount), self.currency_precision
+						)
 						if self.filters.get("group_by") == "Sales Person":
-							new_row.allocated_amount += flt(row.allocated_amount, self.currency_precision)
+							new_row.allocated_amount = flt(
+								(new_row.allocated_amount + row.allocated_amount), self.currency_precision
+							)
 				new_row = self.set_average_rate(new_row)
 				self.grouped_data.append(new_row)
 


### PR DESCRIPTION
Issue: When generating the Gross Profit report with **group_by** set to **"Item Code"** and **Include Returned Invoices (Stand-alone)** enabled, the report shows an incorrect Valuation Rate due to floating-point rounding behaviour.

Ref: [60482](https://support.frappe.io/helpdesk/tickets/60482)

Supporting Screenshots:
<img width="1381" height="565" alt="Screenshot 2026-03-02 at 00 12 12" src="https://github.com/user-attachments/assets/f03aeb6a-2e90-4694-b493-7175d374b40a" />


**Before:**
<img width="1379" height="320" alt="Screenshot 2026-03-02 at 00 09 45" src="https://github.com/user-attachments/assets/1d10491d-ff7a-4317-8d18-761bfe422872" />

**After:**
<img width="1376" height="319" alt="Screenshot 2026-03-02 at 00 10 34" src="https://github.com/user-attachments/assets/57d0ba36-3e56-4ea4-abd4-e4656e591760" />

Backport Needed v15 and v16
