### PR TITLE
fix: show inactive product bundles in item where used

### DIFF
--- a/erpnext/stock/report/item_where_used/item_where_used.py
+++ b/erpnext/stock/report/item_where_used/item_where_used.py
@@ -294,7 +294,7 @@ def get_product_bundle_component_rows(item):
 def get_product_bundle_parent_rows(item):
 	rows = frappe.get_all(
 		"Product Bundle",
-		filters={"new_item_code": item, "is_active": 1, "docstatus": 1},
+		filters={"new_item_code": item, "docstatus": 1},
 		fields=["name", "new_item_code", "is_active", "disabled"],
 		order_by="name asc",
 	)
@@ -463,7 +463,7 @@ def get_product_bundle_map(bundle_names):
 		row.name: row
 		for row in frappe.get_all(
 			"Product Bundle",
-			filters={"name": ["in", bundle_names], "is_active": 1, "docstatus": 1},
+			filters={"name": ["in", bundle_names], "docstatus": 1},
 			fields=["name", "new_item_code", "is_active", "disabled"],
 		)
 	}


### PR DESCRIPTION
## Summary

Updates the Item Where Used report to include submitted Product Bundle versions even when they are no longer active.

The report still requires submitted Product Bundles with `docstatus = 1`, but no longer filters Product Bundle rows by `is_active = 1`. This lets historical bundle versions show up as inactive rows instead of being hidden.

## Validation

- `git diff --check frappe/develop..HEAD`
- `python -m py_compile erpnext/stock/report/item_where_used/item_where_used.py`
- `python -m json.tool erpnext/stock/report/item_where_used/item_where_used.json >/dev/null`
- `node -c erpnext/stock/report/item_where_used/item_where_used.js`
- `bench --site mysite.localhost execute erpnext.stock.report.item_where_used.item_where_used.execute --kwargs "{'filters': {'item': 'Petrol', 'section': 'Where Used'}}"`
- `bench --site mysite.localhost execute erpnext.stock.report.item_where_used.item_where_used.execute --kwargs "{'filters': {'item': 'Service Item 1', 'section': 'References'}}"`
- `uvx semgrep scan --config <frappe-semgrep-rules>/rules --config r/python.lang.correctness erpnext/stock/report/item_where_used erpnext/stock/report/test_reports.py`

Verified `Petrol` now shows Product Bundle `PB-Service Item 1-003` with `is_active = 0`.
