### PR TITLE
fix: update label on company change

### DIFF
--- a/erpnext/assets/doctype/asset/asset.js
+++ b/erpnext/assets/doctype/asset/asset.js
@@ -224,7 +224,7 @@ frappe.ui.form.on("Asset", {
 	},
 
 	set_dynamic_labels: function (frm) {
-		frm.set_currency_labels(["net_purchase_amount"], erpnext.get_currency(frm.doc.company));
+		frm.set_currency_labels(["gross_purchase_amount"], erpnext.get_currency(frm.doc.company));
 	},
 
 	set_depr_posting_failure_alert: function (frm) {
@@ -315,7 +315,7 @@ frappe.ui.form.on("Asset", {
 			},
 		});
 	},
-	
+
 	render_depreciation_schedule_view: function (frm, asset_depr_schedule_doc) {
 		let wrapper = $(frm.fields_dict["depreciation_schedule_view"].wrapper).empty();
 
@@ -394,7 +394,6 @@ frappe.ui.form.on("Asset", {
 		datatable.style.setStyle(`.dt-cell--col-2`, { "font-weight": 600 });
 		datatable.style.setStyle(`.dt-cell--col-3`, { "font-weight": 600 });
 	},
-
 
 	setup_chart_and_depr_schedule_view: async function (frm) {
 		if (frm.doc.finance_books.length > 1) {

--- a/erpnext/assets/doctype/asset/asset.js
+++ b/erpnext/assets/doctype/asset/asset.js
@@ -36,6 +36,7 @@ frappe.ui.form.on("Asset", {
 	},
 
 	company: function (frm) {
+		frm.trigger("set_dynamic_labels");
 		erpnext.accounts.dimensions.update_dimension(frm, frm.doctype);
 	},
 
@@ -87,6 +88,7 @@ frappe.ui.form.on("Asset", {
 	},
 
 	refresh: function (frm) {
+		frm.trigger("set_dynamic_labels");
 		frappe.ui.form.trigger("Asset", "is_existing_asset");
 		frm.toggle_display("next_depreciation_date", frm.doc.docstatus < 1);
 
@@ -221,6 +223,10 @@ frappe.ui.form.on("Asset", {
 		}
 	},
 
+	set_dynamic_labels: function (frm) {
+		frm.set_currency_labels(["net_purchase_amount"], erpnext.get_currency(frm.doc.company));
+	},
+
 	set_depr_posting_failure_alert: function (frm) {
 		const alert = `
 			<div class="row">
@@ -309,7 +315,7 @@ frappe.ui.form.on("Asset", {
 			},
 		});
 	},
-
+	
 	render_depreciation_schedule_view: function (frm, asset_depr_schedule_doc) {
 		let wrapper = $(frm.fields_dict["depreciation_schedule_view"].wrapper).empty();
 
@@ -388,6 +394,7 @@ frappe.ui.form.on("Asset", {
 		datatable.style.setStyle(`.dt-cell--col-2`, { "font-weight": 600 });
 		datatable.style.setStyle(`.dt-cell--col-3`, { "font-weight": 600 });
 	},
+
 
 	setup_chart_and_depr_schedule_view: async function (frm) {
 		if (frm.doc.finance_books.length > 1) {

--- a/erpnext/assets/doctype/asset/asset.json
+++ b/erpnext/assets/doctype/asset/asset.json
@@ -229,7 +229,7 @@
    "fieldtype": "Currency",
    "label": "Net Purchase Amount",
    "mandatory_depends_on": "eval:(!doc.is_composite_asset || doc.docstatus==1)",
-   "options": "Company:company:default_currency",
+   "options": "currency",
    "read_only_depends_on": "eval: doc.is_composite_asset"
   },
   {
@@ -597,7 +597,7 @@
    "link_fieldname": "target_asset"
   }
  ],
- "modified": "2025-12-23 16:01:10.195932",
+ "modified": "2026-03-13 12:15:25.734623",
  "modified_by": "Administrator",
  "module": "Assets",
  "name": "Asset",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Currency labels for the purchase amount field now dynamically reflect the selected company currency when the company is changed or the asset form is refreshed, ensuring displayed amounts use the correct currency context.

* **Chores**
  * Net Purchase Amount field updated to use a dedicated currency type for clearer currency handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->