### PR TITLE
ci: test correctness pattern

### DIFF
--- a/semgrep/test-correctness.yml
+++ b/semgrep/test-correctness.yml
@@ -10,9 +10,15 @@ rules:
   languages: [python]
   severity: ERROR
 - id: Dont-override-teardown
-  pattern: |
-    def tearDown(...):
-      ...
+  patterns:
+  - pattern: |
+      def tearDown(...):
+        ...
+  - pattern-not: |
+      def tearDown(...):
+        ...
+        super().tearDown()
+        ...
   message: ERPNextTestSuite forces rollback on each tearDown, which ensures idempotency. Don't override tearDown.
   languages: [python]
   severity: ERROR


### PR DESCRIPTION
Updates the `Dont-override-teardown` rule in `semgrep/test-correctness.yml` to use a `patterns` list, ensuring that only `tearDown` overrides that do not call `super().tearDown()` are flagged. This reduces false positives.

The concern (as the message says) is that `ERPNextTestSuite` forces a rollback in its `tearDown` to keep tests idempotent. If a subclass overrides `tearDown` without calling `super().tearDown()`, the rollback never happens and tests start leaking state into each other.

So the `pattern-not` carves out the one acceptable case: you *can* override `tearDown`, but only if you still call `super().tearDown()` so the base class's rollback logic runs. Without the `pattern-not`, the rule would flag even well-behaved overrides that properly chain to `super()`.