### PR TITLE
fix(controllers): keep Sales/Purchase Trends one row per based-on key (MariaDB parity)

### DIFF
--- a/erpnext/buying/report/purchase_order_trends/test_purchase_order_trends.py
+++ b/erpnext/buying/report/purchase_order_trends/test_purchase_order_trends.py
@@ -1,0 +1,32 @@
+# Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
+# License: GNU General Public License v3. See license.txt
+
+import frappe
+
+from erpnext.tests.utils import ERPNextTestSuite
+
+
+class TestPurchaseOrderTrends(ERPNextTestSuite):
+	def test_supplier_with_divergent_stored_name_stays_one_row(self):
+		# supplier_name is a stored per-transaction field; historical purchase docs can hold a different
+		# value for the same supplier. trends groups by t1.supplier only and aggregates supplier_name with
+		# Max(), so the report stays one row per supplier on both MariaDB and Postgres. Grouping by
+		# supplier_name (the pre-fix behaviour) would split the supplier into two rows.
+		from erpnext.buying.doctype.purchase_order.test_purchase_order import create_purchase_order
+		from erpnext.buying.report.purchase_order_trends.purchase_order_trends import execute
+
+		create_purchase_order(supplier="_Test Supplier", qty=3, rate=100)
+		po2 = create_purchase_order(supplier="_Test Supplier", qty=2, rate=100)
+		# simulate a historical doc that stored a different supplier_name for the same supplier
+		frappe.db.set_value("Purchase Order", po2.name, "supplier_name", "_Test Supplier (renamed)")
+
+		filters = {
+			"company": "_Test Company",
+			"period": "Monthly",
+			"based_on": "Supplier",
+		}
+		columns, data, _chart_none, _chart = execute(filters)
+
+		self.assertTrue(columns)
+		supplier_rows = [row for row in data if row[0] == "_Test Supplier"]
+		self.assertEqual(len(supplier_rows), 1)

--- a/erpnext/controllers/trends.py
+++ b/erpnext/controllers/trends.py
@@ -418,8 +418,14 @@ def based_wise_columns_query(based_on, trans):
 			"Supplier Name:Data:120",
 			"Supplier Group:Link/Supplier Group:140",
 		]
-		based_on_details["based_on_select"] = "t1.supplier, t1.supplier_name, t3.supplier_group,"
-		based_on_details["based_on_group_by"] = "t1.supplier, t1.supplier_name, t3.supplier_group"
+		# supplier_name is a stored per-transaction field (not functionally dependent on supplier), so
+		# it is aggregated to keep one row per supplier — matching the prior MariaDB output, which grouped
+		# by t1.supplier only. supplier_group comes from the joined master and is FD on supplier, so it
+		# stays in GROUP BY (postgres-valid, no row split).
+		based_on_details[
+			"based_on_select"
+		] = "t1.supplier, Max(t1.supplier_name) as supplier_name, t3.supplier_group,"
+		based_on_details["based_on_group_by"] = "t1.supplier, t3.supplier_group"
 		based_on_details["addl_tables"] = ",`tabSupplier` t3"
 		based_on_details["addl_tables_relational_cond"] = " and t1.supplier = t3.name"
 

--- a/erpnext/controllers/trends.py
+++ b/erpnext/controllers/trends.py
@@ -369,8 +369,11 @@ def based_wise_columns_query(based_on, trans):
 	# based_on_cols, based_on_select, based_on_group_by, addl_tables
 	if based_on == "Item":
 		based_on_details["based_on_cols"] = ["Item:Link/Item:120", "Item Name:Data:120"]
-		based_on_details["based_on_select"] = "t2.item_code, t2.item_name,"
-		based_on_details["based_on_group_by"] = "t2.item_code, t2.item_name"
+		# item_name is an editable per-line field, not functionally dependent on item_code, so it
+		# is aggregated (one row per item_code) rather than added to GROUP BY (which would split
+		# the row and change the MariaDB row count). See get_data's group-by query.
+		based_on_details["based_on_select"] = "t2.item_code, Max(t2.item_name) as item_name,"
+		based_on_details["based_on_group_by"] = "t2.item_code"
 		based_on_details["addl_tables"] = ""
 
 	elif based_on == "Item Group":
