### PR TITLE
fix(stock): ignore qty validation for pick list

### DIFF
--- a/erpnext/stock/doctype/material_request/test_material_request.py
+++ b/erpnext/stock/doctype/material_request/test_material_request.py
@@ -1083,7 +1083,9 @@ class TestMaterialRequest(ERPNextTestSuite):
 
 		pl.locations[0].qty = 2
 		pl.locations[0].stock_qty = 2
-		self.assertRaises(frappe.ValidationError, pl.submit)
+
+		# System should allow picking qty for excess transfer
+		pl.submit()
 
 	def test_mr_status_with_partial_and_excess_end_transit(self):
 		material_request = make_material_request(

--- a/erpnext/stock/doctype/pick_list/pick_list.py
+++ b/erpnext/stock/doctype/pick_list/pick_list.py
@@ -88,6 +88,7 @@ class PickList(TransactionBase):
 				"join_field": "material_request_item",
 				"target_ref_field": "stock_qty",
 				"source_field": "stock_qty",
+				"validate_qty": False,
 			}
 		]
 


### PR DESCRIPTION
**Issue:**
While trying to create a Pick List from a Material Request, the system is throwing a "Limit Crossed" error.
The system should allow picking a quantity greater than the requested quantity in the Material Request (excess quantity picking), especially in cases where users intentionally want to pick extra stock. However, the current validation is preventing this.

**Backport Need for v16**