### PR TITLE
test(coupon_code): cover coupon validation and usage-count edges

### DIFF
--- a/erpnext/accounts/doctype/coupon_code/test_coupon_code.py
+++ b/erpnext/accounts/doctype/coupon_code/test_coupon_code.py
@@ -173,3 +173,66 @@ class TestCouponCode(ERPNextTestSuite):
 
 		# Clean up
 		coupon.delete()
+
+	def test_validate_coupon_code_rejections(self):
+		from frappe.utils import add_days, nowdate
+
+		from erpnext.accounts.doctype.pricing_rule.utils import validate_coupon_code
+
+		pricing_rule = frappe.db.get_value("Pricing Rule", {"title": "_Test Pricing Rule for _Test Item"})
+
+		def make_coupon(name, **kwargs):
+			frappe.delete_doc_if_exists("Coupon Code", name)
+			return frappe.get_doc(
+				{
+					"doctype": "Coupon Code",
+					"coupon_name": name,
+					"coupon_code": name,
+					"coupon_type": "Promotional",
+					"pricing_rule": pricing_rule,
+					**kwargs,
+				}
+			).insert(ignore_permissions=True)
+
+		with self.subTest("validity not yet started"):
+			make_coupon("_Test Coupon Future", valid_from=add_days(nowdate(), 5))
+			self.assertRaises(frappe.ValidationError, validate_coupon_code, "_Test Coupon Future")
+
+		with self.subTest("validity expired"):
+			make_coupon("_Test Coupon Expired", valid_upto=add_days(nowdate(), -5))
+			self.assertRaises(frappe.ValidationError, validate_coupon_code, "_Test Coupon Expired")
+
+		with self.subTest("maximum use exhausted"):
+			make_coupon("_Test Coupon Exhausted", maximum_use=2, used=2)
+			self.assertRaises(frappe.ValidationError, validate_coupon_code, "_Test Coupon Exhausted")
+
+		with self.subTest("valid coupon passes"):
+			make_coupon("_Test Coupon Valid", maximum_use=5, used=1, valid_upto=add_days(nowdate(), 5))
+			validate_coupon_code("_Test Coupon Valid")  # no raise
+
+	def test_update_coupon_code_count_cancel_and_exhaust(self):
+		from erpnext.accounts.doctype.pricing_rule.utils import update_coupon_code_count
+
+		pricing_rule = frappe.db.get_value("Pricing Rule", {"title": "_Test Pricing Rule for _Test Item"})
+		frappe.delete_doc_if_exists("Coupon Code", "_Test Coupon Count")
+		frappe.get_doc(
+			{
+				"doctype": "Coupon Code",
+				"coupon_name": "_Test Coupon Count",
+				"coupon_code": "_Test Coupon Count",
+				"coupon_type": "Promotional",
+				"pricing_rule": pricing_rule,
+				"maximum_use": 2,
+				"used": 1,
+			}
+		).insert(ignore_permissions=True)
+
+		# cancelling a transaction releases one use
+		update_coupon_code_count("_Test Coupon Count", "cancelled")
+		self.assertEqual(frappe.db.get_value("Coupon Code", "_Test Coupon Count", "used"), 0)
+
+		# using up to the maximum is allowed, beyond it is rejected
+		update_coupon_code_count("_Test Coupon Count", "used")
+		update_coupon_code_count("_Test Coupon Count", "used")
+		self.assertEqual(frappe.db.get_value("Coupon Code", "_Test Coupon Count", "used"), 2)
+		self.assertRaises(frappe.ValidationError, update_coupon_code_count, "_Test Coupon Count", "used")

--- a/erpnext/accounts/doctype/pricing_rule/utils.py
+++ b/erpnext/accounts/doctype/pricing_rule/utils.py
@@ -756,21 +756,16 @@ def validate_coupon_code(coupon_name):
 
 def update_coupon_code_count(coupon_name, transaction_type):
 	coupon = frappe.get_doc("Coupon Code", coupon_name)
-	if coupon:
-		if transaction_type == "used":
-			if not coupon.maximum_use:
-				coupon.used = coupon.used + 1
-				coupon.save(ignore_permissions=True)
-			elif coupon.used < coupon.maximum_use:
-				coupon.used = coupon.used + 1
-				coupon.save(ignore_permissions=True)
-			else:
-				frappe.throw(
-					_("{0} Coupon used are {1}. Allowed quantity is exhausted").format(
-						coupon.coupon_code, coupon.used
-					)
+	if transaction_type == "used":
+		if coupon.maximum_use and coupon.used >= coupon.maximum_use:
+			frappe.throw(
+				_("{0} Coupon used are {1}. Allowed quantity is exhausted").format(
+					coupon.coupon_code, coupon.used
 				)
-		elif transaction_type == "cancelled":
-			if coupon.used > 0:
-				coupon.used = coupon.used - 1
-				coupon.save(ignore_permissions=True)
+			)
+		coupon.used = coupon.used + 1
+		coupon.save(ignore_permissions=True)
+	elif transaction_type == "cancelled":
+		if coupon.used > 0:
+			coupon.used = coupon.used - 1
+			coupon.save(ignore_permissions=True)


### PR DESCRIPTION
Adds tests for coupon-code validation, which previously only covered the happy path.

Covers a coupon being rejected when its validity hasn't started, has expired, or its maximum use is exhausted; and the usage count releasing a use when a transaction is cancelled and rejecting use beyond the maximum.

**Manual QA:** Create a Coupon Code with a future "valid from" date (or an expired "valid upto", or a maximum use already reached) and confirm using it on a Sales Order is blocked; place and then cancel an order using a coupon and confirm its used count goes back down.
