### PR TITLE
fix(selling): handle None values while grouping opportunities by utm …

### DIFF
--- a/erpnext/selling/page/sales_funnel/sales_funnel.py
+++ b/erpnext/selling/page/sales_funnel/sales_funnel.py
@@ -102,6 +102,7 @@ def get_opp_by(by_field, from_date, to_date, company):
 				},
 			)
 			for x in opportunities
+			if x.get(by_field)
 		]
 
 		summary = {}


### PR DESCRIPTION
Issue: Sales funnel crashes when the opportunity contains an empty UTM source

Ref: [#69423](https://support.frappe.io/helpdesk/tickets/69423)

Description : 
Fixed a TypeError in the Sales Funnel page while grouping opportunities by UTM source. The issue occurred when opportunities contained empty UTM source values, causing sorting to compare NoneType with string values. Added filtering to exclude records with empty grouping field values before sorting and grouping.

Before: 

<img width="1850" height="924" alt="image" src="https://github.com/user-attachments/assets/239e68a9-2530-45bb-b4f9-905a6d5e82b8" />


After : 

<img width="1854" height="934" alt="image" src="https://github.com/user-attachments/assets/29facf92-e5ba-4b1d-bf74-fa672e4c3b3e" />


Backport Needed For V16