### PR TITLE
fix(stock): show available qty in warehouse link field

### DIFF
--- a/erpnext/public/js/utils/serial_no_batch_selector.js
+++ b/erpnext/public/js/utils/serial_no_batch_selector.js
@@ -106,10 +106,12 @@ erpnext.SerialBatchPackageSelector = class SerialNoBatchBundleUpdate {
 			},
 			get_query: () => {
 				return {
-					filters: {
-						is_group: 0,
-						company: this.frm.doc.company,
-					},
+					query: "erpnext.controllers.queries.warehouse_query",
+					filters: [
+						["Bin", "item_code", "=", this.item.item_code],
+						["Warehouse", "is_group", "=", 0],
+						["Warehouse", "company", "=", this.frm.doc.company],
+					],
 				};
 			},
 		});


### PR DESCRIPTION
**Issue:**
The Serial and Batch Selector has a warehouse field as a link field within the selection dialog. In Version 14, this field displayed the available quantity for each warehouse directly in the dropdown, helping users easily identify and select the appropriate warehouse.

In the current version, this behavior has been removed, and the available quantity is no longer shown in the warehouse link field. As a result, users are unable to quickly determine stock availability while selecting Serial or Batch Numbers, making the process less efficient and user-friendly.

**Ref:** [#66029](https://support.frappe.io/helpdesk/tickets/66029)

**Backport Needed for v15 & v16**