### PR TITLE
fix(PCV): set correct filters of `from_date` and `to_date` on General Ledger Report on clicking `Ledger` button

### DIFF
--- a/erpnext/accounts/doctype/period_closing_voucher/period_closing_voucher.js
+++ b/erpnext/accounts/doctype/period_closing_voucher/period_closing_voucher.js
@@ -46,8 +46,8 @@ frappe.ui.form.on("Period Closing Voucher", {
 				function () {
 					frappe.route_options = {
 						voucher_no: frm.doc.name,
-						from_date: frm.doc.posting_date,
-						to_date: moment(frm.doc.modified).format("YYYY-MM-DD"),
+						from_date: frm.doc.period_start_date,
+						to_date: frm.doc.period_end_date,
 						company: frm.doc.company,
 						categorize_by: "",
 						show_cancelled_entries: frm.doc.docstatus === 2,


### PR DESCRIPTION
Fixed the filters of the `Ledger` Button as the `posting_date` of GL Entries of PCVs are set to the `period_end_date`.