### PR TITLE
fix(buying): honour over delivery/receipt allowance in PR mapper

### DIFF
--- a/erpnext/buying/doctype/purchase_order/purchase_order.js
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.js
@@ -351,9 +351,10 @@ erpnext.buying.PurchaseOrderController = class PurchaseOrderController extends (
 			if (doc.status != "Closed") {
 				if (doc.status != "On Hold") {
 					if (
-						doc.items
+						(doc.items
 							.filter((item) => !item.delivered_by_supplier)
-							.some((item) => item.received_qty < item.qty) &&
+							.some((item) => item.received_qty < item.qty) ||
+							doc.__onload?.has_pending_receivable_qty) &&
 						allow_receipt
 					) {
 						this.frm.add_custom_button(

--- a/erpnext/buying/doctype/purchase_order/purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.py
@@ -19,6 +19,7 @@ from erpnext.accounts.doctype.sales_invoice.sales_invoice import (
 from erpnext.accounts.party import get_party_account, get_party_account_currency
 from erpnext.buying.utils import check_on_hold_or_closed_status, validate_for_items
 from erpnext.controllers.buying_controller import BuyingController
+from erpnext.controllers.status_updater import get_allowance_for
 from erpnext.manufacturing.doctype.blanket_order.blanket_order import (
 	validate_against_blanket_order,
 )
@@ -183,6 +184,7 @@ class PurchaseOrder(BuyingController):
 
 	def onload(self):
 		self.set_onload("can_update_items", self.can_update_items())
+		self.set_onload("has_pending_receivable_qty", self.has_pending_receivable_qty())
 
 	def before_validate(self):
 		self.set_has_unit_price_items()
@@ -656,6 +658,19 @@ class PurchaseOrder(BuyingController):
 
 		return result
 
+	def has_pending_receivable_qty(self) -> bool:
+		"""Return True if any non-drop-ship item can still be received,
+		considering the configured over_delivery_receipt_allowance.
+		"""
+		for item in self.get("items", []):
+			if item.delivered_by_supplier:
+				continue
+			tolerance = flt(get_allowance_for(item.item_code, qty_or_amount="qty")[0])
+			max_receivable_qty = flt(item.qty) * (100 + tolerance) / 100
+			if abs(flt(item.received_qty)) < abs(max_receivable_qty):
+				return True
+		return False
+
 	def update_ordered_qty_in_so_for_removed_items(self, removed_items):
 		"""
 		Updates ordered_qty in linked SO when item rows are removed using Update Items
@@ -757,13 +772,25 @@ def make_purchase_receipt(
 	def is_unit_price_row(source):
 		return has_unit_price_items and source.qty == 0
 
+	def get_max_receivable_qty(source):
+		tolerance = flt(get_allowance_for(source.item_code, qty_or_amount="qty")[0])
+		return flt(source.qty) * (100 + tolerance) / 100
+
 	def update_item(obj, target, source_parent):
-		target.qty = flt(obj.qty) if is_unit_price_row(obj) else flt(obj.qty) - flt(obj.received_qty)
-		target.stock_qty = (flt(obj.qty) - flt(obj.received_qty)) * flt(obj.conversion_factor)
-		target.amount = (flt(obj.qty) - flt(obj.received_qty)) * flt(obj.rate)
-		target.base_amount = (
-			(flt(obj.qty) - flt(obj.received_qty)) * flt(obj.rate) * flt(source_parent.conversion_rate)
-		)
+		received_qty = flt(obj.received_qty)
+		qty = flt(obj.qty)
+		pending_qty = qty - received_qty
+
+		if is_unit_price_row(obj):
+			target.qty = qty
+		elif pending_qty > 0:
+			target.qty = pending_qty
+		else:
+			target.qty = max(get_max_receivable_qty(obj) - received_qty, 0)
+
+		target.stock_qty = target.qty * flt(obj.conversion_factor)
+		target.amount = target.qty * flt(obj.rate)
+		target.base_amount = target.qty * flt(obj.rate) * flt(source_parent.conversion_rate)
 
 	def select_item(d):
 		filtered_items = args.get("filtered_children", [])
@@ -795,7 +822,9 @@ def make_purchase_receipt(
 				},
 				"postprocess": update_item,
 				"condition": lambda doc: (
-					True if is_unit_price_row(doc) else abs(doc.received_qty) < abs(doc.qty)
+					True
+					if is_unit_price_row(doc)
+					else abs(doc.received_qty) < abs(get_max_receivable_qty(doc))
 				)
 				and doc.delivered_by_supplier != 1
 				and select_item(doc),

--- a/erpnext/buying/doctype/purchase_order/test_purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/test_purchase_order.py
@@ -98,6 +98,60 @@ class TestPurchaseOrder(ERPNextTestSuite):
 		po.load_from_db()
 		self.assertEqual(po.get("items")[0].received_qty, 4)
 
+	def test_make_purchase_receipt_respects_over_receipt_allowance(self):
+		"""make_purchase_receipt must include fully-received PO lines when
+		over_delivery_receipt_allowance permits further receipt.
+
+		Regression test for #55246: the mapper dropped rows once
+		received_qty >= qty, ignoring the configured tolerance.
+		"""
+		from erpnext.buying.doctype.purchase_order.purchase_order import make_purchase_receipt
+
+		# 50% tolerance — 10 ordered allows up to 15 received
+		frappe.db.set_value("Item", "_Test Item", "over_delivery_receipt_allowance", 50)
+		try:
+			po = create_purchase_order()
+			create_pr_against_po(po.name, received_qty=10)
+
+			po.load_from_db()
+			self.assertEqual(po.get("items")[0].received_qty, 10)
+
+			# onload must flag pending receivable qty so the UI keeps the
+			# "Create > Purchase Receipt" button visible even at per_received = 100
+			po.run_method("onload")
+			self.assertTrue(
+				po.get_onload("has_pending_receivable_qty"),
+				"onload should flag pending receivable qty while tolerance is available",
+			)
+
+			# Re-mapping the same PO must yield a PR with the row present
+			# and qty pre-filled to the remaining tolerance (15 - 10 = 5)
+			pr = make_purchase_receipt(po.name)
+			self.assertEqual(
+				len(pr.get("items")), 1, "Fully-received row dropped despite available tolerance"
+			)
+			self.assertEqual(pr.get("items")[0].item_code, "_Test Item")
+			self.assertEqual(pr.get("items")[0].qty, 5)
+			self.assertEqual(pr.get("items")[0].purchase_order_item, po.get("items")[0].name)
+
+			# Tolerance exhausted → row must be filtered out as before
+			create_pr_against_po(po.name, received_qty=5)
+			po.load_from_db()
+			self.assertEqual(po.get("items")[0].received_qty, 15)
+
+			po.run_method("onload")
+			self.assertFalse(
+				po.get_onload("has_pending_receivable_qty"),
+				"onload should clear pending receivable flag once tolerance is exhausted",
+			)
+
+			pr_empty = make_purchase_receipt(po.name)
+			self.assertEqual(
+				len(pr_empty.get("items")), 0, "Row should be dropped once tolerance is exhausted"
+			)
+		finally:
+			frappe.db.set_value("Item", "_Test Item", "over_delivery_receipt_allowance", 0)
+
 	def test_ordered_qty_against_pi_with_update_stock(self):
 		existing_ordered_qty = get_ordered_qty()
 		po = create_purchase_order()


### PR DESCRIPTION
### Issue
When creating a Purchase Receipt from a Purchase Order via `make_purchase_receipt`, the mapper ignores `over_delivery_receipt_allowance` from the Item master / Stock Settings.

Two problems:
1. Fully-received PO lines are dropped from the mapped PR even when tolerance still allows more receipt. The user has no way to receive the extra qty from the UI.
2. The default qty caps at the ordered qty — tolerance is ignored when pre-filling.

The validation layer (`status_updater.check_overflow_with_allowance`) already respects this allowance on submit, so the mapper is the only place that doesn't.

### Fix
- Add a nested helper `get_max_receivable_qty(source)` that computes `qty * (100 + allowance) / 100` using the existing `get_allowance_for()` utility.
- Update the `condition` lambda to keep rows where `received_qty < max_receivable_qty`.
- Update `update_item` to pre-fill the remaining tolerance qty when the line is fully received.
- Add `has_pending_receivable_qty` to `onload` so the PO form keeps the "Create > Purchase Receipt" button visible while tolerance is available. Update `purchase_order.js` button condition to use this flag.

### Tests
Added `test_make_purchase_receipt_respects_over_receipt_allowance` to `TestPurchaseOrder`:
- Fully-received PO with 50% tolerance → mapped PR has the row with qty = remaining tolerance.
- `onload` flag is `True` while tolerance is available, `False` once used up.
- Tolerance used up → row dropped (old behavior kept).
- `purchase_order_item` link preserved so PR submit updates the PO's received_qty correctly.

### Manually verified
On a real PO: qty=1500, fully received, item tolerance=10% → "Create > Purchase Receipt" now opens a draft PR with qty=150 pre-filled (it was empty before). The `has_pending_receivable_qty` flag switches `True → False` as tolerance is used up.

### Related but out of scope
The "Get Items From > Purchase Order" picker in `erpnext/stock/doctype/purchase_receipt/purchase_receipt.js` has a `per_received < 99.99` filter that may have the same tolerance-awareness gap. Unsure if that's intentional or oversight, so leaving it for maintainers to decide.

closes #55246

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Purchase Receipt button now appears when an over-delivery allowance means receivable quantity remains, even after standard receipt completion.
  * Purchase receipt quantity mapping now respects configured over-delivery allowance when determining remaining receivable quantity.

* **Tests**
  * Added regression test covering over-delivery allowance behavior and remapping of purchase receipts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/frappe/erpnext/pull/55247?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->