### PR TITLE
fix(crm): update crm_deal on existing Customer and handle Industry Type mismatch

### DIFF
--- a/erpnext/crm/frappe_crm_api.py
+++ b/erpnext/crm/frappe_crm_api.py
@@ -159,10 +159,21 @@ def create_customer(customer_data=None):
 	try:
 		customer_name = frappe.db.exists("Customer", {"customer_name": customer_data.get("customer_name")})
 		if not customer_name:
-			customer = frappe.get_doc({"doctype": "Customer", **customer_data}).insert(
+			customer_doc_data = dict(customer_data)
+			industry = customer_doc_data.get("industry")
+			if industry and not frappe.db.exists("Industry Type", industry):
+				frappe.get_doc({"doctype": "Industry Type", "industry": industry}).insert(
+					ignore_permissions=True
+				)
+			customer = frappe.get_doc({"doctype": "Customer", **customer_doc_data}).insert(
 				ignore_permissions=True
 			)
 			customer_name = customer.name
+		elif customer_data.get("crm_deal"):
+			# Update existing Customer's crm_deal to point to the latest deal so that
+			# the direct {"crm_deal": deal_name} lookup always resolves for the most
+			# recent deal. Older deals still work via the erpnext_customer fallback.
+			frappe.db.set_value("Customer", customer_name, "crm_deal", customer_data["crm_deal"])
 
 		contacts = json.loads(customer_data.get("contacts"))
 		create_contacts(contacts, customer_name, "Customer", customer_name)

--- a/erpnext/selling/doctype/quotation/quotation.py
+++ b/erpnext/selling/doctype/quotation/quotation.py
@@ -560,7 +560,10 @@ def _make_customer(source_name, ignore_permissions=False):
 	if quotation.quotation_to == "Customer":
 		return frappe.get_doc("Customer", quotation.party_name)
 	elif quotation.quotation_to == "CRM Deal":
-		return frappe.get_doc("Customer", {"crm_deal": quotation.party_name})
+		customer_name = frappe.db.exists("Customer", {"crm_deal": quotation.party_name})
+		if customer_name:
+			return frappe.get_doc("Customer", customer_name)
+		return None
 
 	# Check if a Customer already exists for the Lead or Prospect.
 	existing_customer = None


### PR DESCRIPTION
## What

Two bugs in the Frappe CRM ↔ ERPNext integration when a Customer is linked to more than one CRM Deal.

---

## Bug 1 — `create_customer`: `crm_deal` not updated for existing customers

**File:** `erpnext/crm/frappe_crm_api.py`

### Problem

When a Customer already exists (matched by `customer_name`), the `if not customer_name:` block is skipped entirely, so the Customer's `crm_deal` field is never updated. Only the **first** deal that created the Customer gets linked. Any subsequent deal can't be found via the `{"crm_deal": deal_name}` filter used by `_make_customer` and other callers.

### Fix

Added an `elif` branch: when the Customer already exists and `customer_data` contains a `crm_deal`, update the field with `frappe.db.set_value`.

---

## Bug 2 — `create_customer`: `Industry Type` link validation error

**File:** `erpnext/crm/frappe_crm_api.py`

### Problem

The `industry` value on a CRM Deal comes from Frappe CRM's `CRM Industry` doctype. ERPNext's `Customer.industry` links to `Industry Type`. If the value doesn't exist in `Industry Type`, inserting the Customer raises a link validation error.

### Fix

Before inserting the new Customer, check if the industry value exists in `Industry Type` and auto-create it if missing.

---

## Bug 3 — `_make_customer`: `DoesNotExistError` on Quotation → Sales Order

**File:** `erpnext/selling/doctype/quotation/quotation.py`

### Problem

```python
elif quotation.quotation_to == "CRM Deal":
    return frappe.get_doc("Customer", {"crm_deal": quotation.party_name})
```

`frappe.get_doc` with a filter dict raises `DoesNotExistError` when no match is found (unlike `frappe.db.exists` which returns `None`). This crashes the Quotation → Sales Order conversion whenever the Customer's `crm_deal` field no longer matches (e.g. it was updated to a newer deal as fixed above, or it was never set).

### Fix

Replace with `frappe.db.exists` and return `None` gracefully when no Customer is found.

---

## Reproduction

1. Create CRM Deal A → convert to Customer (`crm_deal` = Deal A).
2. Create CRM Deal B for the same company → convert to Customer (same Customer reused, `crm_deal` still = Deal A).
3. Create a Quotation against Deal A → convert to Sales Order → `DoesNotExistError`.

With this fix: step 2 updates `crm_deal` to Deal B, and step 3 falls back gracefully to `None` instead of crashing.

## Test plan

- [ ] New Customer from CRM Deal — `crm_deal` field is set correctly.
- [ ] Same Customer from a second CRM Deal — `crm_deal` is updated to the new deal.
- [ ] Quotation against a CRM Deal with no matching Customer `crm_deal` — returns `None` without error.
- [ ] New Customer with an `industry` value not in `Industry Type` — auto-created, no validation error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)