### PR TITLE
fix: task gantt popup text not visible in light theme

### DIFF
--- a/erpnext/projects/doctype/task/task_list.js
+++ b/erpnext/projects/doctype/task/task_list.js
@@ -35,30 +35,30 @@ frappe.listview_settings["Task"] = {
 	},
 	gantt_custom_popup_html: function (ganttobj, task) {
 		let html = `
-			<a class="text-white mb-2 inline-block cursor-pointer"
-				href="/app/task/${ganttobj.id}"">
+			<a class="mb-2 inline-block cursor-pointer"
+				href="/app/task/${ganttobj.id}">
 				${ganttobj.name}
 			</a>
 		`;
 
 		if (task.project) {
 			html += `<p class="mb-1">${__("Project")}:
-				<a class="text-white inline-block"
-					href="/app/project/${task.project}"">
+				<a class="inline-block"
+					href="/app/project/${task.project}">
 					${task.project}
 				</a>
 			</p>`;
 		}
 		html += `<p class="mb-1">
 			${__("Progress")}:
-			<span class="text-white">${ganttobj.progress}%</span>
+			<span>${ganttobj.progress}%</span>
 		</p>`;
 
 		if (task._assign) {
 			const assign_list = JSON.parse(task._assign);
 			const assignment_wrapper = `
 				<span>Assigned to:</span>
-				<span class="text-white">
+				<span>
 					${assign_list.map((user) => frappe.user_info(user).fullname).join(", ")}
 				</span>
 			`;


### PR DESCRIPTION
**Issue:** 
In the Task doctype Gantt view, the popup text (Task name, Project, Progress) is not visible when the application is in light theme.

**Ref:**  [63424](https://support.frappe.io/helpdesk/tickets/63424) 

**Before:**
<img width="1852" height="965" alt="Screenshot from 2026-03-29 19-05-11" src="https://github.com/user-attachments/assets/90dee3a9-4dea-4316-8912-6f4f82dfc419" />
<img width="1852" height="971" alt="image" src="https://github.com/user-attachments/assets/6e40ce3e-260f-40bd-a398-7ba4aad47f4f" />


**After:**
<img width="1848" height="959" alt="image" src="https://github.com/user-attachments/assets/6f519259-40c6-4b5e-912c-0fc8c6aa3481" />

<img width="1852" height="971" alt="image" src="https://github.com/user-attachments/assets/5a0033b2-fece-438c-a871-c76100eed1ee" />

**Backport Needed for v16**