### PR TITLE
fix: update delivery date in line items

### DIFF
--- a/erpnext/buying/doctype/purchase_order/purchase_order.js
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.js
@@ -769,10 +769,6 @@ erpnext.buying.PurchaseOrderController = class PurchaseOrderController extends (
 	items_on_form_rendered() {
 		set_schedule_date(this.frm);
 	}
-
-	schedule_date() {
-		set_schedule_date(this.frm);
-	}
 };
 
 // for backward compatibility: combine new and previous states

--- a/erpnext/public/js/controllers/buying.js
+++ b/erpnext/public/js/controllers/buying.js
@@ -140,6 +140,7 @@ erpnext.buying = {
 
 				this.toggle_subcontracting_fields();
 				super.refresh();
+				this.prevent_past_schedule_dates(this.frm);
 			}
 
 			toggle_subcontracting_fields() {
@@ -181,6 +182,28 @@ erpnext.buying = {
 					},
 				});
 				erpnext.utils.set_letter_head(this.frm)
+			}
+
+			schedule_date(doc, cdt, cdn) {
+				if (doc.schedule_date && !cdt.endsWith(" Item")) {
+					doc.items.forEach((d) => {
+						frappe.model.set_value(d.doctype, d.name, "schedule_date", doc.schedule_date);
+					});
+				}
+			}
+
+			transaction_date() {
+				super.transaction_date();
+				this.frm.set_value("schedule_date", "");
+				this.prevent_past_schedule_dates(this.frm);
+			}
+
+			prevent_past_schedule_dates(frm) {
+				if (frm.doc.transaction_date && frm.fields_dict["schedule_date"]) {
+					frm.fields_dict["schedule_date"].datepicker?.update({
+						minDate: new Date(frm.doc.transaction_date),
+					});
+				}
 			}
 
 			supplier_address() {

--- a/erpnext/stock/doctype/material_request/material_request.js
+++ b/erpnext/stock/doctype/material_request/material_request.js
@@ -642,10 +642,6 @@ erpnext.buying.MaterialRequestController = class MaterialRequestController exten
 		set_schedule_date(this.frm);
 	}
 
-	schedule_date() {
-		set_schedule_date(this.frm);
-	}
-
 	qty(doc, cdt, cdn) {
 		var row = frappe.get_doc(cdt, cdn);
 		row.amount = flt(row.qty) * flt(row.rate);


### PR DESCRIPTION
alternative to #53255

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Schedule dates can no longer be set earlier than the transaction date — the date picker enforces a minimum bound.
* **New Features**
  * Schedule date propagation centralized so setting a schedule date applies consistently across relevant line items and after refresh.
* **Chores**
  * Per-item schedule_date handlers removed; automatic copying to newly added material-request items has been removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->