### PR TITLE
fix: clear conditions table when calculate_based_on is set to Fixed

### DIFF
--- a/erpnext/accounts/doctype/shipping_rule/shipping_rule.js
+++ b/erpnext/accounts/doctype/shipping_rule/shipping_rule.js
@@ -25,6 +25,10 @@ frappe.ui.form.on("Shipping Rule", {
 	},
 	calculate_based_on: function (frm) {
 		frm.trigger("toggle_reqd");
+		if (frm.doc.calculate_based_on === "Fixed") {
+			frm.clear_table("conditions");
+			frm.refresh_field("conditions");
+		}
 	},
 	toggle_reqd: function (frm) {
 		frm.toggle_reqd("shipping_amount", frm.doc.calculate_based_on === "Fixed");

--- a/erpnext/accounts/doctype/shipping_rule/shipping_rule.py
+++ b/erpnext/accounts/doctype/shipping_rule/shipping_rule.py
@@ -58,6 +58,11 @@ class ShippingRule(Document):
 		self.validate_overlapping_shipping_rule_conditions()
 
 	def validate_from_to_values(self):
+		if self.calculate_based_on == "Fixed":
+			if self.conditions:
+				self.set("conditions", [])
+			return
+
 		zero_to_values = []
 
 		for d in self.get("conditions"):


### PR DESCRIPTION
**Issue:**
While creating a **Shipping Rule**, selecting **calculate_based_on** as `Net Total` or `Net Weight` displays the conditions table. After adding empty rows and changing **calculate_based_on** to `Fixed`, the conditions table is hidden, but the previously added rows remain in the document. As a result, saving the form throws a mandatory field validation error.

**Before:**

[conditionsbefore.webm](https://github.com/user-attachments/assets/37864b83-e347-4190-b0c6-2434f12818cf)


**After:**

[conditionsafter.webm](https://github.com/user-attachments/assets/e2d86ae9-3287-45ca-afd5-f60b349d93bc)


**Backport needed for v15, v16**