### PR TITLE
fix: validate company region in uae vat 201

### DIFF
--- a/erpnext/regional/report/uae_vat_201/test_uae_vat_201.py
+++ b/erpnext/regional/report/uae_vat_201/test_uae_vat_201.py
@@ -4,6 +4,7 @@ import erpnext
 from erpnext.accounts.doctype.purchase_invoice.test_purchase_invoice import make_purchase_invoice
 from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_sales_invoice
 from erpnext.regional.report.uae_vat_201.uae_vat_201 import (
+	execute,
 	get_exempt_total,
 	get_standard_rated_expenses_tax,
 	get_standard_rated_expenses_total,
@@ -29,6 +30,13 @@ class TestUaeVat201(ERPNextTestSuite):
 		make_item("_Test UAE VAT Item", properties={"is_zero_rated": 0, "is_exempt": 0})
 		make_item("_Test UAE VAT Zero Rated Item", properties={"is_zero_rated": 1, "is_exempt": 0})
 		make_item("_Test UAE VAT Exempt Item", properties={"is_zero_rated": 0, "is_exempt": 1})
+
+	def test_validate_company_region(self):
+		self.assertRaises(
+			frappe.exceptions.ValidationError,
+			execute,
+			{"company": "_Test Company"},
+		)
 
 	def test_uae_vat_201_report(self):
 		make_sales_invoices()

--- a/erpnext/regional/report/uae_vat_201/uae_vat_201.js
+++ b/erpnext/regional/report/uae_vat_201/uae_vat_201.js
@@ -10,6 +10,13 @@ frappe.query_reports["UAE VAT 201"] = {
 			options: "Company",
 			reqd: 1,
 			default: frappe.defaults.get_user_default("Company"),
+			get_query: function () {
+				return {
+					filters: {
+						country: "United Arab Emirates",
+					},
+				};
+			},
 		},
 		{
 			fieldname: "from_date",

--- a/erpnext/regional/report/uae_vat_201/uae_vat_201.py
+++ b/erpnext/regional/report/uae_vat_201/uae_vat_201.py
@@ -5,11 +5,23 @@
 import frappe
 from frappe import _
 
+from erpnext import get_region
+
 
 def execute(filters=None):
+	validate_company_region(filters)
 	columns = get_columns()
 	data, emirates, amounts_by_emirate = get_data(filters)
 	return columns, data
+
+
+def validate_company_region(filters):
+	if filters.get("company") and get_region(filters.get("company")) != "United Arab Emirates":
+		frappe.throw(
+			_(
+				"The company {0} is not in United Arab Emirates. UAE VAT 201 report is only available for companies in United Arab Emirates."
+			).format(frappe.bold(filters.get("company")))
+		)
 
 
 def get_columns():


### PR DESCRIPTION
Issue: uae vat 201 report throws a database error for non-uae companies because it queries the vat_emirate field, which only exists for uae companies.

Traceback :

```
 File "apps/frappe/frappe/app.py", line 121, in application
    response = frappe.api.handle(request)
  File "apps/frappe/frappe/api/__init__.py", line 63, in handle
    data = endpoint(**arguments)
  File "apps/frappe/frappe/api/v1.py", line 40, in handle_rpc_call
    return frappe.handler.handle()
           ~~~~~~~~~~~~~~~~~~~~~^^
  File "apps/frappe/frappe/handler.py", line 54, in handle
    data = execute_cmd(cmd)
  File "apps/frappe/frappe/handler.py", line 87, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
           ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/__init__.py", line 1131, in call
    return fn(*args, **newargs)
  File "apps/frappe/frappe/utils/typing_validations.py", line 49, in wrapper
    return func(*args, **kwargs)
  File "apps/frappe/frappe/__init__.py", line 493, in wrapper_fn
    retval = fn(*args, **get_newargs(fn, kwargs))
  File "apps/frappe/frappe/desk/query_report.py", line 240, in run
    result = generate_report_result(report, filters, user, custom_columns, is_tree, parent_field)
  File "apps/frappe/frappe/__init__.py", line 493, in wrapper_fn
    retval = fn(*args, **get_newargs(fn, kwargs))
  File "apps/frappe/frappe/desk/query_report.py", line 92, in generate_report_result
    res = get_report_result(report, filters) or []
          ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/desk/query_report.py", line 68, in get_report_result
    res = report.execute_script_report(filters)
  File "apps/frappe/frappe/core/doctype/report/report.py", line 202, in execute_script_report
    res = self.execute_module(filters)
  File "apps/frappe/frappe/core/doctype/report/report.py", line 221, in execute_module
    return self.get_module_method("execute")(frappe._dict(filters))
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/erpnext/erpnext/regional/report/uae_vat_201/uae_vat_201.py", line 11, in execute
    data, emirates, amounts_by_emirate = get_data(filters)
                                         ~~~~~~~~^^^^^^^^^
  File "apps/erpnext/erpnext/regional/report/uae_vat_201/uae_vat_201.py", line 38, in get_data
    emirates, amounts_by_emirate = append_vat_on_sales(data, filters)
                                   ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
  File "apps/erpnext/erpnext/regional/report/uae_vat_201/uae_vat_201.py", line 47, in append_vat_on_sales
    emirates, amounts_by_emirate = standard_rated_expenses_emiratewise(data, filters)
                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
  File "apps/erpnext/erpnext/regional/report/uae_vat_201/uae_vat_201.py", line 76, in standard_rated_expenses_emiratewise
    total_emiratewise = get_total_emiratewise(filters)
  File "apps/erpnext/erpnext/regional/report/uae_vat_201/uae_vat_201.py", line 137, in get_total_emiratewise
    return frappe.db.sql(
           ~~~~~~~~~~~~~^
    	f"""
     ^^^^
    ...<12 lines>...
    	filters,
     ^^^^^^^^
    )
    ^
  File "apps/frappe/frappe/database/database.py", line 272, in sql
    self.execute_query(query, values)
    ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/database/database.py", line 374, in execute_query
    return self._cursor.execute(query, values)
           ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
  File "env/lib/python3.14/site-packages/MySQLdb/cursors.py", line 179, in execute
    res = self._query(mogrified_query)
  File "env/lib/python3.14/site-packages/MySQLdb/cursors.py", line 330, in _query
    db.query(q)
    ~~~~~~~~^^^
  File "env/lib/python3.14/site-packages/MySQLdb/connections.py", line 280, in query
    _mysql.connection.query(self, query)
    ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
MySQLdb.OperationalError: (1054, "Unknown column 's.vat_emirate' in 'SELECT'")
```

Backport needed: v16, v15