### PR TITLE
fix: incorrect error message string in sales order

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -454,7 +454,7 @@ class SalesOrder(SellingController):
 				and not cint(d.delivered_by_supplier)
 			):
 				frappe.throw(
-					_("Delivery warehouse required for stock item {0}").format(d.item_code), WarehouseRequired
+					_("Source warehouse required for stock item {0}").format(d.item_code), WarehouseRequired
 				)
 
 	def validate_with_previous_doc(self):


### PR DESCRIPTION
Before:

<img width="1375" height="697" alt="Screenshot 2026-05-20 at 1 15 25 PM" src="https://github.com/user-attachments/assets/69595447-a05f-4a12-8d63-9c0cd3ac57c6" />

After:

<img width="1101" height="378" alt="Screenshot 2026-05-20 at 2 19 15 PM" src="https://github.com/user-attachments/assets/40c091df-6bd3-4c97-a9a1-ac252278a5b9" />
