### PR TITLE
test: Subcontracting coverage; fix service-cost mismatch by PO item

### DIFF
--- a/erpnext/subcontracting/doctype/subcontracting_order/subcontracting_order.py
+++ b/erpnext/subcontracting/doctype/subcontracting_order/subcontracting_order.py
@@ -182,8 +182,15 @@ class SubcontractingOrder(SubcontractingController):
 		self.calculate_items_qty_and_amount()
 
 	def calculate_service_costs(self):
-		for idx, item in enumerate(self.get("service_items")):
-			self.items[idx].service_cost_per_qty = item.amount / self.items[idx].qty
+		# Match by purchase_order_item rather than list position: the service_items and items
+		# tables are not guaranteed to stay index-aligned (e.g. a skipped zero-qty service item).
+		service_amount_by_po_item = {
+			service_item.purchase_order_item: service_item.amount
+			for service_item in self.get("service_items")
+		}
+		for item in self.items:
+			service_amount = flt(service_amount_by_po_item.get(item.purchase_order_item))
+			item.service_cost_per_qty = service_amount / item.qty if item.qty else 0
 
 	def calculate_supplied_items_qty_and_amount(self):
 		for item in self.get("items"):

--- a/erpnext/subcontracting/doctype/subcontracting_order/test_subcontracting_order.py
+++ b/erpnext/subcontracting/doctype/subcontracting_order/test_subcontracting_order.py
@@ -118,12 +118,12 @@ class TestSubcontractingOrder(ERPNextTestSuite):
 		self.assertRaises(frappe.ValidationError, sco.validate_purchase_order_for_subcontracting)
 
 	def test_service_item_must_be_non_stock(self):
-		sco = get_subcontracting_order()
+		sco = get_subcontracting_order(do_not_submit=1)
 		sco.service_items[0].item_code = "_Test Item"  # a stock item
 		self.assertRaises(frappe.ValidationError, sco.validate_service_items)
 
 	def test_reserve_warehouse_must_differ_from_supplier_warehouse(self):
-		sco = get_subcontracting_order()
+		sco = get_subcontracting_order(do_not_submit=1)
 		sco.supplied_items[0].reserve_warehouse = sco.supplier_warehouse
 		self.assertRaises(frappe.ValidationError, sco.validate_supplied_items)
 

--- a/erpnext/subcontracting/doctype/subcontracting_order/test_subcontracting_order.py
+++ b/erpnext/subcontracting/doctype/subcontracting_order/test_subcontracting_order.py
@@ -138,6 +138,38 @@ class TestSubcontractingOrder(ERPNextTestSuite):
 		self.assertEqual(scr.items[0].process_loss_qty, 1)
 		self.assertEqual(scr.items[0].qty, 9)
 
+	def test_service_cost_is_matched_by_purchase_order_item(self):
+		service_items = [
+			{
+				"warehouse": "_Test Warehouse - _TC",
+				"item_code": "Subcontracted Service Item 7",
+				"qty": 10,
+				"rate": 100,
+				"fg_item": "Subcontracted Item SA7",
+				"fg_item_qty": 10,
+			},
+			{
+				"warehouse": "_Test Warehouse - _TC",
+				"item_code": "Subcontracted Service Item 1",
+				"qty": 10,
+				"rate": 200,
+				"fg_item": "Subcontracted Item SA1",
+				"fg_item_qty": 10,
+			},
+		]
+		sco = get_subcontracting_order(service_items=service_items)
+		expected = {item.purchase_order_item: item.service_cost_per_qty for item in sco.items}
+
+		# The two finished goods have distinct service costs, so a position-based pairing would swap them
+		self.assertEqual(len(set(expected.values())), 2)
+
+		# Service costs must follow purchase_order_item, not list position
+		sco.service_items.reverse()
+		sco.calculate_service_costs()
+
+		for item in sco.items:
+			self.assertEqual(item.service_cost_per_qty, expected[item.purchase_order_item])
+
 	def test_make_rm_stock_entry(self):
 		sco = get_subcontracting_order()
 		rm_items = get_rm_items(sco.supplied_items)

--- a/erpnext/subcontracting/doctype/subcontracting_order/test_subcontracting_order.py
+++ b/erpnext/subcontracting/doctype/subcontracting_order/test_subcontracting_order.py
@@ -112,6 +112,32 @@ class TestSubcontractingOrder(ERPNextTestSuite):
 		sco.load_from_db()
 		self.assertEqual(sco.status, "Partially Received")
 
+	def test_sco_requires_a_subcontracting_purchase_order(self):
+		sco = get_subcontracting_order(do_not_save=1)
+		sco.purchase_order = None
+		self.assertRaises(frappe.ValidationError, sco.validate_purchase_order_for_subcontracting)
+
+	def test_service_item_must_be_non_stock(self):
+		sco = get_subcontracting_order()
+		sco.service_items[0].item_code = "_Test Item"  # a stock item
+		self.assertRaises(frappe.ValidationError, sco.validate_service_items)
+
+	def test_reserve_warehouse_must_differ_from_supplier_warehouse(self):
+		sco = get_subcontracting_order()
+		sco.supplied_items[0].reserve_warehouse = sco.supplier_warehouse
+		self.assertRaises(frappe.ValidationError, sco.validate_supplied_items)
+
+	def test_subcontracting_receipt_applies_bom_process_loss(self):
+		sco = get_subcontracting_order()
+		frappe.db.set_value("BOM", sco.items[0].bom, "process_loss_percentage", 10)
+
+		scr = make_subcontracting_receipt(sco.name)
+
+		# 10% of the ordered 10 qty is lost in processing
+		self.assertEqual(scr.items[0].received_qty, 10)
+		self.assertEqual(scr.items[0].process_loss_qty, 1)
+		self.assertEqual(scr.items[0].qty, 9)
+
 	def test_make_rm_stock_entry(self):
 		sco = get_subcontracting_order()
 		rm_items = get_rm_items(sco.supplied_items)


### PR DESCRIPTION
Adds test coverage for Subcontracting Order setup rules and the Subcontracting Receipt process-loss calculation, and fixes a fragility found while writing it.

### Bug fixed
**Service costs could be assigned to the wrong finished good.** The Subcontracting Order calculated each finished good's service cost by pairing the service-items and items tables by list position. If those tables aren't perfectly aligned (e.g. a service item with zero available quantity is skipped while building items), costs get assigned to the wrong item or the save errors out. Now matched by the linked purchase order item, with a guard against divide-by-zero.

### Tests added
- A Subcontracting Order can't be created without a subcontracting Purchase Order.
- Service items must be non-stock items.
- A supplied (raw material) item's reserve warehouse must differ from the supplier warehouse.
- When the BOM has a process-loss percentage, the Subcontracting Receipt reduces the finished-good quantity accordingly (received 10 → 1 lost → 9 good).
- Service costs follow the linked purchase order item regardless of row order (regression test for the fix).

### How to test
- Try saving a Subcontracting Order with no Purchase Order, or with a stock item as a service item → both blocked.
- Set a supplied item's reserve warehouse equal to the supplier warehouse → blocked.
- On a finished good's BOM set a process-loss percentage, create a Subcontracting Receipt from the order, and confirm the good quantity drops by the loss while received quantity stays full.
- Create a Subcontracting Order with two finished goods at different service rates and confirm each shows its own service cost.
