### PR TITLE
fix: raise valuation rate error only on submit, not on draft Stock Entry

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -547,8 +547,8 @@ class StockEntry(StockController, SubcontractingInwardController):
 
 	def set_basic_rate(self, reset_outgoing_rate=True, raise_error_if_no_rate=True):
 		"""Set rate for outgoing, secondary and finished items."""
+		raise_error_if_no_rate = raise_error_if_no_rate and self.docstatus == 1
 		outgoing_items_cost = self.set_rate_for_outgoing_items(reset_outgoing_rate, raise_error_if_no_rate)
-		raise_error_if_no_rate = raise_error_if_no_rate and not self.is_new()
 
 		zero_valuation_items = []
 		for d in self.get("items"):

--- a/erpnext/stock/doctype/stock_entry/test_stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/test_stock_entry.py
@@ -2915,36 +2915,6 @@ class TestStockEntry(ERPNextTestSuite):
 		self.assertEqual(se.items[2].qty, 4.5)
 		self.assertEqual(se.items[2].amount, 5)
 
-	def test_valuation_rate_missing_only_on_submit_not_draft(self):
-		"""Saving a draft Stock Entry for an item with no valuation rate should not raise
-		'Valuation Rate Missing'. The error should only fire on submit."""
-		import frappe
-
-		item_code = "_Test No-Rate Item for SE Draft"
-		create_item(item_code, is_stock_item=1, valuation_rate=0)
-
-		se = frappe.new_doc("Stock Entry")
-		se.purpose = "Material Transfer for Manufacture"
-		se.company = "_Test Company"
-		se.set_stock_entry_type()
-		se.append(
-			"items",
-			{
-				"item_code": item_code,
-				"qty": 1,
-				"uom": "Nos",
-				"s_warehouse": "_Test Warehouse - _TC",
-				"t_warehouse": "_Test Warehouse 1 - _TC",
-			},
-		)
-
-		# Save as draft must not raise "Valuation Rate Missing"
-		se.save()
-		self.assertEqual(se.docstatus, 0)
-
-		# Submit must raise "Valuation Rate Missing" because no stock exists
-		self.assertRaises(frappe.ValidationError, se.submit)
-
 
 class TestStockEntryCoverage(ERPNextTestSuite):
 	"""Tests for functions previously lacking dedicated coverage."""

--- a/erpnext/stock/doctype/stock_entry/test_stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/test_stock_entry.py
@@ -2915,6 +2915,36 @@ class TestStockEntry(ERPNextTestSuite):
 		self.assertEqual(se.items[2].qty, 4.5)
 		self.assertEqual(se.items[2].amount, 5)
 
+	def test_valuation_rate_missing_only_on_submit_not_draft(self):
+		"""Saving a draft Stock Entry for an item with no valuation rate should not raise
+		'Valuation Rate Missing'. The error should only fire on submit."""
+		import frappe
+
+		item_code = "_Test No-Rate Item for SE Draft"
+		create_item(item_code, is_stock_item=1, valuation_rate=0)
+
+		se = frappe.new_doc("Stock Entry")
+		se.purpose = "Material Transfer for Manufacture"
+		se.company = "_Test Company"
+		se.set_stock_entry_type()
+		se.append(
+			"items",
+			{
+				"item_code": item_code,
+				"qty": 1,
+				"uom": "Nos",
+				"s_warehouse": "_Test Warehouse - _TC",
+				"t_warehouse": "_Test Warehouse 1 - _TC",
+			},
+		)
+
+		# Save as draft must not raise "Valuation Rate Missing"
+		se.save()
+		self.assertEqual(se.docstatus, 0)
+
+		# Submit must raise "Valuation Rate Missing" because no stock exists
+		self.assertRaises(frappe.ValidationError, se.submit)
+
 
 class TestStockEntryCoverage(ERPNextTestSuite):
 	"""Tests for functions previously lacking dedicated coverage."""


### PR DESCRIPTION
## Problem

When creating a **Material Transfer for Manufacture** Stock Entry from a Job Card, the system showed a "Valuation Rate Missing" dialog even on a **draft** (docstatus=0). This blocked users from saving a draft when the item had no prior stock.

## Root Cause

In `set_basic_rate()`, `set_rate_for_outgoing_items()` was called **before** the `raise_error_if_no_rate` guard was applied:

```python
def set_basic_rate(self, reset_outgoing_rate=True, raise_error_if_no_rate=True):
    outgoing_items_cost = self.set_rate_for_outgoing_items(reset_outgoing_rate, raise_error_if_no_rate)
    raise_error_if_no_rate = raise_error_if_no_rate and not self.is_new()  # only affected incoming items
```

Items with `s_warehouse` (outgoing) are processed in `set_rate_for_outgoing_items`, which calls `get_incoming_rate` → `get_valuation_rate` with `raise_error_if_no_rate=True`. The guard `not self.is_new()` only suppressed the error for brand-new (never-saved) documents, not for **saved drafts**.

## Fix

Move the guard before the outgoing-items call and change the condition to `self.docstatus == 1` so the error only fires on **submit**:

```python
def set_basic_rate(self, reset_outgoing_rate=True, raise_error_if_no_rate=True):
    raise_error_if_no_rate = raise_error_if_no_rate and self.docstatus == 1
    outgoing_items_cost = self.set_rate_for_outgoing_items(reset_outgoing_rate, raise_error_if_no_rate)
```

This is safe because Frappe's `_submit()` sets `docstatus = 1` **before** calling `save()` → `validate()`, so the error is still raised correctly on submit.

## Test

Added `test_valuation_rate_missing_only_on_submit_not_draft` in `test_stock_entry.py`:
- Saves a "Material Transfer for Manufacture" SE with an unstocked item as draft → asserts no exception
- Submits the same SE → asserts `frappe.ValidationError` is raised

## Checklist

- [x] Follows the [Contribution Guidelines](https://github.com/frappe/erpnext/wiki/Contribution-Guidelines)
- [x] Includes test cases
- [x] Pre-commit hooks pass (ruff, prettier, eslint)
- [x] No server-side `console.log` or debug prints