### PR TITLE
fix: implement get_notification_email hook on Opportunity, Prospect and Customer

### DIFF
--- a/erpnext/crm/doctype/lead/test_lead.py
+++ b/erpnext/crm/doctype/lead/test_lead.py
@@ -148,6 +148,15 @@ class TestLead(ERPNextTestSuite):
 		self.assertEqual(event.event_participants[1].reference_doctype, "Prospect")
 		self.assertEqual(event.event_participants[1].reference_docname, prospect)
 
+	def test_get_notification_email(self):
+		admin_email = frappe.db.get_value("User", "Administrator", "email")
+		lead = frappe.new_doc("Lead")
+		lead.lead_owner = "Administrator"
+		self.assertEqual(lead.get_notification_email(), admin_email)
+
+		lead.lead_owner = None
+		self.assertIsNone(lead.get_notification_email())
+
 
 def create_event(subject, starts_on, reference_type, reference_name):
 	event = frappe.new_doc("Event")

--- a/erpnext/crm/doctype/opportunity/opportunity.py
+++ b/erpnext/crm/doctype/opportunity/opportunity.py
@@ -363,6 +363,13 @@ class Opportunity(TransactionBase, CRMNote):
 				if not d.get(key):
 					d.set(key, item.get(key))
 
+	def get_notification_email(self):
+		"""Hook to return the target email address for notifications."""
+		if self.opportunity_owner:
+			return frappe.db.get_value("User", self.opportunity_owner, "email")
+
+		return None
+
 
 @frappe.whitelist()
 def get_item_details(item_code: str):

--- a/erpnext/crm/doctype/opportunity/test_opportunity.py
+++ b/erpnext/crm/doctype/opportunity/test_opportunity.py
@@ -91,6 +91,15 @@ class TestOpportunity(ERPNextTestSuite):
 		create_communication(opp_doc.doctype, opp_doc.name, opp_doc.contact_email)
 		create_communication(opp_doc.doctype, opp_doc.name, opp_doc.contact_email)
 
+	def test_get_notification_email(self):
+		admin_email = frappe.db.get_value("User", "Administrator", "email")
+		opp = frappe.new_doc("Opportunity")
+		opp.opportunity_owner = "Administrator"
+		self.assertEqual(opp.get_notification_email(), admin_email)
+
+		opp.opportunity_owner = None
+		self.assertIsNone(opp.get_notification_email())
+
 
 def make_opportunity_from_lead(company):
 	new_lead_email_id = f"new{random_string(5)}@example.com"

--- a/erpnext/crm/doctype/prospect/prospect.py
+++ b/erpnext/crm/doctype/prospect/prospect.py
@@ -86,6 +86,13 @@ class Prospect(CRMNote):
 					linked_doc.append("links", {"link_doctype": self.doctype, "link_name": self.name})
 					linked_doc.save(ignore_permissions=True)
 
+	def get_notification_email(self):
+		"""Hook to return the target email address for notifications."""
+		if self.prospect_owner:
+			return frappe.db.get_value("User", self.prospect_owner, "email")
+
+		return None
+
 
 @frappe.whitelist()
 def make_customer(source_name: str, target_doc: str | Document | None = None):

--- a/erpnext/crm/doctype/prospect/test_prospect.py
+++ b/erpnext/crm/doctype/prospect/test_prospect.py
@@ -51,6 +51,15 @@ class TestProspect(ERPNextTestSuite):
 		customer.company = "_Test Company"
 		customer.insert()
 
+	def test_get_notification_email(self):
+		admin_email = frappe.db.get_value("User", "Administrator", "email")
+		prospect = frappe.new_doc("Prospect")
+		prospect.prospect_owner = "Administrator"
+		self.assertEqual(prospect.get_notification_email(), admin_email)
+
+		prospect.prospect_owner = None
+		self.assertIsNone(prospect.get_notification_email())
+
 
 def make_prospect(**args):
 	args = frappe._dict(args)

--- a/erpnext/selling/doctype/customer/customer.py
+++ b/erpnext/selling/doctype/customer/customer.py
@@ -442,6 +442,13 @@ class Customer(TransactionBase):
 				)
 			)
 
+	def get_notification_email(self):
+		"""Hook to return the target email address for notifications."""
+		if self.account_manager:
+			return frappe.db.get_value("User", self.account_manager, "email")
+
+		return None
+
 
 @frappe.whitelist()
 def make_quotation(source_name: str, target_doc: str | Document | None = None):

--- a/erpnext/selling/doctype/customer/test_customer.py
+++ b/erpnext/selling/doctype/customer/test_customer.py
@@ -350,6 +350,15 @@ class TestCustomer(ERPNextTestSuite):
 		self.assertEqual(middle, "Michael")
 		self.assertEqual(last, "Doe")
 
+	def test_get_notification_email(self):
+		admin_email = frappe.db.get_value("User", "Administrator", "email")
+		customer = frappe.new_doc("Customer")
+		customer.account_manager = "Administrator"
+		self.assertEqual(customer.get_notification_email(), admin_email)
+
+		customer.account_manager = None
+		self.assertIsNone(customer.get_notification_email())
+
 
 def get_customer_dict(customer_name):
 	return {


### PR DESCRIPTION
Implements `get_notification_email` on the **Opportunity**, **Prospect** and **Customer** DocTypes so that email thread notifications are sent to the dedicated _Owner_ / _Account Manager_ instead of the document creator.

Previously, the user who created a record (`doc.owner`) received all email thread notifications, even if a different user was assigned as _Owner_ / _Account Manager_. This is disruptive when one person creates records but another person manages them.

Now, if an _Owner_ / _Account Manager_ is set, that user receives thread notifications. If not, it falls back to the document creator.

Same for **Lead**: https://github.com/frappe/erpnext/pull/53959
Depends on: frappe/frappe#38365