### PR TITLE
fix: reset base_rounded_total when rounded_total resets

### DIFF
--- a/erpnext/controllers/taxes_and_totals.py
+++ b/erpnext/controllers/taxes_and_totals.py
@@ -781,18 +781,17 @@ class calculate_taxes_and_totals:
 		if self.doc.meta.get_field("rounded_total"):
 			if self.doc.is_rounded_total_disabled():
 				self.doc.rounded_total = 0
-				self.doc.base_rounded_total = 0
 				self.doc.rounding_adjustment = 0
-				return
 
-			self.doc.rounded_total = round_based_on_smallest_currency_fraction(
-				self.doc.grand_total, self.doc.currency, self.doc.precision("rounded_total")
-			)
+			else:
+				self.doc.rounded_total = round_based_on_smallest_currency_fraction(
+					self.doc.grand_total, self.doc.currency, self.doc.precision("rounded_total")
+				)
 
-			# rounding adjustment should always be the difference vetween grand and rounded total
-			self.doc.rounding_adjustment = flt(
-				self.doc.rounded_total - self.doc.grand_total, self.doc.precision("rounding_adjustment")
-			)
+				# rounding adjustment should always be the difference vetween grand and rounded total
+				self.doc.rounding_adjustment = flt(
+					self.doc.rounded_total - self.doc.grand_total, self.doc.precision("rounding_adjustment")
+				)
 
 			self._set_in_company_currency(self.doc, ["rounding_adjustment", "rounded_total"])
 

--- a/erpnext/controllers/taxes_and_totals.py
+++ b/erpnext/controllers/taxes_and_totals.py
@@ -788,7 +788,7 @@ class calculate_taxes_and_totals:
 					self.doc.grand_total, self.doc.currency, self.doc.precision("rounded_total")
 				)
 
-				# rounding adjustment should always be the difference vetween grand and rounded total
+				# rounding adjustment should always be the difference between grand and rounded total
 				self.doc.rounding_adjustment = flt(
 					self.doc.rounded_total - self.doc.grand_total, self.doc.precision("rounding_adjustment")
 				)

--- a/erpnext/controllers/tests/test_taxes_and_totals.py
+++ b/erpnext/controllers/tests/test_taxes_and_totals.py
@@ -29,3 +29,33 @@ class TestTaxesAndTotals(ERPNextTestSuite):
 			calculate_taxes_and_totals(so)
 
 		self.assertIn(test_account, frappe.flags.round_off_applicable_accounts)
+
+	def test_disabling_rounded_total_resets_base_fields(self):
+		"""Disabling rounded total should also clear base rounded values."""
+		so = make_sales_order(do_not_save=True)
+		so.items[0].qty = 1
+		so.items[0].rate = 1000.25
+		so.items[0].price_list_rate = 1000.25
+		so.items[0].discount_percentage = 0
+		so.items[0].discount_amount = 0
+		so.set("taxes", [])
+
+		so.disable_rounded_total = 0
+		calculate_taxes_and_totals(so)
+
+		self.assertEqual(so.grand_total, 1000.25)
+		self.assertEqual(so.rounded_total, 1000.0)
+		self.assertEqual(so.rounding_adjustment, -0.25)
+		self.assertEqual(so.base_grand_total, 1000.25)
+		self.assertEqual(so.base_rounded_total, 1000.0)
+		self.assertEqual(so.base_rounding_adjustment, -0.25)
+
+		# User toggles disable_rounded_total after values are already set.
+		so.disable_rounded_total = 1
+
+		calculate_taxes_and_totals(so)
+
+		self.assertEqual(so.rounded_total, 0)
+		self.assertEqual(so.rounding_adjustment, 0)
+		self.assertEqual(so.base_rounded_total, 0)
+		self.assertEqual(so.base_rounding_adjustment, 0)

--- a/erpnext/public/js/controllers/taxes_and_totals.js
+++ b/erpnext/public/js/controllers/taxes_and_totals.js
@@ -716,23 +716,21 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 			disable_rounded_total = frappe.sys_defaults.disable_rounded_total;
 		}
 
-		if (cint(disable_rounded_total)) {
-			this.frm.doc.rounded_total = 0;
-			this.frm.doc.base_rounded_total = 0;
-			this.frm.doc.rounding_adjustment = 0;
-			return;
-		}
-
 		if (frappe.meta.get_docfield(this.frm.doc.doctype, "rounded_total", this.frm.doc.name)) {
-			this.frm.doc.rounded_total = round_based_on_smallest_currency_fraction(
-				this.frm.doc.grand_total,
-				this.frm.doc.currency,
-				precision("rounded_total")
-			);
-			this.frm.doc.rounding_adjustment = flt(
-				this.frm.doc.rounded_total - this.frm.doc.grand_total,
-				precision("rounding_adjustment")
-			);
+			if (cint(disable_rounded_total)) {
+				this.frm.doc.rounded_total = 0;
+				this.frm.doc.rounding_adjustment = 0;
+			} else {
+				this.frm.doc.rounded_total = round_based_on_smallest_currency_fraction(
+					this.frm.doc.grand_total,
+					this.frm.doc.currency,
+					precision("rounded_total")
+				);
+				this.frm.doc.rounding_adjustment = flt(
+					this.frm.doc.rounded_total - this.frm.doc.grand_total,
+					precision("rounding_adjustment")
+				);
+			}
 
 			this.set_in_company_currency(this.frm.doc, ["rounding_adjustment", "rounded_total"]);
 		}


### PR DESCRIPTION
Issue: “base_rounding_adjustment” doesn’t become zero even if rounding is disabled later.


Steps to reproduce:
- Create an invoice with rounded total (make sure rounding adjustment is not zero)
- Disable rounded total (the field rounding_adjustment will have zero value now, but base_rounding_adjustment will still have the old value)


Frappe Support Issue: https://support.frappe.io/desk/hd-ticket/65194