### PR TITLE
fix #55292: distributed discount amount to read only

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice_item/sales_invoice_item.json
+++ b/erpnext/accounts/doctype/sales_invoice_item/sales_invoice_item.json
@@ -947,7 +947,8 @@
    "fieldtype": "Currency",
    "label": "Distributed Discount Amount",
    "options": "currency",
-   "print_hide": 1
+   "print_hide": 1,
+   "read_only": 1
   },
   {
    "fieldname": "available_quantity_section",


### PR DESCRIPTION
changed the distributed-discount-amount to read only mentioned in this bug #55292 :
<img width="1600" height="822" alt="image" src="https://github.com/user-attachments/assets/d7ae45c8-dd6d-4c8e-90ac-0f32dad212b8" />
