### PR TITLE
feat(payment-entry): warn user before cancelling reconciled payment entry

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.js
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.js
@@ -1726,6 +1726,35 @@ frappe.ui.form.on("Payment Entry", {
 			},
 		});
 	},
+
+	before_cancel: function (frm) {
+		return new Promise((resolve, reject) => {
+			frappe.call({
+				method: "erpnext.accounts.doctype.payment_entry.payment_entry.get_linked_bank_transactions",
+				args: { payment_entry: frm.doc.name },
+				callback: function (r) {
+					const linked = r.message || [];
+					if (!linked.length) {
+						resolve();
+						return;
+					}
+					const bt_links = linked
+						.map((name) => frappe.utils.get_form_link("Bank Transaction", name, true))
+						.join(", ");
+					frappe.confirm(
+						__(
+							"This Payment Entry is reconciled with {0}. Cancelling will automatically unreconcile it. Do you want to proceed?",
+							[bt_links]
+						),
+						() => resolve(),
+						() => reject(),
+						__("Yes"),
+						__("No")
+					);
+				},
+			});
+		});
+	},
 });
 
 frappe.ui.form.on("Payment Entry Reference", {

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -3574,3 +3574,16 @@ def make_payment_order(source_name: str, target_doc: str | Document | None = Non
 @erpnext.allow_regional
 def add_regional_gl_entries(gl_entries, doc):
 	return
+
+
+@frappe.whitelist()
+def get_linked_bank_transactions(payment_entry: str) -> list:
+	frappe.has_permission("Payment Entry", ptype="read", doc=payment_entry, throw=True)
+	return frappe.get_all(
+		"Bank Transaction Payments",
+		filters={
+			"payment_document": "Payment Entry",
+			"payment_entry": payment_entry,
+		},
+		pluck="parent",
+	)


### PR DESCRIPTION
- Add `before_cancel` JS hook that checks for linked Bank Transactions
  and shows a confirmation dialog before proceeding with cancellation
- Add `get_linked_bank_transactions` whitelisted method with read
  permission check to securely fetch linked Bank Transactions

no-docs


Support Ticket: https://support.frappe.io/helpdesk/tickets/67086
closes: https://github.com/frappe/erpnext/issues/54665