### PR TITLE
fix: allow rename for Quality Inspection Parameter

### DIFF
--- a/erpnext/stock/doctype/quality_inspection_parameter/quality_inspection_parameter.json
+++ b/erpnext/stock/doctype/quality_inspection_parameter/quality_inspection_parameter.json
@@ -1,5 +1,6 @@
 {
  "actions": [],
+ "allow_rename": 1,
  "autoname": "field:parameter",
  "creation": "2020-12-28 17:06:00.254129",
  "doctype": "DocType",


### PR DESCRIPTION
## Problem

The **Quality Inspection Parameter** DocType does not have `allow_rename` enabled. As a result, the **Rename** action is missing from the form's ⋮ (3-dots) menu, and users have no way to change the name of a parameter after it has been created.

This is significant because the DocType is auto-named directly from the `parameter` field:

```json
"autoname": "field:parameter"
```

So the document name *is* the parameter name. Without rename, a typo or a change in naming convention forces the user to delete and recreate the parameter (and re-link it everywhere), instead of simply renaming it.

## Steps to reproduce

1. Go to a **Quality Inspection Parameter** record.
2. Open the ⋮ (3-dots) menu.
3. Notice there is no **Rename** option.

## Fix

Enable `allow_rename` on the DocType:

```json
"allow_rename": 1,
```

With this set, Frappe shows the **Rename** action in the form menu. Because the DocType is named from the `parameter` field, renaming updates the parameter name and propagates through Frappe's standard rename (link field updates) mechanism.

## After the fix

The **Rename** option appears in the ⋮ menu of a Quality Inspection Parameter, allowing users to correct/change a parameter name without deleting and recreating it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)