### PR TITLE
fix(promotional_scheme): restrict buying/selling selection and stabil…

### DIFF
--- a/erpnext/accounts/doctype/promotional_scheme/promotional_scheme.js
+++ b/erpnext/accounts/doctype/promotional_scheme/promotional_scheme.js
@@ -21,10 +21,12 @@ frappe.ui.form.on("Promotional Scheme", {
 
 	selling: function (frm) {
 		frm.trigger("set_options_for_applicable_for");
+		frm.set_df_property("buying", "read_only", frm.doc.selling ? 1 : 0);
 	},
 
 	buying: function (frm) {
 		frm.trigger("set_options_for_applicable_for");
+		frm.set_df_property("selling", "read_only", frm.doc.buying ? 1 : 0);
 	},
 
 	set_options_for_applicable_for: function (frm) {

--- a/erpnext/accounts/doctype/promotional_scheme/promotional_scheme.py
+++ b/erpnext/accounts/doctype/promotional_scheme/promotional_scheme.py
@@ -145,6 +145,8 @@ class PromotionalScheme(Document):
 	def validate(self):
 		if not self.selling and not self.buying:
 			frappe.throw(_("Either 'Selling' or 'Buying' must be selected"), title=_("Mandatory"))
+		if self.selling and self.buying:
+			frappe.throw(_("Both 'Selling' and 'Buying' cannot be selected at the same time"))
 		if not (self.price_discount_slabs or self.product_discount_slabs):
 			frappe.throw(_("Price or product discount slabs are required"))
 


### PR DESCRIPTION
fix(promotional_scheme): enforce mutual exclusivity between Buying and Selling

- Add server-side validation to prevent selecting both Selling and Buying simultaneously
  and throw an error if both are enabled

- Improve client-side  by dynamically disabling the opposite option when one is selected
  (Selling disables Buying and vice versa)



[Screencast from 03 أبر, 2026 EET 11:15:07 م.webm](https://github.com/user-attachments/assets/d780b8b3-3380-4dc8-a932-657dd9ec0809)
