### PR TITLE
feat: Set weight in new items in so update_child_qty_rate

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -4169,6 +4169,12 @@ def update_child_qty_rate(
 
 		validate_quantity_and_rate(child_item, d)
 
+		if d.get("__islocal"):
+			child_item.weight_per_unit = frappe.db.get_value(
+				"Item", d.get("item_code"), "weight_per_unit"
+			) or 0
+			child_item.total_weight = d.get("qty", 0) * child_item.weight_per_unit
+
 		if flt(child_item.get("qty")) != flt(d.get("qty")):
 			any_qty_changed = True
 


### PR DESCRIPTION
In a Sales Order, when we click in "Update Items" button and add a new item with weight, the weight is not set in the Sales Order Item row.

## How to Simulate

1. Set the Weight Per Unit in a item
<img width="1900" height="880" alt="image" src="https://github.com/user-attachments/assets/401190d1-6409-4524-b092-957ceca978fb" />
2. In a submitted Sales Order, click at "Update Items" button
<img width="1425" height="848" alt="image" src="https://github.com/user-attachments/assets/5cc549a3-8f30-4205-99e4-62befbdd0e5d" />
3. Add a new item in the order in this Dialog
<img width="1240" height="447" alt="image" src="https://github.com/user-attachments/assets/0d6c5ad0-b87a-4119-8524-ee40facb854d" />
4. Check that the weight is not updated currently
<img width="933" height="837" alt="image" src="https://github.com/user-attachments/assets/94dd791f-3b4f-47a9-98cf-79aa7f03c143" />
Consequently, the total weight in the order is also not updated:
<img width="1077" height="390" alt="image" src="https://github.com/user-attachments/assets/37918130-ef44-49a2-9fe6-ea5d869bf681" />
