### PR TITLE
feat(Lead)!: send notifications to lead owner

### DIFF
--- a/erpnext/crm/doctype/lead/lead.py
+++ b/erpnext/crm/doctype/lead/lead.py
@@ -314,6 +314,13 @@ class Lead(SellingController, CRMNote):
 		except frappe.DuplicateEntryError:
 			frappe.throw(_("Prospect {0} already exists").format(company_name or self.company_name))
 
+	def get_notification_email(self):
+		"""Hook to return the target email address for notifications."""
+		if self.lead_owner:
+			return frappe.db.get_value("User", self.lead_owner, "email")
+
+		return None
+
 
 @frappe.whitelist()
 def make_customer(source_name: str, target_doc: str | Document | None = None):


### PR DESCRIPTION
## Summary

Implements `get_notification_email` on the **Lead** DocType (introduced in frappe/frappe#38365) so that email thread notifications are sent to the _Lead Owner_ instead of the document creator.

Previously, the user who created a **Lead** (`doc.owner`) received all email thread notifications, even if a different user was assigned as _Lead Owner_. This is disruptive when one person creates leads but another person manages them.

Now, if a _Lead Owner_ is set, that user receives thread notifications. If no _Lead Owner_ is set, it falls back to the document creator.

**Depends on:** frappe/frappe#38365

I would be happy with a backport to v16 or even v15, but it's a breaking change and easy to customize (via hooks) for companies who want it today.

## Test plan

- [ ] Create a Lead as User A, set Lead Owner to User B
- [ ] Receive an email on that Lead
- [ ] Verify User B gets the notification, User A does not
- [ ] Remove Lead Owner, verify fallback to User A

Ref: VOI-73