### PR TITLE
fix:  Handle mandantory filters for financial statements report

### DIFF
--- a/erpnext/accounts/doctype/financial_report_template/financial_report_engine.py
+++ b/erpnext/accounts/doctype/financial_report_template/financial_report_engine.py
@@ -203,21 +203,6 @@ class FormattingRule:
 # ============================================================================
 
 
-FILTER_LABELS = {
-	"report_template": _("Report Template"),
-	"filter_based_on": _("Filter Based On"),
-	"period_start_date": _("Start Date"),
-	"period_end_date": _("End Date"),
-	"from_fiscal_year": _("Start Year"),
-	"to_fiscal_year": _("End Year"),
-}
-
-REQUIRED_FILTERS_BY_BASIS = {
-	"Date Range": ("period_start_date", "period_end_date"),
-	"Fiscal Year": ("from_fiscal_year", "to_fiscal_year"),
-}
-
-
 class FinancialReportEngine:
 	def execute(self, filters: dict[str, Any]) -> tuple[list[dict], list[dict]]:
 		"""Execute the complete report generation"""
@@ -237,15 +222,29 @@ class FinancialReportEngine:
 		return context.get_result()
 
 	def _validate_filters(self, filters: dict[str, Any]) -> None:
+		filter_labels = {
+			"report_template": _("Report Template"),
+			"filter_based_on": _("Filter Based On"),
+			"period_start_date": _("Start Date"),
+			"period_end_date": _("End Date"),
+			"from_fiscal_year": _("Start Year"),
+			"to_fiscal_year": _("End Year"),
+		}
+
+		required_filters_by_basis = {
+			"Date Range": ("period_start_date", "period_end_date"),
+			"Fiscal Year": ("from_fiscal_year", "to_fiscal_year"),
+		}
+
 		required_filters = ["report_template", "filter_based_on"]
-		required_filters.extend(REQUIRED_FILTERS_BY_BASIS.get(filters.get("filter_based_on"), ()))
+		required_filters.extend(required_filters_by_basis.get(filters.get("filter_based_on"), ()))
 
 		for filter_key in required_filters:
 			if not filters.get(filter_key):
 				frappe.throw(
 					title=_("Missing Required Filter"),
 					msg=_("Missing required filter: {0}").format(
-						frappe.bold(FILTER_LABELS.get(filter_key, filter_key))
+						frappe.bold(filter_labels.get(filter_key, filter_key))
 					),
 				)
 

--- a/erpnext/accounts/doctype/financial_report_template/financial_report_engine.py
+++ b/erpnext/accounts/doctype/financial_report_template/financial_report_engine.py
@@ -203,6 +203,21 @@ class FormattingRule:
 # ============================================================================
 
 
+FILTER_LABELS = {
+	"report_template": _("Report Template"),
+	"filter_based_on": _("Filter Based On"),
+	"period_start_date": _("Start Date"),
+	"period_end_date": _("End Date"),
+	"from_fiscal_year": _("Start Year"),
+	"to_fiscal_year": _("End Year"),
+}
+
+REQUIRED_FILTERS_BY_BASIS = {
+	"Date Range": ("period_start_date", "period_end_date"),
+	"Fiscal Year": ("from_fiscal_year", "to_fiscal_year"),
+}
+
+
 class FinancialReportEngine:
 	def execute(self, filters: dict[str, Any]) -> tuple[list[dict], list[dict]]:
 		"""Execute the complete report generation"""
@@ -222,14 +237,24 @@ class FinancialReportEngine:
 		return context.get_result()
 
 	def _validate_filters(self, filters: dict[str, Any]) -> None:
-		required_filters = ["report_template", "period_start_date", "period_end_date"]
+		required_filters = ["report_template", "filter_based_on"]
+		required_filters.extend(REQUIRED_FILTERS_BY_BASIS.get(filters.get("filter_based_on"), ()))
 
 		for filter_key in required_filters:
 			if not filters.get(filter_key):
