### PR TITLE
fix: strip diacritics from label when generating Accounting Dimension…

### DIFF
--- a/erpnext/accounts/doctype/accounting_dimension/accounting_dimension.js
+++ b/erpnext/accounts/doctype/accounting_dimension/accounting_dimension.js
@@ -58,7 +58,9 @@ frappe.ui.form.on("Accounting Dimension", {
 	},
 
 	label: function (frm) {
-		frm.set_value("fieldname", frm.doc.label.replace(/ /g, "_").replace(/-/g, "_").toLowerCase());
+		// Strip diacritics (e.g. "Département" → "departement") to match server-side fieldname generation.
+		const ascii_label = frm.doc.label.normalize("NFKD").replace(/[\u0300-\u036f]/g, "");
+		frm.set_value("fieldname", ascii_label.replace(/ /g, "_").replace(/-/g, "_").toLowerCase());
 	},
 
 	document_type: function (frm) {

--- a/erpnext/accounts/doctype/accounting_dimension/accounting_dimension.js
+++ b/erpnext/accounts/doctype/accounting_dimension/accounting_dimension.js
@@ -58,8 +58,8 @@ frappe.ui.form.on("Accounting Dimension", {
 	},
 
 	label: function (frm) {
-		// Strip diacritics (e.g. "Département" → "departement") to match server-side fieldname generation.
-		const ascii_label = frm.doc.label.normalize("NFKD").replace(/[\u0300-\u036f]/g, "");
+		if (!frm.doc.label) return;
+		const ascii_label = frm.doc.label.normalize("NFKD").replace(/[^\x00-\x7F]/g, "");
 		frm.set_value("fieldname", ascii_label.replace(/ /g, "_").replace(/-/g, "_").toLowerCase());
 	},
 

--- a/erpnext/accounts/doctype/accounting_dimension/accounting_dimension.py
+++ b/erpnext/accounts/doctype/accounting_dimension/accounting_dimension.py
@@ -3,6 +3,7 @@
 
 
 import json
+import unicodedata
 
 import frappe
 from frappe import _, scrub
@@ -101,7 +102,9 @@ class AccountingDimension(Document):
 			self.label = cstr(self.document_type)
 
 		if not self.fieldname:
-			self.fieldname = scrub(self.label)
+			# Strip diacritics (e.g. "Département" → "departement") to produce a valid ASCII fieldname.
+			ascii_label = unicodedata.normalize("NFKD", self.label).encode("ascii", "ignore").decode("ascii")
+			self.fieldname = scrub(ascii_label)
 
 
 def make_dimension_in_accounting_doctypes(doc, doclist=None):

--- a/erpnext/accounts/doctype/accounting_dimension/test_accounting_dimension.py
+++ b/erpnext/accounts/doctype/accounting_dimension/test_accounting_dimension.py
@@ -155,7 +155,8 @@ class TestAccountingDimension(ERPNextTestSuite):
 			ascii_label = unicodedata.normalize("NFKD", label).encode("ascii", "ignore").decode("ascii")
 			client_fieldname = ascii_label.replace(" ", "_").replace("-", "_").lower()
 			server_fieldname = self._get_fieldname(label)
-			self.assertEqual(client_fieldname, server_fieldname)
+			self.assertEqual(client_fieldname, expected_fieldname)
+			self.assertEqual(server_fieldname, expected_fieldname)
 
 	def test_edge_cases_fieldname_generation(self):
 		test_cases = [

--- a/erpnext/accounts/doctype/accounting_dimension/test_accounting_dimension.py
+++ b/erpnext/accounts/doctype/accounting_dimension/test_accounting_dimension.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2019, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
 
+import unicodedata
+
 import frappe
 
 from erpnext.accounts.doctype.journal_entry.test_journal_entry import make_journal_entry
@@ -73,3 +75,176 @@ class TestAccountingDimension(ERPNextTestSuite):
 
 		si.save()
 		self.assertRaises(frappe.ValidationError, si.submit)
+
+	def test_accented_label_generates_ascii_fieldname(self):
+		doc = frappe.new_doc("Accounting Dimension")
+		doc.label = "Département"
+		doc.set_fieldname_and_label()
+		self.assertEqual(doc.fieldname, "departement")
+
+	def test_various_diacritics_stripped_from_fieldname(self):
+		test_cases = [
+			("München", "munchen"),
+			("España", "espana"),
+			("Naïve", "naive"),
+			("Zürich", "zurich"),
+			("Îles", "iles"),
+			("Çà", "ca"),
+		]
+
+		for label, expected_fieldname in test_cases:
+			self.assertEqual(self._get_fieldname(label), expected_fieldname)
+
+	def test_fieldname_generation_with_spaces_and_hyphens(self):
+		test_cases = [
+			("Département Region", "departement_region"),
+			("Zone-Test", "zone_test"),
+			("Café Paris", "cafe_paris"),
+			("Test-Field-Name", "test_field_name"),
+		]
+
+		for label, expected_fieldname in test_cases:
+			self.assertEqual(self._get_fieldname(label), expected_fieldname)
+
+	def test_fieldname_generation_with_mixed_special_chars(self):
+		test_cases = [
+			("Café-Restaurant München", "cafe_restaurant_munchen"),
+			("Área de Vendas", "area_de_vendas"),
+			("Coût & Prix", "cout_prix"),
+		]
+
+		for label, expected_fieldname in test_cases:
+			self.assertEqual(self._get_fieldname(label), expected_fieldname)
+
+	def test_fieldname_validation_rejects_diacritics_without_stripping(self):
+		from frappe.database.schema import validate_column_name
+		from frappe.exceptions import InvalidColumnName
+
+		validate_column_name("departement")
+		validate_column_name("test_field")
+
+		with self.assertRaises(InvalidColumnName):
+			validate_column_name("département")
+
+		with self.assertRaises(InvalidColumnName):
+			validate_column_name("münchen")
+
+	def test_set_fieldname_and_label_method(self):
+		test_cases = [
+			("Département", "departement"),
+			("Test Label", "test_label"),
+			("Café", "cafe"),
+			("Ñoño", "nono"),
+			("Ångström", "angstrom"),
+		]
+
+		for label, expected_fieldname in test_cases:
+			self.assertEqual(self._get_fieldname(label), expected_fieldname)
+
+	def test_client_server_fieldname_consistency(self):
+		"""Test that client-side JS and server-side Python generate the same fieldname."""
+		test_cases = [
+			("Département", "departement"),
+			("Département Region", "departement_region"),
+			("Zone-Test", "zone_test"),
+			("Café-Restaurant München", "cafe_restaurant_munchen"),
+			("Área de Vendas", "area_de_vendas"),
+		]
+
+		for label, expected_fieldname in test_cases:
+			ascii_label = unicodedata.normalize("NFKD", label).encode("ascii", "ignore").decode("ascii")
+			client_fieldname = ascii_label.replace(" ", "_").replace("-", "_").lower()
+			server_fieldname = self._get_fieldname(label)
+			self.assertEqual(client_fieldname, server_fieldname)
+
+	def test_edge_cases_fieldname_generation(self):
+		test_cases = [
+			("  Test  ", "__test__"),
+			("Test--Field", "test__field"),
+			("Test  Field", "test__field"),
+			("-Test-", "_test_"),
+			("Zone-123", "zone_123"),
+			("Test-1ère", "test_1ere"),
+			("Test@", "test"),
+		]
+
+		for label, expected_fieldname in test_cases:
+			self.assertEqual(self._get_fieldname(label), expected_fieldname)
+
+	def test_empty_fieldname_from_special_chars(self):
+		"""Test that labels with only special characters produce fieldname with special chars."""
+		doc = frappe.new_doc("Accounting Dimension")
+		doc.label = "!!!"
+		doc.set_fieldname_and_label()
+		self.assertEqual(doc.fieldname, "!!!")
+
+	def _get_fieldname(self, label):
+		doc = frappe.new_doc("Accounting Dimension")
+		doc.label = label
+		doc.set_fieldname_and_label()
+		return doc.fieldname
+
+	def tearDown(self):
+		disable_dimension()
+		frappe.flags.accounting_dimensions_details = None
+		frappe.flags.dimension_filter_map = None
+
+
+def create_dimension():
+	frappe.set_user("Administrator")
+
+	if not frappe.db.exists("Accounting Dimension", {"document_type": "Department"}):
+		dimension = frappe.get_doc(
+			{
+				"doctype": "Accounting Dimension",
+				"document_type": "Department",
+			}
+		)
+		dimension.append(
+			"dimension_defaults",
+			{
+				"company": "_Test Company",
+				"reference_document": "Department",
+				"default_dimension": "_Test Department - _TC",
+			},
+		)
+		dimension.insert()
+		dimension.save()
+	else:
+		dimension = frappe.get_doc("Accounting Dimension", "Department")
+		dimension.disabled = 0
+		dimension.save()
+
+	if not frappe.db.exists("Accounting Dimension", {"document_type": "Location"}):
+		dimension1 = frappe.get_doc(
+			{
+				"doctype": "Accounting Dimension",
+				"document_type": "Location",
+			}
+		)
+
+		dimension1.append(
+			"dimension_defaults",
+			{
+				"company": "_Test Company",
+				"reference_document": "Location",
+				"default_dimension": "Block 1",
+			},
+		)
+
+		dimension1.insert()
+		dimension1.save()
+	else:
+		dimension1 = frappe.get_doc("Accounting Dimension", "Location")
+		dimension1.disabled = 0
+		dimension1.save()
+
+
+def disable_dimension():
+	dimension1 = frappe.get_doc("Accounting Dimension", "Department")
+	dimension1.disabled = 1
+	dimension1.save()
+
+	dimension2 = frappe.get_doc("Accounting Dimension", "Location")
+	dimension2.disabled = 1
+	dimension2.save()


### PR DESCRIPTION
## Description:
When creating an Accounting Dimension with an accented label (e.g. "Département"), the auto-generated fieldname retained the accent (département). This passed creation-time validation but blocked any `rename_doc` operation on the linked DocType with "Invalid characters in fieldname".

Fixed by normalizing the label to ASCII before calling `scrub()` in `set_fieldname_and_label()`, and mirroring the same logic in the JS so the fieldname preview is consistent.

Note: this fix is preventive only — existing Custom Fields with accented fieldnames are not migrated automatically.