### PR TITLE
fix(regional): deterministic IRS-1099 payer-address pick across engines

### DIFF
--- a/erpnext/regional/report/irs_1099/irs_1099.py
+++ b/erpnext/regional/report/irs_1099/irs_1099.py
@@ -131,6 +131,7 @@ def get_payer_address_html(company):
 		.where(address.is_your_company_address == 1)
 		.orderby(Case().when(address.address_type == "Postal", 1).else_(0), order=frappe.qb.desc)
 		.orderby(Case().when(address.address_type == "Billing", 1).else_(0), order=frappe.qb.desc)
+		.orderby(address.name)  # deterministic LIMIT-1 tie-break across engines
 		.limit(1)
 		.run(as_dict=True)
 	)


### PR DESCRIPTION
### Problem (round-4 convergent re-audit of the Postgres-parity effort)

`get_payer_address_html` picks one company address with `ORDER BY (Postal DESC, Billing DESC) LIMIT 1`
and **no column tie-break**. When a company has two addresses of the **same** `address_type`, both CASE
keys tie, so the `LIMIT 1` row is implementation-defined — and MariaDB and PostgreSQL can return a
**different `address.name`**, i.e. a different payer address on the rendered IRS-1099 form for identical
data. (`is_your_company_address` is a plain checkbox auto-set on every company-linked address, and the
query has no company filter, so ties are realistic.)

### Fix

Add a final `.orderby(address.name)`, **mirroring the sibling `get_street_address_html` in the same file**,
which already carries the `# deterministic LIMIT-1 tie-break across engines` order — this one was missed in
the original conversion. The pick is now the lexicographically-smallest name, identical on both engines.

### Verification
Existing `test_irs_1099` suite green on both engines (`mdbtest` / `pgtest`, `--lightmode`). Mechanical
one-line change mirroring the same-file sibling.

This was the **only** finding of round 4 (which the completeness critic reported as **converged** — no
regressions, no other parity gaps; a parallel scan of 26 untouched GROUP BY queries also found zero
PG-invalid GROUP BYs).
