### PR TITLE
fix: match free-text dedup lookups case-insensitively (MariaDB↔Postgres parity)

### DIFF
--- a/erpnext/accounts/doctype/tax_rule/tax_rule.py
+++ b/erpnext/accounts/doctype/tax_rule/tax_rule.py
@@ -9,7 +9,7 @@ from frappe import _
 from frappe.contacts.doctype.address.address import get_default_address
 from frappe.model.document import Document
 from frappe.query_builder import DocType
-from frappe.query_builder.functions import IfNull
+from frappe.query_builder.functions import IfNull, Lower
 from frappe.utils import cstr
 from frappe.utils.nestedset import get_root_of
 
@@ -212,7 +212,15 @@ def get_tax_template(posting_date, args):
 				IfNull(TaxRule[key], "").isin(get_group_ancestors(doctype, get_parents, value))
 			)
 		else:
-			query = query.where(IfNull(TaxRule[key], "").isin(["", value or ""]))
+			# The remaining keys are the free-text address fields (billing/shipping
+			# city/state/county/zipcode). MariaDB matches them case-insensitively but Postgres does
+			# not, so Lower() both sides for Data keys to keep the rule matching the same on both
+			# engines. Any non-Data key keeps its exact-case comparison.
+			meta_field = frappe.get_meta("Tax Rule").get_field(key)
+			if meta_field and meta_field.fieldtype == "Data":
+				query = query.where(Lower(IfNull(TaxRule[key], "")).isin(["", (value or "").lower()]))
+			else:
+				query = query.where(IfNull(TaxRule[key], "").isin(["", value or ""]))
 
 	tax_rule = query.run(as_dict=True)
 

--- a/erpnext/crm/doctype/lead/mapper.py
+++ b/erpnext/crm/doctype/lead/mapper.py
@@ -8,6 +8,7 @@ from frappe.contacts.doctype.contact.contact import get_default_contact
 from frappe.email.inbox import link_communication_to_document
 from frappe.model.document import Document
 from frappe.model.mapper import get_mapped_doc
+from frappe.query_builder.functions import Lower
 
 
 @frappe.whitelist()
