### PR TITLE
fix: remove unnecessary expense head warning for purchase invoices with update stock

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/services/expense_account.py
+++ b/erpnext/accounts/doctype/purchase_invoice/services/expense_account.py
@@ -51,16 +51,6 @@ class ExpenseAccountService:
 				if doc.update_stock and item.warehouse and (not item.from_warehouse):
 					_inv_dict = doc.get_inventory_account_dict(item, inventory_account_map)
 
-					if for_validate and item.expense_account and item.expense_account != _inv_dict["account"]:
-						msg = _(
-							"Row {0}: Expense Head changed to {1} because account {2} is not linked to warehouse {3} or it is not the default inventory account"
-						).format(
-							item.idx,
-							frappe.bold(_inv_dict["account"]),
-							frappe.bold(item.expense_account),
-							frappe.bold(item.warehouse),
-						)
-						frappe.msgprint(msg, title=_("Expense Head Changed"))
 					item.expense_account = _inv_dict["account"]
 				else:
 					# check if 'Stock Received But Not Billed' account is credited in Purchase receipt or not


### PR DESCRIPTION
## Problem

When a Purchase Invoice is created with **Update Stock = 1**, the system displays the following warning popup:

> Row N: Expense Head changed to **Stock In Hand** because account **Cost of Goods Sold** is not linked to warehouse **Stores** or it is not the default inventory account.

This occurs because `ExpenseAccountService.set_expense_account()` calls `frappe.msgprint()` whenever it detects that the item's `expense_account` differs from the resolved inventory account.

## Why This Warning Is Unnecessary

When `update_stock` is enabled on a Purchase Invoice, the system **automatically and intentionally** replaces the expense account with the correct inventory (Stock In Hand) account for perpetual inventory accounting. This is expected, documented behaviour — not an anomaly the user needs to be warned about.

The message:
- Provides no actionable information (the user cannot or should not change the account manually in this flow).
- Confuses users who deliberately enable Update Stock.
- Fires for every line item, creating noise in the UI.

## Fix

Removed the `frappe.msgprint` call inside the `update_stock` branch of `set_expense_account()` in:

```
erpnext/accounts/doctype/purchase_invoice/services/expense_account.py
```

The account substitution logic (`item.expense_account = _inv_dict["account"]`) is **completely unchanged** — only the popup is suppressed.

The two other warning messages in the same method (for the Purchase-Receipt-linked flow and the PI-before-PR flow) are **intentionally preserved** — those inform the user of a less obvious automatic change.

## Changes

- `erpnext/accounts/doctype/purchase_invoice/services/expense_account.py` — removed 10 lines (the `for_validate` guard and `frappe.msgprint` call in the `update_stock` branch)

## Testing

- Existing tests `test_purchase_invoice_update_stock_gl_entry_with_perpetual_inventory` and `test_purchase_invoice_for_is_paid_and_update_stock_gl_entry_with_perpetual_inventory` cover the GL entry correctness for this path and remain unaffected.
- No test previously asserted on the warning message being shown.
- Manually verified: creating a Purchase Invoice with Update Stock enabled no longer shows the warning; the expense account is still correctly set to the inventory account and GL entries are correct.

## Checklist

- [x] Underlying accounting logic unchanged
- [x] Warning suppressed only for the `update_stock` scenario
- [x] Other expense head warnings preserved
- [x] No new tests needed (existing GL tests cover the accounting path)