### PR TITLE
fix: guard against division by zero in POS bundle availability

### DIFF
--- a/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
+++ b/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
@@ -942,7 +942,7 @@ def get_bundle_availability(bundle_item_code, warehouse):
 	for item in product_bundle.items:
 		item_bin_qty = get_bin_qty(item.item_code, warehouse)
 
-		max_available_bundles = item_bin_qty / item.qty
+		max_available_bundles = item_bin_qty / item.qty if item.qty else 0
 		if bundle_bin_qty > max_available_bundles and frappe.get_value(
 			"Item", item.item_code, "is_stock_item"
 		):

--- a/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
+++ b/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
@@ -942,7 +942,9 @@ def get_bundle_availability(bundle_item_code, warehouse):
 	for item in product_bundle.items:
 		item_bin_qty = get_bin_qty(item.item_code, warehouse)
 
-		max_available_bundles = item_bin_qty / item.qty if item.qty else 0
+		if not item.qty:
+			continue
+		max_available_bundles = item_bin_qty / item.qty
 		if bundle_bin_qty > max_available_bundles and frappe.get_value(
 			"Item", item.item_code, "is_stock_item"
 		):

--- a/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
+++ b/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
@@ -942,7 +942,7 @@ def get_bundle_availability(bundle_item_code, warehouse):
 	for item in product_bundle.items:
 		item_bin_qty = get_bin_qty(item.item_code, warehouse)
 
-		if not item.qty:
+		if flt(item.qty) <= 0:
 			continue
 		max_available_bundles = item_bin_qty / item.qty
 		if bundle_bin_qty > max_available_bundles and frappe.get_value(


### PR DESCRIPTION
## Summary
- `get_bundle_availability()` divides by `item.qty` from Product Bundle items without checking for zero
- If a Product Bundle child item has `qty = 0`, this raises `ZeroDivisionError` in the POS interface
- Returns 0 available bundles when a component qty is zero

## Steps to reproduce
1. Create a Product Bundle with a child item that has qty = 0
2. Open the POS Invoice interface
3. Try to add the bundle item
4. `ZeroDivisionError` crashes the POS

## Fix
Add an inline zero check: `item_bin_qty / item.qty if item.qty else 0`