### PR TITLE
fix: avoid double counting bundled batch SLE rows

### DIFF
--- a/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py
+++ b/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py
@@ -3326,7 +3326,14 @@ def get_stock_ledgers_batches(kwargs):
 			stock_ledger_entry.batch_no,
 			batch_table.expiry_date,
 		)
-		.where((stock_ledger_entry.is_cancelled == 0) & (stock_ledger_entry.batch_no.isnotnull()))
+		.where(
+			(stock_ledger_entry.is_cancelled == 0)
+			& (stock_ledger_entry.batch_no.isnotnull())
+			& (
+				(stock_ledger_entry.serial_and_batch_bundle.isnull())
+				| (stock_ledger_entry.serial_and_batch_bundle == "")
+			)
+		)
 		.groupby(stock_ledger_entry.batch_no, stock_ledger_entry.warehouse)
 	)
 


### PR DESCRIPTION
## Summary
- Fixes Batch Stock Levels double-counting when Stock Ledger Entry rows have both batch_no and serial_and_batch_bundle populated.
- Updates get_stock_ledgers_batches() to exclude SLE rows already represented through Serial and Batch Bundle data.
- Preserves legacy/direct batch_no SLE rows where no bundle exists.

## Problem
get_auto_batch_nos() combines quantities from:
1. tabSerial and Batch Entry via get_available_batches()
2. tabStock Ledger Entry.batch_no via get_stock_ledgers_batches()

When an SLE row contains both batch_no and serial_and_batch_bundle, the same movement is counted through both paths. This can make Batch Stock Levels incorrect even when Stock Ledger balance is correct.

Example case:
- Batch: SPKI-2602-091-002
- Item: MP203-FTD-BR
- Warehouse: ASO-Assembly - MT
- Correct Stock Ledger qty: 350
- Batch Stock Levels before fix: -494

## Fix
Filter direct SLE batch aggregation to only include rows where serial_and_batch_bundle is null/blank.

## Test Plan
- [x] python -m py_compile apps/erpnext/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py
- [x] git diff --check
- [x] Ran targeted get_batch_qty() call on dev-mkt.wijayacorp.com
- [x] Cleared cache and restarted ERP v16 web/workers on dev

Note: the exact production sample SLE rows are not present in the dev database, so exact numeric reproduction was not possible on dev.
