### PR TITLE
fix(general-ledger): include linked party entries in General Ledger report

### DIFF
--- a/erpnext/accounts/report/general_ledger/general_ledger.py
+++ b/erpnext/accounts/report/general_ledger/general_ledger.py
@@ -95,6 +95,9 @@ def validate_filters(filters, account_details):
 def validate_party(filters):
 	party_type, party = filters.get("party_type"), filters.get("party")
 
+	if party and not party_type:
+		frappe.throw(_("Please select a Party Type before selecting a Party."))
+
 	if party and party_type:
 		for d in party:
 			if not frappe.db.exists(party_type, d):

--- a/erpnext/accounts/report/general_ledger/general_ledger.py
+++ b/erpnext/accounts/report/general_ledger/general_ledger.py
@@ -285,7 +285,12 @@ def get_conditions(filters):
 		if filters.get("_is_common_party"):
 			cpa_jvs = frappe.get_all(
 				"Journal Entry",
-				filters={"company": filters.get("company"), "docstatus": 1, "is_system_generated": 1},
+				filters={
+					"company": filters.get("company"),
+					"docstatus": 1,
+					"is_system_generated": 1,
+					"voucher_type": "Journal Entry",
+				},
 				pluck="name",
 			)
 			if cpa_jvs:

--- a/erpnext/accounts/report/general_ledger/general_ledger.py
+++ b/erpnext/accounts/report/general_ledger/general_ledger.py
@@ -277,11 +277,10 @@ def get_conditions(filters):
 	if filters.get("categorize_by") == "Categorize by Party" and not filters.get("party_type"):
 		conditions.append("party_type in ('Customer', 'Supplier')")
 
-	if filters.get("party_type"):
-		conditions.append("party_type=%(party_type)s")
-
 	if filters.get("party"):
