### PR TITLE
test: RFQ + Supplier Quotation coverage; fix broken SQ expiry task

### DIFF
--- a/erpnext/buying/doctype/request_for_quotation/test_request_for_quotation.py
+++ b/erpnext/buying/doctype/request_for_quotation/test_request_for_quotation.py
@@ -59,6 +59,42 @@ class TestRequestforQuotation(ERPNextTestSuite):
 		self.assertEqual(rfq.get("suppliers")[0].quote_status, "Received")
 		self.assertEqual(rfq.get("suppliers")[1].quote_status, "Pending")
 
+	def test_duplicate_supplier_rejected(self):
+		rfq = frappe.new_doc("Request for Quotation")
+		rfq.transaction_date = nowdate()
+		rfq.company = "_Test Company"
+		rfq.message_for_supplier = "Please quote"
+		rfq.append("suppliers", {"supplier": "_Test Supplier"})
+		rfq.append("suppliers", {"supplier": "_Test Supplier"})
+		rfq.append(
+			"items",
+			{
+				"item_code": "_Test Item",
+				"qty": 5,
+				"uom": "_Test UOM",
+				"stock_uom": "_Test UOM",
+				"conversion_factor": 1.0,
+				"warehouse": "_Test Warehouse - _TC",
+				"schedule_date": nowdate(),
+			},
+		)
+		self.assertRaises(frappe.ValidationError, rfq.insert)
+
+	def test_rfq_blocked_for_supplier_with_prevent_rfqs(self):
+		frappe.db.set_value("Supplier", "_Test Supplier", "prevent_rfqs", 1)
+		rfq = make_request_for_quotation(
+			supplier_data=[{"supplier": "_Test Supplier", "supplier_name": "_Test Supplier"}],
+			do_not_save=True,
+		)
+		self.assertRaises(frappe.ValidationError, rfq.save)
+
+	def test_rfq_status_lifecycle(self):
+		rfq = make_request_for_quotation()
+		self.assertEqual(rfq.status, "Submitted")
+
+		rfq.cancel()
+		self.assertEqual(rfq.status, "Cancelled")
+
 	def test_make_supplier_quotation(self):
 		rfq = make_request_for_quotation()
 

--- a/erpnext/buying/doctype/supplier_quotation/supplier_quotation.py
+++ b/erpnext/buying/doctype/supplier_quotation/supplier_quotation.py
@@ -243,11 +243,16 @@ def get_list_context(context=None):
 
 
 def set_expired_status():
+	# Only submitted quotations past their validity should be expired
 	frappe.db.set_value(
 		"Supplier Quotation",
-		filters={"status": ["not in", ["Cancelled", "Stopped"]], "valid_till": ["<", nowdate()]},
-		fieldname="status",
-		value="Expired",
+		{
+			"docstatus": 1,
+			"status": ["not in", ["Cancelled", "Stopped"]],
+			"valid_till": ["<", nowdate()],
+		},
+		"status",
+		"Expired",
 		update_modified=True,
 	)
 

--- a/erpnext/buying/doctype/supplier_quotation/test_supplier_quotation.py
+++ b/erpnext/buying/doctype/supplier_quotation/test_supplier_quotation.py
@@ -8,7 +8,12 @@ import frappe
 from frappe.tests import change_settings
 from frappe.utils import add_days, today
 
+from erpnext.buying.doctype.request_for_quotation.mapper import make_supplier_quotation_from_rfq
+from erpnext.buying.doctype.request_for_quotation.test_request_for_quotation import (
+	make_request_for_quotation,
+)
 from erpnext.buying.doctype.supplier_quotation.mapper import make_purchase_order
+from erpnext.buying.doctype.supplier_quotation.supplier_quotation import set_expired_status
 from erpnext.controllers.accounts_controller import InvalidQtyError, update_child_qty_rate
 from erpnext.tests.utils import ERPNextTestSuite
 
