### PR TITLE
refactor(sales_invoice): shrink make_inter_company_transaction mapper

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/mapper.py
+++ b/erpnext/accounts/doctype/sales_invoice/mapper.py
@@ -200,106 +200,11 @@ def make_inter_company_transaction(doctype, source_name, target_doc=None):
 		set_purchase_references(target)
 
 	def update_details(source_doc, target_doc, source_parent):
-		def _validate_address_link(address, link_doctype, link_name):
-			return frappe.db.get_value(
-				"Dynamic Link",
-				{
-					"parent": address,
-					"parenttype": "Address",
-					"link_doctype": link_doctype,
-					"link_name": link_name,
-				},
-				"parent",
-			)
-
 		target_doc.inter_company_invoice_reference = source_doc.name
 		if target_doc.doctype in ["Purchase Invoice", "Purchase Order"]:
-			currency = frappe.db.get_value("Supplier", details.get("party"), "default_currency")
-			target_doc.company = details.get("company")
-			target_doc.supplier = details.get("party")
-			target_doc.is_internal_supplier = 1
-			target_doc.ignore_pricing_rule = 1
-			target_doc.buying_price_list = source_doc.selling_price_list
-
-			# Invert Addresses
-			if source_doc.company_address and _validate_address_link(
-				source_doc.company_address, "Supplier", details.get("party")
-			):
-				update_address(target_doc, "supplier_address", "address_display", source_doc.company_address)
-			if source_doc.dispatch_address_name and _validate_address_link(
-				source_doc.dispatch_address_name, "Company", details.get("company")
-			):
-				update_address(
-					target_doc,
-					"dispatch_address",
-					"dispatch_address_display",
-					source_doc.dispatch_address_name,
-				)
-			if source_doc.shipping_address_name and _validate_address_link(
-				source_doc.shipping_address_name, "Company", details.get("company")
-			):
-				update_address(
-					target_doc,
-					"shipping_address",
-					"shipping_address_display",
-					source_doc.shipping_address_name,
-				)
-			if source_doc.customer_address and _validate_address_link(
-				source_doc.customer_address, "Company", details.get("company")
-			):
-				update_address(
-					target_doc, "billing_address", "billing_address_display", source_doc.customer_address
-				)
-
-			if currency:
-				target_doc.currency = currency
-
-			update_taxes(
-				target_doc,
-				party=target_doc.supplier,
-				party_type="Supplier",
-				company=target_doc.company,
-				doctype=target_doc.doctype,
-				party_address=target_doc.supplier_address,
-				company_address=target_doc.shipping_address,
-			)
-
+			_apply_purchase_party_details(target_doc, source_doc, details)
 		else:
-			currency = frappe.db.get_value("Customer", details.get("party"), "default_currency")
-			target_doc.company = details.get("company")
-			target_doc.customer = details.get("party")
-			target_doc.selling_price_list = source_doc.buying_price_list
-
-			if source_doc.supplier_address and _validate_address_link(
-				source_doc.supplier_address, "Company", details.get("company")
-			):
-				update_address(
-					target_doc, "company_address", "company_address_display", source_doc.supplier_address
-				)
-			if source_doc.shipping_address and _validate_address_link(
-				source_doc.shipping_address, "Customer", details.get("party")
-			):
-				update_address(
-					target_doc, "shipping_address_name", "shipping_address", source_doc.shipping_address
-				)
-			if source_doc.shipping_address and _validate_address_link(
-				source_doc.shipping_address, "Customer", details.get("party")
-			):
-				update_address(target_doc, "customer_address", "address_display", source_doc.shipping_address)
-
-			if currency:
-				target_doc.currency = currency
-
-			update_taxes(
-				target_doc,
-				party=target_doc.customer,
-				party_type="Customer",
-				company=target_doc.company,
-				doctype=target_doc.doctype,
-				party_address=target_doc.customer_address,
-				company_address=target_doc.company_address,
-				shipping_address_name=target_doc.shipping_address_name,
-			)
+			_apply_sales_party_details(target_doc, source_doc, details)
 
 	def update_item(source, target, source_parent):
 		target.qty = flt(source.qty) - received_items.get(source.name, 0.0)
@@ -376,6 +281,97 @@ def make_inter_company_transaction(doctype, source_name, target_doc=None):
 		)
 
 	return doclist
