### PR TITLE
fix: disallow editing on reversal journals

### DIFF
--- a/erpnext/accounts/doctype/journal_entry/journal_entry.js
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.js
@@ -70,6 +70,10 @@ frappe.ui.form.on("Journal Entry", {
 	},
 
 	refresh: function (frm) {
+		if (frm.doc.reversal_of && (frm.is_new() || frm.doc.docstatus == 0)) {
+			frm.set_read_only();
+		}
+
 		erpnext.toggle_naming_series();
 
 		if (frm.doc.docstatus > 0) {


### PR DESCRIPTION
System allow users to modify reversal entry in however way they want - post modification they might not even have the same accounts as the original journal. 

Prevent users from modifying reversal journals. In other words, full reversal is possible, partial is not.

Ref: [67100](https://support.frappe.io/helpdesk/tickets/67100)