### PR TITLE
regional(setup): add 0% and 6% VAT rates for Belgium

### DIFF
--- a/erpnext/setup/setup_wizard/data/country_wise_tax.json
+++ b/erpnext/setup/setup_wizard/data/country_wise_tax.json
@@ -262,7 +262,15 @@
 		},
 		"Belgium VAT 12%": {
 			"account_name": "VAT 12%",
-			"tax_rate": 12
+			"tax_rate": 12.00
+		},
+		"Belgium VAT 6%": {
+			"account_name": "VAT 6%",
+			"tax_rate": 6.00
+		},
+		"Belgium VAT 0%": {
+			"account_name": "VAT 0%",
+			"tax_rate": 0.00
 		}
 	},
 


### PR DESCRIPTION
The `Belgium` entry in `country_wise_tax.json` only ships 21% (standard) and 12% (intermediate). The 6% reduced rate and 0% rate (exports, intra-community supplies, exemptions) were missing — both are official Belgian VAT rates per SPF Finances and apply to common day-to-day transactions (food, books, medicines, water, transport for 6%; exports/exemptions for 0%).

Adds the two missing entries and normalizes `12` → `12.00` for consistency with the other rates in the file.

Reference: https://finances.belgium.be/fr/entreprises/tva/declaration/operations_a_la_sortie/taux_tva

no-docs