### PR TITLE
Fix duplicate shipping charges for non-stock items in Purchase Orders

### DIFF
--- a/erpnext/accounts/doctype/shipping_rule/shipping_rule.py
+++ b/erpnext/accounts/doctype/shipping_rule/shipping_rule.py
@@ -155,7 +155,9 @@ class ShippingRule(Document):
 			shipping_charge["category"] = "Valuation and Total"
 			shipping_charge["add_deduct_tax"] = "Add"
 
-		existing_shipping_charge = doc.get("taxes", filters=shipping_charge)
+		# Exclude 'category' from filter since it can change for non-stock items
+		filter_dict = {k: v for k, v in shipping_charge.items() if k != "category"}
+		existing_shipping_charge = doc.get("taxes", filters=filter_dict)
 		if existing_shipping_charge:
 			# take the last record found
 			existing_shipping_charge[-1].tax_amount = shipping_amount


### PR DESCRIPTION
Fixes #53205. The shipping_rule.py module was using the full shipping_charge dict (including category) as a filter to find existing tax rows. For Buying transactions, the category was hardcoded as "Valuation and Total". However, buying_controller.py changes this category to "Total" for non-stock items. This mismatch caused the lookup to fail and duplicate shipping charges to be added on submit.

The fix excludes the "category" field from the filter dict since it can legitimately change based on document state (stock vs non-stock items).