### PR TITLE
fix: set transaction currency on payment entry gl entries

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/services/gl_composer.py
+++ b/erpnext/accounts/doctype/payment_entry/services/gl_composer.py
@@ -34,7 +34,13 @@ class PaymentEntryGLComposer(BaseGLComposer):
 		self.add_deductions_gl_entries(gl_entries)
 		self.add_tax_gl_entries(gl_entries)
 		add_regional_gl_entries(gl_entries, doc)
+		self.set_transaction_currency_and_rate_in_gl_map(gl_entries, doc)
 		return gl_entries
+
+	def set_transaction_currency_and_rate_in_gl_map(self, gl_entries, doc):
+		for gle in gl_entries:
+			gle.setdefault("transaction_currency", doc.transaction_currency)
+			gle.setdefault("transaction_exchange_rate", doc.transaction_exchange_rate)
 
 	def add_party_gl_entries(self, gl_entries):
 		doc = self.doc

--- a/erpnext/accounts/doctype/payment_entry/test_payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/test_payment_entry.py
@@ -1033,14 +1033,17 @@ class TestPaymentEntry(ERPNextTestSuite):
 				gle.credit_in_account_currency,
 				gle.debit_in_transaction_currency,
 				gle.credit_in_transaction_currency,
+				gle.transaction_currency,
+				gle.transaction_exchange_rate,
 			)
 			.orderby(gle.account)
 			.where(gle.voucher_no == payment_entry.name)
 			.run()
 		)
+		# transaction currency/rate come from the paid-from USD account (company currency is INR)
 		expected_gl_entries = (
-			(paid_from, 0.0, 8440.0, 0.0, 100.0, 0.0, 100.0),
-			("_Test Payable USD - _TC", 8440.0, 0.0, 100.0, 0.0, 100.0, 0.0),
+			(paid_from, 0.0, 8440.0, 0.0, 100.0, 0.0, 100.0, "USD", 84.4),
+			("_Test Payable USD - _TC", 8440.0, 0.0, 100.0, 0.0, 100.0, 0.0, "USD", 84.4),
 		)
 		self.assertEqual(gl_entries, expected_gl_entries)
 


### PR DESCRIPTION
Issue:
When "Add Columns in Transaction Currency" is enabled in the General Ledger report, the Debit in Transaction Currency and Credit in Transaction Currency values for Payment Entry transactions are displayed in an incorrect currency. This happens because the transaction currency is not being set properly for Payment Entries.

Ref: [#67727](https://support.frappe.io/helpdesk/tickets/67727)