### PR TITLE
fix: make inv dimen reqd only in delivery note

### DIFF
--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -479,3 +479,4 @@ erpnext.patches.v16_0.uom_category
 erpnext.patches.v16_0.merge_repost_settings_to_accounts_settings
 erpnext.patches.v16_0.set_root_type_in_account_categories
 erpnext.patches.v16_0.scr_inv_dimension
+erpnext.patches.v16_0.packed_item_inv_dimen

--- a/erpnext/patches/v16_0/packed_item_inv_dimen.py
+++ b/erpnext/patches/v16_0/packed_item_inv_dimen.py
@@ -1,0 +1,27 @@
+import frappe
+
+from erpnext.stock.doctype.inventory_dimension.inventory_dimension import get_inventory_dimensions
+
+
+def execute():
+	for dimension in get_inventory_dimensions():
+		if frappe.db.exists(
+			"Custom Field",
+			{
+				"fieldname": dimension.source_fieldname,
+				"dt": "Packed Item",
+				"reqd": 1,
+			},
+		):
+			frappe.set_value(
+				"Custom Field",
+				{
+					"fieldname": dimension.source_fieldname,
+					"dt": "Packed Item",
+					"reqd": 1,
+				},
+				{
+					"reqd": 0,
+					"mandatory_depends_on": "eval:doc.parent_detail_docname && ['Delivery Note', 'Sales Invoice', 'POS Invoice'].includes(parent.doctype)",
+				},
+			)

--- a/erpnext/stock/doctype/inventory_dimension/inventory_dimension.py
+++ b/erpnext/stock/doctype/inventory_dimension/inventory_dimension.py
@@ -175,6 +175,8 @@ class InventoryDimension(Document):
 				mandatory_depends_on = "eval:doc.s_warehouse"
 			elif doctype == "Subcontracting Receipt Supplied Item":
 				mandatory_depends_on = "eval:doc.reference_name"
+			elif doctype == "Packed Item":
+				mandatory_depends_on = "eval:doc.parent_detail_docname && ['Delivery Note', 'Sales Invoice', 'POS Invoice'].includes(parent.doctype)"
 
 		dimension_fields = [
 			dict(
@@ -195,7 +197,8 @@ class InventoryDimension(Document):
 				reqd=1
 				if self.reqd
 				and not self.mandatory_depends_on
-				and doctype not in ["Stock Entry Detail", "Subcontracting Receipt Supplied Item"]
+				and doctype
+				not in ["Stock Entry Detail", "Subcontracting Receipt Supplied Item", "Packed Item"]
 				else 0,
 				mandatory_depends_on=mandatory_depends_on,
 			),

--- a/erpnext/stock/doctype/packed_item/packed_item.json
+++ b/erpnext/stock/doctype/packed_item/packed_item.json
@@ -8,6 +8,7 @@
   "parent_item",
   "item_code",
   "item_name",
+  "delivered_by_supplier",
   "column_break_5",
   "description",
   "section_break_6",
@@ -23,7 +24,6 @@
   "use_serial_batch_fields",
   "column_break_11",
   "serial_and_batch_bundle",
-  "delivered_by_supplier",
   "section_break_bgys",
   "serial_no",
   "column_break_qlha",
@@ -119,6 +119,7 @@
    "read_only": 1
   },
   {
+   "depends_on": "eval:parent.doctype !== \"Sales Order\"",
    "fieldname": "section_break_9",
    "fieldtype": "Section Break"
   },
@@ -285,7 +286,7 @@
    "label": "Use Serial No / Batch Fields"
   },
   {
-   "depends_on": "eval:doc.use_serial_batch_fields === 1",
+   "depends_on": "eval:doc.use_serial_batch_fields === 1 && parent.doctype !== \"Sales Order\"",
    "fieldname": "section_break_bgys",
    "fieldtype": "Section Break"
   },
@@ -314,7 +315,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-03-16 18:10:47.511381",
+ "modified": "2026-04-27 13:00:22.949296",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Packed Item",


### PR DESCRIPTION
1. SABB fields (Packed Item) should not be shown in Sales Order
2. Inventory dimensions should be mandatory only if reference to parent is present