### PR TITLE
fix(manufacturing): make item_code mandatory in Job Card Item

### DIFF
--- a/erpnext/manufacturing/doctype/job_card_item/job_card_item.json
+++ b/erpnext/manufacturing/doctype/job_card_item/job_card_item.json
@@ -27,7 +27,8 @@
    "fieldtype": "Link",
    "in_list_view": 1,
    "label": "Item Code",
-   "options": "Item"
+   "options": "Item",
+   "reqd": 1
   },
   {
    "fieldname": "source_warehouse",
@@ -115,7 +116,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-05-12 12:22:18.506904",
+ "modified": "2026-06-23 16:52:37.669110",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "Job Card Item",

--- a/erpnext/manufacturing/doctype/job_card_item/job_card_item.py
+++ b/erpnext/manufacturing/doctype/job_card_item/job_card_item.py
@@ -17,7 +17,7 @@ class JobCardItem(Document):
 		allow_alternative_item: DF.Check
 		consumed_qty: DF.Float
 		description: DF.Text | None
-		item_code: DF.Link | None
+		item_code: DF.Link
 		item_group: DF.Link | None
 		item_name: DF.Data | None
 		parent: DF.Data


### PR DESCRIPTION
Issue: In the Job Card Item child table, the item_code field is currently optional. This allows a job card to be saved with a raw material row without a linked item, resulting in incomplete or invalid manufacturing data.

Before : 

<img width="1310" height="780" alt="image" src="https://github.com/user-attachments/assets/d643a012-6872-407a-b927-35e5fea38d91" />


After:

<img width="1827" height="916" alt="image" src="https://github.com/user-attachments/assets/78b15dfe-7075-4b94-911a-bde654fdb0ed" />


Backport Needed For V15 and V16