### PR TITLE
fix: don't reset net_purchase_amount for Composite Asset if already set

### DIFF
--- a/erpnext/assets/doctype/asset/asset.js
+++ b/erpnext/assets/doctype/asset/asset.js
@@ -551,7 +551,9 @@ frappe.ui.form.on("Asset", {
 	asset_type: function (frm) {
 		if (frm.doc.docstatus == 0) {
 			if (frm.doc.asset_type == "Composite Asset") {
-				frm.set_value("net_purchase_amount", 0);
+				if (!frm.doc.net_purchase_amount) {
+					frm.set_value("net_purchase_amount", 0);
+				}
 			} else {
 				frm.set_df_property("net_purchase_amount", "read_only", 0);
 			}


### PR DESCRIPTION
fixes: https://github.com/frappe/erpnext/issues/54802