### PR TITLE
fix(stock): remove float precision to fix precision issue

### DIFF
--- a/erpnext/stock/report/batch_wise_balance_history/batch_wise_balance_history.py
+++ b/erpnext/stock/report/batch_wise_balance_history/batch_wise_balance_history.py
@@ -250,7 +250,7 @@ def get_item_warehouse_batch_map(filters, float_precision):
 				)
 
 		qty_dict.bal_qty = flt(qty_dict.bal_qty, float_precision) + flt(d.actual_qty, float_precision)
-		qty_dict.bal_value += flt(d.stock_value_difference, float_precision)
+		qty_dict.bal_value += flt(d.stock_value_difference)
 
 	return iwb_map
 


### PR DESCRIPTION
**Issue:**
When all stock of a batch is fully consumed, the Balance Qty correctly shows 0 but the Balance Value shows a small residual amount (e.g. -0.0001) instead of 0. This happens because the report computes the Balance Value by accumulating many small rounded figures across multiple transactions, and the tiny rounding differences in each transaction add up to a small non-zero total.

**Ref:** [#64780](https://support.frappe.io/helpdesk/tickets/64780)

**Backport Needed for v15 & v16**