### PR TITLE
[codex] Show in-transit status for add-to-transit Stock Entries

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry_list.js
+++ b/erpnext/stock/doctype/stock_entry/stock_entry_list.js
@@ -1,11 +1,13 @@
 frappe.listview_settings["Stock Entry"] = {
 	add_fields: [
-		"`tabStock Entry`.`from_warehouse`",
-		"`tabStock Entry`.`to_warehouse`",
-		"`tabStock Entry`.`purpose`",
-		"`tabStock Entry`.`work_order`",
-		"`tabStock Entry`.`bom_no`",
-		"`tabStock Entry`.`is_return`",
+		"from_warehouse",
+		"to_warehouse",
+		"purpose",
+		"work_order",
+		"bom_no",
+		"is_return",
+		"add_to_transit",
+		"per_transferred",
 	],
 	get_indicator: function (doc) {
 		if (doc.is_return === 1 && doc.purpose === "Material Transfer for Manufacture") {
@@ -16,6 +18,17 @@ frappe.listview_settings["Stock Entry"] = {
 			];
 		} else if (doc.docstatus === 0) {
 			return [__("Draft"), "red", "docstatus,=,0"];
+		} else if (
+			doc.docstatus === 1 &&
+			doc.add_to_transit === 1 &&
+			doc.purpose === "Material Transfer" &&
+			doc.per_transferred < 100
+		) {
+			return [
+				__("In Transit"),
+				"yellow",
+				"docstatus,=,1|add_to_transit,=,1|purpose,=,Material Transfer|per_transferred,<,100",
+			];
 		} else if (doc.purpose === "Send to Warehouse" && doc.per_transferred < 100) {
 			// not delivered & overdue
 			return [__("Goods In Transit"), "grey", "per_transferred,<,100"];

--- a/erpnext/stock/doctype/stock_entry/test_stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/test_stock_entry.py
@@ -234,7 +234,15 @@ class TestStockEntry(ERPNextTestSuite):
 		self.assertEqual(transit_entry.name, end_transit_entry.items[0].against_stock_entry)
 		self.assertEqual(transit_entry.items[0].name, end_transit_entry.items[0].ste_detail)
 
-		# create add to transit
+		transit_entry.reload()
+		self.assertEqual(transit_entry.per_transferred, 0)
+
+		end_transit_entry.to_warehouse = "Test To Warehouse - _TC"
+		end_transit_entry.items[0].t_warehouse = "Test To Warehouse - _TC"
+		end_transit_entry.save().submit()
+
+		transit_entry.reload()
+		self.assertEqual(transit_entry.per_transferred, 100)
 
 	def test_material_receipt_gl_entry(self):
 		company = frappe.db.get_value("Warehouse", "Stores - TCP1", "company")


### PR DESCRIPTION
## Summary

- show submitted Add to Transit Material Transfers as `In Transit` in the Stock Entry list until they are fully received
- include `add_to_transit` and `per_transferred` in the list query so the list indicator can compute and filter that status consistently
- extend the existing Add to Transit test to verify `per_transferred` moves from `0` to `100` after End Transit is submitted

## Issue

Closes #46130

## Validation

- `python -m py_compile erpnext/stock/doctype/stock_entry/stock_entry.py erpnext/stock/doctype/stock_entry/stock_entry_handler/material_transfer.py erpnext/stock/doctype/stock_entry/test_stock_entry.py`
- `git diff --check`
- `bench --site testing run-tests --doctype "Stock Entry" --test test_add_to_transit_entry`