### PR TITLE
refactor(test): speed up payment reconciliation tests

### DIFF
--- a/erpnext/accounts/doctype/payment_reconciliation/test_payment_reconciliation.py
+++ b/erpnext/accounts/doctype/payment_reconciliation/test_payment_reconciliation.py
@@ -21,122 +21,23 @@ from erpnext.tests.utils import ERPNextTestSuite
 
 class TestPaymentReconciliation(ERPNextTestSuite):
 	def setUp(self):
-		self.create_company()
-		self.create_item()
-		self.create_customer()
-		self.create_account()
-		self.create_cost_center()
-		self.clear_old_entries()
-
-	def create_company(self):
-		company = None
-		if frappe.db.exists("Company", "_Test Payment Reconciliation"):
-			company = frappe.get_doc("Company", "_Test Payment Reconciliation")
-		else:
-			company = frappe.get_doc(
-				{
-					"doctype": "Company",
-					"company_name": "_Test Payment Reconciliation",
-					"country": "India",
-					"default_currency": "INR",
-					"create_chart_of_accounts_based_on": "Standard Template",
-					"chart_of_accounts": "Standard",
-				}
-			)
-			company = company.save()
-
-		self.company = company.name
-		self.cost_center = company.cost_center
-		self.warehouse = "All Warehouses - _PR"
-		self.income_account = "Sales - _PR"
-		self.expense_account = "Cost of Goods Sold - _PR"
-		self.debit_to = "Debtors - _PR"
-		self.creditors = "Creditors - _PR"
-		self.cash = "Cash - _PR"
-
-		# create bank account
-		if frappe.db.exists("Account", "HDFC - _PR"):
-			self.bank = "HDFC - _PR"
-		else:
-			bank_acc = frappe.get_doc(
-				{
-					"doctype": "Account",
-					"account_name": "HDFC",
-					"parent_account": "Bank Accounts - _PR",
-					"company": self.company,
-				}
-			)
-			bank_acc.save()
-			self.bank = bank_acc.name
-
-	def create_item(self):
-		item = create_item(
-			item_code="_Test PR Item", is_stock_item=0, company=self.company, warehouse=self.warehouse
-		)
-		self.item = item if isinstance(item, str) else item.item_code
-
-	def create_customer(self):
-		self.customer = make_customer("_Test PR Customer")
-		self.customer2 = make_customer("_Test PR Customer 2")
-		self.customer3 = make_customer("_Test PR Customer 3", "EUR")
-		self.customer4 = make_customer("_Test PR Customer 4", "EUR")
-		self.customer5 = make_customer("_Test PR Customer 5", "EUR")
-
-	def create_account(self):
-		accounts = [
-			{
-				"attribute": "debtors_eur",
-				"account_name": "Debtors EUR",
-				"parent_account": "Accounts Receivable - _PR",
-				"account_currency": "EUR",
-				"account_type": "Receivable",
-			},
-			{
-				"attribute": "creditors_usd",
-				"account_name": "Payable USD",
-				"parent_account": "Accounts Payable - _PR",
-				"account_currency": "USD",
-				"account_type": "Payable",
-			},
-			# 'Payable' account for capturing advance paid, under 'Assets' group
-			{
-				"attribute": "advance_payable_account",
-				"account_name": "Advance Paid",
-				"parent_account": "Current Assets - _PR",
-				"account_currency": "INR",
-				"account_type": "Payable",
-			},
-			# 'Receivable' account for capturing advance received, under 'Liabilities' group
-			{
-				"attribute": "advance_receivable_account",
-				"account_name": "Advance Received",
-				"parent_account": "Current Liabilities - _PR",
-				"account_currency": "INR",
-				"account_type": "Receivable",
-			},
-		]
-
-		for x in accounts:
-			x = frappe._dict(x)
-			if not frappe.db.get_value(
-				"Account", filters={"account_name": x.account_name, "company": self.company}
-			):
-				acc = frappe.new_doc("Account")
-				acc.account_name = x.account_name
-				acc.parent_account = x.parent_account
-				acc.company = self.company
-				acc.account_currency = x.account_currency
-				acc.account_type = x.account_type
-				acc.insert()
-			else:
-				name = frappe.db.get_value(
-					"Account",
-					filters={"account_name": x.account_name, "company": self.company},
-					fieldname="name",
-					pluck=True,
-				)
-				acc = frappe.get_doc("Account", name)
-			setattr(self, x.attribute, acc.name)
+		self.company = "_Test Company"
+		self.debit_to = "Debtors - _TC"
+		self.creditors = "Creditors - _TC"
+		self.bank = "HDFC - _TC"
+		self.cash = "Cash - _TC"
+		self.item = "_Test Item"
+		self.cost_center = self.main_cc = "Main - _TC"
+		self.sub_cc = "Sub - _TC"
+		self.customer = "_Test Customer"
+		self.advance_receivable_account = "Advance Received - _TC"
+		self.advance_payable_account = "Advance Paid - _TC"
+		self.income_account = "Sales - _TC"
+		self.expense_account = "Cost of Goods Sold - _TC"
+		self.warehouse = "All Warehouses - _TC"
+		self.customer_usd = "_Test Customer USD"
+		self.debtors_usd = "_Test Receivable USD - _TC"
+		self.creditors_usd = "_Test Payable USD - _TC"
 
 	def create_sales_invoice(
 		self, qty=1, rate=100, posting_date=None, do_not_save=False, do_not_submit=False
@@ -253,18 +154,6 @@ class TestPaymentReconciliation(ERPNextTestSuite):
 		)
 		return pord
 
