### PR TITLE
fix: add custom dimensions filters in Gross and Net profit report

### DIFF
--- a/erpnext/accounts/report/gross_and_net_profit_report/gross_and_net_profit_report.js
+++ b/erpnext/accounts/report/gross_and_net_profit_report/gross_and_net_profit_report.js
@@ -1,9 +1,13 @@
 // Copyright (c) 2016, Frappe Technologies Pvt. Ltd. and contributors
 // For license information, please see license.txt
 
-frappe.query_reports["Gross and Net Profit Report"] = $.extend({}, erpnext.financial_statements);
+const GNP_REPORT = "Gross and Net Profit Report";
 
-frappe.query_reports["Gross and Net Profit Report"]["filters"].push({
+frappe.query_reports[GNP_REPORT] = $.extend({}, erpnext.financial_statements);
+
+erpnext.utils.add_dimensions(GNP_REPORT, 10);
+
+frappe.query_reports[GNP_REPORT]["filters"].push({
 	fieldname: "accumulated_values",
 	label: __("Accumulated Values"),
 	fieldtype: "Check",


### PR DESCRIPTION
## Before

<img width="1878" height="295" alt="image" src="https://github.com/user-attachments/assets/b01ef0a0-af1c-4c81-a341-b612a67a4caf" />

## After

<img width="1845" height="369" alt="image" src="https://github.com/user-attachments/assets/56a30af8-b890-493e-9f5b-15d1cbed70c3" />

> [!NOTE]
> Backport to V-16