### PR TITLE
fix: handle blank rows in financial statement formatter

### DIFF
--- a/erpnext/accounts/report/cash_flow/cash_flow.py
+++ b/erpnext/accounts/report/cash_flow/cash_flow.py
@@ -132,7 +132,14 @@ def execute(filters=None):
 		)
 
 	net_change_in_cash = add_total_row_account(
-		data, data, _("Net Change in Cash"), period_list, company_currency, summary_data, filters
+		data,
+		data,
+		_("Net Change in Cash"),
+		period_list,
+		company_currency,
+		summary_data,
+		filters,
+		add_blank_row=False,
 	)
 
 	if filters.show_opening_and_closing_balance:
@@ -250,7 +257,17 @@ def get_start_date(period, accumulated_values, company):
 	return start_date
 
 
-def add_total_row_account(out, data, label, period_list, currency, summary_data, filters, consolidated=False):
+def add_total_row_account(
+	out,
+	data,
+	label,
+	period_list,
+	currency,
+	summary_data,
+	filters,
+	consolidated=False,
+	add_blank_row=True,
+):
 	total_row = {
 		"section_name": "'" + _("{0}").format(label) + "'",
 		"section": "'" + _("{0}").format(label) + "'",
@@ -275,7 +292,9 @@ def add_total_row_account(out, data, label, period_list, currency, summary_data,
 			total_row["total"] += row["total"]
 
 	out.append(total_row)
-	out.append({})
+
+	if add_blank_row:
+		out.append({})
 
 	return total_row
 

--- a/erpnext/public/js/financial_statements.js
+++ b/erpnext/public/js/financial_statements.js
@@ -15,6 +15,8 @@ erpnext.financial_statements = {
 	},
 
 	formatter: function (value, row, column, data, default_formatter, filter) {
+		if (erpnext.financial_statements._is_separator_row(data)) return "";
+
 		const report_params = [value, row, column, data, default_formatter, filter];
 		// Growth/Margin
 		if (erpnext.financial_statements._is_special_view(column, data))
@@ -23,6 +25,10 @@ erpnext.financial_statements = {
 		if (get_filter_value("report_template"))
 			return erpnext.financial_statements._format_custom_report(...report_params);
 		else return erpnext.financial_statements._format_standard_report(...report_params);
+	},
+
+	_is_separator_row: function (data) {
+		return data && !data.account && !data.account_name && !data.section_name;
 	},
 
 	_is_special_view: function (column, data) {

--- a/erpnext/public/js/financial_statements.js
+++ b/erpnext/public/js/financial_statements.js
@@ -15,7 +15,7 @@ erpnext.financial_statements = {
 	},
 
 	formatter: function (value, row, column, data, default_formatter, filter) {
-		if (erpnext.financial_statements._is_separator_row(data)) return "";
+		if (erpnext.financial_statements.is_blank_row(data)) return "";
 
 		const report_params = [value, row, column, data, default_formatter, filter];
 		// Growth/Margin
@@ -27,8 +27,15 @@ erpnext.financial_statements = {
 		else return erpnext.financial_statements._format_standard_report(...report_params);
 	},
 
-	_is_separator_row: function (data) {
-		return data && !data.account && !data.account_name && !data.section_name;
+	is_blank_row: function (data) {
+		return (
+			data &&
+			!data.account &&
+			!data.accounts &&
+			!data.child_accounts &&
+			!data.account_name &&
+			!data.section_name
+		);
 	},
 
 	_is_special_view: function (column, data) {


### PR DESCRIPTION
<details>
<summary>Issue 1: Blank rows getting formatted</summary>

## Before

<img width="564" height="529" alt="image" src="https://github.com/user-attachments/assets/c79764c7-854f-4cda-9b26-0e4a70a9b63f" />

## After

<img width="611" height="533" alt="image" src="https://github.com/user-attachments/assets/01052a9c-7209-4691-bb68-8528ed1656c8" />

</details> 

---

<details>
<summary>Issue 2:  Cash flow have extra blank row</summary>

## Before

<img width="556" height="712" alt="image" src="https://github.com/user-attachments/assets/95a8de4b-c36f-48f2-b23e-611d32ac067b" />


## After

<img width="570" height="670" alt="image" src="https://github.com/user-attachments/assets/7c55fbf2-c9b1-4324-bdd8-729ead70c29e" />


</details> 

---


- `no-docs`

> [!NOTE]
> Backport to V-16