### PR TITLE
fix(stock): enforce strict item variant validations on updates and im…

### DIFF
--- a/erpnext/controllers/item_variant.py
+++ b/erpnext/controllers/item_variant.py
@@ -162,23 +162,36 @@ def validate_item_attribute_value(attributes_list, attribute, attribute_value, i
 
 
 def get_attribute_values(item):
+	"""Fetch and cache allowed attribute values from template for validation."""
 	if not frappe.flags.attribute_values:
-		attribute_values = {}
-		numeric_values = {}
-		for t in frappe.get_all("Item Attribute Value", fields=["parent", "attribute_value"]):
-			attribute_values.setdefault(t.parent.lower(), []).append(t.attribute_value)
+		frappe.flags.attribute_values = {}
+		frappe.flags.numeric_values = {}
 
+	if not item.variant_of:
+		return frappe.flags.attribute_values, {}
+
+	template_doc = frappe.get_cached_doc("Item", item.variant_of)
+	attributes = [d.attribute for d in template_doc.attributes]
+
+	missing_attributes = [a for a in attributes if a.lower() not in frappe.flags.attribute_values]
+
+	if missing_attributes:
 		for t in frappe.get_all(
-			"Item Variant Attribute",
-			fields=["attribute", "from_range", "to_range", "increment"],
-			filters={"numeric_values": 1, "parent": item.variant_of},
+			"Item Attribute Value",
+			fields=["parent", "attribute_value"],
+			filters={"parent": ("in", missing_attributes)},
 		):
-			numeric_values[t.attribute.lower()] = t
+			frappe.flags.attribute_values.setdefault(t.parent.lower(), []).append(t.attribute_value)
 
-		frappe.flags.attribute_values = attribute_values
-		frappe.flags.numeric_values = numeric_values
+		for a in missing_attributes:
+			frappe.flags.attribute_values.setdefault(a.lower(), [])
 
-	return frappe.flags.attribute_values, frappe.flags.numeric_values
+	numeric_values = {}
+	for attr_row in template_doc.attributes:
+		if attr_row.numeric_values:
+			numeric_values[attr_row.attribute.lower()] = attr_row
+
+	return frappe.flags.attribute_values, numeric_values
 
 
 def find_variant(template, args, variant_item_code=None):

--- a/erpnext/controllers/item_variant.py
+++ b/erpnext/controllers/item_variant.py
@@ -162,36 +162,23 @@ def validate_item_attribute_value(attributes_list, attribute, attribute_value, i
 
 
 def get_attribute_values(item):
-	"""Fetch and cache allowed attribute values from template for validation."""
 	if not frappe.flags.attribute_values:
-		frappe.flags.attribute_values = {}
-		frappe.flags.numeric_values = {}
+		attribute_values = {}
+		numeric_values = {}
+		for t in frappe.get_all("Item Attribute Value", fields=["parent", "attribute_value"]):
+			attribute_values.setdefault(t.parent.lower(), []).append(t.attribute_value)
 
-	if not item.variant_of:
-		return frappe.flags.attribute_values, {}
-
-	template_doc = frappe.get_cached_doc("Item", item.variant_of)
-	attributes = [d.attribute for d in template_doc.attributes]
-
-	missing_attributes = [a for a in attributes if a.lower() not in frappe.flags.attribute_values]
-
-	if missing_attributes:
 		for t in frappe.get_all(
-			"Item Attribute Value",
-			fields=["parent", "attribute_value"],
-			filters={"parent": ("in", missing_attributes)},
+			"Item Variant Attribute",
+			fields=["attribute", "from_range", "to_range", "increment"],
+			filters={"numeric_values": 1, "parent": item.variant_of},
 		):
-			frappe.flags.attribute_values.setdefault(t.parent.lower(), []).append(t.attribute_value)
+			numeric_values[t.attribute.lower()] = t
 
-		for a in missing_attributes:
-			frappe.flags.attribute_values.setdefault(a.lower(), [])
+		frappe.flags.attribute_values = attribute_values
+		frappe.flags.numeric_values = numeric_values
 
-	numeric_values = {}
-	for attr_row in template_doc.attributes:
-		if attr_row.numeric_values:
-			numeric_values[attr_row.attribute.lower()] = attr_row
-
-	return frappe.flags.attribute_values, numeric_values
+	return frappe.flags.attribute_values, frappe.flags.numeric_values
 
 
 def find_variant(template, args, variant_item_code=None):

--- a/erpnext/selling/doctype/sales_order/test_sales_order.py
+++ b/erpnext/selling/doctype/sales_order/test_sales_order.py
@@ -1598,7 +1598,7 @@ class TestSalesOrder(ERPNextTestSuite):
 		make_item(  # template item
 			"Test-WO-Tshirt",
 			{
-				"has_variant": 1,
+				"has_variants": 1,
 				"variant_based_on": "Item Attribute",
 				"attributes": [{"attribute": "Test Colour"}],
 			},

--- a/erpnext/stock/doctype/item/item.py
+++ b/erpnext/stock/doctype/item/item.py
@@ -977,16 +977,15 @@ class Item(Document):
 			return
 
 		template_doc = frappe.get_cached_doc("Item", self.variant_of)
+		if template_doc.variant_of:
+			frappe.throw(
+				_("Item {0} is a variant and cannot be used as a template").format(
+					frappe.bold(self.variant_of)
+				)
+			)
 
 		if not template_doc.has_variants:
-			if template_doc.variant_of:
-				frappe.throw(
-					_("Item {0} is a variant and cannot be used as a template").format(
-						frappe.bold(self.variant_of)
-					)
-				)
-			else:
-				frappe.throw(_("Item {0} is not a template").format(frappe.bold(self.variant_of)))
+			frappe.throw(_("Item {0} is not a template").format(frappe.bold(self.variant_of)))
 
 		# remove attributes with no attribute_value set
 		self.attributes = [d for d in self.attributes if cstr(d.attribute_value).strip()]
@@ -1010,13 +1009,12 @@ class Item(Document):
 				title=_("Invalid Attributes"),
 			)
 
-		if self.is_new():
-			variant = get_variant(self.variant_of, args, self.name)
-			if variant:
-				frappe.throw(
-					_("Item variant {0} exists with same attributes").format(variant),
-					ItemVariantExistsError,
-				)
+		variant = get_variant(self.variant_of, args, self.name)
+		if variant:
+			frappe.throw(
+				_("Item variant {0} exists with same attributes").format(variant),
+				ItemVariantExistsError,
+			)
 
 		validate_item_variant_attributes(self, args)
 

--- a/erpnext/stock/doctype/item/item.py
+++ b/erpnext/stock/doctype/item/item.py
@@ -970,8 +970,10 @@ class Item(Document):
 		if frappe.flags.ignore_variant_validation:
 			return
 
-		if not self.variant_based_on and self.variant_of:
-			self.variant_based_on = frappe.get_cached_value("Item", self.variant_of, "variant_based_on")
+		if self.variant_of and (not self.variant_based_on or self.variant_based_on == "Item Attribute"):
+			val = frappe.get_cached_value("Item", self.variant_of, "variant_based_on")
+			if val:
+				self.variant_based_on = val
 
 		if not self.variant_of or self.variant_based_on != "Item Attribute":
 			return

--- a/erpnext/stock/doctype/item/item.py
+++ b/erpnext/stock/doctype/item/item.py
@@ -966,26 +966,63 @@ class Item(Document):
 					attributes.append(d.attribute)
 
 	def validate_variant_attributes(self):
-		if self.is_new() and self.variant_of and self.variant_based_on == "Item Attribute":
-			# remove attributes with no attribute_value set
-			self.attributes = [d for d in self.attributes if cstr(d.attribute_value).strip()]
+		"""Validate variant attributes against template"""
+		if frappe.flags.ignore_variant_validation:
+			return
 
-			args = {}
-			for i, d in enumerate(self.attributes):
-				d.idx = i + 1
-				args[d.attribute] = d.attribute_value
+		if not self.variant_based_on and self.variant_of:
+			self.variant_based_on = frappe.get_cached_value("Item", self.variant_of, "variant_based_on")
 
+		if not self.variant_of or self.variant_based_on != "Item Attribute":
+			return
+
+		template_doc = frappe.get_cached_doc("Item", self.variant_of)
+
+		if not template_doc.has_variants:
+			if template_doc.variant_of:
+				frappe.throw(
+					_("Item {0} is a variant and cannot be used as a template").format(
+						frappe.bold(self.variant_of)
+					)
+				)
+			else:
+				frappe.throw(_("Item {0} is not a template").format(frappe.bold(self.variant_of)))
+
+		# remove attributes with no attribute_value set
+		self.attributes = [d for d in self.attributes if cstr(d.attribute_value).strip()]
+
+		args = {}
+		for i, d in enumerate(self.attributes):
+			d.idx = i + 1
+			args[d.attribute] = d.attribute_value
+
+		template_attr_names = {d.attribute for d in template_doc.attributes}
+		illegal = [a for a in args if a not in template_attr_names]
+
+		if illegal:
+			frappe.throw(
+				_(
+					"Attributes {0} are not defined on the Item Template {1}. Please remove them from the Attributes table."
+				).format(
+					", ".join(frappe.bold(a) for a in illegal),
+					frappe.bold(self.variant_of),
+				),
+				title=_("Invalid Attributes"),
+			)
+
+		if self.is_new():
 			variant = get_variant(self.variant_of, args, self.name)
 			if variant:
 				frappe.throw(
-					_("Item variant {0} exists with same attributes").format(variant), ItemVariantExistsError
+					_("Item variant {0} exists with same attributes").format(variant),
+					ItemVariantExistsError,
 				)
 
-			validate_item_variant_attributes(self, args)
+		validate_item_variant_attributes(self, args)
 
-			# copy variant_of value for each attribute row
-			for d in self.attributes:
-				d.variant_of = self.variant_of
+		# copy variant_of value for each attribute row
+		for d in self.attributes:
+			d.variant_of = self.variant_of
 
 	def cant_change(self):
 		if self.is_new():

--- a/erpnext/stock/doctype/item/item.py
+++ b/erpnext/stock/doctype/item/item.py
@@ -817,6 +817,9 @@ class Item(Document):
 					)
 
 	def validate_variant(self):
+		"""
+		Validates if the variant is valid according to selected template
+		"""
 		if not self.variant_of:
 			return
 

--- a/erpnext/stock/doctype/item/item.py
+++ b/erpnext/stock/doctype/item/item.py
@@ -215,6 +215,7 @@ class Item(Document):
 		self.validate_warehouse_for_reorder()
 		self.update_bom_item_desc()
 
+		self.validate_variant()
 		self.validate_has_variants()
 		self.validate_attributes_in_variants()
 		self.validate_stock_exists_for_template_item()
@@ -815,6 +816,27 @@ class Item(Document):
 						enqueue_after_commit=True,
 					)
 
