### PR TITLE
fix(sales_invoice): remove dead, non-functional POSService.get_warehouse

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/services/pos.py
+++ b/erpnext/accounts/doctype/sales_invoice/services/pos.py
@@ -4,7 +4,7 @@
 """POS helpers for Sales Invoice."""
 
 import frappe
-from frappe import _, msgprint
+from frappe import _
 from frappe.utils import cint, flt, get_link_to_form
 
 
@@ -280,38 +280,6 @@ class POSService:
 		for entry in self.doc.payments:
 			if entry.amount > 0:
 				frappe.throw(_("Row #{0} (Payment Table): Amount must be negative").format(entry.idx))
-
-	def get_warehouse(self) -> str | None:
-		doc = self.doc
-		POSProfile = frappe.qb.DocType("POS Profile")
-
-		user_query = (
-			frappe.qb.from_(POSProfile)
-			.select(POSProfile.name, POSProfile.warehouse)
-			.where(POSProfile.company == doc.company)
-			.where(
-				(POSProfile.user == frappe.session["user"])
-				| ((POSProfile.user.isnull() | (POSProfile.user == "")) & (frappe.session["user"] == ""))
-			)
-		)
-		user_pos_profile = user_query.run()
-		warehouse = user_pos_profile[0][1] if user_pos_profile else None
-
-		if not warehouse:
-			global_query = (
-				frappe.qb.from_(POSProfile)
-				.select(POSProfile.name, POSProfile.warehouse)
-				.where(POSProfile.company == doc.company)
-				.where(POSProfile.user.isnull() | (POSProfile.user == ""))
-			)
-			global_pos_profile = global_query.run()
-
-			if global_pos_profile:
-				warehouse = global_pos_profile[0][1]
-			elif not user_pos_profile:
-				msgprint(_("POS Profile required to make POS Entry"), raise_exception=True)
-
-		return warehouse
 
 
 def get_bank_cash_account(mode_of_payment: str, company: str) -> dict:


### PR DESCRIPTION
## Problem

`POSService.get_warehouse` (in `accounts/doctype/sales_invoice/services/pos.py`) is dead code that could never have executed:

1. It filters `POS Profile` on a **`user` column that does not exist** — POS Profile links users through the `applicable_for_users` child table (`POS Profile User`), not a direct field. Running the query raises `Unknown column 'user'`.
2. Before even reaching the database, it embeds a **Python bool** (`frappe.session["user"] == ""`) inside a query-builder predicate, so pypika raises `'bool' object has no attribute 'nodes_'` at build time for any logged-in session.
3. It has **no callers** anywhere in the codebase (the `get_warehouse()` references elsewhere are unrelated client-side and stock helpers).

Warehouse resolution for POS invoices is already handled in `set_pos_fields` via the profile's item defaults, so this method is redundant as well as broken.

No linked issue.

## Change

Remove the method and the now-unused `msgprint` import. No behaviour change — the method was unreachable and non-functional.

## Manual QA

- Create and submit a POS Sales Invoice from a POS Profile and confirm the item warehouse is still populated from the profile as before (handled by `set_pos_fields`, unaffected by this removal).