### PR TITLE
fix: consistently disassemble based on source  > SE / WO / BOM

### DIFF
--- a/erpnext/manufacturing/doctype/work_order/test_work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/test_work_order.py
@@ -2639,17 +2639,16 @@ class TestWorkOrder(ERPNextTestSuite):
 
 	def test_disassembly_with_additional_rm_not_in_bom(self):
 		"""
-		Test that disassembly correctly handles additional raw materials that were
-		manually added during manufacturing (not part of the BOM).
+		Test that SE-linked disassembly includes additional raw materials
+		that were manually added during manufacturing (not part of the BOM).
 
 		Scenario:
 		1. Create Work Order for 10 units with 2 raw materials in BOM
 		2. Transfer raw materials for manufacture
 		3. Manufacture in 2 parts (3 units, then 7 units)
 		4. In each manufacture entry, manually add an extra consumable item
-		   (not in BOM) in proportion to the manufactured qty
-		5. Create Disassembly for 4 units
-		6. Verify that the additional RM is included in disassembly with proportional qty
+		5. Disassemble 3 units linked to first manufacture entry
+		6. Verify additional RM is included with correct proportional qty from SE1
 		"""
 		from erpnext.stock.doctype.stock_entry.test_stock_entry import (
 			make_stock_entry as make_stock_entry_test_record,
@@ -2685,9 +2684,8 @@ class TestWorkOrder(ERPNextTestSuite):
 		se_for_material_transfer.save()
 		se_for_material_transfer.submit()
 
-		# First Manufacture Entry - 3 units
+		# First Manufacture Entry - 3 units with additional RM
 		se_manufacture1 = frappe.get_doc(make_stock_entry(wo.name, "Manufacture", 3))
-		# Additional RM
 		se_manufacture1.append(
 			"items",
 			{
@@ -2700,9 +2698,8 @@ class TestWorkOrder(ERPNextTestSuite):
 		se_manufacture1.save()
 		se_manufacture1.submit()
 
-		# Second Manufacture Entry - 7 units
+		# Second Manufacture Entry - 7 units with additional RM
 		se_manufacture2 = frappe.get_doc(make_stock_entry(wo.name, "Manufacture", 7))
-		# AAdditional RM
 		se_manufacture2.append(
 			"items",
 			{
@@ -2718,13 +2715,15 @@ class TestWorkOrder(ERPNextTestSuite):
 		wo.reload()
 		self.assertEqual(wo.produced_qty, 10)
 
-		# Disassembly for 4 units
-		disassemble_qty = 4
-		stock_entry = frappe.get_doc(make_stock_entry(wo.name, "Disassemble", disassemble_qty))
+		# Disassemble 3 units linked to first manufacture entry
+		disassemble_qty = 3
+		stock_entry = frappe.get_doc(
+			make_stock_entry(wo.name, "Disassemble", disassemble_qty, source_stock_entry=se_manufacture1.name)
+		)
 		stock_entry.save()
 		stock_entry.submit()
 
-		# No duplicate
+		# No duplicates
 		item_counts = {}
 		for item in stock_entry.items:
 			item_code = item.item_code
@@ -2737,16 +2736,15 @@ class TestWorkOrder(ERPNextTestSuite):
 			f"Found duplicate items in disassembly stock entry: {duplicates}",
 		)
 
-		# Additional RM qty
+		# Additional RM should be included — qty proportional to SE1 (3 units -> 3 additional RM)
 		additional_rm_row = next((i for i in stock_entry.items if i.item_code == additional_rm), None)
 		self.assertIsNotNone(
 			additional_rm_row,
 			f"Additional raw material {additional_rm} not found in disassembly",
 		)
 
-		# intentional full reversal as not part of BOM
-		# eg: dies or consumables used during manufacturing
-		expected_additional_rm_qty = 3 + 7
+		# SE1 had 3 additional RM for 3 manufactured units, disassembling all 3
+		expected_additional_rm_qty = 3
 		self.assertAlmostEqual(
 			additional_rm_row.qty,
 			expected_additional_rm_qty,
@@ -2754,7 +2752,7 @@ class TestWorkOrder(ERPNextTestSuite):
 			msg=f"Additional RM qty mismatch: expected {expected_additional_rm_qty}, got {additional_rm_row.qty}",
 		)
 
-		# RM qty
+		# BOM RM qty — scaled from SE1's rows
 		for bom_item in bom.items:
 			expected_qty = (bom_item.qty / bom.quantity) * disassemble_qty
 			rm_row = next((i for i in stock_entry.items if i.item_code == bom_item.item_code), None)
@@ -2770,12 +2768,18 @@ class TestWorkOrder(ERPNextTestSuite):
 		fg_item_row = next((i for i in stock_entry.items if i.item_code == fg_item), None)
 		self.assertEqual(fg_item_row.qty, disassemble_qty)
 
+		# FG + 2 BOM RM + 1 additional RM = 4 items
 		expected_items = 4
 		self.assertEqual(
 			len(stock_entry.items),
 			expected_items,
 			f"Expected {expected_items} items, found {len(stock_entry.items)}",
 		)
+
+		# Verify traceability
+		for item in stock_entry.items:
+			self.assertEqual(item.against_stock_entry, se_manufacture1.name)
+			self.assertTrue(item.ste_detail)
 
 	def test_components_alternate_item_for_bom_based_manufacture_entry(self):
 		frappe.db.set_single_value("Manufacturing Settings", "backflush_raw_materials_based_on", "BOM")

--- a/erpnext/manufacturing/doctype/work_order/test_work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/test_work_order.py
@@ -2658,6 +2658,15 @@ class TestWorkOrder(ERPNextTestSuite):
 			)
 
 		# -- BOM-path disassembly (no source_stock_entry, no work_order) --
+
+		make_stock_entry_test_record(
+			item_code=scrap_item,
+			purpose="Material Receipt",
+			target=wo.fg_warehouse,
+			qty=50,
+			basic_rate=10,
+		)
+
 		bom_disassemble_qty = 2
 		bom_se = frappe.get_doc(
 			{

--- a/erpnext/manufacturing/doctype/work_order/test_work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/test_work_order.py
@@ -2419,7 +2419,7 @@ class TestWorkOrder(ERPNextTestSuite):
 
 		stock_entry.submit()
 
-	def test_disassembly_order_with_qty_behavior(self):
+	def test_disassembly_order_with_qty_from_wo_behavior(self):
 		# Create raw material and FG item
 		raw_item = make_item("Test Raw for Disassembly", {"is_stock_item": 1}).name
 		fg_item = make_item("Test FG for Disassembly", {"is_stock_item": 1}).name
@@ -2459,27 +2459,9 @@ class TestWorkOrder(ERPNextTestSuite):
 		se_for_manufacture = frappe.get_doc(make_stock_entry(wo.name, "Manufacture", wo.qty))
 		se_for_manufacture.submit()
 
-		# Simulate a disassembly stock entry
+		# Disassembly via WO required_items path (no source_stock_entry)
 		disassemble_qty = 4
 		stock_entry = frappe.get_doc(make_stock_entry(wo.name, "Disassemble", disassemble_qty))
-		stock_entry.append(
-			"items",
-			{
-				"item_code": fg_item,
-				"qty": disassemble_qty,
-				"s_warehouse": wo.fg_warehouse,
-			},
-		)
-
-		for bom_item in bom.items:
-			stock_entry.append(
-				"items",
-				{
-					"item_code": bom_item.item_code,
-					"qty": (bom_item.qty / bom.quantity) * disassemble_qty,
-					"t_warehouse": wo.source_warehouse,
-				},
-			)
 
 		wo.reload()
 		stock_entry.save()
@@ -2494,7 +2476,7 @@ class TestWorkOrder(ERPNextTestSuite):
 			f"Expected FG qty {disassemble_qty}, found {finished_good_entry.qty}",
 		)
 
-		# Assert raw materials
+		# Assert raw materials - qty scaled from WO required_items
 		for item in stock_entry.items:
 			if item.item_code == fg_item:
 				continue

--- a/erpnext/manufacturing/doctype/work_order/test_work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/test_work_order.py
@@ -2915,49 +2915,81 @@ class TestWorkOrder(ERPNextTestSuite):
 			status="Not Started",
 		)
 
-		# Stock up RM — batch auto-created on receipt
-		rm_receipt = make_stock_entry_test_record(
-			item_code=rm_item, purpose="Material Receipt", target=wip_wh, qty=18, basic_rate=100
+		# Two separate RM receipts → two distinct batches (batch_1, batch_2)
+		rm_receipt_1 = make_stock_entry_test_record(
+			item_code=rm_item, purpose="Material Receipt", target=wip_wh, qty=6, basic_rate=100
 		)
-		rm_bundle = frappe.db.get_value(
-			"Stock Entry Detail", {"parent": rm_receipt.name, "item_code": rm_item}, "serial_and_batch_bundle"
+		rm_batch_1 = get_batch_from_bundle(
+			frappe.db.get_value(
+				"Stock Entry Detail",
+				{"parent": rm_receipt_1.name, "item_code": rm_item},
+				"serial_and_batch_bundle",
+			)
 		)
-		rm_batch = get_batch_from_bundle(rm_bundle)
 
-		# Pre-create FG batch so we can assign it to the manufacture row
-		fg_batch = make_batch(frappe._dict(item=fg_item))
+		rm_receipt_2 = make_stock_entry_test_record(
+			item_code=rm_item, purpose="Material Receipt", target=wip_wh, qty=6, basic_rate=100
+		)
+		rm_batch_2 = get_batch_from_bundle(
+			frappe.db.get_value(
+				"Stock Entry Detail",
+				{"parent": rm_receipt_2.name, "item_code": rm_item},
+				"serial_and_batch_bundle",
+			)
+		)
 
-		# Manufacture 3 units: assign batches explicitly on RM and FG rows
-		se_manufacture = frappe.get_doc(make_stock_entry(wo.name, "Manufacture", 3))
-		for row in se_manufacture.items:
+		self.assertNotEqual(rm_batch_1, rm_batch_2, "Two receipts must create two distinct RM batches")
+
+		fg_batch_1 = make_batch(frappe._dict(item=fg_item))
+		fg_batch_2 = make_batch(frappe._dict(item=fg_item))
+
+		# Manufacture entry 1 — 3 FG using batch_1 RM/FG
+		se_manufacture_1 = frappe.get_doc(make_stock_entry(wo.name, "Manufacture", 3))
+		for row in se_manufacture_1.items:
 			if row.item_code == rm_item:
-				row.batch_no = rm_batch
+				row.batch_no = rm_batch_1
 				row.use_serial_batch_fields = 1
 			elif row.item_code == fg_item:
-				row.batch_no = fg_batch
+				row.batch_no = fg_batch_1
 				row.use_serial_batch_fields = 1
-		se_manufacture.save()
-		se_manufacture.submit()
+		se_manufacture_1.save()
+		se_manufacture_1.submit()
 
-		# Disassemble 2 of the 3 manufactured units linked to the manufacture SE
+		# Manufacture entry 2 — 3 FG using batch_2 RM/FG
+		se_manufacture_2 = frappe.get_doc(make_stock_entry(wo.name, "Manufacture", 3))
+		for row in se_manufacture_2.items:
+			if row.item_code == rm_item:
+				row.batch_no = rm_batch_2
+				row.use_serial_batch_fields = 1
+			elif row.item_code == fg_item:
+				row.batch_no = fg_batch_2
+				row.use_serial_batch_fields = 1
+		se_manufacture_2.save()
+		se_manufacture_2.submit()
+
+		# Disassemble 2 units from SE_1 only — must use SE_1's batches, not SE_2's
 		disassemble_qty = 2
 		stock_entry = frappe.get_doc(
-			make_stock_entry(wo.name, "Disassemble", disassemble_qty, source_stock_entry=se_manufacture.name)
+			make_stock_entry(
+				wo.name, "Disassemble", disassemble_qty, source_stock_entry=se_manufacture_1.name
+			)
 		)
 		stock_entry.save()
 		stock_entry.submit()
 
-		# FG row: consuming batch from FG warehouse — bundle must use FG batch
+		# FG row: must use fg_batch_1 exclusively (fg_batch_2 must not appear)
 		fg_row = next((i for i in stock_entry.items if i.item_code == fg_item), None)
 		self.assertIsNotNone(fg_row)
 		self.assertTrue(fg_row.serial_and_batch_bundle, "FG row must have a serial_and_batch_bundle")
-		self.assertEqual(get_batch_from_bundle(fg_row.serial_and_batch_bundle), fg_batch)
+		self.assertEqual(get_batch_from_bundle(fg_row.serial_and_batch_bundle), fg_batch_1)
+		self.assertNotEqual(get_batch_from_bundle(fg_row.serial_and_batch_bundle), fg_batch_2)
 
-		# RM row: returning to WIP warehouse — bundle must use RM batch
+		# RM row: must use rm_batch_1 exclusively (rm_batch_2 must not appear)
 		rm_row = next((i for i in stock_entry.items if i.item_code == rm_item), None)
 		self.assertIsNotNone(rm_row)
 		self.assertTrue(rm_row.serial_and_batch_bundle, "RM row must have a serial_and_batch_bundle")
-		self.assertEqual(get_batch_from_bundle(rm_row.serial_and_batch_bundle), rm_batch)
+		self.assertEqual(get_batch_from_bundle(rm_row.serial_and_batch_bundle), rm_batch_1)
+		self.assertNotEqual(get_batch_from_bundle(rm_row.serial_and_batch_bundle), rm_batch_2)
 
 		# RM qty: 2 FG disassembled x 2 RM per FG = 4
 		self.assertAlmostEqual(rm_row.qty, 4.0, places=3)
@@ -2990,55 +3022,94 @@ class TestWorkOrder(ERPNextTestSuite):
 			status="Not Started",
 		)
 
-		# Stock up 6 RM serials — series auto-generates them
-		rm_receipt = make_stock_entry_test_record(
+		# Two separate RM receipts → two disjoint sets of serial numbers
+		rm_receipt_1 = make_stock_entry_test_record(
 			item_code=rm_item, purpose="Material Receipt", target=wip_wh, qty=6, basic_rate=100
 		)
-		rm_bundle = frappe.db.get_value(
-			"Stock Entry Detail", {"parent": rm_receipt.name, "item_code": rm_item}, "serial_and_batch_bundle"
+		rm_serials_1 = get_serial_nos_from_bundle(
+			frappe.db.get_value(
+				"Stock Entry Detail",
+				{"parent": rm_receipt_1.name, "item_code": rm_item},
+				"serial_and_batch_bundle",
+			)
 		)
-		all_rm_serials = get_serial_nos_from_bundle(rm_bundle)
-		self.assertEqual(len(all_rm_serials), 6)
+		self.assertEqual(len(rm_serials_1), 6)
 
-		# Pre-generate 3 FG serial numbers
+		rm_receipt_2 = make_stock_entry_test_record(
+			item_code=rm_item, purpose="Material Receipt", target=wip_wh, qty=6, basic_rate=100
+		)
+		rm_serials_2 = get_serial_nos_from_bundle(
+			frappe.db.get_value(
+				"Stock Entry Detail",
+				{"parent": rm_receipt_2.name, "item_code": rm_item},
+				"serial_and_batch_bundle",
+			)
+		)
+		self.assertEqual(len(rm_serials_2), 6)
+		self.assertFalse(
+			set(rm_serials_1) & set(rm_serials_2), "Two receipts must produce disjoint RM serial sets"
+		)
+
+		# Pre-generate two sets of FG serial numbers
 		series = frappe.db.get_value("Item", fg_item, "serial_no_series")
-		fg_serials = [make_autoname(series) for _ in range(3)]
+		fg_serials_1 = [make_autoname(series) for _ in range(3)]
+		fg_serials_2 = [make_autoname(series) for _ in range(3)]
 
-		# Manufacture 3 units: consume first 6 RM serials, produce 3 FG serials
-		se_manufacture = frappe.get_doc(make_stock_entry(wo.name, "Manufacture", 3))
-		for row in se_manufacture.items:
+		# Manufacture entry 1 — consumes rm_serials_1, produces fg_serials_1
+		se_manufacture_1 = frappe.get_doc(make_stock_entry(wo.name, "Manufacture", 3))
+		for row in se_manufacture_1.items:
 			if row.item_code == rm_item:
-				row.serial_no = "\n".join(all_rm_serials)
+				row.serial_no = "\n".join(rm_serials_1)
 				row.use_serial_batch_fields = 1
 			elif row.item_code == fg_item:
-				row.serial_no = "\n".join(fg_serials)
+				row.serial_no = "\n".join(fg_serials_1)
 				row.use_serial_batch_fields = 1
-		se_manufacture.save()
-		se_manufacture.submit()
+		se_manufacture_1.save()
+		se_manufacture_1.submit()
 
-		# Disassemble 2 of the 3 manufactured units
+		# Manufacture entry 2 — consumes rm_serials_2, produces fg_serials_2
+		se_manufacture_2 = frappe.get_doc(make_stock_entry(wo.name, "Manufacture", 3))
+		for row in se_manufacture_2.items:
+			if row.item_code == rm_item:
+				row.serial_no = "\n".join(rm_serials_2)
+				row.use_serial_batch_fields = 1
+			elif row.item_code == fg_item:
+				row.serial_no = "\n".join(fg_serials_2)
+				row.use_serial_batch_fields = 1
+		se_manufacture_2.save()
+		se_manufacture_2.submit()
+
+		# Disassemble 2 units from SE_1 only — must use SE_1's serials, not SE_2's
 		disassemble_qty = 2
 		stock_entry = frappe.get_doc(
-			make_stock_entry(wo.name, "Disassemble", disassemble_qty, source_stock_entry=se_manufacture.name)
+			make_stock_entry(
+				wo.name, "Disassemble", disassemble_qty, source_stock_entry=se_manufacture_1.name
+			)
 		)
 		stock_entry.save()
 		stock_entry.submit()
 
-		# FG row: 2 serials consumed — must be a subset of the manufacture FG serials
+		# FG row: 2 serials consumed — must be subset of fg_serials_1, disjoint from fg_serials_2
 		fg_row = next((i for i in stock_entry.items if i.item_code == fg_item), None)
 		self.assertIsNotNone(fg_row)
 		self.assertTrue(fg_row.serial_and_batch_bundle, "FG row must have a serial_and_batch_bundle")
 		fg_dasm_serials = get_serial_nos_from_bundle(fg_row.serial_and_batch_bundle)
 		self.assertEqual(len(fg_dasm_serials), disassemble_qty)
-		self.assertTrue(set(fg_dasm_serials).issubset(set(fg_serials)))
+		self.assertTrue(set(fg_dasm_serials).issubset(set(fg_serials_1)))
+		self.assertFalse(
+			set(fg_dasm_serials) & set(fg_serials_2), "Disassembly must not use SE_2's FG serials"
+		)
 
-		# RM row: 4 serials returned (2 FG x 2 RM each) — must be a subset of manufacture RM serials
+		# RM row: 4 serials returned (2 FG x 2 RM each) — subset of rm_serials_1, disjoint from rm_serials_2
 		rm_row = next((i for i in stock_entry.items if i.item_code == rm_item), None)
 		self.assertIsNotNone(rm_row)
 		self.assertTrue(rm_row.serial_and_batch_bundle, "RM row must have a serial_and_batch_bundle")
 		rm_dasm_serials = get_serial_nos_from_bundle(rm_row.serial_and_batch_bundle)
 		self.assertEqual(len(rm_dasm_serials), disassemble_qty * 2)
-		self.assertTrue(set(rm_dasm_serials).issubset(set(all_rm_serials)))
+		self.assertTrue(set(rm_dasm_serials).issubset(set(rm_serials_1)))
+		self.assertFalse(
+			set(rm_dasm_serials) & set(rm_serials_2), "Disassembly must not use SE_2's RM serials"
+		)
 
 	def test_components_alternate_item_for_bom_based_manufacture_entry(self):
 		frappe.db.set_single_value("Manufacturing Settings", "backflush_raw_materials_based_on", "BOM")

--- a/erpnext/manufacturing/doctype/work_order/test_work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/test_work_order.py
@@ -2500,6 +2500,30 @@ class TestWorkOrder(ERPNextTestSuite):
 			f"Work Order disassembled_qty mismatch: expected {disassemble_qty}, got {wo.disassembled_qty}",
 		)
 
+		# Second disassembly: explicitly linked to manufacture SE — verifies SE-linked path
+		# (first disassembly auto-set source_stock_entry since there's only one manufacture entry)
+		disassemble_qty_2 = 2
+		stock_entry_2 = frappe.get_doc(
+			make_stock_entry(
+				wo.name, "Disassemble", disassemble_qty_2, source_stock_entry=se_for_manufacture.name
+			)
+		)
+		stock_entry_2.save()
+		stock_entry_2.submit()
+
+		# All rows must trace back to se_for_manufacture
+		for item in stock_entry_2.items:
+			self.assertEqual(item.against_stock_entry, se_for_manufacture.name)
+			self.assertTrue(item.ste_detail)
+
+		# RM qty scaled from the manufacture SE rows
+		rm_row = next((i for i in stock_entry_2.items if i.item_code == raw_item), None)
+		expected_rm_qty = (bom.items[0].qty / bom.quantity) * disassemble_qty_2
+		self.assertAlmostEqual(rm_row.qty, expected_rm_qty, places=3)
+
+		wo.reload()
+		self.assertEqual(wo.disassembled_qty, disassemble_qty + disassemble_qty_2)
+
 	def test_disassembly_with_multiple_manufacture_entries(self):
 		"""
 		Test that disassembly does not create duplicate items when manufacturing

--- a/erpnext/manufacturing/doctype/work_order/test_work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/test_work_order.py
@@ -2642,7 +2642,9 @@ class TestWorkOrder(ERPNextTestSuite):
 		self.assertTrue(scrap_row.s_warehouse)
 		self.assertFalse(scrap_row.t_warehouse)
 		self.assertEqual(scrap_row.s_warehouse, wo.scrap_warehouse)
-		self.assertEqual(scrap_row.qty, 40)
+		# BOM has scrap_qty=10/FG but also process_loss_per=10%, so actual scrap per FG = 9
+		# Total produced = 9*3 + 9*7 = 90, disassemble 4/10 → 36
+		self.assertEqual(scrap_row.qty, 36)
 
 		# RM quantities
 		for bom_item in bom.items:

--- a/erpnext/manufacturing/doctype/work_order/test_work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/test_work_order.py
@@ -6,7 +6,7 @@ from collections import defaultdict
 
 import frappe
 from frappe.tests import timeout
-from frappe.utils import add_days, add_months, add_to_date, cint, flt, now, today
+from frappe.utils import add_days, add_months, add_to_date, cint, flt, now, nowdate, nowtime, today
 
 from erpnext.manufacturing.doctype.job_card.job_card import JobCardCancelError
 from erpnext.manufacturing.doctype.job_card.job_card import make_stock_entry as make_stock_entry_from_jc
@@ -2656,6 +2656,36 @@ class TestWorkOrder(ERPNextTestSuite):
 				places=3,
 				msg=f"Raw material {bom_item.item_code} qty mismatch",
 			)
+
+		# -- BOM-path disassembly (no source_stock_entry, no work_order) --
+		bom_disassemble_qty = 2
+		bom_se = frappe.get_doc(
+			{
+				"doctype": "Stock Entry",
+				"stock_entry_type": "Disassemble",
+				"purpose": "Disassemble",
+				"from_bom": 1,
+				"bom_no": bom.name,
+				"fg_completed_qty": bom_disassemble_qty,
+				"from_warehouse": wo.fg_warehouse,
+				"to_warehouse": wo.wip_warehouse,
+				"company": wo.company,
+				"posting_date": nowdate(),
+				"posting_time": nowtime(),
+			}
+		)
+		bom_se.get_items()
+		bom_se.save()
+		bom_se.submit()
+
+		bom_scrap_row = next((i for i in bom_se.items if i.item_code == scrap_item), None)
+		self.assertIsNotNone(bom_scrap_row, "Scrap item must appear in BOM-path disassembly")
+		# Without fix 3: qty = 10 * 2 = 20; with fix 3 (process_loss_per=10%): qty = 9 * 2 = 18
+		self.assertEqual(
+			bom_scrap_row.qty,
+			18,
+			f"BOM-path disassembly must apply process_loss_per; expected 18, got {bom_scrap_row.qty}",
+		)
 
 	def test_disassembly_with_additional_rm_not_in_bom(self):
 		"""

--- a/erpnext/manufacturing/doctype/work_order/test_work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/test_work_order.py
@@ -2781,6 +2781,206 @@ class TestWorkOrder(ERPNextTestSuite):
 			self.assertEqual(item.against_stock_entry, se_manufacture1.name)
 			self.assertTrue(item.ste_detail)
 
+	def test_disassembly_auto_sets_source_stock_entry(self):
+		from erpnext.stock.doctype.stock_entry.test_stock_entry import (
+			make_stock_entry as make_stock_entry_test_record,
+		)
+
+		raw_item = make_item("Test Raw Auto Set Disassembly", {"is_stock_item": 1}).name
+		fg_item = make_item("Test FG Auto Set Disassembly", {"is_stock_item": 1}).name
+		bom = make_bom(item=fg_item, quantity=1, raw_materials=[raw_item], rm_qty=2)
+
+		wo = make_wo_order_test_record(production_item=fg_item, qty=5, bom_no=bom.name, status="Not Started")
+
+		make_stock_entry_test_record(
+			item_code=raw_item, purpose="Material Receipt", target=wo.wip_warehouse, qty=50, basic_rate=100
+		)
+
+		se_transfer = frappe.get_doc(make_stock_entry(wo.name, "Material Transfer for Manufacture", wo.qty))
+		for item in se_transfer.items:
+			item.s_warehouse = wo.wip_warehouse
+		se_transfer.save()
+		se_transfer.submit()
+
+		se_manufacture = frappe.get_doc(make_stock_entry(wo.name, "Manufacture", wo.qty))
+		se_manufacture.submit()
+
+		# Disassemble without specifying source_stock_entry
+		stock_entry = frappe.get_doc(make_stock_entry(wo.name, "Disassemble", 3))
+		stock_entry.save()
+
+		# source_stock_entry should be auto-set since only one manufacture entry
+		self.assertEqual(stock_entry.source_stock_entry, se_manufacture.name)
+
+		# All items should have against_stock_entry linked
+		for item in stock_entry.items:
+			self.assertEqual(item.against_stock_entry, se_manufacture.name)
+			self.assertTrue(item.ste_detail)
+
+		stock_entry.submit()
+
+	def test_disassembly_batch_tracked_items(self):
+		from erpnext.stock.doctype.batch.batch import make_batch
+		from erpnext.stock.doctype.stock_entry.test_stock_entry import (
+			make_stock_entry as make_stock_entry_test_record,
+		)
+
+		wip_wh = "_Test Warehouse - _TC"
+
+		rm_item = make_item(
+			"Test Batch RM for Disassembly SB",
+			{
+				"is_stock_item": 1,
+				"has_batch_no": 1,
+				"create_new_batch": 1,
+				"batch_number_series": "TBRD-RM-.###",
+			},
+		).name
+		fg_item = make_item(
+			"Test Batch FG for Disassembly SB",
+			{
+				"is_stock_item": 1,
+				"has_batch_no": 1,
+				"create_new_batch": 1,
+				"batch_number_series": "TBRD-FG-.###",
+			},
+		).name
+
+		bom = make_bom(item=fg_item, quantity=1, raw_materials=[rm_item], rm_qty=2)
+		wo = make_wo_order_test_record(
+			production_item=fg_item,
+			qty=6,
+			bom_no=bom.name,
+			skip_transfer=1,
+			source_warehouse=wip_wh,
+			status="Not Started",
+		)
+
+		# Stock up RM — batch auto-created on receipt
+		rm_receipt = make_stock_entry_test_record(
+			item_code=rm_item, purpose="Material Receipt", target=wip_wh, qty=18, basic_rate=100
+		)
+		rm_bundle = frappe.db.get_value(
+			"Stock Entry Detail", {"parent": rm_receipt.name, "item_code": rm_item}, "serial_and_batch_bundle"
+		)
+		rm_batch = get_batch_from_bundle(rm_bundle)
+
+		# Pre-create FG batch so we can assign it to the manufacture row
+		fg_batch = make_batch(frappe._dict(item=fg_item))
+
+		# Manufacture 3 units: assign batches explicitly on RM and FG rows
+		se_manufacture = frappe.get_doc(make_stock_entry(wo.name, "Manufacture", 3))
+		for row in se_manufacture.items:
+			if row.item_code == rm_item:
+				row.batch_no = rm_batch
+				row.use_serial_batch_fields = 1
+			elif row.item_code == fg_item:
+				row.batch_no = fg_batch
+				row.use_serial_batch_fields = 1
+		se_manufacture.save()
+		se_manufacture.submit()
+
+		# Disassemble 2 of the 3 manufactured units linked to the manufacture SE
+		disassemble_qty = 2
+		stock_entry = frappe.get_doc(
+			make_stock_entry(wo.name, "Disassemble", disassemble_qty, source_stock_entry=se_manufacture.name)
+		)
+		stock_entry.save()
+		stock_entry.submit()
+
+		# FG row: consuming batch from FG warehouse — bundle must use FG batch
+		fg_row = next((i for i in stock_entry.items if i.item_code == fg_item), None)
+		self.assertIsNotNone(fg_row)
+		self.assertTrue(fg_row.serial_and_batch_bundle, "FG row must have a serial_and_batch_bundle")
+		self.assertEqual(get_batch_from_bundle(fg_row.serial_and_batch_bundle), fg_batch)
+
+		# RM row: returning to WIP warehouse — bundle must use RM batch
+		rm_row = next((i for i in stock_entry.items if i.item_code == rm_item), None)
+		self.assertIsNotNone(rm_row)
+		self.assertTrue(rm_row.serial_and_batch_bundle, "RM row must have a serial_and_batch_bundle")
+		self.assertEqual(get_batch_from_bundle(rm_row.serial_and_batch_bundle), rm_batch)
+
+		# RM qty: 2 FG disassembled x 2 RM per FG = 4
+		self.assertAlmostEqual(rm_row.qty, 4.0, places=3)
+
+	def test_disassembly_serial_tracked_items(self):
+		from frappe.model.naming import make_autoname
+
+		from erpnext.stock.doctype.stock_entry.test_stock_entry import (
+			make_stock_entry as make_stock_entry_test_record,
+		)
+
+		wip_wh = "_Test Warehouse - _TC"
+
+		rm_item = make_item(
+			"Test Serial RM for Disassembly SB",
+			{"is_stock_item": 1, "has_serial_no": 1, "serial_no_series": "TSRD-RM-.####"},
+		).name
+		fg_item = make_item(
+			"Test Serial FG for Disassembly SB",
+			{"is_stock_item": 1, "has_serial_no": 1, "serial_no_series": "TSRD-FG-.####"},
+		).name
+
+		bom = make_bom(item=fg_item, quantity=1, raw_materials=[rm_item], rm_qty=2)
+		wo = make_wo_order_test_record(
+			production_item=fg_item,
+			qty=6,
+			bom_no=bom.name,
+			skip_transfer=1,
+			source_warehouse=wip_wh,
+			status="Not Started",
+		)
+
+		# Stock up 6 RM serials — series auto-generates them
+		rm_receipt = make_stock_entry_test_record(
+			item_code=rm_item, purpose="Material Receipt", target=wip_wh, qty=6, basic_rate=100
+		)
+		rm_bundle = frappe.db.get_value(
+			"Stock Entry Detail", {"parent": rm_receipt.name, "item_code": rm_item}, "serial_and_batch_bundle"
+		)
+		all_rm_serials = get_serial_nos_from_bundle(rm_bundle)
+		self.assertEqual(len(all_rm_serials), 6)
+
+		# Pre-generate 3 FG serial numbers
+		series = frappe.db.get_value("Item", fg_item, "serial_no_series")
+		fg_serials = [make_autoname(series) for _ in range(3)]
+
+		# Manufacture 3 units: consume first 6 RM serials, produce 3 FG serials
+		se_manufacture = frappe.get_doc(make_stock_entry(wo.name, "Manufacture", 3))
+		for row in se_manufacture.items:
+			if row.item_code == rm_item:
+				row.serial_no = "\n".join(all_rm_serials)
+				row.use_serial_batch_fields = 1
+			elif row.item_code == fg_item:
+				row.serial_no = "\n".join(fg_serials)
+				row.use_serial_batch_fields = 1
+		se_manufacture.save()
+		se_manufacture.submit()
+
+		# Disassemble 2 of the 3 manufactured units
+		disassemble_qty = 2
+		stock_entry = frappe.get_doc(
+			make_stock_entry(wo.name, "Disassemble", disassemble_qty, source_stock_entry=se_manufacture.name)
+		)
+		stock_entry.save()
+		stock_entry.submit()
+
+		# FG row: 2 serials consumed — must be a subset of the manufacture FG serials
+		fg_row = next((i for i in stock_entry.items if i.item_code == fg_item), None)
+		self.assertIsNotNone(fg_row)
+		self.assertTrue(fg_row.serial_and_batch_bundle, "FG row must have a serial_and_batch_bundle")
+		fg_dasm_serials = get_serial_nos_from_bundle(fg_row.serial_and_batch_bundle)
+		self.assertEqual(len(fg_dasm_serials), disassemble_qty)
+		self.assertTrue(set(fg_dasm_serials).issubset(set(fg_serials)))
+
+		# RM row: 4 serials returned (2 FG x 2 RM each) — must be a subset of manufacture RM serials
+		rm_row = next((i for i in stock_entry.items if i.item_code == rm_item), None)
+		self.assertIsNotNone(rm_row)
+		self.assertTrue(rm_row.serial_and_batch_bundle, "RM row must have a serial_and_batch_bundle")
+		rm_dasm_serials = get_serial_nos_from_bundle(rm_row.serial_and_batch_bundle)
+		self.assertEqual(len(rm_dasm_serials), disassemble_qty * 2)
+		self.assertTrue(set(rm_dasm_serials).issubset(set(all_rm_serials)))
+
 	def test_components_alternate_item_for_bom_based_manufacture_entry(self):
 		frappe.db.set_single_value("Manufacturing Settings", "backflush_raw_materials_based_on", "BOM")
 		frappe.db.set_single_value("Manufacturing Settings", "validate_components_quantities_per_bom", 1)

--- a/erpnext/manufacturing/doctype/work_order/test_work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/test_work_order.py
@@ -2527,7 +2527,8 @@ class TestWorkOrder(ERPNextTestSuite):
 	def test_disassembly_with_multiple_manufacture_entries(self):
 		"""
 		Test that disassembly does not create duplicate items when manufacturing
-		is done in multiple batches (multiple manufacture stock entries).
+		is done in multiple batches (multiple manufacture stock entries), including
+		secondary/scrap items.
 
 		Scenario:
 		1. Create Work Order for 10 units
@@ -2536,11 +2537,19 @@ class TestWorkOrder(ERPNextTestSuite):
 		4. Create Disassembly for 4 units
 		5. Verify no duplicate items in the disassembly stock entry
 		"""
-		# Create RM and FG item
+		# Create RM, scrap and FG item
 		raw_item1 = make_item("Test Raw for Multi Batch Disassembly 1", {"is_stock_item": 1}).name
 		raw_item2 = make_item("Test Raw for Multi Batch Disassembly 2", {"is_stock_item": 1}).name
+		scrap_item = make_item("Test Scrap for Multi Batch Disassembly", {"is_stock_item": 1}).name
 		fg_item = make_item("Test FG for Multi Batch Disassembly", {"is_stock_item": 1}).name
-		bom = make_bom(item=fg_item, quantity=1, raw_materials=[raw_item1, raw_item2], rm_qty=2)
+		bom = make_bom(
+			item=fg_item,
+			quantity=1,
+			raw_materials=[raw_item1, raw_item2],
+			rm_qty=2,
+			scrap_items=[scrap_item],
+			scrap_qty=10,
+		)
 
 		# Create WO
 		wo = make_wo_order_test_record(production_item=fg_item, qty=10, bom_no=bom.name, status="Not Started")
@@ -2615,7 +2624,7 @@ class TestWorkOrder(ERPNextTestSuite):
 			f"Found duplicate items in disassembly stock entry: {duplicates}",
 		)
 
-		expected_items = 3  # FG item + 2 raw materials
+		expected_items = 4  # FG item + 2 raw materials + 1 scrap item
 		self.assertEqual(
 			len(stock_entry.items),
 			expected_items,
@@ -2625,6 +2634,15 @@ class TestWorkOrder(ERPNextTestSuite):
 		# FG item qty
 		fg_item_row = next((i for i in stock_entry.items if i.item_code == fg_item), None)
 		self.assertEqual(fg_item_row.qty, disassemble_qty)
+
+		# Secondary/Scrap item: should be taken from scrap warehouse in disassembly
+		scrap_row = next((i for i in stock_entry.items if i.item_code == scrap_item), None)
+		self.assertIsNotNone(scrap_row)
+		self.assertEqual(scrap_row.type, "Scrap")
+		self.assertTrue(scrap_row.s_warehouse)
+		self.assertFalse(scrap_row.t_warehouse)
+		self.assertEqual(scrap_row.s_warehouse, wo.scrap_warehouse)
+		self.assertEqual(scrap_row.qty, 40)
 
 		# RM quantities
 		for bom_item in bom.items:

--- a/erpnext/manufacturing/doctype/work_order/work_order.js
+++ b/erpnext/manufacturing/doctype/work_order/work_order.js
@@ -438,7 +438,7 @@ frappe.ui.form.on("Work Order", {
 
 	make_disassembly_order(frm) {
 		erpnext.work_order
-			.show_prompt_for_qty_input(frm, "Disassemble")
+			.show_disassembly_prompt(frm)
 			.then((data) => {
 				if (flt(data.qty) <= 0) {
 					frappe.msgprint(__("Disassemble Qty cannot be less than or equal to <b>0</b>."));
@@ -448,11 +448,14 @@ frappe.ui.form.on("Work Order", {
 					work_order_id: frm.doc.name,
 					purpose: "Disassemble",
 					qty: data.qty,
+					source_stock_entry: data.source_stock_entry,
 				});
 			})
 			.then((stock_entry) => {
-				frappe.model.sync(stock_entry);
-				frappe.set_route("Form", stock_entry.doctype, stock_entry.name);
+				if (stock_entry) {
+					frappe.model.sync(stock_entry);
+					frappe.set_route("Form", stock_entry.doctype, stock_entry.name);
+				}
 			});
 	},
 
@@ -997,6 +1000,60 @@ erpnext.work_order = {
 			}
 		}
 		return flt(max, precision("qty"));
+	},
+
+	show_disassembly_prompt: function (frm) {
+		let max_qty = flt(frm.doc.produced_qty - frm.doc.disassembled_qty);
+
+		let fields = [
+			{
+				fieldtype: "Link",
+				label: __("Source Manufacture Entry"),
+				fieldname: "source_stock_entry",
+				options: "Stock Entry",
+				description: __("Optional. Select a specific manufacture entry to reverse."),
+				get_query: () => {
+					return {
+						filters: {
+							work_order: frm.doc.name,
+							purpose: "Manufacture",
+							docstatus: 1,
+						},
+					};
+				},
+				onchange: async function () {
+					if (!frm.disassembly_prompt) return;
+
+					let se_name = this.value;
+					let qty = max_qty;
+					if (se_name) {
+						qty = await frappe.xcall(
+							"erpnext.manufacturing.doctype.work_order.work_order.get_disassembly_available_qty",
+							{ stock_entry_name: se_name }
+						);
+					}
+
+					frm.disassembly_prompt.set_value("qty", qty);
+					frm.disassembly_prompt.fields_dict.qty.set_description(__("Max: {0}", [qty]));
+				},
+			},
+			{
+				fieldtype: "Float",
+				label: __("Qty for {0}", [__("Disassemble")]),
+				fieldname: "qty",
+				description: __("Max: {0}", [max_qty]),
+				default: max_qty,
+			},
+		];
+
+		return new Promise((resolve, reject) => {
+			frm.disassembly_prompt = frappe.prompt(
+				fields,
+				(data) => resolve(data),
+				__("Disassemble"),
+				__("Create")
+			);
+		});
 	},
 
 	show_prompt_for_qty_input: function (frm, purpose, qty, additional_transfer_entry) {

--- a/erpnext/manufacturing/doctype/work_order/work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/work_order.py
@@ -2384,6 +2384,7 @@ def make_stock_entry(
 	qty: float | None = None,
 	target_warehouse: str | None = None,
 	is_additional_transfer_entry: bool = False,
+	source_stock_entry: str | None = None,
 ):
 	work_order = frappe.get_doc("Work Order", work_order_id)
 	if not frappe.db.get_value("Warehouse", work_order.wip_warehouse, "is_group"):
@@ -2424,6 +2425,8 @@ def make_stock_entry(
 	if purpose == "Disassemble":
 		stock_entry.from_warehouse = work_order.fg_warehouse
 		stock_entry.to_warehouse = target_warehouse or work_order.source_warehouse
+		if source_stock_entry:
+			stock_entry.source_stock_entry = source_stock_entry
 
 	stock_entry.set_stock_entry_type()
 	stock_entry.is_additional_transfer_entry = is_additional_transfer_entry
@@ -2434,6 +2437,27 @@ def make_stock_entry(
 		stock_entry.set_serial_no_batch_for_finished_good()
 
 	return stock_entry.as_dict()
+
+
+@frappe.whitelist()
+def get_disassembly_available_qty(stock_entry_name: str) -> float:
+	se = frappe.db.get_value("Stock Entry", stock_entry_name, ["fg_completed_qty"], as_dict=True)
+	if not se:
+		return 0.0
+
+	already_disassembled = flt(
+		frappe.db.get_value(
+			"Stock Entry",
+			{
+				"source_stock_entry": stock_entry_name,
+				"purpose": "Disassemble",
+				"docstatus": 1,
+			},
+			[{"SUM": "fg_completed_qty"}],
+		)
+	)
+
+	return flt(se.fg_completed_qty) - already_disassembled
 
 
 @frappe.whitelist()

--- a/erpnext/manufacturing/doctype/work_order/work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/work_order.py
@@ -2440,22 +2440,21 @@ def make_stock_entry(
 
 
 @frappe.whitelist()
-def get_disassembly_available_qty(stock_entry_name: str) -> float:
+def get_disassembly_available_qty(stock_entry_name: str, current_se_name: str | None = None) -> float:
 	se = frappe.db.get_value("Stock Entry", stock_entry_name, ["fg_completed_qty"], as_dict=True)
 	if not se:
 		return 0.0
 
-	already_disassembled = flt(
-		frappe.db.get_value(
-			"Stock Entry",
-			{
-				"source_stock_entry": stock_entry_name,
-				"purpose": "Disassemble",
-				"docstatus": 1,
-			},
-			[{"SUM": "fg_completed_qty"}],
-		)
-	)
+	filters = {
+		"source_stock_entry": stock_entry_name,
+		"purpose": "Disassemble",
+		"docstatus": 1,
+	}
+
+	if current_se_name:
+		filters["name"] = ("!=", current_se_name)
+
+	already_disassembled = flt(frappe.db.get_value("Stock Entry", filters, [{"SUM": "fg_completed_qty"}]))
 
 	return flt(se.fg_completed_qty) - already_disassembled
 

--- a/erpnext/stock/doctype/stock_entry/stock_entry.js
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.js
@@ -340,6 +340,55 @@ frappe.ui.form.on("Stock Entry", {
 					__("View")
 				);
 			}
+
+			if (frm.doc.purpose === "Manufacture" && frm.doc.work_order) {
+				frm.add_custom_button(
+					__("Disassemble"),
+					async function () {
+						let available_qty = await frappe.xcall(
+							"erpnext.manufacturing.doctype.work_order.work_order.get_disassembly_available_qty",
+							{ stock_entry_name: frm.doc.name }
+						);
+						frappe.prompt(
+							// fields
+							{
+								fieldtype: "Float",
+								label: __("Qty to Disassemble"),
+								fieldname: "qty",
+								default: available_qty,
+								description: __("Max: {0}", [available_qty]),
+							},
+							// callback
+							async (data) => {
+								if (data.qty > available_qty) {
+									frappe.throw(
+										__("Cannot disassemble more than available quantity ({0})", [
+											available_qty,
+										])
+									);
+								}
+
+								let stock_entry = await frappe.xcall(
+									"erpnext.manufacturing.doctype.work_order.work_order.make_stock_entry",
+									{
+										work_order_id: frm.doc.work_order,
+										purpose: "Disassemble",
+										qty: data.qty,
+										source_stock_entry: frm.doc.name,
+									}
+								);
+								if (stock_entry) {
+									frappe.model.sync(stock_entry);
+									frappe.set_route("Form", stock_entry.doctype, stock_entry.name);
+								}
+							},
+							__("Disassemble"),
+							__("Create")
+						);
+					},
+					__("Create")
+				);
+			}
 		}
 
 		if (frm.doc.docstatus === 0 && !frm.doc.subcontracting_inward_order) {

--- a/erpnext/stock/doctype/stock_entry/stock_entry.js
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.js
@@ -36,6 +36,16 @@ frappe.ui.form.on("Stock Entry", {
 			};
 		});
 
+		frm.set_query("source_stock_entry", function () {
+			return {
+				filters: {
+					purpose: "Manufacture",
+					docstatus: 1,
+					work_order: frm.doc.work_order || undefined,
+				},
+			};
+		});
+
 		frm.set_query("source_warehouse_address", function () {
 			return {
 				query: "erpnext.controllers.queries.get_warehouse_address",

--- a/erpnext/stock/doctype/stock_entry/stock_entry.js
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.js
@@ -242,6 +242,30 @@ frappe.ui.form.on("Stock Entry", {
 		});
 	},
 
+	source_stock_entry: async function (frm) {
+		if (!frm.doc.source_stock_entry || frm.doc.purpose !== "Disassemble") return;
+
+		if (frm._via_source_stock_entry) {
+			frm.call({
+				doc: frm.doc,
+				method: "get_items",
+				callback: function (r) {
+					if (!r.exc) refresh_field("items");
+				},
+			});
+			frm._via_source_stock_entry = false;
+			return;
+		}
+
+		let available_qty = await frappe.xcall(
+			"erpnext.manufacturing.doctype.work_order.work_order.get_disassembly_available_qty",
+			{ stock_entry_name: frm.doc.source_stock_entry }
+		);
+
+		// triggers get_items() via its onchange
+		await frm.set_value("fg_completed_qty", available_qty);
+	},
+
 	outgoing_stock_entry: function (frm) {
 		frappe.call({
 			doc: frm.doc,
@@ -341,7 +365,7 @@ frappe.ui.form.on("Stock Entry", {
 				);
 			}
 
-			if (frm.doc.purpose === "Manufacture" && frm.doc.work_order) {
+			if (frm.doc.purpose === "Manufacture") {
 				frm.add_custom_button(
 					__("Disassemble"),
 					async function () {
@@ -350,7 +374,6 @@ frappe.ui.form.on("Stock Entry", {
 							{ stock_entry_name: frm.doc.name }
 						);
 						frappe.prompt(
-							// fields
 							{
 								fieldtype: "Float",
 								label: __("Qty to Disassemble"),
@@ -358,28 +381,33 @@ frappe.ui.form.on("Stock Entry", {
 								default: available_qty,
 								description: __("Max: {0}", [available_qty]),
 							},
-							// callback
 							async (data) => {
-								if (data.qty > available_qty) {
-									frappe.throw(
-										__("Cannot disassemble more than available quantity ({0})", [
-											available_qty,
-										])
+								if (frm.doc.work_order) {
+									let stock_entry = await frappe.xcall(
+										"erpnext.manufacturing.doctype.work_order.work_order.make_stock_entry",
+										{
+											work_order_id: frm.doc.work_order,
+											purpose: "Disassemble",
+											qty: data.qty,
+											source_stock_entry: frm.doc.name,
+										}
 									);
-								}
-
-								let stock_entry = await frappe.xcall(
-									"erpnext.manufacturing.doctype.work_order.work_order.make_stock_entry",
-									{
-										work_order_id: frm.doc.work_order,
-										purpose: "Disassemble",
-										qty: data.qty,
-										source_stock_entry: frm.doc.name,
+									if (stock_entry) {
+										frappe.model.sync(stock_entry);
+										frappe.set_route("Form", stock_entry.doctype, stock_entry.name);
 									}
-								);
-								if (stock_entry) {
-									frappe.model.sync(stock_entry);
-									frappe.set_route("Form", stock_entry.doctype, stock_entry.name);
+								} else {
+									let se = frappe.model.get_new_doc("Stock Entry");
+									se.company = frm.doc.company;
+									se.stock_entry_type = "Disassemble";
+									se.purpose = "Disassemble";
+									se.source_stock_entry = frm.doc.name;
+									se.from_bom = frm.doc.from_bom;
+									se.bom_no = frm.doc.bom_no;
+									se.fg_completed_qty = data.qty;
+									frm._via_source_stock_entry = true;
+
+									frappe.set_route("Form", "Stock Entry", se.name);
 								}
 							},
 							__("Disassemble"),
@@ -1401,8 +1429,11 @@ erpnext.stock.StockEntry = class StockEntry extends erpnext.stock.StockControlle
 	get_items() {
 		var me = this;
 
-		if (this.frm.doc.work_order || this.frm.doc.bom_no) {
-			// if work order / bom is mentioned, get items
+		if (
+			this.frm.doc.work_order ||
+			this.frm.doc.bom_no ||
+			(this.frm.doc.purpose === "Disassemble" && this.frm.doc.source_stock_entry)
+		) {
 			return this.frm.call({
 				doc: me.frm.doc,
 				freeze: true,

--- a/erpnext/stock/doctype/stock_entry/stock_entry.json
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.json
@@ -24,6 +24,7 @@
   "work_order",
   "subcontracting_order",
   "outgoing_stock_entry",
+  "source_stock_entry",
   "bom_info_section",
   "from_bom",
   "use_multi_level_bom",
@@ -124,6 +125,15 @@
    "label": "Stock Entry (Outward GIT)",
    "options": "Stock Entry",
    "read_only": 1
+  },
+  {
+   "depends_on": "eval:doc.purpose == 'Disassemble'",
+   "fieldname": "source_stock_entry",
+   "fieldtype": "Link",
+   "label": "Source Stock Entry (Manufacture)",
+   "no_copy": 1,
+   "options": "Stock Entry",
+   "print_hide": 1
   },
   {
    "bold": 1,

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -342,9 +342,7 @@ class StockEntry(StockController, SubcontractingInwardController):
 		scale_factor = flt(self.fg_completed_qty) / source_fg_qty if source_fg_qty else 0
 
 		bundle_data = get_voucher_wise_serial_batch_from_bundle(voucher_no=[self.source_stock_entry])
-		source_rows_by_name = {
-			r.name: r for r in self.get_items_from_manufacture_stock_entry(self.source_stock_entry)
-		}
+		source_rows_by_name = {r.name: r for r in self.get_items_from_manufacture_stock_entry()}
 
 		for row in self.items:
 			if not row.ste_detail:
@@ -2375,7 +2373,6 @@ class StockEntry(StockController, SubcontractingInwardController):
 		self._append_disassembly_row_from_source(
 			disassemble_qty=disassemble_qty,
 			scale_factor=scale_factor,
-			source_stock_entry=self.source_stock_entry,
 		)
 
 	def _add_items_for_disassembly_from_work_order(self):
@@ -2396,8 +2393,8 @@ class StockEntry(StockController, SubcontractingInwardController):
 			scale_factor=scale_factor,
 		)
 
-	def _append_disassembly_row_from_source(self, disassemble_qty, scale_factor, source_stock_entry=None):
-		for source_row in self.get_items_from_manufacture_stock_entry(self.source_stock_entry):
+	def _append_disassembly_row_from_source(self, disassemble_qty, scale_factor):
+		for source_row in self.get_items_from_manufacture_stock_entry():
 			if source_row.is_finished_item:
 				qty = disassemble_qty
 				s_warehouse = self.from_warehouse or source_row.t_warehouse
@@ -2433,10 +2430,10 @@ class StockEntry(StockController, SubcontractingInwardController):
 				"use_serial_batch_fields": 1 if (source_row.batch_no or source_row.serial_no) else 0,
 			}
 
-			if source_stock_entry:
+			if self.source_stock_entry:
 				item.update(
 					{
-						"against_stock_entry": source_stock_entry,
+						"against_stock_entry": self.source_stock_entry,
 						"ste_detail": source_row.name,
 					}
 				)
@@ -2483,7 +2480,7 @@ class StockEntry(StockController, SubcontractingInwardController):
 		# Finished goods
 		self.load_items_from_bom()
 
-	def get_items_from_manufacture_stock_entry(self, stock_entry=None):
+	def get_items_from_manufacture_stock_entry(self):
 		SE = frappe.qb.DocType("Stock Entry")
 		SED = frappe.qb.DocType("Stock Entry Detail")
 		query = frappe.qb.from_(SED).join(SE).on(SED.parent == SE.name).where(SE.docstatus == 1)
@@ -2508,10 +2505,10 @@ class StockEntry(StockController, SubcontractingInwardController):
 			SED.bom_no,
 		]
 
-		if stock_entry:
+		if self.source_stock_entry:
 			return (
 				query.select(SED.name, SED.qty, SED.transfer_qty, *common_fields)
-				.where(SE.name == stock_entry)
+				.where(SE.name == self.source_stock_entry)
 				.orderby(SED.idx)
 				.run(as_dict=True)
 			)

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -904,6 +904,16 @@ class StockEntry(StockController, SubcontractingInwardController):
 		if not self.get("source_stock_entry"):
 			return
 
+		if self.work_order:
+			source_wo = frappe.db.get_value("Stock Entry", self.source_stock_entry, "work_order")
+			if source_wo and source_wo != self.work_order:
+				frappe.throw(
+					_(
+						"Source Stock Entry {0} belongs to Work Order {1}, not {2}. Please use a manufacture entry from the same Work Order."
+					).format(self.source_stock_entry, source_wo, self.work_order),
+					title=_("Work Order Mismatch"),
+				)
+
 		from erpnext.manufacturing.doctype.work_order.work_order import get_disassembly_available_qty
 
 		available_qty = get_disassembly_available_qty(self.source_stock_entry, self.name)
@@ -2701,7 +2711,7 @@ class StockEntry(StockController, SubcontractingInwardController):
 		sorted_items = sorted(self.items, key=lambda x: x.item_code)
 		if self.purpose == "Manufacture":
 			# ensure finished item at last
-			sorted_items = sorted(sorted_items, key=lambda x: (x.t_warehouse))
+			sorted_items = sorted(sorted_items, key=lambda x: x.t_warehouse)
 
 		idx = 0
 		for row in sorted_items:

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -2359,7 +2359,8 @@ class StockEntry(StockController, SubcontractingInwardController):
 					"stock_uom": ri.stock_uom,
 					"uom": ri.stock_uom,
 					"conversion_factor": 1,
-					"t_warehouse": ri.source_warehouse or wo.source_warehouse or self.to_warehouse,
+					# manufacture transfers RMs from WIP (not source warehouse)
+					"t_warehouse": self.to_warehouse or wo.wip_warehouse,
 					"s_warehouse": "",
 					"is_finished_item": 0,
 				},

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -861,7 +861,7 @@ class StockEntry(StockController, SubcontractingInwardController):
 
 			if self.purpose == "Disassemble":
 				if has_bom:
-					if d.is_finished_item:
+					if d.is_finished_item or d.type or d.is_legacy_scrap_item:
 						d.t_warehouse = None
 						if not d.s_warehouse:
 							frappe.throw(_("Source warehouse is mandatory for row {0}").format(d.idx))
@@ -2366,10 +2366,16 @@ class StockEntry(StockController, SubcontractingInwardController):
 				qty = flt(self.fg_completed_qty)
 				s_warehouse = self.from_warehouse or source_row.t_warehouse
 				t_warehouse = ""
-			else:
+			elif source_row.s_warehouse:
+				# RM: was consumed FROM s_warehouse → return TO s_warehouse
 				qty = flt(source_row.qty * scale_factor)
 				s_warehouse = ""
 				t_warehouse = self.to_warehouse or source_row.s_warehouse
+			else:
+				# Scrap/secondary: was produced TO t_warehouse → take FROM t_warehouse
+				qty = flt(source_row.qty * scale_factor)
+				s_warehouse = source_row.t_warehouse
+				t_warehouse = ""
 
 			use_serial_batch_fields = 1 if (source_row.batch_no or source_row.serial_no) else 0
 
@@ -2387,6 +2393,9 @@ class StockEntry(StockController, SubcontractingInwardController):
 					"s_warehouse": s_warehouse,
 					"t_warehouse": t_warehouse,
 					"is_finished_item": source_row.is_finished_item,
+					"type": source_row.type,
+					"is_legacy_scrap_item": source_row.is_legacy_scrap_item,
+					"bom_secondary_item": source_row.bom_secondary_item,
 					"against_stock_entry": self.source_stock_entry,
 					"ste_detail": source_row.name,
 					# batch and serial bundles built on submit
@@ -2421,6 +2430,16 @@ class StockEntry(StockController, SubcontractingInwardController):
 				},
 			)
 
+		# Secondary/Scrap items
+		secondary_items = self.get_secondary_items(self.fg_completed_qty)
+		if secondary_items:
+			scrap_warehouse = wo.scrap_warehouse or self.from_warehouse or wo.fg_warehouse
+			for item in secondary_items.values():
+				item["from_warehouse"] = scrap_warehouse
+				item["to_warehouse"] = ""
+				item["is_finished_item"] = 0
+			self.add_to_stock_entry_detail(secondary_items, bom_no=self.bom_no)
+
 		# FG
 		self.append(
 			"items",
@@ -2452,6 +2471,23 @@ class StockEntry(StockController, SubcontractingInwardController):
 
 		self.add_to_stock_entry_detail(item_dict)
 
+		# Secondary/Scrap items (reverse of what set_secondary_items does for Manufacture)
+		secondary_items = self.get_secondary_items(self.fg_completed_qty)
+		if secondary_items:
+			scrap_warehouse = self.from_warehouse
+			if self.work_order:
+				wo_values = frappe.db.get_value(
+					"Work Order", self.work_order, ["scrap_warehouse", "fg_warehouse"], as_dict=True
+				)
+				scrap_warehouse = wo_values.scrap_warehouse or scrap_warehouse or wo_values.fg_warehouse
+
+			for item in secondary_items.values():
+				item["from_warehouse"] = scrap_warehouse
+				item["to_warehouse"] = ""
+				item["is_finished_item"] = 0
+
+			self.add_to_stock_entry_detail(secondary_items, bom_no=self.bom_no)
+
 		# Finished goods
 		self.load_items_from_bom()
 
@@ -2475,6 +2511,9 @@ class StockEntry(StockController, SubcontractingInwardController):
 				SED.basic_rate,
 				SED.conversion_factor,
 				SED.is_finished_item,
+				SED.type,
+				SED.is_legacy_scrap_item,
+				SED.bom_secondary_item,
 				SED.batch_no,
 				SED.serial_no,
 				SED.use_serial_batch_fields,

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -244,6 +244,7 @@ class StockEntry(StockController, SubcontractingInwardController):
 		self.validate_warehouse()
 		self.validate_warehouse_of_sabb()
 		self.validate_work_order()
+		self.validate_source_stock_entry()
 		self.validate_bom()
 		self.set_process_loss_qty()
 		self.validate_purchase_order()
@@ -843,6 +844,26 @@ class StockEntry(StockController, SubcontractingInwardController):
 				self.check_duplicate_entry_for_work_order()
 		elif self.purpose != "Material Transfer":
 			self.work_order = None
+
+	def validate_source_stock_entry(self):
+		if not self.get("source_stock_entry"):
+			return
+
+		from erpnext.manufacturing.doctype.work_order.work_order import get_disassembly_available_qty
+
+		available_qty = get_disassembly_available_qty(self.source_stock_entry, self.name)
+
+		if flt(self.fg_completed_qty) > available_qty:
+			frappe.throw(
+				_(
+					"Cannot disassemble {0} qty against Stock Entry {1}. Only {2} qty available to disassemble."
+				).format(
+					self.fg_completed_qty,
+					self.source_stock_entry,
+					available_qty,
+				),
+				title=_("Excess Disassembly"),
+			)
 
 	def check_if_operations_completed(self):
 		"""Check if Time Sheets are completed against before manufacturing to capture operating costs."""

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -2369,9 +2369,9 @@ class StockEntry(StockController, SubcontractingInwardController):
 		)
 
 	def _add_items_for_disassembly_from_work_order(self):
-		wo = frappe.get_doc("Work Order", self.work_order)
+		wo_produced_qty = frappe.db.get_value("Work Order", self.work_order, "produced_qty")
 
-		wo_produced_qty = flt(wo.produced_qty)
+		wo_produced_qty = flt(wo_produced_qty)
 		if wo_produced_qty <= 0:
 			frappe.throw(_("Work Order {0} has no produced qty").format(self.work_order))
 

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -328,6 +328,58 @@ class StockEntry(StockController, SubcontractingInwardController):
 		if self.purpose != "Disassemble":
 			return
 
+		if self.get("source_stock_entry"):
+			self._set_serial_batch_for_disassembly_from_stock_entry()
+		else:
+			self._set_serial_batch_for_disassembly_from_available_materials()
+
+	def _set_serial_batch_for_disassembly_from_stock_entry(self):
+		from erpnext.stock.doctype.serial_and_batch_bundle.serial_and_batch_bundle import (
+			get_voucher_wise_serial_batch_from_bundle,
+		)
+
+		source_fg_qty = flt(frappe.db.get_value("Stock Entry", self.source_stock_entry, "fg_completed_qty"))
+		scale_factor = flt(self.fg_completed_qty) / source_fg_qty if source_fg_qty else 0
+
+		bundle_data = get_voucher_wise_serial_batch_from_bundle(voucher_no=[self.source_stock_entry])
+		source_rows_by_name = {
+			r.name: r for r in self.get_items_from_manufacture_stock_entry(self.source_stock_entry)
+		}
+
+		for row in self.items:
+			if not row.ste_detail:
+				continue
+
+			source_row = source_rows_by_name.get(row.ste_detail)
+			if not source_row:
+				continue
+
+			source_warehouse = source_row.s_warehouse or source_row.t_warehouse
+			key = (source_row.item_code, source_warehouse, self.source_stock_entry)
+			source_bundle = bundle_data.get(key, {})
+
+			batches = defaultdict(float)
+			serial_nos = []
+
+			if source_bundle.get("batch_nos"):
+				qty_remaining = row.transfer_qty
+				for batch_no, batch_qty in source_bundle["batch_nos"].items():
+					if qty_remaining <= 0:
+						break
+					alloc = min(flt(batch_qty) * scale_factor, qty_remaining)
+					batches[batch_no] = alloc
+					qty_remaining -= alloc
+			elif source_row.batch_no:
+				batches[source_row.batch_no] = row.transfer_qty
+
+			if source_bundle.get("serial_nos"):
+				serial_nos = get_serial_nos(source_bundle["serial_nos"])[: int(row.transfer_qty)]
+			elif source_row.serial_no:
+				serial_nos = get_serial_nos(source_row.serial_no)[: int(row.transfer_qty)]
+
+			self._set_serial_batch_bundle_for_disassembly_row(row, serial_nos, batches)
+
+	def _set_serial_batch_for_disassembly_from_available_materials(self):
 		available_materials = get_available_materials(self.work_order, self)
 		for row in self.items:
 			warehouse = row.s_warehouse or row.t_warehouse
@@ -353,33 +405,37 @@ class StockEntry(StockController, SubcontractingInwardController):
 			if materials.serial_nos:
 				serial_nos = materials.serial_nos[: int(row.transfer_qty)]
 
-			if not serial_nos and not batches:
-				continue
+			self._set_serial_batch_bundle_for_disassembly_row(row, serial_nos, batches)
 
-			bundle_doc = SerialBatchCreation(
-				{
-					"item_code": row.item_code,
-					"warehouse": warehouse,
-					"posting_datetime": get_combine_datetime(self.posting_date, self.posting_time),
-					"voucher_type": self.doctype,
-					"voucher_no": self.name,
-					"voucher_detail_no": row.name,
-					"qty": row.transfer_qty,
-					"type_of_transaction": "Inward" if row.t_warehouse else "Outward",
-					"company": self.company,
-					"do_not_submit": True,
-				}
-			).make_serial_and_batch_bundle(serial_nos=serial_nos, batch_nos=batches)
+	def _set_serial_batch_bundle_for_disassembly_row(self, row, serial_nos, batches):
+		if not serial_nos and not batches:
+			return
 
-			row.serial_and_batch_bundle = bundle_doc.name
-			row.use_serial_batch_fields = 0
+		warehouse = row.s_warehouse or row.t_warehouse
+		bundle_doc = SerialBatchCreation(
+			{
+				"item_code": row.item_code,
+				"warehouse": warehouse,
+				"posting_datetime": get_combine_datetime(self.posting_date, self.posting_time),
+				"voucher_type": self.doctype,
+				"voucher_no": self.name,
+				"voucher_detail_no": row.name,
+				"qty": row.transfer_qty,
+				"type_of_transaction": "Inward" if row.t_warehouse else "Outward",
+				"company": self.company,
+				"do_not_submit": True,
+			}
+		).make_serial_and_batch_bundle(serial_nos=serial_nos, batch_nos=batches)
 
-			row.db_set(
-				{
-					"serial_and_batch_bundle": bundle_doc.name,
-					"use_serial_batch_fields": 0,
-				}
-			)
+		row.serial_and_batch_bundle = bundle_doc.name
+		row.use_serial_batch_fields = 0
+
+		row.db_set(
+			{
+				"serial_and_batch_bundle": bundle_doc.name,
+				"use_serial_batch_fields": 0,
+			}
+		)
 
 	def on_submit(self):
 		self.set_serial_batch_for_disassembly()
@@ -2333,8 +2389,7 @@ class StockEntry(StockController, SubcontractingInwardController):
 					"is_finished_item": source_row.is_finished_item,
 					"against_stock_entry": self.source_stock_entry,
 					"ste_detail": source_row.name,
-					"batch_no": source_row.batch_no,
-					"serial_no": source_row.serial_no,
+					# batch and serial bundles built on submit
 					"use_serial_batch_fields": use_serial_batch_fields,
 				},
 			)

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -2325,7 +2325,7 @@ class StockEntry(StockController, SubcontractingInwardController):
 
 		Priority:
 		1. From a specific Manufacture Stock Entry (exact reversal)
-		2. From Work Order required_items (reflects WO changes)
+		2. From Work Order Manufacture Stock Entries (averaged reversal)
 		3. From BOM (standalone disassembly)
 		"""
 
@@ -2359,103 +2359,78 @@ class StockEntry(StockController, SubcontractingInwardController):
 				_("Source Stock Entry {0} has no finished goods quantity").format(self.source_stock_entry)
 			)
 
-		scale_factor = flt(self.fg_completed_qty) / flt(source_fg_qty)
+		disassemble_qty = flt(self.fg_completed_qty)
+		scale_factor = disassemble_qty / flt(source_fg_qty)
 
-		for source_row in self.get_items_from_manufacture_stock_entry(self.source_stock_entry):
-			if source_row.is_finished_item:
-				qty = flt(self.fg_completed_qty)
-				s_warehouse = self.from_warehouse or source_row.t_warehouse
-				t_warehouse = ""
-			elif source_row.s_warehouse:
-				# RM: was consumed FROM s_warehouse → return TO s_warehouse
-				qty = flt(source_row.qty * scale_factor)
-				s_warehouse = ""
-				t_warehouse = self.to_warehouse or source_row.s_warehouse
-			else:
-				# Scrap/secondary: was produced TO t_warehouse → take FROM t_warehouse
-				qty = flt(source_row.qty * scale_factor)
-				s_warehouse = source_row.t_warehouse
-				t_warehouse = ""
-
-			use_serial_batch_fields = 1 if (source_row.batch_no or source_row.serial_no) else 0
-
-			self.append(
-				"items",
-				{
-					"item_code": source_row.item_code,
-					"item_name": source_row.item_name,
-					"description": source_row.description,
-					"stock_uom": source_row.stock_uom,
-					"uom": source_row.uom,
-					"conversion_factor": source_row.conversion_factor,
-					"basic_rate": source_row.basic_rate,
-					"qty": qty,
-					"s_warehouse": s_warehouse,
-					"t_warehouse": t_warehouse,
-					"is_finished_item": source_row.is_finished_item,
-					"type": source_row.type,
-					"is_legacy_scrap_item": source_row.is_legacy_scrap_item,
-					"bom_secondary_item": source_row.bom_secondary_item,
-					"against_stock_entry": self.source_stock_entry,
-					"ste_detail": source_row.name,
-					# batch and serial bundles built on submit
-					"use_serial_batch_fields": use_serial_batch_fields,
-				},
-			)
+		self._append_disassembly_row_from_source(
+			disassemble_qty=disassemble_qty,
+			scale_factor=scale_factor,
+			source_stock_entry=self.source_stock_entry,
+		)
 
 	def _add_items_for_disassembly_from_work_order(self):
 		wo = frappe.get_doc("Work Order", self.work_order)
 
-		if not wo.required_items:
-			return self._add_items_for_disassembly_from_bom()
+		wo_produced_qty = flt(wo.produced_qty)
+		if wo_produced_qty <= 0:
+			frappe.throw(_("Work Order {0} has no produced qty").format(self.work_order))
 
-		scale_factor = flt(self.fg_completed_qty) / flt(wo.qty) if flt(wo.qty) else 0
+		disassemble_qty = flt(self.fg_completed_qty)
+		if disassemble_qty <= 0:
+			frappe.throw(_("Disassemble Qty cannot be less than or equal to 0."))
 
-		# RMs
-		for ri in wo.required_items:
-			self.append(
-				"items",
-				{
-					"item_code": ri.item_code,
-					"item_name": ri.item_name,
-					"description": ri.description,
-					"qty": flt(ri.required_qty * scale_factor),
-					"stock_uom": ri.stock_uom,
-					"uom": ri.stock_uom,
-					"conversion_factor": 1,
-					# manufacture transfers RMs from WIP (not source warehouse)
-					"t_warehouse": self.to_warehouse or wo.wip_warehouse,
-					"s_warehouse": "",
-					"is_finished_item": 0,
-				},
-			)
+		scale_factor = disassemble_qty / wo_produced_qty
 
-		# Secondary/Scrap items
-		secondary_items = self.get_secondary_items(self.fg_completed_qty)
-		if secondary_items:
-			scrap_warehouse = wo.scrap_warehouse or self.from_warehouse or wo.fg_warehouse
-			for item in secondary_items.values():
-				item["from_warehouse"] = scrap_warehouse
-				item["to_warehouse"] = ""
-				item["is_finished_item"] = 0
-			self.add_to_stock_entry_detail(secondary_items, bom_no=self.bom_no)
-
-		# FG
-		self.append(
-			"items",
-			{
-				"item_code": wo.production_item,
-				"item_name": wo.item_name,
-				"description": wo.description,
-				"qty": flt(self.fg_completed_qty),
-				"stock_uom": wo.stock_uom,
-				"uom": wo.stock_uom,
-				"conversion_factor": 1,
-				"s_warehouse": self.from_warehouse or wo.fg_warehouse,
-				"t_warehouse": "",
-				"is_finished_item": 1,
-			},
+		self._append_disassembly_row_from_source(
+			disassemble_qty=disassemble_qty,
+			scale_factor=scale_factor,
 		)
+
+	def _append_disassembly_row_from_source(self, disassemble_qty, scale_factor, source_stock_entry=None):
+		for source_row in self.get_items_from_manufacture_stock_entry(self.source_stock_entry):
+			if source_row.is_finished_item:
+				qty = disassemble_qty
+				s_warehouse = self.from_warehouse or source_row.t_warehouse
+				t_warehouse = ""
+			elif source_row.s_warehouse:
+				# RM: was consumed FROM s_warehouse -> return TO s_warehouse
+				qty = flt(source_row.qty * scale_factor)
+				s_warehouse = ""
+				t_warehouse = self.to_warehouse or source_row.s_warehouse
+			else:
+				# Scrap/secondary: was produced TO t_warehouse -> take FROM t_warehouse
+				qty = flt(source_row.qty * scale_factor)
+				s_warehouse = source_row.t_warehouse
+				t_warehouse = ""
+
+			item = {
+				"item_code": source_row.item_code,
+				"item_name": source_row.item_name,
+				"description": source_row.description,
+				"stock_uom": source_row.stock_uom,
+				"uom": source_row.uom,
+				"conversion_factor": source_row.conversion_factor,
+				"basic_rate": source_row.basic_rate,
+				"qty": qty,
+				"s_warehouse": s_warehouse,
+				"t_warehouse": t_warehouse,
+				"is_finished_item": source_row.is_finished_item,
+				"type": source_row.type,
+				"is_legacy_scrap_item": source_row.is_legacy_scrap_item,
+				"bom_secondary_item": source_row.bom_secondary_item,
+				# batch and serial bundles built on submit
+				"use_serial_batch_fields": 1 if (source_row.batch_no or source_row.serial_no) else 0,
+			}
+
+			if source_stock_entry:
+				item.update(
+					{
+						"against_stock_entry": source_stock_entry,
+						"ste_detail": source_row.name,
+					}
+				)
+
+			self.append("items", item)
 
 	def _add_items_for_disassembly_from_bom(self):
 		if not self.bom_no or not self.fg_completed_qty:

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -152,6 +152,7 @@ class StockEntry(StockController, SubcontractingInwardController):
 		select_print_heading: DF.Link | None
 		set_posting_time: DF.Check
 		source_address_display: DF.TextEditor | None
+		source_stock_entry: DF.Link | None
 		source_warehouse_address: DF.Link | None
 		stock_entry_type: DF.Link
 		subcontracting_inward_order: DF.Link | None

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -2471,6 +2471,12 @@ class StockEntry(StockController, SubcontractingInwardController):
 				item["to_warehouse"] = ""
 				item["is_finished_item"] = 0
 
+				if item.get("process_loss_per"):
+					item["qty"] -= flt(
+						item["qty"] * (item["process_loss_per"] / 100),
+						self.precision("fg_completed_qty"),
+					)
+
 			self.add_to_stock_entry_detail(secondary_items, bom_no=self.bom_no)
 
 		# Finished goods

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -30,7 +30,6 @@ from erpnext.buying.utils import check_on_hold_or_closed_status
 from erpnext.controllers.taxes_and_totals import init_landed_taxes_and_totals
 from erpnext.manufacturing.doctype.bom.bom import (
 	add_additional_cost,
-	get_bom_items_as_dict,
 	get_op_cost_from_sub_assemblies,
 	get_secondary_items_from_sub_assemblies,
 	validate_bom_no,
@@ -2266,44 +2265,107 @@ class StockEntry(StockController, SubcontractingInwardController):
 				)
 
 	def get_items_for_disassembly(self):
-		"""Get items for Disassembly Order"""
+		"""Get items for Disassembly Order.
+
+		Priority:
+		1. From a specific Manufacture Stock Entry (exact reversal)
+		2. From Work Order required_items (reflects WO changes)
+		3. From BOM (standalone disassembly)
+		"""
+
+		if self.get("source_stock_entry"):
+			return self._add_items_for_disassembly_from_stock_entry()
 
 		if self.work_order:
 			return self._add_items_for_disassembly_from_work_order()
 
 		return self._add_items_for_disassembly_from_bom()
 
+	def _add_items_for_disassembly_from_stock_entry(self):
+		source_fg_qty = frappe.db.get_value("Stock Entry", self.source_stock_entry, "fg_completed_qty")
+		if not source_fg_qty:
+			frappe.throw(
+				_("Source Stock Entry {0} has no finished goods quantity").format(self.source_stock_entry)
+			)
+
+		scale_factor = flt(self.fg_completed_qty) / flt(source_fg_qty)
+
+		for source_row in self.get_items_from_manufacture_stock_entry(self.source_stock_entry):
+			if source_row.is_finished_item:
+				qty = flt(self.fg_completed_qty)
+				s_warehouse = self.from_warehouse or source_row.t_warehouse
+				t_warehouse = ""
+			else:
+				qty = flt(source_row.qty * scale_factor)
+				s_warehouse = ""
+				t_warehouse = self.to_warehouse or source_row.s_warehouse
+
+			use_serial_batch_fields = 1 if (source_row.batch_no or source_row.serial_no) else 0
+
+			self.append(
+				"items",
+				{
+					"item_code": source_row.item_code,
+					"item_name": source_row.item_name,
+					"description": source_row.description,
+					"stock_uom": source_row.stock_uom,
+					"uom": source_row.uom,
+					"conversion_factor": source_row.conversion_factor,
+					"basic_rate": source_row.basic_rate,
+					"qty": qty,
+					"s_warehouse": s_warehouse,
+					"t_warehouse": t_warehouse,
+					"is_finished_item": source_row.is_finished_item,
+					"against_stock_entry": self.source_stock_entry,
+					"ste_detail": source_row.name,
+					"batch_no": source_row.batch_no,
+					"serial_no": source_row.serial_no,
+					"use_serial_batch_fields": use_serial_batch_fields,
+				},
+			)
+
 	def _add_items_for_disassembly_from_work_order(self):
-		items = self.get_items_from_manufacture_entry()
+		wo = frappe.get_doc("Work Order", self.work_order)
 
-		s_warehouse = frappe.db.get_value("Work Order", self.work_order, "fg_warehouse")
+		if not wo.required_items:
+			return self._add_items_for_disassembly_from_bom()
 
-		items_dict = get_bom_items_as_dict(
-			self.bom_no,
-			self.company,
-			self.fg_completed_qty,
-			fetch_exploded=self.use_multi_level_bom,
-			fetch_qty_in_stock_uom=False,
+		scale_factor = flt(self.fg_completed_qty) / flt(wo.qty) if flt(wo.qty) else 0
+
+		# RMs
+		for ri in wo.required_items:
+			self.append(
+				"items",
+				{
+					"item_code": ri.item_code,
+					"item_name": ri.item_name,
+					"description": ri.description,
+					"qty": flt(ri.required_qty * scale_factor),
+					"stock_uom": ri.stock_uom,
+					"uom": ri.stock_uom,
+					"conversion_factor": 1,
+					"t_warehouse": ri.source_warehouse or wo.source_warehouse or self.to_warehouse,
+					"s_warehouse": "",
+					"is_finished_item": 0,
+				},
+			)
+
+		# FG
+		self.append(
+			"items",
+			{
+				"item_code": wo.production_item,
+				"item_name": wo.item_name,
+				"description": wo.description,
+				"qty": flt(self.fg_completed_qty),
+				"stock_uom": wo.stock_uom,
+				"uom": wo.stock_uom,
+				"conversion_factor": 1,
+				"s_warehouse": self.from_warehouse or wo.fg_warehouse,
+				"t_warehouse": "",
+				"is_finished_item": 1,
+			},
 		)
-
-		for row in items:
-			child_row = self.append("items", {})
-			for field, value in row.items():
-				if value is not None:
-					child_row.set(field, value)
-
-			# update qty and amount from BOM items
-			bom_items = items_dict.get(row.item_code)
-			if bom_items:
-				child_row.qty = bom_items.get("qty", child_row.qty)
-				child_row.amount = bom_items.get("amount", child_row.amount)
-
-			if row.is_finished_item:
-				child_row.qty = self.fg_completed_qty
-
-			child_row.s_warehouse = (self.from_warehouse or s_warehouse) if row.is_finished_item else ""
-			child_row.t_warehouse = row.s_warehouse
-			child_row.is_finished_item = 0 if row.is_finished_item else 1
 
 	def _add_items_for_disassembly_from_bom(self):
 		if not self.bom_no or not self.fg_completed_qty:
@@ -2322,34 +2384,36 @@ class StockEntry(StockController, SubcontractingInwardController):
 		# Finished goods
 		self.load_items_from_bom()
 
-	def get_items_from_manufacture_entry(self):
-		return frappe.get_all(
-			"Stock Entry",
-			fields=[
-				"`tabStock Entry Detail`.`item_code`",
-				"`tabStock Entry Detail`.`item_name`",
-				"`tabStock Entry Detail`.`description`",
-				{"SUM": "`tabStock Entry Detail`.`qty`", "as": "qty"},
-				{"SUM": "`tabStock Entry Detail`.`transfer_qty`", "as": "transfer_qty"},
-				"`tabStock Entry Detail`.`stock_uom`",
-				"`tabStock Entry Detail`.`uom`",
-				"`tabStock Entry Detail`.`basic_rate`",
-				"`tabStock Entry Detail`.`conversion_factor`",
-				"`tabStock Entry Detail`.`is_finished_item`",
-				"`tabStock Entry Detail`.`batch_no`",
-				"`tabStock Entry Detail`.`serial_no`",
-				"`tabStock Entry Detail`.`s_warehouse`",
-				"`tabStock Entry Detail`.`t_warehouse`",
-				"`tabStock Entry Detail`.`use_serial_batch_fields`",
-			],
-			filters=[
-				["Stock Entry", "purpose", "=", "Manufacture"],
-				["Stock Entry", "work_order", "=", self.work_order],
-				["Stock Entry", "docstatus", "=", 1],
-				["Stock Entry Detail", "docstatus", "=", 1],
-			],
-			order_by="`tabStock Entry Detail`.`idx` desc, `tabStock Entry Detail`.`is_finished_item` desc",
-			group_by="`tabStock Entry Detail`.`item_code`",
+	def get_items_from_manufacture_stock_entry(self, stock_entry):
+		SE = frappe.qb.DocType("Stock Entry")
+		SED = frappe.qb.DocType("Stock Entry Detail")
+
+		return (
+			frappe.qb.from_(SED)
+			.join(SE)
+			.on(SED.parent == SE.name)
+			.select(
+				SED.name,
+				SED.item_code,
+				SED.item_name,
+				SED.description,
+				SED.qty,
+				SED.transfer_qty,
+				SED.stock_uom,
+				SED.uom,
+				SED.basic_rate,
+				SED.conversion_factor,
+				SED.is_finished_item,
+				SED.batch_no,
+				SED.serial_no,
+				SED.use_serial_batch_fields,
+				SED.s_warehouse,
+				SED.t_warehouse,
+			)
+			.where(SE.name == stock_entry)
+			.where(SE.docstatus == 1)
+			.orderby(SED.idx)
+			.run(as_dict=True)
 		)
 
 	@frappe.whitelist()

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -366,7 +366,7 @@ class StockEntry(StockController, SubcontractingInwardController):
 				for batch_no, batch_qty in source_bundle["batch_nos"].items():
 					if qty_remaining <= 0:
 						break
-					alloc = min(flt(batch_qty) * scale_factor, qty_remaining)
+					alloc = min(abs(flt(batch_qty)) * scale_factor, qty_remaining)
 					batches[batch_no] = alloc
 					qty_remaining -= alloc
 			elif source_row.batch_no:
@@ -2428,6 +2428,7 @@ class StockEntry(StockController, SubcontractingInwardController):
 				"type": source_row.type,
 				"is_legacy_scrap_item": source_row.is_legacy_scrap_item,
 				"bom_secondary_item": source_row.bom_secondary_item,
+				"bom_no": source_row.bom_no,
 				# batch and serial bundles built on submit
 				"use_serial_batch_fields": 1 if (source_row.batch_no or source_row.serial_no) else 0,
 			}
@@ -2504,6 +2505,7 @@ class StockEntry(StockController, SubcontractingInwardController):
 			SED.use_serial_batch_fields,
 			SED.s_warehouse,
 			SED.t_warehouse,
+			SED.bom_no,
 		]
 
 		if stock_entry:

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -2491,37 +2491,43 @@ class StockEntry(StockController, SubcontractingInwardController):
 		# Finished goods
 		self.load_items_from_bom()
 
-	def get_items_from_manufacture_stock_entry(self, stock_entry):
+	def get_items_from_manufacture_stock_entry(self, stock_entry=None):
 		SE = frappe.qb.DocType("Stock Entry")
 		SED = frappe.qb.DocType("Stock Entry Detail")
+		query = frappe.qb.from_(SED).join(SE).on(SED.parent == SE.name).where(SE.docstatus == 1)
+
+		common_fields = [
+			SED.item_code,
+			SED.item_name,
+			SED.description,
+			SED.stock_uom,
+			SED.uom,
+			SED.basic_rate,
+			SED.conversion_factor,
+			SED.is_finished_item,
+			SED.type,
+			SED.is_legacy_scrap_item,
+			SED.bom_secondary_item,
+			SED.batch_no,
+			SED.serial_no,
+			SED.use_serial_batch_fields,
+			SED.s_warehouse,
+			SED.t_warehouse,
+		]
+
+		if stock_entry:
+			return (
+				query.select(SED.name, SED.qty, SED.transfer_qty, *common_fields)
+				.where(SE.name == stock_entry)
+				.orderby(SED.idx)
+				.run(as_dict=True)
+			)
 
 		return (
-			frappe.qb.from_(SED)
-			.join(SE)
-			.on(SED.parent == SE.name)
-			.select(
-				SED.name,
-				SED.item_code,
-				SED.item_name,
-				SED.description,
-				SED.qty,
-				SED.transfer_qty,
-				SED.stock_uom,
-				SED.uom,
-				SED.basic_rate,
-				SED.conversion_factor,
-				SED.is_finished_item,
-				SED.type,
-				SED.is_legacy_scrap_item,
-				SED.bom_secondary_item,
-				SED.batch_no,
-				SED.serial_no,
-				SED.use_serial_batch_fields,
-				SED.s_warehouse,
-				SED.t_warehouse,
-			)
-			.where(SE.name == stock_entry)
-			.where(SE.docstatus == 1)
+			query.select(Sum(SED.qty).as_("qty"), Sum(SED.transfer_qty).as_("transfer_qty"), *common_fields)
+			.where(SE.purpose == "Manufacture")
+			.where(SE.work_order == self.work_order)
+			.groupby(SED.item_code)
 			.orderby(SED.idx)
 			.run(as_dict=True)
 		)

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -2273,6 +2273,21 @@ class StockEntry(StockController, SubcontractingInwardController):
 		3. From BOM (standalone disassembly)
 		"""
 
+		# Auto-set source_stock_entry if WO has exactly one manufacture entry
+		if not self.get("source_stock_entry") and self.work_order:
+			manufacture_entries = frappe.get_all(
+				"Stock Entry",
+				filters={
+					"work_order": self.work_order,
+					"purpose": "Manufacture",
+					"docstatus": 1,
+				},
+				pluck="name",
+				limit_page_length=2,
+			)
+			if len(manufacture_entries) == 1:
+				self.source_stock_entry = manufacture_entries[0]
+
 		if self.get("source_stock_entry"):
 			return self._add_items_for_disassembly_from_stock_entry()
 


### PR DESCRIPTION
Reference Issue: https://github.com/frappe/erpnext/issues/53667

## Fixes

- New field introduced in stock entry > `source_stock_entry` > Refers to stock entry that should be disassembled
- Workflow for disassembly from WO: Now asks for source stock entry to reverse (optional)
- Added workflow to create disassembly from manufacturing stock entry (may or maynot be linked with WO)
- New API in `work_order.py` > returns max qty that's available for disassembly
- Revised priority for how RM items are determined in disassembly
- Use batch and serial numbers only from source_stock_entry if it exists (for reversal)
- Disassembly now also handles secondary / scrap items reversal

## Revised Priority

BOM acts as a template to auto-fill work order / manufacturing entry. User still get's a chance to update the required items in work order / stock entry for final consumption.

Disassembly should be based on how the material is consumed.

- First Priority: Usage in stock entry
- Next: Avg manufacturing stock entry from work order
- Last: BOM

## After Fix

https://github.com/user-attachments/assets/960265ec-bcf1-4f80-83f7-00495a1c896d

