### PR TITLE
fix: warn when accounting dimension fieldname conflicts with existing fields

### DIFF
--- a/erpnext/accounts/doctype/accounting_dimension/accounting_dimension.py
+++ b/erpnext/accounts/doctype/accounting_dimension/accounting_dimension.py
@@ -43,6 +43,7 @@ class AccountingDimension(Document):
 	def validate(self):
 		self.validate_doctype()
 		validate_column_name(self.fieldname)
+		self.validate_fieldname_conflict()
 		self.validate_dimension_defaults()
 
 	def validate_doctype(self):
@@ -73,6 +74,27 @@ class AccountingDimension(Document):
 			message = _("Cannot change Reference Document Type.")
 			message += _("Please create a new Accounting Dimension if required.")
 			frappe.throw(message)
+
+	def validate_fieldname_conflict(self):
+		conflicting_doctypes = []
+		for doctype in get_doctypes_with_dimensions():
+			meta = frappe.get_meta(doctype, cached=False)
+			if any(f.fieldname == self.fieldname for f in meta.get("fields")):
+				conflicting_doctypes.append(doctype)
+
+		if conflicting_doctypes:
+			frappe.msgprint(
+				_(
+					"Fieldname {0} already exists in the following doctypes: {1}. "
+					"A separate dimension field will not be added to these doctypes. "
+					"GL Entries will use the value of the existing field as the dimension value."
+				).format(
+					frappe.bold(self.fieldname),
+					", ".join(frappe.bold(d) for d in conflicting_doctypes),
+				),
+				title=_("Fieldname Conflict"),
+				indicator="orange",
+			)
 
 	def validate_dimension_defaults(self):
 		companies = []


### PR DESCRIPTION
## Summary

When an Accounting Dimension is created with a fieldname that already exists in one of the target doctypes (e.g., creating a \"Supplier\" dimension generates fieldname `supplier`, which conflicts with the existing `supplier` field on Purchase Invoice), the system silently skips creating the custom field with no feedback to the user.

This leads to two confusing outcomes:
- The dimension field doesn't appear in the form for the conflicting doctypes
- GL Entries are silently tagged using the value of the existing field as the dimension value (since `self.get(fieldname)` reads whatever field exists with that name)

**Fix:** Add `validate_fieldname_conflict` to show an orange warning listing the conflicting doctypes and explaining that GL Entries will use the existing field's value as the dimension value.

Fixes #54801