### PR TITLE
fix(ux): refresh grid to correctly persist the state of fields

### DIFF
--- a/erpnext/manufacturing/doctype/work_order/work_order.js
+++ b/erpnext/manufacturing/doctype/work_order/work_order.js
@@ -244,13 +244,16 @@ frappe.ui.form.on("Work Order", {
 	},
 
 	toggle_items_editable(frm) {
-		if (!frm.doc.__onload?.allow_editing_items) {
-			frm.set_df_property("required_items", "cannot_delete_rows", true);
-			frm.set_df_property("required_items", "cannot_add_rows", true);
-			frm.fields_dict["required_items"].grid.update_docfield_property("item_code", "read_only", 1);
-			frm.fields_dict["required_items"].grid.update_docfield_property("required_qty", "read_only", 1);
-			frm.fields_dict["required_items"].grid.refresh();
-		}
+		let allow_edit = true;
+		if (!frm.doc.__onload?.allow_editing_items) allow_edit = false;
+
+		frm.set_df_property("required_items", "cannot_delete_rows", !allow_edit);
+		frm.set_df_property("required_items", "cannot_add_rows", !allow_edit);
+
+		const grid = frm.fields_dict["required_items"].grid;
+		grid.update_docfield_property("item_code", "read_only", !allow_edit);
+		grid.update_docfield_property("required_qty", "read_only", !allow_edit);
+		grid.refresh();
 	},
 
 	hide_reserve_stock_button(frm) {


### PR DESCRIPTION
## Issue

Buttons to add or remove rows not consistently visible based on settings.

## Screen Recording

### Before

https://github.com/user-attachments/assets/63fc3d9a-5123-4c96-8d31-22414a498029

### After

https://github.com/user-attachments/assets/c63465a8-5c33-4f80-a94a-617a5e831dc6
