### PR TITLE
fix(stock): apply filters for rejected warehouse in pick list

### DIFF
--- a/erpnext/stock/doctype/pick_list/pick_list.js
+++ b/erpnext/stock/doctype/pick_list/pick_list.js
@@ -9,6 +9,22 @@ frappe.ui.form.on("Pick List", {
 		}, 500);
 	},
 
+	set_warehouse_query: function (frm, fieldname, parentfield = null) {
+		const query = () => {
+			let filters = { company: frm.doc.company };
+
+			frm.doc.consider_rejected_warehouses ? null : (filters.is_rejected_warehouse = 0);
+
+			return { filters };
+		};
+
+		if (parentfield) {
+			frm.set_query(fieldname, parentfield, query);
+		} else {
+			frm.set_query(fieldname, query);
+		}
+	},
+
 	setup: (frm) => {
 		frm.ignore_doctypes_on_cancel_all = ["Serial and Batch Bundle"];
 
@@ -21,21 +37,8 @@ frappe.ui.form.on("Pick List", {
 			"Stock Entry": "Stock Entry",
 		};
 
-		frm.set_query("warehouse", "locations", () => {
-			return {
-				filters: {
-					company: frm.doc.company,
-				},
-			};
-		});
-
-		frm.set_query("parent_warehouse", () => {
-			return {
-				filters: {
-					company: frm.doc.company,
-				},
-			};
-		});
+		frm.events.set_warehouse_query(frm, "warehouse", "locations");
+		frm.events.set_warehouse_query(frm, "parent_warehouse");
 
 		frm.set_query("work_order", () => {
 			return {


### PR DESCRIPTION
Issue: Rejected warehouses appear in the Pick List even when “Consider Rejected Warehouses” is not enabled.

Ref : [#67475](https://support.frappe.io/helpdesk/tickets/67475)

Description : 
Warehouses marked with “Is Rejected” are currently included in the Pick List selection without any restriction. These warehouses should be excluded unless the “Consider Rejected Warehouses” option is explicitly enabled, but the system does not enforce this behavior.

Before : 

[Screencast from 05-05-26 11:42:16 AM IST.webm](https://github.com/user-attachments/assets/09ed29aa-97a8-40a3-a5a0-280f442f6d15)


After : 

[Screencast from 05-05-26 11:41:03 AM IST.webm](https://github.com/user-attachments/assets/15d6bf88-dd86-48bc-b686-42d8fd8c8637)

Backport Needed For V16 and V15