### PR TITLE
fix: do not modify rate in the child item merely for comparison

### DIFF
--- a/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py
+++ b/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py
@@ -527,11 +527,11 @@ class StockReconciliation(StockController):
 					return True
 
 			rate_precision = item.precision("valuation_rate")
-			item_dict["rate"] = flt(item_dict.get("rate"), rate_precision)
-			item.valuation_rate = flt(item.valuation_rate, rate_precision) if item.valuation_rate else None
+			rate = flt(item_dict.get("rate"), rate_precision)
+			valuation_rate = flt(item.valuation_rate, rate_precision) if item.valuation_rate else None
 			if (
 				(item.qty is None or item.qty == item_dict.get("qty"))
-				and (item.valuation_rate is None or item.valuation_rate == item_dict.get("rate"))
+				and (valuation_rate is None or valuation_rate == rate)
 				and (not item.serial_no or (item.serial_no == item_dict.get("serial_nos")))
 			):
 				return False
@@ -1011,9 +1011,9 @@ class StockReconciliation(StockController):
 
 	def set_total_qty_and_amount(self):
 		for d in self.get("items"):
-			d.amount = flt(d.qty, d.precision("qty")) * flt(d.valuation_rate, d.precision("valuation_rate"))
-			d.current_amount = flt(d.current_qty, d.precision("current_qty")) * flt(
-				d.current_valuation_rate, d.precision("current_valuation_rate")
+			d.amount = flt(flt(d.qty) * flt(d.valuation_rate), d.precision("amount"))
+			d.current_amount = flt(
+				flt(d.current_qty) * flt(d.current_valuation_rate), d.precision("current_amount")
 			)
 
 			d.quantity_difference = flt(d.qty) - flt(d.current_qty)


### PR DESCRIPTION
[Reference support ticket](https://support.frappe.io/helpdesk/tickets/62306)

ref https://github.com/frappe/erpnext/pull/53067

when stock reco was saved, the current amount value changed due to precision issues
