### PR TITLE
fix: minor improvements to web templates, banking page and CI workflow

### DIFF
--- a/.github/workflows/sync-hotfix-translations.yml
+++ b/.github/workflows/sync-hotfix-translations.yml
@@ -16,6 +16,10 @@ on:
     - cron: "0 10 * * 1"
   workflow_dispatch:
 
+# The runner dispatch uses RELEASE_TOKEN (a PAT), not the default GITHUB_TOKEN,
+# so no GITHUB_TOKEN permissions are required.
+permissions: {}
+
 jobs:
   trigger-runners:
     name: Trigger sync → ${{ matrix.hotfix_branch }}

--- a/erpnext/templates/includes/announcement/announcement_row.html
+++ b/erpnext/templates/includes/announcement/announcement_row.html
@@ -24,10 +24,10 @@
 			if(content.length > show_char) {
 
 				var c = content.substr(0, show_char)
-				var h = content.substr(show_char, content.length - show_char);
 
-				html = c + '&nbsp;&nbsp;...'
-				$(this).html(html);
+				// Set as text (not HTML) so DOM text isn't re-interpreted as
+				// markup (XSS). \u00a0 is a non-breaking space (same as &nbsp;).
+				$(this).text(c + '\u00a0\u00a0...');
 			}
 		});
 	});

--- a/erpnext/templates/includes/projects/project_search_box.html
+++ b/erpnext/templates/includes/projects/project_search_box.html
@@ -18,7 +18,7 @@ frappe.ready(function() {
 	}
 	var thread = null;
 	function findResult(t) {
-		window.location.href="/projects?project={{doc.name}}&q=" + t;
+		window.location.href="/projects?project={{doc.name}}&q=" + encodeURIComponent(t);
 	}
 
 	$("#project-search").keyup(function() {

--- a/erpnext/www/banking.py
+++ b/erpnext/www/banking.py
@@ -8,8 +8,8 @@ from frappe.utils.jinja_globals import is_rtl
 
 no_cache = 1
 
-SCRIPT_TAG_PATTERN = re.compile(r"\<script[^<]*\</script\>")
-CLOSING_SCRIPT_TAG_PATTERN = re.compile(r"</script\>")
+SCRIPT_TAG_PATTERN = re.compile(r"\<script[^<]*\</script\>", re.IGNORECASE)
+CLOSING_SCRIPT_TAG_PATTERN = re.compile(r"</script\>", re.IGNORECASE)
 
 
 def get_context(context):


### PR DESCRIPTION
## Summary

Small correctness and robustness improvements across a few areas:

| File | Change |
|------|--------|
| `erpnext/templates/includes/announcement/announcement_row.html` | Render the truncated announcement description with `.text()` instead of `.html()` (uses ` ` for the non-breaking spaces). |
| `erpnext/templates/includes/projects/project_search_box.html` | URL-encode the search term (`encodeURIComponent`) before building the navigation URL — mirrors the existing handling a few lines above. |
| `erpnext/www/banking.py` | Make the boot `<script>` stripping patterns case-insensitive (mirrors `frappe/www/desk.py`). |
| `.github/workflows/sync-hotfix-translations.yml` | Add an explicit top-level `permissions` block; the runner dispatch authenticates with `RELEASE_TOKEN`, not the default `GITHUB_TOKEN`. |

All changes are behavior-preserving for normal input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)