### PR TITLE
feat(accounts): support multi-company financial report templates

### DIFF
--- a/erpnext/accounts/doctype/financial_report_template/financial_report_engine.py
+++ b/erpnext/accounts/doctype/financial_report_template/financial_report_engine.py
@@ -5,6 +5,7 @@ import ast
 import json
 import math
 from abc import ABC, abstractmethod
+from collections import defaultdict
 from dataclasses import dataclass, field
 from functools import reduce
 from typing import Any, Union
@@ -17,7 +18,6 @@ from frappe.query_builder.functions import Sum
 from frappe.utils import cstr, date_diff, flt, getdate
 from pypika.terms import Bracket, LiteralValue
 
-from erpnext import get_company_currency
 from erpnext.accounts.doctype.accounting_dimension.accounting_dimension import (
 	get_accounting_dimensions,
 	get_dimension_with_children,
@@ -72,6 +72,7 @@ class AccountData:
 	"""Account data across all periods"""
 
 	account: str  # docname
+	company: str = ""
 	account_name: str = ""  # account name
 	account_number: str = ""
 	period_values: dict[str, PeriodValue] = field(default_factory=dict)
@@ -107,6 +108,7 @@ class AccountData:
 	def copy(self):
 		copied = AccountData(
 			account=self.account,
+			company=self.company,
 			account_name=self.account_name,
 			account_number=self.account_number,
 		)
@@ -198,6 +200,53 @@ class FormattingRule:
 		return self.format_properties
 
 
+def get_report_companies(filters: dict[str, Any]) -> list[str]:
+	companies = filters.get("companies")
+
+	if isinstance(companies, str):
+		companies = frappe.parse_json(companies)
+
+	if not companies:
+		companies = [filters.get("company")] if filters.get("company") else []
+	elif not isinstance(companies, list):
+		companies = [companies]
+
+	normalized_companies = []
+	seen_companies = set()
+
+	for company in companies:
+		if company and company not in seen_companies:
+			normalized_companies.append(company)
+			seen_companies.add(company)
+
+	return normalized_companies
+
+
+def get_primary_company(filters: dict[str, Any]) -> str | None:
+	report_companies = get_report_companies(filters)
+	return report_companies[0] if report_companies else None
+
+
+def get_report_currency(filters: dict[str, Any]) -> str | None:
+	report_companies = get_report_companies(filters)
+
+	if not report_companies:
+		return None
+
+	default_currencies = {
+		frappe.get_cached_value("Company", company, "default_currency") for company in report_companies
+	}
+
+	if len(default_currencies) > 1:
+		frappe.throw(
+			_(
+				"Custom Financial Report currently supports multi-company reporting only when all selected companies use the same default currency."
+			)
+		)
+
+	return default_currencies.pop()
+
+
 # ============================================================================
 # REPORT ENGINE
 # ============================================================================
@@ -231,6 +280,12 @@ class FinancialReportEngine:
 		if filters.get("presentation_currency"):
 			frappe.msgprint(_("Currency filters are currently unsupported in Custom Financial Report."))
 
+		if not get_report_companies(filters):
+			frappe.throw(_("Please select either a Company or one or more Companies."))
+
+		# Validate the selected company scope before period generation.
+		get_report_currency(filters)
+
 		# Margin view is dependent on first row being an income account. Hence not supported.
 		# Way to implement this would be using calculated rows with formulas.
 		supported_views = ("Report", "Growth")
@@ -240,6 +295,8 @@ class FinancialReportEngine:
 	def _initialize_context(self, filters: dict[str, Any]) -> ReportContext:
 		template_name = filters.get("report_template")
 		template = frappe.get_doc("Financial Report Template", template_name)
+		primary_company = get_primary_company(filters)
+		report_companies = get_report_companies(filters)
 
 		if not template:
 			frappe.throw(_("Financial Report Template {0} not found").format(template_name))
@@ -255,7 +312,7 @@ class FinancialReportEngine:
 			filters.period_end_date,
 			filters.filter_based_on,
 			filters.periodicity,
-			company=filters.company,
+			company=primary_company,
 		)
 
 		# Support both old and new field names for backward compatibility
@@ -266,12 +323,12 @@ class FinancialReportEngine:
 			filters=filters,
 			period_list=period_list,
 			show_detailed=show_detailed,
