### PR TITLE
fix: add missing fields in set_currency_labels

### DIFF
--- a/erpnext/accounts/doctype/pos_invoice/pos_invoice.json
+++ b/erpnext/accounts/doctype/pos_invoice/pos_invoice.json
@@ -664,6 +664,7 @@
    "fieldname": "total_billing_amount",
    "fieldtype": "Currency",
    "label": "Total Billing Amount",
+   "options": "currency",
    "print_hide": 1,
    "read_only": 1
   },
@@ -1531,6 +1532,7 @@
    "fieldname": "amount_eligible_for_commission",
    "fieldtype": "Currency",
    "label": "Amount Eligible for Commission",
+   "options": "Company:company:default_currency",
    "read_only": 1
   },
   {
@@ -1639,7 +1641,7 @@
  "icon": "fa fa-file-text",
  "is_submittable": 1,
  "links": [],
- "modified": "2026-03-30 12:15:57.253316",
+ "modified": "2026-05-01 02:37:30.580568",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "POS Invoice",

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.json
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.json
@@ -1150,6 +1150,7 @@
    "hide_seconds": 1,
    "label": "Rounding Adjustment",
    "no_copy": 1,
+   "options": "Company:company:default_currency",
    "print_hide": 1,
    "read_only": 1
   },
@@ -1162,6 +1163,7 @@
    "label": "Rounded Total",
    "oldfieldname": "rounded_total",
    "oldfieldtype": "Currency",
+   "options": "Company:company:default_currency",
    "print_hide": 1,
    "read_only": 1
   },
@@ -2355,7 +2357,7 @@
    "link_fieldname": "consolidated_invoice"
   }
  ],
- "modified": "2026-03-30 12:17:16.201016",
+ "modified": "2026-05-01 02:37:29.742764",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Sales Invoice",

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -1847,6 +1847,9 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 				"base_net_total",
 				"base_total_taxes_and_charges",
 				"base_discount_amount",
+				"base_grand_total",
+				"base_rounding_adjustment",
+				"base_rounded_total",
 				"base_taxes_and_charges_added",
 				"base_taxes_and_charges_deducted",
 				"total_amount_to_pay",
@@ -1858,6 +1861,10 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 				"base_total_cost",
 				"base_secondary_items_cost",
 				"base_totals_section",
+				"loyalty_amount",
+				"total_commission",
+				"amount_eligible_for_commission",
+				"claimed_landed_cost_amount",
 			],
 			company_currency
 		);
@@ -1868,19 +1875,31 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 				"net_total",
 				"total_taxes_and_charges",
 				"discount_amount",
+				"grand_total",
+				"rounding_adjustment",
+				"rounded_total",
 				"taxes_and_charges_added",
 				"taxes_and_charges_deducted",
 				"tax_withholding_net_total",
 				"paid_amount",
 				"write_off_amount",
+				"change_amount",
 				"operating_cost",
 				"secondary_items_cost",
 				"raw_material_cost",
 				"total_cost",
 				"totals_section",
+				"total_billing_amount",
 			],
 			this.frm.doc.currency
 		);
