### PR TITLE
fix: add icon in clear demo data

### DIFF
--- a/erpnext/hooks.py
+++ b/erpnext/hooks.py
@@ -221,11 +221,12 @@ website_route_rules = [
 
 standard_navbar_items = [
 	{
-		"item_label": "Clear Demo Data",
+		"item_label": "Erase Demo Data",
 		"item_type": "Action",
 		"action": "erpnext.demo.clear_demo();",
 		"is_standard": 1,
-		"condition": "eval: frappe.boot.sysdefaults.demo_company",
+		"condition": "eval: frappe.boot.sysdefaults.demo_company && frappe.boot.sysdefaults.demo_company.length > 0",
+		"icon": "trash",
 	},
 ]
 

--- a/erpnext/hooks.py
+++ b/erpnext/hooks.py
@@ -221,7 +221,7 @@ website_route_rules = [
 
 standard_navbar_items = [
 	{
-		"item_label": "Erase Demo Data",
+		"item_label": "Delete Demo Data",
 		"item_type": "Action",
 		"action": "erpnext.demo.clear_demo();",
 		"is_standard": 1,

--- a/erpnext/public/js/utils/demo.js
+++ b/erpnext/public/js/utils/demo.js
@@ -2,7 +2,7 @@ frappe.provide("erpnext.demo");
 
 $(document).on("desktop_screen", function (event, data) {
 	data.desktop.add_menu_item({
-		label: __("Clear Demo Data"),
+		label: __("Delete Demo Data"),
 		icon: "trash",
 		condition: function () {
 			return frappe.boot.sysdefaults.demo_company;


### PR DESCRIPTION

<img width="254" height="512" alt="Screenshot 2026-03-11 at 1 28 47 PM" src="https://github.com/user-attachments/assets/6fb9afcd-8abe-406c-8a8e-be6d182128c7" />

Depends on https://github.com/frappe/frappe/pull/37926
Closes https://github.com/frappe/erpnext/issues/53424