### PR TITLE
refactor(purchase-order): use ORM syntax for min order quantity query

### DIFF
--- a/erpnext/buying/doctype/purchase_order/purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.py
@@ -300,7 +300,7 @@ class PurchaseOrder(BuyingController):
 
 		itemwise_min_order_qty = frappe._dict(
 			frappe.get_all(
-				"Item",fields=["name", "min_order_qty"], filters={"name": ["in", items]}, as_list=True
+				"Item", fields=["name", "min_order_qty"], filters={"name": ["in", items]}, as_list=True
 			)
 		)
 

--- a/erpnext/buying/doctype/purchase_order/purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.py
@@ -293,15 +293,16 @@ class PurchaseOrder(BuyingController):
 		self.party_account_currency = get_party_account_currency("Supplier", self.supplier, self.company)
 
 	def validate_minimum_order_qty(self):
+		"""Check if total ordered quantities meet the Item's minimum order requirement."""
 		if not self.get("items"):
 			return
 		items = list(set(d.item_code for d in self.get("items")))
 
 		itemwise_min_order_qty = frappe._dict(
-			frappe.db.sql(
-				"""select name, min_order_qty
-			from tabItem where name in ({})""".format(", ".join(["%s"] * len(items))),
-				items,
+			frappe.get_all("Item",
+				fields=["name", "min_order_qty"], 
+				filters={"name": ["in", items]}, 
+				as_list=True
 			)
 		)
 

--- a/erpnext/buying/doctype/purchase_order/purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.py
@@ -299,10 +299,7 @@ class PurchaseOrder(BuyingController):
 		items = list(set(d.item_code for d in self.get("items")))
 
 		itemwise_min_order_qty = frappe._dict(
-			frappe.get_all("Item",
-				fields=["name", "min_order_qty"], 
-				filters={"name": ["in", items]}, 
-				as_list=True
+			frappe.get_all("Item",fields=["name", "min_order_qty"], filters={"name": ["in", items]}, as_list=True
 			)
 		)
 

--- a/erpnext/buying/doctype/purchase_order/purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.py
@@ -299,7 +299,8 @@ class PurchaseOrder(BuyingController):
 		items = list(set(d.item_code for d in self.get("items")))
 
 		itemwise_min_order_qty = frappe._dict(
-			frappe.get_all("Item",fields=["name", "min_order_qty"], filters={"name": ["in", items]}, as_list=True
+			frappe.get_all(
+				"Item",fields=["name", "min_order_qty"], filters={"name": ["in", items]}, as_list=True
 			)
 		)
 


### PR DESCRIPTION
Use frappe.get_all instead of raw SQL with manual string formatting to fetch min_order_qty. This improves code readability and leverages the framework's built-in database abstraction.