### PR TITLE
feat(rfq): add accounting dimensions support to Request for Quotation

### DIFF
--- a/erpnext/buying/doctype/request_for_quotation/mapper.py
+++ b/erpnext/buying/doctype/request_for_quotation/mapper.py
@@ -43,6 +43,7 @@ def make_supplier_quotation_from_rfq(
 					"name": "request_for_quotation_item",
 					"parent": "request_for_quotation",
 					"project_name": "project",
+					"cost_center": "cost_center",
 				},
 			},
 		},
@@ -110,6 +111,7 @@ def create_rfq_items(sq_doc, supplier, data):
 		"material_request_item",
 		"stock_qty",
 		"uom",
+		"cost_center",
 	]:
 		args[field] = data.get(field)
 
@@ -176,6 +178,7 @@ def get_item_from_material_requests_based_on_supplier(
 						["name", "material_request_item"],
 						["parent", "material_request"],
 						["uom", "uom"],
+						["cost_center", "cost_center"],
 					],
 				},
 			},

--- a/erpnext/buying/doctype/request_for_quotation/test_request_for_quotation.py
+++ b/erpnext/buying/doctype/request_for_quotation/test_request_for_quotation.py
@@ -262,9 +262,10 @@ class TestRequestforQuotation(ERPNextTestSuite):
 		self.assertEqual(rfq.items[0].cost_center, "_Test Cost Center - _TC")
 
 	def test_cost_center_flows_from_rfq_to_supplier_quotation(self):
-		rfq = make_request_for_quotation()
+		rfq = make_request_for_quotation(do_not_submit=True)
 		rfq.items[0].cost_center = "_Test Cost Center - _TC"
 		rfq.save()
+		rfq.submit()
 
 		sq = make_supplier_quotation_from_rfq(rfq.name, for_supplier=rfq.get("suppliers")[0].supplier)
 

--- a/erpnext/buying/doctype/request_for_quotation/test_request_for_quotation.py
+++ b/erpnext/buying/doctype/request_for_quotation/test_request_for_quotation.py
@@ -19,6 +19,7 @@ from erpnext.controllers.accounts_controller import InvalidQtyError
 from erpnext.crm.doctype.opportunity.mapper import make_request_for_quotation as make_rfq
 from erpnext.crm.doctype.opportunity.test_opportunity import make_opportunity
 from erpnext.stock.doctype.item.test_item import make_item
+from erpnext.stock.doctype.material_request.test_material_request import make_material_request
 from erpnext.templates.pages.rfq import check_supplier_has_docname_access
 from erpnext.tests.utils import ERPNextTestSuite
 
@@ -249,6 +250,40 @@ class TestRequestforQuotation(ERPNextTestSuite):
 		self.assertEqual(len(sq.items), 1)
 		self.assertEqual(sq.items[0].qty, 0)
 		self.assertEqual(sq.items[0].item_code, rfq.items[0].item_code)
+
+	def test_cost_center_flows_from_mr_to_rfq(self):
+		from erpnext.stock.doctype.material_request.mapper import (
+			make_request_for_quotation as mr_make_rfq,
+		)
+
+		mr = make_material_request(cost_center="_Test Cost Center - _TC")
+		rfq = mr_make_rfq(mr.name)
+
+		self.assertEqual(rfq.items[0].cost_center, "_Test Cost Center - _TC")
+
+	def test_cost_center_flows_from_rfq_to_supplier_quotation(self):
+		rfq = make_request_for_quotation()
+		rfq.items[0].cost_center = "_Test Cost Center - _TC"
+		rfq.save()
+
+		sq = make_supplier_quotation_from_rfq(rfq.name, for_supplier=rfq.get("suppliers")[0].supplier)
+
+		self.assertEqual(sq.items[0].cost_center, "_Test Cost Center - _TC")
+
+	def test_cost_center_flows_end_to_end_mr_rfq_sq(self):
+		from erpnext.stock.doctype.material_request.mapper import (
+			make_request_for_quotation as mr_make_rfq,
+		)
+
+		mr = make_material_request(cost_center="_Test Cost Center - _TC")
+		rfq = mr_make_rfq(mr.name)
+		rfq.append("suppliers", {"supplier": "_Test Supplier", "supplier_name": "_Test Supplier"})
+		rfq.insert()
+		rfq.submit()
+
+		sq = make_supplier_quotation_from_rfq(rfq.name, for_supplier="_Test Supplier")
+
+		self.assertEqual(sq.items[0].cost_center, "_Test Cost Center - _TC")
 
 
 def make_request_for_quotation(**args):

