### PR TITLE
fix(postgres): resolve remaining Postgres test failures on develop

### DIFF
--- a/erpnext/accounts/doctype/process_payment_reconciliation/process_payment_reconciliation.py
+++ b/erpnext/accounts/doctype/process_payment_reconciliation/process_payment_reconciliation.py
@@ -479,7 +479,7 @@ def reconcile(doc: None | str = None) -> None:
 				finally:
 					if reconciled_entries == total_allocations:
 						frappe.db.set_value("Process Payment Reconciliation Log", log, "status", "Reconciled")
-						frappe.db.set_value("Process Payment Reconciliation Log", log, "reconciled", True)
+						frappe.db.set_value("Process Payment Reconciliation Log", log, "reconciled", 1)
 						frappe.db.set_value("Process Payment Reconciliation", doc, "status", "Completed")
 					else:
 						if frappe.db.get_value("Process Payment Reconciliation", doc, "status") != "Paused":

--- a/erpnext/accounts/doctype/unreconcile_payment/test_unreconcile_payment.py
+++ b/erpnext/accounts/doctype/unreconcile_payment/test_unreconcile_payment.py
@@ -424,7 +424,7 @@ class TestUnreconcilePayment(ERPNextTestSuite, AccountsTestMixin):
 		self.disable_advance_as_liability()
 
 	def test_07_adv_from_so_to_invoice(self):
-		frappe.db.set_value("Company", self.company, "book_advance_payments_in_separate_party_account", True)
+		frappe.db.set_value("Company", self.company, "book_advance_payments_in_separate_party_account", 1)
 		frappe.db.set_value(
 			"Company", self.company, "default_advance_received_account", "Advance Received - _TC"
 		)

--- a/erpnext/manufacturing/doctype/bom/bom.py
+++ b/erpnext/manufacturing/doctype/bom/bom.py
@@ -1402,16 +1402,18 @@ def validate_bom_no(item, bom_no):
 
 
 def _bom_contains_item(bom, item):
-	item = item.lower()
+	item_lower = item.lower()
 	for d in bom.items:
-		if d.item_code.lower() == item:
+		if d.item_code.lower() == item_lower:
 			return True
 	for d in bom.secondary_items:
-		if d.item_code.lower() == item:
+		if d.item_code.lower() == item_lower:
 			return True
 
+	# Use the original-cased `item` for the Item lookup: names are case-sensitive on Postgres,
+	# so a lowercased name would miss the record and drop the variant->template BOM match.
 	return (
-		bom.item.lower() == item
+		bom.item.lower() == item_lower
 		or bom.item.lower() == cstr(frappe.db.get_value("Item", item, "variant_of")).lower()
 	)
 

--- a/erpnext/stock/doctype/bin/test_bin.py
+++ b/erpnext/stock/doctype/bin/test_bin.py
@@ -19,8 +19,10 @@ class TestBin(ERPNextTestSuite):
 		bin1.insert()
 
 		bin2 = frappe.get_doc(doctype="Bin", item_code=item_code, warehouse=warehouse)
+		frappe.db.savepoint("dup_bin")
 		with self.assertRaises(frappe.UniqueValidationError):
 			bin2.insert()
+		frappe.db.rollback(save_point="dup_bin")  # preserve transaction in postgres
 
 		# util method should handle it
 		bin = _create_bin(item_code, warehouse)

--- a/erpnext/stock/doctype/item/test_item.py
+++ b/erpnext/stock/doctype/item/test_item.py
@@ -770,10 +770,14 @@ class TestItem(ERPNextTestSuite):
 
 		now = time.time()
 		one_year_ago = now - 366 * 24 * 60 * 60
+		# posting_date is a calendar date; its midnight unix timestamp (taken in the database
+		# session timezone) can sit up to a day ahead of the precise current instant when the app
+		# timezone is ahead of UTC, so allow a day of slack on the upper bound.
+		one_day = 24 * 60 * 60
 
 		for timestamp, count in data.items():
 			self.assertIsInstance(timestamp, int)
-			self.assertTrue(one_year_ago <= timestamp <= now)
+			self.assertTrue(one_year_ago <= timestamp <= now + one_day)
 			self.assertIsInstance(count, int)
 			self.assertGreaterEqual(count, 0)
 

--- a/erpnext/stock/doctype/item/test_item.py
+++ b/erpnext/stock/doctype/item/test_item.py
@@ -751,7 +751,9 @@ class TestItem(ERPNextTestSuite):
 		item_doc = frappe.get_doc("Item", item_code)
 		new_barcode = item_doc.append("barcodes")
 		new_barcode.update(barcode_properties_list[0])
+		frappe.db.savepoint("dup_barcode")
 		self.assertRaises(frappe.UniqueValidationError, item_doc.save)
+		frappe.db.rollback(save_point="dup_barcode")  # preserve transaction in postgres
 
 		# Add invalid barcode - should cause InvalidBarcode
 		item_doc = frappe.get_doc("Item", item_code)

--- a/erpnext/tests/test_perf.py
+++ b/erpnext/tests/test_perf.py
@@ -9,6 +9,37 @@ INDEXED_FIELDS = {
 }
 
 
