### PR TITLE
fix(project): add asset capitalization cost to project

### DIFF
--- a/erpnext/projects/doctype/project/project.json
+++ b/erpnext/projects/doctype/project/project.json
@@ -37,6 +37,7 @@
   "total_billable_amount",
   "total_billed_amount",
   "total_consumed_material_cost",
+  "total_asset_capitalization_amount",
   "cost_center",
   "margin",
   "gross_margin",
@@ -327,6 +328,12 @@
    "read_only": 1
   },
   {
+   "fieldname": "total_asset_capitalization_amount",
+   "fieldtype": "Currency",
+   "label": "Total Asset Capitalization Cost (via Asset Capitalization)",
+   "read_only": 1
+  },
+  {
    "fieldname": "cost_center",
    "fieldtype": "Link",
    "label": "Default Cost Center",
@@ -480,7 +487,7 @@
  "index_web_pages_for_search": 1,
  "links": [],
  "max_attachments": 4,
- "modified": "2026-03-09 17:15:24.426294",
+ "modified": "2026-03-04 11:09:55.253367",
  "modified_by": "Administrator",
  "module": "Projects",
  "name": "Project",

--- a/erpnext/projects/doctype/project/project.py
+++ b/erpnext/projects/doctype/project/project.py
@@ -71,6 +71,7 @@ class Project(Document):
 		total_costing_amount: DF.Currency
 		total_purchase_cost: DF.Currency
 		total_sales_amount: DF.Currency
+		total_asset_capitalization_amount: DF.Currency
 		users: DF.Table[ProjectUser]
 		weekly_time_to_send: DF.Time | None
 	# end: auto-generated types
@@ -294,6 +295,7 @@ class Project(Document):
 		self.total_billable_amount = from_time_sheet.base_billing_amount
 		self.actual_time = from_time_sheet.time
 
+		self.update_asset_capitalization_costing()
 		self.update_purchase_costing()
 		self.update_sales_amount()
 		self.update_billed_amount()
@@ -303,6 +305,7 @@ class Project(Document):
 		expense_amount = (
 			flt(self.total_costing_amount)
 			+ flt(self.total_purchase_cost)
+			+ flt(self.total_asset_capitalization_amount)
 			+ flt(self.get("total_consumed_material_cost", 0))
 		)
 
@@ -315,6 +318,17 @@ class Project(Document):
 	def update_purchase_costing(self):
 		total_purchase_cost = calculate_total_purchase_cost(self.name)
 		self.total_purchase_cost = total_purchase_cost and total_purchase_cost[0][0] or 0
+
+	def update_asset_capitalization_costing(self):
+		total_asset_capitalization_amount = frappe.db.sql(
+			"""select sum(total_value)
+			from `tabAsset Capitalization` where project = %s and docstatus=1""",
+			self.name,
+		)
+
+		self.total_asset_capitalization_amount = (
+			total_asset_capitalization_amount and total_asset_capitalization_amount[0][0] or 0
+		)
 
 	def update_sales_amount(self):
 		total_sales_amount = frappe.db.sql(


### PR DESCRIPTION
Asset capitalization entries have a project link, but they are not taken into account for a project costing.

This commit adds a field to the project doctype to sum up all the asset capitalization entries linked to the project.

<img width="917" height="407" alt="image" src="https://github.com/user-attachments/assets/85c5fc4e-a370-463f-83b9-5ac681720608" />
