### PR TITLE
fix: correct supplier filter in rfq_transaction_list (Unknown column …

### DIFF
--- a/erpnext/controllers/website_list_for_contact.py
+++ b/erpnext/controllers/website_list_for_contact.py
@@ -183,7 +183,7 @@ def rfq_transaction_list(parties_doctype, doctype, parties, limit_start, limit_p
 		frappe.qb.from_(party)
 		.select(party.parent.as_("name"), party.supplier)
 		.distinct()
-		.where((party.supplier == party[0]) & (party.docstatus == 1))
+		.where((party.supplier.isin(parties)) & (party.docstatus == 1))
 		.orderby(party.creation, order=frappe.qb.desc)
 		.limit(limit_page_length)
 		.offset(limit_start)


### PR DESCRIPTION
When a Supplier website user opens the Request for Quotation list in the portal, the page crashes with \`pymysql.err.OperationalError: (1054, \"Unknown column '0' in 'WHERE'\")\`.

## Root cause

In \`rfq_transaction_list\` (\`erpnext/controllers/website_list_for_contact.py\`), the query builder filters on \`party[0]\`. \`party\` is the \`frappe.qb.DocType\` object, so \`party[0]\` resolves to a column literally named \`0\` instead of the intended Python value. The original SQL filtered on \`parties[0]\`; the query-builder conversion dropped the \`parties\` reference.

## Fix

Filter on the contact's supplier list with \`party.supplier.isin(parties)\` — valid SQL, and also covers contacts mapped to more than one supplier (consistent with how \`get_transaction_list\` filters suppliers with \`[\"in\", suppliers]\`).

## Impact

Suppliers can open the Request for Quotation portal list again. Verified locally on a v15 site. No schema changes."