### PR TITLE
fix(UX): Store weekly off at the end of holiday list

### DIFF
--- a/erpnext/setup/doctype/holiday_list/holiday_list.py
+++ b/erpnext/setup/doctype/holiday_list/holiday_list.py
@@ -109,7 +109,7 @@ class HolidayList(Document):
 			)
 
 	def sort_holidays(self):
-		self.holidays.sort(key=lambda x: getdate(x.holiday_date))
+		self.holidays.sort(key=lambda x: (x.weekly_off, getdate(x.holiday_date)))
 		for i in range(len(self.holidays)):
 			self.holidays[i].idx = i + 1
 


### PR DESCRIPTION
Actual holidays are hard to find because we sort by date, this PR adds extra sorting by throwing weekly offs at end of the list.

<img width="1255" height="974" alt="image" src="https://github.com/user-attachments/assets/1f217cb3-7da5-44c7-8961-41d4dff6e1c0" />


---

Perhaps these two should be stored separately too?

