### PR TITLE
fix: fetch item tax template from item group when creating item

### DIFF
--- a/erpnext/stock/doctype/item/item.py
+++ b/erpnext/stock/doctype/item/item.py
@@ -794,6 +794,19 @@ class Item(Document):
 					{"company": defaults.get("company"), "default_warehouse": defaults.default_warehouse},
 				)
 
+		if not self.taxes and item_group.taxes:
+			for tax in item_group.taxes:
+				self.append(
+					"taxes",
+					{
+						"item_tax_template": tax.item_tax_template,
+						"tax_category": tax.tax_category,
+						"valid_from": tax.valid_from,
+						"minimum_net_rate": tax.minimum_net_rate,
+						"maximum_net_rate": tax.maximum_net_rate,
+					},
+				)
+
 	def update_variants(self):
 		if self.flags.dont_update_variants or frappe.db.get_single_value(
 			"Item Variant Settings", "do_not_update_variants"


### PR DESCRIPTION
**Issue:** Item Tax Template Not Fetched from Item Group on Item Creation

**Ref :** [#65226](https://support.frappe.io/helpdesk/tickets/65226) 

**Steps to Reproduce:** 
1. Go to Item Group and open any existing Item Group
2. Under Item Tax table, add an Item Tax Template and save
3. Go to Item and create a new Item
4. Save the Item
5. See the tax template in Item Group if not fetched in new Item

**Before :** 

[Screencast from 13-04-26 05:38:53 PM IST.webm](https://github.com/user-attachments/assets/ee30d1a6-e728-4c16-bb86-55d452a7d207)

**After :**

[Screencast from 13-04-26 06:01:22 PM IST.webm](https://github.com/user-attachments/assets/e04c19cb-d876-49d3-93da-c19ab358bb86)

**Backport Needed For V16 and V15**
