### PR TITLE
refactor(postgres): Authorization Control + startup boot raw SQL → qb/ORM

### DIFF
--- a/erpnext/setup/doctype/authorization_control/authorization_control.py
+++ b/erpnext/setup/doctype/authorization_control/authorization_control.py
@@ -4,6 +4,7 @@
 
 import frappe
 from frappe import _, session
+from frappe.query_builder.functions import Coalesce
 from frappe.utils import comma_or, cstr, flt, has_common
 
 from erpnext.utilities.transaction_base import TransactionBase
@@ -41,7 +42,7 @@ class AuthorizationControl(TransactionBase):
 				app_dtl = frappe.db.sql(
 					"""select approving_user, approving_role from `tabAuthorization Rule`
 					where transaction = {} and (value = {} or value > {}) and docstatus != 2
-					and based_on = {} and ifnull(company,'') = '' {}""".format(
+					and based_on = {} and coalesce(company,'') = '' {}""".format(
 						"%s", "%s", "%s", "%s", condition
 					),
 					(doctype_name, flt(max_amount), total, based_on),
@@ -77,7 +78,7 @@ class AuthorizationControl(TransactionBase):
 				itemwise_exists = frappe.db.sql(
 					"""select value from `tabAuthorization Rule`
 					where transaction = {} and value <= {} and based_on = {}
-					and ifnull(company,'') = ''	and docstatus != 2 {} {}""".format(
+					and coalesce(company,'') = ''	and docstatus != 2 {} {}""".format(
 						"%s", "%s", "%s", cond, add_cond1
 					),
 					(doctype_name, total, based_on),
@@ -90,7 +91,7 @@ class AuthorizationControl(TransactionBase):
 				chk = 0
 		if chk == 1:
 			if based_on in ["Itemwise Discount", "Item Group wise Discount"]:
-				add_cond2 += " and ifnull(master_name,'') = ''"
+				add_cond2 += " and coalesce(master_name,'') = ''"
 
 			appr = frappe.db.sql(
 				"""select value from `tabAuthorization Rule`
@@ -103,7 +104,7 @@ class AuthorizationControl(TransactionBase):
 				appr = frappe.db.sql(
 					"""select value from `tabAuthorization Rule`
 					where transaction = {} and value <= {} and based_on = {}
-					and ifnull(company,'') = '' and docstatus != 2 {} {}""".format(
+					and coalesce(company,'') = '' and docstatus != 2 {} {}""".format(
 						"%s", "%s", "%s", cond, add_cond2
 					),
 					(doctype_name, total, based_on),
@@ -124,7 +125,7 @@ class AuthorizationControl(TransactionBase):
 				frappe.db.escape(r) for r in frappe.get_roles()
 			)
 		else:
-			add_cond += " and ifnull(system_user,'') = '' and ifnull(system_role,'') = ''"
+			add_cond += " and coalesce(system_user,'') = '' and coalesce(system_role,'') = ''"
 
 		if based_on == "Grand Total":
 			auth_value = total
@@ -175,15 +176,22 @@ class AuthorizationControl(TransactionBase):
 			"Item Group wise Discount",
 		]
 
+		auth_rule = frappe.qb.DocType("Authorization Rule")
+
 		# Check for authorization set for individual user
 		based_on = [
 			x[0]
-			for x in frappe.db.sql(
-				"""select distinct based_on from `tabAuthorization Rule`
-			where transaction = %s and system_user = %s
-			and (company = %s or ifnull(company,'')='') and docstatus != 2""",
-				(doctype_name, session["user"], company),
-			)
+			for x in (
+				frappe.qb.from_(auth_rule)
+				.select(auth_rule.based_on)
+				.distinct()
+				.where(
+					(auth_rule.transaction == doctype_name)
+					& (auth_rule.system_user == session["user"])
+					& ((auth_rule.company == company) | (Coalesce(auth_rule.company, "") == ""))
+					& (auth_rule.docstatus != 2)
+				)
+			).run()
 		]
 
 		for d in based_on:
@@ -200,20 +208,17 @@ class AuthorizationControl(TransactionBase):
 		# Check for authorization set on particular roles
 		based_on = [
 			x[0]
-			for x in frappe.db.sql(
-				"""select based_on
-			from `tabAuthorization Rule`
-			where transaction = {} and system_role IN ({}) and based_on IN ({})
-			and (company = {} or ifnull(company,'')='')
-			and docstatus != 2
-		""".format(
-					"%s",
-					", ".join(frappe.db.escape(r) for r in frappe.get_roles()),
-					", ".join(frappe.db.escape(b) for b in final_based_on),
-					"%s",
-				),
-				(doctype_name, company),
-			)
+			for x in (
+				frappe.qb.from_(auth_rule)
+				.select(auth_rule.based_on)
+				.where(
+					(auth_rule.transaction == doctype_name)
+					& auth_rule.system_role.isin(frappe.get_roles())
+					& auth_rule.based_on.isin(final_based_on)
+					& ((auth_rule.company == company) | (Coalesce(auth_rule.company, "") == ""))
+					& (auth_rule.docstatus != 2)
+				)
+			).run()
 		]
 
 		for d in based_on:
@@ -232,23 +237,38 @@ class AuthorizationControl(TransactionBase):
 			self.bifurcate_based_on_type(doctype_name, total, av_dis, g, doc_obj, 0, company)
 
 	def get_value_based_rule(self, doctype_name, employee, total_claimed_amount, company):
+		auth_rule = frappe.qb.DocType("Authorization Rule")
+		emp = frappe.qb.DocType("Employee")
+
+		def emp_designation():
+			# fresh subquery per use to avoid sharing a pypika builder across queries
+			return frappe.qb.from_(emp).select(emp.designation).where(emp.name == employee)
+
 		val_lst = []
-		val = frappe.db.sql(
-			"""select value from `tabAuthorization Rule`
-			where transaction=%s and (to_emp=%s or
-				to_designation IN (select designation from `tabEmployee` where name=%s))
-			and ifnull(value,0)< %s and company = %s and docstatus!=2""",
-			(doctype_name, employee, employee, total_claimed_amount, company),
-		)
+		val = (
+			frappe.qb.from_(auth_rule)
+			.select(auth_rule.value)
+			.where(
+				(auth_rule.transaction == doctype_name)
+				& ((auth_rule.to_emp == employee) | auth_rule.to_designation.isin(emp_designation()))
+				& (Coalesce(auth_rule.value, 0) < total_claimed_amount)
+				& (auth_rule.company == company)
+				& (auth_rule.docstatus != 2)
+			)
+		).run()
 
 		if not val:
-			val = frappe.db.sql(
-				"""select value from `tabAuthorization Rule`
-				where transaction=%s and (to_emp=%s or
-					to_designation IN (select designation from `tabEmployee` where name=%s))
-				and ifnull(value,0)< %s and ifnull(company,'') = '' and docstatus!=2""",
-				(doctype_name, employee, employee, total_claimed_amount),
-			)
+			val = (
+				frappe.qb.from_(auth_rule)
+				.select(auth_rule.value)
+				.where(
+					(auth_rule.transaction == doctype_name)
+					& ((auth_rule.to_emp == employee) | auth_rule.to_designation.isin(emp_designation()))
+					& (Coalesce(auth_rule.value, 0) < total_claimed_amount)
+					& (Coalesce(auth_rule.company, "") == "")
+					& (auth_rule.docstatus != 2)
+				)
+			).run()
 
 		if val:
 			val_lst = [y[0] for y in val]
@@ -256,25 +276,41 @@ class AuthorizationControl(TransactionBase):
 			val_lst.append(0)
 
 		max_val = max(val_lst)
-		rule = frappe.db.sql(
-			"""select name, to_emp, to_designation, approving_role, approving_user
-			from `tabAuthorization Rule`
-			where transaction=%s and company = %s
-			and (to_emp=%s or to_designation IN (select designation from `tabEmployee` where name=%s))
-			and ifnull(value,0)= %s and docstatus!=2""",
-			(doctype_name, company, employee, employee, flt(max_val)),
-			as_dict=1,
-		)
+		rule = (
+			frappe.qb.from_(auth_rule)
+			.select(
+				auth_rule.name,
+				auth_rule.to_emp,
+				auth_rule.to_designation,
+				auth_rule.approving_role,
+				auth_rule.approving_user,
+			)
+			.where(
+				(auth_rule.transaction == doctype_name)
+				& (auth_rule.company == company)
+				& ((auth_rule.to_emp == employee) | auth_rule.to_designation.isin(emp_designation()))
+				& (Coalesce(auth_rule.value, 0) == flt(max_val))
+				& (auth_rule.docstatus != 2)
+			)
+		).run(as_dict=1)
 
 		if not rule:
-			rule = frappe.db.sql(
-				"""select name, to_emp, to_designation, approving_role, approving_user
-				from `tabAuthorization Rule`
-				where transaction=%s and ifnull(company,'') = ''
-				and (to_emp=%s or to_designation IN (select designation from `tabEmployee` where name=%s))
-				and ifnull(value,0)= %s and docstatus!=2""",
-				(doctype_name, employee, employee, flt(max_val)),
-				as_dict=1,
-			)
+			rule = (
+				frappe.qb.from_(auth_rule)
+				.select(
+					auth_rule.name,
+					auth_rule.to_emp,
+					auth_rule.to_designation,
+					auth_rule.approving_role,
+					auth_rule.approving_user,
+				)
+				.where(
+					(auth_rule.transaction == doctype_name)
+					& (Coalesce(auth_rule.company, "") == "")
+					& ((auth_rule.to_emp == employee) | auth_rule.to_designation.isin(emp_designation()))
+					& (Coalesce(auth_rule.value, 0) == flt(max_val))
+					& (auth_rule.docstatus != 2)
+				)
+			).run(as_dict=1)
 
 		return rule

--- a/erpnext/setup/doctype/authorization_control/test_authorization_control.py
+++ b/erpnext/setup/doctype/authorization_control/test_authorization_control.py
@@ -1,0 +1,59 @@
+# Copyright (c) 2025, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt
+
+import frappe
+
+from erpnext.tests.utils import ERPNextTestSuite
+
+
+class TestAuthorizationControl(ERPNextTestSuite):
+	def test_validate_approving_authority_raises_when_over_limit(self):
+		# Exercises validate_approving_authority -> the based_on query-builder lookups and the
+		# coalesce()-based rule lookups (formerly ifnull, which is invalid on Postgres).
+		if not frappe.db.exists("Role", "_Test Approver Role"):
+			frappe.get_doc({"doctype": "Role", "role_name": "_Test Approver Role"}).insert()
+
+		# Run as a non-admin user without the approving role; Administrator implicitly holds every
+		# role, so the not-authorized branch would never fire as Administrator.
+		user = "_test_auth_control_user@example.com"
+		if not frappe.db.exists("User", user):
+			frappe.get_doc(
+				{
+					"doctype": "User",
+					"email": user,
+					"first_name": "Auth Control",
+					"send_welcome_email": 0,
+					"roles": [{"role": "Sales User"}],
+				}
+			).insert(ignore_permissions=True)
+
+		rule = frappe.get_doc(
+			{
+				"doctype": "Authorization Rule",
+				"transaction": "Sales Order",
+				"based_on": "Grand Total",
+				"company": "_Test Company",
+				"value": 1000,
+				"approving_role": "_Test Approver Role",
+			}
+		).insert()
+		self.addCleanup(frappe.delete_doc, "Authorization Rule", rule.name, force=1)
+
+		controller = frappe.get_cached_doc("Authorization Control")
+		frappe.set_user(user)
+		self.addCleanup(frappe.set_user, "Administrator")
+		# User lacks _Test Approver Role and the total exceeds the rule value -> not authorized.
+		self.assertRaises(
+			frappe.ValidationError,
+			controller.validate_approving_authority,
+			"Sales Order",
+			"_Test Company",
+			5000,
+		)
+
+	def test_get_value_based_rule_runs(self):
+		# Exercises the four query-builder lookups (incl. the Employee designation subquery) added in
+		# get_value_based_rule; with no matching rule they must run and return empty on both engines.
+		controller = frappe.get_cached_doc("Authorization Control")
+		result = controller.get_value_based_rule("Expense Claim", "_NONEXISTENT-EMP", 100, "_Test Company")
+		self.assertEqual(list(result), [])

--- a/erpnext/startup/boot.py
+++ b/erpnext/startup/boot.py
@@ -34,28 +34,35 @@ def boot_session(bootinfo):
 		)
 
 		# if no company, show a dialog box to create a new company
