### PR TITLE
fix #55292: distributed discount amount to read only

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice_item/sales_invoice_item.json
+++ b/erpnext/accounts/doctype/sales_invoice_item/sales_invoice_item.json
@@ -947,7 +947,8 @@
    "fieldtype": "Currency",
    "label": "Distributed Discount Amount",
    "options": "currency",
-   "print_hide": 1
+   "print_hide": 1,
+   "read_only": 1
   },
   {
    "fieldname": "available_quantity_section",

--- a/erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py
+++ b/erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py
@@ -1717,7 +1717,7 @@ def create_stock_reservation_entries_for_so_items(
 			if not from_voucher_type and (
 				not item.get("qty_to_reserve") or qty_to_be_reserved < flt(item.get("qty_to_reserve"))
 			):
-				msg = _("Row #{0}: Only {1} available to reserve for the Item {2}").format(
+				msg = _("Row #{0}: Partial reservation completed. Only {1} could be reserved for Item {2}.").format(
 					item.idx,
 					frappe.bold(str(qty_to_be_reserved / item.conversion_factor) + " " + item.uom),
 					frappe.bold(item.item_code),


### PR DESCRIPTION
changed the distributed-discount-amount to read only mentioned in this bug #55292 :
<img width="1600" height="822" alt="image" src="https://github.com/user-attachments/assets/d7ae45c8-dd6d-4c8e-90ac-0f32dad212b8" />