-	def clear_old_entries(self):
-		doctype_list = [
-			"GL Entry",
-			"Payment Ledger Entry",
-			"Sales Invoice",
-			"Purchase Invoice",
-			"Payment Entry",
-			"Journal Entry",
-		]
-		for doctype in doctype_list:
-			qb.from_(qb.DocType(doctype)).delete().where(qb.DocType(doctype).company == self.company).run()
-
 	def create_payment_reconciliation(self, party_is_customer=True):
 		pr = frappe.new_doc("Payment Reconciliation")
 		pr.company = self.company
@@ -299,22 +188,6 @@ class TestPaymentReconciliation(ERPNextTestSuite):
 			],
 		)
 		return je
-
-	def create_cost_center(self):
-		# Setup cost center
-		cc_name = "Sub"
-
-		self.main_cc = frappe.get_doc("Cost Center", get_default_cost_center(self.company))
-
-		cc_exists = frappe.db.get_list("Cost Center", filters={"cost_center_name": cc_name})
-		if cc_exists:
-			self.sub_cc = frappe.get_doc("Cost Center", cc_exists[0].name)
-		else:
-			sub_cc = frappe.new_doc("Cost Center")
-			sub_cc.cost_center_name = "Sub"
-			sub_cc.parent_cost_center = self.main_cc.parent_cost_center
-			sub_cc.company = self.main_cc.company
-			self.sub_cc = sub_cc.save()
 
 	def test_filter_min_max(self):
 		# check filter condition minimum and maximum amount
@@ -478,7 +351,7 @@ class TestPaymentReconciliation(ERPNextTestSuite):
 	def test_payment_against_journal(self):
 		transaction_date = nowdate()
 
-		sales = "Sales - _PR"
+		sales = "Sales - _TC"
 		amount = 921
 		# debit debtors account to record an invoice
 		je = self.create_journal_entry(self.debit_to, sales, amount, transaction_date)
@@ -513,7 +386,7 @@ class TestPaymentReconciliation(ERPNextTestSuite):
 		transaction_date = nowdate()
 
 		self.supplier = "_Test Supplier USD"
-		self.supplier2 = make_supplier("_Test Supplier2 USD", "USD")
+		self.supplier2 = "_Test Another Supplier USD"
 		amount = 100
 		exc_rate1 = 80
 		exc_rate2 = 83
@@ -666,7 +539,7 @@ class TestPaymentReconciliation(ERPNextTestSuite):
 
 	def test_journal_against_journal(self):
 		transaction_date = nowdate()
-		sales = "Sales - _PR"
+		sales = "Sales - _TC"
 		amount = 100
 
 		# debit debtors account to simulate a invoice
@@ -841,47 +714,49 @@ class TestPaymentReconciliation(ERPNextTestSuite):
 	def test_pr_output_foreign_currency_and_amount(self):
 		# test for currency and amount invoices and payments
 		transaction_date = nowdate()
-		# In EUR
+		# In USD
 		amount = 100
 		exchange_rate = 80
 
 		si = self.create_sales_invoice(
 			qty=1, rate=amount, posting_date=transaction_date, do_not_save=True, do_not_submit=True
 		)
-		si.customer = self.customer3
-		si.currency = "EUR"
+		si.customer = self.customer_usd
+		si.currency = "USD"
 		si.conversion_rate = exchange_rate
