### PR TITLE
fix: inclusive tax amount not considered while setting LCV from purchase invoice

### DIFF
--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
@@ -1375,7 +1375,7 @@ def get_billed_qty_amount_against_purchase_receipt(pr_doc):
 		.on(parent_table.name == table.parent)
 		.select(
 			table.pr_detail,
-			fn.Sum(table.amount * parent_table.conversion_rate).as_("amount"),
+			fn.Sum(table.base_net_amount).as_("amount"),
 			fn.Sum(table.qty).as_("qty"),
 		)
 		.where((table.pr_detail.isin(pr_names)) & (table.docstatus == 1))
@@ -1421,7 +1421,7 @@ def get_billed_qty_amount_against_purchase_order(pr_doc):
 			.select(
 				table.po_detail,
 				fn.Sum(table.qty).as_("qty"),
-				fn.Sum(table.amount * parent_table.conversion_rate).as_("amount"),
+				fn.Sum(table.base_net_amount).as_("amount"),
 			)
 			.where((table.po_detail.isin(po_names)) & (table.docstatus == 1) & (table.pr_detail.isnull()))
 			.groupby(table.po_detail)

--- a/erpnext/stock/doctype/purchase_receipt/test_purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/test_purchase_receipt.py
@@ -5602,6 +5602,157 @@ class TestPurchaseReceipt(ERPNextTestSuite):
 		self.assertIn(company.default_inventory_account, gl_accounts)
 		pr.cancel()
 
