### PR TITLE
feat(party-link): Add Create/Remove UI for Linking Customers & Suppliers

### DIFF
--- a/erpnext/accounts/doctype/party_link/party_link.py
+++ b/erpnext/accounts/doctype/party_link/party_link.py
@@ -172,6 +172,8 @@ def create_and_link_party(
 	if not frappe.db.exists(primary_role, primary_party):
 		frappe.throw(_("{} {} does not exist").format(primary_role, frappe.bold(primary_party)))
 
+	frappe.has_permission(primary_role, "write", doc=primary_party, throw=True)
+
 	secondary_role = "Customer" if primary_role == "Supplier" else "Supplier"
 	role_lower = secondary_role.lower()
 

--- a/erpnext/accounts/doctype/party_link/party_link.py
+++ b/erpnext/accounts/doctype/party_link/party_link.py
@@ -21,6 +21,18 @@ class PartyLink(Document):
 		secondary_role: DF.Link | None
 	# end: auto-generated types
 
+	def on_trash(self):
+		if self.primary_role == "Customer":
+			customer, supplier = self.primary_party, self.secondary_party
+		else:
+			customer, supplier = self.secondary_party, self.primary_party
+
+		if customer and frappe.db.exists("Customer", customer):
+			frappe.db.set_value("Customer", customer, "linked_supplier", None)
+
+		if supplier and frappe.db.exists("Supplier", supplier):
+			frappe.db.set_value("Supplier", supplier, "linked_customer", None)
+
 	def validate(self):
 		if self.primary_role not in ["Customer", "Supplier"]:
 			frappe.throw(
@@ -67,7 +79,12 @@ class PartyLink(Document):
 
 
 @frappe.whitelist()
-def create_party_link(primary_role: str, primary_party: str, secondary_party: str):
+def create_party_link(
+	primary_role: str,
+	primary_party: str,
+	secondary_party: str,
+	copy_address_and_contacts: bool = False,
+):
 	party_link = frappe.new_doc("Party Link")
 	party_link.primary_role = primary_role
 	party_link.primary_party = primary_party
@@ -76,4 +93,115 @@ def create_party_link(primary_role: str, primary_party: str, secondary_party: st
 
 	party_link.save()
 
+	if copy_address_and_contacts:
+		_copy_address_and_contacts(party_link)
+
 	return party_link
+
+
+def _copy_address_and_contacts(party_link: "PartyLink"):
+	"""Copy Dynamic Link rows from primary party's Addresses and Contacts to the secondary party."""
+	source_party = party_link.primary_party
+	source_role = party_link.primary_role
+	target_party = party_link.secondary_party
+	target_role = party_link.secondary_role
+
+	for doctype in ("Address", "Contact"):
+		dl = frappe.qb.DocType("Dynamic Link")
+		linked_docs = (
+			frappe.qb.from_(dl)
+			.select(dl.parent)
+			.where(
+				(dl.link_doctype == source_role) & (dl.link_name == source_party) & (dl.parenttype == doctype)
+			)
+			.run(pluck="parent")
+		)
+
+		for doc_name in linked_docs:
+			already_linked = frappe.db.exists(
+				"Dynamic Link",
+				{
+					"parenttype": doctype,
+					"parent": doc_name,
+					"link_doctype": target_role,
+					"link_name": target_party,
+				},
+			)
+			if already_linked:
+				continue
+
+			if not frappe.has_permission(doctype, "write", doc=doc_name):
+				continue
+
+			doc = frappe.get_doc(doctype, doc_name)
+			doc.append(
+				"links",
+				{
+					"link_doctype": target_role,
+					"link_name": target_party,
+				},
+			)
+			doc.save()
+
+
+def _find_party_link(party_type: str, party: str) -> "dict | None":
+	PL = frappe.qb.DocType("Party Link")
+	result = (
+		frappe.qb.from_(PL)
+		.select(PL.name, PL.primary_role, PL.primary_party, PL.secondary_role, PL.secondary_party)
+		.where(
+			((PL.primary_role == party_type) & (PL.primary_party == party))
+			| ((PL.secondary_role == party_type) & (PL.secondary_party == party))
+		)
+		.run(as_dict=True)
+	)
+	return result[0] if result else None
+
+
+@frappe.whitelist()
+def create_and_link_party(
+	primary_role: str,
+	primary_party: str,
+	new_party_name: str,
+	new_party_type: str,
+	new_party_group: str | None = None,
+):
+	if primary_role not in ("Customer", "Supplier"):
+		frappe.throw(_("primary_role must be 'Customer' or 'Supplier'"))
+
+	if not frappe.db.exists(primary_role, primary_party):
+		frappe.throw(_("{} {} does not exist").format(primary_role, frappe.bold(primary_party)))
+
+	secondary_role = "Customer" if primary_role == "Supplier" else "Supplier"
+	role_lower = secondary_role.lower()
+
+	sp = "create_and_link_party"
+	frappe.db.savepoint(sp)
+	try:
+		new_doc = frappe.new_doc(secondary_role)
+		new_doc.set(f"{role_lower}_name", new_party_name)
+		new_doc.set(f"{role_lower}_type", new_party_type)
+		if new_party_group:
+			new_doc.set(f"{role_lower}_group", new_party_group)
+		new_doc.insert()
+
+		return create_party_link(
+			primary_role=primary_role,
+			primary_party=primary_party,
+			secondary_party=new_doc.name,
+			copy_address_and_contacts=True,
+		)
+	except Exception:
+		frappe.db.rollback(save_point=sp)
+		raise
+
+
+@frappe.whitelist()
+def remove_party_link(party_type: str, party: str):
+	frappe.has_permission("Party Link", "delete", throw=True)
+
+	link = _find_party_link(party_type, party)
+	if not link:
+		frappe.throw(_("No Party Link found for {} {}").format(party_type, frappe.bold(party)))
+
+	frappe.delete_doc("Party Link", link.name)

--- a/erpnext/accounts/doctype/party_link/test_party_link.py
+++ b/erpnext/accounts/doctype/party_link/test_party_link.py
@@ -1,9 +1,171 @@
 # Copyright (c) 2021, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-# import frappe
 
+import frappe
+from frappe import _
+
+from erpnext.accounts.doctype.party_link.party_link import (
+	_copy_address_and_contacts,
+	_find_party_link,
+	create_and_link_party,
+	create_party_link,
+	remove_party_link,
+)
+from erpnext.accounts.party import load_party_link
 from erpnext.tests.utils import ERPNextTestSuite
 
 
 class TestPartyLink(ERPNextTestSuite):
-	pass
+	def setUp(self):
+		self.customer = _make_customer("_Test Party Link Customer")
+		self.supplier = _make_supplier("_Test Party Link Supplier")
+
+	def test_create_party_link(self):
+		link = create_party_link("Supplier", self.supplier.name, self.customer.name)
+		self.assertEqual(link.primary_role, "Supplier")
+		self.assertEqual(link.primary_party, self.supplier.name)
+		self.assertEqual(link.secondary_role, "Customer")
+		self.assertEqual(link.secondary_party, self.customer.name)
+		self.assertTrue(frappe.db.exists("Party Link", link.name))
+
+	def test_find_party_link_from_primary_side(self):
+		link = create_party_link("Supplier", self.supplier.name, self.customer.name)
+		found = _find_party_link("Supplier", self.supplier.name)
+		self.assertIsNotNone(found)
+		self.assertEqual(found.name, link.name)
+
+	def test_find_party_link_from_secondary_side(self):
+		link = create_party_link("Supplier", self.supplier.name, self.customer.name)
+		found = _find_party_link("Customer", self.customer.name)
+		self.assertIsNotNone(found)
+		self.assertEqual(found.name, link.name)
+
+	def test_find_party_link_returns_none_when_no_link(self):
+		result = _find_party_link("Supplier", self.supplier.name)
+		self.assertIsNone(result)
+
+	def test_load_party_link_on_supplier_sets_onload(self):
+		create_party_link("Supplier", self.supplier.name, self.customer.name)
+		supplier_doc = frappe.get_doc("Supplier", self.supplier.name)
+		load_party_link(supplier_doc)
+		onload = supplier_doc.get_onload("party_link")
+		self.assertEqual(onload["name"], self.customer.name)
+		self.assertEqual(onload["role"], "Customer")
+
+	def test_load_party_link_on_customer_sets_onload(self):
+		create_party_link("Supplier", self.supplier.name, self.customer.name)
+		customer_doc = frappe.get_doc("Customer", self.customer.name)
+		load_party_link(customer_doc)
+		onload = customer_doc.get_onload("party_link")
+		self.assertEqual(onload["name"], self.supplier.name)
+		self.assertEqual(onload["role"], "Supplier")
+
+	def test_load_party_link_does_nothing_when_no_link(self):
+		supplier_doc = frappe.get_doc("Supplier", self.supplier.name)
+		load_party_link(supplier_doc)
+		self.assertIsNone(supplier_doc.get_onload().get("party_link"))
+
+	def test_remove_party_link(self):
+		link = create_party_link("Supplier", self.supplier.name, self.customer.name)
+		remove_party_link("Supplier", self.supplier.name)
+		self.assertFalse(frappe.db.exists("Party Link", link.name))
+
+	def test_remove_party_link_throws_when_not_found(self):
+		self.assertRaises(
+			frappe.exceptions.ValidationError, remove_party_link, "Supplier", self.supplier.name
+		)
+
+	def test_create_and_link_party_creates_customer_and_link(self):
+		result = create_and_link_party(
+			primary_role="Supplier",
+			primary_party=self.supplier.name,
+			new_party_name="_Test Auto Customer",
+			new_party_type="Company",
+		)
+		self.assertEqual(result.primary_role, "Supplier")
+		self.assertEqual(result.primary_party, self.supplier.name)
+		self.assertEqual(result.secondary_role, "Customer")
+		linked_customer = frappe.db.get_value("Customer", result.secondary_party, "customer_name")
+		self.assertEqual(linked_customer, "_Test Auto Customer")
+
+	def test_create_and_link_party_creates_supplier_and_link(self):
+		result = create_and_link_party(
+			primary_role="Customer",
+			primary_party=self.customer.name,
+			new_party_name="_Test Auto Supplier",
+			new_party_type="Company",
+		)
+		self.assertEqual(result.primary_role, "Customer")
+		self.assertEqual(result.primary_party, self.customer.name)
+		self.assertEqual(result.secondary_role, "Supplier")
+		linked_supplier = frappe.db.get_value("Supplier", result.secondary_party, "supplier_name")
+		self.assertEqual(linked_supplier, "_Test Auto Supplier")
+
+	def test_copy_address_and_contacts_links_address_to_secondary(self):
+		address = _make_address("_Test PL Address", "Supplier", self.supplier.name)
+		link = create_party_link("Supplier", self.supplier.name, self.customer.name)
+		_copy_address_and_contacts(link)
+
+		linked = frappe.db.exists(
+			"Dynamic Link",
+			{
+				"parenttype": "Address",
+				"parent": address.name,
+				"link_doctype": "Customer",
+				"link_name": self.customer.name,
+			},
+		)
+		self.assertTrue(linked)
+
+	def test_copy_address_and_contacts_skips_already_linked(self):
+		address = _make_address("_Test PL Address Dup", "Supplier", self.supplier.name)
+		link = create_party_link("Supplier", self.supplier.name, self.customer.name)
+
+		_copy_address_and_contacts(link)
+		_copy_address_and_contacts(link)
+
+		count = frappe.db.count(
+			"Dynamic Link",
+			{
+				"parenttype": "Address",
+				"parent": address.name,
+				"link_doctype": "Customer",
+				"link_name": self.customer.name,
+			},
+		)
+		self.assertEqual(count, 1)
+
+
+def _make_customer(customer_name):
+	if frappe.db.exists("Customer", {"customer_name": customer_name}):
+		return frappe.get_doc("Customer", {"customer_name": customer_name})
+	doc = frappe.new_doc("Customer")
+	doc.customer_name = customer_name
+	doc.customer_type = "Company"
+	doc.customer_group = frappe.db.get_value("Customer Group", {"is_group": 0}, "name")
+	doc.territory = frappe.db.get_single_value("Selling Settings", "territory") or "All Territories"
+	doc.insert(ignore_permissions=True)
+	return doc
+
+
+def _make_supplier(supplier_name):
+	if frappe.db.exists("Supplier", {"supplier_name": supplier_name}):
+		return frappe.get_doc("Supplier", {"supplier_name": supplier_name})
+	doc = frappe.new_doc("Supplier")
+	doc.supplier_name = supplier_name
+	doc.supplier_type = "Company"
+	doc.supplier_group = frappe.db.get_value("Supplier Group", {"is_group": 0}, "name")
+	doc.insert(ignore_permissions=True)
+	return doc
+
+
+def _make_address(title, link_doctype, link_name):
+	doc = frappe.new_doc("Address")
+	doc.address_title = title
+	doc.address_type = "Billing"
+	doc.address_line1 = "Test Street"
+	doc.city = "Test City"
+	doc.country = "India"
+	doc.append("links", {"link_doctype": link_doctype, "link_name": link_name})
+	doc.insert(ignore_permissions=True)
+	return doc

--- a/erpnext/accounts/party.py
+++ b/erpnext/accounts/party.py
@@ -829,6 +829,22 @@ def validate_account_party_type(self):
 			)
 
 
+def load_party_link(doc) -> None:
+	from erpnext.accounts.doctype.party_link.party_link import _find_party_link
+
+	party_type = doc.doctype
+	link = _find_party_link(party_type, doc.name)
+	if not link:
+		return
+
+	if link.primary_party == doc.name:
+		peer = {"role": link.secondary_role, "name": link.secondary_party}
+	else:
+		peer = {"role": link.primary_role, "name": link.primary_party}
+
+	doc.set_onload("party_link", peer)
+
+
 def get_dashboard_info(party_type, party, loyalty_program=None):
 	current_fiscal_year = get_fiscal_year(nowdate(), as_dict=True)
 

--- a/erpnext/buying/doctype/supplier/supplier.js
+++ b/erpnext/buying/doctype/supplier/supplier.js
@@ -119,11 +119,8 @@ frappe.ui.form.on("Supplier", {
 
 			const party_link = frm.doc.__onload?.party_link;
 
-			if (
-				cint(frappe.defaults.get_default("enable_common_party_accounting")) &&
-				frappe.model.can_create("Party Link")
-			) {
-				if (!party_link) {
+			if (cint(frappe.defaults.get_default("enable_common_party_accounting"))) {
+				if (!party_link && frappe.model.can_create("Party Link")) {
 					frm.add_custom_button(
 						__("Link with Customer"),
 						function () {
@@ -131,34 +128,32 @@ frappe.ui.form.on("Supplier", {
 						},
 						__("Actions")
 					);
-				} else {
-					if (frappe.model.can_delete("Party Link")) {
-						frm.add_custom_button(
-							__("Remove Link with Customer"),
-							function () {
-								frappe.confirm(
-									__(
-										"Are you sure you want to unlink {0} and {1}? This will stop Common Party Accounting between them.",
-										[
-											frappe.utils.get_form_link("Supplier", frm.doc.name, true),
-											frappe.utils.get_form_link("Customer", party_link.name, true),
-										]
-									),
-									function () {
-										frappe.call({
-											method: "erpnext.accounts.doctype.party_link.party_link.remove_party_link",
-											args: { party_type: "Supplier", party: frm.doc.name },
-											freeze: true,
-											callback: function () {
-												frm.reload_doc();
-											},
-										});
-									}
-								);
-							},
-							__("Actions")
-						);
-					}
+				} else if (party_link && frappe.model.can_delete("Party Link")) {
+					frm.add_custom_button(
+						__("Remove Link with Customer"),
+						function () {
+							frappe.confirm(
+								__(
+									"Are you sure you want to unlink {0} and {1}? This will stop Common Party Accounting between them.",
+									[
+										frappe.utils.get_form_link("Supplier", frm.doc.name, true),
+										frappe.utils.get_form_link("Customer", party_link.name, true),
+									]
+								),
+								function () {
+									frappe.call({
+										method: "erpnext.accounts.doctype.party_link.party_link.remove_party_link",
+										args: { party_type: "Supplier", party: frm.doc.name },
+										freeze: true,
+										callback: function () {
+											frm.reload_doc();
+										},
+									});
+								}
+							);
+						},
+						__("Actions")
+					);
 				}
 			}
 

--- a/erpnext/buying/doctype/supplier/supplier.js
+++ b/erpnext/buying/doctype/supplier/supplier.js
@@ -117,18 +117,53 @@ frappe.ui.form.on("Supplier", {
 				__("View")
 			);
 
+			const party_link = frm.doc.__onload?.party_link;
+
 			if (
 				cint(frappe.defaults.get_default("enable_common_party_accounting")) &&
 				frappe.model.can_create("Party Link")
 			) {
-				frm.add_custom_button(
-					__("Link with Customer"),
-					function () {
-						frm.trigger("show_party_link_dialog");
-					},
-					__("Actions")
-				);
+				if (!party_link) {
+					frm.add_custom_button(
+						__("Link with Customer"),
+						function () {
+							frm.trigger("show_party_link_dialog");
+						},
+						__("Actions")
+					);
+				} else {
+					if (frappe.model.can_delete("Party Link")) {
+						frm.add_custom_button(
+							__("Remove Link with Customer"),
+							function () {
+								frappe.confirm(
+									__(
+										"Are you sure you want to unlink {0} and {1}? This will stop Common Party Accounting between them.",
+										[
+											frappe.utils.get_form_link("Supplier", frm.doc.name, true),
+											frappe.utils.get_form_link("Customer", party_link.name, true),
+										]
+									),
+									function () {
+										frappe.call({
+											method: "erpnext.accounts.doctype.party_link.party_link.remove_party_link",
+											args: { party_type: "Supplier", party: frm.doc.name },
+											freeze: true,
+											callback: function () {
+												frm.reload_doc();
+											},
+										});
+									}
+								);
+							},
+							__("Actions")
+						);
+					}
+				}
 			}
+
+			frm.doc.linked_customer = party_link ? party_link.name : null;
+			frm.refresh_field("linked_customer");
 
 			// indicators
 			erpnext.utils.set_party_dashboard_indicators(frm);
@@ -185,6 +220,7 @@ frappe.ui.form.on("Supplier", {
 					options: "Customer",
 					fieldname: "customer",
 					reqd: 1,
+					only_select: 1,
 				},
 			],
 			primary_action: function ({ customer }) {
@@ -202,6 +238,7 @@ frappe.ui.form.on("Supplier", {
 							message: __("Successfully linked to Customer"),
 							alert: true,
 						});
+						frm.reload_doc();
 					},
 					error: function () {
 						dialog.hide();
@@ -213,8 +250,64 @@ frappe.ui.form.on("Supplier", {
 					},
 				});
 			},
-			primary_action_label: __("Create Link"),
+			primary_action_label: __("Link"),
 		});
+
+		if (frappe.model.can_create("Customer")) {
+			dialog.set_secondary_action(function () {
+				frappe.model.with_doctype("Customer", function () {
+					const customer_type_options = frappe.meta.get_field("Customer", "customer_type").options;
+
+					const create_dialog = new frappe.ui.Dialog({
+						title: __("Create New Customer"),
+						fields: [
+							{
+								fieldname: "customer_name",
+								fieldtype: "Data",
+								label: __("Customer Name"),
+								reqd: 1,
+							},
+							{
+								fieldname: "customer_type",
+								fieldtype: "Select",
+								label: __("Customer Type"),
+								options: customer_type_options,
+								default: "Company",
+								reqd: 1,
+							},
+							{
+								fieldname: "customer_group",
+								fieldtype: "Link",
+								label: __("Customer Group"),
+								options: "Customer Group",
+							},
+						],
+						primary_action_label: __("Create & Link"),
+						primary_action: function (values) {
+							frappe.call({
+								method: "erpnext.accounts.doctype.party_link.party_link.create_and_link_party",
+								args: {
+									primary_role: "Supplier",
+									primary_party: frm.doc.name,
+									new_party_name: values.customer_name,
+									new_party_type: values.customer_type,
+									new_party_group: values.customer_group,
+								},
+								freeze: true,
+								callback: function () {
+									create_dialog.hide();
+									dialog.hide();
+									frm.reload_doc();
+								},
+							});
+						},
+					});
+					create_dialog.show();
+				});
+			});
+			dialog.set_secondary_action_label(__("Create new Customer"));
+		}
+
 		dialog.show();
 	},
 	make_pricing_rule: function (frm) {

--- a/erpnext/buying/doctype/supplier/supplier.js
+++ b/erpnext/buying/doctype/supplier/supplier.js
@@ -294,6 +294,15 @@ frappe.ui.form.on("Supplier", {
 									dialog.hide();
 									frm.reload_doc();
 								},
+								error: function () {
+									frappe.msgprint({
+										message: __(
+											"Creating and linking Customer failed. Please try again."
+										),
+										title: __("Linking Failed"),
+										indicator: "red",
+									});
+								},
 							});
 						},
 					});

--- a/erpnext/buying/doctype/supplier/supplier.json
+++ b/erpnext/buying/doctype/supplier/supplier.json
@@ -17,6 +17,7 @@
   "column_break0",
   "supplier_group",
   "country",
+  "linked_customer",
   "is_transporter",
   "image",
   "defaults_section",
@@ -100,6 +101,14 @@
    "oldfieldname": "supplier_name",
    "oldfieldtype": "Data",
    "reqd": 1
+  },
+  {
+   "fieldname": "linked_customer",
+   "fieldtype": "Link",
+   "label": "Linked Customer",
+   "no_copy": 1,
+   "options": "Customer",
+   "read_only": 1
   },
   {
    "fieldname": "country",
@@ -517,7 +526,7 @@
    "link_fieldname": "party"
   }
  ],
