### PR TITLE
feat: Allow to edit stock UOM qty for Stock Entry

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry.js
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.js
@@ -9,6 +9,8 @@ frappe.ui.form.on("Stock Entry", {
 	setup: function (frm) {
 		frm.ignore_doctypes_on_cancel_all = ["Serial and Batch Bundle"];
 
+		frm.trigger("toggle_enable_for_stock_uom_qty");
+
 		frm.set_indicator_formatter("item_code", function (doc) {
 			if (!doc.s_warehouse) {
 				return "blue";
@@ -272,6 +274,20 @@ frappe.ui.form.on("Stock Entry", {
 			method: "set_items_for_stock_in",
 			callback: function () {
 				refresh_field("items");
+			},
+		});
+	},
+
+	toggle_enable_for_stock_uom_qty: function (frm) {
+		frappe.call({
+			method: "erpnext.stock.doctype.stock_settings.stock_settings.get_enable_stock_uom_editing",
+			callback: (r) => {
+				if (r.message) {
+					frm.fields_dict["items"].grid.toggle_enable(
+						"transfer_qty",
+						r.message.allow_to_edit_stock_uom_qty_for_stock_entry
+					);
+				}
 			},
 		});
 	},
@@ -1014,6 +1030,21 @@ frappe.ui.form.on("Stock Entry Detail", {
 
 	conversion_factor(frm, cdt, cdn) {
 		frm.events.set_basic_rate(frm, cdt, cdn);
+	},
+
+	transfer_qty(frm, cdt, cdn) {
+		let item = locals[cdt][cdn];
+		let old_conversion_factor = item.conversion_factor;
+		let conversion_factor = 1.0;
+		if (flt(item.qty) && flt(item.transfer_qty)) {
+			conversion_factor = flt(item.transfer_qty) / flt(item.qty);
+		}
+
+		if (old_conversion_factor !== conversion_factor) {
+			item.conversion_factor = conversion_factor;
+			refresh_field("conversion_factor", item.name, item.parentfield);
+			frm.events.set_basic_rate(frm, cdt, cdn);
+		}
 	},
 
 	s_warehouse(frm, cdt, cdn) {

--- a/erpnext/stock/doctype/stock_settings/stock_settings.json
+++ b/erpnext/stock/doctype/stock_settings/stock_settings.json
@@ -21,6 +21,7 @@
   "stock_uom",
   "allow_to_edit_stock_uom_qty_for_sales",
   "allow_to_edit_stock_uom_qty_for_purchase",
+  "allow_to_edit_stock_uom_qty_for_stock_entry",
   "allow_uom_with_conversion_rate_defined_in_item",
   "warehouse_defaults_section",
   "default_warehouse",
@@ -406,6 +407,13 @@
   },
   {
    "default": "0",
+   "documentation_url": "https://docs.frappe.io/erpnext/stock-settings#why-to-edit-stock-qty-qty-as-per-stock-uom",
+   "fieldname": "allow_to_edit_stock_uom_qty_for_stock_entry",
+   "fieldtype": "Check",
+   "label": "Allow to edit stock UOM qty for Stock Entry"
+  },
+  {
+   "default": "0",
    "depends_on": "eval: doc.enable_stock_reservation",
    "description": "Stock will be reserved on submission of <b>Purchase Receipt</b> created against Material Request for Sales Order.",
    "fieldname": "auto_reserve_stock_for_sales_order_on_purchase",
@@ -594,7 +602,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2026-06-03 12:38:02.202183",
+ "modified": "2026-06-13 12:38:02.202183",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Stock Settings",

--- a/erpnext/stock/doctype/stock_settings/stock_settings.py
+++ b/erpnext/stock/doctype/stock_settings/stock_settings.py
@@ -31,6 +31,7 @@ class StockSettings(Document):
 		allow_partial_reservation: DF.Check
 		allow_to_edit_stock_uom_qty_for_purchase: DF.Check
 		allow_to_edit_stock_uom_qty_for_sales: DF.Check
+		allow_to_edit_stock_uom_qty_for_stock_entry: DF.Check
 		allow_to_make_quality_inspection_after_purchase_or_delivery: DF.Check
 		allow_uom_with_conversion_rate_defined_in_item: DF.Check
 		auto_create_serial_and_batch_bundle_for_outward: DF.Check
@@ -111,6 +112,7 @@ class StockSettings(Document):
 		self.validate_auto_insert_price_list_rate_if_missing()
 		self.change_precision_for_for_sales()
 		self.change_precision_for_purchase()
+		self.change_precision_for_stock_entry()
 		self.validate_do_not_use_batchwise_valuation()
 
 	def validate_do_not_use_batchwise_valuation(self):
@@ -289,6 +291,18 @@ class StockSettings(Document):
 			]
 			self.make_property_setter_for_precision(doctypes)
 
+	def change_precision_for_stock_entry(self):
+		doc_before_save = self.get_doc_before_save()
+		if doc_before_save and (
+			doc_before_save.allow_to_edit_stock_uom_qty_for_stock_entry
+			== self.allow_to_edit_stock_uom_qty_for_stock_entry
+		):
+			return
+
+		if self.allow_to_edit_stock_uom_qty_for_stock_entry:
+			doctypes = ["Stock Entry Detail"]
+			self.make_property_setter_for_precision(doctypes)
+
 	@staticmethod
 	def make_property_setter_for_precision(doctypes):
 		for doctype in doctypes:
@@ -321,6 +335,10 @@ def clean_all_descriptions():
 def get_enable_stock_uom_editing():
 	return frappe.get_single_value(
 		"Stock Settings",
-		["allow_to_edit_stock_uom_qty_for_sales", "allow_to_edit_stock_uom_qty_for_purchase"],
+		[
+			"allow_to_edit_stock_uom_qty_for_sales",
+			"allow_to_edit_stock_uom_qty_for_purchase",
+			"allow_to_edit_stock_uom_qty_for_stock_entry",
+		],
 		as_dict=1,
 	)


### PR DESCRIPTION
By default the qty-in-stock-UOM field is read-only and is always derived from `qty × conversion_factor`. The user controls it indirectly by changing `qty` or `conversion_factor`.

These settings let the user **edit the qty-in-stock-UOM field directly**. When the user types a value, the system back computes the conversion factor so the edited value is preserved:

```
conversion_factor = qty (in stock UOM) ÷ qty (in transaction UOM)
```

Why to edit?
If you're using multi-uom and your stock uom is a whole number, then you might face the issue that the Stock UOM should be non-decimal. Users experience this problem when they are unable to set an accurate conversion factor

docs https://docs.frappe.io/erpnext/stock-settings#allow-to-edit-qty-as-per-stock-uom-in-stock-entry