### PR TITLE
fix(stock): keep supplier-based Material Request picker valid on Postgres

### DIFF
--- a/erpnext/stock/doctype/material_request/material_request.py
+++ b/erpnext/stock/doctype/material_request/material_request.py
@@ -12,7 +12,7 @@ import frappe.defaults
 from frappe import _, msgprint
 from frappe.model.document import Document
 from frappe.query_builder import Order
-from frappe.query_builder.functions import Sum
+from frappe.query_builder.functions import Min, Sum
 from frappe.utils import cint, flt, get_datetime, get_link_to_form, getdate, new_line_sep, nowdate
 
 from erpnext.buying.utils import check_on_hold_or_closed_status, validate_for_items
@@ -483,9 +483,7 @@ def get_material_requests_based_on_supplier(
 	query = (
 		frappe.qb.from_(mr)
 		.from_(mr_item)
-		.select(mr.name)
-		.distinct()
-		.select(mr.transaction_date, mr.company)
+		.select(mr.name, mr.transaction_date, mr.company)
 		.where(
 			(mr.name == mr_item.parent)
 			& (mr_item.item_code.isin(supplier_items))
@@ -495,7 +493,8 @@ def get_material_requests_based_on_supplier(
 			& (mr.status != "Stopped")
 			& (mr.company == filters.get("company"))
 		)
-		.orderby(mr_item.item_code, order=Order.asc)
+		.groupby(mr.name, mr.transaction_date, mr.company)
+		.orderby(Min(mr_item.item_code), order=Order.asc)
 		.limit(cint(page_len))
 		.offset(cint(start))
 	)

--- a/erpnext/stock/doctype/material_request/test_material_request.py
+++ b/erpnext/stock/doctype/material_request/test_material_request.py
@@ -1252,6 +1252,44 @@ class TestMaterialRequest(ERPNextTestSuite):
 		over.items[0].qty = 4
 		over.validate_qty_against_so()
 
+	def test_get_material_requests_based_on_supplier(self):
+		"""The supplier-based Material Request picker must run on every engine.
+
+		It deduplicated requests with SELECT DISTINCT while ordering by an item
+		column that is not in the select list; PostgreSQL rejects that, so the
+		picker has to group and order by an aggregate instead.
+		"""
+		from erpnext.stock.doctype.material_request.material_request import (
+			get_material_requests_based_on_supplier,
+		)
+
+		item = create_item("_Test MR Default Supplier Item")
+		item.set("item_defaults", [])
+		item.append(
+			"item_defaults",
+			{
+				"company": "_Test Company",
+				"default_warehouse": "_Test Warehouse - _TC",
+				"default_supplier": "_Test Supplier",
+			},
+		)
+		item.save()
+
+		mr1 = make_material_request(item_code=item.name, qty=5)
+		mr2 = make_material_request(item_code=item.name, qty=7)
+
+		result = get_material_requests_based_on_supplier(
+			doctype="Material Request",
+			txt="",
+			searchfield="name",
+			start=0,
+			page_len=20,
+			filters={"supplier": "_Test Supplier", "company": "_Test Company"},
+		)
+		returned = {row["name"] for row in result}
+		self.assertIn(mr1.name, returned)
+		self.assertIn(mr2.name, returned)
+
 
 def get_in_transit_warehouse(company):
 	if not frappe.db.exists("Warehouse Type", "Transit"):


### PR DESCRIPTION
### Problem

`get_material_requests_based_on_supplier` (`erpnext/stock/doctype/material_request/material_request.py`) powers the supplier-based Material Request link picker. It deduplicated requests with `SELECT DISTINCT (name, transaction_date, company)` while **ordering by `mr_item.item_code`, which is not in the select list**.

MariaDB tolerates this; **PostgreSQL rejects it**:

```
psycopg2.errors.InvalidColumnReference: for SELECT DISTINCT, ORDER BY expressions must appear in select list
```

so the picker raised on Postgres. (This is a raw query-builder query run via `.run()`, so frappe's "drop ORDER BY under DISTINCT" handling for `get_all`/`get_list` does not apply.) Pre-existing — predates the Postgres-parity effort.

### Fix

Replace `DISTINCT` with `GROUP BY name, transaction_date, company` (the same deduplication, so the **same set of requests** is returned) and order by `Min(item_code)`:

- The ordering key is still `item_code`, now expressed as a well-defined aggregate that is valid under both engines.
- The order becomes **deterministic and identical on MariaDB and Postgres** (the prior `ORDER BY` over a non-selected, multi-valued column was already engine-defined/arbitrary on MariaDB).

### Verification

Runtime-checked on both engines (dedicated MariaDB + PostgreSQL test sites):

| | before fix | after fix |
|---|---|---|
| **PostgreSQL** | `InvalidColumnReference` | ✅ returns requests |
| **MariaDB** | ✅ returns requests | ✅ returns requests (same set) |

Added `TestMaterialRequest.test_get_material_requests_based_on_supplier`, which sets a default supplier on an item, creates two matching requests, and asserts the picker returns them. Reverting the query change makes it fail on PostgreSQL with the `InvalidColumnReference` above; it passes on MariaDB regardless. Full `test_material_request` module (43 tests) passes on both engines.