### PR TITLE
fix: enable toolbar in settings doctypes to show comments and timeline

### DIFF
--- a/erpnext/accounts/doctype/currency_exchange_settings/currency_exchange_settings.json
+++ b/erpnext/accounts/doctype/currency_exchange_settings/currency_exchange_settings.json
@@ -101,7 +101,6 @@
    "label": "Use HTTP Protocol"
   }
  ],
- "hide_toolbar": 1,
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],

--- a/erpnext/accounts/doctype/pos_settings/pos_settings.json
+++ b/erpnext/accounts/doctype/pos_settings/pos_settings.json
@@ -50,7 +50,6 @@
    "options": "1"
   }
  ],
- "hide_toolbar": 1,
  "issingle": 1,
  "links": [],
  "modified": "2026-01-09 17:30:41.476806",

--- a/erpnext/accounts/doctype/repost_accounting_ledger_settings/repost_accounting_ledger_settings.json
+++ b/erpnext/accounts/doctype/repost_accounting_ledger_settings/repost_accounting_ledger_settings.json
@@ -15,7 +15,6 @@
   }
  ],
  "grid_page_length": 50,
- "hide_toolbar": 1,
  "in_create": 1,
  "issingle": 1,
  "links": [],

--- a/erpnext/accounts/doctype/subscription_settings/subscription_settings.json
+++ b/erpnext/accounts/doctype/subscription_settings/subscription_settings.json
@@ -31,7 +31,6 @@
   }
  ],
  "grid_page_length": 50,
- "hide_toolbar": 1,
  "issingle": 1,
  "links": [],
  "modified": "2026-01-02 18:18:34.671062",

--- a/erpnext/buying/doctype/buying_settings/buying_settings.json
+++ b/erpnext/buying/doctype/buying_settings/buying_settings.json
@@ -282,7 +282,6 @@
   }
  ],
  "grid_page_length": 50,
- "hide_toolbar": 1,
  "icon": "fa fa-cog",
  "idx": 1,
  "index_web_pages_for_search": 1,

--- a/erpnext/crm/doctype/appointment_booking_settings/appointment_booking_settings.json
+++ b/erpnext/crm/doctype/appointment_booking_settings/appointment_booking_settings.json
@@ -102,7 +102,6 @@
   }
  ],
  "grid_page_length": 50,
- "hide_toolbar": 1,
  "issingle": 1,
  "links": [],
  "modified": "2026-01-02 18:18:46.617101",

--- a/erpnext/crm/doctype/crm_settings/crm_settings.json
+++ b/erpnext/crm/doctype/crm_settings/crm_settings.json
@@ -101,7 +101,6 @@
   }
  ],
  "grid_page_length": 50,
- "hide_toolbar": 1,
  "icon": "fa fa-cog",
  "index_web_pages_for_search": 1,
  "issingle": 1,

--- a/erpnext/manufacturing/doctype/manufacturing_settings/manufacturing_settings.json
+++ b/erpnext/manufacturing/doctype/manufacturing_settings/manufacturing_settings.json
@@ -239,7 +239,6 @@
    "label": "Set Operating Cost / Secondary Items From Sub-assemblies"
   }
  ],
- "hide_toolbar": 1,
  "icon": "icon-wrench",
  "index_web_pages_for_search": 1,
  "issingle": 1,

--- a/erpnext/projects/doctype/projects_settings/projects_settings.json
+++ b/erpnext/projects/doctype/projects_settings/projects_settings.json
@@ -43,7 +43,6 @@
    "label": "Fetch Timesheet in Sales Invoice"
   }
  ],
- "hide_toolbar": 1,
  "issingle": 1,
  "links": [],
  "modified": "2026-01-02 18:18:28.414222",

--- a/erpnext/selling/doctype/selling_settings/selling_settings.json
+++ b/erpnext/selling/doctype/selling_settings/selling_settings.json
@@ -323,7 +323,6 @@
   }
  ],
  "grid_page_length": 50,
- "hide_toolbar": 1,
  "icon": "fa fa-cog",
  "idx": 1,
  "index_web_pages_for_search": 1,

--- a/erpnext/setup/doctype/global_defaults/global_defaults.json
+++ b/erpnext/setup/doctype/global_defaults/global_defaults.json
@@ -91,7 +91,6 @@
   }
  ],
  "grid_page_length": 50,
- "hide_toolbar": 1,
  "icon": "fa fa-cog",
  "idx": 1,
  "in_create": 1,

--- a/erpnext/stock/doctype/delivery_settings/delivery_settings.json
+++ b/erpnext/stock/doctype/delivery_settings/delivery_settings.json
@@ -50,7 +50,6 @@
   }
  ],
  "grid_page_length": 50,
- "hide_toolbar": 1,
  "issingle": 1,
  "links": [],
  "modified": "2026-01-02 18:18:39.931428",

--- a/erpnext/stock/doctype/item_variant_settings/item_variant_settings.json
+++ b/erpnext/stock/doctype/item_variant_settings/item_variant_settings.json
@@ -49,7 +49,6 @@
    "label": "Allow Variant UOM to be different from Template UOM"
   }
  ],
- "hide_toolbar": 1,
  "issingle": 1,
  "links": [],
  "modified": "2026-01-02 18:18:23.005859",

--- a/erpnext/stock/doctype/stock_reposting_settings/stock_reposting_settings.json
+++ b/erpnext/stock/doctype/stock_reposting_settings/stock_reposting_settings.json
@@ -101,7 +101,6 @@
    "label": "Enable Separate Reposting for GL"
   }
  ],
- "hide_toolbar": 1,
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],

--- a/erpnext/stock/doctype/stock_settings/stock_settings.json
+++ b/erpnext/stock/doctype/stock_settings/stock_settings.json
@@ -558,7 +558,6 @@
    "label": "Enable Serial / Batch No for Item"
   }
  ],
- "hide_toolbar": 1,
  "icon": "icon-cog",
  "idx": 1,
  "index_web_pages_for_search": 1,

--- a/erpnext/support/doctype/support_settings/support_settings.json
+++ b/erpnext/support/doctype/support_settings/support_settings.json
@@ -154,7 +154,6 @@
   }
  ],
  "grid_page_length": 50,
- "hide_toolbar": 1,
  "issingle": 1,
  "links": [],
  "modified": "2026-01-02 18:18:11.475222",


### PR DESCRIPTION
Issue: frappe/frappe#38153
Removed "hide_toolbar": 1 from settings doctypes to restore the toolbar. 
This enables comments and activity timeline to appear again in settings forms.

Before:
Toolbar was hidden due to "hide_toolbar": 1, so comments and activity timeline were not visible.
<img width="1061" height="662" alt="Screenshot from 2026-03-16 13-55-36" src="https://github.com/user-attachments/assets/60b41db2-ea3b-4e8a-bb56-f63b78821afa" />

After:
Toolbar is visible and comments/activity timeline appear correctly.
<img width="1061" height="662" alt="Screenshot from 2026-03-16 13-54-04" src="https://github.com/user-attachments/assets/92e961b1-618e-4908-9d96-a00b831a5fa9" />