### PR TITLE
feat: integrate Cerbos PDP for authorization

### DIFF
--- a/cerbos/README.md
+++ b/cerbos/README.md
@@ -1,0 +1,104 @@
+# Cerbos Authorization for ERPNext
+
+This directory wires [Cerbos](https://cerbos.dev) into ERPNext as an external
+Policy Decision Point (PDP). Cerbos owns the **business** authorization rules
+(role + attribute checks, multi-company scoping, document lifecycle, portal
+access) while Frappe's framework continues to handle session, login, and
+DocType existence.
+
+## Layout
+
+```
+cerbos/
+  policies/                  # Cerbos policy bundle
+    _schemas/                # Principal + resource attribute schemas
+    derived_roles/           # Shared roles + exported variables
+    resource_policies/
+      accounts/              # Sales/Purchase Invoice, Payment / Journal Entry
+      buying/                # Supplier, Purchase Order, Purchase Receipt
+      hr/                    # Employee, Leave, Expense, Timesheet
+      projects/              # Project, Task
+      selling/               # Customer, Quotation, Sales Order, Delivery Note
+      stock/                 # Item, Stock Entry
+  config/
+    cerbos.yaml              # PDP configuration
+  docker-compose.yml         # Local PDP
+```
+
+Each `resource_policies/<domain>/` folder ships a policy per resource, a
+`*_test.yaml` suite, and a shared `testdata/` fixture set used by every test
+in the domain.
+
+## Running the PDP locally
+
+```bash
+cd cerbos
+docker compose up -d
+curl http://localhost:3592/_cerbos/health
+```
+
+The PDP exposes:
+
+- HTTP/REST on `:3592`
+- gRPC on `:3593` (used by the Python SDK in `erpnext/cerbos_authz/`)
+
+Edit a `.yaml` under `policies/` and the running PDP picks up the change live
+(`watchForChanges: true`).
+
+## Validating policies
+
+```bash
+docker run --rm -v "$(pwd)/policies:/policies" \
+  ghcr.io/cerbos/cerbos:latest compile /policies
+```
+
+A green run means schemas resolve, every policy compiles, and every test in
+`*_test.yaml` passes.
+
+## How ERPNext talks to the PDP
+
+`erpnext/cerbos_authz/` provides:
+
+- `client.py` — a thread-safe Cerbos client (singleton)
+- `principal.py` — builds the Cerbos principal from `frappe.session.user`
+- `resources.py` — builds the Cerbos resource from a Frappe `Document`
+- `hooks.py` — `has_permission` callbacks registered into ERPNext's
+  `hooks.py` for every doctype with a Cerbos resource policy
+
+When Frappe asks "can user X do action Y on doctype Z?", the callback looks up
+the doctype, builds the principal + resource, calls Cerbos via gRPC, and
+returns a boolean. If the PDP is unreachable the callback fails closed (denies
+access) — so a downed PDP locks the system rather than silently allowing
+everything.
+
+## Adding a new resource
+
+1. Add an attribute schema at `policies/_schemas/resources/<resource>.json`.
+2. Add a policy at `policies/resource_policies/<domain>/<resource>.yaml` and a
+   matching `*_test.yaml`.
+3. Add fixtures to the domain's `testdata/`.
+4. Run `cerbos compile` and confirm exit 0.
+5. Add the DocType → resource mapping in
+   `erpnext/cerbos_authz/resources.py::DOCTYPE_TO_RESOURCE`.
+
+## Spec summary
+
+- **Principal**: Frappe user. Attributes: `user_type`, default `company`,
+  `allowed_companies` (from User Permissions), optional `employee`,
+  `customer`, `supplier`, plus `leave_approver_for` / `expense_approver_for`
+  lists.
+- **Resource**: a Frappe Document. Attributes vary by doctype; common ones
+  are `company`, `owner`, `docstatus`, plus party links (`customer`,
+  `supplier`, `employee`).
+- **Actions**: ERPNext's standard ptypes — `read`, `write`, `create`,
+  `delete`, `submit`, `cancel`, `amend`, `print`, `email`, `export`, `share`,
+  `report`.
+- **Cross-cutting rules**:
+  - Submitted documents (`docstatus == 1`) are not writable or deletable.
+  - Cancelled documents (`docstatus == 2`) cannot be re-submitted /
+    re-cancelled and are the only ones that can be amended.
+  - Region locks: deletion of submitted Sales Invoices / Payment Entries is
+    blocked when `country == "Nepal"` (mirrors
+    `erpnext.regional.check_deletion_permission`).
+  - Portal Customer / Supplier users see only their own party's documents.
+  - Employees self-service their own HR records via `employee == P.employee`.

--- a/cerbos/config/cerbos.yaml
+++ b/cerbos/config/cerbos.yaml
@@ -1,0 +1,25 @@
+# Cerbos PDP configuration for ERPNext
+# Mounted at /config/cerbos.yaml inside the container.
+server:
+  httpListenAddr: ":3592"
+  grpcListenAddr: ":3593"
+  metricsEnabled: true
+  playgroundEnabled: false
+
+storage:
+  driver: disk
+  disk:
+    directory: /policies
+    watchForChanges: true
+
+audit:
+  enabled: true
+  accessLogsEnabled: true
+  decisionLogsEnabled: true
+  backend: local
+  local:
+    storagePath: /audit
+    retentionPeriod: 168h
+
+schema:
+  enforcement: reject

--- a/cerbos/docker-compose.yml
+++ b/cerbos/docker-compose.yml
@@ -1,0 +1,32 @@
+# Cerbos PDP for ERPNext authorization.
+#
+# Run from the cerbos/ directory:
+#   docker compose up -d
+#
+# Cerbos listens on:
+#   - http://localhost:3592   (REST/health)
+#   - localhost:3593          (gRPC, used by the Python SDK)
+#
+# Policies are mounted from ./policies and watched for changes,
+# so edits picked up live without restart.
+services:
+  cerbos:
+    image: ghcr.io/cerbos/cerbos:latest
+    container_name: erpnext-cerbos-pdp
+    command: ["server", "--config=/config/cerbos.yaml"]
+    ports:
+      - "3592:3592"
+      - "3593:3593"
+    volumes:
+      - ./config:/config:ro
+      - ./policies:/policies:ro
+      - cerbos-audit:/audit
+    healthcheck:
+      test: ["CMD", "/cerbos", "healthcheck", "--insecure"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+    restart: unless-stopped
+
+volumes:
+  cerbos-audit:

--- a/cerbos/policies/_schemas/principal.json
+++ b/cerbos/policies/_schemas/principal.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["company", "allowed_companies", "user_type"],
+  "properties": {
+    "user_type": {
+      "type": "string",
+      "enum": ["System User", "Website User"]
+    },
+    "company": {
+      "type": "string",
+      "description": "Default company for the user"
+    },
+    "allowed_companies": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Companies the user is permitted to access"
+    },
+    "employee": {
+      "type": "string",
+      "description": "Linked Employee record id, if any"
+    },
+    "customer": {
+      "type": "string",
+      "description": "Linked Customer record id (portal users)"
+    },
+    "supplier": {
+      "type": "string",
+      "description": "Linked Supplier record id (portal users)"
+    },
+    "department": { "type": "string" },
+    "territory": { "type": "string" },
+    "leave_approver_for": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Employee ids whose leave this user can approve"
+    },
+    "expense_approver_for": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Employee ids whose expenses this user can approve"
+    }
+  }
+}

--- a/cerbos/policies/_schemas/resources/customer.json
+++ b/cerbos/policies/_schemas/resources/customer.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["owner"],
+  "properties": {
+    "owner": { "type": "string" },
+    "territory": { "type": "string" },
+    "customer_group": { "type": "string" },
+    "disabled": { "type": "boolean" }
+  }
+}

--- a/cerbos/policies/_schemas/resources/delivery_note.json
+++ b/cerbos/policies/_schemas/resources/delivery_note.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["company", "docstatus", "owner", "customer"],
+  "properties": {
+    "company": { "type": "string" },
+    "owner": { "type": "string" },
+    "docstatus": { "type": "integer", "enum": [0, 1, 2] },
+    "customer": { "type": "string" },
+    "is_return": { "type": "boolean" }
+  }
+}

--- a/cerbos/policies/_schemas/resources/employee.json
+++ b/cerbos/policies/_schemas/resources/employee.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["company", "owner"],
+  "properties": {
+    "company": { "type": "string" },
+    "owner": { "type": "string" },
+    "user_id": { "type": "string", "description": "User account linked to this Employee" },
+    "department": { "type": "string" },
+    "status": { "type": "string", "enum": ["Active", "Inactive", "Suspended", "Left"] }
+  }
+}

--- a/cerbos/policies/_schemas/resources/expense_claim.json
+++ b/cerbos/policies/_schemas/resources/expense_claim.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["company", "docstatus", "owner", "employee"],
+  "properties": {
+    "company": { "type": "string" },
+    "owner": { "type": "string" },
+    "docstatus": { "type": "integer", "enum": [0, 1, 2] },
+    "employee": { "type": "string" },
+    "approval_status": { "type": "string", "enum": ["Draft", "Approved", "Rejected"] },
+    "expense_approver": { "type": "string" }
+  }
+}

--- a/cerbos/policies/_schemas/resources/item.json
+++ b/cerbos/policies/_schemas/resources/item.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["owner"],
+  "properties": {
+    "owner": { "type": "string" },
+    "item_group": { "type": "string" },
+    "disabled": { "type": "boolean" },
+    "is_stock_item": { "type": "boolean" }
+  }
+}

--- a/cerbos/policies/_schemas/resources/journal_entry.json
+++ b/cerbos/policies/_schemas/resources/journal_entry.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["company", "docstatus", "owner"],
+  "properties": {
+    "company": { "type": "string" },
+    "owner": { "type": "string" },
+    "docstatus": { "type": "integer", "enum": [0, 1, 2] }
+  }
+}

--- a/cerbos/policies/_schemas/resources/leave_application.json
+++ b/cerbos/policies/_schemas/resources/leave_application.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["company", "docstatus", "owner", "employee"],
+  "properties": {
+    "company": { "type": "string" },
+    "owner": { "type": "string" },
+    "docstatus": { "type": "integer", "enum": [0, 1, 2] },
+    "employee": { "type": "string" },
+    "status": { "type": "string", "enum": ["Open", "Approved", "Rejected", "Cancelled"] },
+    "leave_approver": { "type": "string" }
+  }
+}

--- a/cerbos/policies/_schemas/resources/payment_entry.json
+++ b/cerbos/policies/_schemas/resources/payment_entry.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["company", "docstatus", "owner"],
+  "properties": {
+    "company": { "type": "string" },
+    "owner": { "type": "string" },
+    "docstatus": { "type": "integer", "enum": [0, 1, 2] },
+    "payment_type": { "type": "string", "enum": ["Receive", "Pay", "Internal Transfer"] },
+    "country": { "type": "string" }
+  }
+}

--- a/cerbos/policies/_schemas/resources/project.json
+++ b/cerbos/policies/_schemas/resources/project.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["company", "owner"],
+  "properties": {
+    "company": { "type": "string" },
+    "owner": { "type": "string" },
+    "customer": { "type": "string" },
+    "status": { "type": "string" }
+  }
+}

--- a/cerbos/policies/_schemas/resources/purchase_invoice.json
+++ b/cerbos/policies/_schemas/resources/purchase_invoice.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["company", "docstatus", "owner", "supplier"],
+  "properties": {
+    "company": { "type": "string" },
+    "owner": { "type": "string" },
+    "docstatus": { "type": "integer", "enum": [0, 1, 2] },
+    "supplier": { "type": "string" },
+    "is_return": { "type": "boolean" },
+    "country": { "type": "string" }
+  }
+}

--- a/cerbos/policies/_schemas/resources/purchase_order.json
+++ b/cerbos/policies/_schemas/resources/purchase_order.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["company", "docstatus", "owner", "supplier"],
+  "properties": {
+    "company": { "type": "string" },
+    "owner": { "type": "string" },
+    "docstatus": { "type": "integer", "enum": [0, 1, 2] },
+    "supplier": { "type": "string" },
+    "status": { "type": "string" }
+  }
+}

--- a/cerbos/policies/_schemas/resources/purchase_receipt.json
+++ b/cerbos/policies/_schemas/resources/purchase_receipt.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["company", "docstatus", "owner", "supplier"],
+  "properties": {
+    "company": { "type": "string" },
+    "owner": { "type": "string" },
+    "docstatus": { "type": "integer", "enum": [0, 1, 2] },
+    "supplier": { "type": "string" },
+    "is_return": { "type": "boolean" }
+  }
+}

--- a/cerbos/policies/_schemas/resources/quotation.json
+++ b/cerbos/policies/_schemas/resources/quotation.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["company", "docstatus", "owner", "customer"],
+  "properties": {
+    "company": { "type": "string" },
+    "owner": { "type": "string" },
+    "docstatus": { "type": "integer", "enum": [0, 1, 2] },
+    "customer": { "type": "string" },
+    "territory": { "type": "string" },
+    "status": { "type": "string" }
+  }
+}

--- a/cerbos/policies/_schemas/resources/sales_invoice.json
+++ b/cerbos/policies/_schemas/resources/sales_invoice.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["company", "docstatus", "owner", "customer"],
+  "properties": {
+    "company": { "type": "string" },
+    "owner": { "type": "string" },
+    "docstatus": { "type": "integer", "enum": [0, 1, 2] },
+    "customer": { "type": "string" },
+    "is_return": { "type": "boolean" },
+    "country": { "type": "string" }
+  }
+}

--- a/cerbos/policies/_schemas/resources/sales_order.json
+++ b/cerbos/policies/_schemas/resources/sales_order.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["company", "docstatus", "owner", "customer"],
+  "properties": {
+    "company": { "type": "string" },
+    "owner": { "type": "string" },
+    "docstatus": { "type": "integer", "enum": [0, 1, 2] },
+    "customer": { "type": "string" },
+    "status": { "type": "string" }
+  }
+}

--- a/cerbos/policies/_schemas/resources/stock_entry.json
+++ b/cerbos/policies/_schemas/resources/stock_entry.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["company", "docstatus", "owner"],
+  "properties": {
+    "company": { "type": "string" },
+    "owner": { "type": "string" },
+    "docstatus": { "type": "integer", "enum": [0, 1, 2] },
+    "purpose": { "type": "string" }
+  }
+}

--- a/cerbos/policies/_schemas/resources/supplier.json
+++ b/cerbos/policies/_schemas/resources/supplier.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["owner"],
+  "properties": {
+    "owner": { "type": "string" },
+    "supplier_group": { "type": "string" },
+    "disabled": { "type": "boolean" }
+  }
+}

--- a/cerbos/policies/_schemas/resources/task.json
+++ b/cerbos/policies/_schemas/resources/task.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["owner"],
+  "properties": {
+    "owner": { "type": "string" },
+    "project": { "type": "string" },
+    "status": { "type": "string" },
+    "assigned_to": {
+      "type": "array",
+      "items": { "type": "string" }
+    }
+  }
+}

--- a/cerbos/policies/_schemas/resources/timesheet.json
+++ b/cerbos/policies/_schemas/resources/timesheet.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["company", "docstatus", "owner", "employee"],
+  "properties": {
+    "company": { "type": "string" },
+    "owner": { "type": "string" },
+    "docstatus": { "type": "integer", "enum": [0, 1, 2] },
+    "employee": { "type": "string" },
+    "customer": { "type": "string" }
+  }
+}

--- a/cerbos/policies/derived_roles/common_roles.yaml
+++ b/cerbos/policies/derived_roles/common_roles.yaml
@@ -1,0 +1,80 @@
+# yaml-language-server: $schema=https://api.cerbos.dev/latest/cerbos/policy/v1/Policy.schema.json
+apiVersion: api.cerbos.dev/v1
+derivedRoles:
+  name: erpnext_common_roles
+  definitions:
+    # Document creator (Frappe's `owner` field == user id who created the doc).
+    - name: doc_owner
+      parentRoles: ["*"]
+      condition:
+        match:
+          expr: R.attr.owner == P.id
+
+    # Portal Customer accessing documents linked to their Customer record.
+    - name: customer_portal_self
+      parentRoles:
+        - Customer
+      condition:
+        match:
+          all:
+            of:
+              - expr: P.attr.user_type == "Website User"
+              - expr: has(P.attr.customer)
+              - expr: has(R.attr.customer)
+              - expr: R.attr.customer == P.attr.customer
+
+    # Portal Supplier accessing documents linked to their Supplier record.
+    - name: supplier_portal_self
+      parentRoles:
+        - Supplier
+      condition:
+        match:
+          all:
+            of:
+              - expr: P.attr.user_type == "Website User"
+              - expr: has(P.attr.supplier)
+              - expr: has(R.attr.supplier)
+              - expr: R.attr.supplier == P.attr.supplier
+
+    # Employee accessing their own HR document (employee == user.employee).
+    - name: employee_self
+      parentRoles:
+        - Employee
+        - Employee Self Service
+      condition:
+        match:
+          all:
+            of:
+              - expr: has(P.attr.employee)
+              - expr: has(R.attr.employee)
+              - expr: R.attr.employee == P.attr.employee
+
+    # The configured leave approver for the resource's employee.
+    - name: leave_approver_for_employee
+      parentRoles:
+        - HR User
+        - HR Manager
+        - Employee
+        - Employee Self Service
+      condition:
+        match:
+          any:
+            of:
+              - expr: has(R.attr.leave_approver) && R.attr.leave_approver == P.id
+              - expr: has(P.attr.leave_approver_for) && has(R.attr.employee) && R.attr.employee in P.attr.leave_approver_for
+
+    # The configured expense approver for the resource's employee.
+    - name: expense_approver_for_employee
+      parentRoles:
+        - HR User
+        - HR Manager
+        - Accounts User
+        - Accounts Manager
+        - Employee
+        - Employee Self Service
+      condition:
+        match:
+          any:
+            of:
+              - expr: has(R.attr.expense_approver) && R.attr.expense_approver == P.id
+              - expr: has(P.attr.expense_approver_for) && has(R.attr.employee) && R.attr.employee in P.attr.expense_approver_for

--- a/cerbos/policies/derived_roles/common_vars.yaml
+++ b/cerbos/policies/derived_roles/common_vars.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://api.cerbos.dev/latest/cerbos/policy/v1/Policy.schema.json
+apiVersion: api.cerbos.dev/v1
+exportVariables:
+  name: erpnext_common_vars
+  definitions:
+    # Frappe docstatus: 0 = Draft, 1 = Submitted, 2 = Cancelled.
+    is_draft: R.attr.docstatus == 0
+    is_submitted: R.attr.docstatus == 1
+    is_cancelled: R.attr.docstatus == 2
+    # Region-locked deletion: ERPNext blocks deletion of submitted Sales Invoices
+    # / Payment Entries in regulated regions like Nepal.
+    region_locks_deletion: has(R.attr.country) && R.attr.country == "Nepal"
+    # Company-scope check used everywhere a rule is gated by Frappe's
+    # User Permission row-scoping by Company.
+    is_in_company: R.attr.company in P.attr.allowed_companies

--- a/cerbos/policies/resource_policies/accounts/journal_entry.yaml
+++ b/cerbos/policies/resource_policies/accounts/journal_entry.yaml
@@ -1,0 +1,59 @@
+# yaml-language-server: $schema=https://api.cerbos.dev/latest/cerbos/policy/v1/Policy.schema.json
+apiVersion: api.cerbos.dev/v1
+resourcePolicy:
+  version: default
+  resource: journal_entry
+  schemas:
+    principalSchema:
+      ref: cerbos:///principal.json
+    resourceSchema:
+      ref: cerbos:///resources/journal_entry.json
+  importDerivedRoles:
+    - erpnext_common_roles
+  variables:
+    import:
+      - erpnext_common_vars
+  rules:
+    - actions: ["create", "read", "write", "delete", "submit", "cancel", "amend", "print", "email", "export", "share", "report"]
+      effect: EFFECT_ALLOW
+      roles: ["System Manager"]
+      condition:
+        match:
+          expr: V.is_in_company
+
+    - actions: ["create", "read", "write", "submit", "cancel", "amend", "print", "email", "export", "share", "report"]
+      effect: EFFECT_ALLOW
+      roles: ["Accounts Manager"]
+      condition:
+        match:
+          expr: V.is_in_company
+
+    # Accounts User can post Journal Entries but cannot cancel them
+    # (cancellation is gated to Manager-level for audit reasons).
+    - actions: ["create", "read", "write", "submit", "amend", "print", "email", "export", "report"]
+      effect: EFFECT_ALLOW
+      roles: ["Accounts User"]
+      condition:
+        match:
+          expr: V.is_in_company
+
+    - actions: ["write", "delete"]
+      effect: EFFECT_DENY
+      roles: ["*"]
+      condition:
+        match:
+          expr: V.is_submitted
+
+    - actions: ["submit", "cancel"]
+      effect: EFFECT_DENY
+      roles: ["*"]
+      condition:
+        match:
+          expr: V.is_cancelled
+
+    - actions: ["amend"]
+      effect: EFFECT_DENY
+      roles: ["*"]
+      condition:
+        match:
+          expr: "!V.is_cancelled"

