### PR TITLE
fix: validate portal user ownership in create_supplier_quotation

### DIFF
--- a/erpnext/buying/doctype/request_for_quotation/request_for_quotation.py
+++ b/erpnext/buying/doctype/request_for_quotation/request_for_quotation.py
@@ -481,20 +481,26 @@ def create_supplier_quotation(doc: str | Document | dict):
 	if isinstance(doc, str):
 		doc = json.loads(doc)
 
+	supplier = doc.get("supplier")
+	if frappe.session.user not in frappe.get_all(
+		"Portal User", {"parent": supplier}, pluck="user"
+	):
+		frappe.throw(_("Not Permitted"), frappe.PermissionError)
+
 	try:
 		sq_doc = frappe.get_doc(
 			{
 				"doctype": "Supplier Quotation",
-				"supplier": doc.get("supplier"),
+				"supplier": supplier,
 				"terms": doc.get("terms"),
 				"company": doc.get("company"),
 				"currency": doc.get("currency")
-				or get_party_account_currency("Supplier", doc.get("supplier"), doc.get("company")),
+				or get_party_account_currency("Supplier", supplier, doc.get("company")),
 				"buying_price_list": doc.get("buying_price_list")
 				or frappe.db.get_single_value("Buying Settings", "buying_price_list"),
 			}
 		)
-		add_items(sq_doc, doc.get("supplier"), doc.get("items"))
+		add_items(sq_doc, supplier, doc.get("items"))
 		sq_doc.flags.ignore_permissions = True
 		sq_doc.run_method("set_missing_values")
 		sq_doc.save()


### PR DESCRIPTION
## Description

`create_supplier_quotation` is a `@frappe.whitelist()` endpoint used by the supplier portal. It creates a Supplier Quotation with `ignore_permissions=True` but does not verify that the logged-in portal user (`frappe.session.user`) is actually linked to the supplier specified in the request payload.

This allows any authenticated supplier portal user to create quotations on behalf of any other supplier, enabling procurement fraud / supplier impersonation.

## Fix

Add a Portal User ownership check before document creation — the same pattern already used in `make_purchase_invoice_from_portal` (`erpnext/buying/doctype/purchase_order/purchase_order.py`):

```python
supplier = doc.get("supplier")
if frappe.session.user not in frappe.get_all(
    "Portal User", {"parent": supplier}, pluck="user"
):
    frappe.throw(_("Not Permitted"), frappe.PermissionError)
```

If the session user is not in the supplier's Portal User list, the request is rejected with `PermissionError`.

Fixes #54210