-		bootinfo.customer_count = frappe.db.sql("""SELECT count(*) FROM `tabCustomer`""")[0][0]
+		bootinfo.customer_count = frappe.db.count("Customer")
 
 		if not bootinfo.customer_count:
-			bootinfo.setup_complete = (
-				frappe.db.sql(
-					"""SELECT `name`
-				FROM `tabCompany`
-				LIMIT 1"""
-				)
-				and "Yes"
-				or "No"
-			)
+			bootinfo.setup_complete = "Yes" if frappe.db.get_all("Company", limit=1) else "No"
 
-		bootinfo.docs += frappe.db.sql(
-			"""select name, default_currency, cost_center, default_selling_terms, default_buying_terms,
-			default_letter_head, default_letter_head_report, default_bank_account, enable_perpetual_inventory, country, exchange_gain_loss_account from `tabCompany`""",
-			as_dict=1,
-			update={"doctype": ":Company"},
+		companies = frappe.get_all(
+			"Company",
+			fields=[
+				"name",
+				"default_currency",
+				"cost_center",
+				"default_selling_terms",
+				"default_buying_terms",
+				"default_letter_head",
+				"default_letter_head_report",
+				"default_bank_account",
+				"enable_perpetual_inventory",
+				"country",
+				"exchange_gain_loss_account",
+			],
 		)
+		for company in companies:
+			company.doctype = ":Company"
+		bootinfo.docs += companies
 
-		party_account_types = frappe.db.sql(""" select name, ifnull(account_type, '') from `tabParty Type`""")
-		bootinfo.party_account_types = frappe._dict(party_account_types)
+		party_account_types = frappe.get_all("Party Type", fields=["name", "account_type"], as_list=True)
+		bootinfo.party_account_types = frappe._dict(
+			(name, account_type or "") for name, account_type in party_account_types
+		)
 		fiscal_year = erpnext.accounts.utils.get_fiscal_years(
 			frappe.utils.nowdate(), company=get_user_default("company"), raise_on_missing=False
 		)

--- a/erpnext/startup/boot.py
+++ b/erpnext/startup/boot.py
@@ -54,6 +54,7 @@ def boot_session(bootinfo):
 				"country",
 				"exchange_gain_loss_account",
 			],
