### PR TITLE
fix(controllers): fix supplier-RFQ portal list query (wrong column + Postgres DISTINCT)

### DIFF
--- a/erpnext/controllers/tests/test_website_list_for_contact.py
+++ b/erpnext/controllers/tests/test_website_list_for_contact.py
@@ -17,3 +17,20 @@ class TestWebsiteListForContact(ERPNextTestSuite):
 		symbols = json.loads(context["currency_symbols"])
 		self.assertIsInstance(symbols, dict)
 		self.assertIn("USD", symbols)
+
+	def test_rfq_transaction_list_returns_supplier_rfq(self):
+		# rfq_transaction_list filters RFQs by the supplier (parties[0]) and uses SELECT DISTINCT with
+		# ORDER BY creation -- both must be valid on Postgres, and the supplier filter must compare to the
+		# party value (not a stray `party[0]` column reference).
+		from erpnext.buying.doctype.request_for_quotation.test_request_for_quotation import (
+			make_request_for_quotation,
+		)
+		from erpnext.controllers.website_list_for_contact import rfq_transaction_list
+
+		rfq = make_request_for_quotation()
+		supplier = rfq.suppliers[0].supplier
+
+		rows = rfq_transaction_list(
+			"Request for Quotation Supplier", "Request for Quotation", [supplier], 0, 20
+		)
+		self.assertIn(rfq.name, [row.name for row in rows])

--- a/erpnext/controllers/website_list_for_contact.py
+++ b/erpnext/controllers/website_list_for_contact.py
@@ -184,9 +184,10 @@ def rfq_transaction_list(parties_doctype, doctype, parties, limit_start, limit_p
 	party = frappe.qb.DocType(parties_doctype)
 	data = (
 		frappe.qb.from_(party)
-		.select(party.parent.as_("name"), party.supplier)
+		# creation must be selected: Postgres requires SELECT DISTINCT order-by exprs in the select list
+		.select(party.parent.as_("name"), party.supplier, party.creation)
 		.distinct()
-		.where((party.supplier == party[0]) & (party.docstatus == 1))
+		.where((party.supplier == parties[0]) & (party.docstatus == 1))
 		.orderby(party.creation, order=frappe.qb.desc)
 		.limit(limit_page_length)
 		.offset(limit_start)


### PR DESCRIPTION
## Problem

`rfq_transaction_list` (the supplier-facing portal list of Requests for Quotation) has **two** defects introduced when it was converted to the query builder in #55647:

### 1. Wrong column in the supplier filter — breaks on **both** engines

```python
.where((party.supplier == party[0]) & (party.docstatus == 1))
```

`party[0]` indexes the **DocType** object, producing a reference to a column literally named `0`, instead of `parties[0]` (the supplier value passed in). It renders as:

- MariaDB: `` `supplier` = `0` `` → `OperationalError (1054, "Unknown column '0' in 'WHERE'")`
- Postgres: `"supplier" = "0"` → `UndefinedColumn: column "0" does not exist`

So the supplier portal RFQ list is **completely broken on both engines** today (the path simply isn't exercised by CI).

The original raw SQL was `where supplier = '{parties[0]}'`.

### 2. `SELECT DISTINCT` + `ORDER BY` a non-selected column — breaks on Postgres

```python
.select(party.parent.as_("name"), party.supplier)
.distinct()
.orderby(party.creation, ...)
```

Postgres: `for SELECT DISTINCT, ORDER BY expressions must appear in select list`. (MariaDB tolerates it.)

## Fix

```python
.select(party.parent.as_("name"), party.supplier, party.creation)
.distinct()
.where((party.supplier == parties[0]) & (party.docstatus == 1))
.orderby(party.creation, order=frappe.qb.desc)
```

- Compare to `parties[0]` (the value), restoring the original behaviour.
- Add `creation` to the select list so `DISTINCT` + `ORDER BY creation` is valid on Postgres. Each `(parent, supplier)` row is already unique per RFQ, so adding `creation` does not change the result set; `post_process` ignores the extra key.

## Behaviour impact

- **Both engines**: the query now runs (it errored before) and returns the supplier's submitted RFQs, newest first.

## Verification

Added `test_rfq_transaction_list_returns_supplier_rfq` — creates a submitted RFQ and asserts it is returned for its supplier. Confirmed it **fails on both engines** against the current code (each with the error above), and **passes on both** with the fix. Each defect was also confirmed independently load-bearing.

- ✅ MariaDB: passes
- ✅ Postgres: passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)