### PR TITLE
fix: check for return invoices

### DIFF
--- a/erpnext/accounts/doctype/payment_request/payment_request.py
+++ b/erpnext/accounts/doctype/payment_request/payment_request.py
@@ -3,6 +3,7 @@ import json
 import frappe
 from frappe import _
 from frappe.model.document import Document
+from frappe.query_builder import Criterion
 from frappe.query_builder.functions import Sum
 from frappe.utils import flt, nowdate
 from frappe.utils.background_jobs import enqueue
@@ -1163,10 +1164,10 @@ def get_available_payment_schedules(reference_doctype: str, reference_name: str)
 
 	if get_existing_payment_entry(reference_name):
 		return []
-
+	if get_return_invoices(reference_doctype, reference_name):
+		return []
 	existing_refs = get_existing_payment_references(reference_name)
 	existing_ids = {r["payment_schedule"] for r in existing_refs if r.get("payment_schedule")}
-
 	return [r for r in ref_doc.payment_schedule if r.name not in existing_ids]
 
 
@@ -1193,3 +1194,20 @@ def get_existing_payment_references(reference_name):
 	).run(as_dict=True)
 
 	return result
+
+
+def get_return_invoices(reference_doctype, reference_name):
+	if reference_doctype not in ("Sales Invoice", "Purchase Invoice"):
+		return False
+
+	doc = frappe.qb.DocType(reference_doctype)
+
+	return_invoices = (
+		frappe.qb.from_(doc)
+		.select(doc.name)
+		.where(doc.docstatus == 1)
+		.where(doc.is_return == 1)
+		.where(doc.return_against == reference_name)
+	).run()
+
+	return bool(return_invoices)

--- a/erpnext/accounts/doctype/payment_request/test_payment_request.py
+++ b/erpnext/accounts/doctype/payment_request/test_payment_request.py
@@ -10,7 +10,10 @@ from frappe.utils import add_days, nowdate
 
 from erpnext.accounts.doctype.payment_entry.payment_entry import get_payment_entry
 from erpnext.accounts.doctype.payment_entry.test_payment_entry import create_payment_terms_template
-from erpnext.accounts.doctype.payment_request.payment_request import make_payment_request
+from erpnext.accounts.doctype.payment_request.payment_request import (
+	get_return_invoices,
+	make_payment_request,
+)
 from erpnext.accounts.doctype.purchase_invoice.test_purchase_invoice import make_purchase_invoice
 from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_sales_invoice
 from erpnext.buying.doctype.purchase_order.test_purchase_order import create_purchase_order
@@ -974,3 +977,27 @@ class TestPaymentRequest(ERPNextTestSuite):
 				return_doc=True,
 				schedules=schedules,
 			)
+
+	def test_get_return_invoices_blocks_schedule_for_purchase_return(self):
+		pi = make_purchase_invoice(currency="INR", qty=1, rate=1400)
+		pi.submit()
+
+		self.assertFalse(get_return_invoices("Purchase Invoice", pi.name))
+
+		pi_return = make_purchase_invoice(
+			currency="INR", qty=-1, rate=700, is_return=1, return_against=pi.name
+		)
+		pi_return.submit()
+
+		self.assertTrue(get_return_invoices("Purchase Invoice", pi.name))
+
+		pi.load_from_db()
+		self.assertEqual(pi.outstanding_amount, 700)
+
+		pr = make_payment_request(
+			dt="Purchase Invoice",
+			dn=pi.name,
+			mute_email=1,
+			return_doc=1,
+		)
+		self.assertEqual(pr.grand_total, 700)

--- a/erpnext/accounts/doctype/payment_request/test_payment_request.py
+++ b/erpnext/accounts/doctype/payment_request/test_payment_request.py
@@ -985,8 +985,10 @@ class TestPaymentRequest(ERPNextTestSuite):
 		self.assertFalse(get_return_invoices("Purchase Invoice", pi.name))
 
 		pi_return = make_purchase_invoice(
-			currency="INR", qty=-1, rate=700, is_return=1, return_against=pi.name
+			currency="INR", qty=-1, rate=700, is_return=1, return_against=pi.name, do_not_save=1
 		)
+		pi_return.update_outstanding_for_self = 0
+		pi_return.save()
 		pi_return.submit()
 
 		self.assertTrue(get_return_invoices("Purchase Invoice", pi.name))


### PR DESCRIPTION
**Issue:**
The system is not considering the Return Transaction while making the Payment Request based on the Purchase Invoice.

The user made a Purchase Invoice for 1400. Here the Outstanding amount is 1400 which is correct.

Then the user made a purchase return for 700 and submitted the Return entry now the system shows the outstanding in the Purchase Invoice as 700 which is also correct.

Now the user is trying to make the Payment Request from the actual Purchase Invoice then the system is creating a Payment Request for 1400/- which is not correct as the system should consider the Actual Outstanding amount that need to be paid.

**Ref:**[#62602](https://support.frappe.io/helpdesk/tickets/62602)
