### PR TITLE
fix(stock): ignore delivery note on delivery trip on_cancel trigger

### DIFF
--- a/erpnext/stock/doctype/delivery_trip/delivery_trip.js
+++ b/erpnext/stock/doctype/delivery_trip/delivery_trip.js
@@ -41,6 +41,8 @@ frappe.ui.form.on("Delivery Trip", {
 	},
 
 	refresh: function (frm) {
+		frm.ignore_doctypes_on_cancel_all = ["Delivery Note"];
+
 		if (frm.doc.docstatus == 1 && frm.doc.delivery_stops.length > 0) {
 			frm.add_custom_button(__("Notify Customers via Email"), function () {
 				frm.trigger("notify_customers");


### PR DESCRIPTION
**Issue:**
While cancelling the Delivery Trip, the system force the user to cancel the linked delivery note and linked documents of delivery note.

**Ref:** [#64814](https://support.frappe.io/helpdesk/tickets/64814)

<img width="1136" height="410" alt="image" src="https://github.com/user-attachments/assets/89fbdc1c-c3bb-4385-af22-a3d971b18c25" />


**Backport Needed for v16**