### PR TITLE
fix(accounts): allow process statement of account generation with opening entries

### DIFF
--- a/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.json
+++ b/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.json
@@ -16,6 +16,7 @@
   "categorize_by",
   "cost_center",
   "territory",
+  "show_opening_entries",
   "ignore_exchange_rate_revaluation_journals",
   "ignore_cr_dr_notes",
   "column_break_14",
@@ -414,10 +415,17 @@
    "fieldtype": "Link",
    "label": "Print Format",
    "options": "Print Format"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:(doc.report == 'General Ledger');",
+   "fieldname": "show_opening_entries",
+   "fieldtype": "Check",
+   "label": "Show Opening Entries"
   }
  ],
  "links": [],
- "modified": "2025-10-07 12:19:20.719898",
+ "modified": "2026-06-01 15:37:07.660442",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Process Statement Of Accounts",

--- a/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.py
+++ b/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.py
@@ -75,6 +75,7 @@ class ProcessStatementOfAccounts(Document):
 		sender: DF.Link | None
 		show_future_payments: DF.Check
 		show_net_values_in_party_account: DF.Check
+		show_opening_entries: DF.Check
 		show_remarks: DF.Check
 		start_date: DF.Date | None
 		subject: DF.Data | None
@@ -270,7 +271,7 @@ def get_gl_filters(doc, entry, tax_id, presentation_currency):
 		"categorize_by": doc.categorize_by,
 		"currency": doc.currency,
 		"project": [p.project_name for p in doc.project],
-		"show_opening_entries": 0,
+		"show_opening_entries": doc.show_opening_entries,
 		"include_default_book_entries": 0,
 		"tax_id": tax_id if tax_id else None,
 		"show_net_values_in_party_account": doc.show_net_values_in_party_account,


### PR DESCRIPTION
**Issue:**
Process Statement of Account shows “No Record Found” when only opening balance entries exist, even though they are available in the General Ledger. The report works only when other transactions are present.

**Ref:** [68415](https://support.frappe.io/helpdesk/tickets/68415?view=VIEW-HD+Ticket-745)

**Backport Needed v15 &  v16**