### PR TITLE
fix: billing address does not belongs to the company error

### DIFF
--- a/erpnext/public/js/controllers/buying.js
+++ b/erpnext/public/js/controllers/buying.js
@@ -174,14 +174,9 @@ erpnext.buying = {
 					callback: (r) => {
 						if (!r.message) return;
 
-						if (!this.frm.doc.billing_address) {
-							this.frm.set_value("billing_address", r.message.primary_address || "");
-						}
+						this.frm.set_value("billing_address", r.message.primary_address || "");
 
-						if (
-							frappe.meta.has_field(this.frm.doc.doctype, "shipping_address") &&
-							!this.frm.doc.shipping_address
-						) {
+						if (frappe.meta.has_field(this.frm.doc.doctype, "shipping_address")) {
 							this.frm.set_value("shipping_address", r.message.shipping_address || "");
 						}
 					},


### PR DESCRIPTION
1. Create purchase receipt for company A
2. Change the company to B and save 
3. You will get the error "billing address does not belongs to the company B"

Ideally system should reset the shipping and billing address on change of the company