### PR TITLE
fix: mark item tax templates as not applicable

### DIFF
--- a/erpnext/setup/setup_wizard/data/country_wise_tax.json
+++ b/erpnext/setup/setup_wizard/data/country_wise_tax.json
@@ -3119,7 +3119,8 @@
 									"root_type": "Liability",
 									"tax_rate": 19.00
 								},
-								"tax_rate": 19.00
+								"not_applicable": 1,
+								"tax_rate": 0.00
 							},
 							{
 								"tax_type": {

--- a/erpnext/setup/setup_wizard/data/country_wise_tax.json
+++ b/erpnext/setup/setup_wizard/data/country_wise_tax.json
@@ -1387,6 +1387,7 @@
 									"root_type": "Liability",
 									"tax_rate": 7.00
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							},
 							{
@@ -1405,6 +1406,7 @@
 									"root_type": "Liability",
 									"tax_rate": 7.00
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							},
 							{
@@ -1423,6 +1425,7 @@
 									"root_type": "Liability",
 									"tax_rate": 7.00
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							},
 							{
@@ -1441,6 +1444,7 @@
 									"root_type": "Asset",
 									"tax_rate": 7.00
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							},
 							{
@@ -1459,6 +1463,7 @@
 									"root_type": "Asset",
 									"tax_rate": 7.00
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							},
 							{
@@ -1477,6 +1482,7 @@
 									"root_type": "Asset",
 									"tax_rate": 7.00
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							},
 							{
@@ -1499,6 +1505,7 @@
 									"root_type": "Liability",
 									"tax_rate": 19.00
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							},
 							{
@@ -1517,6 +1524,7 @@
 									"root_type": "Liability",
 									"tax_rate": 19.00
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							},
 							{
@@ -1535,6 +1543,7 @@
 									"root_type": "Liability",
 									"tax_rate": 19.00
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							},
 							{
@@ -1553,6 +1562,7 @@
 									"root_type": "Asset",
 									"tax_rate": 19.00
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							},
 							{
@@ -1571,6 +1581,7 @@
 									"root_type": "Asset",
 									"tax_rate": 19.00
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							},
 							{
@@ -1589,6 +1600,7 @@
 									"root_type": "Asset",
 									"tax_rate": 19.00
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							},
 							{
@@ -1620,6 +1632,7 @@
 									"root_type": "Liability",
 									"tax_rate": 19.00
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							},
 							{
@@ -1629,6 +1642,7 @@
 									"root_type": "Liability",
 									"tax_rate": 7.00
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							},
 							{
@@ -1638,6 +1652,7 @@
 									"root_type": "Liability",
 									"tax_rate": 19.00
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							},
 							{
@@ -1647,6 +1662,7 @@
 									"root_type": "Liability",
 									"tax_rate": 7.00
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							},
 							{
@@ -1656,6 +1672,7 @@
 									"root_type": "Liability",
 									"tax_rate": 19.00
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							},
 							{
@@ -1665,6 +1682,7 @@
 									"root_type": "Liability",
 									"tax_rate": 7.00
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							},
 							{
@@ -1674,6 +1692,7 @@
 									"root_type": "Asset",
 									"tax_rate": 19.00
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							},
 							{
@@ -1683,6 +1702,7 @@
 									"root_type": "Asset",
 									"tax_rate": 7.00
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							},
 							{
@@ -1692,6 +1712,7 @@
 									"root_type": "Asset",
 									"tax_rate": 19.00
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							},
 							{
@@ -1701,6 +1722,7 @@
 									"root_type": "Asset",
 									"tax_rate": 7.00
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							},
 							{
@@ -1710,6 +1732,7 @@
 									"root_type": "Asset",
 									"tax_rate": 19.00
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							},
 							{
@@ -1719,6 +1742,7 @@
 									"root_type": "Asset",
 									"tax_rate": 7.00
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							},
 							{
@@ -1727,6 +1751,7 @@
 									"account_number": "1433",
 									"root_type": "Asset"
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							}
 						]
