### PR TITLE
fix: Backfill `not_applicable` on Item Tax Template Details for German companies

### DIFF
--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -480,3 +480,4 @@ erpnext.patches.v16_0.merge_repost_settings_to_accounts_settings
 erpnext.patches.v16_0.set_root_type_in_account_categories
 erpnext.patches.v16_0.scr_inv_dimension
 erpnext.patches.v16_0.packed_item_inv_dimen
+erpnext.patches.v16_0.set_not_applicable_on_german_item_tax_templates

--- a/erpnext/patches/v16_0/set_not_applicable_on_german_item_tax_templates.py
+++ b/erpnext/patches/v16_0/set_not_applicable_on_german_item_tax_templates.py
@@ -26,15 +26,59 @@ NOT_APPLICABLE_19_PERCENT_ACCOUNTS = frozenset(
 	}
 )
 
+NOT_APPLICABLE_7_PERCENT_ACCOUNTS_WITH_NUMBERS = frozenset(
+	{
+		"Umsatzsteuer 7 %",
+		"Umsatzsteuer aus innergemeinschaftlichen Erwerb 7 %",
+		"Umsatzsteuer nach § 13b UStG 7%",
+		"Abziehbare Vorsteuer 7 %",
+		"Abziehbare Vorsteuer aus innergemeinschaftlichen Erwerb 7 %",
+		"Abziehbare Vorsteuer nach § 13b UStG 7%",
+	}
+)
+
+NOT_APPLICABLE_19_PERCENT_ACCOUNTS_WITH_NUMBERS = frozenset(
+	{
+		"Umsatzsteuer 19 %",
+		"Umsatzsteuer aus innergemeinschaftlichen Erwerb 19 %",
+		"Umsatzsteuer nach § 13b UStG 19%",
+		"Abziehbare Vorsteuer 19 %",
+		"Abziehbare Vorsteuer aus innergemeinschaftlichen Erwerb 19 %",
+		"Abziehbare Vorsteuer nach § 13b UStG 19%",
+	}
+)
+
+NOT_APPLICABLE_IMPORT_TAX_ACCOUNT = frozenset({"Entstandene Einfuhrumsatzsteuer"})
+
 GERMAN_ITEM_TAX_TEMPLATE_NOT_APPLICABLE_ACCOUNTS = {
-	chart: {
+	"SKR03 mit Kontonummern": {
 		"19 %": NOT_APPLICABLE_7_PERCENT_ACCOUNTS,
 		"7 %": NOT_APPLICABLE_19_PERCENT_ACCOUNTS,
 		"0 %": NOT_APPLICABLE_7_PERCENT_ACCOUNTS
 		| NOT_APPLICABLE_19_PERCENT_ACCOUNTS
-		| frozenset({"Entstandene Einfuhrumsatzsteuer"}),
-	}
-	for chart in ("SKR03 mit Kontonummern", "SKR04 mit Kontonummern")
+		| NOT_APPLICABLE_IMPORT_TAX_ACCOUNT,
+	},
+	"SKR04 mit Kontonummern": {
+		"19 %": NOT_APPLICABLE_7_PERCENT_ACCOUNTS,
+		"7 %": NOT_APPLICABLE_19_PERCENT_ACCOUNTS,
+		"0 %": NOT_APPLICABLE_7_PERCENT_ACCOUNTS
+		| NOT_APPLICABLE_19_PERCENT_ACCOUNTS
+		| NOT_APPLICABLE_IMPORT_TAX_ACCOUNT,
+	},
+	"Standard": {
+		"19 %": NOT_APPLICABLE_7_PERCENT_ACCOUNTS,
+		"7 %": NOT_APPLICABLE_19_PERCENT_ACCOUNTS,
+		"0%": NOT_APPLICABLE_7_PERCENT_ACCOUNTS
+		| NOT_APPLICABLE_19_PERCENT_ACCOUNTS
+		| NOT_APPLICABLE_IMPORT_TAX_ACCOUNT,
+	},
+	"Standard with Numbers": {
+		"19%": NOT_APPLICABLE_7_PERCENT_ACCOUNTS_WITH_NUMBERS,
+		"7%": NOT_APPLICABLE_19_PERCENT_ACCOUNTS_WITH_NUMBERS,
+		"0 %": NOT_APPLICABLE_7_PERCENT_ACCOUNTS_WITH_NUMBERS
+		| NOT_APPLICABLE_19_PERCENT_ACCOUNTS_WITH_NUMBERS
+		| NOT_APPLICABLE_IMPORT_TAX_ACCOUNT,
+	},
 }
 
 

