### PR TITLE
fix: block Accounting Dimension creation when feature is disabled in Accounts Settings

### DIFF
--- a/erpnext/accounts/doctype/accounting_dimension/accounting_dimension.py
+++ b/erpnext/accounts/doctype/accounting_dimension/accounting_dimension.py
@@ -39,12 +39,22 @@ class AccountingDimension(Document):
 
 	def before_insert(self):
 		self.set_fieldname_and_label()
+		self.validate_accounting_dimensions_enabled()
 
 	def validate(self):
 		self.validate_doctype()
 		validate_column_name(self.fieldname)
 		self.validate_fieldname_conflict()
 		self.validate_dimension_defaults()
+
+	def validate_accounting_dimensions_enabled(self):
+		if not frappe.db.get_single_value("Accounts Settings", "enable_accounting_dimensions"):
+			frappe.throw(
+				_("Please enable {0} in {1} before creating an Accounting Dimension.").format(
+					frappe.bold(_("Enable Accounting Dimensions")),
+					frappe.utils.get_link_to_form("Accounts Settings", "Accounts Settings"),
+				)
+			)
 
 	def validate_doctype(self):
 		if self.document_type in (

--- a/erpnext/accounts/doctype/accounting_dimension/test_accounting_dimension.py
+++ b/erpnext/accounts/doctype/accounting_dimension/test_accounting_dimension.py
@@ -51,6 +51,23 @@ class TestAccountingDimension(ERPNextTestSuite):
 		self.assertEqual(gle.get("department"), "_Test Department - _TC")
 		self.assertEqual(gle1.get("department"), "_Test Department - _TC")
 
+	def test_cannot_create_dimension_when_feature_disabled(self):
+		frappe.db.set_single_value("Accounts Settings", "enable_accounting_dimensions", 0)
+		try:
+			dim = frappe.new_doc("Accounting Dimension")
+			dim.document_type = "Branch"
+			self.assertRaises(frappe.ValidationError, dim.insert)
+		finally:
+			frappe.db.set_single_value("Accounts Settings", "enable_accounting_dimensions", 1)
+
+	def test_can_create_dimension_when_feature_enabled(self):
+		frappe.db.set_single_value("Accounts Settings", "enable_accounting_dimensions", 1)
+		dim = frappe.new_doc("Accounting Dimension")
+		dim.document_type = "Branch"
+		# insert should not raise
+		dim.insert(ignore_permissions=True)
+		frappe.delete_doc("Accounting Dimension", dim.name, force=True)
+
 	def test_mandatory(self):
 		location = frappe.get_doc("Accounting Dimension", "Location")
 		location.dimension_defaults[0].mandatory_for_bs = True


### PR DESCRIPTION
## Summary

- Throws a `ValidationError` in `AccountingDimension.before_insert()` if **Enable Accounting Dimensions** is not checked in Accounts Settings
- Without this guard, users could create dimensions that add custom fields across all configured doctypes even when the feature is intentionally disabled

## Test plan

- [ ] Go to Accounts Settings → uncheck **Enable Accounting Dimensions** → try to create a new Accounting Dimension → should get an error with a link to Accounts Settings
- [ ] Enable the setting → create an Accounting Dimension → should succeed normally

Fixes #56026

🤖 Generated with [Claude Code](https://claude.com/claude-code)