### PR TITLE
fix: check for bank account permission when updating balance

### DIFF
--- a/banking/src/components/features/BankReconciliation/BankBalance.tsx
+++ b/banking/src/components/features/BankReconciliation/BankBalance.tsx
@@ -250,7 +250,7 @@ const ClosingBalanceForm = ({ defaultBalance, date, bankAccount, onClose }: { de
                     {_("Enter the closing balance you see in your bank statement for {0} as of the {1}", [bankAccount?.account_name ?? bankAccount?.name ?? '', formatDate(date, 'Do MMM YYYY')])}
                 </DialogDescription>
             </DialogHeader>
-            {error && <ErrorBanner error={error} />}
+            {error && <div className="py-2"><ErrorBanner error={error} /></div>}
             <div className="py-4">
                 <CurrencyFormField
                     name="balance"

--- a/banking/src/lib/frappe.ts
+++ b/banking/src/lib/frappe.ts
@@ -35,12 +35,12 @@ export const getErrorMessages = (error?: FrappeError | null): ParsedErrorMessage
 
     // @ts-expect-error - some errors have _error_message
     if (error?._error_message) {
-        eMessages = [{
+        eMessages.push({
             // @ts-expect-error - some errors have _error_message
             message: error?._error_message,
             title: "Error",
             indicator: "red"
-        }]
+        })
     }
 
     if (eMessages.length === 0) {

--- a/banking/src/lib/frappe.ts
+++ b/banking/src/lib/frappe.ts
@@ -33,6 +33,16 @@ export const getErrorMessages = (error?: FrappeError | null): ParsedErrorMessage
         }
     })
 
+    // @ts-expect-error - some errors have _error_message
+    if (error?._error_message) {
+        eMessages = [{
+            // @ts-expect-error - some errors have _error_message
+            message: error?._error_message,
+            title: "Error",
+            indicator: "red"
+        }]
+    }
+
     if (eMessages.length === 0) {
         // Get the message from the exception by removing the exc_type
         const indexOfFirstColon = error?.exception?.indexOf(':')

--- a/erpnext/accounts/doctype/bank_account/bank_account.py
+++ b/erpnext/accounts/doctype/bank_account/bank_account.py
@@ -194,8 +194,6 @@ def set_closing_balance_as_per_statement(bank_account: str, date: str | datetime
 	Set the closing balance as per statement for a bank account and date
 	"""
 
-	frappe.has_permission("Bank Account", doc=bank_account, ptype="write", throw=True)
-
 	existing = frappe.db.exists("Bank Account Balance", {"bank_account": bank_account, "date": date})
 
 	if existing:

--- a/erpnext/accounts/doctype/bank_account/bank_account.py
+++ b/erpnext/accounts/doctype/bank_account/bank_account.py
@@ -194,6 +194,8 @@ def set_closing_balance_as_per_statement(bank_account: str, date: str | datetime
 	Set the closing balance as per statement for a bank account and date
 	"""
 
+	frappe.has_permission("Bank Account", doc=bank_account, ptype="write", throw=True)
+
 	existing = frappe.db.exists("Bank Account Balance", {"bank_account": bank_account, "date": date})
 
 	if existing:

--- a/erpnext/accounts/doctype/bank_account_balance/bank_account_balance.json
+++ b/erpnext/accounts/doctype/bank_account_balance/bank_account_balance.json
@@ -1,5 +1,6 @@
 {
  "actions": [],
+ "allow_bulk_edit": 1,
  "allow_rename": 1,
  "creation": "2026-04-11 19:48:13.622253",
  "doctype": "DocType",
@@ -7,7 +8,8 @@
  "field_order": [
   "bank_account",
   "date",
-  "balance"
+  "balance",
+  "company"
  ],
  "fields": [
   {
@@ -31,12 +33,20 @@
    "in_list_view": 1,
    "label": "Balance",
    "reqd": 1
+  },
+  {
+   "fetch_from": "bank_account.company",
+   "fieldname": "company",
+   "fieldtype": "Link",
+   "label": "Company",
+   "options": "Company",
+   "read_only": 1
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-04-11 19:49:45.374695",
+ "modified": "2026-06-16 22:17:48.007982",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Bank Account Balance",

--- a/erpnext/accounts/doctype/bank_account_balance/bank_account_balance.py
+++ b/erpnext/accounts/doctype/bank_account_balance/bank_account_balance.py
@@ -16,6 +16,7 @@ class BankAccountBalance(Document):
 
 		balance: DF.Currency
 		bank_account: DF.Link
+		company: DF.Link | None
 		date: DF.Date
 	# end: auto-generated types
 


### PR DESCRIPTION
If the user does not have access to the Bank Account (via company permissions) - do not allow updating bank balance. Simple fix was to add a company field in the Bank Account Balance DocType - fetch from.

`no-docs`