### PR TITLE
fix: BOM Creator miscalculates sub-assembly raw material cost

### DIFF
--- a/erpnext/manufacturing/doctype/bom_creator/bom_creator.py
+++ b/erpnext/manufacturing/doctype/bom_creator/bom_creator.py
@@ -203,7 +203,7 @@ class BOMCreator(Document):
 					self,
 				)
 			else:
-				row.rate = flt(self.get_raw_material_cost(row.item_code) * row.conversion_factor)
+				row.rate = flt(self.get_raw_material_cost(row.item_code) / flt(row.qty or 1) * row.conversion_factor)
 
 			row.amount = flt(row.rate) * flt(row.qty)
 			amount += flt(row.amount)


### PR DESCRIPTION
## Description

Fixes #52149

The BOM Creator's `get_raw_material_cost` method uses the **total** raw material cost of a sub-assembly directly as its per-unit `rate`. This causes the sub-assembly `amount` (`rate × qty`) to be inflated by a factor of `qty`, since:

- **Before:** `rate = total_rm_cost`, `amount = total_rm_cost × qty` (wrong — double-counts qty)
- **After:** `rate = total_rm_cost / qty`, `amount = (total_rm_cost / qty) × qty = total_rm_cost` (correct)

This is consistent with how the standard BOM calculates per-unit cost in `get_bom_unitcost`: `base_total_cost / quantity`.

The bug compounds exponentially in multi-level BOMs, causing wildly inflated costs as reported in the issue (e.g., INR 518,934 instead of INR 350).

## Fix

In `bom_creator.py` line 206, divide by `row.qty` to convert total cost to per-unit rate:

```python
# Before
row.rate = flt(self.get_raw_material_cost(row.item_code) * row.conversion_factor)

# After
row.rate = flt(self.get_raw_material_cost(row.item_code) / flt(row.qty or 1) * row.conversion_factor)
```

## Test plan

- [ ] Create a BOM Creator with a sub-assembly having qty > 1
- [ ] Verify the sub-assembly rate shows per-unit cost (total RM cost ÷ qty), not total cost
- [ ] Verify the final product raw material cost matches manual BOM creation
- [ ] Verify multi-level BOMs (sub-assemblies within sub-assemblies) calculate correctly
- [ ] Verify existing BOM Creator tests still pass