### PR TITLE
fix(stock): set incoming rate as zero for outward sle

### DIFF
--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -955,6 +955,9 @@ class update_entries_after:
 		if not self.wh_data.qty_after_transaction:
 			self.wh_data.stock_value = 0.0
 
+		if sle.actual_qty < 0:
+			sle.incoming_rate = 0
+
 		stock_value_difference = self.wh_data.stock_value - self.wh_data.prev_stock_value
 		self.wh_data.prev_stock_value = self.wh_data.stock_value
 


### PR DESCRIPTION
**Issue:**
The system is updating the incoming rate for outward transactions in Stock Ledger Entries, which is not required. Incoming rate should only be applicable for inward transactions, not outward ones. This behavior may lead to confusion in stock reports. The incoming rate for outward entries should ideally be set to zero.

**Before:**
<img width="1696" height="313" alt="image" src="https://github.com/user-attachments/assets/2a22167e-fec4-454a-b9b9-8e3e244d14b7" />

**After:**
<img width="1695" height="328" alt="image" src="https://github.com/user-attachments/assets/309d78f8-ef46-4313-b1f7-905b60c638fc" />

**Backport Needed for v15 & v16**