### PR TITLE
fix(accounts): skip permission check for Shopping Cart payment requests

### DIFF
--- a/erpnext/accounts/doctype/payment_request/payment_request.py
+++ b/erpnext/accounts/doctype/payment_request/payment_request.py
@@ -569,11 +569,15 @@ def make_payment_request(**args):
 	if args.dn and not isinstance(args.dn, str):
 		frappe.throw(_("Invalid parameter. 'dn' should be of type str"))
 
-	if args.order_type != "Shopping Cart":
+	ref_doc = args.ref_doc or frappe.get_doc(args.dt, args.dn)
+	is_shopping_cart_flow = (
+		args.order_type == "Shopping Cart"
+		and ref_doc.doctype == "Sales Order"
+		and ref_doc.get("order_type") == "Shopping Cart"
+	)
+	if not is_shopping_cart_flow:
 		frappe.has_permission("Payment Request", "create", throw=True)
 		frappe.has_permission(args.dt, "read", args.dn, throw=True)
-
-	ref_doc = args.ref_doc or frappe.get_doc(args.dt, args.dn)
 	if not args.get("company"):
 		args.company = ref_doc.company
 

--- a/erpnext/accounts/doctype/payment_request/payment_request.py
+++ b/erpnext/accounts/doctype/payment_request/payment_request.py
@@ -569,8 +569,9 @@ def make_payment_request(**args):
 	if args.dn and not isinstance(args.dn, str):
 		frappe.throw(_("Invalid parameter. 'dn' should be of type str"))
 
-	frappe.has_permission("Payment Request", "create", throw=True)
-	frappe.has_permission(args.dt, "read", args.dn, throw=True)
+	if args.order_type != "Shopping Cart":
+		frappe.has_permission("Payment Request", "create", throw=True)
+		frappe.has_permission(args.dt, "read", args.dn, throw=True)
 
 	ref_doc = args.ref_doc or frappe.get_doc(args.dt, args.dn)
 	if not args.get("company"):


### PR DESCRIPTION
## Summary
- Guest checkout fails with `PermissionError` when creating a Payment Request via Shopping Cart
- Commit f36962fc58 added `frappe.has_permission("Payment Request", "create", throw=True)` which blocks guest/portal users who don't have explicit create permission
- The Shopping Cart flow already uses `ignore_permissions=True` when inserting the Payment Request (lines 746/749), so the upstream gate is redundant for this path
- Fix: skip the permission check when `order_type == "Shopping Cart"`

Fixes #52844

## Test plan
- [x] All 21 `test_payment_request` tests pass
- [x] Manual test: as Guest user, calling `make_payment_request(order_type="Shopping Cart")` no longer raises `PermissionError` (fails with `DoesNotExistError` for missing doc instead)
- [x] Manual test: as Guest user, calling `make_payment_request(order_type="Other")` still raises `PermissionError` as expected
- [x] Ruff lint/format pass
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)