### PR TITLE
feat: add cost center field to the stock entry accounting dimension tab

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry.js
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.js
@@ -564,7 +564,9 @@ frappe.ui.form.on("Stock Entry", {
 		frm.fields_dict.items.grid.refresh();
 		frm.cscript.toggle_related_fields(frm.doc);
 	},
-
+	cost_center(frm, cdt, cdn) {
+		erpnext.utils.copy_value_in_all_rows(frm.doc, cdt, cdn, "items", "cost_center");
+	},
 	validate_purpose_consumption: function (frm) {
 		frappe
 			.call({

--- a/erpnext/stock/doctype/stock_entry/stock_entry.json
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.json
@@ -65,6 +65,8 @@
   "address_display",
   "accounting_dimensions_section",
   "project",
+  "column_break_wgvc",
+  "cost_center",
   "other_info_tab",
   "printing_settings",
   "select_print_heading",
@@ -739,6 +741,16 @@
   {
    "fieldname": "column_break_qpvo",
    "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "column_break_wgvc",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "cost_center",
+   "fieldtype": "Link",
+   "label": "Cost Center",
+   "options": "Cost Center"
   }
  ],
  "grid_page_length": 50,
@@ -747,7 +759,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2026-02-06 19:26:59.518312",
+ "modified": "2026-03-04 19:03:23.426082",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Stock Entry",

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -107,6 +107,7 @@ class StockEntry(StockController, SubcontractingInwardController):
 		asset_repair: DF.Link | None
 		bom_no: DF.Link | None
 		company: DF.Link
+		cost_center: DF.Link | None
 		credit_note: DF.Link | None
 		delivery_note_no: DF.Link | None
 		fg_completed_qty: DF.Float


### PR DESCRIPTION
**Issue Ref**: [#49132](https://github.com/frappe/erpnext/issues/49132)

**Description**: When creating a stock entry of type transfer, the Cost Centre field is not available at the parent level, and all accounting dimensions must be specified in the Accounting Dimensions tab

**Before**: 
<img width="823" height="245" alt="image" src="https://github.com/user-attachments/assets/195a62c6-704e-44fe-a7d3-ff235e5c643f" />

**After**: 
<img width="823" height="245" alt="image" src="https://github.com/user-attachments/assets/fa8fc7bd-35cc-4aa7-97b1-81fd66542439" />

Backport needed in V15
