### PR TITLE
fix: update reference doctype mapping and field visibility in bank guarantee

### DIFF
--- a/erpnext/accounts/doctype/bank_guarantee/bank_guarantee.js
+++ b/erpnext/accounts/doctype/bank_guarantee/bank_guarantee.js
@@ -9,6 +9,13 @@ cur_frm.add_fetch("bank", "swift_number", "swift_number");
 
 frappe.ui.form.on("Bank Guarantee", {
 	setup: function (frm) {
+		frm.set_query("reference_doctype", function () {
+			return {
+				filters: {
+					name: ["in", ["Sales Order", "Purchase Order"]],
+				},
+			};
+		});
 		frm.set_query("bank_account", function () {
 			return {
 				filters: {

--- a/erpnext/accounts/doctype/bank_guarantee/bank_guarantee.json
+++ b/erpnext/accounts/doctype/bank_guarantee/bank_guarantee.json
@@ -1,5 +1,6 @@
 {
  "actions": [],
+ "allow_bulk_edit": 1,
  "autoname": "ACC-BG-.YYYY.-.#####",
  "creation": "2016-12-17 10:43:35.731631",
  "doctype": "DocType",
@@ -50,8 +51,7 @@
    "fieldname": "reference_doctype",
    "fieldtype": "Link",
    "label": "Reference Document Type",
-   "options": "DocType",
-   "read_only": 1
+   "options": "DocType"
   },
   {
    "fieldname": "reference_docname",
@@ -60,14 +60,14 @@
    "options": "reference_doctype"
   },
   {
-   "depends_on": "eval: doc.bg_type == \"Receiving\"",
+   "depends_on": "eval: doc.reference_doctype == \"Sales Order\"",
    "fieldname": "customer",
    "fieldtype": "Link",
    "label": "Customer",
    "options": "Customer"
   },
   {
-   "depends_on": "eval: doc.bg_type == \"Providing\"",
+   "depends_on": "eval: doc.reference_doctype == \"Purchase Order\"",
    "fieldname": "supplier",
    "fieldtype": "Link",
    "label": "Supplier",
@@ -218,10 +218,11 @@
  "grid_page_length": 50,
  "is_submittable": 1,
  "links": [],
- "modified": "2025-08-29 11:52:33.550847",
+ "modified": "2026-05-25 18:12:10.768835",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Bank Guarantee",
+ "naming_rule": "Expression",
  "owner": "Administrator",
  "permissions": [
   {


### PR DESCRIPTION
**Issue:** #49489 

**Description:** In Bank Guarantee, the system was restrictive because:

- Receiving type could only be linked with Sales Order
- Providing type could only be linked with Purchase Order

so this not be applicable for some business cases like, 

- Companies may provide bank guarantees to customers
- Companies may receive bank guarantees from suppliers


**Before:**

[Screencast from 2026-05-25 18-46-34.webm](https://github.com/user-attachments/assets/f7d328d2-f81d-4524-b7ba-a7df06b96b1f)


**After:**

[Screencast from 2026-05-25 18-35-41.webm](https://github.com/user-attachments/assets/97070cc4-b057-4765-8221-19cc9fb24b48)


Backport needed for v-15, v-16