### PR TITLE
fix(test): pin posting date in test_depreciation_on_cancel_invoice

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
@@ -3230,7 +3230,7 @@ class TestSalesInvoice(FrappeTestCase):
 			calculate_depreciation=1,
 			submit=1,
 		)
-		post_depreciation_entries()
+		post_depreciation_entries(date="2025-04-01")
 
 		si = create_sales_invoice(
 			item_code="Macbook Pro", asset=asset.name, qty=1, rate=10000, posting_date=getdate("2025-05-01")


### PR DESCRIPTION
Fixing broken test

<img width="1076" height="423" alt="Screenshot 2026-04-03 at 12 34 50 AM" src="https://github.com/user-attachments/assets/02eba7b3-b4de-4b01-a9ac-47546c9ba61d" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test infrastructure for depreciation handling on sales invoice cancellation to use explicit date parameters for improved test consistency.

**Note:** This release contains no user-visible changes; modifications are limited to internal test updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->