### PR TITLE
Fix/item:numeric attribute string

### DIFF
--- a/erpnext/stock/doctype/item/item.js
+++ b/erpnext/stock/doctype/item/item.js
@@ -1250,7 +1250,8 @@ $.extend(erpnext.item, {
 											(row) => row.attribute_value
 										);
 										resolve();
-									});
+									})
+									.catch(() => resolve());
 							} else {
 								let values = [];
 								if (flt(attr.increment) > 0) {
@@ -1265,7 +1266,8 @@ $.extend(erpnext.item, {
 								attr_val_fields[d.attribute] = values;
 								resolve();
 							}
-						});
+						})
+						.catch(() => resolve());
 				});
 
 				promises.push(p);

--- a/erpnext/stock/doctype/item/item.js
+++ b/erpnext/stock/doctype/item/item.js
@@ -1243,7 +1243,7 @@ $.extend(erpnext.item, {
 					} else {
 						let values = [];
 						for (var i = d.from_range; i <= d.to_range; i = flt(i + d.increment, 6)) {
-							values.push(i);
+							values.push(String(i));
 						}
 						attr_val_fields[d.attribute] = values;
 						resolve();

--- a/erpnext/stock/doctype/item/item.js
+++ b/erpnext/stock/doctype/item/item.js
@@ -1219,35 +1219,53 @@ $.extend(erpnext.item, {
 		frm.doc.attributes.forEach(function (d) {
 			if (!d.disabled) {
 				let p = new Promise((resolve) => {
-					if (!d.numeric_values) {
-						frappe
-							.call({
-								method: "frappe.client.get_list",
-								args: {
-									doctype: "Item Attribute Value",
-									filters: [["parent", "=", d.attribute]],
-									fields: ["attribute_value"],
-									limit_page_length: 0,
-									parent: "Item Attribute",
-									order_by: "idx",
-								},
-							})
-							.then((r) => {
-								if (r.message) {
-									attr_val_fields[d.attribute] = r.message.map(function (d) {
-										return d.attribute_value;
+					// Read the numeric configuration from the Item Attribute master
+					// instead of the variant attribute row, which may be stale or
+					// blank if the attribute was made numeric after it was added here.
+					frappe.db
+						.get_value("Item Attribute", d.attribute, [
+							"numeric_values",
+							"from_range",
+							"to_range",
+							"increment",
+						])
+						.then((res) => {
+							let attr = res.message || {};
+
+							if (!attr.numeric_values) {
+								frappe
+									.call({
+										method: "frappe.client.get_list",
+										args: {
+											doctype: "Item Attribute Value",
+											filters: [["parent", "=", d.attribute]],
+											fields: ["attribute_value"],
+											limit_page_length: 0,
+											parent: "Item Attribute",
+											order_by: "idx",
+										},
+									})
+									.then((r) => {
+										attr_val_fields[d.attribute] = (r.message || []).map(
+											(row) => row.attribute_value
+										);
+										resolve();
 									});
-									resolve();
+							} else {
+								let values = [];
+								if (flt(attr.increment) > 0) {
+									for (
+										var i = flt(attr.from_range);
+										i <= flt(attr.to_range);
+										i = flt(i + flt(attr.increment), 6)
+									) {
+										values.push(String(i));
+									}
 								}
-							});
-					} else {
-						let values = [];
-						for (var i = d.from_range; i <= d.to_range; i = flt(i + d.increment, 6)) {
-							values.push(String(i));
-						}
-						attr_val_fields[d.attribute] = values;
-						resolve();
-					}
+								attr_val_fields[d.attribute] = values;
+								resolve();
+							}
+						});
 				});
 
 				promises.push(p);


### PR DESCRIPTION
## Problem

When creating variants from a template item via **Create → Multiple Variants**, the dialog showed the attribute's column header (e.g. "Size") but **no values to select** for numeric (range-based) attributes. This made it impossible to create variants for numeric attributes.

### Steps to reproduce
1. Create an Item Attribute (e.g. "Size") with **Numeric Values** enabled and a range, e.g. From `10`, To `15`, Increment `5`.
2. Create an Item with **Has Variants** checked and add "Size" to the Attributes table; save.
3. Click **Create → Multiple Variants**.
4. The popup shows the "Size" column but the numeric values (10, 15, …) are missing.

## Root cause

The dialog read `numeric_values`, `from_range`, `to_range`, and `increment` from the **Item Variant Attribute child row** on the template. Those fields are only populated via `add_fetch` at the moment the attribute is picked in the grid, so a template whose attribute was made numeric (or whose range was set) afterwards keeps them at `0`.

With `numeric_values = 0` on the row, the dialog took the *non-numeric* branch and queried the `Item Attribute Value` table — which is empty for a numeric attribute — producing an empty list and rendering the column with no checkboxes.

## Fix

- Read `numeric_values` and the range fields from the **Item Attribute master** (the source of truth) instead of the possibly-stale child row, so the numeric values are always generated correctly.
- Guard `increment > 0` before building the range to avoid an infinite loop when the increment is unset.

## Impact

Numeric attribute values now render as selectable checkboxes in the Multiple Variants dialog regardless of when the attribute was made numeric. No schema changes; client-side only.