### PR TITLE
fix: skip depreciation rescheduling when asset is fully depreciated on sale

### DIFF
--- a/erpnext/assets/doctype/asset_depreciation_schedule/asset_depreciation_schedule.py
+++ b/erpnext/assets/doctype/asset_depreciation_schedule/asset_depreciation_schedule.py
@@ -194,7 +194,7 @@ def reschedule_depreciation(asset_doc, notes, disposal_date=None):
 	for row in asset_doc.get("finance_books"):
 		current_schedule = get_asset_depr_schedule_doc(asset_doc.name, None, row.finance_book)
 
-		if flt(row.value_after_depreciation) <= flt(row.expected_value_after_useful_life):
+		if disposal_date and flt(row.value_after_depreciation) <= flt(row.expected_value_after_useful_life):
 			continue
 
 		if current_schedule:

--- a/erpnext/assets/doctype/asset_depreciation_schedule/asset_depreciation_schedule.py
+++ b/erpnext/assets/doctype/asset_depreciation_schedule/asset_depreciation_schedule.py
@@ -194,6 +194,9 @@ def reschedule_depreciation(asset_doc, notes, disposal_date=None):
 	for row in asset_doc.get("finance_books"):
 		current_schedule = get_asset_depr_schedule_doc(asset_doc.name, None, row.finance_book)
 
+		if flt(row.value_after_depreciation) <= flt(row.expected_value_after_useful_life):
+			continue
+
 		if current_schedule:
 			if current_schedule.docstatus == 1:
 				new_schedule = frappe.copy_doc(current_schedule)


### PR DESCRIPTION

<img width="1183" height="807" alt="Screenshot 2026-04-30 at 2 03 25 AM" src="https://github.com/user-attachments/assets/0df2d1fe-6be9-4c4e-b348-3f59858635ca" />
