### PR TITLE
fix(Bank Transaction): validate bank transaction over allocation

### DIFF
--- a/erpnext/accounts/doctype/bank_transaction/bank_transaction.json
+++ b/erpnext/accounts/doctype/bank_transaction/bank_transaction.json
@@ -135,6 +135,7 @@
    "fieldname": "payment_entries",
    "fieldtype": "Table",
    "label": "Payment Entries",
+   "no_copy": 1,
    "options": "Bank Transaction Payments"
   },
   {
@@ -279,7 +280,7 @@
  "grid_page_length": 50,
  "is_submittable": 1,
  "links": [],
- "modified": "2026-04-11 20:41:15.124085",
+ "modified": "2026-04-12 18:49:21.813808",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Bank Transaction",

--- a/erpnext/accounts/doctype/bank_transaction/bank_transaction.py
+++ b/erpnext/accounts/doctype/bank_transaction/bank_transaction.py
@@ -5,7 +5,7 @@ import frappe
 from frappe import _
 from frappe.model.docstatus import DocStatus
 from frappe.model.document import Document
-from frappe.query_builder import Tuple
+from frappe.query_builder import Criterion, Tuple
 from frappe.query_builder.functions import Abs, Max, Sum
 from frappe.utils import flt, getdate
 
@@ -138,8 +138,12 @@ class BankTransaction(Document):
 	def before_update_after_submit(self):
 		self.validate_duplicate_references()
 		self.update_allocated_amount()
+
+		gl_bank_account = frappe.db.get_value("Bank Account", self.bank_account, "account")
+		payment_entry_docs = [(pe.payment_document, pe.payment_entry) for pe in self.payment_entries]
+		self.validate_over_allocation(gl_bank_account, payment_entry_docs)
 		self.delink_old_payment_entries()
-		self.allocate_payment_entries()
+		self.allocate_payment_entries(gl_bank_account)
 		self.set_status()
 
 	def on_cancel(self):
@@ -171,7 +175,7 @@ class BankTransaction(Document):
 				},
 			)
 
