### PR TITLE
fix: fall back to default_dimension when round-off GLE inherits None from parent

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
@@ -2346,6 +2346,177 @@ class TestSalesInvoice(FrappeTestCase):
 
 		disable_dimension()
 
+	def test_round_off_gle_falls_back_to_default_for_mandatory_pl_dimension(self):
+		"""
+		Round-off GL entry should inherit the per-company default_dimension when
+		the parent voucher exposes a mandatory_for_pl accounting dimension field
+		but its value is None. Previously the parent's None was copied verbatim,
+		causing the validate_dimensions_for_pl_and_bs validator to reject the
+		round-off GLE on submit.
+		"""
+		from erpnext.accounts.doctype.accounting_dimension.test_accounting_dimension import (
+			create_dimension,
+			disable_dimension,
+		)
+
+		create_dimension()
+		frappe.db.set_value("Company", "_Test Company", "round_off_account", "Round Off - _TC")
+
+		# Mark Location as mandatory for P&L (Round Off account is P&L). Persist
+		# the prior values so we can restore them at the end.
+		location = frappe.get_doc("Accounting Dimension", "Location")
+		original = [
+			(d.company, d.mandatory_for_pl, d.mandatory_for_bs, d.default_dimension)
+			for d in location.dimension_defaults
+		]
+		for d in location.dimension_defaults:
+			if d.company == "_Test Company":
+				d.mandatory_for_pl = 1
+				d.mandatory_for_bs = 0
+				d.default_dimension = "Block 1"
+		location.save()
+
+		try:
+			# Build an SI that produces a round-off GLE (cents drift via inclusive tax).
+			# Crucially, leave si.location unset so the parent has the field but value is None.
+			si = create_sales_invoice(do_not_save=True)
+			si.items = []
+			for d in [(1122, 2), (1122.01, 1), (1122.01, 1)]:
+				si.append(
+					"items",
+					{
+						"item_code": "_Test Item",
+						"gst_hsn_code": "999800",
+						"warehouse": "_Test Warehouse - _TC",
+						"qty": d[1],
+						"rate": d[0],
+						"income_account": "Sales - _TC",
+						"cost_center": "_Test Cost Center - _TC",
+						"location": "Block 1",
+					},
+				)
+			for tax_account in ["_Test Account VAT - _TC", "_Test Account Service Tax - _TC"]:
+				si.append(
+					"taxes",
+					{
+						"charge_type": "On Net Total",
+						"account_head": tax_account,
+						"description": tax_account,
+						"rate": 6,
+						"cost_center": "_Test Cost Center - _TC",
+						"included_in_print_rate": 1,
+					},
+				)
+
+			# Ensure header-level dimension is None (the bug condition).
+			si.location = None
+			si.save()
+			self.assertIsNone(si.location)
+
+			# Submit must succeed; pre-fix this raised:
+			#   "Accounting Dimension Location is required for 'Profit and Loss' account Round Off - _TC"
+			si.submit()
+
+			round_off_gle = frappe.db.get_value(
+				"GL Entry",
+				{"voucher_type": "Sales Invoice", "voucher_no": si.name, "account": "Round Off - _TC"},
+				["location"],
+				as_dict=1,
+			)
+			self.assertIsNotNone(round_off_gle, "Round Off GL entry should exist for this invoice")
+			self.assertEqual(round_off_gle.location, "Block 1")
+		finally:
+			# Restore original mandatory flags / defaults
+			location = frappe.get_doc("Accounting Dimension", "Location")
+			for d, prior in zip(location.dimension_defaults, original, strict=False):
+				d.mandatory_for_pl = prior[1]
+				d.mandatory_for_bs = prior[2]
+				d.default_dimension = prior[3]
+			location.save()
+			disable_dimension()
+
+	def test_round_off_gle_preserves_parent_value_for_mandatory_dimension(self):
+		"""
+		When the parent voucher carries a non-None value for a mandatory_for_pl
+		dimension, the round-off GLE should keep that value rather than be
+		overwritten by the per-company default fallback.
+		"""
+		from erpnext.accounts.doctype.accounting_dimension.test_accounting_dimension import (
+			create_dimension,
+			disable_dimension,
+		)
+
+		create_dimension()
+		frappe.db.set_value("Company", "_Test Company", "round_off_account", "Round Off - _TC")
+
+		# Point the per-company default at a location that DIFFERS from the
+		# value we set on the parent. If the parent's value is preserved as
+		# expected, the round-off GLE will hold "Block 1" (parent value), not
+		# "Field 1" (the default).
+		location = frappe.get_doc("Accounting Dimension", "Location")
+		original = [
+			(d.company, d.mandatory_for_pl, d.mandatory_for_bs, d.default_dimension)
+			for d in location.dimension_defaults
+		]
+		for d in location.dimension_defaults:
+			if d.company == "_Test Company":
+				d.mandatory_for_pl = 1
+				d.mandatory_for_bs = 0
+				d.default_dimension = "Field 1"
+		location.save()
+
+		try:
+			si = create_sales_invoice(do_not_save=True)
+			si.items = []
+			for d in [(1122, 2), (1122.01, 1), (1122.01, 1)]:
+				si.append(
+					"items",
+					{
+						"item_code": "_Test Item",
+						"gst_hsn_code": "999800",
+						"warehouse": "_Test Warehouse - _TC",
+						"qty": d[1],
+						"rate": d[0],
+						"income_account": "Sales - _TC",
+						"cost_center": "_Test Cost Center - _TC",
+						"location": "Block 1",
+					},
+				)
+			for tax_account in ["_Test Account VAT - _TC", "_Test Account Service Tax - _TC"]:
+				si.append(
+					"taxes",
+					{
+						"charge_type": "On Net Total",
+						"account_head": tax_account,
+						"description": tax_account,
+						"rate": 6,
+						"cost_center": "_Test Cost Center - _TC",
+						"included_in_print_rate": 1,
+					},
+				)
+
+			# Header carries an explicit non-default value; fallback must NOT overwrite it.
+			si.location = "Block 1"
+			si.save()
+			si.submit()
+
+			round_off_gle = frappe.db.get_value(
+				"GL Entry",
+				{"voucher_type": "Sales Invoice", "voucher_no": si.name, "account": "Round Off - _TC"},
+				["location"],
+				as_dict=1,
+			)
+			self.assertIsNotNone(round_off_gle, "Round Off GL entry should exist for this invoice")
+			self.assertEqual(round_off_gle.location, "Block 1")
+		finally:
+			location = frappe.get_doc("Accounting Dimension", "Location")
+			for d, prior in zip(location.dimension_defaults, original, strict=False):
+				d.mandatory_for_pl = prior[1]
+				d.mandatory_for_bs = prior[2]
+				d.default_dimension = prior[3]
+			location.save()
+			disable_dimension()
+
 	def test_sales_invoice_with_shipping_rule(self):
 		from erpnext.accounts.doctype.shipping_rule.test_shipping_rule import create_shipping_rule
 

