### PR TITLE
fix: exclude Period Closing Voucher entries from net movement calculations in financial reports

### DIFF
--- a/erpnext/accounts/doctype/financial_report_template/financial_report_engine.py
+++ b/erpnext/accounts/doctype/financial_report_template/financial_report_engine.py
@@ -632,6 +632,18 @@ class FinancialQueryBuilder:
 			)
 			query = query.select(Sum(period_condition).as_(period["key"]))
 
+			pcv_period_condition = (
+				Case()
+				.when(
+					(gl_table.posting_date >= period["from_date"])
+					& (gl_table.posting_date <= period["to_date"])
+					& (gl_table.voucher_type == "Period Closing Voucher"),
+					gl_table.debit - gl_table.credit,
+				)
+				.else_(0)
+			)
+			query = query.select(Sum(pcv_period_condition).as_(f"{period['key']}__pcv"))
+
 		query = self._apply_standard_filters(query, gl_table)
 		return self._execute_with_permissions(query, "GL Entry")
 
@@ -654,8 +666,12 @@ class FinancialQueryBuilder:
 
 			for period in self.periods:
 				period_key = period["key"]
-				movement = gl_movement.get(period_key, 0.0)
-				closing_balance = current_balance + movement
+				total_movement = gl_movement.get(period_key, 0.0)
+				pcv_movement = gl_movement.get(f"{period_key}__pcv", 0.0)
+				closing_balance = current_balance + total_movement
+
+				# Net/period movement should exclude PCV entries.
+				movement = total_movement - flt(pcv_movement)
 
 				account_data.add_period(PeriodValue(period_key, current_balance, closing_balance, movement))
 
@@ -680,12 +696,6 @@ class FinancialQueryBuilder:
 				account_data.unaccumulate_values()
 
 	def _apply_standard_filters(self, query, table, doctype: str = "GL Entry"):
-		if self.filters.get("ignore_closing_entries"):
-			if doctype == "GL Entry":
-				query = query.where(table.voucher_type != "Period Closing Voucher")
-			else:
-				query = query.where(table.is_period_closing_voucher_entry == 0)
-
 		if self.filters.get("project"):
 			projects = self.filters.get("project")
 			if isinstance(projects, str):

--- a/erpnext/accounts/doctype/financial_report_template/financial_report_engine.py
+++ b/erpnext/accounts/doctype/financial_report_template/financial_report_engine.py
@@ -94,16 +94,6 @@ class AccountData:
 	def has_periods(self) -> bool:
 		return len(self.period_values) > 0
 
