### PR TITLE
fix: skip validate_stock_accounts in Journal Entry when perpetual inventory is disabled

### DIFF
--- a/erpnext/accounts/doctype/journal_entry/journal_entry.py
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.py
@@ -269,6 +269,9 @@ class JournalEntry(AccountsController):
 			frappe.throw(_("Journal Entry type should be set as Depreciation Entry for asset depreciation"))
 
 	def validate_stock_accounts(self):
+		if not erpnext.is_perpetual_inventory_enabled(self.company):
+			return
+
 		stock_accounts = get_stock_accounts(self.company, accounts=self.accounts)
 		for account in stock_accounts:
 			account_bal, stock_bal, warehouse_list = get_stock_and_account_balance(


### PR DESCRIPTION
## Problem

When **perpetual inventory is disabled**, posting a Journal Entry against a stock-type account throws:

```
StockAccountInvalidTransaction: Account: {account} can only be updated via Stock Transactions
```

This happens because `validate_stock_accounts()` is called unconditionally in `validate()` with no guard for whether perpetual inventory is enabled.

When perpetual inventory is disabled, stock transactions produce no GL entries, so there is no reason to block manual Journal Entries against stock accounts — the restriction is only meaningful when the GL and stock ledger are expected to stay in sync (i.e., perpetual inventory is on).

## Root Cause

`validate_stock_accounts()` in `journal_entry.py` checks whether the account balance equals the stock ledger balance and throws an error if they match. This logic assumes perpetual inventory is active. With perpetual inventory off, the check is a false positive.

## Fix

Added an early return at the top of `validate_stock_accounts()` when `is_perpetual_inventory_enabled()` returns `False`:

```python
def validate_stock_accounts(self):
    if not erpnext.is_perpetual_inventory_enabled(self.company):
        return
    ...
```

## Steps to Reproduce

1. Disable perpetual inventory on a company (`enable_perpetual_inventory = 0`)
2. Create a Journal Entry that includes a stock-type account (e.g. Stock in Hand)
3. Save/submit → error is thrown

## Related

- Same guard already exists in `stock_controller.py` `make_gl_entries()` and `validate_expense_account()` in Stock Reconciliation
- No existing issue or PR addresses this specific case

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Stock account validation now skips when perpetual inventory is disabled for the company.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->