### PR TITLE
fix(stock): handle NoneType error

### DIFF
--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
@@ -406,7 +406,7 @@ class PurchaseReceipt(BuyingController):
 		self.update_received_qty_if_from_pp()
 
 	def update_received_qty_if_from_pp(self):
-		from frappe.query_builder.functions import Sum
+		from frappe.query_builder.functions import Coalesce, Sum
 
 		items_from_po = [item.purchase_order_item for item in self.items if item.purchase_order_item]
 		if items_from_po:
@@ -415,7 +415,10 @@ class PurchaseReceipt(BuyingController):
 				frappe.qb.from_(table)
 				.select(table.production_plan_sub_assembly_item)
 				.distinct()
-				.where(table.name.isin(items_from_po) & table.production_plan_sub_assembly_item.isnotnull())
+				.where(
+					table.name.isin(items_from_po)
+					& Coalesce(table.production_plan_sub_assembly_item, "").ne("")
+				)
 			)
 			result = subquery.run(as_dict=True)
 			if result:


### PR DESCRIPTION
**Issue :** Handle blank string in production_plan_sub_assembly_item during Purchase Receipt submit

**Ref:** [#62748](https://support.frappe.io/helpdesk/tickets/62748)

**Description:** 

When a Purchase Receipt is submitted, it throws a server error in most cases. After investigating, the root cause was found in the database — some Purchase Order Items had a blank string "" in the production_plan_sub_assembly_item field instead of NULL. The existing code only checks for NULL values, so blank strings slip through and cause the crash. Fixed the condition to handle both NULL and blank strings so the Purchase Receipt submits successfully.

Before :

[Screencast from 18-03-26 03:59:57 PM IST.webm](https://github.com/user-attachments/assets/6dcb4408-3ae5-40fc-81c6-66378c290db6)

After : 

[Screencast from 18-03-26 04:00:41 PM IST.webm](https://github.com/user-attachments/assets/01eba1fa-2b44-4383-a139-e82dd98b93f6)

BackPort Needed for V16