### PR TITLE
fix(pos-invoice): `set_missing_value` type annotation error

### DIFF
--- a/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
+++ b/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
@@ -754,7 +754,7 @@ class POSInvoice(SalesInvoice):
 		return profile
 
 	@frappe.whitelist()
-	def set_missing_values(self, for_validate: bool = False):
+	def set_missing_values(self, for_validate: bool | None = False):
 		profile = self.set_pos_fields(for_validate)
 
 		if not self.debit_to:


### PR DESCRIPTION
Ref: #52732
