### PR TITLE
refactor: `normalize_ctx_input` utility function

### DIFF
--- a/erpnext/__init__.py
+++ b/erpnext/__init__.py
@@ -1,6 +1,7 @@
 import functools
 import inspect
-from typing import TypeVar
+from types import UnionType
+from typing import TypeVar, get_origin
 
 import frappe
 from frappe.model.document import Document
@@ -167,18 +168,31 @@ def check_app_permission():
 T = TypeVar("T")
 
 
-def normalize_ctx_input(T: type) -> callable:
+def normalize_ctx_input() -> callable:
 	"""
-	Normalizes the first argument (ctx) of the decorated function by:
+	Normalizes the `ctx` argument of the decorated function by:
 	- Converting Document objects to dictionaries
 	- Parsing JSON strings
-	- Casting the result to the specified type T
+	- Casting the result to the specified type on parameter annotations
+	- Adds Document, dict and str type annotation to the `ctx` parameter
+
+	On function definition, add only single type.
 	"""
 
 	def decorator(func: callable):
-		# conserve annotations for frappe.utils.typing_validations
-		@functools.wraps(func, assigned=(a for a in functools.WRAPPER_ASSIGNMENTS if a != "__annotations__"))
-		def wrapper(ctx: T | Document | dict | str, *args, **kwargs):
+		T = func.__annotations__.get("ctx", None)
+		sig = inspect.signature(func)
+		is_union = get_origin(T) is UnionType
+
+		@functools.wraps(func)
+		def wrapper(*args, **kwargs):
+			if not T or is_union:
+				return func(*args, **kwargs)
+
+			bound = sig.bind(*args, **kwargs)
+			bound.apply_defaults()
+			ctx = bound.arguments.get("ctx")
+
 			if isinstance(ctx, Document):
 				ctx = T(**ctx.as_dict())
 			elif isinstance(ctx, dict):
@@ -186,10 +200,13 @@ def normalize_ctx_input(T: type) -> callable:
 			else:
 				ctx = T(**frappe.parse_json(ctx))
 
-			return func(ctx, *args, **kwargs)
+			bound.arguments["ctx"] = ctx
 
-		# set annotations from function
-		wrapper.__annotations__.update({k: v for k, v in func.__annotations__.items() if k != "ctx"})
+			return func(*bound.args, **bound.kwargs)
+
+		if T and not is_union:
+			wrapper.__annotations__["ctx"] = T | Document | dict | str
+
 		return wrapper
 
 	return decorator

