### PR TITLE
fix: workstation type change does not update operating components cost

### DIFF
--- a/erpnext/manufacturing/doctype/workstation/workstation.py
+++ b/erpnext/manufacturing/doctype/workstation/workstation.py
@@ -115,9 +115,7 @@ class Workstation(Document):
 
 	@frappe.whitelist()
 	def set_data_based_on_workstation_type(self):
-		if self.workstation_costs:
-			return
-
+		self.workstation_costs = []
 		if self.workstation_type:
 			data = frappe.get_all(
 				"Workstation Cost",

--- a/erpnext/manufacturing/doctype/workstation/workstation.py
+++ b/erpnext/manufacturing/doctype/workstation/workstation.py
@@ -115,6 +115,12 @@ class Workstation(Document):
 
 	@frappe.whitelist()
 	def set_data_based_on_workstation_type(self):
+		if not self.workstation_type:
+			return
+
+		old_type = self.get_doc_before_save() and self.get_doc_before_save().get("workstation_type")
+		if old_type == self.workstation_type and self.workstation_costs:
+			return
 		self.workstation_costs = []
 		if self.workstation_type:
 			data = frappe.get_all(


### PR DESCRIPTION

## Problem

When a Workstation Type is selected or changed on the Workstation form, the Operating Components Cost table does not refresh correctly. Instead of replacing existing rows, new rows are appended on top — resulting in duplicate entries.

## Root Cause

Two issues working together:

1. `set_data_based_on_workstation_type()` had an early return:
   if self.workstation_costs:
       return
   This prevented any update when costs already existed.

2. `before_save()` was calling `set_data_based_on_workstation_type()`
   again — causing a second append on top of what the JS trigger
   had already added.

## Fix

**workstation.py — set_data_based_on_workstation_type()**
- Removed early return condition
- Used self.set("workstation_costs", []) to clear old rows before appending 

https://github.com/user-attachments/assets/67eea5fa-16e0-4288-b22d-4d6dba13f32f

#54370

