### PR TITLE
fix: show current stock qty in Stock Entry PDF

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -202,6 +202,13 @@ class StockEntry(StockController, SubcontractingInwardController):
 			)
 
 	def onload(self):
+		self.update_item_bin_details()
+
+	def before_print(self, settings=None):
+		super().before_print(settings)
+		self.update_item_bin_details()
+
+	def update_item_bin_details(self):
 		for item in self.get("items"):
 			item.update(get_bin_details(item.item_code, item.s_warehouse or item.t_warehouse))
 

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -202,11 +202,11 @@ class StockEntry(StockController, SubcontractingInwardController):
 			)
 
 	def onload(self):
-		self.update_item_bin_details()
+		self.update_items_from_bin_details()
 
 	def before_print(self, settings=None):
 		super().before_print(settings)
-		self.update_item_bin_details()
+		self.update_items_from_bin_details()
 
 	def update_items_from_bin_details(self):
 		for item in self.get("items"):

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -208,7 +208,7 @@ class StockEntry(StockController, SubcontractingInwardController):
 		super().before_print(settings)
 		self.update_item_bin_details()
 
-	def update_item_bin_details(self):
+	def update_items_from_bin_details(self):
 		for item in self.get("items"):
 			item.update(get_bin_details(item.item_code, item.s_warehouse or item.t_warehouse))
 


### PR DESCRIPTION
## Summary
- Stock Entry PDF  shows historical `actual_qty` (from Stock Ledger at posting time)
  while print preview shows current stock (from Bin table via `onload`)
- Extract bin details update into `update_item_bin_details()` and call it
  from both `onload` and `before_print` so PDF renders match print preview

## Before Fix
[Screencast from 2026-03-24 23-44-17.webm](https://github.com/user-attachments/assets/8f73f617-0df9-49f2-805d-47e8835a9dbf)

## After Fix
[Screencast from 2026-03-24 23-49-06.webm](https://github.com/user-attachments/assets/e16d6d38-94fc-4b62-bdd8-55dad533647b)

**Support Ticket**: [https://support.frappe.io/helpdesk/tickets/62363](https://support.frappe.io/helpdesk/tickets/62363)