--- a/erpnext/accounts/general_ledger.py
+++ b/erpnext/accounts/general_ledger.py
@@ -613,18 +613,24 @@ def update_accounting_dimensions(round_off_gle):
 
 		for dimension in dimensions:
 			round_off_gle[dimension] = dimension_values.get(dimension)
-	else:
-		report_type = frappe.get_cached_value("Account", round_off_gle.account, "report_type")
-		for dimension in get_checks_for_pl_and_bs_accounts():
-			if (
-				round_off_gle.company == dimension.company
-				and (
-					(report_type == "Profit and Loss" and dimension.mandatory_for_pl)
-					or (report_type == "Balance Sheet" and dimension.mandatory_for_bs)
-				)
-				and dimension.default_dimension
-			):
-				round_off_gle[dimension.fieldname] = dimension.default_dimension
+
+	# Fall back to the per-company default dimension for any mandatory dimension
+	# that is still unset. This handles the common case where the parent voucher
+	# has the dimension field but its value is None (e.g. line-level dimensions
+	# rather than header-level), which would otherwise trip the mandatory-dimension
+	# validator on the round-off GL entry.
+	report_type = frappe.get_cached_value("Account", round_off_gle.account, "report_type")
+	for dimension in get_checks_for_pl_and_bs_accounts():
+		if (
+			round_off_gle.company == dimension.company
+			and (
+				(report_type == "Profit and Loss" and dimension.mandatory_for_pl)
+				or (report_type == "Balance Sheet" and dimension.mandatory_for_bs)
+			)
+			and dimension.default_dimension
+			and not round_off_gle.get(dimension.fieldname)
+		):
+			round_off_gle[dimension.fieldname] = dimension.default_dimension
 
 
 def get_round_off_account_and_cost_center(company, voucher_type, voucher_no, use_company_default=False):


