### PR TITLE
fix: retain saved filters in Consolidated Financial Statement

### DIFF
--- a/erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.js
+++ b/erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.js
@@ -163,13 +163,16 @@ frappe.query_reports["Consolidated Financial Statement"] = {
 	},
 	onload: function () {
 		let fiscal_year = erpnext.utils.get_fiscal_year(frappe.datetime.get_today());
+		var filters = frappe.query_report.get_values();
 
-		frappe.model.with_doc("Fiscal Year", fiscal_year, function (r) {
-			var fy = frappe.model.get_doc("Fiscal Year", fiscal_year);
-			frappe.query_report.set_filter_value({
-				period_start_date: fy.year_start_date,
-				period_end_date: fy.year_end_date,
+		if (!filters.period_start_date || !filters.period_end_date) {
+			frappe.model.with_doc("Fiscal Year", fiscal_year, function (r) {
+				var fy = frappe.model.get_doc("Fiscal Year", fiscal_year);
+				frappe.query_report.set_filter_value({
+					period_start_date: fy.year_start_date,
+					period_end_date: fy.year_end_date,
+				});
 			});
-		});
+		}
 	},
 };


### PR DESCRIPTION
## Summary
- Add conditional guard to `onload` in `consolidated_financial_statement.js` so default date filters are only set when no values are already present
- Matches the existing pattern in `financial_statements.js` (used by P&L, Balance Sheet, Cash Flow)
- Without this fix, saved reports and URL-based filters are always overwritten on load

Closes #53339

backport version-16

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized the consolidated financial statement report to prevent unnecessary fiscal year date retrieval when date filters are already provided, improving load times and respecting existing filter selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->