### PR TITLE
fix(accounts): prevent update_stock on Debit Notes

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
@@ -567,6 +567,9 @@ erpnext.accounts.SalesInvoiceController = class SalesInvoiceController extends (
 	set_dynamic_labels() {
 		super.set_dynamic_labels();
 		this.frm.events.hide_fields(this.frm);
+		if (this.frm.doc.is_debit_note) {
+			this.frm.set_df_property("update_stock", "hidden", 1);
+		}
 	}
 
 	items_on_form_rendered() {
@@ -1153,6 +1156,16 @@ frappe.ui.form.on("Sales Invoice", {
 			"total_billing_hours",
 			frm.doc.timesheets.reduce((a, b) => a + (b["billing_hours"] || 0.0), 0.0)
 		);
+	},
+
+	is_debit_note: function (frm) {
+		if (frm.doc.is_debit_note) {
+			frm.set_value("update_stock", 0);
+			frm.set_df_property("update_stock", "hidden", 1);
+		} else {
+			frm.set_df_property("update_stock", "hidden", 0);
+		}
+		frm.refresh_field("update_stock");
 	},
 
 	refresh: function (frm) {

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
@@ -567,7 +567,8 @@ erpnext.accounts.SalesInvoiceController = class SalesInvoiceController extends (
 	set_dynamic_labels() {
 		super.set_dynamic_labels();
 		this.frm.events.hide_fields(this.frm);
-		this.frm.set_df_property("update_stock", "hidden", cint(this.frm.doc.is_debit_note));
+		const hide_update_stock = cint(this.frm.doc.is_debit_note) || cint(this.frm.doc.has_subcontracted);
+		this.frm.set_df_property("update_stock", "hidden", hide_update_stock);
 	}
 
 	items_on_form_rendered() {
@@ -1160,8 +1161,8 @@ frappe.ui.form.on("Sales Invoice", {
 		if (frm.doc.is_debit_note) {
 			frm.set_value("update_stock", 0);
 		}
-		frm.set_df_property("update_stock", "hidden", cint(frm.doc.is_debit_note));
-		frm.refresh_field("update_stock");
+		// visibility handled by set_dynamic_labels()
+		frm.cscript.set_dynamic_labels();
 	},
 
 	refresh: function (frm) {
@@ -1170,7 +1171,6 @@ frappe.ui.form.on("Sales Invoice", {
 		}
 
 		frm.set_df_property("update_stock", "read_only", frm.doc.has_subcontracted);
-		frm.toggle_display("update_stock", !frm.doc.has_subcontracted);
 	},
 });
 

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
@@ -567,9 +567,7 @@ erpnext.accounts.SalesInvoiceController = class SalesInvoiceController extends (
 	set_dynamic_labels() {
 		super.set_dynamic_labels();
 		this.frm.events.hide_fields(this.frm);
-		if (this.frm.doc.is_debit_note) {
-			this.frm.set_df_property("update_stock", "hidden", 1);
-		}
+		this.frm.set_df_property("update_stock", "hidden", cint(this.frm.doc.is_debit_note));
 	}
 
 	items_on_form_rendered() {
@@ -1161,10 +1159,8 @@ frappe.ui.form.on("Sales Invoice", {
 	is_debit_note: function (frm) {
 		if (frm.doc.is_debit_note) {
 			frm.set_value("update_stock", 0);
-			frm.set_df_property("update_stock", "hidden", 1);
-		} else {
-			frm.set_df_property("update_stock", "hidden", 0);
 		}
+		frm.set_df_property("update_stock", "hidden", cint(frm.doc.is_debit_note));
 		frm.refresh_field("update_stock");
 	},
 

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -315,6 +315,7 @@ class SalesInvoice(SellingController):
 		self.validate_uom_is_integer("uom", "qty")
 		self.check_sales_order_on_hold_or_close("sales_order")
 		self.validate_debit_to_acc()
+		self.validate_debit_note_with_update_stock()
 		self.clear_unallocated_advances("Sales Invoice Advance", "advances")
 		self.validate_fixed_asset()
 		self.set_income_account_for_fixed_assets()
@@ -1283,6 +1284,16 @@ class SalesInvoice(SellingController):
 	def validate_account_for_change_amount(self):
 		if flt(self.change_amount) and not self.account_for_change_amount:
 			msgprint(_("Please enter Account for Change Amount"), raise_exception=1)
+
+	def validate_debit_note_with_update_stock(self):
+		if self.is_debit_note and cint(self.update_stock):
+			frappe.throw(
+				_(
+					"You cannot update stock for a Debit Note. A Debit Note is a financial "
+					"document that should not affect inventory. Please disable 'Update Stock'."
+				),
+				title=_("Invalid Configuration"),
+			)
 
 	def validate_dropship_item(self):
 		"""If items are drop shipped, stock cannot be updated."""

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -1286,6 +1286,7 @@ class SalesInvoice(SellingController):
 			msgprint(_("Please enter Account for Change Amount"), raise_exception=1)
 
 	def validate_debit_note_with_update_stock(self):
+		"""Prevent stock update when Sales Invoice is marked as Debit Note."""
 		if self.is_debit_note and cint(self.update_stock):
 			frappe.throw(
 				_(

--- a/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
@@ -4863,6 +4863,7 @@ class TestSalesInvoice(ERPNextTestSuite):
 		frappe.db.set_value("Company", "_Test Company 1", "cost_center", cost_center)
 
 	def test_debit_note_with_update_stock_validation(self):
+		"""Test that saving a Debit Note with Update Stock enabled raises ValidationError."""
 		si = create_sales_invoice(do_not_save=True)
 		si.is_debit_note = 1
 		si.update_stock = 1

--- a/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
@@ -4862,6 +4862,12 @@ class TestSalesInvoice(ERPNextTestSuite):
 
 		frappe.db.set_value("Company", "_Test Company 1", "cost_center", cost_center)
 
+	def test_debit_note_with_update_stock_validation(self):
+		si = create_sales_invoice(do_not_save=True)
+		si.is_debit_note = 1
+		si.update_stock = 1
+		self.assertRaises(frappe.ValidationError, si.save)
+
 
 def make_item_for_si(item_code, properties=None):
 	from erpnext.stock.doctype.item.test_item import make_item


### PR DESCRIPTION
Fixes #54891
https://github.com/frappe/erpnext/issues/54891

What was wrong

A Sales Invoice with `is_debit_note = 1` could have `update_stock = 1` enabled at 
the same time. Submitting it would reduce stock and create Stock Ledger Entries 
which should never happen for a financial-only document.

Changes

- `sales_invoice.py` — added `validate_debit_note_with_update_stock()`, called in 
  `validate()` before any stock logic
  
- `sales_invoice.js` — hide `update_stock` field when `is_debit_note` is checked 
  (on load via `set_dynamic_labels()`, on toggle via field handler)
  
- `test_sales_invoice.py` — added test confirming `ValidationError` is raised

Tested

ValidationError raised as expected. Full `test_sales_invoice` suite passes.