-		conditions.append("party in %(party)s")
+		conditions.append(build_common_party_condition(filters))
+	elif filters.get("party_type"):
+		conditions.append("party_type=%(party_type)s")
 
 	if not (
 		filters.get("account")
@@ -343,6 +342,44 @@ def get_conditions(filters):
 						conditions.append(f"{dimension.fieldname} in %({dimension.fieldname})s")
 
 	return "and {}".format(" and ".join(conditions)) if conditions else ""
+
+
+def get_linked_parties(party_list: list, party_type: str) -> dict:
+	parties_by_type = {party_type: list(party_list)}
+
+	party_link_dt = frappe.qb.DocType("Party Link")
+	links = (
+		frappe.qb.from_(party_link_dt)
+		.select(
+			party_link_dt.primary_role,
+			party_link_dt.primary_party,
+			party_link_dt.secondary_role,
+			party_link_dt.secondary_party,
+		)
+		.where(
+			(party_link_dt.secondary_party.isin(party_list)) | (party_link_dt.primary_party.isin(party_list))
+		)
+		.run(as_dict=True)
+	)
+
+	for link in links:
+		if link.secondary_party in party_list and link.secondary_role == party_type:
+			parties_by_type.setdefault(link.primary_role, []).append(link.primary_party)
+		elif link.primary_party in party_list and link.primary_role == party_type:
+			parties_by_type.setdefault(link.secondary_role, []).append(link.secondary_party)
+
+	return parties_by_type
+
+
+def build_common_party_condition(filters):
+	parties_by_type = get_linked_parties(list(filters.get("party")), filters.get("party_type"))
+
+	parts = []
+	for ptype, p_list in parties_by_type.items():
+		escaped_parties = ", ".join(frappe.db.escape(p) for p in p_list)
+		parts.append(f"(party_type = {frappe.db.escape(ptype)} AND party IN ({escaped_parties}))")
+
+	return "(" + " OR ".join(parts) + ")"
 
 
 def get_party_name_map():

--- a/erpnext/accounts/report/general_ledger/general_ledger.py
+++ b/erpnext/accounts/report/general_ledger/general_ledger.py
@@ -280,7 +280,10 @@ def get_conditions(filters):
 	if filters.get("categorize_by") == "Categorize by Party" and not filters.get("party_type"):
 		conditions.append("party_type in ('Customer', 'Supplier')")
 
-	if filters.get("party"):
+	if filters.get("party") and filters.get("account"):
+		conditions.append("party_type=%(party_type)s")
+		conditions.append("party in %(party)s")
+	elif filters.get("party"):
 		conditions.append(build_common_party_condition(filters))
 		if filters.get("_is_common_party"):
 			cpa_jvs = frappe.get_all(

--- a/erpnext/accounts/report/general_ledger/general_ledger.py
+++ b/erpnext/accounts/report/general_ledger/general_ledger.py
@@ -282,6 +282,16 @@ def get_conditions(filters):
 
 	if filters.get("party"):
 		conditions.append(build_common_party_condition(filters))
+		if filters.get("_is_common_party"):
+			cpa_jvs = frappe.get_all(
+				"Journal Entry",
+				filters={"company": filters.get("company"), "docstatus": 1, "is_system_generated": 1},
+				pluck="name",
+			)
+			if cpa_jvs:
+				filters["voucher_no_not_in"] = (filters.get("voucher_no_not_in") or []) + cpa_jvs
+				if "voucher_no not in %(voucher_no_not_in)s" not in conditions:
+					conditions.append("voucher_no not in %(voucher_no_not_in)s")
 	elif filters.get("party_type"):
 		conditions.append("party_type=%(party_type)s")
 
@@ -375,7 +385,10 @@ def get_linked_parties(party_list: list, party_type: str) -> dict:
 
 
 def build_common_party_condition(filters):
-	parties_by_type = get_linked_parties(list(filters.get("party")), filters.get("party_type"))
+	parties_by_type = get_linked_parties(filters.get("party"), filters.get("party_type"))
+
+	if len(parties_by_type) > 1:
+		filters["_is_common_party"] = True
 
 	parts = []
 	for ptype, p_list in parties_by_type.items():

--- a/erpnext/accounts/report/general_ledger/test_general_ledger.py
+++ b/erpnext/accounts/report/general_ledger/test_general_ledger.py
@@ -5,6 +5,7 @@ import frappe
 from frappe import qb
 from frappe.utils import flt, today
 
+from erpnext.accounts.doctype.party_link.party_link import create_party_link
 from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_sales_invoice
 from erpnext.accounts.report.general_ledger.general_ledger import execute
 from erpnext.controllers.sales_and_purchase_return import make_return_doc
@@ -27,6 +28,176 @@ class TestGeneralLedger(ERPNextTestSuite):
 		]
 		for doctype in doctype_list:
 			qb.from_(qb.DocType(doctype)).delete().where(qb.DocType(doctype).company == self.company).run()
+
+	def test_cpa_includes_linked_party_entries(self):
+		"""
+		CPA support: filtering GL by a Customer should also return GL entries posted under the linked Supplier (and vice versa) via Party Link.
+		"""
+		company = self.company
+		customer = "_Test Customer"
+		supplier = "_Test Supplier"
+
+		# clean up any existing Party Link involving either party on either side
+		if pl_name := frappe.get_all(
+			"Party Link",
+			or_filters=[
+				["primary_party", "in", [customer, supplier]],
+				["secondary_party", "in", [customer, supplier]],
+			],
+			pluck="name",
+		):
+			frappe.delete_doc("Party Link", pl_name[0], ignore_permissions=True)
+
+		party_link = create_party_link(
+			primary_role="Customer",
+			primary_party=customer,
+			secondary_party=supplier,
+		)
+
+		try:
+			# GL entry via Sales Invoice (Customer side)
+			si = create_sales_invoice(customer=customer, company=company, do_not_submit=False)
+
+			# GL entry via Purchase Invoice (Supplier side)
+			from erpnext.accounts.doctype.purchase_invoice.test_purchase_invoice import make_purchase_invoice
+
+			pi = make_purchase_invoice(supplier=supplier, company=company, do_not_submit=False)
+
+			# Filter by Customer only — should include both Customer and Supplier entries
+			_, data = execute(
+				frappe._dict(
+					{
+						"company": company,
+						"from_date": si.posting_date,
+						"to_date": si.posting_date,
+						"party_type": "Customer",
+						"party": [customer],
+					}
+				)
+			)
+
+			party_types_in_result = {row.party_type for row in data if row.get("party_type")}
+			self.assertIn("Customer", party_types_in_result)
+			self.assertIn("Supplier", party_types_in_result)
+
+			# Filter by Supplier only — should include both sides too
+			_, data = execute(
+				frappe._dict(
+					{
+						"company": company,
+						"from_date": pi.posting_date,
+						"to_date": pi.posting_date,
+						"party_type": "Supplier",
+						"party": [supplier],
+					}
+				)
+			)
+
+			party_types_in_result = {row.party_type for row in data if row.get("party_type")}
+			self.assertIn("Customer", party_types_in_result)
+			self.assertIn("Supplier", party_types_in_result)
+		finally:
+			frappe.delete_doc("Party Link", party_link.name, ignore_permissions=True)
+
+	def test_party_filter_without_party_link(self):
+		"""
+		When a party has no Party Link, GL filtering should only return entries for that party — no cross-party leakage.
+		"""
+		company = self.company
+		customer = "_Test Customer"
+		other_customer = "_Test Customer 1"
+
+		# Ensure no Party Link exists for these parties (either side)
+		if pl_name := frappe.get_all(
+			"Party Link",
+			or_filters=[
+				["primary_party", "in", [customer, other_customer]],
+				["secondary_party", "in", [customer, other_customer]],
+			],
+			pluck="name",
+		):
+			frappe.delete_doc("Party Link", pl_name[0], ignore_permissions=True)
+
+		# GL entry for customer
+		si = create_sales_invoice(customer=customer, company=company, do_not_submit=False)
+		# GL entry for a different customer
+		create_sales_invoice(customer=other_customer, company=company, do_not_submit=False)
+
+		_, data = execute(
+			frappe._dict(
+				{
+					"company": company,
+					"from_date": si.posting_date,
+					"to_date": si.posting_date,
+					"party_type": "Customer",
+					"party": [customer],
+				}
+			)
+		)
+
+		parties_in_result = {row.party for row in data if row.get("party")}
+		self.assertIn(customer, parties_in_result)
+		self.assertNotIn(other_customer, parties_in_result)
+
+	def test_cpa_mixed_party_list_partial_links(self):
+		"""
+		Linked counterparts are included only for parties that have a Party Link; unlinked parties return only their own GL entries.
+		"""
+		company = self.company
+		linked_customer = "_Test Customer"
+		unlinked_customer = "_Test Customer 1"
+		supplier = "_Test Supplier"
+
+		# clean up any existing Party Link touching these parties
+		if pl_name := frappe.get_all(
+			"Party Link",
+			or_filters=[
+				["primary_party", "in", [linked_customer, unlinked_customer, supplier]],
+				["secondary_party", "in", [linked_customer, unlinked_customer, supplier]],
+			],
+			pluck="name",
+		):
+			frappe.delete_doc("Party Link", pl_name[0], ignore_permissions=True)
+
+		party_link = create_party_link(
+			primary_role="Customer",
+			primary_party=linked_customer,
+			secondary_party=supplier,
+		)
+
+		try:
+			from erpnext.accounts.doctype.purchase_invoice.test_purchase_invoice import make_purchase_invoice
+
+			si_linked = create_sales_invoice(customer=linked_customer, company=company, do_not_submit=False)
+			_si_unlinked = create_sales_invoice(
+				customer=unlinked_customer, company=company, do_not_submit=False
+			)
+			make_purchase_invoice(supplier=supplier, company=company, do_not_submit=False)
+
+			_, data = execute(
+				frappe._dict(
+					{
+						"company": company,
+						"from_date": si_linked.posting_date,
+						"to_date": si_linked.posting_date,
+						"party_type": "Customer",
+						"party": [linked_customer, unlinked_customer],
+					}
+				)
+			)
+
+			parties_in_result = {row.party for row in data if row.get("party")}
+			party_types_in_result = {row.party_type for row in data if row.get("party_type")}
+
+			# linked_customer's own entries are present
+			self.assertIn(linked_customer, parties_in_result)
+			# unlinked_customer's own entries are present
+			self.assertIn(unlinked_customer, parties_in_result)
+			# supplier linked to linked_customer is pulled in
+			self.assertIn(supplier, parties_in_result)
+			self.assertIn("Supplier", party_types_in_result)
+		finally:
+			frappe.delete_doc("Party Link", party_link.name, ignore_permissions=True)
 
 	def test_foreign_account_balance_after_exchange_rate_revaluation(self):
 		"""

--- a/erpnext/accounts/report/general_ledger/test_general_ledger.py
+++ b/erpnext/accounts/report/general_ledger/test_general_ledger.py
@@ -6,7 +6,9 @@ from frappe import qb
 from frappe.utils import flt, today
 
 from erpnext.accounts.doctype.party_link.party_link import create_party_link
+from erpnext.accounts.doctype.purchase_invoice.test_purchase_invoice import make_purchase_invoice
 from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_sales_invoice
+from erpnext.accounts.party import get_party_account
 from erpnext.accounts.report.general_ledger.general_ledger import execute
 from erpnext.controllers.sales_and_purchase_return import make_return_doc
 from erpnext.tests.utils import ERPNextTestSuite
@@ -29,6 +31,39 @@ class TestGeneralLedger(ERPNextTestSuite):
 		for doctype in doctype_list:
 			qb.from_(qb.DocType(doctype)).delete().where(qb.DocType(doctype).company == self.company).run()
 
+	def _make_setoff_jv(self, company, customer, supplier, amount, posting_date):
+		"""Explicitly create a CPA set-off Journal Entry with is_system_generated=1."""
+		customer_account = get_party_account("Customer", customer, company)
+		supplier_account = get_party_account("Supplier", supplier, company)
+
+		jv = frappe.new_doc("Journal Entry")
+		jv.voucher_type = "Journal Entry"
+		jv.posting_date = posting_date
+		jv.company = company
+		jv.is_system_generated = 1
+		jv.remark = "Test CPA set-off JV"
+		jv.append(
+			"accounts",
+			{
+				"account": customer_account,
+				"party_type": "Customer",
+				"party": customer,
+				"credit_in_account_currency": amount,
+			},
+		)
+		jv.append(
+			"accounts",
+			{
+				"account": supplier_account,
+				"party_type": "Supplier",
+				"party": supplier,
+				"debit_in_account_currency": amount,
+			},
+		)
+		jv.save()
+		jv.submit()
+		return jv
+
 	def test_cpa_includes_linked_party_entries(self):
 		"""
 		CPA support: filtering GL by a Customer should also return GL entries posted under the linked Supplier (and vice versa) via Party Link.
@@ -45,6 +80,7 @@ class TestGeneralLedger(ERPNextTestSuite):
 				["secondary_party", "in", [customer, supplier]],
 			],
 			pluck="name",
