### PR TITLE
fix: prevent duplication of child rows when fetching items from source doc

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js
@@ -158,6 +158,7 @@ erpnext.accounts.PurchaseInvoice = class PurchaseInvoice extends erpnext.buying.
 							per_billed: ["<", 99.99],
 							company: me.frm.doc.company,
 						},
+						cur_items: me.frm.doc.items,
 						allow_child_item_selection: true,
 						child_fieldname: "items",
 						child_columns: ["item_code", "item_name", "qty", "amount", "billed_amt"],
@@ -183,6 +184,7 @@ erpnext.accounts.PurchaseInvoice = class PurchaseInvoice extends erpnext.buying.
 							company: me.frm.doc.company,
 							is_return: 0,
 						},
+						cur_items: me.frm.doc.items,
 						allow_child_item_selection: true,
 						child_fieldname: "items",
 						child_columns: ["item_code", "item_name", "qty", "amount", "billed_amt"],
@@ -721,6 +723,24 @@ frappe.ui.form.on("Purchase Invoice", {
 					if (response) frm.set_value("credit_to", response.message);
 				},
 			});
+		}
+	},
+});
+
+frappe.ui.form.on("Purchase Invoice Item", {
+	item_code: function (frm, cdt, cdn) {
+		let row = locals[cdt][cdn];
+		if (row.po_detail) {
+			frappe.model.set_value(row.doctype, row.name, "po_detail", null);
+		}
+		if (row.purchase_order) {
+			frappe.model.set_value(row.doctype, row.name, "purchase_order", null);
+		}
+		if (row.pr_detail) {
+			frappe.model.set_value(row.doctype, row.name, "pr_detail", null);
+		}
+		if (row.purchase_receipt) {
+			frappe.model.set_value(row.doctype, row.name, "purchase_receipt", null);
 		}
 	},
 });

--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
@@ -2012,6 +2012,36 @@ def make_purchase_receipt(
 		args = json.loads(args)
 
 	def post_parent_process(source_parent, target_parent):
+		pi_detail_map = {}
+		items_to_remove = []
+		has_partial_merge = False
+		for item in target_parent.items:
+			if not item.purchase_invoice_item:
+				continue
+			if item.purchase_invoice_item in pi_detail_map:
+				existing = pi_detail_map[item.purchase_invoice_item]
+				remaining = flt(item.qty) - flt(existing.qty)
+				if remaining > 0:
+					existing.qty = flt(existing.qty) + remaining
+					has_partial_merge = True
+				items_to_remove.append(item)
+			else:
+				pi_detail_map[item.purchase_invoice_item] = item
+		for item in items_to_remove:
+			target_parent.remove(item)
+		if items_to_remove:
+			if has_partial_merge:
+				frappe.msgprint(
+					_("Duplicate items were merged into existing rows in the Items table."),
+					indicator="blue",
+				)
+			else:
+				frappe.msgprint(
+					_("All items from {0} {1} are already fully added in the items table").format(
+						source_parent.doctype, source_parent.name
+					),
+					indicator="blue",
+				)
 		remove_items_with_zero_qty(target_parent)
 		set_missing_values(source_parent, target_parent)
 

--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
@@ -2035,7 +2035,7 @@ def make_purchase_receipt(
 					_("Duplicate items were merged into existing rows in the Items table."),
 					indicator="blue",
 				)
-			else:
+			elif len(pi_detail_map) == len(items_to_remove):
 				frappe.msgprint(
 					_("All items from {0} {1} are already fully added in the items table").format(
 						source_parent.doctype, source_parent.name

--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
@@ -36,6 +36,7 @@ from erpnext.accounts.party import get_due_date, get_party_account
 from erpnext.accounts.utils import get_account_currency, get_fiscal_year, update_voucher_outstanding
 from erpnext.assets.doctype.asset.asset import is_cwip_accounting_enabled
 from erpnext.assets.doctype.asset_category.asset_category import get_asset_category_account
+from erpnext.buying.doctype.purchase_order.purchase_order import merge_and_remove_duplicate_items
 from erpnext.buying.utils import check_on_hold_or_closed_status
 from erpnext.controllers.accounts_controller import merge_taxes, validate_account_head
 from erpnext.controllers.buying_controller import BuyingController
@@ -2012,36 +2013,7 @@ def make_purchase_receipt(
 		args = json.loads(args)
 
 	def post_parent_process(source_parent, target_parent):
-		pi_detail_map = {}
-		items_to_remove = []
-		has_partial_merge = False
-		for item in target_parent.items:
-			if not item.purchase_invoice_item:
-				continue
-			if item.purchase_invoice_item in pi_detail_map:
-				existing = pi_detail_map[item.purchase_invoice_item]
-				remaining = flt(item.qty) - flt(existing.qty)
-				if remaining > 0:
-					existing.qty = flt(existing.qty) + remaining
-					has_partial_merge = True
-				items_to_remove.append(item)
-			else:
-				pi_detail_map[item.purchase_invoice_item] = item
-		for item in items_to_remove:
-			target_parent.remove(item)
-		if items_to_remove:
-			if has_partial_merge:
-				frappe.msgprint(
-					_("Duplicate items were merged into existing rows in the Items table."),
-					indicator="blue",
-				)
-			elif len(pi_detail_map) == len(items_to_remove):
-				frappe.msgprint(
-					_("All items from {0} {1} are already fully added in the items table").format(
-						source_parent.doctype, source_parent.name
-					),
-					indicator="blue",
-				)
+		merge_and_remove_duplicate_items(source_parent, target_parent, "purchase_invoice_item")
 		remove_items_with_zero_qty(target_parent)
 		set_missing_values(source_parent, target_parent)
 

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
@@ -368,6 +368,7 @@ erpnext.accounts.SalesInvoiceController = class SalesInvoiceController extends (
 					get_query_filters: filters,
 					allow_child_item_selection: true,
 					child_fieldname: "items",
+					cur_items: me.frm.doc.items,
 					child_columns: ["item_code", "item_name", "qty", "amount", "billed_amt"],
 				});
 			},
@@ -438,6 +439,7 @@ erpnext.accounts.SalesInvoiceController = class SalesInvoiceController extends (
 							filters: filters,
 						};
 					},
+					cur_items: me.frm.doc.items,
 					allow_child_item_selection: true,
 					child_fieldname: "items",
 					child_columns: ["item_code", "item_name", "qty", "amount", "billed_amt"],
@@ -1158,6 +1160,24 @@ frappe.ui.form.on("Sales Invoice", {
 
 		frm.set_df_property("update_stock", "read_only", frm.doc.has_subcontracted);
 		frm.toggle_display("update_stock", !frm.doc.has_subcontracted);
+	},
+});
+
+frappe.ui.form.on("Sales Invoice Item", {
+	item_code(frm, cdt, cdn) {
+		let row = locals[cdt][cdn];
+		if (row.sales_order) {
+			frappe.model.set_value(row.doctype, row.name, "sales_order", null);
+		}
+		if (row.so_detail) {
+			frappe.model.set_value(row.doctype, row.name, "so_detail", null);
+		}
+		if (row.dn_detail) {
+			frappe.model.set_value(row.doctype, row.name, "dn_detail", null);
+		}
+		if (row.delivery_note) {
+			frappe.model.set_value(row.doctype, row.name, "delivery_note", null);
+		}
 	},
 });
 

