### PR TITLE
fix(selling): consider delivered qty

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.js
+++ b/erpnext/selling/doctype/sales_order/sales_order.js
@@ -27,7 +27,7 @@ frappe.ui.form.on("Sales Order", {
 			let color;
 			if (!doc.qty && frm.doc.has_unit_price_items) {
 				color = "yellow";
-			} else if (doc.stock_qty <= doc.actual_qty) {
+			} else if (doc.stock_qty - doc.delivered_qty <= doc.actual_qty) {
 				color = "green";
 			} else {
 				color = "orange";


### PR DESCRIPTION
Description: 
Previously, the stock availability indicator validation did not consider the delivered quantity and compared the actual quantity directly with the total stock quantity. Due to this, partially delivered sales order items were incorrectly shown with an orange indicator even when sufficient stock was available. Now, the validation logic has been updated to consider the remaining quantity after delivery to display the correct stock status indicator.


Ref: [#69121](https://support.frappe.io/helpdesk/tickets/69121)

Before: 

[Screencast from 2026-06-03 15-52-08.webm](https://github.com/user-attachments/assets/76859c22-24b7-4939-8a70-5b7467896e0a)

After:

[Screencast from 2026-06-03 15-56-19.webm](https://github.com/user-attachments/assets/5119ffe2-1ad4-4886-a59b-ab8f30036500)

Backport Needed For V16 and V15