+def _is_leading_index_column(doctype: str, field: str) -> bool:
+	"""Whether `field` is the first column of some index on the doctype's table.
+
+	`SHOW INDEX` is MySQL-only; on Postgres read the leading key column (indkey[0])
+	from the pg_index catalog. Both check the same thing across engines.
+	"""
+	table = f"tab{doctype}"
+	if frappe.db.db_type == "postgres":
+		return bool(
+			frappe.db.sql(
+				"""
+				SELECT 1
+				FROM pg_index i
+				JOIN pg_class t ON t.oid = i.indrelid
+				JOIN pg_attribute a ON a.attrelid = t.oid AND a.attnum = i.indkey[0]
+				WHERE t.relname = %s AND a.attname = %s
+				LIMIT 1
+				""",
+				(table, field),
+			)
+		)
+	# `table` is a trusted constant (from INDEXED_FIELDS); a table identifier can't be a %s
+	# placeholder in SHOW INDEX, so the f-string is unavoidable and safe here.
+	return bool(
+		frappe.db.sql(
+			f"""SHOW INDEX FROM `{table}` WHERE Column_name = %s AND Seq_in_index = 1""",
+			(field,),
+		)
+	)
+
+
 class TestPerformance(ERPNextTestSuite):
 	def test_ensure_indexes(self):
 		# These fields are not explicitly indexed BUT they are prefix in some
@@ -17,8 +48,6 @@ class TestPerformance(ERPNextTestSuite):
 		for doctype, fields in INDEXED_FIELDS.items():
 			for field in fields:
 				self.assertTrue(
-					frappe.db.sql(
-						f"""SHOW INDEX FROM `tab{doctype}`
-						WHERE Column_name = "{field}" AND Seq_in_index = 1"""
-					)
+					_is_leading_index_column(doctype, field),
+					msg=f"{field} is not the leading column of any index on tab{doctype}",
 				)


### PR DESCRIPTION
### Context

With the Postgres CI now building against clean `frappe develop` (PR #56243 also adds the missing `payments` app to the PG test site), the full ERPNext suite surfaced a small set of genuine Postgres failures that the previously PG-patched local frappe had masked. This PR fixes all of them. **Every fix keeps MariaDB output identical** — Postgres is bent to match MariaDB.

Each fix verified on **both** engines (`--lightmode`): Postgres (`postgres.localhost`) and MariaDB (`mdbtest.localhost`).

### Fixes

**1. `manufacturing/bom.py` — variant BOM lookup was case-sensitive on PG (production bug)**
`_bom_contains_item()` lowercased the item name and then reused that lowercased value as a **doc name** in `frappe.db.get_value("Item", item, "variant_of")`. Doc names are case-sensitive on Postgres, so the lookup missed the row, `variant_of` came back `NULL`, and a Work Order for a variant item built from the *template's* BOM was wrongly rejected (`BOM ... does not belong to Item ...`). Now the original case is kept for the Item lookup; the `.lower()` comparisons are unchanged. MariaDB unchanged (its name lookup was case-insensitive anyway).
_Caught by `test_stock_entry.test_variant_work_order`._

**2. `accounts/process_payment_reconciliation.py` — `set_value` Check field with bool (production bug)**
`frappe.db.set_value(..., "reconciled", True)` renders `SET reconciled=true`; the column is `smallint`, which Postgres rejects (`DatatypeMismatch`). MariaDB coerces `true→1`. Pass `1`.

**3-6. Test-only Postgres-validity fixes**
- `test_unreconcile_payment.py` — same bool→int (`book_advance_payments_in_separate_party_account`, smallint).
- `test_bin.py` / `test_item.py` — a deliberate `UniqueValidationError` (duplicate Bin / duplicate barcode) aborts the transaction on Postgres, so the *following* statements failed with `InFailedSqlTransaction`. Wrapped each expected-failure insert in a `savepoint` + `rollback(save_point=...)`, mirroring the existing `_create_bin()` "preserve transaction in postgres" pattern. No-op on MariaDB.
- `test_perf.py` — `SHOW INDEX` is MySQL-only; added a db-aware helper that reads the leading index column from `pg_index` on Postgres and keeps `SHOW INDEX` on MariaDB.

### Why MariaDB is unchanged
- Case fix (#1): MariaDB resolved the lowercased name to the same row, so the returned `variant_of` is identical.
- bool→int (#2,#3): MariaDB already stored `True` as `1`; `1` stores the same.
- savepoints (#4,#5): rolling back a no-op failed insert to a savepoint changes nothing on MariaDB.
- index check (#6): MariaDB still runs the exact `SHOW INDEX` query.

### Verification (both engines, per test)

| Test | MariaDB | Postgres |
|---|---|---|
| `unreconcile_payment.test_07_adv_from_so_to_invoice` | OK | OK |
| `bin.test_concurrent_inserts` | OK | OK |
| `item.test_add_item_barcode` | OK | OK |
| `stock_entry.test_variant_work_order` | OK | OK |
| `test_perf.test_ensure_indexes` | OK | OK |

(`payment_terms_template.test_create_template` also failed in CI but was a cascade victim of an aborted transaction; it passes in isolation and is fixed implicitly by the savepoint changes above.)

### Related
- #56243 — Postgres CI workflow + installs the `payments` app on the PG test site (fixes the `tabPayment Gateway` failures, the largest CI chunk).

---

**Added (from a comprehensive `sql-to-orm-postgres`→`develop` reconciliation):** `test_item.test_heatmap_data` — `get_timeline_data` uses `UnixTimestamp(posting_date)`, whose midnight epoch (in the DB session timezone) can sit up to a day ahead of `time.time()` when the app TZ is ahead of UTC, making the strict `<= now` upper bound flaky on Postgres. Widened the bound by a day; MariaDB unchanged. Verified green on both engines.

> A 60-file staging↔develop reconciliation found this was the **only** remaining unported PG fix (everything else was already on develop or was unrelated churn).