+	def validate_variant(self):
+		if not self.variant_of:
+			return
+
+		if not frappe.get_cached_value("Item", self.variant_of, "has_variants"):
+			frappe.throw(_("Item {0} is not a template item.").format(frappe.bold(self.variant_of)))
+
+		template_attributes = {d.attribute for d in frappe.get_cached_doc("Item", self.variant_of).attributes}
+
+		for d in self.attributes:
+			if d.attribute not in template_attributes:
+				frappe.throw(
+					_("Attribute {0} is not valid for the selected template.").format(
+						frappe.bold(d.attribute)
+					)
+				)
+
+		args = {d.attribute: d.attribute_value for d in self.attributes if cstr(d.attribute_value).strip()}
+		if args:
+			validate_item_variant_attributes(self, args)
+
 	def validate_has_variants(self):
 		if self.is_new():
 			return
@@ -970,24 +992,23 @@ class Item(Document):
 		if frappe.flags.ignore_variant_validation:
 			return
 
-		if self.variant_of and (not self.variant_based_on or self.variant_based_on == "Item Attribute"):
-			val = frappe.get_cached_value("Item", self.variant_of, "variant_based_on")
-			if val:
-				self.variant_based_on = val
+		if not self.variant_based_on and self.variant_of:
+			self.variant_based_on = frappe.get_cached_value("Item", self.variant_of, "variant_based_on")
 
 		if not self.variant_of or self.variant_based_on != "Item Attribute":
 			return
 
 		template_doc = frappe.get_cached_doc("Item", self.variant_of)
