### PR TITLE
feat: add auto advance payment allocation settings for buying and sel…

### DIFF
--- a/erpnext/buying/doctype/buying_settings/buying_settings.json
+++ b/erpnext/buying/doctype/buying_settings/buying_settings.json
@@ -33,6 +33,8 @@
   "disable_last_purchase_rate",
   "show_pay_button",
   "allow_zero_qty_in_purchase_order",
+  "auto_allocate_advance_payment",
+  "fetch_only_allocated_advance_payment",
   "subcontract",
   "backflush_raw_materials_of_subcontract_based_on",
   "column_break_11",
@@ -283,19 +285,27 @@
   },
   {
    "default": "0",
-   "fieldname": "allow_negative_rates_for_items",
+   "description": "Automatically fetches and allocates available advance payments when creating an Purchase invoice from a Purchase Order/Purchase Receipt",
+   "fieldname": "auto_allocate_advance_payment",
    "fieldtype": "Check",
-   "label": "Allow Negative rates for Items"
+   "label": "Auto Allocate Advance Payment"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:doc.auto_allocate_advance_payment==1",
+   "description": "Retrieves advance payments that have been allocated to Purchase Order, excluding unallocated payments.",
+   "fieldname": "fetch_only_allocated_advance_payment",
+   "fieldtype": "Check",
+   "label": "Fetch Only Allocated Advance Payment"
   }
  ],
  "grid_page_length": 50,
- "hide_toolbar": 0,
  "icon": "fa fa-cog",
  "idx": 1,
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2026-04-15 16:07:35.484787",
+ "modified": "2026-04-16 16:51:16.270301",
  "modified_by": "Administrator",
  "module": "Buying",
  "name": "Buying Settings",