--- a/cerbos/policies/resource_policies/accounts/journal_entry_test.yaml
+++ b/cerbos/policies/resource_policies/accounts/journal_entry_test.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://api.cerbos.dev/latest/cerbos/policy/v1/TestSuite.schema.json
+name: JournalEntryPolicyTest
+description: Tests for the Journal Entry resource policy
+
+tests:
+  - name: Accounts User can submit but cannot cancel journal entries
+    input:
+      principals: [accounts_user]
+      resources: [je_draft_acme]
+      actions: [submit, cancel]
+    expected:
+      - principal: accounts_user
+        resource: je_draft_acme
+        actions:
+          submit: EFFECT_ALLOW
+          cancel: EFFECT_DENY
+
+  - name: Accounts Manager can cancel submitted journal entries
+    input:
+      principals: [accounts_manager]
+      resources: [je_submitted_acme]
+      actions: [cancel, write]
+    expected:
+      - principal: accounts_manager
+        resource: je_submitted_acme
+        actions:
+          cancel: EFFECT_ALLOW
+          write: EFFECT_DENY

--- a/cerbos/policies/resource_policies/accounts/payment_entry.yaml
+++ b/cerbos/policies/resource_policies/accounts/payment_entry.yaml
@@ -1,0 +1,68 @@
+# yaml-language-server: $schema=https://api.cerbos.dev/latest/cerbos/policy/v1/Policy.schema.json
+apiVersion: api.cerbos.dev/v1
+resourcePolicy:
+  version: default
+  resource: payment_entry
+  schemas:
+    principalSchema:
+      ref: cerbos:///principal.json
+    resourceSchema:
+      ref: cerbos:///resources/payment_entry.json
+  importDerivedRoles:
+    - erpnext_common_roles
+  variables:
+    import:
+      - erpnext_common_vars
+  rules:
+    - actions: ["create", "read", "write", "delete", "submit", "cancel", "amend", "print", "email", "export", "share", "report"]
+      effect: EFFECT_ALLOW
+      roles: ["System Manager"]
+      condition:
+        match:
+          expr: V.is_in_company
+
+    - actions: ["create", "read", "write", "submit", "cancel", "amend", "print", "email", "export", "share", "report"]
+      effect: EFFECT_ALLOW
+      roles: ["Accounts Manager"]
+      condition:
+        match:
+          expr: V.is_in_company
+
+    - actions: ["create", "read", "write", "submit", "cancel", "amend", "print", "email", "export", "report"]
+      effect: EFFECT_ALLOW
+      roles: ["Accounts User"]
+      condition:
+        match:
+          expr: V.is_in_company
+
+    # Region lock: deletion blocked for submitted/cancelled in Nepal.
+    - actions: ["delete"]
+      effect: EFFECT_DENY
+      roles: ["*"]
+      condition:
+        match:
+          all:
+            of:
+              - expr: V.region_locks_deletion
+              - expr: R.attr.docstatus != 0
+
+    - actions: ["write", "delete"]
+      effect: EFFECT_DENY
+      roles: ["*"]
+      condition:
+        match:
+          expr: V.is_submitted
+
+    - actions: ["submit", "cancel"]
+      effect: EFFECT_DENY
+      roles: ["*"]
+      condition:
+        match:
+          expr: V.is_cancelled
+
+    - actions: ["amend"]
+      effect: EFFECT_DENY
+      roles: ["*"]
+      condition:
+        match:
+          expr: "!V.is_cancelled"

--- a/cerbos/policies/resource_policies/accounts/payment_entry_test.yaml
+++ b/cerbos/policies/resource_policies/accounts/payment_entry_test.yaml
@@ -1,0 +1,41 @@
+# yaml-language-server: $schema=https://api.cerbos.dev/latest/cerbos/policy/v1/TestSuite.schema.json
+name: PaymentEntryPolicyTest
+description: Tests for the Payment Entry resource policy
+
+tests:
+  - name: Accounts Manager full lifecycle on draft payment entry
+    input:
+      principals: [accounts_manager]
+      resources: [pe_draft_acme]
+      actions: [create, read, write, submit]
+    expected:
+      - principal: accounts_manager
+        resource: pe_draft_acme
+        actions:
+          create: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          write: EFFECT_ALLOW
+          submit: EFFECT_ALLOW
+
+  - name: Region lock blocks deletion of submitted PE in Nepal
+    input:
+      principals: [system_manager]
+      resources: [pe_submitted_nepal]
+      actions: [delete]
+    expected:
+      - principal: system_manager
+        resource: pe_submitted_nepal
+        actions:
+          delete: EFFECT_DENY
+
+  - name: Sales User has no access to payment entries
+    input:
+      principals: [sales_user]
+      resources: [pe_draft_acme]
+      actions: [read, write]
+    expected:
+      - principal: sales_user
+        resource: pe_draft_acme
+        actions:
+          read: EFFECT_DENY
+          write: EFFECT_DENY

--- a/cerbos/policies/resource_policies/accounts/purchase_invoice.yaml
+++ b/cerbos/policies/resource_policies/accounts/purchase_invoice.yaml
@@ -1,0 +1,70 @@
+# yaml-language-server: $schema=https://api.cerbos.dev/latest/cerbos/policy/v1/Policy.schema.json
+apiVersion: api.cerbos.dev/v1
+resourcePolicy:
+  version: default
+  resource: purchase_invoice
+  schemas:
+    principalSchema:
+      ref: cerbos:///principal.json
+    resourceSchema:
+      ref: cerbos:///resources/purchase_invoice.json
+  importDerivedRoles:
+    - erpnext_common_roles
+  variables:
+    import:
+      - erpnext_common_vars
+  rules:
+    - actions: ["create", "read", "write", "delete", "submit", "cancel", "amend", "print", "email", "export", "share", "report"]
+      effect: EFFECT_ALLOW
+      roles: ["System Manager"]
+      condition:
+        match:
+          expr: V.is_in_company
+
+    - actions: ["create", "read", "write", "submit", "cancel", "amend", "print", "email", "export", "share", "report"]
+      effect: EFFECT_ALLOW
+      roles: ["Accounts Manager"]
+      condition:
+        match:
+          expr: V.is_in_company
+
+    - actions: ["create", "read", "write", "submit", "cancel", "amend", "print", "email", "export", "report"]
+      effect: EFFECT_ALLOW
+      roles: ["Accounts User"]
+      condition:
+        match:
+          expr: V.is_in_company
+
+    # Purchase managers/users: read & report (visibility into AP cycle).
+    - actions: ["read", "print", "email", "export", "report"]
+      effect: EFFECT_ALLOW
+      roles: ["Purchase Manager", "Purchase User"]
+      condition:
+        match:
+          expr: V.is_in_company
+
+    # Supplier portal: read own invoices only.
+    - actions: ["read", "print"]
+      effect: EFFECT_ALLOW
+      derivedRoles: [supplier_portal_self]
+
+    - actions: ["write", "delete"]
+      effect: EFFECT_DENY
+      roles: ["*"]
+      condition:
+        match:
+          expr: V.is_submitted
+
+    - actions: ["submit", "cancel"]
+      effect: EFFECT_DENY
+      roles: ["*"]
+      condition:
+        match:
+          expr: V.is_cancelled
+
+    - actions: ["amend"]
+      effect: EFFECT_DENY
+      roles: ["*"]
+      condition:
+        match:
+          expr: "!V.is_cancelled"

--- a/cerbos/policies/resource_policies/accounts/purchase_invoice_test.yaml
+++ b/cerbos/policies/resource_policies/accounts/purchase_invoice_test.yaml
@@ -1,0 +1,68 @@
+# yaml-language-server: $schema=https://api.cerbos.dev/latest/cerbos/policy/v1/TestSuite.schema.json
+name: PurchaseInvoicePolicyTest
+description: Tests for the Purchase Invoice resource policy
+
+tests:
+  - name: Accounts User creates and submits draft purchase invoice
+    input:
+      principals: [accounts_user]
+      resources: [pinv_draft_acme]
+      actions: [create, read, write, submit]
+    expected:
+      - principal: accounts_user
+        resource: pinv_draft_acme
+        actions:
+          create: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          write: EFFECT_ALLOW
+          submit: EFFECT_ALLOW
+
+  - name: Submitted invoice cannot be edited
+    input:
+      principals: [accounts_manager]
+      resources: [pinv_submitted_acme]
+      actions: [write, cancel]
+    expected:
+      - principal: accounts_manager
+        resource: pinv_submitted_acme
+        actions:
+          write: EFFECT_DENY
+          cancel: EFFECT_ALLOW
+
+  - name: Supplier portal can read their own invoice only
+    input:
+      principals: [supplier_portal_user]
+      resources: [pinv_draft_acme, pinv_other_supplier]
+      actions: [read]
+    expected:
+      - principal: supplier_portal_user
+        resource: pinv_draft_acme
+        actions:
+          read: EFFECT_ALLOW
+      - principal: supplier_portal_user
+        resource: pinv_other_supplier
+        actions:
+          read: EFFECT_DENY
+
+  - name: Customer portal user has no access to purchase invoices
+    input:
+      principals: [customer_portal_user]
+      resources: [pinv_draft_acme]
+      actions: [read]
+    expected:
+      - principal: customer_portal_user
+        resource: pinv_draft_acme
+        actions:
+          read: EFFECT_DENY
+
+  - name: Purchase User has read-only visibility
+    input:
+      principals: [purchase_user]
+      resources: [pinv_draft_acme]
+      actions: [read, write]
+    expected:
+      - principal: purchase_user
+        resource: pinv_draft_acme
+        actions:
+          read: EFFECT_ALLOW
+          write: EFFECT_DENY

--- a/cerbos/policies/resource_policies/accounts/sales_invoice.yaml
+++ b/cerbos/policies/resource_policies/accounts/sales_invoice.yaml
@@ -1,0 +1,89 @@
+# yaml-language-server: $schema=https://api.cerbos.dev/latest/cerbos/policy/v1/Policy.schema.json
+apiVersion: api.cerbos.dev/v1
+resourcePolicy:
+  version: default
+  resource: sales_invoice
+  schemas:
+    principalSchema:
+      ref: cerbos:///principal.json
+    resourceSchema:
+      ref: cerbos:///resources/sales_invoice.json
+  importDerivedRoles:
+    - erpnext_common_roles
+  variables:
+    import:
+      - erpnext_common_vars
+  rules:
+    # System Manager has full access within allowed companies.
+    - actions: ["create", "read", "write", "delete", "submit", "cancel", "amend", "print", "email", "export", "share", "report"]
+      effect: EFFECT_ALLOW
+      roles: ["System Manager"]
+      condition:
+        match:
+          expr: V.is_in_company
+
+    # Accounts Manager: full lifecycle within company.
+    - actions: ["create", "read", "write", "submit", "cancel", "amend", "print", "email", "export", "share", "report"]
+      effect: EFFECT_ALLOW
+      roles: ["Accounts Manager"]
+      condition:
+        match:
+          expr: V.is_in_company
+
+    # Accounts User: full lifecycle except cross-company; cannot delete.
+    - actions: ["create", "read", "write", "submit", "cancel", "amend", "print", "email", "export", "report"]
+      effect: EFFECT_ALLOW
+      roles: ["Accounts User"]
+      condition:
+        match:
+          expr: V.is_in_company
+
+    # Sales Manager / Sales User: read & report on invoices for their company
+    # (visibility into the AR cycle), no write.
+    - actions: ["read", "print", "email", "export", "report"]
+      effect: EFFECT_ALLOW
+      roles: ["Sales Manager", "Sales User"]
+      condition:
+        match:
+          expr: V.is_in_company
+
+    # Customer portal: read their own invoices.
+    - actions: ["read", "print"]
+      effect: EFFECT_ALLOW
+      derivedRoles: [customer_portal_self]
+
+    # Region lock: even with permission, deletion of submitted invoices is
+    # blocked in regulated regions (Nepal). Mirrors regional.check_deletion_permission.
+    - actions: ["delete"]
+      effect: EFFECT_DENY
+      roles: ["*"]
+      condition:
+        match:
+          all:
+            of:
+              - expr: V.region_locks_deletion
+              - expr: R.attr.docstatus != 0
+
+    # Submitted/cancelled docs cannot be edited or deleted (Frappe invariant).
+    - actions: ["write", "delete"]
+      effect: EFFECT_DENY
+      roles: ["*"]
+      condition:
+        match:
+          expr: V.is_submitted
+
+    # Cancelled documents cannot be re-submitted or re-cancelled.
+    - actions: ["submit", "cancel"]
+      effect: EFFECT_DENY
+      roles: ["*"]
+      condition:
+        match:
+          expr: V.is_cancelled
+
+    # Amend is only meaningful for cancelled documents.
+    - actions: ["amend"]
+      effect: EFFECT_DENY
+      roles: ["*"]
+      condition:
+        match:
+          expr: "!V.is_cancelled"

--- a/cerbos/policies/resource_policies/accounts/sales_invoice_test.yaml
+++ b/cerbos/policies/resource_policies/accounts/sales_invoice_test.yaml
@@ -1,0 +1,128 @@
+# yaml-language-server: $schema=https://api.cerbos.dev/latest/cerbos/policy/v1/TestSuite.schema.json
+name: SalesInvoicePolicyTest
+description: Tests for the Sales Invoice resource policy
+
+tests:
+  - name: Accounts User can create/read/write/submit a draft invoice in their company
+    input:
+      principals: [accounts_user]
+      resources: [sinv_draft_acme]
+      actions: [create, read, write, submit, print]
+    expected:
+      - principal: accounts_user
+        resource: sinv_draft_acme
+        actions:
+          create: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          write: EFFECT_ALLOW
+          submit: EFFECT_ALLOW
+          print: EFFECT_ALLOW
+
+  - name: Accounts User cannot delete (no delete permission for that role)
+    input:
+      principals: [accounts_user]
+      resources: [sinv_draft_acme]
+      actions: [delete]
+    expected:
+      - principal: accounts_user
+        resource: sinv_draft_acme
+        actions:
+          delete: EFFECT_DENY
+
+  - name: Accounts Manager can cancel a submitted invoice
+    input:
+      principals: [accounts_manager]
+      resources: [sinv_submitted_acme]
+      actions: [cancel, write]
+    expected:
+      - principal: accounts_manager
+        resource: sinv_submitted_acme
+        actions:
+          cancel: EFFECT_ALLOW
+          write: EFFECT_DENY
+
+  - name: Submitted invoices cannot be edited even by System Manager
+    input:
+      principals: [system_manager]
+      resources: [sinv_submitted_acme]
+      actions: [write, delete]
+    expected:
+      - principal: system_manager
+        resource: sinv_submitted_acme
+        actions:
+          write: EFFECT_DENY
+          delete: EFFECT_DENY
+
+  - name: Cancelled invoice can be amended but not re-submitted
+    input:
+      principals: [accounts_manager]
+      resources: [sinv_cancelled_acme]
+      actions: [amend, submit, cancel]
+    expected:
+      - principal: accounts_manager
+        resource: sinv_cancelled_acme
+        actions:
+          amend: EFFECT_ALLOW
+          submit: EFFECT_DENY
+          cancel: EFFECT_DENY
+
+  - name: Region lock blocks deletion of submitted invoice in Nepal
+    input:
+      principals: [system_manager]
+      resources: [sinv_submitted_nepal]
+      actions: [delete]
+    expected:
+      - principal: system_manager
+        resource: sinv_submitted_nepal
+        actions:
+          delete: EFFECT_DENY
+
+  - name: Customer portal user can read their own invoice
+    input:
+      principals: [customer_portal_user]
+      resources: [sinv_draft_acme]
+      actions: [read, print, write]
+    expected:
+      - principal: customer_portal_user
+        resource: sinv_draft_acme
+        actions:
+          read: EFFECT_ALLOW
+          print: EFFECT_ALLOW
+          write: EFFECT_DENY
+
+  - name: Customer portal user cannot read another customer's invoice
+    input:
+      principals: [customer_portal_user]
+      resources: [sinv_other_customer]
+      actions: [read]
+    expected:
+      - principal: customer_portal_user
+        resource: sinv_other_customer
+        actions:
+          read: EFFECT_DENY
+
+  - name: Other-company Accounts User cannot access Acme invoices
+    input:
+      principals: [other_company_acct_user]
+      resources: [sinv_draft_acme]
+      actions: [read, write, submit]
+    expected:
+      - principal: other_company_acct_user
+        resource: sinv_draft_acme
+        actions:
+          read: EFFECT_DENY
+          write: EFFECT_DENY
+          submit: EFFECT_DENY
+
+  - name: Sales User has read-only visibility into invoices
+    input:
+      principals: [sales_user]
+      resources: [sinv_draft_acme]
+      actions: [read, write, submit]
+    expected:
+      - principal: sales_user
+        resource: sinv_draft_acme
+        actions:
+          read: EFFECT_ALLOW
+          write: EFFECT_DENY
+          submit: EFFECT_DENY

--- a/cerbos/policies/resource_policies/accounts/testdata/principals.yaml
+++ b/cerbos/policies/resource_policies/accounts/testdata/principals.yaml
@@ -1,0 +1,75 @@
+# yaml-language-server: $schema=https://api.cerbos.dev/latest/cerbos/policy/v1/TestFixture/Principals.schema.json
+principals:
+  system_manager:
+    id: "sysmgr@acme.test"
+    roles:
+      - System Manager
+    attr:
+      user_type: System User
+      company: Acme
+      allowed_companies: ["Acme"]
+
+  accounts_manager:
+    id: "acct.mgr@acme.test"
+    roles:
+      - Accounts Manager
+    attr:
+      user_type: System User
+      company: Acme
+      allowed_companies: ["Acme"]
+
+  accounts_user:
+    id: "acct.user@acme.test"
+    roles:
+      - Accounts User
+    attr:
+      user_type: System User
+      company: Acme
+      allowed_companies: ["Acme"]
+
+  sales_user:
+    id: "sales.user@acme.test"
+    roles:
+      - Sales User
+    attr:
+      user_type: System User
+      company: Acme
+      allowed_companies: ["Acme"]
+
+  purchase_user:
+    id: "purch.user@acme.test"
+    roles:
+      - Purchase User
+    attr:
+      user_type: System User
+      company: Acme
+      allowed_companies: ["Acme"]
+
+  customer_portal_user:
+    id: "alice@bigco.test"
+    roles:
+      - Customer
+    attr:
+      user_type: Website User
+      company: Acme
+      allowed_companies: []
+      customer: "BigCo"
+
+  supplier_portal_user:
+    id: "bob@megasupply.test"
+    roles:
+      - Supplier
+    attr:
+      user_type: Website User
+      company: Acme
+      allowed_companies: []
+      supplier: "MegaSupply"
+
+  other_company_acct_user:
+    id: "acct.user@globex.test"
+    roles:
+      - Accounts User
+    attr:
+      user_type: System User
+      company: Globex
+      allowed_companies: ["Globex"]

