### PR TITLE
fix(stock): stock ageing crashes with unbuffered cursor error on bundle/batch rows

### DIFF
--- a/erpnext/stock/report/stock_ageing/stock_ageing.py
+++ b/erpnext/stock/report/stock_ageing/stock_ageing.py
@@ -291,6 +291,7 @@ class FIFOSlots:
 		self.batchwise_valuation_by_batch = {}
 		self.filters = filters
 		self.sle = sle
+		self.streaming_mode = sle is None
 
 	def generate(self) -> dict:
 		"""
@@ -395,12 +396,12 @@ class FIFOSlots:
 
 		if row.serial_and_batch_bundle:
 			if row.has_serial_no:
-				if bundle_wise_serial_nos:
+				if self.streaming_mode:
 					serial_nos = bundle_wise_serial_nos.get(row.serial_and_batch_bundle) or []
 				else:
 					serial_nos = sorted(get_serial_nos_from_bundle(row.serial_and_batch_bundle)) or []
 			elif row.has_batch_no:
-				if bundle_wise_batch_nos:
+				if self.streaming_mode:
 					batch_nos = bundle_wise_batch_nos.get(row.serial_and_batch_bundle) or []
 				else:
 					batch_nos = (
@@ -440,14 +441,14 @@ class FIFOSlots:
 		return [sn.upper() for sn in serial_nos]
 
 	def _get_batchwise_valuation(self, batch_no: str):
-		if batch_no not in self.batchwise_valuation_by_batch:
+		if not self.streaming_mode and batch_no not in self.batchwise_valuation_by_batch:
 			# only reachable when stock ledger entries are passed in directly;
 			# the streaming path prefetches all flags before iteration
 			self.batchwise_valuation_by_batch[batch_no] = frappe.db.get_value(
 				"Batch", batch_no, "use_batchwise_valuation"
 			)
 
-		return self.batchwise_valuation_by_batch[batch_no]
+		return self.batchwise_valuation_by_batch.get(batch_no)
 
 	def _prefetch_batchwise_valuations(self) -> None:
 		sle = frappe.qb.DocType("Stock Ledger Entry")


### PR DESCRIPTION
**Issue:**
The Stock Ageing report streams SLEs through a server-side unbuffered cursor, which forbids any other query mid-iteration. The in-loop bundle/batch fallbacks were gated on dict truthiness (`if bundle_wise_serial_nos:`), so when a prefetch dict came back empty but the stream still had a bundle/batch row, the fallback fired a DB query and invalidated the cursor — raising `'NoneType' object has no attribute '_read_rowdata_packet_unbuffered'`.

**Error Traceback:**
```Traceback with variables (most recent call last):
  File "apps/frappe/frappe/core/doctype/prepared_report/prepared_report.py", line 124, in generate_report
    result = generate_report_result(report=report, filters=instance.filters, user=instance.owner)
      prepared_report = 'bi3q5ehimh'
      instance = <PreparedReport: bi3q5ehimh>
      report = <Report: Stock Ageing>
  File "apps/frappe/frappe/__init__.py", line 899, in wrapper_fn
    retval = fn(*args, **get_newargs(fn, kwargs))
      args = ()
      kwargs = {'report': <Report: Stock Ageing>, 'filters': '{"company":"Methods Automotive Pvt. Ltd","range":"30, 60, 90","to_date":"2026-06-22","warehouse":"Kumbalgodu - MAPL"}', 'user': 'Administrator'}
      switched_connection = False
      fn = <function generate_report_result at 0xffffa64282c0>
  File "apps/frappe/frappe/desk/query_report.py", line 85, in generate_report_result
    res = get_report_result(report, filters) or []
      report = <Report: Stock Ageing>
      filters = {'company': 'Methods Automotive Pvt. Ltd', 'range': '30, 60, 90', 'to_date': '2026-06-22', 'warehouse': 'Kumbalgodu - MAPL'}
      user = 'Administrator'
      custom_columns = None
      is_tree = False
      parent_field = None
  File "apps/frappe/frappe/desk/query_report.py", line 66, in get_report_result
    res = report.execute_script_report(filters)
      report = <Report: Stock Ageing>
      filters = {'company': 'Methods Automotive Pvt. Ltd', 'range': '30, 60, 90', 'to_date': '2026-06-22', 'warehouse': 'Kumbalgodu - MAPL'}
      res = None
  File "apps/frappe/frappe/core/doctype/report/report.py", line 179, in execute_script_report
    res = self.execute_module(filters)
      self = <Report: Stock Ageing>
      filters = {'company': 'Methods Automotive Pvt. Ltd', 'range': '30, 60, 90', 'to_date': '2026-06-22', 'warehouse': 'Kumbalgodu - MAPL'}
      threshold = 15
      res = []
      start_time = datetime.datetime(2026, 6, 22, 9, 3, 46, 700496)
      prepared_report_watcher = None
  File "apps/frappe/frappe/core/doctype/report/report.py", line 195, in execute_module
    return frappe.get_attr(method_name)(frappe._dict(filters))
      self = <Report: Stock Ageing>
      filters = {'company': 'Methods Automotive Pvt. Ltd', 'range': '30, 60, 90', 'to_date': '2026-06-22', 'warehouse': 'Kumbalgodu - MAPL'}
      module = 'Stock'
      method_name = 'erpnext.stock.report.stock_ageing.stock_ageing.execute'
  File "apps/erpnext/erpnext/stock/report/stock_ageing/stock_ageing.py", line 40, in execute
    item_details = FIFOSlots(filters).generate()
      filters = {'company': 'Methods Automotive Pvt. Ltd', 'range': '30, 60, 90', 'to_date': '2026-06-22', 'warehouse': 'Kumbalgodu - MAPL', 'ranges': ['30', '60', '90']}
      to_date = '2026-06-22'
      columns = [{'label': 'Item Code', 'fieldname': 'item_code', 'fieldtype': 'Link', 'options': 'Item', 'width': 100}, {'label': 'Item Name', 'fieldname': 'item_name', 'fieldtype': 'Data', 'width': 100}, {'label': 'Description', 'fieldname': 'description', 'fieldtype': 'Data', 'width': 200}, {'label': 'Item Group', 'fieldname': 'item_group', 'fieldtype': 'Link', 'options': 'Item Group', 'width': 100}, {'label': 'Brand', 'fieldname': 'brand', 'fieldtype': 'Link', 'options': 'Brand', 'width': 100}, {'label': 'Available Qty', 'fieldname': 'qty', 'fieldtype': 'Float', 'width': 100}, {'label': 'Average Age', 'fieldname': 'average_age', 'fieldtype': 'Float', 'width': 100}, {'label': 'Age (0 - 30)', 'fieldname': 'range1', 'fieldtype': 'Float', 'width': 140}, {'label': 'Value (0 - 30)', 'fieldname': 'range1value', 'fieldtype': 'Float', 'width': 140}, {'label': 'Age (31 - 60)', 'fieldname': 'range2', 'fieldtype': 'Float', 'width': 140}, {'label': 'Value (31 - 60)', 'fieldname': 'range2value', 'fieldtype': 'F...
  File "apps/erpnext/erpnext/stock/report/stock_ageing/stock_ageing.py", line 313, in generate
    for row in stock_ledger_entries:
      self = <erpnext.stock.report.stock_ageing.stock_ageing.FIFOSlots object at 0xffffa55bae90>
      stock_ledger_entries = <generator object Database._return_as_iterator at 0xffffa5120af0>
      bundle_wise_serial_nos = {}
      bundle_wise_batch_nos = {}
      row = {'name': 'U1P-17152', 'item_name': 'Little Trees Air Freshner - Pure Steel', 'item_group': 'Little Trees', 'brand': 'Little Trees', 'description': 'Little Trees Air Freshner - Pure Steel', 'stock_uom': 'Nos', 'has_batch_no': 0, 'has_serial_no': 0, 'actual_qty': -36.0, 'stock_value_difference': -1143.72, 'valuation_rate': 31.77, 'posting_date': datetime.date(2018, 8, 8), 'voucher_type': 'Delivery Note', 'voucher_no': 'DN-00134', 'voucher_detail_no': '636718923a', 'serial_no': '', 'batch_no': '', 'qty_after_transaction': 1552.0, 'serial_and_batch_bundle': None, 'warehouse': 'Kumbalgodu - MAPL'}
  File "apps/frappe/frappe/database/database.py", line 302, in _return_as_iterator
    while result := self._transform_result(self._cursor.fetchmany(SQL_ITERATOR_BATCH_SIZE)):
      self = <frappe.database.mariadb.database.MariaDBDatabase object at 0xffffa6e12710>
      pluck = False
      as_dict = True
      as_list = 0
      update = None
      result = [('990J0M999H2-340', 'Xtreme Microfiber Cloth Interior (Blue)', 'ECSTAR', None, 'Xtreme Microfiber Cloth Interior (Blue)<br>', 'Nos', 0, 0, 20047.0, 552294.85, 27.55, datetime.date(2018, 3, 31), 'Stock Entry', 'STE-01318', '7baba7b182', None, '', 20047.0, None, 'Kumbalgodu - MAPL'), ('419 200', 'Sonax Car Care Cloth', 'Sonax DIY', None, 'Sonax Car Care Cloth', 'Nos', 0, 0, 0.0, 16542.96, 393.88, datetime.date(2018, 7, 19), 'Stock Reconciliation', 'SR/00012', None, None, None, 42.0, None, 'Kumbalgodu - MAPL'), ('450 800', 'Sonax Microfiber Drying Cloth', 'Sonax DIY', 'Sonax', '<div>Sonax Microfiber Drying Cloth</div>', 'Nos', 0, 0, 0.0, 571.94, 571.94, datetime.date(2018, 7, 19), 'Stock Reconciliation', 'SR/00012', None, None, None, 1.0, None, 'Kumbalgodu - MAPL'), ('422 200', 'Sonax Polishing Cloth', 'Sonax DIY', 'Sonax', 'Sonax Polishing Cloth', 'Nos', 0, 0, 0.0, 51817.36, 108.86, datetime.date(2018, 7, 19), 'Stock Reconciliation', 'SR/00012', None, None, None, 476.0, None, 'Kumbalgod...
      row = {'name': 'U1P-17152', 'item_name': 'Little Trees Air Freshner - Pure Steel', 'item_group': 'Little Trees', 'brand': 'Little Trees', 'description': 'Little Trees Air Freshner - Pure Steel', 'stock_uom': 'Nos', 'has_batch_no': 0, 'has_serial_no': 0, 'actual_qty': -36.0, 'stock_value_difference': -1143.72, 'valuation_rate': 31.77, 'posting_date': datetime.date(2018, 8, 8), 'voucher_type': 'Delivery Note', 'voucher_no': 'DN-00134', 'voucher_detail_no': '636718923a', 'serial_no': '', 'batch_no': '', 'qty_after_transaction': 1552.0, 'serial_and_batch_bundle': None, 'warehouse': 'Kumbalgodu - MAPL'}
      keys = ********
  File "env/lib/python3.11/site-packages/pymysql/cursors.py", line 492, in fetchmany
    row = self.read_next()
      self = <pymysql.cursors.SSCursor object at 0xffffa52818d0>
      size = 1000
      rows = []
      i = 0
  File "env/lib/python3.11/site-packages/pymysql/cursors.py", line 456, in read_next
    return self._conv_row(self._result._read_rowdata_packet_unbuffered())
      self = <pymysql.cursors.SSCursor object at 0xffffa52818d0>
builtins.AttributeError: 'NoneType' object has no attribute '_read_rowdata_packet_unbuffered'
```

**Ref:** [#71967](https://support.frappe.io/helpdesk/tickets/71967)

**Backport Needed for v15 & v16**