### PR TITLE
fix: link portal address rows to web form

### DIFF
--- a/erpnext/templates/includes/address_row.html
+++ b/erpnext/templates/includes/address_row.html
@@ -1,5 +1,5 @@
 <div class="web-list-item mb-3">
-    <a href="/addresses?name={{ doc.name | urlencode }}" class="no-underline text-reset">
+    <a href="/address/{{ doc.name | urlencode }}" class="no-underline text-reset">
 	    <div class="row">
 	        <div class="col-3">
 	                 <span class="indicator {{ "red" if doc.address_type=="Office" else "green" if doc.address_type=="Billing" else "blue" if doc.address_type=="Shipping" else "gray" }}">{{ doc.address_title }}</span>
@@ -7,7 +7,7 @@
 			<div class="col-2"> {{ _(doc.address_type) }} </div>
 			<div class="col-2"> {{ doc.city }} </div>
 			<div class="col-5 text-right small text-muted">
-	            {{ frappe.get_doc(doc).get_display() }}
+	            {{ doc.address_display or "" }}
 	        </div>
 	    </div>
     </a>


### PR DESCRIPTION
## What changed
- Update the Address portal row template to link saved rows to the Address web form route.
- Render a precomputed `address_display` value instead of calling `frappe.get_doc(...).get_display()` from restricted Jinja.

## Why
The `/addresses` portal list could crash when rendering rows under restricted template rendering. Clicking a row also stayed on the list route because it linked to `/addresses?name=...` instead of the Address web form route.

Closes #56198

## Dependency
Depends on frappe/frappe#40180, which provides `address_display` in the Address portal list context and preserves the web list page context.

## Validation
- `python -m py_compile frappe/contacts/doctype/address/address.py frappe/contacts/doctype/address/test_address.py`
- `python /Users/mihirkandoi/bench-cli/bench --site testing run-tests --doctype Address`
- `git diff --check`