--- a/erpnext/buying/doctype/purchase_order/purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.py
@@ -717,6 +717,39 @@ def make_purchase_receipt(
 
 	has_unit_price_items = frappe.db.get_value("Purchase Order", source_name, "has_unit_price_items")
 
+	def post_process(source, target):
+		po_detail_map = {}
+		items_to_remove = []
+		has_partial_merge = False
+		for item in target.items:
+			if not item.purchase_order_item:
+				continue
+			if item.purchase_order_item in po_detail_map:
+				existing = po_detail_map[item.purchase_order_item]
+				remaining = flt(item.qty) - flt(existing.qty)
+				if remaining > 0:
+					existing.qty = flt(existing.qty) + remaining
+					has_partial_merge = True
+				items_to_remove.append(item)
+			else:
+				po_detail_map[item.purchase_order_item] = item
+		for item in items_to_remove:
+			target.remove(item)
+		if items_to_remove:
+			if has_partial_merge:
+				frappe.msgprint(
+					_("Duplicate items were merged into existing rows in the Items table."),
+					indicator="blue",
+				)
+			else:
+				frappe.msgprint(
+					_("All items from {0} {1} are already fully added in the items table").format(
+						source.doctype, source.name
+					),
+					indicator="blue",
+				)
+		set_missing_values(source, target)
+
 	def is_unit_price_row(source):
 		return has_unit_price_items and source.qty == 0
 
@@ -766,7 +799,7 @@ def make_purchase_receipt(
 			"Purchase Taxes and Charges": {"doctype": "Purchase Taxes and Charges", "reset_value": True},
 		},
 		target_doc,
-		set_missing_values,
+		post_process,
 	)
 
 	return doc
