### PR TITLE
fix: allow CRM Deal as Quotation To for CRM integration

### DIFF
--- a/erpnext/selling/doctype/quotation/quotation.js
+++ b/erpnext/selling/doctype/quotation/quotation.js
@@ -16,7 +16,7 @@ frappe.ui.form.on("Quotation", {
 			frm.set_query("quotation_to", function () {
 				return {
 					filters: {
-						name: ["in", ["Customer", "Lead", "Prospect"]],
+						name: ["in", ["Customer", "Lead", "Prospect", "CRM Deal"]],
 					},
 				};
 			});


### PR DESCRIPTION
Framework now disallows link values not matching field filters [ref](https://github.com/frappe/frappe/pull/35033). The quotation_to set_query didnt include 'CRM Deal', so the value prefilled when creating a Quotation from a CRM Deal was cleared on validation which made the required field empty and blocked save. https://github.com/frappe/crm/issues/1869