### PR TITLE
fix: guard against division by zero in Payment Entry GL entries

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -1291,6 +1291,13 @@ class PaymentEntry(AccountsController):
 			self.setup_party_account_field()
 		self.set_transaction_currency_and_rate()
 
+		if not self.transaction_exchange_rate:
+			frappe.throw(
+				_("Transaction Exchange Rate is required to create GL Entries for Payment Entry {0}").format(
+					self.name
+				)
+			)
+
 		gl_entries = []
 		self.add_party_gl_entries(gl_entries)
 		self.add_bank_gl_entries(gl_entries)

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -1372,7 +1372,7 @@ class PaymentEntry(AccountsController):
 						dr_or_cr: allocated_amount_in_company_currency,
 						dr_or_cr + "_in_transaction_currency": d.allocated_amount
 						if self.transaction_currency == self.party_account_currency
-						else allocated_amount_in_company_currency / self.transaction_exchange_rate,
+						else allocated_amount_in_company_currency / (self.transaction_exchange_rate or 1),
 						"advance_voucher_type": d.advance_voucher_type,
 						"advance_voucher_no": d.advance_voucher_no,
 						"transaction_exchange_rate": self.target_exchange_rate,
@@ -1424,7 +1424,7 @@ class PaymentEntry(AccountsController):
 						dr_or_cr + "_in_account_currency": self.unallocated_amount,
 						dr_or_cr + "_in_transaction_currency": self.unallocated_amount
 						if self.party_account_currency == self.transaction_currency
-						else base_unallocated_amount / self.transaction_exchange_rate,
+						else base_unallocated_amount / (self.transaction_exchange_rate or 1),
 						dr_or_cr: base_unallocated_amount,
 					},
 					item=self,
@@ -1517,7 +1517,7 @@ class PaymentEntry(AccountsController):
 		args_dict[dr_or_cr + "_in_transaction_currency"] = (
 			invoice.allocated_amount
 			if self.party_account_currency == self.transaction_currency
-			else base_allocated_amount / self.transaction_exchange_rate
+			else base_allocated_amount / (self.transaction_exchange_rate or 1)
 		)
 
 		args_dict.update(
@@ -1544,7 +1544,7 @@ class PaymentEntry(AccountsController):
 		args_dict[dr_or_cr + "_in_transaction_currency"] = (
 			invoice.allocated_amount
 			if self.party_account_currency == self.transaction_currency
-			else base_allocated_amount / self.transaction_exchange_rate
+			else base_allocated_amount / (self.transaction_exchange_rate or 1)
 		)
 		args_dict.update(
 			{
@@ -1571,7 +1571,7 @@ class PaymentEntry(AccountsController):
 						"credit_in_account_currency": self.paid_amount,
 						"credit_in_transaction_currency": self.paid_amount
 						if self.paid_from_account_currency == self.transaction_currency
-						else self.base_paid_amount / self.transaction_exchange_rate,
+						else self.base_paid_amount / (self.transaction_exchange_rate or 1),
 						"credit": self.base_paid_amount,
 						"cost_center": self.cost_center,
 						"post_net_value": True,
@@ -1589,7 +1589,7 @@ class PaymentEntry(AccountsController):
 						"debit_in_account_currency": self.received_amount,
 						"debit_in_transaction_currency": self.received_amount
 						if self.paid_to_account_currency == self.transaction_currency
-						else self.base_received_amount / self.transaction_exchange_rate,
+						else self.base_received_amount / (self.transaction_exchange_rate or 1),
 						"debit": self.base_received_amount,
 						"cost_center": self.cost_center,
 					},
@@ -1626,7 +1626,7 @@ class PaymentEntry(AccountsController):
 						if account_currency == self.company_currency
 						else d.tax_amount,
 						dr_or_cr + "_in_transaction_currency": base_tax_amount
-						/ self.transaction_exchange_rate,
+						/ (self.transaction_exchange_rate or 1),
 						"cost_center": d.cost_center,
 						"post_net_value": True,
 					},
@@ -1653,7 +1653,7 @@ class PaymentEntry(AccountsController):
 							if account_currency == self.company_currency
 							else d.tax_amount,
 							rev_dr_or_cr + "_in_transaction_currency": base_tax_amount
-							/ self.transaction_exchange_rate,
+							/ (self.transaction_exchange_rate or 1),
 							"cost_center": self.cost_center,
 							"post_net_value": True,
 						},
@@ -1678,7 +1678,7 @@ class PaymentEntry(AccountsController):
 						"account_currency": account_currency,
 						"against": self.party or self.paid_from,
 						"debit_in_account_currency": d.amount,
-						"debit_in_transaction_currency": d.amount / self.transaction_exchange_rate,
+						"debit_in_transaction_currency": d.amount / (self.transaction_exchange_rate or 1),
 						"debit": d.amount,
 						"cost_center": d.cost_center,
 					},

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -1372,7 +1372,7 @@ class PaymentEntry(AccountsController):
 						dr_or_cr: allocated_amount_in_company_currency,
 						dr_or_cr + "_in_transaction_currency": d.allocated_amount
 						if self.transaction_currency == self.party_account_currency
