### PR TITLE
fix: add missing process_item_selection method in BOMCreator

### DIFF
--- a/erpnext/manufacturing/doctype/bom_creator/bom_creator.js
+++ b/erpnext/manufacturing/doctype/bom_creator/bom_creator.js
@@ -215,6 +215,13 @@ frappe.ui.form.on("BOM Creator Item", {
 		}
 	},
 
+	qty(frm, cdt, cdn) {
+		let item = frappe.get_doc(cdt, cdn);
+		if (!item.qty) {
+			frappe.model.set_value(cdt, cdn, "qty", 1.0);
+		}
+	},
+
 	do_not_explode(frm, cdt, cdn) {
 		let item = frappe.get_doc(cdt, cdn);
 		if (!item.do_not_explode) {

--- a/erpnext/manufacturing/doctype/bom_creator/bom_creator.py
+++ b/erpnext/manufacturing/doctype/bom_creator/bom_creator.py
@@ -411,6 +411,49 @@ class BOMCreator(Document):
 
 		return self
 
+	@frappe.whitelist()
+	def process_item_selection(self, item_idx: int):
+		item_obj = self.get("items", {"idx": item_idx})
+		if not item_obj:
+			return
+
+		item_obj = item_obj[0]
+		if not item_obj.item_code:
+			return
+
+		item_details = get_item_details(item_obj.item_code)
+		if not item_details:
+			frappe.throw(_("Item {0} does not exist in the system").format(item_obj.item_code))
+
+		item_obj.item_name = item_details.item_name
+		item_obj.description = item_details.description
+		item_obj.stock_uom = item_details.stock_uom
+		if not item_obj.uom:
+			item_obj.uom = item_details.stock_uom
+		if not item_obj.conversion_factor:
+			item_obj.conversion_factor = 1.0
+		if not item_obj.qty:
+			item_obj.qty = 1.0
+
+		item_obj.stock_qty = flt(item_obj.qty) * flt(item_obj.conversion_factor)
+
+		item_obj.rate = get_bom_item_rate(
+			{
+				"company": self.company,
+				"item_code": item_obj.item_code,
+				"bom_no": "",
+				"qty": item_obj.qty,
+				"uom": item_obj.uom,
+				"stock_uom": item_obj.stock_uom,
+				"conversion_factor": item_obj.conversion_factor,
+				"sourced_by_supplier": item_obj.sourced_by_supplier,
+			},
+			self,
+		)
+		item_obj.amount = flt(item_obj.rate) * flt(item_obj.qty)
+
+		return self
+
 	def has_operations(self):
 		for row in self.items:
 			if row.operation:


### PR DESCRIPTION
Issue:  The BOMCreator doctype was missing the process_item_selection method that is called from the client side when an item is selected in the BOM items table. This caused an AttributeError whenever a user selected an item in the BOM Creator form, preventing item details from being auto-populated.

Before:

<img width="1845" height="923" alt="image" src="https://github.com/user-attachments/assets/ae55c135-e6d3-4e4d-8054-d0e8ea6621e1" />


After: 

<img width="1852" height="928" alt="image" src="https://github.com/user-attachments/assets/2e229a77-e3f2-4c89-8173-128f477b8da1" />

Backport Needed For v16
