### PR TITLE
refactor(supplier): use frappe orm for criteria retrieval

### DIFF
--- a/erpnext/buying/doctype/supplier_scorecard_criteria/supplier_scorecard_criteria.py
+++ b/erpnext/buying/doctype/supplier_scorecard_criteria/supplier_scorecard_criteria.py
@@ -55,17 +55,10 @@ class SupplierScorecardCriteria(Document):
 
 @frappe.whitelist()
 def get_criteria_list():
-	criteria = frappe.db.sql(
-		"""
-		SELECT
-			scs.name
-		FROM
-			`tabSupplier Scorecard Criteria` scs""",
-		{},
-		as_dict=1,
-	)
-
-	return criteria
+	"""
+	Get the list of criteria
+	"""
+	return frappe.get_list("Supplier Scorecard Criteria", fields=["name"])
 
 
 def get_variables(criteria_name):


### PR DESCRIPTION
Replace raw SQL with frappe.get_all in get_criteria_list to leverage the standard Frappe API. This improves code readability and follows framework best practices.
