### PR TITLE
fix #55128 : improve partial stock reservation message

### DIFF
--- a/erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py
+++ b/erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py
@@ -1717,7 +1717,7 @@ def create_stock_reservation_entries_for_so_items(
 			if not from_voucher_type and (
 				not item.get("qty_to_reserve") or qty_to_be_reserved < flt(item.get("qty_to_reserve"))
 			):
-				msg = _("Row #{0}: Only {1} available to reserve for the Item {2}").format(
+				msg = _("Row #{0}: Partial reservation completed. Only {1} could be reserved for Item {2}.").format(
 					item.idx,
 					frappe.bold(str(qty_to_be_reserved / item.conversion_factor) + " " + item.uom),
 					frappe.bold(item.item_code),


### PR DESCRIPTION
Fix from #55128 
I have improved the partial reservation alert message see if this can be a good choice 
<img width="1600" height="650" alt="image" src="https://github.com/user-attachments/assets/245d83a9-9116-4545-b84c-176900aea229" />
