### PR TITLE
Fix Exchange Gain/Loss Account not staying cleared

### DIFF
--- a/erpnext/setup/doctype/company/company.py
+++ b/erpnext/setup/doctype/company/company.py
@@ -649,7 +649,7 @@ class Company(NestedSet):
 			for default_account in default_accounts:
 				self._set_default_account(default_account, default_accounts.get(default_account))
 
-		if not self.default_income_account:
+		if self.update_default_account and not self.default_income_account:
 			income_account = frappe.db.get_all(
 				"Account",
 				filters={"company": self.name, "is_group": 0},
@@ -667,24 +667,24 @@ class Company(NestedSet):
 
 			self.db_set("default_income_account", income_account)
 
-		if not self.default_payable_account:
+		if self.update_default_account and not self.default_payable_account:
 			self.db_set("default_payable_account", self.default_payable_account)
 
-		if not self.write_off_account:
+		if self.update_default_account and not self.write_off_account:
 			write_off_acct = frappe.db.get_value(
 				"Account", {"account_name": _("Write Off"), "company": self.name, "is_group": 0}
 			)
 
 			self.db_set("write_off_account", write_off_acct)
 
-		if not self.exchange_gain_loss_account:
+		if self.update_default_account and not self.exchange_gain_loss_account:
 			exchange_gain_loss_acct = frappe.db.get_value(
 				"Account", {"account_name": _("Exchange Gain/Loss"), "company": self.name, "is_group": 0}
 			)
 
 			self.db_set("exchange_gain_loss_account", exchange_gain_loss_acct)
 
-		if not self.disposal_account:
+		if self.update_default_account and not self.disposal_account:
 			disposal_acct = frappe.db.get_value(
 				"Account",
 				{"account_name": _("Gain/Loss on Asset Disposal"), "company": self.name, "is_group": 0},

--- a/erpnext/setup/doctype/company/company.py
+++ b/erpnext/setup/doctype/company/company.py
@@ -667,9 +667,6 @@ class Company(NestedSet):
 
 			self.db_set("default_income_account", income_account)
 
-		if self.update_default_account and not self.default_payable_account:
-			self.db_set("default_payable_account", self.default_payable_account)
-
 		if self.update_default_account and not self.write_off_account:
 			write_off_acct = frappe.db.get_value(
 				"Account", {"account_name": _("Write Off"), "company": self.name, "is_group": 0}

--- a/erpnext/setup/doctype/company/test_company.py
+++ b/erpnext/setup/doctype/company/test_company.py
@@ -234,6 +234,22 @@ class TestCompany(ERPNextTestSuite):
 		after = get_all_transactions_annual_history(company).get(key, 0)
 		self.assertEqual(after - before, 2)
 
+	def test_cleared_default_account_is_not_refilled_on_save(self):
+		company = frappe.get_doc("Company", "_Test Company")
+		original_account = company.exchange_gain_loss_account
+		self.assertTrue(original_account)
+
+		company.exchange_gain_loss_account = ""
+		company.save()
+		self.addCleanup(
+			lambda: frappe.db.set_value(
+				"Company", "_Test Company", "exchange_gain_loss_account", original_account
+			)
+		)
+
+		company.reload()
+		self.assertFalse(company.exchange_gain_loss_account)
+
 	def test_demo_data(self):
 		from erpnext.setup.demo import clear_demo_data, setup_demo_data
 

--- a/erpnext/stock/doctype/item/item.json
+++ b/erpnext/stock/doctype/item/item.json
@@ -1090,7 +1090,7 @@
  "image_field": "image",
  "links": [],
  "make_attachments_public": 1,
- "modified": "2026-05-27 10:18:46.862670",
+ "modified": "2026-07-05 23:24:45.734144",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Item",

--- a/erpnext/stock/doctype/item/item.json
+++ b/erpnext/stock/doctype/item/item.json
@@ -1090,7 +1090,7 @@
  "image_field": "image",
  "links": [],
  "make_attachments_public": 1,
- "modified": "2026-07-05 23:24:45.734144",
+ "modified": "2026-05-27 10:18:46.862670",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Item",


### PR DESCRIPTION
This PR fixes a bug where some default accounts on the Company
document could not be cleared. If you removed the Exchange Gain/Loss
Account (or Write Off Account, Default Payable Account, or
Disposal Account) and saved, the system would fill it back in
on its own.
Issue: https://support.frappe.io/helpdesk/tickets/71270
Before:

https://github.com/user-attachments/assets/99d1b7ae-1af5-43fc-b27a-b566a83ba46a



Now these accounts only get filled in automatically when a new
company is created. After that, if you clear the field and save,
it will stay empty.

After:

https://github.com/user-attachments/assets/c605779f-fac6-4852-8139-a4c3db8b2056



