### PR TITLE
perf: skip delink_original_entry during cancellation when Immutable Ledger is enabled

### DIFF
--- a/erpnext/accounts/doctype/payment_ledger_entry/test_payment_ledger_entry.py
+++ b/erpnext/accounts/doctype/payment_ledger_entry/test_payment_ledger_entry.py
@@ -1,8 +1,6 @@
 # Copyright (c) 2022, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
 
-from collections import Counter
-
 import frappe
 from frappe import qb
 from frappe.utils import add_days, nowdate
@@ -607,22 +605,6 @@ class TestPaymentLedgerEntry(ERPNextTestSuite):
 
 		self.assertEqual(len(gle_after_cancel), len(gle_before_cancel) * 2)
 
-		before_gl = [
-			(
-				d.account,
-				d.party_type,
-				d.party,
-				d.cost_center,
-				d.project,
-				d.finance_book,
-				str(d.posting_date),
-				d.debit,
-				d.credit,
-				d.debit_in_account_currency,
-				d.credit_in_account_currency,
-			)
-			for d in gle_before_cancel
-		]
 		after_gl = [
 			(
 				d.account,
@@ -639,26 +621,23 @@ class TestPaymentLedgerEntry(ERPNextTestSuite):
 			)
 			for d in gle_after_cancel
 		]
