### PR TITLE
fix: restrict Party Type/Party to Receivable/Payable accounts in Journal Entry

### DIFF
--- a/erpnext/accounts/doctype/journal_entry/journal_entry.py
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.py
@@ -484,6 +484,12 @@ class JournalEntry(AccountsController):
 							d.idx, d.account, d.party_type
 						)
 					)
+			elif d.party_type or d.party:
+				frappe.throw(
+					_(
+						"Row {0}: Party Type or Party can only be set for Receivable / Payable account, but account {1} is of type {2}"
+					).format(d.idx, d.account, account_type or _("None"))
+				)
 
 	def check_credit_limit(self):
 		customers = list(

--- a/erpnext/accounts/doctype/journal_entry/test_journal_entry.py
+++ b/erpnext/accounts/doctype/journal_entry/test_journal_entry.py
@@ -662,6 +662,13 @@ class TestJournalEntry(ERPNextTestSuite):
 		jv.save()
 		self.assertRaises(frappe.ValidationError, jv.submit)
 
+	def test_party_not_allowed_for_non_receivable_payable_account(self):
+		customer = make_customer("_Test New Customer")
+		jv = make_journal_entry(account1="_Test Cash - _TC", account2="_Test Bank - _TC", amount=100, save=False)
+		jv.accounts[0].party_type = "Customer"
+		jv.accounts[0].party = customer
+		self.assertRaises(frappe.ValidationError, jv.save)
+
 	def test_validate_reference_doc_debit_against_sales_order_throws(self):
 		"""Characterize: a debit entry linked to a Sales Order is rejected."""
 		from erpnext.selling.doctype.sales_order.test_sales_order import make_sales_order


### PR DESCRIPTION
## Problem

In v15/v16, a Journal Entry allows entering **Party Type** and **Party** against accounts that are **not** configured with Account Type = Receivable/Payable. The entry can be saved and submitted successfully. This differs from v14, where party information could only be captured for Receivable/Payable accounts.

### Steps to reproduce
1. Create/select an Account with Account Type left blank (or any non-Receivable/Payable type).
2. Create a Journal Entry and select that account.
3. Enter Party Type and Party, and a debit/credit amount.
4. Save and submit — succeeds (incorrect).

## Fix

`JournalEntry.validate_party()` only validated party details *when* the account was Receivable/Payable; it never restricted party entry on other account types. This PR adds a branch that throws when a Party Type or Party is set on an account that is not Receivable/Payable, with a clear validation message indicating the row, account, and its actual type.

## Test

Added `test_party_not_allowed_for_non_receivable_payable_account` asserting that a Journal Entry with a party on a cash account raises `ValidationError`.