### PR TITLE
fix(stock): update voucher valuaion rate in sle

### DIFF
--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -914,6 +914,16 @@ class update_entries_after:
 				and not has_dimensions
 			):
 				# assert
+				if (
+					sle.voucher_detail_no
+					and self.repost_doc
+					and self.repost_doc.get("recalculate_valuation_rate")
+				):
+					source_rate = frappe.get_cached_value(
+						"Stock Reconciliation Item", sle.voucher_detail_no, "valuation_rate"
+					)
+					if source_rate:
+						sle.valuation_rate = source_rate
 				self.wh_data.valuation_rate = sle.valuation_rate
 				self.wh_data.qty_after_transaction = sle.qty_after_transaction
 				self.wh_data.stock_value = flt(self.wh_data.qty_after_transaction) * flt(


### PR DESCRIPTION
**Issue:**
Previously, the system applied precision to the **Valuation Rate** while creating Stock Reconciliations, which resulted in incorrect valuation rates being posted to Stock Ledger Entries (SLEs) for non-serial and non-batch items.

Although the issue has been fixed for newly created Stock Reconciliations, existing affected Stock Reconciliations cannot be corrected through reposting. During reposting, the system recalculates values using the valuation rate stored in the SLE, which already contains the incorrect rounded value. Instead, the reposting process should use the original valuation rate from the Stock Reconciliation document so that historical Stock Reconciliation entries can be corrected accurately.

**Ref:** [#68993](https://support.frappe.io/helpdesk/tickets/68993)

**Backport Needed for v15 & v16**