### PR TITLE
fix: allow payment_request to be created in draft

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -543,7 +543,7 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 						schedules: selected,
 					},
 				});
-
+				frappe.model.sync(pr_name);
 				frappe.set_route("Form", "Payment Request", pr_name.name);
 			},
 		});


### PR DESCRIPTION
**Issue:**
When creating a Payment Request from a Purchase Order, the system does not open the Payment Request document directly; instead, it redirects to the list view. 

**Ref:**[#61233](https://support.frappe.io/helpdesk/tickets/61233), [#61866](https://support.frappe.io/helpdesk/tickets/61866), [#61585](https://support.frappe.io/helpdesk/tickets/61585)