### PR TITLE
fix: Party Field only visibile when party type selected

### DIFF
--- a/erpnext/accounts/report/general_ledger/general_ledger.js
+++ b/erpnext/accounts/report/general_ledger/general_ledger.js
@@ -74,6 +74,7 @@ frappe.query_reports["General Ledger"] = {
 			label: __("Party"),
 			fieldtype: "MultiSelectList",
 			options: "party_type",
+			depends_on: "party_type",
 			get_data: function (txt) {
 				if (!frappe.query_report.filters) return;
 


### PR DESCRIPTION
The Party field must be visible only in the General Ledger if the party type has been selected 
fixes: https://github.com/frappe/erpnext/issues/53962