### PR TITLE
fix: spelling of Payment Reconciliation in sidebar

### DIFF
--- a/erpnext/locale/ar.po
+++ b/erpnext/locale/ar.po
@@ -35902,7 +35902,7 @@ msgstr "تم استلام الدفعة"
 
 #. Label of a Workspace Sidebar Item
 #: erpnext/workspace_sidebar/invoicing.json
-msgid "Payment Reconciliaition"
+msgid "Payment Reconciliation"
 msgstr ""
 
 #. Name of a DocType

--- a/erpnext/locale/bs.po
+++ b/erpnext/locale/bs.po
@@ -36018,7 +36018,7 @@ msgstr "Plaćanje Primljeno"
 
 #. Label of a Workspace Sidebar Item
 #: erpnext/workspace_sidebar/invoicing.json
-msgid "Payment Reconciliaition"
+msgid "Payment Reconciliation"
 msgstr "Usklađivanje Plaćanja"
 
 #. Name of a DocType

--- a/erpnext/locale/cs.po
+++ b/erpnext/locale/cs.po
@@ -35899,7 +35899,7 @@ msgstr ""
 
 #. Label of a Workspace Sidebar Item
 #: erpnext/workspace_sidebar/invoicing.json
-msgid "Payment Reconciliaition"
+msgid "Payment Reconciliation"
 msgstr ""
 
 #. Name of a DocType

--- a/erpnext/locale/da.po
+++ b/erpnext/locale/da.po
@@ -35895,7 +35895,7 @@ msgstr ""
 
 #. Label of a Workspace Sidebar Item
 #: erpnext/workspace_sidebar/invoicing.json
-msgid "Payment Reconciliaition"
+msgid "Payment Reconciliation"
 msgstr ""
 
 #. Name of a DocType

--- a/erpnext/locale/de.po
+++ b/erpnext/locale/de.po
@@ -36020,7 +36020,7 @@ msgstr "Zahlung erhalten"
 
 #. Label of a Workspace Sidebar Item
 #: erpnext/workspace_sidebar/invoicing.json
-msgid "Payment Reconciliaition"
+msgid "Payment Reconciliation"
 msgstr "Zahlungsabgleich"
 
 #. Name of a DocType

--- a/erpnext/locale/eo.po
+++ b/erpnext/locale/eo.po
@@ -35895,7 +35895,7 @@ msgstr "crwdns78710:0crwdne78710:0"
 
 #. Label of a Workspace Sidebar Item
 #: erpnext/workspace_sidebar/invoicing.json
-msgid "Payment Reconciliaition"
+msgid "Payment Reconciliation"
 msgstr "crwdns195880:0crwdne195880:0"
 
 #. Name of a DocType

--- a/erpnext/locale/es.po
+++ b/erpnext/locale/es.po
@@ -36012,7 +36012,7 @@ msgstr "Pago recibido"
 
 #. Label of a Workspace Sidebar Item
 #: erpnext/workspace_sidebar/invoicing.json
-msgid "Payment Reconciliaition"
+msgid "Payment Reconciliation"
 msgstr ""
 
 #. Name of a DocType

--- a/erpnext/locale/fa.po
+++ b/erpnext/locale/fa.po
@@ -35916,7 +35916,7 @@ msgstr "پرداخت دریافت شد"
 
 #. Label of a Workspace Sidebar Item
 #: erpnext/workspace_sidebar/invoicing.json
-msgid "Payment Reconciliaition"
+msgid "Payment Reconciliation"
 msgstr ""
 
 #. Name of a DocType

--- a/erpnext/locale/fr.po
+++ b/erpnext/locale/fr.po
@@ -35924,7 +35924,7 @@ msgstr "Paiement reçu"
 
 #. Label of a Workspace Sidebar Item
 #: erpnext/workspace_sidebar/invoicing.json
-msgid "Payment Reconciliaition"
+msgid "Payment Reconciliation"
 msgstr ""
 
 #. Name of a DocType

--- a/erpnext/locale/hr.po
+++ b/erpnext/locale/hr.po
@@ -36018,7 +36018,7 @@ msgstr "Plaćanje Primljeno"
 
 #. Label of a Workspace Sidebar Item
 #: erpnext/workspace_sidebar/invoicing.json
-msgid "Payment Reconciliaition"
+msgid "Payment Reconciliation"
 msgstr "Usklađivanje Plaćanja"
 
 #. Name of a DocType

