### PR TITLE
fix: prevent Work Order from using disabled production items

### DIFF
--- a/erpnext/manufacturing/doctype/work_order/work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/work_order.py
@@ -1402,9 +1402,14 @@ class WorkOrder(Document):
 	def validate_production_item(self):
 		if frappe.get_cached_value("Item", self.production_item, "has_variants"):
 			frappe.throw(_("Work Order cannot be raised against a Item Template"), ItemHasVariantError)
-
 		if self.production_item:
 			validate_end_of_life(self.production_item)
+			if frappe.db.get_value("Item", self.production_item, "disabled"):
+				frappe.throw(
+					_("Production Item {0} is disabled. Please select an active item.").format(
+						frappe.bold(self.production_item)
+					)
+				)
 
 	def validate_qty(self):
 		if self.qty <= 0:


### PR DESCRIPTION
Closes #53814

Added a validation check in the existing `validate_production_item` 
method in work_order.py to prevent saving a Work Order when the 
selected production item is disabled.

Previously, a disabled item could be used in a Work Order without 
any error, which is incorrect behavior.

The fix adds a check using `frappe.db.get_value` to detect if the 
item is disabled and throws a user-friendly error message if so.