### PR TITLE
fix(taxes): add category and add_deduct_tax fields to tax entries

### DIFF
--- a/erpnext/controllers/tests/test_accounts_controller.py
+++ b/erpnext/controllers/tests/test_accounts_controller.py
@@ -988,6 +988,34 @@ class TestAccountsController(ERPNextTestSuite):
 		self.assertEqual(sinv.taxes[0].account_head, "_Test Account Excise Duty - _TC")
 		self.assertEqual(sinv.total_taxes_and_charges, 5)
 
+	@ERPNextTestSuite.change_settings(
+		"Accounts Settings",
+		{"add_taxes_from_item_tax_template": 1, "add_taxes_from_taxes_and_charges_template": 0},
+	)
+	def test_19b_fetch_taxes_from_item_tax_template_purchase_invoice(self):
+		pinv = frappe.new_doc("Purchase Invoice")
+		pinv.supplier = "_Test Supplier"
+		pinv.company = self.company
+		pinv.currency = "INR"
+		item = pinv.append(
+			"items",
+			{
+				"item_code": "_Test Item",
+				"qty": 1,
+				"rate": 50,
+				"item_tax_template": "_Test Account Excise Duty @ 10 - _TC",
+			},
+		)
+
+		item_details = pinv.fetch_item_details(item)
+		pinv.add_taxes_from_item_template(item, item_details)
+
+		self.assertEqual(len(pinv.taxes), 1)
+		tax_row = pinv.taxes[0]
+		self.assertEqual(tax_row.account_head, "_Test Account Excise Duty - _TC")
+		self.assertEqual(tax_row.category, "Total")
+		self.assertEqual(tax_row.add_deduct_tax, "Add")
+
 	def test_20_journal_against_sales_invoice(self):
 		# Invoice in Foreign Currency
 		si = self.create_sales_invoice(qty=1, conversion_rate=80, rate=1)

--- a/erpnext/utilities/transaction_base.py
+++ b/erpnext/utilities/transaction_base.py
@@ -429,7 +429,7 @@ class TransactionBase(StatusUpdater):
 
 				found = [x for x in self.taxes if x.account_head == tax_head]
 				if not found:
-					child_doctype = self._table_fieldnames.get("taxes")
+					child_doctype = self.get_table_field_doctype("taxes")
 					child = frappe.new_doc(child_doctype, parent_doc=self, parentfield="taxes")
 					child.charge_type = "On Net Total"
 					child.account_head = tax_head

--- a/erpnext/utilities/transaction_base.py
+++ b/erpnext/utilities/transaction_base.py
@@ -429,7 +429,12 @@ class TransactionBase(StatusUpdater):
 
 				found = [x for x in self.taxes if x.account_head == tax_head]
 				if not found:
-					self.append("taxes", {"charge_type": "On Net Total", "account_head": tax_head, "rate": 0})
+					child_doctype = self._table_fieldnames.get("taxes")
+					child = frappe.new_doc(child_doctype, parent_doc=self, parentfield="taxes")
+					child.charge_type = "On Net Total"
+					child.account_head = tax_head
+					child.rate = 0
+					self.append("taxes", child)
 
 	def set_rate_based_on_price_list(self, item_obj: object, item_details: dict) -> None:
 		if item_obj.price_list_rate and item_obj.discount_percentage:


### PR DESCRIPTION
Issue: The default values of category and add_deduct_tax are not automatically set if taxes are appended from the Item Tax Template.

Before

https://github.com/user-attachments/assets/722822f9-cbb6-4f94-99d6-503308c5cb9d



After

https://github.com/user-attachments/assets/011a208d-a6f4-45a2-ab9a-2f3f135b8a7b





Frappe Support Issue: https://support.frappe.io/helpdesk/tickets/70324?view=VIEW-HD+Ticket-771