--- a/erpnext/locale/hu.po
+++ b/erpnext/locale/hu.po
@@ -35899,7 +35899,7 @@ msgstr ""
 
 #. Label of a Workspace Sidebar Item
 #: erpnext/workspace_sidebar/invoicing.json
-msgid "Payment Reconciliaition"
+msgid "Payment Reconciliation"
 msgstr ""
 
 #. Name of a DocType

--- a/erpnext/locale/id.po
+++ b/erpnext/locale/id.po
@@ -35994,7 +35994,7 @@ msgstr "Pembayaran diterima"
 
 #. Label of a Workspace Sidebar Item
 #: erpnext/workspace_sidebar/invoicing.json
-msgid "Payment Reconciliaition"
+msgid "Payment Reconciliation"
 msgstr ""
 
 #. Name of a DocType

--- a/erpnext/locale/it.po
+++ b/erpnext/locale/it.po
@@ -35908,7 +35908,7 @@ msgstr ""
 
 #. Label of a Workspace Sidebar Item
 #: erpnext/workspace_sidebar/invoicing.json
-msgid "Payment Reconciliaition"
+msgid "Payment Reconciliation"
 msgstr ""
 
 #. Name of a DocType

--- a/erpnext/locale/ko.po
+++ b/erpnext/locale/ko.po
@@ -35926,7 +35926,7 @@ msgstr "결제 완료"
 
 #. Label of a Workspace Sidebar Item
 #: erpnext/workspace_sidebar/invoicing.json
-msgid "Payment Reconciliaition"
+msgid "Payment Reconciliation"
 msgstr "지불 대조"
 
 #. Name of a DocType

--- a/erpnext/locale/main.pot
+++ b/erpnext/locale/main.pot
@@ -35958,7 +35958,7 @@ msgstr ""
 
 #. Label of a Workspace Sidebar Item
 #: erpnext/workspace_sidebar/invoicing.json
-msgid "Payment Reconciliaition"
+msgid "Payment Reconciliation"
 msgstr ""
 
 #. Name of a DocType

--- a/erpnext/locale/my.po
+++ b/erpnext/locale/my.po
@@ -35897,7 +35897,7 @@ msgstr ""
 
 #. Label of a Workspace Sidebar Item
 #: erpnext/workspace_sidebar/invoicing.json
-msgid "Payment Reconciliaition"
+msgid "Payment Reconciliation"
 msgstr ""
 
 #. Name of a DocType

--- a/erpnext/locale/nb.po
+++ b/erpnext/locale/nb.po
@@ -36000,7 +36000,7 @@ msgstr ""
 
 #. Label of a Workspace Sidebar Item
 #: erpnext/workspace_sidebar/invoicing.json
-msgid "Payment Reconciliaition"
+msgid "Payment Reconciliation"
 msgstr ""
 
 #. Name of a DocType

--- a/erpnext/locale/nl.po
+++ b/erpnext/locale/nl.po
@@ -36015,7 +36015,7 @@ msgstr "Betaling ontvangen"
 
 #. Label of a Workspace Sidebar Item
 #: erpnext/workspace_sidebar/invoicing.json
-msgid "Payment Reconciliaition"
+msgid "Payment Reconciliation"
 msgstr ""
 
 #. Name of a DocType

--- a/erpnext/locale/pl.po
+++ b/erpnext/locale/pl.po
@@ -35948,7 +35948,7 @@ msgstr ""
 
 #. Label of a Workspace Sidebar Item
 #: erpnext/workspace_sidebar/invoicing.json
-msgid "Payment Reconciliaition"
+msgid "Payment Reconciliation"
 msgstr ""
 
 #. Name of a DocType

--- a/erpnext/locale/pt.po
+++ b/erpnext/locale/pt.po
@@ -35899,7 +35899,7 @@ msgstr ""
 
 #. Label of a Workspace Sidebar Item
 #: erpnext/workspace_sidebar/invoicing.json
-msgid "Payment Reconciliaition"
+msgid "Payment Reconciliation"
 msgstr ""
 
 #. Name of a DocType

--- a/erpnext/locale/pt_BR.po
+++ b/erpnext/locale/pt_BR.po
@@ -35899,7 +35899,7 @@ msgstr "Pagamento Recebido"
 
 #. Label of a Workspace Sidebar Item
 #: erpnext/workspace_sidebar/invoicing.json
-msgid "Payment Reconciliaition"
+msgid "Payment Reconciliation"
 msgstr ""
 
 #. Name of a DocType

--- a/erpnext/locale/ru.po
+++ b/erpnext/locale/ru.po
@@ -36018,7 +36018,7 @@ msgstr "Платеж получен"
 
 #. Label of a Workspace Sidebar Item
 #: erpnext/workspace_sidebar/invoicing.json
