### PR TITLE
test(lead): cover lead details and prospect sync/unlink

### DIFF
--- a/erpnext/crm/doctype/lead/test_lead.py
+++ b/erpnext/crm/doctype/lead/test_lead.py
@@ -157,6 +157,42 @@ class TestLead(ERPNextTestSuite):
 		lead.lead_owner = None
 		self.assertIsNone(lead.get_notification_email())
 
+	def test_get_lead_details(self):
+		from erpnext.crm.doctype.lead.lead import get_lead_details
+
+		lead = make_lead(
+			first_name="Detail",
+			last_name="Lead",
+			email_id="detail_lead@example.com",
+			company_name="Detail Org",
+		)
+		details = get_lead_details(lead.name, company="_Test Company")
+		self.assertEqual(details["customer_name"], "Detail Org")  # company_name preferred over lead_name
+		self.assertEqual(details["contact_email"], "detail_lead@example.com")
+
+		# no lead -> empty dict, not an error
+		self.assertEqual(get_lead_details("", company="_Test Company"), {})
+
+	def test_lead_prospect_sync_and_unlink(self):
+		lead = make_lead(
+			first_name="Link",
+			last_name="Lead",
+			email_id="link_lead@example.com",
+			company_name="Link Prospect Co",
+		)
+		lead.create_prospect(lead.company_name)
+		prospect_name = get_linked_prospect("Lead", lead.name)
+		self.assertEqual(prospect_name, "Link Prospect Co")
+
+		# editing the lead syncs into its Prospect Lead row
+		lead.mobile_no = "9999999999"
+		lead.save()
+		self.assertEqual(frappe.db.get_value("Prospect Lead", {"lead": lead.name}, "mobile_no"), "9999999999")
+
+		# deleting the only lead of a prospect removes the prospect
+		lead.delete()
+		self.assertFalse(frappe.db.exists("Prospect", prospect_name))
+
 
 def create_event(subject, starts_on, reference_type, reference_name):
 	event = frappe.new_doc("Event")


### PR DESCRIPTION
Adds tests for the thinly-covered Lead controller.

Covers fetching lead details (used when creating a quotation/opportunity from a lead) and the Lead ↔ Prospect lifecycle: editing a lead syncs the changes into its row on the linked Prospect, and deleting a lead that is the prospect's only lead removes the prospect.

**Manual QA:** Create a Lead and a Prospect from it, edit the lead's mobile number and confirm it updates on the Prospect; delete that lead and confirm the (now empty) Prospect is removed.
