### PR TITLE
fix: fetch item tax template from item group when creating item

### DIFF
--- a/erpnext/stock/doctype/item/item.py
+++ b/erpnext/stock/doctype/item/item.py
@@ -791,6 +791,20 @@ class Item(Document):
 					{"company": defaults.get("company"), "default_warehouse": defaults.default_warehouse},
 				)
 
+		item_group = frappe.get_cached_doc("Item Group", self.item_group)
+		if not self.taxes and item_group.taxes:
+			for tax in item_group.taxes:
+				self.append(
+					"taxes",
+					{
+						"item_tax_template": tax.item_tax_template,
+						"tax_category": tax.tax_category,
+						"valid_from": tax.valid_from,
+						"minimum_net_rate": tax.minimum_net_rate,
+						"maximum_net_rate": tax.maximum_net_rate,
+					},
+				)
+
 	def update_variants(self):
 		if self.flags.dont_update_variants or frappe.db.get_single_value(
 			"Item Variant Settings", "do_not_update_variants"


### PR DESCRIPTION
Backport : [#54367](https://github.com/frappe/erpnext/pull/54367)

Ref : [#65226](https://support.frappe.io/helpdesk/tickets/65226)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Items now automatically inherit tax configurations from their assigned Item Group when no taxes are already defined on the item.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->