### PR TITLE
fix: use get_query instead of get_all for data fetching

### DIFF
--- a/erpnext/selling/report/sales_analytics/sales_analytics.py
+++ b/erpnext/selling/report/sales_analytics/sales_analytics.py
@@ -191,11 +191,29 @@ class Analytics:
 			self.get_sales_transactions_based_on_project()
 			self.get_rows()
 
+	def _get_permitted_parent_names(self):
+		return frappe.qb.get_query(
+			table=self.filters.doc_type,
+			fields=["name"],
+			filters={
+				"docstatus": 1,
+				"company": ["in", self.filters.company],
+				self.date_field: ("between", [self.filters.from_date, self.filters.to_date]),
+			},
+			ignore_permissions=False,
+		).run(pluck="name")
+
 	def get_sales_transactions_based_on_order_type(self):
 		if self.filters["value_quantity"] == "Value":
 			value_field = "base_net_total"
 		else:
 			value_field = "total_qty"
+
+		permitted_names = self._get_permitted_parent_names()
+		if not permitted_names:
+			self.entries = []
+			self.get_teams()
+			return
 
 		doctype = DocType(self.filters.doc_type)
 
@@ -206,12 +224,7 @@ class Analytics:
 				doctype[self.date_field],
 				doctype[value_field].as_("value_field"),
 			)
-			.where(
-				(doctype.docstatus == 1)
-				& (doctype.company.isin(self.filters.company))
-				& (doctype[self.date_field].between(self.filters.from_date, self.filters.to_date))
-				& (IfNull(doctype.order_type, "") != "")
-			)
+			.where((doctype.name.isin(permitted_names)) & (IfNull(doctype.order_type, "") != ""))
 			.orderby(doctype.order_type)
 		).run(as_dict=True)
 
@@ -250,9 +263,12 @@ class Analytics:
 		if self.filters.doc_type in ["Sales Invoice", "Purchase Invoice", "Payment Entry"]:
 			filters.update({"is_opening": "No"})
 
-		self.entries = frappe.get_all(
-			self.filters.doc_type, fields=[entity, entity_name, value_field, self.date_field], filters=filters
-		)
+		self.entries = frappe.qb.get_query(
+			table=self.filters.doc_type,
+			fields=[entity, entity_name, value_field, self.date_field],
+			filters=filters,
+			ignore_permissions=False,
+		).run(as_dict=True)
 
 		self.entity_names = {}
 		for d in self.entries:
@@ -263,6 +279,12 @@ class Analytics:
 			value_field = "base_net_amount"
 		else:
 			value_field = "stock_qty"
+
+		permitted_names = self._get_permitted_parent_names()
+		if not permitted_names:
+			self.entries = []
+			self.entity_names = {}
+			return
 
 		doctype = DocType(self.filters.doc_type)
 		doctype_item = DocType(f"{self.filters.doc_type} Item")
@@ -278,11 +300,7 @@ class Analytics:
 				doctype_item[value_field].as_("value_field"),
 				doctype[self.date_field],
 			)
-			.where(
-				(doctype_item.docstatus == 1)
-				& (doctype.company.isin(self.filters.company))
-				& (doctype[self.date_field].between(self.filters.from_date, self.filters.to_date))
-			)
+			.where((doctype_item.docstatus == 1) & (doctype.name.isin(permitted_names)))
 		).run(as_dict=True)
 
 		self.entity_names = {}
@@ -312,11 +330,12 @@ class Analytics:
 		if self.filters.doc_type in ["Sales Invoice", "Purchase Invoice", "Payment Entry"]:
 			filters.update({"is_opening": "No"})
 
-		self.entries = frappe.get_all(
-			self.filters.doc_type,
+		self.entries = frappe.qb.get_query(
+			table=self.filters.doc_type,
 			fields=[entity_field, value_field, self.date_field],
 			filters=filters,
-		)
+			ignore_permissions=False,
+		).run(as_dict=True)
 		self.get_groups()
 
 	def get_sales_transactions_based_on_item_group(self):
@@ -324,6 +343,12 @@ class Analytics:
 			value_field = "base_net_amount"
 		else:
 			value_field = "qty"
+
+		permitted_names = self._get_permitted_parent_names()
+		if not permitted_names:
+			self.entries = []
+			self.get_groups()
+			return
 
 		doctype = DocType(self.filters.doc_type)
 		doctype_item = DocType(f"{self.filters.doc_type} Item")
@@ -337,11 +362,7 @@ class Analytics:
 				doctype_item[value_field].as_("value_field"),
 				doctype[self.date_field],
 			)
-			.where(
-				(doctype_item.docstatus == 1)
-				& (doctype.company.isin(self.filters.company))
-				& (doctype[self.date_field].between(self.filters.from_date, self.filters.to_date))
-			)
+			.where((doctype_item.docstatus == 1) & (doctype.name.isin(permitted_names)))
 		).run(as_dict=True)
 
 		self.get_groups()
@@ -367,9 +388,12 @@ class Analytics:
 		if self.filters.doc_type in ["Sales Invoice", "Purchase Invoice", "Payment Entry"]:
 			filters.update({"is_opening": "No"})
 
-		self.entries = frappe.get_all(
-			self.filters.doc_type, fields=[entity, value_field, self.date_field], filters=filters
-		)
+		self.entries = frappe.qb.get_query(
+			table=self.filters.doc_type,
+			fields=[entity, value_field, self.date_field],
+			filters=filters,
+			ignore_permissions=False,
+		).run(as_dict=True)
 
 	def get_rows(self):
 		self.data = []


### PR DESCRIPTION
**Problem**

frappe.get_all() explicitly bypasses all user permissions (ignore_permissions=True). As a result, restricted users, for example, those limited to specific Territories or Customer Groups via User Permissions, could see data from all territories and customers in the Sales Analytics report.

**Fix**

Replaced frappe.get_all() with frappe.qb.get_query(ignore_permissions=False) for queries on single doctypes (Customer, Supplier, Territory, Customer Group, Project tree types). This runs through Frappe's permission machinery and applies the user's restrictions as WHERE conditions automatically.

For tree types that JOIN a parent doctype with its child item table (Item, Item Group, Order Type), raw frappe.qb cannot apply permissions inline. Added a helper _get_permitted_parent_names() that fetches only the parent document names the current user is allowed to see, then filters the JOIN query against those names.