### PR TITLE
fix: add company filter to Budget Against dimension options

### DIFF
--- a/erpnext/accounts/report/budget_variance_report/budget_variance_report.js
+++ b/erpnext/accounts/report/budget_variance_report/budget_variance_report.js
@@ -39,6 +39,14 @@ function get_filters() {
 
 	let filters = [
 		{
+			fieldname: "company",
+			label: __("Company"),
+			fieldtype: "Link",
+			options: "Company",
+			default: frappe.defaults.get_user_default("Company"),
+			reqd: 1,
+		},
+		{
 			fieldname: "from_fiscal_year",
 			label: __("From Fiscal Year"),
 			fieldtype: "Link",
@@ -68,14 +76,6 @@ function get_filters() {
 			reqd: 1,
 		},
 		{
-			fieldname: "company",
-			label: __("Company"),
-			fieldtype: "Link",
-			options: "Company",
-			default: frappe.defaults.get_user_default("Company"),
-			reqd: 1,
-		},
-		{
 			fieldname: "budget_against",
 			label: __("Budget Against"),
 			fieldtype: "Select",
@@ -98,7 +98,7 @@ function get_filters() {
 				let budget_against = frappe.query_report.get_filter_value("budget_against");
 				let company = frappe.query_report.get_filter_value("company");
 				if (!budget_against) return;
-				// Branch does not have company field
+
 				const filters = budget_against !== "Branch" && company ? { company: company } : {};
 
 				return frappe.db.get_link_options(budget_against, txt, filters);

--- a/erpnext/accounts/report/budget_variance_report/budget_variance_report.js
+++ b/erpnext/accounts/report/budget_variance_report/budget_variance_report.js
@@ -96,9 +96,12 @@ function get_filters() {
 				if (!frappe.query_report.filters) return;
 
 				let budget_against = frappe.query_report.get_filter_value("budget_against");
+				let company = frappe.query_report.get_filter_value("company");
 				if (!budget_against) return;
+				// Branch does not have company field
+				const filters = budget_against !== "Branch" && company ? { company: company } : {};
 
-				return frappe.db.get_link_options(budget_against, txt);
+				return frappe.db.get_link_options(budget_against, txt, filters);
 			},
 		},
 		{


### PR DESCRIPTION
## Summary

* Added company-based filtering for `budget_against_filter` options in Budget Variance Report.
* When budget dimension is not `Branch` and company is selected, link options are fetched with `{ company }`.
* Preserved existing fallback behavior for `Branch` and cases where company is not set.

## Why

This improves relevance of dimension suggestions and avoids showing cross-company records while keeping existing behavior intact where company scoping is not applicable.

## Testing

* Open Budget Variance Report.
* Select Company and set Budget Against to non-Branch dimensions (e.g. Cost Center / Project).
* Verify Dimension Filter suggestions are restricted by selected company.
* Set Budget Against to Branch and verify previous behavior remains unchanged.

## Issue Reference

#54487
