### PR TITLE
fix: populate mr owner and set po owner as fallback

### DIFF
--- a/erpnext/buying/report/procurement_tracker/procurement_tracker.py
+++ b/erpnext/buying/report/procurement_tracker/procurement_tracker.py
@@ -165,7 +165,7 @@ def get_data(filters):
 				"cost_center": po.cost_center,
 				"project": po.project,
 				"requesting_site": po.warehouse,
-				"requestor": po.owner,
+				"requestor": mr_record.get("owner", po.owner),
 				"material_request_no": po.material_request,
 				"item_code": po.item_code,
 				"quantity": flt(po.qty),


### PR DESCRIPTION
**Issue:** Procurement Report shows Purchase Order owner as a requestor despite of  it's created from Material Request document.

**Ref: [61562](https://support.frappe.io/helpdesk/tickets/61562)**

**Material Request**
<img width="1684" height="884" alt="Screenshot 2026-03-02 at 11 45 10 PM" src="https://github.com/user-attachments/assets/27c3601f-0178-42aa-8dbe-3b25caf4039d" />


**Purchase Order**
<img width="1684" height="902" alt="Screenshot 2026-03-02 at 11 46 26 PM" src="https://github.com/user-attachments/assets/b8a41d56-d420-4cc4-b8a9-923b75177faf" />


**Before:**
<img width="1684" height="902" alt="Screenshot 2026-03-02 at 11 47 07 PM" src="https://github.com/user-attachments/assets/c5454eaa-dfa0-46e7-b092-90cb7e6d10be" />


**After:**

<img width="1684" height="884" alt="Screenshot 2026-03-02 at 11 44 33 PM" src="https://github.com/user-attachments/assets/80edef82-7077-45ee-89ae-721c22b25f32" />

