### PR TITLE
fix: opportunity creation from contact us page

### DIFF
--- a/erpnext/crm/doctype/crm_settings/crm_settings.json
+++ b/erpnext/crm/doctype/crm_settings/crm_settings.json
@@ -14,6 +14,7 @@
   "opportunity_section",
   "close_opportunity_after_days",
   "column_break_9",
+  "enable_opportunity_creation_from_contact_us",
   "quotation_section",
   "default_valid_till",
   "section_break_13",
@@ -98,15 +99,20 @@
    "fieldname": "update_timestamp_on_new_communication",
    "fieldtype": "Check",
    "label": "Update timestamp on new communication"
+  },
+  {
+   "default": "0",
+   "fieldname": "enable_opportunity_creation_from_contact_us",
+   "fieldtype": "Check",
+   "label": "Enable Opportunity Creation from Contact Us"
   }
  ],
  "grid_page_length": 50,
- "hide_toolbar": 0,
  "icon": "fa fa-cog",
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2026-03-16 13:28:19.573964",
+ "modified": "2026-06-11 23:09:49.750381",
  "modified_by": "Administrator",
  "module": "CRM",
  "name": "CRM Settings",

--- a/erpnext/crm/doctype/crm_settings/crm_settings.py
+++ b/erpnext/crm/doctype/crm_settings/crm_settings.py
@@ -2,6 +2,7 @@
 # For license information, please see license.txt
 
 import frappe
+from frappe import _
 from frappe.model.document import Document
 
 
@@ -20,8 +21,20 @@ class CRMSettings(Document):
 		carry_forward_communication_and_comments: DF.Check
 		close_opportunity_after_days: DF.Int
 		default_valid_till: DF.Data | None
+		enable_opportunity_creation_from_contact_us: DF.Check
 		update_timestamp_on_new_communication: DF.Check
 	# end: auto-generated types
 
 	def validate(self):
 		frappe.db.set_default("campaign_naming_by", self.get("campaign_naming_by", ""))
+		self.validate_enable_opportunity_creation_from_contact_us()
+
+	def validate_enable_opportunity_creation_from_contact_us(self):
+		contact_disabled = frappe.get_single_value("Contact Us Settings", "is_disabled")
+
+		if self.enable_opportunity_creation_from_contact_us and contact_disabled:
+			frappe.throw(
+				_(
+					"Cannot enable Opportunity creation from Contact Us because the Contact Us form is disabled."
+				)
+			)

--- a/erpnext/crm/utils.py
+++ b/erpnext/crm/utils.py
@@ -5,6 +5,11 @@ from frappe.utils import cstr, now, today
 from pypika import functions
 
 
+def disable_opportunity_creation_on_contact_us_disabled(doc, method):
+	if doc.is_disabled:
+		frappe.db.set_single_value("CRM Settings", "enable_opportunity_creation_from_contact_us", 0)
+
+
 def update_lead_phone_numbers(contact, method):
 	if contact.phone_nos:
 		contact_lead = contact.get_link_for("Lead")

--- a/erpnext/hooks.py
+++ b/erpnext/hooks.py
@@ -383,6 +383,9 @@ doc_events = {
 	"Event": {
 		"after_insert": "erpnext.crm.utils.link_events_with_prospect",
 	},
+	"Contact Us Settings": {
+		"on_update": "erpnext.crm.utils.disable_opportunity_creation_on_contact_us_disabled",
+	},
 	"Sales Invoice": {
 		"on_submit": [
 			"erpnext.regional.italy.utils.sales_invoice_on_submit",

--- a/erpnext/templates/utils.py
+++ b/erpnext/templates/utils.py
@@ -7,8 +7,8 @@ from frappe.rate_limiter import rate_limit
 from frappe.utils import escape_html
 
 
-@frappe.whitelist(allow_guest=True)
-@rate_limit(limit=1000, seconds=60 * 60)
+@frappe.whitelist(allow_guest=True, methods=["POST"])
+@rate_limit(limit=10, seconds=3 * 60)
 def send_message(sender: str, message: str, subject: str = "Website Query"):
 	from frappe.www.contact import send_message as website_send_message
 

--- a/erpnext/templates/utils.py
+++ b/erpnext/templates/utils.py
@@ -3,16 +3,26 @@
 
 
 import frappe
+from frappe.rate_limiter import rate_limit
 from frappe.utils import escape_html
 
 
 @frappe.whitelist(allow_guest=True)
+@rate_limit(limit=1000, seconds=60 * 60)
 def send_message(sender: str, message: str, subject: str = "Website Query"):
 	from frappe.www.contact import send_message as website_send_message
 
 	website_send_message(sender, message, subject)
 
 	message = escape_html(message)
+
+	oppotunity_creation = frappe.get_single_value(
+		"CRM Settings", "enable_opportunity_creation_from_contact_us"
+	)
+
+	if not oppotunity_creation:
+		# Meant to silently fail instead of throwing error.
+		return
 
 	lead = customer = None
 	customer = frappe.db.sql(


### PR DESCRIPTION
Changes include:

- Introduced a new configuration on CRM Settings, which will act as a safeguard for Opportunity creation.
- Added a rate_limit on send_message.