### PR TITLE
fix: inventory dimensions should not be mandatory unnecesarily

### DIFF
--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -473,3 +473,4 @@ erpnext.patches.v16_0.enable_serial_batch_setting
 erpnext.patches.v16_0.co_by_product_patch
 erpnext.patches.v16_0.update_requested_qty_packed_item
 erpnext.patches.v16_0.remove_payables_receivables_workspace
+erpnext.patches.v16_0.depends_on_inv_dimensions

--- a/erpnext/patches/v16_0/depends_on_inv_dimensions.py
+++ b/erpnext/patches/v16_0/depends_on_inv_dimensions.py
@@ -1,0 +1,70 @@
+import frappe
+
+
+def get_inventory_dimensions():
+	return frappe.get_all(
+		"Inventory Dimension",
+		fields=[
+			"target_fieldname as fieldname",
+			"source_fieldname",
+			"reference_document as doctype",
+			"reqd",
+			"mandatory_depends_on",
+		],
+		order_by="creation",
+		distinct=True,
+	)
+
+
+def get_display_depends_on(doctype):
+	if doctype not in [
+		"Stock Entry Detail",
+		"Sales Invoice Item",
+		"Delivery Note Item",
+		"Purchase Invoice Item",
+		"Purchase Receipt Item",
+	]:
+		return
+
+	display_depends_on = ""
+
+	if doctype in ["Purchase Invoice Item", "Purchase Receipt Item"]:
+		display_depends_on = "eval:parent.is_internal_supplier == 1"
+	elif doctype != "Stock Entry Detail":
+		display_depends_on = "eval:parent.is_internal_customer == 1"
+	elif doctype == "Stock Entry Detail":
+		display_depends_on = "eval:doc.t_warehouse"
+
+	return display_depends_on
+
+
+def execute():
+	for dimension in get_inventory_dimensions():
+		frappe.set_value(
+			"Custom Field",
+			{"fieldname": dimension.source_fieldname, "dt": "Stock Entry Detail"},
+			"depends_on",
+			"eval:doc.s_warehouse",
+		)
+		frappe.set_value(
+			"Custom Field",
+			{"fieldname": dimension.source_fieldname, "dt": "Stock Entry Detail", "reqd": 1},
+			{"mandatory_depends_on": "eval:doc.s_warehouse", "reqd": 0},
+		)
+		frappe.set_value(
+			"Custom Field",
+			{
+				"fieldname": f"to_{dimension.fieldname}",
+				"dt": "Stock Entry Detail",
+				"depends_on": "eval:parent.purpose != 'Material Issue'",
+			},
+			"depends_on",
+			"eval:doc.t_warehouse",
+		)
+		if display_depends_on := get_display_depends_on(dimension.doctype):
+			frappe.set_value(
+				"Custom Field",
+				{"fieldname": dimension.fieldname, "dt": dimension.doctype},
+				"mandatory_depends_on",
+				display_depends_on if dimension.reqd else dimension.mandatory_depends_on,
+			)

