### PR TITLE
fix: add warehouse vaildation for repack entry

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -845,7 +845,7 @@ class StockEntry(StockController, SubcontractingInwardController):
 				else:
 					frappe.throw(_("Target warehouse is mandatory for row {0}").format(d.idx))
 
-			if self.purpose == "Manufacture":
+			if self.purpose in ["Manufacture", "Repack"]:
 				if d.is_finished_item or d.type or d.is_legacy_scrap_item:
 					d.s_warehouse = None
 					if not d.t_warehouse:


### PR DESCRIPTION
Description: Added validation for Repack Stock Entries to enforce correct warehouse assignment by ensuring finished items have a Target Warehouse and raw material items have a Source Warehouse.

Ref : [#67118](https://support.frappe.io/helpdesk/tickets/67118)

Backport Needed For V16 and V15.