### PR TITLE
test(stock): make Bin/Item index tests Postgres-valid (SHOW INDEX → db-agnostic helpers)

### DIFF
--- a/erpnext/stock/doctype/bin/test_bin.py
+++ b/erpnext/stock/doctype/bin/test_bin.py
@@ -27,6 +27,6 @@ class TestBin(ERPNextTestSuite):
 		self.assertEqual(bin.item_code, item_code)
 
 	def test_index_exists(self):
-		indexes = frappe.db.sql("show index from tabBin where Non_unique = 0", as_dict=1)
-		if not any(index.get("Key_name") == "unique_item_warehouse" for index in indexes):
+		# has_index is db-agnostic; raw "SHOW INDEX" is MySQL-only and errors on Postgres
+		if not frappe.db.has_index("tabBin", "unique_item_warehouse"):
 			self.fail("Expected unique index on item-warehouse")

--- a/erpnext/stock/doctype/item/test_item.py
+++ b/erpnext/stock/doctype/item/test_item.py
@@ -778,10 +778,13 @@ class TestItem(ERPNextTestSuite):
 	def test_index_creation(self):
 		"check if index is getting created in db"
 
-		indices = frappe.db.sql("show index from tabItem", as_dict=1)
+		# get_column_index is db-agnostic; raw "SHOW INDEX" is MySQL-only and errors on Postgres
 		expected_columns = {"item_code", "item_name", "item_group"}
-		for index in indices:
-			expected_columns.discard(index.get("Column_name"))
+		for column in list(expected_columns):
+			if frappe.db.get_column_index("tabItem", column, unique=False) or frappe.db.get_column_index(
+				"tabItem", column, unique=True
+			):
+				expected_columns.discard(column)
 
 		if expected_columns:
 			self.fail(f"Expected db index on these columns: {', '.join(expected_columns)}")


### PR DESCRIPTION
## Problem

Two stock index tests introspect the schema with raw `frappe.db.sql("SHOW INDEX FROM ...")`. `SHOW INDEX` is **MySQL-only** syntax — on Postgres it errors (`syntax error at or near "from"`), so the tests cannot run there:

- `bin/test_bin.py::test_index_exists` — `show index from tabBin where Non_unique = 0`
- `item/test_item.py::test_index_creation` — `show index from tabItem` (and the MySQL-only result key `Column_name`)

## Fix

Use the db-agnostic helpers frappe already provides for both engines:

- `test_index_exists` → `frappe.db.has_index("tabBin", "unique_item_warehouse")`
- `test_index_creation` → `frappe.db.get_column_index("tabItem", column)` for each expected column (checking both non-unique and unique single-column indexes, mirroring the original "appears in any index" semantics)

No production code changes — test-only portability.

## Behaviour impact

- **MariaDB**: same assertions, same result (both still pass).
- **Postgres**: the tests now run (they errored on the `SHOW INDEX` syntax before) and pass.

## Verification

- ✅ MariaDB: `test_index_exists`, `test_index_creation` pass
- ✅ Postgres: both pass (confirmed the old `SHOW INDEX` raw SQL errors on PG with `syntax error at or near "from"`)

Two commits, one per test file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)