### PR TITLE
fix: correct initialization of round off applicable accounts

### DIFF
--- a/erpnext/controllers/taxes_and_totals.py
+++ b/erpnext/controllers/taxes_and_totals.py
@@ -29,7 +29,9 @@ class calculate_taxes_and_totals:
 		frappe.flags.round_row_wise_tax = frappe.get_single_value("Accounts Settings", "round_row_wise_tax")
 
 		self._items = self.filter_rows() if self.doc.doctype == "Quotation" else self.doc.get("items")
-		frappe.flags.round_off_applicable_accounts = get_round_off_applicable_accounts(self.doc.company, [])
+		frappe.flags.round_off_applicable_accounts = (
+			get_round_off_applicable_accounts(self.doc.company, []) or []
+		)
 		self.calculate()
 
 	def filter_rows(self):

--- a/erpnext/controllers/taxes_and_totals.py
+++ b/erpnext/controllers/taxes_and_totals.py
@@ -26,11 +26,10 @@ from erpnext.utilities.regional import temporary_flag
 class calculate_taxes_and_totals:
 	def __init__(self, doc: Document):
 		self.doc = doc
-		frappe.flags.round_off_applicable_accounts = []
 		frappe.flags.round_row_wise_tax = frappe.get_single_value("Accounts Settings", "round_row_wise_tax")
 
 		self._items = self.filter_rows() if self.doc.doctype == "Quotation" else self.doc.get("items")
-		get_round_off_applicable_accounts(self.doc.company, frappe.flags.round_off_applicable_accounts)
+		frappe.flags.round_off_applicable_accounts = get_round_off_applicable_accounts(self.doc.company, [])
 		self.calculate()
 
 	def filter_rows(self):


### PR DESCRIPTION
`get_round_off_applicable_accounts` accepts `account_list: list | str`, and Frappe's type validation on whitelisted functions creates a new list from the argument rather than mutating it in place. Passing `frappe.flags.round_off_applicable_accounts` as the seed list therefore had no effect — the flag was never populated.

Related to: https://github.com/frappe/frappe/issues/37449