-	def accumulate_values(self) -> None:
-		for period_value in self.period_values.values():
-			period_value.movement += period_value.opening
-			# closing is accumulated by default
-
-	def unaccumulate_values(self) -> None:
-		for period_value in self.period_values.values():
-			period_value.closing -= period_value.opening
-			# movement is unaccumulated by default
-
 	def copy(self):
 		copied = AccountData(
 			account=self.account,
@@ -351,6 +341,7 @@ class DataCollector:
 
 		# Get all accounts
 		all_accounts = []
+		should_accumulate = bool(self.filters.get("accumulated_values"))
 
 		for request in self.account_requests:
 			all_accounts.extend(request["accounts"])
@@ -388,6 +379,10 @@ class DataCollector:
 					account_obj.reverse_values()
 
 				account_values = account_obj.get_ordered_values(period_keys, balance_type)
+				if should_accumulate:
+					account_values = self._accumulate_and_set_period_values(
+						account_obj, period_keys, account_values, balance_type
+					)
 
 				# Add to totals
 				for i, value in enumerate(account_values):
@@ -400,6 +395,27 @@ class DataCollector:
 			account_details[ref_code] = request_account_details
 
 		return {"account_data": account_data, "summary": summary, "account_details": account_details}
+
+	@staticmethod
+	def _accumulate_and_set_period_values(
+		account_data: AccountData, period_keys: list[str], values: list[float], balance_type: str
+	) -> list[float]:
+		"""Accumulate a series and sync detail rows for the selected balance type."""
+		cumulative = 0.0
+		result = []
+		for index, period_key in enumerate(period_keys):
+			value = values[index] if index < len(values) else 0.0
+			cumulative += flt(value)
+			result.append(cumulative)
+			if period_value := account_data.get_period(period_key):
+				if balance_type == "Opening Balance":
+					period_value.opening = cumulative
+				elif balance_type == "Closing Balance":
+					period_value.closing = cumulative
+				elif balance_type == "Period Movement (Debits - Credits)":
+					period_value.movement = cumulative
+
+		return result
 
 	@staticmethod
 	def _parse_account_filter(company, report_row) -> list[dict]:
@@ -493,7 +509,6 @@ class FinancialQueryBuilder:
 		balances_data = self._get_opening_balances(account_names)
 		gl_data = self._get_gl_movements(account_names)
 		self._calculate_running_balances(balances_data, gl_data)
-		self._handle_balance_accumulation(balances_data)
 
 		return balances_data
 
@@ -676,24 +691,6 @@ class FinancialQueryBuilder:
 				account_data.add_period(PeriodValue(period_key, current_balance, closing_balance, movement))
 
 				current_balance = closing_balance
-
-	def _handle_balance_accumulation(self, balances_data):
-		for account_data in balances_data.values():
-			account_data: AccountData
-
-			accumulated_values = self.filters.get("accumulated_values")
-
-			if accumulated_values is None:
-				# respect user setting if not in filters
-				# closing = accumulated
-				# movement = unaccumulated
-				continue
-
-			# for legacy reports
-			elif accumulated_values:
-				account_data.accumulate_values()
-			else:
-				account_data.unaccumulate_values()
 
 	def _apply_standard_filters(self, query, table, doctype: str = "GL Entry"):
 		if self.filters.get("project"):

--- a/erpnext/accounts/doctype/financial_report_template/test_financial_report_engine.py
+++ b/erpnext/accounts/doctype/financial_report_template/test_financial_report_engine.py
@@ -2,7 +2,8 @@
 # For license information, please see license.txt
 
 import frappe
-from frappe.utils import flt
+from frappe.tests.utils import change_settings
+from frappe.utils import add_days, flt
 
 from erpnext.accounts.doctype.financial_report_template.financial_report_engine import (
 	DependencyResolver,
@@ -1667,6 +1668,85 @@ class TestFilterExpressionParser(FinancialReportTemplateTestCase):
 
 
 class TestFinancialQueryBuilder(FinancialReportTemplateTestCase):
+	@change_settings("Accounts Settings", {"use_legacy_controller_for_pcv": 1})
+	def test_pcv_excluded_from_movement_but_included_in_closing(self):
+		company = "_Test Company"
+		sales_account = "Sales - _TC"
+		cash_account = "_Test Cash - _TC"
+		posting_date = "2023-10-15"
+		fiscal_year = get_fiscal_year(posting_date, company=company)
+		period_start = fiscal_year[1]
+		period_end = fiscal_year[2]
+		period_key = "fy_period"
+
+		jv = make_journal_entry(
+			account1=cash_account,
+			account2=sales_account,
+			amount=5000,
+			posting_date=posting_date,
+			company=company,
+			submit=True,
+		)
+
+		pcv = None
+		prior_year_pcvs = []
+
+		try:
+			closing_account = get_closing_account(company)
+			prior_year_pcvs = create_missing_prior_year_pcvs(company, fiscal_year[1], closing_account)
+
+			pcv = create_pcv(
+				transaction_date=period_end,
+				period_start_date=period_start,
+				period_end_date=period_end,
+				company=company,
+				fiscal_year=fiscal_year[0],
+				cost_center="_Test Cost Center - _TC",
+				closing_account_head=closing_account,
+				remarks="Test PCV movement exclusion",
+			)
+
+			filters = frappe._dict(
+				{
+					"company": company,
+					"from_fiscal_year": fiscal_year[0],
+					"to_fiscal_year": fiscal_year[0],
+					"period_start_date": period_start,
+					"period_end_date": period_end,
+					"filter_based_on": "Date Range",
+					"periodicity": "Quarterly",
+				}
+			)
+
+			periods = [{"key": period_key, "from_date": period_start, "to_date": period_end}]
+
+			qb = FinancialQueryBuilder(filters, periods)
+			accounts = [
+				frappe._dict({"name": sales_account, "account_name": "Sales", "account_number": ""}),
+				frappe._dict(
+					{
+						"name": closing_account,
+						"account_name": frappe.db.get_value("Account", closing_account, "account_name"),
+						"account_number": "",
+					}
+				),
+			]
+			balances = qb.fetch_account_balances(accounts)
+
+			sales_q4 = balances.get(sales_account).get_period(period_key)
+			self.assertEqual(sales_q4.movement, -5000.0)
+			self.assertEqual(sales_q4.closing, 0.0)
+
+			# Net movement should always exclude PCV entries, including the transfer account.
+			closing_q4 = balances.get(closing_account).get_period(period_key)
+			self.assertEqual(closing_q4.movement, 0.0)
+			self.assertEqual(closing_q4.closing - closing_q4.opening, -5000.0)
+
+		finally:
+			cleanup_pcvs(pcv=pcv, prior_year_pcvs=prior_year_pcvs)
+
+			jv.cancel()
+
 	def test_fetch_balances_with_journal_entries(self):
 		company = "_Test Company"
 		cash_account = "_Test Cash - _TC"
@@ -1766,6 +1846,7 @@ class TestFinancialQueryBuilder(FinancialReportTemplateTestCase):
 			jv_nov.cancel()
 			jv_oct.cancel()
 
+	@change_settings("Accounts Settings", {"use_legacy_controller_for_pcv": 1})
 	def test_opening_balance_from_previous_period_closing(self):
 		company = "_Test Company"
 		cash_account = "_Test Cash - _TC"
@@ -1784,44 +1865,28 @@ class TestFinancialQueryBuilder(FinancialReportTemplateTestCase):
 		)
 
 		pcv = None
+		prior_year_pcvs = []
 		jv_2024 = None
-		original_pcv_setting = frappe.db.get_single_value(
-			"Accounts Settings", "use_legacy_controller_for_pcv"
-		)
 
 		try:
 			# Create Period Closing Voucher for 2023
 			# This will create Account Closing Balance entries
-			closing_account = frappe.db.get_value(
-				"Account",
-				{
-					"company": company,
-					"root_type": "Liability",
-					"is_group": 0,
-					"account_type": ["not in", ["Payable", "Receivable"]],
-				},
-				"name",
-			)
+			closing_account = get_closing_account(company)
 
 			fy_2023 = get_fiscal_year(posting_date_2023, company=company)
 
-			frappe.db.set_single_value("Accounts Settings", "use_legacy_controller_for_pcv", 1)
+			prior_year_pcvs = create_missing_prior_year_pcvs(company, fy_2023[1], closing_account)
 
-			pcv = frappe.get_doc(
-				{
-					"doctype": "Period Closing Voucher",
-					"transaction_date": "2023-12-31",
-					"period_start_date": fy_2023[1],
-					"period_end_date": fy_2023[2],
-					"company": company,
-					"fiscal_year": fy_2023[0],
-					"cost_center": "_Test Cost Center - _TC",
-					"closing_account_head": closing_account,
-					"remarks": "Test Period Closing",
-				}
+			pcv = create_pcv(
+				transaction_date="2023-12-31",
+				period_start_date=fy_2023[1],
+				period_end_date=fy_2023[2],
+				company=company,
+				fiscal_year=fy_2023[0],
+				cost_center="_Test Cost Center - _TC",
+				closing_account_head=closing_account,
+				remarks="Test Period Closing",
 			)
-			pcv.insert()
-			pcv.submit()
 			pcv.reload()
 
 			# Now create a small transaction in 2024 to ensure the account appears
@@ -1934,17 +1999,9 @@ class TestFinancialQueryBuilder(FinancialReportTemplateTestCase):
 
 		finally:
 			# Clean up
-			frappe.db.set_single_value(
-				"Accounts Settings", "use_legacy_controller_for_pcv", original_pcv_setting or 0
-			)
-
 			if jv_2024:
 				jv_2024.cancel()
-
-			if pcv:
-				pcv.reload()
-				if pcv.docstatus == 1:
-					pcv.cancel()
+			cleanup_pcvs(pcv=pcv, prior_year_pcvs=prior_year_pcvs)
 
 			jv_2023.cancel()
 
@@ -2021,3 +2078,79 @@ class TestFinancialQueryBuilder(FinancialReportTemplateTestCase):
 
 		finally:
 			jv.cancel()
+
+
+def get_closing_account(company):
+	return frappe.db.get_value(
+		"Account",
+		{
+			"company": company,
+			"root_type": "Liability",
+			"is_group": 0,
+			"account_type": ["not in", ["Payable", "Receivable"]],
+		},
+		"name",
+	)
+
+
+def create_pcv(*, do_not_save=False, do_not_submit=False, **pcv_fields):
+	pcv = frappe.get_doc({"doctype": "Period Closing Voucher", **pcv_fields})
+	if not do_not_save:
+		pcv.insert()
+		if not do_not_submit:
+			pcv.submit()
+	return pcv
+
+
+def create_missing_prior_year_pcvs(company, current_fy_start_date, closing_account):
+	created_pcvs = []
+	prior_fiscal_years = []
+	previous_fy_date = add_days(current_fy_start_date, -1)
+
+	for _ in range(10):
+		previous_fy = get_fiscal_year(previous_fy_date, company=company, boolean=True)
+		if not previous_fy:
+			break
+
+		previous_fy_name, previous_fy_start, previous_fy_end = previous_fy
+		prior_fiscal_years.append((previous_fy_name, previous_fy_start, previous_fy_end))
+		previous_fy_date = add_days(previous_fy_start, -1)
+
+	for previous_fy_name, previous_fy_start, previous_fy_end in reversed(prior_fiscal_years):
+		previous_fy_closed = frappe.db.exists(
+			"Period Closing Voucher",
+			{
+				"docstatus": 1,
+				"company": company,
+				"period_end_date": ("between", [previous_fy_start, previous_fy_end]),
+			},
+		)
+		if previous_fy_closed:
+			continue
+
+		previous_fy_pcv = create_pcv(
+			transaction_date=previous_fy_end,
+			period_start_date=previous_fy_start,
+			period_end_date=previous_fy_end,
+			company=company,
+			fiscal_year=previous_fy_name,
+			cost_center="_Test Cost Center - _TC",
+			closing_account_head=closing_account,
+			remarks="Test setup prior year closing",
+		)
+		created_pcvs.append(previous_fy_pcv)
+
+	return created_pcvs
+
+
+def cleanup_pcvs(pcv=None, prior_year_pcvs=None):
+	if pcv and frappe.db.exists("Period Closing Voucher", pcv.name):
+		pcv.reload()
+		if pcv.docstatus == 1:
+			pcv.cancel()
+
+	for previous_fy_pcv in reversed(prior_year_pcvs or []):
+		if frappe.db.exists("Period Closing Voucher", previous_fy_pcv.name):
+			previous_fy_pcv.reload()
+			if previous_fy_pcv.docstatus == 1:
+				previous_fy_pcv.cancel()

--- a/erpnext/accounts/doctype/financial_report_template/test_financial_report_engine.py
+++ b/erpnext/accounts/doctype/financial_report_template/test_financial_report_engine.py
@@ -6,6 +6,7 @@ from frappe.tests.utils import change_settings
 from frappe.utils import add_days, flt
 
 from erpnext.accounts.doctype.financial_report_template.financial_report_engine import (
+	DataCollector,
 	DependencyResolver,
 	FilterExpressionParser,
 	FinancialQueryBuilder,
@@ -2078,6 +2079,84 @@ class TestFinancialQueryBuilder(FinancialReportTemplateTestCase):
 
 		finally:
 			jv.cancel()
+
+
+class TestAccumulatedValues(FinancialReportTemplateTestCase):
+	"""Test cases for post-fetch, balance-type based accumulation"""
+
+	def test_accumulate_and_set_period_values_helper_series(self):
+		"""Merged helper should return cumulative values from fetched series."""
+		from erpnext.accounts.doctype.financial_report_template.financial_report_engine import (
+			AccountData,
+		)
+
+		account_data = AccountData(account="Series Account", account_name="Series", account_number="1000")
+		input_values = [100.0, 200.0, -50.0, 0.0]
+		period_keys = ["2024_jan", "2024_feb", "2024_mar", "2024_apr"]
+
+		output_values = DataCollector._accumulate_and_set_period_values(
+			account_data, period_keys, input_values, "Period Movement (Debits - Credits)"
+		)
+
+		self.assertEqual(input_values, [100.0, 200.0, -50.0, 0.0], "Input must remain unchanged")
+		self.assertEqual(output_values, [100.0, 300.0, 250.0, 250.0], "Cumulative series mismatch")
+
+	def test_accumulate_and_set_period_values_for_movement(self):
+		"""Merged helper should sync accumulated movement to detail rows."""
+		from erpnext.accounts.doctype.financial_report_template.financial_report_engine import (
+			AccountData,
+			PeriodValue,
+		)
+
+		account_data = AccountData(account="Detail Account", account_name="Detail", account_number="1001")
+		account_data.add_period(PeriodValue("2024_jan", opening=0, closing=0, movement=100))
+		account_data.add_period(PeriodValue("2024_feb", opening=0, closing=0, movement=200))
+		account_data.add_period(PeriodValue("2024_mar", opening=0, closing=0, movement=300))
+
+		period_keys = ["2024_jan", "2024_feb", "2024_mar"]
+		accumulated = DataCollector._accumulate_and_set_period_values(
+			account_data, period_keys, [100, 200, 300], "Period Movement (Debits - Credits)"
+		)
+
+		self.assertEqual(accumulated, [100, 300, 600])
+		self.assertEqual(account_data.get_period("2024_jan").movement, 100)
+		self.assertEqual(account_data.get_period("2024_feb").movement, 300)
+		self.assertEqual(account_data.get_period("2024_mar").movement, 600)
+
+	def test_accumulate_and_set_period_values_for_opening_and_closing(self):
+		"""Merged helper should apply accumulation to opening and closing values."""
+		from erpnext.accounts.doctype.financial_report_template.financial_report_engine import (
+			AccountData,
+			PeriodValue,
+		)
+
+		period_keys = ["2024_jan", "2024_feb", "2024_mar"]
+
+		opening_data = AccountData(account="Open Account", account_name="Open", account_number="1001")
+		opening_data.add_period(PeriodValue("2024_jan", opening=10, closing=0, movement=0))
+		opening_data.add_period(PeriodValue("2024_feb", opening=20, closing=0, movement=0))
+		opening_data.add_period(PeriodValue("2024_mar", opening=30, closing=0, movement=0))
+		opening_accumulated = DataCollector._accumulate_and_set_period_values(
+			opening_data, period_keys, [10, 20, 30], "Opening Balance"
+		)
+
+		self.assertEqual(opening_accumulated, [10, 30, 60])
+		self.assertEqual(opening_data.get_period("2024_jan").opening, 10)
+		self.assertEqual(opening_data.get_period("2024_feb").opening, 30)
+		self.assertEqual(opening_data.get_period("2024_mar").opening, 60)
+
+		closing_data = AccountData(account="Close Account", account_name="Close", account_number="1002")
+		closing_data.add_period(PeriodValue("2024_jan", opening=0, closing=100, movement=0))
+		closing_data.add_period(PeriodValue("2024_feb", opening=0, closing=200, movement=0))
+		closing_data.add_period(PeriodValue("2024_mar", opening=0, closing=300, movement=0))
+		closing_accumulated = DataCollector._accumulate_and_set_period_values(
+			closing_data, period_keys, [100, 200, 300], "Closing Balance"
+		)
+
+		self.assertEqual(closing_accumulated, [100, 300, 600])
+		self.assertEqual(closing_data.get_period("2024_jan").closing, 100)
+		self.assertEqual(closing_data.get_period("2024_feb").closing, 300)
+		self.assertEqual(closing_data.get_period("2024_mar").closing, 600)
 
 
 def get_closing_account(company):


### PR DESCRIPTION
Issue: Period Movement included Period Closing Entry, due to which Accounts in Profit and Loss were showing a 0 balance.

