### PR TITLE
fix: clear stale payment rows on non-POS returns so they don't surface in bank reconciliation

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -412,8 +412,8 @@ class SalesInvoice(SellingController):
 			validate_account_head(item.idx, item.income_account, self.company, _("Income"))
 
 	def before_save(self):
+		POSService(self).update_paid_amount()
 		POSService(self).set_account_for_mode_of_payment()
-		POSService(self).set_paid_amount()
 
 	def before_submit(self):
 		self.add_remarks()

--- a/erpnext/accounts/doctype/sales_invoice/services/pos.py
+++ b/erpnext/accounts/doctype/sales_invoice/services/pos.py
@@ -114,10 +114,17 @@ class POSService:
 
 		return pos
 
-	def set_paid_amount(self) -> None:
+	def update_paid_amount(self) -> None:
 		doc = self.doc
 		paid_amount = 0.0
 		base_paid_amount = 0.0
+
+		if not cint(doc.is_pos) and doc.is_return:
+			doc.set("payments", [])
+			doc.paid_amount = paid_amount
+			doc.base_paid_amount = base_paid_amount
+			return
+
 		for data in doc.payments:
 			data.base_amount = flt(data.amount * doc.conversion_rate, doc.precision("base_paid_amount"))
 			paid_amount += data.amount


### PR DESCRIPTION
Fix for TN-70582