### PR TITLE
fix: show company name in delete transactions confirmation dialog

### DIFF
--- a/erpnext/setup/doctype/company/company.js
+++ b/erpnext/setup/doctype/company/company.js
@@ -227,7 +227,9 @@ frappe.ui.form.on("Company", {
 							{
 								fieldtype: "Data",
 								fieldname: "company_name",
-								label: __("Please enter the company name to confirm"),
+								label: __('Please enter the company name <b>"{0}"</b> to confirm', [
+									frappe.utils.escape_html(frm.doc.name),
+								]),
 								reqd: 1,
 								description: __(
 									"Please make sure you really want to delete all the transactions for this company. Your master data will remain as it is. This action cannot be undone."


### PR DESCRIPTION
## Summary

- The confirmation dialog for **Delete Transactions** on the Company form previously showed a generic label with no hint of what to type.
- Updated the label to display the actual company name in bold, so users immediately know the exact text required to confirm.

## Before

<img width="1120" height="507" alt="image" src="https://github.com/user-attachments/assets/9cbdcd2b-2703-4b06-ace9-fd8ab521fed7" />

## After

<img width="1134" height="512" alt="image" src="https://github.com/user-attachments/assets/dced65e4-c068-4149-a935-e28ffcd02f96" />
