### PR TITLE
fix(accounts): sync Purchase Invoice title when supplier changes

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
@@ -267,6 +267,8 @@ class PurchaseInvoice(BuyingController):
 
 		super().validate()
 
+		self.title = self.supplier_name
+
 		if not self.is_return:
 			self.po_required()
 			self.pr_required()


### PR DESCRIPTION
## Summary
- Purchase Invoice `title` field defaults to `{supplier_name}` at creation but never updates when the supplier is changed, causing stale names in list views
- Added `self.title = self.supplier_name` in `validate()` to keep it in sync, matching the pattern used by Payment Entry and Journal Entry

Closes #52662

## Test plan
- [x] Create a new Purchase Invoice with a supplier and save it
- [x] Change the supplier to a different one and save again
- [x] Verify the title updates to the new supplier's name
- [x] Check the Purchase Invoice list view shows the updated name

Manually tested on a local bench dev server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)