### PR TITLE
ci(patch): cache the v14 baseline backup instead of re-downloading every run

### DIFF
--- a/.github/workflows/patch.yml
+++ b/.github/workflows/patch.yml
@@ -65,6 +65,19 @@ jobs:
       - name: Add to Hosts
         run: echo "127.0.0.1 test_site" | sudo tee -a /etc/hosts
 
+      # The v14 baseline backup is a fixed published file — cache it instead of re-downloading
+      # ~100MB from frappe.io every run.
+      - name: Cache erpnext v14 backup
+        id: cache-v14
+        uses: actions/cache@v4
+        with:
+          path: ~/erpnext-v14.sql.gz
+          key: erpnext-v14-sql-gz
+
+      - name: Download erpnext v14 backup
+        if: steps.cache-v14.outputs.cache-hit != 'true'
+        run: wget -O ~/erpnext-v14.sql.gz https://frappe.io/files/erpnext-v14.sql.gz
+
       - name: Cache pip
         uses: actions/cache@v4
         with:
@@ -113,8 +126,7 @@ jobs:
           jq 'del(.install_apps)' ~/frappe-bench/sites/test_site/site_config.json > tmp.json
           mv tmp.json ~/frappe-bench/sites/test_site/site_config.json
 
-          wget https://frappe.io/files/erpnext-v14.sql.gz
-          bench --site test_site --force restore ~/frappe-bench/erpnext-v14.sql.gz
+          bench --site test_site --force restore ~/erpnext-v14.sql.gz
 
           git -C "apps/frappe" remote set-url upstream https://github.com/frappe/frappe.git
           git -C "apps/erpnext" remote set-url upstream https://github.com/frappe/erpnext.git


### PR DESCRIPTION
## What

The patch test downloads erpnext's **v14 baseline backup** (`erpnext-v14.sql.gz`, ~100MB) from frappe.io on **every run**. It's a fixed, published file, so this caches it via `actions/cache` (stable key `erpnext-v14-sql-gz`) and only `wget`s on a cache miss.

## Effect

- Saves the ~100MB download (and its latency/flakiness) on every patch run after the first.
- No behaviour change otherwise — the restore now reads the cached `~/erpnext-v14.sql.gz`.

Nothing else in the workflow is touched.