- "modified": "2026-03-09 17:15:25.465759",
+ "modified": "2026-05-11 17:20:14.382941",
  "modified_by": "Administrator",
  "module": "Buying",
  "name": "Supplier",

--- a/erpnext/buying/doctype/supplier/supplier.py
+++ b/erpnext/buying/doctype/supplier/supplier.py
@@ -13,6 +13,7 @@ from frappe.model.naming import set_name_by_naming_series, set_name_from_naming_
 
 from erpnext.accounts.party import (
 	get_dashboard_info,
+	load_party_link,
 	validate_party_accounts,
 	validate_party_currency_before_merging,
 )
@@ -56,6 +57,7 @@ class Supplier(TransactionBase):
 		is_internal_supplier: DF.Check
 		is_transporter: DF.Check
 		language: DF.Link | None
+		linked_customer: DF.Link | None
 		mobile_no: DF.ReadOnly | None
 		naming_series: DF.Literal["SUP-.YYYY.-"]
 		on_hold: DF.Check
@@ -85,6 +87,8 @@ class Supplier(TransactionBase):
 		"""Load address and contacts in `__onload`"""
 		load_address_and_contact(self)
 		self.load_dashboard_info()
+		if not self.is_new():
+			load_party_link(self)
 
 	def before_save(self):
 		if not self.on_hold:

