### PR TITLE
fix(manufacturing): close work order status when stock reservation is…

### DIFF
--- a/erpnext/manufacturing/doctype/work_order/work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/work_order.py
@@ -587,7 +587,7 @@ class WorkOrder(Document):
 		if self.docstatus == 0:
 			status = "Draft"
 		elif self.docstatus == 1:
-			if status != "Stopped":
+			if status != "Stopped" and status != "Closed":
 				status = "Not Started"
 				if flt(self.material_transferred_for_manufacturing) > 0:
 					status = "In Process"

--- a/erpnext/manufacturing/doctype/work_order/work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/work_order.py
@@ -587,7 +587,7 @@ class WorkOrder(Document):
 		if self.docstatus == 0:
 			status = "Draft"
 		elif self.docstatus == 1:
-			if status != "Stopped" and status != "Closed":
+			if status not in ["Closed", "Stopped"]:
 				status = "Not Started"
 				if flt(self.material_transferred_for_manufacturing) > 0:
 					status = "In Process"


### PR DESCRIPTION
**Issue :** When attempting to close a Work Order with Stock Reservation enabled, the status does not update to "Closed" as expected. It still shows the old status "Not Started"

fixes https://github.com/frappe/erpnext/issues/53709

**Steps to Replicate:**
1. Create a Work Order and enable Stock Reservation
2. Submit the Work Order
3. Close the Work Order
4. Observe the status does not update to "Closed"

**Before :** 

[Screencast from 23-03-26 06:43:45 PM IST.webm](https://github.com/user-attachments/assets/567352b1-945b-47a7-9998-04abed9b77b5)


**After :**  

[Screencast from 23-03-26 06:42:53 PM IST.webm](https://github.com/user-attachments/assets/dbcf5ab7-5f10-41ad-af64-f34df35f3b42)

**Backport Needed for V16 and V15**