### PR TITLE
feat: Increase GL_Entry autoname hash size

### DIFF
--- a/erpnext/accounts/doctype/gl_entry/gl_entry.py
+++ b/erpnext/accounts/doctype/gl_entry/gl_entry.py
@@ -76,7 +76,7 @@ class GLEntry(Document):
 		Temporarily name doc for fast insertion
 		name will be changed using autoname options (in a scheduled job)
 		"""
-		self.name = frappe.generate_hash(txt="", length=10)
+		self.name = frappe.generate_hash(txt="", length=15)
 		if self.meta.autoname == "hash":
 			self.to_rename = 0
 


### PR DESCRIPTION
Reduces risk of collisions when working with extremely large data sets

> Please provide enough information so that others can review your pull request:

Currently, the hash size of 10 for the GL Entry autoname can cause collisions when working on extremely large data sets due to the risk of a duplicate hash occuring. This PR reduces that risk by increasing the hash length to 15.

<img width="657" height="50" alt="{02E620AA-3B32-437E-9644-2CAD6412EF33}" src="https://github.com/user-attachments/assets/72aa844e-5e40-4ce5-ab34-fb7a89bef1c4" />
Image: Example of a hash collision
