### PR TITLE
fix(stock): update company validation for expense account in lcv

### DIFF
--- a/erpnext/stock/doctype/landed_cost_voucher/landed_cost_voucher.py
+++ b/erpnext/stock/doctype/landed_cost_voucher/landed_cost_voucher.py
@@ -12,6 +12,7 @@ from frappe.query_builder.custom import ConstantColumn
 from frappe.utils import cint, flt
 
 import erpnext
+from erpnext import is_perpetual_inventory_enabled
 from erpnext.controllers.taxes_and_totals import init_landed_taxes_and_totals
 from erpnext.stock.doctype.serial_no.serial_no import get_serial_nos
 
@@ -177,6 +178,9 @@ class LandedCostVoucher(Document):
 				)
 
 	def validate_expense_accounts(self):
+		if not is_perpetual_inventory_enabled(self.company):
+			return
+
 		for t in self.taxes:
 			company = frappe.get_cached_value("Account", t.expense_account, "company")
 

--- a/erpnext/stock/doctype/landed_cost_voucher/test_landed_cost_voucher.py
+++ b/erpnext/stock/doctype/landed_cost_voucher/test_landed_cost_voucher.py
@@ -180,12 +180,28 @@ class TestLandedCostVoucher(ERPNextTestSuite):
 		self.assertEqual(last_sle_after_landed_cost.stock_value - last_sle.stock_value, 50.0)
 
 	def test_lcv_validates_company(self):
+		from erpnext import is_perpetual_inventory_enabled
+		from erpnext.accounts.doctype.account.test_account import create_account
 		from erpnext.stock.doctype.landed_cost_voucher.landed_cost_voucher import (
 			IncorrectCompanyValidationError,
 		)
 
 		company_a = "_Test Company"
 		company_b = "_Test Company with perpetual inventory"
+
+		srbnb = create_account(
+			account_name="Stock Received But Not Billed",
+			account_type="Stock Received But Not Billed",
+			parent_account="Stock Liabilities - _TC",
+			company=company_a,
+			account_currency="INR",
+		)
+
+		epi = is_perpetual_inventory_enabled(company_a)
+		company_doc = frappe.get_doc("Company", company_a)
+		company_doc.enable_perpetual_inventory = 1
+		company_doc.stock_received_but_not_billed = srbnb
+		company_doc.save()
 
 		pr = make_purchase_receipt(
 			company=company_a,
@@ -211,6 +227,9 @@ class TestLandedCostVoucher(ERPNextTestSuite):
 		lcv.save()
 		distribute_landed_cost_on_items(lcv)
 		lcv.submit()
+
+		frappe.db.set_value("Company", company_a, "enable_perpetual_inventory", epi)
+		frappe.local.enable_perpetual_inventory = {}
 
 	def test_landed_cost_voucher_for_zero_purchase_rate(self):
 		"Test impact of LCV on future stock balances."


### PR DESCRIPTION
**Issue:**
The system is throwing an error for "Expense Account Company Validation" even when there is no need to provide an Expense Account.

**Description:**
When Perpetual Inventory is disabled for the company, users should be allowed to create and submit Landed Cost Voucher without entering an Expense Account, as no GL entries are posted. However, the system is still enforcing the company validation check on the Expense Account field, causing unnecessary errors and preventing document submission.

**Backport Needed for v15 & v16**