--- a/cerbos/policies/resource_policies/accounts/testdata/resources.yaml
+++ b/cerbos/policies/resource_policies/accounts/testdata/resources.yaml
@@ -1,0 +1,121 @@
+# yaml-language-server: $schema=https://api.cerbos.dev/latest/cerbos/policy/v1/TestFixture/Resources.schema.json
+resources:
+  # --- Sales Invoices ---
+  sinv_draft_acme:
+    kind: sales_invoice
+    id: SINV-001
+    attr:
+      company: Acme
+      owner: acct.user@acme.test
+      docstatus: 0
+      customer: BigCo
+      country: India
+
+  sinv_submitted_acme:
+    kind: sales_invoice
+    id: SINV-002
+    attr:
+      company: Acme
+      owner: acct.user@acme.test
+      docstatus: 1
+      customer: BigCo
+      country: India
+
+  sinv_cancelled_acme:
+    kind: sales_invoice
+    id: SINV-003
+    attr:
+      company: Acme
+      owner: acct.user@acme.test
+      docstatus: 2
+      customer: BigCo
+      country: India
+
+  sinv_submitted_nepal:
+    kind: sales_invoice
+    id: SINV-004
+    attr:
+      company: Acme
+      owner: acct.user@acme.test
+      docstatus: 1
+      customer: BigCo
+      country: Nepal
+
+  sinv_other_customer:
+    kind: sales_invoice
+    id: SINV-005
+    attr:
+      company: Acme
+      owner: acct.user@acme.test
+      docstatus: 0
+      customer: SmallCorp
+      country: India
+
+  # --- Purchase Invoices ---
+  pinv_draft_acme:
+    kind: purchase_invoice
+    id: PINV-001
+    attr:
+      company: Acme
+      owner: acct.user@acme.test
+      docstatus: 0
+      supplier: MegaSupply
+      country: India
+
+  pinv_submitted_acme:
+    kind: purchase_invoice
+    id: PINV-002
+    attr:
+      company: Acme
+      owner: acct.user@acme.test
+      docstatus: 1
+      supplier: MegaSupply
+      country: India
+
+  pinv_other_supplier:
+    kind: purchase_invoice
+    id: PINV-003
+    attr:
+      company: Acme
+      owner: acct.user@acme.test
+      docstatus: 0
+      supplier: SmallSupply
+      country: India
+
+  # --- Payment Entries ---
+  pe_draft_acme:
+    kind: payment_entry
+    id: PE-001
+    attr:
+      company: Acme
+      owner: acct.user@acme.test
+      docstatus: 0
+      payment_type: Receive
+      country: India
+
+  pe_submitted_nepal:
+    kind: payment_entry
+    id: PE-002
+    attr:
+      company: Acme
+      owner: acct.user@acme.test
+      docstatus: 1
+      payment_type: Receive
+      country: Nepal
+
+  # --- Journal Entries ---
+  je_draft_acme:
+    kind: journal_entry
+    id: JE-001
+    attr:
+      company: Acme
+      owner: acct.user@acme.test
+      docstatus: 0
+
+  je_submitted_acme:
+    kind: journal_entry
+    id: JE-002
+    attr:
+      company: Acme
+      owner: acct.user@acme.test
+      docstatus: 1

--- a/cerbos/policies/resource_policies/buying/purchase_order.yaml
+++ b/cerbos/policies/resource_policies/buying/purchase_order.yaml
@@ -1,0 +1,68 @@
+# yaml-language-server: $schema=https://api.cerbos.dev/latest/cerbos/policy/v1/Policy.schema.json
+apiVersion: api.cerbos.dev/v1
+resourcePolicy:
+  version: default
+  resource: purchase_order
+  schemas:
+    principalSchema:
+      ref: cerbos:///principal.json
+    resourceSchema:
+      ref: cerbos:///resources/purchase_order.json
+  importDerivedRoles:
+    - erpnext_common_roles
+  variables:
+    import:
+      - erpnext_common_vars
+  rules:
+    - actions: ["create", "read", "write", "delete", "submit", "cancel", "amend", "print", "email", "export", "share", "report"]
+      effect: EFFECT_ALLOW
+      roles: ["System Manager"]
+      condition:
+        match:
+          expr: V.is_in_company
+
+    - actions: ["create", "read", "write", "submit", "cancel", "amend", "print", "email", "export", "share", "report"]
+      effect: EFFECT_ALLOW
+      roles: ["Purchase Manager"]
+      condition:
+        match:
+          expr: V.is_in_company
+
+    - actions: ["create", "read", "write", "submit", "cancel", "amend", "print", "email", "export", "report"]
+      effect: EFFECT_ALLOW
+      roles: ["Purchase User"]
+      condition:
+        match:
+          expr: V.is_in_company
+
+    - actions: ["read", "print", "export", "report"]
+      effect: EFFECT_ALLOW
+      roles: ["Stock User", "Stock Manager", "Accounts User", "Accounts Manager"]
+      condition:
+        match:
+          expr: V.is_in_company
+
+    - actions: ["read", "print"]
+      effect: EFFECT_ALLOW
+      derivedRoles: [supplier_portal_self]
+
+    - actions: ["write", "delete"]
+      effect: EFFECT_DENY
+      roles: ["*"]
+      condition:
+        match:
+          expr: V.is_submitted
+
+    - actions: ["submit", "cancel"]
+      effect: EFFECT_DENY
+      roles: ["*"]
+      condition:
+        match:
+          expr: V.is_cancelled
+
+    - actions: ["amend"]
+      effect: EFFECT_DENY
+      roles: ["*"]
+      condition:
+        match:
+          expr: "!V.is_cancelled"

--- a/cerbos/policies/resource_policies/buying/purchase_order_test.yaml
+++ b/cerbos/policies/resource_policies/buying/purchase_order_test.yaml
@@ -1,0 +1,55 @@
+# yaml-language-server: $schema=https://api.cerbos.dev/latest/cerbos/policy/v1/TestSuite.schema.json
+name: PurchaseOrderPolicyTest
+tests:
+  - name: Purchase User can submit POs in their company
+    input:
+      principals: [purchase_user]
+      resources: [po_draft]
+      actions: [create, read, write, submit]
+    expected:
+      - principal: purchase_user
+        resource: po_draft
+        actions:
+          create: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          write: EFFECT_ALLOW
+          submit: EFFECT_ALLOW
+
+  - name: Submitted PO is locked from edits
+    input:
+      principals: [purchase_manager]
+      resources: [po_submitted]
+      actions: [write, cancel]
+    expected:
+      - principal: purchase_manager
+        resource: po_submitted
+        actions:
+          write: EFFECT_DENY
+          cancel: EFFECT_ALLOW
+
+  - name: Supplier portal sees own PO only
+    input:
+      principals: [supplier_portal_user]
+      resources: [po_draft, po_other_supplier]
+      actions: [read]
+    expected:
+      - principal: supplier_portal_user
+        resource: po_draft
+        actions:
+          read: EFFECT_ALLOW
+      - principal: supplier_portal_user
+        resource: po_other_supplier
+        actions:
+          read: EFFECT_DENY
+
+  - name: Stock User has read-only access to POs
+    input:
+      principals: [stock_user]
+      resources: [po_draft]
+      actions: [read, write]
+    expected:
+      - principal: stock_user
+        resource: po_draft
+        actions:
+          read: EFFECT_ALLOW
+          write: EFFECT_DENY

--- a/cerbos/policies/resource_policies/buying/purchase_receipt.yaml
+++ b/cerbos/policies/resource_policies/buying/purchase_receipt.yaml
@@ -1,0 +1,61 @@
+# yaml-language-server: $schema=https://api.cerbos.dev/latest/cerbos/policy/v1/Policy.schema.json
+apiVersion: api.cerbos.dev/v1
+resourcePolicy:
+  version: default
+  resource: purchase_receipt
+  schemas:
+    principalSchema:
+      ref: cerbos:///principal.json
+    resourceSchema:
+      ref: cerbos:///resources/purchase_receipt.json
+  importDerivedRoles:
+    - erpnext_common_roles
+  variables:
+    import:
+      - erpnext_common_vars
+  rules:
+    - actions: ["create", "read", "write", "delete", "submit", "cancel", "amend", "print", "email", "export", "share", "report"]
+      effect: EFFECT_ALLOW
+      roles: ["System Manager"]
+      condition:
+        match:
+          expr: V.is_in_company
+
+    - actions: ["create", "read", "write", "submit", "cancel", "amend", "print", "email", "export", "share", "report"]
+      effect: EFFECT_ALLOW
+      roles: ["Stock Manager", "Purchase Manager"]
+      condition:
+        match:
+          expr: V.is_in_company
+
+    - actions: ["create", "read", "write", "submit", "cancel", "amend", "print", "email", "export", "report"]
+      effect: EFFECT_ALLOW
+      roles: ["Stock User", "Purchase User"]
+      condition:
+        match:
+          expr: V.is_in_company
+
+    - actions: ["read", "print"]
+      effect: EFFECT_ALLOW
+      derivedRoles: [supplier_portal_self]
+
+    - actions: ["write", "delete"]
+      effect: EFFECT_DENY
+      roles: ["*"]
+      condition:
+        match:
+          expr: V.is_submitted
+
+    - actions: ["submit", "cancel"]
+      effect: EFFECT_DENY
+      roles: ["*"]
+      condition:
+        match:
+          expr: V.is_cancelled
+
+    - actions: ["amend"]
+      effect: EFFECT_DENY
+      roles: ["*"]
+      condition:
+        match:
+          expr: "!V.is_cancelled"

--- a/cerbos/policies/resource_policies/buying/purchase_receipt_test.yaml
+++ b/cerbos/policies/resource_policies/buying/purchase_receipt_test.yaml
@@ -1,0 +1,38 @@
+# yaml-language-server: $schema=https://api.cerbos.dev/latest/cerbos/policy/v1/TestSuite.schema.json
+name: PurchaseReceiptPolicyTest
+tests:
+  - name: Stock User can submit purchase receipts
+    input:
+      principals: [stock_user]
+      resources: [pr_draft]
+      actions: [create, read, write, submit]
+    expected:
+      - principal: stock_user
+        resource: pr_draft
+        actions:
+          create: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          write: EFFECT_ALLOW
+          submit: EFFECT_ALLOW
+
+  - name: Purchase User can also submit purchase receipts
+    input:
+      principals: [purchase_user]
+      resources: [pr_draft]
+      actions: [submit]
+    expected:
+      - principal: purchase_user
+        resource: pr_draft
+        actions:
+          submit: EFFECT_ALLOW
+
+  - name: Sales User has no access to purchase receipts
+    input:
+      principals: [sales_user]
+      resources: [pr_draft]
+      actions: [read]
+    expected:
+      - principal: sales_user
+        resource: pr_draft
+        actions:
+          read: EFFECT_DENY

--- a/cerbos/policies/resource_policies/buying/supplier.yaml
+++ b/cerbos/policies/resource_policies/buying/supplier.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://api.cerbos.dev/latest/cerbos/policy/v1/Policy.schema.json
+apiVersion: api.cerbos.dev/v1
+resourcePolicy:
+  version: default
+  resource: supplier
+  schemas:
+    principalSchema:
+      ref: cerbos:///principal.json
+    resourceSchema:
+      ref: cerbos:///resources/supplier.json
+  rules:
+    - actions: ["create", "read", "write", "delete", "print", "email", "export", "share", "report"]
+      effect: EFFECT_ALLOW
+      roles: ["System Manager", "Purchase Master Manager"]
+
+    - actions: ["create", "read", "write", "print", "email", "export", "report"]
+      effect: EFFECT_ALLOW
+      roles: ["Purchase Manager", "Purchase User"]
+
+    - actions: ["read", "print", "export", "report"]
+      effect: EFFECT_ALLOW
+      roles: ["Accounts User", "Accounts Manager", "Stock User", "Stock Manager"]

--- a/cerbos/policies/resource_policies/buying/supplier_test.yaml
+++ b/cerbos/policies/resource_policies/buying/supplier_test.yaml
@@ -1,0 +1,38 @@
+# yaml-language-server: $schema=https://api.cerbos.dev/latest/cerbos/policy/v1/TestSuite.schema.json
+name: SupplierPolicyTest
+tests:
+  - name: Purchase User can manage suppliers (no delete)
+    input:
+      principals: [purchase_user]
+      resources: [supplier_megasupply]
+      actions: [create, read, write, delete]
+    expected:
+      - principal: purchase_user
+        resource: supplier_megasupply
+        actions:
+          create: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          write: EFFECT_ALLOW
+          delete: EFFECT_DENY
+
+  - name: Purchase Master Manager can delete suppliers
+    input:
+      principals: [purchase_master_manager]
+      resources: [supplier_megasupply]
+      actions: [delete]
+    expected:
+      - principal: purchase_master_manager
+        resource: supplier_megasupply
+        actions:
+          delete: EFFECT_ALLOW
+
+  - name: Sales User has no access to suppliers
+    input:
+      principals: [sales_user]
+      resources: [supplier_megasupply]
+      actions: [read]
+    expected:
+      - principal: sales_user
+        resource: supplier_megasupply
+        actions:
+          read: EFFECT_DENY

--- a/cerbos/policies/resource_policies/buying/testdata/principals.yaml
+++ b/cerbos/policies/resource_policies/buying/testdata/principals.yaml
@@ -1,0 +1,75 @@
+# yaml-language-server: $schema=https://api.cerbos.dev/latest/cerbos/policy/v1/TestFixture/Principals.schema.json
+principals:
+  system_manager:
+    id: "sysmgr@acme.test"
+    roles: [System Manager]
+    attr:
+      user_type: System User
+      company: Acme
+      allowed_companies: ["Acme"]
+
+  purchase_manager:
+    id: "purch.mgr@acme.test"
+    roles: [Purchase Manager]
+    attr:
+      user_type: System User
+      company: Acme
+      allowed_companies: ["Acme"]
+
+  purchase_user:
+    id: "purch.user@acme.test"
+    roles: [Purchase User]
+    attr:
+      user_type: System User
+      company: Acme
+      allowed_companies: ["Acme"]
+
+  purchase_master_manager:
+    id: "pmm@acme.test"
+    roles: [Purchase Master Manager]
+    attr:
+      user_type: System User
+      company: Acme
+      allowed_companies: ["Acme"]
+
+  stock_user:
+    id: "stock.user@acme.test"
+    roles: [Stock User]
+    attr:
+      user_type: System User
+      company: Acme
+      allowed_companies: ["Acme"]
+
+  accounts_user:
+    id: "acct.user@acme.test"
+    roles: [Accounts User]
+    attr:
+      user_type: System User
+      company: Acme
+      allowed_companies: ["Acme"]
+
+  sales_user:
+    id: "sales.user@acme.test"
+    roles: [Sales User]
+    attr:
+      user_type: System User
+      company: Acme
+      allowed_companies: ["Acme"]
+
+  supplier_portal_user:
+    id: "bob@megasupply.test"
+    roles: [Supplier]
+    attr:
+      user_type: Website User
+      company: Acme
+      allowed_companies: []
+      supplier: "MegaSupply"
+
+  other_supplier_portal_user:
+    id: "dave@smallsupply.test"
+    roles: [Supplier]
+    attr:
+      user_type: Website User
+      company: Acme
+      allowed_companies: []
+      supplier: "SmallSupply"

--- a/cerbos/policies/resource_policies/buying/testdata/resources.yaml
+++ b/cerbos/policies/resource_policies/buying/testdata/resources.yaml
@@ -1,0 +1,49 @@
+# yaml-language-server: $schema=https://api.cerbos.dev/latest/cerbos/policy/v1/TestFixture/Resources.schema.json
+resources:
+  supplier_megasupply:
+    kind: supplier
+    id: MegaSupply
+    attr:
+      owner: purch.user@acme.test
+      supplier_group: Goods
+      disabled: false
+
+  po_draft:
+    kind: purchase_order
+    id: PO-001
+    attr:
+      company: Acme
+      owner: purch.user@acme.test
+      docstatus: 0
+      supplier: MegaSupply
+      status: Draft
+
+  po_submitted:
+    kind: purchase_order
+    id: PO-002
+    attr:
+      company: Acme
+      owner: purch.user@acme.test
+      docstatus: 1
+      supplier: MegaSupply
+      status: To Receive
+
+  po_other_supplier:
+    kind: purchase_order
+    id: PO-003
+    attr:
+      company: Acme
+      owner: purch.user@acme.test
+      docstatus: 0
+      supplier: SmallSupply
+      status: Draft
+
+  pr_draft:
+    kind: purchase_receipt
+    id: PR-001
+    attr:
+      company: Acme
+      owner: stock.user@acme.test
+      docstatus: 0
+      supplier: MegaSupply
+      is_return: false

--- a/cerbos/policies/resource_policies/hr/employee.yaml
+++ b/cerbos/policies/resource_policies/hr/employee.yaml
@@ -1,0 +1,45 @@
+# yaml-language-server: $schema=https://api.cerbos.dev/latest/cerbos/policy/v1/Policy.schema.json
+apiVersion: api.cerbos.dev/v1
+resourcePolicy:
+  version: default
+  resource: employee
+  schemas:
+    principalSchema:
+      ref: cerbos:///principal.json
+    resourceSchema:
+      ref: cerbos:///resources/employee.json
+  importDerivedRoles:
+    - erpnext_common_roles
+  rules:
+    - actions: ["create", "read", "write", "delete", "print", "email", "export", "share", "report"]
+      effect: EFFECT_ALLOW
+      condition:
+        match:
+          expr: R.attr.company in P.attr.allowed_companies
+      roles: ["System Manager"]
+
+    - actions: ["create", "read", "write", "delete", "print", "email", "export", "share", "report"]
+      effect: EFFECT_ALLOW
+      condition:
+        match:
+          expr: R.attr.company in P.attr.allowed_companies
+      roles: ["HR Manager"]
+
+    - actions: ["create", "read", "write", "print", "email", "export", "report"]
+      effect: EFFECT_ALLOW
+      condition:
+        match:
+          expr: R.attr.company in P.attr.allowed_companies
+      roles: ["HR User"]
+
+    # Self-service: an employee can read their own Employee record and upload
+    # files (mirrors employee.has_upload_permission: doc.user_id == user).
+    - actions: ["read", "print"]
+      effect: EFFECT_ALLOW
+      roles: ["Employee", "Employee Self Service"]
+      condition:
+        match:
+          any:
+            of:
+              - expr: has(R.attr.user_id) && R.attr.user_id == P.id
+              - expr: has(P.attr.employee) && P.attr.employee == R.id

--- a/cerbos/policies/resource_policies/hr/employee_test.yaml
+++ b/cerbos/policies/resource_policies/hr/employee_test.yaml
@@ -1,0 +1,61 @@
+# yaml-language-server: $schema=https://api.cerbos.dev/latest/cerbos/policy/v1/TestSuite.schema.json
+name: EmployeePolicyTest
+tests:
+  - name: HR User can manage employees in their company (no delete)
+    input:
+      principals: [hr_user]
+      resources: [emp_alice]
+      actions: [create, read, write, delete]
+    expected:
+      - principal: hr_user
+        resource: emp_alice
+        actions:
+          create: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          write: EFFECT_ALLOW
+          delete: EFFECT_DENY
+
+  - name: HR Manager can delete employees
+    input:
+      principals: [hr_manager]
+      resources: [emp_alice]
+      actions: [delete]
+    expected:
+      - principal: hr_manager
+        resource: emp_alice
+        actions:
+          delete: EFFECT_ALLOW
+
+  - name: Employee can read their own employee record
+    input:
+      principals: [employee_alice]
+      resources: [emp_alice]
+      actions: [read, write]
+    expected:
+      - principal: employee_alice
+        resource: emp_alice
+        actions:
+          read: EFFECT_ALLOW
+          write: EFFECT_DENY
+
+  - name: Employee cannot read another employee's record
+    input:
+      principals: [employee_alice]
+      resources: [emp_bob]
+      actions: [read]
+    expected:
+      - principal: employee_alice
+        resource: emp_bob
+        actions:
+          read: EFFECT_DENY
+
+  - name: Accounts User has no access to employee records
+    input:
+      principals: [accounts_user]
+      resources: [emp_alice]
+      actions: [read]
+    expected:
+      - principal: accounts_user
+        resource: emp_alice
+        actions:
+          read: EFFECT_DENY

--- a/cerbos/policies/resource_policies/hr/expense_claim.yaml
+++ b/cerbos/policies/resource_policies/hr/expense_claim.yaml
@@ -1,0 +1,73 @@
+# yaml-language-server: $schema=https://api.cerbos.dev/latest/cerbos/policy/v1/Policy.schema.json
+apiVersion: api.cerbos.dev/v1
+resourcePolicy:
+  version: default
+  resource: expense_claim
+  schemas:
+    principalSchema:
+      ref: cerbos:///principal.json
+    resourceSchema:
+      ref: cerbos:///resources/expense_claim.json
+  importDerivedRoles:
+    - erpnext_common_roles
+  variables:
+    import:
+      - erpnext_common_vars
+  rules:
+    - actions: ["create", "read", "write", "delete", "submit", "cancel", "amend", "print", "email", "export", "share", "report"]
+      effect: EFFECT_ALLOW
+      roles: ["System Manager"]
+      condition:
+        match:
+          expr: V.is_in_company
+
+    - actions: ["create", "read", "write", "delete", "submit", "cancel", "amend", "print", "email", "export", "share", "report"]
+      effect: EFFECT_ALLOW
+      roles: ["HR Manager"]
+      condition:
+        match:
+          expr: V.is_in_company
+
+    - actions: ["create", "read", "write", "submit", "cancel", "amend", "print", "email", "export", "report"]
+      effect: EFFECT_ALLOW
+      roles: ["HR User", "Accounts Manager", "Accounts User"]
+      condition:
+        match:
+          expr: V.is_in_company
+
+    # Employees: file expense claims for themselves only.
+    - actions: ["create", "read", "write", "submit", "print"]
+      effect: EFFECT_ALLOW
+      derivedRoles: [employee_self]
+
+    - actions: ["cancel"]
+      effect: EFFECT_ALLOW
+      derivedRoles: [employee_self]
+      condition:
+        match:
+          expr: R.attr.approval_status == "Draft"
+
+    - actions: ["read", "write", "submit", "print"]
+      effect: EFFECT_ALLOW
+      derivedRoles: [expense_approver_for_employee]
+
+    - actions: ["write", "delete"]
+      effect: EFFECT_DENY
+      roles: ["*"]
+      condition:
+        match:
+          expr: V.is_submitted
+
+    - actions: ["submit", "cancel"]
+      effect: EFFECT_DENY
+      roles: ["*"]
+      condition:
+        match:
+          expr: V.is_cancelled
+
+    - actions: ["amend"]
+      effect: EFFECT_DENY
+      roles: ["*"]
+      condition:
+        match:
+          expr: "!V.is_cancelled"

