### PR TITLE
fix(controllers): make update_variant_attribute_values Postgres-valid (drop UPDATE..JOIN)

### DIFF
--- a/erpnext/controllers/item_variant.py
+++ b/erpnext/controllers/item_variant.py
@@ -169,13 +169,17 @@ def update_variant_attribute_values(item_attribute):
 	for old_value, new_value in value_map.items():
 		attribute_value_case = attribute_value_case.when(attribute_value == old_value, new_value)
 
-	(
-		frappe.qb.update(item_variant_table)
-		.join(item_table)
-		.on(item_table.name == item_variant_table.parent)
-		.set(attribute_value, attribute_value_case.else_(attribute_value))
+	# Postgres has no UPDATE ... JOIN; restrict to variant items via a subquery on the parent instead.
+	variant_items = (
+		frappe.qb.from_(item_table)
+		.select(item_table.name)
 		.where(item_table.variant_of.isnotnull())
 		.where(item_table.variant_of != "")
+	)
+	(
+		frappe.qb.update(item_variant_table)
+		.set(attribute_value, attribute_value_case.else_(attribute_value))
+		.where(item_variant_table.parent.isin(variant_items))
 		.where(item_variant_table.attribute == item_attribute.name)
 		.where(attribute_value.isin(list(value_map)))
 	).run()


### PR DESCRIPTION
Found by the repo-wide query audit (#43). **High** — renaming an Item Attribute Value errors on Postgres.

## What
`update_variant_attribute_values` propagates a renamed Item Attribute Value onto variant items with a `qb` **`UPDATE … JOIN`**. PostgreSQL has no `UPDATE…JOIN` syntax (pypika renders the JOIN right after `UPDATE <table>` for both dialects), so the statement is invalid on PG.

## Fix
Rewrite as a correlated `UPDATE` restricted to variant items via a subquery on the parent (`item_variant_table.parent.isin(<variant Items>)`) instead of joining `Item`. MariaDB behaviour unchanged.

## Tests
Covered by existing `test_item.test_rename_attribute_value_updates_variants` and `test_swapped_attribute_value_renames_update_variants` — they **errored on Postgres** before this change and now pass on **MariaDB and Postgres**.