### PR TITLE
fix(manufacturing): update non-stock item dict

### DIFF
--- a/erpnext/manufacturing/doctype/bom/bom.py
+++ b/erpnext/manufacturing/doctype/bom/bom.py
@@ -1613,13 +1613,14 @@ def add_non_stock_items_cost(stock_entry, work_order, expense_account, job_card=
 	if work_order and not job_card:
 		table = "exploded_items" if work_order.get("use_multi_level_bom") else "items"
 
-	items = {}
+	items = frappe._dict()
 	for d in bom.get(table):
 		# Phantom item is exploded, so its cost is considered via its components
 		if d.get("is_phantom_item"):
 			continue
 
-		items.setdefault(d.item_code, d.amount)
+		items.setdefault(d.item_code, 0)
+		items[d.item_code] += flt(d.amount)
 
 	non_stock_items = frappe.get_all(
 		"Item",


### PR DESCRIPTION
**Issue:**
While calculating the additional costs(for non-stock items) in manufacturing stock entry, the system is considering only one non-stock Raw Material amount, if it contains duplicate items.

**Description:**
When a BOM contains multiple line items of the same non-stock item, the system incorrectly considers only the first occurrence of that item code when calculating the additional amount during the creation of the Stock Entry (type: Manufacture).
All subsequent duplicate non-stock lines with the same item code are ignored, leading to under-calculation of the total additional cost transferred to the finished good.
The expected behavior is that all line items in the BOM’s raw materials table should contribute to the additional amount calculation, regardless of duplicate item codes.

**Ref:** [#61429](https://support.frappe.io/helpdesk/tickets/61429)

**Backport Needed for v15 & v16**