### PR TITLE
fix(accounts): set supplier name as title field in Purchase Invoice

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
@@ -8,7 +8,6 @@
  "email_append_to": 1,
  "engine": "InnoDB",
  "field_order": [
-  "title",
   "naming_series",
   "supplier",
   "supplier_name",
@@ -209,16 +208,6 @@
   "connections_tab"
  ],
  "fields": [
-  {
-   "allow_on_submit": 1,
-   "default": "{supplier_name}",
-   "fieldname": "title",
-   "fieldtype": "Data",
-   "hidden": 1,
-   "label": "Title",
-   "no_copy": 1,
-   "print_hide": 1
-  },
   {
    "fieldname": "naming_series",
    "fieldtype": "Select",
@@ -1693,7 +1682,7 @@
  "idx": 204,
  "is_submittable": 1,
  "links": [],
- "modified": "2026-03-17 20:44:00.221219",
+ "modified": "2026-03-25 11:45:38.696888",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Purchase Invoice",
@@ -1756,6 +1745,6 @@
  "sort_order": "DESC",
  "states": [],
  "timeline_field": "supplier",
- "title_field": "title",
+ "title_field": "supplier_name",
  "track_changes": 1
 }

--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
@@ -204,7 +204,6 @@ class PurchaseInvoice(BuyingController):
 		taxes_and_charges_deducted: DF.Currency
 		tc_name: DF.Link | None
 		terms: DF.TextEditor | None
-		title: DF.Data | None
 		to_date: DF.Date | None
 		total: DF.Currency
 		total_advance: DF.Currency

--- a/erpnext/buying/doctype/purchase_order/purchase_order.json
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.json
@@ -10,7 +10,6 @@
  "field_order": [
   "supplier_section",
   "company",
-  "title",
   "naming_series",
   "supplier",
   "supplier_name",
@@ -171,17 +170,6 @@
    "fieldname": "supplier_section",
    "fieldtype": "Section Break",
    "options": "fa fa-user"
-  },
-  {
-   "allow_on_submit": 1,
-   "default": "{supplier_name}",
-   "fieldname": "title",
-   "fieldtype": "Data",
-   "hidden": 1,
-   "label": "Title",
-   "no_copy": 1,
-   "print_hide": 1,
-   "reqd": 1
   },
   {
    "fieldname": "naming_series",
@@ -1328,7 +1316,7 @@
  "idx": 105,
  "is_submittable": 1,
  "links": [],
- "modified": "2026-03-09 17:15:29.184682",
+ "modified": "2026-03-25 11:46:18.748951",
  "modified_by": "Administrator",
  "module": "Buying",
  "name": "Purchase Order",

--- a/erpnext/buying/doctype/purchase_order/purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.py
@@ -160,7 +160,6 @@ class PurchaseOrder(BuyingController):
 		taxes_and_charges_deducted: DF.Currency
 		tc_name: DF.Link | None
 		terms: DF.TextEditor | None
-		title: DF.Data
 		to_date: DF.Date | None
 		total: DF.Currency
 		total_net_weight: DF.Float


### PR DESCRIPTION
**Issue:** The Purchase Invoice title does not update when the Supplier is changed and saved. It still shows the old Supplier name instead of the updated one.

**Ref:**[#63364](https://support.frappe.io/helpdesk/tickets/63364)

**Steps to Replicate:**
1. Go to Purchase Invoice → New
2. Set Supplier as ABC and Save the document
3. Update the Supplier field to XYZ
4. Save  the document
5. Observe the document title still shows ABC instead of XYZ

**Before :** 

[Screencast from 23-03-26 05:25:55 PM IST.webm](https://github.com/user-attachments/assets/435b2075-4e01-4130-abed-777e4c099d4d)


**After :** 

[Screencast from 23-03-26 05:18:07 PM IST.webm](https://github.com/user-attachments/assets/82665037-a709-4dda-bf2b-662b61db2d20)

**Backport Needed For V16 and V15**