### PR TITLE
fix: mark invoice-grouped total row as bold in Gross Profit report

### DIFF
--- a/erpnext/accounts/report/gross_profit/gross_profit.py
+++ b/erpnext/accounts/report/gross_profit/gross_profit.py
@@ -214,6 +214,7 @@ def get_data_when_grouped_by_invoice(columns, gross_profit_data, filters, group_
 	data.append(
 		frappe._dict(
 			{
+				"bold": 1,
 				"sales_invoice": "Total",
 				"qty": None,
 				"avg._selling_rate": None,


### PR DESCRIPTION
## Summary

- The total row appended by `get_data_when_grouped_by_invoice` was a plain dict with no marker, so number card widgets could not distinguish it from regular data rows.
- This caused incorrect Sum/Average values on dashboards (e.g. showing 7.046% average instead of the true average across invoices).

## Fix

Add `bold: 1` to the total row dict. The number card widget (frappe/frappe#40070) already checks `row.bold` to skip summary rows; this makes the Gross Profit total row identifiable by that check.

The non-invoice grouping path is unaffected — it already returns the total as an array, which is filtered out by the `Array.isArray` check.