### PR TITLE
feat: company-wise master filtering for Customer, Supplier, and Item

### DIFF
--- a/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
+++ b/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
@@ -111,6 +111,8 @@
   "create_pr_in_draft_status",
   "budget_section",
   "use_legacy_budget_controller",
+  "company_wise_masters_section",
+  "enable_company_wise_masters",
   "document_naming_tab",
   "transaction_naming_html"
  ],
@@ -734,6 +736,17 @@
    "fieldname": "preview_mode",
    "fieldtype": "Check",
    "label": "Preview mode"
+  },
+  {
+   "fieldname": "company_wise_masters_section",
+   "fieldtype": "Section Break",
+   "label": "Company-wise Masters"
+  },
+  {
+   "fieldname": "enable_company_wise_masters",
+   "fieldtype": "Check",
+   "label": "Enable Company-wise Master Filtering",
+   "description": "When enabled, Supplier, Customer, and Item records can be restricted to specific companies via their <b>Allowed Companies</b> table. Transactions will only show masters configured for the selected company."
   },
   {
    "fieldname": "document_naming_tab",

--- a/erpnext/accounts/doctype/accounts_settings/accounts_settings.py
+++ b/erpnext/accounts/doctype/accounts_settings/accounts_settings.py
@@ -73,6 +73,7 @@ class AccountsSettings(Document):
 		determine_address_tax_category_from: DF.Literal["Billing Address", "Shipping Address"]
 		enable_accounting_dimensions: DF.Check
 		enable_common_party_accounting: DF.Check
+		enable_company_wise_masters: DF.Check
 		enable_discounts_and_margin: DF.Check
 		enable_fuzzy_matching: DF.Check
 		enable_immutable_ledger: DF.Check

--- a/erpnext/accounts/doctype/journal_entry/journal_entry.js
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.js
@@ -338,6 +338,14 @@ erpnext.accounts.JournalEntry = class JournalEntry extends frappe.ui.form.Contro
 			};
 		});
 
