### PR TITLE
Revert "fix(postgres): three parity fixes — POS NULL ordering, traceability div-by-zero, LIKE on non-text"

### DIFF
--- a/erpnext/accounts/doctype/financial_report_template/financial_report_engine.py
+++ b/erpnext/accounts/doctype/financial_report_template/financial_report_engine.py
@@ -12,9 +12,8 @@ from typing import Any, Union
 import frappe
 from frappe import _
 from frappe.database.operator_map import OPERATOR_MAP
-from frappe.model import numeric_fieldtypes
 from frappe.query_builder import Case
-from frappe.query_builder.functions import Cast_, Sum
+from frappe.query_builder.functions import Sum
 from frappe.utils import cstr, date_diff, flt, getdate
 from frappe.utils.xlsxutils import XLSXMetadata, XLSXStyleBuilder
 from pypika.terms import Bracket, LiteralValue
@@ -865,15 +864,8 @@ class FilterExpressionParser:
 		field = getattr(table, field_name, None)
 		operator_fn = OPERATOR_MAP.get(operator.casefold())
 
-		if "like" in operator.casefold():
-			if "%" not in value:
-				value = f"%{value}%"
-			# Postgres has no LIKE/ILIKE operator for non-text columns; MariaDB implicitly casts
-			# the numeric column to text. Cast a numeric/Check Account field to varchar so the
-			# match runs on both engines and reproduces MariaDB's result.
-			meta_field = frappe.get_meta("Account").get_field(field_name)
-			if meta_field and meta_field.fieldtype in numeric_fieldtypes:
-				field = Cast_(field, "varchar")
+		if "like" in operator.casefold() and "%" not in value:
+			value = f"%{value}%"
 
 		return operator_fn(field, value)
 

--- a/erpnext/selling/page/point_of_sale/point_of_sale.py
+++ b/erpnext/selling/page/point_of_sale/point_of_sale.py
@@ -6,7 +6,6 @@ import json
 
 import frappe
 from frappe.query_builder import Criterion, DocType, Order
-from frappe.query_builder.functions import Coalesce
 from frappe.utils import cint, get_datetime
 from frappe.utils.nestedset import get_root_of
 
@@ -232,10 +231,7 @@ def get_items(
 			.where(ItemPrice.selling == 1)
 			.where((ItemPrice.valid_from <= current_date) | (ItemPrice.valid_from.isnull()))
 			.where((ItemPrice.valid_upto >= current_date) | (ItemPrice.valid_upto.isnull()))
-			# Coalesce so a NULL valid_from (open-ended base price) sorts last under DESC on both
-			# engines: MariaDB already sorts NULL last for DESC, Postgres defaults to NULLS FIRST, which
-			# would otherwise make the base price win the positional pick over a dated override.
-			.orderby(Coalesce(ItemPrice.valid_from, "1900-01-01"), order=Order.desc)
+			.orderby(ItemPrice.valid_from, order=Order.desc)
 		).run(as_dict=True)
 
 		stock_uom_price = next((d for d in item_prices if d.get("uom") == item.stock_uom), {})

--- a/erpnext/stock/report/serial_no_and_batch_traceability/serial_no_and_batch_traceability.py
+++ b/erpnext/stock/report/serial_no_and_batch_traceability/serial_no_and_batch_traceability.py
@@ -4,7 +4,6 @@
 import frappe
 from frappe import _
 from frappe.query_builder import Case
-from frappe.query_builder.functions import NullIf
 
 
 def execute(filters: dict | None = None):
@@ -301,12 +300,9 @@ class ReportData:
 				(
 					(
 						stock_entry_detail.qty
-						/ NullIf(
-							Case()
-							.when(stock_entry.fg_completed_qty > 0, stock_entry.fg_completed_qty)
-							.else_(sabb_data.qty),
-							0,
-						)
+						/ Case()
+						.when(stock_entry.fg_completed_qty > 0, stock_entry.fg_completed_qty)
+						.else_(sabb_data.qty)
 					)
 					* sabb_data.qty
 				).as_("qty"),


### PR DESCRIPTION
Reverts frappe/erpnext#56378