--- a/cerbos/policies/resource_policies/hr/expense_claim_test.yaml
+++ b/cerbos/policies/resource_policies/hr/expense_claim_test.yaml
@@ -1,0 +1,40 @@
+# yaml-language-server: $schema=https://api.cerbos.dev/latest/cerbos/policy/v1/TestSuite.schema.json
+name: ExpenseClaimPolicyTest
+tests:
+  - name: Employee can submit own draft expense claim
+    input:
+      principals: [employee_alice]
+      resources: [expense_alice_draft]
+      actions: [create, read, write, submit]
+    expected:
+      - principal: employee_alice
+        resource: expense_alice_draft
+        actions:
+          create: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          write: EFFECT_ALLOW
+          submit: EFFECT_ALLOW
+
+  - name: Configured expense approver can approve
+    input:
+      principals: [manager_carol_leave_approver]
+      resources: [expense_alice_draft]
+      actions: [read, write, submit]
+    expected:
+      - principal: manager_carol_leave_approver
+        resource: expense_alice_draft
+        actions:
+          read: EFFECT_ALLOW
+          write: EFFECT_ALLOW
+          submit: EFFECT_ALLOW
+
+  - name: Employee cannot edit a submitted expense claim
+    input:
+      principals: [employee_alice]
+      resources: [expense_alice_submitted]
+      actions: [write]
+    expected:
+      - principal: employee_alice
+        resource: expense_alice_submitted
+        actions:
+          write: EFFECT_DENY

--- a/cerbos/policies/resource_policies/hr/leave_application.yaml
+++ b/cerbos/policies/resource_policies/hr/leave_application.yaml
@@ -1,0 +1,76 @@
+# yaml-language-server: $schema=https://api.cerbos.dev/latest/cerbos/policy/v1/Policy.schema.json
+apiVersion: api.cerbos.dev/v1
+resourcePolicy:
+  version: default
+  resource: leave_application
+  schemas:
+    principalSchema:
+      ref: cerbos:///principal.json
+    resourceSchema:
+      ref: cerbos:///resources/leave_application.json
+  importDerivedRoles:
+    - erpnext_common_roles
+  variables:
+    import:
+      - erpnext_common_vars
+  rules:
+    - actions: ["create", "read", "write", "delete", "submit", "cancel", "amend", "print", "email", "export", "share", "report"]
+      effect: EFFECT_ALLOW
+      roles: ["System Manager"]
+      condition:
+        match:
+          expr: V.is_in_company
+
+    - actions: ["create", "read", "write", "delete", "submit", "cancel", "amend", "print", "email", "export", "share", "report"]
+      effect: EFFECT_ALLOW
+      roles: ["HR Manager"]
+      condition:
+        match:
+          expr: V.is_in_company
+
+    - actions: ["create", "read", "write", "submit", "cancel", "amend", "print", "email", "export", "report"]
+      effect: EFFECT_ALLOW
+      roles: ["HR User"]
+      condition:
+        match:
+          expr: V.is_in_company
+
+    # Employees: file leave for themselves only.
+    - actions: ["create", "read", "write", "submit", "print"]
+      effect: EFFECT_ALLOW
+      derivedRoles: [employee_self]
+
+    # Employee can cancel their own leave only while still in Open status —
+    # once Approved, only HR can cancel.
+    - actions: ["cancel"]
+      effect: EFFECT_ALLOW
+      derivedRoles: [employee_self]
+      condition:
+        match:
+          expr: R.attr.status == "Open"
+
+    # The configured leave approver can read/approve.
+    - actions: ["read", "write", "submit", "cancel", "print"]
+      effect: EFFECT_ALLOW
+      derivedRoles: [leave_approver_for_employee]
+
+    - actions: ["write", "delete"]
+      effect: EFFECT_DENY
+      roles: ["*"]
+      condition:
+        match:
+          expr: V.is_submitted
+
+    - actions: ["submit", "cancel"]
+      effect: EFFECT_DENY
+      roles: ["*"]
+      condition:
+        match:
+          expr: V.is_cancelled
+
+    - actions: ["amend"]
+      effect: EFFECT_DENY
+      roles: ["*"]
+      condition:
+        match:
+          expr: "!V.is_cancelled"

--- a/cerbos/policies/resource_policies/hr/leave_application_test.yaml
+++ b/cerbos/policies/resource_policies/hr/leave_application_test.yaml
@@ -1,0 +1,69 @@
+# yaml-language-server: $schema=https://api.cerbos.dev/latest/cerbos/policy/v1/TestSuite.schema.json
+name: LeaveApplicationPolicyTest
+tests:
+  - name: Employee can file and submit own leave application
+    input:
+      principals: [employee_alice]
+      resources: [leave_alice_open]
+      actions: [create, read, write, submit]
+    expected:
+      - principal: employee_alice
+        resource: leave_alice_open
+        actions:
+          create: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          write: EFFECT_ALLOW
+          submit: EFFECT_ALLOW
+
+  - name: Employee can cancel own Open leave but not Approved leave
+    input:
+      principals: [employee_alice]
+      resources: [leave_alice_open, leave_alice_approved]
+      actions: [cancel]
+    expected:
+      - principal: employee_alice
+        resource: leave_alice_open
+        actions:
+          cancel: EFFECT_ALLOW
+      - principal: employee_alice
+        resource: leave_alice_approved
+        actions:
+          cancel: EFFECT_DENY
+
+  - name: Employee cannot read another employee's leave
+    input:
+      principals: [employee_alice]
+      resources: [leave_bob_open]
+      actions: [read]
+    expected:
+      - principal: employee_alice
+        resource: leave_bob_open
+        actions:
+          read: EFFECT_DENY
+
+  - name: Configured leave approver can approve leave
+    input:
+      principals: [manager_carol_leave_approver]
+      resources: [leave_alice_open]
+      actions: [read, write, submit]
+    expected:
+      - principal: manager_carol_leave_approver
+        resource: leave_alice_open
+        actions:
+          read: EFFECT_ALLOW
+          write: EFFECT_ALLOW
+          submit: EFFECT_ALLOW
+
+  - name: HR Manager can manage all leave applications
+    input:
+      principals: [hr_manager]
+      resources: [leave_bob_open]
+      actions: [read, write, submit, delete]
+    expected:
+      - principal: hr_manager
+        resource: leave_bob_open
+        actions:
+          read: EFFECT_ALLOW
+          write: EFFECT_ALLOW
+          submit: EFFECT_ALLOW
+          delete: EFFECT_ALLOW

--- a/cerbos/policies/resource_policies/hr/testdata/principals.yaml
+++ b/cerbos/policies/resource_policies/hr/testdata/principals.yaml
@@ -1,0 +1,70 @@
+# yaml-language-server: $schema=https://api.cerbos.dev/latest/cerbos/policy/v1/TestFixture/Principals.schema.json
+principals:
+  system_manager:
+    id: "sysmgr@acme.test"
+    roles: [System Manager]
+    attr:
+      user_type: System User
+      company: Acme
+      allowed_companies: ["Acme"]
+
+  hr_manager:
+    id: "hr.mgr@acme.test"
+    roles: [HR Manager]
+    attr:
+      user_type: System User
+      company: Acme
+      allowed_companies: ["Acme"]
+
+  hr_user:
+    id: "hr.user@acme.test"
+    roles: [HR User]
+    attr:
+      user_type: System User
+      company: Acme
+      allowed_companies: ["Acme"]
+
+  accounts_user:
+    id: "acct.user@acme.test"
+    roles: [Accounts User]
+    attr:
+      user_type: System User
+      company: Acme
+      allowed_companies: ["Acme"]
+
+  employee_alice:
+    id: "alice@acme.test"
+    roles: [Employee, Employee Self Service]
+    attr:
+      user_type: System User
+      company: Acme
+      allowed_companies: ["Acme"]
+      employee: EMP-0001
+
+  employee_bob:
+    id: "bob@acme.test"
+    roles: [Employee, Employee Self Service]
+    attr:
+      user_type: System User
+      company: Acme
+      allowed_companies: ["Acme"]
+      employee: EMP-0002
+
+  manager_carol_leave_approver:
+    id: "carol@acme.test"
+    roles: [Employee, Employee Self Service]
+    attr:
+      user_type: System User
+      company: Acme
+      allowed_companies: ["Acme"]
+      employee: EMP-0003
+      leave_approver_for: ["EMP-0001"]
+      expense_approver_for: ["EMP-0001"]
+
+  guest_user:
+    id: "guest@elsewhere.test"
+    roles: [Customer]
+    attr:
+      user_type: Website User
+      company: Acme
+      allowed_companies: []

--- a/cerbos/policies/resource_policies/hr/testdata/resources.yaml
+++ b/cerbos/policies/resource_policies/hr/testdata/resources.yaml
@@ -1,0 +1,96 @@
+# yaml-language-server: $schema=https://api.cerbos.dev/latest/cerbos/policy/v1/TestFixture/Resources.schema.json
+resources:
+  emp_alice:
+    kind: employee
+    id: EMP-0001
+    attr:
+      company: Acme
+      owner: hr.user@acme.test
+      user_id: alice@acme.test
+      department: Engineering
+      status: Active
+
+  emp_bob:
+    kind: employee
+    id: EMP-0002
+    attr:
+      company: Acme
+      owner: hr.user@acme.test
+      user_id: bob@acme.test
+      department: Sales
+      status: Active
+
+  leave_alice_open:
+    kind: leave_application
+    id: LA-001
+    attr:
+      company: Acme
+      owner: alice@acme.test
+      docstatus: 0
+      employee: EMP-0001
+      status: Open
+      leave_approver: carol@acme.test
+
+  leave_alice_approved:
+    kind: leave_application
+    id: LA-002
+    attr:
+      company: Acme
+      owner: alice@acme.test
+      docstatus: 1
+      employee: EMP-0001
+      status: Approved
+      leave_approver: carol@acme.test
+
+  leave_bob_open:
+    kind: leave_application
+    id: LA-003
+    attr:
+      company: Acme
+      owner: bob@acme.test
+      docstatus: 0
+      employee: EMP-0002
+      status: Open
+      leave_approver: hr.user@acme.test
+
+  expense_alice_draft:
+    kind: expense_claim
+    id: EXP-001
+    attr:
+      company: Acme
+      owner: alice@acme.test
+      docstatus: 0
+      employee: EMP-0001
+      approval_status: Draft
+      expense_approver: carol@acme.test
+
+  expense_alice_submitted:
+    kind: expense_claim
+    id: EXP-002
+    attr:
+      company: Acme
+      owner: alice@acme.test
+      docstatus: 1
+      employee: EMP-0001
+      approval_status: Approved
+      expense_approver: carol@acme.test
+
+  ts_alice_draft:
+    kind: timesheet
+    id: TS-001
+    attr:
+      company: Acme
+      owner: alice@acme.test
+      docstatus: 0
+      employee: EMP-0001
+      customer: BigCo
+
+  ts_alice_submitted:
+    kind: timesheet
+    id: TS-002
+    attr:
+      company: Acme
+      owner: alice@acme.test
+      docstatus: 1
+      employee: EMP-0001
+      customer: BigCo

--- a/cerbos/policies/resource_policies/hr/timesheet.yaml
+++ b/cerbos/policies/resource_policies/hr/timesheet.yaml
@@ -1,0 +1,67 @@
+# yaml-language-server: $schema=https://api.cerbos.dev/latest/cerbos/policy/v1/Policy.schema.json
+apiVersion: api.cerbos.dev/v1
+resourcePolicy:
+  version: default
+  resource: timesheet
+  schemas:
+    principalSchema:
+      ref: cerbos:///principal.json
+    resourceSchema:
+      ref: cerbos:///resources/timesheet.json
+  importDerivedRoles:
+    - erpnext_common_roles
+  variables:
+    import:
+      - erpnext_common_vars
+  rules:
+    - actions: ["create", "read", "write", "delete", "submit", "cancel", "amend", "print", "email", "export", "share", "report"]
+      effect: EFFECT_ALLOW
+      roles: ["System Manager", "HR Manager", "Projects Manager"]
+      condition:
+        match:
+          expr: V.is_in_company
+
+    - actions: ["create", "read", "write", "submit", "cancel", "amend", "print", "email", "export", "report"]
+      effect: EFFECT_ALLOW
+      roles: ["HR User", "Projects User"]
+      condition:
+        match:
+          expr: V.is_in_company
+
+    # Employee files own timesheets.
+    - actions: ["create", "read", "write", "submit", "cancel", "print"]
+      effect: EFFECT_ALLOW
+      derivedRoles: [employee_self]
+      condition:
+        match:
+          expr: R.attr.docstatus != 1
+
+    - actions: ["read", "print"]
+      effect: EFFECT_ALLOW
+      derivedRoles: [employee_self]
+
+    # Customer portal: read timesheets billed to their Customer.
+    - actions: ["read", "print"]
+      effect: EFFECT_ALLOW
+      derivedRoles: [customer_portal_self]
+
+    - actions: ["write", "delete"]
+      effect: EFFECT_DENY
+      roles: ["*"]
+      condition:
+        match:
+          expr: V.is_submitted
+
+    - actions: ["submit", "cancel"]
+      effect: EFFECT_DENY
+      roles: ["*"]
+      condition:
+        match:
+          expr: V.is_cancelled
+
+    - actions: ["amend"]
+      effect: EFFECT_DENY
+      roles: ["*"]
+      condition:
+        match:
+          expr: "!V.is_cancelled"

--- a/cerbos/policies/resource_policies/hr/timesheet_test.yaml
+++ b/cerbos/policies/resource_policies/hr/timesheet_test.yaml
@@ -1,0 +1,54 @@
+# yaml-language-server: $schema=https://api.cerbos.dev/latest/cerbos/policy/v1/TestSuite.schema.json
+name: TimesheetPolicyTest
+tests:
+  - name: Employee can file and submit own timesheet
+    input:
+      principals: [employee_alice]
+      resources: [ts_alice_draft]
+      actions: [create, read, write, submit]
+    expected:
+      - principal: employee_alice
+        resource: ts_alice_draft
+        actions:
+          create: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          write: EFFECT_ALLOW
+          submit: EFFECT_ALLOW
+
+  - name: Employee can read submitted own timesheet but not edit
+    input:
+      principals: [employee_alice]
+      resources: [ts_alice_submitted]
+      actions: [read, write]
+    expected:
+      - principal: employee_alice
+        resource: ts_alice_submitted
+        actions:
+          read: EFFECT_ALLOW
+          write: EFFECT_DENY
+
+  - name: Other employee cannot read someone else's timesheet
+    input:
+      principals: [employee_bob]
+      resources: [ts_alice_draft]
+      actions: [read]
+    expected:
+      - principal: employee_bob
+        resource: ts_alice_draft
+        actions:
+          read: EFFECT_DENY
+
+  - name: HR Manager can fully manage timesheets
+    input:
+      principals: [hr_manager]
+      resources: [ts_alice_draft]
+      actions: [read, write, submit, cancel, delete]
+    expected:
+      - principal: hr_manager
+        resource: ts_alice_draft
+        actions:
+          read: EFFECT_ALLOW
+          write: EFFECT_ALLOW
+          submit: EFFECT_ALLOW
+          cancel: EFFECT_ALLOW
+          delete: EFFECT_ALLOW

--- a/cerbos/policies/resource_policies/projects/project.yaml
+++ b/cerbos/policies/resource_policies/projects/project.yaml
@@ -1,0 +1,43 @@
+# yaml-language-server: $schema=https://api.cerbos.dev/latest/cerbos/policy/v1/Policy.schema.json
+apiVersion: api.cerbos.dev/v1
+resourcePolicy:
+  version: default
+  resource: project
+  schemas:
+    principalSchema:
+      ref: cerbos:///principal.json
+    resourceSchema:
+      ref: cerbos:///resources/project.json
+  importDerivedRoles:
+    - erpnext_common_roles
+  variables:
+    import:
+      - erpnext_common_vars
+  rules:
+    - actions: ["create", "read", "write", "delete", "print", "email", "export", "share", "report"]
+      effect: EFFECT_ALLOW
+      roles: ["System Manager", "Projects Manager"]
+      condition:
+        match:
+          expr: V.is_in_company
+
+    - actions: ["create", "read", "write", "print", "email", "export", "report"]
+      effect: EFFECT_ALLOW
+      roles: ["Projects User"]
+      condition:
+        match:
+          expr: V.is_in_company
+
+    # Internal staff: read projects within their company.
+    - actions: ["read", "print"]
+      effect: EFFECT_ALLOW
+      roles: ["Employee", "Employee Self Service", "HR Manager", "HR User", "Accounts Manager", "Accounts User"]
+      condition:
+        match:
+          expr: V.is_in_company
+
+    # Customer portal: project belongs to their Customer.
+    # Mirrors get_project_list scoping by linked customer.
+    - actions: ["read", "print"]
+      effect: EFFECT_ALLOW
+      derivedRoles: [customer_portal_self]

--- a/cerbos/policies/resource_policies/projects/project_test.yaml
+++ b/cerbos/policies/resource_policies/projects/project_test.yaml
@@ -1,0 +1,51 @@
+# yaml-language-server: $schema=https://api.cerbos.dev/latest/cerbos/policy/v1/TestSuite.schema.json
+name: ProjectPolicyTest
+tests:
+  - name: Projects Manager has full access in their company
+    input:
+      principals: [projects_manager]
+      resources: [proj_bigco]
+      actions: [create, read, write, delete]
+    expected:
+      - principal: projects_manager
+        resource: proj_bigco
+        actions:
+          create: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          write: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+
+  - name: Customer portal can read their own project
+    input:
+      principals: [customer_portal_user]
+      resources: [proj_bigco]
+      actions: [read, write]
+    expected:
+      - principal: customer_portal_user
+        resource: proj_bigco
+        actions:
+          read: EFFECT_ALLOW
+          write: EFFECT_DENY
+
+  - name: Other-customer portal user cannot read project
+    input:
+      principals: [other_customer_portal_user]
+      resources: [proj_bigco]
+      actions: [read]
+    expected:
+      - principal: other_customer_portal_user
+        resource: proj_bigco
+        actions:
+          read: EFFECT_DENY
+
+  - name: Internal Employee can read projects in their company
+    input:
+      principals: [employee_alice]
+      resources: [proj_internal]
+      actions: [read, write]
+    expected:
+      - principal: employee_alice
+        resource: proj_internal
+        actions:
+          read: EFFECT_ALLOW
+          write: EFFECT_DENY

--- a/cerbos/policies/resource_policies/projects/task.yaml
+++ b/cerbos/policies/resource_policies/projects/task.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://api.cerbos.dev/latest/cerbos/policy/v1/Policy.schema.json
+apiVersion: api.cerbos.dev/v1
+resourcePolicy:
+  version: default
+  resource: task
+  schemas:
+    principalSchema:
+      ref: cerbos:///principal.json
+    resourceSchema:
+      ref: cerbos:///resources/task.json
+  rules:
+    - actions: ["create", "read", "write", "delete", "print", "email", "export", "share", "report"]
+      effect: EFFECT_ALLOW
+      roles: ["System Manager", "Projects Manager"]
+
+    - actions: ["create", "read", "write", "print", "email", "export", "report"]
+      effect: EFFECT_ALLOW
+      roles: ["Projects User"]
+
+    # Document creator can edit their own task.
+    - actions: ["read", "write", "print"]
+      effect: EFFECT_ALLOW
+      roles: ["Employee", "Employee Self Service"]
+      condition:
+        match:
+          expr: R.attr.owner == P.id
+
+    # Assignees (ToDo-assigned) can read/update their tasks.
+    - actions: ["read", "write", "print"]
+      effect: EFFECT_ALLOW
+      roles: ["Employee", "Employee Self Service", "Projects User"]
+      condition:
+        match:
+          expr: has(R.attr.assigned_to) && P.id in R.attr.assigned_to

