### PR TITLE
feat: add button to create Work Orders for all BOM levels at once

### DIFF
--- a/erpnext/manufacturing/doctype/bom/bom.js
+++ b/erpnext/manufacturing/doctype/bom/bom.js
@@ -262,6 +262,17 @@ frappe.ui.form.on("BOM", {
 				__("Create")
 			);
 
+			const has_sub_assemblies = frm.doc.items && frm.doc.items.some((i) => i.bom_no);
+			if (has_sub_assemblies) {
+				frm.add_custom_button(
+					__("Work Orders (All Levels)"),
+					function () {
+						frm.trigger("make_work_orders_for_sub_assemblies");
+					},
+					__("Create")
+				);
+			}
+
 			if (frm.doc.has_variants) {
 				frm.add_custom_button(
 					__("Variant BOM"),
@@ -353,6 +364,53 @@ frappe.ui.form.on("BOM", {
 				});
 			}
 		);
+	},
+
+	make_work_orders_for_sub_assemblies(frm) {
+		let dialog = new frappe.ui.Dialog({
+			title: __("Create Work Orders for All BOM Levels"),
+			fields: [
+				{
+					fieldname: "qty",
+					fieldtype: "Float",
+					label: __("Qty to Manufacture"),
+					reqd: 1,
+					default: 1,
+				},
+			],
+			primary_action_label: __("Create"),
+			primary_action(data) {
+				dialog.hide();
+				frappe.call({
+					method: "erpnext.manufacturing.doctype.bom.bom.make_work_orders_for_sub_assemblies",
+					args: {
+						bom_no: frm.doc.name,
+						qty: data.qty,
+						company: frm.doc.company,
+						project: frm.doc.project || null,
+					},
+					freeze: true,
+					callback(r) {
+						if (r.message && r.message.length) {
+							const links = r.message
+								.map(
+									(wo) =>
+										`<a href="/app/work-order/${encodeURIComponent(wo.name)}">${
+											wo.name
+										}</a>` + ` &mdash; ${wo.item} (Qty: ${wo.qty})`
+								)
+								.join("<br>");
+							frappe.msgprint({
+								title: __("{0} Work Order(s) Created", [r.message.length]),
+								message: links,
+								indicator: "green",
+							});
+						}
+					},
+				});
+			},
+		});
+		dialog.show();
 	},
 
 	make_variant_bom(frm) {

--- a/erpnext/manufacturing/doctype/bom/bom.py
+++ b/erpnext/manufacturing/doctype/bom/bom.py
@@ -1411,3 +1411,55 @@ def get_backflush_based_on(bom_no=None):
 		)
 
 	return backflush_based_on
+
+
+@frappe.whitelist()
+def make_work_orders_for_sub_assemblies(
+	bom_no: str, qty: float, company: str, project: str | None = None
+) -> list[frappe._dict]:
+	"""Create a Work Order for the given BOM and one for every sub-assembly BOM in its tree.
+
+	Each Work Order is created flat (use_multi_level_bom=0) so that its required-items
+	list reflects only the direct inputs for that assembly level.  Sub-assembly quantities
+	are scaled from the root qty using the exploded_qty values in the BOM tree.
+
+	Returns a list of dicts: {name, item, qty, bom_no} for every Work Order created.
+	"""
+	from erpnext import get_default_company
+	from erpnext.manufacturing.doctype.work_order.mapper import get_item_details as _wo_item_details
+
+	if not frappe.has_permission("Work Order", "write"):
+		frappe.throw(_("Not permitted"), frappe.PermissionError)
+
+	qty = flt(qty)
+	if not qty:
+		frappe.throw(_("Quantity to Manufacture is required"))
+
+	company = company or get_default_company()
+	bom_tree = BOMTree(bom_no)
+
+	# Root node first, then every sub-assembly node (breadth-first)
+	nodes: list[tuple[BOMTree, float]] = [(bom_tree, qty)]
+	for node in bom_tree.level_order_traversal():
+		if node.is_bom:
+			nodes.append((node, flt(qty) * flt(node.exploded_qty)))
+
+	created = []
+	for node, node_qty in nodes:
+		item_details = _wo_item_details(node.item_code, project, throw=False)
+		wo_doc = frappe.new_doc("Work Order")
+		wo_doc.production_item = node.item_code
+		wo_doc.company = company
+		wo_doc.track_semi_finished_goods = frappe.db.get_value("BOM", node.name, "track_semi_finished_goods")
+		wo_doc.update(item_details)
+		# override with the specific BOM for this node (item_details may carry a different default)
+		wo_doc.bom_no = node.name
+		wo_doc.use_multi_level_bom = 0
+		wo_doc.qty = flt(node_qty)
+		wo_doc.get_items_and_operations_from_bom()
+		wo_doc.insert()
+		created.append(
+			frappe._dict(name=wo_doc.name, item=node.item_code, qty=flt(node_qty), bom_no=node.name)
+		)
+
+	return created


### PR DESCRIPTION
## Summary

- Adds a **"Work Orders (All Levels)"** button under the **Create** dropdown on the BOM form
- The button appears only when the BOM is submitted and contains at least one sub-assembly item (i.e. a genuine multi-level BOM)
- Clicking it opens a dialog asking for **Qty to Manufacture**, then creates one flat Work Order per assembly level in one shot:
  - **Root BOM** → Work Order at the user-specified qty
  - **Each sub-assembly BOM** → Work Order with qty scaled by `BOMTree.exploded_qty` (units required per unit of the root)
- Each Work Order uses `use_multi_level_bom=0` so its required-items list reflects only that level's direct inputs
- After creation, a success message lists clickable links to all created Work Orders

## Changes

- `erpnext/manufacturing/doctype/bom/bom.py` — new `@frappe.whitelist()` function `make_work_orders_for_sub_assemblies` that uses the existing `BOMTree` class for tree traversal
- `erpnext/manufacturing/doctype/bom/bom.js` — new button + `make_work_orders_for_sub_assemblies` trigger

## Test plan

- [ ] Open a multi-level BOM (root → sub-assembly → raw materials)
- [ ] Submit the BOM; confirm **Create → Work Orders (All Levels)** button is visible
- [ ] On a flat BOM (no items with `bom_no`), confirm the button is **not** shown
- [ ] Click the button, enter a qty, and confirm Work Orders are created for root + all sub-assemblies
- [ ] Verify sub-assembly WO quantities match `root_qty × exploded_qty`
- [ ] Confirm each WO's required-items list contains only that level's direct raw materials

🤖 Generated with [Claude Code](https://claude.com/claude-code)