### PR TITLE
fix: banner to enable serial / batch feature

### DIFF
--- a/erpnext/stock/doctype/item/item.js
+++ b/erpnext/stock/doctype/item/item.js
@@ -87,16 +87,40 @@ frappe.ui.form.on("Item", {
 	toggle_has_serial_batch_fields(frm) {
 		let hide_fields = cint(frappe.user_defaults?.enable_serial_and_batch_no_for_item) === 0 ? 1 : 0;
 
-		frm.toggle_display(["serial_no_series", "batch_number_series", "create_new_batch"], !hide_fields);
+		frm.toggle_display(
+			[
+				"serial_no_series",
+				"batch_number_series",
+				"create_new_batch",
+				"has_expiry_date",
+				"retain_sample",
+			],
+			!hide_fields
+		);
 		frm.toggle_enable(["has_serial_no", "has_batch_no"], !hide_fields);
 
 		if (hide_fields) {
-			let description = __(
-				"To enable the Serial No and Batch No feature, please check the 'Enable Serial / Batch No for Item' checkbox in Stock Settings."
-			);
+			let header = frm.fields_dict["serial_nos_and_batches"].wrapper;
+			let wrapper = header.find(".section-head.collapsible");
 
-			frm.set_df_property("has_serial_no", "description", description);
-			frm.set_df_property("has_batch_no", "description", description);
+			render_serial_batch_banner(wrapper);
+
+			if (!wrapper.data("banner-handler-added")) {
+				wrapper.data("banner-handler-added", true);
+
+				wrapper.on("click", function () {
+					setTimeout(() => {
+						let isCollapsed = $(this).hasClass("collapsed");
+
+						wrapper.find(".custom-serial-batch-banner").toggleClass("hidden", isCollapsed);
+					}, 10);
+				});
+			}
+
+			// Button action
+			wrapper.find(".go-to-settings").on("click", function () {
+				frappe.set_route("Form", "Stock Settings");
+			});
 		}
 	},
 
@@ -371,6 +395,63 @@ var set_customer_group = function (frm, cdt, cdn) {
 	});
 	return true;
 };
+
+function render_serial_batch_banner(wrapper) {
+	let hiddenClass = "";
+	if (wrapper.hasClass("collapsed")) {
+		hiddenClass = "hidden";
+	}
+
+	wrapper.find(".custom-serial-batch-banner").remove();
+
+	let banner_html = `
+		<div class="custom-serial-batch-banner ${hiddenClass}">
+			<div class="banner-content">
+				<span class="banner-icon">${frappe.utils.icon("solid-warning", "lg", "", "padding-bottom:2px")}</span>
+				<span class="banner-text">
+					${__("To use Serial / Batch feature, enable {0} in {1}.", [
+						`<b>${__("Activate Serial / Batch No for Item")}</b>`,
+						`<a class="go-to-settings" style="text-decoration: underline;">${__(
+							"Stock Settings"
+						)}</a>`,
+					])}
+				</span>
+			</div>
+		</div>
+		<style>
+			.custom-serial-batch-banner {
+				background-color: var(--amber-50);
+				border: 1px solid var(--amber-50);
+				border-radius: 8px;
+				padding: 12px 16px;
+				margin-top: 16px;
+			}
+
+			.custom-serial-batch-banner .banner-content {
+				display: flex;
+				align-items: center;
+				gap: 12px;
+			}
+
+			.custom-serial-batch-banner .banner-icon {
+				font-size: 18px;
+			}
+
+			.custom-serial-batch-banner .banner-text {
+				flex: 1;
+				font-size: 14px;
+				color: var(--gray-800);
+			}
+
+			.custom-serial-batch-banner .btn {
+				white-space: nowrap;
+			}
+		</style>
+	`;
+
+	// Insert banner at top of section
+	wrapper.append(banner_html);
+}
 
 $.extend(erpnext.item, {
 	setup_queries: function (frm) {

--- a/erpnext/stock/doctype/item/item.json
+++ b/erpnext/stock/doctype/item/item.json
@@ -433,7 +433,7 @@
    "depends_on": "eval:doc.is_stock_item",
    "fieldname": "serial_nos_and_batches",
    "fieldtype": "Section Break",
-   "label": "Serial Nos and Batches"
+   "label": "Serial Nos / Batches"
   },
   {
    "default": "0",
@@ -995,7 +995,7 @@
  "image_field": "image",
  "links": [],
  "make_attachments_public": 1,
- "modified": "2026-03-24 15:45:40.207531",
+ "modified": "2026-04-14 13:37:00.183583",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Item",

--- a/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py
+++ b/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py
@@ -148,7 +148,7 @@ class SerialandBatchBundle(Document):
 		if not frappe.db.get_single_value("Stock Settings", "enable_serial_and_batch_no_for_item"):
 			frappe.throw(
 				_(
-					"Please check the 'Enable Serial and Batch No for Item' checkbox in the {0} to make Serial and Batch Bundle for the item."
+					"Please check the 'Activate Serial and Batch No for Item' checkbox in the {0} to make Serial and Batch Bundle for the item."
 				).format(get_link_to_form("Stock Settings", "Stock Settings")),
 				title=_("Serial and Batch No for Item Disabled"),
 			)

--- a/erpnext/stock/doctype/stock_settings/stock_settings.js
+++ b/erpnext/stock/doctype/stock_settings/stock_settings.js
@@ -15,6 +15,12 @@ frappe.ui.form.on("Stock Settings", {
 		frm.set_query("sample_retention_warehouse", filters);
 	},
 
+	enable_serial_and_batch_no_for_item(frm) {
+		if (frm.doc.enable_serial_and_batch_no_for_item) {
+			frappe.msgprint(__("After save, please refresh the page to apply the changes."));
+		}
+	},
+
 	use_serial_batch_fields(frm) {
 		if (frm.doc.use_serial_batch_fields && !frm.doc.disable_serial_no_and_batch_selector) {
 			frm.set_value("disable_serial_no_and_batch_selector", 1);

--- a/erpnext/stock/doctype/stock_settings/stock_settings.json
+++ b/erpnext/stock/doctype/stock_settings/stock_settings.json
@@ -528,18 +528,18 @@
    "label": "Allow Negative Stock for Batch"
   },
   {
+   "default": "0",
    "fieldname": "enable_serial_and_batch_no_for_item",
    "fieldtype": "Check",
-   "label": "Enable Serial / Batch No for Item"
+   "label": "Activate Serial / Batch No for Item"
   }
  ],
- "hide_toolbar": 0,
  "icon": "icon-cog",
  "idx": 1,
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2026-03-27 22:39:16.812184",
+ "modified": "2026-04-14 13:51:49.545114",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Stock Settings",


### PR DESCRIPTION
## **Before Change**

The same description was used for both serial / batch fields and not looking good.

<img width="959" height="144" alt="Screenshot 2026-04-14 at 2 01 54 PM" src="https://github.com/user-attachments/assets/af4d391a-3821-4883-8f75-06deba7c07a1" />


## **After Change**

<img width="956" height="180" alt="Screenshot 2026-04-14 at 5 51 25 PM" src="https://github.com/user-attachments/assets/4be49142-41f9-4f2d-8b1a-702d49698b34" />

