### PR TITLE
fix: use parameterized queries in check_modified_date methods

### DIFF
--- a/erpnext/buying/doctype/purchase_order/purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.py
@@ -429,7 +429,7 @@ class PurchaseOrder(BuyingController):
 
 	def check_modified_date(self):
 		mod_db = frappe.db.sql("select modified from `tabPurchase Order` where name = %s", self.name)
-		date_diff = frappe.db.sql(f"select '{mod_db[0][0]}' - '{cstr(self.modified)}' ")
+		date_diff = frappe.db.sql("select TIMEDIFF(%s, %s)", (mod_db[0][0], cstr(self.modified)))
 
 		if date_diff and date_diff[0][0]:
 			msgprint(

--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -594,7 +594,7 @@ class SalesOrder(SellingController):
 
 	def check_modified_date(self):
 		mod_db = frappe.db.get_value("Sales Order", self.name, "modified")
-		date_diff = frappe.db.sql(f"select TIMEDIFF('{mod_db}', '{cstr(self.modified)}')")
+		date_diff = frappe.db.sql("select TIMEDIFF(%s, %s)", (mod_db, cstr(self.modified)))
 		if date_diff and date_diff[0][0]:
 			frappe.throw(_("{0} {1} has been modified. Please refresh.").format(self.doctype, self.name))
 

--- a/erpnext/stock/doctype/material_request/material_request.py
+++ b/erpnext/stock/doctype/material_request/material_request.py
@@ -243,7 +243,7 @@ class MaterialRequest(BuyingController):
 
 	def check_modified_date(self):
 		mod_db = frappe.db.sql("""select modified from `tabMaterial Request` where name = %s""", self.name)
-		date_diff = frappe.db.sql(f"""select TIMEDIFF('{mod_db[0][0]}', '{cstr(self.modified)}')""")
+		date_diff = frappe.db.sql("select TIMEDIFF(%s, %s)", (mod_db[0][0], cstr(self.modified)))
 
 		if date_diff and date_diff[0][0]:
 			frappe.throw(_("{0} {1} has been modified. Please refresh.").format(_(self.doctype), self.name))


### PR DESCRIPTION
## Summary
- Sales Order, Purchase Order, and Material Request all interpolate datetime values directly into SQL via f-strings in their `check_modified_date()` methods
- While the values come from the database, this violates the principle of parameterized queries and is fragile if data is ever corrupted
- Replaced with `%s` parameterized placeholders

## Files changed
- `erpnext/selling/doctype/sales_order/sales_order.py`
- `erpnext/buying/doctype/purchase_order/purchase_order.py`
- `erpnext/stock/doctype/material_request/material_request.py`

## Before
```python
date_diff = frappe.db.sql(f"select TIMEDIFF('{mod_db}', '{cstr(self.modified)}')")
```

## After
```python
date_diff = frappe.db.sql("select TIMEDIFF(%s, %s)", (mod_db, cstr(self.modified)))
```