+
+		if (this.frm.doc.party_account_currency) {
+			this.frm.set_currency_labels(
+				["total_advance", "outstanding_amount"],
+				this.frm.doc.party_account_currency
+			);
+		}
 
 		this.frm.set_df_property(
 			"conversion_rate",
@@ -1993,13 +2012,13 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 
 		if (this.frm.doc.taxes && this.frm.doc.taxes.length > 0) {
 			this.frm.set_currency_labels(
-				["tax_amount", "total", "tax_amount_after_discount"],
+				["tax_amount", "total", "tax_amount_after_discount_amount", "net_amount"],
 				this.frm.doc.currency,
 				"taxes"
 			);
 
 			this.frm.set_currency_labels(
-				["base_tax_amount", "base_total", "base_tax_amount_after_discount"],
+				["base_tax_amount", "base_total", "base_tax_amount_after_discount_amount", "base_net_amount"],
 				company_currency,
 				"taxes"
 			);
@@ -2025,6 +2044,7 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 				"base_amount",
 				"base_net_amount",
 				"base_rate_with_margin",
+				"incoming_rate",
 			],
 			company_currency,
 			"items"
@@ -2039,6 +2059,8 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 				"net_amount",
 				"stock_uom_rate",
 				"rate_with_margin",
+				"discount_amount",
+				"distributed_discount_amount",
 			],
 			this.frm.doc.currency,
 			"items"

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -1824,82 +1824,49 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 
 		if (
 			this._last_currency === this.frm.doc.currency &&
-			this._last_price_list_currency === this.frm.doc.price_list_currency
+			this._last_price_list_currency === this.frm.doc.price_list_currency &&
+			this._last_party_account_currency === this.frm.doc.party_account_currency
 		) {
 			return;
 		}
 
 		this._last_currency = this.frm.doc.currency;
 		this._last_price_list_currency = this.frm.doc.price_list_currency;
+		this._last_party_account_currency = this.frm.doc.party_account_currency;
 
 		this.change_form_labels(company_currency);
 		this.change_grid_labels(company_currency);
 		this.frm.refresh_fields();
 	}
 
