### PR TITLE
chore: mark as out of beta (backport #55439)

### DIFF
--- a/erpnext/accounts/doctype/bank_statement_import/bank_statement_import.json
+++ b/erpnext/accounts/doctype/bank_statement_import/bank_statement_import.json
@@ -1,7 +1,6 @@
 {
  "actions": [],
  "autoname": "format:Bank Statement Import on {creation}",
- "beta": 1,
  "creation": "2019-08-04 14:16:08.318714",
  "doctype": "DocType",
  "editable_grid": 1,
@@ -211,10 +210,11 @@
  ],
  "hide_toolbar": 1,
  "links": [],
- "modified": "2024-06-25 17:32:07.658250",
+ "modified": "2026-05-30 20:51:10.353723",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Bank Statement Import",
+ "naming_rule": "Expression (old style)",
  "owner": "Administrator",
  "permissions": [
   {
@@ -230,7 +230,9 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "track_changes": 1
 }

--- a/erpnext/accounts/doctype/dunning/dunning.json
+++ b/erpnext/accounts/doctype/dunning/dunning.json
@@ -2,7 +2,6 @@
  "actions": [],
  "allow_events_in_timeline": 1,
  "autoname": "naming_series:",
- "beta": 1,
  "creation": "2019-07-05 16:34:31.013238",
  "doctype": "DocType",
  "engine": "InnoDB",
@@ -400,7 +399,7 @@
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2024-11-26 13:46:07.760867",
+ "modified": "2026-05-30 20:40:30.851842",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Dunning",
@@ -449,6 +448,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "ASC",
  "states": [],

--- a/erpnext/accounts/doctype/dunning_type/dunning_type.json
+++ b/erpnext/accounts/doctype/dunning_type/dunning_type.json
@@ -1,7 +1,6 @@
 {
  "actions": [],
  "allow_rename": 1,
- "beta": 1,
  "creation": "2019-12-04 04:59:08.003664",
  "doctype": "DocType",
  "editable_grid": 1,
@@ -107,7 +106,7 @@
    "link_fieldname": "dunning_type"
   }
  ],
- "modified": "2021-11-13 00:25:35.659283",
+ "modified": "2026-05-30 20:40:09.952533",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Dunning Type",
@@ -151,7 +150,9 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "track_changes": 1
 }

--- a/erpnext/accounts/doctype/opening_invoice_creation_tool/opening_invoice_creation_tool.json
+++ b/erpnext/accounts/doctype/opening_invoice_creation_tool/opening_invoice_creation_tool.json
@@ -1,6 +1,6 @@
 {
+ "actions": [],
  "allow_copy": 1,
- "beta": 1,
  "creation": "2017-08-29 02:22:54.947711",
  "doctype": "DocType",
  "editable_grid": 1,
@@ -64,10 +64,10 @@
    "options": "Cost Center"
   },
   {
-    "fieldname": "project",
-    "fieldtype": "Link",
-    "label": "Project",
-    "options": "Project"
+   "fieldname": "project",
+   "fieldtype": "Link",
+   "label": "Project",
+   "options": "Project"
   },
   {
    "collapsible": 1,
@@ -82,7 +82,8 @@
  ],
  "hide_toolbar": 1,
  "issingle": 1,
- "modified": "2022-01-04 15:25:06.053187",
+ "links": [],
+ "modified": "2026-05-30 20:43:36.282738",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Opening Invoice Creation Tool",
@@ -99,7 +100,9 @@
   }
  ],
  "quick_entry": 1,
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "track_changes": 1
 }

--- a/erpnext/accounts/doctype/opening_invoice_creation_tool/opening_invoice_creation_tool.py
+++ b/erpnext/accounts/doctype/opening_invoice_creation_tool/opening_invoice_creation_tool.py
@@ -31,6 +31,7 @@ class OpeningInvoiceCreationTool(Document):
 		create_missing_party: DF.Check
 		invoice_type: DF.Literal["Sales", "Purchase"]
 		invoices: DF.Table[OpeningInvoiceCreationToolItem]
+		project: DF.Link | None
 	# end: auto-generated types
 
 	def onload(self):

--- a/erpnext/portal/doctype/homepage/homepage.json
+++ b/erpnext/portal/doctype/homepage/homepage.json
@@ -1,6 +1,5 @@
 {
  "actions": [],
- "beta": 1,
  "creation": "2016-04-22 05:27:52.109319",
  "doctype": "DocType",
  "document_type": "Setup",
@@ -87,7 +86,7 @@
  ],
  "issingle": 1,
  "links": [],
- "modified": "2022-12-19 21:10:29.127277",
+ "modified": "2026-05-30 20:51:04.415019",
  "modified_by": "Administrator",
  "module": "Portal",
  "name": "Homepage",
@@ -114,6 +113,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": [],


### PR DESCRIPTION
Remove `is_beta` mark from DocTypes that have been in use for a long time.

These DocTypes have been created >3 years before the first v15 release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional Project field to the Opening Invoice Creation Tool for tracking invoices by project.

* **Chores**
  * Removed beta status from Dunning, Dunning Type, Opening Invoice Creation Tool, Bank Statement Import, and Homepage.
  * Refreshed form metadata and list/layout settings across several records for improved consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/frappe/erpnext/pull/55440?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->