### PR TITLE
fix: show only pending items in job card material transfer and add partially transferred status

### DIFF
--- a/erpnext/manufacturing/doctype/job_card/job_card.js
+++ b/erpnext/manufacturing/doctype/job_card/job_card.js
@@ -207,7 +207,9 @@ frappe.ui.form.on("Job Card", {
 		if (frm.is_new() || doc.skip_material_transfer || doc.docstatus >= 2) return;
 
 		const excess_transfer_allowed = doc.__onload.job_card_excess_transfer;
-		const to_request = doc.for_quantity > doc.transferred_qty;
+		const to_transfer =
+			has_items && doc.items.some((row) => flt(row.transferred_qty) < flt(row.required_qty));
+		const to_request = to_transfer;
 
 		if (has_items && (to_request || excess_transfer_allowed)) {
 			frm.add_custom_button(
@@ -216,9 +218,6 @@ frappe.ui.form.on("Job Card", {
 				__("Create")
 			);
 		}
-
-		// check if any row has untransferred materials in case of multiple items in JC
-		const to_transfer = doc.items.some((row) => row.transferred_qty < row.required_qty);
 
 		if (has_items && (to_transfer || excess_transfer_allowed)) {
 			frm.add_custom_button(
@@ -586,11 +585,10 @@ frappe.ui.form.on("Job Card", {
 
 		// ── Determine which action buttons to show ────────────────────────
 		const has_remaining_qty = doc.for_quantity + doc.process_loss_qty > doc.total_completed_qty;
+		const pending_transfer =
+			has_items && doc.items.some((row) => flt(row.transferred_qty) < flt(row.required_qty));
 		const materials_ready =
-			doc.skip_material_transfer ||
-			doc.transferred_qty >= doc.for_quantity + doc.process_loss_qty ||
-			!doc.finished_good ||
-			!has_items?.length;
+			doc.skip_material_transfer || !pending_transfer || !doc.finished_good || !has_items;
 
 		let last_row = {};
 		const has_sub_ops_or_pending_qty = doc.sub_operations?.length || doc.pending_qty > 0;

--- a/erpnext/manufacturing/doctype/job_card/job_card.json
+++ b/erpnext/manufacturing/doctype/job_card/job_card.json
@@ -272,7 +272,7 @@
    "fieldtype": "Select",
    "label": "Status",
    "no_copy": 1,
-   "options": "Open\nWork In Progress\nMaterial Transferred\nOn Hold\nSubmitted\nCancelled\nCompleted",
+   "options": "Open\nWork In Progress\nPartially Transferred\nMaterial Transferred\nOn Hold\nSubmitted\nCancelled\nCompleted",
    "read_only": 1
   },
   {
@@ -695,7 +695,7 @@
  "grid_page_length": 50,
  "is_submittable": 1,
  "links": [],
- "modified": "2026-05-21 18:37:05.688342",
+ "modified": "2026-06-19 17:39:42.293242",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "Job Card",

--- a/erpnext/manufacturing/doctype/job_card/job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/job_card.py
@@ -127,6 +127,7 @@ class JobCard(Document):
 		status: DF.Literal[
 			"Open",
 			"Work In Progress",
+			"Partially Transferred",
 			"Material Transferred",
 			"On Hold",
 			"Submitted",
@@ -1195,6 +1196,8 @@ class JobCard(Document):
 
 			frappe.db.set_value("Job Card Item", row.job_card_item, "transferred_qty", flt(transferred_qty))
 
+		self.set_status(update_status=True)
+
 	def get_job_card_items_transferred_qty(self, ste_doc):
 		from frappe.query_builder.functions import Sum
 
@@ -1305,7 +1308,22 @@ class JobCard(Document):
 			self.status = "Work In Progress"
 
 	def set_non_semi_fg_status(self):
-		if flt(self.for_quantity) <= flt(self.transferred_qty):
+		if self.items:
+			item_data = frappe.get_all(
+				"Job Card Item",
+				filters={"parent": self.name},
+				fields=["transferred_qty", "required_qty"],
+			)
+			all_transferred = item_data and all(
+				flt(d.transferred_qty) >= flt(d.required_qty) for d in item_data
+			)
+			any_transferred = any(flt(d.transferred_qty) > 0 for d in item_data)
+
+			if all_transferred:
+				self.status = "Material Transferred"
+			elif any_transferred:
+				self.status = "Partially Transferred"
+		elif flt(self.for_quantity) <= flt(self.transferred_qty):
 			self.status = "Material Transferred"
 
 		if self.time_logs:
@@ -1829,6 +1847,7 @@ def get_calendar_event(d):
 	event_color = {
 		"Completed": "#cdf5a6",
 		"Material Transferred": "#ffdd9e",
+		"Partially Transferred": "#ffe5b4",
 		"Work In Progress": "#D3D3D3",
 	}
 

--- a/erpnext/manufacturing/doctype/job_card/job_card_list.js
+++ b/erpnext/manufacturing/doctype/job_card/job_card_list.js
@@ -7,6 +7,7 @@ frappe.listview_settings["Job Card"] = {
 			Completed: "green",
 			Cancelled: "red",
 			"Material Transferred": "blue",
+			"Partially Transferred": "yellow",
 			Open: "red",
 		};
 		const status = doc.status || "Open";

--- a/erpnext/projects/report/daily_timesheet_summary/test_daily_timesheet_summary.py
+++ b/erpnext/projects/report/daily_timesheet_summary/test_daily_timesheet_summary.py
@@ -1,8 +1,10 @@
 # Copyright (c) 2024, Frappe Technologies Pvt. Ltd. and Contributors
 # License: GNU General Public License v3. See license.txt
 
+from datetime import timedelta
+
 import frappe
-from frappe.utils import today
+from frappe.utils import get_datetime, today
 
 from erpnext.projects.doctype.timesheet.test_timesheet import make_timesheet
 from erpnext.projects.report.daily_timesheet_summary.daily_timesheet_summary import execute
@@ -16,6 +18,18 @@ class TestDailyTimesheetSummary(ERPNextTestSuite):
 
 		employee = make_employee("test_employee_6@salary.com", company="_Test Company")
 		timesheet = make_timesheet(employee, simulate=True)
+
+		# make_timesheet logs at now_datetime(); run late in the day (under the site timezone)
+		# the 2h log crosses midnight and falls outside the report's `to_time <= end-of-day`
+		# bound. Pin the log to a fixed mid-day window on today so the assertion is
+		# time-of-day independent.
+		start = get_datetime(today()) + timedelta(hours=9)
+		frappe.db.set_value(
+			"Timesheet Detail",
+			timesheet.time_logs[0].name,
+			{"from_time": start, "to_time": start + timedelta(hours=2)},
+			update_modified=False,
+		)
 
 		_columns, data = execute({"from_date": today(), "to_date": today()})
 


### PR DESCRIPTION
Issue:
When a Job Card has multiple raw material items, and the user transfers only one item, clicking Material Transfer again incorrectly shows all items, including the already-transferred one. The same issue exists in the Material Request. Additionally, the Job Card status jumps to "Material Transferred."


Steps to Replicate:
1. Create a Work Order for a product with at least 2 raw materials
2. Open the generated Job Card
3. Click Create → Material Transfer
4. In the stock entry dialog, remove one item and transfer only the first item with full qty → Submit
5. Go back to the Job Card — notice the status shows "Material Transferred" (wrong)
6. Click Create → Material Transfer again
7. The dialog shows both items, including the already-transferred one (wrong — should show only the pending item)
8. Also, notice the Material Request button disappears after step 4, even though the second item is still pending

Before:

[Screencast from 2026-06-19 17-56-16.webm](https://github.com/user-attachments/assets/25ce80b9-7653-4174-bde0-63b762fd3065)


After : 

[Screencast from 2026-06-19 17-53-08.webm](https://github.com/user-attachments/assets/44bd5759-512c-41df-acf5-aa58c5a132c6)

Backport Needed For V16 and V15