### PR TITLE
test: Cash Flow report correctness coverage

### DIFF
--- a/erpnext/accounts/report/cash_flow/test_cash_flow.py
+++ b/erpnext/accounts/report/cash_flow/test_cash_flow.py
@@ -2,12 +2,34 @@
 # For license information, please see license.txt
 
 import frappe
+from frappe.utils import today
 
 from erpnext.accounts.report.cash_flow.cash_flow import execute
+from erpnext.accounts.utils import get_fiscal_year
 from erpnext.tests.utils import ERPNextTestSuite
 
 
 class TestCashFlow(ERPNextTestSuite):
+	def setUp(self):
+		self.company = "_Test Company"
+
+	def net_change_in_cash(self):
+		"""Run the report for the current fiscal year and return the Net Change in Cash total."""
+		fiscal_year, year_start, year_end = get_fiscal_year(today(), company=self.company)
+		filters = frappe._dict(
+			company=self.company,
+			from_fiscal_year=fiscal_year,
+			to_fiscal_year=fiscal_year,
+			period_start_date=year_start,
+			period_end_date=year_end,
+			filter_based_on="Fiscal Year",
+			periodicity="Yearly",
+			accumulated_values=0,
+		)
+		rows = execute(filters)[1]
+		row = next(row for row in rows if row.get("section") == "'Net Change in Cash'")
+		return row["total"]
+
 	def test_report_executes(self):
 		# Smoke-guards the raw-SQL -> query-builder port: the report query must compile and run on
 		# both MariaDB and postgres.
@@ -25,3 +47,31 @@ class TestCashFlow(ERPNextTestSuite):
 			)
 		)
 		self.assertTrue(columns)
+
+	def test_cash_sale_increases_net_change_in_cash(self):
+		"""A cash sale (debit Cash, credit Income) increases net change in cash by the amount."""
+		from erpnext.accounts.doctype.journal_entry.test_journal_entry import make_journal_entry
+
+		before = self.net_change_in_cash()
+		make_journal_entry("Cash - _TC", "Sales - _TC", 500, posting_date=today(), submit=True)
+
+		self.assertEqual(self.net_change_in_cash() - before, 500)
+
+	def test_cash_purchase_of_asset_is_investing_outflow(self):
+		"""Buying a fixed asset for cash is an investing outflow that reduces net change in cash."""
+		from erpnext.accounts.doctype.account.test_account import create_account
+		from erpnext.accounts.doctype.journal_entry.test_journal_entry import make_journal_entry
+
+		create_account(
+			account_name="_Test Cash Flow Asset",
+			company=self.company,
+			parent_account="Fixed Assets - _TC",
+			account_type="Fixed Asset",
+		)
+		asset_account = "_Test Cash Flow Asset - _TC"
+
+		before = self.net_change_in_cash()
+		# debit the fixed asset, credit cash -> cash goes out
+		make_journal_entry(asset_account, "Cash - _TC", 800, posting_date=today(), submit=True)
+
+		self.assertEqual(self.net_change_in_cash() - before, -800)


### PR DESCRIPTION
Adds correctness coverage for the **Cash Flow** report, which previously had only a smoke test.

### Tests added
- A cash sale (cash received against income) increases the net change in cash by the sale amount.
- Buying a fixed asset for cash is an investing outflow that reduces the net change in cash.

Both measure the change in "Net Change in Cash" around a single posting, so they're independent of whatever else exists in the company's books.

### How to test
- Record a cash receipt against an income account and confirm the Cash Flow report's net change in cash rises by that amount.
- Pay cash to acquire a fixed asset and confirm the net change in cash falls by that amount (shown under investing activities).
