### PR TITLE
fix: update type hint for get_item_tax_template function

### DIFF
--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -704,7 +704,9 @@ def get_item_tax_info(
 
 @frappe.whitelist()
 @erpnext.normalize_ctx_input(ItemDetailsCtx)
-def get_item_tax_template(ctx: ItemDetailsCtx, item: Document | None = None, out: ItemDetails | None = None):
+def get_item_tax_template(
+	ctx: ItemDetailsCtx | str, item: Document | None = None, out: ItemDetails | None = None
+):
 	"""
 	Determines item_tax template from item or parent item groups.
 


### PR DESCRIPTION
Traceback
```
Traceback (most recent call last):
  File "apps/frappe/frappe/utils/typing_validations.py", line 184, in transform_parameter_types
    current_arg_value_after = TypeAdapter(current_arg_type).validate_python(current_arg_value)
  File "env/lib/python3.14/site-packages/pydantic/type_adapter.py", line 441, in validate_python
    return self.validator.validate_python(
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        object,
        ^^^^^^^
    ...<6 lines>...
        by_name=by_name,
        ^^^^^^^^^^^^^^^^
    )
    ^
pydantic_core._pydantic_core.ValidationError: 1 validation error for is-instance[_dict]
  Input should be an instance of _dict [type=is_instance_of, input_value='{"item_code":"14 INCH CU...ing_date":"2026-03-16"}', input_type=str]
    For further information visit https://errors.pydantic.dev/2.12/v/is_instance_of

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "apps/frappe/frappe/app.py", line 121, in application
    response = frappe.api.handle(request)
  File "apps/frappe/frappe/api/__init__.py", line 63, in handle
    data = endpoint(**arguments)
  File "apps/frappe/frappe/api/v1.py", line 40, in handle_rpc_call
    return frappe.handler.handle()
           ~~~~~~~~~~~~~~~~~~~~~^^
  File "apps/frappe/frappe/handler.py", line 54, in handle
    data = execute_cmd(cmd)
  File "apps/frappe/frappe/handler.py", line 87, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
           ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/__init__.py", line 1131, in call
    return fn(*args, **newargs)
  File "apps/frappe/frappe/utils/typing_validations.py", line 47, in wrapper
    args, kwargs = transform_parameter_types(func, args, kwargs, force_types)
                   ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/utils/typing_validations.py", line 186, in transform_parameter_types
    raise_type_error(func, current_arg, current_arg_type, current_arg_value, current_exception=e)
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/utils/typing_validations.py", line 86, in raise_type_error
    raise FrappeTypeError(
    ...<2 lines>...
    ) from current_exception
frappe.exceptions.FrappeTypeError: Argument 'ctx' in 'erpnext.stock.get_item_details.get_item_tax_template' should be of type 'frappe.types.frappedict._dict' but got 'str' instead.
```