### PR TITLE
fix(stock): get_actual_qty during cancellations

### DIFF
--- a/erpnext/stock/doctype/bin/bin.py
+++ b/erpnext/stock/doctype/bin/bin.py
@@ -255,8 +255,9 @@ def update_qty(bin_name, args):
 	# actual qty is already updated by processing current voucher
 	actual_qty = bin_details.actual_qty or 0.0
 
-	# actual qty is not up to date in case of backdated transaction
-	if future_sle_exists(args):
+	# actual qty is not up to date in case of backdated transactions
+	# or when cancellations are the most recent SLE
+	if future_sle_exists(args) or args.get("is_cancelled"):
 		actual_qty = get_actual_qty(args.get("item_code"), args.get("warehouse"))
 
 	ordered_qty = flt(bin_details.ordered_qty) + flt(args.get("ordered_qty"))


### PR DESCRIPTION
closes #55387

## Proposed Fix

A single-line change to `update_qty` in `bin.py`:

```python
# erpnext/stock/doctype/bin/bin.py

# Before
if future_sle_exists(args):
    actual_qty = get_actual_qty(args.get("item_code"), args.get("warehouse"))

# After
if future_sle_exists(args) or args.get("is_cancelled"):
    actual_qty = get_actual_qty(args.get("item_code"), args.get("warehouse"))
```

When `is_cancelled` is set on args — meaning a cancellation reversal SLE is being processed — skip the cached Bin value and derive `actual_qty` directly from the last non-cancelled SLE via `get_actual_qty`. This is a single indexed lookup already made in the `future_sle_exists = True` path.

### Correctness in all cases

| Scenario | Before fix | After fix |
|---|---|---|
| Cancellation, no future SLEs (the bug) | Uses stale `bin_details.actual_qty` | Uses `get_actual_qty` → correct value |
| Cancellation, future SLEs exist | `future_sle_exists = True` → already calls `get_actual_qty` | No change |
| Normal submission | `is_cancelled = 0` → condition not triggered | No change |

**Performance:** one additional indexed SLE lookup only in the cancellation-with-no-future-SLEs case, which is already the broken path. No regression elsewhere.