### PR TITLE
fix: re-calculate taxes and totals after resetting bundle item rate

### DIFF
--- a/erpnext/stock/doctype/packed_item/packed_item.py
+++ b/erpnext/stock/doctype/packed_item/packed_item.py
@@ -359,6 +359,11 @@ def set_product_bundle_rate_amount(doc, parent_items_price):
 		if bundle_rate and bundle_rate != item.rate:
 			item.rate = bundle_rate
 			item.amount = flt(bundle_rate * item.qty)
+			item.margin_rate_or_amount = 0
+			item.discount_percentage = 0
+			item.discount_amount = 0
+	doc.calculate_taxes_and_totals()
+	doc.set_total_in_words()
 
 
 def on_doctype_update():

--- a/erpnext/stock/doctype/packed_item/packed_item.py
+++ b/erpnext/stock/doctype/packed_item/packed_item.py
@@ -354,6 +354,7 @@ def update_product_bundle_rate(parent_items_price, pi_row, item_row):
 
 def set_product_bundle_rate_amount(doc, parent_items_price):
 	"Set cumulative rate and amount in bundle item."
+	rate_updated = False
 	for item in doc.get("items"):
 		bundle_rate = parent_items_price.get((item.item_code, item.name))
 		if bundle_rate and bundle_rate != item.rate:
@@ -362,8 +363,10 @@ def set_product_bundle_rate_amount(doc, parent_items_price):
 			item.margin_rate_or_amount = 0
 			item.discount_percentage = 0
 			item.discount_amount = 0
-	doc.calculate_taxes_and_totals()
-	doc.set_total_in_words()
+			rate_updated = True
+	if rate_updated:
+		doc.calculate_taxes_and_totals()
+		doc.set_total_in_words()
 
 
 def on_doctype_update():


### PR DESCRIPTION
Closes: https://github.com/frappe/erpnext/issues/53341

**Before:**


https://github.com/user-attachments/assets/f3aded2b-dbed-4e47-9644-857efe09d4aa





**After:**



https://github.com/user-attachments/assets/7ddfd00d-1a9f-4ddf-ae89-8ecc57498524

