### PR TITLE
fix: exclude rate-adjustment credit notes from stock return qty check

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
@@ -4886,6 +4886,52 @@ class TestSalesInvoice(ERPNextTestSuite):
 
 		self.assertRaises(StockOverReturnError, return_doc.save)
 
+	def test_stock_return_allowed_after_rate_adjustment_credit_note(self):
+		from erpnext.controllers.sales_and_purchase_return import StockOverReturnError, make_return_doc
+
+		make_stock_entry(item_code="_Test Item", target="_Test Warehouse - _TC", qty=10, basic_rate=100)
+
+		# Original sales invoice with stock effect
+		invoice = create_sales_invoice(qty=5, rate=100, update_stock=1)
+
+		# Rate-adjustment credit note: adjusts price only, no stock movement (update_stock=0)
+		create_sales_invoice(
+			qty=-5,
+			rate=20,
+			is_return=1,
+			return_against=invoice.name,
+			update_stock=0,
+		)
+
+		# Stock return should not be blocked by the rate-adjustment credit note
+		stock_return = make_return_doc(invoice.doctype, invoice.name)
+		stock_return.update_stock = 1
+		self.assertEqual(stock_return.items[0].qty, -5)
+
+		# Should not raise StockOverReturnError — save and submit should succeed
+		stock_return.save()
+		stock_return.submit()
+
+	def test_rate_adjustment_credit_note_blocked_by_prior_rate_adjustment(self):
+		from erpnext.controllers.sales_and_purchase_return import StockOverReturnError, make_return_doc
+
+		# Original sales invoice without stock effect
+		invoice = create_sales_invoice(qty=5, rate=100)
+
+		# Full rate-adjustment credit note (update_stock=0)
+		create_sales_invoice(
+			qty=-5,
+			rate=100,
+			is_return=1,
+			return_against=invoice.name,
+			update_stock=0,
+		)
+
+		# A second rate-adjustment credit note should be blocked
+		return_doc = make_return_doc(invoice.doctype, invoice.name)
+		return_doc.items[0].qty = -1
+		self.assertRaises(StockOverReturnError, return_doc.save)
+
 	def test_pos_sales_invoice_creation_during_pos_invoice_mode(self):
 		# Deleting all opening entry
 		frappe.db.sql("delete from `tabPOS Opening Entry`")

--- a/erpnext/controllers/sales_and_purchase_return.py
+++ b/erpnext/controllers/sales_and_purchase_return.py
@@ -271,38 +271,48 @@ def get_ref_item_dict(valid_items, ref_item_row):
 
 
 def get_already_returned_items(doc):
-	column = "child.item_code, sum(abs(child.qty)) as qty, sum(abs(child.stock_qty)) as stock_qty"
-	if doc.doctype in ["Purchase Invoice", "Purchase Receipt", "Subcontracting Receipt"]:
-		column += """, sum(abs(child.rejected_qty) * child.conversion_factor) as rejected_qty,
-			sum(abs(child.received_qty) * child.conversion_factor) as received_qty"""
+	from frappe.query_builder.functions import Abs, Sum
+
+	par = frappe.qb.DocType(doc.doctype)
+	child = frappe.qb.DocType(doc.doctype + " Item")
 
 	field = (
 		frappe.scrub(doc.doctype) + "_item"
 		if doc.doctype in ["Purchase Invoice", "Purchase Receipt", "Sales Invoice", "POS Invoice"]
 		else "dn_detail"
 	)
+	child_field = getattr(child, field)
+
+	query = (
+		frappe.qb.from_(par)
+		.inner_join(child)
+		.on(child.parent == par.name)
+		.select(
+			child.item_code,
+			Sum(Abs(child.qty)).as_("qty"),
+			Sum(Abs(child.stock_qty)).as_("stock_qty"),
+			child_field,
+		)
+		.where(
+			(par.docstatus == 1)
+			& (par.is_return == 1)
+			& (par.return_against == doc.return_against)
+		)
+		.groupby(child.item_code, child_field)
+	)
+
+	if doc.doctype in ["Purchase Invoice", "Purchase Receipt", "Subcontracting Receipt"]:
+		query = query.select(
+			Sum(Abs(child.rejected_qty) * child.conversion_factor).as_("rejected_qty"),
+			Sum(Abs(child.received_qty) * child.conversion_factor).as_("received_qty"),
+		)
 
 	# For invoice doctypes, only count returns with matching update_stock so that
 	# rate-adjustment returns (update_stock=0) don't block stock returns (update_stock=1) and vice versa.
-	update_stock_condition = ""
 	if doc.doctype in ["Sales Invoice", "Purchase Invoice"]:
-		update_stock_val = 1 if doc.get("update_stock") else 0
-		update_stock_condition = f"and par.update_stock = {update_stock_val}"
+		query = query.where(par.update_stock == (1 if doc.get("update_stock") else 0))
 
-	data = frappe.db.sql(
-		f"""
-		select {column}, child.{field}
-		from
-			`tab{doc.doctype} Item` child, `tab{doc.doctype}` par
-		where
-			child.parent = par.name and par.docstatus = 1
-			and par.is_return = 1 and par.return_against = %s
-			{update_stock_condition}
-		group by item_code, {field}
-	""",
-		doc.return_against,
-		as_dict=1,
-	)
+	data = query.run(as_dict=True)
 
 	items = {}
 

--- a/erpnext/controllers/sales_and_purchase_return.py
+++ b/erpnext/controllers/sales_and_purchase_return.py
@@ -281,6 +281,14 @@ def get_already_returned_items(doc):
 		if doc.doctype in ["Purchase Invoice", "Purchase Receipt", "Sales Invoice", "POS Invoice"]
 		else "dn_detail"
 	)
