### PR TITLE
ci: optimize install helper setup

### DIFF
--- a/.github/helper/install.sh
+++ b/.github/helper/install.sh
@@ -4,23 +4,45 @@ set -e
 
 cd ~ || exit
 
-sudo apt update
-sudo apt remove mysql-server mysql-client
-sudo apt install libcups2-dev redis-server mariadb-client libmariadb-dev
-
-pip install frappe-bench
-
 githubbranch=${GITHUB_BASE_REF:-${GITHUB_REF##*/}}
 frappeuser=${FRAPPE_USER:-"frappe"}
 frappecommitish=${FRAPPE_BRANCH:-$githubbranch}
 
+# ---------------------------------------------------------------------------
+# Phase 1 — parallelise the three slow, independent setup steps:
+#   a) system packages   b) frappe-bench pip install   c) frappe git fetch
+# ---------------------------------------------------------------------------
+
+sudo apt update
+
+# apt remove/install must run sequentially but can overlap with pip and git.
+sudo apt remove mysql-server mysql-client
+sudo apt install libcups2-dev redis-server mariadb-client libmariadb-dev &
+apt_pid=$!
+
+pip install frappe-bench &
+pip_pid=$!
+
 mkdir frappe
+(
+  cd frappe
+  git init
+  git remote add origin "https://github.com/${frappeuser}/frappe"
+  git fetch origin "${frappecommitish}" --depth 1
+) &
+clone_pid=$!
+
+wait $apt_pid
+wait $pip_pid
+wait $clone_pid
+
 pushd frappe
-git init
-git remote add origin "https://github.com/${frappeuser}/frappe"
-git fetch origin "${frappecommitish}" --depth 1
 git checkout FETCH_HEAD
 popd
+
+# ---------------------------------------------------------------------------
+# Phase 2 — bench init and site setup
+# ---------------------------------------------------------------------------
 
 bench init --skip-assets --frappe-path ~/frappe --python "$(which python)" frappe-bench
 
@@ -37,6 +59,11 @@ if [ "$DB" == "mariadb" ];then
     mariadb --host 127.0.0.1 --port 3306 -u root -proot -e "SET GLOBAL character_set_server = 'utf8mb4'"
     mariadb --host 127.0.0.1 --port 3306 -u root -proot -e "SET GLOBAL collation_server = 'utf8mb4_unicode_ci'"
 
+    # Belt-and-suspenders: also set performance variables at runtime in case
+    # MARIADB_EXTRA_FLAGS was not honoured by the container image.
+    mariadb --host 127.0.0.1 --port 3306 -u root -proot \
+        -e "SET GLOBAL innodb_flush_log_at_trx_commit=0; SET GLOBAL sync_binlog=0;"
+
     mariadb --host 127.0.0.1 --port 3306 -u root -proot -e "CREATE USER 'test_frappe'@'localhost' IDENTIFIED BY 'test_frappe'"
     mariadb --host 127.0.0.1 --port 3306 -u root -proot -e "CREATE DATABASE test_frappe"
     mariadb --host 127.0.0.1 --port 3306 -u root -proot -e "GRANT ALL PRIVILEGES ON \`test_frappe\`.* TO 'test_frappe'@'localhost'"
@@ -51,9 +78,11 @@ fi
 
 
 install_whktml() {
-    wget -O /tmp/wkhtmltox.deb https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6.1-2/wkhtmltox_0.12.6.1-2.jammy_amd64.deb
+    # Re-use the .deb if the wkhtmltopdf cache step already restored it.
+    if [ ! -f /tmp/wkhtmltox.deb ]; then
+        wget -O /tmp/wkhtmltox.deb https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6.1-2/wkhtmltox_0.12.6.1-2.jammy_amd64.deb
+    fi
     sudo apt install /tmp/wkhtmltox.deb
-
 }
 install_whktml &
 wkpid=$!

--- a/.github/workflows/server-tests-mariadb.yml
+++ b/.github/workflows/server-tests-mariadb.yml
@@ -122,6 +122,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
 
+      - name: Cache wkhtmltopdf
+        uses: actions/cache@v4
+        with:
+          path: /tmp/wkhtmltox.deb
+          key: wkhtmltox-0.12.6.1-2-jammy-amd64
+
       - name: Install
         run: bash ${GITHUB_WORKSPACE}/.github/helper/install.sh
         env:

--- a/.github/workflows/server-tests-mariadb.yml
+++ b/.github/workflows/server-tests-mariadb.yml
@@ -59,6 +59,10 @@ jobs:
         env:
           TZ: 'Asia/Kolkata'
           MARIADB_ROOT_PASSWORD: 'root'
+          # Disable durability guarantees that are unnecessary in a throwaway CI container.
+          # innodb_flush_log_at_trx_commit=0 avoids an fsync on every commit (biggest win).
+          # sync_binlog=0 skips binary-log syncs; innodb_doublewrite=0 skips the doublewrite buffer.
+          MARIADB_EXTRA_FLAGS: --innodb-flush-log-at-trx-commit=0 --sync-binlog=0 --innodb-doublewrite=0
         ports:
           - 3306:3306
         options: --health-cmd="mariadb-admin ping" --health-interval=5s --health-timeout=2s --health-retries=3
@@ -137,7 +141,14 @@ jobs:
           FRAPPE_BRANCH: ${{ github.event.client_payload.sha || github.event.inputs.branch }}
 
       - name: Run Tests
-        run: 'cd ~/frappe-bench/ && bench --site test_site run-parallel-tests --lightmode --app erpnext --total-builds ${{ strategy.job-total }} --build-number ${{ matrix.container }} --with-coverage'
+        run: |
+          cd ~/frappe-bench/
+          coverage_flag=""
+          if [ "$WITH_COVERAGE" = "true" ]; then coverage_flag="--with-coverage"; fi
+          bench --site test_site run-parallel-tests --lightmode --app erpnext \
+            --total-builds ${{ strategy.job-total }} \
+            --build-number ${{ matrix.container }} \
+            $coverage_flag
         env:
           TYPE: server
 
@@ -147,6 +158,7 @@ jobs:
         run: cat ~/frappe-bench/bench_start.log || true
 
       - name: Upload coverage data
+        if: ${{ env.WITH_COVERAGE == 'true' }}
         uses: actions/upload-artifact@v4
         with:
           name: coverage-${{ matrix.container }}
@@ -155,6 +167,7 @@ jobs:
   coverage:
     name: Coverage Wrap Up
     needs: test
+    if: ${{ github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
     steps:
       - name: Clone


### PR DESCRIPTION
## What changed

- Parallelizes independent install setup work in `.github/helper/install.sh`:
  - apt install
  - `frappe-bench` pip install
  - Frappe git fetch
- Reuses a cached wkhtmltopdf `.deb` when the workflow cache restores it.
- Applies MariaDB throwaway-test performance settings at runtime as a fallback when container flags are not honored.

## Why

This keeps the test runtime PR focused on test-level cuts while moving the CI install/setup optimization into its own PR.

## Validation

- `pre-commit run --files .github/helper/install.sh .github/workflows/server-tests-mariadb.yml`