--- a/erpnext/stock/doctype/inventory_dimension/inventory_dimension.json
+++ b/erpnext/stock/doctype/inventory_dimension/inventory_dimension.json
@@ -152,6 +152,7 @@
    "label": "Conditional Rule Examples"
   },
   {
+   "depends_on": "eval:!doc.apply_to_all_doctypes",
    "description": "To apply condition on parent field use parent.field_name and to apply condition on child table use doc.field_name. Here field_name could be based on the actual column name of the respective field.",
    "fieldname": "mandatory_depends_on",
    "fieldtype": "Small Text",
@@ -181,7 +182,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-04-07 10:46:33.877978",
+ "modified": "2026-04-08 10:10:16.884388",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Inventory Dimension",

--- a/erpnext/stock/doctype/inventory_dimension/inventory_dimension.json
+++ b/erpnext/stock/doctype/inventory_dimension/inventory_dimension.json
@@ -8,9 +8,8 @@
  "field_order": [
   "dimension_details_tab",
   "dimension_name",
-  "reference_document",
   "column_break_4",
-  "disabled",
+  "reference_document",
   "field_mapping_section",
   "source_fieldname",
   "column_break_9",
@@ -94,12 +93,6 @@
    "label": "Apply to All Inventory Documents"
   },
   {
-   "default": "0",
-   "fieldname": "disabled",
-   "fieldtype": "Check",
-   "label": "Disabled"
-  },
-  {
    "fieldname": "target_fieldname",
    "fieldtype": "Data",
    "label": "Target Fieldname (Stock Ledger Entry)",
@@ -162,8 +155,7 @@
    "description": "To apply condition on parent field use parent.field_name and to apply condition on child table use doc.field_name. Here field_name could be based on the actual column name of the respective field.",
    "fieldname": "mandatory_depends_on",
    "fieldtype": "Small Text",
-   "label": "Mandatory Depends On",
-   "read_only_depends_on": "reqd"
+   "label": "Mandatory Depends On"
   },
   {
    "fieldname": "conditional_mandatory_section",
@@ -189,7 +181,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-04-06 15:07:32.767433",
+ "modified": "2026-04-07 10:46:33.877978",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Inventory Dimension",

--- a/erpnext/stock/doctype/inventory_dimension/inventory_dimension.json
+++ b/erpnext/stock/doctype/inventory_dimension/inventory_dimension.json
@@ -162,7 +162,8 @@
    "description": "To apply condition on parent field use parent.field_name and to apply condition on child table use doc.field_name. Here field_name could be based on the actual column name of the respective field.",
    "fieldname": "mandatory_depends_on",
    "fieldtype": "Small Text",
-   "label": "Mandatory Depends On"
+   "label": "Mandatory Depends On",
+   "read_only_depends_on": "reqd"
   },
   {
    "fieldname": "conditional_mandatory_section",
@@ -188,7 +189,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-07-07 15:51:29.329064",
+ "modified": "2026-04-06 15:07:32.767433",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Inventory Dimension",

--- a/erpnext/stock/doctype/inventory_dimension/inventory_dimension.py
+++ b/erpnext/stock/doctype/inventory_dimension/inventory_dimension.py
@@ -59,10 +59,22 @@ class InventoryDimension(Document):
 			"Stock Ledger Entry", filters={self.target_fieldname: ("is", "set"), "is_cancelled": 0}, limit=1
 		)
 
+	def before_validate(self):
+		if not self.disabled and self.mandatory_depends_on and self.reqd:
+			self.reqd = 0
+			frappe.msgprint(
+				_(
+					"Warning: An Inventory Dimension can not be mandatory and have a mandatory dependency at the same time. Mandatory field has been unchecked."
+				),
+				alert=True,
+				indicator="orange",
+			)
+
 	def validate(self):
 		self.validate_reference_document()
 
 	def before_save(self):
+		self.show_disable_warning()
 		self.do_not_update_document()
 		self.reset_value()
 		self.set_source_and_target_fieldname()
@@ -71,6 +83,16 @@ class InventoryDimension(Document):
 	def set_type_of_transaction(self):
 		if self.apply_to_all_doctypes:
 			self.type_of_transaction = "Both"
+
+	def show_disable_warning(self):
+		if self.disabled and (self.reqd or self.mandatory_depends_on):
+			frappe.msgprint(
+				_(
+					"Warning: Disabling Inventory Dimensions will still keep the fields mandatory. If you wish to make the fields <b>not</b> mandatory, you will need to delete this Inventory Dimension instead."
+				),
+				alert=True,
+				indicator="orange",
+			)
 
 	def do_not_update_document(self):
 		if self.is_new() or not self.has_stock_ledger():
@@ -187,7 +209,9 @@ class InventoryDimension(Document):
 				depends_on="eval:doc.s_warehouse" if doctype == "Stock Entry Detail" else "",
 				search_index=1,
 				reqd=self.reqd,
-				mandatory_depends_on=self.mandatory_depends_on,
+				mandatory_depends_on="eval:doc.s_warehouse"
+				if doctype == "Stock Entry Detail"
+				else self.mandatory_depends_on,
 			),
 		]
 
