### PR TITLE
fix(regional): Japanese CT Rate

### DIFF
--- a/erpnext/setup/setup_wizard/data/country_wise_tax.json
+++ b/erpnext/setup/setup_wizard/data/country_wise_tax.json
@@ -4221,7 +4221,8 @@
 	"Japan": {
 		"Japan Tax 10%": {
 			"account_name": "CT 10%",
-			"tax_rate": 10.00
+			"tax_rate": 10.00,
+			"default": 1
 		},
 		"Japan Tax 8%": {
 			"account_name": "CT 8%",

--- a/erpnext/setup/setup_wizard/data/country_wise_tax.json
+++ b/erpnext/setup/setup_wizard/data/country_wise_tax.json
@@ -4219,9 +4219,13 @@
 	},
 
 	"Japan": {
-		"Japan Tax": {
+		"Japan Tax 10%": {
 			"account_name": "CT",
-			"tax_rate": 5.00
+			"tax_rate": 10.00
+		},
+		"Japan Tax 8%": {
+			"account_name": "CT",
+			"tax_rate": 8.00
 		}
 	},
 

--- a/erpnext/setup/setup_wizard/data/country_wise_tax.json
+++ b/erpnext/setup/setup_wizard/data/country_wise_tax.json
@@ -4220,11 +4220,11 @@
 
 	"Japan": {
 		"Japan Tax 10%": {
-			"account_name": "CT",
+			"account_name": "CT 10%",
 			"tax_rate": 10.00
 		},
 		"Japan Tax 8%": {
-			"account_name": "CT",
+			"account_name": "CT 8%",
 			"tax_rate": 8.00
 		}
 	},


### PR DESCRIPTION
Since 1 October 2019, Japanese CT rate changed to 10%, but some products, such as foods, remained 8%.

The document from National Tax Agency
- https://www.nta.go.jp/taxes/shiraberu/taxanswer/shohi/6303.htm

<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/erpnext/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->