@@ -313,7 +323,6 @@
   {
    "create": 1,
    "email": 1,
-   "export": 1,
    "print": 1,
    "read": 1,
    "role": "Purchase Manager",

--- a/erpnext/buying/doctype/buying_settings/buying_settings.py
+++ b/erpnext/buying/doctype/buying_settings/buying_settings.py
@@ -22,6 +22,7 @@ class BuyingSettings(Document):
 		allow_zero_qty_in_purchase_order: DF.Check
 		allow_zero_qty_in_request_for_quotation: DF.Check
 		allow_zero_qty_in_supplier_quotation: DF.Check
+		auto_allocate_advance_payment: DF.Check
 		auto_create_purchase_receipt: DF.Check
 		auto_create_subcontracting_order: DF.Check
 		backflush_raw_materials_of_subcontract_based_on: DF.Literal[
@@ -31,6 +32,7 @@ class BuyingSettings(Document):
 		blanket_order_allowance: DF.Float
 		buying_price_list: DF.Link | None
 		disable_last_purchase_rate: DF.Check
+		fetch_only_allocated_advance_payment: DF.Check
 		fixed_email: DF.Link | None
 		maintain_same_rate: DF.Check
 		maintain_same_rate_action: DF.Literal["Stop", "Warn"]

--- a/erpnext/buying/doctype/purchase_order/purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.py
@@ -802,6 +802,11 @@ def get_mapped_purchase_invoice(source_name, target_doc=None, ignore_permissions
 		set_missing_values(source, target)
 
 		# Get the advance paid Journal Entries in Purchase Invoice Advance
+		advance, allocated = frappe.db.get_value(
+			"Buying Settings", None, ["auto_allocate_advance_payment", "fetch_only_allocated_advance_payment"]
+		)
+		target.allocate_advances_automatically = advance
+		target.only_include_allocated_payments = allocated
 		if target.get("allocate_advances_automatically"):
 			target.set_advances()
 

--- a/erpnext/buying/doctype/purchase_order/test_purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/test_purchase_order.py
@@ -767,8 +767,6 @@ class TestPurchaseOrder(ERPNextTestSuite):
 		"Accounts Settings", {"unlink_advance_payment_on_cancelation_of_order": 1}
 	)
 	def test_advance_payment_entry_unlink_against_purchase_order(self):
-		from erpnext.accounts.doctype.payment_entry.test_payment_entry import get_payment_entry
-
 		po_doc = create_purchase_order()
 
 		pe = get_payment_entry("Purchase Order", po_doc.name, bank_account="_Test Bank - _TC")
@@ -823,8 +821,6 @@ class TestPurchaseOrder(ERPNextTestSuite):
 		company_doc.save()
 
 		po_doc = create_purchase_order(supplier=supplier)
-
-		from erpnext.accounts.doctype.payment_entry.test_payment_entry import get_payment_entry
 
 		pe = get_payment_entry("Purchase Order", po_doc.name)
 		pe.save().submit()
@@ -1206,7 +1202,7 @@ class TestPurchaseOrder(ERPNextTestSuite):
 
 	def test_purchase_order_advance_payment_status(self):
 		frappe.flags.is_reverse_depr_entry = False
-		from erpnext.accounts.doctype.payment_entry.test_payment_entry import get_payment_entry
+
 		from erpnext.accounts.doctype.payment_request.payment_request import make_payment_request
 
 		po = create_purchase_order()
@@ -1435,6 +1431,61 @@ class TestPurchaseOrder(ERPNextTestSuite):
 
 		pi2 = make_pi_from_po(po.name)
 		self.assertEqual(len(pi2.items), 2)
+
+	@ERPNextTestSuite.change_settings(
+		"Buying Settings", {"auto_allocate_advance_payment": 1, "fetch_only_allocated_advance_payment": 0}
+	)
+	def test_auto_allocate_advance_payment_from_purchase_order(self):
+		from erpnext.buying.doctype.purchase_order.purchase_order import make_purchase_invoice
+
+		po = create_purchase_order(rate=1000)
+
+		pe1 = get_payment_entry("Purchase Order", po.name)
+
+		pe1.paid_amount = 500
+		pe1.received_amount = 500
+		pe1.references[0].allocated_amount = 500
+		pe1.insert().submit()
+
+		pe2 = get_payment_entry("Purchase Order", po.name)
+		pe2.paid_amount = 100
+		pe2.received_amount = 100
+		pe2.references = []
+		pe2.insert().submit()
+
+		pi = make_purchase_invoice(po.name)
+
+		references = [d.reference_name for d in pi.advances]
+
+		self.assertIn(pe1.name, references)
+		self.assertIn(pe2.name, references)
+
+	@ERPNextTestSuite.change_settings(
+		"Buying Settings", {"auto_allocate_advance_payment": 1, "fetch_only_allocated_advance_payment": 1}
+	)
+	def test_auto_allocate_fetches_only_allocated_advances(self):
+		from erpnext.buying.doctype.purchase_order.purchase_order import make_purchase_invoice
+
+		po = create_purchase_order(rate=1000)
+
+		pe1 = get_payment_entry("Purchase Order", po.name)
+		pe1.paid_amount = 500
+		pe1.received_amount = 500
+		pe1.references[0].allocated_amount = 500
+		pe1.insert().submit()
+
+		pe2 = get_payment_entry("Purchase Order", po.name)
+		pe2.paid_amount = 100
+		pe2.received_amount = 100
+		pe2.references = []
+		pe2.insert().submit()
+
+		pi = make_purchase_invoice(po.name)
+
+		references = [d.reference_name for d in pi.advances]
+
+		self.assertIn(pe1.name, references)
+		self.assertNotIn(pe2.name, references)
 
 
 def create_po_for_sc_testing():

--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -1348,6 +1348,13 @@ def make_sales_invoice(
 	def postprocess(source, target):
 		set_missing_values(source, target)
 		# Get the advance paid Journal Entries in Sales Invoice Advance
+		advance, allocated = frappe.db.get_value(
+			"Selling Settings",
+			None,
+			["auto_allocate_advance_payment", "fetch_only_allocated_advance_payment"],
+		)
+		target.allocate_advances_automatically = advance
+		target.only_include_allocated_payments = allocated
 		if target.get("allocate_advances_automatically"):
 			target.set_advances()
 

--- a/erpnext/selling/doctype/sales_order/test_sales_order.py
+++ b/erpnext/selling/doctype/sales_order/test_sales_order.py
@@ -2757,6 +2757,59 @@ class TestSalesOrder(ERPNextTestSuite):
 		so = make_sales_order(item_code=fg_item, qty=10, rate=50, warehouse=fg_warehouse, do_not_save=1)
 		self.assertRaises(frappe.ValidationError, so.save)
 
+	@ERPNextTestSuite.change_settings(
+		"Selling Settings", {"auto_allocate_advance_payment": 1, "fetch_only_allocated_advance_payment": 0}
+	)
+	def test_auto_allocate_advance_payment_from_sales_order(self):
+		from erpnext.accounts.doctype.payment_entry.test_payment_entry import get_payment_entry
+
+		so = make_sales_order(rate=1000)
+
+		pe1 = get_payment_entry("Sales Order", so.name)
+		pe1.paid_amount = 500
+		pe1.received_amount = 500
+		pe1.references[0].allocated_amount = 500
+		pe1.insert().submit()
+
+		pe2 = get_payment_entry("Sales Order", so.name)
+		pe2.paid_amount = 100
+		pe2.received_amount = 100
+		pe2.references = []
+		pe2.insert().submit()
+
+		si = make_sales_invoice(so.name)
+
+		references = [d.reference_name for d in si.advances]
+
+		self.assertIn(pe1.name, references)
+		self.assertIn(pe2.name, references)
+
+	@ERPNextTestSuite.change_settings(
+		"Selling Settings", {"auto_allocate_advance_payment": 1, "fetch_only_allocated_advance_payment": 1}
+	)
+	def test_auto_allocate_fetches_only_allocated_advances(self):
+		from erpnext.accounts.doctype.payment_entry.test_payment_entry import get_payment_entry
+
+		so = make_sales_order(rate=1000)
+
+		pe1 = get_payment_entry("Sales Order", so.name)
+		pe1.paid_amount = 500
+		pe1.received_amount = 500
+		pe1.references[0].allocated_amount = 500
+		pe1.insert().submit()
+
+		pe2 = get_payment_entry("Sales Order", so.name)
+		pe2.paid_amount = 100
+		pe2.received_amount = 100
+		pe2.references = []
+		pe2.insert().submit()
+
+		si = make_sales_invoice(so.name)
+		references = [d.reference_name for d in si.advances]
+
+		self.assertIn(pe1.name, references)
+		self.assertNotIn(pe2.name, references)
+
 
 def compare_payment_schedules(doc, doc1, doc2):
 	for index, schedule in enumerate(doc1.get("payment_schedule")):

--- a/erpnext/selling/doctype/selling_settings/selling_settings.json
+++ b/erpnext/selling/doctype/selling_settings/selling_settings.json
@@ -41,6 +41,8 @@
   "allow_zero_qty_in_quotation",
   "allow_zero_qty_in_sales_order",
   "set_zero_rate_for_expired_batch",
+  "auto_allocate_advance_payment",
+  "fetch_only_allocated_advance_payment",
   "section_break_avhb",
   "enable_utm",
   "experimental_section",
@@ -320,16 +322,30 @@
    "fieldname": "deliver_secondary_items",
    "fieldtype": "Check",
    "label": "Deliver Secondary Items"
+  },
+  {
+   "default": "0",
+   "description": "Automatically fetches and allocates available advance payments when creating an Sales invoice from a Sales Order/Delivery Note",
+   "fieldname": "auto_allocate_advance_payment",
+   "fieldtype": "Check",
+   "label": "Auto Allocate Advance Payment"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:doc.auto_allocate_advance_payment==1",
+   "description": "Retrieves advance payments that have been allocated to Sales Order, excluding unallocated payments.",
+   "fieldname": "fetch_only_allocated_advance_payment",
+   "fieldtype": "Check",
+   "label": "Fetch Only Allocated Advance Payment"
   }
  ],
  "grid_page_length": 50,
- "hide_toolbar": 0,
  "icon": "fa fa-cog",
  "idx": 1,
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2026-03-16 13:28:18.988883",
+ "modified": "2026-04-16 16:51:53.201084",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Selling Settings",

--- a/erpnext/selling/doctype/selling_settings/selling_settings.py
+++ b/erpnext/selling/doctype/selling_settings/selling_settings.py
@@ -38,6 +38,7 @@ class SellingSettings(Document):
 		allow_sales_order_creation_for_expired_quotation: DF.Check
 		allow_zero_qty_in_quotation: DF.Check
 		allow_zero_qty_in_sales_order: DF.Check
+		auto_allocate_advance_payment: DF.Check
 		blanket_order_allowance: DF.Float
 		cust_master_name: DF.Literal["Customer Name", "Naming Series", "Auto Name"]
 		customer_group: DF.Link | None
@@ -51,6 +52,7 @@ class SellingSettings(Document):
 		enable_tracking_sales_commissions: DF.Check
 		enable_utm: DF.Check
 		fallback_to_default_price_list: DF.Check
+		fetch_only_allocated_advance_payment: DF.Check
 		hide_tax_id: DF.Check
 		maintain_same_rate_action: DF.Literal["Stop", "Warn"]
 		maintain_same_sales_rate: DF.Check

--- a/erpnext/stock/doctype/delivery_note/delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.py
@@ -888,6 +888,16 @@ def make_sales_invoice(
 		if target.company_address:
 			target.update(get_fetch_values("Sales Invoice", "company_address", target.company_address))
 
+		advance, allocated = frappe.db.get_value(
+			"Selling Settings",
+			None,
+			["auto_allocate_advance_payment", "fetch_only_allocated_advance_payment"],
+		)
+		target.allocate_advances_automatically = advance
+		target.only_include_allocated_payments = allocated
+		if target.get("allocate_advances_automatically"):
+			target.set_advances()
+
 	def update_item(source_doc, target_doc, source_parent):
 		target_doc.qty = to_make_invoice_qty_map[source_doc.name]
 		target_doc._old_name = source_doc.name

--- a/erpnext/stock/doctype/delivery_note/test_delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/test_delivery_note.py
@@ -2882,6 +2882,67 @@ class TestDeliveryNote(ERPNextTestSuite):
 		dn.items[0].stock_qty = 2
 		dn.save()
 
+	@ERPNextTestSuite.change_settings(
+		"Selling Settings", {"auto_allocate_advance_payment": 1, "fetch_only_allocated_advance_payment": 0}
+	)
+	def test_auto_allocate_advance_payment_from_sales_order(self):
+		from erpnext.accounts.doctype.payment_entry.test_payment_entry import get_payment_entry
+		from erpnext.selling.doctype.sales_order.sales_order import make_delivery_note
+
+		so = make_sales_order(rate=1000)
+
+		pe1 = get_payment_entry("Sales Order", so.name)
+		pe1.paid_amount = 500
+		pe1.received_amount = 500
+		pe1.references[0].allocated_amount = 500
+		pe1.insert().submit()
+
+		pe2 = get_payment_entry("Sales Order", so.name)
+		pe2.paid_amount = 100
+		pe2.received_amount = 100
+		pe2.references = []
+		pe2.insert().submit()
+
+		dn = make_delivery_note(so.name)
+		dn.insert().submit()
+		si = make_sales_invoice(dn.name)
+
+		references = [d.reference_name for d in si.advances]
+
+		self.assertIn(pe1.name, references)
+		self.assertIn(pe2.name, references)
+
+	@ERPNextTestSuite.change_settings(
+		"Selling Settings", {"auto_allocate_advance_payment": 1, "fetch_only_allocated_advance_payment": 1}
+	)
+	def test_auto_allocate_fetches_only_allocated_advances(self):
+		from erpnext.accounts.doctype.payment_entry.test_payment_entry import get_payment_entry
+		from erpnext.selling.doctype.sales_order.sales_order import make_delivery_note
+
+		so = make_sales_order(rate=1000)
+
+		pe1 = get_payment_entry("Sales Order", so.name)
+		pe1.paid_amount = 500
+		pe1.received_amount = 500
+		pe1.references[0].allocated_amount = 500
+		pe1.insert().submit()
+
+		pe2 = get_payment_entry("Sales Order", so.name)
+		pe2.paid_amount = 100
+		pe2.received_amount = 100
+		pe2.references = []
+		pe2.insert().submit()
+
+		dn = make_delivery_note(so.name)
+		dn.insert().submit()
+
+		si = make_sales_invoice(dn.name)
+
+		references = [d.reference_name for d in si.advances]
+
+		self.assertIn(pe1.name, references)
+		self.assertNotIn(pe2.name, references)
+
 
 def create_delivery_note(**args):
 	dn = frappe.new_doc("Delivery Note")

--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
@@ -1501,6 +1501,14 @@ def make_purchase_invoice(
 		doc.run_method("calculate_taxes_and_totals")
 		doc.set_payment_schedule()
 
+		advance, allocated = frappe.db.get_value(
+			"Buying Settings", None, ["auto_allocate_advance_payment", "fetch_only_allocated_advance_payment"]
+		)
+		target.allocate_advances_automatically = advance
+		target.only_include_allocated_payments = allocated
+		if target.get("allocate_advances_automatically"):
+			target.set_advances()
+
 	def update_item(source_doc, target_doc, source_parent):
 		target_doc.qty, returned_qty = get_pending_qty(source_doc)
 		if frappe.db.get_single_value("Buying Settings", "bill_for_rejected_quantity_in_purchase_invoice"):

--- a/erpnext/stock/doctype/purchase_receipt/test_purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/test_purchase_receipt.py
@@ -5510,6 +5510,70 @@ class TestPurchaseReceipt(ERPNextTestSuite):
 			"Buying Settings", "set_landed_cost_based_on_purchase_invoice_rate", original_value
 		)
 
+	@ERPNextTestSuite.change_settings(
+		"Buying Settings", {"auto_allocate_advance_payment": 1, "fetch_only_allocated_advance_payment": 0}
+	)
+	def test_auto_allocate_advance_payment_from_purchase_order(self):
+		from erpnext.accounts.doctype.payment_entry.payment_entry import get_payment_entry
+		from erpnext.buying.doctype.purchase_order.purchase_order import make_purchase_receipt
+		from erpnext.buying.doctype.purchase_order.test_purchase_order import create_purchase_order
+
+		po = create_purchase_order(rate=1000)
+
+		pe1 = get_payment_entry("Purchase Order", po.name)
+		pe1.paid_amount = 500
+		pe1.received_amount = 500
+		pe1.references[0].allocated_amount = 500
+		pe1.insert().submit()
+
+		pe2 = get_payment_entry("Purchase Order", po.name)
+		pe2.paid_amount = 100
+		pe2.received_amount = 100
+		pe2.references = []
+		pe2.insert().submit()
+
+		pr = make_purchase_receipt(po.name)
+		pr.insert().submit()
+
+		pi = make_purchase_invoice(pr.name)
+
+		references = [d.reference_name for d in pi.advances]
+
+		self.assertIn(pe1.name, references)
+		self.assertIn(pe2.name, references)
+
+	@ERPNextTestSuite.change_settings(
+		"Buying Settings", {"auto_allocate_advance_payment": 1, "fetch_only_allocated_advance_payment": 1}
+	)
+	def test_auto_allocate_fetches_only_allocated_advances(self):
+		from erpnext.accounts.doctype.payment_entry.payment_entry import get_payment_entry
+		from erpnext.buying.doctype.purchase_order.purchase_order import make_purchase_receipt
+		from erpnext.buying.doctype.purchase_order.test_purchase_order import create_purchase_order
+
+		po = create_purchase_order(rate=1000)
+
+		pe1 = get_payment_entry("Purchase Order", po.name)
+		pe1.paid_amount = 500
+		pe1.received_amount = 500
+		pe1.references[0].allocated_amount = 500
+		pe1.insert().submit()
+
+		pe2 = get_payment_entry("Purchase Order", po.name)
+		pe2.paid_amount = 100
+		pe2.received_amount = 100
+		pe2.references = []
+		pe2.insert().submit()
+
+		pr = make_purchase_receipt(po.name)
+		pr.insert().submit()
+
+		pi = make_purchase_invoice(pr.name)
+
+		references = [d.reference_name for d in pi.advances]
+
+		self.assertIn(pe1.name, references)
+		self.assertNotIn(pe2.name, references)
+
 
 def prepare_data_for_internal_transfer():
 	from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_internal_supplier


### PR DESCRIPTION
**Issue :** Advance payment against SO/PO is not auto-allocated to invoice

**Ref :** [52237](https://github.com/frappe/erpnext/issues/52237)

**Fix :**  Added settings in Buying and Selling Settings to auto allocate advance payments and fetch only allocated payments while creating Purchase Invoice / Sales Invoice from PO / SO or DN / PR

**Solution :** Implemented auto advance payment allocation in invoice creation for the following flows:

1) Sales Order → Sales Invoice
Advances are automatically fetched and allocated while creating a Sales Invoice from a Sales Order.

2) Delivery Note → Sales Invoice
Advances are automatically fetched and allocated while creating a Sales Invoice from a Delivery Note.

3) Purchase Order → Purchase Invoice
Advances are automatically fetched and allocated while creating a Purchase Invoice from a Purchase Order.

4) Purchase Receipt → Purchase Invoice
Advances are automatically fetched and allocated while creating a Purchase Invoice from a Purchase Receipt.

Before : 

[Before.webm](https://github.com/user-attachments/assets/cba8f714-fc23-4379-8b6b-ea6a2714446e)

After : 

[After.webm](https://github.com/user-attachments/assets/94358f96-972c-491d-a758-eea39be56575)

**Backport needed: v16**


