### PR TITLE
fix(stock): update bin to zero when no previous sle exists

### DIFF
--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -556,6 +556,16 @@ class update_entries_after:
 		previous_sle = get_previous_sle_of_current_voucher(args)
 		if previous_sle:
 			self.prev_sle_dict[(args.get("item_code"), args.get("warehouse"))] = previous_sle
+		else:
+			self.prev_sle_dict[(args.get("item_code"), args.get("warehouse"))] = frappe._dict(
+				{
+					"qty_after_transaction": 0.0,
+					"valuation_rate": 0.0,
+					"stock_value": 0.0,
+					"prev_stock_value": 0.0,
+					"stock_queue": [],
+				}
+			)
 
 		warehouse_dict.previous_sle = previous_sle
 


### PR DESCRIPTION
**Issue:**
Bin is not getting updated if there is no non-cancelled stock ledger entries.

**Description:**
when **get_previous_sle_of_current_voucher** returns no result (i.e., the item-warehouse has no prior stock ledger entry), the key is never added to **prev_sle_dict**. Since update_bin only iterates over **prev_sle_dict**, the bin is never updated.

**Ref:** [#64701](https://support.frappe.io/helpdesk/tickets/64701)

**Backport Needed for v16**