### PR TITLE
fix: update frappe docker badge and link

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 [![Learn on Frappe School](https://img.shields.io/badge/Frappe%20School-Learn%20ERPNext-blue?style=flat-square)](https://frappe.school)<br><br>
 [![CI](https://github.com/frappe/erpnext/actions/workflows/server-tests-mariadb.yml/badge.svg?event=schedule)](https://github.com/frappe/erpnext/actions/workflows/server-tests-mariadb.yml)
-[![docker pulls](https://img.shields.io/docker/pulls/frappe/erpnext-worker.svg)](https://hub.docker.com/r/frappe/erpnext-worker)
+[![docker pulls](https://img.shields.io/docker/pulls/frappe/erpnext.svg)](https://hub.docker.com/r/frappe/erpnext)
 
 </div>
 

--- a/README.md
+++ b/README.md
@@ -88,14 +88,6 @@ See [Frappe Docker Documentation](https://github.com/frappe/frappe_docker) for f
 
 > For Docker basics and best practices refer to Docker's [documentation](https://docs.docker.com)
 
-#### Demo setup
-
-The fastest way to try ERPNext is to play in a pre-configured sandbox, in your browser, click the button below:
-
-<a href="https://labs.play-with-docker.com/?stack=https://raw.githubusercontent.com/frappe/frappe_docker/main/pwd.yml">
-  <img src="https://raw.githubusercontent.com/play-with-docker/stacks/master/assets/images/button.png" alt="Try in PWD"/>
-</a>
-
 ### Try on your environment
 
 > **⚠️ Disposable demo only**


### PR DESCRIPTION
Changes:

1. Change ERPNext docker reference in readme from old ERPNext-worker to ERPNext
2. Remove reference to PWD as it is deprecated as of March 2026: https://forums.docker.com/t/play-with-docker-is-deprecated-and-will-be-unavailable-starting-march-1-2026-learn-about-alternatives/151177

**Before:**
1. Docker Build Link
<img width="883" height="333" alt="image" src="https://github.com/user-attachments/assets/f9acb560-1e7d-40ca-be9a-a1141014480e" />

2. PWD:
<img width="904" height="136" alt="image" src="https://github.com/user-attachments/assets/0c7db13a-6972-494d-aeac-751bfea6c351" />


**After:**
1. Docker Build
<img width="1050" height="338" alt="image" src="https://github.com/user-attachments/assets/1da56aa9-277a-41ac-81e1-10669fb2fb2e" />

2. PWD removed:

<img width="1073" height="456" alt="image" src="https://github.com/user-attachments/assets/1b7259ba-7f40-4150-8560-458484b4ff9d" />
