### PR TITLE
feat: revamp Inventory Dimension feature -> Inventory Dimension Bundle

### DIFF
--- a/erpnext/accounts/doctype/pos_invoice/pos_invoice.js
+++ b/erpnext/accounts/doctype/pos_invoice/pos_invoice.js
@@ -26,6 +26,7 @@ erpnext.selling.POSInvoiceController = class POSInvoiceController extends erpnex
 			"POS Invoice Merge Log",
 			"POS Closing Entry",
 			"Serial and Batch Bundle",
+			"Inventory Dimension Bundle",
 		];
 
 		if (doc.__islocal && doc.is_pos && frappe.get_route_str() !== "point-of-sale") {

--- a/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
+++ b/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
@@ -286,7 +286,11 @@ class POSInvoice(SalesInvoice):
 			)
 
 	def on_cancel(self):
-		self.ignore_linked_doctypes = ["Payment Ledger Entry", "Serial and Batch Bundle"]
+		self.ignore_linked_doctypes = [
+			"Payment Ledger Entry",
+			"Serial and Batch Bundle",
+			"Inventory Dimension Bundle",
+		]
 		# run on cancel method of selling controller
 		super(SalesInvoice, self).on_cancel()
 		if not self.is_return and self.loyalty_program:

--- a/erpnext/accounts/doctype/pos_invoice_item/pos_invoice_item.json
+++ b/erpnext/accounts/doctype/pos_invoice_item/pos_invoice_item.json
@@ -93,6 +93,9 @@
   "serial_no",
   "column_break_ciit",
   "batch_no",
+  "inventory_dimension_section",
+  "add_inventory_dimension",
+  "inventory_dimension_bundle",
   "edit_references",
   "sales_order",
   "so_detail",
@@ -854,6 +857,27 @@
    "print_hide": 1
   },
   {
+   "fieldname": "inventory_dimension_bundle",
+   "fieldtype": "Link",
+   "label": "Inventory Dimension Bundle",
+   "no_copy": 1,
+   "options": "Inventory Dimension Bundle",
+   "print_hide": 1,
+   "search_index": 1
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "inventory_dimension_section",
+   "fieldtype": "Section Break",
+   "label": "Inventory Dimension"
+  },
+  {
+   "depends_on": "eval:parent.docstatus == 0",
+   "fieldname": "add_inventory_dimension",
+   "fieldtype": "Button",
+   "label": "Add Inventory Dimension"
+  },
+  {
    "default": "0",
    "fieldname": "use_serial_batch_fields",
    "fieldtype": "Check",
@@ -877,7 +901,7 @@
  ],
  "istable": 1,
  "links": [],
- "modified": "2026-06-08 20:00:00.000000",
+ "modified": "2026-06-21 10:00:00.000000",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "POS Invoice Item",

--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js
@@ -57,6 +57,7 @@ erpnext.accounts.PurchaseInvoice = class PurchaseInvoice extends erpnext.buying.
 			"Unreconcile Payment",
 			"Unreconcile Payment Entries",
 			"Serial and Batch Bundle",
+			"Inventory Dimension Bundle",
 			"Bank Transaction",
 		];
 

--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
@@ -767,6 +767,7 @@ class PurchaseInvoice(BuyingController):
 			"Unreconcile Payment Entries",
 			"Payment Ledger Entry",
 			"Serial and Batch Bundle",
+			"Inventory Dimension Bundle",
 			"Tax Withholding Entry",
 		)
 

--- a/erpnext/accounts/doctype/purchase_invoice_item/purchase_invoice_item.json
+++ b/erpnext/accounts/doctype/purchase_invoice_item/purchase_invoice_item.json
@@ -80,6 +80,12 @@
   "rejected_serial_no",
   "column_break_vbbb",
   "batch_no",
+  "inventory_dimension_section",
+  "add_inventory_dimension",
+  "inventory_dimension_bundle",
+  "column_break_inv_dim",
+  "add_inventory_dimension_for_rejected_qty",
+  "rejected_inventory_dimension_bundle",
   "manufacture_details",
   "manufacturer",
   "column_break_13",
@@ -912,6 +918,46 @@
    "search_index": 1
   },
   {
+   "fieldname": "inventory_dimension_bundle",
+   "fieldtype": "Link",
+   "label": "Inventory Dimension Bundle",
+   "no_copy": 1,
+   "options": "Inventory Dimension Bundle",
+   "print_hide": 1,
+   "search_index": 1
+  },
+  {
+   "fieldname": "column_break_inv_dim",
+   "fieldtype": "Column Break"
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "inventory_dimension_section",
+   "fieldtype": "Section Break",
+   "label": "Inventory Dimension"
+  },
+  {
+   "depends_on": "eval:parent.docstatus == 0",
+   "fieldname": "add_inventory_dimension",
+   "fieldtype": "Button",
+   "label": "Add Inventory Dimension"
+  },
+  {
+   "depends_on": "eval:parent.docstatus == 0",
+   "fieldname": "add_inventory_dimension_for_rejected_qty",
+   "fieldtype": "Button",
+   "label": "Add Inventory Dimension (Rejected Qty)"
+  },
+  {
+   "fieldname": "rejected_inventory_dimension_bundle",
+   "fieldtype": "Link",
+   "label": "Rejected Inventory Dimension Bundle",
+   "no_copy": 1,
+   "options": "Inventory Dimension Bundle",
+   "print_hide": 1,
+   "search_index": 1
+  },
+  {
    "depends_on": "eval:doc.use_serial_batch_fields === 0 || doc.docstatus === 1",
    "fieldname": "rejected_serial_and_batch_bundle",
    "fieldtype": "Link",
@@ -1010,7 +1056,7 @@
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-06-08 21:00:00.000000",
+ "modified": "2026-06-21 10:00:00.000000",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Purchase Invoice Item",

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
@@ -43,6 +43,7 @@ erpnext.accounts.SalesInvoiceController = class SalesInvoiceController extends (
 			"Unreconcile Payment",
 			"Unreconcile Payment Entries",
 			"Serial and Batch Bundle",
+			"Inventory Dimension Bundle",
 			"Bank Transaction",
 			"Packing Slip",
 		];

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -573,6 +573,7 @@ class SalesInvoice(SellingController):
 			"Unreconcile Payment Entries",
 			"Payment Ledger Entry",
 			"Serial and Batch Bundle",
+			"Inventory Dimension Bundle",
 			"Tax Withholding Entry",
 		)
 

--- a/erpnext/accounts/doctype/sales_invoice_item/sales_invoice_item.json
+++ b/erpnext/accounts/doctype/sales_invoice_item/sales_invoice_item.json
@@ -98,6 +98,9 @@
   "serial_no",
   "column_break_ytgd",
   "batch_no",
+  "inventory_dimension_section",
+  "add_inventory_dimension",
+  "inventory_dimension_bundle",
   "available_quantity_section",
   "actual_qty",
   "column_break_ogff",
