### PR TITLE
fix: skip discount amount validation when not saving

### DIFF
--- a/erpnext/buying/doctype/purchase_order/test_purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/test_purchase_order.py
@@ -291,6 +291,30 @@ class TestPurchaseOrder(ERPNextTestSuite):
 		# ordered qty should decrease (back to initial) on row deletion
 		self.assertEqual(get_ordered_qty(), existing_ordered_qty)
 
+	def test_discount_amount_partial_purchase_receipt(self):
+		po = create_purchase_order(qty=4, rate=100, do_not_save=1)
+		po.apply_discount_on = "Grand Total"
+		po.discount_amount = 120
+		po.save()
+		po.submit()
+
+		self.assertEqual(po.grand_total, 280)
+
+		pr1 = make_purchase_receipt(po.name)
+		pr1.items[0].qty = 3
+		pr1.save()
+		pr1.submit()
+
+		self.assertEqual(pr1.discount_amount, 120)
+		self.assertEqual(pr1.grand_total, 180)
+
+		pr2 = make_purchase_receipt(po.name)
+		pr2.save()
+		pr2.submit()
+
+		self.assertEqual(pr2.discount_amount, 0)
+		self.assertEqual(pr2.grand_total, 100)
+
 	def test_update_child_perm(self):
 		po = create_purchase_order(item_code="_Test Item", qty=4)
 

--- a/erpnext/controllers/taxes_and_totals.py
+++ b/erpnext/controllers/taxes_and_totals.py
@@ -825,7 +825,8 @@ class calculate_taxes_and_totals:
 			discount_amount += total_return_discount
 
 		# validate that discount amount cannot exceed the total before discount
-		if (
+		# only during save (i.e. when `_action` is set)
+		if self.doc.get("_action") and (
 			(grand_total >= 0 and discount_amount > grand_total)
 			or (grand_total < 0 and discount_amount < grand_total)  # returns
 		):


### PR DESCRIPTION
When a Purchase Order has an Additional Discount Amount and multiple partial Purchase Receipts are created, the discount amount validation throws an error during `get_mapped_doc` (before saving), because the full discount is validated before `after_mapping` has a chance to set the correct value.

Fix: only run the discount amount > grand total validation when `_action` is set (i.e., during an actual save/submit), not during mapping/fetching.

Closes #54023

Backport needed: v16, v15