### PR TITLE
fix: skip budget validation when cancelling GL entries

### DIFF
--- a/erpnext/accounts/general_ledger.py
+++ b/erpnext/accounts/general_ledger.py
@@ -35,7 +35,8 @@ def make_gl_entries(
 ):
 	if gl_map:
 		if (
-			not cint(frappe.get_single_value("Accounts Settings", "use_legacy_budget_controller"))
+			not cancel
+			and not cint(frappe.get_single_value("Accounts Settings", "use_legacy_budget_controller"))
 			and gl_map[0].voucher_type != "Period Closing Voucher"
 		):
 			bud_val = BudgetValidation(gl_map=gl_map)


### PR DESCRIPTION
**Ref:** [#60912](https://support.frappe.io/helpdesk/tickets/60912)

**Issue:** When cancelling an Expense Claim for an account with a monthly budget configured, Budget Validation is triggered during the cancellation process. During this validation, the existing amount is fetched from the GL Entry and the current amount is taken from the Expense Claim being cancelled. Since the GL already contains the entry created during the original submission, both amounts are considered together during validation, causing the system to interpret it as exceeding the budget and resulting in a "Budget Exceeded" error during cancellation.

**Before:** 

[Screencast from 2026-03-11 11-56-32.webm](https://github.com/user-attachments/assets/6640fd09-e74d-4da7-8840-db420b61b250)


**After:**

[Screencast from 2026-03-11 11-57-43.webm](https://github.com/user-attachments/assets/1dfe49fa-6423-48f8-946f-0fa0a6ce8f73)


Backport needed for V-15, V-16