### PR TITLE
fix(tests): point _Test Workstation 1 fixture at an existing warehouse

### DIFF
--- a/erpnext/tests/utils.py
+++ b/erpnext/tests/utils.py
@@ -2544,7 +2544,7 @@ class BootStrapTestData:
 				"doctype": "Workstation",
 				"name": "_Test Workstation 1",
 				"workstation_name": "_Test Workstation 1",
-				"warehouse": "_Test warehouse - _TC",
+				"warehouse": "_Test Warehouse - _TC",
 				"hour_rate_labour": 25,
 				"hour_rate_electricity": 25,
 				"hour_rate_consumable": 25,


### PR DESCRIPTION
### Problem

`BootStrapTestData.make_workstation()` creates `_Test Workstation 1` referencing the warehouse **`_Test warehouse - _TC`** (lowercase `w`). But `make_warehouse()` never creates that name — it creates `_Test Warehouse - _TC` (capital `W`), `_Test Scrap Warehouse`, `_Test Warehouse 1/2`, etc.

- On **MariaDB**, the lowercase reference resolves to the capital warehouse via the default case-insensitive collation, so it silently works.
- On **PostgreSQL** (case-sensitive), the link can't be found, so on a freshly-bootstrapped site `make_workstation()` raises:
  ```
  frappe.exceptions.LinkValidationError: Could not find Warehouse: _Test warehouse - _TC
  ```
  Because `BootStrapTestData()` runs at **module import** (`erpnext/tests/utils.py`), this aborts the import and **blocks every test that extends `ERPNextTestSuite`** on Postgres.

It was masked on sites where `_Test Workstation 1` was already bootstrapped (`make_records` skips existing records) or where the lowercase name happened to exist from legacy data.

### Fix

Point the fixture at the warehouse that `make_warehouse()` actually creates — `_Test Warehouse - _TC` — rather than adding a near-duplicate fixture.

```diff
-				"warehouse": "_Test warehouse - _TC",
+				"warehouse": "_Test Warehouse - _TC",
```

### Verification

On a freshly-reset site (with `_Test Workstation 1` deleted so the bootstrap actually inserts), `--lightmode`:

- **Postgres, before:** `LinkValidationError: Could not find Warehouse: _Test warehouse - _TC`
- **Postgres, after:** ✅ tests run (`test_opportunity` 5/5)
- **MariaDB:** ✅ either way (collation masks it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
