### PR TITLE
fix: correct payment terms fetching and recalculation logic

### DIFF
--- a/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
+++ b/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
@@ -216,7 +216,7 @@
    "description": "Payment Terms from orders will be fetched into the invoices as is",
    "fieldname": "automatically_fetch_payment_terms",
    "fieldtype": "Check",
-   "label": "Automatically Fetch Payment Terms from Order"
+   "label": "Automatically Fetch Payment Terms from Order/Quotation"
   },
   {
    "description": "The percentage you are allowed to bill more against the amount ordered. For example, if the order value is $100 for an item and tolerance is set as 10%, then you are allowed to bill up to $110 ",
@@ -671,7 +671,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-12-26 19:46:55.093717",
+ "modified": "2026-02-27 01:04:09.415288",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Accounts Settings",

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -2502,13 +2502,14 @@ class AccountsController(TransactionBase):
 		grand_total = self.get("rounded_total") or self.grand_total
 		automatically_fetch_payment_terms = 0
 
-		if self.doctype in ("Sales Invoice", "Purchase Invoice"):
-			base_grand_total = base_grand_total - flt(self.base_write_off_amount)
-			grand_total = grand_total - flt(self.write_off_amount)
+		if self.doctype in ("Sales Invoice", "Purchase Invoice", "Sales Order"):
 			po_or_so, doctype, fieldname = self.get_order_details()
 			automatically_fetch_payment_terms = cint(
 				frappe.db.get_single_value("Accounts Settings", "automatically_fetch_payment_terms")
 			)
+			if self.doctype != "Sales Order":
+				base_grand_total = base_grand_total - flt(self.base_write_off_amount)
+				grand_total = grand_total - flt(self.write_off_amount)
 
 		if self.get("total_advance"):
 			if party_account_currency == self.company_currency:
@@ -2524,7 +2525,7 @@ class AccountsController(TransactionBase):
 
 		if not self.get("payment_schedule"):
 			if (
-				self.doctype in ["Sales Invoice", "Purchase Invoice"]
+				self.doctype in ["Sales Invoice", "Purchase Invoice", "Sales Order"]
 				and automatically_fetch_payment_terms
 				and self.linked_order_has_payment_terms(po_or_so, fieldname, doctype)
 			):
@@ -2580,16 +2581,18 @@ class AccountsController(TransactionBase):
 
 	def get_order_details(self):
 		if self.doctype == "Sales Invoice":
-			po_or_so = self.get("items") and self.get("items")[0].get("sales_order")
-			po_or_so_doctype = "Sales Order"
-			po_or_so_doctype_name = "sales_order"
-
+			prev_doc = self.get("items")[0].get("sales_order")
+			prev_doctype = "Sales Order"
+			prev_doctype_name = "sales_order"
+		elif self.doctype == "Purchase Invoice":
+			prev_doc = self.get("items")[0].get("purchase_order")
+			prev_doctype = "Purchase Order"
+			prev_doctype_name = "purchase_order"
 		else:
-			po_or_so = self.get("items") and self.get("items")[0].get("purchase_order")
-			po_or_so_doctype = "Purchase Order"
-			po_or_so_doctype_name = "purchase_order"
-
-		return po_or_so, po_or_so_doctype, po_or_so_doctype_name
+			prev_doc = self.get("items")[0].get("prevdoc_docname")
+			prev_doctype = "Quotation"
+			prev_doctype_name = "prevdoc_docname"
+		return prev_doc, prev_doctype, prev_doctype_name
 
 	def linked_order_has_payment_terms(self, po_or_so, fieldname, doctype):
 		if po_or_so and self.all_items_have_same_po_or_so(po_or_so, fieldname):

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -1052,6 +1052,7 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 		if (this.frm.doc.transaction_date) {
 			this.frm.transaction_date = this.frm.doc.transaction_date;
 			frappe.ui.form.trigger(this.frm.doc.doctype, "currency");
+			this.recalculate_terms();
 		}
 	}
 

