### PR TITLE
fix: WDV depreciation fiscal-year detection (rebased with first-FY monthly carry-forward fix)

### DIFF
--- a/erpnext/assets/doctype/asset_depreciation_schedule/asset_depreciation_schedule.py
+++ b/erpnext/assets/doctype/asset_depreciation_schedule/asset_depreciation_schedule.py
@@ -863,6 +863,7 @@ def get_wdv_or_dd_depr_amount(
 		asset,
 		fb_row,
 		depreciable_value,
+		yearly_opening_wdv,
 		schedule_idx,
 		prev_depreciation_amount,
 		has_wdv_or_dd_non_yearly_pro_rata,
@@ -875,6 +876,7 @@ def get_default_wdv_or_dd_depr_amount(
 	asset,
 	fb_row,
 	depreciable_value,
+	yearly_opening_wdv,
 	schedule_idx,
 	prev_depreciation_amount,
 	has_wdv_or_dd_non_yearly_pro_rata,
@@ -886,6 +888,7 @@ def get_default_wdv_or_dd_depr_amount(
 			asset,
 			fb_row,
 			depreciable_value,
+			yearly_opening_wdv,
 			schedule_idx,
 			prev_depreciation_amount,
 			has_wdv_or_dd_non_yearly_pro_rata,
@@ -896,6 +899,7 @@ def get_default_wdv_or_dd_depr_amount(
 			asset,
 			fb_row,
 			depreciable_value,
+			yearly_opening_wdv,
 			schedule_idx,
 			prev_depreciation_amount,
 			has_wdv_or_dd_non_yearly_pro_rata,
@@ -904,10 +908,35 @@ def get_default_wdv_or_dd_depr_amount(
 		)
 
 
+def _is_fiscal_year_start(depreciable_value, yearly_opening_wdv, schedule_idx):
+	"""
+	Detect if current depreciation period is at a fiscal year boundary.
+
+	The caller (_make_depr_schedule) resets yearly_opening_wdv = value_after_depreciation
+	whenever schedule_date crosses fiscal year end. At fiscal year start, both values
+	will be equal (within tolerance). Mid-year, yearly_opening_wdv > depreciable_value
+	as the asset value has depreciated.
+
+	Args:
+	        depreciable_value: Current asset value
+	        yearly_opening_wdv: Asset value at start of current fiscal year
+	        schedule_idx: Current period index (0-based)
+
+	Returns:
+	        bool: True if at fiscal year start, False otherwise
+	"""
+	if schedule_idx == 0:
+		return True
+
+	# Use tolerance for floating point comparison
+	return abs(flt(yearly_opening_wdv) - flt(depreciable_value)) < 0.01
+
+
 def _get_default_wdv_or_dd_depr_amount(
 	asset,
 	fb_row,
 	depreciable_value,
+	yearly_opening_wdv,
 	schedule_idx,
 	prev_depreciation_amount,
 	has_wdv_or_dd_non_yearly_pro_rata,
@@ -916,21 +945,25 @@ def _get_default_wdv_or_dd_depr_amount(
 	if cint(fb_row.frequency_of_depreciation) == 12:
 		return flt(depreciable_value) * (flt(fb_row.rate_of_depreciation) / 100)
 	else:
+		# Detect fiscal year start by comparing yearly_opening_wdv with depreciable_value
+		# The caller resets yearly_opening_wdv = value_after_depreciation at fiscal year boundary
+		is_fiscal_year_start = _is_fiscal_year_start(depreciable_value, yearly_opening_wdv, schedule_idx)
+
 		if has_wdv_or_dd_non_yearly_pro_rata:
 			if schedule_idx == 0:
 				return flt(depreciable_value) * (flt(fb_row.rate_of_depreciation) / 100)
-			elif schedule_idx % (12 / cint(fb_row.frequency_of_depreciation)) == 1:
+			elif is_fiscal_year_start:
 				return (
-					flt(depreciable_value)
+					flt(yearly_opening_wdv)
 					* flt(fb_row.frequency_of_depreciation)
 					* (flt(fb_row.rate_of_depreciation) / 1200)
 				)
 			else:
 				return prev_depreciation_amount
 		else:
-			if schedule_idx % (12 / cint(fb_row.frequency_of_depreciation)) == 0:
+			if is_fiscal_year_start:
 				return (
-					flt(depreciable_value)
+					flt(yearly_opening_wdv)
 					* flt(fb_row.frequency_of_depreciation)
 					* (flt(fb_row.rate_of_depreciation) / 1200)
 				)
@@ -942,23 +975,27 @@ def _get_daily_prorata_based_default_wdv_or_dd_depr_amount(
 	asset,
 	fb_row,
 	depreciable_value,
+	yearly_opening_wdv,
 	schedule_idx,
 	prev_depreciation_amount,
 	has_wdv_or_dd_non_yearly_pro_rata,
 	asset_depr_schedule,
 	prev_per_day_depr,
 ):
-	if has_wdv_or_dd_non_yearly_pro_rata:  # If applicable days for ther first month is less than full month
+	# Detect fiscal year start by comparing yearly_opening_wdv with depreciable_value
+	is_fiscal_year_start = _is_fiscal_year_start(depreciable_value, yearly_opening_wdv, schedule_idx)
+
+	if has_wdv_or_dd_non_yearly_pro_rata:  # If applicable days for the first month is less than full month
 		if schedule_idx == 0:
 			return flt(depreciable_value) * (flt(fb_row.rate_of_depreciation) / 100), None
 
-		elif schedule_idx % (12 / cint(fb_row.frequency_of_depreciation)) == 1:  # Year changes
-			return get_monthly_depr_amount(fb_row, schedule_idx, depreciable_value)
+		elif is_fiscal_year_start:
+			return get_monthly_depr_amount(fb_row, schedule_idx, yearly_opening_wdv)
 		else:
 			return get_monthly_depr_amount_based_on_prev_per_day_depr(fb_row, schedule_idx, prev_per_day_depr)
 	else:
-		if schedule_idx % (12 / cint(fb_row.frequency_of_depreciation)) == 0:  # year changes
-			return get_monthly_depr_amount(fb_row, schedule_idx, depreciable_value)
+		if is_fiscal_year_start:
+			return get_monthly_depr_amount(fb_row, schedule_idx, yearly_opening_wdv)
 		else:
 			return get_monthly_depr_amount_based_on_prev_per_day_depr(fb_row, schedule_idx, prev_per_day_depr)
 

--- a/erpnext/assets/doctype/asset_depreciation_schedule/asset_depreciation_schedule.py
+++ b/erpnext/assets/doctype/asset_depreciation_schedule/asset_depreciation_schedule.py
@@ -989,7 +989,9 @@ def _get_daily_prorata_based_default_wdv_or_dd_depr_amount(
 		if schedule_idx == 0:
 			return flt(depreciable_value) * (flt(fb_row.rate_of_depreciation) / 100), None
 
-		elif is_fiscal_year_start:
+		elif is_fiscal_year_start or prev_per_day_depr is None:
+			# Recalculate at fiscal year boundary or when per_day_depr not yet established
+			# (prev_per_day_depr is None after first pro-rated period)
 			return get_monthly_depr_amount(fb_row, schedule_idx, yearly_opening_wdv)
 		else:
 			return get_monthly_depr_amount_based_on_prev_per_day_depr(fb_row, schedule_idx, prev_per_day_depr)

--- a/erpnext/assets/doctype/asset_depreciation_schedule/asset_depreciation_schedule.py
+++ b/erpnext/assets/doctype/asset_depreciation_schedule/asset_depreciation_schedule.py
@@ -952,14 +952,16 @@ def _get_default_wdv_or_dd_depr_amount(
 		if has_wdv_or_dd_non_yearly_pro_rata:
 			if schedule_idx == 0:
 				return flt(depreciable_value) * (flt(fb_row.rate_of_depreciation) / 100)
-			elif is_fiscal_year_start:
-				return (
-					flt(yearly_opening_wdv)
-					* flt(fb_row.frequency_of_depreciation)
-					* (flt(fb_row.rate_of_depreciation) / 1200)
-				)
-			else:
-				return prev_depreciation_amount
+			# All subsequent periods use the current fiscal year's opening WDV scaled
+			# to the period frequency. The caller resets yearly_opening_wdv at every
+			# fiscal year boundary, so this single expression correctly handles both
+			# the remaining months of the first fiscal year (after the prorated row 0)
+			# and every subsequent fiscal year start/continuation.
+			return (
+				flt(yearly_opening_wdv)
+				* flt(fb_row.frequency_of_depreciation)
+				* (flt(fb_row.rate_of_depreciation) / 1200)
+			)
 		else:
 			if is_fiscal_year_start:
 				return (


### PR DESCRIPTION
Reopening the work from #51117 (closed). The original issue #51115 was closed because @DipenFrappe asked for "the issue functionally with an example/use case and steps to replicate" and that context was never provided. Adding it here.

## Functional issue + concrete repro

A New Zealand customer migrated from NetSuite to ERPNext in September 2025, mid-fiscal-year (NZ FY = 1 April – 31 March). For all post-go-live fixed assets using Written Down Value depreciation with monthly frequency, the first fiscal year of the depreciation schedule is materially under-stated.

Audit findings on the customer's live data, six assets affected:

| Asset | Cost (NZD) | WDV rate | AFU date | FY26 booked | FY26 should be | Short by |
|---|---:|---:|---|---:|---:|---:|
| Printer | $5,202.42 | 40% | 2025-09-30 | $39.90 | $1,047.16 | **$1,007.62** |
| O2/CO2 Checkpoint | $5,862.00 | 25% | 2025-09-30 | $42.78 | $753.18 | **$709.21** |
| Conveyor | $9,090.00 | 13% | 2025-09-30 | $34.55 | $606.21 | **$571.66** |
| Plant Stand | $7,018.54 | 13% | 2025-09-30 | $26.67 | $468.07 | **$441.40** |
| Thermofermer | $338,084.54 | 13% | 2025-09-30 | $842.87 | $22,105.04 | **$21,262.17** |
| Sealing Jaws | $7,958.44 | 13% | 2025-10-10 | $374.16 | $497.50 | **$123.34** |
| **Cumulative FY26 understatement** | | | | | | **~$24,116** |

Steps to reproduce on a fresh install (using the Thermofermer example):

1. Create an Asset with `is_existing_asset=1`, `opening_accumulated_depreciation=0`, `gross_purchase_amount=338084.54`, `available_for_use_date=2025-09-30`.
2. Add a Finance Book row with `depreciation_method="Written Down Value"`, `frequency_of_depreciation=1` (monthly), `rate_of_depreciation=13`, `total_number_of_depreciations=240`, `daily_prorata_based=0`, `depreciation_start_date=2025-09-30`, `expected_value_after_useful_life=0`.
3. Save and submit.
4. Inspect the Asset Depreciation Schedule. Rows 0-6 (Sept 30 2025 through March 31 2026) all show `depreciation_amount=120.41`. The accumulated FY26 depreciation is $842.87.
5. The accounting-correct schedule for monthly WDV on $338,084.54 at 13% rate is `gross × rate / 12 = $3,663.25` per month. Row 0 (1-day partial) ~$120.41, rows 1-6 should each be $3,663.25, giving an FY26 total of ~$22,099.91.

The schedule "self-corrects" from April 1 onwards because the caller resets `yearly_opening_wdv` at the FY boundary and rows from FY27 onwards recompute. So the impact is **a $24K FY26 understatement that distorts P&L and balance sheet for that year**, before the WDV recalibration kicks in.

## Root cause

`get_wdv_or_dd_depr_amount` has had `yearly_opening_wdv` in its signature for some time (since #50500-era), and the caller `_make_depr_schedule` correctly tracks fiscal-year boundaries and resets `yearly_opening_wdv = value_after_depreciation` at every boundary using `get_fiscal_year()` from the company's Fiscal Year configuration.

But the inner helpers `_get_default_wdv_or_dd_depr_amount` and `_get_daily_prorata_based_default_wdv_or_dd_depr_amount` (lines 907 and 941 of `asset_depreciation_schedule.py` on version-15-hotfix) **never received `yearly_opening_wdv` as a parameter**. They use `schedule_idx % (12 / cint(fb_row.frequency_of_depreciation)) == 0` or `== 1` to detect "year changes". The modulo happens to align with real fiscal years for greenfield assets whose `depreciation_start_date` is the first month of a fiscal year, but breaks for:

- **Migrated assets** (`opening_number_of_booked_depreciations > 0`): modulo phase is shifted off the real FY boundary by the number of pre-existing booked depreciations.
- **First fiscal year of any asset with mid-period AFU**: the prorated row 0 leads into rows 1..N of the same FY, and the modulo says "year change" at idx=1 (not at the real FY boundary), so rows 2..N get `prev_depreciation_amount` which is the partial-prorate value from row 0.

## What this PR does

Three commits on top of `version-15-hotfix`:

1. **`fix: use yearly_opening_wdv for WDV depreciation fiscal year detection`** (was the original #51117). Passes `yearly_opening_wdv` through to the inner helpers and adds `_is_fiscal_year_start()` which detects the boundary by comparing `yearly_opening_wdv` to `depreciable_value`. The caller has already set these equal at every real FY boundary; mid-FY the value has depreciated so they differ.

2. **`fix: handle prev_per_day_depr is None in daily prorata WDV calculation`**. After the pro-rated first row returns `None` for `prev_per_day_depr`, idx=1 used to dereference it (TypeError when no FY boundary fires). Recalculate the per-day rate from `yearly_opening_wdv` when not yet established.

3. **`fix: collapse WDV prorata branch to use yearly_opening_wdv unconditionally`** (new). For the prorata-true case in `_get_default_wdv_or_dd_depr_amount`, every `schedule_idx > 0` now uses `yearly_opening_wdv * frequency * rate / 1200`. The caller resets at every FY boundary, so this single expression correctly handles both the remaining months of FY1 (after the prorated row 0) and every subsequent FY start/continuation. This is the first-FY carry-forward fix.

The downstream NexWave regional override (one-highflyer/erpnext_new_zealand_customizations#268 and one-highflyer/erpnext_new_zealand_customizations#269) deploys the equivalent logic at the `regional_overrides` level for NZ and AU. The override is the only thing keeping affected NZ/AU customers' books accurate today.

## What still needs to happen before merge

**Existing daily-prorata tests in `test_asset_depreciation_schedule.py` need updating**. Three test cases fail under the new code:
- `test_for_daily_prorata_based_depreciation_wdv_method_frequency_3_months`
- `test_for_daily_prorata_based_depreciation_wdv_method_frequency_6_months`
- `test_for_daily_prorata_based_depreciation_wdv_method_frequency_12_months` (likely)

Values diverge from the test's hardcoded expectations by hundreds of dollars per row. Expected, because the fix changes the FY-boundary detection logic — the test's old values locked in the modulo-based behavior, which is exactly what we're trying to fix. **Each updated value needs hand-computation against the WDV formula to confirm it's accounting-correct** — auto-updating to match what the code produces would just re-lock the bug.

New tests should also lock down the migrated-asset case and the first-FY monthly carry-forward case explicitly. The NexWave override has 11 unit tests covering these and could be adapted to upstream's style.

## Marking as draft

Until the test reconciliation lands. Treating this as a starting point for review rather than a ready-to-merge change. Happy to iterate or hand off.

Closes #51115.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved asset depreciation calculations for WDV (Weighted Depreciation Value) and Double Declining Balance depreciation methods with non-standard fiscal year frequencies. The system now accurately detects fiscal year boundaries for more precise depreciation amount computations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/frappe/erpnext/pull/55310?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->