+		if (frappe.sys_defaults.enable_company_wise_masters) {
+			me.frm.set_query("party", "accounts", function (doc, cdt, cdn) {
+				const row = locals[cdt][cdn];
+				if (row.party_type === "Customer") return erpnext.queries.customer(me.frm.doc);
+				if (row.party_type === "Supplier") return erpnext.queries.supplier(me.frm.doc);
+			});
+		}
+
 		me.frm.set_query("reference_name", "accounts", function (doc, cdt, cdn) {
 			var jvd = frappe.get_doc(cdt, cdn);
 

--- a/erpnext/buying/doctype/supplier/supplier.json
+++ b/erpnext/buying/doctype/supplier/supplier.json
@@ -53,6 +53,8 @@
   "tax_withholding_category",
   "tax_withholding_group",
   "settings_tab",
+  "company_restrictions_section",
+  "allowed_companies",
   "invoice_settings_section",
   "is_transporter",
   "allow_purchase_invoice_creation_without_purchase_order",
@@ -423,6 +425,18 @@
    "fieldname": "settings_tab",
    "fieldtype": "Tab Break",
    "label": "Settings"
+  },
+  {
+   "fieldname": "company_restrictions_section",
+   "fieldtype": "Section Break",
+   "label": "Company Restrictions",
+   "description": "If set, this Supplier is only available for transactions in the listed companies. Leave empty for no restriction."
+  },
+  {
+   "fieldname": "allowed_companies",
+   "fieldtype": "Table",
+   "label": "Allowed Companies",
+   "options": "Allowed To Transact With"
   },
   {
    "fieldname": "contact_and_address_tab",

--- a/erpnext/buying/doctype/supplier/supplier.json
+++ b/erpnext/buying/doctype/supplier/supplier.json
@@ -430,13 +430,15 @@
    "fieldname": "company_restrictions_section",
    "fieldtype": "Section Break",
    "label": "Company Restrictions",
-   "description": "If set, this Supplier is only available for transactions in the listed companies. Leave empty for no restriction."
+   "description": "If set, this Supplier is only available for transactions in the listed companies. Leave empty for no restriction.",
+   "depends_on": "eval:frappe.sys_defaults.enable_company_wise_masters"
   },
   {
    "fieldname": "allowed_companies",
    "fieldtype": "Table",
    "label": "Allowed Companies",
-   "options": "Allowed To Transact With"
+   "options": "Allowed To Transact With",
+   "depends_on": "eval:frappe.sys_defaults.enable_company_wise_masters"
   },
   {
    "fieldname": "contact_and_address_tab",

--- a/erpnext/buying/doctype/supplier/supplier.py
+++ b/erpnext/buying/doctype/supplier/supplier.py
@@ -41,6 +41,7 @@ class Supplier(TransactionBase):
 		accounts: DF.Table[PartyAccount]
 		allow_purchase_invoice_creation_without_purchase_order: DF.Check
 		allow_purchase_invoice_creation_without_purchase_receipt: DF.Check
+		allowed_companies: DF.Table[AllowedToTransactWith]
 		companies: DF.Table[AllowedToTransactWith]
 		country: DF.Link | None
 		customer_numbers: DF.Table[CustomerNumberAtSupplier]

--- a/erpnext/controllers/party_permissions.py
+++ b/erpnext/controllers/party_permissions.py
@@ -18,6 +18,11 @@ Enforcement happens at three layers:
 import frappe
 
 
+def is_enabled() -> bool:
+    """Return True when company-wise master filtering is turned on in Accounts Settings."""
+    return bool(frappe.db.get_single_value("Accounts Settings", "enable_company_wise_masters"))
+
+
 def _get_user_companies(user: str) -> list[str]:
     """Return companies the user is restricted to via User Permissions on Company."""
     return frappe.get_all(
@@ -32,9 +37,13 @@ def _company_filter_sql(doctype: str, user: str) -> str:
     Return an SQL fragment that filters `tab{doctype}` rows by allowed_companies.
 
     Returns "" (no restriction) when:
+    - the feature is disabled in Accounts Settings, or
     - the user is System Manager, or
     - the user has no User Permission rows for Company (not company-restricted).
     """
+    if not is_enabled():
+        return ""
+
     if "System Manager" in frappe.get_roles(user):
         return ""
 
@@ -79,6 +88,9 @@ def item_query_conditions(user=None):
 
 
 def party_has_permission(doc, user=None, permission_type=None):
+    if not is_enabled():
+        return True
+
     user = user or frappe.session.user
     if "System Manager" in frappe.get_roles(user):
         return True
@@ -130,6 +142,9 @@ _SALES_DOCTYPES = frozenset(
 
 def validate_party_company(doc, method=None):
     """Throw if the supplier/customer/items are not configured for doc.company."""
+    if not is_enabled():
+        return
+
     if doc.doctype in _PURCHASE_DOCTYPES:
         supplier = doc.get("supplier")
         if supplier and not _allowed_for_company("Supplier", supplier, doc.company):

--- a/erpnext/controllers/party_permissions.py
+++ b/erpnext/controllers/party_permissions.py
@@ -1,0 +1,161 @@
+# Copyright (c) 2025, Frappe Technologies Pvt. Ltd. and Contributors
+# License: GNU General Public License v3. See license.txt
+
+"""
+Company-wise master filtering for Supplier, Customer, and Item.
+
+When a master record has rows in its `allowed_companies` child table, it is
+only visible/usable for transactions belonging to those companies.  An empty
+`allowed_companies` table means the record is global — accessible from all
+companies.
+
+Enforcement happens at three layers:
+  1. List view / link search  — permission_query_conditions hook
+  2. Direct form / API access — has_permission hook
+  3. Transaction save         — doc_events validate hook
+"""
+
+import frappe
+
+
+def _get_user_companies(user: str) -> list[str]:
+    """Return companies the user is restricted to via User Permissions on Company."""
+    return frappe.get_all(
+        "User Permission",
+        filters={"user": user, "allow": "Company"},
+        pluck="for_value",
+    )
+
+
+def _company_filter_sql(doctype: str, user: str) -> str:
+    """
+    Return an SQL fragment that filters `tab{doctype}` rows by allowed_companies.
+
+    Returns "" (no restriction) when:
+    - the user is System Manager, or
+    - the user has no User Permission rows for Company (not company-restricted).
+    """
+    if "System Manager" in frappe.get_roles(user):
+        return ""
+
+    user_companies = _get_user_companies(user)
+    if not user_companies:
+        return ""
+
+    companies_sql = ", ".join(frappe.db.escape(c) for c in user_companies)
+    return f"""(
+        not exists (
+            select 1 from `tabAllowed To Transact With` attw
+            where attw.parent      = `tab{doctype}`.name
+              and attw.parenttype  = '{doctype}'
+              and attw.parentfield = 'allowed_companies'
+        )
+        or exists (
+            select 1 from `tabAllowed To Transact With` attw
+            where attw.parent      = `tab{doctype}`.name
+              and attw.parenttype  = '{doctype}'
+              and attw.parentfield = 'allowed_companies'
+              and attw.company in ({companies_sql})
+        )
+    )"""
+
+
+# ---------- permission_query_conditions hooks ----------
+
+
+def supplier_query_conditions(user=None):
+    return _company_filter_sql("Supplier", user or frappe.session.user)
+
+
+def customer_query_conditions(user=None):
+    return _company_filter_sql("Customer", user or frappe.session.user)
+
+
+def item_query_conditions(user=None):
+    return _company_filter_sql("Item", user or frappe.session.user)
+
+
+# ---------- has_permission hook ----------
+
+
+def party_has_permission(doc, user=None, permission_type=None):
+    user = user or frappe.session.user
+    if "System Manager" in frappe.get_roles(user):
+        return True
+
+    user_companies = _get_user_companies(user)
+    if not user_companies:
+        return True
+
+    doc_companies = [row.company for row in (doc.get("allowed_companies") or [])]
+    if not doc_companies:
+        return True  # global master — visible to all
+
+    return bool(set(doc_companies) & set(user_companies))
+
+
+# ---------- validate doc_event hook ----------
+
+
+def _allowed_for_company(master_dt: str, name: str, company: str) -> bool:
+    """Return True if the master has no company restriction or explicitly allows `company`."""
+    rows = frappe.get_all(
+        "Allowed To Transact With",
+        filters={"parent": name, "parenttype": master_dt, "parentfield": "allowed_companies"},
+        pluck="company",
+    )
+    return (not rows) or (company in rows)
+
+
+_PURCHASE_DOCTYPES = frozenset(
+    [
+        "Purchase Order",
+        "Purchase Invoice",
+        "Purchase Receipt",
+        "Subcontracting Order",
+        "Subcontracting Receipt",
+    ]
+)
+
+_SALES_DOCTYPES = frozenset(
+    [
+        "Sales Order",
+        "Sales Invoice",
+        "Delivery Note",
+        "Quotation",
+        "POS Invoice",
+    ]
+)
+
+
+def validate_party_company(doc, method=None):
+    """Throw if the supplier/customer/items are not configured for doc.company."""
+    if doc.doctype in _PURCHASE_DOCTYPES:
+        supplier = doc.get("supplier")
+        if supplier and not _allowed_for_company("Supplier", supplier, doc.company):
+            frappe.throw(
+                frappe._(
+                    "Supplier {0} is not configured for company {1}. "
+                    "Add {1} to the Supplier's <b>Allowed Companies</b> table or leave it empty for global access."
+                ).format(frappe.bold(supplier), frappe.bold(doc.company))
+            )
+
+    elif doc.doctype in _SALES_DOCTYPES:
+        customer = doc.get("customer")
+        if customer and not _allowed_for_company("Customer", customer, doc.company):
+            frappe.throw(
+                frappe._(
+                    "Customer {0} is not configured for company {1}. "
+                    "Add {1} to the Customer's <b>Allowed Companies</b> table or leave it empty for global access."
+                ).format(frappe.bold(customer), frappe.bold(doc.company))
+            )
+
+    for row in doc.get("items") or []:
+        item_code = row.get("item_code")
+        if item_code and not _allowed_for_company("Item", item_code, doc.company):
+            frappe.throw(
+                frappe._(
+                    "Item {0} (row {1}) is not configured for company {2}. "
+                    "Add {2} to the Item's <b>Allowed Companies</b> table or leave it empty for global access."
+                ).format(frappe.bold(item_code), row.idx, frappe.bold(doc.company))
+            )

--- a/erpnext/controllers/party_permissions.py
+++ b/erpnext/controllers/party_permissions.py
@@ -4,7 +4,7 @@
 """
 Company-wise master filtering for Supplier, Customer, and Item.
 
-When a master record has rows in its `allowed_companies` child table, it is
+When a master record has rows in its `allowed_companies` child table it is
 only visible/usable for transactions belonging to those companies.  An empty
 `allowed_companies` table means the record is global — accessible from all
 companies.
@@ -12,47 +12,55 @@ companies.
 Enforcement happens at three layers:
   1. List view / link search  — permission_query_conditions hook
   2. Direct form / API access — has_permission hook
-  3. Transaction save         — doc_events validate hook
+  3. Transaction save         — doc_events validate hook (validate_party_company)
+
+The set of covered DocTypes is driven by the `company_wise_masters_config` hook
+so any installed app can extend coverage without patching this file:
+
+    # in another app's hooks.py
+    company_wise_masters_config = [
+        {"doctype": "MyDocType", "customer_field": "customer", "items_table": "items"},
+    ]
 """
 
 import frappe
 
 
 def is_enabled() -> bool:
-    """Return True when company-wise master filtering is turned on in Accounts Settings."""
-    return bool(frappe.db.get_single_value("Accounts Settings", "enable_company_wise_masters"))
+	"""Return True when company-wise master filtering is turned on in Accounts Settings."""
+	return bool(frappe.db.get_single_value("Accounts Settings", "enable_company_wise_masters"))
 
 
 def _get_user_companies(user: str) -> list[str]:
-    """Return companies the user is restricted to via User Permissions on Company."""
-    return frappe.get_all(
-        "User Permission",
-        filters={"user": user, "allow": "Company"},
-        pluck="for_value",
-    )
+	"""Return companies the user is restricted to via User Permissions on Company."""
+	return frappe.get_all(
+		"User Permission",
+		filters={"user": user, "allow": "Company"},
+		pluck="for_value",
+	)
 
 
 def _company_filter_sql(doctype: str, user: str) -> str:
-    """
-    Return an SQL fragment that filters `tab{doctype}` rows by allowed_companies.
+	"""
+	Return an SQL fragment that filters `tab{doctype}` rows by allowed_companies.
 
-    Returns "" (no restriction) when:
-    - the feature is disabled in Accounts Settings, or
-    - the user is System Manager, or
-    - the user has no User Permission rows for Company (not company-restricted).
-    """
-    if not is_enabled():
-        return ""
+	Returns "" (no restriction) when:
+	- the feature is disabled in Accounts Settings, or
+	- the user is System Manager, or
+	- the user has no User Permission rows for Company (not company-restricted).
+	"""
+	if not is_enabled():
+		return ""
 
-    if "System Manager" in frappe.get_roles(user):
-        return ""
+	if "System Manager" in frappe.get_roles(user):
+		return ""
 
-    user_companies = _get_user_companies(user)
-    if not user_companies:
-        return ""
+	user_companies = _get_user_companies(user)
+	if not user_companies:
+		return ""
 
-    companies_sql = ", ".join(frappe.db.escape(c) for c in user_companies)
-    return f"""(
+	companies_sql = ", ".join(frappe.db.escape(c) for c in user_companies)
+	return f"""(
         not exists (
             select 1 from `tabAllowed To Transact With` attw
             where attw.parent      = `tab{doctype}`.name
@@ -73,104 +81,149 @@ def _company_filter_sql(doctype: str, user: str) -> str:
 
 
 def supplier_query_conditions(user=None):
-    return _company_filter_sql("Supplier", user or frappe.session.user)
+	return _company_filter_sql("Supplier", user or frappe.session.user)
 
 
 def customer_query_conditions(user=None):
-    return _company_filter_sql("Customer", user or frappe.session.user)
+	return _company_filter_sql("Customer", user or frappe.session.user)
 
 
 def item_query_conditions(user=None):
-    return _company_filter_sql("Item", user or frappe.session.user)
+	return _company_filter_sql("Item", user or frappe.session.user)
 
 
 # ---------- has_permission hook ----------
 
 
 def party_has_permission(doc, user=None, permission_type=None):
-    if not is_enabled():
-        return True
+	if not is_enabled():
+		return True
 
-    user = user or frappe.session.user
-    if "System Manager" in frappe.get_roles(user):
-        return True
+	user = user or frappe.session.user
+	if "System Manager" in frappe.get_roles(user):
+		return True
 
-    user_companies = _get_user_companies(user)
-    if not user_companies:
-        return True
+	user_companies = _get_user_companies(user)
+	if not user_companies:
+		return True
 
-    doc_companies = [row.company for row in (doc.get("allowed_companies") or [])]
-    if not doc_companies:
-        return True  # global master — visible to all
+	doc_companies = [row.company for row in (doc.get("allowed_companies") or [])]
+	if not doc_companies:
+		return True  # global master — visible to all
 
-    return bool(set(doc_companies) & set(user_companies))
+	return bool(set(doc_companies) & set(user_companies))
 
 
 # ---------- validate doc_event hook ----------
 
 
 def _allowed_for_company(master_dt: str, name: str, company: str) -> bool:
-    """Return True if the master has no company restriction or explicitly allows `company`."""
-    rows = frappe.get_all(
-        "Allowed To Transact With",
-        filters={"parent": name, "parenttype": master_dt, "parentfield": "allowed_companies"},
-        pluck="company",
-    )
-    return (not rows) or (company in rows)
+	"""Return True if the master has no company restriction or explicitly allows `company`."""
+	rows = frappe.get_all(
+		"Allowed To Transact With",
+		filters={"parent": name, "parenttype": master_dt, "parentfield": "allowed_companies"},
+		pluck="company",
+	)
+	return (not rows) or (company in rows)
 
 
-_PURCHASE_DOCTYPES = frozenset(
-    [
-        "Purchase Order",
-        "Purchase Invoice",
-        "Purchase Receipt",
-        "Subcontracting Order",
-        "Subcontracting Receipt",
-    ]
-)
+def _get_masters_config() -> dict:
+	"""
+	Return a {doctype: config_dict} map built from the company_wise_masters_config hook.
 
-_SALES_DOCTYPES = frozenset(
-    [
-        "Sales Order",
-        "Sales Invoice",
-        "Delivery Note",
-        "Quotation",
-        "POS Invoice",
-    ]
-)
+	frappe.get_hooks() is already cached per-process, so this is effectively O(1) after
+	the first call within a request.
+	"""
+	entries = frappe.get_hooks("company_wise_masters_config") or []
+	return {entry["doctype"]: entry for entry in entries}
 
 
 def validate_party_company(doc, method=None):
-    """Throw if the supplier/customer/items are not configured for doc.company."""
-    if not is_enabled():
-        return
+	"""
+	Throw if any master referenced by the document is not configured for doc.company.
 
-    if doc.doctype in _PURCHASE_DOCTYPES:
-        supplier = doc.get("supplier")
-        if supplier and not _allowed_for_company("Supplier", supplier, doc.company):
-            frappe.throw(
-                frappe._(
-                    "Supplier {0} is not configured for company {1}. "
-                    "Add {1} to the Supplier's <b>Allowed Companies</b> table or leave it empty for global access."
-                ).format(frappe.bold(supplier), frappe.bold(doc.company))
-            )
+	Reads the company_wise_masters_config hook so coverage extends automatically to
+	any DocType registered by an installed app.
+	"""
+	if not is_enabled():
+		return
 
-    elif doc.doctype in _SALES_DOCTYPES:
-        customer = doc.get("customer")
-        if customer and not _allowed_for_company("Customer", customer, doc.company):
-            frappe.throw(
-                frappe._(
-                    "Customer {0} is not configured for company {1}. "
-                    "Add {1} to the Customer's <b>Allowed Companies</b> table or leave it empty for global access."
-                ).format(frappe.bold(customer), frappe.bold(doc.company))
-            )
+	config = _get_masters_config().get(doc.doctype)
+	if not config:
+		return
 
-    for row in doc.get("items") or []:
-        item_code = row.get("item_code")
-        if item_code and not _allowed_for_company("Item", item_code, doc.company):
-            frappe.throw(
-                frappe._(
-                    "Item {0} (row {1}) is not configured for company {2}. "
-                    "Add {2} to the Item's <b>Allowed Companies</b> table or leave it empty for global access."
-                ).format(frappe.bold(item_code), row.idx, frappe.bold(doc.company))
-            )
+	company = doc.company
+
+	# --- supplier at document level ---
+	supplier_field = config.get("supplier_field")
+	if supplier_field:
+		supplier = doc.get(supplier_field)
+		if supplier and not _allowed_for_company("Supplier", supplier, company):
+			frappe.throw(
+				frappe._(
+					"Supplier {0} is not configured for company {1}. "
+					"Add {1} to the Supplier's <b>Allowed Companies</b> table or leave it empty for global access."
+				).format(frappe.bold(supplier), frappe.bold(company))
+			)
+
+	# --- customer at document level ---
+	customer_field = config.get("customer_field")
+	if customer_field:
+		customer = doc.get(customer_field)
+		if customer and not _allowed_for_company("Customer", customer, company):
+			frappe.throw(
+				frappe._(
+					"Customer {0} is not configured for company {1}. "
+					"Add {1} to the Customer's <b>Allowed Companies</b> table or leave it empty for global access."
+				).format(frappe.bold(customer), frappe.bold(company))
+			)
+
+	# --- dynamic party at document level (Payment Entry, Quotation) ---
+	party_field = config.get("party_field")
+	party_type_field = config.get("party_type_field")
+	party_rows_table = config.get("party_rows_table")
+
+	if party_field and not party_rows_table:
+		party_type = doc.get(party_type_field) if party_type_field else None
+		party = doc.get(party_field)
+		if party and party_type in ("Customer", "Supplier"):
+			if not _allowed_for_company(party_type, party, company):
+				frappe.throw(
+					frappe._(
+						"{0} {1} is not configured for company {2}. "
+						"Add {2} to the {0}'s <b>Allowed Companies</b> table or leave it empty for global access."
+					).format(frappe.bold(party_type), frappe.bold(party), frappe.bold(company))
+				)
+
+	# --- dynamic party inside child rows (Journal Entry accounts) ---
+	if party_field and party_rows_table:
+		for row in doc.get(party_rows_table) or []:
+			party_type = row.get(party_type_field) if party_type_field else None
+			party = row.get(party_field)
+			if party and party_type in ("Customer", "Supplier"):
+				if not _allowed_for_company(party_type, party, company):
+					frappe.throw(
+						frappe._(
+							"{0} {1} (row {2}) is not configured for company {3}. "
+							"Add {3} to the {0}'s <b>Allowed Companies</b> table or leave it empty for global access."
+						).format(
+							frappe.bold(party_type),
+							frappe.bold(party),
+							row.idx,
+							frappe.bold(company),
+						)
+					)
+
+	# --- item_code in items child table ---
+	items_table = config.get("items_table")
+	if items_table:
+		item_field = config.get("item_field", "item_code")
+		for row in doc.get(items_table) or []:
+			item_code = row.get(item_field)
+			if item_code and not _allowed_for_company("Item", item_code, company):
+				frappe.throw(
+					frappe._(
+						"Item {0} (row {1}) is not configured for company {2}. "
+						"Add {2} to the Item's <b>Allowed Companies</b> table or leave it empty for global access."
+					).format(frappe.bold(item_code), row.idx, frappe.bold(company))
+				)

--- a/erpnext/controllers/queries.py
+++ b/erpnext/controllers/queries.py
@@ -239,6 +239,11 @@ def item_query(
 			filters.pop("customer", None)
 			filters.pop("supplier", None)
 
+	# Extract company filter before building the query — Item has no company field
+	company = None
+	if filters and isinstance(filters, dict):
+		company = filters.pop("company", None)
+
 	item = DocType(doctype)
 
 	# Condition for the date
@@ -327,7 +332,120 @@ def item_query(
 		.offset(start)
 	)
 
+	if company:
+		attw = DocType("Allowed To Transact With")
+		allowed_sq = (
+			frappe.qb.from_(attw)
+			.select(attw.parent)
+			.where(attw.parenttype == "Item")
+			.where(attw.parentfield == "allowed_companies")
+			.where(attw.company == company)
+		)
+		restricted_sq = (
+			frappe.qb.from_(attw)
+			.select(attw.parent)
+			.where(attw.parenttype == "Item")
+			.where(attw.parentfield == "allowed_companies")
+		)
+		# global items (no rows) OR explicitly allowed for this company
+		query = query.where(item.name.notin(restricted_sq) | item.name.isin(allowed_sq))
+
 	return query.run(as_dict=as_dict)
+
+
+@frappe.whitelist()
+@frappe.validate_and_sanitize_search_inputs
+def supplier_query(
+	doctype: str,
+	txt: str,
+	searchfield: str,
+	start: int,
+	page_len: int,
+	filters: dict | str | None = None,
+):
+	"""Link field query for Supplier — filters by allowed_companies when company is provided."""
+	if isinstance(filters, str):
+		filters = json.loads(filters)
+
+	company = (filters or {}).pop("company", None)
+	supplier = DocType("Supplier")
+	search_str = f"%{txt}%"
+	mcond = get_match_cond("Supplier")
+
+	base = (
+		frappe.get_query("Supplier", filters=filters, ignore_permissions=False)
+		.select(supplier.name, supplier.supplier_name, supplier.supplier_group)
+		.where(supplier.disabled == 0)
+		.where(supplier[searchfield].like(search_str) | supplier.supplier_name.like(search_str))
+		.limit(page_len)
+		.offset(start)
+	)
+
+	if company:
+		attw = DocType("Allowed To Transact With")
+		allowed_sq = (
+			frappe.qb.from_(attw)
+			.select(attw.parent)
+			.where(attw.parenttype == "Supplier")
+			.where(attw.parentfield == "allowed_companies")
+			.where(attw.company == company)
+		)
+		restricted_sq = (
+			frappe.qb.from_(attw)
+			.select(attw.parent)
+			.where(attw.parenttype == "Supplier")
+			.where(attw.parentfield == "allowed_companies")
+		)
+		base = base.where(supplier.name.notin(restricted_sq) | supplier.name.isin(allowed_sq))
+
+	return base.run()
+
+
+@frappe.whitelist()
+@frappe.validate_and_sanitize_search_inputs
+def customer_query(
+	doctype: str,
+	txt: str,
+	searchfield: str,
+	start: int,
+	page_len: int,
+	filters: dict | str | None = None,
+):
+	"""Link field query for Customer — filters by allowed_companies when company is provided."""
+	if isinstance(filters, str):
+		filters = json.loads(filters)
+
+	company = (filters or {}).pop("company", None)
+	customer = DocType("Customer")
+	search_str = f"%{txt}%"
+
+	base = (
+		frappe.get_query("Customer", filters=filters, ignore_permissions=False)
+		.select(customer.name, customer.customer_name, customer.customer_group)
+		.where(customer.disabled == 0)
+		.where(customer[searchfield].like(search_str) | customer.customer_name.like(search_str))
+		.limit(page_len)
+		.offset(start)
+	)
+
+	if company:
+		attw = DocType("Allowed To Transact With")
+		allowed_sq = (
+			frappe.qb.from_(attw)
+			.select(attw.parent)
+			.where(attw.parenttype == "Customer")
+			.where(attw.parentfield == "allowed_companies")
+			.where(attw.company == company)
+		)
+		restricted_sq = (
+			frappe.qb.from_(attw)
+			.select(attw.parent)
+			.where(attw.parenttype == "Customer")
+			.where(attw.parentfield == "allowed_companies")
+		)
+		base = base.where(customer.name.notin(restricted_sq) | customer.name.isin(allowed_sq))
+
+	return base.run()
 
 
 @frappe.whitelist()

--- a/erpnext/controllers/queries.py
+++ b/erpnext/controllers/queries.py
@@ -239,10 +239,16 @@ def item_query(
 			filters.pop("customer", None)
 			filters.pop("supplier", None)
 
-	# Extract company filter before building the query — Item has no company field
+	# Extract company filter before building the query — Item has no company field.
+	# Always pop so the unknown key doesn't reach frappe.get_query; only use the
+	# value for sub-query filtering when the feature is enabled.
 	company = None
 	if filters and isinstance(filters, dict):
-		company = filters.pop("company", None)
+		from erpnext.controllers.party_permissions import is_enabled
+
+		_company = filters.pop("company", None)
+		if is_enabled():
+			company = _company
 
 	item = DocType(doctype)
 
@@ -364,10 +370,12 @@ def supplier_query(
 	filters: dict | str | None = None,
 ):
 	"""Link field query for Supplier — filters by allowed_companies when company is provided."""
+	from erpnext.controllers.party_permissions import is_enabled
+
 	if isinstance(filters, str):
 		filters = json.loads(filters)
 
-	company = (filters or {}).pop("company", None)
+	company = (filters or {}).pop("company", None) if is_enabled() else None
 	supplier = DocType("Supplier")
 	search_str = f"%{txt}%"
 	mcond = get_match_cond("Supplier")
@@ -412,10 +420,12 @@ def customer_query(
 	filters: dict | str | None = None,
 ):
 	"""Link field query for Customer — filters by allowed_companies when company is provided."""
+	from erpnext.controllers.party_permissions import is_enabled
+
 	if isinstance(filters, str):
 		filters = json.loads(filters)
 
-	company = (filters or {}).pop("company", None)
+	company = (filters or {}).pop("company", None) if is_enabled() else None
 	customer = DocType("Customer")
 	search_str = f"%{txt}%"
 

--- a/erpnext/hooks.py
+++ b/erpnext/hooks.py
@@ -22,6 +22,18 @@ add_to_apps_screen = [
 
 develop_version = "17.x.x-develop"
 
+permission_query_conditions = {
+	"Supplier": "erpnext.controllers.party_permissions.supplier_query_conditions",
+	"Customer": "erpnext.controllers.party_permissions.customer_query_conditions",
+	"Item": "erpnext.controllers.party_permissions.item_query_conditions",
+}
+
+has_permission = {
+	"Supplier": "erpnext.controllers.party_permissions.party_has_permission",
+	"Customer": "erpnext.controllers.party_permissions.party_has_permission",
+	"Item": "erpnext.controllers.party_permissions.party_has_permission",
+}
+
 app_include_js = "erpnext.bundle.js"
 app_include_css = "erpnext.bundle.css"
 web_include_css = "erpnext-web.bundle.css"
@@ -348,12 +360,28 @@ pre_submit_validation_doctypes = [
 	"Sales Order",
 ]
 
+_party_company_doctypes = (
+	"Purchase Order",
+	"Purchase Invoice",
+	"Purchase Receipt",
+	"Subcontracting Order",
+	"Subcontracting Receipt",
+	"Sales Order",
+	"Sales Invoice",
+	"Delivery Note",
+	"Quotation",
+	"POS Invoice",
+)
+
 doc_events = {
 	"*": {
 		"validate": [
 			"erpnext.support.doctype.service_level_agreement.service_level_agreement.apply",
 			"erpnext.setup.doctype.transaction_deletion_record.transaction_deletion_record.check_for_running_deletion_job",
 		],
+	},
+	tuple(_party_company_doctypes): {
+		"validate": "erpnext.controllers.party_permissions.validate_party_company",
 	},
 	tuple(period_closing_doctypes): {
 		"validate": "erpnext.accounts.doctype.accounting_period.accounting_period.validate_accounting_period_on_doc_save",

--- a/erpnext/hooks.py
+++ b/erpnext/hooks.py
@@ -360,18 +360,50 @@ pre_submit_validation_doctypes = [
 	"Sales Order",
 ]
 
-_party_company_doctypes = (
-	"Purchase Order",
-	"Purchase Invoice",
-	"Purchase Receipt",
-	"Subcontracting Order",
-	"Subcontracting Receipt",
-	"Sales Order",
-	"Sales Invoice",
-	"Delivery Note",
-	"Quotation",
-	"POS Invoice",
-)
+# Hook: other apps can extend this list to add their own doctypes.
+# Each entry is a dict with keys:
+#   doctype          (required)  — DocType name
+#   customer_field   (optional)  — Link field pointing to Customer at doc level
+#   supplier_field   (optional)  — Link field pointing to Supplier at doc level
+#   party_field      (optional)  — Generic party Link field (Customer or Supplier)
+#   party_type_field (optional)  — Companion field holding the party type string
+#   party_rows_table (optional)  — Child table containing party/party_type per row
+#   items_table      (optional)  — Child table with an item_code field
+#   item_field       (optional)  — Field name inside items_table (default: "item_code")
+company_wise_masters_config = [
+	# Sales
+	{"doctype": "Sales Order", "customer_field": "customer", "items_table": "items"},
+	{"doctype": "Delivery Note", "customer_field": "customer", "items_table": "items"},
+	{"doctype": "Sales Invoice", "customer_field": "customer", "items_table": "items"},
+	{"doctype": "POS Invoice", "customer_field": "customer", "items_table": "items"},
+	# Quotation uses party_name/quotation_to — customer or lead
+	{
+		"doctype": "Quotation",
+		"party_field": "party_name",
+		"party_type_field": "quotation_to",
+		"items_table": "items",
+	},
+	# Buying
+	{"doctype": "Purchase Order", "supplier_field": "supplier", "items_table": "items"},
+	{"doctype": "Purchase Receipt", "supplier_field": "supplier", "items_table": "items"},
+	{"doctype": "Purchase Invoice", "supplier_field": "supplier", "items_table": "items"},
+	{"doctype": "Subcontracting Order", "supplier_field": "supplier", "items_table": "items"},
+	{"doctype": "Subcontracting Receipt", "supplier_field": "supplier", "items_table": "items"},
+	# Stock — items only, no party at doc level
+	{"doctype": "Stock Entry", "items_table": "items"},
+	{"doctype": "Stock Reconciliation", "items_table": "items"},
+	{"doctype": "Material Request", "items_table": "items"},
+	# Finance — dynamic party_type/party
+	{"doctype": "Payment Entry", "party_field": "party", "party_type_field": "party_type"},
+	{
+		"doctype": "Journal Entry",
+		"party_rows_table": "accounts",
+		"party_field": "party",
+		"party_type_field": "party_type",
+	},
+]
+
+_party_company_doctypes = tuple(entry["doctype"] for entry in company_wise_masters_config)
 
 doc_events = {
 	"*": {

--- a/erpnext/manufacturing/doctype/blanket_order/blanket_order.js
+++ b/erpnext/manufacturing/doctype/blanket_order/blanket_order.js
@@ -15,6 +15,15 @@ frappe.ui.form.on("Blanket Order", {
 
 		frm.add_fetch("customer", "customer_name", "customer_name");
 		frm.add_fetch("supplier", "supplier_name", "supplier_name");
+
+		frm.set_query("customer", () => erpnext.queries.customer(frm.doc));
+		frm.set_query("supplier", () => erpnext.queries.supplier(frm.doc));
+		frm.set_query("item_code", "items", function () {
+			return {
+				query: "erpnext.controllers.queries.item_query",
+				filters: { company: frm.doc.company, has_variants: 0 },
+			};
+		});
 	},
 
 	refresh: function (frm) {

--- a/erpnext/manufacturing/doctype/work_order/work_order.js
+++ b/erpnext/manufacturing/doctype/work_order/work_order.js
@@ -47,11 +47,13 @@ frappe.ui.form.on("Work Order", {
 
 		// Set query for FG Item
 		frm.set_query("production_item", function () {
+			const filters = { is_stock_item: 1 };
+			if (frappe.sys_defaults.enable_company_wise_masters) {
+				filters.company = frm.doc.company;
+			}
 			return {
 				query: "erpnext.controllers.queries.item_query",
-				filters: {
-					is_stock_item: 1,
-				},
+				filters: filters,
 			};
 		});
 

--- a/erpnext/public/js/controllers/buying.js
+++ b/erpnext/public/js/controllers/buying.js
@@ -82,7 +82,7 @@ erpnext.buying = {
 					});
 				}
 
-				me.frm.set_query("supplier", erpnext.queries.supplier);
+				me.frm.set_query("supplier", () => erpnext.queries.supplier(me.frm.doc));
 				me.frm.set_query("contact_person", erpnext.queries.contact_query);
 				me.frm.set_query("supplier_address", erpnext.queries.address_query);
 
@@ -91,7 +91,7 @@ erpnext.buying = {
 
 				this.frm.set_query("item_code", "items", function () {
 					if (me.frm.doc.is_subcontracted) {
-						var filters = { supplier: me.frm.doc.supplier };
+						var filters = { supplier: me.frm.doc.supplier, company: me.frm.doc.company };
 						filters["is_stock_item"] = 0;
 
 						return {
@@ -101,7 +101,12 @@ erpnext.buying = {
 					} else {
 						return {
 							query: "erpnext.controllers.queries.item_query",
-							filters: { supplier: me.frm.doc.supplier, is_purchase_item: 1, has_variants: 0 },
+							filters: {
+								supplier: me.frm.doc.supplier,
+								company: me.frm.doc.company,
+								is_purchase_item: 1,
+								has_variants: 0,
+							},
 						};
 					}
 				});

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -10,25 +10,9 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 		this.set_fields_onload_for_line_item();
 		this.frm.ignore_doctypes_on_cancel_all = ["Serial and Batch Bundle"];
 
-		// Company-wise master filtering
+		// Company-wise master filtering: customer link
 		if (this.frm.fields_dict["customer"]) {
 			this.frm.set_query("customer", () => erpnext.queries.customer(me.frm.doc));
-		}
-		if (
-			this.frm.fields_dict["items"] &&
-			this.frm.fields_dict["items"].grid.get_field("item_code")
-		) {
-			// Base item query with company filter; buying.js overrides this for purchase forms
-			// with additional supplier / is_purchase_item constraints.
-			this.frm.set_query("item_code", "items", function () {
-				return {
-					query: "erpnext.controllers.queries.item_query",
-					filters: {
-						customer: me.frm.doc.customer,
-						company: me.frm.doc.company,
-					},
-				};
-			});
 		}
 
 		frappe.flags.hide_serial_batch_dialog = true;

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -10,6 +10,27 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 		this.set_fields_onload_for_line_item();
 		this.frm.ignore_doctypes_on_cancel_all = ["Serial and Batch Bundle"];
 
+		// Company-wise master filtering
+		if (this.frm.fields_dict["customer"]) {
+			this.frm.set_query("customer", () => erpnext.queries.customer(me.frm.doc));
+		}
+		if (
+			this.frm.fields_dict["items"] &&
+			this.frm.fields_dict["items"].grid.get_field("item_code")
+		) {
+			// Base item query with company filter; buying.js overrides this for purchase forms
+			// with additional supplier / is_purchase_item constraints.
+			this.frm.set_query("item_code", "items", function () {
+				return {
+					query: "erpnext.controllers.queries.item_query",
+					filters: {
+						customer: me.frm.doc.customer,
+						company: me.frm.doc.company,
+					},
+				};
+			});
+		}
+
 		frappe.flags.hide_serial_batch_dialog = true;
 		frappe.ui.form.on(this.frm.doctype + " Item", "rate", function (frm, cdt, cdn) {
 			var item = frappe.get_doc(cdt, cdn);

--- a/erpnext/public/js/queries.js
+++ b/erpnext/public/js/queries.js
@@ -18,6 +18,20 @@ $.extend(erpnext.queries, {
 		return args;
 	},
 
+	supplier: function (doc) {
+		return {
+			query: "erpnext.controllers.queries.supplier_query",
+			filters: { company: doc && doc.company },
+		};
+	},
+
+	customer: function (doc) {
+		return {
+			query: "erpnext.controllers.queries.customer_query",
+			filters: { company: doc && doc.company },
+		};
+	},
+
 	bom: function () {
 		return { query: "erpnext.controllers.queries.bom" };
 	},

--- a/erpnext/public/js/queries.js
+++ b/erpnext/public/js/queries.js
@@ -247,3 +247,15 @@ erpnext.queries.setup_warehouse_query = function (frm) {
 		return filters;
 	});
 };
+
+// Payment Entry: party link filtered by company based on party_type
+frappe.ui.form.on("Payment Entry", {
+	setup: function (frm) {
+		if (!frappe.sys_defaults.enable_company_wise_masters) return;
+		frm.set_query("party", function () {
+			var party_type = frm.doc.party_type;
+			if (party_type === "Customer") return erpnext.queries.customer(frm.doc);
+			if (party_type === "Supplier") return erpnext.queries.supplier(frm.doc);
+		});
+	},
+});

--- a/erpnext/public/js/utils/sales_common.js
+++ b/erpnext/public/js/utils/sales_common.js
@@ -79,9 +79,13 @@ erpnext.sales_common = {
 						if (me.frm.doc.doctype == "Quotation" && me.frm.doc.quotation_to == "Customer") {
 							customer = me.frm.doc.party_name;
 						}
+						const filters = { is_sales_item: 1, customer: customer, has_variants: 0 };
+						if (frappe.sys_defaults.enable_company_wise_masters) {
+							filters.company = me.frm.doc.company;
+						}
 						return {
 							query: "erpnext.controllers.queries.item_query",
-							filters: { is_sales_item: 1, customer: customer, has_variants: 0 },
+							filters: filters,
 						};
 					});
 				}

--- a/erpnext/selling/doctype/customer/customer.json
+++ b/erpnext/selling/doctype/customer/customer.json
@@ -517,13 +517,15 @@
    "fieldname": "company_restrictions_section",
    "fieldtype": "Section Break",
    "label": "Company Restrictions",
-   "description": "If set, this Customer is only available for transactions in the listed companies. Leave empty for no restriction."
+   "description": "If set, this Customer is only available for transactions in the listed companies. Leave empty for no restriction.",
+   "depends_on": "eval:frappe.sys_defaults.enable_company_wise_masters"
   },
   {
    "fieldname": "allowed_companies",
    "fieldtype": "Table",
    "label": "Allowed Companies",
-   "options": "Allowed To Transact With"
+   "options": "Allowed To Transact With",
+   "depends_on": "eval:frappe.sys_defaults.enable_company_wise_masters"
   },
   {
    "collapsible": 1,

--- a/erpnext/selling/doctype/customer/customer.json
+++ b/erpnext/selling/doctype/customer/customer.json
@@ -64,6 +64,8 @@
   "tax_withholding_group",
   "tax_withholding_category",
   "settings_tab",
+  "company_restrictions_section",
+  "allowed_companies",
   "so_required",
   "dn_required",
   "column_break_53",
@@ -510,6 +512,18 @@
    "fieldname": "settings_tab",
    "fieldtype": "Tab Break",
    "label": "Settings"
+  },
+  {
+   "fieldname": "company_restrictions_section",
+   "fieldtype": "Section Break",
+   "label": "Company Restrictions",
+   "description": "If set, this Customer is only available for transactions in the listed companies. Leave empty for no restriction."
+  },
+  {
+   "fieldname": "allowed_companies",
+   "fieldtype": "Table",
+   "label": "Allowed Companies",
+   "options": "Allowed To Transact With"
   },
   {
    "collapsible": 1,

--- a/erpnext/selling/doctype/customer/customer.py
+++ b/erpnext/selling/doctype/customer/customer.py
@@ -55,6 +55,7 @@ class Customer(TransactionBase):
 
 		account_manager: DF.Link | None
 		accounts: DF.Table[PartyAccount]
+		allowed_companies: DF.Table[AllowedToTransactWith]
 		companies: DF.Table[AllowedToTransactWith]
 		credit_limits: DF.Table[CustomerCreditLimit]
 		customer_details: DF.Text | None

--- a/erpnext/selling/doctype/quotation/quotation.js
+++ b/erpnext/selling/doctype/quotation/quotation.js
@@ -204,7 +204,7 @@ erpnext.selling.QuotationController = class QuotationController extends erpnext.
 	set_dynamic_field_label() {
 		if (this.frm.doc.quotation_to == "Customer") {
 			this.frm.set_df_property("party_name", "label", "Customer");
-			this.frm.fields_dict.party_name.get_query = null;
+			this.frm.fields_dict.party_name.get_query = () => erpnext.queries.customer(this.frm.doc);
 		} else if (this.frm.doc.quotation_to == "Lead") {
 			this.frm.set_df_property("party_name", "label", "Lead");
 			this.frm.fields_dict.party_name.get_query = function () {

--- a/erpnext/startup/boot.py
+++ b/erpnext/startup/boot.py
@@ -24,6 +24,9 @@ def boot_session(bootinfo):
 		bootinfo.sysdefaults.over_billing_allowance = frappe.get_single_value(
 			"Accounts Settings", "over_billing_allowance"
 		)
+		bootinfo.sysdefaults.enable_company_wise_masters = cint(
+			frappe.get_single_value("Accounts Settings", "enable_company_wise_masters")
+		)
 
 		bootinfo.sysdefaults.quotation_valid_till = cint(
 			frappe.db.get_single_value("CRM Settings", "default_valid_till")

--- a/erpnext/startup/boot.py
+++ b/erpnext/startup/boot.py
@@ -27,6 +27,10 @@ def boot_session(bootinfo):
 		bootinfo.sysdefaults.enable_company_wise_masters = cint(
 			frappe.get_single_value("Accounts Settings", "enable_company_wise_masters")
 		)
+		if bootinfo.sysdefaults.enable_company_wise_masters:
+			# Expose the full doctype config so client JS can auto-register set_query
+			# for every covered form without hard-coding doctype names.
+			bootinfo.company_wise_masters_config = frappe.get_hooks("company_wise_masters_config") or []
 
 		bootinfo.sysdefaults.quotation_valid_till = cint(
 			frappe.db.get_single_value("CRM Settings", "default_valid_till")

--- a/erpnext/stock/doctype/item/item.json
+++ b/erpnext/stock/doctype/item/item.json
@@ -350,13 +350,15 @@
    "fieldname": "company_restrictions_section",
    "fieldtype": "Section Break",
    "label": "Company Restrictions",
-   "description": "If set, this Item is only available for transactions in the listed companies. Leave empty for no restriction."
+   "description": "If set, this Item is only available for transactions in the listed companies. Leave empty for no restriction.",
+   "depends_on": "eval:frappe.sys_defaults.enable_company_wise_masters"
   },
   {
    "fieldname": "allowed_companies",
    "fieldtype": "Table",
    "label": "Allowed Companies",
-   "options": "Allowed To Transact With"
+   "options": "Allowed To Transact With",
+   "depends_on": "eval:frappe.sys_defaults.enable_company_wise_masters"
   },
   {
    "collapsible": 1,

--- a/erpnext/stock/doctype/item/item.json
+++ b/erpnext/stock/doctype/item/item.json
@@ -65,6 +65,8 @@
   "purchase_tax_withholding_category",
   "column_break_ltlb",
   "sales_tax_withholding_category",
+  "company_restrictions_section",
+  "allowed_companies",
   "inventory_section",
   "stock_levels_section",
   "stock_levels_html",
@@ -343,6 +345,18 @@
    "fieldtype": "Table",
    "label": "Barcodes",
    "options": "Item Barcode"
+  },
+  {
+   "fieldname": "company_restrictions_section",
+   "fieldtype": "Section Break",
+   "label": "Company Restrictions",
+   "description": "If set, this Item is only available for transactions in the listed companies. Leave empty for no restriction."
+  },
+  {
+   "fieldname": "allowed_companies",
+   "fieldtype": "Table",
+   "label": "Allowed Companies",
+   "options": "Allowed To Transact With"
   },
   {
    "collapsible": 1,

--- a/erpnext/stock/doctype/item/item.py
+++ b/erpnext/stock/doctype/item/item.py
@@ -59,6 +59,9 @@ class Item(Document):
 	if TYPE_CHECKING:
 		from frappe.types import DF
 
+		from erpnext.accounts.doctype.allowed_to_transact_with.allowed_to_transact_with import (
+			AllowedToTransactWith,
+		)
 		from erpnext.stock.doctype.item_barcode.item_barcode import ItemBarcode
 		from erpnext.stock.doctype.item_customer_detail.item_customer_detail import ItemCustomerDetail
 		from erpnext.stock.doctype.item_default.item_default import ItemDefault
@@ -70,6 +73,7 @@ class Item(Document):
 
 		allow_alternative_item: DF.Check
 		allow_negative_stock: DF.Check
+		allowed_companies: DF.Table[AllowedToTransactWith]
 		asset_category: DF.Link | None
 		asset_naming_series: DF.Literal[None]
 		attributes: DF.Table[ItemVariantAttribute]

--- a/erpnext/stock/doctype/stock_entry/stock_entry.js
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.js
@@ -1197,7 +1197,11 @@ erpnext.stock.StockEntry = class StockEntry extends erpnext.stock.StockControlle
 		};
 
 		this.frm.fields_dict.items.grid.get_field("item_code").get_query = function () {
-			return erpnext.queries.item({ is_stock_item: 1 });
+			const filters = { is_stock_item: 1 };
+			if (frappe.sys_defaults.enable_company_wise_masters) {
+				filters.company = me.frm.doc.company;
+			}
+			return erpnext.queries.item(filters);
 		};
 
 		this.frm.set_query("subcontracting_order", function () {

--- a/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.js
+++ b/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.js
@@ -18,11 +18,13 @@ frappe.ui.form.on("Stock Reconciliation", {
 
 		// end of life
 		frm.set_query("item_code", "items", function (doc, cdt, cdn) {
+			const filters = { is_stock_item: 1 };
+			if (frappe.sys_defaults.enable_company_wise_masters) {
+				filters.company = frm.doc.company;
+			}
 			return {
 				query: "erpnext.controllers.queries.item_query",
-				filters: {
-					is_stock_item: 1,
-				},
+				filters: filters,
 			};
 		});
 		frm.set_query("batch_no", "items", function (doc, cdt, cdn) {


### PR DESCRIPTION
## Summary

- Adds an **Enable Company-wise Masters** toggle in Accounts Settings that restricts which Customers, Suppliers, and Items are visible per company
- Each master (Customer, Supplier, Item) gets an **Allowed Companies** child table; records with no rows are global (visible to all companies)
- Filtering is enforced at three layers: link search / list view, form-level `has_permission`, and transaction `validate`
- Coverage spans all major transaction forms: Sales Invoice, Sales Order, Delivery Note, Quotation, Purchase Invoice, Purchase Order, Purchase Receipt, Supplier Quotation, Stock Entry, Stock Reconciliation, Journal Entry, Payment Entry, Blanket Order, and Work Order

## What changed

**New infrastructure**
- `controllers/party_permissions.py` — core filtering logic (`item_query`, `customer_query`, `supplier_query`, permission query conditions, `has_permission`, validate hook)
- `controllers/queries.py` — `item_query`, `customer_query`, `supplier_query` extended to accept a `company` filter and restrict results to allowed companies
- `hooks.py` — `company_wise_masters_config` hook listing all covered doctypes; `permission_query_conditions` and `has_permission` hooks wired up
- `startup/boot.py` — exposes `enable_company_wise_masters` and `company_wise_masters_config` to the client via bootinfo

**Doctype changes**
- Accounts Settings — new `enable_company_wise_masters` toggle
- Customer, Supplier, Item — new `allowed_companies` child table (Allowed To Transact With)

**JS fixes (set_query ordering)**
- `sales_common.js` — `SellingController.setup_queries()` now passes `company` to `item_query` (was the final authority, overwriting TransactionController)
- `stock_entry.js` — company filter added directly in `StockEntry` class `setup()` (class runs after new_style handlers)
- `stock_reconciliation.js` — company filter added in `onload` handler (ran after setup, overwrote it)
- `quotation.js` — `set_dynamic_field_label()` was explicitly setting `party_name.get_query = null` for Customer; replaced with `erpnext.queries.customer()`
- `queries.js` — Payment Entry party query moved out of `frappe.ready()` (was causing blank forms) into a top-level `frappe.ui.form.on` handler
- `transaction.js` — redundant item_code `set_query` removed (always overwritten by SellingController/BuyingController)
- `blanket_order.js` — added customer, supplier, and item_code queries
- `work_order.js` — added company filter to `production_item` query

## Test plan

- [ ] Enable **Company-wise Masters** in Accounts Settings
- [ ] Add `Allowed Companies` rows to a few Items, Customers, Suppliers restricting them to specific companies
- [ ] Verify restricted records do **not** appear in link dropdowns for other companies across: Sales Invoice, Sales Order, Delivery Note, Quotation, Purchase Invoice, Purchase Order, Stock Entry, Stock Reconciliation, Journal Entry, Payment Entry, Blanket Order, Work Order
- [ ] Verify global records (no `Allowed Companies` rows) appear in all companies
- [ ] Disable the toggle and verify all records are visible again (no filtering)
- [ ] Verify Quotation customer dropdown filters correctly when switching between companies

🤖 Generated with [Claude Code](https://claude.com/claude-code)