### PR TITLE
fix(bom): fetch routing operations when Routing is selected

### DIFF
--- a/erpnext/manufacturing/doctype/bom/bom.js
+++ b/erpnext/manufacturing/doctype/bom/bom.js
@@ -175,6 +175,9 @@ frappe.ui.form.on("BOM", {
 	with_operations: function (frm) {
 		frm.set_df_property("fg_based_operating_cost", "hidden", frm.doc.with_operations ? 1 : 0);
 		frm.trigger("toggle_fields_for_semi_finished_goods");
+		if (frm.doc.routing && frm.doc.with_operations && !frm.doc.operations.length) {
+			frm.trigger("routing");
+		}
 	},
 
 	fg_based_operating_cost: function (frm) {
@@ -583,7 +586,7 @@ frappe.ui.form.on("BOM", {
 	},
 
 	routing(frm) {
-		if (frm.doc.routing && frm.doc.with_operations && !frm.doc.operations) {
+		if (frm.doc.routing && frm.doc.with_operations && !frm.doc.operations.length) {
 			frappe.call({
 				doc: frm.doc,
 				method: "get_routing",


### PR DESCRIPTION
## Problem

When selecting a **Routing** on a BOM that has **With Operations** enabled, the operations table from the Routing is never populated.

### Root cause

In `bom.js`, the guard condition in the `routing` field handler was:

```js
if (frm.doc.routing && frm.doc.with_operations && !frm.doc.operations) {
```

`frm.doc.operations` is always an array in Frappe (initialised as `[]`). In JavaScript, `![]` evaluates to `false` because an empty array is truthy, so `get_routing()` was never called even when the operations table was empty.

## Fix

Changed the guard to check the array length:

```js
if (frm.doc.routing && frm.doc.with_operations && !frm.doc.operations.length) {
```

Also wired the same fetch into the `with_operations` handler, so that enabling the checkbox *after* a Routing is already set will populate operations without requiring the user to re-select the Routing.

## Steps to reproduce

1. Open Manufacturing → BOM → New
2. Set item, enable **With Operations**, select a **Routing** with operations defined
3. Operations table stays empty — expected: operations from the Routing appear

## After fix

Selecting a Routing (or enabling With Operations when Routing is already set) immediately calls `get_routing()` and populates the operations table.