### PR TITLE
ci: fix timezone for python mariadb tests

### DIFF
--- a/.github/workflows/server-tests-mariadb.yml
+++ b/.github/workflows/server-tests-mariadb.yml
@@ -41,6 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     env:
+      TZ: 'Pacific/Kiritimati'
       NODE_ENV: "production"
       WITH_COVERAGE: ${{ github.event_name != 'pull_request' }}
 
@@ -56,6 +57,7 @@ jobs:
       mysql:
         image: mariadb:10.6
         env:
+          TZ: 'Pacific/Kiritimati'
           MARIADB_ROOT_PASSWORD: 'root'
         ports:
           - 3306:3306

--- a/.github/workflows/server-tests-mariadb.yml
+++ b/.github/workflows/server-tests-mariadb.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     env:
-      TZ: 'Pacific/Kiritimati'
+      TZ: 'Asia/Kolkata'
       NODE_ENV: "production"
       WITH_COVERAGE: ${{ github.event_name != 'pull_request' }}
 
@@ -57,7 +57,7 @@ jobs:
       mysql:
         image: mariadb:10.6
         env:
-          TZ: 'Pacific/Kiritimati'
+          TZ: 'Asia/Kolkata'
           MARIADB_ROOT_PASSWORD: 'root'
         ports:
           - 3306:3306

--- a/erpnext/tests/utils.py
+++ b/erpnext/tests/utils.py
@@ -225,7 +225,7 @@ class BootStrapTestData:
 
 	def update_system_settings(self):
 		system_settings = frappe.get_doc("System Settings")
-		system_settings.time_zone = "Pacific/Kiritimati"
+		system_settings.time_zone = "Asia/Kolkata"
 		system_settings.language = "en"
 		system_settings.currency_precision = system_settings.float_precision = 2
 		system_settings.rounding_method = "Banker's Rounding"

--- a/erpnext/tests/utils.py
+++ b/erpnext/tests/utils.py
@@ -151,6 +151,7 @@ class BootStrapTestData:
 		frappe.db.commit()  # nosemgrep
 
 	def make_master_data(self):
+		self.update_system_settings()
 		self.make_fiscal_year()
 		self.make_holiday_list()
 		self.make_company()
@@ -203,7 +204,6 @@ class BootStrapTestData:
 		self.update_support_settings()
 		self.update_selling_settings()
 		self.update_stock_settings()
-		self.update_system_settings()
 
 		frappe.db.commit()  # nosemgrep
 
@@ -225,7 +225,7 @@ class BootStrapTestData:
 
 	def update_system_settings(self):
 		system_settings = frappe.get_doc("System Settings")
-		system_settings.time_zone = "Asia/Kolkata"
+		system_settings.time_zone = "Pacific/Kiritimati"
 		system_settings.language = "en"
 		system_settings.currency_precision = system_settings.float_precision = 2
 		system_settings.rounding_method = "Banker's Rounding"


### PR DESCRIPTION
_Aims to fix the Item Heatmap Test, which fails if CI/CD is run between 12:00 AM and 05:30 AM IST_

Test records are generated with the time zone Asia/Kolkata; however, certain tests, such as `test_heatmap_data`, fail because MariaDB's System Time Zone is set to Etc/UTC.