### PR TITLE
fix(manufacturing): handle null cur_dialog in BOM work order dialog

### DIFF
--- a/erpnext/manufacturing/doctype/bom/bom.js
+++ b/erpnext/manufacturing/doctype/bom/bom.js
@@ -407,6 +407,7 @@ frappe.ui.form.on("BOM", {
 				reqd: 1,
 				default: 1,
 				onchange: () => {
+					if (!cur_dialog) return;
 					const { quantity, items: rm } = frm.doc;
 					const variant_items_map = rm.reduce((acc, item) => {
 						acc[item.item_code] = item.qty;


### PR DESCRIPTION
Issue : When opening the Work Order creation dialog from a BOM form, a JavaScript error was thrown in the browser console.

Ref: [#63653](https://support.frappe.io/helpdesk/tickets/63653)

Steps To Replicate : 
1. Open any BOM document that is submitted (docstatus = 1)
2. Click Create → Work Order
3. The Work Order dialog opens. Immediately open browser  Console
4. Observe the error

Before : 

<img width="1851" height="532" alt="image" src="https://github.com/user-attachments/assets/232c71de-f4c7-47d6-9816-2cc1bc1c3e06" />

After : 

<img width="1860" height="423" alt="image" src="https://github.com/user-attachments/assets/18485b6f-6cff-4455-9743-a171ba482678" />

Backport Needed For V16 and V15

