### PR TITLE
refactor(test): faster transaction deletion record tests

### DIFF
--- a/erpnext/setup/doctype/transaction_deletion_record/test_transaction_deletion_record.py
+++ b/erpnext/setup/doctype/transaction_deletion_record/test_transaction_deletion_record.py
@@ -11,7 +11,6 @@ class TestTransactionDeletionRecord(ERPNextTestSuite):
 	def setUp(self):
 		# Clear all deletion cache flags from previous tests
 		self._clear_all_deletion_cache_flags()
-		create_company("Dunder Mifflin Paper Co")
 
 	def _clear_all_deletion_cache_flags(self):
 		"""Clear all deletion_running_doctype:* cache keys"""
@@ -31,7 +30,7 @@ class TestTransactionDeletionRecord(ERPNextTestSuite):
 
 	def test_doctypes_contain_company_field(self):
 		"""Test that all DocTypes in To Delete list have a valid company link field"""
-		tdr = create_and_submit_transaction_deletion_doc("Dunder Mifflin Paper Co")
+		tdr = create_and_submit_transaction_deletion_doc("_Test Company 7")
 		for doctype_row in tdr.doctypes_to_delete:
 			# If company_field is specified, verify it's a valid Company link field
 			if doctype_row.company_field:
@@ -53,8 +52,8 @@ class TestTransactionDeletionRecord(ERPNextTestSuite):
 	def test_no_of_docs_is_correct(self):
 		"""Test that document counts are calculated correctly in To Delete list"""
 		for _ in range(5):
-			create_task("Dunder Mifflin Paper Co")
-		tdr = create_and_submit_transaction_deletion_doc("Dunder Mifflin Paper Co")
+			create_task("_Test Company 7")
+		tdr = create_and_submit_transaction_deletion_doc("_Test Company 7")
 		tdr.reload()
 
 		# Check To Delete list has correct count
@@ -68,9 +67,9 @@ class TestTransactionDeletionRecord(ERPNextTestSuite):
 
 	def test_deletion_is_successful(self):
 		"""Test that deletion actually removes documents"""
-		create_task("Dunder Mifflin Paper Co")
-		create_and_submit_transaction_deletion_doc("Dunder Mifflin Paper Co")
-		tasks_containing_company = frappe.get_all("Task", filters={"company": "Dunder Mifflin Paper Co"})
+		create_task("_Test Company 7")
+		create_and_submit_transaction_deletion_doc("_Test Company 7")
+		tasks_containing_company = frappe.get_all("Task", filters={"company": "_Test Company 7"})
 		self.assertEqual(tasks_containing_company, [])
 
 	def test_company_transaction_deletion_request(self):
@@ -78,15 +77,14 @@ class TestTransactionDeletionRecord(ERPNextTestSuite):
 		from erpnext.setup.doctype.company.company import create_transaction_deletion_request
 
 		# don't reuse below company for other test cases
-		company = "Deep Space Exploration"
-		create_company(company)
+		company = "_Test Company 7"
 
 		# below call should not raise any exceptions or throw errors
 		create_transaction_deletion_request(company)
 
 	def test_generate_to_delete_list(self):
 		"""Test automatic generation of To Delete list"""
-		company = "Dunder Mifflin Paper Co"
+		company = "_Test Company 7"
 		create_task(company)
 
 		tdr = frappe.new_doc("Transaction Deletion Record")
@@ -104,7 +102,7 @@ class TestTransactionDeletionRecord(ERPNextTestSuite):
 
 	def test_validation_prevents_child_tables(self):
 		"""Test that child tables cannot be added to To Delete list"""
-		company = "Dunder Mifflin Paper Co"
+		company = "_Test Company 7"
 
 		tdr = frappe.new_doc("Transaction Deletion Record")
 		tdr.company = company
@@ -116,7 +114,7 @@ class TestTransactionDeletionRecord(ERPNextTestSuite):
 
 	def test_validation_prevents_protected_doctypes(self):
 		"""Test that protected DocTypes cannot be added to To Delete list"""
-		company = "Dunder Mifflin Paper Co"
+		company = "_Test Company 7"
 
 		tdr = frappe.new_doc("Transaction Deletion Record")
 		tdr.company = company
@@ -128,7 +126,7 @@ class TestTransactionDeletionRecord(ERPNextTestSuite):
 
 	def test_csv_export_import(self):
 		"""Test CSV export and import functionality with company_field column"""
-		company = "Dunder Mifflin Paper Co"
+		company = "_Test Company 7"
 		create_task(company)
 
 		# Create and generate To Delete list
