### PR TITLE
fix: validate south africa company in vat audit report

### DIFF
--- a/erpnext/regional/doctype/south_africa_vat_settings/south_africa_vat_settings.py
+++ b/erpnext/regional/doctype/south_africa_vat_settings/south_africa_vat_settings.py
@@ -1,8 +1,11 @@
 # Copyright (c) 2021, Frappe Technologies Pvt. Ltd. and contributors
 # For license information, please see license.txt
 
-# import frappe
+import frappe
+from frappe import _
 from frappe.model.document import Document
+
+from erpnext import get_region
 
 
 class SouthAfricaVATSettings(Document):
@@ -22,4 +25,9 @@ class SouthAfricaVATSettings(Document):
 		vat_accounts: DF.Table[SouthAfricaVATAccount]
 	# end: auto-generated types
 
-	pass
+	def validate(self):
+		self.validate_company_region()
+
+	def validate_company_region(self):
+		if self.company and get_region(self.company) != "South Africa":
+			frappe.throw(_("Company {0} is not in South Africa.").format(frappe.bold(self.company)))

--- a/erpnext/regional/report/vat_audit_report/vat_audit_report.js
+++ b/erpnext/regional/report/vat_audit_report/vat_audit_report.js
@@ -10,6 +10,13 @@ frappe.query_reports["VAT Audit Report"] = {
 			options: "Company",
 			reqd: 1,
 			default: frappe.defaults.get_user_default("Company"),
+			get_query: function () {
+				return {
+					filters: {
+						country: "South Africa",
+					},
+				};
+			},
 		},
 		{
 			fieldname: "from_date",

--- a/erpnext/regional/report/vat_audit_report/vat_audit_report.py
+++ b/erpnext/regional/report/vat_audit_report/vat_audit_report.py
@@ -26,16 +26,6 @@ class VATAuditReport:
 		self.get_sa_vat_accounts()
 		self.get_columns()
 		for doctype in self.doctypes:
-			self.select_columns = """
-			name as voucher_no,
-			posting_date, remarks"""
-			columns = (
-				", supplier as party, credit_to as account"
-				if doctype == "Purchase Invoice"
-				else ", customer as party, debit_to as account"
-			)
-			self.select_columns += columns
-
 			self.get_invoice_data(doctype)
 
 			if self.invoices:
@@ -64,27 +54,38 @@ class VATAuditReport:
 			frappe.throw(_("Please set VAT Accounts in {0}").format(link_to_settings))
 
 	def get_invoice_data(self, doctype):
-		conditions = self.get_conditions()
 		self.invoices = frappe._dict()
-
-		invoice_data = frappe.db.sql(
-			f"""
-			SELECT
-				{self.select_columns}
-			FROM
-				`tab{doctype}`
-			WHERE
-				docstatus = 1 {conditions}
-				and is_opening = 'No'
-			ORDER BY
-				posting_date DESC
-			""",
-			self.filters,
-			as_dict=1,
+		invoice_doctype = frappe.qb.DocType(doctype)
+		party_field = invoice_doctype.supplier if doctype == "Purchase Invoice" else invoice_doctype.customer
+		account_field = (
+			invoice_doctype.credit_to if doctype == "Purchase Invoice" else invoice_doctype.debit_to
 		)
 
-		for d in invoice_data:
-			self.invoices.setdefault(d.voucher_no, d)
+		query = (
+			frappe.qb.from_(invoice_doctype)
+			.select(
+				invoice_doctype.name.as_("voucher_no"),
+				invoice_doctype.posting_date,
+				invoice_doctype.remarks,
+				party_field.as_("party"),
+				account_field.as_("account"),
+			)
+			.where(invoice_doctype.docstatus == 1)
+			.where(invoice_doctype.is_opening == "No")
+			.orderby(invoice_doctype.posting_date, order=frappe.qb.desc)
+		)
+
+		if self.filters.get("company"):
+			query = query.where(invoice_doctype.company == self.filters.company)
+		if self.filters.get("from_date"):
+			query = query.where(invoice_doctype.posting_date >= self.filters.from_date)
+		if self.filters.get("to_date"):
+			query = query.where(invoice_doctype.posting_date <= self.filters.to_date)
+
+		invoice_data = query.run(as_dict=True)
+
+		for row in invoice_data:
+			self.invoices.setdefault(row.voucher_no, row)
 
 	def get_invoice_items(self, doctype):
 		self.invoice_items = frappe._dict()
@@ -136,18 +137,6 @@ class VATAuditReport:
 			self.items_based_on_tax_rate[parent][row.rate]["tax_amount"] += row.amount
 			self.items_based_on_tax_rate[parent][row.rate]["net_amount"] += row.taxable_amount
 			self.items_based_on_tax_rate[parent][row.rate]["gross_amount"] += row.amount + row.taxable_amount
-
-	def get_conditions(self):
-		conditions = ""
-		for opts in (
-			("company", " and company=%(company)s"),
-			("from_date", " and posting_date>=%(from_date)s"),
-			("to_date", " and posting_date<=%(to_date)s"),
-		):
-			if self.filters.get(opts[0]):
-				conditions += opts[1]
-
-		return conditions
 
 	def get_data(self, doctype):
 		consolidated_data = self.get_consolidated_data(doctype)

--- a/erpnext/regional/report/vat_audit_report/vat_audit_report.py
+++ b/erpnext/regional/report/vat_audit_report/vat_audit_report.py
@@ -6,6 +6,7 @@ import frappe
 from frappe import _
 from frappe.utils import formatdate, get_link_to_form
 
+from erpnext import get_region
 from erpnext.accounts.report.item_wise_sales_register.item_wise_sales_register import get_tax_details_query
 
 
@@ -21,6 +22,7 @@ class VATAuditReport:
 		self.doctypes = ["Purchase Invoice", "Sales Invoice"]
 
 	def run(self):
+		self.validate_company_region()
 		self.get_sa_vat_accounts()
 		self.get_columns()
 		for doctype in self.doctypes:
@@ -42,6 +44,14 @@ class VATAuditReport:
 				self.get_data(doctype)
 
 		return self.columns, self.data
+
+	def validate_company_region(self):
+		if self.filters.company and get_region(self.filters.company) != "South Africa":
+			frappe.throw(
+				_(
+					"The company {0} is not in South Africa. VAT Audit Report is only available for companies in South Africa."
+				).format(frappe.bold(self.filters.company))
+			)
 
 	def get_sa_vat_accounts(self):
 		self.sa_vat_accounts = frappe.get_all(


### PR DESCRIPTION
Issue:

VAT Audit Report was allowing non South Africa companies to be selected and used through South Africa VAT Settings. Because of that, the report could run with an invalid company setup and fail with an unexpected server error

Traceback:

```
File "apps/frappe/frappe/app.py", line 121, in application
04:55:06 web.1         |     response = frappe.api.handle(request)
04:55:06 web.1         |   File "apps/frappe/frappe/api/__init__.py", line 63, in handle
04:55:06 web.1         |     data = endpoint(**arguments)
04:55:06 web.1         |   File "apps/frappe/frappe/api/v1.py", line 40, in handle_rpc_call
04:55:06 web.1         |     return frappe.handler.handle()
04:55:06 web.1         |            ~~~~~~~~~~~~~~~~~~~~~^^
04:55:06 web.1         |   File "apps/frappe/frappe/handler.py", line 53, in handle
04:55:06 web.1         |     data = execute_cmd(cmd)
04:55:06 web.1         |   File "apps/frappe/frappe/handler.py", line 86, in execute_cmd
04:55:06 web.1         |     return frappe.call(method, **frappe.form_dict)
04:55:06 web.1         |            ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^
04:55:06 web.1         |   File "apps/frappe/frappe/__init__.py", line 1129, in call
04:55:06 web.1         |     return fn(*args, **newargs)
04:55:06 web.1         |   File "apps/frappe/frappe/utils/typing_validations.py", line 36, in wrapper
04:55:06 web.1         |     return func(*args, **kwargs)
04:55:06 web.1         |   File "apps/frappe/frappe/__init__.py", line 491, in wrapper_fn
04:55:06 web.1         |     retval = fn(*args, **get_newargs(fn, kwargs))
04:55:06 web.1         |   File "apps/frappe/frappe/desk/query_report.py", line 231, in run
04:55:06 web.1         |     result = generate_report_result(report, filters, user, custom_columns, is_tree, parent_field)
04:55:06 web.1         |   File "apps/frappe/frappe/__init__.py", line 491, in wrapper_fn
04:55:06 web.1         |     retval = fn(*args, **get_newargs(fn, kwargs))
04:55:06 web.1         |   File "apps/frappe/frappe/desk/query_report.py", line 86, in generate_report_result
04:55:06 web.1         |     res = get_report_result(report, filters) or []
04:55:06 web.1         |           ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
04:55:06 web.1         |   File "apps/frappe/frappe/desk/query_report.py", line 67, in get_report_result
04:55:06 web.1         |     res = report.execute_script_report(filters)
04:55:06 web.1         |   File "apps/frappe/frappe/core/doctype/report/report.py", line 191, in execute_script_report
04:55:06 web.1         |     res = self.execute_module(filters)
04:55:06 web.1         |   File "apps/frappe/frappe/core/doctype/report/report.py", line 207, in execute_module
04:55:06 web.1         |     return frappe.get_attr(method_name)(frappe._dict(filters))
04:55:06 web.1         |            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^
04:55:06 web.1         |   File "apps/erpnext/erpnext/regional/report/vat_audit_report/vat_audit_report.py", line 13, in execute
04:55:06 web.1         |     return VATAuditReport(filters).run()
04:55:06 web.1         |            ~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
04:55:06 web.1         |   File "apps/erpnext/erpnext/regional/report/vat_audit_report/vat_audit_report.py", line 40, in run
04:55:06 web.1         |     self.get_invoice_items(doctype)
04:55:06 web.1         |     ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
04:55:06 web.1         |   File "apps/erpnext/erpnext/regional/report/vat_audit_report/vat_audit_report.py", line 89, in get_invoice_items
04:55:06 web.1         |     .run(as_list=1)
04:55:06 web.1         |      ~~~^^^^^^^^^^^
04:55:06 web.1         |   File "apps/frappe/frappe/query_builder/utils.py", line 131, in execute_query
04:55:06 web.1         |     result = frappe.local.db.sql(query, params, *args, **kwargs)  # nosemgrep
04:55:06 web.1         |   File "apps/frappe/frappe/database/database.py", line 272, in sql
04:55:06 web.1         |     self.execute_query(query, values)
04:55:06 web.1         |     ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
04:55:06 web.1         |   File "apps/frappe/frappe/database/database.py", line 372, in execute_query
04:55:06 web.1         |     return self._cursor.execute(query, values)
04:55:06 web.1         |            ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
04:55:06 web.1         |   File "env/lib/python3.14/site-packages/MySQLdb/cursors.py", line 179, in execute
04:55:06 web.1         |     res = self._query(mogrified_query)
04:55:06 web.1         |   File "env/lib/python3.14/site-packages/MySQLdb/cursors.py", line 330, in _query
04:55:06 web.1         |     db.query(q)
04:55:06 web.1         |     ~~~~~~~~^^^
04:55:06 web.1         |   File "env/lib/python3.14/site-packages/MySQLdb/connections.py", line 280, in query
04:55:06 web.1         |     _mysql.connection.query(self, query)
04:55:06 web.1         |     ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
04:55:06 web.1         | MySQLdb.OperationalError: (1054, "Unknown column 'is_zero_rated' in 'SELECT'")
```

Backport needed: v16

no-docs