### PR TITLE
refactor(sales_order):Replace SQL with query builder in get_events

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -1655,32 +1655,39 @@ def get_events(start: str, end: str, filters: str | dict | None = None):
 	:param end: End date-time.
 	:param filters: Filters (JSON).
 	"""
-	from frappe.desk.calendar import get_event_conditions
 
-	conditions = get_event_conditions("Sales Order", filters)
+	SalesOrder = frappe.qb.DocType("Sales Order")
+	SalesOrderItem = frappe.qb.DocType("Sales Order Item")
 
-	data = frappe.db.sql(
-		f"""
-		select
-			distinct `tabSales Order`.name, `tabSales Order`.customer_name, `tabSales Order`.status,
-			`tabSales Order`.delivery_status, `tabSales Order`.billing_status,
-			`tabSales Order Item`.delivery_date
-		from
-			`tabSales Order`, `tabSales Order Item`
-		where `tabSales Order`.name = `tabSales Order Item`.parent
-			and `tabSales Order`.skip_delivery_note = 0
-			and (ifnull(`tabSales Order Item`.delivery_date, '0000-00-00')!= '0000-00-00') \
-			and (`tabSales Order Item`.delivery_date between %(start)s and %(end)s)
-			and `tabSales Order`.docstatus < 2
-			{conditions}
-		""",
-		{"start": start, "end": end},
-		as_dict=True,
-		update={
-			"allDay": 0,
-			"convertToUserTz": 0,
-		},
+	query = (
+		frappe.get_query("Sales Order", filters=filters, ignore_permissions=False)
+		.join(SalesOrderItem)
+		.on(SalesOrder.name == SalesOrderItem.parent)
+		.select(
+			SalesOrder.name,
+			SalesOrder.customer_name,
+			SalesOrder.status,
+			SalesOrder.delivery_status,
+			SalesOrder.billing_status,
+			SalesOrderItem.delivery_date,
+		)
+		.distinct()
+		.where(SalesOrder.skip_delivery_note == 0)
+		.where(SalesOrder.docstatus < 2)
+		.where(SalesOrderItem.delivery_date.between(start, end))
+		.where(SalesOrderItem.delivery_date.isnotnull())
 	)
+
+	data = query.run(as_dict=True)
+
+	for row in data:
+		row.update(
+			{
+				"allDay": 0,
+				"convertToUserTz": 0,
+			}
+		)
+
 	return data
 
 


### PR DESCRIPTION
Replace SQL query with query builder to ensure compatibility with postgreSQL. get_query is used to keep the permission and filter check without introducing SQL.

Contribution made on behalf of Orange SA

<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/erpnext/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->
