### PR TITLE
fix(printing): added posting date in purchase auditing voucher print …

### DIFF
--- a/erpnext/accounts/print_format/purchase_auditing_voucher/purchase_auditing_voucher.html
+++ b/erpnext/accounts/print_format/purchase_auditing_voucher/purchase_auditing_voucher.html
@@ -8,7 +8,7 @@
         <div class="col-xs-6">
             <table>
             <tr><td><strong>Supplier Name: </strong></td><td>{{ doc.supplier }}</td></tr>
-            <tr><td><strong>Due Date: </strong></td><td>{{ frappe.utils.format_date(doc.due_date) }}</td></tr>
+			<tr><td><strong>Posting Date: </strong></td><td>{{ frappe.utils.format_date(doc.posting_date) }}</td></tr>
             <tr><td><strong>Address: </strong></td><td>{{doc.address_display}}</td></tr>
             <tr><td><strong>Contact: </strong></td><td>{{doc.contact_display}}</td></tr>
             <tr><td><strong>Mobile no: </strong> </td><td>{{doc.contact_mobile}}</td></tr>
@@ -17,7 +17,8 @@
         <div class="col-xs-6">
             <table>
                 <tr><td><strong>Voucher No: </strong></td><td>{{ doc.name }}</td></tr>
-                <tr><td><strong>Date: </strong></td><td>{{ frappe.utils.format_date(doc.creation) }}</td></tr>
+				<tr><td><strong>Due Date: </strong></td><td>{{ frappe.utils.format_date(doc.due_date) }}</td></tr>
+                <tr><td><strong>Creation Date: </strong></td><td>{{ frappe.utils.format_date(doc.creation) }}</td></tr>
             </table>
         </div>
     </div>


### PR DESCRIPTION
- Added Posting Date
- Changed Name of Date to Creation Date to eliminate confusion on which date is being printed
- Re-ordered the dates in the order of priority

<img width="672" height="454" alt="image" src="https://github.com/user-attachments/assets/8dd11c2f-bd5e-4c33-9640-5be72d3ac1b2" />


I propose to add the posting date as the primary date as it affects accounting the most. I've also changed the names in the print format to eliminate confusion and make it easier for accountants to read the print format.
