### PR TITLE
fix: prevent previous warehouse from being reused in item defaults resolution

### DIFF
--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -603,7 +603,7 @@ def get_item_warehouse_(ctx: ItemDetailsCtx, item, overwrite_warehouse, defaults
 			or defaults.item_defaults.get("default_warehouse")
 			or defaults.item_group_defaults.get("default_warehouse")
 			or defaults.brand_defaults.get("default_warehouse")
-			or ctx.warehouse
+			or None
 		)
 
 	else:


### PR DESCRIPTION
prevention of the usage of the previous value, now it removes the value if no default is found.