### PR TITLE
Revert "fix: update_nsm only in warehouse creation (backport #54165)"

### DIFF
--- a/erpnext/stock/doctype/warehouse/warehouse.py
+++ b/erpnext/stock/doctype/warehouse/warehouse.py
@@ -65,8 +65,7 @@ class Warehouse(NestedSet):
 		self.warn_about_multiple_warehouse_account()
 
 	def on_update(self):
-		if self.is_new() or self.has_value_changed("parent_warehouse"):
-			self.update_nsm_model()
+		self.update_nsm_model()
 
 	def update_nsm_model(self):
 		frappe.utils.nestedset.update_nsm(self)


### PR DESCRIPTION
Reverts frappe/erpnext#54170

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved warehouse hierarchy update consistency across all warehouse modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->