### PR TITLE
fix: fix incorrect issue link numbers in sponsors.md

### DIFF
--- a/sponsors.md
+++ b/sponsors.md
@@ -42,7 +42,7 @@
 				<a href="http://www.gps.gt">Startrack</a>
 			</td>
 			<td>
-				Delivery to Target Warehouse <a href="https://github.com/frappe/erpnext/issues/3970">#3546</a>
+				Delivery to Target Warehouse <a href="https://github.com/frappe/erpnext/issues/3970">#3970</a>
 			</td>
 		</tr>
 		<tr>
@@ -58,7 +58,7 @@
 				<a href="http://agtech.com.sq">AG Technologies, Singapore</a>
 			</td>
 			<td>
-				Bulk edit via export-import in Bank Reconciliation <a href="https://github.com/frappe/erpnext/issues/1938">#4356</a>
+				Bulk edit via export-import in Bank Reconciliation <a href="https://github.com/frappe/erpnext/issues/4356">#4356</a>
 			</td>
 		</tr>
 		<tr>


### PR DESCRIPTION
Fixed two incorrect issue link numbers in sponsors.md:

- Startrack row: display text showed #3546 but the link pointed 
  to #3970. Fixed the display text to match the link (#3970).
- AG Technologies row: link pointed to #1938 but the display 
  text showed #4356. Fixed the link to point to the correct 
  issue (#4356).