### PR TITLE
Use query-builder permission conditions in General Ledger

### DIFF
--- a/erpnext/accounts/report/general_ledger/general_ledger.py
+++ b/erpnext/accounts/report/general_ledger/general_ledger.py
@@ -14,7 +14,7 @@ from erpnext.accounts.doctype.accounting_dimension.accounting_dimension import (
 )
 from erpnext.accounts.report.financial_statements import get_cost_centers_with_children
 from erpnext.accounts.report.utils import convert_to_presentation_currency, get_currency
-from erpnext.accounts.utils import get_account_currency
+from erpnext.accounts.utils import build_qb_match_conditions, get_account_currency
 
 DEBIT_CREDIT_DICT = {
 	"debit": 0.0,
@@ -322,10 +322,8 @@ def get_conditions(filters):
 	if not filters.get("show_cancelled_entries"):
 		conditions.append("is_cancelled = 0")
 
-	from frappe.desk.reportview import build_match_conditions
-
-	if match_conditions := build_match_conditions("GL Entry"):
-		conditions.append(f"({match_conditions})")
+	if user_permission_condition := get_user_permission_condition():
+		conditions.append(f"({user_permission_condition})")
 
 	accounting_dimensions = get_accounting_dimensions(as_list=False)
 
@@ -343,6 +341,17 @@ def get_conditions(filters):
 						conditions.append(f"{dimension.fieldname} in %({dimension.fieldname})s")
 
 	return "and {}".format(" and ".join(conditions)) if conditions else ""
+
+
+def get_user_permission_condition():
+	if not (match_conditions := build_qb_match_conditions("GL Entry")):
+		return ""
+
+	quote_char = '"' if frappe.db.db_type == "postgres" else "`"
+	return Criterion.all(match_conditions).get_sql(
+		quote_char=quote_char,
+		secondary_quote_char="'",
+	)
 
 
 def get_party_name_map():

--- a/erpnext/accounts/report/general_ledger/test_general_ledger.py
+++ b/erpnext/accounts/report/general_ledger/test_general_ledger.py
@@ -1,12 +1,14 @@
 # Copyright (c) 2022, Frappe Technologies Pvt. Ltd. and Contributors
 # MIT License. See license.txt
 
+from unittest.mock import patch
+
 import frappe
 from frappe import qb
 from frappe.utils import flt, today
 
 from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_sales_invoice
-from erpnext.accounts.report.general_ledger.general_ledger import execute
+from erpnext.accounts.report.general_ledger.general_ledger import execute, get_conditions
 from erpnext.controllers.sales_and_purchase_return import make_return_doc
 from erpnext.tests.utils import ERPNextTestSuite
 
@@ -332,3 +334,31 @@ class TestGeneralLedger(ERPNextTestSuite):
 		)
 		actual = set([x.voucher_no for x in data if x.voucher_no])
 		self.assertEqual(expected, actual)
+
+	def test_get_conditions_uses_qb_user_permission_conditions(self):
+		rendered_condition = "`tabGL Entry`.`company` in ('_Test Company')"
+		filters = frappe._dict(
+			{
+				"company": "_Test Company",
+				"from_date": today(),
+				"to_date": today(),
+			}
+		)
+
+		with (
+			patch(
+				"erpnext.accounts.report.general_ledger.general_ledger.build_qb_match_conditions",
+				return_value=[object()],
+			),
+			patch(
+				"erpnext.accounts.report.general_ledger.general_ledger.get_accounting_dimensions",
+				return_value=[],
+			),
+			patch("frappe.get_single_value", return_value=0),
+			patch("erpnext.accounts.report.general_ledger.general_ledger.Criterion.all") as criterion_all,
+		):
+			criterion_all.return_value.get_sql.return_value = rendered_condition
+
+			conditions = get_conditions(filters)
+
+		self.assertIn(f"({rendered_condition})", conditions)


### PR DESCRIPTION
This updates the General Ledger report to use query-builder permission conditions for `GL Entry` instead of the raw match condition string.

It also adds a regression test for the generated condition.

Tested with:
- `python3 -m py_compile erpnext/accounts/report/general_ledger/general_ledger.py erpnext/accounts/report/general_ledger/test_general_ledger.py`
- `git diff --check`

Closes #53731
