### PR TITLE
feat: add setting to hide Subscription references across doctypes

### DIFF
--- a/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
+++ b/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
@@ -16,6 +16,7 @@
   "invoicing_features_section",
   "check_supplier_invoice_uniqueness",
   "automatically_fetch_payment_terms",
+  "enable_subscription",
   "column_break_17",
   "enable_common_party_accounting",
   "allow_multi_currency_invoices_against_single_party_account",

--- a/erpnext/accounts/doctype/accounts_settings/accounts_settings.py
+++ b/erpnext/accounts/doctype/accounts_settings/accounts_settings.py
@@ -77,6 +77,7 @@ class AccountsSettings(Document):
 		enable_immutable_ledger: DF.Check
 		enable_loyalty_point_program: DF.Check
 		enable_party_matching: DF.Check
+		enable_subscription: DF.Check
 		exchange_gain_loss_posting_date: DF.Literal["Invoice", "Payment", "Reconciliation Date"]
 		fetch_payment_schedule_in_payment_request: DF.Check
 		fetch_valuation_rate_for_internal_transaction: DF.Check
@@ -140,6 +141,10 @@ class AccountsSettings(Document):
 
 		if old_doc.enable_loyalty_point_program != self.enable_loyalty_point_program:
 			toggle_loyalty_point_program_section(not self.enable_loyalty_point_program)
+			clear_cache = True
+
+		if old_doc.enable_subscription != self.enable_subscription:
+			toggle_subscription_sections(not self.enable_subscription)
 			clear_cache = True
 
 		if clear_cache:
@@ -232,6 +237,12 @@ def toggle_loyalty_point_program_section(hide):
 		meta = frappe.get_meta(doctype)
 		if meta.has_field("loyalty_points_redemption"):
 			create_property_setter_for_hiding_field(doctype, "loyalty_points_redemption", hide)
+
+
+def toggle_subscription_sections(hide):
+	subscription_doctypes = frappe.get_hooks("subscription_doctypes")
+	for doctype in subscription_doctypes:
+		create_property_setter_for_hiding_field(doctype, "subscription_section", hide)
 
 
 def create_property_setter_for_hiding_field(doctype, field_name, hide):

--- a/erpnext/accounts/doctype/journal_entry/journal_entry.json
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.json
@@ -39,7 +39,7 @@
   "clearance_date",
   "column_break_oizh",
   "user_remark",
-  "subscription_section",
+  "auto_repeat_section",
   "auto_repeat",
   "tax_withholding_tab",
   "section_tax_withholding_entry",
@@ -476,11 +476,6 @@
    "label": "Stock Entry",
    "options": "Stock Entry",
    "read_only": 1
-  },
-  {
-   "fieldname": "subscription_section",
-   "fieldtype": "Section Break",
-   "label": "Subscription"
   },
   {
    "allow_on_submit": 1,

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.json
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.json
@@ -89,6 +89,7 @@
   "remarks",
   "base_in_words",
   "is_opening",
+  "title",
   "column_break_16",
   "letter_head",
   "print_heading",
@@ -96,10 +97,9 @@
   "bank_account_no",
   "payment_order",
   "in_words",
-  "subscription_section",
-  "auto_repeat",
   "amended_from",
-  "title"
+  "auto_repeat_section",
+  "auto_repeat"
  ],
  "fields": [
   {
@@ -504,11 +504,6 @@
    "read_only": 1
   },
   {
-   "fieldname": "subscription_section",
-   "fieldtype": "Section Break",
-   "label": "Subscription Section"
-  },
-  {
    "allow_on_submit": 1,
    "fieldname": "auto_repeat",
    "fieldtype": "Link",
@@ -781,6 +776,11 @@
    "fieldname": "override_tax_withholding_entries",
    "fieldtype": "Check",
    "label": "Edit Tax Withholding Entries"
+  },
+  {
+   "fieldname": "auto_repeat_section",
+   "fieldtype": "Section Break",
+   "label": "Auto Repeat"
   }
  ],
  "grid_page_length": 50,

