### PR TITLE
refactor: setup wizard stages and demo data creation

### DIFF
--- a/erpnext/hooks.py
+++ b/erpnext/hooks.py
@@ -62,7 +62,6 @@ welcome_email = "erpnext.setup.utils.welcome_email"
 # setup wizard
 setup_wizard_requires = "assets/erpnext/js/setup_wizard.js"
 setup_wizard_stages = "erpnext.setup.setup_wizard.setup_wizard.get_setup_stages"
-setup_wizard_complete = "erpnext.setup.setup_wizard.setup_wizard.setup_demo"
 
 after_install = "erpnext.setup.install.after_install"
 

--- a/erpnext/setup/demo.py
+++ b/erpnext/setup/demo.py
@@ -7,7 +7,7 @@ from random import randint
 
 import frappe
 from frappe import _
-from frappe.utils import add_days, getdate
+from frappe.utils import add_days, get_url_to_form, getdate
 
 from erpnext.accounts.doctype.payment_entry.payment_entry import get_payment_entry
 from erpnext.accounts.utils import get_fiscal_year
@@ -16,21 +16,44 @@ from erpnext.selling.doctype.sales_order.sales_order import make_sales_invoice
 from erpnext.setup.setup_wizard.operations.install_fixtures import create_bank_account
 
 
-def setup_demo_data():
+def setup_demo_data(company_name):
 	from frappe.utils.telemetry import capture
 
 	capture("demo_data_creation_started", "erpnext")
 	try:
-		company = create_demo_company()
+		frappe.db.savepoint("demo_data")
+		company = create_demo_company(company_name)
 		process_masters()
 		make_transactions(company)
-		frappe.cache.delete_keys("bootinfo")
-		frappe.publish_realtime("demo_data_complete")
+		capture("demo_data_creation_completed", "erpnext")
+		frappe.clear_messages()
 	except Exception:
-		frappe.log_error("Failed to create demo data")
+		frappe.db.rollback(save_point="demo_data")
+		error_log = frappe.log_error("Failed to create demo data")
+		log_demo_data_failed_notification(error_log)
 		capture("demo_data_creation_failed", "erpnext", properties={"exception": frappe.get_traceback()})
-		raise
-	capture("demo_data_creation_completed", "erpnext")
+
+
+def log_demo_data_failed_notification(error_log):
+	from frappe.core.doctype.role.role import get_users
+	from frappe.desk.doctype.notification_log.notification_log import make_notification_logs
+
+	frappe.msgprint(
+		_("Demo data creation failed. Check notifications for more info."),
+		alert=True,
+		indicator="red",
+		realtime=True,
+	)
+
+	users = get_users("System Manager")
+
+	notif_log_doc = {
+		"subject": _("Demo Data creation failed."),
+		"type": "Alert",
+		"link": get_url_to_form("Error Log", error_log.name),
+	}
+
+	make_notification_logs(notif_log_doc, users)
 
 
 @frappe.whitelist()
@@ -56,21 +79,8 @@ def clear_demo_data():
 		)
 
 
-def create_demo_company():
-	if frappe.flags.in_test:
-		hash = frappe.generate_hash(length=3)
-		company_doc = frappe._dict(
-			{
-				"company_name": "Test Company" + " " + hash,
-				"abbr": "TC" + hash,
-				"default_currency": "INR",
-				"country": "India",
-				"chart_of_accounts": "Standard",
-			}
-		)
-	else:
-		company = frappe.db.get_all("Company")[0].name
-		company_doc = frappe.get_doc("Company", company).as_dict()
+def create_demo_company(company):
+	company_doc = frappe.get_doc("Company", company).as_dict()
 
 	# Make a dummy company
 	new_company = frappe.new_doc("Company")

--- a/erpnext/setup/doctype/company/test_company.py
+++ b/erpnext/setup/doctype/company/test_company.py
@@ -199,7 +199,9 @@ class TestCompany(ERPNextTestSuite):
 	def test_demo_data(self):
 		from erpnext.setup.demo import clear_demo_data, setup_demo_data
 
