### PR TITLE
fix: serno recursion limit

### DIFF
--- a/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py
+++ b/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py
@@ -3284,10 +3284,12 @@ def get_stock_ledgers_for_serial_nos(kwargs):
 		bundle_match = serial_batch_entry.serial_no.isin(serial_nos)
 
 		padded_serial_no = Concat_ws("", "\n", stock_ledger_entry.serial_no, "\n")
-		direct_match = None
-		for sn in serial_nos:
-			cond = Locate(f"\n{sn}\n", padded_serial_no) > 0
-			direct_match = cond if direct_match is None else (direct_match | cond)
+		conds = [Locate(f"\n{sn}\n", padded_serial_no) > 0 for sn in serial_nos]
+		while len(conds) > 1:
+			conds = [
+				conds[i] | conds[i + 1] if i + 1 < len(conds) else conds[i] for i in range(0, len(conds), 2)
+			]
+		direct_match = conds[0] if conds else None
 
 		query = query.where(bundle_match | direct_match)
 


### PR DESCRIPTION
For branches develop, version-16

For 1000 serials, tree depth drops from 1000 → 10, well under Python's default 1000-frame limit. Query semantics are identical (OR is associative/commutative).

The per-serial direct_match was built as a left-skewed a | b | c | ... chain. pypika's nodes_() walks the resulting syntax tree recursively, so validating the WHERE clause with >~900 serials raises RecursionError. Reducing the conditions pairwise produces an O(log N)-depth tree with identical semantics.

closes #54364


