### PR TITLE
fix: whitelist get_payment_terms api

### DIFF
--- a/erpnext/accounts/services/payment_schedule.py
+++ b/erpnext/accounts/services/payment_schedule.py
@@ -302,6 +302,7 @@ def linked_order_has_payment_schedule(po_or_so) -> list:
 	return frappe.get_all("Payment Schedule", filters={"parent": po_or_so})
 
 
+@frappe.whitelist()
 def get_payment_terms(
 	terms_template: str,
 	posting_date: DateTimeLikeObject | None = None,


### PR DESCRIPTION
Issue: @frappe.whitelist() was removed from API

Regression: https://github.com/frappe/erpnext/pull/55327/changes#diff-70fca67b7fdc9bc43a6957ae13b3a4817eccd4e62b1cd4a1335407dfb4bc945dL3566

```
Traceback (most recent call last):
  File "apps/frappe/frappe/app.py", line 121, in application
    response = frappe.api.handle(request)
  File "apps/frappe/frappe/api/__init__.py", line 63, in handle
    data = endpoint(**arguments)
  File "apps/frappe/frappe/api/v1.py", line 40, in handle_rpc_call
    return frappe.handler.handle()
           ~~~~~~~~~~~~~~~~~~~~~^^
  File "apps/frappe/frappe/handler.py", line 54, in handle
    data = execute_cmd(cmd)
  File "apps/frappe/frappe/handler.py", line 84, in execute_cmd
    is_whitelisted(method)
    ~~~~~~~~~~~~~~^^^^^^^^
  File "apps/frappe/frappe/__init__.py", line 614, in is_whitelisted
    throw(msg, PermissionError, title=_("Method Not Allowed"))
    ~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/utils/messages.py", line 159, in throw
    msgprint(
    ~~~~~~~~^
        msg,
     ^^^^
    ...<7 lines>...
        allow_dangerous_html=allow_dangerous_html,
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "apps/frappe/frappe/utils/messages.py", line 118, in msgprint
    _raise_exception()
    ~~~~~~~~~~~~~~~~^^
  File "apps/frappe/frappe/utils/messages.py", line 59, in _raise_exception
    raise exc
frappe.exceptions.PermissionError: You are not permitted to access this resource. Login to accessFunction erpnext.accounts.services.payment_schedule.get_payment_terms is not whitelisted.
```


https://github.com/user-attachments/assets/fe2c5dbd-9166-4c7c-9e86-60bfb9026189




On behalf of @Abdeali099 