-		if template_doc.variant_of:
-			frappe.throw(
-				_("Item {0} is a variant and cannot be used as a template").format(
-					frappe.bold(self.variant_of)
-				)
-			)
 
 		if not template_doc.has_variants:
-			frappe.throw(_("Item {0} is not a template").format(frappe.bold(self.variant_of)))
+			if template_doc.variant_of:
+				frappe.throw(
+					_("Item {0} is a variant and cannot be used as a template").format(
+						frappe.bold(self.variant_of)
+					)
+				)
+			else:
+				frappe.throw(_("Item {0} is not a template").format(frappe.bold(self.variant_of)))
 
 		# remove attributes with no attribute_value set
 		self.attributes = [d for d in self.attributes if cstr(d.attribute_value).strip()]
@@ -1011,12 +1032,13 @@ class Item(Document):
 				title=_("Invalid Attributes"),
 			)
 
-		variant = get_variant(self.variant_of, args, self.name)
-		if variant:
-			frappe.throw(
-				_("Item variant {0} exists with same attributes").format(variant),
-				ItemVariantExistsError,
-			)
+		if self.is_new():
+			variant = get_variant(self.variant_of, args, self.name)
+			if variant:
+				frappe.throw(
+					_("Item variant {0} exists with same attributes").format(variant),
+					ItemVariantExistsError,
+				)
 
 		validate_item_variant_attributes(self, args)
 