@@ -386,19 +389,21 @@ def based_wise_columns_query(based_on, trans):
 				"Party Name:Data:120",
 				"Territory:Link/Territory:120",
 			]
-			based_on_details["based_on_select"] = "t1.party_name, t1.customer_name, t1.territory,"
+			based_on_details[
+				"based_on_select"
+			] = "t1.party_name, Max(t1.customer_name) as customer_name, Max(t1.territory) as territory,"
 		else:
 			based_on_details["based_on_cols"] = [
 				"Customer:Link/Customer:120",
 				"Customer Name:Data:120",
 				"Territory:Link/Territory:120",
 			]
-			based_on_details["based_on_select"] = "t1.customer, t1.customer_name, t1.territory,"
-		based_on_details["based_on_group_by"] = (
-			"t1.party_name, t1.customer_name, t1.territory"
-			if trans == "Quotation"
-			else "t1.customer, t1.customer_name, t1.territory"
-		)
+			based_on_details[
+				"based_on_select"
+			] = "t1.customer, Max(t1.customer_name) as customer_name, Max(t1.territory) as territory,"
+		# territory (and customer_name) are not functionally dependent on the customer key, so they
+		# are aggregated rather than grouped — one row per customer, matching the prior MariaDB output.
+		based_on_details["based_on_group_by"] = "t1.party_name" if trans == "Quotation" else "t1.customer"
 		based_on_details["addl_tables"] = ""
 
 	elif based_on == "Customer Group":

--- a/erpnext/selling/report/sales_order_trends/test_sales_order_trends.py
+++ b/erpnext/selling/report/sales_order_trends/test_sales_order_trends.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: GNU General Public License v3. See license.txt
 
+import frappe
+
 from erpnext.tests.utils import ERPNextTestSuite
 
 
@@ -25,3 +27,27 @@ class TestSalesOrderTrends(ERPNextTestSuite):
 
 		self.assertTrue(columns)
 		self.assertTrue(any("_Test Item" in [str(cell) for cell in row] for row in data))
+
+	def test_customer_with_divergent_stored_territory_stays_one_row(self):
+		# territory (and customer_name) are stored per-transaction fields; historical sales docs can hold a
+		# different value for the same customer. trends groups by t1.customer only and aggregates these with
+		# Max(), so the report stays one row per customer on both MariaDB and Postgres. Grouping by territory
+		# (the pre-fix behaviour) would split the customer into two rows.
+		from erpnext.selling.doctype.sales_order.test_sales_order import make_sales_order
+		from erpnext.selling.report.sales_order_trends.sales_order_trends import execute
+
+		make_sales_order(customer="_Test Customer", item_code="_Test Item", qty=3, rate=100)
+		so2 = make_sales_order(customer="_Test Customer", item_code="_Test Item", qty=2, rate=100)
+		# simulate a historical doc that stored a different territory for the same customer
+		frappe.db.set_value("Sales Order", so2.name, "territory", "_Test Territory Rest Of The World")
+
+		filters = {
+			"company": "_Test Company",
+			"period": "Monthly",
+			"based_on": "Customer",
+		}
+		columns, data, _chart_none, _chart = execute(filters)
+
+		self.assertTrue(columns)
+		customer_rows = [row for row in data if row[0] == "_Test Customer"]
+		self.assertEqual(len(customer_rows), 1)

--- a/erpnext/selling/report/sales_order_trends/test_sales_order_trends.py
+++ b/erpnext/selling/report/sales_order_trends/test_sales_order_trends.py
@@ -7,8 +7,9 @@ from erpnext.tests.utils import ERPNextTestSuite
 class TestSalesOrderTrends(ERPNextTestSuite):
 	def test_report_executes_with_group_by(self):
 		# trends.get_data builds per-period SUM(CASE ...) aggregates (converted from MySQL SUM(IF)),
