### PR TITLE
fix(stock): use case instead of if in get_reserved_qty for postgres

### DIFF
--- a/erpnext/stock/stock_balance.py
+++ b/erpnext/stock/stock_balance.py
@@ -97,7 +97,7 @@ def get_reserved_qty(item_code, warehouse):
 	reserved_qty = frappe.db.sql(
 		f"""
 		select
-			sum(dnpi_qty * ((so_item_qty - so_item_delivered_qty - if(dont_reserve_qty_on_return, so_item_returned_qty, 0)) / so_item_qty))
+			sum(dnpi_qty * ((so_item_qty - so_item_delivered_qty - (case when dont_reserve_qty_on_return = 1 then so_item_returned_qty else 0 end)) / so_item_qty))
 		from
 			(
 				(select


### PR DESCRIPTION
Replace MariaDB-specific `if()` function with standard SQL `case when` statement in the `get_reserved_qty` query. This ensures the stock balance query executes successfully in PostgreSQL and still keeps existing MariaDB functionality.
