### PR TITLE
fix(je): preserve account on duplicate row when party row exists

### DIFF
--- a/erpnext/accounts/doctype/journal_entry/journal_entry.js
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.js
@@ -433,15 +433,17 @@ erpnext.accounts.JournalEntry = class JournalEntry extends frappe.ui.form.Contro
 
 	accounts_add(doc, cdt, cdn) {
 		var row = frappe.get_doc(cdt, cdn);
-		row.exchange_rate = 1;
-		$.each(doc.accounts, function (i, d) {
-			if (d.account && d.party && d.party_type) {
-				row.account = d.account;
-				row.party = d.party;
-				row.party_type = d.party_type;
-				row.exchange_rate = d.exchange_rate;
-			}
-		});
+		if (!row.exchange_rate) row.exchange_rate = 1;
+		if (!row.account) {
+			$.each(doc.accounts, function (i, d) {
+				if (d.account && d.party && d.party_type) {
+					row.account = d.account;
+					row.party = d.party;
+					row.party_type = d.party_type;
+					row.exchange_rate = d.exchange_rate;
+				}
+			});
+		}
 
 		// set difference
 		if (doc.difference) {


### PR DESCRIPTION
## Problem
Duplicating a Journal Entry row replaces duplicated row's account with another account from same JV (typically last Customer/Supplier party row). Causes wrong account mapping during data entry.

## Root cause
`accounts_add` handler in `journal_entry.js` runs on every new row, including duplicates. Loops over existing accounts and, if any row has `account + party+ party_type`, overwrites new row's account/ party/ party_type/ exchange_rate. Intended to auto-fill blank rows in party-only JVs, but stomps values just copied by `grid.duplicate_rows()`.

## Fix
Skip overwrite block when new row already has `account` set. Duplicate-row path keeps copied values; blank-add path keeps original auto-fill behavior.

### Before Fix
[Screencast from 2026-05-22 14-15-18.webm](https://github.com/user-attachments/assets/b5415bf5-fb10-44d1-8e85-b880e7c6e105)



### After Fix
[Screencast from 2026-05-22 14-28-11.webm](https://github.com/user-attachments/assets/830ba579-f51c-4056-b597-1af80c075111)

**Support Ticket**: [https://support.frappe.io/helpdesk/tickets/68646](https://support.frappe.io/helpdesk/tickets/68646)