### PR TITLE
fix: populate actual_qty when adding order lines via Update Items

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -73,6 +73,7 @@ from erpnext.stock.get_item_details import (
 	ItemDetailsCtx,
 	_get_item_tax_template,
 	_get_item_tax_template_from_item_group,
+	get_bin_details,
 	get_conversion_factor,
 	get_item_details,
 	get_item_tax_map,
@@ -3769,7 +3770,28 @@ def set_order_defaults(parent_doctype, parent_doctype_name, child_doctype, child
 
 	set_child_tax_template_and_map(item, child_item, p_doc)
 	add_taxes_from_tax_template(child_item, p_doc)
+	set_bin_details_on_child_item(child_item, item, p_doc.company)
 	return child_item
+
+
+def set_bin_details_on_child_item(child_item, item, company):
+	if not item.is_stock_item or not child_item.warehouse:
+		return
+
+	child_meta = child_item.meta
+	if not child_meta.has_field("actual_qty"):
+		return
+
+	bin_details = get_bin_details(
+		child_item.item_code,
+		child_item.warehouse,
+		company,
+		include_child_warehouses=True,
+	)
+	child_item.actual_qty = flt(bin_details.get("actual_qty"))
+
+	if child_meta.has_field("projected_qty"):
+		child_item.projected_qty = flt(bin_details.get("projected_qty"))
 
 
 def validate_child_on_delete(row, parent, ordered_item=None):

--- a/erpnext/selling/doctype/sales_order/test_sales_order.py
+++ b/erpnext/selling/doctype/sales_order/test_sales_order.py
@@ -572,6 +572,12 @@ class TestSalesOrder(ERPNextTestSuite):
 		self.assertEqual(so.get("items")[-1].qty, 7)
 		self.assertEqual(so.get("items")[-1].amount, 1400)
 
+		new_item = so.get("items")[-1]
+		bin_actual_qty = get_bin_details(
+			new_item.item_code, new_item.warehouse, so.company, include_child_warehouses=True
+		).get("actual_qty", 0)
+		self.assertEqual(flt(new_item.actual_qty), flt(bin_actual_qty))
+
 		# reserved qty should increase after adding row
 		self.assertEqual(get_reserved_qty("_Test Item 2"), reserved_qty_for_second_item + 7)
 


### PR DESCRIPTION
closes #55070


## Summary

When adding item rows on a submitted order via **Update Items**, `actual_qty` was never set on the new child row (stayed 0). The item indicator then showed insufficient stock even when the warehouse had stock.

## Changes

- Set `actual_qty` (and `projected_qty` where present) from `get_bin_details()` in `set_order_defaults()` for new rows created by `update_child_qty_rate()`.
- Extend `test_update_child_adding_new_item` to assert `actual_qty` matches bin stock.

## Checklist

1. **Base branch:** `develop`
2. **Title:** `fix: set actual_qty for items added via Update Items after submit`
3. **Tests:** Unit test updated; manual SO verification done. <!-- add: full suite run if you did it -->
4. **Server-side:** Yes — logic in `accounts_controller.py` only.
5. **Docs:** Not required for this bug fix.
6. **Issue:** #55070

## How to test

1. Create and submit a Sales Order with stock in the default warehouse.
2. **Update Items** → add a new item line → Update.
3. Confirm **Qty (Warehouse)** matches bin stock and item indicator is correct (green when ordered qty ≤ available).

<img width="1929" height="962" alt="Screenshot from 2026-05-20 09-41-18" src="https://github.com/user-attachments/assets/c5467e06-9c30-49df-8d50-f79b52708710" />
<img width="1929" height="962" alt="Screenshot from 2026-05-20 09-40-49" src="https://github.com/user-attachments/assets/283e45b6-c1d3-4322-af65-570b50191829" />

Supersedes #55069 (previous PR had unrelated commits).