--- a/erpnext/selling/doctype/quotation/quotation.py
+++ b/erpnext/selling/doctype/quotation/quotation.py
@@ -442,34 +442,33 @@ def _make_sales_order(source_name, target_doc=None, ignore_permissions=False, ar
 		child_filter = d.name in filtered_items if filtered_items else True
 		return child_filter
 
-	doclist = get_mapped_doc(
-		"Quotation",
-		source_name,
-		{
-			"Quotation": {
-				"doctype": "Sales Order",
-				"validation": {"docstatus": ["=", 1]},
-			},
-			"Quotation Item": {
-				"doctype": "Sales Order Item",
-				"field_map": {"parent": "prevdoc_docname", "name": "quotation_item"},
-				"postprocess": update_item,
-				"condition": lambda d: can_map_row(d) and select_item(d),
-			},
-			"Sales Taxes and Charges": {"doctype": "Sales Taxes and Charges", "reset_value": True},
-			"Sales Team": {"doctype": "Sales Team", "add_if_empty": True},
-		},
-		target_doc,
-		set_missing_values,
-		ignore_permissions=ignore_permissions,
-	)
-
 	automatically_fetch_payment_terms = cint(
 		frappe.get_single_value("Selling Settings", "automatically_fetch_payment_terms_from_quotation")
 	)
 
+	mapping = {
+		"Quotation": {"doctype": "Sales Order", "validation": {"docstatus": ["=", 1]}},
+		"Quotation Item": {
+			"doctype": "Sales Order Item",
+			"field_map": {"parent": "prevdoc_docname", "name": "quotation_item"},
+			"postprocess": update_item,
+			"condition": lambda d: can_map_row(d) and select_item(d),
+		},
+		"Sales Taxes and Charges": {"doctype": "Sales Taxes and Charges", "reset_value": True},
+		"Sales Team": {"doctype": "Sales Team", "add_if_empty": True},
+	}
+
 	if automatically_fetch_payment_terms:
-		doclist.set_payment_schedule()
+		mapping["Payment Schedule"] = {"doctype": "Payment Schedule", "add_if_empty": True}
+
+	doclist = get_mapped_doc(
+		"Quotation",
+		source_name,
+		mapping,
+		target_doc,
+		set_missing_values,
+		ignore_permissions=ignore_permissions,
+	)
 
 	return doclist
 

--- a/erpnext/selling/doctype/quotation/quotation.py
+++ b/erpnext/selling/doctype/quotation/quotation.py
@@ -443,34 +443,34 @@ def _make_sales_order(source_name, target_doc=None, ignore_permissions=False, ar
 		return child_filter
 
 	automatically_fetch_payment_terms = cint(
-		frappe.get_single_value("Selling Settings", "automatically_fetch_payment_terms_from_quotation")
+		frappe.get_single_value("Accounts Settings", "automatically_fetch_payment_terms")
 	)
-
-	mapping = {
-		"Quotation": {"doctype": "Sales Order", "validation": {"docstatus": ["=", 1]}},
-		"Quotation Item": {
-			"doctype": "Sales Order Item",
-			"field_map": {"parent": "prevdoc_docname", "name": "quotation_item"},
-			"postprocess": update_item,
-			"condition": lambda d: can_map_row(d) and select_item(d),
-		},
-		"Sales Taxes and Charges": {"doctype": "Sales Taxes and Charges", "reset_value": True},
-		"Sales Team": {"doctype": "Sales Team", "add_if_empty": True},
-	}
-
-	if automatically_fetch_payment_terms:
-		mapping["Payment Schedule"] = {"doctype": "Payment Schedule", "add_if_empty": True}
-	else:
-		mapping["Quotation"]["field_no_map"] = ["payment_terms_template"]
 
 	doclist = get_mapped_doc(
 		"Quotation",
 		source_name,
-		mapping,
+		{
+			"Quotation": {
+				"doctype": "Sales Order",
+				"validation": {"docstatus": ["=", 1]},
+				"field_no_map": ["payment_terms_template"],
+			},
+			"Quotation Item": {
+				"doctype": "Sales Order Item",
+				"field_map": {"parent": "prevdoc_docname", "name": "quotation_item"},
+				"postprocess": update_item,
+				"condition": lambda d: can_map_row(d) and select_item(d),
+			},
+			"Sales Taxes and Charges": {"doctype": "Sales Taxes and Charges", "reset_value": True},
+			"Sales Team": {"doctype": "Sales Team", "add_if_empty": True},
+		},
 		target_doc,
 		set_missing_values,
 		ignore_permissions=ignore_permissions,
 	)
+
+	if automatically_fetch_payment_terms:
+		doclist.set_payment_schedule()
 
 	return doclist
 

--- a/erpnext/selling/doctype/quotation/quotation.py
+++ b/erpnext/selling/doctype/quotation/quotation.py
@@ -7,7 +7,7 @@ import json
 import frappe
 from frappe import _
 from frappe.model.mapper import get_mapped_doc
-from frappe.utils import flt, getdate, nowdate
+from frappe.utils import cint, flt, getdate, nowdate
 
 from erpnext.controllers.selling_controller import SellingController
 
@@ -458,12 +458,18 @@ def _make_sales_order(source_name, target_doc=None, ignore_permissions=False, ar
 			},
 			"Sales Taxes and Charges": {"doctype": "Sales Taxes and Charges", "reset_value": True},
 			"Sales Team": {"doctype": "Sales Team", "add_if_empty": True},
-			"Payment Schedule": {"doctype": "Payment Schedule", "add_if_empty": True},
 		},
 		target_doc,
 		set_missing_values,
 		ignore_permissions=ignore_permissions,
 	)
