### PR TITLE
fix(sales_invoice): reset payment methods on `pos_profile` change

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -920,11 +920,9 @@ class SalesInvoice(SellingController):
 		if self.pos_profile:
 			pos = frappe.get_doc("POS Profile", self.pos_profile)
 
-		if not self.get("payments") and not for_validate:
-			update_multi_mode_option(self, pos)
-
 		if pos:
 			if not for_validate:
+				update_multi_mode_option(self, pos)
 				self.tax_category = pos.get("tax_category")
 
 			if not for_validate and not self.customer:
@@ -3009,6 +3007,8 @@ def update_multi_mode_option(doc, pos_profile):
 		payment.account = payment_mode.default_account
 		payment.type = payment_mode.type
 
+	mop_refetched = bool(doc.payments) and not doc.is_created_using_pos
+
 	doc.set("payments", [])
 	invalid_modes = []
 	mode_of_payments = [d.mode_of_payment for d in pos_profile.get("payments")]
@@ -3029,6 +3029,12 @@ def update_multi_mode_option(doc, pos_profile):
 		else:
 			msg = _("Please set default Cash or Bank account in Mode of Payments {}")
 		frappe.throw(msg.format(", ".join(invalid_modes)), title=_("Missing Account"))
+
+	if mop_refetched:
+		frappe.toast(
+			_("Payment methods refreshed. Please review before proceeding."),
+			indicator="orange",
+		)
 
 
 def get_all_mode_of_payments(doc):


### PR DESCRIPTION
The `payments` child table is refetched on changing `pos_profile` on the Sales Invoice. Triggers the following alert on changing the `pos_profile` to notify users that payments require review before proceeding.

<img width="850" height="214" alt="image" src="https://github.com/user-attachments/assets/82485056-cbdb-4014-aa77-ff37f82afd38" />