### PR TITLE
fix: material transfer in transit issue

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -3638,12 +3638,12 @@ class StockEntry(StockController, SubcontractingInwardController):
 			args = {
 				"source_dt": "Stock Entry Detail",
 				"target_field": "transferred_qty",
-				"target_ref_field": "qty",
+				"target_ref_field": "transfer_qty",
 				"target_dt": "Stock Entry Detail",
 				"join_field": "ste_detail",
 				"target_parent_dt": "Stock Entry",
 				"target_parent_field": "per_transferred",
-				"source_field": "qty",
+				"source_field": "transfer_qty",
 				"percent_join_field": "against_stock_entry",
 			}
 


### PR DESCRIPTION
Steps to replicate the issue
1. Make material transfer stock entry and enable Add to Transit
2. Add item which has stock uom Nos with qty 10 and UOM as BOX and conversion factor as 0.5
3. Submit the entry, and click on End Transit
4. Submit the new entry and goto original in transit entry
5. You will notice the end transit but is still showing even after transferring all quantities 
