### PR TITLE
fix: update return value in workstation list view indicator

### DIFF
--- a/erpnext/manufacturing/doctype/workstation/workstation_list.js
+++ b/erpnext/manufacturing/doctype/workstation/workstation_list.js
@@ -10,6 +10,6 @@ frappe.listview_settings["Workstation"] = {
 			Setup: "blue",
 		};
 
-		return [__(doc.status), color_map[doc.status], true];
+		return [__(doc.status), color_map[doc.status], "status,=," + doc.status];
 	},
 };


### PR DESCRIPTION
**Issue:**

In Manufacturing module, the Workstation doctype list view does not apply filters when a Status field is selected. While selecting the ID field works as expected, choosing the Status field fails to trigger any filtering, leaving the list view unchanged.

**Ref:** [#54195](https://github.com/frappe/erpnext/issues/54195)




**Before :**  

[Screencast from 2026-04-10 03-51-49.webm](https://github.com/user-attachments/assets/4070cffb-e8c3-4622-b91e-b5c1f25a58cf)






**After :**

[Screencast from 2026-04-10 03-55-30.webm](https://github.com/user-attachments/assets/f1c0c2b3-6d66-4abf-b616-739f919fcbb0)



**Backport needed: v16, v15**