### PR TITLE
fix: change shipment parcel dimension fields from Int to Float

### DIFF
--- a/erpnext/stock/doctype/shipment_parcel/shipment_parcel.json
+++ b/erpnext/stock/doctype/shipment_parcel/shipment_parcel.json
@@ -14,19 +14,19 @@
  "fields": [
   {
    "fieldname": "length",
-   "fieldtype": "Int",
+   "fieldtype": "Float",
    "in_list_view": 1,
    "label": "Length (cm)"
   },
   {
    "fieldname": "width",
-   "fieldtype": "Int",
+   "fieldtype": "Float",
    "in_list_view": 1,
    "label": "Width (cm)"
   },
   {
    "fieldname": "height",
-   "fieldtype": "Int",
+   "fieldtype": "Float",
    "in_list_view": 1,
    "label": "Height (cm)"
   },
@@ -49,7 +49,7 @@
  ],
  "istable": 1,
  "links": [],
- "modified": "2024-03-27 13:10:41.396354",
+ "modified": "2026-03-29 00:00:00.000000",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Shipment Parcel",

--- a/erpnext/stock/doctype/shipment_parcel_template/shipment_parcel_template.json
+++ b/erpnext/stock/doctype/shipment_parcel_template/shipment_parcel_template.json
@@ -15,21 +15,21 @@
  "fields": [
   {
    "fieldname": "length",
-   "fieldtype": "Int",
+   "fieldtype": "Float",
    "in_list_view": 1,
    "label": "Length (cm)",
    "reqd": 1
   },
   {
    "fieldname": "width",
-   "fieldtype": "Int",
+   "fieldtype": "Float",
    "in_list_view": 1,
    "label": "Width (cm)",
    "reqd": 1
   },
   {
    "fieldname": "height",
-   "fieldtype": "Int",
+   "fieldtype": "Float",
    "in_list_view": 1,
    "label": "Height (cm)",
    "reqd": 1
@@ -52,7 +52,7 @@
   }
  ],
  "links": [],
- "modified": "2024-03-27 13:10:41.521126",
+ "modified": "2026-03-29 00:00:00.000000",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Shipment Parcel Template",


### PR DESCRIPTION

## Issue
`length`, `width`, and `height` fields on **Shipment Parcel** and **Shipment Parcel Template** were typed as `Int`, causing decimal values to be truncated (e.g., 1.7 → 1).


## Fix
Changed fieldtype to Float to match weight. No schema migration needed — existing integer values are compatible with Float columns.


https://github.com/user-attachments/assets/013a5d07-ba7d-4bce-892a-6b72c7e63755

### Ref: https://support.frappe.io/helpdesk/tickets/63851