### PR TITLE
ci(postgres): flag get_all(distinct=True, order_by=...) in the static checker

### DIFF
--- a/.github/helper/postgres_compat.py
+++ b/.github/helper/postgres_compat.py
@@ -71,6 +71,11 @@ MYSQL_RESULT_KEYS = {"Column_name", "Key_name", "Seq_in_index", "Non_unique", "I
 
 SET_BOOL_FUNCS = {"set_value", "db_set"}
 
+# frappe.get_all / get_list: frappe's db_query SILENTLY drops ORDER BY for `distinct` queries on
+# Postgres (the ORDER BY column must appear in the SELECT-DISTINCT list), so `distinct=True` together
+# with a literal `order_by` is a no-op on PG and the result comes back unordered.
+DISTINCT_ORDER_FUNCS = {"get_all", "get_list"}
+
 
 def _docstring_ids(tree: ast.AST) -> set[int]:
 	"""ids of Constant nodes that are docstrings (so prose describing the rules isn't flagged)."""
@@ -153,6 +158,25 @@ class Visitor(ast.NodeVisitor):
 				a = node.args[value_idx]
 				if isinstance(a, ast.Constant) and isinstance(a.value, bool):
 					self._flag(node, f"{name}(..., {a.value}) sets an int/Check column with a bool -> pass 1/0 (Postgres rejects bool->smallint)")
+
+		# frappe.get_all/get_list(..., distinct=True, order_by="<col>") -> ORDER BY is silently dropped
+		# for distinct queries on Postgres, so the result is unordered there. Sort in python instead
+		# (e.g. sorted(frappe.get_all(..., distinct=True), key=str.casefold)). An empty order_by="" (the
+		# explicit "suppress the injected default" idiom) and a dynamic/variable order_by are not flagged.
+		if name in DISTINCT_ORDER_FUNCS:
+			has_distinct = any(
+				kw.arg == "distinct" and isinstance(kw.value, ast.Constant) and kw.value.value
+				for kw in node.keywords
+			)
+			order_kw = next((kw for kw in node.keywords if kw.arg == "order_by"), None)
+			has_literal_order = (
+				order_kw is not None
+				and isinstance(order_kw.value, ast.Constant)
+				and isinstance(order_kw.value.value, str)
+				and order_kw.value.value.strip()
+			)
+			if has_distinct and has_literal_order:
+				self._flag(node, f"{name}(distinct=True, order_by=...) -> frappe drops ORDER BY for distinct queries on Postgres; sort in python instead, e.g. sorted(..., key=str.casefold)")
 
 		self.generic_visit(node)
 

--- a/erpnext/manufacturing/doctype/job_card/job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/job_card.py
@@ -1725,7 +1725,7 @@ def get_operations(doctype: str, txt: str, searchfield: str, start: int, page_le
 		fields=["operation"],
 		limit_start=start,
 		limit_page_length=page_len,
-		order_by="idx asc",
+		order_by="idx asc",  # pg-ok: dropped under distinct on PG — paging order of an operation autocomplete only
 		as_list=1,
 		distinct=True,
 	)

--- a/erpnext/manufacturing/doctype/work_order/test_work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/test_work_order.py
@@ -1048,7 +1048,7 @@ class TestWorkOrder(ERPNextTestSuite):
 		job_cards = frappe.get_all(
 			"Job Card Time Log",
 			fields=["parent as name", "docstatus"],
-			order_by="creation asc",
+			order_by="creation asc",  # pg-ok: dropped under distinct on PG — set is just iterated to cancel, order irrelevant
 			distinct=True,
 		)
 

--- a/erpnext/stock/doctype/inventory_dimension/inventory_dimension.py
+++ b/erpnext/stock/doctype/inventory_dimension/inventory_dimension.py
@@ -409,7 +409,7 @@ def get_inventory_dimensions():
 			"validate_negative_stock",
 			"name as dimension_name",
 		],
-		order_by="creation",
+		order_by="creation",  # pg-ok: dropped under distinct on PG — config-list iteration order only, not data
 		distinct=True,
 	)
 


### PR DESCRIPTION
### What

Adds a rule to the always-on static PG-compat checker (`.github/helper/postgres_compat.py`) for the
`distinct` + `order_by` pattern, and grandfathers the three pre-existing low-impact sites it surfaces.

### Why

frappe's `db_query` **silently drops `ORDER BY` for `distinct` queries on Postgres** (Postgres requires the
ORDER BY column to be in the SELECT-DISTINCT list), so `frappe.get_all/get_list(distinct=True,
order_by="<col>")` is a no-op there and the result comes back unordered. This was the root cause of three
shipped fixes — Sales Register, Purchase Register, and Sales Analytics column/row ordering — so it's worth
catching mechanically going forward, since the semantic divergence is invisible to a MariaDB-only run.

### Rule

AST check on `get_all`/`get_list` calls: flags `distinct=True` **and** a non-empty **literal** `order_by`.
Deliberately does **not** flag `order_by=""` (the explicit "suppress the injected default" idiom) or a
dynamic/variable `order_by`. The `# pg-ok` escape hatch works as for every other rule.

### Grandfathered (pre-existing, low impact — paging/iteration order only, not data)
- `job_card` operation autocomplete (`order_by="idx asc"`)
- `inventory_dimension` config list (`order_by="creation"`)
- a `test_work_order` cancel loop (order irrelevant)

Verified the rule fires on the target pattern and is silent on the `""`/dynamic/no-distinct cases; the full
non-patch `erpnext/` tree is clean (0 remaining flags), so repo-wide pre-commit CI stays green.
