### PR TITLE
fix: BootStrapTestData should not be at module level

### DIFF
--- a/erpnext/hooks.py
+++ b/erpnext/hooks.py
@@ -319,6 +319,8 @@ has_website_permission = {
 	"Project": "erpnext.controllers.website_list_for_contact.has_website_permission",
 }
 
+before_tests = "erpnext.setup.utils.before_tests"
+
 
 period_closing_doctypes = [
 	"Sales Invoice",

--- a/erpnext/setup/utils.py
+++ b/erpnext/setup/utils.py
@@ -10,6 +10,16 @@ from frappe.utils.nestedset import get_root_of
 from erpnext import get_default_company
 
 
+def before_tests():
+	frappe.clear_cache()
+	from erpnext.tests.utils import BootStrapTestData
+
+	BootStrapTestData()
+	_enable_all_roles_for_admin()
+	set_defaults_for_tests()
+	frappe.db.commit()
+
+
 def get_pegged_currencies():
 	pegged_currencies = frappe.get_all(
 		"Pegged Currency Details",

--- a/erpnext/tests/utils.py
+++ b/erpnext/tests/utils.py
@@ -2795,9 +2795,6 @@ class BootStrapTestData:
 		self.make_records(["address_title", "address_type"], records)
 
 
-BootStrapTestData()
-
-
 class ERPNextTestSuite(unittest.TestCase):
 	@classmethod
 	def registerAs(cls, _as):


### PR DESCRIPTION
In erpnext/tests/utils.py, BootStrapTestData() is called at module level, so it runs every time any file imports from erpnext.tests.utils. This crashes in parallel test runs because master data already exists.

The commits which caused this breaking: https://github.com/frappe/erpnext/commit/518800cd2f5e7fef00e70a5c90da14af2a5e522c and https://github.com/frappe/erpnext/commit/5a4a77f5d27510ce809923b81028a8f59b3a9dba

