### PR TITLE
fix: read demo data from all app paths

### DIFF
--- a/erpnext/setup/demo.py
+++ b/erpnext/setup/demo.py
@@ -244,9 +244,16 @@ def delete_company(company):
 
 
 def read_data_file_using_hooks(doctype):
-	path = os.path.join(os.path.dirname(__file__), "demo_data")
-	with open(os.path.join(path, doctype + ".json")) as f:
-		data = f.read()
+	apps = frappe.get_installed_apps()
+	data = None
+	for app in apps:
+		path = frappe.get_app_path(app, "setup")
+		try:
+			with open(os.path.join(path, "demo_data", doctype + ".json")) as f:
+				data = f.read()
+			break
+		except FileNotFoundError:
+			continue
 
 	return data
 


### PR DESCRIPTION
> Please provide enough information so that others can review your pull request:

- demo data was being read only from erpnext/setup/demo_data
- fix makes demo_data to be read from custom_app/setup/demo_data