--- a/erpnext/patches/v16_0/set_not_applicable_on_german_item_tax_templates.py
+++ b/erpnext/patches/v16_0/set_not_applicable_on_german_item_tax_templates.py
@@ -4,82 +4,144 @@ import frappe
 # Migration patches must not read mutable setup data, otherwise future edits to
 # country_wise_tax.json would change what this patch does on sites that have not
 # run it yet.
-NOT_APPLICABLE_7_PERCENT_ACCOUNTS = frozenset(
+#
+# For numbered charts, compare account_number + root_type because Account.account_name
+# is not unique within a company.
+SKR04_NOT_APPLICABLE_7_PERCENT_ACCOUNT_IDS = frozenset(
 	{
-		"Umsatzsteuer 7 %",
-		"Umsatzsteuer aus innergemeinschaftlichem Erwerb",
-		"Umsatzsteuer nach § 13b UStG",
-		"Abziehbare Vorsteuer 7 %",
-		"Abziehbare Vorsteuer aus innergemeinschaftlichem Erwerb",
-		"Abziehbare Vorsteuer nach § 13b UStG",
+		("3801", "Liability"),
+		("3802", "Liability"),
+		("3835", "Liability"),
+		("1401", "Asset"),
+		("1402", "Asset"),
+		("1541", "Asset"),
 	}
 )
 
-NOT_APPLICABLE_19_PERCENT_ACCOUNTS = frozenset(
+SKR04_NOT_APPLICABLE_19_PERCENT_ACCOUNT_IDS = frozenset(
 	{
-		"Umsatzsteuer 19 %",
-		"Umsatzsteuer aus innergemeinschaftlichem Erwerb 19 %",
-		"Umsatzsteuer nach § 13b UStG 19 %",
-		"Abziehbare Vorsteuer 19 %",
-		"Abziehbare Vorsteuer aus innergemeinschaftlichem Erwerb 19 %",
-		"Abziehbare Vorsteuer nach § 13b UStG 19 %",
+		("3806", "Liability"),
+		("3804", "Liability"),
+		("3837", "Liability"),
+		("1406", "Asset"),
+		("1404", "Asset"),
+		("1540", "Asset"),
 	}
 )
 
-NOT_APPLICABLE_7_PERCENT_ACCOUNTS_WITH_NUMBERS = frozenset(
+SKR03_NOT_APPLICABLE_7_PERCENT_ACCOUNT_IDS = frozenset(
 	{
-		"Umsatzsteuer 7 %",
-		"Umsatzsteuer aus innergemeinschaftlichen Erwerb 7 %",
-		"Umsatzsteuer nach § 13b UStG 7%",
-		"Abziehbare Vorsteuer 7 %",
-		"Abziehbare Vorsteuer aus innergemeinschaftlichen Erwerb 7 %",
-		"Abziehbare Vorsteuer nach § 13b UStG 7%",
+		("1771", "Liability"),
+		("1772", "Liability"),
+		("1785", "Liability"),
+		("1571", "Asset"),
+		("1572", "Asset"),
+		("1541", "Asset"),
 	}
 )
 
-NOT_APPLICABLE_19_PERCENT_ACCOUNTS_WITH_NUMBERS = frozenset(
+SKR03_NOT_APPLICABLE_19_PERCENT_ACCOUNT_IDS = frozenset(
 	{
-		"Umsatzsteuer 19 %",
-		"Umsatzsteuer aus innergemeinschaftlichen Erwerb 19 %",
-		"Umsatzsteuer nach § 13b UStG 19%",
-		"Abziehbare Vorsteuer 19 %",
-		"Abziehbare Vorsteuer aus innergemeinschaftlichen Erwerb 19 %",
-		"Abziehbare Vorsteuer nach § 13b UStG 19%",
+		("1776", "Liability"),
+		("1774", "Liability"),
+		("1787", "Liability"),
+		("1576", "Asset"),
+		("1574", "Asset"),
+		("1540", "Asset"),
 	}
 )
 
-NOT_APPLICABLE_IMPORT_TAX_ACCOUNT = frozenset({"Entstandene Einfuhrumsatzsteuer"})
+STANDARD_NOT_APPLICABLE_7_PERCENT_ACCOUNT_LABELS = frozenset(
+	{
+		("Umsatzsteuer 7 %", "Liability"),
+		("Umsatzsteuer aus innergemeinschaftlichem Erwerb", "Liability"),
+		("Umsatzsteuer nach § 13b UStG", "Liability"),
+		("Abziehbare Vorsteuer 7 %", "Asset"),
+		("Abziehbare Vorsteuer aus innergemeinschaftlichem Erwerb", "Asset"),
+		("Abziehbare Vorsteuer nach § 13b UStG", "Asset"),
+	}
+)
+
+STANDARD_NOT_APPLICABLE_19_PERCENT_ACCOUNT_LABELS = frozenset(
+	{
+		("Umsatzsteuer 19 %", "Liability"),
+		("Umsatzsteuer aus innergemeinschaftlichem Erwerb 19 %", "Liability"),
+		("Umsatzsteuer nach § 13b UStG 19 %", "Liability"),
+		("Abziehbare Vorsteuer 19 %", "Asset"),
+		("Abziehbare Vorsteuer aus innergemeinschaftlichem Erwerb 19 %", "Asset"),
+		("Abziehbare Vorsteuer nach § 13b UStG 19 %", "Asset"),
+	}
+)
+
+STANDARD_WITH_NUMBERS_NOT_APPLICABLE_7_PERCENT_ACCOUNT_IDS = frozenset(
+	{
+		("2321", "Liability"),
+		("2331", "Liability"),
+		("2341", "Liability"),
+		("1521", "Asset"),
+		("1531", "Asset"),
+		("1541", "Asset"),
+	}
+)
+
+STANDARD_WITH_NUMBERS_NOT_APPLICABLE_19_PERCENT_ACCOUNT_IDS = frozenset(
+	{
+		("2320", "Liability"),
+		("2330", "Liability"),
+		("2340", "Liability"),
+		("1520", "Asset"),
+		("1530", "Asset"),
+		("1540", "Asset"),
+	}
+)
 
 GERMAN_ITEM_TAX_TEMPLATE_NOT_APPLICABLE_ACCOUNTS = {
 	"SKR03 mit Kontonummern": {
-		"19 %": NOT_APPLICABLE_7_PERCENT_ACCOUNTS,
-		"7 %": NOT_APPLICABLE_19_PERCENT_ACCOUNTS,
-		"0 %": NOT_APPLICABLE_7_PERCENT_ACCOUNTS
-		| NOT_APPLICABLE_19_PERCENT_ACCOUNTS
-		| NOT_APPLICABLE_IMPORT_TAX_ACCOUNT,
+		"identifier_field": "account_number",
+		"templates": {
+			"19 %": SKR03_NOT_APPLICABLE_7_PERCENT_ACCOUNT_IDS,
+			"7 %": SKR03_NOT_APPLICABLE_19_PERCENT_ACCOUNT_IDS,
+			"0 %": SKR03_NOT_APPLICABLE_7_PERCENT_ACCOUNT_IDS
+			| SKR03_NOT_APPLICABLE_19_PERCENT_ACCOUNT_IDS
+			| frozenset({("1588", "Asset")}),
+		},
 	},
 	"SKR04 mit Kontonummern": {
-		"19 %": NOT_APPLICABLE_7_PERCENT_ACCOUNTS,
-		"7 %": NOT_APPLICABLE_19_PERCENT_ACCOUNTS,
-		"0 %": NOT_APPLICABLE_7_PERCENT_ACCOUNTS
-		| NOT_APPLICABLE_19_PERCENT_ACCOUNTS
-		| NOT_APPLICABLE_IMPORT_TAX_ACCOUNT,
+		"identifier_field": "account_number",
+		"templates": {
+			"19 %": SKR04_NOT_APPLICABLE_7_PERCENT_ACCOUNT_IDS,
+			"7 %": SKR04_NOT_APPLICABLE_19_PERCENT_ACCOUNT_IDS,
+			"0 %": SKR04_NOT_APPLICABLE_7_PERCENT_ACCOUNT_IDS
+			| SKR04_NOT_APPLICABLE_19_PERCENT_ACCOUNT_IDS
+			| frozenset({("1433", "Asset")}),
+		},
 	},
 	"Standard": {
-		"19 %": NOT_APPLICABLE_7_PERCENT_ACCOUNTS,
-		"7 %": NOT_APPLICABLE_19_PERCENT_ACCOUNTS,
-		"0%": NOT_APPLICABLE_7_PERCENT_ACCOUNTS
-		| NOT_APPLICABLE_19_PERCENT_ACCOUNTS
-		| NOT_APPLICABLE_IMPORT_TAX_ACCOUNT,
+		"identifier_field": "account_name",
+		"templates": {
+			"19 %": STANDARD_NOT_APPLICABLE_7_PERCENT_ACCOUNT_LABELS,
+			"7 %": STANDARD_NOT_APPLICABLE_19_PERCENT_ACCOUNT_LABELS,
+			"0%": STANDARD_NOT_APPLICABLE_7_PERCENT_ACCOUNT_LABELS
+			| STANDARD_NOT_APPLICABLE_19_PERCENT_ACCOUNT_LABELS
+			| frozenset({("Entstandene Einfuhrumsatzsteuer", "Asset")}),
+		},
 	},
 	"Standard with Numbers": {
-		"19%": NOT_APPLICABLE_7_PERCENT_ACCOUNTS_WITH_NUMBERS,
-		"7%": NOT_APPLICABLE_19_PERCENT_ACCOUNTS_WITH_NUMBERS,
-		"0 %": NOT_APPLICABLE_7_PERCENT_ACCOUNTS_WITH_NUMBERS
-		| NOT_APPLICABLE_19_PERCENT_ACCOUNTS_WITH_NUMBERS
-		| NOT_APPLICABLE_IMPORT_TAX_ACCOUNT,
+		"identifier_field": "account_number",
+		"templates": {
+			"19%": STANDARD_WITH_NUMBERS_NOT_APPLICABLE_7_PERCENT_ACCOUNT_IDS,
+			"7%": STANDARD_WITH_NUMBERS_NOT_APPLICABLE_19_PERCENT_ACCOUNT_IDS,
+			"0 %": STANDARD_WITH_NUMBERS_NOT_APPLICABLE_7_PERCENT_ACCOUNT_IDS
+			| STANDARD_WITH_NUMBERS_NOT_APPLICABLE_19_PERCENT_ACCOUNT_IDS
+			| frozenset({("1550", "Asset")}),
+		},
 	},
 }
+
+
+def get_account_identifier(account, identifier_field):
+	identifier, root_type = frappe.get_cached_value("Account", account, [identifier_field, "root_type"])
+	return identifier, root_type
 
 
 def execute():
@@ -90,7 +152,7 @@ def execute():
 	an explicit 0% rate). For each German company, this patch looks up the
 	historical defaults for its Chart of Accounts and sets
 	`not_applicable = 1` on detail rows that still match those defaults
-	(same template title, same zero-rate tax account set, flag still unset),
+	(same template title, same zero-rate tax account identifier set, flag still unset),
 	leaving any user-customised rows untouched.
 	"""
 	companies = frappe.get_all(
@@ -104,7 +166,8 @@ def execute():
 		if not chart:
 			continue
 
-		for template_title, target_accounts in chart.items():
+		identifier_field = chart["identifier_field"]
+		for template_title, target_accounts in chart["templates"].items():
 			itt_names = frappe.get_all(
 				"Item Tax Template",
 				filters={"company": company.name, "title": template_title},
@@ -117,8 +180,7 @@ def execute():
 					fields=["name", "tax_type", "not_applicable"],
 				)
 				zero_rate_accounts_by_detail = {
-					d.name: frappe.get_cached_value("Account", d.tax_type, "account_name")
-					for d in zero_rate_details
+					d.name: get_account_identifier(d.tax_type, identifier_field) for d in zero_rate_details
 				}
 				if set(zero_rate_accounts_by_detail.values()) != target_accounts:
 					continue

--- a/erpnext/patches/v16_0/set_not_applicable_on_german_item_tax_templates.py
+++ b/erpnext/patches/v16_0/set_not_applicable_on_german_item_tax_templates.py
@@ -153,7 +153,10 @@ def update_account_cache(accounts, account_cache):
 
 
 def get_account_identifier(account, identifier_field, account_cache):
-	cached_account = account_cache[account]
+	cached_account = account_cache.get(account)
+	if not cached_account:
+		return None
+
 	return cached_account.get(identifier_field), cached_account.root_type
 
 
@@ -198,6 +201,9 @@ def execute():
 					d.name: get_account_identifier(d.tax_type, identifier_field, account_cache)
 					for d in zero_rate_details
 				}
+				if any(identifier is None for identifier in zero_rate_accounts_by_detail.values()):
+					continue
+
 				if set(zero_rate_accounts_by_detail.values()) != target_accounts:
 					continue
 

--- a/erpnext/patches/v16_0/set_not_applicable_on_german_item_tax_templates.py
+++ b/erpnext/patches/v16_0/set_not_applicable_on_german_item_tax_templates.py
@@ -1,7 +1,41 @@
-import json
-from pathlib import Path
-
 import frappe
+
+# Snapshot of the relevant German defaults when this migration was written.
+# Migration patches must not read mutable setup data, otherwise future edits to
+# country_wise_tax.json would change what this patch does on sites that have not
+# run it yet.
+NOT_APPLICABLE_7_PERCENT_ACCOUNTS = frozenset(
+	{
+		"Umsatzsteuer 7 %",
+		"Umsatzsteuer aus innergemeinschaftlichem Erwerb",
+		"Umsatzsteuer nach § 13b UStG",
+		"Abziehbare Vorsteuer 7 %",
+		"Abziehbare Vorsteuer aus innergemeinschaftlichem Erwerb",
+		"Abziehbare Vorsteuer nach § 13b UStG",
+	}
+)
+
+NOT_APPLICABLE_19_PERCENT_ACCOUNTS = frozenset(
+	{
+		"Umsatzsteuer 19 %",
+		"Umsatzsteuer aus innergemeinschaftlichem Erwerb 19 %",
+		"Umsatzsteuer nach § 13b UStG 19 %",
+		"Abziehbare Vorsteuer 19 %",
+		"Abziehbare Vorsteuer aus innergemeinschaftlichem Erwerb 19 %",
+		"Abziehbare Vorsteuer nach § 13b UStG 19 %",
+	}
+)
+
+GERMAN_ITEM_TAX_TEMPLATE_NOT_APPLICABLE_ACCOUNTS = {
+	chart: {
+		"19 %": NOT_APPLICABLE_7_PERCENT_ACCOUNTS,
+		"7 %": NOT_APPLICABLE_19_PERCENT_ACCOUNTS,
+		"0 %": NOT_APPLICABLE_7_PERCENT_ACCOUNTS
+		| NOT_APPLICABLE_19_PERCENT_ACCOUNTS
+		| frozenset({"Entstandene Einfuhrumsatzsteuer"}),
+	}
+	for chart in ("SKR03 mit Kontonummern", "SKR04 mit Kontonummern")
+}
 
 
 def execute():
@@ -10,18 +44,11 @@ def execute():
 	Before the `not_applicable` flag existed, German default templates used
 	`tax_rate: 0` to mean "this tax does not apply to the item" (as opposed to
 	an explicit 0% rate). For each German company, this patch looks up the
-	defaults for its Chart of Accounts in `country_wise_tax.json` and sets
+	historical defaults for its Chart of Accounts and sets
 	`not_applicable = 1` on detail rows that still match those defaults
 	(same template title, same tax account, rate still 0, flag still unset),
 	leaving any user-customised rows untouched.
 	"""
-	json_path = (
-		Path(frappe.get_app_path("erpnext")) / "setup" / "setup_wizard" / "data" / "country_wise_tax.json"
-	)
-	germany_charts = json.loads(json_path.read_text()).get("Germany", {}).get("chart_of_accounts", {})
-	if not germany_charts:
-		return
-
 	companies = frappe.get_all(
 		"Company",
 		filters={"country": "Germany"},
@@ -29,20 +56,14 @@ def execute():
 	)
 
 	for company in companies:
-		chart = germany_charts.get(company.chart_of_accounts) or germany_charts.get("*")
+		chart = GERMAN_ITEM_TAX_TEMPLATE_NOT_APPLICABLE_ACCOUNTS.get(company.chart_of_accounts)
 		if not chart:
 			continue
 
-		for tmpl in chart.get("item_tax_templates", []):
-			target_accounts = {
-				tax["tax_type"]["account_name"] for tax in tmpl.get("taxes", []) if tax.get("not_applicable")
-			}
-			if not target_accounts:
-				continue
-
+		for template_title, target_accounts in chart.items():
 			itt_names = frappe.get_all(
 				"Item Tax Template",
-				filters={"company": company.name, "title": tmpl["title"]},
+				filters={"company": company.name, "title": template_title},
 				pluck="name",
 			)
 			for itt_name in itt_names:

--- a/erpnext/patches/v16_0/set_not_applicable_on_german_item_tax_templates.py
+++ b/erpnext/patches/v16_0/set_not_applicable_on_german_item_tax_templates.py
@@ -46,7 +46,7 @@ def execute():
 	an explicit 0% rate). For each German company, this patch looks up the
 	historical defaults for its Chart of Accounts and sets
 	`not_applicable = 1` on detail rows that still match those defaults
-	(same template title, same tax account, rate still 0, flag still unset),
+	(same template title, same zero-rate tax account set, flag still unset),
 	leaving any user-customised rows untouched.
 	"""
 	companies = frappe.get_all(
@@ -67,14 +67,20 @@ def execute():
 				pluck="name",
 			)
 			for itt_name in itt_names:
-				details = frappe.get_all(
+				zero_rate_details = frappe.get_all(
 					"Item Tax Template Detail",
-					filters={"parent": itt_name, "tax_rate": 0, "not_applicable": 0},
-					fields=["name", "tax_type"],
+					filters={"parent": itt_name, "tax_rate": 0},
+					fields=["name", "tax_type", "not_applicable"],
 				)
-				for d in details:
-					account_name = frappe.get_cached_value("Account", d.tax_type, "account_name")
-					if account_name in target_accounts:
+				zero_rate_accounts_by_detail = {
+					d.name: frappe.get_cached_value("Account", d.tax_type, "account_name")
+					for d in zero_rate_details
+				}
+				if set(zero_rate_accounts_by_detail.values()) != target_accounts:
+					continue
+
+				for d in zero_rate_details:
+					if not d.not_applicable:
 						frappe.db.set_value(
 							"Item Tax Template Detail",
 							d.name,

--- a/erpnext/patches/v16_0/set_not_applicable_on_german_item_tax_templates.py
+++ b/erpnext/patches/v16_0/set_not_applicable_on_german_item_tax_templates.py
@@ -139,9 +139,22 @@ GERMAN_ITEM_TAX_TEMPLATE_NOT_APPLICABLE_ACCOUNTS = {
 }
 
 
-def get_account_identifier(account, identifier_field):
-	identifier, root_type = frappe.get_cached_value("Account", account, [identifier_field, "root_type"])
-	return identifier, root_type
+def update_account_cache(accounts, account_cache):
+	missing_accounts = set(accounts) - set(account_cache)
+	if not missing_accounts:
+		return
+
+	for account in frappe.get_all(
+		"Account",
+		filters={"name": ("in", tuple(sorted(missing_accounts)))},
+		fields=["name", "account_name", "account_number", "root_type"],
+	):
+		account_cache[account.name] = account
+
+
+def get_account_identifier(account, identifier_field, account_cache):
+	cached_account = account_cache[account]
+	return cached_account.get(identifier_field), cached_account.root_type
 
 
 def execute():
@@ -160,6 +173,7 @@ def execute():
 		filters={"country": "Germany"},
 		fields=["name", "chart_of_accounts"],
 	)
+	account_cache = {}
 
 	for company in companies:
 		chart = GERMAN_ITEM_TAX_TEMPLATE_NOT_APPLICABLE_ACCOUNTS.get(company.chart_of_accounts)
@@ -179,8 +193,10 @@ def execute():
 					filters={"parent": itt_name, "tax_rate": 0},
 					fields=["name", "tax_type", "not_applicable"],
 				)
+				update_account_cache((d.tax_type for d in zero_rate_details), account_cache)
 				zero_rate_accounts_by_detail = {
-					d.name: get_account_identifier(d.tax_type, identifier_field) for d in zero_rate_details
+					d.name: get_account_identifier(d.tax_type, identifier_field, account_cache)
+					for d in zero_rate_details
 				}
 				if set(zero_rate_accounts_by_detail.values()) != target_accounts:
 					continue

--- a/erpnext/patches/v16_0/set_not_applicable_on_german_item_tax_templates.py
+++ b/erpnext/patches/v16_0/set_not_applicable_on_german_item_tax_templates.py
@@ -1,0 +1,63 @@
+import json
+from pathlib import Path
+
+import frappe
+
+
+def execute():
+	"""Backfill `not_applicable` on Item Tax Template Details for German companies.
+
+	Before the `not_applicable` flag existed, German default templates used
+	`tax_rate: 0` to mean "this tax does not apply to the item" (as opposed to
+	an explicit 0% rate). For each German company, this patch looks up the
+	defaults for its Chart of Accounts in `country_wise_tax.json` and sets
+	`not_applicable = 1` on detail rows that still match those defaults
+	(same template title, same tax account, rate still 0, flag still unset),
+	leaving any user-customised rows untouched.
+	"""
+	json_path = (
+		Path(frappe.get_app_path("erpnext")) / "setup" / "setup_wizard" / "data" / "country_wise_tax.json"
+	)
+	germany_charts = json.loads(json_path.read_text()).get("Germany", {}).get("chart_of_accounts", {})
+	if not germany_charts:
+		return
+
+	companies = frappe.get_all(
+		"Company",
+		filters={"country": "Germany"},
+		fields=["name", "chart_of_accounts"],
+	)
+
+	for company in companies:
+		chart = germany_charts.get(company.chart_of_accounts) or germany_charts.get("*")
+		if not chart:
+			continue
+
+		for tmpl in chart.get("item_tax_templates", []):
+			target_accounts = {
+				tax["tax_type"]["account_name"] for tax in tmpl.get("taxes", []) if tax.get("not_applicable")
+			}
+			if not target_accounts:
+				continue
+
+			itt_names = frappe.get_all(
+				"Item Tax Template",
+				filters={"company": company.name, "title": tmpl["title"]},
+				pluck="name",
+			)
+			for itt_name in itt_names:
+				details = frappe.get_all(
+					"Item Tax Template Detail",
+					filters={"parent": itt_name, "tax_rate": 0, "not_applicable": 0},
+					fields=["name", "tax_type"],
+				)
+				for d in details:
+					account_name = frappe.get_cached_value("Account", d.tax_type, "account_name")
+					if account_name in target_accounts:
+						frappe.db.set_value(
+							"Item Tax Template Detail",
+							d.name,
+							"not_applicable",
+							1,
+							update_modified=False,
+						)


### PR DESCRIPTION
Before the `not_applicable` flag existed, German default templates used `tax_rate: 0` to mean "this tax does not apply to the item" (as opposed to an explicit 0% rate). For each German company, this patch looks up the defaults for its Chart of Accounts in `country_wise_tax.json` and sets `not_applicable = 1` on detail rows that still match those defaults (same template title, same tax account, rate still 0, flag still unset), leaving any user-customised rows untouched.

Same as https://github.com/frappe/erpnext/pull/54673, but for existing Companies.