### PR DESCRIPTION
## Problem

`update_accounting_dimensions` in `erpnext/accounts/general_ledger.py` populates accounting dimensions on the auto-created round-off GL entry through one of two mutually exclusive paths:

1. If the parent voucher exposes all configured dimension fields, copy each dimension value verbatim from the parent (including `None`).
2. Otherwise, for any dimension marked `mandatory_for_pl` / `mandatory_for_bs`, fall back to the per-company `default_dimension`.

The first branch swallows the second. When the parent has the dimension field but the value is `None` (a common case where header-level dimensions are blank and each line item carries its own value), `None` is copied onto the round-off GLE. The mandatory-dimension validator at `gl_entry.py` then rejects submission with:

> Accounting Dimension `<X>` is required for 'Profit and Loss' account `<round-off account>`.

This affects any deployment that configures an accounting dimension as `mandatory_for_pl=1` (or `mandatory_for_bs=1`) and produces invoices with sub-cent rounding drift, e.g. tax-inclusive line items.

### Reproducer
1. Create an Accounting Dimension with a per-company default and `mandatory_for_pl = 1`.
2. Create a Sales / Purchase Invoice with tax-inclusive line items that produces cents drift (so a Round Off GL entry is generated).
3. Leave the header-level dimension value blank.
4. Submit the invoice -> fails with the validator error above.

## Fix

Always run the mandatory-dimension fallback after copying parent values, but only fill dimensions that are still unset on the round-off GLE. The two existing branches become a two-pass flow:

- Pass 1 (unchanged): copy parent values onto the round-off GLE when the parent has all dimension fields.
- Pass 2 (newly always-on): for each mandatory dimension with a `default_dimension`, set it on the round-off GLE only if not already set.

The `not round_off_gle.get(dimension.fieldname)` guard preserves any value already populated by Pass 1 or already present on the GLE, so non-`None` parent values are never overwritten. The previous "no-field" code path (Pass 2 only) is unchanged: if the parent doesn't have the dimension field, Pass 1 is a no-op and Pass 2 fills mandatory defaults exactly as before.

## Tests

Two tests added to `test_sales_invoice.py` next to the existing `test_rounding_adjustment_3`:

- `test_round_off_gle_falls_back_to_default_for_mandatory_pl_dimension`: parent has the dimension field but its value is `None`. Pre-fix: submit fails with the validator error. Post-fix: submit succeeds and the round-off GLE inherits the per-company `default_dimension`.
- `test_round_off_gle_preserves_parent_value_for_mandatory_dimension`: parent carries a non-default value. Verifies the fallback does not overwrite it (regression guard for Pass 2's guard condition).

Both tests reuse the existing `create_dimension()` fixture and restore the original `mandatory_for_pl` / `default_dimension` values in `finally`, so they don't leak state into other tests in the suite.

Backport Needed For V16
