### PR TITLE
fix: change "Date" label to "Posting Date" in Sales Invoice and Purchase Invoice

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
@@ -321,7 +321,7 @@
    "fieldtype": "Date",
    "in_list_view": 1,
    "in_standard_filter": 1,
-   "label": "Date",
+   "label": "Posting Date",
    "oldfieldname": "posting_date",
    "oldfieldtype": "Date",
    "print_hide": 1,

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.json
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.json
@@ -383,7 +383,7 @@
    "hide_seconds": 1,
    "in_list_view": 1,
    "in_standard_filter": 1,
-   "label": "Date",
+   "label": "Posting Date",
    "no_copy": 1,
    "oldfieldname": "posting_date",
    "oldfieldtype": "Date",


### PR DESCRIPTION
### Issue

The field `posting_date` in **Sales Invoice** and **Purchase Invoice** is labeled **"Date"** in the UI, even though the fieldname is `posting_date`.

### Fix

Updated the label from **"Date"** to **"Posting Date"** for the `posting_date` field in:

* Sales Invoice
* Purchase Invoice

### Result

This aligns the label with the fieldname and maintains consistency with other accounting documents in ERPNext.

Closes #53433