### PR TITLE
feat: add Sales Invoice support to POS profile print format filter

### DIFF
--- a/erpnext/accounts/doctype/pos_profile/pos_profile.js
+++ b/erpnext/accounts/doctype/pos_profile/pos_profile.js
@@ -16,7 +16,9 @@ frappe.ui.form.on("POS Profile", {
 
 		frm.set_query("print_format", function () {
 			return {
-				filters: [["Print Format", "doc_type", "=", "POS Invoice"]],
+				filters: [
+					["Print Format", "doc_type", "in", ["POS Invoice", "Sales Invoice"]]
+				],
 			};
 		});
 


### PR DESCRIPTION
Adds support for Sales Invoice in POS Profile print format filter.
In version 16, Sales Invoice can be created directly from POS, but the filter was not applied.
This ensures consistent print format behavior across POS Invoice and Sales Invoice. 
#53857
![WhatsApp Image 2026-03-27 at 9 36 10 PM](https://github.com/user-attachments/assets/2c123ab6-2988-4ac4-baa4-bf2bd106086c)
