### PR TITLE
fix(payment_entry): recompute base amount when exchange rate changes

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.js
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.js
@@ -754,17 +754,21 @@ frappe.ui.form.on("Payment Entry", {
 		frm.set_paid_amount_based_on_received_amount = true;
 		let company_currency = frappe.get_doc(":Company", frm.doc.company).default_currency;
 
-		if (frm.doc.base_received_amount && frm.doc.source_exchange_rate) {
-			frm.set_value("base_paid_amount", frm.doc.base_received_amount);
+		if (frm.doc.paid_amount && frm.doc.source_exchange_rate) {
+			frm.set_value("base_paid_amount", flt(frm.doc.paid_amount) * flt(frm.doc.source_exchange_rate));
+			frm.set_value("base_received_amount", frm.doc.base_paid_amount);
 
 			// target exchange rate should always be same as source if both account currencies is same
 			if (frm.doc.paid_from_account_currency == frm.doc.paid_to_account_currency) {
 				frm.set_value("target_exchange_rate", frm.doc.source_exchange_rate);
+				frm.set_value("received_amount", frm.doc.paid_amount);
 			} else {
-				frm.set_value(
-					"paid_amount",
-					flt(frm.doc.base_paid_amount) / flt(frm.doc.source_exchange_rate)
-				);
+				const target_rate =
+					flt(frm.doc.target_exchange_rate) ||
+					(company_currency == frm.doc.paid_to_account_currency ? 1 : 0);
+				if (target_rate) {
+					frm.set_value("received_amount", flt(frm.doc.base_received_amount) / target_rate);
+				}
 			}
 
 			// set_unallocated_amount is called by below method,
@@ -780,18 +784,23 @@ frappe.ui.form.on("Payment Entry", {
 	target_exchange_rate: function (frm) {
 		let company_currency = frappe.get_doc(":Company", frm.doc.company).default_currency;
 
-		if (frm.doc.base_paid_amount && frm.doc.target_exchange_rate) {
-			frm.set_value("base_received_amount", frm.doc.base_paid_amount);
-			if (
-				!frm.doc.source_exchange_rate &&
-				frm.doc.paid_from_account_currency == frm.doc.paid_to_account_currency
-			) {
+		if (frm.doc.received_amount && frm.doc.target_exchange_rate) {
+			frm.set_value(
+				"base_received_amount",
+				flt(frm.doc.received_amount) * flt(frm.doc.target_exchange_rate)
+			);
+			frm.set_value("base_paid_amount", frm.doc.base_received_amount);
+
+			if (frm.doc.paid_from_account_currency == frm.doc.paid_to_account_currency) {
 				frm.set_value("source_exchange_rate", frm.doc.target_exchange_rate);
+				frm.set_value("paid_amount", frm.doc.received_amount);
 			} else {
-				frm.set_value(
-					"received_amount",
-					flt(frm.doc.base_received_amount) / flt(frm.doc.target_exchange_rate)
-				);
+				const source_rate =
+					flt(frm.doc.source_exchange_rate) ||
+					(company_currency == frm.doc.paid_from_account_currency ? 1 : 0);
+				if (source_rate) {
+					frm.set_value("paid_amount", flt(frm.doc.base_paid_amount) / source_rate);
+				}
 			}
 
 			// set_unallocated_amount is called by below method,


### PR DESCRIPTION
**Issue:**
When a Payment Entry is created in a foreign currency, changing the exchange rate causes the system to keep the base currency amount (INR) unchanged and automatically recalculate the foreign currency amount (USD). For example, changing the exchange rate from 86.60 to 96.00 keeps the INR amount fixed at ₹1,23,664.80 and reduces the USD amount from 1,428.00 to 1,288.18. The expected behavior is for the USD amount to remain fixed at 1,428.00 and for the INR amount to be recalculated based on the updated exchange rate.

Ref: [#71439](https://support.frappe.io/helpdesk/tickets/71439)

Raising this PR on behalf of @ervishnucs 