### PR TITLE
fix: validate duplicate reverse journal entry

### DIFF
--- a/erpnext/accounts/doctype/journal_entry/journal_entry.py
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.py
@@ -161,6 +161,8 @@ class JournalEntry(AccountsController):
 
 		if self.is_new() or not self.title:
 			self.title = self.get_title()
+		if self.reversal_of:
+			check_reverse_entry_exists(source_name=self.reversal_of, exclude_name=self.name)
 
 	def validate_advance_accounts(self):
 		journal_accounts = set([x.account for x in self.accounts])
@@ -1788,13 +1790,7 @@ def make_inter_company_journal_entry(name: str, voucher_type: str, company: str)
 
 @frappe.whitelist()
 def make_reverse_journal_entry(source_name: str, target_doc: str | Document | None = None):
-	existing_reverse = frappe.db.exists("Journal Entry", {"reversal_of": source_name, "docstatus": 1})
-	if existing_reverse:
-		frappe.throw(
-			_("A Reverse Journal Entry {0} already exists for this Journal Entry.").format(
-				get_link_to_form("Journal Entry", existing_reverse)
-			)
-		)
+	check_reverse_entry_exists(source_name)
 
 	from frappe.model.mapper import get_mapped_doc
 
@@ -1825,3 +1821,16 @@ def make_reverse_journal_entry(source_name: str, target_doc: str | Document | No
 	)
 
 	return doclist
+
+
+def check_reverse_entry_exists(source_name: str, exclude_name: str | None = None):
+	filters = {"reversal_of": source_name, "docstatus": ["!=", 2]}
+	if exclude_name:
+		filters["name"] = ["!=", exclude_name]
+	existing_reverse = frappe.db.exists("Journal Entry", filters)
+	if existing_reverse:
+		frappe.throw(
+			_("A Reverse Journal Entry {0} already exists for this Journal Entry.").format(
+				get_link_to_form("Journal Entry", existing_reverse)
+			)
+		)

--- a/erpnext/accounts/doctype/journal_entry/test_journal_entry.py
+++ b/erpnext/accounts/doctype/journal_entry/test_journal_entry.py
@@ -216,6 +216,9 @@ class TestJournalEntry(ERPNextTestSuite):
 		rjv.posting_date = nowdate()
 		rjv.submit()
 
+		# check duplicate reverse entry creation
+		self.assertRaises(frappe.ValidationError, make_reverse_journal_entry, jv.name)
+
 		self.voucher_no = rjv.name
 
 		self.fields = [


### PR DESCRIPTION
**Issue:** 
In V15, once a Journal Entry is reversed using the "Reverse Journal Entry" action, the original Journal Entry continues to show the same action, allowing it to be reversed multiple times. Also, in develop the Reverse JE created without validation if we save the JE as a draft.

**Ref:**[66002](https://support.frappe.io/helpdesk/tickets/66002?view=VIEW-HD+Ticket-745)

**Before:**

[reversejebefore.webm](https://github.com/user-attachments/assets/b10e6107-96f2-4675-af15-318565c9a127)


**After:**

[reversejeafter.webm](https://github.com/user-attachments/assets/6c9cd32b-c6c4-4658-bc96-3ac6ccf25e70)


**Backport needed for v15, v16** 