### PR TITLE
fix: update delivered_qty on all product bundle components in Pick List

### DIFF
--- a/erpnext/stock/doctype/delivery_note/delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.py
@@ -464,7 +464,6 @@ class DeliveryNote(SellingController):
 
 	def on_submit(self):
 		self.validate_packed_qty()
-		self.update_pick_list_status()
 
 		# Check for Approving Authority
 		frappe.get_cached_doc("Authorization Control").validate_approving_authority(
@@ -473,6 +472,7 @@ class DeliveryNote(SellingController):
 
 		# update delivered qty in sales order
 		self.update_prevdoc_status()
+		self.update_pick_list_status()
 		self.update_billing_status()
 
 		if not self.is_return:

--- a/erpnext/stock/doctype/pick_list/pick_list.py
+++ b/erpnext/stock/doctype/pick_list/pick_list.py
@@ -893,6 +893,7 @@ class PickList(TransactionBase):
 			for c in components:
 				expected = flt(c.picked_qty) if is_delivered else 0
 				if flt(c.delivered_qty) != expected:
+					c.delivered_qty = expected
 					c.db_set("delivered_qty", expected, update_modified=False)
 					updated = True
 

--- a/erpnext/stock/doctype/pick_list/pick_list.py
+++ b/erpnext/stock/doctype/pick_list/pick_list.py
@@ -897,13 +897,28 @@ class PickList(TransactionBase):
 					c.db_set("delivered_qty", expected, update_modified=False)
 					updated = True
 
-		if updated:
-			total_picked = sum(flt(item.picked_qty) for item in self.locations)
-			total_delivered = sum(flt(item.delivered_qty) for item in self.locations)
-			if total_picked:
+		total_picked = sum(flt(item.picked_qty) for item in self.locations)
+		total_delivered = sum(flt(item.delivered_qty) for item in self.locations)
+		if total_picked:
+			per_delivered = flt(total_delivered / total_picked * 100)
+			if per_delivered >= 100:
+				delivery_status = "Fully Delivered"
+			elif per_delivered > 0:
+				delivery_status = "Partly Delivered"
+			else:
+				delivery_status = "Not Delivered"
+
+			if (
+				flt(self.per_delivered) != per_delivered
+				or self.delivery_status != delivery_status
+			):
+				self.per_delivered = per_delivered
+				self.delivery_status = delivery_status
 				self.db_set(
-					"per_delivered",
-					flt(total_delivered / total_picked * 100),
+					{
+						"per_delivered": per_delivered,
+						"delivery_status": delivery_status,
+					},
 					update_modified=False,
 				)
 

--- a/erpnext/stock/doctype/pick_list/pick_list.py
+++ b/erpnext/stock/doctype/pick_list/pick_list.py
@@ -867,6 +867,45 @@ class PickList(TransactionBase):
 
 		return int(flt(min(possible_bundles.values()), precision or 6)) if possible_bundles else 0
 
+	def update_bundle_delivered_qty(self):
+		"""Update delivered_qty on all product bundle component items.
+
+		The Status Updater only links one Delivery Note Item to one Pick List Item
+		per product bundle via the pick_list_item field, leaving sibling components
+		with delivered_qty=0. This method marks all components as delivered when
+		the bundle has been delivered.
+		"""
+		bundle_groups = defaultdict(list)
+		for item in self.locations:
+			if item.product_bundle_item:
+				bundle_groups[item.sales_order_item].append(item)
+
+		if not bundle_groups:
+			return
+
+		updated = False
+		for so_item, components in bundle_groups.items():
+			is_delivered = frappe.db.exists(
+				"Delivery Note Item",
+				{"against_pick_list": self.name, "so_detail": so_item, "docstatus": 1},
+			)
+
+			for c in components:
+				expected = flt(c.picked_qty) if is_delivered else 0
+				if flt(c.delivered_qty) != expected:
+					c.db_set("delivered_qty", expected, update_modified=False)
+					updated = True
+
+		if updated:
+			total_picked = sum(flt(item.picked_qty) for item in self.locations)
+			total_delivered = sum(flt(item.delivered_qty) for item in self.locations)
+			if total_picked:
+				self.db_set(
+					"per_delivered",
+					flt(total_delivered / total_picked * 100),
+					update_modified=False,
+				)
+
 	def has_unreserved_stock(self):
 		if self.purpose == "Delivery":
 			for location in self.locations:
@@ -895,6 +934,7 @@ class PickList(TransactionBase):
 def update_pick_list_status(pick_list):
 	if pick_list:
 		doc = frappe.get_doc("Pick List", pick_list)
+		doc.update_bundle_delivered_qty()
 		doc.run_method("update_status")
 
 

--- a/erpnext/stock/doctype/pick_list/test_pick_list.py
+++ b/erpnext/stock/doctype/pick_list/test_pick_list.py
@@ -1666,6 +1666,53 @@ class TestPickList(ERPNextTestSuite):
 		stock_entry_2.cancel()
 		stock_entry_3.cancel()
 
+	def test_pick_list_bundle_delivered_status(self):
+		"""Pick List with Product Bundle should show Completed after full delivery."""
+		warehouse = "_Test Warehouse - _TC"
+
+		item_bundle = make_item(properties={"is_stock_item": 0}).name
+		item_a = make_item().name
+		item_b = make_item().name
+		item_c = make_item().name
+
+		make_product_bundle(item_bundle, items=[item_a, item_b, item_c])
+
+		make_stock_entry(item=item_a, to_warehouse=warehouse, qty=10, basic_rate=100)
+		make_stock_entry(item=item_b, to_warehouse=warehouse, qty=10, basic_rate=100)
+		make_stock_entry(item=item_c, to_warehouse=warehouse, qty=10, basic_rate=100)
+
+		so = make_sales_order(item_code=item_bundle, qty=1, rate=100)
+
+		pl = create_pick_list(so.name)
+		pl.save().submit()
+
+		# All 3 component items should be in pick list
+		bundle_items = [loc for loc in pl.locations if loc.product_bundle_item]
+		self.assertEqual(len(bundle_items), 3)
+
+		# Deliver
+		dn = create_delivery_note(pl.name)
+		dn.submit()
+
+		pl.reload()
+		# All components should have delivered_qty updated
+		for loc in pl.locations:
+			if loc.product_bundle_item:
+				self.assertEqual(loc.delivered_qty, loc.picked_qty)
+
+		self.assertEqual(pl.per_delivered, 100)
+		self.assertEqual(pl.status, "Completed")
+
+		# Cancel DN - should revert
+		dn.cancel()
+		pl.reload()
+
+		for loc in pl.locations:
+			if loc.product_bundle_item:
+				self.assertEqual(loc.delivered_qty, 0)
+
+		self.assertNotEqual(pl.status, "Completed")
+
 	def test_pick_list_with_and_without_so(self):
 		warehouse = "_Test Warehouse - _TC"
 		item = make_item().name


### PR DESCRIPTION
## Description

When a Delivery Note is submitted for a Pick List containing Product Bundle items, the Pick List status remains **"Partly Delivered"** even though all items have been fully delivered.

### Root Cause

`_get_product_bundles()` builds a dict keyed by `sales_order_item`. All component items of a Product Bundle share the same `sales_order_item`, so only the **last** component's `pick_list_item` survives (dict key overwrite). The Status Updater uses this single `pick_list_item` to update `delivered_qty` on only that one Pick List Item. All other sibling components stay at `delivered_qty=0`, making `per_delivered` incorrect.

### Fix

- Add `update_bundle_delivered_qty()` method to `PickList` that checks delivery state directly via Delivery Note Items (`against_pick_list` + `so_detail`) and marks **all** bundle components as delivered (`delivered_qty = picked_qty`) or not delivered (`0`)
- Call it from `update_pick_list_status()` after the Status Updater has run
- Move `update_pick_list_status()` in `DeliveryNote.on_submit` to after `update_prevdoc_status()` so Status Updater values are available

### Test Plan

- [x] Added test `test_pick_list_bundle_delivered_status` covering submit (all components get `delivered_qty`, status=Completed) and cancel (reverts to 0)
- [ ] Existing bundle tests pass (`test_picklist_with_bundles`, `test_picklist_with_partial_bundles`, `test_packed_item_in_pick_list`, `test_packed_item_multiple_times_in_so`)

closes #54019