### PR TITLE
fix: ensure POS return payments are strictly negative to prevent rounding crash

### DIFF
--- a/erpnext/accounts/doctype/pos_invoice/test_pos_invoice.py
+++ b/erpnext/accounts/doctype/pos_invoice/test_pos_invoice.py
@@ -254,6 +254,10 @@ class TestPOSInvoice(POSInvoiceTestMixin):
 		self.assertEqual(pos_return.get("payments")[1].amount, -500)
 
 	def test_pos_return_with_negative_rounding(self):
+		"""
+		Test that POS invoice returns process correctly with negative rounding adjustments,
+		ensuring the validation loop does not crash on absolute values.
+		"""
 		# 1. Create a POS Invoice that requires negative rounding 
 		# (Grand Total is 100.05, but user pays exactly 100.00)
 		pos = create_pos_invoice(qty=1, rate=100.05, do_not_save=True)
@@ -269,14 +273,15 @@ class TestPOSInvoice(POSInvoiceTestMixin):
 		
 		# Before your -abs() fix, this insert() would crash with a Validation Error
 		pos_return.insert()
+		pos_return.submit() # Added to satisfy the full document lifecycle
 
 		# 3. Assert the fix works
 		self.assertEqual(pos_return.is_return, 1)
+		self.assertEqual(pos_return.docstatus, 1) # Added to verify submitted state
 		
 		# Verify that all returned payment amounts are strictly negative or zero
 		for payment in pos_return.get("payments"):
-			self.assertLessEqual(payment.amount, 0)
-			
+			self.assertLessEqual(payment.amount, 0)			
 
 	def test_pos_return_for_serialized_item(self):
 		from erpnext.stock.doctype.stock_entry.test_stock_entry import make_serialized_item

--- a/erpnext/accounts/doctype/pos_invoice/test_pos_invoice.py
+++ b/erpnext/accounts/doctype/pos_invoice/test_pos_invoice.py
@@ -253,6 +253,31 @@ class TestPOSInvoice(POSInvoiceTestMixin):
 		self.assertEqual(pos_return.get("payments")[0].amount, -500)
 		self.assertEqual(pos_return.get("payments")[1].amount, -500)
 
+	def test_pos_return_with_negative_rounding(self):
+		# 1. Create a POS Invoice that requires negative rounding 
+		# (Grand Total is 100.05, but user pays exactly 100.00)
+		pos = create_pos_invoice(qty=1, rate=100.05, do_not_save=True)
+
+		pos.set("payments", [])
+		pos.append("payments", {"mode_of_payment": "Cash", "amount": 100.00, "default": 1})
+		
+		pos.insert()
+		pos.submit()
+
+		# 2. Generate the return document
+		pos_return = make_sales_return(pos.name)
+		
+		# Before your -abs() fix, this insert() would crash with a Validation Error
+		pos_return.insert()
+
+		# 3. Assert the fix works
+		self.assertEqual(pos_return.is_return, 1)
+		
+		# Verify that all returned payment amounts are strictly negative or zero
+		for payment in pos_return.get("payments"):
+			self.assertLessEqual(payment.amount, 0)
+			
+
 	def test_pos_return_for_serialized_item(self):
 		from erpnext.stock.doctype.stock_entry.test_stock_entry import make_serialized_item
 

--- a/erpnext/controllers/sales_and_purchase_return.py
+++ b/erpnext/controllers/sales_and_purchase_return.py
@@ -489,8 +489,8 @@ def make_return_doc(doctype: str, source_name: str, target_doc=None, return_agai
 						{
 							"mode_of_payment": data.mode_of_payment,
 							"type": data.type,
-							"amount": -1 * paid_amount,
-							"base_amount": -1 * base_paid_amount,
+							"amount": -abs(paid_amount),
+							"base_amount": -abs(base_paid_amount),
 							"account": data.account,
 							"default": data.default,
 						},


### PR DESCRIPTION
## Description
When creating a return document for a POS invoice where the original `paid_amount` included a negative rounding adjustment (e.g., rounding down to the nearest 0.05), the `make_return_doc` function incorrectly inverted this negative adjustment into a positive payment row by multiplying it by `-1`. This caused a validation crash since return payments cannot be positive.

This PR fixes the issue by replacing the `-1 * amount` logic with Python's built-in `-abs(amount)` function. This mathematically guarantees that return payments are always correctly formatted as negative absolute values, preventing the validation loop from crashing on returned rounding adjustments.

closes #55227

## Checklist
- [x] I have tested this locally.
- [x] The code follows the Frappe/ERPNext framework style guide.
- [x] All business logic and validations are on the server-side.