### PR TITLE
fix(manufacturing): apply work order status filter in job card

### DIFF
--- a/erpnext/manufacturing/doctype/job_card/job_card.js
+++ b/erpnext/manufacturing/doctype/job_card/job_card.js
@@ -31,8 +31,6 @@ frappe.ui.form.on("Job Card", {
 			};
 		});
 
-<<<<<<< HEAD
-=======
 		frm.set_query("operation", "time_logs", () => {
 			let operations = (frm.doc.sub_operations || []).map((d) => d.sub_operation);
 			return {
@@ -61,7 +59,6 @@ frappe.ui.form.on("Job Card", {
 			};
 		});
 
->>>>>>> d43d308e2f (fix(manufacturing): apply work order status filter in job card (#53766))
 		frm.set_indicator_formatter("sub_operation", function (doc) {
 			if (doc.status == "Pending") {
 				return "red";


### PR DESCRIPTION
Backport : [#53767](https://github.com/frappe/erpnext/pull/53767)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved leftover merge conflict markers that were interfering with field query functionality in the Job Card module, restoring proper behavior for operation field queries in time tracking workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->