### PR TITLE
feat(stock): implement fallback logic for Delivery Trip address mapping

### DIFF
--- a/erpnext/stock/doctype/delivery_note/delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.py
@@ -987,6 +987,11 @@ def make_delivery_trip(
 ):
 	if not target_doc:
 		target_doc = frappe.new_doc("Delivery Trip")
+
+	def postprocess(source, target):
+		target.address = source.shipping_address_name or source.customer_address
+		target.customer_address = source.shipping_address or source.address_display
+
 	doclist = get_mapped_doc(
 		"Delivery Note",
 		source_name,
@@ -996,11 +1001,10 @@ def make_delivery_trip(
 				"on_parent": target_doc,
 				"field_map": {
 					"name": "delivery_note",
-					"shipping_address_name": "address",
-					"shipping_address": "customer_address",
 					"contact_person": "contact",
 					"contact_display": "customer_contact",
 				},
+				"postprocess": postprocess,
 			},
 		},
 		ignore_child_tables=True,

--- a/erpnext/stock/doctype/delivery_note/delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.py
@@ -988,9 +988,9 @@ def make_delivery_trip(
 	if not target_doc:
 		target_doc = frappe.new_doc("Delivery Trip")
 
-	def postprocess(source, target):
-		target.address = source.shipping_address_name or source.customer_address
-		target.customer_address = source.shipping_address or source.address_display
+	def update_address(source_doc, target_doc, source_parent):
+		target_doc.address = source_doc.shipping_address_name or source_doc.customer_address
+		target_doc.customer_address = source_doc.shipping_address or source_doc.address_display
 
 	doclist = get_mapped_doc(
 		"Delivery Note",
@@ -1004,7 +1004,7 @@ def make_delivery_trip(
 					"contact_person": "contact",
 					"contact_display": "customer_contact",
 				},
-				"postprocess": postprocess,
+				"postprocess": update_address,
 			},
 		},
 		ignore_child_tables=True,


### PR DESCRIPTION
> Please provide enough information so that others can review your pull request:

This PR introduces an address fallback mechanism for the `Delivery Trip` doctype to ensure all delivery stops always have a valid location populated.

> Explain the **details** for making this change. What existing problem does the pull request solve?

**Problem:** When creating a `Delivery Trip`, the `Delivery Stop` fetches address details from the associated reference document (such as a `Delivery Note` or `Sales Invoice`). If a specific shipping address is not explicitly defined or linked in that reference document, the address fields in the Delivery Stop can remain completely blank. This missing information causes confusion for delivery drivers and can break integrations that rely on routing or distance calculations.

**Solution:**
This change implements a fallback logic. If the primary shipping address is missing from the referenced document, the system will now automatically fall back to fetching the customer's default address (e.g., their primary or billing address). This ensures that every delivery stop reliably has the necessary address information.