### PR TITLE
fix(company): replaced "this company" with company name on delete transactions dialog

### DIFF
--- a/erpnext/setup/doctype/company/company.js
+++ b/erpnext/setup/doctype/company/company.js
@@ -227,12 +227,11 @@ frappe.ui.form.on("Company", {
 							{
 								fieldtype: "Data",
 								fieldname: "company_name",
-								label: __('Please enter the company name <b>"{0}"</b> to confirm', [
-									frappe.utils.escape_html(frm.doc.name),
-								]),
+								label: __("Please enter the company name to confirm"),
 								reqd: 1,
 								description: __(
-									"Please make sure you really want to delete all the transactions for this company. Your master data will remain as it is. This action cannot be undone."
+									"Please make sure you really want to delete all the transactions for {0}. Your master data will remain as it is. This action cannot be undone.",
+									[frappe.utils.bold(frm.doc.name)]
 								),
 							},
 							function (data) {
@@ -252,7 +251,7 @@ frappe.ui.form.on("Company", {
 									},
 								});
 							},
-							__("Delete all the Transactions for this Company"),
+							__("Delete all the Transactions for {0}", [frappe.utils.bold(frm.doc.name)]),
 							__("Delete")
 						);
 						d.get_primary_btn().addClass("btn-danger");


### PR DESCRIPTION
Before:


<img width="591" height="282" alt="image" src="https://github.com/user-attachments/assets/3b0d04e6-44c7-4d91-9bb6-659cec682b40" />

After:


<img width="589" height="280" alt="image" src="https://github.com/user-attachments/assets/d63621a6-f0fc-489d-82a0-3d714c209159" />

Mainly made this change as the previous changes consisted of HTML tags, which mess up the translation string.
