### PR TITLE
fix(postgres): more MariaDB↔Postgres parity fixes — case-insensitive dedup siblings, div-by-zero, NULL ordering

### DIFF
--- a/erpnext/accounts/doctype/tax_rule/tax_rule.py
+++ b/erpnext/accounts/doctype/tax_rule/tax_rule.py
@@ -115,7 +115,14 @@ class TaxRule(Document):
 		)
 
 		for field, value in filters.items():
-			query = query.where(IfNull(TaxRule[field], "") == cstr(value))
+			# Free-text address fields (billing/shipping city/state/county/zipcode) match
+			# case-insensitively on MariaDB but not Postgres; Lower() both sides for Data keys so the
+			# conflict detector finds the same overlapping rules on both engines (Link keys stay exact).
+			meta_field = frappe.get_meta("Tax Rule").get_field(field)
+			if meta_field and meta_field.fieldtype == "Data":
+				query = query.where(Lower(IfNull(TaxRule[field], "")) == cstr(value).lower())
+			else:
+				query = query.where(IfNull(TaxRule[field], "") == cstr(value))
 
 		if self.from_date and self.to_date:
 			query = query.where(

--- a/erpnext/accounts/doctype/tax_rule/tax_rule.py
+++ b/erpnext/accounts/doctype/tax_rule/tax_rule.py
@@ -9,7 +9,7 @@ from frappe import _
 from frappe.contacts.doctype.address.address import get_default_address
 from frappe.model.document import Document
 from frappe.query_builder import DocType
-from frappe.query_builder.functions import IfNull
+from frappe.query_builder.functions import IfNull, Lower
 from frappe.utils import cstr
 from frappe.utils.nestedset import get_root_of
 
@@ -212,7 +212,15 @@ def get_tax_template(posting_date, args):
 				IfNull(TaxRule[key], "").isin(get_group_ancestors(doctype, get_parents, value))
 			)
 		else:
-			query = query.where(IfNull(TaxRule[key], "").isin(["", value or ""]))
+			# The remaining keys are the free-text address fields (billing/shipping
+			# city/state/county/zipcode). MariaDB matches them case-insensitively but Postgres does
+			# not, so Lower() both sides for Data keys to keep the rule matching the same on both
+			# engines. Any non-Data key keeps its exact-case comparison.
+			meta_field = frappe.get_meta("Tax Rule").get_field(key)
+			if meta_field and meta_field.fieldtype == "Data":
+				query = query.where(Lower(IfNull(TaxRule[key], "")).isin(["", (value or "").lower()]))
+			else:
+				query = query.where(IfNull(TaxRule[key], "").isin(["", value or ""]))
 
 	tax_rule = query.run(as_dict=True)
 

--- a/erpnext/controllers/sales_and_purchase_return.py
+++ b/erpnext/controllers/sales_and_purchase_return.py
@@ -7,7 +7,7 @@ import frappe
 from frappe import _, bold
 from frappe.model.meta import get_field_precision
 from frappe.query_builder import DocType
-from frappe.query_builder.functions import Abs, Sum
+from frappe.query_builder.functions import Abs, NullIf, Sum
 from frappe.utils import cint, flt, format_datetime, get_datetime
 
 import erpnext
