### PR TITLE
fix: NoneType reference error in Stock Entry

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry_handler/manufacturing.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry_handler/manufacturing.py
@@ -91,6 +91,11 @@ class BaseManufactureStockEntry(BaseStockEntry):
 			else:
 				item_args["t_warehouse"] = self.doc.to_warehouse
 
+			if not item_args.get("t_warehouse"):
+				item_args["t_warehouse"] = frappe.get_cached_value(
+					"BOM", self.doc.bom_no, "default_target_warehouse"
+				)
+
 			row.qty = row.qty * self.doc.fg_completed_qty
 			if row.get("process_loss_per"):
 				row.qty -= flt(
@@ -142,7 +147,8 @@ class BaseManufactureStockEntry(BaseStockEntry):
 				"conversion_factor": 1,
 				"uom": item_details.stock_uom,
 				"qty": ceil_qty_if_uom_has_whole_number(fg_item_qty, item_details.stock_uom),
-				"t_warehouse": self.doc.to_warehouse,
+				"t_warehouse": self.doc.to_warehouse
+				or frappe.get_cached_value("BOM", self.doc.bom_no, "default_target_warehouse"),
 				"s_warehouse": None,
 				"is_finished_item": 1,
 			}
@@ -366,8 +372,10 @@ class ManufactureStockEntry(BaseManufactureStockEntry):
 	def _resolve_rm_warehouse(self, row):
 		if self.doc.from_warehouse:
 			return self.doc.from_warehouse
-		if self.wo_doc.from_wip_warehouse:
+		if self.wo_doc and self.wo_doc.from_wip_warehouse:
 			return self.wo_doc.wip_warehouse
+		if s_warehouse := frappe.get_cached_value("BOM", self.doc.bom_no, "default_source_warehouse"):
+			return s_warehouse
 		return row.get("source_warehouse")
 
 	def get_alternative_items(self, bom_items):


### PR DESCRIPTION
When clicking on "Get Items" to fetch raw materials in a Stock Entry without Work Order, this error was thrown
<img width="1280" height="797" alt="telegram-cloud-photo-size-5-6118582918255939871-y" src="https://github.com/user-attachments/assets/0cb1e2d3-73df-4efe-be3a-367266996165" />
