### PR TITLE
fix(promotional_scheme): toggle enable state between Buying and Selli…

### DIFF
--- a/erpnext/accounts/doctype/promotional_scheme/promotional_scheme.js
+++ b/erpnext/accounts/doctype/promotional_scheme/promotional_scheme.js
@@ -21,12 +21,12 @@ frappe.ui.form.on("Promotional Scheme", {
 
 	selling: function (frm) {
 		frm.trigger("set_options_for_applicable_for");
-		frm.toggle_enable("selling", frm.doc.buying ? false : true);
+		frm.toggle_enable("buying", !frm.doc.selling);
 	},
 
 	buying: function (frm) {
 		frm.trigger("set_options_for_applicable_for");
-		frm.toggle_enable("buying", frm.doc.selling ? false : true);
+		frm.toggle_enable("selling", !frm.doc.buying);
 	},
 
 	set_options_for_applicable_for: function (frm) {

--- a/erpnext/accounts/doctype/promotional_scheme/promotional_scheme.js
+++ b/erpnext/accounts/doctype/promotional_scheme/promotional_scheme.js
@@ -21,10 +21,12 @@ frappe.ui.form.on("Promotional Scheme", {
 
 	selling: function (frm) {
 		frm.trigger("set_options_for_applicable_for");
+		frm.toggle_enable("selling", frm.doc.buying ? false : true);
 	},
 
 	buying: function (frm) {
 		frm.trigger("set_options_for_applicable_for");
+		frm.toggle_enable("buying", frm.doc.selling ? false : true);
 	},
 
 	set_options_for_applicable_for: function (frm) {


### PR DESCRIPTION
fix(promotional_scheme): enforce mutual exclusivity between Buying and Selling

Add server-side validation to prevent selecting both Selling and Buying simultaneously
and throw an error if both are enabled

Improve client-side by dynamically disabling the opposite option when one is selected
(Selling disables Buying and vice versa)

🔧 Changes Made:
Added UI logic to
modified:   erpnext/accounts/doctype/promotional_scheme/promotional_scheme.js

 use  frm.toggle_enable() for cleaner and more maintainable Frappe standards.

closed https://github.com/frappe/erpnext/issues/53434