### PR TITLE
fix(general-ledger): show raw GL entries when categorize_by is empty

### DIFF
--- a/erpnext/accounts/report/general_ledger/general_ledger.py
+++ b/erpnext/accounts/report/general_ledger/general_ledger.py
@@ -417,7 +417,13 @@ def get_data_with_opening_closing(filters, account_details, accounting_dimension
 	# Opening for filtered account
 	add_total_to_data(totals, "opening")
 
-	if filters.get("categorize_by") != "Categorize by Voucher (Consolidated)":
+	if not filters.get("categorize_by"):
+		all_entries = []
+		for acc_dict in gle_map.values():
+			all_entries.extend(acc_dict.entries)
+		data += all_entries
+
+	elif filters.get("categorize_by") != "Categorize by Voucher (Consolidated)":
 		set_opening_closing = (not filters.get("categorize_by") and not filters.get("voucher_no")) or (
 			filters.get("categorize_by") and filters.get("categorize_by") != "Categorize by Voucher"
 		)
@@ -483,7 +489,6 @@ def initialize_gle_map(gl_entries, filters):
 				totals=get_totals_dict(),
 				entries=[],
 			)
-
 	return gle_map
 
 


### PR DESCRIPTION
Previously, leaving categorize_by blank would still group entries by
voucher_no and render per-voucher opening/total's rows.
Now, an empty categorize_by renders every GL entry as an individual row
with only the global opening, total, and closing, no grouping or
consolidation.

https://support.frappe.io/helpdesk/tickets/67129?view=VIEW-HD+Ticket-1547