### PR TITLE
fix: update delivery date in line items

### DIFF
--- a/erpnext/buying/doctype/purchase_order/purchase_order.js
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.js
@@ -57,6 +57,18 @@ frappe.ui.form.on("Purchase Order", {
 	company: function (frm) {
 		erpnext.accounts.dimensions.update_dimension(frm, frm.doctype);
 	},
+	schedule_date(frm) {
+		if (frm.doc.schedule_date) {
+			frm.doc.items.forEach((d) => {
+				frappe.model.set_value(d.doctype, d.name, "schedule_date", frm.doc.schedule_date);
+			});
+		}
+	},
+
+	transaction_date(frm) {
+		erpnext.buying.prevent_past_schedule_dates(frm);
+		frm.set_value("schedule_date", "");
+	},
 
 	refresh: function (frm) {
 		if (frm.doc.is_old_subcontracting_flow) {
@@ -74,6 +86,7 @@ frappe.ui.form.on("Purchase Order", {
 		if (frm.doc.docstatus == 0) {
 			erpnext.set_unit_price_items_note(frm);
 		}
+		erpnext.buying.prevent_past_schedule_dates(frm);
 	},
 
 	supplier: function (frm) {
@@ -769,10 +782,6 @@ erpnext.buying.PurchaseOrderController = class PurchaseOrderController extends (
 	items_on_form_rendered() {
 		set_schedule_date(this.frm);
 	}
-
-	schedule_date() {
-		set_schedule_date(this.frm);
-	}
 };
 
 // for backward compatibility: combine new and previous states
@@ -828,3 +837,4 @@ frappe.ui.form.on("Purchase Order", "is_subcontracted", function (frm) {
 		erpnext.buying.get_default_bom(frm);
 	}
 });
+

--- a/erpnext/buying/doctype/purchase_order/purchase_order.js
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.js
@@ -837,4 +837,3 @@ frappe.ui.form.on("Purchase Order", "is_subcontracted", function (frm) {
 		erpnext.buying.get_default_bom(frm);
 	}
 });
-

--- a/erpnext/public/js/controllers/buying.js
+++ b/erpnext/public/js/controllers/buying.js
@@ -626,3 +626,10 @@ erpnext.buying.get_items_from_product_bundle = function(frm) {
 
 	dialog.show();
 }
+erpnext.buying.prevent_past_schedule_dates = function (frm) {
+	if (frm.doc.transaction_date) {
+		frm.fields_dict["schedule_date"].datepicker?.update({
+			minDate: new Date(frm.doc.transaction_date),
+		});
+	}
+};

--- a/erpnext/stock/doctype/material_request/material_request.js
+++ b/erpnext/stock/doctype/material_request/material_request.js
@@ -55,7 +55,13 @@ frappe.ui.form.on("Material Request", {
 			};
 		});
 	},
-
+	schedule_date(frm) {
+		if (frm.doc.schedule_date) {
+			frm.doc.items.forEach((d) => {
+				frappe.model.set_value(d.doctype, d.name, "schedule_date", frm.doc.schedule_date);
+			});
+		}
+	},
 	onload: function (frm) {
 		// add item, if previous view was item
 		erpnext.utils.add_item(frm);
@@ -109,8 +115,12 @@ frappe.ui.form.on("Material Request", {
 		frm.events.make_custom_buttons(frm);
 		frm.toggle_reqd("customer", frm.doc.material_request_type == "Customer Provided");
 		frm.trigger("set_warehouse_label");
+		erpnext.buying.prevent_past_schedule_dates(frm);
 	},
-
+	transaction_date(frm) {
+		erpnext.buying.prevent_past_schedule_dates(frm);
+		frm.set_value("schedule_date", "");
+	},
 	set_from_warehouse: function (frm) {
 		if (frm.doc.material_request_type == "Material Transfer" && frm.doc.set_from_warehouse) {
 			frm.doc.items.forEach((d) => {
@@ -642,10 +652,6 @@ erpnext.buying.MaterialRequestController = class MaterialRequestController exten
 		set_schedule_date(this.frm);
 	}
 
-	schedule_date() {
-		set_schedule_date(this.frm);
-	}
-
 	qty(doc, cdt, cdn) {
 		var row = frappe.get_doc(cdt, cdn);
 		row.amount = flt(row.qty) * flt(row.rate);
@@ -668,3 +674,4 @@ function set_schedule_date(frm) {
 		);
 	}
 }
+

--- a/erpnext/stock/doctype/material_request/material_request.js
+++ b/erpnext/stock/doctype/material_request/material_request.js
@@ -674,4 +674,3 @@ function set_schedule_date(frm) {
 		);
 	}
 }
-


### PR DESCRIPTION
Backport : [#48072](https://github.com/frappe/erpnext/pull/48072/)

Ref : [#62106](https://support.frappe.io/helpdesk/tickets/62106)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Schedule dates now automatically propagate to all line items when set on Purchase Orders and Material Requests, including per-item entry.

* **Improvements**
  * Date validation now prevents schedule dates earlier than the transaction date and enforces this on form refresh.
  * Schedule dates are cleared when the transaction date changes; date picker behavior now respects the transaction date as the minimum.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->