-		si.debit_to = self.debtors_eur
+		si.debit_to = self.debtors_usd
 		si = si.save().submit()
 
 		cr_note = self.create_sales_invoice(
 			qty=-1, rate=amount, posting_date=transaction_date, do_not_save=True, do_not_submit=True
 		)
-		cr_note.customer = self.customer3
+		cr_note.customer = self.customer_usd
 		cr_note.is_return = 1
-		cr_note.currency = "EUR"
+		cr_note.currency = "USD"
 		cr_note.conversion_rate = exchange_rate
-		cr_note.debit_to = self.debtors_eur
+		cr_note.debit_to = self.debtors_usd
 		cr_note = cr_note.save().submit()
 
 		pr = self.create_payment_reconciliation()
-		pr.party = self.customer3
-		pr.receivable_payable_account = self.debtors_eur
+		pr.party = self.customer_usd
+		pr.receivable_payable_account = self.debtors_usd
 		pr.get_unreconciled_entries()
 
 		self.assertEqual(len(pr.invoices), 1)
 		self.assertEqual(len(pr.payments), 1)
 
 		self.assertEqual(pr.invoices[0].amount, amount)
-		self.assertEqual(pr.invoices[0].currency, "EUR")
+		self.assertEqual(pr.invoices[0].currency, "USD")
 		self.assertEqual(pr.payments[0].amount, amount)
-		self.assertEqual(pr.payments[0].currency, "EUR")
+		self.assertEqual(pr.payments[0].currency, "USD")
 
 		cr_note.cancel()
 
-		pay = self.create_payment_entry(amount=amount, posting_date=transaction_date, customer=self.customer3)
-		pay.paid_from = self.debtors_eur
-		pay.paid_from_account_currency = "EUR"
+		pay = self.create_payment_entry(
+			amount=amount, posting_date=transaction_date, customer=self.customer_usd
+		)
+		pay.paid_from = self.debtors_usd
+		pay.paid_from_account_currency = "USD"
 		pay.source_exchange_rate = exchange_rate
 		pay.received_amount = exchange_rate * amount
 		pay = pay.save().submit()
@@ -890,21 +765,21 @@ class TestPaymentReconciliation(ERPNextTestSuite):
 		self.assertEqual(len(pr.invoices), 1)
 		self.assertEqual(len(pr.payments), 1)
 		self.assertEqual(pr.payments[0].amount, amount)
-		self.assertEqual(pr.payments[0].currency, "EUR")
+		self.assertEqual(pr.payments[0].currency, "USD")
 
 	def test_difference_amount_via_journal_entry(self):
 		# Make Sale Invoice
 		si = self.create_sales_invoice(
 			qty=1, rate=100, posting_date=nowdate(), do_not_save=True, do_not_submit=True
 		)
-		si.customer = self.customer4
-		si.currency = "EUR"
+		si.customer = self.customer_usd
+		si.currency = "USD"
 		si.conversion_rate = 85
-		si.debit_to = self.debtors_eur
+		si.debit_to = self.debtors_usd
 		si.save().submit()
 
 		# Make payment using Journal Entry
-		je1 = self.create_journal_entry("HDFC - _PR", self.debtors_eur, 100, nowdate())
+		je1 = self.create_journal_entry("HDFC - _TC", self.debtors_usd, 100, nowdate())
 		je1.multi_currency = 1
 		je1.accounts[0].exchange_rate = 1
 		je1.accounts[0].credit_in_account_currency = 0
@@ -912,7 +787,7 @@ class TestPaymentReconciliation(ERPNextTestSuite):
 		je1.accounts[0].debit_in_account_currency = 8000
 		je1.accounts[0].debit = 8000
 		je1.accounts[1].party_type = "Customer"
-		je1.accounts[1].party = self.customer4
+		je1.accounts[1].party = self.customer_usd
 		je1.accounts[1].exchange_rate = 80
 		je1.accounts[1].credit_in_account_currency = 100
 		je1.accounts[1].credit = 8000
@@ -921,7 +796,7 @@ class TestPaymentReconciliation(ERPNextTestSuite):
 		je1.save()
 		je1.submit()
 
-		je2 = self.create_journal_entry("HDFC - _PR", self.debtors_eur, 200, nowdate())
+		je2 = self.create_journal_entry("HDFC - _TC", self.debtors_usd, 200, nowdate())
 		je2.multi_currency = 1
 		je2.accounts[0].exchange_rate = 1
 		je2.accounts[0].credit_in_account_currency = 0