-		# with a GROUP BY widened to every selected non-aggregated column and a based_on_key for the
-		# group-by detail subqueries. Setting group_by exercises that full path on both engines.
+		# groups by the based-on KEY only (non-key descriptive columns like item_name/territory are
+		# MAX()-aggregated so the report stays one row per key on both engines), and uses a based_on_key
+		# for the group-by detail subqueries. Setting group_by exercises that full path on both engines.
 		from erpnext.selling.doctype.sales_order.test_sales_order import make_sales_order
 		from erpnext.selling.report.sales_order_trends.sales_order_trends import execute
 


### PR DESCRIPTION
### Problem (found by a MariaDB-no-regression audit of the Postgres-parity effort)

#56192 made the Sales/Purchase **Trends** queries (`controllers/trends.py`) Postgres-strict-
`GROUP BY`-valid by **widening `based_on_group_by` to include the selected descriptive columns**.
For `based_on="Item"` it added `t2.item_name`; for `based_on="Customer"` it added `t1.territory`
(and `t1.customer_name`); for `based_on="Supplier"` it added `t1.supplier_name`.

But `item_name`, `territory`, `customer_name` and `supplier_name` are **stored, editable
per-transaction** fields — none is functionally dependent on the `item_code` / `customer` /
`supplier` key. On MariaDB (`ONLY_FULL_GROUP_BY` off) this **splits** the previously-single row
per key into one row per distinct `(key, descriptive-value)` tuple. So a customer transacting
across two territories — or a supplier whose stored `supplier_name` differs across historical
docs — now produces **duplicate rows with fractured per-period subtotals**. That's a regression
of the "MariaDB output must not change" contract (verified live on MariaDB 10.6).

### Fix

Group by the **key only** and aggregate the non-key descriptive columns with `Max()`:

```python
# Item
based_on_select   = "t2.item_code, Max(t2.item_name) as item_name,"
based_on_group_by = "t2.item_code"
# Customer
based_on_select   = "t1.customer, Max(t1.customer_name) as customer_name, Max(t1.territory) as territory,"
based_on_group_by = "t1.customer"   # ("t1.party_name" for Quotation)
# Supplier
based_on_select   = "t1.supplier, Max(t1.supplier_name) as supplier_name, t3.supplier_group,"
based_on_group_by = "t1.supplier, t3.supplier_group"
```

- One row per based-on key — **identical row count to the pre-#56192 MariaDB output**; for the
  common case (one descriptive value per key) the `Max()` returns that same single value.
- Still **Postgres-valid** (every non-grouped selected column is either aggregated or in GROUP BY).
- The detail sub-queries are unaffected: `based_on_key = group_by.split(",")[0]` is still the key.
- **Supplier:** `supplier_name` is stored per-transaction, so it is `Max()`-aggregated; the
  `supplier_group` column comes from the joined `tabSupplier` master and **is** functionally
  dependent on `t1.supplier`, so it stays in GROUP BY (Postgres-valid, no split). This restores
  the original one-row-per-supplier behaviour, which grouped by `t1.supplier` only.
  (Thanks to the review on this PR for catching that Supplier had the same split risk.)

### Verification
Report tests green on **both engines** (`--lightmode`): MariaDB OK, Postgres OK.

- `selling/report/sales_order_trends/test_sales_order_trends.py` — exercises the `group_by` path,
  plus a new regression test asserting **one row per customer** even when two orders for the same
  customer store divergent `territory` values.
- `buying/report/purchase_order_trends/test_purchase_order_trends.py` (new) — regression test
  asserting **one row per supplier** even when two POs for the same supplier store divergent
  `supplier_name` values.

Both new tests **fail on the pre-fix multi-column GROUP BY** (`2 != 1`) and pass after the fix, on
both engines.

Context: one of two genuinely-live MariaDB divergences found by a full adversarial re-audit of the
177 production commits in the Postgres-parity effort (the other is #56260). The audit flagged 6
"confirmed regressions", but 4 had already been self-corrected by later commits during the effort —
only this and #56260 remained live on `develop`.
