### PR TITLE
refactor(stock): remove dead get_batches() in batch.py

### DIFF
--- a/erpnext/stock/doctype/batch/batch.py
+++ b/erpnext/stock/doctype/batch/batch.py
@@ -9,7 +9,6 @@ import frappe
 from frappe import _
 from frappe.model.document import Document
 from frappe.model.naming import make_autoname, revert_series_if_last
-from frappe.query_builder.functions import CurDate, Sum
 from frappe.utils import cint, flt, get_link_to_form
 from frappe.utils.data import DateTimeLikeObject, add_days
 
@@ -379,50 +378,6 @@ def make_batch_bundle(
 		.make_serial_and_batch_bundle()
 		.name
 	)
-
-
-def get_batches(item_code, warehouse, qty=1, throw=False, serial_no=None):
-	from erpnext.stock.doctype.serial_no.serial_no import get_serial_nos
-
-	batch = frappe.qb.DocType("Batch")
-	sle = frappe.qb.DocType("Stock Ledger Entry")
-
-	query = (
-		frappe.qb.from_(batch)
-		.join(sle)
-		.on(batch.batch_id == sle.batch_no)
-		.select(
-			batch.batch_id,
-			Sum(sle.actual_qty).as_("qty"),
-		)
-		.where(
-			(sle.item_code == item_code)
-			& (sle.warehouse == warehouse)
-			& (sle.is_cancelled == 0)
-			& ((batch.expiry_date >= CurDate()) | (batch.expiry_date.isnull()))
-		)
-		.groupby(batch.batch_id)
-		.orderby(batch.expiry_date, batch.creation)
-	)
-
-	if serial_no and frappe.get_cached_value("Item", item_code, "has_batch_no"):
-		serial_nos = get_serial_nos(serial_no)
-		batches = frappe.get_all(
-			"Serial No",
-			fields=["batch_no"],
-			filters={"item_code": item_code, "warehouse": warehouse, "name": ("in", serial_nos)},
-			distinct=True,
-		)
-
-		if not batches:
-			validate_serial_no_with_batch(serial_nos, item_code)
-
-		if batches and len(batches) > 1:
-			return []
-
-		query = query.where(batch.name == batches[0].batch_no)
-
-	return query.run(as_dict=True)
 
 
 def validate_serial_no_with_batch(serial_nos, item_code):


### PR DESCRIPTION
## What

Removes the unused `get_batches(item_code, warehouse, ...)` function from `batch.py`.

## Why

**Dead** — added in #55647, it has **no callers** anywhere in erpnext, frappe, or payments (not `@frappe.whitelist()`, not referenced from JS/hooks/server scripts). The only reference was none — confirmed by searching all installed apps for `get_batches(`.

**Obsolete** — it joins `Stock Ledger Entry` on `batch_no`:

```python
.join(sle).on(batch.batch_id == sle.batch_no)
```

With the Serial and Batch Bundle system, SLEs created via bundles do **not** populate `batch_no`, so the join matches nothing — the function returns `[]` even on MariaDB. Live batch-quantity lookups go through `get_batch_qty()` / `get_auto_batch_nos()`, which use the bundle model.

**Postgres-invalid** — for completeness, the query was also not Postgres-valid: `GROUP BY batch_id` with `ORDER BY expiry_date, creation` raises `GroupingError` on PG (`batch_id` is a Data column, not the primary key `name`, so no functional-dependency exemption). Rather than fix a query nothing can reach, the dead function is removed.

The now-unused `CurDate`/`Sum` import is dropped with it.

## Verification

- `erpnext/stock/doctype/batch/test_batch.py` — **18/18 pass on both MariaDB and Postgres** after removal (the module imports `get_batch_qty`, not `get_batches`).
- No remaining references to `get_batches(` in any installed app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)