### PR TITLE
fix: handle NoneType error while creating a item

### DIFF
--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -1620,7 +1620,7 @@ def parse_naming_series_variable(doc, variable):
 				getdate(doc.get("posting_date") or doc.get("transaction_date") or doc.get("posting_datetime"))
 				or now_datetime()
 			)
-			if frappe.get_single_value("Global Defaults", "use_posting_datetime_for_naming_documents")
+			if doc and frappe.get_single_value("Global Defaults", "use_posting_datetime_for_naming_documents")
 			else now_datetime()
 		)
 		return date.strftime(data[variable]) if variable in data else determine_consecutive_week_number(date)


### PR DESCRIPTION
**Issue:** Item throws an **NoneType** error when the Batch Number Series contains date variables such as .YY., .MM., .DD.,or .YYYY. (e.g., YY.MM.DD.##)

**Step to reproduce:**
1. Go to Global Defaults.
2. Enable Use Posting Datetime for Naming Documents.
3. Go to Stock → Item.
4. Create a new Item with Has Batch No enabled.
5. Set Batch Number Series to YY.MM.DD.##.
6. Save the Item.

**Before :**

[Screencast from 11-03-26 10:53:42 AM IST.webm](https://github.com/user-attachments/assets/6f83d3e6-8fb9-43d7-af6b-950396e7521e)

**After :** 

[Screencast from 11-03-26 10:52:55 AM IST.webm](https://github.com/user-attachments/assets/f73984bf-aafb-47e6-8c01-844bff678f21)

Backport Need for V16
