### PR TITLE
test(stock): order get_sle by posting_datetime, not MySQL timestamp()

### DIFF
--- a/erpnext/stock/doctype/stock_entry/test_stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/test_stock_entry.py
@@ -47,8 +47,9 @@ def get_sle(**args):
 		values.append(value)
 
 	return frappe.db.sql(
+		# posting_datetime is the precomputed date+time column; MySQL-only timestamp(date,time) errors on Postgres
 		"""select * from `tabStock Ledger Entry` %s
-		order by timestamp(posting_date, posting_time) desc, creation desc limit 1"""
+		order by posting_datetime desc, creation desc limit 1"""
 		% condition,
 		values,
 		as_dict=1,


### PR DESCRIPTION
## Problem

`test_stock_entry.get_sle` (a test helper used by `test_fifo`, `test_stock_entry_qty`, and others) ordered its lookup by:

```sql
order by timestamp(posting_date, posting_time) desc, creation desc
```

`timestamp(date, time)` is a **MySQL-only** two-argument function. On Postgres it errors (`function timestamp(date, time) does not exist`), so every test calling `get_sle` fails to run on Postgres.

## Fix

Order by the precomputed `posting_datetime` column, which already holds `timestamp(posting_date, posting_time)`:

```sql
order by posting_datetime desc, creation desc
```

Identical ordering on MariaDB; valid on both engines. Test-only change.

## Verification

- ✅ MariaDB: `test_fifo` passes
- ✅ Postgres: `test_fifo` passes (confirmed it errored on the `timestamp()` call before the fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)