### PR TITLE
fix(profit-loss-report): handle zero base values and prevent null% display

### DIFF
--- a/erpnext/accounts/report/financial_statements.py
+++ b/erpnext/accounts/report/financial_statements.py
@@ -790,14 +790,14 @@ def compute_margin_view_data(data, columns, accumulated_values):
 			curr_value = row.get(curr_period)
 
 			if base_value is None or curr_value is None:
-				data[row_idx][curr_period] = "N/A"
+				data[row_idx][curr_period] = None
 				continue
 
 			if base_value == 0:
 				if curr_value == 0:
 					data[row_idx][curr_period] = 0
 				else:
-					data[row_idx][curr_period] = "N/A"
+					data[row_idx][curr_period] = None
 				continue
 
 			margin_percent = round((curr_value / base_value) * 100, 2)

--- a/erpnext/accounts/report/financial_statements.py
+++ b/erpnext/accounts/report/financial_statements.py
@@ -737,6 +737,9 @@ def compute_growth_view_data(data, columns):
 	data_copy = copy.deepcopy(data)
 
 	for row_idx in range(len(data_copy)):
+		if not data_copy[row_idx]:
+			continue
+
 		for column_idx in range(1, len(columns)):
 			previous_period_key = columns[column_idx - 1].get("key")
 			current_period_key = columns[column_idx].get("key")

--- a/erpnext/accounts/report/financial_statements.py
+++ b/erpnext/accounts/report/financial_statements.py
@@ -795,7 +795,7 @@ def compute_margin_view_data(data, columns, accumulated_values):
 
 			if base_value == 0:
 				if curr_value == 0:
-					data[row_idx][curr_period] = ""
+					data[row_idx][curr_period] = 0
 				else:
 					data[row_idx][curr_period] = "N/A"
 				continue

--- a/erpnext/accounts/report/financial_statements.py
+++ b/erpnext/accounts/report/financial_statements.py
@@ -785,11 +785,19 @@ def compute_margin_view_data(data, columns, accumulated_values):
 
 		for column in columns:
 			curr_period = column.get("key")
-			base_value = base_row[curr_period]
-			curr_value = row[curr_period]
 
-			if curr_value is None or base_value <= 0:
-				data[row_idx][curr_period] = None
+			base_value = base_row.get(curr_period)
+			curr_value = row.get(curr_period)
+
+			if base_value is None or curr_value is None:
+				data[row_idx][curr_period] = "N/A"
+				continue
+
+			if base_value == 0:
+				if curr_value == 0:
+					data[row_idx][curr_period] = ""
+				else:
+					data[row_idx][curr_period] = "N/A"
 				continue
 
 			margin_percent = round((curr_value / base_value) * 100, 2)


### PR DESCRIPTION
fix margin calculation and prevent invalid percentage display in Profit and Loss report
- If both base_value and curr_value are 0 → the result will be 0%
- If base_value is 0 and curr_value is not 0 → the result will be displayed as "N/A" (None) the UI will return it 0%
-  If either value is None → display "N/A" (None)  Ensured consistent data contract between backend (Python) and frontend (HTML template)
Before
<img width="1224" height="596" alt="image" src="https://github.com/user-attachments/assets/1f61ffa4-acc5-47ed-8ebf-067e84b17b5b" />
After
<img width="1359" height="592" alt="image" src="https://github.com/user-attachments/assets/5047e735-c5e1-455c-9973-b0bd7d47a669" />
