### PR TITLE
fix: bump BOM secondary item modified timestamp

### DIFF
--- a/erpnext/manufacturing/doctype/bom_secondary_item/bom_secondary_item.json
+++ b/erpnext/manufacturing/doctype/bom_secondary_item/bom_secondary_item.json
@@ -217,7 +217,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-06-03 16:10:18.474377",
+ "modified": "2026-06-16 16:51:40.000000",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "BOM Secondary Item",


### PR DESCRIPTION
## Summary

Bump the `modified` timestamp on `BOM Secondary Item` after the `qty` field metadata changed.

The `reqd` flag was removed from `qty`, but without a newer DocType `modified` timestamp, migration can skip syncing the schema metadata.

## Validation

- `python -m json.tool erpnext/manufacturing/doctype/bom_secondary_item/bom_secondary_item.json >/dev/null`
- `git diff --check`
