### PR TITLE
fix: disable is_debit_note while creating credit note

### DIFF
--- a/erpnext/controllers/sales_and_purchase_return.py
+++ b/erpnext/controllers/sales_and_purchase_return.py
@@ -445,6 +445,8 @@ def make_return_doc(doctype: str, source_name: str, target_doc=None, return_agai
 		doc.pricing_rules = []
 		doc.return_against = source.name
 		doc.set_warehouse = ""
+		if doctype == "Sales Invoice":
+			doc.is_debit_note = 0
 		if doctype == "Sales Invoice" or doctype == "POS Invoice":
 			doc.is_pos = source.is_pos
 


### PR DESCRIPTION
Description: While creating a Sales Return for a Rate Adjustment Sales Invoice, the is_debit_note flag is not required.

Ref : [#71415](https://support.frappe.io/helpdesk/tickets/71415)

Backport Needed For v16 and V15