### PR TITLE
feat(stock): add setting to keep unchanged rows in Stock Reconciliation

### DIFF
--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -482,3 +482,4 @@ erpnext.patches.v16_0.scr_inv_dimension
 erpnext.patches.v16_0.packed_item_inv_dimen
 erpnext.patches.v16_0.set_not_applicable_on_german_item_tax_templates
 erpnext.patches.v16_0.clear_procedures_from_receivable_report
+erpnext.patches.v16_0.set_remove_unchanged_stock_reconciliation_entries

--- a/erpnext/patches/v16_0/set_remove_unchanged_stock_reconciliation_entries.py
+++ b/erpnext/patches/v16_0/set_remove_unchanged_stock_reconciliation_entries.py
@@ -1,0 +1,9 @@
+import frappe
+
+
+def execute():
+	frappe.db.set_single_value(
+		"Stock Settings",
+		"remove_unchanged_stock_reconciliation_entries",
+		1,
+	)

--- a/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py
+++ b/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py
@@ -488,6 +488,10 @@ class StockReconciliation(StockController):
 		"""Remove items if qty or rate is not changed"""
 		self.difference_amount = 0.0
 
+		remove_unchanged = frappe.db.get_single_value(
+			"Stock Settings", "remove_unchanged_stock_reconciliation_entries"
+		)
+
 		def _changed(item):
 			if item.current_serial_and_batch_bundle:
 				bundle_data = frappe.get_all(
@@ -535,6 +539,7 @@ class StockReconciliation(StockController):
 				(item.qty is None or item.qty == item_dict.get("qty"))
 				and (valuation_rate is None or valuation_rate == rate)
 				and (not item.serial_no or (item.serial_no == item_dict.get("serial_nos")))
+				and remove_unchanged
 			):
 				return False
 			else:
@@ -806,11 +811,23 @@ class StockReconciliation(StockController):
 
 			self.make_sl_entries(sl_entries, allow_negative_stock=allow_negative_stock)
 		elif self.docstatus == 1:
-			frappe.throw(
-				_(
-					"No stock ledger entries were created. Please set the quantity or valuation rate for the items properly and try again."
-				)
+			remove_unchanged = frappe.db.get_single_value(
+				"Stock Settings", "remove_unchanged_stock_reconciliation_entries"
 			)
+			if not remove_unchanged:
+				frappe.throw(
+					_(
+						"Cannot submit Stock Reconciliation: no items have any change in quantity or value, "
+						"so no stock ledger entries would be created."
+					)
+				)
+			else:
+				frappe.throw(
+					_(
+						"No stock ledger entries were created. Please set the quantity or valuation rate "
+						"for the items properly and try again."
+					)
+				)
 
 	def make_adjustment_entry(self, row, sl_entries):
 		from erpnext.stock.stock_ledger import get_stock_value_difference

--- a/erpnext/stock/doctype/stock_reconciliation/test_stock_reconciliation.py
+++ b/erpnext/stock/doctype/stock_reconciliation/test_stock_reconciliation.py
@@ -1841,32 +1841,22 @@ class TestStockReconciliation(ERPNextTestSuite, StockTestMixin):
 
 		self.assertEqual(frappe.get_value("Serial No", serial_no, "status"), "Delivered")
 
+	@ERPNextTestSuite.change_settings("Stock Settings", {"remove_unchanged_stock_reconciliation_entries": 0})
 	def test_unchanged_rows_kept_when_setting_disabled(self):
 		item_code = self.make_item().name
 
 		create_stock_reconciliation(item_code=item_code, qty=10, rate=100)
 
-		frappe.db.set_single_value(
-			"Stock Settings",
-			"remove_unchanged_stock_reconciliation_entries",
-			0,
-		)
-
-		sr2 = create_stock_reconciliation(item_code=item_code, qty=10, rate=100, do_not_submit=True)
+		sr = create_stock_reconciliation(item_code=item_code, qty=10, rate=100, do_not_submit=True)
 
 		# If the setting is disabled, we expect the stock reconciliation to still have the entry.
-		self.assertEqual(len(sr2.items), 1)
+		self.assertEqual(len(sr.items), 1)
 
+	@ERPNextTestSuite.change_settings("Stock Settings", {"remove_unchanged_stock_reconciliation_entries": 1})
 	def test_unchanged_rows_removed_when_setting_enabled(self):
 		item_code = self.make_item().name
 
 		create_stock_reconciliation(item_code=item_code, qty=10, rate=100)
-
-		frappe.db.set_single_value(
-			"Stock Settings",
-			"remove_unchanged_stock_reconciliation_entries",
-			1,
-		)
 
 		# If the setting is enabled, we expect the stock reconciliation to end up empty
 		# because all entries have unchanged values.
@@ -1878,16 +1868,11 @@ class TestStockReconciliation(ERPNextTestSuite, StockTestMixin):
 			rate=100,
 		)
 