+	@ERPNextTestSuite.change_settings(
+		"Buying Settings", {"set_landed_cost_based_on_purchase_invoice_rate": 1, "maintain_same_rate": 0}
+	)
+	def test_srbnb_with_inclusive_tax_and_rate_change_in_pi(self):
+		"""
+		When 'Set Landed Cost Based on PI Rate' is enabled and PI has an inclusive tax:
+		  - PR: qty=2, rate=1000 INR → base_net_amount=2000
+		  - PI: rate changed to 2000, 5% tax included in basic rate
+		      → PI base_net_amount = 2 * 2000 / 1.05 ≈ 3809.52
+
+		The system must use PI's base_net_amount (not amount=4000) so that
+		SRBNB credit on PR = 3809.52, not 4000.
+		"""
+		company = "_Test Company with perpetual inventory"
+		warehouse = "Stores - TCP1"
+		cost_center = "Main - TCP1"
+
+		item_code = make_item(
+			"Test Item for SRBNB Inclusive Tax Rate Change",
+			{"is_stock_item": 1},
+		).name
+
+		pr = make_purchase_receipt(
+			item_code=item_code,
+			qty=2,
+			rate=1000,
+			company=company,
+			warehouse=warehouse,
+			cost_center=cost_center,
+		)
+
+		pi = make_purchase_invoice(pr.name)
+		pi.items[0].rate = 2000
+		pi.append(
+			"taxes",
+			{
+				"charge_type": "On Net Total",
+				"account_head": "_Test Account VAT - TCP1",
+				"category": "Total",
+				"add_deduct_tax": "Add",
+				"included_in_print_rate": 1,
+				"rate": 5,
+				"description": "Test Inclusive Tax",
+				"cost_center": cost_center,
+			},
+		)
+		pi.save()
+		pi.submit()
+
+		pr.reload()
+
+		# PI base_net_amount = qty * (rate / (1 + tax_rate/100)) = 2 * (2000 / 1.05)
+		pi_base_net_amount = flt(2 * 2000 / 1.05, 2)
+		pr_base_net_amount = flt(pr.items[0].amount, 2)  # 2 * 1000 = 2000
+		expected_diff = flt(pi_base_net_amount - pr_base_net_amount, 2)
+
+		self.assertAlmostEqual(pr.items[0].amount_difference_with_purchase_invoice, expected_diff, places=2)
+
+		# Total SRBNB credit = PR base_net_amount + amount_difference = PI base_net_amount
+		srbnb_account = "Stock Received But Not Billed - TCP1"
+		gl_entries = get_gl_entries("Purchase Receipt", pr.name, skip_cancelled=True)
+		srbnb_credit = sum(flt(row.credit) for row in gl_entries if row.account == srbnb_account)
+		self.assertAlmostEqual(srbnb_credit, pi_base_net_amount, places=2)
+
+	@ERPNextTestSuite.change_settings(
+		"Buying Settings", {"set_landed_cost_based_on_purchase_invoice_rate": 1, "maintain_same_rate": 0}
+	)
+	def test_srbnb_with_inclusive_tax_and_exchange_rate_change_in_pi(self):
+		"""
+		When 'Set Landed Cost Based on PI Rate' is enabled, PI has an inclusive tax, and only
+		the exchange rate changes on the PI (rate stays the same):
+		  - PR: qty=2, rate=100 USD, conversion_rate=70 → base_net_amount=14000 INR
+		  - PI: same rate=100 USD, conversion_rate changed to 90, 5% tax included in basic rate
+		      → PI base_net_amount = 2 * (100 / 1.05) * 90 ≈ 17142.86 INR
+
+		The system must use PI's base_net_amount (not amount = 2*100*90 = 18000) so that
+		SRBNB credit on PR = 17142.86, not 18000.
+		"""
+		from erpnext.accounts.doctype.account.test_account import create_account
+
+		company = "_Test Company with perpetual inventory"
+		warehouse = "Stores - TCP1"
+		cost_center = "Main - TCP1"
+
+		party_account = create_account(
+			account_name="USD Payable For SRBNB Exchange Rate Test",
+			parent_account="Accounts Payable - TCP1",
+			account_type="Payable",
+			company=company,
+			account_currency="USD",
+		)
+
+		supplier = create_supplier(
+			supplier_name="_Test USD Supplier for SRBNB Exchange Rate",
+			default_currency="USD",
+			party_account=party_account,
+		).name
+
+		item_code = make_item(
+			"Test Item for SRBNB Inclusive Tax Exchange Rate Change",
+			{"is_stock_item": 1},
+		).name
+
+		pr = make_purchase_receipt(
+			item_code=item_code,
+			qty=2,
+			rate=100,
+			currency="USD",
+			conversion_rate=70,
+			company=company,
+			warehouse=warehouse,
+			supplier=supplier,
+		)
+
+		pi = make_purchase_invoice(pr.name)
+		pi.conversion_rate = 90
+		pi.append(
+			"taxes",
+			{
+				"charge_type": "On Net Total",
+				"account_head": "_Test Account VAT - TCP1",
+				"category": "Total",
+				"add_deduct_tax": "Add",
+				"included_in_print_rate": 1,
+				"rate": 5,
+				"description": "Test Inclusive Tax",
+				"cost_center": cost_center,
+			},
+		)
+		pi.save()
+		pi.submit()
+
+		pr.reload()
+
+		# PI base_net_amount = qty * (rate / (1 + tax_rate/100)) * new_conversion_rate
+		#                    = 2 * (100 / 1.05) * 90 ≈ 17142.86 INR
+		# PR base_net_amount = qty * rate * pr_conversion_rate = 2 * 100 * 70 = 14000 INR
+		tax_amount_pr = (200 - flt(200 / 1.05, 2)) * 90
+
+		pi_base_net_amount = flt(2 * 100 * 90) - flt(tax_amount_pr)
+		pr_base_net_amount = flt(2 * 100 * 70)
+		expected_diff = flt(pi_base_net_amount - pr_base_net_amount)
+
+		self.assertAlmostEqual(pr.items[0].amount_difference_with_purchase_invoice, expected_diff, places=2)
+
+		# Total SRBNB credit = PR base_net_amount + amount_difference = PI base_net_amount
+		srbnb_account = "Stock Received But Not Billed - TCP1"
+		gl_entries = get_gl_entries("Purchase Receipt", pr.name, skip_cancelled=True)
+		srbnb_credit = sum(flt(row.credit) for row in gl_entries if row.account == srbnb_account)
+		self.assertAlmostEqual(srbnb_credit, pi_base_net_amount, places=2)
+
 
 def create_asset_category_for_pr_test():
 	category_name = "Test Asset Category for PR"


### PR DESCRIPTION
## Incoming Rate Adjustment (LCV ) when PI Has Inclusive Tax

### Problem

When **"Set Landed Cost Based on Purchase Invoice Rate"** (`set_landed_cost_based_on_purchase_invoice_rate`) is enabled in Buying Settings, submitting a Purchase Invoice with a tax marked **"Included in Basic Rate"** (`included_in_print_rate = 1`) caused an incorrect credit to **Stock Received But Not Billed (SRBNB)** on the linked Purchase Receipt.

**Example — rate change with inclusive tax:**

|                   | PR     | PI         |
|-------------------|--------|------------|
| Item qty          | 2      | 2          |
| Rate              | 1000   | 2000       |
| 5% inclusive tax  | —      | Yes        |
| `amount`          | 2000   | 4000       |
| `base_net_amount` | 2000   | **3809.52** |

- Expected SRBNB credit on PR after repost: **3809.52**
- Actual SRBNB credit (before fix): **4000**

