### PR TITLE
refactor(test): move remaining commits inside test guard

### DIFF
--- a/erpnext/accounts/doctype/accounting_dimension/test_accounting_dimension.py
+++ b/erpnext/accounts/doctype/accounting_dimension/test_accounting_dimension.py
@@ -9,9 +9,6 @@ from erpnext.tests.utils import ERPNextTestSuite
 
 
 class TestAccountingDimension(ERPNextTestSuite):
-	def setUp(self):
-		create_dimension()
-
 	def test_dimension_against_sales_invoice(self):
 		si = create_sales_invoice(do_not_save=1)
 
@@ -76,63 +73,3 @@ class TestAccountingDimension(ERPNextTestSuite):
 
 		si.save()
 		self.assertRaises(frappe.ValidationError, si.submit)
-
-
-def create_dimension():
-	frappe.set_user("Administrator")
-
-	if not frappe.db.exists("Accounting Dimension", {"document_type": "Department"}):
-		dimension = frappe.get_doc(
-			{
-				"doctype": "Accounting Dimension",
-				"document_type": "Department",
-			}
-		)
-		dimension.append(
-			"dimension_defaults",
-			{
-				"company": "_Test Company",
-				"reference_document": "Department",
-				"default_dimension": "_Test Department - _TC",
-			},
-		)
-		dimension.insert()
-		dimension.save()
-	else:
-		dimension = frappe.get_doc("Accounting Dimension", "Department")
-		dimension.disabled = 0
-		dimension.save()
-
-	if not frappe.db.exists("Accounting Dimension", {"document_type": "Location"}):
-		dimension1 = frappe.get_doc(
-			{
-				"doctype": "Accounting Dimension",
-				"document_type": "Location",
-			}
-		)
-
-		dimension1.append(
-			"dimension_defaults",
-			{
-				"company": "_Test Company",
-				"reference_document": "Location",
-				"default_dimension": "Block 1",
-			},
-		)
-
-		dimension1.insert()
-		dimension1.save()
-	else:
-		dimension1 = frappe.get_doc("Accounting Dimension", "Location")
-		dimension1.disabled = 0
-		dimension1.save()
-
-
-def disable_dimension():
-	dimension1 = frappe.get_doc("Accounting Dimension", "Department")
-	dimension1.disabled = 1
-	dimension1.save()
-
-	dimension2 = frappe.get_doc("Accounting Dimension", "Location")
-	dimension2.disabled = 1
-	dimension2.save()

--- a/erpnext/accounts/doctype/accounting_dimension_filter/test_accounting_dimension_filter.py
+++ b/erpnext/accounts/doctype/accounting_dimension_filter/test_accounting_dimension_filter.py
@@ -3,9 +3,6 @@
 
 import frappe
 
-from erpnext.accounts.doctype.accounting_dimension.test_accounting_dimension import (
-	create_dimension,
-)
 from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_sales_invoice
 from erpnext.exceptions import InvalidAccountDimensionError, MandatoryAccountDimensionError
 from erpnext.tests.utils import ERPNextTestSuite
@@ -13,7 +10,6 @@ from erpnext.tests.utils import ERPNextTestSuite
 
 class TestAccountingDimensionFilter(ERPNextTestSuite):
 	def setUp(self):
-		create_dimension()
 		create_accounting_dimension_filter()
 		self.invoice_list = []
 

--- a/erpnext/accounts/doctype/gl_entry/gl_entry.py
+++ b/erpnext/accounts/doctype/gl_entry/gl_entry.py
@@ -489,4 +489,5 @@ def rename_temporarily_named_docs(doctype):
 				for hook in frappe.get_hooks(hook_type):
 					frappe.call(hook, newname=newname, oldname=oldname)
 
-		frappe.db.commit()
+		if not frappe.in_test:
+			frappe.db.commit()

--- a/erpnext/accounts/doctype/ledger_merge/ledger_merge.py
+++ b/erpnext/accounts/doctype/ledger_merge/ledger_merge.py
@@ -79,7 +79,8 @@ def start_merge(docname):
 					{"ledger_merge": ledger_merge.name, "current": successful_merges, "total": total},
 				)
 			except Exception:
-				frappe.db.rollback()
+				if not frappe.in_test:
+					frappe.db.rollback()
 				ledger_merge.log_error("Ledger merge failed")
 			finally:
 				if successful_merges == total:

--- a/erpnext/accounts/doctype/ledger_merge/ledger_merge.py
+++ b/erpnext/accounts/doctype/ledger_merge/ledger_merge.py
@@ -71,7 +71,8 @@ def start_merge(docname):
 					ledger_merge.account,
 				)
 				row.db_set("merged", 1)
