### PR TITLE
ci: don't run background workers during patch-test migrate

### DIFF
--- a/.github/workflows/patch.yml
+++ b/.github/workflows/patch.yml
@@ -119,6 +119,15 @@ jobs:
           git -C "apps/frappe" remote set-url upstream https://github.com/frappe/frappe.git
           git -C "apps/erpnext" remote set-url upstream https://github.com/frappe/erpnext.git
 
+          # Start every bench process except the background workers. If workers run during a
+          # migrate, they pick up the orphan-link cleanup jobs it enqueues and race its schema
+          # changes, which fails with MySQL 1412 "Table definition has changed". Redis and the
+          # other services stay up; the queued jobs simply wait and are harmless here.
+          function start_bench_without_workers() {
+            local procs
+            procs=$(awk -F: '/^[a-z_]+:/ && $1 !~ /worker/ {print $1}' ~/frappe-bench/Procfile)
+            honcho start -f ~/frappe-bench/Procfile $procs &>> ~/frappe-bench/bench_start.log &
+          }
 
           function update_to_version() {
             version=$1
@@ -137,7 +146,7 @@ jobs:
             rm -rf ~/frappe-bench/env
             bench -v setup env --python python$2
             bench pip install -e ./apps/erpnext
-            bench start &>> ~/frappe-bench/bench_start.log &
+            start_bench_without_workers
 
             bench --site test_site migrate
           }
@@ -154,7 +163,7 @@ jobs:
           rm -rf ~/frappe-bench/env
           bench -v setup env
           bench pip install -e ./apps/erpnext
-          bench start &>> ~/frappe-bench/bench_start.log &
+          start_bench_without_workers
 
           bench --site test_site migrate
 


### PR DESCRIPTION
The Patch Test fails intermittently with `MySQLdb.OperationalError: (1412, 'Table definition has changed, please retry transaction')`, which has been hitting several open PRs (unrelated to their changes).

**Cause:** the workflow starts the full bench — including background workers — and then runs `bench migrate`. Migrate deletes orphan doctypes/pages and enqueues `delete_dynamic_links` jobs; a worker picks one up and runs it while migrate is altering tables, so the two collide and MySQL aborts the transaction with 1412.

**Fix:** during the migrate, start every bench process *except* the workers, so nothing consumes the queue while tables are changing. Redis and the other services stay up, and the queued jobs simply wait (the patch test doesn't need them).

> Note: GitHub workflows can't be run locally, so this needs a CI run on the PR to confirm.
