### PR TITLE
fix: add hd_customer field in customer doctype

### DIFF
--- a/erpnext/setup/install.py
+++ b/erpnext/setup/install.py
@@ -39,6 +39,7 @@ def after_install():
 	set_default_print_formats()
 	create_letter_head()
 	toggle_hidden_fields()
+	create_helpdesk_fields()
 	frappe.db.commit()
 
 
@@ -408,3 +409,11 @@ DEFAULT_ROLE_PROFILES = {
 		"Purchase Manager",
 	],
 }
+
+
+def create_helpdesk_fields():
+	if "helpdesk" not in frappe.get_installed_apps():
+		return
+	from helpdesk.helpdesk.integrations.erpnext.customer import create_helpdesk_fields_in_customer
+
+	create_helpdesk_fields_in_customer()


### PR DESCRIPTION
This PR created "hd_customer" field in Customer Master, when ERPNext is installed after Helpdesk is installed on a site.


**Why?**
From Helpdesk App I can control if Helpdesk after ERPNext, but there is no way to to "hook" to installation of ERPNext on a site which already has Helpdesk installed.



related-pr: https://github.com/frappe/helpdesk/pull/3357