-				frappe.db.commit()
+				if not frappe.in_test:
+					frappe.db.commit()
 				successful_merges += 1
 				frappe.publish_realtime(
 					"ledger_merge_progress",

--- a/erpnext/accounts/doctype/opening_invoice_creation_tool/opening_invoice_creation_tool.py
+++ b/erpnext/accounts/doctype/opening_invoice_creation_tool/opening_invoice_creation_tool.py
@@ -274,7 +274,8 @@ def start_import(invoices):
 			doc.flags.ignore_mandatory = True
 			doc.insert(set_name=invoice_number)
 			doc.submit()
-			frappe.db.commit()
+			if not frappe.in_test:
+				frappe.db.commit()
 			names.append(doc.name)
 		except Exception:
 			errors += 1

--- a/erpnext/accounts/doctype/opening_invoice_creation_tool/test_opening_invoice_creation_tool.py
+++ b/erpnext/accounts/doctype/opening_invoice_creation_tool/test_opening_invoice_creation_tool.py
@@ -10,11 +10,6 @@ from erpnext.tests.utils import ERPNextTestSuite
 
 
 class TestOpeningInvoiceCreationTool(ERPNextTestSuite):
-	def setUp(self):
-		# TODO: move to bootstrap
-		if not frappe.db.exists("Company", "_Test Opening Invoice Company"):
-			make_company()
-
 	def make_invoices(
 		self,
 		invoice_type="Sales",
@@ -177,19 +172,6 @@ def get_opening_invoice_creation_dict(**args):
 
 	invoice_dict.update(args)
 	return invoice_dict
-
-
-def make_company():
-	if frappe.db.exists("Company", "_Test Opening Invoice Company"):
-		return frappe.get_doc("Company", "_Test Opening Invoice Company")
-
-	company = frappe.new_doc("Company")
-	company.company_name = "_Test Opening Invoice Company"
-	company.abbr = "_TOIC"
-	company.default_currency = "INR"
-	company.country = "Pakistan"
-	company.insert()
-	return company
 
 
 def make_customer(customer=None):

--- a/erpnext/accounts/doctype/opening_invoice_creation_tool/test_opening_invoice_creation_tool.py
+++ b/erpnext/accounts/doctype/opening_invoice_creation_tool/test_opening_invoice_creation_tool.py
@@ -3,9 +3,6 @@
 
 import frappe
 
-from erpnext.accounts.doctype.accounting_dimension.test_accounting_dimension import (
-	create_dimension,
-)
 from erpnext.accounts.doctype.opening_invoice_creation_tool.opening_invoice_creation_tool import (
 	get_temporary_opening_account,
 )
@@ -14,9 +11,9 @@ from erpnext.tests.utils import ERPNextTestSuite
 
 class TestOpeningInvoiceCreationTool(ERPNextTestSuite):
 	def setUp(self):
+		# TODO: move to bootstrap
 		if not frappe.db.exists("Company", "_Test Opening Invoice Company"):
 			make_company()
-		create_dimension()
 
 	def make_invoices(
 		self,

--- a/erpnext/accounts/doctype/payment_request/payment_request.py
+++ b/erpnext/accounts/doctype/payment_request/payment_request.py
@@ -750,7 +750,8 @@ def make_payment_request(**args):
 			pr.submit()
 
 	if args.order_type == "Shopping Cart":
-		frappe.db.commit()
+		if not frappe.in_test:
+			frappe.db.commit()
 		frappe.local.response["type"] = "redirect"
 		frappe.local.response["location"] = pr.get_payment_url()
 

--- a/erpnext/accounts/doctype/pos_closing_entry/test_pos_closing_entry.py
+++ b/erpnext/accounts/doctype/pos_closing_entry/test_pos_closing_entry.py
@@ -3,10 +3,6 @@
 
 import frappe
 
-from erpnext.accounts.doctype.accounting_dimension.test_accounting_dimension import (
-	create_dimension,
-	disable_dimension,
-)
 from erpnext.accounts.doctype.pos_closing_entry.pos_closing_entry import (
 	make_closing_entry_from_opening,
 )
@@ -161,7 +157,6 @@ class TestPOSClosingEntry(ERPNextTestSuite):
 		test case to check whether we can create POS Closing Entry without mandatory accounting dimension
 		"""
 
-		create_dimension()
 		location = frappe.get_doc("Accounting Dimension", "Location")
 		location.dimension_defaults[0].mandatory_for_bs = True
 		location.save()
@@ -197,7 +192,6 @@ class TestPOSClosingEntry(ERPNextTestSuite):
 		)
 		accounting_dimension_department.mandatory_for_bs = 0
 		accounting_dimension_department.save()
-		disable_dimension()
 
 	def test_merging_into_sales_invoice_for_batched_item(self):
 		frappe.flags.print_message = False

--- a/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.py
+++ b/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.py
@@ -566,10 +566,10 @@ def send_emails(document_name: str, from_scheduler: bool = False, posting_date: 
 			new_from_date = add_months(new_to_date, -1 * doc.filter_duration)
 			doc.add_comment("Comment", "Emails sent on: " + frappe.utils.format_datetime(frappe.utils.now()))
 			if doc.report == "General Ledger":
-				doc.db_set("to_date", new_to_date, commit=True)
-				doc.db_set("from_date", new_from_date, commit=True)
+				frappe.db.set_value(doc.doctype, doc.name, "to_date", new_to_date)
+				frappe.db.set_value(doc.doctype, doc.name, "from_date", new_from_date)
 			else:
-				doc.db_set("posting_date", new_to_date, commit=True)
+				frappe.db.set_value(doc.doctype, doc.name, "posting_date", new_to_date)
 		return True
 	else:
 		return False

--- a/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py
@@ -2189,11 +2189,6 @@ class TestPurchaseInvoice(ERPNextTestSuite, StockTestMixin):
 
 	def test_offsetting_entries_for_accounting_dimensions(self):
 		from erpnext.accounts.doctype.account.test_account import create_account
-		from erpnext.accounts.report.trial_balance.test_trial_balance import (
-			clear_dimension_defaults,
-			create_accounting_dimension,
-			disable_dimension,
-		)
 
 		create_account(
 			account_name="Offsetting",
@@ -2201,7 +2196,16 @@ class TestPurchaseInvoice(ERPNextTestSuite, StockTestMixin):
 			parent_account="Temporary Accounts - _TC",
 		)
 
-		create_accounting_dimension(company="_Test Company", offsetting_account="Offsetting - _TC")
+		dim = frappe.get_doc("Accounting Dimension", "Branch")
+		dim.append(
+			"dimension_defaults",
+			{
+				"company": "_Test Company",
+				"reference_document": "Branch",
+				"offsetting_account": "Offsetting - _TC",
+			},
+		)
+		dim.save()
 
 		branch1 = frappe.new_doc("Branch")
 		branch1.branch = "Location 1"
@@ -2238,8 +2242,6 @@ class TestPurchaseInvoice(ERPNextTestSuite, StockTestMixin):
 			voucher_type="Purchase Invoice",
 			additional_columns=["branch"],
 		)
-		clear_dimension_defaults("Branch")
-		disable_dimension()
 
 	def test_repost_accounting_entries(self):
 		# update repost settings

--- a/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
@@ -2246,13 +2246,6 @@ class TestSalesInvoice(ERPNextTestSuite):
 
 	@ERPNextTestSuite.change_settings("Selling Settings", {"allow_multiple_items": True})
 	def test_rounding_adjustment_3(self):
-		from erpnext.accounts.doctype.accounting_dimension.test_accounting_dimension import create_dimension
-
-		# Dimension creates custom field, which does an implicit DB commit as it is a DDL command
-		# Ensure dimension don't have any mandatory fields
-		create_dimension()
-
-		# rollback from tearDown() happens till here
 		si = create_sales_invoice(do_not_save=True)
 		si.items = []
 		for d in [(1122, 2), (1122.01, 1), (1122.01, 1)]:

--- a/erpnext/accounts/doctype/subscription/subscription.py
+++ b/erpnext/accounts/doctype/subscription/subscription.py
@@ -772,7 +772,8 @@ def process_all(subscription: list, posting_date: DateTimeLikeObject | None = No
 		try:
 			subscription = frappe.get_doc("Subscription", subscription_name)
 			subscription.process(posting_date)
-			frappe.db.commit()
+			if not frappe.in_test:
+				frappe.db.commit()
 		except frappe.ValidationError:
 			frappe.db.rollback()
 			subscription.log_error("Subscription failed")

--- a/erpnext/accounts/doctype/tax_withholding_category/test_tax_withholding_category.py
+++ b/erpnext/accounts/doctype/tax_withholding_category/test_tax_withholding_category.py
@@ -18,7 +18,6 @@ class TestTaxWithholdingCategory(ERPNextTestSuite):
 		# create relevant supplier, etc
 		create_records()
 		create_tax_withholding_category_records()
-		make_pan_no_field()
 
 	def validate_tax_withholding_entries(self, doctype, docname, expected_entries):
 		"""Validate tax withholding entries for a document"""
@@ -3998,18 +3997,3 @@ def create_lower_deduction_certificate(
 				"certificate_limit": limit,
 			}
 		).insert()
-
-
-def make_pan_no_field():
-	pan_field = {
-		"Supplier": [
-			{
-				"fieldname": "pan",
-				"label": "PAN",
-				"fieldtype": "Data",
-				"translatable": 0,
-			}
-		]
-	}
-
-	create_custom_fields(pan_field, update=1)

--- a/erpnext/accounts/report/trial_balance/test_trial_balance.py
+++ b/erpnext/accounts/report/trial_balance/test_trial_balance.py
@@ -14,7 +14,6 @@ class TestTrialBalance(ERPNextTestSuite):
 		from erpnext.accounts.doctype.cost_center.test_cost_center import create_cost_center
 		from erpnext.accounts.utils import get_fiscal_year
 
-		self.company = create_company()
 		create_cost_center(
 			cost_center_name="Test Cost Center",
 			company="Trial Balance Company",
@@ -26,7 +25,16 @@ class TestTrialBalance(ERPNextTestSuite):
 			parent_account="Temporary Accounts - TBC",
 		)
 		self.fiscal_year = get_fiscal_year(today(), company="Trial Balance Company")[0]
-		create_accounting_dimension()
+		dim = frappe.get_doc("Accounting Dimension", "Branch")
+		dim.append(
+			"dimension_defaults",
+			{
+				"company": "Trial Balance Company",
+				"automatically_post_balancing_accounting_entry": 1,
+				"offsetting_account": "Offsetting - TBC",
+			},
+		)
+		dim.save()
 
 	def test_offsetting_entries_for_accounting_dimensions(self):
 		"""
@@ -45,7 +53,7 @@ class TestTrialBalance(ERPNextTestSuite):
 		branch2.insert(ignore_if_duplicate=True)
 
 		si = create_sales_invoice(
-			company=self.company,
+			company="Trial Balance Company",
 			debit_to="Debtors - TBC",
 			cost_center="Test Cost Center - TBC",
 			income_account="Sales - TBC",
@@ -57,60 +65,7 @@ class TestTrialBalance(ERPNextTestSuite):
 		si.submit()
 
 		filters = frappe._dict(
-			{"company": self.company, "fiscal_year": self.fiscal_year, "branch": ["Location 1"]}
+			{"company": "Trial Balance Company", "fiscal_year": self.fiscal_year, "branch": ["Location 1"]}
 		)
 		total_row = execute(filters)[1][-1]
 		self.assertEqual(total_row["debit"], total_row["credit"])
-
-
-def create_company(**args):
-	args = frappe._dict(args)
-	company = frappe.get_doc(
-		{
-			"doctype": "Company",
-			"company_name": args.company_name or "Trial Balance Company",
-			"country": args.country or "India",
-			"default_currency": args.currency or "INR",
-			"parent_company": args.get("parent_company"),
-			"is_group": args.get("is_group"),
-		}
-	)
-	company.insert(ignore_if_duplicate=True)
-	return company.name
-
-
-def create_accounting_dimension(**args):
-	args = frappe._dict(args)
-	document_type = args.document_type or "Branch"
-	if frappe.db.exists("Accounting Dimension", document_type):
-		accounting_dimension = frappe.get_doc("Accounting Dimension", document_type)
-		accounting_dimension.disabled = 0
-	else:
-		accounting_dimension = frappe.new_doc("Accounting Dimension")
-		accounting_dimension.document_type = document_type
-		accounting_dimension.insert()
-
-	accounting_dimension.set("dimension_defaults", [])
-	accounting_dimension.append(
-		"dimension_defaults",
-		{
-			"company": args.company or "Trial Balance Company",
-			"automatically_post_balancing_accounting_entry": 1,
-			"offsetting_account": args.offsetting_account or "Offsetting - TBC",
-		},
-	)
-	accounting_dimension.save()
-
-
-def disable_dimension(**args):
-	args = frappe._dict(args)
-	document_type = args.document_type or "Branch"
-	dimension = frappe.get_doc("Accounting Dimension", document_type)
-	dimension.disabled = 1
-	dimension.save()
-
-
-def clear_dimension_defaults(dimension_name):
-	accounting_dimension = frappe.get_doc("Accounting Dimension", dimension_name)
-	accounting_dimension.dimension_defaults = []
-	accounting_dimension.save()

--- a/erpnext/assets/doctype/asset/depreciation.py
+++ b/erpnext/assets/doctype/asset/depreciation.py
@@ -62,7 +62,9 @@ def book_depreciation_entries(date):
 				accounting_dimensions,
 			)
 
-			frappe.db.commit()
+			if not frappe.in_test:
+				frappe.db.commit()
+
 		except Exception as e:
 			frappe.db.rollback()
 			failed_assets.append(asset_name)
@@ -72,7 +74,8 @@ def book_depreciation_entries(date):
 	if failed_assets:
 		set_depr_entry_posting_status_for_failed_assets(failed_assets)
 		notify_depr_entry_posting_error(failed_assets, error_logs)
-	frappe.db.commit()
+	if not frappe.in_test:
+		frappe.db.commit()
 
 
 def get_depreciable_assets_data(date):

--- a/erpnext/assets/doctype/asset_capitalization/test_asset_capitalization.py
+++ b/erpnext/assets/doctype/asset_capitalization/test_asset_capitalization.py
@@ -376,6 +376,7 @@ class TestAssetCapitalization(ERPNextTestSuite):
 				"asset_type": "Composite Component",
 				"purchase_date": pr.posting_date,
 				"available_for_use_date": pr.posting_date,
+				"location": "Test Location",
 			}
 		)
 		consumed_asset_doc.save()

--- a/erpnext/assets/doctype/asset_movement/test_asset_movement.py
+++ b/erpnext/assets/doctype/asset_movement/test_asset_movement.py
@@ -15,7 +15,6 @@ class TestAssetMovement(ERPNextTestSuite):
 		frappe.db.set_value(
 			"Company", "_Test Company", "capital_work_in_progress_account", "CWIP Account - _TC"
 		)
-		make_location()
 
 	def test_movement(self):
 		pr = make_purchase_receipt(item_code="Macbook Pro", qty=1, rate=100000.0, location="Test Location")
@@ -38,10 +37,6 @@ class TestAssetMovement(ERPNextTestSuite):
 
 		if asset.docstatus == 0:
 			asset.submit()
-
-		# check asset movement is created
-		if not frappe.db.exists("Location", "Test Location 2"):
-			frappe.get_doc({"doctype": "Location", "location_name": "Test Location 2"}).insert()
 
 		create_asset_movement(
 			purpose="Transfer",
@@ -121,9 +116,6 @@ class TestAssetMovement(ERPNextTestSuite):
 		if asset.docstatus == 0:
 			asset.submit()
 
-		if not frappe.db.exists("Location", "Test Location 2"):
-			frappe.get_doc({"doctype": "Location", "location_name": "Test Location 2"}).insert()
-
 		movement = frappe.get_doc({"doctype": "Asset Movement", "reference_name": pr.name})
 		self.assertRaises(frappe.ValidationError, movement.cancel)
 
@@ -148,9 +140,6 @@ class TestAssetMovement(ERPNextTestSuite):
 	def test_movement_transaction_date(self):
 		asset = create_asset(item_code="Macbook Pro", do_not_save=1)
 		asset.save().submit()
-
-		if not frappe.db.exists("Location", "Test Location 2"):
-			frappe.get_doc({"doctype": "Location", "location_name": "Test Location 2"}).insert()
 
 		asset_creation_date = frappe.db.get_value(
 			"Asset Movement",
@@ -196,9 +185,3 @@ def create_asset_movement(**args):
 			movement.submit()
 
 	return movement
-
-
-def make_location():
-	for location in ["Pune", "Mumbai", "Nagpur"]:
-		if not frappe.db.exists("Location", location):
-			frappe.get_doc({"doctype": "Location", "location_name": location}).insert(ignore_permissions=True)

--- a/erpnext/buying/doctype/purchase_order/purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.py
@@ -785,7 +785,8 @@ def make_purchase_invoice_from_portal(purchase_order_name: str):
 	if frappe.session.user not in frappe.get_all("Portal User", {"parent": doc.supplier}, pluck="user"):
 		frappe.throw(_("Not Permitted"), frappe.PermissionError)
 	doc.save()
-	frappe.db.commit()
+	if not frappe.in_test:
+		frappe.db.commit()
 	frappe.response["type"] = "redirect"
 	frappe.response.location = "/purchase-invoices/" + doc.name
 

--- a/erpnext/controllers/tests/test_accounts_controller.py
+++ b/erpnext/controllers/tests/test_accounts_controller.py
@@ -1567,25 +1567,10 @@ class TestAccountsController(ERPNextTestSuite):
 
 		frappe.db.set_value("Company", self.company, "cost_center", cc)
 
-	def setup_dimensions(self):
-		# create dimension
-		from erpnext.accounts.doctype.accounting_dimension.test_accounting_dimension import (
-			create_dimension,
-		)
-
-		create_dimension()
-		# make it non-mandatory
-		loc = frappe.get_doc("Accounting Dimension", "Location")
-		for x in loc.dimension_defaults:
-			x.mandatory_for_bs = False
-			x.mandatory_for_pl = False
-		loc.save()
-
 	def test_90_dimensions_filter(self):
 		"""
 		Test workings of dimension filters
 		"""
-		self.setup_dimensions()
 		rate_in_account_currency = 1
 
 		# Invoices
@@ -1653,7 +1638,6 @@ class TestAccountsController(ERPNextTestSuite):
 		self.assertEqual(len(pr.payments), 1)
 
 	def test_91_cr_note_should_inherit_dimension(self):
-		self.setup_dimensions()
 		rate_in_account_currency = 1
 
 		# Invoice
@@ -1698,7 +1682,6 @@ class TestAccountsController(ERPNextTestSuite):
 
 	def test_92_dimension_inhertiance_exc_gain_loss(self):
 		# Sales Invoice in Foreign Currency
-		self.setup_dimensions()
 		rate_in_account_currency = 1
 		dpt = "Research & Development - _TC"
 
@@ -1734,7 +1717,6 @@ class TestAccountsController(ERPNextTestSuite):
 		)
 
 	def test_93_dimension_inheritance_on_advance(self):
-		self.setup_dimensions()
 		dpt = "Research & Development - _TC"
 
 		adv = self.create_payment_entry(amount=1, source_exc_rate=85)

--- a/erpnext/crm/doctype/appointment/appointment.py
+++ b/erpnext/crm/doctype/appointment/appointment.py
@@ -120,7 +120,8 @@ class Appointment(Document):
 		self.auto_assign()
 		self.create_calendar_event()
 		self.save(ignore_permissions=True)
-		frappe.db.commit()
+		if not frappe.in_test:
+			frappe.db.commit()
 
 	def create_lead_and_link(self):
 		# Return if already linked

--- a/erpnext/setup/doctype/company/company.py
+++ b/erpnext/setup/doctype/company/company.py
@@ -926,7 +926,7 @@ def update_transactions_annual_history(company, commit=False):
 	transactions_history = get_all_transactions_annual_history(company)
 	frappe.db.set_value("Company", company, "transactions_annual_history", json.dumps(transactions_history))
 
-	if commit:
+	if commit and not frappe.in_test:
 		frappe.db.commit()
 
 
@@ -935,7 +935,9 @@ def cache_companies_monthly_sales_history():
 	for company in companies:
 		update_company_monthly_sales(company)
 		update_transactions_annual_history(company)
-	frappe.db.commit()
+
+	if not frappe.in_test:
+		frappe.db.commit()
 
 
 @frappe.whitelist()

--- a/erpnext/setup/doctype/company/test_records.json
+++ b/erpnext/setup/doctype/company/test_records.json
@@ -205,6 +205,14 @@
 		"doctype": "Company",
 		"chart_of_accounts": "Standard",
 		"create_chart_of_accounts_based_on": "Standard Template"
+	},
+	{
+		"abbr": "TQC",
+		"company_name": "Test Quality Company",
+		"country": "India",
+		"default_currency": "INR",
+		"doctype": "Company",
+		"chart_of_accounts": "Standard",
+		"create_chart_of_accounts_based_on": "Standard Template"
 	}
-
 ]

