### PR TITLE
fix: set general ledger from date to fiscal year start

### DIFF
--- a/erpnext/accounts/report/general_ledger/general_ledger.js
+++ b/erpnext/accounts/report/general_ledger/general_ledger.js
@@ -21,7 +21,7 @@ frappe.query_reports["General Ledger"] = {
 			fieldname: "from_date",
 			label: __("From Date"),
 			fieldtype: "Date",
-			default: frappe.datetime.add_months(frappe.datetime.get_today(), -1),
+			default: frappe.datetime.get_today(),
 			reqd: 1,
 			width: "60px",
 		},
@@ -235,3 +235,19 @@ frappe.query_reports["General Ledger"] = {
 };
 
 erpnext.utils.add_dimensions("General Ledger", 15);
+
+frappe.query_reports["General Ledger"].onload = function(report) {
+	frappe.call({
+		method: "erpnext.accounts.utils.get_fiscal_year",
+		args: {
+			date: frappe.datetime.get_today(),
+			company: report.get_filter_value("company")
+		},
+		callback: function(r) {
+			if (r.message) {
+				report.set_filter_value("from_date", r.message[1]);
+				report.set_filter_value("to_date", frappe.datetime.get_today());
+			}
+		}
+	});
+};

--- a/erpnext/accounts/report/general_ledger/general_ledger.js
+++ b/erpnext/accounts/report/general_ledger/general_ledger.js
@@ -1,5 +1,20 @@
 // Copyright (c) 2018, Frappe Technologies Pvt. Ltd. and Contributors
 // License: GNU General Public License v3. See license.txt
+function set_fiscal_year_dates(report) {
+	frappe.call({
+		method: "erpnext.accounts.utils.get_fiscal_year",
+		args: {
+			date: frappe.datetime.get_today(),
+			company: report.get_filter_value("company")
+		},
+		callback: function(r) {
+			if (r.message) {
+				report.set_filter_value("from_date", r.message[1]);
+				report.set_filter_value("to_date", frappe.datetime.get_today());
+			}
+		}
+	});
+}
 
 frappe.query_reports["General Ledger"] = {
 	filters: [
@@ -10,6 +25,8 @@ frappe.query_reports["General Ledger"] = {
 			options: "Company",
 			default: frappe.defaults.get_user_default("Company"),
 			reqd: 1,
+			on_change: function(report) {
+	        set_fiscal_year_dates(report);},
 		},
 		{
 			fieldname: "finance_book",
@@ -237,17 +254,5 @@ frappe.query_reports["General Ledger"] = {
 erpnext.utils.add_dimensions("General Ledger", 15);
 
 frappe.query_reports["General Ledger"].onload = function(report) {
-	frappe.call({
-		method: "erpnext.accounts.utils.get_fiscal_year",
-		args: {
-			date: frappe.datetime.get_today(),
-			company: report.get_filter_value("company")
-		},
-		callback: function(r) {
-			if (r.message) {
-				report.set_filter_value("from_date", r.message[1]);
-				report.set_filter_value("to_date", frappe.datetime.get_today());
-			}
-		}
-	});
+	set_fiscal_year_dates(report);
 };


### PR DESCRIPTION
## Issue

The General Ledger report currently defaults the `from_date` filter to one month before today, which is not aligned with standard accounting workflows.

## Fix

Updated the report to dynamically fetch the fiscal year start date using `erpnext.accounts.utils.get_fiscal_year()` and use it as the default `from_date`.

## Result

* `from_date` defaults to the fiscal year start date
* `to_date` defaults to today's date
* supports company-specific fiscal years
