### PR TITLE
feat: Convert Project DocType to NestedSet (Tree Structure) for hierarchical management

### DIFF
--- a/erpnext/projects/doctype/project/project.json
+++ b/erpnext/projects/doctype/project/project.json
@@ -478,6 +478,7 @@
  "icon": "fa fa-puzzle-piece",
  "idx": 29,
  "index_web_pages_for_search": 1,
+ "is_tree": 1,
  "links": [],
  "max_attachments": 4,
  "modified": "2026-03-09 17:15:24.426294",


### PR DESCRIPTION
The projects are all nested, so this must be enabled.