### PR TITLE
fix(Lead): stop storing Gravatar image URLs for Leads

### DIFF
--- a/erpnext/crm/doctype/lead/lead.py
+++ b/erpnext/crm/doctype/lead/lead.py
@@ -8,7 +8,7 @@ from frappe.contacts.address_and_contact import (
 	load_address_and_contact,
 )
 from frappe.model.document import Document
-from frappe.utils import comma_and, get_link_to_form, has_gravatar, validate_email_address
+from frappe.utils import comma_and, get_link_to_form, validate_email_address
 from frappe.utils.data import DateTimeLikeObject
 
 from erpnext.accounts.party import set_taxes
@@ -172,9 +172,6 @@ class Lead(SellingController, CRMNote):
 
 			if self.email_id == self.lead_owner:
 				frappe.throw(_("Lead Owner cannot be same as the Lead Email Address"))
-
-			if self.is_new() or not self.image:
-				self.image = has_gravatar(self.email_id)
 
 	def link_to_contact(self):
 		# update contact links

--- a/erpnext/templates/includes/projects.css
+++ b/erpnext/templates/includes/projects.css
@@ -79,10 +79,6 @@
 	padding: 8px;
 }
 
-.gravatar-top{
-	margin-top:8px;
-}
-
 .progress-hg{
 	margin-bottom: 30!important;
 	height:2px;


### PR DESCRIPTION
Issue: https://github.com/frappe/frappe/issues/39869

Related framework change: https://github.com/frappe/frappe/pull/39946