### PR TITLE
fix: don't convert item margin on exchange rate refresh

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -600,6 +600,10 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 	refresh() {
 		erpnext.toggle_naming_series();
 		erpnext.hide_company(this.frm);
+		// Remember the currency the rendered document is denominated in, so that a
+		// real currency change can be told apart from a mere exchange rate refresh
+		// (e.g. triggered by a date change).
+		this._doc_currency = this.frm.doc.currency;
 		this.set_dynamic_labels();
 		this.setup_sms();
 		this.setup_quality_inspection();
@@ -1470,6 +1474,10 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 		let me = this;
 		this.set_dynamic_labels();
 		let company_currency = this.get_company_currency();
+		// Currency the stored margins/actual charges are denominated in, captured
+		// before this trigger updates the tracker for the next one.
+		let previous_currency = this._doc_currency;
+		this._doc_currency = this.frm.doc.currency;
 		// Added `load_after_mapping` to determine if document is loading after mapping from another doc
 		if (
 			this.frm.doc.currency &&
@@ -1482,8 +1490,14 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 				company_currency,
 				function (exchange_rate) {
 					if (exchange_rate != me.frm.doc.conversion_rate) {
-						me.set_margin_amount_based_on_currency(exchange_rate);
-						me.set_actual_charges_based_on_currency(exchange_rate);
+						// Margins and actual charges are amounts in the transaction
+						// currency; convert them only when the currency itself changed,
+						// not when just the exchange rate was refreshed (e.g. by a date
+						// change), otherwise the entered margin keeps shrinking.
+						if (previous_currency !== me.frm.doc.currency) {
+							me.set_margin_amount_based_on_currency(exchange_rate);
+							me.set_actual_charges_based_on_currency(exchange_rate);
+						}
 						me.frm.set_value("conversion_rate", exchange_rate);
 					}
 				}

--- a/erpnext/selling/doctype/quotation/quotation.js
+++ b/erpnext/selling/doctype/quotation/quotation.js
@@ -382,26 +382,6 @@ erpnext.selling.QuotationController = class QuotationController extends erpnext.
 		dialog.show();
 	}
 
-	currency() {
-		super.currency();
-		let me = this;
-		const company_currency = this.get_company_currency();
-		if (this.frm.doc.currency && this.frm.doc.currency !== company_currency) {
-			this.get_exchange_rate(
-				this.frm.doc.transaction_date,
-				this.frm.doc.currency,
-				company_currency,
-				function (exchange_rate) {
-					if (exchange_rate != me.frm.doc.conversion_rate) {
-						me.set_margin_amount_based_on_currency(exchange_rate);
-						me.set_actual_charges_based_on_currency(exchange_rate);
-						me.frm.set_value("conversion_rate", exchange_rate);
-					}
-				}
-			);
-		}
-	}
-
 	disable_customer_if_creating_from_opportunity(doc) {
 		if (doc.opportunity) {
 			this.frm.set_df_property("party_name", "read_only", 1);


### PR DESCRIPTION
## Description

Fixes #45210

When a Sales Invoice is created from a Sales Order (or any multicurrency selling/buying transaction), refreshing the exchange rate — e.g. by changing the posting/transaction date — silently shrinks the item **Margin** (and Actual tax charges) for every item that had an *Amount*-type margin. The rates agreed with the customer in the document currency no longer hold.

### Root cause

Changing the date re-triggers the `currency` handler (`transaction.js` → `posting_date()`/`transaction_date()` call `frappe.ui.form.trigger(doctype, "currency")`). The handler fetches a fresh exchange rate and, whenever it differs from the current `conversion_rate`, **converts** every Amount margin and Actual charge:

```js
if (exchange_rate != me.frm.doc.conversion_rate) {
    me.set_margin_amount_based_on_currency(exchange_rate);   // margin / new rate
    me.set_actual_charges_based_on_currency(exchange_rate);  // actual tax / new rate
    me.frm.set_value("conversion_rate", exchange_rate);
}
```

`margin_rate_or_amount` is an amount in the **transaction currency** — dividing it by the rate is only meaningful when the document *switches* currency (e.g. company → foreign). When only the rate moves (date change / stale-rate refresh), the division keeps shrinking the margin.

On **Quotation** it was worse: `quotation.js` overrode `currency()`, called `super.currency()` and then duplicated the entire fetch-and-convert block, so margins could be converted twice per trigger (and the override lacked the base `load_after_mapping` guard).

### Fix

1. `transaction.js`: track the currency the rendered document is denominated in (`_doc_currency`, set in `refresh()` and updated on each `currency()` trigger) and convert margins/actual charges **only when the currency itself changed**, not on a plain rate refresh. `conversion_rate` is still updated so base amounts recalculate correctly. The previous currency is captured into a local before updating the tracker, so the async rate callback compares against the right value and the duplicate triggers fired by `company()` setup don't double-convert.
2. `quotation.js`: remove the duplicated `currency()` override — the base handler already covers Quotation (`transaction_date || posting_date`).

`sales_invoice.js` keeps its `currency()` override (timesheet handling); it just delegates to `super.currency()`, so it inherits the fix.

## How to test

1. Create item prices, then a multicurrency **Sales Order** (e.g. document currency USD, company currency INR). For one item enter a rate above its price list rate so it has an *Amount* margin (Margin Amount = 5 USD).
2. Submit it, then `Create > Sales Invoice`.
3. Save the invoice, then change the posting date (or exchange rate) so a fresh rate is fetched.
4. **Before:** the item rate/margin changes as the rate is applied. **After:** the entered margin (and item rate) stays as agreed, while `conversion_rate` and the base amounts update.
5. Repeat the date change on a multicurrency **Quotation** — margins stay stable (previously they were converted, sometimes twice).

> Note: this is a client-side controller fix. ERPNext has no JS/UI (Cypress) test harness, and the behaviour lives entirely in the form's `currency` handler, so it isn't reachable from server-side `bench run-tests`. Verified manually per the steps above; `node --check` passes on both files.

# no-docs