-			# TODO: Enhance this to support report currencies
-			# after fixing which exchange rate to use for P&L
-			currency=get_company_currency(filters.company),
+			currency=get_report_currency(filters),
 		)
 		# Add period_keys to context
 		context.raw_data["period_keys"] = [p["key"] for p in period_list]
+		context.raw_data["report_companies"] = report_companies
+		context.raw_data["primary_company"] = primary_company
 		return context
 
 	def collect_financial_data(self, context: ReportContext) -> ReportContext:
@@ -329,16 +386,14 @@ class DataCollector:
 	def __init__(self, filters: dict[str, Any], periods: list[dict]):
 		self.filters = filters
 		self.periods = periods
-		self.company = filters.get("company")
+		self.companies = get_report_companies(filters)
 		self.account_requests = []
-		self.query_builder = FinancialQueryBuilder(filters, periods)
-		self.account_fields = {field.fieldname for field in frappe.get_meta("Account").fields}
 
 	def add_account_request(self, row):
 		self.account_requests.append(
 			{
 				"row": row,
-				"accounts": self._parse_account_filter(self.company, row),
+				"accounts": self._parse_account_filter(self.companies, row),
 				"balance_type": row.balance_type,
 				"reference_code": row.reference_code,
 				"reverse_sign": row.reverse_sign,
@@ -358,8 +413,17 @@ class DataCollector:
 		if not all_accounts:
 			return {"account_data": {}, "summary": {}, "account_details": {}}
 
-		# Fetch balance data for all accounts
-		account_data = self.query_builder.fetch_account_balances(all_accounts)
+		accounts_by_company = defaultdict(list)
+		for account in all_accounts:
+			accounts_by_company[account.company].append(account)
+
+		account_data = {}
+		for company, company_accounts in accounts_by_company.items():
+			company_filters = frappe._dict(dict(self.filters))
+			company_filters.company = company
+			account_data.update(
+				FinancialQueryBuilder(company_filters, self.periods).fetch_account_balances(company_accounts)
+			)
 
 		# Calculate summaries for each request
 		summary = {}
@@ -402,7 +466,7 @@ class DataCollector:
 		return {"account_data": account_data, "summary": summary, "account_details": account_details}
 
 	@staticmethod
-	def _parse_account_filter(company, report_row) -> list[dict]:
+	def _parse_account_filter(companies: list[str], report_row) -> list[dict]:
 		"""
 		Find accounts matching filter criteria.
 
@@ -416,13 +480,13 @@ class DataCollector:
 		account = frappe.qb.DocType("Account")
 		query = (
 			frappe.qb.from_(account)
-			.select(account.name, account.account_name, account.account_number)
+			.select(account.name, account.company, account.account_name, account.account_number)
 			.where(account.disabled == 0)
 			.where(account.is_group == 0)
 		)
 
-		if company:
-			query = query.where(account.company == company)
+		if companies:
+			query = query.where(account.company.isin(companies))
 
 		where_condition = filter_parser.build_condition(report_row, account)
 		if where_condition is None:
@@ -486,7 +550,11 @@ class FinancialQueryBuilder:
 		account_names = list({acc.name for acc in accounts})
 		# NOTE: do not change accounts list as it is used in caller function
 		self.account_meta = {
-			acc.name: {"account_name": acc.account_name, "account_number": acc.account_number}
+			acc.name: {
+				"company": getattr(acc, "company", ""),
+				"account_name": acc.account_name,
+				"account_number": acc.account_number,
+			}
 			for acc in accounts
 		}
 
@@ -1357,7 +1425,7 @@ class DataFormatter:
 			self.context.filters.get("periodicity"),
 			self.context.period_list,
 			self.context.filters.get("accumulated_values") in (1, None),
-			self.context.filters.get("company"),
+			self.context.raw_data.get("primary_company"),
 		)
 
 		return self.formatter.get_columns(self.organizer.section_with_max_segments.segments, base_columns)
@@ -1576,18 +1644,25 @@ class RowFormatterBase(ABC):
 			return getattr(self.context.filters, key, default) or default
 
 		child_accounts = []
+		child_companies = []
 
 		if row_data.account_details:
 			child_accounts = list(row_data.account_details.keys())
+			child_companies = sorted(
+				{account.company for account in row_data.account_details.values() if account.company}
+			)
 
 		display_name = _get_row_data("display_name", "")
+		row_company = _get_row_data("company", "")
 
 		values = {
 			"account": _get_row_data("account", "") or display_name,
 			"account_name": display_name,
 			"acc_name": _get_row_data("account_name", ""),
 			"acc_number": _get_row_data("account_number", ""),
+			"company": row_company or (child_companies[0] if len(child_companies) == 1 else ""),
 			"child_accounts": child_accounts,
+			"child_companies": child_companies,
 			"currency": self.context.currency or "",
 			"indent": _get_row_data("indentation_level", 0),
 			"period_start_date": _get_filter_value("period_start_date", ""),
@@ -1732,6 +1807,7 @@ class DetailRowBuilder:
 			(),
 			{
 				"account": account_data.account,
+				"company": account_data.company,
 				"display_name": display_name,
 				"account_name": acc_name,
 				"account_number": acc_number,

--- a/erpnext/accounts/doctype/financial_report_template/test_financial_report_multi_company.py
+++ b/erpnext/accounts/doctype/financial_report_template/test_financial_report_multi_company.py
@@ -1,0 +1,250 @@
+import json
+
+import frappe
+from frappe.tests import IntegrationTestCase
+from frappe.utils import flt
+
+from erpnext.accounts.doctype.financial_report_template.financial_report_engine import (
+	FinancialReportEngine,
+)
+
+
+class TestFinancialReportEngineMultiCompany(IntegrationTestCase):
+	@classmethod
+	def setUpClass(cls):
+		cls.company_a = cls._ensure_company("Consolidated Report Test A", "CRTA", "INR")
+		cls.company_b = cls._ensure_company("Consolidated Report Test B", "CRTB", "INR")
+		cls.company_c = cls._ensure_company("Consolidated Report Test C", "CRTC", "USD")
+		for company in (cls.company_a, cls.company_b, cls.company_c):
+			cls._ensure_company_in_fiscal_year(company, "_Test Fiscal Year 2027")
+		cls.create_test_template()
+
+	@staticmethod
+	def _ensure_company(company_name: str, abbr: str, currency: str) -> str:
+		if frappe.db.exists("Company", company_name):
+			return company_name
+
+		company = frappe.get_doc(
+			{
+				"doctype": "Company",
+				"company_name": company_name,
+				"abbr": abbr,
+				"country": "India" if currency == "INR" else "United States",
+				"default_currency": currency,
+				"create_chart_of_accounts_based_on": "Standard Template",
+				"chart_of_accounts": "Standard",
+			}
+		).insert()
+
+		return company.name
+
+	@staticmethod
+	def _ensure_company_in_fiscal_year(company: str, fiscal_year_name: str):
+		fiscal_year = frappe.get_doc("Fiscal Year", fiscal_year_name)
+		linked_companies = {row.company for row in fiscal_year.companies}
+
+		if company not in linked_companies:
+			fiscal_year.append("companies", {"company": company})
+			fiscal_year.save()
+
+	@staticmethod
+	def _get_accounts(
+		company: str, root_type: str, limit: int = 1, exclude_account_types: list[str] | None = None
+	):
+		filters = {"company": company, "root_type": root_type, "is_group": 0, "disabled": 0}
+
+		if exclude_account_types:
+			filters["account_type"] = ["not in", exclude_account_types]
+
+		return frappe.get_all("Account", filters=filters, pluck="name", order_by="lft", limit=limit)
+
+	@staticmethod
+	def _make_account_filter(company: str, account: str) -> str:
+		account_name = frappe.db.get_value("Account", account, "account_name")
+		return json.dumps({"and": [["company", "=", company], ["account_name", "=", account_name]]})
+
+	@staticmethod
+	def _get_cost_center(company: str) -> str:
+		return frappe.get_all(
+			"Cost Center", filters={"company": company, "is_group": 0}, pluck="name", order_by="lft", limit=1
+		)[0]
+
+	@classmethod
+	def _make_journal_entry(
+		cls, company: str, account1: str, account2: str, amount: float, posting_date: str
+	):
+		cost_center = cls._get_cost_center(company)
+		journal_entry = frappe.new_doc("Journal Entry")
+		journal_entry.posting_date = posting_date
+		journal_entry.company = company
+		journal_entry.user_remark = "test"
+		journal_entry.multi_currency = 1
+		journal_entry.set(
+			"accounts",
+			[
+				{
+					"account": account1,
+					"cost_center": cost_center,
+					"debit_in_account_currency": amount if amount > 0 else 0,
+					"credit_in_account_currency": abs(amount) if amount < 0 else 0,
+					"exchange_rate": 1,
+				},
+				{
+					"account": account2,
+					"cost_center": cost_center,
+					"credit_in_account_currency": amount if amount > 0 else 0,
+					"debit_in_account_currency": abs(amount) if amount < 0 else 0,
+					"exchange_rate": 1,
+				},
+			],
+		)
+		journal_entry.insert()
+		journal_entry.submit()
+		return journal_entry
+
+	@staticmethod
+	def _get_period_key(columns: list[dict]) -> str:
+		for column in columns:
+			if column.get("fieldtype") == "Currency" and column.get("fieldname") != "total":
+				return column["fieldname"]
+
+		raise AssertionError("No period column found in custom financial report output")
+
+	@classmethod
+	def create_test_template(cls):
+		if not frappe.db.exists("Financial Report Template", "Test P&L Template"):
+			frappe.get_doc(
+				{
+					"doctype": "Financial Report Template",
+					"template_name": "Test P&L Template",
+					"report_type": "Profit and Loss Statement",
+					"rows": [
+						{
+							"reference_code": "INC001",
+							"display_name": "Income",
+							"data_source": "Account Data",
+							"balance_type": "Closing Balance",
+							"calculation_formula": '["root_type", "=", "Income"]',
+						},
+						{
+							"reference_code": "EXP001",
+							"display_name": "Expenses",
+							"data_source": "Account Data",
+							"balance_type": "Closing Balance",
+							"calculation_formula": '["root_type", "=", "Expense"]',
+						},
+					],
+				}
+			).insert()
+
+		cls.test_template = frappe.get_doc("Financial Report Template", "Test P&L Template")
+
+	@staticmethod
+	def create_test_template_with_rows(rows_data):
+		template_name = f"Test Template {frappe.generate_hash()[:8]}"
+		return frappe.get_doc(
+			{"doctype": "Financial Report Template", "template_name": template_name, "rows": rows_data}
+		)
+
+	def test_execute_uses_selected_companies_for_template_rows(self):
+		company_a = self.company_a
+		company_b = self.company_b
+
+		income_a = self._get_accounts(company_a, "Income")[0]
+		expense_a = self._get_accounts(company_a, "Expense")[0]
+		asset_a = self._get_accounts(company_a, "Asset", exclude_account_types=["Receivable"])[0]
+		liability_a = self._get_accounts(company_a, "Liability", exclude_account_types=["Payable"])[0]
+		expense_b = self._get_accounts(company_b, "Expense")[0]
+		liability_b = self._get_accounts(company_b, "Liability", exclude_account_types=["Payable"])[0]
+
+		journal_entries = []
+		template = None
+
+		try:
+			journal_entries.append(self._make_journal_entry(company_a, asset_a, income_a, 200, "2027-04-05"))
+			journal_entries.append(
+				self._make_journal_entry(company_b, expense_b, liability_b, 200, "2027-04-09")
+			)
+			journal_entries.append(
+				self._make_journal_entry(company_a, expense_a, liability_a, 50, "2027-04-12")
+			)
+
+			template = self.create_test_template_with_rows(
+				[
+					{
+						"reference_code": "A_INTERCO",
+						"display_name": "Company A Intercompany Income",
+						"data_source": "Account Data",
+						"balance_type": "Period Movement (Debits - Credits)",
+						"reverse_sign": 1,
+						"hidden_calculation": 1,
+						"calculation_formula": self._make_account_filter(company_a, income_a),
+					},
+					{
+						"reference_code": "B_INTERCO",
+						"display_name": "Company B Intercompany Expense",
+						"data_source": "Account Data",
+						"balance_type": "Period Movement (Debits - Credits)",
+						"hidden_calculation": 1,
+						"calculation_formula": self._make_account_filter(company_b, expense_b),
+					},
+					{
+						"reference_code": "LOCAL_EXPENSE",
+						"display_name": "Local Expense",
+						"data_source": "Account Data",
+						"balance_type": "Period Movement (Debits - Credits)",
+						"calculation_formula": self._make_account_filter(company_a, expense_a),
+					},
+					{
+						"reference_code": "NET_INTERCO",
+						"display_name": "Intercompany Eliminated",
+						"data_source": "Calculated Amount",
+						"hide_when_empty": 1,
+						"calculation_formula": "A_INTERCO - B_INTERCO",
+					},
+				]
+			)
+			template.insert()
+
+			columns, data, _, _ = FinancialReportEngine().execute(
+				frappe._dict(
+					{
+						"report_template": template.name,
+						# Mimic the default single-company filter still being populated in the UI.
+						"company": company_a,
+						"companies": [company_a, company_b],
+						"period_start_date": "2027-04-01",
+						"period_end_date": "2027-04-30",
+						"filter_based_on": "Date Range",
+						"periodicity": "Monthly",
+						"selected_view": "Report",
+						"accumulated_values": 0,
+					}
+				)
+			)
+
+			period_key = self._get_period_key(columns)
+			local_expense_row = next(row for row in data if row.get("account_name") == "Local Expense")
+
+			self.assertEqual(flt(local_expense_row.get(period_key), 2), 50.0)
+			self.assertFalse(any(row.get("account_name") == "Intercompany Eliminated" for row in data))
+		finally:
+			for journal_entry in reversed(journal_entries):
+				journal_entry.cancel()
+
+	def test_execute_rejects_multi_company_reports_with_mixed_default_currencies(self):
+		with self.assertRaisesRegex(frappe.ValidationError, "same default currency"):
+			FinancialReportEngine().execute(
+				frappe._dict(
+					{
+						"report_template": self.test_template.name,
+						"company": self.company_a,
+						"companies": [self.company_a, self.company_c],
+						"period_start_date": "2027-04-01",
+						"period_end_date": "2027-04-30",
+						"filter_based_on": "Date Range",
+						"periodicity": "Monthly",
+						"selected_view": "Report",
+					}
+				)
+			)

--- a/erpnext/accounts/report/balance_sheet/balance_sheet.js
+++ b/erpnext/accounts/report/balance_sheet/balance_sheet.js
@@ -16,6 +16,16 @@ frappe.query_reports[BS_REPORT_NAME]["filters"].push(
 		get_query: { filters: { report_type: BS_REPORT_NAME, disabled: 0 } },
 	},
 	{
+		fieldname: "companies",
+		label: __("Companies"),
+		fieldtype: "MultiSelectList",
+		options: "Company",
+		depends_on: "eval:doc.report_template",
+		get_data: function (txt) {
+			return frappe.db.get_link_options("Company", txt);
+		},
+	},
+	{
 		fieldname: "show_account_details",
 		label: __("Account Detail Level"),
 		fieldtype: "Select",

--- a/erpnext/accounts/report/custom_financial_statement/custom_financial_statement.js
+++ b/erpnext/accounts/report/custom_financial_statement/custom_financial_statement.js
@@ -17,6 +17,16 @@ frappe.query_reports[CFS_REPORT_NAME]["filters"].push(
 		reqd: 1,
 	},
 	{
+		fieldname: "companies",
+		label: __("Companies"),
+		fieldtype: "MultiSelectList",
+		options: "Company",
+		depends_on: "eval:doc.report_template",
+		get_data: function (txt) {
+			return frappe.db.get_link_options("Company", txt);
+		},
+	},
+	{
 		fieldname: "show_account_details",
 		label: __("Account Detail Level"),
 		fieldtype: "Select",

--- a/erpnext/accounts/report/profit_and_loss_statement/profit_and_loss_statement.js
+++ b/erpnext/accounts/report/profit_and_loss_statement/profit_and_loss_statement.js
@@ -16,6 +16,16 @@ frappe.query_reports[PL_REPORT_NAME]["filters"].push(
 		get_query: { filters: { report_type: PL_REPORT_NAME, disabled: 0 } },
 	},
 	{
+		fieldname: "companies",
+		label: __("Companies"),
+		fieldtype: "MultiSelectList",
+		options: "Company",
+		depends_on: "eval:doc.report_template",
+		get_data: function (txt) {
+			return frappe.db.get_link_options("Company", txt);
+		},
+	},
+	{
 		fieldname: "show_account_details",
 		label: __("Account Detail Level"),
 		fieldtype: "Select",

--- a/erpnext/public/js/financial_statements.js
+++ b/erpnext/public/js/financial_statements.js
@@ -5,6 +5,24 @@ function get_filter_value(filter_name) {
 	return frappe.query_report.get_filter_value(filter_name, false);
 }
 
+function get_route_company(filters = {}) {
+	const companies = filters.companies ?? get_filter_value("companies");
+	if (Array.isArray(companies) && companies.length > 0) {
+		return companies[0];
+	}
+
+	return filters.company ?? get_filter_value("company");
+}
+
+function get_custom_report_ledger_company(formatting) {
+	if (formatting.company) {
+		return formatting.company;
+	}
+
+	const child_companies = formatting.child_companies || [];
+	return child_companies.length === 1 ? child_companies[0] : null;
+}
+
 erpnext.financial_statements = {
 	filters: get_filters(),
 	baseData: null,
@@ -91,10 +109,15 @@ erpnext.financial_statements = {
 
 		if (!value) return "";
 
+		const ledgerCompany = get_custom_report_ledger_company(formatting);
+
 		// Link to open ledger
 		const should_link_to_ledger =
-			formatting.is_detail ||
-			(formatting.account_filters && formatting.child_accounts && formatting.child_accounts.length);
+			ledgerCompany &&
+			(formatting.is_detail ||
+				(formatting.account_filters &&
+					formatting.child_accounts &&
+					formatting.child_accounts.length));
 
 		if (should_link_to_ledger) {
 			const glData = {
@@ -105,7 +128,7 @@ erpnext.financial_statements = {
 				from_date: formatting.from_date || formatting.period_start_date,
 				to_date: formatting.to_date || formatting.period_end_date,
 				account_type: formatting.account_type,
-				company: get_filter_value("company"),
+				company: ledgerCompany,
 			};
 
 			column.link_onclick =
@@ -257,7 +280,7 @@ erpnext.financial_statements = {
 
 		frappe.route_options = {
 			account: data.account || data.accounts,
-			company: get_filter_value("company"),
+			company: data.company || get_route_company(),
 			from_date: data.from_date || data.year_start_date,
 			to_date: data.to_date || data.year_end_date,
 			project: project && project.length > 0 ? project[0].get_value() : "",
@@ -311,7 +334,8 @@ erpnext.financial_statements = {
 			report.page.add_custom_menu_item(views_menu, __("Balance Sheet"), function () {
 				var filters = report.get_values();
 				frappe.set_route("query-report", "Balance Sheet", {
-					company: filters.company,
+					company: get_route_company(filters),
+					companies: filters.companies,
 					filter_based_on: filters.filter_based_on,
 					period_start_date: filters.period_start_date,
 					period_end_date: filters.period_end_date,
@@ -327,7 +351,8 @@ erpnext.financial_statements = {
 			report.page.add_custom_menu_item(views_menu, __("Profit and Loss"), function () {
 				var filters = report.get_values();
 				frappe.set_route("query-report", "Profit and Loss Statement", {
-					company: filters.company,
+					company: get_route_company(filters),
+					companies: filters.companies,
 					filter_based_on: filters.filter_based_on,
 					period_start_date: filters.period_start_date,
 					period_end_date: filters.period_end_date,
@@ -343,7 +368,8 @@ erpnext.financial_statements = {
 			report.page.add_custom_menu_item(views_menu, __("Cash Flow Statement"), function () {
 				var filters = report.get_values();
 				frappe.set_route("query-report", "Cash Flow", {
-					company: filters.company,
+					company: get_route_company(filters),
+					companies: filters.companies,
 					filter_based_on: filters.filter_based_on,
 					period_start_date: filters.period_start_date,
 					period_end_date: filters.period_end_date,
@@ -366,7 +392,7 @@ function get_filters() {
 			fieldtype: "Link",
 			options: "Company",
 			default: frappe.defaults.get_user_default("Company"),
-			reqd: 1,
+			mandatory_depends_on: "eval:!doc.report_template || !(doc.companies && doc.companies.length)",
 		},
 		{
 			fieldname: "finance_book",


### PR DESCRIPTION
## Summary

This change unblocks consolidated reporting use cases for template-backed financial statements, especially intercompany elimination setups where rows from one company are intended to offset rows from another.

- add a `companies` multi-select filter for template-backed Balance Sheet, Profit and Loss Statement, Cash Flow, and Custom Financial Statement reports
- update the financial report template engine to collect and aggregate account data across the selected companies instead of forcing a single `company` filter
- preserve row-level company filtering so elimination logic can be modeled directly in report template rows
- make GL drilldowns safer for multi-company rows by only linking when a single company can be determined
- reject multi-company template reports when the selected companies have different default currencies

## Why

Today, custom financial report templates are effectively blocked from consolidated multi-company reporting because the report flow assumes a single company throughout execution.

With this change, users can build consolidated templates where intercompany income and expense rows cancel each other out and are hidden through the existing template row and formula system.

## Testing

- `bench --site alyf-dev run-tests --module erpnext.accounts.doctype.financial_report_template.test_financial_report_multi_company`