--- a/erpnext/selling/doctype/customer/customer.js
+++ b/erpnext/selling/doctype/customer/customer.js
@@ -195,11 +195,8 @@ frappe.ui.form.on("Customer", {
 
 			const party_link = frm.doc.__onload?.party_link;
 
-			if (
-				cint(frappe.defaults.get_default("enable_common_party_accounting")) &&
-				frappe.model.can_create("Party Link")
-			) {
-				if (!party_link) {
+			if (cint(frappe.defaults.get_default("enable_common_party_accounting"))) {
+				if (!party_link && frappe.model.can_create("Party Link")) {
 					frm.add_custom_button(
 						__("Link with Supplier"),
 						function () {
@@ -207,34 +204,32 @@ frappe.ui.form.on("Customer", {
 						},
 						__("Actions")
 					);
-				} else {
-					if (frappe.model.can_delete("Party Link")) {
-						frm.add_custom_button(
-							__("Remove Link with Supplier"),
-							function () {
-								frappe.confirm(
-									__(
-										"Are you sure you want to unlink {0} and {1}? This will stop Common Party Accounting between them.",
-										[
-											frappe.utils.get_form_link("Customer", frm.doc.name, true),
-											frappe.utils.get_form_link("Supplier", party_link.name, true),
-										]
-									),
-									function () {
-										frappe.call({
-											method: "erpnext.accounts.doctype.party_link.party_link.remove_party_link",
-											args: { party_type: "Customer", party: frm.doc.name },
-											freeze: true,
-											callback: function () {
-												frm.reload_doc();
-											},
-										});
-									}
-								);
-							},
-							__("Actions")
-						);
-					}
+				} else if (party_link && frappe.model.can_delete("Party Link")) {
+					frm.add_custom_button(
+						__("Remove Link with Supplier"),
+						function () {
+							frappe.confirm(
+								__(
+									"Are you sure you want to unlink {0} and {1}? This will stop Common Party Accounting between them.",
+									[
+										frappe.utils.get_form_link("Customer", frm.doc.name, true),
+										frappe.utils.get_form_link("Supplier", party_link.name, true),
+									]
+								),
+								function () {
+									frappe.call({
+										method: "erpnext.accounts.doctype.party_link.party_link.remove_party_link",
+										args: { party_type: "Customer", party: frm.doc.name },
+										freeze: true,
+										callback: function () {
+											frm.reload_doc();
+										},
+									});
+								}
+							);
+						},
+						__("Actions")
+					);
 				}
 			}
 

--- a/erpnext/selling/doctype/customer/customer.js
+++ b/erpnext/selling/doctype/customer/customer.js
@@ -365,6 +365,15 @@ frappe.ui.form.on("Customer", {
 									dialog.hide();
 									frm.reload_doc();
 								},
+								error: function () {
+									frappe.msgprint({
+										message: __(
+											"Creating and linking Supplier failed. Please try again."
+										),
+										title: __("Linking Failed"),
+										indicator: "red",
+									});
+								},
 							});
 						},
 					});

--- a/erpnext/selling/doctype/customer/customer.js
+++ b/erpnext/selling/doctype/customer/customer.js
@@ -193,18 +193,53 @@ frappe.ui.form.on("Customer", {
 				__("Actions")
 			);
 
+			const party_link = frm.doc.__onload?.party_link;
+
 			if (
 				cint(frappe.defaults.get_default("enable_common_party_accounting")) &&
 				frappe.model.can_create("Party Link")
 			) {
-				frm.add_custom_button(
-					__("Link with Supplier"),
-					function () {
-						frm.trigger("show_party_link_dialog");
-					},
-					__("Actions")
-				);
+				if (!party_link) {
+					frm.add_custom_button(
+						__("Link with Supplier"),
+						function () {
+							frm.trigger("show_party_link_dialog");
+						},
+						__("Actions")
+					);
+				} else {
+					if (frappe.model.can_delete("Party Link")) {
+						frm.add_custom_button(
+							__("Remove Link with Supplier"),
+							function () {
+								frappe.confirm(
+									__(
+										"Are you sure you want to unlink {0} and {1}? This will stop Common Party Accounting between them.",
+										[
+											frappe.utils.get_form_link("Customer", frm.doc.name, true),
+											frappe.utils.get_form_link("Supplier", party_link.name, true),
+										]
+									),
+									function () {
+										frappe.call({
+											method: "erpnext.accounts.doctype.party_link.party_link.remove_party_link",
+											args: { party_type: "Customer", party: frm.doc.name },
+											freeze: true,
+											callback: function () {
+												frm.reload_doc();
+											},
+										});
+									}
+								);
+							},
+							__("Actions")
+						);
+					}
+				}
 			}
+
+			frm.doc.linked_supplier = party_link ? party_link.name : null;
+			frm.refresh_field("linked_supplier");
 
 			// indicator
 			erpnext.utils.set_party_dashboard_indicators(frm);
@@ -256,6 +291,7 @@ frappe.ui.form.on("Customer", {
 					options: "Supplier",
 					fieldname: "supplier",
 					reqd: 1,
+					only_select: 1,
 				},
 			],
 			primary_action: function ({ supplier }) {
@@ -273,6 +309,7 @@ frappe.ui.form.on("Customer", {
 							message: __("Successfully linked to Supplier"),
 							alert: true,
 						});
+						frm.reload_doc();
 					},
 					error: function () {
 						dialog.hide();
@@ -284,8 +321,64 @@ frappe.ui.form.on("Customer", {
 					},
 				});
 			},
-			primary_action_label: __("Create Link"),
+			primary_action_label: __("Link"),
 		});
