### PR TITLE
fix: prevent false log entries in Bank Clearance when date unchanged (#55322)

### DIFF
--- a/erpnext/accounts/doctype/bank_clearance/bank_clearance.py
+++ b/erpnext/accounts/doctype/bank_clearance/bank_clearance.py
@@ -94,6 +94,7 @@ class BankClearance(Document):
 		invalid_document = []
 		invalid_cheque_date = []
 		entries_to_update = []
+		no_change_entries = []
 
 		def validate_entry(d):
 			is_valid = True
@@ -146,37 +147,62 @@ class BankClearance(Document):
 					"clearance_date",
 				)
 				if d.clearance_date or old_clearance_date:
-					frappe.db.set_value(
-						"Sales Invoice Payment",
-						{"parent": d.payment_entry, "account": self.get("account"), "amount": [">", 0]},
-						"clearance_date",
-						d.clearance_date,
-					)
-					sales_invoice = frappe.get_lazy_doc("Sales Invoice", d.payment_entry)
-					sales_invoice.add_comment(
-						"Comment",
-						_("Clearance date changed from {0} to {1} via Bank Clearance Tool").format(
-							old_clearance_date, d.clearance_date
-						),
-					)
+					# Compare: None vs value = different, value vs None = different, both values = use getdate
+					if (d.clearance_date is None and old_clearance_date is not None) or \
+					   (d.clearance_date is not None and old_clearance_date is None) or \
+					   (d.clearance_date and old_clearance_date and getdate(d.clearance_date) != getdate(old_clearance_date)):
+						frappe.db.set_value(
+							"Sales Invoice Payment",
+							{"parent": d.payment_entry, "account": self.get("account"), "amount": [">", 0]},
+							"clearance_date",
+							d.clearance_date,
+						)
+						sales_invoice = frappe.get_lazy_doc("Sales Invoice", d.payment_entry)
+						sales_invoice.add_comment(
+							"Comment",
+							_("Clearance date changed from {0} to {1} via Bank Clearance Tool").format(
+								old_clearance_date, d.clearance_date
+							),
+						)
+					else:
+						no_change_entries.append(d.payment_entry)
+				else:
+					# Both clearance dates are None - no change needed
+					no_change_entries.append(d.payment_entry)
 
 			else:
 				payment_entry = frappe.get_lazy_doc(d.payment_document, d.payment_entry)
 				old_clearance_date = payment_entry.clearance_date
 
 				if d.clearance_date or old_clearance_date:
-					# using db_set to trigger notification
-					payment_entry.db_set("clearance_date", d.clearance_date)
+					# Compare: None vs value = different, value vs None = different, both values = use getdate
+					if (d.clearance_date is None and old_clearance_date is not None) or \
+					   (d.clearance_date is not None and old_clearance_date is None) or \
+					   (d.clearance_date and old_clearance_date and getdate(d.clearance_date) != getdate(old_clearance_date)):
+						# using db_set to trigger notification
+						payment_entry.db_set("clearance_date", d.clearance_date)
 
-					payment_entry.add_comment(
-						"Comment",
-						_("Clearance date changed from {0} to {1} via Bank Clearance Tool").format(
-							old_clearance_date, d.clearance_date
-						),
-					)
+						payment_entry.add_comment(
+							"Comment",
+							_("Clearance date changed from {0} to {1} via Bank Clearance Tool").format(
+								old_clearance_date, d.clearance_date
+							),
+						)
+					else:
+						no_change_entries.append(d.payment_entry)
+				else:
+					# Both clearance dates are None - no change needed
+					no_change_entries.append(d.payment_entry)
 
 		self.get_payment_entries()
-		msgprint(_("Clearance Date updated"))
+		
+		if no_change_entries:
+			if len(no_change_entries) == len(entries_to_update):
+				msgprint(_("No changes made. Clearance date already set to the specified date."))
+			else:
+				msgprint(_("Clearance Date updated. Some entries were already set to the specified date."))
+		else:
+			msgprint(_("Clearance Date updated"))
 
 
 def get_payment_entries_for_bank_clearance(


### PR DESCRIPTION
Fixes #55322

This PR prevents false log entries in Bank Clearance when the clearance date hasn't actually changed.

## Problem
When clicking "Update Clearance Date" in Bank Clearance without modifying the clearance date, the system was creating unnecessary log entries in the Activity log, polluting the audit trail.

**Steps to reproduce the issue:**
1. Create a payment entry and set a clearance date
2. Go to Bank Clearance, tick 'Include Reconciled Entries'
3. Click 'Get Payment Entries'
4. Do not modify the clearance date
5. Click 'Update Clearance Date'
6. Check the payment entry's Activity log - false log entry appears

## Solution
- Added date comparison logic to skip updates when clearance date is unchanged
- Properly handle None values to avoid data type mismatch (string vs date object)
- Track no-change entries and provide accurate user feedback
- Fixed both Sales Invoice Payment and Payment Entry code paths

## Changes
- **File Modified:** [erpnext/accounts/doctype/bank_clearance/bank_clearance.py](cci:7://file:///home/erpnext/bench-v16/apps/erpnext/erpnext/accounts/doctype/bank_clearance/bank_clearance.py:0:0-0:0)
- **Lines Changed:** +49 insertions, -23 deletions

## Testing Performed
Tested all scenarios to ensure the fix works correctly:

| Scenario | Expected Behavior | Result |
|----------|------------------|--------|
| Date → Same Date | Skip update, no log entry | ✅ Pass |
| None → None | Skip update, no log entry | ✅ Pass |
| None → Date | Update with log entry | ✅ Pass |
| Date → None | Update with log entry | ✅ Pass |
| Date → Different Date | Update with log entry | ✅ Pass |

## Breaking Changes
None. This is a bug fix that maintains backward compatibility.

## Additional Notes
- No new tests added as this is a logic fix in existing functionality
- Follows existing code patterns in the file
- No linting errors introduced