### PR TITLE
fix(project): update customer and sales order as no copy

### DIFF
--- a/erpnext/projects/doctype/project/project.json
+++ b/erpnext/projects/doctype/project/project.json
@@ -181,6 +181,7 @@
    "fieldtype": "Link",
    "in_global_search": 1,
    "label": "Customer",
+   "no_copy": 1,
    "oldfieldname": "customer",
    "oldfieldtype": "Link",
    "options": "Customer",
@@ -195,6 +196,7 @@
    "fieldname": "sales_order",
    "fieldtype": "Link",
    "label": "Sales Order",
+   "no_copy": 1,
    "options": "Sales Order"
   },
   {
@@ -480,7 +482,7 @@
  "index_web_pages_for_search": 1,
  "links": [],
  "max_attachments": 4,
- "modified": "2026-04-14 18:17:40.676750",
+ "modified": "2026-05-22 16:45:50.762759",
  "modified_by": "Administrator",
  "module": "Projects",
  "name": "Project",


### PR DESCRIPTION
**Ref:** #[69032](https://support.frappe.io/helpdesk/tickets/69032?view=VIEW-HD%20Ticket-850)

**Issue:** While duplicating a Project that is already linked with a Sales Order and Customer, the system currently allows the creation of a new Project with the same Sales Order and Customer without any validation.

**Before:**

[Screencast from 2026-05-22 16-51-53.webm](https://github.com/user-attachments/assets/1b3711e0-dcb5-44e7-9586-c13fbbdd7b1b)

**After:**

[Screencast from 2026-05-22 16-49-22.webm](https://github.com/user-attachments/assets/93ec2724-69a9-4d74-b999-637c181d4c86)


Backport needed for v-15, v-16