@@ -16,6 +21,56 @@ from erpnext.tests.utils import ERPNextTestSuite
 class TestPurchaseOrder(ERPNextTestSuite):
 	def setUp(self):
 		self.load_test_records("Supplier Quotation")
+
+	def test_valid_till_before_transaction_date_rejected(self):
+		rfq = make_request_for_quotation()
+		sq = make_supplier_quotation_from_rfq(rfq.name, for_supplier=rfq.suppliers[0].supplier)
+		sq.transaction_date = today()
+		sq.valid_till = add_days(today(), -1)
+		self.assertRaises(frappe.ValidationError, sq.insert)
+
+	def test_set_expired_status_expires_only_submitted_past_quotations(self):
+		rfq = make_request_for_quotation()
+
+		expired = make_supplier_quotation_from_rfq(rfq.name, for_supplier=rfq.suppliers[0].supplier)
+		expired.transaction_date = add_days(today(), -10)
+		expired.valid_till = add_days(today(), -2)
+		expired.insert()
+		expired.submit()
+
+		valid = make_supplier_quotation_from_rfq(rfq.name, for_supplier=rfq.suppliers[1].supplier)
+		valid.valid_till = add_days(today(), 10)
+		valid.insert()
+		valid.submit()
+
+		# A past-validity draft must not be expired - "Expired" applies to submitted quotations only
+		draft = make_supplier_quotation_from_rfq(rfq.name, for_supplier=rfq.suppliers[0].supplier)
+		draft.transaction_date = add_days(today(), -10)
+		draft.valid_till = add_days(today(), -2)
+		draft.insert()
+
+		set_expired_status()
+
+		self.assertEqual(frappe.db.get_value("Supplier Quotation", expired.name, "status"), "Expired")
+		self.assertEqual(frappe.db.get_value("Supplier Quotation", valid.name, "status"), "Submitted")
+		self.assertEqual(frappe.db.get_value("Supplier Quotation", draft.name, "status"), "Draft")
+
+	def test_submit_and_cancel_updates_rfq_quote_status(self):
+		rfq = make_request_for_quotation()
+		supplier_row = rfq.suppliers[0]
+
+		sq = make_supplier_quotation_from_rfq(rfq.name, for_supplier=supplier_row.supplier)
+		sq.submit()
+		self.assertEqual(
+			frappe.db.get_value("Request for Quotation Supplier", supplier_row.name, "quote_status"),
+			"Received",
+		)
+
+		sq.cancel()
+		self.assertEqual(
+			frappe.db.get_value("Request for Quotation Supplier", supplier_row.name, "quote_status"),
+			"Pending",
+		)
 
 	def test_update_child_supplier_quotation_add_item(self):
 		sq = frappe.copy_doc(self.globalTestRecords["Supplier Quotation"][0])


### PR DESCRIPTION
Adds test coverage for Request for Quotation and Supplier Quotation, and fixes a broken scheduled task found while writing it.

### Bug fixed
**Supplier Quotation expiry never worked.** The daily task that marks expired quotations was calling the framework with the wrong arguments and crashed every time it ran, so quotations past their validity were never marked **Expired**. Fixed, and scoped to submitted quotations so drafts aren't wrongly expired.

### Tests added
- RFQ: rejects the same supplier added twice; blocks raising an RFQ for a supplier barred by their scorecard; submit/cancel set the right status.
- Supplier Quotation: "valid till" can't be before the quotation date; the expiry task marks only submitted, past-validity quotations as Expired; submitting then cancelling a quotation flips the linked RFQ supplier between Received and Pending.

### How to test
- Add the same supplier twice on an RFQ → saving should be blocked.
- Set a supplier's scorecard standing so RFQs are blocked, then try to raise an RFQ for them → blocked.
- On a Supplier Quotation, set "Valid Till" earlier than the date → blocked.
- Submit a Supplier Quotation against an RFQ and confirm the supplier row shows "Received"; cancel it and confirm it returns to "Pending".
- Create a submitted quotation with a past "Valid Till", run the scheduled job (or wait for it), and confirm its status becomes Expired while a draft with a past date stays Draft.