@@ -929,7 +804,7 @@ class TestPaymentReconciliation(ERPNextTestSuite):
 		je2.accounts[0].debit_in_account_currency = 16000
 		je2.accounts[0].debit = 16000
 		je2.accounts[1].party_type = "Customer"
-		je2.accounts[1].party = self.customer4
+		je2.accounts[1].party = self.customer_usd
 		je2.accounts[1].exchange_rate = 80
 		je2.accounts[1].credit_in_account_currency = 200
 		je1.accounts[1].credit = 16000
@@ -939,8 +814,8 @@ class TestPaymentReconciliation(ERPNextTestSuite):
 		je2.submit()
 
 		pr = self.create_payment_reconciliation()
-		pr.party = self.customer4
-		pr.receivable_payable_account = self.debtors_eur
+		pr.party = self.customer_usd
+		pr.receivable_payable_account = self.debtors_usd
 		pr.get_unreconciled_entries()
 
 		self.assertEqual(len(pr.invoices), 1)
@@ -960,7 +835,7 @@ class TestPaymentReconciliation(ERPNextTestSuite):
 		invoices = [x.as_dict() for x in pr.invoices]
 		payments = [pr.payments[1].as_dict()]
 		pr.allocate_entries(frappe._dict({"invoices": invoices, "payments": payments}))
-		pr.allocation[0].difference_account = "Exchange Gain/Loss - _PR"
+		pr.allocation[0].difference_account = "Exchange Gain/Loss - _TC"
 
 		self.assertEqual(pr.allocation[0].allocated_amount, 100)
 		self.assertEqual(pr.allocation[0].difference_amount, -500)
@@ -969,7 +844,7 @@ class TestPaymentReconciliation(ERPNextTestSuite):
 		pr.reconcile()
 		total_credit_amount = frappe.db.get_all(
 			"Journal Entry Account",
-			{"account": self.debtors_eur, "docstatus": 1, "reference_name": si.name},
+			{"account": self.debtors_usd, "docstatus": 1, "reference_name": si.name},
 			[{"SUM": "credit", "as": "amount"}],
 			group_by="reference_name",
 		)[0].amount
