### PR TITLE
Feat-include-dimensions-in-accounting-preview

### DIFF
--- a/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
+++ b/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
@@ -104,7 +104,9 @@
   "payment_request_section",
   "create_pr_in_draft_status",
   "budget_section",
-  "use_legacy_budget_controller"
+  "use_legacy_budget_controller",
+  "preview_tab",
+  "include_dimensions_in_preview"
  ],
  "fields": [
   {
@@ -688,6 +690,17 @@
    "fieldname": "enable_accounting_dimensions",
    "fieldtype": "Check",
    "label": "Enable Accounting Dimensions"
+  },
+  {
+   "fieldname": "preview_tab",
+   "fieldtype": "Tab Break",
+   "label": "Preview"
+  },
+  {
+   "default": "0",
+   "fieldname": "include_dimensions_in_preview",
+   "fieldtype": "Check",
+   "label": "Include Dimensions In Preview"
   }
  ],
  "grid_page_length": 50,

--- a/erpnext/accounts/doctype/accounts_settings/accounts_settings.py
+++ b/erpnext/accounts/doctype/accounts_settings/accounts_settings.py
@@ -77,6 +77,7 @@ class AccountsSettings(Document):
 		general_ledger_remarks_length: DF.Int
 		ignore_account_closing_balance: DF.Check
 		ignore_is_opening_check_for_reporting: DF.Check
+		include_dimensions_in_preview: DF.Check
 		maintain_same_internal_transaction_rate: DF.Check
 		maintain_same_rate_action: DF.Literal["Stop", "Warn"]
 		make_payment_via_journal_entry: DF.Check

--- a/erpnext/controllers/stock_controller.py
+++ b/erpnext/controllers/stock_controller.py
@@ -1982,6 +1982,7 @@ def get_accounting_ledger_preview(doc, filters):
 		"against",
 		"party_type",
 		"party",
+		"cost_center",
 		"against_voucher_type",
 		"against_voucher",
 	]
@@ -1990,7 +1991,6 @@ def get_accounting_ledger_preview(doc, filters):
 		dimensions = get_accounting_dimensions()
 		fields.append('project')
 		fields.extend(dimensions)
-		fields.append('cost_center')
 
 	doc.docstatus = 1
 

--- a/erpnext/controllers/stock_controller.py
+++ b/erpnext/controllers/stock_controller.py
@@ -2017,7 +2017,7 @@ def get_accounting_ledger_preview(doc, filters):
 
 	if filters["include_dimensions"]:
 		dimensions = get_accounting_dimensions()
-		fields.append('project')
+		fields.append("project")
 		fields.extend(dimensions)
 
 	doc.docstatus = 1

--- a/erpnext/controllers/stock_controller.py
+++ b/erpnext/controllers/stock_controller.py
@@ -1963,31 +1963,6 @@ def show_stock_ledger_preview(company: str, doctype: str, docname: str):
 def get_accounting_ledger_preview(doc, filters):
 	"""
 	Generate the Accounting Ledger Preview for a document.
-
-	This function prepares the General Ledger preview entries before the
-	document is submitted. By default, the preview shows standard fields
-	such as posting date, account, debit, credit, and cost center.
-
-	If the **Include Dimensions In Preview** option is enabled in
-	Accounts Settings, the preview will also include all configured
-	accounting dimensions (including project and other dimensions).
-
-	The function:
-	- Reads the Accounts Settings configuration.
-	- Dynamically includes accounting dimensions if enabled.
-	- Generates temporary GL entries for preview.
-	- Returns the formatted columns and data for display.
-
-	Args:
-		doc (Document): The source document for which the ledger preview
-			is being generated.
-		filters (dict | None): Optional filters used for configuring
-			the preview output.
-
-	Returns:
-		tuple: A tuple containing:
-			- gl_columns (list): Column definitions for the preview.
-			- gl_data (list): Ledger entry rows for the preview.
 	"""
 	from erpnext.accounts.report.general_ledger.general_ledger import get_columns as get_gl_columns
 	from erpnext.accounts.doctype.accounting_dimension.accounting_dimension import get_accounting_dimensions
@@ -2032,6 +2007,15 @@ def get_accounting_ledger_preview(doc, filters):
 	doc.make_gl_entries()
 
 	columns = get_gl_columns(filters)
+
+	if not any(col.get("fieldname") == "cost_center" for col in columns):
+		columns.append({
+			"label": frappe._("Cost Center"),
+			"fieldname": "cost_center",
+			"fieldtype": "Link",
+			"options": "Cost Center",
+			"width": 100,
+		})
 
 	gl_entries = get_gl_entries_for_preview(doc.doctype, doc.name, fields)
 

--- a/erpnext/controllers/stock_controller.py
+++ b/erpnext/controllers/stock_controller.py
@@ -1961,6 +1961,34 @@ def show_stock_ledger_preview(company: str, doctype: str, docname: str):
 
 
 def get_accounting_ledger_preview(doc, filters):
