### PR TITLE
fix: show remaining in bank account currency on reconciliation dialog

### DIFF
--- a/erpnext/accounts/doctype/bank_reconciliation_tool/bank_reconciliation_tool.py
+++ b/erpnext/accounts/doctype/bank_reconciliation_tool/bank_reconciliation_tool.py
@@ -1355,7 +1355,9 @@ def get_pe_matching_query(
 			(ref_rank + amount_rank + party_rank + 1).as_("rank"),
 			ConstantColumn("Payment Entry").as_("doctype"),
 			pe.name,
-			pe.base_paid_amount_after_tax.as_("paid_amount"),
+			(pe.paid_amount_after_tax if to_from == "from" else pe.received_amount_after_tax).as_(
+				"paid_amount"
+			),
 			pe.reference_no,
 			pe.reference_date,
 			pe.party,


### PR DESCRIPTION
Issue:
When a company has a USD bank account but the company's default  currency is in INR, and a Payment Entry is made (e.g. $100 USD paid, exchange rate 90 = ₹9,000 INR), the Bank Reconciliation dialog shows the Remaining amount as $9,000 instead of $100

Ref: [#67863](https://support.frappe.io/helpdesk/tickets/67863)

Backport needed: v16, v15