--- a/erpnext/assets/doctype/asset_capitalization/asset_capitalization.py
+++ b/erpnext/assets/doctype/asset_capitalization/asset_capitalization.py
@@ -663,7 +663,7 @@ def get_target_asset_details(asset: str | None = None, company: str | None = Non
 
 
 @frappe.whitelist()
-@erpnext.normalize_ctx_input(ItemDetailsCtx)
+@erpnext.normalize_ctx_input()
 def get_consumed_stock_item_details(ctx: ItemDetailsCtx):
 	out = frappe._dict()
 
@@ -711,7 +711,7 @@ def get_consumed_stock_item_details(ctx: ItemDetailsCtx):
 
 
 @frappe.whitelist()
-@erpnext.normalize_ctx_input(ItemDetailsCtx)
+@erpnext.normalize_ctx_input()
 def get_warehouse_details(ctx: ItemDetailsCtx) -> frappe._dict:
 	out = frappe._dict()
 	if ctx.warehouse and ctx.item_code:
@@ -725,7 +725,7 @@ def get_warehouse_details(ctx: ItemDetailsCtx) -> frappe._dict:
 
 
 @frappe.whitelist()
-@erpnext.normalize_ctx_input(ItemDetailsCtx)
+@erpnext.normalize_ctx_input()
 def get_consumed_asset_details(ctx: ItemDetailsCtx) -> frappe._dict:
 	out = frappe._dict()
 
@@ -771,7 +771,7 @@ def get_consumed_asset_details(ctx: ItemDetailsCtx) -> frappe._dict:
 
 
 @frappe.whitelist()
-@erpnext.normalize_ctx_input(ItemDetailsCtx)
+@erpnext.normalize_ctx_input()
 def get_service_item_details(ctx: ItemDetailsCtx) -> frappe._dict:
 	out = frappe._dict()
 

--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -54,9 +54,9 @@ def _preprocess_ctx(ctx):
 
 
 @frappe.whitelist()
-@erpnext.normalize_ctx_input(ItemDetailsCtx)
+@erpnext.normalize_ctx_input()
 def get_item_details(
-	ctx: ItemDetailsCtx | str,
+	ctx: ItemDetailsCtx,
 	doc: Document | str | None = None,
 	for_validate: bool = False,
 	overwrite_warehouse: bool = True,
@@ -586,7 +586,7 @@ def get_basic_details(ctx: ItemDetailsCtx, item, overwrite_warehouse=True) -> It
 	return out
 
 
-@erpnext.normalize_ctx_input(ItemDetailsCtx)
+@erpnext.normalize_ctx_input()
 def get_item_warehouse_(ctx: ItemDetailsCtx, item, overwrite_warehouse, defaults=None):
 	if not defaults:
 		defaults = frappe._dict(
@@ -701,7 +701,7 @@ def get_item_tax_info(
 
 
 @frappe.whitelist()
-@erpnext.normalize_ctx_input(ItemDetailsCtx)
+@erpnext.normalize_ctx_input()
 def get_item_tax_template(ctx: ItemDetailsCtx, item: Document | None = None, out: ItemDetails | None = None):
 	"""
 	Determines item_tax template from item or parent item groups.
@@ -743,7 +743,7 @@ def get_item_tax_template(ctx: ItemDetailsCtx, item: Document | None = None, out
 	return item_tax_template
 
 
-@erpnext.normalize_ctx_input(ItemDetailsCtx)
+@erpnext.normalize_ctx_input()
 def _get_item_tax_template(
 	ctx: ItemDetailsCtx, taxes, out: ItemDetails | None = None, for_validate=False
 ) -> None | str | list[str]:
@@ -814,7 +814,7 @@ def _get_item_tax_template(
 	return None
 
 
-@erpnext.normalize_ctx_input(ItemDetailsCtx)
+@erpnext.normalize_ctx_input()
 def is_within_valid_range(ctx: ItemDetailsCtx, tax) -> bool:
 	"""
 	Accesses:
@@ -849,7 +849,7 @@ def get_item_tax_map(*, doc: str | dict | Document, tax_template: str | None = N
 
 
 @frappe.whitelist()
-@erpnext.normalize_ctx_input(ItemDetailsCtx)
+@erpnext.normalize_ctx_input()
 def calculate_service_end_date(ctx: ItemDetailsCtx, item: Document | None = None):
 	_preprocess_ctx(ctx)
 	if not item:
@@ -950,7 +950,7 @@ def get_default_deferred_account(ctx: ItemDetailsCtx, item, fieldname=None):
 		return None
 
 
-@erpnext.normalize_ctx_input(ItemDetailsCtx)
+@erpnext.normalize_ctx_input()
 def get_default_cost_center(ctx: ItemDetailsCtx, item=None, item_group=None, brand=None, company=None):
 	cost_center = None
 
@@ -1183,7 +1183,7 @@ def get_batch_based_item_price(pctx: ItemPriceCtx | dict | str, item_code: str):
 	return 0.0
 
 
-@erpnext.normalize_ctx_input(ItemDetailsCtx)
+@erpnext.normalize_ctx_input()
 def get_price_list_rate_for(ctx: ItemDetailsCtx, item_code: str):
 	"""
 	:param customer: link to Customer DocType
@@ -1346,7 +1346,7 @@ def get_tax_withholding_category(ctx: ItemDetailsCtx, item_doc, out: ItemDetails
 	out.tax_withholding_category = tax_withholding_category
 
 
-@erpnext.normalize_ctx_input(ItemDetailsCtx)
+@erpnext.normalize_ctx_input()
 def get_pos_profile_item_details_(ctx: ItemDetailsCtx, company, pos_profile=None, update_data=False):
 	res = frappe._dict()
 
@@ -1494,8 +1494,8 @@ def get_batch_qty(batch_no: str, warehouse: str, item_code: str):
 
 
 @frappe.whitelist()
-@erpnext.normalize_ctx_input(ItemDetailsCtx)
-def apply_price_list(ctx: ItemDetailsCtx | str, as_doc: bool = False, doc: Document | str | None = None):
+@erpnext.normalize_ctx_input()
+def apply_price_list(ctx: ItemDetailsCtx, as_doc: bool = False, doc: Document | str | None = None):
 	"""Apply pricelist on a document-like dict object and return as
 	{'parent': dict, 'children': list}
 
@@ -1667,7 +1667,7 @@ def update_party_blanket_order(ctx: ItemDetailsCtx, out: ItemDetails | dict):
 
 
 @frappe.whitelist()
-@erpnext.normalize_ctx_input(ItemDetailsCtx)
+@erpnext.normalize_ctx_input()
 def get_blanket_order_details(ctx: ItemDetailsCtx):
 	blanket_order_details = None
 


### PR DESCRIPTION
Refactored `normalize_ctx_input`.

Changes include:
- Removed the requirement of passing a type to the decorator function`normalize_ctx_input`. Instead, `ctx` will be normalized with whatever `type` is annotated with on the function definition.
- Removed the requirement of adding `ctx` as the first parameter in the function definition with `normalize_ctx_input` decorator.
- Adds `Document`, `dict`, and `str` type annotations on the `ctx` parameter, which handles `typing_validation`. 