### PR TITLE
fix: prevent exchange rate flow from transaction to payment

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -2780,7 +2780,7 @@ def get_payment_entry(
 				pe, doc, discount_amount, base_total_discount_loss, party_account_currency
 			)
 
-		pe.set_exchange_rate(ref_doc=doc)
+		pe.set_exchange_rate()
 		pe.set_amounts()
 
 	# If PE is created from PR directly, then no need to find open PRs for the references

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -3022,7 +3022,7 @@ def get_payment_entry(
 				pe, doc, discount_amount, base_total_discount_loss, party_account_currency
 			)
 
-		pe.set_exchange_rate(ref_doc=doc)
+		pe.set_exchange_rate()
 		pe.set_amounts()
 
 	# If PE is created from PR directly, then no need to find open PRs for the references

--- a/erpnext/accounts/doctype/payment_entry/test_payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/test_payment_entry.py
@@ -532,6 +532,8 @@ class TestPaymentEntry(ERPNextTestSuite):
 		si.submit()
 
 		pe = get_payment_entry("Sales Invoice", si.name, bank_account="_Test Bank - _TC", bank_amount=4700)
+		pe.source_exchange_rate = 50
+		pe.set_amounts()
 		pe.reference_no = si.name
 		pe.reference_date = nowdate()
 
@@ -607,6 +609,8 @@ class TestPaymentEntry(ERPNextTestSuite):
 		pe = get_payment_entry(
 			"Sales Invoice", si.name, party_amount=20, bank_account="_Test Bank - _TC", bank_amount=900
 		)
+		pe.source_exchange_rate = 50
+		pe.set_amounts()
 		pe.reference_no = "1"
 		pe.reference_date = "2016-01-01"
 

--- a/erpnext/accounts/doctype/payment_entry/test_payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/test_payment_entry.py
@@ -508,6 +508,8 @@ class TestPaymentEntry(ERPNextTestSuite):
 		si.submit()
 
 		pe = get_payment_entry("Sales Invoice", si.name, bank_account="_Test Bank - _TC", bank_amount=4700)
+		pe.source_exchange_rate = 50
+		pe.set_amounts()
 		pe.reference_no = si.name
 		pe.reference_date = nowdate()
 
@@ -583,6 +585,8 @@ class TestPaymentEntry(ERPNextTestSuite):
 		pe = get_payment_entry(
 			"Sales Invoice", si.name, party_amount=20, bank_account="_Test Bank - _TC", bank_amount=900
 		)
+		pe.source_exchange_rate = 50
+		pe.set_amounts()
 		pe.reference_no = "1"
 		pe.reference_date = "2016-01-01"
 

--- a/erpnext/accounts/doctype/payment_request/test_payment_request.py
+++ b/erpnext/accounts/doctype/payment_request/test_payment_request.py
@@ -332,7 +332,12 @@ class TestPaymentRequest(ERPNextTestSuite):
 			return_doc=1,
 		)
 
-		pe = pr.set_as_paid()
+		pe = pr.create_payment_entry(submit=False)
+		pe.source_exchange_rate = 50
+		pe.target_exchange_rate = 50
+		pe.set_amounts()
+		pe.insert(ignore_permissions=True)
+		pe.submit()
 
 		expected_gle = dict(
 			(d[0], d)
@@ -418,7 +423,12 @@ class TestPaymentRequest(ERPNextTestSuite):
 		pr = make_payment_request(dt=po_doc.doctype, dn=po_doc.name, recipient_id="nabin@erpnext.com")
 		pr = frappe.get_doc(pr).save().submit()
 
-		pe = pr.create_payment_entry()
+		pe = pr.create_payment_entry(submit=False)
+		pe.target_exchange_rate = 80
+		pe.paid_amount = 800
+		pe.set_amounts()
+		pe.insert(ignore_permissions=True)
+		pe.submit()
 		self.assertEqual(pe.base_paid_amount, 800)
 		self.assertEqual(pe.paid_amount, 800)
 		self.assertEqual(pe.base_received_amount, 800)

--- a/erpnext/accounts/doctype/payment_request/test_payment_request.py
+++ b/erpnext/accounts/doctype/payment_request/test_payment_request.py
@@ -331,7 +331,12 @@ class TestPaymentRequest(ERPNextTestSuite):
 			return_doc=1,
 		)
 
-		pe = pr.set_as_paid()
+		pe = pr.create_payment_entry(submit=False)
+		pe.source_exchange_rate = 50
+		pe.target_exchange_rate = 50
+		pe.set_amounts()
+		pe.insert(ignore_permissions=True)
+		pe.submit()
 
 		expected_gle = dict(
 			(d[0], d)
@@ -417,7 +422,12 @@ class TestPaymentRequest(ERPNextTestSuite):
 		pr = make_payment_request(dt=po_doc.doctype, dn=po_doc.name, recipient_id="nabin@erpnext.com")
 		pr = frappe.get_doc(pr).save().submit()
 
-		pe = pr.create_payment_entry()
+		pe = pr.create_payment_entry(submit=False)
+		pe.target_exchange_rate = 80
+		pe.paid_amount = 800
+		pe.set_amounts()
+		pe.insert(ignore_permissions=True)
+		pe.submit()
 		self.assertEqual(pe.base_paid_amount, 800)
 		self.assertEqual(pe.paid_amount, 800)
 		self.assertEqual(pe.base_received_amount, 800)

--- a/erpnext/accounts/test/test_utils.py
+++ b/erpnext/accounts/test/test_utils.py
@@ -80,6 +80,8 @@ class TestUtils(ERPNextTestSuite):
 		purchase_invoice.submit()
 
 		payment_entry = get_payment_entry(purchase_invoice.doctype, purchase_invoice.name)
+		payment_entry.target_exchange_rate = 82.32
+		payment_entry.set_amounts()
 		payment_entry.paid_amount = 15725
 		payment_entry.deductions = []
 		payment_entry.save()

--- a/erpnext/accounts/test/test_utils.py
+++ b/erpnext/accounts/test/test_utils.py
@@ -78,6 +78,8 @@ class TestUtils(ERPNextTestSuite):
 		purchase_invoice.submit()
 
 		payment_entry = get_payment_entry(purchase_invoice.doctype, purchase_invoice.name)
+		payment_entry.target_exchange_rate = 82.32
+		payment_entry.set_amounts()
 		payment_entry.paid_amount = 15725
 		payment_entry.deductions = []
 		payment_entry.save()


### PR DESCRIPTION
**Issue:**
The Field "Source Exchange Rate" is not updating Run-time when accessed from Purchase or Sales Invoice.

**Steps to Reproduce**

1. A Sales Invoice was created with a backdated Posting Date for an export customer. The system correctly fetched the exchange rate applicable to the selected posting date.
2. The Sales Invoice was submitted, and a Payment Entry was generated using the “Create” button.
3. In the Payment Entry, the Posting Date was automatically set to the current date. However, the “Source Exchange Rate” field reflected the exchange rate based on the Invoice Posting Date instead of the current Posting Date.

**Ref:**[#61394](https://support.frappe.io/helpdesk/tickets/61394)
