### PR TITLE
fix(payment_entry): sync paid/received amounts for cross-currency entries

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.js
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.js
@@ -807,11 +807,14 @@ frappe.ui.form.on("Payment Entry", {
 		frm.set_value("base_paid_amount", flt(frm.doc.paid_amount) * flt(frm.doc.source_exchange_rate));
 		let company_currency = frappe.get_doc(":Company", frm.doc.company).default_currency;
 		if (!frm.doc.received_amount) {
-			if (frm.doc.paid_from_account_currency == frm.doc.paid_to_account_currency) {
-				frm.set_value("received_amount", frm.doc.paid_amount);
-			} else if (company_currency == frm.doc.paid_to_account_currency) {
+			frm.set_value("base_received_amount", frm.doc.base_paid_amount);
+			if (company_currency == frm.doc.paid_to_account_currency) {
 				frm.set_value("received_amount", frm.doc.base_paid_amount);
-				frm.set_value("base_received_amount", frm.doc.base_paid_amount);
+			} else if (frm.doc.target_exchange_rate) {
+				frm.set_value(
+					"received_amount",
+					flt(frm.doc.base_paid_amount) / flt(frm.doc.target_exchange_rate)
+				);
 			}
 		}
 		frm.trigger("reset_received_amount");
@@ -828,15 +831,14 @@ frappe.ui.form.on("Payment Entry", {
 		);
 
 		if (!frm.doc.paid_amount) {
-			if (frm.doc.paid_from_account_currency == frm.doc.paid_to_account_currency) {
-				frm.set_value("paid_amount", frm.doc.received_amount);
-				if (frm.doc.target_exchange_rate) {
-					frm.set_value("source_exchange_rate", frm.doc.target_exchange_rate);
-				}
-				frm.set_value("base_paid_amount", frm.doc.base_received_amount);
-			} else if (company_currency == frm.doc.paid_from_account_currency) {
+			frm.set_value("base_paid_amount", frm.doc.base_received_amount);
+			if (company_currency == frm.doc.paid_from_account_currency) {
 				frm.set_value("paid_amount", frm.doc.base_received_amount);
-				frm.set_value("base_paid_amount", frm.doc.base_received_amount);
+			} else if (frm.doc.source_exchange_rate) {
+				frm.set_value(
+					"paid_amount",
+					flt(frm.doc.base_received_amount) / flt(frm.doc.source_exchange_rate)
+				);
 			}
 		}
 


### PR DESCRIPTION
## Problem

When both account currencies differ from company currency (e.g., USD → EUR with INR as company currency), the `paid_amount` and `received_amount` triggers silently skipped populating the counterpart field. The code used a `paid_from_account_currency == paid_to_account_currency` shortcut that only handled two of three possible cases:

1. Same currency → set `received_amount = paid_amount` (no `base_received_amount`)
2. `paid_to_account_currency == company_currency` → set both
3. **Cross-currency (neither account in company currency) → nothing set** ← bug

Additionally, the `received_amount` trigger was overwriting `source_exchange_rate` with `target_exchange_rate` for same-currency entries, which is the wrong direction (the correct sync is `target ← source`, handled by `reset_received_amount`).

## Fix

- Unconditionally set the base amount first (`base_received_amount = base_paid_amount` and vice versa).
- Derive the actual amount via exchange rate division for the cross-currency case.
- Remove the erroneous `source_exchange_rate = target_exchange_rate` assignment.
- Same-currency path continues to be handled correctly by `reset_received_amount`.



Description generated using Claude Code; code changes were made manually.