### PR TITLE
fix: prevent AttributeError in batch query filters

### DIFF
--- a/erpnext/controllers/queries.py
+++ b/erpnext/controllers/queries.py
@@ -544,7 +544,7 @@ def get_batches_from_stock_ledger_entries(searchfields, txt, filters, start=0, p
 		if filters.get("posting_date") and filters.get("posting_time"):
 			query = query.where(
 				stock_ledger_entry.posting_datetime
-				<= get_combine_datetime(filters.posting_date, filters.posting_time)
+				<= get_combine_datetime(filters.get("posting_date"), filters.get("posting_time"))
 			)
 
 	if not filters.get("include_expired_batches"):
@@ -604,7 +604,7 @@ def get_batches_from_serial_and_batch_bundle(searchfields, txt, filters, start=0
 		if filters.get("posting_date") and filters.get("posting_time"):
 			bundle_query = bundle_query.where(
 				stock_ledger_entry.posting_datetime
-				<= get_combine_datetime(filters.posting_date, filters.posting_time)
+				<= get_combine_datetime(filters.get("posting_date"), filters.get("posting_time"))
 			)
 
 	if not filters.get("include_expired_batches"):


### PR DESCRIPTION
Issue: Batch No search was failing due to attribute-style access on dict filters

Description : 
While fetching Batch No in Purchase Receipt, the query accessed filters using attribute notation (`filters.posting_date` and `filters.posting_time`) even though filters were received as a dict.
This fix updates the query to use `filters.get()` for safely accessing filter values and prevents the AttributeError during batch selection.

Before : 

<img width="1833" height="884" alt="image" src="https://github.com/user-attachments/assets/a7399120-2678-42b7-b423-b533c7d000d9" />

After : 

<img width="1845" height="936" alt="image" src="https://github.com/user-attachments/assets/23fcb583-9679-4d20-b6c6-0f016ea98a96" />

Backport Needed For V16 and v15