### PR TITLE
fix(crm): drive opportunity auto-close days from CRM Settings, not a hardcoded fallback

### DIFF
--- a/erpnext/crm/doctype/opportunity/opportunity.py
+++ b/erpnext/crm/doctype/opportunity/opportunity.py
@@ -399,8 +399,8 @@ def set_multiple_status(names: str | list[str], status: str):
 
 
 def auto_close_opportunity():
-	"""auto close the `Replied` Opportunities after 7 days"""
-	auto_close_after_days = frappe.db.get_single_value("CRM Settings", "close_opportunity_after_days") or 15
+	"""Auto close `Replied` Opportunities inactive for the days configured in CRM Settings."""
+	auto_close_after_days = frappe.db.get_single_value("CRM Settings", "close_opportunity_after_days")
 
 	table = frappe.qb.DocType("Opportunity")
 	opportunities = (

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -489,3 +489,4 @@ erpnext.patches.v16_0.submit_existing_product_bundles #1
 erpnext.patches.v16_0.migrate_subscription_generate_invoice_at
 erpnext.patches.v16_0.rename_subscription_billing_period_fields
 erpnext.patches.v16_0.drop_redundant_serial_no_index_from_sabb
+erpnext.patches.v16_0.set_default_close_opportunity_after_days

--- a/erpnext/patches/v16_0/set_default_close_opportunity_after_days.py
+++ b/erpnext/patches/v16_0/set_default_close_opportunity_after_days.py
@@ -1,0 +1,12 @@
+import frappe
+
+
+def execute():
+	"""Backfill the default for CRM Settings.close_opportunity_after_days.
+
+	The auto-close logic used to fall back to 15 days in code. Now that the fallback is removed,
+	existing sites that never set the value (left blank / 0) need it filled in so opportunities
+	keep auto-closing on the same schedule.
+	"""
+	if not frappe.db.get_single_value("CRM Settings", "close_opportunity_after_days"):
+		frappe.db.set_single_value("CRM Settings", "close_opportunity_after_days", 15)


### PR DESCRIPTION
The "auto-close Replied opportunities" job used a 15-day value hardcoded in code whenever the CRM Setting "Close Replied Opportunity After Days" was left blank (and its docstring still said 7 days).

Now the number of days comes only from CRM Settings — the field already defaults to 15 — and a patch fills in 15 for existing sites that had it blank, so they keep auto-closing on the same schedule. Sites that set their own value are untouched.

**Manual QA:** Open CRM Settings and confirm "Close Replied Opportunity After Days" is 15 (change it if you like); confirm Replied opportunities inactive beyond that many days get auto-closed.
