### PR TITLE
fix: make Source Warehouse non-mandatory in Sales Order items #53439

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -450,9 +450,11 @@ class SalesOrder(SellingController):
 				and not d.warehouse
 				and not cint(d.delivered_by_supplier)
 			):
-				frappe.throw(
-					_("Delivery warehouse required for stock item {0}").format(d.item_code), WarehouseRequired
-				)
+				frappe.msgprint(
+                                        _("Delivery warehouse not set for stock item {0}").format(d.item_code),
+                                        indicator="orange",
+                                        alert=True,
+                                )
 
 	def validate_with_previous_doc(self):
 		super().validate_with_previous_doc(


### PR DESCRIPTION
## Problem
In Sales Order line items, the Source Warehouse field was enforced as
mandatory via a hard `frappe.throw()` in `validate_warehouse()`. This
blocks saving orders where warehouse selection is intentionally deferred
(e.g. service items, drop-ship, or warehouse assigned later at delivery).

Fixes #53439

## Solution
Replaced `frappe.throw` with `frappe.msgprint` (orange alert warning)
so the user is informed but not blocked from saving the Sales Order.

## Changes
- `erpnext/selling/doctype/sales_order/sales_order.py`
  - `validate_warehouse()`: changed hard error to soft warning
