### PR TITLE
refactor: use consistent report column names

### DIFF
--- a/erpnext/accounts/report/tax_withholding_details/tax_withholding_details.py
+++ b/erpnext/accounts/report/tax_withholding_details/tax_withholding_details.py
@@ -119,8 +119,8 @@ def get_result(filters, tds_accounts, tax_category_map, net_total_map):
 
 				row.update(
 					{
-						"section_code": tax_withholding_category or "",
-						"entity_type": party_map.get(party, {}).get(party_type),
+						"tax_withholding_category": tax_withholding_category or "",
+						"party_entity_type": party_map.get(party, {}).get(party_type),
 						"rate": rate,
 						"total_amount": total_amount,
 						"grand_total": grand_total,
@@ -141,7 +141,7 @@ def get_result(filters, tds_accounts, tax_category_map, net_total_map):
 				else:
 					entries[key] = row
 	out = list(entries.values())
-	out.sort(key=lambda x: (x["section_code"], x["transaction_date"], x["ref_no"]))
+	out.sort(key=lambda x: (x["tax_withholding_category"], x["transaction_date"], x["ref_no"]))
 
 	return out
 
@@ -207,7 +207,7 @@ def get_columns(filters):
 		{
 			"label": _("Section Code"),
 			"options": "Tax Withholding Category",
-			"fieldname": "section_code",
+			"fieldname": "tax_withholding_category",
 			"fieldtype": "Link",
 			"width": 90,
 		},
@@ -236,7 +236,7 @@ def get_columns(filters):
 
 	columns.extend(
 		[
-			{"label": _("Entity Type"), "fieldname": "entity_type", "fieldtype": "Data", "width": 100},
+			{"label": _("Entity Type"), "fieldname": "party_entity_type", "fieldtype": "Data", "width": 100},
 		]
 	)
 	if filters.party_type == "Supplier":

--- a/erpnext/accounts/report/tax_withholding_details/tax_withholding_details.py
+++ b/erpnext/accounts/report/tax_withholding_details/tax_withholding_details.py
@@ -205,7 +205,7 @@ def get_columns(filters):
 	pan = "pan" if frappe.db.has_column(filters.party_type, "pan") else "tax_id"
 	columns = [
 		{
-			"label": _("Section Code"),
+			"label": _("Tax Withholding Category"),
 			"options": "Tax Withholding Category",
 			"fieldname": "tax_withholding_category",
 			"fieldtype": "Link",
@@ -236,7 +236,12 @@ def get_columns(filters):
 
 	columns.extend(
 		[
-			{"label": _("Entity Type"), "fieldname": "party_entity_type", "fieldtype": "Data", "width": 100},
+			{
+				"label": _(f"{filters.get('party_type', 'Party')} Type"),
+				"fieldname": "party_entity_type",
+				"fieldtype": "Data",
+				"width": 100,
+			},
 		]
 	)
 	if filters.party_type == "Supplier":

--- a/erpnext/accounts/report/tax_withholding_details/test_tax_withholding_details.py
+++ b/erpnext/accounts/report/tax_withholding_details/test_tax_withholding_details.py
@@ -118,7 +118,7 @@ class TestTaxWithholdingDetails(AccountsTestMixin, FrappeTestCase):
 			voucher_expected_values = expected_values[i]
 			voucher_actual_values = (
 				voucher.ref_no,
-				voucher.section_code,
+				voucher.tax_withholding_category,
 				voucher.rate,
 				voucher.base_tax_withholding_net_total,
 				voucher.base_total,

--- a/erpnext/accounts/report/tds_computation_summary/tds_computation_summary.py
+++ b/erpnext/accounts/report/tds_computation_summary/tds_computation_summary.py
@@ -63,13 +63,13 @@ def group_by_party_and_category(data, filters):
 			},
 		)
 
-		party_category_wise_map.get((row.get("party"), row.get("tax_withholding_category")))["total_amount"] += row.get(
-			"total_amount", 0.0
-		)
+		party_category_wise_map.get((row.get("party"), row.get("tax_withholding_category")))[
+			"total_amount"
+		] += row.get("total_amount", 0.0)
 
-		party_category_wise_map.get((row.get("party"), row.get("tax_withholding_category")))["tax_amount"] += row.get(
-			"tax_amount", 0.0
-		)
+		party_category_wise_map.get((row.get("party"), row.get("tax_withholding_category")))[
+			"tax_amount"
+		] += row.get("tax_amount", 0.0)
 
 	final_result = get_final_result(party_category_wise_map)
 
@@ -110,13 +110,18 @@ def get_columns(filters):
 	columns.extend(
 		[
 			{
-				"label": _("Section Code"),
+				"label": _("Tax Withholding Category"),
 				"options": "Tax Withholding Category",
 				"fieldname": "tax_withholding_category",
 				"fieldtype": "Link",
 				"width": 180,
 			},
-			{"label": _("Entity Type"), "fieldname": "party_entity_type", "fieldtype": "Data", "width": 180},
+			{
+				"label": _(f"{filters.get('party_type', 'Party')} Type"),
+				"fieldname": "party_entity_type",
+				"fieldtype": "Data",
+				"width": 180,
+			},
 			{
 				"label": _("TDS Rate %") if filters.get("party_type") == "Supplier" else _("TCS Rate %"),
 				"fieldname": "rate",

--- a/erpnext/accounts/report/tds_computation_summary/tds_computation_summary.py
+++ b/erpnext/accounts/report/tds_computation_summary/tds_computation_summary.py
@@ -49,25 +49,25 @@ def group_by_party_and_category(data, filters):
 
 	for row in data:
 		party_category_wise_map.setdefault(
-			(row.get("party"), row.get("section_code")),
+			(row.get("party"), row.get("tax_withholding_category")),
 			{
 				"pan": row.get("pan"),
 				"tax_id": row.get("tax_id"),
 				"party": row.get("party"),
 				"party_name": row.get("party_name"),
-				"section_code": row.get("section_code"),
-				"entity_type": row.get("entity_type"),
+				"tax_withholding_category": row.get("tax_withholding_category"),
+				"party_entity_type": row.get("party_entity_type"),
 				"rate": row.get("rate"),
 				"total_amount": 0.0,
 				"tax_amount": 0.0,
 			},
 		)
 
-		party_category_wise_map.get((row.get("party"), row.get("section_code")))["total_amount"] += row.get(
+		party_category_wise_map.get((row.get("party"), row.get("tax_withholding_category")))["total_amount"] += row.get(
 			"total_amount", 0.0
 		)
 
-		party_category_wise_map.get((row.get("party"), row.get("section_code")))["tax_amount"] += row.get(
+		party_category_wise_map.get((row.get("party"), row.get("tax_withholding_category")))["tax_amount"] += row.get(
 			"tax_amount", 0.0
 		)
 
@@ -112,11 +112,11 @@ def get_columns(filters):
 			{
 				"label": _("Section Code"),
 				"options": "Tax Withholding Category",
-				"fieldname": "section_code",
+				"fieldname": "tax_withholding_category",
 				"fieldtype": "Link",
 				"width": 180,
 			},
-			{"label": _("Entity Type"), "fieldname": "entity_type", "fieldtype": "Data", "width": 180},
+			{"label": _("Entity Type"), "fieldname": "party_entity_type", "fieldtype": "Data", "width": 180},
 			{
 				"label": _("TDS Rate %") if filters.get("party_type") == "Supplier" else _("TCS Rate %"),
 				"fieldname": "rate",

--- a/erpnext/accounts/report/tds_computation_summary/tds_computation_summary.py
+++ b/erpnext/accounts/report/tds_computation_summary/tds_computation_summary.py
@@ -49,11 +49,12 @@ def group_by_party_and_category(data, filters):
 
 	for row in data:
 		party_category_wise_map.setdefault(
-			(row.get("party"), row.get("tax_withholding_category")),
+			(row.get("party_type"), row.get("party"), row.get("tax_withholding_category")),
 			{
 				"pan": row.get("pan"),
 				"tax_id": row.get("tax_id"),
 				"party": row.get("party"),
+				"party_type": row.get("party_type"),
 				"party_name": row.get("party_name"),
 				"tax_withholding_category": row.get("tax_withholding_category"),
 				"party_entity_type": row.get("party_entity_type"),

--- a/erpnext/accounts/report/tds_computation_summary/tds_computation_summary.py
+++ b/erpnext/accounts/report/tds_computation_summary/tds_computation_summary.py
@@ -48,8 +48,9 @@ def group_by_party_and_category(data, filters):
 	party_category_wise_map = {}
 
 	for row in data:
+		key = (row.get("party_type"), row.get("party"), row.get("tax_withholding_category"))
 		party_category_wise_map.setdefault(
-			(row.get("party_type"), row.get("party"), row.get("tax_withholding_category")),
+			key,
 			{
 				"pan": row.get("pan"),
 				"tax_id": row.get("tax_id"),
@@ -64,13 +65,8 @@ def group_by_party_and_category(data, filters):
 			},
 		)
 
-		party_category_wise_map.get((row.get("party"), row.get("tax_withholding_category")))[
-			"total_amount"
-		] += row.get("total_amount", 0.0)
-
-		party_category_wise_map.get((row.get("party"), row.get("tax_withholding_category")))[
-			"tax_amount"
-		] += row.get("tax_amount", 0.0)
+		party_category_wise_map.get(key)["total_amount"] += row.get("total_amount", 0.0)
+		party_category_wise_map.get(key)["tax_amount"] += row.get("tax_amount", 0.0)
 
 	final_result = get_final_result(party_category_wise_map)
 


### PR DESCRIPTION
- consistent names (so they don't conflict with regional apps)

Backporting to v14, as changes in regulatory requirements > making report consistent and extending it in regional apps.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reports now show Tax Withholding Category instead of prior section identifier and use it for sorting and aggregation.
  * Entity/party type display updated to show the correct party entity/type label in report columns.

* **Tests**
  * Updated test expectations to match the revised report column ordering and values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->