### PR TITLE
refactor: make cost center editable in payment entry deduction

### DIFF
--- a/erpnext/accounts/doctype/payment_entry_deduction/payment_entry_deduction.json
+++ b/erpnext/accounts/doctype/payment_entry_deduction/payment_entry_deduction.json
@@ -22,6 +22,7 @@
    "reqd": 1
   },
   {
+   "allow_on_submit": 1,
    "fieldname": "cost_center",
    "fieldtype": "Link",
    "in_list_view": 1,
@@ -59,7 +60,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-08-13 06:52:46.130142",
+ "modified": "2026-03-11 14:26:11.312950",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Payment Entry Deduction",


### PR DESCRIPTION
Allow cost center in deductions child table to be editable as payment entry already supports reposting.