+
+	automatically_fetch_payment_terms = cint(
+		frappe.get_single_value("Selling Settings", "automatically_fetch_payment_terms_from_quotation")
+	)
+
+	if automatically_fetch_payment_terms:
+		doclist.set_payment_schedule()
 
 	return doclist
 

--- a/erpnext/selling/doctype/quotation/quotation.py
+++ b/erpnext/selling/doctype/quotation/quotation.py
@@ -460,6 +460,8 @@ def _make_sales_order(source_name, target_doc=None, ignore_permissions=False, ar
 
 	if automatically_fetch_payment_terms:
 		mapping["Payment Schedule"] = {"doctype": "Payment Schedule", "add_if_empty": True}
+	else:
+		mapping["Quotation"]["field_no_map"] = ["payment_terms_template"]
 
 	doclist = get_mapped_doc(
 		"Quotation",

--- a/erpnext/selling/doctype/quotation/test_quotation.py
+++ b/erpnext/selling/doctype/quotation/test_quotation.py
@@ -175,6 +175,10 @@ class TestQuotation(FrappeTestCase):
 
 		self.assertTrue(quotation.payment_schedule)
 
+	@IntegrationTestCase.change_settings(
+		"Selling Settings",
+		{"automatically_fetch_payment_terms_from_quotation": 1},
+	)
 	def test_make_sales_order_terms_copied(self):
 		from erpnext.selling.doctype.quotation.quotation import make_sales_order
 
@@ -318,6 +322,10 @@ class TestQuotation(FrappeTestCase):
 	@change_settings(
 		"Accounts Settings",
 		{"add_taxes_from_item_tax_template": 0, "add_taxes_from_taxes_and_charges_template": 0},
+	)
+	@IntegrationTestCase.change_settings(
+		"Selling Settings",
+		{"automatically_fetch_payment_terms_from_quotation": 1},
 	)
 	def test_make_sales_order_with_terms(self):
 		from erpnext.selling.doctype.quotation.quotation import make_sales_order

--- a/erpnext/selling/doctype/quotation/test_quotation.py
+++ b/erpnext/selling/doctype/quotation/test_quotation.py
@@ -175,9 +175,9 @@ class TestQuotation(FrappeTestCase):
 
 		self.assertTrue(quotation.payment_schedule)
 
-	@IntegrationTestCase.change_settings(
-		"Selling Settings",
-		{"automatically_fetch_payment_terms_from_quotation": 1},
+	@change_settings(
+		"Accounts Settings",
+		{"automatically_fetch_payment_terms": 1},
 	)
 	def test_make_sales_order_terms_copied(self):
 		from erpnext.selling.doctype.quotation.quotation import make_sales_order
@@ -321,11 +321,11 @@ class TestQuotation(FrappeTestCase):
 
 	@change_settings(
 		"Accounts Settings",
-		{"add_taxes_from_item_tax_template": 0, "add_taxes_from_taxes_and_charges_template": 0},
-	)
-	@IntegrationTestCase.change_settings(
-		"Selling Settings",
-		{"automatically_fetch_payment_terms_from_quotation": 1},
+		{
+			"add_taxes_from_item_tax_template": 0,
+			"add_taxes_from_taxes_and_charges_template": 0,
+			"automatically_fetch_payment_terms": 1,
+		},
 	)
 	def test_make_sales_order_with_terms(self):
 		from erpnext.selling.doctype.quotation.quotation import make_sales_order
@@ -363,10 +363,13 @@ class TestQuotation(FrappeTestCase):
 		sales_order.save()
 
 		self.assertEqual(sales_order.payment_schedule[0].payment_amount, 8906.00)
-		self.assertEqual(sales_order.payment_schedule[0].due_date, getdate(quotation.transaction_date))
+		self.assertEqual(
+			getdate(sales_order.payment_schedule[0].due_date), getdate(quotation.transaction_date)
+		)
 		self.assertEqual(sales_order.payment_schedule[1].payment_amount, 8906.00)
 		self.assertEqual(
-			sales_order.payment_schedule[1].due_date, getdate(add_days(quotation.transaction_date, 30))
+			getdate(sales_order.payment_schedule[1].due_date),
+			getdate(add_days(quotation.transaction_date, 30)),
 		)
 
 	def test_valid_till_before_transaction_date(self):
@@ -1065,6 +1068,56 @@ class TestQuotation(FrappeTestCase):
 
 		quotation.reload()
 		self.assertEqual(quotation.status, "Open")
+
+	@change_settings(
+		"Accounts Settings",
+		{"automatically_fetch_payment_terms": 1},
+	)
+	def test_make_sales_order_with_payment_terms(self):
+		from erpnext.selling.doctype.quotation.quotation import make_sales_order
+
+		template = frappe.get_doc(
+			{
+				"doctype": "Payment Terms Template",
+				"template_name": "_Test Payment Terms Template for Quotation",
+				"terms": [
+					{
+						"doctype": "Payment Terms Template Detail",
+						"invoice_portion": 50.00,
+						"credit_days_based_on": "Day(s) after invoice date",
+						"credit_days": 0,
+					},
+					{
+						"doctype": "Payment Terms Template Detail",
+						"invoice_portion": 50.00,
+						"credit_days_based_on": "Day(s) after invoice date",
+						"credit_days": 10,
+					},
+				],
+			}
+		).save()
+
+		quotation = make_quotation(qty=10, rate=1000, do_not_submit=1)
+		quotation.transaction_date = add_days(nowdate(), -2)
+		quotation.valid_till = add_days(nowdate(), 10)
+		quotation.update({"payment_terms_template": template.name, "payment_schedule": []})
+		quotation.save()
+		quotation.submit()
+
+		self.assertEqual(quotation.payment_schedule[0].payment_amount, 5000)
+		self.assertEqual(quotation.payment_schedule[1].payment_amount, 5000)
+		self.assertEqual(quotation.payment_schedule[0].due_date, quotation.transaction_date)
+		self.assertEqual(quotation.payment_schedule[1].due_date, add_days(quotation.transaction_date, 10))
+
+		sales_order = make_sales_order(quotation.name)
+		sales_order.transaction_date = nowdate()
+		sales_order.delivery_date = nowdate()
+		sales_order.save()
+
+		self.assertEqual(sales_order.payment_schedule[0].due_date, sales_order.transaction_date)
+		self.assertEqual(sales_order.payment_schedule[1].due_date, add_days(sales_order.transaction_date, 10))
+		self.assertEqual(sales_order.payment_schedule[0].payment_amount, 5000)
+		self.assertEqual(sales_order.payment_schedule[1].payment_amount, 5000)
 
 
 test_records = frappe.get_test_records("Quotation")

--- a/erpnext/selling/doctype/sales_order/sales_order.json
+++ b/erpnext/selling/doctype/sales_order/sales_order.json
@@ -120,6 +120,7 @@
   "company_contact_person",
   "payment_schedule_section",
   "payment_terms_section",
+  "ignore_default_payment_terms_template",
   "payment_terms_template",
   "payment_schedule",
   "terms_section_break",
@@ -1665,13 +1666,90 @@
    "fieldtype": "Data",
    "is_virtual": 1,
    "label": "Last Scanned Warehouse"
+  },
+  {
+   "default": "0",
+   "fieldname": "is_subcontracted",
+   "fieldtype": "Check",
+   "label": "Is Subcontracted",
+   "print_hide": 1
+  },
+  {
+   "fieldname": "item_wise_tax_details",
+   "fieldtype": "Table",
+   "hidden": 1,
+   "label": "Item Wise Tax Details",
+   "no_copy": 1,
+   "options": "Item Wise Tax Detail",
+   "print_hide": 1
+  },
+  {
+   "fieldname": "totals_section",
+   "fieldtype": "Section Break",
+   "hide_days": 1,
+   "hide_seconds": 1,
+   "label": "Totals",
+   "oldfieldtype": "Section Break",
+   "options": "fa fa-money",
+   "print_hide": 1
+  },
+  {
+   "fieldname": "base_totals_section",
+   "fieldtype": "Section Break",
+   "label": "Totals (Company Currency)"
+  },
+  {
+   "fieldname": "column_break_nuxg",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "column_break_bgfw",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "section_break_efew",
+   "fieldtype": "Section Break"
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "additional_discount_section",
+   "fieldtype": "Section Break",
+   "hide_days": 1,
+   "hide_seconds": 1,
+   "label": "Additional Discount"
+  },
+  {
+   "fieldname": "column_break_ijxt",
+   "fieldtype": "Column Break"
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "utm_analytics_section",
+   "fieldtype": "Section Break",
+   "label": "UTM Analytics"
+  },
+  {
+   "default": "Now",
+   "depends_on": "is_internal_customer",
+   "fieldname": "transaction_time",
+   "fieldtype": "Time",
+   "label": "Time",
+   "mandatory_depends_on": "is_internal_customer"
+  },
+  {
+   "default": "0",
+   "fieldname": "ignore_default_payment_terms_template",
+   "fieldtype": "Check",
+   "hidden": 1,
+   "label": "Ignore Default Payment Terms Template",
+   "read_only": 1
   }
  ],
  "icon": "fa fa-file-text",
  "idx": 105,
  "is_submittable": 1,
  "links": [],
- "modified": "2026-02-06 11:06:16.092658",
+ "modified": "2026-03-04 18:04:05.873483",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Sales Order",

--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -111,6 +111,7 @@ class SalesOrder(SellingController):
 		grand_total: DF.Currency
 		group_same_items: DF.Check
 		has_unit_price_items: DF.Check
+		ignore_default_payment_terms_template: DF.Check
 		ignore_pricing_rule: DF.Check
 		in_words: DF.Data | None
 		incoterm: DF.Link | None

--- a/erpnext/selling/doctype/selling_settings/selling_settings.json
+++ b/erpnext/selling/doctype/selling_settings/selling_settings.json
@@ -36,7 +36,17 @@
   "enable_discount_accounting",
   "allow_zero_qty_in_quotation",
   "allow_zero_qty_in_sales_order",
-  "set_zero_rate_for_expired_batch"
+  "set_zero_rate_for_expired_batch",
+  "automatically_fetch_payment_terms_from_quotation",
+  "section_break_avhb",
+  "enable_utm",
+  "experimental_section",
+  "use_legacy_js_reactivity",
+  "subcontracting_inward_tab",
+  "section_break_zwh6",
+  "allow_delivery_of_overproduced_qty",
+  "column_break_mla9",
+  "deliver_scrap_items"
  ],
  "fields": [
   {
@@ -232,6 +242,32 @@
    "fieldname": "set_zero_rate_for_expired_batch",
    "fieldtype": "Check",
    "label": "Set Incoming Rate as Zero for Expired Batch"
+  },
+  {
+   "default": "0",
+   "description": "Manage sales partner's and sales team's commissions",
+   "fieldname": "enable_tracking_sales_commissions",
+   "fieldtype": "Check",
+   "label": "Enable tracking sales commissions"
+  },
+  {
+   "fieldname": "section_break_avhb",
+   "fieldtype": "Section Break",
+   "label": "Analytics"
+  },
+  {
+   "default": "0",
+   "description": "Enable Urchin Tracking Module parameters in Quotation, Sales Order, Sales Invoice, POS Invoice, Lead,  and Delivery Note.",
+   "documentation_url": "https://en.wikipedia.org/wiki/UTM_parameters",
+   "fieldname": "enable_utm",
+   "fieldtype": "Check",
+   "label": "Enable UTM"
+   },
+  {
+   "default": "0",
+   "fieldname": "automatically_fetch_payment_terms_from_quotation",
+   "fieldtype": "Check",
+   "label": "Automatically Fetch Payment Terms from Quotation"
   }
  ],
  "grid_page_length": 50,

