### PR TITLE
fix(regional): use Property Setters for Italy Customer name fields

### DIFF
--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -471,3 +471,4 @@ erpnext.patches.v16_0.update_order_qty_and_requested_qty_based_on_mr_and_po
 erpnext.patches.v16_0.complete_onboarding_steps_for_older_sites #2
 erpnext.patches.v16_0.enable_serial_batch_setting
 erpnext.patches.v16_0.co_by_product_patch
+erpnext.patches.v15_0.fix_italy_customer_name_fields

--- a/erpnext/patches/v15_0/fix_italy_customer_name_fields.py
+++ b/erpnext/patches/v15_0/fix_italy_customer_name_fields.py
@@ -1,0 +1,17 @@
+"""Fix duplicate Customer first_name/last_name fields on Italian installations.
+
+The Italy regional setup created Custom Fields with the same names as standard
+fields, causing UniqueFieldnameError. This patch cleans up the duplicates and
+uses Property Setters instead.
+"""
+
+import frappe
+
+
+def execute():
+	if not frappe.db.exists("Company", {"country": "Italy"}):
+		return
+
+	from erpnext.regional.italy.setup import setup_customer_name_fields
+
+	setup_customer_name_fields()

--- a/erpnext/regional/italy/setup.py
+++ b/erpnext/regional/italy/setup.py
@@ -18,8 +18,79 @@ from erpnext.regional.italy import (
 
 def setup(company=None, patch=True):
 	make_custom_fields()
+	setup_customer_name_fields()
 	setup_report()
 	add_permissions()
+
+
+def setup_customer_name_fields():
+	"""Set up first_name/last_name as editable fields for Italian e-invoicing.
+
+	The standard Customer doctype has first_name/last_name as Read Only hidden fields
+	that fetch from customer_primary_contact. Italian e-invoicing (SDI) requires these
+	to be editable for Individual customers (ditta individuale).
+
+	Instead of creating duplicate Custom Fields (which causes UniqueFieldnameError),
+	we use Property Setters to modify the standard fields' behavior.
+	"""
+	# Clean up duplicate Custom Fields from old regional setup
+	for fieldname in ("first_name", "last_name"):
+		cf_name = f"Customer-{fieldname}"
+		if frappe.db.exists("Custom Field", cf_name):
+			frappe.delete_doc("Custom Field", cf_name, force=True)
+
+	# Use Property Setters to make standard fields editable
+	property_setters = [
+		{"field_name": "first_name", "property": "fieldtype", "value": "Data", "property_type": "Select"},
+		{"field_name": "first_name", "property": "hidden", "value": "0", "property_type": "Check"},
+		{"field_name": "first_name", "property": "fetch_from", "value": "", "property_type": "Small Text"},
+		{"field_name": "first_name", "property": "depends_on", "value": 'eval:doc.customer_type!="Company"', "property_type": "Data"},
+		{"field_name": "first_name", "property": "print_hide", "value": "1", "property_type": "Check"},
+		{"field_name": "last_name", "property": "fieldtype", "value": "Data", "property_type": "Select"},
+		{"field_name": "last_name", "property": "hidden", "value": "0", "property_type": "Check"},
+		{"field_name": "last_name", "property": "fetch_from", "value": "", "property_type": "Small Text"},
+		{"field_name": "last_name", "property": "depends_on", "value": 'eval:doc.customer_type!="Company"', "property_type": "Data"},
+		{"field_name": "last_name", "property": "print_hide", "value": "1", "property_type": "Check"},
+	]
+
+	for ps_data in property_setters:
+		ps_name = f"Customer-{ps_data['field_name']}-{ps_data['property']}"
+		if not frappe.db.exists("Property Setter", ps_name):
+			frappe.get_doc({
+				"doctype": "Property Setter",
+				"doctype_or_field": "DocField",
+				"doc_type": "Customer",
+				"field_name": ps_data["field_name"],
+				"property": ps_data["property"],
+				"value": ps_data["value"],
+				"property_type": ps_data["property_type"],
+				"is_system_generated": 1,
+			}).insert(ignore_permissions=True)
+
+	# Client Script to reposition first_name/last_name after customer_type
+	script_name = "Italy - Customer Name Fields"
+	if not frappe.db.exists("Client Script", script_name):
+		frappe.get_doc({
+			"doctype": "Client Script",
+			"name": script_name,
+			"dt": "Customer",
+			"script_type": "Client",
+			"enabled": 1,
+			"script": """
+frappe.ui.form.on('Customer', {
+	refresh(frm) {
+		// Move first_name and last_name after customer_type for Italian e-invoicing
+		const customer_type_field = frm.fields_dict.customer_type;
+		const first_name_field = frm.fields_dict.first_name;
+		const last_name_field = frm.fields_dict.last_name;
+		if (customer_type_field && first_name_field && last_name_field) {
+			customer_type_field.$wrapper.after(last_name_field.$wrapper);
+			customer_type_field.$wrapper.after(first_name_field.$wrapper);
+		}
+	}
+});
+""",
+		}).insert(ignore_permissions=True)
 
 
 def make_custom_fields(update=True):
@@ -230,22 +301,6 @@ def make_custom_fields(update=True):
 				print_hide=1,
 				description=_("Set this if the customer is a Public Administration company."),
 				depends_on='eval:doc.customer_type=="Company"',
-			),
-			dict(
-				fieldname="first_name",
-				label="First Name",
-				fieldtype="Data",
-				insert_after="salutation",
-				print_hide=1,
-				depends_on='eval:doc.customer_type!="Company"',
-			),
-			dict(
-				fieldname="last_name",
-				label="Last Name",
-				fieldtype="Data",
-				insert_after="first_name",
-				print_hide=1,
-				depends_on='eval:doc.customer_type!="Company"',
 			),
 		],
 		"Mode of Payment": [

--- a/erpnext/regional/italy/setup.py
+++ b/erpnext/regional/italy/setup.py
@@ -44,39 +44,52 @@ def setup_customer_name_fields():
 		{"field_name": "first_name", "property": "fieldtype", "value": "Data", "property_type": "Select"},
 		{"field_name": "first_name", "property": "hidden", "value": "0", "property_type": "Check"},
 		{"field_name": "first_name", "property": "fetch_from", "value": "", "property_type": "Small Text"},
-		{"field_name": "first_name", "property": "depends_on", "value": 'eval:doc.customer_type!="Company"', "property_type": "Data"},
+		{
+			"field_name": "first_name",
+			"property": "depends_on",
+			"value": 'eval:doc.customer_type!="Company"',
+			"property_type": "Data",
+		},
 		{"field_name": "first_name", "property": "print_hide", "value": "1", "property_type": "Check"},
 		{"field_name": "last_name", "property": "fieldtype", "value": "Data", "property_type": "Select"},
 		{"field_name": "last_name", "property": "hidden", "value": "0", "property_type": "Check"},
 		{"field_name": "last_name", "property": "fetch_from", "value": "", "property_type": "Small Text"},
-		{"field_name": "last_name", "property": "depends_on", "value": 'eval:doc.customer_type!="Company"', "property_type": "Data"},
+		{
+			"field_name": "last_name",
+			"property": "depends_on",
+			"value": 'eval:doc.customer_type!="Company"',
+			"property_type": "Data",
+		},
 		{"field_name": "last_name", "property": "print_hide", "value": "1", "property_type": "Check"},
 	]
 
 	for ps_data in property_setters:
 		ps_name = f"Customer-{ps_data['field_name']}-{ps_data['property']}"
 		if not frappe.db.exists("Property Setter", ps_name):
