### PR TITLE
fix: apply docstatus filter to exclude cancelled Work Orders in Seria…

### DIFF
--- a/erpnext/stock/doctype/serial_no/serial_no.js
+++ b/erpnext/stock/doctype/serial_no/serial_no.js
@@ -1,26 +1,30 @@
 // Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 // License: GNU General Public License v3. See license.txt
 
-cur_frm.add_fetch("customer", "customer_name", "customer_name");
-cur_frm.add_fetch("supplier", "supplier_name", "supplier_name");
-
-cur_frm.add_fetch("item_code", "item_name", "item_name");
-cur_frm.add_fetch("item_code", "description", "description");
-cur_frm.add_fetch("item_code", "item_group", "item_group");
-cur_frm.add_fetch("item_code", "brand", "brand");
-
-cur_frm.cscript.onload = function () {
-	cur_frm.set_query("item_code", function () {
-		return erpnext.queries.item({ is_stock_item: 1, has_serial_no: 1 });
-	});
-};
-
-frappe.ui.form.on("Serial No", "refresh", function (frm) {
-	frm.toggle_enable("item_code", frm.doc.__islocal);
-});
-
 frappe.ui.form.on("Serial No", {
+	setup(frm) {
+		frm.add_fetch("customer", "customer_name", "customer_name");
+		frm.add_fetch("supplier", "supplier_name", "supplier_name");
+		frm.add_fetch("item_code", "item_name", "item_name");
+		frm.add_fetch("item_code", "description", "description");
+		frm.add_fetch("item_code", "item_group", "item_group");
+		frm.add_fetch("item_code", "brand", "brand");
+
+		frm.set_query("item_code", function () {
+			return erpnext.queries.item({ is_stock_item: 1, has_serial_no: 1 });
+		});
+
+		frm.set_query("work_order", () => {
+			return {
+				filters: {
+					docstatus: 1,
+				},
+			};
+		});
+	},
+
 	refresh(frm) {
+		frm.toggle_enable("item_code", frm.doc.__islocal);
 		frm.trigger("view_ledgers");
 	},
 


### PR DESCRIPTION
Issue: In the Serial No document, the Work Order link field displays cancelled Work Orders in the search results. Cancelled documents should not appear in the lookup.

Before :

<img width="1652" height="763" alt="image" src="https://github.com/user-attachments/assets/d59488cb-0898-41e6-bc07-fab8098c7258" />


<img width="1556" height="926" alt="image" src="https://github.com/user-attachments/assets/8f71513f-6294-4f02-a70e-782c9fbef2dc" />



After : 

<img width="1476" height="896" alt="image" src="https://github.com/user-attachments/assets/15a96286-5996-408b-9ed3-27d9c785acbc" />


Backport Needed For v16 and v15