### PR TITLE
feat/advance payment auto allocation settings

### DIFF
--- a/erpnext/buying/doctype/buying_settings/buying_settings.json
+++ b/erpnext/buying/doctype/buying_settings/buying_settings.json
@@ -41,6 +41,8 @@
   "allow_zero_qty_in_purchase_order",
   "blanket_order_section",
   "blanket_order_allowance",
+  "auto_allocate_advance_payment",
+  "fetch_only_allocated_advance_payment",
   "subcontract",
   "backflush_raw_materials_of_subcontract_based_on",
   "over_transfer_allowance",
@@ -342,6 +344,21 @@
   {
    "fieldname": "column_break_kdcm",
    "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "description": "Automatically fetches and allocates available advance payments when creating an Purchase invoice from a Purchase Order/Purchase Receipt",
+   "fieldname": "auto_allocate_advance_payment",
+   "fieldtype": "Check",
+   "label": "Auto Allocate Advance Payment"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:doc.auto_allocate_advance_payment==1",
+   "description": "Retrieves advance payments that have been allocated to Purchase Order, excluding unallocated payments.",
+   "fieldname": "fetch_only_allocated_advance_payment",
+   "fieldtype": "Check",
+   "label": "Fetch Only Allocated Advance Payment"
   }
  ],
  "grid_page_length": 50,

--- a/erpnext/buying/doctype/buying_settings/buying_settings.py
+++ b/erpnext/buying/doctype/buying_settings/buying_settings.py
@@ -22,6 +22,7 @@ class BuyingSettings(Document):
 		allow_zero_qty_in_purchase_order: DF.Check
 		allow_zero_qty_in_request_for_quotation: DF.Check
 		allow_zero_qty_in_supplier_quotation: DF.Check
+		auto_allocate_advance_payment: DF.Check
 		auto_create_purchase_receipt: DF.Check
 		auto_create_subcontracting_order: DF.Check
 		backflush_raw_materials_of_subcontract_based_on: DF.Literal[
@@ -31,6 +32,7 @@ class BuyingSettings(Document):
 		blanket_order_allowance: DF.Float
 		buying_price_list: DF.Link | None
 		disable_last_purchase_rate: DF.Check
+		fetch_only_allocated_advance_payment: DF.Check
 		fixed_email: DF.Link | None
 		maintain_same_rate: DF.Check
 		maintain_same_rate_action: DF.Literal["Stop", "Warn"]

--- a/erpnext/buying/doctype/purchase_order/purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.py
@@ -744,6 +744,192 @@ def close_or_unclose_purchase_orders(names: str, status: str):
 	frappe.local.message_log = []
 
 
+def set_missing_values(source, target):
+	target.run_method("set_missing_values")
+	target.run_method("calculate_taxes_and_totals")
+	target.run_method("set_use_serial_batch_fields")
+
+
+@frappe.whitelist()
+def make_purchase_receipt(
+	source_name: str, target_doc: str | Document | None = None, args: str | dict | None = None
+):
+	if args is None:
+		args = {}
+	if isinstance(args, str):
+		args = json.loads(args)
+
+	has_unit_price_items = frappe.db.get_value("Purchase Order", source_name, "has_unit_price_items")
+
+	def is_unit_price_row(source):
+		return has_unit_price_items and source.qty == 0
+
+	def update_item(obj, target, source_parent):
+		target.qty = flt(obj.qty) if is_unit_price_row(obj) else flt(obj.qty) - flt(obj.received_qty)
+		target.stock_qty = (flt(obj.qty) - flt(obj.received_qty)) * flt(obj.conversion_factor)
+		target.amount = (flt(obj.qty) - flt(obj.received_qty)) * flt(obj.rate)
+		target.base_amount = (
+			(flt(obj.qty) - flt(obj.received_qty)) * flt(obj.rate) * flt(source_parent.conversion_rate)
+		)
+
+	def select_item(d):
+		filtered_items = args.get("filtered_children", [])
+		child_filter = d.name in filtered_items if filtered_items else True
+		return child_filter
+
+	doc = get_mapped_doc(
+		"Purchase Order",
+		source_name,
+		{
+			"Purchase Order": {
+				"doctype": "Purchase Receipt",
+				"field_map": {"supplier_warehouse": "supplier_warehouse"},
+				"validation": {
+					"docstatus": ["=", 1],
+				},
+			},
+			"Purchase Order Item": {
+				"doctype": "Purchase Receipt Item",
+				"field_map": {
+					"name": "purchase_order_item",
+					"parent": "purchase_order",
+					"bom": "bom",
+					"material_request": "material_request",
+					"material_request_item": "material_request_item",
+					"sales_order": "sales_order",
+					"sales_order_item": "sales_order_item",
+					"wip_composite_asset": "wip_composite_asset",
+				},
+				"postprocess": update_item,
+				"condition": lambda doc: (
+					True if is_unit_price_row(doc) else abs(doc.received_qty) < abs(doc.qty)
+				)
+				and doc.delivered_by_supplier != 1
+				and select_item(doc),
+			},
+			"Purchase Taxes and Charges": {"doctype": "Purchase Taxes and Charges", "reset_value": True},
+		},
+		target_doc,
+		set_missing_values,
+	)
+
+	return doc
+
+
+@frappe.whitelist()
+def make_purchase_invoice(
+	source_name: str, target_doc: str | Document | None = None, args: str | dict | None = None
+):
+	return get_mapped_purchase_invoice(source_name, target_doc, args=args)
+
+
+@frappe.whitelist()
+def make_purchase_invoice_from_portal(purchase_order_name: str):
+	doc = get_mapped_purchase_invoice(purchase_order_name, ignore_permissions=True)
+	if frappe.session.user not in frappe.get_all("Portal User", {"parent": doc.supplier}, pluck="user"):
+		frappe.throw(_("Not Permitted"), frappe.PermissionError)
+	doc.save()
+	if not frappe.in_test:
+		frappe.db.commit()
+	frappe.response["type"] = "redirect"
+	frappe.response.location = "/purchase-invoices/" + doc.name
+
+
+def get_mapped_purchase_invoice(source_name, target_doc=None, ignore_permissions=False, args=None):
+	if args is None:
+		args = {}
+	if isinstance(args, str):
+		args = json.loads(args)
+
+	def postprocess(source, target):
+		target.flags.ignore_permissions = ignore_permissions
+		set_missing_values(source, target)
+
+		# Get the advance paid Journal Entries in Purchase Invoice Advance
+		advance, allocated = frappe.db.get_value(
+			"Buying Settings", None, ["auto_allocate_advance_payment", "fetch_only_allocated_advance_payment"]
+		)
+		target.allocate_advances_automatically = advance
+		target.only_include_allocated_payments = allocated
+		if target.get("allocate_advances_automatically"):
+			target.set_advances()
+
+		target.set_payment_schedule()
+		target.credit_to = get_party_account("Supplier", source.supplier, source.company)
+
+	def get_billed_qty(po_item_name):
+		from frappe.query_builder.functions import Sum
+
+		table = frappe.qb.DocType("Purchase Invoice Item")
+		query = (
+			frappe.qb.from_(table)
+			.select(Sum(table.qty).as_("qty"))
+			.where((table.docstatus == 1) & (table.po_detail == po_item_name))
+		)
+		return query.run(pluck="qty")[0] or 0
+
+	def update_item(obj, target, source_parent):
+		billed_qty = flt(get_billed_qty(obj.name))
+		target.qty = flt(obj.qty) - billed_qty
+
+		item = get_item_defaults(target.item_code, source_parent.company)
+		item_group = get_item_group_defaults(target.item_code, source_parent.company)
+		target.cost_center = (
+			obj.cost_center
+			or frappe.db.get_value("Project", obj.project, "cost_center")
+			or item.get("buying_cost_center")
+			or item_group.get("buying_cost_center")
+		)
+
+	def select_item(d):
+		filtered_items = args.get("filtered_children", [])
+		child_filter = d.name in filtered_items if filtered_items else True
+		return child_filter
+
+	fields = {
+		"Purchase Order": {
+			"doctype": "Purchase Invoice",
+			"field_map": {
+				"party_account_currency": "party_account_currency",
+				"supplier_warehouse": "supplier_warehouse",
+			},
+			"field_no_map": ["payment_terms_template"],
+			"validation": {
+				"docstatus": ["=", 1],
+			},
+		},
+		"Purchase Order Item": {
+			"doctype": "Purchase Invoice Item",
+			"field_map": {
+				"name": "po_detail",
+				"parent": "purchase_order",
+				"material_request": "material_request",
+				"material_request_item": "material_request_item",
+				"wip_composite_asset": "wip_composite_asset",
+			},
+			"postprocess": update_item,
+			"condition": lambda doc: (
+				doc.base_amount == 0
+				or abs(doc.billed_amt) < abs(doc.amount)
+				or doc.qty > flt(get_billed_qty(doc.name))
+			)
+			and select_item(doc),
+		},
+		"Purchase Taxes and Charges": {"doctype": "Purchase Taxes and Charges", "reset_value": True},
+	}
+
+	doc = get_mapped_doc(
+		"Purchase Order",
+		source_name,
+		fields,
+		target_doc,
+		postprocess,
+		ignore_permissions=ignore_permissions,
+	)
+
+	return doc
+
+
 def get_list_context(context=None):
 	from erpnext.controllers.website_list_for_contact import get_list_context
 

--- a/erpnext/buying/doctype/purchase_order/test_purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/test_purchase_order.py
@@ -859,8 +859,6 @@ class TestPurchaseOrder(ERPNextTestSuite):
 		"Accounts Settings", {"unlink_advance_payment_on_cancelation_of_order": 1}
 	)
 	def test_advance_payment_entry_unlink_against_purchase_order(self):
