### PR TITLE
fix(task): update depends_on for closing date and review date #54850

### DIFF
--- a/erpnext/projects/doctype/task/task.json
+++ b/erpnext/projects/doctype/task/task.json
@@ -305,7 +305,7 @@
    "label": "Additional Info"
   },
   {
-   "depends_on": "eval:doc.status == \"Closed\" || doc.status == \"Pending Review\"",
+   "depends_on": "eval:doc.status == \"Completed\" || doc.status == \"Pending Review\"",
    "fieldname": "review_date",
    "fieldtype": "Date",
    "label": "Review Date",
@@ -313,7 +313,7 @@
    "oldfieldtype": "Date"
   },
   {
-   "depends_on": "eval:doc.status == \"Closed\"",
+   "depends_on": "eval:doc.status == \"Completed\"",
    "fieldname": "closing_date",
    "fieldtype": "Date",
    "label": "Closing Date",


### PR DESCRIPTION
## Description
Closes #54850
### Root Cause:
In the `Task` doctype, the `depends_on` logic for the `closing_date` and `review_date` fields incorrectly relied on the task status being set to "Closed". However, "Closed" is not a valid option for the Task `status` field (the correct corresponding status is "Completed"). As a result, these fields were permanently hidden and could not be accessed.
### Changes:
Updated the `depends_on` conditions for both `closing_date` and `review_date` in `task.json` to use the correct status `"Completed"` instead of `"Closed"`. 
This ensures that the "Closing Date" and "Review Date" fields now properly display in the "More Info" section when a task is completed or pending review.