### PR TITLE
fix: non-collapsible in customer quick entry

### DIFF
--- a/erpnext/public/js/utils/contact_address_quick_entry.js
+++ b/erpnext/public/js/utils/contact_address_quick_entry.js
@@ -39,7 +39,7 @@ frappe.ui.form.ContactAddressQuickEntryForm = class ContactAddressQuickEntryForm
 			{
 				fieldtype: "Section Break",
 				label: __("Primary Contact Details"),
-				collapsible: 1,
+				collapsible: 0,
 			},
 			{
 				label: __("First Name"),
@@ -71,7 +71,7 @@ frappe.ui.form.ContactAddressQuickEntryForm = class ContactAddressQuickEntryForm
 			{
 				fieldtype: "Section Break",
 				label: __("Primary Address Details"),
-				collapsible: 1,
+				collapsible: 0,
 			},
 			{
 				label: __("Address Line 1"),


### PR DESCRIPTION
Issue:
When creating Customer or Supplier via Quick Entry, the Address and Contact sections are collapsed by default, causing users to miss entering essential details during onboarding.

Fixes:#54053

Before:
<img width="1719" height="921" alt="Screenshot from 2026-04-15 16-49-42" src="https://github.com/user-attachments/assets/85f55c5a-573c-4b8a-8095-59deb27b5542" />

After:
<img width="1719" height="921" alt="Screenshot from 2026-04-15 16-49-24" src="https://github.com/user-attachments/assets/bb7e22ea-9d8f-4e9b-b3cd-c2a0f243ff6a" />


Backport needed v15, v16