### PR TITLE
chore: mark as out of beta

### DIFF
--- a/erpnext/accounts/doctype/dunning/dunning.json
+++ b/erpnext/accounts/doctype/dunning/dunning.json
@@ -1,8 +1,8 @@
 {
  "actions": [],
+ "allow_bulk_edit": 1,
  "allow_events_in_timeline": 1,
  "autoname": "naming_series:",
- "beta": 1,
  "creation": "2019-07-05 16:34:31.013238",
  "doctype": "DocType",
  "engine": "InnoDB",
@@ -400,7 +400,7 @@
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2024-11-26 13:46:07.760867",
+ "modified": "2026-05-30 23:18:04.712528",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Dunning",
@@ -449,6 +449,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "ASC",
  "states": [],

--- a/erpnext/accounts/doctype/dunning_type/dunning_type.json
+++ b/erpnext/accounts/doctype/dunning_type/dunning_type.json
@@ -1,7 +1,7 @@
 {
  "actions": [],
+ "allow_bulk_edit": 1,
  "allow_rename": 1,
- "beta": 1,
  "creation": "2019-12-04 04:59:08.003664",
  "doctype": "DocType",
  "editable_grid": 1,
@@ -107,7 +107,7 @@
    "link_fieldname": "dunning_type"
   }
  ],
- "modified": "2024-03-27 13:08:19.584112",
+ "modified": "2026-05-30 23:18:20.740726",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Dunning Type",
@@ -151,6 +151,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],

--- a/erpnext/accounts/doctype/opening_invoice_creation_tool/opening_invoice_creation_tool.json
+++ b/erpnext/accounts/doctype/opening_invoice_creation_tool/opening_invoice_creation_tool.json
@@ -1,7 +1,7 @@
 {
  "actions": [],
+ "allow_bulk_edit": 1,
  "allow_copy": 1,
- "beta": 1,
  "creation": "2017-08-29 02:22:54.947711",
  "doctype": "DocType",
  "editable_grid": 1,
@@ -90,7 +90,7 @@
  "hide_toolbar": 1,
  "issingle": 1,
  "links": [],
- "modified": "2026-03-31 01:47:20.360352",
+ "modified": "2026-05-30 23:18:48.691227",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Opening Invoice Creation Tool",


### PR DESCRIPTION
Remove the `beta` mark from DocTypes that have been in use for a long time.
