### PR TITLE
Fix(bom): refetch the rate of item when 'source_from_supplier' is updated

### DIFF
--- a/erpnext/manufacturing/doctype/bom/bom.js
+++ b/erpnext/manufacturing/doctype/bom/bom.js
@@ -955,6 +955,8 @@ frappe.ui.form.on("BOM Item", "sourced_by_supplier", function (frm, cdt, cdn) {
 	if (d.sourced_by_supplier) {
 		d.rate = 0;
 		refresh_field("rate", d.name, d.parentfield);
+	} else {
+		get_bom_material_detail(frm.doc, cdt, cdn, false);
 	}
 });
 


### PR DESCRIPTION
While creating a BOM, when we add an Item to the table, and try to enable the 'Sourced by Supplier' checkbox, it reduces the rate when checked, but doesn't restore it back to the original rate even though the form is not saved.

Fixes #54185

<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/erpnext/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

To fix, I ended up having fetch the rate of item again from the `get_bom_material_detail` function to re-populate the original price of the respective item.

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

If a user ever updates the checkbox for 'source from supplier', the rate would be re-fetched again.

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs


https://github.com/user-attachments/assets/ba5a5f74-4769-4de2-877d-d5dd800b5526



<!-- Add images/recordings to better visualize the change: expected/current behviour -->
