### PR TITLE
fix: broke cost center filter in get outstanding reference docs

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -2558,14 +2558,9 @@ def get_orders_to_be_billed(
 	if not voucher_type:
 		return []
 
-	# Add cost center condition
-	doc = frappe.get_doc({"doctype": voucher_type})
-	condition = ""
-	if doc and hasattr(doc, "cost_center") and doc.cost_center:
-		condition = " and cost_center='%s'" % cost_center
-
 	# dynamic dimension filters
-	active_dimensions = get_dimensions()[0]
+	condition = ""
+	active_dimensions = get_dimensions(True)[0]
 	for dim in active_dimensions:
 		if filters.get(dim.fieldname):
 			condition += f" and {dim.fieldname}='{filters.get(dim.fieldname)}'"


### PR DESCRIPTION
Cost Center filter wasn't working in `Get Outstanding Order` button in Payment Entry.
Ref:  [62656](https://support.frappe.io/helpdesk/tickets/62656)