### PR TITLE
feat: add party groups functionality to party specific item

### DIFF
--- a/erpnext/controllers/queries.py
+++ b/erpnext/controllers/queries.py
@@ -198,15 +198,27 @@ def item_query(
 
 	if filters and isinstance(filters, dict):
 		if filters.get("customer") or filters.get("supplier"):
+			party_type = "Customer" if filters.get("customer") else "Supplier"
 			party = filters.get("customer") or filters.get("supplier")
+			group = "Customer Group" if filters.get("customer") else "Supplier Group"
 			item_rules_list = frappe.get_all(
 				"Party Specific Item",
 				filters={
 					"party": ["!=", party],
-					"party_type": "Customer" if filters.get("customer") else "Supplier",
+					"party_type": party_type,
 				},
 				fields=["restrict_based_on", "based_on_value"],
 			)
+
+			party_group_rules_list = frappe.get_all(
+				"Party Specific Item",
+				filters={"party_type": group},
+				fields=["party as party_group", "restrict_based_on", "based_on_value"],
+			)
+			current_party_group = frappe.get_value(party_type, party, frappe.scrub(group))
+			for rule in party_group_rules_list:
+				if current_party_group != rule.party_group:
+					item_rules_list.append(rule)
 
 			filters_dict = {}
 			for rule in item_rules_list:

--- a/erpnext/selling/doctype/party_specific_item/party_specific_item.js
+++ b/erpnext/selling/doctype/party_specific_item/party_specific_item.js
@@ -2,6 +2,21 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on("Party Specific Item", {
-	// refresh: function(frm) {
-	// }
+	setup: function (frm) {
+		frm.trigger("party_type");
+	},
+
+	party_type: function (frm) {
+		if (["Customer Group", "Supplier Group"].includes(frm.doc.party_type)) {
+			frm.set_query("party", function () {
+				return {
+					filters: {
+						is_group: 0,
+					},
+				};
+			});
+		} else {
+			frm.set_query("party", null);
+		}
+	},
 });

--- a/erpnext/selling/doctype/party_specific_item/party_specific_item.json
+++ b/erpnext/selling/doctype/party_specific_item/party_specific_item.json
@@ -1,5 +1,6 @@
 {
  "actions": [],
+ "allow_bulk_edit": 1,
  "allow_import": 1,
  "creation": "2021-08-27 19:28:07.559978",
  "doctype": "DocType",
@@ -18,7 +19,7 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Party Type",
-   "options": "Customer\nSupplier",
+   "options": "Customer\nCustomer Group\nSupplier\nSupplier Group",
    "reqd": 1
   },
   {
@@ -52,7 +53,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-03-27 13:10:08.752476",
+ "modified": "2026-05-17 11:46:17.634855",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Party Specific Item",
@@ -71,6 +72,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],

--- a/erpnext/selling/doctype/party_specific_item/party_specific_item.py
+++ b/erpnext/selling/doctype/party_specific_item/party_specific_item.py
@@ -17,7 +17,7 @@ class PartySpecificItem(Document):
 
 		based_on_value: DF.DynamicLink
 		party: DF.DynamicLink
-		party_type: DF.Literal["Customer", "Supplier"]
+		party_type: DF.Literal["Customer", "Customer Group", "Supplier", "Supplier Group"]
 		restrict_based_on: DF.Literal["Item", "Item Group", "Brand"]
 	# end: auto-generated types
 

--- a/erpnext/selling/doctype/party_specific_item/test_party_specific_item.py
+++ b/erpnext/selling/doctype/party_specific_item/test_party_specific_item.py
@@ -49,6 +49,23 @@ class TestPartySpecificItem(ERPNextTestSuite):
 		)
 		self.assertTrue(item in flatten(items))
 
+	def test_party_group(self):
+		customer = "_Test Customer With Template"
+		item = "_Test Item"
+		frappe.set_value("Customer", customer, "customer_group", "Government")
+
+		create_party_specific_item(
+			party_type="Customer Group",
+			party="Government",
+			restrict_based_on="Item",
+			based_on_value=item,
+		)
+		filters = {"is_sales_item": 1, "customer": customer}
+		items = item_query(
+			doctype="Item", txt="", searchfield="name", start=0, page_len=20, filters=filters, as_dict=False
+		)
+		self.assertTrue(item in flatten(items))
+
 
 def flatten(lst):
 	result = []


### PR DESCRIPTION
resolves #54987 

Note: there is no server side validation for party specific items, meaning one can change the party to an eligible one for X item, set the item_code and then switch to an ineligible party and save, no error will be thrown