### PR TITLE
fix: guard division-by-zero divisors across reports/doctypes (Postgres parity)

### DIFF
--- a/erpnext/accounts/doctype/exchange_rate_revaluation/exchange_rate_revaluation.py
+++ b/erpnext/accounts/doctype/exchange_rate_revaluation/exchange_rate_revaluation.py
@@ -605,7 +605,10 @@ def calculate_exchange_rate_using_last_gle(company, account, party_type, party):
 
 		last_exchange_rate = (
 			qb.from_(gl)
-			.select((gl.debit - gl.credit) / (gl.debit_in_account_currency - gl.credit_in_account_currency))
+			.select(
+				(gl.debit - gl.credit)
+				/ NullIf(gl.debit_in_account_currency - gl.credit_in_account_currency, 0)
+			)
 			.where(
 				(gl.voucher_type == voucher_type) & (gl.voucher_no == voucher_no) & (gl.account == account)
 			)

--- a/erpnext/manufacturing/doctype/bom/bom.py
+++ b/erpnext/manufacturing/doctype/bom/bom.py
@@ -9,7 +9,7 @@ import frappe
 from frappe import _, bold
 from frappe.model.document import Document
 from frappe.query_builder import Field
-from frappe.query_builder.functions import Count, IfNull, Max, Min, Sum
+from frappe.query_builder.functions import Count, IfNull, Max, Min, NullIf, Sum
 from frappe.utils import cint, cstr, flt, get_link_to_form, parse_json
 from frappe.website.website_generator import WebsiteGenerator
 
@@ -1124,7 +1124,8 @@ def _get_avg_valuation_rate_from_bins(item_code, company, data):
 		.select(
 			Case()
 			.when(
-				Count(bin_table.name) > 0, IfNull(Sum(bin_table.stock_value) / Sum(bin_table.actual_qty), 0.0)
+				Count(bin_table.name) > 0,
+				IfNull(Sum(bin_table.stock_value) / NullIf(Sum(bin_table.actual_qty), 0), 0.0),
 			)
 			.else_(None)
 			.as_("valuation_rate")

--- a/erpnext/selling/report/lost_quotations/lost_quotations.py
+++ b/erpnext/selling/report/lost_quotations/lost_quotations.py
@@ -6,7 +6,7 @@ from typing import Literal
 import frappe
 from frappe import _
 from frappe.model.docstatus import DocStatus
-from frappe.query_builder.functions import Coalesce, Count, Round, Sum
+from frappe.query_builder.functions import Coalesce, Count, NullIf, Round, Sum
 from frappe.utils.data import get_timespan_date_range
 
 
@@ -86,7 +86,7 @@ def get_data(company: str, from_date: str, to_date: str, group_by: Literal["Lost
 			# `* 100.0` before dividing: count/count is integer division on Postgres (truncates to 0)
 			Round((Count(q.name).distinct() * 100.0 / total_quotations), 2),
 			Sum(q.base_net_total),
-			Round((Sum(q.base_net_total) / total_value * 100), 2),
+			Round((Sum(q.base_net_total) / NullIf(total_value, 0) * 100), 2),
 		)
 		.left_join(dimension)
 		.on(dimension.parent == q.name)

--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
@@ -383,7 +383,7 @@ class PurchaseReceipt(BuyingController):
 		self.update_received_qty_if_from_pp()
 
 	def update_received_qty_if_from_pp(self):
-		from frappe.query_builder.functions import Coalesce, Sum
+		from frappe.query_builder.functions import Coalesce, NullIf, Sum
 
 		items_from_po = [item.purchase_order_item for item in self.items if item.purchase_order_item]
 		if items_from_po:
@@ -404,7 +404,9 @@ class PurchaseReceipt(BuyingController):
 					frappe.qb.from_(table)
 					.select(
 						table.production_plan_sub_assembly_item,
-						Sum(table.received_qty / (table.qty / table.fg_item_qty)).as_("received_qty"),
+						Sum(table.received_qty / NullIf(table.qty / NullIf(table.fg_item_qty, 0), 0)).as_(
+							"received_qty"
+						),
 					)
 					.where(table.production_plan_sub_assembly_item.isin(result))
 					.groupby(table.production_plan_sub_assembly_item)

--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -11,7 +11,7 @@ from frappe.model import child_table_fields, default_fields
 from frappe.model.document import Document
 from frappe.model.meta import get_field_precision
 from frappe.model.utils import get_fetch_values
-from frappe.query_builder.functions import IfNull, Sum
+from frappe.query_builder.functions import IfNull, NullIf, Sum
 from frappe.utils import add_days, add_months, cint, cstr, flt, get_link_to_form, getdate, parse_json
 
 import erpnext
@@ -1734,7 +1734,7 @@ def get_valuation_rate(item_code: str, company: str, warehouse: str | None = Non
 		pi_item = frappe.qb.DocType("Purchase Invoice Item")
 		valuation_rate = (
 			frappe.qb.from_(pi_item)
-			.select(Sum(pi_item.base_net_amount) / Sum(pi_item.qty * pi_item.conversion_factor))
+			.select(Sum(pi_item.base_net_amount) / NullIf(Sum(pi_item.qty * pi_item.conversion_factor), 0))
 			.where((pi_item.docstatus == 1) & (pi_item.item_code == item_code))
 		).run()
 

--- a/erpnext/stock/report/incorrect_serial_no_valuation/incorrect_serial_no_valuation.py
+++ b/erpnext/stock/report/incorrect_serial_no_valuation/incorrect_serial_no_valuation.py
@@ -115,7 +115,7 @@ def get_stock_ledger_entries(report_filters):
 		"posting_time",
 		"company",
 		"warehouse",
-		{"DIV": ["stock_value_difference", "actual_qty"], "as": "valuation_rate"},
+		{"DIV": ["stock_value_difference", {"NULLIF": ["actual_qty", 0]}], "as": "valuation_rate"},
 	]
 
 	filters = {"is_cancelled": 0}


### PR DESCRIPTION
## Problem

`x / 0` behaves differently on the two engines:

| Engine | `x / 0` |
|--------|---------|
| MariaDB | returns `NULL` |
| PostgreSQL | raises `division by zero` and **aborts the query** |

A whole-repo parity scan found six places that divide by an aggregate or column the data can drive to zero, with no guard. On MariaDB they silently produce `NULL` (and downstream `IfNull`/`or 0.0`/`Sum` absorb it); on PostgreSQL the report or document operation errors out.

## Fix (one commit per file)

Each divisor is wrapped in `NullIf(divisor, 0)`. Since MariaDB **already** returns `NULL` for division by zero, making that `NULL` explicit changes nothing on MariaDB — only PostgreSQL stops erroring (it now also yields `NULL`, matching MariaDB).

| File | Divisor that can be 0 |
|------|------------------------|
| `accounts/.../exchange_rate_revaluation.py` | last-GLE `debit_in_account_currency - credit_in_account_currency` (re-selected row drops the `> 0` filter) |
| `manufacturing/.../bom.py` | `Sum(actual_qty)` of an item's **bins** (`Count>0` only proves a bin exists; on-hand stock can be 0) |
| `selling/report/lost_quotations` | `Sum(base_net_total)` subquery (all-zero-amount period) |
| `stock/.../purchase_receipt.py` | PP `qty / fg_item_qty` |
| `stock/report/incorrect_serial_no_valuation` | `actual_qty` (valuation-only SLE has `actual_qty = 0`) |
| `stock/get_item_details.py` | `Sum(qty * conversion_factor)` over Purchase Invoice Items (returns carry negative qty and can net to 0) |

The `incorrect_serial_no_valuation` one uses the `get_all` nested form `{"DIV": [..., {"NULLIF": ["actual_qty", 0]}]}`, which renders `"stock_value_difference"/NULLIF("actual_qty",0)` (verified on a live PG site).

*(Two further BOM-report divisions by `bom.quantity`/`Sum(BOM Item.stock_qty)` were considered and **excluded**: BOM validates `quantity > 0` and BOM Item `qty > 0`, so those divisors cannot reach zero through the application — guarding them would be dead code.)*

## Why MariaDB output is unchanged
`NullIf(d, 0)` only differs from `d` when `d = 0`, and in that case MariaDB's `x / d` was already `NULL`. So every non-zero-divisor row is untouched, and the zero-divisor row stays `NULL` on MariaDB — identical output, no error on PostgreSQL.

## Verification
Each query verified to render `NULLIF` and run on a live PostgreSQL site. Same divide-by-zero class as the already-merged `stock_ledger.py` fix (#56361).

Part of issue #56241.