### PR TITLE
fix: call set_missing_values after get_mapped_doc in make_purchase_receipt

### DIFF
--- a/erpnext/buying/doctype/purchase_order/purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.py
@@ -732,6 +732,7 @@ def make_purchase_receipt(
 		child_filter = d.name in filtered_items if filtered_items else True
 		return child_filter
 
+	source_doc = frappe.get_doc("Purchase Order", source_name)
 	doc = get_mapped_doc(
 		"Purchase Order",
 		source_name,
@@ -765,9 +766,8 @@ def make_purchase_receipt(
 			"Purchase Taxes and Charges": {"doctype": "Purchase Taxes and Charges", "reset_value": True},
 		},
 		target_doc,
-		set_missing_values,
 	)
-
+	set_missing_values(source_doc, doc)
 	return doc
 
 

--- a/erpnext/buying/doctype/purchase_order/test_purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/test_purchase_order.py
@@ -291,6 +291,30 @@ class TestPurchaseOrder(ERPNextTestSuite):
 		# ordered qty should decrease (back to initial) on row deletion
 		self.assertEqual(get_ordered_qty(), existing_ordered_qty)
 
+	def test_discount_amount_partial_purchase_receipt(self):
+		po = create_purchase_order(qty=4, rate=100, do_not_save=1)
+		po.apply_discount_on = "Grand Total"
+		po.discount_amount = 120
+		po.save()
+		po.submit()
+
+		self.assertEqual(po.grand_total, 280)
+
+		pr1 = make_purchase_receipt(po.name)
+		pr1.items[0].qty = 3
+		pr1.save()
+		pr1.submit()
+
+		self.assertEqual(pr1.discount_amount, 120)
+		self.assertEqual(pr1.grand_total, 180)
+
+		pr2 = make_purchase_receipt(po.name)
+		pr2.save()
+		pr2.submit()
+
+		self.assertEqual(pr2.discount_amount, 0)
+		self.assertEqual(pr2.grand_total, 100)
+
 	def test_update_child_perm(self):
 		po = create_purchase_order(item_code="_Test Item", qty=4)
 


### PR DESCRIPTION
Issue:
When a Purchase Order has an Additional Discount Amount and multiple partial Purchase Receipts are created against it, the full discount amount is blindly copied to every Purchase Receipt.

Ref: [#64295](https://support.frappe.io/helpdesk/tickets/64295)

Steps to reproduce:                                                                                                                                                                                                                     
1. Create a Purchase Order with 4 items at a rate of 100  with a total of 400. Additional Discount Amount = 120
2. Create Purchase Receipt 1 for 3 items total = 300, and an Additional Discount Amount of 120 is fully applied.                                                                                                                                                                            
3.  Try creating Purchase Receipt 2 for the remaining 1 item of a total of 100, you can notice that it fails with the error



Backport needed: v16, v15