### PR TITLE
fix(manufacturing): keep MPS cumulative lead-time fractional across engines

### DIFF
--- a/erpnext/manufacturing/doctype/master_production_schedule/master_production_schedule.py
+++ b/erpnext/manufacturing/doctype/master_production_schedule/master_production_schedule.py
@@ -453,7 +453,7 @@ def get_item_lead_time(item_code):
 	query = (
 		frappe.qb.from_(doctype)
 		.select(
-			((doctype.manufacturing_time_in_mins / 1440) + doctype.purchase_time + doctype.buffer_time).as_(
+			((doctype.manufacturing_time_in_mins / 1440.0) + doctype.purchase_time + doctype.buffer_time).as_(
 				"cumulative_lead_time"
 			)
 		)

--- a/erpnext/manufacturing/doctype/master_production_schedule/test_master_production_schedule.py
+++ b/erpnext/manufacturing/doctype/master_production_schedule/test_master_production_schedule.py
@@ -16,6 +16,8 @@ class TestMasterProductionSchedule(ERPNextTestSuite):
 		manufacturing_time_in_mins is an Int column; integer/integer division truncates on
 		PostgreSQL (720/1440 -> 0) while MariaDB yields 0.5, changing the planned release date."""
 		item = make_item("_Test MPS Lead Time Item", {"is_stock_item": 1}).name
+		# idempotent across re-runs / a shared CI database
+		frappe.db.delete("Item Lead Time", {"item_code": item})
 		frappe.get_doc(
 			{
 				"doctype": "Item Lead Time",

--- a/erpnext/manufacturing/doctype/master_production_schedule/test_master_production_schedule.py
+++ b/erpnext/manufacturing/doctype/master_production_schedule/test_master_production_schedule.py
@@ -1,4 +1,29 @@
 # Copyright (c) 2025, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
 
-# import frappe
+import frappe
+
+from erpnext.manufacturing.doctype.master_production_schedule.master_production_schedule import (
+	get_item_lead_time,
+)
+from erpnext.stock.doctype.item.test_item import make_item
+from erpnext.tests.utils import ERPNextTestSuite
+
+
+class TestMasterProductionSchedule(ERPNextTestSuite):
+	def test_cumulative_lead_time_is_not_int_truncated(self):
+		"""cumulative_lead_time = manufacturing_time_in_mins / 1440 + purchase_time + buffer_time.
+		manufacturing_time_in_mins is an Int column; integer/integer division truncates on
+		PostgreSQL (720/1440 -> 0) while MariaDB yields 0.5, changing the planned release date."""
+		item = make_item("_Test MPS Lead Time Item", {"is_stock_item": 1}).name
+		frappe.get_doc(
+			{
+				"doctype": "Item Lead Time",
+				"item_code": item,
+				"manufacturing_time_in_mins": 720,
+				"purchase_time": 0,
+				"buffer_time": 0,
+			}
+		).insert()
+		# 720 / 1440 = 0.5; a truncating integer division on PostgreSQL would give 0.
+		self.assertAlmostEqual(float(get_item_lead_time(item)), 0.5, places=2)


### PR DESCRIPTION
Sibling of the Material Requirements Planning report lead-time fix (#56343); found by the same whole-repo MariaDB↔PostgreSQL scan. Pre-existing, PostgreSQL-only.

### Problem

`get_item_lead_time` in Master Production Schedule computes:

```python
(manufacturing_time_in_mins / 1440) + purchase_time + buffer_time
```

`manufacturing_time_in_mins` is an **Int** column and `1440` an int literal, so pypika emits a bare SQL `/`. **MariaDB**'s `/` yields a decimal (`720/1440 = 0.5`); **PostgreSQL** truncates integer/integer (`720/1440 = 0`). The value is summed over the BOM tree in `get_cumulative_lead_time()`, `math.ceil()`'d, and drives `order_release_date = add_days(delivery_date, -cumulative_lead_time)` shown on the MPS items table — so the planned release date **differs by a day between engines**.

### Fix

Make the literal a float (`1440.0`) so the division is decimal on both engines. MariaDB already returned a decimal, so its output is **unchanged**; PostgreSQL now matches it. (Mirrors #56343, which applied the same fix to the MRP report.)

### Verification

Runtime-checked on dedicated MariaDB + PostgreSQL test sites. Added `test_cumulative_lead_time_is_not_int_truncated` (creates an Item Lead Time with `manufacturing_time_in_mins=720`, asserts `get_item_lead_time(...) ≈ 0.5`); it **fails on PostgreSQL** (`0.0 != 0.5`) when the float is reverted, and passes on MariaDB regardless.