### PR TITLE
fix: asset capitalization when using item-wise inventory

### DIFF
--- a/erpnext/controllers/stock_controller.py
+++ b/erpnext/controllers/stock_controller.py
@@ -205,7 +205,7 @@ class StockController(AccountsController):
 
 	def get_item_wise_inventory_account_map(self):
 		inventory_account_map = frappe._dict()
-		for table in ["items", "packed_items", "supplied_items"]:
+		for table in ["items", "packed_items", "supplied_items", "stock_items"]:
 			if not self.get(table):
 				continue
 


### PR DESCRIPTION
Currently when using latest ERPNext  v16.18.3 then it's not possible to submit `Asset Capitalization` when using `Item-wise Inventory Account`.
<img width="1247" height="442" alt="image" src="https://github.com/user-attachments/assets/4ab0f577-5ddf-4797-b7d1-7139100f2240" />
Trying to submit we get error: `Please set default inventory account for item [...], or their item group or brand.`
<img width="1041" height="257" alt="image" src="https://github.com/user-attachments/assets/0ce6eb04-a6e2-4c41-944a-81e453b69bdc" />
Even when ` Default Inventory Account` is already set for Item/Item group.

This happens because `get_item_wise_inventory_account_map()` returns `{}` due to `Asset Capitalization` having different field for items `stock_items` which is not present.

This PR adds `stock_items` fixing this issue.