@@ -942,6 +945,27 @@
    "search_index": 1
   },
   {
+   "fieldname": "inventory_dimension_bundle",
+   "fieldtype": "Link",
+   "label": "Inventory Dimension Bundle",
+   "no_copy": 1,
+   "options": "Inventory Dimension Bundle",
+   "print_hide": 1,
+   "search_index": 1
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "inventory_dimension_section",
+   "fieldtype": "Section Break",
+   "label": "Inventory Dimension"
+  },
+  {
+   "depends_on": "eval:parent.docstatus == 0",
+   "fieldname": "add_inventory_dimension",
+   "fieldtype": "Button",
+   "label": "Add Inventory Dimension"
+  },
+  {
    "depends_on": "eval:doc.use_serial_batch_fields === 0 && doc.docstatus === 0",
    "fieldname": "pick_serial_and_batch",
    "fieldtype": "Button",
@@ -1055,7 +1079,7 @@
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-06-08 20:00:00.000000",
+ "modified": "2026-06-21 10:00:00.000000",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Sales Invoice Item",

--- a/erpnext/assets/doctype/asset_capitalization/asset_capitalization.js
+++ b/erpnext/assets/doctype/asset_capitalization/asset_capitalization.js
@@ -5,7 +5,11 @@ frappe.provide("erpnext.assets");
 
 erpnext.assets.AssetCapitalization = class AssetCapitalization extends erpnext.stock.StockController {
 	setup() {
-		this.frm.ignore_doctypes_on_cancel_all = ["Serial and Batch Bundle", "Asset Movement"];
+		this.frm.ignore_doctypes_on_cancel_all = [
+			"Serial and Batch Bundle",
+			"Inventory Dimension Bundle",
+			"Asset Movement",
+		];
 		this.setup_posting_date_time_check();
 	}
 

--- a/erpnext/assets/doctype/asset_capitalization/asset_capitalization.py
+++ b/erpnext/assets/doctype/asset_capitalization/asset_capitalization.py
@@ -119,6 +119,7 @@ class AssetCapitalization(StockController):
 			"Stock Ledger Entry",
 			"Repost Item Valuation",
 			"Serial and Batch Bundle",
+			"Inventory Dimension Bundle",
 			"Asset",
 			"Asset Movement",
 		)

--- a/erpnext/assets/doctype/asset_capitalization_stock_item/asset_capitalization_stock_item.json
+++ b/erpnext/assets/doctype/asset_capitalization_stock_item/asset_capitalization_stock_item.json
@@ -25,6 +25,9 @@
   "serial_no",
   "column_break_mbuv",
   "batch_no",
+  "inventory_dimension_section",
+  "add_inventory_dimension",
+  "inventory_dimension_bundle",
   "accounting_dimensions_section",
   "cost_center",
   "dimension_col_break"
@@ -160,6 +163,27 @@
    "print_hide": 1
   },
   {
+   "fieldname": "inventory_dimension_bundle",
+   "fieldtype": "Link",
+   "label": "Inventory Dimension Bundle",
+   "no_copy": 1,
+   "options": "Inventory Dimension Bundle",
+   "print_hide": 1,
+   "search_index": 1
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "inventory_dimension_section",
+   "fieldtype": "Section Break",
+   "label": "Inventory Dimension"
+  },
+  {
+   "depends_on": "eval:parent.docstatus == 0",
+   "fieldname": "add_inventory_dimension",
+   "fieldtype": "Button",
+   "label": "Add Inventory Dimension"
+  },
+  {
    "default": "0",
    "fieldname": "use_serial_batch_fields",
    "fieldtype": "Check",
@@ -185,7 +209,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-03-05 12:46:01.074742",
+ "modified": "2026-06-21 10:00:00.000000",
  "modified_by": "Administrator",
  "module": "Assets",
  "name": "Asset Capitalization Stock Item",

--- a/erpnext/assets/doctype/asset_repair/asset_repair.js
+++ b/erpnext/assets/doctype/asset_repair/asset_repair.js
@@ -3,7 +3,7 @@
 
 frappe.ui.form.on("Asset Repair", {
 	setup: function (frm) {
-		frm.ignore_doctypes_on_cancel_all = ["Serial and Batch Bundle"];
+		frm.ignore_doctypes_on_cancel_all = ["Serial and Batch Bundle", "Inventory Dimension Bundle"];
 
 		frm.fields_dict.cost_center.get_query = function (doc) {
 			return {

--- a/erpnext/assets/doctype/asset_repair_consumed_item/asset_repair_consumed_item.json
+++ b/erpnext/assets/doctype/asset_repair_consumed_item/asset_repair_consumed_item.json
@@ -13,7 +13,10 @@
   "serial_no",
   "column_break_xzfr",
   "pick_serial_and_batch",
-  "serial_and_batch_bundle"
+  "serial_and_batch_bundle",
+  "inventory_dimension_section",
+  "add_inventory_dimension",
+  "inventory_dimension_bundle"
  ],
  "fields": [
   {
@@ -57,6 +60,27 @@
    "options": "Serial and Batch Bundle"
   },
   {
+   "fieldname": "inventory_dimension_bundle",
+   "fieldtype": "Link",
+   "label": "Inventory Dimension Bundle",
+   "no_copy": 1,
+   "options": "Inventory Dimension Bundle",
+   "print_hide": 1,
+   "search_index": 1
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "inventory_dimension_section",
+   "fieldtype": "Section Break",
+   "label": "Inventory Dimension"
+  },
+  {
+   "depends_on": "eval:parent.docstatus == 0",
+   "fieldname": "add_inventory_dimension",
+   "fieldtype": "Button",
+   "label": "Add Inventory Dimension"
+  },
+  {
    "fieldname": "warehouse",
    "fieldtype": "Link",
    "in_list_view": 1,
@@ -77,7 +101,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-06-27 14:52:56.311166",
+ "modified": "2026-06-21 10:00:00.000000",
  "modified_by": "Administrator",
  "module": "Assets",
  "name": "Asset Repair Consumed Item",

--- a/erpnext/controllers/buying_controller.py
+++ b/erpnext/controllers/buying_controller.py
@@ -874,6 +874,7 @@ class BuyingController(SubcontractingController):
 							"incoming_rate": valuation_rate_for_rejected_item if not self.is_return else 0.0,
 							"outgoing_rate": valuation_rate_for_rejected_item if self.is_return else 0.0,
 							"serial_and_batch_bundle": d.rejected_serial_and_batch_bundle,
+							"inventory_dimension_bundle": d.get("rejected_inventory_dimension_bundle"),
 						},
 					)
 				)

--- a/erpnext/controllers/selling_controller.py
+++ b/erpnext/controllers/selling_controller.py
@@ -366,6 +366,7 @@ class SellingController(StockController):
 									"uom": p.uom,
 									"serial_and_batch_bundle": p.serial_and_batch_bundle
 									or get_serial_and_batch_bundle(p, self, d),
+									"inventory_dimension_bundle": p.get("inventory_dimension_bundle"),
 									"name": d.name,
 									"target_warehouse": p.target_warehouse,
 									"company": self.company,
@@ -391,6 +392,7 @@ class SellingController(StockController):
 							"stock_uom": d.stock_uom,
 							"conversion_factor": d.conversion_factor,
 							"serial_and_batch_bundle": d.serial_and_batch_bundle,
+							"inventory_dimension_bundle": d.get("inventory_dimension_bundle"),
 							"name": d.name,
 							"target_warehouse": d.target_warehouse,
 							"company": self.company,

--- a/erpnext/controllers/stock_controller.py
+++ b/erpnext/controllers/stock_controller.py
@@ -250,6 +250,22 @@ class StockController(AccountsController):
 
 		return SerialBatchBundleService(self).set_serial_and_batch_bundle(table_name, ignore_validate)
 
+	def set_inventory_dimension_bundle(self, table_name=None, ignore_validate=False):
+		from erpnext.stock.services.inventory_dimension_bundle_service import (
+			InventoryDimensionBundleService,
+		)
+
+		return InventoryDimensionBundleService(self).set_inventory_dimension_bundle(
+			table_name, ignore_validate
+		)
+
+	def validate_inventory_dimension_bundle(self, table_name=None):
+		from erpnext.stock.services.inventory_dimension_bundle_service import (
+			InventoryDimensionBundleService,
+		)
+
+		return InventoryDimensionBundleService(self).validate_inventory_dimension_bundle(table_name)
+
 	def make_package_for_transfer(
 		self, serial_and_batch_bundle, warehouse, type_of_transaction=None, do_not_submit=None, qty=0
 	):

--- a/erpnext/controllers/tests/test_subcontracting_controller.py
+++ b/erpnext/controllers/tests/test_subcontracting_controller.py
@@ -1271,12 +1271,25 @@ def make_stock_in_entry(**args):
 	for row in args.rm_items:
 		row = frappe._dict(row)
 
-		doc = make_stock_entry(
-			target=row.warehouse or "_Test Warehouse - _TC",
-			item_code=row.item_code,
-			qty=row.qty or 1,
-			basic_rate=row.rate or 100,
-		)
+		# A row may carry an Inventory Dimension Bundle (mandatory dimensions require one on the
+		# resulting SLE); stamp it before submit, mirroring the serial/batch bundle handling above.
+		if row.inventory_dimension_bundle:
+			doc = make_stock_entry(
+				target=row.warehouse or "_Test Warehouse - _TC",
+				item_code=row.item_code,
+				qty=row.qty or 1,
+				basic_rate=row.rate or 100,
+				do_not_save=True,
+			)
+			doc.items[0].inventory_dimension_bundle = row.inventory_dimension_bundle
+			doc.submit()
+		else:
+			doc = make_stock_entry(
+				target=row.warehouse or "_Test Warehouse - _TC",
+				item_code=row.item_code,
+				qty=row.qty or 1,
+				basic_rate=row.rate or 100,
+			)
 
 		if row.item_code not in items:
 			items.setdefault(

--- a/erpnext/maintenance/doctype/maintenance_schedule_item/maintenance_schedule_item.json
+++ b/erpnext/maintenance/doctype/maintenance_schedule_item/maintenance_schedule_item.json
@@ -22,7 +22,10 @@
   "serial_no",
   "sales_order",
   "column_break_ugqr",
-  "serial_and_batch_bundle"
+  "serial_and_batch_bundle",
+  "inventory_dimension_section",
+  "add_inventory_dimension",
+  "inventory_dimension_bundle"
  ],
  "fields": [
   {
@@ -159,12 +162,33 @@
    "no_copy": 1,
    "options": "Serial and Batch Bundle",
    "print_hide": 1
+  },
+  {
+   "fieldname": "inventory_dimension_bundle",
+   "fieldtype": "Link",
+   "label": "Inventory Dimension Bundle",
+   "no_copy": 1,
+   "options": "Inventory Dimension Bundle",
+   "print_hide": 1,
+   "search_index": 1
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "inventory_dimension_section",
+   "fieldtype": "Section Break",
+   "label": "Inventory Dimension"
+  },
+  {
+   "depends_on": "eval:parent.docstatus == 0",
+   "fieldname": "add_inventory_dimension",
+   "fieldtype": "Button",
+   "label": "Add Inventory Dimension"
   }
  ],
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-03-27 13:10:03.992727",
+ "modified": "2026-06-21 10:00:00.000000",
  "modified_by": "Administrator",
  "module": "Maintenance",
  "name": "Maintenance Schedule Item",

--- a/erpnext/manufacturing/doctype/job_card/job_card.json
+++ b/erpnext/manufacturing/doctype/job_card/job_card.json
@@ -101,6 +101,9 @@
   "column_break_swqr",
   "barcode",
   "batch_no",
+  "inventory_dimension_section",
+  "add_inventory_dimension",
+  "inventory_dimension_bundle",
   "connections_tab"
  ],
  "fields": [
@@ -453,6 +456,27 @@
    "read_only": 1
   },
   {
+   "fieldname": "inventory_dimension_bundle",
+   "fieldtype": "Link",
+   "label": "Inventory Dimension Bundle",
+   "no_copy": 1,
+   "options": "Inventory Dimension Bundle",
+   "print_hide": 1,
+   "search_index": 1
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "inventory_dimension_section",
+   "fieldtype": "Section Break",
+   "label": "Inventory Dimension"
+  },
+  {
+   "depends_on": "eval:parent.docstatus == 0",
+   "fieldname": "add_inventory_dimension",
+   "fieldtype": "Button",
+   "label": "Add Inventory Dimension"
+  },
+  {
    "depends_on": "process_loss_qty",
    "fieldname": "process_loss_qty",
    "fieldtype": "Float",
@@ -695,7 +719,7 @@
  "grid_page_length": 50,
  "is_submittable": 1,
  "links": [],
- "modified": "2026-06-19 17:39:42.293242",
+ "modified": "2026-06-21 11:00:00.000000",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "Job Card",

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -492,3 +492,5 @@ erpnext.patches.v16_0.rename_subscription_billing_period_fields
 erpnext.patches.v16_0.drop_redundant_serial_no_index_from_sabb
 erpnext.patches.v16_0.set_default_close_opportunity_after_days
 execute:frappe.db.set_single_value("Accounts Settings", "pcv_job_timeout", 3600)
+erpnext.patches.v16_0.migrate_inventory_dimensions_to_bundles
+erpnext.patches.v16_0.drop_legacy_inventory_dimension_fields

--- a/erpnext/patches/v16_0/drop_legacy_inventory_dimension_fields.py
+++ b/erpnext/patches/v16_0/drop_legacy_inventory_dimension_fields.py
@@ -1,0 +1,103 @@
+import frappe
+
+from erpnext.stock.doctype.inventory_dimension.inventory_dimension import get_inventory_dimensions
+
+ENTRY_DOCTYPE = "Inventory Dimension Entry"
+LAYOUT_FIELDS = ("inventory_dimension", "inventory_dimension_col_break")
+
+
+def execute():
+	"""Remove the legacy per-dimension custom fields once data is on the sub-ledger.
+
+	The old design scattered a Link field (+ ``to_`` / ``from_`` / ``rejected_`` variants and a
+	section/column break) across every stock doctype + Stock Ledger Entry per dimension. After
+	``migrate_inventory_dimensions_to_bundles`` reconstructs the quantity sub-ledger, those fields
+	are redundant. We only delete the **Custom Field** definitions, identified by their original
+	structure, so we never touch a standard field (e.g. the core ``project`` field), a legitimate
+	user custom field of the same name, or the new ``Inventory Dimension Entry`` column. The
+	physical columns are left as harmless orphans (the data also lives in the sub-ledger).
+	"""
+	legacy = [
+		d for d in get_inventory_dimensions() if frappe.db.has_column("Stock Ledger Entry", d.fieldname)
+	]
+	if not legacy:
+		return
+
+	all_confirmed = True
+	for dimension in legacy:
+		if not backfill_confirmed(dimension):
+			all_confirmed = False
+			continue
+
+		for name in get_legacy_custom_fields(dimension):
+			frappe.delete_doc("Custom Field", name, ignore_permissions=True)
+
+	# The shared section / column break were created once per doctype and reused by every
+	# dimension, so only remove them after every dimension has been migrated.
+	if all_confirmed:
+		for name in get_layout_custom_fields():
+			frappe.delete_doc("Custom Field", name, ignore_permissions=True)
+
+
+def backfill_confirmed(dimension) -> bool:
+	"""True when no live SLE carries this dimension's value without a bundle (backfill complete)."""
+	column = dimension.fieldname
+	if not frappe.db.has_column("Stock Ledger Entry", column):
+		return True
+
+	sle = frappe.qb.DocType("Stock Ledger Entry")
+	unlinked = (
+		frappe.qb.from_(sle)
+		.select(sle.name)
+		.where(sle.is_cancelled == 0)
+		.where(sle[column].isnotnull() & (sle[column] != ""))
+		.where(sle.inventory_dimension_bundle.isnull() | (sle.inventory_dimension_bundle == ""))
+		.limit(1)
+		.run()
+	)
+	return not unlinked
+
+
+def get_legacy_custom_fields(dimension) -> list[str]:
+	"""Custom Field names created by the old dimension flow for this dimension (structurally matched)."""
+	source = dimension.source_fieldname
+	reference = dimension.doctype  # get_inventory_dimensions aliases reference_document -> doctype
+	names = []
+
+	# Main Link field on the transaction doctypes + SLE / Stock Closing Balance. The new sub-ledger
+	# column is excluded because it sits after `warehouse`, not after the `inventory_dimension` break.
+	for row in frappe.get_all(
+		"Custom Field",
+		filters={"fieldname": source, "options": reference, "insert_after": "inventory_dimension"},
+		fields=["name", "dt"],
+	):
+		if row.dt != ENTRY_DOCTYPE:
+			names.append(row.name)
+
+	# Inward/outward transfer variants.
+	names += frappe.get_all(
+		"Custom Field",
+		filters={
+			"fieldname": ("in", [f"to_{source}", f"from_{source}"]),
+			"options": reference,
+			"insert_after": "inventory_dimension_col_break",
+		},
+		pluck="name",
+	)
+
+	# Rejected-warehouse variant.
+	names += frappe.get_all(
+		"Custom Field",
+		filters={"fieldname": f"rejected_{source}", "options": reference, "insert_after": source},
+		pluck="name",
+	)
+
+	return names
+
+
+def get_layout_custom_fields() -> list[str]:
+	return frappe.get_all(
+		"Custom Field",
+		filters={"fieldname": ("in", LAYOUT_FIELDS), "fieldtype": ("in", ["Section Break", "Column Break"])},
+		pluck="name",
+	)

--- a/erpnext/patches/v16_0/migrate_inventory_dimensions_to_bundles.py
+++ b/erpnext/patches/v16_0/migrate_inventory_dimensions_to_bundles.py
@@ -1,0 +1,158 @@
+import frappe
+from frappe.query_builder import Criterion
+from frappe.utils import flt
+
+from erpnext.stock.doctype.inventory_dimension.inventory_dimension import get_inventory_dimensions
+
+# Voucher type -> its stock items child doctype (for linking the migrated bundle back to the row).
+ITEM_TABLE = {
+	"Stock Entry": "Stock Entry Detail",
+	"Purchase Receipt": "Purchase Receipt Item",
+	"Purchase Invoice": "Purchase Invoice Item",
+	"Delivery Note": "Delivery Note Item",
+	"Sales Invoice": "Sales Invoice Item",
+	"POS Invoice": "POS Invoice Item",
+	"Stock Reconciliation": "Stock Reconciliation Item",
+	"Subcontracting Receipt": "Subcontracting Receipt Item",
+}
+
+
+def execute():
+	"""Move legacy inventory-dimension data onto the new quantity sub-ledger.
+
+	Old dimensions stored their value as a column on every stock doctype + Stock Ledger Entry.
+	The redesign keeps a single Link column per dimension on Inventory Dimension Entry and a
+	single `inventory_dimension_bundle` link on the transaction rows + SLE. This patch:
+	  1. adds the per-dimension column to Inventory Dimension Entry for each legacy dimension, and
+	  2. reconstructs the sub-ledger from historical SLEs (one Inventory Dimension Bundle per
+	     voucher row), stamping the bundle back onto the SLEs and the transaction rows.
+	"""
+	# Existing sites that already use Inventory Dimensions should keep the feature on after the
+	# redesign (it is gated behind a Stock Settings switch that defaults to off for new sites).
+	enable_inventory_dimension_feature()
+
+	# SLE column == target fieldname; Entry column == source fieldname.
+	legacy = [
+		d for d in get_inventory_dimensions() if frappe.db.has_column("Stock Ledger Entry", d.fieldname)
+	]
+	if not legacy:
+		return
+
+	add_entry_columns(legacy)
+	backfill_sub_ledger(legacy)
+
+
+def enable_inventory_dimension_feature():
+	"""Turn on the Stock Settings switch if any Inventory Dimension is already defined."""
+	if not frappe.db.count("Inventory Dimension"):
+		return
+
+	if not frappe.db.get_single_value("Stock Settings", "enable_inventory_dimension"):
+		frappe.db.set_single_value("Stock Settings", "enable_inventory_dimension", 1)
+
+
+def add_entry_columns(legacy):
+	created = False
+	for dimension in legacy:
+		if frappe.db.has_column("Inventory Dimension Entry", dimension.source_fieldname):
+			continue
+		frappe.get_doc("Inventory Dimension", dimension.dimension_name).add_dimension_field()
+		created = True
+
+	if created:
+		frappe.clear_cache(doctype="Inventory Dimension Entry")
+
+
+def backfill_sub_ledger(legacy):
+	sle_cols = sorted({d.fieldname for d in legacy})
+	source_by_sle_col = {d.fieldname: d.source_fieldname for d in legacy}
+
+	sle = frappe.qb.DocType("Stock Ledger Entry")
+	query = (
+		frappe.qb.from_(sle)
+		.select(
+			sle.name,
+			sle.item_code,
+			sle.warehouse,
+			sle.company,
+			sle.voucher_type,
+			sle.voucher_no,
+			sle.voucher_detail_no,
+			sle.actual_qty,
+			sle.posting_datetime,
+			*[sle[col] for col in sle_cols],
+		)
+		.where(sle.is_cancelled == 0)
+		.where(sle.inventory_dimension_bundle.isnull() | (sle.inventory_dimension_bundle == ""))
+		# at least one legacy dimension column is set on the SLE
+		.where(Criterion.any([sle[col].isnotnull() & (sle[col] != "") for col in sle_cols]))
+		.orderby(sle.voucher_type)
+		.orderby(sle.voucher_no)
+		.orderby(sle.voucher_detail_no)
+		.orderby(sle.posting_datetime)
+	)
+	rows = query.run(as_dict=True)
+	if not rows:
+		return
+
+	groups = {}
+	for sle in rows:
+		groups.setdefault((sle.voucher_type, sle.voucher_no, sle.voucher_detail_no), []).append(sle)
+
+	# Rebuild bundles in chronological order so an inward receipt is always migrated before the
+	# outward issue that draws it down (the SQL sort is by voucher_type/no, which is not chronological).
+	ordered_groups = sorted(groups.items(), key=lambda group: group[1][0].posting_datetime)
+
+	for (voucher_type, voucher_no, voucher_detail_no), entries in ordered_groups:
+		first = entries[0]
+		net_qty = sum(flt(e.actual_qty) for e in entries)
+
+		bundle = frappe.new_doc("Inventory Dimension Bundle")
+		bundle.company = first.company
+		bundle.item_code = first.item_code
+		bundle.warehouse = first.warehouse
+		bundle.voucher_type = voucher_type
+		bundle.voucher_no = voucher_no
+		bundle.voucher_detail_no = voucher_detail_no
+		bundle.posting_datetime = first.posting_datetime
+		bundle.type_of_transaction = "Outward" if net_qty < 0 else "Inward"
+
+		for sle in entries:
+			row = {
+				# qty is stored signed (negative for outward), matching the SLE's actual_qty.
+				"qty": flt(sle.actual_qty),
+				"is_outward": 1 if flt(sle.actual_qty) < 0 else 0,
+				"warehouse": sle.warehouse,
+				"posting_datetime": sle.posting_datetime,
+			}
+			for col in sle_cols:
+				if sle.get(col):
+					row[source_by_sle_col[col]] = sle.get(col)
+			bundle.append("entries", row)
+
+		bundle.flags.ignore_permissions = True
+		bundle.insert()
+		bundle.submit()
+
+		for sle in entries:
+			frappe.db.set_value(
+				"Stock Ledger Entry",
+				sle.name,
+				"inventory_dimension_bundle",
+				bundle.name,
+				update_modified=False,
+			)
+
+		link_transaction_row(voucher_type, voucher_detail_no, bundle.name)
+
+
+def link_transaction_row(voucher_type, voucher_detail_no, bundle):
+	child_doctype = ITEM_TABLE.get(voucher_type)
+	if not child_doctype or not voucher_detail_no:
+		return
+	if not frappe.db.has_column(child_doctype, "inventory_dimension_bundle"):
+		return
+	if frappe.db.exists(child_doctype, voucher_detail_no):
+		frappe.db.set_value(
+			child_doctype, voucher_detail_no, "inventory_dimension_bundle", bundle, update_modified=False
+		)

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -8,7 +8,7 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 		this.barcode_scanner = new erpnext.utils.BarcodeScanner({ frm: this.frm });
 
 		this.set_fields_onload_for_line_item();
-		this.frm.ignore_doctypes_on_cancel_all = ["Serial and Batch Bundle"];
+		this.frm.ignore_doctypes_on_cancel_all = ["Serial and Batch Bundle", "Inventory Dimension Bundle"];
 
 		frappe.flags.hide_serial_batch_dialog = true;
 		frappe.ui.form.on(this.frm.doctype + " Item", "rate", function (frm, cdt, cdn) {

--- a/erpnext/public/js/erpnext.bundle.js
+++ b/erpnext/public/js/erpnext.bundle.js
@@ -6,6 +6,7 @@ import "./sms_manager";
 import "./utils/party";
 import "./controllers/stock_controller";
 import "./utils/serial_no_batch_selector";
+import "./utils/inventory_dimension_selector";
 import "./payment/payments";
 import "./templates/visual_plant_floor_template.html";
 import "./plant_floor_visual/visual_plant";

--- a/erpnext/public/js/utils/inventory_dimension_selector.js
+++ b/erpnext/public/js/utils/inventory_dimension_selector.js
@@ -1,0 +1,276 @@
+// Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
+// For license information, please see license.txt
+
+/**
+ * Inventory Dimension capture dialog (mirrors the Serial / Batch selector).
+ *
+ * Lets a stock row split its quantity across inventory-dimension combinations and stores the
+ * result in an Inventory Dimension Bundle, linked back to the row via `inventory_dimension_bundle`
+ * (or `rejected_inventory_dimension_bundle` for the rejected qty on purchase documents).
+ *
+ * Each applicable dimension renders one Link column (to its reference document); a `qty` column
+ * captures the split, reconciled against the row quantity.
+ */
+erpnext.show_inventory_dimension_selector = function (frm, item_row, opts = {}) {
+	const child_doctype = item_row.doctype;
+
+	frappe.call({
+		method: "erpnext.stock.doctype.inventory_dimension_bundle.inventory_dimension_bundle.get_dimensions_for_selector",
+		args: { child_doctype: child_doctype },
+		callback: function (r) {
+			const dimensions = r.message || [];
+			if (!dimensions.length) {
+				frappe.msgprint(__("No inventory dimensions apply to {0}.", [child_doctype]));
+				return;
+			}
+			new erpnext.InventoryDimensionSelector(frm, item_row, dimensions, opts);
+		},
+		error: function () {
+			frappe.msgprint(__("Could not load inventory dimensions for {0}.", [child_doctype]));
+		},
+	});
+};
+
+erpnext.InventoryDimensionSelector = class InventoryDimensionSelector {
+	constructor(frm, item_row, dimensions, opts = {}) {
+		this.frm = frm;
+		this.item_row = item_row;
+		this.dimensions = dimensions;
+		// `opts` lets the rejected-qty button reuse the same dialog: a different qty field,
+		// warehouse field and target bundle link on the row.
+		this.qty_field = opts.qty_field || "qty";
+		this.warehouse_field = opts.warehouse_field || "warehouse";
+		this.bundle_field = opts.bundle_field || "inventory_dimension_bundle";
+		this.is_rejected = !!opts.is_rejected;
+		this.make_dialog();
+	}
+
+	get_warehouse() {
+		return (
+			this.item_row[this.warehouse_field] ||
+			this.item_row.warehouse ||
+			this.item_row.t_warehouse ||
+			this.item_row.s_warehouse
+		);
+	}
+
+	build_entry_fields() {
+		const fields = this.dimensions.map((dim) => ({
+			fieldname: dim.fieldname,
+			label: dim.dimension,
+			fieldtype: "Link",
+			options: dim.reference_document,
+			in_list_view: 1,
+			reqd: dim.reqd ? 1 : 0,
+		}));
+
+		fields.push({
+			fieldname: "qty",
+			label: __("Qty"),
+			fieldtype: "Float",
+			in_list_view: 1,
+			reqd: 1,
+		});
+
+		return fields;
+	}
+
+	make_dialog() {
+		const me = this;
+		const title = this.is_rejected
+			? __("Inventory Dimensions for {0} (Rejected Qty)", [this.item_row.item_code])
+			: __("Inventory Dimensions for {0}", [this.item_row.item_code]);
+
+		this.dialog = new frappe.ui.Dialog({
+			title: title,
+			size: "large",
+			fields: [
+				{
+					fieldname: "entries",
+					fieldtype: "Table",
+					label: __("Dimensions"),
+					cannot_add_rows: false,
+					in_place_edit: true,
+					data: [],
+					fields: this.build_entry_fields(),
+				},
+			],
+			primary_action_label: __("Save"),
+			primary_action: () => me.create_bundle(),
+		});
+
+		this.dialog.show();
+		this.load_existing_entries();
+	}
+
+	load_existing_entries() {
+		const me = this;
+		const bundle = this.item_row[this.bundle_field];
+		if (!bundle) return;
+
+		frappe.call({
+			method: "erpnext.stock.doctype.inventory_dimension_bundle.inventory_dimension_bundle.get_inventory_dimension_bundle_entries",
+			args: { bundle: bundle },
+			callback: function (r) {
+				if (r.message && r.message.length) {
+					me.dialog.fields_dict.entries.df.data = r.message;
+					me.dialog.fields_dict.entries.grid.refresh();
+				}
+			},
+		});
+	}
+
+	create_bundle() {
+		const me = this;
+		const entries = this.dialog.get_value("entries") || [];
+
+		// The captured dimension qty is authoritative: push the total back onto the row's qty field
+		// (e.g. a PR item qty of 5 becomes 10 if the user split 10 across dimensions).
+		const total = entries.reduce((sum, row) => sum + flt(row.qty), 0);
+
+		frappe.call({
+			method: "erpnext.stock.doctype.inventory_dimension_bundle.inventory_dimension_bundle.create_inventory_dimension_bundle",
+			args: {
+				company: this.frm.doc.company,
+				item_code: this.item_row.item_code,
+				warehouse: this.get_warehouse(),
+				type_of_transaction: null,
+				voucher_type: this.frm.doc.doctype,
+				bundle: this.item_row[this.bundle_field],
+				entries: entries,
+			},
+			callback: function (r) {
+				if (r.message) {
+					frappe.model.set_value(me.item_row.doctype, me.item_row.name, me.bundle_field, r.message);
+					frappe.model
+						.set_value(me.item_row.doctype, me.item_row.name, me.qty_field, total)
+						.then(() => {
+							me.dialog.hide();
+							// Persist the link on the transaction so it survives a page refresh
+							// without the user manually saving.
+							me.frm.save();
+						});
+				}
+			},
+			error: function () {
+				frappe.msgprint(
+					__("Could not save the inventory dimensions. Please review the entries and try again.")
+				);
+			},
+		});
+	}
+};
+
+// Wire the grid "Inventory Dimension" button (and the rejected-qty variant on purchase docs) for
+// every child doctype that carries the bundle field. Mirrors the Serial / Batch grid button.
+erpnext.inventory_dimension_child_doctypes = [
+	"Purchase Receipt Item",
+	"Purchase Invoice Item",
+	"Sales Invoice Item",
+	"POS Invoice Item",
+	"Delivery Note Item",
+	"Stock Entry Detail",
+	"Stock Reconciliation Item",
+	"Subcontracting Receipt Item",
+	"Subcontracting Receipt Supplied Item",
+	"Packed Item",
+	"Pick List Item",
+	"Maintenance Schedule Item",
+	"Installation Note Item",
+	"Asset Capitalization Stock Item",
+	"Asset Repair Consumed Item",
+];
+
+erpnext.inventory_dimension_rejected_doctypes = [
+	"Purchase Receipt Item",
+	"Purchase Invoice Item",
+	"Subcontracting Receipt Item",
+];
+
+erpnext.inventory_dimension_child_doctypes.forEach((child_doctype) => {
+	frappe.ui.form.on(child_doctype, {
+		add_inventory_dimension(frm, cdt, cdn) {
+			erpnext.show_inventory_dimension_selector(frm, locals[cdt][cdn]);
+		},
+	});
+});
+
+erpnext.inventory_dimension_rejected_doctypes.forEach((child_doctype) => {
+	frappe.ui.form.on(child_doctype, {
+		add_inventory_dimension_for_rejected_qty(frm, cdt, cdn) {
+			erpnext.show_inventory_dimension_selector(frm, locals[cdt][cdn], {
+				is_rejected: true,
+				qty_field: "rejected_qty",
+				warehouse_field: "rejected_warehouse",
+				bundle_field: "rejected_inventory_dimension_bundle",
+			});
+		},
+	});
+});
+
+// Inventory Dimensions are gated behind a Stock Settings switch. When disabled, hide every
+// dimension field/button on the child grids so the feature is invisible across all doctypes.
+erpnext.inventory_dimension_grid_fields = [
+	"inventory_dimension_section",
+	"column_break_inv_dim",
+	"add_inventory_dimension",
+	"inventory_dimension_bundle",
+	"add_inventory_dimension_for_rejected_qty",
+	"rejected_inventory_dimension_bundle",
+];
+
+erpnext.is_inventory_dimension_enabled = function () {
+	// Cache the lookup so we don't refetch on every form refresh. A whitelisted method is used
+	// (instead of frappe.db.get_single_value) so users without read access to Stock Settings can
+	// still resolve the flag.
+	if (!erpnext._inventory_dimension_enabled) {
+		erpnext._inventory_dimension_enabled = frappe
+			.xcall(
+				"erpnext.stock.doctype.inventory_dimension.inventory_dimension.inventory_dimension_enabled"
+			)
+			.then((enabled) => !!enabled);
+	}
+	return erpnext._inventory_dimension_enabled;
+};
+
+erpnext.toggle_inventory_dimension_fields = function (frm) {
+	erpnext.is_inventory_dimension_enabled().then((enabled) => {
+		const hidden = enabled ? 0 : 1;
+		Object.values(frm.fields_dict || {}).forEach((field) => {
+			const grid = field.grid;
+			if (!grid || !erpnext.inventory_dimension_child_doctypes.includes(grid.doctype)) return;
+
+			erpnext.inventory_dimension_grid_fields.forEach((fieldname) => {
+				if (grid.fields_map && grid.fields_map[fieldname]) {
+					grid.update_docfield_property(fieldname, "hidden", hidden);
+				}
+			});
+		});
+		frm.refresh_fields();
+	});
+};
+
+// Parent doctypes that carry one of the inventory-dimension child tables.
+erpnext.inventory_dimension_parent_doctypes = [
+	"Purchase Receipt",
+	"Purchase Invoice",
+	"Sales Invoice",
+	"POS Invoice",
+	"Delivery Note",
+	"Stock Entry",
+	"Stock Reconciliation",
+	"Subcontracting Receipt",
+	"Pick List",
+	"Maintenance Schedule",
+	"Installation Note",
+	"Asset Capitalization",
+	"Asset Repair",
+];
+
+erpnext.inventory_dimension_parent_doctypes.forEach((doctype) => {
+	frappe.ui.form.on(doctype, {
+		refresh(frm) {
+			erpnext.toggle_inventory_dimension_fields(frm);
+		},
+	});
+});

--- a/erpnext/selling/doctype/installation_note_item/installation_note_item.json
+++ b/erpnext/selling/doctype/installation_note_item/installation_note_item.json
@@ -13,7 +13,10 @@
   "description",
   "prevdoc_detail_docname",
   "prevdoc_docname",
-  "prevdoc_doctype"
+  "prevdoc_doctype",
+  "inventory_dimension_section",
+  "add_inventory_dimension",
+  "inventory_dimension_bundle"
  ],
  "fields": [
   {
@@ -107,12 +110,33 @@
    "no_copy": 1,
    "options": "Serial and Batch Bundle",
    "print_hide": 1
+  },
+  {
+   "fieldname": "inventory_dimension_bundle",
+   "fieldtype": "Link",
+   "label": "Inventory Dimension Bundle",
+   "no_copy": 1,
+   "options": "Inventory Dimension Bundle",
+   "print_hide": 1,
+   "search_index": 1
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "inventory_dimension_section",
+   "fieldtype": "Section Break",
+   "label": "Inventory Dimension"
+  },
+  {
+   "depends_on": "eval:parent.docstatus == 0",
+   "fieldname": "add_inventory_dimension",
+   "fieldtype": "Button",
+   "label": "Add Inventory Dimension"
   }
  ],
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-03-27 13:09:51.390239",
+ "modified": "2026-06-21 10:00:00.000000",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Installation Note Item",

--- a/erpnext/stock/doctype/delivery_note/delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.py
@@ -517,6 +517,7 @@ class DeliveryNote(SellingController):
 			"Stock Ledger Entry",
 			"Repost Item Valuation",
 			"Serial and Batch Bundle",
+			"Inventory Dimension Bundle",
 		)
 
 		self.delete_auto_created_batches()

--- a/erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
+++ b/erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
@@ -95,6 +95,9 @@
   "actual_batch_qty",
   "column_break_atna",
   "company_total_stock",
+  "inventory_dimension_section",
+  "add_inventory_dimension",
+  "inventory_dimension_bundle",
   "section_break_kejd",
   "installed_qty",
   "packed_qty",
@@ -888,6 +891,27 @@
    "search_index": 1
   },
   {
+   "fieldname": "inventory_dimension_bundle",
+   "fieldtype": "Link",
+   "label": "Inventory Dimension Bundle",
+   "no_copy": 1,
+   "options": "Inventory Dimension Bundle",
+   "print_hide": 1,
+   "search_index": 1
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "inventory_dimension_section",
+   "fieldtype": "Section Break",
+   "label": "Inventory Dimension"
+  },
+  {
+   "depends_on": "eval:parent.docstatus == 0",
+   "fieldname": "add_inventory_dimension",
+   "fieldtype": "Button",
+   "label": "Add Inventory Dimension"
+  },
+  {
    "depends_on": "eval:doc.use_serial_batch_fields === 0 || doc.docstatus === 1",
    "fieldname": "pick_serial_and_batch",
    "fieldtype": "Button",
@@ -971,7 +995,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-06-08 20:00:00.000000",
+ "modified": "2026-06-21 10:00:00.000000",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Delivery Note Item",

--- a/erpnext/stock/doctype/inventory_dimension/inventory_dimension.json
+++ b/erpnext/stock/doctype/inventory_dimension/inventory_dimension.json
@@ -18,6 +18,7 @@
   "apply_to_all_doctypes",
   "column_break_niy2u",
   "validate_negative_stock",
+  "negative_stock_validation_method",
   "column_break_13",
   "document_type",
   "type_of_transaction",
@@ -27,7 +28,6 @@
   "condition",
   "conditional_mandatory_section",
   "reqd",
-  "mandatory_depends_on",
   "conditional_rule_examples_section",
   "html_19"
  ],
@@ -152,19 +152,12 @@
    "label": "Conditional Rule Examples"
   },
   {
-   "depends_on": "eval:!doc.apply_to_all_doctypes",
-   "description": "To apply condition on parent field use parent.field_name and to apply condition on child table use doc.field_name. Here field_name could be based on the actual column name of the respective field.",
-   "fieldname": "mandatory_depends_on",
-   "fieldtype": "Small Text",
-   "label": "Mandatory Depends On"
-  },
-  {
    "fieldname": "conditional_mandatory_section",
    "fieldtype": "Section Break",
    "label": "Mandatory Section"
   },
   {
-   "default": "0",
+   "default": "1",
    "fieldname": "reqd",
    "fieldtype": "Check",
    "label": "Mandatory"
@@ -174,15 +167,24 @@
    "fieldtype": "Column Break"
   },
   {
-   "default": "0",
+   "default": "1",
    "fieldname": "validate_negative_stock",
    "fieldtype": "Check",
    "label": "Validate Negative Stock"
+  },
+  {
+   "default": "Per Dimension",
+   "depends_on": "validate_negative_stock",
+   "description": "Per Dimension validates each inventory dimension's available balance independently. Combined validates the exact combination of all negative-stock dimensions present on a line together.",
+   "fieldname": "negative_stock_validation_method",
+   "fieldtype": "Select",
+   "label": "Negative Stock Validation Method",
+   "options": "Per Dimension\nCombined"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-04-08 10:10:16.884388",
+ "modified": "2026-06-23 11:55:47.694616",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Inventory Dimension",

--- a/erpnext/stock/doctype/inventory_dimension/inventory_dimension.py
+++ b/erpnext/stock/doctype/inventory_dimension/inventory_dimension.py
@@ -22,6 +22,29 @@ class CanNotBeDefaultDimension(frappe.ValidationError):
 	pass
 
 
+class InventoryDimensionNotEnabled(frappe.ValidationError):
+	pass
+
+
+def is_inventory_dimension_enabled() -> bool:
+	"""Inventory Dimensions are gated behind a Stock Settings switch (Inventory Dimension tab).
+
+	Tests set ``frappe.flags.enable_inventory_dimension`` so the feature can be toggled per-test
+	without writing to (and leaking through) the committed Stock Settings single.
+	"""
+	if frappe.flags.get("enable_inventory_dimension") is not None:
+		return bool(frappe.flags.enable_inventory_dimension)
+
+	return bool(frappe.db.get_single_value("Stock Settings", "enable_inventory_dimension"))
+
+
+@frappe.whitelist()
+def inventory_dimension_enabled() -> bool:
+	"""Whitelisted accessor for the client so the grids can toggle the dimension fields without
+	requiring the user to have read permission on Stock Settings."""
+	return is_inventory_dimension_enabled()
+
+
 class InventoryDimension(Document):
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
@@ -37,7 +60,7 @@ class InventoryDimension(Document):
 		document_type: DF.Link | None
 		fetch_from_parent: DF.Literal[None]
 		istable: DF.Check
-		mandatory_depends_on: DF.SmallText | None
+		negative_stock_validation_method: DF.Literal["Per Dimension", "Combined"]
 		reference_document: DF.Link
 		reqd: DF.Check
 		source_fieldname: DF.Data | None
@@ -46,20 +69,36 @@ class InventoryDimension(Document):
 		validate_negative_stock: DF.Check
 	# end: auto-generated types
 
+	ENTRY_DOCTYPE = "Inventory Dimension Entry"
+
 	def onload(self):
-		if not self.is_new() and frappe.db.has_column("Stock Ledger Entry", self.target_fieldname):
+		if not self.is_new() and frappe.db.has_column(self.ENTRY_DOCTYPE, self.source_fieldname):
 			self.set_onload("has_stock_ledger", self.has_stock_ledger())
 
 	def has_stock_ledger(self) -> str:
-		if not self.target_fieldname:
+		if not self.source_fieldname or not frappe.db.has_column(self.ENTRY_DOCTYPE, self.source_fieldname):
 			return
 
+		# Dimension values now live on the quantity sub-ledger (Inventory Dimension Entry),
+		# not on Stock Ledger Entry.
 		return frappe.get_all(
-			"Stock Ledger Entry", filters={self.target_fieldname: ("is", "set"), "is_cancelled": 0}, limit=1
+			self.ENTRY_DOCTYPE,
+			filters={self.source_fieldname: ("is", "set"), "is_cancelled": 0},
+			limit=1,
 		)
 
 	def validate(self):
+		self.validate_inventory_dimension_enabled()
 		self.validate_reference_document()
+
+	def validate_inventory_dimension_enabled(self):
+		if not is_inventory_dimension_enabled():
+			frappe.throw(
+				_("Please enable {0} in {1} before creating an Inventory Dimension.").format(
+					bold(_("Enable Inventory Dimension")), bold(_("Stock Settings"))
+				),
+				InventoryDimensionNotEnabled,
+			)
 
 	def before_save(self):
 		self.do_not_update_document()
@@ -81,6 +120,7 @@ class InventoryDimension(Document):
 			"type_of_transaction",
 			"condition",
 			"validate_negative_stock",
+			"negative_stock_validation_method",
 		]
 
 		for field in frappe.get_meta("Inventory Dimension").fields:
@@ -93,34 +133,22 @@ class InventoryDimension(Document):
 				frappe.throw(_(msg), DoNotChangeError)
 
 	def on_trash(self):
-		self.delete_custom_fields()
+		self.delete_dimension_field()
 
-	def delete_custom_fields(self):
-		filters = {
-			"fieldname": (
-				"in",
-				[
-					self.source_fieldname,
-					f"to_{self.source_fieldname}",
-					f"from_{self.source_fieldname}",
-					f"rejected_{self.source_fieldname}",
-				],
+	def delete_dimension_field(self):
+		"""Remove the single dimension column from Inventory Dimension Entry."""
+		name = frappe.db.get_value(
+			"Custom Field", {"dt": self.ENTRY_DOCTYPE, "fieldname": self.source_fieldname}
+		)
+		if name:
+			frappe.delete_doc("Custom Field", name)
+			frappe.msgprint(
+				_("Deleted the inventory dimension field {0}").format(bold(self.source_fieldname))
 			)
-		}
-
-		if self.document_type:
-			filters["dt"] = self.document_type
-
-		for field in frappe.get_all("Custom Field", filters=filters):
-			frappe.delete_doc("Custom Field", field.name)
-
-		msg = f"Deleted custom fields related to the dimension {self.name}"
-		frappe.msgprint(_(msg))
 
 	def reset_value(self):
 		if self.apply_to_all_doctypes:
 			self.type_of_transaction = ""
-			self.mandatory_depends_on = ""
 
 			self.istable = 0
 			for field in ["document_type", "condition"]:
@@ -143,177 +171,37 @@ class InventoryDimension(Document):
 			self.target_fieldname = scrub(self.dimension_name)
 
 	def on_update(self):
-		self.add_custom_fields()
+		self.add_dimension_field()
 
-	@staticmethod
-	def get_insert_after_fieldname(doctype):
-		return frappe.get_all(
-			"DocField",
-			fields=["fieldname"],
-			filters={"parent": doctype},
-			order_by="idx desc",
-			limit=1,
-		)[0].fieldname
+	def add_dimension_field(self):
+		"""Add a single Link column for this dimension to Inventory Dimension Entry.
 
-	def get_dimension_fields(self, doctype=None):
-		if not doctype:
-			doctype = self.document_type
-
-		label_start_with = ""
-		if doctype in ["Purchase Invoice Item", "Purchase Receipt Item"]:
-			label_start_with = "Target"
-		elif doctype in ["Sales Invoice Item", "Delivery Note Item", "Stock Entry Detail"]:
-			label_start_with = "Source"
-
-		label = self.dimension_name
-		if label_start_with:
-			label = f"{label_start_with} {self.dimension_name}"
-
-		mandatory_depends_on = self.mandatory_depends_on
-		if self.reqd:
-			if doctype == "Stock Entry Detail":
-				mandatory_depends_on = "eval:doc.s_warehouse"
-			elif doctype == "Subcontracting Receipt Supplied Item":
-				mandatory_depends_on = "eval:doc.reference_name"
-			elif doctype == "Packed Item":
-				mandatory_depends_on = "eval:doc.parent_detail_docname && ['Delivery Note', 'Sales Invoice', 'POS Invoice'].includes(parent.doctype)"
-
-		dimension_fields = [
-			dict(
-				fieldname="inventory_dimension",
-				fieldtype="Section Break",
-				insert_after=self.get_insert_after_fieldname(doctype),
-				label=_("Inventory Dimension"),
-				collapsible=1,
-			),
-			dict(
-				fieldname=self.source_fieldname,
-				fieldtype="Link",
-				insert_after="inventory_dimension",
-				options=self.reference_document,
-				label=_(label),
-				depends_on="eval:doc.s_warehouse" if doctype == "Stock Entry Detail" else "",
-				search_index=1,
-				reqd=1
-				if self.reqd
-				and not self.mandatory_depends_on
-				and doctype
-				not in ["Stock Entry Detail", "Subcontracting Receipt Supplied Item", "Packed Item"]
-				else 0,
-				mandatory_depends_on=mandatory_depends_on,
-			),
-		]
-
-		if doctype in ["Purchase Invoice Item", "Purchase Receipt Item"]:
-			dimension_fields.append(
-				dict(
-					fieldname="rejected_" + self.source_fieldname,
-					fieldtype="Link",
-					insert_after=self.source_fieldname,
-					options=self.reference_document,
-					label=_("Rejected " + self.dimension_name),
-					search_index=1,
-					mandatory_depends_on="eval:doc.rejected_qty > 0",
-				)
-			)
-
-		return dimension_fields
-
-	def add_custom_fields(self):
-		custom_fields = {}
-
-		dimension_fields = []
-		if self.apply_to_all_doctypes:
-			for doctype in get_inventory_documents():
-				dimension_fields = self.get_dimension_fields(doctype[0])
-				self.add_transfer_field(doctype[0], dimension_fields)
-				custom_fields.setdefault(doctype[0], dimension_fields)
-		else:
-			dimension_fields = self.get_dimension_fields()
-
-			self.add_transfer_field(self.document_type, dimension_fields)
-			custom_fields.setdefault(self.document_type, dimension_fields)
-
-		for dt in ["Stock Ledger Entry", "Stock Closing Balance"]:
-			if (
-				dimension_fields
-				and not frappe.db.get_value("Custom Field", {"dt": dt, "fieldname": self.target_fieldname})
-				and not field_exists(dt, self.target_fieldname)
-			):
-				dimension_field = dimension_fields[1]
-				dimension_field["mandatory_depends_on"] = ""
-				dimension_field["reqd"] = 0
-				dimension_field["fieldname"] = self.target_fieldname
-				custom_fields[dt] = dimension_field
-
-		filter_custom_fields = {}
-		ignore_doctypes = [
-			"Serial and Batch Bundle",
-			"Serial and Batch Entry",
-			"Pick List Item",
-			"Maintenance Visit Purpose",
-		]
-
-		if custom_fields:
-			for doctype, fields in custom_fields.items():
-				if doctype in ignore_doctypes:
-					continue
-
-				if isinstance(fields, dict):
-					fields = [fields]
-
-				for field in fields:
-					if not field_exists(doctype, field["fieldname"]):
-						filter_custom_fields.setdefault(doctype, []).append(field)
-
-		create_custom_fields(filter_custom_fields)
-
-	def add_transfer_field(self, doctype, dimension_fields):
-		if doctype not in [
-			"Stock Entry Detail",
-			"Sales Invoice Item",
-			"Delivery Note Item",
-			"Purchase Invoice Item",
-			"Purchase Receipt Item",
-		]:
+		This replaces the previous behaviour of injecting custom fields into every stock
+		transaction doctype (+ SLE + Stock Closing Balance). A new dimension now alters exactly
+		one table - the quantity sub-ledger - instead of ~25, so large databases no longer take a
+		storm of ``ALTER TABLE`` statements. Mandatory capture is enforced by the controller
+		(``InventoryDimensionBundleService.validate_inventory_dimension_bundle``), gated on
+		``is_stock_item``, rather than at field level.
+		"""
+		if frappe.db.get_value(
+			"Custom Field", {"dt": self.ENTRY_DOCTYPE, "fieldname": self.source_fieldname}
+		) or field_exists(self.ENTRY_DOCTYPE, self.source_fieldname):
 			return
 
-		fieldname_start_with = "to"
-		label_start_with = "Target"
-		display_depends_on = ""
-
-		if doctype in ["Purchase Invoice Item", "Purchase Receipt Item"]:
-			fieldname_start_with = "from"
-			label_start_with = "Source"
-			display_depends_on = "eval:parent.is_internal_supplier == 1"
-		elif doctype != "Stock Entry Detail":
-			display_depends_on = "eval:parent.is_internal_customer == 1"
-		elif doctype == "Stock Entry Detail":
-			display_depends_on = "eval:doc.t_warehouse"
-
-		fieldname = f"{fieldname_start_with}_{self.source_fieldname}"
-		label = f"{label_start_with} {self.dimension_name}"
-
-		if field_exists(doctype, fieldname):
-			return
-
-		dimension_fields.extend(
-			[
-				dict(
-					fieldname="inventory_dimension_col_break",
-					fieldtype="Column Break",
-					insert_after=self.source_fieldname,
-				),
-				dict(
-					fieldname=fieldname,
-					fieldtype="Link",
-					insert_after="inventory_dimension_col_break",
-					options=self.reference_document,
-					label=label,
-					depends_on=display_depends_on,
-					mandatory_depends_on=display_depends_on if self.reqd else self.mandatory_depends_on,
-				),
-			]
+		create_custom_fields(
+			{
+				self.ENTRY_DOCTYPE: [
+					dict(
+						fieldname=self.source_fieldname,
+						fieldtype="Link",
+						insert_after="warehouse",
+						options=self.reference_document,
+						label=_(self.dimension_name),
+						search_index=1,
+						in_list_view=1,
+					)
+				]
+			}
 		)
 
 
@@ -388,13 +276,33 @@ def get_document_wise_inventory_dimensions(doctype) -> dict:
 		fields=[
 			"name",
 			"source_fieldname",
+			"reference_document",
 			"condition",
 			"target_fieldname",
 			"type_of_transaction",
 			"fetch_from_parent",
+			"reqd",
 		],
 		or_filters={"document_type": doctype, "apply_to_all_doctypes": 1},
 	)
+
+
+def get_voucher_child_doctype(voucher_type: str) -> str | None:
+	"""The stock item child doctype for a voucher (e.g. Stock Entry -> Stock Entry Detail)."""
+	if not voucher_type:
+		return None
+
+	meta = frappe.get_meta(voucher_type)
+	field = meta.get_field("items")
+	return field.options if field else None
+
+
+def get_mandatory_inventory_dimensions(child_doctype: str) -> list:
+	"""Mandatory (``reqd``) inventory dimensions applicable to a child doctype."""
+	if not child_doctype:
+		return []
+
+	return [d for d in (get_document_wise_inventory_dimensions(child_doctype) or []) if d.get("reqd")]
 
 
 @frappe.whitelist()
@@ -407,6 +315,7 @@ def get_inventory_dimensions():
 			"source_fieldname",
 			"reference_document as doctype",
 			"validate_negative_stock",
+			"negative_stock_validation_method",
 			"name as dimension_name",
 		],
 		order_by="creation",  # pg-ok: dropped under distinct on PG — config-list iteration order only, not data

--- a/erpnext/stock/doctype/inventory_dimension/test_inventory_dimension.py
+++ b/erpnext/stock/doctype/inventory_dimension/test_inventory_dimension.py
@@ -2,27 +2,55 @@
 # See license.txt
 
 import frappe
-from frappe.custom.doctype.custom_field.custom_field import create_custom_field
-from frappe.utils import nowdate, nowtime
 
-from erpnext.stock.doctype.delivery_note.test_delivery_note import create_delivery_note
 from erpnext.stock.doctype.inventory_dimension.inventory_dimension import (
 	CanNotBeChildDoc,
 	CanNotBeDefaultDimension,
-	DoNotChangeError,
+	InventoryDimensionNotEnabled,
 	delete_dimension,
+)
+from erpnext.stock.doctype.inventory_dimension_bundle.inventory_dimension_bundle import (
+	InventoryDimensionNegativeStockError,
+	get_dimension_sub_ledger_balance,
 )
 from erpnext.stock.doctype.item.test_item import create_item
 from erpnext.stock.doctype.purchase_receipt.test_purchase_receipt import make_purchase_receipt
 from erpnext.stock.doctype.stock_entry.stock_entry_utils import make_stock_entry
-from erpnext.stock.doctype.stock_ledger_entry.stock_ledger_entry import InventoryDimensionNegativeStockError
 from erpnext.stock.doctype.warehouse.test_warehouse import create_warehouse
+from erpnext.stock.services.inventory_dimension_bundle_service import InventoryDimensionBundleService
 from erpnext.tests.utils import ERPNextTestSuite
+
+ENTRY_DOCTYPE = "Inventory Dimension Entry"
 
 
 class TestInventoryDimension(ERPNextTestSuite):
+	def setUp(self):
+		# Enable the feature via a flag (not the committed Stock Settings single) so it can never
+		# leak into unrelated test modules. Dimension Custom Fields are committed (DDL), so dimension
+		# records and their reqd / validate_negative_stock flags survive the per-test rollback; reset
+		# them so a sibling test's flag cannot make this one fail.
+		frappe.flags.enable_inventory_dimension = 1
+		reset_inventory_dimension_flags()
+
+	def tearDown(self):
+		frappe.flags.enable_inventory_dimension = None
+		super().tearDown()
+		clear_dimension_cache()
+
+	def test_inventory_dimension_requires_stock_setting(self):
+		# With the feature off, creating a dimension must be blocked.
+		frappe.flags.enable_inventory_dimension = 0
+
+		inv_dim = create_inventory_dimension(
+			reference_document="Shelf",
+			dimension_name="From Shelf",
+			apply_to_all_doctypes=1,
+			do_not_save=True,
+		)
+		self.assertRaises(InventoryDimensionNotEnabled, inv_dim.insert)
+
 	def test_validate_inventory_dimension(self):
-		# Can not be child doc
+		# The reference document can not be a child table.
 		inv_dim1 = create_inventory_dimension(
 			reference_document="Stock Entry Detail",
 			type_of_transaction="Outward",
@@ -32,9 +60,9 @@ class TestInventoryDimension(ERPNextTestSuite):
 			document_type="Stock Entry",
 			do_not_save=True,
 		)
-
 		self.assertRaises(CanNotBeChildDoc, inv_dim1.insert)
 
+		# The reference document can not be one of the built-in dimensions.
 		inv_dim1 = create_inventory_dimension(
 			reference_document="Batch",
 			type_of_transaction="Outward",
@@ -43,513 +71,766 @@ class TestInventoryDimension(ERPNextTestSuite):
 			document_type="Stock Entry Detail",
 			do_not_save=True,
 		)
-
 		self.assertRaises(CanNotBeDefaultDimension, inv_dim1.insert)
 
-	def test_delete_inventory_dimension(self):
-		inv_dim1 = create_inventory_dimension(
+	def test_dimension_creates_and_drops_subledger_column(self):
+		"""A dimension adds a single column to the quantity sub-ledger - not to every stock doctype."""
+		inv_dim = create_inventory_dimension(
 			reference_document="Shelf",
-			type_of_transaction="Outward",
 			dimension_name="From Shelf",
-			apply_to_all_doctypes=0,
-			document_type="Stock Entry Detail",
-			condition="parent.purpose == 'Material Issue'",
-		)
-
-		inv_dim1.save()
-
-		custom_field = frappe.db.get_value(
-			"Custom Field", {"fieldname": "from_shelf", "dt": "Stock Entry Detail"}, "name"
-		)
-
-		self.assertTrue(custom_field)
-
-		delete_dimension(inv_dim1.name)
-
-		custom_field = frappe.db.get_value(
-			"Custom Field", {"fieldname": "from_shelf", "dt": "Stock Entry Detail"}, "name"
-		)
-
-		self.assertFalse(custom_field)
-
-	def test_inventory_dimension(self):
-		create_warehouse("Shelf Warehouse")
-		warehouse = "Shelf Warehouse - _TC"
-		item_code = "_Test Item"
-
-		inv_dim1 = create_inventory_dimension(
-			reference_document="Shelf",
-			type_of_transaction="Outward",
-			dimension_name="Shelf",
-			apply_to_all_doctypes=0,
-			document_type="Stock Entry Detail",
-			condition="parent.purpose == 'Material Issue'",
-		)
-
-		inv_dim1.reqd = 0
-		inv_dim1.save()
-
-		create_inventory_dimension(
-			reference_document="Shelf",
-			type_of_transaction="Inward",
-			dimension_name="To Shelf",
-			apply_to_all_doctypes=0,
-			document_type="Stock Entry Detail",
-			condition="parent.purpose == 'Material Receipt'",
-		)
-
-		inward = make_stock_entry(
-			item_code=item_code,
-			target=warehouse,
-			qty=5,
-			basic_rate=10,
-			do_not_save=True,
-			purpose="Material Receipt",
-		)
-
-		inward.items[0].to_shelf = "Shelf 1"
-		inward.save()
-		inward.submit()
-		inward.load_from_db()
-
-		sle_data = frappe.db.get_value(
-			"Stock Ledger Entry", {"voucher_no": inward.name}, ["to_shelf", "warehouse"], as_dict=1
-		)
-
-		self.assertEqual(inward.items[0].to_shelf, "Shelf 1")
-		self.assertEqual(sle_data.warehouse, warehouse)
-		self.assertEqual(sle_data.to_shelf, "Shelf 1")
-
-		outward = make_stock_entry(
-			item_code=item_code,
-			source=warehouse,
-			qty=3,
-			basic_rate=10,
-			do_not_save=True,
-			purpose="Material Issue",
-		)
-
-		outward.items[0].shelf = "Shelf 1"
-		outward.save()
-		outward.submit()
-		outward.load_from_db()
-
-		sle_shelf = frappe.db.get_value("Stock Ledger Entry", {"voucher_no": outward.name}, "shelf")
-		self.assertEqual(sle_shelf, "Shelf 1")
-
-		inv_dim1.load_from_db()
-		inv_dim1.apply_to_all_doctypes = 1
-
-		self.assertTrue(inv_dim1.has_stock_ledger())
-		self.assertRaises(DoNotChangeError, inv_dim1.save)
-
-	def test_inventory_dimension_for_purchase_receipt_and_delivery_note(self):
-		inv_dimension = create_inventory_dimension(
-			reference_document="Rack", dimension_name="Rack", apply_to_all_doctypes=1
-		)
-
-		inv_dimension.db_set("fetch_from_parent", "Rack")
-
-		self.assertEqual(inv_dimension.type_of_transaction, "Both")
-		self.assertEqual(inv_dimension.fetch_from_parent, "Rack")
-
-		create_custom_field(
-			"Purchase Receipt", dict(fieldname="rack", label="Rack", fieldtype="Link", options="Rack")
-		)
-
-		create_custom_field(
-			"Delivery Note", dict(fieldname="rack", label="Rack", fieldtype="Link", options="Rack")
-		)
-
-		pr_doc = make_purchase_receipt(qty=2, do_not_submit=True)
-		pr_doc.rack = "Rack 1"
-		pr_doc.save()
-		pr_doc.submit()
-
-		pr_doc.load_from_db()
-
-		self.assertEqual(pr_doc.items[0].rack, "Rack 1")
-		sle_rack = frappe.db.get_value(
-			"Stock Ledger Entry",
-			{"voucher_detail_no": pr_doc.items[0].name, "voucher_type": pr_doc.doctype},
-			"rack",
-		)
-
-		self.assertEqual(sle_rack, "Rack 1")
-
-		dn_doc = create_delivery_note(qty=2, do_not_submit=True)
-		dn_doc.rack = "Rack 1"
-		dn_doc.save()
-		dn_doc.submit()
-
-		dn_doc.load_from_db()
-
-		self.assertEqual(dn_doc.items[0].rack, "Rack 1")
-		sle_rack = frappe.db.get_value(
-			"Stock Ledger Entry",
-			{"voucher_detail_no": dn_doc.items[0].name, "voucher_type": dn_doc.doctype},
-			"rack",
-		)
-
-		self.assertEqual(sle_rack, "Rack 1")
-
-	def test_check_standard_dimensions(self):
-		create_inventory_dimension(
-			reference_document="Project",
-			type_of_transaction="Outward",
-			dimension_name="Project",
-			apply_to_all_doctypes=0,
-			document_type="Stock Ledger Entry",
-		)
-
-		self.assertFalse(
-			frappe.db.get_value("Custom Field", {"fieldname": "project", "dt": "Stock Ledger Entry"}, "name")
-		)
-
-	def test_check_mandatory_dimensions(self):
-		doc = create_inventory_dimension(
-			reference_document="Pallet",
-			type_of_transaction="Outward",
-			dimension_name="Pallet 75",
-			apply_to_all_doctypes=0,
-			document_type="Delivery Note Item",
-		)
-
-		doc.reqd = 1
-		doc.save()
-
-		self.assertTrue(
-			frappe.db.get_value(
-				"Custom Field", {"fieldname": "pallet_75", "dt": "Delivery Note Item", "reqd": 1}, "name"
-			)
-		)
-
-		doc.reqd = 0
-		doc.save()
-
-	def test_check_mandatory_depends_on_dimensions(self):
-		doc = create_inventory_dimension(
-			reference_document="Pallet",
-			type_of_transaction="Outward",
-			dimension_name="Pallet",
-			apply_to_all_doctypes=0,
-			document_type="Stock Entry Detail",
-		)
-
-		doc.mandatory_depends_on = "t_warehouse"
-		doc.save()
-
-		self.assertTrue(
-			frappe.db.get_value(
-				"Custom Field",
-				{"fieldname": "pallet", "dt": "Stock Entry Detail", "mandatory_depends_on": "t_warehouse"},
-				"name",
-			)
-		)
-
-	def test_for_purchase_sales_and_stock_transaction(self):
-		from erpnext.controllers.sales_and_purchase_return import make_return_doc
-
-		create_inventory_dimension(
-			reference_document="Store",
-			type_of_transaction="Outward",
-			dimension_name="Store",
 			apply_to_all_doctypes=1,
 		)
 
-		item_code = "Test Inventory Dimension Item"
+		# One Link column is added to Inventory Dimension Entry.
+		self.assertTrue(frappe.db.get_value("Custom Field", {"dt": ENTRY_DOCTYPE, "fieldname": "from_shelf"}))
+
+		# No per-doctype custom field is created on the stock transaction doctypes anymore.
+		self.assertFalse(
+			frappe.db.get_value("Custom Field", {"dt": "Stock Entry Detail", "fieldname": "from_shelf"})
+		)
+
+		delete_dimension(inv_dim.name)
+		self.assertFalse(
+			frappe.db.get_value("Custom Field", {"dt": ENTRY_DOCTYPE, "fieldname": "from_shelf"})
+		)
+
+	def test_inventory_dimension_subledger_posting(self):
+		"""Submitting a voucher posts its bundle to the sub-ledger; cancelling reverses it."""
+		create_inventory_dimension(
+			reference_document="Shelf", dimension_name="Shelf", apply_to_all_doctypes=1
+		)
+
+		warehouse = create_warehouse("Shelf Warehouse")
+		item_code = "_Test Item"
+
+		se = make_stock_entry(item_code=item_code, target=warehouse, qty=5, basic_rate=10, do_not_save=True)
+		bundle = make_inventory_dimension_bundle(item_code, warehouse, [{"qty": 5, "shelf": "Shelf 1"}])
+		se.items[0].inventory_dimension_bundle = bundle
+		se.submit()
+
+		# The Stock Ledger Entry links the single bundle.
+		self.assertEqual(
+			frappe.db.get_value(
+				"Stock Ledger Entry",
+				{"voucher_no": se.name, "is_cancelled": 0},
+				"inventory_dimension_bundle",
+			),
+			bundle,
+		)
+
+		# The dimension value lives on the sub-ledger entry, not on the SLE.
+		entry = frappe.get_all(
+			ENTRY_DOCTYPE, filters={"parent": bundle}, fields=["shelf", "qty", "is_outward"]
+		)[0]
+		self.assertEqual(entry.shelf, "Shelf 1")
+		self.assertEqual(entry.is_outward, 0)
+
+		self.assertEqual(
+			get_dimension_sub_ledger_balance(item_code, warehouse, {"shelf": "Shelf 1"}, inclusive=True),
+			5,
+		)
+
+		# Cancelling the voucher cancels the bundle and removes the qty from the sub-ledger.
+		se.cancel()
+		self.assertEqual(
+			get_dimension_sub_ledger_balance(item_code, warehouse, {"shelf": "Shelf 1"}, inclusive=True),
+			0,
+		)
+
+	def test_outward_bundle_stores_signed_qty(self):
+		"""An outward bundle stores qty negative + is_outward set (mirrors SLE actual_qty)."""
+		create_inventory_dimension(reference_document="Rack", dimension_name="Rack", apply_to_all_doctypes=1)
+
+		item_code = "Test Signed Qty Item"
 		create_item(item_code)
-		warehouse = create_warehouse("Store Warehouse")
-		rj_warehouse = create_warehouse("RJ Warehouse")
+		warehouse = create_warehouse("Signed Qty Warehouse")
 
-		if not frappe.db.exists("Store", "Rejected Store"):
-			frappe.get_doc({"doctype": "Store", "store_name": "Rejected Store"}).insert(
-				ignore_permissions=True
+		# Receive 50 first so the outward issue has stock to draw from.
+		se_in = make_stock_entry(
+			item_code=item_code, target=warehouse, qty=50, basic_rate=10, do_not_save=True
+		)
+		se_in.items[0].inventory_dimension_bundle = make_inventory_dimension_bundle(
+			item_code, warehouse, [{"qty": 50, "rack": "Rack 1"}]
+		)
+		se_in.submit()
+
+		# Issue 10: the bundle is stamped Outward on submit, so its entry qty is signed negative.
+		se_out = make_stock_entry(item_code=item_code, source=warehouse, qty=10, do_not_save=True)
+		bundle = make_inventory_dimension_bundle(item_code, warehouse, [{"qty": 10, "rack": "Rack 1"}])
+		se_out.items[0].inventory_dimension_bundle = bundle
+		se_out.submit()
+
+		doc = frappe.get_doc("Inventory Dimension Bundle", bundle)
+		self.assertEqual(doc.type_of_transaction, "Outward")
+		self.assertEqual(doc.entries[0].is_outward, 1)
+		self.assertEqual(doc.entries[0].qty, -10)
+		self.assertEqual(doc.total_qty, -10)
+
+		# The signed sub-ledger nets to 40 (50 in - 10 out).
+		self.assertEqual(
+			get_dimension_sub_ledger_balance(item_code, warehouse, {"rack": "Rack 1"}, inclusive=True), 40
+		)
+
+	def test_material_transfer_posts_both_legs(self):
+		"""A Stock Entry transfer posts the dimension out of the source and into the target warehouse."""
+		create_inventory_dimension(reference_document="Rack", dimension_name="Rack", apply_to_all_doctypes=1)
+
+		item_code = "Test Transfer Item"
+		create_item(item_code)
+		wh_a = create_warehouse("Transfer Source Warehouse")
+		wh_b = create_warehouse("Transfer Target Warehouse")
+
+		# Receive 10 into the source warehouse / Rack 1.
+		se_in = make_stock_entry(item_code=item_code, target=wh_a, qty=10, basic_rate=100, do_not_save=True)
+		se_in.items[0].inventory_dimension_bundle = make_inventory_dimension_bundle(
+			item_code, wh_a, [{"qty": 10, "rack": "Rack 1"}]
+		)
+		se_in.submit()
+
+		# Transfer 4 from source to target: the outward leg draws Rack 1 down at the source and the
+		# inward leg posts it into the target (the bug was the inward leg being lost).
+		se_t = make_stock_entry(item_code=item_code, source=wh_a, target=wh_b, qty=4, do_not_save=True)
+		se_t.items[0].inventory_dimension_bundle = make_inventory_dimension_bundle(
+			item_code, wh_a, [{"qty": 4, "rack": "Rack 1"}]
+		)
+		se_t.submit()
+
+		self.assertEqual(
+			get_dimension_sub_ledger_balance(item_code, wh_a, {"rack": "Rack 1"}, inclusive=True), 6
+		)
+		self.assertEqual(
+			get_dimension_sub_ledger_balance(item_code, wh_b, {"rack": "Rack 1"}, inclusive=True), 4
+		)
+
+		# Cancelling the transfer reverses both legs (including the target's inward bundle).
+		se_t.reload()
+		se_t.cancel()
+		self.assertEqual(
+			get_dimension_sub_ledger_balance(item_code, wh_a, {"rack": "Rack 1"}, inclusive=True), 10
+		)
+		self.assertEqual(
+			get_dimension_sub_ledger_balance(item_code, wh_b, {"rack": "Rack 1"}, inclusive=True), 0
+		)
+
+	def test_delivery_note_dimension_bundle_posts_to_sle(self):
+		"""A dimension bundle assigned to a Delivery Note row must reach the Stock Ledger Entry.
+
+		Regression: the selling controller rebuilt each row via get_item_list() and dropped
+		inventory_dimension_bundle, so the SLE was posted without it and the mandatory-dimension
+		check spuriously failed.
+		"""
+		create_inventory_dimension(reference_document="Rack", dimension_name="Rack", apply_to_all_doctypes=1)
+
+		item_code = "Test DN Dimension Item"
+		create_item(item_code, is_stock_item=1)
+		warehouse = create_warehouse("DN Dimension Warehouse")
+		company = frappe.db.get_value("Warehouse", warehouse, "company")
+
+		# Stock the item so there is something to deliver.
+		se = make_stock_entry(item_code=item_code, target=warehouse, qty=10, basic_rate=100, do_not_save=True)
+		se.items[0].inventory_dimension_bundle = make_inventory_dimension_bundle(
+			item_code, warehouse, [{"qty": 10, "rack": "Rack 1"}]
+		)
+		se.submit()
+
+		dn = frappe.new_doc("Delivery Note")
+		dn.company = company
+		dn.customer = "_Test Customer"
+		dn.append(
+			"items",
+			{"item_code": item_code, "warehouse": warehouse, "qty": 4, "rate": 150},
+		)
+		dn.insert()
+		dn.items[0].inventory_dimension_bundle = make_inventory_dimension_bundle(
+			item_code, warehouse, [{"qty": 4, "rack": "Rack 1"}]
+		)
+		dn.save()
+		dn.submit()
+
+		# The Stock Ledger Entry carries the bundle (no mandatory-dimension error was raised).
+		sle_bundle = frappe.db.get_value(
+			"Stock Ledger Entry", {"voucher_no": dn.name, "is_cancelled": 0}, "inventory_dimension_bundle"
+		)
+		self.assertTrue(sle_bundle)
+
+		# The outward delivery draws Rack 1 down from 10 to 6.
+		self.assertEqual(
+			get_dimension_sub_ledger_balance(item_code, warehouse, {"rack": "Rack 1"}, inclusive=True), 6
+		)
+
+	def test_product_bundle_packed_item_dimension_bundle_is_submitted(self):
+		"""A dimension bundle on a Product Bundle's packed item must be submitted with the voucher."""
+		from erpnext.selling.doctype.product_bundle.test_product_bundle import make_product_bundle
+
+		create_inventory_dimension(reference_document="Rack", dimension_name="Rack", apply_to_all_doctypes=1)
+
+		parent_item = "Test PB Parent Item"
+		child_item = "Test PB Child Item"
+		create_item(parent_item, is_stock_item=0)
+		create_item(child_item, is_stock_item=1)
+		make_product_bundle(parent_item, [child_item])
+
+		warehouse = create_warehouse("PB Dimension Warehouse")
+		company = frappe.db.get_value("Warehouse", warehouse, "company")
+
+		# Stock the child item into Rack 1.
+		se = make_stock_entry(
+			item_code=child_item, target=warehouse, qty=10, basic_rate=100, do_not_save=True
+		)
+		se.items[0].inventory_dimension_bundle = make_inventory_dimension_bundle(
+			child_item, warehouse, [{"qty": 10, "rack": "Rack 1"}]
+		)
+		se.submit()
+
+		dn = frappe.new_doc("Delivery Note")
+		dn.company = company
+		dn.customer = "_Test Customer"
+		dn.append("items", {"item_code": parent_item, "warehouse": warehouse, "qty": 3, "rate": 150})
+		dn.insert()  # packed_items are generated for the product bundle's child
+
+		packed = dn.packed_items[0]
+		bundle = make_inventory_dimension_bundle(
+			child_item, packed.warehouse, [{"qty": packed.qty, "rack": "Rack 1"}]
+		)
+		packed.inventory_dimension_bundle = bundle
+		dn.save()
+		dn.submit()
+
+		# The packed item's bundle is submitted (posted to the sub-ledger), not left a draft.
+		self.assertEqual(frappe.db.get_value("Inventory Dimension Bundle", bundle, "docstatus"), 1)
+
+		# Rack 1 was drawn down by the delivered packed qty (10 received - 3 delivered).
+		self.assertEqual(
+			get_dimension_sub_ledger_balance(child_item, warehouse, {"rack": "Rack 1"}, inclusive=True),
+			10 - packed.qty,
+		)
+
+	def test_manual_bundle_infers_direction_from_voucher(self):
+		"""A bundle created/linked manually for a Delivery Note is stamped Outward on save."""
+		create_inventory_dimension(reference_document="Rack", dimension_name="Rack", apply_to_all_doctypes=1)
+
+		item_code = "Test Manual Direction Item"
+		create_item(item_code)
+		warehouse = create_warehouse("Manual Direction Warehouse")
+		company = frappe.db.get_value("Warehouse", warehouse, "company")
+
+		doc = frappe.new_doc("Inventory Dimension Bundle")
+		doc.company = company
+		doc.item_code = item_code
+		doc.warehouse = warehouse
+		doc.voucher_type = "Delivery Note"
+		doc.append("entries", {"qty": 5, "rack": "Rack 1", "warehouse": warehouse})
+		doc.flags.ignore_permissions = True
+		doc.save()
+
+		# Direction inferred from the voucher type while still a draft (no voucher submit yet).
+		self.assertEqual(doc.type_of_transaction, "Outward")
+		self.assertEqual(doc.entries[0].is_outward, 1)
+		self.assertEqual(doc.entries[0].qty, -5)
+
+	def test_bundle_cannot_be_submitted_manually(self):
+		"""The bundle is submitted only by its voucher; a manual submit must be blocked."""
+		create_inventory_dimension(reference_document="Rack", dimension_name="Rack", apply_to_all_doctypes=1)
+
+		item_code = "Test Manual Submit Item"
+		create_item(item_code)
+		warehouse = create_warehouse("Manual Submit Warehouse")
+		bundle = make_inventory_dimension_bundle(item_code, warehouse, [{"qty": 5, "rack": "Rack 1"}])
+
+		doc = frappe.get_doc("Inventory Dimension Bundle", bundle)
+		self.assertRaises(frappe.ValidationError, doc.submit)
+
+	def test_bundle_cannot_be_cancelled_manually(self):
+		"""The bundle is cancelled only by its voucher; a manual cancel must be blocked."""
+		create_inventory_dimension(reference_document="Rack", dimension_name="Rack", apply_to_all_doctypes=1)
+
+		item_code = "Test Manual Cancel Item"
+		create_item(item_code)
+		warehouse = create_warehouse("Manual Cancel Warehouse")
+
+		# Submit a bundle the only legitimate way - through its voucher.
+		se = make_stock_entry(item_code=item_code, target=warehouse, qty=5, basic_rate=10, do_not_save=True)
+		bundle = make_inventory_dimension_bundle(item_code, warehouse, [{"qty": 5, "rack": "Rack 1"}])
+		se.items[0].inventory_dimension_bundle = bundle
+		se.submit()
+
+		doc = frappe.get_doc("Inventory Dimension Bundle", bundle)
+		self.assertRaises(frappe.ValidationError, doc.cancel)
+
+	def test_cancelling_voucher_unlinks_bundle(self):
+		"""Cancelling a voucher detaches its now-cancelled bundle so the voucher can be amended."""
+		create_inventory_dimension(reference_document="Rack", dimension_name="Rack", apply_to_all_doctypes=1)
+
+		item_code = "Test Unlink Item"
+		create_item(item_code)
+		warehouse = create_warehouse("Unlink Warehouse")
+
+		se = make_stock_entry(item_code=item_code, target=warehouse, qty=10, basic_rate=100, do_not_save=True)
+		bundle = make_inventory_dimension_bundle(item_code, warehouse, [{"qty": 10, "rack": "Rack 1"}])
+		se.items[0].inventory_dimension_bundle = bundle
+		se.submit()
+
+		se.reload()
+		se.cancel()
+
+		# The bundle is cancelled and detached from the voucher row.
+		self.assertEqual(frappe.db.get_value("Inventory Dimension Bundle", bundle, "docstatus"), 2)
+		self.assertFalse(
+			frappe.db.get_value("Stock Entry Detail", se.items[0].name, "inventory_dimension_bundle")
+		)
+
+		# Amending the cancelled voucher saves without a "Cannot link cancelled document" error.
+		amended = frappe.copy_doc(se)
+		amended.amended_from = se.name
+		amended.docstatus = 0
+		amended.save()
+		self.assertFalse(amended.items[0].inventory_dimension_bundle)
+
+	def test_dimension_wise_stock_balance_report(self):
+		"""The Stock Balance report splits an item/warehouse row by dimension from the sub-ledger."""
+		from frappe.utils import add_days, today
+
+		from erpnext.stock.report.stock_balance.stock_balance import execute
+
+		create_inventory_dimension(reference_document="Rack", dimension_name="Rack", apply_to_all_doctypes=1)
+
+		item_code = "Test Dimension Balance Item"
+		create_item(item_code)
+		warehouse = create_warehouse("Dimension Balance Warehouse")
+		company = frappe.db.get_value("Warehouse", warehouse, "company")
+
+		# Receive 30 into Rack 1 and 20 into Rack 2 (same item + warehouse).
+		for rack, qty in [("Rack 1", 30), ("Rack 2", 20)]:
+			se = make_stock_entry(
+				item_code=item_code, target=warehouse, qty=qty, basic_rate=10, do_not_save=True
 			)
+			bundle = make_inventory_dimension_bundle(item_code, warehouse, [{"qty": qty, "rack": rack}])
+			se.items[0].inventory_dimension_bundle = bundle
+			se.submit()
 
-		# Purchase Receipt -> Inward in Store 1
-		pr_doc = make_purchase_receipt(
+		filters = frappe._dict(
+			company=company,
+			from_date=add_days(today(), -1),
+			to_date=today(),
+			item_code=[item_code],
+			warehouse=[warehouse],
+			show_dimension_wise_stock=1,
+		)
+
+		_columns, data = execute(filters)
+		rack_balances = {
+			row.get("rack"): row.get("bal_qty") for row in data if row.get("item_code") == item_code
+		}
+
+		# One row per rack, each carrying only its own balance (no residual since all 50 is captured).
+		self.assertEqual(rack_balances.get("Rack 1"), 30)
+		self.assertEqual(rack_balances.get("Rack 2"), 20)
+		self.assertNotIn(None, rack_balances)
+		self.assertEqual(sum(rack_balances.values()), 50)
+
+	def test_dimension_wise_stock_ledger_report(self):
+		"""Filtering the Stock Ledger report by a dimension shows that dimension's ledger only."""
+		from frappe.utils import add_days, today
+
+		from erpnext.stock.report.stock_ledger.stock_ledger import execute
+
+		create_inventory_dimension(reference_document="Rack", dimension_name="Rack", apply_to_all_doctypes=1)
+
+		item_code = "Test Dimension Ledger Item"
+		create_item(item_code)
+		warehouse = create_warehouse("Dimension Ledger Warehouse")
+		company = frappe.db.get_value("Warehouse", warehouse, "company")
+
+		# Receive 30 into Rack 1 and 20 into Rack 2, then issue 10 from Rack 1.
+		for rack, qty in [("Rack 1", 30), ("Rack 2", 20)]:
+			se = make_stock_entry(
+				item_code=item_code, target=warehouse, qty=qty, basic_rate=10, do_not_save=True
+			)
+			bundle = make_inventory_dimension_bundle(item_code, warehouse, [{"qty": qty, "rack": rack}])
+			se.items[0].inventory_dimension_bundle = bundle
+			se.submit()
+
+		se = make_stock_entry(item_code=item_code, source=warehouse, qty=10, do_not_save=True)
+		bundle = make_inventory_dimension_bundle(item_code, warehouse, [{"qty": 10, "rack": "Rack 1"}])
+		se.items[0].inventory_dimension_bundle = bundle
+		se.submit()
+
+		filters = frappe._dict(
+			company=company,
+			from_date=add_days(today(), -1),
+			to_date=today(),
+			item_code=[item_code],
+			warehouse=[warehouse],
+			rack=["Rack 1"],
+		)
+
+		_columns, data = execute(filters)
+		rows = [row for row in data if row.get("item_code") == item_code]
+
+		# Only Rack 1 movements: a +30 receipt and a -10 issue (Rack 2 is excluded).
+		self.assertEqual(len(rows), 2)
+		self.assertTrue(all(row.get("rack") == "Rack 1" for row in rows))
+		self.assertEqual([row.get("actual_qty") for row in rows], [30, -10])
+		# Running balance for Rack 1 ends at 20.
+		self.assertEqual(rows[-1].get("qty_after_transaction"), 20)
+
+		# Without a dimension filter, each row still shows its bundle's dimension value in the column.
+		unfiltered = frappe._dict(
+			company=company,
+			from_date=add_days(today(), -1),
+			to_date=today(),
+			item_code=[item_code],
+			warehouse=[warehouse],
+		)
+		_columns, data = execute(unfiltered)
+		rack_values = {row.get("rack") for row in data if row.get("voucher_type") == "Stock Entry"}
+		self.assertEqual(rack_values, {"Rack 1", "Rack 2"})
+
+		# With the feature disabled, the report must not fetch any sub-ledger dimension data.
+		frappe.flags.enable_inventory_dimension = 0
+		_columns, data = execute(unfiltered)
+		self.assertTrue(all(not row.get("rack") for row in data))
+
+	def test_dimension_ledger_running_balance_is_per_item_warehouse(self):
+		"""A dimension filter spanning warehouses keeps a separate running balance per warehouse."""
+		from frappe.utils import add_days, today
+
+		from erpnext.stock.report.stock_ledger.stock_ledger import execute
+
+		frappe.flags.enable_inventory_dimension = 1
+		create_inventory_dimension(reference_document="Rack", dimension_name="Rack", apply_to_all_doctypes=1)
+
+		item_code = "Test Dimension Multi WH Item"
+		create_item(item_code)
+		wh_a = create_warehouse("Dimension WH A")
+		wh_b = create_warehouse("Dimension WH B")
+		company = frappe.db.get_value("Warehouse", wh_a, "company")
+
+		# Receive Rack 1: 30 into WH A and 50 into WH B.
+		for warehouse, qty in [(wh_a, 30), (wh_b, 50)]:
+			se = make_stock_entry(
+				item_code=item_code, target=warehouse, qty=qty, basic_rate=10, do_not_save=True
+			)
+			bundle = make_inventory_dimension_bundle(item_code, warehouse, [{"qty": qty, "rack": "Rack 1"}])
+			se.items[0].inventory_dimension_bundle = bundle
+			se.submit()
+
+		# Filter by Rack 1 only (no warehouse restriction): each warehouse keeps its own balance.
+		filters = frappe._dict(
+			company=company,
+			from_date=add_days(today(), -1),
+			to_date=today(),
+			item_code=[item_code],
+			rack=["Rack 1"],
+		)
+		_columns, data = execute(filters)
+		balances = {
+			row.get("warehouse"): row.get("qty_after_transaction")
+			for row in data
+			if row.get("voucher_type") == "Stock Entry"
+		}
+		self.assertEqual(balances.get(wh_a), 30)
+		self.assertEqual(balances.get(wh_b), 50)
+
+	def test_mandatory_dimension_for_stock_item(self):
+		"""A mandatory dimension is enforced for stock rows at submit (gated on is_stock_item)."""
+		item_code = "_Test Item"
+		dimension = create_inventory_dimension(
+			reference_document="Pallet", dimension_name="Pallet", apply_to_all_doctypes=1
+		)
+		dimension.db_set("reqd", 1)
+		clear_dimension_cache()
+
+		if not frappe.db.exists("Pallet", "Pallet 1"):
+			frappe.get_doc({"doctype": "Pallet", "pallet_name": "Pallet 1"}).insert(ignore_permissions=True)
+
+		warehouse = create_warehouse("Pallet Warehouse")
+
+		try:
+			# No bundle attached -> the SLE requires the bundle (req #1).
+			se = make_stock_entry(
+				item_code=item_code, target=warehouse, qty=5, basic_rate=10, do_not_save=True
+			)
+			se.save()
+			self.assertRaises(frappe.ValidationError, se.submit)
+
+			# Bundle attached but missing the mandatory dimension value -> the entry requires it (req #2).
+			se = make_stock_entry(
+				item_code=item_code, target=warehouse, qty=5, basic_rate=10, do_not_save=True
+			)
+			bundle = make_inventory_dimension_bundle(item_code, warehouse, [{"qty": 5}])
+			se.items[0].inventory_dimension_bundle = bundle
+			self.assertRaises(frappe.ValidationError, se.submit)
+
+			# With the dimension captured in a bundle, the voucher submits fine.
+			se = make_stock_entry(
+				item_code=item_code, target=warehouse, qty=5, basic_rate=10, do_not_save=True
+			)
+			bundle = make_inventory_dimension_bundle(item_code, warehouse, [{"qty": 5, "pallet": "Pallet 1"}])
+			se.items[0].inventory_dimension_bundle = bundle
+			se.submit()
+			self.assertEqual(se.docstatus, 1)
+		finally:
+			dimension.db_set("reqd", 0)
+			clear_dimension_cache()
+
+	def test_bundle_cannot_be_shared_across_vouchers(self):
+		"""One Inventory Dimension Bundle may back only a single voucher's stock ledger."""
+		create_inventory_dimension(
+			reference_document="Shelf", dimension_name="Shelf", apply_to_all_doctypes=1
+		)
+		warehouse = create_warehouse("Shelf Share Warehouse")
+		item_code = "_Test Item"
+
+		se = make_stock_entry(item_code=item_code, target=warehouse, qty=5, basic_rate=10, do_not_save=True)
+		bundle = make_inventory_dimension_bundle(item_code, warehouse, [{"qty": 5, "shelf": "Shelf 1"}])
+		se.items[0].inventory_dimension_bundle = bundle
+		se.submit()
+
+		# Re-using the same bundle on a different voucher must be rejected.
+		other = make_stock_entry(
+			item_code=item_code, target=warehouse, qty=5, basic_rate=10, do_not_save=True
+		)
+		other.items[0].inventory_dimension_bundle = bundle
+		self.assertRaises(frappe.ValidationError, other.submit)
+
+	def test_rejected_inventory_dimension_bundle(self):
+		"""The rejected-qty bundle posts to the rejected warehouse's dimension sub-ledger."""
+		item_code = "_Test Item"
+		create_inventory_dimension(
+			reference_document="Shelf", dimension_name="Shelf", apply_to_all_doctypes=1
+		)
+		warehouse = create_warehouse("PR Accepted Warehouse")
+		rejected_warehouse = create_warehouse("PR Rejected Warehouse")
+
+		pr = make_purchase_receipt(
 			item_code=item_code,
 			warehouse=warehouse,
 			qty=10,
-			rejected_qty=5,
+			rejected_qty=4,
 			rate=100,
-			rejected_warehouse=rj_warehouse,
+			rejected_warehouse=rejected_warehouse,
 			do_not_submit=True,
 		)
+		pr.items[0].inventory_dimension_bundle = make_inventory_dimension_bundle(
+			item_code, warehouse, [{"qty": 10, "shelf": "Shelf 1"}]
+		)
+		pr.items[0].rejected_inventory_dimension_bundle = make_inventory_dimension_bundle(
+			item_code, rejected_warehouse, [{"qty": 4, "shelf": "Shelf 2"}]
+		)
+		pr.submit()
 
-		pr_doc.items[0].store = "Store 1"
-		pr_doc.items[0].rejected_store = "Rejected Store"
-		pr_doc.save()
-		pr_doc.submit()
-
-		entries = frappe.get_all(
-			"Stock Ledger Entry",
-			filters={"voucher_no": pr_doc.name, "warehouse": warehouse},
-			fields=["store"],
-			order_by="creation",
+		self.assertEqual(
+			get_dimension_sub_ledger_balance(item_code, warehouse, {"shelf": "Shelf 1"}, inclusive=True),
+			10,
+		)
+		self.assertEqual(
+			get_dimension_sub_ledger_balance(
+				item_code, rejected_warehouse, {"shelf": "Shelf 2"}, inclusive=True
+			),
+			4,
 		)
 
-		self.assertEqual(entries[0].store, "Store 1")
+	def test_service_item_skips_dimension(self):
+		"""Non-stock (service) rows never require a dimension - they are skipped entirely."""
+		service_item = "Test Service Dimension Item"
+		if not frappe.db.exists("Item", service_item):
+			create_item(service_item)
+		frappe.db.set_value("Item", service_item, "is_stock_item", 0)
 
-		entries = frappe.get_all(
-			"Stock Ledger Entry",
-			filters={"voucher_no": pr_doc.name, "warehouse": rj_warehouse},
-			fields=["store"],
-			order_by="creation",
-		)
+		service = InventoryDimensionBundleService(frappe.new_doc("Delivery Note"))
 
-		self.assertEqual(entries[0].store, "Rejected Store")
+		# Service / non-stock row -> skipped (no dimension demanded).
+		self.assertFalse(service.row_has_dimension_qty(frappe._dict(item_code=service_item, qty=5)))
 
-		# Stock Entry -> Transfer from Store 1 to Store 2
-		se_doc = make_stock_entry(
-			item_code=item_code, qty=10, from_warehouse=warehouse, to_warehouse=warehouse, do_not_save=True
-		)
+		# A stock row with qty -> participates.
+		self.assertTrue(service.row_has_dimension_qty(frappe._dict(item_code="_Test Item", qty=5)))
 
-		se_doc.items[0].store = "Store 1"
-		se_doc.items[0].to_store = "Store 2"
-
-		se_doc.save()
-		se_doc.submit()
-
-		entries = get_voucher_sl_entries(se_doc.name, ["warehouse", "store", "incoming_rate", "actual_qty"])
-
-		for entry in entries:
-			self.assertEqual(entry.warehouse, warehouse)
-			if entry.actual_qty > 0:
-				self.assertEqual(entry.store, "Store 2")
-				self.assertEqual(entry.incoming_rate, 100.0)
-			else:
-				self.assertEqual(entry.store, "Store 1")
-
-		# Delivery Note -> Outward from Store 2
-
-		dn_doc = create_delivery_note(item_code=item_code, qty=10, warehouse=warehouse, do_not_save=True)
-
-		dn_doc.items[0].store = "Store 2"
-		dn_doc.save()
-		dn_doc.submit()
-
-		entries = get_voucher_sl_entries(dn_doc.name, ["warehouse", "store", "actual_qty"])
-
-		self.assertEqual(entries[0].warehouse, warehouse)
-		self.assertEqual(entries[0].store, "Store 2")
-		self.assertEqual(entries[0].actual_qty, -10.0)
-
-		return_dn = make_return_doc("Delivery Note", dn_doc.name)
-		return_dn.submit()
-		entries = get_voucher_sl_entries(return_dn.name, ["warehouse", "store", "actual_qty"])
-
-		self.assertEqual(entries[0].warehouse, warehouse)
-		self.assertEqual(entries[0].store, "Store 2")
-		self.assertEqual(entries[0].actual_qty, 10.0)
-
-		se_doc = make_stock_entry(
-			item_code=item_code, qty=10, from_warehouse=warehouse, to_warehouse=warehouse, do_not_save=True
-		)
-
-		se_doc.items[0].store = "Store 2"
-		se_doc.items[0].to_store = "Store 1"
-
-		se_doc.save()
-		se_doc.submit()
-
-		return_pr = make_return_doc("Purchase Receipt", pr_doc.name)
-		return_pr.submit()
-		entries = get_voucher_sl_entries(return_pr.name, ["warehouse", "store", "actual_qty"])
-
-		self.assertEqual(entries[0].warehouse, warehouse)
-		self.assertEqual(entries[0].store, "Store 1")
-		self.assertEqual(entries[0].actual_qty, -10.0)
-
-	def test_inter_transfer_return_against_inventory_dimension(self):
-		from erpnext.controllers.sales_and_purchase_return import make_return_doc
-		from erpnext.stock.doctype.delivery_note.mapper import make_inter_company_purchase_receipt
-
-		data = prepare_data_for_internal_transfer()
-
-		dn_doc = create_delivery_note(
-			customer=data.customer,
-			company=data.company,
-			warehouse=data.from_warehouse,
-			target_warehouse=data.to_warehouse,
-			qty=5,
-			cost_center=data.cost_center,
-			expense_account=data.expense_account,
-			do_not_submit=True,
-		)
-
-		dn_doc.items[0].store = "Inter Transfer Store 1"
-		dn_doc.items[0].to_store = "Inter Transfer Store 2"
-		dn_doc.save()
-		dn_doc.submit()
-
-		for d in get_voucher_sl_entries(dn_doc.name, ["store", "actual_qty"]):
-			if d.actual_qty > 0:
-				self.assertEqual(d.store, "Inter Transfer Store 2")
-			else:
-				self.assertEqual(d.store, "Inter Transfer Store 1")
-
-		pr_doc = make_inter_company_purchase_receipt(dn_doc.name)
-		pr_doc.items[0].warehouse = data.store_warehouse
-		pr_doc.items[0].from_store = "Inter Transfer Store 2"
-		pr_doc.items[0].store = "Inter Transfer Store 3"
-		pr_doc.save()
-		pr_doc.submit()
-
-		for d in get_voucher_sl_entries(pr_doc.name, ["store", "actual_qty"]):
-			if d.actual_qty > 0:
-				self.assertEqual(d.store, "Inter Transfer Store 3")
-			else:
-				self.assertEqual(d.store, "Inter Transfer Store 2")
-
-		return_doc = make_return_doc("Purchase Receipt", pr_doc.name)
-		return_doc.submit()
-
-		for d in get_voucher_sl_entries(return_doc.name, ["store", "actual_qty"]):
-			if d.actual_qty > 0:
-				self.assertEqual(d.store, "Inter Transfer Store 2")
-			else:
-				self.assertEqual(d.store, "Inter Transfer Store 3")
-
-		dn_doc.load_from_db()
-
-		return_doc1 = make_return_doc("Delivery Note", dn_doc.name)
-		return_doc1.posting_date = nowdate()
-		return_doc1.posting_time = nowtime()
-		return_doc1.items[0].target_warehouse = dn_doc.items[0].target_warehouse
-		return_doc1.items[0].warehouse = dn_doc.items[0].warehouse
-		return_doc1.save()
-		return_doc1.submit()
-
-		for d in get_voucher_sl_entries(return_doc1.name, ["store", "actual_qty"]):
-			if d.actual_qty > 0:
-				self.assertEqual(d.store, "Inter Transfer Store 1")
-			else:
-				self.assertEqual(d.store, "Inter Transfer Store 2")
-
+	@ERPNextTestSuite.change_settings("Stock Settings", {"allow_negative_stock": 1})
 	def test_validate_negative_stock_for_inventory_dimension(self):
 		item_code = "Test Negative Inventory Dimension Item"
-		frappe.db.set_single_value("Stock Settings", "allow_negative_stock", 1)
 		create_item(item_code)
 
 		inv_dimension = create_inventory_dimension(
 			apply_to_all_doctypes=1,
 			dimension_name="Inv Site",
 			reference_document="Inv Site",
-			document_type="Inv Site",
 			validate_negative_stock=1,
 		)
+		inv_dimension.db_set("validate_negative_stock", 1)
+		clear_dimension_cache()
 
 		warehouse = create_warehouse("Negative Stock Warehouse")
 
-		# Try issuing 10 qty, more than available stock against inventory dimension
-		doc = make_stock_entry(item_code=item_code, source=warehouse, qty=10, do_not_submit=True)
-		doc.items[0].inv_site = "Site 1"
-		self.assertRaises(InventoryDimensionNegativeStockError, doc.submit)
+		# Issue 10 against Site 1 with no stock -> blocked on the dimension.
+		se = make_stock_entry(item_code=item_code, source=warehouse, qty=10, do_not_save=True)
+		bundle = make_inventory_dimension_bundle(item_code, warehouse, [{"qty": 10, "inv_site": "Site 1"}])
+		se.items[0].inventory_dimension_bundle = bundle
+		self.assertRaises(InventoryDimensionNegativeStockError, se.submit)
 
-		# cancel the stock entry
-		doc.reload()
-		if doc.docstatus == 1:
-			doc.cancel()
+		# Receive 10 against Site 1.
+		se = make_stock_entry(item_code=item_code, target=warehouse, qty=10, basic_rate=10, do_not_save=True)
+		bundle = make_inventory_dimension_bundle(item_code, warehouse, [{"qty": 10, "inv_site": "Site 1"}])
+		se.items[0].inventory_dimension_bundle = bundle
+		se.submit()
+		self.assertEqual(
+			get_dimension_sub_ledger_balance(item_code, warehouse, {"inv_site": "Site 1"}, inclusive=True),
+			10,
+		)
 
-		# Receive 10 qty against inventory dimension
-		doc = make_stock_entry(item_code=item_code, target=warehouse, qty=10, do_not_submit=True)
-		doc.items[0].to_inv_site = "Site 1"
-		doc.submit()
+		# Receive another 100 with no dimension (general warehouse stock).
+		make_stock_entry(item_code=item_code, target=warehouse, qty=100, basic_rate=10)
 
-		# check inventory dimension value in stock ledger entry
-		site_name = frappe.get_all(
-			"Stock Ledger Entry", filters={"voucher_no": doc.name, "is_cancelled": 0}, fields=["inv_site"]
-		)[0].inv_site
+		# Issue 100 against Site 1: warehouse has 110 but Site 1 only has 10 -> blocked.
+		se = make_stock_entry(item_code=item_code, source=warehouse, qty=100, do_not_save=True)
+		bundle = make_inventory_dimension_bundle(item_code, warehouse, [{"qty": 100, "inv_site": "Site 1"}])
+		se.items[0].inventory_dimension_bundle = bundle
+		self.assertRaises(InventoryDimensionNegativeStockError, se.submit)
 
-		self.assertEqual(site_name, "Site 1")
-
-		# Receive another 100 qty without inventory dimension
-		doc = make_stock_entry(item_code=item_code, target=warehouse, qty=100)
-
-		# Try issuing 100 qty, more than available stock against inventory dimension
-		# Note: total available qty for the item is 110, but against inventory dimension, only 10 qty is available
-		doc = make_stock_entry(item_code=item_code, source=warehouse, qty=100, do_not_submit=True)
-		doc.items[0].inv_site = "Site 1"
-		self.assertRaises(InventoryDimensionNegativeStockError, doc.submit)
-
-		# disable validate_negative_stock for inventory dimension
+		# Disable the check on the dimension -> the same issue now goes through.
 		inv_dimension.reload()
 		inv_dimension.db_set("validate_negative_stock", 0)
-		frappe.clear_cache(doctype="Inventory Dimension")
+		clear_dimension_cache()
 
-		# Try issuing 100 qty, more than available stock against inventory dimension
-		doc = make_stock_entry(item_code=item_code, source=warehouse, qty=100, do_not_submit=True)
-		doc.items[0].inv_site = "Site 1"
-		doc.submit()
-		self.assertEqual(doc.docstatus, 1)
+		se = make_stock_entry(item_code=item_code, source=warehouse, qty=100, do_not_save=True)
+		bundle = make_inventory_dimension_bundle(item_code, warehouse, [{"qty": 100, "inv_site": "Site 1"}])
+		se.items[0].inventory_dimension_bundle = bundle
+		se.submit()
+		self.assertEqual(se.docstatus, 1)
 
-		# check inventory dimension value in stock ledger entry
-		site_name = frappe.get_all(
-			"Stock Ledger Entry", filters={"voucher_no": doc.name, "is_cancelled": 0}, fields=["inv_site"]
-		)[0].inv_site
-
-		self.assertEqual(site_name, "Site 1")
-
-	@ERPNextTestSuite.change_settings("Stock Settings", {"allow_negative_stock": 0})
-	def test_validate_negative_stock_with_multiple_dimension(self):
-		item_code = "Test Negative Multi Inventory Dimension Item"
+	@ERPNextTestSuite.change_settings("Stock Settings", {"allow_negative_stock": 1})
+	def test_negative_stock_per_dimension_method(self):
+		"""Per Dimension: each dimension is validated independently (combination may be short)."""
+		item_code = "Test ND Per Dimension Item"
 		create_item(item_code)
+		self._setup_two_dimensions("Per Dimension")
+		warehouse = create_warehouse("ND Per Dimension Warehouse")
 
-		inv_dimension_1 = create_inventory_dimension(
-			apply_to_all_doctypes=1,
-			dimension_name="Inv Site",
-			reference_document="Inv Site",
-			document_type="Inv Site",
-			validate_negative_stock=1,
+		# Balances after receipts: Site 1 = 30, Site 2 = 55, Rack 1 = 60, Rack 2 = 25.
+		self._receive(
+			item_code,
+			warehouse,
+			[("Site 1", "Rack 1", 30), ("Site 2", "Rack 1", 30), ("Site 2", "Rack 2", 25)],
 		)
-		inv_dimension_1.db_set("validate_negative_stock", 1)
 
-		inv_dimension_2 = create_inventory_dimension(
-			apply_to_all_doctypes=1,
-			dimension_name="Rack",
-			reference_document="Rack",
-			document_type="Rack",
-			validate_negative_stock=1,
+		# Issue 35 from Site 2 + Rack 1. Per dimension both are sufficient (55, 60) even though the
+		# exact combination Site 2 + Rack 1 only has 30 -> allowed.
+		se = make_stock_entry(item_code=item_code, source=warehouse, qty=35, do_not_save=True)
+		bundle = make_inventory_dimension_bundle(
+			item_code, warehouse, [{"qty": 35, "inv_site": "Site 2", "rack": "Rack 1"}]
 		)
-		inv_dimension_2.db_set("validate_negative_stock", 1)
+		se.items[0].inventory_dimension_bundle = bundle
+		se.submit()
+		self.assertEqual(se.docstatus, 1)
 
-		pr_doc = make_purchase_receipt(item_code=item_code, qty=30, do_not_submit=True)
-		pr_doc.items[0].inv_site = "Site 1"
-		pr_doc.items[0].rack = "Rack 1"
-		pr_doc.save()
-		pr_doc.submit()
+		# Issue 30 from Rack 2 (only 25 available on that single dimension) -> blocked.
+		se = make_stock_entry(item_code=item_code, source=warehouse, qty=30, do_not_save=True)
+		bundle = make_inventory_dimension_bundle(
+			item_code, warehouse, [{"qty": 30, "inv_site": "Site 2", "rack": "Rack 2"}]
+		)
+		se.items[0].inventory_dimension_bundle = bundle
+		self.assertRaises(InventoryDimensionNegativeStockError, se.submit)
 
-		pr_doc = make_purchase_receipt(item_code=item_code, qty=15, do_not_submit=True)
-		pr_doc.items[0].inv_site = "Site 1"
-		pr_doc.items[0].rack = "Rack 2"
-		pr_doc.save()
-		pr_doc.submit()
+	@ERPNextTestSuite.change_settings("Stock Settings", {"allow_negative_stock": 1})
+	def test_negative_stock_combined_method(self):
+		"""Combined: the exact combination of all combined-method dimensions is validated together."""
+		item_code = "Test ND Combined Item"
+		create_item(item_code)
+		self._setup_two_dimensions("Combined")
+		warehouse = create_warehouse("ND Combined Warehouse")
 
-		pr_doc = make_purchase_receipt(item_code=item_code, qty=30, do_not_submit=True)
-		pr_doc.items[0].inv_site = "Site 2"
-		pr_doc.items[0].rack = "Rack 1"
-		pr_doc.save()
-		pr_doc.submit()
+		# Same balances: Site 2 = 55, Rack 1 = 60, but the combination Site 2 + Rack 1 = 30.
+		self._receive(
+			item_code,
+			warehouse,
+			[("Site 1", "Rack 1", 30), ("Site 2", "Rack 1", 30), ("Site 2", "Rack 2", 25)],
+		)
 
-		pr_doc = make_purchase_receipt(item_code=item_code, qty=25, do_not_submit=True)
-		pr_doc.items[0].inv_site = "Site 2"
-		pr_doc.items[0].rack = "Rack 2"
-		pr_doc.save()
-		pr_doc.submit()
+		# Issue 35 from Site 2 + Rack 1: the combination only has 30 -> blocked.
+		se = make_stock_entry(item_code=item_code, source=warehouse, qty=35, do_not_save=True)
+		bundle = make_inventory_dimension_bundle(
+			item_code, warehouse, [{"qty": 35, "inv_site": "Site 2", "rack": "Rack 1"}]
+		)
+		se.items[0].inventory_dimension_bundle = bundle
+		self.assertRaises(InventoryDimensionNegativeStockError, se.submit)
 
-		dn_doc = create_delivery_note(item_code=item_code, qty=35, do_not_submit=True)
-		dn_doc.items[0].inv_site = "Site 2"
-		dn_doc.items[0].rack = "Rack 1"
-		dn_doc.save()
-		self.assertRaises(InventoryDimensionNegativeStockError, dn_doc.submit)
+		# Issue 30 from Site 2 + Rack 1 (exactly the combination balance) -> allowed.
+		se = make_stock_entry(item_code=item_code, source=warehouse, qty=30, do_not_save=True)
+		bundle = make_inventory_dimension_bundle(
+			item_code, warehouse, [{"qty": 30, "inv_site": "Site 2", "rack": "Rack 1"}]
+		)
+		se.items[0].inventory_dimension_bundle = bundle
+		se.submit()
+		self.assertEqual(se.docstatus, 1)
+
+	# ------------------------------------------------------------------ helpers
+
+	def _setup_two_dimensions(self, method):
+		for name, reference in [("Inv Site", "Inv Site"), ("Rack", "Rack")]:
+			dimension = create_inventory_dimension(
+				apply_to_all_doctypes=1,
+				dimension_name=name,
+				reference_document=reference,
+				validate_negative_stock=1,
+			)
+			dimension.db_set("validate_negative_stock", 1)
+			dimension.db_set("negative_stock_validation_method", method)
+		clear_dimension_cache()
+
+	def _receive(self, item_code, warehouse, allocations):
+		for site, rack, qty in allocations:
+			se = make_stock_entry(
+				item_code=item_code, target=warehouse, qty=qty, basic_rate=10, do_not_save=True
+			)
+			bundle = make_inventory_dimension_bundle(
+				item_code, warehouse, [{"qty": qty, "inv_site": site, "rack": rack}]
+			)
+			se.items[0].inventory_dimension_bundle = bundle
+			se.submit()
 
 
-def get_voucher_sl_entries(voucher_no, fields):
-	return frappe.get_all(
-		"Stock Ledger Entry", filters={"voucher_no": voucher_no}, fields=fields, order_by="creation"
-	)
+def make_inventory_dimension_bundle(item_code, warehouse, entries):
+	"""Build and save a draft Inventory Dimension Bundle (the dialog's job in the UI).
+
+	``entries`` is a list of dicts: ``{"qty": <qty>, "<dimension_source_fieldname>": <value>, ...}``.
+	"""
+	company = frappe.db.get_value("Warehouse", warehouse, "company")
+
+	doc = frappe.new_doc("Inventory Dimension Bundle")
+	doc.company = company
+	doc.item_code = item_code
+	doc.warehouse = warehouse
+	for entry in entries:
+		row = {"qty": entry["qty"], "warehouse": entry.get("warehouse") or warehouse}
+		for key, value in entry.items():
+			if key not in ("qty", "warehouse"):
+				row[key] = value
+		doc.append("entries", row)
+
+	doc.flags.ignore_permissions = True
+	doc.save()
+	return doc.name
+
+
+def reset_inventory_dimension_flags():
+	"""Clear ``reqd`` / ``validate_negative_stock`` on every dimension so leaked records from a
+	committed Custom Field DDL cannot impose mandatory/negative-stock validation on other tests."""
+	for name in frappe.get_all("Inventory Dimension", pluck="name"):
+		frappe.db.set_value(
+			"Inventory Dimension", name, {"reqd": 0, "validate_negative_stock": 0}, update_modified=False
+		)
+	clear_dimension_cache()
+
+
+def clear_dimension_cache():
+	"""Reset the per-request caches so dimension config changes are picked up mid-test.
+
+	``get_inventory_dimensions`` / ``get_document_wise_inventory_dimensions`` are ``@request_cache``d;
+	clear the request cache in place (it is a ``defaultdict(dict)``, so it must not be replaced).
+	"""
+	frappe.clear_cache(doctype="Inventory Dimension")
+	if getattr(frappe.local, "request_cache", None) is not None:
+		frappe.local.request_cache.clear()
 
 
 def create_inventory_dimension(**args):
@@ -565,75 +846,3 @@ def create_inventory_dimension(**args):
 		doc.insert(ignore_permissions=True)
 
 	return doc
-
-
-def prepare_data_for_internal_transfer():
-	from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_internal_supplier
-	from erpnext.selling.doctype.customer.test_customer import create_internal_customer
-	from erpnext.stock.doctype.purchase_receipt.test_purchase_receipt import make_purchase_receipt
-	from erpnext.stock.doctype.warehouse.test_warehouse import create_warehouse
-
-	company = "_Test Company with perpetual inventory"
-
-	customer = create_internal_customer(
-		"_Test Internal Customer 2",
-		company,
-		company,
-	)
-
-	supplier = create_internal_supplier(
-		"_Test Internal Supplier 2",
-		company,
-		company,
-	)
-
-	for store in ["Inter Transfer Store 1", "Inter Transfer Store 2", "Inter Transfer Store 3"]:
-		if not frappe.db.exists("Store", store):
-			frappe.get_doc({"doctype": "Store", "store_name": store}).insert(ignore_permissions=True)
-
-	warehouse = create_warehouse("_Test Internal Warehouse New A", company=company)
-
-	to_warehouse = create_warehouse("_Test Internal Warehouse GIT A", company=company)
-
-	pr_doc = make_purchase_receipt(company=company, warehouse=warehouse, qty=10, rate=100, do_not_submit=True)
-	pr_doc.items[0].store = "Inter Transfer Store 1"
-	pr_doc.submit()
-
-	if not frappe.db.get_value("Company", company, "unrealized_profit_loss_account"):
-		account = "Unrealized Profit and Loss - TCP1"
-		if not frappe.db.exists("Account", account):
-			frappe.get_doc(
-				{
-					"doctype": "Account",
-					"account_name": "Unrealized Profit and Loss",
-					"parent_account": "Direct Income - TCP1",
-					"company": company,
-					"is_group": 0,
-					"account_type": "Income Account",
-				}
-			).insert()
-
-		frappe.db.set_value("Company", company, "unrealized_profit_loss_account", account)
-
-	cost_center = frappe.db.get_value("Company", company, "cost_center") or frappe.db.get_value(
-		"Cost Center", {"company": company}, "name"
-	)
-
-	expene_account = frappe.db.get_value(
-		"Company", company, "stock_adjustment_account"
-	) or frappe.db.get_value("Account", {"company": company, "account_type": "Expense Account"}, "name")
-
-	return frappe._dict(
-		{
-			"from_warehouse": warehouse,
-			"to_warehouse": to_warehouse,
-			"customer": customer,
-			"supplier": supplier,
-			"company": company,
-			"cost_center": cost_center,
-			"expene_account": expene_account,
-			"store_warehouse": frappe.db.get_value(
-				"Warehouse", {"name": ("like", "Store%"), "company": company}, "name"
-			),
-		}
-	)

--- a/erpnext/stock/doctype/inventory_dimension/test_inventory_dimension.py
+++ b/erpnext/stock/doctype/inventory_dimension/test_inventory_dimension.py
@@ -474,6 +474,23 @@ class TestInventoryDimension(ERPNextTestSuite):
 		# Running balance for Rack 1 ends at 20.
 		self.assertEqual(rows[-1].get("qty_after_transaction"), 20)
 
+		# Filtering on multiple values must show each row's own value, not the first selected one
+		# stamped on every row (the +30 and -10 are Rack 1, the +20 is Rack 2).
+		multi = frappe._dict(
+			company=company,
+			from_date=add_days(today(), -1),
+			to_date=today(),
+			item_code=[item_code],
+			warehouse=[warehouse],
+			rack=["Rack 1", "Rack 2"],
+		)
+		_columns, data = execute(multi)
+		multi_rows = [row for row in data if row.get("item_code") == item_code]
+		self.assertEqual(
+			[(row.get("rack"), row.get("actual_qty")) for row in multi_rows],
+			[("Rack 1", 30), ("Rack 2", 20), ("Rack 1", -10)],
+		)
+
 		# Without a dimension filter, each row still shows its bundle's dimension value in the column.
 		unfiltered = frappe._dict(
 			company=company,
@@ -679,6 +696,33 @@ class TestInventoryDimension(ERPNextTestSuite):
 				"rejected_inventory_dimension_bundle": rejected_bundle,
 			}
 		)
+
+	def test_mandatory_dimension_validation_reads_supplied_item_fields(self):
+		"""The mandatory check resolves the item/qty from the table config, so a Subcontracting
+		Receipt's ``supplied_items`` (RM in ``rm_item_code``, consumed via ``consumed_qty``) are not
+		silently skipped - they are enforced like any other stock-moving row."""
+		item_code = "_Test Item"
+		dimension = create_inventory_dimension(
+			reference_document="Shelf", dimension_name="Shelf", apply_to_all_doctypes=1
+		)
+		dimension.db_set("reqd", 1)
+		clear_dimension_cache()
+
+		warehouse = create_warehouse("Supplied Reqd Warehouse")
+		bundle = make_inventory_dimension_bundle(item_code, warehouse, [{"qty": 5, "shelf": "Shelf 1"}])
+
+		service = InventoryDimensionBundleService(frappe.new_doc("Subcontracting Receipt"))
+
+		def _check(row):
+			service.doc.set("supplied_items", [frappe._dict(idx=1, rm_item_code=item_code, **row)])
+			service.validate_inventory_dimension_bundle("supplied_items")
+
+		# A consumed RM row without a bundle must be caught (previously skipped: item_code was read
+		# from the absent ``item_code`` field, so is_stock_item(None) gated the row out).
+		self.assertRaises(frappe.ValidationError, _check, {"consumed_qty": 5})
+
+		# The same row with a covering bundle passes.
+		_check({"consumed_qty": 5, "inventory_dimension_bundle": bundle})
 
 	def test_service_item_skips_dimension(self):
 		"""Non-stock (service) rows never require a dimension - they are skipped entirely."""

--- a/erpnext/stock/doctype/inventory_dimension/test_inventory_dimension.py
+++ b/erpnext/stock/doctype/inventory_dimension/test_inventory_dimension.py
@@ -631,6 +631,55 @@ class TestInventoryDimension(ERPNextTestSuite):
 			4,
 		)
 
+	def test_mandatory_dimension_validates_each_qty_leg(self):
+		"""Mandatory coverage is enforced per leg: the accepted leg uses ``inventory_dimension_bundle``
+		and the rejected leg uses ``rejected_inventory_dimension_bundle``. A row that captured its
+		dimension on the rejected bundle alone must pass, and an uncovered rejected leg must be caught."""
+		item_code = "_Test Item"
+		dimension = create_inventory_dimension(
+			reference_document="Shelf", dimension_name="Shelf", apply_to_all_doctypes=1
+		)
+		dimension.db_set("reqd", 1)
+		clear_dimension_cache()
+
+		warehouse = create_warehouse("Reqd Leg Accepted Warehouse")
+		rejected_warehouse = create_warehouse("Reqd Leg Rejected Warehouse")
+
+		accepted_bundle = make_inventory_dimension_bundle(
+			item_code, warehouse, [{"qty": 10, "shelf": "Shelf 1"}]
+		)
+		rejected_bundle = make_inventory_dimension_bundle(
+			item_code, rejected_warehouse, [{"qty": 4, "shelf": "Shelf 2"}]
+		)
+
+		service = InventoryDimensionBundleService(frappe.new_doc("Purchase Receipt"))
+
+		def _check(row):
+			service.doc.set("items", [frappe._dict(idx=1, item_code=item_code, **row)])
+			service.validate_inventory_dimension_bundle()
+
+		# Rejected-only row (qty=0): the dimension is captured on the rejected bundle, so the row is
+		# fully covered. Previously the check only inspected the accepted bundle and falsely threw.
+		_check({"qty": 0, "rejected_qty": 4, "rejected_inventory_dimension_bundle": rejected_bundle})
+
+		# Both legs move stock but the rejected bundle is missing: the rejected leg must be caught.
+		# Previously the rejected bundle was never fetched, so this gap was silently skipped.
+		self.assertRaises(
+			frappe.ValidationError,
+			_check,
+			{"qty": 10, "rejected_qty": 4, "inventory_dimension_bundle": accepted_bundle},
+		)
+
+		# Both legs covered on their own bundles -> passes.
+		_check(
+			{
+				"qty": 10,
+				"rejected_qty": 4,
+				"inventory_dimension_bundle": accepted_bundle,
+				"rejected_inventory_dimension_bundle": rejected_bundle,
+			}
+		)
+
 	def test_service_item_skips_dimension(self):
 		"""Non-stock (service) rows never require a dimension - they are skipped entirely."""
 		service_item = "Test Service Dimension Item"

--- a/erpnext/stock/doctype/inventory_dimension_bundle/inventory_dimension_bundle.js
+++ b/erpnext/stock/doctype/inventory_dimension_bundle/inventory_dimension_bundle.js
@@ -1,0 +1,14 @@
+// Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
+// For license information, please see license.txt
+
+frappe.ui.form.on("Inventory Dimension Bundle", {
+	before_submit(frm) {
+		// The bundle is submitted automatically when its linked voucher is submitted.
+		frappe.throw(__("The user cannot submit the Inventory Dimension Bundle manually."));
+	},
+
+	before_cancel(frm) {
+		// The bundle is cancelled automatically when its linked voucher is cancelled.
+		frappe.throw(__("The user cannot cancel the Inventory Dimension Bundle manually."));
+	},
+});

--- a/erpnext/stock/doctype/inventory_dimension_bundle/inventory_dimension_bundle.json
+++ b/erpnext/stock/doctype/inventory_dimension_bundle/inventory_dimension_bundle.json
@@ -1,0 +1,277 @@
+{
+ "actions": [],
+ "autoname": "hash",
+ "creation": "2026-06-19 00:00:00.000000",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "item_details_tab",
+  "naming_series",
+  "company",
+  "item_name",
+  "item_group",
+  "column_break_4",
+  "item_code",
+  "warehouse",
+  "type_of_transaction",
+  "dimensions_tab",
+  "entries",
+  "quantity_section",
+  "total_qty",
+  "reference_tab",
+  "voucher_type",
+  "voucher_no",
+  "voucher_detail_no",
+  "column_break_ref",
+  "posting_datetime",
+  "is_cancelled",
+  "amended_from"
+ ],
+ "fields": [
+  {
+   "fieldname": "item_details_tab",
+   "fieldtype": "Tab Break",
+   "label": "Inventory Dimension"
+  },
+  {
+   "default": "IDB-.########",
+   "fieldname": "naming_series",
+   "fieldtype": "Select",
+   "label": "Naming Series",
+   "options": "\nIDB-.########",
+   "set_only_once": 1
+  },
+  {
+   "fieldname": "company",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Company",
+   "options": "Company",
+   "reqd": 1
+  },
+  {
+   "fetch_from": "item_code.item_name",
+   "fieldname": "item_name",
+   "fieldtype": "Data",
+   "label": "Item Name",
+   "read_only": 1
+  },
+  {
+   "fetch_from": "item_code.item_group",
+   "fieldname": "item_group",
+   "fieldtype": "Link",
+   "hidden": 1,
+   "label": "Item Group",
+   "options": "Item Group"
+  },
+  {
+   "fieldname": "column_break_4",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "item_code",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Item Code",
+   "options": "Item",
+   "reqd": 1
+  },
+  {
+   "depends_on": "company",
+   "fieldname": "warehouse",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Warehouse",
+   "options": "Warehouse"
+  },
+  {
+   "fieldname": "type_of_transaction",
+   "fieldtype": "Select",
+   "label": "Type of Transaction",
+   "options": "\nInward\nOutward"
+  },
+  {
+   "fieldname": "dimensions_tab",
+   "fieldtype": "Tab Break",
+   "label": "Dimensions"
+  },
+  {
+   "allow_bulk_edit": 1,
+   "fieldname": "entries",
+   "fieldtype": "Table",
+   "options": "Inventory Dimension Entry",
+   "reqd": 1
+  },
+  {
+   "fieldname": "quantity_section",
+   "fieldtype": "Section Break"
+  },
+  {
+   "allow_on_submit": 1,
+   "fieldname": "total_qty",
+   "fieldtype": "Float",
+   "label": "Total Qty",
+   "no_copy": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "reference_tab",
+   "fieldtype": "Tab Break",
+   "label": "Reference"
+  },
+  {
+   "fieldname": "voucher_type",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Voucher Type",
+   "options": "DocType",
+   "search_index": 1
+  },
+  {
+   "fieldname": "voucher_no",
+   "fieldtype": "Dynamic Link",
+   "in_standard_filter": 1,
+   "label": "Voucher No",
+   "no_copy": 1,
+   "options": "voucher_type"
+  },
+  {
+   "fieldname": "voucher_detail_no",
+   "fieldtype": "Data",
+   "label": "Voucher Detail No",
+   "no_copy": 1,
+   "read_only": 1,
+   "search_index": 1
+  },
+  {
+   "fieldname": "column_break_ref",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "posting_datetime",
+   "fieldtype": "Datetime",
+   "label": "Posting Datetime"
+  },
+  {
+   "default": "0",
+   "fieldname": "is_cancelled",
+   "fieldtype": "Check",
+   "label": "Is Cancelled",
+   "no_copy": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "amended_from",
+   "fieldtype": "Link",
+   "label": "Amended From",
+   "no_copy": 1,
+   "options": "Inventory Dimension Bundle",
+   "print_hide": 1,
+   "read_only": 1
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "is_submittable": 1,
+ "links": [],
+ "modified": "2026-06-19 00:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Stock",
+ "name": "Inventory Dimension Bundle",
+ "naming_rule": "Random",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "cancel": 1,
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "submit": 1,
+   "write": 1
+  },
+  {
+   "cancel": 1,
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Stock User",
+   "share": 1,
+   "submit": 1,
+   "write": 1
+  },
+  {
+   "cancel": 1,
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Stock Manager",
+   "share": 1,
+   "submit": 1,
+   "write": 1
+  },
+  {
+   "cancel": 1,
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Purchase User",
+   "share": 1,
+   "submit": 1,
+   "write": 1
+  },
+  {
+   "cancel": 1,
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Delivery User",
+   "share": 1,
+   "submit": 1,
+   "write": 1
+  },
+  {
+   "cancel": 1,
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Manufacturing User",
+   "share": 1,
+   "submit": 1,
+   "write": 1
+  }
+ ],
+ "row_format": "Dynamic",
+ "sort_field": "creation",
+ "sort_order": "DESC",
+ "states": [],
+ "title_field": "item_code"
+}

--- a/erpnext/stock/doctype/inventory_dimension_bundle/inventory_dimension_bundle.py
+++ b/erpnext/stock/doctype/inventory_dimension_bundle/inventory_dimension_bundle.py
@@ -307,13 +307,18 @@ class InventoryDimensionBundle(Document):
 				).format(frappe.bold(self.total_qty), frappe.bold(row_qty))
 			)
 
-	def set_inventory_dimension_values(self, parent_doc, row, qty_field="qty", warehouse=None):
+	def set_inventory_dimension_values(
+		self, parent_doc, row, qty_field="qty", warehouse=None, item_code=None, type_of_transaction=None
+	):
 		"""Stamp the linked transaction's references onto the bundle and submit it.
 
 		Mirrors ``Serial and Batch Bundle.set_serial_and_batch_values``. Called from the
 		transaction controllers on submit for stock-item rows that carry an inventory
 		dimension bundle. ``warehouse`` is passed for the rejected-qty bundle so it posts against
-		the rejected warehouse; otherwise it is derived from the row.
+		the rejected warehouse; otherwise it is derived from the row. ``item_code`` and
+		``type_of_transaction`` are passed for rows whose stock identity isn't ``row.item_code`` or
+		whose direction the voucher can't infer from the row (e.g. a Subcontracting Receipt's
+		``supplied_items``, which consume ``rm_item_code`` outward from the supplier warehouse).
 		"""
 		from erpnext.stock.doctype.serial_and_batch_bundle.serial_and_batch_bundle import (
 			combine_datetime,
@@ -323,12 +328,12 @@ class InventoryDimensionBundle(Document):
 		self.voucher_type = parent_doc.doctype
 		self.voucher_no = parent_doc.name
 		self.voucher_detail_no = row.name
-		self.item_code = row.item_code
+		self.item_code = item_code or row.item_code
 		self.company = parent_doc.company
 
 		# The voucher is authoritative for direction (it knows returns, transfers, etc.); overwrite
 		# any direction inferred while the bundle was a manually created draft.
-		self.type_of_transaction = get_type_of_transaction(parent_doc, row)
+		self.type_of_transaction = type_of_transaction or get_type_of_transaction(parent_doc, row)
 
 		if warehouse:
 			self.warehouse = warehouse

--- a/erpnext/stock/doctype/inventory_dimension_bundle/inventory_dimension_bundle.py
+++ b/erpnext/stock/doctype/inventory_dimension_bundle/inventory_dimension_bundle.py
@@ -1,0 +1,549 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt
+
+import typing
+
+import frappe
+from frappe import _
+from frappe.model.document import Document
+from frappe.query_builder.functions import Sum
+from frappe.utils import cint, flt
+
+
+class InventoryDimensionNegativeStockError(frappe.ValidationError):
+	pass
+
+
+class InventoryDimensionBundle(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		from erpnext.stock.doctype.inventory_dimension_entry.inventory_dimension_entry import (
+			InventoryDimensionEntry,
+		)
+
+		amended_from: DF.Link | None
+		company: DF.Link
+		entries: DF.Table[InventoryDimensionEntry]
+		is_cancelled: DF.Check
+		item_code: DF.Link
+		item_group: DF.Link | None
+		item_name: DF.Data | None
+		naming_series: DF.Literal["", "IDB-.########"]
+		posting_datetime: DF.Datetime | None
+		total_qty: DF.Float
+		type_of_transaction: DF.Literal["", "Inward", "Outward"]
+		voucher_detail_no: DF.Data | None
+		voucher_no: DF.DynamicLink | None
+		voucher_type: DF.Link | None
+		warehouse: DF.Link | None
+	# end: auto-generated types
+
+	# Voucher types whose direction is unambiguous, used to stamp the bundle's direction when it
+	# was created/linked manually before the voucher stamps it on submit. Ambiguous voucher types
+	# (Stock Entry, Stock Reconciliation, Subcontracting Receipt) and returns are left to the
+	# voucher, which stamps the exact direction via ``get_type_of_transaction`` on submit.
+	DIRECTIONAL_VOUCHERS: typing.ClassVar[dict] = {
+		"Delivery Note": "Outward",
+		"Sales Invoice": "Outward",
+		"POS Invoice": "Outward",
+		"Purchase Receipt": "Inward",
+		"Purchase Invoice": "Inward",
+	}
+
+	def validate(self):
+		self.set_type_of_transaction()
+		self.set_entry_references()
+		self.calculate_total_qty()
+
+	def set_type_of_transaction(self):
+		"""Infer the bundle direction from the voucher when it is still unset.
+
+		A bundle built/linked manually (the full form, not the on-submit stamp) has no direction
+		yet, so its entries would default to inward. Stamp it from the voucher type for the
+		unambiguous cases; the voucher overrides this with the exact direction on submit.
+		"""
+		if not self.type_of_transaction and self.voucher_type:
+			self.type_of_transaction = self.DIRECTIONAL_VOUCHERS.get(self.voucher_type, "")
+
+	def before_submit(self):
+		self.validate_voucher_controlled("submitted")
+
+		# Direction is unknown while the bundle is a draft created from the dialog; it is
+		# stamped from the voucher on submit. Enforce it only at submit time.
+		if not self.type_of_transaction:
+			frappe.throw(_("Type of Transaction is required to submit an Inventory Dimension Bundle."))
+
+		self.validate_mandatory_dimensions()
+		self.validate_negative_stock()
+
+	def before_cancel(self):
+		self.validate_voucher_controlled("cancelled")
+
+	def validate_voucher_controlled(self, action):
+		"""The bundle's lifecycle is owned by its voucher: it is submitted/cancelled only when the
+		linked voucher is submitted/cancelled (the controller sets ``flags.from_voucher``), never by
+		hand. The migration patch reconstructs bundles directly and is exempt."""
+		if self.flags.from_voucher or frappe.flags.in_patch:
+			return
+
+		frappe.throw(
+			_(
+				"An Inventory Dimension Bundle is {0} automatically when its linked voucher is {0};"
+				" it cannot be {0} manually."
+			).format(_(action)),
+			title=_("Not Allowed"),
+		)
+
+	def validate_mandatory_dimensions(self):
+		"""Each entry must carry a value for every dimension configured as Mandatory.
+
+		The set of mandatory dimensions is taken from the dimension's ``reqd`` flag, scoped to the
+		bundle's voucher (its item child doctype).
+		"""
+		# Migrating historical vouchers rebuilds bundles from SLEs that were posted when a dimension
+		# may still have been optional; enforcing a now-mandatory dimension here would abort the
+		# migration mid-run (mirrors the guard in validate_negative_stock).
+		if frappe.flags.in_patch:
+			return
+
+		from erpnext.stock.doctype.inventory_dimension.inventory_dimension import (
+			get_mandatory_inventory_dimensions,
+			get_voucher_child_doctype,
+		)
+
+		child_doctype = get_voucher_child_doctype(self.voucher_type)
+		mandatory = get_mandatory_inventory_dimensions(child_doctype)
+		if not mandatory:
+			return
+
+		for row in self.entries:
+			for dimension in mandatory:
+				fieldname = dimension.get("source_fieldname")
+				if not frappe.db.has_column("Inventory Dimension Entry", fieldname):
+					continue
+				if not row.get(fieldname):
+					frappe.throw(
+						_("Row #{0}: {1} is mandatory in the Inventory Dimension Bundle.").format(
+							row.idx, frappe.bold(dimension.get("name"))
+						),
+						title=_("Inventory Dimension Required"),
+					)
+
+	def validate_negative_stock(self):
+		"""Block submission when an outward entry would drive a dimension negative.
+
+		Only dimensions flagged ``validate_negative_stock`` are checked. Each such dimension carries
+		a ``negative_stock_validation_method``:
+
+		* ``Per Dimension`` (default) - the dimension's own balance is validated independently, so
+		  e.g. ``Rack=A`` must have stock regardless of which ``Bin`` it sits in.
+		* ``Combined`` - the exact combination of *all* combined-method dimensions on a line is
+		  validated together, so e.g. only ``Rack=A`` + ``Bin=X`` jointly must have stock.
+
+		Availability is taken from the quantity sub-ledger strictly before this bundle's posting
+		(this bundle excluded).
+		"""
+		from erpnext.stock.doctype.inventory_dimension.inventory_dimension import (
+			get_inventory_dimensions,
+		)
+
+		# Migrating historical vouchers reconstructs an already-valid ledger; enforcing negative stock
+		# here would spuriously fail whenever an outward bundle is rebuilt before its inward source.
+		if frappe.flags.in_patch:
+			return
+
+		neg_dimensions = [d for d in get_inventory_dimensions() if d.get("validate_negative_stock")]
+		if not neg_dimensions:
+			return
+
+		combined_dimensions = [
+			d for d in neg_dimensions if d.get("negative_stock_validation_method") == "Combined"
+		]
+		per_dimensions = [
+			d for d in neg_dimensions if d.get("negative_stock_validation_method") != "Combined"
+		]
+
+		flt_precision = cint(frappe.db.get_default("float_precision")) or 2
+
+		# Aggregate outward qty per check key:
+		# - one key holding every "Combined" dimension value present on the row, and
+		# - one key per individual "Per Dimension" value on the row.
+		outward_qty = {}
+		combinations = {}
+		for row in self.entries:
+			if not row.is_outward:
+				continue
+
+			row_combinations = []
+
+			combined = {
+				d.source_fieldname: row.get(d.source_fieldname)
+				for d in combined_dimensions
+				if row.get(d.source_fieldname)
+			}
+			if combined:
+				row_combinations.append(combined)
+
+			for d in per_dimensions:
+				value = row.get(d.source_fieldname)
+				if value:
+					row_combinations.append({d.source_fieldname: value})
+
+			for combination in row_combinations:
+				key = tuple(sorted(combination.items()))
+				# qty is stored negative for outward; accumulate the outward demand as a magnitude.
+				outward_qty[key] = outward_qty.get(key, 0.0) + abs(flt(row.qty))
+				combinations[key] = combination
+
+		for key, qty in outward_qty.items():
+			available_qty = get_dimension_sub_ledger_balance(
+				self.item_code,
+				self.warehouse,
+				combinations[key],
+				posting_datetime=self.posting_datetime,
+				exclude_bundle=self.name,
+			)
+			diff = flt(available_qty - qty, flt_precision)
+			if diff < 0 and abs(diff) > 0.0001:
+				self.throw_negative_stock_error(diff, combinations[key])
+
+	def throw_negative_stock_error(self, diff, combination):
+		frappe.throw(
+			_(
+				"{0} units of {1} are required in {2} with the inventory dimension: {3} to complete the transaction."
+			).format(
+				abs(diff),
+				frappe.get_desk_link("Item", self.item_code),
+				frappe.get_desk_link("Warehouse", self.warehouse),
+				frappe.bold(", ".join([f"{field}: {value}" for field, value in combination.items()])),
+			),
+			title=_("Inventory Dimension Negative Stock"),
+			exc=InventoryDimensionNegativeStockError,
+		)
+
+	def set_entry_references(self):
+		"""Denormalize parent context onto each entry and normalise direction + sign.
+
+		Runs on every save (mirrors Serial and Batch Entry): each reference is re-synced from the
+		parent so a bundle edited directly - or stamped from its voucher on submit - always agrees
+		with the parent (voucher no, posting datetime, etc. that were blank on a freshly created
+		draft get filled in once the voucher stamps them).
+
+		Direction is the parent's ``type_of_transaction`` unless an entry already carries its own
+		``is_outward`` (a transfer migrated into one bundle keeps an outward leg + an inward leg).
+		The entry ``qty`` is then signed to match - negative for outward, positive for inward -
+		mirroring Stock Ledger Entry's ``actual_qty`` and Serial and Batch Bundle.
+		"""
+		is_outward = 1 if self.type_of_transaction == "Outward" else 0
+		for row in self.entries:
+			row.item_code = self.item_code
+			row.voucher_type = self.voucher_type
+			row.voucher_no = self.voucher_no
+			row.voucher_detail_no = self.voucher_detail_no
+			row.posting_datetime = self.posting_datetime
+			row.is_cancelled = self.is_cancelled
+			if not row.warehouse:
+				row.warehouse = self.warehouse
+			if not row.is_outward:
+				row.is_outward = is_outward
+			self.normalize_entry_qty(row)
+
+	@staticmethod
+	def normalize_entry_qty(row):
+		"""Store qty signed by direction: negative for outward, positive for inward."""
+		qty = flt(row.qty)
+		if row.is_outward and qty > 0:
+			row.qty = -qty
+		elif not row.is_outward and qty < 0:
+			row.qty = -qty
+
+	def calculate_total_qty(self):
+		# qty is stored signed (negative for outward), so the total nets per direction, matching
+		# the voucher row's signed stock qty.
+		self.total_qty = flt(sum(flt(row.qty) for row in self.entries))
+
+	def on_submit(self):
+		# Phase 3 will post the quantity sub-ledger from these entries.
+		pass
+
+	def on_cancel(self):
+		# The voucher (and its item row) that links this bundle is still submitted while the
+		# bundle is cancelled as part of the voucher's own cancellation; exempt those links and
+		# the immutable Stock Ledger Entry from the back-link check.
+		self.ignore_linked_doctypes = (
+			"Stock Ledger Entry",
+			"Stock Entry",
+			"Delivery Note",
+			"Sales Invoice",
+			"POS Invoice",
+			"Purchase Receipt",
+			"Purchase Invoice",
+			"Stock Reconciliation",
+			"Subcontracting Receipt",
+		)
+		self.set_is_cancelled(1)
+
+	def set_is_cancelled(self, value: int):
+		self.db_set("is_cancelled", value)
+		for row in self.entries:
+			row.db_set("is_cancelled", value)
+
+	def validate_total_qty_against_voucher(self, row_qty: float):
+		"""Helper used by the transaction controllers (Phase 2): the bundle's total qty
+		must reconcile with the linked transaction row qty."""
+		# Compare magnitudes: total_qty is stored signed (negative for outward) while the voucher
+		# row's qty may be positive. Tolerate float rounding (e.g. 1.2000000000000002 vs 1.2);
+		# matches the negative-stock guard's tolerance rather than an exact equality test.
+		if abs(abs(flt(self.total_qty)) - abs(flt(row_qty))) > 0.0001:
+			frappe.throw(
+				_(
+					"Total quantity {0} in the inventory dimensions does not match the row quantity {1}."
+				).format(frappe.bold(self.total_qty), frappe.bold(row_qty))
+			)
+
+	def set_inventory_dimension_values(self, parent_doc, row, qty_field="qty", warehouse=None):
+		"""Stamp the linked transaction's references onto the bundle and submit it.
+
+		Mirrors ``Serial and Batch Bundle.set_serial_and_batch_values``. Called from the
+		transaction controllers on submit for stock-item rows that carry an inventory
+		dimension bundle. ``warehouse`` is passed for the rejected-qty bundle so it posts against
+		the rejected warehouse; otherwise it is derived from the row.
+		"""
+		from erpnext.stock.doctype.serial_and_batch_bundle.serial_and_batch_bundle import (
+			combine_datetime,
+			get_type_of_transaction,
+		)
+
+		self.voucher_type = parent_doc.doctype
+		self.voucher_no = parent_doc.name
+		self.voucher_detail_no = row.name
+		self.item_code = row.item_code
+		self.company = parent_doc.company
+
+		# The voucher is authoritative for direction (it knows returns, transfers, etc.); overwrite
+		# any direction inferred while the bundle was a manually created draft.
+		self.type_of_transaction = get_type_of_transaction(parent_doc, row)
+
+		if warehouse:
+			self.warehouse = warehouse
+		else:
+			# Derive by direction so a transfer's outward leg posts against the source warehouse
+			# (the inward leg gets its own bundle via make_inventory_dimension_bundle_for_transfer).
+			self.warehouse = self.get_voucher_warehouse(row)
+
+		if parent_doc.get("posting_date"):
+			self.posting_datetime = combine_datetime(
+				parent_doc.get("posting_date"), parent_doc.get("posting_time")
+			)
+
+		self.calculate_total_qty()
+		self.validate_total_qty_against_voucher(flt(row.get(qty_field)))
+
+		if self.docstatus == 0:
+			self.flags.ignore_permissions = True
+			# The voucher owns the bundle's lifecycle; authorise this submit (manual submit is blocked).
+			self.flags.from_voucher = True
+			self.submit()
+
+	def get_voucher_warehouse(self, row):
+		"""The warehouse this bundle posts against, by direction.
+
+		An outward leg posts against the source warehouse and an inward leg against the target, so a
+		two-legged Stock Entry transfer resolves each side correctly.
+		"""
+		if self.type_of_transaction == "Outward":
+			return row.get("warehouse") or row.get("s_warehouse") or row.get("t_warehouse")
+		return row.get("warehouse") or row.get("t_warehouse") or row.get("s_warehouse")
+
+
+def make_inventory_dimension_bundle_for_transfer(source_bundle, warehouse, parent_doc, voucher_detail_no):
+	"""Build (and submit) the inward Inventory Dimension Bundle for a transfer's target leg.
+
+	A material transfer / Send to Subcontractor moves a row's qty out of the source warehouse and
+	into the target warehouse, producing two Stock Ledger Entries. The row carries one (outward)
+	bundle for the source leg; the target leg needs its own inward bundle, posting the same
+	dimension split into the target warehouse. Mirrors Serial and Batch Bundle's
+	``make_bundle_for_material_transfer``.
+	"""
+	from erpnext.stock.doctype.serial_and_batch_bundle.serial_and_batch_bundle import combine_datetime
+
+	doc = frappe.copy_doc(frappe.get_doc("Inventory Dimension Bundle", source_bundle))
+	doc.docstatus = 0
+	doc.warehouse = warehouse
+	doc.type_of_transaction = "Inward"
+	doc.voucher_type = parent_doc.doctype
+	doc.voucher_no = parent_doc.name
+	doc.voucher_detail_no = voucher_detail_no
+	doc.is_cancelled = 0
+
+	if parent_doc.get("posting_date"):
+		doc.posting_datetime = combine_datetime(
+			parent_doc.get("posting_date"), parent_doc.get("posting_time")
+		)
+
+	for entry in doc.entries:
+		entry.warehouse = warehouse
+		entry.is_outward = 0
+		entry.qty = abs(flt(entry.qty))
+		entry.is_cancelled = 0
+
+	doc.flags.ignore_permissions = True
+	doc.flags.from_voucher = True
+	doc.submit()
+	return doc.name
+
+
+def get_inventory_dimension_bundle_naming_series():
+	return "IDB-.########"
+
+
+def get_dimension_sub_ledger_balance(
+	item_code: str,
+	warehouse: str,
+	dimension_filters: dict | None = None,
+	posting_datetime=None,
+	company: str | None = None,
+	inclusive: bool = False,
+	exclude_bundle: str | None = None,
+) -> float:
+	"""Net quantity balance for an item/warehouse (and optional dimension combination).
+
+	The Inventory Dimension Entry rows are the quantity sub-ledger. Inward entries add,
+	outward entries subtract. Pass ``dimension_filters`` (``{source_fieldname: value}``) to
+	restrict to a specific dimension combination. ``posting_datetime`` caps the cutoff:
+	``inclusive=False`` (default) counts entries strictly before it (balance *before* a posting);
+	``inclusive=True`` counts entries up to and including it (balance *as of* a date).
+	"""
+	entry = frappe.qb.DocType("Inventory Dimension Entry")
+	query = (
+		frappe.qb.from_(entry)
+		# qty is stored signed (negative for outward), so the net balance is a plain sum.
+		.select(Sum(entry.qty))
+		.where(
+			(entry.item_code == item_code)
+			& (entry.warehouse == warehouse)
+			& (entry.is_cancelled == 0)
+			# Only submitted bundles form the sub-ledger; draft bundles (e.g. a dialog draft or a
+			# bundle whose voucher failed to submit) must never count toward a balance.
+			& (entry.docstatus == 1)
+		)
+	)
+
+	if company:
+		bundle = frappe.qb.DocType("Inventory Dimension Bundle")
+		query = query.join(bundle).on(entry.parent == bundle.name).where(bundle.company == company)
+
+	if posting_datetime:
+		if inclusive:
+			query = query.where(entry.posting_datetime <= posting_datetime)
+		else:
+			query = query.where(entry.posting_datetime < posting_datetime)
+
+	if exclude_bundle:
+		query = query.where(entry.parent != exclude_bundle)
+
+	for fieldname, value in (dimension_filters or {}).items():
+		query = query.where(entry[fieldname] == value)
+
+	result = query.run()
+	return flt(result[0][0]) if result and result[0][0] is not None else 0.0
+
+
+@frappe.whitelist()
+def get_dimensions_for_selector(child_doctype: str) -> list:
+	"""Dimensions (with their reference doctype + fieldname) that apply to a child doctype.
+
+	Drives the dimension capture dialog: one Link column per dimension + a qty column.
+	"""
+	from erpnext.stock.doctype.inventory_dimension.inventory_dimension import (
+		get_document_wise_inventory_dimensions,
+	)
+
+	dimensions = get_document_wise_inventory_dimensions(child_doctype) or []
+	result = []
+	for dimension in dimensions:
+		result.append(
+			{
+				"dimension": dimension.get("name"),
+				"fieldname": dimension.get("source_fieldname"),
+				"reference_document": dimension.get("reference_document"),
+				"reqd": dimension.get("reqd"),
+			}
+		)
+
+	return result
+
+
+@frappe.whitelist()
+def get_inventory_dimension_bundle_entries(bundle: str) -> list:
+	"""Return an existing bundle's entries (qty + dimension values) to pre-fill the capture dialog."""
+	from erpnext.stock.doctype.inventory_dimension.inventory_dimension import get_inventory_dimensions
+
+	if not bundle or not frappe.db.exists("Inventory Dimension Bundle", bundle):
+		return []
+
+	frappe.has_permission("Inventory Dimension Bundle", "read", bundle, throw=True)
+
+	dimension_fields = [
+		d.source_fieldname
+		for d in get_inventory_dimensions()
+		if d.source_fieldname and frappe.db.has_column("Inventory Dimension Entry", d.source_fieldname)
+	]
+
+	return frappe.get_all(
+		"Inventory Dimension Entry",
+		filters={"parent": bundle},
+		fields=["qty", *dimension_fields],
+		order_by="idx",
+	)
+
+
+@frappe.whitelist()
+def create_inventory_dimension_bundle(
+	company: str,
+	item_code: str,
+	warehouse: str | None = None,
+	type_of_transaction: str | None = None,
+	voucher_type: str | None = None,
+	entries: str | list | None = None,
+	bundle: str | None = None,
+):
+	"""Create (or replace) a draft Inventory Dimension Bundle from dialog input.
+
+	Dimension values are written only to Entry fields that actually exist (the per-dimension
+	columns are added in Phase 3), so this is safe to call before that migration runs.
+	"""
+	if isinstance(entries, str):
+		entries = frappe.parse_json(entries)
+	entries = entries or []
+
+	if bundle and frappe.db.exists("Inventory Dimension Bundle", bundle):
+		doc = frappe.get_doc("Inventory Dimension Bundle", bundle)
+		if doc.docstatus == 0:
+			doc.set("entries", [])
+	else:
+		doc = frappe.new_doc("Inventory Dimension Bundle")
+
+	doc.company = company
+	doc.item_code = item_code
+	doc.warehouse = warehouse
+	doc.type_of_transaction = type_of_transaction
+	doc.voucher_type = voucher_type
+
+	entry_meta_fields = {df.fieldname for df in frappe.get_meta("Inventory Dimension Entry").fields}
+	for entry in entries:
+		row = {"qty": flt(entry.get("qty")), "warehouse": entry.get("warehouse") or warehouse}
+		for key, value in entry.items():
+			if key in entry_meta_fields and key not in ("qty", "warehouse"):
+				row[key] = value
+		doc.append("entries", row)
+
+	# Permission alread handled
+	doc.save()
+	return doc.name

--- a/erpnext/stock/doctype/inventory_dimension_bundle/test_inventory_dimension_bundle.py
+++ b/erpnext/stock/doctype/inventory_dimension_bundle/test_inventory_dimension_bundle.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and Contributors
+# See license.txt
+
+from erpnext.tests.utils import ERPNextTestSuite
+
+
+class TestInventoryDimensionBundle(ERPNextTestSuite):
+	pass

--- a/erpnext/stock/doctype/inventory_dimension_entry/inventory_dimension_entry.json
+++ b/erpnext/stock/doctype/inventory_dimension_entry/inventory_dimension_entry.json
@@ -1,0 +1,117 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2026-06-19 00:00:00.000000",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "qty",
+  "is_outward",
+  "warehouse",
+  "column_break_dim",
+  "item_code",
+  "section_break_ref",
+  "voucher_type",
+  "voucher_no",
+  "voucher_detail_no",
+  "column_break_ref",
+  "posting_datetime",
+  "is_cancelled"
+ ],
+ "fields": [
+  {
+   "columns": 2,
+   "fieldname": "qty",
+   "fieldtype": "Float",
+   "in_list_view": 1,
+   "label": "Qty"
+  },
+  {
+   "default": "0",
+   "fieldname": "is_outward",
+   "fieldtype": "Check",
+   "label": "Is Outward",
+   "no_copy": 1
+  },
+  {
+   "fieldname": "warehouse",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Warehouse",
+   "options": "Warehouse"
+  },
+  {
+   "fieldname": "column_break_dim",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "item_code",
+   "fieldtype": "Link",
+   "label": "Item Code",
+   "options": "Item",
+   "search_index": 1
+  },
+  {
+   "fieldname": "section_break_ref",
+   "fieldtype": "Section Break",
+   "label": "Reference"
+  },
+  {
+   "fieldname": "voucher_type",
+   "fieldtype": "Data",
+   "label": "Voucher Type",
+   "no_copy": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "voucher_no",
+   "fieldtype": "Data",
+   "label": "Voucher No",
+   "no_copy": 1,
+   "read_only": 1,
+   "search_index": 1
+  },
+  {
+   "fieldname": "voucher_detail_no",
+   "fieldtype": "Data",
+   "label": "Voucher Detail No",
+   "no_copy": 1,
+   "read_only": 1,
+   "search_index": 1
+  },
+  {
+   "fieldname": "column_break_ref",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "posting_datetime",
+   "fieldtype": "Datetime",
+   "label": "Posting Datetime",
+   "no_copy": 1,
+   "read_only": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "is_cancelled",
+   "fieldtype": "Check",
+   "label": "Is Cancelled",
+   "no_copy": 1,
+   "read_only": 1
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2026-06-19 00:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "Stock",
+ "name": "Inventory Dimension Entry",
+ "owner": "Administrator",
+ "permissions": [],
+ "row_format": "Dynamic",
+ "sort_field": "creation",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/erpnext/stock/doctype/inventory_dimension_entry/inventory_dimension_entry.py
+++ b/erpnext/stock/doctype/inventory_dimension_entry/inventory_dimension_entry.py
@@ -1,0 +1,30 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt
+
+from frappe.model.document import Document
+
+
+class InventoryDimensionEntry(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		is_cancelled: DF.Check
+		is_outward: DF.Check
+		item_code: DF.Link | None
+		parent: DF.Data
+		parentfield: DF.Data
+		parenttype: DF.Data
+		posting_datetime: DF.Datetime | None
+		qty: DF.Float
+		voucher_detail_no: DF.Data | None
+		voucher_no: DF.Data | None
+		voucher_type: DF.Data | None
+		warehouse: DF.Link | None
+	# end: auto-generated types
+
+	pass

--- a/erpnext/stock/doctype/inventory_dimension_entry/inventory_dimension_entry.py
+++ b/erpnext/stock/doctype/inventory_dimension_entry/inventory_dimension_entry.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
 # For license information, please see license.txt
 
+import frappe
 from frappe.model.document import Document
 
 
@@ -28,3 +29,17 @@ class InventoryDimensionEntry(Document):
 	# end: auto-generated types
 
 	pass
+
+
+def on_doctype_update():
+	"""Composite indexes for the quantity sub-ledger, mirroring Stock Ledger Entry.
+
+	The sub-ledger is read like the SLE: per item + warehouse balances over time (reporting,
+	opening balances, negative-stock checks) and voucher-scoped lookups. At million-row scale a
+	single composite index on each access path keeps these from degrading into full scans. Frappe
+	runs this on every ``bench migrate`` and on install; ``add_index`` is idempotent.
+	"""
+	frappe.db.add_index(
+		"Inventory Dimension Entry", ["item_code", "warehouse", "posting_datetime", "creation"]
+	)
+	frappe.db.add_index("Inventory Dimension Entry", ["voucher_no", "voucher_type"])

--- a/erpnext/stock/doctype/packed_item/packed_item.json
+++ b/erpnext/stock/doctype/packed_item/packed_item.json
@@ -31,6 +31,9 @@
   "column_break_qlha",
   "batch_no",
   "actual_batch_qty",
+  "inventory_dimension_section",
+  "add_inventory_dimension",
+  "inventory_dimension_bundle",
   "section_break_13",
   "actual_qty",
   "projected_qty",
@@ -287,6 +290,27 @@
    "print_hide": 1
   },
   {
+   "fieldname": "inventory_dimension_bundle",
+   "fieldtype": "Link",
+   "label": "Inventory Dimension Bundle",
+   "no_copy": 1,
+   "options": "Inventory Dimension Bundle",
+   "print_hide": 1,
+   "search_index": 1
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "inventory_dimension_section",
+   "fieldtype": "Section Break",
+   "label": "Inventory Dimension"
+  },
+  {
+   "depends_on": "eval:parent.docstatus == 0",
+   "fieldname": "add_inventory_dimension",
+   "fieldtype": "Button",
+   "label": "Add Inventory Dimension"
+  },
+  {
    "depends_on": "eval:doc.use_serial_batch_fields === 0 || doc.docstatus === 1",
    "fieldname": "pick_serial_and_batch",
    "fieldtype": "Button",
@@ -338,7 +362,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-06-08 15:00:00.000000",
+ "modified": "2026-06-21 10:00:00.000000",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Packed Item",

--- a/erpnext/stock/doctype/pick_list_item/pick_list_item.json
+++ b/erpnext/stock/doctype/pick_list_item/pick_list_item.json
@@ -35,6 +35,9 @@
   "serial_no",
   "column_break_belw",
   "batch_no",
+  "inventory_dimension_section",
+  "add_inventory_dimension",
+  "inventory_dimension_bundle",
   "column_break_15",
   "sales_order",
   "sales_order_item",
@@ -214,6 +217,27 @@
    "search_index": 1
   },
   {
+   "fieldname": "inventory_dimension_bundle",
+   "fieldtype": "Link",
+   "label": "Inventory Dimension Bundle",
+   "no_copy": 1,
+   "options": "Inventory Dimension Bundle",
+   "print_hide": 1,
+   "search_index": 1
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "inventory_dimension_section",
+   "fieldtype": "Section Break",
+   "label": "Inventory Dimension"
+  },
+  {
+   "depends_on": "eval:parent.docstatus == 0",
+   "fieldname": "add_inventory_dimension",
+   "fieldtype": "Button",
+   "label": "Add Inventory Dimension"
+  },
+  {
    "depends_on": "eval:doc.use_serial_batch_fields === 0 || doc.docstatus === 1",
    "fieldname": "pick_serial_and_batch",
    "fieldtype": "Button",
@@ -285,7 +309,7 @@
  ],
  "istable": 1,
  "links": [],
- "modified": "2026-03-17 16:25:10.358013",
+ "modified": "2026-06-21 10:00:00.000000",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Pick List Item",

--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
@@ -458,6 +458,7 @@ class PurchaseReceipt(BuyingController):
 			"Stock Ledger Entry",
 			"Repost Item Valuation",
 			"Serial and Batch Bundle",
+			"Inventory Dimension Bundle",
 		)
 		self.delete_auto_created_batches()
 		self.set_consumed_qty_in_subcontract_order()

--- a/erpnext/stock/doctype/purchase_receipt_item/purchase_receipt_item.json
+++ b/erpnext/stock/doctype/purchase_receipt_item/purchase_receipt_item.json
@@ -106,6 +106,12 @@
   "rejected_serial_no",
   "column_break_tolu",
   "batch_no",
+  "inventory_dimension_section",
+  "add_inventory_dimension",
+  "inventory_dimension_bundle",
+  "column_break_inv_dim",
+  "add_inventory_dimension_for_rejected_qty",
+  "rejected_inventory_dimension_bundle",
   "item_weight_details",
   "weight_per_unit",
   "total_weight",
@@ -995,6 +1001,46 @@
    "search_index": 1
   },
   {
+   "fieldname": "inventory_dimension_bundle",
+   "fieldtype": "Link",
+   "label": "Inventory Dimension Bundle",
+   "no_copy": 1,
+   "options": "Inventory Dimension Bundle",
+   "print_hide": 1,
+   "search_index": 1
+  },
+  {
+   "fieldname": "column_break_inv_dim",
+   "fieldtype": "Column Break"
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "inventory_dimension_section",
+   "fieldtype": "Section Break",
+   "label": "Inventory Dimension"
+  },
+  {
+   "depends_on": "eval:parent.docstatus == 0",
+   "fieldname": "add_inventory_dimension",
+   "fieldtype": "Button",
+   "label": "Add Inventory Dimension"
+  },
+  {
+   "depends_on": "eval:parent.docstatus == 0",
+   "fieldname": "add_inventory_dimension_for_rejected_qty",
+   "fieldtype": "Button",
+   "label": "Add Inventory Dimension (Rejected Qty)"
+  },
+  {
+   "fieldname": "rejected_inventory_dimension_bundle",
+   "fieldtype": "Link",
+   "label": "Rejected Inventory Dimension Bundle",
+   "no_copy": 1,
+   "options": "Inventory Dimension Bundle",
+   "print_hide": 1,
+   "search_index": 1
+  },
+  {
    "fieldname": "serial_no",
    "fieldtype": "Text",
    "label": "Serial No",
@@ -1122,7 +1168,7 @@
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-06-08 21:00:00.000000",
+ "modified": "2026-06-21 08:46:54.418497",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Purchase Receipt Item",

--- a/erpnext/stock/doctype/purchase_receipt_item/purchase_receipt_item.py
+++ b/erpnext/stock/doctype/purchase_receipt_item/purchase_receipt_item.py
@@ -40,6 +40,7 @@ class PurchaseReceiptItem(Document):
 		from_warehouse: DF.Link | None
 		has_item_scanned: DF.Check
 		image: DF.Attach | None
+		inventory_dimension_bundle: DF.Link | None
 		is_fixed_asset: DF.Check
 		is_free_item: DF.Check
 		item_code: DF.Link
@@ -78,6 +79,7 @@ class PurchaseReceiptItem(Document):
 		rate_with_margin: DF.Currency
 		received_qty: DF.Float
 		received_stock_qty: DF.Float
+		rejected_inventory_dimension_bundle: DF.Link | None
 		rejected_qty: DF.Float
 		rejected_serial_and_batch_bundle: DF.Link | None
 		rejected_serial_no: DF.Text | None

--- a/erpnext/stock/doctype/stock_closing_entry/stock_closing_entry.py
+++ b/erpnext/stock/doctype/stock_closing_entry/stock_closing_entry.py
@@ -162,7 +162,14 @@ class StockClosing:
 		self.from_date = from_date
 		self.to_date = to_date
 		self.kwargs = kwargs
-		self.inv_dimensions = get_inventory_dimensions()
+		# Dimensions are a quantity-only sub-ledger and no longer live on Stock Ledger Entry.
+		# Closing is a valuation snapshot (item + warehouse), so only legacy dimensions that still
+		# have a real SLE column are partitioned here (none after the old columns are dropped).
+		self.inv_dimensions = [
+			dimension
+			for dimension in get_inventory_dimensions()
+			if frappe.db.has_column("Stock Ledger Entry", dimension.fieldname)
+		]
 		self.last_closing_balance = self.get_last_stock_closing_entry()
 
 	def get_stock_closing_entries(self):

--- a/erpnext/stock/doctype/stock_entry/stock_entry.js
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.js
@@ -7,7 +7,7 @@ erpnext.landed_cost_taxes_and_charges.setup_triggers("Stock Entry");
 
 frappe.ui.form.on("Stock Entry", {
 	setup: function (frm) {
-		frm.ignore_doctypes_on_cancel_all = ["Serial and Batch Bundle"];
+		frm.ignore_doctypes_on_cancel_all = ["Serial and Batch Bundle", "Inventory Dimension Bundle"];
 
 		frm.trigger("toggle_enable_for_stock_uom_qty");
 

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -363,6 +363,7 @@ class StockEntry(StockController, SubcontractingInwardController):
 			"Stock Ledger Entry",
 			"Repost Item Valuation",
 			"Serial and Batch Bundle",
+			"Inventory Dimension Bundle",
 		)
 
 		self.make_gl_entries_on_cancel()
@@ -1039,6 +1040,32 @@ class StockEntry(StockController, SubcontractingInwardController):
 				if self.purpose in allowed_types and d.serial_and_batch_bundle and self.docstatus == 1:
 					sle.serial_and_batch_bundle = self.make_package_for_transfer(
 						d.serial_and_batch_bundle, d.t_warehouse
+					)
+
+				# A transfer's inward (target) leg needs its own inward Inventory Dimension Bundle;
+				# the row's bundle covers only the outward (source) leg.
+				if (
+					self.purpose in allowed_types
+					and d.get("inventory_dimension_bundle")
+					and self.docstatus == 1
+				):
+					from erpnext.stock.doctype.inventory_dimension_bundle.inventory_dimension_bundle import (
+						make_inventory_dimension_bundle_for_transfer,
+					)
+
+					sle.inventory_dimension_bundle = make_inventory_dimension_bundle_for_transfer(
+						d.inventory_dimension_bundle, d.t_warehouse, self, d.name
+					)
+				elif sle.get("inventory_dimension_bundle") and self.docstatus == 2:
+					sle.inventory_dimension_bundle = frappe.get_cached_value(
+						"Inventory Dimension Bundle",
+						{
+							"voucher_detail_no": d.name,
+							"voucher_no": self.name,
+							"is_cancelled": 0,
+							"type_of_transaction": "Inward",
+						},
+						"name",
 					)
 
 				if sle.serial_and_batch_bundle and self.docstatus == 2:

--- a/erpnext/stock/doctype/stock_entry_detail/stock_entry_detail.json
+++ b/erpnext/stock/doctype/stock_entry_detail/stock_entry_detail.json
@@ -58,6 +58,9 @@
   "serial_no",
   "column_break_prps",
   "batch_no",
+  "inventory_dimension_section",
+  "add_inventory_dimension",
+  "inventory_dimension_bundle",
   "accounting",
   "expense_account",
   "accounting_dimensions_section",
@@ -600,6 +603,27 @@
    "search_index": 1
   },
   {
+   "fieldname": "inventory_dimension_bundle",
+   "fieldtype": "Link",
+   "label": "Inventory Dimension Bundle",
+   "no_copy": 1,
+   "options": "Inventory Dimension Bundle",
+   "print_hide": 1,
+   "search_index": 1
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "inventory_dimension_section",
+   "fieldtype": "Section Break",
+   "label": "Inventory Dimension"
+  },
+  {
+   "depends_on": "eval:parent.docstatus == 0",
+   "fieldname": "add_inventory_dimension",
+   "fieldtype": "Button",
+   "label": "Add Inventory Dimension"
+  },
+  {
    "default": "0",
    "fieldname": "use_serial_batch_fields",
    "fieldtype": "Check",
@@ -679,7 +703,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-06-01 10:00:00.000000",
+ "modified": "2026-06-21 10:00:00.000000",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Stock Entry Detail",

--- a/erpnext/stock/doctype/stock_ledger_entry/stock_ledger_entry.json
+++ b/erpnext/stock/doctype/stock_ledger_entry/stock_ledger_entry.json
@@ -20,6 +20,7 @@
   "voucher_no",
   "voucher_detail_no",
   "serial_and_batch_bundle",
+  "inventory_dimension_bundle",
   "dependant_sle_voucher_detail_no",
   "section_break_11",
   "recalculate_rate",
@@ -323,6 +324,15 @@
    "search_index": 1
   },
   {
+   "fieldname": "inventory_dimension_bundle",
+   "fieldtype": "Link",
+   "label": "Inventory Dimension Bundle",
+   "no_copy": 1,
+   "options": "Inventory Dimension Bundle",
+   "print_hide": 1,
+   "search_index": 1
+  },
+  {
    "default": "0",
    "fetch_from": "item_code.has_batch_no",
    "fieldname": "has_batch_no",
@@ -363,7 +373,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2026-05-26 19:07:43.537450",
+ "modified": "2026-06-23 19:07:43.537450",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Stock Ledger Entry",

--- a/erpnext/stock/doctype/stock_ledger_entry/stock_ledger_entry.py
+++ b/erpnext/stock/doctype/stock_ledger_entry/stock_ledger_entry.py
@@ -13,7 +13,6 @@ from frappe.utils import add_days, cint, flt, formatdate, get_datetime, getdate
 
 from erpnext.accounts.utils import get_fiscal_year
 from erpnext.controllers.item_variant import ItemTemplateCannotHaveStock
-from erpnext.stock.doctype.inventory_dimension.inventory_dimension import get_inventory_dimensions
 from erpnext.stock.serial_batch_bundle import SerialBatchBundle
 
 
@@ -22,10 +21,6 @@ class StockFreezeError(frappe.ValidationError):
 
 
 class BackDatedStockTransaction(frappe.ValidationError):
-	pass
-
-
-class InventoryDimensionNegativeStockError(frappe.ValidationError):
 	pass
 
 
@@ -96,80 +91,11 @@ class StockLedgerEntry(Document):
 		self.validate_and_set_fiscal_year()
 		self.block_transactions_against_group_warehouse()
 		self.validate_with_last_transaction_posting_time()
-		self.validate_inventory_dimension_negative_stock()
 
 	def set_posting_datetime(self):
 		from erpnext.stock.utils import get_combine_datetime
 
 		self.posting_datetime = get_combine_datetime(self.posting_date, self.posting_time)
-
-	def validate_inventory_dimension_negative_stock(self):
-		if self.is_cancelled or self.actual_qty >= 0:
-			return
-
-		dimensions = self._get_inventory_dimensions()
-		if not dimensions:
-			return
-
-		flt_precision = cint(frappe.db.get_default("float_precision")) or 2
-		available_qty = self.get_available_qty_after_prev_transaction(dimensions)
-
-		diff = flt(available_qty + flt(self.actual_qty), flt_precision)  # qty after current transaction
-		if diff < 0 and abs(diff) > 0.0001:
-			self.throw_validation_error(diff, dimensions)
-
-	def get_available_qty_after_prev_transaction(self, dimensions):
-		sle = frappe.qb.DocType("Stock Ledger Entry")
-		available_qty_query = (
-			frappe.qb.from_(sle)
-			.select(Sum(sle.actual_qty))
-			.where(
-				(sle.item_code == self.item_code)
-				& (sle.warehouse == self.warehouse)
-				& (sle.posting_datetime < self.posting_datetime)
-				& (sle.company == self.company)
-				& (sle.is_cancelled == 0)
-			)
-		)
-
-		for dimension, values in dimensions.items():
-			dimension_value = values.get("value")
-			available_qty_query = available_qty_query.where(sle[dimension] == dimension_value)
-
-		available_qty = available_qty_query.run()
-
-		return available_qty[0][0] or 0
-
-	def throw_validation_error(self, diff, dimensions):
-		msg = _(
-			"{0} units of {1} are required in {2} with the inventory dimension: {3} on {4} {5} for {6} to complete the transaction."
-		).format(
-			abs(diff),
-			frappe.get_desk_link("Item", self.item_code),
-			frappe.get_desk_link("Warehouse", self.warehouse),
-			frappe.bold(
-				", ".join([f"{dimension}: {values.get('value')}" for dimension, values in dimensions.items()])
-			),
-			self.posting_date,
-			self.posting_time,
-			frappe.get_desk_link(self.voucher_type, self.voucher_no),
-		)
-
-		frappe.throw(
-			msg, title=_("Inventory Dimension Negative Stock"), exc=InventoryDimensionNegativeStockError
-		)
-
-	def _get_inventory_dimensions(self):
-		inv_dimensions = get_inventory_dimensions()
-		inv_dimension_dict = {}
-		for dimension in inv_dimensions:
-			if not dimension.get("validate_negative_stock") or not self.get(dimension.fieldname):
-				continue
-
-			dimension["value"] = self.get(dimension.fieldname)
-			inv_dimension_dict.setdefault(dimension.fieldname, dimension)
-
-		return inv_dimension_dict
 
 	def on_submit(self):
 		self.check_stock_frozen_date()
@@ -190,6 +116,72 @@ class StockLedgerEntry(Document):
 			)
 
 		self.validate_serial_batch_no_bundle()
+		self.validate_inventory_dimension_bundle()
+
+	def validate_inventory_dimension_bundle(self):
+		from erpnext.stock.doctype.inventory_dimension.inventory_dimension import (
+			is_inventory_dimension_enabled,
+		)
+
+		if self.is_cancelled or not is_inventory_dimension_enabled():
+			return
+
+		if self.inventory_dimension_bundle:
+			self.validate_unique_inventory_dimension_bundle()
+		else:
+			self.validate_mandatory_inventory_dimension()
+
+	def validate_mandatory_inventory_dimension(self):
+		"""Require an Inventory Dimension Bundle when a mandatory dimension applies to the item.
+
+		Mirrors the serial/batch bundle requirement: if the voucher's item rows have an applicable
+		mandatory inventory dimension, the resulting Stock Ledger Entry must carry the bundle.
+		Conditional dimensions are skipped here (the condition needs the source row); they are
+		enforced at the voucher level.
+		"""
+		from erpnext.stock.doctype.inventory_dimension.inventory_dimension import (
+			get_mandatory_inventory_dimensions,
+			get_voucher_child_doctype,
+		)
+
+		child_doctype = get_voucher_child_doctype(self.voucher_type)
+		mandatory = [d for d in get_mandatory_inventory_dimensions(child_doctype) if not d.get("condition")]
+		if not mandatory:
+			return
+
+		names = ", ".join(frappe.bold(d.get("name")) for d in mandatory)
+		self.throw_error_message(
+			_(
+				"Inventory Dimension {0} is mandatory for Item {1}. Please set the Inventory Dimension Bundle."
+			).format(names, self.item_code)
+		)
+
+	def validate_unique_inventory_dimension_bundle(self):
+		"""An Inventory Dimension Bundle records the dimension split for a single voucher.
+
+		It must not be shared with the stock ledger of a different voucher, which would double-count
+		the quantity sub-ledger. The two legs of a transfer (source + target) share one bundle, so
+		only a *different* voucher is rejected.
+		"""
+		sle = frappe.qb.DocType("Stock Ledger Entry")
+		existing = (
+			frappe.qb.from_(sle)
+			.select(sle.voucher_type, sle.voucher_no)
+			.where(
+				(sle.inventory_dimension_bundle == self.inventory_dimension_bundle)
+				& (sle.name != self.name)
+				& (sle.is_cancelled == 0)
+				& ((sle.voucher_no != self.voucher_no) | (sle.voucher_type != self.voucher_type))
+			)
+			.limit(1)
+		).run()
+
+		if existing:
+			self.throw_error_message(
+				_("Inventory Dimension Bundle {0} is already linked to {1} {2}.").format(
+					self.inventory_dimension_bundle, existing[0][0], existing[0][1]
+				)
+			)
 
 	def validate_mandatory(self):
 		mandatory = ["warehouse", "posting_date", "voucher_type", "voucher_no", "company"]

--- a/erpnext/stock/doctype/stock_ledger_entry/stock_ledger_entry.py
+++ b/erpnext/stock/doctype/stock_ledger_entry/stock_ledger_entry.py
@@ -126,6 +126,12 @@ class StockLedgerEntry(Document):
 		if self.is_cancelled or not is_inventory_dimension_enabled():
 			return
 
+		# Skip mandatory enforcement while a patch is backfilling/reposting the ledger: historical SLEs
+		# may predate the dimension or legitimately carry no bundle, and a throw would abort the migrate.
+		# Mirrors the guards in InventoryDimensionBundle.validate_mandatory_dimensions / validate_negative_stock.
+		if frappe.flags.in_patch:
+			return
+
 		if self.inventory_dimension_bundle:
 			self.validate_unique_inventory_dimension_bundle()
 		else:

--- a/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.js
+++ b/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.js
@@ -6,7 +6,7 @@ frappe.provide("erpnext.accounts.dimensions");
 
 frappe.ui.form.on("Stock Reconciliation", {
 	setup(frm) {
-		frm.ignore_doctypes_on_cancel_all = ["Serial and Batch Bundle"];
+		frm.ignore_doctypes_on_cancel_all = ["Serial and Batch Bundle", "Inventory Dimension Bundle"];
 		frm.barcode_scanner = new erpnext.utils.BarcodeScanner({
 			frm: frm,
 			uom_field: "stock_uom",

--- a/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py
+++ b/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py
@@ -101,15 +101,17 @@ class StockReconciliation(StockController):
 		self.set_serial_and_batch_bundle(ignore_validate=True)
 
 	def validate_inventory_dimension(self):
-		dimensions = get_inventory_dimensions()
-		for dimension in dimensions:
-			for row in self.items:
-				if not row.batch_no and row.current_qty and row.get(dimension.get("source_fieldname")):
-					frappe.throw(
-						_(
-							"Row #{0}: You cannot use the inventory dimension '{1}' in Stock Reconciliation to modify the quantity or valuation rate. Stock reconciliation with inventory dimensions is intended solely for performing opening entries."
-						).format(row.idx, bold(dimension.get("doctype")))
-					)
+		if not get_inventory_dimensions():
+			return
+
+		# Dimension values now live in the Inventory Dimension Bundle linked to the row.
+		for row in self.items:
+			if not row.batch_no and row.current_qty and row.get("inventory_dimension_bundle"):
+				frappe.throw(
+					_(
+						"Row #{0}: You cannot use inventory dimensions in Stock Reconciliation to modify the quantity or valuation rate. Stock reconciliation with inventory dimensions is intended solely for performing opening entries."
+					).format(row.idx)
+				)
 
 	def on_submit(self):
 		self.make_bundle_for_current_qty()
@@ -125,6 +127,7 @@ class StockReconciliation(StockController):
 			"Stock Ledger Entry",
 			"Repost Item Valuation",
 			"Serial and Batch Bundle",
+			"Inventory Dimension Bundle",
 		)
 		self.make_sle_on_cancel()
 		self.make_gl_entries_on_cancel()
@@ -604,9 +607,10 @@ class StockReconciliation(StockController):
 				if row.get(field):
 					key.append(row.get(field))
 
-			for dimension in get_inventory_dimensions():
-				if row.get(dimension.get("fieldname")):
-					key.append(row.get(dimension.get("fieldname")))
+			# Inventory dimension values now live on the row's Inventory Dimension Bundle, so the
+			# bundle distinguishes otherwise-identical item/warehouse rows (one per dimension split).
+			if row.get("inventory_dimension_bundle"):
+				key.append(row.get("inventory_dimension_bundle"))
 
 			if key in item_warehouse_combinations:
 				self.validation_messages.append(
@@ -881,6 +885,7 @@ class StockReconciliation(StockController):
 				"stock_uom": frappe.db.get_value("Item", row.item_code, "stock_uom"),
 				"is_cancelled": 1 if self.docstatus == 2 else 0,
 				"valuation_rate": flt(row.valuation_rate),
+				"inventory_dimension_bundle": row.get("inventory_dimension_bundle"),
 			}
 		)
 
@@ -913,10 +918,6 @@ class StockReconciliation(StockController):
 			data.actual_qty = row.qty
 			data.qty_after_transaction = 0.0
 			data.incoming_rate = flt(row.valuation_rate)
-
-		from erpnext.stock.services.stock_ledger_service import StockLedgerService
-
-		StockLedgerService(self).update_inventory_dimensions(row, data)
 
 		return data
 

--- a/erpnext/stock/doctype/stock_reconciliation/test_stock_reconciliation.py
+++ b/erpnext/stock/doctype/stock_reconciliation/test_stock_reconciliation.py
@@ -1708,49 +1708,54 @@ class TestStockReconciliation(ERPNextTestSuite, StockTestMixin):
 	def test_stock_reco_with_opening_stock_with_diff_inventory(self):
 		from erpnext.stock.doctype.inventory_dimension.test_inventory_dimension import (
 			create_inventory_dimension,
+			make_inventory_dimension_bundle,
+			reset_inventory_dimension_flags,
+		)
+		from erpnext.stock.doctype.inventory_dimension_bundle.inventory_dimension_bundle import (
+			get_dimension_sub_ledger_balance,
 		)
 
-		if frappe.db.exists("DocType", "Plant"):
-			return
+		# Inventory Dimensions are gated behind a feature flag; enable it for this test only.
+		frappe.flags.enable_inventory_dimension = 1
+		self.addCleanup(frappe.flags.pop, "enable_inventory_dimension", None)
 
-		doctype = frappe.get_doc(
-			{
-				"doctype": "DocType",
-				"name": "Plant",
-				"module": "Stock",
-				"custom": 1,
-				"fields": [
-					{
-						"fieldname": "plant_name",
-						"fieldtype": "Data",
-						"label": "Plant Name",
-						"reqd": 1,
-					}
-				],
-				"autoname": "field:plant_name",
-			}
-		)
-		doctype.insert(ignore_permissions=True)
+		# Inventory Dimension records are committed via Custom Field DDL, so a sibling test's
+		# mandatory (reqd) dimension can leak in and impose itself on this test. Neutralise those
+		# flags for this run (rolled back at teardown).
+		reset_inventory_dimension_flags()
+
+		if not frappe.db.exists("DocType", "Plant"):
+			frappe.get_doc(
+				{
+					"doctype": "DocType",
+					"name": "Plant",
+					"module": "Stock",
+					"custom": 1,
+					"fields": [
+						{
+							"fieldname": "plant_name",
+							"fieldtype": "Data",
+							"label": "Plant Name",
+							"reqd": 1,
+						}
+					],
+					"autoname": "field:plant_name",
+				}
+			).insert(ignore_permissions=True)
+
 		create_inventory_dimension(dimension_name="ID-Plant", reference_document="Plant")
 
-		plant_a = frappe.get_doc(
-			{
-				"doctype": "Plant",
-				"plant_name": "Plant A",
-			}
-		).insert(ignore_permissions=True)
-
-		plant_b = frappe.get_doc(
-			{
-				"doctype": "Plant",
-				"plant_name": "Plant B",
-			}
-		).insert(ignore_permissions=True)
+		for plant in ["Plant A", "Plant B"]:
+			if not frappe.db.exists("Plant", plant):
+				frappe.get_doc({"doctype": "Plant", "plant_name": plant}).insert(ignore_permissions=True)
 
 		warehouse = "_Test Warehouse - _TC"
-
 		item_code = "Item-Test"
 		item = self.make_item(item_code, {"is_stock_item": 1})
+
+		# The dimension split for each row is captured in its own Inventory Dimension Bundle.
+		bundle_a = make_inventory_dimension_bundle(item.name, warehouse, [{"qty": 5, "id_plant": "Plant A"}])
+		bundle_b = make_inventory_dimension_bundle(item.name, warehouse, [{"qty": 3, "id_plant": "Plant B"}])
 
 		sr = frappe.new_doc("Stock Reconciliation")
 		sr.purpose = "Opening Stock"
@@ -1765,10 +1770,9 @@ class TestStockReconciliation(ERPNextTestSuite, StockTestMixin):
 				"warehouse": warehouse,
 				"qty": 5,
 				"valuation_rate": 100,
-				"id_plant": plant_a.name,
+				"inventory_dimension_bundle": bundle_a,
 			},
 		)
-
 		sr.append(
 			"items",
 			{
@@ -1776,7 +1780,7 @@ class TestStockReconciliation(ERPNextTestSuite, StockTestMixin):
 				"warehouse": warehouse,
 				"qty": 3,
 				"valuation_rate": 110,
-				"id_plant": plant_b.name,
+				"inventory_dimension_bundle": bundle_b,
 			},
 		)
 
@@ -1784,21 +1788,16 @@ class TestStockReconciliation(ERPNextTestSuite, StockTestMixin):
 		sr.submit()
 
 		self.assertEqual(len(sr.items), 2)
-		sle_count = frappe.db.count(
-			"Stock Ledger Entry",
-			{"voucher_type": "Stock Reconciliation", "voucher_no": sr.name, "is_cancelled": 0},
+
+		# Each dimension value's quantity lives on the sub-ledger.
+		self.assertEqual(
+			get_dimension_sub_ledger_balance(item.name, warehouse, {"id_plant": "Plant A"}, inclusive=True),
+			5,
 		)
-		self.assertEqual(sle_count, 2)
-		sle = frappe.get_all(
-			"Stock Ledger Entry",
-			{"voucher_type": "Stock Reconciliation", "voucher_no": sr.name, "is_cancelled": 0},
-			["item_code", "id_plant", "actual_qty", "valuation_rate"],
+		self.assertEqual(
+			get_dimension_sub_ledger_balance(item.name, warehouse, {"id_plant": "Plant B"}, inclusive=True),
+			3,
 		)
-		for s in sle:
-			if s.id_plant == plant_a.name:
-				self.assertEqual(s.actual_qty, 5)
-			elif s.id_plant == plant_b.name:
-				self.assertEqual(s.actual_qty, 3)
 
 	def test_serial_no_status_with_backdated_stock_reco(self):
 		from erpnext.stock.doctype.delivery_note.test_delivery_note import create_delivery_note

--- a/erpnext/stock/doctype/stock_reconciliation_item/stock_reconciliation_item.json
+++ b/erpnext/stock/doctype/stock_reconciliation_item/stock_reconciliation_item.json
@@ -35,6 +35,9 @@
   "column_break_9",
   "current_valuation_rate",
   "current_serial_no",
+  "inventory_dimension_section",
+  "add_inventory_dimension",
+  "inventory_dimension_bundle",
   "section_break_14",
   "quantity_difference",
   "column_break_16",
@@ -219,6 +222,27 @@
    "search_index": 1
   },
   {
+   "fieldname": "inventory_dimension_bundle",
+   "fieldtype": "Link",
+   "label": "Inventory Dimension Bundle",
+   "no_copy": 1,
+   "options": "Inventory Dimension Bundle",
+   "print_hide": 1,
+   "search_index": 1
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "inventory_dimension_section",
+   "fieldtype": "Section Break",
+   "label": "Inventory Dimension"
+  },
+  {
+   "depends_on": "eval:parent.docstatus == 0",
+   "fieldname": "add_inventory_dimension",
+   "fieldtype": "Button",
+   "label": "Add Inventory Dimension"
+  },
+  {
    "depends_on": "eval:doc.use_serial_batch_fields === 0 || doc.docstatus === 1",
    "fieldname": "current_serial_and_batch_bundle",
    "fieldtype": "Link",
@@ -266,7 +290,7 @@
  "grid_page_length": 50,
  "istable": 1,
  "links": [],
- "modified": "2025-11-20 15:27:13.868179",
+ "modified": "2026-06-21 10:00:00.000000",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Stock Reconciliation Item",

--- a/erpnext/stock/doctype/stock_settings/stock_settings.json
+++ b/erpnext/stock/doctype/stock_settings/stock_settings.json
@@ -86,7 +86,9 @@
   "section_break_kcvr",
   "role_allowed_to_create_edit_back_dated_transactions",
   "document_naming_tab",
-  "transaction_naming_html"
+  "transaction_naming_html",
+  "inventory_dimension_tab",
+  "enable_inventory_dimension"
  ],
  "fields": [
   {
@@ -595,6 +597,18 @@
   {
    "fieldname": "section_break_kcvr",
    "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "inventory_dimension_tab",
+   "fieldtype": "Tab Break",
+   "label": "Inventory Dimension"
+  },
+  {
+   "default": "0",
+   "description": "Enable to capture inventory dimensions (e.g. rack, shelf, pallet) on stock transactions.",
+   "fieldname": "enable_inventory_dimension",
+   "fieldtype": "Check",
+   "label": "Enable Inventory Dimension"
   }
  ],
  "icon": "icon-cog",
@@ -602,7 +616,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2026-06-13 12:38:02.202183",
+ "modified": "2026-06-22 12:38:02.202183",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Stock Settings",

--- a/erpnext/stock/report/stock_balance/stock_balance.py
+++ b/erpnext/stock/report/stock_balance/stock_balance.py
@@ -9,7 +9,7 @@ from typing import Any, TypedDict
 import frappe
 from frappe import _
 from frappe.query_builder.functions import Coalesce, Count
-from frappe.utils import add_days, cint, date_diff, flt, getdate
+from frappe.utils import add_days, cint, date_diff, flt, get_datetime, getdate
 from frappe.utils.nestedset import get_descendants_of
 
 import erpnext
@@ -72,6 +72,7 @@ class StockBalanceReport:
 		self.prepare_sle_query()
 		self.prepare_item_warehouse_map_for_current_period()
 		self.prepare_new_data()
+		self.add_dimension_wise_stock()
 
 		if not self.columns:
 			self.columns = self.get_columns()
@@ -328,6 +329,147 @@ class StockBalanceReport:
 				continue
 
 			self.data.append(report_data)
+
+	def add_dimension_wise_stock(self):
+		"""Expand each item/warehouse row into per-dimension rows from the qty-only sub-ledger.
+
+		Inventory dimensions no longer live on Stock Ledger Entry; their quantity split is recorded
+		on Inventory Dimension Entry (the sub-ledger). Since that sub-ledger is qty-only, each
+		dimension row's value is derived from the item/warehouse valuation rate, and any qty/value
+		not captured against a dimension is reconciled into a single residual row so the report
+		totals still match the non-dimension view.
+		"""
+		from erpnext.stock.doctype.inventory_dimension.inventory_dimension import (
+			is_inventory_dimension_enabled,
+		)
+
+		if not self.filters.get("show_dimension_wise_stock") or not is_inventory_dimension_enabled():
+			return
+
+		dimensions = self.get_sub_ledger_dimensions()
+		if not dimensions or not self.data:
+			return
+
+		balances = self.get_dimension_sub_ledger_balances(dimensions)
+		if not balances:
+			return
+
+		expanded = []
+		for row in self.data:
+			combos = balances.get((row.item_code, row.warehouse))
+			if not combos:
+				expanded.append(row)
+				continue
+
+			expanded.extend(self.build_dimension_rows(row, combos, dimensions))
+
+		self.data = expanded
+
+	def get_sub_ledger_dimensions(self) -> list:
+		"""Dimensions whose value column exists on Inventory Dimension Entry, with the report column
+		(``target``) and sub-ledger column (``source``) fieldnames."""
+		entry_doctype = "Inventory Dimension Entry"
+		dimensions = []
+		for dimension in get_inventory_dimensions():
+			if dimension.source_fieldname and frappe.db.has_column(entry_doctype, dimension.source_fieldname):
+				dimensions.append(frappe._dict(source=dimension.source_fieldname, target=dimension.fieldname))
+
+		return dimensions
+
+	def get_dimension_sub_ledger_balances(self, dimensions) -> dict:
+		"""Net qty per (item, warehouse, dimension-combination) split into opening / in / out / balance."""
+		item_codes = list({row.item_code for row in self.data})
+		warehouses = list({row.warehouse for row in self.data})
+		if not item_codes or not warehouses:
+			return {}
+
+		entry = frappe.qb.DocType("Inventory Dimension Entry")
+		query = (
+			frappe.qb.from_(entry)
+			.select(entry.item_code, entry.warehouse, entry.qty, entry.posting_datetime)
+			.where((entry.is_cancelled == 0) & (entry.docstatus == 1))
+			.where(entry.item_code.isin(item_codes))
+			.where(entry.warehouse.isin(warehouses))
+			.where(entry.posting_datetime <= get_datetime(f"{self.to_date} 23:59:59"))
+		)
+
+		for dimension in dimensions:
+			query = query.select(entry[dimension.source])
+
+		if company := self.filters.get("company"):
+			bundle = frappe.qb.DocType("Inventory Dimension Bundle")
+			query = query.join(bundle).on(entry.parent == bundle.name).where(bundle.company == company)
+
+		from_datetime = get_datetime(self.from_date)
+		balances = {}
+		for record in query.run(as_dict=True):
+			combo = tuple(record.get(dimension.source) for dimension in dimensions)
+			if not any(combo):
+				# An entry with no dimension value contributes nothing to a dimension breakdown.
+				continue
+
+			combos = balances.setdefault((record.item_code, record.warehouse), {})
+			agg = combos.setdefault(
+				combo, frappe._dict(opening_qty=0.0, in_qty=0.0, out_qty=0.0, bal_qty=0.0)
+			)
+
+			# Inventory Dimension Entry qty is stored signed (negative for outward).
+			signed_qty = flt(record.qty)
+			agg.bal_qty += signed_qty
+			if record.posting_datetime < from_datetime:
+				agg.opening_qty += signed_qty
+			elif signed_qty >= 0:
+				agg.in_qty += signed_qty
+			else:
+				agg.out_qty += abs(signed_qty)
+
+		return balances
+
+	def build_dimension_rows(self, row, combos, dimensions) -> list:
+		"""One report row per dimension combination, plus a residual row for the uncaptured remainder."""
+		val_rate = flt(row.val_rate)
+		qty_fields = ["opening_qty", "in_qty", "out_qty", "bal_qty"]
+		val_fields = {
+			"opening_qty": "opening_val",
+			"in_qty": "in_val",
+			"out_qty": "out_val",
+			"bal_qty": "bal_val",
+		}
+
+		rows = []
+		totals = frappe._dict({field: 0.0 for field in qty_fields})
+		val_totals = frappe._dict({val_fields[field]: 0.0 for field in qty_fields})
+
+		for combo, agg in combos.items():
+			dimension_row = row.copy()
+			for dimension, value in zip(dimensions, combo, strict=False):
+				dimension_row[dimension.target] = value
+
+			for field in qty_fields:
+				dimension_row[field] = agg[field]
+				dimension_row[val_fields[field]] = agg[field] * val_rate
+				totals[field] += agg[field]
+				val_totals[val_fields[field]] += agg[field] * val_rate
+
+			rows.append(dimension_row)
+
+		# Stock that was never captured against a dimension (and valuation rounding) lands here so the
+		# per-dimension rows still add up to the original item/warehouse balance.
+		residual = {field: flt(row.get(field)) - totals[field] for field in qty_fields}
+		if any(abs(flt(value, self.float_precision)) for value in residual.values()):
+			residual_row = row.copy()
+			for dimension in dimensions:
+				residual_row[dimension.target] = None
+
+			for field in qty_fields:
+				residual_row[field] = residual[field]
+				residual_row[val_fields[field]] = (
+					flt(row.get(val_fields[field])) - val_totals[val_fields[field]]
+				)
+
+			rows.append(residual_row)
+
+		return rows
 
 	def get_sre_reserved_qty_details(self) -> dict:
 		from erpnext.stock.doctype.stock_reservation_entry.stock_reservation_entry import (
@@ -769,7 +911,16 @@ class StockBalanceReport:
 
 	@staticmethod
 	def get_inventory_dimension_fields():
-		return [dimension.fieldname for dimension in get_inventory_dimensions()]
+		# Dimensions are a quantity-only sub-ledger now. A dimension with a sub-ledger column
+		# (Inventory Dimension Entry) is surfaced via add_dimension_wise_stock(), not this column path,
+		# even if the legacy SLE column still physically exists as an unpopulated orphan. Only a truly
+		# legacy dimension (SLE column, no sub-ledger column) uses this column-based path.
+		return [
+			dimension.fieldname
+			for dimension in get_inventory_dimensions()
+			if frappe.db.has_column("Stock Ledger Entry", dimension.fieldname)
+			and not frappe.db.has_column("Inventory Dimension Entry", dimension.source_fieldname)
+		]
 
 	@staticmethod
 	def get_opening_fifo_queue(report_data):

--- a/erpnext/stock/report/stock_ledger/stock_ledger.py
+++ b/erpnext/stock/report/stock_ledger/stock_ledger.py
@@ -34,13 +34,15 @@ def execute(filters=None):
 	# Skip entirely when the feature is disabled in Stock Settings.
 	dimension_enabled = is_inventory_dimension_enabled()
 	dimension_filter, dimension_display = ({}, {})
-	dimension_contributions, dimension_bundles = {}, None
+	dimension_contributions, dimension_bundles, dimension_value_map = {}, None, {}
 	if dimension_enabled:
 		dimension_filter, dimension_display = get_dimension_sub_ledger_filter(filters)
 		if dimension_filter:
-			dimension_contributions, dimension_bundles = get_dimension_bundle_contributions(
-				filters, dimension_filter, items
-			)
+			(
+				dimension_contributions,
+				dimension_bundles,
+				dimension_value_map,
+			) = get_dimension_bundle_contributions(filters, dimension_filter, items)
 
 	sl_entries = get_stock_ledger_entries(filters, items, bundles=dimension_bundles)
 	item_details = get_item_details(items, sl_entries, include_uom)
@@ -115,7 +117,9 @@ def execute(filters=None):
 		sle.update(item_detail)
 
 		if dimension_filter:
-			apply_sub_ledger_dimension(sle, dimension_contributions, dimension_display, dimension_running)
+			apply_sub_ledger_dimension(
+				sle, dimension_contributions, dimension_display, dimension_running, dimension_value_map
+			)
 			data.append(sle)
 			if include_uom:
 				conversion_factors.append(item_detail.conversion_factor)
@@ -1003,10 +1007,21 @@ def _apply_dimension_filter(query, entry, source_values):
 def get_dimension_bundle_contributions(filters, source_values, items):
 	"""Net qty each bundle contributes to the filtered dimension, keyed by ``(bundle, warehouse)``.
 
-	Also returns the set of bundles touching the dimension so the SLE query can be restricted to them.
+	Returns ``(contributions, bundles, value_map)``: ``bundles`` is the set of bundles touching the
+	dimension (so the SLE query can be restricted to them); ``value_map`` records, per
+	``(bundle, warehouse)``, the actual filtered dimension value(s) the bundle holds, so each result row
+	shows what it really contributed instead of just the first selected filter value.
 	"""
 	entry = frappe.qb.DocType("Inventory Dimension Entry")
 	bundle = frappe.qb.DocType("Inventory Dimension Bundle")
+
+	# Map each filtered source column to its report column, and pull the source columns so we can show
+	# the real value(s) per row (a multi-value filter must not stamp the first value on every row).
+	source_to_target = {
+		dimension.source_fieldname: dimension.fieldname
+		for dimension in get_inventory_dimensions()
+		if dimension.source_fieldname in source_values
+	}
 
 	query = (
 		frappe.qb.from_(entry)
@@ -1016,6 +1031,7 @@ def get_dimension_bundle_contributions(filters, source_values, items):
 			entry.parent.as_("bundle"),
 			entry.warehouse,
 			entry.qty,
+			*[entry[source] for source in source_to_target],
 		)
 		.where((entry.is_cancelled == 0) & (entry.docstatus == 1))
 	)
@@ -1028,16 +1044,19 @@ def get_dimension_bundle_contributions(filters, source_values, items):
 	if filters.get("company"):
 		query = query.where(bundle.company == filters.get("company"))
 
-	contributions, bundles = {}, set()
+	contributions, bundles, value_map = {}, set(), {}
 	for row in query.run(as_dict=True):
 		bundles.add(row.bundle)
+		key = (row.bundle, row.warehouse)
 		# Inventory Dimension Entry qty is stored signed (negative for outward).
-		signed_qty = flt(row.qty)
-		contributions[(row.bundle, row.warehouse)] = (
-			contributions.get((row.bundle, row.warehouse), 0.0) + signed_qty
-		)
+		contributions[key] = contributions.get(key, 0.0) + flt(row.qty)
 
-	return contributions, bundles
+		bucket = value_map.setdefault(key, {})
+		for source, target in source_to_target.items():
+			if row.get(source):
+				bucket.setdefault(target, set()).add(row.get(source))
+
+	return contributions, bundles, value_map
 
 
 def as_filter_list(value) -> list:
@@ -1121,13 +1140,14 @@ def get_valuation_rate_before(item_code, warehouse, from_date):
 	return flt(rate[0][0]) if rate else 0.0
 
 
-def apply_sub_ledger_dimension(sle, contributions, display_map, running):
+def apply_sub_ledger_dimension(sle, contributions, display_map, running, value_map=None):
 	"""Override an SLE row with the filtered dimension's qty/value and running balance.
 
 	The running balance is tracked per ``(item_code, warehouse)`` so a dimension filter spanning
 	multiple items/warehouses does not produce a meaningless combined balance.
 	"""
-	dim_qty = flt(contributions.get((sle.get("inventory_dimension_bundle"), sle.warehouse), 0.0))
+	key = (sle.get("inventory_dimension_bundle"), sle.warehouse)
+	dim_qty = flt(contributions.get(key, 0.0))
 	valuation_rate = flt(sle.valuation_rate)
 	dim_value = dim_qty * valuation_rate
 
@@ -1142,4 +1162,11 @@ def apply_sub_ledger_dimension(sle, contributions, display_map, running):
 	sle.stock_value = balance["value"]
 	sle.incoming_rate = valuation_rate if dim_qty > 0 else 0
 	sle.in_out_rate = valuation_rate
-	sle.update(display_map)
+
+	# Show the actual filtered value(s) this row's bundle holds; fall back to the filter label
+	# (display_map) only for rows whose bundle did not record a value for the dimension.
+	row_display = dict(display_map)
+	for target, values in (value_map or {}).get(key, {}).items():
+		if values:
+			row_display[target] = ", ".join(sorted(values))
+	sle.update(row_display)

--- a/erpnext/stock/report/stock_ledger/stock_ledger.py
+++ b/erpnext/stock/report/stock_ledger/stock_ledger.py
@@ -6,10 +6,14 @@ import copy
 
 import frappe
 from frappe import _
+from frappe.query_builder import Order
 from frappe.query_builder.functions import Sum
 from frappe.utils import cint, flt, get_datetime
 
-from erpnext.stock.doctype.inventory_dimension.inventory_dimension import get_inventory_dimensions
+from erpnext.stock.doctype.inventory_dimension.inventory_dimension import (
+	get_inventory_dimensions,
+	is_inventory_dimension_enabled,
+)
 from erpnext.stock.doctype.serial_no.serial_no import get_serial_nos
 from erpnext.stock.doctype.stock_reconciliation.stock_reconciliation import get_stock_balance_for
 from erpnext.stock.doctype.warehouse.warehouse import apply_warehouse_filter
@@ -24,8 +28,27 @@ def execute(filters=None):
 	include_uom = filters.get("include_uom")
 	columns = get_columns(filters)
 	items = get_items(filters)
-	sl_entries = get_stock_ledger_entries(filters, items)
+
+	# Sub-ledger-backed inventory dimensions: filter by the matching bundles and read the dimension
+	# split from the Inventory Dimension Entry sub-ledger instead of (now non-existent) SLE columns.
+	# Skip entirely when the feature is disabled in Stock Settings.
+	dimension_enabled = is_inventory_dimension_enabled()
+	dimension_filter, dimension_display = ({}, {})
+	dimension_contributions, dimension_bundles = {}, None
+	if dimension_enabled:
+		dimension_filter, dimension_display = get_dimension_sub_ledger_filter(filters)
+		if dimension_filter:
+			dimension_contributions, dimension_bundles = get_dimension_bundle_contributions(
+				filters, dimension_filter, items
+			)
+
+	sl_entries = get_stock_ledger_entries(filters, items, bundles=dimension_bundles)
 	item_details = get_item_details(items, sl_entries, include_uom)
+
+	# When the report is not already filtered by a dimension, still show each row's dimension
+	# value(s) from its bundle so the dimension columns aren't blank.
+	if dimension_enabled and not dimension_filter:
+		set_sub_ledger_dimension_values(sl_entries)
 
 	inv_dimension_key = []
 	inv_dimension_wise_value = get_inv_dimension_wise_value(filters)
@@ -39,6 +62,8 @@ def execute(filters=None):
 
 	if filters.get("batch_no"):
 		opening_row = get_opening_balance_from_batch(filters, columns, sl_entries)
+	elif dimension_filter:
+		opening_row = get_sub_ledger_dimension_opening(filters, dimension_filter, dimension_display)
 	elif inv_dimension_wise_value:
 		opening_row = get_opening_balance_for_inv_dimension(filters, inv_dimension_wise_value)
 	else:
@@ -72,11 +97,30 @@ def execute(filters=None):
 		inv_dimension_wise_dict, filters, inv_dimension_key=inv_dimension_key, opening_row=opening_row
 	)
 
+	# Running balance per (item_code, warehouse) for the dimension-filtered path. An opening row only
+	# exists for a single item+warehouse combination; seed that combination from it.
+	dimension_running = {}
+	opening_item_codes = as_filter_list(filters.get("item_code"))
+	opening_warehouses = as_filter_list(filters.get("warehouse"))
+	if opening_row and len(opening_item_codes) == 1 and len(opening_warehouses) == 1:
+		dimension_running[(opening_item_codes[0], opening_warehouses[0])] = {
+			"qty": flt(opening_row.get("qty_after_transaction")),
+			"value": flt(opening_row.get("stock_value")),
+		}
+
 	item_wh_wise_prev_sle = {}
 	for sle in sl_entries:
 		item_detail = item_details[sle.item_code]
 
 		sle.update(item_detail)
+
+		if dimension_filter:
+			apply_sub_ledger_dimension(sle, dimension_contributions, dimension_display, dimension_running)
+			data.append(sle)
+			if include_uom:
+				conversion_factors.append(item_detail.conversion_factor)
+			continue
+
 		if bundle_info := bundle_details.get(sle.serial_and_batch_bundle):
 			data.extend(get_segregated_bundle_entries(sle, bundle_info, batch_balance_dict, filters))
 			continue
@@ -450,7 +494,7 @@ def get_columns(filters):
 	return columns
 
 
-def get_stock_ledger_entries(filters, items):
+def get_stock_ledger_entries(filters, items, bundles=None):
 	from_date = get_datetime(filters.from_date + " 00:00:00")
 	to_date = get_datetime(filters.to_date + " 23:59:59")
 
@@ -471,6 +515,7 @@ def get_stock_ledger_entries(filters, items):
 			sle.qty_after_transaction,
 			sle.stock_value_difference,
 			sle.serial_and_batch_bundle,
+			sle.inventory_dimension_bundle,
 			sle.voucher_no,
 			sle.stock_value,
 			sle.batch_no,
@@ -488,6 +533,13 @@ def get_stock_ledger_entries(filters, items):
 			query = query.select(fieldname)
 			if fieldname in filters and filters.get(fieldname):
 				query = query.where(sle[fieldname].isin(filters.get(fieldname)))
+
+	# Sub-ledger-backed dimensions are filtered by the matching bundles (the dimension value is no
+	# longer a column on Stock Ledger Entry); an empty set means nothing matched the dimension.
+	if bundles is not None:
+		if not bundles:
+			return []
+		query = query.where(sle.inventory_dimension_bundle.isin(list(bundles)))
 
 	if items:
 		query = query.where(sle.item_code.isin(items))
@@ -532,7 +584,16 @@ def get_serial_and_batch_bundles(filters):
 
 
 def get_inventory_dimension_fields():
-	return [dimension.fieldname for dimension in get_inventory_dimensions()]
+	# Inventory dimensions are stored in the qty-only sub-ledger now. A dimension that has a
+	# sub-ledger column (Inventory Dimension Entry) is read from there, not from Stock Ledger Entry,
+	# even if the legacy SLE column still physically exists (it is left as an unpopulated orphan).
+	# Only a truly legacy dimension - one with an SLE column but no sub-ledger column - uses this path.
+	return [
+		dimension.fieldname
+		for dimension in get_inventory_dimensions()
+		if frappe.db.has_column("Stock Ledger Entry", dimension.fieldname)
+		and not frappe.db.has_column("Inventory Dimension Entry", dimension.source_fieldname)
+	]
 
 
 def get_items(filters):
@@ -845,7 +906,15 @@ def get_opening_balance_for_inv_dimension(filters, inv_dimension_wise_value):
 def get_inv_dimension_wise_value(filters) -> list:
 	inv_dimension_key = frappe._dict({})
 	for dimension in get_inventory_dimensions():
-		if dimension.fieldname in filters and filters.get(dimension.fieldname):
+		# Sub-ledger-backed dimensions are handled separately via the Inventory Dimension Entry
+		# sub-ledger; only truly legacy column-backed dimensions (SLE column, no sub-ledger column)
+		# use this running-balance path.
+		if (
+			dimension.fieldname in filters
+			and filters.get(dimension.fieldname)
+			and frappe.db.has_column("Stock Ledger Entry", dimension.fieldname)
+			and not frappe.db.has_column("Inventory Dimension Entry", dimension.source_fieldname)
+		):
 			inv_dimension_key[dimension.fieldname] = filters.get(dimension.fieldname)
 
 	if filters.get("project") and not frappe.get_all(
@@ -854,3 +923,223 @@ def get_inv_dimension_wise_value(filters) -> list:
 		inv_dimension_key["project"] = filters.get("project")
 
 	return inv_dimension_key
+
+
+def get_dimension_sub_ledger_filter(filters):
+	"""Dimensions the user filtered on that are backed by the Inventory Dimension Entry sub-ledger.
+
+	Returns ``({source_fieldname: value}, {report_column_fieldname: display_value})``. The first drives
+	the sub-ledger query; the second sets the dimension column on each row for display.
+	"""
+	entry_doctype = "Inventory Dimension Entry"
+	source_values, display_map = {}, {}
+	for dimension in get_inventory_dimensions():
+		target, source = dimension.fieldname, dimension.source_fieldname
+		if not source or not filters.get(target) or not frappe.db.has_column(entry_doctype, source):
+			continue
+
+		source_values[source] = filters.get(target)
+		value = filters.get(target)
+		display_map[target] = value[0] if isinstance(value, list | tuple) else value
+
+	return source_values, display_map
+
+
+def set_sub_ledger_dimension_values(sl_entries):
+	"""Populate each SLE row's inventory-dimension columns from its bundle's sub-ledger entries.
+
+	A bundle may split a row's qty across several dimension values; they are shown comma-separated.
+	"""
+	entry_doctype = "Inventory Dimension Entry"
+	dimensions = [
+		frappe._dict(source=dimension.source_fieldname, target=dimension.fieldname)
+		for dimension in get_inventory_dimensions()
+		if dimension.source_fieldname and frappe.db.has_column(entry_doctype, dimension.source_fieldname)
+	]
+	if not dimensions:
+		return
+
+	bundles = {
+		sle.get("inventory_dimension_bundle") for sle in sl_entries if sle.get("inventory_dimension_bundle")
+	}
+	if not bundles:
+		return
+
+	entry = frappe.qb.DocType(entry_doctype)
+	query = (
+		frappe.qb.from_(entry)
+		.select(entry.parent, *[entry[dimension.source] for dimension in dimensions])
+		.where((entry.parent.isin(list(bundles))) & (entry.is_cancelled == 0))
+	)
+
+	values_by_bundle = {}
+	for row in query.run(as_dict=True):
+		bucket = values_by_bundle.setdefault(
+			row.parent, {dimension.target: set() for dimension in dimensions}
+		)
+		for dimension in dimensions:
+			if row.get(dimension.source):
+				bucket[dimension.target].add(row.get(dimension.source))
+
+	for sle in sl_entries:
+		bucket = values_by_bundle.get(sle.get("inventory_dimension_bundle"))
+		if not bucket:
+			continue
+
+		for target, values in bucket.items():
+			if values:
+				sle[target] = ", ".join(sorted(values))
+
+
+def _apply_dimension_filter(query, entry, source_values):
+	for source, value in source_values.items():
+		if isinstance(value, list | tuple):
+			query = query.where(entry[source].isin(value))
+		else:
+			query = query.where(entry[source] == value)
+	return query
+
+
+def get_dimension_bundle_contributions(filters, source_values, items):
+	"""Net qty each bundle contributes to the filtered dimension, keyed by ``(bundle, warehouse)``.
+
+	Also returns the set of bundles touching the dimension so the SLE query can be restricted to them.
+	"""
+	entry = frappe.qb.DocType("Inventory Dimension Entry")
+	bundle = frappe.qb.DocType("Inventory Dimension Bundle")
+
+	query = (
+		frappe.qb.from_(entry)
+		.join(bundle)
+		.on(entry.parent == bundle.name)
+		.select(
+			entry.parent.as_("bundle"),
+			entry.warehouse,
+			entry.qty,
+		)
+		.where((entry.is_cancelled == 0) & (entry.docstatus == 1))
+	)
+	query = _apply_dimension_filter(query, entry, source_values)
+
+	if items:
+		query = query.where(entry.item_code.isin(items))
+	if filters.get("warehouse"):
+		query = query.where(entry.warehouse.isin(filters.get("warehouse")))
+	if filters.get("company"):
+		query = query.where(bundle.company == filters.get("company"))
+
+	contributions, bundles = {}, set()
+	for row in query.run(as_dict=True):
+		bundles.add(row.bundle)
+		# Inventory Dimension Entry qty is stored signed (negative for outward).
+		signed_qty = flt(row.qty)
+		contributions[(row.bundle, row.warehouse)] = (
+			contributions.get((row.bundle, row.warehouse), 0.0) + signed_qty
+		)
+
+	return contributions, bundles
+
+
+def as_filter_list(value) -> list:
+	"""Normalise a filter value (scalar or list) to a list so ``[0]``/``len`` are safe.
+
+	The report passes item_code/warehouse as MultiSelectLists, but the function may also be called
+	with a scalar string; ``len("ITEM-001") > 1`` would otherwise misfire.
+	"""
+	if not value:
+		return []
+	return list(value) if isinstance(value, list | tuple) else [value]
+
+
+def get_sub_ledger_dimension_opening(filters, source_values, display_map):
+	"""Opening row for the filtered dimension, computed from the sub-ledger before ``from_date``."""
+	item_codes = as_filter_list(filters.get("item_code"))
+	warehouses = as_filter_list(filters.get("warehouse"))
+	if not item_codes or not warehouses or not filters.get("from_date"):
+		return
+
+	if len(item_codes) > 1 or len(warehouses) > 1:
+		return
+
+	item_code, warehouse = item_codes[0], warehouses[0]
+	entry = frappe.qb.DocType("Inventory Dimension Entry")
+	bundle = frappe.qb.DocType("Inventory Dimension Bundle")
+	from_datetime = get_datetime(filters.from_date + " 00:00:00")
+
+	query = (
+		frappe.qb.from_(entry)
+		.join(bundle)
+		.on(entry.parent == bundle.name)
+		.select(entry.qty)
+		.where(
+			(entry.is_cancelled == 0)
+			& (entry.docstatus == 1)
+			& (entry.item_code == item_code)
+			& (entry.warehouse == warehouse)
+			& (entry.posting_datetime < from_datetime)
+		)
+	)
+	query = _apply_dimension_filter(query, entry, source_values)
+	if filters.get("company"):
+		query = query.where(bundle.company == filters.get("company"))
+
+	# Inventory Dimension Entry qty is stored signed (negative for outward).
+	opening_qty = sum(flt(row.qty) for row in query.run(as_dict=True))
+	if not opening_qty:
+		return
+
+	rate = get_valuation_rate_before(item_code, warehouse, filters.from_date)
+	opening_row = frappe._dict(
+		{
+			"item_code": _("'Opening'"),
+			"qty_after_transaction": opening_qty,
+			"stock_value": opening_qty * rate,
+			"valuation_rate": rate,
+		}
+	)
+	opening_row.update(display_map)
+	return opening_row
+
+
+def get_valuation_rate_before(item_code, warehouse, from_date):
+	"""Valuation rate of the last Stock Ledger Entry for the item/warehouse before ``from_date``."""
+	sle = frappe.qb.DocType("Stock Ledger Entry")
+	rate = (
+		frappe.qb.from_(sle)
+		.select(sle.valuation_rate)
+		.where(
+			(sle.item_code == item_code)
+			& (sle.warehouse == warehouse)
+			& (sle.is_cancelled == 0)
+			& (sle.posting_date < from_date)
+		)
+		.orderby(sle.posting_datetime, order=Order.desc)
+		.orderby(sle.creation, order=Order.desc)
+		.limit(1)
+	).run()
+
+	return flt(rate[0][0]) if rate else 0.0
+
+
+def apply_sub_ledger_dimension(sle, contributions, display_map, running):
+	"""Override an SLE row with the filtered dimension's qty/value and running balance.
+
+	The running balance is tracked per ``(item_code, warehouse)`` so a dimension filter spanning
+	multiple items/warehouses does not produce a meaningless combined balance.
+	"""
+	dim_qty = flt(contributions.get((sle.get("inventory_dimension_bundle"), sle.warehouse), 0.0))
+	valuation_rate = flt(sle.valuation_rate)
+	dim_value = dim_qty * valuation_rate
+
+	balance = running.setdefault((sle.item_code, sle.warehouse), {"qty": 0.0, "value": 0.0})
+	balance["qty"] += dim_qty
+	balance["value"] += dim_value
+
+	sle.actual_qty = dim_qty
+	sle.stock_value_difference = dim_value
+	sle.update({"in_qty": max(dim_qty, 0), "out_qty": min(dim_qty, 0)})
+	sle.qty_after_transaction = balance["qty"]
+	sle.stock_value = balance["value"]
+	sle.incoming_rate = valuation_rate if dim_qty > 0 else 0
+	sle.in_out_rate = valuation_rate
+	sle.update(display_map)

--- a/erpnext/stock/services/inventory_dimension_bundle_service.py
+++ b/erpnext/stock/services/inventory_dimension_bundle_service.py
@@ -12,6 +12,8 @@ qty is split across dimension combinations. The check is gated on ``is_stock_ite
 service / non-stock rows are never asked for dimension values.
 """
 
+import typing
+
 import frappe
 from frappe import _, bold
 from frappe.utils import flt
@@ -31,16 +33,32 @@ class InventoryDimensionBundleService:
 	def get_table_name(self, table_name=None) -> str:
 		return table_name or "items"
 
+	# Tables other than ``items`` whose rows can carry a dimension bundle, with the field overrides
+	# needed to stamp it. A Subcontracting Receipt consumes raw materials through ``supplied_items``,
+	# which name the item/qty/warehouse differently and always move stock *out* of the supplier
+	# warehouse - so the bundle is stamped as an Outward consumption against that warehouse.
+	TABLE_CONFIG: typing.ClassVar[dict] = {
+		"packed_items": {},
+		"supplied_items": {
+			"item_field": "rm_item_code",
+			"qty_field": "consumed_qty",
+			"type_of_transaction": "Outward",
+			"warehouse_attr": "supplier_warehouse",
+		},
+	}
+
 	def get_bundle_tables(self, table_name=None) -> list:
 		"""Item tables that can carry inventory dimension bundles.
 
-		Besides the main ``items`` table, a Product Bundle line's stock moves through ``packed_items``,
-		so a dimension bundle captured on a packed row must be stamped/submitted/cancelled too.
+		Besides the main ``items`` table, a Product Bundle line's stock moves through ``packed_items``
+		and a Subcontracting Receipt's raw material is consumed through ``supplied_items``; a dimension
+		bundle captured on either must be stamped/submitted/cancelled alongside the main rows.
 		"""
 		if table_name:
 			return [table_name]
 
-		return [table for table in ("items", "packed_items") if self.doc.meta.get_field(table)]
+		tables = ["items", *self.TABLE_CONFIG]
+		return [table for table in tables if self.doc.meta.get_field(table)]
 
 	def get_child_doctype(self, table_name) -> str | None:
 		meta_field = self.doc.meta.get_field(table_name)
@@ -103,14 +121,17 @@ class InventoryDimensionBundleService:
 	def set_inventory_dimension_bundle(self, table_name=None, ignore_validate=False):
 		"""On submit, stamp references onto each row's bundle(s) and submit them."""
 		table_name = self.get_table_name(table_name)
+		config = self.TABLE_CONFIG.get(table_name, {})
+		item_field = config.get("item_field", "item_code")
 
 		for row in self.doc.get(table_name):
+			item_code = row.get(item_field)
 			for fieldname, qty_field, warehouse_field in self.BUNDLE_FIELDS:
 				bundle = row.get(fieldname)
 				if not bundle:
 					continue
 
-				if not self.is_stock_item(row.get("item_code")):
+				if not self.is_stock_item(item_code):
 					# A non-stock row must never carry a dimension bundle.
 					row.set(fieldname, None)
 					continue
@@ -120,9 +141,18 @@ class InventoryDimensionBundleService:
 					doc.set_inventory_dimension_values(
 						self.doc,
 						row,
-						qty_field=qty_field,
-						warehouse=row.get(warehouse_field) if warehouse_field else None,
+						qty_field=config.get("qty_field", qty_field),
+						warehouse=self._bundle_warehouse(row, warehouse_field, config),
+						item_code=item_code,
+						type_of_transaction=config.get("type_of_transaction"),
 					)
+
+	def _bundle_warehouse(self, row, warehouse_field, config):
+		"""Warehouse the bundle posts against: a parent attribute (supplied items consume from the
+		supplier warehouse, which the row does not name), else the row's own warehouse field."""
+		if config.get("warehouse_attr"):
+			return self.doc.get(config["warehouse_attr"])
+		return row.get(warehouse_field) if warehouse_field else None
 
 	def cancel_inventory_dimension_bundles(self, table_name=None):
 		"""Cancel the submitted bundles of a voucher being cancelled, then unlink them from its rows.
@@ -186,14 +216,23 @@ class InventoryDimensionBundleService:
 		# stock on either or both legs, and each leg captures its dimensions on its own bundle; checking
 		# them together would falsely flag a row that captured its dimension on the other leg's bundle.
 		for bundle_field, qty_field, _warehouse_field in self.BUNDLE_FIELDS:
-			self._validate_leg(table_name, dimensions, mandatory, bundle_field, qty_field)
+			self._validate_accepted_dim_qty(table_name, dimensions, mandatory, bundle_field, qty_field)
 
-	def _validate_leg(self, table_name, dimensions, mandatory, bundle_field, qty_field):
+	def _validate_accepted_dim_qty(self, table_name, dimensions, mandatory, bundle_field, qty_field):
 		"""Enforce mandatory dimensions for the rows that move stock on one leg (accepted/rejected)."""
+		# Some tables name the item/qty fields differently (supplied items hold the RM in
+		# ``rm_item_code`` and consume ``consumed_qty``); resolve them the same way the stamping does
+		# so the gate is not silently skipped. The per-table qty override is the accepted-leg field;
+		# the rejected leg keeps its own (``rejected_qty``), which such tables simply do not have.
+		config = self.TABLE_CONFIG.get(table_name, {})
+		item_field = config.get("item_field", "item_code")
+		if bundle_field == "inventory_dimension_bundle":
+			qty_field = config.get("qty_field", qty_field)
+
 		rows = [
 			row
 			for row in self.doc.get(table_name)
-			if self.is_stock_item(row.get("item_code")) and flt(row.get(qty_field))
+			if self.is_stock_item(row.get(item_field)) and flt(row.get(qty_field))
 		]
 		if not rows:
 			return
@@ -211,7 +250,7 @@ class InventoryDimensionBundleService:
 				if dimension.get("name") not in covered:
 					frappe.throw(
 						_("Row #{0}: Please set the inventory dimension {1} for item {2}.").format(
-							row.idx, bold(dimension.get("name")), bold(row.get("item_code"))
+							row.idx, bold(dimension.get("name")), bold(row.get(item_field))
 						),
 						title=_("Inventory Dimension Required"),
 					)

--- a/erpnext/stock/services/inventory_dimension_bundle_service.py
+++ b/erpnext/stock/services/inventory_dimension_bundle_service.py
@@ -1,0 +1,238 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and Contributors
+# License: GNU General Public License v3. See license.txt
+
+"""Inventory Dimension Bundle handling for stock transactions.
+
+Mirrors ``SerialBatchBundleService``: owns creation, validation and submission of
+Inventory Dimension Bundles for a stock voucher. The controller keeps thin delegators
+for methods reached from other doctypes / ``run_method``; internal helpers live here.
+
+Inventory dimensions are a **quantity-only** sub-ledger: a bundle captures how a row's
+qty is split across dimension combinations. The check is gated on ``is_stock_item`` so
+service / non-stock rows are never asked for dimension values.
+"""
+
+import frappe
+from frappe import _, bold
+from frappe.utils import flt
+
+from erpnext.stock.doctype.inventory_dimension.inventory_dimension import (
+	get_document_wise_inventory_dimensions,
+	is_inventory_dimension_enabled,
+)
+
+
+class InventoryDimensionBundleService:
+	def __init__(self, doc) -> None:
+		self.doc = doc
+
+	# ------------------------------------------------------------------ helpers
+
+	def get_table_name(self, table_name=None) -> str:
+		return table_name or "items"
+
+	def get_bundle_tables(self, table_name=None) -> list:
+		"""Item tables that can carry inventory dimension bundles.
+
+		Besides the main ``items`` table, a Product Bundle line's stock moves through ``packed_items``,
+		so a dimension bundle captured on a packed row must be stamped/submitted/cancelled too.
+		"""
+		if table_name:
+			return [table_name]
+
+		return [table for table in ("items", "packed_items") if self.doc.meta.get_field(table)]
+
+	def get_child_doctype(self, table_name) -> str | None:
+		meta_field = self.doc.meta.get_field(table_name)
+		return meta_field.options if meta_field else None
+
+	def get_applicable_dimensions(self, table_name) -> list:
+		"""Inventory dimensions that apply to this voucher's child doctype (or all doctypes)."""
+		child_doctype = self.get_child_doctype(table_name)
+		if not child_doctype:
+			return []
+
+		return get_document_wise_inventory_dimensions(child_doctype) or []
+
+	@staticmethod
+	def is_stock_item(item_code) -> bool:
+		if not item_code:
+			return False
+
+		return bool(frappe.get_cached_value("Item", item_code, "is_stock_item"))
+
+	def row_has_dimension_qty(self, row) -> bool:
+		"""True only for stock rows that actually move stock (qty or rejected qty)."""
+		return bool(self.is_stock_item(row.get("item_code"))) and bool(
+			flt(row.get("qty")) or flt(row.get("rejected_qty"))
+		)
+
+	def dimension_applies_to_row(self, dimension, row) -> bool:
+		"""Honour the dimension's optional ``condition`` against the row."""
+		if not dimension.get("condition"):
+			return True
+
+		try:
+			return bool(frappe.safe_eval(dimension.get("condition"), None, {"doc": row, "parent": self.doc}))
+		except Exception:
+			# A malformed condition should not block posting; treat as applicable.
+			return True
+
+	# ------------------------------------------------------------- build / submit
+
+	def process_bundles_on_stock_posting(self, table_name=None):
+		"""Single entry point invoked from the shared stock-posting chokepoint.
+
+		On submit (docstatus 1) the linked draft bundles are stamped + submitted, posting the
+		quantity sub-ledger. On cancel (docstatus 2) the submitted bundles are cancelled. Both the
+		main ``items`` table and (for Product Bundle lines) ``packed_items`` are processed.
+		"""
+		for table in self.get_bundle_tables(table_name):
+			if self.doc.docstatus == 2:
+				self.cancel_inventory_dimension_bundles(table)
+			else:
+				self.set_inventory_dimension_bundle(table)
+
+	# The accepted-qty bundle and (on purchase docs) the rejected-qty bundle are stamped/submitted
+	# and cancelled the same way, only differing in the qty field, warehouse and link field.
+	BUNDLE_FIELDS = (
+		("inventory_dimension_bundle", "qty", None),
+		("rejected_inventory_dimension_bundle", "rejected_qty", "rejected_warehouse"),
+	)
+
+	def set_inventory_dimension_bundle(self, table_name=None, ignore_validate=False):
+		"""On submit, stamp references onto each row's bundle(s) and submit them."""
+		table_name = self.get_table_name(table_name)
+
+		for row in self.doc.get(table_name):
+			for fieldname, qty_field, warehouse_field in self.BUNDLE_FIELDS:
+				bundle = row.get(fieldname)
+				if not bundle:
+					continue
+
+				if not self.is_stock_item(row.get("item_code")):
+					# A non-stock row must never carry a dimension bundle.
+					row.set(fieldname, None)
+					continue
+
+				doc = frappe.get_doc("Inventory Dimension Bundle", bundle)
+				if doc.docstatus == 0:
+					doc.set_inventory_dimension_values(
+						self.doc,
+						row,
+						qty_field=qty_field,
+						warehouse=row.get(warehouse_field) if warehouse_field else None,
+					)
+
+	def cancel_inventory_dimension_bundles(self, table_name=None):
+		"""Cancel the submitted bundles of a voucher being cancelled, then unlink them from its rows.
+
+		Detaching the bundle from the row keeps a later amend from carrying a link to a now-cancelled
+		document ("Cannot link cancelled document"). The Stock Ledger Entry keeps its own (immutable)
+		link, so the sub-ledger reversal is unaffected.
+		"""
+		table_name = self.get_table_name(table_name)
+
+		# Detach the bundles from this table's rows (covers the main item row and a Product Bundle's
+		# packed item row). The field is no_copy, but clearing it here also covers amend on sites
+		# whose meta predates that flag.
+		for row in self.doc.get(table_name):
+			for fieldname, _qty_field, _warehouse_field in self.BUNDLE_FIELDS:
+				if row.get(fieldname):
+					row.db_set(fieldname, None, update_modified=False)
+
+		self.cancel_voucher_bundles()
+
+	def cancel_voucher_bundles(self):
+		"""Cancel every submitted bundle of this voucher.
+
+		Besides the bundles linked on the voucher rows, this also catches the inward bundle a
+		transfer's target leg creates on its Stock Ledger Entry (it is not linked on any row).
+		"""
+		bundles = frappe.get_all(
+			"Inventory Dimension Bundle",
+			filters={"voucher_type": self.doc.doctype, "voucher_no": self.doc.name, "docstatus": 1},
+			pluck="name",
+		)
+		for bundle in bundles:
+			doc = frappe.get_doc("Inventory Dimension Bundle", bundle)
+			doc.flags.ignore_permissions = True
+			# The voucher owns the bundle's lifecycle; authorise this cancel (manual cancel is blocked).
+			doc.flags.from_voucher = True
+			doc.cancel()
+
+	# --------------------------------------------------------------- validation
+
+	def validate_inventory_dimension_bundle(self, table_name=None):
+		"""is_stock_item-gated mandatory-dimension enforcement (replaces field-level reqd).
+
+		Service / non-stock rows are skipped entirely (fixes the spurious 'set the
+		Inventory Dimension' error on service items).
+		"""
+		if not is_inventory_dimension_enabled():
+			return
+
+		table_name = self.get_table_name(table_name)
+		dimensions = self.get_applicable_dimensions(table_name)
+		if not dimensions:
+			return
+
+		mandatory = [d for d in dimensions if d.get("reqd")]
+		if not mandatory:
+			return
+
+		rows = [row for row in self.doc.get(table_name) if self.row_has_dimension_qty(row)]
+		if not rows:
+			return
+
+		# Batch-fetch every linked bundle's entries up front so the per-row coverage check below
+		# is a dict lookup, not an N+1 query (a 50-line receipt fired 50 queries previously).
+		entries_by_bundle = self._get_entries_by_bundle(rows)
+
+		for row in rows:
+			covered = self._covered_dimensions(row, dimensions, entries_by_bundle)
+			for dimension in mandatory:
+				if not self.dimension_applies_to_row(dimension, row):
+					continue
+
+				if dimension.get("name") not in covered:
+					frappe.throw(
+						_("Row #{0}: Please set the inventory dimension {1} for item {2}.").format(
+							row.idx, bold(dimension.get("name")), bold(row.get("item_code"))
+						),
+						title=_("Inventory Dimension Required"),
+					)
+
+	def _get_entries_by_bundle(self, rows) -> dict:
+		"""All Inventory Dimension Entry rows for the rows' bundles, grouped by bundle, in one query."""
+		bundles = [
+			row.get("inventory_dimension_bundle") for row in rows if row.get("inventory_dimension_bundle")
+		]
+		if not bundles:
+			return {}
+
+		entries_by_bundle = {}
+		for entry in frappe.get_all(
+			"Inventory Dimension Entry", filters={"parent": ("in", bundles)}, fields=["*"]
+		):
+			entries_by_bundle.setdefault(entry.parent, []).append(entry)
+
+		return entries_by_bundle
+
+	def _covered_dimensions(self, row, dimensions, entries_by_bundle) -> set:
+		"""Set of dimension names that the row's bundle provides a value for."""
+		bundle = row.get("inventory_dimension_bundle")
+		if not bundle:
+			return set()
+
+		# Dimension values live in custom columns on Inventory Dimension Entry (added per
+		# dimension in Phase 3); a dimension is "covered" when at least one entry has a value.
+		entries = entries_by_bundle.get(bundle, [])
+
+		covered = set()
+		for dimension in dimensions:
+			fieldname = dimension.get("source_fieldname")
+			if fieldname and any(entry.get(fieldname) for entry in entries):
+				covered.add(dimension.get("name"))
+
+		return covered

--- a/erpnext/stock/services/inventory_dimension_bundle_service.py
+++ b/erpnext/stock/services/inventory_dimension_bundle_service.py
@@ -181,16 +181,29 @@ class InventoryDimensionBundleService:
 		if not mandatory:
 			return
 
-		rows = [row for row in self.doc.get(table_name) if self.row_has_dimension_qty(row)]
+		# Validate the accepted leg (qty -> inventory_dimension_bundle) and the rejected leg
+		# (rejected_qty -> rejected_inventory_dimension_bundle) independently. A purchase row can move
+		# stock on either or both legs, and each leg captures its dimensions on its own bundle; checking
+		# them together would falsely flag a row that captured its dimension on the other leg's bundle.
+		for bundle_field, qty_field, _warehouse_field in self.BUNDLE_FIELDS:
+			self._validate_leg(table_name, dimensions, mandatory, bundle_field, qty_field)
+
+	def _validate_leg(self, table_name, dimensions, mandatory, bundle_field, qty_field):
+		"""Enforce mandatory dimensions for the rows that move stock on one leg (accepted/rejected)."""
+		rows = [
+			row
+			for row in self.doc.get(table_name)
+			if self.is_stock_item(row.get("item_code")) and flt(row.get(qty_field))
+		]
 		if not rows:
 			return
 
 		# Batch-fetch every linked bundle's entries up front so the per-row coverage check below
 		# is a dict lookup, not an N+1 query (a 50-line receipt fired 50 queries previously).
-		entries_by_bundle = self._get_entries_by_bundle(rows)
+		entries_by_bundle = self._get_entries_by_bundle(rows, bundle_field)
 
 		for row in rows:
-			covered = self._covered_dimensions(row, dimensions, entries_by_bundle)
+			covered = self._covered_dimensions(row, dimensions, entries_by_bundle, bundle_field)
 			for dimension in mandatory:
 				if not self.dimension_applies_to_row(dimension, row):
 					continue
@@ -203,11 +216,9 @@ class InventoryDimensionBundleService:
 						title=_("Inventory Dimension Required"),
 					)
 
-	def _get_entries_by_bundle(self, rows) -> dict:
+	def _get_entries_by_bundle(self, rows, bundle_field="inventory_dimension_bundle") -> dict:
 		"""All Inventory Dimension Entry rows for the rows' bundles, grouped by bundle, in one query."""
-		bundles = [
-			row.get("inventory_dimension_bundle") for row in rows if row.get("inventory_dimension_bundle")
-		]
+		bundles = [row.get(bundle_field) for row in rows if row.get(bundle_field)]
 		if not bundles:
 			return {}
 
@@ -219,9 +230,11 @@ class InventoryDimensionBundleService:
 
 		return entries_by_bundle
 
-	def _covered_dimensions(self, row, dimensions, entries_by_bundle) -> set:
+	def _covered_dimensions(
+		self, row, dimensions, entries_by_bundle, bundle_field="inventory_dimension_bundle"
+	) -> set:
 		"""Set of dimension names that the row's bundle provides a value for."""
-		bundle = row.get("inventory_dimension_bundle")
+		bundle = row.get(bundle_field)
 		if not bundle:
 			return set()
 

--- a/erpnext/stock/services/stock_ledger_service.py
+++ b/erpnext/stock/services/stock_ledger_service.py
@@ -13,9 +13,6 @@ import frappe
 from frappe.utils import flt
 
 from erpnext.accounts.utils import get_fiscal_year
-from erpnext.stock.doctype.inventory_dimension.inventory_dimension import (
-	get_evaluated_inventory_dimension,
-)
 
 
 class StockLedgerService:
@@ -83,6 +80,7 @@ class StockLedgerService:
 				"item_code": d.get("item_code", None),
 				"warehouse": d.get("warehouse", None),
 				"serial_and_batch_bundle": d.get("serial_and_batch_bundle"),
+				"inventory_dimension_bundle": d.get("inventory_dimension_bundle"),
 				"posting_date": self.doc.posting_date,
 				"posting_time": self.doc.posting_time,
 				"fiscal_year": get_fiscal_year(self.doc.posting_date, company=self.doc.company)[0],
@@ -101,7 +99,6 @@ class StockLedgerService:
 		)
 
 		sl_dict.update(args)
-		self.update_inventory_dimensions(d, sl_dict)
 
 		if self.doc.docstatus == 2:
 			from erpnext.deprecation_dumpster import deprecation_warning
@@ -114,97 +111,18 @@ class StockLedgerService:
 
 		return sl_dict
 
-	def update_inventory_dimensions(self, row, sl_dict) -> None:
-		# To handle delivery note and sales invoice
-		if row.get("item_row"):
-			row = row.get("item_row")
-
-		dimensions = get_evaluated_inventory_dimension(row, sl_dict, parent_doc=self.doc)
-		for dimension in dimensions:
-			if not dimension:
-				continue
-
-			if (
-				self.doc.doctype in ["Purchase Invoice", "Purchase Receipt"]
-				and row.get("rejected_warehouse")
-				and sl_dict.get("warehouse") == row.get("rejected_warehouse")
-			):
-				fieldname = f"rejected_{dimension.source_fieldname}"
-				sl_dict[dimension.target_fieldname] = row.get(fieldname)
-				continue
-
-			if self.doc.doctype in [
-				"Purchase Invoice",
-				"Purchase Receipt",
-				"Sales Invoice",
-				"Delivery Note",
-				"Stock Entry",
-			]:
-				if (
-					(
-						sl_dict.actual_qty > 0
-						and not self.doc.get("is_return")
-						or sl_dict.actual_qty < 0
-						and self.doc.get("is_return")
-					)
-					and self.doc.doctype in ["Purchase Invoice", "Purchase Receipt", "Stock Entry"]
-				) or (
-					(
-						sl_dict.actual_qty < 0
-						and not self.doc.get("is_return")
-						or sl_dict.actual_qty > 0
-						and self.doc.get("is_return")
-					)
-					and self.doc.doctype in ["Sales Invoice", "Delivery Note", "Stock Entry"]
-				):
-					if self.doc.doctype == "Stock Entry":
-						if row.get("t_warehouse") == sl_dict.warehouse and sl_dict.get("actual_qty") > 0:
-							fieldname = f"to_{dimension.source_fieldname}"
-							if dimension.source_fieldname.startswith("to_"):
-								fieldname = f"{dimension.source_fieldname}"
-
-							sl_dict[dimension.target_fieldname] = row.get(fieldname)
-							continue
-
-					sl_dict[dimension.target_fieldname] = row.get(dimension.source_fieldname)
-				else:
-					fieldname_start_with = "to"
-					if self.doc.doctype in ["Purchase Invoice", "Purchase Receipt"]:
-						fieldname_start_with = "from"
-
-					fieldname = f"{fieldname_start_with}_{dimension.source_fieldname}"
-					sl_dict[dimension.target_fieldname] = row.get(fieldname)
-
-					if not sl_dict.get(dimension.target_fieldname):
-						sl_dict[dimension.target_fieldname] = row.get(dimension.source_fieldname)
-
-			elif row.get(dimension.source_fieldname):
-				sl_dict[dimension.target_fieldname] = row.get(dimension.source_fieldname)
-
-			if not sl_dict.get(dimension.target_fieldname) and dimension.fetch_from_parent:
-				sl_dict[dimension.target_fieldname] = self.doc.get(dimension.fetch_from_parent)
-
-				# Get value based on doctype name
-				if not sl_dict.get(dimension.target_fieldname):
-					fieldname = next(
-						(
-							field.fieldname
-							for field in frappe.get_meta(self.doc.doctype).fields
-							if field.options == dimension.fetch_from_parent
-						),
-						None,
-					)
-
-					if fieldname and self.doc.get(fieldname):
-						sl_dict[dimension.target_fieldname] = self.doc.get(fieldname)
-
-				if sl_dict[dimension.target_fieldname] and self.doc.docstatus == 1:
-					row.db_set(dimension.source_fieldname, sl_dict[dimension.target_fieldname])
-
 	def make_sl_entries(self, sl_entries, allow_negative_stock=False, via_landed_cost_voucher=False):
 		from erpnext.stock.serial_batch_bundle import update_batch_qty
+		from erpnext.stock.services.inventory_dimension_bundle_service import (
+			InventoryDimensionBundleService,
+		)
 		from erpnext.stock.services.serial_batch_bundle_service import SerialBatchBundleService
 		from erpnext.stock.stock_ledger import make_sl_entries
+
+		# Submit (on docstatus 1) or cancel (on docstatus 2) the linked inventory dimension
+		# bundles, posting/reversing the quantity sub-ledger alongside the stock ledger.
+		if self.doc.meta.get_field("items"):
+			InventoryDimensionBundleService(self.doc).process_bundles_on_stock_posting()
 
 		make_sl_entries(sl_entries, allow_negative_stock, via_landed_cost_voucher)
 		update_batch_qty(

--- a/erpnext/stock/utils.py
+++ b/erpnext/stock/utils.py
@@ -125,22 +125,44 @@ def get_stock_balance(
 		"posting_time": posting_time,
 	}
 
-	extra_cond = ""
-
 	if inventory_dimensions_dict:
-		inventory_dimensions_fieldname = [d.get("fieldname") for d in get_inventory_dimensions()]
+		# Dimensions are a quantity-only sub-ledger (Inventory Dimension Entry); they no longer
+		# live on Stock Ledger Entry. The dimension-filtered figure is therefore a qty only -
+		# the valuation rate is not dimension-specific.
+		from erpnext.stock.doctype.inventory_dimension_bundle.inventory_dimension_bundle import (
+			get_dimension_sub_ledger_balance,
+		)
 
+		valid_fields = {d.get("fieldname"): d.get("source_fieldname") for d in get_inventory_dimensions()}
+		combination = {}
 		for field, value in inventory_dimensions_dict.items():
-			if field not in inventory_dimensions_fieldname:
+			if field not in valid_fields:
 				frappe.throw(
 					_("{0} is not a valid {1} fieldname.").format(
 						frappe.bold(field), frappe.bold("Inventory Dimension")
 					)
 				)
-			args[field] = value
-			extra_cond += f" and {field} = %({field})s"
+			combination[valid_fields.get(field) or field] = value
 
-	last_entry = get_previous_sle(args, extra_cond=extra_cond)
+		qty = get_dimension_sub_ledger_balance(
+			item_code,
+			warehouse,
+			combination,
+			posting_datetime=get_combine_datetime(posting_date, posting_time),
+			inclusive=True,
+		)
+
+		if with_valuation_rate:
+			_qty, rate = get_stock_balance(
+				item_code, warehouse, posting_date, posting_time, with_valuation_rate=True
+			)
+
+			_qty = 0 if _qty is None else _qty  # ignore this code
+
+			return (qty, rate, None) if with_serial_no else (qty, rate)
+		return qty
+
+	last_entry = get_previous_sle(args)
 
 	if with_valuation_rate:
 		if with_serial_no:

--- a/erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.js
+++ b/erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.js
@@ -7,7 +7,7 @@ erpnext.landed_cost_taxes_and_charges.setup_triggers("Subcontracting Receipt");
 
 frappe.ui.form.on("Subcontracting Receipt", {
 	setup: (frm) => {
-		frm.ignore_doctypes_on_cancel_all = ["Serial and Batch Bundle"];
+		frm.ignore_doctypes_on_cancel_all = ["Serial and Batch Bundle", "Inventory Dimension Bundle"];
 		frm.get_field("supplied_items").grid.cannot_add_rows = true;
 		frm.get_field("supplied_items").grid.only_sortable();
 		frm.trigger("set_queries");

--- a/erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py
+++ b/erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py
@@ -13,7 +13,6 @@ import erpnext
 from erpnext.controllers.subcontracting_controller import SubcontractingController
 from erpnext.setup.doctype.brand.brand import get_brand_defaults
 from erpnext.setup.doctype.item_group.item_group import get_item_group_defaults
-from erpnext.stock.doctype.inventory_dimension.inventory_dimension import get_inventory_dimensions
 from erpnext.stock.doctype.item.item import get_item_defaults
 from erpnext.stock.get_item_details import get_default_cost_center, get_default_expense_account
 from erpnext.stock.stock_ledger import get_valuation_rate
@@ -195,6 +194,7 @@ class SubcontractingReceipt(SubcontractingController):
 			"Stock Ledger Entry",
 			"Repost Item Valuation",
 			"Serial and Batch Bundle",
+			"Inventory Dimension Bundle",
 		)
 		self.validate_closed_subcontracting_order()
 		self.update_status_updater_args()
@@ -315,20 +315,15 @@ class SubcontractingReceipt(SubcontractingController):
 				)
 
 	def set_supplied_items_inventory_dimensions(self):
-		if hasattr(self, "inventory_dimensions") and (inventory_dimensions := get_inventory_dimensions()):
-			for item in self.supplied_items:
-				key = (
-					item.reference_name,
-					item.rm_item_code,
-					item.main_item_code,
-					item.batch_no,
-					item.serial_no,
-				)
+		"""Restore the Inventory Dimension Bundle captured before the supplied items were rebuilt."""
+		saved = getattr(self, "_supplied_item_dimension_bundles", None)
+		if not saved:
+			return
 
-				for dimension in inventory_dimensions:
-					dimension_values = self.inventory_dimensions.get(dimension.source_fieldname, {})
-					if key in dimension_values:
-						item.set(dimension.source_fieldname, dimension_values[key])
+		for item in self.supplied_items:
+			key = (item.reference_name, item.rm_item_code, item.main_item_code)
+			if not item.get("inventory_dimension_bundle") and key in saved:
+				item.inventory_dimension_bundle = saved[key]
 
 	def set_supplied_items_expense_account(self):
 		for item in self.supplied_items:
@@ -347,17 +342,16 @@ class SubcontractingReceipt(SubcontractingController):
 				)
 
 	def save_inventory_dimensions(self):
-		if inventory_dimensions := get_inventory_dimensions():
-			if not getattr(self, "inventory_dimensions", None):
-				self.inventory_dimensions = {}
+		"""Capture each supplied item's Inventory Dimension Bundle before the table is rebuilt.
 
-			for dimension in inventory_dimensions:
-				self.inventory_dimensions[dimension.source_fieldname] = {
-					(d.reference_name, d.rm_item_code, d.main_item_code, d.batch_no, d.serial_no): d.get(
-						dimension.source_fieldname
-					)
-					for d in self.supplied_items
-				}
+		The supplied items are reset and rebuilt from the BOM on save (``reset_supplied_items``);
+		stash the bundle links so they can be restored onto the matching rebuilt rows.
+		"""
+		self._supplied_item_dimension_bundles = {
+			(d.reference_name, d.rm_item_code, d.main_item_code): d.inventory_dimension_bundle
+			for d in self.supplied_items
+			if d.get("inventory_dimension_bundle")
+		}
 
 	def reset_supplied_items(self):
 		if (

--- a/erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py
+++ b/erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py
@@ -321,9 +321,25 @@ class SubcontractingReceipt(SubcontractingController):
 			return
 
 		for item in self.supplied_items:
-			key = (item.reference_name, item.rm_item_code, item.main_item_code)
+			key = self._supplied_item_dimension_key(item)
 			if not item.get("inventory_dimension_bundle") and key in saved:
 				item.inventory_dimension_bundle = saved[key]
+
+	@staticmethod
+	def _supplied_item_dimension_key(item):
+		"""Stable identity of a supplied row across the BOM rebuild.
+
+		The batch / serial identity is part of the key so the same RM consumed against the same
+		finished good across multiple batches keeps a distinct bundle per row instead of collapsing
+		to (and restoring) a single one.
+		"""
+		return (
+			item.reference_name,
+			item.rm_item_code,
+			item.main_item_code,
+			item.get("batch_no"),
+			item.get("serial_no"),
+		)
 
 	def set_supplied_items_expense_account(self):
 		for item in self.supplied_items:
@@ -348,7 +364,7 @@ class SubcontractingReceipt(SubcontractingController):
 		stash the bundle links so they can be restored onto the matching rebuilt rows.
 		"""
 		self._supplied_item_dimension_bundles = {
-			(d.reference_name, d.rm_item_code, d.main_item_code): d.inventory_dimension_bundle
+			self._supplied_item_dimension_key(d): d.inventory_dimension_bundle
 			for d in self.supplied_items
 			if d.get("inventory_dimension_bundle")
 		}

--- a/erpnext/subcontracting/doctype/subcontracting_receipt/test_subcontracting_receipt.py
+++ b/erpnext/subcontracting/doctype/subcontracting_receipt/test_subcontracting_receipt.py
@@ -2036,10 +2036,9 @@ class TestSubcontractingReceipt(ERPNextTestSuite):
 		frappe.flags["args"].pop("items", None)
 
 	def test_inventory_dimensions(self):
-		"""
-		The subcontracting controller resets the supplied items table on each save. This test ensures
-		the inventory dimension bundle linked on a supplied item is retained across saves.
-		"""
+		"""Inventory Dimension Bundles attached to a subcontracting RM transfer Stock Entry and to a
+		Subcontracting Receipt are stamped, submitted and posted to the quantity sub-ledger."""
+		from erpnext.controllers.subcontracting_controller import make_rm_stock_entry
 		from erpnext.stock.doctype.inventory_dimension.test_inventory_dimension import (
 			create_inventory_dimension,
 			make_inventory_dimension_bundle,
@@ -2049,11 +2048,6 @@ class TestSubcontractingReceipt(ERPNextTestSuite):
 		# Inventory Dimensions are gated behind a feature flag; enable it for this test only.
 		frappe.flags.enable_inventory_dimension = 1
 		self.addCleanup(frappe.flags.pop, "enable_inventory_dimension", None)
-
-		# Inventory Dimension records are committed via Custom Field DDL, so a sibling test's
-		# mandatory (reqd) dimension can leak in and block this test's bundle-less setup receipts.
-		# Neutralise those flags for this run (rolled back at teardown).
-		reset_inventory_dimension_flags()
 
 		create_inventory_dimension(
 			apply_to_all_doctypes=1,
@@ -2065,26 +2059,81 @@ class TestSubcontractingReceipt(ERPNextTestSuite):
 
 		sco = get_subcontracting_order()
 		rm_items = get_rm_items(sco.supplied_items)
-		itemwise_details = make_stock_in_entry(rm_items=rm_items)
-		make_stock_transfer_entry(
-			sco_no=sco.name,
-			rm_items=rm_items,
-			itemwise_details=copy.deepcopy(itemwise_details),
+
+		# Inventory Dimension records are committed via Custom Field DDL, so a sibling test's mandatory
+		# (reqd) dimension can leak in and demand a bundle on rows this test does not stamp - notably the
+		# receipt's RM consumption, which flows through ``supplied_items`` and cannot carry a bundle.
+		# Neutralise those flags only now, after the heavy SCO setup (whose commits/rollbacks could
+		# otherwise revert the change), so the neutralisation is live for the stock movements below.
+		reset_inventory_dimension_flags()
+
+		# Stamp a dimension bundle on each RM receipt so its Stock Ledger Entry carries one. This keeps
+		# the receipt valid even if a leaked mandatory dimension survives reset on a shared test runner.
+		for row in rm_items:
+			warehouse = row.get("warehouse") or "_Test Warehouse - _TC"
+			row["inventory_dimension_bundle"] = make_inventory_dimension_bundle(
+				row["item_code"], warehouse, [{"qty": row["qty"], "inv_site": "Site 1"}]
+			)
+		make_stock_in_entry(rm_items=rm_items)
+
+		# --- RM transfer Stock Entry ("Send to Subcontractor") ----------------------------------
+		# Mirrors the UI: build the transfer, attach a dimension bundle to each RM row, then submit.
+		ste = frappe.get_doc(make_rm_stock_entry(sco.name))
+		for row in ste.items:
+			row.inventory_dimension_bundle = make_inventory_dimension_bundle(
+				row.item_code, row.s_warehouse, [{"qty": row.qty, "inv_site": "Site 1"}]
+			)
+		ste.insert()
+		ste.submit()
+		ste.reload()
+
+		source_bundle = ste.items[0].inventory_dimension_bundle
+		self.assertTrue(source_bundle, "RM transfer did not retain its inventory dimension bundle")
+		self.assertEqual(
+			frappe.db.get_value("Inventory Dimension Bundle", source_bundle, "docstatus"),
+			1,
+			"RM transfer bundle was not submitted on stock posting",
 		)
+		# A two-legged transfer posts a bundle on both the source (outward) and target (inward) SLE.
+		sle_bundles = frappe.get_all(
+			"Stock Ledger Entry",
+			filters={"voucher_type": "Stock Entry", "voucher_no": ste.name, "is_cancelled": 0},
+			pluck="inventory_dimension_bundle",
+		)
+		self.assertTrue(sle_bundles, "RM transfer posted no stock ledger entries")
+		self.assertTrue(
+			all(sle_bundles), "A leg of the RM transfer posted to the ledger without a dimension bundle"
+		)
+
+		# --- Subcontracting Receipt -------------------------------------------------------------
 		scr = make_subcontracting_receipt(sco.name)
 		scr.save()
 
-		supplied = scr.supplied_items[0]
-		warehouse = supplied.get("warehouse") or "_Test Warehouse - _TC"
-		bundle = make_inventory_dimension_bundle(
-			supplied.rm_item_code,
-			warehouse,
-			[{"qty": supplied.required_qty, "inv_site": "Site 1"}],
+		received = scr.items[0]
+		received.inventory_dimension_bundle = make_inventory_dimension_bundle(
+			received.item_code, received.warehouse, [{"qty": received.qty, "inv_site": "Site 1"}]
 		)
-		scr.supplied_items[0].inventory_dimension_bundle = bundle
-		scr.save()
+		scr.submit()
+		scr.reload()
 
-		self.assertEqual(scr.supplied_items[0].inventory_dimension_bundle, bundle)
+		receipt_bundle = scr.items[0].inventory_dimension_bundle
+		self.assertTrue(receipt_bundle, "Subcontracting Receipt did not retain its dimension bundle")
+		self.assertEqual(
+			frappe.db.get_value("Inventory Dimension Bundle", receipt_bundle, "docstatus"),
+			1,
+			"Subcontracting Receipt bundle was not submitted on stock posting",
+		)
+		self.assertTrue(
+			frappe.db.exists(
+				"Stock Ledger Entry",
+				{
+					"voucher_type": "Subcontracting Receipt",
+					"voucher_no": scr.name,
+					"inventory_dimension_bundle": receipt_bundle,
+				},
+			),
+			"Subcontracting Receipt's finished-good SLE did not carry the dimension bundle",
+		)
 
 
 def make_return_subcontracting_receipt(**args):

--- a/erpnext/subcontracting/doctype/subcontracting_receipt/test_subcontracting_receipt.py
+++ b/erpnext/subcontracting/doctype/subcontracting_receipt/test_subcontracting_receipt.py
@@ -2106,6 +2106,8 @@ class TestSubcontractingReceipt(ERPNextTestSuite):
 		)
 
 		# --- Subcontracting Receipt -------------------------------------------------------------
+		# Stamp a bundle on the received finished good (items) and on the consumed raw material
+		# (supplied_items); both must be submitted and posted to the sub-ledger on receipt submit.
 		scr = make_subcontracting_receipt(sco.name)
 		scr.save()
 
@@ -2113,6 +2115,14 @@ class TestSubcontractingReceipt(ERPNextTestSuite):
 		received.inventory_dimension_bundle = make_inventory_dimension_bundle(
 			received.item_code, received.warehouse, [{"qty": received.qty, "inv_site": "Site 1"}]
 		)
+
+		supplied = scr.supplied_items[0]
+		supplied.inventory_dimension_bundle = make_inventory_dimension_bundle(
+			supplied.rm_item_code,
+			scr.supplier_warehouse,
+			[{"qty": supplied.consumed_qty, "inv_site": "Site 1"}],
+		)
+
 		scr.submit()
 		scr.reload()
 
@@ -2133,6 +2143,43 @@ class TestSubcontractingReceipt(ERPNextTestSuite):
 				},
 			),
 			"Subcontracting Receipt's finished-good SLE did not carry the dimension bundle",
+		)
+
+		# The supplied (consumed RM) bundle is submitted too, and the supplier-warehouse consumption
+		# SLE carries it - so a dimension bundle on supplied_items is no longer left in draft.
+		supplied_bundle = scr.supplied_items[0].inventory_dimension_bundle
+		self.assertTrue(supplied_bundle, "Subcontracting Receipt dropped the supplied item's bundle")
+		self.assertEqual(
+			frappe.db.get_value("Inventory Dimension Bundle", supplied_bundle, "docstatus"),
+			1,
+			"Supplied item's dimension bundle was not submitted on stock posting",
+		)
+		self.assertTrue(
+			frappe.db.exists(
+				"Stock Ledger Entry",
+				{
+					"voucher_type": "Subcontracting Receipt",
+					"voucher_no": scr.name,
+					"inventory_dimension_bundle": supplied_bundle,
+				},
+			),
+			"Supplied item's consumption SLE did not carry the dimension bundle",
+		)
+
+		# Cancelling the receipt cancels both bundles and unlinks them from their rows (so a later
+		# amend does not carry a link to a cancelled document).
+		scr.reload()
+		scr.cancel()
+		for bundle in (receipt_bundle, supplied_bundle):
+			self.assertEqual(
+				frappe.db.get_value("Inventory Dimension Bundle", bundle, "docstatus"),
+				2,
+				"Dimension bundle was not cancelled with its receipt",
+			)
+		scr.reload()
+		self.assertFalse(scr.items[0].inventory_dimension_bundle, "Finished-good bundle was not unlinked")
+		self.assertFalse(
+			scr.supplied_items[0].inventory_dimension_bundle, "Supplied item bundle was not unlinked"
 		)
 
 

--- a/erpnext/subcontracting/doctype/subcontracting_receipt/test_subcontracting_receipt.py
+++ b/erpnext/subcontracting/doctype/subcontracting_receipt/test_subcontracting_receipt.py
@@ -2037,22 +2037,29 @@ class TestSubcontractingReceipt(ERPNextTestSuite):
 
 	def test_inventory_dimensions(self):
 		"""
-		The subcontracting controller resets the supplied items table on each save causing the inventory dimensions to be lost.
-		This test ensures that the inventory dimensions are retained on each save.
+		The subcontracting controller resets the supplied items table on each save. This test ensures
+		the inventory dimension bundle linked on a supplied item is retained across saves.
 		"""
 		from erpnext.stock.doctype.inventory_dimension.test_inventory_dimension import (
 			create_inventory_dimension,
+			make_inventory_dimension_bundle,
+			reset_inventory_dimension_flags,
 		)
 
-		inventory_dimension = create_inventory_dimension(
+		# Inventory Dimensions are gated behind a feature flag; enable it for this test only.
+		frappe.flags.enable_inventory_dimension = 1
+		self.addCleanup(frappe.flags.pop, "enable_inventory_dimension", None)
+
+		# Inventory Dimension records are committed via Custom Field DDL, so a sibling test's
+		# mandatory (reqd) dimension can leak in and block this test's bundle-less setup receipts.
+		# Neutralise those flags for this run (rolled back at teardown).
+		reset_inventory_dimension_flags()
+
+		create_inventory_dimension(
 			apply_to_all_doctypes=1,
 			dimension_name="Inv Site",
 			reference_document="Inv Site",
-			document_type="Inv Site",
 		)
-
-		inventory_dimension.reqd = 1
-		inventory_dimension.save()
 
 		set_backflush_based_on("BOM")
 
@@ -2065,16 +2072,19 @@ class TestSubcontractingReceipt(ERPNextTestSuite):
 			itemwise_details=copy.deepcopy(itemwise_details),
 		)
 		scr = make_subcontracting_receipt(sco.name)
-		scr.items[0].inv_site = "Site 1"
 		scr.save()
 
-		scr.supplied_items[0].inv_site = "Site 1"
+		supplied = scr.supplied_items[0]
+		warehouse = supplied.get("warehouse") or "_Test Warehouse - _TC"
+		bundle = make_inventory_dimension_bundle(
+			supplied.rm_item_code,
+			warehouse,
+			[{"qty": supplied.required_qty, "inv_site": "Site 1"}],
+		)
+		scr.supplied_items[0].inventory_dimension_bundle = bundle
 		scr.save()
 
-		self.assertEqual(scr.supplied_items[0].inv_site, "Site 1")
-
-		inventory_dimension.reqd = 0
-		inventory_dimension.save()
+		self.assertEqual(scr.supplied_items[0].inventory_dimension_bundle, bundle)
 
 
 def make_return_subcontracting_receipt(**args):

--- a/erpnext/subcontracting/doctype/subcontracting_receipt_item/subcontracting_receipt_item.json
+++ b/erpnext/subcontracting/doctype/subcontracting_receipt_item/subcontracting_receipt_item.json
@@ -62,6 +62,12 @@
   "rejected_serial_no",
   "column_break_henr",
   "batch_no",
+  "inventory_dimension_section",
+  "add_inventory_dimension",
+  "inventory_dimension_bundle",
+  "column_break_inv_dim",
+  "add_inventory_dimension_for_rejected_qty",
+  "rejected_inventory_dimension_bundle",
   "manufacture_details",
   "manufacturer",
   "column_break_16",
@@ -499,6 +505,46 @@
    "print_hide": 1
   },
   {
+   "fieldname": "inventory_dimension_bundle",
+   "fieldtype": "Link",
+   "label": "Inventory Dimension Bundle",
+   "no_copy": 1,
+   "options": "Inventory Dimension Bundle",
+   "print_hide": 1,
+   "search_index": 1
+  },
+  {
+   "fieldname": "column_break_inv_dim",
+   "fieldtype": "Column Break"
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "inventory_dimension_section",
+   "fieldtype": "Section Break",
+   "label": "Inventory Dimension"
+  },
+  {
+   "depends_on": "eval:parent.docstatus == 0",
+   "fieldname": "add_inventory_dimension",
+   "fieldtype": "Button",
+   "label": "Add Inventory Dimension"
+  },
+  {
+   "depends_on": "eval:parent.docstatus == 0",
+   "fieldname": "add_inventory_dimension_for_rejected_qty",
+   "fieldtype": "Button",
+   "label": "Add Inventory Dimension (Rejected Qty)"
+  },
+  {
+   "fieldname": "rejected_inventory_dimension_bundle",
+   "fieldtype": "Link",
+   "label": "Rejected Inventory Dimension Bundle",
+   "no_copy": 1,
+   "options": "Inventory Dimension Bundle",
+   "print_hide": 1,
+   "search_index": 1
+  },
+  {
    "depends_on": "eval:(doc.use_serial_batch_fields === 0 || doc.docstatus === 1) && !doc.secondary_item_type && !doc.is_legacy_scrap_item",
    "fieldname": "rejected_serial_and_batch_bundle",
    "fieldtype": "Link",
@@ -635,7 +681,7 @@
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-06-01 10:00:00.000000",
+ "modified": "2026-06-21 10:00:00.000000",
  "modified_by": "Administrator",
  "module": "Subcontracting",
  "name": "Subcontracting Receipt Item",

--- a/erpnext/subcontracting/doctype/subcontracting_receipt_supplied_item/subcontracting_receipt_supplied_item.json
+++ b/erpnext/subcontracting/doctype/subcontracting_receipt_supplied_item/subcontracting_receipt_supplied_item.json
@@ -34,6 +34,9 @@
   "serial_no",
   "column_break_qibi",
   "batch_no",
+  "inventory_dimension_section",
+  "add_inventory_dimension",
+  "inventory_dimension_bundle",
   "accounting_details_section",
   "expense_account",
   "accounting_dimensions_section",
@@ -216,6 +219,27 @@
    "print_hide": 1
   },
   {
+   "fieldname": "inventory_dimension_bundle",
+   "fieldtype": "Link",
+   "label": "Inventory Dimension Bundle",
+   "no_copy": 1,
+   "options": "Inventory Dimension Bundle",
+   "print_hide": 1,
+   "search_index": 1
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "inventory_dimension_section",
+   "fieldtype": "Section Break",
+   "label": "Inventory Dimension"
+  },
+  {
+   "depends_on": "eval:parent.docstatus == 0",
+   "fieldname": "add_inventory_dimension",
+   "fieldtype": "Button",
+   "label": "Add Inventory Dimension"
+  },
+  {
    "default": "0",
    "fieldname": "use_serial_batch_fields",
    "fieldtype": "Check",
@@ -264,7 +288,7 @@
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-05-27 12:33:58.772638",
+ "modified": "2026-06-21 10:00:00.000000",
  "modified_by": "Administrator",
  "module": "Subcontracting",
  "name": "Subcontracting Receipt Supplied Item",


### PR DESCRIPTION
# Inventory Dimension

Inventory Dimensions let you track stock against extra parameters beyond the built-in ones (Warehouse, Batch, Serial No). A dimension can be anything you need to slice inventory by — **Rack**, **Bin**, **Shelf**, **Project**, **Zone**, and so on.

> **What changed in v16**
>
> The Inventory Dimension feature has been redesigned. Earlier, creating a dimension added custom fields to **every** stock transaction doctype (~23 of them) plus the Stock Ledger Entry. On large databases this triggered a storm of `ALTER TABLE` statements, and service (non-stock) items wrongly demanded dimension values.
>
> The new design stores dimension data in a dedicated **quantity sub-ledger** built from two doctypes, and every transaction carries a **single** link field. Creating a dimension now alters exactly **one** table.

To create one, go to:

> **Home > Stock > Settings > Inventory Dimension**

---

## 1. Concepts

| Concept | Description |
|---|---|
| **Inventory Dimension** | The definition record (e.g. "Rack"). Configuring it adds one column to the sub-ledger and makes the dimension available for capture on transactions. |
| **Inventory Dimension Bundle** | A submittable document that groups the dimension values captured for a single transaction line, along with quantity. One bundle per item row. Conceptually mirrors the **Serial and Batch Bundle**, but tracks **quantity only** (no valuation). |
| **Inventory Dimension Entry** | The child rows inside a bundle. **These rows are the quantity sub-ledger** — the running balance of any dimension combination is the signed sum of these entries (inward adds, outward subtracts). |
| **`inventory_dimension_bundle`** | A single Link field present on all stock transaction item rows and on the Stock Ledger Entry. It points to the bundle for that line. |

---

## 2. Creating an Inventory Dimension

1. Create a new **Inventory Dimension** record.
2. Set the **Reference Document** — the master against which the dimension is a custom link (for example, a **Warehouse**-like custom doctype "Rack"). The reference document **cannot** be a child table, nor one of `Batch`, `Serial No`, `Warehouse`, or `Item` (those are already built in).
3. Enter a **Dimension Name**. The system derives the field name from it and creates a single Link column on the **Inventory Dimension Entry** sub-ledger.

When you save, **only one table is altered** (Inventory Dimension Entry) — not
every stock doctype as before.

### Applicable For

- **Apply to All Inventory Document Types** (default ON) — the dimension can be captured on every stock transaction.
- Turn it **OFF** to target a specific **Document Type** and/or add a **Conditional Rule**. This is how you build directional dimensions such as a "From Shelf" that only applies to outward (issue) lines and a "To Shelf" that only applies to inward (receipt) lines, using **Type of Transaction** (Inward / Outward / Both) and the **Conditional Rule** code.

### Fetch Value From

Auto-populates the dimension value from a field on the parent form, so you don't
re-enter it on every line.

### Mandatory

- **Mandatory** / **Mandatory Depends On** — make capture compulsory. The check
  is enforced by the controller and is **gated on `is_stock_item`**, so
  **service items no longer demand dimension values**.

---

## 3. Negative Stock Validation

Tick **Validate Negative Stock** to block a transaction that would drive a dimension's balance below zero.

When this is enabled, a new option appears:

### Negative Stock Validation Method

| Option | Behaviour |
|---|---|
| **Per Dimension** *(default)* | Each dimension's balance is validated **independently**. e.g. `Rack=A` must have enough stock regardless of which `Bin` it sits in. |
| **Combined** | The **exact combination** of all combined-method dimensions on a line is validated **together**. e.g. only `Rack=A` **and** `Bin=X` jointly must have enough stock. |

The two methods can be mixed across dimensions: combined-method dimensions are validated as one joint balance, while per-dimension dimensions are each checked on their own.

Availability is taken from the quantity sub-ledger **strictly before** the posting datetime of the transaction being submitted, so back-dated and same-instant postings are handled correctly. The check runs when the **Inventory Dimension Bundle** is submitted.

---

## 4. Capturing dimensions on a transaction

1. Open any stock transaction (Stock Entry, Delivery Note, Purchase Receipt, …).
2. On an item **row**, open the **Inventory Dimension** selector. It shows one column per applicable dimension plus a **Qty** column.
3. Enter the dimension values and quantities. This creates a draft **Inventory Dimension Bundle** linked to the row via `inventory_dimension_bundle`.
4. On submit, the bundle's total quantity is reconciled against the row quantity, the bundle is submitted, and its entries post to the sub-ledger.

> Only **stock items** participate. Rows whose item has `is_stock_item`
> disabled never require — and are never blocked for — a dimension bundle.

---

## 5. How it works now

```
Transaction row ──(inventory_dimension_bundle)──▶ Inventory Dimension Bundle
                                                        │ entries
                                                        ▼
Stock Ledger Entry ─(inventory_dimension_bundle)─▶ Inventory Dimension Entry  ◀── the sub-ledger
```

- **One link field, everywhere.** Every stock transaction item row and the Stock Ledger Entry carry a single `inventory_dimension_bundle` link - analogous to `serial_and_batch_bundle`.
- **Entries are the ledger.** The balance of any item / warehouse / dimension combination is `Σ(qty signed by direction)` over non-cancelled Inventory Dimension Entry rows. There is no per-dimension column on 23 doctypes.
- **One ALTER per dimension.** Adding a dimension adds one Link column to Inventory Dimension Entry only.
- **Submit / cancel.** Submitting a transaction submits its bundles (posting the sub-ledger); cancelling reverses them. Cancellation marks the bundle and its entries `is_cancelled = 1` and exempts the still-submitted voucher and the immutable Stock Ledger Entry from the back-link check.

---

## 6. Reporting

Stock reports (Stock Balance, Stock Ledger) continue to support dimension-based filtering. Balances for dimension combinations are read from the **Inventory Dimension Entry** sub-ledger rather than from columns on the Stock
Ledger Entry.

---

## 7. Stock Reconciliation

Stock Reconciliation supports **opening value** entry only when a dimension is active; quantity/valuation changes against an active dimension are not permitted, the same restriction as before.

---

## 8. Migrating from the old design

Two patches handle the transition automatically on upgrade:

1. **`migrate_inventory_dimensions_to_bundles`** — reconstructs the quantity sub-ledger. It adds the per-dimension column(s) to Inventory Dimension Entry and backfills one bundle per voucher row from the existing Stock Ledger Entries, preserving balances exactly.

2. **`drop_legacy_inventory_dimension_fields`** — once data is on the sub-ledger, removes the now-redundant **Custom Field** definitions the old design scattered across the stock doctypes and the Stock Ledger Entry. It identifies those fields **structurally** so it never touches a standard field (e.g. the core `project` field), a legitimate user custom field of the same name, or the new sub-ledger column. Only Custom Field *definitions* are removed — no transaction data is deleted.

No manual steps are required; balances are preserved through the migration.

---

## Summary of fields on the Inventory Dimension form

| Field | Purpose |
|---|---|
| **Reference Document** | Master the dimension links to (not a child table; not Batch/Serial No/Warehouse/Item). |
| **Dimension Name** | Name of the dimension; drives the sub-ledger column name. |
| **Apply to All Inventory Document Types** | Make the dimension available on every stock transaction. |
| **Apply to Document** / **Conditional Rule** | Restrict to a specific document type and/or condition. |
| **Type of Transaction** | Inward / Outward / Both — for directional dimensions. |
| **Fetch Value From** | Auto-populate the value from a parent-form field. |
| **Mandatory** / **Mandatory Depends On** | Compulsory capture (gated on stock items). |
| **Validate Negative Stock** | Block transactions that drive the dimension negative. |
| **Negative Stock Validation Method** | Per Dimension (independent) or Combined (exact combination). |
