### PR TITLE
fix: payment request amount change after completion

### DIFF
--- a/erpnext/accounts/doctype/payment_request/payment_request.py
+++ b/erpnext/accounts/doctype/payment_request/payment_request.py
@@ -1137,6 +1137,9 @@ def update_payment_requests_as_per_pe_references(references=None, cancel=False):
 			"grand_total",
 			"outstanding_amount",
 			"payment_request_type",
+			"company",
+			"currency",
+			"party_account_currency",
 		],
 	)
 
@@ -1150,10 +1153,19 @@ def update_payment_requests_as_per_pe_references(references=None, cancel=False):
 		payment_request = referenced_payment_requests[ref.payment_request]
 		pr_outstanding = payment_request["outstanding_amount"]
 
-		# update outstanding amount
+		# `outstanding_amount` is stored in company currency only when the party account
+		# is maintained in company currency but the transaction itself is in a foreign
+		# currency (see `before_submit`). Only then should the Payment Entry's allocated
+		# amount (in transaction currency) be converted using its exchange rate.
+		allocated_amount = ref.allocated_amount
+		if payment_request["currency"] != payment_request["party_account_currency"] and payment_request[
+			"party_account_currency"
+		] == get_company_currency(payment_request["company"]):
+			exchange_rate = frappe.get_cached_value("Payment Entry", ref.parent, "source_exchange_rate")
+			allocated_amount = ref.allocated_amount * flt(exchange_rate or 1)
+
 		new_outstanding_amount = flt(
-			pr_outstanding + ref.allocated_amount if cancel else pr_outstanding - ref.allocated_amount,
-			precision,
+			pr_outstanding + allocated_amount if cancel else pr_outstanding - allocated_amount, precision
 		)
 
 		# to handle same payment request for the multiple allocations

--- a/erpnext/accounts/doctype/payment_request/test_payment_request.py
+++ b/erpnext/accounts/doctype/payment_request/test_payment_request.py
@@ -7,11 +7,17 @@ import sys
 from unittest.mock import MagicMock, patch
 
 import frappe
-from frappe.utils import add_days, nowdate
+from frappe.utils import add_days, flt, nowdate
 
 from erpnext.accounts.doctype.payment_entry.payment_entry import get_payment_entry
-from erpnext.accounts.doctype.payment_entry.test_payment_entry import create_payment_terms_template
-from erpnext.accounts.doctype.payment_request.payment_request import make_payment_request
+from erpnext.accounts.doctype.payment_entry.test_payment_entry import (
+	create_payment_entry,
+	create_payment_terms_template,
+)
+from erpnext.accounts.doctype.payment_request.payment_request import (
+	make_payment_request,
+	update_payment_requests_as_per_pe_references,
+)
 from erpnext.accounts.doctype.purchase_invoice.test_purchase_invoice import make_purchase_invoice
 from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_sales_invoice
 from erpnext.buying.doctype.purchase_order.test_purchase_order import create_purchase_order
@@ -1000,6 +1006,44 @@ class TestPaymentRequest(ERPNextTestSuite):
 				return_doc=True,
 				schedules=schedules,
 			)
+
+	def create_data(self):
+		# Reuse the bootstrap "_Test Customer" (Debtors - _TC, INR) so that the
+		# Payment Request's outstanding amount is tracked in company currency.
+		# Fix the SO's conversion_rate so it matches the PE's exchange rate below.
+		so = make_sales_order(customer="_Test Customer", currency="USD", qty=10, rate=100, do_not_save=True)
+		so.conversion_rate = 83
+		so.insert()
+		so.submit()
+
+		pr = make_payment_request(dt="Sales Order", dn=so.name, mute_email=1, return_doc=True)
+
+		# Manually set grand_total for partial payment test scenario
+		pr.grand_total = 100
+		pr.save().submit()
+
+		# Use the same real (non-unity) exchange rate as the Sales Order so the
+		# fix is actually exercised and the outstanding amount reconciles exactly
+		pe = create_payment_entry(paid_amount=100, paid_from="_Test Bank USD - _TC", save=False)
+		pe.source_exchange_rate = 83
+		pe.target_exchange_rate = 83
+		pe.save()
+		pe.submit()
+
+		# Manually add references in Payment Entry
+		references = [frappe._dict({"payment_request": pr.name, "allocated_amount": 100, "parent": pe.name})]
+
+		return pr, pe, references
+
+	@ERPNextTestSuite.change_settings("Accounts Settings", {"fetch_payment_schedule_in_payment_request": 0})
+	def test_exchange_rate_applied(self):
+		pr, pe, references = self.create_data()
+		update_payment_requests_as_per_pe_references(references, cancel=False)
+		pr.reload()
+
+		# Convert grand_total from USD to INR (base currency) to compare with outstanding_amount(INR)
+		grand_total = pr.grand_total * pe.source_exchange_rate
+		self.assertEqual(flt(pr.outstanding_amount), grand_total - pe.base_paid_amount)
 
 
 class TestPaymentRequestV2Gateway(ERPNextTestSuite):


### PR DESCRIPTION
**Issue**: Payment request amount changing after completion which causing the issue
**Ref**: [66428](https://support.frappe.io/helpdesk/tickets/66428?view=VIEW-HD+Ticket-745)

**Steps to Verify Resolution**:

1. Create a Sales Order for an international customer (e.g., country: US, currency: USD).
2. Create a partial Payment Request from Sales Order:
      Example:
          Sales Order value = 1000 USD
          Payment Request = 600 USD
3. Create and submit a Payment Entry for the requested amount from Sales Order.
4. Open the Payment Request and refresh:
        Verify that the received amount remains consistent (no unexpected change due to exchange rate)
        Outstanding amount is correctly calculated using exchange rate (Need to be 0 for current example)
5. Go back to the Sales Order and create another Payment Request for the remaining amount (400 USD).
6. Verify:
         System allows creating another Payment Request
         Total of all Payment Requests matches the Sales Order value.

Before:

https://github.com/user-attachments/assets/b2c19789-e620-409f-84f6-5398c9de4931





After : 

[After.webm](https://github.com/user-attachments/assets/48f6d5f4-cd88-4bdc-a220-f3b80d71e19b)



     