### PR TITLE
fix: block cancellation if reconciled with a Bank Transaction

### DIFF
--- a/erpnext/accounts/doctype/bank_transaction/test_bank_transaction.py
+++ b/erpnext/accounts/doctype/bank_transaction/test_bank_transaction.py
@@ -97,12 +97,14 @@ class TestBankTransaction(ERPNextTestSuite):
 			]
 		)
 		reconcile_vouchers(bank_transaction.name, vouchers)
-		payment.reload()
-		payment.cancel()
 		bank_transaction.reload()
-		self.assertEqual(bank_transaction.docstatus, DocStatus.submitted())
+		bank_transaction.remove_payment_entries()
+		bank_transaction.reload()
 		self.assertEqual(bank_transaction.unallocated_amount, 1700)
 		self.assertEqual(bank_transaction.payment_entries, [])
+		payment.reload()
+		payment.cancel()
+		self.assertEqual(bank_transaction.docstatus, DocStatus.submitted())
 
 	# Check if ERPNext can correctly filter a linked payments based on the debit/credit amount
 	def test_debit_credit_output(self):

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -292,6 +292,30 @@ class PaymentEntry(AccountsController):
 			alert=True,
 		)
 
+	def before_cancel(self):
+		from erpnext.accounts.doctype.bank_transaction.bank_transaction import (
+			get_reconciled_bank_transactions,
+		)
+
+		linked_bank_transactions = get_reconciled_bank_transactions(self.doctype, self.name)
+
+		active_bank_transactions = []
+		if linked_bank_transactions:
+			active_bank_transactions = frappe.get_all(
+				"Bank Transaction",
+				filters={"name": ("in", linked_bank_transactions), "docstatus": 1},
+				pluck="name",
+			)
+		if active_bank_transactions:
+			frappe.throw(
+				_(
+					"Payment Entry {0} is reconciled with Bank Transaction(s): {1}. Please unreconcile it before cancelling."
+				).format(
+					frappe.bold(self.name),
+					", ".join(frappe.bold(bt) for bt in active_bank_transactions),
+				)
+			)
+
 	def on_cancel(self):
 		self.ignore_linked_doctypes = (
 			"GL Entry",


### PR DESCRIPTION
Prevent Payment Entry cancellation when reconciled with a Bank Transaction

Before cancelling, validate that the Payment Entry is not linked to any submitted Bank Transaction. If it is, throw an error prompting the user to unreconcile first.