### PR TITLE
fix: disallow BOM finished good item in secondary items table

### DIFF
--- a/erpnext/manufacturing/doctype/bom/bom.py
+++ b/erpnext/manufacturing/doctype/bom/bom.py
@@ -366,6 +366,13 @@ class BOM(WebsiteGenerator):
 
 	def validate_secondary_items(self):
 		for item in self.secondary_items:
+			if not item.is_legacy and item.item_code == self.item:
+				frappe.throw(
+					_(
+						"Row #{0}: Finished Good Item {1} cannot be added in the Secondary Items table."
+					).format(item.idx, get_link_to_form("Item", item.item_code))
+				)
+
 			if not item.qty:
 				frappe.throw(
 					_("Row #{0}: Quantity should be greater than 0 for {1} Item {2}").format(

--- a/erpnext/manufacturing/doctype/bom/test_bom.py
+++ b/erpnext/manufacturing/doctype/bom/test_bom.py
@@ -445,6 +445,30 @@ class TestBOM(ERPNextTestSuite):
 		self.assertRaises(frappe.ValidationError, bom_doc.submit)
 
 	@timeout
+	def test_fg_item_not_allowed_in_secondary_items(self):
+		fg_item = make_item(properties={"is_stock_item": 1, "valuation_rate": 100}).name
+		rm_item = make_item(properties={"is_stock_item": 1, "valuation_rate": 100}).name
+
+		bom_doc = frappe.new_doc("BOM")
+		bom_doc.item = fg_item
+		bom_doc.quantity = 1
+		bom_doc.company = "_Test Company"
+		bom_doc.currency = "INR"
+		bom_doc.append("items", {"item_code": rm_item, "qty": 1, "rate": 100.0})
+		bom_doc.append(
+			"secondary_items",
+			{
+				"item_code": fg_item,
+				"secondary_item_type": "Additional Finished Good",
+				"qty": 1,
+				"cost_allocation_per": 10,
+			},
+		)
+
+		# FG item of the BOM cannot also be a secondary item
+		self.assertRaises(frappe.ValidationError, bom_doc.save)
+
+	@timeout
 	def test_bom_item_query(self):
 		query = partial(
 			item_query,


### PR DESCRIPTION
## Problem

When an **Additional Finished Good** (or any other secondary item) in a BOM shares the **same Item Code as the main Finished Good** (`BOM.item`), the resulting Stock Entry (Manufacture) ends up with two rows of the same item carrying **different valuation rates** — the main FG row derives its rate from the production run's raw material cost, while the secondary row falls back to the item's existing warehouse valuation rate. This creates inconsistent cost layers in the Stock Ledger and unreliable COGS.

Fixes #55654

## Change

Adds a validation in `BOM.validate_secondary_items()` that throws if a secondary item's `item_code` matches the BOM's finished good item. The FG item should never appear as a secondary output (Co-Product / By-Product / Scrap / Additional Finished Good).

- Legacy rows (`is_legacy`) are exempted so migrated BOMs can still be re-saved, consistent with how `is_legacy` is treated elsewhere in `bom.py`.

## Tests

- Added `test_fg_item_not_allowed_in_secondary_items` asserting a `ValidationError` is raised.
- Existing `test_bom_with_process_loss_item` still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)