### PR TITLE
fix: serial no status for Disassemble entry

### DIFF
--- a/erpnext/stock/serial_batch_bundle.py
+++ b/erpnext/stock/serial_batch_bundle.py
@@ -461,6 +461,11 @@ class SerialBatchBundle:
 		if sle.voucher_type in ["Sales Invoice", "Delivery Note"] and sle.actual_qty < 0:
 			customer = frappe.get_cached_value(sle.voucher_type, sle.voucher_no, "customer")
 
+		if sle.voucher_type in ["Stock Entry"] and sle.actual_qty < 0:
+			purpose = frappe.get_cached_value("Stock Entry", sle.voucher_no, "purpose")
+			if purpose in ["Disassemble", "Material Receipt"]:
+				status = "Inactive"
+
 		sn_table = frappe.qb.DocType("Serial No")
 
 		query = (


### PR DESCRIPTION
**Issue**

The status of the serial no of the FG Item has set as Delivered, after the disassemble entry and due to which the system has not allowing to use the same serial no again in the repack entry

**After Fix**

The status of the serial no of the FG Item has set as Inactive, so that now the system is allowing to use the same serial no in the repack entry 