-				frappe.throw(_("Missing required filter: {0}").format(filter_key))
+				frappe.throw(
+					title=_("Missing Required Filter"),
+					msg=_("Missing required filter: {0}").format(
+						frappe.bold(FILTER_LABELS.get(filter_key, filter_key))
+					),
+				)
 
 		if filters.get("presentation_currency"):
-			frappe.msgprint(_("Currency filters are currently unsupported in Custom Financial Report."))
+			frappe.msgprint(
+				title=_("Unsupported Feature"),
+				msg=_("Currency filters are currently unsupported in Custom Financial Report."),
+				indicator="orange",
+			)
 
 		# Margin view is dependent on first row being an income account. Hence not supported.
 		# Way to implement this would be using calculated rows with formulas.

--- a/erpnext/public/js/financial_statements.js
+++ b/erpnext/public/js/financial_statements.js
@@ -64,7 +64,7 @@ erpnext.financial_statements = {
 		const isPeriodColumn = periodKeys.includes(baseName);
 
 		return {
-			isAccount: baseName === erpnext.financial_statements.name_field,
+			isAccount: baseName === "account", // DO NOT USE `name_field` ! This can be overridden in some reports!
 			isPeriod: isPeriodColumn,
 			segmentIndex: valueMatch && valueMatch[1] ? parseInt(valueMatch[1]) : null,
 			fieldname: baseName,

--- a/erpnext/public/js/financial_statements.js
+++ b/erpnext/public/js/financial_statements.js
@@ -298,7 +298,7 @@ erpnext.financial_statements = {
 		let fiscal_year = erpnext.utils.get_fiscal_year(frappe.datetime.get_today());
 		var filters = report.get_values();
 
-		if (!filters.period_start_date || !filters.period_end_date) {
+		if (fiscal_year && (!filters.period_start_date || !filters.period_end_date)) {
 			frappe.model.with_doc("Fiscal Year", fiscal_year, function (r) {
 				var fy = frappe.model.get_doc("Fiscal Year", fiscal_year);
 				frappe.query_report.set_filter_value({

--- a/erpnext/public/js/financial_statements.js
+++ b/erpnext/public/js/financial_statements.js
@@ -422,16 +422,16 @@ function get_filters() {
 			label: __("Start Year"),
 			fieldtype: "Link",
 			options: "Fiscal Year",
-			reqd: 1,
 			depends_on: "eval:doc.filter_based_on == 'Fiscal Year'",
+			mandatory_depends_on: "eval:doc.filter_based_on == 'Fiscal Year'",
 		},
 		{
 			fieldname: "to_fiscal_year",
 			label: __("End Year"),
 			fieldtype: "Link",
 			options: "Fiscal Year",
-			reqd: 1,
 			depends_on: "eval:doc.filter_based_on == 'Fiscal Year'",
+			mandatory_depends_on: "eval:doc.filter_based_on == 'Fiscal Year'",
 		},
 		{
 			fieldname: "periodicity",


### PR DESCRIPTION
## Issue 1

- Date filter based on `filter_based_on` field, but in server side both filters are check even if it is not mandatory

<img width="977" height="306" alt="image_2026-04-23_15-39-19" src="https://github.com/user-attachments/assets/09f461aa-f05c-4c8b-979c-67f99888f663" />

## Issue 2

- When current fiscal year data is not available error getting thrown

<img width="827" height="237" alt="image" src="https://github.com/user-attachments/assets/43dcd9fd-2303-4539-b438-890526e7ba68" />



## Issue 3

- `period_start_date` and `period_end_date` have property `reqd:1`  instead of `mandatory_depends_on`


## Issue 4

- Some heading getting blank

<img width="812" height="881" alt="image_2026-04-23_13-11-34" src="https://github.com/user-attachments/assets/f96a38ef-b999-47c6-bb1b-7276bd38c208" />

---

> [!NOTE]
> Backport to V-16