### PR TITLE
fix: whitelist `get_tax_rate`

### DIFF
--- a/erpnext/accounts/services/taxes.py
+++ b/erpnext/accounts/services/taxes.py
@@ -177,6 +177,7 @@ class TaxService:
 		return amount, base_amount
 
 
+@frappe.whitelist()
 def get_tax_rate(account_head: str) -> dict:
 	return frappe.get_cached_value("Account", account_head, ["tax_rate", "account_name"], as_dict=True)
 


### PR DESCRIPTION
Introduced by https://github.com/frappe/erpnext/commit/29261c5fc2a417fd8f9226236eb8e4330f7e2879

<img width="1278" height="399" alt="image" src="https://github.com/user-attachments/assets/404934a7-30dd-42a4-a6bf-1dda589c4381" />

Traceback:
```
Traceback (most recent call last):
  File "apps/frappe/frappe/app.py", line 125, in application
    response = frappe.api.handle(request)
  File "apps/frappe/frappe/api/__init__.py", line 64, in handle
    data = endpoint(**arguments)
  File "apps/frappe/frappe/api/v1.py", line 40, in handle_rpc_call
    return frappe.handler.handle()
           ~~~~~~~~~~~~~~~~~~~~~^^
  File "apps/frappe/frappe/handler.py", line 54, in handle
    data = execute_cmd(cmd)
  File "apps/frappe/frappe/handler.py", line 84, in execute_cmd
    is_whitelisted(method)
    ~~~~~~~~~~~~~~^^^^^^^^
  File "apps/frappe/frappe/__init__.py", line 614, in is_whitelisted
    throw(msg, PermissionError, title=_("Method Not Allowed"))
    ~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/utils/messages.py", line 159, in throw
    msgprint(
    ~~~~~~~~^
    	msg,
     ^^^^
    ...<7 lines>...
    	allow_dangerous_html=allow_dangerous_html,
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "apps/frappe/frappe/utils/messages.py", line 118, in msgprint
    _raise_exception()
    ~~~~~~~~~~~~~~~~^^
  File "apps/frappe/frappe/utils/messages.py", line 59, in _raise_exception
    raise exc
frappe.exceptions.PermissionError: You are not permitted to access this resource. Login to accessFunction erpnext.accounts.services.taxes.get_tax_rate is not whitelisted.
```