### PR TITLE
fix: Append existing ignored doctypes in Journal Entry on_cancel instead of overwriting

### DIFF
--- a/erpnext/accounts/doctype/journal_entry/journal_entry.py
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.py
@@ -294,6 +294,8 @@ class JournalEntry(AccountsController):
 
 		# References for this Journal are removed on the `on_cancel` event in accounts_controller
 		super().on_cancel()
+
+		from_doc_events = getattr(self, "ignore_linked_doctypes", ())
 		self.ignore_linked_doctypes = (
 			"GL Entry",
 			"Stock Ledger Entry",
@@ -307,6 +309,10 @@ class JournalEntry(AccountsController):
 			"Advance Payment Ledger Entry",
 			"Tax Withholding Entry",
 		)
+
+		if from_doc_events and from_doc_events != self.ignore_linked_doctypes:
+			self.ignore_linked_doctypes = self.ignore_linked_doctypes + from_doc_events
+
 		self.make_gl_entries(1)
 		JournalTaxWithholding(self).on_cancel()
 		self.unlink_advance_entry_reference()


### PR DESCRIPTION
**Issue:**
Currently, when a Journal Entry is cancelled, its on_cancel method sets ignore_linked_doctypes to a fixed list of ERPNext doctypes. This overwrites any values added by other apps, making it impossible for apps to add their own doctypes to the ignore list.

**Fix:**
Modify the ignore_linked_doctypes to append any existing values instead of overwriting them. This helps to add values from custom apps.