### PR TITLE
fix: add validation before multiple reverse journal entry

### DIFF
--- a/erpnext/accounts/doctype/journal_entry/journal_entry.py
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.py
@@ -152,6 +152,8 @@ class JournalEntry(AccountsController):
 			self.apply_tax_withholding()
 		if self.is_new() or not self.title:
 			self.title = self.get_title()
+		if self.reversal_of:
+			check_reverse_entry_exists(source_name=self.reversal_of, exclude_name=self.name)
 
 	def validate_advance_accounts(self):
 		journal_accounts = set([x.account for x in self.accounts])
@@ -1866,7 +1868,9 @@ def make_inter_company_journal_entry(name, voucher_type, company):
 
 
 @frappe.whitelist()
-def make_reverse_journal_entry(source_name, target_doc=None):
+def make_reverse_journal_entry(source_name: str, target_doc: str | None = None):
+	check_reverse_entry_exists(source_name)
+
 	from frappe.model.mapper import get_mapped_doc
 
 	def post_process(source, target):
@@ -1896,3 +1900,16 @@ def make_reverse_journal_entry(source_name, target_doc=None):
 	)
 
 	return doclist
+
+
+def check_reverse_entry_exists(source_name: str, exclude_name: str | None = None):
+	filters = {"reversal_of": source_name, "docstatus": ["!=", 2]}
+	if exclude_name:
+		filters["name"] = ["!=", exclude_name]
+	existing_reverse = frappe.db.exists("Journal Entry", filters)
+	if existing_reverse:
+		frappe.throw(
+			_("A Reverse Journal Entry {0} already exists for this Journal Entry.").format(
+				get_link_to_form("Journal Entry", existing_reverse)
+			)
+		)

--- a/erpnext/accounts/doctype/journal_entry/test_journal_entry.py
+++ b/erpnext/accounts/doctype/journal_entry/test_journal_entry.py
@@ -217,6 +217,9 @@ class TestJournalEntry(unittest.TestCase):
 		rjv.posting_date = nowdate()
 		rjv.submit()
 
+		# check duplicate reverse entry creation
+		self.assertRaises(frappe.ValidationError, make_reverse_journal_entry, jv.name)
+
 		self.voucher_no = rjv.name
 
 		self.fields = [


### PR DESCRIPTION
**Issue:**
In V15, once a Journal Entry is reversed using the "Reverse Journal Entry" action, the original Journal Entry continues to show the same action, allowing it to be reversed multiple times.

**Ref:**[66002](https://support.frappe.io/helpdesk/tickets/66002?view=VIEW-HD+Ticket-745)

**Before:**

[reversejebefore.webm](https://github.com/user-attachments/assets/b10e6107-96f2-4675-af15-318565c9a127)


**After:**

[reversejeafter.webm](https://github.com/user-attachments/assets/6c9cd32b-c6c4-4658-bc96-3ac6ccf25e70)


**No Bachport needed**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents creation of duplicate reverse Journal Entries by enforcing a single reversal per original entry.
  * Validation now checks for an existing reversal before allowing creation, submission, or saving edits.
  * Improved error messaging links to the existing reversal to reduce confusion.

* **Tests**
  * Added coverage to confirm attempts to create a second reverse entry are blocked.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->