### PR TITLE
fix: preserve asset movement field properties after save

### DIFF
--- a/erpnext/assets/doctype/asset_movement/asset_movement.js
+++ b/erpnext/assets/doctype/asset_movement/asset_movement.js
@@ -41,7 +41,7 @@ frappe.ui.form.on("Asset Movement", {
 			});
 	},
 
-	onload: (frm) => {
+	refresh: (frm) => {
 		frm.trigger("set_required_fields");
 	},
 


### PR DESCRIPTION
Issue:
In Asset Movement, the fields `target_location`, `source_location`, `from_employee`, and `to_employee` change field property based on purpose after saving, those fields reset back to their original properties.

Ref: [#64119](https://support.frappe.io/helpdesk/tickets/64119)

Backport needed: v16, v15