### PR TITLE
refactor(buying): replace raw sql with orm in supplier scorecard

### DIFF
--- a/erpnext/buying/doctype/supplier_scorecard_standing/supplier_scorecard_standing.py
+++ b/erpnext/buying/doctype/supplier_scorecard_standing/supplier_scorecard_standing.py
@@ -40,14 +40,7 @@ def get_scoring_standing(standing_name: str):
 
 @frappe.whitelist()
 def get_standings_list():
-	standings = frappe.db.sql(
-		"""
-		SELECT
-			scs.name
-		FROM
-			`tabSupplier Scorecard Standing` scs""",
-		{},
-		as_dict=1,
-	)
+	"""Returns a list of all Supplier Scorecard Standings."""
+	standings = frappe.get_all("Supplier Scorecard Standing", fields=["name"])
 
 	return standings


### PR DESCRIPTION
Use frappe.get_all instead of frappe.db.sql to fetch standings list.  This improves code readability and adheres to Frappe framework best  practices for database abstraction.