### PR TITLE
fix: zero valuation rate popup on SI

### DIFF
--- a/erpnext/controllers/stock_controller.py
+++ b/erpnext/controllers/stock_controller.py
@@ -142,14 +142,19 @@ class StockController(AccountsController):
 		]:
 			for item in self.get("items"):
 				if (
-					(item.get("valuation_rate") == 0 or item.get("incoming_rate") == 0)
+					(
+						item.get("valuation_rate") == 0
+						or (item.get("incoming_rate") == 0 and self.get("update_stock", 1))
+					)
 					and item.get("allow_zero_valuation_rate") == 0
 					and frappe.get_cached_value("Item", item.item_code, "is_stock_item")
 				):
 					frappe.toast(
-						_(
-							"Row #{0}: Item {1} has zero rate but 'Allow Zero Valuation Rate' is not enabled."
-						).format(item.idx, frappe.bold(item.item_code)),
+						_("Row #{0}: Item {1} has zero rate but '{2}' is not enabled.").format(
+							item.idx,
+							frappe.bold(item.item_code),
+							item.meta.get_label("allow_zero_valuation_rate"),
+						),
 						indicator="orange",
 					)
 


### PR DESCRIPTION
When a new Sales Invoice is made, the zero valuation rate warning was shown if update stock was disabled (which doesn't make sense)

[Ref](https://discuss.frappe.io/t/need-help-on-these-popups-on-sales-invoice-screen/161947/9)