### PR TITLE
refactor: resolve regression-safe CodeQL code-quality findings

### DIFF
--- a/erpnext/accounts/doctype/bank_transaction/test_bank_transaction.py
+++ b/erpnext/accounts/doctype/bank_transaction/test_bank_transaction.py
@@ -47,7 +47,7 @@ class TestBankTransaction(ERPNextTestSuite):
 			from_date=bank_transaction.date,
 			to_date=utils.today(),
 		)
-		self.assertTrue(linked_payments[0]["party"] == "Conrad Electronic")
+		self.assertEqual(linked_payments[0]["party"], "Conrad Electronic")
 
 	# This test validates a simple reconciliation leading to the clearance of the bank transaction and the payment
 	def test_reconcile(self):
@@ -70,10 +70,10 @@ class TestBankTransaction(ERPNextTestSuite):
 		unallocated_amount = frappe.db.get_value(
 			"Bank Transaction", bank_transaction.name, "unallocated_amount"
 		)
-		self.assertTrue(unallocated_amount == 0)
+		self.assertEqual(unallocated_amount, 0)
 
 		clearance_date = frappe.db.get_value("Payment Entry", payment.name, "clearance_date")
-		self.assertTrue(clearance_date is not None)
+		self.assertIsNot(clearance_date, None)
 
 		bank_transaction.reload()
 		bank_transaction.cancel()
@@ -178,9 +178,8 @@ class TestBankTransaction(ERPNextTestSuite):
 		self.assertEqual(
 			frappe.db.get_value("Bank Transaction", bank_transaction.name, "unallocated_amount"), 0
 		)
-		self.assertTrue(
-			frappe.db.get_value("Sales Invoice Payment", dict(parent=payment.name), "clearance_date")
-			is not None
+		self.assertIsNot(
+			frappe.db.get_value("Sales Invoice Payment", dict(parent=payment.name), "clearance_date"), None
 		)
 
 	@if_lending_app_installed

--- a/erpnext/accounts/doctype/cost_center_allocation/test_cost_center_allocation.py
+++ b/erpnext/accounts/doctype/cost_center_allocation/test_cost_center_allocation.py
@@ -182,7 +182,7 @@ class TestCostCenterAllocation(ERPNextTestSuite):
 		self.assertTrue(gl_entries)
 
 		for gle in gl_entries:
-			self.assertTrue(gle.cost_center in expected_values)
+			self.assertIn(gle.cost_center, expected_values)
 			self.assertEqual(gle.debit, 0)
 			self.assertEqual(gle.credit, expected_values[gle.cost_center])
 

--- a/erpnext/accounts/doctype/financial_report_template/financial_report_validation.py
+++ b/erpnext/accounts/doctype/financial_report_template/financial_report_validation.py
@@ -361,7 +361,7 @@ class CalculationFormulaValidator(Validator):
 					"sqrt": lambda x: x**0.5,
 					"pow": pow,
 					"ceil": lambda x: int(x) + (1 if x % 1 else 0),
-					"floor": lambda x: int(x),
+					"floor": int,
 				}
 			)
 

--- a/erpnext/accounts/doctype/journal_entry/test_journal_entry.py
+++ b/erpnext/accounts/doctype/journal_entry/test_journal_entry.py
@@ -89,7 +89,7 @@ class TestJournalEntry(ERPNextTestSuite):
 		)
 		payment_against_order = base_jv.get("accounts")[0].get(dr_or_cr)
 
-		self.assertTrue(flt(advance_paid[0][0]) == flt(payment_against_order))
+		self.assertEqual(flt(advance_paid[0][0]), flt(payment_against_order))
 
 	def cancel_against_voucher_testcase(self, test_voucher):
 		if test_voucher.doctype == "Journal Entry":

--- a/erpnext/accounts/doctype/payment_entry/test_payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/test_payment_entry.py
@@ -1119,7 +1119,7 @@ class TestPaymentEntry(ERPNextTestSuite):
 		with self.assertRaises(frappe.ValidationError) as err:
 			pe.save()
 
-		self.assertTrue("is on hold" in str(err.exception).lower())
+		self.assertIn("is on hold", str(err.exception).lower())
 
 	def test_payment_entry_for_employee(self):
 		employee = make_employee("test_payment_entry@salary.com", company="_Test Company")
@@ -2035,8 +2035,8 @@ class TestPaymentEntry(ERPNextTestSuite):
 
 		# check cancellation of payment entry and journal entry
 		pe.cancel()
-		self.assertTrue(pe.docstatus == 2)
-		self.assertTrue(frappe.db.get_value("Journal Entry", {"name": jv[0]}, "docstatus") == 2)
+		self.assertEqual(pe.docstatus, 2)
+		self.assertEqual(frappe.db.get_value("Journal Entry", {"name": jv[0]}, "docstatus"), 2)
 
 		# check deletion of payment entry and journal entry
 		pe.delete()

--- a/erpnext/accounts/doctype/payment_reconciliation/test_payment_reconciliation.py
+++ b/erpnext/accounts/doctype/payment_reconciliation/test_payment_reconciliation.py
@@ -3,11 +3,9 @@
 
 
 import frappe
-from frappe import qb
 from frappe.utils import add_days, add_years, flt, getdate, nowdate, today
 from frappe.utils.data import getdate as convert_to_date
 
-from erpnext import get_default_cost_center
 from erpnext.accounts.doctype.payment_entry.payment_entry import get_payment_entry
 from erpnext.accounts.doctype.payment_entry.test_payment_entry import create_payment_entry
 from erpnext.accounts.doctype.purchase_invoice.test_purchase_invoice import make_purchase_invoice
@@ -15,7 +13,6 @@ from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_sal
 from erpnext.accounts.party import get_party_account
 from erpnext.accounts.utils import get_fiscal_year
 from erpnext.buying.doctype.purchase_order.test_purchase_order import create_purchase_order
-from erpnext.stock.doctype.item.test_item import create_item
 from erpnext.tests.utils import ERPNextTestSuite
 
 

--- a/erpnext/accounts/doctype/pos_invoice_merge_log/test_pos_invoice_merge_log.py
+++ b/erpnext/accounts/doctype/pos_invoice_merge_log/test_pos_invoice_merge_log.py
@@ -59,7 +59,7 @@ class TestPOSInvoiceMergeLog(ERPNextTestSuite):
 		pos_inv3.load_from_db()
 		self.assertTrue(frappe.db.exists("Sales Invoice", pos_inv3.consolidated_invoice))
 
-		self.assertFalse(pos_inv.consolidated_invoice == pos_inv3.consolidated_invoice)
+		self.assertNotEqual(pos_inv.consolidated_invoice, pos_inv3.consolidated_invoice)
 
 	def test_consolidated_credit_note_creation(self):
 		pos_inv = create_pos_invoice(rate=300, do_not_submit=1)
@@ -454,12 +454,12 @@ class TestPOSInvoiceMergeLog(ERPNextTestSuite):
 		pos_inv2.load_from_db()
 		self.assertTrue(frappe.db.exists("Sales Invoice", pos_inv2.consolidated_invoice))
 
-		self.assertFalse(pos_inv.consolidated_invoice == pos_inv3.consolidated_invoice)
+		self.assertNotEqual(pos_inv.consolidated_invoice, pos_inv3.consolidated_invoice)
 
 		pos_inv3.load_from_db()
 		self.assertTrue(frappe.db.exists("Sales Invoice", pos_inv3.consolidated_invoice))
 
