### PR TITLE
fix: check for `submit` permissions instead of `write` permissions when updating status (backport #53697)

### DIFF
--- a/erpnext/buying/doctype/purchase_order/purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.py
@@ -912,7 +912,7 @@ def get_list_context(context=None):
 
 @frappe.whitelist()
 def update_status(status, name):
-	frappe.has_permission("Purchase Order", "write", name, throw=True)
+	frappe.has_permission("Purchase Order", "submit", name, throw=True)
 
 	po = frappe.get_doc("Purchase Order", name)
 	po.update_status(status)

--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -1681,7 +1681,7 @@ def make_work_orders(items, sales_order, company, project=None):
 
 @frappe.whitelist()
 def update_status(status, name):
-	frappe.has_permission("Sales Order", "write", name, throw=True)
+	frappe.has_permission("Sales Order", "submit", name, throw=True)
 
 	so = frappe.get_doc("Sales Order", name)
 	so.update_status(status)

--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
@@ -328,7 +328,10 @@ class PurchaseReceipt(BuyingController):
 			)
 
 	def po_required(self):
-		if frappe.db.get_single_value("Buying Settings", "po_required") == "Yes" and not self.is_internal_transfer():
+		if (
+			frappe.db.get_single_value("Buying Settings", "po_required") == "Yes"
+			and not self.is_internal_transfer()
+		):
 			for d in self.get("items"):
 				if not d.purchase_order:
 					frappe.throw(_("Purchase Order number required for Item {0}").format(d.item_code))
@@ -1415,7 +1418,7 @@ def make_purchase_return(source_name, target_doc=None):
 
 @frappe.whitelist()
 def update_purchase_receipt_status(docname, status):
-	frappe.has_permission("Purchase Receipt", "write", docname, throw=True)
+	frappe.has_permission("Purchase Receipt", "submit", docname, throw=True)
 
 	pr = frappe.get_doc("Purchase Receipt", docname)
 	pr.update_status(status)


### PR DESCRIPTION
Backport #53697 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Updates**
  * Strengthened access control permissions for status updates on Purchase Orders, Sales Orders, and Purchase Receipts. The system now enforces stricter authorization requirements to ensure proper role-based access. Users and administrators should verify that appropriate permissions are assigned to users who manage document statuses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->