### PR TITLE
fix(stock): change valuation rate column label in stock ledger entry/report

### DIFF
--- a/erpnext/stock/doctype/stock_ledger_entry/stock_ledger_entry.json
+++ b/erpnext/stock/doctype/stock_ledger_entry/stock_ledger_entry.json
@@ -1,12 +1,12 @@
 {
  "actions": [],
+ "allow_bulk_edit": 1,
  "allow_copy": 1,
  "autoname": "MAT-SLE-.YYYY.-.#####",
  "creation": "2013-01-29 19:25:42",
  "doctype": "DocType",
  "document_type": "Other",
  "engine": "InnoDB",
- "is_submittable": 1,
  "field_order": [
   "item_code",
   "warehouse",
@@ -205,7 +205,7 @@
   {
    "fieldname": "valuation_rate",
    "fieldtype": "Currency",
-   "label": "Valuation Rate",
+   "label": "Average Rate",
    "oldfieldname": "valuation_rate",
    "oldfieldtype": "Currency",
    "options": "Company:company:default_currency",
@@ -361,12 +361,13 @@
  "idx": 1,
  "in_create": 1,
  "index_web_pages_for_search": 1,
+ "is_submittable": 1,
  "links": [],
- "modified": "2025-10-04 09:59:15.546556",
+ "modified": "2026-05-26 19:07:43.537450",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Stock Ledger Entry",
- "naming_rule": "Expression (old style)",
+ "naming_rule": "Expression",
  "owner": "Administrator",
  "permissions": [
   {

--- a/erpnext/stock/report/stock_ledger/stock_ledger.py
+++ b/erpnext/stock/report/stock_ledger/stock_ledger.py
@@ -374,7 +374,7 @@ def get_columns(filters):
 				"convertible": "rate",
 			},
 			{
-				"label": _("Valuation Rate"),
+				"label": _("Outgoing Rate"),
 				"fieldname": "in_out_rate",
 				"fieldtype": filters.valuation_field_type,
 				"width": 140,

--- a/erpnext/stock/report/stock_ledger/stock_ledger.py
+++ b/erpnext/stock/report/stock_ledger/stock_ledger.py
@@ -108,10 +108,11 @@ def execute(filters=None):
 		if sle.serial_no:
 			update_available_serial_nos(available_serial_nos, sle)
 
-		if sle.actual_qty:
+		if sle.actual_qty < 0:
 			sle["in_out_rate"] = flt(sle.stock_value_difference / sle.actual_qty, precision)
+			sle["incoming_rate"] = 0
 
-		elif sle.voucher_type == "Stock Reconciliation":
+		elif sle.voucher_type == "Stock Reconciliation" and sle.actual_qty < 0:
 			sle["in_out_rate"] = sle.valuation_rate
 
 		if (
@@ -192,7 +193,7 @@ def get_segregated_bundle_entries(sle, bundle_details, batch_balance_dict, filte
 		new_sle.update(row)
 		new_sle.update(
 			{
-				"in_out_rate": flt(new_sle.stock_value_difference / row.qty) if row.qty else 0,
+				"in_out_rate": flt(new_sle.stock_value_difference / row.qty) if row.qty < 0 else 0,
 				"in_qty": row.qty if row.qty > 0 else 0,
 				"out_qty": row.qty if row.qty < 0 else 0,
 				"qty_after_transaction": qty_before_transaction + row.qty,


### PR DESCRIPTION
**Issue:**
Users are getting confused with the Valuation Rate labels in Stock Ledger Entry and Stock Ledger Report.

In Stock Ledger Report, the Average Rate is actually the valuation rate, and the Valuation Rate column shows the outgoing rate. But in Stock Ledger Entry, the label is still shown as Valuation Rate.

So this PR:

1. Changes the Valuation Rate label to Average Rate in Stock Ledger Entry.
2. Changes the Valuation Rate column to Outgoing Rate in Stock Ledger Report.


**Ref:** [#68170](https://support.frappe.io/helpdesk/tickets/68170)

**Backport Needed for v15 & v16**