### PR TITLE
refactor(company): don't force set service expense account on save

### DIFF
--- a/erpnext/accounts/doctype/repost_accounting_ledger/test_repost_accounting_ledger.py
+++ b/erpnext/accounts/doctype/repost_accounting_ledger/test_repost_accounting_ledger.py
@@ -203,6 +203,11 @@ class TestRepostAccountingLedger(ERPNextTestSuite):
 	def test_06_repost_purchase_receipt(self):
 		from erpnext.accounts.doctype.account.test_account import create_account
 
+		if not frappe.db.set_value("Company", "_Test Company", "service_expense_account"):
+			frappe.db.set_value(
+				"Company", "_Test Company", "service_expense_account", "Marketing Expenses - _TC"
+			)
+
 		provisional_account = create_account(
 			account_name="Provision Account",
 			parent_account="Current Liabilities - _TC",

--- a/erpnext/setup/doctype/company/company.py
+++ b/erpnext/setup/doctype/company/company.py
@@ -683,21 +683,6 @@ class Company(NestedSet):
 
 			self.db_set("disposal_account", disposal_acct)
 
-		if not self.service_expense_account:
-			service_expense_acct = frappe.db.get_value(
-				"Account",
-				{
-					"account_name": _("Marketing Expenses"),
-					"company": self.name,
-					"is_group": 0,
-					"root_type": "Expense",
-				},
-				"name",
-			)
-
-			if service_expense_acct:
-				self.db_set("service_expense_account", service_expense_acct)
-
 	def _set_default_account(self, fieldname, account_type):
 		if self.get(fieldname):
 			return


### PR DESCRIPTION
Service Expense Account is not mandatory and shouldn't be auto set on save.
ref: [65406](https://support.frappe.io/helpdesk/tickets/65406)