+	get_currency_label_options(company_currency) {
+		return {
+			currency: this.frm.doc.currency,
+			"Company:company:default_currency": company_currency,
+			party_account_currency: this.frm.doc.party_account_currency,
+		};
+	}
+
+	set_currency_labels_from_options(currency_options, parentfield) {
+		const doctype = parentfield ? this.frm.fields_dict[parentfield].grid.doctype : this.frm.doc.doctype;
+		const docfields = frappe.meta.get_docfields(doctype);
+
+		Object.entries(currency_options).forEach(([options, currency]) => {
+			const fields = docfields
+				.filter((df) => df.fieldtype === "Currency" && df.options === options)
+				.map((df) => df.fieldname);
+
+			this.frm.set_currency_labels(fields, currency, parentfield);
+		});
+	}
+
 	change_form_labels(company_currency) {
 		let me = this;
+		const currency_options = this.get_currency_label_options(company_currency);
 
-		this.frm.set_currency_labels(
-			[
-				"advance_paid",
-				"base_total",
-				"base_net_total",
-				"base_total_taxes_and_charges",
-				"base_discount_amount",
-				"base_grand_total",
-				"base_rounding_adjustment",
-				"base_rounded_total",
-				"base_taxes_and_charges_added",
-				"base_taxes_and_charges_deducted",
-				"total_amount_to_pay",
-				"base_paid_amount",
-				"base_write_off_amount",
-				"base_change_amount",
-				"base_operating_cost",
-				"base_raw_material_cost",
-				"base_total_cost",
-				"base_secondary_items_cost",
-				"base_totals_section",
-				"loyalty_amount",
-				"total_commission",
-				"amount_eligible_for_commission",
-				"claimed_landed_cost_amount",
-			],
-			company_currency
-		);
-
-		this.frm.set_currency_labels(
-			[
-				"total",
-				"net_total",
-				"total_taxes_and_charges",
-				"discount_amount",
-				"grand_total",
-				"rounding_adjustment",
-				"rounded_total",
-				"taxes_and_charges_added",
-				"taxes_and_charges_deducted",
-				"tax_withholding_net_total",
-				"paid_amount",
-				"write_off_amount",
-				"change_amount",
-				"operating_cost",
-				"secondary_items_cost",
-				"raw_material_cost",
-				"total_cost",
-				"totals_section",
-				"total_billing_amount",
-			],
-			this.frm.doc.currency
-		);
-
-		if (this.frm.doc.party_account_currency) {
-			this.frm.set_currency_labels(
-				["total_advance", "outstanding_amount"],
-				this.frm.doc.party_account_currency
-			);
-		}
+		this.set_currency_labels_from_options(currency_options);
+		this.frm.set_currency_labels(["totals_section"], this.frm.doc.currency);
+		this.frm.set_currency_labels(["base_totals_section"], company_currency);
 
 		this.frm.set_df_property(
 			"conversion_rate",
@@ -1975,22 +1942,14 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 
 	change_grid_labels(company_currency) {
 		var me = this;
+		const currency_options = this.get_currency_label_options(company_currency);
 
-		this.update_item_grid_labels(company_currency);
+		this.update_item_grid_labels(currency_options);
 
 		this.toggle_item_grid_columns(company_currency);
 
 		if (this.frm.doc.operations && this.frm.doc.operations.length > 0) {
-			this.frm.set_currency_labels(
-				["operating_cost", "hour_rate"],
-				this.frm.doc.currency,
-				"operations"
-			);
-			this.frm.set_currency_labels(
-				["base_operating_cost", "base_hour_rate"],
-				company_currency,
-				"operations"
-			);
+			this.set_currency_labels_from_options(currency_options, "operations");
 
 			var item_grid = this.frm.fields_dict["operations"].grid;
 			$.each(["base_operating_cost", "base_hour_rate"], function (i, fname) {
@@ -2000,8 +1959,7 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 		}
 
 		if (this.frm.doc.secondary_items && this.frm.doc.secondary_items.length > 0) {
-			this.frm.set_currency_labels(["rate", "amount"], this.frm.doc.currency, "secondary_items");
-			this.frm.set_currency_labels(["base_rate", "base_amount"], company_currency, "secondary_items");
+			this.set_currency_labels_from_options(currency_options, "secondary_items");
 
 			var item_grid = this.frm.fields_dict["secondary_items"].grid;
 			$.each(["base_rate", "base_amount"], function (i, fname) {
@@ -2011,75 +1969,24 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 		}
 
 		if (this.frm.doc.taxes && this.frm.doc.taxes.length > 0) {
-			this.frm.set_currency_labels(
-				["tax_amount", "total", "tax_amount_after_discount_amount", "net_amount"],
-				this.frm.doc.currency,
-				"taxes"
-			);
-
-			this.frm.set_currency_labels(
-				["base_tax_amount", "base_total", "base_tax_amount_after_discount_amount", "base_net_amount"],
-				company_currency,
-				"taxes"
-			);
+			this.set_currency_labels_from_options(currency_options, "taxes");
 		}
 
 		if (this.frm.doc.advances && this.frm.doc.advances.length > 0) {
-			this.frm.set_currency_labels(
-				["advance_amount", "allocated_amount"],
-				this.frm.doc.party_account_currency,
-				"advances"
-			);
+			this.set_currency_labels_from_options(currency_options, "advances");
 		}
 
-		this.update_payment_schedule_grid_labels(company_currency);
+		this.update_payment_schedule_grid_labels(currency_options, company_currency);
 	}
 
-	update_item_grid_labels(company_currency) {
-		this.frm.set_currency_labels(
-			[
-				"base_rate",
-				"base_net_rate",
-				"base_price_list_rate",
-				"base_amount",
-				"base_net_amount",
-				"base_rate_with_margin",
-				"incoming_rate",
-			],
-			company_currency,
-			"items"
-		);
-
-		this.frm.set_currency_labels(
-			[
-				"rate",
-				"net_rate",
-				"price_list_rate",
-				"amount",
-				"net_amount",
-				"stock_uom_rate",
-				"rate_with_margin",
-				"discount_amount",
-				"distributed_discount_amount",
-			],
-			this.frm.doc.currency,
-			"items"
-		);
+	update_item_grid_labels(currency_options) {
+		this.set_currency_labels_from_options(currency_options, "items");
 	}
 
-	update_payment_schedule_grid_labels(company_currency) {
+	update_payment_schedule_grid_labels(currency_options, company_currency) {
 		const me = this;
 		if (this.frm.doc.payment_schedule && this.frm.doc.payment_schedule.length > 0) {
-			this.frm.set_currency_labels(
-				["base_payment_amount", "base_outstanding", "base_paid_amount"],
-				company_currency,
-				"payment_schedule"
-			);
-			this.frm.set_currency_labels(
-				["payment_amount", "outstanding", "paid_amount"],
-				this.frm.doc.currency,
-				"payment_schedule"
-			);
+			this.set_currency_labels_from_options(currency_options, "payment_schedule");
 
 			var schedule_grid = this.frm.fields_dict["payment_schedule"].grid;
 			$.each(["base_payment_amount", "base_outstanding", "base_paid_amount"], function (i, fname) {

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -1977,14 +1977,14 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 			});
 		}
 
-		this.update_payment_schedule_grid_labels(currency_options, company_currency);
+		this.update_payment_schedule_grid_labels(company_currency);
 	}
 
 	update_item_grid_labels(currency_options) {
 		this.set_currency_labels_from_options(currency_options, "items");
 	}
 
-	update_payment_schedule_grid_labels(currency_options, company_currency) {
+	update_payment_schedule_grid_labels(company_currency) {
 		const me = this;
 		if (this.frm.doc.payment_schedule && this.frm.doc.payment_schedule.length > 0) {
 			var schedule_grid = this.frm.fields_dict["payment_schedule"].grid;

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -870,12 +870,6 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 										me.apply_rule_on_other_items({ key: item });
 									}
 								},
-								() => {
-									var company_currency = me.get_company_currency();
-									me.update_item_grid_labels(
-										me.get_currency_label_options(company_currency)
-									);
-								},
 							]);
 						}
 					},
@@ -1948,11 +1942,10 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 		var me = this;
 		const currency_options = this.get_currency_label_options(company_currency);
 
-		this.update_item_grid_labels(currency_options);
-
 		this.toggle_item_grid_columns(company_currency);
 
 		for (const child_table of [
+			"items",
 			"operations",
 			"secondary_items",
 			"taxes",
@@ -1982,10 +1975,6 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 		}
 
 		this.update_payment_schedule_grid_labels(company_currency);
-	}
-
-	update_item_grid_labels(currency_options) {
-		this.set_currency_labels_from_options(currency_options, "items");
 	}
 
 	update_payment_schedule_grid_labels(company_currency) {

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -1825,7 +1825,8 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 		if (
 			this._last_currency === this.frm.doc.currency &&
 			this._last_price_list_currency === this.frm.doc.price_list_currency &&
-			this._last_party_account_currency === this.frm.doc.party_account_currency
+			this._last_party_account_currency === this.frm.doc.party_account_currency &&
+			this._last_company_currency === company_currency
 		) {
 			return;
 		}
@@ -1833,6 +1834,7 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 		this._last_currency = this.frm.doc.currency;
 		this._last_price_list_currency = this.frm.doc.price_list_currency;
 		this._last_party_account_currency = this.frm.doc.party_account_currency;
+		this._last_company_currency = company_currency;
 
 		this.change_form_labels(company_currency);
 		this.change_grid_labels(company_currency);

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -1948,9 +1948,20 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 
 		this.toggle_item_grid_columns(company_currency);
 
-		if (this.frm.doc.operations && this.frm.doc.operations.length > 0) {
-			this.set_currency_labels_from_options(currency_options, "operations");
+		for (const child_table of [
+			"operations",
+			"secondary_items",
+			"taxes",
+			"advances",
+			"payment_schedule",
+			"sales_team",
+		]) {
+			if (this.frm.fields_dict[child_table]) {
+				this.set_currency_labels_from_options(currency_options, child_table);
+			}
+		}
 
+		if (this.frm.doc.operations && this.frm.doc.operations.length > 0) {
 			var item_grid = this.frm.fields_dict["operations"].grid;
 			$.each(["base_operating_cost", "base_hour_rate"], function (i, fname) {
 				if (frappe.meta.get_docfield(item_grid.doctype, fname))
@@ -1959,21 +1970,11 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 		}
 
 		if (this.frm.doc.secondary_items && this.frm.doc.secondary_items.length > 0) {
-			this.set_currency_labels_from_options(currency_options, "secondary_items");
-
 			var item_grid = this.frm.fields_dict["secondary_items"].grid;
 			$.each(["base_rate", "base_amount"], function (i, fname) {
 				if (frappe.meta.get_docfield(item_grid.doctype, fname))
 					item_grid.set_column_disp(fname, me.frm.doc.currency != company_currency);
 			});
-		}
-
-		if (this.frm.doc.taxes && this.frm.doc.taxes.length > 0) {
-			this.set_currency_labels_from_options(currency_options, "taxes");
-		}
-
-		if (this.frm.doc.advances && this.frm.doc.advances.length > 0) {
-			this.set_currency_labels_from_options(currency_options, "advances");
 		}
 
 		this.update_payment_schedule_grid_labels(currency_options, company_currency);
@@ -1986,8 +1987,6 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 	update_payment_schedule_grid_labels(currency_options, company_currency) {
 		const me = this;
 		if (this.frm.doc.payment_schedule && this.frm.doc.payment_schedule.length > 0) {
-			this.set_currency_labels_from_options(currency_options, "payment_schedule");
-
 			var schedule_grid = this.frm.fields_dict["payment_schedule"].grid;
 			$.each(["base_payment_amount", "base_outstanding", "base_paid_amount"], function (i, fname) {
 				if (frappe.meta.get_docfield(schedule_grid.doctype, fname))

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -872,7 +872,9 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 								},
 								() => {
 									var company_currency = me.get_company_currency();
-									me.update_item_grid_labels(company_currency);
+									me.update_item_grid_labels(
+										me.get_currency_label_options(company_currency)
+									);
 								},
 							]);
 						}

--- a/erpnext/selling/doctype/sales_order/sales_order.json
+++ b/erpnext/selling/doctype/sales_order/sales_order.json
@@ -847,6 +847,7 @@
    "hide_days": 1,
    "hide_seconds": 1,
    "label": "Loyalty Amount",
+   "options": "Company:company:default_currency",
    "print_hide": 1,
    "read_only": 1
   },
@@ -1480,6 +1481,7 @@
    "fieldname": "amount_eligible_for_commission",
    "fieldtype": "Currency",
    "label": "Amount Eligible for Commission",
+   "options": "Company:company:default_currency",
    "read_only": 1
   },
   {
@@ -1763,7 +1765,7 @@
  "idx": 105,
  "is_submittable": 1,
  "links": [],
- "modified": "2026-03-30 12:19:27.522646",
+ "modified": "2026-05-01 02:37:30.937916",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Sales Order",

--- a/erpnext/stock/doctype/delivery_note/delivery_note.json
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.json
@@ -1266,6 +1266,7 @@
    "fieldname": "amount_eligible_for_commission",
    "fieldtype": "Currency",
    "label": "Amount Eligible for Commission",
+   "options": "Company:company:default_currency",
    "read_only": 1
   },
   {
@@ -1470,7 +1471,7 @@
  "idx": 146,
  "is_submittable": 1,
  "links": [],
- "modified": "2026-03-30 12:19:56.889644",
+ "modified": "2026-05-01 02:37:31.430649",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Delivery Note",


### PR DESCRIPTION

This PR refactors transaction currency label handling to derive labels from **DocType** metadata instead of maintaining hard-coded field lists.

- Sets currency labels for `Currency` fields based on their `options` value:
  - `currency`
  - `Company:company:default_currency`
  - `party_account_currency`
- Applies child table currency labels even when the table has no rows yet, so newly added rows get the correct labels.
- Keeps section break label handling explicit for totals sections.
- Fixes missing currency `options` metadata on affected transaction fields.
- Includes company currency in the label refresh cache so changing company/base currency does not leave stale labels or descriptions.

---

Slightly breaking, if we consider this a public interface: `update_item_grid_labels` is being removed from `erpnext.TransactionController`.