### PR TITLE
fix: use net fixed assets for Fixed Asset Turnover Ratio

### DIFF
--- a/erpnext/accounts/report/financial_ratios/financial_ratios.py
+++ b/erpnext/accounts/report/financial_ratios/financial_ratios.py
@@ -71,6 +71,7 @@ def get_ratios_data(filters, period_list, years):
 	assets, liabilities, income, expense = get_gl_data(filters, period_list, years)
 
 	current_asset, total_asset = {}, {}
+	fixed_asset = {}
 	current_liability, total_liability = {}, {}
 	net_sales, total_income = {}, {}
 	cogs, total_expense = {}, {}
@@ -93,6 +94,7 @@ def get_ratios_data(filters, period_list, years):
 				quick_asset,
 				total_quick_asset,
 			],
+			[fixed_asset, total_asset, "Fixed Asset", year, assets, "Asset", {}, 0],
 			[
 				current_liability,
 				total_liability,
@@ -112,7 +114,7 @@ def get_ratios_data(filters, period_list, years):
 	add_solvency_ratios(
 		data, years, total_asset, total_liability, net_sales, cogs, total_income, total_expense
 	)
-	add_turnover_ratios(data, years, period_list, filters, total_asset, net_sales, cogs, direct_expense)
+	add_turnover_ratios(data, years, period_list, filters, fixed_asset, net_sales, cogs, direct_expense)
 
 	return data
 
@@ -193,7 +195,7 @@ def add_solvency_ratios(
 	data.append(return_on_equity_ratio)
 
 
-def add_turnover_ratios(data, years, period_list, filters, total_asset, net_sales, cogs, direct_expense):
+def add_turnover_ratios(data, years, period_list, filters, fixed_asset, net_sales, cogs, direct_expense):
 	precision = frappe.db.get_single_value("System Settings", "float_precision")
 	data.append({"ratio": _("Turnover Ratios")})
 
@@ -208,7 +210,7 @@ def add_turnover_ratios(data, years, period_list, filters, total_asset, net_sale
 	)
 
 	ratio_data = [
-		[_("Fixed Asset Turnover Ratio"), net_sales, total_asset],
+		[_("Fixed Asset Turnover Ratio"), net_sales, fixed_asset],
 		[_("Debtor Turnover Ratio"), net_sales, avg_debtors],
 		[_("Creditor Turnover Ratio"), direct_expense, avg_creditors],
 		[_("Inventory Turnover Ratio"), cogs, avg_stock],

--- a/erpnext/accounts/report/financial_ratios/test_financial_ratios.py
+++ b/erpnext/accounts/report/financial_ratios/test_financial_ratios.py
@@ -1,0 +1,89 @@
+# Copyright (c) 2023, Frappe Technologies Pvt. Ltd. and Contributors
+# MIT License. See license.txt
+
+import frappe
+from frappe.utils import today
+
+from erpnext.accounts.report.financial_ratios.financial_ratios import execute
+from erpnext.tests.utils import ERPNextTestSuite
+
+COMPANY = "_Test Company Financial Ratios"
+ABBR = "_TCFR"
+
+
+class TestFinancialRatios(ERPNextTestSuite):
+	def setUp(self):
+		self.create_company()
+		# The report matches the group accounts by their account_type, which the
+		# standard chart of accounts does not set on group accounts by default.
+		self.set_account_type("Fixed Assets", "Fixed Asset")
+		self.set_account_type("Direct Income", "Direct Income")
+
+	def create_company(self):
+		if frappe.db.exists("Company", COMPANY):
+			return
+		frappe.get_doc(
+			{
+				"doctype": "Company",
+				"company_name": COMPANY,
+				"abbr": ABBR,
+				"country": "India",
+				"default_currency": "INR",
+				"create_chart_of_accounts_based_on": "Standard Template",
+				"chart_of_accounts": "Standard",
+			}
+		).insert()
+
+	def set_account_type(self, account_name, account_type):
+		frappe.db.set_value("Account", f"{account_name} - {ABBR}", "account_type", account_type)
+
+	def test_fixed_asset_turnover_uses_net_fixed_assets(self):
+		# Acquire a fixed asset worth 10,000 funded by equity.
+		self.make_journal_entry("Buildings", "Capital Stock", 10000)
+		# Book sales of 20,000 collected in cash. Total assets now = 30,000
+		# (Buildings 10,000 + Cash 20,000), while net fixed assets stay at 10,000.
+		self.make_journal_entry("Cash", "Sales", 20000)
+
+		columns, data = execute(self.get_report_filters())
+		year_key = columns[1]["fieldname"]
+		ratio_row = next(row for row in data if row.get("ratio") == "Fixed Asset Turnover Ratio")
+
+		# Net Sales / Net Fixed Assets = 20,000 / 10,000 = 2.0
+		# (the old behaviour divided by total assets, giving 20,000 / 30,000 = 0.667)
+		self.assertEqual(ratio_row[year_key], 2.0)
+
+	def get_report_filters(self):
+		active_fy = frappe.db.get_value(
+			"Fiscal Year",
+			{"disabled": 0, "year_start_date": ("<=", today()), "year_end_date": (">=", today())},
+			["name", "year_start_date", "year_end_date"],
+			as_dict=True,
+		)
+		return frappe._dict(
+			company=COMPANY,
+			from_fiscal_year=active_fy.name,
+			to_fiscal_year=active_fy.name,
+			period_start_date=active_fy.year_start_date,
+			period_end_date=active_fy.year_end_date,
+			filter_based_on="Fiscal Year",
+			periodicity="Yearly",
+		)
+
+	def make_journal_entry(self, debit_account, credit_account, amount):
+		journal_entry = frappe.new_doc("Journal Entry")
+		journal_entry.posting_date = today()
+		journal_entry.company = COMPANY
+		for account, debit, credit in (
+			(debit_account, amount, 0),
+			(credit_account, 0, amount),
+		):
+			journal_entry.append(
+				"accounts",
+				{
+					"account": f"{account} - {ABBR}",
+					"debit_in_account_currency": debit,
+					"credit_in_account_currency": credit,
+				},
+			)
+		journal_entry.insert()
+		journal_entry.submit()

--- a/erpnext/accounts/report/financial_ratios/test_financial_ratios.py
+++ b/erpnext/accounts/report/financial_ratios/test_financial_ratios.py
@@ -46,7 +46,8 @@ class TestFinancialRatios(ERPNextTestSuite):
 
 		columns, data = execute(self.get_report_filters())
 		year_key = columns[1]["fieldname"]
-		ratio_row = next(row for row in data if row.get("ratio") == "Fixed Asset Turnover Ratio")
+		ratio_row = next((row for row in data if row.get("ratio") == "Fixed Asset Turnover Ratio"), None)
+		self.assertIsNotNone(ratio_row, "Fixed Asset Turnover Ratio row not found in report output")
 
 		# Net Sales / Net Fixed Assets = 20,000 / 10,000 = 2.0
 		# (the old behaviour divided by total assets, giving 20,000 / 30,000 = 0.667)


### PR DESCRIPTION
## Description

Fixes #54529

The **Fixed Asset Turnover Ratio** in the Financial Ratios report (`Accounts > Reports > Financial Ratios`) was computed using **Total Assets** as the denominator instead of **Net Fixed Assets**. This effectively produced the *Total* Asset Turnover Ratio.

Standard definition:

```
Fixed Asset Turnover Ratio = Net Sales / Net Fixed Assets
```

### Root cause

In `add_turnover_ratios`, the denominator was `total_asset`, which is populated from the root-level Asset group (the sum of **all** assets — current, fixed and others). There was no isolation of fixed assets anywhere in the report.

### Fix

Added a `fixed_asset` balance populated from the asset account carrying the `Fixed Asset` `account_type` — mirroring how `current_asset` is derived for `Current Asset` — and used it as the denominator. Because children are accumulated into the parent group account, the Fixed Assets group value is already net of accumulated depreciation, yielding **Net Sales / Net Fixed Assets**.

## How to test

1. Open `Accounts > Reports > Financial Ratios`.
2. Ensure the Fixed Assets group account has `account_type = Fixed Asset` set (same convention the report already relies on for Current Assets).
3. Confirm the **Fixed Asset Turnover Ratio** now equals `Net Sales / Net Fixed Assets` rather than `Net Sales / Total Assets`.

Automated test added in `test_financial_ratios.py`:

```
bench --site <site> run-tests --module erpnext.accounts.report.financial_ratios.test_financial_ratios
```

The test books a 10,000 fixed asset and 20,000 of sales (total assets = 30,000) and asserts the ratio is `2.0` (20,000 / 10,000), not `0.67` (20,000 / 30,000).