-msgid "Payment Reconciliaition"
+msgid "Payment Reconciliation"
 msgstr "Сверка платежей"
 
 #. Name of a DocType

--- a/erpnext/locale/sl.po
+++ b/erpnext/locale/sl.po
@@ -35991,7 +35991,7 @@ msgstr ""
 
 #. Label of a Workspace Sidebar Item
 #: erpnext/workspace_sidebar/invoicing.json
-msgid "Payment Reconciliaition"
+msgid "Payment Reconciliation"
 msgstr ""
 
 #. Name of a DocType

--- a/erpnext/locale/sr.po
+++ b/erpnext/locale/sr.po
@@ -36020,7 +36020,7 @@ msgstr "Плаћање примљено"
 
 #. Label of a Workspace Sidebar Item
 #: erpnext/workspace_sidebar/invoicing.json
-msgid "Payment Reconciliaition"
+msgid "Payment Reconciliation"
 msgstr "Усклађивање плаћања"
 
 #. Name of a DocType

--- a/erpnext/locale/sr_CS.po
+++ b/erpnext/locale/sr_CS.po
@@ -36020,7 +36020,7 @@ msgstr "Plaćanje primljeno"
 
 #. Label of a Workspace Sidebar Item
 #: erpnext/workspace_sidebar/invoicing.json
-msgid "Payment Reconciliaition"
+msgid "Payment Reconciliation"
 msgstr "Usklađivanje plaćanja"
 
 #. Name of a DocType

--- a/erpnext/locale/sv.po
+++ b/erpnext/locale/sv.po
@@ -36023,7 +36023,7 @@ msgstr "Betalning Mottagen"
 
 #. Label of a Workspace Sidebar Item
 #: erpnext/workspace_sidebar/invoicing.json
-msgid "Payment Reconciliaition"
+msgid "Payment Reconciliation"
 msgstr "Betalning Avstämning"
 
 #. Name of a DocType

--- a/erpnext/locale/th.po
+++ b/erpnext/locale/th.po
@@ -36014,7 +36014,7 @@ msgstr "ได้รับการชำระเงิน"
 
 #. Label of a Workspace Sidebar Item
 #: erpnext/workspace_sidebar/invoicing.json
-msgid "Payment Reconciliaition"
+msgid "Payment Reconciliation"
 msgstr ""
 
 #. Name of a DocType

--- a/erpnext/locale/tr.po
+++ b/erpnext/locale/tr.po
@@ -36009,7 +36009,7 @@ msgstr "Ödeme Alındı"
 
 #. Label of a Workspace Sidebar Item
 #: erpnext/workspace_sidebar/invoicing.json
-msgid "Payment Reconciliaition"
+msgid "Payment Reconciliation"
 msgstr ""
 
 #. Name of a DocType

--- a/erpnext/locale/vi.po
+++ b/erpnext/locale/vi.po
@@ -35965,7 +35965,7 @@ msgstr "Đã nhận thanh toán"
 
 #. Label of a Workspace Sidebar Item
 #: erpnext/workspace_sidebar/invoicing.json
-msgid "Payment Reconciliaition"
+msgid "Payment Reconciliation"
 msgstr "Đối soát thanh toán"
 
 #. Name of a DocType

--- a/erpnext/locale/zh.po
+++ b/erpnext/locale/zh.po
@@ -36006,7 +36006,7 @@ msgstr "已收付款"
 
 #. Label of a Workspace Sidebar Item
 #: erpnext/workspace_sidebar/invoicing.json
-msgid "Payment Reconciliaition"
+msgid "Payment Reconciliation"
 msgstr ""
 
 #. Name of a DocType

--- a/erpnext/workspace_sidebar/invoicing.json
+++ b/erpnext/workspace_sidebar/invoicing.json
@@ -218,7 +218,7 @@
    "collapsible": 1,
    "indent": 0,
    "keep_closed": 0,
-   "label": "Payment Reconciliaition",
+   "label": "Payment Reconciliation",
    "link_to": "Payment Reconciliation",
    "link_type": "DocType",
    "show_arrow": 0,
@@ -325,7 +325,7 @@
    "type": "Link"
   }
  ],
- "modified": "2026-02-23 19:50:17.815817",
+ "modified": "2026-06-03 19:50:17.815817",
  "modified_by": "Administrator",
  "module": "Accounts",
  "module_onboarding": "Accounting Onboarding",


### PR DESCRIPTION
`no-docs`
