### PR TITLE
fix: update user status depends on employee status

### DIFF
--- a/erpnext/setup/doctype/employee/employee.py
+++ b/erpnext/setup/doctype/employee/employee.py
@@ -183,13 +183,11 @@ class Employee(NestedSet):
 				throw(_("Please enter relieving date."))
 
 	def validate_for_enabled_user_id(self, enabled):
-		if self.status != "Active":
-			return
-
 		if enabled is None:
 			frappe.throw(_("User {0} does not exist").format(self.user_id))
-		if enabled == 0:
-			frappe.throw(_("User {0} is disabled").format(self.user_id), EmployeeUserDisabledError)
+
+		if self.status != "Active" and enabled or self.status == "Active" and enabled == 0:
+			frappe.set_value("User", self.user_id, "enabled", not enabled)
 
 	def validate_duplicate_user_id(self):
 		Employee = frappe.qb.DocType("Employee")


### PR DESCRIPTION
**Issue**: When an employee is marked as inactive, the linked user account still remains active.

**Ref**: [61459](https://support.frappe.io/helpdesk/tickets/61459?view=VIEW-HD+Ticket-781)

**Before**:

https://github.com/user-attachments/assets/fadc5e7b-86d1-4ac4-b705-329b06f2338d


**After**:

https://github.com/user-attachments/assets/2320c13a-d8a0-4423-aee1-faa21c43f5f9


Backport needed **version-16**, **version-15**

