### PR TITLE
fix: correct overlap detection in JobCard.has_overlap

### DIFF
--- a/erpnext/manufacturing/doctype/job_card/job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/job_card.py
@@ -402,8 +402,6 @@ class JobCard(Document):
 		# if key number reaches/crosses to production_capacity means capacity is full and overlap error generated
 		# this will store last to_time of sequential job cards
 		alloted_capacity = {1: time_logs[0]["to_time"]}
-		# flag for sequential Job card found
-		sequential_job_card_found = False
 		for i in range(1, len(time_logs)):
 			sequential_job_card_found = False
 			# scanning for all Existing keys

--- a/erpnext/manufacturing/doctype/job_card/job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/job_card.py
@@ -405,6 +405,7 @@ class JobCard(Document):
 		# flag for sequential Job card found
 		sequential_job_card_found = False
 		for i in range(1, len(time_logs)):
+			sequential_job_card_found = False
 			# scanning for all Existing keys
 			for key in alloted_capacity.keys():
 				# if current Job Card from time is greater than last to_time in that key means these job card are sequential


### PR DESCRIPTION
## Problem

In `JobCard.has_overlap()`, the variable `sequential_job_card_found` is not reset
inside the outer loop that iterates through time logs.

Once it becomes `True` for a previous iteration, it remains `True` for subsequent
iterations. This causes overlapping jobs to be incorrectly treated as sequential,
resulting in incorrect workstation capacity validation.

---

## Root Cause

`sequential_job_card_found` is initialized before the loop but never reset
during each iteration.

```python
sequential_job_card_found = False
for i in range(1, len(time_logs)):
```

Because of this, once a sequential job match is found, the flag remains `True`
for later iterations, preventing the capacity counter from incrementing even
when jobs actually overlap.

---

## Fix

Reset `sequential_job_card_found` at the beginning of each iteration of the
outer loop.

```diff
sequential_job_card_found = False
for i in range(1, len(time_logs)):
+    sequential_job_card_found = False
     for key in alloted_capacity.keys():
```

---

## Impact

Without this fix, overlapping Job Cards may bypass workstation capacity
validation, allowing more jobs to run concurrently than the workstation
capacity allows.

This fix ensures correct overlap detection and proper enforcement of
workstation capacity limits.