### PR TITLE
feat(company): add a default_letter_head_report field in company doctype

### DIFF
--- a/erpnext/setup/doctype/company/company.js
+++ b/erpnext/setup/doctype/company/company.js
@@ -69,6 +69,22 @@ frappe.ui.form.on("Company", {
 				},
 			};
 		});
+
+		frm.set_query("default_letter_head", function () {
+			return {
+				filters: {
+					letter_head_for: "DocType",
+				},
+			};
+		});
+
+		frm.set_query("default_letter_head_report", function () {
+			return {
+				filters: {
+					letter_head_for: "Report",
+				},
+			};
+		});
 	},
 
 	company_name: function (frm) {

--- a/erpnext/setup/doctype/company/company.json
+++ b/erpnext/setup/doctype/company/company.json
@@ -17,12 +17,15 @@
   "is_group",
   "default_holiday_list",
   "cb0",
-  "default_letter_head",
   "tax_id",
   "domain",
   "date_of_establishment",
   "parent_company",
   "reporting_currency",
+  "section_break_soma",
+  "default_letter_head",
+  "column_break_zqmp",
+  "default_letter_head_report",
   "company_info",
   "company_logo",
   "date_of_incorporation",
@@ -253,7 +256,7 @@
   {
    "fieldname": "default_letter_head",
    "fieldtype": "Link",
-   "label": "Default Letter Head",
+   "label": "Default Letter Head (DocType)",
    "options": "Letter Head"
   },
   {
@@ -962,6 +965,20 @@
   {
    "fieldname": "accounts_closing_section",
    "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "default_letter_head_report",
+   "fieldtype": "Link",
+   "label": "Default Letter Head (Report)",
+   "options": "Letter Head"
+  },
+  {
+   "fieldname": "section_break_soma",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "column_break_zqmp",
+   "fieldtype": "Column Break"
   }
  ],
  "grid_page_length": 50,
@@ -970,7 +987,7 @@
  "image_field": "company_logo",
  "is_tree": 1,
  "links": [],
- "modified": "2026-04-17 17:11:46.586135",
+ "modified": "2026-05-14 16:50:34.132345",
  "modified_by": "Administrator",
  "module": "Setup",
  "name": "Company",

--- a/erpnext/setup/doctype/company/company.py
+++ b/erpnext/setup/doctype/company/company.py
@@ -76,6 +76,7 @@ class Company(NestedSet):
 		default_income_account: DF.Link | None
 		default_inventory_account: DF.Link | None
 		default_letter_head: DF.Link | None
+		default_letter_head_report: DF.Link | None
 		default_operating_cost_account: DF.Link | None
 		default_payable_account: DF.Link | None
 		default_provisional_account: DF.Link | None

--- a/erpnext/startup/boot.py
+++ b/erpnext/startup/boot.py
@@ -49,7 +49,7 @@ def boot_session(bootinfo):
 
 		bootinfo.docs += frappe.db.sql(
 			"""select name, default_currency, cost_center, default_selling_terms, default_buying_terms,
-			default_letter_head, default_bank_account, enable_perpetual_inventory, country, exchange_gain_loss_account from `tabCompany`""",
+			default_letter_head, default_letter_head_report, default_bank_account, enable_perpetual_inventory, country, exchange_gain_loss_account from `tabCompany`""",
 			as_dict=1,
 			update={"doctype": ":Company"},
 		)


### PR DESCRIPTION
Introduce a default_letter_head_report in Company doctype to track a company-level default letter head for reports as we do for doctype

no-docs