--- a/erpnext/selling/doctype/selling_settings/selling_settings.json
+++ b/erpnext/selling/doctype/selling_settings/selling_settings.json
@@ -262,9 +262,9 @@
    "fieldname": "enable_utm",
    "fieldtype": "Check",
    "label": "Enable UTM"
-   },
+  },
   {
-   "default": "0",
+   "default": "1",
    "fieldname": "automatically_fetch_payment_terms_from_quotation",
    "fieldtype": "Check",
    "label": "Automatically Fetch Payment Terms from Quotation"
@@ -276,7 +276,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2026-01-24 00:04:33.105916",
+ "modified": "2026-02-18 21:25:56.307468",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Selling Settings",

--- a/erpnext/selling/doctype/selling_settings/selling_settings.json
+++ b/erpnext/selling/doctype/selling_settings/selling_settings.json
@@ -37,7 +37,6 @@
   "allow_zero_qty_in_quotation",
   "allow_zero_qty_in_sales_order",
   "set_zero_rate_for_expired_batch",
-  "automatically_fetch_payment_terms_from_quotation",
   "section_break_avhb",
   "enable_utm",
   "experimental_section",
@@ -262,12 +261,6 @@
    "fieldname": "enable_utm",
    "fieldtype": "Check",
    "label": "Enable UTM"
-  },
-  {
-   "default": "1",
-   "fieldname": "automatically_fetch_payment_terms_from_quotation",
-   "fieldtype": "Check",
-   "label": "Automatically Fetch Payment Terms from Quotation"
   }
  ],
  "grid_page_length": 50,
