### PR TITLE
fix: remove old subcontracting flow references in BOM

### DIFF
--- a/erpnext/manufacturing/doctype/bom/bom_dashboard.py
+++ b/erpnext/manufacturing/doctype/bom/bom_dashboard.py
@@ -7,22 +7,18 @@ def get_data():
 		"non_standard_fieldnames": {
 			"Item": "default_bom",
 			"Purchase Order": "bom",
-			"Purchase Receipt": "bom",
-			"Purchase Invoice": "bom",
 		},
 		"transactions": [
 			{"label": _("Stock"), "items": ["Item", "Stock Entry", "Quality Inspection"]},
 			{"label": _("Manufacture"), "items": ["BOM", "Work Order", "Job Card"]},
 			{
 				"label": _("Subcontract"),
-				"items": ["Purchase Order", "Purchase Receipt", "Purchase Invoice"],
+				"items": ["Purchase Order"],
 			},
 		],
 		"disable_create_buttons": [
 			"Item",
 			"Purchase Order",
-			"Purchase Receipt",
-			"Purchase Invoice",
 			"Job Card",
 			"Stock Entry",
 			"BOM",


### PR DESCRIPTION
BOM connections was looking for old flow subcontracting fields which was removed recently, causing unknown column error to be thrown