### PR TITLE
fix: initialize all tax columns to resolve Key error in `item_wise_sales_register` and `item_wise_purchase_register` reports

### DIFF
--- a/erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py
+++ b/erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py
@@ -32,6 +32,7 @@ def _execute(filters=None, additional_table_columns=None):
 
 	item_list = get_items(filters, additional_table_columns)
 	aii_account_map = get_aii_accounts()
+	default_taxes = {}
 	if item_list:
 		itemised_tax, tax_columns = get_tax_accounts(
 			item_list,
@@ -40,6 +41,9 @@ def _execute(filters=None, additional_table_columns=None):
 			doctype="Purchase Invoice",
 			tax_doctype="Purchase Taxes and Charges",
 		)
+		for tax in tax_columns:
+			default_taxes[f"{tax}_rate"] = 0
+			default_taxes[f"{tax}_amount"] = 0
 
 	po_pr_map = get_purchase_receipts_against_purchase_order(item_list)
 
@@ -87,6 +91,7 @@ def _execute(filters=None, additional_table_columns=None):
 
 		total_tax = 0
 		total_other_charges = 0
+		row.update(default_taxes.copy())
 		for tax, details in itemised_tax.get(d.name, {}).items():
 			row.update(
 				{

--- a/erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py
+++ b/erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py
@@ -33,6 +33,10 @@ def _execute(filters=None, additional_table_columns=None, additional_conditions=
 		return columns, [], None, None, None, 0
 
 	itemised_tax, tax_columns = get_tax_accounts(item_list, columns, company_currency)
+	default_taxes = {}
+	for tax in tax_columns:
+		default_taxes[f"{tax}_rate"] = 0
+		default_taxes[f"{tax}_amount"] = 0
 
 	mode_of_payments = get_mode_of_payments(set(d.parent for d in item_list))
 	so_dn_map = get_delivery_notes_against_sales_order(item_list)
@@ -90,6 +94,9 @@ def _execute(filters=None, additional_table_columns=None, additional_conditions=
 
 		total_tax = 0
 		total_other_charges = 0
+
+		row.update(default_taxes.copy())
+
 		for tax, details in itemised_tax.get(d.name, {}).items():
 			row.update(
 				{

--- a/erpnext/accounts/report/item_wise_sales_register/test_item_wise_sales_register.py
+++ b/erpnext/accounts/report/item_wise_sales_register/test_item_wise_sales_register.py
@@ -16,9 +16,11 @@ class TestItemWiseSalesRegister(AccountsTestMixin, IntegrationTestCase):
 	def tearDown(self):
 		frappe.db.rollback()
 
-	def create_sales_invoice(self, do_not_submit=False):
+	def create_sales_invoice(self, item=None, taxes=None, do_not_submit=False):
 		si = create_sales_invoice(
-			item=self.item,
+			item=item or self.item,
+			item_name=item or self.item,
+			description=item or self.item,
 			company=self.company,
 			customer=self.customer,
 			debit_to=self.debit_to,
@@ -29,6 +31,19 @@ class TestItemWiseSalesRegister(AccountsTestMixin, IntegrationTestCase):
 			price_list_rate=100,
 			do_not_save=1,
 		)
+
+		for tax in taxes or []:
+			si.append(
+				"taxes",
+				{
+					"charge_type": "On Net Total",
+					"account_head": tax["account_head"],
+					"cost_center": self.cost_center,
+					"description": tax["description"],
+					"rate": tax["rate"],
+				},
+			)
+
 		si = si.save()
 		if not do_not_submit:
 			si = si.submit()
@@ -62,3 +77,50 @@ class TestItemWiseSalesRegister(AccountsTestMixin, IntegrationTestCase):
 
 		report_output = {k: v for k, v in report[1][0].items() if k in expected_result}
 		self.assertDictEqual(report_output, expected_result)
+
+	def test_grouped_report_handles_different_tax_descriptions(self):
+		self.create_item(item_name="_Test Item Tax Description A")
+		first_item = self.item
+		self.create_item(item_name="_Test Item Tax Description B")
+		second_item = self.item
+
+		first_tax_description = "Tax Description A"
+		second_tax_description = "Tax Description B"
+		first_tax_amount_field = f"{frappe.scrub(first_tax_description)}_amount"
+		second_tax_amount_field = f"{frappe.scrub(second_tax_description)}_amount"
+
+		self.create_sales_invoice(
+			item=first_item,
+			taxes=[
+				{
+					"account_head": "_Test Account VAT - _TC",
+					"description": first_tax_description,
+					"rate": 5,
+				}
+			],
+		)
+		self.create_sales_invoice(
+			item=second_item,
+			taxes=[
+				{
+					"account_head": "_Test Account Service Tax - _TC",
+					"description": second_tax_description,
+					"rate": 2,
+				}
+			],
+		)
+
+		filters = frappe._dict(
+			{
+				"from_date": today(),
+				"to_date": today(),
+				"company": self.company,
+				"group_by": "Customer",
+			}
+		)
+		_, data, _, _, _, _ = execute(filters)
+
+		grand_total_row = next(row for row in data if row.get("bold") and row.get("item_code") == "Total")
+
+		self.assertEqual(grand_total_row[first_tax_amount_field], 5.0)
+		self.assertEqual(grand_total_row[second_tax_amount_field], 2.0)


### PR DESCRIPTION
regression:  #50979 
```
 Traceback (most recent call last):
13:35:28 web.1            |   File "apps/frappe/frappe/app.py", line 121, in application
13:35:28 web.1            |     response = frappe.api.handle(request)
13:35:28 web.1            |   File "apps/frappe/frappe/api/__init__.py", line 63, in handle
13:35:28 web.1            |     data = endpoint(**arguments)
13:35:28 web.1            |   File "apps/frappe/frappe/api/v1.py", line 40, in handle_rpc_call
13:35:28 web.1            |     return frappe.handler.handle()
13:35:28 web.1            |            ~~~~~~~~~~~~~~~~~~~~~^^
13:35:28 web.1            |   File "apps/frappe/frappe/handler.py", line 53, in handle
13:35:28 web.1            |     data = execute_cmd(cmd)
13:35:28 web.1            |   File "apps/frappe/frappe/handler.py", line 86, in execute_cmd
13:35:28 web.1            |     return frappe.call(method, **frappe.form_dict)
13:35:28 web.1            |            ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^
13:35:28 web.1            |   File "apps/frappe/frappe/__init__.py", line 1131, in call
13:35:28 web.1            |     return fn(*args, **newargs)
13:35:28 web.1            |   File "apps/frappe/frappe/utils/typing_validations.py", line 49, in wrapper
13:35:28 web.1            |     return func(*args, **kwargs)
13:35:28 web.1            |   File "apps/frappe/frappe/__init__.py", line 493, in wrapper_fn
13:35:28 web.1            |     retval = fn(*args, **get_newargs(fn, kwargs))
13:35:28 web.1            |   File "apps/frappe/frappe/desk/query_report.py", line 242, in run
13:35:28 web.1            |     result = generate_report_result(
13:35:28 web.1            |     	report, filters, user, custom_columns, is_tree, parent_field, skip_total_calculation
13:35:28 web.1            |     )
13:35:28 web.1            |   File "apps/frappe/frappe/__init__.py", line 493, in wrapper_fn
13:35:28 web.1            |     retval = fn(*args, **get_newargs(fn, kwargs))
13:35:28 web.1            |   File "apps/frappe/frappe/desk/query_report.py", line 92, in generate_report_result
13:35:28 web.1            |     res = get_report_result(report, filters) or []
13:35:28 web.1            |           ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
13:35:28 web.1            |   File "apps/frappe/frappe/desk/query_report.py", line 67, in get_report_result
13:35:28 web.1            |     res = report.execute_script_report(filters)
13:35:28 web.1            |   File "apps/frappe/frappe/core/doctype/report/report.py", line 193, in execute_script_report
13:35:28 web.1            |     res = self.execute_module(filters)
13:35:28 web.1            |   File "apps/frappe/frappe/core/doctype/report/report.py", line 209, in execute_module
13:35:28 web.1            |     return frappe.get_attr(method_name)(frappe._dict(filters))
13:35:28 web.1            |            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^
13:35:28 web.1            |   File "apps/erpnext/erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py", line 21, in execute
13:35:28 web.1            |     return _execute(filters)
13:35:28 web.1            |   File "apps/erpnext/erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py", line 128, in _execute
13:35:28 web.1            |     add_sub_total_row(row, total_row_map, d.get(group_by_field, ""), tax_columns)
13:35:28 web.1            |     ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
13:35:28 web.1            |   File "apps/erpnext/erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py", line 761, in add_sub_total_row
13:35:28 web.1            |     total_row[f"{tax}_amount"] += flt(item[f"{tax}_amount"])
13:35:28 web.1            |                                       ~~~~^^^^^^^^^^^^^^^^^
13:35:28 web.1            | KeyError: '206c(1h)_amount'

```

Frappe Support Issue: https://support.frappe.io/desk/hd-ticket/61861