--- a/cerbos/policies/resource_policies/projects/task_test.yaml
+++ b/cerbos/policies/resource_policies/projects/task_test.yaml
@@ -1,0 +1,51 @@
+# yaml-language-server: $schema=https://api.cerbos.dev/latest/cerbos/policy/v1/TestSuite.schema.json
+name: TaskPolicyTest
+tests:
+  - name: Projects User has full lifecycle on tasks
+    input:
+      principals: [projects_user]
+      resources: [task_assigned_to_alice]
+      actions: [create, read, write]
+    expected:
+      - principal: projects_user
+        resource: task_assigned_to_alice
+        actions:
+          create: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          write: EFFECT_ALLOW
+
+  - name: Assignee can read and write their assigned task
+    input:
+      principals: [employee_alice]
+      resources: [task_assigned_to_alice]
+      actions: [read, write]
+    expected:
+      - principal: employee_alice
+        resource: task_assigned_to_alice
+        actions:
+          read: EFFECT_ALLOW
+          write: EFFECT_ALLOW
+
+  - name: Non-assignee employee cannot read task
+    input:
+      principals: [employee_bob]
+      resources: [task_assigned_to_alice]
+      actions: [read, write]
+    expected:
+      - principal: employee_bob
+        resource: task_assigned_to_alice
+        actions:
+          read: EFFECT_DENY
+          write: EFFECT_DENY
+
+  - name: Document owner can read/write own task
+    input:
+      principals: [employee_bob]
+      resources: [task_owned_by_bob]
+      actions: [read, write]
+    expected:
+      - principal: employee_bob
+        resource: task_owned_by_bob
+        actions:
+          read: EFFECT_ALLOW
+          write: EFFECT_ALLOW

--- a/cerbos/policies/resource_policies/projects/testdata/principals.yaml
+++ b/cerbos/policies/resource_policies/projects/testdata/principals.yaml
@@ -1,0 +1,61 @@
+# yaml-language-server: $schema=https://api.cerbos.dev/latest/cerbos/policy/v1/TestFixture/Principals.schema.json
+principals:
+  system_manager:
+    id: "sysmgr@acme.test"
+    roles: [System Manager]
+    attr:
+      user_type: System User
+      company: Acme
+      allowed_companies: ["Acme"]
+
+  projects_manager:
+    id: "pm@acme.test"
+    roles: [Projects Manager]
+    attr:
+      user_type: System User
+      company: Acme
+      allowed_companies: ["Acme"]
+
+  projects_user:
+    id: "pu@acme.test"
+    roles: [Projects User]
+    attr:
+      user_type: System User
+      company: Acme
+      allowed_companies: ["Acme"]
+
+  employee_alice:
+    id: "alice@acme.test"
+    roles: [Employee, Employee Self Service]
+    attr:
+      user_type: System User
+      company: Acme
+      allowed_companies: ["Acme"]
+      employee: EMP-0001
+
+  employee_bob:
+    id: "bob@acme.test"
+    roles: [Employee, Employee Self Service]
+    attr:
+      user_type: System User
+      company: Acme
+      allowed_companies: ["Acme"]
+      employee: EMP-0002
+
+  customer_portal_user:
+    id: "alice@bigco.test"
+    roles: [Customer]
+    attr:
+      user_type: Website User
+      company: Acme
+      allowed_companies: []
+      customer: BigCo
+
+  other_customer_portal_user:
+    id: "x@smallcorp.test"
+    roles: [Customer]
+    attr:
+      user_type: Website User
+      company: Acme
+      allowed_companies: []
+      customer: SmallCorp

--- a/cerbos/policies/resource_policies/projects/testdata/resources.yaml
+++ b/cerbos/policies/resource_policies/projects/testdata/resources.yaml
@@ -1,0 +1,37 @@
+# yaml-language-server: $schema=https://api.cerbos.dev/latest/cerbos/policy/v1/TestFixture/Resources.schema.json
+resources:
+  proj_bigco:
+    kind: project
+    id: PROJ-001
+    attr:
+      company: Acme
+      owner: pm@acme.test
+      customer: BigCo
+      status: Open
+
+  proj_internal:
+    kind: project
+    id: PROJ-002
+    attr:
+      company: Acme
+      owner: pm@acme.test
+      customer: Acme
+      status: Open
+
+  task_assigned_to_alice:
+    kind: task
+    id: TASK-001
+    attr:
+      owner: pm@acme.test
+      project: PROJ-001
+      status: Open
+      assigned_to: ["alice@acme.test"]
+
+  task_owned_by_bob:
+    kind: task
+    id: TASK-002
+    attr:
+      owner: bob@acme.test
+      project: PROJ-001
+      status: Open
+      assigned_to: []

--- a/cerbos/policies/resource_policies/selling/customer.yaml
+++ b/cerbos/policies/resource_policies/selling/customer.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://api.cerbos.dev/latest/cerbos/policy/v1/Policy.schema.json
+apiVersion: api.cerbos.dev/v1
+resourcePolicy:
+  version: default
+  resource: customer
+  schemas:
+    principalSchema:
+      ref: cerbos:///principal.json
+    resourceSchema:
+      ref: cerbos:///resources/customer.json
+  rules:
+    - actions: ["create", "read", "write", "delete", "print", "email", "export", "share", "report"]
+      effect: EFFECT_ALLOW
+      roles: ["System Manager", "Sales Master Manager"]
+
+    - actions: ["create", "read", "write", "print", "email", "export", "report"]
+      effect: EFFECT_ALLOW
+      roles: ["Sales Manager"]
+
+    - actions: ["create", "read", "write", "print", "email", "export", "report"]
+      effect: EFFECT_ALLOW
+      roles: ["Sales User"]
+
+    # Other downstream consumers: read-only.
+    - actions: ["read", "print", "report", "export"]
+      effect: EFFECT_ALLOW
+      roles: ["Accounts User", "Accounts Manager", "Stock User", "Stock Manager"]

--- a/cerbos/policies/resource_policies/selling/customer_test.yaml
+++ b/cerbos/policies/resource_policies/selling/customer_test.yaml
@@ -1,0 +1,41 @@
+# yaml-language-server: $schema=https://api.cerbos.dev/latest/cerbos/policy/v1/TestSuite.schema.json
+name: CustomerPolicyTest
+description: Tests for the Customer resource policy
+
+tests:
+  - name: Sales User can manage customers (no delete)
+    input:
+      principals: [sales_user]
+      resources: [customer_bigco]
+      actions: [create, read, write, delete]
+    expected:
+      - principal: sales_user
+        resource: customer_bigco
+        actions:
+          create: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          write: EFFECT_ALLOW
+          delete: EFFECT_DENY
+
+  - name: Sales Master Manager can delete customers
+    input:
+      principals: [sales_master_manager]
+      resources: [customer_bigco]
+      actions: [delete]
+    expected:
+      - principal: sales_master_manager
+        resource: customer_bigco
+        actions:
+          delete: EFFECT_ALLOW
+
+  - name: Accounts User has read-only access to customers
+    input:
+      principals: [accounts_user]
+      resources: [customer_bigco]
+      actions: [read, write]
+    expected:
+      - principal: accounts_user
+        resource: customer_bigco
+        actions:
+          read: EFFECT_ALLOW
+          write: EFFECT_DENY

--- a/cerbos/policies/resource_policies/selling/delivery_note.yaml
+++ b/cerbos/policies/resource_policies/selling/delivery_note.yaml
@@ -1,0 +1,61 @@
+# yaml-language-server: $schema=https://api.cerbos.dev/latest/cerbos/policy/v1/Policy.schema.json
+apiVersion: api.cerbos.dev/v1
+resourcePolicy:
+  version: default
+  resource: delivery_note
+  schemas:
+    principalSchema:
+      ref: cerbos:///principal.json
+    resourceSchema:
+      ref: cerbos:///resources/delivery_note.json
+  importDerivedRoles:
+    - erpnext_common_roles
+  variables:
+    import:
+      - erpnext_common_vars
+  rules:
+    - actions: ["create", "read", "write", "delete", "submit", "cancel", "amend", "print", "email", "export", "share", "report"]
+      effect: EFFECT_ALLOW
+      roles: ["System Manager"]
+      condition:
+        match:
+          expr: V.is_in_company
+
+    - actions: ["create", "read", "write", "submit", "cancel", "amend", "print", "email", "export", "share", "report"]
+      effect: EFFECT_ALLOW
+      roles: ["Stock Manager", "Sales Manager"]
+      condition:
+        match:
+          expr: V.is_in_company
+
+    - actions: ["create", "read", "write", "submit", "cancel", "amend", "print", "email", "export", "report"]
+      effect: EFFECT_ALLOW
+      roles: ["Stock User", "Sales User"]
+      condition:
+        match:
+          expr: V.is_in_company
+
+    - actions: ["read", "print"]
+      effect: EFFECT_ALLOW
+      derivedRoles: [customer_portal_self]
+
+    - actions: ["write", "delete"]
+      effect: EFFECT_DENY
+      roles: ["*"]
+      condition:
+        match:
+          expr: V.is_submitted
+
+    - actions: ["submit", "cancel"]
+      effect: EFFECT_DENY
+      roles: ["*"]
+      condition:
+        match:
+          expr: V.is_cancelled
+
+    - actions: ["amend"]
+      effect: EFFECT_DENY
+      roles: ["*"]
+      condition:
+        match:
+          expr: "!V.is_cancelled"

--- a/cerbos/policies/resource_policies/selling/delivery_note_test.yaml
+++ b/cerbos/policies/resource_policies/selling/delivery_note_test.yaml
@@ -1,0 +1,41 @@
+# yaml-language-server: $schema=https://api.cerbos.dev/latest/cerbos/policy/v1/TestSuite.schema.json
+name: DeliveryNotePolicyTest
+tests:
+  - name: Stock User can submit delivery notes in their company
+    input:
+      principals: [stock_user]
+      resources: [dn_draft]
+      actions: [create, read, write, submit]
+    expected:
+      - principal: stock_user
+        resource: dn_draft
+        actions:
+          create: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          write: EFFECT_ALLOW
+          submit: EFFECT_ALLOW
+
+  - name: Customer portal can read own delivery note
+    input:
+      principals: [customer_portal_user]
+      resources: [dn_draft]
+      actions: [read, write]
+    expected:
+      - principal: customer_portal_user
+        resource: dn_draft
+        actions:
+          read: EFFECT_ALLOW
+          write: EFFECT_DENY
+
+  - name: Sales User can also create delivery notes
+    input:
+      principals: [sales_user]
+      resources: [dn_draft]
+      actions: [create, write, submit]
+    expected:
+      - principal: sales_user
+        resource: dn_draft
+        actions:
+          create: EFFECT_ALLOW
+          write: EFFECT_ALLOW
+          submit: EFFECT_ALLOW

--- a/cerbos/policies/resource_policies/selling/quotation.yaml
+++ b/cerbos/policies/resource_policies/selling/quotation.yaml
@@ -1,0 +1,62 @@
+# yaml-language-server: $schema=https://api.cerbos.dev/latest/cerbos/policy/v1/Policy.schema.json
+apiVersion: api.cerbos.dev/v1
+resourcePolicy:
+  version: default
+  resource: quotation
+  schemas:
+    principalSchema:
+      ref: cerbos:///principal.json
+    resourceSchema:
+      ref: cerbos:///resources/quotation.json
+  importDerivedRoles:
+    - erpnext_common_roles
+  variables:
+    import:
+      - erpnext_common_vars
+  rules:
+    - actions: ["create", "read", "write", "delete", "submit", "cancel", "amend", "print", "email", "export", "share", "report"]
+      effect: EFFECT_ALLOW
+      roles: ["System Manager"]
+      condition:
+        match:
+          expr: V.is_in_company
+
+    - actions: ["create", "read", "write", "submit", "cancel", "amend", "print", "email", "export", "share", "report"]
+      effect: EFFECT_ALLOW
+      roles: ["Sales Manager"]
+      condition:
+        match:
+          expr: V.is_in_company
+
+    - actions: ["create", "read", "write", "submit", "cancel", "amend", "print", "email", "export", "report"]
+      effect: EFFECT_ALLOW
+      roles: ["Sales User"]
+      condition:
+        match:
+          expr: V.is_in_company
+
+    # Customer portal: read own quotations only.
+    - actions: ["read", "print"]
+      effect: EFFECT_ALLOW
+      derivedRoles: [customer_portal_self]
+
+    - actions: ["write", "delete"]
+      effect: EFFECT_DENY
+      roles: ["*"]
+      condition:
+        match:
+          expr: V.is_submitted
+
+    - actions: ["submit", "cancel"]
+      effect: EFFECT_DENY
+      roles: ["*"]
+      condition:
+        match:
+          expr: V.is_cancelled
+
+    - actions: ["amend"]
+      effect: EFFECT_DENY
+      roles: ["*"]
+      condition:
+        match:
+          expr: "!V.is_cancelled"

--- a/cerbos/policies/resource_policies/selling/quotation_test.yaml
+++ b/cerbos/policies/resource_policies/selling/quotation_test.yaml
@@ -1,0 +1,51 @@
+# yaml-language-server: $schema=https://api.cerbos.dev/latest/cerbos/policy/v1/TestSuite.schema.json
+name: QuotationPolicyTest
+tests:
+  - name: Sales User can submit quotations in their company
+    input:
+      principals: [sales_user]
+      resources: [quotation_draft]
+      actions: [create, read, write, submit]
+    expected:
+      - principal: sales_user
+        resource: quotation_draft
+        actions:
+          create: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          write: EFFECT_ALLOW
+          submit: EFFECT_ALLOW
+
+  - name: Customer portal user can read own quotation
+    input:
+      principals: [customer_portal_user]
+      resources: [quotation_draft]
+      actions: [read, write]
+    expected:
+      - principal: customer_portal_user
+        resource: quotation_draft
+        actions:
+          read: EFFECT_ALLOW
+          write: EFFECT_DENY
+
+  - name: Customer portal user denied for another customer's quotation
+    input:
+      principals: [other_customer_portal_user]
+      resources: [quotation_draft]
+      actions: [read]
+    expected:
+      - principal: other_customer_portal_user
+        resource: quotation_draft
+        actions:
+          read: EFFECT_DENY
+
+  - name: Submitted quotation cannot be edited
+    input:
+      principals: [sales_manager]
+      resources: [quotation_submitted_other]
+      actions: [write, cancel]
+    expected:
+      - principal: sales_manager
+        resource: quotation_submitted_other
+        actions:
+          write: EFFECT_DENY
+          cancel: EFFECT_ALLOW

--- a/cerbos/policies/resource_policies/selling/sales_order.yaml
+++ b/cerbos/policies/resource_policies/selling/sales_order.yaml
@@ -1,0 +1,69 @@
+# yaml-language-server: $schema=https://api.cerbos.dev/latest/cerbos/policy/v1/Policy.schema.json
+apiVersion: api.cerbos.dev/v1
+resourcePolicy:
+  version: default
+  resource: sales_order
+  schemas:
+    principalSchema:
+      ref: cerbos:///principal.json
+    resourceSchema:
+      ref: cerbos:///resources/sales_order.json
+  importDerivedRoles:
+    - erpnext_common_roles
+  variables:
+    import:
+      - erpnext_common_vars
+  rules:
+    - actions: ["create", "read", "write", "delete", "submit", "cancel", "amend", "print", "email", "export", "share", "report"]
+      effect: EFFECT_ALLOW
+      roles: ["System Manager"]
+      condition:
+        match:
+          expr: V.is_in_company
+
+    - actions: ["create", "read", "write", "submit", "cancel", "amend", "print", "email", "export", "share", "report"]
+      effect: EFFECT_ALLOW
+      roles: ["Sales Manager"]
+      condition:
+        match:
+          expr: V.is_in_company
+
+    - actions: ["create", "read", "write", "submit", "cancel", "amend", "print", "email", "export", "report"]
+      effect: EFFECT_ALLOW
+      roles: ["Sales User"]
+      condition:
+        match:
+          expr: V.is_in_company
+
+    # Stock teams need to see Sales Orders for fulfilment planning.
+    - actions: ["read", "print", "report", "export"]
+      effect: EFFECT_ALLOW
+      roles: ["Stock User", "Stock Manager", "Accounts User", "Accounts Manager"]
+      condition:
+        match:
+          expr: V.is_in_company
+
+    - actions: ["read", "print"]
+      effect: EFFECT_ALLOW
+      derivedRoles: [customer_portal_self]
+
+    - actions: ["write", "delete"]
+      effect: EFFECT_DENY
+      roles: ["*"]
+      condition:
+        match:
+          expr: V.is_submitted
+
+    - actions: ["submit", "cancel"]
+      effect: EFFECT_DENY
+      roles: ["*"]
+      condition:
+        match:
+          expr: V.is_cancelled
+
+    - actions: ["amend"]
+      effect: EFFECT_DENY
+      roles: ["*"]
+      condition:
+        match:
+          expr: "!V.is_cancelled"

--- a/cerbos/policies/resource_policies/selling/sales_order_test.yaml
+++ b/cerbos/policies/resource_policies/selling/sales_order_test.yaml
@@ -1,0 +1,63 @@
+# yaml-language-server: $schema=https://api.cerbos.dev/latest/cerbos/policy/v1/TestSuite.schema.json
+name: SalesOrderPolicyTest
+tests:
+  - name: Sales User can submit a sales order in their company
+    input:
+      principals: [sales_user]
+      resources: [so_draft]
+      actions: [create, read, write, submit]
+    expected:
+      - principal: sales_user
+        resource: so_draft
+        actions:
+          create: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          write: EFFECT_ALLOW
+          submit: EFFECT_ALLOW
+
+  - name: Stock User can read SOs (fulfilment) but not write
+    input:
+      principals: [stock_user]
+      resources: [so_draft]
+      actions: [read, write]
+    expected:
+      - principal: stock_user
+        resource: so_draft
+        actions:
+          read: EFFECT_ALLOW
+          write: EFFECT_DENY
+
+  - name: Cross-company sales user cannot access another company's SO
+    input:
+      principals: [other_company_sales_user]
+      resources: [so_draft]
+      actions: [read, write]
+    expected:
+      - principal: other_company_sales_user
+        resource: so_draft
+        actions:
+          read: EFFECT_DENY
+          write: EFFECT_DENY
+
+  - name: Customer portal can read their own SO
+    input:
+      principals: [customer_portal_user]
+      resources: [so_draft]
+      actions: [read]
+    expected:
+      - principal: customer_portal_user
+        resource: so_draft
+        actions:
+          read: EFFECT_ALLOW
+
+  - name: Submitted SO is locked from edits but can be cancelled
+    input:
+      principals: [sales_manager]
+      resources: [so_submitted]
+      actions: [write, cancel]
+    expected:
+      - principal: sales_manager
+        resource: so_submitted
+        actions:
+          write: EFFECT_DENY
+          cancel: EFFECT_ALLOW

--- a/cerbos/policies/resource_policies/selling/testdata/principals.yaml
+++ b/cerbos/policies/resource_policies/selling/testdata/principals.yaml
@@ -1,0 +1,75 @@
+# yaml-language-server: $schema=https://api.cerbos.dev/latest/cerbos/policy/v1/TestFixture/Principals.schema.json
+principals:
+  system_manager:
+    id: "sysmgr@acme.test"
+    roles: [System Manager]
+    attr:
+      user_type: System User
+      company: Acme
+      allowed_companies: ["Acme"]
+
+  sales_manager:
+    id: "sales.mgr@acme.test"
+    roles: [Sales Manager]
+    attr:
+      user_type: System User
+      company: Acme
+      allowed_companies: ["Acme"]
+
+  sales_user:
+    id: "sales.user@acme.test"
+    roles: [Sales User]
+    attr:
+      user_type: System User
+      company: Acme
+      allowed_companies: ["Acme"]
+
+  sales_master_manager:
+    id: "smm@acme.test"
+    roles: [Sales Master Manager]
+    attr:
+      user_type: System User
+      company: Acme
+      allowed_companies: ["Acme"]
+
+  accounts_user:
+    id: "acct.user@acme.test"
+    roles: [Accounts User]
+    attr:
+      user_type: System User
+      company: Acme
+      allowed_companies: ["Acme"]
+
+  stock_user:
+    id: "stock.user@acme.test"
+    roles: [Stock User]
+    attr:
+      user_type: System User
+      company: Acme
+      allowed_companies: ["Acme"]
+
+  customer_portal_user:
+    id: "alice@bigco.test"
+    roles: [Customer]
+    attr:
+      user_type: Website User
+      company: Acme
+      allowed_companies: []
+      customer: "BigCo"
+
+  other_customer_portal_user:
+    id: "carol@smallcorp.test"
+    roles: [Customer]
+    attr:
+      user_type: Website User
+      company: Acme
+      allowed_companies: []
+      customer: "SmallCorp"
+
+  other_company_sales_user:
+    id: "sales@globex.test"
+    roles: [Sales User]
+    attr:
+      user_type: System User
+      company: Globex
+      allowed_companies: ["Globex"]

