### PR TITLE
fix(stock): set stock received but not billed account for purchase

### DIFF
--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -537,10 +537,21 @@ def get_basic_details(ctx: ItemDetailsCtx, item, overwrite_warehouse=True) -> It
 			ctx.name, ctx.conversion_rate, item.name, out.conversion_factor
 		)
 
+	expense_account_field = "default_expense_account"
+	if (
+		item.is_stock_item
+		and erpnext.is_perpetual_inventory_enabled(ctx.company)
+		and (
+			ctx.doctype == "Purchase Receipt"
+			or (ctx.doctype == "Purchase Invoice" and ctx.get("update_stock"))
+		)
+	):
+		expense_account_field = "stock_received_but_not_billed"
+
 	# if default specified in item is for another company, fetch from company
 	for d in [
 		["Account", "income_account", "default_income_account"],
-		["Account", "expense_account", "default_expense_account"],
+		["Account", "expense_account", expense_account_field],
 		["Cost Center", "cost_center", "cost_center"],
 		["Warehouse", "warehouse", ""],
 	]:


### PR DESCRIPTION
Issue: The Purchase Receipt was fetching the COGS account for the Expense Account. Actually, it should fetch the Stock Received But Not Billed account.

Ref : [#66925](https://support.frappe.io/helpdesk/tickets/66925)

Description:
Updated item expense account fallback logic to use stock_received_but_not_billed only for Purchase Receipt and Purchase Invoice with update_stock enabled for stock items; otherwise, use default_expense_account.

Steps To Replicate : 
1. Go to Purchase Receipt 
2. Add an item 
3. See the expense account, it is **COGS**

Before : 

<img width="1861" height="939" alt="before cogs" src="https://github.com/user-attachments/assets/b231fb20-1262-4b61-958e-9dbccbb2f608" />


After : 

<img width="1861" height="939" alt="after cogs" src="https://github.com/user-attachments/assets/d0da35ef-1dc0-4f60-8e75-0d732868e94a" />


Backport Needed For V16 and V15

