### PR TITLE
feat(selling): show customer name in delivery note get items from sales order dialog

### DIFF
--- a/erpnext/stock/doctype/delivery_note/delivery_note.js
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.js
@@ -171,6 +171,7 @@ erpnext.stock.DeliveryNoteController = class DeliveryNoteController extends (
 						target: me.frm,
 						setters: {
 							customer: me.frm.doc.customer,
+							customer_name: me.frm.doc.customer_name,
 						},
 						get_query_filters: {
 							docstatus: 1,


### PR DESCRIPTION
feat(selling): show customer name in delivery note get items from sales order dialog

- add customer_name to child_columns in map_current_doc
- improve clarity when selecting sales orders
- previously only customer ID was shown
- works for both new and existing sales orders
- backported to version-16 branch