### PR TITLE
perf: add index on reference_purchase_receipt column

### DIFF
--- a/erpnext/stock/doctype/stock_entry_detail/stock_entry_detail.json
+++ b/erpnext/stock/doctype/stock_entry_detail/stock_entry_detail.json
@@ -498,7 +498,8 @@
    "fieldtype": "Link",
    "label": "Reference Purchase Receipt",
    "options": "Purchase Receipt",
-   "read_only": 1
+   "read_only": 1,
+   "search_index": 1
   },
   {
    "fieldname": "project",
@@ -660,7 +661,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-10-16 11:50:50.573443",
+ "modified": "2026-03-02 14:05:23.116017",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Stock Entry Detail",


### PR DESCRIPTION
**Issue:** When performing cancelling event on Purchase Receipt, system throws timeout error as the Stock Entry item rows referenced with Purchase Receipt in **reference_purchase_receipt** field. This performs a slow query if the stock entry has high volume of data.

**Resolution:** Indexed **reference_purchase_receipt** column to faster the read query triggered from **get_submitted_linked_docs**

Ref: [60545](https://support.frappe.io/helpdesk/tickets/60545)

