### PR TITLE
feat(report): add service start/end date and amount with roll-ups in deferred revenue/expense report

### DIFF
--- a/erpnext/accounts/report/deferred_revenue_and_expense/deferred_revenue_and_expense.py
+++ b/erpnext/accounts/report/deferred_revenue_and_expense/deferred_revenue_and_expense.py
@@ -48,6 +48,9 @@ class Deferred_Item:
 		Generate report data for output
 		"""
 		ret_data = frappe._dict({"name": self.item_name})
+		ret_data.service_start_date = self.service_start_date
+		ret_data.service_end_date = self.service_end_date
+		ret_data.amount = self.base_net_amount
 		for period in self.period_total:
 			ret_data[period.key] = period.total
 			ret_data.indent = 1
@@ -205,6 +208,9 @@ class Deferred_Invoice:
 		for item in self.uniq_items:
 			self.items.append(Deferred_Item(item, self, [x for x in items if x.item == item]))
 
+		# roll-up amount from all deferred items
+		self.amount_total = sum(item.base_net_amount for item in self.items)
+
 	def calculate_invoice_revenue_expense_for_period(self):
 		"""
 		calculate deferred revenue/expense for all items in invoice
@@ -232,7 +238,7 @@ class Deferred_Invoice:
 		generate report data for invoice, includes invoice total
 		"""
 		ret_data = []
-		inv_total = frappe._dict({"name": self.name})
+		inv_total = frappe._dict({"name": self.name, "amount": self.amount_total})
 		for x in self.period_total:
 			inv_total[x.key] = x.total
 			inv_total.indent = 0
@@ -386,6 +392,24 @@ class Deferred_Revenue_and_Expense_Report:
 	def get_columns(self):
 		columns = []
 		columns.append({"label": _("Name"), "fieldname": "name", "fieldtype": "Data", "read_only": 1})
+		columns.append(
+			{
+				"label": _("Service Start Date"),
+				"fieldname": "service_start_date",
+				"fieldtype": "Date",
+				"read_only": 1,
+			}
+		)
+		columns.append(
+			{
+				"label": _("Service End Date"),
+				"fieldname": "service_end_date",
+				"fieldtype": "Date",
+				"read_only": 1,
+			}
+		)
+		columns.append({"label": _("Amount"), "fieldname": "amount", "fieldtype": "Currency", "read_only": 1})
+
 		for period in self.period_list:
 			columns.append(
 				{
@@ -414,6 +438,8 @@ class Deferred_Revenue_and_Expense_Report:
 			total_row = frappe._dict({"name": "Total Deferred Income"})
 		elif self.filters.type == "Expense":
 			total_row = frappe._dict({"name": "Total Deferred Expense"})
+
+		total_row["amount"] = sum(inv.amount_total for inv in self.deferred_invoices)
 
 		for idx, period in enumerate(self.period_list, 0):
 			total_row[period.key] = self.period_total[idx].total


### PR DESCRIPTION
Before: 

<img width="1440" height="900" alt="Screenshot 2026-03-13 at 8 42 05 PM" src="https://github.com/user-attachments/assets/258bdd4d-96d5-470e-887e-25b49556ccbc" />


After:

<img width="1440" height="900" alt="Screenshot 2026-03-13 at 8 42 18 PM" src="https://github.com/user-attachments/assets/4712e056-389b-4ec5-a990-49f63b883c6d" />


closes #52850 

`no docs`