### PR TITLE
fix: item leaderboard uses Sales/Purchase Invoice instead of Orders

### DIFF
--- a/erpnext/startup/leaderboard.py
+++ b/erpnext/startup/leaderboard.py
@@ -88,7 +88,7 @@ def get_all_customers(date_range, company, field, limit=None):
 
 
 @frappe.whitelist()
-def get_all_items(date_range, company, field, limit=None):
+def get_all_items(date_range: str, company: str, field: str, limit: int | None = None):
 	if field in ("available_stock_qty", "available_stock_value"):
 		select_field = "sum(actual_qty)" if field == "available_stock_qty" else "sum(stock_value)"
 		results = frappe.db.get_all(
@@ -103,21 +103,21 @@ def get_all_items(date_range, company, field, limit=None):
 	else:
 		if field == "total_sales_amount":
 			select_field = "base_net_amount"
-			select_doctype = "Sales Order"
+			select_doctype = "Sales Invoice"
 		elif field == "total_purchase_amount":
 			select_field = "base_net_amount"
-			select_doctype = "Purchase Order"
+			select_doctype = "Purchase Invoice"
 		elif field == "total_qty_sold":
 			select_field = "stock_qty"
-			select_doctype = "Sales Order"
+			select_doctype = "Sales Invoice"
 		elif field == "total_qty_purchased":
 			select_field = "stock_qty"
-			select_doctype = "Purchase Order"
+			select_doctype = "Purchase Invoice"
 
 		filters = [["docstatus", "=", "1"], ["company", "=", company]]
 		from_date, to_date = parse_date_range(date_range)
 		if from_date and to_date:
-			filters.append(["transaction_date", "between", [from_date, to_date]])
+			filters.append(["posting_date", "between", [from_date, to_date]])
 
 		child_doctype = f"{select_doctype} Item"
 		return frappe.get_list(


### PR DESCRIPTION
Fixes https://github.com/frappe/erpnext/issues/46657

## Root cause

`get_all_items` was querying **Sales Order** / **Purchase Order** filtered by `transaction_date` for the `total_sales_amount`, `total_qty_sold`, `total_purchase_amount`, and `total_qty_purchased` fields.

When a user creates invoices directly (without a corresponding order — a very common workflow), the ordered quantity and amount are zero, so the item never appears in any date-filtered leaderboard view. The "All time" view appeared to work because it skips the date filter entirely, returning whatever orders happen to exist.

## Fix

Query **Sales Invoice** / **Purchase Invoice** instead, and filter by `posting_date` (the date field on invoices). Invoices represent the actual completed transaction and exist regardless of whether a Sales/Purchase Order was raised.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated item-level metrics calculation to use finalized invoice data instead of orders, ensuring accurate representation of completed sales and purchases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/frappe/erpnext/pull/55038?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->