### PR TITLE
fix: avoid double reduction of pe reference outstanding

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/test_payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/test_payment_entry.py
@@ -195,6 +195,30 @@ class TestPaymentEntry(ERPNextTestSuite):
 		outstanding_amount = flt(frappe.db.get_value("Sales Invoice", si.name, "outstanding_amount"))
 		self.assertEqual(outstanding_amount, 100)
 
+	def test_reference_outstanding_amount_on_advance_pull(self):
+		from erpnext.selling.doctype.sales_order.sales_order import make_sales_invoice
+
+		so = make_sales_order(qty=1, rate=1000)
+		pe = get_payment_entry("Sales Order", so.name, bank_account="_Test Cash - _TC")
+		pe.paid_amount = pe.received_amount = 500
+		pe.references[0].allocated_amount = 500
+		pe.insert()
+		pe.submit()
+
+		so.reload()
+		self.assertEqual(so.advance_paid, 500)
+
+		si = make_sales_invoice(so.name)
+		si.allocate_advances_automatically = 1
+		si.save()
+		self.assertEqual(si.get("advances")[0].allocated_amount, 500)
+		self.assertEqual(si.get("advances")[0].reference_name, pe.name)
+		si.submit()
+
+		pe.load_from_db()
+		self.assertEqual(pe.references[0].reference_name, si.name)
+		self.assertEqual(pe.references[0].outstanding_amount, si.outstanding_amount)
+
 	def test_payment_entry_against_pi(self):
 		pi = make_purchase_invoice(
 			supplier="_Test Supplier USD",

--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -2,8 +2,8 @@
 # License: GNU General Public License v3. See license.txt
 
 
+import datetime
 from collections import defaultdict
-from datetime import date, datetime
 from json import loads
 from typing import TYPE_CHECKING, Optional
 
@@ -61,7 +61,7 @@ OUTSTANDING_DOCTYPES = frozenset(["Sales Invoice", "Purchase Invoice", "Fees"])
 
 @frappe.whitelist()
 def get_fiscal_year(
-	date: str | datetime | None = None,
+	date: str | datetime.datetime | None = None,
 	fiscal_year: str | None = None,
 	label: str = "Date",
 	verbose: int = 1,
@@ -201,7 +201,7 @@ def validate_fiscal_year(date, fiscal_year, company, label="Date", doc=None):
 @frappe.whitelist()
 def get_balance_on(
 	account: str | None = None,
-	date: str | date | None = None,
+	date: str | datetime.date | None = None,
 	party_type: str | None = None,
 	party: str | None = None,
 	company: str | None = None,

--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -547,7 +547,7 @@ def reconcile_against_document(
 					skip_ref_details_update_for_pe=skip_ref_details_update_for_pe,
 					dimensions_dict=dimensions_dict,
 				)
-				if referenced_row.get("outstanding_amount"):
+				if referenced_row.get("outstanding_amount") and entry.get("outstanding_amount") is None:
 					referenced_row.outstanding_amount -= flt(entry.allocated_amount)
 
 				reposting_rows.append(referenced_row)

--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -2,7 +2,6 @@
 # License: GNU General Public License v3. See license.txt
 
 
-import datetime
 from collections import defaultdict
 from json import loads
 from typing import TYPE_CHECKING, Optional
@@ -31,6 +30,7 @@ from frappe.utils import (
 	nowdate,
 )
 from frappe.utils.caching import site_cache
+from frappe.utils.data import DateTimeLikeObject
 from pypika import Order
 from pypika.functions import Coalesce
 from pypika.terms import ExistsCriterion
@@ -61,7 +61,7 @@ OUTSTANDING_DOCTYPES = frozenset(["Sales Invoice", "Purchase Invoice", "Fees"])
 
 @frappe.whitelist()
 def get_fiscal_year(
-	date: str | datetime.datetime | None = None,
+	date: DateTimeLikeObject | None = None,
 	fiscal_year: str | None = None,
 	label: str = "Date",
 	verbose: int = 1,
@@ -201,7 +201,7 @@ def validate_fiscal_year(date, fiscal_year, company, label="Date", doc=None):
 @frappe.whitelist()
 def get_balance_on(
 	account: str | None = None,
-	date: str | datetime.date | None = None,
+	date: DateTimeLikeObject | None = None,
 	party_type: str | None = None,
 	party: str | None = None,
 	company: str | None = None,


### PR DESCRIPTION
Issue:
When a Sales Invoice is created from a Sales Order with a partial advance Payment Entry, the Sales Invoice correctly reflects the outstanding amount however, in the linked Payment Entry, the reference row shows an incorrect value, as the outstanding amount is reduced twice.

Ref: [#64841](https://support.frappe.io/helpdesk/tickets/64841)

steps:

1. Create a Sales Order with a total amount of 10000.
2. Create a Payment Entry from that Sales Order for 5000 and submit it.
3. Create a Sales Invoice from that Sales Order.
4. Pull the advance into the Sales Invoice and submit it.
5. Open the original Payment Entry, check the references child table where the outstanding amount shows 0 instead of 5000.


Backport needed: v16, v15