### PR TITLE
fix: prevent selling items from sample retention warehouse

### DIFF
--- a/erpnext/controllers/selling_controller.py
+++ b/erpnext/controllers/selling_controller.py
@@ -70,6 +70,7 @@ class SellingController(StockController):
 		self.validate_for_duplicate_items()
 		self.validate_target_warehouse()
 		self.validate_auto_repeat_subscription_dates()
+		self.validate_sample_retention_warehouse()
 		for table_field in ["items", "packed_items"]:
 			if self.get(table_field):
 				self.set_serial_and_batch_bundle(table_field)
@@ -890,6 +891,26 @@ class SellingController(StockController):
 		from erpnext.controllers.buying_controller import validate_item_type
 
 		validate_item_type(self, "is_sales_item", "sales")
+
+	def validate_sample_retention_warehouse(self):
+		if self.get("is_return"):
+			return
+
+		sample_retention_warehouse = frappe.db.get_single_value(
+			"Stock Settings", "sample_retention_warehouse"
+		)
+		if not sample_retention_warehouse:
+			return
+
+		items = self.get("items") + (self.get("packed_items"))
+		for item in items:
+			if item.get("warehouse") == sample_retention_warehouse:
+				frappe.throw(
+					_("Row {0}: Cannot sell item {1} from Sample Retention Warehouse {2}").format(
+						item.idx, frappe.bold(item.item_code), frappe.bold(sample_retention_warehouse)
+					),
+					title=_("Not Allowed"),
+				)
 
 	def update_stock_reservation_entries(self) -> None:
 		"""Updates Delivered Qty in Stock Reservation Entries."""


### PR DESCRIPTION
**Issue:**

Currently, the system allows selling retained sample stock, which undermines the purpose of sample retention. Sample stock is for retention and testing only and should not be used for outbound sales.

**Step To Reproduce:**

1. Configure a "Sample Retention Warehouse" in Stock Settings.
2. Ensure you have some item quantities retained in this warehouse.
3. Create a Sales Order, Delivery Note, or Sales Invoice.
4. Add the item and select the Sample Retention Warehouse as the source warehouse.
5. Save and Submit. The system successfully submits the transaction, thereby selling the retained sample stock.


**Expected behavior**: 
The system should throw a validation error blocking the transaction if any item is being sourced from the configured Sample Retention Warehouse during a sales workflow.

**Backport Needed For V16 and V15**