### PR TITLE
fix: validate returned items against reference document

### DIFF
--- a/erpnext/controllers/sales_and_purchase_return.py
+++ b/erpnext/controllers/sales_and_purchase_return.py
@@ -120,22 +120,20 @@ def validate_returned_items(doc):
 	items_returned = False
 	for d in doc.get("items"):
 		key = d.item_code
-		raise_exception = False
 		if doc.doctype in ["Purchase Receipt", "Purchase Invoice", "Sales Invoice", "POS Invoice"]:
 			field = frappe.scrub(doc.doctype) + "_item"
 			if d.get(field):
 				key = (d.item_code, d.get(field))
-				raise_exception = True
 		elif doc.doctype == "Delivery Note":
-			key = (d.item_code, d.get("dn_detail"))
+			if d.get("dn_detail"):
+				key = (d.item_code, d.get("dn_detail"))
 
 		if d.item_code and (flt(d.qty) <= 0 or flt(d.get("received_qty")) <= 0):
 			if key not in valid_items:
-				frappe.msgprint(
+				frappe.throw(
 					_("Row # {0}: Returned Item {1} does not exist in {2} {3}").format(
 						d.idx, d.item_code, doc.doctype, doc.return_against
 					),
-					raise_exception=raise_exception,
 				)
 			else:
 				ref = valid_items.get(key, frappe._dict())


### PR DESCRIPTION
Issue:
Return documents, such as Purchase Receipt, Purchase Invoice, Sales Invoice, and Delivery Note, allowed users to add items not present in the original reference document. In some cases, the system only displayed a message instead of blocking the transaction.

Description:
Updated returned item validation to validate items against the reference document strictly. The system now throws an exception for invalid returned items, preventing submission of return documents with mismatched items across Purchase Receipt, Purchase Invoice, Sales Invoice, and Delivery Note.

Before: 

[Screencast from 2026-05-26 16-58-32.webm](https://github.com/user-attachments/assets/d730581f-33d7-4e54-aad0-7f6ac1a3f0e6)

After : 

[Screencast from 2026-05-26 16-59-43.webm](https://github.com/user-attachments/assets/d78cc1a8-0984-4b55-86a1-82ccae41aac6)

Backport Needed for V16 and V15