### PR TITLE
fix(UX): Item master form cleanup

### DIFF
--- a/erpnext/manufacturing/report/bom_stock_analysis/test_bom_stock_analysis.py
+++ b/erpnext/manufacturing/report/bom_stock_analysis/test_bom_stock_analysis.py
@@ -94,6 +94,7 @@ def create_items():
 			"is_stock_item": 1,
 			"standard_rate": 100,
 			"opening_stock": 100,
+			"valuation_rate": 100,
 			"last_purchase_rate": 100,
 			"item_defaults": [{"company": "_Test Company", "default_warehouse": "Stores - _TC"}],
 		}
@@ -103,6 +104,7 @@ def create_items():
 			"is_stock_item": 1,
 			"standard_rate": 200,
 			"opening_stock": 200,
+			"valuation_rate": 200,
 			"last_purchase_rate": 200,
 			"item_defaults": [{"company": "_Test Company", "default_warehouse": "Stores - _TC"}],
 		}

--- a/erpnext/stock/doctype/item/item.js
+++ b/erpnext/stock/doctype/item/item.js
@@ -73,6 +73,7 @@ frappe.ui.form.on("Item", {
 			},
 		};
 	},
+
 	onload: function (frm) {
 		erpnext.item.setup_queries(frm);
 		if (frm.doc.variant_of) {
@@ -126,6 +127,14 @@ frappe.ui.form.on("Item", {
 
 	refresh: function (frm) {
 		frm.trigger("toggle_has_serial_batch_fields");
+
+		if (frm.is_new()) {
+			frm.toggle_display(["standard_rate"], frappe.model.can_create("Item Price"));
+			frm.toggle_display("disabled", false);
+			return;
+		}
+
+		frm.toggle_display("disabled", true);
 
 		if (frm.doc.is_stock_item) {
 			frm.add_custom_button(
@@ -229,8 +238,6 @@ frappe.ui.form.on("Item", {
 					__("Create")
 				);
 			}
-
-			// frm.page.set_inner_btn_group_as_primary(__('Create'));
 		}
 		if (frm.doc.variant_of) {
 			frm.set_intro(
@@ -661,10 +668,10 @@ $.extend(erpnext.item, {
 	make_dashboard: function (frm) {
 		if (frm.doc.__islocal) return;
 
-		// Show Stock Levels only if is_stock_item
 		if (frm.doc.is_stock_item) {
 			frappe.require("item-dashboard.bundle.js", function () {
-				const section = frm.dashboard.add_section("", __("Stock Levels"));
+				const section = frm.fields_dict["stock_levels_html"].$wrapper;
+
 				erpnext.item.item_dashboard = new erpnext.stock.ItemDashboard({
 					parent: section,
 					item_code: frm.doc.name,

--- a/erpnext/stock/doctype/item/item.js
+++ b/erpnext/stock/doctype/item/item.js
@@ -128,8 +128,15 @@ frappe.ui.form.on("Item", {
 	refresh: function (frm) {
 		frm.trigger("toggle_has_serial_batch_fields");
 
+		if (frappe.defaults.get_default("item_naming_by") != "Naming Series" || frm.doc.variant_of) {
+			frm.toggle_display("naming_series", false);
+		} else {
+			erpnext.toggle_naming_series();
+		}
+
+		frm.toggle_display(["standard_rate"], frappe.model.can_create("Item Price"));
+
 		if (frm.is_new()) {
-			frm.toggle_display(["standard_rate"], frappe.model.can_create("Item Price"));
 			frm.toggle_display("disabled", false);
 			return;
 		}
@@ -248,12 +255,6 @@ frappe.ui.form.on("Item", {
 			);
 		}
 
-		if (frappe.defaults.get_default("item_naming_by") != "Naming Series" || frm.doc.variant_of) {
-			frm.toggle_display("naming_series", false);
-		} else {
-			erpnext.toggle_naming_series();
-		}
-
 		erpnext.item.edit_prices_button(frm);
 		erpnext.item.toggle_attributes(frm);
 
@@ -293,8 +294,6 @@ frappe.ui.form.on("Item", {
 				},
 			};
 		});
-
-		frm.toggle_display(["standard_rate"], frappe.model.can_create("Item Price"));
 	},
 
 	validate: function (frm) {

--- a/erpnext/stock/doctype/item/item.json
+++ b/erpnext/stock/doctype/item/item.json
@@ -40,6 +40,28 @@
   "section_break_11",
   "brand",
   "description",
+  "accounting",
+  "section_break_wfkx",
+  "item_defaults",
+  "deferred_accounting_section",
+  "enable_deferred_expense",
+  "no_of_months_exp",
+  "column_break_9s9o",
+  "enable_deferred_revenue",
+  "no_of_months",
+  "uom_tab",
+  "unit_of_measure_conversion",
+  "uom_conversion_details_column",
+  "uom_help_html",
+  "uoms",
+  "item_tax_section_break",
+  "section_break_oilf",
+  "column_break_aytr",
+  "taxes",
+  "section_break_fxqz",
+  "purchase_tax_withholding_category",
+  "column_break_ltlb",
+  "sales_tax_withholding_category",
   "inventory_section",
   "stock_levels_section",
   "stock_levels_html",
@@ -74,33 +96,8 @@
   "variant_of",
   "variant_based_on",
   "attributes",
-  "uom_tab",
-  "units_of_measure_section",
-  "purchase_uom",
-  "sales_uom",
-  "column_break_wdwi",
-  "unit_of_measure_conversion",
-  "uom_conversion_details_column",
-  "uom_help_html",
-  "uoms",
-  "accounting",
-  "deferred_accounting_section",
-  "enable_deferred_expense",
-  "no_of_months_exp",
-  "column_break_9s9o",
-  "enable_deferred_revenue",
-  "no_of_months",
-  "section_break_wfkx",
-  "item_defaults",
-  "item_tax_section_break",
-  "section_break_oilf",
-  "column_break_aytr",
-  "taxes",
-  "section_break_fxqz",
-  "purchase_tax_withholding_category",
-  "column_break_ltlb",
-  "sales_tax_withholding_category",
   "purchasing_tab",
+  "purchase_uom",
   "min_order_qty",
   "safety_stock",
   "purchase_details_cb",
@@ -117,6 +114,7 @@
   "column_break_59",
   "customs_tariff_number",
   "sales_details",
+  "sales_uom",
   "grant_commission",
   "column_break3",
   "max_discount",
@@ -254,6 +252,7 @@
   {
    "bold": 1,
    "depends_on": "eval:(doc.__islocal&&doc.is_stock_item && !doc.has_serial_no && !doc.has_batch_no)",
+   "description": "Used to create an opening Stock Entry with the Valuation Rate when the item is saved",
    "fieldname": "opening_stock",
    "fieldtype": "Float",
    "label": "Opening Stock"
@@ -267,6 +266,7 @@
   {
    "bold": 1,
    "depends_on": "eval:doc.__islocal && doc.is_sales_item",
+   "description": "Used to create an Item Price with the selling rate when the item is saved",
    "fieldname": "standard_rate",
    "fieldtype": "Currency",
    "label": "Standard Selling Rate"
@@ -621,7 +621,7 @@
   },
   {
    "default": "0",
-   "description": "Enable if this item is provided by a customer and received via Stock Entry. Customer field becomes mandatory.",
+   "description": "Enable if this item is provided by a customer and received via Stock Entry.",
    "fieldname": "is_customer_provided_item",
    "fieldtype": "Check",
    "label": "Is Customer Provided Item"
@@ -882,7 +882,7 @@
   },
   {
    "default": "1",
-   "description": "If disabled, sales from this item will be excluded from Sales Person and Sales Partner commission calculations.",
+   "description": "If enabled, sales from this item will be included in Sales Person and Sales Partner commission calculations",
    "fieldname": "grant_commission",
    "fieldtype": "Check",
    "label": "Grant Commission",
@@ -1025,7 +1025,7 @@
    "fieldname": "stock_levels_html",
    "fieldtype": "HTML",
    "label": "Stock Levels HTML",
-   "options": "<div id='stock-levels-placeholder'></div>"
+   "options": "<div id=\"stock-levels-placeholder\"></div>"
   },
   {
    "fieldname": "section_break_wfkx",
@@ -1041,18 +1041,10 @@
    "label": "UOM"
   },
   {
-   "fieldname": "column_break_wdwi",
-   "fieldtype": "Column Break"
-  },
-  {
+   "depends_on": "eval: !doc.__islocal && doc.is_stock_item",
    "fieldname": "stock_levels_section",
    "fieldtype": "Section Break",
    "label": "Stock Levels"
-  },
-  {
-   "fieldname": "units_of_measure_section",
-   "fieldtype": "Section Break",
-   "label": "Units of Measure"
   },
   {
    "fieldname": "uom_conversion_details_column",
@@ -1062,7 +1054,7 @@
   {
    "fieldname": "uom_help_html",
    "fieldtype": "HTML",
-   "options": "<div style='margin-bottom:10px; color: var(--text-muted);'>Define alternate units for this item. Eg: 1 Box = 12 Nos, set conversion factor as 12. (Will also apply for variants) <a href='https://docs.frappe.io/erpnext/uom' target='_blank'>Learn more \u2192</a></div>"
+   "options": "<div style=\"margin-bottom:10px; color: var(--gray-500) !important;\">Define alternate units for this item. Eg: 1 Box = 12 Nos, set conversion factor as 12. (Will also apply for variants) <a href=\"https://docs.frappe.io/erpnext/uom\" target=\"_blank\">Learn more &#8594;</a></div>"
   }
  ],
  "icon": "fa fa-tag",
@@ -1070,7 +1062,7 @@
  "image_field": "image",
  "links": [],
  "make_attachments_public": 1,
- "modified": "2026-04-23 02:19:06.451024",
+ "modified": "2026-04-27 02:15:02.064950",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Item",

--- a/erpnext/stock/doctype/item/item.json
+++ b/erpnext/stock/doctype/item/item.json
@@ -18,20 +18,24 @@
   "stock_uom",
   "column_break0",
   "disabled",
-  "allow_alternative_item",
   "is_stock_item",
-  "is_purchase_item",
-  "is_sales_item",
-  "has_variants",
   "is_fixed_asset",
   "auto_create_assets",
   "is_grouped_asset",
   "asset_category",
   "asset_naming_series",
+  "section_break_zlmj",
+  "is_sales_item",
+  "allow_alternative_item",
+  "has_variants",
+  "column_break_kpmi",
+  "is_purchase_item",
+  "is_customer_provided_item",
+  "customer",
   "section_break_gjns",
-  "opening_stock",
-  "column_break_ixrh",
   "standard_rate",
+  "column_break_ixrh",
+  "opening_stock",
   "section_break_znra",
   "over_delivery_receipt_allowance",
   "column_break_wugd",
@@ -103,8 +107,6 @@
   "purchase_details_cb",
   "lead_time_days",
   "last_purchase_rate",
-  "is_customer_provided_item",
-  "customer",
   "supplier_details",
   "delivered_by_supplier",
   "section_break_ylma",
@@ -266,7 +268,7 @@
   {
    "bold": 1,
    "depends_on": "eval:doc.__islocal && doc.is_sales_item",
-   "description": "Used to create an Item Price with the selling rate when the item is saved",
+   "description": "Creates an Item Price automatically when the item is saved",
    "fieldname": "standard_rate",
    "fieldtype": "Currency",
    "label": "Standard Selling Rate"
@@ -537,7 +539,8 @@
    "fieldname": "has_variants",
    "fieldtype": "Check",
    "in_standard_filter": 1,
-   "label": "Has Variants"
+   "label": "Has Variants",
+   "show_description_on_click": 1
   },
   {
    "default": "Item Attribute",
@@ -568,6 +571,7 @@
    "fieldname": "is_purchase_item",
    "fieldtype": "Check",
    "label": "Allow Purchase",
+   "read_only_depends_on": "eval: doc.is_customer_provided_item",
    "show_description_on_click": 1
   },
   {
@@ -624,7 +628,9 @@
    "description": "Enable if this item is provided by a customer and received via Stock Entry.",
    "fieldname": "is_customer_provided_item",
    "fieldtype": "Check",
-   "label": "Is Customer Provided Item"
+   "label": "Is Customer Provided Item",
+   "read_only_depends_on": "eval: doc.is_purchase_item",
+   "show_description_on_click": 1
   },
   {
    "depends_on": "eval:doc.is_customer_provided_item",
@@ -863,7 +869,6 @@
   {
    "default": "0",
    "depends_on": "is_fixed_asset",
-   "description": "Automatically creates Asset records when this item is received via Purchase Receipt.",
    "fieldname": "auto_create_assets",
    "fieldtype": "Check",
    "label": "Auto create assets on purchase"
@@ -1056,6 +1061,15 @@
    "fieldname": "uom_help_html",
    "fieldtype": "HTML",
    "options": "<div style=\"margin-bottom:10px; color: var(--gray-500) !important;\">Define alternate units for this item. Eg: 1 Box = 12 Nos, set conversion factor as 12. (Will also apply for variants) <a href=\"https://docs.frappe.io/erpnext/uom\" target=\"_blank\">Learn more &#8594;</a></div>"
+  },
+  {
+   "fieldname": "section_break_zlmj",
+   "fieldtype": "Section Break",
+   "label": "Item Attributes"
+  },
+  {
+   "fieldname": "column_break_kpmi",
+   "fieldtype": "Column Break"
   }
  ],
  "icon": "fa fa-tag",
@@ -1063,7 +1077,7 @@
  "image_field": "image",
  "links": [],
  "make_attachments_public": 1,
- "modified": "2026-04-27 16:03:38.940472",
+ "modified": "2026-04-28 17:31:47.613279",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Item",

--- a/erpnext/stock/doctype/item/item.json
+++ b/erpnext/stock/doctype/item/item.json
@@ -40,11 +40,9 @@
   "section_break_11",
   "brand",
   "description",
-  "unit_of_measure_conversion",
-  "uoms",
-  "stock_levels_tab",
-  "stock_levels_html",
   "inventory_section",
+  "stock_levels_section",
+  "stock_levels_html",
   "inventory_valuation_section",
   "valuation_method",
   "column_break_cqdk",
@@ -76,6 +74,15 @@
   "variant_of",
   "variant_based_on",
   "attributes",
+  "uom_tab",
+  "units_of_measure_section",
+  "purchase_uom",
+  "sales_uom",
+  "column_break_wdwi",
+  "unit_of_measure_conversion",
+  "uom_conversion_details_column",
+  "uom_help_html",
+  "uoms",
   "accounting",
   "deferred_accounting_section",
   "enable_deferred_expense",
@@ -85,8 +92,15 @@
   "no_of_months",
   "section_break_wfkx",
   "item_defaults",
+  "item_tax_section_break",
+  "section_break_oilf",
+  "column_break_aytr",
+  "taxes",
+  "section_break_fxqz",
+  "purchase_tax_withholding_category",
+  "column_break_ltlb",
+  "sales_tax_withholding_category",
   "purchasing_tab",
-  "purchase_uom",
   "min_order_qty",
   "safety_stock",
   "purchase_details_cb",
@@ -103,25 +117,11 @@
   "column_break_59",
   "customs_tariff_number",
   "sales_details",
-  "sales_uom",
   "grant_commission",
   "column_break3",
   "max_discount",
   "customer_details",
   "customer_items",
-  "item_tax_section_break",
-  "section_break_oilf",
-  "column_break_aytr",
-  "taxes",
-  "section_break_fxqz",
-  "purchase_tax_withholding_category",
-  "column_break_ltlb",
-  "sales_tax_withholding_category",
-  "quality_tab",
-  "inspection_required_before_purchase",
-  "inspection_required_before_delivery",
-  "column_break_pxjh",
-  "quality_inspection_template",
   "manufacturing",
   "include_item_in_manufacturing",
   "is_sub_contracted_item",
@@ -134,6 +134,11 @@
   "default_item_manufacturer",
   "column_break_vipt",
   "customer_code",
+  "quality_tab",
+  "inspection_required_before_purchase",
+  "inspection_required_before_delivery",
+  "column_break_pxjh",
+  "quality_inspection_template",
   "dashboard_tab"
  ],
  "fields": [
@@ -210,21 +215,26 @@
   },
   {
    "default": "0",
+   "description": "Disabled items cannot be selected in any transaction.",
    "fieldname": "disabled",
    "fieldtype": "Check",
    "label": "Disabled",
-   "search_index": 1
+   "search_index": 1,
+   "show_description_on_click": 1
   },
   {
    "default": "0",
+   "description": "Allow substituting this item with an alternative from the Item Alternative list when stock is unavailable.",
    "fieldname": "allow_alternative_item",
    "fieldtype": "Check",
-   "label": "Allow Alternative Item"
+   "label": "Allow Alternative Item",
+   "show_description_on_click": 1
   },
   {
    "allow_in_quick_entry": 1,
    "bold": 1,
    "default": "1",
+   "description": "ERPNext will make a stock ledger entry for each transaction of this item. Keep unchecked for non-stock or service items.",
    "fieldname": "is_stock_item",
    "fieldtype": "Check",
    "in_list_view": 1,
@@ -236,6 +246,7 @@
   {
    "default": "1",
    "depends_on": "eval:!doc.is_fixed_asset",
+   "description": "Enable for raw material items used in BOM. Uncheck for additional services like 'washing' used in manufacturing.",
    "fieldname": "include_item_in_manufacturing",
    "fieldtype": "Check",
    "label": "Include Item In Manufacturing"
@@ -263,6 +274,7 @@
   {
    "allow_in_quick_entry": 1,
    "default": "0",
+   "description": "Enable if this item is a company asset like machinery or furniture.",
    "fieldname": "is_fixed_asset",
    "fieldtype": "Check",
    "label": "Is Fixed Asset",
@@ -416,16 +428,12 @@
    "options": "Item Reorder"
   },
   {
-   "collapsible": 1,
    "fieldname": "unit_of_measure_conversion",
-   "fieldtype": "Section Break",
-   "label": "Units of Measure"
+   "fieldtype": "Section Break"
   },
   {
-   "description": "Will also apply for variants",
    "fieldname": "uoms",
    "fieldtype": "Table",
-   "label": "UOMs",
    "oldfieldname": "uom_conversion_details",
    "oldfieldtype": "Table",
    "options": "UOM Conversion Detail"
@@ -441,15 +449,18 @@
   {
    "default": "0",
    "depends_on": "eval:doc.is_stock_item",
+   "description": "Track this item in batches. Cannot be changed after a stock transaction exists.",
    "fieldname": "has_batch_no",
    "fieldtype": "Check",
    "label": "Has Batch No",
    "oldfieldname": "has_batch_no",
-   "oldfieldtype": "Select"
+   "oldfieldtype": "Select",
+   "show_description_on_click": 1
   },
   {
    "default": "0",
    "depends_on": "has_batch_no",
+   "description": "Batch number will be auto-created in format AAAA.00001 if not specified in transactions. Leave blank to always enter batch numbers manually.",
    "fieldname": "create_new_batch",
    "fieldtype": "Check",
    "label": "Automatically Create New Batch"
@@ -466,6 +477,7 @@
   {
    "default": "0",
    "depends_on": "has_batch_no",
+   "description": "Batch number will be created based on expiry date. Expiry dates can be set in the Batch master.",
    "fieldname": "has_expiry_date",
    "fieldtype": "Check",
    "label": "Has Expiry Date"
@@ -494,11 +506,13 @@
   {
    "default": "0",
    "depends_on": "eval:doc.is_stock_item",
+   "description": "Track each unit with a unique serial number for warranty and return tracking. Cannot be changed after a stock transaction exists.",
    "fieldname": "has_serial_no",
    "fieldtype": "Check",
    "label": "Has Serial No",
    "oldfieldname": "has_serial_no",
-   "oldfieldtype": "Select"
+   "oldfieldtype": "Select",
+   "show_description_on_click": 1
   },
   {
    "depends_on": "has_serial_no",
@@ -550,11 +564,14 @@
   },
   {
    "default": "1",
+   "description": "Allow this item to be used in purchase transactions.",
    "fieldname": "is_purchase_item",
    "fieldtype": "Check",
-   "label": "Allow Purchase"
+   "label": "Allow Purchase",
+   "show_description_on_click": 1
   },
   {
+   "depends_on": "eval: doc.is_purchase_item",
    "fieldname": "purchase_uom",
    "fieldtype": "Link",
    "label": "Default Purchase Unit of Measure",
@@ -563,7 +580,7 @@
   {
    "default": "0.00",
    "depends_on": "is_stock_item",
-   "description": "Minimum quantity should be as per Stock UOM",
+   "description": "Minimum quantity should be as per Stock UOM\n\n",
    "fieldname": "min_order_qty",
    "fieldtype": "Float",
    "label": "Minimum Order Qty",
@@ -572,6 +589,7 @@
    "oldfieldtype": "Currency"
   },
   {
+   "description": "Minimum stock level to maintain as a buffer. Used to calculate recommended reorder level: Reorder Level = Safety Stock + (Average Daily Consumption \u00d7 Lead Time).",
    "fieldname": "safety_stock",
    "fieldtype": "Float",
    "label": "Safety Stock",
@@ -591,6 +609,7 @@
    "oldfieldtype": "Int"
   },
   {
+   "description": "The rate at which this item was last purchased via a Purchase Invoice. Auto-updated by the system.",
    "fieldname": "last_purchase_rate",
    "fieldtype": "Float",
    "label": "Last Purchase Rate",
@@ -602,6 +621,7 @@
   },
   {
    "default": "0",
+   "description": "Enable if this item is provided by a customer and received via Stock Entry. Customer field becomes mandatory.",
    "fieldname": "is_customer_provided_item",
    "fieldtype": "Check",
    "label": "Is Customer Provided Item"
@@ -622,6 +642,7 @@
   },
   {
    "default": "0",
+   "description": "Enable for drop shipping - supplier delivers directly to the customer without passing through your warehouse.",
    "fieldname": "delivered_by_supplier",
    "fieldtype": "Check",
    "label": "Delivered by Supplier (Drop Ship)",
@@ -657,6 +678,7 @@
   },
   {
    "collapsible": 1,
+   "depends_on": "eval: doc.is_sales_item",
    "fieldname": "sales_details",
    "fieldtype": "Tab Break",
    "label": "Sales",
@@ -664,6 +686,7 @@
    "options": "fa fa-tag"
   },
   {
+   "depends_on": "eval: doc.is_sales_item",
    "fieldname": "sales_uom",
    "fieldtype": "Link",
    "label": "Default Sales Unit of Measure",
@@ -671,9 +694,11 @@
   },
   {
    "default": "1",
+   "description": "Allow this item to be used in sales transactions.",
    "fieldname": "is_sales_item",
    "fieldtype": "Check",
-   "label": "Allow Sales"
+   "label": "Allow Sales",
+   "show_description_on_click": 1
   },
   {
    "fieldname": "column_break3",
@@ -682,6 +707,7 @@
    "width": "50%"
   },
   {
+   "description": "Maximum discount % allowed when selling this item. Eg: if set to 20%, a discount greater than 20% cannot be applied in sales transactions.",
    "fieldname": "max_discount",
    "fieldtype": "Float",
    "label": "Max Discount (%)",
@@ -690,6 +716,7 @@
   },
   {
    "default": "0",
+   "description": "Expense for this item will be recognized over a period of months. Eg: prepaid insurance or annual software license",
    "fieldname": "enable_deferred_revenue",
    "fieldtype": "Check",
    "label": "Enable Deferred Revenue"
@@ -702,6 +729,7 @@
   },
   {
    "default": "0",
+   "description": "Income from this item will be recognized over a period of months instead of all at once. Eg: annual subscription paid upfront.",
    "fieldname": "enable_deferred_expense",
    "fieldtype": "Check",
    "label": "Enable Deferred Expense"
@@ -743,17 +771,21 @@
   },
   {
    "default": "0",
+   "description": "A quality inspection must be completed before generating a Purchase Receipt for this item.",
    "fieldname": "inspection_required_before_purchase",
    "fieldtype": "Check",
    "label": "Inspection Required before Purchase",
    "oldfieldname": "inspection_required",
-   "oldfieldtype": "Select"
+   "oldfieldtype": "Select",
+   "show_description_on_click": 1
   },
   {
    "default": "0",
+   "description": "A quality inspection must be completed before generating a Delivery Note for this item.",
    "fieldname": "inspection_required_before_delivery",
    "fieldtype": "Check",
-   "label": "Inspection Required before Delivery"
+   "label": "Inspection Required before Delivery",
+   "show_description_on_click": 1
   },
   {
    "fieldname": "quality_inspection_template",
@@ -784,6 +816,7 @@
   },
   {
    "default": "0",
+   "description": "Enable if a vendor manufactures this item for you. You can choose to provide them raw materials using the default BOM.",
    "fieldname": "is_sub_contracted_item",
    "fieldtype": "Check",
    "label": "Is Subcontracted Item",
@@ -812,6 +845,7 @@
   },
   {
    "depends_on": "eval:!doc.__islocal && !doc.is_fixed_asset",
+   "description": "Percentage by which over-delivery or over-receipt is allowed against a Sales/Purchase Order for this item. If not set, value from Stock Settings will be used.",
    "fieldname": "over_delivery_receipt_allowance",
    "fieldtype": "Float",
    "label": "Over Delivery/Receipt Allowance (%)",
@@ -820,6 +854,7 @@
   },
   {
    "depends_on": "eval:!doc.__islocal && !doc.is_fixed_asset",
+   "description": "Percentage by which over-billing is allowed against a Sales/Purchase Order for this item. If not set, value from Accounts Settings will be used.",
    "fieldname": "over_billing_allowance",
    "fieldtype": "Float",
    "label": "Over Billing Allowance (%)"
@@ -827,6 +862,7 @@
   {
    "default": "0",
    "depends_on": "is_fixed_asset",
+   "description": "Automatically creates Asset records when this item is received via Purchase Receipt.",
    "fieldname": "auto_create_assets",
    "fieldtype": "Check",
    "label": "Auto create assets on purchase"
@@ -846,19 +882,24 @@
   },
   {
    "default": "1",
+   "description": "If disabled, sales from this item will be excluded from Sales Person and Sales Partner commission calculations.",
    "fieldname": "grant_commission",
    "fieldtype": "Check",
-   "label": "Grant Commission"
+   "label": "Grant Commission",
+   "show_description_on_click": 1
   },
   {
    "default": "0",
    "depends_on": "eval: doc.is_fixed_asset && doc.auto_create_assets",
+   "description": "Creates a single grouped asset instead of individual assets when purchased in bulk.",
    "fieldname": "is_grouped_asset",
    "fieldtype": "Check",
-   "label": "Create Grouped Asset"
+   "label": "Create Grouped Asset",
+   "show_description_on_click": 1
   },
   {
    "default": "0",
+   "description": "Allow stock to go below zero for this item, even if negative stock is disabled in Stock Settings.",
    "fieldname": "allow_negative_stock",
    "fieldtype": "Check",
    "label": "Allow Negative Stock"
@@ -869,6 +910,7 @@
    "label": "Inventory Settings"
   },
   {
+   "depends_on": "eval: doc.is_purchase_item",
    "fieldname": "purchasing_tab",
    "fieldtype": "Tab Break",
    "label": "Purchasing"
@@ -980,11 +1022,6 @@
    "fieldtype": "Column Break"
   },
   {
-   "fieldname": "stock_levels_tab",
-   "fieldtype": "Tab Break",
-   "label": "Stock Levels"
-  },
-  {
    "fieldname": "stock_levels_html",
    "fieldtype": "HTML",
    "label": "Stock Levels HTML",
@@ -997,6 +1034,35 @@
   {
    "fieldname": "section_break_ylma",
    "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "uom_tab",
+   "fieldtype": "Tab Break",
+   "label": "UOM"
+  },
+  {
+   "fieldname": "column_break_wdwi",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "stock_levels_section",
+   "fieldtype": "Section Break",
+   "label": "Stock Levels"
+  },
+  {
+   "fieldname": "units_of_measure_section",
+   "fieldtype": "Section Break",
+   "label": "Units of Measure"
+  },
+  {
+   "fieldname": "uom_conversion_details_column",
+   "fieldtype": "Column Break",
+   "label": "UOM Conversion Details"
+  },
+  {
+   "fieldname": "uom_help_html",
+   "fieldtype": "HTML",
+   "options": "<div style='margin-bottom:10px; color: var(--text-muted);'>Define alternate units for this item. Eg: 1 Box = 12 Nos, set conversion factor as 12. (Will also apply for variants) <a href='https://docs.frappe.io/erpnext/uom' target='_blank'>Learn more \u2192</a></div>"
   }
  ],
  "icon": "fa fa-tag",
@@ -1004,7 +1070,7 @@
  "image_field": "image",
  "links": [],
  "make_attachments_public": 1,
- "modified": "2026-04-22 02:10:00.931777",
+ "modified": "2026-04-23 02:19:06.451024",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Item",

--- a/erpnext/stock/doctype/item/item.json
+++ b/erpnext/stock/doctype/item/item.json
@@ -20,6 +20,8 @@
   "disabled",
   "allow_alternative_item",
   "is_stock_item",
+  "is_purchase_item",
+  "is_sales_item",
   "has_variants",
   "is_fixed_asset",
   "auto_create_assets",
@@ -36,11 +38,12 @@
   "over_billing_allowance",
   "image",
   "section_break_11",
-  "description",
   "brand",
+  "description",
   "unit_of_measure_conversion",
   "uoms",
-  "dashboard_tab",
+  "stock_levels_tab",
+  "stock_levels_html",
   "inventory_section",
   "inventory_valuation_section",
   "valuation_method",
@@ -69,8 +72,6 @@
   "column_break_37",
   "has_serial_no",
   "serial_no_series",
-  "defaults_tab",
-  "item_defaults",
   "variants_section",
   "variant_of",
   "variant_based_on",
@@ -82,11 +83,12 @@
   "column_break_9s9o",
   "enable_deferred_revenue",
   "no_of_months",
+  "section_break_wfkx",
+  "item_defaults",
   "purchasing_tab",
   "purchase_uom",
   "min_order_qty",
   "safety_stock",
-  "is_purchase_item",
   "purchase_details_cb",
   "lead_time_days",
   "last_purchase_rate",
@@ -94,7 +96,7 @@
   "customer",
   "supplier_details",
   "delivered_by_supplier",
-  "column_break2",
+  "section_break_ylma",
   "supplier_items",
   "foreign_trade_details",
   "country_of_origin",
@@ -103,7 +105,6 @@
   "sales_details",
   "sales_uom",
   "grant_commission",
-  "is_sales_item",
   "column_break3",
   "max_discount",
   "customer_details",
@@ -129,10 +130,11 @@
   "production_capacity",
   "total_projected_qty",
   "section_break_xili",
-  "customer_code",
-  "column_break_vipt",
   "default_manufacturer_part_no",
-  "default_item_manufacturer"
+  "default_item_manufacturer",
+  "column_break_vipt",
+  "customer_code",
+  "dashboard_tab"
  ],
  "fields": [
   {
@@ -223,13 +225,13 @@
    "allow_in_quick_entry": 1,
    "bold": 1,
    "default": "1",
-   "depends_on": "eval:!doc.is_fixed_asset",
    "fieldname": "is_stock_item",
    "fieldtype": "Check",
    "in_list_view": 1,
    "label": "Maintain Stock",
    "oldfieldname": "is_stock_item",
-   "oldfieldtype": "Select"
+   "oldfieldtype": "Select",
+   "read_only_depends_on": "eval:doc.is_fixed_asset"
   },
   {
    "default": "1",
@@ -253,7 +255,7 @@
   },
   {
    "bold": 1,
-   "depends_on": "eval:doc.__islocal",
+   "depends_on": "eval:doc.__islocal && doc.is_sales_item",
    "fieldname": "standard_rate",
    "fieldtype": "Currency",
    "label": "Standard Selling Rate"
@@ -263,7 +265,8 @@
    "default": "0",
    "fieldname": "is_fixed_asset",
    "fieldtype": "Check",
-   "label": "Is Fixed Asset"
+   "label": "Is Fixed Asset",
+   "read_only_depends_on": "eval:doc.is_stock_item"
   },
   {
    "allow_in_quick_entry": 1,
@@ -611,10 +614,10 @@
    "options": "Customer"
   },
   {
-   "collapsible": 1,
    "depends_on": "eval:!doc.is_fixed_asset",
    "fieldname": "supplier_details",
    "fieldtype": "Section Break",
+   "hide_border": 1,
    "label": "Supplier Details"
   },
   {
@@ -625,15 +628,9 @@
    "print_hide": 1
   },
   {
-   "fieldname": "column_break2",
-   "fieldtype": "Column Break",
-   "oldfieldtype": "Column Break",
-   "width": "50%"
-  },
-  {
    "fieldname": "supplier_items",
    "fieldtype": "Table",
-   "label": "Supplier Items",
+   "label": "Item Supplier",
    "options": "Item Supplier"
   },
   {
@@ -716,11 +713,9 @@
    "label": "No of Months (Expense)"
   },
   {
-   "collapsible": 1,
    "depends_on": "eval:!doc.is_fixed_asset",
    "fieldname": "customer_details",
-   "fieldtype": "Section Break",
-   "label": "Customer Details"
+   "fieldtype": "Section Break"
   },
   {
    "fieldname": "customer_items",
@@ -834,7 +829,7 @@
    "depends_on": "is_fixed_asset",
    "fieldname": "auto_create_assets",
    "fieldtype": "Check",
-   "label": "Auto Create Assets on Purchase"
+   "label": "Auto create assets on purchase"
   },
   {
    "fieldname": "default_item_manufacturer",
@@ -857,7 +852,7 @@
   },
   {
    "default": "0",
-   "depends_on": "auto_create_assets",
+   "depends_on": "eval: doc.is_fixed_asset && doc.auto_create_assets",
    "fieldname": "is_grouped_asset",
    "fieldtype": "Check",
    "label": "Create Grouped Asset"
@@ -893,7 +888,7 @@
   {
    "fieldname": "dashboard_tab",
    "fieldtype": "Tab Break",
-   "label": "Dashboard",
+   "label": "Connections",
    "show_dashboard": 1
   },
   {
@@ -915,11 +910,6 @@
    "fieldname": "production_capacity",
    "fieldtype": "Int",
    "label": "Production Capacity"
-  },
-  {
-   "fieldname": "defaults_tab",
-   "fieldtype": "Tab Break",
-   "label": "Defaults"
   },
   {
    "fieldname": "section_break_znra",
@@ -988,6 +978,25 @@
   {
    "fieldname": "column_break_vipt",
    "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "stock_levels_tab",
+   "fieldtype": "Tab Break",
+   "label": "Stock Levels"
+  },
+  {
+   "fieldname": "stock_levels_html",
+   "fieldtype": "HTML",
+   "label": "Stock Levels HTML",
+   "options": "<div id='stock-levels-placeholder'></div>"
+  },
+  {
+   "fieldname": "section_break_wfkx",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "section_break_ylma",
+   "fieldtype": "Section Break"
   }
  ],
  "icon": "fa fa-tag",
@@ -995,7 +1004,7 @@
  "image_field": "image",
  "links": [],
  "make_attachments_public": 1,
- "modified": "2026-04-14 13:37:00.183583",
+ "modified": "2026-04-22 02:10:00.931777",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Item",

--- a/erpnext/stock/doctype/item/item.json
+++ b/erpnext/stock/doctype/item/item.json
@@ -743,7 +743,8 @@
   {
    "depends_on": "eval:!doc.is_fixed_asset",
    "fieldname": "customer_details",
-   "fieldtype": "Section Break"
+   "fieldtype": "Section Break",
+   "label": "Customer Details"
   },
   {
    "fieldname": "customer_items",
@@ -1062,7 +1063,7 @@
  "image_field": "image",
  "links": [],
  "make_attachments_public": 1,
- "modified": "2026-04-27 02:15:02.064950",
+ "modified": "2026-04-27 16:03:38.940472",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Item",

--- a/erpnext/stock/doctype/item/item.py
+++ b/erpnext/stock/doctype/item/item.py
@@ -309,7 +309,7 @@ class Item(Document):
 		):
 			return
 
-		if not self.valuation_rate and not self.standard_rate and not self.is_customer_provided_item:
+		if self.valuation_rate is None and not self.is_customer_provided_item:
 			frappe.throw(_("Valuation Rate is mandatory if Opening Stock entered"))
 
 		from erpnext.stock.doctype.stock_entry.stock_entry_utils import make_stock_entry
@@ -334,13 +334,37 @@ class Item(Document):
 					item_code=self.name,
 					target=default_warehouse,
 					qty=self.opening_stock,
-					rate=self.valuation_rate or self.standard_rate,
+					rate=self.valuation_rate,
 					company=default.company,
 					posting_date=getdate(),
 					posting_time=nowtime(),
+					do_not_save=True,
 				)
 
+				if self.valuation_rate == 0:
+					for item in stock_entry.items:
+						item.allow_zero_valuation_rate = 1
+
+				stock_entry.insert()
+				stock_entry.submit()
+				stock_entry.load_from_db()
 				stock_entry.add_comment("Comment", _("Opening Stock"))
+
+				stock_entry_link = frappe.utils.get_link_to_form("Stock Entry", stock_entry.name)
+				if self.valuation_rate == 0:
+					frappe.msgprint(
+						_("Opening Stock entry created with zero valuation rate: {0}").format(
+							stock_entry_link
+						),
+						indicator="orange",
+						alert=True,
+					)
+				else:
+					frappe.msgprint(
+						_("Opening Stock entry created: {0}").format(stock_entry_link),
+						indicator="green",
+						alert=True,
+					)
 
 	def validate_fixed_asset(self):
 		if self.is_fixed_asset:

--- a/erpnext/stock/doctype/item/item.py
+++ b/erpnext/stock/doctype/item/item.py
@@ -179,6 +179,14 @@ class Item(Document):
 			for default in self.item_defaults or [frappe._dict()]:
 				self.add_price(default.default_price_list)
 
+			frappe.msgprint(
+				_("Item Price created at rate {0}").format(
+					frappe.format(self.standard_rate, {"fieldtype": "Currency"})
+				),
+				indicator="green",
+				alert=True,
+			)
+
 		if self.opening_stock:
 			if self.opening_stock > 10000 and self.has_serial_no:
 				frappe.enqueue(

--- a/erpnext/stock/doctype/item_customer_detail/item_customer_detail.json
+++ b/erpnext/stock/doctype/item_customer_detail/item_customer_detail.json
@@ -36,6 +36,7 @@
    "options": "Customer Group"
   },
   {
+   "description": "Enter the Item Code that this customer uses at their end. This will be shown in Sales Orders for the customer's reference.",
    "fieldname": "ref_code",
    "fieldtype": "Data",
    "in_filter": 1,
@@ -52,12 +53,13 @@
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-03-27 13:09:54.332166",
+ "modified": "2026-04-23 02:09:39.602010",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Item Customer Detail",
  "owner": "Administrator",
  "permissions": [],
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": []

--- a/erpnext/stock/doctype/item_default/item_default.json
+++ b/erpnext/stock/doctype/item_default/item_default.json
@@ -55,11 +55,13 @@
    "fieldtype": "Column Break"
   },
   {
+   "description": "Default price list for buying or selling this item",
    "fieldname": "default_price_list",
    "fieldtype": "Link",
    "in_list_view": 1,
    "label": "Default Price List",
-   "options": "Price List"
+   "options": "Price List",
+   "show_description_on_click": 1
   },
   {
    "fieldname": "purchase_defaults",
@@ -67,12 +69,15 @@
    "label": "Purchase Defaults"
   },
   {
+   "description": "Cost center used for tracking purchase expenses for this item",
    "fieldname": "buying_cost_center",
    "fieldtype": "Link",
    "label": "Default Buying Cost Center",
-   "options": "Cost Center"
+   "options": "Cost Center",
+   "show_description_on_click": 1
   },
   {
+   "description": "This supplier will be auto-selected in new purchase transactions",
    "fieldname": "default_supplier",
    "fieldtype": "Link",
    "label": "Default Supplier",
@@ -83,10 +88,12 @@
    "fieldtype": "Column Break"
   },
   {
+   "description": "Account where the cost of this item will be debited on purchase",
    "fieldname": "expense_account",
    "fieldtype": "Link",
    "label": "Default Expense Account",
-   "options": "Account"
+   "options": "Account",
+   "show_description_on_click": 1
   },
   {
    "fieldname": "selling_defaults",
@@ -94,20 +101,24 @@
    "label": "Sales Defaults"
   },
   {
+   "description": "Cost center used for tracking sales revenue for this item",
    "fieldname": "selling_cost_center",
    "fieldtype": "Link",
    "label": "Default Selling Cost Center",
-   "options": "Cost Center"
+   "options": "Cost Center",
+   "show_description_on_click": 1
   },
   {
    "fieldname": "column_break_12",
    "fieldtype": "Column Break"
   },
   {
+   "description": "Account where revenue from selling this item will be credited",
    "fieldname": "income_account",
    "fieldtype": "Link",
    "label": "Default Income Account",
-   "options": "Account"
+   "options": "Account",
+   "show_description_on_click": 1
   },
   {
    "fieldname": "default_discount_account",
@@ -116,6 +127,7 @@
    "options": "Account"
   },
   {
+   "description": "Provisional liability account used for service items before invoice is received",
    "fieldname": "default_provisional_account",
    "fieldtype": "Link",
    "label": "Default Provisional Account (Service)",
@@ -128,17 +140,21 @@
   },
   {
    "depends_on": "eval: parent.enable_deferred_expense",
+   "description": "When you pay for something upfront (like annual insurance), the cost is held here and recognized gradually over time",
    "fieldname": "deferred_expense_account",
    "fieldtype": "Link",
    "label": "Deferred Expense Account",
-   "options": "Account"
+   "options": "Account",
+   "show_description_on_click": 1
   },
   {
    "depends_on": "eval: parent.enable_deferred_revenue",
+   "description": "Revenue received in advance (e.g. annual subscription) is held here and recognized gradually over time",
    "fieldname": "deferred_revenue_account",
    "fieldtype": "Link",
    "label": "Deferred Revenue Account",
-   "options": "Account"
+   "options": "Account",
+   "show_description_on_click": 1
   },
   {
    "fieldname": "column_break_kwad",
@@ -154,28 +170,35 @@
    "label": "Cost of Goods Sold"
   },
   {
+   "description": "Account where cost of goods sold will be posted when this item is sold",
    "fieldname": "default_cogs_account",
    "fieldtype": "Link",
    "label": "Default COGS Account",
-   "options": "Account"
+   "options": "Account",
+   "show_description_on_click": 1
   },
   {
+   "description": "Account to record additional purchase expenses like freight or customs for this item",
    "fieldname": "purchase_expense_account",
    "fieldtype": "Link",
    "label": "Purchase Expense Account",
-   "options": "Account"
+   "options": "Account",
+   "show_description_on_click": 1
   },
   {
+   "description": "Used to balance the books when recording extra purchase costs like freight or customs",
    "fieldname": "purchase_expense_contra_account",
    "fieldtype": "Link",
    "label": "Purchase Expense Contra Account",
    "options": "Account"
   },
   {
+   "description": "Stock account where inventory value for this item will be tracked",
    "fieldname": "default_inventory_account",
    "fieldtype": "Link",
    "label": "Default Inventory Account",
-   "options": "Account"
+   "options": "Account",
+   "show_description_on_click": 1
   },
   {
    "fetch_from": "default_inventory_account.account_currency",
@@ -188,7 +211,7 @@
  ],
  "istable": 1,
  "links": [],
- "modified": "2025-10-21 10:50:46.144721",
+ "modified": "2026-04-27 01:49:01.396845",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Item Default",

--- a/erpnext/stock/doctype/item_supplier/item_supplier.json
+++ b/erpnext/stock/doctype/item_supplier/item_supplier.json
@@ -6,6 +6,7 @@
  "engine": "InnoDB",
  "field_order": [
   "supplier",
+  "column_break_vcuv",
   "supplier_part_no"
  ],
  "fields": [
@@ -25,17 +26,22 @@
    "label": "Supplier Part Number",
    "print_width": "200px",
    "width": "200px"
+  },
+  {
+   "fieldname": "column_break_vcuv",
+   "fieldtype": "Column Break"
   }
  ],
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-03-27 13:09:55.339052",
+ "modified": "2026-04-22 02:08:38.777228",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Item Supplier",
  "owner": "Administrator",
  "permissions": [],
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],

--- a/erpnext/stock/doctype/uom_conversion_detail/uom_conversion_detail.json
+++ b/erpnext/stock/doctype/uom_conversion_detail/uom_conversion_detail.json
@@ -7,6 +7,7 @@
  "engine": "InnoDB",
  "field_order": [
   "uom",
+  "column_break_nmeg",
   "conversion_factor"
  ],
  "fields": [
@@ -27,12 +28,16 @@
    "non_negative": 1,
    "oldfieldname": "conversion_factor",
    "oldfieldtype": "Float"
+  },
+  {
+   "fieldname": "column_break_nmeg",
+   "fieldtype": "Column Break"
   }
  ],
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-11-19 21:27:13.968771",
+ "modified": "2026-04-27 02:22:52.652036",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "UOM Conversion Detail",


### PR DESCRIPTION
Issues with current form:

<img width="1243" height="836" alt="Screenshot 2026-04-27 at 12 00 13 PM" src="https://github.com/user-attachments/assets/49d821be-0668-4e9c-83a4-f27fc6f4ce2d" />
<hr>
<img width="1245" height="769" alt="Screenshot 2026-04-27 at 12 18 47 PM" src="https://github.com/user-attachments/assets/d0bb1a5e-99da-4d02-ad43-15b6e90f039d" />
<hr>
<img width="950" height="246" alt="Screenshot 2026-04-27 at 12 30 41 PM" src="https://github.com/user-attachments/assets/144a397b-9964-4a02-bdd5-386c859776de" />
<hr>
<img width="1249" height="524" alt="Screenshot 2026-04-27 at 12 48 06 PM" src="https://github.com/user-attachments/assets/cb011f4b-9228-4f33-b747-e812ea7fbb11" />
<hr>
<img width="1242" height="728" alt="Screenshot 2026-04-27 at 12 31 48 PM" src="https://github.com/user-attachments/assets/b76bf5ea-19ff-481e-86d3-1685c1d7049d" />
<hr>
<img width="1248" height="616" alt="Screenshot 2026-04-27 at 12 38 09 PM" src="https://github.com/user-attachments/assets/a9b794bd-841e-46dd-a48d-b9bcd2f60439" />
<hr>

- All field need tooltip for better understanding of the purpose.

<img width="1163" height="804" alt="Screenshot 2026-04-27 at 12 45 46 PM" src="https://github.com/user-attachments/assets/1bbf81f6-a33a-438c-8e5c-3bbba1824d23" />
<hr>

- Checkboxes need description/tooltip

<img width="1246" height="480" alt="Screenshot 2026-04-27 at 12 58 14 PM" src="https://github.com/user-attachments/assets/893b0f38-85e8-4e6a-adc0-4129b8b793f7" />
<hr>

### After the refactor:

https://github.com/user-attachments/assets/a5e49ea5-531b-4d95-a91b-64b1e1a4a5b4

### More UX issue:

- Saving an item with opening stock silently creates a stock entry without notifying the user.

https://github.com/user-attachments/assets/a5df42b0-6868-43d5-a7b2-86a836501446

- Saving an item with a Standard Selling Rate creates an Item Price record without any user notification.

https://github.com/user-attachments/assets/30bd0c1a-9389-44f8-a889-432ce6c351e2
