### PR TITLE
fix: hide feature flag controlled fields on install

### DIFF
--- a/erpnext/setup/install.py
+++ b/erpnext/setup/install.py
@@ -38,6 +38,7 @@ def after_install():
 	update_pegged_currencies()
 	set_default_print_formats()
 	create_letter_head()
+	toggle_hidden_fields()
 	frappe.db.commit()
 
 
@@ -363,6 +364,21 @@ def create_letter_head():
 				}
 			)
 			doc.insert(ignore_permissions=True)
+
+
+def toggle_hidden_fields():
+	from erpnext.accounts.doctype.accounts_settings.accounts_settings import (
+		toggle_accounting_dimension_sections,
+		toggle_loyalty_point_program_section,
+		toggle_sales_discount_section,
+		toggle_subscription_sections,
+	)
+
+	acc_settings = frappe.get_doc("Accounts Settings")
+	toggle_accounting_dimension_sections(not acc_settings.enable_accounting_dimensions)
+	toggle_sales_discount_section(not acc_settings.enable_discounts_and_margin)
+	toggle_subscription_sections(not acc_settings.enable_subscription)
+	toggle_loyalty_point_program_section(not acc_settings.enable_loyalty_point_program)
 
 
 DEFAULT_ROLE_PROFILES = {


### PR DESCRIPTION
Accounting Dimensions, Discount, Subscription are all controlled by feature flags and are disabled by default. On fresh install, they should be hidden unless explicitly enabled.