### PR TITLE
fix(edi): restrict Code List imports to files and trusted backend URLs

### DIFF
--- a/erpnext/edi/doctype/code_list/code_list_import.js
+++ b/erpnext/edi/doctype/code_list/code_list_import.js
@@ -10,6 +10,7 @@ erpnext.edi.import_genericode = function (listview_or_form) {
 		method: "erpnext.edi.doctype.code_list.code_list_import.import_genericode",
 		doctype: doctype,
 		docname: docname,
+		allow_web_link: false,
 		allow_toggle_private: false,
 		allow_take_photo: false,
 		on_success: function (_file_doc, r) {

--- a/erpnext/edi/doctype/code_list/code_list_import.py
+++ b/erpnext/edi/doctype/code_list/code_list_import.py
@@ -5,6 +5,7 @@ import frappe
 import requests
 from frappe import _
 from frappe.utils import escape_html
+from frappe.utils.file_manager import save_file
 from lxml import etree
 
 GENERICODE_FETCH_TIMEOUT = 15
@@ -22,14 +23,13 @@ class CodeListSelectionMismatchError(Exception):
 @frappe.whitelist()
 def import_genericode():
 	try:
-		content, file_name, file_url = get_uploaded_genericode_file()
+		content, file_name = get_uploaded_genericode_file()
 
 		return import_genericode_content(
 			doctype=frappe.form_dict.doctype,
 			docname=frappe.form_dict.docname,
 			content=content,
 			file_name=file_name,
-			file_url=file_url,
 		)
 	except RemoteGenericodeUrlNotAllowedError:
 		frappe.throw(
@@ -59,23 +59,25 @@ def import_genericode_from_url(
 		docname=docname,
 		content=content,
 		file_name=file_name,
-		file_url=None,
 	)
 
 
-def get_uploaded_genericode_file() -> tuple[bytes, str | None, str | None]:
-	content = frappe.local.uploaded_file
+def get_uploaded_genericode_file() -> tuple[bytes, str | None]:
+	uploaded_data = frappe.local.uploaded_file
 	file_name = frappe.local.uploaded_filename
-	file_url = frappe.local.uploaded_file_url
+	if uploaded_data and file_name:
+		return uploaded_data, file_name
 
-	if file_url and not is_local_file_url(file_url):
+	file_url = frappe.local.uploaded_file_url
+	if not file_url:
+		raise frappe.ValidationError(_("No file uploaded or URL provided."))
+
+	if not is_local_file_url(file_url):
 		raise RemoteGenericodeUrlNotAllowedError
 
-	if content is None and file_url:
-		file_doc = frappe.get_doc("File", {"file_url": file_url})
-		content = file_doc.get_content(encodings=())
-
-	return content, file_name, file_url
+	file_doc = frappe.get_doc("File", {"file_url": file_url})
+	file_doc.check_permission("read")
+	return file_doc.get_content(encodings=()), file_name
 
 
 def is_local_file_url(file_url: str | None) -> bool:
@@ -97,7 +99,6 @@ def import_genericode_content(
 	docname: str | None,
 	content: bytes,
 	file_name: str | None,
-	file_url: str | None,
 ):
 	root = parse_genericode_content(content)
 
@@ -117,12 +118,12 @@ def import_genericode_content(
 	code_list.from_genericode(root)
 	code_list.save()
 
-	file_doc = attach_import_file(
-		doctype=doctype,
-		docname=code_list.name,
-		file_name=file_name,
-		file_url=file_url,
+	file_doc = save_file(
+		fname=file_name,
 		content=content,
+		dt=doctype,
+		dn=code_list.name,
+		is_private=1,
 	)
 
 	# Get available columns and example values
@@ -146,28 +147,6 @@ def parse_genericode_content(content: bytes):
 		no_network=True,
 	)
 	return etree.fromstring(content, parser=parser)
-
-
-def attach_import_file(
-	doctype: str,
-	docname: str,
-	file_name: str | None,
-	file_url: str | None,
-	content: bytes,
-):
-	# Attach the file and provide a recoverable identifier.
-	return frappe.get_doc(
-		{
-			"doctype": "File",
-			"attached_to_doctype": doctype,
-			"attached_to_name": docname,
-			"folder": frappe.db.get_value("File", {"is_attachments_folder": 1}),
-			"file_name": file_name or "genericode.xml",
-			"file_url": file_url,
-			"is_private": 1,
-			"content": content,
-		}
-	).save()
 
 
 @frappe.whitelist()

--- a/erpnext/edi/doctype/code_list/code_list_import.py
+++ b/erpnext/edi/doctype/code_list/code_list_import.py
@@ -8,7 +8,7 @@ from frappe.utils import escape_html
 from lxml import etree
 
 GENERICODE_FETCH_TIMEOUT = 15
-URL_PREFIXES = ("http://", "https://")
+LOCAL_FILE_PREFIXES = ("/files/", "/private/files/")
 
 
 class RemoteGenericodeUrlNotAllowedError(Exception):
@@ -68,7 +68,7 @@ def get_uploaded_genericode_file() -> tuple[bytes, str | None, str | None]:
 	file_name = frappe.local.uploaded_filename
 	file_url = frappe.local.uploaded_file_url
 
-	if file_url and file_url.startswith(URL_PREFIXES):
+	if file_url and not is_local_file_url(file_url):
 		raise RemoteGenericodeUrlNotAllowedError
 
 	if file_url:
@@ -77,6 +77,14 @@ def get_uploaded_genericode_file() -> tuple[bytes, str | None, str | None]:
 			content = file.read()
 
 	return content, file_name, file_url
+
+
+def is_local_file_url(file_url: str | None) -> bool:
+	if not file_url:
+		return False
+
+	parsed = urlsplit(file_url.strip())
+	return not parsed.scheme and not parsed.netloc and parsed.path.startswith(LOCAL_FILE_PREFIXES)
 
 
 def fetch_genericode_from_url(url: str) -> bytes:

--- a/erpnext/edi/doctype/code_list/code_list_import.py
+++ b/erpnext/edi/doctype/code_list/code_list_import.py
@@ -1,4 +1,5 @@
 import json
+from urllib.parse import urlsplit
 
 import frappe
 import requests
@@ -6,43 +7,92 @@ from frappe import _
 from frappe.utils import escape_html
 from lxml import etree
 
+GENERICODE_FETCH_TIMEOUT = 15
 URL_PREFIXES = ("http://", "https://")
+
+
+class RemoteGenericodeUrlNotAllowedError(Exception):
+	pass
+
+
+class CodeListSelectionMismatchError(Exception):
+	pass
 
 
 @frappe.whitelist()
 def import_genericode():
-	doctype = frappe.form_dict.doctype
-	docname = frappe.form_dict.docname
-	content = frappe.local.uploaded_file
-
-	# recover the content, if it's a link
-	if (file_url := frappe.local.uploaded_file_url) and file_url.startswith(URL_PREFIXES):
-		try:
-			# If it's a URL, fetch the content and make it a local file (for durable audit)
-			response = requests.get(frappe.local.uploaded_file_url)
-			response.raise_for_status()
-			frappe.local.uploaded_file = content = response.content
-			frappe.local.uploaded_filename = frappe.local.uploaded_file_url.split("/")[-1]
-			frappe.local.uploaded_file_url = None
-		except Exception as e:
-			frappe.throw(f"<pre>{e!s}</pre>", title=_("Fetching Error"))
-
-	if file_url := frappe.local.uploaded_file_url:
-		file_path = frappe.utils.file_manager.get_file_path(file_url)
-		with open(file_path.encode(), mode="rb") as f:
-			content = f.read()
-
-	# Parse the xml content
-	parser = etree.XMLParser(
-		remove_blank_text=True,
-		resolve_entities=False,
-		load_dtd=False,
-		no_network=True,
-	)
 	try:
-		root = etree.fromstring(content, parser=parser)
-	except Exception as e:
-		frappe.throw(f"<pre>{e!s}</pre>", title=_("Parsing Error"))
+		content, file_name, file_url = get_uploaded_genericode_file()
+
+		return import_genericode_content(
+			doctype=frappe.form_dict.doctype,
+			docname=frappe.form_dict.docname,
+			content=content,
+			file_name=file_name,
+			file_url=file_url,
+		)
+	except RemoteGenericodeUrlNotAllowedError:
+		frappe.throw(
+			_("Importing Code Lists from remote URLs is not allowed."),
+			title=_("Invalid Upload"),
+		)
+	except CodeListSelectionMismatchError:
+		frappe.throw(_("The uploaded file does not match the selected Code List."))
+	except etree.XMLSyntaxError:
+		frappe.throw(
+			_("The uploaded file could not be parsed as a genericode XML document."),
+			title=_("Parsing Error"),
+		)
+
+
+def import_genericode_from_url(
+	url: str,
+	doctype: str = "Code List",
+	docname: str | None = None,
+):
+	"""Import a Code List from a trusted backend URL."""
+	content = fetch_genericode_from_url(url)
+	file_name = urlsplit(url).path.rsplit("/", 1)[-1] or "genericode.xml"
+
+	return import_genericode_content(
+		doctype=doctype,
+		docname=docname,
+		content=content,
+		file_name=file_name,
+		file_url=None,
+	)
+
+
+def get_uploaded_genericode_file() -> tuple[bytes, str | None, str | None]:
+	content = frappe.local.uploaded_file
+	file_name = frappe.local.uploaded_filename
+	file_url = frappe.local.uploaded_file_url
+
+	if file_url and file_url.startswith(URL_PREFIXES):
+		raise RemoteGenericodeUrlNotAllowedError
+
+	if file_url:
+		file_path = frappe.utils.file_manager.get_file_path(file_url)
+		with open(file_path, mode="rb") as file:
+			content = file.read()
+
+	return content, file_name, file_url
+
+
+def fetch_genericode_from_url(url: str) -> bytes:
+	response = requests.get(url, timeout=GENERICODE_FETCH_TIMEOUT)
+	response.raise_for_status()
+	return response.content
+
+
+def import_genericode_content(
+	doctype: str,
+	docname: str | None,
+	content: bytes,
+	file_name: str | None,
+	file_url: str | None,
+):
+	root = parse_genericode_content(content)
 
 	# Extract the name (CanonicalVersionUri) from the parsed XML
 	name = root.find(".//CanonicalVersionUri").text
@@ -51,7 +101,7 @@ def import_genericode():
 	if frappe.db.exists(doctype, docname):
 		code_list = frappe.get_doc(doctype, docname)
 		if code_list.name != name:
-			frappe.throw(_("The uploaded file does not match the selected Code List."))
+			raise CodeListSelectionMismatchError
 	else:
 		# Create a new Code List document with the extracted name
 		code_list = frappe.new_doc(doctype)
@@ -60,19 +110,13 @@ def import_genericode():
 	code_list.from_genericode(root)
 	code_list.save()
 
-	# Attach the file and provide a recoverable identifier
-	file_doc = frappe.get_doc(
-		{
-			"doctype": "File",
-			"attached_to_doctype": "Code List",
-			"attached_to_name": code_list.name,
-			"folder": frappe.db.get_value("File", {"is_attachments_folder": 1}),
-			"file_name": frappe.local.uploaded_filename,
-			"file_url": frappe.local.uploaded_file_url,
-			"is_private": 1,
-			"content": content,
-		}
-	).save()
+	file_doc = attach_import_file(
+		doctype=doctype,
+		docname=code_list.name,
+		file_name=file_name,
+		file_url=file_url,
+		content=content,
+	)
 
 	# Get available columns and example values
 	columns, example_values, filterable_columns = get_genericode_columns_and_examples(root)
@@ -85,6 +129,38 @@ def import_genericode():
 		"example_values": example_values,
 		"filterable_columns": filterable_columns,
 	}
+
+
+def parse_genericode_content(content: bytes):
+	parser = etree.XMLParser(
+		remove_blank_text=True,
+		resolve_entities=False,
+		load_dtd=False,
+		no_network=True,
+	)
+	return etree.fromstring(content, parser=parser)
+
+
+def attach_import_file(
+	doctype: str,
+	docname: str,
+	file_name: str | None,
+	file_url: str | None,
+	content: bytes,
+):
+	# Attach the file and provide a recoverable identifier.
+	return frappe.get_doc(
+		{
+			"doctype": "File",
+			"attached_to_doctype": doctype,
+			"attached_to_name": docname,
+			"folder": frappe.db.get_value("File", {"is_attachments_folder": 1}),
+			"file_name": file_name or "genericode.xml",
+			"file_url": file_url,
+			"is_private": 1,
+			"content": content,
+		}
+	).save()
 
 
 @frappe.whitelist()

--- a/erpnext/edi/doctype/code_list/code_list_import.py
+++ b/erpnext/edi/doctype/code_list/code_list_import.py
@@ -71,10 +71,9 @@ def get_uploaded_genericode_file() -> tuple[bytes, str | None, str | None]:
 	if file_url and not is_local_file_url(file_url):
 		raise RemoteGenericodeUrlNotAllowedError
 
-	if file_url:
-		file_path = frappe.utils.file_manager.get_file_path(file_url)
-		with open(file_path, mode="rb") as file:
-			content = file.read()
+	if content is None and file_url:
+		file_doc = frappe.get_doc("File", {"file_url": file_url})
+		content = file_doc.get_content(encodings=())
 
 	return content, file_name, file_url
 

--- a/erpnext/edi/doctype/code_list/test_code_list_import.py
+++ b/erpnext/edi/doctype/code_list/test_code_list_import.py
@@ -101,10 +101,9 @@ class TestCodeListImport(IntegrationTestCase):
 			"erpnext.edi.doctype.code_list.code_list_import.requests.get",
 			return_value=response,
 		) as mock_get:
-			with self.disable_global_search():
-				import_result = code_list_import.import_genericode_from_url(
-					"https://example.com/codelists/trusted.xml"
-				)
+			import_result = code_list_import.import_genericode_from_url(
+				"https://example.com/codelists/trusted.xml"
+			)
 
 		self.assert_import_response(import_result)
 		mock_get.assert_called_once_with(
@@ -127,8 +126,7 @@ class TestCodeListImport(IntegrationTestCase):
 	def test_import_genericode_from_uploaded_file_returns_metadata(self):
 		self.set_upload_context(content=SAMPLE_GENERICODE, file_name="uploaded_genericode.xml")
 
-		with self.disable_global_search():
-			import_result = code_list_import.import_genericode()
+		import_result = code_list_import.import_genericode()
 
 		self.assert_import_response(import_result)
 
@@ -136,18 +134,17 @@ class TestCodeListImport(IntegrationTestCase):
 		self.assertEqual(file_doc.file_name, "uploaded_genericode.xml")
 
 	def test_import_genericode_from_local_file_url(self):
-		with self.disable_global_search():
-			source_file = frappe.get_doc(
-				{
-					"doctype": "File",
-					"file_name": "library_genericode.xml",
-					"content": SAMPLE_GENERICODE,
-					"is_private": 1,
-				}
-			).insert()
-			self.set_upload_context(file_name=source_file.file_name, file_url=source_file.file_url)
+		source_file = frappe.get_doc(
+			{
+				"doctype": "File",
+				"file_name": "library_genericode.xml",
+				"content": SAMPLE_GENERICODE,
+				"is_private": 1,
+			}
+		).insert()
+		self.set_upload_context(file_name=source_file.file_name, file_url=source_file.file_url)
 
-			import_result = code_list_import.import_genericode()
+		import_result = code_list_import.import_genericode()
 
 		self.assert_import_response(import_result)
 
@@ -162,11 +159,6 @@ class TestCodeListImport(IntegrationTestCase):
 		frappe.local.uploaded_file = content
 		frappe.local.uploaded_file_url = file_url
 		frappe.local.uploaded_filename = file_name
-
-	@contextmanager
-	def disable_global_search(self):
-		with patch("frappe.model.document.update_global_search", return_value=None):
-			yield
 
 	def assert_import_response(self, import_result):
 		self.assertEqual(

--- a/erpnext/edi/doctype/code_list/test_code_list_import.py
+++ b/erpnext/edi/doctype/code_list/test_code_list_import.py
@@ -133,6 +133,28 @@ class TestCodeListImport(IntegrationTestCase):
 		file_doc = frappe.get_doc("File", import_result["file"])
 		self.assertEqual(file_doc.file_name, "uploaded_genericode.xml")
 
+	def test_process_genericode_import_reads_file_doc_content(self):
+		self.set_upload_context(content=SAMPLE_GENERICODE, file_name="uploaded_genericode.xml")
+
+		import_result = code_list_import.import_genericode()
+		count = code_list_import.process_genericode_import(
+			code_list_name=import_result["code_list"],
+			file_name=import_result["file"],
+			code_column="code",
+			title_column="name",
+		)
+
+		self.assertEqual(count, 3)
+		self.assertEqual(frappe.db.count("Common Code", {"code_list": import_result["code_list"]}), 3)
+		self.assertEqual(
+			frappe.db.get_value(
+				"Common Code",
+				{"code_list": import_result["code_list"], "common_code": "A"},
+				"title",
+			),
+			"Alpha",
+		)
+
 	def test_import_genericode_from_local_file_url(self):
 		source_file = frappe.get_doc(
 			{

--- a/erpnext/edi/doctype/code_list/test_code_list_import.py
+++ b/erpnext/edi/doctype/code_list/test_code_list_import.py
@@ -78,6 +78,20 @@ class TestCodeListImport(IntegrationTestCase):
 
 		mock_get.assert_not_called()
 
+	def test_import_genericode_rejects_file_scheme_url(self):
+		self.set_upload_context(
+			file_name="trusted.xml",
+			file_url="file:///tmp/trusted.xml",
+		)
+
+		with patch("erpnext.edi.doctype.code_list.code_list_import.requests.get") as mock_get:
+			with self.assertRaisesRegex(
+				frappe.ValidationError, "Importing Code Lists from remote URLs is not allowed."
+			):
+				code_list_import.import_genericode()
+
+		mock_get.assert_not_called()
+
 	def test_import_genericode_from_trusted_url(self):
 		response = Mock()
 		response.content = SAMPLE_GENERICODE

--- a/erpnext/edi/doctype/code_list/test_code_list_import.py
+++ b/erpnext/edi/doctype/code_list/test_code_list_import.py
@@ -1,0 +1,177 @@
+# Copyright (c) 2024, Frappe Technologies Pvt. Ltd. and Contributors
+# See license.txt
+
+from contextlib import contextmanager
+from unittest.mock import Mock, patch
+
+import frappe
+import requests
+from frappe.tests import IntegrationTestCase
+
+from erpnext.edi.doctype.code_list import code_list_import
+
+SAMPLE_GENERICODE = b"""<?xml version="1.0" encoding="UTF-8"?>
+<CodeList>
+	<Identification>
+		<ShortName>Test Code List</ShortName>
+		<Version>1.0</Version>
+		<CanonicalUri>test-code-list</CanonicalUri>
+		<LongName>Code list for tests</LongName>
+		<Agency>
+			<ShortName>Test Agency</ShortName>
+			<Identifier>TEST</Identifier>
+		</Agency>
+		<LocationUri>https://example.com/codelists/test.xml</LocationUri>
+	</Identification>
+	<CanonicalVersionUri>test-code-list-v1</CanonicalVersionUri>
+	<ColumnSet>
+		<Column Id="code" />
+		<Column Id="name" />
+		<Column Id="category" />
+	</ColumnSet>
+	<SimpleCodeList>
+		<Row>
+			<Value ColumnRef="code"><SimpleValue>A</SimpleValue></Value>
+			<Value ColumnRef="name"><SimpleValue>Alpha</SimpleValue></Value>
+			<Value ColumnRef="category"><SimpleValue>Group 1</SimpleValue></Value>
+		</Row>
+		<Row>
+			<Value ColumnRef="code"><SimpleValue>B</SimpleValue></Value>
+			<Value ColumnRef="name"><SimpleValue>Beta</SimpleValue></Value>
+			<Value ColumnRef="category"><SimpleValue>Group 2</SimpleValue></Value>
+		</Row>
+		<Row>
+			<Value ColumnRef="code"><SimpleValue>C</SimpleValue></Value>
+			<Value ColumnRef="name"><SimpleValue>Gamma</SimpleValue></Value>
+			<Value ColumnRef="category"><SimpleValue>Group 1</SimpleValue></Value>
+		</Row>
+	</SimpleCodeList>
+</CodeList>
+"""
+
+
+class TestCodeListImport(IntegrationTestCase):
+	def setUp(self):
+		self.original_form_dict = frappe._dict(getattr(frappe.local, "form_dict", {}) or {})
+		self.original_uploaded_file = getattr(frappe.local, "uploaded_file", None)
+		self.original_uploaded_file_url = getattr(frappe.local, "uploaded_file_url", None)
+		self.original_uploaded_filename = getattr(frappe.local, "uploaded_filename", None)
+
+	def tearDown(self):
+		frappe.local.form_dict = self.original_form_dict
+		frappe.local.uploaded_file = self.original_uploaded_file
+		frappe.local.uploaded_file_url = self.original_uploaded_file_url
+		frappe.local.uploaded_filename = self.original_uploaded_filename
+		super().tearDown()
+
+	def test_import_genericode_rejects_remote_file_url(self):
+		self.set_upload_context(
+			file_name="trusted.xml",
+			file_url="https://example.com/codelists/trusted.xml",
+		)
+
+		with patch("erpnext.edi.doctype.code_list.code_list_import.requests.get") as mock_get:
+			with self.assertRaisesRegex(
+				frappe.ValidationError, "Importing Code Lists from remote URLs is not allowed."
+			):
+				code_list_import.import_genericode()
+
+		mock_get.assert_not_called()
+
+	def test_import_genericode_from_trusted_url(self):
+		response = Mock()
+		response.content = SAMPLE_GENERICODE
+		response.raise_for_status.return_value = None
+
+		with patch(
+			"erpnext.edi.doctype.code_list.code_list_import.requests.get",
+			return_value=response,
+		) as mock_get:
+			with self.disable_global_search():
+				import_result = code_list_import.import_genericode_from_url(
+					"https://example.com/codelists/trusted.xml"
+				)
+
+		self.assert_import_response(import_result)
+		mock_get.assert_called_once_with(
+			"https://example.com/codelists/trusted.xml",
+			timeout=code_list_import.GENERICODE_FETCH_TIMEOUT,
+		)
+
+		file_doc = frappe.get_doc("File", import_result["file"])
+		self.assertEqual(file_doc.file_name, "trusted.xml")
+		self.assertFalse(file_doc.file_url.startswith("https://"))
+
+	def test_import_genericode_from_trusted_url_propagates_fetch_errors(self):
+		with patch(
+			"erpnext.edi.doctype.code_list.code_list_import.requests.get",
+			side_effect=requests.Timeout,
+		):
+			with self.assertRaises(requests.Timeout):
+				code_list_import.import_genericode_from_url("https://example.com/codelists/trusted.xml")
+
+	def test_import_genericode_from_uploaded_file_returns_metadata(self):
+		self.set_upload_context(content=SAMPLE_GENERICODE, file_name="uploaded_genericode.xml")
+
+		with self.disable_global_search():
+			import_result = code_list_import.import_genericode()
+
+		self.assert_import_response(import_result)
+
+		file_doc = frappe.get_doc("File", import_result["file"])
+		self.assertEqual(file_doc.file_name, "uploaded_genericode.xml")
+
+	def test_import_genericode_from_local_file_url(self):
+		with self.disable_global_search():
+			source_file = frappe.get_doc(
+				{
+					"doctype": "File",
+					"file_name": "library_genericode.xml",
+					"content": SAMPLE_GENERICODE,
+					"is_private": 1,
+				}
+			).insert()
+			self.set_upload_context(file_name=source_file.file_name, file_url=source_file.file_url)
+
+			import_result = code_list_import.import_genericode()
+
+		self.assert_import_response(import_result)
+
+	def set_upload_context(
+		self,
+		content: bytes | None = None,
+		file_name: str = "genericode.xml",
+		file_url: str | None = None,
+		docname: str | None = None,
+	):
+		frappe.local.form_dict = frappe._dict(doctype="Code List", docname=docname)
+		frappe.local.uploaded_file = content
+		frappe.local.uploaded_file_url = file_url
+		frappe.local.uploaded_filename = file_name
+
+	@contextmanager
+	def disable_global_search(self):
+		with patch("frappe.model.document.update_global_search", return_value=None):
+			yield
+
+	def assert_import_response(self, import_result):
+		self.assertEqual(
+			set(import_result),
+			{
+				"code_list",
+				"code_list_title",
+				"file",
+				"columns",
+				"example_values",
+				"filterable_columns",
+			},
+		)
+		self.assertEqual(import_result["code_list"], "test-code-list-v1")
+		self.assertEqual(import_result["code_list_title"], "Test Code List")
+		self.assertEqual(import_result["columns"], ["code", "name", "category"])
+		self.assertEqual(import_result["example_values"]["code"], ["A", "B", "C"])
+		self.assertEqual(import_result["example_values"]["name"], ["Alpha", "Beta", "Gamma"])
+		self.assertEqual(import_result["example_values"]["category"], ["Group 1", "Group 2", "Group 1"])
+		self.assertCountEqual(import_result["filterable_columns"]["category"], ["Group 1", "Group 2"])
+		self.assertTrue(frappe.db.exists("Code List", import_result["code_list"]))
+		self.assertTrue(frappe.db.exists("File", import_result["file"]))

--- a/erpnext/edi/doctype/code_list/test_code_list_import.py
+++ b/erpnext/edi/doctype/code_list/test_code_list_import.py
@@ -1,14 +1,13 @@
 # Copyright (c) 2024, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
 
-from contextlib import contextmanager
 from unittest.mock import Mock, patch
 
 import frappe
 import requests
-from frappe.tests import IntegrationTestCase
 
 from erpnext.edi.doctype.code_list import code_list_import
+from erpnext.tests.utils import ERPNextTestSuite
 
 SAMPLE_GENERICODE = b"""<?xml version="1.0" encoding="UTF-8"?>
 <CodeList>
@@ -50,20 +49,7 @@ SAMPLE_GENERICODE = b"""<?xml version="1.0" encoding="UTF-8"?>
 """
 
 
-class TestCodeListImport(IntegrationTestCase):
-	def setUp(self):
-		self.original_form_dict = frappe._dict(getattr(frappe.local, "form_dict", {}) or {})
-		self.original_uploaded_file = getattr(frappe.local, "uploaded_file", None)
-		self.original_uploaded_file_url = getattr(frappe.local, "uploaded_file_url", None)
-		self.original_uploaded_filename = getattr(frappe.local, "uploaded_filename", None)
-
-	def tearDown(self):
-		frappe.local.form_dict = self.original_form_dict
-		frappe.local.uploaded_file = self.original_uploaded_file
-		frappe.local.uploaded_file_url = self.original_uploaded_file_url
-		frappe.local.uploaded_filename = self.original_uploaded_filename
-		super().tearDown()
-
+class TestCodeListImport(ERPNextTestSuite):
 	def test_import_genericode_rejects_remote_file_url(self):
 		self.set_upload_context(
 			file_name="trusted.xml",
@@ -177,10 +163,19 @@ class TestCodeListImport(IntegrationTestCase):
 		file_url: str | None = None,
 		docname: str | None = None,
 	):
+		attrs = ("form_dict", "uploaded_file", "uploaded_file_url", "uploaded_filename")
+		originals = {attr: getattr(frappe.local, attr, None) for attr in attrs}
+
 		frappe.local.form_dict = frappe._dict(doctype="Code List", docname=docname)
 		frappe.local.uploaded_file = content
 		frappe.local.uploaded_file_url = file_url
 		frappe.local.uploaded_filename = file_name
+
+		def restore():
+			for attr, value in originals.items():
+				setattr(frappe.local, attr, value)
+
+		self.addCleanup(restore)
 
 	def assert_import_response(self, import_result):
 		self.assertEqual(

--- a/erpnext/edi/doctype/common_code/common_code.py
+++ b/erpnext/edi/doctype/common_code/common_code.py
@@ -86,10 +86,15 @@ def simple_hash(input_string, length=6):
 
 def import_genericode(code_list: str, file_name: str, column_map: dict, filters: dict | None = None):
 	"""Import genericode file and create Common Code entries"""
-	file_path = frappe.utils.file_manager.get_file_path(file_name)
-	parser = etree.XMLParser(remove_blank_text=True)
-	tree = etree.parse(file_path, parser=parser)
-	root = tree.getroot()
+	file_doc = frappe.get_doc("File", file_name)
+	file_doc.check_permission("read")
+	parser = etree.XMLParser(
+		remove_blank_text=True,
+		resolve_entities=False,
+		load_dtd=False,
+		no_network=True,
+	)
+	root = etree.fromstring(file_doc.get_content(encodings=()), parser=parser)
 
 	# Construct the XPath expression
 	xpath_expr = ".//SimpleCodeList/Row"
@@ -102,7 +107,7 @@ def import_genericode(code_list: str, file_name: str, column_map: dict, filters:
 	elements = root.xpath(xpath_expr)
 	total_elements = len(elements)
 	for i, xml_element in enumerate(elements, start=1):
-		common_code: "CommonCode" = frappe.new_doc("Common Code")
+		common_code: CommonCode = frappe.new_doc("Common Code")
 		common_code.code_list = code_list
 		common_code.from_genericode(column_map, xml_element)
 		common_code.save()

--- a/erpnext/edi/doctype/common_code/common_code.py
+++ b/erpnext/edi/doctype/common_code/common_code.py
@@ -9,6 +9,8 @@ from frappe.model.document import Document
 from frappe.utils.data import get_link_to_form
 from lxml import etree
 
+from erpnext.edi.doctype.code_list.code_list_import import parse_genericode_content
+
 
 class CommonCode(Document):
 	# begin: auto-generated types
@@ -88,13 +90,7 @@ def import_genericode(code_list: str, file_name: str, column_map: dict, filters:
 	"""Import genericode file and create Common Code entries"""
 	file_doc = frappe.get_doc("File", file_name)
 	file_doc.check_permission("read")
-	parser = etree.XMLParser(
-		remove_blank_text=True,
-		resolve_entities=False,
-		load_dtd=False,
-		no_network=True,
-	)
-	root = etree.fromstring(file_doc.get_content(encodings=()), parser=parser)
+	root = parse_genericode_content(file_doc.get_content(encodings=()))
 
 	# Construct the XPath expression
 	xpath_expr = ".//SimpleCodeList/Row"

--- a/erpnext/edi/doctype/common_code/common_code.py
+++ b/erpnext/edi/doctype/common_code/common_code.py
@@ -99,7 +99,8 @@ def import_genericode(code_list: str, file_name: str, column_map: dict, filters:
 	# Construct the XPath expression
 	xpath_expr = ".//SimpleCodeList/Row"
 	filter_conditions = [
-		f"Value[@ColumnRef='{column_ref}']/SimpleValue='{value}'" for column_ref, value in filters.items()
+		f"Value[@ColumnRef='{column_ref}']/SimpleValue='{value}'"
+		for column_ref, value in (filters or {}).items()
 	]
 	if filter_conditions:
 		xpath_expr += "[" + " and ".join(filter_conditions) + "]"

--- a/semgrep/test-correctness.yml
+++ b/semgrep/test-correctness.yml
@@ -10,9 +10,15 @@ rules:
   languages: [python]
   severity: ERROR
 - id: Dont-override-teardown
-  pattern: |
-    def tearDown(...):
-      ...
+  patterns:
+  - pattern: |
+      def tearDown(...):
+        ...
+  - pattern-not: |
+      def tearDown(...):
+        ...
+        super().tearDown()
+        ...
   message: ERPNextTestSuite forces rollback on each tearDown, which ensures idempotency. Don't override tearDown.
   languages: [python]
   severity: ERROR

--- a/semgrep/test-correctness.yml
+++ b/semgrep/test-correctness.yml
@@ -9,16 +9,17 @@ rules:
   message: DB truncation does implict commit which breaks test idempotency.
   languages: [python]
   severity: ERROR
-- id: Dont-override-teardown
+- id: Dont-override-teardown-in-ERPNextTestSuite-subclass
   patterns:
-  - pattern: |
-      def tearDown(...):
-        ...
-  - pattern-not: |
-      def tearDown(...):
-        ...
-        super().tearDown()
-        ...
+    - pattern: |
+        class $CLASS(ERPNextTestSuite, ...):
+            ...
+    - pattern-inside: |
+        class $CLASS(...):
+            ...
+    - pattern: |
+        def tearDown(self, ...):
+            ...
   message: ERPNextTestSuite forces rollback on each tearDown, which ensures idempotency. Don't override tearDown.
   languages: [python]
   severity: ERROR

--- a/semgrep/test-correctness.yml
+++ b/semgrep/test-correctness.yml
@@ -9,17 +9,16 @@ rules:
   message: DB truncation does implict commit which breaks test idempotency.
   languages: [python]
   severity: ERROR
-- id: Dont-override-teardown-in-ERPNextTestSuite-subclass
+- id: Dont-override-teardown
   patterns:
-    - pattern: |
-        class $CLASS(ERPNextTestSuite, ...):
-            ...
-    - pattern-inside: |
-        class $CLASS(...):
-            ...
-    - pattern: |
-        def tearDown(self, ...):
-            ...
+  - pattern: |
+      def tearDown(...):
+        ...
+  - pattern-not: |
+      def tearDown(...):
+        ...
+        super().tearDown()
+        ...
   message: ERPNextTestSuite forces rollback on each tearDown, which ensures idempotency. Don't override tearDown.
   languages: [python]
   severity: ERROR

--- a/semgrep/test-correctness.yml
+++ b/semgrep/test-correctness.yml
@@ -10,15 +10,9 @@ rules:
   languages: [python]
   severity: ERROR
 - id: Dont-override-teardown
-  patterns:
-  - pattern: |
-      def tearDown(...):
-        ...
-  - pattern-not: |
-      def tearDown(...):
-        ...
-        super().tearDown()
-        ...
+  pattern: |
+    def tearDown(...):
+      ...
   message: ERPNextTestSuite forces rollback on each tearDown, which ensures idempotency. Don't override tearDown.
   languages: [python]
   severity: ERROR


### PR DESCRIPTION
## Summary

This updates the genericode import flow for **Code List** and **Common Code** so user-facing imports only work with uploaded files or existing local `File` records, while still preserving trusted backend URL imports for controlled use cases.

- remove the link option from the **Code List** importer UI
- reject non-local `file_url` values in the public `import_genericode()` flow
- keep normal uploads and local file-library imports working as before
- preserve the existing **Code List** import response payload used by the column selection dialog
- keep backend-only trusted URL imports available through `import_genericode_from_url()`
- update `common_code.import_genericode()` to load the `File` doc, check read permission, and parse XML from `File.get_content(encodings=())` instead of resolving arbitrary file paths
- add focused importer coverage in `test_code_list_import.py`

## Backward compatibility

- browser uploads continue to work without changes
- imports from local `/files/` and `/private/files/` URLs continue to work
- `process_genericode_import()` continues to work with the `File.name` returned by the first import step
- the public `import_genericode()` flow still returns the same metadata contract:
  `code_list`, `code_list_title`, `file`, `columns`, `example_values`, `filterable_columns`
- the only blocked path is passing non-local URLs or other non-local schemes into the public upload/import flow

## Developer impact

- apps that previously tried to drive imports by sending remote URLs through the public `import_genericode()` flow need to move that fetch step into backend Python
- trusted backend callers can use `erpnext.edi.doctype.code_list.code_list_import.import_genericode_from_url(...)`

## Test plan

- `bench run-tests --module erpnext.edi.doctype.code_list.test_code_list_import`