--- a/erpnext/setup/doctype/company/test_records.json
+++ b/erpnext/setup/doctype/company/test_records.json
@@ -196,5 +196,15 @@
 		"default_currency": "INR",
 		"doctype": "Company",
 		"create_chart_of_accounts_based_on": "Standard Template"
+	},
+	{
+		"abbr": "_TSS",
+		"company_name": "_Test Support SLA",
+		"country": "India",
+		"default_currency": "INR",
+		"doctype": "Company",
+		"chart_of_accounts": "Standard",
+		"create_chart_of_accounts_based_on": "Standard Template"
 	}
+
 ]

--- a/erpnext/setup/doctype/company/test_records.json
+++ b/erpnext/setup/doctype/company/test_records.json
@@ -180,5 +180,13 @@
 		"default_currency": "ZAR",
 		"doctype": "Company",
 		"create_chart_of_accounts_based_on": "Standard Template"
+	},
+	{
+		"abbr": "_TOIC",
+		"company_name": "_Test Opening Invoice Company",
+		"country": "Pakistan",
+		"default_currency": "INR",
+		"doctype": "Company",
+		"create_chart_of_accounts_based_on": "Standard Template"
 	}
 ]

--- a/erpnext/setup/doctype/company/test_records.json
+++ b/erpnext/setup/doctype/company/test_records.json
@@ -188,5 +188,13 @@
 		"default_currency": "INR",
 		"doctype": "Company",
 		"create_chart_of_accounts_based_on": "Standard Template"
