### PR TITLE
fix: use completion_date not posting date

### DIFF
--- a/erpnext/assets/doctype/asset_repair/asset_repair.js
+++ b/erpnext/assets/doctype/asset_repair/asset_repair.js
@@ -131,7 +131,7 @@ frappe.ui.form.on("Asset Repair", {
 				function () {
 					frappe.route_options = {
 						voucher_no: frm.doc.name,
-						from_date: frm.doc.completion_date,
+						from_date: moment(frm.doc.completion_date).format("YYYY-MM-DD"),
 						to_date: moment(frm.doc.modified).format("YYYY-MM-DD"),
 						company: frm.doc.company,
 						categorize_by: "",

--- a/erpnext/assets/doctype/asset_repair/asset_repair.js
+++ b/erpnext/assets/doctype/asset_repair/asset_repair.js
@@ -131,7 +131,7 @@ frappe.ui.form.on("Asset Repair", {
 				function () {
 					frappe.route_options = {
 						voucher_no: frm.doc.name,
-						from_date: frm.doc.posting_date,
+						from_date: frm.doc.completion_date,
 						to_date: moment(frm.doc.modified).format("YYYY-MM-DD"),
 						company: frm.doc.company,
 						categorize_by: "",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The General Ledger button in Asset Repair now uses the asset's completion date (formatted YYYY‑MM‑DD) as the default "from" date when opening the Accounting Ledger view. Other report options and behavior remain unchanged, aligning the ledger's default timeframe with repair completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->