### PR TITLE
chore(Bank Statement Import): mark as out of beta

### DIFF
--- a/erpnext/accounts/doctype/bank_statement_import/bank_statement_import.json
+++ b/erpnext/accounts/doctype/bank_statement_import/bank_statement_import.json
@@ -1,7 +1,7 @@
 {
  "actions": [],
+ "allow_bulk_edit": 1,
  "autoname": "format:Bank Statement Import on {creation}",
- "beta": 1,
  "creation": "2019-08-04 14:16:08.318714",
  "doctype": "DocType",
  "editable_grid": 1,
@@ -226,11 +226,11 @@
  ],
  "hide_toolbar": 1,
  "links": [],
- "modified": "2025-06-11 02:23:22.159961",
+ "modified": "2026-05-31 00:41:11.251215",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Bank Statement Import",
- "naming_rule": "Expression",
+ "naming_rule": "Expression (old style)",
  "owner": "Administrator",
  "permissions": [
   {


### PR DESCRIPTION
Exists since 2019.

Backport not needed, it's already updated on older branches.