### PR TITLE
feat: enable item level quality inspection without mandatory check

### DIFF
--- a/erpnext/controllers/stock_controller.py
+++ b/erpnext/controllers/stock_controller.py
@@ -2106,9 +2106,16 @@ def repost_required_for_queue(doc: StockController) -> bool:
 
 
 @frappe.whitelist()
-def check_item_quality_inspection(doctype: str, items: str | list[dict]):
+def check_item_quality_inspection(
+	doctype: str, items: str | list[dict], include_non_mandatory_items: str | bool = "false"
+):
+	include_non_mandatory_items = frappe.parse_json(include_non_mandatory_items)
+
 	if isinstance(items, str):
 		items = json.loads(items)
+
+	if include_non_mandatory_items:
+		return items
 
 	inspection_fieldname_map = {
 		"Purchase Receipt": "inspection_required_before_purchase",

--- a/erpnext/manufacturing/doctype/bom/bom.js
+++ b/erpnext/manufacturing/doctype/bom/bom.js
@@ -7,7 +7,6 @@ frappe.ui.form.on("BOM", {
 	setup(frm) {
 		frm.custom_make_buttons = {
 			"Work Order": "Work Order",
-			"Quality Inspection": "Quality Inspection",
 		};
 
 		frm.set_query("bom_no", "items", function () {
@@ -226,16 +225,6 @@ frappe.ui.form.on("BOM", {
 					__("Variant BOM"),
 					function () {
 						frm.trigger("make_variant_bom");
-					},
-					__("Create")
-				);
-			}
-
-			if (frm.doc.inspection_required) {
-				frm.add_custom_button(
-					__("Quality Inspection"),
-					function () {
-						frm.trigger("make_quality_inspection");
 					},
 					__("Create")
 				);

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -2878,6 +2878,22 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 		let data = [];
 		const fields = [
 			{
+				label: "Include Items without mandatory Quality Inspection",
+				fieldtype: "Check",
+				fieldname: "include_non_mandatory_items",
+				default: 0,
+				description: __(
+					"If checked, items which do not require mandatory quality inspection will also be included."
+				),
+				hidden: !["Stock Entry", "Purchase Receipt"].includes(this.frm.doc.doctype),
+				onchange: (e) => {
+					const include_all = dialog.get_value("include_non_mandatory_items");
+					include_all
+						? this.refresh_quality_inspection(dialog, true)
+						: this.refresh_quality_inspection(dialog, false);
+				},
+			},
+			{
 				label: "Items",
 				fieldtype: "Table",
 				fieldname: "items",
@@ -2989,18 +3005,28 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 			primary_action_label: __("Create"),
 		});
 
+		this.refresh_quality_inspection(dialog, false);
+	}
+	refresh_quality_inspection(dialog, include_non_mandatory_items, show_include_item_check = false) {
+		const me = this;
+		let data = [];
 		frappe.call({
 			method: "erpnext.controllers.stock_controller.check_item_quality_inspection",
 			args: {
 				doctype: this.frm.doc.doctype,
 				items: this.frm.doc.items,
+				include_non_mandatory_items: include_non_mandatory_items,
 			},
 			freeze: true,
 			callback: function (r) {
+				let dialog_items = [];
+				if (show_include_item_check) {
+					dialog.fields_dict.include_non_mandatory_items.df.hidden = true;
+					dialog.fields_dict.include_non_mandatory_items.refresh();
+				}
 				r.message.forEach((item) => {
-					if (me.has_inspection_required(item)) {
-						let dialog_items = dialog.fields_dict.items;
-						dialog_items.df.data.push({
+					if (me.has_inspection_required(item) || include_non_mandatory_items) {
+						dialog_items.push({
 							item_code: item.item_code,
 							item_name: item.item_name,
 							qty: item.qty,
@@ -3010,14 +3036,21 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 							sample_size: item.sample_quantity,
 							child_row_reference: item.name,
 						});
-						dialog_items.grid.refresh();
+						dialog.fields_dict.items.df.data = dialog_items;
+						dialog.fields_dict.items.grid.refresh();
 					}
 				});
 
 				data = dialog.fields_dict.items.df.data;
 				if (!data.length) {
-					frappe.msgprint(
-						__("All items in this document already have a linked Quality Inspection.")
+					frappe.confirm(
+						"No items require quality inspection. Do you want to proceed?",
+						function () {
+							me.refresh_quality_inspection(dialog, true, true);
+						},
+						function () {
+							dialog.hide();
+						}
 					);
 				} else {
 					dialog.show();
@@ -3025,7 +3058,6 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 			},
 		});
 	}
-
 	has_inspection_required(item) {
 		if (this.frm.doc.doctype === "Stock Entry" && this.frm.doc.purpose == "Manufacture") {
 			if (item.is_finished_item && !item.quality_inspection) {


### PR DESCRIPTION
There are scenarios where certain items for which there are multiple vendors,  If we enable mandatory Quality Inspection at the Item level, then every Purchase Receipt created for that item will require a Quality Inspection, which is not always the case.

So in this case if the item is not marked for mandatory Quality Inspection, we can still be able to create a Quality Inspection voluntarily whenever required. Ref: https://support.frappe.io/helpdesk/tickets/61910

`no-docs`