@@ -2150,6 +2175,7 @@
 									"root_type": "Liability",
 									"tax_rate": 7.00
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							},
 							{
@@ -2168,6 +2194,7 @@
 									"root_type": "Liability",
 									"tax_rate": 7.00
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							},
 							{
@@ -2186,6 +2213,7 @@
 									"root_type": "Liability",
 									"tax_rate": 7.00
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							},
 							{
@@ -2204,6 +2232,7 @@
 									"root_type": "Asset",
 									"tax_rate": 7.00
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							},
 							{
@@ -2222,6 +2251,7 @@
 									"root_type": "Asset",
 									"tax_rate": 7.00
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							},
 							{
@@ -2240,6 +2270,7 @@
 									"root_type": "Asset",
 									"tax_rate": 7.00
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							},
 							{
@@ -2262,6 +2293,7 @@
 									"root_type": "Liability",
 									"tax_rate": 19.00
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							},
 							{
@@ -2280,6 +2312,7 @@
 									"root_type": "Liability",
 									"tax_rate": 19.00
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							},
 							{
@@ -2298,6 +2331,7 @@
 									"root_type": "Liability",
 									"tax_rate": 19.00
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							},
 							{
@@ -2316,6 +2350,7 @@
 									"root_type": "Asset",
 									"tax_rate": 19.00
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							},
 							{
@@ -2334,6 +2369,7 @@
 									"root_type": "Asset",
 									"tax_rate": 19.00
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							},
 							{
@@ -2352,6 +2388,7 @@
 									"root_type": "Asset",
 									"tax_rate": 19.00
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							},
 							{
@@ -2383,6 +2420,7 @@
 									"root_type": "Liability",
 									"tax_rate": 19.00
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							},
 							{
@@ -2392,6 +2430,7 @@
 									"root_type": "Liability",
 									"tax_rate": 7.00
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							},
 							{
@@ -2401,6 +2440,7 @@
 									"root_type": "Liability",
 									"tax_rate": 19.00
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							},
 							{
@@ -2410,6 +2450,7 @@
 									"root_type": "Liability",
 									"tax_rate": 7.00
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							},
 							{
@@ -2419,6 +2460,7 @@
 									"root_type": "Liability",
 									"tax_rate": 19.00
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							},
 							{
@@ -2428,6 +2470,7 @@
 									"root_type": "Liability",
 									"tax_rate": 7.00
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							},
 							{
@@ -2437,6 +2480,7 @@
 									"root_type": "Asset",
 									"tax_rate": 19.00
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							},
 							{
@@ -2446,6 +2490,7 @@
 									"root_type": "Asset",
 									"tax_rate": 7.00
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							},
 							{
@@ -2455,6 +2500,7 @@
 									"root_type": "Asset",
 									"tax_rate": 19.00
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							},
 							{
@@ -2464,6 +2510,7 @@
 									"root_type": "Asset",
 									"tax_rate": 7.00
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							},
 							{
@@ -2473,6 +2520,7 @@
 									"root_type": "Asset",
 									"tax_rate": 19.00
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							},
 							{
@@ -2482,6 +2530,7 @@
 									"root_type": "Asset",
 									"tax_rate": 7.00
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							},
 							{
@@ -2490,6 +2539,7 @@
 									"account_number": "1588",
 									"root_type": "Asset"
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							}
 						]
@@ -2913,6 +2963,7 @@
 									"root_type": "Liability",
 									"tax_rate": 7.00
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							},
 							{
@@ -2931,6 +2982,7 @@
 									"root_type": "Liability",
 									"tax_rate": 7.00
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							},
 							{
@@ -2949,6 +3001,7 @@
 									"root_type": "Liability",
 									"tax_rate": 7.00
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							},
 							{
@@ -2967,6 +3020,7 @@
 									"root_type": "Asset",
 									"tax_rate": 7.00
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							},
 							{
@@ -2985,6 +3039,7 @@
 									"root_type": "Asset",
 									"tax_rate": 7.00
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							},
 							{
@@ -3003,6 +3058,7 @@
 									"root_type": "Asset",
 									"tax_rate": 7.00
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							},
 							{
@@ -3025,6 +3081,7 @@
 									"root_type": "Liability",
 									"tax_rate": 19.00
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							},
 							{
@@ -3043,6 +3100,7 @@
 									"root_type": "Liability",
 									"tax_rate": 19.00
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							},
 							{
@@ -3079,6 +3137,7 @@
 									"root_type": "Asset",
 									"tax_rate": 19.00
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							},
 							{
@@ -3097,6 +3156,7 @@
 									"root_type": "Asset",
 									"tax_rate": 19.00
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							},
 							{
@@ -3115,6 +3175,7 @@
 									"root_type": "Asset",
 									"tax_rate": 19.00
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							},
 							{
@@ -3146,6 +3207,7 @@
 									"root_type": "Liability",
 									"tax_rate": 19.00
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							},
 							{
@@ -3155,6 +3217,7 @@
 									"root_type": "Liability",
 									"tax_rate": 7.00
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							},
 							{
@@ -3164,6 +3227,7 @@
 									"root_type": "Liability",
 									"tax_rate": 19.00
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							},
 							{
@@ -3173,6 +3237,7 @@
 									"root_type": "Liability",
 									"tax_rate": 7.00
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							},
 							{
@@ -3182,6 +3247,7 @@
 									"root_type": "Liability",
 									"tax_rate": 19.00
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							},
 							{
@@ -3191,6 +3257,7 @@
 									"root_type": "Liability",
 									"tax_rate": 7.00
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							},
 							{
@@ -3200,6 +3267,7 @@
 									"root_type": "Asset",
 									"tax_rate": 19.00
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							},
 							{
@@ -3209,6 +3277,7 @@
 									"root_type": "Asset",
 									"tax_rate": 7.00
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							},
 							{
@@ -3218,6 +3287,7 @@
 									"root_type": "Asset",
 									"tax_rate": 19.00
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							},
 							{
@@ -3227,6 +3297,7 @@
 									"root_type": "Asset",
 									"tax_rate": 7.00
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							},
 							{
@@ -3236,6 +3307,7 @@
 									"root_type": "Asset",
 									"tax_rate": 19.00
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							},
 							{
@@ -3245,6 +3317,7 @@
 									"root_type": "Asset",
 									"tax_rate": 7.00
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							},
 							{
@@ -3253,6 +3326,7 @@
 									"account_number": "1550",
 									"root_type": "Asset"
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							}
 						]
