### PR TITLE
fix: pass source cost center to target cost center

### DIFF
--- a/erpnext/controllers/sales_and_purchase_return.py
+++ b/erpnext/controllers/sales_and_purchase_return.py
@@ -598,6 +598,7 @@ def make_return_doc(doctype: str, source_name: str, target_doc=None, return_agai
 			target_doc.so_detail = source_doc.so_detail
 			target_doc.expense_account = source_doc.expense_account
 			target_doc.dn_detail = source_doc.name
+			target_doc.cost_center = source_doc.cost_center
 			if default_warehouse_for_sales_return:
 				target_doc.warehouse = default_warehouse_for_sales_return
 		elif doctype == "Sales Invoice" or doctype == "POS Invoice":


### PR DESCRIPTION
### Issue
When creating a Sales Return from a Delivery Note, the item-level Cost Center from the original Delivery Note is not copied to the returned Delivery Note item. This results in missing Cost Center information in the Sales Return document.

### Fix

Copy the Cost Center from the Delivery Note item to the Sales Return item during return document creation.

This ensures that the Cost Center is preserved when creating a Sales Return against a Delivery Note, maintaining accurate accounting and reporting.

Fixes #55804 