### PR TITLE
fix: exclude completed projects from buying transaction project picker

### DIFF
--- a/erpnext/public/js/controllers/buying.js
+++ b/erpnext/public/js/controllers/buying.js
@@ -25,13 +25,14 @@ erpnext.buying = {
 					};
 				});
 
-				this.frm.set_query("project", function (doc) {
-					return {
-						filters: {
-							company: doc.company,
-						},
-					};
-				});
+			this.frm.set_query("project", function (doc) {
+				return {
+					query: "erpnext.controllers.queries.get_project_name",
+					filters: {
+						company: doc.company,
+					},
+				};
+			});
 
 				if (
 					this.frm.doc.__islocal &&


### PR DESCRIPTION
Fixes #54636

The BuyingController project query only filtered by company, unlike the SellingController which uses get_project_name to exclude Completed and Cancelled projects.

Added the same get_project_name query to the buying side, so the behavior is now consistent across all transaction types.

Note: item-level project fields on buying docs (Purchase Invoice, Purchase Order, Supplier Quotation) already had this filter via get_query in their respective JS files. This fix covers the header-level project field.