@@ -3645,6 +3719,7 @@
 									"root_type": "Liability",
 									"tax_rate": 7.00
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							},
 							{
@@ -3661,6 +3736,7 @@
 									"root_type": "Liability",
 									"tax_rate": 7.00
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							},
 							{
@@ -3677,6 +3753,7 @@
 									"root_type": "Liability",
 									"tax_rate": 7.00
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							},
 							{
@@ -3693,6 +3770,7 @@
 									"root_type": "Asset",
 									"tax_rate": 7.00
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							},
 							{
@@ -3709,6 +3787,7 @@
 									"root_type": "Asset",
 									"tax_rate": 7.00
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							},
 							{
@@ -3725,6 +3804,7 @@
 									"root_type": "Asset",
 									"tax_rate": 7.00
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							},
 							{
@@ -3745,6 +3825,7 @@
 									"root_type": "Liability",
 									"tax_rate": 19.00
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							},
 							{
@@ -3761,6 +3842,7 @@
 									"root_type": "Liability",
 									"tax_rate": 19.00
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							},
 							{
@@ -3777,6 +3859,7 @@
 									"root_type": "Liability",
 									"tax_rate": 19.00
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							},
 							{
@@ -3793,6 +3876,7 @@
 									"root_type": "Asset",
 									"tax_rate": 19.00
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							},
 							{
@@ -3809,6 +3893,7 @@
 									"root_type": "Asset",
 									"tax_rate": 19.00
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							},
 							{
@@ -3825,6 +3910,7 @@
 									"root_type": "Asset",
 									"tax_rate": 19.00
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							},
 							{
@@ -3853,6 +3939,7 @@
 									"root_type": "Liability",
 									"tax_rate": 19.00
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							},
 							{
@@ -3861,6 +3948,7 @@
 									"root_type": "Liability",
 									"tax_rate": 7.00
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							},
 							{
@@ -3869,6 +3957,7 @@
 									"root_type": "Liability",
 									"tax_rate": 19.00
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							},
 							{
@@ -3877,6 +3966,7 @@
 									"root_type": "Liability",
 									"tax_rate": 7.00
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							},
 							{
@@ -3885,6 +3975,7 @@
 									"root_type": "Liability",
 									"tax_rate": 19.00
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							},
 							{
@@ -3893,6 +3984,7 @@
 									"root_type": "Liability",
 									"tax_rate": 7.00
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							},
 							{
@@ -3901,6 +3993,7 @@
 									"root_type": "Asset",
 									"tax_rate": 19.00
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							},
 							{
@@ -3909,6 +4002,7 @@
 									"root_type": "Asset",
 									"tax_rate": 7.00
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							},
 							{
@@ -3917,6 +4011,7 @@
 									"root_type": "Asset",
 									"tax_rate": 19.00
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							},
 							{
@@ -3925,6 +4020,7 @@
 									"root_type": "Asset",
 									"tax_rate": 7.00
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							},
 							{
@@ -3933,6 +4029,7 @@
 									"root_type": "Asset",
 									"tax_rate": 19.00
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							},
 							{
@@ -3941,6 +4038,7 @@
 									"root_type": "Asset",
 									"tax_rate": 7.00
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							},
 							{
@@ -3948,6 +4046,7 @@
 									"account_name": "Entstandene Einfuhrumsatzsteuer",
 									"root_type": "Asset"
 								},
+								"not_applicable": 1,
 								"tax_rate": 0.00
 							}
 						]


### PR DESCRIPTION
For new German charts of accounts, mark accounts for different tax rates as *Not Applicable* in **Item Tax Templates**.

E.g. in **Item Tax Template** "7%" all non-7% accounts get _Not Applicable_ enabled:

<img width="1411" height="897" alt="Bildschirmfoto 2026-04-30 um 12 54 42" src="https://github.com/user-attachments/assets/2ad031c8-e089-47af-93b9-db7e681b88b9" />

Related: https://github.com/frappe/erpnext/pull/50898