### PR TITLE
fix: replace payment term outstanding with outstanding amount while f…

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -1975,9 +1975,10 @@ class PaymentEntry(AccountsController):
 		# allocate amount based on `paid_amount` is changed or not
 		if not paid_amount_change:
 			for ref in self.references:
+				row_outstanding = ref.payment_term_outstanding if ref.payment_term else ref.outstanding_amount
 				allocated_positive_outstanding, allocated_negative_outstanding = _allocation_to_unset_pr_row(
 					ref,
-					ref.outstanding_amount,
+					row_outstanding,
 					allocated_positive_outstanding,
 					allocated_negative_outstanding,
 				)
@@ -2525,9 +2526,7 @@ def get_split_invoice_rows(invoice: dict, payment_term_template: str, exc_rates:
 					"voucher_type": invoice.voucher_type,
 					"posting_date": invoice.posting_date,
 					"invoice_amount": flt(invoice.invoice_amount),
-					"outstanding_amount": payment_term_outstanding
-					if payment_term_outstanding
-					else invoice.outstanding_amount,
+					"outstanding_amount": invoice.outstanding_amount,
 					"payment_term_outstanding": payment_term_outstanding,
 					"payment_amount": payment_term.payment_amount,
 					"payment_term": payment_term.payment_term,


### PR DESCRIPTION
**Issue Ref**: [#52548 ](https://github.com/frappe/erpnext/issues/52548)

**Description**: While fetching outstanding invoices in payment entry, the outstanding amount is wrongly calculated (fetching the payment term outstanding) for the invoice row with payment terms in the payment reference table

Below is the Payment Schedule of invoice with payment terms
<img width="822" height="256" alt="image" src="https://github.com/user-attachments/assets/2e890f33-b728-4551-a494-b0a87f8c3625" />


**Before**: 
<img width="839" height="355" alt="Screenshot from 2026-05-08 19-01-48_spotlight" src="https://github.com/user-attachments/assets/aea9456c-3d24-4cdf-8c6b-76ce5b891240" />

**After**: 
<img width="1118" height="266" alt="Screenshot from 2026-05-08 19-09-02_spotlight" src="https://github.com/user-attachments/assets/4bbaf325-72d4-495c-9aa6-6169ba83b37e" />

Backport needed in V15