### PR TITLE
fix(selling): make commission_rate a Percent field on Sales Person and Sales Team

### DIFF
--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -261,6 +261,7 @@ erpnext.patches.v14_0.update_proprietorship_to_individual
 erpnext.patches.v15_0.rename_subcontracting_fields
 erpnext.patches.v15_0.unset_incorrect_additional_discount_percentage
 erpnext.patches.v16_0.create_company_custom_fields
+erpnext.patches.v16_0.convert_commission_rate_to_percent
 
 [post_model_sync]
 erpnext.patches.v15_0.rename_gross_purchase_amount_to_net_purchase_amount

--- a/erpnext/patches/v16_0/convert_commission_rate_to_percent.py
+++ b/erpnext/patches/v16_0/convert_commission_rate_to_percent.py
@@ -1,0 +1,22 @@
+import frappe
+from frappe.utils import flt
+
+
+def execute():
+	"""Sanitize the free-text commission_rate values before the Data -> Percent column change.
+
+	Sales Person and Sales Team stored ``commission_rate`` as Data (varchar). This runs in
+	pre_model_sync so the values are clean numeric strings by the time the schema sync alters
+	the column to Percent; empty or non-numeric values become 0.
+	"""
+	for doctype in ("Sales Person", "Sales Team"):
+		if not frappe.db.has_column(doctype, "commission_rate"):
+			continue
+
+		# Percent maps to a NOT NULL decimal column, so empty/NULL/non-numeric text must become 0
+		# as well, otherwise the column type change fails under strict SQL mode.
+		rows = frappe.db.get_all(doctype, fields=["name", "commission_rate"])
+		for row in rows:
+			cleaned = flt(row.commission_rate)
+			if str(row.commission_rate) != str(cleaned):
+				frappe.db.set_value(doctype, row.name, "commission_rate", cleaned, update_modified=False)

--- a/erpnext/patches/v16_0/convert_commission_rate_to_percent.py
+++ b/erpnext/patches/v16_0/convert_commission_rate_to_percent.py
@@ -14,13 +14,30 @@ def execute():
 		if not frappe.db.has_column(doctype, "commission_rate"):
 			continue
 
-		# Percent maps to a NOT NULL decimal column, so empty/NULL/non-numeric text must become 0
-		# as well, otherwise the column type change fails under strict SQL mode.
+		# Only rewrite the rows the column change can't cast as-is. Plain numeric strings (the vast
+		# majority, e.g. "20") are left untouched so this stays a targeted cleanup instead of a
+		# full-table rewrite; NULL / empty / non-numeric / percent-sign values become a clean number,
+		# otherwise the Data -> Percent change fails under strict SQL mode (Percent is NOT NULL decimal).
 		rows = frappe.db.get_all(doctype, fields=["name", "commission_rate"])
 		for row in rows:
+			if _is_plain_number(row.commission_rate):
+				continue
 			cleaned = flt(_strip_percent_sign(row.commission_rate))
-			if str(row.commission_rate) != str(cleaned):
-				frappe.db.set_value(doctype, row.name, "commission_rate", cleaned, update_modified=False)
+			frappe.db.set_value(doctype, row.name, "commission_rate", cleaned, update_modified=False)
+
+
+def _is_plain_number(value) -> bool:
+	"""True if the stored value is already a clean numeric string the column change can cast."""
+	if value is None:
+		return False
+	text = str(value)
+	if text != text.strip() or "%" in text:
+		return False
+	try:
+		float(text)
+	except ValueError:
+		return False
+	return True
 
 
 def _strip_percent_sign(value):

--- a/erpnext/patches/v16_0/convert_commission_rate_to_percent.py
+++ b/erpnext/patches/v16_0/convert_commission_rate_to_percent.py
@@ -6,8 +6,9 @@ def execute():
 	"""Sanitize the free-text commission_rate values before the Data -> Percent column change.
 
 	Sales Person and Sales Team stored ``commission_rate`` as Data (varchar). This runs in
-	pre_model_sync so the values are clean numeric strings by the time the schema sync alters
-	the column to Percent; empty or non-numeric values become 0.
+	pre_model_sync so the values are clean numbers by the time the schema sync alters the column
+	to Percent: a trailing percent sign (e.g. "20%" / "20 %") is stripped, and empty / NULL /
+	non-numeric values become 0.
 	"""
 	for doctype in ("Sales Person", "Sales Team"):
 		if not frappe.db.has_column(doctype, "commission_rate"):
@@ -17,6 +18,13 @@ def execute():
 		# as well, otherwise the column type change fails under strict SQL mode.
 		rows = frappe.db.get_all(doctype, fields=["name", "commission_rate"])
 		for row in rows:
-			cleaned = flt(row.commission_rate)
+			cleaned = flt(_strip_percent_sign(row.commission_rate))
 			if str(row.commission_rate) != str(cleaned):
 				frappe.db.set_value(doctype, row.name, "commission_rate", cleaned, update_modified=False)
+
+
+def _strip_percent_sign(value):
+	"""Drop a trailing percent sign so "20%" / "20 %" parse as 20 instead of 0."""
+	if isinstance(value, str):
+		return value.replace("%", "").strip()
+	return value

--- a/erpnext/selling/doctype/sales_team/sales_team.json
+++ b/erpnext/selling/doctype/sales_team/sales_team.json
@@ -68,7 +68,7 @@
    "fetch_from": "sales_person.commission_rate",
    "fetch_if_empty": 1,
    "fieldname": "commission_rate",
-   "fieldtype": "Data",
+   "fieldtype": "Percent",
    "in_list_view": 1,
    "label": "Commission Rate",
    "read_only": 1
@@ -87,7 +87,7 @@
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-03-27 13:10:38.504580",
+ "modified": "2026-06-21 12:52:33.742603",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Sales Team",

--- a/erpnext/setup/doctype/sales_person/sales_person.json
+++ b/erpnext/setup/doctype/sales_person/sales_person.json
@@ -54,7 +54,7 @@
   },
   {
    "fieldname": "commission_rate",
-   "fieldtype": "Data",
+   "fieldtype": "Percent",
    "label": "Commission Rate",
    "print_hide": 1
   },
@@ -145,7 +145,7 @@
  "idx": 1,
  "is_tree": 1,
  "links": [],
- "modified": "2024-03-27 13:10:37.891377",
+ "modified": "2026-06-21 12:52:33.742603",
  "modified_by": "Administrator",
  "module": "Setup",
  "name": "Sales Person",


### PR DESCRIPTION
Commission Rate on the Sales Person master and the Sales Team table was a plain text field. This turns it into a proper percentage field so it behaves like other rate fields and can be used in calculations.

Existing values are migrated automatically — including ones typed with a percent sign like "20%"; anything blank or non-numeric becomes 0.

**Manual QA:** After upgrading, run `bench migrate` and confirm existing Sales Person / Sales Team commission rates are kept as numbers and the field now shows as a percentage.
