### PR TITLE
fix: work order status should be in process if material transfer is skipped (backport #55641 to version-15-hotfix)

### DIFF
--- a/erpnext/manufacturing/doctype/work_order/work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/work_order.py
@@ -406,7 +406,7 @@ class WorkOrder(Document):
 		elif self.docstatus == 1:
 			if status not in ["Closed", "Stopped"]:
 				status = "Not Started"
-				if flt(self.material_transferred_for_manufacturing) > 0:
+				if flt(self.material_transferred_for_manufacturing) > 0 or self.skip_transfer:
 					status = "In Process"
 
 				precision = frappe.get_precision("Work Order", "produced_qty")


### PR DESCRIPTION
Automated backport of #55641 to `version-15-hotfix`.

On `develop` the work order status logic lives in `services/status.py`; on this branch it is inline in `work_order.py::get_status()`. The same change is applied: a work order with `skip_transfer` enabled should be **In Process** rather than **Not Started**.

fixes https://github.com/frappe/erpnext/issues/53108

🤖 Generated with [Claude Code](https://claude.com/claude-code)