### PR TITLE
fix(manufacturing): case-sensitive variant BOM lookup on Postgres

### DIFF
--- a/erpnext/manufacturing/doctype/bom/bom.py
+++ b/erpnext/manufacturing/doctype/bom/bom.py
@@ -1403,16 +1403,18 @@ def validate_bom_no(item, bom_no):
 
 
 def _bom_contains_item(bom, item):
-	item = item.lower()
+	item_lower = item.lower()
 	for d in bom.items:
-		if d.item_code.lower() == item:
+		if d.item_code.lower() == item_lower:
 			return True
 	for d in bom.secondary_items:
-		if d.item_code.lower() == item:
+		if d.item_code.lower() == item_lower:
 			return True
 
+	# Use the original-cased `item` for the Item lookup: names are case-sensitive on Postgres,
+	# so a lowercased name would miss the record and drop the variant->template BOM match.
 	return (
-		bom.item.lower() == item
+		bom.item.lower() == item_lower
 		or bom.item.lower() == cstr(frappe.db.get_value("Item", item, "variant_of")).lower()
 	)
 


### PR DESCRIPTION
Reapplies the variant-BOM case-sensitivity fix that was reverted in #56394 (revert commit `1f86b57f94`). The revert re-introduced the bug below and broke `test_variant_work_order` on Postgres.

## Problem
`_bom_contains_item` (used by `validate_bom_no` when a Work Order produces a **variant** from the **template's** BOM) lowercases the item code and then uses that lowercased value as a **document-name** lookup:

```python
item = item.lower()
...
bom.item.lower() == cstr(frappe.db.get_value("Item", item, "variant_of")).lower()
#                                              ^^^^ lowercased name
```

Item `name` is the primary key. MariaDB's default collation makes the PK lookup **case-insensitive**, so the lowercased name still resolves the variant Item and returns its `variant_of` → the variant→template BOM is accepted. PostgreSQL compares the PK **case-sensitively**, so the lowercased name matches nothing → `variant_of` is `None` → `validate_bom_no` throws *"BOM {0} does not belong to Item {1}"*.

So a Work Order for a variant item, using the template's default BOM, fails to validate on Postgres only.

## Fix
Keep a separate lowercased variable for the in-memory `==` comparisons, but pass the **original-cased** `item` to the `get_value("Item", item, "variant_of")` name lookup. MariaDB behaviour is unchanged; Postgres now resolves the variant the same way.

## Verification
`test_variant_work_order` errors on Postgres before this change and passes after (and stays green on MariaDB).