### PR TITLE
fix: search translated UOM labels in get_item_uom_query

### DIFF
--- a/erpnext/controllers/queries.py
+++ b/erpnext/controllers/queries.py
@@ -3,6 +3,7 @@
 
 
 import json
+import re
 from collections import OrderedDict, defaultdict
 
 import frappe
@@ -1031,29 +1032,32 @@ def get_filtered_child_rows(
 @frappe.validate_and_sanitize_search_inputs
 def get_item_uom_query(doctype: str, txt: str, searchfield: str, start: int, page_len: int, filters: dict):
 	if frappe.get_single_value("Stock Settings", "allow_uom_with_conversion_rate_defined_in_item"):
-		query_filters = {"parent": filters.get("item_code")}
-
-		if txt:
-			query_filters["uom"] = ["like", f"%{txt}%"]
-
-		return frappe.get_all(
+		results = frappe.get_all(
 			"UOM Conversion Detail",
-			filters=query_filters,
+			filters={"parent": filters.get("item_code")},
 			fields=["uom", "conversion_factor"],
-			limit_start=start,
-			limit_page_length=page_len,
 			order_by="idx",
 			as_list=1,
 		)
 
-	return frappe.get_all(
+		if txt:
+			results = [
+				row for row in results if re.search(re.escape(txt), frappe._(row[0]) or "", re.IGNORECASE)
+			]
+
+		return results[start : start + page_len]
+
+	results = frappe.get_all(
 		"UOM",
-		filters={"name": ["like", f"%{txt}%"], "enabled": 1},
+		filters={"enabled": 1},
 		fields=["name"],
-		limit_start=start,
-		limit_page_length=page_len,
 		as_list=1,
 	)
+
+	if txt:
+		results = [row for row in results if re.search(re.escape(txt), frappe._(row[0]) or "", re.IGNORECASE)]
+
+	return results[start : start + page_len]
 
 
 @frappe.whitelist()


### PR DESCRIPTION
## Summary

- `UOM` is a `translated_doctype`, so users in non-English locales see translated labels (e.g. `Stk` instead of `Nos` in German)
- The previous `get_item_uom_query` filtered UOMs with a DB `LIKE` on the internal name, which never matched translated labels
- Fix: fetch all candidate UOMs without a DB-level text filter, then filter in Python using `frappe._()` so translated labels are matched — the same approach Frappe's standard link search uses for `translated_doctype`

## Steps to reproduce (before fix)

1. Set user language to German
2. Open a Sales Order and add an item whose UOM is `Nos` (shown as `Stk` in German)
3. Click the UOM field in the item row and type `Stk`
4. **Expected:** `Nos` (shown as `Stk`) is returned — **Actual:** nothing found

Fixes https://github.com/frappe/erpnext/issues/54996