--- a/erpnext/buying/doctype/request_for_quotation_item/request_for_quotation_item.json
+++ b/erpnext/buying/doctype/request_for_quotation_item/request_for_quotation_item.json
@@ -30,7 +30,9 @@
   "col_break4",
   "material_request",
   "material_request_item",
-  "section_break_24",
+  "accounting_dimensions_section",
+  "cost_center",
+  "dimension_col_break",
   "project_name",
   "section_break_23",
   "page_break"
@@ -253,15 +255,26 @@
   },
   {
    "collapsible": 1,
-   "fieldname": "section_break_24",
+   "fieldname": "accounting_dimensions_section",
    "fieldtype": "Section Break",
    "label": "Accounting Dimensions"
+  },
+  {
+   "fieldname": "cost_center",
+   "fieldtype": "Link",
+   "label": "Cost Center",
+   "options": "Cost Center",
+   "print_hide": 1
+  },
+  {
+   "fieldname": "dimension_col_break",
+   "fieldtype": "Column Break"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-01-31 19:46:27.884592",
+ "modified": "2026-06-15 00:00:00.000000",
  "modified_by": "Administrator",
  "module": "Buying",
  "name": "Request for Quotation Item",

--- a/erpnext/hooks.py
+++ b/erpnext/hooks.py
@@ -596,6 +596,7 @@ accounting_dimension_doctypes = [
 	"Account Closing Balance",
 	"Supplier Quotation",
 	"Supplier Quotation Item",
+	"Request for Quotation Item",
 	"Payment Reconciliation",
 	"Payment Reconciliation Allocation",
 	"Payment Request",

--- a/erpnext/stock/doctype/material_request/mapper.py
+++ b/erpnext/stock/doctype/material_request/mapper.py
@@ -131,6 +131,7 @@ def make_request_for_quotation(source_name: str, target_doc: str | Document | No
 					["name", "material_request_item"],
 					["parent", "material_request"],
 					["project", "project_name"],
+					["cost_center", "cost_center"],
 				],
 			},
 		},


### PR DESCRIPTION
## Summary

Fixes #55855

- Added `cost_center` field and standard `accounting_dimensions_section` / `dimension_col_break` section breaks to the **Request for Quotation Item** DocType, so custom accounting dimensions automatically propagate via `make_dimension_in_accounting_doctypes()`
- Registered `Request for Quotation Item` in the `accounting_dimension_doctypes` hook in `hooks.py`
- Mapped `cost_center` (and by extension any custom accounting dimensions with matching fieldnames) through the full chain:
  - **Material Request → RFQ** (`material_request/mapper.py` — `make_request_for_quotation`)
  - **RFQ → Supplier Quotation** (`request_for_quotation/mapper.py` — `make_supplier_quotation_from_rfq`)
  - **RFQ → Supplier Quotation via portal** (`request_for_quotation/mapper.py` — `create_rfq_items`)
  - **MR-based RFQ creation** (`request_for_quotation/mapper.py` — `get_item_from_material_requests_based_on_supplier`)

## Test plan

- [ ] Create a Material Request with a `cost_center` set on items — verify `cost_center` appears on the mapped RFQ items
- [ ] Create an RFQ with `cost_center` set on items — verify `cost_center` appears on the mapped Supplier Quotation items
- [ ] End-to-end: MR → RFQ → SQ, confirm `cost_center` flows through all three
- [ ] Add a custom accounting dimension via Accounting Dimension doctype — confirm it appears in RFQ Item and flows to SQ

🤖 Generated with [Claude Code](https://claude.com/claude-code)

#no-docs