### PR TITLE
fix(accounts): include asset items in purchase receipt validation

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
@@ -635,15 +635,16 @@ class PurchaseInvoice(BuyingController):
 					throw(msg, title=_("Mandatory Purchase Order"))
 
 	def pr_required(self):
-		stock_items = self.get_stock_items()
 		if frappe.db.get_single_value("Buying Settings", "pr_required") == "Yes":
+			stock_and_asset_items = self.get_stock_items()
+			stock_and_asset_items.extend(self.get_asset_items())
 			if frappe.get_value(
 				"Supplier", self.supplier, "allow_purchase_invoice_creation_without_purchase_receipt"
 			):
 				return
 
 			for d in self.get("items"):
-				if not d.purchase_receipt and d.item_code in stock_items:
+				if not d.purchase_receipt and d.item_code in stock_and_asset_items:
 					msg = _("Purchase Receipt Required for item {}").format(frappe.bold(d.item_code))
 					msg += "<br><br>"
 					msg += _(


### PR DESCRIPTION
Issue: If "Purchase Receipt Required" is enabled in Buying Settings, validation considers only stock items before allowing Purchase Invoice submission. Asset items were not included in this validation.
Since for Asset items, purchase receipts or invoices (**with update stock enabled**) need to be created. In that case, it should consider the **Asset items** while validating the purchase receipts.

Ref : [#68578](https://support.frappe.io/helpdesk/tickets/68578)

Backport Needed For V16 and V15