### PR TITLE
feat: added cost of goods sold

### DIFF
--- a/erpnext/accounts/doctype/account/chart_of_accounts/verified/philippines.json
+++ b/erpnext/accounts/doctype/account/chart_of_accounts/verified/philippines.json
@@ -570,7 +570,6 @@
 			"account_number": "5000",
 			"is_group": 1,
 			"root_type": "Expense",
-
 			"Cost of Goods Sold": {
 				"account_number": "5001",
 				"is_group": 1,

--- a/erpnext/accounts/doctype/account/chart_of_accounts/verified/philippines.json
+++ b/erpnext/accounts/doctype/account/chart_of_accounts/verified/philippines.json
@@ -570,6 +570,18 @@
 			"account_number": "5000",
 			"is_group": 1,
 			"root_type": "Expense",
+
+			"Cost of Goods Sold": {
+				"account_number": "5001",
+				"is_group": 1,
+				"root_type": "Expense",
+				"Cost of Goods Sold": {
+					"account_number": "5010",
+					"is_group": 0,
+					"root_type": "Expense",
+					"account_type": "Cost of Goods Sold"
+				}
+			},
 			"Operating Expenses": {
 				"account_number": "5100",
 				"is_group": 1,


### PR DESCRIPTION
<!--
Some key notes before you open a PR:
 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes
Also, if you're new here
- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation
- Contribution Guide => https://github.com/frappe/erpnext/blob/develop/.github/CONTRIBUTING.md
- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist
-->
> Please provide enough information so that others can review your pull request:
This PR adds a missing `Cost of Goods Sold` account to the Philippines Chart of Accounts JSON to ensure the default expense account is auto-selected during company setup.
<!-- You can skip this if you're fixing a typo or updating existing documentation -->
> Explain the **details** for making this change. What existing problem does the pull request solve?
The Philippines Chart of Accounts was missing an account with `account_type` set to `"Cost of Goods Sold"`.
As a result, during company setup, the default expense account is not auto-selected, requiring users to manually select one later in order to complete transactions.
This change adds a `Cost of Goods Sold` group (account number `5001`) and leaf account (account number `5010`) with `"account_type": "Cost of Goods Sold"` under the `Expense` section, before `Operating Expenses`.
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
*Documentation*
- Chart of Accounts updated as a verified JSON under ERPNext
- Documentation Link: https://docs.google.com/document/d/13b3-i82yuILM_Yxc5_NDW4ioUfVYYTcwLO6VBU7SFng/edit?usp=sharing
> Screenshots/GIFs
<!-- Add images/recordings to better visualize the change: expected/current behviour -->
N/A — data-only change to the Philippines Chart of Accounts JSON template. No UI changes.
<!-- no-docs -->