### PR TITLE
fix: auto-calculate process loss qty from BOM percentage in stock entry

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry.js
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.js
@@ -1413,6 +1413,13 @@ erpnext.stock.StockEntry = class StockEntry extends erpnext.stock.StockControlle
 	}
 
 	fg_completed_qty() {
+		this.frm.set_value(
+			"process_loss_qty",
+			flt(
+				(this.frm.doc.fg_completed_qty * (this.frm.doc.process_loss_percentage || 0)) / 100,
+				precision("process_loss_qty", this.frm.doc)
+			)
+		);
 		if (!this.frm.doc.job_card) {
 			this.get_items();
 		}
@@ -1441,6 +1448,20 @@ erpnext.stock.StockEntry = class StockEntry extends erpnext.stock.StockControlle
 		}
 	}
 
+	bom_no() {
+		if (this.frm.doc.bom_no) {
+			frappe.db.get_value("BOM", this.frm.doc.bom_no, "process_loss_percentage").then((r) => {
+				if (r && r.message) {
+					this.frm.set_value("process_loss_percentage", r.message.process_loss_percentage || 0);
+				}
+				this.fg_completed_qty();
+			});
+		} else {
+			this.frm.set_value("process_loss_percentage", 0);
+			this.fg_completed_qty();
+		}
+	}
+
 	work_order() {
 		var me = this;
 		this.toggle_enable_bom();
@@ -1457,7 +1478,13 @@ erpnext.stock.StockEntry = class StockEntry extends erpnext.stock.StockControlle
 			callback: function (r) {
 				if (!r.exc) {
 					$.each(
-						["from_bom", "bom_no", "fg_completed_qty", "use_multi_level_bom"],
+						[
+							"from_bom",
+							"bom_no",
+							"fg_completed_qty",
+							"use_multi_level_bom",
+							"process_loss_percentage",
+						],
 						function (i, field) {
 							me.frm.set_value(field, r.message[field]);
 						}

--- a/erpnext/stock/doctype/stock_entry/stock_entry.json
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.json
@@ -32,9 +32,7 @@
   "cb1",
   "fg_completed_qty",
   "get_items",
-  "section_break_7qsm",
   "process_loss_percentage",
-  "column_break_e92r",
   "process_loss_qty",
   "section_break_jwgn",
   "from_warehouse",
@@ -671,27 +669,18 @@
    "oldfieldtype": "Section Break"
   },
   {
-   "collapsible": 1,
-   "depends_on": "eval: doc.fg_completed_qty > 0 && in_list([\"Manufacture\", \"Repack\"], doc.purpose)",
-   "fieldname": "section_break_7qsm",
-   "fieldtype": "Section Break",
-   "label": "Process Loss"
-  },
-  {
    "depends_on": "eval: doc.fg_completed_qty > 0 && in_list([\"Manufacture\", \"Repack\"], doc.purpose)",
    "fieldname": "process_loss_qty",
    "fieldtype": "Float",
-   "label": "Process Loss Qty"
-  },
-  {
-   "fieldname": "column_break_e92r",
-   "fieldtype": "Column Break"
+   "label": "Process Loss Qty",
+   "read_only": 1
   },
   {
    "depends_on": "eval:doc.from_bom && doc.fg_completed_qty",
    "fieldname": "process_loss_percentage",
    "fieldtype": "Percent",
-   "label": "% Process Loss"
+   "label": "% Process Loss",
+   "read_only": 1
   },
   {
    "fieldname": "items_section",

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -2808,6 +2808,7 @@ class StockEntry(StockController, SubcontractingInwardController):
 			return
 
 		precision = self.precision("process_loss_qty")
+		job_card_process_loss = False
 		if self.work_order:
 			data = frappe.get_all(
 				"Work Order Operation",
@@ -2816,6 +2817,7 @@ class StockEntry(StockController, SubcontractingInwardController):
 			)
 
 			if data and data[0].process_loss_qty:
+				job_card_process_loss = True
 				process_loss_qty = data[0].process_loss_qty
 				if flt(self.process_loss_qty, precision) != flt(process_loss_qty, precision):
 					self.process_loss_qty = flt(process_loss_qty, precision)
@@ -2824,18 +2826,13 @@ class StockEntry(StockController, SubcontractingInwardController):
 						_("The Process Loss Qty has reset as per job cards Process Loss Qty"), alert=True
 					)
 
-		if not self.process_loss_percentage and not self.process_loss_qty:
-			self.process_loss_percentage = frappe.get_cached_value(
-				"BOM", self.bom_no, "process_loss_percentage"
-			)
+		self.process_loss_percentage = (
+			frappe.get_cached_value("BOM", self.bom_no, "process_loss_percentage") or 0.0
+		)
 
-		if self.process_loss_percentage and not self.process_loss_qty:
+		if not job_card_process_loss and self.process_loss_percentage:
 			self.process_loss_qty = flt(
 				(flt(self.fg_completed_qty) * flt(self.process_loss_percentage)) / 100
-			)
-		elif self.process_loss_qty and not self.process_loss_percentage:
-			self.process_loss_percentage = flt(
-				(flt(self.process_loss_qty) / flt(self.fg_completed_qty)) * 100
 			)
 
 	def set_work_order_details(self):
@@ -3892,6 +3889,10 @@ def get_work_order_details(work_order: str, company: str):
 		"wip_warehouse": work_order.wip_warehouse,
 		"fg_warehouse": work_order.fg_warehouse,
 		"fg_completed_qty": pending_qty_to_produce,
+		"process_loss_percentage": frappe.get_cached_value(
+			"BOM", work_order.bom_no, "process_loss_percentage"
+		)
+		or 0.0,
 	}
 
 


### PR DESCRIPTION
<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/erpnext/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request: closes #53744

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> 
<img width="960" height="435" alt="Screenshot 2026-04-18 190429" src="https://github.com/user-attachments/assets/4ed7354a-1bc6-4106-bcff-97e784543851" />

 The process loss section in the Stock Entry was standalone and editable, which didn't make sense since the process loss
      quantity should strictly be derived from the percentage configured in the Bill of Materials (BOM) and the final quantity of the
      transaction.
 This PR solves the problem by:
   1. Removing the separate "Process Loss" section break and moving the `process_loss_qty` and `process_loss_percentage` fields
      into the main Details/BOM Info section.
   2. Setting both `process_loss_qty` and `process_loss_percentage` as **read-only**.
   3. Adding frontend triggers to automatically fetch the `process_loss_percentage` directly from the selected BOM (`bom_no`).
   4. Auto-calculating `process_loss_qty` dynamically whenever the final quantity (`fg_completed_qty`) is modified by the user.
   5. Enforcing the process loss auto-calculation backend logic so it correctly pulls the percentage from the BOM on save.
  These changes prevent manual overrides, reduce confusion, and ensure the process loss in the transaction perfectly aligns with
      the BOM definition.
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->