@@ -117,7 +118,17 @@ def make_lead_from_communication(communication: str, ignore_communication_links:
 	doc = frappe.get_doc("Communication", communication)
 	lead_name = None
 	if doc.sender:
-		lead_name = frappe.db.get_value("Lead", {"email_id": doc.sender})
+		# Match email_id case-insensitively so Postgres reuses an existing Lead like MariaDB does
+		# (whose default collation is case-insensitive) instead of creating a duplicate.
+		_lead = frappe.qb.DocType("Lead")
+		_rows = (
+			frappe.qb.from_(_lead)
+			.select(_lead.name)
+			.where(Lower(_lead.email_id) == (doc.sender or "").lower())
+			.limit(1)
+			.run()
+		)
+		lead_name = _rows[0][0] if _rows else None
 	if not lead_name and doc.phone_no:
 		lead_name = frappe.db.get_value("Lead", {"mobile_no": doc.phone_no})
 	if not lead_name:

--- a/erpnext/crm/doctype/opportunity/opportunity.py
+++ b/erpnext/crm/doctype/opportunity/opportunity.py
@@ -9,7 +9,7 @@ from frappe import _
 from frappe.contacts.address_and_contact import load_address_and_contact
 from frappe.model.document import Document
 from frappe.query_builder import DocType, Interval
-from frappe.query_builder.functions import Now
+from frappe.query_builder.functions import Lower, Now
 from frappe.utils import flt, get_fullname
 
 from erpnext.crm.utils import (
@@ -234,7 +234,17 @@ class Opportunity(TransactionBase, CRMNote):
 				self.opportunity_from = "Customer"
 				return
 
-			lead_name = frappe.db.get_value("Lead", {"email_id": self.contact_email})
+			# Match email_id case-insensitively so Postgres finds an existing Lead like MariaDB
+			# (case-insensitive collation) instead of auto-creating a duplicate.
+			_lead = frappe.qb.DocType("Lead")
+			_rows = (
+				frappe.qb.from_(_lead)
+				.select(_lead.name)
+				.where(Lower(_lead.email_id) == (self.contact_email or "").lower())
+				.limit(1)
+				.run()
+			)
+			lead_name = _rows[0][0] if _rows else None
 			if not lead_name:
 				sender_name = get_fullname(self.contact_email)
 				if sender_name == self.contact_email:

--- a/erpnext/crm/frappe_crm_api.py
+++ b/erpnext/crm/frappe_crm_api.py
@@ -2,6 +2,25 @@ import json
 
 import frappe
 from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
+from frappe.query_builder.functions import Lower
+
+
+def _ci_match(doctype, fieldname, value):
+	"""Return the docname whose free-text ``fieldname`` equals ``value`` ignoring case, else None.
+
+	MariaDB matches such Data fields case-insensitively via its default collation; Postgres does
+	not, so a plain dict-filter dedup lookup misses on Postgres and creates a duplicate record.
+	Lower() both sides keeps the same match set on both engines (MariaDB output unchanged).
+	"""
+	dt = frappe.qb.DocType(doctype)
+	rows = (
+		frappe.qb.from_(dt)
+		.select(dt.name)
+		.where(Lower(dt[fieldname]) == (value or "").lower())
+		.limit(1)
+		.run()
+	)
+	return rows[0][0] if rows else None
 
 
 @frappe.whitelist()
@@ -43,7 +62,7 @@ def create_prospect_against_crm_deal():
 	prospect.annual_revenue = doc.annual_revenue
 
 	try:
-		prospect_name = frappe.db.get_value("Prospect", {"company_name": prospect.company_name})
+		prospect_name = _ci_match("Prospect", "company_name", prospect.company_name)
 		if not prospect_name:
 			prospect.insert()
 			prospect_name = prospect.name
@@ -134,7 +153,7 @@ def link_doc(doc, link_doctype, link_docname):
 
 
 def contact_exists(email, mobile_no):
-	email_exist = frappe.db.exists("Contact Email", {"email_id": email})
+	email_exist = _ci_match("Contact Email", "email_id", email)
 	mobile_exist = frappe.db.exists("Contact Phone", {"phone": mobile_no})
 
 	doctype = "Contact Email" if email_exist else "Contact Phone"
@@ -164,7 +183,7 @@ def create_customer(customer_data: dict | None = None):
 		customer_data = frappe.form_dict
 
 	try:
-		customer_name = frappe.db.exists("Customer", {"customer_name": customer_data.get("customer_name")})
+		customer_name = _ci_match("Customer", "customer_name", customer_data.get("customer_name"))
 		if not customer_name:
 			customer = frappe.new_doc("Customer")
 			for field in CUSTOMER_ALLOWED_FIELDS:

--- a/erpnext/portal/utils.py
+++ b/erpnext/portal/utils.py
@@ -1,4 +1,5 @@
 import frappe
+from frappe.query_builder.functions import Lower
 
 
 def set_default_role(doc, method):
@@ -87,7 +88,17 @@ def create_party_contact(doctype, fullname, user, party_name):
 
 def party_exists(doctype, user):
 	# check if contact exists against party and if it is linked to the doctype
-	contact_name = frappe.db.get_value("Contact", {"email_id": user})
+	# Match email_id case-insensitively so portal access resolves the Contact on Postgres the same
+	# way MariaDB does (its default collation is case-insensitive).
+	_contact = frappe.qb.DocType("Contact")
+	_rows = (
+		frappe.qb.from_(_contact)
+		.select(_contact.name)
+		.where(Lower(_contact.email_id) == (user or "").lower())
+		.limit(1)
+		.run()
+	)
+	contact_name = _rows[0][0] if _rows else None
 	if contact_name:
 		contact = frappe.get_doc("Contact", contact_name)
 		doctypes = [d.link_doctype for d in contact.links]


### PR DESCRIPTION
## Problem

MariaDB's default collation makes string equality **case-insensitive**; PostgreSQL is **case-sensitive**. So a `frappe.db.get_value`/`exists` dict-filter on a **free-text `Data` field** matches differently across engines. For dedup/resolution lookups this is a silent data-integrity divergence:

- a "find existing record before creating" lookup **misses on PostgreSQL** and inserts a **duplicate** record;
- a Tax Rule keyed on address text **silently fails to match** on PostgreSQL, returning a different (or no) tax template.

Verified live: `get_value("Customer", {"customer_name": "_Test NC"})` matches on PG, but the swap-cased value does **not** (MariaDB matches both).

## Fix (one commit per file)

Compare `Lower(field) == value.lower()` so both engines match the same set. MariaDB was **already** case-insensitive, so its matched set — and output — is unchanged; only PostgreSQL is brought into line.

| File | Lookup |
|------|--------|
| `accounts/.../tax_rule.py` | billing/shipping `city/state/county/zipcode` (fieldtype-guarded so Link keys stay exact-case) |
| `crm/frappe_crm_api.py` | Prospect `company_name`, Customer `customer_name`, Contact Email `email_id` (via a small `_ci_match` helper) |
| `crm/doctype/lead/mapper.py` | Lead `email_id` (raise-from-email dedup) |
| `crm/doctype/opportunity/opportunity.py` | Lead `email_id` (opportunity-contact dedup) |
| `portal/utils.py` | Contact `email_id` (portal access resolution) |

**Deliberately excluded** (not case divergences / exact-case intended): `mobile_no`/`phone` (no case), and Link/`name` fields such as `Customer.lead_name` and Opportunity `{"lead": …}`.

## Why MariaDB output is unchanged
`Lower(col) == value.lower()` selects exactly the rows MariaDB's case-insensitive `=` already selected; the change only affects PostgreSQL, which now matches case-insensitively too.

## Verification
Case-insensitive match confirmed live on a PostgreSQL site (exact **and** swap-cased now match; `None`-safe). `test_tax_rule` (16) and `test_opportunity` (10) green on PostgreSQL.

This is the audit-14 case-sensitivity class. Part of issue #56241.