### PR TITLE
fix(assets): deterministic latest Asset Movement on tied transaction_date

### DIFF
--- a/erpnext/assets/doctype/asset_movement/asset_movement.py
+++ b/erpnext/assets/doctype/asset_movement/asset_movement.py
@@ -138,7 +138,10 @@ class AssetMovement(Document):
 			.on(asm_item.parent == asm.name)
 			.select(asm_item.target_location, asm_item.to_employee)
 			.where((asm_item.asset == asset) & (asm.company == self.company) & (asm.docstatus == 1))
+			# name tiebreaker so the latest movement is deterministic when transaction_date ties (Postgres
+			# has no implicit row order; without it the chosen location/custodian can differ per engine)
 			.orderby(asm.transaction_date, order=frappe.qb.desc)
+			.orderby(asm.name, order=frappe.qb.desc)
 			.limit(1)
 			.run()
 		)

--- a/erpnext/assets/doctype/asset_movement/test_asset_movement.py
+++ b/erpnext/assets/doctype/asset_movement/test_asset_movement.py
@@ -161,6 +161,44 @@ class TestAssetMovement(ERPNextTestSuite):
 		)
 		self.assertRaises(frappe.ValidationError, asset_movement.save)
 
+	def test_latest_movement_tiebreaker_on_same_transaction_date(self):
+		# When two movements share the same transaction_date, the latest one (by name) must be chosen
+		# deterministically. Postgres has no implicit row order, so without a name tiebreaker the
+		# resulting Asset.location/custodian could differ between MariaDB and Postgres.
+		asset = create_asset(item_code="Macbook Pro", do_not_save=1)
+		asset.save().submit()
+
+		txn_date = now()
+		create_asset_movement(
+			purpose="Transfer",
+			company=asset.company,
+			transaction_date=txn_date,
+			assets=[
+				{
+					"asset": asset.name,
+					"source_location": "Test Location",
+					"target_location": "Test Location 2",
+				}
+			],
+		)
+		movement2 = create_asset_movement(
+			purpose="Transfer",
+			company=asset.company,
+			transaction_date=txn_date,
+			assets=[
+				{
+					"asset": asset.name,
+					"source_location": "Test Location 2",
+					"target_location": "Test Location",
+				}
+			],
+		)
+
+		# movement2 is the higher-named movement on the tied date -> it is the deterministic latest
+		location, _ = movement2.get_latest_location_and_custodian(asset.name)
+		self.assertEqual(location, "Test Location")
+		self.assertEqual(frappe.db.get_value("Asset", asset.name, "location"), "Test Location")
+
 
 def create_asset_movement(**args):
 	args = frappe._dict(args)


### PR DESCRIPTION
## Problem

`AssetMovement.get_latest_location_and_custodian` finds the asset's current location/custodian by:

```python
.orderby(asm.transaction_date, order=frappe.qb.desc)
.limit(1)
```

and writes the result to `Asset.location` / `Asset.custodian` on submit/cancel. With **no tiebreaker**, when two Asset Movements share the same `transaction_date`, the "latest" row is non-deterministic — Postgres has no implicit row order, and even MariaDB does not guarantee one.

In practice this returns the **wrong** movement (an earlier one, not the most recent) on **both** engines when dates tie, so `Asset.location`/`custodian` can be incorrect and can differ between MariaDB and Postgres.

## Fix

Add a deterministic name tiebreaker (Asset Movement `name` is the primary key and monotonically increasing, so highest name = most recently created):

```python
.orderby(asm.transaction_date, order=frappe.qb.desc)
.orderby(asm.name, order=frappe.qb.desc)
.limit(1)
```

## Behaviour impact

- Tied `transaction_date`: now deterministically picks the latest movement (highest name) on both engines. Previously picked an engine-dependent / incorrect earlier row.
- Distinct dates: unchanged.

## Verification

Added `test_latest_movement_tiebreaker_on_same_transaction_date` — creates two movements on the same `transaction_date` to different locations and asserts the latest (movement2) wins. The test **fails on both engines** against current develop (`'Test Location 2' != 'Test Location'` — the older movement was chosen) and **passes on both** with the fix.

- ✅ MariaDB: passes (failed before)
- ✅ Postgres: passes (failed before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)