### PR TITLE
fix: use isin(parties) in rfq_transaction_list to fix supplier portal…

### DIFF
--- a/erpnext/controllers/website_list_for_contact.py
+++ b/erpnext/controllers/website_list_for_contact.py
@@ -183,7 +183,7 @@ def rfq_transaction_list(parties_doctype, doctype, parties, limit_start, limit_p
 		frappe.qb.from_(party)
 		.select(party.parent.as_("name"), party.supplier)
 		.distinct()
-		.where((party.supplier == party[0]) & (party.docstatus == 1))
+		.where((party.supplier.isin(parties)) & (party.docstatus == 1))
 		.orderby(party.creation, order=frappe.qb.desc)
 		.limit(limit_page_length)
 		.offset(limit_start)


### PR DESCRIPTION
> on behalf of @vishwajeet-13 
## Problem
Suppliers cannot view the Request for Quotation list on the portal.
The page crashes with pymysql.err.OperationalError: (1054, "Unknown column '0' in 'WHERE'").

## Root Cause
party[0] was used instead of parties (the list of suppliers).
Since party is a query builder table object, party[0] generates a column named 0 instead of a value, producing invalid SQL.

*Broken:* WHERE supplier = \`0\`
*Fixed:* WHERE supplier IN ('Supplier Name')

## Fix
Changed party.supplier == party[0] to party.supplier.isin(parties) in rfq_transaction_list.

### Before Fix
<img width="1600" height="902" alt="image" src="https://github.com/user-attachments/assets/57773e41-a612-4991-be5d-bd5e077a554b" />

### After Fix
<img width="1600" height="902" alt="image" src="https://github.com/user-attachments/assets/dfbe6c00-83b5-4458-bea7-9fc78e934df1" />


**Support Ticket**: [71374](https://support.frappe.io/helpdesk/tickets/71374)