### PR TITLE
fix: divide sub-assembly cost by qty to get per-unit rate in BOM Creator

### DIFF
--- a/erpnext/manufacturing/doctype/bom_creator/bom_creator.py
+++ b/erpnext/manufacturing/doctype/bom_creator/bom_creator.py
@@ -203,7 +203,7 @@ class BOMCreator(Document):
 					self,
 				)
 			else:
-				row.rate = flt(self.get_raw_material_cost(row.item_code) * row.conversion_factor)
+				row.rate = flt(self.get_raw_material_cost(row.item_code) / flt(row.qty or 1) * row.conversion_factor)
 
 			row.amount = flt(row.rate) * flt(row.qty)
 			amount += flt(row.amount)

--- a/erpnext/manufacturing/doctype/bom_creator/bom_creator.py
+++ b/erpnext/manufacturing/doctype/bom_creator/bom_creator.py
@@ -203,7 +203,10 @@ class BOMCreator(Document):
 					self,
 				)
 			else:
-				row.rate = flt(self.get_raw_material_cost(row.item_code) / flt(row.qty or 1) * row.conversion_factor)
+				row.rate = flt(
+					self.get_raw_material_cost(row.item_code) / flt(row.qty or 1) * row.conversion_factor
+				)
+
 
 			row.amount = flt(row.rate) * flt(row.qty)
 			amount += flt(row.amount)

--- a/erpnext/manufacturing/doctype/bom_creator/bom_creator.py
+++ b/erpnext/manufacturing/doctype/bom_creator/bom_creator.py
@@ -207,7 +207,6 @@ class BOMCreator(Document):
 					self.get_raw_material_cost(row.item_code) / flt(row.qty or 1) * row.conversion_factor
 				)
 
-
 			row.amount = flt(row.rate) * flt(row.qty)
 			amount += flt(row.amount)
 


### PR DESCRIPTION
credits to @ravindu2012

fixes #52149