### PR TITLE
fix(accounts): stop coalescing a DATE with an int in Asset Depreciations report

### DIFF
--- a/erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py
+++ b/erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py
@@ -82,7 +82,7 @@ def get_asset_categories_for_grouped_by_category(filters):
 	asset_capitalization = frappe.qb.DocType("Asset Capitalization")
 
 	disposal_in_period = (
-		(IfNull(asset.disposal_date, 0) != 0)
+		(asset.disposal_date.isnotnull())
 		& (asset.disposal_date >= filters.from_date)
 		& (asset.disposal_date <= filters.to_date)
 	)
@@ -92,7 +92,7 @@ def get_asset_categories_for_grouped_by_category(filters):
 			frappe.qb.terms.Case()
 			.when(
 				(asset.purchase_date < filters.from_date)
-				& ((IfNull(asset.disposal_date, 0) == 0) | (asset.disposal_date >= filters.from_date)),
+				& ((asset.disposal_date.isnull()) | (asset.disposal_date >= filters.from_date)),
 				asset.net_purchase_amount,
 			)
 			.else_(0)
@@ -209,9 +209,7 @@ def get_assets_for_grouped_by_category(filters):
 					frappe.qb.terms.Case()
 					.when(
 						(gl_entry.posting_date < filters.from_date)
-						& (
-							(IfNull(asset.disposal_date, 0) == 0) | (asset.disposal_date >= filters.from_date)
-						),
+						& ((asset.disposal_date.isnull()) | (asset.disposal_date >= filters.from_date)),
 						gl_entry.debit,
 					)
 					.else_(0)
