### PR TITLE
fix: fix max recursion in get_stock_ledgers_for_serial_nos for large …

### DIFF
--- a/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py
+++ b/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py
@@ -15,7 +15,6 @@ from frappe import _, _dict, bold
 from frappe.model.document import Document
 from frappe.model.naming import make_autoname
 from frappe.query_builder.functions import Sum
-from pypika.terms import Criterion, ValueWrapper
 from frappe.utils import (
 	cint,
 	cstr,
@@ -29,6 +28,7 @@ from frappe.utils import (
 	today,
 )
 from frappe.utils.csvutils import build_csv_response
+from pypika.terms import Criterion, ValueWrapper
 
 from erpnext.stock.doctype.purchase_receipt_item.purchase_receipt_item import PurchaseReceiptItem
 from erpnext.stock.serial_batch_bundle import (

--- a/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py
+++ b/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py
@@ -3258,10 +3258,7 @@ class _RegexpMatch(Criterion):
 		self.pattern = ValueWrapper(pattern)
 
 	def get_sql(self, **kwargs):
-		return "{field} REGEXP {pattern}".format(
-			field=self.field.get_sql(**kwargs),
-			pattern=self.pattern.get_sql(**kwargs),
-		)
+		return f"{self.field.get_sql(**kwargs)} REGEXP {self.pattern.get_sql(**kwargs)}"
 
 
 def get_stock_ledgers_for_serial_nos(kwargs):

--- a/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py
+++ b/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py
@@ -14,7 +14,8 @@ import frappe.query_builder.functions
 from frappe import _, _dict, bold
 from frappe.model.document import Document
 from frappe.model.naming import make_autoname
-from frappe.query_builder.functions import CustomFunction, Sum
+from frappe.query_builder.functions import Sum
+from pypika.terms import Criterion, ValueWrapper
 from frappe.utils import (
 	cint,
 	cstr,
@@ -3247,6 +3248,22 @@ def get_ledgers_from_serial_batch_bundle(**kwargs) -> list[frappe._dict]:
 	return query.run(as_dict=True)
 
 
+class _RegexpMatch(Criterion):
+	"""Generates ``field REGEXP 'pattern'`` — REGEXP is an infix operator in MariaDB/MySQL,
+	not a two-argument function."""
+
+	def __init__(self, field, pattern):
+		super().__init__()
+		self.field = field
+		self.pattern = ValueWrapper(pattern)
+
+	def get_sql(self, **kwargs):
+		return "{field} REGEXP {pattern}".format(
+			field=self.field.get_sql(**kwargs),
+			pattern=self.pattern.get_sql(**kwargs),
+		)
+
+
 def get_stock_ledgers_for_serial_nos(kwargs):
 	"""
 	Fetch stock ledger entries based on various filters.
@@ -3307,10 +3324,9 @@ def get_stock_ledgers_for_serial_nos(kwargs):
 
 		# Legacy path: serial numbers stored as newline-separated string in serial_no field.
 		# Use REGEXP instead of 1000+ OR conditions to avoid PyPika recursion.
-		Regexp = CustomFunction("REGEXP", ["field", "pattern"])
 		escaped = [re.escape(sn) for sn in serial_nos]
 		pattern = "(^|\\n)(" + "|".join(escaped) + ")(\\n|$)"
-		direct_match = Regexp(stock_ledger_entry.serial_no, pattern)
+		direct_match = _RegexpMatch(stock_ledger_entry.serial_no, pattern)
 
 		if bundle_parents:
 			serial_condition = stock_ledger_entry.serial_and_batch_bundle.isin(bundle_parents) | direct_match

--- a/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py
+++ b/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py
@@ -4,6 +4,7 @@
 import collections
 import csv
 import json
+import re
 from collections import Counter, defaultdict
 from typing import Any
 
@@ -13,7 +14,7 @@ import frappe.query_builder.functions
 from frappe import _, _dict, bold
 from frappe.model.document import Document
 from frappe.model.naming import make_autoname
-from frappe.query_builder.functions import Concat_ws, Locate, Sum
+from frappe.query_builder.functions import CustomFunction, Sum
 from frappe.utils import (
 	cint,
 	cstr,
@@ -3296,21 +3297,27 @@ def get_stock_ledgers_for_serial_nos(kwargs):
 		serial_nos = [serial_nos]
 
 	if serial_nos:
-		query = (
-			query.left_join(serial_batch_entry)
-			.on(stock_ledger_entry.serial_and_batch_bundle == serial_batch_entry.parent)
+		# Pre-fetch bundle parents via subquery to avoid PyPika recursion with 1000+ serial numbers
+		bundle_parents = (
+			frappe.qb.from_(serial_batch_entry)
+			.select(serial_batch_entry.parent)
 			.distinct()
-		)
+			.where(serial_batch_entry.serial_no.isin(serial_nos))
+		).run(pluck=True)
 
-		bundle_match = serial_batch_entry.serial_no.isin(serial_nos)
+		# Legacy path: serial numbers stored as newline-separated string in serial_no field.
+		# Use REGEXP instead of 1000+ OR conditions to avoid PyPika recursion.
+		Regexp = CustomFunction("REGEXP", ["field", "pattern"])
+		escaped = [re.escape(sn) for sn in serial_nos]
+		pattern = "(^|\\n)(" + "|".join(escaped) + ")(\\n|$)"
+		direct_match = Regexp(stock_ledger_entry.serial_no, pattern)
 
-		padded_serial_no = Concat_ws("", "\n", stock_ledger_entry.serial_no, "\n")
-		direct_match = None
-		for sn in serial_nos:
-			cond = Locate(f"\n{sn}\n", padded_serial_no) > 0
-			direct_match = cond if direct_match is None else (direct_match | cond)
+		if bundle_parents:
+			serial_condition = stock_ledger_entry.serial_and_batch_bundle.isin(bundle_parents) | direct_match
+		else:
+			serial_condition = direct_match
 
-		query = query.where(bundle_match | direct_match)
+		query = query.where(serial_condition)
 
 	if kwargs.ignore_voucher_detail_no:
 		query = query.where(stock_ledger_entry.voucher_detail_no != kwargs.ignore_voucher_detail_no)


### PR DESCRIPTION
More optimized version of [https://github.com/frappe/erpnext/pull/51644](https://github.com/frappe/erpnext/pull/51644) PR. Found one edge case, when child table contains qty > than 1000+, where condition limit gets excedded and gives Max recursion occured. And filtering records is even better than full table join. Have tested this on scale.

<img width="1441" height="781" alt="image" src="https://github.com/user-attachments/assets/509c04c2-cda6-49ff-8b10-4d897d3111b7" />
