### PR TITLE
test(blanket_order): cover over-ordering aggregated across rows

### DIFF
--- a/erpnext/manufacturing/doctype/blanket_order/test_blanket_order.py
+++ b/erpnext/manufacturing/doctype/blanket_order/test_blanket_order.py
@@ -91,6 +91,29 @@ class TestBlanketOrder(ERPNextTestSuite):
 		frappe.db.set_single_value("Buying Settings", "blanket_order_allowance", 10)
 		po.submit()
 
+	def test_blanket_order_over_order_aggregated_across_rows(self):
+		# the over-order check should sum the same item across multiple order rows
+		frappe.db.set_single_value("Selling Settings", "blanket_order_allowance", 0)
+		bo = make_blanket_order(blanket_order_type="Selling", quantity=100)
+
+		frappe.flags.args.doctype = "Sales Order"
+		so = make_order(bo.name)
+		so.currency = get_company_currency(so.company)
+		so.delivery_date = today()
+		so.items[0].qty = 60
+		so.append(
+			"items",
+			{
+				"item_code": so.items[0].item_code,
+				"qty": 50,  # 60 + 50 = 110 > 100 blanket qty
+				"rate": so.items[0].rate,
+				"delivery_date": today(),
+				"against_blanket_order": 1,
+				"blanket_order": bo.name,
+			},
+		)
+		self.assertRaises(frappe.ValidationError, so.submit)
+
 	def test_party_item_code(self):
 		item_doc = make_item("_Test Item 1 for Blanket Order")
 		item_code = item_doc.name


### PR DESCRIPTION
Adds a test for the blanket-order over-ordering check when the same item is split across multiple order rows.

The check sums the item's quantity across all rows against a blanket order, so two Sales Order rows of the same item that together exceed the blanket quantity should be blocked — this covers that aggregation, which wasn't tested before.

**Manual QA:** Create a blanket order for an item (qty 100), make a Sales Order against it with the same item in two rows (e.g. 60 + 50), and confirm submitting is blocked for exceeding the blanket quantity.
