### PR TITLE
fix: check posting_date in args

### DIFF
--- a/erpnext/accounts/doctype/pricing_rule/utils.py
+++ b/erpnext/accounts/doctype/pricing_rule/utils.py
@@ -242,8 +242,10 @@ def get_other_conditions(conditions, values, args):
 		if group_condition:
 			conditions += " and " + group_condition
 
-	date = args.get("transaction_date") or frappe.get_value(
-		args.get("doctype"), args.get("name"), "posting_date", ignore=True
+	date = (
+		args.get("transaction_date")
+		or args.get("posting_date")
+		or frappe.get_value(args.get("doctype"), args.get("name"), "posting_date", ignore=True)
 	)
 	if date:
 		conditions += """ and %(transaction_date)s between ifnull(`tabPricing Rule`.valid_from, '2000-01-01')


### PR DESCRIPTION
**Issue:**
When a Pricing Rule with the purpose **"Apply on Transaction"** is evaluated before the document is saved, the rule condition may not work correctly. At this stage, the document does not yet have a `transaction_date`, and since it is not saved, `frappe.get_value()` cannot retrieve the `posting_date` from the database and returns an empty value, which causes the retrieval of the wrong pricing rule 

**Solution**
 To handle this case, if `posting_date` is already available in the `args`, it should be used first before attempting to fetch it using `frappe.get_value()`.

**Ref:**[#61893](https://support.frappe.io/helpdesk/tickets/61893)

Backport Needed: v14, v15