+			limit=1,
 		):
 			frappe.delete_doc("Party Link", pl_name[0], ignore_permissions=True)
 
@@ -59,9 +95,12 @@ class TestGeneralLedger(ERPNextTestSuite):
 			si = create_sales_invoice(customer=customer, company=company, do_not_submit=False)
 
 			# GL entry via Purchase Invoice (Supplier side)
-			from erpnext.accounts.doctype.purchase_invoice.test_purchase_invoice import make_purchase_invoice
+			pi = make_purchase_invoice(supplier=supplier, company=company)
 
-			pi = make_purchase_invoice(supplier=supplier, company=company, do_not_submit=False)
+			# Explicitly create a CPA set-off JV so the exclusion test is not relying on auto-creation
+			setoff_jv = self._make_setoff_jv(
+				company, customer, supplier, si.outstanding_amount, si.posting_date
+			)
 
 			# Filter by Customer only — should include both Customer and Supplier entries
 			_, data = execute(
@@ -79,6 +118,9 @@ class TestGeneralLedger(ERPNextTestSuite):
 			party_types_in_result = {row.party_type for row in data if row.get("party_type")}
 			self.assertIn("Customer", party_types_in_result)
 			self.assertIn("Supplier", party_types_in_result)
+			# The explicitly created set-off JV must not appear in GL results
+			voucher_nos = {row.voucher_no for row in data if row.get("voucher_no")}
+			self.assertNotIn(setoff_jv.name, voucher_nos, "CPA set-off JV should be excluded from GL results")
 
 			# Filter by Supplier only — should include both sides too
 			_, data = execute(
@@ -96,6 +138,8 @@ class TestGeneralLedger(ERPNextTestSuite):
 			party_types_in_result = {row.party_type for row in data if row.get("party_type")}
 			self.assertIn("Customer", party_types_in_result)
 			self.assertIn("Supplier", party_types_in_result)
+			voucher_nos = {row.voucher_no for row in data if row.get("voucher_no")}
+			self.assertNotIn(setoff_jv.name, voucher_nos, "CPA set-off JV should be excluded from GL results")
 		finally:
 			frappe.delete_doc("Party Link", party_link.name, ignore_permissions=True)
 
@@ -115,6 +159,7 @@ class TestGeneralLedger(ERPNextTestSuite):
 				["secondary_party", "in", [customer, other_customer]],
 			],
 			pluck="name",
+			limit=1,
 		):
 			frappe.delete_doc("Party Link", pl_name[0], ignore_permissions=True)
 
