### PR TITLE
fix: set letter_head_for letterhead and remove unknown letterhead from report

### DIFF
--- a/erpnext/accounts/report/voucher_wise_balance/voucher_wise_balance.json
+++ b/erpnext/accounts/report/voucher_wise_balance/voucher_wise_balance.json
@@ -1,5 +1,6 @@
 {
  "add_total_row": 0,
+ "add_translate_data": 0,
  "columns": [],
  "creation": "2023-06-27 16:40:15.109554",
  "disabled": 0,
@@ -9,8 +10,7 @@
  "idx": 0,
  "is_standard": "Yes",
  "json": "{}",
- "letter_head": "LetterHead",
- "modified": "2023-06-27 16:40:32.493725",
+ "modified": "2026-04-20 16:55:11.962163",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Voucher-wise Balance",
@@ -29,5 +29,6 @@
   {
    "role": "Auditor"
   }
- ]
+ ],
+ "timeout": 0
 }

--- a/erpnext/crm/report/first_response_time_for_opportunity/first_response_time_for_opportunity.json
+++ b/erpnext/crm/report/first_response_time_for_opportunity/first_response_time_for_opportunity.json
@@ -1,14 +1,15 @@
 {
  "add_total_row": 0,
+ "add_translate_data": 0,
+ "columns": [],
  "creation": "2020-08-10 18:34:19.083872",
- "disable_prepared_report": 0,
  "disabled": 0,
  "docstatus": 0,
  "doctype": "Report",
+ "filters": [],
  "idx": 0,
  "is_standard": "Yes",
- "letter_head": "Test 2",
- "modified": "2020-08-10 18:34:19.083872",
+ "modified": "2026-04-20 16:55:11.923322",
  "modified_by": "Administrator",
  "module": "CRM",
  "name": "First Response Time for Opportunity",
@@ -24,5 +25,6 @@
   {
    "role": "Sales Manager"
   }
- ]
+ ],
+ "timeout": 0
 }

--- a/erpnext/manufacturing/report/downtime_analysis/downtime_analysis.json
+++ b/erpnext/manufacturing/report/downtime_analysis/downtime_analysis.json
@@ -1,14 +1,15 @@
 {
  "add_total_row": 1,
+ "add_translate_data": 0,
+ "columns": [],
  "creation": "2020-04-20 18:26:04.345289",
- "disable_prepared_report": 0,
  "disabled": 0,
  "docstatus": 0,
  "doctype": "Report",
+ "filters": [],
  "idx": 0,
  "is_standard": "Yes",
- "letter_head": "Gadgets International",
- "modified": "2020-04-20 18:26:04.345289",
+ "modified": "2026-04-20 16:55:11.891636",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "Downtime Analysis",
@@ -27,5 +28,6 @@
   {
    "role": "Manufacturing Manager"
   }
- ]
+ ],
+ "timeout": 0
 }

--- a/erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.json
+++ b/erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.json
@@ -1,15 +1,16 @@
 {
  "add_total_row": 0,
+ "add_translate_data": 0,
+ "columns": [],
  "creation": "2020-04-26 18:23:53.475110",
- "disable_prepared_report": 0,
  "disabled": 0,
  "docstatus": 0,
  "doctype": "Report",
+ "filters": [],
  "idx": 0,
  "is_standard": "Yes",
  "json": "{}",
- "letter_head": "Gadgets International",
- "modified": "2020-04-26 18:24:50.529940",
+ "modified": "2026-04-20 16:55:11.903547",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "Quality Inspection Summary",
@@ -28,5 +29,6 @@
   {
    "role": "Stock Manager"
   }
- ]
+ ],
+ "timeout": 0
 }

--- a/erpnext/manufacturing/report/work_order_consumed_materials/work_order_consumed_materials.json
+++ b/erpnext/manufacturing/report/work_order_consumed_materials/work_order_consumed_materials.json
@@ -1,16 +1,15 @@
 {
  "add_total_row": 0,
+ "add_translate_data": 0,
  "columns": [],
  "creation": "2021-11-22 17:36:11.886939",
- "disable_prepared_report": 0,
  "disabled": 0,
  "docstatus": 0,
  "doctype": "Report",
  "filters": [],
  "idx": 0,
  "is_standard": "Yes",
- "letter_head": "Gadgets International",
- "modified": "2021-11-22 17:36:14.999091",
+ "modified": "2026-04-20 16:55:11.935728",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "Work Order Consumed Materials",
@@ -26,5 +25,6 @@
   {
    "role": "Stock User"
   }
- ]
+ ],
+ "timeout": 0
 }

--- a/erpnext/manufacturing/report/work_order_summary/work_order_summary.json
+++ b/erpnext/manufacturing/report/work_order_summary/work_order_summary.json
@@ -1,14 +1,15 @@
 {
  "add_total_row": 0,
+ "add_translate_data": 0,
+ "columns": [],
  "creation": "2020-04-17 17:07:56.830358",
- "disable_prepared_report": 0,
  "disabled": 0,
  "docstatus": 0,
  "doctype": "Report",
+ "filters": [],
  "idx": 0,
  "is_standard": "Yes",
- "letter_head": "Gadgets International",
- "modified": "2020-04-19 16:59:47.979278",
+ "modified": "2026-04-20 16:55:11.869366",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "Work Order Summary",
@@ -27,5 +28,6 @@
   {
    "role": "Manufacturing Manager"
   }
- ]
+ ],
+ "timeout": 0
 }

