### PR TITLE
fix(manufacturing): update working hours validation

### DIFF
--- a/erpnext/manufacturing/doctype/workstation/workstation.py
+++ b/erpnext/manufacturing/doctype/workstation/workstation.py
@@ -102,9 +102,6 @@ class Workstation(Document):
 				self.total_working_hours += row.hours
 
 	def validate_working_hours(self, row):
-		if not (row.start_time and row.end_time):
-			frappe.throw(_("Row #{0}: Start Time and End Time are required").format(row.idx))
-
 		if get_time(row.start_time) >= get_time(row.end_time):
 			frappe.throw(_("Row #{0}: Start Time must be before End Time").format(row.idx))
 


### PR DESCRIPTION
**Issue:**
The system is throwing error, when trying to update the workstation from back-end code, if the start_time is set to "00:00:00".

**Description:**
When updating the Workstation document from the site, the start_time is passed as a string "00:00:00". The system allows the document to be updated successfully in this case.
However, when fetching the document using frappe.get_doc(...) in Python, the start_time field is returned as a datetime.timedelta (datetime.timedelta(0)) object.
When attempting to save the same document object (e.g., doc.save()), the validation for the Time field triggers and throws an error due to the datetime.timedelta(0) will return false.

**Ref:** [#62605](https://support.frappe.io/helpdesk/tickets/62605)

**Backport Needed for V15 & V16**