--- a/cerbos/policies/resource_policies/selling/testdata/resources.yaml
+++ b/cerbos/policies/resource_policies/selling/testdata/resources.yaml
@@ -1,0 +1,72 @@
+# yaml-language-server: $schema=https://api.cerbos.dev/latest/cerbos/policy/v1/TestFixture/Resources.schema.json
+resources:
+  customer_bigco:
+    kind: customer
+    id: BigCo
+    attr:
+      owner: sales.user@acme.test
+      territory: India
+      customer_group: Commercial
+      disabled: false
+
+  quotation_draft:
+    kind: quotation
+    id: QTN-001
+    attr:
+      company: Acme
+      owner: sales.user@acme.test
+      docstatus: 0
+      customer: BigCo
+      territory: India
+      status: Draft
+
+  quotation_submitted_other:
+    kind: quotation
+    id: QTN-002
+    attr:
+      company: Acme
+      owner: sales.user@acme.test
+      docstatus: 1
+      customer: SmallCorp
+      territory: India
+      status: Open
+
+  so_draft:
+    kind: sales_order
+    id: SO-001
+    attr:
+      company: Acme
+      owner: sales.user@acme.test
+      docstatus: 0
+      customer: BigCo
+      status: Draft
+
+  so_submitted:
+    kind: sales_order
+    id: SO-002
+    attr:
+      company: Acme
+      owner: sales.user@acme.test
+      docstatus: 1
+      customer: BigCo
+      status: To Deliver
+
+  so_other_company:
+    kind: sales_order
+    id: SO-003
+    attr:
+      company: Globex
+      owner: sales@globex.test
+      docstatus: 0
+      customer: BigCo
+      status: Draft
+
+  dn_draft:
+    kind: delivery_note
+    id: DN-001
+    attr:
+      company: Acme
+      owner: stock.user@acme.test
+      docstatus: 0
+      customer: BigCo
+      is_return: false

--- a/cerbos/policies/resource_policies/stock/item.yaml
+++ b/cerbos/policies/resource_policies/stock/item.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://api.cerbos.dev/latest/cerbos/policy/v1/Policy.schema.json
+apiVersion: api.cerbos.dev/v1
+resourcePolicy:
+  version: default
+  resource: item
+  schemas:
+    principalSchema:
+      ref: cerbos:///principal.json
+    resourceSchema:
+      ref: cerbos:///resources/item.json
+  rules:
+    - actions: ["create", "read", "write", "delete", "print", "email", "export", "share", "report"]
+      effect: EFFECT_ALLOW
+      roles: ["System Manager", "Item Manager"]
+
+    - actions: ["create", "read", "write", "print", "email", "export", "report"]
+      effect: EFFECT_ALLOW
+      roles: ["Stock Manager", "Sales Manager", "Purchase Manager"]
+
+    # Operational roles need read-only catalog visibility.
+    - actions: ["read", "print", "export", "report"]
+      effect: EFFECT_ALLOW
+      roles: ["Stock User", "Sales User", "Purchase User", "Accounts User", "Accounts Manager", "Manufacturing User", "Manufacturing Manager"]

--- a/cerbos/policies/resource_policies/stock/item_test.yaml
+++ b/cerbos/policies/resource_policies/stock/item_test.yaml
@@ -1,0 +1,51 @@
+# yaml-language-server: $schema=https://api.cerbos.dev/latest/cerbos/policy/v1/TestSuite.schema.json
+name: ItemPolicyTest
+tests:
+  - name: Item Manager has full access
+    input:
+      principals: [item_manager]
+      resources: [item_widget]
+      actions: [create, read, write, delete]
+    expected:
+      - principal: item_manager
+        resource: item_widget
+        actions:
+          create: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          write: EFFECT_ALLOW
+          delete: EFFECT_ALLOW
+
+  - name: Stock Manager can write but not delete
+    input:
+      principals: [stock_manager]
+      resources: [item_widget]
+      actions: [write, delete]
+    expected:
+      - principal: stock_manager
+        resource: item_widget
+        actions:
+          write: EFFECT_ALLOW
+          delete: EFFECT_DENY
+
+  - name: Sales User has read-only catalog access
+    input:
+      principals: [sales_user]
+      resources: [item_widget]
+      actions: [read, write]
+    expected:
+      - principal: sales_user
+        resource: item_widget
+        actions:
+          read: EFFECT_ALLOW
+          write: EFFECT_DENY
+
+  - name: Customer portal cannot access items directly
+    input:
+      principals: [customer_portal_user]
+      resources: [item_widget]
+      actions: [read]
+    expected:
+      - principal: customer_portal_user
+        resource: item_widget
+        actions:
+          read: EFFECT_DENY

--- a/cerbos/policies/resource_policies/stock/stock_entry.yaml
+++ b/cerbos/policies/resource_policies/stock/stock_entry.yaml
@@ -1,0 +1,64 @@
+# yaml-language-server: $schema=https://api.cerbos.dev/latest/cerbos/policy/v1/Policy.schema.json
+apiVersion: api.cerbos.dev/v1
+resourcePolicy:
+  version: default
+  resource: stock_entry
+  schemas:
+    principalSchema:
+      ref: cerbos:///principal.json
+    resourceSchema:
+      ref: cerbos:///resources/stock_entry.json
+  importDerivedRoles:
+    - erpnext_common_roles
+  variables:
+    import:
+      - erpnext_common_vars
+  rules:
+    - actions: ["create", "read", "write", "delete", "submit", "cancel", "amend", "print", "email", "export", "share", "report"]
+      effect: EFFECT_ALLOW
+      roles: ["System Manager"]
+      condition:
+        match:
+          expr: V.is_in_company
+
+    - actions: ["create", "read", "write", "submit", "cancel", "amend", "print", "email", "export", "share", "report"]
+      effect: EFFECT_ALLOW
+      roles: ["Stock Manager", "Manufacturing Manager"]
+      condition:
+        match:
+          expr: V.is_in_company
+
+    - actions: ["create", "read", "write", "submit", "cancel", "amend", "print", "email", "export", "report"]
+      effect: EFFECT_ALLOW
+      roles: ["Stock User", "Manufacturing User"]
+      condition:
+        match:
+          expr: V.is_in_company
+
+    - actions: ["read", "print", "export", "report"]
+      effect: EFFECT_ALLOW
+      roles: ["Accounts Manager", "Accounts User"]
+      condition:
+        match:
+          expr: V.is_in_company
+
+    - actions: ["write", "delete"]
+      effect: EFFECT_DENY
+      roles: ["*"]
+      condition:
+        match:
+          expr: V.is_submitted
+
+    - actions: ["submit", "cancel"]
+      effect: EFFECT_DENY
+      roles: ["*"]
+      condition:
+        match:
+          expr: V.is_cancelled
+
+    - actions: ["amend"]
+      effect: EFFECT_DENY
+      roles: ["*"]
+      condition:
+        match:
+          expr: "!V.is_cancelled"

--- a/cerbos/policies/resource_policies/stock/stock_entry_test.yaml
+++ b/cerbos/policies/resource_policies/stock/stock_entry_test.yaml
@@ -1,0 +1,62 @@
+# yaml-language-server: $schema=https://api.cerbos.dev/latest/cerbos/policy/v1/TestSuite.schema.json
+name: StockEntryPolicyTest
+tests:
+  - name: Stock User can submit stock entries in their company
+    input:
+      principals: [stock_user]
+      resources: [se_draft_acme]
+      actions: [create, read, write, submit]
+    expected:
+      - principal: stock_user
+        resource: se_draft_acme
+        actions:
+          create: EFFECT_ALLOW
+          read: EFFECT_ALLOW
+          write: EFFECT_ALLOW
+          submit: EFFECT_ALLOW
+
+  - name: Manufacturing User can also submit stock entries
+    input:
+      principals: [manufacturing_user]
+      resources: [se_draft_acme]
+      actions: [submit]
+    expected:
+      - principal: manufacturing_user
+        resource: se_draft_acme
+        actions:
+          submit: EFFECT_ALLOW
+
+  - name: Cross-company stock user denied
+    input:
+      principals: [other_company_stock_user]
+      resources: [se_draft_acme]
+      actions: [read, write]
+    expected:
+      - principal: other_company_stock_user
+        resource: se_draft_acme
+        actions:
+          read: EFFECT_DENY
+          write: EFFECT_DENY
+
+  - name: Submitted stock entry is locked from edits
+    input:
+      principals: [stock_manager]
+      resources: [se_submitted_acme]
+      actions: [write, cancel]
+    expected:
+      - principal: stock_manager
+        resource: se_submitted_acme
+        actions:
+          write: EFFECT_DENY
+          cancel: EFFECT_ALLOW
+
+  - name: Sales User has no access to stock entries
+    input:
+      principals: [sales_user]
+      resources: [se_draft_acme]
+      actions: [read]
+    expected:
+      - principal: sales_user
+        resource: se_draft_acme
+        actions:
+          read: EFFECT_DENY

--- a/cerbos/policies/resource_policies/stock/testdata/principals.yaml
+++ b/cerbos/policies/resource_policies/stock/testdata/principals.yaml
@@ -1,0 +1,66 @@
+# yaml-language-server: $schema=https://api.cerbos.dev/latest/cerbos/policy/v1/TestFixture/Principals.schema.json
+principals:
+  system_manager:
+    id: "sysmgr@acme.test"
+    roles: [System Manager]
+    attr:
+      user_type: System User
+      company: Acme
+      allowed_companies: ["Acme"]
+
+  item_manager:
+    id: "item.mgr@acme.test"
+    roles: [Item Manager]
+    attr:
+      user_type: System User
+      company: Acme
+      allowed_companies: ["Acme"]
+
+  stock_manager:
+    id: "stock.mgr@acme.test"
+    roles: [Stock Manager]
+    attr:
+      user_type: System User
+      company: Acme
+      allowed_companies: ["Acme"]
+
+  stock_user:
+    id: "stock.user@acme.test"
+    roles: [Stock User]
+    attr:
+      user_type: System User
+      company: Acme
+      allowed_companies: ["Acme"]
+
+  manufacturing_user:
+    id: "mfg.user@acme.test"
+    roles: [Manufacturing User]
+    attr:
+      user_type: System User
+      company: Acme
+      allowed_companies: ["Acme"]
+
+  sales_user:
+    id: "sales.user@acme.test"
+    roles: [Sales User]
+    attr:
+      user_type: System User
+      company: Acme
+      allowed_companies: ["Acme"]
+
+  customer_portal_user:
+    id: "alice@bigco.test"
+    roles: [Customer]
+    attr:
+      user_type: Website User
+      company: Acme
+      allowed_companies: []
+      customer: "BigCo"
+
+  other_company_stock_user:
+    id: "stock@globex.test"
+    roles: [Stock User]
+    attr:
+      user_type: System User
+      company: Globex
+      allowed_companies: ["Globex"]

--- a/cerbos/policies/resource_policies/stock/testdata/resources.yaml
+++ b/cerbos/policies/resource_policies/stock/testdata/resources.yaml
@@ -1,0 +1,37 @@
+# yaml-language-server: $schema=https://api.cerbos.dev/latest/cerbos/policy/v1/TestFixture/Resources.schema.json
+resources:
+  item_widget:
+    kind: item
+    id: WIDGET-1
+    attr:
+      owner: item.mgr@acme.test
+      item_group: Products
+      disabled: false
+      is_stock_item: true
+
+  se_draft_acme:
+    kind: stock_entry
+    id: STE-001
+    attr:
+      company: Acme
+      owner: stock.user@acme.test
+      docstatus: 0
+      purpose: Material Issue
+
+  se_submitted_acme:
+    kind: stock_entry
+    id: STE-002
+    attr:
+      company: Acme
+      owner: stock.user@acme.test
+      docstatus: 1
+      purpose: Material Issue
+
+  se_other_company:
+    kind: stock_entry
+    id: STE-003
+    attr:
+      company: Globex
+      owner: stock@globex.test
+      docstatus: 0
+      purpose: Material Issue

--- a/erpnext/cerbos_authz/__init__.py
+++ b/erpnext/cerbos_authz/__init__.py
@@ -1,0 +1,23 @@
+"""Cerbos authorization integration for ERPNext.
+
+Replaces ERPNext's reliance on Frappe DocType row-level permissions with calls
+to an external Cerbos PDP. The PDP is configured via site_config:
+
+    {
+        "cerbos_host": "localhost:3593",   # gRPC endpoint
+        "cerbos_tls":  false,
+        "cerbos_fail_closed": true,        # deny on PDP errors (default true)
+    }
+"""
+
+from erpnext.cerbos_authz.hooks import (
+    cerbos_has_permission,
+    cerbos_permission_query_conditions,
+    DOCTYPE_TO_RESOURCE,
+)
+
+__all__ = [
+    "cerbos_has_permission",
+    "cerbos_permission_query_conditions",
+    "DOCTYPE_TO_RESOURCE",
+]

--- a/erpnext/cerbos_authz/client.py
+++ b/erpnext/cerbos_authz/client.py
@@ -1,0 +1,51 @@
+"""Thread-safe Cerbos client singleton.
+
+Wraps the official `cerbos` Python SDK. The client is lazily initialised on
+first use and reused for the lifetime of the worker process.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Optional
+
+import frappe
+
+
+_lock = threading.Lock()
+_client = None
+
+
+def get_client():
+    """Return a cached Cerbos gRPC client, creating it on first call."""
+    global _client
+    if _client is not None:
+        return _client
+
+    with _lock:
+        if _client is not None:
+            return _client
+
+        from cerbos.sdk.grpc.client import CerbosClient
+
+        host = frappe.conf.get("cerbos_host", "localhost:3593")
+        use_tls = bool(frappe.conf.get("cerbos_tls", False))
+
+        _client = CerbosClient(host=host, tls_verify=use_tls)
+        return _client
+
+
+def fail_closed() -> bool:
+    """When the PDP is unreachable, deny rather than allow.
+
+    Defaults to True. Set ``cerbos_fail_closed`` to ``false`` in
+    ``site_config.json`` to fail open during local development.
+    """
+    return bool(frappe.conf.get("cerbos_fail_closed", True))
+
+
+def reset_client_for_testing() -> None:
+    """Drop the cached client. Used by unit tests."""
+    global _client
+    with _lock:
+        _client = None

--- a/erpnext/cerbos_authz/hooks.py
+++ b/erpnext/cerbos_authz/hooks.py
@@ -1,0 +1,128 @@
+"""Hook callbacks ERPNext registers with Frappe for Cerbos-managed doctypes.
+
+Wired in ``erpnext/hooks.py`` via ``has_permission`` and
+``permission_query_conditions``.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import frappe
+from frappe import _
+
+from erpnext.cerbos_authz.client import fail_closed, get_client
+from erpnext.cerbos_authz.principal import build_principal
+from erpnext.cerbos_authz.resources import DOCTYPE_TO_RESOURCE, build_resource
+
+
+# Mapping from Frappe ptype → Cerbos action name. They line up 1:1 today, but
+# this indirection keeps room for future divergence (e.g. compound actions).
+_PTYPE_TO_ACTION = {
+    "read": "read",
+    "write": "write",
+    "create": "create",
+    "delete": "delete",
+    "submit": "submit",
+    "cancel": "cancel",
+    "amend": "amend",
+    "print": "print",
+    "email": "email",
+    "export": "export",
+    "import": "import",
+    "share": "share",
+    "report": "report",
+}
+
+
+def cerbos_has_permission(doc, ptype: str = "read", user: Optional[str] = None) -> bool:
+    """``has_permission`` hook callback for any Cerbos-managed doctype.
+
+    Returns:
+        True if the PDP says ``EFFECT_ALLOW``, False otherwise. On PDP errors
+        we honour ``cerbos_fail_closed`` (default: deny).
+    """
+    user = user or frappe.session.user
+
+    # Administrator bypass keeps install/migration scripts working.
+    if user == "Administrator":
+        return True
+
+    doctype = getattr(doc, "doctype", None) or (doc.get("doctype") if hasattr(doc, "get") else None)
+    if not doctype or doctype not in DOCTYPE_TO_RESOURCE:
+        # Not under Cerbos management — defer to the framework default by
+        # returning None so Frappe applies its own logic.
+        return None  # type: ignore[return-value]
+
+    action = _PTYPE_TO_ACTION.get(ptype, ptype)
+
+    try:
+        principal = build_principal(user)
+        resource = build_resource(doctype, doc)
+        if resource is None:
+            return None  # type: ignore[return-value]
+        client = get_client()
+        decision = client.is_allowed(action, principal, resource)
+        return bool(decision)
+    except Exception:
+        frappe.log_error(
+            title="Cerbos PDP error",
+            message=f"doctype={doctype} ptype={ptype} user={user}",
+        )
+        if fail_closed():
+            return False
+        # Fall back to the framework default.
+        return None  # type: ignore[return-value]
+
+
+def cerbos_permission_query_conditions(user: Optional[str] = None) -> str:
+    """``permission_query_conditions`` callback used to filter list views.
+
+    For Customer/Supplier portal users we restrict the result set to documents
+    linked to their party. Internal users currently see everything they have
+    framework-level access to — per-row filtering for them is left to Frappe's
+    User Permission system to keep query overhead low.
+    """
+    user = user or frappe.session.user
+    if user in ("Administrator", "Guest"):
+        return ""
+
+    from erpnext.cerbos_authz.principal import _linked_party  # type: ignore
+
+    parts = []
+    customer_filters = _linked_party(user, "Customer")
+    if customer_filters:
+        joined = ", ".join(frappe.db.escape(c) for c in customer_filters)
+        parts.append(f"`tab{{doctype}}`.`customer` in ({joined})")
+
+    supplier_filters = _linked_party(user, "Supplier")
+    if supplier_filters:
+        joined = ", ".join(frappe.db.escape(s) for s in supplier_filters)
+        parts.append(f"`tab{{doctype}}`.`supplier` in ({joined})")
+
+    if not parts:
+        return ""
+    return " or ".join(parts)
+
+
+# --- per-doctype thunks ------------------------------------------------------
+# Frappe registers each ``has_permission`` entry against a single doctype.
+# These thunks let us reference one callable per doctype in ``hooks.py`` while
+# delegating to the shared implementation above.
+
+
+def _make_thunk(doctype: str):
+    def _thunk(doc, ptype: str = "read", user: Optional[str] = None) -> bool:
+        if not getattr(doc, "doctype", None) and hasattr(doc, "get"):
+            # Some callers pass a dict. Inject the doctype so the dispatch
+            # works.
+            doc["doctype"] = doctype
+        return cerbos_has_permission(doc, ptype=ptype, user=user)
+
+    _thunk.__name__ = f"has_permission_{doctype.lower().replace(' ', '_')}"
+    return _thunk
+
+
+HAS_PERMISSION_HOOKS = {
+    doctype: _make_thunk(doctype) for doctype in DOCTYPE_TO_RESOURCE.keys()
+}

