### PR TITLE
fix(stock): guard batchwise valuation-rate division against a zero divisor (Postgres)

### DIFF
--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -10,7 +10,7 @@ import frappe
 from frappe import _, bold, scrub
 from frappe.model.meta import get_field_precision
 from frappe.query_builder import Order
-from frappe.query_builder.functions import Lower, Sum
+from frappe.query_builder.functions import Lower, NullIf, Sum
 from frappe.utils import (
 	cint,
 	flt,
@@ -1975,7 +1975,7 @@ def get_valuation_rate(
 		table = frappe.qb.DocType("Stock Ledger Entry")
 		query = (
 			frappe.qb.from_(table)
-			.select(Sum(table.stock_value_difference) / Sum(table.actual_qty))
+			.select(Sum(table.stock_value_difference) / NullIf(Sum(table.actual_qty), 0))
 			.where(
 				(table.item_code == item_code)
 				& (table.warehouse == warehouse)


### PR DESCRIPTION
Found by the whole-repo MariaDB↔PostgreSQL audit. Pre-existing, PostgreSQL-only.

### Problem

`get_valuation_rate`'s batchwise fallback (`erpnext/stock/stock_ledger.py`) selects:

```python
Sum(table.stock_value_difference) / Sum(table.actual_qty)
```

When a batch's non-current Stock Ledger Entries net to **zero quantity** (equal received and issued), the divisor `Sum(actual_qty)` is `0`. On **MariaDB** `x / 0` yields `NULL`, and the caller's `if last_valuation_rate and last_valuation_rate[0][0] is not None` check absorbs it and falls through to the next valuation strategy. On **PostgreSQL** float division by zero raises:

```
psycopg2.errors.DivisionByZero: division by zero
```

— aborting the query (and the surrounding transaction). Reached when `warehouse` + `batch_no` are set and the Batch has `use_batchwise_valuation`.

### Fix

Wrap the divisor in `NullIf(Sum(actual_qty), 0)` so a zero divisor yields `NULL` on **both** engines, matching MariaDB and preserving the caller's is-not-None fall-through.

### Verification

Runtime-checked on both engines: a non-NULL numerator over a zero divisor (`5.0/0`) raises `DivisionByZero` on PostgreSQL but returns `NULL` on MariaDB; `5.0 / NULLIF(0, 0)` returns `NULL` on both. (`stock_value_difference` is Currency and `actual_qty` is Float, so the division was already float — no integer-truncation change.) The trigger is a rare valuation edge case (value ≠ 0 while net qty = 0) that isn't deterministically reproducible in a fixture, so this relies on the SQL-level proof; `NullIf` is the standard portable guard.