### PR TITLE
fix: incorrect validation thrown for drop shipped PI

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice_item/purchase_invoice_item.json
+++ b/erpnext/accounts/doctype/purchase_invoice_item/purchase_invoice_item.json
@@ -110,6 +110,7 @@
   "sales_invoice_item",
   "material_request",
   "material_request_item",
+  "delivered_by_supplier",
   "item_weight_details",
   "weight_per_unit",
   "total_weight",
@@ -992,13 +993,22 @@
    "label": "Tax Withholding Category",
    "options": "Tax Withholding Category",
    "print_hide": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "delivered_by_supplier",
+   "fieldtype": "Check",
+   "hidden": 1,
+   "label": "Delivered by Supplier",
+   "print_hide": 1,
+   "read_only": 1
   }
  ],
  "grid_page_length": 50,
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-05-04 10:48:54.535480",
+ "modified": "2026-05-06 08:08:40.782395",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Purchase Invoice Item",

--- a/erpnext/accounts/doctype/purchase_invoice_item/purchase_invoice_item.py
+++ b/erpnext/accounts/doctype/purchase_invoice_item/purchase_invoice_item.py
@@ -30,6 +30,7 @@ class PurchaseInvoiceItem(Document):
 		conversion_factor: DF.Float
 		cost_center: DF.Link | None
 		deferred_expense_account: DF.Link | None
+		delivered_by_supplier: DF.Check
 		description: DF.TextEditor | None
 		discount_amount: DF.Currency
 		discount_percentage: DF.Percent

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -329,6 +329,7 @@ class AccountsController(TransactionBase):
 		# Determine if drop ship applies
 		is_drop_ship = self.doctype in {
 			"Purchase Order",
+			"Purchase Invoice",
 			"Sales Order",
 			"Sales Invoice",
 		} and self.is_drop_ship(self.items)

--- a/erpnext/public/js/controllers/buying.js
+++ b/erpnext/public/js/controllers/buying.js
@@ -25,15 +25,15 @@ erpnext.buying = {
 					};
 				});
 
-				const project_filters = {
+				const get_project_filters = () => ({
 					query: "erpnext.controllers.queries.get_project_name",
 					filters: {
-						company: doc.company,
+						company: this.frm.doc.company,
 					},
-				};
+				});
 
-				this.frm.set_query("project", (_) => project_filters);
-				this.frm.set_query("project", "items", (_, __, ___) => project_filters);
+				this.frm.set_query("project", get_project_filters);
+				this.frm.set_query("project", "items", get_project_filters);
 
 				if (
 					this.frm.doc.__islocal &&
@@ -174,9 +174,14 @@ erpnext.buying = {
 					callback: (r) => {
 						if (!r.message) return;
 
-						this.frm.set_value("billing_address", r.message.primary_address || "");
+						if (!this.frm.doc.billing_address) {
+							this.frm.set_value("billing_address", r.message.primary_address || "");
+						}
 
-						if (frappe.meta.has_field(this.frm.doc.doctype, "shipping_address")) {
+						if (
+							frappe.meta.has_field(this.frm.doc.doctype, "shipping_address") &&
+							!this.frm.doc.shipping_address
+						) {
 							this.frm.set_value("shipping_address", r.message.shipping_address || "");
 						}
 					},

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -1291,7 +1291,7 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 			["Purchase Order", "Purchase Receipt", "Purchase Invoice"].includes(this.frm.doctype) &&
 			!this.frm.doc.shipping_address
 		) {
-			let is_drop_ship = me.frm.doc.items.some((item) => item.delivered_by_supplier);
+			const is_drop_ship = me.frm.doc.items.some((item) => item.delivered_by_supplier);
 
 			if (!is_drop_ship) {
 				erpnext.utils.get_shipping_address(this.frm, function () {

--- a/erpnext/public/js/queries.js
+++ b/erpnext/public/js/queries.js
@@ -106,15 +106,19 @@ $.extend(erpnext.queries, {
 			});
 		}
 
+		let filters = { link_doctype: "Company", link_name: doc.company || "" };
+		const is_drop_ship = doc.items.some((item) => item.delivered_by_supplier);
+		if (is_drop_ship) filters = {};
+
 		return {
 			query: "frappe.contacts.doctype.address.address.address_query",
-			filters: { link_doctype: "Company", link_name: doc.company },
+			filters: filters,
 		};
 	},
 
 	dispatch_address_query: function (doc) {
-		var filters = { link_doctype: "Company", link_name: doc.company || "" };
-		var is_drop_ship = doc.items.some((item) => item.delivered_by_supplier);
+		let filters = { link_doctype: "Company", link_name: doc.company || "" };
+		const is_drop_ship = doc.items.some((item) => item.delivered_by_supplier);
 		if (is_drop_ship) filters = {};
 		return {
 			query: "frappe.contacts.doctype.address.address.address_query",


### PR DESCRIPTION
Shipping address doesn't belong to company error is thrown when purchase invoice has drop shipped items which doesnt make any sense