### PR TITLE
fix: fix typos, grammar and numbering in CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Feature requests are also a great way to take the product forward. New ideas can
 
 When you are raising an Issue, you should keep a few things in mind. Remember that the developer does not have access to your machine so you must give all the information you can while raising an Issue. If you are suggesting a feature, you should be very clear about what you want.
 
-The Issue list is not the right place to ask a question or start a general discussion. If you want to do that , then the right place is the forum [https://discuss.frappe.io](https://discuss.frappe.io/c/erpnext/6).
+The Issue list is not the right place to ask a question or start a general discussion. If you want to do that, then the right place is the forum [https://discuss.frappe.io](https://discuss.frappe.io/c/erpnext/6).
 
 ### Reply and Closing Policy
 
@@ -14,22 +14,22 @@ If your issue is not clear or does not meet the guidelines, then it will be clos
 
 ### General Issue Guidelines
 
-1. **Search existing Issues:** Before raising a Issue, search if it has been raised before. Maybe add a 👍 or give additional help by creating a mockup if it is not already created.
-1. **Report each issue separately:** Don't club multiple, unreleated issues in one note.
-1. **Brief:** Please don't include long explanations. Use screenshots and bullet points instead of descriptive paragraphs.
+1. **Search existing Issues:** Before raising an Issue, search if it has been raised before. Maybe add a 👍 or give additional help by creating a mockup if it is not already created.
+2. **Report each issue separately:** Don't club multiple, unrelated issues in one note.
+3. **Brief:** Please don't include long explanations. Use screenshots and bullet points instead of descriptive paragraphs.
 
 ### Bug Report Guidelines
 
 1. **Steps to Reproduce:** The bug report must have a list of steps needed to reproduce a bug. If we cannot reproduce it, then we cannot solve it.
-1. **Version Number:** Please add the version number in your report. Often a bug is fixed in the latest version
-1. **Clear Title:** Add a clear subject to your bug report like "Unable to submit Purchase Order without Basic Rate" instead of just "Cannot Submit"
-1. **Screenshots:** Screenshots are a great way of communicating issues. Try adding annotations or using LiceCAP to take a screencast in `gif`.
+2. **Version Number:** Please add the version number in your report. Often a bug is fixed in the latest version.
+3. **Clear Title:** Add a clear subject to your bug report like "Unable to submit Purchase Order without Basic Rate" instead of just "Cannot Submit".
+4. **Screenshots:** Screenshots are a great way of communicating issues. Try adding annotations or using LiceCAP to take a screencast in `gif`.
 
 ### Feature Request Guidelines
 
-1. **Clarity:** Clearly specify how do you want the feature to behave. Don't just say "I would like multiple PDF formats", say that "Ability to add multiple print formats for customers with different languages".
-1. **Solution:** Try and identify how the feature should look like.
-1. **Mockups:** Mockups are a great way to explain your requirement.
+1. **Clarity:** Clearly specify how you want the feature to behave. Don't just say "I would like multiple PDF formats", say that "Ability to add multiple print formats for customers with different languages".
+2. **Solution:** Try to identify what the feature should look like.
+3. **Mockups:** Mockups are a great way to explain your requirement.
 
 ### What if my Issue is closed
 


### PR DESCRIPTION
Fixed a double space before comma in the Introduction section,  corrected "a Issue" to "an Issue" and "unreleated" to "unrelated"  in General Issue Guidelines, fixed broken numbered lists in all  three sections (1,1,1 → 1,2,3), added a missing period in Bug  Report Guidelines, corrected grammar in Feature Request Guidelines  ("how do you want" → "how you want"), and fixed awkward phrasing  in Solution item ("Try and identify how" → "Try to identify what").

