### PR TITLE
fix: bypass project permission check when updating consumed material …

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -434,7 +434,7 @@ class StockEntry(StockController, SubcontractingInwardController):
 		for project in projects:
 			project_doc = frappe.get_doc("Project", project)
 			project_doc.set_consumed_material_cost()
-			project_doc.save()
+			project_doc.save(ignore_permissions=True)
 
 	def validate_item(self):
 		for item in self.get("items"):


### PR DESCRIPTION
Description:
Users with only read and select permissions for the Project DocType were able to select a project in Stock Entry. However, while updating the project consumed material cost during Stock Entry submission, a permission error was thrown because the user did not have write access to the Project document. 

Ref : [#70407](https://support.frappe.io/helpdesk/tickets/70407)

Before: 

<img width="1280" height="641" alt="image" src="https://github.com/user-attachments/assets/a73159cd-1cbd-423c-9458-9f4107163a13" />

After:

<img width="1280" height="641" alt="image" src="https://github.com/user-attachments/assets/29ecc8da-8649-4f5e-a205-b48b7f1dc209" />


Backport Needed For V16 and V15