### PR TITLE
fix(manufacturing): allow to edit batch size while creating a work order

### DIFF
--- a/erpnext/manufacturing/doctype/bom_operation/bom_operation.json
+++ b/erpnext/manufacturing/doctype/bom_operation/bom_operation.json
@@ -1,5 +1,6 @@
 {
  "actions": [],
+ "allow_bulk_edit": 1,
  "creation": "2013-02-22 01:27:49",
  "doctype": "DocType",
  "document_type": "Setup",
@@ -139,11 +140,13 @@
    "label": "Image"
   },
   {
+   "default": "1",
    "fetch_from": "operation.batch_size",
    "fetch_if_empty": 1,
    "fieldname": "batch_size",
-   "fieldtype": "Int",
-   "label": "Batch Size"
+   "fieldtype": "Float",
+   "label": "Batch Size",
+   "non_negative": 1
   },
   {
    "depends_on": "eval:doc.parenttype == \"Routing\" || !parent.routing",
@@ -304,7 +307,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-04-01 17:09:48.771834",
+ "modified": "2026-05-25 17:15:42.044630",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "BOM Operation",

--- a/erpnext/manufacturing/doctype/bom_operation/bom_operation.py
+++ b/erpnext/manufacturing/doctype/bom_operation/bom_operation.py
@@ -18,7 +18,7 @@ class BOMOperation(Document):
 		base_cost_per_unit: DF.Float
 		base_hour_rate: DF.Currency
 		base_operating_cost: DF.Currency
-		batch_size: DF.Int
+		batch_size: DF.Float
 		bom_no: DF.Link | None
 		cost_per_unit: DF.Float
 		description: DF.TextEditor | None

--- a/erpnext/manufacturing/doctype/work_order/test_work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/test_work_order.py
@@ -4225,6 +4225,7 @@ class TestWorkOrder(ERPNextTestSuite):
 			"operations",
 			{
 				"operation": fg_operation.name,
+				"batch_size": fg_operation.batch_size,
 				"time_in_mins": 60,
 				"workstation": workstation.name,
 			},
@@ -4233,6 +4234,7 @@ class TestWorkOrder(ERPNextTestSuite):
 		fg_bom.items[0].bom_no = subassembly_bom.name
 		fg_bom.save()
 		fg_bom.submit()
+		self.assertEqual(fg_bom.operations[0].batch_size, 25)
 
 		wo_order = make_wo_order_test_record(
 			item=fg_item.name,

--- a/erpnext/manufacturing/doctype/work_order/work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/work_order.py
@@ -202,7 +202,7 @@ class WorkOrder(Document):
 		self.calculate_operating_cost()
 		self.validate_qty()
 		self.validate_transfer_against()
-		self.validate_operation_time()
+		self.validate_operations()
 		self.status = self.get_status()
 		self.validate_workstation_type()
 		self.reset_use_multi_level_bom()
@@ -1499,8 +1499,11 @@ class WorkOrder(Document):
 				title=_("Missing value"),
 			)
 
-	def validate_operation_time(self):
+	def validate_operations(self):
 		for d in self.operations:
+			if not d.batch_size or d.batch_size <= 0:
+				d.batch_size = 1
+
 			if d.time_in_mins <= 0:
 				frappe.throw(_("Operation Time must be greater than 0 for Operation {0}").format(d.operation))
 

--- a/erpnext/manufacturing/doctype/work_order_operation/work_order_operation.json
+++ b/erpnext/manufacturing/doctype/work_order_operation/work_order_operation.json
@@ -196,10 +196,11 @@
    "read_only": 1
   },
   {
+   "default": "1",
    "fieldname": "batch_size",
    "fieldtype": "Float",
    "label": "Batch Size",
-   "read_only": 1
+   "non_negative": 1
   },
   {
    "fieldname": "sequence_id",
@@ -316,7 +317,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-05-20 13:01:21.827200",
+ "modified": "2026-05-25 17:15:12.038470",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "Work Order Operation",


### PR DESCRIPTION
**Issue:**
The system currently considers the Batch Size defined in the BOM Operation, but it does not allow users to edit the Batch Size while creating a work order.

Because of this limitation, whenever a user wants to change the Batch Size, they are forced to create a new BOM each time. Instead, the system should allow editing the Batch Size in the work order.

**Backport Needed for v15 & v16** 