### PR TITLE
fix: correct typo in Bank Statement Import MT940 label

### DIFF
--- a/erpnext/accounts/doctype/bank_statement_import/bank_statement_import.json
+++ b/erpnext/accounts/doctype/bank_statement_import/bank_statement_import.json
@@ -226,7 +226,7 @@
  ],
  "hide_toolbar": 1,
  "links": [],
- "modified": "2026-05-31 00:41:11.251215",
+ "modified": "2026-06-19 00:00:00.000000",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Bank Statement Import",

--- a/erpnext/accounts/doctype/bank_statement_import/bank_statement_import.json
+++ b/erpnext/accounts/doctype/bank_statement_import/bank_statement_import.json
@@ -226,7 +226,7 @@
  ],
  "hide_toolbar": 1,
  "links": [],
- "modified": "2026-06-19 00:00:00.000000",
+ "modified": "2026-06-19 14:18:00.000000",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Bank Statement Import",

--- a/erpnext/accounts/doctype/bank_statement_import/bank_statement_import.json
+++ b/erpnext/accounts/doctype/bank_statement_import/bank_statement_import.json
@@ -221,7 +221,7 @@
    "default": "0",
    "fieldname": "import_mt940_fromat",
    "fieldtype": "Check",
-   "label": "Import MT940 Fromat"
+   "label": "Import MT940 Format"
   }
  ],
  "hide_toolbar": 1,


### PR DESCRIPTION
## Summary

- Fixes a typo in the `Bank Statement Import` doctype: **"Import MT940 Fromat"** → **"Import MT940 Format"**