### PR TITLE
fix: guard against division by zero in Work Order calculate_time

### DIFF
--- a/erpnext/manufacturing/doctype/work_order/work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/work_order.py
@@ -1321,7 +1321,7 @@ class WorkOrder(Document):
 	def calculate_time(self):
 		for d in self.get("operations"):
 			if not d.fixed_time:
-				d.time_in_mins = flt(d.time_in_mins) * (flt(self.qty) / flt(d.batch_size))
+				d.time_in_mins = flt(d.time_in_mins) * flt(flt(self.qty) / flt(d.batch_size or 1))
 
 		self.calculate_operating_cost()
 


### PR DESCRIPTION
## Summary
- `calculate_time()` divides by `d.batch_size` without a zero guard, causing `ZeroDivisionError` when `batch_size` is 0 or unset
- The same operation in `_get_operations()` (line 1287) correctly uses `d.batch_size or 1`
- Applied the same safeguard to `calculate_time()` for consistency

## Steps to reproduce
1. Create a Work Order with an operation that has `batch_size = 0`
2. Save or submit the Work Order
3. `calculate_time()` raises `ZeroDivisionError`

## Fix
Use `d.batch_size or 1` as the divisor, matching the existing pattern on line 1287.