--- a/erpnext/projects/report/timesheet_billing_summary/timesheet_billing_summary.json
+++ b/erpnext/projects/report/timesheet_billing_summary/timesheet_billing_summary.json
@@ -1,5 +1,6 @@
 {
  "add_total_row": 1,
+ "add_translate_data": 0,
  "columns": [],
  "creation": "2023-10-10 23:53:43.692067",
  "disabled": 0,
@@ -8,9 +9,7 @@
  "filters": [],
  "idx": 0,
  "is_standard": "Yes",
- "letter_head": "ALYF GmbH",
- "letterhead": null,
- "modified": "2023-10-11 00:58:30.639078",
+ "modified": "2026-04-20 16:55:11.807564",
  "modified_by": "Administrator",
  "module": "Projects",
  "name": "Timesheet Billing Summary",
@@ -38,5 +37,6 @@
   {
    "role": "Employee Self Service"
   }
- ]
+ ],
+ "timeout": 0
 }

--- a/erpnext/setup/install.py
+++ b/erpnext/setup/install.py
@@ -359,6 +359,7 @@ def create_letter_head():
 					"source": "HTML",
 					"content": content,
 					"is_default": 1 if name == "Company Letterhead - Grey" else 0,
+					"letter_head_for": "Report",
 				}
 			)
 			doc.insert(ignore_permissions=True)

--- a/erpnext/stock/report/fifo_queue_vs_qty_after_transaction_comparison/fifo_queue_vs_qty_after_transaction_comparison.json
+++ b/erpnext/stock/report/fifo_queue_vs_qty_after_transaction_comparison/fifo_queue_vs_qty_after_transaction_comparison.json
@@ -1,16 +1,15 @@
 {
  "add_total_row": 0,
+ "add_translate_data": 0,
  "columns": [],
  "creation": "2022-05-11 04:09:13.460652",
- "disable_prepared_report": 0,
  "disabled": 0,
  "docstatus": 0,
  "doctype": "Report",
  "filters": [],
  "idx": 0,
  "is_standard": "Yes",
- "letter_head": "abc",
- "modified": "2022-05-11 04:09:20.232177",
+ "modified": "2026-04-20 16:55:11.950413",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "FIFO Queue vs Qty After Transaction Comparison",
@@ -23,5 +22,6 @@
   {
    "role": "Administrator"
   }
- ]
+ ],
+ "timeout": 0
 }

--- a/erpnext/stock/report/incorrect_serial_and_batch_bundle/incorrect_serial_and_batch_bundle.json
+++ b/erpnext/stock/report/incorrect_serial_and_batch_bundle/incorrect_serial_and_batch_bundle.json
@@ -1,5 +1,6 @@
 {
  "add_total_row": 0,
+ "add_translate_data": 0,
  "columns": [],
  "creation": "2025-02-03 15:39:44.521366",
  "disabled": 0,
@@ -9,9 +10,7 @@
  "idx": 0,
  "is_standard": "Yes",
  "json": "{}",
- "letter_head": null,
- "letterhead": null,
- "modified": "2025-02-03 15:39:47.613040",
+ "modified": "2026-04-20 16:55:11.972979",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Incorrect Serial and Batch Bundle",

--- a/erpnext/support/report/first_response_time_for_issues/first_response_time_for_issues.json
+++ b/erpnext/support/report/first_response_time_for_issues/first_response_time_for_issues.json
@@ -1,14 +1,15 @@
 {
  "add_total_row": 0,
+ "add_translate_data": 0,
+ "columns": [],
  "creation": "2020-08-10 18:12:42.391224",
- "disable_prepared_report": 0,
  "disabled": 0,
  "docstatus": 0,
  "doctype": "Report",
+ "filters": [],
  "idx": 0,
  "is_standard": "Yes",
- "letter_head": "Test 2",
- "modified": "2020-08-10 18:12:42.391224",
+ "modified": "2026-04-20 16:55:11.913714",
  "modified_by": "Administrator",
  "module": "Support",
  "name": "First Response Time for Issues",
@@ -22,5 +23,6 @@
   {
    "role": "Support Team"
   }
- ]
+ ],
+ "timeout": 0
 }


### PR DESCRIPTION
Remove invalid default letterhead usage in reports.

<img width="2880" height="1368" alt="scrnli_gL8EUH6vo3Ei17" src="https://github.com/user-attachments/assets/2a316f16-601f-4bd9-bfdd-5dcaab69c710" />

Set `letter_head_for` as `Report` for default ERPNext letterheads created during install, since the default letterhead was being auto-assigned to reports and causing test failures.

Lending testcases were failing on fresh CI sites: https://github.com/frappe/lending/actions/runs/24658866952/job/72099299043