### PR TITLE
Fix : None handling in pricing rule free item quantity calculation

### DIFF
--- a/erpnext/accounts/doctype/pricing_rule/utils.py
+++ b/erpnext/accounts/doctype/pricing_rule/utils.py
@@ -661,7 +661,7 @@ def get_product_discount_rule(pricing_rule, item_details, args=None, doc=None):
 	if pricing_rule.is_recursive:
 		transaction_qty = sum(
 			[
-				flt(row.qty or 0)
+				flt(row.qty)
 				for row in doc.items
 				if not row.is_free_item
 				and row.item_code == args.item_code

--- a/erpnext/accounts/doctype/pricing_rule/utils.py
+++ b/erpnext/accounts/doctype/pricing_rule/utils.py
@@ -661,7 +661,7 @@ def get_product_discount_rule(pricing_rule, item_details, args=None, doc=None):
 	if pricing_rule.is_recursive:
 		transaction_qty = sum(
 			[
-				row.qty
+				flt(row.qty or 0)
 				for row in doc.items
 				if not row.is_free_item
 				and row.item_code == args.item_code


### PR DESCRIPTION


https://github.com/user-attachments/assets/2c8d4187-ce00-4bf9-bede-8d3e28a8b187

**Summary**

This PR fixes a potential issue in pricing rule free item calculation where row.qty could be None, leading to incorrect aggregation or runtime errors during transaction quantity computation.

**Changes Made**

- Ensured safe aggregation of item quantities by treating None values as 0
- Improved robustness of transaction_qty calculation in pricing rule recursion logic
- Prevented incorrect free item computation when item quantities are missing or null
- No functional change in pricing logic when valid quantities are present

**Technical Details**

- Updated summation logic to safely handle nullable qty values (row.qty or 0)
- Ensures consistent behavior when computing:
- recursive free item eligibility
- proportional free quantity allocation
- Preserves existing rounding and recursion rules

**Impact**

