### PR TITLE
fix(manufacturing): check remaining qty to calculate operating cost

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -3733,9 +3733,12 @@ def get_operating_cost_per_unit(work_order=None, bom_no=None):
 
 		for d in work_order.get("operations"):
 			if flt(d.completed_qty):
-				operating_cost_per_unit += flt(
-					d.actual_operating_cost - get_consumed_operating_cost(work_order.name, bom_no)
-				) / flt(d.completed_qty - work_order.produced_qty)
+				if not (remaining_qty := flt(d.completed_qty - work_order.produced_qty)):
+					continue
+				operating_cost_per_unit += (
+					flt(d.actual_operating_cost - get_consumed_operating_cost(work_order.name, bom_no))
+					/ remaining_qty
+				)
 			elif work_order.qty:
 				operating_cost_per_unit += flt(d.planned_operating_cost) / flt(work_order.qty)
 


### PR DESCRIPTION
**Issue:**
While trying to create a manufacturing stock entry from job card, the system is throwing **ZeroDivisionError**.

**Ref:** [#63874](https://support.frappe.io/helpdesk/tickets/63874)

<img width="1136" height="410" alt="image" src="https://github.com/user-attachments/assets/4f273701-c112-46f3-941e-e78f59e63395" />


**Backport Needed for v16**