@@ -766,7 +766,9 @@ def get_rate_for_return(
 		select_field = "incoming_rate"
 	else:
 		StockLedgerEntry = frappe.qb.DocType("Stock Ledger Entry")
-		select_field = Abs(StockLedgerEntry.stock_value_difference / StockLedgerEntry.actual_qty)
+		# NullIf so a zero-qty SLE (valuation-only repost) yields NULL instead of aborting on Postgres;
+		# MariaDB already returns NULL for x/0, so its value is unchanged.
+		select_field = Abs(StockLedgerEntry.stock_value_difference / NullIf(StockLedgerEntry.actual_qty, 0))
 
 	item_details = frappe.get_cached_value("Item", item_code, ["has_batch_no", "has_expiry_date"], as_dict=1)
 	set_zero_rate_for_expired_batch = frappe.db.get_single_value(

--- a/erpnext/crm/doctype/appointment/appointment.py
+++ b/erpnext/crm/doctype/appointment/appointment.py
@@ -8,6 +8,7 @@ import frappe
 from frappe import _
 from frappe.desk.form.assign_to import add as add_assignment
 from frappe.model.document import Document
+from frappe.query_builder.functions import Lower
 from frappe.share import add_docshare
 from frappe.utils import get_url, getdate, now
 from frappe.utils.verified_command import get_signed_params
@@ -35,20 +36,29 @@ class Appointment(Document):
 	# end: auto-generated types
 
 	def find_lead_by_email(self):
-		lead_list = frappe.get_list(
-			"Lead", filters={"email_id": self.customer_email}, ignore_permissions=True
+		# Match email_id case-insensitively so Postgres finds the Lead like MariaDB does (its default
+		# collation is case-insensitive) instead of leaving the appointment unlinked.
+		lead = frappe.qb.DocType("Lead")
+		rows = (
+			frappe.qb.from_(lead)
+			.select(lead.name)
+			.where(Lower(lead.email_id) == (self.customer_email or "").lower())
+			.limit(1)
+			.run()
 		)
-		if lead_list:
-			return lead_list[0].name
-		return None
+		return rows[0][0] if rows else None
 
 	def find_customer_by_email(self):
-		customer_list = frappe.get_list(
-			"Customer", filters={"email_id": self.customer_email}, ignore_permissions=True
+		# Match email_id case-insensitively so Postgres links the existing Customer like MariaDB does.
+		customer = frappe.qb.DocType("Customer")
+		rows = (
+			frappe.qb.from_(customer)
+			.select(customer.name)
+			.where(Lower(customer.email_id) == (self.customer_email or "").lower())
+			.limit(1)
+			.run()
 		)
-		if customer_list:
-			return customer_list[0].name
-		return None
+		return rows[0][0] if rows else None
 
 	def before_insert(self):
 		number_of_appointments_in_same_slot = frappe.db.count(

--- a/erpnext/crm/doctype/lead/mapper.py
+++ b/erpnext/crm/doctype/lead/mapper.py
@@ -8,6 +8,7 @@ from frappe.contacts.doctype.contact.contact import get_default_contact
 from frappe.email.inbox import link_communication_to_document
 from frappe.model.document import Document
 from frappe.model.mapper import get_mapped_doc
+from frappe.query_builder.functions import Lower
 
 
 @frappe.whitelist()
@@ -117,7 +118,17 @@ def make_lead_from_communication(communication: str, ignore_communication_links:
 	doc = frappe.get_doc("Communication", communication)
 	lead_name = None
 	if doc.sender:
-		lead_name = frappe.db.get_value("Lead", {"email_id": doc.sender})
+		# Match email_id case-insensitively so Postgres reuses an existing Lead like MariaDB does
+		# (whose default collation is case-insensitive) instead of creating a duplicate.
+		_lead = frappe.qb.DocType("Lead")
+		_rows = (
+			frappe.qb.from_(_lead)
+			.select(_lead.name)
+			.where(Lower(_lead.email_id) == (doc.sender or "").lower())
+			.limit(1)
+			.run()
+		)
+		lead_name = _rows[0][0] if _rows else None
 	if not lead_name and doc.phone_no:
 		lead_name = frappe.db.get_value("Lead", {"mobile_no": doc.phone_no})
 	if not lead_name:

--- a/erpnext/crm/doctype/opportunity/opportunity.py
+++ b/erpnext/crm/doctype/opportunity/opportunity.py
@@ -9,7 +9,7 @@ from frappe import _
 from frappe.contacts.address_and_contact import load_address_and_contact
 from frappe.model.document import Document
 from frappe.query_builder import DocType, Interval
-from frappe.query_builder.functions import Now
+from frappe.query_builder.functions import Lower, Now
 from frappe.utils import flt, get_fullname
 
 from erpnext.crm.utils import (
@@ -234,7 +234,17 @@ class Opportunity(TransactionBase, CRMNote):
 				self.opportunity_from = "Customer"
 				return
 
-			lead_name = frappe.db.get_value("Lead", {"email_id": self.contact_email})
+			# Match email_id case-insensitively so Postgres finds an existing Lead like MariaDB
+			# (case-insensitive collation) instead of auto-creating a duplicate.
+			_lead = frappe.qb.DocType("Lead")
+			_rows = (
+				frappe.qb.from_(_lead)
+				.select(_lead.name)
+				.where(Lower(_lead.email_id) == (self.contact_email or "").lower())
+				.limit(1)
+				.run()
+			)
+			lead_name = _rows[0][0] if _rows else None
 			if not lead_name:
 				sender_name = get_fullname(self.contact_email)
 				if sender_name == self.contact_email:

--- a/erpnext/crm/frappe_crm_api.py
+++ b/erpnext/crm/frappe_crm_api.py
@@ -2,6 +2,25 @@ import json
 
 import frappe
 from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
+from frappe.query_builder.functions import Lower
+
+
+def _ci_match(doctype, fieldname, value):
+	"""Return the docname whose free-text ``fieldname`` equals ``value`` ignoring case, else None.
+
+	MariaDB matches such Data fields case-insensitively via its default collation; Postgres does
+	not, so a plain dict-filter dedup lookup misses on Postgres and creates a duplicate record.
+	Lower() both sides keeps the same match set on both engines (MariaDB output unchanged).
+	"""
+	dt = frappe.qb.DocType(doctype)
+	rows = (
+		frappe.qb.from_(dt)
+		.select(dt.name)
+		.where(Lower(dt[fieldname]) == (value or "").lower())
+		.limit(1)
+		.run()
+	)
+	return rows[0][0] if rows else None
 
 
 @frappe.whitelist()
@@ -43,7 +62,7 @@ def create_prospect_against_crm_deal():
 	prospect.annual_revenue = doc.annual_revenue
 
 	try:
-		prospect_name = frappe.db.get_value("Prospect", {"company_name": prospect.company_name})
+		prospect_name = _ci_match("Prospect", "company_name", prospect.company_name)
 		if not prospect_name:
 			prospect.insert()
 			prospect_name = prospect.name
@@ -134,7 +153,7 @@ def link_doc(doc, link_doctype, link_docname):
 
 
 def contact_exists(email, mobile_no):
-	email_exist = frappe.db.exists("Contact Email", {"email_id": email})
+	email_exist = _ci_match("Contact Email", "email_id", email)
 	mobile_exist = frappe.db.exists("Contact Phone", {"phone": mobile_no})
 
 	doctype = "Contact Email" if email_exist else "Contact Phone"
@@ -164,7 +183,7 @@ def create_customer(customer_data: dict | None = None):
 		customer_data = frappe.form_dict
 
 	try:
-		customer_name = frappe.db.exists("Customer", {"customer_name": customer_data.get("customer_name")})
+		customer_name = _ci_match("Customer", "customer_name", customer_data.get("customer_name"))
 		if not customer_name:
 			customer = frappe.new_doc("Customer")
 			for field in CUSTOMER_ALLOWED_FIELDS:

--- a/erpnext/portal/utils.py
+++ b/erpnext/portal/utils.py
@@ -1,4 +1,5 @@
 import frappe
+from frappe.query_builder.functions import Lower
 
 
 def set_default_role(doc, method):
@@ -87,7 +88,17 @@ def create_party_contact(doctype, fullname, user, party_name):
 
 def party_exists(doctype, user):
 	# check if contact exists against party and if it is linked to the doctype
-	contact_name = frappe.db.get_value("Contact", {"email_id": user})
+	# Match email_id case-insensitively so portal access resolves the Contact on Postgres the same
+	# way MariaDB does (its default collation is case-insensitive).
+	_contact = frappe.qb.DocType("Contact")
+	_rows = (
+		frappe.qb.from_(_contact)
+		.select(_contact.name)
+		.where(Lower(_contact.email_id) == (user or "").lower())
+		.limit(1)
+		.run()
+	)
+	contact_name = _rows[0][0] if _rows else None
 	if contact_name:
 		contact = frappe.get_doc("Contact", contact_name)
 		doctypes = [d.link_doctype for d in contact.links]

--- a/erpnext/portal/utils.py
+++ b/erpnext/portal/utils.py
@@ -9,7 +9,17 @@ def set_default_role(doc, method):
 
 	roles = frappe.get_roles(doc.name)
 
-	contact_name = frappe.get_value("Contact", dict(email_id=doc.email))
+	# Match email_id case-insensitively (like party_exists) so the role is granted on Postgres the
+	# same way MariaDB does (its default collation is case-insensitive).
+	_contact = frappe.qb.DocType("Contact")
+	_rows = (
+		frappe.qb.from_(_contact)
+		.select(_contact.name)
+		.where(Lower(_contact.email_id) == (doc.email or "").lower())
+		.limit(1)
+		.run()
+	)
+	contact_name = _rows[0][0] if _rows else None
 	if contact_name:
 		contact = frappe.get_doc("Contact", contact_name)
 		for link in contact.links:

--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -1122,16 +1122,22 @@ def insert_item_price(ctx: ItemDetailsCtx):
 		or getdate()
 	)
 
-	item_prices = frappe.get_all(
-		"Item Price",
-		filters={
-			"item_code": ctx.item_code,
-			"price_list": ctx.price_list,
-			"currency": ctx.currency,
-			"uom": ctx.stock_uom,
-		},
-		fields=["name", "price_list_rate", "valid_from", "valid_upto"],
-		order_by="valid_from desc, creation desc",
+	ip = frappe.qb.DocType("Item Price")
+	item_prices = (
+		frappe.qb.from_(ip)
+		.select(ip.name, ip.price_list_rate, ip.valid_from, ip.valid_upto)
+		.where(
+			(ip.item_code == ctx.item_code)
+			& (ip.price_list == ctx.price_list)
+			& (ip.currency == ctx.currency)
+			& (ip.uom == ctx.stock_uom)
+		)
+		# IfNull so a NULL valid_from sorts last under DESC on both engines: MariaDB already sorts
+		# NULL last for DESC, but Postgres defaults to NULLS FIRST, which would otherwise win the
+		# first-match pick below.
+		.orderby(IfNull(ip.valid_from, "1900-01-01"), order=frappe.qb.desc)
+		.orderby(ip.creation, order=frappe.qb.desc)
+		.run(as_dict=True)
 	)
 	item_price = next(
 		(

--- a/erpnext/support/doctype/issue/issue.py
+++ b/erpnext/support/doctype/issue/issue.py
@@ -12,7 +12,7 @@ from frappe.email.inbox import link_communication_to_document
 from frappe.model.document import Document
 from frappe.model.mapper import get_mapped_doc
 from frappe.query_builder import Interval
-from frappe.query_builder.functions import Now
+from frappe.query_builder.functions import Lower, Now
 from frappe.utils import date_diff, get_datetime, now_datetime, time_diff_in_seconds
 from frappe.utils.user import is_website_user
 
@@ -82,11 +82,29 @@ class Issue(Document):
 
 		email_id = email.utils.parseaddr(email_id)[1]
 		if email_id:
+			# Match email_id case-insensitively so Postgres links the Lead/Contact like MariaDB does
+			# (its default collation is case-insensitive) rather than missing on a casing difference.
 			if not self.lead:
-				self.lead = frappe.db.get_value("Lead", {"email_id": email_id})
+				lead = frappe.qb.DocType("Lead")
+				rows = (
+					frappe.qb.from_(lead)
+					.select(lead.name)
+					.where(Lower(lead.email_id) == email_id.lower())
+					.limit(1)
+					.run()
+				)
+				self.lead = rows[0][0] if rows else None
 
 			if not self.contact and not self.customer:
-				self.contact = frappe.db.get_value("Contact", {"email_id": email_id})
+				contact = frappe.qb.DocType("Contact")
+				rows = (
+					frappe.qb.from_(contact)
+					.select(contact.name)
+					.where(Lower(contact.email_id) == email_id.lower())
+					.limit(1)
+					.run()
+				)
+				self.contact = rows[0][0] if rows else None
 
 				if self.contact:
 					contact = frappe.get_doc("Contact", self.contact)

--- a/erpnext/templates/utils.py
+++ b/erpnext/templates/utils.py
@@ -29,7 +29,17 @@ def send_message(sender: str, message: str, subject: str = "Website Query"):
 	customer = get_customer_from_contact_email(sender)
 
 	if not customer:
-		lead = frappe.db.get_value("Lead", dict(email_id=sender))
+		# Match email_id case-insensitively so Postgres reuses an existing Lead like MariaDB does
+		# (its default collation is case-insensitive) instead of creating a duplicate from contact-us.
+		_lead = frappe.qb.DocType("Lead")
+		_rows = (
+			frappe.qb.from_(_lead)
+			.select(_lead.name)
+			.where(Lower(_lead.email_id) == (sender or "").lower())
+			.limit(1)
+			.run()
+		)
+		lead = _rows[0][0] if _rows else None
 		if not lead:
 			new_lead = frappe.get_doc(
 				doctype="Lead", email_id=sender, lead_name=sender.split("@")[0].title()


### PR DESCRIPTION
Nine more MariaDB↔PostgreSQL divergences found by a whole-repo parity audit, each adjudicated live on both engines. One commit per file.

> **Stacked on #56381.** This branch relies on the `Lower` imports #56381 adds to `tax_rule.py` and `portal/utils.py`, so until #56381 merges this PR also shows its 5 commits; it will auto-clean to just the 7 commits below once #56381 lands. **Please merge #56381 first.**

## Case-sensitivity on free-text `Data` fields (sibling call sites of #56381)
MariaDB's collation matches strings case-insensitively; PostgreSQL is case-sensitive, so these dedup/match lookups miss on PG and create duplicate records (or fail to link). Fixed with `Lower(field) == value.lower()` + `.limit(1)` (MariaDB's matched set unchanged):

- **`accounts/.../tax_rule.py`** — `validate_filters`, the conflict detector (sibling of the already-fixed `get_tax_template`): address fields, fieldtype-guarded so Link keys stay exact-case.
- **`crm/.../appointment.py`** — `find_lead_by_email` / `find_customer_by_email` (guest-entered email).
- **`portal/utils.py`** — `set_default_role` (sibling of the already-fixed `party_exists`): Contact email → role assignment.
- **`support/.../issue.py`** — `set_lead_contact`: Lead + Contact by sender email.
- **`templates/utils.py`** — contact-us Lead dedup by email.

## Division by a possibly-zero divisor (hard error on PG)
- **`controllers/sales_and_purchase_return.py`** — `get_rate_for_return`: `Abs(stock_value_difference / actual_qty)` over an SLE with no `actual_qty != 0` filter; a valuation-only zero-qty SLE → PG `division by zero`. Wrapped in `NullIf(actual_qty, 0)`.

## NULL ordering (silent divergence)
- **`stock/get_item_details.py`** — `insert_item_price`: `valid_from DESC` first-match pick; NULL sorts last on MariaDB, first on PG. Converted to a query-builder query ordered by `IfNull(valid_from, '1900-01-01') desc`.

## Why MariaDB output is unchanged
Every fix is a no-op on MariaDB: `Lower()==lower()` selects the same rows its case-insensitive `=` already did; `NullIf(d,0)` only differs when `d=0`, where MariaDB's `x/0` was already NULL; and the NULL-ordering sentinel reproduces MariaDB's existing NULL-last-under-DESC placement.

## Verification
Each fix reproduced erroring/diverging on PostgreSQL before and verified correct after (case-insensitive matches confirmed live; `NULLIF`/`COALESCE` rendered on PG). `test_tax_rule` (16) and `test_issue` (37) green on PostgreSQL. (Appointment's 2 test errors are pre-existing/environmental — no outgoing email account — failing identically on MariaDB and on unmodified develop.)

The critic's re-flagged BOM-report divisions were rejected as false positives (BOM validates `quantity > 0` and item `qty > 0`).

Part of issue #56241 (audit 15).