+			limit_page_length=0,  # intentionally unbounded: all companies are needed for boot
 		)
 		for company in companies:
 			company.doctype = ":Company"

--- a/erpnext/startup/test_boot.py
+++ b/erpnext/startup/test_boot.py
@@ -1,0 +1,22 @@
+# Copyright (c) 2025, Frappe Technologies Pvt. Ltd. and Contributors
+# License: GNU General Public License v3. See license.txt
+
+import frappe
+
+from erpnext.tests.utils import ERPNextTestSuite
+
+
+class TestBoot(ERPNextTestSuite):
+	def test_boot_session_populates_companies_and_party_types(self):
+		# boot_session reads Customer count, Company list and Party Type account types via ORM/qb
+		# (formerly raw SQL with ifnull, which is invalid on Postgres). Exercises that on both engines.
+		from erpnext.startup.boot import boot_session
+
+		bootinfo = frappe._dict(sysdefaults=frappe._dict(), page_info=frappe._dict(), docs=[])
+		boot_session(bootinfo)
+
+		self.assertIsInstance(bootinfo.customer_count, int)
+		self.assertIn("party_account_types", bootinfo)
+
+		company_docs = [d for d in bootinfo.docs if d.get("doctype") == ":Company"]
+		self.assertTrue(any(d.get("name") == "_Test Company" for d in company_docs))


