### PR TITLE
fix(UX): improve party selection UX with party name field

### DIFF
--- a/erpnext/accounts/doctype/opening_invoice_creation_tool/opening_invoice_creation_tool.js
+++ b/erpnext/accounts/doctype/opening_invoice_creation_tool/opening_invoice_creation_tool.js
@@ -124,7 +124,8 @@ frappe.ui.form.on("Opening Invoice Creation Tool", {
 	invoice_type: function (frm) {
 		$.each(frm.doc.invoices, (idx, row) => {
 			row.party_type = frm.doc.invoice_type == "Sales" ? "Customer" : "Supplier";
-			row.party = "";
+			frappe.model.set_value(row.doctype, row.name, "party", "");
+			frappe.model.set_value(row.doctype, row.name, "party_name", "");
 		});
 		frm.refresh_fields();
 	},

--- a/erpnext/accounts/doctype/opening_invoice_creation_tool/opening_invoice_creation_tool.js
+++ b/erpnext/accounts/doctype/opening_invoice_creation_tool/opening_invoice_creation_tool.js
@@ -50,6 +50,7 @@ frappe.ui.form.on("Opening Invoice Creation Tool", {
 
 	refresh: function (frm) {
 		frm.disable_save();
+		frm.trigger("create_missing_party");
 		!frm.doc.import_in_progress && frm.trigger("make_dashboard");
 		frm.page.set_primary_action(__("Create Invoices"), () => {
 			let btn_primary = frm.page.btn_primary.get(0);
@@ -162,9 +163,35 @@ frappe.ui.form.on("Opening Invoice Creation Tool", {
 			row.party_type = frm.doc.invoice_type == "Sales" ? "Customer" : "Supplier";
 		});
 	},
+
+	create_missing_party: function (frm) {
+		if (frm.doc.create_missing_party) {
+			frm.fields_dict["invoices"].grid.update_docfield_property("party", "reqd", 0);
+			frm.fields_dict["invoices"].grid.update_docfield_property("party_name", "read_only", 0);
+		} else {
+			frm.fields_dict["invoices"].grid.update_docfield_property("party", "reqd", 1);
+			frm.fields_dict["invoices"].grid.update_docfield_property("party_name", "read_only", 1);
+		}
+		frm.refresh_field("invoices");
+	},
 });
 
 frappe.ui.form.on("Opening Invoice Creation Tool Item", {
+	party: function (frm, cdt, cdn) {
+		let row = locals[cdt][cdn];
+		if (!row.party) {
+			frappe.model.set_value(cdt, cdn, "party_name", "");
+			return;
+		}
+
+		let party_type = frm.doc.invoice_type == "Sales" ? "Customer" : "Supplier";
+		let name_field = party_type === "Customer" ? "customer_name" : "supplier_name";
+
+		frappe.db.get_value(party_type, row.party, name_field, (r) => {
+			frappe.model.set_value(cdt, cdn, "party_name", r?.[name_field] || "");
+		});
+	},
+
 	invoices_add: (frm) => {
 		frm.trigger("update_invoice_table");
 	},

--- a/erpnext/accounts/doctype/opening_invoice_creation_tool/opening_invoice_creation_tool.json
+++ b/erpnext/accounts/doctype/opening_invoice_creation_tool/opening_invoice_creation_tool.json
@@ -8,9 +8,9 @@
  "engine": "InnoDB",
  "field_order": [
   "company",
-  "create_missing_party",
   "column_break_3",
   "invoice_type",
+  "create_missing_party",
   "accounting_dimensions_section",
   "cost_center",
   "dimension_col_break",
@@ -29,7 +29,7 @@
   },
   {
    "default": "0",
-   "description": "Create missing customer or supplier.",
+   "description": "If party does not exist, create it using the Party Name field.",
    "fieldname": "create_missing_party",
    "fieldtype": "Check",
    "label": "Create Missing Party"
@@ -65,10 +65,10 @@
    "options": "Cost Center"
   },
   {
-    "fieldname": "project",
-    "fieldtype": "Link",
-    "label": "Project",
-    "options": "Project"
+   "fieldname": "project",
+   "fieldtype": "Link",
+   "label": "Project",
+   "options": "Project"
   },
   {
    "collapsible": 1,
@@ -84,7 +84,7 @@
  "hide_toolbar": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-03-27 13:10:06.564397",
+ "modified": "2026-03-23 00:32:15.600086",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Opening Invoice Creation Tool",
@@ -101,6 +101,7 @@
   }
  ],
  "quick_entry": 1,
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],

--- a/erpnext/accounts/doctype/opening_invoice_creation_tool/opening_invoice_creation_tool.py
+++ b/erpnext/accounts/doctype/opening_invoice_creation_tool/opening_invoice_creation_tool.py
@@ -108,11 +108,10 @@ class OpeningInvoiceCreationTool(Document):
 				frappe.throw(_("Row #{}: Either Party ID or Party Name is required").format(row.idx))
 
 			if not row.party and row.party_name:
-				self.add_party(row.party_type, row.party_name)
-				row.party = row.party_name
+				row.party = self.add_party(row.party_type, row.party_name)
 
 			if row.party and not frappe.db.exists(row.party_type, row.party):
-				self.add_party(row.party_type, row.party)
+				row.party = self.add_party(row.party_type, row.party)
 
 		else:
 			if not row.party:
@@ -171,6 +170,7 @@ class OpeningInvoiceCreationTool(Document):
 
 		party_doc.flags.ignore_mandatory = True
 		party_doc.save(ignore_permissions=True)
+		return party_doc.name
 
 	def get_invoice_dict(self, row=None):
 		def get_item_dict():

--- a/erpnext/accounts/doctype/opening_invoice_creation_tool/opening_invoice_creation_tool.py
+++ b/erpnext/accounts/doctype/opening_invoice_creation_tool/opening_invoice_creation_tool.py
@@ -32,6 +32,7 @@ class OpeningInvoiceCreationTool(Document):
 		create_missing_party: DF.Check
 		invoice_type: DF.Literal["Sales", "Purchase"]
 		invoices: DF.Table[OpeningInvoiceCreationToolItem]
+		project: DF.Link | None
 	# end: auto-generated types
 
 	def onload(self):
@@ -102,10 +103,21 @@ class OpeningInvoiceCreationTool(Document):
 		row.due_date = row.due_date or nowdate()
 
 	def validate_mandatory_invoice_fields(self, row):
-		if not frappe.db.exists(row.party_type, row.party):
-			if self.create_missing_party:
+		if self.create_missing_party:
+			if not row.party and not row.party_name:
+				frappe.throw(_("Row #{}: Either Party ID or Party Name is required").format(row.idx))
+
+			if not row.party and row.party_name:
+				self.add_party(row.party_type, row.party_name)
+				row.party = row.party_name
+
+			if row.party and not frappe.db.exists(row.party_type, row.party):
 				self.add_party(row.party_type, row.party)
-			else:
+
+		else:
+			if not row.party:
+				frappe.throw(_("Row #{}: Party ID is required").format(row.idx))
+			if not frappe.db.exists(row.party_type, row.party):
 				frappe.throw(
 					_("Row #{}: {} {} does not exist.").format(
 						row.idx, frappe.bold(row.party_type), frappe.bold(row.party)
@@ -113,7 +125,7 @@ class OpeningInvoiceCreationTool(Document):
 				)
 
 		mandatory_error_msg = _("Row #{0}: {1} is required to create the Opening {2} Invoices")
-		for d in ("Party", "Outstanding Amount", "Temporary Opening Account"):
+		for d in ("Outstanding Amount", "Temporary Opening Account"):
 			if not row.get(scrub(d)):
 				frappe.throw(mandatory_error_msg.format(row.idx, d, self.invoice_type))
 

--- a/erpnext/accounts/doctype/opening_invoice_creation_tool/opening_invoice_creation_tool_dashboard.html
+++ b/erpnext/accounts/doctype/opening_invoice_creation_tool/opening_invoice_creation_tool_dashboard.html
@@ -1,5 +1,5 @@
 {% $.each(data, (company, summary) => { %}
-<h6 style="margin: 15px 0px -10px 0px;"><a class="company-link"> {{ company }}</a></h6>
+<div style="margin: 15px 0px -10px 0px;"> {{ company }}</div>
 
 <table class="table table-bordered small">
 	<thead>
@@ -23,7 +23,7 @@
 			<td class="text-right">
 				{{ format_currency(summary[doctype].outstanding_amount, summary.currency, 2) }}
 			</td>
-		</div>
+		</tr>
 		{% endif %}
 		{% }); %}
 	</tbody>

--- a/erpnext/accounts/doctype/opening_invoice_creation_tool_item/opening_invoice_creation_tool_item.json
+++ b/erpnext/accounts/doctype/opening_invoice_creation_tool_item/opening_invoice_creation_tool_item.json
@@ -8,6 +8,7 @@
   "invoice_number",
   "party_type",
   "party",
+  "party_name",
   "temporary_opening_account",
   "column_break_3",
   "posting_date",
@@ -35,9 +36,9 @@
    "fieldname": "party",
    "fieldtype": "Dynamic Link",
    "in_list_view": 1,
-   "label": "Party",
-   "options": "party_type",
-   "reqd": 1
+   "label": "Party ID",
+   "mandatory_depends_on": "eval: !parent.create_missing_party",
+   "options": "party_type"
   },
   {
    "fieldname": "temporary_opening_account",
@@ -118,11 +119,17 @@
    "fieldname": "supplier_invoice_date",
    "fieldtype": "Date",
    "label": "Supplier Invoice Date"
+  },
+  {
+   "fieldname": "party_name",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Party Name"
   }
  ],
  "istable": 1,
  "links": [],
- "modified": "2025-12-01 16:18:07.997594",
+ "modified": "2026-03-20 02:11:42.023575",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Opening Invoice Creation Tool Item",

--- a/erpnext/accounts/doctype/opening_invoice_creation_tool_item/opening_invoice_creation_tool_item.py
+++ b/erpnext/accounts/doctype/opening_invoice_creation_tool_item/opening_invoice_creation_tool_item.py
@@ -22,7 +22,8 @@ class OpeningInvoiceCreationToolItem(Document):
 		parent: DF.Data
 		parentfield: DF.Data
 		parenttype: DF.Data
-		party: DF.DynamicLink
+		party: DF.DynamicLink | None
+		party_name: DF.Data | None
 		party_type: DF.Link | None
 		posting_date: DF.Date | None
 		qty: DF.Data | None


### PR DESCRIPTION
Adds a `Party Name` field to the invoice table to support creating missing parties during opening invoice entry.

**Changes:**
- `Party Name` auto-fills when a Party ID is selected
- When `Create Missing Party` is checked, Party Name becomes editable and either Party ID or Party Name is required
- When unchecked, Party ID is mandatory and Party Name is read-only