### PR TITLE
feat: quantity based billing percentage calculation in Delivery Note

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -350,7 +350,16 @@ class SalesInvoice(SellingController):
 
 		from erpnext.accounts.services.billing_validation import BillingValidationService
 
-		BillingValidationService(self).validate_multiple_billing("Delivery Note", "dn_detail", "amount")
+		based_on = (
+			"qty"
+			if frappe.db.get_single_value(
+				"Selling Settings",
+				"quantity_based_billing_percentage"
+			)
+			else "amount"
+		)
+
+		BillingValidationService(self).validate_multiple_billing("Delivery Note", "dn_detail", based_on)
 
 		if self.is_return and self.return_against:
 			for row in self.timesheets:

--- a/erpnext/controllers/status_updater.py
+++ b/erpnext/controllers/status_updater.py
@@ -647,13 +647,26 @@ class StatusUpdater(Document):
 		update_data = {}
 
 		if args.get("target_parent_field"):
-			update_data[args.get("target_parent_field")] = self._calculate_target_parent_percentage(
-				args["name"],
-				args["target_parent_dt"],
-				args["target_dt"],
-				args["target_ref_field"],
-				args["target_field"],
-			)
+
+			quantity_based_billing = (
+            args.get("target_parent_dt") == "Delivery Note"
+            and frappe.db.get_single_value("Selling Settings", "quantity_based_billing_percentage")
+        	)
+
+			if quantity_based_billing:
+				total_qty = flt(args.get("total_qty", 0))
+				total_invoiced_qty = flt(args.get("total_invoiced_qty", 0))
+				per_billed = (total_invoiced_qty / total_qty * 100) if total_qty > 0 else 0
+				update_data[args.get("target_parent_field")] = per_billed
+
+			else:
+				update_data[args.get("target_parent_field")] = self._calculate_target_parent_percentage(
+					args["name"],
+					args["target_parent_dt"],
+					args["target_dt"],
+					args["target_ref_field"],
+					args["target_field"],
+				)
 			# update field
 			if args.get("status_field"):
 				update_data[args.get("status_field")] = self._determine_status(

--- a/erpnext/controllers/stock_controller.py
+++ b/erpnext/controllers/stock_controller.py
@@ -6,6 +6,7 @@ import json
 import frappe
 from frappe import _, bold
 from frappe.utils import cint, cstr, flt, get_link_to_form, getdate
+from frappe.query_builder.functions import Sum
 
 import erpnext
 from erpnext.accounts.general_ledger import (
@@ -309,14 +310,33 @@ class StockController(AccountsController):
 
 	def update_billing_percentage(self, update_modified=True):
 		target_ref_field = "amount"
+		target_field = "billed_amt"
+
+		total_amount = total_returned = 0
+		total_qty = total_invoiced_qty = 0
+
 		if self.doctype == "Delivery Note":
-			total_amount = total_returned = 0
 			for item in self.items:
 				total_amount += flt(item.amount)
 				total_returned += flt(item.returned_qty * item.rate)
+				total_qty += flt(item.qty)           
 
-			if total_returned < total_amount:
-				target_ref_field = {"SUB": ["amount", {"MUL": ["returned_qty", "rate"]}], "as": "ref_amount"}
+				Sales_Invoice_Item = frappe.qb.DocType("Sales Invoice Item")
+				invoiced_qty = (
+					frappe.qb.from_(Sales_Invoice_Item)
+					.select(Sum(Sales_Invoice_Item.qty))
+					.where(
+						(Sales_Invoice_Item.dn_detail == item.name)
+						& (Sales_Invoice_Item.docstatus == 1)
+						& (Sales_Invoice_Item.delivery_note == self.name)
+        				& (Sales_Invoice_Item.item_code == item.item_code)
+					)
+				).run()
+				total_invoiced_qty += flt(invoiced_qty[0][0] if invoiced_qty else 0)
+
+				if total_returned < total_amount:
+					target_ref_field = {"SUB": ["amount", {"MUL": ["returned_qty", "rate"]}], "as": "ref_amount"}
+				
 
 		self._update_percent_field(
 			{
@@ -324,12 +344,13 @@ class StockController(AccountsController):
 				"target_parent_dt": self.doctype,
 				"target_parent_field": "per_billed",
 				"target_ref_field": target_ref_field,
-				"target_field": "billed_amt",
+				"target_field": target_field,
 				"name": self.name,
+				"total_qty": total_qty,
+            	"total_invoiced_qty": total_invoiced_qty,
 			},
 			update_modified,
 		)
-
 	def validate_inspection(self):
 		from erpnext.stock.services.quality_inspection_service import QualityInspectionService
 

--- a/erpnext/controllers/stock_controller.py
+++ b/erpnext/controllers/stock_controller.py
@@ -321,15 +321,15 @@ class StockController(AccountsController):
 				total_returned += flt(item.returned_qty * item.rate)
 				total_qty += flt(item.qty)           
 
-				Sales_Invoice_Item = frappe.qb.DocType("Sales Invoice Item")
+				SalesInvoiceItem = frappe.qb.DocType("Sales Invoice Item")
 				invoiced_qty = (
-					frappe.qb.from_(Sales_Invoice_Item)
-					.select(Sum(Sales_Invoice_Item.qty))
+					frappe.qb.from_(SalesInvoiceItem)
+					.select(Sum(SalesInvoiceItem.qty))
 					.where(
-						(Sales_Invoice_Item.dn_detail == item.name)
-						& (Sales_Invoice_Item.docstatus == 1)
-						& (Sales_Invoice_Item.delivery_note == self.name)
-        				& (Sales_Invoice_Item.item_code == item.item_code)
+						(SalesInvoiceItem.dn_detail == item.name)
+						& (SalesInvoiceItem.docstatus == 1)
+						& (SalesInvoiceItem.delivery_note == self.name)
+        				& (SalesInvoiceItem.item_code == item.item_code)
 					)
 				).run()
 				total_invoiced_qty += flt(invoiced_qty[0][0] if invoiced_qty else 0)
@@ -337,7 +337,6 @@ class StockController(AccountsController):
 				if total_returned < total_amount:
 					target_ref_field = {"SUB": ["amount", {"MUL": ["returned_qty", "rate"]}], "as": "ref_amount"}
 				
-
 		self._update_percent_field(
 			{
 				"target_dt": self.doctype + " Item",

--- a/erpnext/selling/doctype/selling_settings/selling_settings.json
+++ b/erpnext/selling/doctype/selling_settings/selling_settings.json
@@ -37,6 +37,7 @@
   "allow_multiple_items",
   "allow_against_multiple_purchase_orders",
   "hide_tax_id",
+  "quantity_based_billing_percentage",
   "section_break_jcmi",
   "allow_sales_order_creation_for_expired_quotation",
   "dont_reserve_sales_order_qty_on_sales_return",
@@ -405,6 +406,14 @@
    "fieldname": "transaction_naming_html",
    "fieldtype": "HTML"
   }
+  ,
+  {
+   "default": "0",
+   "description": "When enabled, billing status is calculated using delivered and invoiced quantities. When disabled, billing status is calculated using invoiced amount versus the total Delivery Note amount.",
+   "fieldname": "quantity_based_billing_percentage",
+   "fieldtype": "Check",
+   "label": "Quantity Based Billing Percentage In Delivery Note"
+  }
  ],
  "grid_page_length": 50,
  "icon": "fa fa-cog",
@@ -412,7 +421,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2026-04-29 11:05:48.836362",
+ "modified": "2026-06-16 13:23:31.413701",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Selling Settings",

--- a/erpnext/selling/doctype/selling_settings/selling_settings.py
+++ b/erpnext/selling/doctype/selling_settings/selling_settings.py
@@ -54,6 +54,7 @@ class SellingSettings(Document):
 		hide_tax_id: DF.Check
 		maintain_same_rate_action: DF.Literal["Stop", "Warn"]
 		maintain_same_sales_rate: DF.Check
+		quantity_based_billing_percentage: DF.Check
 		role_to_override_stop_action: DF.Link | None
 		sales_update_frequency: DF.Literal["Monthly", "Each Transaction", "Daily"]
 		selling_price_list: DF.Link | None

--- a/erpnext/stock/doctype/delivery_note/test_delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/test_delivery_note.py
@@ -1051,6 +1051,37 @@ class TestDeliveryNote(ERPNextTestSuite):
 		self.assertEqual(dn2.get("items")[0].billed_amt, 300)
 		self.assertEqual(dn2.per_billed, 100)
 		self.assertEqual(dn2.status, "Completed")
+		
+	@ERPNextTestSuite.change_settings("Selling Settings", {"quantity_based_billing_percentage": 1})
+	
+	def test_dn_billing_status_quantity_based(self):
+		# SO -> DN -> SI (quantity based billing)
+		so = make_sales_order(po_no="12345")
+		dn = create_dn_against_so(so.name, delivered_qty=5)
+
+		self.assertEqual(dn.status, "To Bill")
+		self.assertEqual(dn.per_billed, 0)
+
+		# Partial qty invoice → Partially Billed
+		si1 = make_sales_invoice(dn.name)
+		si1.items[0].qty = 2
+		si1.items[0].rate = 250
+		si1.save()
+		si1.submit()
+
+		dn.load_from_db()
+		self.assertEqual(dn.per_billed, 40)
+		self.assertEqual(dn.status, "Partially Billed")
+
+		# Full qty invoiced → Completed
+		si2 = make_sales_invoice(dn.name)
+		si2.items[0].qty = 3
+		si2.save()
+		si2.submit()
+
+		dn.load_from_db()
+		self.assertEqual(dn.per_billed, 100)
+		self.assertEqual(dn.status, "Completed")
 
 	@ERPNextTestSuite.change_settings("Accounts Settings", {"delete_linked_ledger_entries": True})
 	def test_sales_invoice_qty_after_return(self):


### PR DESCRIPTION
**Issue:**
Currently, Delivery Note billing status is calculated only based on the billed amount percentage. Because of this, if the invoiced amount reaches 100%, the Delivery Note is marked as Completed, even when the delivered quantity has not been fully invoiced.

To support quantity-driven billing workflows, a new option "Quantity Based Billing Percentage in Delivery Note" has been added to the Delivery Note. When enabled, the system calculates the billing percentage using the invoiced quantity instead of the billed amount.

**Ref:** [#49115](https://support.frappe.io/helpdesk/tickets/49115)