### PR TITLE
 fix(stock): apply precision to the additional cost amount in stock entry

### DIFF
--- a/erpnext/stock/doctype/stock_entry/services/gl_composer.py
+++ b/erpnext/stock/doctype/stock_entry/services/gl_composer.py
@@ -69,10 +69,15 @@ class StockEntryGLComposer(BaseStockGLComposer):
 		self, gl_entries: list, item_account_wise_additional_cost: dict
 	) -> None:
 		doc = self.doc
+		precision = self.get_debit_field_precision()
+
 		for d in doc.get("items"):
 			for account, amount in item_account_wise_additional_cost.get((d.item_code, d.name), {}).items():
 				if not amount:
 					continue
+
+				amount["amount"] = flt(amount["amount"], precision)
+				amount["base_amount"] = flt(amount["base_amount"], precision)
 
 				gl_entries.append(
 					self.get_gl_dict(

--- a/erpnext/stock/doctype/stock_entry/test_stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/test_stock_entry.py
@@ -542,6 +542,60 @@ class TestStockEntry(ERPNextTestSuite):
 			sorted([[stock_in_hand_account, 1200, 0.0], ["Cost of Goods Sold - TCP1", 0.0, 1200.0]]),
 		)
 
+	def test_additional_cost_no_rounding_residual_on_stock_adjustment(self):
+		company = frappe.db.get_value("Warehouse", "Stores - TCP1", "company")
+		warehouse = "Stores - TCP1"
+		items = [
+			make_item(f"_Test Addl Cost Rounding {x}", {"is_stock_item": 1}).name for x in ("A", "B", "C")
+		]
+
+		for item_code in items:
+			make_stock_entry(item_code=item_code, target=warehouse, company=company, qty=100, basic_rate=10)
+
+		transfer = make_stock_entry(company=company, purpose="Material Transfer", do_not_save=True)
+		transfer.from_warehouse = warehouse
+		transfer.to_warehouse = warehouse
+		transfer.items = []
+		for item_code in items:
+			transfer.append(
+				"items",
+				{
+					"item_code": item_code,
+					"qty": 100,
+					"s_warehouse": warehouse,
+					"t_warehouse": warehouse,
+					"uom": "Nos",
+					"conversion_factor": 1,
+				},
+			)
+		transfer.append(
+			"additional_costs",
+			{
+				"expense_account": "Expenses Included In Valuation - TCP1",
+				"description": "freight",
+				"amount": 100,
+			},
+		)
+		transfer.insert()
+		transfer.submit()
+
+		gl_entries = frappe.get_all(
+			"GL Entry",
+			filters={"voucher_type": "Stock Entry", "voucher_no": transfer.name},
+			fields=["account", "debit", "credit"],
+		)
+		gl_map = {}
+		for row in gl_entries:
+			account = gl_map.setdefault(row.account, frappe._dict(debit=0.0, credit=0.0))
+			account.debit += row.debit
+			account.credit += row.credit
+
+		self.assertNotIn("Stock Adjustment - TCP1", gl_map)
+
+		stock_in_hand_account = get_inventory_account(company, warehouse)
+		self.assertEqual(flt(gl_map[stock_in_hand_account].debit, 2), 99.99)
+		self.assertEqual(flt(gl_map["Expenses Included In Valuation - TCP1"].credit, 2), 99.99)
+
 	def check_stock_ledger_entries(self, voucher_type, voucher_no, expected_sle):
 		expected_sle.sort(key=lambda x: x[1])
 


### PR DESCRIPTION
**Issue:**
When a Material Transfer Stock Entry has additional costs (such as freight or operating cost) and those costs do not split evenly across the items, a tiny rounding difference was being posted to the Stock Adjustment account.

This left a confusing stray entry in the General Ledger that did not actually belong there. It happened because the value added to stock and the matching cost entry were rounded in two different ways.

This change rounds both sides the same way for each item, so the amounts line up and no stray balance is left on the Stock Adjustment account.

Ref: [#69720](https://support.frappe.io/helpdesk/tickets/69720)
