### PR TITLE
fix(item): add condition to check variant attribute

### DIFF
--- a/erpnext/stock/doctype/item/item.py
+++ b/erpnext/stock/doctype/item/item.py
@@ -888,9 +888,12 @@ class Item(Document):
 
 					if disabled:
 						frappe.throw(_("Attribute {0} is disabled.").format(frappe.bold(d.attribute)))
-
-					if not numeric_values and not frappe.db.exists(
-						"Item Attribute Value", {"parent": d.attribute, "attribute_value": d.attribute_value}
+					if (
+						not numeric_values
+						and d.attribute_value
+						and not frappe.db.get_list(
+							"Item Attribute Value", {"parent": d.attribute}, pluck="attribute_value"
+						)
 					):
 						frappe.throw(
 							_("Attribute Value {0} is not valid for the selected attribute {1}.").format(


### PR DESCRIPTION
**Ref:** #[69033](https://support.frappe.io/helpdesk/tickets/69033?view=VIEW-HD+Ticket-1014)

**Issue:** The Item with variants has one or more attributes. When trying to create a single variant with one attribute throws an error `Attribute Value **None** is not valid for the selected attribute {1}`

**Before:** 

[Screencast from 2026-05-22 18-11-58.webm](https://github.com/user-attachments/assets/8d6efdc4-c1df-4200-a6d7-1284935cb247)


**After:**

[Screencast from 2026-05-22 18-11-13.webm](https://github.com/user-attachments/assets/b2739f91-420b-4fc4-a6a2-886fba29fe63)


Backport needed for v-15, v-16