### PR TITLE
fix(support-settings): disable the auto-close tickets feature if `close_issue_after_days` is set to 0

### DIFF
--- a/erpnext/support/doctype/issue/issue.py
+++ b/erpnext/support/doctype/issue/issue.py
@@ -227,8 +227,14 @@ def set_status(name: str, status: str):
 
 
 def auto_close_tickets():
-	"""Auto-close replied support tickets after 7 days"""
-	auto_close_after_days = frappe.db.get_single_value("Support Settings", "close_issue_after_days") or 7
+	"""
+	Auto-close replied support tickets as defined on `close_issue_after_days` in Support Settings.
+	Disables the feature if `close_issue_after_days` is set to 0.
+	"""
+	auto_close_after_days = frappe.db.get_single_value("Support Settings", "close_issue_after_days")
+
+	if not auto_close_after_days:
+		return
 
 	table = frappe.qb.DocType("Issue")
 	issues = (

--- a/erpnext/support/doctype/support_settings/support_settings.json
+++ b/erpnext/support/doctype/support_settings/support_settings.json
@@ -37,9 +37,11 @@
   },
   {
    "default": "7",
+   "description": "Set this value to 0 to disable the feature.",
    "fieldname": "close_issue_after_days",
    "fieldtype": "Int",
-   "label": "Close Issue After Days"
+   "label": "Close Issue After Days",
+   "non_negative": 1
   },
   {
    "fieldname": "portal_sb",
@@ -157,7 +159,7 @@
  "hide_toolbar": 1,
  "issingle": 1,
  "links": [],
- "modified": "2026-01-02 18:18:11.475222",
+ "modified": "2026-03-16 16:33:45.859541",
  "modified_by": "Administrator",
  "module": "Support",
  "name": "Support Settings",


### PR DESCRIPTION
Changes include:
- Disable the auto-close tickets feature if `close_issue_after_days` is set to 0 on Support Settings.