### PR TITLE
ci: configure auto-merge for backport PRs

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -92,3 +92,14 @@ pull_request_rules:
           {{ title }} (#{{ number }})
 
           {{ body }}
+
+- name: Auto-merge eligible backport PRs
+  conditions:
+    - author=mergify[bot]
+    - base~=^version-(15|16)-hotfix$
+    - backport_of.label=automerge-backports
+    - check-success=*
+  actions:
+    merge:
+      method: squash
+      commit_message: title+body

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -93,13 +93,13 @@ pull_request_rules:
 
           {{ body }}
 
-- name: Auto-merge eligible backport PRs
-  conditions:
-    - author=mergify[bot]
-    - base~=^version-(15|16)-hotfix$
-    - backport_of.label=automerge-backports
-    - check-success=*
-  actions:
-    merge:
-      method: squash
-      commit_message: title+body
+  - name: Auto-merge eligible backport PRs
+    conditions:
+      - author=mergify[bot]
+      - base~=^version-(15|16)-hotfix$
+      - backport_of.label=automerge-backports
+      - check-success=*
+    actions:
+      merge:
+        method: squash
+        commit_message: title+body


### PR DESCRIPTION
Add auto-merge configuration for backport PRs. Any source PR with the `automerge-backports` label will automatically have auto merge enabled on the backports created by @Mergifyio