### PR TITLE
fix: exclude returned items when fetching landed cost voucher items

### DIFF
--- a/erpnext/stock/doctype/landed_cost_voucher/landed_cost_voucher.py
+++ b/erpnext/stock/doctype/landed_cost_voucher/landed_cost_voucher.py
@@ -62,13 +62,16 @@ class LandedCostVoucher(Document):
 				pr_items = get_pr_items(pr)
 
 				for d in pr_items:
+					net_qty = flt(d.qty) - flt(d.get("returned_qty", 0))
+					if net_qty <= 0:
+						continue
 					item = self.append("items")
 					item.item_code = d.item_code
 					item.description = d.description
-					item.qty = d.qty
+					item.qty = net_qty
 					item.rate = d.get("base_rate") or d.get("rate")
 					item.cost_center = d.cost_center or erpnext.get_default_cost_center(self.company)
-					item.amount = d.base_amount
+					item.amount = flt(item.rate) * net_qty
 					item.receipt_document_type = pr.receipt_document_type
 					item.receipt_document = pr.receipt_document
 					item.is_fixed_asset = d.is_fixed_asset
@@ -466,6 +469,7 @@ def get_pr_items(purchase_receipt):
 			pr_item.base_rate,
 			pr_item.base_amount,
 			pr_item.is_fixed_asset,
+			pr_item.returned_qty,
 		)
 
 	return query.run(as_dict=True)


### PR DESCRIPTION
**Issue**: When creating a Landed Cost Voucher using the "Get Items From Purchase Receipts" button, the system fetches items using the original Purchase Receipt quantity without considering returned quantities from Purchase Returns.

**Fix : [#54867](https://github.com/frappe/erpnext/issues/54867)**

**Steps to Reproduce :**
1. Create and submit a Purchase Receipt with Item A (Qty: 10).
2. Create and submit a Purchase Return for Item A (Qty: 5) against the same Purchase Receipt.
3. Create a new Landed Cost Voucher.
4. Select the original Purchase Receipt.
5. Click "Get Items From Purchase Receipts".
6. See the items it is fetching 10 qty, it is considering the returned qty.

Before:

[Screencast from 13-05-26 09:57:42 PM IST.webm](https://github.com/user-attachments/assets/7911d641-1424-4e44-9a17-f13cef151c29)

After : 

[Screencast from 13-05-26 10:00:17 PM IST.webm](https://github.com/user-attachments/assets/5bfb77e7-95b6-4bf7-bc26-00fa27f7abd6)


**Current Behavior**
The Landed Cost Voucher fetches Item A with the original quantity (10), ignoring the returned quantity.

**Expected Behavior**
Returned quantities should be excluded while fetching items for Landed Cost Voucher.
If qty - returned_qty <= 0, the item should not be fetched.
For partial returns, only the remaining quantity should be considered.

Backport Needed For V16 and V15