+
+		if (frappe.model.can_create("Supplier")) {
+			dialog.set_secondary_action(function () {
+				frappe.model.with_doctype("Supplier", function () {
+					const supplier_type_options = frappe.meta.get_field("Supplier", "supplier_type").options;
+
+					const create_dialog = new frappe.ui.Dialog({
+						title: __("Create New Supplier"),
+						fields: [
+							{
+								fieldname: "supplier_name",
+								fieldtype: "Data",
+								label: __("Supplier Name"),
+								reqd: 1,
+							},
+							{
+								fieldname: "supplier_type",
+								fieldtype: "Select",
+								label: __("Supplier Type"),
+								options: supplier_type_options,
+								default: "Company",
+								reqd: 1,
+							},
+							{
+								fieldname: "supplier_group",
+								fieldtype: "Link",
+								label: __("Supplier Group"),
+								options: "Supplier Group",
+							},
+						],
+						primary_action_label: __("Create & Link"),
+						primary_action: function (values) {
+							frappe.call({
+								method: "erpnext.accounts.doctype.party_link.party_link.create_and_link_party",
+								args: {
+									primary_role: "Customer",
+									primary_party: frm.doc.name,
+									new_party_name: values.supplier_name,
+									new_party_type: values.supplier_type,
+									new_party_group: values.supplier_group,
+								},
+								freeze: true,
+								callback: function () {
+									create_dialog.hide();
+									dialog.hide();
+									frm.reload_doc();
+								},
+							});
+						},
+					});
+					create_dialog.show();
+				});
+			});
+			dialog.set_secondary_action_label(__("Create new Supplier"));
+		}
+
 		dialog.show();
 	},
 	make_pricing_rule: function (frm) {

--- a/erpnext/selling/doctype/customer/customer.json
+++ b/erpnext/selling/doctype/customer/customer.json
@@ -18,6 +18,7 @@
   "column_break0",
   "customer_group",
   "territory",
+  "linked_supplier",
   "image",
   "defaults_tab",
   "default_currency",
@@ -120,6 +121,14 @@
    "oldfieldtype": "Data",
    "reqd": 1,
    "search_index": 1
+  },
+  {
+   "fieldname": "linked_supplier",
+   "fieldtype": "Link",
+   "label": "Linked Supplier",
+   "no_copy": 1,
+   "options": "Supplier",
+   "read_only": 1
   },
   {
    "depends_on": "eval:doc.customer_type == 'Individual'",
@@ -640,7 +649,7 @@
    "link_fieldname": "party"
   }
  ],
