### PR TITLE
fix: deadlock issue for SLE

### DIFF
--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -2046,7 +2046,6 @@ def update_qty_in_future_sle(args, allow_negative_stock=False):
 		where
 			item_code = %(item_code)s
 			and warehouse = %(warehouse)s
-			and voucher_no != %(voucher_no)s
 			and is_cancelled = 0
 			and (
 				posting_datetime > %(posting_datetime)s


### PR DESCRIPTION
Below two queries causing deadlock even though item and warehouses are different

"update `tabStock Ledger Entry`
set qty_after_transaction = qty_after_transaction + -1.0
where
item_code = 'ABC1'
and warehouse = 'T1'
and voucher_no != '5gkv4c40mr'
and is_cancelled = 0
and (
posting_datetime > '2026-03-17 12:21:08.816715'
) /* FRAPPE_TRACE_ID: 1b88d1e9-cfc7-4dc0-89fc-41f4a25ccd65 */"

"INSERT INTO `tabStock Ledger Entry` (`name`, `owner`, `creation`, `modified`, `modified_by`, `docstatus`, `idx`, `item_code`, `warehouse`, `posting_date`, `posting_time`, `posting_datetime`, `is_adjustment_entry`, `auto_created_serial_and_batch_bundle`, `voucher_type`, `voucher_no`, `voucher_detail_no`, `serial_and_batch_bundle`, `dependant_sle_voucher_detail_no`, `recalculate_rate`, `actual_qty`, `qty_after_transaction`, `incoming_rate`, `outgoing_rate`, `valuation_rate`, `stock_value`, `stock_value_difference`, `stock_queue`, `company`, `stock_uom`, `project`, `fiscal_year`, `has_batch_no`, `has_serial_no`, `is_cancelled`, `to_rename`, `serial_no`, `batch_no`)
VALUES ('7ecef5383f', 'sas2', '2026-03-17 12:21:09.066284', '2026-03-17 12:21:09.066284', 'sas2', '1', 0, 'ABC2', 'T2', '2026-03-17', '12:21:08.877913', '2026-03-17 12:21:08.877913', 0, 0, 'Stock Entry', 'fgl0', 'fg', 'aa0', NULL, 1, 1.0e0, 0.0e0, 456.09e0, 0.0e0, 0.0e0, 0.0e0, 0.0e0, NULL, '(Demo)', 'Nos', NULL, '2025-2026', 1, 1, 0, 1, NULL, NULL) /* FRAPPE_TRACE_ID: 9b25490b-1c7c-490f-b841-98455467488f */"