-		setup_demo_data()
+		self.load_test_records("Company")
+
+		setup_demo_data(self.globalTestRecords["Company"][0]["company_name"])
 		company_name = frappe.db.get_value("Company", {"name": ("like", "%(Demo)")})
 		self.assertTrue(company_name)
 

--- a/erpnext/setup/setup_wizard/setup_wizard.py
+++ b/erpnext/setup/setup_wizard/setup_wizard.py
@@ -10,39 +10,34 @@ from erpnext.setup.setup_wizard.operations import install_fixtures as fixtures
 
 
 def get_setup_stages(args=None):
-	if frappe.db.sql("select name from tabCompany"):
-		stages = [
+	stages = [
+		{
+			"status": _("Installing presets"),
+			"fail_msg": _("Failed to install presets"),
+			"tasks": [{"fn": stage_fixtures, "args": args, "fail_msg": _("Failed to install presets")}],
+		},
+		{
+			"status": _("Setting up company"),
+			"fail_msg": _("Failed to setup company"),
+			"tasks": [{"fn": setup_company, "args": args, "fail_msg": _("Failed to setup company")}],
+		},
+		{
+			"status": _("Setting defaults"),
+			"fail_msg": _("Failed to set defaults"),
+			"tasks": [
+				{"fn": setup_defaults, "args": args, "fail_msg": _("Failed to setup defaults")},
+			],
+		},
+	]
+
+	if args.get("setup_demo"):
+		stages.append(
 			{
-				"status": _("Wrapping up"),
-				"fail_msg": _("Failed to login"),
-				"tasks": [{"fn": fin, "args": args, "fail_msg": _("Failed to login")}],
+				"status": _("Creating demo data"),
+				"fail_msg": _("Failed to create demo data"),
+				"tasks": [{"fn": setup_demo, "args": args, "fail_msg": _("Failed to create demo data")}],
 			}
-		]
-	else:
-		stages = [
-			{
-				"status": _("Installing presets"),
-				"fail_msg": _("Failed to install presets"),
-				"tasks": [{"fn": stage_fixtures, "args": args, "fail_msg": _("Failed to install presets")}],
-			},
-			{
-				"status": _("Setting up company"),
-				"fail_msg": _("Failed to setup company"),
-				"tasks": [{"fn": setup_company, "args": args, "fail_msg": _("Failed to setup company")}],
-			},
-			{
-				"status": _("Setting defaults"),
-				"fail_msg": "Failed to set defaults",
-				"tasks": [
-					{"fn": setup_defaults, "args": args, "fail_msg": _("Failed to setup defaults")},
-				],
-			},
-			{
-				"status": _("Wrapping up"),
-				"fail_msg": _("Failed to login"),
-				"tasks": [{"fn": fin, "args": args, "fail_msg": _("Failed to login")}],
-			},
-		]
+		)
 
 	return stages
 
@@ -59,19 +54,8 @@ def setup_defaults(args):
 	fixtures.install_defaults(frappe._dict(args))
 
 
-def fin(args):
-	frappe.local.message_log = []
-	login_as_first_user(args)
-
-
-def setup_demo(args):
-	if args.get("setup_demo"):
-		frappe.enqueue(setup_demo_data, enqueue_after_commit=True, at_front=True)
-
-
-def login_as_first_user(args):
-	if args.get("email") and hasattr(frappe.local, "login_manager"):
-		frappe.local.login_manager.login_as(args.get("email"))
+def setup_demo(args):  # nosemgrep
+	setup_demo_data(args.get("company_name"))
 
 
 # Only for programmatical use
@@ -79,4 +63,3 @@ def setup_complete(args=None):
 	stage_fixtures(args)
 	setup_company(args)
 	setup_defaults(args)
-	fin(args)


### PR DESCRIPTION
Changes include:
- Removed user login that gets created in Setup Wizard, as Framework handles it. (Ref: https://github.com/frappe/frappe/pull/38260)
- Made demo data creation as one of the setup stages instead of a background job. If demo data creation fails, an alert will show up on the Stages page. A notification log will also be created for every user with the System Manager Role.

Screengrab:

https://github.com/user-attachments/assets/d7716cac-e44f-4763-be81-2930bb428684