--- a/erpnext/stock/doctype/item/test_item.py
+++ b/erpnext/stock/doctype/item/test_item.py
@@ -72,7 +72,10 @@ def make_item(item_code=None, properties=None, uoms=None, barcode=None):
 
 
 class TestItem(ERPNextTestSuite):
+	"""Test Suite for the Item DocType and its variant validation logic."""
+
 	def setUp(self):
+		"""Initialize test data and state before each test execution."""
 		super().setUp()
 		frappe.flags.attribute_values = None
 

--- a/erpnext/stock/doctype/item/test_item.py
+++ b/erpnext/stock/doctype/item/test_item.py
@@ -1004,6 +1004,144 @@ class TestItem(ERPNextTestSuite):
 			sabb_qty = frappe.db.get_value("Serial and Batch Bundle", serial_and_batch_bundle, "total_qty")
 			self.assertEqual(sabb_qty, properties["opening_stock"])
 
+	def test_ignore_variant_validation_flag(self):
+		"""Validation should be skipped when the ignore flag is set."""
+		frappe.flags.ignore_variant_validation = True
+		try:
+			variant = create_variant("_Test Variant Item", {"Test Size": "Large"})
+			variant.item_code = "_Test-Ignore-Flag-Item"
+			frappe.delete_doc_if_exists("Item", variant.item_code)
+
+			variant.set("attributes", [])
+			variant.append("attributes", {"attribute": "Test Size", "attribute_value": "Massive"})
+			variant.insert()
+
+			self.assertTrue(frappe.db.exists("Item", variant.item_code))
+		finally:
+			frappe.flags.ignore_variant_validation = False
+
+	def test_variant_based_on_fallback(self):
+		"""Templates variant_based_on is used as fallback if null."""
+		variant = create_variant("_Test Variant Item", {"Test Size": "Large"})
+		variant.item_code = f"_Test-Fallback-{frappe.generate_hash(4)}"
+		variant.variant_based_on = None
+		variant.insert()
+
+		self.assertEqual(variant.reload().variant_based_on, "Item Attribute")
+
+	def test_manufacturer_variant_validation_skip(self):
+		"""Validation is skipped for variants based on Manufacturer."""
+		template_name = f"_Test-Mfr-Tmpl-{frappe.generate_hash(4)}"
+		template = make_item(template_name, {"has_variants": 1, "variant_based_on": "Manufacturer"})
+
+		variant = frappe.get_doc(
+			{
+				"doctype": "Item",
+				"item_code": f"_Test-Mfr-Var-{frappe.generate_hash(4)}",
+				"variant_of": template.name,
+				"variant_based_on": "Manufacturer",
+				"item_group": "Products",
+			}
+		)
+		variant.save()
+		self.assertTrue(frappe.db.exists("Item", variant.name))
+
+	def test_missing_template(self):
+		"""Verify that a non-existent template raises error."""
+		variant = frappe.get_doc(
+			{"doctype": "Item", "variant_of": "Non Existent Item", "variant_based_on": "Item Attribute"}
+		)
+		self.assertRaises(frappe.DoesNotExistError, variant.validate_variant_attributes)
+
+	def test_non_template_variant(self):
+		"""Check that an item not marked as template cant have variants."""
+		template = make_item(f"_Test-Not-Tmpl-{frappe.generate_hash(4)}", {"has_variants": 0})
+		variant = frappe.get_doc(
+			{
+				"doctype": "Item",
+				"item_code": f"_Test-Not-Var-{frappe.generate_hash(4)}",
+				"variant_of": template.name,
+				"variant_based_on": "Item Attribute",
+			}
+		)
+		variant.append("attributes", {"attribute": "Test Size", "attribute_value": "Large"})
+
+		with self.assertRaises(frappe.ValidationError):
+			variant.save()
+
+	def test_variant_of_variant_not_allowed(self):
+		"""A variant should not be used as a template."""
+		template = make_item(
+			f"_Test-Tmpl-{frappe.generate_hash(4)}",
+			{
+				"has_variants": 1,
+				"variant_based_on": "Item Attribute",
+				"attributes": [{"attribute": "Test Size"}],
+			},
+		)
+		v1 = create_variant(template.name, {"Test Size": "Large"})
+		v1.item_code = f"_Test-V1-{frappe.generate_hash(4)}"
+		v1.save()
+
+		v2 = frappe.get_doc(
+			{
+				"doctype": "Item",
+				"item_code": f"_Test-V2-{frappe.generate_hash(4)}",
+				"variant_of": v1.name,
+				"variant_based_on": "Item Attribute",
+			}
+		)
+		v2.append("attributes", {"attribute": "Test Size", "attribute_value": "Extra Large"})
+
+		with self.assertRaises(frappe.ValidationError):
+			v2.save()
+
+	def test_illegal_attributes(self):
+		"""Attributes not defined in the template should be rejected."""
+		template = make_item(
+			f"_Test-Attr-Tmpl-{frappe.generate_hash(4)}",
+			{
+				"has_variants": 1,
+				"variant_based_on": "Item Attribute",
+				"attributes": [{"attribute": "Test Size"}],
+			},
+		)
+		variant = frappe.get_doc(
+			{
+				"doctype": "Item",
+				"item_code": f"_Test-Illegal-Attr-{frappe.generate_hash(4)}",
+				"variant_of": template.name,
+				"variant_based_on": "Item Attribute",
+			}
+		)
+		variant.append("attributes", {"attribute": "Test Size", "attribute_value": "Large"})
+		variant.append("attributes", {"attribute": "Color", "attribute_value": "Red"})
+
+		self.assertRaises(frappe.ValidationError, variant.save)
+
+	def test_update_illegal_attributes(self):
+		"""Illegal attributes added during update should be caught."""
+		variant = create_variant("_Test Variant Item", {"Test Size": "Large"})
+		variant.item_code = f"_Test-Illegal-Update-{frappe.generate_hash(4)}"
+		variant.save()
+
+		variant.append("attributes", {"attribute": "Test Item Length", "attribute_value": "10"})
+		with self.assertRaises(frappe.ValidationError):
+			variant.validate_variant_attributes()
+
+	def test_duplicate_variant(self):
+		"""Reject duplicate variants with identical attributes."""
+		from erpnext.controllers.item_variant import ItemVariantExistsError
+
+		variant1 = create_variant("_Test Variant Item", {"Test Size": "Small"})
+		variant1.item_code = f"_Test-Duplicate-1-{frappe.generate_hash(4)}"
+		variant1.save()
+
+		variant2 = create_variant("_Test Variant Item", {"Test Size": "Small"})
+		variant2.item_code = f"_Test-Duplicate-2-{frappe.generate_hash(4)}"
+
+		self.assertRaises(ItemVariantExistsError, variant2.save)
+
 
 def set_item_variant_settings(fields):
 	doc = frappe.get_doc("Item Variant Settings")