@@ -222,7 +220,7 @@ def get_assets_for_grouped_by_category(filters):
 				Sum(
 					frappe.qb.terms.Case()
 					.when(
-						(gl_entry.posting_date <= filters.to_date) & (IfNull(asset.disposal_date, 0) == 0),
+						(gl_entry.posting_date <= filters.to_date) & (asset.disposal_date.isnull()),
 						gl_entry.credit,
 					)
 					.else_(0)
@@ -233,7 +231,7 @@ def get_assets_for_grouped_by_category(filters):
 				Sum(
 					frappe.qb.terms.Case()
 					.when(
-						(IfNull(asset.disposal_date, 0) != 0)
+						(asset.disposal_date.isnotnull())
 						& (asset.disposal_date >= filters.from_date)
 						& (asset.disposal_date <= filters.to_date)
 						& (gl_entry.posting_date <= asset.disposal_date),
@@ -249,10 +247,7 @@ def get_assets_for_grouped_by_category(filters):
 					.when(
 						(gl_entry.posting_date >= filters.from_date)
 						& (gl_entry.posting_date <= filters.to_date)
-						& (
-							(IfNull(asset.disposal_date, 0) == 0)
-							| (gl_entry.posting_date <= asset.disposal_date)
-						),
+						& ((asset.disposal_date.isnull()) | (gl_entry.posting_date <= asset.disposal_date)),
 						gl_entry.debit,
 					)
 					.else_(0)
@@ -282,7 +277,7 @@ def get_assets_for_grouped_by_category(filters):
 				Sum(
 					frappe.qb.terms.Case()
 					.when(
-						(IfNull(asset.disposal_date, 0) != 0) & (asset.disposal_date < filters.from_date),
+						(asset.disposal_date.isnotnull()) & (asset.disposal_date < filters.from_date),
 						0,
 					)
 					.else_(asset.opening_accumulated_depreciation)
@@ -476,7 +471,7 @@ def get_asset_details_for_grouped_by_category(filters):
 	asset_capitalization = frappe.qb.DocType("Asset Capitalization")
 
 	disposal_in_period = (
-		(IfNull(asset.disposal_date, 0) != 0)
+		(asset.disposal_date.isnotnull())
 		& (asset.disposal_date >= filters.from_date)
 		& (asset.disposal_date <= filters.to_date)
 	)
@@ -500,9 +495,7 @@ def get_asset_details_for_grouped_by_category(filters):
 					frappe.qb.terms.Case()
 					.when(
 						(asset.purchase_date < filters.from_date)
-						& (
-							(IfNull(asset.disposal_date, 0) == 0) | (asset.disposal_date >= filters.from_date)
-						),
+						& ((asset.disposal_date.isnull()) | (asset.disposal_date >= filters.from_date)),
 						asset.net_purchase_amount,
 					)
 					.else_(0)
@@ -599,9 +592,7 @@ def get_assets_for_grouped_by_asset(filters):
 					frappe.qb.terms.Case()
 					.when(
 						(gl_entry.posting_date < filters.from_date)
-						& (
-							(IfNull(asset.disposal_date, 0) == 0) | (asset.disposal_date >= filters.from_date)
-						),
+						& ((asset.disposal_date.isnull()) | (asset.disposal_date >= filters.from_date)),
 						gl_entry.debit,
 					)
 					.else_(0)
@@ -612,7 +603,7 @@ def get_assets_for_grouped_by_asset(filters):
 				Sum(
 					frappe.qb.terms.Case()
 					.when(
-						(gl_entry.posting_date <= filters.to_date) & (IfNull(asset.disposal_date, 0) == 0),
+						(gl_entry.posting_date <= filters.to_date) & (asset.disposal_date.isnull()),
 						gl_entry.credit,
 					)
 					.else_(0)
@@ -623,7 +614,7 @@ def get_assets_for_grouped_by_asset(filters):
 				Sum(
 					frappe.qb.terms.Case()
 					.when(
-						(IfNull(asset.disposal_date, 0) != 0)
+						(asset.disposal_date.isnotnull())
 						& (asset.disposal_date >= filters.from_date)
 						& (asset.disposal_date <= filters.to_date)
 						& (gl_entry.posting_date <= asset.disposal_date),
@@ -639,10 +630,7 @@ def get_assets_for_grouped_by_asset(filters):
 					.when(
 						(gl_entry.posting_date >= filters.from_date)
 						& (gl_entry.posting_date <= filters.to_date)
-						& (
-							(IfNull(asset.disposal_date, 0) == 0)
-							| (gl_entry.posting_date <= asset.disposal_date)
-						),
+						& ((asset.disposal_date.isnull()) | (gl_entry.posting_date <= asset.disposal_date)),
 						gl_entry.debit,
 					)
 					.else_(0)
@@ -672,7 +660,7 @@ def get_assets_for_grouped_by_asset(filters):
 				Sum(
 					frappe.qb.terms.Case()
 					.when(
-						(IfNull(asset.disposal_date, 0) != 0) & (asset.disposal_date < filters.from_date),
+						(asset.disposal_date.isnotnull()) & (asset.disposal_date < filters.from_date),
 						0,
 					)
 					.else_(asset.opening_accumulated_depreciation)

--- a/erpnext/accounts/report/asset_depreciations_and_balances/test_asset_depreciations_and_balances.py
+++ b/erpnext/accounts/report/asset_depreciations_and_balances/test_asset_depreciations_and_balances.py
@@ -1,0 +1,26 @@
+# Copyright (c) 2024, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt
+
+import frappe
+
+from erpnext.accounts.report.asset_depreciations_and_balances.asset_depreciations_and_balances import (
+	execute,
+)
+from erpnext.tests.utils import ERPNextTestSuite
+
+
+class TestAssetDepreciationsAndBalancesReport(ERPNextTestSuite):
+	def test_report_runs_on_both_engines(self):
+		"""The report compared IfNull(asset.disposal_date, 0) against 0 -- coalescing a DATE
+		column with integer 0. Postgres rejects that (COALESCE types date and integer cannot be
+		matched) at plan time, so the whole report errored there regardless of data. It must run
+		on both engines."""
+		for group_by in ("Asset Category", "Asset"):
+			filters = frappe._dict(
+				company="_Test Company",
+				from_date="2020-01-01",
+				to_date="2030-12-31",
+				group_by=group_by,
+			)
+			result = execute(filters)
+			self.assertIsInstance(result[1], list)


### PR DESCRIPTION
## Problem

The **Asset Depreciations and Balances** report tests disposal status with `IfNull(asset.disposal_date, 0) != 0` / `== 0` (14 sites). `disposal_date` is a **Date** field, and `frappe.db`'s query builder renders `IfNull` → `COALESCE`, so this becomes `COALESCE("disposal_date", 0)` — coalescing a date with an integer.

PostgreSQL requires `COALESCE` arguments to share a type and raises:

```
DatatypeMismatch: COALESCE types date and integer cannot be matched
```

This predicate sits in the WHERE/CASE of **every** query the report runs (both `group_by` modes), so the **entire report errors on PostgreSQL**. MariaDB's `IFNULL`/`COALESCE` is permissive and returns a valid result.

Verified live on a PostgreSQL site (the report's `execute()` aborts) and on MariaDB (unchanged).

## Fix

These are pure NULL-presence tests, so replace them with the explicit null check the same file already uses elsewhere (`get_asset_value_adjustment_map` uses `asset.disposal_date.isnull()`):

- `IfNull(asset.disposal_date, 0) != 0` → `asset.disposal_date.isnotnull()`
- `IfNull(asset.disposal_date, 0) == 0` → `asset.disposal_date.isnull()`

A stored date is non-NULL **iff** `IFNULL(date, 0) != 0` (a real date never equals integer `0`), so MariaDB's result is identical, and PostgreSQL no longer sees a `date`/`int` `COALESCE`.

## Why MariaDB output is unchanged
Same rows selected: the null check is semantically identical to the old integer-presence test for a Date column. The `IfNull` import is kept — it is still used for the numeric `IfNull(Sum(...), 0)` aggregates.

## Verification
`test_report_runs_on_both_engines` runs the report on both engines: passes on MariaDB and PostgreSQL after the fix, and (revert-proven) errors on PostgreSQL with the old `IfNull(date, 0)` form.

Part of the ongoing parity work (issue #56241). Re-ships a fix that was dropped when an earlier combined PR (#56357) was closed during a code/tooling split.