### PR TITLE
fix: fetch accounting dimensions from child row in asset creation

### DIFF
--- a/erpnext/controllers/buying_controller.py
+++ b/erpnext/controllers/buying_controller.py
@@ -1061,7 +1061,6 @@ class BuyingController(SubcontractingController):
 				"asset_category": item_data.get("asset_category"),
 				"location": row.asset_location,
 				"company": self.company,
-				"cost_center": row.cost_center or self.cost_center or None,
 				"status": "Draft",
 				"supplier": self.supplier,
 				"purchase_date": self.posting_date,
@@ -1078,8 +1077,8 @@ class BuyingController(SubcontractingController):
 		for dimension in accounting_dimensions[0]:
 			asset.update(
 				{
-					dimension["fieldname"]: row.get(dimension["fieldname"])   
-					or self.get(dimension["fieldname"])                        
+					dimension["fieldname"]: row.get(dimension["fieldname"])
+					or self.get(dimension["fieldname"])
 					or dimension.get("default_dimension")
 				}
 			)

--- a/erpnext/controllers/buying_controller.py
+++ b/erpnext/controllers/buying_controller.py
@@ -1075,13 +1075,9 @@ class BuyingController(SubcontractingController):
 			}
 		)
 		for dimension in accounting_dimensions[0]:
-			asset.update(
-				{
-					dimension["fieldname"]: row.get(dimension["fieldname"])
-					or self.get(dimension["fieldname"])
-					or dimension.get("default_dimension")
-				}
-			)
+			fieldname = dimension["fieldname"]
+			default_dimension = accounting_dimensions[1].get(self.company, {}).get(fieldname)
+			asset.update({fieldname: row.get(fieldname) or self.get(fieldname) or default_dimension})
 
 		asset.flags.ignore_validate = True
 		asset.flags.ignore_mandatory = True

--- a/erpnext/controllers/buying_controller.py
+++ b/erpnext/controllers/buying_controller.py
@@ -1061,6 +1061,7 @@ class BuyingController(SubcontractingController):
 				"asset_category": item_data.get("asset_category"),
 				"location": row.asset_location,
 				"company": self.company,
+				"cost_center": row.cost_center or self.cost_center or None,
 				"status": "Draft",
 				"supplier": self.supplier,
 				"purchase_date": self.posting_date,
@@ -1077,7 +1078,8 @@ class BuyingController(SubcontractingController):
 		for dimension in accounting_dimensions[0]:
 			asset.update(
 				{
-					dimension["fieldname"]: self.get(dimension["fieldname"])
+					dimension["fieldname"]: row.get(dimension["fieldname"])   
+					or self.get(dimension["fieldname"])                        
 					or dimension.get("default_dimension")
 				}
 			)


### PR DESCRIPTION
### Problem

When assets are auto-created via Purchase Receipt or Purchase Invoice,
accounting dimension values (e.g., Cost Center) set at the **line item level**
were not being applied to the created Asset records.

The system was only reading dimension values from the **parent document**,
causing row-level overrides to be silently ignored.

Fixes #53445

---

### Root Cause

In `buying_controller.py`, the `auto_make_assets()` function fetched
accounting dimension values only from the parent document (`self`):
```python
# Before
for dimension in accounting_dimensions[0]:
    asset.update({
        dimension["fieldname"]: self.get(dimension["fieldname"])
        or dimension.get("default_dimension")
    })
```

---

### Solution

Updated the lookup order to: **row value → parent value → default dimension**
```python
# After
for dimension in accounting_dimensions[0]:
    asset.update({
        dimension["fieldname"]: row.get(dimension["fieldname"])
        or self.get(dimension["fieldname"])
        or dimension.get("default_dimension")
    })
```


https://github.com/user-attachments/assets/0940e371-541d-4d03-94ed-37f231de235c




