### PR TITLE
fix: add validation for doctype and docname in edit_qty

### DIFF
--- a/erpnext/manufacturing/doctype/bom_creator/bom_creator.py
+++ b/erpnext/manufacturing/doctype/bom_creator/bom_creator.py
@@ -514,6 +514,19 @@ def delete_node(**kwargs):
 
 @frappe.whitelist()
 def edit_qty(doctype, docname, qty, parent):
+	if doctype != "BOM Creator Item":
+		frappe.throw(_("Invalid doctype"), frappe.PermissionError)
+
+	if not frappe.has_permission(doctype="BOM Creator", doc=parent, ptype="write"):
+		frappe.throw(_("You do not have permission to edit this document"), frappe.PermissionError)
+
+	if not frappe.db.exists("BOM Creator Item", {"name": docname, "parent": parent}):
+		frappe.throw(_("Row does not belong to this BOM Creator"), frappe.PermissionError)
+
+	qty = flt(qty)
+	if qty <= 0:
+		frappe.throw(_("Quantity must be greater than zero"))
+
 	frappe.db.set_value(doctype, docname, "qty", qty)
 	doc = frappe.get_doc("BOM Creator", parent)
 	doc.set_rate_for_items()


### PR DESCRIPTION
https://support.frappe.io/helpdesk/tickets/68488?view=VIEW-HD+Ticket-1547

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced quantity edit controls with mandatory authorization verification and comprehensive input validation. The system now strictly verifies write permissions and validates that target items exist before processing modifications, effectively preventing unauthorized and invalid edits while maintaining data integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->