@@ -268,6 +292,7 @@ class InventoryDimension(Document):
 		fieldname_start_with = "to"
 		label_start_with = "Target"
 		display_depends_on = ""
+		mandatory_depends_on = ""
 
 		if doctype in ["Purchase Invoice Item", "Purchase Receipt Item"]:
 			fieldname_start_with = "from"
@@ -277,6 +302,7 @@ class InventoryDimension(Document):
 			display_depends_on = "eval:parent.is_internal_customer == 1"
 		elif doctype == "Stock Entry Detail":
 			display_depends_on = "eval:doc.t_warehouse"
+			mandatory_depends_on = "eval:doc.t_warehouse"
 
 		fieldname = f"{fieldname_start_with}_{self.source_fieldname}"
 		label = f"{label_start_with} {self.dimension_name}"
@@ -298,6 +324,8 @@ class InventoryDimension(Document):
 					options=self.reference_document,
 					label=label,
 					depends_on=display_depends_on,
+					reqd=self.reqd,
+					mandatory_depends_on=mandatory_depends_on or self.mandatory_depends_on,
 				),
 			]
 		)

--- a/erpnext/stock/doctype/inventory_dimension/inventory_dimension.py
+++ b/erpnext/stock/doctype/inventory_dimension/inventory_dimension.py
@@ -58,6 +58,10 @@ class InventoryDimension(Document):
 			"Stock Ledger Entry", filters={self.target_fieldname: ("is", "set"), "is_cancelled": 0}, limit=1
 		)
 
+	def before_validate(self):
+		if self.apply_to_all_doctypes and self.mandatory_depends_on:
+			self.mandatory_depends_on = ""
+
 	def validate(self):
 		self.validate_reference_document()
 
@@ -184,9 +188,8 @@ class InventoryDimension(Document):
 				label=_(label),
 				depends_on="eval:doc.s_warehouse" if doctype == "Stock Entry Detail" else "",
 				search_index=1,
-				reqd=self.reqd,
 				mandatory_depends_on="eval:doc.s_warehouse"
-				if doctype == "Stock Entry Detail"
+				if self.reqd and doctype == "Stock Entry Detail"
 				else self.mandatory_depends_on,
 			),
 		]
@@ -298,9 +301,7 @@ class InventoryDimension(Document):
 					options=self.reference_document,
 					label=label,
 					depends_on=display_depends_on,
-					mandatory_depends_on="eval:doc.t_warehouse"
-					if doctype == "Stock Entry Detail"
-					else self.mandatory_depends_on,
+					mandatory_depends_on=display_depends_on if self.reqd else self.mandatory_depends_on,
 				),
 			]
 		)

--- a/erpnext/stock/doctype/inventory_dimension/inventory_dimension.py
+++ b/erpnext/stock/doctype/inventory_dimension/inventory_dimension.py
@@ -34,7 +34,6 @@ class InventoryDimension(Document):
 		apply_to_all_doctypes: DF.Check
 		condition: DF.Code | None
 		dimension_name: DF.Data
-		disabled: DF.Check
 		document_type: DF.Link | None
 		fetch_from_parent: DF.Literal[None]
 		istable: DF.Check
@@ -59,22 +58,10 @@ class InventoryDimension(Document):
 			"Stock Ledger Entry", filters={self.target_fieldname: ("is", "set"), "is_cancelled": 0}, limit=1
 		)
 
-	def before_validate(self):
-		if not self.disabled and self.mandatory_depends_on and self.reqd:
-			self.reqd = 0
-			frappe.msgprint(
-				_(
-					"Warning: An Inventory Dimension can not be mandatory and have a mandatory dependency at the same time. Mandatory field has been unchecked."
-				),
-				alert=True,
-				indicator="orange",
-			)
-
 	def validate(self):
 		self.validate_reference_document()
 
 	def before_save(self):
