### PR TITLE
fix(italy): fix e-invoice ScontoMaggiorazione structure and included_in_print_rate support

### DIFF
--- a/erpnext/regional/italy/e-invoice.xml
+++ b/erpnext/regional/italy/e-invoice.xml
@@ -188,7 +188,7 @@
         <Descrizione>{{ html2text(item.description or '') or item.item_name }}</Descrizione>
         <Quantita>{{ format_float(item.qty) }}</Quantita>
         <UnitaMisura>{{ item.stock_uom }}</UnitaMisura>
-        <PrezzoUnitario>{{ format_float(item.net_rate or item.price_list_rate or item.rate, item_meta.get_field("rate").precision) }}</PrezzoUnitario>
+        <PrezzoUnitario>{{ format_float(item.price_list_rate or item.net_rate or item.rate, item_meta.get_field("rate").precision) }}</PrezzoUnitario>
         {{ render_discount_or_margin(item) }}
         <PrezzoTotale>{{ format_float(item.net_amount, item_meta.get_field("amount").precision) }}</PrezzoTotale>
         <AliquotaIVA>{{ format_float(item.tax_rate, item_meta.get_field("tax_rate").precision) }}</AliquotaIVA>

--- a/erpnext/regional/italy/e-invoice.xml
+++ b/erpnext/regional/italy/e-invoice.xml
@@ -18,24 +18,26 @@
 <Nazione>{{ address.country_code }}</Nazione>
 {%- endmacro %}
 
-{%- macro render_discount_or_margin(item) -%}
-{%- if (item.discount_percentage and item.discount_percentage > 0.0) or item.margin_type %}
+{%- macro render_discount_or_margin(item, tax_divisor) -%}
+{%- if item.discount_percentage and item.discount_percentage > 0.0 %}
 <ScontoMaggiorazione>
-  {%- if item.discount_percentage > 0.0 %}
   <Tipo>SC</Tipo>
   <Percentuale>{{ format_float(item.discount_percentage) }}</Percentuale>
-  {%- endif %}
-  {%- if item.margin_rate_or_amount > 0.0 -%}
-    <Tipo>MG</Tipo>
-    {%- if item.margin_type == "Percentage" -%}
-      <Percentuale>{{ format_float(item.margin_rate_or_amount) }}</Percentuale>
-    {%- elif item.margin_type == "Amount" -%}
-      <Importo>{{ format_float(item.margin_rate_or_amount) }}</Importo>
-    {%- endif -%}
-  {%- endif %}
 </ScontoMaggiorazione>
-{%- endif -%}
+{%- endif %}
+{%- if item.margin_rate_or_amount and item.margin_rate_or_amount > 0.0 %}
+<ScontoMaggiorazione>
+  <Tipo>MG</Tipo>
+  {%- if item.margin_type == "Percentage" -%}
+    <Percentuale>{{ format_float(item.margin_rate_or_amount) }}</Percentuale>
+  {%- elif item.margin_type == "Amount" -%}
+    <Importo>{{ format_float(item.margin_rate_or_amount / tax_divisor) }}</Importo>
+  {%- endif -%}
+</ScontoMaggiorazione>
+{%- endif %}
 {%- endmacro -%}
+
+{%- set has_inclusive_tax = doc.taxes | selectattr("included_in_print_rate") | list | length > 0 -%}
 
 <?xml version='1.0' encoding='UTF-8'?>
 <p:FatturaElettronica xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
@@ -179,6 +181,7 @@
     </DatiGenerali>
     <DatiBeniServizi>
       {%- for item in doc.e_invoice_items %}
+      {%- set tax_divisor = (1 + item.tax_rate / 100) if has_inclusive_tax and item.tax_rate else 1 %}
       <DettaglioLinee>
         <NumeroLinea>{{ item.idx }}</NumeroLinea>
         <CodiceArticolo>
@@ -188,8 +191,9 @@
         <Descrizione>{{ html2text(item.description or '') or item.item_name }}</Descrizione>
         <Quantita>{{ format_float(item.qty) }}</Quantita>
         <UnitaMisura>{{ item.stock_uom }}</UnitaMisura>
-        <PrezzoUnitario>{{ format_float(item.price_list_rate or item.net_rate or item.rate, item_meta.get_field("rate").precision) }}</PrezzoUnitario>
-        {{ render_discount_or_margin(item) }}
+        {%- set item_unit_net_price = (item.price_list_rate / tax_divisor) or (item.net_rate) or (item.rate / tax_divisor) %}
+        <PrezzoUnitario>{{ format_float(item_unit_net_price, item_meta.get_field("rate").precision) }}</PrezzoUnitario>
+        {{ render_discount_or_margin(item, tax_divisor) }}
         <PrezzoTotale>{{ format_float(item.net_amount, item_meta.get_field("amount").precision) }}</PrezzoTotale>
         <AliquotaIVA>{{ format_float(item.tax_rate, item_meta.get_field("tax_rate").precision) }}</AliquotaIVA>
         {%- if item.tax_exemption_reason %}


### PR DESCRIPTION
### PR body:
Merge into: version-15, version-16
Closes #53310 Closes #40254

### What does this PR do?
Fixes the Italian e-invoice XML template (erpnext/regional/italy/e-invoice.xml) to:
1. Render each <ScontoMaggiorazione> entry (discount/margin) as a separate XML block, per SDI XSD schema requirements.
2. Correctly compute PrezzoUnitario and ScontoMaggiorazione amounts when included_in_print_rate is enabled on taxes.

### Why is this needed?
Schema violation (FeX 178): The <Tipo> and <Importo> nodes inside <ScontoMaggiorazione> are not repeatable per the SDI schema. When an item had both a discount and a margin, both were placed in a single block causing a validation error.

PrezzoTotale mismatch (SdI 00423): When included_in_print_rate is enabled, price_list_rate and margin_rate_or_amount store tax-inclusive values. SDI expects net-of-tax values. The formula Quantita × (PrezzoUnitario ± ScontoMaggiorazione) = PrezzoTotale failed validation.

### How does it work?
All changes are in the Jinja template only — no Python changes.

- Detects included_in_print_rate from doc.taxes via selectattr
- Computes tax_divisor = 1 + tax_rate / 100 per item (defaults to 1 when not inclusive — no regression)
- Divides price_list_rate and margin_rate_or_amount (Amount type) by tax_divisor
- Uses net_amount for PrezzoTotale (always correct regardless of tax inclusion)
- Splits SC and MG into separate <ScontoMaggiorazione> blocks

### Checklist

- [x]  Branch targets version-15 and version-16
- [x]  PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
- [x]  All business logic is template-side (Jinja), no server-side changes needed
- [x]  No regression: when included_in_print_rate is not set, tax_divisor = 1 and all values pass through unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detects and handles taxes included in item prices for Italian e-invoices.
* **Bug Fixes**
  * More accurate unit price calculation when taxes are inclusive.
  * Corrected display and amounts for discounts and margins on invoice items, including fixed handling of percentage vs. amount cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->