### PR TITLE
fix(postgres): final fix-class changes (asset GROUP BY + accounts-controller boolean)

### DIFF
--- a/erpnext/assets/doctype/asset/depreciation.py
+++ b/erpnext/assets/doctype/asset/depreciation.py
@@ -96,7 +96,9 @@ def get_depreciable_assets_data(date):
 		.where(a.status.isin(["Submitted", "Partially Depreciated"]))
 		.where(ds.journal_entry.isnull())
 		.where(ds.schedule_date <= date)
-		.groupby(ads.name)
+		# a.name/a.creation are constant per ads.name; include them so postgres accepts the
+		# SELECT and ORDER BY (one row per Asset Depreciation Schedule either way)
+		.groupby(ads.name, a.name, a.creation)
 		.orderby(a.creation, order=Order.desc)
 	)
 

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -1583,13 +1583,13 @@ def update_invoice_status():
 
 		total = (
 			frappe.qb.terms.Case()
-			.when(invoice.disable_rounded_total, invoice.grand_total)
+			.when(invoice.disable_rounded_total == 1, invoice.grand_total)
 			.else_(invoice.rounded_total)
 		)
 
 		base_total = (
 			frappe.qb.terms.Case()
-			.when(invoice.disable_rounded_total, invoice.base_grand_total)
+			.when(invoice.disable_rounded_total == 1, invoice.base_grand_total)
 			.else_(invoice.base_rounded_total)
 		)
 
@@ -1602,7 +1602,7 @@ def update_invoice_status():
 			& (invoice.outstanding_amount > 0)
 			& (invoice.status.like("Unpaid%") | invoice.status.like("Partly Paid%"))
 			& (
-				((invoice.is_pos & invoice.due_date < today) | is_overdue)
+				(((invoice.is_pos == 1) & (invoice.due_date < today)) | is_overdue)
 				if doctype == "Sales Invoice"
 				else is_overdue
 			)


### PR DESCRIPTION
## Goal

Make ERPNext run identically on **MariaDB and PostgreSQL from a single codebase**. Two tiny, independent PostgreSQL-strictness fixes — different classes, each a **no-op on MariaDB** — as separate commits. This wraps up the cleanly-separable fix-class changes; the remaining engine fixes are entangled with raw-SQL→ORM conversions and ship with their area PRs.

> [!NOTE]
> PostgreSQL CI for ERPNext is added in the final PR of the series; until then this is gated only by the existing **MariaDB** suite staying green.

## The fixes (one commit each)

**1. Strict GROUP BY — `assets/doctype/asset/depreciation.py`**
The query grouped by `ads.name` but selected/ordered by `a.name`/`a.creation`. Those are functionally dependent on `ads.name` (one Asset per schedule), so they're added to the `GROUP BY` — postgres now accepts the query; MariaDB result is unchanged.

**2. Boolean type — `controllers/accounts_controller.py`**
`disable_rounded_total` and `is_pos` are smallint **Check** fields. They were used as bare boolean conditions (`CASE WHEN <int>`, `is_pos & …`), which PostgreSQL rejects. Comparing explicitly against `== 1` renders valid SQL on both backends.

## Verification (both MariaDB and PostgreSQL)

- [x] `erpnext.assets.doctype.asset.test_asset` — 61 tests pass on MariaDB and PostgreSQL
- [x] `erpnext.controllers.tests.test_accounts_controller` — 40 tests pass on MariaDB and PostgreSQL

🤖 Generated with [Claude Code](https://claude.com/claude-code)
