### PR TITLE
fix: prevent provisional reversal entry for purchase return

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
@@ -1140,7 +1140,7 @@ class PurchaseInvoice(BuyingController):
 					account_currency = get_account_currency(expense_account)
 					amount, base_amount = self.get_amount_and_base_amount(item, None)
 
-					if provisional_accounting_for_non_stock_items:
+					if provisional_accounting_for_non_stock_items and not self.is_return:
 						self.make_provisional_gl_entry(gl_entries, item)
 
 					if not self.is_internal_transfer():

--- a/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py
@@ -1814,6 +1814,62 @@ class TestPurchaseInvoice(ERPNextTestSuite, StockTestMixin):
 
 		toggle_provisional_accounting_setting()
 
+	def test_no_provisional_reversal_on_return_against_purchase_receipt(self):
+		from erpnext.accounts.doctype.purchase_invoice.purchase_invoice import make_debit_note
+
+		setup_provisional_accounting()
+		frappe.db.set_single_value("Buying Settings", "maintain_same_rate", 0)
+
+		pr = make_purchase_receipt(
+			item_code="_Test Non Stock Item", rate=1000, qty=5, posting_date=add_days(nowdate(), -2)
+		)
+
+		pi = create_purchase_invoice_from_receipt(pr.name)
+		pi.set_posting_time = 1
+		pi.posting_date = add_days(pr.posting_date, 1)
+		pi.items[0].expense_account = "Cost of Goods Sold - _TC"
+		pi.save()
+		pi.submit()
+
+		return_pi = make_debit_note(pi.name)
+		return_pi.set_posting_time = 1
+		return_pi.posting_date = add_days(pi.posting_date, 1)
+		return_pi.save()
+		return_pi.submit()
+
+		self.assertTrue(return_pi.is_return)
+		self.assertEqual(return_pi.items[0].qty, -5)
+		self.assertEqual(return_pi.items[0].purchase_receipt, pr.name)
+
+		expected_gle_for_purchase_receipt = [
+			["_Test Account Cost for Goods Sold - _TC", 5000, 0, pr.posting_date],
+			["Provision Account - _TC", 0, 5000, pr.posting_date],
+			["_Test Account Cost for Goods Sold - _TC", 0, 5000, pi.posting_date],
+			["Provision Account - _TC", 5000, 0, pi.posting_date],
+		]
+		check_gl_entries(
+			self, pr.name, expected_gle_for_purchase_receipt, pr.posting_date, voucher_type="Purchase Receipt"
+		)
+
+		pr_gl_count = frappe.db.count(
+			"GL Entry",
+			{"voucher_type": "Purchase Receipt", "voucher_no": pr.name, "is_cancelled": 0},
+		)
+		self.assertEqual(pr_gl_count, 4)
+
+		extra_reversal_on_return = frappe.db.count(
+			"GL Entry",
+			{
+				"voucher_type": "Purchase Receipt",
+				"voucher_no": pr.name,
+				"posting_date": return_pi.posting_date,
+				"is_cancelled": 0,
+			},
+		)
+		self.assertEqual(extra_reversal_on_return, 0)
+
+		toggle_provisional_accounting_setting()
+
 	def test_provisional_accounting_entry_multi_currency(self):
 		setup_provisional_accounting()
 


### PR DESCRIPTION
**Issue:**
When “Enable Provisional Accounting For Non-Stock Items” is enabled, creating a return entry from a Purchase Invoice results in the system posting a reverse accounting entry against the Purchase Receipt.

**Ref:**[#68786](https://support.frappe.io/helpdesk/tickets/68786?view=VIEW-HD+Ticket-745)

**Steps To Reproduce:**
1)Create a Purchase Receipt for 2 items INR 500.
2)Create a Purchase Invoice against the PR.
3)Create a return of 1 item INR 500. The system is posting a reverse accounting entry against the Purchase Receipt.

Backport Needed : v15 , v16