### PR TITLE
refactor: configurable timeout on process pcv

### DIFF
--- a/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
+++ b/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
@@ -87,6 +87,7 @@
   "period_closing_settings_section",
   "ignore_account_closing_balance",
   "use_legacy_controller_for_pcv",
+  "pcv_job_timeout",
   "column_break_25",
   "reports_tab",
   "remarks_section",
@@ -611,6 +612,13 @@
    "fieldname": "use_legacy_controller_for_pcv",
    "fieldtype": "Check",
    "label": "Use legacy controller for Period Closing Voucher"
+  },
+  {
+   "default": "3600",
+   "description": "Timeout (in seconds) for each background job enqueued by Process Period Closing Voucher",
+   "fieldname": "pcv_job_timeout",
+   "fieldtype": "Int",
+   "label": "PCV Job Timeout (seconds)"
   },
   {
    "description": "Users with this role will be notified if the asset depreciation gets failed",

--- a/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
+++ b/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
@@ -615,6 +615,7 @@
   },
   {
    "default": "3600",
+   "depends_on": "eval: !doc.use_legacy_controller_for_pcv",
    "description": "Timeout (in seconds) for each background job enqueued by Process Period Closing Voucher",
    "fieldname": "pcv_job_timeout",
    "fieldtype": "Int",
@@ -764,7 +765,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2026-06-03 13:11:54.721495",
+ "modified": "2026-06-24 12:59:41.868865",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Accounts Settings",

--- a/erpnext/accounts/doctype/accounts_settings/accounts_settings.py
+++ b/erpnext/accounts/doctype/accounts_settings/accounts_settings.py
@@ -90,6 +90,7 @@ class AccountsSettings(Document):
 		make_payment_via_journal_entry: DF.Check
 		merge_similar_account_heads: DF.Check
 		over_billing_allowance: DF.Currency
+		pcv_job_timeout: DF.Int
 		preview_mode: DF.Check
 		receivable_payable_fetch_method: DF.Literal["Buffered Cursor", "UnBuffered Cursor"]
 		receivable_payable_remarks_length: DF.Int

--- a/erpnext/accounts/doctype/process_period_closing_voucher/process_period_closing_voucher.py
+++ b/erpnext/accounts/doctype/process_period_closing_voucher/process_period_closing_voucher.py
@@ -95,6 +95,8 @@ def start_pcv_processing(docname: str):
 		frappe.has_permission("Process Payment Reconciliation", "write", doc=docname, throw=True)
 		frappe.db.set_value("Process Period Closing Voucher", docname, "status", "Running")
 
+		timeout = frappe.db.get_single_value("Accounts Settings", "pcv_job_timeout") or 3600
+
 		ppcvd = qb.DocType("Process Period Closing Voucher Detail")
 		if normal_balances := (
 			qb.from_(ppcvd)
@@ -121,7 +123,7 @@ def start_pcv_processing(docname: str):
 					frappe.enqueue(
 						method="erpnext.accounts.doctype.process_period_closing_voucher.process_period_closing_voucher.process_individual_date",
 						queue="long",
-						timeout="3600",
+						timeout=timeout,
 						is_async=True,
 						enqueue_after_commit=True,
 						docname=docname,
@@ -247,6 +249,8 @@ def get_gle_for_closing_account(pcv, dimension_balance, dimensions):
 
 @frappe.whitelist()
 def schedule_next_date(docname: str):
+	timeout = frappe.db.get_single_value("Accounts Settings", "pcv_job_timeout") or 3600
+
 	ppcvd = qb.DocType("Process Period Closing Voucher Detail")
 	if to_process := (
 		qb.from_(ppcvd)
@@ -272,7 +276,7 @@ def schedule_next_date(docname: str):
 			frappe.enqueue(
 				method="erpnext.accounts.doctype.process_period_closing_voucher.process_period_closing_voucher.process_individual_date",
 				queue="long",
-				timeout="3600",
+				timeout=timeout,
 				is_async=True,
 				enqueue_after_commit=True,
 				docname=docname,
@@ -302,7 +306,7 @@ def schedule_next_date(docname: str):
 				frappe.enqueue(
 					method="erpnext.accounts.doctype.process_period_closing_voucher.process_period_closing_voucher.summarize_and_post_ledger_entries",
 					queue="long",
-					timeout="3600",
+					timeout=timeout,
 					is_async=True,
 					job_name=job_name,
 					enqueue_after_commit=True,

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -491,3 +491,4 @@ erpnext.patches.v16_0.migrate_subscription_generate_invoice_at
 erpnext.patches.v16_0.rename_subscription_billing_period_fields
 erpnext.patches.v16_0.drop_redundant_serial_no_index_from_sabb
 erpnext.patches.v16_0.set_default_close_opportunity_after_days
+execute:frappe.db.set_single_value("Accounts Settings", "pcv_job_timeout", 3600)


### PR DESCRIPTION
On large sites, even the standard 1hr isn't enough for `Account Closing Balance` creation. This is a temporary workaround, until a stable solution is found.