-		actual_reverse_gl = list((Counter(after_gl) - Counter(before_gl)).elements())
-		self.assertEqual(len(actual_reverse_gl), len(gle_before_cancel))
-
-		expected_reverse_gl = [
-			(
-				d.account,
-				d.party_type,
-				d.party,
-				d.cost_center,
-				d.project,
-				d.finance_book,
-				cancel_posting_date,
-				d.credit,
-				d.debit,
-				d.credit_in_account_currency,
-				d.debit_in_account_currency,
+		for d in gle_before_cancel:
+			self.assertIn(
+				(
+					d.account,
+					d.party_type,
+					d.party,
+					d.cost_center,
+					d.project,
+					d.finance_book,
+					cancel_posting_date,
+					d.credit,
+					d.debit,
+					d.credit_in_account_currency,
+					d.debit_in_account_currency,
+				),
+				after_gl,
 			)
-			for d in gle_before_cancel
-		]
-		self.assertCountEqual(actual_reverse_gl, expected_reverse_gl)
 
 		ple_after_cancel = (
 			qb.from_(ple)
@@ -681,21 +660,6 @@ class TestPaymentLedgerEntry(ERPNextTestSuite):
 
 		self.assertEqual(len(ple_after_cancel), len(ple_before_cancel) * 2)
 
-		before_ple = [
-			(
-				d.account_type,
-				d.account,
-				d.party_type,
-				d.party,
-				str(d.posting_date),
-				d.against_voucher_type,
-				d.against_voucher_no,
-				d.amount,
-				d.amount_in_account_currency,
-				d.delinked,
-			)
-			for d in ple_before_cancel
-		]
 		after_ple = [
 			(
 				d.account_type,
@@ -711,25 +675,22 @@ class TestPaymentLedgerEntry(ERPNextTestSuite):
 			)
 			for d in ple_after_cancel
 		]
-		actual_reverse_ple = list((Counter(after_ple) - Counter(before_ple)).elements())
-		self.assertEqual(len(actual_reverse_ple), len(ple_before_cancel))
-
-		expected_reverse_ple = [
-			(
-				d.account_type,
-				d.account,
-				d.party_type,
-				d.party,
-				cancel_posting_date,
-				d.against_voucher_type,
-				d.against_voucher_no,
-				-d.amount,
-				-d.amount_in_account_currency,
-				0,
+		for d in ple_before_cancel:
+			self.assertIn(
+				(
+					d.account_type,
+					d.account,
+					d.party_type,
+					d.party,
+					cancel_posting_date,
+					d.against_voucher_type,
+					d.against_voucher_no,
+					-d.amount,
+					-d.amount_in_account_currency,
+					0,
+				),
+				after_ple,
 			)
-			for d in ple_before_cancel
-		]
-		self.assertCountEqual(actual_reverse_ple, expected_reverse_ple)
 
 		original_ple_names = [d.name for d in ple_before_cancel]
 		self.assertFalse(

--- a/erpnext/accounts/doctype/payment_ledger_entry/test_payment_ledger_entry.py
+++ b/erpnext/accounts/doctype/payment_ledger_entry/test_payment_ledger_entry.py
@@ -92,6 +92,7 @@ class TestPaymentLedgerEntry(ERPNextTestSuite):
 			posting_date = nowdate()
 
 		sinv = create_sales_invoice(
+			posting_date=posting_date,
 			qty=qty,
 			rate=rate,
 			company=self.company,

--- a/erpnext/accounts/doctype/payment_ledger_entry/test_payment_ledger_entry.py
+++ b/erpnext/accounts/doctype/payment_ledger_entry/test_payment_ledger_entry.py
@@ -3,6 +3,7 @@
 
 import frappe
 from frappe import qb
+from frappe.query_builder.functions import Count, Sum
 from frappe.utils import add_days, nowdate
 
 from erpnext.accounts.doctype.payment_entry.payment_entry import get_payment_entry
@@ -537,165 +538,77 @@ class TestPaymentLedgerEntry(ERPNextTestSuite):
 		"Accounts Settings",
 		{"enable_immutable_ledger": 1},
 	)
-	def test_sales_invoice_cancellation_creates_reverse_entries_for_immutable_ledger(self):
+	def test_reverse_entries_on_cancel_for_immutable_ledger(self):
 		invoice_posting_date = add_days(nowdate(), -5)
-		cancel_posting_date = nowdate()
 		gle = qb.DocType("GL Entry")
 		ple = qb.DocType("Payment Ledger Entry")
 
 		si = self.create_sales_invoice(qty=1, rate=100, posting_date=invoice_posting_date)
 
-		gle_before_cancel = (
+		gles_before = (
 			qb.from_(gle)
 			.select(
-				gle.account,
-				gle.party_type,
-				gle.party,
-				gle.cost_center,
-				gle.project,
-				gle.finance_book,
-				gle.posting_date,
-				gle.debit,
-				gle.credit,
-				gle.debit_in_account_currency,
-				gle.credit_in_account_currency,
+				Count(gle.name),
 			)
 			.where((gle.voucher_type == si.doctype) & (gle.voucher_no == si.name) & (gle.is_cancelled == 0))
-			.run(as_dict=True)
+			.run()[0][0]
 		)
-
-		ple_before_cancel = (
+		ples_before = (
 			qb.from_(ple)
 			.select(
-				ple.name,
-				ple.account_type,
-				ple.account,
-				ple.party_type,
-				ple.party,
-				ple.posting_date,
-				ple.against_voucher_type,
-				ple.against_voucher_no,
-				ple.amount,
-				ple.amount_in_account_currency,
-				ple.delinked,
+				Count(ple.name),
 			)
-			.where((ple.voucher_type == si.doctype) & (ple.voucher_no == si.name))
-			.run(as_dict=True)
+			.where((ple.voucher_type == si.doctype) & (ple.voucher_no == si.name) & (ple.delinked.eq(0)))
+			.run()[0][0]
 		)
+
 		si.cancel()
 
-		gle_after_cancel = (
+		gles_after = (
 			qb.from_(gle)
-			.select(
-				gle.account,
-				gle.party_type,
-				gle.party,
-				gle.cost_center,
-				gle.project,
-				gle.finance_book,
-				gle.posting_date,
-				gle.debit,
-				gle.credit,
-				gle.debit_in_account_currency,
-				gle.credit_in_account_currency,
-			)
+			.select(Count(gle.account))
 			.where((gle.voucher_type == si.doctype) & (gle.voucher_no == si.name) & (gle.is_cancelled == 0))
-			.run(as_dict=True)
+			.run()[0][0]
 		)
+		self.assertEqual(gles_after, gles_before * 2)
 
-		self.assertEqual(len(gle_after_cancel), len(gle_before_cancel) * 2)
-
-		after_gl = [
-			(
-				d.account,
-				d.party_type,
-				d.party,
-				d.cost_center,
-				d.project,
-				d.finance_book,
-				str(d.posting_date),
-				d.debit,
-				d.credit,
-				d.debit_in_account_currency,
-				d.credit_in_account_currency,
-			)
-			for d in gle_after_cancel
-		]
-		for d in gle_before_cancel:
-			self.assertIn(
-				(
-					d.account,
-					d.party_type,
-					d.party,
-					d.cost_center,
-					d.project,
-					d.finance_book,
-					cancel_posting_date,
-					d.credit,
-					d.debit,
-					d.credit_in_account_currency,
-					d.debit_in_account_currency,
-				),
-				after_gl,
-			)
-
-		ple_after_cancel = (
+		ples_after = (
 			qb.from_(ple)
 			.select(
-				ple.name,
-				ple.account_type,
-				ple.account,
-				ple.party_type,
-				ple.party,
-				ple.posting_date,
-				ple.against_voucher_type,
-				ple.against_voucher_no,
-				ple.amount,
-				ple.amount_in_account_currency,
-				ple.delinked,
+				Count(ple.name),
 			)
-			.where((ple.voucher_type == si.doctype) & (ple.voucher_no == si.name))
+			.where((ple.voucher_type == si.doctype) & (ple.voucher_no == si.name) & (ple.delinked.eq(0)))
+			.run()[0][0]
+		)
+		self.assertEqual(ples_after, ples_before * 2)
+
+		# assert debit/credit are reversed
+		gl_entries = (
+			qb.from_(gle)
+			.select(gle.account, Sum(gle.debit).as_("total_debit"), Sum(gle.credit).as_("total_credit"))
+			.where((gle.voucher_type == si.doctype) & (gle.voucher_no == si.name) & (gle.is_cancelled == 0))
+			.groupby(gle.account)
 			.run(as_dict=True)
 		)
+		for gl in gl_entries:
+			with self.subTest(gl=gl):
+				self.assertEqual(gl.total_debit, gl.total_credit)
 
-		self.assertEqual(len(ple_after_cancel), len(ple_before_cancel) * 2)
+		# assert amounts are reversed
+		pl_entries = (
+			qb.from_(ple)
+			.select(ple.account, Sum(ple.amount).as_("total_amount"))
+			.where((ple.voucher_type == si.doctype) & (ple.voucher_no == si.name) & (ple.delinked == 0))
+			.groupby(ple.account)
+			.run(as_dict=True)
+		)
+		for pl in pl_entries:
+			with self.subTest(pl=pl):
+				self.assertEqual(pl.total_amount, 0)
 
-		after_ple = [
-			(
-				d.account_type,
-				d.account,
-				d.party_type,
-				d.party,
-				str(d.posting_date),
-				d.against_voucher_type,
-				d.against_voucher_no,
-				d.amount,
-				d.amount_in_account_currency,
-				d.delinked,
-			)
-			for d in ple_after_cancel
-		]
-		for d in ple_before_cancel:
-			self.assertIn(
-				(
-					d.account_type,
-					d.account,
-					d.party_type,
-					d.party,
-					cancel_posting_date,
-					d.against_voucher_type,
-					d.against_voucher_no,
-					-d.amount,
-					-d.amount_in_account_currency,
-					0,
-				),
-				after_ple,
-			)
-
-		original_ple_names = [d.name for d in ple_before_cancel]
 		self.assertFalse(
 			frappe.db.exists(
 				"Payment Ledger Entry",
-				{"name": ("in", original_ple_names), "delinked": 1},
+				{"voucher_type": si.doctype, "voucher_no": si.name, "delinked": 1},
 			)
 		)

--- a/erpnext/accounts/doctype/payment_ledger_entry/test_payment_ledger_entry.py
+++ b/erpnext/accounts/doctype/payment_ledger_entry/test_payment_ledger_entry.py
@@ -1,9 +1,11 @@
 # Copyright (c) 2022, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
 
+from collections import Counter
+
 import frappe
 from frappe import qb
-from frappe.utils import nowdate
+from frappe.utils import add_days, nowdate
 
 from erpnext.accounts.doctype.payment_entry.payment_entry import get_payment_entry
 from erpnext.accounts.doctype.payment_entry.test_payment_entry import create_payment_entry
@@ -531,3 +533,207 @@ class TestPaymentLedgerEntry(ERPNextTestSuite):
 		# with references removed, deletion should be possible
 		so.delete()
 		self.assertRaises(frappe.DoesNotExistError, frappe.get_doc, so.doctype, so.name)
+
+	@ERPNextTestSuite.change_settings(
+		"Accounts Settings",
+		{"enable_immutable_ledger": 1},
+	)
+	def test_sales_invoice_cancellation_creates_reverse_entries_for_immutable_ledger(self):
+		invoice_posting_date = add_days(nowdate(), -5)
+		cancel_posting_date = nowdate()
+		gle = qb.DocType("GL Entry")
+		ple = qb.DocType("Payment Ledger Entry")
+
+		si = self.create_sales_invoice(qty=1, rate=100, posting_date=invoice_posting_date)
+
+		gle_before_cancel = (
+			qb.from_(gle)
+			.select(
+				gle.account,
+				gle.party_type,
+				gle.party,
+				gle.cost_center,
+				gle.project,
+				gle.finance_book,
+				gle.posting_date,
+				gle.debit,
+				gle.credit,
+				gle.debit_in_account_currency,
+				gle.credit_in_account_currency,
+			)
+			.where((gle.voucher_type == si.doctype) & (gle.voucher_no == si.name) & (gle.is_cancelled == 0))
+			.run(as_dict=True)
+		)
+
+		ple_before_cancel = (
+			qb.from_(ple)
+			.select(
+				ple.name,
+				ple.account_type,
+				ple.account,
+				ple.party_type,
+				ple.party,
+				ple.posting_date,
+				ple.against_voucher_type,
+				ple.against_voucher_no,
+				ple.amount,
+				ple.amount_in_account_currency,
+				ple.delinked,
+			)
+			.where((ple.voucher_type == si.doctype) & (ple.voucher_no == si.name))
+			.run(as_dict=True)
+		)
+		si.cancel()
+
+		gle_after_cancel = (
+			qb.from_(gle)
+			.select(
+				gle.account,
+				gle.party_type,
+				gle.party,
+				gle.cost_center,
+				gle.project,
+				gle.finance_book,
+				gle.posting_date,
+				gle.debit,
+				gle.credit,
+				gle.debit_in_account_currency,
+				gle.credit_in_account_currency,
+			)
+			.where((gle.voucher_type == si.doctype) & (gle.voucher_no == si.name) & (gle.is_cancelled == 0))
+			.run(as_dict=True)
+		)
+
+		self.assertEqual(len(gle_after_cancel), len(gle_before_cancel) * 2)
+
+		before_gl = [
+			(
+				d.account,
+				d.party_type,
+				d.party,
+				d.cost_center,
+				d.project,
+				d.finance_book,
+				str(d.posting_date),
+				d.debit,
+				d.credit,
+				d.debit_in_account_currency,
+				d.credit_in_account_currency,
+			)
+			for d in gle_before_cancel
+		]
+		after_gl = [
+			(
+				d.account,
+				d.party_type,
+				d.party,
+				d.cost_center,
+				d.project,
+				d.finance_book,
+				str(d.posting_date),
+				d.debit,
+				d.credit,
+				d.debit_in_account_currency,
+				d.credit_in_account_currency,
+			)
+			for d in gle_after_cancel
+		]
+		actual_reverse_gl = list((Counter(after_gl) - Counter(before_gl)).elements())
+		self.assertEqual(len(actual_reverse_gl), len(gle_before_cancel))
+
+		expected_reverse_gl = [
+			(
+				d.account,
+				d.party_type,
+				d.party,
+				d.cost_center,
+				d.project,
+				d.finance_book,
+				cancel_posting_date,
+				d.credit,
+				d.debit,
+				d.credit_in_account_currency,
+				d.debit_in_account_currency,
+			)
+			for d in gle_before_cancel
+		]
+		self.assertCountEqual(actual_reverse_gl, expected_reverse_gl)
+
+		ple_after_cancel = (
+			qb.from_(ple)
+			.select(
+				ple.name,
+				ple.account_type,
+				ple.account,
+				ple.party_type,
+				ple.party,
+				ple.posting_date,
+				ple.against_voucher_type,
+				ple.against_voucher_no,
+				ple.amount,
+				ple.amount_in_account_currency,
+				ple.delinked,
+			)
+			.where((ple.voucher_type == si.doctype) & (ple.voucher_no == si.name))
+			.run(as_dict=True)
+		)
+
+		self.assertEqual(len(ple_after_cancel), len(ple_before_cancel) * 2)
+
+		before_ple = [
+			(
+				d.account_type,
+				d.account,
+				d.party_type,
+				d.party,
+				str(d.posting_date),
+				d.against_voucher_type,
+				d.against_voucher_no,
+				d.amount,
+				d.amount_in_account_currency,
+				d.delinked,
+			)
+			for d in ple_before_cancel
+		]
+		after_ple = [
+			(
+				d.account_type,
+				d.account,
+				d.party_type,
+				d.party,
+				str(d.posting_date),
+				d.against_voucher_type,
+				d.against_voucher_no,
+				d.amount,
+				d.amount_in_account_currency,
+				d.delinked,
+			)
+			for d in ple_after_cancel
+		]
+		actual_reverse_ple = list((Counter(after_ple) - Counter(before_ple)).elements())
+		self.assertEqual(len(actual_reverse_ple), len(ple_before_cancel))
+
+		expected_reverse_ple = [
+			(
+				d.account_type,
+				d.account,
+				d.party_type,
+				d.party,
+				cancel_posting_date,
+				d.against_voucher_type,
+				d.against_voucher_no,
+				-d.amount,
+				-d.amount_in_account_currency,
+				0,
+			)
+			for d in ple_before_cancel
+		]
+		self.assertCountEqual(actual_reverse_ple, expected_reverse_ple)
+
+		original_ple_names = [d.name for d in ple_before_cancel]
+		self.assertFalse(
+			frappe.db.exists(
+				"Payment Ledger Entry",
+				{"name": ("in", original_ple_names), "delinked": 1},
+			)
+		)

--- a/erpnext/accounts/general_ledger.py
+++ b/erpnext/accounts/general_ledger.py
@@ -430,7 +430,8 @@ def make_entry(args, adv_adj, update_outstanding, from_repost=False):
 	gle.flags.adv_adj = adv_adj
 	gle.flags.update_outstanding = update_outstanding or "Yes"
 	gle.flags.notify_update = False
-	gle.flags.ignore_links = True
+	if gle.is_cancelled or is_immutable_ledger_enabled():
+		gle.flags.ignore_links = True
 	gle.submit()
 
 	if (

--- a/erpnext/accounts/general_ledger.py
+++ b/erpnext/accounts/general_ledger.py
@@ -430,8 +430,7 @@ def make_entry(args, adv_adj, update_outstanding, from_repost=False):
 	gle.flags.adv_adj = adv_adj
 	gle.flags.update_outstanding = update_outstanding or "Yes"
 	gle.flags.notify_update = False
-	if gle.is_cancelled:
-		gle.flags.ignore_links = True
+	gle.flags.ignore_links = True
 	gle.submit()
 
 	if (

--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -2012,7 +2012,7 @@ def get_payment_ledger_entries(gl_entries, cancel=0):
 
 		# companies
 		account = qb.DocType("Account")
-		companies = list({x.company for x in gl_entries})
+		companies = list(set([x.company for x in gl_entries]))
 
 		# receivable/payable account
 		accounts_with_types = (
@@ -2021,18 +2021,19 @@ def get_payment_ledger_entries(gl_entries, cancel=0):
 			.where(account.account_type.isin(["Receivable", "Payable"]) & (account.company.isin(companies)))
 			.run(as_dict=True)
 		)
-		account_type_by_account = {entry.name: entry.account_type for entry in accounts_with_types}
-		receivable_or_payable_accounts = set(account_type_by_account)
+		receivable_or_payable_accounts = [y.name for y in accounts_with_types]
 
-		dimensions_and_defaults = get_dimensions()
-		dimensions = dimensions_and_defaults[0] if dimensions_and_defaults else []
+		def get_account_type(account):
+			for entry in accounts_with_types:
+				if entry.name == account:
+					return entry.account_type
 
 		dr_or_cr = 0
 		account_type = None
 
 		for gle in gl_entries:
 			if gle.account in receivable_or_payable_accounts:
-				account_type = account_type_by_account.get(gle.account)
+				account_type = get_account_type(gle.account)
 				if account_type == "Receivable":
 					dr_or_cr = gle.debit - gle.credit
 					dr_or_cr_account_currency = gle.debit_in_account_currency - gle.credit_in_account_currency
@@ -2073,8 +2074,10 @@ def get_payment_ledger_entries(gl_entries, cancel=0):
 					remarks=gle.remarks,
 				)
 
-				for dimension in dimensions:
-					ple[dimension.fieldname] = gle.get(dimension.fieldname)
+				dimensions_and_defaults = get_dimensions()
+				if dimensions_and_defaults:
+					for dimension in dimensions_and_defaults[0]:
+						ple[dimension.fieldname] = gle.get(dimension.fieldname)
 
 				if gle.advance_voucher_no:
 					# create advance entry

--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -2142,8 +2142,9 @@ def create_payment_ledger_entry(
 			ple = frappe.get_doc(entry)
 
 			if cancel:
-				delink_original_entry(ple, partial_cancel=partial_cancel)
-				if is_immutable_ledger_enabled():
+				if not is_immutable_ledger_enabled():
+					delink_original_entry(ple, partial_cancel=partial_cancel)
+				else:
 					ple.delinked = 0
 					ple.posting_date = frappe.form_dict.get("posting_date") or getdate()
 				ple.flags.ignore_links = True
@@ -2210,9 +2211,6 @@ def delink_original_entry(pl_entry, partial_cancel=False):
 	if not pl_entry:
 		return
 
-	if pl_entry.doctype == "Payment Ledger Entry" and is_immutable_ledger_enabled():
-		return
-
 	if pl_entry.doctype == "Advance Payment Ledger Entry":
 		adv = qb.DocType("Advance Payment Ledger Entry")
 
@@ -2236,6 +2234,7 @@ def delink_original_entry(pl_entry, partial_cancel=False):
 			qb.update(ple)
 			.set(ple.modified, now())
 			.set(ple.modified_by, frappe.session.user)
+			.set(ple.delinked, True)
 			.where(
 				(ple.company == pl_entry.company)
 				& (ple.account_type == pl_entry.account_type)
@@ -2251,9 +2250,6 @@ def delink_original_entry(pl_entry, partial_cancel=False):
 
 		if partial_cancel:
 			query = query.where(ple.voucher_detail_no == pl_entry.voucher_detail_no)
-
-		if not is_immutable_ledger_enabled():
-			query = query.set(ple.delinked, True)
 
 		query.run()
 

--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -2012,7 +2012,7 @@ def get_payment_ledger_entries(gl_entries, cancel=0):
 
 		# companies
 		account = qb.DocType("Account")
-		companies = list(set([x.company for x in gl_entries]))
+		companies = list({x.company for x in gl_entries})
 
 		# receivable/payable account
 		accounts_with_types = (
@@ -2021,19 +2021,18 @@ def get_payment_ledger_entries(gl_entries, cancel=0):
 			.where(account.account_type.isin(["Receivable", "Payable"]) & (account.company.isin(companies)))
 			.run(as_dict=True)
 		)
-		receivable_or_payable_accounts = [y.name for y in accounts_with_types]
+		account_type_by_account = {entry.name: entry.account_type for entry in accounts_with_types}
+		receivable_or_payable_accounts = set(account_type_by_account)
 
-		def get_account_type(account):
-			for entry in accounts_with_types:
-				if entry.name == account:
-					return entry.account_type
+		dimensions_and_defaults = get_dimensions()
+		dimensions = dimensions_and_defaults[0] if dimensions_and_defaults else []
 
 		dr_or_cr = 0
 		account_type = None
 
 		for gle in gl_entries:
 			if gle.account in receivable_or_payable_accounts:
-				account_type = get_account_type(gle.account)
+				account_type = account_type_by_account.get(gle.account)
 				if account_type == "Receivable":
 					dr_or_cr = gle.debit - gle.credit
 					dr_or_cr_account_currency = gle.debit_in_account_currency - gle.credit_in_account_currency
@@ -2074,10 +2073,8 @@ def get_payment_ledger_entries(gl_entries, cancel=0):
 					remarks=gle.remarks,
 				)
 
-				dimensions_and_defaults = get_dimensions()
-				if dimensions_and_defaults:
-					for dimension in dimensions_and_defaults[0]:
-						ple[dimension.fieldname] = gle.get(dimension.fieldname)
+				for dimension in dimensions:
+					ple[dimension.fieldname] = gle.get(dimension.fieldname)
 
 				if gle.advance_voucher_no:
 					# create advance entry
@@ -2208,6 +2205,9 @@ def update_voucher_outstanding(voucher_type, voucher_no, account, party_type, pa
 
 def delink_original_entry(pl_entry, partial_cancel=False):
 	if not pl_entry:
+		return
+
+	if pl_entry.doctype == "Payment Ledger Entry" and is_immutable_ledger_enabled():
 		return
 
 	if pl_entry.doctype == "Advance Payment Ledger Entry":


### PR DESCRIPTION
**Issue:**
When Immutable Ledger is enabled and a document is cancelled, the system creates new reverse ledger entries instead of modifying old ones; that's the core of Immutable Ledger. 

However, during cancellation, `delink_original_entry` was still being called. This function runs a database update query on the **old** Payment Ledger Entries, but it only updates `modified` and `modified_by`; nothing meaningful. With Immutable Ledger, these old records should never be touched, making this update completely useless. In documents with many ledger entries, these pointless queries accumulate and cause significant slowdowns.

**Real-Time Impact in Lending App**

This issue becomes severe in real-world usage. In the Lending product, when users repost loan accounts 7-8 times and then perform a cancellation, thousands of unnecessary `delink_original_entry` queries pile up. Each repost creates new ledger entries, and cancellation tries to "update" all of them; resulting in extremely long wait times.

**Fix**

Wrapped the `delink_original_entry` call with a check for Immutable Ledger. When enabled, the function is skipped entirely, and the new document's `delinked` and `posting_date` fields are set directly; no database updates on old records.

**Performance Improvement**

**Before:**
<img width="704" height="752" alt="Screenshot 2026-05-21 at 1 52 58 PM" src="https://github.com/user-attachments/assets/e213afde-11a8-4b29-b1ca-9141db90568c" />

<br>

**After:**
<img width="882" height="737" alt="Screenshot 2026-05-21 at 2 01 25 PM" src="https://github.com/user-attachments/assets/799cf64c-d696-4ef7-8f77-4eb4c70c10c3" />



Tested on real Lending app data after multiple reposts:

| Metric | Before | After |
|--------|--------|-------|
| Cancellation Time | 449 seconds (~7.5 min) | 14.5 seconds |
| Improvement | - | **~97% faster** |

This benefits any module using Immutable Ledger, not just Lending.