### PR TITLE
fix(stock): make Landed Cost Voucher vendor-invoice query Postgres-valid (HAVING→WHERE)

### DIFF
--- a/erpnext/stock/doctype/landed_cost_voucher/landed_cost_voucher.py
+++ b/erpnext/stock/doctype/landed_cost_voucher/landed_cost_voucher.py
@@ -516,8 +516,9 @@ def get_vendor_invoice_query(filters):
 			& (doctype.update_stock == 0)
 			& (doctype.company == filters.get("company"))
 			& (item.is_stock_item == 0)
+			# WHERE not HAVING: no GROUP BY here, and Postgres rejects HAVING on a SELECT alias
+			& ((doctype.base_total - doctype.claimed_landed_cost_amount) > 0)
 		)
-		.having(frappe.qb.Field("unclaimed_amount") > 0)
 	)
 
 	if filters.get("name"):

--- a/erpnext/stock/doctype/landed_cost_voucher/test_landed_cost_voucher.py
+++ b/erpnext/stock/doctype/landed_cost_voucher/test_landed_cost_voucher.py
@@ -27,6 +27,28 @@ class TestLandedCostVoucher(ERPNextTestSuite):
 	def setUp(self):
 		self.load_test_records("Currency Exchange")
 
+	def test_get_vendor_invoices_runs(self):
+		# get_vendor_invoice_query filters unclaimed vendor invoices; the threshold moved from a HAVING
+		# (which referenced a SELECT alias with no GROUP BY -- invalid on Postgres) to a WHERE.
+		from erpnext.stock.doctype.landed_cost_voucher.landed_cost_voucher import get_vendor_invoices
+
+		pi = make_purchase_invoice(item_code="_Test Non Stock Item", qty=1, rate=100)
+		self.addCleanup(self._cancel_and_delete_pi, pi.name)
+
+		rows = get_vendor_invoices(
+			"Purchase Invoice", "", "name", 0, 20, {"company": "_Test Company", "name": pi.name}
+		)
+		self.assertTrue(any(r[0] == pi.name for r in rows))
+
+	@staticmethod
+	def _cancel_and_delete_pi(name):
+		if not frappe.db.exists("Purchase Invoice", name):
+			return
+		doc = frappe.get_doc("Purchase Invoice", name)
+		if doc.docstatus == 1:
+			doc.cancel()
+		frappe.delete_doc("Purchase Invoice", name, force=1)
+
 	def test_landed_cost_voucher(self):
 		frappe.db.set_single_value("Buying Settings", "allow_multiple_items", 1)
 


### PR DESCRIPTION
## Problem

`get_vendor_invoice_query` (used by the Landed Cost Voucher "Get Items From → Purchase Invoice" lookup) filtered unclaimed vendor invoices with:

```python
.having(frappe.qb.Field("unclaimed_amount") > 0)
```

The query has **no `GROUP BY` and no aggregate**, and `unclaimed_amount` is a **`SELECT` alias** (`base_total - claimed_landed_cost_amount AS unclaimed_amount`).

- **MariaDB**: accepts `HAVING` that references a `SELECT` alias (vendor extension) → works.
- **Postgres**: rejects `HAVING` on a `SELECT` alias, and rejects `HAVING` on a non-aggregated column with no `GROUP BY` → **hard error** (`column "unclaimed_amount" does not exist`).

## Fix

Move the threshold into `WHERE`, applied to the underlying expression instead of the alias:

```python
.where(
    ...
    & ((doctype.base_total - doctype.claimed_landed_cost_amount) > 0)
)
```

`WHERE` is the semantically correct clause here anyway — `HAVING` is only meaningful with grouping/aggregation.

## Behaviour impact

- **MariaDB**: identical result set (same rows; `WHERE expr > 0` ≡ `HAVING alias > 0` when the alias *is* that expr and there's no grouping).
- **Postgres**: was a hard error, now runs and returns the same rows.

## Verification

Added `test_get_vendor_invoices_runs` (creates a non-stock Purchase Invoice, calls `get_vendor_invoices(...)`, asserts the invoice is returned). This test errored on Postgres before the fix (the `HAVING` alias reference) and passes after.

- ✅ MariaDB: `test_get_vendor_invoices_runs` passes
- ✅ Postgres: `test_get_vendor_invoices_runs` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)