### PR TITLE
feat: show reconciled/unreconciled indicator in list view

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry_list.js
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry_list.js
@@ -1,4 +1,20 @@
 frappe.listview_settings["Payment Entry"] = {
+	add_fields: ["unallocated_amount", "docstatus"],
+	get_indicator: function (doc) {
+		if (doc.docstatus === 2) {
+			return [__("Cancelled"), "red", "docstatus,=,2"];
+		}
+
+		if (doc.docstatus === 0) {
+			return [__("Draft"), "orange", "docstatus,=,0"];
+		}
+
+		if (flt(doc.unallocated_amount) > 0) {
+			return [__("Unreconciled"), "orange", "docstatus,=,1|unallocated_amount,>,0"];
+		}
+
+		return [__("Reconciled"), "green", "docstatus,=,1|unallocated_amount,=,0"];
+	},
 	onload: function (listview) {
 		if (listview.page.fields_dict.party_type) {
 			listview.page.fields_dict.party_type.get_query = function () {

--- a/erpnext/public/js/utils/unreconcile.js
+++ b/erpnext/public/js/utils/unreconcile.js
@@ -140,7 +140,8 @@ erpnext.accounts.unreconcile_payment = {
 											selected_allocations
 										);
 									erpnext.accounts.unreconcile_payment.create_unreconcile_docs(
-										selection_map
+										selection_map,
+										frm
 									);
 									d.hide();
 								} else {
@@ -156,11 +157,22 @@ erpnext.accounts.unreconcile_payment = {
 		}
 	},
 
-	create_unreconcile_docs(selection_map) {
+	create_unreconcile_docs(selection_map, frm) {
 		frappe.call({
 			method: "erpnext.accounts.doctype.unreconcile_payment.unreconcile_payment.create_unreconcile_doc_for_selection",
 			args: {
 				selections: selection_map,
+			},
+			callback: function (r) {
+				if (r.exc) {
+					return;
+				}
+
+				if (frm && !frm.is_new()) {
+					frm.reload_doc();
+				}
+
+				frappe.show_alert({ message: __("Unreconciled successfully"), indicator: "green" });
 			},
 		});
 	},


### PR DESCRIPTION
Before:
<img width="1248" height="552" alt="Screenshot 2026-04-09 at 6 19 33 PM" src="https://github.com/user-attachments/assets/0b10944f-49b1-45c9-b756-710674255a34" />

After:
<img width="1242" height="530" alt="Screenshot 2026-04-09 at 6 19 17 PM" src="https://github.com/user-attachments/assets/1bc86daa-f11e-4f6f-9888-b64e3f9c246c" />

Closes: https://github.com/frappe/erpnext/issues/48261

no-docs