### PR TITLE
ci: upgrade the PostgreSQL server test workflow (kept opt-in via 'postgres' label)

### DIFF
--- a/.github/workflows/server-tests-postgres.yml
+++ b/.github/workflows/server-tests-postgres.yml
@@ -1,33 +1,61 @@
 name: Server (Postgres)
 
 on:
+  repository_dispatch:
+    types: [frappe-framework-change]
   pull_request:
+    # 'labeled' is required so adding the 'postgres' label to an open PR triggers this run
+    # (the job itself is gated on that label below)
+    types: [opened, reopened, synchronize, labeled]
     paths-ignore:
       - '**.js'
+      - '**.css'
+      - '**.svg'
       - '**.md'
       - '**.html'
       - 'crowdin.yml'
       - '.coderabbit.yml'
       - '.mergify.yml'
-    types: [opened, labelled, synchronize, reopened]
+  schedule:
+    # Run everday at midnight UTC / 5:30 IST
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+    inputs:
+      user:
+        description: 'Frappe Framework repository user (add your username for forks)'
+        required: true
+        default: 'frappe'
+        type: string
+      branch:
+        description: 'Frappe Framework branch'
+        default: 'develop'
+        required: false
+        type: string
+
+permissions:
+  contents: read
 
 concurrency:
   group: server-postgres-develop-${{ github.event_name }}-${{ github.event.number || github.event_name == 'workflow_dispatch' && github.run_id || '' }}
   cancel-in-progress: true
 
-permissions:
-  contents: read
-
 jobs:
   test:
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'postgres') }}
+    # Opt-in on PRs: only runs when the PR carries the 'postgres' label. Scheduled / manual /
+    # framework-dispatch runs always execute (no PR labels to gate on).
+    if: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'postgres') }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    env:
+      TZ: 'Asia/Kolkata'
+      NODE_ENV: "production"
+      WITH_COVERAGE: ${{ github.event_name != 'pull_request' }}
 
     strategy:
       fail-fast: false
+
       matrix:
-       container: [1]
+        container: [1, 2, 3, 4]
 
     name: Python Unit Tests
 
@@ -36,16 +64,15 @@ jobs:
         image: postgres:13.3
         env:
           POSTGRES_PASSWORD: travis
+        ports:
+          - 5432:5432
         options: >-
           --health-cmd pg_isready
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
-        ports:
-          - 5432:5432
 
     steps:
-
       - name: Clone
         uses: actions/checkout@v6
 
@@ -104,15 +131,63 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
 
+      - name: Cache wkhtmltopdf
+        uses: actions/cache@v4
+        with:
+          path: /tmp/wkhtmltox.deb
+          key: wkhtmltox-0.12.6.1-2-jammy-amd64
+
       - name: Install
         run: bash ${GITHUB_WORKSPACE}/.github/helper/install.sh
         env:
           DB: postgres
           TYPE: server
+          FRAPPE_USER: ${{ github.event.inputs.user }}
+          FRAPPE_BRANCH: ${{ github.event.client_payload.sha || github.event.inputs.branch }}
 
       - name: Run Tests
-        run: cd ~/frappe-bench/ && bench --site test_site run-parallel-tests --app erpnext --use-orchestrator
+        run: |
+          cd ~/frappe-bench/
+          coverage_flag=""
+          if [ "$WITH_COVERAGE" = "true" ]; then coverage_flag="--with-coverage"; fi
+          bench --site test_site run-parallel-tests --lightmode --app erpnext \
+            --total-builds ${{ strategy.job-total }} \
+            --build-number ${{ matrix.container }} \
+            $coverage_flag
         env:
           TYPE: server
-          CI_BUILD_ID: ${{ github.run_id }}
-          ORCHESTRATOR_URL: http://test-orchestrator.frappe.io
+
+
+      - name: Show bench output
+        if: ${{ always() }}
+        run: cat ~/frappe-bench/bench_start.log || true
+
+      - name: Upload coverage data
+        if: ${{ env.WITH_COVERAGE == 'true' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-postgres-${{ matrix.container }}
+          path: /home/runner/frappe-bench/sites/coverage.xml
+
+  coverage:
+    name: Coverage Wrap Up
+    needs: test
+    if: ${{ github.event_name != 'pull_request' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone
+        uses: actions/checkout@v6
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: coverage-postgres-*
+
+      - name: Upload coverage data
+        uses: codecov/codecov-action@v4
+        with:
+          name: Postgres
+          flags: postgres
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true
+          verbose: true


### PR DESCRIPTION
## What

Brings the **Server (Postgres)** workflow in line with **Server (MariaDB)** internals, while keeping it **opt-in for now**:

- `pull_request` runs still require the **`postgres` label** (unchanged gate)
- full **4-container** matrix (was 1)
- adds nightly `schedule` + `workflow_dispatch` + `repository_dispatch` triggers (these always run; only PR runs are label-gated)
- coverage upload (Codecov, `postgres` flag)
- builds ERPNext against **frappe `develop`** — PostgreSQL query-builder/ORM support is already merged there, so no fork override is needed

Otherwise a 1:1 mirror of `server-tests-mariadb.yml` with the DB swapped to `postgres`.

## Why

The ERPNext server test suite now passes on **PostgreSQL and MariaDB from a single codebase** after a large cross-engine conversion effort (~60 merged PRs, each shipping a both-engine test). This upgrades the Postgres CI so it can exercise the full suite (add the `postgres` label to a PR to run it). Flipping it to run on **every** PR / become a **required** check is a deliberate later step.

Full write-up of the approach, the non-trivial conversions, and the MariaDB↔Postgres behavioural differences (and why none of the fixes change MariaDB behaviour): #56241.

## Linked issues

Resolves #24389 (Postgres support for ERPNext)
Fixes #55640 (PostgreSQL: Sales Invoice submit / Payment Entry outstanding lookup)
Summary / documentation: #56241

Historical Postgres-specific bugs addressed by this effort (already closed, linked for traceability): #46000, #42234, #42214, #42212, #41341, #39518, #36836, #35181, #35180, #18028

🤖 Generated with [Claude Code](https://claude.com/claude-code)