### PR TITLE
fix(timesheet): update exchange rate field before calculating billing…

### DIFF
--- a/erpnext/projects/doctype/timesheet/timesheet.js
+++ b/erpnext/projects/doctype/timesheet/timesheet.js
@@ -153,6 +153,7 @@ frappe.ui.form.on("Timesheet", {
 	},
 
 	exchange_rate: function (frm) {
+		frm.refresh_field("exchange_rate");
 		$.each(frm.doc.time_logs, function (i, d) {
 			calculate_billing_costing_amount(frm, d.doctype, d.name);
 		});


### PR DESCRIPTION
**Ref:** [62459](https://support.frappe.io/helpdesk/tickets/62459)

**Issue:** When manually changing the currency or exchange rate in the Timesheet, the exchange rate value was being lost, causing all base amounts to be calculated incorrectly.

**Before:**

[Screencast from 2026-04-09 20-49-26.webm](https://github.com/user-attachments/assets/2aabf80d-53ab-4b7f-9f74-569c8b66b2be)


**After:**

[Screencast from 2026-04-09 20-53-35.webm](https://github.com/user-attachments/assets/37b3ccd7-8cbb-425c-a925-b77cc45026f7)



Backport Needed for v15, v16