@@ -167,7 +165,7 @@ class TestTransactionDeletionRecord(ERPNextTestSuite):
 
 	def test_progress_tracking(self):
 		"""Test that deleted checkbox is marked when DocType deletion completes"""
-		company = "Dunder Mifflin Paper Co"
+		company = "_Test Company 7"
 		create_task(company)
 
 		tdr = create_and_submit_transaction_deletion_doc(company)
@@ -186,7 +184,7 @@ class TestTransactionDeletionRecord(ERPNextTestSuite):
 
 	def test_composite_key_validation(self):
 		"""Test that duplicate (doctype_name + company_field) combinations are prevented"""
-		company = "Dunder Mifflin Paper Co"
+		company = "_Test Company 7"
 
 		tdr = frappe.new_doc("Transaction Deletion Record")
 		tdr.company = company
@@ -199,7 +197,7 @@ class TestTransactionDeletionRecord(ERPNextTestSuite):
 
 	def test_same_doctype_different_company_field_allowed(self):
 		"""Test that same DocType can be added with different company_field values"""
-		company = "Dunder Mifflin Paper Co"
+		company = "_Test Company 7"
 
 		tdr = frappe.new_doc("Transaction Deletion Record")
 		tdr.company = company
@@ -220,7 +218,7 @@ class TestTransactionDeletionRecord(ERPNextTestSuite):
 
 	def test_company_field_validation(self):
 		"""Test that invalid company_field values are rejected"""
-		company = "Dunder Mifflin Paper Co"
+		company = "_Test Company 7"
 
 		tdr = frappe.new_doc("Transaction Deletion Record")
 		tdr.company = company
@@ -274,7 +272,7 @@ class TestTransactionDeletionRecord(ERPNextTestSuite):
 
 	def test_cache_flag_management(self):
 		"""Test that cache flags can be set and cleared correctly"""
-		company = "Dunder Mifflin Paper Co"
+		company = "_Test Company 7"
 		create_task(company)
 
 		tdr = frappe.new_doc("Transaction Deletion Record")
@@ -303,7 +301,7 @@ class TestTransactionDeletionRecord(ERPNextTestSuite):
 			check_for_running_deletion_job,
 		)
 
-		company = "Dunder Mifflin Paper Co"
+		company = "_Test Company 7"
 
 		# Manually set cache flag to simulate running deletion
 		frappe.cache.set_value("deletion_running_doctype:Task", "TDR-00001", expires_in_sec=60)
@@ -327,7 +325,7 @@ class TestTransactionDeletionRecord(ERPNextTestSuite):
 
 	def test_check_for_running_deletion_allows_save_when_no_flag(self):
 		"""Test that documents can be saved when no deletion is running"""
-		company = "Dunder Mifflin Paper Co"
+		company = "_Test Company 7"
 
 		# Ensure no cache flag exists
 		frappe.cache.delete_value("deletion_running_doctype:Task")
@@ -347,10 +345,8 @@ class TestTransactionDeletionRecord(ERPNextTestSuite):
 
 	def test_only_one_deletion_allowed_globally(self):
 		"""Test that only one deletion can be submitted at a time (global enforcement)"""
-		company1 = "Dunder Mifflin Paper Co"
-		company2 = "Sabre Corporation"
-
-		create_company(company2)
+		company1 = "_Test Company 6"
+		company2 = "_Test Company 7"
 
 		# Create and submit first deletion (but don't start it)
 		tdr1 = frappe.new_doc("Transaction Deletion Record")
@@ -377,13 +373,6 @@ class TestTransactionDeletionRecord(ERPNextTestSuite):
 		finally:
 			# Cleanup
 			tdr1.cancel()
-
-
-def create_company(company_name):
-	company = frappe.get_doc(
-		{"doctype": "Company", "company_name": company_name, "default_currency": "INR", "country": "India"}
-	)
-	company.insert(ignore_if_duplicate=True)
 
 
 def create_and_submit_transaction_deletion_doc(company):


### PR DESCRIPTION
## Before
<img width="1850" height="828" alt="Screenshot 2026-06-16 at 8 05 38 AM" src="https://github.com/user-attachments/assets/6a52f7e9-6b10-48f0-9420-140c3063f6fe" />


## After
<img width="1854" height="840" alt="Screenshot 2026-06-16 at 8 04 06 AM" src="https://github.com/user-attachments/assets/4f93b0b1-ad50-4016-a513-a165e6cb328b" />
