### PR TITLE
fix: fetch get_item_tax_template while update items

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -68,6 +68,7 @@ from erpnext.stock.doctype.item.item import get_uom_conv_factor
 from erpnext.stock.doctype.packed_item.packed_item import make_packing_list
 from erpnext.stock.get_item_details import (
 	_get_item_tax_template,
+	_get_item_tax_template_from_item_group,
 	get_conversion_factor,
 	get_item_details,
 	get_item_tax_map,
@@ -3647,6 +3648,10 @@ def set_child_tax_template_and_map(item, child_item, parent_doc):
 	}
 
 	child_item.item_tax_template = _get_item_tax_template(args, item.taxes)
+
+	if not child_item.get("item_tax_template"):
+		child_item.item_tax_template = _get_item_tax_template_from_item_group(args, item.item_group)
+
 	if child_item.get("item_tax_template"):
 		child_item.item_tax_rate = get_item_tax_map(
 			parent_doc.get("company"), child_item.item_tax_template, as_json=True

--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -671,6 +671,7 @@ def get_item_tax_info(company, tax_category, item_codes, item_rates=None, item_t
 	return out
 
 
+# nosemgrep: frappe-semgrep-rules.rules.security.missing-argument-type-hint
 @frappe.whitelist()
 def get_item_tax_template(args, item=None, out=None):
 	if isinstance(args, str):
@@ -687,16 +688,24 @@ def get_item_tax_template(args, item=None, out=None):
 		item_tax_template = _get_item_tax_template(args, item.taxes, out)
 
 	if not item_tax_template:
-		item_group = item.item_group
-		while item_group and not item_tax_template:
-			item_group_doc = frappe.get_cached_doc("Item Group", item_group)
-			item_tax_template = _get_item_tax_template(args, item_group_doc.taxes, out)
-			item_group = item_group_doc.parent_item_group
+		item_tax_template = _get_item_tax_template_from_item_group(args, item.item_group, out)
 
 	if out and args.get("child_doctype") and item_tax_template:
 		out.update(get_fetch_values(args.get("child_doctype"), "item_tax_template", item_tax_template))
 
 	return item_tax_template
+
+
+def _get_item_tax_template_from_item_group(args, item_group, out=None):
+	from frappe.utils.nestedset import get_ancestors_of
+
+	ancestors = get_ancestors_of("Item Group", item_group)
+	for group in [item_group, *ancestors]:
+		group_doc = frappe.get_cached_doc("Item Group", group)
+		item_tax_template = _get_item_tax_template(args, group_doc.taxes, out)
+		if item_tax_template:
+			return item_tax_template
+	return None
 
 
 def _get_item_tax_template(args, taxes, out=None, for_validate=False):


### PR DESCRIPTION
**Issue:**
Tax at Item Group Level is not applied when Items are updated through "Update Items".

**Ref:**[#63027](https://support.frappe.io/helpdesk/tickets/63027)

Added a targeted nosemgrep suppression for get_item_tax_template. This whitelisted function uses dynamic inputs, and adding argument type hints caused a runtime regression in item tax template updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Item tax templates are now automatically derived from an item's group when not explicitly set on the item.
  * The system now correctly falls back through parent item groups to find the nearest tax template, ensuring consistent tax configuration for items without direct templates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->