- "modified": "2026-03-09 17:15:26.040050",
+ "modified": "2026-05-11 17:19:56.753853",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Customer",

--- a/erpnext/selling/doctype/customer/customer.py
+++ b/erpnext/selling/doctype/customer/customer.py
@@ -21,6 +21,7 @@ from frappe.utils.user import get_users_with_role
 
 from erpnext.accounts.party import (
 	get_dashboard_info,
+	load_party_link,
 	validate_party_accounts,
 	validate_party_currency_before_merging,
 )
@@ -76,6 +77,7 @@ class Customer(TransactionBase):
 		language: DF.Link | None
 		last_name: DF.ReadOnly | None
 		lead_name: DF.Link | None
+		linked_supplier: DF.Link | None
 		loyalty_program: DF.Link | None
 		loyalty_program_tier: DF.Data | None
 		market_segment: DF.Link | None
@@ -102,6 +104,8 @@ class Customer(TransactionBase):
 		"""Load address and contacts in `__onload`"""
 		load_address_and_contact(self)
 		self.load_dashboard_info()
+		if not self.is_new():
+			load_party_link(self)
 
 	def load_dashboard_info(self):
 		info = get_dashboard_info(self.doctype, self.name, self.loyalty_program)


### PR DESCRIPTION
### Customer & Supplier forms

- Link button — appears only when no link exists; opens a dialog to pick the other party
- Remove button — appears when already linked; asks for confirmation before removing
- Create & Link — option in the link dialog to create the counterparty on the spot, link it, and copy over the existing party's addresses and contacts to the new one automatically
- Linked Supplier / Linked Customer — read-only field on each form showing the current link
- Form reloads after link/unlink so the button state stays in sync

- `no-docs`