+
+	# For invoice doctypes, only count returns with matching update_stock so that
+	# rate-adjustment returns (update_stock=0) don't block stock returns (update_stock=1) and vice versa.
+	update_stock_condition = ""
+	if doc.doctype in ["Sales Invoice", "Purchase Invoice"]:
+		update_stock_val = 1 if doc.get("update_stock") else 0
+		update_stock_condition = f"and par.update_stock = {update_stock_val}"
+
 	data = frappe.db.sql(
 		f"""
 		select {column}, child.{field}
@@ -289,6 +297,7 @@ def get_already_returned_items(doc):
 		where
 			child.parent = par.name and par.docstatus = 1
 			and par.is_return = 1 and par.return_against = %s
+			{update_stock_condition}
 		group by item_code, {field}
 	""",
 		doc.return_against,

--- a/erpnext/controllers/sales_and_purchase_return.py
+++ b/erpnext/controllers/sales_and_purchase_return.py
@@ -384,7 +384,7 @@ def get_returned_qty_map_for_purchase_flow(return_against, supplier, row_name, d
 	return _return_map
 
 
-def get_returned_qty_map_for_row(return_against, party, row_name, doctype):
+def get_returned_qty_map_for_row(return_against, party, row_name, doctype, update_stock=None):
 	child_doctype = doctype + " Item"
 	reference_field = "dn_detail" if doctype == "Delivery Note" else frappe.scrub(child_doctype)
 
@@ -414,16 +414,23 @@ def get_returned_qty_map_for_row(return_against, party, row_name, doctype):
 			]
 
 	# Used retrun against and supplier and is_retrun because there is an index added for it
+	filters = [
+		[doctype, "return_against", "=", return_against],
+		[doctype, party_type, "=", party],
+		[doctype, "docstatus", "=", 1],
+		[doctype, "is_return", "=", 1],
+		[child_doctype, reference_field, "=", row_name],
+	]
+
+	# For invoice doctypes, only count returns with matching update_stock so that
+	# rate-adjustment returns (update_stock=0) don't reduce the returnable qty for stock returns (update_stock=1).
+	if update_stock is not None and doctype in ("Sales Invoice", "Purchase Invoice"):
+		filters.append([doctype, "update_stock", "=", 1 if update_stock else 0])
+
 	data = frappe.get_all(
 		doctype,
 		fields=fields,
-		filters=[
-			[doctype, "return_against", "=", return_against],
-			[doctype, party_type, "=", party],
-			[doctype, "docstatus", "=", 1],
-			[doctype, "is_return", "=", 1],
-			[child_doctype, reference_field, "=", row_name],
-		],
+		filters=filters,
 	)
 
 	return data[0]
@@ -575,7 +582,11 @@ def make_return_doc(doctype: str, source_name: str, target_doc=None, return_agai
 
 		elif doctype == "Purchase Invoice":
 			returned_qty_map = get_returned_qty_map_for_row(
-				source_parent.name, source_parent.supplier, source_doc.name, doctype
+				source_parent.name,
+				source_parent.supplier,
+				source_doc.name,
+				doctype,
+				update_stock=source_parent.get("update_stock"),
 			)
 			target_doc.received_qty = -1 * flt(
 				source_doc.received_qty - (returned_qty_map.get("received_qty") or 0)
@@ -612,7 +623,11 @@ def make_return_doc(doctype: str, source_name: str, target_doc=None, return_agai
 				target_doc.warehouse = default_warehouse_for_sales_return
 		elif doctype == "Sales Invoice" or doctype == "POS Invoice":
 			returned_qty_map = get_returned_qty_map_for_row(
-				source_parent.name, source_parent.customer, source_doc.name, doctype
+				source_parent.name,
+				source_parent.customer,
+				source_doc.name,
+				doctype,
+				update_stock=source_parent.get("update_stock") if doctype == "Sales Invoice" else None,
 			)
 			target_doc.qty = -1 * flt(source_doc.qty - (returned_qty_map.get("qty") or 0))
 			target_doc.stock_qty = -1 * flt(source_doc.stock_qty - (returned_qty_map.get("stock_qty") or 0))


### PR DESCRIPTION
## Problem

When a **rate-adjustment credit note** (`update_stock = 0`) is created against a Sales Invoice, and a user subsequently tries to create a **stock-return credit note** (`update_stock = 1`) against the same invoice, the return qty shows as **0** and the save throws `StockOverReturnError`.

**Steps to reproduce:**
1. Create Sales Invoice (qty=5, update_stock=1)
2. Create Credit Note against it with `update_stock=0` (rate adjustment only, no stock movement)
3. Try to create another Credit Note with `update_stock=1` (stock return)
4. Observe: qty is 0 / StockOverReturnError is thrown

## Root Cause

`get_already_returned_items()` in `sales_and_purchase_return.py` fetches **all** return documents matching `return_against`, regardless of their `update_stock` value. This means a rate-adjustment credit note (which does not move stock) is incorrectly counted toward the returnable stock qty.

## Fix

When `doc.doctype` is `Sales Invoice` or `Purchase Invoice`, add an `update_stock` filter to the SQL query in `get_already_returned_items()` so that:
- A stock-return (`update_stock=1`) only counts previously submitted stock-returns
- A rate-adjustment return (`update_stock=0`) only counts previously submitted rate-adjustment returns

## Test Cases

- `test_stock_return_allowed_after_rate_adjustment_credit_note`: verifies a stock return succeeds after a prior rate-adjustment credit note
- `test_rate_adjustment_credit_note_blocked_by_prior_rate_adjustment`: verifies a second full rate-adjustment is correctly blocked after the first fully covers the invoice qty

Fixes #55860