### PR TITLE
fix(item): format integer numeric variant attributes without decimals

### DIFF
--- a/erpnext/stock/doctype/item/item.js
+++ b/erpnext/stock/doctype/item/item.js
@@ -935,11 +935,17 @@ $.extend(erpnext.item, {
 
 			if (!row.disabled) {
 				if (row.numeric_values) {
-					fieldtype = "Float";
+					const all_are_int =
+						flt(row.from_range) === cint(row.from_range) &&
+						flt(row.to_range) === cint(row.to_range) &&
+						flt(row.increment) === cint(row.increment);
+					fieldtype = all_are_int ? "Int" : "Float";
+					const df = { fieldtype };
+					const options = all_are_int ? { inline: 1 } : { always_show_decimals: true, inline: 1 };
 					desc = __("Min Value: {0}, Max Value: {1}, in Increments of: {2}", [
-						frappe.format(row.from_range, { fieldtype: "Float" }, { always_show_decimals: true }),
-						frappe.format(row.to_range, { fieldtype: "Float" }, { always_show_decimals: true }),
-						frappe.format(row.increment, { fieldtype: "Float" }, { always_show_decimals: true }),
+						frappe.format(row.from_range, df, options),
+						frappe.format(row.to_range, df, options),
+						frappe.format(row.increment, df, options),
 					]);
 				} else {
 					fieldtype = "Data";


### PR DESCRIPTION
- Show integer numeric variant attributes (min, max, increment) without forced decimals in the "Create Variant" dialog
- Use `Int` fieldtype for the input when all range values are whole numbers

### Before
<img width="575" height="551" alt="Bildschirmfoto 2026-06-02 um 22 36 59" src="https://github.com/user-attachments/assets/cdaa4877-1511-437d-a00e-ec34ebd68812" />


### After
<img width="575" height="343" alt="Bildschirmfoto 2026-06-02 um 22 35 55" src="https://github.com/user-attachments/assets/38301cc6-36cc-409b-8898-c13f0da0046b" />

