### PR TITLE
fix(regional): update japan ct tax rate

### DIFF
--- a/erpnext/setup/setup_wizard/data/country_wise_tax.json
+++ b/erpnext/setup/setup_wizard/data/country_wise_tax.json
@@ -4219,9 +4219,14 @@
 	},
 
 	"Japan": {
-		"Japan Tax": {
-			"account_name": "CT",
-			"tax_rate": 5.00
+		"Japan CT 10%": {
+			"account_name": "CT 10%",
+			"tax_rate": 10.00,
+			"default": 1
+		},
+		"Japan CT 8%": {
+			"account_name": "CT 8%",
+			"tax_rate": 8.00
 		}
 	},
 


### PR DESCRIPTION
Fixes frappe/erpnext#55386

Added Japan CT Tax Rate for both 10% and 8%. If users have already not created, they can create using the following steps:

Company > Manage (on top right corner) > Create Tax Template