### PR TITLE
fix: remove unnecessary expense head warning for purchase invoices with update stock

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
@@ -483,16 +483,6 @@ class PurchaseInvoice(BuyingController):
 				if self.update_stock and item.warehouse and (not item.from_warehouse):
 					_inv_dict = self.get_inventory_account_dict(item, inventory_account_map)
 
-					if for_validate and item.expense_account and item.expense_account != _inv_dict["account"]:
-						msg = _(
-							"Row {0}: Expense Head changed to {1} because account {2} is not linked to warehouse {3} or it is not the default inventory account"
-						).format(
-							item.idx,
-							frappe.bold(_inv_dict["account"]),
-							frappe.bold(item.expense_account),
-							frappe.bold(item.warehouse),
-						)
-						frappe.msgprint(msg, title=_("Expense Head Changed"))
 					item.expense_account = _inv_dict["account"]
 				else:
 					# check if 'Stock Received But Not Billed' account is credited in Purchase receipt or not


### PR DESCRIPTION
## Backport of #55845 (develop → version-16)

> The file structure differs between branches: in `version-16` the logic is inline in `purchase_invoice.py`; in `develop` it was refactored into `services/expense_account.py`. The fix is identical in intent.

---

## Problem

When a Purchase Invoice is created with **Update Stock = 1**, the system displays the following warning popup:

> Row N: Expense Head changed to **Stock In Hand** because account **Cost of Goods Sold** is not linked to warehouse **Stores** or it is not the default inventory account.

This fires from `set_expense_account()` in `purchase_invoice.py` whenever the item's `expense_account` differs from the resolved inventory account.

## Why This Warning Is Unnecessary

When `update_stock` is enabled on a Purchase Invoice, the system **automatically and intentionally** replaces the expense account with the correct inventory (Stock In Hand) account for perpetual inventory accounting. This is expected, documented behaviour — not an anomaly the user needs to be warned about.

The message:
- Provides no actionable information (the account is set correctly by the system).
- Confuses users who deliberately enable Update Stock.
- Fires for every line item, polluting the UI on every save/validate.

## Fix

Removed the `frappe.msgprint` call inside the `update_stock` branch of `set_expense_account()` in `purchase_invoice.py` (lines 486–495).

The account substitution logic (`item.expense_account = _inv_dict["account"]`) is **completely unchanged** — only the popup is suppressed.

The two other `msgprint` calls (for the Purchase-Receipt-linked flow and the PI-before-PR flow) are **intentionally preserved**.

## Changes

- `erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py` — removed 10 lines (the `for_validate` guard and `frappe.msgprint` in the `update_stock` branch)

## Testing

- Existing tests `test_purchase_invoice_update_stock_gl_entry_with_perpetual_inventory` and `test_purchase_invoice_for_is_paid_and_update_stock_gl_entry_with_perpetual_inventory` cover GL entry correctness for this path.
- No test previously asserted on the warning being shown.
- Account substitution logic is unchanged; all existing stock accounting behaviour is preserved.