### PR TITLE
fix: two Postgres hard errors — Check-vs-bool and capital-cased fieldname

### DIFF
--- a/erpnext/selling/report/customer_wise_item_price/customer_wise_item_price.py
+++ b/erpnext/selling/report/customer_wise_item_price/customer_wise_item_price.py
@@ -62,7 +62,7 @@ def fetch_item_prices(
 	or_conditions = []
 	if items:
 		and_conditions.append(ip.item_code.isin([x.item_code for x in items]))
-		and_conditions.append(ip.selling.eq(True))
+		and_conditions.append(ip.selling.eq(1))
 
 		or_conditions.append(ip.customer.isnull())
 		or_conditions.append(ip.price_list.isnull())

--- a/erpnext/setup/doctype/employee/employee.py
+++ b/erpnext/setup/doctype/employee/employee.py
@@ -427,7 +427,7 @@ def is_holiday(employee, date=None, raise_exception=True, only_non_weekly=False,
 def deactivate_sales_person(status: str, employee: str):
 	frappe.has_permission("Employee", doc=employee, ptype="write", throw=True)
 	if status == "Left":
-		sales_person = frappe.db.get_value("Sales Person", {"Employee": employee})
+		sales_person = frappe.db.get_value("Sales Person", {"employee": employee})
 		if sales_person:
 			frappe.db.set_value("Sales Person", sales_person, "enabled", 0)
 


### PR DESCRIPTION
## Problem

Two unrelated queries error on PostgreSQL (verified live):

### 1. `customer_wise_item_price` — Check field compared with a Python bool
`ip.selling.eq(True)` → `WHERE "selling" = true`. `selling` is a Check field (`smallint` on Postgres):
```
operator does not exist: smallint = boolean
```
MariaDB accepts it (`true` aliases to `1`).

### 2. `employee.deactivate_sales_person` — capital-cased fieldname in a filter
`frappe.db.get_value("Sales Person", {"Employee": employee})`. The Sales Person field is `employee` (lower case); the lookup runs with `ignore_permissions`, so the key reaches the query as the column `"Employee"`. PostgreSQL matches quoted identifiers case-sensitively:
```
column "Employee" does not exist
```
MariaDB resolves it case-insensitively.

## Fix (one commit per file)
- `ip.selling.eq(True)` → `ip.selling.eq(1)` — `selling = 1` selects identical rows on MariaDB, valid on Postgres.
- `{"Employee": employee}` → `{"employee": employee}` — the stored fieldname; same row on MariaDB, valid on Postgres.

## Why MariaDB output is unchanged
`selling = 1` and `selling = true` are the same predicate on MariaDB; `Employee`/`employee` resolve to the same column on MariaDB. Both fixes are no-ops there.

## Verification
Both reproduced erroring on a live PostgreSQL site before the change, and both fixed forms run clean on PostgreSQL after.

Part of issue #56241.