--- a/erpnext/cerbos_authz/principal.py
+++ b/erpnext/cerbos_authz/principal.py
@@ -1,0 +1,119 @@
+"""Build a Cerbos Principal from a Frappe user.
+
+The principal mirrors the schema declared in
+``cerbos/policies/_schemas/principal.json``: roles, default + allowed
+companies, linked Employee/Customer/Supplier records, and approver lists.
+"""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import Optional
+
+import frappe
+from frappe.utils.user import is_website_user
+
+
+def build_principal(user: Optional[str] = None):
+    """Construct a `cerbos.sdk.model.Principal` for the given user.
+
+    The result is per-request (not cached across users) but the underlying
+    lookups against Frappe's DB are cheap because they're tiny indexed
+    queries.
+    """
+    from cerbos.sdk.model import Principal
+
+    user = user or frappe.session.user
+    roles = frappe.get_roles(user)
+    user_type = "Website User" if is_website_user(user) else "System User"
+
+    attr = {
+        "user_type": user_type,
+        "company": _default_company(user) or "",
+        "allowed_companies": _allowed_companies(user),
+    }
+
+    employee = _linked_employee(user)
+    if employee:
+        attr["employee"] = employee
+
+    customers = _linked_party(user, "Customer")
+    if customers:
+        # Cerbos schema permits a single linked customer; pick the first.
+        attr["customer"] = customers[0]
+
+    suppliers = _linked_party(user, "Supplier")
+    if suppliers:
+        attr["supplier"] = suppliers[0]
+
+    leave_for = _approver_for(user, "leave_approver")
+    if leave_for:
+        attr["leave_approver_for"] = leave_for
+
+    expense_for = _approver_for(user, "expense_approver")
+    if expense_for:
+        attr["expense_approver_for"] = expense_for
+
+    department = frappe.db.get_value("Employee", {"user_id": user}, "department")
+    if department:
+        attr["department"] = department
+
+    territory = frappe.db.get_default("territory", user)
+    if territory:
+        attr["territory"] = territory
+
+    return Principal(id=user, roles=roles, attr=attr)
+
+
+def _default_company(user: str) -> Optional[str]:
+    return frappe.defaults.get_user_default("company", user)
+
+
+def _allowed_companies(user: str) -> list[str]:
+    """Companies the user has User Permission rows for, plus their default.
+
+    Frappe stores these in the `User Permission` doctype with
+    ``allow == "Company"``. If a user has *no* User Permissions for Company,
+    Frappe convention is unrestricted access — we represent that by adding
+    every company to the list.
+    """
+    rows = frappe.get_all(
+        "User Permission",
+        filters={"user": user, "allow": "Company"},
+        fields=["for_value"],
+    )
+    if rows:
+        return [r["for_value"] for r in rows]
+    # Unrestricted: return all companies.
+    return [c["name"] for c in frappe.get_all("Company", fields=["name"])]
+
+
+def _linked_employee(user: str) -> Optional[str]:
+    return frappe.db.get_value("Employee", {"user_id": user}, "name")
+
+
+def _linked_party(user: str, party_type: str) -> list[str]:
+    """Return the list of `Customer`/`Supplier` records linked to this user
+    via the `Portal User` child table."""
+    if user in ("Administrator", "Guest"):
+        return []
+    return [
+        row["parent"]
+        for row in frappe.get_all(
+            "Portal User",
+            filters={"user": user, "parenttype": party_type},
+            fields=["parent"],
+        )
+    ]
+
+
+def _approver_for(user: str, fieldname: str) -> list[str]:
+    """Employees for whom this user is the configured approver."""
+    return [
+        row["name"]
+        for row in frappe.get_all(
+            "Employee",
+            filters={fieldname: user, "status": "Active"},
+            fields=["name"],
+        )
+    ]

--- a/erpnext/cerbos_authz/resources.py
+++ b/erpnext/cerbos_authz/resources.py
@@ -1,0 +1,264 @@
+"""Mapping of ERPNext DocTypes to Cerbos resource kinds + attribute extractors.
+
+Each entry tells the integration:
+
+- ``kind``         — the resource kind in the Cerbos policy (snake_case).
+- ``attrs``        — a callable taking a Frappe ``Document`` (or dict) and
+                     returning the dict of attributes the resource policy
+                     expects, mirroring the JSON schema in
+                     ``cerbos/policies/_schemas/resources/<kind>.json``.
+
+To add a new doctype to the Cerbos integration, add an entry here and ship a
+matching policy + schema under ``cerbos/policies/``.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, Optional
+
+import frappe
+
+
+# --- attribute builders ------------------------------------------------------
+
+
+def _common(doc) -> Dict[str, Any]:
+    return {
+        "owner": doc.get("owner") or "",
+        "docstatus": int(doc.get("docstatus") or 0),
+    }
+
+
+def _company_country(company: Optional[str]) -> Optional[str]:
+    if not company:
+        return None
+    return frappe.db.get_value("Company", company, "country")
+
+
+def _sales_invoice_attrs(doc) -> Dict[str, Any]:
+    company = doc.get("company")
+    return {
+        **_common(doc),
+        "company": company or "",
+        "customer": doc.get("customer") or "",
+        "is_return": bool(doc.get("is_return")),
+        "country": _company_country(company) or "",
+    }
+
+
+def _purchase_invoice_attrs(doc) -> Dict[str, Any]:
+    company = doc.get("company")
+    return {
+        **_common(doc),
+        "company": company or "",
+        "supplier": doc.get("supplier") or "",
+        "is_return": bool(doc.get("is_return")),
+        "country": _company_country(company) or "",
+    }
+
+
+def _payment_entry_attrs(doc) -> Dict[str, Any]:
+    company = doc.get("company")
+    return {
+        **_common(doc),
+        "company": company or "",
+        "payment_type": doc.get("payment_type") or "Receive",
+        "country": _company_country(company) or "",
+    }
+
+
+def _journal_entry_attrs(doc) -> Dict[str, Any]:
+    return {**_common(doc), "company": doc.get("company") or ""}
+
+
+def _customer_attrs(doc) -> Dict[str, Any]:
+    return {
+        "owner": doc.get("owner") or "",
+        "territory": doc.get("territory") or "",
+        "customer_group": doc.get("customer_group") or "",
+        "disabled": bool(doc.get("disabled")),
+    }
+
+
+def _supplier_attrs(doc) -> Dict[str, Any]:
+    return {
+        "owner": doc.get("owner") or "",
+        "supplier_group": doc.get("supplier_group") or "",
+        "disabled": bool(doc.get("disabled")),
+    }
+
+
+def _quotation_attrs(doc) -> Dict[str, Any]:
+    return {
+        **_common(doc),
+        "company": doc.get("company") or "",
+        "customer": doc.get("party_name") or doc.get("customer") or "",
+        "territory": doc.get("territory") or "",
+        "status": doc.get("status") or "Draft",
+    }
+
+
+def _sales_order_attrs(doc) -> Dict[str, Any]:
+    return {
+        **_common(doc),
+        "company": doc.get("company") or "",
+        "customer": doc.get("customer") or "",
+        "status": doc.get("status") or "Draft",
+    }
+
+
+def _delivery_note_attrs(doc) -> Dict[str, Any]:
+    return {
+        **_common(doc),
+        "company": doc.get("company") or "",
+        "customer": doc.get("customer") or "",
+        "is_return": bool(doc.get("is_return")),
+    }
+
+
+def _purchase_order_attrs(doc) -> Dict[str, Any]:
+    return {
+        **_common(doc),
+        "company": doc.get("company") or "",
+        "supplier": doc.get("supplier") or "",
+        "status": doc.get("status") or "Draft",
+    }
+
+
+def _purchase_receipt_attrs(doc) -> Dict[str, Any]:
+    return {
+        **_common(doc),
+        "company": doc.get("company") or "",
+        "supplier": doc.get("supplier") or "",
+        "is_return": bool(doc.get("is_return")),
+    }
+
+
+def _item_attrs(doc) -> Dict[str, Any]:
+    return {
+        "owner": doc.get("owner") or "",
+        "item_group": doc.get("item_group") or "",
+        "disabled": bool(doc.get("disabled")),
+        "is_stock_item": bool(doc.get("is_stock_item")),
+    }
+
+
+def _stock_entry_attrs(doc) -> Dict[str, Any]:
+    return {
+        **_common(doc),
+        "company": doc.get("company") or "",
+        "purpose": doc.get("purpose") or "Material Issue",
+    }
+
+
+def _employee_attrs(doc) -> Dict[str, Any]:
+    return {
+        "company": doc.get("company") or "",
+        "owner": doc.get("owner") or "",
+        "user_id": doc.get("user_id") or "",
+        "department": doc.get("department") or "",
+        "status": doc.get("status") or "Active",
+    }
+
+
+def _leave_application_attrs(doc) -> Dict[str, Any]:
+    return {
+        **_common(doc),
+        "company": doc.get("company") or "",
+        "employee": doc.get("employee") or "",
+        "status": doc.get("status") or "Open",
+        "leave_approver": doc.get("leave_approver") or "",
+    }
+
+
+def _expense_claim_attrs(doc) -> Dict[str, Any]:
+    return {
+        **_common(doc),
+        "company": doc.get("company") or "",
+        "employee": doc.get("employee") or "",
+        "approval_status": doc.get("approval_status") or "Draft",
+        "expense_approver": doc.get("expense_approver") or "",
+    }
+
+
+def _timesheet_attrs(doc) -> Dict[str, Any]:
+    return {
+        **_common(doc),
+        "company": doc.get("company") or "",
+        "employee": doc.get("employee") or "",
+        "customer": doc.get("customer") or "",
+    }
+
+
+def _project_attrs(doc) -> Dict[str, Any]:
+    return {
+        "company": doc.get("company") or "",
+        "owner": doc.get("owner") or "",
+        "customer": doc.get("customer") or "",
+        "status": doc.get("status") or "Open",
+    }
+
+
+def _task_attrs(doc) -> Dict[str, Any]:
+    assigned = []
+    raw = doc.get("_assign")
+    if raw:
+        try:
+            import json
+            assigned = json.loads(raw)
+        except (TypeError, ValueError):
+            assigned = []
+    return {
+        "owner": doc.get("owner") or "",
+        "project": doc.get("project") or "",
+        "status": doc.get("status") or "Open",
+        "assigned_to": assigned,
+    }
+
+
+# --- registry ----------------------------------------------------------------
+
+DOCTYPE_TO_RESOURCE: Dict[str, Dict[str, Any]] = {
+    # accounts
+    "Sales Invoice": {"kind": "sales_invoice", "attrs": _sales_invoice_attrs},
+    "Purchase Invoice": {"kind": "purchase_invoice", "attrs": _purchase_invoice_attrs},
+    "Payment Entry": {"kind": "payment_entry", "attrs": _payment_entry_attrs},
+    "Journal Entry": {"kind": "journal_entry", "attrs": _journal_entry_attrs},
+    # selling
+    "Customer": {"kind": "customer", "attrs": _customer_attrs},
+    "Quotation": {"kind": "quotation", "attrs": _quotation_attrs},
+    "Sales Order": {"kind": "sales_order", "attrs": _sales_order_attrs},
+    "Delivery Note": {"kind": "delivery_note", "attrs": _delivery_note_attrs},
+    # buying
+    "Supplier": {"kind": "supplier", "attrs": _supplier_attrs},
+    "Purchase Order": {"kind": "purchase_order", "attrs": _purchase_order_attrs},
+    "Purchase Receipt": {"kind": "purchase_receipt", "attrs": _purchase_receipt_attrs},
+    # stock
+    "Item": {"kind": "item", "attrs": _item_attrs},
+    "Stock Entry": {"kind": "stock_entry", "attrs": _stock_entry_attrs},
+    # hr
+    "Employee": {"kind": "employee", "attrs": _employee_attrs},
+    "Leave Application": {"kind": "leave_application", "attrs": _leave_application_attrs},
+    "Expense Claim": {"kind": "expense_claim", "attrs": _expense_claim_attrs},
+    "Timesheet": {"kind": "timesheet", "attrs": _timesheet_attrs},
+    # projects
+    "Project": {"kind": "project", "attrs": _project_attrs},
+    "Task": {"kind": "task", "attrs": _task_attrs},
+}
+
+
+def build_resource(doctype: str, doc):
+    """Build a Cerbos `Resource` for the given Frappe document.
+
+    Returns ``None`` if the doctype is not under Cerbos management; the caller
+    should defer to the framework default in that case.
+    """
+    spec = DOCTYPE_TO_RESOURCE.get(doctype)
+    if not spec:
+        return None
+
+    from cerbos.sdk.model import Resource
+
+    name = doc.get("name") or doc.get("id") or ""
+    attrs = spec["attrs"](doc)
+    return Resource(id=name, kind=spec["kind"], attr=attrs)

--- a/erpnext/hooks.py
+++ b/erpnext/hooks.py
@@ -304,6 +304,48 @@ sounds = [
 
 has_upload_permission = {"Employee": "erpnext.setup.doctype.employee.employee.has_upload_permission"}
 
+# --- Cerbos authorization ----------------------------------------------------
+# Permission decisions for the doctypes below are delegated to a Cerbos PDP.
+# Policies live under ``cerbos/policies/``; Python wiring lives in
+# ``erpnext/cerbos_authz/``. See ``cerbos/README.md`` for setup instructions.
+has_permission = {
+	"Sales Invoice":      "erpnext.cerbos_authz.hooks.cerbos_has_permission",
+	"Purchase Invoice":   "erpnext.cerbos_authz.hooks.cerbos_has_permission",
+	"Payment Entry":      "erpnext.cerbos_authz.hooks.cerbos_has_permission",
+	"Journal Entry":      "erpnext.cerbos_authz.hooks.cerbos_has_permission",
+	"Customer":           "erpnext.cerbos_authz.hooks.cerbos_has_permission",
+	"Quotation":          "erpnext.cerbos_authz.hooks.cerbos_has_permission",
+	"Sales Order":        "erpnext.cerbos_authz.hooks.cerbos_has_permission",
+	"Delivery Note":      "erpnext.cerbos_authz.hooks.cerbos_has_permission",
+	"Supplier":           "erpnext.cerbos_authz.hooks.cerbos_has_permission",
+	"Purchase Order":     "erpnext.cerbos_authz.hooks.cerbos_has_permission",
+	"Purchase Receipt":   "erpnext.cerbos_authz.hooks.cerbos_has_permission",
+	"Item":               "erpnext.cerbos_authz.hooks.cerbos_has_permission",
+	"Stock Entry":        "erpnext.cerbos_authz.hooks.cerbos_has_permission",
+	"Employee":           "erpnext.cerbos_authz.hooks.cerbos_has_permission",
+	"Leave Application":  "erpnext.cerbos_authz.hooks.cerbos_has_permission",
+	"Expense Claim":      "erpnext.cerbos_authz.hooks.cerbos_has_permission",
+	"Timesheet":          "erpnext.cerbos_authz.hooks.cerbos_has_permission",
+	"Project":            "erpnext.cerbos_authz.hooks.cerbos_has_permission",
+	"Task":               "erpnext.cerbos_authz.hooks.cerbos_has_permission",
+}
+
+# Restrict list-view queries for portal users to documents linked to their
+# Customer / Supplier party. Internal users continue to use Frappe's User
+# Permission row scoping.
+permission_query_conditions = {
+	"Sales Invoice":      "erpnext.cerbos_authz.hooks.cerbos_permission_query_conditions",
+	"Purchase Invoice":   "erpnext.cerbos_authz.hooks.cerbos_permission_query_conditions",
+	"Quotation":          "erpnext.cerbos_authz.hooks.cerbos_permission_query_conditions",
+	"Sales Order":        "erpnext.cerbos_authz.hooks.cerbos_permission_query_conditions",
+	"Delivery Note":      "erpnext.cerbos_authz.hooks.cerbos_permission_query_conditions",
+	"Purchase Order":     "erpnext.cerbos_authz.hooks.cerbos_permission_query_conditions",
+	"Purchase Receipt":   "erpnext.cerbos_authz.hooks.cerbos_permission_query_conditions",
+	"Project":            "erpnext.cerbos_authz.hooks.cerbos_permission_query_conditions",
+	"Timesheet":          "erpnext.cerbos_authz.hooks.cerbos_permission_query_conditions",
+}
+# --- end Cerbos authorization ------------------------------------------------
+
 has_website_permission = {
 	"Sales Order": "erpnext.controllers.website_list_for_contact.has_website_permission",
 	"Quotation": "erpnext.controllers.website_list_for_contact.has_website_permission",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,9 @@ dependencies = [
 
     # MT940 parser for bank statements
     "mt-940>=4.26.0",
+
+    # Cerbos PDP client for the authorization integration in cerbos_authz/.
+    "cerbos~=0.13",
 ]
 
 [build-system]

--- a/tests/cerbos_authz/__init__.py
+++ b/tests/cerbos_authz/__init__.py
@@ -1,0 +1,7 @@
+"""Unit tests for the ERPNext ↔ Cerbos integration.
+
+These tests stub out ``frappe`` and the ``cerbos`` SDK so they run without
+a Frappe site or a live Cerbos PDP. Run from the repo root::
+
+    python -m unittest discover tests/cerbos_authz -v
+"""

--- a/tests/cerbos_authz/_stubs.py
+++ b/tests/cerbos_authz/_stubs.py
@@ -1,0 +1,226 @@
+"""Lightweight stand-ins for ``frappe`` and the ``cerbos`` SDK.
+
+Installed by each test module via ``install_stubs()`` BEFORE importing
+``erpnext.cerbos_authz.*`` (because ``erpnext/__init__.py`` itself imports
+``frappe`` at module load time).
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from typing import Any, Dict, List, Optional
+
+
+# --- frappe stub -------------------------------------------------------------
+
+
+class _FakeDB:
+    def __init__(self, owner: "FakeFrappe"):
+        self._owner = owner
+
+    def get_value(self, doctype, filters=None, fieldname=None, **kw):
+        return self._owner.db_values.get((doctype, _hashable(filters), fieldname))
+
+    def get_default(self, key, user=None):
+        return self._owner.user_defaults.get((user, key))
+
+    def escape(self, value):
+        return f"'{value}'"
+
+
+class _FakeDefaults:
+    def __init__(self, owner: "FakeFrappe"):
+        self._owner = owner
+
+    def get_user_default(self, key, user=None):
+        return self._owner.user_defaults.get((user, key))
+
+
+class _FakeSession:
+    def __init__(self):
+        self.user = "Administrator"
+
+
+class FakeFrappe(types.ModuleType):
+    def __init__(self):
+        super().__init__("frappe")
+        self.db = _FakeDB(self)
+        self.defaults = _FakeDefaults(self)
+        self.session = _FakeSession()
+        self.conf: Dict[str, Any] = {}
+        self.user_roles: Dict[str, List[str]] = {}
+        self.get_all_results: Dict[str, List[Dict[str, Any]]] = {}
+        self.db_values: Dict[tuple, Any] = {}
+        self.user_defaults: Dict[tuple, Any] = {}
+        self.logged_errors: List[Dict[str, str]] = []
+
+    def get_roles(self, user):
+        return list(self.user_roles.get(user, []))
+
+    def get_all(self, doctype, filters=None, fields=None, **kw):
+        rows = list(self.get_all_results.get(doctype, []))
+        if filters:
+            rows = [r for r in rows if _matches(r, filters)]
+        if fields:
+            rows = [{f: r.get(f) for f in fields} for r in rows]
+        return rows
+
+    def log_error(self, title=None, message=None):
+        self.logged_errors.append({"title": title or "", "message": message or ""})
+
+    def _(self, s):
+        return s
+
+
+def _matches(row: Dict[str, Any], filters) -> bool:
+    if isinstance(filters, dict):
+        return all(row.get(k) == v for k, v in filters.items())
+    if isinstance(filters, list):
+        for f in filters:
+            _, field, op, value = f
+            if op == "in":
+                if row.get(field) not in value:
+                    return False
+            elif row.get(field) != value:
+                return False
+        return True
+    return True
+
+
+def _hashable(x):
+    if isinstance(x, dict):
+        return tuple(sorted(x.items()))
+    return x
+
+
+# --- cerbos SDK stub ---------------------------------------------------------
+
+
+class FakePrincipal:
+    def __init__(self, id, roles, attr=None):
+        self.id = id
+        self.roles = list(roles)
+        self.attr = dict(attr or {})
+
+    def __repr__(self):
+        return f"FakePrincipal({self.id!r}, {self.roles!r}, {self.attr!r})"
+
+
+class FakeResource:
+    def __init__(self, id, kind, attr=None):
+        self.id = id
+        self.kind = kind
+        self.attr = dict(attr or {})
+
+    def __repr__(self):
+        return f"FakeResource({self.id!r}, {self.kind!r}, {self.attr!r})"
+
+
+class FakeCerbosClient:
+    def __init__(self, host=None, tls_verify=False, **kw):
+        self.host = host
+        self.tls_verify = tls_verify
+        self.calls: List[tuple] = []
+        self.next_decision: bool = True
+        self.raise_on_call: Optional[Exception] = None
+
+    def is_allowed(self, action, principal, resource):
+        self.calls.append((action, principal, resource))
+        if self.raise_on_call is not None:
+            raise self.raise_on_call
+        return self.next_decision
+
+
+# --- module installation -----------------------------------------------------
+
+
+def install_stubs() -> FakeFrappe:
+    """Install fake ``frappe`` + ``cerbos.sdk.*`` modules in ``sys.modules``.
+
+    Also installs a minimal ``erpnext`` package shim so ``import
+    erpnext.cerbos_authz.*`` resolves without executing
+    ``erpnext/__init__.py`` (which would pull in the full Frappe stack).
+
+    Always replaces any existing entries — calling between tests gives each
+    one a clean slate.
+    """
+    fake_frappe = _make_frappe_package()
+    sys.modules["frappe"] = fake_frappe
+
+    utils = types.ModuleType("frappe.utils")
+    utils.__path__ = []
+    user_mod = types.ModuleType("frappe.utils.user")
+
+    def is_website_user(user=None):
+        roles = fake_frappe.user_roles.get(user or fake_frappe.session.user, [])
+        return any(r in ("Customer", "Supplier", "Guest") for r in roles)
+
+    user_mod.is_website_user = is_website_user
+    utils.user = user_mod
+    sys.modules["frappe.utils"] = utils
+    sys.modules["frappe.utils.user"] = user_mod
+    fake_frappe.utils = utils
+
+    # frappe.model.document.Document — referenced by erpnext/__init__.py if it
+    # ever loads. We install it so the shim doesn't crash on accidental
+    # re-import paths.
+    model_pkg = types.ModuleType("frappe.model")
+    model_pkg.__path__ = []
+    document_mod = types.ModuleType("frappe.model.document")
+    document_mod.Document = type("Document", (), {})
+    model_pkg.document = document_mod
+    fake_frappe.model = model_pkg
+    sys.modules["frappe.model"] = model_pkg
+    sys.modules["frappe.model.document"] = document_mod
+
+    cerbos_pkg = types.ModuleType("cerbos")
+    cerbos_pkg.__path__ = []
+    sdk_pkg = types.ModuleType("cerbos.sdk")
+    sdk_pkg.__path__ = []
+    model_mod = types.ModuleType("cerbos.sdk.model")
+    grpc_pkg = types.ModuleType("cerbos.sdk.grpc")
+    grpc_pkg.__path__ = []
+    grpc_client_mod = types.ModuleType("cerbos.sdk.grpc.client")
+
+    model_mod.Principal = FakePrincipal
+    model_mod.Resource = FakeResource
+    grpc_client_mod.CerbosClient = FakeCerbosClient
+
+    sdk_pkg.model = model_mod
+    sdk_pkg.grpc = grpc_pkg
+    grpc_pkg.client = grpc_client_mod
+    cerbos_pkg.sdk = sdk_pkg
+
+    sys.modules["cerbos"] = cerbos_pkg
+    sys.modules["cerbos.sdk"] = sdk_pkg
+    sys.modules["cerbos.sdk.model"] = model_mod
+    sys.modules["cerbos.sdk.grpc"] = grpc_pkg
+    sys.modules["cerbos.sdk.grpc.client"] = grpc_client_mod
+
+    # Drop any cached erpnext.* and tests.cerbos_authz._stubs-driven imports so
+    # the next ``import erpnext.cerbos_authz.X`` re-binds against the freshly
+    # installed stubs.
+    for mod in list(sys.modules):
+        if mod.startswith("erpnext"):
+            sys.modules.pop(mod, None)
+
+    # Install a shim ``erpnext`` package whose __path__ points at the real
+    # source dir, but whose __init__ does NOT execute. This lets us import
+    # submodules without dragging in the full erpnext bootstrap.
+    import os.path
+    here = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    erpnext_path = os.path.join(here, "erpnext")
+    erpnext_pkg = types.ModuleType("erpnext")
+    erpnext_pkg.__path__ = [erpnext_path]
+    sys.modules["erpnext"] = erpnext_pkg
+
+    return fake_frappe
+
+
+def _make_frappe_package() -> FakeFrappe:
+    """Build a fresh ``FakeFrappe`` configured as a Python package."""
+    f = FakeFrappe()
+    # Mark as a package so submodule imports resolve.
+    f.__path__ = []  # type: ignore[attr-defined]
+    return f

