### PR TITLE
fix: set valid_from in created Item Price

### DIFF
--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -1031,6 +1031,7 @@ def insert_item_price(args):
 				currency=args.currency,
 				uom=args.stock_uom,
 				price_list=args.price_list,
+				valid_from=transaction_date,
 			)
 			item_price.insert()
 			frappe.msgprint(
@@ -1055,6 +1056,7 @@ def insert_item_price(args):
 				"currency": args.currency,
 				"price_list_rate": price_list_rate,
 				"uom": args.stock_uom,
+				"valid_from": transaction_date,
 			}
 		)
 		item_price.insert()


### PR DESCRIPTION
**What does this PR solve?**
This PR fixes the issue where duplicate Item Price records were being created during Purchase Order submission when the valid_from date was set as the current date on save.

**Existing Problem**
While saving a Purchase Order, the system automatically sets the valid_from date of the Item Price as the current date.

Later, during submission, the validation checks whether:

valid_from <= transaction_date

In some cases, this validation incorrectly fails because the existing Item Price record is not properly matched. As a result, the system attempts to create a new Item Price with the same details and the same current date.

Since Item Price uniqueness depends on fields like:

Price List
Supplier / Customer
Currency
Item
Batch No
UOM
Quantity
Valid From / Valid Upto dates
this leads to a duplicate entry conflict and raises an error during submission.

**Solution Implemented**
The logic has been updated to ensure that the existing Item Price record is correctly identified before creating a new one.

This prevents unnecessary duplicate Item Price creation and avoids validation failure during Purchase Order submission.

The fix ensures smooth PO submission without duplicate Item Price errors.

**Issue**
Generated on issue no https://github.com/frappe/erpnext/issues/54674

**Screenshots / GIFs**
Provided in issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Item prices created during transactions now automatically set their validity start date to the transaction date, ensuring proper date tracking and data consistency across all price list operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->