@@ -276,7 +269,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2026-02-18 21:25:56.307468",
+ "modified": "2026-02-27 00:47:46.003305",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Selling Settings",

--- a/erpnext/selling/doctype/selling_settings/selling_settings.py
+++ b/erpnext/selling/doctype/selling_settings/selling_settings.py
@@ -26,6 +26,7 @@ class SellingSettings(Document):
 		allow_sales_order_creation_for_expired_quotation: DF.Check
 		allow_zero_qty_in_quotation: DF.Check
 		allow_zero_qty_in_sales_order: DF.Check
+		automatically_fetch_payment_terms_from_quotation: DF.Check
 		blanket_order_allowance: DF.Float
 		cust_master_name: DF.Literal["Customer Name", "Naming Series", "Auto Name"]
 		customer_group: DF.Link | None

--- a/erpnext/selling/doctype/selling_settings/selling_settings.py
+++ b/erpnext/selling/doctype/selling_settings/selling_settings.py
@@ -26,7 +26,6 @@ class SellingSettings(Document):
 		allow_sales_order_creation_for_expired_quotation: DF.Check
 		allow_zero_qty_in_quotation: DF.Check
 		allow_zero_qty_in_sales_order: DF.Check
-		automatically_fetch_payment_terms_from_quotation: DF.Check
 		blanket_order_allowance: DF.Float
 		cust_master_name: DF.Literal["Customer Name", "Naming Series", "Auto Name"]
 		customer_group: DF.Link | None


### PR DESCRIPTION
- ensure payment terms are considered only when enabled
- handle disabled payment terms template
- fetch payment terms correctly from the quotation
- add tests for backdated entries

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic payment terms population from quotations when converting to sales orders (controlled by new setting).
  * Payment terms now recalculate automatically when transaction dates change.
  * New analytics and tracking options in Selling Settings: sales commissions tracking, UTM analytics, and experimental features.

* **Enhancements**
  * Updated label for payment terms automatic fetching to include quotations.
  * Improved form organization with new sections for totals and additional discounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->