### PR TITLE
fix: correct quantity reflection in material request from SO with pro…

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -1090,7 +1090,8 @@ def make_material_request(source_name: str, target_doc: str | Document | None = 
 			)
 		)
 		target.amount = target.qty * target.rate
-		target.schedule_date = source_parent.delivery_date
+		if not target.schedule_date:
+			target.schedule_date = source_parent.delivery_date
 
 	doc = get_mapped_doc(
 		"Sales Order",
@@ -1129,7 +1130,6 @@ def make_material_request(source_name: str, target_doc: str | Document | None = 
 			_("Material Request already created for the ordered quantity."),
 			title=_("Material Request Exists"),
 		)
-		return None
 
 
 @frappe.whitelist()

--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -1052,16 +1052,13 @@ def make_material_request(source_name: str, target_doc: str | Document | None = 
 		)
 
 		return flt(
-			(
-				flt(so_item.qty)
-				- flt(requested_item_qty.get(so_item.name, {}).get("qty"))
-				- max(
-					flt(delivered_qty) * flt(bundle_item_qty)
-					- flt(requested_item_qty.get(so_item.name, {}).get("received_qty")),
-					0,
-				)
+			flt(so_item.qty)
+			- flt(requested_item_qty.get(so_item.name, {}).get("qty"))
+			- max(
+				flt(delivered_qty) * flt(bundle_item_qty)
+				- flt(requested_item_qty.get(so_item.name, {}).get("received_qty")),
+				0,
 			)
-			* bundle_item_qty
 		)
 
 	def update_item(source, target, source_parent):
@@ -1093,6 +1090,7 @@ def make_material_request(source_name: str, target_doc: str | Document | None = 
 			)
 		)
 		target.amount = target.qty * target.rate
+		target.schedule_date = source_parent.delivery_date
 
 	doc = get_mapped_doc(
 		"Sales Order",
@@ -1124,7 +1122,14 @@ def make_material_request(source_name: str, target_doc: str | Document | None = 
 		postprocess,
 	)
 
-	return doc
+	if doc and doc.items:
+		return doc
+	else:
+		frappe.throw(
+			_("Material Request already created for the ordered quantity."),
+			title=_("Material Request Exists"),
+		)
+		return None
 
 
 @frappe.whitelist()

--- a/erpnext/selling/doctype/sales_order/test_sales_order.py
+++ b/erpnext/selling/doctype/sales_order/test_sales_order.py
@@ -57,6 +57,30 @@ class TestSalesOrder(AccountsTestMixin, IntegrationTestCase):
 		frappe.db.rollback()
 		frappe.set_user("Administrator")
 
+	def test_sales_order_with_product_bundle_for_partial_material_request(self):
+		product_bundle = make_product_bundle(
+			"_Test Product Bundle Item", ["_Test Item", "_Test Item Home Desktop 100"]
+		)
+		so = make_sales_order(item_code=product_bundle.name, qty=2)
+		mr = make_material_request(so.name)
+		mr.items[0].qty = 4
+		mr.items[1].qty = 2
+		mr.save()
+		mr.submit()
+		mr.reload()
+		self.assertEqual(mr.items[0].qty, 4)
+		mr = make_material_request(so.name)
+		self.assertEqual(mr.items[0].qty, 6)
+
+	def test_sales_order_with_full_material_request(self):
+		so = make_sales_order(item_code="_Test Item", qty=5, do_not_submit=True)
+		so.submit()
+		mr = make_material_request(so.name)
+		mr.save()
+		mr.submit()
+		mr.reload()
+		self.assertRaises(frappe.ValidationError, make_material_request, so.name)
+
 	def test_sales_order_skip_delivery_note(self):
 		so = make_sales_order(do_not_submit=True)
 		so.order_type = "Maintenance"


### PR DESCRIPTION
This fixes: https://github.com/frappe/erpnext/issues/53268

This resolves the following things: 

1. When the Material request is created from SO, the correct quantities get reflected for the product bundle case 
2. If full MR is created then does not allow creating another MR from the same SO
3. Required date gets reflected in MR based on the delivery date   
