### PR TITLE
fix(manufacturing): keep manufacturing lead-time fractional across engines (MRP report + MPS)

### DIFF
--- a/erpnext/manufacturing/report/material_requirements_planning_report/material_requirements_planning_report.py
+++ b/erpnext/manufacturing/report/material_requirements_planning_report/material_requirements_planning_report.py
@@ -1219,7 +1219,7 @@ def get_item_lead_time(item_code, type_of_material):
 			.when(
 				(doctype.manufacturing_time_in_mins.isnull() | (doctype.manufacturing_time_in_mins <= 0)), 0
 			)
-			.else_(1440 / doctype.manufacturing_time_in_mins + doctype.buffer_time)
+			.else_(1440.0 / doctype.manufacturing_time_in_mins + doctype.buffer_time)
 			.as_("lead_time")
 		)
 	else:

--- a/erpnext/manufacturing/report/material_requirements_planning_report/test_material_requirements_planning_report.py
+++ b/erpnext/manufacturing/report/material_requirements_planning_report/test_material_requirements_planning_report.py
@@ -1,0 +1,30 @@
+# Copyright (c) 2024, Frappe Technologies Pvt. Ltd. and Contributors
+# See license.txt
+
+import frappe
+
+from erpnext.manufacturing.report.material_requirements_planning_report.material_requirements_planning_report import (
+	get_item_lead_time,
+)
+from erpnext.stock.doctype.item.test_item import make_item
+from erpnext.tests.utils import ERPNextTestSuite
+
+
+class TestMaterialRequirementsPlanningReport(ERPNextTestSuite):
+	def test_manufacture_lead_time_is_not_int_truncated(self):
+		"""lead_time = 1440 / manufacturing_time_in_mins + buffer_time. Both columns are Int;
+		integer/integer division truncates on Postgres (1440/7 -> 205) while MariaDB yields a
+		decimal, so the computed lead time (and the derived release date) diverged by engine."""
+		item = make_item("_Test MRP Lead Time Item", {"is_stock_item": 1}).name
+		frappe.get_doc(
+			{
+				"doctype": "Item Lead Time",
+				"item_code": item,
+				"manufacturing_time_in_mins": 7,
+				"buffer_time": 2,
+			}
+		).insert()
+
+		lead_time = get_item_lead_time(item, "Manufacture")
+		# 1440 / 7 + 2 = 207.714...; a truncating integer division on Postgres would give 207.
+		self.assertAlmostEqual(float(lead_time), 1440 / 7 + 2, places=2)


### PR DESCRIPTION
Found by an exhaustive whole-repo MariaDB↔PostgreSQL scan. **Two siblings** of the same int-division bug — both pre-existing, both PostgreSQL-only. One commit per file.

Both compute a lead time from `Item Lead Time.manufacturing_time_in_mins` (an **Int** column) divided by `1440` (an int literal). pypika emits a bare SQL `/`: **MariaDB**'s `/` yields a decimal, **PostgreSQL** truncates integer/integer. The value is `math.ceil()`'d and drives a `release_date = add_days(delivery_date, -lead_time)`, so the planned/order-release date **differs by a day between engines**.

### 1. `material_requirements_planning_report.py` — `get_item_lead_time`
`1440 / manufacturing_time_in_mins + buffer_time` → PG `1440/7 = 205`, MariaDB `205.71`.

### 2. `master_production_schedule.py` — `get_item_lead_time`
`manufacturing_time_in_mins / 1440 + purchase_time + buffer_time` → PG `720/1440 = 0`, MariaDB `0.5`.

### Fix
Make the literal a float (`1440.0`) so both engines do decimal division. MariaDB already returned a decimal, so its output is **unchanged**; PostgreSQL now matches it.

### Verification
Runtime-checked on dedicated MariaDB + PostgreSQL test sites. Each fix has a regression test (`test_manufacture_lead_time_is_not_int_truncated`, `test_cumulative_lead_time_is_not_int_truncated`) that **fails on PostgreSQL** when the float is reverted (`207.0 != 207.71`; `0.0 != 0.5`) and passes on MariaDB regardless.