### PR TITLE
fix: correct doctype in pcv processing permission check

### DIFF
--- a/erpnext/accounts/doctype/process_period_closing_voucher/process_period_closing_voucher.py
+++ b/erpnext/accounts/doctype/process_period_closing_voucher/process_period_closing_voucher.py
@@ -92,7 +92,7 @@ class ProcessPeriodClosingVoucher(Document):
 @frappe.whitelist()
 def start_pcv_processing(docname: str):
 	if frappe.db.get_value("Process Period Closing Voucher", docname, "status") in ["Queued", "Running"]:
-		frappe.has_permission("Process Payment Reconciliation", "write", doc=docname, throw=True)
+		frappe.has_permission("Process Period Closing Voucher", "write", doc=docname, throw=True)
 		frappe.db.set_value("Process Period Closing Voucher", docname, "status", "Running")
 
 		ppcvd = qb.DocType("Process Period Closing Voucher Detail")


### PR DESCRIPTION
Issue:

PCV submission fails with error "Process Payment Reconciliation Process-PCV-XXX not found" due to an incorrect doctype reference in the permission check. The system is validating permissions against the wrong doctype (Process Payment Reconciliation) instead of Process Period Closing Voucher. Because of this mismatch, it attempts to fetch a document under an incorrect doctype, resulting in a failed document retrieval and causing the submission to fail

Ref: [#71723](https://support.frappe.io/helpdesk/tickets/71723)

**PCV**

<img width="1600" height="746" alt="WhatsApp Image 2026-06-23 at 19 37 18" src="https://github.com/user-attachments/assets/1d6f1a87-5e7d-4a63-aa81-981ada0d706d" />


Raising this PR on behalf of @ssakthivelmurugan

Backport needed for v15 & v16