### PR TITLE
fix(postgres): savepoint-guard swallow-and-continue insert paths

### DIFF
--- a/erpnext/erpnext_integrations/doctype/plaid_settings/plaid_settings.py
+++ b/erpnext/erpnext_integrations/doctype/plaid_settings/plaid_settings.py
@@ -113,6 +113,8 @@ def add_bank_accounts(response: str | dict, bank: str | dict, company: str):
 
 		if not existing_bank_account:
 			try:
+				# savepoint so a failed insert doesn't poison the transaction on postgres
+				frappe.db.savepoint("plaid_bank_account")
 				gl_account = frappe.get_doc(
 					{
 						"doctype": "Account",
@@ -142,12 +144,14 @@ def add_bank_accounts(response: str | dict, bank: str | dict, company: str):
 
 				result.append(new_account.name)
 			except frappe.UniqueValidationError:
+				frappe.db.rollback(save_point="plaid_bank_account")  # preserve transaction in postgres
 				frappe.msgprint(
 					_("Bank account {0} already exists and could not be created again").format(
 						account["name"]
 					)
 				)
 			except Exception:
+				frappe.db.rollback(save_point="plaid_bank_account")  # preserve transaction in postgres
 				frappe.log_error("Plaid Link Error")
 				frappe.throw(
 					_("There was an error creating Bank Account while linking with Plaid."),

--- a/erpnext/setup/setup_wizard/operations/install_fixtures.py
+++ b/erpnext/setup/setup_wizard/operations/install_fixtures.py
@@ -567,6 +567,7 @@ def create_bank_account(args, demo=False):
 			}
 		)
 		try:
+			frappe.db.savepoint("create_bank_account")
 			doc = bank_account.insert()
 
 			if args.get("set_default"):
@@ -583,6 +584,7 @@ def create_bank_account(args, demo=False):
 		except RootNotEditable:
 			frappe.throw(frappe._("Bank account cannot be named as {0}").format(args.get("bank_account")))
 		except frappe.DuplicateEntryError:
+			frappe.db.rollback(save_point="create_bank_account")  # preserve transaction in postgres
 			# bank account same as a CoA entry
 			pass
 


### PR DESCRIPTION
### Context

frappe#40075 dropped the blanket per-insert/update savepoint from `base_document.py` (it tripled `db_update`'s query count), with the explicit expectation that **swallow-and-continue callers wrap their own savepoint**. Without that net, on Postgres a failed `insert()` aborts the *entire* transaction, so any code that catches the failure and keeps doing DB work in the same transaction dies on the next statement with `InFailedSqlTransaction`. MariaDB is unaffected (a failed statement doesn't poison the transaction).

This PR fixes the two production swallow-and-continue insert paths that aren't already savepoint-guarded. (`_create_bin`, `opening_invoice_creation_tool`, and `bulk_transaction` already are.)

### Audit result

I swept every `except (DuplicateEntryError|UniqueValidationError|IntegrityError)` in erpnext source. Most are safe:
- `crm/lead.py` re-raises via `frappe.throw` → request rolls back cleanly (no further DB in the poisoned txn).
- `employee.py`, `accounts/utils.py` use `insert(ignore_if_duplicate=True)` → on Postgres `on conflict (name) do nothing` makes the insert a no-op (no exception, no abort).
- `stock/.../stock_and_account_value_comparison.py` and `stock_ledger_invariant_check.py` create **Repost Item Valuation** which is `autoname: "hash"` → also covered by `on conflict (name) do nothing`.
- `serial_and_batch_bundle.py` has no DB op in the guarded block.

The two that genuinely swallow-and-continue after a real failed insert:

**1. `plaid_settings.add_bank_accounts`** — inserts a Bank Account per Plaid account in a loop; on `UniqueValidationError` it `msgprint`s and continues, so on Postgres the next iteration hit `InFailedSqlTransaction`.

**2. `install_fixtures.create_bank_account`** — inserts a bank Account and swallows `DuplicateEntryError` ("bank account same as a CoA entry"); the rest of company setup then ran against a poisoned transaction on Postgres.

### Fix

Each wraps the insert in `frappe.db.savepoint(...)` and `frappe.db.rollback(save_point=...)` in the handler — the pattern frappe#40075 prescribes and that `_create_bin` already uses. Behaviour is unchanged on MariaDB (rolling back a no-op failed insert to a savepoint changes nothing) and on Postgres the transaction stays usable.

### Note
These paths have no existing automated tests (Plaid integration / setup-wizard); the change is a minimal, behaviour-preserving savepoint guard verified by `py_compile` and by the mechanism above. Related: #56251 (the test-suite Postgres failures), frappe#40075 (the savepoint removal).
