### PR TITLE
fix(stock): make get_item_price NULL ordering match across engines (Postgres)

### DIFF
--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -1234,7 +1234,10 @@ def get_item_price(
 			& (ip.price_list == pctx.price_list)
 			& (IfNull(ip.uom, "").isin(["", pctx.uom]))
 		)
-		.orderby(ip.valid_from, order=frappe.qb.desc)
+		# IfNull so a NULL valid_from sorts last under DESC on both engines: MariaDB sorts NULL last
+		# for DESC, but Postgres defaults to NULLS FIRST, which would otherwise make a NULL-valid_from
+		# price win the LIMIT 1 over the most-recent dated price.
+		.orderby(IfNull(ip.valid_from, "1900-01-01"), order=frappe.qb.desc)
 		.orderby(IfNull(ip.batch_no, ""), order=frappe.qb.desc)
 		.orderby(ip.uom, order=frappe.qb.desc)
 		.limit(1)


### PR DESCRIPTION
## Problem

`get_item_price` (the core item-price resolver used across selling/buying) orders Item Price rows by `valid_from DESC` and takes `LIMIT 1` to pick the most-recent applicable price. NULL-`valid_from` rows (open-ended prices) are **not** filtered out — the transaction-date guard is `IfNull(valid_from, '2000-01-01') <= transaction_date`.

MariaDB sorts `NULL` **last** under `DESC`; PostgreSQL defaults to **NULLS FIRST**. So when an item/price_list/uom has both a **dated** price and a **NULL-valid_from** price, PostgreSQL's `LIMIT 1` returns the NULL one while MariaDB returns the most-recent dated one — a **silent price divergence** in normal use (`valid_from` is optional on Item Price).

## Fix

Wrap the sort key: `.orderby(IfNull(ip.valid_from, "1900-01-01"), order=desc)`. A NULL `valid_from` becomes a sentinel older than any real date, so it sorts **last** under DESC on both engines.

## Why MariaDB output is unchanged
MariaDB already placed NULL last for DESC, so the row it picks is identical; only PostgreSQL's NULL placement is corrected to match. (`IfNull` renders as `COALESCE` on both engines — verified live.)

Same NULL-ordering class as the POS `get_items` fix in #56378. Part of issue #56241.