### PR TITLE
refactor(general_ledger): update party type options to include empty string

### DIFF
--- a/erpnext/accounts/report/general_ledger/general_ledger.js
+++ b/erpnext/accounts/report/general_ledger/general_ledger.js
@@ -64,7 +64,7 @@ frappe.query_reports["General Ledger"] = {
 			fieldname: "party_type",
 			label: __("Party Type"),
 			fieldtype: "Autocomplete",
-			options: Object.keys(frappe.boot.party_account_types),
+			options: ["", ...Object.keys(frappe.boot.party_account_types)],
 			on_change: function () {
 				frappe.query_report.set_filter_value("party", []);
 			},


### PR DESCRIPTION
## Issue

* When users navigate through filter fields using the **Tab** key, the **Party Type** autocomplete field automatically selects **Customer** when it loses focus, even if no option was explicitly selected.

## Solution

* Add an empty string (`""`) as the first option in the autocomplete field options.

### Before

https://github.com/user-attachments/assets/acd93caa-8b9d-4bd5-b19e-6ad6c099ac66

### After

https://github.com/user-attachments/assets/304c9266-4c8e-41e4-8a20-02bab654d0e7


> [!NOTE]
> Backport to V-16 and V-15.
