### PR TITLE
fix(manufacturing): fetch from_bom name in production plan

### DIFF
--- a/erpnext/manufacturing/doctype/production_plan/production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.py
@@ -1314,6 +1314,7 @@ def get_exploded_items(item_details, company, bom_no, include_non_stock_items, p
 			item_uom.conversion_factor,
 			item.safety_stock,
 			bom.item.as_("main_bom_item"),
+			bom.name.as_("main_bom"),
 		)
 		.where(
 			(bei.docstatus < 2)
@@ -1383,6 +1384,7 @@ def get_subitems(
 			item.purchase_uom,
 			item_uom.conversion_factor,
 			bom.item.as_("main_bom_item"),
+			bom.name.as_("main_bom"),
 			bom_item.is_phantom_item,
 		)
 		.where(


### PR DESCRIPTION
Issue: Production Plan throws a mandatory field validation error for raw materials when Reserve Stock is enabled.

Ref : [#68556](https://support.frappe.io/helpdesk/tickets/68556)

Description: When creating a Production Plan with the "Reserve Stock" option enabled, the system throws the following error while generating raw materials:
**Mandatory fields required in table Raw Materials, Row 1 From BOM**
The issue occurs because the from_bom field is not populated for raw material entries.

Before  : 

[Screencast from 20-05-26 01:35:23 PM IST.webm](https://github.com/user-attachments/assets/5acd253f-74b6-4127-99b3-0f69671d9e44)


After : 

[Screencast from 20-05-26 01:33:31 PM IST.webm](https://github.com/user-attachments/assets/e4654dfa-850f-4b63-9f7b-ca12fcddb8f5)

Backport Needed For V16 and V15