### PR TITLE
fix(manufacturing): remove forecast_qty and adjust_qty fields from sa…

### DIFF
--- a/erpnext/manufacturing/doctype/sales_forecast/sales_forecast.js
+++ b/erpnext/manufacturing/doctype/sales_forecast/sales_forecast.js
@@ -47,11 +47,3 @@ frappe.ui.form.on("Sales Forecast", {
 		}
 	},
 });
-
-frappe.ui.form.on("Sales Forecast Item", {
-	adjust_qty(frm, cdt, cdn) {
-		let row = locals[cdt][cdn];
-		row.demand_qty = row.forecast_qty + row.adjust_qty;
-		frappe.model.set_value(cdt, cdn, "demand_qty", row.demand_qty);
-	},
-});

--- a/erpnext/manufacturing/doctype/sales_forecast_item/sales_forecast_item.json
+++ b/erpnext/manufacturing/doctype/sales_forecast_item/sales_forecast_item.json
@@ -10,8 +10,6 @@
   "item_name",
   "uom",
   "delivery_date",
-  "forecast_qty",
-  "adjust_qty",
   "demand_qty",
   "warehouse"
  ],
@@ -56,22 +54,6 @@
    "read_only": 1
   },
   {
-   "columns": 2,
-   "fieldname": "forecast_qty",
-   "fieldtype": "Float",
-   "in_list_view": 1,
-   "label": "Forecast Qty",
-   "non_negative": 1,
-   "read_only": 1
-  },
-  {
-   "columns": 2,
-   "fieldname": "adjust_qty",
-   "fieldtype": "Float",
-   "in_list_view": 1,
-   "label": "Adjust Qty"
-  },
-  {
    "columns": 3,
    "fieldname": "demand_qty",
    "fieldtype": "Float",
@@ -94,7 +76,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-08-18 21:59:38.859082",
+ "modified": "2026-05-21 12:38:47.636301",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "Sales Forecast Item",

--- a/erpnext/manufacturing/doctype/sales_forecast_item/sales_forecast_item.py
+++ b/erpnext/manufacturing/doctype/sales_forecast_item/sales_forecast_item.py
@@ -14,10 +14,8 @@ class SalesForecastItem(Document):
 	if TYPE_CHECKING:
 		from frappe.types import DF
 
-		adjust_qty: DF.Float
 		delivery_date: DF.Date | None
 		demand_qty: DF.Float
-		forecast_qty: DF.Float
 		item_code: DF.Link
 		item_name: DF.Data | None
 		parent: DF.Data


### PR DESCRIPTION
Description:
The Forecast Quantity and Adjust Quantity fields were not used anywhere, so they have been removed.

Ref : [#68746](https://support.frappe.io/helpdesk/tickets/68746)

Backport Needed For V16