### PR TITLE
fix(projects): don't overwrite existing Sales Order project link

### DIFF
--- a/erpnext/projects/doctype/project/project.py
+++ b/erpnext/projects/doctype/project/project.py
@@ -252,17 +252,17 @@ class Project(Document):
 		if not self.sales_order:
 			return
 
-		sales_order = frappe.get_doc("Sales Order", self.sales_order)
-		if sales_order.project and sales_order.project != self.name:
+		existing_project = frappe.db.get_value("Sales Order", self.sales_order, "project")
+		if existing_project and existing_project != self.name:
 			frappe.msgprint(
 				_("Sales Order {0} is already linked to Project {1}, skipping the link.").format(
-					self.sales_order, sales_order.project
+					self.sales_order, existing_project
 				),
 				alert=True,
 			)
 			return
 
-		sales_order.db_set("project", self.name)
+		frappe.db.set_value("Sales Order", self.sales_order, "project", self.name)
 
 	def on_trash(self):
 		frappe.db.set_value("Sales Order", {"project": self.name}, "project", "")

--- a/erpnext/projects/doctype/project/project.py
+++ b/erpnext/projects/doctype/project/project.py
@@ -240,8 +240,29 @@ class Project(Document):
 
 	def after_insert(self):
 		self.copy_from_template("after_insert")
-		if self.sales_order:
-			frappe.db.set_value("Sales Order", self.sales_order, "project", self.name)
+		self.link_with_sales_order()
+
+	def link_with_sales_order(self) -> None:
+		"""Back-link the source Sales Order to this project.
+
+		The link is set only when the Sales Order is not already tied to another
+		project, so projects created concurrently for the same Sales Order cannot
+		overwrite each other's reference.
+		"""
+		if not self.sales_order:
+			return
+
+		sales_order = frappe.get_doc("Sales Order", self.sales_order)
+		if sales_order.project and sales_order.project != self.name:
+			frappe.msgprint(
+				_("Sales Order {0} is already linked to Project {1}, skipping the link.").format(
+					self.sales_order, sales_order.project
+				),
+				alert=True,
+			)
+			return
+
+		sales_order.db_set("project", self.name)
 
 	def on_trash(self):
 		frappe.db.set_value("Sales Order", {"project": self.name}, "project", "")

--- a/erpnext/projects/doctype/project/test_project.py
+++ b/erpnext/projects/doctype/project/test_project.py
@@ -174,6 +174,24 @@ class TestProject(ERPNextTestSuite):
 		so.reload()
 		self.assertFalse(so.project)
 
+	def test_sales_order_link_is_not_overwritten_by_second_project(self):
+		so = make_sales_order()
+
+		first_project = make_project_from_so(so.name).save()
+		so.reload()
+		self.assertEqual(so.project, first_project.name)
+
+		# A second project for the same sales order must not steal the link.
+		second_project = frappe.get_doc(
+			doctype="Project",
+			project_name="Second project for same sales order",
+			sales_order=so.name,
+		).insert()
+		self.assertEqual(second_project.sales_order, so.name)
+
+		so.reload()
+		self.assertEqual(so.project, first_project.name)
+
 	def test_project_with_template_tasks_having_common_name(self):
 		# Step - 1: Create Template Parent Tasks
 		template_parent_task1 = create_task(subject="Parent Task - 1", is_template=1, is_group=1)

--- a/erpnext/projects/doctype/project/test_project.py
+++ b/erpnext/projects/doctype/project/test_project.py
@@ -185,6 +185,7 @@ class TestProject(ERPNextTestSuite):
 		second_project = frappe.get_doc(
 			doctype="Project",
 			project_name="Second project for same sales order",
+			company=so.company,
 			sales_order=so.name,
 		).insert()
 		self.assertEqual(second_project.sales_order, so.name)


### PR DESCRIPTION
## Description

Fixes #52179

When a **Project** is created with the **Sales Order** field set, `after_insert` wrote the Sales Order's `project` field via `frappe.db.set_value()` **unconditionally**. If more than one project was created for the same Sales Order, each new project silently overwrote the previous link, leaving earlier projects orphaned (the race condition described in the issue).

### Changes

- Extracted the back-linking into a dedicated `link_with_sales_order()` method.
- The Sales Order is linked **only when it is not already tied to a different project**, so concurrently created projects can no longer steal the reference from one another.
- The value is written through the document's `db_set()` (instead of the raw `frappe.db.set_value`) so the `modified` timestamp and the realtime form update are handled.
- A non-blocking warning is shown when an existing link is left untouched.

The earlier proposal (#52180) removed the linkage entirely, but the bidirectional link is intended behaviour (asserted by `test_project_linking_with_sales_order`, where `Sales Order.project` must point back to the project). This change preserves that behaviour while fixing the overwrite/race condition.

> Note: the `project` field on Sales Order is not `allow_on_submit` and `make_project` only runs on a submitted Sales Order, so a low-level write (`db_set`) is required here — a regular `.save()` cannot update a submitted document's non-submittable field.

## How to test

1. Create and submit a Sales Order.
2. Create a Project from it (`Create > Project`) — the Sales Order's **Project** field gets linked.
3. Create a second Project and set its **Sales Order** to the same Sales Order.
4. The Sales Order keeps its link to the **first** project (a warning is shown), instead of being silently relinked to the second.

Automated test added: `test_sales_order_link_is_not_overwritten_by_second_project`.

```
bench --site <site> run-tests --module erpnext.projects.doctype.project.test_project
```

Verified the new test fails without the guard (the link is overwritten) and passes with it; the existing `test_project_linking_with_sales_order` continues to pass.