-			frappe.get_doc({
-				"doctype": "Property Setter",
-				"doctype_or_field": "DocField",
-				"doc_type": "Customer",
-				"field_name": ps_data["field_name"],
-				"property": ps_data["property"],
-				"value": ps_data["value"],
-				"property_type": ps_data["property_type"],
-				"is_system_generated": 1,
-			}).insert(ignore_permissions=True)
+			frappe.get_doc(
+				{
+					"doctype": "Property Setter",
+					"doctype_or_field": "DocField",
+					"doc_type": "Customer",
+					"field_name": ps_data["field_name"],
+					"property": ps_data["property"],
+					"value": ps_data["value"],
+					"property_type": ps_data["property_type"],
+					"is_system_generated": 1,
+				}
+			).insert(ignore_permissions=True)
 
 	# Client Script to reposition first_name/last_name after customer_type
 	script_name = "Italy - Customer Name Fields"
 	if not frappe.db.exists("Client Script", script_name):
-		frappe.get_doc({
-			"doctype": "Client Script",
-			"name": script_name,
-			"dt": "Customer",
-			"script_type": "Client",
-			"enabled": 1,
-			"script": """
+		frappe.get_doc(
+			{
+				"doctype": "Client Script",
+				"name": script_name,
+				"dt": "Customer",
+				"script_type": "Client",
+				"enabled": 1,
+				"script": """
 frappe.ui.form.on('Customer', {
 	refresh(frm) {
 		// Move first_name and last_name after customer_type for Italian e-invoicing
@@ -90,7 +103,8 @@ frappe.ui.form.on('Customer', {
 	}
 });
 """,
-		}).insert(ignore_permissions=True)
+			}
+		).insert(ignore_permissions=True)
 
 
 def make_custom_fields(update=True):

--- a/erpnext/regional/italy/test_italy_setup.py
+++ b/erpnext/regional/italy/test_italy_setup.py
@@ -21,7 +21,7 @@ class TestItalySetup(IntegrationTestCase):
 			frappe.delete_doc("Client Script", "Italy - Customer Name Fields", force=True)
 
 		# Clean up any leftover Custom Fields
-		for fieldname in ("first_name", "last_name"):
+		for fieldname in ("first_name", "last_name", "test_italy_setup_field"):
 			cf_name = f"Customer-{fieldname}"
 			if frappe.db.exists("Custom Field", cf_name):
 				frappe.delete_doc("Custom Field", cf_name, force=True)
@@ -51,6 +51,20 @@ class TestItalySetup(IntegrationTestCase):
 				"value",
 			)
 			self.assertEqual(fetch_from_ps, "")
+
+			depends_on_ps = frappe.db.get_value(
+				"Property Setter",
+				{"doc_type": "Customer", "field_name": fieldname, "property": "depends_on"},
+				"value",
+			)
+			self.assertEqual(depends_on_ps, 'eval:doc.customer_type!="Company"')
+
+			print_hide_ps = frappe.db.get_value(
+				"Property Setter",
+				{"doc_type": "Customer", "field_name": fieldname, "property": "print_hide"},
+				"value",
+			)
+			self.assertEqual(print_hide_ps, "1")
 
 	def test_client_script_created(self):
 		"""Client Script should be created to reposition fields."""

--- a/erpnext/regional/italy/test_italy_setup.py
+++ b/erpnext/regional/italy/test_italy_setup.py
@@ -26,8 +26,6 @@ class TestItalySetup(IntegrationTestCase):
 			if frappe.db.exists("Custom Field", cf_name):
 				frappe.delete_doc("Custom Field", cf_name, force=True)
 
-		frappe.db.commit()
-
 	def test_property_setters_created(self):
 		"""Property Setters should make first_name/last_name editable and visible."""
 		setup_customer_name_fields()

--- a/erpnext/regional/italy/test_italy_setup.py
+++ b/erpnext/regional/italy/test_italy_setup.py
@@ -118,8 +118,9 @@ class TestItalySetup(IntegrationTestCase):
 		setup_customer_name_fields()
 		setup_customer_name_fields()
 
-		ps_count = frappe.db.count(
-			"Property Setter",
-			filters={"doc_type": "Customer", "field_name": "first_name"},
-		)
-		self.assertEqual(ps_count, 5)
+		for fieldname in ("first_name", "last_name"):
+			ps_count = frappe.db.count(
+				"Property Setter",
+				filters={"doc_type": "Customer", "field_name": fieldname},
+			)
+			self.assertEqual(ps_count, 5)

--- a/erpnext/regional/italy/test_italy_setup.py
+++ b/erpnext/regional/italy/test_italy_setup.py
@@ -1,0 +1,113 @@
+# Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
+# License: GNU General Public License v3. See license.txt
+
+import frappe
+from frappe.tests import IntegrationTestCase
+
+from erpnext.regional.italy.setup import setup_customer_name_fields
+
+
+class TestItalySetup(IntegrationTestCase):
+	def tearDown(self):
+		# Clean up Property Setters created during tests
+		for ps in frappe.get_all(
+			"Property Setter",
+			filters={"doc_type": "Customer", "field_name": ["in", ["first_name", "last_name"]]},
+		):
+			frappe.delete_doc("Property Setter", ps.name, force=True)
+
+		# Clean up Client Script
+		if frappe.db.exists("Client Script", "Italy - Customer Name Fields"):
+			frappe.delete_doc("Client Script", "Italy - Customer Name Fields", force=True)
+
+		# Clean up any leftover Custom Fields
+		for fieldname in ("first_name", "last_name"):
+			cf_name = f"Customer-{fieldname}"
+			if frappe.db.exists("Custom Field", cf_name):
+				frappe.delete_doc("Custom Field", cf_name, force=True)
+
+		frappe.db.commit()
+
+	def test_property_setters_created(self):
+		"""Property Setters should make first_name/last_name editable and visible."""
+		setup_customer_name_fields()
+
+		for fieldname in ("first_name", "last_name"):
+			fieldtype_ps = frappe.db.get_value(
+				"Property Setter",
+				{"doc_type": "Customer", "field_name": fieldname, "property": "fieldtype"},
+				"value",
+			)
+			self.assertEqual(fieldtype_ps, "Data")
+
+			hidden_ps = frappe.db.get_value(
+				"Property Setter",
+				{"doc_type": "Customer", "field_name": fieldname, "property": "hidden"},
+				"value",
+			)
+			self.assertEqual(hidden_ps, "0")
+
+			fetch_from_ps = frappe.db.get_value(
+				"Property Setter",
+				{"doc_type": "Customer", "field_name": fieldname, "property": "fetch_from"},
+				"value",
+			)
+			self.assertEqual(fetch_from_ps, "")
+
+	def test_client_script_created(self):
+		"""Client Script should be created to reposition fields."""
+		setup_customer_name_fields()
+		self.assertTrue(frappe.db.exists("Client Script", "Italy - Customer Name Fields"))
+
+	def test_duplicate_custom_fields_cleaned_up(self):
+		"""Old duplicate Custom Fields should be removed."""
+		# Simulate the old regional setup creating duplicate Custom Fields
+		for fieldname in ("first_name", "last_name"):
+			cf_name = f"Customer-{fieldname}"
+			if not frappe.db.exists("Custom Field", cf_name):
+				cf = frappe.get_doc(
+					{
+						"doctype": "Custom Field",
+						"dt": "Customer",
+						"fieldname": fieldname,
+						"fieldtype": "Data",
+						"label": fieldname.replace("_", " ").title(),
+					}
+				)
+				cf.flags.ignore_validate = True
+				cf.insert()
+
+		# Run the setup — it should clean up the duplicates
+		setup_customer_name_fields()
+
+		for fieldname in ("first_name", "last_name"):
+			self.assertFalse(frappe.db.exists("Custom Field", f"Customer-{fieldname}"))
+
+	def test_no_unique_fieldname_error_after_setup(self):
+		"""Adding custom fields to Customer should work after setup."""
+		setup_customer_name_fields()
+
+		cf = frappe.get_doc(
+			{
+				"doctype": "Custom Field",
+				"dt": "Customer",
+				"fieldname": "test_italy_setup_field",
+				"fieldtype": "Data",
+				"label": "Test Italy Setup Field",
+				"insert_after": "customer_name",
+			}
+		)
+		cf.insert()
+		self.assertTrue(frappe.db.exists("Custom Field", "Customer-test_italy_setup_field"))
+		cf.delete()
+
+	def test_idempotent(self):
+		"""Running setup twice should not raise errors or create duplicates."""
+		setup_customer_name_fields()
+		setup_customer_name_fields()
+
+		ps_count = frappe.db.count(
+			"Property Setter",
+			filters={"doc_type": "Customer", "field_name": "first_name"},
+		)
+		self.assertEqual(ps_count, 5)


### PR DESCRIPTION
## Summary

- Replaces duplicate Custom Field creation with Property Setters to resolve `UniqueFieldnameError` on Italian installations
- No field renaming, no data migration — existing integrations, templates, and APIs continue to work unchanged
- Adds Client Script to reposition `first_name`/`last_name` after `customer_type` for backwards compatibility with the old regional setup layout

## Root Cause

The Italy regional setup called `create_custom_fields` to create `first_name`/`last_name` on Customer, but the standard doctype already has fields with the same names (Read Only, hidden, `fetch_from: customer_primary_contact`). During the setup wizard, `ignore_validate=True` bypasses the duplicate check, allowing two field definitions on the same DB column. The `UniqueFieldnameError` only surfaces later when any other app tries to add custom fields to Customer.

## Approach

Instead of renaming the fields (which breaks existing integrations as discussed in #50921), this fix uses **Property Setters** to modify the standard fields' behavior on Italian installations:

- `fieldtype`: `Read Only` → `Data` (editable)
- `hidden`: `1` → `0` (visible)
- `fetch_from`: removed
- `depends_on`: `eval:doc.customer_type!="Company"`

The function is idempotent: it cleans up old duplicate Custom Fields if present, creates Property Setters and Client Script only if they don't exist, and runs on both setup wizard and `bench migrate`.

## Test Plan

- [x] Fresh site with Italy setup wizard — fields are editable and visible for Individual customers
- [x] Adding custom fields to Customer works without `UniqueFieldnameError`
- [x] No duplicate field definitions in meta
- [x] e-invoice XML template reads from the same `first_name`/`last_name` columns
- [x] Fields repositioned after `customer_type` via Client Script

Supersedes #50921
Fixes #50915