### PR TITLE
fix: fetch party types based on account type in journal entry

### DIFF
--- a/erpnext/setup/doctype/party_type/party_type.py
+++ b/erpnext/setup/doctype/party_type/party_type.py
@@ -33,14 +33,11 @@ def get_party_type(doctype: str, txt: str, searchfield: str, start: int, page_le
 
 	if filters and filters.get("account"):
 		account_type = frappe.db.get_value("Account", filters.get("account"), "account_type")
-		if account_type:
-			if account_type in ["Receivable", "Payable"]:
-				# Include Employee regardless of its configured account_type, but still respect the text filter
-				condition_list.append(
-					(PartyType.account_type == account_type) | (PartyType.name == "Employee")
-				)
-			else:
-				condition_list.append(PartyType.account_type == account_type)
+		if account_type in ["Receivable", "Payable"]:
+			# Include Employee regardless of its configured account_type, but still respect the text filter
+			condition_list.append((PartyType.account_type == account_type) | (PartyType.name == "Employee"))
+		else:
+			condition_list.append(PartyType.account_type == account_type)
 
 	for condition in condition_list:
 		get_party_type_query = get_party_type_query.where(condition)


### PR DESCRIPTION
Issue:

In v14, the *Party Type* field in the Journal Entry Accounts child table only returned values when the selected Account had an *Account Type* of *Receivable* or *Payable*.

In v15/v16, Party Types are returned when no Account Type is set for the selected Account. This allows users to select Party Types for accounts where party accounting is not applicable, which can affect party balance calculations and reports such as the *Party-wise Trial Balance*.


Ref: [#70843](https://support.frappe.io/helpdesk/tickets/70843)

Raising this PR on behalf of @ssakthivelmurugan 