### PR TITLE
Fix cost center number #53451

### DIFF
--- a/erpnext/accounts/doctype/cost_center/cost_center.js
+++ b/erpnext/accounts/doctype/cost_center/cost_center.js
@@ -48,65 +48,66 @@ frappe.ui.form.on("Cost Center", {
 		}
 	},
 	update_cost_center_number: function (frm) {
-		var d = new frappe.ui.Dialog({
-			title: __("Update Cost Center Name / Number"),
-			fields: [
-				{
-					label: "Cost Center Name",
-					fieldname: "cost_center_name",
-					fieldtype: "Data",
-					reqd: 1,
-					default: frm.doc.cost_center_name,
-				},
-				{
-					label: "Cost Center Number",
-					fieldname: "cost_center_number",
-					fieldtype: "Data",
-					default: frm.doc.cost_center_number,
-				},
-				{
-					label: __("Merge with existing"),
-					fieldname: "merge",
-					fieldtype: "Check",
-					default: 0,
-				},
-			],
-			primary_action: function () {
-				let data = d.get_values();
-				if (
-					data.cost_center_name === frm.doc.cost_center_name &&
-					data.cost_center_number === frm.doc.cost_center_number
-				) {
-					d.hide();
-					return;
-				}
-				frappe.dom.freeze();
-				frappe.call({
-					method: "erpnext.accounts.utils.update_cost_center",
-					args: {
-						docname: frm.doc.name,
-						cost_center_name: data.cost_center_name,
-						cost_center_number: cstr(data.cost_center_number),
-						company: frm.doc.company,
-						merge: data.merge,
+		frappe.db.get_value("Cost Center", frm.doc.name, ["cost_center_name", "cost_center_number"], (r) => {
+			var d = new frappe.ui.Dialog({
+				title: __("Update Cost Center Name / Number"),
+				fields: [
+					{
+						label: "Cost Center Name",
+						fieldname: "cost_center_name",
+						fieldtype: "Data",
+						reqd: 1,
+						default: r.cost_center_name,
 					},
-					callback: function (r) {
-						frappe.dom.unfreeze();
-						if (!r.exc) {
-							if (r.message) {
-								frappe.set_route("Form", "Cost Center", r.message);
-							} else {
-								frm.set_value("cost_center_name", data.cost_center_name);
-								frm.set_value("cost_center_number", data.cost_center_number);
+					{
+						label: "Cost Center Number",
+						fieldname: "cost_center_number",
+						fieldtype: "Data",
+						default: r.cost_center_number,
+					},
+					{
+						label: __("Merge with existing"),
+						fieldname: "merge",
+						fieldtype: "Check",
+						default: 0,
+					},
+				],
+				primary_action: function () {
+					let data = d.get_values();
+					if (
+						data.cost_center_name === r.cost_center_name &&
+						data.cost_center_number === r.cost_center_number
+					) {
+						d.hide();
+						return;
+					}
+					frappe.dom.freeze();
+					frappe.call({
+						method: "erpnext.accounts.utils.update_cost_center",
+						args: {
+							docname: frm.doc.name,
+							cost_center_name: data.cost_center_name,
+							cost_center_number: cstr(data.cost_center_number),
+							company: frm.doc.company,
+							merge: data.merge,
+						},
+						callback: function (r) {
+							frappe.dom.unfreeze();
+							if (!r.exc) {
+								if (r.message) {
+									frappe.set_route("Form", "Cost Center", r.message);
+								} else {
+									frm.reload_doc();
+								}
+								d.hide();
 							}
-							d.hide();
-						}
-					},
-				});
-			},
-			primary_action_label: __("Update"),
+						},
+					});
+				},
+				primary_action_label: __("Update"),
+			});
+			d.show();
 		});
-		d.show();
 	},
 
 	parent_cost_center(frm) {

--- a/erpnext/accounts/doctype/cost_center/cost_center.py
+++ b/erpnext/accounts/doctype/cost_center/cost_center.py
@@ -101,10 +101,15 @@ class CostCenter(NestedSet):
 		)
 
 	def before_rename(self, olddn, newdn, merge=False):
+		"""
+		Validate and prepare the new Cost Center name before renaming.
+
+		Ensures the company abbreviation is appended and the cost center
+		number prefix is not duplicated if already present in the new name.
+		"""
 		from erpnext.setup.doctype.company.company import get_name_with_abbr
 
 		new_cost_center = get_name_with_abbr(newdn, self.company)
-
 		super().before_rename(olddn, new_cost_center, merge, "is_group")
 
 		if not merge:
@@ -114,6 +119,12 @@ class CostCenter(NestedSet):
 		return new_cost_center
 
 	def after_rename(self, olddn, newdn, merge=False):
+		"""
+		Update cost_center_name and cost_center_number fields after renaming.
+
+		Skips field updates if called from update_cost_center, since that
+		function already sets the correct values before calling rename_doc.
+		"""
 		super().after_rename(olddn, newdn, merge)
 
 		if frappe.flags.get("update_cost_center_in_progress"):
@@ -139,7 +150,6 @@ class CostCenter(NestedSet):
 			if new_cost_center.cost_center_name != cost_center_name:
 				self.cost_center_name = cost_center_name
 				self.db_set("cost_center_name", cost_center_name)
-
 
 def on_doctype_update():
 	frappe.db.add_index("Cost Center", ["lft", "rgt"])

--- a/erpnext/accounts/doctype/cost_center/cost_center.py
+++ b/erpnext/accounts/doctype/cost_center/cost_center.py
@@ -100,16 +100,29 @@ class CostCenter(NestedSet):
 			"Cost Center Allocation Percentage", filters={"cost_center": self.name, "docstatus": 1}
 		)
 
+	# def before_rename(self, olddn, newdn, merge=False):
+	# 	# Add company abbr if not provided
+	# 	from erpnext.setup.doctype.company.company import get_name_with_abbr
+
+	# 	new_cost_center = get_name_with_abbr(newdn, self.company)
+
+	# 	# Validate properties before merging
+	# 	super().before_rename(olddn, new_cost_center, merge, "is_group")
+	# 	if not merge:
+	# 		new_cost_center = get_name_with_number(new_cost_center, self.cost_center_number)
+
+	# 	return new_cost_center
 	def before_rename(self, olddn, newdn, merge=False):
-		# Add company abbr if not provided
 		from erpnext.setup.doctype.company.company import get_name_with_abbr
 
 		new_cost_center = get_name_with_abbr(newdn, self.company)
 
-		# Validate properties before merging
 		super().before_rename(olddn, new_cost_center, merge, "is_group")
+
 		if not merge:
-			new_cost_center = get_name_with_number(new_cost_center, self.cost_center_number)
+        	# Only add number prefix if not already present
+			if self.cost_center_number and not new_cost_center.startswith(self.cost_center_number + " - "):
+				new_cost_center = get_name_with_number(new_cost_center, self.cost_center_number)
 
 		return new_cost_center
 

--- a/erpnext/accounts/doctype/cost_center/cost_center.py
+++ b/erpnext/accounts/doctype/cost_center/cost_center.py
@@ -100,18 +100,6 @@ class CostCenter(NestedSet):
 			"Cost Center Allocation Percentage", filters={"cost_center": self.name, "docstatus": 1}
 		)
 
-	# def before_rename(self, olddn, newdn, merge=False):
-	# 	# Add company abbr if not provided
-	# 	from erpnext.setup.doctype.company.company import get_name_with_abbr
-
-	# 	new_cost_center = get_name_with_abbr(newdn, self.company)
-
-	# 	# Validate properties before merging
-	# 	super().before_rename(olddn, new_cost_center, merge, "is_group")
-	# 	if not merge:
-	# 		new_cost_center = get_name_with_number(new_cost_center, self.cost_center_number)
-
-	# 	return new_cost_center
 	def before_rename(self, olddn, newdn, merge=False):
 		from erpnext.setup.doctype.company.company import get_name_with_abbr
 
@@ -120,7 +108,6 @@ class CostCenter(NestedSet):
 		super().before_rename(olddn, new_cost_center, merge, "is_group")
 
 		if not merge:
-        	# Only add number prefix if not already present
 			if self.cost_center_number and not new_cost_center.startswith(self.cost_center_number + " - "):
 				new_cost_center = get_name_with_number(new_cost_center, self.cost_center_number)
 
@@ -129,14 +116,14 @@ class CostCenter(NestedSet):
 	def after_rename(self, olddn, newdn, merge=False):
 		super().after_rename(olddn, newdn, merge)
 
+		if frappe.flags.get("update_cost_center_in_progress"):
+			return
+
 		if not merge:
 			new_cost_center = frappe.db.get_value(
 				"Cost Center", newdn, ["cost_center_name", "cost_center_number"], as_dict=1
 			)
-
-			# exclude company abbr
 			new_parts = newdn.split(" - ")[:-1]
-			# update cost center number and remove from parts
 			if new_parts[0][0].isdigit():
 				if len(new_parts) == 1:
 					new_parts = newdn.split(" ")
@@ -148,7 +135,6 @@ class CostCenter(NestedSet):
 					self.db_set("cost_center_number", new_parts[0])
 				new_parts = new_parts[1:]
 
-			# update cost center name
 			cost_center_name = " - ".join(new_parts)
 			if new_cost_center.cost_center_name != cost_center_name:
 				self.cost_center_name = cost_center_name

--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -1547,6 +1547,19 @@ def create_payment_gateway_account(gateway, payment_channel="Email", company=Non
 def update_cost_center(
 	docname: str, cost_center_name: str, cost_center_number: str, company: str, merge: bool
 ):
+	"""
+	Update the Cost Center name and/or number.
+
+	Renames the Cost Center document by building a new name from the given
+	number prefix and bare name, updates the cost_center_name and
+	cost_center_number fields, and renames all linked transactions.
+
+	:param docname: Current name of the Cost Center document
+	:param cost_center_name: Bare name of the cost center (without number prefix or company suffix)
+	:param cost_center_number: New number/code prefix for the cost center
+	:param company: Company the cost center belongs to
+	:param merge: Whether to merge with an existing cost center of the same name
+	"""
 	validate_field_number("Cost Center", docname, cost_center_number, company, "cost_center_number")
 
 	bare_name = cost_center_name.strip()
@@ -1560,9 +1573,11 @@ def update_cost_center(
 
 	new_name = get_autoname_with_number(cost_center_number, bare_name, company)
 	if docname != new_name:
-		frappe.flags.update_cost_center_in_progress = True
-		frappe.rename_doc("Cost Center", docname, new_name, force=1, merge=merge)
-		frappe.flags.update_cost_center_in_progress = False
+		try:
+			frappe.flags.update_cost_center_in_progress = True
+			frappe.rename_doc("Cost Center", docname, new_name, force=1, merge=merge)
+		finally:
+			frappe.flags.update_cost_center_in_progress = False
 		return new_name
 
 def validate_field_number(doctype_name, docname, number_value, company, field_name):

--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -1547,19 +1547,9 @@ def create_payment_gateway_account(gateway, payment_channel="Email", company=Non
 def update_cost_center(
 	docname: str, cost_center_name: str, cost_center_number: str, company: str, merge: bool
 ):
-	import re
 	validate_field_number("Cost Center", docname, cost_center_number, company, "cost_center_number")
 
 	bare_name = cost_center_name.strip()
-
-	# Strip company abbreviation suffix if present
-	company_abbr = frappe.get_cached_value("Company", company, "abbr")
-	if bare_name.endswith(" - " + company_abbr):
-		bare_name = bare_name[: -(len(company_abbr) + 3)].strip()
-
-	# Strip all leading code prefixes (e.g. "T009 - T009 - ")
-	while re.match(r"^[A-Z0-9]+ - ", bare_name):
-		bare_name = bare_name.split(" - ", 1)[1].strip()
 
 	if cost_center_number:
 		frappe.db.set_value("Cost Center", docname, "cost_center_number", cost_center_number.strip())
@@ -1570,7 +1560,9 @@ def update_cost_center(
 
 	new_name = get_autoname_with_number(cost_center_number, bare_name, company)
 	if docname != new_name:
+		frappe.flags.update_cost_center_in_progress = True
 		frappe.rename_doc("Cost Center", docname, new_name, force=1, merge=merge)
+		frappe.flags.update_cost_center_in_progress = False
 		return new_name
 
 def validate_field_number(doctype_name, docname, number_value, company, field_name):

--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -1543,29 +1543,35 @@ def create_payment_gateway_account(gateway, payment_channel="Email", company=Non
 		# already exists, due to a reinstall?
 		pass
 
-
 @frappe.whitelist()
 def update_cost_center(
 	docname: str, cost_center_name: str, cost_center_number: str, company: str, merge: bool
 ):
-	"""
-	Renames the document by adding the number as a prefix to the current name and updates
-	all transaction where it was present.
-	"""
+	import re
 	validate_field_number("Cost Center", docname, cost_center_number, company, "cost_center_number")
+
+	bare_name = cost_center_name.strip()
+
+	# Strip company abbreviation suffix if present
+	company_abbr = frappe.get_cached_value("Company", company, "abbr")
+	if bare_name.endswith(" - " + company_abbr):
+		bare_name = bare_name[: -(len(company_abbr) + 3)].strip()
+
+	# Strip all leading code prefixes (e.g. "T009 - T009 - ")
+	while re.match(r"^[A-Z0-9]+ - ", bare_name):
+		bare_name = bare_name.split(" - ", 1)[1].strip()
 
 	if cost_center_number:
 		frappe.db.set_value("Cost Center", docname, "cost_center_number", cost_center_number.strip())
 	else:
 		frappe.db.set_value("Cost Center", docname, "cost_center_number", "")
 
-	frappe.db.set_value("Cost Center", docname, "cost_center_name", cost_center_name.strip())
+	frappe.db.set_value("Cost Center", docname, "cost_center_name", bare_name)
 
-	new_name = get_autoname_with_number(cost_center_number, cost_center_name, company)
+	new_name = get_autoname_with_number(cost_center_number, bare_name, company)
 	if docname != new_name:
 		frappe.rename_doc("Cost Center", docname, new_name, force=1, merge=merge)
 		return new_name
-
 
 def validate_field_number(doctype_name, docname, number_value, company, field_name):
 	"""Validate if the number entered isn't already assigned to some other document."""


### PR DESCRIPTION
<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/erpnext/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:
## Problem

When updating the Cost Center Number using the "Update Cost Center Name / Number" 
dialog, the number was being prepended twice, resulting in names like:

`T001 - T001 - Sample - TT` instead of `T001 - Sample - TT`

This happened on every subsequent update, causing further duplication:
`T002 - T002 - T001 - T001 - Sample - TT`

## Root Cause

Three issues were found:

1. **`cost_center.py` `before_rename`** — `get_name_with_number` was prepending 
   the number prefix even when it was already present in the new name, causing 
   double prefixing.

2. **`cost_center.py` `after_rename`** — After rename, it was re-parsing the 
   document name to extract `cost_center_name` and overwriting the correct bare 
   name already saved by `update_cost_center`.

3. **`cost_center.js`** — The dialog was using `frm.doc.cost_center_name` which 
   holds the stale full document name (e.g. `T001 - Sample`) instead of the bare 
   name stored in the database field (e.g. `Sample`).

## Fix

- **`cost_center.js`**: Fetch `cost_center_name` and `cost_center_number` fresh 
  from the database using `frappe.db.get_value` before showing the dialog, 
  ensuring the bare name is always displayed and sent to the backend.

- **`cost_center.py` `before_rename`**: Added a check to skip adding the number 
  prefix if it is already present in the new name.

- **`cost_center.py` `after_rename`**: Added a flag check 
  `frappe.flags.update_cost_center_in_progress` to skip overwriting 
  `cost_center_name` when called from `update_cost_center`, since it already 
  saves the correct bare name before renaming.

- **`accounts/utils.py` `update_cost_center`**: Sets 
  `frappe.flags.update_cost_center_in_progress = True` around `rename_doc` call 
  and saves the bare `cost_center_name` to DB before renaming.

## Behavior After Fix

| Action | Result |
|--------|--------|
| Create | `Sample - TT` |
| Add number T001 | `T001 - Sample - TT` |
| Change to T002 | `T002 - Sample - TT` |
| Change to T003 | `T003 - Sample - TT` |

## Files Changed

- `erpnext/accounts/utils.py`
- `erpnext/accounts/doctype/cost_center/cost_center.py`
- `erpnext/accounts/doctype/cost_center/cost_center.js`

https://github.com/user-attachments/assets/7d86aab8-5f46-4486-969c-2ea552c00a29


<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->
