### PR TITLE
fix: render HTML labels in open payment requests link dropdown

### DIFF
--- a/erpnext/accounts/doctype/payment_request/payment_request.py
+++ b/erpnext/accounts/doctype/payment_request/payment_request.py
@@ -1293,11 +1293,16 @@ def get_open_payment_requests_query(
 	)
 
 	return [
-		(
-			pr.name,
-			_("<strong>Grand Total:</strong> {0}").format(pr.grand_total),
-			_("<strong>Outstanding Amount:</strong> {0}").format(pr.outstanding_amount),
-		)
+		{
+			"value": pr.name,
+			"description": ", ".join(
+				[
+					_("<strong>Grand Total:</strong> {0}").format(pr.grand_total),
+					_("<strong>Outstanding Amount:</strong> {0}").format(pr.outstanding_amount),
+				]
+			),
+			"description_html": True,
+		}
 		for pr in open_payment_requests
 	]
 


### PR DESCRIPTION
## Summary

- `get_open_payment_requests_query` was returning tuples with `<strong>` HTML tags in the description fields; these were being plain-text escaped in the awesomplete dropdown, showing raw tags to the user
- Changed the return type to dicts with `description_html: True`, using the opt-in flag introduced in frappe (frappe/frappe#39544) to signal intentional HTML so the dropdown renders the labels as intended