+	@ERPNextTestSuite.change_settings("Stock Settings", {"remove_unchanged_stock_reconciliation_entries": 0})
 	def test_unchanged_only_reco_cannot_be_submitted(self):
 		item_code = self.make_item().name
 
 		create_stock_reconciliation(item_code=item_code, qty=10, rate=100)
-
-		frappe.db.set_single_value(
-			"Stock Settings",
-			"remove_unchanged_stock_reconciliation_entries",
-			0,
-		)
 
 		sr = create_stock_reconciliation(item_code=item_code, qty=10, rate=100, do_not_submit=True)
 

--- a/erpnext/stock/doctype/stock_reconciliation/test_stock_reconciliation.py
+++ b/erpnext/stock/doctype/stock_reconciliation/test_stock_reconciliation.py
@@ -1841,6 +1841,59 @@ class TestStockReconciliation(ERPNextTestSuite, StockTestMixin):
 
 		self.assertEqual(frappe.get_value("Serial No", serial_no, "status"), "Delivered")
 
+	def test_unchanged_rows_kept_when_setting_disabled(self):
+		item_code = self.make_item().name
+
+		create_stock_reconciliation(item_code=item_code, qty=10, rate=100)
+
+		frappe.db.set_single_value(
+			"Stock Settings",
+			"remove_unchanged_stock_reconciliation_entries",
+			0,
+		)
+
+		sr2 = create_stock_reconciliation(item_code=item_code, qty=10, rate=100, do_not_submit=True)
+
+		# If the setting is disabled, we expect the stock reconciliation to still have the entry.
+		self.assertEqual(len(sr2.items), 1)
+
+	def test_unchanged_rows_removed_when_setting_enabled(self):
+		item_code = self.make_item().name
+
+		create_stock_reconciliation(item_code=item_code, qty=10, rate=100)
+
+		frappe.db.set_single_value(
+			"Stock Settings",
+			"remove_unchanged_stock_reconciliation_entries",
+			1,
+		)
+
+		# If the setting is enabled, we expect the stock reconciliation to end up empty
+		# because all entries have unchanged values.
+		self.assertRaises(
+			EmptyStockReconciliationItemsError,
+			create_stock_reconciliation,
+			item_code=item_code,
+			qty=10,
+			rate=100,
+		)
+
+	def test_unchanged_only_reco_cannot_be_submitted(self):
+		item_code = self.make_item().name
+
+		create_stock_reconciliation(item_code=item_code, qty=10, rate=100)
+
+		frappe.db.set_single_value(
+			"Stock Settings",
+			"remove_unchanged_stock_reconciliation_entries",
+			0,
+		)
+
+		sr = create_stock_reconciliation(item_code=item_code, qty=10, rate=100, do_not_submit=True)
+
+		# Submitting with unchanged rows only is not supported and should throw a descriptive error.
+		self.assertRaises(frappe.ValidationError, sr.submit)
+
 
 def create_batch_item_with_batch(item_name, batch_id):
 	batch_item_doc = create_item(item_name, is_stock_item=1)

