### PR TITLE
ci: fix branch base and per-language commits in sync-hotfix-translations

### DIFF
--- a/.github/helper/merge_po_files.py
+++ b/.github/helper/merge_po_files.py
@@ -7,7 +7,7 @@ Merge rules:
   b. language not yet in hotfix → copy file as-is (bench will filter to main.pot)
   c. msgid present in both      → use develop's msgstr
 """
-import shutil
+from datetime import datetime, timezone
 from pathlib import Path
 
 from babel.messages.pofile import read_po, write_po
@@ -24,7 +24,9 @@ for src in sorted(DEVELOP.glob("*.po")):
         dev = read_po(f)
 
     if not dst.exists():
-        shutil.copy(src, dst)
+        dev.revision_date = datetime.now(timezone.utc)
+        with dst.open("wb") as f:
+            write_po(f, dev)
         added += 1
         print(f"  [new]     {src.name}")
         continue
@@ -39,6 +41,7 @@ for src in sorted(DEVELOP.glob("*.po")):
             changes += 1
 
     if changes:
+        hf.revision_date = datetime.now(timezone.utc)
         with dst.open("wb") as f:
             write_po(f, hf)
         updated += 1

--- a/.github/helper/sync_hotfix_translations.sh
+++ b/.github/helper/sync_hotfix_translations.sh
@@ -12,6 +12,23 @@ bench -v init frappe-bench --skip-assets --skip-redis-config-generation --python
 cd ./frappe-bench || exit
 bench get-app --skip-assets erpnext "${GITHUB_WORKSPACE}"
 
+echo "=== Setting up translations_hotfix branch ==="
+cd ./apps/erpnext || exit
+git config user.email "developers@erpnext.com"
+git config user.name "frappe-pr-bot"
+git remote set-url upstream https://github.com/frappe/erpnext.git
+gh auth setup-git
+git fetch upstream version-16-hotfix
+git fetch upstream translations_hotfix 2>/dev/null || true
+
+if git rev-parse --verify upstream/translations_hotfix >/dev/null 2>&1; then
+  git checkout -b translations_hotfix upstream/translations_hotfix
+  git merge -X theirs upstream/version-16-hotfix --no-edit
+else
+  git checkout -b translations_hotfix upstream/version-16-hotfix
+fi
+cd ../.. || exit
+
 echo "=== Fetching develop's .po files ==="
 mkdir -p /tmp/develop-po
 git -C "${GITHUB_WORKSPACE}" fetch origin develop
@@ -31,24 +48,33 @@ bench update-po-files --app erpnext
 
 cd ./apps/erpnext || exit
 
-git config user.email "developers@erpnext.com"
-git config user.name "frappe-pr-bot"
-git remote set-url upstream https://github.com/frappe/erpnext.git
-
-if git diff --quiet erpnext/locale/; then
+if git diff --quiet erpnext/locale/ && [ -z "$(git ls-files --others --exclude-standard erpnext/locale/)" ]; then
   echo "Translations are already up to date. No PR needed."
   exit 0
 fi
 
 echo "Changed files:"
 git diff --name-only erpnext/locale/
+git ls-files --others --exclude-standard erpnext/locale/
 
-echo "=== Committing and pushing ==="
-git checkout -B translations_hotfix
-git add erpnext/locale/
-git commit -m "fix: sync translations to version-16-hotfix"
-gh auth setup-git
-git push -u upstream translations_hotfix --force
+echo "=== Committing ==="
+while IFS= read -r file; do
+  git add "${file}"
+  lang=$(basename "${file}" .po)
+  git commit -m "fix: add ${lang} translation to version-16-hotfix"
+done < <(git ls-files --others --exclude-standard erpnext/locale/ | grep '\.po$' | sort)
+
+while IFS= read -r file; do
+  git add "${file}"
+  if ! git diff --staged --quiet -- "${file}"; then
+    lang=$(basename "${file}" .po)
+    git commit -m "fix: sync ${lang} translation to version-16-hotfix"
+  else
+    git restore --staged -- "${file}"
+  fi
+done < <(git diff --name-only erpnext/locale/ | grep '\.po$' | sort)
+
+git push -u upstream translations_hotfix
 
 echo "=== Opening PR (if not already open) ==="
 existing_pr=$(gh pr list \

--- a/.github/helper/sync_hotfix_translations.sh
+++ b/.github/helper/sync_hotfix_translations.sh
@@ -4,6 +4,9 @@
 # Env: GH_TOKEN, PR_REVIEWER, GITHUB_WORKSPACE (all set by Actions).
 
 set -e
+
+HOTFIX_BRANCH="version-16-hotfix"
+
 cd ~ || exit
 
 echo "=== Setting up bench ==="
@@ -18,14 +21,14 @@ git config user.email "developers@erpnext.com"
 git config user.name "frappe-pr-bot"
 git remote set-url upstream https://github.com/frappe/erpnext.git
 gh auth setup-git
-git fetch upstream version-16-hotfix
+git fetch upstream "${HOTFIX_BRANCH}"
 git fetch upstream translations_hotfix 2>/dev/null || true
 
-if git rev-parse --verify upstream/translations_hotfix >/dev/null 2>&1; then
-  git checkout -b translations_hotfix upstream/translations_hotfix
-  git merge -X theirs upstream/version-16-hotfix --no-edit
+if git rev-parse --verify "upstream/translations_hotfix" >/dev/null 2>&1; then
+  git checkout -b translations_hotfix "upstream/translations_hotfix"
+  git merge -X theirs "upstream/${HOTFIX_BRANCH}" --no-edit
 else
-  git checkout -b translations_hotfix upstream/version-16-hotfix
+  git checkout -b translations_hotfix "upstream/${HOTFIX_BRANCH}"
 fi
 cd ../.. || exit
 
@@ -61,14 +64,14 @@ echo "=== Committing ==="
 while IFS= read -r file; do
   git add "${file}"
   lang=$(basename "${file}" .po)
-  git commit -m "fix: add ${lang} translation to version-16-hotfix"
+  git commit -m "fix: add ${lang} translation to ${HOTFIX_BRANCH}"
 done < <(git ls-files --others --exclude-standard erpnext/locale/ | grep '\.po$' | sort)
 
 while IFS= read -r file; do
   git add "${file}"
   if ! git diff --staged --quiet -- "${file}"; then
     lang=$(basename "${file}" .po)
-    git commit -m "fix: sync ${lang} translation to version-16-hotfix"
+    git commit -m "fix: sync ${lang} translation to ${HOTFIX_BRANCH}"
   else
     git restore --staged -- "${file}"
   fi
@@ -78,7 +81,7 @@ git push -u upstream translations_hotfix
 
 echo "=== Opening PR (if not already open) ==="
 existing_pr=$(gh pr list \
-  --base "version-16-hotfix" \
+  --base "${HOTFIX_BRANCH}" \
   --head "translations_hotfix" \
   --state open \
   --json number \
@@ -91,10 +94,10 @@ if [ "${existing_pr}" -gt 0 ]; then
 fi
 
 gh pr create \
-  --base "version-16-hotfix" \
+  --base "${HOTFIX_BRANCH}" \
   --head "translations_hotfix" \
-  --title "fix: sync translations to version-16-hotfix" \
-  --body "Automated sync of Crowdin translations from \`develop\` to \`version-16-hotfix\`.
+  --title "fix: sync translations to ${HOTFIX_BRANCH}" \
+  --body "Automated sync of Crowdin translations from \`develop\` to \`${HOTFIX_BRANCH}\`.
 
 A 3-way merge is performed per language, then \`bench update-po-files\` reconciles each \`.po\` against hotfix's \`main.pot\`:
 


### PR DESCRIPTION
## Summary

Correctness fixes and a cleanup to the `sync-hotfix-translations` CI pipeline.

### 1. Correct base when `translations_hotfix` is absent (`sync_hotfix_translations.sh`)

`translations_hotfix` is a short-lived branch — it is deleted after each sync PR is merged, so on every new sync cycle the `else` branch is the common path.

The previous code ran:

```bash
git checkout -b translations_hotfix
```

This creates the branch from the local HEAD (the Actions checkout commit for `version-16-hotfix`), silently missing any commits pushed directly to `upstream/version-16-hotfix` after the checkout step. Fixed to:

```bash
git checkout -b translations_hotfix "upstream/${HOTFIX_BRANCH}"
```

### 2. Per-language commit loops (`sync_hotfix_translations.sh`)

The previous single `find`-based loop treated new and modified files identically. Replaced with two explicit passes:

| Loop | Source | Commit message |
|------|--------|----------------|
| 1 — new languages | `git ls-files --others --exclude-standard` | `fix: add <lang> translation to <branch>` |
| 2 — modified files | `git diff --name-only` | `fix: sync <lang> translation to <branch>` |

The early-exit check is also updated to include `git ls-files --others` so a run that only adds a new language doesn't incorrectly exit as "no changes".

### 3. `revision_date` for new language files (`merge_po_files.py`)

`shutil.copy` was replaced with `write_po` so that `revision_date` is set explicitly to `datetime.now(timezone.utc)` — the date the file is first committed to hotfix. For updated files this guard was already in place (`if changes:`). No-op files are never written.

### 4. `HOTFIX_BRANCH` variable (`sync_hotfix_translations.sh`)

Extracted `HOTFIX_BRANCH="version-16-hotfix"` at the top of the script so all references — `git fetch`, checkout, merge, commit messages, `gh pr create` base, and PR title/body — draw from a single declaration.

---

## Workflow sequence (unchanged)

```
Sunday 9:30 UTC
  └─▶ generate-pot-file.yml  (matrix: develop + version-16-hotfix)
          │
          └─▶ PR: chore: update POT file  →  version-16-hotfix
                       │  (human merges)
                       ▼
              push to version-16-hotfix: erpnext/locale/main.pot
                       │
                       ▼
              sync-hotfix-translations.yml  ← primary trigger
                1. bench get-app erpnext  (hotfix — has new main.pot + existing .po)
                2. git archive origin/develop erpnext/locale/ → /tmp/develop-po/
                3. merge_po_files.py  (overlay develop msgstr onto hotfix .po)
                4. bench update-po-files  (reconcile against main.pot)
                5. push → translations_hotfix branch
                6. Open PR if none exists; otherwise, update in place

Monday 10:00 UTC
  └─▶ sync-hotfix-translations.yml  (safety net for Crowdin drift)
```

🤖 Generated with [Claude Code](https://claude.ai/code)