### PR TITLE
fix: flag to disable opening balance calculation in general ledger

### DIFF
--- a/erpnext/accounts/report/general_ledger/general_ledger.js
+++ b/erpnext/accounts/report/general_ledger/general_ledger.js
@@ -178,9 +178,15 @@ frappe.query_reports["General Ledger"] = {
 			default: 1,
 		},
 		{
+			fieldname: "disable_opening_balance_calculation",
+			label: __("Disable Opening Balance Calculation"),
+			fieldtype: "Check",
+		},
+		{
 			fieldname: "show_opening_entries",
 			label: __("Show Opening Entries"),
 			fieldtype: "Check",
+			depends_on: "eval: !doc.disable_opening_balance_calculation",
 		},
 		{
 			fieldname: "include_default_book_entries",

--- a/erpnext/accounts/report/general_ledger/general_ledger.py
+++ b/erpnext/accounts/report/general_ledger/general_ledger.py
@@ -283,7 +283,15 @@ def get_conditions(filters):
 	if filters.get("party"):
 		conditions.append("party in %(party)s")
 
-	if not (
+	if filters.get("disable_opening_balance_calculation"):
+		if not ignore_is_opening:
+			conditions.append("(posting_date >=%(from_date)s or is_opening = 'Yes')")
+		else:
+			conditions.append("posting_date >=%(from_date)s")
+
+	# opening balance calculation is done only if filtered on account/party
+	# so from_date filter is not applied
+	elif not (
 		filters.get("account")
 		or filters.get("party")
 		or filters.get("categorize_by") in ["Categorize by Account", "Categorize by Party"]
@@ -553,7 +561,11 @@ def get_accountwise_gle(filters, accounting_dimensions, gl_entries, gle_map):
 		gle.remarks = _(gle.remarks)
 		gle.party_type = _(gle.party_type)
 
-		if gle.posting_date < from_date or (cstr(gle.is_opening) == "Yes" and not show_opening_entries):
+		if gle.posting_date < from_date or (
+			cstr(gle.is_opening) == "Yes"
+			and not show_opening_entries
+			and not filters.disable_opening_balance_calculation
+		):
 			if not group_by_voucher_consolidated:
 				update_value_in_dict(gle_map[group_by_value].totals, "opening", gle, True)
 				update_value_in_dict(gle_map[group_by_value].totals, "closing", gle, True)


### PR DESCRIPTION
Opening balance is only calculated if general ledger is generated on account/party. Which means `from_date` filter is never passed to select query. On large databases, this is a prominent issue.

Added a new flag to disable this behavior.

## Before
<img width="2487" height="789" alt="Screenshot from 2026-05-15 10-51-05" src="https://github.com/user-attachments/assets/20c16a19-7fea-40f2-bdf1-193f59fb9086" />

## After
<img width="2487" height="789" alt="Screenshot from 2026-05-15 11-47-24" src="https://github.com/user-attachments/assets/8d7a707f-24b7-4bb8-b48a-411d6e5b279f" />


ref: [65078](https://support.frappe.io/helpdesk/tickets/65078)