### PR TITLE
fix(minor): filter bank accounts in bank statement import

### DIFF
--- a/erpnext/accounts/doctype/bank_statement_import/bank_statement_import.js
+++ b/erpnext/accounts/doctype/bank_statement_import/bank_statement_import.js
@@ -2,6 +2,15 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on("Bank Statement Import", {
+	onload(frm) {
+		frm.set_query("bank_account", function (doc) {
+			return {
+				filters: {
+					company: doc.company,
+				},
+			};
+		});
+	},
 	setup(frm) {
 		frappe.realtime.on("data_import_refresh", ({ data_import }) => {
 			frm.import_in_progress = false;


### PR DESCRIPTION
**Ref:** [60917](https://support.frappe.io/helpdesk/tickets/60917)

**Issue**
In the Bank Statement Import DocType, the Bank Account link field does not filter records based on the selected Company.

**Fix**
Added a set_query to the Bank Account field to filter accounts based on the selected Company.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Bank Statement Import form now automatically pre-filters bank account options based on the current company, streamlining the selection process when loading the form.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->