### PR TITLE
ci: preventing manual changes in `erpnext/locale/*`

### DIFF
--- a/.github/helper/locale_review.js
+++ b/.github/helper/locale_review.js
@@ -1,0 +1,39 @@
+module.exports = async ({ github, context, localeChanged }) => {
+  const pr = context.payload.pull_request.number
+  const { owner, repo } = context.repo
+  
+  const { data: me } = await github.rest.users.getAuthenticated()
+  const botUser = me.login
+
+  const reviews = await github.rest.pulls.listReviews({
+    owner,
+    repo,
+    pull_number: pr
+  })
+
+  const botReview = reviews.data
+    .reverse()
+    .find(r => r.user.login === botUser && r.state === "CHANGES_REQUESTED")
+
+  if (localeChanged) {
+    if (!botReview) {
+      await github.rest.pulls.createReview({
+        owner,
+        repo,
+        pull_number: pr,
+        event: "REQUEST_CHANGES",
+        body: "Translations are managed through [Crowdin](https://crowdin.com/project/frappe/). Consider contributing through Crowdin."
+      })
+    }
+  } else {
+    if (botReview) {
+      await github.rest.pulls.dismissReview({
+        owner,
+        repo,
+        pull_number: pr,
+        review_id: botReview.id,
+        message: ""
+      })
+    }
+  }
+}

--- a/.github/workflows/prevent-locale-changes.yml
+++ b/.github/workflows/prevent-locale-changes.yml
@@ -1,0 +1,42 @@
+name: Prevent Locale Changes
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  check-locale:
+    runs-on: ubuntu-latest
+
+    if: github.actor != 'frappe-pr-bot' 
+    # Exemption for the bot used for Crowdin Sync and POT File generation.
+
+    concurrency:
+      group: prevent-locale-changes-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect locale changes
+        id: check
+        run: |
+          git fetch origin ${{ github.base_ref }}
+
+          if git diff --name-only origin/${{ github.base_ref }}...HEAD | grep -q '^erpnext/locale/'; then
+            echo "locale_changed=true" >> $GITHUB_OUTPUT
+          else
+            echo "locale_changed=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Manage locale review
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.RELEASE_TOKEN }}
+          script: |
+            const localeChanged = "${{ steps.check.outputs.locale_changed }}" === "true"
+            const handler = require('./.github/helper/locale_review.js')
+            await handler({ github, context, localeChanged })


### PR DESCRIPTION
Preventing manual changes on `erpnext/locale/*` and notifying Pull Request authors about Crowdin Platform for translations via PR Review.
