### PR TITLE
fix: handle None delivery_date when sorting MPS data

### DIFF
--- a/erpnext/manufacturing/doctype/master_production_schedule/master_production_schedule.py
+++ b/erpnext/manufacturing/doctype/master_production_schedule/master_production_schedule.py
@@ -289,7 +289,7 @@ class MasterProductionSchedule(Document):
 		return item_wise_data
 
 	def add_mps_data(self, data):
-		data = frappe._dict(sorted(data.items(), key=lambda x: x[0][1]))
+		data = frappe._dict(sorted(data.items(), key=lambda x: x[0][1] or ""))
 
 		for key in data:
 			row = data[key]


### PR DESCRIPTION
## Summary

Fixes a `TypeError: '<' not supported between instances of 'NoneType' and 'NoneType'` crash when running **Get Items For Master Production Schedule** on an item with no delivery date.

## Root Cause

`add_mps_data` sorts the data dict by `delivery_date` (the second element of each key tuple). When an item has no delivery date set, the key contains `None`, and Python's sort cannot compare `None < None`.

## Fix

Use `or ""` as a fallback so `None` dates are treated as empty strings during sorting.

Fixes https://github.com/frappe/erpnext/issues/55019