### PR TITLE
Fix/workorder status cancelled skip transfer

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -2525,7 +2525,6 @@ class AccountsController(TransactionBase):
 		party_account_currency = self.get("party_account_currency")
 		if not party_account_currency:
 			party_type, party = self.get_party()
-
 			if party_type and party:
 				party_account_currency = get_party_account_currency(party_type, party, self.company)
 
@@ -2535,6 +2534,11 @@ class AccountsController(TransactionBase):
 
 		base_grand_total = flt(self.get("base_rounded_total") or self.base_grand_total)
 		grand_total = flt(self.get("rounded_total") or self.grand_total)
+
+		original_grand_total = grand_total
+		original_base_grand_total = base_grand_total
+
+		po_or_so, doctype, fieldname = None, None, None
 		automatically_fetch_payment_terms = 0
 
 		if self.doctype in ("Sales Invoice", "Purchase Invoice", "Sales Order"):
@@ -2545,23 +2549,42 @@ class AccountsController(TransactionBase):
 			if self.doctype != "Sales Order":
 				base_grand_total = base_grand_total - flt(self.base_write_off_amount)
 				grand_total = grand_total - flt(self.write_off_amount)
+				original_grand_total = grand_total
+				original_base_grand_total = base_grand_total
+
+		advance_amount = 0
+		base_advance_amount = 0
 
 		if self.get("total_advance"):
 			if party_account_currency == self.company_currency:
-				base_grand_total -= self.get("total_advance")
+				base_advance_amount = flt(self.get("total_advance"))
+				advance_amount = flt(
+					base_advance_amount / self.get("conversion_rate"), self.precision("grand_total")
+				)
+			else:
+				advance_amount = flt(self.get("total_advance"))
+				base_advance_amount = flt(
+					advance_amount * self.get("conversion_rate"), self.precision("base_grand_total")
+				)
+
+			if party_account_currency == self.company_currency:
+				base_grand_total = flt(
+					base_grand_total - base_advance_amount, self.precision("base_grand_total")
+				)
 				grand_total = flt(
 					base_grand_total / self.get("conversion_rate"), self.precision("grand_total")
 				)
 			else:
-				grand_total -= self.get("total_advance")
+				grand_total = flt(grand_total - advance_amount, self.precision("grand_total"))
 				base_grand_total = flt(
 					grand_total * self.get("conversion_rate"), self.precision("base_grand_total")
 				)
 
-		if not self.get("payment_schedule"):
+		if not self.get("payment_schedule") and not self.get("ignore_default_payment_terms_template"):
 			if (
 				self.doctype in ["Sales Invoice", "Purchase Invoice", "Sales Order"]
 				and automatically_fetch_payment_terms
+				and po_or_so
 				and self.linked_order_has_payment_terms(po_or_so, fieldname, doctype)
 			):
 				self.fetch_payment_terms_from_order(
@@ -2569,12 +2592,14 @@ class AccountsController(TransactionBase):
 				)
 				if self.get("payment_terms_template"):
 					self.ignore_default_payment_terms_template = 1
+
 			elif self.get("payment_terms_template"):
 				data = get_payment_terms(
 					self.payment_terms_template, posting_date, grand_total, base_grand_total
 				)
 				for item in data:
 					self.append("payment_schedule", item)
+
 			elif self.doctype not in ["Purchase Receipt"]:
 				data = dict(
 					due_date=due_date,
@@ -2584,35 +2609,65 @@ class AccountsController(TransactionBase):
 				)
 				self.append("payment_schedule", data)
 
