### PR TITLE
fix(stock): priorities pick list parent warehouse

### DIFF
--- a/erpnext/stock/doctype/pick_list/pick_list.py
+++ b/erpnext/stock/doctype/pick_list/pick_list.py
@@ -524,9 +524,11 @@ class PickList(TransactionBase):
 		picked_items_details = self.get_picked_items_details(items)
 		self.item_location_map = frappe._dict()
 
-		from_warehouses = [self.parent_warehouse] if self.parent_warehouse else []
+		from_warehouses = []
+		if self.parent_warehouse:
+			from_warehouses = [self.parent_warehouse]
 
-		if self.work_order:
+		elif self.work_order:
 			root_warehouse = frappe.db.get_value(
 				"Warehouse", {"company": self.company, "parent_warehouse": ["IS", "NOT SET"], "is_group": 1}
 			)


### PR DESCRIPTION
**Issue:**
The system should prioritize the Pick List parent warehouse, and only if it is not available should it consider the Work Order warehouse. Currently, when creating the entry from a Work Order, the system does not consider the Pick List parent warehouse.

**Ref:** [#67864](https://support.frappe.io/helpdesk/tickets/67864)

**Backport Needed for v15 & v16**