@@ -979,7 +854,7 @@ class TestPaymentReconciliation(ERPNextTestSuite):
 
 		jea_parent = frappe.db.get_all(
 			"Journal Entry Account",
-			filters={"account": self.debtors_eur, "docstatus": 1, "reference_name": si.name, "credit": 500},
+			filters={"account": self.debtors_usd, "docstatus": 1, "reference_name": si.name, "credit": 500},
 			fields=["parent"],
 		)[0]
 		self.assertEqual(
@@ -991,14 +866,14 @@ class TestPaymentReconciliation(ERPNextTestSuite):
 		si = self.create_sales_invoice(
 			qty=1, rate=100, posting_date=nowdate(), do_not_save=True, do_not_submit=True
 		)
-		si.customer = self.customer4
-		si.currency = "EUR"
+		si.customer = self.customer_usd
+		si.currency = "USD"
 		si.conversion_rate = 85
-		si.debit_to = self.debtors_eur
+		si.debit_to = self.debtors_usd
 		si.save().submit()
 
 		# Make payment using Journal Entry
-		je1 = self.create_journal_entry("HDFC - _PR", self.debtors_eur, 100, nowdate())
+		je1 = self.create_journal_entry("HDFC - _TC", self.debtors_usd, 100, nowdate())
 		je1.multi_currency = 1
 		je1.accounts[0].exchange_rate = 1
 		je1.accounts[0].credit_in_account_currency = -8000
@@ -1006,7 +881,7 @@ class TestPaymentReconciliation(ERPNextTestSuite):
 		je1.accounts[0].debit_in_account_currency = 0
 		je1.accounts[0].debit = 0
 		je1.accounts[1].party_type = "Customer"
-		je1.accounts[1].party = self.customer4
+		je1.accounts[1].party = self.customer_usd
 		je1.accounts[1].exchange_rate = 80
 		je1.accounts[1].credit_in_account_currency = 100
 		je1.accounts[1].credit = 8000
@@ -1015,7 +890,7 @@ class TestPaymentReconciliation(ERPNextTestSuite):
 		je1.save()
 		je1.submit()
 
-		je2 = self.create_journal_entry("HDFC - _PR", self.debtors_eur, 200, nowdate())
+		je2 = self.create_journal_entry("HDFC - _TC", self.debtors_usd, 200, nowdate())
 		je2.multi_currency = 1
 		je2.accounts[0].exchange_rate = 1
 		je2.accounts[0].credit_in_account_currency = -16000
@@ -1023,7 +898,7 @@ class TestPaymentReconciliation(ERPNextTestSuite):
 		je2.accounts[0].debit_in_account_currency = 0
 		je2.accounts[0].debit = 0
 		je2.accounts[1].party_type = "Customer"
-		je2.accounts[1].party = self.customer4
+		je2.accounts[1].party = self.customer_usd
 		je2.accounts[1].exchange_rate = 80
 		je2.accounts[1].credit_in_account_currency = 200
 		je1.accounts[1].credit = 16000
@@ -1033,8 +908,8 @@ class TestPaymentReconciliation(ERPNextTestSuite):
 		je2.submit()
 
 		pr = self.create_payment_reconciliation()
-		pr.party = self.customer4
-		pr.receivable_payable_account = self.debtors_eur
+		pr.party = self.customer_usd
+		pr.receivable_payable_account = self.debtors_usd
 		pr.get_unreconciled_entries()
 
 		self.assertEqual(len(pr.invoices), 1)
@@ -1054,7 +929,7 @@ class TestPaymentReconciliation(ERPNextTestSuite):
 		invoices = [x.as_dict() for x in pr.invoices]
 		payments = [pr.payments[1].as_dict()]
 		pr.allocate_entries(frappe._dict({"invoices": invoices, "payments": payments}))
-		pr.allocation[0].difference_account = "Exchange Gain/Loss - _PR"
+		pr.allocation[0].difference_account = "Exchange Gain/Loss - _TC"
 
 		self.assertEqual(pr.allocation[0].allocated_amount, 100)
 		self.assertEqual(pr.allocation[0].difference_amount, -500)
@@ -1063,7 +938,7 @@ class TestPaymentReconciliation(ERPNextTestSuite):
 		pr.reconcile()
 		total_credit_amount = frappe.db.get_all(
 			"Journal Entry Account",
-			{"account": self.debtors_eur, "docstatus": 1, "reference_name": si.name},
+			{"account": self.debtors_usd, "docstatus": 1, "reference_name": si.name},
 			[{"SUM": "credit", "as": "amount"}],
 			group_by="reference_name",
 		)[0].amount
@@ -1073,7 +948,7 @@ class TestPaymentReconciliation(ERPNextTestSuite):
 
 		jea_parent = frappe.db.get_all(
 			"Journal Entry Account",
-			filters={"account": self.debtors_eur, "docstatus": 1, "reference_name": si.name, "credit": 500},
+			filters={"account": self.debtors_usd, "docstatus": 1, "reference_name": si.name, "credit": 500},
 			fields=["parent"],
 		)[0]
 		self.assertEqual(
@@ -1085,10 +960,10 @@ class TestPaymentReconciliation(ERPNextTestSuite):
 		si = self.create_sales_invoice(
 			qty=1, rate=100, posting_date=nowdate(), do_not_save=True, do_not_submit=True
 		)
-		si.customer = self.customer5
-		si.currency = "EUR"
+		si.customer = self.customer_usd
+		si.currency = "USD"
 		si.conversion_rate = 85
-		si.debit_to = self.debtors_eur
+		si.debit_to = self.debtors_usd
 		si.save().submit()
 
 		# Make payment using Payment Entry
@@ -1096,8 +971,8 @@ class TestPaymentReconciliation(ERPNextTestSuite):
 			company=self.company,
 			payment_type="Receive",
 			party_type="Customer",
-			party=self.customer5,
-			paid_from=self.debtors_eur,
+			party=self.customer_usd,
+			paid_from=self.debtors_usd,
 			paid_to=self.bank,
 			paid_amount=100,
 		)
@@ -1111,8 +986,8 @@ class TestPaymentReconciliation(ERPNextTestSuite):
 			company=self.company,
 			payment_type="Receive",
 			party_type="Customer",
-			party=self.customer5,
-			paid_from=self.debtors_eur,
+			party=self.customer_usd,
+			paid_from=self.debtors_usd,
 			paid_to=self.bank,
 			paid_amount=200,
 		)
@@ -1123,8 +998,8 @@ class TestPaymentReconciliation(ERPNextTestSuite):
 		pe2.submit()
 
 		pr = self.create_payment_reconciliation()
-		pr.party = self.customer5
-		pr.receivable_payable_account = self.debtors_eur
+		pr.party = self.customer_usd
+		pr.receivable_payable_account = self.debtors_usd
 		pr.get_unreconciled_entries()
 
 		self.assertEqual(len(pr.invoices), 1)
