### PR TITLE
fix(stock): update stock value calculation in stock balance report

### DIFF
--- a/erpnext/stock/report/stock_balance/stock_balance.py
+++ b/erpnext/stock/report/stock_balance/stock_balance.py
@@ -351,12 +351,13 @@ class StockBalanceReport:
 				qty_dict.opening_qty -= self.stock_reco_voucher_wise_count.get(entry.voucher_detail_no, 0)
 				qty_dict.bal_qty = 0.0
 				qty_diff = flt(entry.actual_qty)
+				value_diff = flt(entry.stock_value_difference)
 			else:
 				qty_diff = flt(entry.qty_after_transaction) - flt(qty_dict.bal_qty)
+				value_diff = flt(entry.stock_value) - flt(qty_dict.bal_val)
 		else:
 			qty_diff = flt(entry.actual_qty)
-
-		value_diff = flt(entry.stock_value_difference)
+			value_diff = flt(entry.stock_value_difference)
 
 		if entry.posting_date < self.from_date or entry.voucher_no in self.opening_vouchers.get(
 			entry.voucher_type, []


### PR DESCRIPTION
**Issue:**
When the Item has a Stock Reconciliation, the stock balance report keeps adding up each entry's value change to the balance value, instead of corrected value set by the reconciliation. The stock ledger report already uses the reconciled value, so the two reports showing a different balance values for the same item and warehouse.

**Fix:** in prepare_item_warehouse_map, for Stock Reconciliation rows compute value_diff = stock_value − bal_val instead of stock_value_difference, so both reports show the same reconciled value.

**Ref:** [#70854](https://support.frappe.io/helpdesk/tickets/70854)
 
**Backport Needed for v16 & v15**