### PR TITLE
fix(pos): remove redundant opening balance dialog onchange handler

### DIFF
--- a/erpnext/selling/page/point_of_sale/pos_controller.js
+++ b/erpnext/selling/page/point_of_sale/pos_controller.js
@@ -40,15 +40,6 @@ erpnext.PointOfSale.Controller = class {
 				in_list_view: 1,
 				label: __("Opening Amount"),
 				options: "company:company_currency",
-				onchange: function () {
-					dialog.fields_dict.balance_details.df.data.some((d) => {
-						if (d.idx == this.doc.idx) {
-							d.opening_amount = this.value;
-							dialog.fields_dict.balance_details.grid.refresh();
-							return true;
-						}
-					});
-				},
 			},
 		];
 		const fetch_pos_payment_methods = () => {


### PR DESCRIPTION
Issue:

In the POS Opening Entry dialog, when editing `balance_details.opening_amount`, the value in the currently edited row resets to 0.

Root Cause:

A custom `onChange` handler was implemented on the dialog’s child table that manually rewrote the `opening_amount` field and triggered a full grid refresh. However, the dialog table fields already persist edits using the system’s built in grid control, making this handler redundant.

https://github.com/frappe/frappe/blame/9d683f15c7c0ff73f8dcc7464a20c25530cf43c9/frappe/public/js/frappe/form/controls/base_control.js#L270

Additionally, the handler relied on a stale row context (`this`), which caused the active row to refresh with an incorrect state, resulting in the value being reset.

Backport needed v16, v15