### PR DESCRIPTION
Two setup/startup files that used MySQL-only `ifnull()` and raw `frappe.db.sql` — invalid on Postgres. One commit per file.

## 1. `setup/doctype/authorization_control/authorization_control.py` (#40)

- Replace every `ifnull(...)` → portable `coalesce(...)` in the rule lookups that stay raw (they interpolate dynamic `condition`/`add_cond` strings and rely on Frappe's Postgres backtick→double-quote translation at runtime).
- Convert to `frappe.qb`: the two `based_on` lookups in `validate_approving_authority` and the four value lookups in `get_value_based_rule` (using `Coalesce`, `isin`, and a fresh Employee-designation subquery per use).

`max_val` is a Python `max()`, not SQL `Max()`, so there's no aggregate-bias concern. `system_role.isin(frappe.get_roles())` and `based_on.isin(final_based_on)` are never called with an empty list (`get_roles()` always returns ≥1; `final_based_on` always retains the Itemwise/Item-Group entries).

## 2. `startup/boot.py`

- `SELECT count(*)` → `frappe.db.count`; `SELECT name … LIMIT 1` → `get_all(limit=1)`; company select → `frappe.get_all` (keeping the `:Company` virtual-doc marker).
- `ifnull(account_type,'')` → `frappe.get_all` + Python `account_type or ""`, which collapses `NULL→''` and `''→''` identically on both engines (also handles Postgres storing empty strings as `NULL`).

## Tests

Both files had **no test file**:
- `test_authorization_control.py` — a not-authorized case exercising the `based_on` + `coalesce` rule lookups (run as a non-admin user, since Administrator implicitly holds every role), plus a `get_value_based_rule` call exercising all four query-builder lookups.
- `test_boot.py` — runs `boot_session` and asserts the company list + `party_account_types` populate.

All pass on **MariaDB and Postgres**.