+
+
+def _get_linked_address(address, link_doctype, link_name):
+	return frappe.db.get_value(
+		"Dynamic Link",
+		{
+			"parent": address,
+			"parenttype": "Address",
+			"link_doctype": link_doctype,
+			"link_name": link_name,
+		},
+		"parent",
+	)
+
+
+def _apply_purchase_party_details(target_doc, source_doc, details):
+	currency = frappe.db.get_value("Supplier", details.get("party"), "default_currency")
+	target_doc.company = details.get("company")
+	target_doc.supplier = details.get("party")
+	target_doc.is_internal_supplier = 1
+	target_doc.ignore_pricing_rule = 1
+	target_doc.buying_price_list = source_doc.selling_price_list
+
+	# Invert Addresses
+	if source_doc.company_address and _get_linked_address(
+		source_doc.company_address, "Supplier", details.get("party")
+	):
+		update_address(target_doc, "supplier_address", "address_display", source_doc.company_address)
+	if source_doc.dispatch_address_name and _get_linked_address(
+		source_doc.dispatch_address_name, "Company", details.get("company")
+	):
+		update_address(
+			target_doc, "dispatch_address", "dispatch_address_display", source_doc.dispatch_address_name
+		)
+	if source_doc.shipping_address_name and _get_linked_address(
+		source_doc.shipping_address_name, "Company", details.get("company")
+	):
+		update_address(
+			target_doc, "shipping_address", "shipping_address_display", source_doc.shipping_address_name
+		)
+	if source_doc.customer_address and _get_linked_address(
+		source_doc.customer_address, "Company", details.get("company")
+	):
+		update_address(target_doc, "billing_address", "billing_address_display", source_doc.customer_address)
+
+	if currency:
+		target_doc.currency = currency
+
+	update_taxes(
+		target_doc,
+		party=target_doc.supplier,
+		party_type="Supplier",
+		company=target_doc.company,
+		doctype=target_doc.doctype,
+		party_address=target_doc.supplier_address,
+		company_address=target_doc.shipping_address,
+	)
+
+
+def _apply_sales_party_details(target_doc, source_doc, details):
+	currency = frappe.db.get_value("Customer", details.get("party"), "default_currency")
+	target_doc.company = details.get("company")
+	target_doc.customer = details.get("party")
+	target_doc.selling_price_list = source_doc.buying_price_list
+
+	if source_doc.supplier_address and _get_linked_address(
+		source_doc.supplier_address, "Company", details.get("company")
+	):
+		update_address(target_doc, "company_address", "company_address_display", source_doc.supplier_address)
+	if source_doc.shipping_address and _get_linked_address(
+		source_doc.shipping_address, "Customer", details.get("party")
+	):
+		update_address(target_doc, "shipping_address_name", "shipping_address", source_doc.shipping_address)
+	if source_doc.shipping_address and _get_linked_address(
+		source_doc.shipping_address, "Customer", details.get("party")
+	):
+		update_address(target_doc, "customer_address", "address_display", source_doc.shipping_address)
+
+	if currency:
+		target_doc.currency = currency
+
+	update_taxes(
+		target_doc,
+		party=target_doc.customer,
+		party_type="Customer",
+		company=target_doc.company,
+		doctype=target_doc.doctype,
+		party_address=target_doc.customer_address,
+		company_address=target_doc.company_address,
+		shipping_address_name=target_doc.shipping_address_name,
+	)
 
 
 @frappe.whitelist()


### PR DESCRIPTION
## Why

`make_inter_company_transaction` in the Sales Invoice mapper was **199 lines**, dominated by a **102-line nested `update_details` closure** holding two large party-mapping branches (purchase side / sales side). The file is otherwise healthy (MI: A, no high-complexity functions) — this is purely a length/readability cleanup.

No linked issue — internal code-quality work.

## What

Pure structural extraction, no behaviour change:

- Move the two branches of `update_details` into module helpers **`_apply_purchase_party_details`** and **`_apply_sales_party_details`**.
- Move the inline address-link lookup into **`_get_linked_address`**.
- `update_details` is now a 6-line dispatcher; `make_inter_company_transaction` drops from **199 → ~104 lines**.

All extracted code is moved verbatim (party/company assignment, address inversion, taxes).

## Manual QA

Covered by the existing inter-company suites (both directions):
- Create an inter-company Purchase Invoice from a Sales Invoice (`_apply_purchase_party_details`) and confirm party, company, addresses and taxes map as before.
- Create an inter-company Sales Order from a Purchase Order (`_apply_sales_party_details`) and confirm the same.