### PR TITLE
fix(lead): don't crash deriving lead name when only ignore_mandatory is set

### DIFF
--- a/erpnext/crm/doctype/lead/lead.py
+++ b/erpnext/crm/doctype/lead/lead.py
@@ -140,7 +140,7 @@ class Lead(SellingController, CRMNote):
 				frappe.throw(_("A Lead requires either a person's name or an organization's name"))
 			elif self.company_name:
 				self.lead_name = self.company_name
-			else:
+			elif self.email_id:
 				self.lead_name = self.email_id.split("@")[0]
 
 	def set_title(self):

--- a/erpnext/crm/doctype/lead/lead.py
+++ b/erpnext/crm/doctype/lead/lead.py
@@ -197,17 +197,17 @@ class Lead(SellingController, CRMNote):
 			lead_row.db_update()
 
 	def remove_link_from_prospect(self):
-		prospects = self.get_linked_prospects()
+		linked_prospects = self.get_linked_prospects()
 
-		for d in prospects:
-			prospect = frappe.get_doc("Prospect", d.parent)
+		for linked_prospect in linked_prospects:
+			prospect = frappe.get_doc("Prospect", linked_prospect.parent)
 			if len(prospect.get("leads")) == 1:
 				prospect.delete(ignore_permissions=True)
 			else:
 				to_remove = None
-				for d in prospect.get("leads"):
-					if d.lead == self.name:
-						to_remove = d
+				for lead in prospect.get("leads"):
+					if lead.lead == self.name:
+						to_remove = lead
 
 				if to_remove:
 					prospect.remove(to_remove)

--- a/erpnext/crm/doctype/lead/test_lead.py
+++ b/erpnext/crm/doctype/lead/test_lead.py
@@ -193,6 +193,29 @@ class TestLead(ERPNextTestSuite):
 		lead.delete()
 		self.assertFalse(frappe.db.exists("Prospect", prospect_name))
 
+	def test_set_lead_name_fallbacks(self):
+		# organization name is used when there is no person name
+		lead = frappe.new_doc("Lead")
+		lead.company_name = "_Test Org Lead"
+		lead.set_lead_name()
+		self.assertEqual(lead.lead_name, "_Test Org Lead")
+
+		# the email local-part is used when only an email is present
+		lead = frappe.new_doc("Lead")
+		lead.email_id = "jane.doe@example.com"
+		lead.set_lead_name()
+		self.assertEqual(lead.lead_name, "jane.doe")
+
+		# data import (ignore_mandatory) with no name/company/email must not crash
+		lead = frappe.new_doc("Lead")
+		lead.flags.ignore_mandatory = True
+		lead.set_lead_name()
+		self.assertFalse(lead.lead_name)
+
+		# otherwise a lead with no name source is rejected
+		lead = frappe.new_doc("Lead")
+		self.assertRaises(frappe.ValidationError, lead.set_lead_name)
+
 
 def create_event(subject, starts_on, reference_type, reference_name):
 	event = frappe.new_doc("Event")


### PR DESCRIPTION
Creating a Lead with no person name, no organization name and no email — but with mandatory validation skipped (e.g. during a data import) — crashed with `AttributeError: 'NoneType' object has no attribute 'split'`, because the lead-name logic fell through to splitting a missing email address.

Now the email is only used to derive the lead name when an email actually exists; otherwise the lead name is simply left blank, which is the intended behaviour for the import path. Normal leads (with a name, organization or email) are unaffected.

**Manual QA:** Import Leads with only partial data (e.g. a row with just a phone number, no name/email) and confirm the import no longer errors. Confirm a normally-entered Lead still gets its name from the organization name or email as before.