The same incorrect behaviour occurs when only the exchange rate changes on the PI (not the item rate), combined with an inclusive tax.

---

### Root Cause

`get_billed_qty_amount_against_purchase_receipt` and `get_billed_qty_amount_against_purchase_order` were summing `amount` from Purchase Invoice items instead of `base_net_amount`.

| Field             | Description |
|-------------------|-------------|
| `amount`          | `qty × rate` — gross amount in document currency; **does not strip inclusive taxes** |
| `base_net_amount` | `qty × net_rate × conversion_rate` — net amount in company currency **after removing inclusive tax and applying exchange rate** |

The adjustment formula in `update_billing_percentage` compares the PI's per-unit billed amount against the PR's per-unit base amount (`item.rate × pr_doc.conversion_rate`), both of which must be in **company currency**. Feeding `amount` (transaction currency, inclusive of tax) into this formula produces a larger-than-correct `amount_difference_with_purchase_invoice`, which then over-credits SRBNB on repost.

```python
# purchase_receipt.py — update_billing_percentage
adjusted_amt = (
    flt(billed_amt / qty) - (flt(item.rate) * flt(pr_doc.conversion_rate))
) * item.qty
```

Both sides of this subtraction must be in the same unit (company currency, per unit). Only `base_net_amount` satisfies that requirement.

---

### Fix

**File:** `erpnext/stock/doctype/purchase_receipt/purchase_receipt.py`

Changed `fn.Sum(table.amount)` → `fn.Sum(table.base_net_amount)` in two functions:

#### `get_billed_qty_amount_against_purchase_receipt` (line 1378)
Covers PRs linked directly to a PI via `pr_detail`.

```python
## Before
fn.Sum(table.amount).as_("amount"),

## After
fn.Sum(table.base_net_amount).as_("amount"),
```

#### `get_billed_qty_amount_against_purchase_order` (line 1424)
Covers PRs linked to a PI via a Purchase Order.

```python
## Before
fn.Sum(table.amount).as_("amount"),

## After
fn.Sum(table.base_net_amount).as_("amount"),
```

---

## Expected Behaviour After Fix

| Scenario | `amount_difference_with_purchase_invoice` | Total SRBNB credit |
|---|---|---|
| Rate change (1000 → 2000) + 5% inclusive tax, INR | ≈ 1809.52 | ≈ 3809.52 |
| Exchange rate change (70 → 90) + 5% inclusive tax, USD → INR | ≈ 3142.86 | ≈ 17142.86 |

The total SRBNB credit on the PR after repost always equals the PI's `base_net_amount`, regardless of whether the PI carries inclusive taxes, a changed exchange rate, or both.

---

### Steps to Reproduce (Before Fix)

1. Enable **"Set Landed Cost Based on Purchase Invoice Rate"** in Buying Settings.
2. Create a Purchase Receipt: item qty = 2, rate = 1000.
3. Create a Purchase Invoice from the PR, change rate to 2000.
4. Add a tax of 5% with:
   - **Category:** Total
   - **Is this Tax included in Basic Rate:** ✓ (checked)
5. Submit the Purchase Invoice.
6. Wait for reposting to complete.
7. Open the Purchase Receipt → **Stock Received But Not Billed** GL entry shows **4000** instead of **3809.52**.

---

### Test Coverage

**File:** `erpnext/stock/doctype/purchase_receipt/test_purchase_receipt.py`

#### `test_srbnb_with_inclusive_tax_and_rate_change_in_pi`

- PR: qty=2, rate=1000 INR
- PI: rate changed to 2000, 5% tax included in basic rate
- PI `base_net_amount` = 2 × (2000 / 1.05) ≈ 3809.52
- Asserts `amount_difference_with_purchase_invoice` ≈ 1809.52
- Asserts total SRBNB GL credit ≈ 3809.52

### `test_srbnb_with_inclusive_tax_and_exchange_rate_change_in_pi`

- PR: qty=2, rate=100 USD, conversion_rate=70 → base_net_amount=14000 INR
- PI: same rate=100 USD, conversion_rate changed to 90, 5% tax included in basic rate
- PI `base_net_amount` = 2 × (100 / 1.05) × 90 ≈ 17142.86 INR
- Asserts `amount_difference_with_purchase_invoice` ≈ 3142.86
- Asserts total SRBNB GL credit ≈ 17142.86

Both tests use `@ERPNextTestSuite.change_settings` to scope the Buying Settings flag and verify GL entries with `skip_cancelled=True` after the PI-triggered repost completes.
