### PR TITLE
fix: use return value of `get_round_off_applicable_accounts`

### DIFF
--- a/erpnext/controllers/taxes_and_totals.py
+++ b/erpnext/controllers/taxes_and_totals.py
@@ -26,11 +26,12 @@ from erpnext.utilities.regional import temporary_flag
 class calculate_taxes_and_totals:
 	def __init__(self, doc: Document):
 		self.doc = doc
-		frappe.flags.round_off_applicable_accounts = []
+		frappe.flags.round_off_applicable_accounts = (
+			get_round_off_applicable_accounts(self.doc.company, []) or []
+		)
 		frappe.flags.round_row_wise_tax = frappe.get_single_value("Accounts Settings", "round_row_wise_tax")
 
 		self._items = self.filter_rows() if self.doc.doctype == "Quotation" else self.doc.get("items")
-		get_round_off_applicable_accounts(self.doc.company, frappe.flags.round_off_applicable_accounts)
 		self.calculate()
 
 	def filter_rows(self):

--- a/erpnext/controllers/tests/test_taxes_and_totals.py
+++ b/erpnext/controllers/tests/test_taxes_and_totals.py
@@ -1,0 +1,31 @@
+from unittest.mock import patch
+
+import frappe
+from frappe.tests import IntegrationTestCase
+
+from erpnext.controllers.taxes_and_totals import calculate_taxes_and_totals
+from erpnext.selling.doctype.sales_order.test_sales_order import make_sales_order
+
+
+class TestTaxesAndTotals(IntegrationTestCase):
+	def test_regional_round_off_accounts(self):
+		"""
+		Regional overrides cannot extend the list in-place — the return
+		value must be assigned back to frappe.flags.round_off_applicable_accounts.
+		"""
+		test_account = "_Test Round Off Account"
+
+		def mock_regional(company, account_list: list) -> list:
+			# Simulates a regional override
+			account_list.extend([test_account])
+			return account_list
+
+		so = make_sales_order(do_not_save=True)
+
+		with patch(
+			"erpnext.controllers.taxes_and_totals.get_regional_round_off_accounts",
+			mock_regional,
+		):
+			calculate_taxes_and_totals(so)
+
+		self.assertIn(test_account, frappe.flags.round_off_applicable_accounts)


### PR DESCRIPTION
## Issue

Typed validation of `@frappe.whitelist()` creates a new list object. Hence regional apps cannot mutate or extend them. Because of this, regional override had no effect on the flag.

Fix: use the return value of `get_round_off_applicable_accounts` to set the flag