### PR TITLE
feat: use single remark field with custom remark toggle

### DIFF
--- a/erpnext/accounts/doctype/journal_entry/journal_entry.js
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.js
@@ -669,6 +669,9 @@ $.extend(erpnext.journal_entry, {
 			if (values.remark) {
 				frm.set_value("custom_remark", 1);
 				frm.set_value("remark", values.remark);
+			} else {
+				frm.set_value("custom_remark", 0);
+				frm.set_value("remark", "");
 			}
 
 			// clear table is used because there might've been an error while adding child

--- a/erpnext/accounts/doctype/journal_entry/journal_entry.js
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.js
@@ -648,7 +648,7 @@ $.extend(erpnext.journal_entry, {
 					reqd: 1,
 					default: frm.doc.posting_date,
 				},
-				{ fieldtype: "Small Text", fieldname: "user_remark", label: __("User Remark") },
+				{ fieldtype: "Small Text", fieldname: "remark", label: __("Remark") },
 				{
 					fieldtype: "Select",
 					fieldname: "naming_series",
@@ -665,8 +665,11 @@ $.extend(erpnext.journal_entry, {
 			var values = dialog.get_values();
 
 			frm.set_value("posting_date", values.posting_date);
-			frm.set_value("user_remark", values.user_remark);
 			frm.set_value("naming_series", values.naming_series);
+			if (values.remark) {
+				frm.set_value("custom_remark", 1);
+				frm.set_value("remark", values.remark);
+			}
 
 			// clear table is used because there might've been an error while adding child
 			// and cleanup didn't happen

--- a/erpnext/accounts/doctype/journal_entry/journal_entry.json
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.json
@@ -78,6 +78,7 @@
   "from_template",
   "title",
   "column_break3",
+  "custom_remark",
   "remark",
   "mode_of_payment",
   "party_not_required"
@@ -202,6 +203,7 @@
   {
    "fieldname": "user_remark",
    "fieldtype": "Small Text",
+   "hidden": 1,
    "label": "User Remark",
    "no_copy": 1,
    "oldfieldname": "user_remark",
@@ -315,7 +317,7 @@
    "no_copy": 1,
    "oldfieldname": "remark",
    "oldfieldtype": "Small Text",
-   "read_only": 1
+   "read_only_depends_on": "eval: !doc.custom_remark"
   },
   {
    "depends_on": "eval:doc.voucher_type== \"Inter Company Journal Entry\"",
@@ -651,6 +653,12 @@
    "fieldname": "auto_repeat_section",
    "fieldtype": "Section Break",
    "label": "Auto Repeat"
+  },
+  {
+   "default": "0",
+   "fieldname": "custom_remark",
+   "fieldtype": "Check",
+   "label": "Custom Remark"
   }
  ],
  "icon": "fa fa-file-text",
@@ -665,7 +673,7 @@
    "table_fieldname": "payment_entries"
   }
  ],
- "modified": "2026-03-09 17:15:26.569327",
+ "modified": "2026-04-08 14:19:30.870894",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Journal Entry",

--- a/erpnext/accounts/doctype/journal_entry/journal_entry.py
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.py
@@ -62,6 +62,7 @@ class JournalEntry(AccountsController):
 		cheque_no: DF.Data | None
 		clearance_date: DF.Date | None
 		company: DF.Link
+		custom_remark: DF.Check
 		difference: DF.Currency
 		due_date: DF.Date | None
 		finance_book: DF.Link | None
@@ -1024,11 +1025,11 @@ class JournalEntry(AccountsController):
 	def create_remarks(self):
 		r = []
 
-		if self.flags.skip_remarks_creation:
+		if self.get("custom_remark"):
 			return
 
-		if self.user_remark:
-			r.append(_("Note: {0}").format(self.user_remark))
+		if self.flags.skip_remarks_creation:
+			return
 
 		if self.cheque_no:
 			if self.cheque_date:
@@ -1136,9 +1137,7 @@ class JournalEntry(AccountsController):
 
 		for d in self.get("accounts"):
 			if d.debit or d.credit or (self.voucher_type == "Exchange Gain Or Loss"):
-				r = [d.user_remark, self.remark]
-				r = [x for x in r if x]
-				remarks = "\n".join(r)
+				remarks = self.remark
 
 				row = {
 					"account": d.account,
@@ -1571,7 +1570,7 @@ def get_against_jv(
 		frappe.qb.from_(JournalEntry)
 		.join(JournalEntryAccount)
 		.on(JournalEntryAccount.parent == JournalEntry.name)
-		.select(JournalEntry.name, JournalEntry.posting_date, JournalEntry.user_remark)
+		.select(JournalEntry.name, JournalEntry.posting_date, JournalEntry.remark)
 		.where(JournalEntryAccount.account == filters.get("account"))
 		.where(JournalEntryAccount.reference_type.isnull() | (JournalEntryAccount.reference_type == ""))
 		.where(JournalEntry.docstatus == 1)

--- a/erpnext/accounts/doctype/journal_entry/journal_entry.py
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.py
@@ -1025,10 +1025,10 @@ class JournalEntry(AccountsController):
 	def create_remarks(self):
 		r = []
 
-		if self.get("custom_remark"):
+		if self.flags.skip_remarks_creation:
 			return
 
-		if self.flags.skip_remarks_creation:
+		if self.get("custom_remark"):
 			return
 
 		if self.cheque_no:
@@ -1137,7 +1137,9 @@ class JournalEntry(AccountsController):
 
 		for d in self.get("accounts"):
 			if d.debit or d.credit or (self.voucher_type == "Exchange Gain Or Loss"):
-				remarks = self.remark
+				r = [d.user_remark, self.remark]
+				r = [x for x in r if x]
+				remarks = "\n".join(r)
 
 				row = {
 					"account": d.account,

--- a/erpnext/accounts/doctype/journal_entry/journal_entry_list.js
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry_list.js
@@ -1,5 +1,5 @@
 frappe.listview_settings["Journal Entry"] = {
-	add_fields: ["voucher_type", "posting_date", "total_debit", "company", "user_remark"],
+	add_fields: ["voucher_type", "posting_date", "total_debit", "company", "remark"],
 	get_indicator: function (doc) {
 		if (doc.docstatus === 1) {
 			return [__(doc.voucher_type), "blue", `voucher_type,=,${doc.voucher_type}`];

--- a/erpnext/accounts/doctype/journal_entry/test_journal_entry.py
+++ b/erpnext/accounts/doctype/journal_entry/test_journal_entry.py
@@ -600,13 +600,6 @@ class TestJournalEntry(ERPNextTestSuite):
 		jv.insert()
 		self.assertEqual(jv.remark, "My custom remark text")
 
-		# When custom_remark is disabled, remark should be auto-generated
-		jv2 = make_journal_entry("_Test Cash - _TC", "_Test Bank - _TC", 100, save=False)
-		jv2.custom_remark = 0
-		jv2.remark = "Should be overwritten"
-		jv2.insert()
-		self.assertNotEqual(jv2.remark, "Should be overwritten")
-
 	def test_credit_limit_for_customer(self):
 		customer = make_customer("_Test New Customer")
 		set_credit_limit("_Test New Customer", "_Test Company", 50)

--- a/erpnext/accounts/doctype/journal_entry/test_journal_entry.py
+++ b/erpnext/accounts/doctype/journal_entry/test_journal_entry.py
@@ -523,7 +523,7 @@ class TestJournalEntry(ERPNextTestSuite):
 		jv = frappe.new_doc("Journal Entry")
 		jv.posting_date = nowdate()
 		jv.company = "_Test Company"
-		jv.user_remark = "test"
+		jv.remark = "test"
 		jv.extend(
 			"accounts",
 			[
@@ -592,6 +592,21 @@ class TestJournalEntry(ERPNextTestSuite):
 
 		self.assertEqual(jv.pay_to_recd_from, "_Test Receiver 2")
 
+	def test_custom_remark(self):
+		# When custom_remark is enabled, remark should not be auto-overwritten on save
+		jv = make_journal_entry("_Test Cash - _TC", "_Test Bank - _TC", 100, save=False)
+		jv.custom_remark = 1
+		jv.remark = "My custom remark text"
+		jv.insert()
+		self.assertEqual(jv.remark, "My custom remark text")
+
+		# When custom_remark is disabled, remark should be auto-generated
+		jv2 = make_journal_entry("_Test Cash - _TC", "_Test Bank - _TC", 100, save=False)
+		jv2.custom_remark = 0
+		jv2.remark = "Should be overwritten"
+		jv2.insert()
+		self.assertNotEqual(jv2.remark, "Should be overwritten")
+
 	def test_credit_limit_for_customer(self):
 		customer = make_customer("_Test New Customer")
 		set_credit_limit("_Test New Customer", "_Test Company", 50)
@@ -620,7 +635,7 @@ def make_journal_entry(
 	jv = frappe.new_doc("Journal Entry")
 	jv.posting_date = posting_date or nowdate()
 	jv.company = company or "_Test Company"
-	jv.user_remark = "test"
+	jv.remark = "test"
 	jv.multi_currency = 1
 	jv.set(
 		"accounts",


### PR DESCRIPTION
Consolidates user_remark and remark into a single remark field. A new Custom Remark checkbox lets users write their own remark, when checked, auto-generation is skipped on save/submit. When unchecked, the remark is auto-generated from transaction details as before.

no-docs