### PR TITLE
refactor: boldface for group accounts in financial statements

### DIFF
--- a/erpnext/accounts/report/dimension_wise_accounts_balance_report/dimension_wise_accounts_balance_report.py
+++ b/erpnext/accounts/report/dimension_wise_accounts_balance_report/dimension_wise_accounts_balance_report.py
@@ -142,6 +142,7 @@ def prepare_data(accounts, filters, company_currency, dimension_list):
 		total = 0
 		row = {
 			"account": d.name,
+			"is_group": d.is_group,
 			"parent_account": d.parent_account,
 			"indent": d.indent,
 			"from_date": filters.from_date,

--- a/erpnext/public/js/financial_statements.js
+++ b/erpnext/public/js/financial_statements.js
@@ -230,7 +230,10 @@ erpnext.financial_statements = {
 
 		value = default_formatter(value, row, column, data);
 
-		if (data && !data.parent_account && !data.parent_section) {
+		if (
+			data &&
+			((!data.parent_account && !data.parent_section) || data.is_group_account || data.is_group)
+		) {
 			value = $(`<span>${value}</span>`);
 
 			var $value = $(value).css("font-weight", "bold");


### PR DESCRIPTION
Boldface group accounts in financial statements.
## Before
<img width="774" height="1297" alt="Screenshot from 2026-04-13 11-17-29" src="https://github.com/user-attachments/assets/688872c2-2441-4d87-8b86-ce24646c1de4" />
<img width="1404" height="1297" alt="Screenshot from 2026-04-13 11-17-19" src="https://github.com/user-attachments/assets/e0d0deed-59a2-41c3-a6ee-8345a4a48eba" />
## After
<img width="1404" height="1297" alt="Screenshot from 2026-04-13 11-17-10" src="https://github.com/user-attachments/assets/ddc7d7ce-9285-45ca-8230-2e7e3b26d078" />
<img width="841" height="1297" alt="Screenshot from 2026-04-13 11-11-33" src="https://github.com/user-attachments/assets/ab8bcb5c-22ee-4eef-a62a-c2b4dbf7271c" />
