### PR TITLE
fix(report): format Deferred Revenue and Expense chart tooltips as currency

### DIFF
--- a/erpnext/accounts/report/deferred_revenue_and_expense/deferred_revenue_and_expense.py
+++ b/erpnext/accounts/report/deferred_revenue_and_expense/deferred_revenue_and_expense.py
@@ -6,6 +6,7 @@ from frappe import _, qb
 from frappe.query_builder import Column, functions
 from frappe.utils import add_days, date_diff, flt, get_first_day, get_last_day, getdate, rounded
 
+from erpnext import get_company_currency
 from erpnext.accounts.report.financial_statements import get_period_list
 from erpnext.accounts.utils import get_fiscal_year
 
@@ -469,6 +470,11 @@ class Deferred_Revenue_and_Expense_Report:
 			chart["data"]["datasets"].append(
 				{"name": _("Expected"), "chartType": "line", "values": [x.total for x in self.period_total]}
 			)
+
+		company_currency = get_company_currency(self.filters.company)
+		chart["fieldtype"] = "Currency"
+		chart["options"] = "currency"
+		chart["currency"] = company_currency
 
 		return chart
 


### PR DESCRIPTION
Chart tooltips in the **Deferred Revenue and Expense** report showed raw numeric values instead of formatted currency amounts.

The report grid already defines amount columns as `Currency`. The chart returned from `prepare_chart()` did not include the metadata Frappe uses to format tooltip values (`fieldtype`, `options`, `currency`), unlike other account reports (Profit and Loss, Balance Sheet, Cash Flow).

### Changes

- Set `fieldtype`, `options`, and `currency` on the chart dict in `prepare_chart()`
- Resolve currency via `get_company_currency(self.filters.company)` from the report’s company filter

**File changed:** `erpnext/accounts/report/deferred_revenue_and_expense/deferred_revenue_and_expense.py`

### Before / After

<img width="398" height="337" alt="Screenshot 2026-05-15 at 15 24 13" src="https://github.com/user-attachments/assets/9dc7fb06-ebb8-4851-94e3-99da5639f665" />

> Before

<img width="410" height="339" alt="Screenshot 2026-05-15 at 15 23 14" src="https://github.com/user-attachments/assets/9de2a9cc-d39f-4a5f-863e-1dbf16acaf2d" />

> After

### Steps to reproduce (before fix)

1. Open **Accounting → Reports → Deferred Revenue and Expense**
2. Select a company with deferred revenue/expense data and run the report
3. Ensure **Show with upcoming revenue/expense** is checked so the chart is visible
4. Hover over a bar/line point — tooltip shows unformatted numbers

### Test plan

- [ ] Open Deferred Revenue and Expense for a company with deferred items
- [ ] Run for **Revenue** and **Expense** with chart enabled
- [ ] Confirm chart tooltips show formatted currency for the selected company
- [ ] Confirm grid amount/period columns still display correctly

> No server-side tests we made, as UI/chart metadata change only, existing report tests unchanged.

### Checklist

- [x] Business logic on server-side only
- [x] Single focused change (chart metadata only)
- [x] Screenshots/GIF attached
- [x] No documentation update required (behaviour matches other financial reports)