### PR TITLE
fix(payment_schedule): using `show_alert` instead of `msgprint` for non-selection of payment schedule

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -516,7 +516,10 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 				const selected = values.payment_schedules.filter((r) => r.__checked);
 
 				if (!selected.length) {
-					frappe.msgprint(__("Please select at least one schedule."));
+					frappe.show_alert({
+						message: __("Please select at least one schedule."),
+						indicator: "orange",
+					});
 					return;
 				}
 				console.log(selected);


### PR DESCRIPTION
Using `show_alert` for better UX to alert users about non-selection of Payment Schedules while creating a Payment Request.


https://github.com/user-attachments/assets/c70580e4-daf1-4739-9f39-74e1db5646c8

