### PR TITLE
fix(manufacturing): show returned qty in progress bar

### DIFF
--- a/erpnext/manufacturing/doctype/work_order/work_order.js
+++ b/erpnext/manufacturing/doctype/work_order/work_order.js
@@ -461,10 +461,11 @@ frappe.ui.form.on("Work Order", {
 		var added_min = false;
 
 		// produced qty
-		var title = __("{0} items produced", [frm.doc.produced_qty]);
+		let produced_qty = frm.doc.produced_qty - frm.doc.disassembled_qty;
+		var title = __("{0} items produced", [produced_qty]);
 		bars.push({
 			title: title,
-			width: (frm.doc.produced_qty / frm.doc.qty) * 100 + "%",
+			width: (flt(produced_qty) / frm.doc.qty) * 100 + "%",
 			progress_class: "progress-bar-success",
 		});
 		if (bars[0].width == "0%") {
@@ -500,6 +501,8 @@ frappe.ui.form.on("Work Order", {
 				message = message + ". " + title;
 			}
 		}
+
+		//process loss qty
 		if (frm.doc.process_loss_qty) {
 			var process_loss_width = (frm.doc.process_loss_qty / frm.doc.qty) * 100;
 			title = __("{0} items lost during process.", [frm.doc.process_loss_qty]);
@@ -510,6 +513,19 @@ frappe.ui.form.on("Work Order", {
 			});
 			message = message + ". " + title;
 		}
+
+		// disassembled qty
+		if (frm.doc.disassembled_qty) {
+			var disassembled_width = (frm.doc.disassembled_qty / frm.doc.qty) * 100;
+			title = __("{0} items disassembled", [frm.doc.disassembled_qty]);
+			bars.push({
+				title: title,
+				width: disassembled_width + "%",
+				progress_class: "progress-bar-secondary",
+			});
+			message = message + ". " + title;
+		}
+
 		frm.dashboard.add_progress(__("Status"), bars, message);
 	},
 

--- a/erpnext/manufacturing/doctype/work_order/work_order.js
+++ b/erpnext/manufacturing/doctype/work_order/work_order.js
@@ -481,10 +481,21 @@ frappe.ui.form.on("Work Order", {
 			if (pending_complete > 0) {
 				var width = (pending_complete / frm.doc.qty) * 100 - added_min;
 				title = __("{0} items in progress", [pending_complete]);
+				let progress_class = "progress-bar-warning";
+				if (frm.doc.status == "Closed") {
+					if (frm.doc.required_items.find((d) => d.returned_qty > 0)) {
+						title = __("{0} items returned", [pending_complete]);
+						progress_class = "progress-bar-warning";
+					} else {
+						title = __("{0} items to return", [pending_complete]);
+						progress_class = "progress-bar-info";
+					}
+				}
+
 				bars.push({
 					title: title,
 					width: (width > 100 ? "99.5" : width) + "%",
-					progress_class: "progress-bar-warning",
+					progress_class: progress_class,
 				});
 				message = message + ". " + title;
 			}


### PR DESCRIPTION
**Issue:**
After closing the work order, the system still showing the returned qty as "In Progress" in the progress bar.

**Ref:** [#61532](https://support.frappe.io/helpdesk/tickets/61532)

**Before:**
<img width="1296" height="543" alt="image" src="https://github.com/user-attachments/assets/b4a0c3ca-3e98-412f-a4fc-019215cb0493" />

**After:**

<img width="1292" height="679" alt="image" src="https://github.com/user-attachments/assets/802925f6-824c-4f91-bb52-4bb0976f04f5" />

**Backport Needed for v15 & v16**