### PR TITLE
fix(stock): make get_incoming_value_for_serial_nos a staticmethod

### DIFF
--- a/erpnext/stock/doctype/stock_ledger_entry/test_stock_ledger_entry.py
+++ b/erpnext/stock/doctype/stock_ledger_entry/test_stock_ledger_entry.py
@@ -77,7 +77,7 @@ class TestStockLedgerEntry(ERPNextTestSuite, StockTestMixin):
 		mk_sle("MAT-SLE-TIE-B", 200)  # later/larger name -> deterministic winner
 
 		value = update_entries_after.get_incoming_value_for_serial_nos(
-			None, frappe._dict(company=company_a), [serial]
+			frappe._dict(company=company_a), [serial]
 		)
 		# the latest (creation/name desc) same-date SLE wins -> 200 on both engines
 		self.assertEqual(value, 200.0)

--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -1473,7 +1473,8 @@ class update_entries_after:
 			for item in sr.items:
 				item.db_update()
 
-	def get_incoming_value_for_serial_nos(self, sle, serial_nos):
+	@staticmethod
+	def get_incoming_value_for_serial_nos(sle, serial_nos):
 		# get rate from serial nos within same company
 		all_serial_nos = frappe.get_all(
 			"Serial No", fields=["purchase_rate", "name", "company"], filters={"name": ("in", serial_nos)}


### PR DESCRIPTION
### Problem

Follow-up to #56249 (Greptile review). The deterministic-serial-value test added there calls:

```python
update_entries_after.get_incoming_value_for_serial_nos(None, frappe._dict(company=company_a), [serial])
```

passing `None` as `self`. This works today only because the method never touches any instance attribute — but it's fragile: if a future change adds `self.allow_zero_rate` (or similar), the test would fail with an opaque `AttributeError` far from the real cause.

### Change

`update_entries_after.get_incoming_value_for_serial_nos` genuinely never references `self`, so declare it a `@staticmethod` and drop the `None` from the test call.

```python
# before
def get_incoming_value_for_serial_nos(self, sle, serial_nos): ...
... get_incoming_value_for_serial_nos(None, sle, serial_nos)

# after
@staticmethod
def get_incoming_value_for_serial_nos(sle, serial_nos): ...
... get_incoming_value_for_serial_nos(sle, serial_nos)
```

### Why it's safe / backward compatible

- The method body (stock_ledger.py) uses only `sle` and `serial_nos` — never `self`.
- It has **no in-repo callers** other than the test (`grep` for `get_incoming_value_for_serial_nos` across `erpnext/` confirms; the identically-named method in `deprecated_serial_batch.py` is a different class with a different signature).
- Even a hypothetical `self.get_incoming_value_for_serial_nos(sle, serial_nos)` call still binds correctly to a `@staticmethod` in Python, so nothing breaks.

No behaviour change on either engine — this is a signature/declaration cleanup.

### Verification

`stock_ledger_entry` test module, both engines (`--lightmode`):

- **MariaDB:** `Ran 23 tests … OK`
- **PostgreSQL:** `Ran 23 tests … OK`

(incl. `test_incoming_value_for_transferred_serial_no_is_deterministic`, which exercises the changed call.)
