### PR TITLE
fix: incorrect expense account book in purchase return

### DIFF
--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
@@ -725,6 +725,9 @@ class PurchaseReceipt(BuyingController):
 					or stock_asset_rbnb
 				)
 
+				if self.is_return and item.expense_account:
+					loss_account = item.expense_account
+
 				cost_center = item.cost_center or frappe.get_cached_value(
 					"Company", self.company, "cost_center"
 				)


### PR DESCRIPTION
- Make purchase receipt with 1 qty rate as 100
- Make LCV for 50
- Make purchase return
- System books the 50 in the COGS account instead of the expense account set in the line item