### PR TITLE
fix: remove payables and receivables workspace

### DIFF
--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -472,3 +472,4 @@ erpnext.patches.v16_0.complete_onboarding_steps_for_older_sites #2
 erpnext.patches.v16_0.enable_serial_batch_setting
 erpnext.patches.v16_0.co_by_product_patch
 erpnext.patches.v16_0.update_requested_qty_packed_item
+erpnext.patches.v16_0.remove_payables_receivables_workspace

--- a/erpnext/patches/v16_0/remove_payables_receivables_workspace.py
+++ b/erpnext/patches/v16_0/remove_payables_receivables_workspace.py
@@ -1,0 +1,6 @@
+import frappe
+
+
+def execute():
+	for ws in ["Receivables", "Payables"]:
+		frappe.delete_doc_if_exists("Workspace", ws)


### PR DESCRIPTION
Issue:
Payable and Receivable workspaces are still present in v16 after their removal in PR [#51286](https://github.com/frappe/erpnext/pull/51286)


Backport needed: v16