### PR TITLE
fix: status for settled credit notes in sales invoice list

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice_list.js
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice_list.js
@@ -27,6 +27,15 @@ frappe.listview_settings["Sales Invoice"] = {
 			"Partly Paid": "yellow",
 			"Internal Transfer": "darkgrey",
 		};
+
+		if (doc.status === "Credit Note Issued" && flt(doc.outstanding_amount) === 0) {
+			return [
+				__("Settled with Credit Note"),
+				"green",
+				`status,=,Credit Note Issued|outstanding_amount,=,0`,
+			];
+		}
+
 		return [__(doc.status), status_colors[doc.status], "status,=," + doc.status];
 	},
 	right_column: "grand_total",


### PR DESCRIPTION
### Problem
**Sales Invoice** records closed by a credit note currently appear as "Credit Note Issued" with a gray indicator. For users reviewing receivables, this looks unresolved or exceptional even when `outstanding_amount` is zero and no further collection action is needed.

### Changes
Show settled **Sales Invoice** records with credit notes as "Settled with Credit Note" in the list view when `outstanding_amount` is zero. Use a green indicator for that state to signal that there is no remaining receivable.
