### PR TITLE
fix(stock): remove validation for transfer_qty field

### DIFF
--- a/erpnext/stock/doctype/stock_entry_detail/stock_entry_detail.json
+++ b/erpnext/stock/doctype/stock_entry_detail/stock_entry_detail.json
@@ -278,8 +278,7 @@
    "oldfieldname": "transfer_qty",
    "oldfieldtype": "Currency",
    "print_hide": 1,
-   "read_only": 1,
-   "reqd": 1
+   "read_only": 1
   },
   {
    "default": "0",
@@ -680,7 +679,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-03-02 14:05:23.116017",
+ "modified": "2026-04-27 11:40:38.294196",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Stock Entry Detail",


### PR DESCRIPTION
Issue: When we uploaded item data without the transfer_qty column(system should calculate) in the stock entry, the mandatory error for transfer_qty is thrown while trying to save the document. The system should allow for saving the document since there is a proper validation for the transfer_qty field in the backend.

Ref : [#66646](https://support.frappe.io/helpdesk/tickets/66646)


Ref Screenshot :

<img width="1280" height="438" alt="image" src="https://github.com/user-attachments/assets/53494129-51bc-4411-ad1b-72c0dd72c3cf" />

Backport Needed For V16 and V15
