### PR TITLE
fix(stock): keep item-search ordering for Quality Inspection on Postgres

### DIFF
--- a/erpnext/stock/doctype/quality_inspection/quality_inspection.py
+++ b/erpnext/stock/doctype/quality_inspection/quality_inspection.py
@@ -413,16 +413,22 @@ def item_query(doctype: Any, txt: str | None, searchfield: Any, start: int, page
 				]
 			)
 
-		return frappe.get_query(
+		query = frappe.get_query(
 			reference_doctype,
 			fields=["items.item_code, items.item_name"],
 			filters=my_filters,
 			offset=start,
 			limit=page_len,
-			order_by="items.item_code",
 			ignore_permissions=False,
 			distinct=True,
-		).run()
+		)
+		# frappe's db_query drops ORDER BY for a distinct query on Postgres, which (with offset/limit)
+		# changes both the order and the page contents vs MariaDB. Appending the order to the built
+		# query instead keeps it -- item_code is in the DISTINCT select, so it is valid on Postgres.
+		items_field = frappe.get_meta(reference_doctype).get_field("items")
+		if items_field:
+			query = query.orderby(frappe.qb.DocType(items_field.options).item_code)
+		return query.run()
 
 
 @frappe.whitelist()


### PR DESCRIPTION
## Problem

The Quality Inspection item link-field search (`item_query`) runs a **distinct, paginated** `frappe.get_query(... order_by="items.item_code", distinct=True, offset=start, limit=page_len)`.

frappe's `db_query` **silently drops the `ORDER BY` for a `distinct` query on PostgreSQL**. Combined with `offset`/`limit`, PostgreSQL returns the suggestions in a different **order** *and* a different **page slice** than MariaDB (which keeps the `ORDER BY`). Verified live: on PostgreSQL the emitted SQL is `SELECT DISTINCT ... LIMIT n` with no `ORDER BY`.

## Fix

Append the ordering to the built query instead of passing `order_by=`:

```python
child = frappe.qb.DocType(frappe.get_meta(reference_doctype).get_field("items").options)
return frappe.get_query(..., distinct=True).orderby(child.item_code).run()
```

`item_code` is already in the `DISTINCT` select list, so `ORDER BY item_code` is valid under `DISTINCT` on PostgreSQL, and it now applies **before** `LIMIT` on both engines — so the same page of suggestions comes back in the same order.

## Why MariaDB output is unchanged
The query was already ordered by `item_code` on MariaDB; this just guarantees that ordering survives to PostgreSQL. Verified both engines now emit `ORDER BY "...Item"."item_code"` and run clean.

Part of issue #56241.