### PR TITLE
fix: show contextual balance label on party dashboard for net balances

### DIFF
--- a/erpnext/accounts/party.py
+++ b/erpnext/accounts/party.py
@@ -935,6 +935,15 @@ def get_dashboard_info(party_type, party, loyalty_program=None):
 		if party_type == "Supplier":
 			info["total_unpaid"] = -1 * info["total_unpaid"]
 
+		if info["total_unpaid"] < 0:
+			info["balance_label"] = (
+				"Total Advance Paid" if party_type == "Supplier" else "Total Advance Received"
+			)
+			info["balance_amount"] = abs(info["total_unpaid"])
+		else:
+			info["balance_label"] = "Total Unpaid"
+			info["balance_amount"] = info["total_unpaid"]
+
 		company_wise_info.append(info)
 
 	return company_wise_info

--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -188,11 +188,19 @@ $.extend(erpnext.utils, {
 					]),
 					"blue"
 				);
+				var info = company_wise_info[0];
+				var is_advance = info.balance_label !== "Total Unpaid";
+				var indicator_label =
+					info.balance_label === "Total Advance Paid"
+						? __("Total Advance Paid: {0}", [format_currency(info.balance_amount, info.currency)])
+						: info.balance_label === "Total Advance Received"
+						? __("Total Advance Received: {0}", [
+								format_currency(info.balance_amount, info.currency),
+						  ])
+						: __("Total Unpaid: {0}", [format_currency(info.balance_amount, info.currency)]);
 				frm.dashboard.add_indicator(
-					__("Total Unpaid: {0}", [
-						format_currency(company_wise_info[0].total_unpaid, company_wise_info[0].currency),
-					]),
-					company_wise_info[0].total_unpaid ? "orange" : "green"
+					indicator_label,
+					is_advance ? "green" : info.balance_amount ? "orange" : "green"
 				);
 
 				if (company_wise_info[0].loyalty_points) {
@@ -235,7 +243,14 @@ $.extend(erpnext.utils, {
 		frm.dashboard.stats_area_row.addClass("flex");
 		frm.dashboard.stats_area_row.css("flex-wrap", "wrap");
 
-		var color = info.total_unpaid ? "orange" : "green";
+		var is_advance = info.balance_label !== "Total Unpaid";
+		var color = is_advance ? "green" : info.balance_amount ? "orange" : "green";
+		var balance_label_text =
+			info.balance_label === "Total Advance Paid"
+				? __("Total Advance Paid")
+				: info.balance_label === "Total Advance Received"
+				? __("Total Advance Received")
+				: __("Total Unpaid");
 
 		var indicator = $(
 			'<div class="flex-column col-xs-6">' +
@@ -249,8 +264,10 @@ $.extend(erpnext.utils, {
 				'<div class="badge-link small" style="margin-bottom:10px">' +
 				'<span class="indicator ' +
 				color +
-				'">Total Unpaid: ' +
-				format_currency(info.total_unpaid, info.currency) +
+				'">' +
+				balance_label_text +
+				": " +
+				format_currency(info.balance_amount, info.currency) +
 				"</span></div>" +
 				"</div>"
 		).appendTo(frm.dashboard.stats_area_row);


### PR DESCRIPTION
https://support.frappe.io/helpdesk/tickets/71335?view=VIEW-HD+Ticket-70177

before:

<img width="1431" height="499" alt="imagefe6131" src="https://github.com/user-attachments/assets/8cb17bb3-3289-4ed4-9fb2-c4ac7094db09" />


after:

<img width="888" height="270" alt="Screenshot 2026-06-23 at 12 20 18 AM" src="https://github.com/user-attachments/assets/652b2401-4029-4872-a757-87a5756c9037" />

<img width="868" height="300" alt="Screenshot 2026-06-23 at 12 20 31 AM" src="https://github.com/user-attachments/assets/00b9950a-bbbc-4b06-84b8-30c7ff3f636a" />
