### PR TITLE
refactor: add type-hints in whitelisted functions

### DIFF
--- a/erpnext/crm/doctype/lead/lead.py
+++ b/erpnext/crm/doctype/lead/lead.py
@@ -10,6 +10,7 @@ from frappe.contacts.address_and_contact import (
 from frappe.contacts.doctype.address.address import get_default_address
 from frappe.contacts.doctype.contact.contact import get_default_contact
 from frappe.email.inbox import link_communication_to_document
+from frappe.model.document import Document
 from frappe.model.mapper import get_mapped_doc
 from frappe.utils import comma_and, get_link_to_form, has_gravatar, validate_email_address
 
@@ -314,7 +315,7 @@ class Lead(SellingController, CRMNote):
 
 
 @frappe.whitelist()
-def make_customer(source_name, target_doc=None):
+def make_customer(source_name: str, target_doc: str | Document | None = None):
 	return _make_customer(source_name, target_doc)
 
 
@@ -361,7 +362,7 @@ def _make_customer(source_name, target_doc=None, ignore_permissions=False):
 
 
 @frappe.whitelist()
-def make_opportunity(source_name, target_doc=None):
+def make_opportunity(source_name: str, target_doc: str | Document | None = None):
 	def set_missing_values(source, target):
 		_set_missing_values(source, target)
 
@@ -391,7 +392,7 @@ def make_opportunity(source_name, target_doc=None):
 
 
 @frappe.whitelist()
-def make_quotation(source_name, target_doc=None):
+def make_quotation(source_name: str, target_doc: str | Document | None = None):
 	def set_missing_values(source, target):
 		_set_missing_values(source, target)
 

--- a/erpnext/crm/doctype/opportunity/opportunity.py
+++ b/erpnext/crm/doctype/opportunity/opportunity.py
@@ -8,6 +8,7 @@ import frappe
 from frappe import _
 from frappe.contacts.address_and_contact import load_address_and_contact
 from frappe.email.inbox import link_communication_to_document
+from frappe.model.document import Document
 from frappe.model.mapper import get_mapped_doc
 from frappe.query_builder import DocType, Interval
 from frappe.query_builder.functions import Now
@@ -380,7 +381,7 @@ def get_item_details(item_code):
 
 
 @frappe.whitelist()
-def make_quotation(source_name, target_doc=None):
+def make_quotation(source_name: str, target_doc: str | Document | None = None):
 	def set_missing_values(source, target):
 		from erpnext.controllers.accounts_controller import get_default_taxes_and_charges
 
@@ -433,7 +434,7 @@ def make_quotation(source_name, target_doc=None):
 
 
 @frappe.whitelist()
-def make_request_for_quotation(source_name, target_doc=None):
+def make_request_for_quotation(source_name: str, target_doc: str | Document | None = None):
 	def update_item(obj, target, source_parent):
 		target.conversion_factor = 1.0
 
@@ -455,7 +456,7 @@ def make_request_for_quotation(source_name, target_doc=None):
 
 
 @frappe.whitelist()
-def make_customer(source_name, target_doc=None):
+def make_customer(source_name: str, target_doc: str | Document | None = None):
 	def set_missing_values(source, target):
 		target.opportunity_name = source.name
 
@@ -479,7 +480,7 @@ def make_customer(source_name, target_doc=None):
 
 
 @frappe.whitelist()
-def make_supplier_quotation(source_name, target_doc=None):
+def make_supplier_quotation(source_name: str, target_doc: str | Document | None = None):
 	doclist = get_mapped_doc(
 		"Opportunity",
 		source_name,

--- a/erpnext/crm/doctype/prospect/prospect.py
+++ b/erpnext/crm/doctype/prospect/prospect.py
@@ -6,6 +6,7 @@ from frappe.contacts.address_and_contact import (
 	delete_contact_and_address,
 	load_address_and_contact,
 )
+from frappe.model.document import Document
 from frappe.model.mapper import get_mapped_doc
 
 from erpnext.crm.utils import CRMNote, copy_comments, link_communications, link_open_events
@@ -87,7 +88,7 @@ class Prospect(CRMNote):
 
 
 @frappe.whitelist()
-def make_customer(source_name, target_doc=None):
+def make_customer(source_name: str, target_doc: str | Document | None = None):
 	def set_missing_values(source, target):
 		target.customer_type = "Company"
 		target.company_name = source.name
@@ -111,7 +112,7 @@ def make_customer(source_name, target_doc=None):
 
 
 @frappe.whitelist()
-def make_opportunity(source_name, target_doc=None):
+def make_opportunity(source_name: str, target_doc: str | Document | None = None):
 	def set_missing_values(source, target):
 		target.opportunity_from = "Prospect"
 		target.customer_name = source.company_name

--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
@@ -1577,7 +1577,7 @@ def make_purchase_return(source_name: str, target_doc: str | Document | None = N
 
 
 @frappe.whitelist()
-def update_purchase_receipt_status(docname, status):
+def update_purchase_receipt_status(docname: str, status: str):
 	pr = frappe.get_lazy_doc("Purchase Receipt", docname)
 	pr.update_status(status)
 

--- a/erpnext/support/doctype/issue/issue.py
+++ b/erpnext/support/doctype/issue/issue.py
@@ -216,13 +216,13 @@ def get_issue_list(doctype, txt, filters, limit_start, limit_page_length=20, ord
 
 
 @frappe.whitelist()
-def set_multiple_status(names, status):
+def set_multiple_status(names: str, status: str):
 	for name in json.loads(names):
 		frappe.db.set_value("Issue", name, "status", status)
 
 
 @frappe.whitelist()
-def set_status(name, status):
+def set_status(name: str, status: str):
 	frappe.db.set_value("Issue", name, "status", status)
 
 
@@ -261,12 +261,12 @@ def update_issue(contact, method):
 
 
 @frappe.whitelist()
-def make_task(source_name, target_doc=None):
+def make_task(source_name: str, target_doc: str | Document | None = None):
 	return get_mapped_doc("Issue", source_name, {"Issue": {"doctype": "Task"}}, target_doc)
 
 
 @frappe.whitelist()
-def make_issue_from_communication(communication, ignore_communication_links=False):
+def make_issue_from_communication(communication: str, ignore_communication_links: bool = False):
 	"""raise a issue from email"""
 
 	doc = frappe.get_doc("Communication", communication)

--- a/erpnext/support/doctype/warranty_claim/warranty_claim.py
+++ b/erpnext/support/doctype/warranty_claim/warranty_claim.py
@@ -4,6 +4,7 @@
 
 import frappe
 from frappe import _, session
+from frappe.model.document import Document
 from frappe.utils import now_datetime
 
 from erpnext.utilities.transaction_base import TransactionBase
@@ -78,7 +79,7 @@ class WarrantyClaim(TransactionBase):
 
 
 @frappe.whitelist()
-def make_maintenance_visit(source_name, target_doc=None):
+def make_maintenance_visit(source_name: str, target_doc: str | Document | None = None):
 	from frappe.model.mapper import get_mapped_doc, map_child_doc
 
 	def _update_links(source_doc, target_doc, source_parent):


### PR DESCRIPTION
Adds Python type annotations to standalone `@frappe.whitelist()` module-level functions across **CRM**, **Stock**, **Support**, and **Telephony** modules.
