### PR TITLE
fix(dashboard-trends): set default fiscal year and company before val…

### DIFF
--- a/erpnext/controllers/trends.py
+++ b/erpnext/controllers/trends.py
@@ -5,7 +5,9 @@
 import frappe
 from frappe import _
 from frappe.utils import DateTimeLikeObject, getdate, today
+
 from erpnext.accounts.utils import get_fiscal_year
+
 
 def get_columns(filters, trans):
 	validate_filters(filters)
@@ -46,9 +48,9 @@ def get_columns(filters, trans):
 
 def validate_filters(filters):
 	if not filters.get("fiscal_year"):
-		filters.setdefault("fiscal_year", get_fiscal_year(today())[0])
+		filters["fiscal_year"] = get_fiscal_year(today())[0]
 	if not filters.get("company"):
-		filters.setdefault("company", frappe.db.get_default("company"))
+		filters["company"] = frappe.db.get_default("company")
 	for f in ["Fiscal Year", "Based On", "Period", "Company"]:
 		if not filters.get(f.lower().replace(" ", "_")):
 			frappe.throw(_("{0} is mandatory").format(_(f)))

--- a/erpnext/controllers/trends.py
+++ b/erpnext/controllers/trends.py
@@ -50,7 +50,7 @@ def validate_filters(filters):
 	if not filters.get("fiscal_year"):
 		filters["fiscal_year"] = get_fiscal_year(today())[0]
 	if not filters.get("company"):
-		filters["company"] = frappe.db.get_default("company")
+		filters["company"] = frappe.defaults.get_user_default("Company")
 	for f in ["Fiscal Year", "Based On", "Period", "Company"]:
 		if not filters.get(f.lower().replace(" ", "_")):
 			frappe.throw(_("{0} is mandatory").format(_(f)))

--- a/erpnext/controllers/trends.py
+++ b/erpnext/controllers/trends.py
@@ -4,8 +4,8 @@
 
 import frappe
 from frappe import _
-from frappe.utils import DateTimeLikeObject, getdate
-
+from frappe.utils import DateTimeLikeObject, getdate, today
+from erpnext.accounts.utils import get_fiscal_year
 
 def get_columns(filters, trans):
 	validate_filters(filters)
@@ -45,6 +45,10 @@ def get_columns(filters, trans):
 
 
 def validate_filters(filters):
+	if not filters.get("fiscal_year"):
+		filters.setdefault("fiscal_year", get_fiscal_year(today())[0])
+	if not filters.get("company"):
+		filters.setdefault("company", frappe.db.get_default("company"))
 	for f in ["Fiscal Year", "Based On", "Period", "Company"]:
 		if not filters.get(f.lower().replace(" ", "_")):
 			frappe.throw(_("{0} is mandatory").format(_(f)))


### PR DESCRIPTION
Fix trends report filter validation by setting default fiscal year and company

Added fallback for fiscal_year using current fiscal year based on today’s date.
Added fallback for company using system default company.
Kept strict validation for required filters (Fiscal Year, Based On, Period, Company).