### PR TITLE
feat: explain FIFO allocation of fixed Discount Amount on Sales Order

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.json
+++ b/erpnext/selling/doctype/sales_order/sales_order.json
@@ -893,6 +893,7 @@
    "print_hide": 1
   },
   {
+   "description": "Applying a Discount Amount? When this Sales Order is partially fulfilled through multiple Delivery Notes and Sales Invoices, the Discount Amount is allocated on a FIFO basis — earlier transactions receive a larger share of the discount. To spread the discount proportionally across item prices, use Additional Discount Percentage instead.",
    "fieldname": "discount_amount",
    "fieldtype": "Currency",
    "hide_days": 1,


### PR DESCRIPTION
## What

Adds an informational note (a field `description`) on the **Additional Discount Amount** field of the Sales Order, explaining how a fixed Discount Amount behaves when the order is fulfilled across multiple Delivery Notes and Sales Invoices.

Note text shown in the form:

> Applying a Discount Amount? When this Sales Order is partially fulfilled through multiple Delivery Notes and Sales Invoices, the Discount Amount is allocated on a FIFO basis — earlier transactions receive a larger share of the discount. To spread the discount proportionally across item prices, use Additional Discount Percentage instead.

## Why

When a fixed **Discount Amount** is entered on a Sales Order and the order is fulfilled through multiple Delivery Notes / Sales Invoices, the discount is **not** distributed proportionally across those documents. ERPNext cannot reliably split/merge a fixed Discount Amount proportionally — the totals would not reconcile, and back-calculating a percentage introduces rounding/precision differences. Instead, the amount is consumed on a **FIFO (First-In-First-Out)** basis: the earliest-created Delivery Notes and Sales Invoices absorb the discount first.

**Example:** an order value of 1,000 with a Discount Amount of 300, fulfilled via three Delivery Notes/Invoices — the full 300 is consumed by the earliest-created documents first, rather than being split 100/100/100.

Users who want the discount spread proportionally across item prices on every document should use **Additional Discount Percentage** instead. This note surfaces that behavior right at the point of entry.

## Implementation notes

- The note is placed as the `description` on the `discount_amount` field rather than on the `additional_discount_section` section break, so it renders **only when the section is expanded**. In Frappe, a section-break description stays visible even while the section is collapsed, whereas a field description lives inside the collapsible section body.
- The string is a standard doctype `description`, which Frappe extracts for translation automatically.

## Screenshot

<!-- Drag the Additional Discount section screenshot here; GitHub will upload it. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
