### PR TITLE
fix(manufacturing): remove conversion factor for stock qty

### DIFF
--- a/erpnext/manufacturing/doctype/production_plan/production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.py
@@ -381,9 +381,9 @@ class ProductionPlan(Document):
 		items = items_query.run(as_dict=True)
 
 		for item in items:
-			item.pending_qty = (
-				flt(item.qty) - max(item.work_order_qty, item.delivered_qty, 0)
-			) * item.conversion_factor
+			item.pending_qty = flt(item.qty) - max(
+				item.work_order_qty, flt(item.delivered_qty) * item.conversion_factor, 0
+			)
 
 		pi = frappe.qb.DocType("Packed Item")
 


### PR DESCRIPTION
**Issue:**
While creating a Production Plan from a Sales Order, the pending quantity to manufacture is being calculated incorrectly. The system is multiplying the stock quantity by the conversion factor. This results in inaccurate manufacturing requirements being generated. The pending quantity should be derived without applying the conversion factor multiple times.

**Ref:** [#66148](https://support.frappe.io/helpdesk/tickets/66148)

**Backport Needed for v16**