### PR TITLE
fix(selling): blanket order ordered qty recalculation on sales order status change

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -611,6 +611,7 @@ class SalesOrder(SellingController):
 		self.update_subcontracting_order_status()
 		self.notify_update()
 		clear_doctype_notifications(self)
+		self.update_blanket_order()
 
 	def update_subcontracting_order_status(self):
 		from erpnext.subcontracting.doctype.subcontracting_inward_order.subcontracting_inward_order import (


### PR DESCRIPTION
**Issue:** Blanket Order Ordered Quantity Not Updating on Sales Order Status Change

**Ref:** [#66655](https://support.frappe.io/helpdesk/tickets/66655)

**Description:** 
When creating a Sales Order from a Blanket Order, the ordered quantity in the Blanket Order item table was updating correctly. However, when the Sales Order status was changed, the corresponding ordered quantity in the Blanket Order was not being recalculated or updated accordingly.

This resulted in incorrect tracking of ordered quantities in the Blanket Order.

**Before:** 

[Screencast from 29-04-26 11:01:23 AM IST.webm](https://github.com/user-attachments/assets/04d4ccb5-49d3-4878-adfe-fc2adf7f4bf6)


**After:**

[Screencast from 29-04-26 10:58:42 AM IST.webm](https://github.com/user-attachments/assets/707dff52-5649-4c27-884d-3340df73e80b)


Backport Needed For V16 and V15