### PR TITLE
fix: remove inspection_required filter from item_query in Quality Inspection

### DIFF
--- a/erpnext/stock/doctype/quality_inspection/quality_inspection.py
+++ b/erpnext/stock/doctype/quality_inspection/quality_inspection.py
@@ -392,25 +392,6 @@ def item_query(doctype, txt, searchfield, start, page_len, filters):
 					["items.t_warehouse", "is", "not set"],
 				]
 			)
-		elif filters.get("inspection_type") != "In Process":
-			my_filters.extend(
-				[
-					"and",
-					[
-						"items.item_code",
-						"in",
-						frappe.get_list(
-							"Item",
-							filters={
-								"inspection_required_before_purchase"
-								if filters.get("inspection_type") == "Incoming"
-								else "inspection_required_before_delivery": 1
-							},
-							pluck="name",
-						),
-					],
-				]
-			)
 
 		return frappe.get_query(
 			reference_doctype,


### PR DESCRIPTION
Items were not showing in Item Code field when creating Quality Inspection
against a Delivery Note because the query was filtering items by
inspection_required_before_delivery flag on the Item master.

Fixes #54981