### PR TITLE
feat: add additional key to the total dictionary row is_total_row as …

### DIFF
--- a/erpnext/accounts/report/gross_profit/gross_profit.py
+++ b/erpnext/accounts/report/gross_profit/gross_profit.py
@@ -227,6 +227,7 @@ def get_data_when_grouped_by_invoice(columns, gross_profit_data, filters, group_
 				)
 				if total_base_amount
 				else 0,
+				"is_total_row": True,
 			}
 		)
 	)
@@ -235,7 +236,7 @@ def get_data_when_grouped_by_invoice(columns, gross_profit_data, filters, group_
 def get_data_when_not_grouped_by_invoice(gross_profit_data, filters, group_wise_columns, data):
 	total_base_amount = 0
 	total_buying_amount = 0
-
+	column_names = get_column_names()
 	group_columns = group_wise_columns.get(scrub(filters.group_by))
 
 	# removing customer_name from group columns
@@ -251,7 +252,8 @@ def get_data_when_not_grouped_by_invoice(gross_profit_data, filters, group_wise_
 		total_base_amount += src.base_amount or 0.00
 		total_buying_amount += src.buying_amount or 0.00
 
-		row = [src.get(col) for col in group_columns] + [filters.currency]
+		row = {column_names.get(col, col): src.get(col) for col in group_columns}
+		row["currency"] = filters.currency
 
 		data.append(row)
 
@@ -268,10 +270,9 @@ def get_data_when_not_grouped_by_invoice(gross_profit_data, filters, group_wise_
 		"base_amount": total_base_amount,
 		"buying_amount": total_buying_amount,
 		"gross_profit": total_gross_profit,
-		"gross_profit_percent": flt(gross_profit_percent, currency_precision),
+		"gross_profit_%": flt(gross_profit_percent, currency_precision),
+		"is_total_row": True,
 	}
-
-	total_row = [total_row.get(col, None) for col in [*group_columns, "currency"]]
 	data.append(total_row)
 
 

--- a/erpnext/accounts/report/gross_profit/test_gross_profit.py
+++ b/erpnext/accounts/report/gross_profit/test_gross_profit.py
@@ -727,11 +727,10 @@ class TestGrossProfit(IntegrationTestCase):
 
 		_, data = execute(filters=filters)
 		total = data[-1]
-
-		self.assertEqual(total[5], 1000.0)
-		self.assertEqual(total[6], 0.0)
-		self.assertEqual(total[7], 1000.0)
-		self.assertEqual(total[8], 100.0)
+		self.assertEqual(total["base_amount"], 1000.0)
+		self.assertEqual(total["buying_amount"], 0.0)
+		self.assertEqual(total["gross_profit"], 1000.0)
+		self.assertEqual(total["gross_profit_%"], 100.0)
 
 
 def make_sales_person(sales_person_name="_Test Sales Person"):


### PR DESCRIPTION
**Issue Ref**: [35799](https://github.com/frappe/frappe/issues/35799)

**Description**: When a report contains a total row calculated on the backend (instead of using the Add Total Row option), the total row is included in the sorting logic. As a result, when sorting any column, the total row also gets sorted along with the data rows

**Solution**: Added `is_total_row` as true to the total row of the gross profit report in which the Totals are calculated.

This issue depends on the PR [37939](https://github.com/frappe/frappe/pull/37939)

**Before**: 

https://github.com/user-attachments/assets/4b988084-20e1-4a98-b3f5-a7d497c0772e

**After**: 

https://github.com/user-attachments/assets/9af1b349-fc55-4116-96e0-440442127ada

backport needed in v15