### PR TITLE
fix: use parameterized queries in sales payment summary report

### DIFF
--- a/erpnext/accounts/report/sales_payment_summary/sales_payment_summary.py
+++ b/erpnext/accounts/report/sales_payment_summary/sales_payment_summary.py
@@ -177,21 +177,22 @@ def get_sales_invoice_data(filters):
 def get_mode_of_payments(filters):
 	mode_of_payments = {}
 	invoice_list = get_invoices(filters)
-	invoice_list_names = ",".join("'" + invoice["name"] + "'" for invoice in invoice_list)
+	invoice_list_names = [invoice["name"] for invoice in invoice_list]
 	if invoice_list:
+		placeholders = ", ".join(["%s"] * len(invoice_list_names))
 		inv_mop = frappe.db.sql(
 			f"""select a.owner,a.posting_date, ifnull(b.mode_of_payment, '') as mode_of_payment
 			from `tabSales Invoice` a, `tabSales Invoice Payment` b
 			where a.name = b.parent
 			and a.docstatus = 1
-			and a.name in ({invoice_list_names})
+			and a.name in ({placeholders})
 			union
 			select a.owner,a.posting_date, ifnull(b.mode_of_payment, '') as mode_of_payment
 			from `tabSales Invoice` a, `tabPayment Entry` b,`tabPayment Entry Reference` c
 			where a.name = c.reference_name
 			and b.name = c.parent
 			and b.docstatus = 1
-			and a.name in ({invoice_list_names})
+			and a.name in ({placeholders})
 			union
 			select a.owner, a.posting_date,
 			ifnull(a.voucher_type,'') as mode_of_payment
@@ -199,8 +200,9 @@ def get_mode_of_payments(filters):
 			where a.name = b.parent
 			and a.docstatus = 1
 			and b.reference_type = 'Sales Invoice'
-			and b.reference_name in ({invoice_list_names})
+			and b.reference_name in ({placeholders})
 			""",
+			invoice_list_names * 3,
 			as_dict=1,
 		)
 		for d in inv_mop:
@@ -222,8 +224,9 @@ def get_invoices(filters):
 def get_mode_of_payment_details(filters):
 	mode_of_payment_details = {}
 	invoice_list = get_invoices(filters)
-	invoice_list_names = ",".join("'" + invoice["name"] + "'" for invoice in invoice_list)
+	invoice_list_names = [invoice["name"] for invoice in invoice_list]
 	if invoice_list:
+		placeholders = ", ".join(["%s"] * len(invoice_list_names))
 		inv_mop_detail = frappe.db.sql(
 			f"""
 			select t.owner,
@@ -236,7 +239,7 @@ def get_mode_of_payment_details(filters):
 				from `tabSales Invoice` a, `tabSales Invoice Payment` b
 				where a.name = b.parent
 				and a.docstatus = 1
-				and a.name in ({invoice_list_names})
+				and a.name in ({placeholders})
 				group by a.owner, a.posting_date, mode_of_payment
 				union
 				select a.owner,a.posting_date,
@@ -245,7 +248,7 @@ def get_mode_of_payment_details(filters):
 				where a.name = c.reference_name
 				and b.name = c.parent
 				and b.docstatus = 1
-				and a.name in ({invoice_list_names})
+				and a.name in ({placeholders})
 				group by a.owner, a.posting_date, mode_of_payment
 				union
 				select a.owner, a.posting_date,
@@ -254,11 +257,12 @@ def get_mode_of_payment_details(filters):
 				where a.name = b.parent
 				and a.docstatus = 1
 				and b.reference_type = 'Sales Invoice'
-				and b.reference_name in ({invoice_list_names})
+				and b.reference_name in ({placeholders})
 				group by a.owner, a.posting_date, mode_of_payment
 			) t
 			group by t.owner, t.posting_date, t.mode_of_payment
 			""",
+			invoice_list_names * 3,
 			as_dict=1,
 		)
 
@@ -267,10 +271,11 @@ def get_mode_of_payment_details(filters):
 			ifnull(b.mode_of_payment, '') as mode_of_payment, sum(a.base_change_amount) as change_amount
 			from `tabSales Invoice` a, `tabSales Invoice Payment` b
 			where a.name = b.parent
-			and a.name in ({invoice_list_names})
+			and a.name in ({placeholders})
 			and b.type = 'Cash'
 			and a.base_change_amount > 0
 			group by a.owner, a.posting_date, mode_of_payment""",
+			invoice_list_names,
 			as_dict=1,
 		)
 


### PR DESCRIPTION
## Summary
- `get_mode_of_payments()` and `get_mode_of_payment_details()` build SQL IN clauses by concatenating invoice names wrapped in single quotes without escaping
- This is vulnerable to second-order SQL injection if an invoice name contains a single quote character (e.g. via custom naming series or data migration)
- Replaced with parameterized `%s` placeholders passed as query arguments

## Before (vulnerable)
```python
invoice_list_names = ",".join("'" + invoice["name"] + "'" for invoice in invoice_list)
# used directly in f-string SQL: ... and a.name in ({invoice_list_names})
```

## After (safe)
```python
invoice_list_names = [invoice["name"] for invoice in invoice_list]
placeholders = ", ".join(["%s"] * len(invoice_list_names))
# parameterized: ... and a.name in ({placeholders}), invoice_list_names
```

## Affected queries
8 occurrences across `get_mode_of_payments()` and `get_mode_of_payment_details()` functions, all converted to parameterized queries.