### PR TITLE
ci: semgrep to prevent test regression

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -43,3 +43,6 @@ jobs:
 
       - name: Run Semgrep rules
         run: semgrep ci --config ./frappe-semgrep-rules/rules --config r/python.lang.correctness
+
+      - name: Semgrep for Test Correctness
+        run: semgrep ci --include=**/test_*.py --config ./semgrep/test-correctness.yml

--- a/semgrep/test-correctness.yml
+++ b/semgrep/test-correctness.yml
@@ -1,0 +1,18 @@
+rules:
+- id: Dont-commit
+  pattern: frappe.db.commit()
+  message: Commiting inside test breaks idempotency.
+  languages: [python]
+  severity: ERROR
+- id: Implicit-commit
+  pattern: frappe.db.truncate()
+  message: DB truncation does implict commit which breaks test idempotency.
+  languages: [python]
+  severity: ERROR
+- id: Dont-override-teardown
+  pattern: |
+    def tearDown(...):
+      ...
+  message: ERPNextTestSuite forces rollback on each tearDown, which ensures idempotency. Don't override tearDown.
+  languages: [python]
+  severity: ERROR


### PR DESCRIPTION
Below patterns are blocked.
1. `frappe.db.commit`
2. `frappe.db.truncate` - does implicit commit
3. No overriding of `tearDown()`