@@ -156,6 +201,7 @@ class TestGeneralLedger(ERPNextTestSuite):
 				["secondary_party", "in", [linked_customer, unlinked_customer, supplier]],
 			],
 			pluck="name",
+			limit=1,
 		):
 			frappe.delete_doc("Party Link", pl_name[0], ignore_permissions=True)
 
@@ -166,13 +212,16 @@ class TestGeneralLedger(ERPNextTestSuite):
 		)
 
 		try:
-			from erpnext.accounts.doctype.purchase_invoice.test_purchase_invoice import make_purchase_invoice
-
 			si_linked = create_sales_invoice(customer=linked_customer, company=company, do_not_submit=False)
 			_si_unlinked = create_sales_invoice(
 				customer=unlinked_customer, company=company, do_not_submit=False
 			)
 			make_purchase_invoice(supplier=supplier, company=company, do_not_submit=False)
+
+			# Explicitly create a CPA set-off JV so the exclusion test is not relying on auto-creation
+			setoff_jv = self._make_setoff_jv(
+				company, linked_customer, supplier, si_linked.outstanding_amount, si_linked.posting_date
+			)
 
 			_, data = execute(
 				frappe._dict(
@@ -196,6 +245,9 @@ class TestGeneralLedger(ERPNextTestSuite):
 			# supplier linked to linked_customer is pulled in
 			self.assertIn(supplier, parties_in_result)
 			self.assertIn("Supplier", party_types_in_result)
+			# The explicitly created set-off JV must not appear in GL results
+			voucher_nos = {row.voucher_no for row in data if row.get("voucher_no")}
+			self.assertNotIn(setoff_jv.name, voucher_nos, "CPA set-off JV should be excluded from GL results")
 		finally:
 			frappe.delete_doc("Party Link", party_link.name, ignore_permissions=True)
 


### PR DESCRIPTION
- Closes: https://github.com/frappe/erpnext/issues/54638

---

When a Customer and Supplier are linked via Party Link (Common Party Accounting), filtering the General Ledger by either party now returns entries from both sides — previously only the filtered party's entries were shown.

**Changes:**

- GL party filter now includes linked party entries automatically
- System-generated set-off Journal Entries are excluded from the GL view
- Selecting a Party without a Party Type now raises a validation error on the backend instead of silently returning empty results

**Why this isn't a report filter:**
A Party Link is an accounting relationship, not a display preference. Showing only one side produces an incomplete balance. If no Party Link exists, the report behaves exactly as before.

> **Before**

<img width="1920" height="1080" alt="Screenshot 2026-05-07 at 10 38 01 AM (2)" src="https://github.com/user-attachments/assets/609f4685-a9f4-4b3d-8158-574e81fcdd68" />

---

> **After**

<img width="1920" height="1080" alt="Screenshot 2026-05-07 at 10 36 13 AM (2)" src="https://github.com/user-attachments/assets/ba00d264-0779-403d-ad48-57cea2898f5d" />
