### PR TITLE
fix(manufacturing): handle empty list in query builder

### DIFF
--- a/erpnext/manufacturing/report/material_requirements_planning_report/material_requirements_planning_report.py
+++ b/erpnext/manufacturing/report/material_requirements_planning_report/material_requirements_planning_report.py
@@ -77,9 +77,11 @@ class MaterialRequirementsPlanningReport:
 				(so.docstatus == 1)
 				& (so.status.notin(["Closed", "Completed", "Stopped"]))
 				& (so_item.docstatus == 1)
-				& (so_item.item_code.isin(items))
 			)
 		)
+
+		if items:
+			query = query.where(so_item.item_code.isin(items))
 
 		if self.filters.get("warehouse"):
 			warehouses = [self.filters.get("warehouse")]


### PR DESCRIPTION
**Issue:** The Material Requirements Planning Report throws an SQL error when an empty list is passed to the Query Builder filter.

**Ref :** [#65791](https://support.frappe.io/helpdesk/tickets/65791)

Before : 

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/5ce90409-d6c6-436f-942b-98204e6d86a0" />


After : 

[Screencast from 17-04-26 06:36:33 PM IST.webm](https://github.com/user-attachments/assets/0dbe4184-7007-4e0e-9147-163e3027cb61)

**Backport Needed For V16**