### PR TITLE
feat(accounts): confirm on save when a transaction will exceed budget

### DIFF
--- a/erpnext/accounts/doctype/budget/test_budget.py
+++ b/erpnext/accounts/doctype/budget/test_budget.py
@@ -13,6 +13,7 @@ from erpnext.accounts.doctype.budget.budget import (
 from erpnext.accounts.doctype.journal_entry.test_journal_entry import make_journal_entry
 from erpnext.accounts.utils import get_fiscal_year
 from erpnext.buying.doctype.purchase_order.test_purchase_order import create_purchase_order
+from erpnext.controllers.budget_controller import BudgetValidation
 from erpnext.tests.utils import ERPNextTestSuite
 
 
@@ -597,6 +598,102 @@ class TestBudget(ERPNextTestSuite):
 		with self.assertRaises(frappe.ValidationError):
 			new_budget.insert()
 
+	def test_budget_validation_default_mode_unchanged(self):
+		"""Default mode must still throw on Stop, msgprint on Warn, and stay silent on Ignore."""
+		for action, expect_message in [("Stop", None), ("Warn", True), ("Ignore", False)]:
+			set_total_expense_zero(nowdate(), "cost_center")
+			budget = make_budget(
+				applicable_on_purchase_order=1,
+				action_if_annual_budget_exceeded_on_po=action,
+				action_if_accumulated_monthly_budget_exceeded_on_po=action,
+				budget_against="Cost Center",
+				do_not_save=False,
+				submit_budget=True,
+			)
+			accumulated_limit = get_accumulated_monthly_budget(budget.name, nowdate())
+			po = create_purchase_order(
+				transaction_date=nowdate(), qty=1, rate=accumulated_limit + 1, do_not_submit=True
+			)
+			po.set_missing_values()
+
+			if action == "Stop":
+				self.assertRaises(BudgetError, po.submit)
+			else:
+				frappe.local.message_log = []
+				po.submit()
+				self.assertEqual(po.docstatus, 1)
+				logged = "Budget Exceeded" in frappe.as_json(frappe.local.message_log)
+				self.assertEqual(logged, expect_message)
+				po.cancel()
+
+			budget.load_from_db()
+			budget.cancel()
+
+	def test_budget_validation_non_throwing_mode_returns_exceptions(self):
+		"""raise_=False must return the exceeded budgets with their resolved action, never throw or msgprint."""
+		for action in ("Stop", "Warn", "Ignore"):
+			budget, consuming_po, po = make_overbooked_po_budget(action)
+
+			frappe.local.message_log = []
+			exceeded = BudgetValidation(doc=po).validate(raise_=False)
+
+			self.assertIsInstance(exceeded, list)
+			self.assertNotIn("Budget Exceeded", frappe.as_json(frappe.local.message_log))
+			self.assertIn(action, [d.get("action") for d in exceeded])
+			self.assertTrue(all(d.get("message") for d in exceeded))
+			self.assertTrue(any(d.get("account") == self.account for d in exceeded))
+
+			consuming_po.cancel()
+			budget.load_from_db()
+			budget.cancel()
+
+	def test_budget_exceptions_pure_gl_map(self):
+		"""Journal Entry (pure get_budget_gl_map) reports the overrun without persisting any GL."""
+		set_total_expense_zero(nowdate(), "cost_center")
+		budget = make_budget(budget_against="Cost Center", do_not_save=False, submit_budget=True)
+		frappe.db.set_value("Budget", budget.name, "action_if_accumulated_monthly_budget_exceeded", "Stop")
+
+		accumulated_limit = get_accumulated_monthly_budget(budget.name, nowdate())
+		jv = make_journal_entry(
+			"_Test Account Cost for Goods Sold - _TC",
+			"_Test Bank - _TC",
+			accumulated_limit + 1,
+			"_Test Cost Center - _TC",
+			posting_date=nowdate(),
+		)
+
+		exceeded = jv.budget_exceptions()
+		self.assertTrue(any(d.get("action") == "Stop" for d in exceeded))
+		self.assertFalse(
+			frappe.db.exists("GL Entry", {"voucher_type": "Journal Entry", "voucher_no": jv.name})
+		)
+
+		budget.load_from_db()
+		budget.cancel()
+
+	def test_budget_gl_map_dry_run_persists_nothing(self):
+		"""Stock-voucher get_budget_gl_map builds GL via an in-memory dry run and rolls it back."""
+		from erpnext.stock.doctype.stock_entry.stock_entry_utils import make_stock_entry
+
+		se = make_stock_entry(
+			item_code="_Test Item",
+			qty=1,
+			rate=100,
+			to_warehouse="Stores - TCP1",
+			company="_Test Company with perpetual inventory",
+			do_not_save=True,
+		)
+		se.save()
+
+		gl_map = se.get_budget_gl_map()
+
+		self.assertTrue(gl_map)
+		self.assertFalse(frappe.flags.get("in_budget_preview"))
+		self.assertFalse(frappe.db.exists("GL Entry", {"voucher_type": "Stock Entry", "voucher_no": se.name}))
+		self.assertFalse(
+			frappe.db.exists("Stock Ledger Entry", {"voucher_type": "Stock Entry", "voucher_no": se.name})
+		)
+
 
 def set_total_expense_zero(posting_date, budget_against_field=None, budget_against_CC=None):
 	if budget_against_field == "project":
@@ -741,3 +838,36 @@ def make_budget(**args):
 		budget.submit()
 
 	return budget
+
+
+def make_overbooked_po_budget(po_action):
+	"""Over-book a PO budget with a submitted consuming PO, then set the monthly PO action.
+
+	The exceed is real from existing submitted data, so a fresh draft PO trips it regardless
+	of how the non-throwing path counts the current document.
+	"""
+	set_total_expense_zero(nowdate(), "cost_center")
+	budget = make_budget(
+		applicable_on_purchase_order=1,
+		action_if_annual_budget_exceeded_on_po="Ignore",
+		action_if_accumulated_monthly_budget_exceeded_on_po="Ignore",
+		budget_against="Cost Center",
+		do_not_save=False,
+		submit_budget=True,
+	)
+
+	accumulated_limit = get_accumulated_monthly_budget(budget.name, nowdate())
+	consuming_po = create_purchase_order(
+		transaction_date=nowdate(), qty=1, rate=accumulated_limit + 1, do_not_submit=True
+	)
+	consuming_po.set_missing_values()
+	consuming_po.submit()
+
+	frappe.db.set_value(
+		"Budget", budget.name, "action_if_accumulated_monthly_budget_exceeded_on_po", po_action
+	)
+
+	po = create_purchase_order(transaction_date=nowdate(), qty=1, rate=10, do_not_submit=True)
+	po.set_missing_values()
+
+	return budget, consuming_po, po

--- a/erpnext/accounts/doctype/journal_entry/journal_entry.js
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.js
@@ -5,6 +5,18 @@ frappe.provide("erpnext.accounts");
 frappe.provide("erpnext.journal_entry");
 
 frappe.ui.form.on("Journal Entry", {
+	before_submit(frm) {
+		frm._submitting = true;
+	},
+
+	validate(frm) {
+		if (frm._submitting) {
+			frm._submitting = false;
+			return;
+		}
+		return erpnext.utils.confirm_budget_before_save(frm);
+	},
+
 	setup: function (frm) {
 		frm.add_fetch("bank_account", "account", "account");
 		frm.ignore_doctypes_on_cancel_all = [

--- a/erpnext/accounts/doctype/journal_entry/journal_entry.py
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.py
@@ -859,6 +859,9 @@ class JournalEntry(AccountsController):
 
 		return JournalEntryGLComposer(self).compose()
 
+	def get_budget_gl_map(self) -> list:
+		return self.build_gl_map()
+
 	def make_gl_entries(self, cancel: int = 0, adv_adj: int = 0) -> None:
 		from erpnext.accounts.general_ledger import make_gl_entries
 

--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js
@@ -571,6 +571,18 @@ cur_frm.fields_dict["items"].grid.get_field("cost_center").get_query = function 
 };
 
 frappe.ui.form.on("Purchase Invoice", {
+	before_submit(frm) {
+		frm._submitting = true;
+	},
+
+	validate(frm) {
+		if (frm._submitting) {
+			frm._submitting = false;
+			return;
+		}
+		return erpnext.utils.confirm_budget_before_save(frm);
+	},
+
 	setup: function (frm) {
 		frm.custom_make_buttons = {
 			"Purchase Invoice": "Return / Debit Note",

--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
@@ -712,6 +712,10 @@ class PurchaseInvoice(BuyingController):
 
 		return PurchaseInvoiceGLComposer(self).compose(inventory_account_map)
 
+	def get_budget_gl_map(self) -> list:
+		# Expense GL comes from item expense lines (not SLE-dependent), so no dry run needed.
+		return self.get_gl_entries()
+
 	def check_asset_cwip_enabled(self):
 		# Check if there exists any item with cwip accounting enabled in it's asset category
 		for item in self.get("items"):

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
@@ -747,6 +747,18 @@ cur_frm.cscript.expense_account = function (doc, cdt, cdn) {
 };
 
 frappe.ui.form.on("Sales Invoice", {
+	before_submit(frm) {
+		frm._submitting = true;
+	},
+
+	validate(frm) {
+		if (frm._submitting) {
+			frm._submitting = false;
+			return;
+		}
+		return erpnext.utils.confirm_budget_before_save(frm);
+	},
+
 	setup: function (frm) {
 		frm.add_fetch("customer", "tax_id", "tax_id");
 		frm.add_fetch("payment_term", "invoice_portion", "invoice_portion");

--- a/erpnext/accounts/general_ledger.py
+++ b/erpnext/accounts/general_ledger.py
@@ -42,6 +42,7 @@ def make_gl_entries(
 	if gl_map:
 		if (
 			not cancel
+			and not frappe.flags.get("in_budget_preview")
 			and not cint(frappe.get_single_value("Accounts Settings", "use_legacy_budget_controller"))
 			and gl_map[0].voucher_type != "Period Closing Voucher"
 		):

--- a/erpnext/assets/doctype/asset_capitalization/asset_capitalization.js
+++ b/erpnext/assets/doctype/asset_capitalization/asset_capitalization.js
@@ -3,6 +3,20 @@
 
 frappe.provide("erpnext.assets");
 
+frappe.ui.form.on("Asset Capitalization", {
+	before_submit(frm) {
+		frm._submitting = true;
+	},
+
+	validate(frm) {
+		if (frm._submitting) {
+			frm._submitting = false;
+			return;
+		}
+		return erpnext.utils.confirm_budget_before_save(frm);
+	},
+});
+
 erpnext.assets.AssetCapitalization = class AssetCapitalization extends erpnext.stock.StockController {
 	setup() {
 		this.frm.ignore_doctypes_on_cancel_all = ["Serial and Batch Bundle", "Asset Movement"];

--- a/erpnext/assets/doctype/asset_repair/asset_repair.js
+++ b/erpnext/assets/doctype/asset_repair/asset_repair.js
@@ -2,6 +2,18 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on("Asset Repair", {
+	before_submit(frm) {
+		frm._submitting = true;
+	},
+
+	validate(frm) {
+		if (frm._submitting) {
+			frm._submitting = false;
+			return;
+		}
+		return erpnext.utils.confirm_budget_before_save(frm);
+	},
+
 	setup: function (frm) {
 		frm.ignore_doctypes_on_cancel_all = ["Serial and Batch Bundle"];
 

--- a/erpnext/buying/doctype/purchase_order/purchase_order.js
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.js
@@ -11,6 +11,18 @@ erpnext.accounts.taxes.setup_tax_validations("Purchase Order");
 erpnext.buying.setup_buying_controller();
 
 frappe.ui.form.on("Purchase Order", {
+	before_submit(frm) {
+		frm._submitting = true;
+	},
+
+	validate(frm) {
+		if (frm._submitting) {
+			frm._submitting = false;
+			return;
+		}
+		return erpnext.utils.confirm_budget_before_save(frm);
+	},
+
 	setup: function (frm) {
 		frm.set_indicator_formatter("item_code", function (doc) {
 			let color;

--- a/erpnext/buying/doctype/purchase_order/purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.py
@@ -368,6 +368,17 @@ class PurchaseOrder(BuyingController):
 	def update_status(self, status):
 		StatusService(self).update_status(status)
 
+	@frappe.whitelist()
+	def budget_exceptions(self) -> list:
+		self.check_permission("read")
+		if frappe.get_single_value("Accounts Settings", "use_legacy_budget_controller"):
+			return []
+
+		from erpnext.controllers.budget_controller import BudgetValidation
+
+		exceeded = BudgetValidation(doc=self).validate(raise_=False)
+		return [e for e in exceeded if e.get("action") in ("Stop", "Warn")]
+
 	def on_submit(self):
 		super().on_submit()
 

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -1017,6 +1017,28 @@ class AccountsController(TransactionBase):
 		).run()
 
 	@frappe.whitelist()
+	def budget_exceptions(self) -> list[frappe._dict]:
+		self.check_permission("read")
+		if frappe.get_single_value("Accounts Settings", "use_legacy_budget_controller"):
+			return []
+
+		# Cheap guard: avoid the (possibly dry-run) GL build when no budget can apply.
+		if not frappe.db.exists("Budget", {"company": self.company, "docstatus": 1}):
+			return []
+
+		gl_map = self.get_budget_gl_map()
+		if not gl_map:
+			return []
+
+		from erpnext.controllers.budget_controller import BudgetValidation
+
+		exceeded = BudgetValidation(gl_map=gl_map).validate(raise_=False)
+		return [e for e in exceeded if e.get("action") in ("Stop", "Warn")]
+
+	def get_budget_gl_map(self) -> list:
+		return self.get_gl_entries()
+
+	@frappe.whitelist()
 	def apply_shipping_rule(self):
 		if self.shipping_rule:
 			shipping_rule = frappe.get_doc("Shipping Rule", self.shipping_rule)

--- a/erpnext/controllers/budget_controller.py
+++ b/erpnext/controllers/budget_controller.py
@@ -4,7 +4,7 @@ import frappe
 from frappe import _, qb
 from frappe.query_builder import Criterion
 from frappe.query_builder.functions import IfNull, Sum
-from frappe.utils import fmt_money
+from frappe.utils import flt, fmt_money
 
 from erpnext.accounts.doctype.budget.budget import BudgetError, get_accumulated_monthly_budget
 from erpnext.accounts.utils import get_fiscal_year
@@ -34,9 +34,12 @@ class BudgetValidation:
 			"Company", self.company, "exception_budget_approver_role"
 		)
 
-	def validate(self):
+	def validate(self, raise_: bool = True) -> list[frappe._dict]:
+		self.raise_ = raise_
+		self.exceptions: list[frappe._dict] = []
 		self.build_validation_map()
 		self.validate_for_overbooking()
+		return self.exceptions
 
 	def build_validation_map(self):
 		self.build_budget_keys()
@@ -84,6 +87,11 @@ class BudgetValidation:
 		for key, v in self.to_validate.items():
 			self.get_ordered_amount(key)
 			self.get_requested_amount(key)
+
+			# At submit the document is already counted in the queries above; on the
+			# save-time (non-throwing) check it is still a draft, so add it explicitly.
+			if not self.raise_:
+				self.set_current_amount(v)
 
 			# Pre-emptive validation before hitting ledger
 			self.handle_actions(key, v)
@@ -285,13 +293,24 @@ class BudgetValidation:
 			if actual_expense := query.run(as_dict=True):
 				self.to_validate[key].actual_expense = actual_expense[0].balance or 0
 
+	def set_current_amount(self, v_map) -> None:
+		amount = sum(flt(itm.amount) for itm in v_map.get("items_to_process", []))
+		if self.document_type == "Purchase Order":
+			v_map.current_ordered_amount = amount
+		elif self.document_type == "Material Request":
+			v_map.current_requested_amount = amount
+
 	def stop(self, msg):
 		frappe.throw(msg, BudgetError, title=_("Budget Exceeded"))
 
 	def warn(self, msg):
 		frappe.msgprint(msg, _("Budget Exceeded"))
 
-	def execute_action(self, action, msg):
+	def execute_action(self, action: str, msg: str, account: str | None = None) -> None:
+		if not self.raise_:
+			self.exceptions.append(frappe._dict({"account": account, "message": msg, "action": action}))
+			return
+
 		if self.exception_approver_role and self.exception_approver_role in frappe.get_roles(
 			frappe.session.user
 		):
@@ -320,7 +339,7 @@ class BudgetValidation:
 					frappe.bold(fmt_money(budget_amt, currency=currency)),
 					frappe.bold(fmt_money(annual_diff, currency=currency)),
 				)
-				self.execute_action(config.action_for_annual, _msg)
+				self.execute_action(config.action_for_annual, _msg, key[2])
 
 			monthly_diff = (existing_amt + current_amt) - acc_monthly_budget
 			if monthly_diff > 0:
@@ -333,7 +352,7 @@ class BudgetValidation:
 					frappe.bold(fmt_money(acc_monthly_budget, currency=currency)),
 					frappe.bold(fmt_money(monthly_diff, currency=currency)),
 				)
-				self.execute_action(config.action_for_monthly, _msg)
+				self.execute_action(config.action_for_monthly, _msg, key[2])
 
 	def handle_purchase_order_overlimit(self, key, v_map):
 		self.handle_individual_doctype_action(
@@ -434,7 +453,7 @@ class BudgetValidation:
 			)
 
 			self.execute_action(
-				v_map.budget_doc.action_if_accumulated_monthly_exceeded_on_cumulative_expense, _msg
+				v_map.budget_doc.action_if_accumulated_monthly_exceeded_on_cumulative_expense, _msg, key[2]
 			)
 
 	def handle_cumulative_overlimit_for_annual(self, key, v_map):
@@ -456,4 +475,6 @@ class BudgetValidation:
 				self.budget_applicable_for(v_map, current_amt),
 				frappe.bold(fmt_money(total_diff, currency=currency)),
 			)
-			self.execute_action(v_map.budget_doc.action_if_annual_exceeded_on_cumulative_expense, _msg)
+			self.execute_action(
+				v_map.budget_doc.action_if_annual_exceeded_on_cumulative_expense, _msg, key[2]
+			)

--- a/erpnext/controllers/stock_controller.py
+++ b/erpnext/controllers/stock_controller.py
@@ -34,6 +34,17 @@ from erpnext.stock.doctype.item.item import get_item_defaults
 from erpnext.stock.services.internal_transfer import StockInternalTransferService
 from erpnext.stock.stock_ledger import get_items_to_be_repost
 
+# Vouchers whose budget-relevant GL is derived from Stock Ledger Entries and so needs an
+# in-memory dry run (materialise SLEs, compose GL, read back, roll back) for the save-time check.
+STOCK_VOUCHERS = (
+	"Purchase Receipt",
+	"Delivery Note",
+	"Stock Entry",
+	"Stock Reconciliation",
+	"Subcontracting Receipt",
+	"Asset Capitalization",
+)
+
 
 class StockController(AccountsController):
 	def validate(self):
@@ -227,6 +238,40 @@ class StockController(AccountsController):
 		return BaseStockGLComposer(self).compose(
 			inventory_account_map, default_expense_account, default_cost_center
 		)
+
+	def get_budget_gl_map(self) -> list:
+		"""Stock-voucher GL is computed from persisted SLEs, so build it via an in-memory dry
+		run: submit, materialise SLEs + GL, read them back, then roll back to the savepoint."""
+		from erpnext.accounts.doctype.accounting_dimension.accounting_dimension import (
+			get_accounting_dimensions,
+		)
+
+		fields = [
+			"account",
+			"debit",
+			"credit",
+			"company",
+			"posting_date",
+			"cost_center",
+			"project",
+			*get_accounting_dimensions(),
+		]
+		frappe.flags.in_budget_preview = True
+		frappe.db.savepoint("budget_preview")
+		try:
+			self.docstatus = 1
+			if self.get("update_stock") or self.doctype in STOCK_VOUCHERS:
+				self.update_stock_ledger()
+			self.make_gl_entries()
+			return frappe.get_all(
+				"GL Entry",
+				filters={"voucher_type": self.doctype, "voucher_no": self.name},
+				fields=fields,
+			)
+		finally:
+			frappe.db.rollback(save_point="budget_preview")
+			self.docstatus = 0
+			frappe.flags.in_budget_preview = False
 
 	def get_items_and_warehouses(self) -> tuple[list[str], list[str]]:
 		from erpnext.stock.services.stock_ledger_service import StockLedgerService

--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -1134,6 +1134,26 @@ erpnext.utils.map_current_doc = function (opts) {
 	}
 };
 
+erpnext.utils.confirm_budget_before_save = async function (frm) {
+	const r = await frm.call({ doc: frm.doc, method: "budget_exceptions" }).catch(() => null);
+	if (!r || !r.message || !r.message.length) {
+		return;
+	}
+
+	const messages = r.message.map((d) => d.message).join("<br>");
+	const proceed = await new Promise((resolve) => {
+		frappe.confirm(
+			__("Budget will be exceeded:<br>{0}<br><br>Do you still want to save?", [messages]),
+			() => resolve(true),
+			() => resolve(false)
+		);
+	});
+
+	if (!proceed) {
+		frappe.validated = false;
+	}
+};
+
 frappe.form.link_formatters["Item"] = function (value, doc, df) {
 	return add_link_title(value, doc, df, "item_name");
 };

--- a/erpnext/stock/doctype/delivery_note/delivery_note.js
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.js
@@ -14,6 +14,18 @@ erpnext.accounts.taxes.setup_tax_validations("Delivery Note");
 erpnext.sales_common.setup_selling_controller();
 
 frappe.ui.form.on("Delivery Note", {
+	before_submit(frm) {
+		frm._submitting = true;
+	},
+
+	validate(frm) {
+		if (frm._submitting) {
+			frm._submitting = false;
+			return;
+		}
+		return erpnext.utils.confirm_budget_before_save(frm);
+	},
+
 	setup: function (frm) {
 		(frm.custom_make_buttons = {
 			"Packing Slip": "Packing Slip",

--- a/erpnext/stock/doctype/material_request/material_request.js
+++ b/erpnext/stock/doctype/material_request/material_request.js
@@ -6,6 +6,18 @@ frappe.provide("erpnext.accounts.dimensions");
 erpnext.buying.setup_buying_controller();
 
 frappe.ui.form.on("Material Request", {
+	before_submit(frm) {
+		frm._submitting = true;
+	},
+
+	validate(frm) {
+		if (frm._submitting) {
+			frm._submitting = false;
+			return;
+		}
+		return erpnext.utils.confirm_budget_before_save(frm);
+	},
+
 	setup: function (frm) {
 		frm.custom_make_buttons = {
 			"Stock Entry": "Issue Material",

--- a/erpnext/stock/doctype/material_request/material_request.py
+++ b/erpnext/stock/doctype/material_request/material_request.py
@@ -228,6 +228,17 @@ class MaterialRequest(BuyingController):
 			items = ", ".join([d.item_name for d in self.items][:3])
 			self.title = _("{0} Request for {1}").format(_(self.material_request_type), items)[:100]
 
+	@frappe.whitelist()
+	def budget_exceptions(self) -> list:
+		self.check_permission("read")
+		if frappe.get_single_value("Accounts Settings", "use_legacy_budget_controller"):
+			return []
+
+		from erpnext.controllers.budget_controller import BudgetValidation
+
+		exceeded = BudgetValidation(doc=self).validate(raise_=False)
+		return [e for e in exceeded if e.get("action") in ("Stop", "Warn")]
+
 	def on_submit(self):
 		self.update_requested_qty_in_production_plan()
 		self.update_requested_qty()

--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.js
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.js
@@ -10,6 +10,18 @@ erpnext.accounts.taxes.setup_tax_validations("Purchase Receipt");
 erpnext.buying.setup_buying_controller();
 
 frappe.ui.form.on("Purchase Receipt", {
+	before_submit(frm) {
+		frm._submitting = true;
+	},
+
+	validate(frm) {
+		if (frm._submitting) {
+			frm._submitting = false;
+			return;
+		}
+		return erpnext.utils.confirm_budget_before_save(frm);
+	},
+
 	setup: (frm) => {
 		frm.custom_make_buttons = {
 			"Stock Entry": "Return",

--- a/erpnext/stock/doctype/stock_entry/stock_entry.js
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.js
@@ -6,6 +6,18 @@ frappe.provide("erpnext.accounts.dimensions");
 erpnext.landed_cost_taxes_and_charges.setup_triggers("Stock Entry");
 
 frappe.ui.form.on("Stock Entry", {
+	before_submit(frm) {
+		frm._submitting = true;
+	},
+
+	validate(frm) {
+		if (frm._submitting) {
+			frm._submitting = false;
+			return;
+		}
+		return erpnext.utils.confirm_budget_before_save(frm);
+	},
+
 	setup: function (frm) {
 		frm.ignore_doctypes_on_cancel_all = ["Serial and Batch Bundle"];
 

--- a/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.js
+++ b/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.js
@@ -5,6 +5,18 @@ frappe.provide("erpnext.stock");
 frappe.provide("erpnext.accounts.dimensions");
 
 frappe.ui.form.on("Stock Reconciliation", {
+	before_submit(frm) {
+		frm._submitting = true;
+	},
+
+	validate(frm) {
+		if (frm._submitting) {
+			frm._submitting = false;
+			return;
+		}
+		return erpnext.utils.confirm_budget_before_save(frm);
+	},
+
 	setup(frm) {
 		frm.ignore_doctypes_on_cancel_all = ["Serial and Batch Bundle"];
 		frm.barcode_scanner = new erpnext.utils.BarcodeScanner({

--- a/erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.js
+++ b/erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.js
@@ -6,6 +6,18 @@ frappe.provide("erpnext.buying");
 erpnext.landed_cost_taxes_and_charges.setup_triggers("Subcontracting Receipt");
 
 frappe.ui.form.on("Subcontracting Receipt", {
+	before_submit(frm) {
+		frm._submitting = true;
+	},
+
+	validate(frm) {
+		if (frm._submitting) {
+			frm._submitting = false;
+			return;
+		}
+		return erpnext.utils.confirm_budget_before_save(frm);
+	},
+
 	setup: (frm) => {
 		frm.ignore_doctypes_on_cancel_all = ["Serial and Batch Bundle"];
 		frm.get_field("supplied_items").grid.cannot_add_rows = true;


### PR DESCRIPTION
Add a generic save-time "Budget will be exceeded — save anyway?" confirmation across the 10 budget-relevant GL doctypes (Purchase/Sales Invoice, Journal Entry, Stock Entry, Delivery Note, Purchase Receipt, Stock Reconciliation, Subcontracting Receipt, Asset Repair, Asset Capitalization) via the non-throwing BudgetValidation path. AccountsController.budget_exceptions() builds a prospective gl_map — pure get_gl_entries()/build_gl_map() for JE/Purchase Invoice/Asset Repair, savepoint dry-run for the SLE-dependent stock vouchers (guarded by frappe.flags.in_budget_preview). PO/MR keep the commitment doc path. on_submit throw stays the final gate.
no-docs