--- a/tests/cerbos_authz/test_hooks.py
+++ b/tests/cerbos_authz/test_hooks.py
@@ -1,0 +1,186 @@
+"""Tests for ``erpnext.cerbos_authz.hooks``.
+
+Covers:
+- Administrator bypass.
+- Unknown doctype passthrough (``None`` so Frappe falls back to its default).
+- ALLOW / DENY round trip via the stubbed PDP client.
+- Fail-closed behaviour when the PDP raises.
+- Permission-query SQL generation for portal users.
+"""
+
+import importlib
+import unittest
+
+from tests.cerbos_authz._stubs import install_stubs
+
+
+def _doc(doctype, data):
+    class _D:
+        def __init__(self):
+            self.doctype = doctype
+            self._data = dict(data)
+
+        def get(self, key, default=None):
+            if key == "doctype":
+                return self.doctype
+            return self._data.get(key, default)
+
+    return _D()
+
+
+class HasPermissionTests(unittest.TestCase):
+    def setUp(self):
+        self.frappe = install_stubs()
+        self.client_module = importlib.import_module("erpnext.cerbos_authz.client")
+        self.client_module.reset_client_for_testing()
+        self.hooks_module = importlib.import_module("erpnext.cerbos_authz.hooks")
+
+    def _last_client(self):
+        return self.client_module.get_client()
+
+    def _seed_principal(self, user, roles, company="Acme"):
+        self.frappe.user_roles[user] = list(roles)
+        self.frappe.user_defaults[(user, "company")] = company
+        self.frappe.get_all_results.setdefault("User Permission", []).append(
+            {"user": user, "allow": "Company", "for_value": company}
+        )
+
+    def test_administrator_bypass(self):
+        doc = _doc("Sales Invoice", {"name": "SINV-1", "company": "Acme", "docstatus": 0})
+        self.assertTrue(
+            self.hooks_module.cerbos_has_permission(doc, "read", "Administrator")
+        )
+
+    def test_unknown_doctype_returns_none(self):
+        # Returning None lets Frappe fall back to the framework default.
+        self._seed_principal("alice@acme.test", ["Accounts User"])
+        doc = _doc("ToDo", {"name": "T-1"})
+        self.assertIsNone(
+            self.hooks_module.cerbos_has_permission(doc, "read", "alice@acme.test")
+        )
+
+    def test_known_doctype_round_trips_through_pdp(self):
+        self._seed_principal("alice@acme.test", ["Accounts User"])
+        doc = _doc(
+            "Sales Invoice",
+            {"name": "SINV-1", "company": "Acme", "owner": "alice@acme.test", "docstatus": 0, "customer": "BigCo"},
+        )
+        result = self.hooks_module.cerbos_has_permission(doc, "read", "alice@acme.test")
+        self.assertTrue(result)
+
+        client = self._last_client()
+        self.assertEqual(len(client.calls), 1)
+        action, principal, resource = client.calls[0]
+        self.assertEqual(action, "read")
+        self.assertEqual(principal.id, "alice@acme.test")
+        self.assertEqual(resource.kind, "sales_invoice")
+        self.assertEqual(resource.attr["customer"], "BigCo")
+
+    def test_pdp_deny_returns_false(self):
+        self._seed_principal("alice@acme.test", ["Accounts User"])
+        client = self._last_client()
+        client.next_decision = False
+
+        doc = _doc(
+            "Sales Invoice",
+            {"name": "SINV-1", "company": "Acme", "owner": "x@y.test", "docstatus": 1, "customer": "BigCo"},
+        )
+        self.assertFalse(
+            self.hooks_module.cerbos_has_permission(doc, "write", "alice@acme.test")
+        )
+
+    def test_pdp_error_fails_closed_by_default(self):
+        self._seed_principal("alice@acme.test", ["Accounts User"])
+        client = self._last_client()
+        client.raise_on_call = RuntimeError("PDP unreachable")
+
+        doc = _doc(
+            "Sales Invoice",
+            {"name": "SINV-1", "company": "Acme", "owner": "x@y.test", "docstatus": 0, "customer": "BigCo"},
+        )
+        self.assertFalse(
+            self.hooks_module.cerbos_has_permission(doc, "read", "alice@acme.test")
+        )
+        self.assertEqual(len(self.frappe.logged_errors), 1)
+
+    def test_pdp_error_can_fail_open_when_configured(self):
+        self.frappe.conf["cerbos_fail_closed"] = False
+        self._seed_principal("alice@acme.test", ["Accounts User"])
+        client = self._last_client()
+        client.raise_on_call = RuntimeError("PDP unreachable")
+
+        doc = _doc(
+            "Sales Invoice",
+            {"name": "SINV-1", "company": "Acme", "owner": "x@y.test", "docstatus": 0, "customer": "BigCo"},
+        )
+        # None defers to framework default rather than denying.
+        self.assertIsNone(
+            self.hooks_module.cerbos_has_permission(doc, "read", "alice@acme.test")
+        )
+
+    def test_query_conditions_empty_for_admin_and_guest(self):
+        self.assertEqual(
+            self.hooks_module.cerbos_permission_query_conditions("Administrator"), ""
+        )
+        self.assertEqual(
+            self.hooks_module.cerbos_permission_query_conditions("Guest"), ""
+        )
+
+    def test_query_conditions_for_customer_portal_user(self):
+        self.frappe.user_roles["alice@bigco.test"] = ["Customer"]
+        self.frappe.get_all_results["Portal User"] = [
+            {"user": "alice@bigco.test", "parenttype": "Customer", "parent": "BigCo"},
+            {"user": "alice@bigco.test", "parenttype": "Customer", "parent": "BigCo Subsidiary"},
+        ]
+        sql = self.hooks_module.cerbos_permission_query_conditions("alice@bigco.test")
+        self.assertIn(
+            "`tab{doctype}`.`customer` in ('BigCo', 'BigCo Subsidiary')", sql
+        )
+        self.assertNotIn("supplier", sql)
+
+    def test_query_conditions_for_supplier_portal_user(self):
+        self.frappe.user_roles["bob@megasupply.test"] = ["Supplier"]
+        self.frappe.get_all_results["Portal User"] = [
+            {"user": "bob@megasupply.test", "parenttype": "Supplier", "parent": "MegaSupply"},
+        ]
+        sql = self.hooks_module.cerbos_permission_query_conditions("bob@megasupply.test")
+        self.assertIn("`tab{doctype}`.`supplier` in ('MegaSupply')", sql)
+
+    def test_query_conditions_internal_user_is_empty(self):
+        self.frappe.user_roles["acct@acme.test"] = ["Accounts User"]
+        # No Portal User rows.
+        self.assertEqual(
+            self.hooks_module.cerbos_permission_query_conditions("acct@acme.test"), ""
+        )
+
+
+class ThunkTests(unittest.TestCase):
+    """The per-doctype thunks injected into ``hooks.HAS_PERMISSION_HOOKS``."""
+
+    def setUp(self):
+        self.frappe = install_stubs()
+        self.client_module = importlib.import_module("erpnext.cerbos_authz.client")
+        self.client_module.reset_client_for_testing()
+        self.hooks_module = importlib.import_module("erpnext.cerbos_authz.hooks")
+
+    def test_thunk_injects_doctype_for_dict_callers(self):
+        # Some callers pass a plain dict without a ``doctype`` key.
+        self.frappe.user_roles["alice@acme.test"] = ["Accounts User"]
+        self.frappe.user_defaults[("alice@acme.test", "company")] = "Acme"
+        self.frappe.get_all_results["User Permission"] = [
+            {"user": "alice@acme.test", "allow": "Company", "for_value": "Acme"},
+        ]
+
+        thunk = self.hooks_module.HAS_PERMISSION_HOOKS["Sales Invoice"]
+        result = thunk(
+            {"name": "SINV-1", "company": "Acme", "owner": "x@y.test", "docstatus": 0, "customer": "BigCo"},
+            ptype="read",
+            user="alice@acme.test",
+        )
+        self.assertTrue(result)
+        client = self.client_module.get_client()
+        self.assertEqual(client.calls[-1][2].kind, "sales_invoice")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/cerbos_authz/test_principal.py
+++ b/tests/cerbos_authz/test_principal.py
@@ -1,0 +1,93 @@
+"""Tests for ``erpnext.cerbos_authz.principal.build_principal``."""
+
+import importlib
+import unittest
+
+from tests.cerbos_authz._stubs import install_stubs
+
+
+class BuildPrincipalTests(unittest.TestCase):
+    def setUp(self):
+        self.frappe = install_stubs()
+        self.principal_module = importlib.import_module(
+            "erpnext.cerbos_authz.principal"
+        )
+
+    def test_internal_user_with_company_user_permission(self):
+        self.frappe.user_roles["alice@acme.test"] = ["Accounts User"]
+        self.frappe.get_all_results["User Permission"] = [
+            {"user": "alice@acme.test", "allow": "Company", "for_value": "Acme"},
+        ]
+        self.frappe.user_defaults[("alice@acme.test", "company")] = "Acme"
+
+        p = self.principal_module.build_principal("alice@acme.test")
+
+        self.assertEqual(p.id, "alice@acme.test")
+        self.assertEqual(p.roles, ["Accounts User"])
+        self.assertEqual(p.attr["user_type"], "System User")
+        self.assertEqual(p.attr["company"], "Acme")
+        self.assertEqual(p.attr["allowed_companies"], ["Acme"])
+        self.assertNotIn("customer", p.attr)
+        self.assertNotIn("supplier", p.attr)
+
+    def test_user_with_no_company_user_permissions_sees_all_companies(self):
+        # Frappe convention: no User Permission rows = unrestricted.
+        self.frappe.user_roles["sysmgr@acme.test"] = ["System Manager"]
+        self.frappe.get_all_results["User Permission"] = []
+        self.frappe.get_all_results["Company"] = [{"name": "Acme"}, {"name": "Globex"}]
+
+        p = self.principal_module.build_principal("sysmgr@acme.test")
+
+        self.assertEqual(set(p.attr["allowed_companies"]), {"Acme", "Globex"})
+
+    def test_portal_customer_user(self):
+        self.frappe.user_roles["alice@bigco.test"] = ["Customer"]
+        self.frappe.get_all_results["Portal User"] = [
+            {"user": "alice@bigco.test", "parenttype": "Customer", "parent": "BigCo"},
+        ]
+
+        p = self.principal_module.build_principal("alice@bigco.test")
+
+        self.assertEqual(p.attr["user_type"], "Website User")
+        self.assertEqual(p.attr["customer"], "BigCo")
+        self.assertNotIn("supplier", p.attr)
+
+    def test_portal_supplier_user(self):
+        self.frappe.user_roles["bob@megasupply.test"] = ["Supplier"]
+        self.frappe.get_all_results["Portal User"] = [
+            {"user": "bob@megasupply.test", "parenttype": "Supplier", "parent": "MegaSupply"},
+        ]
+
+        p = self.principal_module.build_principal("bob@megasupply.test")
+
+        self.assertEqual(p.attr["user_type"], "Website User")
+        self.assertEqual(p.attr["supplier"], "MegaSupply")
+
+    def test_employee_link_and_approver_lists(self):
+        self.frappe.user_roles["carol@acme.test"] = ["Employee", "HR User"]
+        self.frappe.db_values[("Employee", (("user_id", "carol@acme.test"),), "name")] = "EMP-0003"
+        self.frappe.db_values[("Employee", (("user_id", "carol@acme.test"),), "department")] = "HR"
+        self.frappe.get_all_results["Employee"] = [
+            {"name": "EMP-0001", "leave_approver": "carol@acme.test", "expense_approver": "carol@acme.test", "status": "Active"},
+            {"name": "EMP-0002", "leave_approver": "someone.else@acme.test", "status": "Active"},
+        ]
+
+        p = self.principal_module.build_principal("carol@acme.test")
+
+        self.assertEqual(p.attr["employee"], "EMP-0003")
+        self.assertEqual(p.attr["department"], "HR")
+        self.assertEqual(p.attr["leave_approver_for"], ["EMP-0001"])
+        self.assertEqual(p.attr["expense_approver_for"], ["EMP-0001"])
+
+    def test_administrator_does_not_get_party_links(self):
+        self.frappe.user_roles["Administrator"] = ["System Manager"]
+        # Even if Portal User rows exist, Administrator/Guest must not be linked.
+        self.frappe.get_all_results["Portal User"] = [
+            {"user": "Administrator", "parenttype": "Customer", "parent": "BigCo"},
+        ]
+        p = self.principal_module.build_principal("Administrator")
+        self.assertNotIn("customer", p.attr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/cerbos_authz/test_resources.py
+++ b/tests/cerbos_authz/test_resources.py
@@ -1,0 +1,139 @@
+"""Tests for ``erpnext.cerbos_authz.resources.build_resource``."""
+
+import importlib
+import unittest
+
+from tests.cerbos_authz._stubs import install_stubs
+
+
+def _doc(d):
+    """Wrap a plain dict as a duck-typed Frappe Document."""
+    class _D:
+        def __init__(self, data):
+            self._data = data
+
+        def get(self, key, default=None):
+            return self._data.get(key, default)
+
+    return _D(d)
+
+
+class BuildResourceTests(unittest.TestCase):
+    def setUp(self):
+        self.frappe = install_stubs()
+        self.resources_module = importlib.import_module(
+            "erpnext.cerbos_authz.resources"
+        )
+
+    def _build(self, doctype, doc_dict):
+        return self.resources_module.build_resource(doctype, _doc(doc_dict))
+
+    def test_unknown_doctype_returns_none(self):
+        self.assertIsNone(self._build("ToDo", {"name": "T-1"}))
+
+    def test_sales_invoice_includes_country_from_company(self):
+        self.frappe.db_values[("Company", "Acme", "country")] = "India"
+        r = self._build(
+            "Sales Invoice",
+            {
+                "name": "SINV-001",
+                "company": "Acme",
+                "owner": "alice@acme.test",
+                "docstatus": 1,
+                "customer": "BigCo",
+                "is_return": False,
+            },
+        )
+        self.assertEqual(r.kind, "sales_invoice")
+        self.assertEqual(r.id, "SINV-001")
+        self.assertEqual(r.attr["company"], "Acme")
+        self.assertEqual(r.attr["customer"], "BigCo")
+        self.assertEqual(r.attr["docstatus"], 1)
+        self.assertEqual(r.attr["country"], "India")
+        self.assertEqual(r.attr["is_return"], False)
+
+    def test_purchase_invoice_uses_supplier(self):
+        self.frappe.db_values[("Company", "Acme", "country")] = "Nepal"
+        r = self._build(
+            "Purchase Invoice",
+            {
+                "name": "PINV-001",
+                "company": "Acme",
+                "owner": "alice@acme.test",
+                "docstatus": 0,
+                "supplier": "MegaSupply",
+            },
+        )
+        self.assertEqual(r.kind, "purchase_invoice")
+        self.assertEqual(r.attr["supplier"], "MegaSupply")
+        self.assertEqual(r.attr["country"], "Nepal")
+
+    def test_quotation_falls_back_to_party_name(self):
+        # Quotation stores the customer in `party_name`, not `customer`.
+        r = self._build(
+            "Quotation",
+            {
+                "name": "QTN-001",
+                "company": "Acme",
+                "owner": "sales@acme.test",
+                "docstatus": 0,
+                "party_name": "BigCo",
+                "status": "Draft",
+            },
+        )
+        self.assertEqual(r.attr["customer"], "BigCo")
+
+    def test_employee_carries_user_id(self):
+        r = self._build(
+            "Employee",
+            {
+                "name": "EMP-0001",
+                "company": "Acme",
+                "owner": "hr@acme.test",
+                "user_id": "alice@acme.test",
+                "department": "Engineering",
+                "status": "Active",
+            },
+        )
+        self.assertEqual(r.attr["user_id"], "alice@acme.test")
+        self.assertEqual(r.attr["status"], "Active")
+
+    def test_task_parses_assigned_to_json(self):
+        r = self._build(
+            "Task",
+            {
+                "name": "TASK-1",
+                "owner": "pm@acme.test",
+                "_assign": '["alice@acme.test", "bob@acme.test"]',
+                "status": "Open",
+                "project": "PROJ-1",
+            },
+        )
+        self.assertEqual(
+            r.attr["assigned_to"], ["alice@acme.test", "bob@acme.test"]
+        )
+
+    def test_task_handles_missing_assign(self):
+        r = self._build(
+            "Task",
+            {"name": "TASK-2", "owner": "x@y.test", "status": "Open", "project": "P"},
+        )
+        self.assertEqual(r.attr["assigned_to"], [])
+
+    def test_task_handles_garbage_assign_field(self):
+        r = self._build(
+            "Task",
+            {"name": "TASK-3", "owner": "x@y.test", "_assign": "not-json"},
+        )
+        self.assertEqual(r.attr["assigned_to"], [])
+
+    def test_docstatus_default_is_zero(self):
+        r = self._build(
+            "Stock Entry",
+            {"name": "STE-1", "company": "Acme", "owner": "stock@acme.test"},
+        )
+        self.assertEqual(r.attr["docstatus"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Replaces ERPNext's reliance on Frappe DocType row-level permissions with an external Cerbos Policy Decision Point for the major business doctypes.

Adds:
- cerbos/policies/ — full Cerbos policy bundle (19 resources across 6 domains: accounts, selling, buying, stock, hr, projects), with schemas, shared derived roles, exported variables, and 184 passing tests.
- cerbos/docker-compose.yml + config/cerbos.yaml — local PDP setup.
- erpnext/cerbos_authz/ — Python client wrapping the Cerbos gRPC SDK, principal + resource builders, and has_permission / permission_query_conditions callbacks.
- hooks.py wiring for the 19 managed doctypes; defaults to fail-closed if the PDP is unreachable.

<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/erpnext/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->
