### PR TITLE
fix: show in and out qty in the stock ledger report for stock recos

### DIFF
--- a/erpnext/stock/report/stock_ledger/stock_ledger.py
+++ b/erpnext/stock/report/stock_ledger/stock_ledger.py
@@ -72,6 +72,7 @@ def execute(filters=None):
 		inv_dimension_wise_dict, filters, inv_dimension_key=inv_dimension_key, opening_row=opening_row
 	)
 
+	item_wh_wise_prev_sle = {}
 	for sle in sl_entries:
 		item_detail = item_details[sle.item_code]
 
@@ -113,6 +114,21 @@ def execute(filters=None):
 		elif sle.voucher_type == "Stock Reconciliation":
 			sle["in_out_rate"] = sle.valuation_rate
 
+		if (
+			sle.voucher_type == "Stock Reconciliation"
+			and not sle.in_qty
+			and not sle.out_qty
+			and not sle.actual_qty
+		):
+			if prev_sle := item_wh_wise_prev_sle.get((sle.item_code, sle.warehouse)):
+				bal_qty = prev_sle.get("qty_after_transaction", 0)
+				qty = sle.qty_after_transaction - bal_qty
+				if qty > 0:
+					sle.in_qty = qty
+				elif qty < 0:
+					sle.out_qty = qty
+
+		item_wh_wise_prev_sle[(sle.item_code, sle.warehouse)] = sle
 		data.append(sle)
 
 		if include_uom:


### PR DESCRIPTION
**Issue**

Stock ledger report shows in qty and out qty as zero for stock reconciliation entries with non serial and non batch items.
<img width="1324" height="576" alt="Screenshot 2026-04-29 at 5 50 25 PM" src="https://github.com/user-attachments/assets/45d1db8b-6334-4a02-8393-8ae2db28ca7f" />


**Afer Fix**
<img width="1380" height="585" alt="Screenshot 2026-04-30 at 12 56 14 PM" src="https://github.com/user-attachments/assets/0242d9d2-cf61-4207-9a9d-95a5ac8f1d46" />


