### PR TITLE
fix: additional costs not applied for 0 value stock movement

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -1413,6 +1413,9 @@ class StockEntry(StockController, SubcontractingInwardController):
 			if d.s_warehouse:
 				self.total_outgoing_value += flt(d.amount)
 
+		if not self.total_incoming_value and self.total_additional_costs:
+			self.total_incoming_value = self.total_additional_costs
+
 		self.value_difference = self.total_incoming_value - self.total_outgoing_value
 
 	def set_total_amount(self):


### PR DESCRIPTION
Additional costs were not being applied to the total incoming value if stock entry incoming value was 0.

(possible) use case:
You receive material from customer for subcontracting but you bear the transportation costs.