### PR TITLE
fix(stock): fix the property setter

### DIFF
--- a/erpnext/public/js/utils/landed_taxes_and_charges_common.js
+++ b/erpnext/public/js/utils/landed_taxes_and_charges_common.js
@@ -42,9 +42,9 @@ erpnext.landed_cost_taxes_and_charges = {
 
 				if (row.account_currency == company_currency) {
 					row.exchange_rate = 1;
-					frm.set_df_property("taxes", "hidden", 1, row.name, "exchange_rate");
+					frm.set_df_property("taxes", "hidden", 1, frm.docname, "exchange_rate", cdn);
 				} else if (!row.exchange_rate || row.exchange_rate == 1) {
-					frm.set_df_property("taxes", "hidden", 0, row.name, "exchange_rate");
+					frm.set_df_property("taxes", "hidden", 0, frm.docname, "exchange_rate", cdn);
 					frappe.call({
 						method: "erpnext.accounts.doctype.journal_entry.journal_entry.get_exchange_rate",
 						args: {


### PR DESCRIPTION
**Issue:**
The exchange_rate field remains visible and editable in the Landed Cost Voucher (LCV) form even after setting the exchange rate to 1, the args for the property setter for child table is wrongly passed.

**Backport Needed for V15 and V16**