### PR TITLE
fix(stock): apply posting datetime filters while fetching available batches

### DIFF
--- a/erpnext/controllers/queries.py
+++ b/erpnext/controllers/queries.py
@@ -17,6 +17,7 @@ from pypika import Order
 import erpnext
 from erpnext.accounts.utils import build_qb_match_conditions
 from erpnext.stock.get_item_details import ItemDetailsCtx, _get_item_tax_template
+from erpnext.stock.utils import get_combine_datetime
 
 
 # searches for active employees
@@ -498,6 +499,13 @@ def get_batches_from_stock_ledger_entries(searchfields, txt, filters, start=0, p
 		.limit(page_len)
 	)
 
+	if not filters.get("is_inward"):
+		if filters.get("posting_date") and filters.get("posting_time"):
+			query = query.where(
+				stock_ledger_entry.posting_datetime
+				<= get_combine_datetime(filters.posting_date, filters.posting_time)
+			)
+
 	if not filters.get("include_expired_batches"):
 		query = query.where((batch_table.expiry_date >= expiry_date) | (batch_table.expiry_date.isnull()))
 
@@ -550,6 +558,13 @@ def get_batches_from_serial_and_batch_bundle(searchfields, txt, filters, start=0
 		.offset(start)
 		.limit(page_len)
 	)
+
+	if not filters.get("is_inward"):
+		if filters.get("posting_date") and filters.get("posting_time"):
+			bundle_query = bundle_query.where(
+				stock_ledger_entry.posting_datetime
+				<= get_combine_datetime(filters.posting_date, filters.posting_time)
+			)
 
 	if not filters.get("include_expired_batches"):
 		bundle_query = bundle_query.where(

--- a/erpnext/public/js/utils/serial_no_batch_selector.js
+++ b/erpnext/public/js/utils/serial_no_batch_selector.js
@@ -484,6 +484,8 @@ erpnext.SerialBatchPackageSelector = class SerialNoBatchBundleUpdate {
 								warehouse:
 									this.item.s_warehouse || this.item.t_warehouse || this.item.warehouse,
 								is_inward: is_inward,
+								posting_date: this.frm.doc.posting_date,
+								posting_time: this.frm.doc.posting_time,
 								include_expired_batches: include_expired_batches,
 							},
 						};


### PR DESCRIPTION
**Issue:**
For outward transactions, on loading the Serial and Batch Selector, the system fetches the available batches based on the posting date and posting time. However, in the Batch link field dropdown, only a few batches are shown because the posting date filter is not applied there.

As a result, batches that are consumed in future transactions are excluded from the dropdown, even though they were available on the selected posting date. The dropdown should respect the posting date and display batches based on availability as of that posting date.

**Ref:** [#68169](https://support.frappe.io/helpdesk/tickets/68169)

**Before:**
<img width="852" height="807" alt="image" src="https://github.com/user-attachments/assets/7d2cf561-407a-4ef6-bbf6-52fd7945a0f4" />

**After:**
<img width="881" height="794" alt="image" src="https://github.com/user-attachments/assets/b40e63ef-b3b2-4920-a1e1-37d0e99cef23" />


**Backport Needed for v15 & v16**