### PR TITLE
feat(sales-invoice): add Rate Adjustment Entry (Debit Note) create button

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/mapper.py
+++ b/erpnext/accounts/doctype/sales_invoice/mapper.py
@@ -100,11 +100,17 @@ def make_debit_note(source_name: str, target_doc: Document | None = None):
 		target.return_against = source.name
 		target.ignore_pricing_rule = 1
 		target.run_method("set_missing_values")
+		# Reset rates after set_missing_values since it may re-fetch rates from
+		# linked Delivery Note items or the item master, overriding our zeroing.
+		for item in target.items:
+			item.rate = 0
+			item.price_list_rate = 0
 		target.run_method("calculate_taxes_and_totals")
 
 	def update_item(source_doc, target_doc, source_parent):
 		target_doc.qty = source_doc.qty
 		target_doc.rate = 0
+		target_doc.price_list_rate = 0
 		target_doc.sales_invoice_item = source_doc.name
 
 	return get_mapped_doc(

--- a/erpnext/accounts/doctype/sales_invoice/mapper.py
+++ b/erpnext/accounts/doctype/sales_invoice/mapper.py
@@ -85,6 +85,46 @@ def make_sales_return(source_name: str, target_doc: Document | None = None):
 	return make_return_doc("Sales Invoice", source_name, target_doc)
 
 
+@frappe.whitelist()
+def make_debit_note(source_name: str, target_doc: Document | None = None):
+	"""Create a Rate Adjustment Entry (Debit Note) from a submitted Sales Invoice.
+
+	Copies the original invoice with positive quantities and rate set to 0 so the
+	user can enter the revised rate. Sets ``is_debit_note = 1`` and links back via
+	``return_against``.
+	"""
+
+	def set_missing_values(source, target):
+		target.is_debit_note = 1
+		target.is_return = 0
+		target.return_against = source.name
+		target.ignore_pricing_rule = 1
+		target.run_method("set_missing_values")
+		target.run_method("calculate_taxes_and_totals")
+
+	def update_item(source_doc, target_doc, source_parent):
+		target_doc.qty = source_doc.qty
+		target_doc.rate = 0
+		target_doc.sales_invoice_item = source_doc.name
+
+	return get_mapped_doc(
+		"Sales Invoice",
+		source_name,
+		{
+			"Sales Invoice": {
+				"doctype": "Sales Invoice",
+				"validation": {"docstatus": ["=", 1]},
+			},
+			"Sales Invoice Item": {
+				"doctype": "Sales Invoice Item",
+				"postprocess": update_item,
+			},
+		},
+		target_doc,
+		set_missing_values,
+	)
+
+
 def get_inter_company_details(doc, doctype):
 	if doctype in ["Sales Invoice", "Sales Order", "Delivery Note"]:
 		parties = frappe.db.get_all(

--- a/erpnext/accounts/doctype/sales_invoice/mapper.py
+++ b/erpnext/accounts/doctype/sales_invoice/mapper.py
@@ -97,6 +97,7 @@ def make_debit_note(source_name: str, target_doc: Document | None = None):
 	def set_missing_values(source, target):
 		target.is_debit_note = 1
 		target.is_return = 0
+		target.update_stock = 0
 		target.return_against = source.name
 		target.ignore_pricing_rule = 1
 		target.run_method("set_missing_values")

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
@@ -117,7 +117,7 @@ erpnext.accounts.SalesInvoiceController = class SalesInvoiceController extends (
 
 			if (!doc.is_debit_note) {
 				this.frm.add_custom_button(
-					__("Rate Adjustment Entry (Debit Note)"),
+					__("Rate Adjustment (Debit Note)"),
 					this.make_debit_note.bind(this),
 					__("Create")
 				);

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
@@ -115,6 +115,14 @@ erpnext.accounts.SalesInvoiceController = class SalesInvoiceController extends (
 				this.frm.page.set_inner_btn_group_as_primary(__("Create"));
 			}
 
+			if (!doc.is_debit_note) {
+				this.frm.add_custom_button(
+					__("Rate Adjustment Entry (Debit Note)"),
+					this.make_debit_note.bind(this),
+					__("Create")
+				);
+			}
+
 			if (cint(doc.update_stock) != 1) {
 				if (!is_delivered_by_supplier) {
 					const should_create_delivery_note = doc.items.some(
@@ -601,6 +609,13 @@ erpnext.accounts.SalesInvoiceController = class SalesInvoiceController extends (
 	make_sales_return() {
 		frappe.model.open_mapped_doc({
 			method: "erpnext.accounts.doctype.sales_invoice.mapper.make_sales_return",
+			frm: this.frm,
+		});
+	}
+
+	make_debit_note() {
+		frappe.model.open_mapped_doc({
+			method: "erpnext.accounts.doctype.sales_invoice.mapper.make_debit_note",
 			frm: this.frm,
 		});
 	}


### PR DESCRIPTION
## Problem

There is no shortcut or button to create a **Rate Adjustment Entry (Debit Note)** Sales Invoice. Users currently have to click *Return / Credit Note*, which creates an invoice with negative (minus) quantities and rates — they must then manually remove the minus sign and zero out the rate. This is error-prone and unintuitive.

Closes #55337

## Solution

Adds a dedicated **Rate Adjustment Entry (Debit Note)** button to the **Create** menu on submitted Sales Invoices.

Clicking it opens a new Sales Invoice pre-filled with:
- `is_debit_note = 1` (Is Rate Adjustment Entry (Debit Note) checked)
- `is_return = 0` (positive quantities, not a return)
- `return_against` pointing to the original invoice
- All item quantities copied as-is (positive)
- Item rates set to `0` so the user can enter the revised/adjusted rate
- Pricing rules ignored so the adjusted rate is not overwritten

The button is hidden on docs that are already debit notes to prevent chaining.

## Changes

- **`erpnext/accounts/doctype/sales_invoice/mapper.py`**: new `make_debit_note` whitelisted mapper function using `get_mapped_doc`
- **`erpnext/accounts/doctype/sales_invoice/sales_invoice.js`**: button added to Create group + `make_debit_note()` controller method

## Testing

1. Submit a Sales Invoice
2. Verify **Create → Rate Adjustment Entry (Debit Note)** button appears
3. Click it — confirm the new invoice opens with `Is Rate Adjustment Entry (Debit Note)` checked, positive quantities, rate = 0, and `Return Against` pre-filled
4. Verify the button does **not** appear on an invoice that is already a debit note
5. Verify **Return / Credit Note** still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)