### PR TITLE
fix: update item row delivery dates when header delivery date changes in sales order

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.js
+++ b/erpnext/selling/doctype/sales_order/sales_order.js
@@ -56,6 +56,13 @@ frappe.ui.form.on("Sales Order", {
 		frm.set_df_property("packed_items", "cannot_add_rows", true);
 		frm.set_df_property("packed_items", "cannot_delete_rows", true);
 	},
+	delivery_date(frm) {
+		if (frm.doc.delivery_date) {
+			frm.doc.items.forEach((d) => {
+				frappe.model.set_value(d.doctype, d.name, "delivery_date", frm.doc.delivery_date);
+			});
+		}
+	},
 
 	refresh: function (frm) {
 		frm.fields_dict["items"].grid.update_docfield_property(
@@ -158,7 +165,7 @@ frappe.ui.form.on("Sales Order", {
 				});
 			}
 		}
-
+		prevent_past_delivery_dates(frm);
 		// Hide `Reserve Stock` field description in submitted or cancelled Sales Order.
 		if (frm.doc.docstatus > 0) {
 			frm.set_df_property("reserve_stock", "description", null);
@@ -236,13 +243,6 @@ frappe.ui.form.on("Sales Order", {
 			"Unreconcile Payment Entries",
 			"Delivery Schedule Item",
 		];
-	},
-
-	delivery_date: function (frm) {
-		$.each(frm.doc.items || [], function (i, d) {
-			if (!d.delivery_date) d.delivery_date = frm.doc.delivery_date;
-		});
-		refresh_field("items");
 	},
 
 	create_stock_reservation_entries(frm) {
@@ -1816,3 +1816,11 @@ erpnext.selling.SalesOrderController = class SalesOrderController extends erpnex
 };
 
 extend_cscript(cur_frm.cscript, new erpnext.selling.SalesOrderController({ frm: cur_frm }));
+
+function prevent_past_delivery_dates(frm) {
+	if (frm.doc.transaction_date) {
+		frm.fields_dict["delivery_date"].datepicker?.update({
+			minDate: new Date(frm.doc.transaction_date),
+		});
+	}
+}


### PR DESCRIPTION
**issue:** Fix the synchronization issue between the Sales Order header Delivery Date and the Items child table Delivery Date

**Description:**
Resolve the issue where changing the Delivery Date at the Sales Order header does not update the Delivery Date in item rows. Ensure the header and child table Delivery Dates remain synchronized.

**Steps To Reproduce:**
1. Create a Sales Order.
2. Add one or more items in the Items child table.
3. Set a Delivery Date at the header level.
4. Save the document.
5. Change the Delivery Date again at the header level.
6. Observe that the Delivery Date in the child table rows does not update.
7. Manually change the Delivery Date in a child row.
8. Save the document.
9. Observe that the header Delivery Date does not updates to match the child row date.

**Current Behaviour :**

When the Delivery Date is updated at the header level after saving the document, the Delivery Date in the child table rows does not update automatically. Similarly, if the Delivery Date is changed in a child row and saved, the header Delivery Date does not update to match the row.

**Expected Behaviour:**

Updating the Delivery Date at the header level should automatically update the Delivery Date for all rows in the Items child table, maintaining consistency between the header and item rows.
Before : 

[Screencast from 09-03-26 01:12:48 AM IST.webm](https://github.com/user-attachments/assets/32040eed-0d3e-464c-a212-b58a324d42c3)

**After:**

[Screencast from 09-03-26 01:20:15 AM IST.webm](https://github.com/user-attachments/assets/048528ca-43a4-4e12-a92e-8bb6db6a8331)

**Backport Needed For V16 and V15**