-		self.show_disable_warning()
 		self.do_not_update_document()
 		self.reset_value()
 		self.set_source_and_target_fieldname()
@@ -84,23 +71,12 @@ class InventoryDimension(Document):
 		if self.apply_to_all_doctypes:
 			self.type_of_transaction = "Both"
 
-	def show_disable_warning(self):
-		if self.disabled and (self.reqd or self.mandatory_depends_on):
-			frappe.msgprint(
-				_(
-					"Warning: Disabling Inventory Dimensions will still keep the fields mandatory. If you wish to make the fields <b>not</b> mandatory, you will need to delete this Inventory Dimension instead."
-				),
-				alert=True,
-				indicator="orange",
-			)
-
 	def do_not_update_document(self):
 		if self.is_new() or not self.has_stock_ledger():
 			return
 
 		old_doc = self._doc_before_save
 		allow_to_edit_fields = [
-			"disabled",
 			"fetch_from_parent",
 			"type_of_transaction",
 			"condition",
@@ -292,7 +268,6 @@ class InventoryDimension(Document):
 		fieldname_start_with = "to"
 		label_start_with = "Target"
 		display_depends_on = ""
-		mandatory_depends_on = ""
 
 		if doctype in ["Purchase Invoice Item", "Purchase Receipt Item"]:
 			fieldname_start_with = "from"
@@ -302,7 +277,6 @@ class InventoryDimension(Document):
 			display_depends_on = "eval:parent.is_internal_customer == 1"
 		elif doctype == "Stock Entry Detail":
 			display_depends_on = "eval:doc.t_warehouse"
-			mandatory_depends_on = "eval:doc.t_warehouse"
 
 		fieldname = f"{fieldname_start_with}_{self.source_fieldname}"
 		label = f"{label_start_with} {self.dimension_name}"
@@ -324,8 +298,9 @@ class InventoryDimension(Document):
 					options=self.reference_document,
 					label=label,
 					depends_on=display_depends_on,
-					reqd=self.reqd,
-					mandatory_depends_on=mandatory_depends_on or self.mandatory_depends_on,
+					mandatory_depends_on="eval:doc.t_warehouse"
+					if doctype == "Stock Entry Detail"
+					else self.mandatory_depends_on,
 				),
 			]
 		)
@@ -407,7 +382,6 @@ def get_document_wise_inventory_dimensions(doctype) -> dict:
 			"type_of_transaction",
 			"fetch_from_parent",
 		],
-		filters={"disabled": 0},
 		or_filters={"document_type": doctype, "apply_to_all_doctypes": 1},
 	)
 
@@ -424,7 +398,6 @@ def get_inventory_dimensions():
 			"validate_negative_stock",
 			"name as dimension_name",
 		],
-		filters={"disabled": 0},
 		order_by="creation",
 		distinct=True,
 	)

--- a/erpnext/stock/doctype/inventory_dimension/inventory_dimension.py
+++ b/erpnext/stock/doctype/inventory_dimension/inventory_dimension.py
@@ -58,10 +58,6 @@ class InventoryDimension(Document):
 			"Stock Ledger Entry", filters={self.target_fieldname: ("is", "set"), "is_cancelled": 0}, limit=1
 		)
 
-	def before_validate(self):
-		if self.apply_to_all_doctypes and self.mandatory_depends_on:
-			self.mandatory_depends_on = ""
-
 	def validate(self):
 		self.validate_reference_document()
 
@@ -124,6 +120,7 @@ class InventoryDimension(Document):
 	def reset_value(self):
 		if self.apply_to_all_doctypes:
 			self.type_of_transaction = ""
+			self.mandatory_depends_on = ""
 
 			self.istable = 0
 			for field in ["document_type", "condition"]:
@@ -188,7 +185,9 @@ class InventoryDimension(Document):
 				label=_(label),
 				depends_on="eval:doc.s_warehouse" if doctype == "Stock Entry Detail" else "",
 				search_index=1,