-		from erpnext.accounts.doctype.payment_entry.test_payment_entry import get_payment_entry
-
 		po_doc = create_purchase_order()
 
 		pe = get_payment_entry("Purchase Order", po_doc.name, bank_account="_Test Bank - _TC")
@@ -915,8 +913,6 @@ class TestPurchaseOrder(ERPNextTestSuite):
 		company_doc.save()
 
 		po_doc = create_purchase_order(supplier=supplier)
-
-		from erpnext.accounts.doctype.payment_entry.test_payment_entry import get_payment_entry
 
 		pe = get_payment_entry("Purchase Order", po_doc.name)
 		pe.save().submit()
@@ -1298,7 +1294,7 @@ class TestPurchaseOrder(ERPNextTestSuite):
 
 	def test_purchase_order_advance_payment_status(self):
 		frappe.flags.is_reverse_depr_entry = False
-		from erpnext.accounts.doctype.payment_entry.test_payment_entry import get_payment_entry
+
 		from erpnext.accounts.doctype.payment_request.payment_request import make_payment_request
 
 		po = create_purchase_order()
@@ -1609,6 +1605,61 @@ class TestPurchaseOrder(ERPNextTestSuite):
 		po.items[0].sales_order = "DUMMY-SO"
 
 		po.update_ordered_qty_in_so_for_removed_items([frappe._dict({"sales_order_item": None, "qty": 1})])
+
+	@ERPNextTestSuite.change_settings(
+		"Buying Settings", {"auto_allocate_advance_payment": 1, "fetch_only_allocated_advance_payment": 0}
+	)
+	def test_auto_allocate_advance_payment_from_purchase_order(self):
+		from erpnext.buying.doctype.purchase_order.purchase_order import make_purchase_invoice
+
+		po = create_purchase_order(rate=1000)
+
+		pe1 = get_payment_entry("Purchase Order", po.name)
+
+		pe1.paid_amount = 500
+		pe1.received_amount = 500
+		pe1.references[0].allocated_amount = 500
+		pe1.insert().submit()
+
+		pe2 = get_payment_entry("Purchase Order", po.name)
+		pe2.paid_amount = 100
+		pe2.received_amount = 100
+		pe2.references = []
+		pe2.insert().submit()
+
+		pi = make_purchase_invoice(po.name)
+
+		references = [d.reference_name for d in pi.advances]
+
+		self.assertIn(pe1.name, references)
+		self.assertIn(pe2.name, references)
+
+	@ERPNextTestSuite.change_settings(
+		"Buying Settings", {"auto_allocate_advance_payment": 1, "fetch_only_allocated_advance_payment": 1}
+	)
+	def test_auto_allocate_fetches_only_allocated_advances(self):
+		from erpnext.buying.doctype.purchase_order.purchase_order import make_purchase_invoice
+
+		po = create_purchase_order(rate=1000)
+
+		pe1 = get_payment_entry("Purchase Order", po.name)
+		pe1.paid_amount = 500
+		pe1.received_amount = 500
+		pe1.references[0].allocated_amount = 500
+		pe1.insert().submit()
+
+		pe2 = get_payment_entry("Purchase Order", po.name)
+		pe2.paid_amount = 100
+		pe2.received_amount = 100
+		pe2.references = []
+		pe2.insert().submit()
+
+		pi = make_purchase_invoice(po.name)
+
+		references = [d.reference_name for d in pi.advances]
+
+		self.assertIn(pe1.name, references)
+		self.assertNotIn(pe2.name, references)
 
 
 def create_po_for_sc_testing():

--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -1037,6 +1037,623 @@ def close_or_unclose_sales_orders(names: str, status: str):
 	frappe.local.message_log = []
 
 
