### PR TITLE
fix(controllers): case-insensitive employee/lead/bom search ranking on Postgres

### DIFF
--- a/erpnext/controllers/queries.py
+++ b/erpnext/controllers/queries.py
@@ -71,14 +71,17 @@ def employee_query(
 		.where(Criterion.any(search_conditions))
 		.orderby(
 			Case()
-			.when(Locate(txt_no_percent, Employee.name) > 0, Locate(txt_no_percent, Employee.name))
+			.when(
+				Locate(Lower(txt_no_percent), Lower(Employee.name)) > 0,
+				Locate(Lower(txt_no_percent), Lower(Employee.name)),
+			)
 			.else_(99999)
 		)
 		.orderby(
 			Case()
 			.when(
-				Locate(txt_no_percent, Employee.employee_name) > 0,
-				Locate(txt_no_percent, Employee.employee_name),
+				Locate(Lower(txt_no_percent), Lower(Employee.employee_name)) > 0,
+				Locate(Lower(txt_no_percent), Lower(Employee.employee_name)),
 			)
 			.else_(99999)
 		)
@@ -135,16 +138,27 @@ def lead_query(
 		.where(Lead.status.isnull() | (Lead.status != "Converted"))
 		.where(Criterion.any(search_conditions))
 		.orderby(
-			Case().when(Locate(txt_no_percent, Lead.name) > 0, Locate(txt_no_percent, Lead.name)).else_(99999)
-		)
-		.orderby(
 			Case()
-			.when(Locate(txt_no_percent, Lead.lead_name) > 0, Locate(txt_no_percent, Lead.lead_name))
+			.when(
+				Locate(Lower(txt_no_percent), Lower(Lead.name)) > 0,
+				Locate(Lower(txt_no_percent), Lower(Lead.name)),
+			)
 			.else_(99999)
 		)
 		.orderby(
 			Case()
-			.when(Locate(txt_no_percent, Lead.company_name) > 0, Locate(txt_no_percent, Lead.company_name))
+			.when(
+				Locate(Lower(txt_no_percent), Lower(Lead.lead_name)) > 0,
+				Locate(Lower(txt_no_percent), Lower(Lead.lead_name)),
+			)
+			.else_(99999)
+		)
+		.orderby(
+			Case()
+			.when(
+				Locate(Lower(txt_no_percent), Lower(Lead.company_name)) > 0,
+				Locate(Lower(txt_no_percent), Lower(Lead.company_name)),
+			)
 			.else_(99999)
 		)
 		.orderby(Lead.idx, order=Order.desc)
@@ -382,7 +396,12 @@ def bom(
 		.where(BOM.is_active == 1)
 		.where(BOM[searchfield].like(f"%{txt}%"))
 		.orderby(
-			Case().when(Locate(txt_no_percent, BOM.name) > 0, Locate(txt_no_percent, BOM.name)).else_(99999)
+			Case()
+			.when(
+				Locate(Lower(txt_no_percent), Lower(BOM.name)) > 0,
+				Locate(Lower(txt_no_percent), Lower(BOM.name)),
+			)
+			.else_(99999)
 		)
 		.orderby(BOM.idx, order=Order.desc)
 		.orderby(BOM.name)


### PR DESCRIPTION
### Problem (convergent re-audit of the Postgres-parity effort)

The `employee_query`, `lead_query` and `bom()` link-search handlers rank autocomplete results
with a bare `Locate(txt, col)` in `ORDER BY`. frappe maps `Locate` → `strpos` on Postgres, which
is **case-sensitive**, while MariaDB's `LOCATE` against a column uses the column's
case-insensitive collation. So the search-dropdown ordering diverged between engines for
mixed-case matches (e.g. `employee_name` "John Smith" vs typed "smith"). Row count and membership
are unaffected — the `WHERE .like()` filter is already `ILIKE` on both engines; only the relevance
ranking diverged.

### Fix

Wrap both `Locate` operands in `Lower()`, exactly as the sibling `item_query` / `get_project_name`
handlers in the same file already do. This is a no-op on MariaDB (lowering both sides of an
already case-insensitive comparison) and makes Postgres' `strpos` case-insensitive — identical
ranking on both engines.

### Verification
Existing `test_queries` suite green on both engines (`--lightmode`).

Part of a final convergent audit of the PG-parity effort; one of several genuine findings (each its own PR).
