### PR TITLE
fix: add dynamic links for customer and supplier dashboards

### DIFF
--- a/erpnext/buying/doctype/supplier/supplier_dashboard.py
+++ b/erpnext/buying/doctype/supplier/supplier_dashboard.py
@@ -5,6 +5,7 @@ def get_data():
 	return {
 		"fieldname": "supplier",
 		"non_standard_fieldnames": {"Payment Entry": "party", "Bank Account": "party"},
+		"dynamic_links": {"party": ["Supplier", "party_type"]},
 		"transactions": [
 			{"label": _("Procurement"), "items": ["Request for Quotation", "Supplier Quotation"]},
 			{"label": _("Orders"), "items": ["Purchase Order", "Purchase Receipt", "Purchase Invoice"]},

--- a/erpnext/selling/doctype/customer/customer_dashboard.py
+++ b/erpnext/selling/doctype/customer/customer_dashboard.py
@@ -11,7 +11,10 @@ def get_data():
 			"Bank Account": "party",
 			"Subscription": "party",
 		},
-		"dynamic_links": {"party_name": ["Customer", "quotation_to"]},
+		"dynamic_links": {
+			"party_name": ["Customer", "quotation_to"],
+			"party": ["Customer", "party_type"],
+		},
 		"transactions": [
 			{"label": _("Pre Sales"), "items": ["Opportunity", "Quotation"]},
 			{"label": _("Orders"), "items": ["Sales Order", "Delivery Note", "Sales Invoice"]},


### PR DESCRIPTION
**Issue:**
When a Customer and a Supplier have the same name, linked documents such as Bank Accounts and Payment Entries can appear in the wrong dashboard connections. This happens because the dashboard lookup does not consider the party type when resolving dynamic links.

backported [#41979](https://github.com/frappe/erpnext/pull/41979)

Ref: [#71159](https://support.frappe.io/helpdesk/tickets/71159)