### PR TITLE
fix(manufacturing): handle multi uom conversion factor for manufacture entry

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry.js
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.js
@@ -932,6 +932,10 @@ frappe.ui.form.on("Stock Entry Detail", {
 	},
 
 	conversion_factor(frm, cdt, cdn) {
+		let item = frappe.get_doc(cdt, cdn);
+		if (item.is_finished_item) {
+			frappe.flags.__skip_fg_completed_qty_refresh = true;
+		}
 		frm.events.set_rate_and_fg_qty(frm, cdt, cdn);
 	},
 
@@ -1332,6 +1336,11 @@ erpnext.stock.StockEntry = class StockEntry extends erpnext.stock.StockControlle
 	}
 
 	fg_completed_qty() {
+		if (frappe.flags.__skip_fg_completed_qty_refresh) {
+			frappe.flags.__skip_fg_completed_qty_refresh = false;
+			return;
+		}
+
 		this.get_items();
 	}
 


### PR DESCRIPTION
**Issue:**
When changing the Finished Goods UOM in a **Stock Entry (Manufacture)**, the system recalculates `fg_completed_qty` and triggers `get_items()`, which refreshes and rebuilds the item rows. Because of this, users cannot change the FG UOM (e.g., from Kg to Litre) even when a valid UOM conversion exists in the Item master. The recalculation happens even when the effective finished goods quantity has not changed. This behavior prevents proper use of Multi UOM for finished goods in Stock Entry.

**Ref:** [#61846](https://support.frappe.io/helpdesk/tickets/61846)

**Before:**

https://github.com/user-attachments/assets/7401912e-37c0-454a-a98f-484fd660d943

**After:**

https://github.com/user-attachments/assets/6b8c079f-b50b-4bc6-a584-01da267430c6

**Backport Needed for v15 & v16**