### PR TITLE
fix(tds): clear error when applying TDS on a Journal Entry without a party

### DIFF
--- a/erpnext/accounts/doctype/tax_withholding_category/tax_withholding_category.py
+++ b/erpnext/accounts/doctype/tax_withholding_category/tax_withholding_category.py
@@ -252,4 +252,8 @@ class TaxWithholdingDetails:
 @allow_regional
 def get_tax_id_for_party(party_type, party):
 	# cannot use tax_id from doc because payment and journal entry do not have tax_id field.\
+	# Journal Entries (and party-less vouchers) have no single party, so there is no tax_id to fetch.
+	if not party_type or not party:
+		return
+
 	return frappe.db.get_value(party_type, party, "tax_id")

--- a/erpnext/accounts/doctype/tax_withholding_entry/tax_withholding_entry.py
+++ b/erpnext/accounts/doctype/tax_withholding_entry/tax_withholding_entry.py
@@ -1443,6 +1443,12 @@ class JournalTaxWithholding(TaxWithholdingController):
 			self.doc.tax_withholding_entries = []
 			return False
 
+		if not self.party_type:
+			frappe.throw(
+				_("To apply Tax Withholding, add a row with a Supplier or Customer party."),
+				title=_("Party Required for Tax Withholding"),
+			)
+
 		return True
 
 	def _get_linked_payments(self):


### PR DESCRIPTION
## Problem

Checking **Apply TDS** on a Journal Entry (Debit Note / Credit Note) and selecting a Tax Withholding Category, **without** an accounting row that has a Supplier/Customer party, crashes the save with an opaque error:

> Not found — **DocType None not found**
<img width="2562" height="1420" alt="Screenshot 2026-06-15 at 7 39 03 PM" src="https://github.com/user-attachments/assets/411ba7ad-a3e0-4f35-b2a5-1391b4d76e66" />


### What the user sees

<!-- Screenshot: drag the "DocType None not found" dialog image here -->

UI dialog:
```
Not found
DocType None not found
The resource you are looking for is not available
```

Browser console:
```
POST /api/method/frappe.desk.form.save.savedocs 404 (NOT FOUND)
TypeError: Cannot read properties of undefined (reading 'exc')  (form.js:824)
```

Server traceback (root):
```
File ".../tax_withholding_entry.py", in on_validate -> self.calculate()
File ".../tax_withholding_entry.py", in _get_category_details
File ".../tax_withholding_category.py", in __init__
    self.tax_id = get_tax_id_for_party(self.party_type, self.party)
File ".../tax_withholding_category.py", in get_tax_id_for_party
    return frappe.db.get_value(party_type, party, "tax_id")   # party_type is None
...
frappe.exceptions.DoesNotExistError: DocType None not found
```

### Root cause

`JournalTaxWithholding._setup_party_info()` only sets `party_type`/`party` when an accounting row has a Supplier or Customer party. With no such row, `party_type` stays `None`, but `_is_tax_withholding_applicable()` returns `True` anyway (it only checks `apply_tds`, voucher type, and category). The calculation then proceeds with `None`:

1. `get_tax_id_for_party(None, None)` → `frappe.db.get_value(None, …)` → **"DocType None not found"**
2. `_calculate_net_total()` → `d.get(None) - d.get(None)` → `TypeError`

## Fix

- **`tax_withholding_entry.py`** — `JournalTaxWithholding._is_tax_withholding_applicable()` now requires a party and raises a clear, actionable message instead of letting the calculation crash:
  > To apply Tax Withholding, add a row with a Supplier or Customer party.

  The party requirement is **enforced** (not relaxed) — TDS on a Journal Entry is meaningless without a party.
- **`tax_withholding_category.py`** — defensive guard so `get_tax_id_for_party` returns early on a missing party and can never raise the cryptic "DocType None not found" from any other code path.

## Testing

Reproduced the exact crash, then verified after the fix:
- Apply TDS + category + **no party** → clear "Party Required for Tax Withholding" message (no crash).
- Non-TDS Journal Entry → saves normally (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)