### PR TITLE
refactor(sales_order): simplify create_stock_reservation_entries

### DIFF
--- a/erpnext/selling/doctype/sales_order/services/reservation.py
+++ b/erpnext/selling/doctype/sales_order/services/reservation.py
@@ -85,15 +85,7 @@ class SalesOrderStockReservation:
 			create_stock_reservation_entries_for_so_items as create_stock_reservation_entries,
 		)
 
-		packed_items = []
-		if items_details:
-			for item in items_details:
-				if not frappe.db.exists("Sales Order Item", item.get("sales_order_item")):
-					item["qty"] = item.pop("qty_to_reserve")
-					packed_items.append(item)
-
-			for item in packed_items:
-				items_details.remove(item)
+		packed_items = self._extract_packed_item_details(items_details)
 
 		sre_count = 0
 		if items_details != []:
@@ -104,22 +96,41 @@ class SalesOrderStockReservation:
 				notify=notify,
 			)
 
-		items = []
-		if packed_items:
-			items = packed_items
-		elif not items_details:
-			items = [item for item in self.doc.packed_items if item.reserve_stock]
-
+		items = self._packed_items_to_reserve(items_details, packed_items)
 		if items:
-			from erpnext.stock.doctype.stock_reservation_entry.stock_reservation_entry import StockReservation
+			self._reserve_packed_items(items, sre_count, notify)
 
-			stock_reservation = StockReservation(doc=self.doc, items=items)
-			stock_reservation.table_name = "packed_items"
-			stock_reservation.qty_field = "qty"
-			is_sre_created = stock_reservation.make_stock_reservation_entries()
+	def _extract_packed_item_details(self, items_details: list[dict] | None) -> list:
+		"""Pull packed-item rows (whose Sales Order Item no longer exists) out of items_details."""
+		packed_items = []
+		if items_details:
+			for item in items_details:
+				if not frappe.db.exists("Sales Order Item", item.get("sales_order_item")):
+					item["qty"] = item.pop("qty_to_reserve")
+					packed_items.append(item)
 
-			if notify and is_sre_created and not sre_count:
-				frappe.msgprint(_("Stock Reservation Entries Created"), alert=True, indicator="green")
+			for item in packed_items:
+				items_details.remove(item)
+
+		return packed_items
+
+	def _packed_items_to_reserve(self, items_details: list[dict] | None, packed_items: list) -> list:
+		if packed_items:
+			return packed_items
+		if not items_details:
+			return [item for item in self.doc.packed_items if item.reserve_stock]
+		return []
+
+	def _reserve_packed_items(self, items: list, sre_count: int, notify: bool) -> None:
+		from erpnext.stock.doctype.stock_reservation_entry.stock_reservation_entry import StockReservation
+
+		stock_reservation = StockReservation(doc=self.doc, items=items)
+		stock_reservation.table_name = "packed_items"
+		stock_reservation.qty_field = "qty"
+		is_sre_created = stock_reservation.make_stock_reservation_entries()
+
+		if notify and is_sre_created and not sre_count:
+			frappe.msgprint(_("Stock Reservation Entries Created"), alert=True, indicator="green")
 
 	def cancel_stock_reservation_entries(self, sre_list: list | None = None, notify: bool = True) -> None:
 		"""Cancel Stock Reservation Entries for Sales Order Items."""


### PR DESCRIPTION
## Why

`SalesOrderStockReservation.create_stock_reservation_entries` was the only C-rank function in the Sales Order services (the rest of `services/` is already MI: A). At C/14 it interleaved three concerns: separating packed-item rows out of `items_details`, creating the Sales Order Item SREs, and reserving packed-item stock.

No linked issue — internal code-quality work.

## What

Pure structural extraction, conditions/expressions moved verbatim:

- `_extract_packed_item_details` — pulls packed-item rows (whose Sales Order Item no longer exists) out of `items_details`.
- `_packed_items_to_reserve` — resolves which packed items to reserve.
- `_reserve_packed_items` — the `StockReservation` block + the "Entries Created" alert.

`create_stock_reservation_entries` drops **C/14 → A/3**; no C-rank function remains in the module.

## Coverage note

The covered paths — default reservation on submit (incl. product bundles), and the Pick List `items_details` path — are exercised by the existing `test_stock_reservation_entry`, `test_product_bundle_reservation`, packing-list and pick-list reservation suites (all green). The packed-item-within-`items_details` sub-branch (a product-bundle reserved via a **Pick List**) was already untested before this change and is moved verbatim here; closing that gap needs a dedicated bundle-pick-list reservation fixture and is left as follow-up.

## Manual QA

- Submit a Sales Order with Reserve Stock (including a product bundle) and confirm SREs are created as before.
- Reserve stock from a Pick List against a Sales Order and confirm the same.