+	"""
+	Generate the Accounting Ledger Preview for a document.
+
+	This function prepares the General Ledger preview entries before the
+	document is submitted. By default, the preview shows standard fields
+	such as posting date, account, debit, credit, and cost center.
+
+	If the **Include Dimensions In Preview** option is enabled in
+	Accounts Settings, the preview will also include all configured
+	accounting dimensions (including project and other dimensions).
+
+	The function:
+	- Reads the Accounts Settings configuration.
+	- Dynamically includes accounting dimensions if enabled.
+	- Generates temporary GL entries for preview.
+	- Returns the formatted columns and data for display.
+
+	Args:
+		doc (Document): The source document for which the ledger preview
+			is being generated.
+		filters (dict | None): Optional filters used for configuring
+			the preview output.
+
+	Returns:
+		tuple: A tuple containing:
+			- gl_columns (list): Column definitions for the preview.
+			- gl_data (list): Ledger entry rows for the preview.
+	"""
 	from erpnext.accounts.report.general_ledger.general_ledger import get_columns as get_gl_columns
 	from erpnext.accounts.doctype.accounting_dimension.accounting_dimension import get_accounting_dimensions
 

--- a/erpnext/controllers/stock_controller.py
+++ b/erpnext/controllers/stock_controller.py
@@ -2010,15 +2010,19 @@ def get_accounting_ledger_preview(doc, filters):
 		"against",
 		"party_type",
 		"party",
-		"cost_center",
-		"against_voucher_type",
-		"against_voucher",
 	]
 
 	if filters["include_dimensions"]:
 		dimensions = get_accounting_dimensions()
 		fields.append("project")
 		fields.extend(dimensions)
+
+	fields.append("cost_center")
+
+	fields.extend([
+		"against_voucher_type",
+		"against_voucher",
+	])
 
 	doc.docstatus = 1
 
@@ -2035,7 +2039,6 @@ def get_accounting_ledger_preview(doc, filters):
 	gl_data = get_data(fields, gl_entries)
 
 	return gl_columns, gl_data
-
 
 def get_stock_ledger_preview(doc, filters):
 	from erpnext.stock.report.stock_ledger.stock_ledger import get_columns as get_sl_columns

--- a/erpnext/controllers/stock_controller.py
+++ b/erpnext/controllers/stock_controller.py
@@ -1962,8 +1962,18 @@ def show_stock_ledger_preview(company: str, doctype: str, docname: str):
 
 def get_accounting_ledger_preview(doc, filters):
 	from erpnext.accounts.report.general_ledger.general_ledger import get_columns as get_gl_columns
+	from erpnext.accounts.doctype.accounting_dimension.accounting_dimension import get_accounting_dimensions
 
-	gl_columns, gl_data = [], []
+	if not filters:
+		filters = {}
+
+	include_dimensions_in_preview = frappe.db.get_single_value(
+		"Accounts Settings",
+		"include_dimensions_in_preview"
+	)
+
+	filters["include_dimensions"] = 1 if include_dimensions_in_preview else 0
+
 	fields = [
 		"posting_date",
 		"account",
@@ -1972,10 +1982,15 @@ def get_accounting_ledger_preview(doc, filters):
 		"against",
 		"party_type",
 		"party",
-		"cost_center",
 		"against_voucher_type",
 		"against_voucher",
 	]
+
+	if filters["include_dimensions"]:
+		dimensions = get_accounting_dimensions()
+		fields.append('project')
+		fields.extend(dimensions)
+		fields.append('cost_center')
 
 	doc.docstatus = 1
 
@@ -1983,7 +1998,9 @@ def get_accounting_ledger_preview(doc, filters):
 		doc.update_stock_ledger()
 
 	doc.make_gl_entries()
+
 	columns = get_gl_columns(filters)
+
 	gl_entries = get_gl_entries_for_preview(doc.doctype, doc.name, fields)
 
 	gl_columns = get_columns(columns, fields)


### PR DESCRIPTION
### Feature

Previously, the Accounting Ledger Preview only displayed the Cost Center field and did not include other configured Accounting Dimensions.

This PR introduces a new checkbox in Account Settings:

**Include Dimensions In Preview**

### Behavior

- If the checkbox is **unchecked**:
  - Only Cost Center is shown in the Accounting Ledger Preview (existing behavior).

- If the checkbox is **checked**:
  - All configured Accounting Dimensions are included in the Accounting Ledger Preview.

### Changes

- Added a new checkbox field **Include Dimensions In Preview** in Account Settings.
- Updated the Accounting Ledger Preview logic to dynamically include Accounting Dimensions when the checkbox is enabled.

### Benefit

This provides flexibility for users who want to review complete dimensional accounting information during the preview without forcing it for all users.