### PR TITLE
fix: use route_options for Credit Note and Debit Note sidebar links

### DIFF
--- a/erpnext/workspace_sidebar/invoicing.json
+++ b/erpnext/workspace_sidebar/invoicing.json
@@ -80,14 +80,13 @@
   {
    "child": 1,
    "collapsible": 1,
-   "filters": "[[\"Sales Invoice\",\"is_return\",\"=\",1]]",
    "icon": "",
    "indent": 0,
    "keep_closed": 0,
    "label": "Credit Note",
    "link_to": "Sales Invoice",
    "link_type": "DocType",
-   "route_options": "",
+   "route_options": "{\"is_return\": 1}",
    "show_arrow": 0,
    "type": "Link"
   },
@@ -139,12 +138,12 @@
   {
    "child": 1,
    "collapsible": 1,
-   "filters": "[[\"Purchase Invoice\",\"is_return\",\"=\",1]]",
    "indent": 0,
    "keep_closed": 0,
    "label": "Debit Note",
    "link_to": "Purchase Invoice",
    "link_type": "DocType",
+   "route_options": "{\"is_return\": 1}",
    "show_arrow": 0,
    "type": "Link"
   },


### PR DESCRIPTION
## Summary

- Replaces `filters` with `route_options` for Credit Note and Debit Note entries in the Invoicing sidebar
- `filters` with `["=", value]` format produces a broken URL `?is_return=%3D%2C1` instead of `?is_return=1`
- `route_options: {"is_return": 1}` generates the correct URL directly

## Root Cause

The sidebar `get_path()` logic converts `filters` via `get_filter_as_json`, which produces `{is_return: ["=", 1]}`. When this is passed to `generate_route`, `.toString()` on the array `["=", 1]` yields `"=,1"`, which gets URL-encoded to `%3D%2C1`.

Using `route_options` with a plain key-value object bypasses this conversion entirely.

Fixes https://github.com/frappe/erpnext/issues/55018