### PR TITLE
fix(manufacturing): update condition for base hour rate calculation

### DIFF
--- a/erpnext/manufacturing/doctype/bom/bom.py
+++ b/erpnext/manufacturing/doctype/bom/bom.py
@@ -991,12 +991,14 @@ class BOM(WebsiteGenerator):
 					hour_rate / flt(self.conversion_rate) if self.conversion_rate and hour_rate else hour_rate
 				)
 
-		if row.hour_rate and row.time_in_mins:
+		if row.hour_rate:
 			row.base_hour_rate = flt(row.hour_rate) * flt(self.conversion_rate)
-			row.operating_cost = flt(row.hour_rate) * flt(row.time_in_mins) / 60.0
-			row.base_operating_cost = flt(row.operating_cost) * flt(self.conversion_rate)
-			row.cost_per_unit = row.operating_cost / (row.batch_size or 1.0)
-			row.base_cost_per_unit = row.base_operating_cost / (row.batch_size or 1.0)
+
+			if row.time_in_mins:
+				row.operating_cost = flt(row.hour_rate) * flt(row.time_in_mins) / 60.0
+				row.base_operating_cost = flt(row.operating_cost) * flt(self.conversion_rate)
+				row.cost_per_unit = row.operating_cost / (row.batch_size or 1.0)
+				row.base_cost_per_unit = row.base_operating_cost / (row.batch_size or 1.0)
 
 		if update_hour_rate:
 			row.db_update()


### PR DESCRIPTION
**Issue:**
In the BOM Operation child table, the Base Hour Rate is not calculated if the Operation Time is not given (when Operation Time is 0).
As a result, even if the Hour Rate is entered, the system does not compute the Base Hour Rate (which is required for correct costing in Work Orders and Manufacturing). The Base Hour Rate field remains zero, leading to incorrect operation cost calculation in the work order.

**Ref:** [#63090](https://support.frappe.io/helpdesk/tickets/63090)

**Backport Needed for v15 & v16**