### PR TITLE
fix: prevent duplicate task execution and timestamp error in transaction deletion

### DIFF
--- a/erpnext/setup/doctype/company/company.py
+++ b/erpnext/setup/doctype/company/company.py
@@ -1087,7 +1087,6 @@ def create_transaction_deletion_request(company: str):
 	tdr.reload()
 
 	tdr.submit()
-	tdr.start_deletion_tasks()
 
 	frappe.msgprint(
 		_("Transaction Deletion Document {0} has been triggered for company {1}").format(

--- a/erpnext/setup/doctype/transaction_deletion_record/test_transaction_deletion_record.py
+++ b/erpnext/setup/doctype/transaction_deletion_record/test_transaction_deletion_record.py
@@ -396,7 +396,6 @@ def create_and_submit_transaction_deletion_doc(company):
 
 	tdr.process_in_single_transaction = True
 	tdr.submit()
-	tdr.start_deletion_tasks()
 	return tdr
 
 

--- a/erpnext/setup/doctype/transaction_deletion_record/transaction_deletion_record.py
+++ b/erpnext/setup/doctype/transaction_deletion_record/transaction_deletion_record.py
@@ -738,10 +738,11 @@ class TransactionDeletionRecord(Document):
 				self.enqueue_task(task="Clear Notifications")
 				return
 
-			company_obj = frappe.get_doc("Company", self.company)
-			company_obj.total_monthly_sales = 0
-			company_obj.sales_monthly_history = None
-			company_obj.save()
+			frappe.db.set_value(
+				"Company",
+				self.company,
+				{"total_monthly_sales": 0, "sales_monthly_history": None},
+			)
 			self.db_set("reset_company_default_values_status", "Completed")
 		self.enqueue_task(task="Clear Notifications")
 


### PR DESCRIPTION
## Summary

- Remove redundant `start_deletion_tasks()` call in `create_transaction_deletion_request` (`company.py`). `on_submit` already invokes it, so the explicit call causes **two parallel background task chains** to race on the Company doc save and corrupt the TDR status — triggering the "not running" validation error during the Clear Notifications task on non-demo companies.
- Replace `company_obj.save()` with `frappe.db.set_value` in `reset_company_values`. The full `save()` triggers Frappe's timestamp concurrency check; if the Company doc is modified between load and save (common with demo-data background jobs), a `TimestampMismatchError` is thrown and the deletion fails.

Fixes #54968