### PR TITLE
feat: party aliases

### DIFF
--- a/erpnext/buying/doctype/supplier/supplier.json
+++ b/erpnext/buying/doctype/supplier/supplier.json
@@ -13,6 +13,7 @@
   "naming_series",
   "supplier_type",
   "supplier_name",
+  "alias",
   "gender",
   "column_break0",
   "supplier_group",
@@ -100,6 +101,13 @@
    "oldfieldname": "supplier_name",
    "oldfieldtype": "Data",
    "reqd": 1
+  },
+  {
+   "fieldname": "alias",
+   "fieldtype": "Data",
+   "in_global_search": 1,
+   "label": "Alias",
+   "unique": 1
   },
   {
    "fieldname": "country",
@@ -522,7 +530,7 @@
    "link_fieldname": "party"
   }
  ],
- "modified": "2026-05-29 16:52:59.441272",
+ "modified": "2026-06-22 12:23:09.241125",
  "modified_by": "Administrator",
  "module": "Buying",
  "name": "Supplier",
@@ -582,7 +590,7 @@
  ],
  "quick_entry": 1,
  "row_format": "Dynamic",
- "search_fields": "supplier_group",
+ "search_fields": "supplier_group, alias",
  "show_name_in_global_search": 1,
  "sort_field": "creation",
  "sort_order": "ASC",

--- a/erpnext/buying/doctype/supplier/supplier.py
+++ b/erpnext/buying/doctype/supplier/supplier.py
@@ -39,6 +39,7 @@ class Supplier(TransactionBase):
 		from erpnext.utilities.doctype.portal_user.portal_user import PortalUser
 
 		accounts: DF.Table[PartyAccount]
+		alias: DF.Data | None
 		allow_purchase_invoice_creation_without_purchase_order: DF.Check
 		allow_purchase_invoice_creation_without_purchase_receipt: DF.Check
 		companies: DF.Table[AllowedToTransactWith]

--- a/erpnext/selling/doctype/customer/customer.json
+++ b/erpnext/selling/doctype/customer/customer.json
@@ -14,6 +14,7 @@
   "naming_series",
   "customer_type",
   "customer_name",
+  "alias",
   "gender",
   "column_break0",
   "customer_group",
@@ -120,6 +121,13 @@
    "oldfieldtype": "Data",
    "reqd": 1,
    "search_index": 1
+  },
+  {
+   "fieldname": "alias",
+   "fieldtype": "Data",
+   "in_global_search": 1,
+   "label": "Alias",
+   "unique": 1
   },
   {
    "depends_on": "eval:doc.customer_type == 'Individual'",
@@ -647,7 +655,7 @@
    "link_fieldname": "party"
   }
  ],
- "modified": "2026-05-29 16:52:59.441272",
+ "modified": "2026-06-22 12:23:19.196991",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Customer",
@@ -726,7 +734,7 @@
  ],
  "quick_entry": 1,
  "row_format": "Dynamic",
- "search_fields": "customer_group,territory, mobile_no,primary_address",
+ "search_fields": "customer_group,territory, mobile_no,primary_address, alias",
  "show_name_in_global_search": 1,
  "sort_field": "creation",
  "sort_order": "DESC",

--- a/erpnext/selling/doctype/customer/customer.py
+++ b/erpnext/selling/doctype/customer/customer.py
@@ -49,6 +49,7 @@ class Customer(TransactionBase):
 
 		account_manager: DF.Link | None
 		accounts: DF.Table[PartyAccount]
+		alias: DF.Data | None
 		companies: DF.Table[AllowedToTransactWith]
 		credit_limits: DF.Table[CustomerCreditLimit]
 		customer_details: DF.Text | None


### PR DESCRIPTION
Backport of #56284 to `version-16-hotfix`.

### Changes
- Add `alias` field to Customer and Supplier DocTypes.
- Include alias in Customer and Supplier search fields.
- Update generated controller type annotations for the new field.

### Validation
- `python -m json.tool` on both touched DocType JSON files
- `python -m py_compile` on both touched controller files
- `git diff --check`
- Cherry-pick pre-commit hooks passed