### PR TITLE
fix: skip asset sale processing for internal transfer invoices

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -1452,6 +1452,9 @@ class SalesInvoice(SellingController):
 		return asset_qty_map
 
 	def process_asset_depreciation(self):
+		if self.is_internal_transfer():
+			return
+
 		if (self.is_return and self.docstatus == 2) or (not self.is_return and self.docstatus == 1):
 			self.depreciate_asset_on_sale()
 		else:


### PR DESCRIPTION
Internal support Issue: https://support.frappe.io/helpdesk/tickets/61249