### PR TITLE
ci: set disabledLabels and context for greptile

### DIFF
--- a/.greptile/config.json
+++ b/.greptile/config.json
@@ -1,0 +1,10 @@
+{
+    "disabledLabels": [
+        "conflicts"
+    ],
+    "context": {
+        "repos": [
+            "frappe/frappe"
+        ]
+    }
+}


### PR DESCRIPTION
- Mergify backports often contain conflicts, automated PR review will invariably request changes, this is wasted compute. -> Ignore PRs labeled "conflicts".
- Greptile can consider other repos when reviewing PRs. -> Set "frappe/frappe" as context.

Ref: https://www.greptile.com/docs/code-review/greptile-json-reference