### PR TITLE
fix: deduct process loss qty from manufacturing qty along with produc…

### DIFF
--- a/erpnext/manufacturing/doctype/work_order/work_order.js
+++ b/erpnext/manufacturing/doctype/work_order/work_order.js
@@ -991,7 +991,10 @@ erpnext.work_order = {
 			max = flt(frm.doc.qty) - flt(frm.doc.produced_qty);
 		} else {
 			if (purpose === "Manufacture") {
-				max = flt(frm.doc.material_transferred_for_manufacturing) - flt(frm.doc.produced_qty);
+				max =
+					flt(frm.doc.material_transferred_for_manufacturing) -
+					flt(frm.doc.produced_qty) -
+					flt(frm.doc.process_loss_qty);
 			} else {
 				max = flt(frm.doc.qty) - flt(frm.doc.material_transferred_for_manufacturing);
 			}


### PR DESCRIPTION
**Ref**: [#53742 ](https://github.com/frappe/erpnext/issues/53742)

**Description**: When any Work Order is partially finished with a process loss percentage, the system auto-fetches the wrong quantity

**Before**: 
![before](https://github.com/user-attachments/assets/598c0c05-0478-4ad1-b37d-37488c5bafc1)

**After**:
![after](https://github.com/user-attachments/assets/9e937d52-eda7-4931-8ea9-7cc21960b2fb)