-		allocate_payment_based_on_payment_terms = frappe.db.get_value(
-			"Payment Terms Template", self.payment_terms_template, "allocate_payment_based_on_payment_terms"
+		allocate_payment_based_on_payment_terms = (
+			frappe.db.get_value(
+				"Payment Terms Template",
+				self.payment_terms_template,
+				"allocate_payment_based_on_payment_terms",
+			)
+			if self.payment_terms_template
+			else 0
 		)
 
-		if not (
+		if self.get("ignore_default_payment_terms_template") or not (
 			automatically_fetch_payment_terms
 			and allocate_payment_based_on_payment_terms
+			and po_or_so
 			and self.linked_order_has_payment_terms(po_or_so, fieldname, doctype)
 		):
+			remaining_advance_amount = advance_amount
+			remaining_base_advance_amount = base_advance_amount
+
 			for d in self.get("payment_schedule"):
 				if d.invoice_portion:
-					d.payment_amount = flt(
-						grand_total * flt(d.invoice_portion) / 100, d.precision("payment_amount")
+					row_amount = flt(
+						original_grand_total * flt(d.invoice_portion) / 100, d.precision("payment_amount")
 					)
+					row_base_amount = flt(
+						original_base_grand_total * flt(d.invoice_portion) / 100,
+						d.precision("base_payment_amount"),
+					)
+
+					allocated_advance = min(row_amount, remaining_advance_amount)
+					allocated_base_advance = min(row_base_amount, remaining_base_advance_amount)
+
+					remaining_advance_amount = flt(
+						remaining_advance_amount - allocated_advance, self.precision("grand_total")
+					)
+					remaining_base_advance_amount = flt(
+						remaining_base_advance_amount - allocated_base_advance,
+						self.precision("base_grand_total"),
+					)
+
+					d.payment_amount = flt(row_amount - allocated_advance, d.precision("payment_amount"))
 					d.base_payment_amount = flt(
-						base_grand_total * flt(d.invoice_portion) / 100, d.precision("base_payment_amount")
+						row_base_amount - allocated_base_advance, d.precision("base_payment_amount")
 					)
 					d.outstanding = d.payment_amount
 					d.base_outstanding = d.base_payment_amount
+
 				elif not d.invoice_portion:
 					d.base_payment_amount = flt(
 						d.payment_amount * self.get("conversion_rate"), d.precision("base_payment_amount")
 					)
 					d.base_outstanding = d.base_payment_amount
+
 		else:
-			self.fetch_payment_terms_from_order(
-				po_or_so, doctype, grand_total, base_grand_total, automatically_fetch_payment_terms
-			)
-			self.ignore_default_payment_terms_template = 1
+			if po_or_so and not self.get("ignore_default_payment_terms_template"):
+				self.fetch_payment_terms_from_order(
+					po_or_so, doctype, grand_total, base_grand_total, automatically_fetch_payment_terms
+				)
+				self.ignore_default_payment_terms_template = 1
 
 	def get_order_details(self):
 		if not self.get("items"):

--- a/erpnext/manufacturing/doctype/work_order/work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/work_order.py
@@ -599,7 +599,7 @@ class WorkOrder(Document):
 		else:
 			status = "Cancelled"
 
-		if (
+		if self.docstatus == 1 and (
 			self.skip_transfer
 			and self.produced_qty
 			and self.qty > (flt(self.produced_qty) + flt(self.process_loss_qty))

--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -159,23 +159,23 @@ def get_args_for_future_sle(row):
 
 def validate_cancellation(kargs):
 	if kargs[0].get("is_cancelled"):
-		repost_entry = frappe.db.get_value(
+		repost_entries = frappe.get_all(
 			"Repost Item Valuation",
-			{
+			filters={
 				"voucher_type": kargs[0].voucher_type,
 				"voucher_no": kargs[0].voucher_no,
 				"docstatus": 1,
 				"recreate_stock_ledgers": 0,
+				"status": ["in", ["Queued", "In Progress"]],
 			},
-			["name", "status"],
-			as_dict=1,
+			fields=["name", "status"],
 		)
 
-		if repost_entry:
+		for repost_entry in repost_entries:
 			if repost_entry.status == "In Progress":
 				frappe.throw(
 					_(
-						"Cannot cancel the transaction. Reposting of item valuation on submission is not completed yet."
+						"Cannot cancel the transaction. Reposting of item valuation on submission is currently In Progress."
 					)
 				)
 			if repost_entry.status == "Queued":
@@ -379,13 +379,24 @@ def get_items_to_be_repost(voucher_type=None, voucher_no=None, doc=None, reposti
 		items_to_be_repost = json.loads(doc.items_to_be_repost)
 
 	if not items_to_be_repost and voucher_type and voucher_no:
-		items_to_be_repost = frappe.db.get_all(
-			"Stock Ledger Entry",
-			filters={"voucher_type": voucher_type, "voucher_no": voucher_no},
-			fields=["item_code", "warehouse", "posting_date", "posting_time", "creation", "posting_datetime"],
-			order_by="creation asc",
-			group_by="item_code, warehouse",
+		sle = frappe.qb.DocType("Stock Ledger Entry")
+		from frappe.query_builder.functions import Min
+
+		query = (
+			frappe.qb.from_(sle)
+			.select(
+				sle.item_code,
+				sle.warehouse,
+				Min(sle.posting_date).as_("posting_date"),
+				Min(sle.posting_time).as_("posting_time"),
+				Min(sle.creation).as_("creation"),
+				Min(sle.posting_datetime).as_("posting_datetime"),
+			)
+			.where((sle.voucher_type == voucher_type) & (sle.voucher_no == voucher_no))
+			.groupby(sle.item_code, sle.warehouse)
+			.orderby("creation", order=frappe.query_builder.Order.asc)
 		)
+		items_to_be_repost = query.run(as_dict=True)
 
 	return items_to_be_repost or []
 
@@ -505,11 +516,17 @@ class update_entries_after:
 	def get_reserved_stock(self):
 		sre = frappe.qb.DocType("Stock Reservation Entry")
 		posting_datetime = get_combine_datetime(self.args.posting_date, self.args.posting_time)
+		from frappe.query_builder.functions import Coalesce, Sum
+
 		query = (
 			frappe.qb.from_(sre)
 			.select(
-				Sum(sre.reserved_qty)
-				- (Sum(sre.delivered_qty) + Sum(sre.transferred_qty) + Sum(sre.consumed_qty))
+				Coalesce(Sum(sre.reserved_qty), 0)
+				- (
+					Coalesce(Sum(sre.delivered_qty), 0)
+					+ Coalesce(Sum(sre.transferred_qty), 0)
+					+ Coalesce(Sum(sre.consumed_qty), 0)
+				)
 			)
 			.where(
 				(sre.item_code == self.item_code)


### PR DESCRIPTION
## Title  
**fix: prevent status override for cancelled Work Orders when skip_transfer is enabled**

---

## Description  

### Problem  
When a Work Order is cancelled (`docstatus == 2`) and:
- `skip_transfer = True`
- `produced_qty > 0`

the system incorrectly updates the status to **"In Process"** instead of preserving **"Cancelled"**.

---

### Root Cause  
In `WorkOrder.get_status()`, the `skip_transfer` logic runs without checking the document status (`docstatus`).

As a result, even cancelled Work Orders are evaluated through production status logic, which can override the terminal state.

---

### Fix  
Restrict the `skip_transfer` logic so it only applies to submitted Work Orders (`docstatus == 1`):
