### PR TITLE
feat: opening invoice tool return option

### DIFF
--- a/erpnext/accounts/doctype/opening_invoice_creation_tool/opening_invoice_creation_tool.py
+++ b/erpnext/accounts/doctype/opening_invoice_creation_tool/opening_invoice_creation_tool.py
@@ -179,6 +179,21 @@ class OpeningInvoiceCreationTool(Document):
 
 	def get_invoice_dict(self, row=None):
 		def get_item_dict():
+			msg = ""
+			if not row.get("is_return"):
+				if flt(row.qty) <= 0:
+					msg = _("Row #{0}: Quantity must be a positive number")
+				elif flt(row.outstanding_amount) <= 0:
+					msg = _("Row #{0}: Outstanding Amount must be a positive number")
+			else:
+				if flt(row.qty) >= 0:
+					msg = _("Row #{0}: Quantity must be a negative number")
+				elif flt(row.outstanding_amount) >= 0:
+					msg = _("Row #{0}: Outstanding Amount must be a negative number")
+
+			if msg:
+				frappe.throw(msg.format(row.idx))
+
 			cost_center = row.get("cost_center") or frappe.get_cached_value(
 				"Company", self.company, "cost_center"
 			)
@@ -197,12 +212,13 @@ class OpeningInvoiceCreationTool(Document):
 				{
 					"uom": default_uom,
 					"rate": rate or 0.0,
-					"qty": row.qty,
+					"qty": flt(row.qty),
 					"conversion_factor": 1.0,
 					"item_name": row.item_name or "Opening Invoice Item",
 					"description": row.item_name or "Opening Invoice Item",
 					income_expense_account_field: row.temporary_opening_account,
 					"cost_center": cost_center,
+					"project": row.project,
 				}
 			)
 
@@ -220,10 +236,12 @@ class OpeningInvoiceCreationTool(Document):
 				"set_posting_time": 1,
 				"company": self.company,
 				"cost_center": self.cost_center,
+				"project": self.project,
 				"due_date": row.due_date,
 				"posting_date": row.posting_date,
 				frappe.scrub(row.party_type): row.party,
 				"is_pos": 0,
+				"is_return": row.is_return,
 				"doctype": "Sales Invoice" if self.invoice_type == "Sales" else "Purchase Invoice",
 				"update_stock": 0,  # important: https://github.com/frappe/erpnext/pull/23559
 				"invoice_number": row.invoice_number,

--- a/erpnext/accounts/doctype/opening_invoice_creation_tool_item/opening_invoice_creation_tool_item.json
+++ b/erpnext/accounts/doctype/opening_invoice_creation_tool_item/opening_invoice_creation_tool_item.json
@@ -14,6 +14,7 @@
   "posting_date",
   "due_date",
   "supplier_invoice_date",
+  "is_return",
   "section_break_5",
   "item_name",
   "outstanding_amount",
@@ -21,7 +22,8 @@
   "qty",
   "accounting_dimensions_section",
   "cost_center",
-  "dimension_col_break"
+  "dimension_col_break",
+  "project"
  ],
  "fields": [
   {
@@ -125,11 +127,23 @@
    "fieldtype": "Data",
    "in_list_view": 1,
    "label": "Party Name"
+  },
+  {
+   "default": "0",
+   "fieldname": "is_return",
+   "fieldtype": "Check",
+   "label": "Is Return"
+  },
+  {
+   "fieldname": "project",
+   "fieldtype": "Link",
+   "label": "Project",
+   "options": "Project"
   }
  ],
  "istable": 1,
  "links": [],
- "modified": "2026-03-20 02:11:42.023575",
+ "modified": "2026-05-29 18:18:01.563833",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Opening Invoice Creation Tool Item",

--- a/erpnext/accounts/doctype/opening_invoice_creation_tool_item/opening_invoice_creation_tool_item.py
+++ b/erpnext/accounts/doctype/opening_invoice_creation_tool_item/opening_invoice_creation_tool_item.py
@@ -17,6 +17,7 @@ class OpeningInvoiceCreationToolItem(Document):
 		cost_center: DF.Link | None
 		due_date: DF.Date | None
 		invoice_number: DF.Data | None
+		is_return: DF.Check
 		item_name: DF.Data | None
 		outstanding_amount: DF.Currency
 		parent: DF.Data
@@ -26,6 +27,7 @@ class OpeningInvoiceCreationToolItem(Document):
 		party_name: DF.Data | None
 		party_type: DF.Link | None
 		posting_date: DF.Date | None
+		project: DF.Link | None
 		qty: DF.Data | None
 		supplier_invoice_date: DF.Date | None
 		temporary_opening_account: DF.Link | None


### PR DESCRIPTION
- When creating opening invoices for Customers or Suppliers using the Opening Invoice Creation Tool, there are cases where the opening balance should be created as a return invoice.

- Currently, the tool only allows positive quantities and amounts. Even if negative values are entered for Qty or Amount, validation prevents the document from being created. As a result, return-type opening invoices cannot be created through the tool.

`no-docs`

Fixes #55223