--- a/erpnext/accounts/doctype/payment_request/payment_request.json
+++ b/erpnext/accounts/doctype/payment_request/payment_request.json
@@ -183,7 +183,7 @@
    "depends_on": "eval:doc.is_a_subscription",
    "fieldname": "subscription_section",
    "fieldtype": "Section Break",
-   "label": "Subscription Section"
+   "label": "Subscription"
   },
   {
    "fieldname": "subscription_plans",
@@ -478,7 +478,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2026-01-13 12:53:00.963274",
+ "modified": "2026-02-27 19:11:03.308896",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Payment Request",

--- a/erpnext/accounts/doctype/pos_invoice/pos_invoice.json
+++ b/erpnext/accounts/doctype/pos_invoice/pos_invoice.json
@@ -187,7 +187,7 @@
   "subscription_section",
   "from_date",
   "to_date",
-  "column_break_140",
+  "auto_repeat_section",
   "auto_repeat",
   "update_auto_repeat_reference",
   "against_income_account"
@@ -1462,7 +1462,7 @@
   {
    "fieldname": "subscription_section",
    "fieldtype": "Section Break",
-   "label": "Subscription Section"
+   "label": "Subscription"
   },
   {
    "allow_on_submit": 1,
@@ -1479,10 +1479,6 @@
    "label": "To Date",
    "no_copy": 1,
    "print_hide": 1
-  },
-  {
-   "fieldname": "column_break_140",
-   "fieldtype": "Column Break"
   },
   {
    "allow_on_submit": 1,
@@ -1619,12 +1615,17 @@
   {
    "fieldname": "column_break_bhao",
    "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "auto_repeat_section",
+   "fieldtype": "Section Break",
+   "label": "Auto Repeat"
   }
  ],
  "icon": "fa fa-file-text",
  "is_submittable": 1,
  "links": [],
- "modified": "2026-02-10 14:23:07.181782",
+ "modified": "2026-03-02 07:32:47.667810",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "POS Invoice",

--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
@@ -180,11 +180,12 @@
   "unrealized_profit_loss_account",
   "subscription_section",
   "subscription",
-  "auto_repeat",
-  "update_auto_repeat_reference",
   "column_break_114",
   "from_date",
   "to_date",
+  "automation_section",
+  "auto_repeat",
+  "update_auto_repeat_reference",
   "printing_settings",
   "letter_head",
   "group_same_items",
@@ -1675,6 +1676,12 @@
    "fieldname": "totals_section",
    "fieldtype": "Section Break",
    "label": "Totals"
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "automation_section",
+   "fieldtype": "Section Break",
+   "label": "Automation"
   }
  ],
  "grid_page_length": 50,

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.json
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.json
@@ -91,9 +91,9 @@
   "column_break_xjag",
   "base_rounding_adjustment",
   "base_rounded_total",
-  "section_break_vacb",
+  "section_break_pxwz",
   "total_advance",
-  "column_break_rdks",
+  "column_break_iaso",
   "outstanding_amount",
   "section_tax_withholding_entry",
   "tax_withholding_group",
@@ -199,6 +199,7 @@
   "unrealized_profit_loss_account",
   "against_income_account",
   "commission_section",
+  "column_break_rdiw",
   "sales_partner",
   "amount_eligible_for_commission",
   "column_break10",
@@ -214,12 +215,14 @@
   "language",
   "subscription_section",
   "subscription",
-  "from_date",
-  "auto_repeat",
   "column_break_140",
+  "from_date",
   "to_date",
+  "automation_section",
+  "auto_repeat",
   "update_auto_repeat_reference",
   "utm_analytics_section",
+  "column_break_rdke",
   "utm_source",
   "utm_medium",
   "column_break_ixxw",
