### PR TITLE
fix: add item_name to quick entry fields in Item doctype

### DIFF
--- a/erpnext/stock/doctype/item/item.json
+++ b/erpnext/stock/doctype/item/item.json
@@ -167,6 +167,7 @@
    "set_only_once": 1
   },
   {
+   "allow_in_quick_entry": 1,
    "bold": 1,
    "fieldname": "item_name",
    "fieldtype": "Data",


### PR DESCRIPTION
Item Name field was not available in the Item Quick Entry dialog.

Added allow_in_quick_entry property to item_name field to ensure it appears in the Quick Entry form.

closes #53511