### PR TITLE
feat: pre-submit validation error for packed quantity mismatch

### DIFF
--- a/erpnext/accounts/test/test_pre_submit_validation.py
+++ b/erpnext/accounts/test/test_pre_submit_validation.py
@@ -1,9 +1,14 @@
 # Copyright (c) 2024, Frappe Technologies Pvt. Ltd. and Contributors
 # License: GNU General Public License v3. See license.txt
 
+from unittest.mock import patch
+
 import frappe
 
-from erpnext.accounts.utils import _check_credit_limit_warn
+from erpnext.accounts.utils import (
+	_check_credit_limit_warn,
+	_check_packed_qty_warn,
+)
 from erpnext.selling.doctype.customer.test_customer import (
 	get_customer_dict,
 	set_credit_limit,
@@ -222,4 +227,48 @@ class TestCreditLimitWarnDeliveryNote(_CreditLimitBase):
 		"""
 		dn = self._make_dn(OVER, bypass=True, against_sales_invoice="SINV-TEST-0001")
 		_check_credit_limit_warn(dn)
+		self.assertFalse(_get_orange_warnings())
+
+
+# ---------------------------------------------------------------------------
+# Packed Qty
+# ---------------------------------------------------------------------------
+
+
+class TestPackedQtyWarn(ERPNextTestSuite):
+	def setUp(self):
+		frappe.message_log.clear()
+
+	def _make_dn(self):
+		dn = frappe.new_doc("Delivery Note")
+		dn.company = COMPANY
+		dn.customer = "_Test Customer"
+		dn.append(
+			"items",
+			{"item_code": "_Test Item", "qty": 2, "rate": 100, "amount": 200, "base_amount": 200},
+		)
+		return dn
+
+	def test_no_warning_for_new_doc(self):
+		"""New doc has no packing slip in DB, so validate_packed_qty is skipped."""
+		dn = self._make_dn()
+		_check_packed_qty_warn(dn)
+		self.assertFalse(_get_orange_warnings())
+
+	def test_warns_when_packed_qty_mismatches(self):
+		"""When validate_packed_qty raises, an orange warning is produced."""
+		dn = self._make_dn()
+		with patch.object(
+			dn,
+			"validate_packed_qty",
+			side_effect=frappe.ValidationError("Packed Qty must be equal to qty"),
+		):
+			_check_packed_qty_warn(dn)
+		self.assertTrue(_get_orange_warnings())
+
+	def test_no_warning_when_packed_qty_matches(self):
+		"""When validate_packed_qty passes silently, no warning is produced."""
+		dn = self._make_dn()
+		with patch.object(dn, "validate_packed_qty", return_value=None):
+			_check_packed_qty_warn(dn)
 		self.assertFalse(_get_orange_warnings())

--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -2737,12 +2737,12 @@ PRE_SUBMIT_DOCTYPE_CONFIG = {
 	"Delivery Note": {
 		"check_prev_docstatus": True,
 		"check_credit_limit": True,
+		"check_packed_qty": True,
 	},
 	"Purchase Receipt": {
 		"check_prev_docstatus": True,
 	},
 	"Sales Order": {
-		"check_prev_docstatus": True,
 		"check_credit_limit": True,
 	},
 }
@@ -2767,10 +2767,13 @@ def _run_pre_submit_checks(doc, cfg):
 	if cfg.get("check_credit_limit"):
 		_check_credit_limit_warn(doc)
 
+	if cfg.get("check_packed_qty"):
+		_check_packed_qty_warn(doc)
+
 
 def _check_prev_docstatus(doc):
 	try:
-		if doc.get("check_prev_docstatus"):
+		if hasattr(doc, "check_prev_docstatus"):
 			doc.check_prev_docstatus()
 	except Exception as e:
 		frappe.msgprint(str(e), title=_("Pre-Submit Warning"), indicator="orange")
@@ -2825,5 +2828,17 @@ def _check_credit_limit_warn(doc):
 		frappe.msgprint(
 			_("Credit limit warning — submission may be blocked: {0}").format(str(e)),
 			title=_("Pre-Submit Warning: Credit Limit"),
+			indicator="orange",
+		)
+
+
+def _check_packed_qty_warn(doc):
+	try:
+		if hasattr(doc, "validate_packed_qty"):
+			doc.validate_packed_qty()
+	except frappe.ValidationError as e:
+		frappe.msgprint(
+			str(e),
+			title=_("Pre-Submit Warning: Packed Qty"),
 			indicator="orange",
 		)


### PR DESCRIPTION
If the delivery note has a submitted packing slip in which a partial item is being shipped, this will throw an error at the time of save.
no-docs