### PR TITLE
fix(manufacturing): prevent Job Card actions when Work Order is Stopped

### DIFF
--- a/erpnext/manufacturing/doctype/job_card/job_card.js
+++ b/erpnext/manufacturing/doctype/job_card/job_card.js
@@ -136,6 +136,7 @@ frappe.ui.form.on("Job Card", {
 		}
 
 		if (!frm.is_new() && frm.doc.__onload?.work_order_stopped) {
+			frm.disable_save();
 			frm.dashboard.add_comment(__("Work Order {0} is stopped.", [frm.doc.work_order]));
 			return;
 		}

--- a/erpnext/manufacturing/doctype/job_card/job_card.js
+++ b/erpnext/manufacturing/doctype/job_card/job_card.js
@@ -135,6 +135,11 @@ frappe.ui.form.on("Job Card", {
 			return;
 		}
 
+		if (!frm.is_new() && frm.doc.__onload?.work_order_stopped) {
+			frm.dashboard.add_comment(__("Work Order {0} is stopped.", [frm.doc.work_order]));
+			return;
+		}
+
 		if (frm.doc.is_subcontracted) {
 			frm.trigger("make_subcontracting_po");
 			return;

--- a/erpnext/manufacturing/doctype/job_card/job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/job_card.py
@@ -145,6 +145,7 @@ class JobCard(Document):
 		excess_transfer = frappe.db.get_single_value("Manufacturing Settings", "job_card_excess_transfer")
 		self.set_onload("job_card_excess_transfer", excess_transfer)
 		self.set_onload("work_order_closed", self.is_work_order_closed())
+		self.set_onload("work_order_stopped", self.is_work_order_stopped())
 		self.set_onload("has_stock_entry", self.has_stock_entry())
 
 	def on_discard(self):
@@ -843,13 +844,6 @@ class JobCard(Document):
 		if self.track_semi_finished_goods:
 			return
 
-		if self.work_order and frappe.get_cached_value("Work Order", self.work_order, "status") == "Stopped":
-			frappe.throw(
-				_("Transaction not allowed against stopped Work Order {0}").format(
-					get_link_to_form("Work Order", self.work_order)
-				)
-			)
-
 		if not self.time_logs:
 			frappe.throw(
 				_("Time logs are required for {0} {1}").format(
@@ -1314,6 +1308,13 @@ class JobCard(Document):
 		if self.is_work_order_closed():
 			frappe.throw(_("You can't make any changes to Job Card since Work Order is closed."))
 
+		if self.is_work_order_stopped():
+			frappe.throw(
+				_("Transaction not allowed against stopped Work Order {0}").format(
+					get_link_to_form("Work Order", self.work_order)
+				)
+			)
+
 	def set_employees(self):
 		self.employee = []
 		for item in self.time_logs:
@@ -1322,11 +1323,12 @@ class JobCard(Document):
 
 	def is_work_order_closed(self):
 		if self.work_order:
-			status = frappe.get_value("Work Order", self.work_order)
+			return frappe.get_cached_value("Work Order", self.work_order, "status") == "Closed"
+		return False
 
-			if status == "Closed":
-				return True
-
+	def is_work_order_stopped(self):
+		if self.work_order:
+			return frappe.get_cached_value("Work Order", self.work_order, "status") == "Stopped"
 		return False
 
 	def update_status_in_workstation(self, status):

--- a/erpnext/manufacturing/doctype/job_card/job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/job_card.py
@@ -617,6 +617,7 @@ class JobCard(Document):
 			)
 
 	def add_time_log(self, args):
+		self.validate_work_order()
 		last_row = []
 		employees = args.employees
 		if isinstance(employees, str):

--- a/erpnext/manufacturing/doctype/job_card/job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/job_card.py
@@ -1229,6 +1229,7 @@ class JobCard(Document):
 
 	@frappe.whitelist()
 	def pause_job(self, **kwargs):
+		self.validate_work_order()
 		if isinstance(kwargs, dict):
 			kwargs = frappe._dict(kwargs)
 
@@ -1237,6 +1238,7 @@ class JobCard(Document):
 
 	@frappe.whitelist()
 	def resume_job(self, **kwargs):
+		self.validate_work_order()
 		if isinstance(kwargs, dict):
 			kwargs = frappe._dict(kwargs)
 
@@ -1338,6 +1340,7 @@ class JobCard(Document):
 		frappe.db.set_value("Workstation", self.workstation, "status", status)
 
 	def add_time_logs(self, **kwargs):
+		self.validate_work_order()
 		kwargs = frappe._dict(kwargs)
 		if not kwargs.employees and kwargs.to_time:
 			for row in self.time_logs:


### PR DESCRIPTION
## Summary
- When a Work Order is **Stopped**, users could still click "Start Job" on linked Job Cards because the Stopped check only ran on the submit path (`validate_job_card`), not on save (which `start_timer` triggers).
- Move the Stopped check into `validate_work_order()` so it blocks on **any save**, not just submit.
- Add `work_order_stopped` onload flag and JS guard to hide Start/Resume/Complete buttons and show a dashboard comment when the Work Order is stopped.
- Fix pre-existing bug in `is_work_order_closed()` which used `frappe.get_value("Work Order", name)` (returns doc name, never `"Closed"`) — switch to `frappe.get_cached_value` with explicit `"status"` field.

Fixes #53101

## Test plan
- [x] **Manual test**: Stop a Work Order → open its Job Card → confirm "Start Job" button is hidden and dashboard shows "Work Order {name} is stopped."
- [x] **Manual test**: Close a Work Order → open its Job Card → confirm save is disabled
- [x] 17/17 `test_job_card` tests pass locally
- [ ] CI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)