### PR TITLE
fix: quality inspection item code fetch perm issue

### DIFF
--- a/erpnext/stock/doctype/quality_inspection/quality_inspection.js
+++ b/erpnext/stock/doctype/quality_inspection/quality_inspection.js
@@ -58,6 +58,7 @@ frappe.ui.form.on("Quality Inspection", {
 			if (doc.reference_type && doc.reference_name) {
 				let filters = {
 					from: doctype,
+					parent_doctype: doc.reference_type,
 					inspection_type: doc.inspection_type,
 				};
 

--- a/erpnext/stock/doctype/quality_inspection/quality_inspection.py
+++ b/erpnext/stock/doctype/quality_inspection/quality_inspection.py
@@ -370,10 +370,11 @@ def item_query(doctype: Any, txt: str | None, searchfield: Any, start: int, page
 	from frappe.desk.reportview import get_match_cond
 
 	from_doctype = cstr(filters.get("from"))
+	parent_doctype = cstr(filters.get("parent_doctype"))
 	if not from_doctype or not frappe.db.exists("DocType", from_doctype):
 		return []
 
-	mcond = get_match_cond(from_doctype)
+	mcond = get_match_cond(parent_doctype) if parent_doctype else get_match_cond(from_doctype)
 	cond, qi_condition = "", "and (quality_inspection is null or quality_inspection = '')"
 
 	if filters.get("parent"):

--- a/erpnext/stock/doctype/quality_inspection/quality_inspection.py
+++ b/erpnext/stock/doctype/quality_inspection/quality_inspection.py
@@ -374,7 +374,7 @@ def item_query(doctype: Any, txt: str | None, searchfield: Any, start: int, page
 	if not from_doctype or not frappe.db.exists("DocType", from_doctype):
 		return []
 
-	mcond = get_match_cond(parent_doctype) if parent_doctype else get_match_cond(from_doctype)
+	mcond = get_match_cond(parent_doctype or from_doctype)
 	cond, qi_condition = "", "and (quality_inspection is null or quality_inspection = '')"
 
 	if filters.get("parent"):


### PR DESCRIPTION
fixes: https://support.frappe.io/helpdesk/tickets/64834?view=VIEW-HD+Ticket-1232 

Currently in the quality inspection, while fetching the item code it checks the permission of the child table, instead should check for the parent doctype. This resolves it.