### PR TITLE
feat: warn when a draft linked document already exists

### DIFF
--- a/erpnext/controllers/queries.py
+++ b/erpnext/controllers/queries.py
@@ -1201,3 +1201,62 @@ def get_warehouse_address(doctype: str, txt: str, searchfield: str, start: int, 
 		.limit(page_len)
 	)
 	return query.run(as_list=1)
+
+
+@frappe.whitelist()
+def get_draft_linked_docs(source_doctype: str, source_name: str, target_doctype: str) -> list[dict]:
+	"""
+	Return draft (docstatus=0) documents of *target_doctype* that were created
+	from *source_name*.  The lookup walks every child-table Link field in the
+	target DocType that points back to *source_doctype*, so it works generically
+	for any SO→DN / SO→SI / PO→PR / PO→PI / DN→SI … relationship.
+
+	Returns an empty list (never raises) when the target DocType doesn't exist
+	or the caller has no permission — this is intentional because the JS side
+	infers the DocType name from the mapper method string and may get it wrong
+	for edge cases (e.g. plural method names like make_work_orders).
+	"""
+	if not frappe.has_permission(target_doctype):
+		return []
+
+	try:
+		target_meta = frappe.get_meta(target_doctype)
+	except frappe.DoesNotExistError:
+		return []
+
+	draft_names: set[str] = set()
+
+	for table_df in target_meta.get_table_fields():
+		try:
+			child_meta = frappe.get_meta(table_df.options)
+		except frappe.DoesNotExistError:
+			continue
+
+		for child_df in child_meta.fields:
+			filters = None
+
+			if child_df.fieldtype == "Link" and child_df.options == source_doctype:
+				# Direct link — e.g. Delivery Note Item.against_sales_order → Sales Order
+				filters = {child_df.fieldname: source_name}
+
+			elif child_df.fieldtype == "Dynamic Link":
+				# Polymorphic link — e.g. Payment Entry Reference.reference_name
+				# whose doctype is stored in the field named by child_df.options
+				# (e.g. reference_doctype).
+				doctype_field = child_df.options
+				filters = {doctype_field: source_doctype, child_df.fieldname: source_name}
+
+			if not filters:
+				continue
+
+			parents = frappe.get_all(
+				table_df.options,
+				filters=filters,
+				pluck="parent",
+				distinct=True,
+			)
+			for parent in parents:
+				if frappe.db.get_value(target_doctype, parent, "docstatus") == 0:
+					draft_names.add(parent)
+
+	return [{"name": n} for n in sorted(draft_names)]

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -2849,12 +2849,61 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 	make_mapped_payment_entry(args) {
 		var me = this;
 		args = args || { dt: this.frm.doc.doctype, dn: this.frm.doc.name };
-		return frappe.call({
-			method: me.get_method_for_payment(),
-			args: args,
-			callback: function (r) {
-				var doclist = frappe.model.sync(r.message);
-				frappe.set_route("Form", doclist[0].doctype, doclist[0].name);
+
+		const do_create = () => {
+			frappe.call({
+				method: me.get_method_for_payment(),
+				args: args,
+				callback: function (r) {
+					var doclist = frappe.model.sync(r.message);
+					frappe.set_route("Form", doclist[0].doctype, doclist[0].name);
+				},
+			});
+		};
+
+		// When the payment will be a Journal Entry, skip the PE draft check.
+		const via_je =
+			me.frm.doc.__onload && me.frm.doc.__onload.make_payment_via_journal_entry;
+		if (via_je) {
+			do_create();
+			return;
+		}
+
+		frappe.call({
+			method: "erpnext.controllers.queries.get_draft_linked_docs",
+			args: {
+				source_doctype: me.frm.doc.doctype,
+				source_name: me.frm.doc.name,
+				target_doctype: "Payment Entry",
+			},
+			callback(r) {
+				const drafts = (r.message || []).map((d) => d.name);
+				if (!drafts.length) {
+					do_create();
+					return;
+				}
+
+				const slug = frappe.router.slug("Payment Entry");
+				const links = drafts
+					.map(
+						(n) =>
+							`<a href="/app/${slug}/${encodeURIComponent(n)}" target="_blank">${frappe.utils.escape_html(n)}</a>`
+					)
+					.join(", ");
+
+				frappe.confirm(
+					__(
+						"There {0} already {1} draft {2}(s) for this {3}: {4}.<br><br>Do you still want to create a new one?",
+						[
+							drafts.length === 1 ? __("is") : __("are"),
+							drafts.length,
+							__("Payment Entry"),
+							__(me.frm.doc.doctype),
+							links,
+						]
+					),
+					do_create
+				);
 			},
 		});
 	}

--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -989,6 +989,77 @@ erpnext.utils.update_child_items = function (opts) {
 	dialog.show();
 };
 
+// ---------------------------------------------------------------------------
+// Global draft-document guard for frappe.model.open_mapped_doc
+//
+// Intercepts every "Create → <DocType>" action in ERPNext.  When a draft of
+// the target DocType that was already created from the same source document is
+// found, a dismissible confirmation dialog is shown before the form opens.
+//
+// Target DocType is inferred from the mapper method name:
+//   "…mapper.make_delivery_note"   → "Delivery Note"
+//   "…mapper.create_pick_list"     → "Pick List"
+// If inference fails or no link field is found the call passes through silently.
+// ---------------------------------------------------------------------------
+(function () {
+	const _orig = frappe.model.open_mapped_doc;
+
+	frappe.model.open_mapped_doc = function (opts) {
+		const frm = opts.frm;
+		if (!frm || !frm.doc || !frm.doc.name) {
+			return _orig.call(frappe.model, opts);
+		}
+
+		// Derive target DocType from the mapper method name.
+		// Supports both "make_*" and "create_*" prefixes.
+		const match = (opts.method || "").match(/\.(make|create)_([a-z0-9_]+)$/i);
+		if (!match) {
+			return _orig.call(frappe.model, opts);
+		}
+
+		const target_doctype = frappe.model.unscrub(match[2]);
+
+		frappe.call({
+			method: "erpnext.controllers.queries.get_draft_linked_docs",
+			args: {
+				source_doctype: frm.doc.doctype,
+				source_name: frm.doc.name,
+				target_doctype,
+			},
+			callback(r) {
+				const drafts = (r.message || []).map((d) => d.name);
+
+				if (!drafts.length) {
+					_orig.call(frappe.model, opts);
+					return;
+				}
+
+				const slug = frappe.router.slug(target_doctype);
+				const links = drafts
+					.map(
+						(n) =>
+							`<a href="/app/${slug}/${encodeURIComponent(n)}" target="_blank">${frappe.utils.escape_html(n)}</a>`
+					)
+					.join(", ");
+
+				frappe.confirm(
+					__(
+						"There {0} already {1} draft {2}(s) for this {3}: {4}.<br><br>Do you still want to create a new one?",
+						[
+							drafts.length === 1 ? __("is") : __("are"),
+							drafts.length,
+							__(target_doctype),
+							__(frm.doc.doctype),
+							links,
+						]
+					),
+					() => _orig.call(frappe.model, opts)
+				);
+			},
+		});
+	};
+})();
+
 erpnext.utils.map_current_doc = function (opts) {
 	function _map() {
 		if ($.isArray(cur_frm.doc.items) && cur_frm.doc.items.length > 0) {


### PR DESCRIPTION
## Summary

- Adds a dismissible confirmation dialog when a user attempts to create a follow-up document (e.g. Delivery Note from Sales Order, Payment Entry from Purchase Invoice) and a draft of that document already exists for the same source record.
- Warning shows clickable links to the existing draft(s) so the user can navigate directly to them.
- Warning only appears for **draft** documents — submitted documents are ignored, so normal workflows are not interrupted.

## Approach

**`erpnext/controllers/queries.py`** — New whitelisted API `get_draft_linked_docs(source_doctype, source_name, target_doctype)`. Walks child-table **Link** and **Dynamic Link** fields generically, covering both standard relationships (SO→DN via `against_sales_order`) and polymorphic ones (PI→PE via `Payment Entry Reference.reference_name`).

**`erpnext/public/js/utils.js`** — Global override of `frappe.model.open_mapped_doc`. Derives the target DocType from the mapper method name (e.g. `make_delivery_note` → `"Delivery Note"`) and runs the draft check before opening the form. Covers **all** `open_mapped_doc`-based flows with zero per-DocType code — SO→DN, SO→SI, SO→PO, SO→Pick List, PO→PR, PO→PI, PO→Subcontracting Order, DN→SI, PR→PI, Quotation→SO, and more.

**`erpnext/public/js/controllers/transaction.js`** — Explicit check in `make_mapped_payment_entry`, which uses `frappe.call` directly and bypasses `open_mapped_doc`.

## Test Plan

- [ ] Confirm a Sales Order → create a Delivery Note → save as draft → go back to SO → click Create > Delivery Note → warning dialog appears with link to the draft DN
- [ ] Confirm the warning dialog does **not** appear when the existing Delivery Note is submitted
- [ ] Confirm clicking **Yes** in the dialog proceeds to create a new document
- [ ] Confirm clicking **No** cancels without creating anything
- [ ] Submit a Purchase Invoice → create a Payment Entry → save as draft → go back to PI → click Create > Payment → warning dialog appears
- [ ] Verify the same behavior for PO→Purchase Receipt and PO→Purchase Invoice

Closes #48350

🤖 Generated with [Claude Code](https://claude.com/claude-code)