### PR TITLE
feat: confirmation dialog when enabling negative stock on Item

### DIFF
--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -562,6 +562,18 @@ $.extend(erpnext.utils, {
 	},
 });
 
+erpnext.utils.confirm_negative_stock = function (frm) {
+	if (!frm.doc.allow_negative_stock) return;
+
+	frappe.confirm(
+		__(
+			"Using negative stock disables FIFO/Moving average valuation when inventory is negative. This is considered dangerous from accounting point of view.<br>Do you still want to enable negative inventory?"
+		),
+		() => {},
+		() => frm.set_value("allow_negative_stock", 0)
+	);
+};
+
 erpnext.utils.select_alternate_items = function (opts) {
 	const frm = opts.frm;
 	const warehouse_field = opts.warehouse_field || "warehouse";

--- a/erpnext/stock/doctype/item/item.js
+++ b/erpnext/stock/doctype/item/item.js
@@ -54,6 +54,28 @@ frappe.ui.form.on("Item", {
 		}
 	},
 
+	allow_negative_stock(frm) {
+		if (!frm.doc.allow_negative_stock) {
+			return;
+		}
+
+		let msg = __(
+			"Using negative stock disables FIFO/Moving average valuation when inventory is negative."
+		);
+		msg += " ";
+		msg += __("This is considered dangerous from accounting point of view.");
+		msg += "<br>";
+		msg += __("Do you still want to enable negative inventory?");
+
+		frappe.confirm(
+			msg,
+			() => {},
+			() => {
+				frm.set_value("allow_negative_stock", 0);
+			}
+		);
+	},
+
 	setup: function (frm) {
 		frm.add_fetch("attribute", "numeric_values", "numeric_values");
 		frm.add_fetch("attribute", "from_range", "from_range");

--- a/erpnext/stock/doctype/item/item.js
+++ b/erpnext/stock/doctype/item/item.js
@@ -55,25 +55,7 @@ frappe.ui.form.on("Item", {
 	},
 
 	allow_negative_stock(frm) {
-		if (!frm.doc.allow_negative_stock) {
-			return;
-		}
-
-		let msg = __(
-			"Using negative stock disables FIFO/Moving average valuation when inventory is negative."
-		);
-		msg += " ";
-		msg += __("This is considered dangerous from accounting point of view.");
-		msg += "<br>";
-		msg += __("Do you still want to enable negative inventory?");
-
-		frappe.confirm(
-			msg,
-			() => {},
-			() => {
-				frm.set_value("allow_negative_stock", 0);
-			}
-		);
+		erpnext.utils.confirm_negative_stock(frm);
 	},
 
 	setup: function (frm) {

--- a/erpnext/stock/doctype/stock_settings/stock_settings.js
+++ b/erpnext/stock/doctype/stock_settings/stock_settings.js
@@ -96,25 +96,7 @@ frappe.ui.form.on("Stock Settings", {
 	},
 
 	allow_negative_stock: function (frm) {
-		if (!frm.doc.allow_negative_stock) {
-			return;
-		}
-
-		let msg = __(
-			"Using negative stock disables FIFO/Moving average valuation when inventory is negative."
-		);
-		msg += " ";
-		msg += __("This is considered dangerous from accounting point of view.");
-		msg += "<br>";
-		msg += __("Do you still want to enable negative inventory?");
-
-		frappe.confirm(
-			msg,
-			() => {},
-			() => {
-				frm.set_value("allow_negative_stock", 0);
-			}
-		);
+		erpnext.utils.confirm_negative_stock(frm);
 	},
 	auto_insert_price_list_rate_if_missing(frm) {
 		if (!frm.doc.auto_insert_price_list_rate_if_missing) return;


### PR DESCRIPTION
### Summary

Currently, when **Allow negative stock** is enabled in **Stock Settings**, the user is shown a confirmation dialog warning that negative stock disables FIFO/Moving average valuation and is dangerous from an accounting point of view.

However, negative stock can also be enabled per-item via the **Allow negative stock** field on the **Item** doctype, where no such warning is shown.

This PR adds the same confirmation dialog at the **Item** level, so the alert is shown whenever `allow_negative_stock` is enabled — not only at the Stock Settings level. If the user cancels, the checkbox is reverted.

### Why

The accounting implications of negative stock are identical whether the setting is enabled globally or for a single item. Users enabling it at the item level should be aware of the repercussions of the same. 

### Screenshot 

<img width="1880" height="559" alt="image" src="https://github.com/user-attachments/assets/dcd45211-584c-491d-8327-860cce3d167a" />

