### PR TITLE
fix: negative quantity check in validate_item_qty

### DIFF
--- a/erpnext/manufacturing/doctype/blanket_order/blanket_order.py
+++ b/erpnext/manufacturing/doctype/blanket_order/blanket_order.py
@@ -120,7 +120,7 @@ class BlanketOrder(Document):
 
 	def validate_item_qty(self):
 		for d in self.items:
-			if d.qty < 0:
+			if flt(d.qty) < 0:
 				frappe.throw(_("Row {0}: Quantity cannot be negative.").format(d.idx))
 
 


### PR DESCRIPTION
When saving a Blanket Order with a blank qty field in the items table, the following error is raised:

TypeError: '<' not supported between instances of 'NoneType' and 'int'

<img width="1826" height="870" alt="Screenshot from 2026-04-27 16-49-39" src="https://github.com/user-attachments/assets/849beffb-e7ab-48f5-9f55-2a3717500922" />


Root cause: The validate_item_qty method compares d.qty < 0 directly. When the qty field is left empty, its value is None, and Python cannot compare None with an integer.

Fix
Wrap d.qty with flt(), which safely converts None (and any non-numeric value) to 0.0 before the comparison.

# Before
if d.qty < 0:

# After
if flt(d.qty) < 0:

