### PR TITLE
fix: removed non existent patch

### DIFF
--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -74,7 +74,6 @@ erpnext.patches.v12_0.make_item_manufacturer
 erpnext.patches.v12_0.move_item_tax_to_item_tax_template
 erpnext.patches.v11_1.set_variant_based_on
 erpnext.patches.v11_1.woocommerce_set_creation_user
-erpnext.patches.v11_1.rename_depends_on_lwp
 execute:frappe.delete_doc("Report", "Inactive Items")
 erpnext.patches.v11_1.delete_scheduling_tool
 erpnext.patches.v12_0.rename_tolerance_fields


### PR DESCRIPTION
rename_depends_on_lwp patch is related to HRMS and rename_depends_on_lwp file does not exists in the ERPNext