### PR TITLE
fix(postgres): engine-semantics fixes (voucher_type casing, null serial_no)

### DIFF
--- a/erpnext/accounts/services/exchange_gain_loss.py
+++ b/erpnext/accounts/services/exchange_gain_loss.py
@@ -141,7 +141,7 @@ def make_exchange_gain_loss_journal(
 					.where(
 						(je.docstatus == 1)
 						& (je.name.isin(parents))
-						& (je.voucher_type == "Exchange Gain or Loss")
+						& (je.voucher_type == "Exchange Gain Or Loss")
 					)
 					.run()
 				)

--- a/erpnext/stock/report/available_serial_no/available_serial_no.py
+++ b/erpnext/stock/report/available_serial_no/available_serial_no.py
@@ -73,7 +73,7 @@ def update_available_serial_nos(available_serial_nos, sle):
 	sle.serial_no = "\n".join(serial_nos) if serial_nos else ""
 	if key not in available_serial_nos:
 		available_serial_nos.setdefault(key, serial_nos)
-		sle.balance_serial_no = "\n".join(serial_nos)
+		sle.balance_serial_no = "\n".join(serial_nos) if serial_nos else ""
 		return
 
 	existing_serial_no = available_serial_nos[key]


### PR DESCRIPTION
## Goal

Make ERPNext run identically on **MariaDB and PostgreSQL from a single codebase**. This PR carries two tiny, independent PostgreSQL-strictness fixes — each a different class, each a **one-line no-op on MariaDB** — as separate commits.

> [!NOTE]
> PostgreSQL CI for ERPNext is added in the final PR of the series; until then this is gated only by the existing **MariaDB** suite staying green.

## The fixes (one commit each)

**1. Case-sensitivity — `accounts/services/exchange_gain_loss.py`**
The "already booked" guard compared `voucher_type == "Exchange Gain or Loss"` (lowercase *or*), but the value is created everywhere as `"Exchange Gain Or Loss"`. MariaDB matches case-insensitively so the guard worked; PostgreSQL is case-sensitive, so the guard never matched and a **second** exchange gain/loss journal entry was booked. Fixed by matching the stored casing.

**2. Null-handling — `stock/report/available_serial_no/available_serial_no.py`**
`balance_serial_no` was set from a bare `"\n".join(serial_nos)`; when the serial list is empty/None this is now defaulted to `""`, keeping the value a string on both backends.

> A related boolean/smallint fix (`process_payment_reconciliation.py`: `.set(reconciled, True)` → `1`) was split out of this PR — its only code path is the queued bulk `reconcile()`, which has no test today and needs a dedicated payment-reconciliation integration test. It'll ship separately **with** that test rather than untested here.

## Verification (both MariaDB and PostgreSQL — green on both)

- [x] `erpnext.controllers.tests.test_accounts_controller` — exchange-gain-loss casing (`test_14_…`); 40 tests pass on MariaDB and PostgreSQL
- [x] `erpnext.stock.report.available_serial_no.test_available_serial_no` — passes on MariaDB and PostgreSQL

🤖 Generated with [Claude Code](https://claude.com/claude-code)
