### PR TITLE
feat(banking): PDF statement importer and overriding column mapping

### DIFF
--- a/banking/src/components/features/BankStatementImporter/CSV/CSVImport.tsx
+++ b/banking/src/components/features/BankStatementImporter/CSV/CSVImport.tsx
@@ -2,9 +2,7 @@ import CSVRawDataPreview from './CSVRawDataPreview'
 import StatementDetails from './StatementDetails'
 import { GetStatementDetailsResponse } from '../import_utils'
 
-const CSVImport = ({ data }: { data: { message: GetStatementDetailsResponse } }) => {
-
-
+const CSVImport = ({ data, mutate }: { data: { message: GetStatementDetailsResponse }, mutate: () => void }) => {
 
     return (
         <div className="w-full flex">
@@ -12,7 +10,7 @@ const CSVImport = ({ data }: { data: { message: GetStatementDetailsResponse } })
                 <StatementDetails data={data.message} />
             </div>
             <div className="w-[50%] border-s border-t pe-1 ps-0 border-outline-gray-2 h-[calc(100vh-72px)] overflow-scroll">
-                <CSVRawDataPreview data={data.message} />
+                <CSVRawDataPreview data={data.message} mutate={mutate} />
             </div>
         </div>
     )

--- a/banking/src/components/features/BankStatementImporter/CSV/CSVRawDataPreview.tsx
+++ b/banking/src/components/features/BankStatementImporter/CSV/CSVRawDataPreview.tsx
@@ -1,151 +1,104 @@
-import { Table, TableBody, TableCell, TableHead, TableRow } from "@/components/ui/table"
-import { cn } from "@/lib/utils"
-import { ArrowDownRightIcon, ArrowUpDownIcon, ArrowUpRightIcon, BanknoteIcon, CalendarIcon, DollarSignIcon, FileTextIcon, ListIcon, ReceiptIcon } from "lucide-react"
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
+import { useEffect, useRef, useState } from "react"
+import { toast } from "sonner"
 import _ from "@/lib/translate"
-import { GetStatementDetailsResponse } from "../import_utils"
-import { useMemo } from "react"
+import RawTableGrid from "../RawTableGrid"
+import {
+    applyColumnMappingChange,
+    ColumnMapsTo,
+    GetStatementDetailsResponse,
+    useSetHeaderIndex,
+    useUpdateColumnMapping,
+} from "../import_utils"
 import { BankStatementImportLogColumnMap } from "@/types/Accounts/BankStatementImportLogColumnMap"
 
+type Mapping = Pick<BankStatementImportLogColumnMap, "index" | "maps_to" | "header_text" | "variable">
 
-const CSVRawDataPreview = ({ data }: { data: GetStatementDetailsResponse }) => {
+const toMapping = (columns?: BankStatementImportLogColumnMap[]): Mapping[] =>
+    (columns ?? []).map((c) => ({
+        index: c.index,
+        maps_to: c.maps_to,
+        header_text: c.header_text,
+        variable: c.variable,
+    }))
 
-    const column_mapping: Record<StandardColumnTypes, number> = useMemo(() => {
+const headerToState = (index?: number) => (index != null && index >= 0 ? index : null)
 
-        const col_map: Record<string, number> = {}
+const CSVRawDataPreview = ({
+    data,
+    mutate,
+}: {
+    data: GetStatementDetailsResponse
+    mutate: () => void
+}) => {
+    const isCompleted = data.doc.status === "Completed"
 
-        data.doc.column_mapping?.forEach(col => {
-            if (col.maps_to && col.maps_to !== "Do not import") {
-                col_map[col.maps_to] = col.index;
-            }
-        })
-
-        return col_map
-
-    }, [data])
-
-    const validColumns = Object.values(column_mapping)
-
-    // Reverse the column mapping to get a map of column index to variable name
-    const columnIndexMap: Record<number, StandardColumnTypes> = Object.fromEntries(Object.entries(column_mapping).map(([variable, columnIndex]) => [columnIndex, variable as StandardColumnTypes]))
-
-    // Loop over the contents of the CSV file and show a preview - highlight the header row and the transaction rows
-    return (
-        <Table containerClassName="rounded-none">
-            <TableBody>
-                {data.raw_data.map((row, index) => {
-
-                    const isHeaderRow = index === data.doc.detected_header_index;
-                    const isTransactionRow = index >= (data.doc.detected_transaction_starting_index ?? 0) && index <= (data.doc.detected_transaction_ending_index ?? 0);
-
-                    return <TableRow key={index}
-                        title={isHeaderRow ? "Header Row" : ""}
-                        className={cn({
-                            // "bg-yellow-100": isHeaderRow,
-                            // "hover:bg-yellow-100": isHeaderRow,
-                            "bg-green-50 hover:bg-green-50 dark:bg-green-700 dark:hover:bg-green-700": isTransactionRow,
-                            "text-ink-gray-5/70": !isTransactionRow && !isHeaderRow,
-                        })}>
-                        {isHeaderRow ? <TableHead className="bg-yellow-100 hover:bg-yellow-100 dark:bg-yellow-400 text-center font-semibold text-ink-gray-8">
-                            {index + 1}
-                        </TableHead> :
-                            <TableCell className="text-center px-1 py-0.5">
-                                {index + 1}
-                            </TableCell>
-                        }
-                        {row.map((cell, cellIndex) => {
-
-                            const isValidColumn = validColumns.includes(cellIndex);
-                            const columnType = columnIndexMap[cellIndex];
-                            const isAmountColumn = ["Amount", "Withdrawal", "Deposit", "Balance"].includes(columnType);
-
-                            if (isHeaderRow) {
-                                return <TableHead key={cellIndex} className={cn("max-w-[250px] w-fit overflow-hidden text-ellipsis py-0.5",
-                                    isValidColumn ? "bg-yellow-100 hover:bg-yellow-100 dark:bg-yellow-400" : "bg-surface-gray-2",
-                                )}>
-                                    <div className={cn("flex items-center text-xs gap-1 px-1 text-ink-gray-8 font-medium", {
-                                        "justify-end": isAmountColumn && isValidColumn
-                                    })}>
-                                        {columnType && <Tooltip>
-                                            <TooltipTrigger>
-                                                <ColumnHeaderIcon columnType={columnType} />
-                                            </TooltipTrigger>
-                                            <TooltipContent>
-                                                {_(columnType)}
-                                            </TooltipContent>
-                                        </Tooltip>
-                                        }
-                                        {cell}
-                                    </div>
-                                </TableHead>
-                            } else {
-                                return <TableCell key={cellIndex} className={cn("max-w-[200px] w-fit overflow-hidden text-ellipsis py-0.5",
-                                    {
-                                        "bg-green-100 dark:bg-green-400 hover:bg-green-100 dark:hover:bg-green-400": isValidColumn && isTransactionRow,
-                                        "text-ink-gray-5": !isValidColumn && isTransactionRow,
-                                    }
-                                )} >
-                                    <div className={cn("min-h-5 flex items-center text-xs px-1", {
-                                        "justify-end": isAmountColumn && isValidColumn && isTransactionRow
-                                    })} title={cell}>
-                                        {cell}
-                                    </div>
-                                </TableCell>
-                            }
-                        }
-
-                        )}
-                    </TableRow>
-                })}
-            </TableBody>
-        </Table >
+    const [mapping, setMapping] = useState<Mapping[]>(() => toMapping(data.doc.column_mapping))
+    const [headerIndex, setHeaderIndex] = useState<number | null>(() =>
+        headerToState(data.doc.detected_header_index),
     )
-}
 
-type StandardColumnTypes = BankStatementImportLogColumnMap['maps_to'];
+    const { call: updateMapping, loading: savingMapping } = useUpdateColumnMapping()
+    const { call: setHeader, loading: savingHeader } = useSetHeaderIndex()
 
-const ColumnHeaderIcon = ({ columnType }: { columnType?: StandardColumnTypes }) => {
-    if (!columnType) {
-        return null
+    const mappingRef = useRef(mapping)
+    const saveTimer = useRef<ReturnType<typeof setTimeout>>(undefined)
+
+    useEffect(() => () => clearTimeout(saveTimer.current), [])
+
+    const columnMappingRecord: Record<number, ColumnMapsTo> = {}
+    mapping.forEach((c) => {
+        if (c.maps_to) columnMappingRecord[c.index] = c.maps_to as ColumnMapsTo
+    })
+
+    const commitMapping = (next: Mapping[]) => {
+        mappingRef.current = next
+        setMapping(next)
     }
 
-    if (columnType === 'Amount') {
-        return <DollarSignIcon className="w-4 h-4" />
+    // Persist mapping edits (debounced) so the transaction preview updates in realtime.
+    const scheduleSaveMapping = () => {
+        if (isCompleted) return
+        clearTimeout(saveTimer.current)
+        saveTimer.current = setTimeout(() => {
+            updateMapping({ statement_import_id: data.doc.name, column_mapping: mappingRef.current })
+                .then(() => mutate())
+                .catch(() => toast.error(_("Could not save the column mapping.")))
+        }, 500)
     }
 
-    if (columnType === 'Withdrawal') {
-        return <ArrowUpRightIcon className="w-4 h-4 text-ink-red-3" />
+    const onChangeMapping = (columnIndex: number, mapsTo: ColumnMapsTo) => {
+        if (isCompleted) return
+        commitMapping(applyColumnMappingChange(mappingRef.current, columnIndex, mapsTo))
+        scheduleSaveMapping()
     }
 
-    if (columnType === 'Deposit') {
-        return <ArrowDownRightIcon className="w-4 h-4 text-ink-green-3" />
+    const onSetHeader = (rowIndex: number | null) => {
+        if (isCompleted) return
+        setHeaderIndex(rowIndex)
+        setHeader({ statement_import_id: data.doc.name, header_index: rowIndex ?? -1 })
+            .then((res) => {
+                // The backend re-derives the mapping for the new header; sync local state.
+                const doc = res?.message?.doc
+                if (doc) {
+                    commitMapping(toMapping(doc.column_mapping))
+                    setHeaderIndex(headerToState(doc.detected_header_index))
+                }
+                mutate()
+            })
+            .catch(() => toast.error(_("Could not update the header row.")))
     }
 
-    if (columnType === 'Balance') {
-        return <BanknoteIcon className="w-4 h-4" />
-    }
-
-    if (columnType === 'Date') {
-        return <CalendarIcon className="w-4 h-4" />
-    }
-
-    if (columnType === 'Description') {
-        return <FileTextIcon className="w-4 h-4" />
-    }
-
-    if (columnType === 'Reference') {
-        return <ReceiptIcon className="w-4 h-4" />
-    }
-
-    if (columnType === 'Transaction Type') {
-        return <ListIcon className="w-4 h-4" />
-    }
-
-    if (columnType === 'Debit/Credit') {
-        return <ArrowUpDownIcon className="w-4 h-4" />
-    }
-
-    return null
+    return (
+        <RawTableGrid
+            rows={data.raw_data}
+            columnMapping={columnMappingRecord}
+            headerIndex={headerIndex}
+            editable={!isCompleted}
+            disabled={isCompleted || savingMapping || savingHeader}
+            onChangeMapping={onChangeMapping}
+            onSetHeader={onSetHeader}
+        />
+    )
 }
 
 export default CSVRawDataPreview

--- a/banking/src/components/features/BankStatementImporter/CSV/StatementDetails.tsx
+++ b/banking/src/components/features/BankStatementImporter/CSV/StatementDetails.tsx
@@ -142,9 +142,14 @@ const StatementDetails = ({ data }: Props) => {
                             <TableCell>
                                 <div className='flex items-center gap-2'>
                                     <BankLogo bank={bank} />
-                                    <span className="tracking-tight text-sm font-medium">{bank?.account_name}</span>
-                                    <span title="GL Account" className="text-sm">{bank?.account}</span>
+                                    <span className="text-sm">{bank?.account_name}</span>
                                 </div>
+                            </TableCell>
+                        </TableRow>
+                        <TableRow>
+                            <TableHead>{_("Account")}</TableHead>
+                            <TableCell>
+                                <span title="GL Account" className="text-sm">{bank?.account}</span>
                             </TableCell>
                         </TableRow>
                         <TableRow>
@@ -158,7 +163,11 @@ const StatementDetails = ({ data }: Props) => {
                         </TableRow>
                         <TableRow>
                             <TableHead>{_("Transaction Dates")}</TableHead>
-                            <TableCell>{_("{0} to {1}", [formatDate(data.doc.start_date, "Do MMMM YYYY"), formatDate(data.doc.end_date, "Do MMMM YYYY")])}</TableCell>
+                            {data.doc.start_date && data.doc.end_date ? (
+                                <TableCell>{_("{0} to {1}", [formatDate(data.doc.start_date, "Do MMMM YYYY"), formatDate(data.doc.end_date, "Do MMMM YYYY")])}</TableCell>
+                            ) : (
+                                <TableCell>-</TableCell>
+                            )}
                         </TableRow>
                         <TableRow>
                             <TableHead>{_("Number of Transactions")}</TableHead>

--- a/banking/src/components/features/BankStatementImporter/PDF/BBoxOverlay.tsx
+++ b/banking/src/components/features/BankStatementImporter/PDF/BBoxOverlay.tsx
@@ -1,0 +1,129 @@
+import { RefObject, useEffect, useRef, useState } from 'react'
+import { cn } from '@/lib/utils'
+
+type Bbox = [number, number, number, number]
+
+const MIN_SIZE = 8 // PDF points
+
+// Keep the box valid: normalise flipped edges, enforce a min size, clamp to the page.
+const clampBbox = (bbox: Bbox, pageWidth: number, pageHeight: number): Bbox => {
+    let [x0, top, x1, bottom] = bbox
+    if (x1 < x0) [x0, x1] = [x1, x0]
+    if (bottom < top) [top, bottom] = [bottom, top]
+    x0 = Math.max(0, Math.min(x0, pageWidth - MIN_SIZE))
+    top = Math.max(0, Math.min(top, pageHeight - MIN_SIZE))
+    x1 = Math.min(pageWidth, Math.max(x1, x0 + MIN_SIZE))
+    bottom = Math.min(pageHeight, Math.max(bottom, top + MIN_SIZE))
+    return [x0, top, x1, bottom]
+}
+
+const HANDLES = [
+    { id: 'nw', className: 'left-0 top-0 -translate-x-1/2 -translate-y-1/2 cursor-nwse-resize' },
+    { id: 'ne', className: 'right-0 top-0 translate-x-1/2 -translate-y-1/2 cursor-nesw-resize' },
+    { id: 'sw', className: 'left-0 bottom-0 -translate-x-1/2 translate-y-1/2 cursor-nesw-resize' },
+    { id: 'se', className: 'right-0 bottom-0 translate-x-1/2 translate-y-1/2 cursor-nwse-resize' },
+]
+
+type Props = {
+    bbox: Bbox
+    pageWidth: number
+    pageHeight: number
+    color: { border: string; bg: string; swatch: string }
+    label: string
+    included: boolean
+    disabled?: boolean
+    containerRef: RefObject<HTMLDivElement | null>
+    onCommit: (bbox: Bbox) => void
+}
+
+/** A draggable + corner-resizable rectangle over a rendered PDF page. Coordinates are in PDF
+ *  points (top-left origin); pixel deltas are converted using the container's rendered size. */
+const BBoxOverlay = ({ bbox, pageWidth, pageHeight, color, label, included, disabled, containerRef, onCommit }: Props) => {
+    const [draft, setDraft] = useState<Bbox>(bbox)
+    const draftRef = useRef<Bbox>(bbox)
+    const drag = useRef<{ mode: string; startX: number; startY: number; start: Bbox } | null>(null)
+
+    // Reset to the authoritative bbox whenever it changes (e.g. after a server re-extract).
+    useEffect(() => {
+        setDraft(bbox)
+        draftRef.current = bbox
+    }, [bbox])
+
+    const apply = (next: Bbox) => {
+        draftRef.current = next
+        setDraft(next)
+    }
+
+    const onPointerDown = (e: React.PointerEvent) => {
+        if (disabled) return
+        e.preventDefault()
+        e.stopPropagation()
+        const mode = (e.target as HTMLElement).dataset.handle ?? 'move'
+        ;(e.currentTarget as HTMLElement).setPointerCapture(e.pointerId)
+        drag.current = { mode, startX: e.clientX, startY: e.clientY, start: draftRef.current }
+    }
+
+    const onPointerMove = (e: React.PointerEvent) => {
+        if (!drag.current || !containerRef.current) return
+        const rect = containerRef.current.getBoundingClientRect()
+        const dx = ((e.clientX - drag.current.startX) / rect.width) * pageWidth
+        const dy = ((e.clientY - drag.current.startY) / rect.height) * pageHeight
+        let [x0, top, x1, bottom] = drag.current.start
+        const m = drag.current.mode
+        if (m === 'move') {
+            x0 += dx
+            x1 += dx
+            top += dy
+            bottom += dy
+        } else {
+            if (m.includes('w')) x0 += dx
+            if (m.includes('e')) x1 += dx
+            if (m.includes('n')) top += dy
+            if (m.includes('s')) bottom += dy
+        }
+        apply(clampBbox([x0, top, x1, bottom], pageWidth, pageHeight))
+    }
+
+    const onPointerUp = (e: React.PointerEvent) => {
+        if (!drag.current) return
+        ;(e.currentTarget as HTMLElement).releasePointerCapture(e.pointerId)
+        drag.current = null
+        onCommit(draftRef.current)
+    }
+
+    const [x0, top, x1, bottom] = draft
+
+    return (
+        <div
+            className={cn(
+                'absolute touch-none border-2',
+                color.border,
+                included ? color.bg : 'opacity-40',
+                disabled ? 'pointer-events-none' : 'cursor-move',
+            )}
+            style={{
+                left: `${(x0 / pageWidth) * 100}%`,
+                top: `${(top / pageHeight) * 100}%`,
+                width: `${((x1 - x0) / pageWidth) * 100}%`,
+                height: `${((bottom - top) / pageHeight) * 100}%`,
+            }}
+            onPointerDown={onPointerDown}
+            onPointerMove={onPointerMove}
+            onPointerUp={onPointerUp}
+        >
+            <span className={cn('pointer-events-none absolute -top-5 left-0 rounded px-1 text-[10px] font-medium text-white', color.swatch)}>
+                {label}
+            </span>
+            {!disabled &&
+                HANDLES.map((handle) => (
+                    <span
+                        key={handle.id}
+                        data-handle={handle.id}
+                        className={cn('absolute size-2.5 rounded-sm border border-white', color.swatch, handle.className)}
+                    />
+                ))}
+        </div>
+    )
+}
+
+export default BBoxOverlay

--- a/banking/src/components/features/BankStatementImporter/PDF/PDFImport.tsx
+++ b/banking/src/components/features/BankStatementImporter/PDF/PDFImport.tsx
@@ -1,0 +1,23 @@
+import StatementDetails from '../CSV/StatementDetails'
+import PDFTableEditor from './PDFTableEditor'
+import { GetStatementDetailsResponse } from '../import_utils'
+
+type Props = {
+    data: { message: GetStatementDetailsResponse }
+    mutate: () => void
+}
+
+const PDFImport = ({ data, mutate }: Props) => {
+    return (
+        <div className="w-full flex">
+            <div className="w-[45%] p-4 h-[calc(100vh-72px)] overflow-scroll">
+                <StatementDetails data={data.message} />
+            </div>
+            <div className="w-[55%] border-s pe-1 ps-0 border-outline-gray-2 h-[calc(100vh-72px)] overflow-scroll">
+                <PDFTableEditor data={data.message} mutate={mutate} />
+            </div>
+        </div>
+    )
+}
+
+export default PDFImport

--- a/banking/src/components/features/BankStatementImporter/PDF/PDFTableEditor.tsx
+++ b/banking/src/components/features/BankStatementImporter/PDF/PDFTableEditor.tsx
@@ -1,0 +1,372 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { toast } from 'sonner'
+import { ChevronDownIcon, ChevronLeftIcon, ChevronRightIcon, FileTextIcon, Loader2Icon, TableIcon } from 'lucide-react'
+import _ from '@/lib/translate'
+import { cn } from '@/lib/utils'
+import { Button } from '@/components/ui/button'
+import { Switch } from '@/components/ui/switch'
+import { Label } from '@/components/ui/label'
+import { H3, Paragraph } from '@/components/ui/typography'
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import ErrorBanner from '@/components/ui/error-banner'
+import RawTableGrid from '../RawTableGrid'
+import BBoxOverlay from './BBoxOverlay'
+import {
+    ColumnMapsTo,
+    GetStatementDetailsResponse,
+    PDFTable,
+    useReextractPDFTable,
+    useSetPDFTableHeader,
+    useUpdatePDFTables,
+} from '../import_utils'
+
+type Props = {
+    data: GetStatementDetailsResponse
+    mutate: () => void
+}
+
+// Distinct overlay colours per table on a page.
+const OVERLAY_COLORS = [
+    { border: 'border-blue-500', bg: 'bg-blue-500/10', swatch: 'bg-blue-500' },
+    { border: 'border-purple-500', bg: 'bg-purple-500/10', swatch: 'bg-purple-500' },
+    { border: 'border-amber-500', bg: 'bg-amber-500/10', swatch: 'bg-amber-500' },
+    { border: 'border-teal-500', bg: 'bg-teal-500/10', swatch: 'bg-teal-500' },
+]
+
+const columnMappingRecord = (table: PDFTable): Record<number, ColumnMapsTo> => {
+    const map: Record<number, ColumnMapsTo> = {}
+    table.column_mapping?.forEach((col) => {
+        map[col.index] = col.maps_to
+    })
+    return map
+}
+
+const PDFTableEditor = ({ data, mutate }: Props) => {
+    const isCompleted = data.doc.status === 'Completed'
+
+    const [tables, setTables] = useState<PDFTable[]>(() => data.pdf_tables ?? [])
+    const [viewMode, setViewMode] = useState<'pdf' | 'table'>('pdf')
+    const [pageIndex, setPageIndex] = useState(0)
+    const [collapsed, setCollapsed] = useState<Set<number>>(new Set())
+
+    const toggleCollapsed = (tableIndex: number) =>
+        setCollapsed((prev) => {
+            const next = new Set(prev)
+            if (next.has(tableIndex)) {
+                next.delete(tableIndex)
+            } else {
+                next.add(tableIndex)
+            }
+            return next
+        })
+
+    const { call, loading, error } = useUpdatePDFTables()
+    const { call: reextract, loading: reextracting } = useReextractPDFTable()
+    const { call: setHeaderCall, loading: settingHeader } = useSetPDFTableHeader()
+    const busy = loading || reextracting || settingHeader
+
+    // Persist edits automatically (debounced) so the transaction preview updates in realtime.
+    const tablesRef = useRef(tables)
+    const saveTimer = useRef<ReturnType<typeof setTimeout>>(undefined)
+    const reextractTimer = useRef<ReturnType<typeof setTimeout>>(undefined)
+
+    const scheduleSave = () => {
+        if (isCompleted) return
+        clearTimeout(saveTimer.current)
+        saveTimer.current = setTimeout(() => {
+            call({ statement_import_id: data.doc.name, tables: tablesRef.current })
+                .then(() => mutate())
+                .catch(() => toast.error(_('Could not save the table settings.')))
+        }, 500)
+    }
+
+    // After a bbox change, re-extract that table's rows from the new region (debounced).
+    // The target is read inside the timeout so it always reflects the committed bbox.
+    const scheduleReextract = (tableIndex: number) => {
+        if (isCompleted) return
+        clearTimeout(reextractTimer.current)
+        reextractTimer.current = setTimeout(() => {
+            const target = tablesRef.current[tableIndex]
+            reextract({
+                statement_import_id: data.doc.name,
+                page: target.page,
+                table_index: target.table_index,
+                bbox: target.bbox,
+            })
+                .then((res) => {
+                    commitTables(res?.message?.pdf_tables ?? [])
+                    mutate()
+                })
+                .catch(() => toast.error(_('Could not re-extract the table.')))
+        }, 500)
+    }
+
+    useEffect(() => () => {
+        clearTimeout(saveTimer.current)
+        clearTimeout(reextractTimer.current)
+    }, [])
+
+    const pages = useMemo(() => Array.from(new Set(tables.map((t) => t.page))).sort((a, b) => a - b), [tables])
+    const currentPage = pages[pageIndex]
+    // Keep the table's position in the flat array so edits target the right one.
+    const pageTables = useMemo(
+        () => tables.map((table, index) => ({ table, index })).filter((t) => t.table.page === currentPage),
+        [tables, currentPage],
+    )
+
+    // Keep tablesRef in sync synchronously so the debounced save/re-extract never read stale state.
+    const commitTables = (next: PDFTable[]) => {
+        tablesRef.current = next
+        setTables(next)
+    }
+
+    const updateTable = (tableIndex: number, updater: (table: PDFTable) => PDFTable) => {
+        commitTables(tablesRef.current.map((t, i) => (i === tableIndex ? updater(t) : t)))
+        scheduleSave()
+    }
+
+    const onChangeMapping = (tableIndex: number, columnIndex: number, mapsTo: ColumnMapsTo) => {
+        updateTable(tableIndex, (table) => {
+            const previous = table.column_mapping.find((c) => c.index === columnIndex)
+            return {
+                ...table,
+                column_mapping: [
+                    ...table.column_mapping.filter((c) => c.index !== columnIndex),
+                    {
+                        index: columnIndex,
+                        header_text: previous?.header_text ?? '',
+                        variable: previous?.variable ?? `column_${columnIndex}`,
+                        maps_to: mapsTo,
+                    },
+                ].sort((a, b) => a.index - b.index),
+            }
+        })
+    }
+
+    const onToggleIncluded = (tableIndex: number, included: boolean) =>
+        updateTable(tableIndex, (table) => ({ ...table, included }))
+
+    const onBboxCommit = (tableIndex: number, bbox: [number, number, number, number]) => {
+        commitTables(tablesRef.current.map((t, i) => (i === tableIndex ? { ...t, bbox } : t)))
+        scheduleReextract(tableIndex)
+    }
+
+    // Set/clear the header row of a table; the backend re-derives the column mapping.
+    const onSetHeader = (tableIndex: number, headerIndex: number | null) => {
+        commitTables(tablesRef.current.map((t, i) => (i === tableIndex ? { ...t, header_index: headerIndex } : t)))
+        const target = tablesRef.current[tableIndex]
+        setHeaderCall({
+            statement_import_id: data.doc.name,
+            page: target.page,
+            table_index: target.table_index,
+            header_index: headerIndex ?? -1,
+        })
+            .then((res) => {
+                commitTables(res?.message?.pdf_tables ?? [])
+                mutate()
+            })
+            .catch(() => toast.error(_('Could not update the header row.')))
+    }
+
+    if (tables.length === 0) {
+        return (
+            <div className="p-4">
+                <Paragraph className="text-p-sm text-ink-gray-5">
+                    {_('No tables were extracted from this PDF.')}
+                </Paragraph>
+            </div>
+        )
+    }
+
+    return (
+        <div className="flex flex-col gap-3 p-4">
+            <div className="flex flex-col gap-1">
+                <H3 className="text-base border-0 p-0">{_('Detected Tables')}</H3>
+                <Paragraph className="text-p-sm">
+                    {_('Review each page. In the Table view, map each column, click a row number to set/clear the header row, and exclude anything that is not transactions (ads, summaries).')}
+                </Paragraph>
+            </div>
+
+            {error && <ErrorBanner error={error} />}
+
+            <div className="flex items-center justify-between gap-2">
+                <Tabs value={viewMode} onValueChange={(v) => setViewMode(v as 'pdf' | 'table')}>
+                    <TabsList variant="subtle">
+                        <TabsTrigger value="pdf"><FileTextIcon />{_('PDF')}</TabsTrigger>
+                        <TabsTrigger value="table"><TableIcon />{_('Table')}</TabsTrigger>
+                    </TabsList>
+                </Tabs>
+
+                <div className="flex items-center gap-1">
+                    {busy && (
+                        <span className="flex items-center gap-1 pe-1 text-xs text-ink-gray-5">
+                            <Loader2Icon className="size-3 animate-spin" />
+                            {reextracting ? _('Re-extracting') : _('Saving')}
+                        </span>
+                    )}
+                    <Button
+                        variant="ghost"
+                        isIconButton
+                        disabled={pageIndex === 0}
+                        onClick={() => setPageIndex((i) => Math.max(0, i - 1))}
+                    >
+                        <ChevronLeftIcon />
+                    </Button>
+                    <span className="min-w-24 text-center text-sm text-ink-gray-7">
+                        {_('Page {0} of {1}', [currentPage.toString(), pages.length.toString()])}
+                    </span>
+                    <Button
+                        variant="ghost"
+                        isIconButton
+                        disabled={pageIndex >= pages.length - 1}
+                        onClick={() => setPageIndex((i) => Math.min(pages.length - 1, i + 1))}
+                    >
+                        <ChevronRightIcon />
+                    </Button>
+                </div>
+            </div>
+
+            {viewMode === 'pdf' ? (
+                <PageView
+                    pageTables={pageTables}
+                    disabled={isCompleted}
+                    onToggleIncluded={onToggleIncluded}
+                    onBboxCommit={onBboxCommit}
+                />
+            ) : (
+                <div className="flex flex-col gap-4">
+                    {pageTables.map(({ table, index }, position) => {
+                        const isCollapsed = collapsed.has(index)
+                        return (
+                            <div
+                                key={index}
+                                className={cn('flex flex-col rounded border border-outline-gray-2', !table.included && 'opacity-60')}
+                            >
+                                <div className="flex items-center justify-between p-2">
+                                    <span className="ps-1 text-sm font-medium text-ink-gray-8">
+                                        {_('Table {0}', [(position + 1).toString()])}
+                                    </span>
+                                    <div className="flex items-center gap-2">
+                                        <IncludeToggle
+                                            id={`tbl-${index}`}
+                                            checked={table.included}
+                                            disabled={isCompleted}
+                                            onCheckedChange={(c) => onToggleIncluded(index, c)}
+                                        />
+                                        <Button variant="ghost" size="sm" isIconButton onClick={() => toggleCollapsed(index)}>
+                                            <ChevronDownIcon className={cn('transition-transform', isCollapsed && '-rotate-90')} />
+                                        </Button>
+                                    </div>
+                                </div>
+                                {!isCollapsed && (
+                                    <div className="overflow-auto border-t border-outline-gray-2">
+                                        <RawTableGrid
+                                            rows={table.rows}
+                                            columnMapping={columnMappingRecord(table)}
+                                            headerIndex={table.header_index}
+                                            editable
+                                            disabled={isCompleted}
+                                            onChangeMapping={(columnIndex, mapsTo) => onChangeMapping(index, columnIndex, mapsTo)}
+                                            onSetHeader={(rowIndex) => onSetHeader(index, rowIndex)}
+                                        />
+                                    </div>
+                                )}
+                            </div>
+                        )
+                    })}
+                </div>
+            )}
+        </div>
+    )
+}
+
+type PageViewProps = {
+    pageTables: { table: PDFTable; index: number }[]
+    disabled: boolean
+    onToggleIncluded: (tableIndex: number, included: boolean) => void
+    onBboxCommit: (tableIndex: number, bbox: [number, number, number, number]) => void
+}
+
+const PageView = ({ pageTables, disabled, onToggleIncluded, onBboxCommit }: PageViewProps) => {
+    const containerRef = useRef<HTMLDivElement>(null)
+    const pageImage = pageTables[0]?.table.page_image
+    const pageWidth = pageTables[0]?.table.page_width ?? 1
+    const pageHeight = pageTables[0]?.table.page_height ?? 1
+
+    if (!pageImage) {
+        return (
+            <Paragraph className="text-p-sm text-ink-gray-5">
+                {_('No page image is available for this page.')}
+            </Paragraph>
+        )
+    }
+
+    return (
+        <div className="flex flex-col gap-3">
+            {!disabled && (
+                <Paragraph className="text-xs text-ink-gray-5">
+                    {_('Drag a box to move it, or drag a corner to resize. The table is re-read from the new region automatically.')}
+                </Paragraph>
+            )}
+            <div ref={containerRef} className="relative w-full overflow-auto rounded border border-outline-gray-2 bg-surface-gray-1">
+                <img src={pageImage} alt={_('Page preview')} className="w-full" />
+                {pageTables.map(({ table, index }, position) => {
+                    const color = OVERLAY_COLORS[position % OVERLAY_COLORS.length]
+                    return (
+                        <BBoxOverlay
+                            key={index}
+                            bbox={table.bbox}
+                            pageWidth={pageWidth}
+                            pageHeight={pageHeight}
+                            color={color}
+                            label={_('Table {0}', [(position + 1).toString()])}
+                            included={table.included}
+                            disabled={disabled}
+                            containerRef={containerRef}
+                            onCommit={(bbox) => onBboxCommit(index, bbox)}
+                        />
+                    )
+                })}
+            </div>
+
+            <div className="flex flex-col gap-1.5">
+                {pageTables.map(({ table, index }, position) => {
+                    const color = OVERLAY_COLORS[position % OVERLAY_COLORS.length]
+                    return (
+                        <div key={index} className="flex items-center justify-between rounded border border-outline-gray-2 px-2 py-1.5">
+                            <div className="flex items-center gap-2">
+                                <span className={cn('size-3 rounded-sm', color.swatch)} />
+                                <span className="text-xs">{_('Table {0}', [(position + 1).toString()])}</span>
+                            </div>
+                            <IncludeToggle
+                                id={`pdf-tbl-${index}`}
+                                checked={table.included}
+                                disabled={disabled}
+                                onCheckedChange={(c) => onToggleIncluded(index, c)}
+                            />
+                        </div>
+                    )
+                })}
+            </div>
+        </div>
+    )
+}
+
+const IncludeToggle = ({
+    id,
+    checked,
+    disabled,
+    onCheckedChange,
+}: {
+    id: string
+    checked: boolean
+    disabled: boolean
+    onCheckedChange: (checked: boolean) => void
+}) => (
+    <div className="flex items-center gap-2">
+        <Label htmlFor={id} className="text-xs text-ink-gray-6">{_('Include')}</Label>
+        <Switch id={id} checked={checked} disabled={disabled} onCheckedChange={onCheckedChange} />
+    </div>
+)
+
+export default PDFTableEditor

--- a/banking/src/components/features/BankStatementImporter/PDF/PDFTableEditor.tsx
+++ b/banking/src/components/features/BankStatementImporter/PDF/PDFTableEditor.tsx
@@ -12,6 +12,7 @@ import ErrorBanner from '@/components/ui/error-banner'
 import RawTableGrid from '../RawTableGrid'
 import BBoxOverlay from './BBoxOverlay'
 import {
+    applyColumnMappingChange,
     ColumnMapsTo,
     GetStatementDetailsResponse,
     PDFTable,
@@ -126,21 +127,10 @@ const PDFTableEditor = ({ data, mutate }: Props) => {
     }
 
     const onChangeMapping = (tableIndex: number, columnIndex: number, mapsTo: ColumnMapsTo) => {
-        updateTable(tableIndex, (table) => {
-            const previous = table.column_mapping.find((c) => c.index === columnIndex)
-            return {
-                ...table,
-                column_mapping: [
-                    ...table.column_mapping.filter((c) => c.index !== columnIndex),
-                    {
-                        index: columnIndex,
-                        header_text: previous?.header_text ?? '',
-                        variable: previous?.variable ?? `column_${columnIndex}`,
-                        maps_to: mapsTo,
-                    },
-                ].sort((a, b) => a.index - b.index),
-            }
-        })
+        updateTable(tableIndex, (table) => ({
+            ...table,
+            column_mapping: applyColumnMappingChange(table.column_mapping, columnIndex, mapsTo),
+        }))
     }
 
     const onToggleIncluded = (tableIndex: number, included: boolean) =>

--- a/banking/src/components/features/BankStatementImporter/RawTableGrid.tsx
+++ b/banking/src/components/features/BankStatementImporter/RawTableGrid.tsx
@@ -33,23 +33,24 @@ type Props = {
 }
 
 /**
- * A read-only-ish preview of extracted rows with the same colour coding as the CSV importer:
- * the header row is highlighted, detected transaction rows are green, and mapped columns are
- * emphasised. When `editable` is set, a row of column -> field dropdowns is shown on top.
+ * A preview of extracted rows with CSV-style colour coding: the header row is highlighted,
+ * detected transaction rows are green, and mapped columns are emphasised. When `editable`, a
+ * compact row of column -> field dropdowns sits at the top, and row numbers can be clicked to
+ * set/clear the header row.
  */
 const RawTableGrid = ({ rows, columnMapping, headerIndex, editable, disabled, onChangeMapping, onSetHeader }: Props) => {
-    const numColumns = useMemo(() => rows.reduce((max, row) => Math.max(max, row.length), 0), [rows])
+    // Tabular (XLSX) cells can be numbers/dates, not strings - coerce so .trim()/render are safe.
+    const stringRows = useMemo(
+        () => rows.map((row) => row.map((cell) => (cell == null ? '' : String(cell)))),
+        [rows],
+    )
+    const numColumns = useMemo(() => stringRows.reduce((max, row) => Math.max(max, row.length), 0), [stringRows])
 
     const validColumns = useMemo(
         () => Object.entries(columnMapping).filter(([, m]) => m && m !== 'Do not import').map(([i]) => Number(i)),
         [columnMapping],
     )
-
-    const dateColumn = useMemo(
-        () => Object.entries(columnMapping).find(([, m]) => m === 'Date')?.[0],
-        [columnMapping],
-    )
-
+    const dateColumn = useMemo(() => Object.entries(columnMapping).find(([, m]) => m === 'Date')?.[0], [columnMapping])
     const amountColumns = useMemo(
         () => Object.entries(columnMapping).filter(([, m]) => ['Amount', 'Withdrawal', 'Deposit'].includes(m)).map(([i]) => Number(i)),
         [columnMapping],
@@ -60,21 +61,20 @@ const RawTableGrid = ({ rows, columnMapping, headerIndex, editable, disabled, on
         const set = new Set<number>()
         if (dateColumn === undefined) return set
         const dateIdx = Number(dateColumn)
-        rows.forEach((row, index) => {
+        stringRows.forEach((row, index) => {
             if (index === headerIndex) return
             const dateCell = (row[dateIdx] ?? '').trim()
             if (!dateCell || !DATE_LIKE.test(dateCell)) return
-            const hasAmount = amountColumns.some((c) => (row[c] ?? '').trim() !== '')
-            if (hasAmount) set.add(index)
+            if (amountColumns.some((c) => (row[c] ?? '').trim() !== '')) set.add(index)
         })
         return set
-    }, [rows, headerIndex, dateColumn, amountColumns])
+    }, [stringRows, headerIndex, dateColumn, amountColumns])
 
     return (
         <Table containerClassName="rounded-none">
             <TableBody>
                 {editable && (
-                    <TableRow className="bg-surface-gray-1 hover:bg-surface-gray-1">
+                    <TableRow className="border-b border-outline-gray-2 bg-surface-white hover:bg-surface-white">
                         <TableHead className="w-8 p-1" />
                         {Array.from({ length: numColumns }).map((_unused, columnIndex) => (
                             <TableHead key={columnIndex} className="p-1 align-top">
@@ -83,13 +83,16 @@ const RawTableGrid = ({ rows, columnMapping, headerIndex, editable, disabled, on
                                     value={columnMapping[columnIndex] ?? 'Do not import'}
                                     onValueChange={(value) => onChangeMapping?.(columnIndex, value as ColumnMapsTo)}
                                 >
-                                    <SelectTrigger inputSize="sm">
+                                    <SelectTrigger variant="outline" inputSize="sm" className="h-7 w-full">
                                         <SelectValue />
                                     </SelectTrigger>
                                     <SelectContent>
                                         {COLUMN_MAPS_TO_OPTIONS.map((option) => (
                                             <SelectItem key={option} value={option}>
-                                                {_(option)}
+                                                <span className="flex items-center gap-1.5">
+                                                    <ColumnHeaderIcon columnType={option} />
+                                                    {_(option)}
+                                                </span>
                                             </SelectItem>
                                         ))}
                                     </SelectContent>
@@ -99,7 +102,7 @@ const RawTableGrid = ({ rows, columnMapping, headerIndex, editable, disabled, on
                     </TableRow>
                 )}
 
-                {rows.map((row, index) => {
+                {stringRows.map((row, index) => {
                     const isHeaderRow = index === headerIndex
                     const isTransactionRow = transactionRows.has(index)
 
@@ -138,10 +141,31 @@ const RawTableGrid = ({ rows, columnMapping, headerIndex, editable, disabled, on
                             ) : (
                                 <TableCell className="w-8 px-1 py-0.5 text-center text-ink-gray-6">{index + 1}</TableCell>
                             )}
+
                             {Array.from({ length: numColumns }).map((_unused, cellIndex) => {
-                                const isValidColumn = validColumns.includes(cellIndex)
                                 const columnType = columnMapping[cellIndex]
+                                const isValidColumn = validColumns.includes(cellIndex)
                                 const isAmountColumn = AMOUNT_COLUMNS.includes(columnType)
+                                const cellText = row[cellIndex] ?? ''
+
+                                // Read-only header row: icon + label.
+                                if (isHeaderRow) {
+                                    return (
+                                        <TableCell key={cellIndex} className="max-w-[200px] overflow-hidden text-ellipsis py-1">
+                                            <div className="flex items-center gap-1 px-1 text-xs font-medium text-ink-gray-8">
+                                                {columnType && (
+                                                    <Tooltip>
+                                                        <TooltipTrigger>
+                                                            <ColumnHeaderIcon columnType={columnType} />
+                                                        </TooltipTrigger>
+                                                        <TooltipContent>{_(columnType)}</TooltipContent>
+                                                    </Tooltip>
+                                                )}
+                                                {cellText}
+                                            </div>
+                                        </TableCell>
+                                    )
+                                }
 
                                 return (
                                     <TableCell
@@ -152,21 +176,12 @@ const RawTableGrid = ({ rows, columnMapping, headerIndex, editable, disabled, on
                                         })}
                                     >
                                         <div
-                                            className={cn('min-h-5 flex items-center gap-1 px-1 text-xs', {
+                                            className={cn('min-h-5 flex items-center px-1 text-xs', {
                                                 'justify-end': isAmountColumn && isValidColumn && isTransactionRow,
-                                                'font-medium text-ink-gray-8': isHeaderRow,
                                             })}
-                                            title={row[cellIndex] ?? ''}
+                                            title={cellText}
                                         >
-                                            {isHeaderRow && columnType && (
-                                                <Tooltip>
-                                                    <TooltipTrigger>
-                                                        <ColumnHeaderIcon columnType={columnType} />
-                                                    </TooltipTrigger>
-                                                    <TooltipContent>{_(columnType)}</TooltipContent>
-                                                </Tooltip>
-                                            )}
-                                            {row[cellIndex] ?? ''}
+                                            {cellText}
                                         </div>
                                     </TableCell>
                                 )

--- a/banking/src/components/features/BankStatementImporter/RawTableGrid.tsx
+++ b/banking/src/components/features/BankStatementImporter/RawTableGrid.tsx
@@ -1,0 +1,207 @@
+import { useMemo } from 'react'
+import {
+    ArrowDownRightIcon,
+    ArrowUpDownIcon,
+    ArrowUpRightIcon,
+    BanknoteIcon,
+    CalendarIcon,
+    DollarSignIcon,
+    FileTextIcon,
+    ListIcon,
+    ReceiptIcon,
+} from 'lucide-react'
+import _ from '@/lib/translate'
+import { cn } from '@/lib/utils'
+import { Table, TableBody, TableCell, TableHead, TableRow } from '@/components/ui/table'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { COLUMN_MAPS_TO_OPTIONS, ColumnMapsTo } from './import_utils'
+
+const AMOUNT_COLUMNS: ColumnMapsTo[] = ['Amount', 'Withdrawal', 'Deposit', 'Balance']
+const DATE_LIKE = /\d{1,4}[/\-.\s]\d{1,2}[/\-.\s]\d{1,4}|\d{1,2}[\s-][a-z]{3}/i
+
+type Props = {
+    rows: string[][]
+    /** Column index -> mapped field */
+    columnMapping: Record<number, ColumnMapsTo>
+    headerIndex: number | null
+    editable?: boolean
+    disabled?: boolean
+    onChangeMapping?: (columnIndex: number, mapsTo: ColumnMapsTo) => void
+    /** Set the header row (or null to mark the table as having no header). */
+    onSetHeader?: (rowIndex: number | null) => void
+}
+
+/**
+ * A read-only-ish preview of extracted rows with the same colour coding as the CSV importer:
+ * the header row is highlighted, detected transaction rows are green, and mapped columns are
+ * emphasised. When `editable` is set, a row of column -> field dropdowns is shown on top.
+ */
+const RawTableGrid = ({ rows, columnMapping, headerIndex, editable, disabled, onChangeMapping, onSetHeader }: Props) => {
+    const numColumns = useMemo(() => rows.reduce((max, row) => Math.max(max, row.length), 0), [rows])
+
+    const validColumns = useMemo(
+        () => Object.entries(columnMapping).filter(([, m]) => m && m !== 'Do not import').map(([i]) => Number(i)),
+        [columnMapping],
+    )
+
+    const dateColumn = useMemo(
+        () => Object.entries(columnMapping).find(([, m]) => m === 'Date')?.[0],
+        [columnMapping],
+    )
+
+    const amountColumns = useMemo(
+        () => Object.entries(columnMapping).filter(([, m]) => ['Amount', 'Withdrawal', 'Deposit'].includes(m)).map(([i]) => Number(i)),
+        [columnMapping],
+    )
+
+    // Approximate the backend's transaction-row detection so the highlighting tracks edits live.
+    const transactionRows = useMemo(() => {
+        const set = new Set<number>()
+        if (dateColumn === undefined) return set
+        const dateIdx = Number(dateColumn)
+        rows.forEach((row, index) => {
+            if (index === headerIndex) return
+            const dateCell = (row[dateIdx] ?? '').trim()
+            if (!dateCell || !DATE_LIKE.test(dateCell)) return
+            const hasAmount = amountColumns.some((c) => (row[c] ?? '').trim() !== '')
+            if (hasAmount) set.add(index)
+        })
+        return set
+    }, [rows, headerIndex, dateColumn, amountColumns])
+
+    return (
+        <Table containerClassName="rounded-none">
+            <TableBody>
+                {editable && (
+                    <TableRow className="bg-surface-gray-1 hover:bg-surface-gray-1">
+                        <TableHead className="w-8 p-1" />
+                        {Array.from({ length: numColumns }).map((_unused, columnIndex) => (
+                            <TableHead key={columnIndex} className="p-1 align-top">
+                                <Select
+                                    disabled={disabled}
+                                    value={columnMapping[columnIndex] ?? 'Do not import'}
+                                    onValueChange={(value) => onChangeMapping?.(columnIndex, value as ColumnMapsTo)}
+                                >
+                                    <SelectTrigger inputSize="sm">
+                                        <SelectValue />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                        {COLUMN_MAPS_TO_OPTIONS.map((option) => (
+                                            <SelectItem key={option} value={option}>
+                                                {_(option)}
+                                            </SelectItem>
+                                        ))}
+                                    </SelectContent>
+                                </Select>
+                            </TableHead>
+                        ))}
+                    </TableRow>
+                )}
+
+                {rows.map((row, index) => {
+                    const isHeaderRow = index === headerIndex
+                    const isTransactionRow = transactionRows.has(index)
+
+                    return (
+                        <TableRow
+                            key={index}
+                            className={cn({
+                                'bg-green-50 hover:bg-green-50 dark:bg-green-700 dark:hover:bg-green-700': isTransactionRow,
+                                'bg-yellow-100 hover:bg-yellow-100 dark:bg-yellow-400': isHeaderRow,
+                                'text-ink-gray-5/70': !isTransactionRow && !isHeaderRow,
+                            })}
+                        >
+                            {editable && onSetHeader ? (
+                                <TableCell className="h-px w-8 p-0 text-center">
+                                    <Tooltip>
+                                        <TooltipTrigger asChild>
+                                            <button
+                                                type="button"
+                                                disabled={disabled}
+                                                onClick={() => onSetHeader(isHeaderRow ? null : index)}
+                                                className={cn(
+                                                    'flex h-full w-full items-center justify-center px-1 text-ink-gray-6 hover:bg-surface-gray-3',
+                                                    isHeaderRow && 'font-semibold text-ink-gray-8',
+                                                )}
+                                            >
+                                                {index + 1}
+                                            </button>
+                                        </TooltipTrigger>
+                                        <TooltipContent>
+                                            {isHeaderRow
+                                                ? _('This is the header row. Click to mark the table as having no header.')
+                                                : _('Click to set this as the header row.')}
+                                        </TooltipContent>
+                                    </Tooltip>
+                                </TableCell>
+                            ) : (
+                                <TableCell className="w-8 px-1 py-0.5 text-center text-ink-gray-6">{index + 1}</TableCell>
+                            )}
+                            {Array.from({ length: numColumns }).map((_unused, cellIndex) => {
+                                const isValidColumn = validColumns.includes(cellIndex)
+                                const columnType = columnMapping[cellIndex]
+                                const isAmountColumn = AMOUNT_COLUMNS.includes(columnType)
+
+                                return (
+                                    <TableCell
+                                        key={cellIndex}
+                                        className={cn('max-w-[200px] overflow-hidden text-ellipsis py-0.5', {
+                                            'bg-green-100 dark:bg-green-400 hover:bg-green-100 dark:hover:bg-green-400': isValidColumn && isTransactionRow,
+                                            'text-ink-gray-5': !isValidColumn && isTransactionRow,
+                                        })}
+                                    >
+                                        <div
+                                            className={cn('min-h-5 flex items-center gap-1 px-1 text-xs', {
+                                                'justify-end': isAmountColumn && isValidColumn && isTransactionRow,
+                                                'font-medium text-ink-gray-8': isHeaderRow,
+                                            })}
+                                            title={row[cellIndex] ?? ''}
+                                        >
+                                            {isHeaderRow && columnType && (
+                                                <Tooltip>
+                                                    <TooltipTrigger>
+                                                        <ColumnHeaderIcon columnType={columnType} />
+                                                    </TooltipTrigger>
+                                                    <TooltipContent>{_(columnType)}</TooltipContent>
+                                                </Tooltip>
+                                            )}
+                                            {row[cellIndex] ?? ''}
+                                        </div>
+                                    </TableCell>
+                                )
+                            })}
+                        </TableRow>
+                    )
+                })}
+            </TableBody>
+        </Table>
+    )
+}
+
+const ColumnHeaderIcon = ({ columnType }: { columnType?: ColumnMapsTo }) => {
+    switch (columnType) {
+        case 'Amount':
+            return <DollarSignIcon className="size-4" />
+        case 'Withdrawal':
+            return <ArrowUpRightIcon className="size-4 text-ink-red-3" />
+        case 'Deposit':
+            return <ArrowDownRightIcon className="size-4 text-ink-green-3" />
+        case 'Balance':
+            return <BanknoteIcon className="size-4" />
+        case 'Date':
+            return <CalendarIcon className="size-4" />
+        case 'Description':
+            return <FileTextIcon className="size-4" />
+        case 'Reference':
+            return <ReceiptIcon className="size-4" />
+        case 'Transaction Type':
+            return <ListIcon className="size-4" />
+        case 'Debit/Credit':
+            return <ArrowUpDownIcon className="size-4" />
+        default:
+            return null
+    }
+}
+
+export default RawTableGrid

--- a/banking/src/components/features/BankStatementImporter/import_utils.ts
+++ b/banking/src/components/features/BankStatementImporter/import_utils.ts
@@ -18,6 +18,40 @@ export type ColumnMapsTo =
     | "Party Account No."
     | "Party IBAN"
 
+export type ColumnMappingEntry = {
+    index: number
+    maps_to: ColumnMapsTo | string
+    header_text?: string
+    variable?: string
+}
+
+/** Apply a column mapping change, clearing the same mapping from any other column. */
+export function applyColumnMappingChange<T extends ColumnMappingEntry>(
+    columns: T[],
+    columnIndex: number,
+    mapsTo: ColumnMapsTo,
+): T[] {
+    const previous = columns.find((c) => c.index === columnIndex)
+    const cleared =
+        mapsTo === "Do not import"
+            ? columns
+            : columns.map((c) =>
+                  c.index !== columnIndex && c.maps_to === mapsTo
+                      ? { ...c, maps_to: "Do not import" as ColumnMapsTo }
+                      : c,
+              )
+
+    return [
+        ...cleared.filter((c) => c.index !== columnIndex),
+        {
+            index: columnIndex,
+            maps_to: mapsTo,
+            header_text: previous?.header_text ?? "",
+            variable: previous?.variable ?? `column_${columnIndex}`,
+        } as T,
+    ].sort((a, b) => a.index - b.index)
+}
+
 export const COLUMN_MAPS_TO_OPTIONS: ColumnMapsTo[] = [
     "Do not import",
     "Date",
@@ -109,4 +143,12 @@ export const useReextractPDFTable = () => {
 
 export const useSetPDFTableHeader = () => {
     return useFrappePostCall<{ message: GetStatementDetailsResponse }>("erpnext.accounts.doctype.bank_statement_import_log.bank_statement_import_log.set_pdf_table_header")
+}
+
+export const useUpdateColumnMapping = () => {
+    return useFrappePostCall<{ message: GetStatementDetailsResponse }>("erpnext.accounts.doctype.bank_statement_import_log.bank_statement_import_log.update_column_mapping")
+}
+
+export const useSetHeaderIndex = () => {
+    return useFrappePostCall<{ message: GetStatementDetailsResponse }>("erpnext.accounts.doctype.bank_statement_import_log.bank_statement_import_log.set_header_index")
 }

--- a/banking/src/components/features/BankStatementImporter/import_utils.ts
+++ b/banking/src/components/features/BankStatementImporter/import_utils.ts
@@ -1,6 +1,63 @@
 import { BankStatementImportLog } from "@/types/Accounts/BankStatementImportLog"
-import { useFrappeGetCall } from "frappe-react-sdk"
+import { useFrappeGetCall, useFrappePostCall } from "frappe-react-sdk"
 
+export type ColumnMapsTo =
+    | "Do not import"
+    | "Date"
+    | "Withdrawal"
+    | "Deposit"
+    | "Amount"
+    | "Description"
+    | "Reference"
+    | "Transaction Type"
+    | "Debit/Credit"
+    | "Balance"
+    | "Included Fee"
+    | "Excluded Fee"
+    | "Party Name/Account Holder"
+    | "Party Account No."
+    | "Party IBAN"
+
+export const COLUMN_MAPS_TO_OPTIONS: ColumnMapsTo[] = [
+    "Do not import",
+    "Date",
+    "Description",
+    "Reference",
+    "Withdrawal",
+    "Deposit",
+    "Amount",
+    "Balance",
+    "Debit/Credit",
+    "Transaction Type",
+    "Included Fee",
+    "Excluded Fee",
+    "Party Name/Account Holder",
+    "Party Account No.",
+    "Party IBAN",
+]
+
+export interface PDFTableColumn {
+    index: number
+    header_text: string
+    variable?: string
+    maps_to: ColumnMapsTo
+}
+
+export interface PDFTable {
+    page: number
+    table_index: number
+    bbox: [number, number, number, number]
+    page_width: number
+    page_height: number
+    page_image: string | null
+    render_scale: number | null
+    rows: string[][]
+    header_index: number | null
+    column_mapping: PDFTableColumn[]
+    date_format?: string
+    amount_format?: string
+    included: boolean
+}
 
 export interface GetStatementDetailsResponse {
     doc: BankStatementImportLog,
@@ -30,6 +87,7 @@ export interface GetStatementDetailsResponse {
     date_format: string,
     raw_data: Array<Array<string>>,
     currency: string,
+    pdf_tables?: PDFTable[],
 }
 
 export const useGetStatementDetails = (id: string) => {
@@ -39,4 +97,16 @@ export const useGetStatementDetails = (id: string) => {
         revalidateOnFocus: false
     })
 
+}
+
+export const useUpdatePDFTables = () => {
+    return useFrappePostCall<{ message: GetStatementDetailsResponse }>("erpnext.accounts.doctype.bank_statement_import_log.bank_statement_import_log.update_pdf_tables")
+}
+
+export const useReextractPDFTable = () => {
+    return useFrappePostCall<{ message: GetStatementDetailsResponse }>("erpnext.accounts.doctype.bank_statement_import_log.bank_statement_import_log.reextract_pdf_table")
+}
+
+export const useSetPDFTableHeader = () => {
+    return useFrappePostCall<{ message: GetStatementDetailsResponse }>("erpnext.accounts.doctype.bank_statement_import_log.bank_statement_import_log.set_pdf_table_header")
 }

--- a/banking/src/components/ui/file-dropzone.tsx
+++ b/banking/src/components/ui/file-dropzone.tsx
@@ -231,7 +231,7 @@ export const FileTypeIcon = ({
     const getTextColor = () => {
         switch (fileType.toLowerCase()) {
             case 'pdf':
-                return 'text-red-700'
+                return 'text-ink-red-3'
             case 'doc':
             case 'docx':
                 return 'text-[#1A5CBD]'

--- a/banking/src/pages/BankStatementImporter.tsx
+++ b/banking/src/pages/BankStatementImporter.tsx
@@ -7,6 +7,7 @@ import { Dialog, DialogClose, DialogContent, DialogDescription, DialogFooter, Di
 import { Empty, EmptyHeader, EmptyMedia, EmptyTitle } from "@/components/ui/empty"
 import ErrorBanner from "@/components/ui/error-banner"
 import { FileDropzone } from "@/components/ui/file-dropzone"
+import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
 import { H3, Paragraph } from "@/components/ui/typography"
@@ -16,7 +17,7 @@ import { flt, formatCurrency } from "@/lib/numbers"
 import _ from "@/lib/translate"
 import { cn } from "@/lib/utils"
 import { BankStatementImportLog } from "@/types/Accounts/BankStatementImportLog"
-import { useFrappeCreateDoc, useFrappeFileUpload, useFrappeGetDocList } from "frappe-react-sdk"
+import { useFrappeCreateDoc, useFrappeFileUpload, useFrappeGetDocList, useFrappeUpdateDoc } from "frappe-react-sdk"
 import { useAtom, useAtomValue } from "jotai"
 import { ListIcon, Loader2Icon } from "lucide-react"
 import { useState } from "react"
@@ -30,11 +31,15 @@ const BankStatementImporter = () => {
     const [selectedBankAccount] = useAtom(selectedBankAccountAtom)
 
     const [files, setFiles] = useState<File[]>([])
+    const [password, setPassword] = useState("")
 
     const { upload, error, loading } = useFrappeFileUpload()
 
     const navigate = useNavigate()
     const { createDoc, loading: createLoading, error: createError } = useFrappeCreateDoc<BankStatementImportLog>()
+    const { updateDoc, error: updateError } = useFrappeUpdateDoc()
+
+    const isPdf = files[0]?.name?.toLowerCase().endsWith(".pdf") ?? false
 
     const onUpload = () => {
 
@@ -44,12 +49,18 @@ const BankStatementImporter = () => {
 
         const id = `new-bank-statement-import-log-${Date.now()}`
 
-        upload(files[0], {
+        // For protected PDFs, persist the password on the Bank Account so it is reused for
+        // every statement of this account (and is available before the import doc is created).
+        const ensurePassword = isPdf && password
+            ? updateDoc("Bank Account", selectedBankAccount.name, { statement_password: password })
+            : Promise.resolve()
+
+        ensurePassword.then(() => upload(files[0], {
             isPrivate: true,
             doctype: "Bank Statement Import Log",
             docname: id,
             fieldname: 'file'
-        }).then((file) => {
+        })).then((file) => {
             return createDoc("Bank Statement Import Log",
                 // @ts-expect-error - not filling everything else
                 {
@@ -67,6 +78,7 @@ const BankStatementImporter = () => {
             <div className="w-[52%]">
                 {error && <ErrorBanner error={error} />}
                 {createError && <ErrorBanner error={createError} />}
+                {updateError && <ErrorBanner error={updateError} />}
                 <div className="py-2 flex flex-col gap-6">
                     <div className="flex flex-col gap-2">
                         <Label>{_("Company")}<span className="text-ink-red-3">*</span></Label>
@@ -89,7 +101,7 @@ const BankStatementImporter = () => {
                                     data-slot="form-description"
                                     className={cn("text-ink-gray-5 text-xs")}
                                 >
-                                    {_("Upload your bank statement file to start the import process. We support CSV, and XLSX files.")}
+                                    {_("Upload your bank statement file to start the import process. We support CSV, XLSX and PDF files.")}
                                 </p>
                             </div>
                             <div>
@@ -105,10 +117,27 @@ const BankStatementImporter = () => {
                                 'text/csv': ['.csv'],
                                 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': ['.xlsx'],
                                 'application/vnd.ms-excel': ['.xls'],
+                                'application/pdf': ['.pdf'],
                                 // 'application/xml': ['.xml'],
                             }}
                             multiple={false}
                         />
+
+                        {isPdf && <div className="flex flex-col gap-2">
+                            <Label htmlFor="pdf-password">{_("PDF Password")}</Label>
+                            <Input
+                                id="pdf-password"
+                                type="password"
+                                autoComplete="off"
+                                value={password}
+                                onChange={(e) => setPassword(e.target.value)}
+                                placeholder={_("Only if the PDF is password protected")}
+                                className="max-w-sm"
+                            />
+                            <p data-slot="form-description" className={cn("text-ink-gray-5 text-p-sm")}>
+                                {_("Leave blank to use the password already saved for this bank account (if any). It is stored encrypted and reused for future statements.")}
+                            </p>
+                        </div>}
                     </div>}
                     <div className="flex justify-end px-4">
                         <Button
@@ -137,9 +166,10 @@ const StatementInstructions = () => {
         <DialogContent className="min-w-7xl">
             <DialogHeader>
                 <DialogTitle>{_("Statement Import Instructions")}</DialogTitle>
-                <DialogDescription>{_("We support uploading CSV, XLSX and XLS files. Please make sure the file contains the correct columns.")}</DialogDescription>
+                <DialogDescription>{_("We support uploading CSV, XLSX, XLS and PDF files. Please make sure the file contains the correct columns.")}</DialogDescription>
             </DialogHeader>
             <Paragraph className="text-sm">{_("The file should contain the following columns with a distinct header row. You can upload most bank statements as is without changing the columns.")}</Paragraph>
+            <Paragraph className="text-sm text-ink-gray-6">{_("For PDF statements, we auto-detect the tables on each page. You can then confirm each detected table, map its columns, and exclude anything that is not transactions (e.g. ads or summaries). Password-protected PDFs are supported - the password is saved on the bank account and reused.")}</Paragraph>
             <Table>
                 <TableHeader>
                     <TableRow>
@@ -231,7 +261,13 @@ const StatementImportLog = () => {
                             <TableRow key={item.name} onClick={() => onViewDetails(item.name)} className="cursor-pointer hover:bg-surface-gray-2">
                                 <TableCell>{formatDate(item.creation, 'Do MMM YYYY')}</TableCell>
                                 <TableCell><Badge theme={item.status === "Completed" ? "green" : "gray"}>{item.status}</Badge></TableCell>
-                                <TableCell>{formatDate(item.start_date, 'Do MMM YYYY')} to {formatDate(item.end_date, 'Do MMM YYYY')}</TableCell>
+                                <TableCell>
+                                    {item.start_date && item.end_date ? (
+                                        <span>{formatDate(item.start_date, 'Do MMM YYYY')} to {formatDate(item.end_date, 'Do MMM YYYY')}</span>
+                                    ) : (
+                                        <span>-</span>
+                                    )}
+                                </TableCell>
                                 <TableCell className="text-end">{item.number_of_transactions}</TableCell>
                                 <TableCell className="text-end font-numeric">{formatCurrency(flt(item.closing_balance, 2))}</TableCell>
                                 <TableCell><a

--- a/banking/src/pages/ViewBankStatementImportLog.tsx
+++ b/banking/src/pages/ViewBankStatementImportLog.tsx
@@ -9,12 +9,13 @@ import { ChevronLeftIcon, ChevronRightIcon } from 'lucide-react'
 import { Link, useParams } from 'react-router'
 
 const CSVImport = lazy(() => import('@/components/features/BankStatementImporter/CSV/CSVImport'))
+const PDFImport = lazy(() => import('@/components/features/BankStatementImporter/PDF/PDFImport'))
 
 const ViewBankStatementImportLog = () => {
 
     const { id } = useParams<{ id: string }>()
 
-    const { data, isLoading, error } = useGetStatementDetails(id ?? "")
+    const { data, isLoading, error, mutate } = useGetStatementDetails(id ?? "")
 
     useFrappeDocumentEventListener("Bank Statement Import Log", id ?? "", () => {
     })
@@ -42,6 +43,12 @@ const ViewBankStatementImportLog = () => {
             <ErrorBanner error={error} />
         </div>
     }
+    const isPdf = data.message.doc.file?.toLowerCase().endsWith('.pdf')
+
+    if (isPdf) {
+        return <PDFImport data={data} mutate={mutate} />
+    }
+
     return <CSVImport data={data} />
 }
 

--- a/banking/src/pages/ViewBankStatementImportLog.tsx
+++ b/banking/src/pages/ViewBankStatementImportLog.tsx
@@ -49,7 +49,7 @@ const ViewBankStatementImportLog = () => {
         return <PDFImport data={data} mutate={mutate} />
     }
 
-    return <CSVImport data={data} />
+    return <CSVImport data={data} mutate={mutate} />
 }
 
 export default ViewBankStatementImportLog

--- a/banking/src/types/Accounts/BankAccount.ts
+++ b/banking/src/types/Accounts/BankAccount.ts
@@ -38,6 +38,8 @@ export interface BankAccount{
 	branch_code?: string
 	/**	Bank Account No : Data	*/
 	bank_account_no?: string
+	/**	Statement PDF Password : Password - Password used to open password-protected PDF statements for this account. Stored encrypted.	*/
+	statement_password?: string
 	/**	Is Credit Card : Check	*/
 	is_credit_card?: 0 | 1
 	/**	Integration ID : Data	*/

--- a/banking/src/types/Accounts/BankStatementImportLog.ts
+++ b/banking/src/types/Accounts/BankStatementImportLog.ts
@@ -47,4 +47,6 @@ export interface BankStatementImportLog {
 	detected_transaction_ending_index?: number
 	/**	Column Mapping : Table - Bank Statement Import Log Column Map	*/
 	column_mapping?: BankStatementImportLogColumnMap[]
+	/**	PDF Tables : JSON - Per-table extraction data for PDF statements	*/
+	pdf_tables?: string
 }

--- a/erpnext/accounts/doctype/bank_account/bank_account.json
+++ b/erpnext/accounts/doctype/bank_account/bank_account.json
@@ -27,6 +27,7 @@
   "column_break_12",
   "branch_code",
   "bank_account_no",
+  "statement_password",
   "address_and_contact",
   "address_html",
   "column_break_13",
@@ -148,6 +149,12 @@
    "in_list_view": 1,
    "label": "Bank Account No",
    "length": 30
+  },
+  {
+   "description": "Password used to open password-protected PDF statements for this account. Stored encrypted.",
+   "fieldname": "statement_password",
+   "fieldtype": "Password",
+   "label": "Statement PDF Password"
   },
   {
    "fieldname": "address_and_contact",

--- a/erpnext/accounts/doctype/bank_account/bank_account.py
+++ b/erpnext/accounts/doctype/bank_account/bank_account.py
@@ -41,6 +41,7 @@ class BankAccount(Document):
 		mask: DF.Data | None
 		party: DF.DynamicLink | None
 		party_type: DF.Link | None
+		statement_password: DF.Password | None
 	# end: auto-generated types
 
 	def onload(self):

--- a/erpnext/accounts/doctype/bank_statement_import_log/bank_statement_import_log.json
+++ b/erpnext/accounts/doctype/bank_statement_import_log/bank_statement_import_log.json
@@ -28,7 +28,8 @@
   "detected_transaction_starting_index",
   "detected_transaction_ending_index",
   "section_break_yulq",
-  "column_mapping"
+  "column_mapping",
+  "pdf_tables"
  ],
  "fields": [
   {
@@ -127,6 +128,13 @@
    "fieldtype": "Table",
    "label": "Column Mapping",
    "options": "Bank Statement Import Log Column Map"
+  },
+  {
+   "description": "Per-table extraction data for PDF statements (rows, bbox, page image, column mapping). Edited via the banking app.",
+   "fieldname": "pdf_tables",
+   "fieldtype": "JSON",
+   "label": "PDF Tables",
+   "read_only": 1
   },
   {
    "default": "Not Started",

--- a/erpnext/accounts/doctype/bank_statement_import_log/bank_statement_import_log.py
+++ b/erpnext/accounts/doctype/bank_statement_import_log/bank_statement_import_log.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
 # For license information, please see license.txt
 
+import io
+import json
 import re
 from datetime import datetime
 
@@ -49,6 +51,7 @@ class BankStatementImportLog(Document):
 		end_date: DF.Date | None
 		file: DF.Attach
 		number_of_transactions: DF.Int
+		pdf_tables: DF.JSON | None
 		start_date: DF.Date | None
 		status: DF.Literal["Not Started", "Completed"]
 		total_credit_transactions: DF.Int
@@ -95,9 +98,19 @@ class BankStatementImportLog(Document):
 			)
 
 	def before_insert(self):
-		data = self.get_data()
+		if self.is_pdf():
+			tables = self.prepare_pdf_tables()
+			self.set_pdf_summary(tables)
+		else:
+			data = self.get_data()
+			self.set_file_properties(data)
 
-		self.set_file_properties(data)
+	def after_insert(self):
+		# Page images are attached here (not in before_insert) because the final docname is
+		# only assigned after before_insert runs - attaching earlier links them to the
+		# temporary name the client sends.
+		if self.is_pdf():
+			self.attach_pdf_page_images()
 
 	def set_file_properties(self, raw_data: list[list]):
 		self.set_header_row_index(raw_data)
@@ -149,27 +162,50 @@ class BankStatementImportLog(Document):
 		self.total_debit_transactions = debit_transactions
 		self.total_credit_transactions = credit_transactions
 
+	def get_file_doc(self):
+		return frappe.get_doc("File", {"file_url": self.file})
+
+	def get_file_extension(self):
+		return self.get_file_doc().get_extension()[1].lower()
+
+	def is_pdf(self):
+		return self.get_file_extension() == ".pdf"
+
+	def get_statement_password(self):
+		"""Decrypted PDF password stored on the linked Bank Account (if any)."""
+		if not self.bank_account:
+			return None
+
+		from frappe.utils.password import get_decrypted_password
+
+		return get_decrypted_password(
+			"Bank Account", self.bank_account, "statement_password", raise_exception=False
+		)
+
 	def get_data(self):
 		"""
-		Extract the data from the attached file
+		Extract the data from a tabular (CSV/XLSX/XLS) attached file as a list of rows.
+
+		PDFs are not handled here - they go through the multi-table PDF pipeline
+		(`prepare_pdf_tables`) since a PDF can yield several tables with differing shapes.
 		"""
 
-		file_doc = frappe.get_doc("File", {"file_url": self.file})
+		file_doc = self.get_file_doc()
 
-		parts = file_doc.get_extension()
-		extension = parts[1]
+		extension = self.get_file_extension()
 		content = file_doc.get_content()
 
-		if extension.lower() not in (".csv", ".xlsx", ".xls"):
+		if extension not in (".csv", ".xlsx", ".xls"):
 			frappe.throw(
-				_("Import template should be of type .csv, .xlsx or .xls"), title=_("Invalid File Type")
+				_("Import template should be of type .csv, .xlsx, .xls or .pdf"),
+				title=_("Invalid File Type"),
 			)
 
-		if extension.lower() == ".csv":
+		if extension == ".csv":
 			data = read_csv_content(content)
-		elif extension.lower() == ".xlsx":
+		elif extension == ".xlsx":
 			data = read_xlsx_file_from_attached_file(fcontent=content)
-		elif extension.lower() == ".xls":
+		elif extension == ".xls":
 			data = read_xls_file_from_attached_file(content)
 
 		return data
@@ -179,105 +215,14 @@ class BankStatementImportLog(Document):
 		Given the data, try to get the row index of the header row.
 		"""
 
-		row_index = 0
-		max_valid_columns = 0
-
-		# Loop over rows and find the first row that has the most number of "valid" column headers
-		# Valid columns is based on keywords present in each cell
-
-		for idx, row in enumerate(data):
-			valid_columns = 0
-			for cell in row:
-				if not cell:
-					continue
-
-				# If cell is a string, then we need to check if it contains any of the keywords
-				if not isinstance(cell, str):
-					continue
-
-				if any(
-					keyword in cell.lower()
-					for keyword in [
-						"date",
-						"amount",
-						"description",
-						"reference",
-						"transaction",
-						"type",
-						"cr",
-						"dr",
-						"deposit",
-						"withdrawal",
-						"balance",
-					]
-				):
-					valid_columns += 1
-			if valid_columns > max_valid_columns:
-				max_valid_columns = valid_columns
-				row_index = idx
-
-		self.detected_header_index = row_index
+		self.detected_header_index, _ = detect_header_row(data)
 
 	def set_column_mapping(self, data: list[list[str]]):
 		"""
 		Given the header row, try to map each column index to a standard variable, or set it to "Do not import"
 		"""
 
-		header_row = data[self.detected_header_index]
-
-		standard_variables = {
-			"Date": ["date", "transaction date"],
-			"Debit/Credit": [
-				"transaction type",
-				"cr/dr",
-				"dr/cr",
-				"debit/credit",
-				"credit/debit",
-				"debit / credit",
-				"credit / debit",
-			],
-			"Withdrawal": ["withdrawal", "debit"],
-			"Deposit": ["deposit", "credit"],
-			"Amount": ["amount"],
-			"Description": ["description", "particulars", "remarks", "narration", "detail", "reference"],
-			"Reference": ["reference", "ref", "tran id", "transaction id", "cheque", "check", "id", "chq"],
-			"Balance": ["balance"],
-		}
-
-		# A standard variable can be represented by multiple names
-
-		column_mapping = {}
-
-		# Loop over all columns and check if they contain any of the standard variable names
-		# If not, we do not import it
-		# If they do, we map the column index to the standard variable
-
-		columns = []
-
-		for idx, cell in enumerate(header_row):
-			if not cell:
-				continue
-
-			if not isinstance(cell, str):
-				continue
-
-			column = {
-				"index": idx,
-				"header_text": cell,
-				"variable": cell.strip().lower().replace(" ", "_").replace("?", "").replace(".", ""),
-				"maps_to": "Do not import",
-			}
-
-			for standard_variable, names in standard_variables.items():
-				if any(name in cell.lower().replace(".", "") for name in names):
-					if column_mapping.get(standard_variable, None) is None:
-						column["maps_to"] = standard_variable
-
-						column_mapping[standard_variable] = idx
-
-						break
-
-			columns.append(column)
+		columns = detect_column_mapping(data[self.detected_header_index])
 
 		self.column_mapping = []
 
@@ -295,10 +240,6 @@ class BankStatementImportLog(Document):
 	def get_transaction_rows(self, data: list[list[str]]):
 		"""
 		Given the data, header index and column mapping, try to get the transaction rows
-
-		For each row after the header row, check if the data makes sense - date column should have a date,
-		amount column should be a number after removing any special charatcers, spaces and "CR/DR" text.
-		Balance column should be a number after removing any special charatcers, spaces and "CR/DR" text.
 		"""
 
 		column_mapping: dict[str, int] = {}
@@ -306,92 +247,7 @@ class BankStatementImportLog(Document):
 			if column.maps_to != "Do not import":
 				column_mapping[column.maps_to] = column.index
 
-		transaction_rows = []
-
-		transaction_starting_index = None
-		transaction_ending_index = None
-
-		valid_rows = data[self.detected_header_index + 1 :]
-
-		column_map_keys = column_mapping.keys()
-
-		for row_index, row in enumerate(valid_rows):
-			date = row[column_mapping["Date"]] if "Date" in column_map_keys else None
-			amount = row[column_mapping["Amount"]] if "Amount" in column_map_keys else None
-			withdrawal = row[column_mapping["Withdrawal"]] if "Withdrawal" in column_map_keys else None
-			deposit = row[column_mapping["Deposit"]] if "Deposit" in column_map_keys else None
-			balance = row[column_mapping["Balance"]] if "Balance" in column_map_keys else None
-
-			if not date:
-				continue
-
-			if isinstance(date, datetime):
-				date = date.strftime("%Y-%m-%d")
-
-			if not isinstance(date, str):
-				continue
-
-			if not amount and not withdrawal and not deposit:
-				continue
-
-			# Check if date column is a valid date
-			row_date_format = frappe.utils.guess_date_format(date)
-
-			if not row_date_format:
-				continue
-
-			# Check if either the amount, withdrawal or deposit column is a valid number
-			amount = get_float_amount(amount)
-			withdrawal = get_float_amount(withdrawal)
-			deposit = get_float_amount(deposit)
-			balance = get_float_amount(balance)
-
-			if not amount and not withdrawal and not deposit:
-				continue
-
-			if transaction_starting_index is None:
-				transaction_starting_index = row_index
-
-			transaction_ending_index = row_index
-
-			transaction_row = {
-				"date_format": row_date_format,
-			}
-
-			# Populate the raw transaction row as is - without any formatting
-
-			field_map = {
-				"Date": "date",
-				"Amount": "amount",
-				"Withdrawal": "withdrawal",
-				"Deposit": "deposit",
-				"Balance": "balance",
-				"Reference": "reference",
-				"Description": "description",
-				"Debit/Credit": "debit_credit",
-				"Transaction Type": "transaction_type",
-				"Included Fee": "included_fee",
-				"Excluded Fee": "excluded_fee",
-				"Party Name/Account Holder": "party_name",
-				"Party Account No.": "party_account_number",
-				"Party IBAN": "party_iban",
-			}
-
-			for source_field, target_field in field_map.items():
-				if source_field in column_map_keys:
-					transaction_row[target_field] = row[column_mapping[source_field]]
-
-			transaction_rows.append(transaction_row)
-
-		base_index = self.detected_header_index + 1
-
-		if transaction_starting_index is not None:
-			transaction_starting_index += base_index
-
-		if transaction_ending_index is not None:
-			transaction_ending_index += base_index
-
-		return transaction_rows, transaction_starting_index, transaction_ending_index
+		return extract_transaction_rows(data, column_mapping, self.detected_header_index)
 
 	def set_closing_balance(self, transactions: list):
 		"""
@@ -431,81 +287,168 @@ class BankStatementImportLog(Document):
 		Given the parameters detected in the statement (including overrides) try to get the final transactions
 		"""
 
-		date_format = self.detected_date_format
-		amount_format = self.detected_amount_format
+		return compute_final_transactions(
+			transaction_rows, self.detected_date_format, self.detected_amount_format
+		)
 
-		final_transactions = []
+	# ------------------------------------------------------------------ #
+	# PDF statement handling
+	# ------------------------------------------------------------------ #
 
-		def parse_amount(transaction_row: dict):
-			"""
-			Given a transaction row, try to parse the amount - returns tuple of (withdrawal, deposit)
-			"""
+	def get_pdf_tables(self) -> list[dict]:
+		"""The stored per-table PDF extraction data, parsed from the JSON field."""
+		if not self.pdf_tables:
+			return []
+		if isinstance(self.pdf_tables, str):
+			return json.loads(self.pdf_tables)
+		return self.pdf_tables
 
-			if amount_format == "Separate columns for withdrawal and deposit":
-				return get_float_amount(transaction_row.get("withdrawal")), get_float_amount(
-					transaction_row.get("deposit")
-				)
+	def prepare_pdf_tables(self) -> list[dict]:
+		"""
+		Extract each table from the PDF (kept separate, never merged), rasterize the
+		pages so the user can confirm tables visually, and run a best-effort per-table
+		column mapping. The result is stored as JSON on `pdf_tables`.
 
-			if amount_format == 'Amount column has "CR"/"DR" values':
-				amount = transaction_row.get("amount")
-				float_amount = get_float_amount(amount)
-				if "cr" in amount.lower():
-					return 0, float_amount
-				else:
-					return float_amount, 0
+		The rendered page images are stashed on the instance and only saved as File docs
+		in `after_insert` (see `attach_pdf_page_images`), once the final docname exists.
+		"""
+		content = self.get_file_doc().get_content()
+		password = self.get_statement_password()
 
-			if amount_format == "Amount column has positive/negative values":
-				amount = get_float_amount(transaction_row.get("amount", "0"))
-				if amount > 0:
-					return 0, abs(amount)
-				else:
-					return abs(amount), 0
+		tables = extract_pdf_tables(content, password)
 
-			if amount_format == 'Transaction type column has "CR"/"DR" values':
-				transaction_type = transaction_row.get("debit_credit")
-				amount = get_float_amount(transaction_row.get("amount", "0"))
-				if "cr" in transaction_type.lower():
-					return 0, abs(amount)
-				else:
-					return abs(amount), 0
+		# Rasterize only the pages that actually produced tables, once each.
+		pages = {table["page"] for table in tables}
+		page_images = render_pdf_pages(content, password, pages)
 
-			if amount_format == 'Transaction type column has "C"/"D" values':
-				transaction_type = transaction_row.get("debit_credit")
-				amount = get_float_amount(transaction_row.get("amount", "0"))
-				if transaction_type.lower().strip() == "c":
-					return 0, abs(amount)
-				else:
-					return abs(amount), 0
+		self._pending_page_images = {page: png for page, (png, _scale) in page_images.items()}
+		page_scales = {page: scale for page, (_png, scale) in page_images.items()}
 
-			if amount_format == 'Transaction type column has "Deposit"/"Withdrawal" values':
-				transaction_type = transaction_row.get("debit_credit")
-				amount = get_float_amount(transaction_row.get("amount", "0"))
-				if "deposit" in transaction_type.lower():
-					return 0, abs(amount)
-				else:
-					return abs(amount), 0
+		for table in tables:
+			table["page_image"] = None  # filled in after_insert
+			table["render_scale"] = page_scales.get(table["page"])
 
-			return 0, 0
-
-		for transaction in transaction_rows:
-			date = transaction.get("date")
-
-			if isinstance(date, datetime):
-				date = date.strftime("%Y-%m-%d")
+			# Best-effort auto mapping. Headers are often missing in PDFs - fall back to
+			# guessing from the column contents. The user can correct this afterwards.
+			header_index, score = detect_header_row(table["rows"])
+			if score >= 2:
+				table["header_index"] = header_index
+				table["column_mapping"] = detect_column_mapping(table["rows"][header_index])
 			else:
-				date = datetime.strptime(date, date_format).strftime("%Y-%m-%d")
+				table["header_index"] = None
+				table["column_mapping"] = guess_column_mapping_by_content(table["rows"])
 
-			withdrawal, deposit = parse_amount(transaction)
-			final_transactions.append(
+			final_transactions, table["date_format"], table["amount_format"] = build_table_transactions(table)
+			# Tables with no detectable transactions (ads, summaries, headers) start excluded.
+			table["included"] = bool(final_transactions)
+
+		self.pdf_tables = json.dumps(tables)
+		return tables
+
+	def attach_pdf_page_images(self):
+		"""Persist the rendered page images (rendered in `prepare_pdf_tables`) as private
+		Files attached to this log, and write their URLs back into `pdf_tables`."""
+		pending = getattr(self, "_pending_page_images", None)
+		if not pending:
+			return
+
+		page_urls = {page: self.save_page_image(png, page) for page, png in pending.items()}
+
+		tables = self.get_pdf_tables()
+		for table in tables:
+			table["page_image"] = page_urls.get(table["page"])
+
+		self.db_set("pdf_tables", json.dumps(tables), update_modified=False)
+		self._pending_page_images = None
+
+	def save_page_image(self, png_bytes: bytes, page_number: int) -> str:
+		"""Save a rendered page as a private File attached to this log; return its URL."""
+		return (
+			frappe.get_doc(
 				{
-					**transaction,
-					"date": date,
-					"withdrawal": withdrawal,
-					"deposit": deposit,
+					"doctype": "File",
+					"file_name": f"statement-{self.name}-page-{page_number}.png",
+					"is_private": 1,
+					"content": png_bytes,
+					"attached_to_doctype": self.doctype,
+					"attached_to_name": self.name,
 				}
 			)
+			.insert(ignore_permissions=True)
+			.file_url
+		)
+
+	def get_pdf_final_transactions(self) -> list[dict]:
+		"""Union of transactions across all included PDF tables."""
+		final_transactions = []
+		for table in self.get_pdf_tables():
+			if not table.get("included", True):
+				continue
+			table_transactions, _df, _af = build_table_transactions(table)
+			final_transactions.extend(table_transactions)
+		return final_transactions
+
+	def set_pdf_summary(self, tables: list[dict]) -> list[dict]:
+		"""Compute the doc-level summary fields from the union of included PDF tables."""
+		final_transactions = []
+		date_format = None
+		amount_format = None
+
+		for table in tables:
+			if not table.get("included", True):
+				continue
+			table_transactions, df, af = build_table_transactions(table)
+			final_transactions.extend(table_transactions)
+			if table_transactions and date_format is None:
+				date_format, amount_format = df, af
+
+		self.detected_date_format = date_format or "%d/%m/%Y"
+		self.detected_amount_format = amount_format or "Separate columns for withdrawal and deposit"
+		self.number_of_transactions = len(final_transactions)
+
+		total_debits = total_credits = 0
+		debit_transactions = credit_transactions = 0
+		start_date = end_date = None
+		closing_balance = None
+
+		for transaction in final_transactions:
+			withdrawal = transaction.get("withdrawal", 0) or 0
+			deposit = transaction.get("deposit", 0) or 0
+			if withdrawal > 0:
+				total_debits += withdrawal
+				debit_transactions += 1
+			if deposit > 0:
+				total_credits += deposit
+				credit_transactions += 1
+
+			date = transaction.get("date")
+			if not date:
+				continue
+			tx_date = getdate(date)
+			if start_date is None or tx_date < start_date:
+				start_date = tx_date
+			if end_date is None or tx_date >= end_date:
+				end_date = tx_date
+				closing_balance = transaction.get("balance")
+
+		self.total_debits = total_debits
+		self.total_credits = total_credits
+		self.total_debit_transactions = debit_transactions
+		self.total_credit_transactions = credit_transactions
+		self.start_date = getdate(start_date) if start_date else None
+		self.end_date = getdate(end_date) if end_date else None
+		self.closing_balance = get_float_amount(closing_balance)
 
 		return final_transactions
+
+	def apply_pdf_tables(self, tables: list[dict]):
+		"""
+		Persist the user's per-table edits (column mapping, include/exclude) and
+		recompute the summary so the preview stays in sync.
+		"""
+		self.pdf_tables = json.dumps(tables)
+		self.set_pdf_summary(tables)
+		self.save()
 
 	@frappe.whitelist(methods=["POST"])
 	def insert_transactions(self):
@@ -530,12 +473,12 @@ class BankStatementImportLog(Document):
 
 		progress = 0
 
-		raw_data = self.get_data()
-		transaction_rows, transaction_starting_index, transaction_ending_index = self.get_transaction_rows(
-			raw_data
-		)
-
-		final_transactions = self.get_final_transactions(transaction_rows=transaction_rows)
+		if self.is_pdf():
+			final_transactions = self.get_pdf_final_transactions()
+		else:
+			raw_data = self.get_data()
+			transaction_rows, _starting_index, _ending_index = self.get_transaction_rows(raw_data)
+			final_transactions = self.get_final_transactions(transaction_rows=transaction_rows)
 
 		total_transactions = len(final_transactions)
 
@@ -589,6 +532,457 @@ class BankStatementImportLog(Document):
 
 		self.status = "Completed"
 		self.save()
+
+
+HEADER_KEYWORDS = [
+	"date",
+	"amount",
+	"description",
+	"reference",
+	"transaction",
+	"type",
+	"cr",
+	"dr",
+	"deposit",
+	"withdrawal",
+	"balance",
+]
+
+STANDARD_VARIABLES = {
+	"Date": ["date", "transaction date"],
+	"Debit/Credit": [
+		"transaction type",
+		"cr/dr",
+		"dr/cr",
+		"debit/credit",
+		"credit/debit",
+		"debit / credit",
+		"credit / debit",
+	],
+	"Withdrawal": ["withdrawal", "debit"],
+	"Deposit": ["deposit", "credit"],
+	"Amount": ["amount"],
+	"Description": ["description", "particulars", "remarks", "narration", "detail", "reference"],
+	"Reference": ["reference", "ref", "tran id", "transaction id", "cheque", "check", "id", "chq"],
+	"Balance": ["balance"],
+}
+
+# Map of standard column variable -> transaction row field
+FIELD_MAP = {
+	"Date": "date",
+	"Amount": "amount",
+	"Withdrawal": "withdrawal",
+	"Deposit": "deposit",
+	"Balance": "balance",
+	"Reference": "reference",
+	"Description": "description",
+	"Debit/Credit": "debit_credit",
+	"Transaction Type": "transaction_type",
+	"Included Fee": "included_fee",
+	"Excluded Fee": "excluded_fee",
+	"Party Name/Account Holder": "party_name",
+	"Party Account No.": "party_account_number",
+	"Party IBAN": "party_iban",
+}
+
+
+def detect_header_row(data: list[list]) -> tuple[int, int]:
+	"""
+	Return ``(row_index, score)`` of the most header-like row. ``score`` is the count of
+	cells containing a banking keyword - callers can treat a low score as "no header".
+	"""
+	row_index = 0
+	max_valid_columns = 0
+
+	for idx, row in enumerate(data):
+		valid_columns = 0
+		for cell in row:
+			if not cell or not isinstance(cell, str):
+				continue
+			if any(keyword in cell.lower() for keyword in HEADER_KEYWORDS):
+				valid_columns += 1
+		if valid_columns > max_valid_columns:
+			max_valid_columns = valid_columns
+			row_index = idx
+
+	return row_index, max_valid_columns
+
+
+def detect_column_mapping(header_row: list) -> list[dict]:
+	"""
+	Given a header row, map each column index to a standard variable, or "Do not import".
+	A standard variable can be represented by multiple names; the first match wins.
+	"""
+	column_mapping: dict[str, int] = {}
+	columns = []
+
+	for idx, cell in enumerate(header_row):
+		if not cell or not isinstance(cell, str):
+			continue
+
+		column = {
+			"index": idx,
+			"header_text": cell,
+			"variable": cell.strip().lower().replace(" ", "_").replace("?", "").replace(".", ""),
+			"maps_to": "Do not import",
+		}
+
+		for standard_variable, names in STANDARD_VARIABLES.items():
+			if any(name in cell.lower().replace(".", "") for name in names):
+				if column_mapping.get(standard_variable, None) is None:
+					column["maps_to"] = standard_variable
+					column_mapping[standard_variable] = idx
+					break
+
+		columns.append(column)
+
+	return columns
+
+
+def guess_column_mapping_by_content(rows: list[list]) -> list[dict]:
+	"""
+	Best-effort column mapping for tables without a usable header row (common in PDFs).
+	Uses cell contents: a mostly-date column -> Date, the widest text column -> Description,
+	and a lone numeric column -> Amount. Ambiguous numeric columns (e.g. separate
+	withdrawal/deposit/balance) are left for the user to map.
+	"""
+	num_cols = max((len(row) for row in rows), default=0)
+	column_stats = []
+
+	for idx in range(num_cols):
+		cells = [row[idx] for row in rows if idx < len(row) and str(row[idx]).strip() != ""]
+		count = len(cells)
+		if not count:
+			column_stats.append({"index": idx, "date_ratio": 0, "num_ratio": 0, "avg_len": 0, "count": 0})
+			continue
+		date_hits = sum(1 for c in cells if isinstance(c, str) and frappe.utils.guess_date_format(c))
+		num_hits = sum(1 for c in cells if get_float_amount(c) is not None)
+		avg_len = sum(len(str(c)) for c in cells) / count
+		column_stats.append(
+			{
+				"index": idx,
+				"date_ratio": date_hits / count,
+				"num_ratio": num_hits / count,
+				"avg_len": avg_len,
+				"count": count,
+			}
+		)
+
+	mapping: dict[int, str] = {}
+	numeric_cols = []
+	date_assigned = False
+
+	for stat in column_stats:
+		if stat["count"] == 0:
+			continue
+		if not date_assigned and stat["date_ratio"] >= 0.6:
+			mapping[stat["index"]] = "Date"
+			date_assigned = True
+		elif stat["num_ratio"] >= 0.6:
+			numeric_cols.append(stat["index"])
+
+	# Description: widest non-date, non-numeric text column
+	text_cols = [
+		s for s in column_stats if s["count"] and s["index"] not in mapping and s["index"] not in numeric_cols
+	]
+	if text_cols:
+		mapping[max(text_cols, key=lambda s: s["avg_len"])["index"]] = "Description"
+
+	# A single numeric column is unambiguously the amount; otherwise leave for the user.
+	if len(numeric_cols) == 1:
+		mapping[numeric_cols[0]] = "Amount"
+
+	return [
+		{
+			"index": idx,
+			"header_text": "",
+			"variable": f"column_{idx}",
+			"maps_to": mapping.get(idx, "Do not import"),
+		}
+		for idx in range(num_cols)
+	]
+
+
+def extract_transaction_rows(data: list[list], column_mapping: dict[str, int], header_index: int):
+	"""
+	Pure version of the transaction-row detector. ``header_index`` may be -1/None to mean
+	"no header row - treat every row as data" (used for headerless PDF tables).
+
+	For each row after the header, validate that the date column holds a date and that at
+	least one of amount/withdrawal/deposit is a number. Returns
+	``(transaction_rows, starting_index, ending_index)``.
+	"""
+	if header_index is None:
+		header_index = -1
+
+	def cell(row, key):
+		idx = column_mapping.get(key)
+		if idx is None or idx >= len(row):
+			return None
+		return row[idx]
+
+	transaction_rows = []
+	transaction_starting_index = None
+	transaction_ending_index = None
+
+	valid_rows = data[header_index + 1 :]
+
+	for row_index, row in enumerate(valid_rows):
+		date = cell(row, "Date")
+		amount = cell(row, "Amount")
+		withdrawal = cell(row, "Withdrawal")
+		deposit = cell(row, "Deposit")
+
+		if not date:
+			continue
+
+		if isinstance(date, datetime):
+			date = date.strftime("%Y-%m-%d")
+
+		if not isinstance(date, str):
+			continue
+
+		if not amount and not withdrawal and not deposit:
+			continue
+
+		row_date_format = frappe.utils.guess_date_format(date)
+		if not row_date_format:
+			continue
+
+		amount = get_float_amount(amount)
+		withdrawal = get_float_amount(withdrawal)
+		deposit = get_float_amount(deposit)
+
+		if not amount and not withdrawal and not deposit:
+			continue
+
+		if transaction_starting_index is None:
+			transaction_starting_index = row_index
+		transaction_ending_index = row_index
+
+		transaction_row = {"date_format": row_date_format}
+		for source_field, target_field in FIELD_MAP.items():
+			if source_field in column_mapping:
+				transaction_row[target_field] = cell(row, source_field)
+
+		transaction_rows.append(transaction_row)
+
+	base_index = header_index + 1
+	if transaction_starting_index is not None:
+		transaction_starting_index += base_index
+	if transaction_ending_index is not None:
+		transaction_ending_index += base_index
+
+	return transaction_rows, transaction_starting_index, transaction_ending_index
+
+
+def compute_final_transactions(transaction_rows: list, date_format: str, amount_format: str) -> list:
+	"""Pure version of the final-transaction builder (date normalized, amount split)."""
+	final_transactions = []
+
+	def parse_amount(transaction_row: dict):
+		if amount_format == "Separate columns for withdrawal and deposit":
+			return get_float_amount(transaction_row.get("withdrawal")), get_float_amount(
+				transaction_row.get("deposit")
+			)
+
+		if amount_format == 'Amount column has "CR"/"DR" values':
+			amount = transaction_row.get("amount")
+			float_amount = get_float_amount(amount)
+			if "cr" in amount.lower():
+				return 0, float_amount
+			else:
+				return float_amount, 0
+
+		if amount_format == "Amount column has positive/negative values":
+			amount = get_float_amount(transaction_row.get("amount", "0"))
+			if amount > 0:
+				return 0, abs(amount)
+			else:
+				return abs(amount), 0
+
+		if amount_format == 'Transaction type column has "CR"/"DR" values':
+			transaction_type = transaction_row.get("debit_credit")
+			amount = get_float_amount(transaction_row.get("amount", "0"))
+			if "cr" in transaction_type.lower():
+				return 0, abs(amount)
+			else:
+				return abs(amount), 0
+
+		if amount_format == 'Transaction type column has "C"/"D" values':
+			transaction_type = transaction_row.get("debit_credit")
+			amount = get_float_amount(transaction_row.get("amount", "0"))
+			if transaction_type.lower().strip() == "c":
+				return 0, abs(amount)
+			else:
+				return abs(amount), 0
+
+		if amount_format == 'Transaction type column has "Deposit"/"Withdrawal" values':
+			transaction_type = transaction_row.get("debit_credit")
+			amount = get_float_amount(transaction_row.get("amount", "0"))
+			if "deposit" in transaction_type.lower():
+				return 0, abs(amount)
+			else:
+				return abs(amount), 0
+
+		return 0, 0
+
+	for transaction in transaction_rows:
+		date = transaction.get("date")
+
+		if isinstance(date, datetime):
+			date = date.strftime("%Y-%m-%d")
+		else:
+			date = datetime.strptime(date, date_format).strftime("%Y-%m-%d")
+
+		withdrawal, deposit = parse_amount(transaction)
+		final_transactions.append(
+			{
+				**transaction,
+				"date": date,
+				"withdrawal": withdrawal,
+				"deposit": deposit,
+			}
+		)
+
+	return final_transactions
+
+
+def build_table_transactions(table: dict):
+	"""
+	Run the per-table detection pipeline on a single PDF table dict and return
+	``(final_transactions, date_format, amount_format)``. A table whose mapping has no Date
+	column (e.g. an ad or summary block) naturally yields zero transactions.
+	"""
+	column_mapping: dict[str, int] = {}
+	for column in table.get("column_mapping", []):
+		if column.get("maps_to") and column["maps_to"] != "Do not import":
+			column_mapping[column["maps_to"]] = column["index"]
+
+	transaction_rows, _start, _end = extract_transaction_rows(
+		table.get("rows", []), column_mapping, table.get("header_index")
+	)
+	date_format, amount_format = get_file_properties(transaction_rows)
+	final_transactions = compute_final_transactions(transaction_rows, date_format, amount_format)
+	return final_transactions, date_format, amount_format
+
+
+def _clean_cell(cell) -> str:
+	"""Normalize a pdfplumber cell: None -> '', collapse wrapped newlines, strip."""
+	if cell is None:
+		return ""
+	return str(cell).replace("\n", " ").strip()
+
+
+def extract_pdf_tables(content: bytes, password: str | None = None) -> list[dict]:
+	"""
+	Extract tables from a PDF, kept SEPARATE (never merged), each with its page, table index,
+	bounding box and page dimensions. Raises a recognizable error for encrypted PDFs without
+	a valid password, and for PDFs where no tables can be detected (e.g. scanned/image PDFs).
+	"""
+	try:
+		import pdfplumber
+	except ImportError:
+		frappe.throw(
+			_("PDF statement support requires the 'pdfplumber' library to be installed."),
+			title=_("Missing Dependency"),
+		)
+
+	from pypdf import PdfReader
+
+	reader = PdfReader(io.BytesIO(content))
+	if reader.is_encrypted and (not password or not reader.decrypt(password)):
+		frappe.throw(
+			_(
+				"This PDF is password protected. Please set the correct statement password on the"
+				" Bank Account and try again."
+			),
+			title=_("Password Required"),
+		)
+
+	text_settings = {"vertical_strategy": "text", "horizontal_strategy": "text"}
+	tables = []
+
+	with pdfplumber.open(io.BytesIO(content), password=password or "") as pdf:
+		for page_number, page in enumerate(pdf.pages, start=1):
+			found_tables = page.find_tables()
+			if not found_tables:
+				found_tables = page.find_tables(table_settings=text_settings)
+
+			for table_index, table in enumerate(found_tables):
+				rows = [[_clean_cell(c) for c in row] for row in (table.extract() or [])]
+				rows = [row for row in rows if any(cell != "" for cell in row)]
+				if not rows:
+					continue
+
+				tables.append(
+					{
+						"page": page_number,
+						"table_index": table_index,
+						"bbox": [round(float(v), 2) for v in table.bbox],
+						"page_width": round(float(page.width), 2),
+						"page_height": round(float(page.height), 2),
+						"rows": rows,
+					}
+				)
+
+	if not tables:
+		frappe.throw(
+			_(
+				"Could not detect any tables in this PDF. It may be a scanned or image-based"
+				" statement, which is not supported (no OCR)."
+			),
+			title=_("No Tables Detected"),
+		)
+
+	return tables
+
+
+def extract_table_in_bbox(
+	content: bytes, password: str | None, page_number: int, bbox: list[float]
+) -> list[list[str]]:
+	"""
+	Re-extract a single table from a user-adjusted region (PDF points, top-left origin) on a
+	given 1-based page. The bbox is clamped to the page bounds before cropping.
+	"""
+	import pdfplumber
+
+	text_settings = {"vertical_strategy": "text", "horizontal_strategy": "text"}
+
+	with pdfplumber.open(io.BytesIO(content), password=password or "") as pdf:
+		page = pdf.pages[page_number - 1]
+
+		x0 = max(0, min(float(bbox[0]), page.width))
+		top = max(0, min(float(bbox[1]), page.height))
+		x1 = max(x0 + 1, min(float(bbox[2]), page.width))
+		bottom = max(top + 1, min(float(bbox[3]), page.height))
+
+		cropped = page.crop((x0, top, x1, bottom))
+		table = cropped.extract_table() or cropped.extract_table(table_settings=text_settings)
+
+	rows = [[_clean_cell(cell) for cell in row] for row in (table or [])]
+	return [row for row in rows if any(cell != "" for cell in row)]
+
+
+def render_pdf_pages(
+	content: bytes, password: str | None, pages: set[int], resolution: int = 150
+) -> dict[int, tuple[bytes, float]]:
+	"""
+	Rasterize the requested (1-based) pages to PNG bytes. Returns
+	``{page_number: (png_bytes, render_scale)}`` where ``render_scale`` is pixels per PDF point.
+	"""
+	import pdfplumber
+
+	images = {}
+	with pdfplumber.open(io.BytesIO(content), password=password or "") as pdf:
+		for page_number, page in enumerate(pdf.pages, start=1):
+			if page_number not in pages:
+				continue
+			page_image = page.to_image(resolution=resolution)
+			buffer = io.BytesIO()
+			page_image.original.save(buffer, format="PNG")
+			images[page_number] = (buffer.getvalue(), round(resolution / 72.0, 4))
+	return images
 
 
 def get_float_amount(amount):
@@ -707,11 +1101,23 @@ def get_statement_details(statement_import_id: str):
 
 	conflicting_transactions = check_for_conflicts(doc.bank_account, doc.start_date, doc.end_date)
 
+	if doc.is_pdf():
+		# PDF: the per-table data lives in `pdf_tables`; transactions are the union of
+		# all included tables. `raw_data` is unused by the PDF frontend.
+		pdf_tables = doc.get_pdf_tables()
+		final_transactions = doc.get_pdf_final_transactions()
+		return {
+			"doc": doc,
+			"date_format": formatted_date_format,
+			"conflicting_transactions": conflicting_transactions,
+			"final_transactions": final_transactions,
+			"raw_data": [],
+			"pdf_tables": pdf_tables,
+		}
+
 	raw_data = doc.get_data()
 
-	transaction_rows, transaction_starting_index, transaction_ending_index = doc.get_transaction_rows(
-		raw_data
-	)
+	transaction_rows, _starting_index, _ending_index = doc.get_transaction_rows(raw_data)
 
 	final_transactions = doc.get_final_transactions(transaction_rows=transaction_rows)
 
@@ -722,6 +1128,114 @@ def get_statement_details(statement_import_id: str):
 		"final_transactions": final_transactions,
 		"raw_data": raw_data,
 	}
+
+
+@frappe.whitelist(methods=["POST"])
+def update_pdf_tables(statement_import_id: str, tables: list | str):
+	"""
+	Persist the user's per-table edits (column mapping, include/exclude flags) for a PDF
+	statement and return the refreshed statement details (so the preview stays in sync).
+	"""
+	doc = frappe.get_doc("Bank Statement Import Log", statement_import_id)
+	doc.check_permission("write")
+
+	if doc.status == "Completed":
+		frappe.throw(_("This statement has already been imported."), title=_("Already Imported"))
+
+	if isinstance(tables, str):
+		tables = json.loads(tables)
+
+	doc.apply_pdf_tables(tables)
+
+	return get_statement_details(statement_import_id)
+
+
+@frappe.whitelist(methods=["POST"])
+def reextract_pdf_table(statement_import_id: str, page: int, table_index: int, bbox: list | str):
+	"""
+	Re-extract one PDF table's rows from a user-adjusted bounding box and refresh the preview.
+	The user's column mapping is preserved when the column count is unchanged; otherwise the
+	table is re-mapped automatically.
+	"""
+	doc = frappe.get_doc("Bank Statement Import Log", statement_import_id)
+	doc.check_permission("write")
+
+	if doc.status == "Completed":
+		frappe.throw(_("This statement has already been imported."), title=_("Already Imported"))
+
+	if isinstance(bbox, str):
+		bbox = json.loads(bbox)
+
+	page = int(page)
+	table_index = int(table_index)
+
+	content = doc.get_file_doc().get_content()
+	password = doc.get_statement_password()
+	rows = extract_table_in_bbox(content, password, page, [float(v) for v in bbox])
+
+	tables = doc.get_pdf_tables()
+	for table in tables:
+		if table["page"] == page and table["table_index"] == table_index:
+			old_columns = max((len(row) for row in table.get("rows", [])), default=0)
+			new_columns = max((len(row) for row in rows), default=0)
+
+			table["rows"] = rows
+			table["bbox"] = [round(float(v), 2) for v in bbox]
+
+			# Keep the user's mapping if the shape is unchanged; otherwise re-detect.
+			if new_columns != old_columns or not table.get("column_mapping"):
+				header_index, score = detect_header_row(rows)
+				if score >= 2:
+					table["header_index"] = header_index
+					table["column_mapping"] = detect_column_mapping(rows[header_index])
+				else:
+					table["header_index"] = None
+					table["column_mapping"] = guess_column_mapping_by_content(rows)
+
+			_finals, table["date_format"], table["amount_format"] = build_table_transactions(table)
+			break
+
+	doc.apply_pdf_tables(tables)
+
+	return get_statement_details(statement_import_id)
+
+
+@frappe.whitelist(methods=["POST"])
+def set_pdf_table_header(statement_import_id: str, page: int, table_index: int, header_index: int):
+	"""
+	Set (or clear) the header row of a PDF table and re-derive its column mapping.
+
+	A ``header_index`` of -1 means the table has NO header row: every row is treated as data
+	and the mapping is guessed from the column contents. Otherwise the given row is the header
+	and the mapping is derived from its labels.
+	"""
+	doc = frappe.get_doc("Bank Statement Import Log", statement_import_id)
+	doc.check_permission("write")
+
+	if doc.status == "Completed":
+		frappe.throw(_("This statement has already been imported."), title=_("Already Imported"))
+
+	page = int(page)
+	table_index = int(table_index)
+	header_index = int(header_index)
+
+	tables = doc.get_pdf_tables()
+	for table in tables:
+		if table["page"] == page and table["table_index"] == table_index:
+			rows = table.get("rows", [])
+			if 0 <= header_index < len(rows):
+				table["header_index"] = header_index
+				table["column_mapping"] = detect_column_mapping(rows[header_index])
+			else:
+				table["header_index"] = None
+				table["column_mapping"] = guess_column_mapping_by_content(rows)
+
+			_finals, table["date_format"], table["amount_format"] = build_table_transactions(table)
+			break
+
+	doc.apply_pdf_tables(tables)
+
+	return get_statement_details(statement_import_id)
 
 
 def check_for_conflicts(bank_account: str, start_date: str, end_date: str):

--- a/erpnext/accounts/doctype/bank_statement_import_log/bank_statement_import_log.py
+++ b/erpnext/accounts/doctype/bank_statement_import_log/bank_statement_import_log.py
@@ -357,7 +357,7 @@ class BankStatementImportLog(Document):
 		pages = {table["page"] for table in tables}
 		page_images = render_pdf_pages(content, password, pages)
 
-		self._pending_page_images = {page: png for page, (png, _scale) in page_images.items()}
+		self.flags._pending_page_images = {page: png for page, (png, _scale) in page_images.items()}
 		page_scales = {page: scale for page, (_png, scale) in page_images.items()}
 
 		for table in tables:
@@ -384,7 +384,7 @@ class BankStatementImportLog(Document):
 	def attach_pdf_page_images(self):
 		"""Persist the rendered page images (rendered in `prepare_pdf_tables`) as private
 		Files attached to this log, and write their URLs back into `pdf_tables`."""
-		pending = getattr(self, "_pending_page_images", None)
+		pending = getattr(self.flags, "_pending_page_images", None)
 		if not pending:
 			return
 
@@ -395,7 +395,7 @@ class BankStatementImportLog(Document):
 			table["page_image"] = page_urls.get(table["page"])
 
 		self.db_set("pdf_tables", json.dumps(tables), update_modified=False)
-		self._pending_page_images = None
+		self.flags._pending_page_images = None
 
 	def save_page_image(self, png_bytes: bytes, page_number: int) -> str:
 		"""Save a rendered page as a private File attached to this log; return its URL."""

--- a/erpnext/accounts/doctype/bank_statement_import_log/bank_statement_import_log.py
+++ b/erpnext/accounts/doctype/bank_statement_import_log/bank_statement_import_log.py
@@ -114,9 +114,15 @@ class BankStatementImportLog(Document):
 
 	def set_file_properties(self, raw_data: list[list]):
 		self.set_header_row_index(raw_data)
-
 		self.set_column_mapping(raw_data)
+		self.recompute_properties(raw_data)
 
+	def recompute_properties(self, raw_data: list[list]):
+		"""
+		Recompute everything that depends on the header row and column mapping: transaction
+		row range, date/amount format, closing balance and totals. Called both during initial
+		detection and after the user overrides the mapping or header row.
+		"""
 		transaction_rows, transaction_starting_index, transaction_ending_index = self.get_transaction_rows(
 			raw_data
 		)
@@ -222,20 +228,50 @@ class BankStatementImportLog(Document):
 		Given the header row, try to map each column index to a standard variable, or set it to "Do not import"
 		"""
 
-		columns = detect_column_mapping(data[self.detected_header_index])
+		self.set_column_mapping_from_columns(detect_column_mapping(data[self.detected_header_index]))
 
+	def set_column_mapping_from_columns(self, columns: list[dict]):
+		"""Replace the column_mapping child table from a list of column dicts."""
 		self.column_mapping = []
 
 		for col in columns:
+			index = col["index"]
+			# header_text is mandatory on the child table; fall back to a readable placeholder
+			# for headerless tables (content-guessed columns) and user overrides.
 			self.append(
 				"column_mapping",
 				{
-					"header_text": col["header_text"],
-					"variable": col["variable"],
-					"maps_to": col["maps_to"],
-					"index": col["index"],
+					"header_text": col.get("header_text") or _("Column {0}").format(index + 1),
+					"variable": col.get("variable") or f"column_{index}",
+					"maps_to": col.get("maps_to", "Do not import"),
+					"index": index,
 				},
 			)
+
+	def apply_column_mapping(self, columns: list[dict]):
+		"""Persist a user-overridden column mapping and recompute the derived properties."""
+		self.set_column_mapping_from_columns(columns)
+		self.recompute_properties(self.get_data())
+
+	def apply_header_index(self, header_index: int):
+		"""
+		Set (or clear, with -1) the header row for a tabular statement.
+
+		The existing column mapping is preserved; it is only re-derived when a header row is
+		selected AND that row resolves to a meaningful mapping. Clearing the header (no header
+		row) never discards the user's mapping.
+		"""
+		raw_data = self.get_data()
+
+		if 0 <= header_index < len(raw_data):
+			self.detected_header_index = header_index
+			candidate = detect_column_mapping(raw_data[header_index])
+			if is_meaningful_mapping(candidate):
+				self.set_column_mapping_from_columns(candidate)
+		else:
+			self.detected_header_index = -1
+
+		self.recompute_properties(raw_data)
 
 	def get_transaction_rows(self, data: list[list[str]]):
 		"""
@@ -637,6 +673,11 @@ def detect_column_mapping(header_row: list) -> list[dict]:
 		columns.append(column)
 
 	return columns
+
+
+def is_meaningful_mapping(columns: list[dict]) -> bool:
+	"""True if at least one column resolves to an actual field (not "Do not import")."""
+	return any(col.get("maps_to") and col["maps_to"] != "Do not import" for col in columns)
 
 
 def guess_column_mapping_by_content(rows: list[list]) -> list[dict]:
@@ -1223,17 +1264,53 @@ def set_pdf_table_header(statement_import_id: str, page: int, table_index: int, 
 	for table in tables:
 		if table["page"] == page and table["table_index"] == table_index:
 			rows = table.get("rows", [])
+			# Preserve the existing mapping; only re-derive when the chosen header row
+			# resolves to a meaningful mapping. Clearing the header keeps the mapping.
 			if 0 <= header_index < len(rows):
 				table["header_index"] = header_index
-				table["column_mapping"] = detect_column_mapping(rows[header_index])
+				candidate = detect_column_mapping(rows[header_index])
+				if is_meaningful_mapping(candidate):
+					table["column_mapping"] = candidate
 			else:
 				table["header_index"] = None
-				table["column_mapping"] = guess_column_mapping_by_content(rows)
 
 			_finals, table["date_format"], table["amount_format"] = build_table_transactions(table)
 			break
 
 	doc.apply_pdf_tables(tables)
+
+	return get_statement_details(statement_import_id)
+
+
+@frappe.whitelist(methods=["POST"])
+def update_column_mapping(statement_import_id: str, column_mapping: list | str):
+	"""Persist a user-overridden column mapping for a tabular (CSV/XLSX) statement."""
+	doc = frappe.get_doc("Bank Statement Import Log", statement_import_id)
+
+	if doc.status == "Completed":
+		frappe.throw(_("This statement has already been imported."), title=_("Already Imported"))
+
+	if isinstance(column_mapping, str):
+		column_mapping = json.loads(column_mapping)
+
+	doc.apply_column_mapping(column_mapping)
+	doc.save()
+
+	return get_statement_details(statement_import_id)
+
+
+@frappe.whitelist(methods=["POST"])
+def set_header_index(statement_import_id: str, header_index: int):
+	"""
+	Set (or clear, with -1) the header row of a tabular statement and re-derive its mapping.
+	"""
+	doc = frappe.get_doc("Bank Statement Import Log", statement_import_id)
+
+	if doc.status == "Completed":
+		frappe.throw(_("This statement has already been imported."), title=_("Already Imported"))
+
+	doc.apply_header_index(int(header_index))
+	doc.save()
 
 	return get_statement_details(statement_import_id)
 

--- a/erpnext/accounts/doctype/bank_statement_import_log/test_bank_statement_import_log.py
+++ b/erpnext/accounts/doctype/bank_statement_import_log/test_bank_statement_import_log.py
@@ -7,7 +7,16 @@ from frappe.utils import getdate
 
 from erpnext.accounts.doctype.bank_statement_import_log.bank_statement_import_log import (
 	BankStatementImportLog,
+	build_table_transactions,
+	detect_column_mapping,
+	detect_header_row,
+	extract_pdf_tables,
 	get_float_amount,
+	get_statement_details,
+	guess_column_mapping_by_content,
+	reextract_pdf_table,
+	set_pdf_table_header,
+	update_pdf_tables,
 )
 from erpnext.accounts.test.accounts_mixin import AccountsTestMixin
 from erpnext.tests.utils import ERPNextTestSuite
@@ -112,6 +121,271 @@ class TestBankStatementImportLog(ERPNextTestSuite, AccountsTestMixin):
 		# Random strings and characters should not throw a ValueError but return None
 		self.assertIsNone(get_float_amount("ABCD"))
 		self.assertIsNone(get_float_amount("****"))
+
+	# ------------------------------------------------------------------ #
+	# PDF statement import
+	# ------------------------------------------------------------------ #
+
+	@staticmethod
+	def _make_pdf(html: str) -> bytes:
+		import pdfkit
+
+		return pdfkit.from_string(html, False)
+
+	@staticmethod
+	def _encrypt(pdf_bytes: bytes, password: str) -> bytes:
+		import io
+
+		from pypdf import PdfReader, PdfWriter
+
+		reader = PdfReader(io.BytesIO(pdf_bytes))
+		writer = PdfWriter()
+		for page in reader.pages:
+			writer.add_page(page)
+		writer.encrypt(password)
+		buffer = io.BytesIO()
+		writer.write(buffer)
+		return buffer.getvalue()
+
+	@staticmethod
+	def _auto_map(table: dict) -> dict:
+		"""Mimic prepare_pdf_tables' best-effort mapping for a single extracted table."""
+		header_index, score = detect_header_row(table["rows"])
+		if score >= 2:
+			table["header_index"] = header_index
+			table["column_mapping"] = detect_column_mapping(table["rows"][header_index])
+		else:
+			table["header_index"] = None
+			table["column_mapping"] = guess_column_mapping_by_content(table["rows"])
+		table["included"] = True
+		return table
+
+	def test_pdf_multi_page_kept_separate_and_unioned(self):
+		"""Tables on separate pages must NOT be merged; transactions are the union."""
+		html = """
+		<html><body>
+		<table border="1"><tr><th>Date</th><th>Narration</th><th>Withdrawal</th><th>Deposit</th><th>Balance</th></tr>
+		<tr><td>01/04/2024</td><td>UPI PAYMENT</td><td>500.00</td><td></td><td>9500.00</td></tr>
+		<tr><td>03/04/2024</td><td>SALARY</td><td></td><td>20000.00</td><td>29500.00</td></tr></table>
+		<div style="page-break-before: always"></div>
+		<table border="1"><tr><th>Date</th><th>Narration</th><th>Withdrawal</th><th>Deposit</th><th>Balance</th></tr>
+		<tr><td>05/04/2024</td><td>ATM WDL</td><td>2000.00</td><td></td><td>27500.00</td></tr></table>
+		</body></html>
+		"""
+		tables = extract_pdf_tables(self._make_pdf(html))
+
+		# Two separate tables, one per page
+		self.assertEqual(len(tables), 2)
+		self.assertEqual(sorted(t["page"] for t in tables), [1, 2])
+		for table in tables:
+			self.assertIn("bbox", table)
+			self.assertEqual(len(table["bbox"]), 4)
+
+		union = []
+		for table in tables:
+			final, _df, _af = build_table_transactions(self._auto_map(table))
+			union.extend(final)
+
+		self.assertEqual(len(union), 3)
+		self.assertEqual(sorted(t["date"] for t in union), ["2024-04-01", "2024-04-03", "2024-04-05"])
+
+	def test_pdf_junk_table_excluded(self):
+		"""A non-transactions table (ad/summary) should yield zero transactions."""
+		ad_table = self._auto_map({"rows": [["Open a new account!", "Call 1800-XYZ"]]})
+		final, _df, _af = build_table_transactions(ad_table)
+		self.assertEqual(final, [])
+
+	def test_headerless_content_mapping(self):
+		"""Without a header row, columns are guessed from their contents."""
+		rows = [
+			["01/04/2024", "UPI PAYMENT", "500.00"],
+			["03/04/2024", "SALARY CREDIT", "20000.00"],
+		]
+		mapping = {
+			c["maps_to"]: c["index"]
+			for c in guess_column_mapping_by_content(rows)
+			if c["maps_to"] != "Do not import"
+		}
+		self.assertEqual(mapping.get("Date"), 0)
+		self.assertEqual(mapping.get("Description"), 1)
+		self.assertEqual(mapping.get("Amount"), 2)
+
+	def test_pdf_password_protected(self):
+		"""Encrypted PDFs error without a password and succeed with the right one."""
+		html = """
+		<html><body><table border="1">
+		<tr><th>Date</th><th>Narration</th><th>Amount</th></tr>
+		<tr><td>01/04/2024</td><td>UPI PAYMENT</td><td>500.00</td></tr></table></body></html>
+		"""
+		encrypted = self._encrypt(self._make_pdf(html), "secret123")
+
+		# No / wrong password -> recognizable error
+		self.assertRaises(frappe.ValidationError, extract_pdf_tables, encrypted)
+		self.assertRaises(frappe.ValidationError, extract_pdf_tables, encrypted, "wrong")
+
+		# Correct password -> extracts
+		tables = extract_pdf_tables(encrypted, "secret123")
+		self.assertTrue(tables)
+
+	def test_pdf_no_tables_detected(self):
+		"""A PDF with no detectable tables raises a clear error (e.g. scanned PDFs)."""
+		html = "<html><body><p>Just some prose with no tabular data at all.</p></body></html>"
+		self.assertRaises(frappe.ValidationError, extract_pdf_tables, self._make_pdf(html))
+
+	def _create_pdf_import_log(self, html: str) -> BankStatementImportLog:
+		pdf_bytes = self._make_pdf(html)
+		file_doc = frappe.get_doc(
+			{
+				"doctype": "File",
+				"file_name": f"test-statement-{frappe.generate_hash(length=8)}.pdf",
+				"is_private": 1,
+				"content": pdf_bytes,
+			}
+		).insert(ignore_permissions=True)
+
+		doc = frappe.get_doc(
+			{
+				"doctype": "Bank Statement Import Log",
+				"name": f"test-pdf-{frappe.generate_hash(length=8)}",
+				"bank_account": self.bank_account,
+				"file": file_doc.file_url,
+			}
+		)
+		return doc.insert()
+
+	def test_pdf_full_lifecycle(self):
+		"""End-to-end doc lifecycle: insert -> rasterize -> preview -> edit -> import."""
+		html = """
+		<html><body>
+		<table border="1"><tr><th>Date</th><th>Narration</th><th>Withdrawal</th><th>Deposit</th><th>Balance</th></tr>
+		<tr><td>01/04/2024</td><td>UPI PAYMENT</td><td>500.00</td><td></td><td>9500.00</td></tr>
+		<tr><td>03/04/2024</td><td>SALARY</td><td></td><td>20000.00</td><td>29500.00</td></tr></table>
+		<div style="page-break-before: always"></div>
+		<table border="1"><tr><th>Date</th><th>Narration</th><th>Withdrawal</th><th>Deposit</th><th>Balance</th></tr>
+		<tr><td>05/04/2024</td><td>ATM WDL</td><td>2000.00</td><td></td><td>27500.00</td></tr></table>
+		</body></html>
+		"""
+		doc = self._create_pdf_import_log(html)
+
+		# before_insert populated the per-table JSON, page images and the union summary
+		tables = doc.get_pdf_tables()
+		self.assertEqual(len(tables), 2)
+		for table in tables:
+			self.assertTrue(table.get("page_image"))
+			self.assertIn("bbox", table)
+			# Page-image File must be attached to the final docname, not the client's temp id
+			attached_to = frappe.db.get_value("File", {"file_url": table["page_image"]}, "attached_to_name")
+			self.assertEqual(attached_to, doc.name)
+		self.assertEqual(doc.number_of_transactions, 3)
+		self.assertEqual(doc.total_debit_transactions, 2)
+		self.assertEqual(doc.total_credit_transactions, 1)
+
+		# get_statement_details returns the union and the per-table data for the editor
+		details = get_statement_details(doc.name)
+		self.assertEqual(len(details["final_transactions"]), 3)
+		self.assertEqual(details["raw_data"], [])
+		self.assertEqual(len(details["pdf_tables"]), 2)
+
+		# Excluding the second table (page 2) drops its single transaction
+		tables[1]["included"] = False
+		update_pdf_tables(doc.name, tables)
+		doc.reload()
+		self.assertEqual(doc.number_of_transactions, 2)
+
+		# Re-include and import; transactions are created for the union
+		tables[1]["included"] = True
+		update_pdf_tables(doc.name, tables)
+		doc.reload()
+		doc.insert_transactions()
+		doc.reload()
+		self.assertEqual(doc.status, "Completed")
+
+		created = frappe.get_all(
+			"Bank Transaction", filters={"bank_account": self.bank_account, "docstatus": 1}
+		)
+		self.assertEqual(len(created), 3)
+
+	def test_pdf_reextract_table_from_bbox(self):
+		"""Re-extracting a table from an adjusted bbox updates its rows and stores the bbox."""
+		html = """
+		<html><body>
+		<table border="1"><tr><th>Date</th><th>Narration</th><th>Amount</th></tr>
+		<tr><td>01/04/2024</td><td>UPI PAYMENT</td><td>500.00</td></tr>
+		<tr><td>03/04/2024</td><td>SALARY</td><td>20000.00</td></tr></table>
+		</body></html>
+		"""
+		doc = self._create_pdf_import_log(html)
+		table = doc.get_pdf_tables()[0]
+		bbox = table["bbox"]
+
+		details = reextract_pdf_table(doc.name, table["page"], table["table_index"], bbox)
+		updated = details["pdf_tables"][0]
+
+		# Same region -> same rows; bbox is persisted
+		self.assertTrue(updated["rows"])
+		self.assertEqual(updated["bbox"], [round(float(v), 2) for v in bbox])
+		self.assertEqual(updated["rows"], table["rows"])
+
+	def test_pdf_reextract_changed_bbox_updates_rows_and_transactions(self):
+		"""Shrinking a table's bbox must drop rows and update the transaction count end-to-end."""
+		html = """
+		<html><body>
+		<table border="1"><tr><th>Date</th><th>Narration</th><th>Amount</th></tr>
+		<tr><td>01/04/2024</td><td>UPI PAYMENT</td><td>500.00</td></tr>
+		<tr><td>03/04/2024</td><td>SALARY</td><td>20000.00</td></tr>
+		<tr><td>05/04/2024</td><td>ATM WDL</td><td>2000.00</td></tr>
+		<tr><td>07/04/2024</td><td>INTEREST</td><td>12.50</td></tr></table>
+		</body></html>
+		"""
+		doc = self._create_pdf_import_log(html)
+		original = doc.get_pdf_tables()[0]
+		original_rows = len(original["rows"])
+		original_txns = doc.number_of_transactions
+
+		# Shrink the box to roughly the top half (simulating a user drag).
+		x0, top, x1, bottom = original["bbox"]
+		shrunk = [x0, top, x1, top + (bottom - top) * 0.5]
+
+		details = reextract_pdf_table(doc.name, original["page"], original["table_index"], shrunk)
+		updated = details["pdf_tables"][0]
+		doc.reload()
+
+		self.assertLess(len(updated["rows"]), original_rows)
+		self.assertLess(doc.number_of_transactions, original_txns)
+		self.assertEqual(len(details["final_transactions"]), doc.number_of_transactions)
+
+	def test_pdf_set_table_header(self):
+		"""User can clear a table's header (no header row) or set a specific header row."""
+		html = """
+		<html><body>
+		<table border="1"><tr><th>Date</th><th>Narration</th><th>Amount</th></tr>
+		<tr><td>01/04/2024</td><td>UPI PAYMENT</td><td>500.00</td></tr>
+		<tr><td>03/04/2024</td><td>SALARY</td><td>20000.00</td></tr></table>
+		</body></html>
+		"""
+		doc = self._create_pdf_import_log(html)
+		table = doc.get_pdf_tables()[0]
+		self.assertEqual(table["header_index"], 0)
+
+		# Mark as headerless (-1): mapping falls back to content-based guessing.
+		details = set_pdf_table_header(doc.name, table["page"], table["table_index"], -1)
+		updated = details["pdf_tables"][0]
+		self.assertIsNone(updated["header_index"])
+		guessed = {
+			c["maps_to"]: c["index"] for c in updated["column_mapping"] if c["maps_to"] != "Do not import"
+		}
+		self.assertEqual(guessed.get("Date"), 0)
+		self.assertEqual(guessed.get("Amount"), 2)
+
+		# Set row 0 back as the header: mapping is re-derived from its labels.
+		details = set_pdf_table_header(doc.name, table["page"], table["table_index"], 0)
+		updated = details["pdf_tables"][0]
+		self.assertEqual(updated["header_index"], 0)
+		mapped = {
+			c["maps_to"]: c["index"] for c in updated["column_mapping"] if c["maps_to"] != "Do not import"
+		}
+		self.assertEqual(mapped.get("Date"), 0)
+		self.assertEqual(mapped.get("Description"), 1)
 
 
 test_hdfc_sample_statement_data = [

--- a/erpnext/accounts/doctype/bank_statement_import_log/test_bank_statement_import_log.py
+++ b/erpnext/accounts/doctype/bank_statement_import_log/test_bank_statement_import_log.py
@@ -15,7 +15,9 @@ from erpnext.accounts.doctype.bank_statement_import_log.bank_statement_import_lo
 	get_statement_details,
 	guess_column_mapping_by_content,
 	reextract_pdf_table,
+	set_header_index,
 	set_pdf_table_header,
+	update_column_mapping,
 	update_pdf_tables,
 )
 from erpnext.accounts.test.accounts_mixin import AccountsTestMixin
@@ -366,18 +368,20 @@ class TestBankStatementImportLog(ERPNextTestSuite, AccountsTestMixin):
 		doc = self._create_pdf_import_log(html)
 		table = doc.get_pdf_tables()[0]
 		self.assertEqual(table["header_index"], 0)
+		original = {
+			c["maps_to"]: c["index"] for c in table["column_mapping"] if c["maps_to"] != "Do not import"
+		}
 
-		# Mark as headerless (-1): mapping falls back to content-based guessing.
+		# Clear the header (-1): header is removed but the mapping is preserved (not re-guessed).
 		details = set_pdf_table_header(doc.name, table["page"], table["table_index"], -1)
 		updated = details["pdf_tables"][0]
 		self.assertIsNone(updated["header_index"])
-		guessed = {
+		preserved = {
 			c["maps_to"]: c["index"] for c in updated["column_mapping"] if c["maps_to"] != "Do not import"
 		}
-		self.assertEqual(guessed.get("Date"), 0)
-		self.assertEqual(guessed.get("Amount"), 2)
+		self.assertEqual(preserved, original)
 
-		# Set row 0 back as the header: mapping is re-derived from its labels.
+		# Set row 0 back as the header: it resolves meaningfully, so mapping is re-derived.
 		details = set_pdf_table_header(doc.name, table["page"], table["table_index"], 0)
 		updated = details["pdf_tables"][0]
 		self.assertEqual(updated["header_index"], 0)
@@ -386,6 +390,79 @@ class TestBankStatementImportLog(ERPNextTestSuite, AccountsTestMixin):
 		}
 		self.assertEqual(mapped.get("Date"), 0)
 		self.assertEqual(mapped.get("Description"), 1)
+
+	# ------------------------------------------------------------------ #
+	# CSV/XLSX column mapping + header overrides
+	# ------------------------------------------------------------------ #
+
+	def _create_csv_import_log(self, csv_text: str) -> BankStatementImportLog:
+		file_doc = frappe.get_doc(
+			{
+				"doctype": "File",
+				"file_name": f"test-statement-{frappe.generate_hash(length=8)}.csv",
+				"is_private": 1,
+				"content": csv_text,
+			}
+		).insert(ignore_permissions=True)
+
+		doc = frappe.get_doc(
+			{
+				"doctype": "Bank Statement Import Log",
+				"bank_account": self.bank_account,
+				"file": file_doc.file_url,
+			}
+		)
+		return doc.insert()
+
+	def test_csv_update_column_mapping(self):
+		"""Overriding the column mapping recomputes the transaction count."""
+		csv_text = "Date,Narration,Amount\n01/04/2024,UPI PAYMENT,500.00\n03/04/2024,SALARY,20000.00\n"
+		doc = self._create_csv_import_log(csv_text)
+		self.assertEqual(doc.number_of_transactions, 2)
+
+		# Drop the amount column -> no amount -> no transactions detected.
+		mapping = [
+			{"index": c.index, "maps_to": "Do not import" if c.maps_to == "Amount" else c.maps_to}
+			for c in doc.column_mapping
+		]
+		details = update_column_mapping(doc.name, mapping)
+		doc.reload()
+		self.assertEqual(doc.number_of_transactions, 0)
+		self.assertEqual(len(details["final_transactions"]), 0)
+
+	def test_csv_set_header_index_preserves_mapping(self):
+		"""Clearing the header keeps the user's mapping; it is not re-guessed."""
+		csv_text = "Date,Narration,Amount\n01/04/2024,UPI PAYMENT,500.00\n03/04/2024,SALARY,20000.00\n"
+		doc = self._create_csv_import_log(csv_text)
+		self.assertEqual(doc.detected_header_index, 0)
+
+		# Manually map the Narration column (1) as Reference.
+		mapping = [
+			{
+				"index": c.index,
+				"maps_to": "Reference" if c.index == 1 else c.maps_to,
+				"header_text": c.header_text,
+			}
+			for c in doc.column_mapping
+		]
+		update_column_mapping(doc.name, mapping)
+		doc.reload()
+
+		# Clear the header row: the manual mapping must be preserved (column 1 stays Reference,
+		# not re-guessed to Description). The label row fails date parsing, so 2 transactions remain.
+		set_header_index(doc.name, -1)
+		doc.reload()
+		self.assertEqual(doc.detected_header_index, -1)
+		self.assertEqual(doc.number_of_transactions, 2)
+		current = {c.index: c.maps_to for c in doc.column_mapping}
+		self.assertEqual(current.get(1), "Reference")
+
+		# Restore row 0 as the header (resolves meaningfully -> re-derived from labels).
+		set_header_index(doc.name, 0)
+		doc.reload()
+		self.assertEqual(doc.detected_header_index, 0)
+		restored = {c.maps_to: c.index for c in doc.column_mapping if c.maps_to != "Do not import"}
+		self.assertEqual(restored.get("Description"), 1)
 
 
 test_hdfc_sample_statement_data = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,11 @@ dependencies = [
 
     # MT940 parser for bank statements
     "mt-940>=4.26.0",
+
+    # PDF bank statement table extraction + page rasterization.
+    # Pulls pdfminer.six (parsing), Pillow, and pypdfium2 (render backend for
+    # Page.to_image) - all pure-Python wheels, no system binaries required.
+    "pdfplumber>=0.11.0",
 ]
 
 [build-system]


### PR DESCRIPTION
This PR adds the ability to upload bank statements in PDF format. PDFs which have actual "text" data (images/scans won't work) can be uploaded to the banking module and the tables are auto-detected. Users can also drag tables and resize them if the detection is inaccurate over a preview of the uploaded PDF.

Once done, the existing logic for mapping columns kicks in for each detected table in the statement and transactions can then be imported. Password protected PDFs also work.

This PR also adds the ability to override the default column mapping that the system suggests - this works for both CSV/Excel imports as well as PDFs.


https://github.com/user-attachments/assets/6b74b0e7-b1dd-415d-b6bc-8bd67db336d9

`no-docs`