-						else allocated_amount_in_company_currency / (self.transaction_exchange_rate or 1),
+						else allocated_amount_in_company_currency / self.transaction_exchange_rate,
 						"advance_voucher_type": d.advance_voucher_type,
 						"advance_voucher_no": d.advance_voucher_no,
 						"transaction_exchange_rate": self.target_exchange_rate,
@@ -1424,7 +1424,7 @@ class PaymentEntry(AccountsController):
 						dr_or_cr + "_in_account_currency": self.unallocated_amount,
 						dr_or_cr + "_in_transaction_currency": self.unallocated_amount
 						if self.party_account_currency == self.transaction_currency
-						else base_unallocated_amount / (self.transaction_exchange_rate or 1),
+						else base_unallocated_amount / self.transaction_exchange_rate,
 						dr_or_cr: base_unallocated_amount,
 					},
 					item=self,
@@ -1517,7 +1517,7 @@ class PaymentEntry(AccountsController):
 		args_dict[dr_or_cr + "_in_transaction_currency"] = (
 			invoice.allocated_amount
 			if self.party_account_currency == self.transaction_currency
-			else base_allocated_amount / (self.transaction_exchange_rate or 1)
+			else base_allocated_amount / self.transaction_exchange_rate
 		)
 
 		args_dict.update(
@@ -1544,7 +1544,7 @@ class PaymentEntry(AccountsController):
 		args_dict[dr_or_cr + "_in_transaction_currency"] = (
 			invoice.allocated_amount
 			if self.party_account_currency == self.transaction_currency
-			else base_allocated_amount / (self.transaction_exchange_rate or 1)
+			else base_allocated_amount / self.transaction_exchange_rate
 		)
 		args_dict.update(
 			{
@@ -1571,7 +1571,7 @@ class PaymentEntry(AccountsController):
 						"credit_in_account_currency": self.paid_amount,
 						"credit_in_transaction_currency": self.paid_amount
 						if self.paid_from_account_currency == self.transaction_currency
-						else self.base_paid_amount / (self.transaction_exchange_rate or 1),
+						else self.base_paid_amount / self.transaction_exchange_rate,
 						"credit": self.base_paid_amount,
 						"cost_center": self.cost_center,
 						"post_net_value": True,
@@ -1589,7 +1589,7 @@ class PaymentEntry(AccountsController):
 						"debit_in_account_currency": self.received_amount,
 						"debit_in_transaction_currency": self.received_amount
 						if self.paid_to_account_currency == self.transaction_currency
-						else self.base_received_amount / (self.transaction_exchange_rate or 1),
+						else self.base_received_amount / self.transaction_exchange_rate,
 						"debit": self.base_received_amount,
 						"cost_center": self.cost_center,
 					},
@@ -1626,7 +1626,7 @@ class PaymentEntry(AccountsController):
 						if account_currency == self.company_currency
 						else d.tax_amount,
 						dr_or_cr + "_in_transaction_currency": base_tax_amount
-						/ (self.transaction_exchange_rate or 1),
+						/ self.transaction_exchange_rate,
 						"cost_center": d.cost_center,
 						"post_net_value": True,
 					},
@@ -1653,7 +1653,7 @@ class PaymentEntry(AccountsController):
 							if account_currency == self.company_currency
 							else d.tax_amount,
 							rev_dr_or_cr + "_in_transaction_currency": base_tax_amount
-							/ (self.transaction_exchange_rate or 1),
+							/ self.transaction_exchange_rate,
 							"cost_center": self.cost_center,
 							"post_net_value": True,
 						},
@@ -1678,7 +1678,7 @@ class PaymentEntry(AccountsController):
 						"account_currency": account_currency,
 						"against": self.party or self.paid_from,
 						"debit_in_account_currency": d.amount,
-						"debit_in_transaction_currency": d.amount / (self.transaction_exchange_rate or 1),
+						"debit_in_transaction_currency": d.amount / self.transaction_exchange_rate,
 						"debit": d.amount,
 						"cost_center": d.cost_center,
 					},


### PR DESCRIPTION
## Summary
- `transaction_exchange_rate` is used as a divisor in 9 places across Payment Entry GL entry methods without any zero check
- If the exchange rate is unset or 0, this produces a `ZeroDivisionError` during GL entry posting
- Used `(self.transaction_exchange_rate or 1)` to safely default to 1, consistent with similar patterns elsewhere (e.g. `accounts_controller.py` uses `self.get("conversion_rate", 1)`)

## Affected methods
- `add_party_gl_entries()` — lines 1375, 1427
- `add_payment_gl_entries()` — lines 1520, 1547, 1574, 1592
- `add_tax_gl_entries()` — lines 1629, 1656
- `add_deductions_gl_entries()` — line 1681

## Steps to reproduce
1. Create a Payment Entry where `transaction_exchange_rate` is 0 or missing
2. Submit the Payment Entry
3. GL entry creation raises `ZeroDivisionError`