@@ -2305,14 +2308,6 @@
    "print_hide": 1
   },
   {
-   "fieldname": "section_break_vacb",
-   "fieldtype": "Section Break"
-  },
-  {
-   "fieldname": "column_break_rdks",
-   "fieldtype": "Column Break"
-  },
-  {
    "fieldname": "column_break_ixxw",
    "fieldtype": "Column Break"
   },
@@ -2321,6 +2316,28 @@
    "fieldname": "utm_analytics_section",
    "fieldtype": "Section Break",
    "label": "UTM Analytics"
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "automation_section",
+   "fieldtype": "Section Break",
+   "label": "Automation"
+  },
+  {
+   "fieldname": "section_break_pxwz",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "column_break_rdke",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "column_break_rdiw",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "column_break_iaso",
+   "fieldtype": "Column Break"
   }
  ],
  "grid_page_length": 50,
@@ -2334,7 +2351,7 @@
    "link_fieldname": "consolidated_invoice"
   }
  ],
- "modified": "2026-03-09 17:15:30.931929",
+ "modified": "2026-04-28 12:39:53.267755",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Sales Invoice",

--- a/erpnext/buying/doctype/purchase_order/purchase_order.json
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.json
@@ -147,7 +147,7 @@
   "column_break_86",
   "select_print_heading",
   "language",
-  "subscription_section",
+  "auto_repeat_section",
   "from_date",
   "to_date",
   "column_break_97",
@@ -1014,12 +1014,6 @@
    "print_hide": 1
   },
   {
-   "collapsible": 1,
-   "fieldname": "subscription_section",
-   "fieldtype": "Section Break",
-   "label": "Auto Repeat"
-  },
-  {
    "allow_on_submit": 1,
    "fieldname": "from_date",
    "fieldtype": "Date",
@@ -1309,6 +1303,12 @@
    "fieldtype": "Time",
    "label": "Time",
    "mandatory_depends_on": "is_internal_supplier"
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "auto_repeat_section",
+   "fieldtype": "Section Break",
+   "label": "Auto Repeat"
   }
  ],
  "grid_page_length": 50,

--- a/erpnext/buying/doctype/supplier_quotation/supplier_quotation.json
+++ b/erpnext/buying/doctype/supplier_quotation/supplier_quotation.json
@@ -111,7 +111,7 @@
   "column_break_85",
   "select_print_heading",
   "language",
-  "subscription_section",
+  "auto_repeat_section",
   "auto_repeat",
   "update_auto_repeat_reference",
   "more_info",
@@ -737,11 +737,6 @@
    "read_only": 1
   },
   {
-   "fieldname": "subscription_section",
-   "fieldtype": "Section Break",
-   "label": "Auto Repeat"
-  },
-  {
    "fieldname": "auto_repeat",
    "fieldtype": "Link",
    "label": "Auto Repeat",
@@ -940,6 +935,11 @@
    "no_copy": 1,
    "options": "Item Wise Tax Detail",
    "print_hide": 1
+  },
+  {
+   "fieldname": "auto_repeat_section",
+   "fieldtype": "Section Break",
+   "label": "Auto Repeat"
   }
  ],
  "grid_page_length": 50,
@@ -948,7 +948,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2026-01-29 21:23:13.778468",
+ "modified": "2026-02-27 18:05:50.121391",
  "modified_by": "Administrator",
  "module": "Buying",
  "name": "Supplier Quotation",

--- a/erpnext/hooks.py
+++ b/erpnext/hooks.py
@@ -581,6 +581,8 @@ accounting_dimension_doctypes = [
 	"Advance Taxes and Charges",
 ]
 
+subscription_doctypes = ["Sales Invoice", "Purchase Invoice", "Payment Request", "POS Invoice"]
+
 get_matching_queries = (
 	"erpnext.accounts.doctype.bank_reconciliation_tool.bank_reconciliation_tool.get_matching_queries"
 )

