### PR TITLE
fix(stock-entry): allow zero qty for secondary item types in manufacture

### DIFF
--- a/erpnext/controllers/stock_controller.py
+++ b/erpnext/controllers/stock_controller.py
@@ -95,6 +95,7 @@ class StockController(AccountsController):
 						or (item.get("incoming_rate") == 0 and self.get("update_stock", 1))
 					)
 					and item.get("allow_zero_valuation_rate") == 0
+					and flt(item.get("qty"))
 					and frappe.get_cached_value("Item", item.item_code, "is_stock_item")
 				):
 					frappe.toast(

--- a/erpnext/stock/doctype/stock_entry/stock_entry.js
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.js
@@ -1035,6 +1035,20 @@ frappe.ui.form.on("Stock Entry Detail", {
 		frm.events.calculate_basic_amount(frm, item);
 	},
 
+	qty(frm, cdt, cdn) {
+		const row = locals[cdt][cdn];
+		const zero_qty_types = ["Co-Product", "By-Product", "Scrap", "Additional Finished Good"];
+		if (flt(row.qty) === 0 && zero_qty_types.includes(row.secondary_item_type)) {
+			frappe.show_alert({
+				message: __(
+					"Row #{0}: Qty for {1} is set to zero. Zero output is allowed for {2} type items.",
+					[row.idx, frappe.bold(row.item_code), row.secondary_item_type]
+				),
+				indicator: "orange",
+			});
+		}
+	},
+
 	uom(doc, cdt, cdn) {
 		var d = locals[cdt][cdn];
 		if (d.uom && d.item_code) {

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -70,6 +70,8 @@ from erpnext.controllers.subcontracting_inward_controller import SubcontractingI
 
 form_grid_templates = {"items": "templates/form_grid/stock_entry_grid.html"}
 
+ZERO_QTY_ALLOWED_ITEM_TYPES = frozenset({"Co-Product", "By-Product", "Scrap", "Additional Finished Good"})
+
 
 class StockEntry(StockController, SubcontractingInwardController):
 	# begin: auto-generated types
@@ -435,6 +437,25 @@ class StockEntry(StockController, SubcontractingInwardController):
 		for row in self.items:
 			row.delink_asset_repair_sabb(self.asset_repair)
 
+	def validate_qty_is_not_zero(self):
+		if self.flags.allow_zero_qty:
+			return
+
+		for item in self.items:
+			if item.get("secondary_item_type") in ZERO_QTY_ALLOWED_ITEM_TYPES:
+				continue
+
+			if not flt(item.qty):
+				from erpnext.controllers.accounts_controller import InvalidQtyError
+
+				frappe.throw(
+					msg=_("Row #{0}: Quantity for Item {1} cannot be zero.").format(
+						item.idx, frappe.bold(item.item_code)
+					),
+					title=_("Invalid Quantity"),
+					exc=InvalidQtyError,
+				)
+
 	def set_transfer_qty(self):
 		self.validate_qty_is_not_zero()
 		for item in self.get("items"):
@@ -575,7 +596,11 @@ class StockEntry(StockController, SubcontractingInwardController):
 			cost_allocation_per = frappe.get_value(
 				"BOM Secondary Item", d.bom_secondary_item, "cost_allocation_per"
 			)
-			d.basic_rate = (outgoing_items_cost * (cost_allocation_per / 100)) / d.transfer_qty
+			d.basic_rate = (
+				(outgoing_items_cost * (cost_allocation_per / 100)) / d.transfer_qty
+				if d.transfer_qty
+				else 0
+			)
 
 		if not d.basic_rate and not d.allow_zero_valuation_rate:
 			d.basic_rate = get_valuation_rate(

--- a/erpnext/stock/doctype/stock_entry_detail/stock_entry_detail.py
+++ b/erpnext/stock/doctype/stock_entry_detail/stock_entry_detail.py
@@ -185,7 +185,12 @@ class StockEntryDetail(Document):
 
 		self.transfer_qty = flt(flt(self.qty) * flt(self.conversion_factor), self.precision("transfer_qty"))
 
-		if not flt(self.transfer_qty):
+		if not flt(self.transfer_qty) and self.secondary_item_type not in (
+			"Co-Product",
+			"By-Product",
+			"Scrap",
+			"Additional Finished Good",
+		):
 			frappe.throw(
 				_("Row {0}: Qty in Stock UOM can not be zero.").format(self.idx), title=_("Zero quantity")
 			)


### PR DESCRIPTION
## Summary

Fixes https://github.com/frappe/erpnext/issues/55401

In a Manufacture stock entry, secondary output items (Co-Product, By-Product, Scrap, Additional Finished Good) do not always guarantee output — their quantity can legitimately be zero. Previously, saving the entry with any of these rows at qty 0 raised an **Invalid Quantity** error (and a **ZeroDivisionError** in rate calculation).

<img width="1986" height="998" alt="zero-qty" src="https://github.com/user-attachments/assets/6a3decb1-cd42-4da6-8876-fa08001bd9e2" />


### Changes

- **`stock_entry.py`** — Overrides `validate_qty_is_not_zero()` to skip rows whose `secondary_item_type` is one of the four secondary types. Guards the `/ d.transfer_qty` division in `set_basic_rate` to return `0` instead of raising `ZeroDivisionError`.
- **`stock_entry_detail.py`** — Skips the `transfer_qty == 0` error in `StockEntryDetail.set_transfer_qty()` for the same secondary item types.
- **`stock_entry.js`** — Adds a `qty` field event handler that shows a non-blocking orange alert when the user manually sets qty to zero for a secondary item type, informing them it is allowed.

### Test plan

- [x] Create a BOM with Co-Product / By-Product / Scrap / Additional Finished Good secondary items
- [x] Create a Work Order and start a Manufacture stock entry
- [x] Set qty to 0 for one or more secondary item rows — save should succeed without errors
- [x] Orange alert appears in the UI when qty is set to 0 for those rows
- [x] Setting qty to 0 for a primary raw material or finished good still raises the validation error
- [x] Valuation / basic rate calculation completes without ZeroDivisionError

🤖 Generated with [Claude Code](https://claude.com/claude-code)