### PR TITLE
fix(stock): make uom mandatory in item uom table

### DIFF
--- a/erpnext/stock/doctype/uom_conversion_detail/uom_conversion_detail.json
+++ b/erpnext/stock/doctype/uom_conversion_detail/uom_conversion_detail.json
@@ -18,7 +18,8 @@
    "label": "UOM",
    "oldfieldname": "uom",
    "oldfieldtype": "Link",
-   "options": "UOM"
+   "options": "UOM",
+   "reqd": 1
   },
   {
    "fieldname": "conversion_factor",
@@ -37,7 +38,7 @@
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-04-27 02:22:52.652036",
+ "modified": "2026-06-11 23:02:54.800673",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "UOM Conversion Detail",

--- a/erpnext/stock/doctype/uom_conversion_detail/uom_conversion_detail.py
+++ b/erpnext/stock/doctype/uom_conversion_detail/uom_conversion_detail.py
@@ -18,7 +18,7 @@ class UOMConversionDetail(Document):
 		parent: DF.Data
 		parentfield: DF.Data
 		parenttype: DF.Data
-		uom: DF.Link | None
+		uom: DF.Link
 	# end: auto-generated types
 
 	pass


### PR DESCRIPTION
Issue: 
In the Item doctype, under the UOMs child table, users can click "Add Row" and save the Item without selecting any UOM in the newly added row. This results in an empty UOM row being saved, leading to incomplete and invalid data in the UOM table.

Before :

<img width="1856" height="932" alt="image" src="https://github.com/user-attachments/assets/2d6cba93-b503-4792-b549-7ea73b4c5625" />


After:

<img width="1848" height="932" alt="image" src="https://github.com/user-attachments/assets/23f5efc6-32a7-46c6-a6f1-cf21001f90c2" />


Backport Needed for v16 and v15
