### PR TITLE
fix: Duplicate Shipping Charges on Purchase Order Submit for Non-Stoc…

### DIFF
--- a/erpnext/accounts/doctype/shipping_rule/shipping_rule.py
+++ b/erpnext/accounts/doctype/shipping_rule/shipping_rule.py
@@ -140,6 +140,7 @@ class ShippingRule(Document):
 			"charge_type": "Actual",
 			"account_head": self.account,
 			"cost_center": self.cost_center,
+			"description": self.label,
 		}
 		if self.shipping_rule_type == "Selling":
 			# check if not applied on purchase
@@ -163,7 +164,6 @@ class ShippingRule(Document):
 			if self.shipping_rule_type != "Selling":
 				shipping_charge["category"] = "Valuation and Total"
 			shipping_charge["tax_amount"] = shipping_amount
-			shipping_charge["description"] = self.label
 			doc.append("taxes", shipping_charge)
 
 	def sort_shipping_rule_conditions(self):

--- a/erpnext/accounts/doctype/shipping_rule/shipping_rule.py
+++ b/erpnext/accounts/doctype/shipping_rule/shipping_rule.py
@@ -152,7 +152,6 @@ class ShippingRule(Document):
 				frappe.throw(_("Shipping rule only applicable for Buying"))
 
 			shipping_charge["doctype"] = "Purchase Taxes and Charges"
-			shipping_charge["category"] = "Valuation and Total"
 			shipping_charge["add_deduct_tax"] = "Add"
 
 		existing_shipping_charge = doc.get("taxes", filters=shipping_charge)
@@ -160,6 +159,9 @@ class ShippingRule(Document):
 			# take the last record found
 			existing_shipping_charge[-1].tax_amount = shipping_amount
 		else:
+			# Set category and other fields only at insert time
+			if self.shipping_rule_type != "Selling":
+				shipping_charge["category"] = "Valuation and Total"
 			shipping_charge["tax_amount"] = shipping_amount
 			shipping_charge["description"] = self.label
 			doc.append("taxes", shipping_charge)


### PR DESCRIPTION
…k Items

Set shipping charge category conditionally based on shipping rule type.

<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/erpnext/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

### Problem:

When a Purchase Order containing only Non-Stock items (Maintain Stock unchecked) has a Shipping Rule applied, the shipping charge is duplicated in the **Taxes and Charges** table upon submission.

### Fix:

In `shipping_rule.py`, inside `add_shipping_rule_to_tax_table()`:

- Moved `shipping_charge["category"] = "Valuation and Total"` from **before** the `doc.get()` lookup to **inside the `else` block**, so it is only applied at insert time and never included in the search filter.

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Fixes #53205

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->
