### PR TITLE
fix: fix formatting and missing bullet point in TRADEMARK_POLICY.md

### DIFF
--- a/TRADEMARK_POLICY.md
+++ b/TRADEMARK_POLICY.md
@@ -18,8 +18,9 @@ We will grant permission to use the ERPNext name and logo for projects that meet
 
 - The primary purpose of your project is to promote the spread and improvement of the ERPNext software.
 - Your project is non-commercial in nature (it can make money to cover its costs or contribute to non-profit entities, but it cannot be run as a for-profit project or business).
-Your project neither promotes nor is associated with entities that currently fail to comply with the GPL license under which ERPNext is distributed.
-- If your project meets these criteria, you will be permitted to use the ERPNext name and logo to promote your project in any way you see fit with one exception: Please do not use ERPNext as part of a domain name.
+- Your project neither promotes nor is associated with entities that currently fail to comply with the GPL license under which ERPNext is distributed.
+
+If your project meets these criteria, you will be permitted to use the ERPNext name and logo to promote your project in any way you see fit with one exception: Please do not use ERPNext as part of a domain name.
 
 Use of the ERPNext name and logo is additionally allowed in the following situations:
 


### PR DESCRIPTION
Fixed a missing bullet point marker on the third criterion in the  Frappe Trademark Usage Policy section, and moved the concluding  sentence about project criteria outside the bullet list as it is  a conclusion, not a criterion.

