### PR TITLE
fix(stock): add whole number quantity validation in Stock Reconciliation

### DIFF
--- a/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py
+++ b/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py
@@ -86,6 +86,7 @@ class StockReconciliation(StockController):
 		self.set_total_qty_and_amount()
 		self.validate_putaway_capacity()
 		self.validate_inventory_dimension()
+		self.validate_uom_is_integer("stock_uom", "qty")
 
 		if self._action == "submit":
 			self.validate_reserved_stock()


### PR DESCRIPTION
Issue: Stock Reconciliation was allowing fractional quantities even when the selected UOM had the "Must be Whole Number" option enabled.

Ref : [#68360](https://support.frappe.io/helpdesk/tickets/68360)

Steps to Reproduce
1. Create or select a UOM with Must be Whole Number enabled.
2. Open Stock Reconciliation.
3. Add an item using that UOM.
4. Enter a fractional quantity such as 1.5.
5. Save or submit the document.

Before : 

[Screencast from 13-05-26 06:17:46 PM IST.webm](https://github.com/user-attachments/assets/cb294db3-f62b-418a-a0bf-4fbf7446d9f1)

After : 

[Screencast from 13-05-26 06:16:41 PM IST.webm](https://github.com/user-attachments/assets/91b6d615-4446-4795-b306-acc8d9f1e587)

Current Behaviour:
Stock Reconciliation accepts and processes fractional quantities for whole-number UOMs without validation.

Expected Behaviour :
Stock Reconciliation should throw a validation error and prevent saving/submitting when a fractional quantity is entered for a UOM configured as Must be Whole Number.

Backport Needed For V16 and V15