--- a/erpnext/selling/doctype/quotation/quotation.json
+++ b/erpnext/selling/doctype/quotation/quotation.json
@@ -109,7 +109,7 @@
   "tc_name",
   "terms",
   "more_info_tab",
-  "subscription_section",
+  "auto_repeat_section",
   "auto_repeat",
   "update_auto_repeat_reference",
   "print_settings",
@@ -833,11 +833,6 @@
    "read_only": 1
   },
   {
-   "fieldname": "subscription_section",
-   "fieldtype": "Section Break",
-   "label": "Auto Repeat"
-  },
-  {
    "fieldname": "auto_repeat",
    "fieldtype": "Link",
    "label": "Auto Repeat",
@@ -1122,6 +1117,11 @@
    "fieldname": "utm_analytics_section",
    "fieldtype": "Section Break",
    "label": "UTM Analytics"
+  },
+  {
+   "fieldname": "auto_repeat_section",
+   "fieldtype": "Section Break",
+   "label": "Auto Repeat"
   }
  ],
  "icon": "fa fa-shopping-cart",

--- a/erpnext/selling/doctype/sales_order/sales_order.json
+++ b/erpnext/selling/doctype/sales_order/sales_order.json
@@ -151,7 +151,7 @@
   "loyalty_points",
   "column_break_116",
   "loyalty_amount",
-  "subscription_section",
+  "auto_repeat_section",
   "from_date",
   "to_date",
   "column_break_108",
@@ -1374,18 +1374,6 @@
   },
   {
    "allow_on_submit": 1,
-   "collapsible": 1,
-   "fieldname": "subscription_section",
-   "fieldtype": "Section Break",
-   "hide_days": 1,
-   "hide_seconds": 1,
-   "label": "Auto Repeat",
-   "no_copy": 1,
-   "print_hide": 1,
-   "read_only": 1
-  },
-  {
-   "allow_on_submit": 1,
    "fieldname": "from_date",
    "fieldtype": "Date",
    "hide_days": 1,
@@ -1741,6 +1729,18 @@
    "fieldtype": "Check",
    "hidden": 1,
    "label": "Ignore Default Payment Terms Template",
+   "read_only": 1
+  },
+  {
+   "allow_on_submit": 1,
+   "collapsible": 1,
+   "fieldname": "auto_repeat_section",
+   "fieldtype": "Section Break",
+   "hide_days": 1,
+   "hide_seconds": 1,
+   "label": "Auto Repeat",
+   "no_copy": 1,
+   "print_hide": 1,
    "read_only": 1
   }
  ],

--- a/erpnext/stock/doctype/delivery_note/delivery_note.json
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.json
@@ -147,7 +147,7 @@
   "total_commission",
   "section_break1",
   "sales_team",
-  "subscription_section",
+  "auto_repeat_section",
   "auto_repeat",
   "printing_details",
   "letter_head",
@@ -1116,11 +1116,6 @@
    "oldfieldtype": "Text"
   },
   {
-   "fieldname": "subscription_section",
-   "fieldtype": "Section Break",
-   "label": "Subscription Section"
-  },
-  {
    "fieldname": "auto_repeat",
    "fieldtype": "Link",
    "label": "Auto Repeat",
@@ -1446,6 +1441,11 @@
   {
    "fieldname": "column_break_neoj",
    "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "auto_repeat_section",
+   "fieldtype": "Section Break",
+   "label": "Auto Repeat"
   }
  ],
  "icon": "fa fa-truck",


### PR DESCRIPTION
Introduced a configurable option to hide Subscription links and references
in all related doctypes to reduce UI clutter for setups not using
the Subscription module.
<img width="933" height="594" alt="556671693-42400063-5b4c-44cc-a572-7020a59f904a" src="https://github.com/user-attachments/assets/2597d0a0-8af0-4b9e-bb58-9f100e8fccfc" />

no-docs