--- a/erpnext/stock/doctype/stock_settings/stock_settings.json
+++ b/erpnext/stock/doctype/stock_settings/stock_settings.json
@@ -25,6 +25,8 @@
   "allow_to_edit_stock_uom_qty_for_purchase",
   "section_break_ylhd",
   "allow_uom_with_conversion_rate_defined_in_item",
+  "column_break_udpi",
+  "remove_unchanged_stock_reconciliation_entries",
   "stock_validations_tab",
   "section_break_9",
   "over_delivery_receipt_allowance",
@@ -532,6 +534,17 @@
    "fieldname": "enable_serial_and_batch_no_for_item",
    "fieldtype": "Check",
    "label": "Activate Serial / Batch No for Item"
+  },
+  {
+   "fieldname": "column_break_udpi",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "1",
+   "description": "If enabled, Stock Reconciliation item rows with no changes in quantity from the current stock will be removed on save.",
+   "fieldname": "remove_unchanged_stock_reconciliation_entries",
+   "fieldtype": "Check",
+   "label": "Remove Unchanged Stock Reconciliation Entries"
   }
  ],
  "icon": "icon-cog",
@@ -539,7 +552,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2026-04-14 13:51:49.545114",
+ "modified": "2026-05-19 16:29:58.147812",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Stock Settings",

--- a/erpnext/stock/doctype/stock_settings/stock_settings.json
+++ b/erpnext/stock/doctype/stock_settings/stock_settings.json
@@ -541,7 +541,7 @@
   },
   {
    "default": "1",
-   "description": "If enabled, Stock Reconciliation item rows with no changes in quantity from the current stock will be removed on save.",
+   "description": "If enabled, Stock Reconciliation item rows with no changes in quantity or valuation rate from current stock will be removed on save.",
    "fieldname": "remove_unchanged_stock_reconciliation_entries",
    "fieldtype": "Check",
    "label": "Remove Unchanged Stock Reconciliation Entries"

--- a/erpnext/stock/doctype/stock_settings/stock_settings.py
+++ b/erpnext/stock/doctype/stock_settings/stock_settings.py
@@ -54,6 +54,7 @@ class StockSettings(Document):
 		over_delivery_receipt_allowance: DF.Float
 		over_picking_allowance: DF.Percent
 		pick_serial_and_batch_based_on: DF.Literal["FIFO", "LIFO", "Expiry"]
+		remove_unchanged_stock_reconciliation_entries: DF.Check
 		reorder_email_notify: DF.Check
 		role_allowed_to_create_edit_back_dated_transactions: DF.Link | None
 		role_allowed_to_over_deliver_receive: DF.Link | None


### PR DESCRIPTION
> Please provide enough information so that others can review your pull request:

This PR adds a checkbox in `Stock Settings` that defaults to `1`. When checked, the current v16 behavior is maintained: all rows for unchanged item quantities are removed when a Stock Reconciliation is saved. When unchecked, this does not happen and the document can be saved with unchanged row entries. It remains impossible to submit the document without any SLEs, and a new error message is provided to cover the specific case where all rows are for unchanged stock values.

> Explain the **details** for making this change. What existing problem does the pull request solve?

[This post](https://discuss.frappe.io/t/stock-reconciliation-stop-removing-items-with-no-change/78303) explains the issue well, but I will reiterate here: It can be important to know that stock was *counted* during a Stock Reconciliation, even if that stock was not changed.

> Screenshots/GIFs

<img width="1202" height="744" alt="image" src="https://github.com/user-attachments/assets/1671850d-fda8-4e08-9b7a-957692442996" />
<img width="574" height="135" alt="image" src="https://github.com/user-attachments/assets/618bd604-268d-4849-9ee9-6c52e3130cdd" />

Closes #14853

I would also like to have this feature backported to the next v16 hotfix (if possible), though I am unsure how that process works. Thanks!