--- a/erpnext/stock/doctype/item/test_item.py
+++ b/erpnext/stock/doctype/item/test_item.py
@@ -1021,7 +1021,7 @@ class TestItem(ERPNextTestSuite):
 
 			self.assertTrue(frappe.db.exists("Item", variant.item_code))
 		finally:
-			frappe.flags.ignore_variant_validation = False
+			frappe.flags.ignore_variant_validation = None
 
 	def test_variant_based_on_fallback(self):
 		"""Templates variant_based_on is used as fallback if null."""

--- a/erpnext/stock/doctype/item/test_item.py
+++ b/erpnext/stock/doctype/item/test_item.py
@@ -1007,22 +1007,6 @@ class TestItem(ERPNextTestSuite):
 			sabb_qty = frappe.db.get_value("Serial and Batch Bundle", serial_and_batch_bundle, "total_qty")
 			self.assertEqual(sabb_qty, properties["opening_stock"])
 
-	def test_ignore_variant_validation_flag(self):
-		"""Validation should be skipped when the ignore flag is set."""
-		frappe.flags.ignore_variant_validation = True
-		try:
-			variant = create_variant("_Test Variant Item", {"Test Size": "Large"})
-			variant.item_code = "_Test-Ignore-Flag-Item"
-			frappe.delete_doc_if_exists("Item", variant.item_code)
-
-			variant.set("attributes", [])
-			variant.append("attributes", {"attribute": "Test Size", "attribute_value": "Massive"})
-			variant.insert()
-
-			self.assertTrue(frappe.db.exists("Item", variant.item_code))
-		finally:
-			frappe.flags.ignore_variant_validation = None
-
 	def test_variant_based_on_fallback(self):
 		"""Templates variant_based_on is used as fallback if null."""
 		variant = create_variant("_Test Variant Item", {"Test Size": "Large"})


### PR DESCRIPTION
Problem
1. Currently, the system is missing validation for these two cases during updates:

2. It does not validate if the item selected in the "Variant Of" field is actually a template (allowing variants of variants).
It does not verify if the attributes on the item variant actually belong to the parent template.
Because these checks were previously gated behind is_new(), it leads to corrupted data when users update Data Import.

My Solution
1. Updated these structural checks to run unconditionally on every save.

2. Fixed the Data Import bypass by explicitly fetching the variant_based_on default if it arrives blank.

3. Added an ignore_variant_validation flag to allow developers to update corrupted data, in case they are not able to remove the incorrect attribute for some reason

Testing
- Added unit tests for all the changes I made



Fixes #54698 