### PR TITLE
fix: skip overwriting existing asset fields with accounting dimensions

### DIFF
--- a/erpnext/controllers/buying_controller.py
+++ b/erpnext/controllers/buying_controller.py
@@ -1094,7 +1094,8 @@ class BuyingController(SubcontractingController):
 		for dimension in accounting_dimensions[0]:
 			fieldname = dimension["fieldname"]
 			default_dimension = accounting_dimensions[1].get(self.company, {}).get(fieldname)
-			asset.update({fieldname: row.get(fieldname) or self.get(fieldname) or default_dimension})
+			if not asset.get(fieldname):
+				asset.update({fieldname: row.get(fieldname) or self.get(fieldname) or default_dimension})
 
 		asset.flags.ignore_validate = True
 		asset.flags.ignore_mandatory = True


### PR DESCRIPTION
<img width="1016" height="388" alt="Screenshot 2026-03-24 at 2 21 02 AM" src="https://github.com/user-attachments/assets/7adec9eb-69b4-416e-ae0d-2d9c0f3848b8" />
