### PR TITLE
fix: prevent duplicate pricing rule evaluation during transaction recalculation

### DIFF
--- a/erpnext/accounts/doctype/pricing_rule/utils.py
+++ b/erpnext/accounts/doctype/pricing_rule/utils.py
@@ -6,6 +6,7 @@
 
 import copy
 import json
+from pydoc import doc
 
 import frappe
 from frappe import _, bold
@@ -17,134 +18,138 @@ from erpnext.stock.get_item_details import get_conversion_factor
 
 
 class MultiplePricingRuleConflict(frappe.ValidationError):
-	pass
+    pass
 
 
 apply_on_table = {"Item Code": "items", "Item Group": "item_groups", "Brand": "brands"}
 
 
 def get_pricing_rules(args, doc=None):
-	pricing_rules = []
-	values = {}
+    pricing_rules = []
+    values = {}
 
-	if not frappe.db.count("Pricing Rule", cache=True):
-		return
+    if not frappe.db.count("Pricing Rule", cache=True):
+        return
 
-	for apply_on in ["Item Code", "Item Group", "Brand"]:
-		pricing_rules.extend(_get_pricing_rules(apply_on, args, values))
-		if pricing_rules and pricing_rules[0].has_priority:
-			continue
+    for apply_on in ["Item Code", "Item Group", "Brand"]:
+        pricing_rules.extend(_get_pricing_rules(apply_on, args, values))
+        if pricing_rules and pricing_rules[0].has_priority:
+            continue
 
-		if pricing_rules and not apply_multiple_pricing_rules(pricing_rules):
-			break
+        if pricing_rules and not apply_multiple_pricing_rules(pricing_rules):
+            break
 
-	rules = []
+    rules = []
 
-	pricing_rules = filter_pricing_rule_based_on_condition(pricing_rules, doc)
+    pricing_rules = filter_pricing_rule_based_on_condition(pricing_rules, doc)
 
-	if not pricing_rules:
-		return []
+    if not pricing_rules:
+        return []
 
-	if apply_multiple_pricing_rules(pricing_rules):
-		pricing_rules = sorted_by_priority(pricing_rules, args, doc)
-		for pricing_rule in pricing_rules:
-			if isinstance(pricing_rule, list):
-				rules.extend(pricing_rule)
-			else:
-				rules.append(pricing_rule)
-	else:
-		pricing_rule = filter_pricing_rules(args, pricing_rules, doc)
-		if pricing_rule:
-			rules.append(pricing_rule)
+    if apply_multiple_pricing_rules(pricing_rules):
+        pricing_rules = sorted_by_priority(pricing_rules, args, doc)
+        for pricing_rule in pricing_rules:
+            if isinstance(pricing_rule, list):
+                rules.extend(pricing_rule)
+            else:
+                rules.append(pricing_rule)
+    else:
+        pricing_rule = filter_pricing_rules(args, pricing_rules, doc)
+        if pricing_rule:
+            rules.append(pricing_rule)
 
-	return rules
+    return rules
 
 
 def sorted_by_priority(pricing_rules, args, doc=None):
-	# If more than one pricing rules, then sort by priority
-	pricing_rules_list = []
-	pricing_rule_dict = {}
+    # If more than one pricing rules, then sort by priority
+    pricing_rules_list = []
+    pricing_rule_dict = {}
 
-	for pricing_rule in pricing_rules:
-		pricing_rule = filter_pricing_rules(args, pricing_rule, doc)
-		if pricing_rule:
-			if not pricing_rule.get("priority"):
-				pricing_rule["priority"] = 1
+    for pricing_rule in pricing_rules:
+        pricing_rule = filter_pricing_rules(args, pricing_rule, doc)
+        if pricing_rule:
+            if not pricing_rule.get("priority"):
+                pricing_rule["priority"] = 1
 
-			if pricing_rule.get("apply_multiple_pricing_rules"):
-				pricing_rule_dict.setdefault(cint(pricing_rule.get("priority")), []).append(pricing_rule)
+            if pricing_rule.get("apply_multiple_pricing_rules"):
+                pricing_rule_dict.setdefault(
+                    cint(pricing_rule.get("priority")), []
+                ).append(pricing_rule)
 
-	for key in sorted(pricing_rule_dict):
-		pricing_rules_list.extend(pricing_rule_dict.get(key))
+    for key in sorted(pricing_rule_dict):
+        pricing_rules_list.extend(pricing_rule_dict.get(key))
 
-	return pricing_rules_list
+    return pricing_rules_list
 
 
 def filter_pricing_rule_based_on_condition(pricing_rules, doc=None):
-	filtered_pricing_rules = []
-	if doc:
-		for pricing_rule in pricing_rules:
-			if pricing_rule.condition:
-				try:
-					if frappe.safe_eval(pricing_rule.condition, None, doc.as_dict()):
-						filtered_pricing_rules.append(pricing_rule)
-				except Exception:
-					pass
-			else:
-				filtered_pricing_rules.append(pricing_rule)
-	else:
-		filtered_pricing_rules = pricing_rules
+    filtered_pricing_rules = []
+    if doc:
+        for pricing_rule in pricing_rules:
+            if pricing_rule.condition:
+                try:
+                    if frappe.safe_eval(pricing_rule.condition, None, doc.as_dict()):
+                        filtered_pricing_rules.append(pricing_rule)
+                except Exception:
+                    pass
+            else:
+                filtered_pricing_rules.append(pricing_rule)
+    else:
+        filtered_pricing_rules = pricing_rules
 
-	return filtered_pricing_rules
+    return filtered_pricing_rules
 
 
 def _get_pricing_rules(apply_on, args, values):
-	apply_on_field = frappe.scrub(apply_on)
+    apply_on_field = frappe.scrub(apply_on)
 
-	if not args.get(apply_on_field):
-		return []
+    if not args.get(apply_on_field):
+        return []
 
-	child_doc = f"`tabPricing Rule {apply_on}`"
+    child_doc = f"`tabPricing Rule {apply_on}`"
 
-	conditions = item_variant_condition = item_conditions = ""
-	values[apply_on_field] = args.get(apply_on_field)
-	if apply_on_field in ["item_code", "brand"]:
-		item_conditions = f"{child_doc}.{apply_on_field}= %({apply_on_field})s"
+    conditions = item_variant_condition = item_conditions = ""
+    values[apply_on_field] = args.get(apply_on_field)
+    if apply_on_field in ["item_code", "brand"]:
+        item_conditions = f"{child_doc}.{apply_on_field}= %({apply_on_field})s"
 
-		if apply_on_field == "item_code":
-			if args.get("uom", None):
-				item_conditions += (
-					" and ({child_doc}.uom={item_uom} or IFNULL({child_doc}.uom, '')='')".format(
-						child_doc=child_doc, item_uom=frappe.db.escape(args.get("uom"))
-					)
-				)
-			if "variant_of" not in args:
-				args.variant_of = frappe.get_cached_value("Item", args.item_code, "variant_of")
+        if apply_on_field == "item_code":
+            if args.get("uom", None):
+                item_conditions += " and ({child_doc}.uom={item_uom} or IFNULL({child_doc}.uom, '')='')".format(
+                    child_doc=child_doc, item_uom=frappe.db.escape(args.get("uom"))
+                )
+            if "variant_of" not in args:
+                args.variant_of = frappe.get_cached_value(
+                    "Item", args.item_code, "variant_of"
+                )
 
-			if args.variant_of:
-				item_variant_condition = f" or {child_doc}.item_code=%(variant_of)s "
-				values["variant_of"] = args.variant_of
-	elif apply_on_field == "item_group":
-		item_conditions = _get_tree_conditions(args, "Item Group", child_doc, False)
-		if args.get("uom", None):
-			item_conditions += " and ({child_doc}.uom={item_uom} or IFNULL({child_doc}.uom, '')='')".format(
-				child_doc=child_doc, item_uom=frappe.db.escape(args.get("uom"))
-			)
+            if args.variant_of:
+                item_variant_condition = f" or {child_doc}.item_code=%(variant_of)s "
+                values["variant_of"] = args.variant_of
+    elif apply_on_field == "item_group":
+        item_conditions = _get_tree_conditions(args, "Item Group", child_doc, False)
+        if args.get("uom", None):
+            item_conditions += " and ({child_doc}.uom={item_uom} or IFNULL({child_doc}.uom, '')='')".format(
+                child_doc=child_doc, item_uom=frappe.db.escape(args.get("uom"))
+            )
 
-	conditions += get_other_conditions(conditions, values, args)
-	warehouse_conditions = _get_tree_conditions(args, "Warehouse", "`tabPricing Rule`")
-	if warehouse_conditions:
-		warehouse_conditions = f" and {warehouse_conditions}"
+    conditions += get_other_conditions(conditions, values, args)
+    warehouse_conditions = _get_tree_conditions(args, "Warehouse", "`tabPricing Rule`")
+    if warehouse_conditions:
+        warehouse_conditions = f" and {warehouse_conditions}"
 
-	if not args.price_list:
-		args.price_list = None
+    if not args.price_list:
+        args.price_list = None
 
-	conditions += " and ifnull(`tabPricing Rule`.for_price_list, '') in (%(price_list)s, '')"
-	values["price_list"] = args.get("price_list")
+    conditions += (
+        " and ifnull(`tabPricing Rule`.for_price_list, '') in (%(price_list)s, '')"
+    )
+    values["price_list"] = args.get("price_list")
 
-	pricing_rules = (
-		frappe.db.sql(
-			"""select `tabPricing Rule`.*,
+    pricing_rules = (
+        frappe.db.sql(
+            """select `tabPricing Rule`.*,
 			{child_doc}.{apply_on_field}, {child_doc}.uom
 		from `tabPricing Rule`, {child_doc}
 		where ({item_conditions} or (`tabPricing Rule`.apply_rule_on_other is not null
@@ -154,387 +159,454 @@ def _get_pricing_rules(apply_on, args, values):
 			`tabPricing Rule`.{transaction_type} = 1 {warehouse_cond} {conditions}
 		order by `tabPricing Rule`.priority desc,
 			`tabPricing Rule`.name desc""".format(
-				child_doc=child_doc,
-				apply_on_field=apply_on_field,
-				item_conditions=item_conditions,
-				item_variant_condition=item_variant_condition,
-				transaction_type=args.transaction_type,
-				warehouse_cond=warehouse_conditions,
-				apply_on_other_field=f"other_{apply_on_field}",
-				conditions=conditions,
-			),
-			values,
-			as_dict=1,
-		)
-		or []
-	)
+                child_doc=child_doc,
+                apply_on_field=apply_on_field,
+                item_conditions=item_conditions,
+                item_variant_condition=item_variant_condition,
+                transaction_type=args.transaction_type,
+                warehouse_cond=warehouse_conditions,
+                apply_on_other_field=f"other_{apply_on_field}",
+                conditions=conditions,
+            ),
+            values,
+            as_dict=1,
+        )
+        or []
+    )
 
-	return pricing_rules
+    return pricing_rules
 
 
 def apply_multiple_pricing_rules(pricing_rules):
-	for d in pricing_rules:
-		if not d.apply_multiple_pricing_rules:
-			return False
+    for d in pricing_rules:
+        if not d.apply_multiple_pricing_rules:
+            return False
 
-	return True
+    return True
 
 
 def _get_tree_conditions(args, parenttype, table, allow_blank=True):
-	field = frappe.scrub(parenttype)
-	condition = ""
-	if args.get(field):
-		if not frappe.flags.tree_conditions:
-			frappe.flags.tree_conditions = {}
-		key = (parenttype, args.get(field))
-		if key in frappe.flags.tree_conditions:
-			return frappe.flags.tree_conditions[key]
+    field = frappe.scrub(parenttype)
+    condition = ""
+    if args.get(field):
+        if not frappe.flags.tree_conditions:
+            frappe.flags.tree_conditions = {}
+        key = (parenttype, args.get(field))
+        if key in frappe.flags.tree_conditions:
+            return frappe.flags.tree_conditions[key]
 
-		try:
-			lft, rgt = frappe.db.get_value(parenttype, args.get(field), ["lft", "rgt"])
-		except TypeError:
-			frappe.throw(_("Invalid {0}").format(args.get(field)))
+        try:
+            lft, rgt = frappe.db.get_value(parenttype, args.get(field), ["lft", "rgt"])
+        except TypeError:
+            frappe.throw(_("Invalid {0}").format(args.get(field)))
 
-		parent_groups = frappe.db.sql_list(
-			"""select name from `tab{}`
-			where lft<={} and rgt>={}""".format(parenttype, "%s", "%s"),
-			(lft, rgt),
-		)
+        parent_groups = frappe.db.sql_list(
+            """select name from `tab{}`
+			where lft<={} and rgt>={}""".format(
+                parenttype, "%s", "%s"
+            ),
+            (lft, rgt),
+        )
 
-		if parenttype in ["Customer Group", "Item Group", "Territory"]:
-			parent_field = f"parent_{frappe.scrub(parenttype)}"
-			root_name = frappe.db.get_list(
-				parenttype,
-				{"is_group": 1, parent_field: ("is", "not set")},
-				"name",
-				as_list=1,
-				ignore_permissions=True,
-			)
+        if parenttype in ["Customer Group", "Item Group", "Territory"]:
+            parent_field = f"parent_{frappe.scrub(parenttype)}"
+            root_name = frappe.db.get_list(
+                parenttype,
+                {"is_group": 1, parent_field: ("is", "not set")},
+                "name",
+                as_list=1,
+                ignore_permissions=True,
+            )
 
-			if root_name and root_name[0][0]:
-				parent_groups.append(root_name[0][0])
+            if root_name and root_name[0][0]:
+                parent_groups.append(root_name[0][0])
 
-		if parent_groups:
-			if allow_blank:
-				parent_groups.append("")
-			condition = "ifnull({table}.{field}, '') in ({parent_groups})".format(
-				table=table, field=field, parent_groups=", ".join(frappe.db.escape(d) for d in parent_groups)
-			)
+        if parent_groups:
+            if allow_blank:
+                parent_groups.append("")
+            condition = "ifnull({table}.{field}, '') in ({parent_groups})".format(
+                table=table,
+                field=field,
+                parent_groups=", ".join(frappe.db.escape(d) for d in parent_groups),
+            )
 
-			frappe.flags.tree_conditions[key] = condition
+            frappe.flags.tree_conditions[key] = condition
 
-	elif allow_blank:
-		condition = f"ifnull({table}.{field}, '') = ''"
+    elif allow_blank:
+        condition = f"ifnull({table}.{field}, '') = ''"
 
-	return condition
+    return condition
 
 
 def get_other_conditions(conditions, values, args):
-	for field in ["company", "customer", "supplier", "campaign", "sales_partner"]:
-		if args.get(field):
-			conditions += f" and ifnull(`tabPricing Rule`.{field}, '') in (%({field})s, '')"
-			values[field] = args.get(field)
-		else:
-			conditions += f" and ifnull(`tabPricing Rule`.{field}, '') = ''"
+    for field in ["company", "customer", "supplier", "campaign", "sales_partner"]:
+        if args.get(field):
+            conditions += (
+                f" and ifnull(`tabPricing Rule`.{field}, '') in (%({field})s, '')"
+            )
+            values[field] = args.get(field)
+        else:
+            conditions += f" and ifnull(`tabPricing Rule`.{field}, '') = ''"
 
-	for parenttype in ["Customer Group", "Territory", "Supplier Group"]:
-		group_condition = _get_tree_conditions(args, parenttype, "`tabPricing Rule`")
-		if group_condition:
-			conditions += " and " + group_condition
+    for parenttype in ["Customer Group", "Territory", "Supplier Group"]:
+        group_condition = _get_tree_conditions(args, parenttype, "`tabPricing Rule`")
+        if group_condition:
+            conditions += " and " + group_condition
 
-	date = (
-		args.get("transaction_date")
-		or args.get("posting_date")
-		or frappe.get_value(args.get("doctype"), args.get("name"), "posting_date", ignore=True)
-	)
-	if date:
-		conditions += """ and %(transaction_date)s between ifnull(`tabPricing Rule`.valid_from, '2000-01-01')
+    date = (
+        args.get("transaction_date")
+        or args.get("posting_date")
+        or frappe.get_value(
+            args.get("doctype"), args.get("name"), "posting_date", ignore=True
+        )
+    )
+    if date:
+        conditions += """ and %(transaction_date)s between ifnull(`tabPricing Rule`.valid_from, '2000-01-01')
 			and ifnull(`tabPricing Rule`.valid_upto, '2500-12-31')"""
-		values["transaction_date"] = date
+        values["transaction_date"] = date
 
-	if args.get("doctype") in [
-		"Quotation",
-		"Quotation Item",
-		"Sales Order",
-		"Sales Order Item",
-		"Delivery Note",
-		"Delivery Note Item",
-		"Sales Invoice",
-		"Sales Invoice Item",
-		"POS Invoice",
-		"POS Invoice Item",
-	]:
-		conditions += """ and ifnull(`tabPricing Rule`.selling, 0) = 1"""
-	else:
-		conditions += """ and ifnull(`tabPricing Rule`.buying, 0) = 1"""
+    if args.get("doctype") in [
+        "Quotation",
+        "Quotation Item",
+        "Sales Order",
+        "Sales Order Item",
+        "Delivery Note",
+        "Delivery Note Item",
+        "Sales Invoice",
+        "Sales Invoice Item",
+        "POS Invoice",
+        "POS Invoice Item",
+    ]:
+        conditions += """ and ifnull(`tabPricing Rule`.selling, 0) = 1"""
+    else:
+        conditions += """ and ifnull(`tabPricing Rule`.buying, 0) = 1"""
 
-	return conditions
+    return conditions
 
 
 def filter_pricing_rules(args, pricing_rules, doc=None):
-	if not isinstance(pricing_rules, list):
-		pricing_rules = [pricing_rules]
+    if not isinstance(pricing_rules, list):
+        pricing_rules = [pricing_rules]
 
-	original_pricing_rule = copy.copy(pricing_rules)
+    original_pricing_rule = copy.copy(pricing_rules)
 
-	# filter for qty
-	if pricing_rules:
-		stock_qty = flt(args.get("stock_qty"))
-		amount = flt(args.get("price_list_rate")) * flt(args.get("qty"))
+    # filter for qty
+    if pricing_rules:
+        stock_qty = flt(args.get("stock_qty"))
+        amount = flt(args.get("price_list_rate")) * flt(args.get("qty"))
 
-		pr_doc = frappe.get_cached_doc("Pricing Rule", pricing_rules[0].name)
+        pr_doc = frappe.get_cached_doc("Pricing Rule", pricing_rules[0].name)
 
-		if pricing_rules[0].mixed_conditions and doc:
-			stock_qty, amount, items = get_qty_and_rate_for_mixed_conditions(doc, pr_doc, args)
-			for pricing_rule_args in pricing_rules:
-				pricing_rule_args.apply_rule_on_other_items = items
+        if pricing_rules[0].mixed_conditions and doc:
+            stock_qty, amount, items = get_qty_and_rate_for_mixed_conditions(
+                doc, pr_doc, args
+            )
+            for pricing_rule_args in pricing_rules:
+                pricing_rule_args.apply_rule_on_other_items = items
 
-		elif pricing_rules[0].is_cumulative:
-			items = [args.get(frappe.scrub(pr_doc.get("apply_on")))]
-			data = get_qty_amount_data_for_cumulative(pr_doc, args, items)
+        elif pricing_rules[0].is_cumulative:
+            items = [args.get(frappe.scrub(pr_doc.get("apply_on")))]
+            data = get_qty_amount_data_for_cumulative(pr_doc, args, items)
 
-			if data:
-				stock_qty += data[0]
-				amount += data[1]
+            if data:
+                stock_qty += data[0]
+                amount += data[1]
 
-		if pricing_rules[0].apply_rule_on_other and not pricing_rules[0].mixed_conditions and doc:
-			pricing_rules = get_qty_and_rate_for_other_item(doc, pr_doc, pricing_rules, args) or []
-		else:
-			pricing_rules = filter_pricing_rules_for_qty_amount(stock_qty, amount, pricing_rules, args)
+        if (
+            pricing_rules[0].apply_rule_on_other
+            and not pricing_rules[0].mixed_conditions
+            and doc
+        ):
+            pricing_rules = (
+                get_qty_and_rate_for_other_item(doc, pr_doc, pricing_rules, args) or []
+            )
+        else:
+            pricing_rules = filter_pricing_rules_for_qty_amount(
+                stock_qty, amount, pricing_rules, args
+            )
 
-		if not pricing_rules:
-			for d in original_pricing_rule:
-				if not d.threshold_percentage:
-					continue
+        if not pricing_rules:
+            for d in original_pricing_rule:
+                if not d.threshold_percentage:
+                    continue
 
-				msg = validate_quantity_and_amount_for_suggestion(
-					d, stock_qty, amount, args.get("item_code"), args.get("transaction_type")
-				)
+                msg = validate_quantity_and_amount_for_suggestion(
+                    d,
+                    stock_qty,
+                    amount,
+                    args.get("item_code"),
+                    args.get("transaction_type"),
+                )
 
-				if msg:
-					return {"suggestion": msg, "item_code": args.get("item_code")}
+                if msg:
+                    return {"suggestion": msg, "item_code": args.get("item_code")}
 
-		# add variant_of property in pricing rule
-		for p in pricing_rules:
-			if p.item_code and args.variant_of:
-				p.variant_of = args.variant_of
-			else:
-				p.variant_of = None
+        # add variant_of property in pricing rule
+        for p in pricing_rules:
+            if p.item_code and args.variant_of:
+                p.variant_of = args.variant_of
+            else:
+                p.variant_of = None
 
-	if len(pricing_rules) > 1:
-		filtered_rules = list(filter(lambda x: x.currency == args.get("currency"), pricing_rules))
-		if filtered_rules:
-			pricing_rules = filtered_rules
+    if len(pricing_rules) > 1:
+        filtered_rules = list(
+            filter(lambda x: x.currency == args.get("currency"), pricing_rules)
+        )
+        if filtered_rules:
+            pricing_rules = filtered_rules
 
-	# find pricing rule with highest priority
-	if pricing_rules:
-		max_priority = max(cint(p.priority) for p in pricing_rules)
-		if max_priority:
-			pricing_rules = list(filter(lambda x: cint(x.priority) == max_priority, pricing_rules))
+    # find pricing rule with highest priority
+    if pricing_rules:
+        max_priority = max(cint(p.priority) for p in pricing_rules)
+        if max_priority:
+            pricing_rules = list(
+                filter(lambda x: cint(x.priority) == max_priority, pricing_rules)
+            )
 
-	if pricing_rules and not isinstance(pricing_rules, list):
-		pricing_rules = list(pricing_rules)
+    if pricing_rules and not isinstance(pricing_rules, list):
+        pricing_rules = list(pricing_rules)
 
-	if len(pricing_rules) > 1:
-		rate_or_discount = list(set(d.rate_or_discount for d in pricing_rules))
-		if len(rate_or_discount) == 1 and rate_or_discount[0] == "Discount Percentage":
-			pricing_rules = (
-				list(filter(lambda x: x.for_price_list == args.price_list, pricing_rules)) or pricing_rules
-			)
+    if len(pricing_rules) > 1:
+        rate_or_discount = list(set(d.rate_or_discount for d in pricing_rules))
+        if len(rate_or_discount) == 1 and rate_or_discount[0] == "Discount Percentage":
+            pricing_rules = (
+                list(
+                    filter(lambda x: x.for_price_list == args.price_list, pricing_rules)
+                )
+                or pricing_rules
+            )
 
-	if len(pricing_rules) > 1 and not args.for_shopping_cart:
-		frappe.throw(
-			_(
-				"Multiple Price Rules exists with same criteria, please resolve conflict by assigning priority. Price Rules: {0}"
-			).format("\n".join(d.name for d in pricing_rules)),
-			MultiplePricingRuleConflict,
-		)
-	elif pricing_rules:
-		return pricing_rules[0]
+    if len(pricing_rules) > 1 and not args.for_shopping_cart:
+        frappe.throw(
+            _(
+                "Multiple Price Rules exists with same criteria, please resolve conflict by assigning priority. Price Rules: {0}"
+            ).format("\n".join(d.name for d in pricing_rules)),
+            MultiplePricingRuleConflict,
+        )
+    elif pricing_rules:
+        return pricing_rules[0]
 
 
-def validate_quantity_and_amount_for_suggestion(args, qty, amount, item_code, transaction_type):
-	fieldname, msg = "", ""
-	type_of_transaction = "purchase" if transaction_type == "buying" else "sale"
+def validate_quantity_and_amount_for_suggestion(
+    args, qty, amount, item_code, transaction_type
+):
+    fieldname, msg = "", ""
+    type_of_transaction = "purchase" if transaction_type == "buying" else "sale"
 
-	for field, value in {"min_qty": qty, "min_amt": amount}.items():
-		if (
-			args.get(field)
-			and value < args.get(field)
-			and (args.get(field) - cint(args.get(field) * args.threshold_percentage * 0.01)) <= value
-		):
-			fieldname = field
+    for field, value in {"min_qty": qty, "min_amt": amount}.items():
+        if (
+            args.get(field)
+            and value < args.get(field)
+            and (
+                args.get(field)
+                - cint(args.get(field) * args.threshold_percentage * 0.01)
+            )
+            <= value
+        ):
+            fieldname = field
 
-	for field, value in {"max_qty": qty, "max_amt": amount}.items():
-		if (
-			args.get(field)
-			and value > args.get(field)
-			and (args.get(field) + cint(args.get(field) * args.threshold_percentage * 0.01)) >= value
-		):
-			fieldname = field
+    for field, value in {"max_qty": qty, "max_amt": amount}.items():
+        if (
+            args.get(field)
+            and value > args.get(field)
+            and (
+                args.get(field)
+                + cint(args.get(field) * args.threshold_percentage * 0.01)
+            )
+            >= value
+        ):
+            fieldname = field
 
-	if fieldname:
-		msg = _(
-			"If you {0} {1} quantities of the item {2}, the scheme {3} will be applied on the item."
-		).format(type_of_transaction, args.get(fieldname), bold(item_code), bold(args.title))
+    if fieldname:
+        msg = _(
+            "If you {0} {1} quantities of the item {2}, the scheme {3} will be applied on the item."
+        ).format(
+            type_of_transaction, args.get(fieldname), bold(item_code), bold(args.title)
+        )
 
-		if fieldname in ["min_amt", "max_amt"]:
-			msg = _("If you {0} {1} worth item {2}, the scheme {3} will be applied on the item.").format(
-				type_of_transaction,
-				fmt_money(args.get(fieldname), currency=args.get("currency")),
-				bold(item_code),
-				bold(args.title),
-			)
+        if fieldname in ["min_amt", "max_amt"]:
+            msg = _(
+                "If you {0} {1} worth item {2}, the scheme {3} will be applied on the item."
+            ).format(
+                type_of_transaction,
+                fmt_money(args.get(fieldname), currency=args.get("currency")),
+                bold(item_code),
+                bold(args.title),
+            )
 
-		frappe.msgprint(msg)
+        frappe.msgprint(msg)
 
-	return msg
+    return msg
 
 
 def filter_pricing_rules_for_qty_amount(qty, rate, pricing_rules, args=None):
-	rules = []
+    rules = []
 
-	for rule in pricing_rules:
-		status = False
-		conversion_factor = 1
+    for rule in pricing_rules:
+        status = False
+        conversion_factor = 1
 
-		if rule.get("uom"):
-			conversion_factor = get_conversion_factor(rule.item_code, rule.uom).get("conversion_factor", 1)
+        if rule.get("uom"):
+            conversion_factor = get_conversion_factor(rule.item_code, rule.uom).get(
+                "conversion_factor", 1
+            )
 
-		if flt(qty) >= (flt(rule.min_qty) * conversion_factor) and (
-			flt(qty) <= (rule.max_qty * conversion_factor) if rule.max_qty else True
-		):
-			status = True
+        if flt(qty) >= (flt(rule.min_qty) * conversion_factor) and (
+            flt(qty) <= (rule.max_qty * conversion_factor) if rule.max_qty else True
+        ):
+            status = True
 
-		# if user has created item price against the transaction UOM
-		if args and rule.get("uom") == args.get("uom"):
-			conversion_factor = 1.0
+        # if user has created item price against the transaction UOM
+        if args and rule.get("uom") == args.get("uom"):
+            conversion_factor = 1.0
 
-		if status and (
-			flt(rate) >= (flt(rule.min_amt) * conversion_factor)
-			and (flt(rate) <= (rule.max_amt * conversion_factor) if rule.max_amt else True)
-		):
-			status = True
-		else:
-			status = False
+        if status and (
+            flt(rate) >= (flt(rule.min_amt) * conversion_factor)
+            and (
+                flt(rate) <= (rule.max_amt * conversion_factor)
+                if rule.max_amt
+                else True
+            )
+        ):
+            status = True
+        else:
+            status = False
 
-		if status:
-			rules.append(rule)
+        if status:
+            rules.append(rule)
 
-	return rules
+    return rules
 
 
 def if_all_rules_same(pricing_rules, fields):
-	all_rules_same = True
-	val = [pricing_rules[0].get(k) for k in fields]
-	for p in pricing_rules[1:]:
-		if val != [p.get(k) for k in fields]:
-			all_rules_same = False
-			break
+    all_rules_same = True
+    val = [pricing_rules[0].get(k) for k in fields]
+    for p in pricing_rules[1:]:
+        if val != [p.get(k) for k in fields]:
+            all_rules_same = False
+            break
 
-	return all_rules_same
+    return all_rules_same
 
 
 def apply_internal_priority(pricing_rules, field_set, args):
-	filtered_rules = []
-	for field in field_set:
-		if args.get(field):
-			# filter function always returns a filter object even if empty
-			# list conversion is necessary to check for an empty result
-			filtered_rules = list(filter(lambda x: x.get(field) == args.get(field), pricing_rules))
-			if filtered_rules:
-				break
+    filtered_rules = []
+    for field in field_set:
+        if args.get(field):
+            # filter function always returns a filter object even if empty
+            # list conversion is necessary to check for an empty result
+            filtered_rules = list(
+                filter(lambda x: x.get(field) == args.get(field), pricing_rules)
+            )
+            if filtered_rules:
+                break
 
-	return filtered_rules or pricing_rules
+    return filtered_rules or pricing_rules
 
 
 def get_qty_and_rate_for_mixed_conditions(doc, pr_doc, args):
-	sum_qty, sum_amt = [0, 0]
-	items = get_pricing_rule_items(pr_doc) or []
-	apply_on = frappe.scrub(pr_doc.get("apply_on"))
+    sum_qty, sum_amt = [0, 0]
+    items = get_pricing_rule_items(pr_doc) or []
+    apply_on = frappe.scrub(pr_doc.get("apply_on"))
 
-	if items and doc.get("items"):
-		for row in doc.get("items"):
-			if (row.get(apply_on) or args.get(apply_on)) not in items:
-				continue
+    if items and doc.get("items"):
+        for row in doc.get("items"):
+            if (row.get(apply_on) or args.get(apply_on)) not in items:
+                continue
 
-			if pr_doc.mixed_conditions:
-				amt = args.get("qty") * args.get("price_list_rate")
-				if args.get("item_code") != row.get("item_code"):
-					amt = flt(row.get("qty")) * flt(row.get("price_list_rate") or args.get("rate"))
+            if pr_doc.mixed_conditions:
+                amt = args.get("qty") * args.get("price_list_rate")
+                if args.get("item_code") != row.get("item_code"):
+                    amt = flt(row.get("qty")) * flt(
+                        row.get("price_list_rate") or args.get("rate")
+                    )
 
-				sum_qty += flt(row.get("stock_qty")) or flt(args.get("stock_qty")) or flt(args.get("qty"))
-				sum_amt += amt
+                sum_qty += (
+                    flt(row.get("stock_qty"))
+                    or flt(args.get("stock_qty"))
+                    or flt(args.get("qty"))
+                )
+                sum_amt += amt
 
-		if pr_doc.is_cumulative:
-			data = get_qty_amount_data_for_cumulative(pr_doc, doc, items)
+        if pr_doc.is_cumulative:
+            data = get_qty_amount_data_for_cumulative(pr_doc, doc, items)
 
-			if data and data[0]:
-				sum_qty += data[0]
-				sum_amt += data[1]
+            if data and data[0]:
+                sum_qty += data[0]
+                sum_amt += data[1]
 
-	return sum_qty, sum_amt, items
+    return sum_qty, sum_amt, items
 
 
 def get_qty_and_rate_for_other_item(doc, pr_doc, pricing_rules, row_item):
-	other_items = get_pricing_rule_items(pr_doc, other_items=True)
-	pricing_rule_apply_on = apply_on_table.get(pr_doc.get("apply_on"))
-	apply_on = frappe.scrub(pr_doc.get("apply_on"))
+    other_items = get_pricing_rule_items(pr_doc, other_items=True)
+    pricing_rule_apply_on = apply_on_table.get(pr_doc.get("apply_on"))
+    apply_on = frappe.scrub(pr_doc.get("apply_on"))
 
-	items = []
-	for d in pr_doc.get(pricing_rule_apply_on):
-		if apply_on == "item_group":
-			items.extend(get_child_item_groups(d.get(apply_on)))
-		else:
-			items.append(d.get(apply_on))
+    items = []
+    for d in pr_doc.get(pricing_rule_apply_on):
+        if apply_on == "item_group":
+            items.extend(get_child_item_groups(d.get(apply_on)))
+        else:
+            items.append(d.get(apply_on))
 
-	for row in doc.items:
-		if row.get(apply_on) in items:
-			if not row.get("qty"):
-				continue
+    for row in doc.items:
+        if row.get(apply_on) in items:
+            if not row.get("qty"):
+                continue
 
-			stock_qty = row.get("qty") * (row.get("conversion_factor") or 1.0)
-			amount = stock_qty * (flt(row.get("price_list_rate")) or flt(row.get("rate")))
-			pricing_rules = filter_pricing_rules_for_qty_amount(stock_qty, amount, pricing_rules, row)
+            stock_qty = row.get("qty") * (row.get("conversion_factor") or 1.0)
+            amount = stock_qty * (
+                flt(row.get("price_list_rate")) or flt(row.get("rate"))
+            )
+            pricing_rules = filter_pricing_rules_for_qty_amount(
+                stock_qty, amount, pricing_rules, row
+            )
 
-			if pricing_rules and pricing_rules[0]:
-				pricing_rules[0].apply_rule_on_other_items = other_items
-				return pricing_rules
+            if pricing_rules and pricing_rules[0]:
+                pricing_rules[0].apply_rule_on_other_items = other_items
+                return pricing_rules
 
 
 def get_qty_amount_data_for_cumulative(pr_doc, doc, items=None):
-	if items is None:
-		items = []
-	sum_qty, sum_amt = [0, 0]
-	doctype = doc.get("parenttype") or doc.doctype
+    if items is None:
+        items = []
+    sum_qty, sum_amt = [0, 0]
+    doctype = doc.get("parenttype") or doc.doctype
 
-	date_field = (
-		"transaction_date" if frappe.get_meta(doctype).has_field("transaction_date") else "posting_date"
-	)
+    date_field = (
+        "transaction_date"
+        if frappe.get_meta(doctype).has_field("transaction_date")
+        else "posting_date"
+    )
 
-	child_doctype = f"{doctype} Item"
-	apply_on = frappe.scrub(pr_doc.get("apply_on"))
+    child_doctype = f"{doctype} Item"
+    apply_on = frappe.scrub(pr_doc.get("apply_on"))
 
-	values = [pr_doc.valid_from, pr_doc.valid_upto]
-	condition = ""
+    values = [pr_doc.valid_from, pr_doc.valid_upto]
+    condition = ""
 
-	if pr_doc.warehouse:
-		warehouses = get_child_warehouses(pr_doc.warehouse)
+    if pr_doc.warehouse:
+        warehouses = get_child_warehouses(pr_doc.warehouse)
 
-		condition += """ and `tab{child_doc}`.warehouse in ({warehouses})
-			""".format(child_doc=child_doctype, warehouses=",".join(["%s"] * len(warehouses)))
+        condition += """ and `tab{child_doc}`.warehouse in ({warehouses})
+			""".format(
+            child_doc=child_doctype, warehouses=",".join(["%s"] * len(warehouses))
+        )
 
-		values.extend(warehouses)
+        values.extend(warehouses)
 
-	if items:
-		condition += " and `tab{child_doc}`.{apply_on} in ({items})".format(
-			child_doc=child_doctype, apply_on=apply_on, items=",".join(["%s"] * len(items))
-		)
+    if items:
+        condition += " and `tab{child_doc}`.{apply_on} in ({items})".format(
+            child_doc=child_doctype,
+            apply_on=apply_on,
+            items=",".join(["%s"] * len(items)),
+        )
 
-		values.extend(items)
+        values.extend(items)
 
-	data_set = frappe.db.sql(
-		f""" SELECT `tab{child_doctype}`.stock_qty,
+    data_set = frappe.db.sql(
+        f""" SELECT `tab{child_doctype}`.stock_qty,
 			`tab{child_doctype}`.amount
 		FROM `tab{child_doctype}`, `tab{doctype}`
 		WHERE
@@ -542,237 +614,258 @@ def get_qty_amount_data_for_cumulative(pr_doc, doc, items=None):
 			between %s and %s and `tab{doctype}`.docstatus = 1
 			{condition} group by `tab{child_doctype}`.name
 	""",
-		tuple(values),
-		as_dict=1,
-	)
+        tuple(values),
+        as_dict=1,
+    )
 
-	for data in data_set:
-		sum_qty += data.get("stock_qty")
-		sum_amt += data.get("amount")
+    for data in data_set:
+        sum_qty += data.get("stock_qty")
+        sum_amt += data.get("amount")
 
-	return [sum_qty, sum_amt]
+    return [sum_qty, sum_amt]
 
 
 def apply_pricing_rule_on_transaction(doc):
-	conditions = "apply_on = 'Transaction'"
+    conditions = "apply_on = 'Transaction'"
 
-	values = {}
-	conditions = get_other_conditions(conditions, values, doc)
+    values = {}
+    conditions = get_other_conditions(conditions, values, doc)
 
-	pricing_rules = frappe.db.sql(
-		f""" Select `tabPricing Rule`.* from `tabPricing Rule`
+    pricing_rules = frappe.db.sql(
+        f""" Select `tabPricing Rule`.* from `tabPricing Rule`
 		where  {conditions} and `tabPricing Rule`.disable = 0
 	""",
-		values,
-		as_dict=1,
-	)
+        values,
+        as_dict=1,
+    )
 
-	if pricing_rules:
-		pricing_rules = filter_pricing_rules_for_qty_amount(doc.total_qty, doc.total, pricing_rules)
-		pricing_rules = filter_pricing_rule_based_on_condition(pricing_rules, doc)
+    if pricing_rules:
+        pricing_rules = filter_pricing_rules_for_qty_amount(
+            doc.total_qty, doc.total, pricing_rules
+        )
+        pricing_rules = filter_pricing_rule_based_on_condition(pricing_rules, doc)
 
-		if not pricing_rules:
-			remove_free_item(doc)
+        if not pricing_rules:
+            remove_free_item(doc)
 
-		for d in pricing_rules:
-			if d.price_or_product_discount == "Price":
-				if d.apply_discount_on:
-					doc.set("apply_discount_on", d.apply_discount_on)
-				# Variable to track whether the condition has been met
-				condition_met = False
+        for d in pricing_rules:
+            if d.price_or_product_discount == "Price":
+                if d.apply_discount_on:
+                    doc.set("apply_discount_on", d.apply_discount_on)
+                # Variable to track whether the condition has been met
+                condition_met = False
 
-				for field in ["additional_discount_percentage", "discount_amount"]:
-					pr_field = "discount_percentage" if field == "additional_discount_percentage" else field
+                for field in ["additional_discount_percentage", "discount_amount"]:
+                    pr_field = (
+                        "discount_percentage"
+                        if field == "additional_discount_percentage"
+                        else field
+                    )
 
-					if not d.get(pr_field):
-						continue
+                    if not d.get(pr_field):
+                        continue
 
-					if (
-						d.validate_applied_rule
-						and doc.get(field) is not None
-						and doc.get(field) < d.get(pr_field)
-					):
-						frappe.msgprint(_("User has not applied rule on the invoice {0}").format(doc.name))
-					else:
-						if not d.coupon_code_based:
-							doc.set(field, d.get(pr_field))
-						elif doc.get("coupon_code"):
-							# coupon code based pricing rule
-							coupon_code_pricing_rule = frappe.db.get_value(
-								"Coupon Code", doc.get("coupon_code"), "pricing_rule"
-							)
-							if coupon_code_pricing_rule == d.name:
-								# if selected coupon code is linked with pricing rule
-								doc.set(field, d.get(pr_field))
+                    if (
+                        d.validate_applied_rule
+                        and doc.get(field) is not None
+                        and doc.get(field) < d.get(pr_field)
+                    ):
+                        frappe.msgprint(
+                            _("User has not applied rule on the invoice {0}").format(
+                                doc.name
+                            )
+                        )
+                    else:
+                        if not d.coupon_code_based:
+                            doc.set(field, d.get(pr_field))
+                        elif doc.get("coupon_code"):
+                            # coupon code based pricing rule
+                            coupon_code_pricing_rule = frappe.db.get_value(
+                                "Coupon Code", doc.get("coupon_code"), "pricing_rule"
+                            )
+                            if coupon_code_pricing_rule == d.name:
+                                # if selected coupon code is linked with pricing rule
+                                doc.set(field, d.get(pr_field))
 
-								# Set the condition_met variable to True and break out of the loop
-								condition_met = True
-								break
+                                # Set the condition_met variable to True and break out of the loop
+                                condition_met = True
+                                break
 
-							else:
-								# reset discount if not linked
-								doc.set(field, 0)
-						else:
-							# if coupon code based but no coupon code selected
-							doc.set(field, 0)
+                            else:
+                                # reset discount if not linked
+                                doc.set(field, 0)
+                        else:
+                            # if coupon code based but no coupon code selected
+                            doc.set(field, 0)
 
-				doc.calculate_taxes_and_totals()
+                doc.calculate_taxes_and_totals()
 
-				# Break out of the main loop if the condition is met
-				if condition_met:
-					break
-			elif d.price_or_product_discount == "Product":
-				item_details = frappe._dict({"parenttype": doc.doctype, "free_item_data": []})
-				get_product_discount_rule(d, item_details, doc=doc)
-				apply_pricing_rule_for_free_items(doc, item_details.free_item_data)
-				doc.set_missing_values()
-				doc.calculate_taxes_and_totals()
+                # Break out of the main loop if the condition is met
+                if condition_met:
+                    break
+            elif d.price_or_product_discount == "Product":
+                item_details = frappe._dict(
+                    {"parenttype": doc.doctype, "free_item_data": []}
+                )
+                get_product_discount_rule(d, item_details, doc=doc)
+                apply_pricing_rule_for_free_items(doc, item_details.free_item_data)
+
+                prev_flag = getattr(doc.flags, "in_pricing_rule_recalc", 0)
+                doc.flags.in_pricing_rule_recalc = 1
+                try:
+                    doc.set_missing_values()
+                finally:
+                    doc.flags.in_pricing_rule_recalc = prev_flag
+
+                doc.calculate_taxes_and_totals()
 
 
 def remove_free_item(doc):
-	for d in doc.items:
-		if d.is_free_item:
-			doc.remove(d)
+    for d in doc.items:
+        if d.is_free_item:
+            doc.remove(d)
 
 
 def get_applied_pricing_rules(pricing_rules):
-	if pricing_rules:
-		if pricing_rules.startswith("["):
-			return json.loads(pricing_rules)
-		else:
-			return pricing_rules.split(",")
+    if pricing_rules:
+        if pricing_rules.startswith("["):
+            return json.loads(pricing_rules)
+        else:
+            return pricing_rules.split(",")
 
-	return []
+    return []
 
 
 def get_product_discount_rule(pricing_rule, item_details, args=None, doc=None):
-	free_item = pricing_rule.free_item
-	if pricing_rule.same_item and pricing_rule.get("apply_on") != "Transaction":
-		free_item = item_details.item_code or args.item_code
+    free_item = pricing_rule.free_item
+    if pricing_rule.same_item and pricing_rule.get("apply_on") != "Transaction":
+        free_item = item_details.item_code or args.item_code
 
-	if not free_item:
-		frappe.throw(
-			_("Free item not set in the pricing rule {0}").format(
-				get_link_to_form("Pricing Rule", pricing_rule.name)
-			)
-		)
+    if not free_item:
+        frappe.throw(
+            _("Free item not set in the pricing rule {0}").format(
+                get_link_to_form("Pricing Rule", pricing_rule.name)
+            )
+        )
 
-	qty = pricing_rule.free_qty or 1
-	if pricing_rule.is_recursive:
-		transaction_qty = sum(
-			[
-				row.qty
-				for row in doc.items
-				if not row.is_free_item
-				and row.item_code == args.item_code
-				and row.pricing_rules == args.pricing_rules
-			]
-		)
-		transaction_qty = transaction_qty - pricing_rule.apply_recursion_over
-		if transaction_qty and transaction_qty > 0:
-			qty = flt(transaction_qty) * qty / pricing_rule.recurse_for
-			if pricing_rule.round_free_qty:
-				qty = (flt(transaction_qty) // pricing_rule.recurse_for) * (pricing_rule.free_qty or 1)
+    qty = pricing_rule.free_qty or 1
+    if pricing_rule.is_recursive:
+        transaction_qty = sum(
+            [
+                row.qty
+                for row in doc.items
+                if not row.is_free_item
+                and row.item_code == args.item_code
+                and row.pricing_rules == args.pricing_rules
+            ]
+        )
+        transaction_qty = transaction_qty - pricing_rule.apply_recursion_over
+        if transaction_qty and transaction_qty > 0:
+            qty = flt(transaction_qty) * qty / pricing_rule.recurse_for
+            if pricing_rule.round_free_qty:
+                qty = (flt(transaction_qty) // pricing_rule.recurse_for) * (
+                    pricing_rule.free_qty or 1
+                )
 
-	if not qty:
-		return
+    if not qty:
+        return
 
-	free_item_data_args = {
-		"item_code": free_item,
-		"qty": qty,
-		"pricing_rules": pricing_rule.name,
-		"rate": pricing_rule.free_item_rate or 0,
-		"price_list_rate": pricing_rule.free_item_rate or 0,
-		"is_free_item": 1,
-	}
+    free_item_data_args = {
+        "item_code": free_item,
+        "qty": qty,
+        "pricing_rules": pricing_rule.name,
+        "rate": pricing_rule.free_item_rate or 0,
+        "price_list_rate": pricing_rule.free_item_rate or 0,
+        "is_free_item": 1,
+    }
 
-	item_data = frappe.get_cached_value(
-		"Item", free_item, ["item_name", "description", "stock_uom"], as_dict=1
-	)
+    item_data = frappe.get_cached_value(
+        "Item", free_item, ["item_name", "description", "stock_uom"], as_dict=1
+    )
 
-	free_item_data_args.update(item_data)
-	free_item_data_args["uom"] = pricing_rule.free_item_uom or item_data.stock_uom
-	free_item_data_args["conversion_factor"] = get_conversion_factor(
-		free_item, free_item_data_args["uom"]
-	).get("conversion_factor", 1)
+    free_item_data_args.update(item_data)
+    free_item_data_args["uom"] = pricing_rule.free_item_uom or item_data.stock_uom
+    free_item_data_args["conversion_factor"] = get_conversion_factor(
+        free_item, free_item_data_args["uom"]
+    ).get("conversion_factor", 1)
 
-	if item_details.get("parenttype") == "Purchase Order":
-		free_item_data_args["schedule_date"] = doc.schedule_date if doc else today()
+    if item_details.get("parenttype") == "Purchase Order":
+        free_item_data_args["schedule_date"] = doc.schedule_date if doc else today()
 
-	if item_details.get("parenttype") == "Sales Order":
-		free_item_data_args["delivery_date"] = doc.delivery_date if doc else today()
+    if item_details.get("parenttype") == "Sales Order":
+        free_item_data_args["delivery_date"] = doc.delivery_date if doc else today()
 
-	item_details.free_item_data.append(free_item_data_args)
+    item_details.free_item_data.append(free_item_data_args)
 
 
 def apply_pricing_rule_for_free_items(doc, pricing_rule_args):
-	if pricing_rule_args:
-		args = {(d["item_code"], d["pricing_rules"]): d for d in pricing_rule_args}
+    if pricing_rule_args:
+        args = {(d["item_code"], d["pricing_rules"]): d for d in pricing_rule_args}
 
-		for item in doc.items:
-			if not item.is_free_item:
-				continue
+        for item in doc.items:
+            if not item.is_free_item:
+                continue
 
-			free_item_data = args.get((item.item_code, item.pricing_rules))
-			if free_item_data:
-				free_item_data.pop("item_name")
-				free_item_data.pop("description")
-				item.update(free_item_data)
-				args.pop((item.item_code, item.pricing_rules))
+            free_item_data = args.get((item.item_code, item.pricing_rules))
+            if free_item_data:
+                free_item_data.pop("item_name")
+                free_item_data.pop("description")
+                item.update(free_item_data)
+                args.pop((item.item_code, item.pricing_rules))
 
-		for free_item in args.values():
-			if doc.is_new() or not frappe.get_value(
-				"Pricing Rule", free_item["pricing_rules"], "dont_enforce_free_item_qty"
-			):
-				doc.append("items", free_item)
+        for free_item in args.values():
+            if doc.is_new() or not frappe.get_value(
+                "Pricing Rule", free_item["pricing_rules"], "dont_enforce_free_item_qty"
+            ):
+                doc.append("items", free_item)
 
 
 def get_pricing_rule_items(pr_doc, other_items=False) -> list:
-	apply_on_data = []
-	apply_on = frappe.scrub(pr_doc.get("apply_on"))
+    apply_on_data = []
+    apply_on = frappe.scrub(pr_doc.get("apply_on"))
 
-	pricing_rule_apply_on = apply_on_table.get(pr_doc.get("apply_on"))
+    pricing_rule_apply_on = apply_on_table.get(pr_doc.get("apply_on"))
 
-	if pr_doc.apply_rule_on_other and other_items:
-		apply_on = frappe.scrub(pr_doc.apply_rule_on_other)
-		apply_on_data.append(pr_doc.get("other_" + apply_on))
-	else:
-		for d in pr_doc.get(pricing_rule_apply_on):
-			if apply_on == "item_group":
-				apply_on_data.extend(get_child_item_groups(d.get(apply_on)))
-			else:
-				apply_on_data.append(d.get(apply_on))
+    if pr_doc.apply_rule_on_other and other_items:
+        apply_on = frappe.scrub(pr_doc.apply_rule_on_other)
+        apply_on_data.append(pr_doc.get("other_" + apply_on))
+    else:
+        for d in pr_doc.get(pricing_rule_apply_on):
+            if apply_on == "item_group":
+                apply_on_data.extend(get_child_item_groups(d.get(apply_on)))
+            else:
+                apply_on_data.append(d.get(apply_on))
 
-	return list(set(apply_on_data))
+    return list(set(apply_on_data))
 
 
 def validate_coupon_code(coupon_name):
-	coupon = frappe.get_doc("Coupon Code", coupon_name)
-	if coupon.valid_from and coupon.valid_from > getdate(today()):
-		frappe.throw(_("Sorry, this coupon code's validity has not started"))
-	elif coupon.valid_upto and coupon.valid_upto < getdate(today()):
-		frappe.throw(_("Sorry, this coupon code's validity has expired"))
-	elif coupon.maximum_use and coupon.used >= coupon.maximum_use:
-		frappe.throw(_("Sorry, this coupon code is no longer valid"))
+    coupon = frappe.get_doc("Coupon Code", coupon_name)
+    if coupon.valid_from and coupon.valid_from > getdate(today()):
+        frappe.throw(_("Sorry, this coupon code's validity has not started"))
+    elif coupon.valid_upto and coupon.valid_upto < getdate(today()):
+        frappe.throw(_("Sorry, this coupon code's validity has expired"))
+    elif coupon.maximum_use and coupon.used >= coupon.maximum_use:
+        frappe.throw(_("Sorry, this coupon code is no longer valid"))
 
 
 def update_coupon_code_count(coupon_name, transaction_type):
-	coupon = frappe.get_doc("Coupon Code", coupon_name)
-	if coupon:
-		if transaction_type == "used":
-			if not coupon.maximum_use:
-				coupon.used = coupon.used + 1
-				coupon.save(ignore_permissions=True)
-			elif coupon.used < coupon.maximum_use:
-				coupon.used = coupon.used + 1
-				coupon.save(ignore_permissions=True)
-			else:
-				frappe.throw(
-					_("{0} Coupon used are {1}. Allowed quantity is exhausted").format(
-						coupon.coupon_code, coupon.used
-					)
-				)
-		elif transaction_type == "cancelled":
-			if coupon.used > 0:
-				coupon.used = coupon.used - 1
-				coupon.save(ignore_permissions=True)
+    coupon = frappe.get_doc("Coupon Code", coupon_name)
+    if coupon:
+        if transaction_type == "used":
+            if not coupon.maximum_use:
+                coupon.used = coupon.used + 1
+                coupon.save(ignore_permissions=True)
+            elif coupon.used < coupon.maximum_use:
+                coupon.used = coupon.used + 1
+                coupon.save(ignore_permissions=True)
+            else:
+                frappe.throw(
+                    _("{0} Coupon used are {1}. Allowed quantity is exhausted").format(
+                        coupon.coupon_code, coupon.used
+                    )
+                )
+        elif transaction_type == "cancelled":
+            if coupon.used > 0:
+                coupon.used = coupon.used - 1
+                coupon.save(ignore_permissions=True)

--- a/erpnext/controllers/selling_controller.py
+++ b/erpnext/controllers/selling_controller.py
@@ -8,1088 +8,1295 @@ from frappe.utils import cint, flt, get_link_to_form, nowtime
 
 from erpnext.accounts.party import render_address
 from erpnext.controllers.accounts_controller import get_taxes_and_charges
-from erpnext.controllers.sales_and_purchase_return import get_rate_for_return, is_batch_expired
+from erpnext.controllers.sales_and_purchase_return import (
+    get_rate_for_return,
+    is_batch_expired,
+)
 from erpnext.controllers.stock_controller import StockController
 from erpnext.stock.doctype.item.item import set_item_default
 from erpnext.stock.get_item_details import get_bin_details, get_conversion_factor
-from erpnext.stock.utils import get_combine_datetime, get_incoming_rate, get_valuation_method
+from erpnext.stock.utils import (
+    get_combine_datetime,
+    get_incoming_rate,
+    get_valuation_method,
+)
 
 
 class SellingController(StockController):
-	def __setup__(self):
-		self.flags.ignore_permlevel_for_fields = ["selling_price_list", "price_list_currency"]
+    def __setup__(self):
+        self.flags.ignore_permlevel_for_fields = [
+            "selling_price_list",
+            "price_list_currency",
+        ]
 
-	def onload(self):
-		super().onload()
-		if (
-			self.doctype in ("Sales Order", "Delivery Note", "Sales Invoice", "Quotation")
-			and self.docstatus.is_draft()
-			and not hasattr(self, "_action")
-		):
-			for item in self.get("items") + (self.get("packed_items") or []):
-				company = self.company
+    def onload(self):
+        super().onload()
+        if (
+            self.doctype
+            in ("Sales Order", "Delivery Note", "Sales Invoice", "Quotation")
+            and self.docstatus.is_draft()
+            and not hasattr(self, "_action")
+        ):
+            for item in self.get("items") + (self.get("packed_items") or []):
+                company = self.company
 
-				item.update(
-					get_bin_details(
-						item.item_code, item.warehouse, company=company, include_child_warehouses=True
-					)
-				)
+                item.update(
+                    get_bin_details(
+                        item.item_code,
+                        item.warehouse,
+                        company=company,
+                        include_child_warehouses=True,
+                    )
+                )
 
-		if self.docstatus == 1 and self.doctype in ["Delivery Note", "Sales Invoice"]:
-			self.set_onload(
-				"allow_to_make_qc_after_submission",
-				frappe.get_single_value(
-					"Stock Settings", "allow_to_make_quality_inspection_after_purchase_or_delivery"
-				),
-			)
+        if self.docstatus == 1 and self.doctype in ["Delivery Note", "Sales Invoice"]:
+            self.set_onload(
+                "allow_to_make_qc_after_submission",
+                frappe.get_single_value(
+                    "Stock Settings",
+                    "allow_to_make_quality_inspection_after_purchase_or_delivery",
+                ),
+            )
 
-		if (
-			self.get("company")
-			and (
-				default_selling_terms := frappe.get_value(
-					"Company", self.get("company"), "default_selling_terms"
-				)
-			)
-			and not self.get("tc_name")
-			and not self.get("terms")
-		):
-			self.tc_name = default_selling_terms
-			self.terms = frappe.get_value("Terms and Conditions", self.get("tc_name"), "terms")
+        if (
+            self.get("company")
+            and (
+                default_selling_terms := frappe.get_value(
+                    "Company", self.get("company"), "default_selling_terms"
+                )
+            )
+            and not self.get("tc_name")
+            and not self.get("terms")
+        ):
+            self.tc_name = default_selling_terms
+            self.terms = frappe.get_value(
+                "Terms and Conditions", self.get("tc_name"), "terms"
+            )
 
-	def validate(self):
-		super().validate()
-		self.validate_items()
-		if not (self.get("is_debit_note") or self.get("is_return")):
-			self.validate_max_discount()
-		self.validate_selling_price()
-		self.set_qty_as_per_stock_uom()
-		self.set_po_nos(for_validate=True)
-		self.set_gross_profit()
-		set_default_income_account_for_item(self)
-		self.set_customer_address()
-		self.validate_for_duplicate_items()
-		self.validate_target_warehouse()
-		self.validate_auto_repeat_subscription_dates()
-		for table_field in ["items", "packed_items"]:
-			if self.get(table_field):
-				self.set_serial_and_batch_bundle(table_field)
+    def validate(self):
+        super().validate()
+        self.validate_items()
+        if not (self.get("is_debit_note") or self.get("is_return")):
+            self.validate_max_discount()
+        self.validate_selling_price()
+        self.set_qty_as_per_stock_uom()
+        self.set_po_nos(for_validate=True)
+        self.set_gross_profit()
+        set_default_income_account_for_item(self)
+        self.set_customer_address()
+        self.validate_for_duplicate_items()
+        self.validate_target_warehouse()
+        self.validate_auto_repeat_subscription_dates()
+        for table_field in ["items", "packed_items"]:
+            if self.get(table_field):
+                self.set_serial_and_batch_bundle(table_field)
 
-	def validate_standalone_serial_nos_customer(self):
-		if not self.is_return or self.return_against:
-			return
+    def validate_standalone_serial_nos_customer(self):
+        if not self.is_return or self.return_against:
+            return
 
-		if self.doctype in ["Sales Invoice", "Delivery Note"]:
-			bundle_ids = [d.serial_and_batch_bundle for d in self.get("items") if d.serial_and_batch_bundle]
-			if not bundle_ids:
-				return
+        if self.doctype in ["Sales Invoice", "Delivery Note"]:
+            bundle_ids = [
+                d.serial_and_batch_bundle
+                for d in self.get("items")
+                if d.serial_and_batch_bundle
+            ]
+            if not bundle_ids:
+                return
 
-			serial_nos = frappe.get_all(
-				"Serial and Batch Entry",
-				filters={"parent": ("in", bundle_ids), "serial_no": ("is", "set")},
-				pluck="serial_no",
-			)
+            serial_nos = frappe.get_all(
+                "Serial and Batch Entry",
+                filters={"parent": ("in", bundle_ids), "serial_no": ("is", "set")},
+                pluck="serial_no",
+            )
 
-			if not serial_nos:
-				return
+            if not serial_nos:
+                return
 
-			if serial_nos := frappe.get_all(
-				"Serial No",
-				filters={"name": ("in", serial_nos), "customer": ("is", "set")},
-				fields=["name", "customer"],
-			):
-				for sn in serial_nos:
-					if sn.customer and sn.customer != self.customer:
-						frappe.throw(
-							_(
-								"Serial No {0} is already assigned to customer {1}. Can only be returned against the customer {1}"
-							).format(frappe.bold(sn.name), frappe.bold(sn.customer)),
-							title=_("Serial No Already Assigned"),
-						)
+            if serial_nos := frappe.get_all(
+                "Serial No",
+                filters={"name": ("in", serial_nos), "customer": ("is", "set")},
+                fields=["name", "customer"],
+            ):
+                for sn in serial_nos:
+                    if sn.customer and sn.customer != self.customer:
+                        frappe.throw(
+                            _(
+                                "Serial No {0} is already assigned to customer {1}. Can only be returned against the customer {1}"
+                            ).format(frappe.bold(sn.name), frappe.bold(sn.customer)),
+                            title=_("Serial No Already Assigned"),
+                        )
 
-	def set_missing_values(self, for_validate=False):
-		super().set_missing_values(for_validate)
+    def set_missing_values(self, for_validate=False):
+        super().set_missing_values(for_validate)
 
-		# set contact and address details for customer, if they are not mentioned
-		self.set_missing_lead_customer_details(for_validate=for_validate)
-		self.set_price_list_and_item_details(for_validate=for_validate)
-		self.set_company_contact_person()
+        # set contact and address details for customer, if they are not mentioned
+        self.set_missing_lead_customer_details(for_validate=for_validate)
+        self.set_price_list_and_item_details(for_validate=for_validate)
+        self.set_company_contact_person()
 
-	def set_missing_lead_customer_details(self, for_validate=False):
-		customer, lead = None, None
-		if getattr(self, "customer", None):
-			customer = self.customer
-		elif self.doctype == "Opportunity" and self.party_name:
-			if self.opportunity_from == "Customer":
-				customer = self.party_name
-			else:
-				lead = self.party_name
-		elif self.doctype == "Quotation" and self.party_name:
-			if self.quotation_to == "Customer":
-				customer = self.party_name
-			elif self.quotation_to == "Lead":
-				lead = self.party_name
+    def set_missing_lead_customer_details(self, for_validate=False):
+        customer, lead = None, None
+        if getattr(self, "customer", None):
+            customer = self.customer
+        elif self.doctype == "Opportunity" and self.party_name:
+            if self.opportunity_from == "Customer":
+                customer = self.party_name
+            else:
+                lead = self.party_name
+        elif self.doctype == "Quotation" and self.party_name:
+            if self.quotation_to == "Customer":
+                customer = self.party_name
+            elif self.quotation_to == "Lead":
+                lead = self.party_name
 
-		if customer:
-			from erpnext.accounts.party import _get_party_details
+        if customer:
+            from erpnext.accounts.party import _get_party_details
 
-			party_details = _get_party_details(
-				customer,
-				ignore_permissions=self.flags.ignore_permissions,
-				doctype=self.doctype,
-				company=self.company,
-				posting_date=self.get("posting_date"),
-				fetch_payment_terms_template=self.has_value_changed("company"),
-				party_address=self.customer_address,
-				shipping_address=self.shipping_address_name,
-				company_address=self.get("company_address"),
-			)
-			if not self.meta.get_field("sales_team"):
-				party_details.pop("sales_team")
-			self.update_if_missing(party_details)
+            party_details = _get_party_details(
+                customer,
+                ignore_permissions=self.flags.ignore_permissions,
+                doctype=self.doctype,
+                company=self.company,
+                posting_date=self.get("posting_date"),
+                fetch_payment_terms_template=self.has_value_changed("company"),
+                party_address=self.customer_address,
+                shipping_address=self.shipping_address_name,
+                company_address=self.get("company_address"),
+            )
+            if not self.meta.get_field("sales_team"):
+                party_details.pop("sales_team")
+            self.update_if_missing(party_details)
 
-		elif lead:
-			from erpnext.crm.doctype.lead.lead import get_lead_details
+        elif lead:
+            from erpnext.crm.doctype.lead.lead import get_lead_details
 
-			self.update_if_missing(
-				get_lead_details(
-					lead,
-					posting_date=self.get("transaction_date") or self.get("posting_date"),
-					company=self.company,
-					doctype=self.doctype,
-				)
-			)
+            self.update_if_missing(
+                get_lead_details(
+                    lead,
+                    posting_date=self.get("transaction_date")
+                    or self.get("posting_date"),
+                    company=self.company,
+                    doctype=self.doctype,
+                )
+            )
 
-		if self.get("taxes_and_charges") and not self.get("taxes") and not for_validate:
-			taxes = get_taxes_and_charges("Sales Taxes and Charges Template", self.taxes_and_charges)
-			for tax in taxes:
-				self.append("taxes", tax)
+        if self.get("taxes_and_charges") and not self.get("taxes") and not for_validate:
+            taxes = get_taxes_and_charges(
+                "Sales Taxes and Charges Template", self.taxes_and_charges
+            )
+            for tax in taxes:
+                self.append("taxes", tax)
 
-	def set_price_list_and_item_details(self, for_validate=False):
-		self.set_price_list_currency("Selling")
-		self.set_missing_item_details(for_validate=for_validate)
+    def set_price_list_and_item_details(self, for_validate=False):
+        self.set_price_list_currency("Selling")
+        prev_skip_flag = getattr(self.flags, "skip_pricing_rule_eval", 0)
+        self.flags.skip_pricing_rule_eval = cint(
+            getattr(self.flags, "in_pricing_rule_recalc", 0)
+        )
+        try:
+            self.set_missing_item_details(for_validate=for_validate)
+        finally:
+            self.flags.skip_pricing_rule_eval = prev_skip_flag
 
-	def set_company_contact_person(self):
-		"""Set the Company's Default Sales Contact as Company Contact Person."""
-		if self.company and self.meta.has_field("company_contact_person") and not self.company_contact_person:
-			self.company_contact_person = frappe.get_cached_value(
-				"Company", self.company, "default_sales_contact"
-			)
+    def set_company_contact_person(self):
+        """Set the Company's Default Sales Contact as Company Contact Person."""
+        if (
+            self.company
+            and self.meta.has_field("company_contact_person")
+            and not self.company_contact_person
+        ):
+            self.company_contact_person = frappe.get_cached_value(
+                "Company", self.company, "default_sales_contact"
+            )
 
-	def remove_shipping_charge(self):
-		if self.shipping_rule:
-			shipping_rule = frappe.get_last_doc("Shipping Rule", self.shipping_rule)
-			existing_shipping_charge = self.get(
-				"taxes",
-				{
-					"doctype": "Sales Taxes and Charges",
-					"charge_type": "Actual",
-					"account_head": shipping_rule.account,
-					"cost_center": shipping_rule.cost_center,
-				},
-			)
-			if existing_shipping_charge:
-				self.get("taxes").remove(existing_shipping_charge[-1])
-				self.calculate_taxes_and_totals()
+    def remove_shipping_charge(self):
+        if self.shipping_rule:
+            shipping_rule = frappe.get_last_doc("Shipping Rule", self.shipping_rule)
+            existing_shipping_charge = self.get(
+                "taxes",
+                {
+                    "doctype": "Sales Taxes and Charges",
+                    "charge_type": "Actual",
+                    "account_head": shipping_rule.account,
+                    "cost_center": shipping_rule.cost_center,
+                },
+            )
+            if existing_shipping_charge:
+                self.get("taxes").remove(existing_shipping_charge[-1])
+                self.calculate_taxes_and_totals()
 
-	def set_total_in_words(self):
-		from frappe.utils import money_in_words
+    def set_total_in_words(self):
+        from frappe.utils import money_in_words
 
-		if self.meta.get_field("base_in_words"):
-			base_amount = abs(
-				self.base_grand_total if self.is_rounded_total_disabled() else self.base_rounded_total
-			)
-			self.base_in_words = money_in_words(base_amount, self.company_currency)
+        if self.meta.get_field("base_in_words"):
+            base_amount = abs(
+                self.base_grand_total
+                if self.is_rounded_total_disabled()
+                else self.base_rounded_total
+            )
+            self.base_in_words = money_in_words(base_amount, self.company_currency)
 
-		if self.meta.get_field("in_words"):
-			amount = abs(self.grand_total if self.is_rounded_total_disabled() else self.rounded_total)
-			self.in_words = money_in_words(amount, self.currency)
+        if self.meta.get_field("in_words"):
+            amount = abs(
+                self.grand_total
+                if self.is_rounded_total_disabled()
+                else self.rounded_total
+            )
+            self.in_words = money_in_words(amount, self.currency)
 
-	def calculate_commission(self):
-		if not self.meta.get_field("commission_rate"):
-			return
+    def calculate_commission(self):
+        if not self.meta.get_field("commission_rate"):
+            return
 
-		self.round_floats_in(self, ("amount_eligible_for_commission", "commission_rate"))
+        self.round_floats_in(
+            self, ("amount_eligible_for_commission", "commission_rate")
+        )
 
-		if not (0 <= self.commission_rate <= 100.0):
-			throw(
-				"{} {}".format(
-					_(self.meta.get_label("commission_rate")),
-					_("must be between 0 and 100"),
-				)
-			)
+        if not (0 <= self.commission_rate <= 100.0):
+            throw(
+                "{} {}".format(
+                    _(self.meta.get_label("commission_rate")),
+                    _("must be between 0 and 100"),
+                )
+            )
 
-		self.amount_eligible_for_commission = sum(
-			item.base_net_amount for item in self.items if item.grant_commission
-		)
+        self.amount_eligible_for_commission = sum(
+            item.base_net_amount for item in self.items if item.grant_commission
+        )
 
-		self.total_commission = flt(
-			self.amount_eligible_for_commission * self.commission_rate / 100.0,
-			self.precision("total_commission"),
-		)
+        self.total_commission = flt(
+            self.amount_eligible_for_commission * self.commission_rate / 100.0,
+            self.precision("total_commission"),
+        )
 
-	def calculate_contribution(self):
-		if not self.meta.get_field("sales_team"):
-			return
+    def calculate_contribution(self):
+        if not self.meta.get_field("sales_team"):
+            return
 
-		total = 0.0
-		sales_team = self.get("sales_team")
+        total = 0.0
+        sales_team = self.get("sales_team")
 
-		self.validate_sales_team(sales_team)
+        self.validate_sales_team(sales_team)
 
-		for sales_person in sales_team:
-			self.round_floats_in(sales_person)
+        for sales_person in sales_team:
+            self.round_floats_in(sales_person)
 
-			sales_person.allocated_amount = flt(
-				flt(self.amount_eligible_for_commission) * sales_person.allocated_percentage / 100.0,
-				self.precision("allocated_amount", sales_person),
-			)
+            sales_person.allocated_amount = flt(
+                flt(self.amount_eligible_for_commission)
+                * sales_person.allocated_percentage
+                / 100.0,
+                self.precision("allocated_amount", sales_person),
+            )
 
-			if sales_person.commission_rate:
-				sales_person.incentives = flt(
-					sales_person.allocated_amount * flt(sales_person.commission_rate) / 100.0,
-					self.precision("incentives", sales_person),
-				)
+            if sales_person.commission_rate:
+                sales_person.incentives = flt(
+                    sales_person.allocated_amount
+                    * flt(sales_person.commission_rate)
+                    / 100.0,
+                    self.precision("incentives", sales_person),
+                )
 
-			total += sales_person.allocated_percentage
+            total += sales_person.allocated_percentage
 
-		if sales_team and total != 100.0:
-			throw(_("Total allocated percentage for sales team should be 100"))
+        if sales_team and total != 100.0:
+            throw(_("Total allocated percentage for sales team should be 100"))
 
-	def validate_sales_team(self, sales_team):
-		sales_persons = [d.sales_person for d in sales_team]
+    def validate_sales_team(self, sales_team):
+        sales_persons = [d.sales_person for d in sales_team]
 
-		if not sales_persons:
-			return
+        if not sales_persons:
+            return
 
-		sales_person_status = frappe.db.get_all(
-			"Sales Person", filters={"name": ["in", sales_persons]}, fields=["name", "enabled"]
-		)
+        sales_person_status = frappe.db.get_all(
+            "Sales Person",
+            filters={"name": ["in", sales_persons]},
+            fields=["name", "enabled"],
+        )
 
-		for row in sales_person_status:
-			if not row.enabled:
-				frappe.throw(_("Sales Person <b>{0}</b> is disabled.").format(row.name))
+        for row in sales_person_status:
+            if not row.enabled:
+                frappe.throw(_("Sales Person <b>{0}</b> is disabled.").format(row.name))
 
-	def validate_max_discount(self):
-		for d in self.get("items"):
-			if d.item_code:
-				discount = flt(frappe.get_cached_value("Item", d.item_code, "max_discount"))
+    def validate_max_discount(self):
+        for d in self.get("items"):
+            if d.item_code:
+                discount = flt(
+                    frappe.get_cached_value("Item", d.item_code, "max_discount")
+                )
 
-				if discount and flt(d.discount_percentage) > discount:
-					frappe.throw(_("Maximum discount for Item {0} is {1}%").format(d.item_code, discount))
+                if discount and flt(d.discount_percentage) > discount:
+                    frappe.throw(
+                        _("Maximum discount for Item {0} is {1}%").format(
+                            d.item_code, discount
+                        )
+                    )
 
-	def set_qty_as_per_stock_uom(self):
-		allow_to_edit_stock_qty = frappe.get_single_value(
-			"Stock Settings", "allow_to_edit_stock_uom_qty_for_sales"
-		)
+    def set_qty_as_per_stock_uom(self):
+        allow_to_edit_stock_qty = frappe.get_single_value(
+            "Stock Settings", "allow_to_edit_stock_uom_qty_for_sales"
+        )
 
-		for d in self.get("items"):
-			if d.meta.get_field("stock_qty"):
-				if not d.conversion_factor:
-					frappe.throw(_("Row {0}: Conversion Factor is mandatory").format(d.idx))
-				d.stock_qty = flt(d.qty) * flt(d.conversion_factor)
-				if allow_to_edit_stock_qty:
-					d.stock_qty = flt(d.stock_qty, d.precision("stock_qty"))
+        for d in self.get("items"):
+            if d.meta.get_field("stock_qty"):
+                if not d.conversion_factor:
+                    frappe.throw(
+                        _("Row {0}: Conversion Factor is mandatory").format(d.idx)
+                    )
+                d.stock_qty = flt(d.qty) * flt(d.conversion_factor)
+                if allow_to_edit_stock_qty:
+                    d.stock_qty = flt(d.stock_qty, d.precision("stock_qty"))
 
-	def validate_selling_price(self):
-		def throw_message(idx, item_name, rate, ref_rate_field):
-			throw(
-				_(
-					"""Row #{0}: Selling rate for item {1} is lower than its {2}.
+    def validate_selling_price(self):
+        def throw_message(idx, item_name, rate, ref_rate_field):
+            throw(
+                _(
+                    """Row #{0}: Selling rate for item {1} is lower than its {2}.
 					Selling {3} should be atleast {4}.<br><br>Alternatively,
 					you can disable '{5}' in {6} to bypass
 					this validation."""
-				).format(
-					idx,
-					bold(item_name),
-					bold(ref_rate_field),
-					bold("net rate"),
-					bold(rate),
-					bold(frappe.get_meta("Selling Settings").get_label("validate_selling_price")),
-					get_link_to_form("Selling Settings"),
-				),
-				title=_("Invalid Selling Price"),
-			)
+                ).format(
+                    idx,
+                    bold(item_name),
+                    bold(ref_rate_field),
+                    bold("net rate"),
+                    bold(rate),
+                    bold(
+                        frappe.get_meta("Selling Settings").get_label(
+                            "validate_selling_price"
+                        )
+                    ),
+                    get_link_to_form("Selling Settings"),
+                ),
+                title=_("Invalid Selling Price"),
+            )
 
-		if self.get("is_return") or not frappe.get_single_value("Selling Settings", "validate_selling_price"):
-			return
+        if self.get("is_return") or not frappe.get_single_value(
+            "Selling Settings", "validate_selling_price"
+        ):
+            return
 
-		is_internal_customer = self.get("is_internal_customer")
+        is_internal_customer = self.get("is_internal_customer")
 
-		for item in self.items:
-			if not item.item_code or item.is_free_item:
-				continue
+        for item in self.items:
+            if not item.item_code or item.is_free_item:
+                continue
 
-			last_purchase_rate, is_stock_item = frappe.get_cached_value(
-				"Item", item.item_code, ("last_purchase_rate", "is_stock_item")
-			)
+            last_purchase_rate, is_stock_item = frappe.get_cached_value(
+                "Item", item.item_code, ("last_purchase_rate", "is_stock_item")
+            )
 
-			last_purchase_rate_in_sales_uom = flt(
-				last_purchase_rate * (item.conversion_factor or 1), item.precision("base_net_rate")
-			)
+            last_purchase_rate_in_sales_uom = flt(
+                last_purchase_rate * (item.conversion_factor or 1),
+                item.precision("base_net_rate"),
+            )
 
-			if flt(item.base_net_rate) < flt(last_purchase_rate_in_sales_uom):
-				throw_message(item.idx, item.item_name, last_purchase_rate_in_sales_uom, "last purchase rate")
+            if flt(item.base_net_rate) < flt(last_purchase_rate_in_sales_uom):
+                throw_message(
+                    item.idx,
+                    item.item_name,
+                    last_purchase_rate_in_sales_uom,
+                    "last purchase rate",
+                )
 
-			if is_internal_customer or not is_stock_item:
-				continue
+            if is_internal_customer or not is_stock_item:
+                continue
 
-			rate_field = "valuation_rate" if self.doctype in ["Sales Order", "Quotation"] else "incoming_rate"
-			if item.get(rate_field) and item.base_net_rate < (
-				valuation_rate := flt(
-					item.get(rate_field) * (item.conversion_factor or 1), item.precision("base_net_rate")
-				)
-			):
-				throw_message(
-					item.idx,
-					item.item_name,
-					valuation_rate,
-					"valuation rate",
-				)
+            rate_field = (
+                "valuation_rate"
+                if self.doctype in ["Sales Order", "Quotation"]
+                else "incoming_rate"
+            )
+            if item.get(rate_field) and item.base_net_rate < (
+                valuation_rate := flt(
+                    item.get(rate_field) * (item.conversion_factor or 1),
+                    item.precision("base_net_rate"),
+                )
+            ):
+                throw_message(
+                    item.idx,
+                    item.item_name,
+                    valuation_rate,
+                    "valuation rate",
+                )
 
-	def get_item_list(self):
-		il = []
-		for d in self.get("items"):
-			if self.has_product_bundle(d.item_code):
-				for p in self.get("packed_items"):
-					if p.parent_detail_docname == d.name and p.parent_item == d.item_code:
-						# the packing details table's qty is already multiplied with parent's qty
-						il.append(
-							frappe._dict(
-								{
-									"warehouse": p.warehouse or d.warehouse,
-									"item_code": p.item_code,
-									"qty": flt(p.qty),
-									"serial_no": p.serial_no if self.docstatus == 2 else None,
-									"batch_no": p.batch_no if self.docstatus == 2 else None,
-									"uom": p.uom,
-									"serial_and_batch_bundle": p.serial_and_batch_bundle
-									or get_serial_and_batch_bundle(p, self, d),
-									"name": d.name,
-									"target_warehouse": p.target_warehouse,
-									"company": self.company,
-									"voucher_type": self.doctype,
-									"allow_zero_valuation": d.allow_zero_valuation_rate,
-									"sales_invoice_item": d.get("sales_invoice_item"),
-									"dn_detail": d.get("dn_detail"),
-									"incoming_rate": p.get("incoming_rate"),
-									"item_row": p,
-								}
-							)
-						)
-			else:
-				il.append(
-					frappe._dict(
-						{
-							"warehouse": d.warehouse,
-							"item_code": d.item_code,
-							"qty": d.stock_qty,
-							"serial_no": d.serial_no if self.docstatus == 2 else None,
-							"batch_no": d.batch_no if self.docstatus == 2 else None,
-							"uom": d.uom,
-							"stock_uom": d.stock_uom,
-							"conversion_factor": d.conversion_factor,
-							"serial_and_batch_bundle": d.serial_and_batch_bundle,
-							"name": d.name,
-							"target_warehouse": d.target_warehouse,
-							"company": self.company,
-							"voucher_type": self.doctype,
-							"allow_zero_valuation": d.allow_zero_valuation_rate,
-							"sales_invoice_item": d.get("sales_invoice_item"),
-							"dn_detail": d.get("dn_detail"),
-							"incoming_rate": d.get("incoming_rate"),
-							"item_row": d,
-						}
-					)
-				)
+    def get_item_list(self):
+        il = []
+        for d in self.get("items"):
+            if self.has_product_bundle(d.item_code):
+                for p in self.get("packed_items"):
+                    if (
+                        p.parent_detail_docname == d.name
+                        and p.parent_item == d.item_code
+                    ):
+                        # the packing details table's qty is already multiplied with parent's qty
+                        il.append(
+                            frappe._dict(
+                                {
+                                    "warehouse": p.warehouse or d.warehouse,
+                                    "item_code": p.item_code,
+                                    "qty": flt(p.qty),
+                                    "serial_no": (
+                                        p.serial_no if self.docstatus == 2 else None
+                                    ),
+                                    "batch_no": (
+                                        p.batch_no if self.docstatus == 2 else None
+                                    ),
+                                    "uom": p.uom,
+                                    "serial_and_batch_bundle": p.serial_and_batch_bundle
+                                    or get_serial_and_batch_bundle(p, self, d),
+                                    "name": d.name,
+                                    "target_warehouse": p.target_warehouse,
+                                    "company": self.company,
+                                    "voucher_type": self.doctype,
+                                    "allow_zero_valuation": d.allow_zero_valuation_rate,
+                                    "sales_invoice_item": d.get("sales_invoice_item"),
+                                    "dn_detail": d.get("dn_detail"),
+                                    "incoming_rate": p.get("incoming_rate"),
+                                    "item_row": p,
+                                }
+                            )
+                        )
+            else:
+                il.append(
+                    frappe._dict(
+                        {
+                            "warehouse": d.warehouse,
+                            "item_code": d.item_code,
+                            "qty": d.stock_qty,
+                            "serial_no": d.serial_no if self.docstatus == 2 else None,
+                            "batch_no": d.batch_no if self.docstatus == 2 else None,
+                            "uom": d.uom,
+                            "stock_uom": d.stock_uom,
+                            "conversion_factor": d.conversion_factor,
+                            "serial_and_batch_bundle": d.serial_and_batch_bundle,
+                            "name": d.name,
+                            "target_warehouse": d.target_warehouse,
+                            "company": self.company,
+                            "voucher_type": self.doctype,
+                            "allow_zero_valuation": d.allow_zero_valuation_rate,
+                            "sales_invoice_item": d.get("sales_invoice_item"),
+                            "dn_detail": d.get("dn_detail"),
+                            "incoming_rate": d.get("incoming_rate"),
+                            "item_row": d,
+                        }
+                    )
+                )
 
-		return il
+        return il
 
-	def has_product_bundle(self, item_code):
-		product_bundle_items = getattr(self, "_product_bundle_items", None)
-		if product_bundle_items is None:
-			self._product_bundle_items = product_bundle_items = {}
+    def has_product_bundle(self, item_code):
+        product_bundle_items = getattr(self, "_product_bundle_items", None)
+        if product_bundle_items is None:
+            self._product_bundle_items = product_bundle_items = {}
 
-		if item_code not in product_bundle_items:
-			self._fetch_product_bundle_items(item_code)
+        if item_code not in product_bundle_items:
+            self._fetch_product_bundle_items(item_code)
 
-		return product_bundle_items[item_code]
+        return product_bundle_items[item_code]
 
-	def _fetch_product_bundle_items(self, item_code):
-		product_bundle_items = self._product_bundle_items
-		items_to_fetch = {row.item_code for row in self.items if row.item_code not in product_bundle_items}
-		# fetch for requisite item_code even if it is not in items
-		items_to_fetch.add(item_code)
+    def _fetch_product_bundle_items(self, item_code):
+        product_bundle_items = self._product_bundle_items
+        items_to_fetch = {
+            row.item_code
+            for row in self.items
+            if row.item_code not in product_bundle_items
+        }
+        # fetch for requisite item_code even if it is not in items
+        items_to_fetch.add(item_code)
 
-		items_with_product_bundle = {
-			row.new_item_code
-			for row in frappe.get_all(
-				"Product Bundle",
-				filters={"new_item_code": ("in", items_to_fetch), "disabled": 0},
-				fields="new_item_code",
-			)
-		}
+        items_with_product_bundle = {
+            row.new_item_code
+            for row in frappe.get_all(
+                "Product Bundle",
+                filters={"new_item_code": ("in", items_to_fetch), "disabled": 0},
+                fields="new_item_code",
+            )
+        }
 
-		for item_code in items_to_fetch:
-			product_bundle_items[item_code] = item_code in items_with_product_bundle
+        for item_code in items_to_fetch:
+            product_bundle_items[item_code] = item_code in items_with_product_bundle
 
-	def get_already_delivered_qty(self, current_docname, so, so_detail):
-		delivered_via_dn = frappe.db.sql(
-			"""select sum(qty) from `tabDelivery Note Item`
+    def get_already_delivered_qty(self, current_docname, so, so_detail):
+        delivered_via_dn = frappe.db.sql(
+            """select sum(qty) from `tabDelivery Note Item`
 			where so_detail = %s and docstatus = 1
 			and against_sales_order = %s
 			and parent != %s""",
-			(so_detail, so, current_docname),
-		)
+            (so_detail, so, current_docname),
+        )
 
-		delivered_via_si = frappe.db.sql(
-			"""select sum(si_item.qty)
+        delivered_via_si = frappe.db.sql(
+            """select sum(si_item.qty)
 			from `tabSales Invoice Item` si_item, `tabSales Invoice` si
 			where si_item.parent = si.name and si.update_stock = 1
 			and si_item.so_detail = %s and si.docstatus = 1
 			and si_item.sales_order = %s
 			and si.name != %s""",
-			(so_detail, so, current_docname),
-		)
+            (so_detail, so, current_docname),
+        )
 
-		total_delivered_qty = (flt(delivered_via_dn[0][0]) if delivered_via_dn else 0) + (
-			flt(delivered_via_si[0][0]) if delivered_via_si else 0
-		)
+        total_delivered_qty = (
+            flt(delivered_via_dn[0][0]) if delivered_via_dn else 0
+        ) + (flt(delivered_via_si[0][0]) if delivered_via_si else 0)
 
-		return total_delivered_qty
+        return total_delivered_qty
 
-	def get_so_qty_and_warehouse(self, so_detail):
-		so_item = frappe.db.sql(
-			"""select qty, warehouse from `tabSales Order Item`
+    def get_so_qty_and_warehouse(self, so_detail):
+        so_item = frappe.db.sql(
+            """select qty, warehouse from `tabSales Order Item`
 			where name = %s and docstatus = 1""",
-			so_detail,
-			as_dict=1,
-		)
-		so_qty = so_item and flt(so_item[0]["qty"]) or 0.0
-		so_warehouse = so_item and so_item[0]["warehouse"] or ""
-		return so_qty, so_warehouse
-
-	def check_sales_order_on_hold_or_close(self, ref_fieldname):
-		for d in self.get("items"):
-			if d.get(ref_fieldname):
-				status = frappe.db.get_value("Sales Order", d.get(ref_fieldname), "status")
-				if status in ("Closed", "On Hold") and not self.is_return:
-					frappe.throw(_("Sales Order {0} is {1}").format(d.get(ref_fieldname), status))
-
-	def update_reserved_qty(self):
-		so_map = {}
-		for d in self.get("items"):
-			if d.so_detail:
-				if self.doctype == "Delivery Note" and d.against_sales_order:
-					so_map.setdefault(d.against_sales_order, []).append(d.so_detail)
-				elif self.doctype == "Sales Invoice" and d.sales_order and self.update_stock:
-					so_map.setdefault(d.sales_order, []).append(d.so_detail)
-
-		for so, so_item_rows in so_map.items():
-			if so and so_item_rows:
-				sales_order = frappe.get_lazy_doc("Sales Order", so)
-
-				if (sales_order.status == "Closed" and not self.is_return) or sales_order.status in [
-					"Cancelled"
-				]:
-					frappe.throw(
-						_("{0} {1} is cancelled or closed").format(_("Sales Order"), so),
-						frappe.InvalidStatusError,
-					)
-
-				sales_order.update_reserved_qty(so_item_rows)
-
-	def set_incoming_rate(self):
-		def reset_incoming_rate():
-			old_item = next(
-				(
-					item
-					for item in (old_doc.get("items") + (old_doc.get("packed_items") or []))
-					if item.name == d.name
-				),
-				None,
-			)
-			if old_item:
-				old_qty = flt(old_item.get("stock_qty") or old_item.get("actual_qty") or old_item.get("qty"))
-				if (
-					old_item.item_code != d.item_code
-					or old_item.warehouse != d.warehouse
-					or old_qty != qty
-					or old_item.serial_no != d.serial_no
-					or get_serial_nos(old_item.serial_and_batch_bundle)
-					!= get_serial_nos(d.serial_and_batch_bundle)
-					or old_item.batch_no != d.batch_no
-					or get_batch_nos(old_item.serial_and_batch_bundle)
-					!= get_batch_nos(d.serial_and_batch_bundle)
-				):
-					d.incoming_rate = 0
-
-		if self.doctype not in ("Delivery Note", "Sales Invoice"):
-			return
-
-		if self.doctype == "Sales Invoice" and not self.update_stock and not self.is_internal_transfer():
-			return
-
-		from erpnext.stock.serial_batch_bundle import get_batch_nos, get_serial_nos
-
-		allow_at_arms_length_price = frappe.get_cached_value(
-			"Stock Settings", None, "allow_internal_transfer_at_arms_length_price"
-		)
-		set_zero_rate_for_expired_batch = frappe.db.get_single_value(
-			"Selling Settings", "set_zero_rate_for_expired_batch"
-		)
-
-		is_standalone = self.is_return and not self.return_against
-
-		old_doc = self.get_doc_before_save()
-		items = self.get("items") + (self.get("packed_items") or [])
-		for d in items:
-			if not frappe.get_cached_value("Item", d.item_code, "is_stock_item"):
-				continue
-
-			item_details = frappe.get_cached_value(
-				"Item", d.item_code, ["has_serial_no", "has_batch_no", "has_expiry_date"], as_dict=1
-			)
-
-			if (
-				set_zero_rate_for_expired_batch
-				and item_details.has_batch_no
-				and item_details.has_expiry_date
-				and self.get("is_return")
-				and not self.get("return_against")
-				and is_batch_expired(d.batch_no, self.get("posting_date"))
-			):
-				# set incoming rate as zero for stand-lone credit note with expired batch
-				d.incoming_rate = 0
-
-			elif not self.get("return_against") or (
-				get_valuation_method(d.item_code, self.company) == "Moving Average"
-				and self.get("is_return")
-				and not item_details.has_serial_no
-				and not item_details.has_batch_no
-			):
-				# Get incoming rate based on original item cost based on valuation method
-				qty = flt(d.get("stock_qty") or d.get("actual_qty") or d.get("qty"))
-
-				if old_doc:
-					reset_incoming_rate()
-
-				if (
-					not d.incoming_rate
-					or self.is_internal_transfer()
-					or (
-						get_valuation_method(d.item_code, self.company) == "Moving Average"
-						and self.get("is_return")
-					)
-				):
-					d.incoming_rate = get_incoming_rate(
-						{
-							"item_code": d.item_code,
-							"warehouse": d.warehouse,
-							"posting_date": self.get("posting_date") or self.get("transaction_date"),
-							"posting_time": self.get("posting_time") or nowtime(),
-							"qty": qty if cint(self.get("is_return")) else (-1 * qty),
-							"serial_and_batch_bundle": d.serial_and_batch_bundle,
-							"company": self.company,
-							"voucher_type": self.doctype,
-							"voucher_no": self.name,
-							"voucher_detail_no": d.name,
-							"allow_zero_valuation": d.get("allow_zero_valuation_rate"),
-							"batch_no": d.batch_no,
-							"serial_no": d.serial_no,
-						},
-						raise_error_if_no_rate=is_standalone,
-						fallbacks=not is_standalone,
-					)
-
-				if (
-					not d.incoming_rate
-					and self.get("return_against")
-					and self.get("is_return")
-					and get_valuation_method(d.item_code, self.company) == "Moving Average"
-				):
-					d.incoming_rate = get_rate_for_return(
-						self.doctype, self.name, d.item_code, self.return_against, item_row=d
-					)
-
-				if (
-					self.get("is_return")
-					and not d.incoming_rate
-					and not self.get("return_against")
-					and not self.is_internal_transfer()
-					and not d.get("allow_zero_valuation_rate")
-				):
-					d.incoming_rate = d.rate
-
-				# For internal transfers use incoming rate as the valuation rate
-				if self.is_internal_transfer():
-					if self.doctype == "Delivery Note" or self.get("update_stock"):
-						if d.doctype == "Packed Item":
-							incoming_rate = flt(
-								flt(d.incoming_rate, d.precision("incoming_rate")) * d.conversion_factor,
-								d.precision("incoming_rate"),
-							)
-							if d.incoming_rate != incoming_rate:
-								d.incoming_rate = incoming_rate
-						else:
-							if allow_at_arms_length_price:
-								continue
-
-							rate = flt(
-								flt(d.incoming_rate, d.precision("incoming_rate")) * d.conversion_factor,
-								d.precision("rate"),
-							)
-							if d.rate != rate:
-								d.rate = rate
-								frappe.msgprint(
-									_(
-										"Row {0}: Item rate has been updated as per valuation rate since its an internal stock transfer"
-									).format(d.idx),
-									alert=1,
-								)
-
-							d.discount_percentage = 0.0
-							d.discount_amount = 0.0
-							d.margin_rate_or_amount = 0.0
-
-			elif self.get("return_against"):
-				# Get incoming rate of return entry from reference document
-				# based on original item cost as per valuation method
-				d.incoming_rate = get_rate_for_return(
-					self.doctype, self.name, d.item_code, self.return_against, item_row=d
-				)
-
-	def update_stock_ledger(self, allow_negative_stock=False):
-		self.update_reserved_qty()
-
-		sl_entries = []
-		# Loop over items and packed items table
-		for d in self.get_item_list():
-			if frappe.get_cached_value("Item", d.item_code, "is_stock_item") == 1 and flt(d.qty):
-				if flt(d.conversion_factor) == 0.0:
-					d.conversion_factor = (
-						get_conversion_factor(d.item_code, d.uom).get("conversion_factor") or 1.0
-					)
-
-				# On cancellation or return entry submission, make stock ledger entry for
-				# target warehouse first, to update serial no values properly
-
-				if d.warehouse and (
-					(not cint(self.is_return) and self.docstatus == 1)
-					or (cint(self.is_return) and self.docstatus == 2)
-				):
-					sl_entries.append(self.get_sle_for_source_warehouse(d))
-
-				if d.target_warehouse:
-					sl_entries.append(self.get_sle_for_target_warehouse(d))
-
-				if d.warehouse and (
-					(not cint(self.is_return) and self.docstatus == 2)
-					or (cint(self.is_return) and self.docstatus == 1)
-				):
-					sl_entries.append(self.get_sle_for_source_warehouse(d))
-
-		self.make_sl_entries(sl_entries, allow_negative_stock=allow_negative_stock)
-
-	def get_sle_for_source_warehouse(self, item_row):
-		serial_and_batch_bundle = (
-			item_row.serial_and_batch_bundle
-			if not self.is_internal_transfer() or self.docstatus == 1
-			else None
-		)
-
-		if self.is_internal_transfer():
-			if serial_and_batch_bundle and self.docstatus == 1 and self.is_return:
-				serial_and_batch_bundle = self.make_package_for_transfer(
-					serial_and_batch_bundle, item_row.warehouse, type_of_transaction="Inward"
-				)
-			elif not serial_and_batch_bundle:
-				serial_and_batch_bundle = frappe.db.get_value(
-					"Stock Ledger Entry",
-					{"voucher_detail_no": item_row.name, "warehouse": item_row.warehouse},
-					"serial_and_batch_bundle",
-				)
-
-		sle = self.get_sl_entries(
-			item_row,
-			{
-				"actual_qty": -1 * flt(item_row.qty),
-				"incoming_rate": item_row.incoming_rate,
-				"recalculate_rate": cint(self.is_return),
-				"serial_and_batch_bundle": serial_and_batch_bundle,
-			},
-		)
-		if item_row.target_warehouse and not cint(self.is_return):
-			sle.dependant_sle_voucher_detail_no = item_row.name
-
-		return sle
-
-	def get_sle_for_target_warehouse(self, item_row):
-		sle = self.get_sl_entries(
-			item_row, {"actual_qty": flt(item_row.qty), "warehouse": item_row.target_warehouse}
-		)
-
-		if self.docstatus == 1:
-			if not cint(self.is_return):
-				sle.update({"incoming_rate": item_row.incoming_rate, "recalculate_rate": 1})
-			else:
-				sle.update({"outgoing_rate": item_row.incoming_rate})
-				if item_row.warehouse:
-					sle.dependant_sle_voucher_detail_no = item_row.name
-
-			if item_row.serial_and_batch_bundle and not cint(self.is_return):
-				type_of_transaction = "Inward"
-				if cint(self.is_return):
-					type_of_transaction = "Outward"
-
-				sle["serial_and_batch_bundle"] = self.make_package_for_transfer(
-					item_row.serial_and_batch_bundle,
-					item_row.target_warehouse,
-					type_of_transaction=type_of_transaction,
-				)
-
-		return sle
-
-	def set_po_nos(self, for_validate=False):
-		if self.doctype == "Sales Invoice" and hasattr(self, "items"):
-			if for_validate and self.po_no:
-				return
-			self.set_pos_for_sales_invoice()
-		if self.doctype == "Delivery Note" and hasattr(self, "items"):
-			if for_validate and self.po_no:
-				return
-			self.set_pos_for_delivery_note()
-
-	def set_pos_for_sales_invoice(self):
-		po_nos = []
-		if self.po_no:
-			po_nos.append(self.po_no)
-		self.get_po_nos("Sales Order", "sales_order", po_nos)
-		self.get_po_nos("Delivery Note", "delivery_note", po_nos)
-		self.po_no = ", ".join(list(set(x.strip() for x in ",".join(po_nos).split(","))))
-
-	def set_pos_for_delivery_note(self):
-		po_nos = []
-		if self.po_no:
-			po_nos.append(self.po_no)
-		self.get_po_nos("Sales Order", "against_sales_order", po_nos)
-		self.get_po_nos("Sales Invoice", "against_sales_invoice", po_nos)
-		self.po_no = ", ".join(list(set(x.strip() for x in ",".join(po_nos).split(","))))
-
-	def get_po_nos(self, ref_doctype, ref_fieldname, po_nos):
-		doc_list = list(set(d.get(ref_fieldname) for d in self.items if d.get(ref_fieldname)))
-		if doc_list:
-			po_nos += [
-				d.po_no
-				for d in frappe.get_all(ref_doctype, "po_no", filters={"name": ("in", doc_list)})
-				if d.get("po_no")
-			]
-
-	def set_gross_profit(self):
-		if self.doctype in ["Sales Order", "Quotation"]:
-			for item in self.items:
-				item.gross_profit = flt(
-					((flt(item.stock_uom_rate) - flt(item.valuation_rate)) * item.stock_qty),
-					self.precision("amount", item),
-				)
-
-	def set_customer_address(self):
-		address_dict = {
-			"customer_address": "address_display",
-			"shipping_address_name": "shipping_address",
-			"company_address": "company_address_display",
-			"dispatch_address_name": "dispatch_address",
-		}
-
-		for address_field, address_display_field in address_dict.items():
-			if self.get(address_field):
-				self.set(
-					address_display_field, render_address(self.get(address_field), check_permissions=False)
-				)
-
-	def validate_for_duplicate_items(self):
-		check_list, chk_dupl_itm = [], []
-		if cint(frappe.get_single_value("Selling Settings", "allow_multiple_items")):
-			return
-		if self.doctype == "Sales Invoice" and self.is_consolidated:
-			return
-		if self.doctype == "POS Invoice":
-			return
-
-		items = [item.item_code for item in self.get("items")]
-		item_stock_map = frappe._dict(
-			frappe.get_all(
-				"Item",
-				filters={"item_code": ["in", items]},
-				fields=["item_code", "is_stock_item"],
-				as_list=True,
-			)
-		)
-
-		for d in self.get("items"):
-			if self.doctype == "Sales Invoice":
-				stock_items = [
-					d.item_code,
-					d.description,
-					d.warehouse,
-					d.sales_order or d.delivery_note,
-					d.batch_no or "",
-				]
-				non_stock_items = [d.item_code, d.description, d.sales_order or d.delivery_note]
-			elif self.doctype == "Delivery Note":
-				stock_items = [
-					d.item_code,
-					d.description,
-					d.warehouse,
-					d.against_sales_order or d.against_sales_invoice,
-					d.batch_no or "",
-				]
-				non_stock_items = [
-					d.item_code,
-					d.description,
-					d.against_sales_order or d.against_sales_invoice,
-				]
-			elif self.doctype in ["Sales Order", "Quotation"]:
-				stock_items = [d.item_code, d.description, d.warehouse, ""]
-				non_stock_items = [d.item_code, d.description]
-
-			duplicate_items_msg = _("Item {0} entered multiple times.").format(frappe.bold(d.item_code))
-			duplicate_items_msg += "<br><br>"
-			duplicate_items_msg += _("Please enable {} in {} to allow same item in multiple rows").format(
-				frappe.bold(_("Allow Item to Be Added Multiple Times in a Transaction")),
-				get_link_to_form("Selling Settings", "Selling Settings"),
-			)
-			if item_stock_map.get(d.item_code):
-				if stock_items in check_list:
-					frappe.throw(duplicate_items_msg)
-				else:
-					check_list.append(stock_items)
-			else:
-				if non_stock_items in chk_dupl_itm:
-					frappe.throw(duplicate_items_msg)
-				else:
-					chk_dupl_itm.append(non_stock_items)
-
-	def validate_target_warehouse(self):
-		items = self.get("items") + (self.get("packed_items") or [])
-
-		for d in items:
-			if d.get("target_warehouse") and d.get("warehouse") == d.get("target_warehouse"):
-				warehouse = frappe.bold(d.get("target_warehouse"))
-				frappe.throw(
-					_(
-						"Row {0}: Delivery Warehouse ({1}) and Customer Warehouse ({2}) can not be same"
-					).format(d.idx, warehouse, warehouse)
-				)
-
-		if not self.get("is_internal_customer") and any(d.get("target_warehouse") for d in items):
-			msg = _("Target Warehouse is set for some items but the customer is not an internal customer.")
-			msg += " " + _("This {} will be treated as material transfer.").format(_(self.doctype))
-			frappe.msgprint(msg, title="Internal Transfer", alert=True)
-
-	def validate_items(self):
-		# validate items to see if they have is_sales_item enabled
-		from erpnext.controllers.buying_controller import validate_item_type
-
-		validate_item_type(self, "is_sales_item", "sales")
-
-	def update_stock_reservation_entries(self) -> None:
-		"""Updates Delivered Qty in Stock Reservation Entries."""
-
-		# Don't update Delivered Qty on Return.
-		if self.is_return:
-			return
-
-		so_field = "sales_order" if self.doctype == "Sales Invoice" else "against_sales_order"
-
-		if self._action == "submit":
-			for item in self.get("items"):
-				# Skip if `Sales Order` or `Sales Order Item` reference is not set.
-				if not item.get(so_field) or not item.so_detail:
-					continue
-
-				table = frappe.qb.DocType("Stock Reservation Entry")
-				query = (
-					frappe.qb.from_(table)
-					.select(table.name)
-					.where(
-						(table.docstatus == 1)
-						& (table.voucher_type == "Sales Order")
-						& (table.voucher_no == item.get(so_field))
-						& (table.voucher_detail_no == item.so_detail)
-						& (table.warehouse == item.warehouse)
-						& (table.delivered_qty < table.reserved_qty)
-					)
-					.orderby(table.creation)
-				)
-				sre_list = query.run(pluck="name")
-
-				# Skip if no Stock Reservation Entries.
-				if not sre_list:
-					continue
-
-				qty_to_deliver = item.stock_qty
-				for sre in sre_list:
-					if qty_to_deliver <= 0:
-						break
-
-					sre_doc = frappe.get_doc("Stock Reservation Entry", sre)
-
-					qty_can_be_deliver = 0
-					if sre_doc.reservation_based_on == "Serial and Batch":
-						sbb = frappe.get_doc("Serial and Batch Bundle", item.serial_and_batch_bundle)
-						if sre_doc.has_serial_no:
-							delivered_serial_nos = [d.serial_no for d in sbb.entries]
-							for entry in sre_doc.sb_entries:
-								if entry.serial_no in delivered_serial_nos:
-									entry.delivered_qty = 1  # Qty will always be 0 or 1 for Serial No.
-									entry.db_update()
-									qty_can_be_deliver += 1
-									delivered_serial_nos.remove(entry.serial_no)
-						else:
-							delivered_batch_qty = {d.batch_no: -1 * d.qty for d in sbb.entries}
-							for entry in sre_doc.sb_entries:
-								if entry.batch_no in delivered_batch_qty:
-									delivered_qty = min(
-										(entry.qty - entry.delivered_qty), delivered_batch_qty[entry.batch_no]
-									)
-									entry.delivered_qty += delivered_qty
-									entry.db_update()
-									qty_can_be_deliver += delivered_qty
-									delivered_batch_qty[entry.batch_no] -= delivered_qty
-					else:
-						# `Delivered Qty` should be less than or equal to `Reserved Qty`.
-						qty_can_be_deliver = min(
-							(sre_doc.reserved_qty - sre_doc.delivered_qty), qty_to_deliver
-						)
-
-					sre_doc.delivered_qty += qty_can_be_deliver
-					sre_doc.db_update()
-
-					# Update Stock Reservation Entry `Status` based on `Delivered Qty`.
-					sre_doc.update_status()
-
-					# Update Reserved Stock in Bin.
-					sre_doc.update_reserved_stock_in_bin()
-
-					qty_to_deliver -= qty_can_be_deliver
-
-		if self._action == "cancel":
-			for item in self.get("items"):
-				# Skip if `Sales Order` or `Sales Order Item` reference is not set.
-				if not item.get(so_field) or not item.so_detail:
-					continue
-
-				sre_list = frappe.db.get_all(
-					"Stock Reservation Entry",
-					{
-						"docstatus": 1,
-						"voucher_type": "Sales Order",
-						"voucher_no": item.get(so_field),
-						"voucher_detail_no": item.so_detail,
-						"warehouse": item.warehouse,
-						"status": ["in", ["Partially Delivered", "Delivered", "Partially Used", "Closed"]],
-					},
-					order_by="creation",
-				)
-
-				# Skip if no Stock Reservation Entries.
-				if not sre_list:
-					continue
-
-				qty_to_undelivered = item.stock_qty
-				for sre in sre_list:
-					if qty_to_undelivered <= 0:
-						break
-
-					sre_doc = frappe.get_doc("Stock Reservation Entry", sre)
-
-					qty_can_be_undelivered = 0
-					if sre_doc.reservation_based_on == "Serial and Batch":
-						sbb = frappe.get_doc("Serial and Batch Bundle", item.serial_and_batch_bundle)
-						if sre_doc.has_serial_no:
-							serial_nos_to_undelivered = [d.serial_no for d in sbb.entries]
-							for entry in sre_doc.sb_entries:
-								if entry.serial_no in serial_nos_to_undelivered:
-									entry.delivered_qty = 0  # Qty will always be 0 or 1 for Serial No.
-									entry.db_update()
-									qty_can_be_undelivered += 1
-									serial_nos_to_undelivered.remove(entry.serial_no)
-						else:
-							batch_qty_to_undelivered = {d.batch_no: -1 * d.qty for d in sbb.entries}
-							for entry in sre_doc.sb_entries:
-								if entry.batch_no in batch_qty_to_undelivered:
-									undelivered_qty = min(
-										entry.delivered_qty, batch_qty_to_undelivered[entry.batch_no]
-									)
-									entry.delivered_qty -= undelivered_qty
-									entry.db_update()
-									qty_can_be_undelivered += undelivered_qty
-									batch_qty_to_undelivered[entry.batch_no] -= undelivered_qty
-					else:
-						# `Qty to Undelivered` should be less than or equal to `Delivered Qty`.
-						qty_can_be_undelivered = min(sre_doc.delivered_qty, qty_to_undelivered)
-
-					sre_doc.delivered_qty -= qty_can_be_undelivered
-					sre_doc.db_update()
-
-					# Update Stock Reservation Entry `Status` based on `Delivered Qty`.
-					sre_doc.update_status()
-
-					# Update Reserved Stock in Bin.
-					sre_doc.update_reserved_stock_in_bin()
-
-					qty_to_undelivered -= qty_can_be_undelivered
+            so_detail,
+            as_dict=1,
+        )
+        so_qty = so_item and flt(so_item[0]["qty"]) or 0.0
+        so_warehouse = so_item and so_item[0]["warehouse"] or ""
+        return so_qty, so_warehouse
+
+    def check_sales_order_on_hold_or_close(self, ref_fieldname):
+        for d in self.get("items"):
+            if d.get(ref_fieldname):
+                status = frappe.db.get_value(
+                    "Sales Order", d.get(ref_fieldname), "status"
+                )
+                if status in ("Closed", "On Hold") and not self.is_return:
+                    frappe.throw(
+                        _("Sales Order {0} is {1}").format(d.get(ref_fieldname), status)
+                    )
+
+    def update_reserved_qty(self):
+        so_map = {}
+        for d in self.get("items"):
+            if d.so_detail:
+                if self.doctype == "Delivery Note" and d.against_sales_order:
+                    so_map.setdefault(d.against_sales_order, []).append(d.so_detail)
+                elif (
+                    self.doctype == "Sales Invoice"
+                    and d.sales_order
+                    and self.update_stock
+                ):
+                    so_map.setdefault(d.sales_order, []).append(d.so_detail)
+
+        for so, so_item_rows in so_map.items():
+            if so and so_item_rows:
+                sales_order = frappe.get_lazy_doc("Sales Order", so)
+
+                if (
+                    sales_order.status == "Closed" and not self.is_return
+                ) or sales_order.status in ["Cancelled"]:
+                    frappe.throw(
+                        _("{0} {1} is cancelled or closed").format(
+                            _("Sales Order"), so
+                        ),
+                        frappe.InvalidStatusError,
+                    )
+
+                sales_order.update_reserved_qty(so_item_rows)
+
+    def set_incoming_rate(self):
+        def reset_incoming_rate():
+            old_item = next(
+                (
+                    item
+                    for item in (
+                        old_doc.get("items") + (old_doc.get("packed_items") or [])
+                    )
+                    if item.name == d.name
+                ),
+                None,
+            )
+            if old_item:
+                old_qty = flt(
+                    old_item.get("stock_qty")
+                    or old_item.get("actual_qty")
+                    or old_item.get("qty")
+                )
+                if (
+                    old_item.item_code != d.item_code
+                    or old_item.warehouse != d.warehouse
+                    or old_qty != qty
+                    or old_item.serial_no != d.serial_no
+                    or get_serial_nos(old_item.serial_and_batch_bundle)
+                    != get_serial_nos(d.serial_and_batch_bundle)
+                    or old_item.batch_no != d.batch_no
+                    or get_batch_nos(old_item.serial_and_batch_bundle)
+                    != get_batch_nos(d.serial_and_batch_bundle)
+                ):
+                    d.incoming_rate = 0
+
+        if self.doctype not in ("Delivery Note", "Sales Invoice"):
+            return
+
+        if (
+            self.doctype == "Sales Invoice"
+            and not self.update_stock
+            and not self.is_internal_transfer()
+        ):
+            return
+
+        from erpnext.stock.serial_batch_bundle import get_batch_nos, get_serial_nos
+
+        allow_at_arms_length_price = frappe.get_cached_value(
+            "Stock Settings", None, "allow_internal_transfer_at_arms_length_price"
+        )
+        set_zero_rate_for_expired_batch = frappe.db.get_single_value(
+            "Selling Settings", "set_zero_rate_for_expired_batch"
+        )
+
+        is_standalone = self.is_return and not self.return_against
+
+        old_doc = self.get_doc_before_save()
+        items = self.get("items") + (self.get("packed_items") or [])
+        for d in items:
+            if not frappe.get_cached_value("Item", d.item_code, "is_stock_item"):
+                continue
+
+            item_details = frappe.get_cached_value(
+                "Item",
+                d.item_code,
+                ["has_serial_no", "has_batch_no", "has_expiry_date"],
+                as_dict=1,
+            )
+
+            if (
+                set_zero_rate_for_expired_batch
+                and item_details.has_batch_no
+                and item_details.has_expiry_date
+                and self.get("is_return")
+                and not self.get("return_against")
+                and is_batch_expired(d.batch_no, self.get("posting_date"))
+            ):
+                # set incoming rate as zero for stand-lone credit note with expired batch
+                d.incoming_rate = 0
+
+            elif not self.get("return_against") or (
+                get_valuation_method(d.item_code, self.company) == "Moving Average"
+                and self.get("is_return")
+                and not item_details.has_serial_no
+                and not item_details.has_batch_no
+            ):
+                # Get incoming rate based on original item cost based on valuation method
+                qty = flt(d.get("stock_qty") or d.get("actual_qty") or d.get("qty"))
+
+                if old_doc:
+                    reset_incoming_rate()
+
+                if (
+                    not d.incoming_rate
+                    or self.is_internal_transfer()
+                    or (
+                        get_valuation_method(d.item_code, self.company)
+                        == "Moving Average"
+                        and self.get("is_return")
+                    )
+                ):
+                    d.incoming_rate = get_incoming_rate(
+                        {
+                            "item_code": d.item_code,
+                            "warehouse": d.warehouse,
+                            "posting_date": self.get("posting_date")
+                            or self.get("transaction_date"),
+                            "posting_time": self.get("posting_time") or nowtime(),
+                            "qty": qty if cint(self.get("is_return")) else (-1 * qty),
+                            "serial_and_batch_bundle": d.serial_and_batch_bundle,
+                            "company": self.company,
+                            "voucher_type": self.doctype,
+                            "voucher_no": self.name,
+                            "voucher_detail_no": d.name,
+                            "allow_zero_valuation": d.get("allow_zero_valuation_rate"),
+                            "batch_no": d.batch_no,
+                            "serial_no": d.serial_no,
+                        },
+                        raise_error_if_no_rate=is_standalone,
+                        fallbacks=not is_standalone,
+                    )
+
+                if (
+                    not d.incoming_rate
+                    and self.get("return_against")
+                    and self.get("is_return")
+                    and get_valuation_method(d.item_code, self.company)
+                    == "Moving Average"
+                ):
+                    d.incoming_rate = get_rate_for_return(
+                        self.doctype,
+                        self.name,
+                        d.item_code,
+                        self.return_against,
+                        item_row=d,
+                    )
+
+                if (
+                    self.get("is_return")
+                    and not d.incoming_rate
+                    and not self.get("return_against")
+                    and not self.is_internal_transfer()
+                    and not d.get("allow_zero_valuation_rate")
+                ):
+                    d.incoming_rate = d.rate
+
+                # For internal transfers use incoming rate as the valuation rate
+                if self.is_internal_transfer():
+                    if self.doctype == "Delivery Note" or self.get("update_stock"):
+                        if d.doctype == "Packed Item":
+                            incoming_rate = flt(
+                                flt(d.incoming_rate, d.precision("incoming_rate"))
+                                * d.conversion_factor,
+                                d.precision("incoming_rate"),
+                            )
+                            if d.incoming_rate != incoming_rate:
+                                d.incoming_rate = incoming_rate
+                        else:
+                            if allow_at_arms_length_price:
+                                continue
+
+                            rate = flt(
+                                flt(d.incoming_rate, d.precision("incoming_rate"))
+                                * d.conversion_factor,
+                                d.precision("rate"),
+                            )
+                            if d.rate != rate:
+                                d.rate = rate
+                                frappe.msgprint(
+                                    _(
+                                        "Row {0}: Item rate has been updated as per valuation rate since its an internal stock transfer"
+                                    ).format(d.idx),
+                                    alert=1,
+                                )
+
+                            d.discount_percentage = 0.0
+                            d.discount_amount = 0.0
+                            d.margin_rate_or_amount = 0.0
+
+            elif self.get("return_against"):
+                # Get incoming rate of return entry from reference document
+                # based on original item cost as per valuation method
+                d.incoming_rate = get_rate_for_return(
+                    self.doctype,
+                    self.name,
+                    d.item_code,
+                    self.return_against,
+                    item_row=d,
+                )
+
+    def update_stock_ledger(self, allow_negative_stock=False):
+        self.update_reserved_qty()
+
+        sl_entries = []
+        # Loop over items and packed items table
+        for d in self.get_item_list():
+            if frappe.get_cached_value(
+                "Item", d.item_code, "is_stock_item"
+            ) == 1 and flt(d.qty):
+                if flt(d.conversion_factor) == 0.0:
+                    d.conversion_factor = (
+                        get_conversion_factor(d.item_code, d.uom).get(
+                            "conversion_factor"
+                        )
+                        or 1.0
+                    )
+
+                # On cancellation or return entry submission, make stock ledger entry for
+                # target warehouse first, to update serial no values properly
+
+                if d.warehouse and (
+                    (not cint(self.is_return) and self.docstatus == 1)
+                    or (cint(self.is_return) and self.docstatus == 2)
+                ):
+                    sl_entries.append(self.get_sle_for_source_warehouse(d))
+
+                if d.target_warehouse:
+                    sl_entries.append(self.get_sle_for_target_warehouse(d))
+
+                if d.warehouse and (
+                    (not cint(self.is_return) and self.docstatus == 2)
+                    or (cint(self.is_return) and self.docstatus == 1)
+                ):
+                    sl_entries.append(self.get_sle_for_source_warehouse(d))
+
+        self.make_sl_entries(sl_entries, allow_negative_stock=allow_negative_stock)
+
+    def get_sle_for_source_warehouse(self, item_row):
+        serial_and_batch_bundle = (
+            item_row.serial_and_batch_bundle
+            if not self.is_internal_transfer() or self.docstatus == 1
+            else None
+        )
+
+        if self.is_internal_transfer():
+            if serial_and_batch_bundle and self.docstatus == 1 and self.is_return:
+                serial_and_batch_bundle = self.make_package_for_transfer(
+                    serial_and_batch_bundle,
+                    item_row.warehouse,
+                    type_of_transaction="Inward",
+                )
+            elif not serial_and_batch_bundle:
+                serial_and_batch_bundle = frappe.db.get_value(
+                    "Stock Ledger Entry",
+                    {
+                        "voucher_detail_no": item_row.name,
+                        "warehouse": item_row.warehouse,
+                    },
+                    "serial_and_batch_bundle",
+                )
+
+        sle = self.get_sl_entries(
+            item_row,
+            {
+                "actual_qty": -1 * flt(item_row.qty),
+                "incoming_rate": item_row.incoming_rate,
+                "recalculate_rate": cint(self.is_return),
+                "serial_and_batch_bundle": serial_and_batch_bundle,
+            },
+        )
+        if item_row.target_warehouse and not cint(self.is_return):
+            sle.dependant_sle_voucher_detail_no = item_row.name
+
+        return sle
+
+    def get_sle_for_target_warehouse(self, item_row):
+        sle = self.get_sl_entries(
+            item_row,
+            {"actual_qty": flt(item_row.qty), "warehouse": item_row.target_warehouse},
+        )
+
+        if self.docstatus == 1:
+            if not cint(self.is_return):
+                sle.update(
+                    {"incoming_rate": item_row.incoming_rate, "recalculate_rate": 1}
+                )
+            else:
+                sle.update({"outgoing_rate": item_row.incoming_rate})
+                if item_row.warehouse:
+                    sle.dependant_sle_voucher_detail_no = item_row.name
+
+            if item_row.serial_and_batch_bundle and not cint(self.is_return):
+                type_of_transaction = "Inward"
+                if cint(self.is_return):
+                    type_of_transaction = "Outward"
+
+                sle["serial_and_batch_bundle"] = self.make_package_for_transfer(
+                    item_row.serial_and_batch_bundle,
+                    item_row.target_warehouse,
+                    type_of_transaction=type_of_transaction,
+                )
+
+        return sle
+
+    def set_po_nos(self, for_validate=False):
+        if self.doctype == "Sales Invoice" and hasattr(self, "items"):
+            if for_validate and self.po_no:
+                return
+            self.set_pos_for_sales_invoice()
+        if self.doctype == "Delivery Note" and hasattr(self, "items"):
+            if for_validate and self.po_no:
+                return
+            self.set_pos_for_delivery_note()
+
+    def set_pos_for_sales_invoice(self):
+        po_nos = []
+        if self.po_no:
+            po_nos.append(self.po_no)
+        self.get_po_nos("Sales Order", "sales_order", po_nos)
+        self.get_po_nos("Delivery Note", "delivery_note", po_nos)
+        self.po_no = ", ".join(
+            list(set(x.strip() for x in ",".join(po_nos).split(",")))
+        )
+
+    def set_pos_for_delivery_note(self):
+        po_nos = []
+        if self.po_no:
+            po_nos.append(self.po_no)
+        self.get_po_nos("Sales Order", "against_sales_order", po_nos)
+        self.get_po_nos("Sales Invoice", "against_sales_invoice", po_nos)
+        self.po_no = ", ".join(
+            list(set(x.strip() for x in ",".join(po_nos).split(",")))
+        )
+
+    def get_po_nos(self, ref_doctype, ref_fieldname, po_nos):
+        doc_list = list(
+            set(d.get(ref_fieldname) for d in self.items if d.get(ref_fieldname))
+        )
+        if doc_list:
+            po_nos += [
+                d.po_no
+                for d in frappe.get_all(
+                    ref_doctype, "po_no", filters={"name": ("in", doc_list)}
+                )
+                if d.get("po_no")
+            ]
+
+    def set_gross_profit(self):
+        if self.doctype in ["Sales Order", "Quotation"]:
+            for item in self.items:
+                item.gross_profit = flt(
+                    (
+                        (flt(item.stock_uom_rate) - flt(item.valuation_rate))
+                        * item.stock_qty
+                    ),
+                    self.precision("amount", item),
+                )
+
+    def set_customer_address(self):
+        address_dict = {
+            "customer_address": "address_display",
+            "shipping_address_name": "shipping_address",
+            "company_address": "company_address_display",
+            "dispatch_address_name": "dispatch_address",
+        }
+
+        for address_field, address_display_field in address_dict.items():
+            if self.get(address_field):
+                self.set(
+                    address_display_field,
+                    render_address(self.get(address_field), check_permissions=False),
+                )
+
+    def validate_for_duplicate_items(self):
+        check_list, chk_dupl_itm = [], []
+        if cint(frappe.get_single_value("Selling Settings", "allow_multiple_items")):
+            return
+        if self.doctype == "Sales Invoice" and self.is_consolidated:
+            return
+        if self.doctype == "POS Invoice":
+            return
+
+        items = [item.item_code for item in self.get("items")]
+        item_stock_map = frappe._dict(
+            frappe.get_all(
+                "Item",
+                filters={"item_code": ["in", items]},
+                fields=["item_code", "is_stock_item"],
+                as_list=True,
+            )
+        )
+
+        for d in self.get("items"):
+            if self.doctype == "Sales Invoice":
+                stock_items = [
+                    d.item_code,
+                    d.description,
+                    d.warehouse,
+                    d.sales_order or d.delivery_note,
+                    d.batch_no or "",
+                ]
+                non_stock_items = [
+                    d.item_code,
+                    d.description,
+                    d.sales_order or d.delivery_note,
+                ]
+            elif self.doctype == "Delivery Note":
+                stock_items = [
+                    d.item_code,
+                    d.description,
+                    d.warehouse,
+                    d.against_sales_order or d.against_sales_invoice,
+                    d.batch_no or "",
+                ]
+                non_stock_items = [
+                    d.item_code,
+                    d.description,
+                    d.against_sales_order or d.against_sales_invoice,
+                ]
+            elif self.doctype in ["Sales Order", "Quotation"]:
+                stock_items = [d.item_code, d.description, d.warehouse, ""]
+                non_stock_items = [d.item_code, d.description]
+
+            duplicate_items_msg = _("Item {0} entered multiple times.").format(
+                frappe.bold(d.item_code)
+            )
+            duplicate_items_msg += "<br><br>"
+            duplicate_items_msg += _(
+                "Please enable {} in {} to allow same item in multiple rows"
+            ).format(
+                frappe.bold(
+                    _("Allow Item to Be Added Multiple Times in a Transaction")
+                ),
+                get_link_to_form("Selling Settings", "Selling Settings"),
+            )
+            if item_stock_map.get(d.item_code):
+                if stock_items in check_list:
+                    frappe.throw(duplicate_items_msg)
+                else:
+                    check_list.append(stock_items)
+            else:
+                if non_stock_items in chk_dupl_itm:
+                    frappe.throw(duplicate_items_msg)
+                else:
+                    chk_dupl_itm.append(non_stock_items)
+
+    def validate_target_warehouse(self):
+        items = self.get("items") + (self.get("packed_items") or [])
+
+        for d in items:
+            if d.get("target_warehouse") and d.get("warehouse") == d.get(
+                "target_warehouse"
+            ):
+                warehouse = frappe.bold(d.get("target_warehouse"))
+                frappe.throw(
+                    _(
+                        "Row {0}: Delivery Warehouse ({1}) and Customer Warehouse ({2}) can not be same"
+                    ).format(d.idx, warehouse, warehouse)
+                )
+
+        if not self.get("is_internal_customer") and any(
+            d.get("target_warehouse") for d in items
+        ):
+            msg = _(
+                "Target Warehouse is set for some items but the customer is not an internal customer."
+            )
+            msg += " " + _("This {} will be treated as material transfer.").format(
+                _(self.doctype)
+            )
+            frappe.msgprint(msg, title="Internal Transfer", alert=True)
+
+    def validate_items(self):
+        # validate items to see if they have is_sales_item enabled
+        from erpnext.controllers.buying_controller import validate_item_type
+
+        validate_item_type(self, "is_sales_item", "sales")
+
+    def update_stock_reservation_entries(self) -> None:
+        """Updates Delivered Qty in Stock Reservation Entries."""
+
+        # Don't update Delivered Qty on Return.
+        if self.is_return:
+            return
+
+        so_field = (
+            "sales_order" if self.doctype == "Sales Invoice" else "against_sales_order"
+        )
+
+        if self._action == "submit":
+            for item in self.get("items"):
+                # Skip if `Sales Order` or `Sales Order Item` reference is not set.
+                if not item.get(so_field) or not item.so_detail:
+                    continue
+
+                table = frappe.qb.DocType("Stock Reservation Entry")
+                query = (
+                    frappe.qb.from_(table)
+                    .select(table.name)
+                    .where(
+                        (table.docstatus == 1)
+                        & (table.voucher_type == "Sales Order")
+                        & (table.voucher_no == item.get(so_field))
+                        & (table.voucher_detail_no == item.so_detail)
+                        & (table.warehouse == item.warehouse)
+                        & (table.delivered_qty < table.reserved_qty)
+                    )
+                    .orderby(table.creation)
+                )
+                sre_list = query.run(pluck="name")
+
+                # Skip if no Stock Reservation Entries.
+                if not sre_list:
+                    continue
+
+                qty_to_deliver = item.stock_qty
+                for sre in sre_list:
+                    if qty_to_deliver <= 0:
+                        break
+
+                    sre_doc = frappe.get_doc("Stock Reservation Entry", sre)
+
+                    qty_can_be_deliver = 0
+                    if sre_doc.reservation_based_on == "Serial and Batch":
+                        sbb = frappe.get_doc(
+                            "Serial and Batch Bundle", item.serial_and_batch_bundle
+                        )
+                        if sre_doc.has_serial_no:
+                            delivered_serial_nos = [d.serial_no for d in sbb.entries]
+                            for entry in sre_doc.sb_entries:
+                                if entry.serial_no in delivered_serial_nos:
+                                    entry.delivered_qty = (
+                                        1  # Qty will always be 0 or 1 for Serial No.
+                                    )
+                                    entry.db_update()
+                                    qty_can_be_deliver += 1
+                                    delivered_serial_nos.remove(entry.serial_no)
+                        else:
+                            delivered_batch_qty = {
+                                d.batch_no: -1 * d.qty for d in sbb.entries
+                            }
+                            for entry in sre_doc.sb_entries:
+                                if entry.batch_no in delivered_batch_qty:
+                                    delivered_qty = min(
+                                        (entry.qty - entry.delivered_qty),
+                                        delivered_batch_qty[entry.batch_no],
+                                    )
+                                    entry.delivered_qty += delivered_qty
+                                    entry.db_update()
+                                    qty_can_be_deliver += delivered_qty
+                                    delivered_batch_qty[entry.batch_no] -= delivered_qty
+                    else:
+                        # `Delivered Qty` should be less than or equal to `Reserved Qty`.
+                        qty_can_be_deliver = min(
+                            (sre_doc.reserved_qty - sre_doc.delivered_qty),
+                            qty_to_deliver,
+                        )
+
+                    sre_doc.delivered_qty += qty_can_be_deliver
+                    sre_doc.db_update()
+
+                    # Update Stock Reservation Entry `Status` based on `Delivered Qty`.
+                    sre_doc.update_status()
+
+                    # Update Reserved Stock in Bin.
+                    sre_doc.update_reserved_stock_in_bin()
+
+                    qty_to_deliver -= qty_can_be_deliver
+
+        if self._action == "cancel":
+            for item in self.get("items"):
+                # Skip if `Sales Order` or `Sales Order Item` reference is not set.
+                if not item.get(so_field) or not item.so_detail:
+                    continue
+
+                sre_list = frappe.db.get_all(
+                    "Stock Reservation Entry",
+                    {
+                        "docstatus": 1,
+                        "voucher_type": "Sales Order",
+                        "voucher_no": item.get(so_field),
+                        "voucher_detail_no": item.so_detail,
+                        "warehouse": item.warehouse,
+                        "status": [
+                            "in",
+                            [
+                                "Partially Delivered",
+                                "Delivered",
+                                "Partially Used",
+                                "Closed",
+                            ],
+                        ],
+                    },
+                    order_by="creation",
+                )
+
+                # Skip if no Stock Reservation Entries.
+                if not sre_list:
+                    continue
+
+                qty_to_undelivered = item.stock_qty
+                for sre in sre_list:
+                    if qty_to_undelivered <= 0:
+                        break
+
+                    sre_doc = frappe.get_doc("Stock Reservation Entry", sre)
+
+                    qty_can_be_undelivered = 0
+                    if sre_doc.reservation_based_on == "Serial and Batch":
+                        sbb = frappe.get_doc(
+                            "Serial and Batch Bundle", item.serial_and_batch_bundle
+                        )
+                        if sre_doc.has_serial_no:
+                            serial_nos_to_undelivered = [
+                                d.serial_no for d in sbb.entries
+                            ]
+                            for entry in sre_doc.sb_entries:
+                                if entry.serial_no in serial_nos_to_undelivered:
+                                    entry.delivered_qty = (
+                                        0  # Qty will always be 0 or 1 for Serial No.
+                                    )
+                                    entry.db_update()
+                                    qty_can_be_undelivered += 1
+                                    serial_nos_to_undelivered.remove(entry.serial_no)
+                        else:
+                            batch_qty_to_undelivered = {
+                                d.batch_no: -1 * d.qty for d in sbb.entries
+                            }
+                            for entry in sre_doc.sb_entries:
+                                if entry.batch_no in batch_qty_to_undelivered:
+                                    undelivered_qty = min(
+                                        entry.delivered_qty,
+                                        batch_qty_to_undelivered[entry.batch_no],
+                                    )
+                                    entry.delivered_qty -= undelivered_qty
+                                    entry.db_update()
+                                    qty_can_be_undelivered += undelivered_qty
+                                    batch_qty_to_undelivered[
+                                        entry.batch_no
+                                    ] -= undelivered_qty
+                    else:
+                        # `Qty to Undelivered` should be less than or equal to `Delivered Qty`.
+                        qty_can_be_undelivered = min(
+                            sre_doc.delivered_qty, qty_to_undelivered
+                        )
+
+                    sre_doc.delivered_qty -= qty_can_be_undelivered
+                    sre_doc.db_update()
+
+                    # Update Stock Reservation Entry `Status` based on `Delivered Qty`.
+                    sre_doc.update_status()
+
+                    # Update Reserved Stock in Bin.
+                    sre_doc.update_reserved_stock_in_bin()
+
+                    qty_to_undelivered -= qty_can_be_undelivered
 
 
 def set_default_income_account_for_item(obj):
-	"""Set income account as default for items in the transaction.
+    """Set income account as default for items in the transaction.
 
-	Updates the item default income account for each item in the transaction
-	if it differs from the company's default income account.
+    Updates the item default income account for each item in the transaction
+    if it differs from the company's default income account.
 
-	Args:
-	    obj: Transaction document containing items table with income_account field
-	"""
-	company_default = frappe.get_cached_value("Company", obj.company, "default_income_account")
-	for d in obj.get("items", default=[]):
-		income_account = getattr(d, "income_account", None)
-		if d.item_code and income_account and income_account != company_default:
-			set_item_default(d.item_code, obj.company, "income_account", income_account)
+    Args:
+        obj: Transaction document containing items table with income_account field
+    """
+    company_default = frappe.get_cached_value(
+        "Company", obj.company, "default_income_account"
+    )
+    for d in obj.get("items", default=[]):
+        income_account = getattr(d, "income_account", None)
+        if d.item_code and income_account and income_account != company_default:
+            set_item_default(d.item_code, obj.company, "income_account", income_account)
 
 
 def get_serial_and_batch_bundle(child, parent, delivery_note_child=None):
-	from erpnext.stock.serial_batch_bundle import SerialBatchCreation
+    from erpnext.stock.serial_batch_bundle import SerialBatchCreation
 
-	if parent.get("is_return") and parent.get("packed_items"):
-		return
+    if parent.get("is_return") and parent.get("packed_items"):
+        return
 
-	if child.get("use_serial_batch_fields"):
-		return
+    if child.get("use_serial_batch_fields"):
+        return
 
-	if not frappe.get_single_value("Stock Settings", "auto_create_serial_and_batch_bundle_for_outward"):
-		return
+    if not frappe.get_single_value(
+        "Stock Settings", "auto_create_serial_and_batch_bundle_for_outward"
+    ):
+        return
 
-	item_details = frappe.db.get_value("Item", child.item_code, ["has_serial_no", "has_batch_no"], as_dict=1)
+    item_details = frappe.db.get_value(
+        "Item", child.item_code, ["has_serial_no", "has_batch_no"], as_dict=1
+    )
 
-	if not item_details.has_serial_no and not item_details.has_batch_no:
-		return
+    if not item_details.has_serial_no and not item_details.has_batch_no:
+        return
 
-	sn_doc = SerialBatchCreation(
-		{
-			"item_code": child.item_code,
-			"warehouse": child.warehouse,
-			"voucher_type": parent.doctype,
-			"voucher_no": parent.name if parent.docstatus < 2 else None,
-			"voucher_detail_no": delivery_note_child.name if delivery_note_child else child.name,
-			"posting_datetime": get_combine_datetime(parent.posting_date, parent.posting_time),
-			"qty": child.qty,
-			"type_of_transaction": "Outward" if child.qty > 0 and parent.docstatus < 2 else "Inward",
-			"company": parent.company,
-			"do_not_submit": "True",
-		}
-	)
+    sn_doc = SerialBatchCreation(
+        {
+            "item_code": child.item_code,
+            "warehouse": child.warehouse,
+            "voucher_type": parent.doctype,
+            "voucher_no": parent.name if parent.docstatus < 2 else None,
+            "voucher_detail_no": (
+                delivery_note_child.name if delivery_note_child else child.name
+            ),
+            "posting_datetime": get_combine_datetime(
+                parent.posting_date, parent.posting_time
+            ),
+            "qty": child.qty,
+            "type_of_transaction": (
+                "Outward" if child.qty > 0 and parent.docstatus < 2 else "Inward"
+            ),
+            "company": parent.company,
+            "do_not_submit": "True",
+        }
+    )
 
-	doc = sn_doc.make_serial_and_batch_bundle()
-	child.db_set("serial_and_batch_bundle", doc.name)
+    doc = sn_doc.make_serial_and_batch_bundle()
+    child.db_set("serial_and_batch_bundle", doc.name)
 
-	return doc.name
+    return doc.name

--- a/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py
+++ b/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py
@@ -14,959 +14,1104 @@ from frappe.model.document import Document
 from frappe.model.naming import make_autoname
 from frappe.query_builder.functions import Concat_ws, Locate, Sum
 from frappe.utils import (
-	cint,
-	cstr,
-	flt,
-	format_datetime,
-	get_datetime,
-	get_link_to_form,
-	getdate,
-	now,
-	parse_json,
-	today,
+    cint,
+    cstr,
+    flt,
+    format_datetime,
+    get_datetime,
+    get_link_to_form,
+    getdate,
+    now,
+    parse_json,
+    today,
 )
 from frappe.utils.csvutils import build_csv_response
 
-from erpnext.stock.doctype.purchase_receipt_item.purchase_receipt_item import PurchaseReceiptItem
-from erpnext.stock.serial_batch_bundle import (
-	BatchNoValuation,
-	SerialNoValuation,
-	get_batches_from_bundle,
+from erpnext.stock.doctype.purchase_receipt_item.purchase_receipt_item import (
+    PurchaseReceiptItem,
 )
-from erpnext.stock.serial_batch_bundle import get_serial_nos as get_serial_nos_from_bundle
+from erpnext.stock.serial_batch_bundle import (
+    BatchNoValuation,
+    SerialNoValuation,
+    get_batches_from_bundle,
+)
+from erpnext.stock.serial_batch_bundle import (
+    get_serial_nos as get_serial_nos_from_bundle,
+)
 from erpnext.stock.valuation import FIFOValuation
 
 
 class SerialNoExistsInFutureTransactionError(frappe.ValidationError):
-	pass
+    pass
 
 
 class BatchNegativeStockError(frappe.ValidationError):
-	pass
+    pass
 
 
 class SerialNoDuplicateError(frappe.ValidationError):
-	pass
+    pass
 
 
 class SerialNoWarehouseError(frappe.ValidationError):
-	pass
+    pass
 
 
 class SerialandBatchBundle(Document):
-	# begin: auto-generated types
-	# This code is auto-generated. Do not modify anything in this block.
-
-	from typing import TYPE_CHECKING
-
-	if TYPE_CHECKING:
-		from frappe.types import DF
-
-		from erpnext.stock.doctype.serial_and_batch_entry.serial_and_batch_entry import SerialandBatchEntry
-
-		amended_from: DF.Link | None
-		avg_rate: DF.Float
-		company: DF.Link
-		entries: DF.Table[SerialandBatchEntry]
-		has_batch_no: DF.Check
-		has_serial_no: DF.Check
-		is_cancelled: DF.Check
-		is_packed: DF.Check
-		is_rejected: DF.Check
-		item_code: DF.Link
-		item_group: DF.Link | None
-		item_name: DF.Data | None
-		naming_series: DF.Literal["", "SABB-.########"]
-		posting_datetime: DF.Datetime | None
-		returned_against: DF.Data | None
-		total_amount: DF.Float
-		total_qty: DF.Float
-		type_of_transaction: DF.Literal["", "Inward", "Outward", "Maintenance", "Asset Repair"]
-		voucher_detail_no: DF.Data | None
-		voucher_no: DF.DynamicLink | None
-		voucher_type: DF.Link
-		warehouse: DF.Link | None
-	# end: auto-generated types
-
-	def autoname(self):
-		if frappe.get_single_value(
-			"Stock Settings", "set_serial_and_batch_bundle_naming_based_on_naming_series"
-		):
-			if not self.naming_series:
-				frappe.throw(_("Naming Series is mandatory"))
-
-			naming_series = self.naming_series
-			if "#" not in naming_series:
-				naming_series += ".#####"
-
-			self.name = make_autoname(self.naming_series)
-		else:
-			try:
-				self.name = frappe.generate_hash(length=20)
-			except frappe.DuplicateEntryError:
-				self.autoname()
-
-	def validate(self):
-		self.validate_allow_to_set_serial_batch()
-		if self.docstatus == 1 and self.voucher_detail_no:
-			self.validate_voucher_detail_no()
-
-		self.reset_serial_batch_bundle()
-		self.set_batch_no()
-		self.validate_serial_and_batch_no()
-		self.validate_duplicate_serial_and_batch_no()
-		self.validate_voucher_no()
-
-		if self.type_of_transaction == "Maintenance":
-			return
-
-		self.allow_existing_serial_nos()
-		if self.docstatus == 1:
-			if not self.flags.ignore_validate_serial_batch or frappe.in_test:
-				self.validate_serial_nos_duplicate()
-
-			self.check_future_entries_exists()
-		elif (
-			self.has_serial_no
-			and self.type_of_transaction == "Outward"
-			and self.voucher_type != "Stock Reconciliation"
-			and self.voucher_no
-		):
-			self.validate_serial_no_status()
-
-		self.set_is_outward()
-		self.calculate_total_qty()
-		self.set_warehouse()
-
-		if self.voucher_type != "Stock Entry" or not self.voucher_no or self.docstatus == 1:
-			self.set_incoming_rate()
-
-		self.calculate_qty_and_amount()
-		self.set_child_details()
-
-	def validate_allow_to_set_serial_batch(self):
-		if not frappe.db.get_single_value("Stock Settings", "enable_serial_and_batch_no_for_item"):
-			frappe.throw(
-				_(
-					"Please check the 'Enable Serial and Batch No for Item' checkbox in the {0} to make Serial and Batch Bundle for the item."
-				).format(get_link_to_form("Stock Settings", "Stock Settings")),
-				title=_("Serial and Batch No for Item Disabled"),
-			)
-
-	def validate_serial_no_status(self):
-		serial_nos = [d.serial_no for d in self.entries if d.serial_no]
-		invalid_serial_nos = frappe.get_all(
-			"Serial No",
-			filters={
-				"name": ("in", serial_nos),
-				"warehouse": ("!=", self.warehouse),
-			},
-			pluck="name",
-		)
-
-		if invalid_serial_nos:
-			msg = _(
-				"You cannot outward following {0} as either they are Delivered, Inactive or located in a different warehouse."
-			).format(_("Serial Nos") if len(invalid_serial_nos) > 1 else _("Serial No"))
-			msg += "<hr>"
-			msg += ", ".join(sn for sn in invalid_serial_nos)
-			frappe.throw(msg)
-
-	def validate_voucher_detail_no(self):
-		if self.type_of_transaction not in ["Inward", "Outward"] or self.voucher_type in [
-			"Installation Note",
-			"Job Card",
-			"Maintenance Schedule",
-			"Pick List",
-		]:
-			return
-
-		if self.voucher_type == "POS Invoice":
-			if not frappe.db.exists("POS Invoice Item", self.voucher_detail_no):
-				frappe.throw(
-					_("The serial and batch bundle {0} not linked to {1} {2}").format(
-						bold(self.name), self.voucher_type, bold(self.voucher_no)
-					)
-				)
-
-		elif not frappe.db.exists("Stock Ledger Entry", {"voucher_detail_no": self.voucher_detail_no}):
-			if self.voucher_type in ["Delivery Note", "Sales Invoice"] and frappe.db.exists(
-				"Packed Item", self.voucher_detail_no
-			):
-				return
-
-			frappe.throw(
-				_("The serial and batch bundle {0} not linked to {1} {2}").format(
-					bold(self.name), self.voucher_type, bold(self.voucher_no)
-				)
-			)
-
-	def allow_existing_serial_nos(self):
-		if self.type_of_transaction == "Outward" or not self.has_serial_no:
-			return
-
-		if frappe.get_single_value("Stock Settings", "allow_existing_serial_no"):
-			return
-
-		if self.voucher_type not in ["Purchase Receipt", "Purchase Invoice", "Stock Entry"]:
-			return
-
-		if self.voucher_type == "Stock Entry" and frappe.get_cached_value(
-			"Stock Entry", self.voucher_no, "purpose"
-		) in ["Material Transfer", "Send to Subcontractor", "Material Transfer for Manufacture"]:
-			return
-
-		serial_nos = [d.serial_no for d in self.entries if d.serial_no]
-
-		data = frappe.get_all(
-			"Serial and Batch Entry",
-			filters={"serial_no": ("in", serial_nos), "docstatus": 1, "qty": ("<", 0)},
-			fields=["serial_no", "parent"],
-		)
-
-		note = "<br><br> <b>Note</b>:<br>"
-		for row in data:
-			frappe.throw(
-				_(
-					"You can't process the serial number {0} as it has already been used in the SABB {1}. {2} if you want to inward same serial number multiple times then enabled 'Allow existing Serial No to be Manufactured/Received again' in the {3}"
-				).format(
-					row.serial_no,
-					get_link_to_form("Serial and Batch Bundle", row.parent),
-					note,
-					get_link_to_form("Stock Settings", "Stock Settings"),
-				)
-			)
-
-	def reset_serial_batch_bundle(self):
-		if self.is_new() and self.amended_from:
-			for field in ["is_cancelled", "is_rejected"]:
-				if self.get(field):
-					self.set(field, 0)
-
-			if self.voucher_detail_no:
-				self.voucher_detail_no = None
-
-	def set_batch_no(self):
-		if self.has_serial_no and self.has_batch_no:
-			serial_nos = [d.serial_no for d in self.entries if d.serial_no]
-			has_no_batch = any(not d.batch_no for d in self.entries)
-			if not has_no_batch:
-				return
-
-			serial_no_batch = frappe._dict(
-				frappe.get_all(
-					"Serial No",
-					filters={"name": ("in", serial_nos)},
-					fields=["name", "batch_no"],
-					as_list=True,
-				)
-			)
-
-			for row in self.entries:
-				if not row.batch_no:
-					row.batch_no = serial_no_batch.get(row.serial_no)
-
-	def validate_serial_nos_inventory(self):
-		if not (self.has_serial_no and self.type_of_transaction == "Outward"):
-			return
-
-		if self.voucher_type == "Stock Reconciliation":
-			serial_nos, batches = self.get_serial_nos_for_validate()
-		else:
-			serial_nos = [d.serial_no for d in self.entries if d.serial_no]
-
-		if not serial_nos:
-			return
-
-		kwargs = {
-			"item_code": self.item_code,
-			"warehouse": self.warehouse,
-			"check_serial_nos": True,
-			"serial_nos": serial_nos,
-			"sabb_voucher_type": self.voucher_type,
-			"sabb_voucher_no": self.voucher_no,
-			"sabb_voucher_detail_no": self.voucher_detail_no,
-		}
-
-		if self.voucher_type == "POS Invoice":
-			kwargs["ignore_voucher_nos"] = [self.voucher_no]
-
-		if self.voucher_type == "Stock Reconciliation":
-			kwargs.update(
-				{
-					"voucher_no": self.voucher_no,
-					"posting_datetime": self.posting_datetime,
-				}
-			)
-
-		available_serial_nos = get_available_serial_nos(frappe._dict(kwargs))
-
-		serial_no_warehouse = {}
-		for data in available_serial_nos:
-			if data.serial_no not in serial_nos:
-				continue
-
-			serial_no_warehouse[data.serial_no] = data.warehouse
-
-		for serial_no in serial_nos:
-			if not serial_no_warehouse.get(serial_no) or serial_no_warehouse.get(serial_no) != self.warehouse:
-				reservation = get_serial_no_reservation(self.item_code, serial_no, self.warehouse)
-				if reservation:
-					self.throw_error_message(
-						f"Serial No {bold(serial_no)} is in warehouse {bold(self.warehouse)}"
-						f" but is reserved for {reservation.voucher_type} {bold(reservation.voucher_no)}"
-						f" via {get_link_to_form('Stock Reservation Entry', reservation.name)}."
-						f" Please use an unreserved serial number or cancel the reservation.",
-						SerialNoWarehouseError,
-					)
-				else:
-					self.throw_error_message(
-						f"Serial No {bold(serial_no)} is not present in the warehouse {bold(self.warehouse)}.",
-						SerialNoWarehouseError,
-					)
-
-	def validate_serial_nos_duplicate(self):
-		# Don't inward same serial number multiple times
-		if self.voucher_type in ["POS Invoice", "Pick List"]:
-			return
-
-		if not self.warehouse:
-			return
-
-		if self.voucher_type in ["Stock Reconciliation", "Stock Entry"] and self.docstatus != 1:
-			return
-
-		if not (self.has_serial_no and self.type_of_transaction == "Inward"):
-			return
-
-		serial_nos = [d.serial_no for d in self.entries if d.serial_no]
-		kwargs = frappe._dict(
-			{
-				"item_code": self.item_code,
-				"posting_datetime": self.posting_datetime,
-				"serial_nos": serial_nos,
-				"check_serial_nos": True,
-			}
-		)
-
-		if (self.returned_against or self.voucher_type == "Stock Reconciliation") and self.docstatus == 1:
-			kwargs["ignore_voucher_detail_no"] = self.voucher_detail_no
-
-		if self.docstatus == 1:
-			kwargs["voucher_no"] = self.voucher_no
-
-		available_serial_nos = get_available_serial_nos(kwargs)
-		for data in available_serial_nos:
-			if data.serial_no in serial_nos:
-				self.throw_error_message(
-					f"Serial No {bold(data.serial_no)} is already present in the warehouse {bold(data.warehouse)}.",
-					SerialNoDuplicateError,
-				)
-
-		if (
-			self.voucher_type == "Stock Entry"
-			and self.type_of_transaction == "Inward"
-			and frappe.get_cached_value("Stock Entry", self.voucher_no, "purpose")
-			in ["Manufacture", "Repack"]
-		):
-			serial_nos = frappe.get_all(
-				"Serial No", filters={"name": ("in", serial_nos), "status": "Delivered"}, pluck="name"
-			)
-
-			if serial_nos:
-				if len(serial_nos) == 1:
-					frappe.throw(
-						_(
-							"Serial No {0} is already Delivered. You cannot use them again in Manufacture / Repack entry."
-						).format(bold(serial_nos[0]))
-					)
-				else:
-					frappe.throw(
-						_(
-							"Serial Nos {0} are already Delivered. You cannot use them again in Manufacture / Repack entry."
-						).format(bold(", ".join(serial_nos)))
-					)
-
-	def throw_error_message(self, message, exception=frappe.ValidationError):
-		frappe.throw(_(message), exception, title=_("Error"))
-
-	def set_incoming_rate(self, parent=None, row=None, save=False, allow_negative_stock=False, prev_sle=None):
-		if self.type_of_transaction not in ["Inward", "Outward"] or self.voucher_type in [
-			"Installation Note",
-			"Job Card",
-			"Maintenance Schedule",
-			"Pick List",
-		]:
-			return
-
-		if return_against := self.get_return_against(parent=parent):
-			self.set_valuation_rate_for_return_entry(return_against, row, save, prev_sle=prev_sle)
-		elif self.type_of_transaction == "Outward":
-			self.set_incoming_rate_for_outward_transaction(
-				row, save, allow_negative_stock=allow_negative_stock
-			)
-		else:
-			self.set_incoming_rate_for_inward_transaction(row, save, prev_sle=prev_sle)
-
-	def set_valuation_rate_for_return_entry(self, return_against, row, save=False, prev_sle=None):
-		if valuation_details := self.get_valuation_rate_for_return_entry(return_against):
-			from erpnext.stock.utils import get_valuation_method
-
-			valuation_method = get_valuation_method(self.item_code, self.company)
-
-			stock_queue = []
-			non_batchwise_batches = []
-			if not self.has_serial_no and valuation_method == "FIFO":
-				non_batchwise_batches = frappe.get_all(
-					"Batch",
-					filters={
-						"name": ("in", [d.batch_no for d in self.entries if d.batch_no]),
-						"use_batchwise_valuation": 0,
-					},
-					pluck="name",
-				)
-
-				if non_batchwise_batches and prev_sle and prev_sle.stock_queue:
-					stock_queue = parse_json(prev_sle.stock_queue)
-
-			for row in self.entries:
-				if valuation_details:
-					self.validate_returned_serial_batch_no(return_against, row, valuation_details)
-
-				if row.serial_no:
-					valuation_rate = valuation_details["serial_nos"].get(row.serial_no)
-				else:
-					valuation_rate = valuation_details["batches"].get(row.batch_no)
-
-				if frappe.flags.through_repost_item_valuation and not valuation_rate:
-					# if different serial nos / batches are returned
-					if row.serial_no:
-						serial_nos = sorted(list(valuation_details["serial_nos"].keys()))
-						valuation_rate = valuation_details["serial_nos"].get(serial_nos[cint(row.idx) - 1])
-					else:
-						batches = sorted(list(valuation_details["batches"].keys()))
-						valuation_rate = valuation_details["batches"].get(batches[cint(row.idx) - 1])
-
-				row.incoming_rate = flt(valuation_rate)
-				row.stock_value_difference = flt(row.qty) * flt(row.incoming_rate)
-
-				if (
-					non_batchwise_batches
-					and row.batch_no in non_batchwise_batches
-					and row.incoming_rate is not None
-				):
-					if flt(row.qty) > 0:
-						stock_queue.append([row.qty, row.incoming_rate])
-					elif flt(row.qty) < 0:
-						stock_queue = FIFOValuation(stock_queue)
-						stock_queue.remove_stock(qty=abs(row.qty))
-						stock_queue = stock_queue.state
-					row.stock_queue = json.dumps(stock_queue)
-
-				if save:
-					row.db_set(
-						{
-							"incoming_rate": row.incoming_rate,
-							"stock_value_difference": row.stock_value_difference,
-							"stock_queue": row.get("stock_queue"),
-						}
-					)
-
-		elif self.type_of_transaction == "Inward":
-			self.set_incoming_rate_for_inward_transaction(row, save, prev_sle=prev_sle)
-
-	def validate_returned_serial_batch_no(self, return_against, row, original_inv_details):
-		if frappe.flags.through_repost_item_valuation and not frappe.in_test:
-			return
-
-		if row.serial_no and row.serial_no not in original_inv_details["serial_nos"]:
-			self.throw_error_message(
-				_(
-					"Serial No {0} is not present in the {1} {2}, hence you can't return it against the {1} {2}"
-				).format(bold(row.serial_no), self.voucher_type, bold(return_against))
-			)
-
-		if row.batch_no and row.batch_no not in original_inv_details["batches"]:
-			self.throw_error_message(
-				_(
-					"Batch No {0} is not present in the original {1} {2}, hence you can't return it against the {1} {2}"
-				).format(bold(row.batch_no), self.voucher_type, bold(return_against))
-			)
-
-	def get_valuation_rate_for_return_entry(self, return_against):
-		from erpnext.controllers.sales_and_purchase_return import get_warehouses_for_return
-
-		if not self.voucher_detail_no:
-			return {}
-
-		valuation_details = frappe._dict(
-			{
-				"serial_nos": defaultdict(float),
-				"batches": defaultdict(float),
-			}
-		)
-
-		field = {
-			"Sales Invoice": "sales_invoice_item",
-			"Purchase Invoice": "purchase_invoice_item",
-			"Delivery Note": "dn_detail",
-			"Purchase Receipt": "purchase_receipt_item",
-		}.get(self.voucher_type)
-
-		return_against_voucher_detail_no = frappe.db.get_value(
-			self.child_table, self.voucher_detail_no, field
-		)
-
-		filters = [
-			["Serial and Batch Bundle", "voucher_no", "=", return_against],
-			["Serial and Batch Entry", "docstatus", "=", 1],
-			["Serial and Batch Bundle", "is_cancelled", "=", 0],
-			["Serial and Batch Bundle", "item_code", "=", self.item_code],
-			["Serial and Batch Bundle", "voucher_detail_no", "=", return_against_voucher_detail_no],
-		]
-
-		# Added to handle rejected warehouse case
-		if self.voucher_type in ["Purchase Receipt", "Purchase Invoice"]:
-			warehouses = get_warehouses_for_return(self.voucher_type, return_against_voucher_detail_no)
-			if self.warehouse in warehouses:
-				filters.append(["Serial and Batch Entry", "warehouse", "=", self.warehouse])
-
-		bundle_data = frappe.get_all(
-			"Serial and Batch Bundle",
-			fields=[
-				"`tabSerial and Batch Entry`.`serial_no`",
-				"`tabSerial and Batch Entry`.`batch_no`",
-				"`tabSerial and Batch Entry`.`incoming_rate`",
-			],
-			filters=filters,
-			order_by="`tabSerial and Batch Bundle`.`creation`, `tabSerial and Batch Entry`.`idx`",
-		)
-
-		if not bundle_data:
-			return {}
-
-		for row in bundle_data:
-			if row.serial_no:
-				valuation_details["serial_nos"][row.serial_no] = row.incoming_rate
-			if row.batch_no:
-				valuation_details["batches"][row.batch_no] = row.incoming_rate
-
-		return valuation_details
-
-	def calculate_total_qty(self, save=True):
-		self.total_qty = 0.0
-		for d in self.entries:
-			d.qty = 1 if self.has_serial_no and abs(d.qty) > 1 else abs(d.qty) if d.qty else 0
-			d.stock_value_difference = abs(d.stock_value_difference) if d.stock_value_difference else 0
-			if self.type_of_transaction == "Outward":
-				d.qty *= -1
-				d.stock_value_difference *= -1
-
-			self.total_qty += flt(d.qty)
-
-		if save:
-			self.db_set("total_qty", self.total_qty)
-
-	def get_serial_nos(self):
-		return [d.serial_no for d in self.entries if d.serial_no]
-
-	def update_valuation_rate(self, valuation_rate=None, save=False):
-		for row in self.entries:
-			row.incoming_rate = valuation_rate
-			row.stock_value_difference = flt(row.qty) * flt(valuation_rate)
-
-			if save:
-				row.db_set(
-					{"incoming_rate": row.incoming_rate, "stock_value_difference": row.stock_value_difference}
-				)
-
-	def set_incoming_rate_for_outward_transaction(self, row=None, save=False, allow_negative_stock=False):
-		from erpnext.stock.utils import get_valuation_method
-
-		sle = self.get_sle_for_outward_transaction()
-
-		if self.has_serial_no:
-			sn_obj = SerialNoValuation(
-				sle=sle,
-				item_code=self.item_code,
-				warehouse=self.warehouse,
-			)
-
-		else:
-			sn_obj = BatchNoValuation(
-				sle=sle,
-				item_code=self.item_code,
-				warehouse=self.warehouse,
-			)
-
-		stock_queue = []
-		if hasattr(sn_obj, "stock_queue") and sn_obj.stock_queue:
-			stock_queue = parse_json(sn_obj.stock_queue)
-
-		val_method = get_valuation_method(self.item_code, self.company)
-
-		for d in self.entries:
-			available_qty = 0
-
-			if self.has_serial_no:
-				d.incoming_rate = abs(sn_obj.serial_no_incoming_rate.get(d.serial_no, 0.0))
-			else:
-				actual_qty = d.qty
-				if (
-					stock_queue
-					and val_method == "FIFO"
-					and d.batch_no in sn_obj.non_batchwise_valuation_batches
-				):
-					if actual_qty < 0:
-						stock_queue = FIFOValuation(stock_queue)
-						_prev_qty, prev_stock_value = stock_queue.get_total_stock_and_value()
-
-						stock_queue.remove_stock(qty=abs(actual_qty))
-						_qty, stock_value = stock_queue.get_total_stock_and_value()
-
-						stock_value_difference = stock_value - prev_stock_value
-						d.incoming_rate = abs(flt(stock_value_difference) / abs(flt(actual_qty)))
-						stock_queue = stock_queue.state
-					else:
-						d.incoming_rate = abs(flt(sn_obj.batch_avg_rate.get(d.batch_no)))
-						stock_queue.append([d.qty, d.incoming_rate])
-					d.stock_queue = json.dumps(stock_queue)
-				else:
-					d.incoming_rate = abs(flt(sn_obj.batch_avg_rate.get(d.batch_no)))
-
-				precision = d.precision("qty")
-				available_qty = flt(sn_obj.available_qty.get(d.batch_no), precision)
-				if self.docstatus == 1:
-					available_qty += flt(d.qty, precision)
-
-				if not allow_negative_stock:
-					self.validate_negative_batch(d.batch_no, available_qty)
-
-			d.stock_value_difference = flt(d.qty) * flt(d.incoming_rate)
-
-			if save:
-				d.db_set(
-					{
-						"incoming_rate": d.incoming_rate,
-						"stock_value_difference": d.stock_value_difference,
-						"stock_queue": d.get("stock_queue"),
-					}
-				)
-
-	def validate_negative_batch(self, batch_no, available_qty):
-		if available_qty < 0 and not self.is_stock_reco_for_valuation_adjustment(available_qty):
-			msg = f"""Batch No {bold(batch_no)} of an Item {bold(self.item_code)}
+    # begin: auto-generated types
+    # This code is auto-generated. Do not modify anything in this block.
+
+    from typing import TYPE_CHECKING
+
+    if TYPE_CHECKING:
+        from frappe.types import DF
+
+        from erpnext.stock.doctype.serial_and_batch_entry.serial_and_batch_entry import (
+            SerialandBatchEntry,
+        )
+
+        amended_from: DF.Link | None
+        avg_rate: DF.Float
+        company: DF.Link
+        entries: DF.Table[SerialandBatchEntry]
+        has_batch_no: DF.Check
+        has_serial_no: DF.Check
+        is_cancelled: DF.Check
+        is_packed: DF.Check
+        is_rejected: DF.Check
+        item_code: DF.Link
+        item_group: DF.Link | None
+        item_name: DF.Data | None
+        naming_series: DF.Literal["", "SABB-.########"]
+        posting_datetime: DF.Datetime | None
+        returned_against: DF.Data | None
+        total_amount: DF.Float
+        total_qty: DF.Float
+        type_of_transaction: DF.Literal[
+            "", "Inward", "Outward", "Maintenance", "Asset Repair"
+        ]
+        voucher_detail_no: DF.Data | None
+        voucher_no: DF.DynamicLink | None
+        voucher_type: DF.Link
+        warehouse: DF.Link | None
+    # end: auto-generated types
+
+    def autoname(self):
+        if frappe.get_single_value(
+            "Stock Settings",
+            "set_serial_and_batch_bundle_naming_based_on_naming_series",
+        ):
+            if not self.naming_series:
+                frappe.throw(_("Naming Series is mandatory"))
+
+            naming_series = self.naming_series
+            if "#" not in naming_series:
+                naming_series += ".#####"
+
+            self.name = make_autoname(self.naming_series)
+        else:
+            try:
+                self.name = frappe.generate_hash(length=20)
+            except frappe.DuplicateEntryError:
+                self.autoname()
+
+    def validate(self):
+        self.validate_allow_to_set_serial_batch()
+        if self.docstatus == 1 and self.voucher_detail_no:
+            self.validate_voucher_detail_no()
+
+        self.reset_serial_batch_bundle()
+        self.set_batch_no()
+        self.validate_serial_and_batch_no()
+        self.validate_duplicate_serial_and_batch_no()
+        self.validate_voucher_no()
+
+        if self.type_of_transaction == "Maintenance":
+            return
+
+        self.allow_existing_serial_nos()
+        if self.docstatus == 1:
+            if not self.flags.ignore_validate_serial_batch or frappe.in_test:
+                self.validate_serial_nos_duplicate()
+
+            self.check_future_entries_exists()
+        elif (
+            self.has_serial_no
+            and self.type_of_transaction == "Outward"
+            and self.voucher_type != "Stock Reconciliation"
+            and self.voucher_no
+        ):
+            self.validate_serial_no_status()
+
+        self.set_is_outward()
+        self.calculate_total_qty()
+        self.set_warehouse()
+
+        if (
+            self.voucher_type != "Stock Entry"
+            or not self.voucher_no
+            or self.docstatus == 1
+        ):
+            self.set_incoming_rate()
+
+        self.calculate_qty_and_amount()
+        self.set_child_details()
+
+    def validate_allow_to_set_serial_batch(self):
+        if not frappe.db.get_single_value(
+            "Stock Settings", "enable_serial_and_batch_no_for_item"
+        ):
+            frappe.throw(
+                _(
+                    "Please check the 'Enable Serial and Batch No for Item' checkbox in the {0} to make Serial and Batch Bundle for the item."
+                ).format(get_link_to_form("Stock Settings", "Stock Settings")),
+                title=_("Serial and Batch No for Item Disabled"),
+            )
+
+    def validate_serial_no_status(self):
+        serial_nos = [d.serial_no for d in self.entries if d.serial_no]
+        invalid_serial_nos = frappe.get_all(
+            "Serial No",
+            filters={
+                "name": ("in", serial_nos),
+                "warehouse": ("!=", self.warehouse),
+            },
+            pluck="name",
+        )
+
+        if invalid_serial_nos:
+            msg = _(
+                "You cannot outward following {0} as either they are Delivered, Inactive or located in a different warehouse."
+            ).format(_("Serial Nos") if len(invalid_serial_nos) > 1 else _("Serial No"))
+            msg += "<hr>"
+            msg += ", ".join(sn for sn in invalid_serial_nos)
+            frappe.throw(msg)
+
+    def validate_voucher_detail_no(self):
+        if self.type_of_transaction not in [
+            "Inward",
+            "Outward",
+        ] or self.voucher_type in [
+            "Installation Note",
+            "Job Card",
+            "Maintenance Schedule",
+            "Pick List",
+        ]:
+            return
+
+        if self.voucher_type == "POS Invoice":
+            if not frappe.db.exists("POS Invoice Item", self.voucher_detail_no):
+                frappe.throw(
+                    _("The serial and batch bundle {0} not linked to {1} {2}").format(
+                        bold(self.name), self.voucher_type, bold(self.voucher_no)
+                    )
+                )
+
+        elif not frappe.db.exists(
+            "Stock Ledger Entry", {"voucher_detail_no": self.voucher_detail_no}
+        ):
+            if self.voucher_type in [
+                "Delivery Note",
+                "Sales Invoice",
+            ] and frappe.db.exists("Packed Item", self.voucher_detail_no):
+                return
+
+            frappe.throw(
+                _("The serial and batch bundle {0} not linked to {1} {2}").format(
+                    bold(self.name), self.voucher_type, bold(self.voucher_no)
+                )
+            )
+
+    def allow_existing_serial_nos(self):
+        if self.type_of_transaction == "Outward" or not self.has_serial_no:
+            return
+
+        if frappe.get_single_value("Stock Settings", "allow_existing_serial_no"):
+            return
+
+        if self.voucher_type not in [
+            "Purchase Receipt",
+            "Purchase Invoice",
+            "Stock Entry",
+        ]:
+            return
+
+        if self.voucher_type == "Stock Entry" and frappe.get_cached_value(
+            "Stock Entry", self.voucher_no, "purpose"
+        ) in [
+            "Material Transfer",
+            "Send to Subcontractor",
+            "Material Transfer for Manufacture",
+        ]:
+            return
+
+        serial_nos = [d.serial_no for d in self.entries if d.serial_no]
+
+        data = frappe.get_all(
+            "Serial and Batch Entry",
+            filters={"serial_no": ("in", serial_nos), "docstatus": 1, "qty": ("<", 0)},
+            fields=["serial_no", "parent"],
+        )
+
+        note = "<br><br> <b>Note</b>:<br>"
+        for row in data:
+            frappe.throw(
+                _(
+                    "You can't process the serial number {0} as it has already been used in the SABB {1}. {2} if you want to inward same serial number multiple times then enabled 'Allow existing Serial No to be Manufactured/Received again' in the {3}"
+                ).format(
+                    row.serial_no,
+                    get_link_to_form("Serial and Batch Bundle", row.parent),
+                    note,
+                    get_link_to_form("Stock Settings", "Stock Settings"),
+                )
+            )
+
+    def reset_serial_batch_bundle(self):
+        if self.is_new() and self.amended_from:
+            for field in ["is_cancelled", "is_rejected"]:
+                if self.get(field):
+                    self.set(field, 0)
+
+            if self.voucher_detail_no:
+                self.voucher_detail_no = None
+
+    def set_batch_no(self):
+        if self.has_serial_no and self.has_batch_no:
+            serial_nos = [d.serial_no for d in self.entries if d.serial_no]
+            has_no_batch = any(not d.batch_no for d in self.entries)
+            if not has_no_batch:
+                return
+
+            serial_no_batch = frappe._dict(
+                frappe.get_all(
+                    "Serial No",
+                    filters={"name": ("in", serial_nos)},
+                    fields=["name", "batch_no"],
+                    as_list=True,
+                )
+            )
+
+            for row in self.entries:
+                if not row.batch_no:
+                    row.batch_no = serial_no_batch.get(row.serial_no)
+
+    def validate_serial_nos_inventory(self):
+        if not (self.has_serial_no and self.type_of_transaction == "Outward"):
+            return
+
+        if self.voucher_type == "Stock Reconciliation":
+            serial_nos, batches = self.get_serial_nos_for_validate()
+        else:
+            serial_nos = [d.serial_no for d in self.entries if d.serial_no]
+
+        if not serial_nos:
+            return
+
+        kwargs = {
+            "item_code": self.item_code,
+            "warehouse": self.warehouse,
+            "check_serial_nos": True,
+            "serial_nos": serial_nos,
+            "sabb_voucher_type": self.voucher_type,
+            "sabb_voucher_no": self.voucher_no,
+            "sabb_voucher_detail_no": self.voucher_detail_no,
+        }
+
+        if self.voucher_type == "POS Invoice":
+            kwargs["ignore_voucher_nos"] = [self.voucher_no]
+
+        if self.voucher_type == "Stock Reconciliation":
+            kwargs.update(
+                {
+                    "voucher_no": self.voucher_no,
+                    "posting_datetime": self.posting_datetime,
+                }
+            )
+
+        available_serial_nos = get_available_serial_nos(frappe._dict(kwargs))
+
+        serial_no_warehouse = {}
+        for data in available_serial_nos:
+            if data.serial_no not in serial_nos:
+                continue
+
+            serial_no_warehouse[data.serial_no] = data.warehouse
+
+        for serial_no in serial_nos:
+            if (
+                not serial_no_warehouse.get(serial_no)
+                or serial_no_warehouse.get(serial_no) != self.warehouse
+            ):
+                reservation = get_serial_no_reservation(
+                    self.item_code, serial_no, self.warehouse
+                )
+                if reservation:
+                    self.throw_error_message(
+                        f"Serial No {bold(serial_no)} is in warehouse {bold(self.warehouse)}"
+                        f" but is reserved for {reservation.voucher_type} {bold(reservation.voucher_no)}"
+                        f" via {get_link_to_form('Stock Reservation Entry', reservation.name)}."
+                        f" Please use an unreserved serial number or cancel the reservation.",
+                        SerialNoWarehouseError,
+                    )
+                else:
+                    self.throw_error_message(
+                        f"Serial No {bold(serial_no)} is not present in the warehouse {bold(self.warehouse)}.",
+                        SerialNoWarehouseError,
+                    )
+
+    def validate_serial_nos_duplicate(self):
+        # Don't inward same serial number multiple times
+        if self.voucher_type in ["POS Invoice", "Pick List"]:
+            return
+
+        if not self.warehouse:
+            return
+
+        if (
+            self.voucher_type in ["Stock Reconciliation", "Stock Entry"]
+            and self.docstatus != 1
+        ):
+            return
+
+        if not (self.has_serial_no and self.type_of_transaction == "Inward"):
+            return
+
+        serial_nos = [d.serial_no for d in self.entries if d.serial_no]
+        kwargs = frappe._dict(
+            {
+                "item_code": self.item_code,
+                "posting_datetime": self.posting_datetime,
+                "serial_nos": serial_nos,
+                "check_serial_nos": True,
+            }
+        )
+
+        if (
+            self.returned_against or self.voucher_type == "Stock Reconciliation"
+        ) and self.docstatus == 1:
+            kwargs["ignore_voucher_detail_no"] = self.voucher_detail_no
+
+        if self.docstatus == 1:
+            kwargs["voucher_no"] = self.voucher_no
+
+        available_serial_nos = get_available_serial_nos(kwargs)
+        for data in available_serial_nos:
+            if data.serial_no in serial_nos:
+                self.throw_error_message(
+                    f"Serial No {bold(data.serial_no)} is already present in the warehouse {bold(data.warehouse)}.",
+                    SerialNoDuplicateError,
+                )
+
+        if (
+            self.voucher_type == "Stock Entry"
+            and self.type_of_transaction == "Inward"
+            and frappe.get_cached_value("Stock Entry", self.voucher_no, "purpose")
+            in ["Manufacture", "Repack"]
+        ):
+            serial_nos = frappe.get_all(
+                "Serial No",
+                filters={"name": ("in", serial_nos), "status": "Delivered"},
+                pluck="name",
+            )
+
+            if serial_nos:
+                if len(serial_nos) == 1:
+                    frappe.throw(
+                        _(
+                            "Serial No {0} is already Delivered. You cannot use them again in Manufacture / Repack entry."
+                        ).format(bold(serial_nos[0]))
+                    )
+                else:
+                    frappe.throw(
+                        _(
+                            "Serial Nos {0} are already Delivered. You cannot use them again in Manufacture / Repack entry."
+                        ).format(bold(", ".join(serial_nos)))
+                    )
+
+    def throw_error_message(self, message, exception=frappe.ValidationError):
+        frappe.throw(_(message), exception, title=_("Error"))
+
+    def set_incoming_rate(
+        self,
+        parent=None,
+        row=None,
+        save=False,
+        allow_negative_stock=False,
+        prev_sle=None,
+    ):
+        if self.type_of_transaction not in [
+            "Inward",
+            "Outward",
+        ] or self.voucher_type in [
+            "Installation Note",
+            "Job Card",
+            "Maintenance Schedule",
+            "Pick List",
+        ]:
+            return
+
+        if return_against := self.get_return_against(parent=parent):
+            self.set_valuation_rate_for_return_entry(
+                return_against, row, save, prev_sle=prev_sle
+            )
+        elif self.type_of_transaction == "Outward":
+            self.set_incoming_rate_for_outward_transaction(
+                row, save, allow_negative_stock=allow_negative_stock
+            )
+        else:
+            self.set_incoming_rate_for_inward_transaction(row, save, prev_sle=prev_sle)
+
+    def set_valuation_rate_for_return_entry(
+        self, return_against, row, save=False, prev_sle=None
+    ):
+        if valuation_details := self.get_valuation_rate_for_return_entry(
+            return_against
+        ):
+            from erpnext.stock.utils import get_valuation_method
+
+            valuation_method = get_valuation_method(self.item_code, self.company)
+
+            stock_queue = []
+            non_batchwise_batches = []
+            if not self.has_serial_no and valuation_method == "FIFO":
+                non_batchwise_batches = frappe.get_all(
+                    "Batch",
+                    filters={
+                        "name": (
+                            "in",
+                            [d.batch_no for d in self.entries if d.batch_no],
+                        ),
+                        "use_batchwise_valuation": 0,
+                    },
+                    pluck="name",
+                )
+
+                if non_batchwise_batches and prev_sle and prev_sle.stock_queue:
+                    stock_queue = parse_json(prev_sle.stock_queue)
+
+            for row in self.entries:
+                if valuation_details:
+                    self.validate_returned_serial_batch_no(
+                        return_against, row, valuation_details
+                    )
+
+                if row.serial_no:
+                    valuation_rate = valuation_details["serial_nos"].get(row.serial_no)
+                else:
+                    valuation_rate = valuation_details["batches"].get(row.batch_no)
+
+                if frappe.flags.through_repost_item_valuation and not valuation_rate:
+                    # if different serial nos / batches are returned
+                    if row.serial_no:
+                        serial_nos = sorted(
+                            list(valuation_details["serial_nos"].keys())
+                        )
+                        valuation_rate = valuation_details["serial_nos"].get(
+                            serial_nos[cint(row.idx) - 1]
+                        )
+                    else:
+                        batches = sorted(list(valuation_details["batches"].keys()))
+                        valuation_rate = valuation_details["batches"].get(
+                            batches[cint(row.idx) - 1]
+                        )
+
+                row.incoming_rate = flt(valuation_rate)
+                row.stock_value_difference = flt(row.qty) * flt(row.incoming_rate)
+
+                if (
+                    non_batchwise_batches
+                    and row.batch_no in non_batchwise_batches
+                    and row.incoming_rate is not None
+                ):
+                    if flt(row.qty) > 0:
+                        stock_queue.append([row.qty, row.incoming_rate])
+                    elif flt(row.qty) < 0:
+                        stock_queue = FIFOValuation(stock_queue)
+                        stock_queue.remove_stock(qty=abs(row.qty))
+                        stock_queue = stock_queue.state
+                    row.stock_queue = json.dumps(stock_queue)
+
+                if save:
+                    row.db_set(
+                        {
+                            "incoming_rate": row.incoming_rate,
+                            "stock_value_difference": row.stock_value_difference,
+                            "stock_queue": row.get("stock_queue"),
+                        }
+                    )
+
+        elif self.type_of_transaction == "Inward":
+            self.set_incoming_rate_for_inward_transaction(row, save, prev_sle=prev_sle)
+
+    def validate_returned_serial_batch_no(
+        self, return_against, row, original_inv_details
+    ):
+        if frappe.flags.through_repost_item_valuation and not frappe.in_test:
+            return
+
+        if row.serial_no and row.serial_no not in original_inv_details["serial_nos"]:
+            self.throw_error_message(
+                _(
+                    "Serial No {0} is not present in the {1} {2}, hence you can't return it against the {1} {2}"
+                ).format(bold(row.serial_no), self.voucher_type, bold(return_against))
+            )
+
+        if row.batch_no and row.batch_no not in original_inv_details["batches"]:
+            self.throw_error_message(
+                _(
+                    "Batch No {0} is not present in the original {1} {2}, hence you can't return it against the {1} {2}"
+                ).format(bold(row.batch_no), self.voucher_type, bold(return_against))
+            )
+
+    def get_valuation_rate_for_return_entry(self, return_against):
+        from erpnext.controllers.sales_and_purchase_return import (
+            get_warehouses_for_return,
+        )
+
+        if not self.voucher_detail_no:
+            return {}
+
+        valuation_details = frappe._dict(
+            {
+                "serial_nos": defaultdict(float),
+                "batches": defaultdict(float),
+            }
+        )
+
+        field = {
+            "Sales Invoice": "sales_invoice_item",
+            "Purchase Invoice": "purchase_invoice_item",
+            "Delivery Note": "dn_detail",
+            "Purchase Receipt": "purchase_receipt_item",
+        }.get(self.voucher_type)
+
+        return_against_voucher_detail_no = frappe.db.get_value(
+            self.child_table, self.voucher_detail_no, field
+        )
+
+        filters = [
+            ["Serial and Batch Bundle", "voucher_no", "=", return_against],
+            ["Serial and Batch Entry", "docstatus", "=", 1],
+            ["Serial and Batch Bundle", "is_cancelled", "=", 0],
+            ["Serial and Batch Bundle", "item_code", "=", self.item_code],
+            [
+                "Serial and Batch Bundle",
+                "voucher_detail_no",
+                "=",
+                return_against_voucher_detail_no,
+            ],
+        ]
+
+        # Added to handle rejected warehouse case
+        if self.voucher_type in ["Purchase Receipt", "Purchase Invoice"]:
+            warehouses = get_warehouses_for_return(
+                self.voucher_type, return_against_voucher_detail_no
+            )
+            if self.warehouse in warehouses:
+                filters.append(
+                    ["Serial and Batch Entry", "warehouse", "=", self.warehouse]
+                )
+
+        bundle_data = frappe.get_all(
+            "Serial and Batch Bundle",
+            fields=[
+                "`tabSerial and Batch Entry`.`serial_no`",
+                "`tabSerial and Batch Entry`.`batch_no`",
+                "`tabSerial and Batch Entry`.`incoming_rate`",
+            ],
+            filters=filters,
+            order_by="`tabSerial and Batch Bundle`.`creation`, `tabSerial and Batch Entry`.`idx`",
+        )
+
+        if not bundle_data:
+            return {}
+
+        for row in bundle_data:
+            if row.serial_no:
+                valuation_details["serial_nos"][row.serial_no] = row.incoming_rate
+            if row.batch_no:
+                valuation_details["batches"][row.batch_no] = row.incoming_rate
+
+        return valuation_details
+
+    def calculate_total_qty(self, save=True):
+        self.total_qty = 0.0
+        for d in self.entries:
+            d.qty = (
+                1
+                if self.has_serial_no and abs(d.qty) > 1
+                else abs(d.qty) if d.qty else 0
+            )
+            d.stock_value_difference = (
+                abs(d.stock_value_difference) if d.stock_value_difference else 0
+            )
+            if self.type_of_transaction == "Outward":
+                d.qty *= -1
+                d.stock_value_difference *= -1
+
+            self.total_qty += flt(d.qty)
+
+        if save:
+            self.db_set("total_qty", self.total_qty)
+
+    def get_serial_nos(self):
+        return [d.serial_no for d in self.entries if d.serial_no]
+
+    def update_valuation_rate(self, valuation_rate=None, save=False):
+        for row in self.entries:
+            row.incoming_rate = valuation_rate
+            row.stock_value_difference = flt(row.qty) * flt(valuation_rate)
+
+            if save:
+                row.db_set(
+                    {
+                        "incoming_rate": row.incoming_rate,
+                        "stock_value_difference": row.stock_value_difference,
+                    }
+                )
+
+    def set_incoming_rate_for_outward_transaction(
+        self, row=None, save=False, allow_negative_stock=False
+    ):
+        from erpnext.stock.utils import get_valuation_method
+
+        sle = self.get_sle_for_outward_transaction()
+
+        if self.has_serial_no:
+            sn_obj = SerialNoValuation(
+                sle=sle,
+                item_code=self.item_code,
+                warehouse=self.warehouse,
+            )
+
+        else:
+            sn_obj = BatchNoValuation(
+                sle=sle,
+                item_code=self.item_code,
+                warehouse=self.warehouse,
+            )
+
+        stock_queue = []
+        if hasattr(sn_obj, "stock_queue") and sn_obj.stock_queue:
+            stock_queue = parse_json(sn_obj.stock_queue)
+
+        val_method = get_valuation_method(self.item_code, self.company)
+
+        for d in self.entries:
+            available_qty = 0
+
+            if self.has_serial_no:
+                d.incoming_rate = abs(
+                    sn_obj.serial_no_incoming_rate.get(d.serial_no, 0.0)
+                )
+            else:
+                actual_qty = d.qty
+                if (
+                    stock_queue
+                    and val_method == "FIFO"
+                    and d.batch_no in sn_obj.non_batchwise_valuation_batches
+                ):
+                    if actual_qty < 0:
+                        stock_queue = FIFOValuation(stock_queue)
+                        _prev_qty, prev_stock_value = (
+                            stock_queue.get_total_stock_and_value()
+                        )
+
+                        stock_queue.remove_stock(qty=abs(actual_qty))
+                        _qty, stock_value = stock_queue.get_total_stock_and_value()
+
+                        stock_value_difference = stock_value - prev_stock_value
+                        d.incoming_rate = abs(
+                            flt(stock_value_difference) / abs(flt(actual_qty))
+                        )
+                        stock_queue = stock_queue.state
+                    else:
+                        d.incoming_rate = abs(
+                            flt(sn_obj.batch_avg_rate.get(d.batch_no))
+                        )
+                        stock_queue.append([d.qty, d.incoming_rate])
+                    d.stock_queue = json.dumps(stock_queue)
+                else:
+                    d.incoming_rate = abs(flt(sn_obj.batch_avg_rate.get(d.batch_no)))
+
+                precision = d.precision("qty")
+                available_qty = flt(sn_obj.available_qty.get(d.batch_no), precision)
+                if self.docstatus == 1:
+                    available_qty += flt(d.qty, precision)
+
+                if not allow_negative_stock:
+                    self.validate_negative_batch(d.batch_no, available_qty)
+
+            d.stock_value_difference = flt(d.qty) * flt(d.incoming_rate)
+
+            if save:
+                d.db_set(
+                    {
+                        "incoming_rate": d.incoming_rate,
+                        "stock_value_difference": d.stock_value_difference,
+                        "stock_queue": d.get("stock_queue"),
+                    }
+                )
+
+    def validate_negative_batch(self, batch_no, available_qty):
+        if available_qty < 0 and not self.is_stock_reco_for_valuation_adjustment(
+            available_qty
+        ):
+            msg = f"""Batch No {bold(batch_no)} of an Item {bold(self.item_code)}
 				has negative stock
 				of quantity {bold(available_qty)} in the
 				warehouse {self.warehouse}"""
 
-			frappe.throw(_(msg), BatchNegativeStockError)
+            frappe.throw(_(msg), BatchNegativeStockError)
 
-	def is_stock_reco_for_valuation_adjustment(self, available_qty):
-		if (
-			self.voucher_type == "Stock Reconciliation"
-			and self.type_of_transaction == "Outward"
-			and self.voucher_detail_no
-			and (
-				abs(frappe.db.get_value("Stock Reconciliation Item", self.voucher_detail_no, "qty"))
-				== abs(available_qty)
-			)
-		):
-			return True
+    def is_stock_reco_for_valuation_adjustment(self, available_qty):
+        if (
+            self.voucher_type == "Stock Reconciliation"
+            and self.type_of_transaction == "Outward"
+            and self.voucher_detail_no
+            and (
+                abs(
+                    frappe.db.get_value(
+                        "Stock Reconciliation Item", self.voucher_detail_no, "qty"
+                    )
+                )
+                == abs(available_qty)
+            )
+        ):
+            return True
 
-		return False
+        return False
 
-	def get_sle_for_outward_transaction(self):
-		sle = frappe._dict(
-			{
-				"posting_datetime": self.posting_datetime,
-				"item_code": self.item_code,
-				"warehouse": self.warehouse,
-				"serial_and_batch_bundle": self.name,
-				"company": self.company,
-				"serial_nos": [row.serial_no for row in self.entries if row.serial_no],
-				"batch_nos": {row.batch_no: row for row in self.entries if row.batch_no},
-				"voucher_type": self.voucher_type,
-				"voucher_detail_no": self.voucher_detail_no,
-				"creation": self.creation,
-			}
-		)
+    def get_sle_for_outward_transaction(self):
+        sle = frappe._dict(
+            {
+                "posting_datetime": self.posting_datetime,
+                "item_code": self.item_code,
+                "warehouse": self.warehouse,
+                "serial_and_batch_bundle": self.name,
+                "company": self.company,
+                "serial_nos": [row.serial_no for row in self.entries if row.serial_no],
+                "batch_nos": {
+                    row.batch_no: row for row in self.entries if row.batch_no
+                },
+                "voucher_type": self.voucher_type,
+                "voucher_detail_no": self.voucher_detail_no,
+                "creation": self.creation,
+            }
+        )
 
-		if self.docstatus == 1:
-			sle["voucher_no"] = self.voucher_no
+        if self.docstatus == 1:
+            sle["voucher_no"] = self.voucher_no
 
-		if not sle.actual_qty:
-			self.calculate_total_qty()
-			sle.actual_qty = self.total_qty
+        if not sle.actual_qty:
+            self.calculate_total_qty()
+            sle.actual_qty = self.total_qty
 
-		return sle
+        return sle
 
-	def get_return_against(self, parent=None):
-		return_against = None
+    def get_return_against(self, parent=None):
+        return_against = None
 
-		if parent and parent.get("is_return") and parent.get("return_against"):
-			return parent.get("return_against")
+        if parent and parent.get("is_return") and parent.get("return_against"):
+            return parent.get("return_against")
 
-		if (
-			self.voucher_type
-			in [
-				"Delivery Note",
-				"Sales Invoice",
-				"Purchase Invoice",
-				"Purchase Receipt",
-				"POS Invoice",
-				"Subcontracting Receipt",
-			]
-			and self.voucher_type
-			and self.voucher_no
-		):
-			voucher_details = frappe.db.get_value(
-				self.voucher_type, self.voucher_no, ["is_return", "return_against"], as_dict=True
-			)
-			if voucher_details and voucher_details.get("is_return") and voucher_details.get("return_against"):
-				return voucher_details.get("return_against")
+        if (
+            self.voucher_type
+            in [
+                "Delivery Note",
+                "Sales Invoice",
+                "Purchase Invoice",
+                "Purchase Receipt",
+                "POS Invoice",
+                "Subcontracting Receipt",
+            ]
+            and self.voucher_type
+            and self.voucher_no
+        ):
+            voucher_details = frappe.db.get_value(
+                self.voucher_type,
+                self.voucher_no,
+                ["is_return", "return_against"],
+                as_dict=True,
+            )
+            if (
+                voucher_details
+                and voucher_details.get("is_return")
+                and voucher_details.get("return_against")
+            ):
+                return voucher_details.get("return_against")
 
-		return return_against
+        return return_against
 
-	def set_incoming_rate_for_inward_transaction(self, row=None, save=False, prev_sle=None):
-		from erpnext.stock.utils import get_valuation_method
+    def set_incoming_rate_for_inward_transaction(
+        self, row=None, save=False, prev_sle=None
+    ):
+        from erpnext.stock.utils import get_valuation_method
 
-		valuation_method = get_valuation_method(self.item_code, self.company)
+        valuation_method = get_valuation_method(self.item_code, self.company)
 
-		valuation_field = "valuation_rate"
-		if self.voucher_type in ["Sales Invoice", "Delivery Note", "Quotation"]:
-			valuation_field = "incoming_rate"
+        valuation_field = "valuation_rate"
+        if self.voucher_type in ["Sales Invoice", "Delivery Note", "Quotation"]:
+            valuation_field = "incoming_rate"
 
-		if self.voucher_type == "POS Invoice":
-			valuation_field = "rate"
+        if self.voucher_type == "POS Invoice":
+            valuation_field = "rate"
 
-		rate = row.get(valuation_field) if row else 0.0
-		child_table = self.child_table
+        rate = row.get(valuation_field) if row else 0.0
+        child_table = self.child_table
 
-		if self.voucher_type == "Subcontracting Receipt":
-			if not self.voucher_detail_no:
-				return
-			elif frappe.db.exists("Subcontracting Receipt Supplied Item", self.voucher_detail_no):
-				valuation_field = "rate"
-				child_table = "Subcontracting Receipt Supplied Item"
-			else:
-				valuation_field = "rate"
-				child_table = "Subcontracting Receipt Item"
+        if self.voucher_type == "Subcontracting Receipt":
+            if not self.voucher_detail_no:
+                return
+            elif frappe.db.exists(
+                "Subcontracting Receipt Supplied Item", self.voucher_detail_no
+            ):
+                valuation_field = "rate"
+                child_table = "Subcontracting Receipt Supplied Item"
+            else:
+                valuation_field = "rate"
+                child_table = "Subcontracting Receipt Item"
 
-		if not rate and self.voucher_detail_no and self.voucher_no:
-			rate = frappe.db.get_value(child_table, self.voucher_detail_no, valuation_field)
+        if not rate and self.voucher_detail_no and self.voucher_no:
+            rate = frappe.db.get_value(
+                child_table, self.voucher_detail_no, valuation_field
+            )
 
-		is_packed_item = False
-		if rate is None and child_table in ["Delivery Note Item", "Sales Invoice Item"]:
-			rate = frappe.db.get_value(
-				"Packed Item",
-				{"parent_detail_docname": self.voucher_detail_no, "item_code": self.item_code},
-				"incoming_rate",
-			)
+        is_packed_item = False
+        if rate is None and child_table in ["Delivery Note Item", "Sales Invoice Item"]:
+            rate = frappe.db.get_value(
+                "Packed Item",
+                {
+                    "parent_detail_docname": self.voucher_detail_no,
+                    "item_code": self.item_code,
+                },
+                "incoming_rate",
+            )
 
-			if rate is None:
-				rate = frappe.db.get_value("Packed Item", self.voucher_detail_no, "incoming_rate")
+            if rate is None:
+                rate = frappe.db.get_value(
+                    "Packed Item", self.voucher_detail_no, "incoming_rate"
+                )
 
-			if rate is not None:
-				is_packed_item = True
+            if rate is not None:
+                is_packed_item = True
 
-		stock_queue = []
-		batches = frappe.get_all(
-			"Batch",
-			filters={
-				"name": ("in", [d.batch_no for d in self.entries if d.batch_no]),
-				"use_batchwise_valuation": 0,
-			},
-			pluck="name",
-		)
+        stock_queue = []
+        batches = frappe.get_all(
+            "Batch",
+            filters={
+                "name": ("in", [d.batch_no for d in self.entries if d.batch_no]),
+                "use_batchwise_valuation": 0,
+            },
+            pluck="name",
+        )
 
-		if prev_sle and prev_sle.stock_queue and parse_json(prev_sle.stock_queue):
-			if batches and valuation_method == "FIFO":
-				stock_queue = parse_json(prev_sle.stock_queue)
+        if prev_sle and prev_sle.stock_queue and parse_json(prev_sle.stock_queue):
+            if batches and valuation_method == "FIFO":
+                stock_queue = parse_json(prev_sle.stock_queue)
 
-		set_valuation_rate_for_rejected_materials = frappe.db.get_single_value(
-			"Buying Settings", "set_valuation_rate_for_rejected_materials"
-		)
+        set_valuation_rate_for_rejected_materials = frappe.db.get_single_value(
+            "Buying Settings", "set_valuation_rate_for_rejected_materials"
+        )
 
-		precision = frappe.get_precision("Serial and Batch Entry", "incoming_rate")
-		for d in self.entries:
-			fifo_batch_wise_val = True
-			if valuation_method == "FIFO" and d.batch_no in batches:
-				fifo_batch_wise_val = False
+        precision = frappe.get_precision("Serial and Batch Entry", "incoming_rate")
+        for d in self.entries:
+            fifo_batch_wise_val = True
+            if valuation_method == "FIFO" and d.batch_no in batches:
+                fifo_batch_wise_val = False
 
-			if self.is_rejected and not set_valuation_rate_for_rejected_materials:
-				rate = 0.0
-			elif (
-				(flt(d.incoming_rate, precision) == flt(rate, precision))
-				and not stock_queue
-				and fifo_batch_wise_val
-				and d.qty
-				and d.stock_value_difference
-			):
-				continue
+            if self.is_rejected and not set_valuation_rate_for_rejected_materials:
+                rate = 0.0
+            elif (
+                (flt(d.incoming_rate, precision) == flt(rate, precision))
+                and not stock_queue
+                and fifo_batch_wise_val
+                and d.qty
+                and d.stock_value_difference
+            ):
+                continue
 
-			if is_packed_item and d.incoming_rate:
-				rate = d.incoming_rate
+            if is_packed_item and d.incoming_rate:
+                rate = d.incoming_rate
 
-			d.incoming_rate = flt(rate)
-			if d.qty:
-				d.stock_value_difference = flt(d.qty) * d.incoming_rate
+            d.incoming_rate = flt(rate)
+            if d.qty:
+                d.stock_value_difference = flt(d.qty) * d.incoming_rate
 
-			if valuation_method == "FIFO" and d.batch_no in batches and d.incoming_rate is not None:
-				stock_queue.append([d.qty, d.incoming_rate])
-				d.stock_queue = json.dumps(stock_queue)
+            if (
+                valuation_method == "FIFO"
+                and d.batch_no in batches
+                and d.incoming_rate is not None
+            ):
+                stock_queue.append([d.qty, d.incoming_rate])
+                d.stock_queue = json.dumps(stock_queue)
 
-			if save:
-				d.db_set(
-					{
-						"incoming_rate": d.incoming_rate,
-						"stock_value_difference": d.stock_value_difference,
-						"stock_queue": d.get("stock_queue"),
-					}
-				)
+            if save:
+                d.db_set(
+                    {
+                        "incoming_rate": d.incoming_rate,
+                        "stock_value_difference": d.stock_value_difference,
+                        "stock_queue": d.get("stock_queue"),
+                    }
+                )
 
-	def set_serial_and_batch_values(self, parent, row, qty_field=None):
-		values_to_set = {}
-		if not self.voucher_no or self.voucher_no != row.parent:
-			values_to_set["voucher_no"] = row.parent
+    def set_serial_and_batch_values(self, parent, row, qty_field=None):
+        values_to_set = {}
+        if not self.voucher_no or self.voucher_no != row.parent:
+            values_to_set["voucher_no"] = row.parent
 
-		self.db_set("is_cancelled", 0)
+        self.db_set("is_cancelled", 0)
 
-		if self.voucher_type != parent.doctype:
-			values_to_set["voucher_type"] = parent.doctype
+        if self.voucher_type != parent.doctype:
+            values_to_set["voucher_type"] = parent.doctype
 
-		if not self.voucher_detail_no or self.voucher_detail_no != row.name:
-			values_to_set["voucher_detail_no"] = row.name
+        if not self.voucher_detail_no or self.voucher_detail_no != row.name:
+            values_to_set["voucher_detail_no"] = row.name
 
-		if row.get("doctype") == "Packed Item" and row.get("parent_detail_docname"):
-			values_to_set["voucher_detail_no"] = row.get("parent_detail_docname")
+        if row.get("doctype") == "Packed Item" and row.get("parent_detail_docname"):
+            values_to_set["voucher_detail_no"] = row.get("parent_detail_docname")
 
-		if parent.get("posting_date") and parent.get("posting_time"):
-			posting_datetime = combine_datetime(parent.posting_date, parent.posting_time)
-			if not self.posting_datetime or self.posting_datetime != posting_datetime:
-				values_to_set["posting_datetime"] = posting_datetime
+        if parent.get("posting_date") and parent.get("posting_time"):
+            posting_datetime = combine_datetime(
+                parent.posting_date, parent.posting_time
+            )
+            if not self.posting_datetime or self.posting_datetime != posting_datetime:
+                values_to_set["posting_datetime"] = posting_datetime
 
-		if parent.doctype in [
-			"Delivery Note",
-			"Purchase Receipt",
-			"Purchase Invoice",
-			"Sales Invoice",
-		] and parent.get("is_return"):
-			return_ref_field = frappe.scrub(parent.doctype) + "_item"
-			if parent.doctype == "Delivery Note":
-				return_ref_field = "dn_detail"
+        if parent.doctype in [
+            "Delivery Note",
+            "Purchase Receipt",
+            "Purchase Invoice",
+            "Sales Invoice",
+        ] and parent.get("is_return"):
+            return_ref_field = frappe.scrub(parent.doctype) + "_item"
+            if parent.doctype == "Delivery Note":
+                return_ref_field = "dn_detail"
 
-			if row.get(return_ref_field):
-				values_to_set["returned_against"] = row.get(return_ref_field)
+            if row.get(return_ref_field):
+                values_to_set["returned_against"] = row.get(return_ref_field)
 
-		if values_to_set:
-			self.db_set(values_to_set)
+        if values_to_set:
+            self.db_set(values_to_set)
 
-		self.calculate_total_qty(save=True)
+        self.calculate_total_qty(save=True)
 
-		# If user has changed the rate in the child table
-		if self.docstatus == 0 and self.type_of_transaction == "Inward":
-			self.set_incoming_rate(parent=parent, row=row, save=True)
+        # If user has changed the rate in the child table
+        if self.docstatus == 0 and self.type_of_transaction == "Inward":
+            self.set_incoming_rate(parent=parent, row=row, save=True)
 
-		if self.docstatus == 0 and parent.get("is_return") and parent.is_new():
-			self.reset_qty(row, qty_field=qty_field)
+        if self.docstatus == 0 and parent.get("is_return") and parent.is_new():
+            self.reset_qty(row, qty_field=qty_field)
 
-		self.calculate_qty_and_amount(save=True)
-		self.validate_quantity(row, qty_field=qty_field)
+        self.calculate_qty_and_amount(save=True)
+        self.validate_quantity(row, qty_field=qty_field)
 
-	def validate_voucher_no(self):
-		if not (self.voucher_type and self.voucher_no):
-			return
+    def validate_voucher_no(self):
+        if not (self.voucher_type and self.voucher_no):
+            return
 
-		if (
-			self.docstatus == 1
-			and self.voucher_no
-			and not frappe.db.exists(self.voucher_type, self.voucher_no)
-		):
-			self.throw_error_message(f"The {self.voucher_type} # {self.voucher_no} does not exist")
+        if (
+            self.docstatus == 1
+            and self.voucher_no
+            and not frappe.db.exists(self.voucher_type, self.voucher_no)
+        ):
+            self.throw_error_message(
+                f"The {self.voucher_type} # {self.voucher_no} does not exist"
+            )
 
-		if self.flags.ignore_voucher_validation:
-			return
+        if self.flags.ignore_voucher_validation:
+            return
 
-		if (
-			self.docstatus == 1
-			and frappe.get_cached_value(self.voucher_type, self.voucher_no, "docstatus") != 1
-		):
-			self.throw_error_message(f"The {self.voucher_type} # {self.voucher_no} should be submit first.")
+        if (
+            self.docstatus == 1
+            and frappe.get_cached_value(self.voucher_type, self.voucher_no, "docstatus")
+            != 1
+        ):
+            self.throw_error_message(
+                f"The {self.voucher_type} # {self.voucher_no} should be submit first."
+            )
 
-	def check_future_entries_exists(self, is_cancelled=False):
-		if self.flags and self.flags.via_landed_cost_voucher:
-			return
+    def check_future_entries_exists(self, is_cancelled=False):
+        if self.flags and self.flags.via_landed_cost_voucher:
+            return
 
-		serial_nos = []
-		batches = []
+        serial_nos = []
+        batches = []
 
-		if self.voucher_type == "Stock Reconciliation":
-			serial_nos, batches = self.get_serial_nos_for_validate(is_cancelled=is_cancelled)
-		else:
-			batches = [d.batch_no for d in self.entries if d.batch_no]
+        if self.voucher_type == "Stock Reconciliation":
+            serial_nos, batches = self.get_serial_nos_for_validate(
+                is_cancelled=is_cancelled
+            )
+        else:
+            batches = [d.batch_no for d in self.entries if d.batch_no]
 
-		if (
-			self.voucher_type != "Stock Reconciliation"
-			and not self.flags.ignore_validate_serial_batch
-			and self.has_serial_no
-		):
-			serial_nos = [d.serial_no for d in self.entries if d.serial_no]
+        if (
+            self.voucher_type != "Stock Reconciliation"
+            and not self.flags.ignore_validate_serial_batch
+            and self.has_serial_no
+        ):
+            serial_nos = [d.serial_no for d in self.entries if d.serial_no]
 
-		if self.has_batch_no and not self.has_serial_no and not batches:
-			return
+        if self.has_batch_no and not self.has_serial_no and not batches:
+            return
 
-		parent = frappe.qb.DocType("Serial and Batch Bundle")
-		child = frappe.qb.DocType("Serial and Batch Entry")
+        parent = frappe.qb.DocType("Serial and Batch Bundle")
+        child = frappe.qb.DocType("Serial and Batch Entry")
 
-		timestamp_condition = parent.posting_datetime > self.posting_datetime
+        timestamp_condition = parent.posting_datetime > self.posting_datetime
 
-		future_entries = (
-			frappe.qb.from_(parent)
-			.inner_join(child)
-			.on(parent.name == child.parent)
-			.select(
-				child.serial_no,
-				child.batch_no,
-				parent.voucher_type,
-				parent.voucher_no,
-			)
-			.where(
-				(child.parent != self.name)
-				& (parent.item_code == self.item_code)
-				& (parent.docstatus == 1)
-				& (parent.is_cancelled == 0)
-				& (parent.type_of_transaction.isin(["Inward", "Outward"]))
-			)
-			.where(timestamp_condition)
-		)
+        future_entries = (
+            frappe.qb.from_(parent)
+            .inner_join(child)
+            .on(parent.name == child.parent)
+            .select(
+                child.serial_no,
+                child.batch_no,
+                parent.voucher_type,
+                parent.voucher_no,
+            )
+            .where(
+                (child.parent != self.name)
+                & (parent.item_code == self.item_code)
+                & (parent.docstatus == 1)
+                & (parent.is_cancelled == 0)
+                & (parent.type_of_transaction.isin(["Inward", "Outward"]))
+            )
+            .where(timestamp_condition)
+        )
 
-		if self.has_batch_no and not self.has_serial_no:
-			future_entries = future_entries.where(parent.voucher_type == "Stock Reconciliation")
+        if self.has_batch_no and not self.has_serial_no:
+            future_entries = future_entries.where(
+                parent.voucher_type == "Stock Reconciliation"
+            )
 
-		if serial_nos:
-			future_entries = future_entries.where(
-				(child.serial_no.isin(serial_nos))
-				| ((parent.warehouse == self.warehouse) & (parent.voucher_type == "Stock Reconciliation"))
-			)
-		elif self.has_serial_no:
-			future_entries = future_entries.where(
-				(parent.warehouse == self.warehouse) & (parent.voucher_type == "Stock Reconciliation")
-			)
-		elif batches:
-			future_entries = future_entries.where(
-				(child.batch_no.isin(batches)) & (parent.warehouse == self.warehouse)
-			)
+        if serial_nos:
+            future_entries = future_entries.where(
+                (child.serial_no.isin(serial_nos))
+                | (
+                    (parent.warehouse == self.warehouse)
+                    & (parent.voucher_type == "Stock Reconciliation")
+                )
+            )
+        elif self.has_serial_no:
+            future_entries = future_entries.where(
+                (parent.warehouse == self.warehouse)
+                & (parent.voucher_type == "Stock Reconciliation")
+            )
+        elif batches:
+            future_entries = future_entries.where(
+                (child.batch_no.isin(batches)) & (parent.warehouse == self.warehouse)
+            )
 
-		future_entries = future_entries.run(as_dict=True)
+        future_entries = future_entries.run(as_dict=True)
 
-		if future_entries:
-			if self.has_serial_no:
-				title = "Serial No Exists In Future Transaction(s)"
-			else:
-				title = "Batches Exists In Future Transaction(s)"
+        if future_entries:
+            if self.has_serial_no:
+                title = "Serial No Exists In Future Transaction(s)"
+            else:
+                title = "Batches Exists In Future Transaction(s)"
 
-			msg = """Since the stock reconciliation exists
+            msg = """Since the stock reconciliation exists
 				for future dates, cancel it first. For Serial/Batch,
 				if you want to make a backdated transaction,
 				avoid using stock reconciliation.
@@ -974,2557 +1119,2781 @@ class SerialandBatchBundle(Document):
 				please refer to the list below.
 			"""
 
-			msg += "<br><br><ul>"
-
-			for d in future_entries:
-				if self.has_serial_no:
-					msg += f"<li>{d.serial_no} in {get_link_to_form(d.voucher_type, d.voucher_no)}</li>"
-				else:
-					msg += f"<li>{d.batch_no} in {get_link_to_form(d.voucher_type, d.voucher_no)}</li>"
-			msg += "</li></ul>"
-
-			frappe.throw(_(msg), title=_(title), exc=SerialNoExistsInFutureTransactionError)
-
-	def get_serial_nos_for_validate(self, is_cancelled=False):
-		serial_nos = [d.serial_no for d in self.entries if d.serial_no]
-		batches = [d.batch_no for d in self.entries if d.batch_no]
-
-		skip_serial_nos, skip_batches = self.get_skip_serial_nos_for_stock_reconciliation(
-			is_cancelled=is_cancelled
-		)
-
-		serial_nos = list(set(sorted(serial_nos)) - set(sorted(skip_serial_nos)))
-		batch_nos = list(set(sorted(batches)) - set(sorted(skip_batches)))
-
-		return serial_nos, batch_nos
-
-	def get_skip_serial_nos_for_stock_reconciliation(self, is_cancelled=False):
-		data = get_stock_reco_details(self.voucher_detail_no)
-
-		if not data:
-			return [], []
-
-		current_serial_nos = set()
-		serial_nos = set()
-		current_batches = set()
-		batches = set()
-
-		if data.current_serial_no:
-			current_serial_nos = set(parse_serial_nos(data.current_serial_no))
-			serial_nos = set(parse_serial_nos(data.serial_no)) if data.serial_no else set([])
-			return list(serial_nos.intersection(current_serial_nos)), []
-
-		elif data.batch_no and data.current_qty == data.qty:
-			return [], [data.batch_no]
-
-		elif data.current_serial_and_batch_bundle:
-			if self.has_serial_no:
-				current_serial_nos = set(get_serial_nos_from_bundle(data.current_serial_and_batch_bundle))
-			else:
-				current_batches = set(get_batches_from_bundle(data.current_serial_and_batch_bundle))
-
-			if is_cancelled:
-				return list(current_serial_nos), list(current_batches)
-
-			if self.has_serial_no:
-				serial_nos = (
-					set(get_serial_nos_from_bundle(data.serial_and_batch_bundle))
-					if data.serial_and_batch_bundle
-					else set([])
-				)
-			elif self.has_batch_no and data.serial_and_batch_bundle:
-				batches = set(get_batches_from_bundle(data.serial_and_batch_bundle))
-
-			return list(serial_nos.intersection(current_serial_nos)), list(
-				batches.intersection(current_batches)
-			)
-
-		return [], []
-
-	def reset_qty(self, row, qty_field=None):
-		qty_field = self.get_qty_field(row, qty_field=qty_field)
-		qty = abs(flt(row.get(qty_field), self.precision("total_qty")))
-
-		idx = None
-		while qty > 0:
-			for d in self.entries:
-				row_qty = abs(flt(d.qty, d.precision("qty")))
-				if row_qty >= qty:
-					d.db_set("qty", qty if self.type_of_transaction == "Inward" else qty * -1)
-					qty = 0
-					idx = d.idx
-					break
-				else:
-					qty = flt(qty - row_qty, d.precision("qty"))
-					idx = d.idx
-
-		if idx and len(self.entries) > idx:
-			remove_rows = []
-			for d in self.entries:
-				if d.idx > idx:
-					remove_rows.append(d)
-
-			for d in remove_rows:
-				self.entries.remove(d)
-
-			self.flags.ignore_links = True
-			self.save()
-
-	def validate_quantity(self, row, qty_field=None):
-		qty_field = self.get_qty_field(row, qty_field=qty_field)
-		qty = row.get(qty_field)
-		if qty_field == "qty" and row.get("stock_qty"):
-			qty = row.get("stock_qty")
-
-		precision = row.precision(qty_field)
-		if abs(abs(flt(self.total_qty, precision)) - abs(flt(qty, precision))) > 0.01:
-			total_qty = frappe.format_value(abs(flt(self.total_qty)), "Float", row)
-			set_qty = frappe.format_value(abs(flt(row.get(qty_field))), "Float", row)
-			self.throw_error_message(
-				f"Total quantity {total_qty} in the Serial and Batch Bundle {bold(self.name)} does not match with the quantity {set_qty} for the Item {bold(self.item_code)} in the {self.voucher_type} # {self.voucher_no}"
-			)
-
-	def get_qty_field(self, row, qty_field=None) -> str:
-		if not qty_field:
-			qty_field = "qty"
-
-		if row.get("doctype") == "Subcontracting Receipt Supplied Item":
-			qty_field = "consumed_qty"
-		elif row.get("doctype") == "Stock Entry Detail":
-			qty_field = "transfer_qty"
-		elif row.get("doctype") in ["Sales Invoice Item", "Purchase Invoice Item"]:
-			qty_field = "stock_qty"
-
-		return qty_field
-
-	def set_is_outward(self):
-		for row in self.entries:
-			if self.type_of_transaction == "Outward" and row.qty > 0:
-				row.qty *= -1
-			elif self.type_of_transaction == "Inward" and row.qty < 0:
-				row.qty *= -1
-
-			row.is_outward = 1 if self.type_of_transaction == "Outward" else 0
-
-	@frappe.whitelist()
-	def set_warehouse(self):
-		for row in self.entries:
-			if row.warehouse != self.warehouse:
-				row.warehouse = self.warehouse
-
-	def calculate_qty_and_amount(self, save=False):
-		self.total_amount = 0.0
-		self.total_qty = 0.0
-		self.avg_rate = 0.0
-
-		for row in self.entries:
-			rate = flt(row.incoming_rate)
-			row.stock_value_difference = flt(row.qty) * rate
-			self.total_amount += flt(row.qty) * rate
-			self.total_qty += flt(row.qty)
-
-		if self.total_qty:
-			self.avg_rate = flt(self.total_amount) / flt(self.total_qty)
-
-		if save:
-			self.db_set(
-				{
-					"total_qty": self.total_qty,
-					"avg_rate": self.avg_rate,
-					"total_amount": self.total_amount,
-				}
-			)
-
-	def calculate_outgoing_rate(self):
-		if not (self.has_serial_no and self.entries):
-			return
-
-		if not (self.voucher_type and self.voucher_no):
-			return False
-
-		if self.voucher_type in ["Purchase Receipt", "Purchase Invoice"]:
-			return frappe.get_cached_value(self.voucher_type, self.voucher_no, "is_return")
-		elif self.voucher_type in ["Sales Invoice", "Delivery Note"]:
-			return not frappe.get_cached_value(self.voucher_type, self.voucher_no, "is_return")
-		elif self.voucher_type == "Stock Entry":
-			return frappe.get_cached_value(self.voucher_type, self.voucher_no, "purpose") in [
-				"Material Receipt"
-			]
-
-	def validate_serial_and_batch_no(self):
-		if self.item_code and not self.has_serial_no and not self.has_batch_no:
-			msg = f"The Item {self.item_code} does not have Serial No or Batch No"
-			frappe.throw(_(msg))
-
-		serial_nos = []
-		batch_nos = []
-
-		serial_batches = {}
-		for row in self.entries:
-			if not row.qty and row.batch_no and not row.serial_no:
-				if self.voucher_type == "Stock Reconciliation" and self.type_of_transaction == "Inward":
-					continue
-
-				frappe.throw(
-					_("At row {0}: Qty is mandatory for the batch {1}").format(
-						bold(row.idx), bold(row.batch_no)
-					)
-				)
-
-			if self.has_serial_no and not row.serial_no:
-				frappe.throw(
-					_("At row {0}: Serial No is mandatory for Item {1}").format(
-						bold(row.idx), bold(self.item_code)
-					),
-					title=_("Serial No is mandatory"),
-				)
-
-			if self.has_batch_no and not row.batch_no:
-				frappe.throw(
-					_("At row {0}: Batch No is mandatory for Item {1}").format(
-						bold(row.idx), bold(self.item_code)
-					),
-					title=_("Batch No is mandatory"),
-				)
-
-			if row.serial_no:
-				serial_nos.append(row.serial_no)
-
-			if row.batch_no and not row.serial_no:
-				batch_nos.append(row.batch_no)
-
-			if row.serial_no and row.batch_no and self.type_of_transaction == "Outward":
-				serial_batches.setdefault(row.serial_no, row.batch_no)
-
-		if serial_nos:
-			self.validate_incorrect_serial_nos(serial_nos)
-
-		elif batch_nos:
-			self.validate_incorrect_batch_nos(batch_nos)
-
-		if serial_batches:
-			self.validate_serial_batch_no(serial_batches)
-
-	def validate_serial_batch_no(self, serial_batches):
-		correct_batches = frappe._dict(
-			frappe.get_all(
-				"Serial No",
-				filters={"name": ("in", list(serial_batches.keys()))},
-				fields=["name", "batch_no"],
-				as_list=True,
-			)
-		)
-
-		for serial_no, batch_no in serial_batches.items():
-			if correct_batches.get(serial_no) and correct_batches.get(serial_no) != batch_no:
-				self.throw_error_message(
-					f"Serial No {bold(serial_no)} does not belong to Batch No {bold(batch_no)}"
-				)
-
-	def validate_incorrect_serial_nos(self, serial_nos):
-		incorrect_serial_nos = frappe.get_all(
-			"Serial No",
-			filters={"name": ("in", serial_nos), "item_code": ("!=", self.item_code)},
-			fields=["name"],
-		)
-
-		if incorrect_serial_nos:
-			incorrect_serial_nos = ", ".join([d.name for d in incorrect_serial_nos])
-			self.throw_error_message(
-				f"Serial Nos {bold(incorrect_serial_nos)} does not belong to Item {bold(self.item_code)}"
-			)
-
-	def validate_incorrect_batch_nos(self, batch_nos):
-		incorrect_batch_nos = frappe.get_all(
-			"Batch", filters={"name": ("in", batch_nos), "item": ("!=", self.item_code)}, fields=["name"]
-		)
-
-		if incorrect_batch_nos:
-			incorrect_batch_nos = ", ".join([d.name for d in incorrect_batch_nos])
-			self.throw_error_message(
-				f"Batch Nos {bold(incorrect_batch_nos)} does not belong to Item {bold(self.item_code)}"
-			)
-
-	def validate_serial_and_batch_no_for_returned(self):
-		if not self.returned_against:
-			return
-
-		if self.voucher_type not in [
-			"Purchase Receipt",
-			"Purchase Invoice",
-			"Sales Invoice",
-			"Delivery Note",
-		]:
-			return
-
-		data = self.get_orignal_document_data()
-		if not data:
-			return
-
-		serial_nos, batches = [], []
-		current_serial_nos = [d.serial_no for d in self.entries if d.serial_no]
-		current_batches = [d.batch_no for d in self.entries if d.batch_no]
-
-		for d in data:
-			if self.has_serial_no:
-				if d.serial_and_batch_bundle:
-					serial_nos = get_serial_nos_from_bundle(d.serial_and_batch_bundle)
-				else:
-					serial_nos = parse_serial_nos(d.serial_no)
-
-			elif self.has_batch_no:
-				if d.serial_and_batch_bundle:
-					batches = get_batches_from_bundle(d.serial_and_batch_bundle)
-				else:
-					batches = frappe._dict({d.batch_no: d.stock_qty})
-
-				if batches:
-					batches = [d for d in batches if batches[d] > 0]
-
-			if serial_nos:
-				if not set(current_serial_nos).issubset(set(serial_nos)):
-					self.throw_error_message(
-						f"Serial Nos {bold(', '.join(serial_nos))} are not part of the original document."
-					)
-
-			if batches:
-				if not set(current_batches).issubset(set(batches)):
-					self.throw_error_message(
-						f"Batch Nos {bold(', '.join(batches))} are not part of the original document."
-					)
-
-	def get_orignal_document_data(self):
-		fields = ["serial_and_batch_bundle", "stock_qty"]
-		if self.has_serial_no:
-			fields.append("serial_no")
-
-		elif self.has_batch_no:
-			fields.append("batch_no")
-
-		child_doc = self.voucher_type + " Item"
-		return frappe.get_all(child_doc, fields=fields, filters={"name": self.returned_against})
-
-	def validate_duplicate_serial_and_batch_no(self):
-		serial_nos = []
-		batch_nos = []
-
-		for row in self.entries:
-			if row.serial_no:
-				serial_nos.append(row.serial_no)
-
-			if row.batch_no and not row.serial_no:
-				batch_nos.append(row.batch_no)
-
-		if serial_nos:
-			for key, value in collections.Counter(serial_nos).items():
-				if value > 1:
-					self.throw_error_message(f"Duplicate Serial No {key} found")
-
-		if batch_nos:
-			for key, value in collections.Counter(batch_nos).items():
-				if value > 1:
-					self.throw_error_message(f"Duplicate Batch No {key} found")
-
-	def before_cancel(self):
-		self.delink_serial_and_batch_bundle()
-
-	def delink_serial_and_batch_bundle(self):
-		sles = frappe.get_all("Stock Ledger Entry", filters={"serial_and_batch_bundle": self.name})
-
-		for sle in sles:
-			frappe.db.set_value("Stock Ledger Entry", sle.name, "serial_and_batch_bundle", None)
-
-	@property
-	def child_table(self):
-		if self.voucher_type == "Job Card":
-			return
-
-		parent_child_map = {
-			"Asset Capitalization": "Asset Capitalization Stock Item",
-			"Asset Repair": "Asset Repair Consumed Item",
-			"Quotation": "Packed Item",
-			"Stock Entry": "Stock Entry Detail",
-		}
-
-		return (
-			parent_child_map[self.voucher_type]
-			if self.voucher_type in parent_child_map
-			else f"{self.voucher_type} Item"
-		)
-
-	def delink_refernce_from_voucher(self):
-		or_filters = {"serial_and_batch_bundle": self.name}
-
-		fields = ["name", "serial_and_batch_bundle"]
-		if self.voucher_type == "Stock Reconciliation":
-			fields = ["name", "current_serial_and_batch_bundle", "serial_and_batch_bundle"]
-			or_filters["current_serial_and_batch_bundle"] = self.name
-
-		elif self.voucher_type == "Purchase Receipt":
-			fields = ["name", "rejected_serial_and_batch_bundle", "serial_and_batch_bundle"]
-			or_filters["rejected_serial_and_batch_bundle"] = self.name
-
-		if (
-			self.voucher_type == "Subcontracting Receipt"
-			and self.voucher_detail_no
-			and not frappe.db.exists("Subcontracting Receipt Item", self.voucher_detail_no)
-		):
-			self.voucher_type = "Subcontracting Receipt Supplied"
-
-		vouchers = frappe.get_all(
-			self.child_table,
-			fields=fields,
-			filters={"docstatus": 0},
-			or_filters=or_filters,
-		)
-
-		if not vouchers and self.voucher_type == "Delivery Note":
-			if frappe.db.exists("Packed Item", self.voucher_detail_no):
-				frappe.db.set_value("Packed Item", self.voucher_detail_no, "serial_and_batch_bundle", None)
-			else:
-				packed_items = frappe.get_all(
-					"Packed Item",
-					filters={
-						"parent_detail_docname": self.voucher_detail_no,
-						"serial_and_batch_bundle": self.name,
-					},
-					pluck="name",
-				)
-
-				for packed_item in packed_items:
-					frappe.db.set_value("Packed Item", packed_item, "serial_and_batch_bundle", None)
-
-			return
-
-		for voucher in vouchers:
-			if voucher.get("current_serial_and_batch_bundle"):
-				frappe.db.set_value(self.child_table, voucher.name, "current_serial_and_batch_bundle", None)
-			elif voucher.get("rejected_serial_and_batch_bundle"):
-				frappe.db.set_value(self.child_table, voucher.name, "rejected_serial_and_batch_bundle", None)
-
-			frappe.db.set_value(self.child_table, voucher.name, "serial_and_batch_bundle", None)
-
-	def delink_reference_from_batch(self):
-		batches = frappe.get_all(
-			"Batch",
-			fields=["name"],
-			filters={"reference_name": self.name, "reference_doctype": "Serial and Batch Bundle"},
-		)
-
-		for batch in batches:
-			frappe.db.set_value("Batch", batch.name, {"reference_name": None, "reference_doctype": None})
-
-	def validate_serial_and_batch_data(self):
-		if not self.voucher_no:
-			frappe.throw(_("Voucher No is mandatory"))
-
-	def before_submit(self):
-		self.validate_serial_and_batch_data()
-		self.validate_serial_and_batch_no_for_returned()
-		self.set_child_details()
-		self.set_source_document_no()
-
-	def on_submit(self):
-		self.validate_docstatus()
-		self.validate_serial_nos_inventory()
-		self.validate_batch_quantity()
-
-	def validate_docstatus(self):
-		for row in self.entries:
-			if row.docstatus != 1:
-				frappe.throw(
-					_("At Row {0}: In Serial and Batch Bundle {1} must have docstatus as 1 and not 0").format(
-						bold(row.idx), bold(self.name)
-					)
-				)
-
-	def set_child_details(self):
-		for row in self.entries:
-			for field in [
-				"warehouse",
-				"posting_datetime",
-				"voucher_type",
-				"voucher_no",
-				"voucher_detail_no",
-				"type_of_transaction",
-				"item_code",
-			]:
-				if not row.get(field) or row.get(field) != self.get(field):
-					row.set(field, self.get(field))
-
-	def set_source_document_no(self):
-		if self.flags.ignore_validate_serial_batch:
-			return
-
-		if not self.has_serial_no and not self.has_batch_no:
-			return
-
-		if self.total_qty <= 0:
-			return
-
-		if self.has_serial_no:
-			serial_nos = [d.serial_no for d in self.entries if d.serial_no]
-			sn_table = frappe.qb.DocType("Serial No")
-			(
-				frappe.qb.update(sn_table)
-				.set(sn_table.reference_doctype, self.voucher_type)
-				.set(sn_table.reference_name, self.voucher_no)
-				.set(sn_table.posting_date, getdate(self.posting_datetime))
-				.where((sn_table.name.isin(serial_nos)) & (sn_table.reference_name.isnull()))
-			).run()
-
-		if self.has_batch_no:
-			batch_nos = [d.batch_no for d in self.entries if d.batch_no]
-			batch_table = frappe.qb.DocType("Batch")
-			(
-				frappe.qb.update(batch_table)
-				.set(batch_table.reference_doctype, self.voucher_type)
-				.set(batch_table.reference_name, self.voucher_no)
-				.where((batch_table.name.isin(batch_nos)) & (batch_table.reference_name.isnull()))
-			).run()
-
-	def validate_serial_and_batch_inventory(self):
-		self.check_future_entries_exists(is_cancelled=True)
-		self.validate_batch_inventory()
-
-	def validate_batch_inventory(self):
-		if not self.has_batch_no:
-			return
-
-		batches = [d.batch_no for d in self.entries if d.batch_no]
-		if not batches:
-			return
-
-		available_batches = get_auto_batch_nos(
-			frappe._dict(
-				{
-					"item_code": self.item_code,
-					"warehouse": self.warehouse,
-					"batch_no": batches,
-					"consider_negative_batches": True,
-				}
-			)
-		)
-
-		if not available_batches:
-			return
-
-		available_batches = get_available_batches_qty(available_batches)
-		for batch_no in batches:
-			if batch_no in available_batches and available_batches[batch_no] < 0:
-				if flt(available_batches.get(batch_no)) < 0:
-					self.validate_negative_batch(batch_no, available_batches[batch_no])
-
-				self.throw_error_message(
-					f"Batch {bold(batch_no)} is not available in the selected warehouse {self.warehouse}"
-				)
-
-	def on_cancel(self):
-		self.validate_voucher_no_docstatus()
-		self.validate_batch_quantity()
-		self.remove_source_document_no()
-
-	def validate_batch_quantity(self):
-		if not self.has_batch_no:
-			return
-
-		if self.type_of_transaction != "Outward" or (
-			self.voucher_type == "Stock Reconciliation" and self.type_of_transaction == "Outward"
-		):
-			return
-
-		batch_wise_available_qty = self.get_batchwise_available_qty()
-		precision = frappe.get_precision("Serial and Batch Entry", "qty")
-
-		for d in self.entries:
-			available_qty = batch_wise_available_qty.get(d.batch_no, 0)
-			if flt(available_qty, precision) < 0:
-				self.throw_negative_batch(d.batch_no, available_qty, precision)
-
-	def remove_source_document_no(self):
-		if not self.has_serial_no and not self.has_batch_no:
-			return
-
-		if self.total_qty <= 0:
-			return
-
-		if self.has_serial_no:
-			serial_nos = [d.serial_no for d in self.entries if d.serial_no]
-			sn_table = frappe.qb.DocType("Serial No")
-			(
-				frappe.qb.update(sn_table)
-				.set(sn_table.reference_doctype, None)
-				.set(sn_table.reference_name, None)
-				.set(sn_table.posting_date, None)
-				.where(
-					(sn_table.name.isin(serial_nos))
-					& (sn_table.reference_doctype == self.voucher_type)
-					& (sn_table.reference_name == self.voucher_no)
-					& (sn_table.posting_date == getdate(self.posting_datetime))
-				)
-			).run()
-
-		if self.has_batch_no:
-			batch_nos = [d.batch_no for d in self.entries if d.batch_no]
-			batch_table = frappe.qb.DocType("Batch")
-			(
-				frappe.qb.update(batch_table)
-				.set(batch_table.reference_doctype, None)
-				.set(batch_table.reference_name, None)
-				.where(
-					(batch_table.name.isin(batch_nos))
-					& (batch_table.reference_doctype == self.voucher_type)
-					& (batch_table.reference_name == self.voucher_no)
-				)
-			).run()
-
-	def throw_negative_batch(self, batch_no, available_qty, precision, posting_datetime=None):
-		from erpnext.stock.stock_ledger import NegativeStockError
-
-		if frappe.db.get_single_value("Stock Settings", "allow_negative_stock_for_batch"):
-			return
-
-		date_msg = ""
-		if posting_datetime:
-			date_msg = " " + _("as of {0}").format(format_datetime(posting_datetime))
-
-		msg = _(
-			"""
+            msg += "<br><br><ul>"
+
+            for d in future_entries:
+                if self.has_serial_no:
+                    msg += f"<li>{d.serial_no} in {get_link_to_form(d.voucher_type, d.voucher_no)}</li>"
+                else:
+                    msg += f"<li>{d.batch_no} in {get_link_to_form(d.voucher_type, d.voucher_no)}</li>"
+            msg += "</li></ul>"
+
+            frappe.throw(
+                _(msg), title=_(title), exc=SerialNoExistsInFutureTransactionError
+            )
+
+    def get_serial_nos_for_validate(self, is_cancelled=False):
+        serial_nos = [d.serial_no for d in self.entries if d.serial_no]
+        batches = [d.batch_no for d in self.entries if d.batch_no]
+
+        skip_serial_nos, skip_batches = (
+            self.get_skip_serial_nos_for_stock_reconciliation(is_cancelled=is_cancelled)
+        )
+
+        serial_nos = list(set(sorted(serial_nos)) - set(sorted(skip_serial_nos)))
+        batch_nos = list(set(sorted(batches)) - set(sorted(skip_batches)))
+
+        return serial_nos, batch_nos
+
+    def get_skip_serial_nos_for_stock_reconciliation(self, is_cancelled=False):
+        data = get_stock_reco_details(self.voucher_detail_no)
+
+        if not data:
+            return [], []
+
+        current_serial_nos = set()
+        serial_nos = set()
+        current_batches = set()
+        batches = set()
+
+        if data.current_serial_no:
+            current_serial_nos = set(parse_serial_nos(data.current_serial_no))
+            serial_nos = (
+                set(parse_serial_nos(data.serial_no)) if data.serial_no else set([])
+            )
+            return list(serial_nos.intersection(current_serial_nos)), []
+
+        elif data.batch_no and data.current_qty == data.qty:
+            return [], [data.batch_no]
+
+        elif data.current_serial_and_batch_bundle:
+            if self.has_serial_no:
+                current_serial_nos = set(
+                    get_serial_nos_from_bundle(data.current_serial_and_batch_bundle)
+                )
+            else:
+                current_batches = set(
+                    get_batches_from_bundle(data.current_serial_and_batch_bundle)
+                )
+
+            if is_cancelled:
+                return list(current_serial_nos), list(current_batches)
+
+            if self.has_serial_no:
+                serial_nos = (
+                    set(get_serial_nos_from_bundle(data.serial_and_batch_bundle))
+                    if data.serial_and_batch_bundle
+                    else set([])
+                )
+            elif self.has_batch_no and data.serial_and_batch_bundle:
+                batches = set(get_batches_from_bundle(data.serial_and_batch_bundle))
+
+            return list(serial_nos.intersection(current_serial_nos)), list(
+                batches.intersection(current_batches)
+            )
+
+        return [], []
+
+    def reset_qty(self, row, qty_field=None):
+        qty_field = self.get_qty_field(row, qty_field=qty_field)
+        qty = abs(flt(row.get(qty_field), self.precision("total_qty")))
+
+        idx = None
+        while qty > 0:
+            for d in self.entries:
+                row_qty = abs(flt(d.qty, d.precision("qty")))
+                if row_qty >= qty:
+                    d.db_set(
+                        "qty", qty if self.type_of_transaction == "Inward" else qty * -1
+                    )
+                    qty = 0
+                    idx = d.idx
+                    break
+                else:
+                    qty = flt(qty - row_qty, d.precision("qty"))
+                    idx = d.idx
+
+        if idx and len(self.entries) > idx:
+            remove_rows = []
+            for d in self.entries:
+                if d.idx > idx:
+                    remove_rows.append(d)
+
+            for d in remove_rows:
+                self.entries.remove(d)
+
+            self.flags.ignore_links = True
+            self.save()
+
+    def validate_quantity(self, row, qty_field=None):
+        qty_field = self.get_qty_field(row, qty_field=qty_field)
+        qty = row.get(qty_field)
+        if qty_field == "qty" and row.get("stock_qty"):
+            qty = row.get("stock_qty")
+
+        precision = row.precision(qty_field)
+        if abs(abs(flt(self.total_qty, precision)) - abs(flt(qty, precision))) > 0.01:
+            total_qty = frappe.format_value(abs(flt(self.total_qty)), "Float", row)
+            set_qty = frappe.format_value(abs(flt(row.get(qty_field))), "Float", row)
+            self.throw_error_message(
+                f"Total quantity {total_qty} in the Serial and Batch Bundle {bold(self.name)} does not match with the quantity {set_qty} for the Item {bold(self.item_code)} in the {self.voucher_type} # {self.voucher_no}"
+            )
+
+    def get_qty_field(self, row, qty_field=None) -> str:
+        if not qty_field:
+            qty_field = "qty"
+
+        if row.get("doctype") == "Subcontracting Receipt Supplied Item":
+            qty_field = "consumed_qty"
+        elif row.get("doctype") == "Stock Entry Detail":
+            qty_field = "transfer_qty"
+        elif row.get("doctype") in ["Sales Invoice Item", "Purchase Invoice Item"]:
+            qty_field = "stock_qty"
+
+        return qty_field
+
+    def set_is_outward(self):
+        for row in self.entries:
+            if self.type_of_transaction == "Outward" and row.qty > 0:
+                row.qty *= -1
+            elif self.type_of_transaction == "Inward" and row.qty < 0:
+                row.qty *= -1
+
+            row.is_outward = 1 if self.type_of_transaction == "Outward" else 0
+
+    @frappe.whitelist()
+    def set_warehouse(self):
+        for row in self.entries:
+            if row.warehouse != self.warehouse:
+                row.warehouse = self.warehouse
+
+    def calculate_qty_and_amount(self, save=False):
+        self.total_amount = 0.0
+        self.total_qty = 0.0
+        self.avg_rate = 0.0
+
+        for row in self.entries:
+            rate = flt(row.incoming_rate)
+            row.stock_value_difference = flt(row.qty) * rate
+            self.total_amount += flt(row.qty) * rate
+            self.total_qty += flt(row.qty)
+
+        if self.total_qty:
+            self.avg_rate = flt(self.total_amount) / flt(self.total_qty)
+
+        if save:
+            self.db_set(
+                {
+                    "total_qty": self.total_qty,
+                    "avg_rate": self.avg_rate,
+                    "total_amount": self.total_amount,
+                }
+            )
+
+    def calculate_outgoing_rate(self):
+        if not (self.has_serial_no and self.entries):
+            return
+
+        if not (self.voucher_type and self.voucher_no):
+            return False
+
+        if self.voucher_type in ["Purchase Receipt", "Purchase Invoice"]:
+            return frappe.get_cached_value(
+                self.voucher_type, self.voucher_no, "is_return"
+            )
+        elif self.voucher_type in ["Sales Invoice", "Delivery Note"]:
+            return not frappe.get_cached_value(
+                self.voucher_type, self.voucher_no, "is_return"
+            )
+        elif self.voucher_type == "Stock Entry":
+            return frappe.get_cached_value(
+                self.voucher_type, self.voucher_no, "purpose"
+            ) in ["Material Receipt"]
+
+    def validate_serial_and_batch_no(self):
+        if self.item_code and not self.has_serial_no and not self.has_batch_no:
+            msg = f"The Item {self.item_code} does not have Serial No or Batch No"
+            frappe.throw(_(msg))
+
+        serial_nos = []
+        batch_nos = []
+
+        serial_batches = {}
+        for row in self.entries:
+            if not row.qty and row.batch_no and not row.serial_no:
+                if (
+                    self.voucher_type == "Stock Reconciliation"
+                    and self.type_of_transaction == "Inward"
+                ):
+                    continue
+
+                frappe.throw(
+                    _("At row {0}: Qty is mandatory for the batch {1}").format(
+                        bold(row.idx), bold(row.batch_no)
+                    )
+                )
+
+            if self.has_serial_no and not row.serial_no:
+                frappe.throw(
+                    _("At row {0}: Serial No is mandatory for Item {1}").format(
+                        bold(row.idx), bold(self.item_code)
+                    ),
+                    title=_("Serial No is mandatory"),
+                )
+
+            if self.has_batch_no and not row.batch_no:
+                frappe.throw(
+                    _("At row {0}: Batch No is mandatory for Item {1}").format(
+                        bold(row.idx), bold(self.item_code)
+                    ),
+                    title=_("Batch No is mandatory"),
+                )
+
+            if row.serial_no:
+                serial_nos.append(row.serial_no)
+
+            if row.batch_no and not row.serial_no:
+                batch_nos.append(row.batch_no)
+
+            if row.serial_no and row.batch_no and self.type_of_transaction == "Outward":
+                serial_batches.setdefault(row.serial_no, row.batch_no)
+
+        if serial_nos:
+            self.validate_incorrect_serial_nos(serial_nos)
+
+        elif batch_nos:
+            self.validate_incorrect_batch_nos(batch_nos)
+
+        if serial_batches:
+            self.validate_serial_batch_no(serial_batches)
+
+    def validate_serial_batch_no(self, serial_batches):
+        correct_batches = frappe._dict(
+            frappe.get_all(
+                "Serial No",
+                filters={"name": ("in", list(serial_batches.keys()))},
+                fields=["name", "batch_no"],
+                as_list=True,
+            )
+        )
+
+        for serial_no, batch_no in serial_batches.items():
+            if (
+                correct_batches.get(serial_no)
+                and correct_batches.get(serial_no) != batch_no
+            ):
+                self.throw_error_message(
+                    f"Serial No {bold(serial_no)} does not belong to Batch No {bold(batch_no)}"
+                )
+
+    def validate_incorrect_serial_nos(self, serial_nos):
+        incorrect_serial_nos = frappe.get_all(
+            "Serial No",
+            filters={"name": ("in", serial_nos), "item_code": ("!=", self.item_code)},
+            fields=["name"],
+        )
+
+        if incorrect_serial_nos:
+            incorrect_serial_nos = ", ".join([d.name for d in incorrect_serial_nos])
+            self.throw_error_message(
+                f"Serial Nos {bold(incorrect_serial_nos)} does not belong to Item {bold(self.item_code)}"
+            )
+
+    def validate_incorrect_batch_nos(self, batch_nos):
+        incorrect_batch_nos = frappe.get_all(
+            "Batch",
+            filters={"name": ("in", batch_nos), "item": ("!=", self.item_code)},
+            fields=["name"],
+        )
+
+        if incorrect_batch_nos:
+            incorrect_batch_nos = ", ".join([d.name for d in incorrect_batch_nos])
+            self.throw_error_message(
+                f"Batch Nos {bold(incorrect_batch_nos)} does not belong to Item {bold(self.item_code)}"
+            )
+
+    def validate_serial_and_batch_no_for_returned(self):
+        if not self.returned_against:
+            return
+
+        if self.voucher_type not in [
+            "Purchase Receipt",
+            "Purchase Invoice",
+            "Sales Invoice",
+            "Delivery Note",
+        ]:
+            return
+
+        data = self.get_orignal_document_data()
+        if not data:
+            return
+
+        serial_nos, batches = [], []
+        current_serial_nos = [d.serial_no for d in self.entries if d.serial_no]
+        current_batches = [d.batch_no for d in self.entries if d.batch_no]
+
+        for d in data:
+            if self.has_serial_no:
+                if d.serial_and_batch_bundle:
+                    serial_nos = get_serial_nos_from_bundle(d.serial_and_batch_bundle)
+                else:
+                    serial_nos = parse_serial_nos(d.serial_no)
+
+            elif self.has_batch_no:
+                if d.serial_and_batch_bundle:
+                    batches = get_batches_from_bundle(d.serial_and_batch_bundle)
+                else:
+                    batches = frappe._dict({d.batch_no: d.stock_qty})
+
+                if batches:
+                    batches = [d for d in batches if batches[d] > 0]
+
+            if serial_nos:
+                if not set(current_serial_nos).issubset(set(serial_nos)):
+                    self.throw_error_message(
+                        f"Serial Nos {bold(', '.join(serial_nos))} are not part of the original document."
+                    )
+
+            if batches:
+                if not set(current_batches).issubset(set(batches)):
+                    self.throw_error_message(
+                        f"Batch Nos {bold(', '.join(batches))} are not part of the original document."
+                    )
+
+    def get_orignal_document_data(self):
+        fields = ["serial_and_batch_bundle", "stock_qty"]
+        if self.has_serial_no:
+            fields.append("serial_no")
+
+        elif self.has_batch_no:
+            fields.append("batch_no")
+
+        child_doc = self.voucher_type + " Item"
+        return frappe.get_all(
+            child_doc, fields=fields, filters={"name": self.returned_against}
+        )
+
+    def validate_duplicate_serial_and_batch_no(self):
+        serial_nos = []
+        batch_nos = []
+
+        for row in self.entries:
+            if row.serial_no:
+                serial_nos.append(row.serial_no)
+
+            if row.batch_no and not row.serial_no:
+                batch_nos.append(row.batch_no)
+
+        if serial_nos:
+            for key, value in collections.Counter(serial_nos).items():
+                if value > 1:
+                    self.throw_error_message(f"Duplicate Serial No {key} found")
+
+        if batch_nos:
+            for key, value in collections.Counter(batch_nos).items():
+                if value > 1:
+                    self.throw_error_message(f"Duplicate Batch No {key} found")
+
+    def before_cancel(self):
+        self.delink_serial_and_batch_bundle()
+
+    def delink_serial_and_batch_bundle(self):
+        sles = frappe.get_all(
+            "Stock Ledger Entry", filters={"serial_and_batch_bundle": self.name}
+        )
+
+        for sle in sles:
+            frappe.db.set_value(
+                "Stock Ledger Entry", sle.name, "serial_and_batch_bundle", None
+            )
+
+    @property
+    def child_table(self):
+        if self.voucher_type == "Job Card":
+            return
+
+        parent_child_map = {
+            "Asset Capitalization": "Asset Capitalization Stock Item",
+            "Asset Repair": "Asset Repair Consumed Item",
+            "Quotation": "Packed Item",
+            "Stock Entry": "Stock Entry Detail",
+        }
+
+        return (
+            parent_child_map[self.voucher_type]
+            if self.voucher_type in parent_child_map
+            else f"{self.voucher_type} Item"
+        )
+
+    def delink_refernce_from_voucher(self):
+        or_filters = {"serial_and_batch_bundle": self.name}
+
+        fields = ["name", "serial_and_batch_bundle"]
+        if self.voucher_type == "Stock Reconciliation":
+            fields = [
+                "name",
+                "current_serial_and_batch_bundle",
+                "serial_and_batch_bundle",
+            ]
+            or_filters["current_serial_and_batch_bundle"] = self.name
+
+        elif self.voucher_type == "Purchase Receipt":
+            fields = [
+                "name",
+                "rejected_serial_and_batch_bundle",
+                "serial_and_batch_bundle",
+            ]
+            or_filters["rejected_serial_and_batch_bundle"] = self.name
+
+        if (
+            self.voucher_type == "Subcontracting Receipt"
+            and self.voucher_detail_no
+            and not frappe.db.exists(
+                "Subcontracting Receipt Item", self.voucher_detail_no
+            )
+        ):
+            self.voucher_type = "Subcontracting Receipt Supplied"
+
+        vouchers = frappe.get_all(
+            self.child_table,
+            fields=fields,
+            filters={"docstatus": 0},
+            or_filters=or_filters,
+        )
+
+        if not vouchers and self.voucher_type == "Delivery Note":
+            if frappe.db.exists("Packed Item", self.voucher_detail_no):
+                frappe.db.set_value(
+                    "Packed Item",
+                    self.voucher_detail_no,
+                    "serial_and_batch_bundle",
+                    None,
+                )
+            else:
+                packed_items = frappe.get_all(
+                    "Packed Item",
+                    filters={
+                        "parent_detail_docname": self.voucher_detail_no,
+                        "serial_and_batch_bundle": self.name,
+                    },
+                    pluck="name",
+                )
+
+                for packed_item in packed_items:
+                    frappe.db.set_value(
+                        "Packed Item", packed_item, "serial_and_batch_bundle", None
+                    )
+
+            return
+
+        for voucher in vouchers:
+            if voucher.get("current_serial_and_batch_bundle"):
+                frappe.db.set_value(
+                    self.child_table,
+                    voucher.name,
+                    "current_serial_and_batch_bundle",
+                    None,
+                )
+            elif voucher.get("rejected_serial_and_batch_bundle"):
+                frappe.db.set_value(
+                    self.child_table,
+                    voucher.name,
+                    "rejected_serial_and_batch_bundle",
+                    None,
+                )
+
+            frappe.db.set_value(
+                self.child_table, voucher.name, "serial_and_batch_bundle", None
+            )
+
+    def delink_reference_from_batch(self):
+        batches = frappe.get_all(
+            "Batch",
+            fields=["name"],
+            filters={
+                "reference_name": self.name,
+                "reference_doctype": "Serial and Batch Bundle",
+            },
+        )
+
+        for batch in batches:
+            frappe.db.set_value(
+                "Batch", batch.name, {"reference_name": None, "reference_doctype": None}
+            )
+
+    def validate_serial_and_batch_data(self):
+        if not self.voucher_no:
+            frappe.throw(_("Voucher No is mandatory"))
+
+    def before_submit(self):
+        self.validate_serial_and_batch_data()
+        self.validate_serial_and_batch_no_for_returned()
+        self.set_child_details()
+        self.set_source_document_no()
+
+    def on_submit(self):
+        self.validate_docstatus()
+        self.validate_serial_nos_inventory()
+        self.validate_batch_quantity()
+
+    def validate_docstatus(self):
+        for row in self.entries:
+            if row.docstatus != 1:
+                frappe.throw(
+                    _(
+                        "At Row {0}: In Serial and Batch Bundle {1} must have docstatus as 1 and not 0"
+                    ).format(bold(row.idx), bold(self.name))
+                )
+
+    def set_child_details(self):
+        for row in self.entries:
+            for field in [
+                "warehouse",
+                "posting_datetime",
+                "voucher_type",
+                "voucher_no",
+                "voucher_detail_no",
+                "type_of_transaction",
+                "item_code",
+            ]:
+                if not row.get(field) or row.get(field) != self.get(field):
+                    row.set(field, self.get(field))
+
+    def set_source_document_no(self):
+        if self.flags.ignore_validate_serial_batch:
+            return
+
+        if not self.has_serial_no and not self.has_batch_no:
+            return
+
+        if self.total_qty <= 0:
+            return
+
+        if self.has_serial_no:
+            serial_nos = [d.serial_no for d in self.entries if d.serial_no]
+            sn_table = frappe.qb.DocType("Serial No")
+            (
+                frappe.qb.update(sn_table)
+                .set(sn_table.reference_doctype, self.voucher_type)
+                .set(sn_table.reference_name, self.voucher_no)
+                .set(sn_table.posting_date, getdate(self.posting_datetime))
+                .where(
+                    (sn_table.name.isin(serial_nos))
+                    & (sn_table.reference_name.isnull())
+                )
+            ).run()
+
+        if self.has_batch_no:
+            batch_nos = [d.batch_no for d in self.entries if d.batch_no]
+            batch_table = frappe.qb.DocType("Batch")
+            (
+                frappe.qb.update(batch_table)
+                .set(batch_table.reference_doctype, self.voucher_type)
+                .set(batch_table.reference_name, self.voucher_no)
+                .where(
+                    (batch_table.name.isin(batch_nos))
+                    & (batch_table.reference_name.isnull())
+                )
+            ).run()
+
+    def validate_serial_and_batch_inventory(self):
+        self.check_future_entries_exists(is_cancelled=True)
+        self.validate_batch_inventory()
+
+    def validate_batch_inventory(self):
+        if not self.has_batch_no:
+            return
+
+        batches = [d.batch_no for d in self.entries if d.batch_no]
+        if not batches:
+            return
+
+        available_batches = get_auto_batch_nos(
+            frappe._dict(
+                {
+                    "item_code": self.item_code,
+                    "warehouse": self.warehouse,
+                    "batch_no": batches,
+                    "consider_negative_batches": True,
+                }
+            )
+        )
+
+        if not available_batches:
+            return
+
+        available_batches = get_available_batches_qty(available_batches)
+        for batch_no in batches:
+            if batch_no in available_batches and available_batches[batch_no] < 0:
+                if flt(available_batches.get(batch_no)) < 0:
+                    self.validate_negative_batch(batch_no, available_batches[batch_no])
+
+                self.throw_error_message(
+                    f"Batch {bold(batch_no)} is not available in the selected warehouse {self.warehouse}"
+                )
+
+    def on_cancel(self):
+        self.validate_voucher_no_docstatus()
+        self.validate_batch_quantity()
+        self.remove_source_document_no()
+
+    def validate_batch_quantity(self):
+        if not self.has_batch_no:
+            return
+
+        if self.type_of_transaction != "Outward" or (
+            self.voucher_type == "Stock Reconciliation"
+            and self.type_of_transaction == "Outward"
+        ):
+            return
+
+        batch_wise_available_qty = self.get_batchwise_available_qty()
+        precision = frappe.get_precision("Serial and Batch Entry", "qty")
+
+        for d in self.entries:
+            available_qty = batch_wise_available_qty.get(d.batch_no, 0)
+            if flt(available_qty, precision) < 0:
+                self.throw_negative_batch(d.batch_no, available_qty, precision)
+
+    def remove_source_document_no(self):
+        if not self.has_serial_no and not self.has_batch_no:
+            return
+
+        if self.total_qty <= 0:
+            return
+
+        if self.has_serial_no:
+            serial_nos = [d.serial_no for d in self.entries if d.serial_no]
+            sn_table = frappe.qb.DocType("Serial No")
+            (
+                frappe.qb.update(sn_table)
+                .set(sn_table.reference_doctype, None)
+                .set(sn_table.reference_name, None)
+                .set(sn_table.posting_date, None)
+                .where(
+                    (sn_table.name.isin(serial_nos))
+                    & (sn_table.reference_doctype == self.voucher_type)
+                    & (sn_table.reference_name == self.voucher_no)
+                    & (sn_table.posting_date == getdate(self.posting_datetime))
+                )
+            ).run()
+
+        if self.has_batch_no:
+            batch_nos = [d.batch_no for d in self.entries if d.batch_no]
+            batch_table = frappe.qb.DocType("Batch")
+            (
+                frappe.qb.update(batch_table)
+                .set(batch_table.reference_doctype, None)
+                .set(batch_table.reference_name, None)
+                .where(
+                    (batch_table.name.isin(batch_nos))
+                    & (batch_table.reference_doctype == self.voucher_type)
+                    & (batch_table.reference_name == self.voucher_no)
+                )
+            ).run()
+
+    def throw_negative_batch(
+        self, batch_no, available_qty, precision, posting_datetime=None
+    ):
+        from erpnext.stock.stock_ledger import NegativeStockError
+
+        if frappe.db.get_single_value(
+            "Stock Settings", "allow_negative_stock_for_batch"
+        ):
+            return
+
+        date_msg = ""
+        if posting_datetime:
+            date_msg = " " + _("as of {0}").format(format_datetime(posting_datetime))
+
+        msg = _(
+            """
 			The Batch {0} of an item {1} has negative stock in the warehouse {2}{3}.
 			Please add a stock quantity of {4} to proceed with this entry.
 			If it is not possible to make an adjustment entry, please enable 'Allow Negative Stock for Batch' in Stock Settings to proceed.
 			However, enabling this setting may lead to negative stock in the system.
 			So please ensure the stock levels are adjusted as soon as possible to maintain the correct valuation rate."""
-		).format(
-			bold(batch_no),
-			bold(self.item_code),
-			bold(self.warehouse),
-			date_msg,
-			bold(abs(flt(available_qty, precision))),
-		)
+        ).format(
+            bold(batch_no),
+            bold(self.item_code),
+            bold(self.warehouse),
+            date_msg,
+            bold(abs(flt(available_qty, precision))),
+        )
 
-		frappe.throw(
-			msg,
-			title=_("Negative Stock Error"),
-			exc=NegativeStockError,
-		)
+        frappe.throw(
+            msg,
+            title=_("Negative Stock Error"),
+            exc=NegativeStockError,
+        )
 
-	def get_batchwise_available_qty(self):
-		batchwise_entries = self.get_available_qty_from_sabb()
-		batchwise_entries.extend(self.get_available_qty_from_stock_ledger())
+    def get_batchwise_available_qty(self):
+        batchwise_entries = self.get_available_qty_from_sabb()
+        batchwise_entries.extend(self.get_available_qty_from_stock_ledger())
 
-		available_qty = frappe._dict({})
-		batchwise_entries = sorted(
-			batchwise_entries,
-			key=lambda x: (get_datetime(x.get("posting_datetime")), get_datetime(x.get("creation"))),
-		)
+        available_qty = frappe._dict({})
+        batchwise_entries = sorted(
+            batchwise_entries,
+            key=lambda x: (
+                get_datetime(x.get("posting_datetime")),
+                get_datetime(x.get("creation")),
+            ),
+        )
 
-		precision = frappe.get_precision("Serial and Batch Entry", "qty")
-		for row in batchwise_entries:
-			if row.batch_no in available_qty:
-				available_qty[row.batch_no] += flt(row.qty)
-			else:
-				available_qty[row.batch_no] = flt(row.qty)
+        precision = frappe.get_precision("Serial and Batch Entry", "qty")
+        for row in batchwise_entries:
+            if row.batch_no in available_qty:
+                available_qty[row.batch_no] += flt(row.qty)
+            else:
+                available_qty[row.batch_no] = flt(row.qty)
 
-			if flt(available_qty[row.batch_no], precision) < 0:
-				self.throw_negative_batch(
-					row.batch_no, available_qty[row.batch_no], precision, row.posting_datetime
-				)
+            if flt(available_qty[row.batch_no], precision) < 0:
+                self.throw_negative_batch(
+                    row.batch_no,
+                    available_qty[row.batch_no],
+                    precision,
+                    row.posting_datetime,
+                )
 
-		return available_qty
+        return available_qty
 
-	def get_available_qty_from_stock_ledger(self):
-		batches = [d.batch_no for d in self.entries if d.batch_no]
+    def get_available_qty_from_stock_ledger(self):
+        batches = [d.batch_no for d in self.entries if d.batch_no]
 
-		sle = frappe.qb.DocType("Stock Ledger Entry")
+        sle = frappe.qb.DocType("Stock Ledger Entry")
 
-		query = (
-			frappe.qb.from_(sle)
-			.select(
-				sle.batch_no,
-				sle.actual_qty.as_("qty"),
-				sle.posting_datetime,
-				sle.creation,
-			)
-			.where(
-				(sle.item_code == self.item_code)
-				& (sle.warehouse == self.warehouse)
-				& (sle.is_cancelled == 0)
-				& (sle.batch_no.isin(batches))
-				& (sle.docstatus == 1)
-				& (sle.serial_and_batch_bundle.isnull())
-				& (sle.batch_no.isnotnull())
-			)
-			.for_update()
-		)
+        query = (
+            frappe.qb.from_(sle)
+            .select(
+                sle.batch_no,
+                sle.actual_qty.as_("qty"),
+                sle.posting_datetime,
+                sle.creation,
+            )
+            .where(
+                (sle.item_code == self.item_code)
+                & (sle.warehouse == self.warehouse)
+                & (sle.is_cancelled == 0)
+                & (sle.batch_no.isin(batches))
+                & (sle.docstatus == 1)
+                & (sle.serial_and_batch_bundle.isnull())
+                & (sle.batch_no.isnotnull())
+            )
+            .for_update()
+        )
 
-		return query.run(as_dict=True)
+        return query.run(as_dict=True)
 
-	def get_available_qty_from_sabb(self):
-		batches = [d.batch_no for d in self.entries if d.batch_no]
+    def get_available_qty_from_sabb(self):
+        batches = [d.batch_no for d in self.entries if d.batch_no]
 
-		sle = frappe.qb.DocType("Stock Ledger Entry")
-		child = frappe.qb.DocType("Serial and Batch Entry")
+        sle = frappe.qb.DocType("Stock Ledger Entry")
+        child = frappe.qb.DocType("Serial and Batch Entry")
 
-		query = (
-			frappe.qb.from_(child)
-			.inner_join(sle)
-			.on(child.parent == sle.serial_and_batch_bundle)
-			.select(
-				child.batch_no,
-				child.qty,
-				child.posting_datetime,
-				child.creation,
-			)
-			.where(
-				(child.item_code == self.item_code)
-				& (sle.is_cancelled == 0)
-				& (child.warehouse == self.warehouse)
-				& (child.is_cancelled == 0)
-				& (child.batch_no.isin(batches))
-				& (child.docstatus == 1)
-				& (child.type_of_transaction.isin(["Inward", "Outward"]))
-			)
-			.for_update()
-		)
-		query = query.where(child.voucher_type != "Pick List")
+        query = (
+            frappe.qb.from_(child)
+            .inner_join(sle)
+            .on(child.parent == sle.serial_and_batch_bundle)
+            .select(
+                child.batch_no,
+                child.qty,
+                child.posting_datetime,
+                child.creation,
+            )
+            .where(
+                (child.item_code == self.item_code)
+                & (sle.is_cancelled == 0)
+                & (child.warehouse == self.warehouse)
+                & (child.is_cancelled == 0)
+                & (child.batch_no.isin(batches))
+                & (child.docstatus == 1)
+                & (child.type_of_transaction.isin(["Inward", "Outward"]))
+            )
+            .for_update()
+        )
+        query = query.where(child.voucher_type != "Pick List")
 
-		return query.run(as_dict=True)
+        return query.run(as_dict=True)
 
-	def validate_voucher_no_docstatus(self):
-		if self.is_cancelled:
-			return
+    def validate_voucher_no_docstatus(self):
+        if self.is_cancelled:
+            return
 
-		if self.voucher_type == "POS Invoice":
-			return
+        if self.voucher_type == "POS Invoice":
+            return
 
-		child_doctype = self.voucher_type + " Item"
-		mapper = {
-			"Asset Capitalization": "Asset Capitalization Stock Item",
-			"Asset Repair": "Asset Repair Consumed Item",
-			"Stock Entry": "Stock Entry Detail",
-		}.get(self.voucher_type)
+        child_doctype = self.voucher_type + " Item"
+        mapper = {
+            "Asset Capitalization": "Asset Capitalization Stock Item",
+            "Asset Repair": "Asset Repair Consumed Item",
+            "Stock Entry": "Stock Entry Detail",
+        }.get(self.voucher_type)
 
-		if mapper:
-			child_doctype = mapper
+        if mapper:
+            child_doctype = mapper
 
-		if self.voucher_type == "Delivery Note" and not frappe.db.exists(
-			"Delivery Note Item", self.voucher_detail_no
-		):
-			child_doctype = "Packed Item"
+        if self.voucher_type == "Delivery Note" and not frappe.db.exists(
+            "Delivery Note Item", self.voucher_detail_no
+        ):
+            child_doctype = "Packed Item"
 
-		elif self.voucher_type == "Sales Invoice" and not frappe.db.exists(
-			"Sales Invoice Item", self.voucher_detail_no
-		):
-			child_doctype = "Packed Item"
+        elif self.voucher_type == "Sales Invoice" and not frappe.db.exists(
+            "Sales Invoice Item", self.voucher_detail_no
+        ):
+            child_doctype = "Packed Item"
 
-		elif self.voucher_type == "Subcontracting Receipt" and not frappe.db.exists(
-			"Subcontracting Receipt Item", self.voucher_detail_no
-		):
-			child_doctype = "Subcontracting Receipt Supplied Item"
+        elif self.voucher_type == "Subcontracting Receipt" and not frappe.db.exists(
+            "Subcontracting Receipt Item", self.voucher_detail_no
+        ):
+            child_doctype = "Subcontracting Receipt Supplied Item"
 
-		if (
-			frappe.db.get_value(self.voucher_type, self.voucher_no, "docstatus") == 1
-			and self.voucher_detail_no
-			and frappe.db.exists(child_doctype, self.voucher_detail_no)
-		):
-			msg = f"""The {self.voucher_type} {bold(self.voucher_no)}
+        if (
+            frappe.db.get_value(self.voucher_type, self.voucher_no, "docstatus") == 1
+            and self.voucher_detail_no
+            and frappe.db.exists(child_doctype, self.voucher_detail_no)
+        ):
+            msg = f"""The {self.voucher_type} {bold(self.voucher_no)}
 				is in submitted state, please cancel it first"""
-			frappe.throw(_(msg))
+            frappe.throw(_(msg))
 
-	def on_trash(self):
-		self.validate_voucher_no_docstatus()
-		self.delink_refernce_from_voucher()
-		self.delink_reference_from_batch()
+    def on_trash(self):
+        self.validate_voucher_no_docstatus()
+        self.delink_refernce_from_voucher()
+        self.delink_reference_from_batch()
 
-	@frappe.whitelist()
-	def add_serial_batch(self, data: str | dict):
-		serial_nos, batch_nos = [], []
-		if isinstance(data, str):
-			data = parse_json(data)
+    @frappe.whitelist()
+    def add_serial_batch(self, data: str | dict):
+        serial_nos, batch_nos = [], []
+        if isinstance(data, str):
+            data = parse_json(data)
 
-		if data.get("csv_file"):
-			serial_nos, batch_nos = get_serial_batch_from_csv(self.item_code, data.get("csv_file"))
-		else:
-			serial_nos, batch_nos = get_serial_batch_from_data(self.item_code, data)
+        if data.get("csv_file"):
+            serial_nos, batch_nos = get_serial_batch_from_csv(
+                self.item_code, data.get("csv_file")
+            )
+        else:
+            serial_nos, batch_nos = get_serial_batch_from_data(self.item_code, data)
 
-		if not serial_nos and not batch_nos:
-			return
+        if not serial_nos and not batch_nos:
+            return
 
-		if serial_nos:
-			self.set("entries", serial_nos)
-		elif batch_nos:
-			self.set("entries", batch_nos)
+        if serial_nos:
+            self.set("entries", serial_nos)
+        elif batch_nos:
+            self.set("entries", batch_nos)
 
-	def delete_serial_batch_entries(self):
-		SBBE = frappe.qb.DocType("Serial and Batch Entry")
+    def delete_serial_batch_entries(self):
+        SBBE = frappe.qb.DocType("Serial and Batch Entry")
 
-		frappe.qb.from_(SBBE).delete().where(SBBE.parent == self.name).run()
+        frappe.qb.from_(SBBE).delete().where(SBBE.parent == self.name).run()
 
-		self.set("entries", [])
+        self.set("entries", [])
 
 
 @frappe.whitelist()
 def download_blank_csv_template(content: str | list):
-	csv_data = []
-	if isinstance(content, str):
-		content = parse_json(content)
+    csv_data = []
+    if isinstance(content, str):
+        content = parse_json(content)
 
-	csv_data.append(content)
-	csv_data.append([])
-	csv_data.append([])
+    csv_data.append(content)
+    csv_data.append([])
+    csv_data.append([])
 
-	filename = "serial_and_batch_bundle"
-	build_csv_response(csv_data, filename)
+    filename = "serial_and_batch_bundle"
+    build_csv_response(csv_data, filename)
 
 
 @frappe.whitelist()
 def upload_csv_file(item_code: str, file_path: str):
-	serial_nos, batch_nos = [], []
-	serial_nos, batch_nos = get_serial_batch_from_csv(item_code, file_path)
+    serial_nos, batch_nos = [], []
+    serial_nos, batch_nos = get_serial_batch_from_csv(item_code, file_path)
 
-	return {
-		"serial_nos": serial_nos,
-		"batch_nos": batch_nos,
-	}
+    return {
+        "serial_nos": serial_nos,
+        "batch_nos": batch_nos,
+    }
 
 
 def get_serial_batch_from_csv(item_code, file_path):
-	from frappe.utils.csvutils import read_csv_content
+    from frappe.utils.csvutils import read_csv_content
 
-	serial_nos = []
-	batch_nos = []
+    serial_nos = []
+    batch_nos = []
 
-	if not file_path:
-		return serial_nos, batch_nos
+    if not file_path:
+        return serial_nos, batch_nos
 
-	try:
-		file = frappe.get_doc("File", {"file_url": file_path})
-	except frappe.DoesNotExistError:
-		frappe.msgprint(
-			_("File '{0}' not found").format(frappe.bold(file_path)),
-			alert=True,
-			indicator="red",
-			raise_exception=FileNotFoundError,
-		)
+    try:
+        file = frappe.get_doc("File", {"file_url": file_path})
+    except frappe.DoesNotExistError:
+        frappe.msgprint(
+            _("File '{0}' not found").format(frappe.bold(file_path)),
+            alert=True,
+            indicator="red",
+            raise_exception=FileNotFoundError,
+        )
 
-	if file.file_type != "CSV":
-		frappe.msgprint(
-			_("{0} is not a CSV file.").format(frappe.bold(file.file_name)),
-			alert=True,
-			indicator="red",
-			raise_exception=frappe.ValidationError,
-		)
+    if file.file_type != "CSV":
+        frappe.msgprint(
+            _("{0} is not a CSV file.").format(frappe.bold(file.file_name)),
+            alert=True,
+            indicator="red",
+            raise_exception=frappe.ValidationError,
+        )
 
-	csv_data = read_csv_content(file.get_content())
-	serial_nos, batch_nos = parse_csv_file_to_get_serial_batch(csv_data)
+    csv_data = read_csv_content(file.get_content())
+    serial_nos, batch_nos = parse_csv_file_to_get_serial_batch(csv_data)
 
-	if serial_nos:
-		make_serial_nos(item_code, serial_nos)
+    if serial_nos:
+        make_serial_nos(item_code, serial_nos)
 
-	if batch_nos:
-		make_batch_nos(item_code, batch_nos)
+    if batch_nos:
+        make_batch_nos(item_code, batch_nos)
 
-	return serial_nos, batch_nos
+    return serial_nos, batch_nos
 
 
 def parse_csv_file_to_get_serial_batch(reader):
-	has_serial_no, has_batch_no = False, False
-	serial_nos = []
-	batch_nos = []
+    has_serial_no, has_batch_no = False, False
+    serial_nos = []
+    batch_nos = []
 
-	for index, row in enumerate(reader):
-		if index == 0:
-			has_serial_no = row[0] == "Serial No"
-			has_batch_no = row[0] == "Batch No"
-			if not has_batch_no and len(row) > 1:
-				has_batch_no = row[1] == "Batch No"
+    for index, row in enumerate(reader):
+        if index == 0:
+            has_serial_no = row[0] == "Serial No"
+            has_batch_no = row[0] == "Batch No"
+            if not has_batch_no and len(row) > 1:
+                has_batch_no = row[1] == "Batch No"
 
-			continue
+            continue
 
-		if not row[0]:
-			continue
+        if not row[0]:
+            continue
 
-		if has_serial_no or (has_serial_no and has_batch_no):
-			_dict = {"serial_no": row[0].strip(), "qty": 1}
+        if has_serial_no or (has_serial_no and has_batch_no):
+            _dict = {"serial_no": row[0].strip(), "qty": 1}
 
-			if has_batch_no:
-				_dict.update(
-					{
-						"batch_no": row[1].strip(),
-						"qty": row[2],
-					}
-				)
+            if has_batch_no:
+                _dict.update(
+                    {
+                        "batch_no": row[1].strip(),
+                        "qty": row[2],
+                    }
+                )
 
-				batch_nos.append(
-					{
-						"batch_no": row[1].strip(),
-						"qty": row[2],
-					}
-				)
+                batch_nos.append(
+                    {
+                        "batch_no": row[1].strip(),
+                        "qty": row[2],
+                    }
+                )
 
-			serial_nos.append(_dict)
-		elif has_batch_no:
-			batch_nos.append(
-				{
-					"batch_no": row[0].strip(),
-					"qty": row[1],
-				}
-			)
+            serial_nos.append(_dict)
+        elif has_batch_no:
+            batch_nos.append(
+                {
+                    "batch_no": row[0].strip(),
+                    "qty": row[1],
+                }
+            )
 
-	return serial_nos, batch_nos
+    return serial_nos, batch_nos
 
 
 def get_serial_batch_from_data(item_code, kwargs):
-	serial_nos = []
-	batch_nos = []
-	if kwargs.get("serial_nos"):
-		data = parse_serial_nos(kwargs.get("serial_nos"))
-		for serial_no in data:
-			if not serial_no:
-				continue
-			serial_nos.append({"serial_no": serial_no, "qty": 1})
+    serial_nos = []
+    batch_nos = []
+    if kwargs.get("serial_nos"):
+        data = parse_serial_nos(kwargs.get("serial_nos"))
+        for serial_no in data:
+            if not serial_no:
+                continue
+            serial_nos.append({"serial_no": serial_no, "qty": 1})
 
-		make_serial_nos(item_code, serial_nos)
+        make_serial_nos(item_code, serial_nos)
 
-	if kwargs.get("_has_serial_nos"):
-		return serial_nos
+    if kwargs.get("_has_serial_nos"):
+        return serial_nos
 
-	return serial_nos, batch_nos
+    return serial_nos, batch_nos
 
 
 @frappe.whitelist()
 def create_serial_nos(item_code: str, serial_nos: list | str):
-	serial_nos = get_serial_batch_from_data(
-		item_code,
-		{
-			"serial_nos": serial_nos,
-			"_has_serial_nos": True,
-		},
-	)
+    serial_nos = get_serial_batch_from_data(
+        item_code,
+        {
+            "serial_nos": serial_nos,
+            "_has_serial_nos": True,
+        },
+    )
 
-	return serial_nos
+    return serial_nos
 
 
 def make_serial_nos(item_code, serial_nos):
-	item = frappe.get_cached_value(
-		"Item", item_code, ["description", "item_code", "item_name", "warranty_period"], as_dict=1
-	)
+    item = frappe.get_cached_value(
+        "Item",
+        item_code,
+        ["description", "item_code", "item_name", "warranty_period"],
+        as_dict=1,
+    )
 
-	serial_nos = [d.get("serial_no").strip() for d in serial_nos if d.get("serial_no")]
-	existing_serial_nos = frappe.get_all("Serial No", filters={"name": ("in", serial_nos)})
+    serial_nos = [d.get("serial_no").strip() for d in serial_nos if d.get("serial_no")]
+    existing_serial_nos = frappe.get_all(
+        "Serial No", filters={"name": ("in", serial_nos)}
+    )
 
-	existing_serial_nos = [d.get("name") for d in existing_serial_nos if d.get("name")]
-	serial_nos = list(set(serial_nos) - set(existing_serial_nos))
+    existing_serial_nos = [d.get("name") for d in existing_serial_nos if d.get("name")]
+    serial_nos = list(set(serial_nos) - set(existing_serial_nos))
 
-	if not serial_nos:
-		return
+    if not serial_nos:
+        return
 
-	serial_nos_details = []
-	user = frappe.session.user
-	for serial_no in serial_nos:
-		serial_nos_details.append(
-			(
-				serial_no,
-				serial_no,
-				now(),
-				now(),
-				user,
-				user,
-				item.item_code,
-				item.item_name,
-				item.description,
-				item.warranty_period or 0,
-				"Inactive",
-			)
-		)
+    serial_nos_details = []
+    user = frappe.session.user
+    for serial_no in serial_nos:
+        serial_nos_details.append(
+            (
+                serial_no,
+                serial_no,
+                now(),
+                now(),
+                user,
+                user,
+                item.item_code,
+                item.item_name,
+                item.description,
+                item.warranty_period or 0,
+                "Inactive",
+            )
+        )
 
-	fields = [
-		"name",
-		"serial_no",
-		"creation",
-		"modified",
-		"owner",
-		"modified_by",
-		"item_code",
-		"item_name",
-		"description",
-		"warranty_period",
-		"status",
-	]
+    fields = [
+        "name",
+        "serial_no",
+        "creation",
+        "modified",
+        "owner",
+        "modified_by",
+        "item_code",
+        "item_name",
+        "description",
+        "warranty_period",
+        "status",
+    ]
 
-	frappe.db.bulk_insert("Serial No", fields=fields, values=set(serial_nos_details))
+    frappe.db.bulk_insert("Serial No", fields=fields, values=set(serial_nos_details))
 
-	frappe.msgprint(_("Serial Nos are created successfully"), alert=True)
+    frappe.msgprint(_("Serial Nos are created successfully"), alert=True)
 
 
 def make_batch_nos(item_code, batch_nos):
-	item = frappe.get_cached_value("Item", item_code, ["description", "item_code"], as_dict=1)
-	batch_nos = [d.get("batch_no") for d in batch_nos if d.get("batch_no")]
+    item = frappe.get_cached_value(
+        "Item", item_code, ["description", "item_code"], as_dict=1
+    )
+    batch_nos = [d.get("batch_no") for d in batch_nos if d.get("batch_no")]
 
-	existing_batches = frappe.get_all("Batch", filters={"name": ("in", batch_nos)})
+    existing_batches = frappe.get_all("Batch", filters={"name": ("in", batch_nos)})
 
-	existing_batches = [d.get("name") for d in existing_batches if d.get("name")]
+    existing_batches = [d.get("name") for d in existing_batches if d.get("name")]
 
-	batch_nos = list(set(batch_nos) - set(existing_batches))
-	if not batch_nos:
-		return
+    batch_nos = list(set(batch_nos) - set(existing_batches))
+    if not batch_nos:
+        return
 
-	batch_nos_details = []
-	user = frappe.session.user
-	for batch_no in batch_nos:
-		if frappe.db.exists("Batch", batch_no):
-			continue
+    batch_nos_details = []
+    user = frappe.session.user
+    for batch_no in batch_nos:
+        if frappe.db.exists("Batch", batch_no):
+            continue
 
-		batch_nos_details.append(
-			(
-				batch_no,
-				batch_no,
-				now(),
-				now(),
-				user,
-				user,
-				item.item_code,
-				item.item_name,
-				item.description,
-				1,
-			)
-		)
+        batch_nos_details.append(
+            (
+                batch_no,
+                batch_no,
+                now(),
+                now(),
+                user,
+                user,
+                item.item_code,
+                item.item_name,
+                item.description,
+                1,
+            )
+        )
 
-	fields = [
-		"name",
-		"batch_id",
-		"creation",
-		"modified",
-		"owner",
-		"modified_by",
-		"item",
-		"item_name",
-		"description",
-		"use_batchwise_valuation",
-	]
+    fields = [
+        "name",
+        "batch_id",
+        "creation",
+        "modified",
+        "owner",
+        "modified_by",
+        "item",
+        "item_name",
+        "description",
+        "use_batchwise_valuation",
+    ]
 
-	frappe.db.bulk_insert("Batch", fields=fields, values=set(batch_nos_details))
+    frappe.db.bulk_insert("Batch", fields=fields, values=set(batch_nos_details))
 
-	frappe.msgprint(_("Batch Nos are created successfully"), alert=True)
+    frappe.msgprint(_("Batch Nos are created successfully"), alert=True)
 
 
 @frappe.whitelist()
 @frappe.validate_and_sanitize_search_inputs
 def item_query(
-	doctype: Any, txt: str, searchfield: str, start: int, page_len: int, filters: Any, as_dict: bool = False
+    doctype: Any,
+    txt: str,
+    searchfield: str,
+    start: int,
+    page_len: int,
+    filters: Any,
+    as_dict: bool = False,
 ):
-	item_filters = {"disabled": 0}
-	if txt:
-		item_filters["name"] = ("like", f"%{txt}%")
+    item_filters = {"disabled": 0}
+    if txt:
+        item_filters["name"] = ("like", f"%{txt}%")
 
-	return frappe.get_all(
-		"Item",
-		filters=item_filters,
-		or_filters={"has_serial_no": 1, "has_batch_no": 1},
-		fields=["name", "item_name"],
-		as_list=1,
-	)
+    return frappe.get_all(
+        "Item",
+        filters=item_filters,
+        or_filters={"has_serial_no": 1, "has_batch_no": 1},
+        fields=["name", "item_name"],
+        as_list=1,
+    )
 
 
 @frappe.whitelist()
 def get_serial_batch_ledgers(
-	item_code: str | None = None,
-	docstatus: str | list | int | None = None,
-	voucher_no: str | None = None,
-	name: str | list | None = None,
-	child_row: dict | str | None = None,
+    item_code: str | None = None,
+    docstatus: str | list | int | None = None,
+    voucher_no: str | None = None,
+    name: str | list | None = None,
+    child_row: dict | str | None = None,
 ):
-	filters = get_filters_for_bundle(
-		item_code=item_code, docstatus=docstatus, voucher_no=voucher_no, name=name, child_row=child_row
-	)
+    filters = get_filters_for_bundle(
+        item_code=item_code,
+        docstatus=docstatus,
+        voucher_no=voucher_no,
+        name=name,
+        child_row=child_row,
+    )
 
-	fields = [
-		"`tabSerial and Batch Bundle`.`item_code`",
-		"`tabSerial and Batch Entry`.`qty`",
-		"`tabSerial and Batch Entry`.`warehouse`",
-		"`tabSerial and Batch Entry`.`batch_no`",
-		"`tabSerial and Batch Entry`.`serial_no`",
-		"`tabSerial and Batch Entry`.`name` as `child_row`",
-	]
+    fields = [
+        "`tabSerial and Batch Bundle`.`item_code`",
+        "`tabSerial and Batch Entry`.`qty`",
+        "`tabSerial and Batch Entry`.`warehouse`",
+        "`tabSerial and Batch Entry`.`batch_no`",
+        "`tabSerial and Batch Entry`.`serial_no`",
+        "`tabSerial and Batch Entry`.`name` as `child_row`",
+    ]
 
-	if not child_row:
-		fields.append("`tabSerial and Batch Bundle`.`name`")
+    if not child_row:
+        fields.append("`tabSerial and Batch Bundle`.`name`")
 
-	return frappe.get_all(
-		"Serial and Batch Bundle",
-		fields=fields,
-		filters=filters,
-		order_by="`tabSerial and Batch Entry`.`idx`",
-	)
+    return frappe.get_all(
+        "Serial and Batch Bundle",
+        fields=fields,
+        filters=filters,
+        order_by="`tabSerial and Batch Entry`.`idx`",
+    )
 
 
-def get_filters_for_bundle(item_code=None, docstatus=None, voucher_no=None, name=None, child_row=None):
-	filters = [
-		["Serial and Batch Bundle", "is_cancelled", "=", 0],
-	]
+def get_filters_for_bundle(
+    item_code=None, docstatus=None, voucher_no=None, name=None, child_row=None
+):
+    filters = [
+        ["Serial and Batch Bundle", "is_cancelled", "=", 0],
+    ]
 
-	if child_row and isinstance(child_row, str):
-		child_row = parse_json(child_row)
+    if child_row and isinstance(child_row, str):
+        child_row = parse_json(child_row)
 
-	if not name and child_row and child_row.get("qty") < 0:
-		bundle = get_reference_serial_and_batch_bundle(child_row)
-		if bundle:
-			voucher_no = None
-			filters.append(["Serial and Batch Bundle", "name", "=", bundle])
+    if not name and child_row and child_row.get("qty") < 0:
+        bundle = get_reference_serial_and_batch_bundle(child_row)
+        if bundle:
+            voucher_no = None
+            filters.append(["Serial and Batch Bundle", "name", "=", bundle])
 
-	if item_code:
-		filters.append(["Serial and Batch Bundle", "item_code", "=", item_code])
+    if item_code:
+        filters.append(["Serial and Batch Bundle", "item_code", "=", item_code])
 
-	if not docstatus:
-		docstatus = [0, 1]
+    if not docstatus:
+        docstatus = [0, 1]
 
-	if isinstance(docstatus, list):
-		filters.append(["Serial and Batch Bundle", "docstatus", "in", docstatus])
-	else:
-		filters.append(["Serial and Batch Bundle", "docstatus", "=", docstatus])
+    if isinstance(docstatus, list):
+        filters.append(["Serial and Batch Bundle", "docstatus", "in", docstatus])
+    else:
+        filters.append(["Serial and Batch Bundle", "docstatus", "=", docstatus])
 
-	if voucher_no:
-		filters.append(["Serial and Batch Bundle", "voucher_no", "=", voucher_no])
+    if voucher_no:
+        filters.append(["Serial and Batch Bundle", "voucher_no", "=", voucher_no])
 
-	if name:
-		if isinstance(name, list):
-			filters.append(["Serial and Batch Entry", "parent", "in", name])
-		else:
-			filters.append(["Serial and Batch Entry", "parent", "=", name])
+    if name:
+        if isinstance(name, list):
+            filters.append(["Serial and Batch Entry", "parent", "in", name])
+        else:
+            filters.append(["Serial and Batch Entry", "parent", "=", name])
 
-	return filters
+    return filters
 
 
 def get_reference_serial_and_batch_bundle(child_row):
-	field = {
-		"Sales Invoice Item": "sales_invoice_item",
-		"Delivery Note Item": "dn_detail",
-		"Purchase Receipt Item": "purchase_receipt_item",
-		"Purchase Invoice Item": "purchase_invoice_item",
-		"POS Invoice Item": "pos_invoice_item",
-	}.get(child_row.doctype)
+    field = {
+        "Sales Invoice Item": "sales_invoice_item",
+        "Delivery Note Item": "dn_detail",
+        "Purchase Receipt Item": "purchase_receipt_item",
+        "Purchase Invoice Item": "purchase_invoice_item",
+        "POS Invoice Item": "pos_invoice_item",
+    }.get(child_row.doctype)
 
-	if field:
-		return frappe.get_cached_value(child_row.doctype, child_row.get(field), "serial_and_batch_bundle")
+    if field:
+        return frappe.get_cached_value(
+            child_row.doctype, child_row.get(field), "serial_and_batch_bundle"
+        )
 
 
 @frappe.whitelist()
 def add_serial_batch_ledgers(
-	entries: list | str,
-	child_row: PurchaseReceiptItem | dict | str,
-	doc: Document | str,
-	warehouse: str | None = None,
-	do_not_save: bool = False,
+    entries: list | str,
+    child_row: PurchaseReceiptItem | dict | str,
+    doc: Document | str,
+    warehouse: str | None = None,
+    do_not_save: bool = False,
 ):
-	if isinstance(child_row, str):
-		child_row = frappe._dict(parse_json(child_row))
+    if isinstance(child_row, str):
+        child_row = frappe._dict(parse_json(child_row))
 
-	if isinstance(entries, str):
-		entries = parse_json(entries)
+    if isinstance(entries, str):
+        entries = parse_json(entries)
 
-	parent_doc = doc
-	if parent_doc and isinstance(parent_doc, str):
-		parent_doc = parse_json(parent_doc)
+    parent_doc = doc
+    if parent_doc and isinstance(parent_doc, str):
+        parent_doc = parse_json(parent_doc)
 
-	bundle = child_row.serial_and_batch_bundle
-	if child_row.get("is_rejected"):
-		bundle = child_row.rejected_serial_and_batch_bundle
+    bundle = child_row.serial_and_batch_bundle
+    if child_row.get("is_rejected"):
+        bundle = child_row.rejected_serial_and_batch_bundle
 
-	if frappe.db.exists("Serial and Batch Bundle", bundle):
-		sb_doc = update_serial_batch_no_ledgers(bundle, entries, child_row, parent_doc, warehouse)
-	else:
-		sb_doc = create_serial_batch_no_ledgers(
-			entries, child_row, parent_doc, warehouse, do_not_save=do_not_save
-		)
+    if frappe.db.exists("Serial and Batch Bundle", bundle):
+        sb_doc = update_serial_batch_no_ledgers(
+            bundle, entries, child_row, parent_doc, warehouse
+        )
+    else:
+        sb_doc = create_serial_batch_no_ledgers(
+            entries, child_row, parent_doc, warehouse, do_not_save=do_not_save
+        )
 
-	return sb_doc
+    return sb_doc
 
 
 def create_serial_batch_no_ledgers(
-	entries, child_row, parent_doc, warehouse=None, do_not_save=False
+    entries, child_row, parent_doc, warehouse=None, do_not_save=False
 ) -> object:
-	warehouse = warehouse or (child_row.rejected_warehouse if child_row.is_rejected else child_row.warehouse)
+    warehouse = warehouse or (
+        child_row.rejected_warehouse if child_row.is_rejected else child_row.warehouse
+    )
 
-	type_of_transaction = get_type_of_transaction(parent_doc, child_row)
-	if parent_doc.get("doctype") == "Stock Entry":
-		warehouse = warehouse or child_row.s_warehouse or child_row.t_warehouse
+    type_of_transaction = get_type_of_transaction(parent_doc, child_row)
+    if parent_doc.get("doctype") == "Stock Entry":
+        warehouse = warehouse or child_row.s_warehouse or child_row.t_warehouse
 
-	posting_datetime = combine_datetime(parent_doc.get("posting_date"), parent_doc.get("posting_time"))
+    posting_datetime = combine_datetime(
+        parent_doc.get("posting_date"), parent_doc.get("posting_time")
+    )
 
-	doc = frappe.get_doc(
-		{
-			"doctype": "Serial and Batch Bundle",
-			"voucher_type": child_row.parenttype,
-			"item_code": child_row.item_code,
-			"warehouse": warehouse,
-			"is_rejected": child_row.is_rejected,
-			"type_of_transaction": type_of_transaction,
-			"posting_datetime": posting_datetime,
-			"company": parent_doc.get("company"),
-		}
-	)
+    doc = frappe.get_doc(
+        {
+            "doctype": "Serial and Batch Bundle",
+            "voucher_type": child_row.parenttype,
+            "item_code": child_row.item_code,
+            "warehouse": warehouse,
+            "is_rejected": child_row.is_rejected,
+            "type_of_transaction": type_of_transaction,
+            "posting_datetime": posting_datetime,
+            "company": parent_doc.get("company"),
+        }
+    )
 
-	batch_no = None
+    batch_no = None
 
-	if (
-		not entries[0].get("batch_no")
-		and entries[0].get("serial_no")
-		and frappe.get_cached_value("Item", child_row.item_code, "has_batch_no")
-	):
-		batch_no = get_batch(child_row.item_code)
+    if (
+        not entries[0].get("batch_no")
+        and entries[0].get("serial_no")
+        and frappe.get_cached_value("Item", child_row.item_code, "has_batch_no")
+    ):
+        batch_no = get_batch(child_row.item_code)
 
-	for row in entries:
-		row = frappe._dict(row)
-		doc.append(
-			"entries",
-			{
-				"qty": (flt(row.qty) or 1.0) * (1 if type_of_transaction == "Inward" else -1),
-				"warehouse": warehouse,
-				"batch_no": row.batch_no or batch_no,
-				"serial_no": row.serial_no,
-			},
-		)
+    for row in entries:
+        row = frappe._dict(row)
+        doc.append(
+            "entries",
+            {
+                "qty": (flt(row.qty) or 1.0)
+                * (1 if type_of_transaction == "Inward" else -1),
+                "warehouse": warehouse,
+                "batch_no": row.batch_no or batch_no,
+                "serial_no": row.serial_no,
+            },
+        )
 
-	doc.save()
+    doc.save()
 
-	if do_not_save:
-		frappe.db.set_value(child_row.doctype, child_row.name, "serial_and_batch_bundle", doc.name)
+    if do_not_save:
+        frappe.db.set_value(
+            child_row.doctype, child_row.name, "serial_and_batch_bundle", doc.name
+        )
 
-	frappe.msgprint(_("Serial and Batch Bundle created"), alert=True)
+    frappe.msgprint(_("Serial and Batch Bundle created"), alert=True)
 
-	return doc
+    return doc
 
 
 def combine_datetime(date, time=None):
-	from erpnext.stock.utils import get_combine_datetime
+    from erpnext.stock.utils import get_combine_datetime
 
-	return get_combine_datetime(date, time)
+    return get_combine_datetime(date, time)
 
 
 def get_batch(item_code):
-	from erpnext.stock.doctype.batch.batch import make_batch
+    from erpnext.stock.doctype.batch.batch import make_batch
 
-	return make_batch(
-		frappe._dict(
-			{
-				"item": item_code,
-			}
-		)
-	)
+    return make_batch(
+        frappe._dict(
+            {
+                "item": item_code,
+            }
+        )
+    )
 
 
 def get_type_of_transaction(parent_doc, child_row):
-	type_of_transaction = child_row.get("type_of_transaction")
-	if parent_doc.get("doctype") == "Stock Entry":
-		type_of_transaction = "Outward" if child_row.s_warehouse else "Inward"
+    type_of_transaction = child_row.get("type_of_transaction")
+    if parent_doc.get("doctype") == "Stock Entry":
+        type_of_transaction = "Outward" if child_row.s_warehouse else "Inward"
 
-	if not type_of_transaction:
-		type_of_transaction = "Outward"
-		if parent_doc.get("doctype") in ["Purchase Receipt", "Purchase Invoice"]:
-			type_of_transaction = "Inward"
+    if not type_of_transaction:
+        type_of_transaction = "Outward"
+        if parent_doc.get("doctype") in ["Purchase Receipt", "Purchase Invoice"]:
+            type_of_transaction = "Inward"
 
-	if parent_doc.get("doctype") == "Subcontracting Receipt":
-		type_of_transaction = "Outward"
-		if child_row.get("doctype") == "Subcontracting Receipt Item":
-			type_of_transaction = "Inward"
-	elif parent_doc.get("doctype") == "Stock Reconciliation":
-		type_of_transaction = "Inward"
+    if parent_doc.get("doctype") == "Subcontracting Receipt":
+        type_of_transaction = "Outward"
+        if child_row.get("doctype") == "Subcontracting Receipt Item":
+            type_of_transaction = "Inward"
+    elif parent_doc.get("doctype") == "Stock Reconciliation":
+        type_of_transaction = "Inward"
 
-	if parent_doc.get("is_return") and parent_doc.get("doctype") != "Stock Entry":
-		type_of_transaction = "Inward"
-		if (
-			parent_doc.get("doctype") in ["Purchase Receipt", "Purchase Invoice"]
-			or child_row.get("doctype") == "Subcontracting Receipt Item"
-		):
-			type_of_transaction = "Outward"
+    if parent_doc.get("is_return") and parent_doc.get("doctype") != "Stock Entry":
+        type_of_transaction = "Inward"
+        if (
+            parent_doc.get("doctype") in ["Purchase Receipt", "Purchase Invoice"]
+            or child_row.get("doctype") == "Subcontracting Receipt Item"
+        ):
+            type_of_transaction = "Outward"
 
-	return type_of_transaction
+    return type_of_transaction
 
 
-def update_serial_batch_no_ledgers(bundle, entries, child_row, parent_doc, warehouse=None) -> object:
-	doc = frappe.get_doc("Serial and Batch Bundle", bundle)
-	doc.voucher_detail_no = child_row.name
-	doc.posting_datetime = combine_datetime(parent_doc.get("posting_date"), parent_doc.get("posting_time"))
+def update_serial_batch_no_ledgers(
+    bundle, entries, child_row, parent_doc, warehouse=None
+) -> object:
+    doc = frappe.get_doc("Serial and Batch Bundle", bundle)
+    doc.voucher_detail_no = child_row.name
+    doc.posting_datetime = combine_datetime(
+        parent_doc.get("posting_date"), parent_doc.get("posting_time")
+    )
 
-	doc.warehouse = warehouse or doc.warehouse
-	doc.set("entries", [])
+    doc.warehouse = warehouse or doc.warehouse
+    doc.set("entries", [])
 
-	for d in entries:
-		doc.append(
-			"entries",
-			{
-				"qty": (flt(d.get("qty")) or 1.0) * (1 if doc.type_of_transaction == "Inward" else -1),
-				"warehouse": warehouse or d.get("warehouse"),
-				"batch_no": d.get("batch_no"),
-				"serial_no": d.get("serial_no"),
-			},
-		)
+    for d in entries:
+        doc.append(
+            "entries",
+            {
+                "qty": (flt(d.get("qty")) or 1.0)
+                * (1 if doc.type_of_transaction == "Inward" else -1),
+                "warehouse": warehouse or d.get("warehouse"),
+                "batch_no": d.get("batch_no"),
+                "serial_no": d.get("serial_no"),
+            },
+        )
 
-	doc.save(ignore_permissions=True)
+    doc.save(ignore_permissions=True)
 
-	frappe.msgprint(_("Serial and Batch Bundle updated"), alert=True)
+    frappe.msgprint(_("Serial and Batch Bundle updated"), alert=True)
 
-	return doc
+    return doc
 
 
 @frappe.whitelist()
-def update_serial_or_batch(bundle_id: str, serial_no: str | None = None, batch_no: str | None = None):
-	if batch_no and not serial_no:
-		if qty := frappe.db.get_value(
-			"Serial and Batch Entry", {"parent": bundle_id, "batch_no": batch_no}, "qty"
-		):
-			frappe.db.set_value(
-				"Serial and Batch Entry", {"parent": bundle_id, "batch_no": batch_no}, "qty", qty + 1
-			)
-			return
+def update_serial_or_batch(
+    bundle_id: str, serial_no: str | None = None, batch_no: str | None = None
+):
+    if batch_no and not serial_no:
+        if qty := frappe.db.get_value(
+            "Serial and Batch Entry", {"parent": bundle_id, "batch_no": batch_no}, "qty"
+        ):
+            frappe.db.set_value(
+                "Serial and Batch Entry",
+                {"parent": bundle_id, "batch_no": batch_no},
+                "qty",
+                qty + 1,
+            )
+            return
 
-	doc = frappe.get_cached_doc("Serial and Batch Bundle", bundle_id)
-	if not serial_no and not batch_no:
-		return
+    doc = frappe.get_cached_doc("Serial and Batch Bundle", bundle_id)
+    if not serial_no and not batch_no:
+        return
 
-	doc.append("entries", {"serial_no": serial_no, "batch_no": batch_no, "qty": 1})
-	doc.save(ignore_permissions=True)
+    doc.append("entries", {"serial_no": serial_no, "batch_no": batch_no, "qty": 1})
+    doc.save(ignore_permissions=True)
 
 
 def get_serial_and_batch_ledger(**kwargs):
-	kwargs = frappe._dict(kwargs)
+    kwargs = frappe._dict(kwargs)
 
-	sle_table = frappe.qb.DocType("Stock Ledger Entry")
-	serial_batch_table = frappe.qb.DocType("Serial and Batch Entry")
+    sle_table = frappe.qb.DocType("Stock Ledger Entry")
+    serial_batch_table = frappe.qb.DocType("Serial and Batch Entry")
 
-	query = (
-		frappe.qb.from_(sle_table)
-		.inner_join(serial_batch_table)
-		.on(sle_table.serial_and_batch_bundle == serial_batch_table.parent)
-		.select(
-			serial_batch_table.serial_no,
-			serial_batch_table.warehouse,
-			serial_batch_table.batch_no,
-			serial_batch_table.qty,
-			serial_batch_table.incoming_rate,
-			serial_batch_table.voucher_detail_no,
-		)
-		.where(
-			(sle_table.item_code == kwargs.item_code)
-			& (sle_table.warehouse == kwargs.warehouse)
-			& (serial_batch_table.is_outward == 0)
-		)
-	)
+    query = (
+        frappe.qb.from_(sle_table)
+        .inner_join(serial_batch_table)
+        .on(sle_table.serial_and_batch_bundle == serial_batch_table.parent)
+        .select(
+            serial_batch_table.serial_no,
+            serial_batch_table.warehouse,
+            serial_batch_table.batch_no,
+            serial_batch_table.qty,
+            serial_batch_table.incoming_rate,
+            serial_batch_table.voucher_detail_no,
+        )
+        .where(
+            (sle_table.item_code == kwargs.item_code)
+            & (sle_table.warehouse == kwargs.warehouse)
+            & (serial_batch_table.is_outward == 0)
+        )
+    )
 
-	if kwargs.serial_nos:
-		query = query.where(serial_batch_table.serial_no.isin(kwargs.serial_nos))
+    if kwargs.serial_nos:
+        query = query.where(serial_batch_table.serial_no.isin(kwargs.serial_nos))
 
-	if kwargs.batch_nos:
-		query = query.where(serial_batch_table.batch_no.isin(kwargs.batch_nos))
+    if kwargs.batch_nos:
+        query = query.where(serial_batch_table.batch_no.isin(kwargs.batch_nos))
 
-	if kwargs.fetch_incoming_rate:
-		query = query.where(sle_table.actual_qty > 0)
+    if kwargs.fetch_incoming_rate:
+        query = query.where(sle_table.actual_qty > 0)
 
-	return query.run(as_dict=True)
+    return query.run(as_dict=True)
 
 
 @frappe.whitelist()
 def get_auto_data(**kwargs):
-	kwargs = frappe._dict(kwargs)
-	if cint(kwargs.has_serial_no):
-		return get_serial_nos_from_sre(kwargs) if kwargs.scio_detail else get_available_serial_nos(kwargs)
-	elif cint(kwargs.has_batch_no):
-		return get_batch_nos_from_sre(kwargs) if kwargs.scio_detail else get_auto_batch_nos(kwargs)
+    kwargs = frappe._dict(kwargs)
+    if cint(kwargs.has_serial_no):
+        return (
+            get_serial_nos_from_sre(kwargs)
+            if kwargs.scio_detail
+            else get_available_serial_nos(kwargs)
+        )
+    elif cint(kwargs.has_batch_no):
+        return (
+            get_batch_nos_from_sre(kwargs)
+            if kwargs.scio_detail
+            else get_auto_batch_nos(kwargs)
+        )
 
 
 def get_available_batches_qty(available_batches):
-	available_batches_qty = defaultdict(float)
-	for batch in available_batches:
-		available_batches_qty[batch.batch_no] += batch.qty
+    available_batches_qty = defaultdict(float)
+    for batch in available_batches:
+        available_batches_qty[batch.batch_no] += batch.qty
 
-	return available_batches_qty
+    return available_batches_qty
 
 
 def get_available_serial_nos(kwargs):
-	fields = ["name as serial_no", "warehouse"]
-	if kwargs.has_batch_no:
-		fields.append("batch_no")
+    fields = ["name as serial_no", "warehouse"]
+    if kwargs.has_batch_no:
+        fields.append("batch_no")
 
-	order_by = "creation"
-	if kwargs.based_on == "LIFO":
-		order_by = "creation"
-	elif kwargs.based_on == "Expiry":
-		order_by = "amc_expiry_date"
+    order_by = "creation"
+    if kwargs.based_on == "LIFO":
+        order_by = "creation"
+    elif kwargs.based_on == "Expiry":
+        order_by = "amc_expiry_date"
 
-	if not kwargs.get("posting_datetime") and kwargs.get("posting_date"):
-		kwargs["posting_datetime"] = combine_datetime(kwargs.get("posting_date"), kwargs.get("posting_time"))
+    if not kwargs.get("posting_datetime") and kwargs.get("posting_date"):
+        kwargs["posting_datetime"] = combine_datetime(
+            kwargs.get("posting_date"), kwargs.get("posting_time")
+        )
 
-	filters = {"item_code": kwargs.item_code}
+    filters = {"item_code": kwargs.item_code}
 
-	# ignore_warehouse is used for backdated stock transactions
-	# There might be chances that the serial no not exists in the warehouse during backdated stock transactions
-	if not kwargs.get("ignore_warehouse"):
-		filters["warehouse"] = ("is", "set")
-		if kwargs.warehouse:
-			filters["warehouse"] = kwargs.warehouse
+    # ignore_warehouse is used for backdated stock transactions
+    # There might be chances that the serial no not exists in the warehouse during backdated stock transactions
+    if not kwargs.get("ignore_warehouse"):
+        filters["warehouse"] = ("is", "set")
+        if kwargs.warehouse:
+            filters["warehouse"] = kwargs.warehouse
 
-	reserved_entries = get_reserved_serial_nos_for_sre(kwargs)
+    reserved_entries = get_reserved_serial_nos_for_sre(kwargs)
 
-	ignore_serial_nos = []
-	if reserved_entries:
-		if kwargs.get("sabb_voucher_type") == "Delivery Note" and kwargs.get("against_sales_order"):
-			reserved_voucher_details = [kwargs.get("against_sales_order")]
-		else:
-			reserved_voucher_details = get_reserved_voucher_details(kwargs)
+    ignore_serial_nos = []
+    if reserved_entries:
+        if kwargs.get("sabb_voucher_type") == "Delivery Note" and kwargs.get(
+            "against_sales_order"
+        ):
+            reserved_voucher_details = [kwargs.get("against_sales_order")]
+        else:
+            reserved_voucher_details = get_reserved_voucher_details(kwargs)
 
-		# Check if serial nos are reserved for the current voucher then fetch only those serial nos
-		if reserved_serial_nos := get_reserved_serial_nos_for_voucher(
-			kwargs, reserved_entries, reserved_voucher_details
-		):
-			filters["name"] = ("in", reserved_serial_nos)
-			return get_serial_nos_based_on_filters(filters, fields, order_by, kwargs)
+        # Check if serial nos are reserved for the current voucher then fetch only those serial nos
+        if reserved_serial_nos := get_reserved_serial_nos_for_voucher(
+            kwargs, reserved_entries, reserved_voucher_details
+        ):
+            filters["name"] = ("in", reserved_serial_nos)
+            return get_serial_nos_based_on_filters(filters, fields, order_by, kwargs)
 
-		# Check if serial nos are reserved for other vouchers then ignore those serial nos
-		elif ignore_reserved_serial_nos := get_other_doc_reserved_serials(
-			kwargs, reserved_entries, reserved_voucher_details
-		):
-			ignore_serial_nos.extend(ignore_reserved_serial_nos)
+        # Check if serial nos are reserved for other vouchers then ignore those serial nos
+        elif ignore_reserved_serial_nos := get_other_doc_reserved_serials(
+            kwargs, reserved_entries, reserved_voucher_details
+        ):
+            ignore_serial_nos.extend(ignore_reserved_serial_nos)
 
-	if reserved_for_pos := get_reserved_serial_nos_for_pos(kwargs):
-		ignore_serial_nos.extend(reserved_for_pos)
+    if reserved_for_pos := get_reserved_serial_nos_for_pos(kwargs):
+        ignore_serial_nos.extend(reserved_for_pos)
 
-	# To ignore serial nos in the same record for the draft state
-	if kwargs.get("ignore_serial_nos"):
-		ignore_serial_nos.extend(kwargs.get("ignore_serial_nos"))
+    # To ignore serial nos in the same record for the draft state
+    if kwargs.get("ignore_serial_nos"):
+        ignore_serial_nos.extend(kwargs.get("ignore_serial_nos"))
 
-	ignore_serial_nos = list(set(ignore_serial_nos))
-	if kwargs.get("posting_datetime"):
-		time_based_serial_nos = get_serial_nos_based_on_posting_date(kwargs, ignore_serial_nos)
+    ignore_serial_nos = list(set(ignore_serial_nos))
+    if kwargs.get("posting_datetime"):
+        time_based_serial_nos = get_serial_nos_based_on_posting_date(
+            kwargs, ignore_serial_nos
+        )
 
-		if not time_based_serial_nos:
-			return []
+        if not time_based_serial_nos:
+            return []
 
-		for sn in ignore_serial_nos:
-			if sn in time_based_serial_nos:
-				time_based_serial_nos.remove(sn)
+        for sn in ignore_serial_nos:
+            if sn in time_based_serial_nos:
+                time_based_serial_nos.remove(sn)
 
-		filters["name"] = ("in", time_based_serial_nos)
-	elif ignore_serial_nos:
-		filters["name"] = ("not in", ignore_serial_nos)
-	elif kwargs.get("serial_nos"):
-		filters["name"] = ("in", kwargs.get("serial_nos"))
+        filters["name"] = ("in", time_based_serial_nos)
+    elif ignore_serial_nos:
+        filters["name"] = ("not in", ignore_serial_nos)
+    elif kwargs.get("serial_nos"):
+        filters["name"] = ("in", kwargs.get("serial_nos"))
 
-	if kwargs.get("batches"):
-		batches = get_non_expired_batches(kwargs.get("batches"))
-		if not batches:
-			return []
+    if kwargs.get("batches"):
+        batches = get_non_expired_batches(kwargs.get("batches"))
+        if not batches:
+            return []
 
-		filters["batch_no"] = ("in", batches)
+        filters["batch_no"] = ("in", batches)
 
-	return get_serial_nos_based_on_filters(filters, fields, order_by, kwargs)
+    return get_serial_nos_based_on_filters(filters, fields, order_by, kwargs)
 
 
 def get_serial_nos_based_on_filters(filters, fields, order_by, kwargs):
-	doctype = frappe.qb.DocType("Serial No")
+    doctype = frappe.qb.DocType("Serial No")
 
-	order_by_column = getattr(doctype, order_by)
-	query = frappe.qb.from_(doctype).limit(cint(kwargs.qty) or 10000000).for_update()
+    order_by_column = getattr(doctype, order_by)
+    query = frappe.qb.from_(doctype).limit(cint(kwargs.qty) or 10000000).for_update()
 
-	if kwargs.based_on == "LIFO":
-		query = query.orderby(order_by_column, order=frappe.query_builder.Order.desc)
-	else:
-		query = query.orderby(order_by_column)
+    if kwargs.based_on == "LIFO":
+        query = query.orderby(order_by_column, order=frappe.query_builder.Order.desc)
+    else:
+        query = query.orderby(order_by_column)
 
-	for key, value in filters.items():
-		column = getattr(doctype, key)
+    for key, value in filters.items():
+        column = getattr(doctype, key)
 
-		if isinstance(value, tuple):
-			operator = value[0]
+        if isinstance(value, tuple):
+            operator = value[0]
 
-			if operator == "between":
-				query = query.where(column.between(value[1], value[2]))
+            if operator == "between":
+                query = query.where(column.between(value[1], value[2]))
 
-			elif operator == "in":
-				query = query.where(column.isin(value[1]))
+            elif operator == "in":
+                query = query.where(column.isin(value[1]))
 
-			elif operator == "not in":
-				query = query.where(column.notin(value[1]))
+            elif operator == "not in":
+                query = query.where(column.notin(value[1]))
 
-			elif operator == "is":
-				if value[1] == "set":
-					query = query.where(column.isnotnull())
-				elif value[1] == "not set":
-					query = query.where(column.isnull())
-		else:
-			query = query.where(column == value)
+            elif operator == "is":
+                if value[1] == "set":
+                    query = query.where(column.isnotnull())
+                elif value[1] == "not set":
+                    query = query.where(column.isnull())
+        else:
+            query = query.where(column == value)
 
-	for field in fields:
-		if " as " in field.lower():
-			# Split field and alias
-			field_name, alias = field.split(" as ", 1)
-			query = query.select(getattr(doctype, field_name).as_(alias))
-		else:
-			query = query.select(getattr(doctype, field))
+    for field in fields:
+        if " as " in field.lower():
+            # Split field and alias
+            field_name, alias = field.split(" as ", 1)
+            query = query.select(getattr(doctype, field_name).as_(alias))
+        else:
+            query = query.select(getattr(doctype, field))
 
-	return query.run(as_dict=True)
+    return query.run(as_dict=True)
 
 
 def get_serial_nos_from_sre(kwargs):
-	table = frappe.qb.DocType("Stock Reservation Entry")
-	child_table = frappe.qb.DocType("Serial and Batch Entry")
-	query = (
-		frappe.qb.from_(table)
-		.join(child_table)
-		.on(table.name == child_table.parent)
-		.select(child_table.serial_no, child_table.batch_no, child_table.warehouse)
-		.where(
-			(table.docstatus == 1)
-			& (table.voucher_detail_no == kwargs.scio_detail)
-			& (child_table.qty != child_table.delivered_qty)
-		)
-		.limit(cint(kwargs.qty) or 10000000)
-	)
-	if kwargs.based_on == "LIFO":
-		query = query.orderby(child_table.creation, order=frappe.query_builder.Order.desc)
-	else:
-		query = query.orderby(child_table.creation)
-	return query.run(as_dict=True)
+    table = frappe.qb.DocType("Stock Reservation Entry")
+    child_table = frappe.qb.DocType("Serial and Batch Entry")
+    query = (
+        frappe.qb.from_(table)
+        .join(child_table)
+        .on(table.name == child_table.parent)
+        .select(child_table.serial_no, child_table.batch_no, child_table.warehouse)
+        .where(
+            (table.docstatus == 1)
+            & (table.voucher_detail_no == kwargs.scio_detail)
+            & (child_table.qty != child_table.delivered_qty)
+        )
+        .limit(cint(kwargs.qty) or 10000000)
+    )
+    if kwargs.based_on == "LIFO":
+        query = query.orderby(
+            child_table.creation, order=frappe.query_builder.Order.desc
+        )
+    else:
+        query = query.orderby(child_table.creation)
+    return query.run(as_dict=True)
 
 
 def get_non_expired_batches(batches):
-	filters = {}
-	if isinstance(batches, list):
-		filters["name"] = ("in", batches)
-	else:
-		filters["name"] = batches
+    filters = {}
+    if isinstance(batches, list):
+        filters["name"] = ("in", batches)
+    else:
+        filters["name"] = batches
 
-	data = frappe.get_all(
-		"Batch",
-		filters=filters,
-		or_filters=[["expiry_date", ">=", today()], ["expiry_date", "is", "not set"]],
-		fields=["name"],
-	)
+    data = frappe.get_all(
+        "Batch",
+        filters=filters,
+        or_filters=[["expiry_date", ">=", today()], ["expiry_date", "is", "not set"]],
+        fields=["name"],
+    )
 
-	return [d.name for d in data] if data else []
+    return [d.name for d in data] if data else []
 
 
 def get_serial_nos_based_on_posting_date(kwargs, ignore_serial_nos):
-	serial_nos = set()
-	data = get_stock_ledgers_for_serial_nos(kwargs)
+    serial_nos = set()
+    data = get_stock_ledgers_for_serial_nos(kwargs)
 
-	bundle_wise_serial_nos = get_bundle_wise_serial_nos(data, kwargs)
-	for d in data:
-		if d.serial_and_batch_bundle:
-			if sns := bundle_wise_serial_nos.get(d.serial_and_batch_bundle):
-				if d.actual_qty > 0:
-					serial_nos.update(sns)
-				else:
-					serial_nos.difference_update(sns)
+    bundle_wise_serial_nos = get_bundle_wise_serial_nos(data, kwargs)
+    for d in data:
+        if d.serial_and_batch_bundle:
+            if sns := bundle_wise_serial_nos.get(d.serial_and_batch_bundle):
+                if d.actual_qty > 0:
+                    serial_nos.update(sns)
+                else:
+                    serial_nos.difference_update(sns)
 
-		elif d.serial_no:
-			sns = parse_serial_nos(d.serial_no)
-			if d.actual_qty > 0:
-				serial_nos.update(sns)
-			else:
-				serial_nos.difference_update(sns)
+        elif d.serial_no:
+            sns = parse_serial_nos(d.serial_no)
+            if d.actual_qty > 0:
+                serial_nos.update(sns)
+            else:
+                serial_nos.difference_update(sns)
 
-	serial_nos = list(serial_nos)
+    serial_nos = list(serial_nos)
 
-	for serial_no in ignore_serial_nos:
-		if serial_no in serial_nos:
-			serial_nos.remove(serial_no)
+    for serial_no in ignore_serial_nos:
+        if serial_no in serial_nos:
+            serial_nos.remove(serial_no)
 
-	return serial_nos
+    return serial_nos
 
 
 def get_bundle_wise_serial_nos(data, kwargs):
-	bundle_wise_serial_nos = defaultdict(list)
-	bundles = [d.serial_and_batch_bundle for d in data if d.serial_and_batch_bundle]
-	if not bundles:
-		return bundle_wise_serial_nos
+    bundle_wise_serial_nos = defaultdict(list)
+    bundles = [d.serial_and_batch_bundle for d in data if d.serial_and_batch_bundle]
+    if not bundles:
+        return bundle_wise_serial_nos
 
-	filters = {"parent": ("in", bundles), "docstatus": 1, "serial_no": ("is", "set")}
+    filters = {"parent": ("in", bundles), "docstatus": 1, "serial_no": ("is", "set")}
 
-	if kwargs.get("check_serial_nos") and kwargs.get("serial_nos"):
-		filters["serial_no"] = ("in", kwargs.get("serial_nos"))
+    if kwargs.get("check_serial_nos") and kwargs.get("serial_nos"):
+        filters["serial_no"] = ("in", kwargs.get("serial_nos"))
 
-	bundle_data = frappe.get_all(
-		"Serial and Batch Entry",
-		fields=["serial_no", "parent"],
-		filters=filters,
-	)
+    bundle_data = frappe.get_all(
+        "Serial and Batch Entry",
+        fields=["serial_no", "parent"],
+        filters=filters,
+    )
 
-	for d in bundle_data:
-		if d.parent:
-			bundle_wise_serial_nos[d.parent].append(d.serial_no)
+    for d in bundle_data:
+        if d.parent:
+            bundle_wise_serial_nos[d.parent].append(d.serial_no)
 
-	return bundle_wise_serial_nos
+    return bundle_wise_serial_nos
 
 
 def get_reserved_voucher_details(kwargs):
-	reserved_voucher_details = []
+    reserved_voucher_details = []
 
-	field_mapper = {
-		"Delivery Note": [["Delivery Note Item", "against_sales_order"]],
-		"Stock Entry": [["Stock Entry", "work_order"], ["Stock Entry", "subcontracting_inward_order"]],
-		"Work Order": [["Work Order", "production_plan"], ["Work Order", "subcontracting_inward_order"]],
-	}.get(kwargs.get("sabb_voucher_type"))
+    field_mapper = {
+        "Delivery Note": [["Delivery Note Item", "against_sales_order"]],
+        "Stock Entry": [
+            ["Stock Entry", "work_order"],
+            ["Stock Entry", "subcontracting_inward_order"],
+        ],
+        "Work Order": [
+            ["Work Order", "production_plan"],
+            ["Work Order", "subcontracting_inward_order"],
+        ],
+    }.get(kwargs.get("sabb_voucher_type"))
 
-	if not field_mapper or not kwargs.get("sabb_voucher_no"):
-		return reserved_voucher_details
+    if not field_mapper or not kwargs.get("sabb_voucher_no"):
+        return reserved_voucher_details
 
-	voucher_based_filters = {
-		"Delivery Note": {
-			"name": kwargs.get("sabb_voucher_detail_no"),
-			"parent": kwargs.get("sabb_voucher_no"),
-			"docstatus": ("<", 2),
-		},
-		"Stock Entry": {
-			"name": kwargs.get("sabb_voucher_no"),
-			"docstatus": ("<", 2),
-		},
-		"Work Order": {
-			"name": kwargs.get("sabb_voucher_no"),
-			"docstatus": ("<", 2),
-		},
-	}.get(kwargs.get("sabb_voucher_type"))
+    voucher_based_filters = {
+        "Delivery Note": {
+            "name": kwargs.get("sabb_voucher_detail_no"),
+            "parent": kwargs.get("sabb_voucher_no"),
+            "docstatus": ("<", 2),
+        },
+        "Stock Entry": {
+            "name": kwargs.get("sabb_voucher_no"),
+            "docstatus": ("<", 2),
+        },
+        "Work Order": {
+            "name": kwargs.get("sabb_voucher_no"),
+            "docstatus": ("<", 2),
+        },
+    }.get(kwargs.get("sabb_voucher_type"))
 
-	reserved_voucher_details = []
-	for row in field_mapper:
-		reserved_voucher_details.extend(
-			frappe.get_all(
-				row[0],
-				pluck=row[1],
-				filters=voucher_based_filters,
-			)
-		)
+    reserved_voucher_details = []
+    for row in field_mapper:
+        reserved_voucher_details.extend(
+            frappe.get_all(
+                row[0],
+                pluck=row[1],
+                filters=voucher_based_filters,
+            )
+        )
 
-	return reserved_voucher_details
+    return reserved_voucher_details
 
 
 def get_reserved_serial_nos_for_pos(kwargs):
-	from erpnext.controllers.sales_and_purchase_return import get_returned_serial_nos
+    from erpnext.controllers.sales_and_purchase_return import get_returned_serial_nos
 
-	ignore_serial_nos = []
-	pos_invoices = frappe.get_all(
-		"POS Invoice",
-		fields=[
-			"`tabPOS Invoice Item`.serial_no",
-			"`tabPOS Invoice`.is_return",
-			"`tabPOS Invoice Item`.name as child_docname",
-			"`tabPOS Invoice`.name as parent_docname",
-			"`tabPOS Invoice Item`.serial_and_batch_bundle",
-		],
-		filters=[
-			["POS Invoice", "consolidated_invoice", "is", "not set"],
-			["POS Invoice", "docstatus", "=", 1],
-			["POS Invoice", "is_return", "=", 0],
-			["POS Invoice Item", "item_code", "=", kwargs.item_code],
-			["POS Invoice", "name", "not in", kwargs.ignore_voucher_nos],
-		],
-	)
+    ignore_serial_nos = []
+    pos_invoices = frappe.get_all(
+        "POS Invoice",
+        fields=[
+            "`tabPOS Invoice Item`.serial_no",
+            "`tabPOS Invoice`.is_return",
+            "`tabPOS Invoice Item`.name as child_docname",
+            "`tabPOS Invoice`.name as parent_docname",
+            "`tabPOS Invoice Item`.serial_and_batch_bundle",
+        ],
+        filters=[
+            ["POS Invoice", "consolidated_invoice", "is", "not set"],
+            ["POS Invoice", "docstatus", "=", 1],
+            ["POS Invoice", "is_return", "=", 0],
+            ["POS Invoice Item", "item_code", "=", kwargs.item_code],
+            ["POS Invoice", "name", "not in", kwargs.ignore_voucher_nos],
+        ],
+    )
 
-	ids = [
-		pos_invoice.serial_and_batch_bundle
-		for pos_invoice in pos_invoices
-		if pos_invoice.serial_and_batch_bundle
-	]
+    ids = [
+        pos_invoice.serial_and_batch_bundle
+        for pos_invoice in pos_invoices
+        if pos_invoice.serial_and_batch_bundle
+    ]
 
-	if not ids:
-		return []
+    if not ids:
+        return []
 
-	for d in get_serial_batch_ledgers(kwargs.item_code, docstatus=1, name=ids):
-		ignore_serial_nos.append(d.serial_no)
+    for d in get_serial_batch_ledgers(kwargs.item_code, docstatus=1, name=ids):
+        ignore_serial_nos.append(d.serial_no)
 
-	returned_serial_nos = []
-	for pos_invoice in pos_invoices:
-		if pos_invoice.serial_no:
-			ignore_serial_nos.extend(parse_serial_nos(pos_invoice.serial_no))
+    returned_serial_nos = []
+    for pos_invoice in pos_invoices:
+        if pos_invoice.serial_no:
+            ignore_serial_nos.extend(parse_serial_nos(pos_invoice.serial_no))
 
-		if pos_invoice.is_return:
-			continue
+        if pos_invoice.is_return:
+            continue
 
-		child_doc = _dict(
-			{
-				"doctype": "POS Invoice Item",
-				"name": pos_invoice.child_docname,
-			}
-		)
+        child_doc = _dict(
+            {
+                "doctype": "POS Invoice Item",
+                "name": pos_invoice.child_docname,
+            }
+        )
 
-		parent_doc = _dict(
-			{
-				"doctype": "POS Invoice",
-				"name": pos_invoice.parent_docname,
-			}
-		)
+        parent_doc = _dict(
+            {
+                "doctype": "POS Invoice",
+                "name": pos_invoice.parent_docname,
+            }
+        )
 
-		returned_serial_nos.extend(
-			get_returned_serial_nos(
-				child_doc, parent_doc, ignore_voucher_detail_no=kwargs.get("ignore_voucher_detail_no")
-			)
-		)
-	# Counter is used to create a hashmap of serial nos, which contains count of each serial no
-	# so we subtract returned serial nos from ignore serial nos after creating a counter of each to get the items which we need 	to ignore(which are sold)
+        returned_serial_nos.extend(
+            get_returned_serial_nos(
+                child_doc,
+                parent_doc,
+                ignore_voucher_detail_no=kwargs.get("ignore_voucher_detail_no"),
+            )
+        )
+    # Counter is used to create a hashmap of serial nos, which contains count of each serial no
+    # so we subtract returned serial nos from ignore serial nos after creating a counter of each to get the items which we need 	to ignore(which are sold)
 
-	ignore_serial_nos_counter = Counter(ignore_serial_nos)
-	returned_serial_nos_counter = Counter(returned_serial_nos)
+    ignore_serial_nos_counter = Counter(ignore_serial_nos)
+    returned_serial_nos_counter = Counter(returned_serial_nos)
 
-	return list(ignore_serial_nos_counter - returned_serial_nos_counter)
+    return list(ignore_serial_nos_counter - returned_serial_nos_counter)
 
 
-def get_reserved_serial_nos_for_voucher(kwargs, reserved_entries, reserved_voucher_details):
-	serial_nos = []
-	if not kwargs.get("pick_reserved_items"):
-		return serial_nos
+def get_reserved_serial_nos_for_voucher(
+    kwargs, reserved_entries, reserved_voucher_details
+):
+    serial_nos = []
+    if not kwargs.get("pick_reserved_items"):
+        return serial_nos
 
-	for entry in reserved_entries:
-		if entry.voucher_no in reserved_voucher_details:
-			serial_nos.append(entry.serial_no)
-			continue
+    for entry in reserved_entries:
+        if entry.voucher_no in reserved_voucher_details:
+            serial_nos.append(entry.serial_no)
+            continue
 
-		if kwargs.get("serial_nos") and entry.serial_no in kwargs.get("serial_nos"):
-			frappe.throw(
-				_(
-					"The Serial No {0} is reserved against the {1} {2} and cannot be used for any other transaction."
-				).format(bold(entry.serial_no), entry.voucher_type, bold(entry.voucher_no)),
-				title=_("Serial No Reserved"),
-			)
+        if kwargs.get("serial_nos") and entry.serial_no in kwargs.get("serial_nos"):
+            frappe.throw(
+                _(
+                    "The Serial No {0} is reserved against the {1} {2} and cannot be used for any other transaction."
+                ).format(
+                    bold(entry.serial_no), entry.voucher_type, bold(entry.voucher_no)
+                ),
+                title=_("Serial No Reserved"),
+            )
 
-	return serial_nos
+    return serial_nos
 
 
 def get_other_doc_reserved_serials(kwargs, reserved_entries, reserved_voucher_details):
-	serial_nos = []
-	for entry in reserved_entries:
-		if entry.voucher_no in reserved_voucher_details:
-			continue
+    serial_nos = []
+    for entry in reserved_entries:
+        if entry.voucher_no in reserved_voucher_details:
+            continue
 
-		serial_nos.append(entry.serial_no)
+        serial_nos.append(entry.serial_no)
 
-	return serial_nos
+    return serial_nos
 
 
 def get_reserved_serial_nos_for_sre(kwargs) -> list:
-	"""Returns a list of `Serial No` reserved in Stock Reservation Entry."""
+    """Returns a list of `Serial No` reserved in Stock Reservation Entry."""
 
-	sre = frappe.qb.DocType("Stock Reservation Entry")
-	sb_entry = frappe.qb.DocType("Serial and Batch Entry")
-	query = (
-		frappe.qb.from_(sre)
-		.inner_join(sb_entry)
-		.on(sre.name == sb_entry.parent)
-		.select(
-			sb_entry.serial_no,
-			sre.voucher_no,
-			sre.voucher_type,
-		)
-		.where(
-			(sre.docstatus == 1)
-			& (sre.item_code == kwargs.item_code)
-			& (sre.delivered_qty < sre.reserved_qty)
-			& (sb_entry.delivered_qty < sb_entry.qty)
-			& (sre.reservation_based_on == "Serial and Batch")
-		)
-		.orderby(sb_entry.idx)
-	)
+    sre = frappe.qb.DocType("Stock Reservation Entry")
+    sb_entry = frappe.qb.DocType("Serial and Batch Entry")
+    query = (
+        frappe.qb.from_(sre)
+        .inner_join(sb_entry)
+        .on(sre.name == sb_entry.parent)
+        .select(
+            sb_entry.serial_no,
+            sre.voucher_no,
+            sre.voucher_type,
+        )
+        .where(
+            (sre.docstatus == 1)
+            & (sre.item_code == kwargs.item_code)
+            & (sre.delivered_qty < sre.reserved_qty)
+            & (sb_entry.delivered_qty < sb_entry.qty)
+            & (sre.reservation_based_on == "Serial and Batch")
+        )
+        .orderby(sb_entry.idx)
+    )
 
-	if kwargs.warehouse:
-		query = query.where(sre.warehouse == kwargs.warehouse)
+    if kwargs.warehouse:
+        query = query.where(sre.warehouse == kwargs.warehouse)
 
-	if kwargs.ignore_voucher_nos:
-		query = query.where(sre.name.notin(kwargs.ignore_voucher_nos))
+    if kwargs.ignore_voucher_nos:
+        query = query.where(sre.name.notin(kwargs.ignore_voucher_nos))
 
-	return query.run(as_dict=True)
+    return query.run(as_dict=True)
 
 
-def get_serial_no_reservation(item_code: str, serial_no: str, warehouse: str) -> _dict | None:
-	"""Returns the Stock Reservation Entry that has reserved the given serial number, if any."""
+def get_serial_no_reservation(
+    item_code: str, serial_no: str, warehouse: str
+) -> _dict | None:
+    """Returns the Stock Reservation Entry that has reserved the given serial number, if any."""
 
-	sre = frappe.qb.DocType("Stock Reservation Entry")
-	sb_entry = frappe.qb.DocType("Serial and Batch Entry")
-	result = (
-		frappe.qb.from_(sre)
-		.inner_join(sb_entry)
-		.on(sre.name == sb_entry.parent)
-		.select(sre.name, sre.voucher_type, sre.voucher_no)
-		.where(
-			(sre.docstatus == 1)
-			& (sre.item_code == item_code)
-			& (sre.warehouse == warehouse)
-			& (sre.status.notin(["Delivered", "Cancelled", "Closed"]))
-			& (sre.reservation_based_on == "Serial and Batch")
-			& (sb_entry.serial_no == serial_no)
-			& (sb_entry.qty != sb_entry.delivered_qty)
-		)
-		.limit(1)
-		.run(as_dict=True)
-	)
+    sre = frappe.qb.DocType("Stock Reservation Entry")
+    sb_entry = frappe.qb.DocType("Serial and Batch Entry")
+    result = (
+        frappe.qb.from_(sre)
+        .inner_join(sb_entry)
+        .on(sre.name == sb_entry.parent)
+        .select(sre.name, sre.voucher_type, sre.voucher_no)
+        .where(
+            (sre.docstatus == 1)
+            & (sre.item_code == item_code)
+            & (sre.warehouse == warehouse)
+            & (sre.status.notin(["Delivered", "Cancelled", "Closed"]))
+            & (sre.reservation_based_on == "Serial and Batch")
+            & (sb_entry.serial_no == serial_no)
+            & (sb_entry.qty != sb_entry.delivered_qty)
+        )
+        .limit(1)
+        .run(as_dict=True)
+    )
 
-	return result[0] if result else None
+    return result[0] if result else None
 
 
 def get_reserved_batches_for_pos(kwargs) -> dict:
-	"""Returns a dict of `Batch No` followed by the `Qty` reserved in POS Invoices."""
+    """Returns a dict of `Batch No` followed by the `Qty` reserved in POS Invoices."""
 
-	pos_batches = frappe._dict()
-	POS_Invoice = frappe.qb.DocType("POS Invoice")
-	POS_Invoice_Item = frappe.qb.DocType("POS Invoice Item")
+    pos_batches = frappe._dict()
+    POS_Invoice = frappe.qb.DocType("POS Invoice")
+    POS_Invoice_Item = frappe.qb.DocType("POS Invoice Item")
 
-	pos_invoices = (
-		frappe.qb.from_(POS_Invoice)
-		.inner_join(POS_Invoice_Item)
-		.on(POS_Invoice.name == POS_Invoice_Item.parent)
-		.select(
-			POS_Invoice_Item.batch_no,
-			POS_Invoice_Item.qty,
-			POS_Invoice.is_return,
-			POS_Invoice_Item.warehouse,
-			POS_Invoice_Item.name.as_("child_docname"),
-			POS_Invoice.name.as_("parent_docname"),
-			POS_Invoice_Item.use_serial_batch_fields,
-			POS_Invoice_Item.serial_and_batch_bundle,
-		)
-		.where(
-			(POS_Invoice.consolidated_invoice.isnull())
-			& (POS_Invoice.docstatus == 1)
-			& (POS_Invoice_Item.item_code == kwargs.item_code)
-		)
-	)
+    pos_invoices = (
+        frappe.qb.from_(POS_Invoice)
+        .inner_join(POS_Invoice_Item)
+        .on(POS_Invoice.name == POS_Invoice_Item.parent)
+        .select(
+            POS_Invoice_Item.batch_no,
+            POS_Invoice_Item.qty,
+            POS_Invoice.is_return,
+            POS_Invoice_Item.warehouse,
+            POS_Invoice_Item.name.as_("child_docname"),
+            POS_Invoice.name.as_("parent_docname"),
+            POS_Invoice_Item.use_serial_batch_fields,
+            POS_Invoice_Item.serial_and_batch_bundle,
+        )
+        .where(
+            (POS_Invoice.consolidated_invoice.isnull())
+            & (POS_Invoice.docstatus == 1)
+            & (POS_Invoice_Item.item_code == kwargs.item_code)
+        )
+    )
 
-	if kwargs.get("company"):
-		pos_invoices = pos_invoices.where(POS_Invoice.company == kwargs.get("company"))
+    if kwargs.get("company"):
+        pos_invoices = pos_invoices.where(POS_Invoice.company == kwargs.get("company"))
 
-	if kwargs.get("ignore_voucher_nos"):
-		pos_invoices = pos_invoices.where(POS_Invoice.name.notin(kwargs.get("ignore_voucher_nos")))
+    if kwargs.get("ignore_voucher_nos"):
+        pos_invoices = pos_invoices.where(
+            POS_Invoice.name.notin(kwargs.get("ignore_voucher_nos"))
+        )
 
-	pos_invoices = pos_invoices.run(as_dict=True)
+    pos_invoices = pos_invoices.run(as_dict=True)
 
-	ids = [
-		pos_invoice.serial_and_batch_bundle
-		for pos_invoice in pos_invoices
-		if pos_invoice.serial_and_batch_bundle and not pos_invoice.use_serial_batch_fields
-	]
+    ids = [
+        pos_invoice.serial_and_batch_bundle
+        for pos_invoice in pos_invoices
+        if pos_invoice.serial_and_batch_bundle
+        and not pos_invoice.use_serial_batch_fields
+    ]
 
-	if ids:
-		for d in get_serial_batch_ledgers(kwargs.item_code, docstatus=1, name=ids):
-			key = (d.batch_no, d.warehouse)
-			if key not in pos_batches:
-				pos_batches[key] = frappe._dict(
-					{
-						"qty": d.qty,
-						"warehouse": d.warehouse,
-					}
-				)
-			else:
-				pos_batches[key].qty += d.qty
+    if ids:
+        for d in get_serial_batch_ledgers(kwargs.item_code, docstatus=1, name=ids):
+            key = (d.batch_no, d.warehouse)
+            if key not in pos_batches:
+                pos_batches[key] = frappe._dict(
+                    {
+                        "qty": d.qty,
+                        "warehouse": d.warehouse,
+                    }
+                )
+            else:
+                pos_batches[key].qty += d.qty
 
-	# POS invoices having batch without bundle (to handle old POS invoices)
-	for row in pos_invoices:
-		if not row.batch_no:
-			continue
+    # POS invoices having batch without bundle (to handle old POS invoices)
+    for row in pos_invoices:
+        if not row.batch_no:
+            continue
 
-		if kwargs.get("batch_no") and row.batch_no != kwargs.get("batch_no"):
-			continue
+        if kwargs.get("batch_no") and row.batch_no != kwargs.get("batch_no"):
+            continue
 
-		key = (row.batch_no, row.warehouse)
-		if key in pos_batches:
-			pos_batches[key]["qty"] += row.qty * -1
-		else:
-			pos_batches[key] = frappe._dict(
-				{
-					"qty": row.qty * -1,
-					"warehouse": row.warehouse,
-				}
-			)
+        key = (row.batch_no, row.warehouse)
+        if key in pos_batches:
+            pos_batches[key]["qty"] += row.qty * -1
+        else:
+            pos_batches[key] = frappe._dict(
+                {
+                    "qty": row.qty * -1,
+                    "warehouse": row.warehouse,
+                }
+            )
 
-	return pos_batches
+    return pos_batches
 
 
 def get_reserved_batches_for_sre(kwargs) -> dict:
-	"""Returns a dict of `Batch No` followed by the `Qty` reserved in Stock Reservation Entry."""
+    """Returns a dict of `Batch No` followed by the `Qty` reserved in Stock Reservation Entry."""
 
-	sre = frappe.qb.DocType("Stock Reservation Entry")
-	sb_entry = frappe.qb.DocType("Serial and Batch Entry")
-	query = (
-		frappe.qb.from_(sre)
-		.inner_join(sb_entry)
-		.on(sre.name == sb_entry.parent)
-		.select(
-			sb_entry.batch_no, sre.warehouse, (-1 * Sum(sb_entry.qty - sb_entry.delivered_qty)).as_("qty")
-		)
-		.where(
-			(sre.docstatus == 1)
-			& (sre.item_code == kwargs.item_code)
-			& (sre.delivered_qty < sre.reserved_qty)
-			& (sre.reservation_based_on == "Serial and Batch")
-		)
-		.groupby(sb_entry.batch_no, sre.warehouse)
-	)
+    sre = frappe.qb.DocType("Stock Reservation Entry")
+    sb_entry = frappe.qb.DocType("Serial and Batch Entry")
+    query = (
+        frappe.qb.from_(sre)
+        .inner_join(sb_entry)
+        .on(sre.name == sb_entry.parent)
+        .select(
+            sb_entry.batch_no,
+            sre.warehouse,
+            (-1 * Sum(sb_entry.qty - sb_entry.delivered_qty)).as_("qty"),
+        )
+        .where(
+            (sre.docstatus == 1)
+            & (sre.item_code == kwargs.item_code)
+            & (sre.delivered_qty < sre.reserved_qty)
+            & (sre.reservation_based_on == "Serial and Batch")
+        )
+        .groupby(sb_entry.batch_no, sre.warehouse)
+    )
 
-	if kwargs.get("company"):
-		query = query.where(sre.company == kwargs.get("company"))
+    if kwargs.get("company"):
+        query = query.where(sre.company == kwargs.get("company"))
 
-	if kwargs.batch_no:
-		if isinstance(kwargs.batch_no, list):
-			query = query.where(sb_entry.batch_no.isin(kwargs.batch_no))
-		else:
-			query = query.where(sb_entry.batch_no == kwargs.batch_no)
+    if kwargs.batch_no:
+        if isinstance(kwargs.batch_no, list):
+            query = query.where(sb_entry.batch_no.isin(kwargs.batch_no))
+        else:
+            query = query.where(sb_entry.batch_no == kwargs.batch_no)
 
-	if kwargs.warehouse:
-		if isinstance(kwargs.warehouse, list):
-			query = query.where(sre.warehouse.isin(kwargs.warehouse))
-		else:
-			query = query.where(sre.warehouse == kwargs.warehouse)
+    if kwargs.warehouse:
+        if isinstance(kwargs.warehouse, list):
+            query = query.where(sre.warehouse.isin(kwargs.warehouse))
+        else:
+            query = query.where(sre.warehouse == kwargs.warehouse)
 
-	if kwargs.ignore_voucher_nos:
-		query = query.where(sre.name.notin(kwargs.ignore_voucher_nos))
+    if kwargs.ignore_voucher_nos:
+        query = query.where(sre.name.notin(kwargs.ignore_voucher_nos))
 
-	data = query.run(as_dict=True)
+    data = query.run(as_dict=True)
 
-	reserved_batches_details = frappe._dict()
-	if data:
-		reserved_batches_details = frappe._dict(
-			{(d.batch_no, d.warehouse): frappe._dict({"warehouse": d.warehouse, "qty": d.qty}) for d in data}
-		)
+    reserved_batches_details = frappe._dict()
+    if data:
+        reserved_batches_details = frappe._dict(
+            {
+                (d.batch_no, d.warehouse): frappe._dict(
+                    {"warehouse": d.warehouse, "qty": d.qty}
+                )
+                for d in data
+            }
+        )
 
-	return reserved_batches_details
+    return reserved_batches_details
 
 
 def get_auto_batch_nos(kwargs):
-	if kwargs.against_sales_order and (
-		only_consider_batches := get_batches_to_be_considered(kwargs.against_sales_order)
-	):
-		batches, warehouses = [], []
-		for item in only_consider_batches:
-			batches.append(item.batch_no)
-			warehouses.append(item.warehouse)
+    if kwargs.against_sales_order and (
+        only_consider_batches := get_batches_to_be_considered(
+            kwargs.against_sales_order
+        )
+    ):
+        batches, warehouses = [], []
+        for item in only_consider_batches:
+            batches.append(item.batch_no)
+            warehouses.append(item.warehouse)
 
-		if batches:
-			kwargs.batch_no = batches
-			kwargs.warehouse = warehouses
+        if batches:
+            kwargs.batch_no = batches
+            kwargs.warehouse = warehouses
 
-	if not kwargs.get("posting_datetime") and kwargs.get("posting_date"):
-		kwargs["posting_datetime"] = combine_datetime(kwargs.get("posting_date"), kwargs.get("posting_time"))
+    if not kwargs.get("posting_datetime") and kwargs.get("posting_date"):
+        kwargs["posting_datetime"] = combine_datetime(
+            kwargs.get("posting_date"), kwargs.get("posting_time")
+        )
 
-	available_batches = get_available_batches(kwargs)
-	stock_ledgers_batches = get_stock_ledgers_batches(kwargs)
+    available_batches = get_available_batches(kwargs)
+    stock_ledgers_batches = get_stock_ledgers_batches(kwargs)
 
-	pos_invoice_batches = frappe._dict()
-	if not kwargs.for_stock_levels:
-		pos_invoice_batches = get_reserved_batches_for_pos(kwargs)
+    pos_invoice_batches = frappe._dict()
+    if not kwargs.for_stock_levels:
+        pos_invoice_batches = get_reserved_batches_for_pos(kwargs)
 
-	sre_reserved_batches = frappe._dict()
-	if not kwargs.ignore_reserved_stock:
-		sre_reserved_batches = get_reserved_batches_for_sre(kwargs)
+    sre_reserved_batches = frappe._dict()
+    if not kwargs.ignore_reserved_stock:
+        sre_reserved_batches = get_reserved_batches_for_sre(kwargs)
 
-	if kwargs.against_sales_order and only_consider_batches:
-		kwargs.batch_no = kwargs.warehouse = None
+    if kwargs.against_sales_order and only_consider_batches:
+        kwargs.batch_no = kwargs.warehouse = None
 
-	picked_batches = frappe._dict()
-	if kwargs.get("is_pick_list"):
-		picked_batches = get_picked_batches(kwargs)
+    picked_batches = frappe._dict()
+    if kwargs.get("is_pick_list"):
+        picked_batches = get_picked_batches(kwargs)
 
-	if stock_ledgers_batches or pos_invoice_batches or sre_reserved_batches or picked_batches:
-		update_available_batches(
-			available_batches,
-			stock_ledgers_batches,
-			pos_invoice_batches,
-			sre_reserved_batches,
-			picked_batches,
-		)
+    if (
+        stock_ledgers_batches
+        or pos_invoice_batches
+        or sre_reserved_batches
+        or picked_batches
+    ):
+        update_available_batches(
+            available_batches,
+            stock_ledgers_batches,
+            pos_invoice_batches,
+            sre_reserved_batches,
+            picked_batches,
+        )
 
-	if kwargs.based_on == "Expiry":
-		available_batches = sorted(available_batches, key=lambda x: x.expiry_date or getdate("9999-12-31"))
+    if kwargs.based_on == "Expiry":
+        available_batches = sorted(
+            available_batches, key=lambda x: x.expiry_date or getdate("9999-12-31")
+        )
 
-	if not kwargs.get("do_not_check_future_batches") and available_batches and kwargs.get("posting_datetime"):
-		filter_zero_near_batches(available_batches, kwargs)
+    if (
+        not kwargs.get("do_not_check_future_batches")
+        and available_batches
+        and kwargs.get("posting_datetime")
+    ):
+        filter_zero_near_batches(available_batches, kwargs)
 
-	if not kwargs.consider_negative_batches:
-		precision = frappe.get_precision("Stock Ledger Entry", "actual_qty")
-		available_batches = [d for d in available_batches if flt(d.qty, precision) > 0]
+    if not kwargs.consider_negative_batches:
+        precision = frappe.get_precision("Stock Ledger Entry", "actual_qty")
+        available_batches = [d for d in available_batches if flt(d.qty, precision) > 0]
 
-	qty = flt(kwargs.qty)
+    qty = flt(kwargs.qty)
 
-	if not qty:
-		return available_batches
+    if not qty:
+        return available_batches
 
-	return get_qty_based_available_batches(available_batches, qty)
+    return get_qty_based_available_batches(available_batches, qty)
 
 
 def get_batch_nos_from_sre(kwargs):
-	from frappe.query_builder.functions import Sum
+    from frappe.query_builder.functions import Sum
 
-	table = frappe.qb.DocType("Stock Reservation Entry")
-	child_table = frappe.qb.DocType("Serial and Batch Entry")
+    table = frappe.qb.DocType("Stock Reservation Entry")
+    child_table = frappe.qb.DocType("Serial and Batch Entry")
 
-	query = (
-		frappe.qb.from_(table)
-		.join(child_table)
-		.on(table.name == child_table.parent)
-		.select(
-			child_table.batch_no,
-			child_table.warehouse,
-			Sum(child_table.qty - child_table.delivered_qty).as_("qty"),
-		)
-		.where(
-			(table.docstatus == 1)
-			& (table.voucher_detail_no == kwargs.scio_detail)
-			& (child_table.qty != child_table.delivered_qty)
-		)
-		.groupby(child_table.batch_no, child_table.warehouse)
-		.orderby(child_table.batch_no, order=frappe.query_builder.Order.asc)
-	)
+    query = (
+        frappe.qb.from_(table)
+        .join(child_table)
+        .on(table.name == child_table.parent)
+        .select(
+            child_table.batch_no,
+            child_table.warehouse,
+            Sum(child_table.qty - child_table.delivered_qty).as_("qty"),
+        )
+        .where(
+            (table.docstatus == 1)
+            & (table.voucher_detail_no == kwargs.scio_detail)
+            & (child_table.qty != child_table.delivered_qty)
+        )
+        .groupby(child_table.batch_no, child_table.warehouse)
+        .orderby(child_table.batch_no, order=frappe.query_builder.Order.asc)
+    )
 
-	result = query.run(as_dict=True)
-	return get_qty_based_available_batches(result, flt(kwargs.qty)) if flt(kwargs.qty) else result
+    result = query.run(as_dict=True)
+    return (
+        get_qty_based_available_batches(result, flt(kwargs.qty))
+        if flt(kwargs.qty)
+        else result
+    )
 
 
 def get_batches_to_be_considered(sales_order_name):
-	parent = frappe.qb.DocType("Stock Reservation Entry")
-	child = frappe.qb.DocType("Serial and Batch Entry")
+    parent = frappe.qb.DocType("Stock Reservation Entry")
+    child = frappe.qb.DocType("Serial and Batch Entry")
 
-	query = (
-		frappe.qb.from_(parent)
-		.join(child)
-		.on(parent.name == child.parent)
-		.select(child.batch_no, child.warehouse)
-		.distinct()
-		.where(
-			(parent.docstatus == 1)
-			& (parent.voucher_no == sales_order_name)
-			& (child.delivered_qty < child.qty)
-		)
-	)
-	return query.run(as_dict=True)
+    query = (
+        frappe.qb.from_(parent)
+        .join(child)
+        .on(parent.name == child.parent)
+        .select(child.batch_no, child.warehouse)
+        .distinct()
+        .where(
+            (parent.docstatus == 1)
+            & (parent.voucher_no == sales_order_name)
+            & (child.delivered_qty < child.qty)
+        )
+    )
+    return query.run(as_dict=True)
 
 
 def filter_zero_near_batches(available_batches, kwargs):
-	kwargs.batch_no = [d.batch_no for d in available_batches]
+    kwargs.batch_no = [d.batch_no for d in available_batches]
 
-	del kwargs["posting_datetime"]
+    del kwargs["posting_datetime"]
 
-	kwargs.do_not_check_future_batches = 1
-	available_batches_in_future = get_auto_batch_nos(kwargs)
-	for batch in available_batches:
-		if batch.qty <= 0:
-			continue
+    kwargs.do_not_check_future_batches = 1
+    available_batches_in_future = get_auto_batch_nos(kwargs)
+    for batch in available_batches:
+        if batch.qty <= 0:
+            continue
 
-		for future_batch in available_batches_in_future:
-			if (
-				batch.batch_no == future_batch.batch_no
-				and batch.warehouse == future_batch.warehouse
-				and future_batch.qty <= 0
-			):
-				batch.qty = 0
+        for future_batch in available_batches_in_future:
+            if (
+                batch.batch_no == future_batch.batch_no
+                and batch.warehouse == future_batch.warehouse
+                and future_batch.qty <= 0
+            ):
+                batch.qty = 0
 
 
 def get_qty_based_available_batches(available_batches, qty):
-	batches = []
-	for batch in available_batches:
-		if qty <= 0:
-			break
+    batches = []
+    for batch in available_batches:
+        if qty <= 0:
+            break
 
-		batch_qty = flt(batch.qty)
-		if qty > batch_qty:
-			batches.append(
-				frappe._dict(
-					{
-						"batch_no": batch.batch_no,
-						"qty": batch_qty,
-						"warehouse": batch.warehouse,
-					}
-				)
-			)
-			qty -= batch_qty
-		else:
-			batches.append(
-				frappe._dict(
-					{
-						"batch_no": batch.batch_no,
-						"qty": qty,
-						"warehouse": batch.warehouse,
-					}
-				)
-			)
-			qty = 0
+        batch_qty = flt(batch.qty)
+        if qty > batch_qty:
+            batches.append(
+                frappe._dict(
+                    {
+                        "batch_no": batch.batch_no,
+                        "qty": batch_qty,
+                        "warehouse": batch.warehouse,
+                    }
+                )
+            )
+            qty -= batch_qty
+        else:
+            batches.append(
+                frappe._dict(
+                    {
+                        "batch_no": batch.batch_no,
+                        "qty": qty,
+                        "warehouse": batch.warehouse,
+                    }
+                )
+            )
+            qty = 0
 
-	return batches
+    return batches
 
 
 def update_available_batches(available_batches, *reserved_batches) -> None:
-	for batches in reserved_batches:
-		if batches:
-			for key, data in batches.items():
-				batch_no, warehouse = key
-				batch_not_exists = True
-				for batch in available_batches:
-					if batch.batch_no == batch_no and batch.warehouse == warehouse:
-						batch.qty += data.qty
-						batch_not_exists = False
+    for batches in reserved_batches:
+        if batches:
+            for key, data in batches.items():
+                batch_no, warehouse = key
+                batch_not_exists = True
+                for batch in available_batches:
+                    if batch.batch_no == batch_no and batch.warehouse == warehouse:
+                        batch.qty += data.qty
+                        batch_not_exists = False
 
-				if batch_not_exists:
-					available_batches.append(data)
+                if batch_not_exists:
+                    available_batches.append(data)
 
 
 def get_available_batches(kwargs):
-	stock_ledger_entry = frappe.qb.DocType("Stock Ledger Entry")
-	batch_ledger = frappe.qb.DocType("Serial and Batch Entry")
-	batch_table = frappe.qb.DocType("Batch")
+    stock_ledger_entry = frappe.qb.DocType("Stock Ledger Entry")
+    batch_ledger = frappe.qb.DocType("Serial and Batch Entry")
+    batch_table = frappe.qb.DocType("Batch")
 
-	query = (
-		frappe.qb.from_(stock_ledger_entry)
-		.inner_join(batch_ledger)
-		.on(stock_ledger_entry.serial_and_batch_bundle == batch_ledger.parent)
-		.inner_join(batch_table)
-		.on(batch_ledger.batch_no == batch_table.name)
-		.select(
-			batch_ledger.batch_no,
-			batch_ledger.warehouse,
-			Sum(batch_ledger.qty).as_("qty"),
-			batch_table.expiry_date,
-		)
-		.where(batch_table.disabled == 0)
-		.where(stock_ledger_entry.is_cancelled == 0)
-		.groupby(batch_ledger.batch_no, batch_ledger.warehouse)
-	)
+    query = (
+        frappe.qb.from_(stock_ledger_entry)
+        .inner_join(batch_ledger)
+        .on(stock_ledger_entry.serial_and_batch_bundle == batch_ledger.parent)
+        .inner_join(batch_table)
+        .on(batch_ledger.batch_no == batch_table.name)
+        .select(
+            batch_ledger.batch_no,
+            batch_ledger.warehouse,
+            Sum(batch_ledger.qty).as_("qty"),
+            batch_table.expiry_date,
+        )
+        .where(batch_table.disabled == 0)
+        .where(stock_ledger_entry.is_cancelled == 0)
+        .groupby(batch_ledger.batch_no, batch_ledger.warehouse)
+    )
 
-	if kwargs.get("company"):
-		query = query.where(stock_ledger_entry.company == kwargs.get("company"))
+    if kwargs.get("company"):
+        query = query.where(stock_ledger_entry.company == kwargs.get("company"))
 
-	if not kwargs.get("for_stock_levels"):
-		query = query.where((batch_table.expiry_date >= today()) | (batch_table.expiry_date.isnull()))
+    if not kwargs.get("for_stock_levels"):
+        query = query.where(
+            (batch_table.expiry_date >= today()) | (batch_table.expiry_date.isnull())
+        )
 
-	if kwargs.get("posting_datetime"):
-		timestamp_condition = stock_ledger_entry.posting_datetime <= kwargs.posting_datetime
+    if kwargs.get("posting_datetime"):
+        timestamp_condition = (
+            stock_ledger_entry.posting_datetime <= kwargs.posting_datetime
+        )
 
-		if kwargs.get("creation"):
-			timestamp_condition = stock_ledger_entry.posting_datetime < kwargs.posting_datetime
+        if kwargs.get("creation"):
+            timestamp_condition = (
+                stock_ledger_entry.posting_datetime < kwargs.posting_datetime
+            )
 
-			timestamp_condition |= (stock_ledger_entry.posting_datetime == kwargs.posting_datetime) & (
-				stock_ledger_entry.creation < kwargs.creation
-			)
+            timestamp_condition |= (
+                stock_ledger_entry.posting_datetime == kwargs.posting_datetime
+            ) & (stock_ledger_entry.creation < kwargs.creation)
 
-		query = query.where(timestamp_condition)
+        query = query.where(timestamp_condition)
 
-	for field in ["warehouse", "item_code"]:
-		if not kwargs.get(field):
-			continue
+    for field in ["warehouse", "item_code"]:
+        if not kwargs.get(field):
+            continue
 
-		if isinstance(kwargs.get(field), list):
-			query = query.where(stock_ledger_entry[field].isin(kwargs.get(field)))
-		else:
-			query = query.where(stock_ledger_entry[field] == kwargs.get(field))
+        if isinstance(kwargs.get(field), list):
+            query = query.where(stock_ledger_entry[field].isin(kwargs.get(field)))
+        else:
+            query = query.where(stock_ledger_entry[field] == kwargs.get(field))
 
-	if kwargs.get("batch_no"):
-		if isinstance(kwargs.batch_no, list):
-			query = query.where(batch_ledger.batch_no.isin(kwargs.batch_no))
-		else:
-			query = query.where(batch_ledger.batch_no == kwargs.batch_no)
+    if kwargs.get("batch_no"):
+        if isinstance(kwargs.batch_no, list):
+            query = query.where(batch_ledger.batch_no.isin(kwargs.batch_no))
+        else:
+            query = query.where(batch_ledger.batch_no == kwargs.batch_no)
 
-	if kwargs.based_on == "LIFO":
-		query = query.orderby(batch_table.creation, order=frappe.qb.desc)
-	elif kwargs.based_on == "Expiry":
-		query = query.orderby(batch_table.expiry_date)
-	else:
-		query = query.orderby(batch_table.creation)
+    if kwargs.based_on == "LIFO":
+        query = query.orderby(batch_table.creation, order=frappe.qb.desc)
+    elif kwargs.based_on == "Expiry":
+        query = query.orderby(batch_table.expiry_date)
+    else:
+        query = query.orderby(batch_table.creation)
 
-	if kwargs.get("ignore_voucher_nos"):
-		query = query.where(stock_ledger_entry.voucher_no.notin(kwargs.get("ignore_voucher_nos")))
+    if kwargs.get("ignore_voucher_nos"):
+        query = query.where(
+            stock_ledger_entry.voucher_no.notin(kwargs.get("ignore_voucher_nos"))
+        )
 
-	data = query.run(as_dict=True)
+    data = query.run(as_dict=True)
 
-	return data
+    return data
 
 
 # For work order and subcontracting
 def get_voucher_wise_serial_batch_from_bundle(**kwargs) -> dict[str, dict]:
-	data = get_ledgers_from_serial_batch_bundle(**kwargs)
-	if not data:
-		return {}
+    data = get_ledgers_from_serial_batch_bundle(**kwargs)
+    if not data:
+        return {}
 
-	group_by_voucher = {}
+    group_by_voucher = {}
 
-	for row in data:
-		key = (row.item_code, row.warehouse, row.voucher_no)
-		if kwargs.get("get_subcontracted_item"):
-			# get_subcontracted_item = ("doctype", "field_name")
-			doctype, field_name = kwargs.get("get_subcontracted_item")
+    for row in data:
+        key = (row.item_code, row.warehouse, row.voucher_no)
+        if kwargs.get("get_subcontracted_item"):
+            # get_subcontracted_item = ("doctype", "field_name")
+            doctype, field_name = kwargs.get("get_subcontracted_item")
 
-			subcontracted_item_code = frappe.get_cached_value(doctype, row.voucher_detail_no, field_name)
-			key = (row.item_code, subcontracted_item_code, row.warehouse, row.voucher_no)
+            subcontracted_item_code = frappe.get_cached_value(
+                doctype, row.voucher_detail_no, field_name
+            )
+            key = (
+                row.item_code,
+                subcontracted_item_code,
+                row.warehouse,
+                row.voucher_no,
+            )
 
-		if key not in group_by_voucher:
-			group_by_voucher.setdefault(
-				key,
-				frappe._dict({"serial_nos": [], "batch_nos": defaultdict(float), "item_row": row}),
-			)
+        if key not in group_by_voucher:
+            group_by_voucher.setdefault(
+                key,
+                frappe._dict(
+                    {"serial_nos": [], "batch_nos": defaultdict(float), "item_row": row}
+                ),
+            )
 
-		child_row = group_by_voucher[key]
-		if row.serial_no:
-			child_row["serial_nos"].append(row.serial_no)
-			child_row["item_row"].qty = len(child_row["serial_nos"]) * (
-				-1 if row.type_of_transaction == "Outward" else 1
-			)
+        child_row = group_by_voucher[key]
+        if row.serial_no:
+            child_row["serial_nos"].append(row.serial_no)
+            child_row["item_row"].qty = len(child_row["serial_nos"]) * (
+                -1 if row.type_of_transaction == "Outward" else 1
+            )
 
-		if row.batch_no:
-			child_row["batch_nos"][row.batch_no] += row.qty
+        if row.batch_no:
+            child_row["batch_nos"][row.batch_no] += row.qty
 
-	return group_by_voucher
+    return group_by_voucher
 
 
 def get_picked_batches(kwargs) -> dict[str, dict]:
-	picked_batches = frappe._dict()
+    picked_batches = frappe._dict()
 
-	table = frappe.qb.DocType("Serial and Batch Bundle")
-	child_table = frappe.qb.DocType("Serial and Batch Entry")
-	pick_list_table = frappe.qb.DocType("Pick List")
+    table = frappe.qb.DocType("Serial and Batch Bundle")
+    child_table = frappe.qb.DocType("Serial and Batch Entry")
+    pick_list_table = frappe.qb.DocType("Pick List")
 
-	query = (
-		frappe.qb.from_(table)
-		.inner_join(child_table)
-		.on(table.name == child_table.parent)
-		.inner_join(pick_list_table)
-		.on(table.voucher_no == pick_list_table.name)
-		.select(
-			child_table.batch_no,
-			child_table.warehouse,
-			Sum(child_table.qty).as_("qty"),
-		)
-		.where(
-			(table.docstatus != 2)
-			& (pick_list_table.status != "Completed")
-			& (table.type_of_transaction == "Outward")
-			& (table.is_cancelled == 0)
-			& (table.voucher_type == "Pick List")
-			& (table.voucher_no.isnotnull())
-		)
-	)
+    query = (
+        frappe.qb.from_(table)
+        .inner_join(child_table)
+        .on(table.name == child_table.parent)
+        .inner_join(pick_list_table)
+        .on(table.voucher_no == pick_list_table.name)
+        .select(
+            child_table.batch_no,
+            child_table.warehouse,
+            Sum(child_table.qty).as_("qty"),
+        )
+        .where(
+            (table.docstatus != 2)
+            & (pick_list_table.status != "Completed")
+            & (table.type_of_transaction == "Outward")
+            & (table.is_cancelled == 0)
+            & (table.voucher_type == "Pick List")
+            & (table.voucher_no.isnotnull())
+        )
+    )
 
-	if kwargs.get("company"):
-		query = query.where(table.company == kwargs.get("company"))
+    if kwargs.get("company"):
+        query = query.where(table.company == kwargs.get("company"))
 
-	if kwargs.get("item_code"):
-		query = query.where(table.item_code == kwargs.get("item_code"))
+    if kwargs.get("item_code"):
+        query = query.where(table.item_code == kwargs.get("item_code"))
 
-	if kwargs.get("warehouse"):
-		if isinstance(kwargs.warehouse, list):
-			query = query.where(table.warehouse.isin(kwargs.warehouse))
-		else:
-			query = query.where(table.warehouse == kwargs.get("warehouse"))
+    if kwargs.get("warehouse"):
+        if isinstance(kwargs.warehouse, list):
+            query = query.where(table.warehouse.isin(kwargs.warehouse))
+        else:
+            query = query.where(table.warehouse == kwargs.get("warehouse"))
 
-	data = query.run(as_dict=True)
-	for row in data:
-		if not row.qty:
-			continue
+    data = query.run(as_dict=True)
+    for row in data:
+        if not row.qty:
+            continue
 
-		key = (row.batch_no, row.warehouse)
-		if key not in picked_batches:
-			picked_batches[key] = frappe._dict(
-				{
-					"qty": row.qty,
-					"warehouse": row.warehouse,
-				}
-			)
-		else:
-			picked_batches[key].qty += row.qty
+        key = (row.batch_no, row.warehouse)
+        if key not in picked_batches:
+            picked_batches[key] = frappe._dict(
+                {
+                    "qty": row.qty,
+                    "warehouse": row.warehouse,
+                }
+            )
+        else:
+            picked_batches[key].qty += row.qty
 
-	return picked_batches
+    return picked_batches
 
 
 def get_picked_serial_nos(item_code, warehouse=None) -> list[str]:
-	table = frappe.qb.DocType("Serial and Batch Bundle")
-	child_table = frappe.qb.DocType("Serial and Batch Entry")
-	pick_list_table = frappe.qb.DocType("Pick List")
+    table = frappe.qb.DocType("Serial and Batch Bundle")
+    child_table = frappe.qb.DocType("Serial and Batch Entry")
+    pick_list_table = frappe.qb.DocType("Pick List")
 
-	query = (
-		frappe.qb.from_(table)
-		.inner_join(child_table)
-		.on(table.name == child_table.parent)
-		.inner_join(pick_list_table)
-		.on(table.voucher_no == pick_list_table.name)
-		.select(
-			child_table.serial_no,
-		)
-		.where(
-			(table.docstatus != 2)
-			& (pick_list_table.status != "Completed")
-			& (table.type_of_transaction == "Outward")
-			& (table.is_cancelled == 0)
-			& (table.voucher_type == "Pick List")
-			& (table.voucher_no.isnotnull())
-		)
-	)
+    query = (
+        frappe.qb.from_(table)
+        .inner_join(child_table)
+        .on(table.name == child_table.parent)
+        .inner_join(pick_list_table)
+        .on(table.voucher_no == pick_list_table.name)
+        .select(
+            child_table.serial_no,
+        )
+        .where(
+            (table.docstatus != 2)
+            & (pick_list_table.status != "Completed")
+            & (table.type_of_transaction == "Outward")
+            & (table.is_cancelled == 0)
+            & (table.voucher_type == "Pick List")
+            & (table.voucher_no.isnotnull())
+        )
+    )
 
-	if item_code:
-		query = query.where(table.item_code == item_code)
+    if item_code:
+        query = query.where(table.item_code == item_code)
 
-	if warehouse:
-		if isinstance(warehouse, list):
-			query = query.where(table.warehouse.isin(warehouse))
-		else:
-			query = query.where(table.warehouse == warehouse)
+    if warehouse:
+        if isinstance(warehouse, list):
+            query = query.where(table.warehouse.isin(warehouse))
+        else:
+            query = query.where(table.warehouse == warehouse)
 
-	data = query.run(as_dict=True)
-	if not data:
-		return []
+    data = query.run(as_dict=True)
+    if not data:
+        return []
 
-	return [row.serial_no for row in data if row.serial_no]
+    return [row.serial_no for row in data if row.serial_no]
 
 
 def get_ledgers_from_serial_batch_bundle(**kwargs) -> list[frappe._dict]:
-	bundle_table = frappe.qb.DocType("Serial and Batch Bundle")
-	serial_batch_table = frappe.qb.DocType("Serial and Batch Entry")
+    bundle_table = frappe.qb.DocType("Serial and Batch Bundle")
+    serial_batch_table = frappe.qb.DocType("Serial and Batch Entry")
 
-	query = (
-		frappe.qb.from_(bundle_table)
-		.inner_join(serial_batch_table)
-		.on(bundle_table.name == serial_batch_table.parent)
-		.select(
-			serial_batch_table.serial_no,
-			bundle_table.warehouse,
-			bundle_table.item_code,
-			serial_batch_table.batch_no,
-			serial_batch_table.qty,
-			serial_batch_table.incoming_rate,
-			bundle_table.voucher_detail_no,
-			bundle_table.voucher_no,
-			bundle_table.posting_datetime,
-			bundle_table.type_of_transaction,
-		)
-		.where(
-			(bundle_table.docstatus == 1)
-			& (bundle_table.is_cancelled == 0)
-			& (bundle_table.type_of_transaction.isin(["Inward", "Outward"]))
-		)
-		.orderby(bundle_table.posting_datetime)
-	)
+    query = (
+        frappe.qb.from_(bundle_table)
+        .inner_join(serial_batch_table)
+        .on(bundle_table.name == serial_batch_table.parent)
+        .select(
+            serial_batch_table.serial_no,
+            bundle_table.warehouse,
+            bundle_table.item_code,
+            serial_batch_table.batch_no,
+            serial_batch_table.qty,
+            serial_batch_table.incoming_rate,
+            bundle_table.voucher_detail_no,
+            bundle_table.voucher_no,
+            bundle_table.posting_datetime,
+            bundle_table.type_of_transaction,
+        )
+        .where(
+            (bundle_table.docstatus == 1)
+            & (bundle_table.is_cancelled == 0)
+            & (bundle_table.type_of_transaction.isin(["Inward", "Outward"]))
+        )
+        .orderby(bundle_table.posting_datetime)
+    )
 
-	for key, val in kwargs.items():
-		if val is None:
-			continue
+    for key, val in kwargs.items():
+        if val is None:
+            continue
 
-		if not val and isinstance(val, list):
-			return []
+        if not val and isinstance(val, list):
+            return []
 
-		if key == "get_subcontracted_item":
-			continue
+        if key == "get_subcontracted_item":
+            continue
 
-		if key in ["name", "item_code", "warehouse", "voucher_no", "company", "voucher_detail_no"]:
-			if isinstance(val, list):
-				query = query.where(bundle_table[key].isin(val))
-			else:
-				query = query.where(bundle_table[key] == val)
-		elif key in ["posting_datetime"]:
-			query = query.where(bundle_table[key] >= val)
-		else:
-			if isinstance(val, list):
-				query = query.where(serial_batch_table[key].isin(val))
-			else:
-				query = query.where(serial_batch_table[key] == val)
+        if key in [
+            "name",
+            "item_code",
+            "warehouse",
+            "voucher_no",
+            "company",
+            "voucher_detail_no",
+        ]:
+            if isinstance(val, list):
+                query = query.where(bundle_table[key].isin(val))
+            else:
+                query = query.where(bundle_table[key] == val)
+        elif key in ["posting_datetime"]:
+            query = query.where(bundle_table[key] >= val)
+        else:
+            if isinstance(val, list):
+                query = query.where(serial_batch_table[key].isin(val))
+            else:
+                query = query.where(serial_batch_table[key] == val)
 
-	return query.run(as_dict=True)
+    return query.run(as_dict=True)
 
 
 def get_stock_ledgers_for_serial_nos(kwargs):
-	"""
-	Fetch stock ledger entries based on various filters.
-	:param kwargs: Filters including posting_datetime, creation, warehouse, item_code, serial_nos, ignore_voucher_detail_no, voucher_no. Joins with Serial and Batch Entry table to filter based on serial numbers.
-	:return: List of stock ledger entries as dictionaries.
-	:rtype: list[dict]
-	"""
+    """
+    Fetch stock ledger entries based on various filters.
+    :param kwargs: Filters including posting_datetime, creation, warehouse, item_code, serial_nos, ignore_voucher_detail_no, voucher_no. Joins with Serial and Batch Entry table to filter based on serial numbers.
+    :return: List of stock ledger entries as dictionaries.
+    :rtype: list[dict]
+    """
+    stock_ledger_entry = frappe.qb.DocType("Stock Ledger Entry")
+    serial_batch_entry = frappe.qb.DocType("Serial and Batch Entry")
+    query = (
+        frappe.qb.from_(stock_ledger_entry)
+        .select(
+            stock_ledger_entry.posting_datetime,
+            stock_ledger_entry.actual_qty,
+            stock_ledger_entry.serial_no,
+            stock_ledger_entry.serial_and_batch_bundle,
+        )
+        .where(stock_ledger_entry.is_cancelled == 0)
+        .orderby(stock_ledger_entry.posting_datetime)
+        .orderby(stock_ledger_entry.creation)
+    )
 
-	stock_ledger_entry = frappe.qb.DocType("Stock Ledger Entry")
-	serial_batch_entry = frappe.qb.DocType("Serial and Batch Entry")
+    if kwargs.get("posting_datetime"):
+        timestamp_condition = (
+            stock_ledger_entry.posting_datetime <= kwargs.posting_datetime
+        )
+        if kwargs.get("creation"):
+            timestamp_condition = (
+                stock_ledger_entry.posting_datetime < kwargs.posting_datetime
+            )
+            timestamp_condition |= (
+                stock_ledger_entry.posting_datetime == kwargs.posting_datetime
+            ) & (stock_ledger_entry.creation < kwargs.creation)
+        query = query.where(timestamp_condition)
 
-	query = (
-		frappe.qb.from_(stock_ledger_entry)
-		.select(
-			stock_ledger_entry.posting_datetime,
-			stock_ledger_entry.actual_qty,
-			stock_ledger_entry.serial_no,
-			stock_ledger_entry.serial_and_batch_bundle,
-		)
-		.where(stock_ledger_entry.is_cancelled == 0)
-		.orderby(stock_ledger_entry.posting_datetime)
-		.orderby(stock_ledger_entry.creation)
-	)
+    for field in ["warehouse", "item_code"]:
+        if not kwargs.get(field):
+            continue
+        if isinstance(kwargs.get(field), list):
+            query = query.where(stock_ledger_entry[field].isin(kwargs.get(field)))
+        else:
+            query = query.where(stock_ledger_entry[field] == kwargs.get(field))
 
-	if kwargs.get("posting_datetime"):
-		timestamp_condition = stock_ledger_entry.posting_datetime <= kwargs.posting_datetime
+    serial_nos = kwargs.get("serial_nos") or kwargs.get("serial_no")
+    if serial_nos and not isinstance(serial_nos, list):
+        serial_nos = [serial_nos]
 
-		if kwargs.get("creation"):
-			timestamp_condition = stock_ledger_entry.posting_datetime < kwargs.posting_datetime
+    if serial_nos:
+        query = (
+            query.left_join(serial_batch_entry)
+            .on(stock_ledger_entry.serial_and_batch_bundle == serial_batch_entry.parent)
+            .distinct()
+        )
 
-			timestamp_condition |= (stock_ledger_entry.posting_datetime == kwargs.posting_datetime) & (
-				stock_ledger_entry.creation < kwargs.creation
-			)
+        # Fix: use flat isin() instead of recursive OR chaining to avoid
+        # PyPika RecursionError when serial_nos list is large (e.g. 1000+ entries).
+        bundle_match = serial_batch_entry.serial_no.isin(serial_nos)
 
-		query = query.where(timestamp_condition)
+        padded_serial_no = Concat_ws("", "\n", stock_ledger_entry.serial_no, "\n")
+        direct_match = Criterion.any(
+            [Locate(f"\n{sn}\n", padded_serial_no) > 0 for sn in serial_nos]
+        )
 
-	for field in ["warehouse", "item_code"]:
-		if not kwargs.get(field):
-			continue
+        query = query.where(bundle_match | direct_match)
 
-		if isinstance(kwargs.get(field), list):
-			query = query.where(stock_ledger_entry[field].isin(kwargs.get(field)))
-		else:
-			query = query.where(stock_ledger_entry[field] == kwargs.get(field))
+    if kwargs.ignore_voucher_detail_no:
+        query = query.where(
+            stock_ledger_entry.voucher_detail_no != kwargs.ignore_voucher_detail_no
+        )
+    elif kwargs.voucher_no:
+        query = query.where(stock_ledger_entry.voucher_no != kwargs.voucher_no)
 
-	serial_nos = kwargs.get("serial_nos") or kwargs.get("serial_no")
-	if serial_nos and not isinstance(serial_nos, list):
-		serial_nos = [serial_nos]
-
-	if serial_nos:
-		query = (
-			query.left_join(serial_batch_entry)
-			.on(stock_ledger_entry.serial_and_batch_bundle == serial_batch_entry.parent)
-			.distinct()
-		)
-
-		bundle_match = serial_batch_entry.serial_no.isin(serial_nos)
-
-		padded_serial_no = Concat_ws("", "\n", stock_ledger_entry.serial_no, "\n")
-		direct_match = None
-		for sn in serial_nos:
-			cond = Locate(f"\n{sn}\n", padded_serial_no) > 0
-			direct_match = cond if direct_match is None else (direct_match | cond)
-
-		query = query.where(bundle_match | direct_match)
-
-	if kwargs.ignore_voucher_detail_no:
-		query = query.where(stock_ledger_entry.voucher_detail_no != kwargs.ignore_voucher_detail_no)
-
-	elif kwargs.voucher_no:
-		query = query.where(stock_ledger_entry.voucher_no != kwargs.voucher_no)
-
-	return query.run(as_dict=True)
+    return query.run(as_dict=True)
 
 
 def get_stock_ledgers_batches(kwargs):
-	stock_ledger_entry = frappe.qb.DocType("Stock Ledger Entry")
-	batch_table = frappe.qb.DocType("Batch")
+    stock_ledger_entry = frappe.qb.DocType("Stock Ledger Entry")
+    batch_table = frappe.qb.DocType("Batch")
 
-	query = (
-		frappe.qb.from_(stock_ledger_entry)
-		.inner_join(batch_table)
-		.on(stock_ledger_entry.batch_no == batch_table.name)
-		.select(
-			stock_ledger_entry.warehouse,
-			stock_ledger_entry.item_code,
-			Sum(stock_ledger_entry.actual_qty).as_("qty"),
-			stock_ledger_entry.batch_no,
-			batch_table.expiry_date,
-		)
-		.where((stock_ledger_entry.is_cancelled == 0) & (stock_ledger_entry.batch_no.isnotnull()))
-		.groupby(stock_ledger_entry.batch_no, stock_ledger_entry.warehouse)
-	)
+    query = (
+        frappe.qb.from_(stock_ledger_entry)
+        .inner_join(batch_table)
+        .on(stock_ledger_entry.batch_no == batch_table.name)
+        .select(
+            stock_ledger_entry.warehouse,
+            stock_ledger_entry.item_code,
+            Sum(stock_ledger_entry.actual_qty).as_("qty"),
+            stock_ledger_entry.batch_no,
+            batch_table.expiry_date,
+        )
+        .where(
+            (stock_ledger_entry.is_cancelled == 0)
+            & (stock_ledger_entry.batch_no.isnotnull())
+        )
+        .groupby(stock_ledger_entry.batch_no, stock_ledger_entry.warehouse)
+    )
 
-	if kwargs.get("company"):
-		query = query.where(stock_ledger_entry.company == kwargs.get("company"))
+    if kwargs.get("company"):
+        query = query.where(stock_ledger_entry.company == kwargs.get("company"))
 
-	for field in ["warehouse", "item_code", "batch_no"]:
-		if not kwargs.get(field):
-			continue
+    for field in ["warehouse", "item_code", "batch_no"]:
+        if not kwargs.get(field):
+            continue
 
-		if isinstance(kwargs.get(field), list):
-			query = query.where(stock_ledger_entry[field].isin(kwargs.get(field)))
-		else:
-			query = query.where(stock_ledger_entry[field] == kwargs.get(field))
+        if isinstance(kwargs.get(field), list):
+            query = query.where(stock_ledger_entry[field].isin(kwargs.get(field)))
+        else:
+            query = query.where(stock_ledger_entry[field] == kwargs.get(field))
 
-	if not kwargs.get("for_stock_levels"):
-		query = query.where((batch_table.expiry_date >= today()) | (batch_table.expiry_date.isnull()))
+    if not kwargs.get("for_stock_levels"):
+        query = query.where(
+            (batch_table.expiry_date >= today()) | (batch_table.expiry_date.isnull())
+        )
 
-	if kwargs.get("posting_datetime"):
-		timestamp_condition = stock_ledger_entry.posting_datetime <= kwargs.posting_datetime
+    if kwargs.get("posting_datetime"):
+        timestamp_condition = (
+            stock_ledger_entry.posting_datetime <= kwargs.posting_datetime
+        )
 
-		if kwargs.get("creation"):
-			timestamp_condition = stock_ledger_entry.posting_datetime < kwargs.posting_datetime
+        if kwargs.get("creation"):
+            timestamp_condition = (
+                stock_ledger_entry.posting_datetime < kwargs.posting_datetime
+            )
 
-			timestamp_condition |= (stock_ledger_entry.posting_datetime == kwargs.posting_datetime) & (
-				stock_ledger_entry.creation < kwargs.creation
-			)
+            timestamp_condition |= (
+                stock_ledger_entry.posting_datetime == kwargs.posting_datetime
+            ) & (stock_ledger_entry.creation < kwargs.creation)
 
-		query = query.where(timestamp_condition)
+        query = query.where(timestamp_condition)
 
-	if kwargs.get("ignore_voucher_nos"):
-		query = query.where(stock_ledger_entry.voucher_no.notin(kwargs.get("ignore_voucher_nos")))
+    if kwargs.get("ignore_voucher_nos"):
+        query = query.where(
+            stock_ledger_entry.voucher_no.notin(kwargs.get("ignore_voucher_nos"))
+        )
 
-	if kwargs.based_on == "LIFO":
-		query = query.orderby(batch_table.creation, order=frappe.qb.desc)
-	elif kwargs.based_on == "Expiry":
-		query = query.orderby(batch_table.expiry_date)
-	else:
-		query = query.orderby(batch_table.creation)
+    if kwargs.based_on == "LIFO":
+        query = query.orderby(batch_table.creation, order=frappe.qb.desc)
+    elif kwargs.based_on == "Expiry":
+        query = query.orderby(batch_table.expiry_date)
+    else:
+        query = query.orderby(batch_table.creation)
 
-	data = query.run(as_dict=True)
-	batches = {}
-	for d in data:
-		key = (d.batch_no, d.warehouse)
-		if key not in batches:
-			batches[key] = d
-		else:
-			batches[key].qty += d.qty
+    data = query.run(as_dict=True)
+    batches = {}
+    for d in data:
+        key = (d.batch_no, d.warehouse)
+        if key not in batches:
+            batches[key] = d
+        else:
+            batches[key].qty += d.qty
 
-	return batches
+    return batches
 
 
 @frappe.whitelist()
 def get_batch_no_from_serial_no(serial_no: str):
-	return frappe.get_cached_value("Serial No", serial_no, "batch_no")
+    return frappe.get_cached_value("Serial No", serial_no, "batch_no")
 
 
 @frappe.whitelist()
 def is_serial_batch_no_exists(
-	item_code: str, type_of_transaction: str, serial_no: str | None = None, batch_no: str | None = None
+    item_code: str,
+    type_of_transaction: str,
+    serial_no: str | None = None,
+    batch_no: str | None = None,
 ):
-	if serial_no and not frappe.db.exists("Serial No", serial_no):
-		if type_of_transaction != "Inward":
-			frappe.throw(_("Serial No {0} does not exists").format(serial_no))
+    if serial_no and not frappe.db.exists("Serial No", serial_no):
+        if type_of_transaction != "Inward":
+            frappe.throw(_("Serial No {0} does not exists").format(serial_no))
 
-		make_serial_no(serial_no, item_code)
+        make_serial_no(serial_no, item_code)
 
-	if batch_no and not frappe.db.exists("Batch", batch_no):
-		if type_of_transaction != "Inward":
-			frappe.throw(_("Batch No {0} does not exists").format(batch_no))
+    if batch_no and not frappe.db.exists("Batch", batch_no):
+        if type_of_transaction != "Inward":
+            frappe.throw(_("Batch No {0} does not exists").format(batch_no))
 
-		make_batch_no(batch_no, item_code)
+        make_batch_no(batch_no, item_code)
 
 
 def make_serial_no(serial_no, item_code):
-	serial_no_doc = frappe.new_doc("Serial No")
-	serial_no_doc.serial_no = serial_no
-	serial_no_doc.item_code = item_code
-	serial_no_doc.save(ignore_permissions=True)
+    serial_no_doc = frappe.new_doc("Serial No")
+    serial_no_doc.serial_no = serial_no
+    serial_no_doc.item_code = item_code
+    serial_no_doc.save(ignore_permissions=True)
 
 
 def make_batch_no(batch_no, item_code):
-	batch_doc = frappe.new_doc("Batch")
-	batch_doc.batch_id = batch_no
-	batch_doc.item = item_code
-	batch_doc.save(ignore_permissions=True)
+    batch_doc = frappe.new_doc("Batch")
+    batch_doc.batch_id = batch_no
+    batch_doc.item = item_code
+    batch_doc.save(ignore_permissions=True)
 
 
 @frappe.whitelist()
 def is_duplicate_serial_no(bundle_id: str, serial_no: str):
-	return frappe.db.exists("Serial and Batch Entry", {"parent": bundle_id, "serial_no": serial_no})
+    return frappe.db.exists(
+        "Serial and Batch Entry", {"parent": bundle_id, "serial_no": serial_no}
+    )
 
 
 def parse_serial_nos(serial_no):
-	if isinstance(serial_no, list):
-		return serial_no
+    if isinstance(serial_no, list):
+        return serial_no
 
-	return [s.strip() for s in cstr(serial_no).strip().replace(",", "\n").split("\n") if s.strip()]
+    return [
+        s.strip()
+        for s in cstr(serial_no).strip().replace(",", "\n").split("\n")
+        if s.strip()
+    ]
 
 
 @frappe.request_cache
 def get_stock_reco_details(voucher_detail_no):
-	return frappe.db.get_value(
-		"Stock Reconciliation Item",
-		voucher_detail_no,
-		[
-			"current_serial_no",
-			"serial_no",
-			"serial_and_batch_bundle",
-			"current_serial_and_batch_bundle",
-			"batch_no",
-			"qty",
-			"current_qty",
-		],
-		as_dict=True,
-	)
+    return frappe.db.get_value(
+        "Stock Reconciliation Item",
+        voucher_detail_no,
+        [
+            "current_serial_no",
+            "serial_no",
+            "serial_and_batch_bundle",
+            "current_serial_and_batch_bundle",
+            "batch_no",
+            "qty",
+            "current_qty",
+        ],
+        as_dict=True,
+    )

--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -12,1728 +12,2009 @@ from frappe.model.document import Document
 from frappe.model.meta import get_field_precision
 from frappe.model.utils import get_fetch_values
 from frappe.query_builder.functions import IfNull, Sum
-from frappe.utils import add_days, add_months, cint, cstr, flt, get_link_to_form, getdate, parse_json
+from frappe.utils import (
+    add_days,
+    add_months,
+    cint,
+    cstr,
+    flt,
+    get_link_to_form,
+    getdate,
+    parse_json,
+)
 
 import erpnext
 from erpnext import get_company_currency
 from erpnext.accounts.doctype.pricing_rule.pricing_rule import (
-	get_pricing_rule_for_item,
-	set_transaction_type,
+    get_pricing_rule_for_item,
+    set_transaction_type,
 )
 from erpnext.setup.doctype.brand.brand import get_brand_defaults
 from erpnext.setup.doctype.item_group.item_group import get_item_group_defaults
 from erpnext.setup.utils import get_exchange_rate
 from erpnext.stock.doctype.item.item import get_item_defaults, get_uom_conv_factor
-from erpnext.stock.doctype.item_manufacturer.item_manufacturer import get_item_manufacturer_part_no
+from erpnext.stock.doctype.item_manufacturer.item_manufacturer import (
+    get_item_manufacturer_part_no,
+)
 from erpnext.stock.doctype.price_list.price_list import get_price_list_details
 
 ItemDetails = frappe._dict
 ItemDetailsCtx = frappe._dict
 ItemPriceCtx = frappe._dict
 
-sales_doctypes = ["Quotation", "Sales Order", "Delivery Note", "Sales Invoice", "POS Invoice"]
+sales_doctypes = [
+    "Quotation",
+    "Sales Order",
+    "Delivery Note",
+    "Sales Invoice",
+    "POS Invoice",
+]
 purchase_doctypes = [
-	"Material Request",
-	"Supplier Quotation",
-	"Purchase Order",
-	"Purchase Receipt",
-	"Purchase Invoice",
+    "Material Request",
+    "Supplier Quotation",
+    "Purchase Order",
+    "Purchase Receipt",
+    "Purchase Invoice",
 ]
 
 
 def _preprocess_ctx(ctx):
-	if not ctx.price_list:
-		ctx.price_list = ctx.selling_price_list or ctx.buying_price_list
+    if not ctx.price_list:
+        ctx.price_list = ctx.selling_price_list or ctx.buying_price_list
 
-	if not ctx.item_code and ctx.barcode:
-		ctx.item_code = get_item_code(barcode=ctx.barcode)
-	elif not ctx.item_code and ctx.serial_no:
-		ctx.item_code = get_item_code(serial_no=ctx.serial_no)
+    if not ctx.item_code and ctx.barcode:
+        ctx.item_code = get_item_code(barcode=ctx.barcode)
+    elif not ctx.item_code and ctx.serial_no:
+        ctx.item_code = get_item_code(serial_no=ctx.serial_no)
 
-	set_transaction_type(ctx)
+    set_transaction_type(ctx)
 
 
 @frappe.whitelist()
 @erpnext.normalize_ctx_input(ItemDetailsCtx)
 def get_item_details(
-	ctx: ItemDetailsCtx | str,
-	doc: Document | str | None = None,
-	for_validate: bool = False,
-	overwrite_warehouse: bool = True,
+    ctx: ItemDetailsCtx | str,
+    doc: Document | str | None = None,
+    for_validate: bool = False,
+    overwrite_warehouse: bool = True,
 ):
-	"""
-	ctx = {
-	        "item_code": "",
-	        "warehouse": None,
-	        "customer": "",
-	        "conversion_rate": 1.0,
-	        "selling_price_list": None,
-	        "price_list_currency": None,
-	        "plc_conversion_rate": 1.0,
-	        "doctype": "",
-	        "name": "",
-	        "supplier": None,
-	        "transaction_date": None,
-	        "conversion_rate": 1.0,
-	        "buying_price_list": None,
-	        "is_subcontracted": 0/1,
-	        "ignore_pricing_rule": 0/1
-	        "project": ""
-	        "set_warehouse": ""
-	}
-	"""
-	_preprocess_ctx(ctx)
-	for_validate = parse_json(for_validate)
-	overwrite_warehouse = parse_json(overwrite_warehouse)
-	item = frappe.get_cached_doc("Item", ctx.item_code)
-	validate_item_details(ctx, item)
+    """
+    ctx = {
+            "item_code": "",
+            "warehouse": None,
+            "customer": "",
+            "conversion_rate": 1.0,
+            "selling_price_list": None,
+            "price_list_currency": None,
+            "plc_conversion_rate": 1.0,
+            "doctype": "",
+            "name": "",
+            "supplier": None,
+            "transaction_date": None,
+            "conversion_rate": 1.0,
+            "buying_price_list": None,
+            "is_subcontracted": 0/1,
+            "ignore_pricing_rule": 0/1
+            "project": ""
+            "set_warehouse": ""
+    }
+    """
+    _preprocess_ctx(ctx)
+    for_validate = parse_json(for_validate)
+    overwrite_warehouse = parse_json(overwrite_warehouse)
+    item = frappe.get_cached_doc("Item", ctx.item_code)
+    validate_item_details(ctx, item)
 
-	if isinstance(doc, str):
-		doc = json.loads(doc)
+    if isinstance(doc, str):
+        doc = json.loads(doc)
 
-	if doc:
-		ctx.transaction_date = doc.get("transaction_date") or doc.get("posting_date")
+    if doc:
+        ctx.transaction_date = doc.get("transaction_date") or doc.get("posting_date")
 
-		if doc.get("doctype") == "Purchase Invoice":
-			ctx.bill_date = doc.get("bill_date")
+        if doc.get("doctype") == "Purchase Invoice":
+            ctx.bill_date = doc.get("bill_date")
 
-	out: ItemDetails = get_basic_details(ctx, item, overwrite_warehouse)
+    out: ItemDetails = get_basic_details(ctx, item, overwrite_warehouse)
 
-	get_item_tax_template(ctx, item, out)
-	out.item_tax_rate = get_item_tax_map(
-		doc=doc or ctx,
-		tax_template=out.item_tax_template or ctx.item_tax_template,
-		as_json=True,
-	)
+    get_item_tax_template(ctx, item, out)
+    out.item_tax_rate = get_item_tax_map(
+        doc=doc or ctx,
+        tax_template=out.item_tax_template or ctx.item_tax_template,
+        as_json=True,
+    )
 
-	get_party_item_code(ctx, item, out)
+    get_party_item_code(ctx, item, out)
 
-	if ctx.doctype in ["Sales Invoice", "Purchase Invoice"]:
-		get_tax_withholding_category(ctx, item, out)
+    if ctx.doctype in ["Sales Invoice", "Purchase Invoice"]:
+        get_tax_withholding_category(ctx, item, out)
 
-	if ctx.doctype in ["Sales Order", "Quotation"]:
-		set_valuation_rate(out, ctx)
+    if ctx.doctype in ["Sales Order", "Quotation"]:
+        set_valuation_rate(out, ctx)
 
-	update_party_blanket_order(ctx, out)
+    update_party_blanket_order(ctx, out)
 
-	# Never try to find a customer price if customer is set in these Doctype
-	current_customer = ctx.customer
-	if ctx.doctype in ["Purchase Order", "Purchase Receipt", "Purchase Invoice"]:
-		ctx.customer = None
+    # Never try to find a customer price if customer is set in these Doctype
+    current_customer = ctx.customer
+    if ctx.doctype in ["Purchase Order", "Purchase Receipt", "Purchase Invoice"]:
+        ctx.customer = None
 
-	out.update(get_price_list_rate(ctx, item))
+    out.update(get_price_list_rate(ctx, item))
 
-	if (
-		not out.price_list_rate
-		and ctx.transaction_type == "selling"
-		and frappe.get_single_value("Selling Settings", "fallback_to_default_price_list")
-	):
-		fallback_args = ctx.copy()
-		fallback_args.price_list = frappe.get_single_value("Selling Settings", "selling_price_list")
-		out.update(get_price_list_rate(fallback_args, item))
+    if (
+        not out.price_list_rate
+        and ctx.transaction_type == "selling"
+        and frappe.get_single_value(
+            "Selling Settings", "fallback_to_default_price_list"
+        )
+    ):
+        fallback_args = ctx.copy()
+        fallback_args.price_list = frappe.get_single_value(
+            "Selling Settings", "selling_price_list"
+        )
+        out.update(get_price_list_rate(fallback_args, item))
 
-	ctx.customer = current_customer
+    ctx.customer = current_customer
 
-	if ctx.customer and cint(ctx.is_pos):
-		out.update(get_pos_profile_item_details_(ctx, ctx.company, update_data=True))
+    if ctx.customer and cint(ctx.is_pos):
+        out.update(get_pos_profile_item_details_(ctx, ctx.company, update_data=True))
 
-	if item.is_stock_item:
-		update_bin_details(ctx, out, doc)
+    if item.is_stock_item:
+        update_bin_details(ctx, out, doc)
 
-	# update ctx with out, if key or value not exists
-	for key, value in out.items():
-		if ctx.get(key) is None:
-			ctx[key] = value
+    # update ctx with out, if key or value not exists
+    for key, value in out.items():
+        if ctx.get(key) is None:
+            ctx[key] = value
 
-	data = get_pricing_rule_for_item(ctx, doc=doc, for_validate=for_validate)
+    skip_pricing_rule_eval = cint(ctx.get("skip_pricing_rule_eval"))
+    if not skip_pricing_rule_eval and doc:
+        skip_pricing_rule_eval = cint(
+            getattr(getattr(doc, "flags", None), "skip_pricing_rule_eval", 0)
+        )
 
-	out.update(data)
+    if not skip_pricing_rule_eval:
+        data = get_pricing_rule_for_item(ctx, doc=doc, for_validate=for_validate)
+        out.update(data)
 
-	if (
-		frappe.get_single_value("Stock Settings", "auto_create_serial_and_batch_bundle_for_outward")
-		and not ctx.get("serial_and_batch_bundle")
-		and (ctx.get("use_serial_batch_fields") or ctx.get("doctype") == "POS Invoice")
-	):
-		update_stock(ctx, out, doc)
+    if (
+        frappe.get_single_value(
+            "Stock Settings", "auto_create_serial_and_batch_bundle_for_outward"
+        )
+        and not ctx.get("serial_and_batch_bundle")
+        and (ctx.get("use_serial_batch_fields") or ctx.get("doctype") == "POS Invoice")
+    ):
+        update_stock(ctx, out, doc)
 
-	if ctx.transaction_date and item.lead_time_days:
-		out.schedule_date = out.lead_time_date = add_days(ctx.transaction_date, item.lead_time_days)
+    if ctx.transaction_date and item.lead_time_days:
+        out.schedule_date = out.lead_time_date = add_days(
+            ctx.transaction_date, item.lead_time_days
+        )
 
-	if ctx.is_subcontracted:
-		out.bom = ctx.bom or get_default_bom(ctx.item_code)
+    if ctx.is_subcontracted:
+        out.bom = ctx.bom or get_default_bom(ctx.item_code)
 
-	get_gross_profit(out)
-	if ctx.doctype == "Material Request":
-		out.rate = ctx.rate or out.price_list_rate
-		out.amount = flt(ctx.qty) * flt(out.rate)
+    get_gross_profit(out)
+    if ctx.doctype == "Material Request":
+        out.rate = ctx.rate or out.price_list_rate
+        out.amount = flt(ctx.qty) * flt(out.rate)
 
-	out = remove_standard_fields(out)
-	return out
+    out = remove_standard_fields(out)
+    return out
 
 
 def remove_standard_fields(out: ItemDetails):
-	for key in child_table_fields + default_fields:
-		out.pop(key, None)
-	return out
+    for key in child_table_fields + default_fields:
+        out.pop(key, None)
+    return out
 
 
 def set_valuation_rate(out: ItemDetails | dict, ctx: ItemDetailsCtx):
-	if frappe.db.exists("Product Bundle", {"name": ctx.item_code, "disabled": 0}, cache=True):
-		valuation_rate = 0.0
-		bundled_items = frappe.get_doc("Product Bundle", ctx.item_code)
+    if frappe.db.exists(
+        "Product Bundle", {"name": ctx.item_code, "disabled": 0}, cache=True
+    ):
+        valuation_rate = 0.0
+        bundled_items = frappe.get_doc("Product Bundle", ctx.item_code)
 
-		for bundle_item in bundled_items.items:
-			valuation_rate += flt(
-				get_valuation_rate(bundle_item.item_code, ctx.company, out.get("warehouse")).get(
-					"valuation_rate"
-				)
-				* bundle_item.qty
-			)
+        for bundle_item in bundled_items.items:
+            valuation_rate += flt(
+                get_valuation_rate(
+                    bundle_item.item_code, ctx.company, out.get("warehouse")
+                ).get("valuation_rate")
+                * bundle_item.qty
+            )
 
-		out.update({"valuation_rate": valuation_rate})
+        out.update({"valuation_rate": valuation_rate})
 
-	else:
-		out.update(get_valuation_rate(ctx.item_code, ctx.company, out.get("warehouse")))
+    else:
+        out.update(get_valuation_rate(ctx.item_code, ctx.company, out.get("warehouse")))
 
 
 def update_stock(ctx, out, doc=None):
-	from erpnext.stock.doctype.batch.batch import get_available_batches
-	from erpnext.stock.doctype.serial_no.serial_no import get_serial_nos_for_outward
+    from erpnext.stock.doctype.batch.batch import get_available_batches
+    from erpnext.stock.doctype.serial_no.serial_no import get_serial_nos_for_outward
 
-	if (
-		(
-			ctx.get("doctype") in ["Delivery Note", "POS Invoice"]
-			or (ctx.get("doctype") == "Sales Invoice" and ctx.get("update_stock"))
-		)
-		and out.warehouse
-		and out.stock_qty > 0
-	):
-		if doc and isinstance(doc, dict):
-			doc = frappe._dict(doc)
+    if (
+        (
+            ctx.get("doctype") in ["Delivery Note", "POS Invoice"]
+            or (ctx.get("doctype") == "Sales Invoice" and ctx.get("update_stock"))
+        )
+        and out.warehouse
+        and out.stock_qty > 0
+    ):
+        if doc and isinstance(doc, dict):
+            doc = frappe._dict(doc)
 
-		kwargs = frappe._dict(
-			{
-				"item_code": ctx.item_code,
-				"warehouse": ctx.warehouse,
-				"based_on": frappe.get_single_value("Stock Settings", "pick_serial_and_batch_based_on"),
-				"sabb_voucher_no": doc.get("name") if doc else None,
-				"sabb_voucher_detail_no": ctx.child_docname,
-				"sabb_voucher_type": ctx.doctype,
-				"pick_reserved_items": True,
-				"qty": out.stock_qty,
-			}
-		)
+        kwargs = frappe._dict(
+            {
+                "item_code": ctx.item_code,
+                "warehouse": ctx.warehouse,
+                "based_on": frappe.get_single_value(
+                    "Stock Settings", "pick_serial_and_batch_based_on"
+                ),
+                "sabb_voucher_no": doc.get("name") if doc else None,
+                "sabb_voucher_detail_no": ctx.child_docname,
+                "sabb_voucher_type": ctx.doctype,
+                "pick_reserved_items": True,
+                "qty": out.stock_qty,
+            }
+        )
 
-		if ctx.get("doctype") == "Delivery Note":
-			kwargs["against_sales_order"] = ctx.get("against_sales_order")
+        if ctx.get("doctype") == "Delivery Note":
+            kwargs["against_sales_order"] = ctx.get("against_sales_order")
 
-		if ctx.get("ignore_serial_nos"):
-			kwargs["ignore_serial_nos"] = ctx.get("ignore_serial_nos")
+        if ctx.get("ignore_serial_nos"):
+            kwargs["ignore_serial_nos"] = ctx.get("ignore_serial_nos")
 
-		qty = out.stock_qty
-		batches = []
-		if out.has_batch_no and not ctx.get("batch_no"):
-			batches = get_available_batches(kwargs)
-			if doc:
-				filter_batches(batches, doc)
+        qty = out.stock_qty
+        batches = []
+        if out.has_batch_no and not ctx.get("batch_no"):
+            batches = get_available_batches(kwargs)
+            if doc:
+                filter_batches(batches, doc)
 
-			for batch_no, batch_qty in batches.items():
-				rate = get_batch_based_item_price(
-					{"price_list": doc.get("selling_price_list"), "uom": out.uom, "batch_no": batch_no},
-					out.item_code,
-				)
-				if batch_qty >= qty:
-					out.update({"batch_no": batch_no, "actual_batch_qty": qty})
-					if rate:
-						out.update({"rate": rate, "price_list_rate": rate})
-					break
-				else:
-					qty -= batch_qty
+            for batch_no, batch_qty in batches.items():
+                rate = get_batch_based_item_price(
+                    {
+                        "price_list": doc.get("selling_price_list"),
+                        "uom": out.uom,
+                        "batch_no": batch_no,
+                    },
+                    out.item_code,
+                )
+                if batch_qty >= qty:
+                    out.update({"batch_no": batch_no, "actual_batch_qty": qty})
+                    if rate:
+                        out.update({"rate": rate, "price_list_rate": rate})
+                    break
+                else:
+                    qty -= batch_qty
 
-				out.update({"batch_no": batch_no, "actual_batch_qty": batch_qty})
-				if rate:
-					out.update({"rate": rate, "price_list_rate": rate})
+                out.update({"batch_no": batch_no, "actual_batch_qty": batch_qty})
+                if rate:
+                    out.update({"rate": rate, "price_list_rate": rate})
 
-		if out.has_serial_no and out.has_batch_no and has_incorrect_serial_nos(ctx, out):
-			kwargs["batches"] = [ctx.get("batch_no")] if ctx.get("batch_no") else [out.get("batch_no")]
-			serial_nos = get_serial_nos_for_outward(kwargs)
-			serial_nos = get_filtered_serial_nos(serial_nos, doc)
+        if (
+            out.has_serial_no
+            and out.has_batch_no
+            and has_incorrect_serial_nos(ctx, out)
+        ):
+            kwargs["batches"] = (
+                [ctx.get("batch_no")] if ctx.get("batch_no") else [out.get("batch_no")]
+            )
+            serial_nos = get_serial_nos_for_outward(kwargs)
+            serial_nos = get_filtered_serial_nos(serial_nos, doc)
 
-			out["serial_no"] = "\n".join(serial_nos[: cint(out.stock_qty)])
+            out["serial_no"] = "\n".join(serial_nos[: cint(out.stock_qty)])
 
-		elif out.has_serial_no and not ctx.get("serial_no"):
-			serial_nos = get_serial_nos_for_outward(kwargs)
-			serial_nos = get_filtered_serial_nos(serial_nos, doc)
+        elif out.has_serial_no and not ctx.get("serial_no"):
+            serial_nos = get_serial_nos_for_outward(kwargs)
+            serial_nos = get_filtered_serial_nos(serial_nos, doc)
 
-			out["serial_no"] = "\n".join(serial_nos[: cint(out.stock_qty)])
+            out["serial_no"] = "\n".join(serial_nos[: cint(out.stock_qty)])
 
 
 def has_incorrect_serial_nos(ctx, out):
-	from erpnext.stock.doctype.serial_no.serial_no import get_serial_nos
+    from erpnext.stock.doctype.serial_no.serial_no import get_serial_nos
 
-	if not ctx.get("serial_no"):
-		return True
+    if not ctx.get("serial_no"):
+        return True
 
-	serial_nos = get_serial_nos(ctx.get("serial_no"))
-	if len(serial_nos) != out.get("stock_qty"):
-		return True
+    serial_nos = get_serial_nos(ctx.get("serial_no"))
+    if len(serial_nos) != out.get("stock_qty"):
+        return True
 
-	return False
+    return False
 
 
 def filter_batches(batches, doc):
-	for row in doc.get("items"):
-		if row.get("batch_no") in batches:
-			batches[row.get("batch_no")] -= row.get("qty")
-			if batches[row.get("batch_no")] <= 0:
-				del batches[row.get("batch_no")]
+    for row in doc.get("items"):
+        if row.get("batch_no") in batches:
+            batches[row.get("batch_no")] -= row.get("qty")
+            if batches[row.get("batch_no")] <= 0:
+                del batches[row.get("batch_no")]
 
 
 def get_filtered_serial_nos(serial_nos, doc, table=None):
-	from erpnext.stock.doctype.serial_no.serial_no import get_serial_nos
+    from erpnext.stock.doctype.serial_no.serial_no import get_serial_nos
 
-	if not table:
-		table = "items"
+    if not table:
+        table = "items"
 
-	for row in doc.get(table):
-		if row.get("serial_no"):
-			for serial_no in get_serial_nos(row.get("serial_no")):
-				if serial_no in serial_nos:
-					serial_nos.remove(serial_no)
+    for row in doc.get(table):
+        if row.get("serial_no"):
+            for serial_no in get_serial_nos(row.get("serial_no")):
+                if serial_no in serial_nos:
+                    serial_nos.remove(serial_no)
 
-	return serial_nos
+    return serial_nos
 
 
 def update_bin_details(ctx: ItemDetailsCtx, out: ItemDetails, doc):
-	if ctx.doctype == "Material Request" and ctx.material_request_type == "Material Transfer":
-		out.update(get_bin_details(ctx.item_code, ctx.from_warehouse))
+    if (
+        ctx.doctype == "Material Request"
+        and ctx.material_request_type == "Material Transfer"
+    ):
+        out.update(get_bin_details(ctx.item_code, ctx.from_warehouse))
 
-	elif out.get("warehouse"):
-		company = ctx.company if (doc and doc.get("doctype") == "Purchase Order") else None
+    elif out.get("warehouse"):
+        company = (
+            ctx.company if (doc and doc.get("doctype") == "Purchase Order") else None
+        )
 
-		# calculate company_total_stock only for po
-		bin_details = get_bin_details(ctx.item_code, out.warehouse, company, include_child_warehouses=True)
+        # calculate company_total_stock only for po
+        bin_details = get_bin_details(
+            ctx.item_code, out.warehouse, company, include_child_warehouses=True
+        )
 
-		out.update(bin_details)
+        out.update(bin_details)
 
 
 def get_item_code(barcode=None, serial_no=None):
-	if barcode:
-		item_code = frappe.db.get_value("Item Barcode", {"barcode": barcode}, fieldname=["parent"])
-		if not item_code:
-			frappe.throw(_("No Item with Barcode {0}").format(barcode))
-	elif serial_no:
-		item_code = frappe.db.get_value("Serial No", serial_no, "item_code")
-		if not item_code:
-			frappe.throw(_("No Item with Serial No {0}").format(serial_no))
+    if barcode:
+        item_code = frappe.db.get_value(
+            "Item Barcode", {"barcode": barcode}, fieldname=["parent"]
+        )
+        if not item_code:
+            frappe.throw(_("No Item with Barcode {0}").format(barcode))
+    elif serial_no:
+        item_code = frappe.db.get_value("Serial No", serial_no, "item_code")
+        if not item_code:
+            frappe.throw(_("No Item with Serial No {0}").format(serial_no))
 
-	return item_code
+    return item_code
 
 
 def validate_item_details(ctx: ItemDetailsCtx, item):
-	if not ctx.company:
-		throw(_("Please specify Company"))
+    if not ctx.company:
+        throw(_("Please specify Company"))
 
-	from erpnext.stock.doctype.item.item import validate_end_of_life
+    from erpnext.stock.doctype.item.item import validate_end_of_life
 
-	validate_end_of_life(item.name, item.end_of_life, item.disabled)
+    validate_end_of_life(item.name, item.end_of_life, item.disabled)
 
-	if cint(item.has_variants):
-		msg = f"Item {item.name} is a template, please select one of its variants"
+    if cint(item.has_variants):
+        msg = f"Item {item.name} is a template, please select one of its variants"
 
-		throw(_(msg), title=_("Template Item Selected"))
+        throw(_(msg), title=_("Template Item Selected"))
 
-	elif ctx.doctype != "Material Request":
-		if ctx.is_subcontracted:
-			if ctx.is_old_subcontracting_flow:
-				if item.is_sub_contracted_item != 1:
-					throw(_("Item {0} must be a Sub-contracted Item").format(item.name))
-			else:
-				if item.is_stock_item:
-					throw(_("Item {0} must be a Non-Stock Item").format(item.name))
+    elif ctx.doctype != "Material Request":
+        if ctx.is_subcontracted:
+            if ctx.is_old_subcontracting_flow:
+                if item.is_sub_contracted_item != 1:
+                    throw(_("Item {0} must be a Sub-contracted Item").format(item.name))
+            else:
+                if item.is_stock_item:
+                    throw(_("Item {0} must be a Non-Stock Item").format(item.name))
 
 
-def get_basic_details(ctx: ItemDetailsCtx, item, overwrite_warehouse=True) -> ItemDetails:
-	"""
-	:param ctx: {
-	                "item_code": "",
-	                "warehouse": None,
-	                "customer": "",
-	                "conversion_rate": 1.0,
-	                "selling_price_list": None,
-	                "price_list_currency": None,
-	                "price_list_uom_dependant": None,
-	                "plc_conversion_rate": 1.0,
-	                "doctype": "",
-	                "name": "",
-	                "supplier": None,
-	                "transaction_date": None,
-	                "conversion_rate": 1.0,
-	                "buying_price_list": None,
-	                "is_subcontracted": 0/1,
-	                "ignore_pricing_rule": 0/1
-	                "project": "",
-	                barcode: "",
-	                serial_no: "",
-	                currency: "",
-	                update_stock: "",
-	                price_list: "",
-	                company: "",
-	                order_type: "",
-	                is_pos: "",
-	                project: "",
-	                qty: "",
-	                stock_qty: "",
-	                conversion_factor: "",
-	                against_blanket_order: 0/1
-	        }
-	:param item: `item_code` of Item object
-	:return: frappe._dict
-	"""
+def get_basic_details(
+    ctx: ItemDetailsCtx, item, overwrite_warehouse=True
+) -> ItemDetails:
+    """
+    :param ctx: {
+                    "item_code": "",
+                    "warehouse": None,
+                    "customer": "",
+                    "conversion_rate": 1.0,
+                    "selling_price_list": None,
+                    "price_list_currency": None,
+                    "price_list_uom_dependant": None,
+                    "plc_conversion_rate": 1.0,
+                    "doctype": "",
+                    "name": "",
+                    "supplier": None,
+                    "transaction_date": None,
+                    "conversion_rate": 1.0,
+                    "buying_price_list": None,
+                    "is_subcontracted": 0/1,
+                    "ignore_pricing_rule": 0/1
+                    "project": "",
+                    barcode: "",
+                    serial_no: "",
+                    currency: "",
+                    update_stock: "",
+                    price_list: "",
+                    company: "",
+                    order_type: "",
+                    is_pos: "",
+                    project: "",
+                    qty: "",
+                    stock_qty: "",
+                    conversion_factor: "",
+                    against_blanket_order: 0/1
+            }
+    :param item: `item_code` of Item object
+    :return: frappe._dict
+    """
 
-	if not item:
-		item = frappe.get_cached_doc("Item", ctx.item_code)
+    if not item:
+        item = frappe.get_cached_doc("Item", ctx.item_code)
 
-	if item.variant_of and not item.taxes and frappe.db.exists("Item Tax", {"parent": item.variant_of}):
-		item.update_template_tables()
+    if (
+        item.variant_of
+        and not item.taxes
+        and frappe.db.exists("Item Tax", {"parent": item.variant_of})
+    ):
+        item.update_template_tables()
 
-	item_defaults = get_item_defaults(item.name, ctx.company)
-	item_group_defaults = get_item_group_defaults(item.name, ctx.company)
-	brand_defaults = get_brand_defaults(item.name, ctx.company)
+    item_defaults = get_item_defaults(item.name, ctx.company)
+    item_group_defaults = get_item_group_defaults(item.name, ctx.company)
+    brand_defaults = get_brand_defaults(item.name, ctx.company)
 
-	defaults = frappe._dict(
-		{
-			"item_defaults": item_defaults,
-			"item_group_defaults": item_group_defaults,
-			"brand_defaults": brand_defaults,
-		}
-	)
+    defaults = frappe._dict(
+        {
+            "item_defaults": item_defaults,
+            "item_group_defaults": item_group_defaults,
+            "brand_defaults": brand_defaults,
+        }
+    )
 
-	warehouse = get_item_warehouse_(ctx, item, overwrite_warehouse, defaults)
+    warehouse = get_item_warehouse_(ctx, item, overwrite_warehouse, defaults)
 
-	if ctx.doctype == "Material Request" and not ctx.material_request_type:
-		ctx["material_request_type"] = frappe.db.get_value(
-			"Material Request", ctx.name, "material_request_type", cache=True
-		)
+    if ctx.doctype == "Material Request" and not ctx.material_request_type:
+        ctx["material_request_type"] = frappe.db.get_value(
+            "Material Request", ctx.name, "material_request_type", cache=True
+        )
 
-	expense_account = None
+    expense_account = None
 
-	if item.is_fixed_asset:
-		from erpnext.assets.doctype.asset.asset import get_asset_account, is_cwip_accounting_enabled
+    if item.is_fixed_asset:
+        from erpnext.assets.doctype.asset.asset import (
+            get_asset_account,
+            is_cwip_accounting_enabled,
+        )
 
-		if is_cwip_accounting_enabled(item.asset_category):
-			expense_account = get_asset_account(
-				"capital_work_in_progress_account",
-				asset_category=item.asset_category,
-				company=ctx.company,
-			)
-		elif ctx.doctype in (
-			"Purchase Invoice",
-			"Purchase Receipt",
-			"Purchase Order",
-			"Material Request",
-		):
-			from erpnext.assets.doctype.asset_category.asset_category import get_asset_category_account
+        if is_cwip_accounting_enabled(item.asset_category):
+            expense_account = get_asset_account(
+                "capital_work_in_progress_account",
+                asset_category=item.asset_category,
+                company=ctx.company,
+            )
+        elif ctx.doctype in (
+            "Purchase Invoice",
+            "Purchase Receipt",
+            "Purchase Order",
+            "Material Request",
+        ):
+            from erpnext.assets.doctype.asset_category.asset_category import (
+                get_asset_category_account,
+            )
 
-			expense_account = get_asset_category_account(
-				fieldname="fixed_asset_account", item=ctx.item_code, company=ctx.company
-			)
+            expense_account = get_asset_category_account(
+                fieldname="fixed_asset_account", item=ctx.item_code, company=ctx.company
+            )
 
-	# Set the UOM to the Default Sales UOM or Default Purchase UOM if configured in the Item Master
-	if not ctx.uom:
-		if ctx.doctype in sales_doctypes:
-			ctx.uom = item.sales_uom if item.sales_uom else item.stock_uom
-		elif (
-			(ctx.doctype in ["Purchase Order", "Purchase Receipt", "Purchase Invoice"])
-			or (ctx.doctype == "Material Request" and ctx.material_request_type == "Purchase")
-			or (ctx.doctype == "Supplier Quotation")
-		):
-			ctx.uom = item.purchase_uom if item.purchase_uom else item.stock_uom
-		else:
-			ctx.uom = item.stock_uom
+    # Set the UOM to the Default Sales UOM or Default Purchase UOM if configured in the Item Master
+    if not ctx.uom:
+        if ctx.doctype in sales_doctypes:
+            ctx.uom = item.sales_uom if item.sales_uom else item.stock_uom
+        elif (
+            (ctx.doctype in ["Purchase Order", "Purchase Receipt", "Purchase Invoice"])
+            or (
+                ctx.doctype == "Material Request"
+                and ctx.material_request_type == "Purchase"
+            )
+            or (ctx.doctype == "Supplier Quotation")
+        ):
+            ctx.uom = item.purchase_uom if item.purchase_uom else item.stock_uom
+        else:
+            ctx.uom = item.stock_uom
 
-	# Set stock UOM in ctx, so that it can be used while fetching item price
-	ctx.stock_uom = item.stock_uom
+    # Set stock UOM in ctx, so that it can be used while fetching item price
+    ctx.stock_uom = item.stock_uom
 
-	if ctx.batch_no and item.name != frappe.get_cached_value("Batch", ctx.batch_no, "item"):
-		ctx.batch_no = ""
+    if ctx.batch_no and item.name != frappe.get_cached_value(
+        "Batch", ctx.batch_no, "item"
+    ):
+        ctx.batch_no = ""
 
-	out = ItemDetails(
-		{
-			"item_code": item.name,
-			"item_name": item.item_name,
-			"description": cstr(item.description).strip(),
-			"image": cstr(item.image).strip(),
-			"warehouse": warehouse,
-			"income_account": get_default_income_account(
-				ctx, item_defaults, item_group_defaults, brand_defaults
-			),
-			"expense_account": expense_account
-			or get_default_expense_account(ctx, item_defaults, item_group_defaults, brand_defaults),
-			"discount_account": get_default_discount_account(
-				ctx, item_defaults, item_group_defaults, brand_defaults
-			),
-			"provisional_expense_account": get_provisional_account(
-				ctx, item_defaults, item_group_defaults, brand_defaults
-			),
-			"cost_center": get_default_cost_center(ctx, item_defaults, item_group_defaults, brand_defaults),
-			"has_serial_no": item.has_serial_no,
-			"has_batch_no": item.has_batch_no,
-			"batch_no": ctx.batch_no,
-			"uom": ctx.uom,
-			"stock_uom": item.stock_uom,
-			"min_order_qty": flt(item.min_order_qty) if ctx.doctype == "Material Request" else "",
-			"qty": flt(ctx.qty) or 1.0,
-			"stock_qty": flt(ctx.qty) or 1.0,
-			"price_list_rate": 0.0,
-			"base_price_list_rate": 0.0,
-			"rate": 0.0,
-			"base_rate": 0.0,
-			"amount": 0.0,
-			"base_amount": 0.0,
-			"net_rate": 0.0,
-			"net_amount": 0.0,
-			"discount_percentage": 0.0,
-			"discount_amount": flt(ctx.discount_amount) or 0.0,
-			"update_stock": ctx.update_stock if ctx.doctype in ["Sales Invoice", "Purchase Invoice"] else 0,
-			"delivered_by_supplier": item.delivered_by_supplier
-			if ctx.doctype in ["Sales Order", "Sales Invoice"]
-			else 0,
-			"is_fixed_asset": item.is_fixed_asset,
-			"last_purchase_rate": item.last_purchase_rate if ctx.doctype in ["Purchase Order"] else 0,
-			"transaction_date": ctx.transaction_date,
-			"against_blanket_order": ctx.against_blanket_order,
-			"bom_no": item.get("default_bom"),
-			"weight_per_unit": ctx.weight_per_unit or item.get("weight_per_unit"),
-			"weight_uom": ctx.weight_uom or item.get("weight_uom"),
-			"grant_commission": item.get("grant_commission"),
-		}
-	)
+    out = ItemDetails(
+        {
+            "item_code": item.name,
+            "item_name": item.item_name,
+            "description": cstr(item.description).strip(),
+            "image": cstr(item.image).strip(),
+            "warehouse": warehouse,
+            "income_account": get_default_income_account(
+                ctx, item_defaults, item_group_defaults, brand_defaults
+            ),
+            "expense_account": expense_account
+            or get_default_expense_account(
+                ctx, item_defaults, item_group_defaults, brand_defaults
+            ),
+            "discount_account": get_default_discount_account(
+                ctx, item_defaults, item_group_defaults, brand_defaults
+            ),
+            "provisional_expense_account": get_provisional_account(
+                ctx, item_defaults, item_group_defaults, brand_defaults
+            ),
+            "cost_center": get_default_cost_center(
+                ctx, item_defaults, item_group_defaults, brand_defaults
+            ),
+            "has_serial_no": item.has_serial_no,
+            "has_batch_no": item.has_batch_no,
+            "batch_no": ctx.batch_no,
+            "uom": ctx.uom,
+            "stock_uom": item.stock_uom,
+            "min_order_qty": (
+                flt(item.min_order_qty) if ctx.doctype == "Material Request" else ""
+            ),
+            "qty": flt(ctx.qty) or 1.0,
+            "stock_qty": flt(ctx.qty) or 1.0,
+            "price_list_rate": 0.0,
+            "base_price_list_rate": 0.0,
+            "rate": 0.0,
+            "base_rate": 0.0,
+            "amount": 0.0,
+            "base_amount": 0.0,
+            "net_rate": 0.0,
+            "net_amount": 0.0,
+            "discount_percentage": 0.0,
+            "discount_amount": flt(ctx.discount_amount) or 0.0,
+            "update_stock": (
+                ctx.update_stock
+                if ctx.doctype in ["Sales Invoice", "Purchase Invoice"]
+                else 0
+            ),
+            "delivered_by_supplier": (
+                item.delivered_by_supplier
+                if ctx.doctype in ["Sales Order", "Sales Invoice"]
+                else 0
+            ),
+            "is_fixed_asset": item.is_fixed_asset,
+            "last_purchase_rate": (
+                item.last_purchase_rate if ctx.doctype in ["Purchase Order"] else 0
+            ),
+            "transaction_date": ctx.transaction_date,
+            "against_blanket_order": ctx.against_blanket_order,
+            "bom_no": item.get("default_bom"),
+            "weight_per_unit": ctx.weight_per_unit or item.get("weight_per_unit"),
+            "weight_uom": ctx.weight_uom or item.get("weight_uom"),
+            "grant_commission": item.get("grant_commission"),
+        }
+    )
 
-	if not item.is_stock_item and not out.expense_account:
-		out.expense_account = frappe.get_cached_value("Company", ctx.company, "service_expense_account")
+    if not item.is_stock_item and not out.expense_account:
+        out.expense_account = frappe.get_cached_value(
+            "Company", ctx.company, "service_expense_account"
+        )
 
-	default_supplier = get_default_supplier(ctx, item_defaults, item_group_defaults, brand_defaults)
-	if default_supplier:
-		out.supplier = default_supplier
+    default_supplier = get_default_supplier(
+        ctx, item_defaults, item_group_defaults, brand_defaults
+    )
+    if default_supplier:
+        out.supplier = default_supplier
 
-	if item.get("enable_deferred_revenue") or item.get("enable_deferred_expense"):
-		out.update(calculate_service_end_date(ctx, item))
+    if item.get("enable_deferred_revenue") or item.get("enable_deferred_expense"):
+        out.update(calculate_service_end_date(ctx, item))
 
-	# calculate conversion factor
-	if item.stock_uom == ctx.uom:
-		out.conversion_factor = 1.0
-	else:
-		out.conversion_factor = ctx.conversion_factor or get_conversion_factor(item.name, ctx.uom).get(
-			"conversion_factor"
-		)
+    # calculate conversion factor
+    if item.stock_uom == ctx.uom:
+        out.conversion_factor = 1.0
+    else:
+        out.conversion_factor = ctx.conversion_factor or get_conversion_factor(
+            item.name, ctx.uom
+        ).get("conversion_factor")
 
-	ctx.conversion_factor = out.conversion_factor
-	out.stock_qty = out.qty * out.conversion_factor
-	ctx.stock_qty = out.stock_qty
+    ctx.conversion_factor = out.conversion_factor
+    out.stock_qty = out.qty * out.conversion_factor
+    ctx.stock_qty = out.stock_qty
 
-	# calculate last purchase rate
-	if ctx.doctype in purchase_doctypes and not frappe.db.get_single_value(
-		"Buying Settings", "disable_last_purchase_rate"
-	):
-		from erpnext.buying.doctype.purchase_order.purchase_order import item_last_purchase_rate
+    # calculate last purchase rate
+    if ctx.doctype in purchase_doctypes and not frappe.db.get_single_value(
+        "Buying Settings", "disable_last_purchase_rate"
+    ):
+        from erpnext.buying.doctype.purchase_order.purchase_order import (
+            item_last_purchase_rate,
+        )
 
-		out.last_purchase_rate = item_last_purchase_rate(
-			ctx.name, ctx.conversion_rate, item.name, out.conversion_factor
-		)
+        out.last_purchase_rate = item_last_purchase_rate(
+            ctx.name, ctx.conversion_rate, item.name, out.conversion_factor
+        )
 
-	# if default specified in item is for another company, fetch from company
-	for d in [
-		["Account", "income_account", "default_income_account"],
-		["Account", "expense_account", "default_expense_account"],
-		["Cost Center", "cost_center", "cost_center"],
-		["Warehouse", "warehouse", ""],
-	]:
-		if not out[d[1]]:
-			out[d[1]] = frappe.get_cached_value("Company", ctx.company, d[2]) if d[2] else None
+    # if default specified in item is for another company, fetch from company
+    for d in [
+        ["Account", "income_account", "default_income_account"],
+        ["Account", "expense_account", "default_expense_account"],
+        ["Cost Center", "cost_center", "cost_center"],
+        ["Warehouse", "warehouse", ""],
+    ]:
+        if not out[d[1]]:
+            out[d[1]] = (
+                frappe.get_cached_value("Company", ctx.company, d[2]) if d[2] else None
+            )
 
-	for fieldname in ("item_name", "item_group", "brand", "stock_uom"):
-		out[fieldname] = item.get(fieldname)
+    for fieldname in ("item_name", "item_group", "brand", "stock_uom"):
+        out[fieldname] = item.get(fieldname)
 
-	if ctx.manufacturer:
-		part_no = get_item_manufacturer_part_no(ctx.item_code, ctx.manufacturer)
-		if part_no:
-			out.manufacturer_part_no = part_no
-		else:
-			out.manufacturer_part_no = None
-			out.manufacturer = None
-	else:
-		data = frappe.get_cached_value(
-			"Item", item.name, ["default_item_manufacturer", "default_manufacturer_part_no"], as_dict=True
-		)
+    if ctx.manufacturer:
+        part_no = get_item_manufacturer_part_no(ctx.item_code, ctx.manufacturer)
+        if part_no:
+            out.manufacturer_part_no = part_no
+        else:
+            out.manufacturer_part_no = None
+            out.manufacturer = None
+    else:
+        data = frappe.get_cached_value(
+            "Item",
+            item.name,
+            ["default_item_manufacturer", "default_manufacturer_part_no"],
+            as_dict=True,
+        )
 
-		if data:
-			out.update(
-				{
-					"manufacturer": data.default_item_manufacturer,
-					"manufacturer_part_no": data.default_manufacturer_part_no,
-				}
-			)
+        if data:
+            out.update(
+                {
+                    "manufacturer": data.default_item_manufacturer,
+                    "manufacturer_part_no": data.default_manufacturer_part_no,
+                }
+            )
 
-	child_doctype = ctx.doctype + " Item"
-	meta = frappe.get_meta(child_doctype)
-	if meta.get_field("barcode"):
-		update_barcode_value(out)
+    child_doctype = ctx.doctype + " Item"
+    meta = frappe.get_meta(child_doctype)
+    if meta.get_field("barcode"):
+        update_barcode_value(out)
 
-	if out.weight_per_unit:
-		out.total_weight = out.weight_per_unit * out.stock_qty
+    if out.weight_per_unit:
+        out.total_weight = out.weight_per_unit * out.stock_qty
 
-	return out
+    return out
 
 
 @erpnext.normalize_ctx_input(ItemDetailsCtx)
 def get_item_warehouse_(ctx: ItemDetailsCtx, item, overwrite_warehouse, defaults=None):
-	if not defaults:
-		defaults = frappe._dict(
-			{
-				"item_defaults": get_item_defaults(item.name, ctx.company),
-				"item_group_defaults": get_item_group_defaults(item.name, ctx.company),
-				"brand_defaults": get_brand_defaults(item.name, ctx.company),
-			}
-		)
+    if not defaults:
+        defaults = frappe._dict(
+            {
+                "item_defaults": get_item_defaults(item.name, ctx.company),
+                "item_group_defaults": get_item_group_defaults(item.name, ctx.company),
+                "brand_defaults": get_brand_defaults(item.name, ctx.company),
+            }
+        )
 
-	if overwrite_warehouse or not ctx.warehouse:
-		warehouse = (
-			ctx.set_warehouse
-			or defaults.item_defaults.get("default_warehouse")
-			or defaults.item_group_defaults.get("default_warehouse")
-			or defaults.brand_defaults.get("default_warehouse")
-			or ctx.warehouse
-		)
+    if overwrite_warehouse or not ctx.warehouse:
+        warehouse = (
+            ctx.set_warehouse
+            or defaults.item_defaults.get("default_warehouse")
+            or defaults.item_group_defaults.get("default_warehouse")
+            or defaults.brand_defaults.get("default_warehouse")
+            or ctx.warehouse
+        )
 
-	else:
-		warehouse = ctx.warehouse
+    else:
+        warehouse = ctx.warehouse
 
-	if not warehouse:
-		default_warehouse = frappe.get_single_value("Stock Settings", "default_warehouse")
-		if (
-			default_warehouse
-			and frappe.get_cached_value("Warehouse", default_warehouse, "company") == ctx.company
-		):
-			return default_warehouse
+    if not warehouse:
+        default_warehouse = frappe.get_single_value(
+            "Stock Settings", "default_warehouse"
+        )
+        if (
+            default_warehouse
+            and frappe.get_cached_value("Warehouse", default_warehouse, "company")
+            == ctx.company
+        ):
+            return default_warehouse
 
-	return warehouse
+    return warehouse
 
 
 def update_barcode_value(out):
-	barcode_data = get_barcode_data([out])
+    barcode_data = get_barcode_data([out])
 
-	# If item has one barcode then update the value of the barcode field
-	if barcode_data and len(barcode_data.get(out.item_code)) == 1:
-		out["barcode"] = barcode_data.get(out.item_code)[0]
+    # If item has one barcode then update the value of the barcode field
+    if barcode_data and len(barcode_data.get(out.item_code)) == 1:
+        out["barcode"] = barcode_data.get(out.item_code)[0]
 
 
 def get_barcode_data(items_list=None, item_code=None):
-	# get item-wise batch no data
-	# example: {'LED-GRE': [Batch001, Batch002]}
-	# where LED-GRE is item code, SN0001 is serial no and Pune is warehouse
+    # get item-wise batch no data
+    # example: {'LED-GRE': [Batch001, Batch002]}
+    # where LED-GRE is item code, SN0001 is serial no and Pune is warehouse
 
-	itemwise_barcode = {}
-	if not items_list and item_code:
-		_dict_item_code = frappe._dict(
-			{
-				"item_code": item_code,
-			}
-		)
+    itemwise_barcode = {}
+    if not items_list and item_code:
+        _dict_item_code = frappe._dict(
+            {
+                "item_code": item_code,
+            }
+        )
 
-		items_list = [frappe._dict(_dict_item_code)]
+        items_list = [frappe._dict(_dict_item_code)]
 
-	for item in items_list:
-		barcodes = frappe.db.get_all("Item Barcode", filters={"parent": item.item_code}, fields="barcode")
+    for item in items_list:
+        barcodes = frappe.db.get_all(
+            "Item Barcode", filters={"parent": item.item_code}, fields="barcode"
+        )
 
-		for barcode in barcodes:
-			if item.item_code not in itemwise_barcode:
-				itemwise_barcode.setdefault(item.item_code, [])
-			itemwise_barcode[item.item_code].append(barcode.get("barcode"))
+        for barcode in barcodes:
+            if item.item_code not in itemwise_barcode:
+                itemwise_barcode.setdefault(item.item_code, [])
+            itemwise_barcode[item.item_code].append(barcode.get("barcode"))
 
-	return itemwise_barcode
+    return itemwise_barcode
 
 
 @frappe.whitelist()
 def get_item_tax_info(
-	doc: Document | str | None,
-	tax_category: str,
-	item_codes: list | str,
-	item_rates: dict | str | None = None,
-	item_tax_templates: dict | str | None = None,
+    doc: Document | str | None,
+    tax_category: str,
+    item_codes: list | str,
+    item_rates: dict | str | None = None,
+    item_tax_templates: dict | str | None = None,
 ):
-	out = {}
+    out = {}
 
-	if item_tax_templates is None:
-		item_tax_templates = {}
+    if item_tax_templates is None:
+        item_tax_templates = {}
 
-	if item_rates is None:
-		item_rates = {}
+    if item_rates is None:
+        item_rates = {}
 
-	doc = parse_json(doc)
-	item_codes = parse_json(item_codes)
-	item_rates = parse_json(item_rates)
-	item_tax_templates = parse_json(item_tax_templates)
+    doc = parse_json(doc)
+    item_codes = parse_json(item_codes)
+    item_rates = parse_json(item_rates)
+    item_tax_templates = parse_json(item_tax_templates)
 
-	for item_code in item_codes:
-		if not item_code or item_code[1] in out or not item_tax_templates.get(item_code[1]):
-			continue
+    for item_code in item_codes:
+        if (
+            not item_code
+            or item_code[1] in out
+            or not item_tax_templates.get(item_code[1])
+        ):
+            continue
 
-		out[item_code[1]] = ItemDetails()
-		item = frappe.get_cached_doc("Item", item_code[0])
-		ctx: ItemDetailsCtx = {
-			"company": doc.company,
-			"tax_category": tax_category,
-			"base_net_rate": item_rates.get(item_code[1]),
-		}
+        out[item_code[1]] = ItemDetails()
+        item = frappe.get_cached_doc("Item", item_code[0])
+        ctx: ItemDetailsCtx = {
+            "company": doc.company,
+            "tax_category": tax_category,
+            "base_net_rate": item_rates.get(item_code[1]),
+        }
 
-		if item_tax_templates:
-			ctx.update({"item_tax_template": item_tax_templates.get(item_code[1])})
+        if item_tax_templates:
+            ctx.update({"item_tax_template": item_tax_templates.get(item_code[1])})
 
-		get_item_tax_template(ctx, item, out[item_code[1]])
-		out[item_code[1]]["item_tax_rate"] = get_item_tax_map(
-			doc=doc,
-			tax_template=out[item_code[1]].get("item_tax_template"),
-			as_json=True,
-		)
+        get_item_tax_template(ctx, item, out[item_code[1]])
+        out[item_code[1]]["item_tax_rate"] = get_item_tax_map(
+            doc=doc,
+            tax_template=out[item_code[1]].get("item_tax_template"),
+            as_json=True,
+        )
 
-	return out
+    return out
 
 
 @frappe.whitelist()
 @erpnext.normalize_ctx_input(ItemDetailsCtx)
-def get_item_tax_template(ctx: ItemDetailsCtx, item: Document | None = None, out: ItemDetails | None = None):
-	"""
-	Determines item_tax template from item or parent item groups.
+def get_item_tax_template(
+    ctx: ItemDetailsCtx, item: Document | None = None, out: ItemDetails | None = None
+):
+    """
+    Determines item_tax template from item or parent item groups.
 
-	Accesses:
-	        ctx = {
-	        "child_doctype": str
-	        }
-	Passes:
-	        ctx = {
-	                "company": str
-	                "bill_date": str
-	                "transaction_date": str
-	        "tax_category": None
-	        "item_tax_template": None
-	        "base_net_rate": float
-	        }
-	"""
-	if not item:
-		if not ctx.get("item_code"):
-			frappe.throw(_("Item/Item Code required to get Item Tax Template."))
-		else:
-			item = frappe.get_cached_doc("Item", ctx.item_code)
+    Accesses:
+            ctx = {
+            "child_doctype": str
+            }
+    Passes:
+            ctx = {
+                    "company": str
+                    "bill_date": str
+                    "transaction_date": str
+            "tax_category": None
+            "item_tax_template": None
+            "base_net_rate": float
+            }
+    """
+    if not item:
+        if not ctx.get("item_code"):
+            frappe.throw(_("Item/Item Code required to get Item Tax Template."))
+        else:
+            item = frappe.get_cached_doc("Item", ctx.item_code)
 
-	item_tax_template = None
-	if item.taxes:
-		item_tax_template = _get_item_tax_template(ctx, item.taxes, out)
+    item_tax_template = None
+    if item.taxes:
+        item_tax_template = _get_item_tax_template(ctx, item.taxes, out)
 
-	if not item_tax_template:
-		item_group = item.item_group
-		while item_group and not item_tax_template:
-			item_group_doc = frappe.get_cached_doc("Item Group", item_group)
-			item_tax_template = _get_item_tax_template(ctx, item_group_doc.taxes, out)
-			item_group = item_group_doc.parent_item_group
+    if not item_tax_template:
+        item_group = item.item_group
+        while item_group and not item_tax_template:
+            item_group_doc = frappe.get_cached_doc("Item Group", item_group)
+            item_tax_template = _get_item_tax_template(ctx, item_group_doc.taxes, out)
+            item_group = item_group_doc.parent_item_group
 
-	if out and ctx.get("child_doctype") and item_tax_template:
-		out.update(get_fetch_values(ctx.get("child_doctype"), "item_tax_template", item_tax_template))
+    if out and ctx.get("child_doctype") and item_tax_template:
+        out.update(
+            get_fetch_values(
+                ctx.get("child_doctype"), "item_tax_template", item_tax_template
+            )
+        )
 
-	return item_tax_template
+    return item_tax_template
 
 
 @erpnext.normalize_ctx_input(ItemDetailsCtx)
 def _get_item_tax_template(
-	ctx: ItemDetailsCtx, taxes, out: ItemDetails | None = None, for_validate=False
+    ctx: ItemDetailsCtx, taxes, out: ItemDetails | None = None, for_validate=False
 ) -> None | str | list[str]:
-	"""
-	Accesses:
-	        ctx = {
-	                "company": str
-	                "bill_date": str
-	                "transaction_date": str
-	        "tax_category": None
-	        "item_tax_template": None
-	        }
-	Passes:
-	        ctx = {
-	        "base_net_rate": float
-	        }
-	"""
-	if out is None:
-		out = ItemDetails()
-	taxes_with_validity = []
-	taxes_with_no_validity = []
+    """
+    Accesses:
+            ctx = {
+                    "company": str
+                    "bill_date": str
+                    "transaction_date": str
+            "tax_category": None
+            "item_tax_template": None
+            }
+    Passes:
+            ctx = {
+            "base_net_rate": float
+            }
+    """
+    if out is None:
+        out = ItemDetails()
+    taxes_with_validity = []
+    taxes_with_no_validity = []
 
-	for tax in taxes:
-		disabled, tax_company = frappe.get_cached_value(
-			"Item Tax Template", tax.item_tax_template, ["disabled", "company"]
-		)
-		if not disabled and tax_company == ctx["company"]:
-			if tax.valid_from or tax.maximum_net_rate:
-				# In purchase Invoice first preference will be given to supplier invoice date
-				# if supplier date is not present then posting date
-				validation_date = (
-					ctx.get("bill_date") or ctx.get("posting_date") or ctx.get("transaction_date")
-				)
+    for tax in taxes:
+        disabled, tax_company = frappe.get_cached_value(
+            "Item Tax Template", tax.item_tax_template, ["disabled", "company"]
+        )
+        if not disabled and tax_company == ctx["company"]:
+            if tax.valid_from or tax.maximum_net_rate:
+                # In purchase Invoice first preference will be given to supplier invoice date
+                # if supplier date is not present then posting date
+                validation_date = (
+                    ctx.get("bill_date")
+                    or ctx.get("posting_date")
+                    or ctx.get("transaction_date")
+                )
 
-				if getdate(tax.valid_from) <= getdate(validation_date) and is_within_valid_range(ctx, tax):
-					taxes_with_validity.append(tax)
-			else:
-				taxes_with_no_validity.append(tax)
+                if getdate(tax.valid_from) <= getdate(
+                    validation_date
+                ) and is_within_valid_range(ctx, tax):
+                    taxes_with_validity.append(tax)
+            else:
+                taxes_with_no_validity.append(tax)
 
-	if taxes_with_validity:
-		taxes = sorted(taxes_with_validity, key=lambda i: i.valid_from or tax.maximum_net_rate, reverse=True)
-	else:
-		taxes = taxes_with_no_validity
+    if taxes_with_validity:
+        taxes = sorted(
+            taxes_with_validity,
+            key=lambda i: i.valid_from or tax.maximum_net_rate,
+            reverse=True,
+        )
+    else:
+        taxes = taxes_with_no_validity
 
-	if for_validate:
-		return [
-			tax.item_tax_template
-			for tax in taxes
-			if (
-				cstr(tax.tax_category) == cstr(ctx.get("tax_category"))
-				and (tax.item_tax_template not in taxes)
-			)
-		]
+    if for_validate:
+        return [
+            tax.item_tax_template
+            for tax in taxes
+            if (
+                cstr(tax.tax_category) == cstr(ctx.get("tax_category"))
+                and (tax.item_tax_template not in taxes)
+            )
+        ]
 
-	# all templates have validity and no template is valid
-	if not taxes_with_validity and (not taxes_with_no_validity):
-		return None
+    # all templates have validity and no template is valid
+    if not taxes_with_validity and (not taxes_with_no_validity):
+        return None
 
-	# do not change if already a valid template
-	if ctx.get("item_tax_template") in {t.item_tax_template for t in taxes}:
-		out.item_tax_template = ctx.get("item_tax_template")
-		return ctx.get("item_tax_template")
+    # do not change if already a valid template
+    if ctx.get("item_tax_template") in {t.item_tax_template for t in taxes}:
+        out.item_tax_template = ctx.get("item_tax_template")
+        return ctx.get("item_tax_template")
 
-	for tax in taxes:
-		if cstr(tax.tax_category) == cstr(ctx.get("tax_category")):
-			out.item_tax_template = tax.item_tax_template
-			return tax.item_tax_template
-	return None
+    for tax in taxes:
+        if cstr(tax.tax_category) == cstr(ctx.get("tax_category")):
+            out.item_tax_template = tax.item_tax_template
+            return tax.item_tax_template
+    return None
 
 
 @erpnext.normalize_ctx_input(ItemDetailsCtx)
 def is_within_valid_range(ctx: ItemDetailsCtx, tax) -> bool:
-	"""
-	Accesses:
-	        ctx = {
-	        "base_net_rate": float
-	        }
-	"""
+    """
+    Accesses:
+            ctx = {
+            "base_net_rate": float
+            }
+    """
 
-	if not flt(tax.maximum_net_rate):
-		# No range specified, just ignore
-		return True
-	elif flt(tax.minimum_net_rate) <= flt(ctx.get("base_net_rate")) <= flt(tax.maximum_net_rate):
-		return True
+    if not flt(tax.maximum_net_rate):
+        # No range specified, just ignore
+        return True
+    elif (
+        flt(tax.minimum_net_rate)
+        <= flt(ctx.get("base_net_rate"))
+        <= flt(tax.maximum_net_rate)
+    ):
+        return True
 
-	return False
+    return False
 
 
 @frappe.whitelist()
-def get_item_tax_map(*, doc: str | dict | Document, tax_template: str | None = None, as_json: bool = True):
-	doc = parse_json(doc)
-	item_tax_map = {}
-	for t in (t for t in (doc.get("taxes") or []) if not t.get("set_by_item_tax_template")):
-		item_tax_map[t.get("account_head")] = t.get("rate")
+def get_item_tax_map(
+    *, doc: str | dict | Document, tax_template: str | None = None, as_json: bool = True
+):
+    doc = parse_json(doc)
+    item_tax_map = {}
+    for t in (
+        t for t in (doc.get("taxes") or []) if not t.get("set_by_item_tax_template")
+    ):
+        item_tax_map[t.get("account_head")] = t.get("rate")
 
-	if tax_template:
-		template = frappe.get_cached_doc("Item Tax Template", tax_template)
-		for d in template.taxes:
-			if frappe.get_cached_value("Account", d.tax_type, "company") == doc.get("company"):
-				item_tax_map[d.tax_type] = d.tax_rate
+    if tax_template:
+        template = frappe.get_cached_doc("Item Tax Template", tax_template)
+        for d in template.taxes:
+            if frappe.get_cached_value("Account", d.tax_type, "company") == doc.get(
+                "company"
+            ):
+                item_tax_map[d.tax_type] = d.tax_rate
 
-	return json.dumps(item_tax_map) if as_json else item_tax_map
+    return json.dumps(item_tax_map) if as_json else item_tax_map
 
 
 @frappe.whitelist()
 @erpnext.normalize_ctx_input(ItemDetailsCtx)
 def calculate_service_end_date(ctx: ItemDetailsCtx, item: Document | None = None):
-	_preprocess_ctx(ctx)
-	if not item:
-		item = frappe.get_cached_doc("Item", ctx.item_code)
+    _preprocess_ctx(ctx)
+    if not item:
+        item = frappe.get_cached_doc("Item", ctx.item_code)
 
-	doctype = ctx.parenttype or ctx.doctype
-	if doctype == "Sales Invoice":
-		enable_deferred = "enable_deferred_revenue"
-		no_of_months = "no_of_months"
-		account = "deferred_revenue_account"
-	else:
-		enable_deferred = "enable_deferred_expense"
-		no_of_months = "no_of_months_exp"
-		account = "deferred_expense_account"
+    doctype = ctx.parenttype or ctx.doctype
+    if doctype == "Sales Invoice":
+        enable_deferred = "enable_deferred_revenue"
+        no_of_months = "no_of_months"
+        account = "deferred_revenue_account"
+    else:
+        enable_deferred = "enable_deferred_expense"
+        no_of_months = "no_of_months_exp"
+        account = "deferred_expense_account"
 
-	service_start_date = ctx.service_start_date if ctx.service_start_date else ctx.transaction_date
-	service_end_date = add_months(service_start_date, item.get(no_of_months))
-	deferred_detail = {"service_start_date": service_start_date, "service_end_date": service_end_date}
-	deferred_detail[enable_deferred] = item.get(enable_deferred)
-	deferred_detail[account] = get_default_deferred_account(ctx, item, fieldname=account)
+    service_start_date = (
+        ctx.service_start_date if ctx.service_start_date else ctx.transaction_date
+    )
+    service_end_date = add_months(service_start_date, item.get(no_of_months))
+    deferred_detail = {
+        "service_start_date": service_start_date,
+        "service_end_date": service_end_date,
+    }
+    deferred_detail[enable_deferred] = item.get(enable_deferred)
+    deferred_detail[account] = get_default_deferred_account(
+        ctx, item, fieldname=account
+    )
 
-	return deferred_detail
+    return deferred_detail
 
 
 def get_default_income_account(ctx: ItemDetailsCtx, item, item_group, brand):
-	return (
-		item.get("income_account")
-		or item_group.get("income_account")
-		or brand.get("income_account")
-		or ctx.income_account
-	)
+    return (
+        item.get("income_account")
+        or item_group.get("income_account")
+        or brand.get("income_account")
+        or ctx.income_account
+    )
 
 
 def get_default_inventory_account(ctx: ItemDetailsCtx, item, item_group, brand):
-	if not frappe.get_cached_value("Company", ctx.company, "enable_item_wise_inventory_account"):
-		return None
+    if not frappe.get_cached_value(
+        "Company", ctx.company, "enable_item_wise_inventory_account"
+    ):
+        return None
 
-	return (
-		ctx.inventory_account
-		or item.get("default_inventory_account")
-		or item_group.get("default_inventory_account")
-		or brand.get("default_inventory_account")
-	)
+    return (
+        ctx.inventory_account
+        or item.get("default_inventory_account")
+        or item_group.get("default_inventory_account")
+        or brand.get("default_inventory_account")
+    )
 
 
 def get_default_expense_account(ctx: ItemDetailsCtx, item, item_group, brand):
-	if ctx.get("doctype") in ["Sales Invoice", "Delivery Note"]:
-		expense_account = (
-			item.get("default_cogs_account")
-			or item_group.get("default_cogs_account")
-			or brand.get("default_cogs_account")
-		)
+    if ctx.get("doctype") in ["Sales Invoice", "Delivery Note"]:
+        expense_account = (
+            item.get("default_cogs_account")
+            or item_group.get("default_cogs_account")
+            or brand.get("default_cogs_account")
+        )
 
-		if not expense_account:
-			expense_account = frappe.get_cached_value("Company", ctx.company, "default_expense_account")
+        if not expense_account:
+            expense_account = frappe.get_cached_value(
+                "Company", ctx.company, "default_expense_account"
+            )
 
-		if expense_account:
-			return expense_account
+        if expense_account:
+            return expense_account
 
-	return (
-		item.get("expense_account")
-		or item_group.get("expense_account")
-		or brand.get("expense_account")
-		or ctx.expense_account
-	)
+    return (
+        item.get("expense_account")
+        or item_group.get("expense_account")
+        or brand.get("expense_account")
+        or ctx.expense_account
+    )
 
 
 def get_provisional_account(ctx: ItemDetailsCtx, item, item_group, brand):
-	return (
-		item.get("default_provisional_account")
-		or item_group.get("default_provisional_account")
-		or brand.get("default_provisional_account")
-		or ctx.default_provisional_account
-	)
+    return (
+        item.get("default_provisional_account")
+        or item_group.get("default_provisional_account")
+        or brand.get("default_provisional_account")
+        or ctx.default_provisional_account
+    )
 
 
 def get_default_discount_account(ctx: ItemDetailsCtx, item, item_group, brand):
-	return (
-		item.get("default_discount_account")
-		or item_group.get("default_discount_account")
-		or brand.get("default_discount_account")
-		or ctx.discount_account
-	)
+    return (
+        item.get("default_discount_account")
+        or item_group.get("default_discount_account")
+        or brand.get("default_discount_account")
+        or ctx.discount_account
+    )
 
 
 def get_default_deferred_account(ctx: ItemDetailsCtx, item, fieldname=None):
-	if item.get("enable_deferred_revenue") or item.get("enable_deferred_expense"):
-		return (
-			frappe.get_cached_value(
-				"Item Default",
-				{"parent": ctx.item_code, "company": ctx.company},
-				fieldname,
-			)
-			or ctx.get(fieldname)
-			or frappe.get_cached_value("Company", ctx.company, "default_" + fieldname)
-		)
-	else:
-		return None
+    if item.get("enable_deferred_revenue") or item.get("enable_deferred_expense"):
+        return (
+            frappe.get_cached_value(
+                "Item Default",
+                {"parent": ctx.item_code, "company": ctx.company},
+                fieldname,
+            )
+            or ctx.get(fieldname)
+            or frappe.get_cached_value("Company", ctx.company, "default_" + fieldname)
+        )
+    else:
+        return None
 
 
 @erpnext.normalize_ctx_input(ItemDetailsCtx)
-def get_default_cost_center(ctx: ItemDetailsCtx, item=None, item_group=None, brand=None, company=None):
-	cost_center = None
+def get_default_cost_center(
+    ctx: ItemDetailsCtx, item=None, item_group=None, brand=None, company=None
+):
+    cost_center = None
 
-	if not company and ctx.get("company"):
-		company = ctx.get("company")
+    if not company and ctx.get("company"):
+        company = ctx.get("company")
 
-	if ctx.get("project"):
-		cost_center = frappe.db.get_value("Project", ctx.get("project"), "cost_center", cache=True)
+    if ctx.get("project"):
+        cost_center = frappe.db.get_value(
+            "Project", ctx.get("project"), "cost_center", cache=True
+        )
 
-	if not cost_center and (item and item_group and brand):
-		if ctx.get("customer"):
-			cost_center = (
-				item.get("selling_cost_center")
-				or item_group.get("selling_cost_center")
-				or brand.get("selling_cost_center")
-			)
-		else:
-			cost_center = (
-				item.get("buying_cost_center")
-				or item_group.get("buying_cost_center")
-				or brand.get("buying_cost_center")
-			)
+    if not cost_center and (item and item_group and brand):
+        if ctx.get("customer"):
+            cost_center = (
+                item.get("selling_cost_center")
+                or item_group.get("selling_cost_center")
+                or brand.get("selling_cost_center")
+            )
+        else:
+            cost_center = (
+                item.get("buying_cost_center")
+                or item_group.get("buying_cost_center")
+                or brand.get("buying_cost_center")
+            )
 
-	elif not cost_center and ctx.get("item_code") and company:
-		for method in ["get_item_defaults", "get_item_group_defaults", "get_brand_defaults"]:
-			path = f"erpnext.stock.get_item_details.{method}"
-			data = frappe.get_attr(path)(ctx.get("item_code"), company)
+    elif not cost_center and ctx.get("item_code") and company:
+        for method in [
+            "get_item_defaults",
+            "get_item_group_defaults",
+            "get_brand_defaults",
+        ]:
+            path = f"erpnext.stock.get_item_details.{method}"
+            data = frappe.get_attr(path)(ctx.get("item_code"), company)
 
-			if data and (data.selling_cost_center or data.buying_cost_center):
-				if ctx.get("customer") and data.selling_cost_center:
-					return data.selling_cost_center
+            if data and (data.selling_cost_center or data.buying_cost_center):
+                if ctx.get("customer") and data.selling_cost_center:
+                    return data.selling_cost_center
 
-				elif ctx.get("supplier") and data.buying_cost_center:
-					return data.buying_cost_center
+                elif ctx.get("supplier") and data.buying_cost_center:
+                    return data.buying_cost_center
 
-				return data.selling_cost_center or data.buying_cost_center
+                return data.selling_cost_center or data.buying_cost_center
 
-	if not cost_center and ctx.get("cost_center"):
-		cost_center = ctx.get("cost_center")
+    if not cost_center and ctx.get("cost_center"):
+        cost_center = ctx.get("cost_center")
 
-	if company and cost_center and frappe.get_cached_value("Cost Center", cost_center, "company") != company:
-		return None
+    if (
+        company
+        and cost_center
+        and frappe.get_cached_value("Cost Center", cost_center, "company") != company
+    ):
+        return None
 
-	if not cost_center and company:
-		cost_center = frappe.get_cached_value("Company", company, "cost_center")
+    if not cost_center and company:
+        cost_center = frappe.get_cached_value("Company", company, "cost_center")
 
-	return cost_center
+    return cost_center
 
 
 def get_default_supplier(_ctx: ItemDetailsCtx, item, item_group, brand):
-	return item.get("default_supplier") or item_group.get("default_supplier") or brand.get("default_supplier")
+    return (
+        item.get("default_supplier")
+        or item_group.get("default_supplier")
+        or brand.get("default_supplier")
+    )
 
 
 def get_price_list_rate(ctx: ItemDetailsCtx, item_doc, out: ItemDetails = None):
-	if out is None:
-		out = ItemDetails()
+    if out is None:
+        out = ItemDetails()
 
-	meta = frappe.get_meta(ctx.parenttype or ctx.doctype)
+    meta = frappe.get_meta(ctx.parenttype or ctx.doctype)
 
-	if meta.get_field("currency") or ctx.get("currency"):
-		if not ctx.price_list_currency or not ctx.plc_conversion_rate:
-			# if currency and plc_conversion_rate exist then
-			# `get_price_list_currency_and_exchange_rate` has already been called
-			pl_details = get_price_list_currency_and_exchange_rate(ctx)
-			ctx.update(pl_details)
+    if meta.get_field("currency") or ctx.get("currency"):
+        if not ctx.price_list_currency or not ctx.plc_conversion_rate:
+            # if currency and plc_conversion_rate exist then
+            # `get_price_list_currency_and_exchange_rate` has already been called
+            pl_details = get_price_list_currency_and_exchange_rate(ctx)
+            ctx.update(pl_details)
 
-		if meta.get_field("currency"):
-			validate_conversion_rate(ctx, meta)
+        if meta.get_field("currency"):
+            validate_conversion_rate(ctx, meta)
 
-		price_list_rate = get_price_list_rate_for(ctx, item_doc.name)
+        price_list_rate = get_price_list_rate_for(ctx, item_doc.name)
 
-		# variant
-		if price_list_rate is None and item_doc.variant_of:
-			price_list_rate = get_price_list_rate_for(ctx, item_doc.variant_of)
+        # variant
+        if price_list_rate is None and item_doc.variant_of:
+            price_list_rate = get_price_list_rate_for(ctx, item_doc.variant_of)
 
-		# insert in database
-		if price_list_rate is None or frappe.get_cached_value(
-			"Stock Settings", "Stock Settings", "update_existing_price_list_rate"
-		):
-			insert_item_price(ctx)
+        # insert in database
+        if price_list_rate is None or frappe.get_cached_value(
+            "Stock Settings", "Stock Settings", "update_existing_price_list_rate"
+        ):
+            insert_item_price(ctx)
 
-		if price_list_rate is None:
-			return out
+        if price_list_rate is None:
+            return out
 
-		out.price_list_rate = flt(price_list_rate) * flt(ctx.plc_conversion_rate) / flt(ctx.conversion_rate)
+        out.price_list_rate = (
+            flt(price_list_rate)
+            * flt(ctx.plc_conversion_rate)
+            / flt(ctx.conversion_rate)
+        )
 
-		if frappe.db.get_single_value("Buying Settings", "disable_last_purchase_rate"):
-			return out
+        if frappe.db.get_single_value("Buying Settings", "disable_last_purchase_rate"):
+            return out
 
-		if not ctx.is_internal_supplier and not out.price_list_rate and ctx.transaction_type == "buying":
-			from erpnext.stock.doctype.item.item import get_last_purchase_details
+        if (
+            not ctx.is_internal_supplier
+            and not out.price_list_rate
+            and ctx.transaction_type == "buying"
+        ):
+            from erpnext.stock.doctype.item.item import get_last_purchase_details
 
-			out.update(get_last_purchase_details(item_doc.name, ctx.name, ctx.conversion_rate))
+            out.update(
+                get_last_purchase_details(item_doc.name, ctx.name, ctx.conversion_rate)
+            )
 
-	return out
+    return out
 
 
 def insert_item_price(ctx: ItemDetailsCtx):
-	"""Insert Item Price if Price List and Price List Rate are specified and currency is the same"""
-	if not ctx.price_list or not ctx.rate or ctx.is_internal_supplier or ctx.is_internal_customer:
-		return
+    """Insert Item Price if Price List and Price List Rate are specified and currency is the same"""
+    if (
+        not ctx.price_list
+        or not ctx.rate
+        or ctx.is_internal_supplier
+        or ctx.is_internal_customer
+    ):
+        return
 
-	stock_settings = frappe.get_cached_doc("Stock Settings")
+    stock_settings = frappe.get_cached_doc("Stock Settings")
 
-	if (
-		not frappe.db.get_value("Price List", ctx.price_list, "currency", cache=True) == ctx.currency
-		or not stock_settings.auto_insert_price_list_rate_if_missing
-		or not frappe.has_permission("Item Price", "write")
-	):
-		return
+    if (
+        not frappe.db.get_value("Price List", ctx.price_list, "currency", cache=True)
+        == ctx.currency
+        or not stock_settings.auto_insert_price_list_rate_if_missing
+        or not frappe.has_permission("Item Price", "write")
+    ):
+        return
 
-	transaction_date = (
-		getdate(ctx.get("posting_date") or ctx.get("transaction_date") or ctx.get("posting_datetime"))
-		or getdate()
-	)
+    transaction_date = (
+        getdate(
+            ctx.get("posting_date")
+            or ctx.get("transaction_date")
+            or ctx.get("posting_datetime")
+        )
+        or getdate()
+    )
 
-	item_prices = frappe.get_all(
-		"Item Price",
-		filters={
-			"item_code": ctx.item_code,
-			"price_list": ctx.price_list,
-			"currency": ctx.currency,
-			"uom": ctx.stock_uom,
-		},
-		fields=["name", "price_list_rate", "valid_from", "valid_upto"],
-		order_by="valid_from desc, creation desc",
-	)
-	item_price = next(
-		(
-			row
-			for row in item_prices
-			if (not row.valid_from or getdate(row.valid_from) <= transaction_date)
-			and (not row.valid_upto or getdate(row.valid_upto) >= transaction_date)
-		),
-		item_prices[0] if item_prices else None,
-	)
+    item_prices = frappe.get_all(
+        "Item Price",
+        filters={
+            "item_code": ctx.item_code,
+            "price_list": ctx.price_list,
+            "currency": ctx.currency,
+            "uom": ctx.stock_uom,
+        },
+        fields=["name", "price_list_rate", "valid_from", "valid_upto"],
+        order_by="valid_from desc, creation desc",
+    )
+    item_price = next(
+        (
+            row
+            for row in item_prices
+            if (not row.valid_from or getdate(row.valid_from) <= transaction_date)
+            and (not row.valid_upto or getdate(row.valid_upto) >= transaction_date)
+        ),
+        item_prices[0] if item_prices else None,
+    )
 
-	update_based_on_price_list_rate = stock_settings.update_price_list_based_on == "Price List Rate"
+    update_based_on_price_list_rate = (
+        stock_settings.update_price_list_based_on == "Price List Rate"
+    )
 
-	if item_price and item_price.name:
-		if not stock_settings.update_existing_price_list_rate:
-			return
+    if item_price and item_price.name:
+        if not stock_settings.update_existing_price_list_rate:
+            return
 
-		rate_to_consider = flt(ctx.price_list_rate) if update_based_on_price_list_rate else flt(ctx.rate)
-		price_list_rate = _get_stock_uom_rate(rate_to_consider, ctx)
+        rate_to_consider = (
+            flt(ctx.price_list_rate)
+            if update_based_on_price_list_rate
+            else flt(ctx.rate)
+        )
+        price_list_rate = _get_stock_uom_rate(rate_to_consider, ctx)
 
-		if not price_list_rate or item_price.price_list_rate == price_list_rate:
-			return
+        if not price_list_rate or item_price.price_list_rate == price_list_rate:
+            return
 
-		is_price_valid_for_transaction = (
-			not item_price.valid_from or getdate(item_price.valid_from) <= transaction_date
-		) and (not item_price.valid_upto or getdate(item_price.valid_upto) >= transaction_date)
-		if is_price_valid_for_transaction:
-			frappe.db.set_value("Item Price", item_price.name, "price_list_rate", price_list_rate)
-			frappe.msgprint(
-				_("Item Price updated for {0} in Price List {1}").format(ctx.item_code, ctx.price_list),
-				alert=True,
-			)
-		else:
-			# if price is not valid for the transaction date, insert a new price list rate with updated price and future validity
+        is_price_valid_for_transaction = (
+            not item_price.valid_from
+            or getdate(item_price.valid_from) <= transaction_date
+        ) and (
+            not item_price.valid_upto
+            or getdate(item_price.valid_upto) >= transaction_date
+        )
+        if is_price_valid_for_transaction:
+            frappe.db.set_value(
+                "Item Price", item_price.name, "price_list_rate", price_list_rate
+            )
+            frappe.msgprint(
+                _("Item Price updated for {0} in Price List {1}").format(
+                    ctx.item_code, ctx.price_list
+                ),
+                alert=True,
+            )
+        else:
+            # if price is not valid for the transaction date, insert a new price list rate with updated price and future validity
 
-			item_price = frappe.new_doc(
-				"Item Price",
-				item_code=ctx.item_code,
-				price_list_rate=price_list_rate,
-				currency=ctx.currency,
-				uom=ctx.stock_uom,
-				price_list=ctx.price_list,
-			)
-			item_price.insert()
-			frappe.msgprint(
-				_("Item Price Added for {0} in Price List {1}").format(
-					get_link_to_form("Item", ctx.item_code), ctx.price_list
-				),
-				alert=True,
-			)
-	else:
-		rate_to_consider = (
-			(flt(ctx.price_list_rate) or flt(ctx.rate)) if update_based_on_price_list_rate else flt(ctx.rate)
-		)
-		price_list_rate = _get_stock_uom_rate(rate_to_consider, ctx)
+            item_price = frappe.new_doc(
+                "Item Price",
+                item_code=ctx.item_code,
+                price_list_rate=price_list_rate,
+                currency=ctx.currency,
+                uom=ctx.stock_uom,
+                price_list=ctx.price_list,
+            )
+            item_price.insert()
+            frappe.msgprint(
+                _("Item Price Added for {0} in Price List {1}").format(
+                    get_link_to_form("Item", ctx.item_code), ctx.price_list
+                ),
+                alert=True,
+            )
+    else:
+        rate_to_consider = (
+            (flt(ctx.price_list_rate) or flt(ctx.rate))
+            if update_based_on_price_list_rate
+            else flt(ctx.rate)
+        )
+        price_list_rate = _get_stock_uom_rate(rate_to_consider, ctx)
 
-		item_price = frappe.get_doc(
-			{
-				"doctype": "Item Price",
-				"price_list": ctx.price_list,
-				"item_code": ctx.item_code,
-				"currency": ctx.currency,
-				"price_list_rate": price_list_rate,
-				"uom": ctx.stock_uom,
-			}
-		)
-		item_price.insert()
-		frappe.msgprint(
-			_("Item Price added for {0} in Price List {1}").format(
-				get_link_to_form("Item", ctx.item_code), ctx.price_list
-			)
-		)
+        item_price = frappe.get_doc(
+            {
+                "doctype": "Item Price",
+                "price_list": ctx.price_list,
+                "item_code": ctx.item_code,
+                "currency": ctx.currency,
+                "price_list_rate": price_list_rate,
+                "uom": ctx.stock_uom,
+            }
+        )
+        item_price.insert()
+        frappe.msgprint(
+            _("Item Price added for {0} in Price List {1}").format(
+                get_link_to_form("Item", ctx.item_code), ctx.price_list
+            )
+        )
 
 
 def _get_stock_uom_rate(rate: float, ctx: ItemDetailsCtx):
-	return rate / ctx.conversion_factor if ctx.conversion_factor else rate
+    return rate / ctx.conversion_factor if ctx.conversion_factor else rate
 
 
 def get_item_price(
-	pctx: ItemPriceCtx | dict, item_code, ignore_party=False, force_batch_no=False
+    pctx: ItemPriceCtx | dict, item_code, ignore_party=False, force_batch_no=False
 ) -> list[dict]:
-	"""
-	Get name, price_list_rate from Item Price based on conditions
-	        Check if the desired qty is within the increment of the packing list.
-	:param pctx: dict (or frappe._dict) with mandatory fields price_list, uom
-	        optional fields transaction_date, customer, supplier
-	:param item_code: str, Item Doctype field item_code
-	"""
-	pctx: ItemPriceCtx = frappe._dict(pctx)
+    """
+    Get name, price_list_rate from Item Price based on conditions
+            Check if the desired qty is within the increment of the packing list.
+    :param pctx: dict (or frappe._dict) with mandatory fields price_list, uom
+            optional fields transaction_date, customer, supplier
+    :param item_code: str, Item Doctype field item_code
+    """
+    pctx: ItemPriceCtx = frappe._dict(pctx)
 
-	ip = frappe.qb.DocType("Item Price")
-	query = (
-		frappe.qb.from_(ip)
-		.select(ip.name, ip.price_list_rate, ip.uom)
-		.where(
-			(ip.item_code == item_code)
-			& (ip.price_list == pctx.price_list)
-			& (IfNull(ip.uom, "").isin(["", pctx.uom]))
-		)
-		.orderby(ip.valid_from, order=frappe.qb.desc)
-		.orderby(IfNull(ip.batch_no, ""), order=frappe.qb.desc)
-		.orderby(ip.uom, order=frappe.qb.desc)
-		.limit(1)
-	)
+    ip = frappe.qb.DocType("Item Price")
+    query = (
+        frappe.qb.from_(ip)
+        .select(ip.name, ip.price_list_rate, ip.uom)
+        .where(
+            (ip.item_code == item_code)
+            & (ip.price_list == pctx.price_list)
+            & (IfNull(ip.uom, "").isin(["", pctx.uom]))
+        )
+        .orderby(ip.valid_from, order=frappe.qb.desc)
+        .orderby(IfNull(ip.batch_no, ""), order=frappe.qb.desc)
+        .orderby(ip.uom, order=frappe.qb.desc)
+        .limit(1)
+    )
 
-	if force_batch_no:
-		query = query.where(ip.batch_no == pctx.batch_no)
-	else:
-		query = query.where(IfNull(ip.batch_no, "").isin(["", pctx.batch_no]))
+    if force_batch_no:
+        query = query.where(ip.batch_no == pctx.batch_no)
+    else:
+        query = query.where(IfNull(ip.batch_no, "").isin(["", pctx.batch_no]))
 
-	if not ignore_party:
-		if pctx.customer:
-			query = query.where(ip.customer == pctx.customer)
-		elif pctx.supplier:
-			query = query.where(ip.supplier == pctx.supplier)
-		else:
-			query = query.where((IfNull(ip.customer, "") == "") & (IfNull(ip.supplier, "") == ""))
+    if not ignore_party:
+        if pctx.customer:
+            query = query.where(ip.customer == pctx.customer)
+        elif pctx.supplier:
+            query = query.where(ip.supplier == pctx.supplier)
+        else:
+            query = query.where(
+                (IfNull(ip.customer, "") == "") & (IfNull(ip.supplier, "") == "")
+            )
 
-	if pctx.transaction_date:
-		query = query.where(
-			(IfNull(ip.valid_from, "2000-01-01") <= pctx.transaction_date)
-			& (IfNull(ip.valid_upto, "2500-12-31") >= pctx.transaction_date)
-		)
+    if pctx.transaction_date:
+        query = query.where(
+            (IfNull(ip.valid_from, "2000-01-01") <= pctx.transaction_date)
+            & (IfNull(ip.valid_upto, "2500-12-31") >= pctx.transaction_date)
+        )
 
-	return query.run(as_dict=True)
+    return query.run(as_dict=True)
 
 
 @frappe.whitelist()
 def get_batch_based_item_price(pctx: ItemPriceCtx | dict | str, item_code: str):
-	pctx = parse_json(pctx)
+    pctx = parse_json(pctx)
 
-	item_price = get_item_price(pctx, item_code, force_batch_no=True)
-	if not item_price:
-		item_price = get_item_price(pctx, item_code, ignore_party=True, force_batch_no=True)
+    item_price = get_item_price(pctx, item_code, force_batch_no=True)
+    if not item_price:
+        item_price = get_item_price(
+            pctx, item_code, ignore_party=True, force_batch_no=True
+        )
 
-	is_free_item = pctx.get("items", [{}])[0].get("is_free_item")
+    is_free_item = pctx.get("items", [{}])[0].get("is_free_item")
 
-	if item_price and item_price[0].uom == pctx.uom and not is_free_item:
-		return item_price[0].price_list_rate
+    if item_price and item_price[0].uom == pctx.uom and not is_free_item:
+        return item_price[0].price_list_rate
 
-	return 0.0
+    return 0.0
 
 
 @erpnext.normalize_ctx_input(ItemDetailsCtx)
 def get_price_list_rate_for(ctx: ItemDetailsCtx, item_code: str):
-	"""
-	:param customer: link to Customer DocType
-	:param supplier: link to Supplier DocType
-	:param price_list: str (Standard Buying or Standard Selling)
-	:param item_code: str, Item Doctype field item_code
-	:param qty: Desired Qty
-	:param transaction_date: Date of the price
-	"""
-	pctx = ItemPriceCtx(
-		{
-			"item_code": item_code,
-			"price_list": ctx.get("price_list"),
-			"customer": ctx.get("customer"),
-			"supplier": ctx.get("supplier"),
-			"uom": ctx.get("uom"),
-			"transaction_date": ctx.get("transaction_date"),
-			"batch_no": ctx.get("batch_no"),
-		}
-	)
+    """
+    :param customer: link to Customer DocType
+    :param supplier: link to Supplier DocType
+    :param price_list: str (Standard Buying or Standard Selling)
+    :param item_code: str, Item Doctype field item_code
+    :param qty: Desired Qty
+    :param transaction_date: Date of the price
+    """
+    pctx = ItemPriceCtx(
+        {
+            "item_code": item_code,
+            "price_list": ctx.get("price_list"),
+            "customer": ctx.get("customer"),
+            "supplier": ctx.get("supplier"),
+            "uom": ctx.get("uom"),
+            "transaction_date": ctx.get("transaction_date"),
+            "batch_no": ctx.get("batch_no"),
+        }
+    )
 
-	item_price_data = 0
-	price_list_rate = get_item_price(pctx, item_code)
-	if price_list_rate:
-		desired_qty = ctx.get("qty")
-		if desired_qty and check_packing_list(price_list_rate[0].name, desired_qty, item_code):
-			item_price_data = price_list_rate
-	else:
-		for field in ["customer", "supplier"]:
-			del pctx[field]
+    item_price_data = 0
+    price_list_rate = get_item_price(pctx, item_code)
+    if price_list_rate:
+        desired_qty = ctx.get("qty")
+        if desired_qty and check_packing_list(
+            price_list_rate[0].name, desired_qty, item_code
+        ):
+            item_price_data = price_list_rate
+    else:
+        for field in ["customer", "supplier"]:
+            del pctx[field]
 
-		general_price_list_rate = get_item_price(pctx, item_code, ignore_party=ctx.get("ignore_party"))
+        general_price_list_rate = get_item_price(
+            pctx, item_code, ignore_party=ctx.get("ignore_party")
+        )
 
-		if not general_price_list_rate and ctx.get("uom") != ctx.get("stock_uom"):
-			pctx.uom = ctx.get("stock_uom")
-			general_price_list_rate = get_item_price(pctx, item_code, ignore_party=ctx.get("ignore_party"))
+        if not general_price_list_rate and ctx.get("uom") != ctx.get("stock_uom"):
+            pctx.uom = ctx.get("stock_uom")
+            general_price_list_rate = get_item_price(
+                pctx, item_code, ignore_party=ctx.get("ignore_party")
+            )
 
-		if general_price_list_rate:
-			item_price_data = general_price_list_rate
+        if general_price_list_rate:
+            item_price_data = general_price_list_rate
 
-	if item_price_data:
-		if item_price_data[0].uom == ctx.get("uom"):
-			return item_price_data[0].price_list_rate
-		elif not ctx.get("price_list_uom_dependant"):
-			return flt(item_price_data[0].price_list_rate * flt(ctx.get("conversion_factor", 1)))
-		else:
-			return item_price_data[0].price_list_rate
+    if item_price_data:
+        if item_price_data[0].uom == ctx.get("uom"):
+            return item_price_data[0].price_list_rate
+        elif not ctx.get("price_list_uom_dependant"):
+            return flt(
+                item_price_data[0].price_list_rate
+                * flt(ctx.get("conversion_factor", 1))
+            )
+        else:
+            return item_price_data[0].price_list_rate
 
 
 def check_packing_list(price_list_rate_name, desired_qty, item_code):
-	"""
-	Check if the desired qty is within the increment of the packing list.
-	:param price_list_rate_name: Name of Item Price
-	:param desired_qty: Desired Qt
-	:param item_code: str, Item Doctype field item_code
-	:param qty: Desired Qt
-	"""
+    """
+    Check if the desired qty is within the increment of the packing list.
+    :param price_list_rate_name: Name of Item Price
+    :param desired_qty: Desired Qt
+    :param item_code: str, Item Doctype field item_code
+    :param qty: Desired Qt
+    """
 
-	flag = True
-	if packing_unit := frappe.db.get_value("Item Price", price_list_rate_name, "packing_unit", cache=True):
-		packing_increment = desired_qty % packing_unit
+    flag = True
+    if packing_unit := frappe.db.get_value(
+        "Item Price", price_list_rate_name, "packing_unit", cache=True
+    ):
+        packing_increment = desired_qty % packing_unit
 
-		if packing_increment != 0:
-			flag = False
+        if packing_increment != 0:
+            flag = False
 
-	return flag
+    return flag
 
 
 def validate_conversion_rate(ctx: ItemDetailsCtx, meta):
-	from erpnext.controllers.accounts_controller import validate_conversion_rate
+    from erpnext.controllers.accounts_controller import validate_conversion_rate
 
-	company_currency = frappe.get_cached_value("Company", ctx.company, "default_currency")
-	if not ctx.conversion_rate and ctx.currency == company_currency:
-		ctx.conversion_rate = 1.0
+    company_currency = frappe.get_cached_value(
+        "Company", ctx.company, "default_currency"
+    )
+    if not ctx.conversion_rate and ctx.currency == company_currency:
+        ctx.conversion_rate = 1.0
 
-	if not ctx.ignore_conversion_rate and ctx.conversion_rate == 1 and ctx.currency != company_currency:
-		ctx.conversion_rate = (
-			get_exchange_rate(ctx.currency, company_currency, ctx.transaction_date, "for_buying") or 1.0
-		)
+    if (
+        not ctx.ignore_conversion_rate
+        and ctx.conversion_rate == 1
+        and ctx.currency != company_currency
+    ):
+        ctx.conversion_rate = (
+            get_exchange_rate(
+                ctx.currency, company_currency, ctx.transaction_date, "for_buying"
+            )
+            or 1.0
+        )
 
-	# validate currency conversion rate
-	validate_conversion_rate(
-		ctx.currency, ctx.conversion_rate, meta.get_label("conversion_rate"), ctx.company
-	)
+    # validate currency conversion rate
+    validate_conversion_rate(
+        ctx.currency,
+        ctx.conversion_rate,
+        meta.get_label("conversion_rate"),
+        ctx.company,
+    )
 
-	ctx.conversion_rate = flt(
-		ctx.conversion_rate,
-		get_field_precision(meta.get_field("conversion_rate"), frappe._dict({"fields": ctx})),
-	)
+    ctx.conversion_rate = flt(
+        ctx.conversion_rate,
+        get_field_precision(
+            meta.get_field("conversion_rate"), frappe._dict({"fields": ctx})
+        ),
+    )
 
-	if ctx.price_list:
-		if not ctx.plc_conversion_rate and ctx.price_list_currency == frappe.db.get_value(
-			"Price List", ctx.price_list, "currency", cache=True
-		):
-			ctx.plc_conversion_rate = 1.0
+    if ctx.price_list:
+        if (
+            not ctx.plc_conversion_rate
+            and ctx.price_list_currency
+            == frappe.db.get_value("Price List", ctx.price_list, "currency", cache=True)
+        ):
+            ctx.plc_conversion_rate = 1.0
 
-		# validate price list currency conversion rate
-		if not ctx.price_list_currency:
-			throw(_("Price List Currency not selected"))
-		else:
-			validate_conversion_rate(
-				ctx.price_list_currency,
-				ctx.plc_conversion_rate,
-				meta.get_label("plc_conversion_rate"),
-				ctx.company,
-			)
+        # validate price list currency conversion rate
+        if not ctx.price_list_currency:
+            throw(_("Price List Currency not selected"))
+        else:
+            validate_conversion_rate(
+                ctx.price_list_currency,
+                ctx.plc_conversion_rate,
+                meta.get_label("plc_conversion_rate"),
+                ctx.company,
+            )
 
-			if meta.get_field("plc_conversion_rate"):
-				ctx.plc_conversion_rate = flt(
-					ctx.plc_conversion_rate,
-					get_field_precision(meta.get_field("plc_conversion_rate"), frappe._dict({"fields": ctx})),
-				)
+            if meta.get_field("plc_conversion_rate"):
+                ctx.plc_conversion_rate = flt(
+                    ctx.plc_conversion_rate,
+                    get_field_precision(
+                        meta.get_field("plc_conversion_rate"),
+                        frappe._dict({"fields": ctx}),
+                    ),
+                )
 
 
 def get_party_item_code(ctx: ItemDetailsCtx, item_doc, out: ItemDetails):
-	if ctx.transaction_type == "selling" and ctx.customer:
-		out.customer_item_code = None
+    if ctx.transaction_type == "selling" and ctx.customer:
+        out.customer_item_code = None
 
-		if ctx.quotation_to and ctx.quotation_to != "Customer":
-			return
+        if ctx.quotation_to and ctx.quotation_to != "Customer":
+            return
 
-		customer_item_code = item_doc.get("customer_items", {"customer_name": ctx.customer})
+        customer_item_code = item_doc.get(
+            "customer_items", {"customer_name": ctx.customer}
+        )
 
-		if customer_item_code:
-			out.customer_item_code = customer_item_code[0].ref_code
-		else:
-			customer_group = frappe.get_cached_value("Customer", ctx.customer, "customer_group")
-			customer_group_item_code = item_doc.get("customer_items", {"customer_group": customer_group})
-			if customer_group_item_code and not customer_group_item_code[0].customer_name:
-				out.customer_item_code = customer_group_item_code[0].ref_code
+        if customer_item_code:
+            out.customer_item_code = customer_item_code[0].ref_code
+        else:
+            customer_group = frappe.get_cached_value(
+                "Customer", ctx.customer, "customer_group"
+            )
+            customer_group_item_code = item_doc.get(
+                "customer_items", {"customer_group": customer_group}
+            )
+            if (
+                customer_group_item_code
+                and not customer_group_item_code[0].customer_name
+            ):
+                out.customer_item_code = customer_group_item_code[0].ref_code
 
-	if ctx.transaction_type == "buying" and ctx.supplier:
-		item_supplier = item_doc.get("supplier_items", {"supplier": ctx.supplier})
-		out.supplier_part_no = item_supplier[0].supplier_part_no if item_supplier else None
+    if ctx.transaction_type == "buying" and ctx.supplier:
+        item_supplier = item_doc.get("supplier_items", {"supplier": ctx.supplier})
+        out.supplier_part_no = (
+            item_supplier[0].supplier_part_no if item_supplier else None
+        )
 
 
 def get_tax_withholding_category(ctx: ItemDetailsCtx, item_doc, out: ItemDetails):
-	"""
-	Get tax withholding category for the item based on the transaction type and party.
-	"""
+    """
+    Get tax withholding category for the item based on the transaction type and party.
+    """
 
-	tax_withholding_category = None
-	field = (
-		"sales_tax_withholding_category"
-		if ctx.transaction_type == "selling"
-		else "purchase_tax_withholding_category"
-	)
+    tax_withholding_category = None
+    field = (
+        "sales_tax_withholding_category"
+        if ctx.transaction_type == "selling"
+        else "purchase_tax_withholding_category"
+    )
 
-	if item_doc.get(field):
-		tax_withholding_category = item_doc.get(field)
-	elif ctx.transaction_type == "buying" and ctx.supplier:
-		tax_withholding_category = frappe.get_cached_value(
-			"Supplier", ctx.supplier, "tax_withholding_category"
-		)
-	elif ctx.transaction_type == "selling" and ctx.customer:
-		tax_withholding_category = frappe.get_cached_value(
-			"Customer", ctx.customer, "tax_withholding_category"
-		)
+    if item_doc.get(field):
+        tax_withholding_category = item_doc.get(field)
+    elif ctx.transaction_type == "buying" and ctx.supplier:
+        tax_withholding_category = frappe.get_cached_value(
+            "Supplier", ctx.supplier, "tax_withholding_category"
+        )
+    elif ctx.transaction_type == "selling" and ctx.customer:
+        tax_withholding_category = frappe.get_cached_value(
+            "Customer", ctx.customer, "tax_withholding_category"
+        )
 
-	out.tax_withholding_category = tax_withholding_category
+    out.tax_withholding_category = tax_withholding_category
 
 
 @erpnext.normalize_ctx_input(ItemDetailsCtx)
-def get_pos_profile_item_details_(ctx: ItemDetailsCtx, company, pos_profile=None, update_data=False):
-	res = frappe._dict()
+def get_pos_profile_item_details_(
+    ctx: ItemDetailsCtx, company, pos_profile=None, update_data=False
+):
+    res = frappe._dict()
 
-	if not frappe.flags.pos_profile and not pos_profile:
-		pos_profile = frappe.flags.pos_profile = get_pos_profile(company, ctx.pos_profile)
+    if not frappe.flags.pos_profile and not pos_profile:
+        pos_profile = frappe.flags.pos_profile = get_pos_profile(
+            company, ctx.pos_profile
+        )
 
-	if pos_profile:
-		for fieldname in ("income_account", "cost_center", "warehouse", "expense_account"):
-			if (not ctx.get(fieldname) or update_data) and pos_profile.get(fieldname):
-				res[fieldname] = pos_profile.get(fieldname)
+    if pos_profile:
+        for fieldname in (
+            "income_account",
+            "cost_center",
+            "warehouse",
+            "expense_account",
+        ):
+            if (not ctx.get(fieldname) or update_data) and pos_profile.get(fieldname):
+                res[fieldname] = pos_profile.get(fieldname)
 
-		if res.get("warehouse"):
-			res.actual_qty = get_bin_details(ctx.item_code, res.warehouse, include_child_warehouses=True).get(
-				"actual_qty"
-			)
+        if res.get("warehouse"):
+            res.actual_qty = get_bin_details(
+                ctx.item_code, res.warehouse, include_child_warehouses=True
+            ).get("actual_qty")
 
-	return res
+    return res
 
 
 @frappe.whitelist()
-def get_pos_profile(company: str, pos_profile: str | None = None, user: str | None = None):
-	if pos_profile:
-		return frappe.get_cached_doc("POS Profile", pos_profile)
+def get_pos_profile(
+    company: str, pos_profile: str | None = None, user: str | None = None
+):
+    if pos_profile:
+        return frappe.get_cached_doc("POS Profile", pos_profile)
 
-	if not user:
-		user = frappe.session["user"]
+    if not user:
+        user = frappe.session["user"]
 
-	pf = frappe.qb.DocType("POS Profile")
-	pfu = frappe.qb.DocType("POS Profile User")
+    pf = frappe.qb.DocType("POS Profile")
+    pfu = frappe.qb.DocType("POS Profile User")
 
-	query = (
-		frappe.qb.from_(pf)
-		.left_join(pfu)
-		.on(pf.name == pfu.parent)
-		.select(pf.star)
-		.where((pfu.user == user) & (pfu.default == 1))
-	)
+    query = (
+        frappe.qb.from_(pf)
+        .left_join(pfu)
+        .on(pf.name == pfu.parent)
+        .select(pf.star)
+        .where((pfu.user == user) & (pfu.default == 1))
+    )
 
-	if company:
-		query = query.where(pf.company == company)
+    if company:
+        query = query.where(pf.company == company)
 
-	pos_profile = query.run(as_dict=True)
+    pos_profile = query.run(as_dict=True)
 
-	if not pos_profile and company:
-		pos_profile = (
-			frappe.qb.from_(pf)
-			.left_join(pfu)
-			.on(pf.name == pfu.parent)
-			.select(pf.star)
-			.where((pf.company == company) & (pf.disabled == 0))
-		).run(as_dict=True)
+    if not pos_profile and company:
+        pos_profile = (
+            frappe.qb.from_(pf)
+            .left_join(pfu)
+            .on(pf.name == pfu.parent)
+            .select(pf.star)
+            .where((pf.company == company) & (pf.disabled == 0))
+        ).run(as_dict=True)
 
-	return pos_profile and pos_profile[0] or None
+    return pos_profile and pos_profile[0] or None
 
 
 @frappe.whitelist()
 def get_conversion_factor(item_code: str | None, uom: str):
-	item = frappe.get_cached_value("Item", item_code, ["variant_of", "stock_uom"], as_dict=True)
-	if not item_code or not item or uom == item.stock_uom:
-		return {"conversion_factor": 1.0}
+    item = frappe.get_cached_value(
+        "Item", item_code, ["variant_of", "stock_uom"], as_dict=True
+    )
+    if not item_code or not item or uom == item.stock_uom:
+        return {"conversion_factor": 1.0}
 
-	item_codes = [item_code]
-	if item.variant_of:
-		item_codes.append(item.variant_of)
+    item_codes = [item_code]
+    if item.variant_of:
+        item_codes.append(item.variant_of)
 
-	parent = frappe.qb.DocType("Item")
-	child = frappe.qb.DocType("UOM Conversion Detail")
-	query = (
-		frappe.qb.from_(parent)
-		.join(child)
-		.on(parent.name == child.parent)
-		.select(child.conversion_factor)
-		.where((parent.name.isin(item_codes)) & (child.uom == uom))
-		.orderby(parent.has_variants)
-		.limit(1)
-	)
-	conversion_factor = query.run(pluck="conversion_factor")
+    parent = frappe.qb.DocType("Item")
+    child = frappe.qb.DocType("UOM Conversion Detail")
+    query = (
+        frappe.qb.from_(parent)
+        .join(child)
+        .on(parent.name == child.parent)
+        .select(child.conversion_factor)
+        .where((parent.name.isin(item_codes)) & (child.uom == uom))
+        .orderby(parent.has_variants)
+        .limit(1)
+    )
+    conversion_factor = query.run(pluck="conversion_factor")
 
-	if not conversion_factor:
-		conversion_factor = get_uom_conv_factor(uom, item.stock_uom)
-	else:
-		conversion_factor = conversion_factor[0]
+    if not conversion_factor:
+        conversion_factor = get_uom_conv_factor(uom, item.stock_uom)
+    else:
+        conversion_factor = conversion_factor[0]
 
-	return {"conversion_factor": conversion_factor or 1.0}
+    return {"conversion_factor": conversion_factor or 1.0}
 
 
 @frappe.whitelist()
 def get_projected_qty(item_code: str, warehouse: str):
-	return {
-		"projected_qty": frappe.db.get_value(
-			"Bin", {"item_code": item_code, "warehouse": warehouse}, "projected_qty"
-		)
-	}
+    return {
+        "projected_qty": frappe.db.get_value(
+            "Bin", {"item_code": item_code, "warehouse": warehouse}, "projected_qty"
+        )
+    }
 
 
 @frappe.whitelist()
 def get_bin_details(
-	item_code: str, warehouse: str | None, company: str | None = None, include_child_warehouses: bool = False
+    item_code: str,
+    warehouse: str | None,
+    company: str | None = None,
+    include_child_warehouses: bool = False,
 ):
-	bin_details = {"projected_qty": 0, "actual_qty": 0, "reserved_qty": 0}
+    bin_details = {"projected_qty": 0, "actual_qty": 0, "reserved_qty": 0}
 
-	if warehouse:
-		from frappe.query_builder.functions import Coalesce, Sum
+    if warehouse:
+        from frappe.query_builder.functions import Coalesce, Sum
 
-		from erpnext.stock.doctype.warehouse.warehouse import get_child_warehouses
+        from erpnext.stock.doctype.warehouse.warehouse import get_child_warehouses
 
-		warehouses = get_child_warehouses(warehouse) if include_child_warehouses else [warehouse]
+        warehouses = (
+            get_child_warehouses(warehouse) if include_child_warehouses else [warehouse]
+        )
 
-		bin = frappe.qb.DocType("Bin")
-		bin_details = (
-			frappe.qb.from_(bin)
-			.select(
-				Coalesce(Sum(bin.projected_qty), 0).as_("projected_qty"),
-				Coalesce(Sum(bin.actual_qty), 0).as_("actual_qty"),
-				Coalesce(Sum(bin.reserved_qty), 0).as_("reserved_qty"),
-			)
-			.where((bin.item_code == item_code) & (bin.warehouse.isin(warehouses)))
-		).run(as_dict=True)[0]
+        bin = frappe.qb.DocType("Bin")
+        bin_details = (
+            frappe.qb.from_(bin)
+            .select(
+                Coalesce(Sum(bin.projected_qty), 0).as_("projected_qty"),
+                Coalesce(Sum(bin.actual_qty), 0).as_("actual_qty"),
+                Coalesce(Sum(bin.reserved_qty), 0).as_("reserved_qty"),
+            )
+            .where((bin.item_code == item_code) & (bin.warehouse.isin(warehouses)))
+        ).run(as_dict=True)[0]
 
-	if company:
-		bin_details["company_total_stock"] = get_company_total_stock(item_code, company)
+    if company:
+        bin_details["company_total_stock"] = get_company_total_stock(item_code, company)
 
-	return bin_details
+    return bin_details
 
 
 def get_company_total_stock(item_code, company):
-	bin = frappe.qb.DocType("Bin")
-	wh = frappe.qb.DocType("Warehouse")
+    bin = frappe.qb.DocType("Bin")
+    wh = frappe.qb.DocType("Warehouse")
 
-	return (
-		frappe.qb.from_(bin)
-		.inner_join(wh)
-		.on(bin.warehouse == wh.name)
-		.select(Sum(bin.actual_qty))
-		.where((wh.company == company) & (bin.item_code == item_code))
-	).run()[0][0]
+    return (
+        frappe.qb.from_(bin)
+        .inner_join(wh)
+        .on(bin.warehouse == wh.name)
+        .select(Sum(bin.actual_qty))
+        .where((wh.company == company) & (bin.item_code == item_code))
+    ).run()[0][0]
 
 
 @frappe.whitelist()
 def get_batch_qty(batch_no: str, warehouse: str, item_code: str):
-	from erpnext.stock.doctype.batch import batch
+    from erpnext.stock.doctype.batch import batch
 
-	if batch_no:
-		return {"actual_batch_qty": batch.get_batch_qty(batch_no, warehouse)}
+    if batch_no:
+        return {"actual_batch_qty": batch.get_batch_qty(batch_no, warehouse)}
 
 
 @frappe.whitelist()
 @erpnext.normalize_ctx_input(ItemDetailsCtx)
-def apply_price_list(ctx: ItemDetailsCtx | str, as_doc: bool = False, doc: Document | str | None = None):
-	"""Apply pricelist on a document-like dict object and return as
-	{'parent': dict, 'children': list}
+def apply_price_list(
+    ctx: ItemDetailsCtx | str, as_doc: bool = False, doc: Document | str | None = None
+):
+    """Apply pricelist on a document-like dict object and return as
+    {'parent': dict, 'children': list}
 
-	:param ctx: See below
-	:param as_doc: Updates value in the passed dict
+    :param ctx: See below
+    :param as_doc: Updates value in the passed dict
 
-	        ctx = {
-	                "doctype": "",
-	                "name": "",
-	                "items": [{"doctype": "", "name": "", "item_code": "", "brand": "", "item_group": ""}, ...],
-	                "conversion_rate": 1.0,
-	                "selling_price_list": None,
-	                "price_list_currency": None,
-	                "price_list_uom_dependant": None,
-	                "plc_conversion_rate": 1.0,
-	                "doctype": "",
-	                "name": "",
-	                "supplier": None,
-	                "transaction_date": None,
-	                "conversion_rate": 1.0,
-	                "buying_price_list": None,
-	                "ignore_pricing_rule": 0/1
-	        }
-	"""
-	_preprocess_ctx(ctx)
-	parent = get_price_list_currency_and_exchange_rate(ctx)
-	ctx.update(parent)
+            ctx = {
+                    "doctype": "",
+                    "name": "",
+                    "items": [{"doctype": "", "name": "", "item_code": "", "brand": "", "item_group": ""}, ...],
+                    "conversion_rate": 1.0,
+                    "selling_price_list": None,
+                    "price_list_currency": None,
+                    "price_list_uom_dependant": None,
+                    "plc_conversion_rate": 1.0,
+                    "doctype": "",
+                    "name": "",
+                    "supplier": None,
+                    "transaction_date": None,
+                    "conversion_rate": 1.0,
+                    "buying_price_list": None,
+                    "ignore_pricing_rule": 0/1
+            }
+    """
+    _preprocess_ctx(ctx)
+    parent = get_price_list_currency_and_exchange_rate(ctx)
+    ctx.update(parent)
 
-	children = []
+    children = []
 
-	if "items" in ctx:
-		item_list = ctx.get("items")
-		ctx.update(parent)
+    if "items" in ctx:
+        item_list = ctx.get("items")
+        ctx.update(parent)
 
-		for item in item_list:
-			ctx_copy = ItemDetailsCtx(ctx.copy())
-			ctx_copy.update(item)
-			item_details = apply_price_list_on_item(ctx_copy, doc=doc)
-			children.append(item_details)
+        for item in item_list:
+            ctx_copy = ItemDetailsCtx(ctx.copy())
+            ctx_copy.update(item)
+            item_details = apply_price_list_on_item(ctx_copy, doc=doc)
+            children.append(item_details)
 
-	if as_doc:
-		ctx.price_list_currency = (parent.price_list_currency,)
-		ctx.plc_conversion_rate = parent.plc_conversion_rate
-		if ctx.get("items"):
-			for i, item in enumerate(ctx.get("items")):
-				for fieldname in children[i]:
-					# if the field exists in the original doc
-					# update the value
-					if fieldname in item and fieldname not in ("name", "doctype"):
-						item[fieldname] = children[i][fieldname]
-		return ctx
-	else:
-		return {"parent": parent, "children": children}
+    if as_doc:
+        ctx.price_list_currency = (parent.price_list_currency,)
+        ctx.plc_conversion_rate = parent.plc_conversion_rate
+        if ctx.get("items"):
+            for i, item in enumerate(ctx.get("items")):
+                for fieldname in children[i]:
+                    # if the field exists in the original doc
+                    # update the value
+                    if fieldname in item and fieldname not in ("name", "doctype"):
+                        item[fieldname] = children[i][fieldname]
+        return ctx
+    else:
+        return {"parent": parent, "children": children}
 
 
 def apply_price_list_on_item(ctx, doc=None):
-	item_doc = frappe.get_cached_doc("Item", ctx.item_code)
-	item_details = get_price_list_rate(ctx, item_doc)
-	item_details.update(get_pricing_rule_for_item(ctx, doc=doc))
+    item_doc = frappe.get_cached_doc("Item", ctx.item_code)
+    item_details = get_price_list_rate(ctx, item_doc)
+    item_details.update(get_pricing_rule_for_item(ctx, doc=doc))
 
-	return item_details
+    return item_details
 
 
 def get_price_list_currency_and_exchange_rate(ctx: ItemDetailsCtx):
-	if not ctx.price_list:
-		return {}
+    if not ctx.price_list:
+        return {}
 
-	if ctx.doctype in ["Quotation", "Sales Order", "Delivery Note", "Sales Invoice"]:
-		ctx.update({"exchange_rate": "for_selling"})
-	elif ctx.doctype in ["Purchase Order", "Purchase Receipt", "Purchase Invoice"]:
-		ctx.update({"exchange_rate": "for_buying"})
+    if ctx.doctype in ["Quotation", "Sales Order", "Delivery Note", "Sales Invoice"]:
+        ctx.update({"exchange_rate": "for_selling"})
+    elif ctx.doctype in ["Purchase Order", "Purchase Receipt", "Purchase Invoice"]:
+        ctx.update({"exchange_rate": "for_buying"})
 
-	price_list_details = get_price_list_details(ctx.price_list)
+    price_list_details = get_price_list_details(ctx.price_list)
 
-	price_list_currency = price_list_details.get("currency")
-	price_list_uom_dependant = price_list_details.get("price_list_uom_dependant")
+    price_list_currency = price_list_details.get("currency")
+    price_list_uom_dependant = price_list_details.get("price_list_uom_dependant")
 
-	plc_conversion_rate = ctx.plc_conversion_rate
-	company_currency = get_company_currency(ctx.company)
+    plc_conversion_rate = ctx.plc_conversion_rate
+    company_currency = get_company_currency(ctx.company)
 
-	if (not plc_conversion_rate) or (
-		price_list_currency and ctx.price_list_currency and price_list_currency != ctx.price_list_currency
-	):
-		# cksgb 19/09/2016: added args.transaction_date as posting_date argument for get_exchange_rate
-		plc_conversion_rate = (
-			get_exchange_rate(price_list_currency, company_currency, ctx.transaction_date, ctx.exchange_rate)
-			or plc_conversion_rate
-		)
+    if (not plc_conversion_rate) or (
+        price_list_currency
+        and ctx.price_list_currency
+        and price_list_currency != ctx.price_list_currency
+    ):
+        # cksgb 19/09/2016: added args.transaction_date as posting_date argument for get_exchange_rate
+        plc_conversion_rate = (
+            get_exchange_rate(
+                price_list_currency,
+                company_currency,
+                ctx.transaction_date,
+                ctx.exchange_rate,
+            )
+            or plc_conversion_rate
+        )
 
-	return frappe._dict(
-		{
-			"price_list_currency": price_list_currency,
-			"price_list_uom_dependant": price_list_uom_dependant,
-			"plc_conversion_rate": plc_conversion_rate or 1,
-		}
-	)
+    return frappe._dict(
+        {
+            "price_list_currency": price_list_currency,
+            "price_list_uom_dependant": price_list_uom_dependant,
+            "plc_conversion_rate": plc_conversion_rate or 1,
+        }
+    )
 
 
 @frappe.whitelist()
 def get_default_bom(item_code: str | None = None):
-	def _get_bom(item):
-		bom = frappe.get_all("BOM", dict(item=item, is_active=True, is_default=True, docstatus=1), limit=1)
-		return bom[0].name if bom else None
+    def _get_bom(item):
+        bom = frappe.get_all(
+            "BOM",
+            dict(item=item, is_active=True, is_default=True, docstatus=1),
+            limit=1,
+        )
+        return bom[0].name if bom else None
 
-	if not item_code:
-		return
+    if not item_code:
+        return
 
-	bom_name = _get_bom(item_code)
+    bom_name = _get_bom(item_code)
 
-	template_item = frappe.db.get_value("Item", item_code, "variant_of")
-	if not bom_name and template_item:
-		bom_name = _get_bom(template_item)
+    template_item = frappe.db.get_value("Item", item_code, "variant_of")
+    if not bom_name and template_item:
+        bom_name = _get_bom(template_item)
 
-	return bom_name
+    return bom_name
 
 
 @frappe.whitelist()
 def get_valuation_rate(item_code: str, company: str, warehouse: str | None = None):
-	if frappe.get_cached_value("Warehouse", warehouse, "is_group"):
-		return {"valuation_rate": 0.0}
+    if frappe.get_cached_value("Warehouse", warehouse, "is_group"):
+        return {"valuation_rate": 0.0}
 
-	item = get_item_defaults(item_code, company)
-	item_group = get_item_group_defaults(item_code, company)
-	brand = get_brand_defaults(item_code, company)
-	if item.get("is_stock_item"):
-		if not warehouse:
-			warehouse = (
-				item.get("default_warehouse")
-				or item_group.get("default_warehouse")
-				or brand.get("default_warehouse")
-			)
+    item = get_item_defaults(item_code, company)
+    item_group = get_item_group_defaults(item_code, company)
+    brand = get_brand_defaults(item_code, company)
+    if item.get("is_stock_item"):
+        if not warehouse:
+            warehouse = (
+                item.get("default_warehouse")
+                or item_group.get("default_warehouse")
+                or brand.get("default_warehouse")
+            )
 
-		return frappe.db.get_value(
-			"Bin", {"item_code": item_code, "warehouse": warehouse}, ["valuation_rate"], as_dict=True
-		) or {"valuation_rate": item.get("valuation_rate") or 0}
+        return frappe.db.get_value(
+            "Bin",
+            {"item_code": item_code, "warehouse": warehouse},
+            ["valuation_rate"],
+            as_dict=True,
+        ) or {"valuation_rate": item.get("valuation_rate") or 0}
 
-	elif not item.get("is_stock_item"):
-		pi_item = frappe.qb.DocType("Purchase Invoice Item")
-		valuation_rate = (
-			frappe.qb.from_(pi_item)
-			.select(Sum(pi_item.base_net_amount) / Sum(pi_item.qty * pi_item.conversion_factor))
-			.where((pi_item.docstatus == 1) & (pi_item.item_code == item_code))
-		).run()
+    elif not item.get("is_stock_item"):
+        pi_item = frappe.qb.DocType("Purchase Invoice Item")
+        valuation_rate = (
+            frappe.qb.from_(pi_item)
+            .select(
+                Sum(pi_item.base_net_amount)
+                / Sum(pi_item.qty * pi_item.conversion_factor)
+            )
+            .where((pi_item.docstatus == 1) & (pi_item.item_code == item_code))
+        ).run()
 
-		if valuation_rate:
-			return {"valuation_rate": valuation_rate[0][0] or 0.0}
-	else:
-		return {"valuation_rate": 0.0}
+        if valuation_rate:
+            return {"valuation_rate": valuation_rate[0][0] or 0.0}
+    else:
+        return {"valuation_rate": 0.0}
 
 
 def get_gross_profit(out: ItemDetails):
-	if out.valuation_rate:
-		out.update({"gross_profit": ((out.base_rate - out.valuation_rate) * out.stock_qty)})
+    if out.valuation_rate:
+        out.update(
+            {"gross_profit": ((out.base_rate - out.valuation_rate) * out.stock_qty)}
+        )
 
-	return out
+    return out
 
 
 @frappe.whitelist()
-def get_serial_no(_args: Any, serial_nos: list | None = None, sales_order: str | None = None):
-	serial_nos = serial_nos or []
-	return serial_nos
+def get_serial_no(
+    _args: Any, serial_nos: list | None = None, sales_order: str | None = None
+):
+    serial_nos = serial_nos or []
+    return serial_nos
 
 
 def update_party_blanket_order(ctx: ItemDetailsCtx, out: ItemDetails | dict):
-	if out["against_blanket_order"]:
-		blanket_order_details = get_blanket_order_details(ctx)
-		if blanket_order_details:
-			out.update(blanket_order_details)
+    if out["against_blanket_order"]:
+        blanket_order_details = get_blanket_order_details(ctx)
+        if blanket_order_details:
+            out.update(blanket_order_details)
 
 
 @frappe.whitelist()
 @erpnext.normalize_ctx_input(ItemDetailsCtx)
 def get_blanket_order_details(ctx: ItemDetailsCtx):
-	blanket_order_details = None
+    blanket_order_details = None
 
-	if ctx.item_code:
-		bo = frappe.qb.DocType("Blanket Order")
-		bo_item = frappe.qb.DocType("Blanket Order Item")
+    if ctx.item_code:
+        bo = frappe.qb.DocType("Blanket Order")
+        bo_item = frappe.qb.DocType("Blanket Order Item")
 
-		query = (
-			frappe.qb.from_(bo)
-			.from_(bo_item)
-			.select(bo_item.rate.as_("blanket_order_rate"), bo.name.as_("blanket_order"))
-			.where(
-				(bo.company == ctx.company)
-				& (bo_item.item_code == ctx.item_code)
-				& (bo.docstatus == 1)
-				& (bo.name == bo_item.parent)
-			)
-		)
+        query = (
+            frappe.qb.from_(bo)
+            .from_(bo_item)
+            .select(
+                bo_item.rate.as_("blanket_order_rate"), bo.name.as_("blanket_order")
+            )
+            .where(
+                (bo.company == ctx.company)
+                & (bo_item.item_code == ctx.item_code)
+                & (bo.docstatus == 1)
+                & (bo.name == bo_item.parent)
+            )
+        )
 
-		if ctx.customer and ctx.doctype == "Sales Order":
-			query = query.where(bo.customer == ctx.customer)
-		elif ctx.supplier and ctx.doctype == "Purchase Order":
-			query = query.where(bo.supplier == ctx.supplier)
-		if ctx.blanket_order:
-			query = query.where(bo.name == ctx.blanket_order)
-		if ctx.transaction_date:
-			query = query.where(bo.to_date >= ctx.transaction_date)
+        if ctx.customer and ctx.doctype == "Sales Order":
+            query = query.where(bo.customer == ctx.customer)
+        elif ctx.supplier and ctx.doctype == "Purchase Order":
+            query = query.where(bo.supplier == ctx.supplier)
+        if ctx.blanket_order:
+            query = query.where(bo.name == ctx.blanket_order)
+        if ctx.transaction_date:
+            query = query.where(bo.to_date >= ctx.transaction_date)
 
-		blanket_order_details = query.run(as_dict=True)
-		blanket_order_details = blanket_order_details[0] if blanket_order_details else ""
+        blanket_order_details = query.run(as_dict=True)
+        blanket_order_details = (
+            blanket_order_details[0] if blanket_order_details else ""
+        )
 
-	return blanket_order_details
+    return blanket_order_details


### PR DESCRIPTION
## Problem
Pricing rules are being evaluated twice during a single transaction validation cycle when Product-based pricing rules trigger an internal recalculation via `set_missing_values()`.

This results in:
- Duplicate execution of `get_pricing_rule_for_item()`
- Unnecessary repeated pricing rule processing
- Potential inconsistencies in pricing application logic

## Root Cause
During `apply_pricing_rule_on_transaction()` for Product-based discounts:
- `set_missing_values()` is called internally
- This re-enters `set_missing_item_details()` → `get_item_details()`
- Which again triggers `get_pricing_rule_for_item()`

Thus, pricing rule evaluation runs twice within the same transaction context.

## Solution
Introduce a scoped flag-based guard to prevent re-entry:

- `doc.flags.in_pricing_rule_recalc`
- `args.skip_pricing_rule_eval`

This ensures pricing rule evaluation happens only once per transaction lifecycle while still allowing:
- full `set_missing_values()` execution
- correct tax recalculation
- unchanged behavior for all non-Product pricing flows

## Changes
- Skip pricing rule evaluation during internal recalculation pass
- Pass recalculation flag from controller to item details layer
- Ensure flags are safely set and restored using try/finally
- No modification to pricing rule logic itself

## Files modified
- erpnext/accounts/doctype/pricing_rule/utils.py
- erpnext/controllers/selling_controller.py
- erpnext/stock/get_item_details.py

## Testing
Verified across:
- Sales Order with pricing rules
- Sales Invoice with product discount rules
- Delivery Note flows
- Standard pricing rule application (no regression)

## Impact
- Fixes duplicate pricing rule evaluation
- No change in business logic output
- Safe, backward-compatible, minimal patch

## Risk
Low — purely guard-based control flow fix with no pricing logic changes.