### PR TITLE
feat: Allow Editing of Items and Quantities in Work Order

### DIFF
--- a/erpnext/manufacturing/doctype/manufacturing_settings/manufacturing_settings.json
+++ b/erpnext/manufacturing/doctype/manufacturing_settings/manufacturing_settings.json
@@ -15,6 +15,7 @@
   "bom_section",
   "update_bom_costs_automatically",
   "column_break_lhyt",
+  "allow_editing_of_items_and_quantities_in_work_order",
   "section_break_6",
   "default_wip_warehouse",
   "default_fg_warehouse",
@@ -243,13 +244,20 @@
    "fieldname": "enforce_time_logs",
    "fieldtype": "Check",
    "label": "Enforce Time Logs"
+  },
+  {
+   "default": "0",
+   "description": "If enabled, the system will allow users to edit the raw materials and their quantities in the Work Order. The system will not reset the quantities as per the BOM, if the user has changed them.",
+   "fieldname": "allow_editing_of_items_and_quantities_in_work_order",
+   "fieldtype": "Check",
+   "label": "Allow Editing of Items and Quantities in Work Order"
   }
  ],
  "icon": "icon-wrench",
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-05-16 11:23:16.916512",
+ "modified": "2025-11-07 14:52:56.241459",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "Manufacturing Settings",

--- a/erpnext/manufacturing/doctype/manufacturing_settings/manufacturing_settings.py
+++ b/erpnext/manufacturing/doctype/manufacturing_settings/manufacturing_settings.py
@@ -18,6 +18,7 @@ class ManufacturingSettings(Document):
 		from frappe.types import DF
 
 		add_corrective_operation_cost_in_finished_good_valuation: DF.Check
+		allow_editing_of_items_and_quantities_in_work_order: DF.Check
 		allow_overtime: DF.Check
 		allow_production_on_holidays: DF.Check
 		backflush_raw_materials_based_on: DF.Literal["BOM", "Material Transferred for Manufacture"]

--- a/erpnext/manufacturing/doctype/work_order/work_order.js
+++ b/erpnext/manufacturing/doctype/work_order/work_order.js
@@ -247,13 +247,16 @@ frappe.ui.form.on("Work Order", {
 	},
 
 	toggle_items_editable(frm) {
-		if (!frm.doc.__onload?.allow_editing_items) {
-			frm.set_df_property("required_items", "cannot_delete_rows", true);
-			frm.set_df_property("required_items", "cannot_add_rows", true);
-			frm.fields_dict["required_items"].grid.update_docfield_property("item_code", "read_only", 1);
-			frm.fields_dict["required_items"].grid.update_docfield_property("required_qty", "read_only", 1);
-			frm.fields_dict["required_items"].grid.refresh();
-		}
+		let allow_edit = true;
+		if (!frm.doc.__onload?.allow_editing_items) allow_edit = false;
+
+		frm.set_df_property("required_items", "cannot_delete_rows", !allow_edit);
+		frm.set_df_property("required_items", "cannot_add_rows", !allow_edit);
+
+		const grid = frm.fields_dict["required_items"].grid;
+		grid.update_docfield_property("item_code", "read_only", !allow_edit);
+		grid.update_docfield_property("required_qty", "read_only", !allow_edit);
+		grid.refresh();
 	},
 
 	add_custom_button_to_return_components: function (frm) {

--- a/erpnext/manufacturing/doctype/work_order/work_order.js
+++ b/erpnext/manufacturing/doctype/work_order/work_order.js
@@ -243,6 +243,11 @@ frappe.ui.form.on("Work Order", {
 
 		frm.trigger("add_custom_button_to_return_components");
 		frm.trigger("allow_alternative_item");
+		frm.trigger("toggle_items_editable");
+	},
+
+	toggle_items_editable(frm) {
+		frm.toggle_enable("required_items", frm.doc.__onload?.allow_editing_items === 1 ? 1 : 0);
 	},
 
 	add_custom_button_to_return_components: function (frm) {

--- a/erpnext/manufacturing/doctype/work_order/work_order.js
+++ b/erpnext/manufacturing/doctype/work_order/work_order.js
@@ -247,7 +247,13 @@ frappe.ui.form.on("Work Order", {
 	},
 
 	toggle_items_editable(frm) {
-		frm.toggle_enable("required_items", frm.doc.__onload?.allow_editing_items === 1 ? 1 : 0);
+		if (!frm.doc.__onload?.allow_editing_items) {
+			frm.set_df_property("required_items", "cannot_delete_rows", true);
+			frm.set_df_property("required_items", "cannot_add_rows", true);
+			frm.fields_dict["required_items"].grid.update_docfield_property("item_code", "read_only", 1);
+			frm.fields_dict["required_items"].grid.update_docfield_property("required_qty", "read_only", 1);
+			frm.fields_dict["required_items"].grid.refresh();
+		}
 	},
 
 	add_custom_button_to_return_components: function (frm) {

--- a/erpnext/manufacturing/doctype/work_order/work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/work_order.py
@@ -141,6 +141,7 @@ class WorkOrder(Document):
 
 	def onload(self):
 		ms = frappe.get_doc("Manufacturing Settings")
+		self.set_onload("allow_editing_items", ms.allow_editing_of_items_and_quantities_in_work_order)
 		self.set_onload("material_consumption", ms.material_consumption)
 		self.set_onload("backflush_raw_materials_based_on", ms.backflush_raw_materials_based_on)
 		self.set_onload("overproduction_percentage", ms.overproduction_percentage_for_work_order)
@@ -167,7 +168,11 @@ class WorkOrder(Document):
 
 		validate_uom_is_integer(self, "stock_uom", ["required_qty"])
 
-		self.set_required_items(reset_only_qty=len(self.get("required_items")))
+		if not len(self.get("required_items")) or not frappe.db.get_single_value(
+			"Manufacturing Settings", "allow_editing_of_items_and_quantities_in_work_order"
+		):
+			self.set_required_items(reset_only_qty=len(self.get("required_items")))
+
 		self.validate_operations_sequence()
 
 	def validate_operations_sequence(self):

--- a/erpnext/manufacturing/doctype/work_order_item/work_order_item.json
+++ b/erpnext/manufacturing/doctype/work_order_item/work_order_item.json
@@ -151,7 +151,7 @@
  ],
  "istable": 1,
  "links": [],
- "modified": "2024-11-19 15:48:16.823384",
+ "modified": "2025-12-02 11:16:05.081613",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "Work Order Item",


### PR DESCRIPTION
Backport of:
https://github.com/frappe/erpnext/pull/50407
https://github.com/frappe/erpnext/pull/50856
https://github.com/frappe/erpnext/pull/53973

Resolves:
#53668 

This allowed partially, making it a bad ux. Hence backporting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new Manufacturing Settings option to enable editing of items and quantities in Work Orders. When activated, users can modify raw materials and quantities without triggering automatic BOM-based resets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->