### PR TITLE
fix(customer_supplier_ledger_summary): include opening entries regard…

### DIFF
--- a/erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py
+++ b/erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py
@@ -345,7 +345,7 @@ class PartyLedgerSummaryReport:
 				& (gle.is_cancelled == 0)
 				& (gle.party_type == self.filters.party_type)
 				& (IfNull(gle.party, "") != "")
-				& (gle.posting_date <= self.filters.to_date)
+				& ((gle.posting_date <= self.filters.to_date) | (gle.is_opening == "Yes"))
 				& (gle.party.isin(self.parties))
 			)
 		)


### PR DESCRIPTION
The Supplier Ledger Summary or Customer Ledger Summary only determines the GL Entry whose posting_date is less than the “To Date” passed in the report filter, even if it is an opening entry.

Ref:[#66921](https://support.frappe.io/helpdesk/tickets/66921?view=VIEW-HD+Ticket-745)

Backport needed:v15,v16