@@ -798,6 +831,39 @@ def get_mapped_purchase_invoice(source_name, target_doc=None, ignore_permissions
 		args = json.loads(args)
 
 	def postprocess(source, target):
+		po_detail_map = {}
+		items_to_remove = []
+		has_partial_merge = False
+		for item in target.items:
+			if not item.po_detail:
+				continue
+			if item.po_detail in po_detail_map:
+				existing = po_detail_map[item.po_detail]
+				remaining = flt(item.qty) - flt(existing.qty)
+				if remaining > 0:
+					existing.qty = flt(existing.qty) + remaining
+					has_partial_merge = True
+				items_to_remove.append(item)
+			else:
+				po_detail_map[item.po_detail] = item
+
+		for item in items_to_remove:
+			target.remove(item)
+
+		if items_to_remove:
+			if has_partial_merge:
+				frappe.msgprint(
+					_("Duplicate items were merged into existing rows in the Items table."),
+					indicator="blue",
+				)
+			else:
+				frappe.msgprint(
+					_("All items from {0} {1} are already fully added in the items table").format(
+						source.doctype, source.name
+					),
+					indicator="blue",
+				)
+
 		target.flags.ignore_permissions = ignore_permissions
 		set_missing_values(source, target)
 

--- a/erpnext/buying/doctype/purchase_order/purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.py
@@ -741,7 +741,7 @@ def make_purchase_receipt(
 					_("Duplicate items were merged into existing rows in the Items table."),
 					indicator="blue",
 				)
-			else:
+			elif len(po_detail_map) == len(items_to_remove):
 				frappe.msgprint(
 					_("All items from {0} {1} are already fully added in the items table").format(
 						source.doctype, source.name
@@ -856,7 +856,7 @@ def get_mapped_purchase_invoice(source_name, target_doc=None, ignore_permissions
 					_("Duplicate items were merged into existing rows in the Items table."),
 					indicator="blue",
 				)
-			else:
+			elif len(po_detail_map) == len(items_to_remove):
 				frappe.msgprint(
 					_("All items from {0} {1} are already fully added in the items table").format(
 						source.doctype, source.name

--- a/erpnext/buying/doctype/purchase_order/purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.py
@@ -706,6 +706,42 @@ def set_missing_values(source, target):
 	target.run_method("set_use_serial_batch_fields")
 
 
+def merge_and_remove_duplicate_items(source, target, source_item_field1, source_item_field2=None):
+	seen_items = {}
+	items_to_remove = []
+	has_partial_merge = False
+	for item in target.items:
+		key = item.get(source_item_field1)
+		if not key and source_item_field2:
+			key = item.get(source_item_field2)
+		if not key:
+			continue
+		if key in seen_items:
+			existing = seen_items[key]
+			remaining = flt(item.qty) - flt(existing.qty)
+			if remaining > 0:
+				existing.qty = flt(existing.qty) + remaining
+				has_partial_merge = True
+			items_to_remove.append(item)
+		else:
+			seen_items[key] = item
+	for item in items_to_remove:
+		target.remove(item)
+	if items_to_remove:
+		if has_partial_merge:
+			frappe.msgprint(
+				_("Duplicate items were merged into existing rows in the Items table."),
+				indicator="blue",
+			)
+		elif len(seen_items) == len(items_to_remove):
+			frappe.msgprint(
+				_("All items from {0} {1} are already fully added in the items table").format(
+					source.doctype, source.name
+				),
+				indicator="blue",
+			)
+
+
 @frappe.whitelist()
 def make_purchase_receipt(
 	source_name: str, target_doc: str | Document | None = None, args: str | dict | None = None
@@ -718,36 +754,7 @@ def make_purchase_receipt(
 	has_unit_price_items = frappe.db.get_value("Purchase Order", source_name, "has_unit_price_items")
 
 	def post_process(source, target):
-		po_detail_map = {}
-		items_to_remove = []
-		has_partial_merge = False
-		for item in target.items:
-			if not item.purchase_order_item:
-				continue
-			if item.purchase_order_item in po_detail_map:
-				existing = po_detail_map[item.purchase_order_item]
-				remaining = flt(item.qty) - flt(existing.qty)
-				if remaining > 0:
-					existing.qty = flt(existing.qty) + remaining
-					has_partial_merge = True
-				items_to_remove.append(item)
-			else:
-				po_detail_map[item.purchase_order_item] = item
-		for item in items_to_remove:
-			target.remove(item)
-		if items_to_remove:
-			if has_partial_merge:
-				frappe.msgprint(
-					_("Duplicate items were merged into existing rows in the Items table."),
-					indicator="blue",
-				)
-			elif len(po_detail_map) == len(items_to_remove):
-				frappe.msgprint(
-					_("All items from {0} {1} are already fully added in the items table").format(
-						source.doctype, source.name
-					),
-					indicator="blue",
-				)
+		merge_and_remove_duplicate_items(source, target, "purchase_order_item")
 		set_missing_values(source, target)
 
 	def is_unit_price_row(source):
@@ -831,39 +838,7 @@ def get_mapped_purchase_invoice(source_name, target_doc=None, ignore_permissions
 		args = json.loads(args)
 
 	def postprocess(source, target):
-		po_detail_map = {}
-		items_to_remove = []
-		has_partial_merge = False
-		for item in target.items:
-			if not item.po_detail:
-				continue
-			if item.po_detail in po_detail_map:
-				existing = po_detail_map[item.po_detail]
-				remaining = flt(item.qty) - flt(existing.qty)
-				if remaining > 0:
-					existing.qty = flt(existing.qty) + remaining
-					has_partial_merge = True
-				items_to_remove.append(item)
-			else:
-				po_detail_map[item.po_detail] = item
-
-		for item in items_to_remove:
-			target.remove(item)
-
-		if items_to_remove:
-			if has_partial_merge:
-				frappe.msgprint(
-					_("Duplicate items were merged into existing rows in the Items table."),
-					indicator="blue",
-				)
-			elif len(po_detail_map) == len(items_to_remove):
-				frappe.msgprint(
-					_("All items from {0} {1} are already fully added in the items table").format(
-						source.doctype, source.name
-					),
-					indicator="blue",
-				)
-
+		merge_and_remove_duplicate_items(source, target, "po_detail")
 		target.flags.ignore_permissions = ignore_permissions
 		set_missing_values(source, target)
 

--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -1118,7 +1118,82 @@ erpnext.utils.map_current_doc = function (opts) {
 					frappe.msgprint(__("Please select {0}", [opts.source_doctype]));
 					return;
 				}
+				if (opts.cur_items) {
+					const doctype_fieldname_map = {
+						"Sales Order": "sales_order",
+						"Purchase Order": "purchase_order",
+						"Delivery Note": "delivery_note",
+						"Purchase Receipt": "purchase_receipt",
+						"Purchase Invoice": "purchase_invoice",
+					};
+					const link_field = doctype_fieldname_map[opts.source_doctype];
+					if (link_field) {
+						const items_present = opts.cur_items.map((item) => item[link_field]).filter(Boolean);
+						const duplicates = values.filter((value) => items_present.includes(value));
+						if (duplicates.length > 0) {
+							let item_qty_map = {};
+							opts.cur_items
+								.filter((item) => duplicates.includes(item[link_field]))
+								.forEach((item) => {
+									const key = item[link_field] + ":" + item.item_code;
+									item_qty_map[key] = (item_qty_map[key] || 0) + flt(item.qty);
+								});
 
+							let fully_added = [];
+							let checked = 0;
+							duplicates.forEach((src) => {
+								frappe.model.with_doc(opts.source_doctype, src, function () {
+									const source_doc = frappe.model.get_doc(opts.source_doctype, src);
+									let source_qty_map = {};
+									(source_doc.items || []).forEach((row) => {
+										const key = src + ":" + row.item_code;
+										source_qty_map[key] = (source_qty_map[key] || 0) + flt(row.qty);
+									});
+									let has_remaining = false;
+									for (const key of Object.keys(source_qty_map)) {
+										if (flt(source_qty_map[key]) > flt(item_qty_map[key] || 0)) {
+											has_remaining = true;
+											break;
+										}
+									}
+									if (!has_remaining) {
+										fully_added.push(src);
+									}
+									checked++;
+									if (checked === duplicates.length) {
+										if (fully_added.length > 0) {
+											frappe.msgprint(
+												__(
+													"All items from {0} {1} are already fully added in the items table",
+													[opts.source_doctype, fully_added.join(", ")]
+												)
+											);
+										}
+										const remaining_values = values.filter(
+											(v) => !fully_added.includes(v)
+										);
+										if (remaining_values.length > 0) {
+											opts.source_name = [...new Set(remaining_values)];
+											if (
+												opts.allow_child_item_selection ||
+												["Purchase Receipt", "Delivery Note", "Pick List"].includes(
+													opts.source_doctype
+												)
+											) {
+												opts.args = args;
+											}
+											d.dialog.hide();
+											_map();
+										} else {
+											d.dialog.hide();
+										}
+									}
+								});
+							});
+							return;
+						}
+					}
+				}
 				opts.source_name = Array.isArray(values) ? [...new Set(values)] : values;
 
 				if (

--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -1208,7 +1208,7 @@ def make_delivery_note(
 					_("Duplicate items were merged into existing rows in the Items table."),
 					indicator="blue",
 				)
-			else:
+			elif len(so_detail_map) == len(items_to_remove):
 				frappe.msgprint(
 					_("All items from {0} {1} are already fully added in the items table").format(
 						source.doctype, source.name
@@ -1405,7 +1405,7 @@ def make_sales_invoice(
 					_("Duplicate items were merged into existing rows in the Items table."),
 					indicator="blue",
 				)
-			else:
+			elif len(so_detail_map) == len(items_to_remove):
 				frappe.msgprint(
 					_("All items from {0} {1} are already fully added in the items table").format(
 						source.doctype, source.name

--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -1190,15 +1190,16 @@ def make_delivery_note(
 		for item in target.items:
 			if not item.so_detail:
 				continue
-			if item.so_detail in so_detail_map:
-				existing = so_detail_map[item.so_detail]
+			key = (item.so_detail, item.warehouse)
+			if key in so_detail_map:
+				existing = so_detail_map[key]
 				remaining = flt(item.qty) - flt(existing.qty)
 				if remaining > 0:
 					existing.qty = flt(existing.qty) + remaining
 					has_partial_merge = True
 				items_to_remove.append(item)
 			else:
-				so_detail_map[item.so_detail] = item
+				so_detail_map[key] = item
 		for item in items_to_remove:
 			target.remove(item)
 		if items_to_remove:

--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -1183,6 +1183,38 @@ def make_delivery_note(
 	# 0 qty is accepted, as the qty is uncertain for some items
 	has_unit_price_items = frappe.db.get_value("Sales Order", source_name, "has_unit_price_items")
 
+	def post_process(source, target):
+		so_detail_map = {}
+		items_to_remove = []
+		has_partial_merge = False
+		for item in target.items:
+			if not item.so_detail:
+				continue
+			if item.so_detail in so_detail_map:
+				existing = so_detail_map[item.so_detail]
+				remaining = flt(item.qty) - flt(existing.qty)
+				if remaining > 0:
+					existing.qty = flt(existing.qty) + remaining
+					has_partial_merge = True
+				items_to_remove.append(item)
+			else:
+				so_detail_map[item.so_detail] = item
+		for item in items_to_remove:
+			target.remove(item)
+		if items_to_remove:
+			if has_partial_merge:
+				frappe.msgprint(
+					_("Duplicate items were merged into existing rows in the Items table."),
+					indicator="blue",
+				)
+			else:
+				frappe.msgprint(
+					_("All items from {0} {1} are already fully added in the items table").format(
+						source.doctype, source.name
+					),
+					indicator="blue",
+				)
+
 	def is_unit_price_row(source):
 		return has_unit_price_items and source.qty == 0
 
@@ -1320,6 +1352,8 @@ def make_delivery_note(
 		del target_doc
 		return
 
+	post_process(so, target_doc)
+
 	# Should be called after mapping items.
 	set_missing_values(so, target_doc)
 
@@ -1330,8 +1364,8 @@ def make_delivery_note(
 def make_sales_invoice(
 	source_name: str,
 	target_doc: str | Document | None = None,
-	ignore_permissions: bool = False,
 	args: str | dict | None = None,
+	ignore_permissions: bool = False,
 ):
 	if args is None:
 		args = {}
@@ -1345,6 +1379,39 @@ def make_sales_invoice(
 		return has_unit_price_items and source.qty == 0
 
 	def postprocess(source, target):
+		so_detail_map = {}
+		items_to_remove = []
+		has_partial_merge = False
+		for item in target.items:
+			if not item.so_detail:
+				continue
+			if item.so_detail in so_detail_map:
+				existing = so_detail_map[item.so_detail]
+				remaining = flt(item.qty) - flt(existing.qty)
+				if remaining > 0:
+					existing.qty = flt(existing.qty) + remaining
+					has_partial_merge = True
+				items_to_remove.append(item)
+			else:
+				so_detail_map[item.so_detail] = item
+
+		for item in items_to_remove:
+			target.remove(item)
+
+		if items_to_remove:
+			if has_partial_merge:
+				frappe.msgprint(
+					_("Duplicate items were merged into existing rows in the Items table."),
+					indicator="blue",
+				)
+			else:
+				frappe.msgprint(
+					_("All items from {0} {1} are already fully added in the items table").format(
+						source.doctype, source.name
+					),
+					indicator="blue",
+				)
+
 		set_missing_values(source, target)
 		# Get the advance paid Journal Entries in Sales Invoice Advance
 		if target.get("allocate_advances_automatically"):

--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -22,6 +22,7 @@ from erpnext.accounts.doctype.sales_invoice.sales_invoice import (
 	validate_inter_company_party,
 )
 from erpnext.accounts.party import get_party_account
+from erpnext.buying.doctype.purchase_order.purchase_order import merge_and_remove_duplicate_items
 from erpnext.controllers.selling_controller import SellingController
 from erpnext.manufacturing.doctype.blanket_order.blanket_order import (
 	validate_against_blanket_order,
@@ -1380,39 +1381,7 @@ def make_sales_invoice(
 		return has_unit_price_items and source.qty == 0
 
 	def postprocess(source, target):
-		so_detail_map = {}
-		items_to_remove = []
-		has_partial_merge = False
-		for item in target.items:
-			if not item.so_detail:
-				continue
-			if item.so_detail in so_detail_map:
-				existing = so_detail_map[item.so_detail]
-				remaining = flt(item.qty) - flt(existing.qty)
-				if remaining > 0:
-					existing.qty = flt(existing.qty) + remaining
-					has_partial_merge = True
-				items_to_remove.append(item)
-			else:
-				so_detail_map[item.so_detail] = item
-
-		for item in items_to_remove:
-			target.remove(item)
-
-		if items_to_remove:
-			if has_partial_merge:
-				frappe.msgprint(
-					_("Duplicate items were merged into existing rows in the Items table."),
-					indicator="blue",
-				)
-			elif len(so_detail_map) == len(items_to_remove):
-				frappe.msgprint(
-					_("All items from {0} {1} are already fully added in the items table").format(
-						source.doctype, source.name
-					),
-					indicator="blue",
-				)
-
+		merge_and_remove_duplicate_items(source, target, "so_detail")
 		set_missing_values(source, target)
 		# Get the advance paid Journal Entries in Sales Invoice Advance
 		if target.get("allocate_advances_automatically"):

--- a/erpnext/stock/doctype/delivery_note/delivery_note.js
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.js
@@ -179,6 +179,7 @@ erpnext.stock.DeliveryNoteController = class DeliveryNoteController extends (
 							company: me.frm.doc.company,
 							project: me.frm.doc.project || undefined,
 						},
+						cur_items: me.frm.doc.items,
 						allow_child_item_selection: true,
 						child_fieldname: "items",
 						child_columns: ["item_code", "item_name", "qty", "delivered_qty"],
@@ -454,6 +455,15 @@ frappe.ui.form.on("Delivery Note", {
 		// unhide expense_account and cost_center if perpetual inventory is enabled in the company
 		var aii_enabled = erpnext.is_perpetual_inventory_enabled(frm.doc.company);
 		frm.fields_dict["items"].grid.set_column_disp(["expense_account", "cost_center"], aii_enabled);
+	},
+});
+
+frappe.ui.form.on("Delivery Note Item", {
+	item_code: function (frm, cdt, cdn) {
+		let row = locals[cdt][cdn];
+		if (row.so_detail) {
+			frappe.model.set_value(row.doctype, row.name, "so_detail", null);
+		}
 	},
 });
 

--- a/erpnext/stock/doctype/delivery_note/delivery_note.js
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.js
@@ -464,6 +464,9 @@ frappe.ui.form.on("Delivery Note Item", {
 		if (row.so_detail) {
 			frappe.model.set_value(row.doctype, row.name, "so_detail", null);
 		}
+		if (row.against_sales_order) {
+			frappe.model.set_value(row.doctype, row.name, "against_sales_order", null);
+		}
 	},
 });
 

--- a/erpnext/stock/doctype/delivery_note/delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.py
@@ -867,6 +867,38 @@ def make_sales_invoice(
 	invoiced_qty_map = get_invoiced_qty_map(source_name)
 
 	def set_missing_values(source, target):
+		detail_map = {}
+		items_to_remove = []
+		has_partial_merge = False
+		for item in target.items:
+			key = item.so_detail or item.dn_detail
+			if not key:
+				continue
+			if key in detail_map:
+				existing = detail_map[key]
+				remaining = flt(item.qty) - flt(existing.qty)
+				if remaining > 0:
+					existing.qty = flt(existing.qty) + remaining
+					has_partial_merge = True
+				items_to_remove.append(item)
+			else:
+				detail_map[key] = item
+		for item in items_to_remove:
+			target.remove(item)
+
+		if items_to_remove:
+			if has_partial_merge:
+				frappe.msgprint(
+					_("Duplicate items were merged into existing rows in the Items table."),
+					indicator="blue",
+				)
+			else:
+				frappe.msgprint(
+					_("All items from {0} {1} are already fully added in the items table").format(
+						source.doctype, source.name
+					),
+					indicator="blue",
+				)
 		target.run_method("set_missing_values")
 		target.run_method("set_po_nos")
 

--- a/erpnext/stock/doctype/delivery_note/delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.py
@@ -871,7 +871,7 @@ def make_sales_invoice(
 		items_to_remove = []
 		has_partial_merge = False
 		for item in target.items:
-			key = item.so_detail or item.dn_detail
+			key = item.dn_detail or item.so_detail
 			if not key:
 				continue
 			if key in detail_map:
@@ -892,7 +892,7 @@ def make_sales_invoice(
 					_("Duplicate items were merged into existing rows in the Items table."),
 					indicator="blue",
 				)
-			else:
+			elif len(detail_map) == len(items_to_remove):
 				frappe.msgprint(
 					_("All items from {0} {1} are already fully added in the items table").format(
 						source.doctype, source.name

--- a/erpnext/stock/doctype/delivery_note/delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.py
@@ -867,38 +867,10 @@ def make_sales_invoice(
 	invoiced_qty_map = get_invoiced_qty_map(source_name)
 
 	def set_missing_values(source, target):
-		detail_map = {}
-		items_to_remove = []
-		has_partial_merge = False
-		for item in target.items:
-			key = item.dn_detail or item.so_detail
-			if not key:
-				continue
-			if key in detail_map:
-				existing = detail_map[key]
-				remaining = flt(item.qty) - flt(existing.qty)
-				if remaining > 0:
-					existing.qty = flt(existing.qty) + remaining
-					has_partial_merge = True
-				items_to_remove.append(item)
-			else:
-				detail_map[key] = item
-		for item in items_to_remove:
-			target.remove(item)
+		from erpnext.buying.doctype.purchase_order.purchase_order import merge_and_remove_duplicate_items
 
-		if items_to_remove:
-			if has_partial_merge:
-				frappe.msgprint(
-					_("Duplicate items were merged into existing rows in the Items table."),
-					indicator="blue",
-				)
-			elif len(detail_map) == len(items_to_remove):
-				frappe.msgprint(
-					_("All items from {0} {1} are already fully added in the items table").format(
-						source.doctype, source.name
-					),
-					indicator="blue",
-				)
+		merge_and_remove_duplicate_items(source, target, "dn_detail", "so_detail")
+
 		target.run_method("set_missing_values")
 		target.run_method("set_po_nos")
 

--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.js
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.js
@@ -158,24 +158,6 @@ frappe.ui.form.on("Purchase Receipt", {
 	},
 });
 
-frappe.ui.form.on("Purchase Receipt Item", {
-	item_code: function (frm, cdt, cdn) {
-		let row = locals[cdt][cdn];
-		if (row.purchase_invoice) {
-			frappe.model.set_value(cdt, cdn, "purchase_invoice", null);
-		}
-		if (row.purchase_invoice_item) {
-			frappe.model.set_value(cdt, cdn, "purchase_invoice_item", null);
-		}
-		if (row.purchase_order) {
-			frappe.model.set_value(cdt, cdn, "purchase_order", null);
-		}
-		if (row.purchase_order_item) {
-			frappe.model.set_value(cdt, cdn, "purchase_order_item", null);
-		}
-	},
-});
-
 erpnext.stock.PurchaseReceiptController = class PurchaseReceiptController extends (
 	erpnext.buying.BuyingController
 ) {
@@ -449,6 +431,18 @@ frappe.ui.form.on("Purchase Receipt", "is_subcontracted", function (frm) {
 frappe.ui.form.on("Purchase Receipt Item", {
 	item_code: function (frm, cdt, cdn) {
 		var d = locals[cdt][cdn];
+		if (d.purchase_invoice) {
+			frappe.model.set_value(cdt, cdn, "purchase_invoice", null);
+		}
+		if (d.purchase_invoice_item) {
+			frappe.model.set_value(cdt, cdn, "purchase_invoice_item", null);
+		}
+		if (d.purchase_order) {
+			frappe.model.set_value(cdt, cdn, "purchase_order", null);
+		}
+		if (d.purchase_order_item) {
+			frappe.model.set_value(cdt, cdn, "purchase_order_item", null);
+		}
 		frappe.db.get_value("Item", { name: d.item_code }, "sample_quantity", (r) => {
 			frappe.model.set_value(cdt, cdn, "sample_quantity", r.sample_quantity);
 			validate_sample_quantity(frm, cdt, cdn);

--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.js
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.js
@@ -136,6 +136,7 @@ frappe.ui.form.on("Purchase Receipt", {
 							company: frm.doc.company,
 							update_stock: 0,
 						},
+						cur_items: frm.doc.items,
 						allow_child_item_selection: true,
 						child_fieldname: "items",
 						child_columns: ["item_code", "item_name", "qty", "received_qty"],
@@ -154,6 +155,24 @@ frappe.ui.form.on("Purchase Receipt", {
 	toggle_display_account_head: function (frm) {
 		var enabled = erpnext.is_perpetual_inventory_enabled(frm.doc.company);
 		frm.fields_dict["items"].grid.set_column_disp(["cost_center"], enabled);
+	},
+});
+
+frappe.ui.form.on("Purchase Receipt Item", {
+	item_code: function (frm, cdt, cdn) {
+		let row = locals[cdt][cdn];
+		if (row.purchase_invoice) {
+			frappe.model.set_value(cdt, cdn, "purchase_invoice", null);
+		}
+		if (row.purchase_invoice_item) {
+			frappe.model.set_value(cdt, cdn, "purchase_invoice_item", null);
+		}
+		if (row.purchase_order) {
+			frappe.model.set_value(cdt, cdn, "purchase_order", null);
+		}
+		if (row.purchase_order_item) {
+			frappe.model.set_value(cdt, cdn, "purchase_order_item", null);
+		}
 	},
 });
 
@@ -236,6 +255,7 @@ erpnext.stock.PurchaseReceiptController = class PurchaseReceiptController extend
 								per_received: ["<", 99.99],
 								company: me.frm.doc.company,
 							},
+							cur_items: me.frm.doc.items,
 							allow_child_item_selection: true,
 							child_fieldname: "items",
 							child_columns: ["item_code", "item_name", "qty", "received_qty"],

--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
@@ -1487,6 +1487,40 @@ def make_purchase_invoice(
 	invoiced_qty_map = get_invoiced_qty_map(source_name)
 
 	def set_missing_values(source, target):
+		detail_map = {}
+		items_to_remove = []
+		has_partial_merge = False
+		for item in target.get("items", []):
+			key = item.pr_detail or item.po_detail
+			if not key:
+				continue
+			if key in detail_map:
+				existing = detail_map[key]
+				remaining = flt(item.qty) - flt(existing.qty)
+				if remaining > 0:
+					existing.qty = flt(existing.qty) + remaining
+					has_partial_merge = True
+				items_to_remove.append(item)
+			else:
+				detail_map[key] = item
+
+		for item in items_to_remove:
+			target.remove(item)
+
+		if items_to_remove:
+			if has_partial_merge:
+				frappe.msgprint(
+					_("Duplicate items were merged into existing rows in the Items table."),
+					indicator="blue",
+				)
+			else:
+				frappe.msgprint(
+					_("All items from {0} {1} are already fully added in the items table").format(
+						source.doctype, source.name
+					),
+					indicator="blue",
+				)
+
 		if len(target.get("items")) == 0:
 			frappe.throw(_("All items have already been Invoiced/Returned"))
 

--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
@@ -1513,7 +1513,7 @@ def make_purchase_invoice(
 					_("Duplicate items were merged into existing rows in the Items table."),
 					indicator="blue",
 				)
-			else:
+			elif len(detail_map) == len(items_to_remove):
 				frappe.msgprint(
 					_("All items from {0} {1} are already fully added in the items table").format(
 						source.doctype, source.name

--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
@@ -16,6 +16,7 @@ from pypika import functions as fn
 import erpnext
 from erpnext.accounts.utils import get_account_currency
 from erpnext.assets.doctype.asset.asset import get_asset_account, is_cwip_accounting_enabled
+from erpnext.buying.doctype.purchase_order.purchase_order import merge_and_remove_duplicate_items
 from erpnext.buying.utils import check_on_hold_or_closed_status
 from erpnext.controllers.accounts_controller import merge_taxes
 from erpnext.controllers.buying_controller import BuyingController
@@ -1487,39 +1488,7 @@ def make_purchase_invoice(
 	invoiced_qty_map = get_invoiced_qty_map(source_name)
 
 	def set_missing_values(source, target):
-		detail_map = {}
-		items_to_remove = []
-		has_partial_merge = False
-		for item in target.get("items", []):
-			key = item.pr_detail or item.po_detail
-			if not key:
-				continue
-			if key in detail_map:
-				existing = detail_map[key]
-				remaining = flt(item.qty) - flt(existing.qty)
-				if remaining > 0:
-					existing.qty = flt(existing.qty) + remaining
-					has_partial_merge = True
-				items_to_remove.append(item)
-			else:
-				detail_map[key] = item
-
-		for item in items_to_remove:
-			target.remove(item)
-
-		if items_to_remove:
-			if has_partial_merge:
-				frappe.msgprint(
-					_("Duplicate items were merged into existing rows in the Items table."),
-					indicator="blue",
-				)
-			elif len(detail_map) == len(items_to_remove):
-				frappe.msgprint(
-					_("All items from {0} {1} are already fully added in the items table").format(
-						source.doctype, source.name
-					),
-					indicator="blue",
-				)
+		merge_and_remove_duplicate_items(source, target, "pr_detail", "po_detail")
 
 		if len(target.get("items")) == 0:
 			frappe.throw(_("All items have already been Invoiced/Returned"))


### PR DESCRIPTION
## Problem

`frappe.model.mapper.get_mapped_doc` always **appends** mapped child rows onto the target. When a user re-opens the "Get Items From" picker and selects the same source document (Sales Order, Purchase Order, Delivery Note, Purchase Receipt, or Purchase Invoice), the mapper blindly adds every eligible row again, producing duplicates in the items table.

**Reproduction:**
1. Create a Sales Invoice from Sales Order SO-001 — items are mapped.
2. Without saving, click *Get Items From → Sales Order* and pick SO-001 again.
3. Every row from SO-001 is added twice, doubling qty/amount/tax totals.

This pr affects 7 mapper workflows:

| Source → Target | File |
|---|---|
| Sales Order → Delivery Note | `sales_order.py:make_delivery_note` |
| Sales Order → Sales Invoice | `sales_order.py:make_sales_invoice` |
| Delivery Note → Sales Invoice | `delivery_note.py:make_sales_invoice` |
| Purchase Order → Purchase Receipt | `purchase_order.py:make_purchase_receipt` |
| Purchase Order → Purchase Invoice | `purchase_order.py:get_mapped_purchase_invoice` |
| Purchase Receipt → Purchase Invoice | `purchase_receipt.py:make_purchase_invoice` |
| Purchase Invoice → Purchase Receipt | `purchase_invoice.py:make_purchase_receipt` |

---

## Solution

### Server-side (Python) — authoritative dedup

In the `postprocess` / `set_missing_values` callback of each mapper, walk `target.items` and when a duplicate is found, any remaining (unallocated) qty on the new row is added as a new row 

### Client-side (JavaScript) — early exit

`erpnext.utils.map_current_doc` now accepts a `cur_items` option containing the current form's child table. When present, the picker checks which selected source documents are already fully represented in `cur_items` (by qty, per item_code), strips them from the server call, and — if nothing remains — skips the server round-trip entirely with a helpful message.

### Stale reference clearing on item_code change

When a user changes item_code on an already-mapped row, the source-link fields so_detail, dn_detail, po_detail are cleared. Without this clearing, the row would still carry references pointing back to the original source document even though it now represents a completely different item. The server-side dedup logic depends on those reference fields — so on the next remap it would see the stale reference, treat the row as already covering that source line, and skip adding it. Below are the source-link fields that are cleared in each file:

- `Sales Invoice Item` — clears `sales_order`, `so_detail`, `delivery_note`, `dn_detail`
- `Delivery Note Item` — clears `so_detail`, `dn_detail`
- `Purchase Invoice Item` — clears `purchase_order`, `po_detail`, `purchase_receipt`, `pr_detail`
- `Purchase Receipt Item` — clears `purchase_invoice`, `purchase_invoice_item`, `purchase_order`, `purchase_order_item`

### Also included

- `sales_order.make_sales_invoice` — reordered parameters (`args` before `ignore_permissions`) to fix frappe whitelisted method type validation error.