### PR TITLE
fix(bom): fetch routing operations when Routing is selected

### DIFF
--- a/erpnext/manufacturing/doctype/bom/bom.js
+++ b/erpnext/manufacturing/doctype/bom/bom.js
@@ -175,6 +175,9 @@ frappe.ui.form.on("BOM", {
 	with_operations: function (frm) {
 		frm.set_df_property("fg_based_operating_cost", "hidden", frm.doc.with_operations ? 1 : 0);
 		frm.trigger("toggle_fields_for_semi_finished_goods");
+		if (frm.doc.routing && frm.doc.with_operations && !frm.doc.operations.length) {
+			frm.trigger("routing");
+		}
 	},
 
 	fg_based_operating_cost: function (frm) {
@@ -583,7 +586,7 @@ frappe.ui.form.on("BOM", {
 	},
 
 	routing(frm) {
-		if (frm.doc.routing && frm.doc.with_operations && !frm.doc.operations) {
+		if (frm.doc.routing && frm.doc.with_operations && !frm.doc.operations.length) {
 			frappe.call({
 				doc: frm.doc,
 				method: "get_routing",


### PR DESCRIPTION
## Problem

When a user selects a **Routing** in BOM (with *With Operations* enabled), the operations table is not populated from the routing master.

**Root cause:** `frm.doc.operations` is always an array in Frappe (never `null`/`undefined`). An empty array `[]` is **truthy** in JavaScript, so the guard `!frm.doc.operations` evaluated to `false` on every call, preventing `get_routing()` from ever firing.

## Fix

- Changed `!frm.doc.operations` → `!frm.doc.operations.length` in the `routing` handler so the fetch triggers when the operations table is empty.
- Also wired the same trigger into the `with_operations` handler, so enabling the checkbox *after* a Routing is already selected will also populate operations (previously required re-selecting the Routing).

## Steps to reproduce (before fix)

1. Create a Routing with some operations.
2. Open a new BOM → enable *With Operations* → select the Routing.
3. **Expected:** Operations table populates from the routing master.
4. **Actual:** Operations table remains empty.

## Testing

After applying the fix, steps 1–3 above correctly populate the operations table. No regressions observed in existing BOM flows.