### PR TITLE
fix(controllers): budget GROUP BY + subcontracting bool-OR Postgres validity

### DIFF
--- a/erpnext/controllers/budget_controller.py
+++ b/erpnext/controllers/budget_controller.py
@@ -3,7 +3,7 @@ from collections import OrderedDict
 import frappe
 from frappe import _, qb
 from frappe.query_builder import Criterion
-from frappe.query_builder.functions import IfNull, Sum
+from frappe.query_builder.functions import IfNull, Max, Sum
 from frappe.utils import fmt_money
 
 from erpnext.accounts.doctype.budget.budget import BudgetError, get_accumulated_monthly_budget
@@ -260,7 +260,11 @@ class BudgetValidation:
 				qb.from_(mr)
 				.inner_join(mri)
 				.on(mr.name == mri.parent)
-				.select((Sum(IfNull(mri.stock_qty, 0) - IfNull(mri.ordered_qty, 0)) * mri.rate).as_("amount"))
+				# rate is outside the Sum (no GROUP BY -> implicit aggregate); Max() keeps it valid on
+				# postgres and matches MySQL's arbitrary single-rate choice for this aggregate.
+				.select(
+					(Sum(IfNull(mri.stock_qty, 0) - IfNull(mri.ordered_qty, 0)) * Max(mri.rate)).as_("amount")
+				)
 				.where(Criterion.all(conditions))
 				.run(as_dict=True)
 			):

--- a/erpnext/controllers/subcontracting_inward_controller.py
+++ b/erpnext/controllers/subcontracting_inward_controller.py
@@ -509,8 +509,9 @@ class SubcontractingInwardController:
 					(
 						Case()
 						.when(
+							# bool() so the literal renders as true/false; postgres rejects `OR <integer>`
 							(table.produced_qty < table.qty)
-							| ValueWrapper(allow_delivery_of_overproduced_qty),
+							| ValueWrapper(bool(allow_delivery_of_overproduced_qty)),
 							table.produced_qty,
 						)
 						.else_(table.qty)


### PR DESCRIPTION
Two one-line Postgres-validity fixes on already-`qb` controller code. One commit per file.

## `budget_controller.py`
The Material Request requested-amount query selects `Sum(stock_qty - ordered_qty) * mri.rate` — an **implicit aggregate** with no GROUP BY, where `mri.rate` is neither grouped nor aggregated. MariaDB arbitrary-picks the rate; **Postgres rejects** it. Wrap the rate in `Max(mri.rate)`.

**Behaviour note (#23 arbitrary-pick convention):** for matched MR items with *differing* rates, `Max()` picks the highest (vs MariaDB's arbitrary single rate), so `requested_amount` could be slightly higher on Postgres in that edge case. The underlying `Sum(qty) * rate` is a pre-existing single-rate aggregation; this preserves it.

## `subcontracting_inward_controller.py`
The max-allowed-qty `Case` used `... | ValueWrapper(allow_delivery_of_overproduced_qty)` where the flag is an int. **Postgres rejects `OR <integer>`** ("argument of OR must be type boolean"). Wrap it in `bool()`.

**Surgical**: only the `bool()` wrap is applied — develop's weighted-average rate logic and the internal/whitelisted status-helper split are preserved (the staging branch predated both).

## Tests
Both paths are covered by existing tests, which **now pass on Postgres** (they error on develop) and are **unchanged on MariaDB**:
- `accounts/doctype/budget/test_budget.py::test_monthly_budget_crossed_for_mr` (verified it errors on develop's Postgres without the `Max` fix)
- `subcontracting/.../test_subcontracting_inward_order.py::test_over_production_delivery`