-		self.assertTrue(pos_inv2.consolidated_invoice == pos_inv3.consolidated_invoice)
+		self.assertEqual(pos_inv2.consolidated_invoice, pos_inv3.consolidated_invoice)
 
 	def test_company_in_pos_invoice_merge_log(self):
 		"""

--- a/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py
@@ -2077,7 +2077,7 @@ class TestPurchaseInvoice(ERPNextTestSuite, StockTestMixin):
 		return_pi = make_return_doc(pi.doctype, pi.name)
 		return_pi.save().submit()
 
-		self.assertTrue(return_pi.docstatus == 1)
+		self.assertEqual(return_pi.docstatus, 1)
 
 	def test_advance_entries_as_asset(self):
 		from erpnext.accounts.doctype.payment_entry.test_payment_entry import create_payment_entry

--- a/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
@@ -881,7 +881,7 @@ class TestSalesInvoice(ERPNextTestSuite):
 		link_doctypes = [d.parent for d in link_data]
 
 		# test case for dynamic link order
-		self.assertTrue(link_doctypes.index("GL Entry") > link_doctypes.index("Journal Entry Account"))
+		self.assertGreater(link_doctypes.index("GL Entry"), link_doctypes.index("Journal Entry Account"))
 
 		jv.cancel()
 		self.assertEqual(frappe.db.get_value("Sales Invoice", w.name, "outstanding_amount"), 562.0)
@@ -3517,7 +3517,7 @@ class TestSalesInvoice(ERPNextTestSuite):
 		with self.assertRaises(frappe.ValidationError) as err:
 			si.save()
 
-		self.assertTrue("cannot overbill" in str(err.exception).lower())
+		self.assertIn("cannot overbill", str(err.exception).lower())
 		dn.cancel()
 
 	@ERPNextTestSuite.change_settings(
@@ -3630,9 +3630,7 @@ class TestSalesInvoice(ERPNextTestSuite):
 			with self.assertRaises(frappe.ValidationError) as err:
 				si.submit()
 
-			self.assertTrue(
-				"Cannot create accounting entries against disabled accounts" in str(err.exception)
-			)
+			self.assertIn("Cannot create accounting entries against disabled accounts", str(err.exception))
 
 		finally:
 			account.disabled = 0
@@ -3727,7 +3725,7 @@ class TestSalesInvoice(ERPNextTestSuite):
 		return_si = make_return_doc(si.doctype, si.name)
 		return_si.save().submit()
 
-		self.assertTrue(return_si.docstatus == 1)
+		self.assertEqual(return_si.docstatus, 1)
 
 	def test_sales_invoice_with_payable_tax_account(self):
 		si = create_sales_invoice(do_not_submit=True)

--- a/erpnext/accounts/doctype/tax_rule/test_tax_rule.py
+++ b/erpnext/accounts/doctype/tax_rule/test_tax_rule.py
@@ -387,7 +387,7 @@ class TestTaxRule(ERPNextTestSuite):
 		self.assertEqual(quotation.taxes_and_charges, "_Test Sales Taxes and Charges Template - _TC")
 
 		# Check if accounts heads and rate fetched are also fetched from tax template or not
-		self.assertTrue(len(quotation.taxes) > 0)
+		self.assertGreater(len(quotation.taxes), 0)
 
 
 def make_tax_rule(**args):

--- a/erpnext/accounts/doctype/tax_withholding_category/test_tax_withholding_category.py
+++ b/erpnext/accounts/doctype/tax_withholding_category/test_tax_withholding_category.py
@@ -476,7 +476,7 @@ class TestTaxWithholdingCategory(ERPNextTestSuite):
 
 		# Cumulative threshold is 10,000
 		# Threshold calculation should be only on the third invoice
-		self.assertTrue(len(pi1.taxes) > 0)
+		self.assertGreater(len(pi1.taxes), 0)
 		self.assertEqual(pi1.taxes[0].tax_amount, 1000)
 
 		self.cleanup_invoices(invoices)
@@ -3654,7 +3654,7 @@ class TestTaxWithholdingCategory(ERPNextTestSuite):
 		pi = create_purchase_invoice(supplier="Test TDS Supplier", rate=50000, do_not_save=True)
 		pi.save()
 
-		self.assertTrue(len(pi.tax_withholding_entries) > 0)
+		self.assertGreater(len(pi.tax_withholding_entries), 0)
 		pi.delete()
 
 	def test_tds_rounding_with_decimal_amounts(self):
@@ -3720,7 +3720,7 @@ class TestTaxWithholdingCategory(ERPNextTestSuite):
 		self.setup_party_with_category("Supplier", "Test TDS Supplier", "Cumulative Threshold TDS")
 		pi = create_purchase_invoice(supplier="Test TDS Supplier", rate=50000)
 
-		self.assertTrue(len(pi.tax_withholding_entries) > 0)
+		self.assertGreater(len(pi.tax_withholding_entries), 0)
 		pi.override_tax_withholding_entries = 1
 
 		entry = pi.tax_withholding_entries[0]

--- a/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
+++ b/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
@@ -6,7 +6,6 @@ from collections import OrderedDict
 
 import frappe
 from frappe import _, qb, query_builder, scrub
-from frappe.database.schema import get_definition
 from frappe.query_builder import Criterion
 from frappe.query_builder.functions import Date, Substring, Sum
 from frappe.utils import cint, cstr, flt, getdate, nowdate

--- a/erpnext/accounts/report/accounts_receivable/test_accounts_receivable.py
+++ b/erpnext/accounts/report/accounts_receivable/test_accounts_receivable.py
@@ -194,7 +194,7 @@ class TestAccountsReceivable(ERPNextTestSuite, AccountsTestMixin):
 		report = execute(filters)
 
 		row = report[1]
-		self.assertTrue(len(row) == 0)
+		self.assertEqual(len(row), 0)
 
 	@ERPNextTestSuite.change_settings(
 		"Accounts Settings",
@@ -764,7 +764,7 @@ class TestAccountsReceivable(ERPNextTestSuite, AccountsTestMixin):
 		report = execute(filters)[1]
 
 		# Assert that the report contains data for the specified customer groups
-		self.assertTrue(len(report) > 0)
+		self.assertGreater(len(report), 0)
 
 		for row in report:
 			# Assert that the customer group of each row is in the list of customer groups

--- a/erpnext/accounts/report/sales_payment_summary/test_sales_payment_summary.py
+++ b/erpnext/accounts/report/sales_payment_summary/test_sales_payment_summary.py
@@ -36,8 +36,8 @@ class TestSalesPaymentSummary(ERPNextTestSuite):
 			pe.submit()
 
 		mop = get_mode_of_payments(filters)
-		self.assertTrue("Credit Card" in next(iter(mop.values())))
-		self.assertTrue("Cash" in next(iter(mop.values())))
+		self.assertIn("Credit Card", next(iter(mop.values())))
+		self.assertIn("Cash", next(iter(mop.values())))
 
 		# Cancel all Cash payment entry and check if this mode of payment is still fetched.
 		payment_entries = frappe.get_all(
@@ -50,8 +50,8 @@ class TestSalesPaymentSummary(ERPNextTestSuite):
 			pe.cancel()
 
 		mop = get_mode_of_payments(filters)
-		self.assertTrue("Credit Card" in next(iter(mop.values())))
-		self.assertTrue("Cash" not in next(iter(mop.values())))
+		self.assertIn("Credit Card", next(iter(mop.values())))
+		self.assertNotIn("Cash", next(iter(mop.values())))
 
 	def test_get_mode_of_payments_details(self):
 		filters = get_filters()
@@ -100,7 +100,7 @@ class TestSalesPaymentSummary(ERPNextTestSuite):
 			if mopd_value[0] == "Credit Card":
 				cc_final_amount = mopd_value[1]
 
-		self.assertTrue(cc_init_amount > cc_final_amount)
+		self.assertGreater(cc_init_amount, cc_final_amount)
 
 
 def get_filters():

--- a/erpnext/accounts/test/test_utils.py
+++ b/erpnext/accounts/test/test_utils.py
@@ -37,15 +37,17 @@ class TestUtils(ERPNextTestSuite):
 		future_vouchers = get_future_stock_vouchers("2021-01-01", "00:00:00", for_items=["_Test Item"])
 
 		voucher_type_and_no = ("Purchase Receipt", pr.name)
-		self.assertTrue(
-			voucher_type_and_no in future_vouchers,
+		self.assertIn(
+			voucher_type_and_no,
+			future_vouchers,
 			msg="get_future_stock_vouchers not returning correct value",
 		)
 
 		posting_date = "2021-01-01"
 		gl_entries = get_voucherwise_gl_entries(future_vouchers, posting_date)
-		self.assertTrue(
-			voucher_type_and_no in gl_entries,
+		self.assertIn(
+			voucher_type_and_no,
+			gl_entries,
 			msg="get_voucherwise_gl_entries not returning expected GLes",
 		)
 

--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -1288,8 +1288,6 @@ def make_asset_movement(
 	assets: list[dict] | str,
 	purpose: str = "Transfer",
 ):
-	import json
-
 	if isinstance(assets, str):
 		assets = json.loads(assets)
 

--- a/erpnext/assets/doctype/asset/test_asset.py
+++ b/erpnext/assets/doctype/asset/test_asset.py
@@ -885,9 +885,9 @@ class TestAsset(AssetSetup):
 			with self.assertRaises(frappe.ValidationError) as err:
 				asset.save()
 
-			self.assertTrue(
-				"Please set Depreciation related Accounts in Asset Category Computers or Company"
-				in str(err.exception)
+			self.assertIn(
+				"Please set Depreciation related Accounts in Asset Category Computers or Company",
+				str(err.exception),
 			)
 		finally:
 			frappe.db.set_value("Company", "_Test Company", company_depreciation_accounts)
@@ -1699,8 +1699,8 @@ class TestDepreciationBasics(AssetSetup):
 			accumulated_depreciation_after_full_schedule
 		)
 
-		self.assertTrue(
-			asset.finance_books[0].expected_value_after_useful_life >= asset_value_after_full_schedule
+		self.assertGreaterEqual(
+			asset.finance_books[0].expected_value_after_useful_life, asset_value_after_full_schedule
 		)
 
 	def test_gle_made_by_depreciation_entries(self):

--- a/erpnext/assets/doctype/asset_category/test_asset_category.py
+++ b/erpnext/assets/doctype/asset_category/test_asset_category.py
@@ -72,7 +72,7 @@ class TestAssetCategory(ERPNextTestSuite):
 		)
 		with self.assertRaises(frappe.ValidationError) as err:
 			asset_category.save()
-		self.assertTrue("Cannot set multiple account rows for the same company" in str(err.exception))
+		self.assertIn("Cannot set multiple account rows for the same company", str(err.exception))
 
 	def test_depreciation_accounts_required_for_existing_depreciable_assets(self):
 		asset = create_asset(
@@ -110,9 +110,9 @@ class TestAssetCategory(ERPNextTestSuite):
 			with self.assertRaises(frappe.ValidationError) as err:
 				asset_category.save()
 
-			self.assertTrue(
-				"Since there are active depreciable assets under this category, the following accounts are required."
-				in str(err.exception)
+			self.assertIn(
+				"Since there are active depreciable assets under this category, the following accounts are required.",
+				str(err.exception),
 			)
 		finally:
 			frappe.db.set_value("Company", asset.company, company_acccount_depreciation)

--- a/erpnext/buying/doctype/purchase_order/purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.py
@@ -5,7 +5,7 @@
 import json
 
 import frappe
-from frappe import _, msgprint
+from frappe import _
 from frappe.desk.notifications import clear_doctype_notifications
 from frappe.model.document import Document
 from frappe.model.mapper import get_mapped_doc
@@ -25,7 +25,6 @@ from erpnext.manufacturing.doctype.blanket_order.blanket_order import (
 from erpnext.setup.doctype.item_group.item_group import get_item_group_defaults
 from erpnext.stock.doctype.item.item import get_item_defaults, get_last_purchase_details
 from erpnext.stock.stock_balance import get_ordered_qty, update_bin_qty
-from erpnext.stock.utils import get_bin
 from erpnext.subcontracting.doctype.subcontracting_bom.subcontracting_bom import (
 	get_subcontracting_boms_for_finished_goods,
 )

--- a/erpnext/buying/doctype/purchase_order/test_purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/test_purchase_order.py
@@ -1469,7 +1469,7 @@ class TestPurchaseOrder(ERPNextTestSuite):
 		pi1.submit()
 
 		self.assertEqual(pi1.grand_total, 10000.0)
-		self.assertTrue(len(pi1.items) == 1)
+		self.assertEqual(len(pi1.items), 1)
 
 		pi2 = make_pi_from_po(po.name)
 		self.assertEqual(len(pi2.items), 2)

--- a/erpnext/buying/doctype/supplier/test_supplier.py
+++ b/erpnext/buying/doctype/supplier/test_supplier.py
@@ -106,7 +106,7 @@ class TestSupplier(ERPNextTestSuite):
 	def test_supplier_country(self):
 		# Test that country field exists in Supplier DocType
 		supplier = frappe.get_doc("Supplier", "_Test Supplier with Country")
-		self.assertTrue("country" in supplier.as_dict())
+		self.assertIn("country", supplier.as_dict())
 
 		# Test if test supplier field record is 'Greece'
 		self.assertEqual(supplier.country, "Greece")

--- a/erpnext/controllers/queries.py
+++ b/erpnext/controllers/queries.py
@@ -9,11 +9,10 @@ import frappe
 from frappe import qb, scrub
 from frappe.desk.reportview import get_filters_cond, get_match_cond
 from frappe.permissions import has_permission
-from frappe.query_builder import Case, Criterion, DocType, Field
+from frappe.query_builder import Case, Criterion, DocType
 from frappe.query_builder.functions import Concat, CustomFunction, Length, Locate, Substring, Sum
 from frappe.utils import nowdate, today, unique
 from pypika import Order
-from pypika.terms import LiteralValue
 
 import erpnext
 from erpnext.accounts.utils import build_qb_match_conditions

--- a/erpnext/erpnext_integrations/doctype/plaid_settings/test_plaid_settings.py
+++ b/erpnext/erpnext_integrations/doctype/plaid_settings/test_plaid_settings.py
@@ -18,7 +18,7 @@ from erpnext.tests.utils import ERPNextTestSuite
 class TestPlaidSettings(ERPNextTestSuite):
 	def test_plaid_disabled(self):
 		frappe.db.set_single_value("Plaid Settings", "enabled", 0)
-		self.assertTrue(get_plaid_configuration() == "disabled")
+		self.assertEqual(get_plaid_configuration(), "disabled")
 
 	def test_add_account_type(self):
 		add_account_type("brokerage")
@@ -98,4 +98,4 @@ class TestPlaidSettings(ERPNextTestSuite):
 
 		new_bank_transaction(transactions)
 
-		self.assertTrue(len(frappe.get_all("Bank Transaction")) == 1)
+		self.assertEqual(len(frappe.get_all("Bank Transaction")), 1)

--- a/erpnext/maintenance/doctype/maintenance_schedule/test_maintenance_schedule.py
+++ b/erpnext/maintenance/doctype/maintenance_schedule/test_maintenance_schedule.py
@@ -43,11 +43,11 @@ class TestMaintenanceSchedule(ERPNextTestSuite):
 		ms.submit()
 
 		all_events = get_events(ms)
-		self.assertTrue(len(all_events) > 0)
+		self.assertGreater(len(all_events), 0)
 
 		ms.cancel()
 		events_after_cancel = get_events(ms)
-		self.assertTrue(len(events_after_cancel) == 0)
+		self.assertEqual(len(events_after_cancel), 0)
 
 	def test_make_schedule(self):
 		ms = make_maintenance_schedule()

--- a/erpnext/manufacturing/doctype/bom/test_bom.py
+++ b/erpnext/manufacturing/doctype/bom/test_bom.py
@@ -34,8 +34,8 @@ class TestBOM(ERPNextTestSuite):
 		items_dict = get_bom_items_as_dict(
 			bom=get_default_bom(), company="_Test Company", qty=1, fetch_exploded=0
 		)
-		self.assertTrue(self.globalTestRecords["BOM"][2]["items"][0]["item_code"] in items_dict)
-		self.assertTrue(self.globalTestRecords["BOM"][2]["items"][1]["item_code"] in items_dict)
+		self.assertIn(self.globalTestRecords["BOM"][2]["items"][0]["item_code"], items_dict)
+		self.assertIn(self.globalTestRecords["BOM"][2]["items"][1]["item_code"], items_dict)
 		self.assertEqual(len(items_dict.values()), 2)
 
 	@timeout
@@ -45,10 +45,10 @@ class TestBOM(ERPNextTestSuite):
 		items_dict = get_bom_items_as_dict(
 			bom=get_default_bom(), company="_Test Company", qty=1, fetch_exploded=1
 		)
-		self.assertTrue(self.globalTestRecords["BOM"][2]["items"][0]["item_code"] in items_dict)
-		self.assertFalse(self.globalTestRecords["BOM"][2]["items"][1]["item_code"] in items_dict)
-		self.assertTrue(self.globalTestRecords["BOM"][0]["items"][0]["item_code"] in items_dict)
-		self.assertTrue(self.globalTestRecords["BOM"][0]["items"][1]["item_code"] in items_dict)
+		self.assertIn(self.globalTestRecords["BOM"][2]["items"][0]["item_code"], items_dict)
+		self.assertNotIn(self.globalTestRecords["BOM"][2]["items"][1]["item_code"], items_dict)
+		self.assertIn(self.globalTestRecords["BOM"][0]["items"][0]["item_code"], items_dict)
+		self.assertIn(self.globalTestRecords["BOM"][0]["items"][1]["item_code"], items_dict)
 		self.assertEqual(len(items_dict.values()), 3)
 
 	@timeout
@@ -763,9 +763,9 @@ class TestBOM(ERPNextTestSuite):
 		for row in data:
 			items.append(row[0])
 
-		self.assertTrue("_Test RM Item 1 Do Not Include In Manufacture" not in items)
-		self.assertTrue("_Test RM Item 2 Fixed Asset Item" not in items)
-		self.assertTrue("_Test RM Item 3 Manufacture Item" in items)
+		self.assertNotIn("_Test RM Item 1 Do Not Include In Manufacture", items)
+		self.assertNotIn("_Test RM Item 2 Fixed Asset Item", items)
+		self.assertIn("_Test RM Item 3 Manufacture Item", items)
 
 	def test_bom_raw_materials_stock_uom(self):
 		rm_item = make_item(

--- a/erpnext/manufacturing/doctype/production_plan/production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.py
@@ -1895,8 +1895,6 @@ def get_materials_from_other_locations(item, warehouses, new_mr_items, company):
 
 	precision = frappe.get_precision("Material Request Plan Item", "quantity")
 	if flt(required_qty, precision) > 0:
-		required_qty = required_qty
-
 		if frappe.db.get_value("UOM", purchase_uom, "must_be_whole_number"):
 			required_qty = ceil(required_qty)
 

--- a/erpnext/manufacturing/doctype/production_plan/test_production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/test_production_plan.py
@@ -900,8 +900,9 @@ class TestProductionPlan(ERPNextTestSuite):
 
 		missing_warehouse = expected_warehouses - warehouses
 
-		self.assertTrue(
-			len(missing_warehouse) == 0,
+		self.assertEqual(
+			len(missing_warehouse),
+			0,
 			msg=f"Following warehouses were expected {', '.join(missing_warehouse)}",
 		)
 
@@ -1392,7 +1393,7 @@ class TestProductionPlan(ERPNextTestSuite):
 
 		validate_mr_items = [d.get("item_code") for d in items]
 		for item_code in mr_items:
-			self.assertTrue(item_code in validate_mr_items)
+			self.assertIn(item_code, validate_mr_items)
 
 	def test_reserved_qty_for_production_plan_for_material_requests(self):
 		from erpnext.stock.utils import get_or_make_bin
@@ -1510,7 +1511,7 @@ class TestProductionPlan(ERPNextTestSuite):
 		non_completed_plans = get_non_completed_production_plans()
 
 		for plan in plans:
-			self.assertTrue(plan in non_completed_plans)
+			self.assertIn(plan, non_completed_plans)
 
 	def test_reserved_qty_for_production_plan_for_material_requests_with_multi_UOM(self):
 		from erpnext.stock.utils import get_or_make_bin
@@ -1721,13 +1722,13 @@ class TestProductionPlan(ERPNextTestSuite):
 		for row in items:
 			row = frappe._dict(row)
 			if row.material_request_type == "Material Transfer":
-				self.assertTrue(row.uom == row.stock_uom)
-				self.assertTrue(row.from_warehouse in [wh1, wh2])
+				self.assertEqual(row.uom, row.stock_uom)
+				self.assertIn(row.from_warehouse, [wh1, wh2])
 				self.assertEqual(row.quantity, 2)
 
 			if row.material_request_type == "Purchase":
-				self.assertTrue(row.uom != row.stock_uom)
-				self.assertTrue(row.warehouse == mrp_warhouse)
+				self.assertNotEqual(row.uom, row.stock_uom)
+				self.assertEqual(row.warehouse, mrp_warhouse)
 				self.assertEqual(row.quantity, 12.0)
 
 	def test_mr_qty_for_complex_bom(self):
@@ -2257,12 +2258,12 @@ class TestProductionPlan(ERPNextTestSuite):
 
 		plan.save()
 
-		self.assertTrue(len(plan.sub_assembly_items) == 3)
+		self.assertEqual(len(plan.sub_assembly_items), 3)
 		for row in plan.sub_assembly_items:
 			self.assertEqual(row.required_qty, 15.0)
 			self.assertEqual(row.qty, 10.0)
 
-		self.assertTrue(len(plan.mr_items) == 3)
+		self.assertEqual(len(plan.mr_items), 3)
 		for row in plan.mr_items:
 			self.assertEqual(row.required_bom_qty, 10.0)
 			self.assertEqual(row.quantity, 5.0)
@@ -2271,7 +2272,7 @@ class TestProductionPlan(ERPNextTestSuite):
 
 		sre = StockReservation(plan)
 		reserved_entries = sre.get_reserved_entries("Production Plan", plan.name)
-		self.assertTrue(len(reserved_entries) == 6)
+		self.assertEqual(len(reserved_entries), 6)
 
 		for row in reserved_entries:
 			self.assertEqual(row.reserved_qty, 5.0)
@@ -2284,7 +2285,7 @@ class TestProductionPlan(ERPNextTestSuite):
 			"Material Request", filters={"production_plan": plan.name}, pluck="name"
 		)
 
-		self.assertTrue(len(material_requests) > 0)
+		self.assertGreater(len(material_requests), 0)
 		for mr_name in list(set(material_requests)):
 			po = make_purchase_order(mr_name)
 			po.supplier = "_Test Supplier"
@@ -2295,7 +2296,7 @@ class TestProductionPlan(ERPNextTestSuite):
 
 		sre = StockReservation(plan)
 		reserved_entries = sre.get_reserved_entries("Production Plan", plan.name)
-		self.assertTrue(len(reserved_entries) == 9)
+		self.assertEqual(len(reserved_entries), 9)
 
 		work_orders = frappe.get_all("Work Order", filters={"production_plan": plan.name}, pluck="name")
 		for wo_name in list(set(work_orders)):
@@ -2318,7 +2319,7 @@ class TestProductionPlan(ERPNextTestSuite):
 
 		sre = StockReservation(plan)
 		reserved_entries = sre.get_reserved_entries("Production Plan", plan.name)
-		self.assertTrue(len(reserved_entries) == 0)
+		self.assertEqual(len(reserved_entries), 0)
 		frappe.db.set_single_value("Stock Settings", "enable_stock_reservation", 0)
 
 	def test_stock_reservation_of_serial_nos_against_production_plan(self):
@@ -2374,12 +2375,12 @@ class TestProductionPlan(ERPNextTestSuite):
 
 		plan.save()
 
-		self.assertTrue(len(plan.sub_assembly_items) == 3)
+		self.assertEqual(len(plan.sub_assembly_items), 3)
 		for row in plan.sub_assembly_items:
 			self.assertEqual(row.required_qty, 15.0)
 			self.assertEqual(row.qty, 10.0)
 
-		self.assertTrue(len(plan.mr_items) == 3)
+		self.assertEqual(len(plan.mr_items), 3)
 		for row in plan.mr_items:
 			self.assertEqual(row.required_bom_qty, 10.0)
 			self.assertEqual(row.quantity, 5.0)
@@ -2388,7 +2389,7 @@ class TestProductionPlan(ERPNextTestSuite):
 
 		sre = StockReservation(plan)
 		reserved_entries = sre.get_reserved_entries("Production Plan", plan.name)
-		self.assertTrue(len(reserved_entries) == 30)
+		self.assertEqual(len(reserved_entries), 30)
 
 		for row in reserved_entries:
 			self.assertEqual(row.reserved_qty, 5.0)
@@ -2416,7 +2417,7 @@ class TestProductionPlan(ERPNextTestSuite):
 
 		self.assertTrue(additional_serial_nos)
 
-		self.assertTrue(len(material_requests) > 0)
+		self.assertGreater(len(material_requests), 0)
 		for mr_name in list(set(material_requests)):
 			po = make_purchase_order(mr_name)
 			po.supplier = "_Test Supplier"
@@ -2427,7 +2428,7 @@ class TestProductionPlan(ERPNextTestSuite):
 
 		sre = StockReservation(plan)
 		reserved_entries = sre.get_reserved_entries("Production Plan", plan.name)
-		self.assertTrue(len(reserved_entries) == 45)
+		self.assertEqual(len(reserved_entries), 45)
 		serial_nos_res_for_pp = frappe.get_all(
 			"Serial and Batch Entry",
 			filters={"parent": ("in", [x.name for x in reserved_entries]), "docstatus": 1},
@@ -2453,8 +2454,8 @@ class TestProductionPlan(ERPNextTestSuite):
 			)
 
 			for serial_no in serial_nos_res_for_wo:
-				self.assertTrue(serial_no in serial_nos_res_for_pp)
-				self.assertFalse(serial_no in additional_serial_nos)
+				self.assertIn(serial_no, serial_nos_res_for_pp)
+				self.assertNotIn(serial_no, additional_serial_nos)
 
 			if wo_doc.production_item == "Finished Good For SR":
 				self.assertEqual(len(reserved_entries), 15)
@@ -2465,7 +2466,7 @@ class TestProductionPlan(ERPNextTestSuite):
 
 		sre = StockReservation(plan)
 		reserved_entries = sre.get_reserved_entries("Production Plan", plan.name)
-		self.assertTrue(len(reserved_entries) == 0)
+		self.assertEqual(len(reserved_entries), 0)
 		frappe.db.set_single_value("Stock Settings", "enable_stock_reservation", 0)
 
 	def test_stock_reservation_of_batch_nos_against_production_plan(self):
@@ -2522,12 +2523,12 @@ class TestProductionPlan(ERPNextTestSuite):
 
 		plan.save()
 
-		self.assertTrue(len(plan.sub_assembly_items) == 3)
+		self.assertEqual(len(plan.sub_assembly_items), 3)
 		for row in plan.sub_assembly_items:
 			self.assertEqual(row.required_qty, 15.0)
 			self.assertEqual(row.qty, 10.0)
 
-		self.assertTrue(len(plan.mr_items) == 3)
+		self.assertEqual(len(plan.mr_items), 3)
 		for row in plan.mr_items:
 			self.assertEqual(row.required_bom_qty, 10.0)
 			self.assertEqual(row.quantity, 5.0)
@@ -2536,7 +2537,7 @@ class TestProductionPlan(ERPNextTestSuite):
 
 		sre = StockReservation(plan)
 		reserved_entries = sre.get_reserved_entries("Production Plan", plan.name)
-		self.assertTrue(len(reserved_entries) == 6)
+		self.assertEqual(len(reserved_entries), 6)
 
 		for row in reserved_entries:
 			self.assertEqual(row.reserved_qty, 5.0)
@@ -2565,7 +2566,7 @@ class TestProductionPlan(ERPNextTestSuite):
 
 		self.assertTrue(additional_batches)
 
-		self.assertTrue(len(material_requests) > 0)
+		self.assertGreater(len(material_requests), 0)
 		for mr_name in list(set(material_requests)):
 			po = make_purchase_order(mr_name)
 			po.supplier = "_Test Supplier"
@@ -2576,7 +2577,7 @@ class TestProductionPlan(ERPNextTestSuite):
 
 		sre = StockReservation(plan)
 		reserved_entries = sre.get_reserved_entries("Production Plan", plan.name)
-		self.assertTrue(len(reserved_entries) == 9)
+		self.assertEqual(len(reserved_entries), 9)
 		batches_reserved_for_pp = frappe.get_all(
 			"Serial and Batch Entry",
 			filters={"parent": ("in", [x.name for x in reserved_entries]), "docstatus": 1},
@@ -2602,8 +2603,8 @@ class TestProductionPlan(ERPNextTestSuite):
 			)
 
 			for batch_no in batches_reserved_for_wo:
-				self.assertTrue(batch_no in batches_reserved_for_pp)
-				self.assertFalse(batch_no in additional_batches)
+				self.assertIn(batch_no, batches_reserved_for_pp)
+				self.assertNotIn(batch_no, additional_batches)
 
 			if wo_doc.production_item == "Finished Good For SR":
 				self.assertEqual(len(reserved_entries), 3)
@@ -2614,7 +2615,7 @@ class TestProductionPlan(ERPNextTestSuite):
 
 		sre = StockReservation(plan)
 		reserved_entries = sre.get_reserved_entries("Production Plan", plan.name)
-		self.assertTrue(len(reserved_entries) == 0)
+		self.assertEqual(len(reserved_entries), 0)
 		frappe.db.set_single_value("Stock Settings", "enable_stock_reservation", 0)
 
 	def test_production_plan_for_partial_sub_assembly_items(self):

--- a/erpnext/manufacturing/doctype/work_order/test_work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/test_work_order.py
@@ -807,7 +807,7 @@ class TestWorkOrder(ERPNextTestSuite):
 
 				bundle_id = frappe.get_doc("Serial and Batch Bundle", row.serial_and_batch_bundle)
 				for bundle_row in bundle_id.get("entries"):
-					self.assertTrue(bundle_row.batch_no in batches)
+					self.assertIn(bundle_row.batch_no, batches)
 					batches.remove(bundle_row.batch_no)
 
 		ste1.submit()
@@ -821,7 +821,7 @@ class TestWorkOrder(ERPNextTestSuite):
 
 				bundle_id = frappe.get_doc("Serial and Batch Bundle", row.serial_and_batch_bundle)
 				for bundle_row in bundle_id.get("entries"):
-					self.assertTrue(bundle_row.batch_no in batches)
+					self.assertIn(bundle_row.batch_no, batches)
 					remaining_batches.append(bundle_row.batch_no)
 
 		self.assertEqual(sorted(remaining_batches), sorted(batches))
@@ -3173,12 +3173,12 @@ class TestWorkOrder(ERPNextTestSuite):
 		transfer_entry.items[0].original_item = raw_materials[0]
 		transfer_entry.submit()
 
-		self.assertTrue(transfer_entry.docstatus == 1)
+		self.assertEqual(transfer_entry.docstatus, 1)
 
 		manufacture_entry = frappe.get_doc(make_stock_entry(wo.name, "Manufacture", 10))
 		manufacture_entry.save()
-		self.assertTrue(manufacture_entry.items[0].item_code == alternate_item[0])
-		self.assertTrue(manufacture_entry.items[0].original_item == raw_materials[0])
+		self.assertEqual(manufacture_entry.items[0].item_code, alternate_item[0])
+		self.assertEqual(manufacture_entry.items[0].original_item, raw_materials[0])
 
 		manufacture_entry.submit()
 
@@ -3882,7 +3882,7 @@ class TestWorkOrder(ERPNextTestSuite):
 				self.assertEqual(sorted(serial_nos), sorted(value.serial_nos))
 
 			if value.batch_nos:
-				self.assertTrue(row.batch_no in value.batch_nos)
+				self.assertIn(row.batch_no, value.batch_nos)
 
 		_before_reserved_item = get_reserved_entries(wo.name, mt_stock_entry.items[0].t_warehouse)
 
@@ -3898,16 +3898,16 @@ class TestWorkOrder(ERPNextTestSuite):
 			if row.serial_no:
 				serial_nos = get_serial_nos_from_bundle(row.serial_and_batch_bundle)
 				for sn in serial_nos:
-					self.assertTrue(sn in value.serial_nos)
+					self.assertIn(sn, value.serial_nos)
 					value.serial_nos.remove(sn)
 
 			if row.batch_no:
-				self.assertTrue(row.batch_no in value.batch_nos)
+				self.assertIn(row.batch_no, value.batch_nos)
 				value.batch_nos[row.batch_no] -= row.qty
 				if row.serial_no:
 					sns = get_serial_nos_from_bundle(row.serial_and_batch_bundle)
 					for sn in sns:
-						self.assertTrue(sn in value.serial_batches[row.batch_no])
+						self.assertIn(sn, value.serial_batches[row.batch_no])
 						value.serial_batches[row.batch_no].remove(sn)
 
 		# Manufacture 3 qty
@@ -3925,7 +3925,7 @@ class TestWorkOrder(ERPNextTestSuite):
 				self.assertEqual(sorted(serial_nos), sorted(value.serial_nos))
 
 			if row.batch_no:
-				self.assertTrue(row.batch_no in value.batch_nos)
+				self.assertIn(row.batch_no, value.batch_nos)
 				self.assertEqual(value.batch_nos[row.batch_no], row.qty)
 				if row.serial_no:
 					sns = get_serial_nos_from_bundle(row.serial_and_batch_bundle)

--- a/erpnext/manufacturing/doctype/work_order/test_work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/test_work_order.py
@@ -31,7 +31,6 @@ from erpnext.stock.doctype.serial_and_batch_bundle.test_serial_and_batch_bundle 
 )
 from erpnext.stock.doctype.serial_no.serial_no import get_serial_nos
 from erpnext.stock.doctype.stock_entry import test_stock_entry
-from erpnext.stock.doctype.stock_entry.stock_entry_handler.manufacturing import ManufactureStockEntry
 from erpnext.stock.doctype.warehouse.test_warehouse import create_warehouse
 from erpnext.stock.utils import get_bin
 from erpnext.tests.utils import ERPNextTestSuite

--- a/erpnext/manufacturing/report/bom_stock_analysis/bom_stock_analysis.py
+++ b/erpnext/manufacturing/report/bom_stock_analysis/bom_stock_analysis.py
@@ -4,7 +4,7 @@
 import frappe
 from frappe import _
 from frappe.query_builder.functions import Floor, IfNull, Sum
-from frappe.utils import flt, fmt_money
+from frappe.utils import flt
 from frappe.utils.data import comma_and
 from pypika.terms import ExistsCriterion
 

--- a/erpnext/projects/doctype/project/test_project.py
+++ b/erpnext/projects/doctype/project/test_project.py
@@ -152,7 +152,7 @@ class TestProject(ERPNextTestSuite):
 
 		self.assertEqual(tasks[1].subject, "Test Template Task with Dependency")
 		self.assertEqual(getdate(tasks[1].exp_end_date), calculate_end_date(project, 2, 2))
-		self.assertTrue(tasks[1].depends_on_tasks.find(tasks[0].name) >= 0)
+		self.assertGreaterEqual(tasks[1].depends_on_tasks.find(tasks[0].name), 0)
 
 		self.assertEqual(tasks[0].subject, "Test Template Task for Dependency")
 		self.assertEqual(getdate(tasks[0].exp_end_date), calculate_end_date(project, 3, 1))

--- a/erpnext/selling/doctype/party_specific_item/test_party_specific_item.py
+++ b/erpnext/selling/doctype/party_specific_item/test_party_specific_item.py
@@ -31,7 +31,7 @@ class TestPartySpecificItem(ERPNextTestSuite):
 		items = item_query(
 			doctype="Item", txt="", searchfield="name", start=0, page_len=20, filters=filters, as_dict=False
 		)
-		self.assertTrue(item in flatten(items))
+		self.assertIn(item, flatten(items))
 
 	def test_item_query_for_supplier(self):
 		supplier = "_Test Supplier With Template 1"
@@ -47,7 +47,7 @@ class TestPartySpecificItem(ERPNextTestSuite):
 		items = item_query(
 			doctype="Item", txt="", searchfield="name", start=0, page_len=20, filters=filters, as_dict=False
 		)
-		self.assertTrue(item in flatten(items))
+		self.assertIn(item, flatten(items))
 
 	def test_party_group(self):
 		customer = "_Test Customer With Template"
@@ -64,7 +64,7 @@ class TestPartySpecificItem(ERPNextTestSuite):
 		items = item_query(
 			doctype="Item", txt="", searchfield="name", start=0, page_len=20, filters=filters, as_dict=False
 		)
-		self.assertTrue(item in flatten(items))
+		self.assertIn(item, flatten(items))
 
 
 def flatten(lst):

--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -1408,10 +1408,9 @@ def make_delivery_note(
 					dn_item.serial_and_batch_bundle = get_ssb_bundle_for_voucher([sre]).name
 
 				target_doc.append("items", dn_item)
-			else:
-				# Correct rows index.
-				for idx, item in enumerate(target_doc.items):
-					item.idx = idx + 1
+			# Correct rows index.
+			for idx, item in enumerate(target_doc.items):
+				item.idx = idx + 1
 
 	if not kwargs.skip_item_mapping and frappe.flags.bulk_transaction and not target_doc.items:
 		# the (date) condition filter resulted in an unintendedly created empty DN; remove it

--- a/erpnext/selling/doctype/sales_order/test_sales_order.py
+++ b/erpnext/selling/doctype/sales_order/test_sales_order.py
@@ -986,8 +986,8 @@ class TestSalesOrder(ERPNextTestSuite):
 
 		so = make_sales_order(item_code="_Test Service Product Bundle", warehouse=None)
 
-		self.assertTrue("_Test Service Product Bundle Item 1" in [d.item_code for d in so.packed_items])
-		self.assertTrue("_Test Service Product Bundle Item 2" in [d.item_code for d in so.packed_items])
+		self.assertIn("_Test Service Product Bundle Item 1", [d.item_code for d in so.packed_items])
+		self.assertIn("_Test Service Product Bundle Item 2", [d.item_code for d in so.packed_items])
 
 	def test_mix_type_product_bundle(self):
 		make_item("_Test Mix Product Bundle", {"is_stock_item": 0})
@@ -2342,8 +2342,8 @@ class TestSalesOrder(ERPNextTestSuite):
 		pick_list.save()
 		for row in pick_list.locations:
 			self.assertEqual(row.qty, 1.0)
-			self.assertFalse(row.warehouse == rejected_warehouse)
-			self.assertTrue(row.warehouse == warehouse)
+			self.assertNotEqual(row.warehouse, rejected_warehouse)
+			self.assertEqual(row.warehouse, warehouse)
 
 	def test_pick_list_for_batch(self):
 		from erpnext.stock.doctype.pick_list.pick_list import create_delivery_note
@@ -2371,16 +2371,16 @@ class TestSalesOrder(ERPNextTestSuite):
 
 		for row in pick_list.locations:
 			self.assertEqual(row.qty, 10.0)
-			self.assertTrue(row.warehouse == warehouse)
-			self.assertTrue(row.batch_no == batch_no)
+			self.assertEqual(row.warehouse, warehouse)
+			self.assertEqual(row.batch_no, batch_no)
 
 		pick_list.submit()
 
 		dn = create_delivery_note(pick_list.name)
 		for row in dn.items:
 			self.assertEqual(row.qty, 10.0)
-			self.assertTrue(row.warehouse == warehouse)
-			self.assertTrue(row.batch_no == batch_no)
+			self.assertEqual(row.warehouse, warehouse)
+			self.assertEqual(row.batch_no, batch_no)
 
 		dn.submit()
 		dn.reload()
@@ -2438,7 +2438,7 @@ class TestSalesOrder(ERPNextTestSuite):
 
 		so.items[0].rate = 90
 		so.save()
-		self.assertTrue(so.items[0].discount_amount == 27558.0)
+		self.assertEqual(so.items[0].discount_amount, 27558.0)
 		so.submit()
 
 		warehouse = create_warehouse("NW Warehouse FOR Rate", company=so.company)
@@ -2584,13 +2584,13 @@ class TestSalesOrder(ERPNextTestSuite):
 
 		self.assertEqual(len(sres), 1)
 		sre_doc = frappe.get_doc("Stock Reservation Entry", sres[0].name)
-		self.assertFalse(sre_doc.status == "Delivered")
+		self.assertNotEqual(sre_doc.status, "Delivered")
 
 		si = make_sales_invoice(so.name)
 		si.update_stock = 1
 		si.submit()
 		sre_doc.reload()
-		self.assertTrue(sre_doc.status == "Delivered")
+		self.assertEqual(sre_doc.status, "Delivered")
 
 	@ERPNextTestSuite.change_settings("Selling Settings", {"allow_zero_qty_in_sales_order": 1})
 	def test_deliver_zero_qty_purchase_order(self):

--- a/erpnext/setup/doctype/company/test_company.py
+++ b/erpnext/setup/doctype/company/test_company.py
@@ -119,12 +119,12 @@ class TestCompany(ERPNextTestSuite):
 
 			self.assertTrue(lft)
 			self.assertTrue(rgt)
-			self.assertTrue(lft < rgt)
-			self.assertTrue(parent_lft < parent_rgt)
-			self.assertTrue(lft > parent_lft)
-			self.assertTrue(rgt < parent_rgt)
-			self.assertTrue(lft >= min_lft)
-			self.assertTrue(rgt <= max_rgt)
+			self.assertLess(lft, rgt)
+			self.assertLess(parent_lft, parent_rgt)
+			self.assertGreater(lft, parent_lft)
+			self.assertLess(rgt, parent_rgt)
+			self.assertGreaterEqual(lft, min_lft)
+			self.assertLessEqual(rgt, max_rgt)
 
 	def test_primary_address(self):
 		company = "_Test Company"

--- a/erpnext/setup/doctype/currency_exchange/test_currency_exchange.py
+++ b/erpnext/setup/doctype/currency_exchange/test_currency_exchange.py
@@ -104,11 +104,11 @@ class TestCurrencyExchange(ERPNextTestSuite):
 		# Exchange rate as on 15th Dec, 2015
 		self.clear_cache()
 		exchange_rate = get_exchange_rate("USD", "INR", "2015-12-15", "for_selling")
-		self.assertFalse(exchange_rate == 60)
+		self.assertNotEqual(exchange_rate, 60)
 		self.assertEqual(flt(exchange_rate, 3), 66.999)
 
 		exchange_rate = get_exchange_rate("USD", "INR", "2016-01-20", "for_buying")
-		self.assertFalse(exchange_rate == 60)
+		self.assertNotEqual(exchange_rate, 60)
 		self.assertEqual(flt(exchange_rate, 3), 65.1)
 
 	def test_exchange_rate_via_exchangerate_host(self, mock_get):
@@ -134,11 +134,11 @@ class TestCurrencyExchange(ERPNextTestSuite):
 		# Exchange rate as on 15th Dec, 2015
 		self.clear_cache()
 		exchange_rate = get_exchange_rate("USD", "INR", "2015-12-15", "for_selling")
-		self.assertFalse(exchange_rate == 60)
+		self.assertNotEqual(exchange_rate, 60)
 		self.assertEqual(flt(exchange_rate, 3), 66.999)
 
 		exchange_rate = get_exchange_rate("USD", "INR", "2016-01-20", "for_buying")
-		self.assertFalse(exchange_rate == 60)
+		self.assertNotEqual(exchange_rate, 60)
 		self.assertEqual(flt(exchange_rate, 3), 65.1)
 
 		settings = frappe.get_single("Currency Exchange Settings")
@@ -175,5 +175,5 @@ class TestCurrencyExchange(ERPNextTestSuite):
 
 		self.clear_cache()
 		exchange_rate = get_exchange_rate("USD", "INR", "2016-01-30", "for_buying")
-		self.assertFalse(exchange_rate == 65)
+		self.assertNotEqual(exchange_rate, 65)
 		self.assertEqual(flt(exchange_rate, 3), 62.9)

--- a/erpnext/setup/doctype/employee/test_employee.py
+++ b/erpnext/setup/doctype/employee/test_employee.py
@@ -28,10 +28,10 @@ class TestEmployee(ERPNextTestSuite):
 		employee = make_employee("test_emp_user_creation@company.com", company="_Test Company")
 		employee_doc = frappe.get_doc("Employee", employee)
 		user = employee_doc.user_id
-		self.assertTrue("Employee" in frappe.get_roles(user))
+		self.assertIn("Employee", frappe.get_roles(user))
 		employee_doc.user_id = ""
 		employee_doc.save()
-		self.assertTrue("Employee" not in frappe.get_roles(user))
+		self.assertNotIn("Employee", frappe.get_roles(user))
 
 	def test_employee_user_permission(self):
 		employee1 = make_employee(

--- a/erpnext/stock/doctype/delivery_note/test_delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/test_delivery_note.py
@@ -307,7 +307,7 @@ class TestDeliveryNote(ERPNextTestSuite):
 
 		returned_serial_nos1 = get_serial_nos_from_bundle(dn1.items[0].serial_and_batch_bundle)
 		for serial_no in returned_serial_nos1:
-			self.assertTrue(serial_no in serial_nos)
+			self.assertIn(serial_no, serial_nos)
 
 		dn2 = make_sales_return(dn.name)
 
@@ -318,8 +318,8 @@ class TestDeliveryNote(ERPNextTestSuite):
 
 		returned_serial_nos2 = get_serial_nos_from_bundle(dn2.items[0].serial_and_batch_bundle)
 		for serial_no in returned_serial_nos2:
-			self.assertTrue(serial_no in serial_nos)
-			self.assertFalse(serial_no in returned_serial_nos1)
+			self.assertIn(serial_no, serial_nos)
+			self.assertNotIn(serial_no, returned_serial_nos1)
 
 	def test_sales_return_for_non_bundled_items_partial(self):
 		company = frappe.db.get_value("Warehouse", "Stores - TCP1", "company")
@@ -1557,7 +1557,7 @@ class TestDeliveryNote(ERPNextTestSuite):
 		return_dn = make_return_doc(dn.doctype, dn.name)
 		return_dn.save().submit()
 
-		self.assertTrue(return_dn.docstatus == 1)
+		self.assertEqual(return_dn.docstatus, 1)
 
 	def test_reserve_qty_on_sales_return(self):
 		frappe.db.set_single_value("Selling Settings", "dont_reserve_sales_order_qty_on_sales_return", 0)
@@ -2772,7 +2772,7 @@ class TestDeliveryNote(ERPNextTestSuite):
 			doc = frappe.get_doc("Serial and Batch Bundle", row.serial_and_batch_bundle)
 			for entry in doc.entries:
 				if entry.serial_no:
-					self.assertTrue(entry.serial_no in serial_batch_map[row.item_code].serial_nos)
+					self.assertIn(entry.serial_no, serial_batch_map[row.item_code].serial_nos)
 					self.assertEqual(
 						entry.incoming_rate,
 						serial_batch_map[row.item_code].serial_no_valuation[entry.serial_no],
@@ -2782,7 +2782,7 @@ class TestDeliveryNote(ERPNextTestSuite):
 
 				elif entry.batch_no:
 					serial_batch_map[row.item_code].batches[entry.batch_no] += entry.qty
-					self.assertTrue(entry.batch_no in serial_batch_map[row.item_code].batches)
+					self.assertIn(entry.batch_no, serial_batch_map[row.item_code].batches)
 					self.assertEqual(entry.qty, 2.0)
 					self.assertEqual(
 						entry.incoming_rate,
@@ -2798,7 +2798,7 @@ class TestDeliveryNote(ERPNextTestSuite):
 			doc = frappe.get_doc("Serial and Batch Bundle", row.serial_and_batch_bundle)
 			for entry in doc.entries:
 				if entry.serial_no:
-					self.assertTrue(entry.serial_no in serial_batch_map[row.item_code].serial_nos)
+					self.assertIn(entry.serial_no, serial_batch_map[row.item_code].serial_nos)
 					self.assertEqual(
 						entry.incoming_rate,
 						serial_batch_map[row.item_code].serial_no_valuation[entry.serial_no],
@@ -2810,7 +2810,7 @@ class TestDeliveryNote(ERPNextTestSuite):
 					serial_batch_map[row.item_code].batches[entry.batch_no] += entry.qty
 					self.assertEqual(serial_batch_map[row.item_code].batches[entry.batch_no], 0.0)
 
-					self.assertTrue(entry.batch_no in serial_batch_map[row.item_code].batches)
+					self.assertIn(entry.batch_no, serial_batch_map[row.item_code].batches)
 
 					self.assertEqual(entry.qty, 3.0)
 					self.assertEqual(

--- a/erpnext/stock/doctype/item/test_item.py
+++ b/erpnext/stock/doctype/item/test_item.py
@@ -391,8 +391,9 @@ class TestItem(ERPNextTestSuite):
 				},
 			)
 
-		self.assertTrue(
-			"belong to company" in str(ve.exception).lower(),
+		self.assertIn(
+			"belong to company",
+			str(ve.exception).lower(),
 			msg="Mismatching company entities in item defaults should not be allowed.",
 		)
 
@@ -676,7 +677,7 @@ class TestItem(ERPNextTestSuite):
 			self.assertIsInstance(timestamp, int)
 			self.assertTrue(one_year_ago <= timestamp <= now)
 			self.assertIsInstance(count, int)
-			self.assertTrue(count >= 0)
+			self.assertGreaterEqual(count, 0)
 
 	def test_index_creation(self):
 		"check if index is getting created in db"
@@ -849,7 +850,7 @@ class TestItem(ERPNextTestSuite):
 		for _row in range(3):
 			item.append("customer_items", {"ref_code": frappe.generate_hash("", 120)})
 		item.save()
-		self.assertTrue(len(item.customer_code) > 140)
+		self.assertGreater(len(item.customer_code), 140)
 
 	def test_update_is_stock_item(self):
 		# Step - 1: Create an Item with Maintain Stock enabled
@@ -890,7 +891,7 @@ class TestItem(ERPNextTestSuite):
 		data = item_query("Item", "Test Item", "", 0, 20, filters={"item_name": "Test Item"}, as_dict=True)
 		self.assertEqual(data[0].name, item.name)
 		self.assertEqual(data[0].item_name, item.item_name)
-		self.assertTrue("description" not in data[0])
+		self.assertNotIn("description", data[0])
 
 		make_property_setter(
 			"Item", None, "search_fields", "item_name, description", "Data", for_doctype="Doctype"
@@ -899,7 +900,7 @@ class TestItem(ERPNextTestSuite):
 		self.assertEqual(data[0].name, item.name)
 		self.assertEqual(data[0].item_name, item.item_name)
 		self.assertEqual(data[0].description, item.description)
-		self.assertTrue("description" in data[0])
+		self.assertIn("description", data[0])
 
 	def test_group_warehouse_for_reorder_item(self):
 		from erpnext.stock.doctype.warehouse.test_warehouse import create_warehouse
@@ -956,8 +957,9 @@ class TestItem(ERPNextTestSuite):
 				}
 			).insert()
 
-		self.assertTrue(
-			"must be same as in Template" in str(ve.exception),
+		self.assertIn(
+			"must be same as in Template",
+			str(ve.exception),
 			msg="Different Variant UOM should not be allowed when `allow_different_uom` is disabled.",
 		)
 

--- a/erpnext/stock/doctype/item_price/test_item_price.py
+++ b/erpnext/stock/doctype/item_price/test_item_price.py
@@ -54,7 +54,7 @@ class TestItemPrice(ERPNextTestSuite):
 		doc_fields = frappe.copy_doc(self.globalTestRecords["Item Price"][1]).__dict__.keys()
 
 		for test_field in test_fields_existance:
-			self.assertTrue(test_field in doc_fields)
+			self.assertIn(test_field, doc_fields)
 
 	def test_dates_validation_error(self):
 		doc = frappe.copy_doc(self.globalTestRecords["Item Price"][1])

--- a/erpnext/stock/doctype/material_request/test_material_request.py
+++ b/erpnext/stock/doctype/material_request/test_material_request.py
@@ -915,7 +915,7 @@ class TestMaterialRequest(ERPNextTestSuite):
 		for company, _mr_list in comapnywise_mr_list.items():
 			emails = get_email_list(company)
 
-			self.assertTrue(comapnywise_users[company] in emails)
+			self.assertIn(comapnywise_users[company], emails)
 
 		for perm in permissions:
 			perm.delete()

--- a/erpnext/stock/doctype/pick_list/test_pick_list.py
+++ b/erpnext/stock/doctype/pick_list/test_pick_list.py
@@ -876,7 +876,7 @@ class TestPickList(ERPNextTestSuite):
 			)
 
 			for d in data:
-				self.assertTrue(d.batch_no in ["PICKLT-000001", "PICKLT-000002"])
+				self.assertIn(d.batch_no, ["PICKLT-000001", "PICKLT-000002"])
 				if d.batch_no == "PICKLT-000001":
 					self.assertEqual(d.qty, 5.0 * -1)
 				elif d.batch_no == "PICKLT-000002":
@@ -927,7 +927,7 @@ class TestPickList(ERPNextTestSuite):
 
 			self.assertEqual(len(data), 10)
 			for d in data:
-				self.assertTrue(d.serial_no not in picked_serial_nos)
+				self.assertNotIn(d.serial_no, picked_serial_nos)
 
 		pl1.cancel()
 		pl.cancel()
@@ -1311,7 +1311,7 @@ class TestPickList(ERPNextTestSuite):
 		self.assertEqual(len(new_serial_nos), 110)
 
 		for sn in serial_nos:
-			self.assertFalse(sn in new_serial_nos)
+			self.assertNotIn(sn, new_serial_nos)
 
 		pl1.submit()
 
@@ -1765,5 +1765,5 @@ class TestPickList(ERPNextTestSuite):
 			else:
 				self.assertEqual(doc.shipping_address_name, customer_shipping_address_1.name)
 				item_codes = [item.item_code for item in doc.items]
-				self.assertTrue(item1 in item_codes)
-				self.assertTrue(item2 in item_codes)
+				self.assertIn(item1, item_codes)
+				self.assertIn(item2, item_codes)

--- a/erpnext/stock/doctype/purchase_receipt/test_purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/test_purchase_receipt.py
@@ -1145,7 +1145,7 @@ class TestPurchaseReceipt(ERPNextTestSuite):
 		new_cost = frappe.db.get_value("Serial and Batch Bundle", new_inward_sabb[0], "total_amount")
 		self.assertEqual(new_cost, original_cost + 100)
 
-		self.assertTrue(new_inward_sabb[0] == inward_sabb[0])
+		self.assertEqual(new_inward_sabb[0], inward_sabb[0])
 
 	def test_stock_transfer_from_purchase_receipt_with_valuation(self):
 		from erpnext.stock.doctype.delivery_note.delivery_note import make_inter_company_purchase_receipt
@@ -1797,7 +1797,7 @@ class TestPurchaseReceipt(ERPNextTestSuite):
 		return_pi = make_return_doc(pi.doctype, pi.name)
 		return_pi.save().submit()
 
-		self.assertTrue(return_pi.docstatus == 1)
+		self.assertEqual(return_pi.docstatus, 1)
 
 	def test_disable_last_purchase_rate(self):
 		from erpnext.stock.get_item_details import ItemDetailsCtx, get_item_details
@@ -2504,7 +2504,7 @@ class TestPurchaseReceipt(ERPNextTestSuite):
 		sbb_doc = frappe.get_doc("Serial and Batch Bundle", pr.items[0].serial_and_batch_bundle)
 
 		for row in sbb_doc.entries:
-			self.assertTrue(row.serial_no in serial_nos)
+			self.assertIn(row.serial_no, serial_nos)
 
 		serial_nos.remove("SNU-TSFISI-000015")
 
@@ -2537,7 +2537,7 @@ class TestPurchaseReceipt(ERPNextTestSuite):
 
 		serial_no_status = frappe.db.get_value("Serial No", "SNU-TSFISI-000015", "status")
 
-		self.assertTrue(serial_no_status != "Active")
+		self.assertNotEqual(serial_no_status, "Active")
 
 		dn = create_delivery_note(
 			item_code=item_code,
@@ -2550,11 +2550,11 @@ class TestPurchaseReceipt(ERPNextTestSuite):
 		self.assertEqual(dn.items[0].qty, 4)
 		doc = frappe.get_doc("Serial and Batch Bundle", dn.items[0].serial_and_batch_bundle)
 		for row in doc.entries:
-			self.assertTrue(row.serial_no in new_serial_nos)
+			self.assertIn(row.serial_no, new_serial_nos)
 
 		for sn in new_serial_nos:
 			serial_no_status = frappe.db.get_value("Serial No", sn, "status")
-			self.assertTrue(serial_no_status != "Active")
+			self.assertNotEqual(serial_no_status, "Active")
 
 		frappe.db.set_single_value(
 			"Stock Settings", "do_not_update_serial_batch_on_creation_of_auto_bundle", 1
@@ -2965,7 +2965,7 @@ class TestPurchaseReceipt(ERPNextTestSuite):
 					serial_no_details = frappe.db.get_value(
 						"Serial No", sn, ["status", "warehouse"], as_dict=1
 					)
-					self.assertTrue(serial_no_details.status == "Active")
+					self.assertEqual(serial_no_details.status, "Active")
 					self.assertEqual(serial_no_details.warehouse, "Work In Progress - TCP1")
 
 		inter_transfer_dn_return = make_return_doc("Delivery Note", inter_transfer_dn.name)
@@ -3104,7 +3104,7 @@ class TestPurchaseReceipt(ERPNextTestSuite):
 					serial_no_details = frappe.db.get_value(
 						"Serial No", sn, ["status", "warehouse"], as_dict=1
 					)
-					self.assertTrue(serial_no_details.status == "Active")
+					self.assertEqual(serial_no_details.status, "Active")
 					self.assertEqual(serial_no_details.warehouse, "Work In Progress - TCP1")
 
 		inter_transfer_dn_return = make_return_doc("Delivery Note", inter_transfer_dn.name)
@@ -4236,7 +4236,7 @@ class TestPurchaseReceipt(ERPNextTestSuite):
 		serial_no = get_serial_nos_from_bundle(pr.items[0].serial_and_batch_bundle)[0]
 
 		status = frappe.db.get_value("Serial No", serial_no, "status")
-		self.assertTrue(status == "Active")
+		self.assertEqual(status, "Active")
 
 		make_stock_entry(
 			item_code=item_code,
@@ -4247,7 +4247,7 @@ class TestPurchaseReceipt(ERPNextTestSuite):
 		)
 
 		status = frappe.db.get_value("Serial No", serial_no, "status")
-		self.assertFalse(status == "Active")
+		self.assertNotEqual(status, "Active")
 
 		pr = make_purchase_receipt(
 			item_code=item_code, qty=1, rate=100, use_serial_batch_fields=1, do_not_submit=1
@@ -4759,8 +4759,8 @@ class TestPurchaseReceipt(ERPNextTestSuite):
 
 		gl_entries = get_gl_entries(pr.doctype, pr.name)
 		accounts = [d.account for d in gl_entries]
-		self.assertTrue(expense_account in accounts)
-		self.assertTrue(expense_contra_account in accounts)
+		self.assertIn(expense_account, accounts)
+		self.assertIn(expense_contra_account, accounts)
 
 		for row in gl_entries:
 			if row.account == expense_account:
@@ -4798,7 +4798,7 @@ class TestPurchaseReceipt(ERPNextTestSuite):
 
 		gl_entries = get_gl_entries(se.doctype, se.name)
 		for row in gl_entries:
-			self.assertTrue(row.account in ["Stock In Hand - TCP1", "Stock Adjustment - TCP1"])
+			self.assertIn(row.account, ["Stock In Hand - TCP1", "Stock Adjustment - TCP1"])
 
 		se.items[0].db_set("expense_account", account)
 		se.reload()
@@ -4820,7 +4820,7 @@ class TestPurchaseReceipt(ERPNextTestSuite):
 
 		gl_entries = get_gl_entries(se.doctype, se.name)
 		for row in gl_entries:
-			self.assertTrue(row.account in ["Stock In Hand - TCP1", account])
+			self.assertIn(row.account, ["Stock In Hand - TCP1", account])
 
 	def test_lcv_for_repack_entry(self):
 		from erpnext.stock.doctype.landed_cost_voucher.test_landed_cost_voucher import (
@@ -5056,7 +5056,7 @@ class TestPurchaseReceipt(ERPNextTestSuite):
 		doc.db_set("use_batchwise_valuation", 0)
 		doc.reload()
 
-		self.assertTrue(doc.use_batchwise_valuation == 0)
+		self.assertEqual(doc.use_batchwise_valuation, 0)
 
 		doc = frappe.new_doc("Batch")
 		doc.update(
@@ -5066,7 +5066,7 @@ class TestPurchaseReceipt(ERPNextTestSuite):
 			}
 		).insert()
 
-		self.assertTrue(doc.use_batchwise_valuation == 1)
+		self.assertEqual(doc.use_batchwise_valuation, 1)
 
 		warehouse = "_Test Warehouse - _TC"
 		make_stock_entry(
@@ -5458,7 +5458,7 @@ class TestPurchaseReceipt(ERPNextTestSuite):
 		self.assertEqual(pr.conversion_rate, 80)
 
 		gl_entries = get_gl_entries(pr.doctype, pr.name)
-		self.assertTrue(len(gl_entries) == 2)
+		self.assertEqual(len(gl_entries), 2)
 		for row in gl_entries:
 			amount = row.credit or row.debit
 			self.assertEqual(amount, 8000.0)
@@ -5471,13 +5471,13 @@ class TestPurchaseReceipt(ERPNextTestSuite):
 		pi.submit()
 
 		gl_entries = get_gl_entries(pi.doctype, pi.name)
-		self.assertTrue(len(gl_entries) == 2)
+		self.assertEqual(len(gl_entries), 2)
 
 		accounts = ["USD Party Account Creditors - TCP1", "Stock Received But Not Billed - TCP1"]
 		for row in gl_entries:
 			amount = row.credit or row.debit
 			self.assertEqual(amount, 9000.0)
-			self.assertTrue(row.account in accounts)
+			self.assertIn(row.account, accounts)
 
 		frappe.db.set_single_value(
 			"Buying Settings", "set_landed_cost_based_on_purchase_invoice_rate", original_value

--- a/erpnext/stock/doctype/quality_inspection/quality_inspection.py
+++ b/erpnext/stock/doctype/quality_inspection/quality_inspection.py
@@ -8,7 +8,7 @@ import frappe
 from frappe import _
 from frappe.model.document import Document
 from frappe.model.mapper import get_mapped_doc
-from frappe.utils import cint, cstr, flt, get_link_to_form, get_number_format_info
+from frappe.utils import cint, flt, get_link_to_form, get_number_format_info
 
 from erpnext.stock.doctype.quality_inspection_template.quality_inspection_template import (
 	get_template_details,

--- a/erpnext/stock/doctype/repost_item_valuation/test_repost_item_valuation.py
+++ b/erpnext/stock/doctype/repost_item_valuation/test_repost_item_valuation.py
@@ -100,14 +100,14 @@ class TestRepostItemValuation(ERPNextTestSuite, StockTestMixin):
 			repost_doc.db_update_all()
 
 		logs = frappe.get_all("Repost Item Valuation", filters={"status": "Skipped"})
-		self.assertTrue(len(logs) > 10)
+		self.assertGreater(len(logs), 10)
 
 		from erpnext.stock.doctype.repost_item_valuation.repost_item_valuation import RepostItemValuation
 
 		RepostItemValuation.clear_old_logs(days=1)
 
 		logs = frappe.get_all("Repost Item Valuation", filters={"status": "Skipped"})
-		self.assertTrue(len(logs) == 0)
+		self.assertEqual(len(logs), 0)
 
 	def test_create_item_wise_repost_item_valuation_entries(self):
 		pr = make_purchase_receipt(
@@ -379,13 +379,13 @@ class TestRepostItemValuation(ERPNextTestSuite, StockTestMixin):
 			get_multiple_items=True,
 		)
 
-		self.assertTrue(pr.docstatus == 1)
+		self.assertEqual(pr.docstatus, 1)
 		self.assertFalse(frappe.db.exists("Repost Item Valuation", {"voucher_no": pr.name}))
 
 		pr.load_from_db()
 
 		pr.cancel()
-		self.assertTrue(pr.docstatus == 2)
+		self.assertEqual(pr.docstatus, 2)
 		self.assertTrue(frappe.db.exists("Repost Item Valuation", {"voucher_no": pr.name}))
 
 	def test_repost_item_valuation_for_closing_stock_balance(self):

--- a/erpnext/stock/doctype/serial_and_batch_bundle/test_serial_and_batch_bundle.py
+++ b/erpnext/stock/doctype/serial_and_batch_bundle/test_serial_and_batch_bundle.py
@@ -1070,11 +1070,11 @@ class TestSerialandBatchBundle(ERPNextTestSuite):
 
 		se.remove(se.items[1])
 		se.save()
-		self.assertTrue(len(se.items) == 1)
+		self.assertEqual(len(se.items), 1)
 		se.submit()
 
 		bundle_doc.reload()
-		self.assertTrue(bundle_doc.docstatus == 0)
+		self.assertEqual(bundle_doc.docstatus, 0)
 		self.assertRaises(frappe.ValidationError, bundle_doc.submit)
 
 	def test_reference_voucher_on_cancel(self):

--- a/erpnext/stock/doctype/stock_closing_entry/stock_closing_entry.py
+++ b/erpnext/stock/doctype/stock_closing_entry/stock_closing_entry.py
@@ -137,8 +137,7 @@ class StockClosingEntry(Document):
 			attached_file = frappe.get_doc("File", attachment.name)
 
 			data = gzip.decompress(attached_file.get_content())
-			if data := json.loads(data.decode("utf-8")):
-				data = data
+			data = json.loads(data.decode("utf-8"))
 
 			return parse_json(data)
 

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -6,20 +6,15 @@ import json
 from collections import defaultdict
 
 import frappe
-from frappe import _, bold
+from frappe import _
 from frappe.model.document import Document
 from frappe.model.mapper import get_mapped_doc
-from frappe.query_builder import DocType
-from frappe.query_builder.functions import Max, Sum
+from frappe.query_builder.functions import Sum
 from frappe.utils import (
 	cint,
-	comma_or,
 	cstr,
 	flt,
-	format_time,
-	formatdate,
 	get_link_to_form,
-	getdate,
 	nowdate,
 )
 
@@ -29,27 +24,17 @@ from erpnext.accounts.utils import get_account_currency
 from erpnext.buying.utils import check_on_hold_or_closed_status
 from erpnext.controllers.taxes_and_totals import init_landed_taxes_and_totals
 from erpnext.manufacturing.doctype.bom.bom import (
-	add_additional_cost,
 	get_op_cost_from_sub_assemblies,
-	get_secondary_items_from_sub_assemblies,
 	validate_bom_no,
 )
 from erpnext.setup.doctype.brand.brand import get_brand_defaults
 from erpnext.setup.doctype.item_group.item_group import get_item_group_defaults
-from erpnext.stock.doctype.item.item import get_item_defaults
-from erpnext.stock.doctype.serial_no.serial_no import get_serial_nos
 from erpnext.stock.get_item_details import (
 	ItemDetailsCtx,
 	get_barcode_data,
 	get_bin_details,
 	get_conversion_factor,
 	get_default_cost_center,
-)
-from erpnext.stock.serial_batch_bundle import (
-	SerialBatchCreation,
-	get_batch_nos,
-	get_empty_batches_based_work_order,
-	get_serial_or_batch_items,
 )
 from erpnext.stock.stock_ledger import get_previous_sle, get_valuation_rate
 from erpnext.stock.utils import get_incoming_rate

--- a/erpnext/stock/doctype/stock_entry/test_stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/test_stock_entry.py
@@ -184,7 +184,7 @@ class TestStockEntry(ERPNextTestSuite):
 			for d in mr.items:
 				items.append(d.item_code)
 
-		self.assertTrue(item_code in items)
+		self.assertIn(item_code, items)
 
 	def test_add_to_transit_entry(self):
 		from erpnext.stock.doctype.warehouse.test_warehouse import create_warehouse
@@ -953,7 +953,7 @@ class TestStockEntry(ERPNextTestSuite):
 
 		stock_entry = frappe.get_doc(make_stock_entry(work_order.name, "Manufacture", 1))
 		stock_entry.insert()
-		self.assertTrue("_Test Variant Item-S" in [d.item_code for d in stock_entry.items])
+		self.assertIn("_Test Variant Item-S", [d.item_code for d in stock_entry.items])
 
 	def test_nagative_stock_for_batch(self):
 		item = make_item(

--- a/erpnext/stock/doctype/stock_entry_detail/stock_entry_detail.py
+++ b/erpnext/stock/doctype/stock_entry_detail/stock_entry_detail.py
@@ -5,20 +5,15 @@ import frappe
 from frappe import _, bold
 from frappe.model.document import Document
 from frappe.utils import (
-	cint,
-	cstr,
 	flt,
-	format_time,
-	formatdate,
 	get_link_to_form,
 	getdate,
-	nowdate,
 )
 
 from erpnext.stock.doctype.stock_reconciliation.stock_reconciliation import (
 	OpeningEntryAccountError,
 )
-from erpnext.stock.stock_ledger import NegativeStockError, get_previous_sle, is_negative_stock_allowed
+from erpnext.stock.stock_ledger import get_previous_sle
 
 
 class StockEntryDetail(Document):

--- a/erpnext/stock/doctype/stock_reconciliation/test_stock_reconciliation.py
+++ b/erpnext/stock/doctype/stock_reconciliation/test_stock_reconciliation.py
@@ -1040,7 +1040,7 @@ class TestStockReconciliation(ERPNextTestSuite, StockTestMixin):
 		)
 
 		batch1 = get_batch_from_bundle(se1.items[0].serial_and_batch_bundle)
-		self.assertFalse(batch1 == batch)
+		self.assertNotEqual(batch1, batch)
 
 		sr.reload()
 		self.assertTrue(sr.items[0].serial_and_batch_bundle)
@@ -1418,7 +1418,7 @@ class TestStockReconciliation(ERPNextTestSuite, StockTestMixin):
 		sr.save()
 		self.assertEqual(sr.items[0].current_valuation_rate, 100)
 		self.assertEqual(sr.difference_amount, 100 * -1)
-		self.assertTrue(sr.items[0].qty == 0)
+		self.assertEqual(sr.items[0].qty, 0)
 
 	def test_stock_reco_recalculate_qty_for_backdated_entry(self):
 		from erpnext.stock.doctype.stock_entry.test_stock_entry import make_stock_entry
@@ -1456,7 +1456,7 @@ class TestStockReconciliation(ERPNextTestSuite, StockTestMixin):
 			pluck="name",
 		)
 
-		self.assertTrue(len(stock_ledgers) == 1)
+		self.assertEqual(len(stock_ledgers), 1)
 
 		se = make_stock_entry(
 			item_code=item_code,
@@ -1515,7 +1515,7 @@ class TestStockReconciliation(ERPNextTestSuite, StockTestMixin):
 			"status",
 		)
 
-		self.assertTrue(status == "Active")
+		self.assertEqual(status, "Active")
 
 		sr = create_stock_reconciliation(
 			item_code=serial_item,
@@ -1534,7 +1534,7 @@ class TestStockReconciliation(ERPNextTestSuite, StockTestMixin):
 			"status",
 		)
 
-		self.assertTrue(status == "Active")
+		self.assertEqual(status, "Active")
 
 		se = make_stock_entry(
 			item_code=serial_item,
@@ -1550,7 +1550,7 @@ class TestStockReconciliation(ERPNextTestSuite, StockTestMixin):
 			"status",
 		)
 
-		self.assertFalse(status == "Active")
+		self.assertNotEqual(status, "Active")
 
 		sr.cancel()
 
@@ -1560,7 +1560,7 @@ class TestStockReconciliation(ERPNextTestSuite, StockTestMixin):
 			"status",
 		)
 
-		self.assertFalse(status == "Active")
+		self.assertNotEqual(status, "Active")
 
 	def test_change_valuation_of_batch_using_backdated_stock_reco(self):
 		from erpnext.stock.doctype.batch.batch import get_batch_qty

--- a/erpnext/stock/doctype/stock_reposting_settings/test_stock_reposting_settings.py
+++ b/erpnext/stock/doctype/stock_reposting_settings/test_stock_reposting_settings.py
@@ -31,9 +31,9 @@ class TestStockRepostingSettings(ERPNextTestSuite):
 		frappe.db.set_single_value("Stock Reposting Settings", "notify_reposting_error_to_role", "")
 
 		users = get_recipients()
-		self.assertFalse(user in users)
+		self.assertNotIn(user, users)
 
 		frappe.db.set_single_value("Stock Reposting Settings", "notify_reposting_error_to_role", role)
 
 		users = get_recipients()
-		self.assertTrue(user in users)
+		self.assertIn(user, users)

--- a/erpnext/stock/doctype/stock_settings/stock_settings.py
+++ b/erpnext/stock/doctype/stock_settings/stock_settings.py
@@ -8,7 +8,6 @@ import frappe
 from frappe import _
 from frappe.custom.doctype.property_setter.property_setter import make_property_setter
 from frappe.model.document import Document
-from frappe.utils import cint
 from frappe.utils.html_utils import clean_html
 
 from erpnext.stock.utils import check_pending_reposting

--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -434,8 +434,7 @@ def get_reposting_data(file_path) -> dict:
 	except Exception:
 		return frappe._dict()
 
-	if data := json.loads(data.decode("utf-8")):
-		data = data
+	data = json.loads(data.decode("utf-8"))
 
 	return parse_json(data)
 
@@ -1457,8 +1456,7 @@ class update_entries_after:
 				item.amount = flt(item.qty) * flt(item.valuation_rate)
 				item.quantity_difference = item.qty - item.current_qty
 				item.amount_difference = item.amount - item.current_amount
-			else:
-				sr.difference_amount = sum([item.amount_difference for item in sr.items])
+			sr.difference_amount = sum([item.amount_difference for item in sr.items])
 			sr.db_update()
 
 			for item in sr.items:

--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -17,7 +17,6 @@ from frappe.utils import (
 	format_date,
 	get_datetime,
 	get_link_to_form,
-	getdate,
 	now,
 	nowdate,
 	nowtime,

--- a/erpnext/subcontracting/doctype/subcontracting_order/subcontracting_order.py
+++ b/erpnext/subcontracting/doctype/subcontracting_order/subcontracting_order.py
@@ -198,9 +198,8 @@ class SubcontractingOrder(SubcontractingController):
 			item.amount = item.qty * item.rate
 			total_qty += flt(item.qty)
 			total += flt(item.amount)
-		else:
-			self.total_qty = total_qty
-			self.total = total
+		self.total_qty = total_qty
+		self.total = total
 
 	def update_ordered_qty_for_subcontracting(self, sco_item_rows=None):
 		item_wh_list = []

--- a/erpnext/subcontracting/doctype/subcontracting_order/test_subcontracting_order.py
+++ b/erpnext/subcontracting/doctype/subcontracting_order/test_subcontracting_order.py
@@ -640,7 +640,7 @@ class TestSubcontractingOrder(ERPNextTestSuite):
 			qty=10,
 		)
 
-		self.assertTrue(mr.docstatus == 1)
+		self.assertEqual(mr.docstatus, 1)
 
 		new_requested_qty = frappe.db.get_value(
 			"Bin",
@@ -726,7 +726,7 @@ class TestSubcontractingOrder(ERPNextTestSuite):
 		sco.submit()
 
 		sre_list = get_sre_details_for_voucher("Subcontracting Order", sco.name)
-		self.assertTrue(len(sre_list) > 0)
+		self.assertGreater(len(sre_list), 0)
 
 		se_dict = make_rm_stock_entry(sco.name)
 		se = frappe.get_doc(se_dict)
@@ -843,9 +843,8 @@ def create_subcontracting_order(**args):
 			warehouses = []
 			for item in po.items:
 				warehouses.append(item.warehouse)
-			else:
-				for idx, val in enumerate(sco.items):
-					val.warehouse = warehouses[idx]
+			for idx, val in enumerate(sco.items):
+				val.warehouse = warehouses[idx]
 
 	warehouses = set()
 	for item in sco.items:

--- a/erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py
+++ b/erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py
@@ -490,11 +490,10 @@ class SubcontractingReceipt(SubcontractingController):
 					supplied_items_details[item.name][
 						supplied_item.rm_item_code
 					] += supplied_item.available_qty
-		else:
-			for item in self.get("supplied_items"):
-				item.available_qty_for_consumption = supplied_items_details.get(item.reference_name, {}).get(
-					item.rm_item_code, 0
-				)
+		for item in self.get("supplied_items"):
+			item.available_qty_for_consumption = supplied_items_details.get(item.reference_name, {}).get(
+				item.rm_item_code, 0
+			)
 
 	def calculate_items_qty_and_amount(self):
 		rm_cost_map = {}
@@ -561,9 +560,8 @@ class SubcontractingReceipt(SubcontractingController):
 
 			total_qty += flt(item.qty) + flt(item.rejected_qty)
 			total_amount += item.amount
-		else:
-			self.total_qty = total_qty
-			self.total = total_amount
+		self.total_qty = total_qty
+		self.total = total_amount
 
 	def validate_secondary_items(self):
 		for item in self.items:

--- a/erpnext/subcontracting/doctype/subcontracting_receipt/test_subcontracting_receipt.py
+++ b/erpnext/subcontracting/doctype/subcontracting_receipt/test_subcontracting_receipt.py
@@ -1311,7 +1311,7 @@ class TestSubcontractingReceipt(ERPNextTestSuite):
 
 		# Step - 8: Cancel Subcontracting Receipt
 		scr.cancel()
-		self.assertTrue(scr.docstatus == 2)
+		self.assertEqual(scr.docstatus, 2)
 
 	def test_subcontract_return_from_rejected_warehouse(self):
 		from erpnext.stock.doctype.warehouse.test_warehouse import create_warehouse

--- a/erpnext/support/doctype/issue/test_issue.py
+++ b/erpnext/support/doctype/issue/test_issue.py
@@ -245,7 +245,7 @@ class TestIssue(TestSetUp):
 
 		issue = make_issue(frappe.flags.current_time, index=1)
 		create_communication(issue.name, "test@example.com", "Received", frappe.flags.current_time)
-		self.assertTrue(issue.status == "Open")
+		self.assertEqual(issue.status, "Open")
 
 		# send a reply within response SLA
 		frappe.flags.current_time = get_datetime("2021-11-02 11:00")

--- a/erpnext/tests/test_webform.py
+++ b/erpnext/tests/test_webform.py
@@ -29,12 +29,12 @@ class TestWebsite(ERPNextTestSuite):
 
 		with self.set_user("supplier1@gmail.com"):
 			# checking if data only consist of order assignment of Supplier1
-			self.assertTrue("Supplier1" in [data.supplier for data in get_data()])
+			self.assertIn("Supplier1", [data.supplier for data in get_data()])
 			self.assertFalse([data.supplier for data in get_data() if data.supplier != "Supplier1"])
 
 		with self.set_user("supplier2@gmail.com"):
 			# checking if data only consist of order assignment of Supplier2
-			self.assertTrue("Supplier2" in [data.supplier for data in get_data()])
+			self.assertIn("Supplier2", [data.supplier for data in get_data()])
 			self.assertFalse([data.supplier for data in get_data() if data.supplier != "Supplier2"])
 
 


### PR DESCRIPTION
## Summary

Resolves the **regression-safe** subset of the CodeQL *Code quality → Standard findings* on `develop`. Every change is behavior-preserving and verified by rebuilding the CodeQL database and re-running the `python-code-quality` suite.

| Commit | Rule | Resolved | Change |
|--------|------|----------|--------|
| `test: use precise unittest assertions` | `py/imprecise-assert` | 179 | `assertTrue(a == b)` → `assertEqual(a, b)`, etc. (libcst codemod) |
| `refactor: remove unused imports` | `py/unused-import` | 23 of 27 | Remove imports unused in their module (`ruff F401`); verified none are re-exported. **4 kept** (see below). |
| `refactor: assorted cleanups` | `py/redundant-else` | 6 | De-indent `for…else` with no `break` (else always runs). |
| ″ | `py/redundant-assignment` | 3 | Remove `x = x` self-assignments. |
| ″ | `py/unnecessary-lambda` | 1 | `lambda x: int(x)` → `int`. |
| ″ | `py/repeated-import` | 1 | Drop a function-local duplicate `import json`. |

**213 findings resolved.**

## Notes on safety
- **unused-import**: both CodeQL and ruff independently agree on the symbol set; a cross-repo grep confirms none of the removed names are re-exported. **4 `get_xlsx_styles` imports annotated `#! DO NOT REMOVE - hook for styling` are intentionally retained** — they are side-effect imports that register styling, so they stay despite being statically "unused".
- **imprecise-assert**: pass/fail outcome is identical for every rewrite. `assertFalse` is only rewritten for exact logical complements (`==`,`!=`,`in`,`not in`,`is`,`is not`); relational operators are deliberately left alone since `not (a > b)` ≠ `a <= b` for `NaN`.
- **redundant-else**: only `for…else` with no `break`, where the `else` is unconditional by definition.
- **redundant-assignment**: the two `if data := json.loads(...): data = data` cases collapse to `data = json.loads(...)` — the walrus guard had no effect.

`py/unnecessary-pass` is intentionally **not** touched — those `pass` statements live in Frappe's auto-generated DocType controller blocks and are re-emitted by the framework's code generator.

## Verification (CodeQL, controlled)

Built CodeQL DBs locally from identical extraction — pristine `develop` vs. this branch — and diffed `python-code-quality.qls`. All targeted rules drop to zero (apart from the 4 intentionally-retained `get_xlsx_styles` imports), with **no new findings introduced and no other rule changed**.

## Deliberately NOT included
Advisory findings or ones carrying real regression risk that need human judgment — e.g. `py/mixed-returns` (239), `py/multiple-definition` (92), `py/unused-local-variable` (89, mostly `x = call()` or dead-code blocks that signal latent bugs), `py/empty-except` (46), plus the JS rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)