### PR TITLE
feat: Added Philippines chart of account json file

### DIFF
--- a/erpnext/accounts/doctype/account/chart_of_accounts/verified/philippines.json
+++ b/erpnext/accounts/doctype/account/chart_of_accounts/verified/philippines.json
@@ -20,28 +20,28 @@
 						"root_type": "Asset",
 						"account_type": "Cash"
 					},
-					"Cash in Bank - BPI Mandaluyong": {
-						"account_number": "1102",
-						"is_group": 0,
-						"root_type": "Asset",
-						"account_type": "Cash"
-					},
-					"Cash in Bank - Citibank": {
-						"account_number": "1103",
-						"is_group": 0,
-						"root_type": "Asset",
-						"account_type": "Cash"
-					}
-				},
-				"Petty Cash Fund": {
-					"account_number": "1200",
-					"is_group": 1,
-					"root_type": "Asset",
 					"Petty Cash Fund": {
 						"account_number": "1201",
 						"is_group": 0,
 						"root_type": "Asset",
 						"account_type": "Cash"
+					}
+				},
+				"Bank": {
+					"account_number": "1110",
+					"is_group": 1,
+					"root_type": "Asset",
+					"Cash in Bank - BPI Mandaluyong": {
+						"account_number": "1102",
+						"is_group": 0,
+						"root_type": "Asset",
+						"account_type": "Bank"
+					},
+					"Cash in Bank - Citibank": {
+						"account_number": "1103",
+						"is_group": 0,
+						"root_type": "Asset",
+						"account_type": "Bank"
 					}
 				},
 				"Advances to Officers & Employees": {
@@ -608,6 +608,12 @@
 				"is_group": 0,
 				"root_type": "Expense",
 				"account_type": "Stock Adjustment"
+			},
+			"Expenses Included In Valuation": {
+				"account_number": "5603",
+				"is_group": 0,
+				"root_type": "Expense",
+				"account_type": "Expenses Included In Valuation"
 			},
 			"Depreciation": {
 				"account_number": "5018",

--- a/erpnext/accounts/doctype/account/chart_of_accounts/verified/philippines.json
+++ b/erpnext/accounts/doctype/account/chart_of_accounts/verified/philippines.json
@@ -14,34 +14,24 @@
 					"account_number": "1100",
 					"is_group": 1,
 					"root_type": "Asset",
+					"account_type": "Cash",
 					"Cash on Hand": {
 						"account_number": "1101",
 						"is_group": 0,
 						"root_type": "Asset",
 						"account_type": "Cash"
-					},
+					}
+				},
+				"Petty Cash Fund": {
+					"account_number": "1200",
+					"is_group": 1,
+					"root_type": "Asset",
+					"account_type": "Cash",
 					"Petty Cash Fund": {
 						"account_number": "1201",
 						"is_group": 0,
 						"root_type": "Asset",
 						"account_type": "Cash"
-					}
-				},
-				"Bank": {
-					"account_number": "1110",
-					"is_group": 1,
-					"root_type": "Asset",
-					"Cash in Bank - BPI Mandaluyong": {
-						"account_number": "1102",
-						"is_group": 0,
-						"root_type": "Asset",
-						"account_type": "Bank"
-					},
-					"Cash in Bank - Citibank": {
-						"account_number": "1103",
-						"is_group": 0,
-						"root_type": "Asset",
-						"account_type": "Bank"
 					}
 				},
 				"Advances to Officers & Employees": {

--- a/erpnext/accounts/doctype/account/chart_of_accounts/verified/philippines.json
+++ b/erpnext/accounts/doctype/account/chart_of_accounts/verified/philippines.json
@@ -2,804 +2,902 @@
 	"name": "Philippines",
 	"country": "Philippines",
 	"tree": {
-	  "Asset": {
-		"account_number": "1000",
-		"is_group": 1,
-		"root_type": "Asset",
-		"Current Assets": {
-		  "account_number": "1001",
-		  "is_group": 1,
-		  "root_type": "Asset",
-		  "Cash": {
-			"account_number": "1100",
+		"Asset": {
+			"account_number": "1000",
 			"is_group": 1,
 			"root_type": "Asset",
-			"Cash on Hand": {
-			  "account_number": "1101",
-			  "is_group": 0,
-			  "root_type": "Asset"
-			}
-		  },
-		  "Petty Cash Fund": {
-			"account_number": "1200",
-			"is_group": 0,
-			"root_type": "Asset"
-		  },
-		  "Advances to Officers & Employees": {
-			"account_number": "1300",
-			"is_group": 0,
-			"root_type": "Asset"
-		  },
-		  "Accounts Receivable Trade": {
-			"account_number": "1301",
-			"is_group": 1,
-			"root_type": "Asset",
-			"Accounts Receivable - Trade": {
-			  "account_number": "1302",
-			  "is_group": 0,
-			  "root_type": "Asset",
-			   "account_type": "Receivable"
-
-			}
-		  },
-		  "Accounts Receivable - Affiliates": {
-			"account_number": "1310",
-			"is_group": 0,
-			"root_type": "Asset"
-		  },
-		  "Accounts Receivable - Others": {
-			"account_number": "1400",
-			"is_group": 0,
-			"root_type": "Asset"
-		  },
-		  "Parts, Materials and Supplies": {
-			"account_number": "1500",
-			"is_group": 1,
-			"root_type": "Asset",
-			"Parts, Materials and Supplies": {
-			  "account_number": "1501",
-			  "is_group": 0,
-			  "root_type": "Asset"
+			"Current Assets": {
+				"account_number": "1001",
+				"is_group": 1,
+				"root_type": "Asset",
+				"Cash": {
+					"account_number": "1100",
+					"is_group": 1,
+					"root_type": "Asset",
+					"Cash on Hand": {
+						"account_number": "1101",
+						"is_group": 0,
+						"root_type": "Asset",
+						"account_type": "Cash"
+					},
+					"Cash in Bank - BPI Mandaluyong": {
+						"account_number": "1102",
+						"is_group": 0,
+						"root_type": "Asset",
+						"account_type": "Cash"
+					},
+					"Cash in Bank - Citibank": {
+						"account_number": "1103",
+						"is_group": 0,
+						"root_type": "Asset",
+						"account_type": "Cash"
+					}
+				},
+				"Petty Cash Fund": {
+					"account_number": "1200",
+					"is_group": 1,
+					"root_type": "Asset",
+					"Petty Cash Fund": {
+						"account_number": "1201",
+						"is_group": 0,
+						"root_type": "Asset",
+						"account_type": "Cash"
+					}
+				},
+				"Advances to Officers & Employees": {
+					"account_number": "1290",
+					"is_group": 1,
+					"root_type": "Asset",
+					"Advances to Officers & Employees": {
+						"account_number": "1291",
+						"is_group": 0,
+						"root_type": "Asset"
+					}
+				},
+				"Accounts Receivable Trade": {
+					"account_number": "1300",
+					"is_group": 1,
+					"root_type": "Asset",
+					"Accounts Receivable - Trade": {
+						"account_number": "1301",
+						"is_group": 0,
+						"root_type": "Asset",
+						"account_type": "Receivable"
+					}
+				},
+				"Accounts Receivable - Affiliates": {
+					"account_number": "1310",
+					"is_group": 1,
+					"root_type": "Asset",
+					"Due from Company": {
+						"account_number": "1311",
+						"is_group": 0,
+						"root_type": "Asset"
+					}
+				},
+				"Accounts Receivable - Others": {
+					"account_number": "1400",
+					"is_group": 1,
+					"root_type": "Asset",
+					"Accounts Receivable - Others": {
+						"account_number": "1401",
+						"is_group": 0,
+						"root_type": "Asset"
+					}
+				},
+				"Parts, Materials and Supplies": {
+					"account_number": "1500",
+					"is_group": 1,
+					"root_type": "Asset",
+					"Parts, Materials and Supplies": {
+						"account_number": "1501",
+						"is_group": 0,
+						"root_type": "Asset"
+					},
+					"Raw Materials - Demo": {
+						"account_number": "1502",
+						"is_group": 0,
+						"root_type": "Asset"
+					}
+				},
+				"Project in Progress": {
+					"account_number": "1510",
+					"is_group": 1,
+					"root_type": "Asset",
+					"Project in Progress": {
+						"account_number": "1511",
+						"is_group": 0,
+						"root_type": "Asset"
+					},
+					"Factory Overhead Variance": {
+						"account_number": "1512",
+						"is_group": 0,
+						"root_type": "Asset"
+					}
+				},
+				"Finished Goods": {
+					"account_number": "1520",
+					"is_group": 1,
+					"root_type": "Asset",
+					"Finished Goods Inventory": {
+						"account_number": "1531",
+						"is_group": 0,
+						"root_type": "Asset"
+					},
+					"Inventory in Transit": {
+						"account_number": "1532",
+						"is_group": 0,
+						"root_type": "Asset"
+					},
+					"Stock In Hand": {
+						"account_number": "1550",
+						"is_group": 0,
+						"root_type": "Asset",
+						"account_type": "Stock"
+					}
+				},
+				"Prepayments": {
+					"account_number": "1600",
+					"is_group": 1,
+					"root_type": "Asset",
+					"Prepaid Insurance & Bonds": {
+						"account_number": "1601",
+						"is_group": 0,
+						"root_type": "Asset"
+					},
+					"Prepaid Rent": {
+						"account_number": "1602",
+						"is_group": 0,
+						"root_type": "Asset"
+					}
+				},
+				"VAT Input Tax": {
+					"account_number": "1610",
+					"is_group": 1,
+					"root_type": "Asset",
+					"VAT Input Tax - Goods": {
+						"account_number": "1611",
+						"is_group": 0,
+						"root_type": "Asset",
+						"account_type": "Tax"
+					}
+				}
 			},
-			"Raw Materials - Demo": {
-			  "account_number": "1502",
-			  "is_group": 0,
-			  "root_type": "Asset"
-			}
-		  },
-		  "Project in Progress": {
-			"account_number": "1510",
-			"is_group": 1,
-			"root_type": "Asset",
-			"Project in Progress": {
-			  "account_number": "1511",
-			  "is_group": 0,
-			  "root_type": "Asset"
+			"Non - Current Assets": {
+				"account_number": "1002",
+				"is_group": 1,
+				"root_type": "Asset",
+				"Property, Plants And Equipments": {
+					"account_number": "1700",
+					"is_group": 1,
+					"root_type": "Asset",
+					"Land": {
+						"account_number": "1701",
+						"is_group": 0,
+						"root_type": "Asset"
+					},
+					"Buildings & Improvements": {
+						"account_number": "1702",
+						"is_group": 0,
+						"root_type": "Asset"
+					},
+					"Delivery & Trans Equipment": {
+						"account_number": "1703",
+						"is_group": 0,
+						"root_type": "Asset"
+					},
+					"Furniture & Fixtures": {
+						"account_number": "1704",
+						"is_group": 0,
+						"root_type": "Asset"
+					},
+					"Machinery & Equipment": {
+						"account_number": "1705",
+						"is_group": 0,
+						"root_type": "Asset"
+					}
+				},
+				"Accum Depr. - Property, Plants and Equipment": {
+					"account_number": "1800",
+					"is_group": 1,
+					"root_type": "Asset",
+					"Accumulated Dep Bdgs & Improv": {
+						"account_number": "1801",
+						"is_group": 0,
+						"root_type": "Asset",
+						"account_type": "Accumulated Depreciation"
+					},
+					"Accumulated Dep Delivery & Trans": {
+						"account_number": "1802",
+						"is_group": 0,
+						"root_type": "Asset",
+						"account_type": "Accumulated Depreciation"
+					},
+					"Accumulated Dep Furniture & Fixture": {
+						"account_number": "1803",
+						"is_group": 0,
+						"root_type": "Asset",
+						"account_type": "Accumulated Depreciation"
+					},
+					"Accumulated Depreciation - Machinery & Equipment": {
+						"account_number": "1804",
+						"is_group": 0,
+						"root_type": "Asset",
+						"account_type": "Accumulated Depreciation"
+					}
+				}
 			},
-			"Factory Overhead Variance": {
-			  "account_number": "1512",
-			  "is_group": 0,
-			  "root_type": "Asset"
+			"Other Assets": {
+				"account_number": "1003",
+				"is_group": 1,
+				"root_type": "Asset",
+				"Advances To Supplier": {
+					"account_number": "1900",
+					"is_group": 1,
+					"root_type": "Asset",
+					"Advances To Supplier": {
+						"account_number": "1901",
+						"is_group": 0,
+						"root_type": "Asset"
+					}
+				},
+				"Miscellaneous Deposits": {
+					"account_number": "1910",
+					"is_group": 1,
+					"root_type": "Asset",
+					"Miscellaneous Deposits": {
+						"account_number": "1911",
+						"is_group": 0,
+						"root_type": "Asset"
+					}
+				},
+				"Retirement Fund": {
+					"account_number": "1920",
+					"is_group": 1,
+					"root_type": "Asset",
+					"Retirement Fund": {
+						"account_number": "1921",
+						"is_group": 0,
+						"root_type": "Asset"
+					}
+				},
+				"Investment": {
+					"account_number": "1930",
+					"is_group": 1,
+					"root_type": "Asset",
+					"Investment": {
+						"account_number": "1931",
+						"is_group": 0,
+						"root_type": "Asset"
+					}
+				},
+				"System Development": {
+					"account_number": "1940",
+					"is_group": 1,
+					"root_type": "Asset",
+					"System Development": {
+						"account_number": "1941",
+						"is_group": 0,
+						"root_type": "Asset"
+					}
+				}
 			}
-		  },
-		  "Finished Goods": {
-			"account_number": "1520",
-			"is_group": 1,
-			"root_type": "Asset",
-			"Finished Good Inventory": {
-			  "account_number": "1531",
-			  "is_group": 0,
-			  "root_type": "Asset"
-			},
-			"Inventory in Transit": {
-			  "account_number": "1532",
-			  "is_group": 0,
-			  "root_type": "Asset"
-			}
-		  },
-		  "Prepayments": {
-			"account_number": "1600",
-			"is_group": 1,
-			"root_type": "Asset",
-			"Prepaid Insurance & Bonds": {
-			  "account_number": "1601",
-			  "is_group": 0,
-			  "root_type": "Asset"
-			},
-			"Prepaid Rent": {
-			  "account_number": "1603",
-			  "is_group": 0,
-			  "root_type": "Asset"
-			}
-		  },
-		  "VAT Input Tax": {
-			"account_number": "1610",
-			"is_group": 1,
-			"root_type": "Asset",
-			"VAT Input Tax - Goods": {
-			  "account_number": "1611",
-			  "is_group": 0,
-			  "root_type": "Asset",
-			  "account_type": "Tax"
-			}
-		  }
 		},
-		"Non - Current Assets": {
-		  "account_number": "1002",
-		  "is_group": 1,
-		  "root_type": "Asset",
-		  "Property, Plants And Equipments": {
-			"account_number": "1700",
-			"is_group": 1,
-			"root_type": "Asset",
-			"Land": {
-			  "account_number": "1701",
-			  "is_group": 0,
-			  "root_type": "Asset"
-			},
-			"Buildings & Improvements": {
-			  "account_number": "1702",
-			  "is_group": 0,
-			  "root_type": "Asset"
-			},
-			"Delivery & Trans Equipment": {
-			  "account_number": "1703",
-			  "is_group": 0,
-			  "root_type": "Asset"
-			},
-			"Furniture & Fixtures": {
-			  "account_number": "1704",
-			  "is_group": 0,
-			  "root_type": "Asset"
-			},
-			"Machinery & Equipment": {
-			  "account_number": "1705",
-			  "is_group": 0,
-			  "root_type": "Asset"
-			}
-		  },
-		  "Accum Depr. - Property, Plants and Equipment": {
-			"account_number": "1800",
-			"is_group": 1,
-			"root_type": "Asset",
-			"Accumulated Dep Bdgs & Improv": {
-			  "account_number": "1801",
-			  "is_group": 0,
-			  "root_type": "Asset"
-			},
-			"Accumulated Dep Delivery & Trans": {
-			  "account_number": "1802",
-			  "is_group": 0,
-			  "root_type": "Asset"
-			},
-			"Accumulated Dep Furniture & Fixture": {
-			  "account_number": "1803",
-			  "is_group": 0,
-			  "root_type": "Asset"
-			},
-			"Accumulated Depreciation - Machinery & Equipment": {
-			  "account_number": "1804",
-			  "is_group": 0,
-			  "root_type": "Asset"
-			}
-		  }
-		},
-		"Other Assets": {
-		  "account_number": "1003",
-		  "is_group": 1,
-		  "root_type": "Asset",
-		  "Advances To Supplier": {
-			"account_number": "1900",
-			"is_group": 1,
-			"root_type": "Asset",
-			"Advances To Supplier": {
-			  "account_number": "1901",
-			  "is_group": 0,
-			  "root_type": "Asset"
-			}
-		  },
-		  "Miscellaneous Deposits": {
-			"account_number": "1910",
-			"is_group": 1,
-			"root_type": "Asset",
-			"Miscellaneous Deposits": {
-			  "account_number": "1911",
-			  "is_group": 0,
-			  "root_type": "Asset"
-			}
-		  },
-		  "Retirement Fund": {
-			"account_number": "1920",
-			"is_group": 1,
-			"root_type": "Asset",
-			"Retirement Fund": {
-			  "account_number": "1921",
-			  "is_group": 0,
-			  "root_type": "Asset"
-			}
-		  },
-		  "Investment": {
-			"account_number": "1930",
-			"is_group": 1,
-			"root_type": "Asset",
-			"Investment": {
-			  "account_number": "1931",
-			  "is_group": 0,
-			  "root_type": "Asset"
-			}
-		  },
-		  "System Development": {
-			"account_number": "1940",
-			"is_group": 1,
-			"root_type": "Asset",
-			"System Development": {
-			  "account_number": "1941",
-			  "is_group": 0,
-			  "root_type": "Asset"
-			}
-		  }
-		}
-	  },
-	  "Liability": {
-		"account_number": "2000",
-		"is_group": 1,
-		"root_type": "Liability",
-		"Current Liabilities": {
-		  "account_number": "2001",
-		  "is_group": 1,
-		  "root_type": "Liability",
-		  "Accounts Payable Trade": {
-			"account_number": "2100",
+		"Liability": {
+			"account_number": "2000",
 			"is_group": 1,
 			"root_type": "Liability",
-			"Accounts Payable - Trade": {
-				"account_number": "2101",
-				"is_group": 0,
+			"Current Liabilities": {
+				"account_number": "2001",
+				"is_group": 1,
 				"root_type": "Liability",
-				"account_type": "Payable"
-			  }
-		  },
-		  "Accounts Payable Others": {
-			"account_number": "2110",
-			"is_group": 1,
-			"root_type": "Liability",
-			"Accounts Payable - Payroll": {
-				"account_number": "2111",
-				"is_group": 0,
-				"root_type": "Liability"
-			  }
-		  },
-		  "VAT Output Tax": {
-			"account_number": "2200",
-			"is_group": 1,
-			"root_type": "Liability",
-			"VAT Output Tax": {
-			  "account_number": "2201",
-			  "is_group": 0,
-			  "root_type": "Liability",
-			  "account_type": "Tax"
+				"Accounts Payable Trade": {
+					"account_number": "2100",
+					"is_group": 1,
+					"root_type": "Liability",
+					"Accounts Payable - Trade": {
+						"account_number": "2101",
+						"is_group": 0,
+						"root_type": "Liability",
+						"account_type": "Payable"
+					}
+				},
+				"Accounts Payable Others": {
+					"account_number": "2110",
+					"is_group": 1,
+					"root_type": "Liability",
+					"Accounts Payable - Payroll": {
+						"account_number": "2111",
+						"is_group": 0,
+						"root_type": "Liability"
+					}
+				},
+				"VAT Output Tax": {
+					"account_number": "2200",
+					"is_group": 1,
+					"root_type": "Liability",
+					"VAT Output Tax": {
+						"account_number": "2201",
+						"is_group": 0,
+						"root_type": "Liability",
+						"account_type": "Tax"
+					}
+				},
+				"Withholding Taxes Payable Wages": {
+					"account_number": "2210",
+					"is_group": 1,
+					"root_type": "Liability",
+					"Withholding Taxes Payable Wages": {
+						"account_number": "2211",
+						"is_group": 0,
+						"root_type": "Liability",
+						"account_type": "Tax"
+					}
+				},
+				"Withholding Taxes Payable Expanded": {
+					"account_number": "2220",
+					"is_group": 1,
+					"root_type": "Liability",
+					"Withholding Taxes Payable Expanded": {
+						"account_number": "2221",
+						"is_group": 0,
+						"root_type": "Liability",
+						"account_type": "Tax"
+					}
+				},
+				"Accruals And Other Current Payables": {
+					"account_number": "2300",
+					"is_group": 1,
+					"root_type": "Liability",
+					"Stock Received But Not Billed": {
+						"account_number": "2301",
+						"is_group": 0,
+						"root_type": "Liability",
+						"account_type": "Stock Received But Not Billed"
+					}
+				},
+				"Payable to Government and Other Institutions": {
+					"account_number": "2400",
+					"is_group": 1,
+					"root_type": "Liability",
+					"SSS Premium Payable": {
+						"account_number": "2401",
+						"is_group": 0,
+						"root_type": "Liability"
+					},
+					"SSS Salary Loan Payable": {
+						"account_number": "2402",
+						"is_group": 0,
+						"root_type": "Liability"
+					},
+					"PhilHealth Premium": {
+						"account_number": "2403",
+						"is_group": 0,
+						"root_type": "Liability"
+					},
+					"Pag-ibig Loan Payable": {
+						"account_number": "2404",
+						"is_group": 0,
+						"root_type": "Liability"
+					},
+					"Coop Loans": {
+						"account_number": "2405",
+						"is_group": 0,
+						"root_type": "Liability"
+					},
+					"Coop Contributions": {
+						"account_number": "2406",
+						"is_group": 0,
+						"root_type": "Liability"
+					},
+					"Canteen": {
+						"account_number": "2407",
+						"is_group": 0,
+						"root_type": "Liability"
+					},
+					"AUB Loan Payable": {
+						"account_number": "2408",
+						"is_group": 0,
+						"root_type": "Liability"
+					},
+					"HSBC Loan Payable": {
+						"account_number": "2409",
+						"is_group": 0,
+						"root_type": "Liability"
+					}
+				},
+				"Customer Deposits": {
+					"account_number": "2500",
+					"is_group": 0,
+					"root_type": "Liability"
+				}
+			},
+			"Non Current Liabilities": {
+				"account_number": "2002",
+				"is_group": 1,
+				"root_type": "Liability",
+				"Due To Associated Company": {
+					"account_number": "2600",
+					"is_group": 1,
+					"root_type": "Liability",
+					"Due To Associated Company": {
+						"account_number": "2601",
+						"is_group": 0,
+						"root_type": "Liability"
+					}
+				},
+				"Deferred Income": {
+					"account_number": "2700",
+					"is_group": 1,
+					"root_type": "Liability",
+					"Deferred Income": {
+						"account_number": "2701",
+						"is_group": 0,
+						"root_type": "Liability"
+					}
+				},
+				"Notes Payable": {
+					"account_number": "2800",
+					"is_group": 1,
+					"root_type": "Liability",
+					"Notes Payable": {
+						"account_number": "2801",
+						"is_group": 0,
+						"root_type": "Liability"
+					}
+				},
+				"Dividends Payable": {
+					"account_number": "2900",
+					"is_group": 0,
+					"root_type": "Liability"
+				}
 			}
 		},
-		"Withholding Taxes Payable Wages": {
-			"account_number": "2210",
-			"is_group": 1,
-			"root_type": "Liability",
-			"Withholding Taxes Payable Wages": {
-			  "account_number": "2211",
-			  "is_group": 0,
-			  "root_type": "Liability",
-			  "account_type": "Tax"
-			}
-		},
-		"Withholding Taxes Payable Expanded": {
-			"account_number": "2220",
-			"is_group": 1,
-			"root_type": "Liability",
-			"Withholding Taxes Payable Expanded": {
-			  "account_number": "2221",
-			  "is_group": 0,
-			  "root_type": "Liability",
-			  "account_type": "Tax"
-			}
-		},
-		  "Accruals And Other Current Payables": {
-			"account_number": "2300",
-			"is_group": 1,
-			"root_type": "Liability",
-			"Stock Received But Not Billed": {
-			  "account_number": "2301",
-			  "is_group": 0,
-			  "root_type": "Liability"
-			}
-		  },
-		  "Payable to Government and Other Institutions": {
-			"account_number": "2400",
-			"is_group": 1,
-			"root_type": "Liability",
-			"SSS Premium Payable": {
-			  "account_number": "2401",
-			  "is_group": 0,
-			  "root_type": "Liability"
-			},
-			"SSS Salary Loan Payable": {
-			  "account_number": "2402",
-			  "is_group": 0,
-			  "root_type": "Liability"
-			},
-			"PhilHealth Premium": {
-			  "account_number": "2403",
-			  "is_group": 0,
-			  "root_type": "Liability"
-			},
-			"Coop Loans": {
-			  "account_number": "2407",
-			  "is_group": 0,
-			  "root_type": "Liability"
-			},
-			"Coop Contributions": {
-			  "account_number": "2408",
-			  "is_group": 0,
-			  "root_type": "Liability"
-			},
-			"Canteen": {
-			  "account_number": "2409",
-			  "is_group": 0,
-			  "root_type": "Liability"
-			},
-			"Pag-ibig Loan Payable": {
-			  "account_number": "2404",
-			  "is_group": 0,
-			  "root_type": "Liability"
-			}
-		},
-		  "Customer Deposits": {
-			"account_number": "2500",
-			"is_group": 0,
-			"root_type": "Liability"
-		}
-		},
-		"Non Current Liabilities": {
-		  "account_number": "2002",
-		  "is_group": 1,
-		  "root_type": "Liability",
-		  "Due To Associated Company": {
-			"account_number": "2600",
-			"is_group": 1,
-			"root_type": "Liability",
-			"Due To Associated Company": {
-			  "account_number": "2601",
-			  "is_group": 0,
-			  "root_type": "Liability"
-			}
-		  },
-		  "Deferred Income": {
-			"account_number": "2700",
-			"is_group": 1,
-			"root_type": "Liability",
-			"Deferred Income": {
-			  "account_number": "2701",
-			  "is_group": 0,
-			  "root_type": "Liability"
-			}
-		  },
-		  "Notes Payable": {
-			"account_number": "2800",
-			"is_group": 1,
-			"root_type": "Liability",
-			"Notes Payable": {
-			  "account_number": "2801",
-			  "is_group": 0,
-			  "root_type": "Liability"
-			}
-		  },
-		  "Dividends Payable": {
-			"account_number": "2900",
-			"is_group": 0,
-			"root_type": "Liability"
-		  }
-		}
-	  },
-	  "Equity": {
-		"account_number": "3000",
-		"is_group": 1,
-		"root_type": "Equity",
-		"STOCKHOLDER'S EQUITY": {
-		  "account_number": "3001",
-		  "is_group": 1,
-		  "root_type": "Equity",
-		  "Capital Stocks": {
-			"account_number": "3100",
+		"Equity": {
+			"account_number": "3000",
 			"is_group": 1,
 			"root_type": "Equity",
-			"Capital Stocks": {
-			  "account_number": "3101",
-			  "is_group": 0,
-			  "root_type": "Equity"
+			"STOCKHOLDER'S EQUITY": {
+				"account_number": "3001",
+				"is_group": 1,
+				"root_type": "Equity",
+				"Capital Stocks": {
+					"account_number": "3100",
+					"is_group": 1,
+					"root_type": "Equity",
+					"Capital Stocks": {
+						"account_number": "3101",
+						"is_group": 0,
+						"root_type": "Equity"
+					}
+				},
+				"Subscription Receivable": {
+					"account_number": "3200",
+					"is_group": 1,
+					"root_type": "Equity",
+					"Subscription Receivable": {
+						"account_number": "3201",
+						"is_group": 0,
+						"root_type": "Equity"
+					}
+				},
+				"Retained Earnings": {
+					"account_number": "3300",
+					"is_group": 1,
+					"root_type": "Equity",
+					"Retained Earnings": {
+						"account_number": "3301",
+						"is_group": 0,
+						"root_type": "Equity"
+					}
+				},
+				"Current Year (Profit/Loss)": {
+					"account_number": "3400",
+					"is_group": 0,
+					"root_type": "Equity"
+				},
+				"Drawings": {
+					"account_number": "3500",
+					"is_group": 1,
+					"root_type": "Equity",
+					"Drawings": {
+						"account_number": "3501",
+						"is_group": 0,
+						"root_type": "Equity"
+					}
+				}
 			}
-		  },
-		  "Subscription Receivable": {
-			"account_number": "3200",
-			"is_group": 1,
-			"root_type": "Equity",
-			"Subscription Receivable": {
-			  "account_number": "3201",
-			  "is_group": 0,
-			  "root_type": "Equity"
-			}
-		  },
-		  "Retained Earnings": {
-			"account_number": "3300",
-			"is_group": 1,
-			"root_type": "Equity",
-			"Retained Earnings": {
-			  "account_number": "3301",
-			  "is_group": 0,
-			  "root_type": "Equity"
-			}
-		  },
-		  "Current Year (Profit/Loss)": {
-			"account_number": "3400",
-			"is_group": 0,
-			"root_type": "Equity"
-		  },
-		  "Drawings": {
-			"account_number": "3500",
-			"is_group": 1,
-			"root_type": "Equity",
-			"Drawings": {
-			  "account_number": "3501",
-			  "is_group": 0,
-			  "root_type": "Equity"
-			}
-		  }
-		}
-	  },
-	  "Income": {
-		"account_number": "4000",
-		"is_group": 1,
-		"root_type": "Income",
-		"Gross Sales": {
-		  "account_number": "4100",
-		  "is_group": 1,
-		  "root_type": "Income",
-		  "Sales": {
-			"account_number": "4101",
-			"is_group": 0,
-			"root_type": "Income"
-		  }
 		},
-		"Sales Adjustment": {
-		  "account_number": "4200",
-		  "is_group": 1,
-		  "root_type": "Income",
-		  "Sales Return And Allowance": {
-			"account_number": "4201",
-			"is_group": 0,
-			"root_type": "Income"
-		  }
-		},
-		"Sales Discount": {
-		  "account_number": "4300",
-		  "is_group": 1,
-		  "root_type": "Income",
-		  "Sales Discount": {
-			"account_number": "4301",
-			"is_group": 0,
-			"root_type": "Income"
-		  }
-		},
-		"Other Income": {
-		  "account_number": "6000",
-		  "is_group": 1,
-		  "root_type": "Income",
-		  "Interest Income Bank": {
-			"account_number": "6010",
+		"Income": {
+			"account_number": "4000",
 			"is_group": 1,
 			"root_type": "Income",
-			"Interest Income Bank": {
-			  "account_number": "6011",
-			  "is_group": 0,
-			  "root_type": "Income"
+			"Gross Sales": {
+				"account_number": "4100",
+				"is_group": 1,
+				"root_type": "Income",
+				"Sales": {
+					"account_number": "4101",
+					"is_group": 0,
+					"root_type": "Income"
+				}
+			},
+			"Sales Adjustment": {
+				"account_number": "4200",
+				"is_group": 1,
+				"root_type": "Income",
+				"Sales Return And Allowance": {
+					"account_number": "4201",
+					"is_group": 0,
+					"root_type": "Income"
+				}
+			},
+			"Sales Discount": {
+				"account_number": "4300",
+				"is_group": 1,
+				"root_type": "Income",
+				"Sales Discount": {
+					"account_number": "4301",
+					"is_group": 0,
+					"root_type": "Income"
+				}
+			},
+			"Other Income": {
+				"account_number": "6000",
+				"is_group": 1,
+				"root_type": "Income",
+				"Interest Income Bank": {
+					"account_number": "6010",
+					"is_group": 1,
+					"root_type": "Income",
+					"Interest Income Bank": {
+						"account_number": "6011",
+						"is_group": 0,
+						"root_type": "Income"
+					}
+				},
+				"Dividend Income": {
+					"account_number": "6020",
+					"is_group": 1,
+					"root_type": "Income",
+					"Dividend Income": {
+						"account_number": "6021",
+						"is_group": 0,
+						"root_type": "Income"
+					}
+				},
+				"Exchange Gain": {
+					"account_number": "6030",
+					"is_group": 0,
+					"root_type": "Income"
+				},
+				"Gain/Loss on Asset Disposal": {
+					"account_number": "6031",
+					"is_group": 0,
+					"root_type": "Income"
+				}
 			}
-		  },
-		  "Dividend Income": {
-			"account_number": "6020",
+		},
+		"Expense": {
+			"account_number": "5000",
 			"is_group": 1,
-			"root_type": "Income",
-			"Dividend Income": {
-			  "account_number": "6021",
-			  "is_group": 0,
-			  "root_type": "Income"
-			}
-		  }
-		}
-	  },
-	  "Expense": {
-		"account_number": "5000",
-		"is_group": 1,
-		"root_type": "Expense",
-		"Direct Labor": {
-		  "account_number": "5400",
-		  "is_group": 0,
-		  "root_type": "Expense"
-		},
-		"Factory Overhead": {
-		  "account_number": "5500",
-		  "is_group": 0,
-		  "root_type": "Expense"
-		},
-		"Cost Of Sales": {
-		  "account_number": "5600",
-		  "is_group": 0,
-		  "root_type": "Expense"
-		},
-		"Other Expenses": {
-		  "account_number": "6200",
-		  "is_group": 1,
-		  "root_type": "Expense",
-		  "Bank Charges": {
-			"account_number": "6201",
-			"is_group": 0,
-			"root_type": "Expense"
-		  },
-		  "Interest Expenses Bank": {
-			"account_number": "6202",
-			"is_group": 0,
-			"root_type": "Expense"
-		  }
-		},
-		"Provision For Income Tax": {
-		  "account_number": "6300",
-		  "is_group": 0,
-		  "root_type": "Expense",
-		  "account_type": "Tax"
-		},
-		"OPERATING EXPENSES (Revenue Expenditures)": {
-		  "account_number": "5001",
-		  "is_group": 1,
-		  "root_type": "Expense",
-		  "Salaries, Wages": {
-			"account_number": "5002",
-			"is_group": 0,
-			"root_type": "Expense"
-		  },
-		  "13th Month Pay & Bonus": {
-			"account_number": "5003",
-			"is_group": 0,
-			"root_type": "Expense"
-		  },
-		  "Overtime & Night Diff": {
-			"account_number": "5004",
-			"is_group": 0,
-			"root_type": "Expense"
-		  },
-		  "Incentive/Performance Bonus": {
-			"account_number": "5005",
-			"is_group": 0,
-			"root_type": "Expense"
-		  },
-		  "Employees Benefits": {
-			"account_number": "5006",
-			"is_group": 0,
-			"root_type": "Expense"
-		  },
-		  "Advertising & Promotions": {
-			"account_number": "5007",
-			"is_group": 0,
-			"root_type": "Expense"
-		  },
-		  "Amortization of Leasehold Improvement": {
-			"account_number": "5008",
-			"is_group": 0,
-			"root_type": "Expense"
-		  },
-		  "Amortization of Pre-Operating": {
-			"account_number": "5009",
-			"is_group": 0,
-			"root_type": "Expense"
-		  },
-		  "Amortization of System Development": {
-			"account_number": "5010",
-			"is_group": 0,
-			"root_type": "Expense"
-		  },
-		  "Audit & Legal Fee": {
-			"account_number": "5011",
-			"is_group": 0,
-			"root_type": "Expense"
-		  },
-		  "Bad Debts Expenses": {
-			"account_number": "5012",
-			"is_group": 0,
-			"root_type": "Expense"
-		  },
-		  "Client Service & Maintenance": {
-			"account_number": "5013",
-			"is_group": 0,
-			"root_type": "Expense"
-		  },
-		  "Commission Expenses": {
-			"account_number": "5014",
-			"is_group": 0,
-			"root_type": "Expense"
-		  },
-		  "Communications": {
-			"account_number": "5015",
-			"is_group": 0,
-			"root_type": "Expense"
-		  },
-		  "Contractual Services": {
-			"account_number": "5016",
-			"is_group": 0,
-			"root_type": "Expense"
-		  },
-		  "Depreciation Expenses": {
-			"account_number": "5017",
-			"is_group": 0,
-			"root_type": "Expense"
-		  },
-		  "Donation & Contribution": {
-			"account_number": "5018",
-			"is_group": 0,
-			"root_type": "Expense"
-		  },
-		  "Dues & Subscription": {
-			"account_number": "5019",
-			"is_group": 0,
-			"root_type": "Expense"
-		  },
-		  "Employee Med/Dental/Hosp Expenses": {
-			"account_number": "5020",
-			"is_group": 0,
-			"root_type": "Expense"
-		  },
-		  "Employee Uniforms": {
-			"account_number": "5021",
-			"is_group": 0,
-			"root_type": "Expense"
-		  },
-		  "Equipage": {
-			"account_number": "5022",
-			"is_group": 0,
-			"root_type": "Expense"
-		  },
-		  "Expenses for Reclassification": {
-			"account_number": "5023",
-			"is_group": 0,
-			"root_type": "Expense"
-		  },
-		  "Gas & Oil": {
-			"account_number": "5024",
-			"is_group": 0,
-			"root_type": "Expense"
-		  },
-		  "Insurance Expenses": {
-			"account_number": "5025",
-			"is_group": 0,
-			"root_type": "Expense"
-		  },
-		  "Light & Water": {
-			"account_number": "5026",
-			"is_group": 0,
-			"root_type": "Expense"
-		  },
-		  "Local/Overseas Travel": {
-			"account_number": "5027",
-			"is_group": 0,
-			"root_type": "Expense"
-		  },
-		  "Meals & Transportation Expenses": {
-			"account_number": "5028",
-			"is_group": 0,
-			"root_type": "Expense"
-		  },
-		  "Meeting & Conferences": {
-			"account_number": "5029",
-			"is_group": 0,
-			"root_type": "Expense"
-		  },
-		  "Miscellaneous Expenses": {
-			"account_number": "5030",
-			"is_group": 0,
-			"root_type": "Expense"
-		  },
-		  "Mockup Expenses": {
-			"account_number": "5031",
-			"is_group": 0,
-			"root_type": "Expense"
-		  },
-		  "Obsolescence Expenses": {
-			"account_number": "5032",
-			"is_group": 0,
-			"root_type": "Expense"
-		  },
-		  "Other Support Cost": {
-			"account_number": "5033",
-			"is_group": 0,
-			"root_type": "Expense"
-		  },
-		  "Pag-ibig Contribution": {
-			"account_number": "5034",
-			"is_group": 0,
-			"root_type": "Expense"
-		  },
-		  "Performance Bonds": {
-			"account_number": "5035",
-			"is_group": 0,
-			"root_type": "Expense"
-		  },
-		  "Pre Employment Expenses": {
-			"account_number": "5036",
-			"is_group": 0,
-			"root_type": "Expense"
-		  },
-		  "Professional Fees": {
-			"account_number": "5037",
-			"is_group": 0,
-			"root_type": "Expense"
-		  },
-		  "Recruitment & Employment": {
-			"account_number": "5038",
-			"is_group": 0,
-			"root_type": "Expense"
-		  },
-		  "Rent Expenses": {
-			"account_number": "5039",
-			"is_group": 0,
-			"root_type": "Expense"
-		  },
-		  "Rent Expenses Others": {
-			"account_number": "5040",
-			"is_group": 0,
-			"root_type": "Expense"
-		  },
-		  "Repairs & Maintenance": {
-			"account_number": "5041",
-			"is_group": 0,
-			"root_type": "Expense"
-		  },
-		  "Representation Expenses": {
-			"account_number": "5042",
-			"is_group": 0,
-			"root_type": "Expense"
-		  },
-		  "Research & Development": {
-			"account_number": "5043",
-			"is_group": 0,
-			"root_type": "Expense"
-		  },
-		  "Security Expenses": {
-			"account_number": "5044",
-			"is_group": 0,
-			"root_type": "Expense"
-		  },
-		  "Shared Services Fee": {
-			"account_number": "5045",
-			"is_group": 0,
-			"root_type": "Expense"
-		  },
-		  "SSS/Medicare/EC Contributions": {
-			"account_number": "5046",
-			"is_group": 0,
-			"root_type": "Expense"
-		  },
-		  "Stationery & Supplies": {
-			"account_number": "5047",
-			"is_group": 0,
-			"root_type": "Expense"
-		  },
-		  "Taxes & Licenses": {
-			"account_number": "5048",
-			"is_group": 0,
 			"root_type": "Expense",
-			"account_type": "Tax"
-		  },
-		  "Training & Seminar": {
-			"account_number": "5049",
-			"is_group": 0,
-			"root_type": "Expense"
-		  }
+			"Direct Labor": {
+				"account_number": "5400",
+				"is_group": 0,
+				"root_type": "Expense"
+			},
+			"Factory Overhead": {
+				"account_number": "5500",
+				"is_group": 0,
+				"root_type": "Expense"
+			},
+			"Cost Of Sales": {
+				"account_number": "5600",
+				"is_group": 0,
+				"root_type": "Expense"
+			},
+			"Cost of Goods Sold": {
+				"account_number": "5601",
+				"is_group": 0,
+				"root_type": "Expense",
+				"account_type": "Cost of Goods Sold"
+			},
+			"Stock Adjustment": {
+				"account_number": "5602",
+				"is_group": 0,
+				"root_type": "Expense",
+				"account_type": "Stock Adjustment"
+			},
+			"Depreciation": {
+				"account_number": "5018",
+				"is_group": 0,
+				"root_type": "Expense",
+				"account_type": "Depreciation"
+			},
+			"Other Expenses": {
+				"account_number": "6200",
+				"is_group": 1,
+				"root_type": "Expense",
+				"Bank Charges": {
+					"account_number": "6201",
+					"is_group": 0,
+					"root_type": "Expense"
+				},
+				"Interest Expenses Bank": {
+					"account_number": "6202",
+					"is_group": 0,
+					"root_type": "Expense"
+				},
+				"Write Off": {
+					"account_number": "6203",
+					"is_group": 0,
+					"root_type": "Expense"
+				},
+				"Round Off": {
+					"account_number": "6205",
+					"is_group": 0,
+					"root_type": "Expense",
+					"account_type": "Round Off"
+				},
+				"Exchange Loss": {
+					"account_number": "6204",
+					"is_group": 0,
+					"root_type": "Expense"
+				}
+			},
+			"Provision For Income Tax": {
+				"account_number": "6300",
+				"is_group": 0,
+				"root_type": "Expense",
+				"account_type": "Tax"
+			},
+			"OPERATING EXPENSES (Revenue Expenditures)": {
+				"account_number": "5001",
+				"is_group": 1,
+				"root_type": "Expense",
+				"Salaries, Wages": {
+					"account_number": "5101",
+					"is_group": 0,
+					"root_type": "Expense"
+				},
+				"13th Month Pay & Bonus": {
+					"account_number": "5102",
+					"is_group": 0,
+					"root_type": "Expense"
+				},
+				"Overtime & Night Diff": {
+					"account_number": "5103",
+					"is_group": 0,
+					"root_type": "Expense"
+				},
+				"Incentive/Performance Bonus": {
+					"account_number": "5104",
+					"is_group": 0,
+					"root_type": "Expense"
+				},
+				"Employees Benefits": {
+					"account_number": "5105",
+					"is_group": 0,
+					"root_type": "Expense"
+				},
+				"Advertising & Promotions": {
+					"account_number": "5106",
+					"is_group": 0,
+					"root_type": "Expense"
+				},
+				"Amortization of Leasehold Improvement": {
+					"account_number": "5107",
+					"is_group": 0,
+					"root_type": "Expense"
+				},
+				"Amortization of Pre-Operating": {
+					"account_number": "5108",
+					"is_group": 0,
+					"root_type": "Expense"
+				},
+				"Amortization of System Development": {
+					"account_number": "5109",
+					"is_group": 0,
+					"root_type": "Expense"
+				},
+				"Audit & Legal Fee": {
+					"account_number": "5110",
+					"is_group": 0,
+					"root_type": "Expense"
+				},
+				"Bad Debts Expenses": {
+					"account_number": "5111",
+					"is_group": 0,
+					"root_type": "Expense"
+				},
+				"Client Service & Maintenance": {
+					"account_number": "5112",
+					"is_group": 0,
+					"root_type": "Expense"
+				},
+				"Commission Expenses": {
+					"account_number": "5113",
+					"is_group": 0,
+					"root_type": "Expense"
+				},
+				"Communications": {
+					"account_number": "5114",
+					"is_group": 0,
+					"root_type": "Expense"
+				},
+				"Contractual Services": {
+					"account_number": "5115",
+					"is_group": 0,
+					"root_type": "Expense"
+				},
+				"Depreciation Expenses": {
+					"account_number": "5116",
+					"is_group": 0,
+					"root_type": "Expense"
+				},
+				"Donation & Contribution": {
+					"account_number": "5117",
+					"is_group": 0,
+					"root_type": "Expense"
+				},
+				"Dues & Subscription": {
+					"account_number": "5118",
+					"is_group": 0,
+					"root_type": "Expense"
+				},
+				"Employee Med/Dental/Hosp Expenses": {
+					"account_number": "5119",
+					"is_group": 0,
+					"root_type": "Expense"
+				},
+				"Employee Uniforms": {
+					"account_number": "5120",
+					"is_group": 0,
+					"root_type": "Expense"
+				},
+				"Equipage": {
+					"account_number": "5121",
+					"is_group": 0,
+					"root_type": "Expense"
+				},
+				"Expenses for Reclassification": {
+					"account_number": "5122",
+					"is_group": 0,
+					"root_type": "Expense"
+				},
+				"Gas & Oil": {
+					"account_number": "5123",
+					"is_group": 0,
+					"root_type": "Expense"
+				},
+				"Insurance Expenses": {
+					"account_number": "5124",
+					"is_group": 0,
+					"root_type": "Expense"
+				},
+				"Light & Water": {
+					"account_number": "5125",
+					"is_group": 0,
+					"root_type": "Expense"
+				},
+				"Local/Overseas Travel": {
+					"account_number": "5126",
+					"is_group": 0,
+					"root_type": "Expense"
+				},
+				"Meals & Transportation Expenses": {
+					"account_number": "5127",
+					"is_group": 0,
+					"root_type": "Expense"
+				},
+				"Meeting & Conferences": {
+					"account_number": "5128",
+					"is_group": 0,
+					"root_type": "Expense"
+				},
+				"Miscellaneous Expenses": {
+					"account_number": "5129",
+					"is_group": 0,
+					"root_type": "Expense"
+				},
+				"Mockup Expenses": {
+					"account_number": "5130",
+					"is_group": 0,
+					"root_type": "Expense"
+				},
+				"Obsolescence Expenses": {
+					"account_number": "5131",
+					"is_group": 0,
+					"root_type": "Expense"
+				},
+				"Other Support Cost": {
+					"account_number": "5132",
+					"is_group": 0,
+					"root_type": "Expense"
+				},
+				"Pag-ibig Contribution": {
+					"account_number": "5133",
+					"is_group": 0,
+					"root_type": "Expense"
+				},
+				"Performance Bonds": {
+					"account_number": "5134",
+					"is_group": 0,
+					"root_type": "Expense"
+				},
+				"Pre Employment Expenses": {
+					"account_number": "5135",
+					"is_group": 0,
+					"root_type": "Expense"
+				},
+				"Professional Fees": {
+					"account_number": "5136",
+					"is_group": 0,
+					"root_type": "Expense"
+				},
+				"Recruitment & Employment": {
+					"account_number": "5137",
+					"is_group": 0,
+					"root_type": "Expense"
+				},
+				"Rent Expenses": {
+					"account_number": "5138",
+					"is_group": 0,
+					"root_type": "Expense"
+				},
+				"Rent Expenses Others": {
+					"account_number": "5139",
+					"is_group": 0,
+					"root_type": "Expense"
+				},
+				"Repairs & Maintenance": {
+					"account_number": "5140",
+					"is_group": 0,
+					"root_type": "Expense"
+				},
+				"Representation Expenses": {
+					"account_number": "5141",
+					"is_group": 0,
+					"root_type": "Expense"
+				},
+				"Research & Development": {
+					"account_number": "5142",
+					"is_group": 0,
+					"root_type": "Expense"
+				},
+				"Security Expenses": {
+					"account_number": "5143",
+					"is_group": 0,
+					"root_type": "Expense"
+				},
+				"Shared Services Fee": {
+					"account_number": "5144",
+					"is_group": 0,
+					"root_type": "Expense"
+				},
+				"SSS/Medicare/EC Contributions": {
+					"account_number": "5145",
+					"is_group": 0,
+					"root_type": "Expense"
+				},
+				"Stationery & Supplies": {
+					"account_number": "5146",
+					"is_group": 0,
+					"root_type": "Expense"
+				},
+				"Taxes & Licenses": {
+					"account_number": "5147",
+					"is_group": 0,
+					"root_type": "Expense",
+					"account_type": "Tax"
+				},
+				"Training & Seminar": {
+					"account_number": "5148",
+					"is_group": 0,
+					"root_type": "Expense"
+				}
+			}
 		}
-	  }
 	}
-  }
+}

--- a/erpnext/accounts/doctype/account/chart_of_accounts/verified/philippines.json
+++ b/erpnext/accounts/doctype/account/chart_of_accounts/verified/philippines.json
@@ -1,0 +1,805 @@
+{
+	"name": "Philippines",
+	"country": "Philippines",
+	"tree": {
+	  "Asset": {
+		"account_number": "1000",
+		"is_group": 1,
+		"root_type": "Asset",
+		"Current Assets": {
+		  "account_number": "1001",
+		  "is_group": 1,
+		  "root_type": "Asset",
+		  "Cash": {
+			"account_number": "1100",
+			"is_group": 1,
+			"root_type": "Asset",
+			"Cash on Hand": {
+			  "account_number": "1101",
+			  "is_group": 0,
+			  "root_type": "Asset"
+			}
+		  },
+		  "Petty Cash Fund": {
+			"account_number": "1200",
+			"is_group": 0,
+			"root_type": "Asset"
+		  },
+		  "Advances to Officers & Employees": {
+			"account_number": "1300",
+			"is_group": 0,
+			"root_type": "Asset"
+		  },
+		  "Accounts Receivable Trade": {
+			"account_number": "1301",
+			"is_group": 1,
+			"root_type": "Asset",
+			"Accounts Receivable - Trade": {
+			  "account_number": "1302",
+			  "is_group": 0,
+			  "root_type": "Asset",
+			   "account_type": "Receivable"
+
+			}
+		  },
+		  "Accounts Receivable - Affiliates": {
+			"account_number": "1310",
+			"is_group": 0,
+			"root_type": "Asset"
+		  },
+		  "Accounts Receivable - Others": {
+			"account_number": "1400",
+			"is_group": 0,
+			"root_type": "Asset"
+		  },
+		  "Parts, Materials and Supplies": {
+			"account_number": "1500",
+			"is_group": 1,
+			"root_type": "Asset",
+			"Parts, Materials and Supplies": {
+			  "account_number": "1501",
+			  "is_group": 0,
+			  "root_type": "Asset"
+			},
+			"Raw Materials - Demo": {
+			  "account_number": "1502",
+			  "is_group": 0,
+			  "root_type": "Asset"
+			}
+		  },
+		  "Project in Progress": {
+			"account_number": "1510",
+			"is_group": 1,
+			"root_type": "Asset",
+			"Project in Progress": {
+			  "account_number": "1511",
+			  "is_group": 0,
+			  "root_type": "Asset"
+			},
+			"Factory Overhead Variance": {
+			  "account_number": "1512",
+			  "is_group": 0,
+			  "root_type": "Asset"
+			}
+		  },
+		  "Finished Goods": {
+			"account_number": "1520",
+			"is_group": 1,
+			"root_type": "Asset",
+			"Finished Good Inventory": {
+			  "account_number": "1531",
+			  "is_group": 0,
+			  "root_type": "Asset"
+			},
+			"Inventory in Transit": {
+			  "account_number": "1532",
+			  "is_group": 0,
+			  "root_type": "Asset"
+			}
+		  },
+		  "Prepayments": {
+			"account_number": "1600",
+			"is_group": 1,
+			"root_type": "Asset",
+			"Prepaid Insurance & Bonds": {
+			  "account_number": "1601",
+			  "is_group": 0,
+			  "root_type": "Asset"
+			},
+			"Prepaid Rent": {
+			  "account_number": "1603",
+			  "is_group": 0,
+			  "root_type": "Asset"
+			}
+		  },
+		  "VAT Input Tax": {
+			"account_number": "1610",
+			"is_group": 1,
+			"root_type": "Asset",
+			"VAT Input Tax - Goods": {
+			  "account_number": "1611",
+			  "is_group": 0,
+			  "root_type": "Asset",
+			  "account_type": "Tax"
+			}
+		  }
+		},
+		"Non - Current Assets": {
+		  "account_number": "1002",
+		  "is_group": 1,
+		  "root_type": "Asset",
+		  "Property, Plants And Equipments": {
+			"account_number": "1700",
+			"is_group": 1,
+			"root_type": "Asset",
+			"Land": {
+			  "account_number": "1701",
+			  "is_group": 0,
+			  "root_type": "Asset"
+			},
+			"Buildings & Improvements": {
+			  "account_number": "1702",
+			  "is_group": 0,
+			  "root_type": "Asset"
+			},
+			"Delivery & Trans Equipment": {
+			  "account_number": "1703",
+			  "is_group": 0,
+			  "root_type": "Asset"
+			},
+			"Furniture & Fixtures": {
+			  "account_number": "1704",
+			  "is_group": 0,
+			  "root_type": "Asset"
+			},
+			"Machinery & Equipment": {
+			  "account_number": "1705",
+			  "is_group": 0,
+			  "root_type": "Asset"
+			}
+		  },
+		  "Accum Depr. - Property, Plants and Equipment": {
+			"account_number": "1800",
+			"is_group": 1,
+			"root_type": "Asset",
+			"Accumulated Dep Bdgs & Improv": {
+			  "account_number": "1801",
+			  "is_group": 0,
+			  "root_type": "Asset"
+			},
+			"Accumulated Dep Delivery & Trans": {
+			  "account_number": "1802",
+			  "is_group": 0,
+			  "root_type": "Asset"
+			},
+			"Accumulated Dep Furniture & Fixture": {
+			  "account_number": "1803",
+			  "is_group": 0,
+			  "root_type": "Asset"
+			},
+			"Accumulated Depreciation - Machinery & Equipment": {
+			  "account_number": "1804",
+			  "is_group": 0,
+			  "root_type": "Asset"
+			}
+		  }
+		},
+		"Other Assets": {
+		  "account_number": "1003",
+		  "is_group": 1,
+		  "root_type": "Asset",
+		  "Advances To Supplier": {
+			"account_number": "1900",
+			"is_group": 1,
+			"root_type": "Asset",
+			"Advances To Supplier": {
+			  "account_number": "1901",
+			  "is_group": 0,
+			  "root_type": "Asset"
+			}
+		  },
+		  "Miscellaneous Deposits": {
+			"account_number": "1910",
+			"is_group": 1,
+			"root_type": "Asset",
+			"Miscellaneous Deposits": {
+			  "account_number": "1911",
+			  "is_group": 0,
+			  "root_type": "Asset"
+			}
+		  },
+		  "Retirement Fund": {
+			"account_number": "1920",
+			"is_group": 1,
+			"root_type": "Asset",
+			"Retirement Fund": {
+			  "account_number": "1921",
+			  "is_group": 0,
+			  "root_type": "Asset"
+			}
+		  },
+		  "Investment": {
+			"account_number": "1930",
+			"is_group": 1,
+			"root_type": "Asset",
+			"Investment": {
+			  "account_number": "1931",
+			  "is_group": 0,
+			  "root_type": "Asset"
+			}
+		  },
+		  "System Development": {
+			"account_number": "1940",
+			"is_group": 1,
+			"root_type": "Asset",
+			"System Development": {
+			  "account_number": "1941",
+			  "is_group": 0,
+			  "root_type": "Asset"
+			}
+		  }
+		}
+	  },
+	  "Liability": {
+		"account_number": "2000",
+		"is_group": 1,
+		"root_type": "Liability",
+		"Current Liabilities": {
+		  "account_number": "2001",
+		  "is_group": 1,
+		  "root_type": "Liability",
+		  "Accounts Payable Trade": {
+			"account_number": "2100",
+			"is_group": 1,
+			"root_type": "Liability",
+			"Accounts Payable - Trade": {
+				"account_number": "2101",
+				"is_group": 0,
+				"root_type": "Liability",
+				"account_type": "Payable"
+			  }
+		  },
+		  "Accounts Payable Others": {
+			"account_number": "2110",
+			"is_group": 1,
+			"root_type": "Liability",
+			"Accounts Payable - Payroll": {
+				"account_number": "2111",
+				"is_group": 0,
+				"root_type": "Liability"
+			  }
+		  },
+		  "VAT Output Tax": {
+			"account_number": "2200",
+			"is_group": 1,
+			"root_type": "Liability",
+			"VAT Output Tax": {
+			  "account_number": "2201",
+			  "is_group": 0,
+			  "root_type": "Liability",
+			  "account_type": "Tax"
+			}
+		},
+		"Withholding Taxes Payable Wages": {
+			"account_number": "2210",
+			"is_group": 1,
+			"root_type": "Liability",
+			"Withholding Taxes Payable Wages": {
+			  "account_number": "2211",
+			  "is_group": 0,
+			  "root_type": "Liability",
+			  "account_type": "Tax"
+			}
+		},
+		"Withholding Taxes Payable Expanded": {
+			"account_number": "2220",
+			"is_group": 1,
+			"root_type": "Liability",
+			"Withholding Taxes Payable Expanded": {
+			  "account_number": "2221",
+			  "is_group": 0,
+			  "root_type": "Liability",
+			  "account_type": "Tax"
+			}
+		},
+		  "Accruals And Other Current Payables": {
+			"account_number": "2300",
+			"is_group": 1,
+			"root_type": "Liability",
+			"Stock Received But Not Billed": {
+			  "account_number": "2301",
+			  "is_group": 0,
+			  "root_type": "Liability"
+			}
+		  },
+		  "Payable to Government and Other Institutions": {
+			"account_number": "2400",
+			"is_group": 1,
+			"root_type": "Liability",
+			"SSS Premium Payable": {
+			  "account_number": "2401",
+			  "is_group": 0,
+			  "root_type": "Liability"
+			},
+			"SSS Salary Loan Payable": {
+			  "account_number": "2402",
+			  "is_group": 0,
+			  "root_type": "Liability"
+			},
+			"PhilHealth Premium": {
+			  "account_number": "2403",
+			  "is_group": 0,
+			  "root_type": "Liability"
+			},
+			"Coop Loans": {
+			  "account_number": "2407",
+			  "is_group": 0,
+			  "root_type": "Liability"
+			},
+			"Coop Contributions": {
+			  "account_number": "2408",
+			  "is_group": 0,
+			  "root_type": "Liability"
+			},
+			"Canteen": {
+			  "account_number": "2409",
+			  "is_group": 0,
+			  "root_type": "Liability"
+			},
+			"Pag-ibig Loan Payable": {
+			  "account_number": "2404",
+			  "is_group": 0,
+			  "root_type": "Liability"
+			}
+		},
+		  "Customer Deposits": {
+			"account_number": "2500",
+			"is_group": 0,
+			"root_type": "Liability"
+		}
+		},
+		"Non Current Liabilities": {
+		  "account_number": "2002",
+		  "is_group": 1,
+		  "root_type": "Liability",
+		  "Due To Associated Company": {
+			"account_number": "2600",
+			"is_group": 1,
+			"root_type": "Liability",
+			"Due To Associated Company": {
+			  "account_number": "2601",
+			  "is_group": 0,
+			  "root_type": "Liability"
+			}
+		  },
+		  "Deferred Income": {
+			"account_number": "2700",
+			"is_group": 1,
+			"root_type": "Liability",
+			"Deferred Income": {
+			  "account_number": "2701",
+			  "is_group": 0,
+			  "root_type": "Liability"
+			}
+		  },
+		  "Notes Payable": {
+			"account_number": "2800",
+			"is_group": 1,
+			"root_type": "Liability",
+			"Notes Payable": {
+			  "account_number": "2801",
+			  "is_group": 0,
+			  "root_type": "Liability"
+			}
+		  },
+		  "Dividends Payable": {
+			"account_number": "2900",
+			"is_group": 0,
+			"root_type": "Liability"
+		  }
+		}
+	  },
+	  "Equity": {
+		"account_number": "3000",
+		"is_group": 1,
+		"root_type": "Equity",
+		"STOCKHOLDER'S EQUITY": {
+		  "account_number": "3001",
+		  "is_group": 1,
+		  "root_type": "Equity",
+		  "Capital Stocks": {
+			"account_number": "3100",
+			"is_group": 1,
+			"root_type": "Equity",
+			"Capital Stocks": {
+			  "account_number": "3101",
+			  "is_group": 0,
+			  "root_type": "Equity"
+			}
+		  },
+		  "Subscription Receivable": {
+			"account_number": "3200",
+			"is_group": 1,
+			"root_type": "Equity",
+			"Subscription Receivable": {
+			  "account_number": "3201",
+			  "is_group": 0,
+			  "root_type": "Equity"
+			}
+		  },
+		  "Retained Earnings": {
+			"account_number": "3300",
+			"is_group": 1,
+			"root_type": "Equity",
+			"Retained Earnings": {
+			  "account_number": "3301",
+			  "is_group": 0,
+			  "root_type": "Equity"
+			}
+		  },
+		  "Current Year (Profit/Loss)": {
+			"account_number": "3400",
+			"is_group": 0,
+			"root_type": "Equity"
+		  },
+		  "Drawings": {
+			"account_number": "3500",
+			"is_group": 1,
+			"root_type": "Equity",
+			"Drawings": {
+			  "account_number": "3501",
+			  "is_group": 0,
+			  "root_type": "Equity"
+			}
+		  }
+		}
+	  },
+	  "Income": {
+		"account_number": "4000",
+		"is_group": 1,
+		"root_type": "Income",
+		"Gross Sales": {
+		  "account_number": "4100",
+		  "is_group": 1,
+		  "root_type": "Income",
+		  "Sales": {
+			"account_number": "4101",
+			"is_group": 0,
+			"root_type": "Income"
+		  }
+		},
+		"Sales Adjustment": {
+		  "account_number": "4200",
+		  "is_group": 1,
+		  "root_type": "Income",
+		  "Sales Return And Allowance": {
+			"account_number": "4201",
+			"is_group": 0,
+			"root_type": "Income"
+		  }
+		},
+		"Sales Discount": {
+		  "account_number": "4300",
+		  "is_group": 1,
+		  "root_type": "Income",
+		  "Sales Discount": {
+			"account_number": "4301",
+			"is_group": 0,
+			"root_type": "Income"
+		  }
+		},
+		"Other Income": {
+		  "account_number": "6000",
+		  "is_group": 1,
+		  "root_type": "Income",
+		  "Interest Income Bank": {
+			"account_number": "6010",
+			"is_group": 1,
+			"root_type": "Income",
+			"Interest Income Bank": {
+			  "account_number": "6011",
+			  "is_group": 0,
+			  "root_type": "Income"
+			}
+		  },
+		  "Dividend Income": {
+			"account_number": "6020",
+			"is_group": 1,
+			"root_type": "Income",
+			"Dividend Income": {
+			  "account_number": "6021",
+			  "is_group": 0,
+			  "root_type": "Income"
+			}
+		  }
+		}
+	  },
+	  "Expense": {
+		"account_number": "5000",
+		"is_group": 1,
+		"root_type": "Expense",
+		"Direct Labor": {
+		  "account_number": "5400",
+		  "is_group": 0,
+		  "root_type": "Expense"
+		},
+		"Factory Overhead": {
+		  "account_number": "5500",
+		  "is_group": 0,
+		  "root_type": "Expense"
+		},
+		"Cost Of Sales": {
+		  "account_number": "5600",
+		  "is_group": 0,
+		  "root_type": "Expense"
+		},
+		"Other Expenses": {
+		  "account_number": "6200",
+		  "is_group": 1,
+		  "root_type": "Expense",
+		  "Bank Charges": {
+			"account_number": "6201",
+			"is_group": 0,
+			"root_type": "Expense"
+		  },
+		  "Interest Expenses Bank": {
+			"account_number": "6202",
+			"is_group": 0,
+			"root_type": "Expense"
+		  }
+		},
+		"Provision For Income Tax": {
+		  "account_number": "6300",
+		  "is_group": 0,
+		  "root_type": "Expense",
+		  "account_type": "Tax"
+		},
+		"OPERATING EXPENSES (Revenue Expenditures)": {
+		  "account_number": "5001",
+		  "is_group": 1,
+		  "root_type": "Expense",
+		  "Salaries, Wages": {
+			"account_number": "5002",
+			"is_group": 0,
+			"root_type": "Expense"
+		  },
+		  "13th Month Pay & Bonus": {
+			"account_number": "5003",
+			"is_group": 0,
+			"root_type": "Expense"
+		  },
+		  "Overtime & Night Diff": {
+			"account_number": "5004",
+			"is_group": 0,
+			"root_type": "Expense"
+		  },
+		  "Incentive/Performance Bonus": {
+			"account_number": "5005",
+			"is_group": 0,
+			"root_type": "Expense"
+		  },
+		  "Employees Benefits": {
+			"account_number": "5006",
+			"is_group": 0,
+			"root_type": "Expense"
+		  },
+		  "Advertising & Promotions": {
+			"account_number": "5007",
+			"is_group": 0,
+			"root_type": "Expense"
+		  },
+		  "Amortization of Leasehold Improvement": {
+			"account_number": "5008",
+			"is_group": 0,
+			"root_type": "Expense"
+		  },
+		  "Amortization of Pre-Operating": {
+			"account_number": "5009",
+			"is_group": 0,
+			"root_type": "Expense"
+		  },
+		  "Amortization of System Development": {
+			"account_number": "5010",
+			"is_group": 0,
+			"root_type": "Expense"
+		  },
+		  "Audit & Legal Fee": {
+			"account_number": "5011",
+			"is_group": 0,
+			"root_type": "Expense"
+		  },
+		  "Bad Debts Expenses": {
+			"account_number": "5012",
+			"is_group": 0,
+			"root_type": "Expense"
+		  },
+		  "Client Service & Maintenance": {
+			"account_number": "5013",
+			"is_group": 0,
+			"root_type": "Expense"
+		  },
+		  "Commission Expenses": {
+			"account_number": "5014",
+			"is_group": 0,
+			"root_type": "Expense"
+		  },
+		  "Communications": {
+			"account_number": "5015",
+			"is_group": 0,
+			"root_type": "Expense"
+		  },
+		  "Contractual Services": {
+			"account_number": "5016",
+			"is_group": 0,
+			"root_type": "Expense"
+		  },
+		  "Depreciation Expenses": {
+			"account_number": "5017",
+			"is_group": 0,
+			"root_type": "Expense"
+		  },
+		  "Donation & Contribution": {
+			"account_number": "5018",
+			"is_group": 0,
+			"root_type": "Expense"
+		  },
+		  "Dues & Subscription": {
+			"account_number": "5019",
+			"is_group": 0,
+			"root_type": "Expense"
+		  },
+		  "Employee Med/Dental/Hosp Expenses": {
+			"account_number": "5020",
+			"is_group": 0,
+			"root_type": "Expense"
+		  },
+		  "Employee Uniforms": {
+			"account_number": "5021",
+			"is_group": 0,
+			"root_type": "Expense"
+		  },
+		  "Equipage": {
+			"account_number": "5022",
+			"is_group": 0,
+			"root_type": "Expense"
+		  },
+		  "Expenses for Reclassification": {
+			"account_number": "5023",
+			"is_group": 0,
+			"root_type": "Expense"
+		  },
+		  "Gas & Oil": {
+			"account_number": "5024",
+			"is_group": 0,
+			"root_type": "Expense"
+		  },
+		  "Insurance Expenses": {
+			"account_number": "5025",
+			"is_group": 0,
+			"root_type": "Expense"
+		  },
+		  "Light & Water": {
+			"account_number": "5026",
+			"is_group": 0,
+			"root_type": "Expense"
+		  },
+		  "Local/Overseas Travel": {
+			"account_number": "5027",
+			"is_group": 0,
+			"root_type": "Expense"
+		  },
+		  "Meals & Transportation Expenses": {
+			"account_number": "5028",
+			"is_group": 0,
+			"root_type": "Expense"
+		  },
+		  "Meeting & Conferences": {
+			"account_number": "5029",
+			"is_group": 0,
+			"root_type": "Expense"
+		  },
+		  "Miscellaneous Expenses": {
+			"account_number": "5030",
+			"is_group": 0,
+			"root_type": "Expense"
+		  },
+		  "Mockup Expenses": {
+			"account_number": "5031",
+			"is_group": 0,
+			"root_type": "Expense"
+		  },
+		  "Obsolescence Expenses": {
+			"account_number": "5032",
+			"is_group": 0,
+			"root_type": "Expense"
+		  },
+		  "Other Support Cost": {
+			"account_number": "5033",
+			"is_group": 0,
+			"root_type": "Expense"
+		  },
+		  "Pag-ibig Contribution": {
+			"account_number": "5034",
+			"is_group": 0,
+			"root_type": "Expense"
+		  },
+		  "Performance Bonds": {
+			"account_number": "5035",
+			"is_group": 0,
+			"root_type": "Expense"
+		  },
+		  "Pre Employment Expenses": {
+			"account_number": "5036",
+			"is_group": 0,
+			"root_type": "Expense"
+		  },
+		  "Professional Fees": {
+			"account_number": "5037",
+			"is_group": 0,
+			"root_type": "Expense"
+		  },
+		  "Recruitment & Employment": {
+			"account_number": "5038",
+			"is_group": 0,
+			"root_type": "Expense"
+		  },
+		  "Rent Expenses": {
+			"account_number": "5039",
+			"is_group": 0,
+			"root_type": "Expense"
+		  },
+		  "Rent Expenses Others": {
+			"account_number": "5040",
+			"is_group": 0,
+			"root_type": "Expense"
+		  },
+		  "Repairs & Maintenance": {
+			"account_number": "5041",
+			"is_group": 0,
+			"root_type": "Expense"
+		  },
+		  "Representation Expenses": {
+			"account_number": "5042",
+			"is_group": 0,
+			"root_type": "Expense"
+		  },
+		  "Research & Development": {
+			"account_number": "5043",
+			"is_group": 0,
+			"root_type": "Expense"
+		  },
+		  "Security Expenses": {
+			"account_number": "5044",
+			"is_group": 0,
+			"root_type": "Expense"
+		  },
+		  "Shared Services Fee": {
+			"account_number": "5045",
+			"is_group": 0,
+			"root_type": "Expense"
+		  },
+		  "SSS/Medicare/EC Contributions": {
+			"account_number": "5046",
+			"is_group": 0,
+			"root_type": "Expense"
+		  },
+		  "Stationery & Supplies": {
+			"account_number": "5047",
+			"is_group": 0,
+			"root_type": "Expense"
+		  },
+		  "Taxes & Licenses": {
+			"account_number": "5048",
+			"is_group": 0,
+			"root_type": "Expense",
+			"account_type": "Tax"
+		  },
+		  "Training & Seminar": {
+			"account_number": "5049",
+			"is_group": 0,
+			"root_type": "Expense"
+		  }
+		}
+	  }
+	}
+  }

--- a/erpnext/accounts/doctype/account/chart_of_accounts/verified/philippines.json
+++ b/erpnext/accounts/doctype/account/chart_of_accounts/verified/philippines.json
@@ -20,18 +20,24 @@
 						"is_group": 0,
 						"root_type": "Asset",
 						"account_type": "Cash"
-					}
-				},
-				"Petty Cash Fund": {
-					"account_number": "1200",
-					"is_group": 1,
-					"root_type": "Asset",
-					"account_type": "Cash",
-					"Petty Cash Fund": {
-						"account_number": "1201",
-						"is_group": 0,
+					},
+					"Bank Accounts": {
+						"account_number": "1102",
+						"is_group": 1,
 						"root_type": "Asset",
-						"account_type": "Cash"
+						"account_type": "Bank"
+					},
+					"Petty Cash Fund": {
+						"account_number": "1200",
+						"is_group": 1,
+						"root_type": "Asset",
+						"account_type": "Cash",
+						"Petty Cash Fund": {
+							"account_number": "1201",
+							"is_group": 0,
+							"root_type": "Asset",
+							"account_type": "Cash"
+						}
 					}
 				},
 				"Advances to Officers & Employees": {
@@ -112,18 +118,14 @@
 					"Finished Goods Inventory": {
 						"account_number": "1531",
 						"is_group": 0,
-						"root_type": "Asset"
+						"root_type": "Asset",
+						"account_type": "Stock"
 					},
 					"Inventory in Transit": {
 						"account_number": "1532",
 						"is_group": 0,
-						"root_type": "Asset"
-					},
-					"Stock In Hand": {
-						"account_number": "1550",
-						"is_group": 0,
 						"root_type": "Asset",
-						"account_type": "Stock"
+						"account_type": "Stock Adjustment"
 					}
 				},
 				"Prepayments": {
@@ -164,27 +166,32 @@
 					"Land": {
 						"account_number": "1701",
 						"is_group": 0,
-						"root_type": "Asset"
+						"root_type": "Asset",
+						"account_type": "Fixed Asset"
 					},
 					"Buildings & Improvements": {
 						"account_number": "1702",
 						"is_group": 0,
-						"root_type": "Asset"
+						"root_type": "Asset",
+						"account_type": "Fixed Asset"
 					},
 					"Delivery & Trans Equipment": {
 						"account_number": "1703",
 						"is_group": 0,
-						"root_type": "Asset"
+						"root_type": "Asset",
+						"account_type": "Fixed Asset"
 					},
 					"Furniture & Fixtures": {
 						"account_number": "1704",
 						"is_group": 0,
-						"root_type": "Asset"
+						"root_type": "Asset",
+						"account_type": "Fixed Asset"
 					},
 					"Machinery & Equipment": {
 						"account_number": "1705",
 						"is_group": 0,
-						"root_type": "Asset"
+						"root_type": "Asset",
+						"account_type": "Fixed Asset"
 					}
 				},
 				"Accum Depr. - Property, Plants and Equipment": {
@@ -399,7 +406,8 @@
 				"Customer Deposits": {
 					"account_number": "2500",
 					"is_group": 0,
-					"root_type": "Liability"
+					"root_type": "Liability",
+					"account_type": "Payable"
 				}
 			},
 			"Non Current Liabilities": {
@@ -555,16 +563,6 @@
 						"is_group": 0,
 						"root_type": "Income"
 					}
-				},
-				"Exchange Gain": {
-					"account_number": "6030",
-					"is_group": 0,
-					"root_type": "Income"
-				},
-				"Gain/Loss on Asset Disposal": {
-					"account_number": "6031",
-					"is_group": 0,
-					"root_type": "Income"
 				}
 			}
 		},
@@ -572,84 +570,8 @@
 			"account_number": "5000",
 			"is_group": 1,
 			"root_type": "Expense",
-			"Direct Labor": {
-				"account_number": "5400",
-				"is_group": 0,
-				"root_type": "Expense"
-			},
-			"Factory Overhead": {
-				"account_number": "5500",
-				"is_group": 0,
-				"root_type": "Expense"
-			},
-			"Cost Of Sales": {
-				"account_number": "5600",
-				"is_group": 0,
-				"root_type": "Expense"
-			},
-			"Cost of Goods Sold": {
-				"account_number": "5601",
-				"is_group": 0,
-				"root_type": "Expense",
-				"account_type": "Cost of Goods Sold"
-			},
-			"Stock Adjustment": {
-				"account_number": "5602",
-				"is_group": 0,
-				"root_type": "Expense",
-				"account_type": "Stock Adjustment"
-			},
-			"Expenses Included In Valuation": {
-				"account_number": "5603",
-				"is_group": 0,
-				"root_type": "Expense",
-				"account_type": "Expenses Included In Valuation"
-			},
-			"Depreciation": {
-				"account_number": "5018",
-				"is_group": 0,
-				"root_type": "Expense",
-				"account_type": "Depreciation"
-			},
-			"Other Expenses": {
-				"account_number": "6200",
-				"is_group": 1,
-				"root_type": "Expense",
-				"Bank Charges": {
-					"account_number": "6201",
-					"is_group": 0,
-					"root_type": "Expense"
-				},
-				"Interest Expenses Bank": {
-					"account_number": "6202",
-					"is_group": 0,
-					"root_type": "Expense"
-				},
-				"Write Off": {
-					"account_number": "6203",
-					"is_group": 0,
-					"root_type": "Expense"
-				},
-				"Round Off": {
-					"account_number": "6205",
-					"is_group": 0,
-					"root_type": "Expense",
-					"account_type": "Round Off"
-				},
-				"Exchange Loss": {
-					"account_number": "6204",
-					"is_group": 0,
-					"root_type": "Expense"
-				}
-			},
-			"Provision For Income Tax": {
-				"account_number": "6300",
-				"is_group": 0,
-				"root_type": "Expense",
-				"account_type": "Tax"
-			},
-			"OPERATING EXPENSES (Revenue Expenditures)": {
-				"account_number": "5001",
+			"Operating Expenses": {
+				"account_number": "5100",
 				"is_group": 1,
 				"root_type": "Expense",
 				"Salaries, Wages": {
@@ -730,7 +652,8 @@
 				"Depreciation Expenses": {
 					"account_number": "5116",
 					"is_group": 0,
-					"root_type": "Expense"
+					"root_type": "Expense",
+					"account_type": "Depreciation"
 				},
 				"Donation & Contribution": {
 					"account_number": "5117",
@@ -893,6 +816,24 @@
 					"is_group": 0,
 					"root_type": "Expense"
 				}
+			},
+			"Stock Adjustment": {
+				"account_number": "5200",
+				"is_group": 0,
+				"root_type": "Expense",
+				"account_type": "Stock Adjustment"
+			},
+			"Round Off": {
+				"account_number": "5300",
+				"is_group": 0,
+				"root_type": "Expense",
+				"account_type": "Round Off"
+			},
+			"Expenses Included In Valuation": {
+				"account_number": "5400",
+				"is_group": 0,
+				"root_type": "Expense",
+				"account_type": "Expenses Included In Valuation"
 			}
 		}
 	}

--- a/erpnext/accounts/doctype/account/chart_of_accounts/verified/philippines.json
+++ b/erpnext/accounts/doctype/account/chart_of_accounts/verified/philippines.json
@@ -21,12 +21,6 @@
 						"root_type": "Asset",
 						"account_type": "Cash"
 					},
-					"Bank Accounts": {
-						"account_number": "1102",
-						"is_group": 1,
-						"root_type": "Asset",
-						"account_type": "Bank"
-					},
 					"Petty Cash Fund": {
 						"account_number": "1200",
 						"is_group": 1,
@@ -39,6 +33,12 @@
 							"account_type": "Cash"
 						}
 					}
+				},
+				"Bank Accounts": {
+					"account_number": "1102",
+					"is_group": 1,
+					"root_type": "Asset",
+					"account_type": "Bank"
 				},
 				"Advances to Officers & Employees": {
 					"account_number": "1290",


### PR DESCRIPTION
<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/erpnext/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:
This PR adds a new Chart of Accounts JSON for the Philippines to support localized accounting and reporting requirements for Philippine companies.

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?
ERPNext does not currently include a default Chart of Accounts for the Philippines.
As a result, users must manually create accounts or modify other country-specific CoAs, which is time-consuming and error-prone.
This change introduces a ready-to-use Philippines CoA JSON, reducing manual setup and enabling consistent, localized financial reporting.
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

*Documentation*

- Chart of Accounts added as a verified JSON under ERPNext

- Documentation Link: https://docs.google.com/document/d/13b3-i82yuILM_Yxc5_NDW4ioUfVYYTcwLO6VBU7SFng/edit?usp=sharing

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->

<!-- no-docs -->