@@ -1152,14 +1027,14 @@ class TestPaymentReconciliation(ERPNextTestSuite):
 		"""
 
 		si = self.create_sales_invoice(qty=1, rate=100, do_not_submit=True)
-		si.cost_center = self.main_cc.name
+		si.cost_center = self.main_cc
 		si.submit()
 		pr = get_payment_entry(si.doctype, si.name)
-		pr.cost_center = self.sub_cc.name
+		pr.cost_center = self.sub_cc
 		pr = pr.save().submit()
 
 		pr = self.create_payment_reconciliation()
-		pr.cost_center = self.main_cc.name
+		pr.cost_center = self.main_cc
 
 		pr.get_unreconciled_entries()
 
@@ -1176,38 +1051,38 @@ class TestPaymentReconciliation(ERPNextTestSuite):
 
 		# 'Main - PR' Cost Center
 		si1 = self.create_sales_invoice(qty=1, rate=rate, posting_date=transaction_date, do_not_submit=True)
-		si1.cost_center = self.main_cc.name
+		si1.cost_center = self.main_cc
 		si1.submit()
 
 		pe1 = self.create_payment_entry(posting_date=transaction_date, amount=rate)
-		pe1.cost_center = self.main_cc.name
+		pe1.cost_center = self.main_cc
 		pe1 = pe1.save().submit()
 
 		je1 = self.create_journal_entry(self.bank, self.debit_to, 100, transaction_date)
-		je1.accounts[0].cost_center = self.main_cc.name
-		je1.accounts[1].cost_center = self.main_cc.name
+		je1.accounts[0].cost_center = self.main_cc
+		je1.accounts[1].cost_center = self.main_cc
 		je1.accounts[1].party_type = "Customer"
 		je1.accounts[1].party = self.customer
 		je1 = je1.save().submit()
 
 		# 'Sub - PR' Cost Center
 		si2 = self.create_sales_invoice(qty=1, rate=rate, posting_date=transaction_date, do_not_submit=True)
-		si2.cost_center = self.sub_cc.name
+		si2.cost_center = self.sub_cc
 		si2.submit()
 
 		pe2 = self.create_payment_entry(posting_date=transaction_date, amount=rate)
-		pe2.cost_center = self.sub_cc.name
+		pe2.cost_center = self.sub_cc
 		pe2 = pe2.save().submit()
 
 		je2 = self.create_journal_entry(self.bank, self.debit_to, 100, transaction_date)
-		je2.accounts[0].cost_center = self.sub_cc.name
-		je2.accounts[1].cost_center = self.sub_cc.name
+		je2.accounts[0].cost_center = self.sub_cc
+		je2.accounts[1].cost_center = self.sub_cc
 		je2.accounts[1].party_type = "Customer"
 		je2.accounts[1].party = self.customer
 		je2 = je2.save().submit()
 
 		pr = self.create_payment_reconciliation()
-		pr.cost_center = self.main_cc.name
+		pr.cost_center = self.main_cc
 
 		pr.get_unreconciled_entries()
 
@@ -1219,7 +1094,7 @@ class TestPaymentReconciliation(ERPNextTestSuite):
 		self.assertCountEqual(payment_vouchers, [pe1.name, je1.name])
 
 		# Change cost center
-		pr.cost_center = self.sub_cc.name
+		pr.cost_center = self.sub_cc
 
 		pr.get_unreconciled_entries()
 
@@ -1242,7 +1117,7 @@ class TestPaymentReconciliation(ERPNextTestSuite):
 			qty=1, rate=1, posting_date=nowdate(), do_not_save=True, do_not_submit=True
 		)
 		si.customer = self.customer
-		si.currency = "EUR"
+		si.currency = "USD"
 		si.conversion_rate = 85
 		si.debit_to = self.debit_to
 		si.save().submit()
@@ -1624,7 +1499,7 @@ class TestPaymentReconciliation(ERPNextTestSuite):
 				"credit": 0.0,
 			},
 			{
-				"account": "Cash - _PR",
+				"account": "Cash - _TC",
 				"voucher_no": pe.name,
 				"against_voucher": None,
 				"debit": 0.0,
@@ -1782,10 +1657,10 @@ class TestPaymentReconciliation(ERPNextTestSuite):
 		)
 		amount = 200.0
 		je = self.create_journal_entry(self.debit_to, self.bank, amount)
-		je.accounts[0].cost_center = self.main_cc.name
+		je.accounts[0].cost_center = self.main_cc
 		je.accounts[0].party_type = "Customer"
 		je.accounts[0].party = self.customer
-		je.accounts[1].cost_center = self.main_cc.name
+		je.accounts[1].cost_center = self.main_cc
 		je = je.save().submit()
 
 		pe = self.create_payment_entry(amount=amount).save().submit()
@@ -1879,7 +1754,7 @@ class TestPaymentReconciliation(ERPNextTestSuite):
 		self.assertEqual(pl_entries, expected_ple)
 
 	def test_advance_payment_reconciliation_against_journal_for_supplier(self):
-		self.supplier = make_supplier("_Test Supplier")
+		self.supplier = "_Test Supplier"
 		frappe.db.set_value(
 			"Company",
 			self.company,
@@ -1891,10 +1766,10 @@ class TestPaymentReconciliation(ERPNextTestSuite):
 		)
 		amount = 200.0
 		je = self.create_journal_entry(self.creditors, self.bank, -amount)
-		je.accounts[0].cost_center = self.main_cc.name
+		je.accounts[0].cost_center = self.main_cc
 		je.accounts[0].party_type = "Supplier"
 		je.accounts[0].party = self.supplier
-		je.accounts[1].cost_center = self.main_cc.name
+		je.accounts[1].cost_center = self.main_cc
 		je = je.save().submit()
 
 		pe = self.create_payment_entry(amount=amount)
@@ -2062,13 +1937,13 @@ class TestPaymentReconciliation(ERPNextTestSuite):
 				},
 				{
 					"account": self.bank,
-					"cost_center": self.sub_cc.name,
+					"cost_center": self.sub_cc,
 					"credit_in_account_currency": 0,
 					"debit_in_account_currency": 500,
 				},
 				{
 					"account": self.cash,
-					"cost_center": self.sub_cc.name,
+					"cost_center": self.sub_cc,
 					"credit_in_account_currency": 0,
 					"debit_in_account_currency": 500,
 				},
@@ -2337,7 +2212,7 @@ class TestPaymentReconciliation(ERPNextTestSuite):
 
 	def test_foreign_currency_reverse_payment_entry_against_payment_entry_for_customer(self):
 		transaction_date = nowdate()
-		customer = self.customer3
+		customer = self.customer_usd
 		amount = 1000
 		exchange_rate_at_payment = 100
 		exchange_rate_at_reverse_payment = 95
@@ -2345,8 +2220,8 @@ class TestPaymentReconciliation(ERPNextTestSuite):
 		# Receive amount from customer - 1,00,000
 		pe = self.create_payment_entry(amount=amount, posting_date=transaction_date, customer=customer)
 		pe.payment_type = "Receive"
-		pe.paid_from = self.debtors_eur
-		pe.paid_from_account_currency = "EUR"
+		pe.paid_from = self.debtors_usd
+		pe.paid_from_account_currency = "USD"
 		pe.source_exchange_rate = exchange_rate_at_payment
 		pe.paid_amount = amount
 		pe.received_amount = exchange_rate_at_payment * amount
@@ -2364,14 +2239,14 @@ class TestPaymentReconciliation(ERPNextTestSuite):
 		reverse_pe.target_exchange_rate = exchange_rate_at_reverse_payment
 		reverse_pe.paid_amount = exchange_rate_at_reverse_payment * amount
 		reverse_pe.received_amount = amount
-		reverse_pe.paid_to = self.debtors_eur
-		reverse_pe.paid_to_account_currency = "EUR"
+		reverse_pe.paid_to = self.debtors_usd
+		reverse_pe.paid_to_account_currency = "USD"
 		reverse_pe.save().submit()
 
 		# Reconcile payments
 		pr = self.create_payment_reconciliation()
 		pr.party = customer
-		pr.receivable_payable_account = self.debtors_eur
+		pr.receivable_payable_account = self.debtors_usd
 		pr.get_unreconciled_entries()
 		invoices = [invoice.as_dict() for invoice in pr.invoices]
 		payments = [payment.as_dict() for payment in pr.payments]
@@ -2436,13 +2311,13 @@ class TestPaymentReconciliation(ERPNextTestSuite):
 
 	def test_foreign_currency_reverse_journal_entry_against_journal_entry_for_customer(self):
 		transaction_date = nowdate()
-		customer = self.customer3
+		customer = self.customer_usd
 		amount = 1000
 		exchange_rate_at_payment = 95
 		exchange_rate_at_reverse_payment = 100
 
 		# Receive amount from customer - 95,000
-		je1 = self.create_journal_entry(self.cash, self.debtors_eur, amount, transaction_date)
+		je1 = self.create_journal_entry(self.cash, self.debtors_usd, amount, transaction_date)
 		je1.multi_currency = 1
 		je1.accounts[0].exchange_rate = 1
 		je1.accounts[0].debit_in_account_currency = exchange_rate_at_payment * amount
@@ -2456,7 +2331,7 @@ class TestPaymentReconciliation(ERPNextTestSuite):
 		je1.submit()
 
 		# Pay amount to customer - 1,00,000
-		je2 = self.create_journal_entry(self.debtors_eur, self.cash, amount, transaction_date)
+		je2 = self.create_journal_entry(self.debtors_usd, self.cash, amount, transaction_date)
 		je2.multi_currency = 1
 		je2.accounts[0].party_type = "Customer"
 		je2.accounts[0].party = customer
@@ -2472,7 +2347,7 @@ class TestPaymentReconciliation(ERPNextTestSuite):
 		# Reconcile payments
 		pr = self.create_payment_reconciliation()
 		pr.party = customer
-		pr.receivable_payable_account = self.debtors_eur
+		pr.receivable_payable_account = self.debtors_usd
 		pr.get_unreconciled_entries()
 
 		self.assertEqual(len(pr.invoices), 1)
@@ -2538,34 +2413,6 @@ class TestPaymentReconciliation(ERPNextTestSuite):
 		# Check the difference_amount is a gain of 5000
 		self.assertEqual(flt(pr.allocation[0].difference_amount), 5000.0)
 		pr.reconcile()
-
-
-def make_customer(customer_name, currency=None):
-	if not frappe.db.exists("Customer", customer_name):
-		customer = frappe.new_doc("Customer")
-		customer.customer_name = customer_name
-		customer.type = "Individual"
-
-		if currency:
-			customer.default_currency = currency
-		customer.save()
-		return customer.name
-	else:
-		return customer_name
-
-
-def make_supplier(supplier_name, currency=None):
-	if not frappe.db.exists("Supplier", supplier_name):
-		supplier = frappe.new_doc("Supplier")
-		supplier.supplier_name = supplier_name
-		supplier.type = "Individual"
-
-		if currency:
-			supplier.default_currency = currency
-		supplier.save()
-		return supplier.name
-	else:
-		return supplier_name
 
 
 def create_fiscal_year(company, year_start_date, year_end_date):

--- a/erpnext/tests/utils.py
+++ b/erpnext/tests/utils.py
@@ -902,6 +902,13 @@ class BootStrapTestData:
 			},
 			{
 				"doctype": "Supplier",
+				"supplier_name": "_Test Another Supplier USD",
+				"supplier_group": "_Test Supplier Group",
+				"default_currency": "USD",
+				"accounts": [{"company": "_Test Company", "account": "_Test Payable USD - _TC"}],
+			},
+			{
+				"doctype": "Supplier",
 				"supplier_name": "_Test Supplier With Tax Category",
 				"supplier_group": "_Test Supplier Group",
 				"tax_category": "_Test Tax Category 1",
@@ -947,6 +954,13 @@ class BootStrapTestData:
 			{
 				"company": "_Test Company",
 				"cost_center_name": "_Test Write Off Cost Center",
+				"doctype": "Cost Center",
+				"is_group": 0,
+				"parent_cost_center": "_Test Company - _TC",
+			},
+			{
+				"company": "_Test Company",
+				"cost_center_name": "Sub",
 				"doctype": "Cost Center",
 				"is_group": 0,
 				"parent_cost_center": "_Test Company - _TC",


### PR DESCRIPTION
[`setUp`](https://github.com/frappe/erpnext/blob/23e9ad3fd9426cfd1f9971b9171473926b2e52ee/erpnext/accounts/doctype/payment_reconciliation/test_payment_reconciliation.py#L23-L29) stage in Payment Reconciliation was heavy, leading to 5+ seconds runtime on each test case.
<img width="2010" height="1398" alt="Screenshot 2026-05-11 at 12 11 33 PM" src="https://github.com/user-attachments/assets/31a13c5d-b535-45e6-8d09-b4707253371d" />


### After
<img width="2010" height="1398" alt="Screenshot 2026-05-11 at 2 08 19 PM" src="https://github.com/user-attachments/assets/7b820ae5-edee-4c25-bbbd-91e38a92e540" />
