### PR TITLE
fix: correct payment request function call in si and so

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
@@ -140,7 +140,7 @@ erpnext.accounts.SalesInvoiceController = class SalesInvoiceController extends (
 					this.frm.add_custom_button(
 						__("Payment Request"),
 						function () {
-							me.make_payment_request_with_schedule();
+							me.make_payment_request();
 						},
 						__("Create")
 					);

--- a/erpnext/selling/doctype/sales_order/sales_order.js
+++ b/erpnext/selling/doctype/sales_order/sales_order.js
@@ -776,7 +776,7 @@ erpnext.selling.SalesOrderController = class SalesOrderController extends erpnex
 					if (frappe.boot.user.in_create.includes("Payment Request")) {
 						this.frm.add_custom_button(
 							__("Payment Request"),
-							() => this.make_payment_request_with_schedule(),
+							() => this.make_payment_request(),
 							__("Create")
 						);
 					}


### PR DESCRIPTION
**Issue Ref**: [#54780 ](https://github.com/frappe/erpnext/issues/54780)

**Description**: When selecting "Create" -> "Payment Request" from the "Sales Invoice", the browser console throws an error me.make_payment_request_with_schedule is not a function

Searching the code, there is no definition for the javacript function make_payment_request_with_schedule



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Modified the Payment Request button behavior in Sales Invoice and Sales Order documents to streamline payment request creation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/frappe/erpnext/pull/54857)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->