### PR TITLE
fix(accounts): party type auto-cleared in non-English locale

### DIFF
--- a/erpnext/accounts/doctype/bank_account/bank_account.js
+++ b/erpnext/accounts/doctype/bank_account/bank_account.js
@@ -14,7 +14,9 @@ frappe.ui.form.on("Bank Account", {
 		});
 		frm.set_query("party_type", function () {
 			return {
-				query: "erpnext.setup.doctype.party_type.party_type.get_party_type",
+				filters: {
+					name: ["in", Object.keys(frappe.boot.party_account_types)],
+				},
 			};
 		});
 	},

--- a/erpnext/accounts/doctype/payment_request/payment_request.js
+++ b/erpnext/accounts/doctype/payment_request/payment_request.js
@@ -6,7 +6,9 @@ frappe.ui.form.on("Payment Request", {
 	setup: function (frm) {
 		frm.set_query("party_type", function () {
 			return {
-				query: "erpnext.setup.doctype.party_type.party_type.get_party_type",
+				filters: {
+					name: ["in", Object.keys(frappe.boot.party_account_types)],
+				},
 			};
 		});
 

--- a/erpnext/setup/doctype/party_type/party_type.py
+++ b/erpnext/setup/doctype/party_type/party_type.py
@@ -49,4 +49,19 @@ def get_party_type(doctype, txt, searchfield, start, page_len, filters):
 		params,
 	)
 
+	if not result and txt:
+		# No match found — txt may be a translated DocType name (non-English locale).
+		# Party Type names are stored in English, so fall back to matching against
+		# translated names.
+		params["txt"] = "%"
+		all_types = frappe.db.sql(
+			f"""select name from `tabParty Type`
+			where `{searchfield}` LIKE %(txt)s {cond}
+			order by name""",
+			params,
+		)
+		search_txt = txt.lower()
+		result = tuple((name,) for (name,) in all_types if search_txt in frappe._(name).lower())
+		result = result[int(start) : int(start) + int(page_len)]
+
 	return result or []

--- a/erpnext/setup/doctype/party_type/party_type.py
+++ b/erpnext/setup/doctype/party_type/party_type.py
@@ -56,7 +56,7 @@ def get_party_type(doctype: str, txt: str, searchfield: str, start: int, page_le
 			params,
 		)
 		search_txt = txt.lower()
-		result = tuple((name,) for (name,) in all_types if search_txt in frappe._(name).lower())
+		result = [(name,) for (name,) in all_types if search_txt in frappe._(name).lower()]
 		result = result[int(start) : int(start) + int(page_len)]
 
 	return result or []

--- a/erpnext/setup/doctype/party_type/party_type.py
+++ b/erpnext/setup/doctype/party_type/party_type.py
@@ -24,7 +24,7 @@ class PartyType(Document):
 
 @frappe.whitelist()
 @frappe.validate_and_sanitize_search_inputs
-def get_party_type(doctype, txt, searchfield, start, page_len, filters):
+def get_party_type(doctype: str, txt: str, searchfield: str, start: int, page_len: int, filters: dict):
 	cond = ""
 	account_type = None
 
@@ -53,13 +53,19 @@ def get_party_type(doctype, txt, searchfield, start, page_len, filters):
 		# No match found — txt may be a translated DocType name (non-English locale).
 		# Party Type names are stored in English, so fall back to matching against
 		# translated names.
-		params["txt"] = "%"
-		all_types = frappe.db.sql(
-			f"""select name from `tabParty Type`
-			where `{searchfield}` LIKE %(txt)s {cond}
-			order by name""",
-			params,
-		)
+		if account_type and account_type in ["Receivable", "Payable"]:
+			all_types = frappe.db.sql(
+				"select name from `tabParty Type` where account_type = %(account_type)s or name = 'Employee' order by name",
+				{"account_type": account_type},
+			)
+		elif account_type:
+			all_types = frappe.db.sql(
+				"select name from `tabParty Type` where account_type = %(account_type)s order by name",
+				{"account_type": account_type},
+			)
+		else:
+			all_types = frappe.db.sql("select name from `tabParty Type` order by name")
+
 		search_txt = txt.lower()
 		result = tuple((name,) for (name,) in all_types if search_txt in frappe._(name).lower())
 		result = result[int(start) : int(start) + int(page_len)]

--- a/erpnext/setup/doctype/party_type/party_type.py
+++ b/erpnext/setup/doctype/party_type/party_type.py
@@ -50,22 +50,11 @@ def get_party_type(doctype: str, txt: str, searchfield: str, start: int, page_le
 	)
 
 	if not result and txt:
-		# No match found — txt may be a translated DocType name (non-English locale).
-		# Party Type names are stored in English, so fall back to matching against
-		# translated names.
-		if account_type and account_type in ["Receivable", "Payable"]:
-			all_types = frappe.db.sql(
-				"select name from `tabParty Type` where account_type = %(account_type)s or name = 'Employee' order by name",
-				{"account_type": account_type},
-			)
-		elif account_type:
-			all_types = frappe.db.sql(
-				"select name from `tabParty Type` where account_type = %(account_type)s order by name",
-				{"account_type": account_type},
-			)
-		else:
-			all_types = frappe.db.sql("select name from `tabParty Type` order by name")
-
+		# txt may be a translated name — re-run with the same filters but match against translations
+		all_types = frappe.db.sql(
+			f"select name from `tabParty Type` where 1=1 {cond} order by name",
+			params,
+		)
 		search_txt = txt.lower()
 		result = tuple((name,) for (name,) in all_types if search_txt in frappe._(name).lower())
 		result = result[int(start) : int(start) + int(page_len)]


### PR DESCRIPTION
## Summary
Fixes #52976
Fixes #53042

When using ERPNext in a non-English locale (e.g. Chinese), selecting a Party Type
on Bank Account or Payment Request would be immediately auto-cleared by the system.

### Root cause
These forms used a custom search query (`get_party_type`) for the Party Type link
field. When Frappe's `validate_link_and_fetch` runs after selection, it calls the
same query with `txt` set to the *translated* doctype name (e.g. "供应商" instead
of "Supplier"). Since Party Type records are stored in English, the SQL `LIKE`
match fails, validation returns no results, and Frappe clears the field.

### Fix
Two changes:

1. **bank_account.js / payment_request.js** — Replace the custom `query` with a
   standard `filters`-based `set_query` using `frappe.boot.party_account_types`.
   This avoids the custom query path in `validate_link_and_fetch` entirely, so
   translated `txt` is no longer an issue.

2. **party_type.py** — Add a translation-aware fallback to `get_party_type` for
   other callers (e.g. Payment Entry, Journal Entry) that still use this query.
   When the initial SQL match returns no results but `txt` is non-empty, it
   re-queries all matching party types and filters by comparing `txt` against
   `frappe._(name)`. This allows translated search terms to resolve to their
   English-stored names.

## Test plan
- [x] 48/48 `payment_entry` tests pass (includes `test_receive_payment_from_payable_party_type`)
- [x] Manual: set locale to non-English, open Bank Account → select Party Type → confirmed not auto-cleared
- [x] Manual: same test on Payment Request form
- [x] Manual: Party Type search in Payment Entry works with translated input