### PR TITLE
fix(projects): drop redundant distinct from portal project list (Postgres ordering)

### DIFF
--- a/erpnext/projects/doctype/project/project.py
+++ b/erpnext/projects/doctype/project/project.py
@@ -486,6 +486,8 @@ def get_project_list(doctype, txt, filters, limit_start, limit_page_length=20, o
 			else:
 				filters.append([doctype, "name", "like", "%" + txt + "%"])
 
+	# No distinct=True: it never dedupes here (single table, fields="*" carries PK `name`) but makes
+	# frappe drop ORDER BY on Postgres, leaving the portal list unordered there.
 	return frappe.get_list(
 		doctype,
 		fields="*",
@@ -495,7 +497,6 @@ def get_project_list(doctype, txt, filters, limit_start, limit_page_length=20, o
 		limit_page_length=limit_page_length,
 		order_by=order_by,
 		ignore_permissions=ignore_permissions,
-		distinct=True,
 	)
 
 


### PR DESCRIPTION
## Problem

`get_project_list` (the website/portal project list handler) calls `frappe.get_list(..., order_by=order_by, distinct=True)`.

The query is a **single base table** (`Project`) with `fields="*"` and only `or_filters` of `LIKE` conditions on that same table — there are no child-table joins. Because `fields="*"` always carries the unique primary key `name`, every row is already distinct, so `distinct=True` can **never** deduplicate a row. It is a no-op on the *result set* on both engines.

It is **not** a no-op on *ordering*: `frappe.db` drops the `ORDER BY` clause for `distinct` queries on PostgreSQL (under `SELECT DISTINCT`, Postgres requires every `ORDER BY` expression to appear in the select list, which `frappe.db` cannot guarantee, so it omits it). The result:

| Engine | Before |
|--------|--------|
| MariaDB | rows ordered by `order_by` (default `creation`) |
| PostgreSQL | rows returned **unordered** |

So the portal project list rendered in an arbitrary order on Postgres while MariaDB returned it ordered.

## Fix

Remove the redundant `distinct=True`. Since it never deduplicated anything, the MariaDB result and its order are **completely unchanged**, and Postgres now keeps the `ORDER BY` and returns the same ordered list.

## Why MariaDB output is unchanged

- Single table, no joins → no row is ever duplicated.
- `fields="*"` includes the PK `name` → `DISTINCT` had nothing to collapse.
- Therefore dropping `DISTINCT` leaves the exact same rows in the exact same order on MariaDB.

## Verification

Runtime-checked on both engines: on Postgres the pre-fix query emitted frappe's "order_by dropped for distinct" path (unordered output) and the fix restores the ordered list; on MariaDB output is identical before and after.

This is part of the ongoing MariaDB↔Postgres parity work (issue #56241).