-	def allocate_payment_entries(self):
+	def allocate_payment_entries(self, gl_bank_account=None):
 		"""Refactored from bank reconciliation tool.
 		Non-zero allocations must be amended/cleared manually
 		Get the bank transaction amount (b) and remove as we allocate
@@ -192,10 +196,11 @@ class BankTransaction(Document):
 		payment_entry_docs = [(pe.payment_document, pe.payment_entry) for pe in self.payment_entries]
 		pe_bt_allocations = get_total_allocated_amount(payment_entry_docs)
 		gl_entries = get_related_bank_gl_entries(payment_entry_docs)
-		gl_bank_account = frappe.db.get_value("Bank Account", self.bank_account, "account")
+		gl_bank_account = gl_bank_account or frappe.db.get_value("Bank Account", self.bank_account, "account")
 
 		for payment_entry in list(self.payment_entries):
 			if payment_entry.allocated_amount != 0:
+				self.clear_linked_payment_entry(payment_entry, clearance_date=getdate(self.date))
 				continue
 
 			allocable_amount, should_clear, clearance_date = get_clearance_details(
@@ -234,6 +239,50 @@ class BankTransaction(Document):
 				self.clear_linked_payment_entry(payment_entry, clearance_date=clearance_date)
 
 		self.update_allocated_amount()
+
+	def validate_over_allocation(self, gl_bank_account, non_bt_vouchers):
+		gl_entries = get_related_bank_gl_entries(non_bt_vouchers)
+
+		BTP = frappe.qb.DocType("Bank Transaction Payments")
+		BT = frappe.qb.DocType("Bank Transaction")
+		BA = frappe.qb.DocType("Bank Account")
+
+		voucher_condition = Criterion.any(
+			(BTP.payment_document == doctype) & (BTP.payment_entry == docname)
+			for doctype, docname in non_bt_vouchers
+		)
+
+		result = (
+			frappe.qb.from_(BTP)
+			.left_join(BT)
+			.on(BT.name == BTP.parent)
+			.left_join(BA)
+			.on(BA.name == BT.bank_account)
+			.select(
+				BTP.payment_document,
+				BTP.payment_entry,
+				BA.account.as_("gl_account"),
+				Sum(BTP.allocated_amount).as_("total"),
+			)
+			.where(voucher_condition)
+			.where(BT.docstatus == 1)
+			.where(BT.name != self.name)
+			.groupby(BA.account, BTP.payment_document, BTP.payment_entry)
+			.run(as_dict=True)
+		)
+
+		other_allocations = {}
+		for row in result:
+			other_allocations.setdefault((row["payment_document"], row["payment_entry"]), {})[
+				row["gl_account"]
+			] = row["total"]
+
+		for doctype, docname in non_bt_vouchers:
+			paid_amount = (gl_entries.get((doctype, docname)) or {}).get(gl_bank_account, 0)
+			allocated = flt(other_allocations.get((doctype, docname), {}).get(gl_bank_account, 0))
+
+			if allocated >= paid_amount and paid_amount > 0:
+				frappe.throw(_("{0} {1} is already fully allocated").format(doctype, frappe.bold(docname)))
 
 	@frappe.whitelist()
 	def remove_payment_entries(self):

--- a/erpnext/accounts/doctype/bank_transaction/bank_transaction.py
+++ b/erpnext/accounts/doctype/bank_transaction/bank_transaction.py
@@ -141,7 +141,8 @@ class BankTransaction(Document):
 
 		gl_bank_account = frappe.db.get_value("Bank Account", self.bank_account, "account")
 		payment_entry_docs = [(pe.payment_document, pe.payment_entry) for pe in self.payment_entries]
-		self.validate_over_allocation(gl_bank_account, payment_entry_docs)
+		if payment_entry_docs:
+			self.validate_over_allocation(gl_bank_account, payment_entry_docs)
 		self.delink_old_payment_entries()
 		self.allocate_payment_entries(gl_bank_account)
 		self.set_status()

--- a/erpnext/accounts/doctype/bank_transaction/bank_transaction.py
+++ b/erpnext/accounts/doctype/bank_transaction/bank_transaction.py
@@ -200,7 +200,24 @@ class BankTransaction(Document):
 
 		for payment_entry in list(self.payment_entries):
 			if payment_entry.allocated_amount != 0:
-				self.clear_linked_payment_entry(payment_entry, clearance_date=getdate(self.date))
+				allocable_amount, should_clear, clearance_date = get_clearance_details(
+					self,
+					payment_entry,
+					pe_bt_allocations.get((payment_entry.payment_document, payment_entry.payment_entry))
+					or {},
+					gl_entries.get((payment_entry.payment_document, payment_entry.payment_entry)) or {},
+					gl_bank_account,
+				)
+				if payment_entry.allocated_amount > allocable_amount:
+					frappe.throw(
+						_("Voucher {0} is over-allocated by {1}").format(
+							frappe.bold(payment_entry.payment_entry),
+							abs(allocable_amount),
+						)
+					)
+
+				if payment_entry.allocated_amount == allocable_amount and should_clear:
+					self.clear_linked_payment_entry(payment_entry, clearance_date=clearance_date)
 				continue
 
 			allocable_amount, should_clear, clearance_date = get_clearance_details(
@@ -211,8 +228,13 @@ class BankTransaction(Document):
 				gl_bank_account,
 			)
 
-			if allocable_amount < 0:
-				frappe.throw(_("Voucher {0} is over-allocated by {1}").format(allocable_amount))
+			if payment_entry.allocated_amount > allocable_amount:
+				frappe.throw(
+					_("Voucher {0} is over-allocated by {1}").format(
+						frappe.bold(payment_entry.payment_entry),
+						abs(allocable_amount),
+					)
+				)
 
 			if remaining_amount <= 0:
 				self.remove(payment_entry)

--- a/erpnext/accounts/doctype/bank_transaction/test_bank_transaction.py
+++ b/erpnext/accounts/doctype/bank_transaction/test_bank_transaction.py
@@ -187,6 +187,37 @@ class TestBankTransaction(ERPNextTestSuite):
 			vouchers=vouchers,
 		)
 
+	def test_reconcile_voucher_with_different_bank_transaction(self):
+		bank_transaction_1 = frappe.get_doc(
+			"Bank Transaction",
+			dict(description="1512567 BG/000002918 OPSKATTUZWXXX AT776000000098709837 Herr G"),
+		)
+		payment = frappe.get_doc("Payment Entry", dict(party="Mr G", paid_amount=1200))
+		vouchers = json.dumps(
+			[
+				{
+					"payment_doctype": "Payment Entry",
+					"payment_name": payment.name,
+					"amount": bank_transaction_1.unallocated_amount,
+				}
+			]
+		)
+		reconcile_vouchers(bank_transaction_1.name, vouchers)
+
+		bank_transaction_2 = frappe.get_doc(
+			"Bank Transaction",
+			dict(description="1512567 BG/000003025 OPSKATTUZWXXX AT776000000098709849 Herr G"),
+		)
+		bank_transaction_2.append(
+			"payment_entries",
+			{
+				"payment_document": "Payment Entry",
+				"payment_entry": payment.name,
+				"allocated_amount": 0.0,
+			},
+		)
+		self.assertRaises(frappe.ValidationError, bank_transaction_2.save)
+
 	# Raise an error if debitor transaction vs debitor payment
 	def test_clear_sales_invoice(self):
 		bank_transaction = frappe.get_doc(


### PR DESCRIPTION
**Issue:**
1) The clearance date is not updated when reconciliation is done manually by entering the allocated amount in the Bank Transaction.
2) The system allows multiple bank transactions to be reconciled against the same payment voucher (Journal Entry), which should not be permitted.

**Ref:** [62876](https://support.frappe.io/helpdesk/tickets/62876)

**Steps to reproduce:**
1) Create a Journal Entry to pay an amount from the company bank account to a supplier.
2) Create a Bank Transaction with the amount entered under Withdrawal, then save and submit.
3) Try reconciling the Bank Transaction manually by entering the allocated amount.
4) Observe that the clearance date is not updated after reconciliation in the Journal Entry.
5) Duplicate the same Bank Transaction.
6) Attempt to reconcile the duplicated Bank Transaction using the same Journal Entry.
6) Observe that the system allows reconciliation again with the same Journal Entry.

**Before:**

https://github.com/user-attachments/assets/0f5448dd-5051-44ed-9ace-6371efc12dc6

**After:**

https://github.com/user-attachments/assets/bc4cb2e8-d8ca-48e6-a3b9-f3d03fbd3054


