### PR TITLE
test(projects): fix time-of-day flaky daily-timesheet-summary test

### DIFF
--- a/erpnext/projects/report/daily_timesheet_summary/test_daily_timesheet_summary.py
+++ b/erpnext/projects/report/daily_timesheet_summary/test_daily_timesheet_summary.py
@@ -1,8 +1,10 @@
 # Copyright (c) 2024, Frappe Technologies Pvt. Ltd. and Contributors
 # License: GNU General Public License v3. See license.txt
 
+from datetime import timedelta
+
 import frappe
-from frappe.utils import today
+from frappe.utils import get_datetime, today
 
 from erpnext.projects.doctype.timesheet.test_timesheet import make_timesheet
 from erpnext.projects.report.daily_timesheet_summary.daily_timesheet_summary import execute
@@ -16,6 +18,18 @@ class TestDailyTimesheetSummary(ERPNextTestSuite):
 
 		employee = make_employee("test_employee_6@salary.com", company="_Test Company")
 		timesheet = make_timesheet(employee, simulate=True)
+
+		# make_timesheet logs at now_datetime(); run late in the day (under the site timezone)
+		# the 2h log crosses midnight and falls outside the report's `to_time <= end-of-day`
+		# bound. Pin the log to a fixed mid-day window on today so the assertion is
+		# time-of-day independent.
+		start = get_datetime(today()) + timedelta(hours=9)
+		frappe.db.set_value(
+			"Timesheet Detail",
+			timesheet.time_logs[0].name,
+			{"from_time": start, "to_time": start + timedelta(hours=2)},
+			update_modified=False,
+		)
 
 		_columns, data = execute({"from_date": today(), "to_date": today()})
 


### PR DESCRIPTION
## Problem

`test_submitted_timesheet_in_summary` is **flaky by time of day**. `make_timesheet(simulate=True)` logs at `now_datetime()` with a 2-hour duration. When the suite runs late in the day under the site timezone (e.g. CI at 22:51 IST), the log's `to_time` crosses midnight into the next day. The Daily Timesheet Summary report bounds results with `to_time <= end of to_date` (next-day midnight), so the midnight-crossing log is correctly excluded — and the assertion `assertIn(timesheet.name, names)` fails with an empty result set.

This fails CI on unrelated PRs whenever the runner happens to execute in the ~22:00–24:00 IST window.

## Fix

Pin the timesheet log to a fixed mid-day window on `today()` (09:00–11:00) before running the report, so the assertion no longer depends on what time the suite runs. No change to the report or to `make_timesheet`.

## Verification

Run at **23:30 IST** (the window that reproduces the failure), the original test fails (`'TS-…' not found in []`) and the fixed test passes — on both MariaDB and Postgres, with `--lightmode`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
