### PR TITLE
fix: remove null from link_filters

### DIFF
--- a/erpnext/assets/doctype/asset_repair/asset_repair.json
+++ b/erpnext/assets/doctype/asset_repair/asset_repair.json
@@ -130,7 +130,7 @@
    "fieldtype": "Link",
    "in_list_view": 1,
    "label": "Asset",
-   "link_filters": "[[\"Asset\",\"status\",\"not in\",[\"Work In Progress\",\"Capitalized\",\"Fully Depreciated\",\"Sold\",\"Scrapped\",\"Cancelled\",null]]]",
+   "link_filters": "[[\"Asset\",\"status\",\"not in\",[\"Work In Progress\",\"Capitalized\",\"Fully Depreciated\",\"Sold\",\"Scrapped\",\"Cancelled\"]]]",
    "options": "Asset",
    "reqd": 1
   },


### PR DESCRIPTION
**Issue:**
Asset not appearing in the Asset field while creating a new Asset Repair despite assets existing in the system.

**Ref:**[#62575](https://support.frappe.io/helpdesk/tickets/62575)