+def get_requested_item_qty(sales_order):
+	result = {}
+
+	so = frappe.get_doc("Sales Order", sales_order)
+
+	for item in so.items:
+		if is_product_bundle(item.item_code):
+			for packed_item in so.get("packed_items"):
+				if (
+					packed_item.parent_item == item.item_code
+					and packed_item.parent_detail_docname == item.name
+				):
+					result[packed_item.name] = frappe._dict({"qty": packed_item.requested_qty})
+		else:
+			result[item.name] = frappe._dict({"qty": item.requested_qty})
+
+	return result
+
+
+@frappe.whitelist()
+def make_material_request(source_name: str, target_doc: str | Document | None = None):
+	requested_item_qty = get_requested_item_qty(source_name)
+
+	def postprocess(source, target):
+		if source.tc_name and frappe.db.get_value("Terms and Conditions", source.tc_name, "buying") != 1:
+			target.tc_name = None
+			target.terms = None
+
+	def get_remaining_qty(so_item):
+		return flt(
+			flt(so_item.qty)
+			- flt(requested_item_qty.get(so_item.name, {}).get("qty"))
+			- max(
+				flt(so_item.get("delivered_qty")),
+				0,
+			)
+		)
+
+	def get_remaining_packed_item_qty(so_item):
+		delivered_qty = frappe.db.get_value(
+			"Sales Order Item", {"name": so_item.parent_detail_docname}, ["delivered_qty"]
+		)
+
+		bundle_item_qty = frappe.db.get_value(
+			"Product Bundle Item", {"parent": so_item.parent_item, "item_code": so_item.item_code}, ["qty"]
+		)
+
+		return flt(
+			flt(so_item.qty)
+			- flt(requested_item_qty.get(so_item.name, {}).get("qty"))
+			- max(
+				flt(delivered_qty) * flt(bundle_item_qty),
+				0,
+			)
+		)
+
+	def update_item(source, target, source_parent):
+		# qty is for packed items, because packed items don't have stock_qty field
+		target.project = source_parent.project
+		target.qty = (
+			get_remaining_packed_item_qty(source)
+			if source.parentfield == "packed_items"
+			else get_remaining_qty(source)
+		)
+		target.stock_qty = flt(target.qty) * flt(target.conversion_factor)
+		target.actual_qty = get_bin_details(
+			target.item_code, target.warehouse, source_parent.company, True
+		).get("actual_qty", 0)
+
+		ctx = ItemDetailsCtx(target.as_dict().copy())
+		ctx.update(
+			{
+				"company": source_parent.get("company"),
+				"price_list": frappe.db.get_single_value("Buying Settings", "buying_price_list"),
+				"currency": source_parent.get("currency"),
+				"conversion_rate": source_parent.get("conversion_rate"),
+			}
+		)
+
+		target.rate = flt(
+			get_price_list_rate(ctx, item_doc=frappe.get_cached_doc("Item", target.item_code)).get(
+				"price_list_rate"
+			)
+		)
+		target.amount = target.qty * target.rate
+
+	doc = get_mapped_doc(
+		"Sales Order",
+		source_name,
+		{
+			"Sales Order": {"doctype": "Material Request", "validation": {"docstatus": ["=", 1]}},
+			"Packed Item": {
+				"doctype": "Material Request Item",
+				"field_map": {"parent": "sales_order", "uom": "stock_uom", "name": "packed_item"},
+				"condition": lambda item: get_remaining_packed_item_qty(item) > 0,
+				"postprocess": update_item,
+			},
+			"Sales Order Item": {
+				"doctype": "Material Request Item",
+				"field_map": {
+					"name": "sales_order_item",
+					"parent": "sales_order",
+					"delivery_date": "schedule_date",
+					"bom_no": "bom_no",
+				},
+				"condition": lambda item: not frappe.db.exists(
+					"Product Bundle", {"name": item.item_code, "disabled": 0}
+				)
+				and get_remaining_qty(item) > 0,
+				"postprocess": update_item,
+			},
+		},
+		target_doc,
+		postprocess,
+	)
+	if doc and doc.items:
+		return doc
+	else:
+		frappe.throw(_("Material Request already created for the ordered quantity"))
+
+
+@frappe.whitelist()
+def make_project(source_name: str, target_doc: str | Document | None = None):
+	def postprocess(source, doc):
+		doc.project_type = "External"
+		doc.project_name = source.name
+
+	doc = get_mapped_doc(
+		"Sales Order",
+		source_name,
+		{
+			"Sales Order": {
+				"doctype": "Project",
+				"validation": {"docstatus": ["=", 1]},
+				"field_map": {
+					"name": "sales_order",
+					"base_grand_total": "estimated_costing",
+					"net_total": "total_sales_amount",
+				},
+			},
+		},
+		target_doc,
+		postprocess,
+	)
+
+	return doc
+
+
+def set_serial_batch_for_bundle_reservation(source, target, use_serial_batch_fields, packed_sre):
+	for item in source.packed_items:
+		target_item = next(
+			(
+				d
+				for d in target.packed_items
+				if (d.parent_item, d.item_code, d.warehouse)
+				== (item.parent_item, item.item_code, item.warehouse)
+			),
+			None,
+		)
+		if target_item and (sre := [sre for sre in packed_sre if sre.voucher_detail_no == item.name]):
+			if sre[0].reservation_based_on == "Serial and Batch":
+				qty = 0
+				serial_nos = []
+				batch_nos = []
+				if use_serial_batch_fields:
+					target_item.use_serial_batch_fields = 1
+					for item in sre:
+						qty += item.reserved_qty
+						if item.has_serial_no:
+							serial_nos.extend(
+								frappe.get_all(
+									"Serial and Batch Entry",
+									filters={"parent": item.name},
+									pluck="serial_no",
+								)
+							)
+						if item.has_batch_no:
+							batch_nos.extend(
+								frappe.get_all(
+									"Serial and Batch Entry",
+									filters={"parent": item.name},
+									pluck="batch_no",
+								)
+							)
+
+					if len(batch_nos) == 1:
+						target_item.batch_no = batch_nos[0] if batch_nos else None
+					if serial_nos and len(batch_nos) < 2:
+						target_item.serial_no = "\n".join(serial_nos)
+
+				if not use_serial_batch_fields or len(batch_nos) > 1:
+					target_item.serial_and_batch_bundle = get_ssb_bundle_for_voucher(sre).name
+
+
+@frappe.whitelist()
+def make_delivery_note(
+	source_name: str, target_doc: str | Document | None = None, kwargs: dict | None = None
+):
+	from erpnext.stock.doctype.stock_reservation_entry.stock_reservation_entry import (
+		get_sre_reserved_qty_details_for_voucher,
+	)
+
+	if not kwargs:
+		kwargs = {
+			"for_reserved_stock": frappe.flags.args and frappe.flags.args.for_reserved_stock,
+			"skip_item_mapping": frappe.flags.args and frappe.flags.args.skip_item_mapping,
+		}
+
+	kwargs = frappe._dict(kwargs)
+
+	sre_details = {}
+	if kwargs.for_reserved_stock:
+		sre_details = get_sre_reserved_qty_details_for_voucher("Sales Order", source_name)
+
+	mapper = {
+		"Sales Order": {"doctype": "Delivery Note", "validation": {"docstatus": ["=", 1]}},
+		"Sales Taxes and Charges": {"doctype": "Sales Taxes and Charges", "reset_value": True},
+		"Sales Team": {"doctype": "Sales Team", "add_if_empty": True},
+	}
+
+	# 0 qty is accepted, as the qty is uncertain for some items
+	has_unit_price_items = frappe.db.get_value("Sales Order", source_name, "has_unit_price_items")
+	use_serial_batch_fields = frappe.get_single_value("Stock Settings", "use_serial_batch_fields")
+
+	def is_unit_price_row(source):
+		return has_unit_price_items and source.qty == 0
+
+	def select_item(d):
+		filtered_items = kwargs.get("filtered_children", [])
+		child_filter = d.name in filtered_items if filtered_items else True
+		return child_filter
+
+	def set_missing_values(source, target):
+		if kwargs.get("ignore_pricing_rule"):
+			# Skip pricing rule when the dn is creating from the pick list
+			target.ignore_pricing_rule = 1
+
+		target.run_method("set_missing_values")
+		target.run_method("set_po_nos")
+		target.run_method("calculate_taxes_and_totals")
+		target.run_method("set_use_serial_batch_fields")
+
+		if source.company_address:
+			target.update({"company_address": source.company_address})
+		else:
+			# set company address
+			target.update(get_company_address(target.company))
+
+		if target.company_address:
+			target.update(get_fetch_values("Delivery Note", "company_address", target.company_address))
+
+		# if invoked in bulk creation, validations are ignored and thus this method is nerver invoked
+		if frappe.flags.bulk_transaction:
+			# set target items names to ensure proper linking with packed_items
+			target.set_new_name()
+
+		make_packing_list(target)
+
+	def condition(doc):
+		if doc.name in sre_details:
+			del sre_details[doc.name]
+			return False
+
+		# make_mapped_doc sets js `args` into `frappe.flags.args`
+		if frappe.flags.args and frappe.flags.args.delivery_dates:
+			if cstr(doc.delivery_date) not in frappe.flags.args.delivery_dates:
+				return False
+		if frappe.flags.args and frappe.flags.args.until_delivery_date:
+			if cstr(doc.delivery_date) > frappe.flags.args.until_delivery_date:
+				return False
+
+		return (
+			(abs(doc.delivered_qty) < abs(doc.qty)) or is_unit_price_row(doc)
+		) and doc.delivered_by_supplier != 1
+
+	def update_item(source, target, source_parent):
+		target.base_amount = (flt(source.qty) - flt(source.delivered_qty)) * flt(source.base_rate)
+		target.amount = (flt(source.qty) - flt(source.delivered_qty)) * flt(source.rate)
+		target.qty = (
+			flt(source.qty) if is_unit_price_row(source) else flt(source.qty) - flt(source.delivered_qty)
+		)
+
+		item = get_item_defaults(target.item_code, source_parent.company)
+		item_group = get_item_group_defaults(target.item_code, source_parent.company)
+
+		if item:
+			target.cost_center = (
+				frappe.db.get_value("Project", source_parent.project, "cost_center")
+				or item.get("buying_cost_center")
+				or item_group.get("buying_cost_center")
+			)
+
+	if not kwargs.skip_item_mapping:
+		mapper["Sales Order Item"] = {
+			"doctype": "Delivery Note Item",
+			"field_map": {
+				"rate": "rate",
+				"name": "so_detail",
+				"parent": "against_sales_order",
+			},
+			"condition": lambda d: condition(d) and select_item(d),
+			"postprocess": update_item,
+		}
+
+	so = frappe.get_doc("Sales Order", source_name)
+	target_doc = get_mapped_doc("Sales Order", so.name, mapper, target_doc)
+
+	packed_sre = []
+	if not kwargs.skip_item_mapping and kwargs.for_reserved_stock:
+		sre_list = get_sre_details_for_voucher("Sales Order", source_name)
+
+		if sre_list:
+
+			def update_dn_item(source, target, source_parent):
+				update_item(source, target, so)
+
+			so_items = {d.name: d for d in so.items if d.stock_reserved_qty}
+
+			for sre in sre_list:
+				if not so_items.get(sre.voucher_detail_no):
+					packed_sre.append(sre)
+					continue
+
+				if not condition(so_items[sre.voucher_detail_no]):
+					continue
+
+				dn_item = get_mapped_doc(
+					"Sales Order Item",
+					sre.voucher_detail_no,
+					{
+						"Sales Order Item": {
+							"doctype": "Delivery Note Item",
+							"field_map": {
+								"rate": "rate",
+								"name": "so_detail",
+								"parent": "against_sales_order",
+							},
+							"postprocess": update_dn_item,
+						}
+					},
+					ignore_permissions=True,
+				)
+
+				dn_item.qty = flt(sre.reserved_qty) / flt(dn_item.get("conversion_factor", 1))
+				dn_item.warehouse = sre.warehouse
+
+				if (
+					not use_serial_batch_fields
+					and sre.reservation_based_on == "Serial and Batch"
+					and (sre.has_serial_no or sre.has_batch_no)
+				):
+					dn_item.serial_and_batch_bundle = get_ssb_bundle_for_voucher([sre]).name
+
+				target_doc.append("items", dn_item)
+			else:
+				# Correct rows index.
+				for idx, item in enumerate(target_doc.items):
+					item.idx = idx + 1
+
+	if not kwargs.skip_item_mapping and frappe.flags.bulk_transaction and not target_doc.items:
+		# the (date) condition filter resulted in an unintendedly created empty DN; remove it
+		del target_doc
+		return
+
+	# Should be called after mapping items.
+	target_doc.packed_items = []
+	set_missing_values(so, target_doc)
+	set_serial_batch_for_bundle_reservation(so, target_doc, use_serial_batch_fields, packed_sre)
+
+	return target_doc
+
+
+@frappe.whitelist()
+def make_sales_invoice(
+	source_name: str,
+	target_doc: str | Document | None = None,
+	ignore_permissions: bool = False,
+	args: str | dict | None = None,
+):
+	if args is None:
+		args = {}
+	if isinstance(args, str):
+		args = json.loads(args)
+
+	# 0 qty is accepted, as the qty is uncertain for some items
+	has_unit_price_items = frappe.db.get_value("Sales Order", source_name, "has_unit_price_items")
+
+	def is_unit_price_row(source):
+		return has_unit_price_items and source.qty == 0
+
+	def postprocess(source, target):
+		set_missing_values(source, target)
+		# Get the advance paid Journal Entries in Sales Invoice Advance
+		advance, allocated = frappe.db.get_value(
+			"Selling Settings",
+			None,
+			["auto_allocate_advance_payment", "fetch_only_allocated_advance_payment"],
+		)
+		target.allocate_advances_automatically = advance
+		target.only_include_allocated_payments = allocated
+		if target.get("allocate_advances_automatically"):
+			target.set_advances()
+
+		make_packing_list(target)
+		set_serial_batch_for_bundle_reservation(
+			source,
+			target,
+			frappe.get_single_value("Stock Settings", "use_serial_batch_fields"),
+			get_sre_details_for_voucher("Sales Order", source_name),
+		)
+
+	def set_missing_values(source, target):
+		target.flags.ignore_permissions = True
+		target.run_method("set_missing_values")
+		target.run_method("set_po_nos")
+		target.run_method("calculate_taxes_and_totals")
+		target.run_method("set_use_serial_batch_fields")
+
+		if source.company_address:
+			target.update({"company_address": source.company_address})
+		else:
+			# set company address
+			target.update(get_company_address(target.company))
+
+		if target.company_address:
+			target.update(get_fetch_values("Sales Invoice", "company_address", target.company_address))
+
+		# set the redeem loyalty points if provided via shopping cart
+		if source.loyalty_points and source.order_type == "Shopping Cart":
+			target.redeem_loyalty_points = 1
+			target.loyalty_points = source.loyalty_points
+
+		target.debit_to = get_party_account("Customer", source.customer, source.company)
+
+	def update_item(source, target, source_parent):
+		def get_billed_qty(so_item_name):
+			from frappe.query_builder.functions import Sum
+
+			table = frappe.qb.DocType("Sales Invoice Item")
+			query = (
+				frappe.qb.from_(table)
+				.select(Sum(table.qty).as_("qty"))
+				.where((table.docstatus == 1) & (table.so_detail == so_item_name))
+			)
+			return query.run(pluck="qty")[0] or 0
+
+		if source_parent.has_unit_price_items:
+			# 0 Amount rows (as seen in Unit Price Items) should be mapped as it is
+			pending_amount = flt(source.amount) - flt(source.billed_amt)
+			target.amount = pending_amount if flt(source.amount) else 0
+		else:
+			target.amount = flt(source.amount) - flt(source.billed_amt)
+
+		target.base_amount = target.amount * flt(source_parent.conversion_rate)
+		target.qty = (
+			source.qty - get_billed_qty(source.name)
+			if (source.qty and source.billed_amt)
+			else (source.qty if is_unit_price_row(source) else source.qty - source.returned_qty)
+		)
+
+		if source_parent.project:
+			target.cost_center = frappe.db.get_value("Project", source_parent.project, "cost_center")
+		if target.item_code:
+			item = get_item_defaults(target.item_code, source_parent.company)
+			item_group = get_item_group_defaults(target.item_code, source_parent.company)
+			cost_center = item.get("selling_cost_center") or item_group.get("selling_cost_center")
+
+			if cost_center:
+				target.cost_center = cost_center
+
+	def select_item(d):
+		filtered_items = args.get("filtered_children", [])
+		child_filter = d.name in filtered_items if filtered_items else True
+		return child_filter
+
+	def add_self_rm(doclist):
+		parent = frappe.qb.DocType("Subcontracting Inward Order")
+		child = frappe.qb.DocType("Subcontracting Inward Order Received Item")
+		query = (
+			frappe.qb.from_(parent)
+			.join(child)
+			.on(parent.name == child.parent)
+			.select(
+				child.required_qty,
+				child.consumed_qty,
+				child.billed_qty,
+				child.rm_item_code,
+				child.stock_uom,
+				child.name,
+			)
+			.where(
+				(parent.docstatus == 1)
+				& (parent.sales_order == source_name)
+				& (child.is_customer_provided_item == 0)
+			)
+		)
+		result = query.run(as_dict=True)
+
+		if result:
+			idx = len(doclist.items) + 1
+			for item in result:
+				if (qty := max(item.required_qty, item.consumed_qty) - item.billed_qty) > 0:
+					doclist.append(
+						"items",
+						{
+							"item_code": item.rm_item_code,
+							"qty": qty,
+							"uom": item.stock_uom,
+							"scio_detail": item.name,
+						},
+					)
+					doclist.process_item_selection(idx)
+					idx += 1
+		doclist.has_subcontracted = 1
+
+	doclist = get_mapped_doc(
+		"Sales Order",
+		source_name,
+		{
+			"Sales Order": {
+				"doctype": "Sales Invoice",
+				"field_map": {
+					"party_account_currency": "party_account_currency",
+				},
+				"field_no_map": ["payment_terms_template"],
+				"validation": {"docstatus": ["=", 1]},
+			},
+			"Sales Order Item": {
+				"doctype": "Sales Invoice Item",
+				"field_map": {
+					"name": "so_detail",
+					"parent": "sales_order",
+				},
+				"postprocess": update_item,
+				"condition": lambda doc: (
+					True
+					if is_unit_price_row(doc)
+					else (doc.qty and (doc.base_amount == 0 or abs(doc.billed_amt) < abs(doc.amount)))
+				)
+				and select_item(doc),
+			},
+			"Sales Taxes and Charges": {
+				"doctype": "Sales Taxes and Charges",
+				"reset_value": True,
+			},
+			"Sales Team": {"doctype": "Sales Team", "add_if_empty": True},
+		},
+		target_doc,
+		postprocess,
+		ignore_permissions=ignore_permissions,
+	)
+
+	if frappe.get_cached_value("Sales Order", source_name, "is_subcontracted"):
+		add_self_rm(doclist)
+
+	automatically_fetch_payment_terms = cint(
+		frappe.get_single_value("Accounts Settings", "automatically_fetch_payment_terms")
+	)
+	if automatically_fetch_payment_terms:
+		doclist.set_payment_schedule()
+
+	return doclist
+
+
+@frappe.whitelist()
+def make_maintenance_schedule(source_name: str, target_doc: str | Document | None = None):
+	maint_schedule = frappe.db.sql(
+		"""select t1.name
+		from `tabMaintenance Schedule` t1, `tabMaintenance Schedule Item` t2
+		where t2.parent=t1.name and t2.sales_order=%s and t1.docstatus=1""",
+		source_name,
+	)
+
+	if not maint_schedule:
+		doclist = get_mapped_doc(
+			"Sales Order",
+			source_name,
+			{
+				"Sales Order": {"doctype": "Maintenance Schedule", "validation": {"docstatus": ["=", 1]}},
+				"Sales Order Item": {
+					"doctype": "Maintenance Schedule Item",
+					"field_map": {"parent": "sales_order"},
+				},
+			},
+			target_doc,
+		)
+
+		return doclist
+
+
+@frappe.whitelist()
+def make_maintenance_visit(source_name: str, target_doc: str | Document | None = None):
+	visit = frappe.db.sql(
+		"""select t1.name
+		from `tabMaintenance Visit` t1, `tabMaintenance Visit Purpose` t2
+		where t2.parent=t1.name and t2.prevdoc_docname=%s
+		and t1.docstatus=1 and t1.completion_status='Fully Completed'""",
+		source_name,
+	)
+
+	if not visit:
+		doclist = get_mapped_doc(
+			"Sales Order",
+			source_name,
+			{
+				"Sales Order": {"doctype": "Maintenance Visit", "validation": {"docstatus": ["=", 1]}},
+				"Sales Order Item": {
+					"doctype": "Maintenance Visit Purpose",
+					"field_map": {"parent": "prevdoc_docname", "parenttype": "prevdoc_doctype"},
+				},
+			},
+			target_doc,
+		)
+
+		return doclist
+
+
 @frappe.whitelist()
 def get_events(start: str, end: str, filters: str | dict | None = None):
 	"""Returns events for Gantt / Calendar view rendering.

--- a/erpnext/selling/doctype/sales_order/test_sales_order.py
+++ b/erpnext/selling/doctype/sales_order/test_sales_order.py
@@ -2915,6 +2915,59 @@ class TestSalesOrder(ERPNextTestSuite):
 		self.assertEqual(serial_nos, serial_nos_in_bundle)
 		self.assertEqual(batch_nos, batches_in_bundle)
 
+	@ERPNextTestSuite.change_settings(
+		"Selling Settings", {"auto_allocate_advance_payment": 1, "fetch_only_allocated_advance_payment": 0}
+	)
+	def test_auto_allocate_advance_payment_from_sales_order(self):
+		from erpnext.accounts.doctype.payment_entry.test_payment_entry import get_payment_entry
+
+		so = make_sales_order(rate=1000)
+
+		pe1 = get_payment_entry("Sales Order", so.name)
+		pe1.paid_amount = 500
+		pe1.received_amount = 500
+		pe1.references[0].allocated_amount = 500
+		pe1.insert().submit()
+
+		pe2 = get_payment_entry("Sales Order", so.name)
+		pe2.paid_amount = 100
+		pe2.received_amount = 100
+		pe2.references = []
+		pe2.insert().submit()
+
+		si = make_sales_invoice(so.name)
+
+		references = [d.reference_name for d in si.advances]
+
+		self.assertIn(pe1.name, references)
+		self.assertIn(pe2.name, references)
+
+	@ERPNextTestSuite.change_settings(
+		"Selling Settings", {"auto_allocate_advance_payment": 1, "fetch_only_allocated_advance_payment": 1}
+	)
+	def test_auto_allocate_fetches_only_allocated_advances(self):
+		from erpnext.accounts.doctype.payment_entry.test_payment_entry import get_payment_entry
+
+		so = make_sales_order(rate=1000)
+
+		pe1 = get_payment_entry("Sales Order", so.name)
+		pe1.paid_amount = 500
+		pe1.received_amount = 500
+		pe1.references[0].allocated_amount = 500
+		pe1.insert().submit()
+
+		pe2 = get_payment_entry("Sales Order", so.name)
+		pe2.paid_amount = 100
+		pe2.received_amount = 100
+		pe2.references = []
+		pe2.insert().submit()
+
+		si = make_sales_invoice(so.name)
+		references = [d.reference_name for d in si.advances]
+
+		self.assertIn(pe1.name, references)
+		self.assertNotIn(pe2.name, references)
+
 
 def compare_payment_schedules(doc, doc1, doc2):
 	for index, schedule in enumerate(doc1.get("payment_schedule")):

--- a/erpnext/selling/doctype/selling_settings/selling_settings.json
+++ b/erpnext/selling/doctype/selling_settings/selling_settings.json
@@ -49,6 +49,8 @@
   "blanket_orders_section",
   "blanket_order_allowance",
   "advanced_features_tab",
+  "auto_allocate_advance_payment",
+  "fetch_only_allocated_advance_payment",
   "section_break_avhb",
   "enable_tracking_sales_commissions",
   "enable_discount_accounting",
@@ -403,7 +405,23 @@
   },
   {
    "fieldname": "transaction_naming_html",
-   "fieldtype": "HTML"
+   "fieldtype": "HTML",
+   "label": "Deliver Secondary Items"
+  },
+  {
+   "default": "0",
+   "description": "Automatically fetches and allocates available advance payments when creating an Sales invoice from a Sales Order/Delivery Note",
+   "fieldname": "auto_allocate_advance_payment",
+   "fieldtype": "Check",
+   "label": "Auto Allocate Advance Payment"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:doc.auto_allocate_advance_payment==1",
+   "description": "Retrieves advance payments that have been allocated to Sales Order, excluding unallocated payments.",
+   "fieldname": "fetch_only_allocated_advance_payment",
+   "fieldtype": "Check",
+   "label": "Fetch Only Allocated Advance Payment"
   }
  ],
  "grid_page_length": 50,

--- a/erpnext/selling/doctype/selling_settings/selling_settings.py
+++ b/erpnext/selling/doctype/selling_settings/selling_settings.py
@@ -38,6 +38,7 @@ class SellingSettings(Document):
 		allow_sales_order_creation_for_expired_quotation: DF.Check
 		allow_zero_qty_in_quotation: DF.Check
 		allow_zero_qty_in_sales_order: DF.Check
+		auto_allocate_advance_payment: DF.Check
 		blanket_order_allowance: DF.Float
 		cust_master_name: DF.Literal["Customer Name", "Naming Series", "Auto Name"]
 		customer_group: DF.Link | None
@@ -51,6 +52,7 @@ class SellingSettings(Document):
 		enable_tracking_sales_commissions: DF.Check
 		enable_utm: DF.Check
 		fallback_to_default_price_list: DF.Check
+		fetch_only_allocated_advance_payment: DF.Check
 		hide_tax_id: DF.Check
 		maintain_same_rate_action: DF.Literal["Stop", "Warn"]
 		maintain_same_sales_rate: DF.Check

--- a/erpnext/stock/doctype/delivery_note/delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.py
@@ -806,6 +806,392 @@ def get_list_context(context=None):
 	return list_context
 
 
+def get_invoiced_qty_map(delivery_note):
+	"""returns a map: {dn_detail: invoiced_qty}"""
+	sii = DocType("Sales Invoice Item")
+
+	invoiced_qty_map = frappe._dict(
+		(
+			frappe.qb.from_(sii)
+			.select(sii.dn_detail, Sum(sii.qty).as_("qty"))
+			.where((sii.delivery_note == delivery_note) & (sii.docstatus == 1))
+			.groupby(sii.dn_detail)
+		).run()
+	)
+
+	return invoiced_qty_map
+
+
+def get_returned_qty_map(delivery_note):
+	"""returns a map: {so_detail: returned_qty}"""
+	dn = DocType("Delivery Note")
+	dni = DocType("Delivery Note Item")
+
+	returned_qty_map = frappe._dict(
+		(
+			frappe.qb.from_(dni)
+			.join(dn)
+			.on(dn.name == dni.parent)
+			.select(dni.dn_detail, Sum(Abs(dni.qty)).as_("qty"))
+			.where(
+				(dn.docstatus == 1)
+				& (dn.is_return == 1)
+				& (dn.return_against == delivery_note)
+				& (dni.qty <= 0)
+			)
+			.groupby(dni.dn_detail)
+		).run()
+	)
+
+	return returned_qty_map
+
+
+@frappe.whitelist()
+def make_sales_invoice(
+	source_name: str, target_doc: str | Document | None = None, args: dict | str | None = None
+):
+	if args is None:
+		args = {}
+	if isinstance(args, str):
+		args = json.loads(args)
+
+	doc = frappe.get_doc("Delivery Note", source_name)
+
+	to_make_invoice_qty_map = {}
+	returned_qty_map = get_returned_qty_map(source_name)
+	invoiced_qty_map = get_invoiced_qty_map(source_name)
+
+	def set_missing_values(source, target):
+		target.run_method("set_missing_values")
+		target.run_method("set_po_nos")
+
+		if len(target.get("items")) == 0:
+			frappe.throw(_("All these items have already been Invoiced/Returned"))
+
+		if args and args.get("merge_taxes"):
+			merge_taxes(source, target)
+
+		target.run_method("calculate_taxes_and_totals")
+
+		# set company address
+		if source.company_address:
+			target.update({"company_address": source.company_address})
+		else:
+			# set company address
+			target.update(get_company_address(target.company))
+
+		if target.company_address:
+			target.update(get_fetch_values("Sales Invoice", "company_address", target.company_address))
+
+		advance, allocated = frappe.db.get_value(
+			"Selling Settings",
+			None,
+			["auto_allocate_advance_payment", "fetch_only_allocated_advance_payment"],
+		)
+		target.allocate_advances_automatically = advance
+		target.only_include_allocated_payments = allocated
+		if target.get("allocate_advances_automatically"):
+			target.set_advances()
+
+	def update_item(source_doc, target_doc, source_parent):
+		target_doc.qty = to_make_invoice_qty_map[source_doc.name]
+		target_doc._old_name = source_doc.name
+
+	def get_pending_qty(item_row):
+		pending_qty = item_row.qty - invoiced_qty_map.get(item_row.name, 0)
+
+		returned_qty = 0
+		if returned_qty_map.get(item_row.name, 0) > 0:
+			returned_qty = flt(returned_qty_map.get(item_row.name, 0))
+			returned_qty_map[item_row.name] -= pending_qty
+
+		if returned_qty:
+			if returned_qty >= pending_qty:
+				pending_qty = 0
+				returned_qty -= pending_qty
+			else:
+				pending_qty -= returned_qty
+				returned_qty = 0
+
+		to_make_invoice_qty_map[item_row.name] = pending_qty
+
+		return pending_qty
+
+	def select_item(d):
+		filtered_items = args.get("filtered_children", [])
+		child_filter = d.name in filtered_items if filtered_items else True
+		return child_filter
+
+	doc = get_mapped_doc(
+		"Delivery Note",
+		source_name,
+		{
+			"Delivery Note": {
+				"doctype": "Sales Invoice",
+				"field_map": {"is_return": "is_return"},
+				"validation": {"docstatus": ["=", 1]},
+			},
+			"Delivery Note Item": {
+				"doctype": "Sales Invoice Item",
+				"field_map": {
+					"name": "dn_detail",
+					"parent": "delivery_note",
+					"so_detail": "so_detail",
+					"against_sales_order": "sales_order",
+					"cost_center": "cost_center",
+				},
+				"postprocess": update_item,
+				"filter": lambda d: get_pending_qty(d) <= 0
+				if not doc.get("is_return")
+				else get_pending_qty(d) > 0,
+				"condition": select_item,
+			},
+			"Sales Taxes and Charges": {
+				"doctype": "Sales Taxes and Charges",
+				"reset_value": not (args and args.get("merge_taxes")),
+				"ignore": args.get("merge_taxes") if args else 0,
+			},
+			"Sales Team": {
+				"doctype": "Sales Team",
+				"field_map": {"incentives": "incentives"},
+				"add_if_empty": True,
+			},
+		},
+		target_doc,
+		set_missing_values,
+	)
+
+	automatically_fetch_payment_terms = cint(
+		frappe.get_single_value("Accounts Settings", "automatically_fetch_payment_terms")
+	)
+
+	if not doc.is_return:
+		so, doctype, fieldname = doc.get_order_details()
+		if (
+			doc.linked_order_has_payment_terms(so, fieldname, doctype)
+			and not automatically_fetch_payment_terms
+		):
+			payment_terms_template = frappe.db.get_value(doctype, so, "payment_terms_template")
+			doc.payment_terms_template = payment_terms_template
+			doc.due_date = get_due_date(
+				doc.posting_date,
+				"Customer",
+				doc.customer,
+				doc.company,
+				template_name=doc.payment_terms_template,
+			)
+
+		elif automatically_fetch_payment_terms:
+			doc.set_payment_schedule()
+
+	return doc
+
+
+@frappe.whitelist()
+def make_delivery_trip(
+	source_name: str, target_doc: str | Document | None = None, kwargs: dict | None = None
+):
+	if not target_doc:
+		target_doc = frappe.new_doc("Delivery Trip")
+
+	def update_address(source_doc, target_doc, source_parent):
+		target_doc.address = source_doc.shipping_address_name or source_doc.customer_address
+		target_doc.customer_address = source_doc.shipping_address or source_doc.address_display
+
+	doclist = get_mapped_doc(
+		"Delivery Note",
+		source_name,
+		{
+			"Delivery Note": {
+				"doctype": "Delivery Stop",
+				"on_parent": target_doc,
+				"field_map": {
+					"name": "delivery_note",
+					"contact_person": "contact",
+					"contact_display": "customer_contact",
+				},
+				"postprocess": update_address,
+			},
+		},
+		ignore_child_tables=True,
+	)
+
+	return doclist
+
+
+@frappe.whitelist()
+def make_installation_note(
+	source_name: str, target_doc: str | Document | None = None, kwargs: dict | None = None
+):
+	def update_item(obj, target, source_parent):
+		target.qty = flt(obj.qty) - flt(obj.installed_qty)
+		target.serial_no = obj.serial_no
+
+	doclist = get_mapped_doc(
+		"Delivery Note",
+		source_name,
+		{
+			"Delivery Note": {"doctype": "Installation Note", "validation": {"docstatus": ["=", 1]}},
+			"Delivery Note Item": {
+				"doctype": "Installation Note Item",
+				"field_map": {
+					"name": "prevdoc_detail_docname",
+					"parent": "prevdoc_docname",
+					"parenttype": "prevdoc_doctype",
+				},
+				"postprocess": update_item,
+				"condition": lambda doc: doc.installed_qty < doc.qty,
+			},
+		},
+		target_doc,
+	)
+
+	return doclist
+
+
+@frappe.whitelist()
+def make_packing_slip(source_name: str, target_doc: str | Document | None = None):
+	def set_missing_values(source, target):
+		target.run_method("set_missing_values")
+
+	def update_item(obj, target, source_parent):
+		target.qty = flt(obj.qty) - flt(obj.packed_qty)
+
+	doclist = get_mapped_doc(
+		"Delivery Note",
+		source_name,
+		{
+			"Delivery Note": {
+				"doctype": "Packing Slip",
+				"field_map": {"name": "delivery_note", "letter_head": "letter_head"},
+				"validation": {"docstatus": ["=", 0]},
+			},
+			"Delivery Note Item": {
+				"doctype": "Packing Slip Item",
+				"field_map": {
+					"item_code": "item_code",
+					"item_name": "item_name",
+					"batch_no": "batch_no",
+					"description": "description",
+					"qty": "qty",
+					"uom": "stock_uom",
+					"name": "dn_detail",
+				},
+				"postprocess": update_item,
+				"condition": lambda item: (
+					not frappe.db.exists("Product Bundle", {"new_item_code": item.item_code, "disabled": 0})
+					and flt(item.packed_qty) < flt(item.qty)
+				),
+			},
+			"Packed Item": {
+				"doctype": "Packing Slip Item",
+				"field_map": {
+					"item_code": "item_code",
+					"item_name": "item_name",
+					"batch_no": "batch_no",
+					"description": "description",
+					"qty": "qty",
+					"name": "pi_detail",
+				},
+				"postprocess": update_item,
+				"condition": lambda item: (flt(item.packed_qty) < flt(item.qty)),
+			},
+		},
+		target_doc,
+		set_missing_values,
+	)
+
+	return doclist
+
+
+@frappe.whitelist()
+def make_shipment(source_name: str, target_doc: str | Document | None = None):
+	def postprocess(source, target):
+		user = frappe.db.get_value(
+			"User", frappe.session.user, ["email", "full_name", "phone", "mobile_no"], as_dict=1
+		)
+		target.pickup_contact_email = user.email
+		pickup_contact_display = f"{user.full_name}"
+		if user:
+			if user.email:
+				pickup_contact_display += "<br>" + user.email
+			if user.phone:
+				pickup_contact_display += "<br>" + user.phone
+			if user.mobile_no and not user.phone:
+				pickup_contact_display += "<br>" + user.mobile_no
+		target.pickup_contact = pickup_contact_display
+
+		# As we are using session user details in the pickup_contact then pickup_contact_person will be session user
+		target.pickup_contact_person = frappe.session.user
+
+		contact_person = source.contact_person or get_default_contact("Customer", source.customer)
+		if contact_person:
+			contact = frappe.db.get_value(
+				"Contact", contact_person, ["email_id", "phone", "mobile_no"], as_dict=1
+			)
+
+			delivery_contact_display = source.contact_display or contact_person or ""
+			if contact and not source.contact_display:
+				if contact.email_id:
+					delivery_contact_display += "<br>" + contact.email_id
+				if contact.phone:
+					delivery_contact_display += "<br>" + contact.phone
+				if contact.mobile_no and not contact.phone:
+					delivery_contact_display += "<br>" + contact.mobile_no
+
+			target.delivery_contact_name = contact_person
+			if contact and contact.email_id and not target.delivery_contact_email:
+				target.delivery_contact_email = contact.email_id
+			target.delivery_contact = delivery_contact_display
+
+		if source.shipping_address_name:
+			target.delivery_address_name = source.shipping_address_name
+			target.delivery_address = source.shipping_address
+		elif source.customer_address:
+			target.delivery_address_name = source.customer_address
+			target.delivery_address = source.address_display
+
+	doclist = get_mapped_doc(
+		"Delivery Note",
+		source_name,
+		{
+			"Delivery Note": {
+				"doctype": "Shipment",
+				"field_map": {
+					"grand_total": "value_of_goods",
+					"company": "pickup_company",
+					"company_address": "pickup_address_name",
+					"company_address_display": "pickup_address",
+					"customer": "delivery_customer",
+					"contact_person": "delivery_contact_name",
+					"contact_email": "delivery_contact_email",
+				},
+				"validation": {"docstatus": ["=", 1]},
+			},
+			"Delivery Note Item": {
+				"doctype": "Shipment Delivery Note",
+				"field_map": {
+					"name": "prevdoc_detail_docname",
+					"parent": "prevdoc_docname",
+					"parenttype": "prevdoc_doctype",
+					"base_amount": "grand_total",
+				},
+			},
+		},
+		target_doc,
+		postprocess,
+	)
+
+	return doclist
+
+
+@frappe.whitelist()
+def make_sales_return(source_name: str, target_doc: str | Document | None = None):
+	from erpnext.controllers.sales_and_purchase_return import make_return_doc
+
+	return make_return_doc("Delivery Note", source_name, target_doc)
+
+
 @frappe.whitelist()
 def update_delivery_note_status(docname: str, status: str):
 	dn = frappe.get_lazy_doc("Delivery Note", docname)

--- a/erpnext/stock/doctype/delivery_note/test_delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/test_delivery_note.py
@@ -3382,6 +3382,67 @@ class TestDeliveryNote(ERPNextTestSuite):
 		dn.items[0].stock_qty = 2
 		dn.save()
 
+	@ERPNextTestSuite.change_settings(
+		"Selling Settings", {"auto_allocate_advance_payment": 1, "fetch_only_allocated_advance_payment": 0}
+	)
+	def test_auto_allocate_advance_payment_from_sales_order(self):
+		from erpnext.accounts.doctype.payment_entry.test_payment_entry import get_payment_entry
+		from erpnext.selling.doctype.sales_order.sales_order import make_delivery_note
+
+		so = make_sales_order(rate=1000)
+
+		pe1 = get_payment_entry("Sales Order", so.name)
+		pe1.paid_amount = 500
+		pe1.received_amount = 500
+		pe1.references[0].allocated_amount = 500
+		pe1.insert().submit()
+
+		pe2 = get_payment_entry("Sales Order", so.name)
+		pe2.paid_amount = 100
+		pe2.received_amount = 100
+		pe2.references = []
+		pe2.insert().submit()
+
+		dn = make_delivery_note(so.name)
+		dn.insert().submit()
+		si = make_sales_invoice(dn.name)
+
+		references = [d.reference_name for d in si.advances]
+
+		self.assertIn(pe1.name, references)
+		self.assertIn(pe2.name, references)
+
+	@ERPNextTestSuite.change_settings(
+		"Selling Settings", {"auto_allocate_advance_payment": 1, "fetch_only_allocated_advance_payment": 1}
+	)
+	def test_auto_allocate_fetches_only_allocated_advances(self):
+		from erpnext.accounts.doctype.payment_entry.test_payment_entry import get_payment_entry
+		from erpnext.selling.doctype.sales_order.sales_order import make_delivery_note
+
+		so = make_sales_order(rate=1000)
+
+		pe1 = get_payment_entry("Sales Order", so.name)
+		pe1.paid_amount = 500
+		pe1.received_amount = 500
+		pe1.references[0].allocated_amount = 500
+		pe1.insert().submit()
+
+		pe2 = get_payment_entry("Sales Order", so.name)
+		pe2.paid_amount = 100
+		pe2.received_amount = 100
+		pe2.references = []
+		pe2.insert().submit()
+
+		dn = make_delivery_note(so.name)
+		dn.insert().submit()
+
+		si = make_sales_invoice(dn.name)
+
+		references = [d.reference_name for d in si.advances]
+
+		self.assertIn(pe1.name, references)
+		self.assertNotIn(pe2.name, references)
+
 
 def create_delivery_note(**args):
 	dn = frappe.new_doc("Delivery Note")

--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
@@ -1066,6 +1066,183 @@ def get_item_wise_returned_qty(pr_doc):
 
 
 @frappe.whitelist()
+def make_purchase_invoice(
+	source_name: str | None, target_doc: str | Document | None = None, args: dict | str | None = None
+):
+	if args is None:
+		args = {}
+	if isinstance(args, str):
+		args = json.loads(args)
+
+	from erpnext.accounts.party import get_payment_terms_template
+
+	doc = frappe.get_doc("Purchase Receipt", source_name)
+	returned_qty_map = get_returned_qty_map(source_name)
+	invoiced_qty_map = get_invoiced_qty_map(source_name)
+
+	def set_missing_values(source, target):
+		if len(target.get("items")) == 0:
+			frappe.throw(_("All items have already been Invoiced/Returned"))
+
+		doc = frappe.get_doc(target)
+		doc.payment_terms_template = get_payment_terms_template(source.supplier, "Supplier", source.company)
+		doc.run_method("onload")
+		doc.run_method("set_missing_values")
+
+		if args and args.get("merge_taxes"):
+			merge_taxes(source, doc)
+
+		doc.run_method("calculate_taxes_and_totals")
+		doc.set_payment_schedule()
+
+		advance, allocated = frappe.db.get_value(
+			"Buying Settings", None, ["auto_allocate_advance_payment", "fetch_only_allocated_advance_payment"]
+		)
+		target.allocate_advances_automatically = advance
+		target.only_include_allocated_payments = allocated
+		if target.get("allocate_advances_automatically"):
+			target.set_advances()
+
+	def update_item(source_doc, target_doc, source_parent):
+		target_doc.qty, returned_qty = get_pending_qty(source_doc)
+		if frappe.db.get_single_value("Buying Settings", "bill_for_rejected_quantity_in_purchase_invoice"):
+			target_doc.rejected_qty = 0
+		target_doc.stock_qty = flt(target_doc.qty) * flt(
+			target_doc.conversion_factor, target_doc.precision("conversion_factor")
+		)
+		returned_qty_map[source_doc.name] = returned_qty
+		target_doc._old_name = source_doc.name
+
+	def get_pending_qty(item_row):
+		qty = item_row.qty
+		if frappe.db.get_single_value("Buying Settings", "bill_for_rejected_quantity_in_purchase_invoice"):
+			qty = item_row.received_qty
+
+		pending_qty = qty - invoiced_qty_map.get(item_row.name, 0)
+
+		if frappe.db.get_single_value("Buying Settings", "bill_for_rejected_quantity_in_purchase_invoice"):
+			return pending_qty, 0
+
+		returned_qty = flt(returned_qty_map.get(item_row.name, 0))
+		if item_row.rejected_qty and returned_qty:
+			returned_qty -= item_row.rejected_qty
+
+		if returned_qty:
+			if returned_qty >= pending_qty:
+				pending_qty = 0
+				returned_qty -= pending_qty
+			else:
+				pending_qty -= returned_qty
+				returned_qty = 0
+
+		return pending_qty, returned_qty
+
+	def select_item(d):
+		filtered_items = args.get("filtered_children", [])
+		child_filter = d.name in filtered_items if filtered_items else True
+		return child_filter
+
+	doclist = get_mapped_doc(
+		"Purchase Receipt",
+		source_name,
+		{
+			"Purchase Receipt": {
+				"doctype": "Purchase Invoice",
+				"field_map": {
+					"supplier_warehouse": "supplier_warehouse",
+					"is_return": "is_return",
+					"bill_date": "bill_date",
+				},
+				"validation": {
+					"docstatus": ["=", 1],
+				},
+			},
+			"Purchase Receipt Item": {
+				"doctype": "Purchase Invoice Item",
+				"field_map": {
+					"name": "pr_detail",
+					"parent": "purchase_receipt",
+					"qty": "received_qty",
+					"purchase_order_item": "po_detail",
+					"purchase_order": "purchase_order",
+					"is_fixed_asset": "is_fixed_asset",
+					"asset_location": "asset_location",
+					"asset_category": "asset_category",
+					"wip_composite_asset": "wip_composite_asset",
+				},
+				"postprocess": update_item,
+				"filter": lambda d: (
+					get_pending_qty(d)[0] <= 0 if not doc.get("is_return") else get_pending_qty(d)[0] > 0
+				),
+				"condition": select_item,
+			},
+			"Purchase Taxes and Charges": {
+				"doctype": "Purchase Taxes and Charges",
+				"reset_value": not (args and args.get("merge_taxes")),
+				"ignore": args.get("merge_taxes") if args else 0,
+			},
+		},
+		target_doc,
+		set_missing_values,
+	)
+
+	return doclist
+
+
+def get_invoiced_qty_map(purchase_receipt):
+	"""returns a map: {pr_detail: invoiced_qty}"""
+	invoiced_qty_map = {}
+
+	for pr_detail, qty in frappe.db.sql(
+		"""select pr_detail, qty from `tabPurchase Invoice Item`
+		where purchase_receipt=%s and docstatus=1""",
+		purchase_receipt,
+	):
+		if not invoiced_qty_map.get(pr_detail):
+			invoiced_qty_map[pr_detail] = 0
+		invoiced_qty_map[pr_detail] += qty
+
+	return invoiced_qty_map
+
+
+def get_returned_qty_map(purchase_receipt):
+	"""returns a map: {pr_detail: returned_qty}"""
+
+	pr = frappe.qb.DocType("Purchase Receipt")
+	pr_item = frappe.qb.DocType("Purchase Receipt Item")
+
+	query = (
+		frappe.qb.from_(pr)
+		.inner_join(pr_item)
+		.on(pr.name == pr_item.parent)
+		.select(pr_item.purchase_receipt_item, Sum(Abs(pr_item.qty)).as_("qty"))
+		.where(
+			(pr.docstatus == 1)
+			& (pr.is_return == 1)
+			& (pr.return_against == purchase_receipt)
+			& (pr_item.purchase_receipt_item.isnotnull())
+		)
+		.groupby(pr_item.purchase_receipt_item)
+	).run(as_list=1)
+
+	return frappe._dict(query) if query else frappe._dict()
+
+
+@frappe.whitelist()
+def make_purchase_return_against_rejected_warehouse(source_name: str):
+	from erpnext.controllers.sales_and_purchase_return import make_return_doc
+
+	return make_return_doc("Purchase Receipt", source_name, return_against_rejected_qty=True)
+
+
+@frappe.whitelist()
+def make_purchase_return(source_name: str, target_doc: str | Document | None = None):
+	from erpnext.controllers.sales_and_purchase_return import make_return_doc
+
+	return make_return_doc("Purchase Receipt", source_name, target_doc)
+
+
+@frappe.whitelist()
 def update_purchase_receipt_status(docname: str, status: str):
 	pr = frappe.get_lazy_doc("Purchase Receipt", docname, check_permission="submit")
 	pr.update_status(status)

--- a/erpnext/stock/doctype/purchase_receipt/test_purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/test_purchase_receipt.py
@@ -5790,6 +5790,71 @@ class TestPurchaseReceipt(ERPNextTestSuite):
 		self.assertAlmostEqual(srbnb_credit, pi_base_net_amount, places=2)
 
 
+	@ERPNextTestSuite.change_settings(
+		"Buying Settings", {"auto_allocate_advance_payment": 1, "fetch_only_allocated_advance_payment": 0}
+	)
+	def test_auto_allocate_advance_payment_from_purchase_order(self):
+		from erpnext.accounts.doctype.payment_entry.payment_entry import get_payment_entry
+		from erpnext.buying.doctype.purchase_order.purchase_order import make_purchase_receipt
+		from erpnext.buying.doctype.purchase_order.test_purchase_order import create_purchase_order
+
+		po = create_purchase_order(rate=1000)
+
+		pe1 = get_payment_entry("Purchase Order", po.name)
+		pe1.paid_amount = 500
+		pe1.received_amount = 500
+		pe1.references[0].allocated_amount = 500
+		pe1.insert().submit()
+
+		pe2 = get_payment_entry("Purchase Order", po.name)
+		pe2.paid_amount = 100
+		pe2.received_amount = 100
+		pe2.references = []
+		pe2.insert().submit()
+
+		pr = make_purchase_receipt(po.name)
+		pr.insert().submit()
+
+		pi = make_purchase_invoice(pr.name)
+
+		references = [d.reference_name for d in pi.advances]
+
+		self.assertIn(pe1.name, references)
+		self.assertIn(pe2.name, references)
+
+	@ERPNextTestSuite.change_settings(
+		"Buying Settings", {"auto_allocate_advance_payment": 1, "fetch_only_allocated_advance_payment": 1}
+	)
+	def test_auto_allocate_fetches_only_allocated_advances(self):
+		from erpnext.accounts.doctype.payment_entry.payment_entry import get_payment_entry
+		from erpnext.buying.doctype.purchase_order.purchase_order import make_purchase_receipt
+		from erpnext.buying.doctype.purchase_order.test_purchase_order import create_purchase_order
+
+		po = create_purchase_order(rate=1000)
+
+		pe1 = get_payment_entry("Purchase Order", po.name)
+		pe1.paid_amount = 500
+		pe1.received_amount = 500
+		pe1.references[0].allocated_amount = 500
+		pe1.insert().submit()
+
+		pe2 = get_payment_entry("Purchase Order", po.name)
+		pe2.paid_amount = 100
+		pe2.received_amount = 100
+		pe2.references = []
+		pe2.insert().submit()
+
+		pr = make_purchase_receipt(po.name)
+		pr.insert().submit()
+
+		pi = make_purchase_invoice(pr.name)
+
+		references = [d.reference_name for d in pi.advances]
+
+		self.assertIn(pe1.name, references)
+		self.assertNotIn(pe2.name, references)
+
+
 def create_asset_category_for_pr_test():
 	category_name = "Test Asset Category for PR"
 


### PR DESCRIPTION
**Issue :** Advance payment against SO/PO is not auto-allocated to invoice

**Ref :** [52237](https://github.com/frappe/erpnext/issues/52237)

**Fix :**  Added settings in Buying and Selling Settings to auto allocate advance payments and fetch only allocated payments while creating Purchase Invoice / Sales Invoice from PO / SO or DN / PR

**Solution :** Implemented auto advance payment allocation in invoice creation for the following flows:

1) Sales Order → Sales Invoice
Advances are automatically fetched and allocated while creating a Sales Invoice from a Sales Order.

2) Delivery Note → Sales Invoice
Advances are automatically fetched and allocated while creating a Sales Invoice from a Delivery Note.

3) Purchase Order → Purchase Invoice
Advances are automatically fetched and allocated while creating a Purchase Invoice from a Purchase Order.

4) Purchase Receipt → Purchase Invoice
Advances are automatically fetched and allocated while creating a Purchase Invoice from a Purchase Receipt.

Before : 

[Before.webm](https://github.com/user-attachments/assets/cba8f714-fc23-4379-8b6b-ea6a2714446e)

After : 

[After.webm](https://github.com/user-attachments/assets/94358f96-972c-491d-a758-eea39be56575)

**Backport needed: v16**


