### PR TITLE
fix(accounts): keep zero-net bank transactions with included fees unreconciled

### DIFF
--- a/erpnext/accounts/doctype/bank_reconciliation_tool/test_bank_reconciliation_tool.py
+++ b/erpnext/accounts/doctype/bank_reconciliation_tool/test_bank_reconciliation_tool.py
@@ -96,3 +96,32 @@ class TestBankReconciliationTool(ERPNextTestSuite, AccountsTestMixin):
 		# assert API output post reconciliation
 		transactions = get_bank_transactions(self.bank_account, from_date, to_date)
 		self.assertEqual(len(transactions), 0)
+
+	def test_zero_net_included_fee_remains_available_for_reconciliation(self):
+		from_date = add_days(today(), -1)
+		to_date = today()
+
+		bank_transaction = (
+			frappe.get_doc(
+				{
+					"doctype": "Bank Transaction",
+					"date": to_date,
+					"deposit": 0,
+					"withdrawal": 0,
+					"included_fee": 5,
+					"bank_account": self.bank_account,
+					"currency": "INR",
+				}
+			)
+			.save()
+			.submit()
+		)
+		bank_transaction.reload()
+
+		self.assertEqual(bank_transaction.status, "Unreconciled")
+		self.assertEqual(bank_transaction.unallocated_amount, 5)
+
+		transactions = get_bank_transactions(self.bank_account, from_date, to_date)
+		self.assertEqual(len(transactions), 1)
+		self.assertEqual(transactions[0].name, bank_transaction.name)
+		self.assertEqual(transactions[0].unallocated_amount, 5)

--- a/erpnext/accounts/doctype/bank_transaction/bank_transaction.py
+++ b/erpnext/accounts/doctype/bank_transaction/bank_transaction.py
@@ -106,10 +106,19 @@ class BankTransaction(Document):
 		allocated_amount = (
 			sum(p.allocated_amount for p in self.payment_entries) if self.payment_entries else 0.0
 		)
-		unallocated_amount = abs(flt(self.withdrawal) - flt(self.deposit)) - allocated_amount
+		unallocated_amount = self.get_reconciliation_amount() - allocated_amount
 
 		self.allocated_amount = flt(allocated_amount, self.precision("allocated_amount"))
 		self.unallocated_amount = flt(unallocated_amount, self.precision("unallocated_amount"))
+
+	def get_reconciliation_amount(self):
+		amount = abs(flt(self.withdrawal) - flt(self.deposit))
+
+		# A zero-net statement row with an included fee still needs manual reconciliation.
+		if amount == 0 and flt(self.included_fee) > 0:
+			return flt(self.included_fee)
+
+		return amount
 
 	def delink_old_payment_entries(self):
 		if self.flags.updating_linked_bank_transaction:

--- a/erpnext/accounts/doctype/bank_transaction/test_bank_transaction_fees.py
+++ b/erpnext/accounts/doctype/bank_transaction/test_bank_transaction_fees.py
@@ -34,6 +34,42 @@ class TestBankTransactionFees(ERPNextTestSuite):
 
 		bt.validate_included_fee()
 
+	def test_zero_net_included_fee_stays_unallocated(self):
+		"""A fee on a zero-net statement row still needs manual reconciliation."""
+		bt = frappe.new_doc("Bank Transaction")
+		bt.deposit = 0
+		bt.withdrawal = 0
+		bt.included_fee = 5
+
+		bt.update_allocated_amount()
+
+		self.assertEqual(bt.allocated_amount, 0)
+		self.assertEqual(bt.unallocated_amount, 5)
+
+	def test_zero_net_included_fee_reduces_with_allocations(self):
+		"""Manual allocations should reduce the fee-backed reconciliation amount."""
+		bt = frappe.new_doc("Bank Transaction")
+		bt.deposit = 0
+		bt.withdrawal = 0
+		bt.included_fee = 5
+		bt.append("payment_entries", {"allocated_amount": 2})
+
+		bt.update_allocated_amount()
+
+		self.assertEqual(bt.allocated_amount, 2)
+		self.assertEqual(bt.unallocated_amount, 3)
+
+	def test_included_fee_does_not_change_non_zero_net_reconciliation_amount(self):
+		"""A fee should not inflate the reconciliation amount when cash already moved."""
+		bt = frappe.new_doc("Bank Transaction")
+		bt.deposit = 10
+		bt.withdrawal = 0
+		bt.included_fee = 999
+
+		bt.update_allocated_amount()
+
+		self.assertEqual(bt.unallocated_amount, 10)
+
 	def test_excluded_fee_noop_when_zero(self):
 		"""When there is no excluded fee to apply, the amounts should remain
 		unchanged."""


### PR DESCRIPTION
When a **Bank Transaction** has `deposit = 0`, `withdrawal = 0`, and a positive `included_fee`, ERPNext currently computes `unallocated_amount` as `0` and marks the transaction as "Reconciled" on submit.

That is unsafe for zero-net fee rows because we cannot know at submit time whether the row is:
- a pure bank fee, or
- a customer receipt fully consumed by fees

In both cases, the safer behavior is to defer handling to reconciliation instead of silently treating the row as fully reconciled.

This change updates the reconciliation amount logic so that:
- zero-net transactions with a positive `included_fee` remain "Unreconciled"
- `unallocated_amount` reflects the fee amount in that special case
- those transactions continue to appear in the bank reconciliation flow
- non-zero net transactions keep their existing reconciliation behavior

## Tests

Added coverage for:
- zero-net transactions with `included_fee` staying unreconciled
- allocations reducing the fee-backed `unallocated_amount`
- non-zero net transactions remaining unaffected
- reconciliation tool visibility for zero-net fee transactions

@0xD0M1M0 FYI