+	},
+	{
+		"abbr": "TBC",
+		"company_name": "Trial Balance Company",
+		"country": "India",
+		"default_currency": "INR",
+		"doctype": "Company",
+		"create_chart_of_accounts_based_on": "Standard Template"
 	}
 ]

--- a/erpnext/stock/doctype/inventory_dimension/test_inventory_dimension.py
+++ b/erpnext/stock/doctype/inventory_dimension/test_inventory_dimension.py
@@ -21,9 +21,6 @@ from erpnext.tests.utils import ERPNextTestSuite
 
 
 class TestInventoryDimension(ERPNextTestSuite):
-	def setUp(self):
-		prepare_test_data()
-
 	def test_validate_inventory_dimension(self):
 		# Can not be child doc
 		inv_dim1 = create_inventory_dimension(
@@ -76,6 +73,7 @@ class TestInventoryDimension(ERPNextTestSuite):
 		self.assertFalse(custom_field)
 
 	def test_inventory_dimension(self):
+		create_warehouse("Shelf Warehouse")
 		warehouse = "Shelf Warehouse - _TC"
 		item_code = "_Test Item"
 
@@ -553,28 +551,6 @@ def get_voucher_sl_entries(voucher_no, fields):
 	return frappe.get_all(
 		"Stock Ledger Entry", filters={"voucher_no": voucher_no}, fields=fields, order_by="creation"
 	)
-
-
-def prepare_test_data():
-	for shelf in ["Shelf 1", "Shelf 2"]:
-		if not frappe.db.exists("Shelf", shelf):
-			frappe.get_doc({"doctype": "Shelf", "shelf_name": shelf}).insert(ignore_permissions=True)
-
-	create_warehouse("Shelf Warehouse")
-
-	for rack in ["Rack 1", "Rack 2"]:
-		if not frappe.db.exists("Rack", rack):
-			frappe.get_doc({"doctype": "Rack", "rack_name": rack}).insert(ignore_permissions=True)
-
-	create_warehouse("Rack Warehouse")
-
-	for site in ["Site 1", "Site 2"]:
-		if not frappe.db.exists("Inv Site", site):
-			frappe.get_doc({"doctype": "Inv Site", "site_name": site}).insert(ignore_permissions=True)
-
-	for store in ["Store 1", "Store 2"]:
-		if not frappe.db.exists("Store", store):
-			frappe.get_doc({"doctype": "Store", "store_name": store}).insert(ignore_permissions=True)
 
 
 def create_inventory_dimension(**args):

--- a/erpnext/stock/doctype/stock_entry/test_stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/test_stock_entry.py
@@ -2421,12 +2421,11 @@ class TestStockEntry(ERPNextTestSuite):
 		Unit test case to check the document naming rule with company condition
 		For Quality Inspection, when created from Stock Entry.
 		"""
-		from erpnext.accounts.report.trial_balance.test_trial_balance import create_company
 		from erpnext.controllers.stock_controller import make_quality_inspections
 		from erpnext.stock.doctype.warehouse.test_warehouse import create_warehouse
 
 		# create a separate company to handle document naming rule with company condition
-		qc_company = create_company(company_name="Test Quality Company")
+		qc_company = "Test Quality Company"
 
 		# create document naming rule based on that for Quality Inspection Doctype
 		qc_naming_rule = frappe.new_doc(

--- a/erpnext/stock/stock_balance.py
+++ b/erpnext/stock/stock_balance.py
@@ -31,7 +31,8 @@ def repost(only_actual=False, allow_negative_stock=False, allow_zero_rate=False,
 	for d in item_warehouses:
 		try:
 			repost_stock(d[0], d[1], allow_zero_rate, only_actual, only_bin, allow_negative_stock)
-			frappe.db.commit()
+			if not frappe.in_test:
+				frappe.db.commit()
 		except Exception:
 			frappe.db.rollback()
 

--- a/erpnext/support/doctype/service_level_agreement/test_service_level_agreement.py
+++ b/erpnext/support/doctype/service_level_agreement/test_service_level_agreement.py
@@ -13,32 +13,6 @@ from erpnext.tests.utils import ERPNextTestSuite
 
 
 class TestServiceLevelAgreement(ERPNextTestSuite):
-	def setUp(self):
-		self.create_company()
-		frappe.db.set_single_value("Support Settings", "track_service_level_agreement", 1)
-		lead = frappe.qb.DocType("Lead")
-		frappe.qb.from_(lead).delete().where(lead.company == self.company).run()
-
-	def create_company(self):
-		name = "_Test Support SLA"
-		company = None
-		if frappe.db.exists("Company", name):
-			company = frappe.get_doc("Company", name)
-		else:
-			company = frappe.get_doc(
-				{
-					"doctype": "Company",
-					"company_name": name,
-					"country": "India",
-					"default_currency": "INR",
-					"create_chart_of_accounts_based_on": "Standard Template",
-					"chart_of_accounts": "Standard",
-				}
-			)
-			company = company.save()
-
-		self.company = company.name
-
 	def test_service_level_agreement(self):
 		# Default Service Level Agreement
 		create_default_service_level_agreement = create_service_level_agreement(
@@ -219,10 +193,9 @@ class TestServiceLevelAgreement(ERPNextTestSuite):
 			doctype=doctype,
 			sla_fulfilled_on=[{"status": "Converted"}],
 		)
-
 		# make lead with default SLA
 		creation = datetime.datetime(2019, 3, 4, 12, 0)
-		lead = make_lead(creation=creation, index=1, company=self.company)
+		lead = make_lead(creation=creation, index=1, company="_Test Support SLA")
 
 		self.assertEqual(lead.service_level_agreement, lead_sla.name)
 		self.assertEqual(lead.response_by, datetime.datetime(2019, 3, 4, 16, 0))
@@ -250,7 +223,7 @@ class TestServiceLevelAgreement(ERPNextTestSuite):
 		)
 
 		creation = datetime.datetime(2020, 3, 4, 4, 0)
-		lead = make_lead(creation, index=2, company=self.company)
+		lead = make_lead(creation, index=2, company="_Test Support SLA")
 
 		frappe.flags.current_time = datetime.datetime(2020, 3, 4, 4, 15)
 		lead.reload()
@@ -284,7 +257,7 @@ class TestServiceLevelAgreement(ERPNextTestSuite):
 		)
 
 		creation = datetime.datetime(2019, 3, 4, 12, 0)
-		lead = make_lead(creation=creation, index=1, company=self.company)
+		lead = make_lead(creation=creation, index=1, company="_Test Support SLA")
 		self.assertEqual(lead.response_by, datetime.datetime(2019, 3, 4, 16, 0))
 
 		# failed with response time only
@@ -311,7 +284,7 @@ class TestServiceLevelAgreement(ERPNextTestSuite):
 
 		# fulfilled with response time only
 		creation = datetime.datetime(2019, 3, 4, 12, 0)
-		lead = make_lead(creation=creation, index=2, company=self.company)
+		lead = make_lead(creation=creation, index=2, company="_Test Support SLA")
 
 		self.assertEqual(lead.service_level_agreement, lead_sla.name)
 		self.assertEqual(lead.response_by, datetime.datetime(2019, 3, 4, 16, 0))
@@ -338,7 +311,7 @@ class TestServiceLevelAgreement(ERPNextTestSuite):
 			apply_sla_for_resolution=0,
 		)
 		creation = datetime.datetime(2019, 3, 4, 12, 0)
-		lead = make_lead(creation=creation, index=4, company=self.company)
+		lead = make_lead(creation=creation, index=4, company="_Test Support SLA")
 		applied_sla = frappe.db.get_value("Lead", lead.name, "service_level_agreement")
 		self.assertFalse(applied_sla)
 

--- a/erpnext/telephony/doctype/call_log/call_log.py
+++ b/erpnext/telephony/doctype/call_log/call_log.py
@@ -190,7 +190,9 @@ def link_existing_conversations(doc, state):
 					call_log = frappe.get_doc("Call Log", log)
 					call_log.add_link(link_type=doc.doctype, link_name=doc.name)
 					call_log.save(ignore_permissions=True)
-				frappe.db.commit()
+
+				if not frappe.in_test:
+					frappe.db.commit()
 	except Exception:
 		frappe.log_error(title=_("Error during caller information update"))
 

--- a/erpnext/tests/test_webform.py
+++ b/erpnext/tests/test_webform.py
@@ -20,7 +20,6 @@ class TestWebsite(ERPNextTestSuite):
 		po1 = create_purchase_order(supplier="Supplier1")
 		po2 = create_purchase_order(supplier="Supplier2")
 
-		create_custom_doctype()
 		create_webform()
 		create_order_assignment(supplier="Supplier1", po=po1.name)
 		create_order_assignment(supplier="Supplier2", po=po2.name)
@@ -56,42 +55,6 @@ def create_user(name, email):
 			"first_name": name,
 			"email": email,
 			"roles": [{"doctype": "Has Role", "role": "Supplier"}],
-		}
-	).insert(ignore_if_duplicate=True)
-
-
-def create_custom_doctype():
-	frappe.get_doc(
-		{
-			"doctype": "DocType",
-			"name": "Order Assignment",
-			"module": "Buying",
-			"custom": 1,
-			"autoname": "field:po",
-			"fields": [
-				{"label": "PO", "fieldname": "po", "fieldtype": "Link", "options": "Purchase Order"},
-				{
-					"label": "Supplier",
-					"fieldname": "supplier",
-					"fieldtype": "Data",
-					"fetch_from": "po.supplier",
-				},
-			],
-			"permissions": [
-				{
-					"create": 1,
-					"delete": 1,
-					"email": 1,
-					"export": 1,
-					"print": 1,
-					"read": 1,
-					"report": 1,
-					"role": "System Manager",
-					"share": 1,
-					"write": 1,
-				},
-				{"read": 1, "role": "Supplier"},
-			],
 		}
 	).insert(ignore_if_duplicate=True)
 

--- a/erpnext/tests/utils.py
+++ b/erpnext/tests/utils.py
@@ -2756,6 +2756,46 @@ class BootStrapTestData:
 					}
 				).insert(ignore_permissions=True)
 
+			if not frappe.db.exists("DocType", "Order Assignment"):
+				frappe.get_doc(
+					{
+						"doctype": "DocType",
+						"name": "Order Assignment",
+						"module": "Buying",
+						"custom": 1,
+						"autoname": "field:po",
+						"fields": [
+							{
+								"label": "PO",
+								"fieldname": "po",
+								"fieldtype": "Link",
+								"options": "Purchase Order",
+							},
+							{
+								"label": "Supplier",
+								"fieldname": "supplier",
+								"fieldtype": "Data",
+								"fetch_from": "po.supplier",
+							},
+						],
+						"permissions": [
+							{
+								"create": 1,
+								"delete": 1,
+								"email": 1,
+								"export": 1,
+								"print": 1,
+								"read": 1,
+								"report": 1,
+								"role": "System Manager",
+								"share": 1,
+								"write": 1,
+							},
+							{"read": 1, "role": "Supplier"},
+						],
+					}
+				).insert(ignore_if_duplicate=True)
+
 	def make_address(self):
 		records = [
 			{

--- a/erpnext/tests/utils.py
+++ b/erpnext/tests/utils.py
@@ -254,6 +254,12 @@ class BootStrapTestData:
 		# custom doctype
 		self.make_custom_doctype()
 
+		# data on custom doctype
+		self.make_shelf()
+		self.make_rack()
+		self.make_inv_site()
+		self.make_store()
+
 		# custom field
 		self.make_custom_field()
 
@@ -2845,6 +2851,58 @@ class BootStrapTestData:
 		}
 
 		create_custom_fields(pan_field, update=1)
+
+	def make_shelf(self):
+		records = [
+			{
+				"doctype": "Shelf",
+				"shelf_name": "Shelf 1",
+			},
+			{
+				"doctype": "Shelf",
+				"shelf_name": "Shelf 2",
+			},
+		]
+		self.make_records(["shelf_name"], records)
+
+	def make_rack(self):
+		records = [
+			{
+				"doctype": "Rack",
+				"rack_name": "Rack 1",
+			},
+			{
+				"doctype": "Rack",
+				"rack_name": "Rack 2",
+			},
+		]
+		self.make_records(["rack_name"], records)
+
+	def make_inv_site(self):
+		records = [
+			{
+				"doctype": "Inv Site",
+				"site_name": "Site 1",
+			},
+			{
+				"doctype": "Inv Site",
+				"site_name": "Site 2",
+			},
+		]
+		self.make_records(["site_name"], records)
+
+	def make_store(self):
+		records = [
+			{
+				"doctype": "Store",
+				"store_name": "Store 1",
+			},
+			{
+				"doctype": "Store",
+				"store_name": "Store 2",
+			},
+		]
+		self.make_records(["store_name"], records)
 
 
 BootStrapTestData()

--- a/erpnext/tests/utils.py
+++ b/erpnext/tests/utils.py
@@ -246,6 +246,10 @@ class BootStrapTestData:
 
 		frappe.db.commit()  # nosemgrep
 
+		# Dimensions
+		# DDL commands have implicit commit
+		self.make_dimensions()
+
 		# custom doctype
 		# DDL commands have implicit commit
 		self.make_custom_doctype()
@@ -2793,6 +2797,33 @@ class BootStrapTestData:
 			},
 		]
 		self.make_records(["address_title", "address_type"], records)
+
+	def make_dimensions(self):
+		records = [
+			{
+				"doctype": "Accounting Dimension",
+				"document_type": "Department",
+				"dimension_defaults": [
+					{
+						"company": "_Test Company",
+						"reference_document": "Department",
+						"default_dimension": "_Test Department - _TC",
+					}
+				],
+			},
+			{
+				"doctype": "Accounting Dimension",
+				"document_type": "Location",
+				"dimension_defaults": [
+					{
+						"company": "_Test Company",
+						"reference_document": "Location",
+						"default_dimension": "Block 1",
+					}
+				],
+			},
+		]
+		self.make_records(["document_type"], records)
 
 
 BootStrapTestData()

--- a/erpnext/tests/utils.py
+++ b/erpnext/tests/utils.py
@@ -2822,6 +2822,10 @@ class BootStrapTestData:
 					}
 				],
 			},
+			{
+				"doctype": "Accounting Dimension",
+				"document_type": "Branch",
+			},
 		]
 		self.make_records(["document_type"], records)
 

--- a/erpnext/tests/utils.py
+++ b/erpnext/tests/utils.py
@@ -8,6 +8,7 @@ from typing import Any, NewType
 import frappe
 from frappe import _
 from frappe.core.doctype.report.report import get_report_module_dotted_path
+from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
 from frappe.tests.utils import load_test_records_for
 from frappe.utils import now_datetime, today
 
@@ -246,13 +247,15 @@ class BootStrapTestData:
 
 		frappe.db.commit()  # nosemgrep
 
-		# Dimensions
 		# DDL commands have implicit commit
+		# Dimensions
 		self.make_dimensions()
 
 		# custom doctype
-		# DDL commands have implicit commit
 		self.make_custom_doctype()
+
+		# custom field
+		self.make_custom_field()
 
 	def update_system_settings(self):
 		system_settings = frappe.get_doc("System Settings")
@@ -2828,6 +2831,20 @@ class BootStrapTestData:
 			},
 		]
 		self.make_records(["document_type"], records)
+
+	def make_custom_field(self):
+		pan_field = {
+			"Supplier": [
+				{
+					"fieldname": "pan",
+					"label": "PAN",
+					"fieldtype": "Data",
+					"translatable": 0,
+				}
+			]
+		}
+
+		create_custom_fields(pan_field, update=1)
 
 
 BootStrapTestData()

--- a/erpnext/tests/utils.py
+++ b/erpnext/tests/utils.py
@@ -975,6 +975,7 @@ class BootStrapTestData:
 	def make_location(self):
 		records = [
 			{"doctype": "Location", "location_name": "Test Location"},
+			{"doctype": "Location", "location_name": "Test Location 2"},
 			{"doctype": "Location", "location_name": "Test Location Area", "is_group": 1, "is_container": 1},
 			{
 				"doctype": "Location",

--- a/erpnext/tests/utils.py
+++ b/erpnext/tests/utils.py
@@ -241,6 +241,7 @@ class BootStrapTestData:
 		self.make_sales_person()
 		self.make_activity_type()
 		self.make_address()
+		self.update_support_settings()
 		self.update_selling_settings()
 		self.update_stock_settings()
 		self.update_system_settings()
@@ -270,6 +271,11 @@ class BootStrapTestData:
 		system_settings.currency_precision = system_settings.float_precision = 2
 		system_settings.rounding_method = "Banker's Rounding"
 		system_settings.save()
+
+	def update_support_settings(self):
+		support_settings = frappe.get_doc("Support Settings")
+		support_settings.track_service_level_agreement = True
+		support_settings.save()
 
 	def update_selling_settings(self):
 		selling_settings = frappe.get_doc("Selling Settings")


### PR DESCRIPTION
1. Move explicit `frappe.db.commit` inside a test guard 
2. Move data on custom doctype creation to bootstrap

continues: https://github.com/frappe/erpnext/pull/47910