### PR TITLE
fix(crm): handle empty _assign in appointment auto assignment

### DIFF
--- a/erpnext/crm/doctype/appointment/appointment.py
+++ b/erpnext/crm/doctype/appointment/appointment.py
@@ -235,10 +235,13 @@ def _get_agents_sorted_by_asc_workload(date):
 		return agent_list
 	appointment_counter = Counter(agent_list)
 	for appointment in appointments:
-		assigned_to = frappe.parse_json(appointment._assign)
-		if not assigned_to:
+		assign_data = appointment._assign
+		if isinstance(assign_data, str):
+			assign_data = assign_data.strip()
+		if not assign_data:
 			continue
-		if (assigned_to[0] in agent_list) and getdate(appointment.scheduled_time) == date:
+		assigned_to = frappe.parse_json(assign_data)
+		if assigned_to and (assigned_to[0] in agent_list) and getdate(appointment.scheduled_time) == date:
 			appointment_counter[assigned_to[0]] += 1
 	sorted_agent_list = appointment_counter.most_common()
 	sorted_agent_list.reverse()


### PR DESCRIPTION
**Issue:**
Creating a new Appointment fails with a JSONDecodeError during auto assignment when an existing Appointment record contains an empty string (" ") in the _assign field.

**Ref:**  [#67515](https://support.frappe.io/helpdesk/tickets/67515?view=VIEW-HD+Ticket-746)