### PR TITLE
fix: prevent status override to In Process for cancelled Work Orders …

### DIFF
--- a/erpnext/manufacturing/doctype/work_order/work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/work_order.py
@@ -599,7 +599,7 @@ class WorkOrder(Document):
 		else:
 			status = "Cancelled"
 
-		if (
+		if self.docstatus == 1 and (
 			self.skip_transfer
 			and self.produced_qty
 			and self.qty > (flt(self.produced_qty) + flt(self.process_loss_qty))


### PR DESCRIPTION
## Title  
**fix: prevent status override for cancelled Work Orders when skip_transfer is enabled**

---

## Description  

### Problem  
When a Work Order is cancelled (`docstatus == 2`) and:
- `skip_transfer = True`
- `produced_qty > 0`

the system incorrectly updates the status to **"In Process"** instead of preserving **"Cancelled"**.

---

### Root Cause  
In `WorkOrder.get_status()`, the `skip_transfer` logic runs without checking the document status (`docstatus`).

As a result, even cancelled Work Orders are evaluated through production status logic, which can override the terminal state.

---

### Fix  
Restrict the `skip_transfer` logic so it only applies to submitted Work Orders (`docstatus == 1`).

---