### PR TITLE
fix: validate batch_size is non-zero in Work Order operations

### DIFF
--- a/erpnext/manufacturing/doctype/work_order/work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/work_order.py
@@ -1321,7 +1321,7 @@ class WorkOrder(Document):
 	def calculate_time(self):
 		for d in self.get("operations"):
 			if not d.fixed_time:
-				d.time_in_mins = flt(d.time_in_mins) * (flt(self.qty) / flt(d.batch_size))
+				d.time_in_mins = flt(d.time_in_mins) * flt(flt(self.qty) / flt(d.batch_size or 1))
 
 		self.calculate_operating_cost()
 

--- a/erpnext/manufacturing/doctype/work_order/work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/work_order.py
@@ -217,6 +217,7 @@ class WorkOrder(Document):
 
 		self.enable_auto_reserve_stock()
 		self.validate_operations_sequence()
+		self.validate_batch_size()
 		self.validate_subcontracting_inward_order()
 
 	def validate_dates(self):
@@ -286,6 +287,15 @@ class WorkOrder(Document):
 						)
 					)
 				sequence_id = op.sequence_id
+
+	def validate_batch_size(self):
+		for d in self.get("operations"):
+			if not d.fixed_time and d.set_cost_based_on_bom_qty and not flt(d.batch_size):
+				frappe.throw(
+					_("Row {0}: Batch Size is required for Operation {1}").format(
+						d.idx, frappe.bold(d.operation)
+					)
+				)
 
 	def validate_subcontracting_inward_order(self):
 		if scio := self.subcontracting_inward_order:
@@ -1321,7 +1331,7 @@ class WorkOrder(Document):
 	def calculate_time(self):
 		for d in self.get("operations"):
 			if not d.fixed_time:
-				d.time_in_mins = flt(d.time_in_mins) * flt(flt(self.qty) / flt(d.batch_size or 1))
+				d.time_in_mins = flt(d.time_in_mins) * (flt(self.qty) / flt(d.batch_size))
 
 		self.calculate_operating_cost()
 


### PR DESCRIPTION
## Summary
Follows up on #53381 based on maintainer feedback.

Instead of silently defaulting `batch_size` to 1, this adds a `validate_batch_size()` method that throws a clear error when `batch_size` is 0 or empty for non-fixed-time operations that use `set_cost_based_on_bom_qty`.

## Changes
- Added `validate_batch_size()` validation in `WorkOrder.validate()`
- Throws `_("Row {0}: Batch Size is required for Operation {1}")` when batch_size is falsy
- Only applies to operations where `fixed_time` is unchecked and `set_cost_based_on_bom_qty` is checked, since only those operations divide by `batch_size`

## Steps to reproduce
1. Create a Work Order with an operation where `set_cost_based_on_bom_qty` is checked and `batch_size` is 0
2. Save the Work Order
3. Previously: `ZeroDivisionError` in `calculate_time()`
4. Now: Clear validation message asking user to set batch_size