### PR TITLE
fix: incoming rate for legacy serial no

### DIFF
--- a/erpnext/stock/deprecated_serial_batch.py
+++ b/erpnext/stock/deprecated_serial_batch.py
@@ -48,9 +48,18 @@ class DeprecatedSerialNoValuation:
 		if not posting_datetime and self.sle.posting_date:
 			posting_datetime = get_combine_datetime(self.sle.posting_date, self.sle.posting_time)
 
+		do_not_fetch_rate = frappe.db.get_single_value(
+			"Stock Reposting Settings", "do_not_fetch_incoming_rate_from_serial_no"
+		)
+
 		for serial_no in serial_nos:
 			sn_details = frappe.db.get_value("Serial No", serial_no, ["purchase_rate", "company"], as_dict=1)
-			if sn_details and sn_details.purchase_rate and sn_details.company == self.sle.company:
+			if (
+				sn_details
+				and sn_details.purchase_rate
+				and sn_details.company == self.sle.company
+				and (not frappe.flags.through_repost_item_valuation or not do_not_fetch_rate)
+			):
 				self.serial_no_incoming_rate[serial_no] += flt(sn_details.purchase_rate)
 				incoming_values += self.serial_no_incoming_rate[serial_no]
 				continue

--- a/erpnext/stock/doctype/stock_reposting_settings/stock_reposting_settings.json
+++ b/erpnext/stock/doctype/stock_reposting_settings/stock_reposting_settings.json
@@ -1,5 +1,6 @@
 {
  "actions": [],
+ "allow_bulk_edit": 1,
  "allow_rename": 1,
  "beta": 1,
  "creation": "2021-10-01 10:56:30.814787",
@@ -13,6 +14,8 @@
   "end_time",
   "limits_dont_apply_on",
   "item_based_reposting",
+  "column_break_mavd",
+  "do_not_fetch_incoming_rate_from_serial_no",
   "section_break_dxuf",
   "enable_parallel_reposting",
   "no_of_parallel_reposting",
@@ -99,13 +102,23 @@
    "fieldname": "enable_separate_reposting_for_gl",
    "fieldtype": "Check",
    "label": "Enable Separate Reposting for GL"
+  },
+  {
+   "fieldname": "column_break_mavd",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "description": "For legacy serial nos, do not fetch incoming rate from serial no and calculate it based on the inward transaction",
+   "fieldname": "do_not_fetch_incoming_rate_from_serial_no",
+   "fieldtype": "Check",
+   "label": "Do not fetch incoming rate from Serial No"
   }
  ],
- "hide_toolbar": 0,
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2026-03-16 13:28:20.978007",
+ "modified": "2026-05-15 12:59:34.392491",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Stock Reposting Settings",

--- a/erpnext/stock/doctype/stock_reposting_settings/stock_reposting_settings.py
+++ b/erpnext/stock/doctype/stock_reposting_settings/stock_reposting_settings.py
@@ -16,6 +16,7 @@ class StockRepostingSettings(Document):
 	if TYPE_CHECKING:
 		from frappe.types import DF
 
+		do_not_fetch_incoming_rate_from_serial_no: DF.Check
 		enable_parallel_reposting: DF.Check
 		enable_separate_reposting_for_gl: DF.Check
 		end_time: DF.Time | None


### PR DESCRIPTION
Issue

For legacy serial numbers:

- Inward serial number ABC with a rate of 14,000
- Outward transaction for the same serial number with a valuation rate of 14,000
- Inward the same serial number ABC again with a rate of 4,000
- Outward transaction for the same serial number with a valuation rate of 4,000

At this point, the incoming rate stored in the serial number becomes 4,000.

If reposting is performed from the second transaction, the valuation rate is calculated incorrectly:

- Inward serial number ABC with a rate of 14,000
- Outward transaction for the same serial number with a valuation rate of 4,000 (**Incorrect**)
- Inward the same serial number ABC with a rate of 4,000
- Outward transaction for the same serial number with a valuation rate of 4,000

The valuation rate in the second row should be 14,000, not 4,000.

This issue affects legacy serial numbers created before Version 15, when the Serial and Batch Bundle feature was not available.

Solution

For legacy serial numbers, provide an option to fetch the incoming rate either:

- From the Serial Number record or
- From the last inward transaction during reposting.
<img width="1038" height="348" alt="Screenshot 2026-05-15 at 1 56 36 PM" src="https://github.com/user-attachments/assets/265e51e5-5d61-441b-a5e8-df05a84b806f" />

docs https://docs.frappe.io/erpnext/stock-reposting-settings#issue-for-legacy-serial-numbers
