### PR TITLE
refactor: ignore cancelled GLE's while looking for account

### DIFF
--- a/erpnext/accounts/party.py
+++ b/erpnext/accounts/party.py
@@ -543,11 +543,19 @@ def get_party_gle_currency(party_type, party, company):
 
 def get_party_gle_account(party_type, party, company):
 	def generator():
-		existing_gle_account = frappe.db.sql(
-			"""select account from `tabGL Entry`
-			where docstatus=1 and company=%(company)s and party_type=%(party_type)s and party=%(party)s
-			limit 1""",
-			{"company": company, "party_type": party_type, "party": party},
+		gl = qb.DocType("GL Entry")
+		existing_gle_account = (
+			qb.from_(gl)
+			.select(gl.account)
+			.where(
+				(gl.docstatus == 1)
+				& (gl.company == company)
+				& (gl.party_type == party_type)
+				& (gl.party == party)
+				& (gl.is_cancelled == 0)
+			)
+			.limit(1)
+			.run()
 		)
 
 		return existing_gle_account[0][0] if existing_gle_account else None


### PR DESCRIPTION
**Issue :** 
On the Customer/Supplier dashboard, Total Unpaid and Annual Billing show the wrong currency symbol. This happens for a party that has cancelled GL Entries in one currency and live GL Entries in another currency within the same company.  

**Ref:** [#71183](https://support.frappe.io/helpdesk/tickets/71183)

**Backport Needed for v15 & v16**