### PR TITLE
Fix:fixed issues in quality module#54073

### DIFF
--- a/erpnext/stock/doctype/quality_inspection/quality_inspection.js
+++ b/erpnext/stock/doctype/quality_inspection/quality_inspection.js
@@ -1,7 +1,7 @@
 // Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 // License: GNU General Public License v3. See license.txt
 
-cur_frm.cscript.refresh = cur_frm.cscript.inspection_type;
+// cur_frm.cscript.refresh = cur_frm.cscript.inspection_type;
 
 frappe.ui.form.on("Quality Inspection", {
 	onload(frm) {
@@ -75,6 +75,9 @@ frappe.ui.form.on("Quality Inspection", {
 	refresh: function (frm) {
 		// Ignore cancellation of reference doctype on cancel all.
 		frm.ignore_doctypes_on_cancel_all = [frm.doc.reference_type, "Serial and Batch Bundle"];
+		if (frm.doc.inspection_type) {
+			frm.trigger("inspection_type");
+		}
 	},
 
 	item_code: function (frm) {
@@ -96,6 +99,28 @@ frappe.ui.form.on("Quality Inspection", {
 				doc: frm.doc,
 				callback: function () {
 					refresh_field("readings");
+				},
+			});
+		}
+	},
+	inspection_type: function (frm) {
+		// Clear the reference_type when inspection_type changes
+		frm.set_value("reference_type", "");
+		frm.set_value("reference_name", "");
+
+		if (frm.doc.inspection_type) {
+			// Call the whitelisted Python function
+			frappe.call({
+				method: "erpnext.stock.doctype.quality_inspection.quality_inspection.get_reference_type_options",
+				args: {
+					inspection_type: frm.doc.inspection_type,
+				},
+				callback: function (r) {
+					if (r.message) {
+						// Set the dropdown options dynamically
+						frm.set_df_property("reference_type", "options", ["", ...r.message].join("\n"));
+						frm.refresh_field("reference_type");
+					}
 				},
 			});
 		}

--- a/erpnext/stock/doctype/quality_inspection/quality_inspection.py
+++ b/erpnext/stock/doctype/quality_inspection/quality_inspection.py
@@ -85,6 +85,7 @@ class QualityInspection(Document):
 		self.validate_inspection_required()
 		self.set_child_row_reference()
 		self.set_company()
+		self.validate_reference_type()
 
 	def set_company(self):
 		if self.reference_type and self.reference_name:
@@ -259,6 +260,26 @@ class QualityInspection(Document):
 					self.modified,
 				)
 
+	def validate_reference_type(self):
+		valid_reference_types = {
+			"Incoming": ["Purchase Receipt", "Purchase Invoice", "Subcontracting Receipt", "Stock Entry"],
+			"Outgoing": ["Delivery Note", "Sales Invoice", "Stock Entry"],
+			"In Process": ["Job Card", "Stock Entry"],
+		}
+
+		if self.inspection_type and self.reference_type:
+			allowed = valid_reference_types.get(self.inspection_type, [])
+			if self.reference_type not in allowed:
+				frappe.throw(
+					_(
+						"Reference Type {0} is not valid for Inspection Type {1}. Allowed types are: {2}"
+					).format(
+						frappe.bold(self.reference_type),
+						frappe.bold(self.inspection_type),
+						", ".join(allowed),
+					)
+				)
+
 	def inspect_and_set_status(self):
 		for reading in self.readings:
 			if not reading.manual_inspection:  # dont auto set status if manual
@@ -282,7 +303,7 @@ class QualityInspection(Document):
 		if not cint(reading.numeric):
 			reading_value = reading.get("reading_value") or ""
 			value = reading.get("value") or ""
-			result = reading_value == value
+			result = reading_value.strip().lower() == value.strip().lower()
 		else:
 			# numeric readings
 			result = self.min_max_criteria_passed(reading)
@@ -477,3 +498,13 @@ def parse_float(num: str) -> float:
 		num = num.replace("#$", ".")
 
 	return flt(num)
+
+
+@frappe.whitelist()
+def get_reference_type_options(inspection_type: str) -> list:
+	options = {
+		"Incoming": ["Purchase Receipt", "Purchase Invoice", "Subcontracting Receipt", "Stock Entry"],
+		"Outgoing": ["Delivery Note", "Sales Invoice", "Stock Entry"],
+		"In Process": ["Job Card", "Stock Entry"],
+	}
+	return options.get(inspection_type, [])

--- a/erpnext/stock/doctype/quality_inspection_reading/quality_inspection_reading.json
+++ b/erpnext/stock/doctype/quality_inspection_reading/quality_inspection_reading.json
@@ -56,6 +56,7 @@
   },
   {
    "columns": 2,
+   "depends_on": "eval:doc.numeric",
    "fieldname": "reading_1",
    "fieldtype": "Data",
    "in_list_view": 1,
@@ -65,6 +66,7 @@
   },
   {
    "columns": 1,
+   "depends_on": "eval:doc.numeric",
    "fieldname": "reading_2",
    "fieldtype": "Data",
    "label": "Reading 2",
@@ -73,6 +75,7 @@
   },
   {
    "columns": 1,
+   "depends_on": "eval:doc.numeric",
    "fieldname": "reading_3",
    "fieldtype": "Data",
    "label": "Reading 3",
@@ -80,6 +83,7 @@
    "oldfieldtype": "Data"
   },
   {
+   "depends_on": "eval:doc.numeric",
    "fieldname": "reading_4",
    "fieldtype": "Data",
    "label": "Reading 4",
@@ -87,6 +91,7 @@
    "oldfieldtype": "Data"
   },
   {
+   "depends_on": "eval:doc.numeric",
    "fieldname": "reading_5",
    "fieldtype": "Data",
    "label": "Reading 5",
@@ -94,6 +99,7 @@
    "oldfieldtype": "Data"
   },
   {
+   "depends_on": "eval:doc.numeric",
    "fieldname": "reading_6",
    "fieldtype": "Data",
    "label": "Reading 6",
@@ -101,6 +107,7 @@
    "oldfieldtype": "Data"
   },
   {
+   "depends_on": "eval:doc.numeric",
    "fieldname": "reading_7",
    "fieldtype": "Data",
    "label": "Reading 7",
@@ -108,6 +115,7 @@
    "oldfieldtype": "Data"
   },
   {
+   "depends_on": "eval:doc.numeric",
    "fieldname": "reading_8",
    "fieldtype": "Data",
    "label": "Reading 8",
@@ -115,6 +123,7 @@
    "oldfieldtype": "Data"
   },
   {
+   "depends_on": "eval:doc.numeric",
    "fieldname": "reading_9",
    "fieldtype": "Data",
    "label": "Reading 9",
@@ -122,6 +131,7 @@
    "oldfieldtype": "Data"
   },
   {
+   "depends_on": "eval:doc.numeric",
    "fieldname": "reading_10",
    "fieldtype": "Data",
    "label": "Reading 10",
@@ -193,7 +203,6 @@
    "label": "Reading Value"
   },
   {
-   "depends_on": "numeric",
    "fieldname": "section_break_14",
    "fieldtype": "Section Break",
    "label": "Numeric Inspection"
@@ -224,12 +233,14 @@
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-03-27 13:10:29.141984",
+ "modified": "2026-04-18 12:29:43.479909",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Quality Inspection Reading",
+ "naming_rule": "Random",
  "owner": "Administrator",
  "permissions": [],
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],


### PR DESCRIPTION
Changes Made:
**1.Reading Value 1-10 fields visibility controlled by numeric flag**
reading_1 to reading_10 fields are now shown only when numeric is enabled, and reading_value field is shown only when numeric is disabled, using depends_on expression in the doctype JSON.

**2.Case-insensitive acceptance criteria comparison**
Previously, non-numeric acceptance criteria comparison was case-sensitive, causing valid values like yes, YES, Yes to be rejected if they didn't exactly match. Fixed by normalizing both reading_value and value to lowercase before comparison.

**3.Reference Type filtered based on Inspection Type**
Reference Type dropdown now shows only relevant options based on the selected Inspection Type:

-             Incoming → Purchase Receipt, Purchase Invoice, Subcontracting Receipt, Stock Entry
-             Outgoing → Delivery Note, Sales Invoice, Stock Entry
-             In Process → Job Card, Stock Entry

Backend validation also added to prevent invalid combinations on save.
#54073