### PR TITLE
fix(stock): fix email error message

### DIFF
--- a/erpnext/stock/reorder_item.py
+++ b/erpnext/stock/reorder_item.py
@@ -7,7 +7,7 @@ from math import ceil
 
 import frappe
 from frappe import _
-from frappe.utils import add_days, cint, flt, nowdate
+from frappe.utils import add_days, cint, escape_html, flt, nowdate
 
 import erpnext
 
@@ -223,15 +223,6 @@ def create_material_request(material_requests):
 	mr_list = []
 	exceptions_list = []
 
-	def _log_exception(mr):
-		if frappe.local.message_log:
-			exceptions_list.extend(frappe.local.message_log)
-			frappe.local.message_log = []
-		else:
-			exceptions_list.append(frappe.get_traceback(with_context=True))
-
-		mr.log_error("Unable to create material request")
-
 	company_wise_mr = frappe._dict({})
 	for request_type in material_requests:
 		for company in material_requests[request_type]:
@@ -305,8 +296,9 @@ def create_material_request(material_requests):
 
 				company_wise_mr.setdefault(company, []).append(mr)
 
-			except Exception:
-				_log_exception(mr)
+			except Exception as exception:
+				exceptions_list.append(exception)
+				mr.log_error("Unable to create material request")
 
 	if company_wise_mr:
 		if getattr(frappe.local, "reorder_email_notify", None) is None:
@@ -391,10 +383,7 @@ def notify_errors(exceptions_list):
 
 	for exception in exceptions_list:
 		try:
-			exception = json.loads(exception)
-			error_message = """<div class='small text-muted'>{}</div><br>""".format(
-				_(exception.get("message"))
-			)
+			error_message = f"<div class='small text-muted'>{escape_html(str(exception))}</div><br>"
 			content += error_message
 		except Exception:
 			pass


### PR DESCRIPTION
**Issue:**
When the reorder scheduler encounters an error for any item. the system sends an email notification, but it contains no error message.

**Ref:** [#62593](https://support.frappe.io/helpdesk/tickets/62593)

**Before:**

<img width="793" height="193" alt="image" src="https://github.com/user-attachments/assets/74f81ecc-d29c-4c66-af20-343725f6bf21" />

**After:**

<img width="798" height="231" alt="image" src="https://github.com/user-attachments/assets/8c586bd3-9fc4-402e-b274-602e557a5a90" />

**Backport Needed for v15 & v16**