### PR TITLE
fix(manufacturing): make Work Order Stock report GROUP BY Postgres-valid

### DIFF
--- a/erpnext/manufacturing/report/work_order_stock_report/test_work_order_stock_report.py
+++ b/erpnext/manufacturing/report/work_order_stock_report/test_work_order_stock_report.py
@@ -1,0 +1,24 @@
+# Copyright (c) 2017, Velometro Mobility Inc and contributors
+# For license information, please see license.txt
+
+import frappe
+
+from erpnext.tests.utils import ERPNextTestSuite
+
+
+class TestWorkOrderStockReport(ERPNextTestSuite):
+	def test_report_executes_and_lists_work_order(self):
+		# get_item_list computes build_qty by multiplying bin/bom/bom_item columns that are not
+		# functionally dependent on the grouped item_code; they must be in the GROUP BY for the
+		# report to run on Postgres. This exercises that query on both engines.
+		from erpnext.manufacturing.doctype.work_order.test_work_order import make_wo_order_test_record
+		from erpnext.manufacturing.report.work_order_stock_report.work_order_stock_report import execute
+
+		wo = make_wo_order_test_record(
+			production_item="_Test FG Item", qty=1, source_warehouse="_Test Warehouse - _TC"
+		)
+
+		columns, data = execute(frappe._dict(warehouse="_Test Warehouse - _TC"))
+
+		self.assertTrue(columns)
+		self.assertIn(wo.name, {row["work_order"] for row in data})

--- a/erpnext/manufacturing/report/work_order_stock_report/work_order_stock_report.py
+++ b/erpnext/manufacturing/report/work_order_stock_report/work_order_stock_report.py
@@ -47,7 +47,10 @@ def get_item_list(wo_list, filters):
 						& (bom_item.item_code == wo_item_details.item_code)
 						& (bom.name == wo_details.bom_no)
 					)
-					.groupby(bom_item.item_code)
+					# build_qty multiplies columns from bin/bom/bom_item that aren't functionally
+					# dependent on the grouped item_code, so postgres requires them in the GROUP BY.
+					# The WHERE pins bom, item and warehouse to single rows, so this stays one row.
+					.groupby(bom_item.item_code, bom.quantity, bom_item.stock_qty, bin.actual_qty)
 				).run(as_dict=1)
 
 				stock_qty = 0


### PR DESCRIPTION
## What

`get_item_list()` in the Work Order Stock report computes `build_qty` as

```python
IfNull(bin.actual_qty * bom.quantity / bom_item.stock_qty, 0).as_("build_qty")
```

while grouping only by `bom_item.item_code`. The three operand columns are neither grouped nor aggregated — MariaDB arbitrary-picks them, but **Postgres rejects the query** with `column "…" must appear in the GROUP BY clause`, so the report is broken on Postgres.

## Fix

Add `bom.quantity`, `bom_item.stock_qty`, `bin.actual_qty` to the `GROUP BY`.

## Why it's MariaDB-identical

The `WHERE` pins `bom`/`item` and the join condition pins `warehouse` to single rows (`Bin` is unique per item+warehouse), so each `item_code` group still resolves to exactly one row. Output on MariaDB is unchanged; the query is now valid on Postgres.

> Note: develop's current state for this file is the revert (`8dacf62da0`) of the earlier parity batch, so this re-lands the GROUP BY fix in isolation.

## Tests

New `test_work_order_stock_report.py` (no test file existed) creates a Work Order and asserts the report runs and lists it. Passes on **MariaDB and Postgres**.