### PR TITLE
fix(postgres): three parity fixes — POS NULL ordering, traceability div-by-zero, LIKE on non-text

### DIFF
--- a/erpnext/accounts/doctype/financial_report_template/financial_report_engine.py
+++ b/erpnext/accounts/doctype/financial_report_template/financial_report_engine.py
@@ -12,8 +12,9 @@ from typing import Any, Union
 import frappe
 from frappe import _
 from frappe.database.operator_map import OPERATOR_MAP
+from frappe.model import numeric_fieldtypes
 from frappe.query_builder import Case
-from frappe.query_builder.functions import Sum
+from frappe.query_builder.functions import Cast_, Sum
 from frappe.utils import cstr, date_diff, flt, getdate
 from frappe.utils.xlsxutils import XLSXMetadata, XLSXStyleBuilder
 from pypika.terms import Bracket, LiteralValue
@@ -864,8 +865,15 @@ class FilterExpressionParser:
 		field = getattr(table, field_name, None)
 		operator_fn = OPERATOR_MAP.get(operator.casefold())
 
-		if "like" in operator.casefold() and "%" not in value:
-			value = f"%{value}%"
+		if "like" in operator.casefold():
+			if "%" not in value:
+				value = f"%{value}%"
+			# Postgres has no LIKE/ILIKE operator for non-text columns; MariaDB implicitly casts
+			# the numeric column to text. Cast a numeric/Check Account field to varchar so the
+			# match runs on both engines and reproduces MariaDB's result.
+			meta_field = frappe.get_meta("Account").get_field(field_name)
+			if meta_field and meta_field.fieldtype in numeric_fieldtypes:
+				field = Cast_(field, "varchar")
 
 		return operator_fn(field, value)
 

--- a/erpnext/selling/page/point_of_sale/point_of_sale.py
+++ b/erpnext/selling/page/point_of_sale/point_of_sale.py
@@ -6,6 +6,7 @@ import json
 
 import frappe
 from frappe.query_builder import Criterion, DocType, Order
+from frappe.query_builder.functions import Coalesce
 from frappe.utils import cint, get_datetime
 from frappe.utils.nestedset import get_root_of
 
@@ -231,7 +232,10 @@ def get_items(
 			.where(ItemPrice.selling == 1)
 			.where((ItemPrice.valid_from <= current_date) | (ItemPrice.valid_from.isnull()))
 			.where((ItemPrice.valid_upto >= current_date) | (ItemPrice.valid_upto.isnull()))
-			.orderby(ItemPrice.valid_from, order=Order.desc)
+			# Coalesce so a NULL valid_from (open-ended base price) sorts last under DESC on both
+			# engines: MariaDB already sorts NULL last for DESC, Postgres defaults to NULLS FIRST, which
+			# would otherwise make the base price win the positional pick over a dated override.
+			.orderby(Coalesce(ItemPrice.valid_from, "1900-01-01"), order=Order.desc)
 		).run(as_dict=True)
 
 		stock_uom_price = next((d for d in item_prices if d.get("uom") == item.stock_uom), {})

--- a/erpnext/stock/report/serial_no_and_batch_traceability/serial_no_and_batch_traceability.py
+++ b/erpnext/stock/report/serial_no_and_batch_traceability/serial_no_and_batch_traceability.py
@@ -4,6 +4,7 @@
 import frappe
 from frappe import _
 from frappe.query_builder import Case
+from frappe.query_builder.functions import NullIf
 
 
 def execute(filters: dict | None = None):
@@ -300,9 +301,12 @@ class ReportData:
 				(
 					(
 						stock_entry_detail.qty
-						/ Case()
-						.when(stock_entry.fg_completed_qty > 0, stock_entry.fg_completed_qty)
-						.else_(sabb_data.qty)
+						/ NullIf(
+							Case()
+							.when(stock_entry.fg_completed_qty > 0, stock_entry.fg_completed_qty)
+							.else_(sabb_data.qty),
+							0,
+						)
 					)
 					* sabb_data.qty
 				).as_("qty"),


### PR DESCRIPTION
Three independent MariaDB↔PostgreSQL divergences found by a whole-repo parity audit, each adjudicated live on both engines. One commit per file.

### 1. POS item-price NULL ordering (silent divergence) — `point_of_sale.py`
`get_items` keeps Item Price rows with `valid_from IS NULL` (open-ended base price) alongside dated rows, orders by `valid_from DESC`, then picks the first matching UOM **positionally** (`next()`/`[0]`). MariaDB sorts NULL **last** for DESC, so a dated override wins; PostgreSQL defaults to **NULLS FIRST** for DESC, so the base price wins — the POS shows a **different price** on the two engines for an item that has both an undated and a dated price.
**Fix:** `Coalesce(valid_from, "1900-01-01")` in the ORDER BY → NULL sorts last on both. MariaDB already did this, so its pick is unchanged.

### 2. Serial/Batch Traceability division-by-zero (hard error) — `serial_no_and_batch_traceability.py`
`get_materials` divides `qty` by a CASE that falls back to `sabb_data.qty` when `fg_completed_qty <= 0` (a branch the code explicitly anticipates). Neither value is constrained non-zero, so the divisor can be 0 → PostgreSQL `division by zero` aborts the report; MariaDB returns NULL.
**Fix:** wrap the CASE in `NullIf(..., 0)` — NULL on both, MariaDB unchanged.

### 3. LIKE on a non-text Account field (hard error) — `financial_report_engine.py`
Financial Report Template `calculation_formula` filters are user-authored and validated only for field existence + operator membership. A filter like `["is_group", "like", "1"]` builds `is_group ILIKE '%1%'`; PostgreSQL has no `smallint ~~* unknown` operator and aborts, while MariaDB implicitly casts. 
**Fix:** for like-family operators, cast a numeric/Check Account field to `varchar` (`Cast_(field, "varchar")`), reproducing MariaDB's implicit coercion. Text-field filters (the normal case) are untouched.

## Verification
Each reproduced on a live PostgreSQL site (erroring / diverging) before, and verified to render the corrected SQL and run after. MariaDB output unchanged in all three (the only NULL-ordering change matches MariaDB's existing DESC behaviour).

Part of issue #56241. These are the audit-13 findings; the critic's two re-flagged BOM divisions were rejected as false positives (BOM validates `quantity > 0` and item `qty > 0`).