### PR TITLE
fix: make operation mandatory when any sub operation row is added

### DIFF
--- a/erpnext/manufacturing/doctype/sub_operation/sub_operation.json
+++ b/erpnext/manufacturing/doctype/sub_operation/sub_operation.json
@@ -16,7 +16,8 @@
    "fieldtype": "Link",
    "in_list_view": 1,
    "label": "Operation",
-   "options": "Operation"
+   "options": "Operation",
+   "reqd": 1
   },
   {
    "default": "0",
@@ -40,7 +41,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-08-04 16:15:11.425349",
+ "modified": "2026-04-13 12:17:33.776504",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "Sub Operation",

--- a/erpnext/manufacturing/doctype/sub_operation/sub_operation.py
+++ b/erpnext/manufacturing/doctype/sub_operation/sub_operation.py
@@ -16,7 +16,7 @@ class SubOperation(Document):
 		from frappe.types import DF
 
 		description: DF.SmallText | None
-		operation: DF.Link | None
+		operation: DF.Link
 		parent: DF.Data
 		parentfield: DF.Data
 		parenttype: DF.Data


### PR DESCRIPTION
**Issue Ref**: [#54219](https://github.com/frappe/erpnext/issues/54219)

**Description**: Whenever any new sub-operation row is added in Operation, and the system allows us to save the operation without an operation name, leaving an empty row

**Solution**: Marked an operation field mandatory in the sub operation child table

<img width="896" height="357" alt="image" src="https://github.com/user-attachments/assets/03e11254-031f-4db6-ad39-78a504e73f8e" />
