### PR TITLE
fix(stock): ignore reserved qty for stock levels in batch

### DIFF
--- a/erpnext/stock/doctype/batch/batch.js
+++ b/erpnext/stock/doctype/batch/batch.js
@@ -70,6 +70,7 @@ frappe.ui.form.on("Batch", {
 					item_code: frm.doc.item,
 					for_stock_levels: for_stock_levels,
 					consider_negative_batches: 1,
+					ignore_reserved_stock: 1,
 				},
 				callback: (r) => {
 					if (!r.message || r.message.length === 0) {


### PR DESCRIPTION
**Issue:** Batch stock levels are deducting reserved stock quantities and showing reduced stock.

**Steps to Replicate**
1. Create a batched item.
2. Add 100 Qty stock for the batch.
3. Create a Stock Reservation for 12 Qty.
4. Open the Batch document and check the Stock Levels.

**Current Behavior**

Stock level shows 88 Qty.

**Expected Behavior**

Stock level should display the actual batch quantity 100 Qty. Reserved stock quantities should not affect the stock levels shown in the Batch document.

**Before:** 

<img width="1861" height="939" alt="Before stock level" src="https://github.com/user-attachments/assets/fdd78c2d-439f-4141-b037-33232676404d" />


**After:** 

<img width="1861" height="939" alt="after stock level" src="https://github.com/user-attachments/assets/1c3c60c9-acd3-46be-a042-ef19a1b91e12" />


Backport Needed For V15 and V16
