### PR TITLE
feat(Payment Request): Added a toggle for using the payment schedule

### DIFF
--- a/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
+++ b/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
@@ -66,6 +66,7 @@
   "payment_options_section",
   "enable_loyalty_point_program",
   "column_break_ctam",
+  "fetch_payment_schedule_in_payment_request",
   "invoicing_settings_tab",
   "accounts_transactions_settings_section",
   "over_billing_allowance",
@@ -696,16 +697,21 @@
    "fieldname": "enable_subscription",
    "fieldtype": "Check",
    "label": "Enable Subscription"
+  },
+  {
+   "default": "1",
+   "fieldname": "fetch_payment_schedule_in_payment_request",
+   "fieldtype": "Check",
+   "label": "Fetch Payment Schedule In Payment Request"
   }
  ],
  "grid_page_length": 50,
- "hide_toolbar": 0,
  "icon": "icon-cog",
  "idx": 1,
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2026-02-27 01:04:09.415288",
+ "modified": "2026-03-30 07:32:58.182018",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Accounts Settings",

--- a/erpnext/accounts/doctype/accounts_settings/accounts_settings.py
+++ b/erpnext/accounts/doctype/accounts_settings/accounts_settings.py
@@ -74,6 +74,7 @@ class AccountsSettings(Document):
 		enable_party_matching: DF.Check
 		enable_subscription: DF.Check
 		exchange_gain_loss_posting_date: DF.Literal["Invoice", "Payment", "Reconciliation Date"]
+		fetch_payment_schedule_in_payment_request: DF.Check
 		fetch_valuation_rate_for_internal_transaction: DF.Check
 		general_ledger_remarks_length: DF.Int
 		ignore_account_closing_balance: DF.Check

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -459,8 +459,12 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 				reference_name: frm.doc.name,
 			},
 		});
+		const value = await frappe.db.get_single_value(
+			"Accounts Settings",
+			"fetch_payment_schedule_in_payment_request"
+		);
 
-		if (!schedules.length) {
+		if (!value || !schedules.length) {
 			this.make_payment_request();
 			return;
 		}


### PR DESCRIPTION
Created a toggle for using the payment schedules in the payment request or creating the payment request upon total
<img width="1025" height="530" alt="Screenshot 2026-03-30 at 5 28 02 PM" src="https://github.com/user-attachments/assets/9e4e1877-af84-4f19-b6c6-c97f8be38e89" />
no-docs