### PR TITLE
fix: fetch hour rate from workstation when operation hour_rate is mis…

### DIFF
--- a/erpnext/manufacturing/doctype/work_order/work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/work_order.py
@@ -324,6 +324,10 @@ class WorkOrder(Document):
 	def calculate_operating_cost(self):
 		self.planned_operating_cost, self.actual_operating_cost = 0.0, 0.0
 		for d in self.get("operations"):
+			if not d.hour_rate:
+				if d.workstation:
+					d.hour_rate = get_hour_rate(d.workstation)
+
 			d.planned_operating_cost = flt(
 				flt(d.hour_rate) * (flt(d.time_in_mins) / 60.0), d.precision("planned_operating_cost")
 			)
@@ -1895,3 +1899,8 @@ def make_stock_return_entry(work_order):
 	stock_entry.set_stock_entry_type()
 
 	return stock_entry
+
+
+@frappe.request_cache
+def get_hour_rate(workstation):
+	return frappe.get_cached_value("Workstation", workstation, "hour_rate") or 0.0


### PR DESCRIPTION
Issue: Fetch the hour_rate from the linked workstation when the operation hour_rate is missing during the operating cost calculation.

Ref : [#63090](https://support.frappe.io/helpdesk/tickets/63090)

Backport Needed for V15 branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Work Order operating cost calculations now automatically retrieve hour rates from workstation configurations when not explicitly set at the operation level, ensuring accurate cost computation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/frappe/erpnext/pull/54820)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->