### PR TITLE
fix: normalize date comparison to avoid datatype mismatch

### DIFF
--- a/erpnext/accounts/party.py
+++ b/erpnext/accounts/party.py
@@ -687,7 +687,7 @@ def validate_due_date_with_template(posting_date, due_date, bill_date, template_
 	if not default_due_date:
 		return
 
-	if default_due_date != posting_date and getdate(due_date) > getdate(default_due_date):
+	if getdate(default_due_date) != getdate(posting_date) and getdate(due_date) > getdate(default_due_date):
 		if frappe.get_single_value("Accounts Settings", "credit_controller") in frappe.get_roles():
 			party_type = "supplier" if doctype == "Purchase Invoice" else "customer"
 


### PR DESCRIPTION
**Description**
The issue seems to arise due to inconsistent data types between posting_date and default_due_date, particularly when a document is submitted via Workflow.

**Steps to Reproduce:**

1. Enable a Workflow on Purchase Invoice.
2. Create a Purchase Invoice from the UI.
3. Set the following values:
      Posting Date: 2026-04-23
      Bill Date: 2026-04-22
     Due Date: 2026-04-23 (same as expected default)
4. Submit the document using a Workflow action (e.g., Approve).

Ref:[#66575](https://support.frappe.io/helpdesk/tickets/66575?view=VIEW-HD+Ticket-745)

