### PR TITLE
fix: POS Closing Entry, reload invoices when changing dates

### DIFF
--- a/erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.js
+++ b/erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.js
@@ -56,7 +56,7 @@ frappe.ui.form.on("POS Closing Entry", {
 		}
 	},
 
-	pos_opening_entry(frm) {
+	reload_invoices: function (frm) {
 		if (
 			frm.doc.pos_opening_entry &&
 			frm.doc.period_start_date &&
@@ -71,6 +71,18 @@ frappe.ui.form.on("POS Closing Entry", {
 				() => frappe.dom.unfreeze(),
 			]);
 		}
+	},
+
+	pos_opening_entry(frm) {
+		frm.trigger("reload_invoices");
+	},
+
+	period_start_date(frm) {
+		frm.trigger("reload_invoices");
+	},
+
+	period_end_date(frm) {
+		frm.trigger("reload_invoices");
 	},
 
 	set_opening_amounts(frm) {

--- a/erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.js
+++ b/erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.js
@@ -8,9 +8,6 @@ frappe.ui.form.on("POS Closing Entry", {
 			return { filters: { status: "Open", docstatus: 1 } };
 		});
 
-		if (frm.doc.docstatus === 0 && !frm.doc.amended_from)
-			frm.set_value("period_end_date", frappe.datetime.now_datetime());
-
 		frappe.realtime.on("closing_process_complete", async function (data) {
 			await frm.reload_doc();
 			if (frm.doc.status == "Failed" && frm.doc.error_message) {

--- a/erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.json
+++ b/erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.json
@@ -49,7 +49,7 @@
    "reqd": 1
   },
   {
-   "default": "Today",
+   "default": "Now",
    "fieldname": "period_end_date",
    "fieldtype": "Datetime",
    "in_list_view": 1,
@@ -261,11 +261,11 @@
    "link_fieldname": "pos_closing_entry"
   }
  ],
- "modified": "2025-06-14 02:38:14.962291",
+ "modified": "2026-04-22 14:10:10.094718",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "POS Closing Entry",
- "naming_rule": "Expression (old style)",
+ "naming_rule": "Expression",
  "owner": "Administrator",
  "permissions": [
   {


### PR DESCRIPTION
For simulate, I have:
- 1 POS Opening Entry having period_start_date "06/04/2026 00:00:00"
- 1 POS Invoice having posting_time "01:17:58"
- 1 POS Invoice having posting_time "17:18:10"
- 1 Draft POS Closing Entry linked to this POS Opening Entry.

The problem is: If the POS Invoices is already loaded in POS Closing Entry but we want to change the period_end_date to some time between the two invoices, they don't reload the invoices, and we still seeing the two invoices.

Before my changes:

https://github.com/user-attachments/assets/b99152a6-542c-4b7c-8ad2-bba39a0e81f1

After my changes:

https://github.com/user-attachments/assets/a56c2ded-2719-4525-b059-24af14f90825

