### PR TITLE
fix(manufacturing): allow to edit batch size while creating a work order

### DIFF
--- a/erpnext/manufacturing/doctype/bom_operation/bom_operation.json
+++ b/erpnext/manufacturing/doctype/bom_operation/bom_operation.json
@@ -126,11 +126,13 @@
    "label": "Image"
   },
   {
+   "default": "1",
    "fetch_from": "operation.batch_size",
    "fetch_if_empty": 1,
    "fieldname": "batch_size",
-   "fieldtype": "Int",
-   "label": "Batch Size"
+   "fieldtype": "Float",
+   "label": "Batch Size",
+   "non_negative": 1
   },
   {
    "depends_on": "eval:doc.parenttype == \"Routing\" || !parent.routing",
@@ -196,12 +198,13 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-02-17 15:33:28.495850",
+ "modified": "2026-05-27 12:09:44.797434",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "BOM Operation",
  "owner": "Administrator",
  "permissions": [],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []

--- a/erpnext/manufacturing/doctype/bom_operation/bom_operation.py
+++ b/erpnext/manufacturing/doctype/bom_operation/bom_operation.py
@@ -17,7 +17,7 @@ class BOMOperation(Document):
 		base_cost_per_unit: DF.Float
 		base_hour_rate: DF.Currency
 		base_operating_cost: DF.Currency
-		batch_size: DF.Int
+		batch_size: DF.Float
 		cost_per_unit: DF.Float
 		description: DF.TextEditor | None
 		fixed_time: DF.Check

--- a/erpnext/manufacturing/doctype/work_order/work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/work_order.py
@@ -158,7 +158,7 @@ class WorkOrder(Document):
 		self.calculate_operating_cost()
 		self.validate_qty()
 		self.validate_transfer_against()
-		self.validate_operation_time()
+		self.validate_operations()
 		self.status = self.get_status()
 		self.validate_workstation_type()
 		self.reset_use_multi_level_bom()
@@ -1120,9 +1120,12 @@ class WorkOrder(Document):
 				title=_("Missing value"),
 			)
 
-	def validate_operation_time(self):
+	def validate_operations(self):
 		for d in self.operations:
-			if not d.time_in_mins > 0:
+			if not d.batch_size or d.batch_size <= 0:
+				d.batch_size = 1
+
+			if d.time_in_mins <= 0:
 				frappe.throw(_("Operation Time must be greater than 0 for Operation {0}").format(d.operation))
 
 	def update_required_items(self):

--- a/erpnext/manufacturing/doctype/work_order_operation/work_order_operation.json
+++ b/erpnext/manufacturing/doctype/work_order_operation/work_order_operation.json
@@ -185,10 +185,11 @@
    "read_only": 1
   },
   {
+   "default": "1",
    "fieldname": "batch_size",
    "fieldtype": "Float",
    "label": "Batch Size",
-   "read_only": 1
+   "non_negative": 1
   },
   {
    "fieldname": "sequence_id",
@@ -225,12 +226,13 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-05-15 15:10:06.885440",
+ "modified": "2026-05-27 12:56:37.240431",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "Work Order Operation",
  "owner": "Administrator",
  "permissions": [],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": [],


### PR DESCRIPTION
Backport : [#55325](https://github.com/frappe/erpnext/pull/55325)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Batch size fields now support decimal values for more granular production planning.
  * Added default batch size value of 1 to streamline operation entry.

* **Bug Fixes**
  * Enhanced validation for work order operations to ensure batch sizes are valid and positive.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/frappe/erpnext/pull/55332?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->