### PR TITLE
fix(stock): show item code in serial and batch selector dialog

### DIFF
--- a/erpnext/public/js/utils/serial_no_batch_selector.js
+++ b/erpnext/public/js/utils/serial_no_batch_selector.js
@@ -87,7 +87,16 @@ erpnext.SerialBatchPackageSelector = class SerialNoBatchBundleUpdate {
 	}
 
 	get_dialog_fields() {
-		let fields = [];
+		let fields = [
+			{
+				fieldname: "item_code",
+				read_only: 1,
+				fieldtype: "Link",
+				options: "Item",
+				label: __("Item Code"),
+				default: this.item.item_code,
+			},
+		];
 
 		fields.push({
 			fieldtype: "Link",

--- a/erpnext/stock/doctype/batch/batch_dashboard.py
+++ b/erpnext/stock/doctype/batch/batch_dashboard.py
@@ -7,7 +7,7 @@ def get_data():
 		"transactions": [
 			{"label": _("Buy"), "items": ["Purchase Invoice", "Purchase Receipt"]},
 			{"label": _("Sell"), "items": ["Sales Invoice", "Delivery Note"]},
-			{"label": _("Move"), "items": ["Serial and Batch Bundle"]},
+			{"label": _("Move"), "items": ["Stock Entry", "Serial and Batch Bundle"]},
 			{"label": _("Quality"), "items": ["Quality Inspection"]},
 		],
 	}


### PR DESCRIPTION
**Issue:**
1. Item Code is not visible in serial and batch selector dialog.
2. Stock Entry connection is missing in Batch master.

**Ref:** [#66029](https://support.frappe.io/helpdesk/tickets/66029)

**Backport Needed for v16**