### PR TITLE
fix: validate operation time > 0 in BOM operations

### DIFF
--- a/erpnext/manufacturing/doctype/bom/bom.py
+++ b/erpnext/manufacturing/doctype/bom/bom.py
@@ -1237,6 +1237,26 @@ class BOM(WebsiteGenerator):
 			for d in self.operations:
 				if not d.description:
 					d.description = frappe.db.get_value("Operation", d.operation, "description")
+
+				if not d.batch_size or d.batch_size <= 0:
+					d.batch_size = 1
+
+				if not d.workstation and not d.workstation_type:
+					frappe.throw(
+						_("Row {0}: Workstation or Workstation Type is mandatory for an operation {1}")
+						.format(d.idx, d.operation)
+					)
+
+				if not d.operation_time or d.operation_time <= 0:
+					frappe.throw(
+						_("Row {0}: Operation Time must be greater than 0 for operation {1}")
+						.format(d.idx, d.operation)
+					)
+
+		if self.with_operations:
+			for d in self.operations:
+				if not d.description:
+					d.description = frappe.db.get_value("Operation", d.operation, "description")
 				if not d.batch_size or d.batch_size <= 0:
 					d.batch_size = 1
 

--- a/erpnext/manufacturing/doctype/bom/bom.py
+++ b/erpnext/manufacturing/doctype/bom/bom.py
@@ -1233,39 +1233,27 @@ class BOM(WebsiteGenerator):
 		if self.with_operations and not self.get("operations") and self.docstatus == 1:
 			frappe.throw(_("Operations cannot be left blank"))
 
-		if self.with_operations:
-			for d in self.operations:
-				if not d.description:
-					d.description = frappe.db.get_value("Operation", d.operation, "description")
+		if not self.with_operations:
+			return
 
-				if not d.batch_size or d.batch_size <= 0:
-					d.batch_size = 1
+		for d in self.operations:
+			if not d.description:
+				d.description = frappe.db.get_value("Operation", d.operation, "description")
 
-				if not d.workstation and not d.workstation_type:
-					frappe.throw(
-						_("Row {0}: Workstation or Workstation Type is mandatory for an operation {1}")
-						.format(d.idx, d.operation)
-					)
+			if not d.batch_size or d.batch_size <= 0:
+				d.batch_size = 1
 
-				if not d.operation_time or d.operation_time <= 0:
-					frappe.throw(
-						_("Row {0}: Operation Time must be greater than 0 for operation {1}")
-						.format(d.idx, d.operation)
-					)
+			if not d.workstation and not d.workstation_type:
+				frappe.throw(
+					_("Row {0}: Workstation or Workstation Type is mandatory for an operation {1}")
+					.format(d.idx, d.operation)
+				)
 
-		if self.with_operations:
-			for d in self.operations:
-				if not d.description:
-					d.description = frappe.db.get_value("Operation", d.operation, "description")
-				if not d.batch_size or d.batch_size <= 0:
-					d.batch_size = 1
-
-				if not d.workstation and not d.workstation_type:
-					frappe.throw(
-						_(
-							"Row {0}: Workstation or Workstation Type is mandatory for an operation {1}"
-						).format(d.idx, d.operation)
-					)
+			if not d.operation_time or d.operation_time <= 0:
+				frappe.throw(
+					_("Row {0}: Operation Time must be greater than 0 for operation {1}")
+					.format(d.idx, d.operation)
+				)
 
 	def get_tree_representation(self) -> BOMTree:
 		"""Get a complete tree representation preserving order of child items."""

--- a/erpnext/manufacturing/doctype/bom/bom.py
+++ b/erpnext/manufacturing/doctype/bom/bom.py
@@ -1245,14 +1245,16 @@ class BOM(WebsiteGenerator):
 
 			if not d.workstation and not d.workstation_type:
 				frappe.throw(
-					_("Row {0}: Workstation or Workstation Type is mandatory for an operation {1}")
-					.format(d.idx, d.operation)
+					_("Row {0}: Workstation or Workstation Type is mandatory for an operation {1}").format(
+						d.idx, d.operation
+					)
 				)
 
-			if not d.operation_time or d.operation_time <= 0:
+			if not d.time_in_mins or d.time_in_mins <= 0:
 				frappe.throw(
-					_("Row {0}: Operation Time must be greater than 0 for operation {1}")
-					.format(d.idx, d.operation)
+					_("Row {0}: Operation Time (mins) must be greater than 0 for operation {1}").format(
+						d.idx, d.operation
+					)
 				)
 
 	def get_tree_representation(self) -> BOMTree:

--- a/erpnext/manufacturing/doctype/bom/bom.py
+++ b/erpnext/manufacturing/doctype/bom/bom.py
@@ -1250,7 +1250,7 @@ class BOM(WebsiteGenerator):
 					)
 				)
 
-			if not d.time_in_mins or d.time_in_mins <= 0:
+			if d.time_in_mins is not None and d.time_in_mins <= 0:
 				frappe.throw(
 					_("Row {0}: Operation Time (mins) must be greater than 0 for operation {1}").format(
 						d.idx, d.operation


### PR DESCRIPTION
### Issue
Closes #53526

When "With Operations" is enabled in BOM, the system allows saving operations
with Operation Time = 0.

This happens because Operation Time is auto-fetched from the linked Operation's
Total Operation Time, which can be 0 when no sub-operations are defined.

Although the field is marked as mandatory, a value of 0 bypasses validation at the BOM level,
leading to a validation error later during Work Order submission.

### Fix
Added validation in BOM to ensure that Operation Time is greater than 0
for all operation rows when "With Operations" is enabled.

### Testing
- Created BOM with operation having Operation Time = 0 → validation error triggered
- Verified BOM saves successfully when Operation Time > 0

### Impact
- Prevents invalid BOM creation
- Ensures early validation instead of failing at Work Order stage
- Aligns BOM validation with Work Order behavior

### Checklist
- [x] Tested locally
- [x] No breaking changes