### PR TITLE
fix(stock): use correct field when reading previous stock closing balance

### DIFF
--- a/erpnext/stock/doctype/stock_closing_entry/stock_closing_entry.py
+++ b/erpnext/stock/doctype/stock_closing_entry/stock_closing_entry.py
@@ -267,7 +267,7 @@ class StockClosing:
 				],
 				filters={
 					"company": self.company,
-					"closing_stock_balance": self.last_closing_balance.name,
+					"stock_closing_entry": self.last_closing_balance.name,
 				},
 			)
 

--- a/erpnext/stock/doctype/stock_closing_entry/test_stock_closing_entry.py
+++ b/erpnext/stock/doctype/stock_closing_entry/test_stock_closing_entry.py
@@ -1,13 +1,16 @@
 # Copyright (c) 2024, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
 
-# import frappe
+import frappe
+from frappe.utils import add_days, today
 
+from erpnext.stock.doctype.item.test_item import make_item
+from erpnext.stock.doctype.stock_closing_entry.stock_closing_entry import StockClosing
+from erpnext.stock.doctype.stock_entry.stock_entry_utils import make_stock_entry
 from erpnext.tests.utils import ERPNextTestSuite
 
-# On ERPNextTestSuite, the doctype test records and all
-# link-field test record depdendencies are recursively loaded
-# Use these module variables to add/remove to/from that list
+COMPANY = "_Test Company"
+WAREHOUSE = "_Test Warehouse - _TC"
 
 
 class TestStockClosingEntry(ERPNextTestSuite):
@@ -16,4 +19,41 @@ class TestStockClosingEntry(ERPNextTestSuite):
 	Use this class for testing interactions between multiple components.
 	"""
 
-	pass
+	def test_closing_entry_reads_previous_closing_balance(self):
+		"""A closing entry created after another one must read the previous balance.
+
+		Regression for the query that filtered `Stock Closing Balance` by a
+		non-existent `closing_stock_balance` column, raising an OperationalError
+		for every closing entry created after the first one.
+		"""
+		item = make_item(properties={"is_stock_item": 1}).name
+		first_date = add_days(today(), -10)
+
+		# A submitted closing entry makes the next closing look up its balance.
+		self.make_stock_closing_entry(first_date, first_date)
+
+		second_from_date = add_days(first_date, 1)
+		make_stock_entry(
+			item_code=item,
+			to_warehouse=WAREHOUSE,
+			qty=10,
+			rate=100,
+			posting_date=second_from_date,
+			company=COMPANY,
+		)
+
+		closing = StockClosing(COMPANY, second_from_date, add_days(second_from_date, 1))
+		entries = closing.get_sle_entries()
+
+		self.assertEqual(closing.last_closing_balance.name, self.last_closing_entry)
+		self.assertIn(item, {row.item_code for row in entries})
+
+	def make_stock_closing_entry(self, from_date, to_date):
+		entry = frappe.get_doc(
+			doctype="Stock Closing Entry",
+			company=COMPANY,
+			from_date=from_date,
+			to_date=to_date,
+		).submit()
+		self.last_closing_entry = entry.name
+		return entry


### PR DESCRIPTION
## Description

Fixes #54819

Submitting a **Stock Closing Entry** failed (status `Failed`) for every entry created **after the first one**, with:

```
MySQLdb.OperationalError: (1054, "Unknown column 'closing_stock_balance' in 'WHERE'")
```

### Root cause

`StockClosing.get_sle_entries()` reads the previous closing's rows from `Stock Closing Balance`, but filtered by a `closing_stock_balance` column that does not exist. The link field back to the closing entry is named `stock_closing_entry` (see `stock_closing_balance.json`; it is also what every other query in this file uses — `remove_stock_closing`, `create_stock_closing_balance_entries`, `get_stock_closing_balance`).

The first Stock Closing Entry works because `last_closing_balance` is empty and this branch is skipped, so the bug only surfaces from the second closing onwards.

### Fix

```diff
 filters={
     "company": self.company,
-    "closing_stock_balance": self.last_closing_balance.name,
+    "stock_closing_entry": self.last_closing_balance.name,
 },
```

## How to test

1. Submit a Stock Closing Entry for a date range (e.g. `2026-05-19` → `2026-05-20`).
2. Submit a second Stock Closing Entry for a later, non-overlapping range (e.g. `2026-05-21` → `2026-05-22`).
3. The second entry now completes instead of going to `Failed`.

Automated regression test added (`test_closing_entry_reads_previous_closing_balance`): it submits one closing entry, then drives `StockClosing.get_sle_entries()` for a later period and asserts it reads the previous balance without raising.

```
bench --site <site> run-tests --module erpnext.stock.doctype.stock_closing_entry.test_stock_closing_entry
```

Verified the test reproduces the exact `Unknown column 'closing_stock_balance'` error on the unpatched code and passes with the fix.