-				reqd=self.reqd,
+				reqd=1
+				if self.reqd and not self.mandatory_depends_on and doctype != "Stock Entry Detail"
+				else 0,
 				mandatory_depends_on="eval:doc.s_warehouse"
 				if self.reqd and doctype == "Stock Entry Detail"
 				else self.mandatory_depends_on,
@@ -308,7 +307,7 @@ class InventoryDimension(Document):
 		)
 
 
-def field_exists(doctype, fieldname) -> str or None:
+def field_exists(doctype, fieldname) -> str | None:
 	return frappe.db.get_value("DocField", {"parent": doctype, "fieldname": fieldname}, "name")
 
 

--- a/erpnext/stock/doctype/inventory_dimension/inventory_dimension.py
+++ b/erpnext/stock/doctype/inventory_dimension/inventory_dimension.py
@@ -188,6 +188,7 @@ class InventoryDimension(Document):
 				label=_(label),
 				depends_on="eval:doc.s_warehouse" if doctype == "Stock Entry Detail" else "",
 				search_index=1,
+				reqd=self.reqd,
 				mandatory_depends_on="eval:doc.s_warehouse"
 				if self.reqd and doctype == "Stock Entry Detail"
 				else self.mandatory_depends_on,

--- a/erpnext/stock/doctype/inventory_dimension/test_inventory_dimension.py
+++ b/erpnext/stock/doctype/inventory_dimension/test_inventory_dimension.py
@@ -210,9 +210,9 @@ class TestInventoryDimension(ERPNextTestSuite):
 		doc = create_inventory_dimension(
 			reference_document="Pallet",
 			type_of_transaction="Outward",
-			dimension_name="Pallet",
+			dimension_name="Pallet 75",
 			apply_to_all_doctypes=0,
-			document_type="Stock Entry Detail",
+			document_type="Delivery Note Item",
 		)
 
 		doc.reqd = 1
@@ -220,7 +220,7 @@ class TestInventoryDimension(ERPNextTestSuite):
 
 		self.assertTrue(
 			frappe.db.get_value(
-				"Custom Field", {"fieldname": "pallet", "dt": "Stock Entry Detail", "reqd": 1}, "name"
+				"Custom Field", {"fieldname": "pallet_75", "dt": "Delivery Note Item", "reqd": 1}, "name"
 			)
 		)
 

--- a/erpnext/stock/doctype/inventory_dimension/test_inventory_dimension.py
+++ b/erpnext/stock/doctype/inventory_dimension/test_inventory_dimension.py
@@ -237,13 +237,16 @@ class TestInventoryDimension(ERPNextTestSuite):
 			document_type="Stock Entry Detail",
 		)
 
-		doc.mandatory_depends_on = "t_warehouse"
 		doc.save()
 
 		self.assertTrue(
 			frappe.db.get_value(
 				"Custom Field",
-				{"fieldname": "pallet", "dt": "Stock Entry Detail", "mandatory_depends_on": "t_warehouse"},
+				{
+					"fieldname": "pallet",
+					"dt": "Stock Entry Detail",
+					"mandatory_depends_on": "eval:doc.s_warehouse",
+				},
 				"name",
 			)
 		)

--- a/erpnext/stock/doctype/inventory_dimension/test_inventory_dimension.py
+++ b/erpnext/stock/doctype/inventory_dimension/test_inventory_dimension.py
@@ -237,16 +237,13 @@ class TestInventoryDimension(ERPNextTestSuite):
 			document_type="Stock Entry Detail",
 		)
 
+		doc.mandatory_depends_on = "t_warehouse"
 		doc.save()
 
 		self.assertTrue(
 			frappe.db.get_value(
 				"Custom Field",
-				{
-					"fieldname": "pallet",
-					"dt": "Stock Entry Detail",
-					"mandatory_depends_on": "eval:doc.s_warehouse",
-				},
+				{"fieldname": "pallet", "dt": "Stock Entry Detail", "mandatory_depends_on": "t_warehouse"},
 				"name",
 			)
 		)


### PR DESCRIPTION
Inventory dimension fields should not be mandatory in cases where it does not make sense (for ex. source fields in material receipt)