### PR TITLE
fix: update item description in Production Plan Assembly Items table

### DIFF
--- a/erpnext/manufacturing/doctype/production_plan/production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.py
@@ -1901,7 +1901,7 @@ def get_item_data(item_code: str):
 	return {
 		"bom_no": item_details.get("bom_no"),
 		"stock_uom": item_details.get("stock_uom"),
-		"description": item_details.get("description")
+		"description": item_details.get("description"),
 	}
 
 

--- a/erpnext/manufacturing/doctype/production_plan/production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.py
@@ -1901,7 +1901,7 @@ def get_item_data(item_code: str):
 	return {
 		"bom_no": item_details.get("bom_no"),
 		"stock_uom": item_details.get("stock_uom"),
-		# 		"description": item_details.get("description")
+		"description": item_details.get("description")
 	}
 
 


### PR DESCRIPTION
Fix: Update item description in Production Plan Assembly Items table.
Issue: #53247 
Before:
Production Plan Assembly Items table showed outdated item description.
[Screencast from 11-03-26 11:18:27 AM IST.webm](https://github.com/user-attachments/assets/508bcb5c-9893-43ab-ad4e-e473fbb18399)
After:
Assembly Items table now reflects the updated description from Item Master.
[Screencast from 11-03-26 11:17:49 AM IST.webm](https://github.com/user-attachments/assets/4208d387-ee2f-4642-90d4-1994ee3203a9)
