### PR TITLE
fix(manufacturing): apply work order status filter in job card

### DIFF
--- a/erpnext/manufacturing/doctype/job_card/job_card.js
+++ b/erpnext/manufacturing/doctype/job_card/job_card.js
@@ -40,6 +40,14 @@ frappe.ui.form.on("Job Card", {
 			};
 		});
 
+		frm.set_query("work_order", function () {
+			return {
+				filters: {
+					status: ["not in", ["Cancelled", "Closed", "Stopped"]],
+				},
+			};
+		});
+
 		frm.events.set_company_filters(frm, "target_warehouse");
 		frm.events.set_company_filters(frm, "source_warehouse");
 		frm.events.set_company_filters(frm, "wip_warehouse");


### PR DESCRIPTION
**Issue:** Job Card - Work Order field displays all Work Orders, including Cancelled, Closed, and Stopped.

**Description:** 
When creating a Job Card, the Work Order field shows all Work Orders including Cancelled, Closed, and Stopped ones. Users should only see active Work Orders to prevent linking a Job Card to an inactive Work Order.

**Steps to Replicate :**
1. Open Work Order
2. Create three Work Orders and set their status to Cancelled, Closed and Stopped
3. Go to Manufacturing → Job Card → New
4. Click on the Work Order field
5. Notice that Cancelled, Closed and Stopped Work Orders appear in the dropdown

**Expected Behavior :**
Work Order dropdown should only show active Work Orders

**Before :** 

[Screencast from 25-03-26 11:11:38 AM IST.webm](https://github.com/user-attachments/assets/8ec44703-44ca-4e4f-99d6-312635118797)

**After :** 

[Screencast from 25-03-26 11:10:31 AM IST.webm](https://github.com/user-attachments/assets/f99e34d3-90c6-4dfd-955f-2cfa1042c2fd)

**Backport Needed For V16 and V15**