### PR TITLE
fix: Workstation hour rate not updating when workstation type changes

### DIFF
--- a/erpnext/manufacturing/doctype/workstation/workstation.py
+++ b/erpnext/manufacturing/doctype/workstation/workstation.py
@@ -120,8 +120,9 @@ class Workstation(Document):
 				return
 
 			for field in fields:
-				if self.get(field):
-					continue
+				# if self.get(field):
+				# 	continue
+				
 
 				if value := data.get(field):
 					self.set(field, value)


### PR DESCRIPTION
  Issue
When a Workstation Type is changed in a Workstation, the operating cost (hour rate) does not update. It continues to show the value from the previously assigned Workstation Type.
 Root Cause
In the function `set_data_based_on_workstation_type`, fields are only set if they are empty:

This prevents updating values when the Workstation Type is changed.

# Fix
Removed the condition so that values are always updated from the selected Workstation Type.

# Impact
- Ensures correct operating cost calculation
- Prevents stale data when changing Workstation Type

# Steps to Reproduce
1. Create Workstation Type A with hour rate = 100
2. Assign it to a Workstation → value is correct
3. Change to Workstation Type B with hour rate = 200
4. Before fix → hour rate remains 100 
5. After fix → hour rate updates to 200 
