### PR TITLE
refactor(accounts): repost accounting ledger

### DIFF
--- a/erpnext/accounts/doctype/repost_accounting_ledger/repost_accounting_ledger.js
+++ b/erpnext/accounts/doctype/repost_accounting_ledger/repost_accounting_ledger.js
@@ -22,27 +22,47 @@ frappe.ui.form.on("Repost Accounting Ledger", {
 	},
 
 	refresh: function (frm) {
-		frm.add_custom_button(__("Show Preview"), () => {
-			frm.call({
-				method: "generate_preview",
-				doc: frm.doc,
-				freeze: true,
-				freeze_message: __("Generating Preview"),
-				callback: function (r) {
-					if (r && r.message) {
-						let content = r.message;
-						let opts = {
-							title: "Preview",
-							subtitle: "preview",
-							content: content,
-							print_settings: { orientation: "landscape" },
-							columns: [],
-							data: [],
-						};
-						frappe.render_grid(opts);
-					}
-				},
+		if (["Partially Reposted", "Failed"].includes(frm.doc.status) && frm.doc.docstatus == 1) {
+			frm.add_custom_button(__("Start Reposting"), () => {
+				frm.events.start_repost(frm);
 			});
+		}
+
+		frm.add_custom_button(__("Show Preview"), () => {
+			frm.events.generate_preview(frm);
+		});
+	},
+
+	generate_preview: function (frm) {
+		frm.call({
+			method: "generate_preview",
+			doc: frm.doc,
+			freeze: true,
+			freeze_message: __("Generating Preview"),
+			callback: function (r) {
+				if (r && r.message) {
+					let content = r.message;
+					let opts = {
+						title: "Preview",
+						subtitle: "preview",
+						content: content,
+						print_settings: { orientation: "landscape" },
+						columns: [],
+						data: [],
+					};
+					frappe.render_grid(opts);
+				}
+			},
+		});
+	},
+
+	start_repost: function (frm) {
+		frm.call({
+			method: "start_repost",
+			doc: frm.doc,
+			callback: function (r) {
+				frm.reload_doc();
+			},
 		});
 	},
 });

--- a/erpnext/accounts/doctype/repost_accounting_ledger/repost_accounting_ledger.js
+++ b/erpnext/accounts/doctype/repost_accounting_ledger/repost_accounting_ledger.js
@@ -30,9 +30,11 @@ frappe.ui.form.on("Repost Accounting Ledger", {
 			});
 		}
 
-		frm.add_custom_button(__("Show Preview"), () => {
-			frm.events.generate_preview(frm);
-		});
+		if (frm.doc.docstatus != 2) {
+			frm.add_custom_button(__("Show Preview"), () => {
+				frm.events.generate_preview(frm);
+			});
+		}
 	},
 
 	generate_preview: function (frm) {

--- a/erpnext/accounts/doctype/repost_accounting_ledger/repost_accounting_ledger.js
+++ b/erpnext/accounts/doctype/repost_accounting_ledger/repost_accounting_ledger.js
@@ -22,7 +22,7 @@ frappe.ui.form.on("Repost Accounting Ledger", {
 	},
 
 	refresh: function (frm) {
-		if (["Partially Reposted", "Failed"].includes(frm.doc.status) && frm.doc.docstatus == 1) {
+		if (["", "Partially Reposted", "Failed"].includes(frm.doc.status) && frm.doc.docstatus == 1) {
 			frm.add_custom_button(__("Start Reposting"), () => {
 				frm.events.start_repost(frm);
 			});

--- a/erpnext/accounts/doctype/repost_accounting_ledger/repost_accounting_ledger.js
+++ b/erpnext/accounts/doctype/repost_accounting_ledger/repost_accounting_ledger.js
@@ -22,8 +22,7 @@ frappe.ui.form.on("Repost Accounting Ledger", {
 	},
 
 	refresh: function (frm) {
-		// `Queued` and `In Progress` stay offered: the server refuses only while the
-		// background job is still alive, so a job that died can be restarted from here.
+		// the server refuses only while the job is alive, so a dead one can be restarted here
 		if (frm.doc.docstatus == 1 && !["Completed", "Cancelled"].includes(frm.doc.status)) {
 			frm.add_custom_button(__("Start Reposting"), () => {
 				frm.events.start_repost(frm);

--- a/erpnext/accounts/doctype/repost_accounting_ledger/repost_accounting_ledger.js
+++ b/erpnext/accounts/doctype/repost_accounting_ledger/repost_accounting_ledger.js
@@ -22,7 +22,9 @@ frappe.ui.form.on("Repost Accounting Ledger", {
 	},
 
 	refresh: function (frm) {
-		if (["", "Partially Reposted", "Failed"].includes(frm.doc.status) && frm.doc.docstatus == 1) {
+		// `Queued` and `In Progress` stay offered: the server refuses only while the
+		// background job is still alive, so a job that died can be restarted from here.
+		if (frm.doc.docstatus == 1 && !["Completed", "Cancelled"].includes(frm.doc.status)) {
 			frm.add_custom_button(__("Start Reposting"), () => {
 				frm.events.start_repost(frm);
 			});

--- a/erpnext/accounts/doctype/repost_accounting_ledger/repost_accounting_ledger.json
+++ b/erpnext/accounts/doctype/repost_accounting_ledger/repost_accounting_ledger.json
@@ -104,7 +104,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2026-07-24 19:24:38.842549",
+ "modified": "2026-07-28 00:56:50.290314",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Repost Accounting Ledger",

--- a/erpnext/accounts/doctype/repost_accounting_ledger/repost_accounting_ledger.json
+++ b/erpnext/accounts/doctype/repost_accounting_ledger/repost_accounting_ledger.json
@@ -24,6 +24,8 @@
   {
    "fieldname": "company",
    "fieldtype": "Link",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
    "label": "Company",
    "options": "Company"
   },
@@ -102,7 +104,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2026-07-24 17:42:33.346509",
+ "modified": "2026-07-24 19:24:38.842549",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Repost Accounting Ledger",

--- a/erpnext/accounts/doctype/repost_accounting_ledger/repost_accounting_ledger.json
+++ b/erpnext/accounts/doctype/repost_accounting_ledger/repost_accounting_ledger.json
@@ -1,5 +1,6 @@
 {
  "actions": [],
+ "allow_bulk_edit": 1,
  "creation": "2023-07-04 13:07:32.923675",
  "default_view": "List",
  "doctype": "DocType",
@@ -7,11 +8,17 @@
  "engine": "InnoDB",
  "field_order": [
   "company",
-  "column_break_vpup",
   "delete_cancelled_entries",
+  "column_break_vpup",
+  "status",
   "section_break_metl",
   "vouchers",
-  "amended_from"
+  "error_section",
+  "error_log",
+  "miscellaneous_section",
+  "amended_from",
+  "column_break_hrah",
+  "scheduled_job"
  ],
  "fields": [
   {
@@ -48,12 +55,54 @@
    "fieldname": "delete_cancelled_entries",
    "fieldtype": "Check",
    "label": "Delete Cancelled Ledger Entries"
+  },
+  {
+   "fieldname": "error_section",
+   "fieldtype": "Section Break",
+   "label": "Error"
+  },
+  {
+   "fieldname": "error_log",
+   "fieldtype": "Code",
+   "label": "Error Log",
+   "no_copy": 1,
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "miscellaneous_section",
+   "fieldtype": "Section Break",
+   "label": "Miscellaneous"
+  },
+  {
+   "fieldname": "column_break_hrah",
+   "fieldtype": "Column Break"
+  },
+  {
+   "depends_on": "eval:doc.docstatus >= 1;",
+   "fieldname": "status",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Status",
+   "no_copy": 1,
+   "options": "\nQueued\nIn Progress\nPartially Reposted\nCompleted\nFailed\nCancelled",
+   "read_only": 1
+  },
+  {
+   "fieldname": "scheduled_job",
+   "fieldtype": "Link",
+   "hidden": 1,
+   "label": "Scheduled Job",
+   "no_copy": 1,
+   "options": "RQ Job",
+   "read_only": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-06-03 17:30:37.012593",
+ "modified": "2026-07-24 17:42:33.346509",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Repost Accounting Ledger",
@@ -76,6 +125,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],

--- a/erpnext/accounts/doctype/repost_accounting_ledger/repost_accounting_ledger.py
+++ b/erpnext/accounts/doctype/repost_accounting_ledger/repost_accounting_ledger.py
@@ -229,24 +229,24 @@ class RepostAccountingLedger(Document):
 			frappe.throw(_("Scheduler is inactive. Cannot start reposting."), title=_("Scheduler Inactive"))
 
 		self.db_set("status", "Queued")
-
-		if frappe.in_test:
-			repost(repost_doc_name=self.name)
-			return
-
-		job_id = frappe.generate_hash()
-		frappe.enqueue(
-			method="erpnext.accounts.doctype.repost_accounting_ledger.repost_accounting_ledger.repost",
-			repost_doc_name=self.name,
-			queue="long",
-			timeout=REPOST_JOB_TIMEOUT,
-			is_async=True,
-			job_name=f"repost_accounting_ledger_{self.name}",
-			job_id=job_id,
-			enqueue_after_commit=True,
-		)
-		self.db_set("scheduled_job", job_id)
+		self.db_set("scheduled_job", _enqueue_repost(self.name))
 		frappe.msgprint(_("Repost has started in the background"), alert=True, indicator="blue")
+
+
+def _enqueue_repost(repost_doc_name: str) -> str:
+	"""Hand the repost over to a background worker and return the id of the job."""
+	job_id = frappe.generate_hash()
+	frappe.enqueue(
+		method="erpnext.accounts.doctype.repost_accounting_ledger.repost_accounting_ledger.repost",
+		repost_doc_name=repost_doc_name,
+		queue="long",
+		timeout=REPOST_JOB_TIMEOUT,
+		is_async=True,
+		job_name=f"repost_accounting_ledger_{repost_doc_name}",
+		job_id=job_id,
+		enqueue_after_commit=True,
+	)
+	return job_id
 
 
 def _lock_vouchers(vouchers):
@@ -264,7 +264,13 @@ def _lock_vouchers(vouchers):
 	return locked_docs
 
 
-def repost(repost_doc_name: str):
+def repost(repost_doc_name: str, commit: bool = True):
+	"""Repost every voucher of the document, one transaction at a time.
+
+	`commit` says whether this call owns the transaction. The background job does: it commits
+	after every voucher so that progress survives a crash, and rolls back what it could not
+	finish. A caller running this inside its own transaction passes `False` and keeps both.
+	"""
 	locked_docs = []
 	repost_doc = None
 	try:
@@ -276,7 +282,7 @@ def repost(repost_doc_name: str):
 
 		locked_docs = _lock_vouchers(repost_doc.vouchers)
 
-		repost_doc.db_set("status", "In Progress", commit=not frappe.in_test)
+		repost_doc.db_set("status", "In Progress", commit=commit)
 
 		for x in repost_doc.vouchers:
 			if x.reposted:
@@ -295,7 +301,6 @@ def repost(repost_doc_name: str):
 								x.voucher_type, x.voucher_no
 							),
 						},
-						commit=not frappe.in_test,
 					)
 					continue
 
@@ -313,23 +318,21 @@ def repost(repost_doc_name: str):
 			else:
 				x.db_set({"reposted": 1, "traceback": ""})
 			finally:
-				if not frappe.in_test:
+				if commit:
 					frappe.db.commit()  # nosemgrep
 
 	except Exception:
-		if frappe.in_test:
-			# Don't silently fail in tests,
-			# there is no reason for reposts to fail in CI
-			raise
+		if commit:
+			frappe.db.rollback()
 
-		frappe.db.rollback()
 		_record_repost_failure(repost_doc_name, repost_doc)
+		raise
 	else:
 		repost_doc.db_set({"status": _derive_status(repost_doc), "error_log": ""}, notify=True)
 	finally:
 		for doc in locked_docs:
 			doc.unlock()
-		if not frappe.in_test:
+		if commit:
 			frappe.db.commit()  # nosemgrep
 
 

--- a/erpnext/accounts/doctype/repost_accounting_ledger/repost_accounting_ledger.py
+++ b/erpnext/accounts/doctype/repost_accounting_ledger/repost_accounting_ledger.py
@@ -238,6 +238,18 @@ class RepostAccountingLedger(Document):
 		frappe.msgprint(_("Repost has started in the background"), alert=True, indicator="blue")
 
 
+def _revalidate_before_repost(repost_doc) -> None:
+	"""Re-run the checks that keep the repost safe, right before it touches the ledger.
+
+	Vouchers are validated when the document is saved, but the repost runs later and can be
+	retried days after that: a period may have been closed or deferred accounting turned on in
+	the meantime. Vouchers cancelled in the meantime are not checked here, they are skipped
+	one by one while reposting.
+	"""
+	repost_doc.validate_for_closed_fiscal_year()
+	repost_doc.validate_for_deferred_accounting()
+
+
 def _enqueue_repost(repost_doc_name: str) -> str:
 	"""Hand the repost over to a background worker and return the id of the job."""
 	job_id = frappe.generate_hash()
@@ -284,6 +296,8 @@ def repost(repost_doc_name: str, commit: bool = True):
 		frappe.flags.through_repost_accounting_ledger = True
 
 		repost_doc = frappe.get_doc("Repost Accounting Ledger", repost_doc_name)
+
+		_revalidate_before_repost(repost_doc)
 
 		locked_docs = _lock_vouchers(repost_doc.vouchers)
 

--- a/erpnext/accounts/doctype/repost_accounting_ledger/repost_accounting_ledger.py
+++ b/erpnext/accounts/doctype/repost_accounting_ledger/repost_accounting_ledger.py
@@ -266,6 +266,7 @@ def _lock_vouchers(vouchers):
 
 def repost(repost_doc_name: str):
 	locked_docs = []
+	repost_doc = None
 	try:
 		from erpnext.accounts.utils import _delete_accounting_ledger_entries, _delete_adv_pl_entries
 
@@ -322,31 +323,44 @@ def repost(repost_doc_name: str):
 			raise
 
 		frappe.db.rollback()
-		traceback = frappe.get_traceback(with_context=True)
-
-		frappe.log_error(
-			title=_("Unable to Repost Accounting Ledger"),
-		)
-
-		frappe.db.set_value(
-			"Repost Accounting Ledger", repost_doc_name, {"error_log": traceback, "status": "Failed"}
-		)
+		_record_repost_failure(repost_doc_name, repost_doc)
 	else:
-		reposted = sum(1 for voucher in repost_doc.vouchers if voucher.reposted)
-
-		if reposted == len(repost_doc.vouchers):
-			status = "Completed"
-		elif reposted == 0:
-			status = "Failed"
-		else:
-			status = "Partially Reposted"
-
-		repost_doc.db_set({"status": status, "error_log": ""}, notify=True)
+		repost_doc.db_set({"status": _derive_status(repost_doc), "error_log": ""}, notify=True)
 	finally:
 		for doc in locked_docs:
 			doc.unlock()
 		if not frappe.in_test:
 			frappe.db.commit()  # nosemgrep
+
+
+def _derive_status(repost_doc) -> str:
+	"""Vouchers are committed one by one, so the status has to follow what was actually reposted."""
+	reposted = sum(1 for voucher in repost_doc.vouchers if voucher.reposted)
+
+	if reposted == len(repost_doc.vouchers):
+		return "Completed"
+	elif reposted == 0:
+		return "Failed"
+
+	return "Partially Reposted"
+
+
+def _record_repost_failure(repost_doc_name: str, repost_doc=None) -> None:
+	"""Persist the traceback of a run that could not finish, without discarding its progress."""
+	traceback = frappe.get_traceback(with_context=True)
+
+	frappe.log_error(
+		title=_("Unable to Repost Accounting Ledger"),
+		reference_doctype="Repost Accounting Ledger",
+		reference_name=repost_doc_name,
+	)
+
+	# the document is unavailable only when it could not be loaded, i.e. nothing was reposted
+	status = _derive_status(repost_doc) if repost_doc else "Failed"
+
+	frappe.db.set_value(
+		"Repost Accounting Ledger", repost_doc_name, {"error_log": traceback, "status": status}
+	)
 
 
 def _repost_vouchers(doc, delete_cancelled_entries: bool | int | None):

--- a/erpnext/accounts/doctype/repost_accounting_ledger/repost_accounting_ledger.py
+++ b/erpnext/accounts/doctype/repost_accounting_ledger/repost_accounting_ledger.py
@@ -286,7 +286,7 @@ def repost(repost_doc_name: str):
 				x.db_set({"reposted": 1, "traceback": ""})
 			finally:
 				if not frappe.in_test:
-					frappe.db.commit()
+					frappe.db.commit()  # nosemgrep
 
 	except Exception:
 		if frappe.in_test:
@@ -319,7 +319,7 @@ def repost(repost_doc_name: str):
 		for doc in locked_docs:
 			doc.unlock()
 		if not frappe.in_test:
-			frappe.db.commit()
+			frappe.db.commit()  # nosemgrep
 
 
 def _repost_vouchers(doc, delete_cancelled_entries: bool | int | None):

--- a/erpnext/accounts/doctype/repost_accounting_ledger/repost_accounting_ledger.py
+++ b/erpnext/accounts/doctype/repost_accounting_ledger/repost_accounting_ledger.py
@@ -343,9 +343,7 @@ def repost(repost_doc_name: str, commit: bool = True):
 			except Exception:
 				frappe.db.rollback(save_point=save_point)
 
-				traceback = frappe.get_traceback(with_context=True)
-
-				x.db_set("traceback", traceback)
+				x.db_set("traceback", frappe.get_traceback())
 			else:
 				x.db_set({"reposted": 1, "traceback": ""})
 			finally:
@@ -381,7 +379,10 @@ def _derive_status(repost_doc) -> str:
 
 def _record_repost_failure(repost_doc_name: str, repost_doc=None) -> None:
 	"""Persist the traceback of a run that could not finish, without discarding its progress."""
-	traceback = frappe.get_traceback(with_context=True)
+	# `frappe.log_error` keeps the full traceback, including the local variables of every
+	# frame. Those belong in the Error Log, which is not readable by everyone who can read
+	# this document.
+	traceback = frappe.get_traceback()
 
 	frappe.log_error(
 		title=_("Unable to Repost Accounting Ledger"),

--- a/erpnext/accounts/doctype/repost_accounting_ledger/repost_accounting_ledger.py
+++ b/erpnext/accounts/doctype/repost_accounting_ledger/repost_accounting_ledger.py
@@ -223,10 +223,15 @@ class RepostAccountingLedger(Document):
 
 		self.check_permission("write")
 
-		# Reposting runs in a background job. Without an active scheduler the job would never be
-		# picked up, leaving the document stuck in `Queued` forever.
-		if is_scheduler_inactive() and not frappe.in_test:
-			frappe.throw(_("Scheduler is inactive. Cannot start reposting."), title=_("Scheduler Inactive"))
+		# Enqueued jobs are picked up by workers, not by the scheduler, so an inactive scheduler
+		# does not necessarily mean the repost will not run. Say so instead of refusing: a
+		# document that is never picked up can be started again once workers are processing.
+		if is_scheduler_inactive():
+			frappe.msgprint(
+				_("Scheduler is inactive. Reposting will only run once background jobs are processed."),
+				alert=True,
+				indicator="orange",
+			)
 
 		self.db_set("status", "Queued")
 		self.db_set("scheduled_job", _enqueue_repost(self.name))

--- a/erpnext/accounts/doctype/repost_accounting_ledger/repost_accounting_ledger.py
+++ b/erpnext/accounts/doctype/repost_accounting_ledger/repost_accounting_ledger.py
@@ -20,6 +20,9 @@ REPOST_JOB_TIMEOUT = 1500
 # `Queued` and `In Progress`, which are held back by the background job instead.
 TERMINAL_STATUSES = ("Completed", "Cancelled")
 
+# Vouchers in these states are done with: a retry moves on to the rest.
+HANDLED_VOUCHER_STATUSES = ("Reposted", "Skipped")
+
 
 class RepostAccountingLedger(Document):
 	# begin: auto-generated types
@@ -316,7 +319,7 @@ def repost(repost_doc_name: str, commit: bool = True):
 		repost_doc.db_set("status", "In Progress", commit=commit)
 
 		for x in repost_doc.vouchers:
-			if x.reposted:
+			if x.status in HANDLED_VOUCHER_STATUSES:
 				continue
 
 			save_point = "reposting"
@@ -327,10 +330,12 @@ def repost(repost_doc_name: str, commit: bool = True):
 				if doc.docstatus == 2:
 					x.db_set(
 						{
+							"status": "Skipped",
 							"reposted": 1,
-							"traceback": _("{0} {1} has been cancelled, nothing to repost.").format(
+							"remark": _("{0} {1} has been cancelled, nothing to repost.").format(
 								x.voucher_type, x.voucher_no
 							),
+							"traceback": "",
 						},
 					)
 					continue
@@ -343,9 +348,9 @@ def repost(repost_doc_name: str, commit: bool = True):
 			except Exception:
 				frappe.db.rollback(save_point=save_point)
 
-				x.db_set("traceback", frappe.get_traceback())
+				x.db_set({"status": "Failed", "reposted": 0, "traceback": frappe.get_traceback()})
 			else:
-				x.db_set({"reposted": 1, "traceback": ""})
+				x.db_set({"status": "Reposted", "reposted": 1, "remark": "", "traceback": ""})
 			finally:
 				if commit:
 					frappe.db.commit()  # nosemgrep
@@ -366,12 +371,12 @@ def repost(repost_doc_name: str, commit: bool = True):
 
 
 def _derive_status(repost_doc) -> str:
-	"""Vouchers are committed one by one, so the status has to follow what was actually reposted."""
-	reposted = sum(1 for voucher in repost_doc.vouchers if voucher.reposted)
+	"""Vouchers are committed one by one, so the status has to follow what was actually handled."""
+	handled = sum(1 for voucher in repost_doc.vouchers if voucher.status in HANDLED_VOUCHER_STATUSES)
 
-	if reposted == len(repost_doc.vouchers):
+	if handled == len(repost_doc.vouchers):
 		return "Completed"
-	elif reposted == 0:
+	elif handled == 0:
 		return "Failed"
 
 	return "Partially Reposted"

--- a/erpnext/accounts/doctype/repost_accounting_ledger/repost_accounting_ledger.py
+++ b/erpnext/accounts/doctype/repost_accounting_ledger/repost_accounting_ledger.py
@@ -11,16 +11,9 @@ from frappe.utils.background_jobs import create_job_id, is_job_enqueued
 from frappe.utils.data import comma_and
 from frappe.utils.scheduler import is_scheduler_inactive
 
-# Every voucher is reposted by a single background job, so the batch has to stay small enough
-# to finish well within the queue timeout.
+# a batch has to finish well within the timeout of the job reposting it
 MAX_VOUCHERS_PER_REPOST = 50
-REPOST_JOB_TIMEOUT = 1500
 
-# Statuses a document cannot be moved out of. Everything else can be restarted, including
-# `Queued` and `In Progress`, which are held back by the background job instead.
-TERMINAL_STATUSES = ("Completed", "Cancelled")
-
-# Vouchers in these states are done with: a retry moves on to the rest.
 HANDLED_VOUCHER_STATUSES = ("Reposted", "Skipped")
 
 
@@ -54,6 +47,11 @@ class RepostAccountingLedger(Document):
 
 	def validate(self):
 		self.validate_vouchers()
+		self.validate_repost_preconditions()
+
+	def validate_repost_preconditions(self):
+		"""The checks a repost queued days ago could have outlived, re-run before it touches
+		the ledger. Vouchers cancelled since are skipped one by one while reposting."""
 		self.validate_for_closed_fiscal_year()
 		self.validate_for_deferred_accounting()
 
@@ -209,7 +207,7 @@ class RepostAccountingLedger(Document):
 		self.db_set("status", "Cancelled")
 
 	def _raise_error_if_reposting_in_progress(self):
-		if is_job_enqueued(_repost_job_id(self.name)):
+		if self.scheduled_job and is_job_enqueued(_repost_job_id(self.name)):
 			frappe.throw(_("Reposting is still in progress in background."))
 
 	@frappe.whitelist()
@@ -217,20 +215,18 @@ class RepostAccountingLedger(Document):
 		if self.docstatus != 1:
 			frappe.throw(_("Reposting can be started only for submitted document."))
 
-		# read the status under a row lock, so two concurrent starts cannot both get past here
+		# under a row lock, so two concurrent starts cannot both get past here
 		status = frappe.db.get_value(self.doctype, self.name, "status", for_update=True)
-		if status in TERMINAL_STATUSES:
+		if status in ("Completed", "Cancelled"):
 			frappe.throw(_("Reposting cannot be started when status is {0}.").format(status))
 
-		# `Queued` and `In Progress` are not blocked by the status alone. A worker that is killed
-		# or times out leaves the status behind, and the document has to stay restartable.
+		# `Queued` and `In Progress` are held back by the job, not by the status: a worker that
+		# died leaves the status behind and the document has to stay restartable
 		self._raise_error_if_reposting_in_progress()
 
 		self.check_permission("write")
 
-		# Enqueued jobs are picked up by workers, not by the scheduler, so an inactive scheduler
-		# does not necessarily mean the repost will not run. Say so instead of refusing: a
-		# document that is never picked up can be started again once workers are processing.
+		# workers pick up enqueued jobs whether or not the scheduler runs, so this is a warning
 		if is_scheduler_inactive():
 			frappe.msgprint(
 				_("Scheduler is inactive. Reposting will only run once background jobs are processed."),
@@ -238,60 +234,42 @@ class RepostAccountingLedger(Document):
 				indicator="orange",
 			)
 
-		self.db_set("status", "Queued")
-		self.db_set("scheduled_job", _enqueue_repost(self.name))
+		self.db_set({"status": "Queued", "scheduled_job": create_job_id(_repost_job_id(self.name))})
+		_enqueue_repost(self.name)
 		frappe.msgprint(_("Repost has started in the background"), alert=True, indicator="blue")
 
 
-def _revalidate_before_repost(repost_doc) -> None:
-	"""Re-run the checks that keep the repost safe, right before it touches the ledger.
-
-	Vouchers are validated when the document is saved, but the repost runs later and can be
-	retried days after that: a period may have been closed or deferred accounting turned on in
-	the meantime. Vouchers cancelled in the meantime are not checked here, they are skipped
-	one by one while reposting.
-	"""
-	repost_doc.validate_for_closed_fiscal_year()
-	repost_doc.validate_for_deferred_accounting()
-
-
 def _repost_job_id(repost_doc_name: str) -> str:
-	"""Derive the job id from the document, so a repost can only ever have one job."""
+	"""Derived from the document, so a repost can only ever have one job."""
 	return f"repost_accounting_ledger::{repost_doc_name}"
 
 
-def _enqueue_repost(repost_doc_name: str) -> str:
-	"""Hand the repost over to a background worker and return the name of the `RQ Job`.
+def _enqueue_repost(repost_doc_name: str) -> None:
+	"""Hand the repost to a background worker.
 
-	Documents edited after submit repost themselves through `repost_accounting_entries`, and
-	tests across apps assert on the ledger right after doing so. They run the repost here
-	instead, in the foreground and inside their own transaction.
+	Tests run it in the foreground, inside their own transaction: documents edited after submit
+	repost themselves through `repost_accounting_entries`, and tests across apps assert on the
+	ledger right after doing so.
 	"""
-	job_id = _repost_job_id(repost_doc_name)
-
-	if frappe.in_test:
-		repost(repost_doc_name, commit=False)
-	else:
-		frappe.enqueue(
-			method="erpnext.accounts.doctype.repost_accounting_ledger.repost_accounting_ledger.repost",
-			repost_doc_name=repost_doc_name,
-			queue="long",
-			timeout=REPOST_JOB_TIMEOUT,
-			job_id=job_id,
-			deduplicate=True,
-			enqueue_after_commit=True,
-		)
-
-	return create_job_id(job_id)
+	frappe.enqueue(
+		method="erpnext.accounts.doctype.repost_accounting_ledger.repost_accounting_ledger.repost",
+		repost_doc_name=repost_doc_name,
+		commit=not frappe.in_test,
+		queue="long",
+		timeout=1500,
+		job_id=_repost_job_id(repost_doc_name),
+		deduplicate=True,
+		enqueue_after_commit=True,
+		now=frappe.in_test,
+	)
 
 
 def _lock_vouchers(vouchers) -> dict:
 	"""Lock every voucher up front so a concurrent repost cannot touch the same GL entries.
 
-	Returns the locked documents keyed by voucher, so reposting does not have to load them
-	a second time. Note that these are file locks under the site directory: they serialise
-	nothing across hosts that do not share it, and a worker killed outright leaves them
-	behind until they expire.
+	Returns them keyed by voucher, so reposting does not load them again. These are file locks
+	under the site directory: they serialise nothing across hosts that do not share it, and a
+	worker killed outright leaves them behind until they expire.
 	"""
 	locked_docs = {}
 	try:
@@ -309,26 +287,27 @@ def _lock_vouchers(vouchers) -> dict:
 def repost(repost_doc_name: str, commit: bool = True):
 	"""Repost every voucher of the document, one transaction at a time.
 
-	`commit` says whether this call owns the transaction. The background job does: it commits
-	after every voucher so that progress survives a crash, and rolls back what it could not
-	finish. A caller running this inside its own transaction passes `False` and keeps both.
+	`commit` says whether this call owns the transaction. The background job does, and commits
+	after every voucher so progress survives a crash; a caller inside its own passes `False`.
 	"""
+	from erpnext.accounts.utils import _delete_accounting_ledger_entries, _delete_adv_pl_entries
+
+	frappe.flags.through_repost_accounting_ledger = True
+
+	repost_doc = frappe.get_doc("Repost Accounting Ledger", repost_doc_name)
 	locked_docs = {}
-	repost_doc = None
+
 	try:
-		from erpnext.accounts.utils import _delete_accounting_ledger_entries, _delete_adv_pl_entries
-
-		frappe.flags.through_repost_accounting_ledger = True
-
-		repost_doc = frappe.get_doc("Repost Accounting Ledger", repost_doc_name)
-
-		_revalidate_before_repost(repost_doc)
+		repost_doc.validate_repost_preconditions()
 
 		locked_docs = _lock_vouchers(repost_doc.vouchers)
 
 		repost_doc.db_set("status", "In Progress", commit=commit)
 
 		for position, x in enumerate(repost_doc.vouchers, start=1):
+			if x.status in HANDLED_VOUCHER_STATUSES:
+				continue
+
 			frappe.publish_progress(
 				position * 100 / len(repost_doc.vouchers),
 				doctype=repost_doc.doctype,
@@ -336,25 +315,13 @@ def repost(repost_doc_name: str, commit: bool = True):
 				description=_("Reposting {0} {1}").format(x.voucher_type, x.voucher_no),
 			)
 
-			if x.status in HANDLED_VOUCHER_STATUSES:
-				continue
-
 			save_point = "reposting"
 			frappe.db.savepoint(save_point=save_point)
 			try:
 				doc = locked_docs[(x.voucher_type, x.voucher_no)]
 
 				if doc.docstatus == 2:
-					x.db_set(
-						{
-							"status": "Skipped",
-							"reposted": 1,
-							"remark": _("{0} {1} has been cancelled, nothing to repost.").format(
-								x.voucher_type, x.voucher_no
-							),
-							"traceback": "",
-						},
-					)
+					x.db_set({"status": "Skipped", "traceback": ""})
 					continue
 
 				if repost_doc.delete_cancelled_entries:
@@ -365,9 +332,9 @@ def repost(repost_doc_name: str, commit: bool = True):
 			except Exception:
 				frappe.db.rollback(save_point=save_point)
 
-				x.db_set({"status": "Failed", "reposted": 0, "traceback": frappe.get_traceback()})
+				x.db_set({"status": "Failed", "traceback": frappe.get_traceback()})
 			else:
-				x.db_set({"status": "Reposted", "reposted": 1, "remark": "", "traceback": ""})
+				x.db_set({"status": "Reposted", "traceback": ""})
 			finally:
 				if commit:
 					frappe.db.commit()  # nosemgrep
@@ -376,7 +343,7 @@ def repost(repost_doc_name: str, commit: bool = True):
 		if commit:
 			frappe.db.rollback()
 
-		_record_repost_failure(repost_doc_name, repost_doc)
+		_record_repost_failure(repost_doc)
 		raise
 	else:
 		repost_doc.db_set({"status": _derive_status(repost_doc), "error_log": ""}, notify=True)
@@ -388,7 +355,7 @@ def repost(repost_doc_name: str, commit: bool = True):
 
 
 def _derive_status(repost_doc) -> str:
-	"""Vouchers are committed one by one, so the status has to follow what was actually handled."""
+	"""Vouchers are committed one by one, so the status follows what was actually handled."""
 	handled = sum(1 for voucher in repost_doc.vouchers if voucher.status in HANDLED_VOUCHER_STATUSES)
 
 	if handled == len(repost_doc.vouchers):
@@ -399,24 +366,19 @@ def _derive_status(repost_doc) -> str:
 	return "Partially Reposted"
 
 
-def _record_repost_failure(repost_doc_name: str, repost_doc=None) -> None:
+def _record_repost_failure(repost_doc) -> None:
 	"""Persist the traceback of a run that could not finish, without discarding its progress."""
-	# `frappe.log_error` keeps the full traceback, including the local variables of every
-	# frame. Those belong in the Error Log, which is not readable by everyone who can read
-	# this document.
+	# the traceback with frame locals goes to the Error Log, which is permissioned separately
 	traceback = frappe.get_traceback()
 
 	frappe.log_error(
 		title=_("Unable to Repost Accounting Ledger"),
-		reference_doctype="Repost Accounting Ledger",
-		reference_name=repost_doc_name,
+		reference_doctype=repost_doc.doctype,
+		reference_name=repost_doc.name,
 	)
 
-	# the document is unavailable only when it could not be loaded, i.e. nothing was reposted
-	status = _derive_status(repost_doc) if repost_doc else "Failed"
-
 	frappe.db.set_value(
-		"Repost Accounting Ledger", repost_doc_name, {"error_log": traceback, "status": status}
+		repost_doc.doctype, repost_doc.name, {"error_log": traceback, "status": _derive_status(repost_doc)}
 	)
 
 

--- a/erpnext/accounts/doctype/repost_accounting_ledger/repost_accounting_ledger.py
+++ b/erpnext/accounts/doctype/repost_accounting_ledger/repost_accounting_ledger.py
@@ -343,7 +343,7 @@ def repost(repost_doc_name: str, commit: bool = True):
 		if commit:
 			frappe.db.rollback()
 
-		_record_repost_failure(repost_doc)
+		_record_repost_failure(repost_doc, commit=commit)
 		raise
 	else:
 		repost_doc.db_set({"status": _derive_status(repost_doc), "error_log": ""}, notify=True)
@@ -366,7 +366,7 @@ def _derive_status(repost_doc) -> str:
 	return "Partially Reposted"
 
 
-def _record_repost_failure(repost_doc) -> None:
+def _record_repost_failure(repost_doc, commit=False) -> None:
 	"""Persist the traceback of a run that could not finish, without discarding its progress."""
 	# the traceback with frame locals goes to the Error Log, which is permissioned separately
 	traceback = frappe.get_traceback()
@@ -380,6 +380,9 @@ def _record_repost_failure(repost_doc) -> None:
 	frappe.db.set_value(
 		repost_doc.doctype, repost_doc.name, {"error_log": traceback, "status": _derive_status(repost_doc)}
 	)
+
+	if commit:
+		frappe.db.commit()
 
 
 def _repost_vouchers(doc, delete_cancelled_entries: bool | int | None):

--- a/erpnext/accounts/doctype/repost_accounting_ledger/repost_accounting_ledger.py
+++ b/erpnext/accounts/doctype/repost_accounting_ledger/repost_accounting_ledger.py
@@ -230,7 +230,7 @@ def _lock_vouchers(vouchers):
 			doc = frappe.get_doc(x.voucher_type, x.voucher_no)
 			doc.lock()
 			locked_docs.append(doc)
-	except frappe.DocumentLockedError:
+	except Exception:
 		for doc in locked_docs:
 			doc.unlock()
 		raise

--- a/erpnext/accounts/doctype/repost_accounting_ledger/repost_accounting_ledger.py
+++ b/erpnext/accounts/doctype/repost_accounting_ledger/repost_accounting_ledger.py
@@ -9,6 +9,7 @@ from frappe.desk.form.linked_with import get_child_tables_of_doctypes
 from frappe.model.document import Document
 from frappe.utils.background_jobs import is_job_enqueued
 from frappe.utils.data import comma_and
+from frappe.utils.scheduler import is_scheduler_inactive
 
 
 class RepostAccountingLedger(Document):
@@ -203,6 +204,12 @@ class RepostAccountingLedger(Document):
 		self._raise_error_if_reposting_in_progress()
 
 		self.check_permission("write")
+
+		# Reposting runs in a background job. Without an active scheduler the job would never be
+		# picked up, leaving the document stuck in `Queued` forever.
+		if is_scheduler_inactive() and not frappe.in_test:
+			frappe.throw(_("Scheduler is inactive. Cannot start reposting."), title=_("Scheduler Inactive"))
+
 		self.db_set("status", "Queued")
 
 		if frappe.in_test:

--- a/erpnext/accounts/doctype/repost_accounting_ledger/repost_accounting_ledger.py
+++ b/erpnext/accounts/doctype/repost_accounting_ledger/repost_accounting_ledger.py
@@ -7,6 +7,7 @@ import frappe
 from frappe import _, qb
 from frappe.desk.form.linked_with import get_child_tables_of_doctypes
 from frappe.model.document import Document
+from frappe.utils.background_jobs import is_job_enqueued
 from frappe.utils.data import comma_and
 
 
@@ -26,6 +27,11 @@ class RepostAccountingLedger(Document):
 		amended_from: DF.Link | None
 		company: DF.Link | None
 		delete_cancelled_entries: DF.Check
+		error_log: DF.Code | None
+		scheduled_job: DF.Link | None
+		status: DF.Literal[
+			"", "Queued", "In Progress", "Partially Reposted", "Completed", "Failed", "Cancelled"
+		]
 		vouchers: DF.Table[RepostAccountingLedgerItems]
 	# end: auto-generated types
 
@@ -71,8 +77,45 @@ class RepostAccountingLedger(Document):
 						frappe.throw(_("Cannot Resubmit Ledger entries for vouchers in Closed fiscal year."))
 
 	def validate_vouchers(self):
-		if self.vouchers:
-			validate_docs_for_voucher_types([x.voucher_type for x in self.vouchers])
+		if not self.vouchers:
+			frappe.throw(_("Add atleast one voucher to repost."))
+
+		validate_docs_for_voucher_types([x.voucher_type for x in self.vouchers])
+
+		self.validate_no_duplicate_vouchers()
+		self.validate_vouchers_are_submitted()
+
+	def validate_no_duplicate_vouchers(self):
+		vouchers = [(x.voucher_type, x.voucher_no) for x in self.vouchers]
+
+		if len(vouchers) != len(set(vouchers)):
+			frappe.throw(_("Duplicate vouchers found. Remove the duplicate vouchers to continue to repost."))
+
+	def validate_vouchers_are_submitted(self):
+		voucher_type_wise_map = {}
+		for d in self.vouchers:
+			voucher_type_wise_map.setdefault(d.voucher_type, [])
+			voucher_type_wise_map[d.voucher_type].append(d.voucher_no)
+
+		non_submitted_vouchers = []
+		for key in voucher_type_wise_map.keys():
+			non_submitted_vouchers.extend(
+				frappe.get_all(
+					key,
+					filters={"name": ["in", voucher_type_wise_map[key]], "docstatus": ["!=", 1]},
+					pluck="name",
+				)
+			)
+
+		if non_submitted_vouchers:
+			frappe.throw(
+				_("The following vouchers are not submitted: {0}").format(
+					comma_and(non_submitted_vouchers, add_quotes=True)
+				)
+			)
+
+	def on_discard(self):
+		self.db_set("status", "Cancelled")
 
 	def get_existing_ledger_entries(self):
 		vouchers = [x.voucher_no for x in self.vouchers]
@@ -137,80 +180,196 @@ class RepostAccountingLedger(Document):
 		return rendered_page
 
 	def on_submit(self):
-		if len(self.vouchers) > 5:
-			job_name = "repost_accounting_ledger_" + self.name
-			frappe.enqueue(
-				method="erpnext.accounts.doctype.repost_accounting_ledger.repost_accounting_ledger.start_repost",
-				account_repost_doc=self.name,
-				is_async=True,
-				job_name=job_name,
-				enqueue_after_commit=True,
-			)
-			frappe.msgprint(_("Repost has started in the background"))
-		else:
-			start_repost(self.name)
+		if frappe.in_test:
+			return
+		self.start_repost()
+
+	def before_cancel(self):
+		self._raise_error_if_reposting_in_progress()
+
+	def on_cancel(self):
+		self.db_set("status", "Cancelled")
+
+	def _raise_error_if_reposting_in_progress(self):
+		if self.scheduled_job and is_job_enqueued(self.scheduled_job):
+			frappe.throw(_("Reposting is still in progress in background."))
+
+	@frappe.whitelist()
+	def start_repost(self):
+		if self.docstatus != 1:
+			frappe.throw(_("Reposting can be started only for submitted document."))
+
+		if self.status in ["Queued", "In Progress", "Completed", "Cancelled"]:
+			frappe.throw(_("Reposting cannot be started when status is {0}.").format(self.status))
+
+		self._raise_error_if_reposting_in_progress()
+
+		self.check_permission("write")
+		self.db_set("status", "Queued")
+
+		job_id = frappe.generate_hash()
+		frappe.enqueue(
+			method="erpnext.accounts.doctype.repost_accounting_ledger.repost_accounting_ledger.repost",
+			repost_doc_name=self.name,
+			is_async=True,
+			job_name=f"repost_accounting_ledger_{self.name}",
+			job_id=job_id,
+			enqueue_after_commit=True,
+		)
+		self.db_set("scheduled_job", job_id)
+		frappe.msgprint(_("Repost has started in the background"), alert=True, indicator="blue")
 
 
-@frappe.whitelist()
-def start_repost(account_repost_doc: str | None = None) -> None:
-	from erpnext.accounts.general_ledger import make_reverse_gl_entries
+def _lock_vouchers(vouchers):
+	"""Lock every voucher up front so a concurrent repost cannot touch the same GL entries."""
+	locked_docs = []
+	try:
+		for x in vouchers:
+			doc = frappe.get_doc(x.voucher_type, x.voucher_no)
+			doc.lock()
+			locked_docs.append(doc)
+	except frappe.DocumentLockedError:
+		for doc in locked_docs:
+			doc.unlock()
+		raise
+	return locked_docs
 
-	frappe.flags.through_repost_accounting_ledger = True
-	if account_repost_doc:
-		repost_doc = frappe.get_doc("Repost Accounting Ledger", account_repost_doc)
-		repost_doc.check_permission("write")
 
-		if repost_doc.docstatus == 1:
-			# Prevent repost on invoices with deferred accounting
-			repost_doc.validate_for_deferred_accounting()
+def repost(repost_doc_name: str):
+	locked_docs = []
+	try:
+		from erpnext.accounts.utils import _delete_accounting_ledger_entries, _delete_adv_pl_entries
 
-			for x in repost_doc.vouchers:
+		frappe.flags.through_repost_accounting_ledger = True
+
+		repost_doc = frappe.get_doc("Repost Accounting Ledger", repost_doc_name)
+
+		locked_docs = _lock_vouchers(repost_doc.vouchers)
+
+		repost_doc.db_set("status", "In Progress", commit=True)
+
+		for x in repost_doc.vouchers:
+			if x.reposted:
+				continue
+
+			save_point = "reposting"
+			frappe.db.savepoint(save_point=save_point)
+			try:
 				doc = frappe.get_doc(x.voucher_type, x.voucher_no)
 
+				if doc.docstatus == 2:
+					x.db_set(
+						{
+							"reposted": 1,
+							"traceback": _("{0} {1} has been cancelled, nothing to repost.").format(
+								x.voucher_type, x.voucher_no
+							),
+						},
+						commit=True,
+					)
+					continue
+
 				if repost_doc.delete_cancelled_entries:
-					frappe.db.delete(
-						"GL Entry", filters={"voucher_type": doc.doctype, "voucher_no": doc.name}
-					)
-					frappe.db.delete(
-						"Payment Ledger Entry", filters={"voucher_type": doc.doctype, "voucher_no": doc.name}
-					)
-					frappe.db.delete(
-						"Advance Payment Ledger Entry",
-						filters={"voucher_type": doc.doctype, "voucher_no": doc.name},
-					)
+					_delete_accounting_ledger_entries(doc.doctype, doc.name)
+					_delete_adv_pl_entries(doc.doctype, doc.name)
 
-				if doc.doctype in ["Sales Invoice", "Purchase Invoice"]:
-					if not repost_doc.delete_cancelled_entries:
-						doc.docstatus = 2
-						doc.make_gl_entries_on_cancel(from_repost=True)
+				_repost_vouchers(doc, repost_doc.delete_cancelled_entries)
+			except Exception:
+				frappe.db.rollback(save_point=save_point)
 
-					doc.docstatus = 1
-					if doc.doctype == "Sales Invoice":
-						doc.force_set_against_income_account()
-					else:
-						doc.force_set_against_expense_account()
-					doc.make_gl_entries()
+				traceback = frappe.get_traceback(with_context=True)
 
-				elif doc.doctype == "Purchase Receipt":
-					if not repost_doc.delete_cancelled_entries:
-						doc.docstatus = 2
-						doc.make_gl_entries_on_cancel(from_repost=True)
+				x.db_set("traceback", traceback)
+			else:
+				x.db_set({"reposted": 1, "traceback": ""})
+			finally:
+				frappe.db.commit()
 
-					doc.docstatus = 1
-					doc.make_gl_entries(from_repost=True)
+	except Exception:
+		if frappe.in_test:
+			# Don't silently fail in tests,
+			# there is no reason for reposts to fail in CI
+			raise
 
-				elif doc.doctype in ["Payment Entry", "Journal Entry", "Expense Claim"]:
-					if not repost_doc.delete_cancelled_entries:
-						doc.make_gl_entries(1)
-					doc.make_gl_entries()
-				elif doc.doctype in frappe.get_hooks("repost_allowed_doctypes"):
-					if hasattr(doc, "make_gl_entries") and callable(doc.make_gl_entries):
-						if not repost_doc.delete_cancelled_entries:
-							if "cancel" in inspect.getfullargspec(doc.make_gl_entries):
-								doc.make_gl_entries(cancel=1)
-							else:
-								make_reverse_gl_entries(voucher_type=doc.doctype, voucher_no=doc.name)
-						doc.make_gl_entries()
+		frappe.db.rollback()
+		traceback = frappe.get_traceback(with_context=True)
+
+		frappe.log_error(
+			title=_("Unable to Repost Accounting Ledger"),
+		)
+
+		frappe.db.set_value(
+			"Repost Accounting Ledger", repost_doc_name, {"error_log": traceback, "status": "Failed"}
+		)
+	else:
+		reposted = sum(1 for voucher in repost_doc.vouchers if voucher.reposted)
+
+		if reposted == len(repost_doc.vouchers):
+			status = "Completed"
+		elif reposted == 0:
+			status = "Failed"
+		else:
+			status = "Partially Reposted"
+
+		repost_doc.db_set({"status": status, "error_log": ""}, notify=True)
+	finally:
+		for doc in locked_docs:
+			doc.unlock()
+		frappe.db.commit()
+
+
+def _repost_vouchers(doc, delete_cancelled_entries: bool | int | None):
+	if doc.doctype in ["Sales Invoice", "Purchase Invoice"]:
+		_repost_invoices(doc, delete_cancelled_entries)
+
+	elif doc.doctype == "Purchase Receipt":
+		_repost_purchase_receipt(doc, delete_cancelled_entries)
+
+	elif doc.doctype in ["Payment Entry", "Journal Entry"]:
+		_repost_pe_je(doc, delete_cancelled_entries)
+
+	elif doc.doctype in frappe.get_hooks("repost_allowed_doctypes"):
+		_repost_allowed_hook_doctypes(doc, delete_cancelled_entries)
+
+
+def _repost_invoices(invoice_doc, delete_cancelled_entries):
+	if not delete_cancelled_entries:
+		invoice_doc.docstatus = 2
+		invoice_doc.make_gl_entries_on_cancel(from_repost=True)
+
+	invoice_doc.docstatus = 1
+	if invoice_doc.doctype == "Sales Invoice":
+		invoice_doc.force_set_against_income_account()
+	else:
+		invoice_doc.force_set_against_expense_account()
+	invoice_doc.make_gl_entries()
+
+
+def _repost_purchase_receipt(receipt_doc, delete_cancelled_entries):
+	if not delete_cancelled_entries:
+		receipt_doc.docstatus = 2
+		receipt_doc.make_gl_entries_on_cancel(from_repost=True)
+
+	receipt_doc.docstatus = 1
+	receipt_doc.make_gl_entries(from_repost=True)
+
+
+def _repost_pe_je(entry_doc, delete_cancelled_entries):
+	if not delete_cancelled_entries:
+		entry_doc.make_gl_entries(cancel=1)
+	entry_doc.make_gl_entries()
+
+
+def _repost_allowed_hook_doctypes(repost_doc, delete_cancelled_entries: bool | int | None):
+	from erpnext.accounts.general_ledger import make_reverse_gl_entries
+
+	if hasattr(repost_doc, "make_gl_entries") and callable(repost_doc.make_gl_entries):
+		if not delete_cancelled_entries:
+			if "cancel" in inspect.getfullargspec(repost_doc.make_gl_entries).args:
+				repost_doc.make_gl_entries(cancel=1)
+			else:
+				make_reverse_gl_entries(voucher_type=repost_doc.doctype, voucher_no=repost_doc.name)
+		repost_doc.make_gl_entries()
 
 
 def get_allowed_types_from_settings(child_doc: bool = False):

--- a/erpnext/accounts/doctype/repost_accounting_ledger/repost_accounting_ledger.py
+++ b/erpnext/accounts/doctype/repost_accounting_ledger/repost_accounting_ledger.py
@@ -272,16 +272,22 @@ def _enqueue_repost(repost_doc_name: str) -> str:
 	return create_job_id(job_id)
 
 
-def _lock_vouchers(vouchers):
-	"""Lock every voucher up front so a concurrent repost cannot touch the same GL entries."""
-	locked_docs = []
+def _lock_vouchers(vouchers) -> dict:
+	"""Lock every voucher up front so a concurrent repost cannot touch the same GL entries.
+
+	Returns the locked documents keyed by voucher, so reposting does not have to load them
+	a second time. Note that these are file locks under the site directory: they serialise
+	nothing across hosts that do not share it, and a worker killed outright leaves them
+	behind until they expire.
+	"""
+	locked_docs = {}
 	try:
 		for x in vouchers:
 			doc = frappe.get_doc(x.voucher_type, x.voucher_no)
 			doc.lock()
-			locked_docs.append(doc)
+			locked_docs[(x.voucher_type, x.voucher_no)] = doc
 	except Exception:
-		for doc in locked_docs:
+		for doc in locked_docs.values():
 			doc.unlock()
 		raise
 	return locked_docs
@@ -294,7 +300,7 @@ def repost(repost_doc_name: str, commit: bool = True):
 	after every voucher so that progress survives a crash, and rolls back what it could not
 	finish. A caller running this inside its own transaction passes `False` and keeps both.
 	"""
-	locked_docs = []
+	locked_docs = {}
 	repost_doc = None
 	try:
 		from erpnext.accounts.utils import _delete_accounting_ledger_entries, _delete_adv_pl_entries
@@ -316,7 +322,7 @@ def repost(repost_doc_name: str, commit: bool = True):
 			save_point = "reposting"
 			frappe.db.savepoint(save_point=save_point)
 			try:
-				doc = frappe.get_doc(x.voucher_type, x.voucher_no)
+				doc = locked_docs[(x.voucher_type, x.voucher_no)]
 
 				if doc.docstatus == 2:
 					x.db_set(
@@ -355,7 +361,7 @@ def repost(repost_doc_name: str, commit: bool = True):
 	else:
 		repost_doc.db_set({"status": _derive_status(repost_doc), "error_log": ""}, notify=True)
 	finally:
-		for doc in locked_docs:
+		for doc in locked_docs.values():
 			doc.unlock()
 		if commit:
 			frappe.db.commit()  # nosemgrep

--- a/erpnext/accounts/doctype/repost_accounting_ledger/repost_accounting_ledger.py
+++ b/erpnext/accounts/doctype/repost_accounting_ledger/repost_accounting_ledger.py
@@ -248,7 +248,7 @@ def repost(repost_doc_name: str):
 
 		locked_docs = _lock_vouchers(repost_doc.vouchers)
 
-		repost_doc.db_set("status", "In Progress", commit=True)
+		repost_doc.db_set("status", "In Progress", commit=not frappe.in_test)
 
 		for x in repost_doc.vouchers:
 			if x.reposted:
@@ -267,7 +267,7 @@ def repost(repost_doc_name: str):
 								x.voucher_type, x.voucher_no
 							),
 						},
-						commit=True,
+						commit=not frappe.in_test,
 					)
 					continue
 

--- a/erpnext/accounts/doctype/repost_accounting_ledger/repost_accounting_ledger.py
+++ b/erpnext/accounts/doctype/repost_accounting_ledger/repost_accounting_ledger.py
@@ -180,8 +180,6 @@ class RepostAccountingLedger(Document):
 		return rendered_page
 
 	def on_submit(self):
-		if frappe.in_test:
-			return
 		self.start_repost()
 
 	def before_cancel(self):
@@ -206,6 +204,10 @@ class RepostAccountingLedger(Document):
 
 		self.check_permission("write")
 		self.db_set("status", "Queued")
+
+		if frappe.in_test:
+			repost(repost_doc_name=self.name)
+			return
 
 		job_id = frappe.generate_hash()
 		frappe.enqueue(
@@ -283,7 +285,8 @@ def repost(repost_doc_name: str):
 			else:
 				x.db_set({"reposted": 1, "traceback": ""})
 			finally:
-				frappe.db.commit()
+				if not frappe.in_test:
+					frappe.db.commit()
 
 	except Exception:
 		if frappe.in_test:
@@ -315,7 +318,8 @@ def repost(repost_doc_name: str):
 	finally:
 		for doc in locked_docs:
 			doc.unlock()
-		frappe.db.commit()
+		if not frappe.in_test:
+			frappe.db.commit()
 
 
 def _repost_vouchers(doc, delete_cancelled_entries: bool | int | None):

--- a/erpnext/accounts/doctype/repost_accounting_ledger/repost_accounting_ledger.py
+++ b/erpnext/accounts/doctype/repost_accounting_ledger/repost_accounting_ledger.py
@@ -7,7 +7,7 @@ import frappe
 from frappe import _, qb
 from frappe.desk.form.linked_with import get_child_tables_of_doctypes
 from frappe.model.document import Document
-from frappe.utils.background_jobs import is_job_enqueued
+from frappe.utils.background_jobs import create_job_id, is_job_enqueued
 from frappe.utils.data import comma_and
 from frappe.utils.scheduler import is_scheduler_inactive
 
@@ -206,7 +206,7 @@ class RepostAccountingLedger(Document):
 		self.db_set("status", "Cancelled")
 
 	def _raise_error_if_reposting_in_progress(self):
-		if self.scheduled_job and is_job_enqueued(self.scheduled_job):
+		if is_job_enqueued(_repost_job_id(self.name)):
 			frappe.throw(_("Reposting is still in progress in background."))
 
 	@frappe.whitelist()
@@ -214,8 +214,10 @@ class RepostAccountingLedger(Document):
 		if self.docstatus != 1:
 			frappe.throw(_("Reposting can be started only for submitted document."))
 
-		if self.status in TERMINAL_STATUSES:
-			frappe.throw(_("Reposting cannot be started when status is {0}.").format(self.status))
+		# read the status under a row lock, so two concurrent starts cannot both get past here
+		status = frappe.db.get_value(self.doctype, self.name, "status", for_update=True)
+		if status in TERMINAL_STATUSES:
+			frappe.throw(_("Reposting cannot be started when status is {0}.").format(status))
 
 		# `Queued` and `In Progress` are not blocked by the status alone. A worker that is killed
 		# or times out leaves the status behind, and the document has to stay restartable.
@@ -250,20 +252,24 @@ def _revalidate_before_repost(repost_doc) -> None:
 	repost_doc.validate_for_deferred_accounting()
 
 
+def _repost_job_id(repost_doc_name: str) -> str:
+	"""Derive the job id from the document, so a repost can only ever have one job."""
+	return f"repost_accounting_ledger::{repost_doc_name}"
+
+
 def _enqueue_repost(repost_doc_name: str) -> str:
-	"""Hand the repost over to a background worker and return the id of the job."""
-	job_id = frappe.generate_hash()
+	"""Hand the repost over to a background worker and return the name of the `RQ Job`."""
+	job_id = _repost_job_id(repost_doc_name)
 	frappe.enqueue(
 		method="erpnext.accounts.doctype.repost_accounting_ledger.repost_accounting_ledger.repost",
 		repost_doc_name=repost_doc_name,
 		queue="long",
 		timeout=REPOST_JOB_TIMEOUT,
-		is_async=True,
-		job_name=f"repost_accounting_ledger_{repost_doc_name}",
 		job_id=job_id,
+		deduplicate=True,
 		enqueue_after_commit=True,
 	)
-	return job_id
+	return create_job_id(job_id)
 
 
 def _lock_vouchers(vouchers):

--- a/erpnext/accounts/doctype/repost_accounting_ledger/repost_accounting_ledger.py
+++ b/erpnext/accounts/doctype/repost_accounting_ledger/repost_accounting_ledger.py
@@ -261,17 +261,27 @@ def _repost_job_id(repost_doc_name: str) -> str:
 
 
 def _enqueue_repost(repost_doc_name: str) -> str:
-	"""Hand the repost over to a background worker and return the name of the `RQ Job`."""
+	"""Hand the repost over to a background worker and return the name of the `RQ Job`.
+
+	Documents edited after submit repost themselves through `repost_accounting_entries`, and
+	tests across apps assert on the ledger right after doing so. They run the repost here
+	instead, in the foreground and inside their own transaction.
+	"""
 	job_id = _repost_job_id(repost_doc_name)
-	frappe.enqueue(
-		method="erpnext.accounts.doctype.repost_accounting_ledger.repost_accounting_ledger.repost",
-		repost_doc_name=repost_doc_name,
-		queue="long",
-		timeout=REPOST_JOB_TIMEOUT,
-		job_id=job_id,
-		deduplicate=True,
-		enqueue_after_commit=True,
-	)
+
+	if frappe.in_test:
+		repost(repost_doc_name, commit=False)
+	else:
+		frappe.enqueue(
+			method="erpnext.accounts.doctype.repost_accounting_ledger.repost_accounting_ledger.repost",
+			repost_doc_name=repost_doc_name,
+			queue="long",
+			timeout=REPOST_JOB_TIMEOUT,
+			job_id=job_id,
+			deduplicate=True,
+			enqueue_after_commit=True,
+		)
+
 	return create_job_id(job_id)
 
 

--- a/erpnext/accounts/doctype/repost_accounting_ledger/repost_accounting_ledger.py
+++ b/erpnext/accounts/doctype/repost_accounting_ledger/repost_accounting_ledger.py
@@ -14,6 +14,11 @@ from frappe.utils.scheduler import is_scheduler_inactive
 # Every voucher is reposted by a single background job, so the batch has to stay small enough
 # to finish well within the queue timeout.
 MAX_VOUCHERS_PER_REPOST = 50
+REPOST_JOB_TIMEOUT = 1500
+
+# Statuses a document cannot be moved out of. Everything else can be restarted, including
+# `Queued` and `In Progress`, which are held back by the background job instead.
+TERMINAL_STATUSES = ("Completed", "Cancelled")
 
 
 class RepostAccountingLedger(Document):
@@ -209,9 +214,11 @@ class RepostAccountingLedger(Document):
 		if self.docstatus != 1:
 			frappe.throw(_("Reposting can be started only for submitted document."))
 
-		if self.status in ["Queued", "In Progress", "Completed", "Cancelled"]:
+		if self.status in TERMINAL_STATUSES:
 			frappe.throw(_("Reposting cannot be started when status is {0}.").format(self.status))
 
+		# `Queued` and `In Progress` are not blocked by the status alone. A worker that is killed
+		# or times out leaves the status behind, and the document has to stay restartable.
 		self._raise_error_if_reposting_in_progress()
 
 		self.check_permission("write")
@@ -231,6 +238,8 @@ class RepostAccountingLedger(Document):
 		frappe.enqueue(
 			method="erpnext.accounts.doctype.repost_accounting_ledger.repost_accounting_ledger.repost",
 			repost_doc_name=self.name,
+			queue="long",
+			timeout=REPOST_JOB_TIMEOUT,
 			is_async=True,
 			job_name=f"repost_accounting_ledger_{self.name}",
 			job_id=job_id,

--- a/erpnext/accounts/doctype/repost_accounting_ledger/repost_accounting_ledger.py
+++ b/erpnext/accounts/doctype/repost_accounting_ledger/repost_accounting_ledger.py
@@ -300,16 +300,16 @@ def repost(repost_doc_name: str, commit: bool = True):
 	try:
 		repost_doc.validate_repost_preconditions()
 
-		locked_docs = _lock_vouchers(repost_doc.vouchers)
+		# a retry leaves the vouchers it is done with alone: they are not locked, not loaded
+		# and not reposted again
+		pending = [x for x in repost_doc.vouchers if x.status not in HANDLED_VOUCHER_STATUSES]
+		locked_docs = _lock_vouchers(pending)
 
 		repost_doc.db_set("status", "In Progress", commit=commit)
 
-		for position, x in enumerate(repost_doc.vouchers, start=1):
-			if x.status in HANDLED_VOUCHER_STATUSES:
-				continue
-
+		for position, x in enumerate(pending, start=1):
 			frappe.publish_progress(
-				position * 100 / len(repost_doc.vouchers),
+				position * 100 / len(pending),
 				doctype=repost_doc.doctype,
 				docname=repost_doc.name,
 				description=_("Reposting {0} {1}").format(x.voucher_type, x.voucher_no),

--- a/erpnext/accounts/doctype/repost_accounting_ledger/repost_accounting_ledger.py
+++ b/erpnext/accounts/doctype/repost_accounting_ledger/repost_accounting_ledger.py
@@ -11,6 +11,10 @@ from frappe.utils.background_jobs import is_job_enqueued
 from frappe.utils.data import comma_and
 from frappe.utils.scheduler import is_scheduler_inactive
 
+# Every voucher is reposted by a single background job, so the batch has to stay small enough
+# to finish well within the queue timeout.
+MAX_VOUCHERS_PER_REPOST = 50
+
 
 class RepostAccountingLedger(Document):
 	# begin: auto-generated types
@@ -80,6 +84,13 @@ class RepostAccountingLedger(Document):
 	def validate_vouchers(self):
 		if not self.vouchers:
 			frappe.throw(_("Add atleast one voucher to repost."))
+
+		if len(self.vouchers) > MAX_VOUCHERS_PER_REPOST:
+			frappe.throw(
+				_("Cannot repost more than {0} vouchers at once. Split them into multiple documents.").format(
+					MAX_VOUCHERS_PER_REPOST
+				)
+			)
 
 		validate_docs_for_voucher_types([x.voucher_type for x in self.vouchers])
 

--- a/erpnext/accounts/doctype/repost_accounting_ledger/repost_accounting_ledger.py
+++ b/erpnext/accounts/doctype/repost_accounting_ledger/repost_accounting_ledger.py
@@ -318,7 +318,14 @@ def repost(repost_doc_name: str, commit: bool = True):
 
 		repost_doc.db_set("status", "In Progress", commit=commit)
 
-		for x in repost_doc.vouchers:
+		for position, x in enumerate(repost_doc.vouchers, start=1):
+			frappe.publish_progress(
+				position * 100 / len(repost_doc.vouchers),
+				doctype=repost_doc.doctype,
+				docname=repost_doc.name,
+				description=_("Reposting {0} {1}").format(x.voucher_type, x.voucher_no),
+			)
+
 			if x.status in HANDLED_VOUCHER_STATUSES:
 				continue
 

--- a/erpnext/accounts/doctype/repost_accounting_ledger/repost_accounting_ledger_list.js
+++ b/erpnext/accounts/doctype/repost_accounting_ledger/repost_accounting_ledger_list.js
@@ -1,0 +1,14 @@
+frappe.listview_settings["Repost Accounting Ledger"] = {
+	add_fields: ["status"],
+	get_indicator: function (doc) {
+		const status_color = {
+			Queued: "yellow",
+			"In Progress": "blue",
+			"Partially Reposted": "orange",
+			Completed: "green",
+			Failed: "red",
+		};
+		const color = status_color[doc.status] || "gray";
+		return [__(doc.status || "Draft"), color, "status,=," + doc.status];
+	},
+};

--- a/erpnext/accounts/doctype/repost_accounting_ledger/repost_accounting_ledger_list.js
+++ b/erpnext/accounts/doctype/repost_accounting_ledger/repost_accounting_ledger_list.js
@@ -7,6 +7,7 @@ frappe.listview_settings["Repost Accounting Ledger"] = {
 			"Partially Reposted": "orange",
 			Completed: "green",
 			Failed: "red",
+			Cancelled: "dark grey",
 		};
 		const color = status_color[doc.status] || "gray";
 		return [__(doc.status || "Draft"), color, "status,=," + doc.status];

--- a/erpnext/accounts/doctype/repost_accounting_ledger/repost_accounting_ledger_list.js
+++ b/erpnext/accounts/doctype/repost_accounting_ledger/repost_accounting_ledger_list.js
@@ -1,15 +1,16 @@
 frappe.listview_settings["Repost Accounting Ledger"] = {
 	add_fields: ["status"],
+	// drafts and cancelled documents are coloured by the framework before it gets here
 	get_indicator: function (doc) {
+		if (!doc.status) return;
+
 		const status_color = {
 			Queued: "yellow",
 			"In Progress": "blue",
 			"Partially Reposted": "orange",
 			Completed: "green",
 			Failed: "red",
-			Cancelled: "dark grey",
 		};
-		const color = status_color[doc.status] || "gray";
-		return [__(doc.status || "Draft"), color, "status,=," + doc.status];
+		return [__(doc.status), status_color[doc.status] || "gray", "status,=," + doc.status];
 	},
 };

--- a/erpnext/accounts/doctype/repost_accounting_ledger/test_repost_accounting_ledger.py
+++ b/erpnext/accounts/doctype/repost_accounting_ledger/test_repost_accounting_ledger.py
@@ -427,7 +427,45 @@ class TestRepostAccountingLedger(ERPNextTestSuite):
 		_record_repost_failure(ral.name)
 		self.assertEqual(frappe.db.get_value(ral.doctype, ral.name, "status"), "Failed")
 
-	def test_13_failed_repost_skips_cancelled_voucher(self):
+	@ERPNextTestSuite.change_settings("Accounts Settings", {"delete_linked_ledger_entries": 1})
+	def test_13_period_closed_after_the_repost_was_started(self):
+		gl = qb.DocType("GL Entry")
+		qb.from_(gl).delete().where(gl.company == "_Test Company").run()
+
+		si = self.create_sales_invoice()
+		ral = self.create_repost_doc([si], submit=True)
+		ral.db_set("status", "Failed")
+		ral.vouchers[0].db_set("reposted", 0)
+
+		# the period is closed between the repost being started and the job running
+		fy = get_fiscal_year(today(), company="_Test Company")
+		pcv = frappe.get_doc(
+			{
+				"doctype": "Period Closing Voucher",
+				"transaction_date": today(),
+				"period_start_date": fy[1],
+				"period_end_date": today(),
+				"company": "_Test Company",
+				"fiscal_year": fy[0],
+				"cost_center": "Main - _TC",
+				"closing_account_head": "Retained Earnings - _TC",
+				"remarks": "test",
+			}
+		)
+		pcv.save().submit()
+
+		gl_entries = frappe.db.count("GL Entry", {"voucher_no": si.name})
+		self.assertRaisesRegex(frappe.ValidationError, "Closed fiscal year", repost, ral.name, commit=False)
+
+		ral.reload()
+		self.assertEqual(ral.status, "Failed")
+		self.assertIn("Closed fiscal year", ral.error_log)
+
+		# the ledger is left exactly as it was
+		self.assertEqual(frappe.db.count("GL Entry", {"voucher_no": si.name}), gl_entries)
+		self.assertEqual(ral.vouchers[0].reposted, 0)
+
+	def test_14_failed_repost_skips_cancelled_voucher(self):
 		si = self.create_sales_invoice()
 
 		ral = self.create_repost_doc([si])
@@ -447,7 +485,7 @@ class TestRepostAccountingLedger(ERPNextTestSuite):
 		self.assertEqual(ral.vouchers[0].reposted, 1)
 		self.assertIn("has been cancelled, nothing to repost", ral.vouchers[0].traceback)
 
-	def test_14_concurrent_repost_is_blocked_by_voucher_lock(self):
+	def test_15_concurrent_repost_is_blocked_by_voucher_lock(self):
 		si, pe = self.create_invoice_and_payment()
 		ral = self.create_repost_doc([si, pe])
 
@@ -462,7 +500,7 @@ class TestRepostAccountingLedger(ERPNextTestSuite):
 		finally:
 			locked_pe.unlock()
 
-	def test_15_journal_entry_repost(self):
+	def test_16_journal_entry_repost(self):
 		je = make_journal_entry("_Test Bank - _TC", "_Test Cash - _TC", 500, submit=True)
 		je = frappe.get_doc("Journal Entry", je.name)
 
@@ -492,7 +530,7 @@ class TestRepostAccountingLedger(ERPNextTestSuite):
 					cancelled_entries,
 				)
 
-	def test_16_hook_allowed_doctype_repost(self):
+	def test_17_hook_allowed_doctype_repost(self):
 		class VoucherWithCancelArg:
 			doctype = "Test Repost Voucher"
 			name = "TRV-00001"

--- a/erpnext/accounts/doctype/repost_accounting_ledger/test_repost_accounting_ledger.py
+++ b/erpnext/accounts/doctype/repost_accounting_ledger/test_repost_accounting_ledger.py
@@ -7,7 +7,6 @@ from unittest.mock import patch
 import frappe
 from frappe import qb
 from frappe.query_builder.functions import Sum
-from frappe.tests.utils import toggle_test_mode
 from frappe.utils import add_days, nowdate, today
 
 from erpnext.accounts.doctype.journal_entry.test_journal_entry import make_journal_entry
@@ -17,6 +16,7 @@ from erpnext.accounts.doctype.repost_accounting_ledger.repost_accounting_ledger 
 	_record_repost_failure,
 	_repost_allowed_hook_doctypes,
 	_repost_vouchers,
+	repost,
 )
 from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_sales_invoice
 from erpnext.accounts.utils import get_fiscal_year
@@ -32,6 +32,16 @@ class TestRepostAccountingLedger(ERPNextTestSuite):
 	def setUp(self):
 		frappe.db.set_single_value("Selling Settings", "validate_selling_price", 0)
 		update_repost_settings()
+
+		# reposting is handed over to a worker; run it in the foreground and inside the
+		# transaction of the test instead
+		patcher = patch(f"{REPOST_MODULE}._enqueue_repost", side_effect=self.repost_in_foreground)
+		patcher.start()
+		self.addCleanup(patcher.stop)
+
+	def repost_in_foreground(self, repost_doc_name):
+		repost(repost_doc_name, commit=False)
+		return frappe.generate_hash()
 
 	def create_sales_invoice(self, **kwargs):
 		return create_sales_invoice(
@@ -77,15 +87,6 @@ class TestRepostAccountingLedger(ERPNextTestSuite):
 
 		with patch(f"{REPOST_MODULE}._repost_vouchers", side_effect=repost_voucher):
 			yield
-
-	@contextmanager
-	def outside_test_mode(self):
-		"""Reposting is only handed over to a background job outside of test mode."""
-		try:
-			toggle_test_mode(False)
-			yield
-		finally:
-			toggle_test_mode(True)
 
 	def assert_repost_blocked(self, ral, message):
 		self.assertRaisesRegex(frappe.ValidationError, message, ral.start_repost)
@@ -359,12 +360,6 @@ class TestRepostAccountingLedger(ERPNextTestSuite):
 		ral.reload()
 
 		with patch(f"{REPOST_MODULE}.is_job_enqueued", return_value=False):
-			with (
-				self.outside_test_mode(),
-				patch(f"{REPOST_MODULE}.is_scheduler_inactive", return_value=True),
-			):
-				self.assert_repost_blocked(ral, "Scheduler is inactive")
-
 			# the job is gone, so `In Progress` must not keep the document stuck
 			ral.start_repost()
 

--- a/erpnext/accounts/doctype/repost_accounting_ledger/test_repost_accounting_ledger.py
+++ b/erpnext/accounts/doctype/repost_accounting_ledger/test_repost_accounting_ledger.py
@@ -1,18 +1,30 @@
 # Copyright (c) 2023, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
 
+from contextlib import contextmanager
+from unittest.mock import patch
+
 import frappe
 from frappe import qb
 from frappe.query_builder.functions import Sum
+from frappe.tests.utils import toggle_test_mode
 from frappe.utils import add_days, nowdate, today
 
+from erpnext.accounts.doctype.journal_entry.test_journal_entry import make_journal_entry
 from erpnext.accounts.doctype.payment_entry.payment_entry import get_payment_entry
 from erpnext.accounts.doctype.payment_request.payment_request import make_payment_request
+from erpnext.accounts.doctype.repost_accounting_ledger.repost_accounting_ledger import (
+	_repost_allowed_hook_doctypes,
+	_repost_vouchers,
+)
 from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_sales_invoice
 from erpnext.accounts.utils import get_fiscal_year
 from erpnext.stock.doctype.item.test_item import make_item
 from erpnext.stock.doctype.purchase_receipt.test_purchase_receipt import get_gl_entries, make_purchase_receipt
 from erpnext.tests.utils import ERPNextTestSuite
+
+REPOST_MODULE = "erpnext.accounts.doctype.repost_accounting_ledger.repost_accounting_ledger"
+SIMULATED_FAILURE = "Simulated repost failure"
 
 
 class TestRepostAccountingLedger(ERPNextTestSuite):
@@ -20,8 +32,8 @@ class TestRepostAccountingLedger(ERPNextTestSuite):
 		frappe.db.set_single_value("Selling Settings", "validate_selling_price", 0)
 		update_repost_settings()
 
-	def test_01_basic_functions(self):
-		si = create_sales_invoice(
+	def create_sales_invoice(self, **kwargs):
+		return create_sales_invoice(
 			item="_Test Item",
 			company="_Test Company",
 			customer="_Test Customer",
@@ -29,7 +41,56 @@ class TestRepostAccountingLedger(ERPNextTestSuite):
 			parent_cost_center="Main - _TC",
 			cost_center="Main - _TC",
 			rate=100,
+			**kwargs,
 		)
+
+	def create_invoice_and_payment(self):
+		si = self.create_sales_invoice()
+		pe = get_payment_entry(si.doctype, si.name)
+		pe.save().submit()
+		return si, pe
+
+	def create_repost_doc(self, vouchers, delete_cancelled_entries=False, submit=False):
+		ral = frappe.new_doc("Repost Accounting Ledger")
+		ral.company = "_Test Company"
+		ral.delete_cancelled_entries = delete_cancelled_entries
+		for voucher in vouchers:
+			ral.append("vouchers", {"voucher_type": voucher.doctype, "voucher_no": voucher.name})
+
+		ral.save()
+		if submit:
+			ral.submit()
+			ral.reload()
+		return ral
+
+	@contextmanager
+	def patched_repost(self, fail_for=(), calls=None):
+		"""Record the vouchers handed over to `_repost_vouchers` and fail the given voucher types."""
+
+		def repost_voucher(doc, delete_cancelled_entries):
+			if calls is not None:
+				calls.append(doc.name)
+			if doc.doctype in fail_for:
+				frappe.throw(SIMULATED_FAILURE)
+			_repost_vouchers(doc, delete_cancelled_entries)
+
+		with patch(f"{REPOST_MODULE}._repost_vouchers", side_effect=repost_voucher):
+			yield
+
+	@contextmanager
+	def outside_test_mode(self):
+		"""Reposting is only handed over to a background job outside of test mode."""
+		try:
+			toggle_test_mode(False)
+			yield
+		finally:
+			toggle_test_mode(True)
+
+	def assert_repost_blocked(self, ral, message):
+		self.assertRaisesRegex(frappe.ValidationError, message, ral.start_repost)
+
+	def test_01_basic_functions(self):
+		si = self.create_sales_invoice()
 
 		preq = frappe.get_doc(
 			make_payment_request(
@@ -91,16 +152,7 @@ class TestRepostAccountingLedger(ERPNextTestSuite):
 		self.assertEqual(res[0], (si.name, 100, 100))
 
 	def test_02_deferred_accounting_valiations(self):
-		si = create_sales_invoice(
-			item="_Test Item",
-			company="_Test Company",
-			customer="_Test Customer",
-			debit_to="Debtors - _TC",
-			parent_cost_center="Main - _TC",
-			cost_center="Main - _TC",
-			rate=100,
-			do_not_submit=True,
-		)
+		si = self.create_sales_invoice(do_not_submit=True)
 		si.items[0].enable_deferred_revenue = True
 		si.items[0].deferred_revenue_account = "Deferred Revenue - _TC"
 		si.items[0].service_start_date = nowdate()
@@ -118,15 +170,7 @@ class TestRepostAccountingLedger(ERPNextTestSuite):
 		gl = frappe.qb.DocType("GL Entry")
 		qb.from_(gl).delete().where(gl.company == "_Test Company").run()
 
-		si = create_sales_invoice(
-			item="_Test Item",
-			company="_Test Company",
-			customer="_Test Customer",
-			debit_to="Debtors - _TC",
-			parent_cost_center="Main - _TC",
-			cost_center="Main - _TC",
-			rate=100,
-		)
+		si = self.create_sales_invoice()
 		fy = get_fiscal_year(today(), company="_Test Company")
 		pcv = frappe.get_doc(
 			{
@@ -153,51 +197,19 @@ class TestRepostAccountingLedger(ERPNextTestSuite):
 		pcv.delete()
 
 	def test_03_deletion_flag_and_preview_function(self):
-		si = create_sales_invoice(
-			item="_Test Item",
-			company="_Test Company",
-			customer="_Test Customer",
-			debit_to="Debtors - _TC",
-			parent_cost_center="Main - _TC",
-			cost_center="Main - _TC",
-			rate=100,
-		)
-
-		pe = get_payment_entry(si.doctype, si.name)
-		pe.save().submit()
+		si, pe = self.create_invoice_and_payment()
 
 		# with deletion flag set
-		ral = frappe.new_doc("Repost Accounting Ledger")
-		ral.company = "_Test Company"
-		ral.delete_cancelled_entries = True
-		ral.append("vouchers", {"voucher_type": si.doctype, "voucher_no": si.name})
-		ral.append("vouchers", {"voucher_type": pe.doctype, "voucher_no": pe.name})
-		ral.save().submit()
+		self.create_repost_doc([si, pe], delete_cancelled_entries=True, submit=True)
 
 		self.assertIsNone(frappe.db.exists("GL Entry", {"voucher_no": si.name, "is_cancelled": 1}))
 		self.assertIsNone(frappe.db.exists("GL Entry", {"voucher_no": pe.name, "is_cancelled": 1}))
 
 	def test_05_without_deletion_flag(self):
-		si = create_sales_invoice(
-			item="_Test Item",
-			company="_Test Company",
-			customer="_Test Customer",
-			debit_to="Debtors - _TC",
-			parent_cost_center="Main - _TC",
-			cost_center="Main - _TC",
-			rate=100,
-		)
-
-		pe = get_payment_entry(si.doctype, si.name)
-		pe.save().submit()
+		si, pe = self.create_invoice_and_payment()
 
 		# without deletion flag set
-		ral = frappe.new_doc("Repost Accounting Ledger")
-		ral.company = "_Test Company"
-		ral.delete_cancelled_entries = False
-		ral.append("vouchers", {"voucher_type": si.doctype, "voucher_no": si.name})
-		ral.append("vouchers", {"voucher_type": pe.doctype, "voucher_no": pe.name})
-		ral.save().submit()
+		self.create_repost_doc([si, pe], submit=True)
 
 		self.assertIsNotNone(frappe.db.exists("GL Entry", {"voucher_no": si.name, "is_cancelled": 1}))
 		self.assertIsNotNone(frappe.db.exists("GL Entry", {"voucher_no": pe.name, "is_cancelled": 1}))
@@ -248,11 +260,7 @@ class TestRepostAccountingLedger(ERPNextTestSuite):
 			another_provisional_account,
 		)
 
-		repost_doc = frappe.new_doc("Repost Accounting Ledger")
-		repost_doc.company = "_Test Company"
-		repost_doc.delete_cancelled_entries = True
-		repost_doc.append("vouchers", {"voucher_type": pr.doctype, "voucher_no": pr.name})
-		repost_doc.save().submit()
+		repost_doc = self.create_repost_doc([pr], delete_cancelled_entries=True, submit=True)
 
 		pr_gles_after_repost = get_gl_entries(pr.doctype, pr.name, skip_cancelled=True)
 		expected_pr_gles_after_repost = [
@@ -272,6 +280,212 @@ class TestRepostAccountingLedger(ERPNextTestSuite):
 		company.enable_provisional_accounting_for_non_stock_items = 0
 		company.default_provisional_account = None
 		company.save()
+
+	def test_07_voucher_validations(self):
+		submitted_si = self.create_sales_invoice()
+		draft_si = self.create_sales_invoice(do_not_submit=True)
+		cancelled_si = self.create_sales_invoice()
+		cancelled_si.cancel()
+
+		for vouchers, exception, message in (
+			([], frappe.ValidationError, "Add atleast one voucher"),
+			([submitted_si, submitted_si], frappe.ValidationError, "Duplicate vouchers found"),
+			([draft_si], frappe.ValidationError, f"not submitted.*{draft_si.name}"),
+			# cancelled vouchers don't make it past link validation
+			([cancelled_si], frappe.CancelledLinkError, "Cannot link cancelled document"),
+		):
+			with self.subTest(vouchers=[x.name for x in vouchers]):
+				self.assertRaisesRegex(exception, message, self.create_repost_doc, vouchers)
+
+		self.create_repost_doc([submitted_si])
+
+	def test_08_status_lifecycle(self):
+		si, pe = self.create_invoice_and_payment()
+
+		ral = self.create_repost_doc([si, pe])
+		self.assertEqual(ral.status, "")
+
+		ral.submit()
+		ral.reload()
+
+		self.assertEqual(ral.status, "Completed")
+		self.assertFalse(ral.error_log)
+		for voucher in ral.vouchers:
+			self.assertEqual(voucher.reposted, 1)
+			self.assertFalse(voucher.traceback)
+
+		ral.cancel()
+		ral.reload()
+		self.assertEqual(ral.status, "Cancelled")
+
+		discarded = self.create_repost_doc([si])
+		discarded.discard()
+		discarded.reload()
+		self.assertEqual(discarded.status, "Cancelled")
+
+	def test_09_start_repost_guards(self):
+		si = self.create_sales_invoice()
+		ral = self.create_repost_doc([si])
+
+		self.assert_repost_blocked(ral, "only for submitted document")
+
+		ral.submit()
+		ral.reload()
+		self.assert_repost_blocked(ral, "cannot be started when status is Completed")
+
+		ral.db_set("status", "Failed")
+		ral.db_set("scheduled_job", frappe.generate_hash())
+
+		with patch(f"{REPOST_MODULE}.is_job_enqueued", return_value=True):
+			self.assert_repost_blocked(ral, "still in progress in background")
+			self.assertRaisesRegex(frappe.ValidationError, "still in progress in background", ral.cancel)
+
+		# `cancel` flips docstatus in memory before running `before_cancel`
+		ral.reload()
+
+		with patch(f"{REPOST_MODULE}.is_job_enqueued", return_value=False):
+			with (
+				self.outside_test_mode(),
+				patch(f"{REPOST_MODULE}.is_scheduler_inactive", return_value=True),
+			):
+				self.assert_repost_blocked(ral, "Scheduler is inactive")
+
+			# none of the guards leave the document in a state that cannot be retried
+			ral.start_repost()
+
+		ral.reload()
+		self.assertEqual(ral.status, "Completed")
+
+	def test_10_voucher_failures_are_isolated_and_retried(self):
+		si, pe = self.create_invoice_and_payment()
+		pe_gl_entries = frappe.db.count("GL Entry", {"voucher_no": pe.name})
+
+		# the deletion flag drops the existing entries before reposting them
+		ral = self.create_repost_doc([si, pe], delete_cancelled_entries=True)
+		with self.patched_repost(fail_for=["Payment Entry"]):
+			ral.submit()
+
+		ral.reload()
+		self.assertEqual(ral.status, "Partially Reposted")
+
+		si_row, pe_row = ral.vouchers
+		self.assertEqual((si_row.reposted, pe_row.reposted), (1, 0))
+		self.assertFalse(si_row.traceback)
+		self.assertIn(SIMULATED_FAILURE, pe_row.traceback)
+
+		# the failed voucher is rolled back to its savepoint, so its entries are back
+		self.assertEqual(frappe.db.count("GL Entry", {"voucher_no": pe.name}), pe_gl_entries)
+
+		# a retry only picks up the vouchers that are not reposted yet
+		retried = []
+		with self.patched_repost(calls=retried):
+			ral.start_repost()
+
+		self.assertEqual(retried, [pe.name])
+
+		ral.reload()
+		self.assertEqual(ral.status, "Completed")
+		for voucher in ral.vouchers:
+			self.assertEqual(voucher.reposted, 1)
+			self.assertFalse(voucher.traceback)
+
+	def test_11_failed_repost_skips_cancelled_voucher(self):
+		si = self.create_sales_invoice()
+
+		ral = self.create_repost_doc([si])
+		with self.patched_repost(fail_for=["Sales Invoice"]):
+			ral.submit()
+
+		ral.reload()
+		self.assertEqual(ral.status, "Failed")
+
+		si.reload()
+		si.cancel()
+
+		ral.start_repost()
+		ral.reload()
+
+		self.assertEqual(ral.status, "Completed")
+		self.assertEqual(ral.vouchers[0].reposted, 1)
+		self.assertIn("has been cancelled, nothing to repost", ral.vouchers[0].traceback)
+
+	def test_12_concurrent_repost_is_blocked_by_voucher_lock(self):
+		si, pe = self.create_invoice_and_payment()
+		ral = self.create_repost_doc([si, pe])
+
+		# a concurrent repost holding the lock on the second voucher
+		locked_pe = frappe.get_doc(pe.doctype, pe.name)
+		locked_pe.lock()
+		try:
+			self.assertRaises(frappe.DocumentLockedError, ral.submit)
+
+			# vouchers locked before the failure are released again
+			self.assertFalse(frappe.get_doc(si.doctype, si.name).is_locked)
+		finally:
+			locked_pe.unlock()
+
+	def test_13_journal_entry_repost(self):
+		je = make_journal_entry("_Test Bank - _TC", "_Test Cash - _TC", 500, submit=True)
+		je = frappe.get_doc("Journal Entry", je.name)
+
+		def get_gl_totals():
+			gl = qb.DocType("GL Entry")
+			return (
+				qb.from_(gl)
+				.select(Sum(gl.debit), Sum(gl.credit))
+				.where((gl.voucher_no == je.name) & (gl.is_cancelled == 0))
+				.run()
+			)[0]
+
+		self.assertEqual(get_gl_totals(), (500.0, 500.0))
+
+		# without the deletion flag the 2 original entries are marked as cancelled,
+		# along with the 2 reverse entries booked against them
+		for delete_cancelled_entries, cancelled_entries in ((False, 4), (True, 0)):
+			with self.subTest(delete_cancelled_entries=delete_cancelled_entries):
+				ral = self.create_repost_doc(
+					[je], delete_cancelled_entries=delete_cancelled_entries, submit=True
+				)
+
+				self.assertEqual(ral.status, "Completed")
+				self.assertEqual(get_gl_totals(), (500.0, 500.0))
+				self.assertEqual(
+					frappe.db.count("GL Entry", {"voucher_no": je.name, "is_cancelled": 1}),
+					cancelled_entries,
+				)
+
+	def test_14_hook_allowed_doctype_repost(self):
+		class VoucherWithCancelArg:
+			doctype = "Test Repost Voucher"
+			name = "TRV-00001"
+
+			def __init__(self):
+				self.calls = []
+
+			def make_gl_entries(self, cancel=0):
+				self.calls.append(cancel)
+
+		class VoucherWithoutCancelArg(VoucherWithCancelArg):
+			def make_gl_entries(self):
+				self.calls.append("repost")
+
+		# vouchers that can reverse their own entries are asked to do so first
+		doc = VoucherWithCancelArg()
+		_repost_allowed_hook_doctypes(doc, delete_cancelled_entries=False)
+		self.assertEqual(doc.calls, [1, 0])
+
+		# nothing to reverse when the old entries are deleted
+		doc = VoucherWithCancelArg()
+		_repost_allowed_hook_doctypes(doc, delete_cancelled_entries=True)
+		self.assertEqual(doc.calls, [0])
+
+		# the rest fall back to the generic reversal
+		doc = VoucherWithoutCancelArg()
+		with patch("erpnext.accounts.general_ledger.make_reverse_gl_entries") as make_reverse_gl_entries:
+			_repost_allowed_hook_doctypes(doc, delete_cancelled_entries=False)
+
+		make_reverse_gl_entries.assert_called_once_with(voucher_type=doc.doctype, voucher_no=doc.name)
+		self.assertEqual(doc.calls, ["repost"])
 
 
 def update_repost_settings():

--- a/erpnext/accounts/doctype/repost_accounting_ledger/test_repost_accounting_ledger.py
+++ b/erpnext/accounts/doctype/repost_accounting_ledger/test_repost_accounting_ledger.py
@@ -13,6 +13,7 @@ from erpnext.accounts.doctype.journal_entry.test_journal_entry import make_journ
 from erpnext.accounts.doctype.payment_entry.payment_entry import get_payment_entry
 from erpnext.accounts.doctype.payment_request.payment_request import make_payment_request
 from erpnext.accounts.doctype.repost_accounting_ledger.repost_accounting_ledger import (
+	_lock_vouchers,
 	_record_repost_failure,
 	_repost_allowed_hook_doctypes,
 	_repost_job_id,
@@ -380,11 +381,16 @@ class TestRepostAccountingLedger(ERPNextTestSuite):
 		# the failed voucher is rolled back to its savepoint, so its entries are back
 		self.assertEqual(frappe.db.count("GL Entry", {"voucher_no": pe.name}), pe_gl_entries)
 
-		# a retry only picks up the vouchers that are not reposted yet
-		with self.patched_repost() as retried:
+		# a retry only picks up the vouchers that are not reposted yet, and leaves the rest
+		# alone entirely: they are not locked or loaded either
+		with (
+			patch(f"{REPOST_MODULE}._lock_vouchers", side_effect=_lock_vouchers) as lock_vouchers,
+			self.patched_repost() as retried,
+		):
 			ral.start_repost()
 
 		self.assertEqual(retried, [pe.name])
+		self.assertEqual([x.voucher_no for x in lock_vouchers.call_args.args[0]], [pe.name])
 
 		ral.reload()
 		self.assertEqual(ral.status, "Completed")

--- a/erpnext/accounts/doctype/repost_accounting_ledger/test_repost_accounting_ledger.py
+++ b/erpnext/accounts/doctype/repost_accounting_ledger/test_repost_accounting_ledger.py
@@ -8,13 +8,16 @@ import frappe
 from frappe import qb
 from frappe.query_builder.functions import Sum
 from frappe.utils import add_days, nowdate, today
+from frappe.utils.background_jobs import create_job_id
 
 from erpnext.accounts.doctype.journal_entry.test_journal_entry import make_journal_entry
 from erpnext.accounts.doctype.payment_entry.payment_entry import get_payment_entry
 from erpnext.accounts.doctype.payment_request.payment_request import make_payment_request
 from erpnext.accounts.doctype.repost_accounting_ledger.repost_accounting_ledger import (
+	_enqueue_repost,
 	_record_repost_failure,
 	_repost_allowed_hook_doctypes,
+	_repost_job_id,
 	_repost_vouchers,
 	repost,
 )
@@ -41,7 +44,7 @@ class TestRepostAccountingLedger(ERPNextTestSuite):
 
 	def repost_in_foreground(self, repost_doc_name):
 		repost(repost_doc_name, commit=False)
-		return frappe.generate_hash()
+		return create_job_id(_repost_job_id(repost_doc_name))
 
 	def create_sales_invoice(self, **kwargs):
 		return create_sales_invoice(
@@ -350,7 +353,6 @@ class TestRepostAccountingLedger(ERPNextTestSuite):
 
 		# a document left behind by a worker that died mid-repost
 		ral.db_set("status", "In Progress")
-		ral.db_set("scheduled_job", frappe.generate_hash())
 
 		with patch(f"{REPOST_MODULE}.is_job_enqueued", return_value=True):
 			self.assert_repost_blocked(ral, "still in progress in background")
@@ -366,7 +368,23 @@ class TestRepostAccountingLedger(ERPNextTestSuite):
 		ral.reload()
 		self.assertEqual(ral.status, "Completed")
 
-	def test_11_voucher_failures_are_isolated_and_retried(self):
+	def test_11_repost_job_is_tied_to_the_document(self):
+		si = self.create_sales_invoice()
+		ral = self.create_repost_doc([si], submit=True)
+
+		# the stored job is the `RQ Job` of this repost, so the link resolves
+		self.assertEqual(ral.scheduled_job, create_job_id(_repost_job_id(ral.name)))
+
+		with patch(f"{REPOST_MODULE}.frappe.enqueue") as enqueue:
+			_enqueue_repost(ral.name)
+
+		kwargs = enqueue.call_args.kwargs
+		self.assertEqual(kwargs["repost_doc_name"], ral.name)
+		self.assertEqual(kwargs["job_id"], _repost_job_id(ral.name))
+		# a second start cannot queue a second job for the same document
+		self.assertTrue(kwargs["deduplicate"])
+
+	def test_12_voucher_failures_are_isolated_and_retried(self):
 		si, pe = self.create_invoice_and_payment()
 		pe_gl_entries = frappe.db.count("GL Entry", {"voucher_no": pe.name})
 
@@ -399,7 +417,7 @@ class TestRepostAccountingLedger(ERPNextTestSuite):
 			self.assertEqual(voucher.reposted, 1)
 			self.assertFalse(voucher.traceback)
 
-	def test_12_status_of_a_run_that_could_not_finish(self):
+	def test_13_status_of_a_run_that_could_not_finish(self):
 		si, pe = self.create_invoice_and_payment()
 
 		ral = self.create_repost_doc([si, pe])
@@ -428,7 +446,7 @@ class TestRepostAccountingLedger(ERPNextTestSuite):
 		self.assertEqual(frappe.db.get_value(ral.doctype, ral.name, "status"), "Failed")
 
 	@ERPNextTestSuite.change_settings("Accounts Settings", {"delete_linked_ledger_entries": 1})
-	def test_13_period_closed_after_the_repost_was_started(self):
+	def test_14_period_closed_after_the_repost_was_started(self):
 		gl = qb.DocType("GL Entry")
 		qb.from_(gl).delete().where(gl.company == "_Test Company").run()
 
@@ -465,7 +483,7 @@ class TestRepostAccountingLedger(ERPNextTestSuite):
 		self.assertEqual(frappe.db.count("GL Entry", {"voucher_no": si.name}), gl_entries)
 		self.assertEqual(ral.vouchers[0].reposted, 0)
 
-	def test_14_failed_repost_skips_cancelled_voucher(self):
+	def test_15_failed_repost_skips_cancelled_voucher(self):
 		si = self.create_sales_invoice()
 
 		ral = self.create_repost_doc([si])
@@ -485,7 +503,7 @@ class TestRepostAccountingLedger(ERPNextTestSuite):
 		self.assertEqual(ral.vouchers[0].reposted, 1)
 		self.assertIn("has been cancelled, nothing to repost", ral.vouchers[0].traceback)
 
-	def test_15_concurrent_repost_is_blocked_by_voucher_lock(self):
+	def test_16_concurrent_repost_is_blocked_by_voucher_lock(self):
 		si, pe = self.create_invoice_and_payment()
 		ral = self.create_repost_doc([si, pe])
 
@@ -500,7 +518,7 @@ class TestRepostAccountingLedger(ERPNextTestSuite):
 		finally:
 			locked_pe.unlock()
 
-	def test_16_journal_entry_repost(self):
+	def test_17_journal_entry_repost(self):
 		je = make_journal_entry("_Test Bank - _TC", "_Test Cash - _TC", 500, submit=True)
 		je = frappe.get_doc("Journal Entry", je.name)
 
@@ -530,7 +548,7 @@ class TestRepostAccountingLedger(ERPNextTestSuite):
 					cancelled_entries,
 				)
 
-	def test_17_hook_allowed_doctype_repost(self):
+	def test_18_hook_allowed_doctype_repost(self):
 		class VoucherWithCancelArg:
 			doctype = "Test Repost Voucher"
 			name = "TRV-00001"

--- a/erpnext/accounts/doctype/repost_accounting_ledger/test_repost_accounting_ledger.py
+++ b/erpnext/accounts/doctype/repost_accounting_ledger/test_repost_accounting_ledger.py
@@ -329,6 +329,7 @@ class TestRepostAccountingLedger(ERPNextTestSuite):
 		self.assertEqual(ral.status, "Completed")
 		self.assertFalse(ral.error_log)
 		for voucher in ral.vouchers:
+			self.assertEqual(voucher.status, "Reposted")
 			self.assertEqual(voucher.reposted, 1)
 			self.assertFalse(voucher.traceback)
 
@@ -397,7 +398,7 @@ class TestRepostAccountingLedger(ERPNextTestSuite):
 		self.assertEqual(ral.status, "Partially Reposted")
 
 		si_row, pe_row = ral.vouchers
-		self.assertEqual((si_row.reposted, pe_row.reposted), (1, 0))
+		self.assertEqual((si_row.status, pe_row.status), ("Reposted", "Failed"))
 		self.assertFalse(si_row.traceback)
 		self.assertIn(SIMULATED_FAILURE, pe_row.traceback)
 
@@ -414,7 +415,7 @@ class TestRepostAccountingLedger(ERPNextTestSuite):
 		ral.reload()
 		self.assertEqual(ral.status, "Completed")
 		for voucher in ral.vouchers:
-			self.assertEqual(voucher.reposted, 1)
+			self.assertEqual(voucher.status, "Reposted")
 			self.assertFalse(voucher.traceback)
 
 	def test_13_status_of_a_run_that_could_not_finish(self):
@@ -453,7 +454,7 @@ class TestRepostAccountingLedger(ERPNextTestSuite):
 		si = self.create_sales_invoice()
 		ral = self.create_repost_doc([si], submit=True)
 		ral.db_set("status", "Failed")
-		ral.vouchers[0].db_set("reposted", 0)
+		ral.vouchers[0].db_set({"status": "Pending", "reposted": 0})
 
 		# the period is closed between the repost being started and the job running
 		fy = get_fiscal_year(today(), company="_Test Company")
@@ -481,7 +482,7 @@ class TestRepostAccountingLedger(ERPNextTestSuite):
 
 		# the ledger is left exactly as it was
 		self.assertEqual(frappe.db.count("GL Entry", {"voucher_no": si.name}), gl_entries)
-		self.assertEqual(ral.vouchers[0].reposted, 0)
+		self.assertEqual(ral.vouchers[0].status, "Pending")
 
 	def test_15_failed_repost_skips_cancelled_voucher(self):
 		si = self.create_sales_invoice()
@@ -499,9 +500,11 @@ class TestRepostAccountingLedger(ERPNextTestSuite):
 		ral.start_repost()
 		ral.reload()
 
+		# nothing was reposted, but there is nothing left to repost either
 		self.assertEqual(ral.status, "Completed")
-		self.assertEqual(ral.vouchers[0].reposted, 1)
-		self.assertIn("has been cancelled, nothing to repost", ral.vouchers[0].traceback)
+		self.assertEqual(ral.vouchers[0].status, "Skipped")
+		self.assertFalse(ral.vouchers[0].traceback)
+		self.assertIn("has been cancelled, nothing to repost", ral.vouchers[0].remark)
 
 	def test_16_concurrent_repost_is_blocked_by_voucher_lock(self):
 		si, pe = self.create_invoice_and_payment()

--- a/erpnext/accounts/doctype/repost_accounting_ledger/test_repost_accounting_ledger.py
+++ b/erpnext/accounts/doctype/repost_accounting_ledger/test_repost_accounting_ledger.py
@@ -346,7 +346,8 @@ class TestRepostAccountingLedger(ERPNextTestSuite):
 		ral.reload()
 		self.assert_repost_blocked(ral, "cannot be started when status is Completed")
 
-		ral.db_set("status", "Failed")
+		# a document left behind by a worker that died mid-repost
+		ral.db_set("status", "In Progress")
 		ral.db_set("scheduled_job", frappe.generate_hash())
 
 		with patch(f"{REPOST_MODULE}.is_job_enqueued", return_value=True):
@@ -363,7 +364,7 @@ class TestRepostAccountingLedger(ERPNextTestSuite):
 			):
 				self.assert_repost_blocked(ral, "Scheduler is inactive")
 
-			# none of the guards leave the document in a state that cannot be retried
+			# the job is gone, so `In Progress` must not keep the document stuck
 			ral.start_repost()
 
 		ral.reload()

--- a/erpnext/accounts/doctype/repost_accounting_ledger/test_repost_accounting_ledger.py
+++ b/erpnext/accounts/doctype/repost_accounting_ledger/test_repost_accounting_ledger.py
@@ -36,16 +36,6 @@ class TestRepostAccountingLedger(ERPNextTestSuite):
 		frappe.db.set_single_value("Selling Settings", "validate_selling_price", 0)
 		update_repost_settings()
 
-		# reposting is handed over to a worker; run it in the foreground and inside the
-		# transaction of the test instead
-		patcher = patch(f"{REPOST_MODULE}._enqueue_repost", side_effect=self.repost_in_foreground)
-		patcher.start()
-		self.addCleanup(patcher.stop)
-
-	def repost_in_foreground(self, repost_doc_name):
-		repost(repost_doc_name, commit=False)
-		return create_job_id(_repost_job_id(repost_doc_name))
-
 	def create_sales_invoice(self, **kwargs):
 		return create_sales_invoice(
 			item="_Test Item",
@@ -376,7 +366,10 @@ class TestRepostAccountingLedger(ERPNextTestSuite):
 		# the stored job is the `RQ Job` of this repost, so the link resolves
 		self.assertEqual(ral.scheduled_job, create_job_id(_repost_job_id(ral.name)))
 
-		with patch(f"{REPOST_MODULE}.frappe.enqueue") as enqueue:
+		with (
+			patch(f"{REPOST_MODULE}.frappe.in_test", False),
+			patch(f"{REPOST_MODULE}.frappe.enqueue") as enqueue,
+		):
 			_enqueue_repost(ral.name)
 
 		kwargs = enqueue.call_args.kwargs

--- a/erpnext/accounts/doctype/repost_accounting_ledger/test_repost_accounting_ledger.py
+++ b/erpnext/accounts/doctype/repost_accounting_ledger/test_repost_accounting_ledger.py
@@ -8,13 +8,11 @@ import frappe
 from frappe import qb
 from frappe.query_builder.functions import Sum
 from frappe.utils import add_days, nowdate, today
-from frappe.utils.background_jobs import create_job_id
 
 from erpnext.accounts.doctype.journal_entry.test_journal_entry import make_journal_entry
 from erpnext.accounts.doctype.payment_entry.payment_entry import get_payment_entry
 from erpnext.accounts.doctype.payment_request.payment_request import make_payment_request
 from erpnext.accounts.doctype.repost_accounting_ledger.repost_accounting_ledger import (
-	_enqueue_repost,
 	_record_repost_failure,
 	_repost_allowed_hook_doctypes,
 	_repost_job_id,
@@ -36,7 +34,7 @@ class TestRepostAccountingLedger(ERPNextTestSuite):
 		frappe.db.set_single_value("Selling Settings", "validate_selling_price", 0)
 		update_repost_settings()
 
-	def create_sales_invoice(self, **kwargs):
+	def make_invoice(self, **kwargs):
 		return create_sales_invoice(
 			item="_Test Item",
 			company="_Test Company",
@@ -48,8 +46,8 @@ class TestRepostAccountingLedger(ERPNextTestSuite):
 			**kwargs,
 		)
 
-	def create_invoice_and_payment(self):
-		si = self.create_sales_invoice()
+	def make_invoice_and_payment(self):
+		si = self.make_invoice()
 		pe = get_payment_entry(si.doctype, si.name)
 		pe.save().submit()
 		return si, pe
@@ -68,24 +66,47 @@ class TestRepostAccountingLedger(ERPNextTestSuite):
 		return ral
 
 	@contextmanager
-	def patched_repost(self, fail_for=(), calls=None):
-		"""Record the vouchers handed over to `_repost_vouchers` and fail the given voucher types."""
+	def patched_repost(self, fail_for=()):
+		"""Yield the vouchers handed over to `_repost_vouchers`, failing the given types."""
+		reposted = []
 
 		def repost_voucher(doc, delete_cancelled_entries):
-			if calls is not None:
-				calls.append(doc.name)
+			reposted.append(doc.name)
 			if doc.doctype in fail_for:
 				frappe.throw(SIMULATED_FAILURE)
 			_repost_vouchers(doc, delete_cancelled_entries)
 
-		with patch(f"{REPOST_MODULE}._repost_vouchers", side_effect=repost_voucher):
-			yield
+		with patch(f"{REPOST_MODULE}._repost_vouchers", new=repost_voucher):
+			yield reposted
 
-	def assert_repost_blocked(self, ral, message):
-		self.assertRaisesRegex(frappe.ValidationError, message, ral.start_repost)
+	def make_period_closing_voucher(self):
+		fy = get_fiscal_year(today(), company="_Test Company")
+		pcv = frappe.get_doc(
+			{
+				"doctype": "Period Closing Voucher",
+				"transaction_date": today(),
+				"period_start_date": fy[1],
+				"period_end_date": today(),
+				"company": "_Test Company",
+				"fiscal_year": fy[0],
+				"cost_center": "Main - _TC",
+				"closing_account_head": "Retained Earnings - _TC",
+				"remarks": "test",
+			}
+		)
+		return pcv.save().submit()
+
+	def get_gl_totals(self, voucher_no, is_cancelled=0):
+		gl = qb.DocType("GL Entry")
+		return (
+			qb.from_(gl)
+			.select(Sum(gl.debit).as_("debit"), Sum(gl.credit).as_("credit"))
+			.where((gl.voucher_no == voucher_no) & (gl.is_cancelled == is_cancelled))
+			.run()
+		)[0]
 
 	def test_01_basic_functions(self):
-		si = self.create_sales_invoice()
+		si = self.make_invoice()
 
 		preq = frappe.get_doc(
 			make_payment_request(
@@ -120,44 +141,24 @@ class TestRepostAccountingLedger(ERPNextTestSuite):
 		gle = frappe.db.get_all("GL Entry", filters={"voucher_no": si.name, "account": "Debtors - _TC"})
 		frappe.db.set_value("GL Entry", gle[0], "debit", 90)
 
-		gl = qb.DocType("GL Entry")
-		res = (
-			qb.from_(gl)
-			.select(gl.voucher_no, Sum(gl.debit).as_("debit"), Sum(gl.credit).as_("credit"))
-			.where((gl.voucher_no == si.name) & (gl.is_cancelled == 0))
-			.groupby(gl.voucher_no)
-			.run()
-		)
-
 		# Assert incorrect ledger balance
-		self.assertNotEqual(res[0], (si.name, 100, 100))
+		self.assertNotEqual(self.get_gl_totals(si.name), (100, 100))
 
 		# Submit repost document
 		ral.save().submit()
 
-		res = (
-			qb.from_(gl)
-			.select(gl.voucher_no, Sum(gl.debit).as_("debit"), Sum(gl.credit).as_("credit"))
-			.where((gl.voucher_no == si.name) & (gl.is_cancelled == 0))
-			.groupby(gl.voucher_no)
-			.run()
-		)
-
 		# Ledger should reflect correct amount post repost
-		self.assertEqual(res[0], (si.name, 100, 100))
+		self.assertEqual(self.get_gl_totals(si.name), (100, 100))
 
 	def test_02_deferred_accounting_valiations(self):
-		si = self.create_sales_invoice(do_not_submit=True)
+		si = self.make_invoice(do_not_submit=True)
 		si.items[0].enable_deferred_revenue = True
 		si.items[0].deferred_revenue_account = "Deferred Revenue - _TC"
 		si.items[0].service_start_date = nowdate()
 		si.items[0].service_end_date = add_days(nowdate(), 90)
 		si.save().submit()
 
-		ral = frappe.new_doc("Repost Accounting Ledger")
-		ral.company = "_Test Company"
-		ral.append("vouchers", {"voucher_type": si.doctype, "voucher_no": si.name})
-		self.assertRaises(frappe.ValidationError, ral.save)
+		self.assertRaises(frappe.ValidationError, self.create_repost_doc, [si])
 
 	@ERPNextTestSuite.change_settings("Accounts Settings", {"delete_linked_ledger_entries": 1})
 	def test_04_pcv_validation(self):
@@ -165,34 +166,17 @@ class TestRepostAccountingLedger(ERPNextTestSuite):
 		gl = frappe.qb.DocType("GL Entry")
 		qb.from_(gl).delete().where(gl.company == "_Test Company").run()
 
-		si = self.create_sales_invoice()
-		fy = get_fiscal_year(today(), company="_Test Company")
-		pcv = frappe.get_doc(
-			{
-				"doctype": "Period Closing Voucher",
-				"transaction_date": today(),
-				"period_start_date": fy[1],
-				"period_end_date": today(),
-				"company": "_Test Company",
-				"fiscal_year": fy[0],
-				"cost_center": "Main - _TC",
-				"closing_account_head": "Retained Earnings - _TC",
-				"remarks": "test",
-			}
-		)
-		pcv.save().submit()
+		si = self.make_invoice()
+		pcv = self.make_period_closing_voucher()
 
-		ral = frappe.new_doc("Repost Accounting Ledger")
-		ral.company = "_Test Company"
-		ral.append("vouchers", {"voucher_type": si.doctype, "voucher_no": si.name})
-		self.assertRaises(frappe.ValidationError, ral.save)
+		self.assertRaises(frappe.ValidationError, self.create_repost_doc, [si])
 
 		pcv.reload()
 		pcv.cancel()
 		pcv.delete()
 
 	def test_03_deletion_flag_and_preview_function(self):
-		si, pe = self.create_invoice_and_payment()
+		si, pe = self.make_invoice_and_payment()
 
 		# with deletion flag set
 		self.create_repost_doc([si, pe], delete_cancelled_entries=True, submit=True)
@@ -201,7 +185,7 @@ class TestRepostAccountingLedger(ERPNextTestSuite):
 		self.assertIsNone(frappe.db.exists("GL Entry", {"voucher_no": pe.name, "is_cancelled": 1}))
 
 	def test_05_without_deletion_flag(self):
-		si, pe = self.create_invoice_and_payment()
+		si, pe = self.make_invoice_and_payment()
 
 		# without deletion flag set
 		self.create_repost_doc([si, pe], submit=True)
@@ -277,9 +261,9 @@ class TestRepostAccountingLedger(ERPNextTestSuite):
 		company.save()
 
 	def test_07_voucher_validations(self):
-		submitted_si = self.create_sales_invoice()
-		draft_si = self.create_sales_invoice(do_not_submit=True)
-		cancelled_si = self.create_sales_invoice()
+		submitted_si = self.make_invoice()
+		draft_si = self.make_invoice(do_not_submit=True)
+		cancelled_si = self.make_invoice()
 		cancelled_si.cancel()
 
 		for vouchers, exception, message in (
@@ -295,8 +279,8 @@ class TestRepostAccountingLedger(ERPNextTestSuite):
 		self.create_repost_doc([submitted_si])
 
 	def test_08_voucher_count_limit(self):
-		si, pe = self.create_invoice_and_payment()
-		another_si = self.create_sales_invoice()
+		si, pe = self.make_invoice_and_payment()
+		another_si = self.make_invoice()
 
 		with patch(f"{REPOST_MODULE}.MAX_VOUCHERS_PER_REPOST", 2):
 			self.create_repost_doc([si, pe])
@@ -308,7 +292,7 @@ class TestRepostAccountingLedger(ERPNextTestSuite):
 			)
 
 	def test_09_status_lifecycle(self):
-		si, pe = self.create_invoice_and_payment()
+		si, pe = self.make_invoice_and_payment()
 
 		ral = self.create_repost_doc([si, pe])
 		self.assertEqual(ral.status, "")
@@ -320,7 +304,6 @@ class TestRepostAccountingLedger(ERPNextTestSuite):
 		self.assertFalse(ral.error_log)
 		for voucher in ral.vouchers:
 			self.assertEqual(voucher.status, "Reposted")
-			self.assertEqual(voucher.reposted, 1)
 			self.assertFalse(voucher.traceback)
 
 		ral.cancel()
@@ -333,20 +316,24 @@ class TestRepostAccountingLedger(ERPNextTestSuite):
 		self.assertEqual(discarded.status, "Cancelled")
 
 	def test_10_start_repost_guards(self):
-		si = self.create_sales_invoice()
+		si = self.make_invoice()
 		ral = self.create_repost_doc([si])
 
-		self.assert_repost_blocked(ral, "only for submitted document")
+		self.assertRaisesRegex(frappe.ValidationError, "only for submitted document", ral.start_repost)
 
 		ral.submit()
 		ral.reload()
-		self.assert_repost_blocked(ral, "cannot be started when status is Completed")
+		self.assertRaisesRegex(
+			frappe.ValidationError, "cannot be started when status is Completed", ral.start_repost
+		)
 
 		# a document left behind by a worker that died mid-repost
 		ral.db_set("status", "In Progress")
 
 		with patch(f"{REPOST_MODULE}.is_job_enqueued", return_value=True):
-			self.assert_repost_blocked(ral, "still in progress in background")
+			self.assertRaisesRegex(
+				frappe.ValidationError, "still in progress in background", ral.start_repost
+			)
 			self.assertRaisesRegex(frappe.ValidationError, "still in progress in background", ral.cancel)
 
 		# `cancel` flips docstatus in memory before running `before_cancel`
@@ -360,17 +347,12 @@ class TestRepostAccountingLedger(ERPNextTestSuite):
 		self.assertEqual(ral.status, "Completed")
 
 	def test_11_repost_job_is_tied_to_the_document(self):
-		si = self.create_sales_invoice()
+		si = self.make_invoice()
 		ral = self.create_repost_doc([si], submit=True)
+		ral.db_set("status", "Failed")
 
-		# the stored job is the `RQ Job` of this repost, so the link resolves
-		self.assertEqual(ral.scheduled_job, create_job_id(_repost_job_id(ral.name)))
-
-		with (
-			patch(f"{REPOST_MODULE}.frappe.in_test", False),
-			patch(f"{REPOST_MODULE}.frappe.enqueue") as enqueue,
-		):
-			_enqueue_repost(ral.name)
+		with patch(f"{REPOST_MODULE}.frappe.enqueue") as enqueue:
+			ral.start_repost()
 
 		kwargs = enqueue.call_args.kwargs
 		self.assertEqual(kwargs["repost_doc_name"], ral.name)
@@ -379,7 +361,7 @@ class TestRepostAccountingLedger(ERPNextTestSuite):
 		self.assertTrue(kwargs["deduplicate"])
 
 	def test_12_voucher_failures_are_isolated_and_retried(self):
-		si, pe = self.create_invoice_and_payment()
+		si, pe = self.make_invoice_and_payment()
 		pe_gl_entries = frappe.db.count("GL Entry", {"voucher_no": pe.name})
 
 		# the deletion flag drops the existing entries before reposting them
@@ -399,8 +381,7 @@ class TestRepostAccountingLedger(ERPNextTestSuite):
 		self.assertEqual(frappe.db.count("GL Entry", {"voucher_no": pe.name}), pe_gl_entries)
 
 		# a retry only picks up the vouchers that are not reposted yet
-		retried = []
-		with self.patched_repost(calls=retried):
+		with self.patched_repost() as retried:
 			ral.start_repost()
 
 		self.assertEqual(retried, [pe.name])
@@ -412,7 +393,7 @@ class TestRepostAccountingLedger(ERPNextTestSuite):
 			self.assertFalse(voucher.traceback)
 
 	def test_13_status_of_a_run_that_could_not_finish(self):
-		si, pe = self.create_invoice_and_payment()
+		si, pe = self.make_invoice_and_payment()
 
 		ral = self.create_repost_doc([si, pe])
 		with self.patched_repost(fail_for=["Payment Entry"]):
@@ -424,7 +405,7 @@ class TestRepostAccountingLedger(ERPNextTestSuite):
 		try:
 			frappe.throw(SIMULATED_FAILURE)
 		except frappe.ValidationError:
-			_record_repost_failure(ral.name, ral)
+			_record_repost_failure(ral)
 
 		ral.reload()
 
@@ -435,36 +416,18 @@ class TestRepostAccountingLedger(ERPNextTestSuite):
 			frappe.db.exists("Error Log", {"reference_doctype": ral.doctype, "reference_name": ral.name})
 		)
 
-		# a document that could not even be loaded has nothing to report but the failure
-		_record_repost_failure(ral.name)
-		self.assertEqual(frappe.db.get_value(ral.doctype, ral.name, "status"), "Failed")
-
 	@ERPNextTestSuite.change_settings("Accounts Settings", {"delete_linked_ledger_entries": 1})
 	def test_14_period_closed_after_the_repost_was_started(self):
 		gl = qb.DocType("GL Entry")
 		qb.from_(gl).delete().where(gl.company == "_Test Company").run()
 
-		si = self.create_sales_invoice()
+		si = self.make_invoice()
 		ral = self.create_repost_doc([si], submit=True)
 		ral.db_set("status", "Failed")
-		ral.vouchers[0].db_set({"status": "Pending", "reposted": 0})
+		ral.vouchers[0].db_set("status", "Pending")
 
 		# the period is closed between the repost being started and the job running
-		fy = get_fiscal_year(today(), company="_Test Company")
-		pcv = frappe.get_doc(
-			{
-				"doctype": "Period Closing Voucher",
-				"transaction_date": today(),
-				"period_start_date": fy[1],
-				"period_end_date": today(),
-				"company": "_Test Company",
-				"fiscal_year": fy[0],
-				"cost_center": "Main - _TC",
-				"closing_account_head": "Retained Earnings - _TC",
-				"remarks": "test",
-			}
-		)
-		pcv.save().submit()
+		self.make_period_closing_voucher()
 
 		gl_entries = frappe.db.count("GL Entry", {"voucher_no": si.name})
 		self.assertRaisesRegex(frappe.ValidationError, "Closed fiscal year", repost, ral.name, commit=False)
@@ -478,7 +441,7 @@ class TestRepostAccountingLedger(ERPNextTestSuite):
 		self.assertEqual(ral.vouchers[0].status, "Pending")
 
 	def test_15_failed_repost_skips_cancelled_voucher(self):
-		si = self.create_sales_invoice()
+		si = self.make_invoice()
 
 		ral = self.create_repost_doc([si])
 		with self.patched_repost(fail_for=["Sales Invoice"]):
@@ -497,10 +460,9 @@ class TestRepostAccountingLedger(ERPNextTestSuite):
 		self.assertEqual(ral.status, "Completed")
 		self.assertEqual(ral.vouchers[0].status, "Skipped")
 		self.assertFalse(ral.vouchers[0].traceback)
-		self.assertIn("has been cancelled, nothing to repost", ral.vouchers[0].remark)
 
 	def test_16_concurrent_repost_is_blocked_by_voucher_lock(self):
-		si, pe = self.create_invoice_and_payment()
+		si, pe = self.make_invoice_and_payment()
 		ral = self.create_repost_doc([si, pe])
 
 		# a concurrent repost holding the lock on the second voucher
@@ -518,16 +480,7 @@ class TestRepostAccountingLedger(ERPNextTestSuite):
 		je = make_journal_entry("_Test Bank - _TC", "_Test Cash - _TC", 500, submit=True)
 		je = frappe.get_doc("Journal Entry", je.name)
 
-		def get_gl_totals():
-			gl = qb.DocType("GL Entry")
-			return (
-				qb.from_(gl)
-				.select(Sum(gl.debit), Sum(gl.credit))
-				.where((gl.voucher_no == je.name) & (gl.is_cancelled == 0))
-				.run()
-			)[0]
-
-		self.assertEqual(get_gl_totals(), (500.0, 500.0))
+		self.assertEqual(self.get_gl_totals(je.name), (500.0, 500.0))
 
 		# without the deletion flag the 2 original entries are marked as cancelled,
 		# along with the 2 reverse entries booked against them
@@ -538,7 +491,7 @@ class TestRepostAccountingLedger(ERPNextTestSuite):
 				)
 
 				self.assertEqual(ral.status, "Completed")
-				self.assertEqual(get_gl_totals(), (500.0, 500.0))
+				self.assertEqual(self.get_gl_totals(je.name), (500.0, 500.0))
 				self.assertEqual(
 					frappe.db.count("GL Entry", {"voucher_no": je.name, "is_cancelled": 1}),
 					cancelled_entries,

--- a/erpnext/accounts/doctype/repost_accounting_ledger/test_repost_accounting_ledger.py
+++ b/erpnext/accounts/doctype/repost_accounting_ledger/test_repost_accounting_ledger.py
@@ -14,6 +14,7 @@ from erpnext.accounts.doctype.journal_entry.test_journal_entry import make_journ
 from erpnext.accounts.doctype.payment_entry.payment_entry import get_payment_entry
 from erpnext.accounts.doctype.payment_request.payment_request import make_payment_request
 from erpnext.accounts.doctype.repost_accounting_ledger.repost_accounting_ledger import (
+	_record_repost_failure,
 	_repost_allowed_hook_doctypes,
 	_repost_vouchers,
 )
@@ -403,7 +404,35 @@ class TestRepostAccountingLedger(ERPNextTestSuite):
 			self.assertEqual(voucher.reposted, 1)
 			self.assertFalse(voucher.traceback)
 
-	def test_12_failed_repost_skips_cancelled_voucher(self):
+	def test_12_status_of_a_run_that_could_not_finish(self):
+		si, pe = self.create_invoice_and_payment()
+
+		ral = self.create_repost_doc([si, pe])
+		with self.patched_repost(fail_for=["Payment Entry"]):
+			ral.submit()
+
+		ral.reload()
+
+		# the job dies after the loop committed the invoice, e.g. killed or timed out
+		try:
+			frappe.throw(SIMULATED_FAILURE)
+		except frappe.ValidationError:
+			_record_repost_failure(ral.name, ral)
+
+		ral.reload()
+
+		# progress already committed must not be reported as a total failure
+		self.assertEqual(ral.status, "Partially Reposted")
+		self.assertIn(SIMULATED_FAILURE, ral.error_log)
+		self.assertTrue(
+			frappe.db.exists("Error Log", {"reference_doctype": ral.doctype, "reference_name": ral.name})
+		)
+
+		# a document that could not even be loaded has nothing to report but the failure
+		_record_repost_failure(ral.name)
+		self.assertEqual(frappe.db.get_value(ral.doctype, ral.name, "status"), "Failed")
+
+	def test_13_failed_repost_skips_cancelled_voucher(self):
 		si = self.create_sales_invoice()
 
 		ral = self.create_repost_doc([si])
@@ -423,7 +452,7 @@ class TestRepostAccountingLedger(ERPNextTestSuite):
 		self.assertEqual(ral.vouchers[0].reposted, 1)
 		self.assertIn("has been cancelled, nothing to repost", ral.vouchers[0].traceback)
 
-	def test_13_concurrent_repost_is_blocked_by_voucher_lock(self):
+	def test_14_concurrent_repost_is_blocked_by_voucher_lock(self):
 		si, pe = self.create_invoice_and_payment()
 		ral = self.create_repost_doc([si, pe])
 
@@ -438,7 +467,7 @@ class TestRepostAccountingLedger(ERPNextTestSuite):
 		finally:
 			locked_pe.unlock()
 
-	def test_14_journal_entry_repost(self):
+	def test_15_journal_entry_repost(self):
 		je = make_journal_entry("_Test Bank - _TC", "_Test Cash - _TC", 500, submit=True)
 		je = frappe.get_doc("Journal Entry", je.name)
 
@@ -468,7 +497,7 @@ class TestRepostAccountingLedger(ERPNextTestSuite):
 					cancelled_entries,
 				)
 
-	def test_15_hook_allowed_doctype_repost(self):
+	def test_16_hook_allowed_doctype_repost(self):
 		class VoucherWithCancelArg:
 			doctype = "Test Repost Voucher"
 			name = "TRV-00001"

--- a/erpnext/accounts/doctype/repost_accounting_ledger/test_repost_accounting_ledger.py
+++ b/erpnext/accounts/doctype/repost_accounting_ledger/test_repost_accounting_ledger.py
@@ -299,7 +299,20 @@ class TestRepostAccountingLedger(ERPNextTestSuite):
 
 		self.create_repost_doc([submitted_si])
 
-	def test_08_status_lifecycle(self):
+	def test_08_voucher_count_limit(self):
+		si, pe = self.create_invoice_and_payment()
+		another_si = self.create_sales_invoice()
+
+		with patch(f"{REPOST_MODULE}.MAX_VOUCHERS_PER_REPOST", 2):
+			self.create_repost_doc([si, pe])
+			self.assertRaisesRegex(
+				frappe.ValidationError,
+				"Cannot repost more than 2 vouchers",
+				self.create_repost_doc,
+				[si, pe, another_si],
+			)
+
+	def test_09_status_lifecycle(self):
 		si, pe = self.create_invoice_and_payment()
 
 		ral = self.create_repost_doc([si, pe])
@@ -323,7 +336,7 @@ class TestRepostAccountingLedger(ERPNextTestSuite):
 		discarded.reload()
 		self.assertEqual(discarded.status, "Cancelled")
 
-	def test_09_start_repost_guards(self):
+	def test_10_start_repost_guards(self):
 		si = self.create_sales_invoice()
 		ral = self.create_repost_doc([si])
 
@@ -356,7 +369,7 @@ class TestRepostAccountingLedger(ERPNextTestSuite):
 		ral.reload()
 		self.assertEqual(ral.status, "Completed")
 
-	def test_10_voucher_failures_are_isolated_and_retried(self):
+	def test_11_voucher_failures_are_isolated_and_retried(self):
 		si, pe = self.create_invoice_and_payment()
 		pe_gl_entries = frappe.db.count("GL Entry", {"voucher_no": pe.name})
 
@@ -389,7 +402,7 @@ class TestRepostAccountingLedger(ERPNextTestSuite):
 			self.assertEqual(voucher.reposted, 1)
 			self.assertFalse(voucher.traceback)
 
-	def test_11_failed_repost_skips_cancelled_voucher(self):
+	def test_12_failed_repost_skips_cancelled_voucher(self):
 		si = self.create_sales_invoice()
 
 		ral = self.create_repost_doc([si])
@@ -409,7 +422,7 @@ class TestRepostAccountingLedger(ERPNextTestSuite):
 		self.assertEqual(ral.vouchers[0].reposted, 1)
 		self.assertIn("has been cancelled, nothing to repost", ral.vouchers[0].traceback)
 
-	def test_12_concurrent_repost_is_blocked_by_voucher_lock(self):
+	def test_13_concurrent_repost_is_blocked_by_voucher_lock(self):
 		si, pe = self.create_invoice_and_payment()
 		ral = self.create_repost_doc([si, pe])
 
@@ -424,7 +437,7 @@ class TestRepostAccountingLedger(ERPNextTestSuite):
 		finally:
 			locked_pe.unlock()
 
-	def test_13_journal_entry_repost(self):
+	def test_14_journal_entry_repost(self):
 		je = make_journal_entry("_Test Bank - _TC", "_Test Cash - _TC", 500, submit=True)
 		je = frappe.get_doc("Journal Entry", je.name)
 
@@ -454,7 +467,7 @@ class TestRepostAccountingLedger(ERPNextTestSuite):
 					cancelled_entries,
 				)
 
-	def test_14_hook_allowed_doctype_repost(self):
+	def test_15_hook_allowed_doctype_repost(self):
 		class VoucherWithCancelArg:
 			doctype = "Test Repost Voucher"
 			name = "TRV-00001"

--- a/erpnext/accounts/doctype/repost_accounting_ledger_items/repost_accounting_ledger_items.json
+++ b/erpnext/accounts/doctype/repost_accounting_ledger_items/repost_accounting_ledger_items.json
@@ -12,8 +12,6 @@
   "voucher_no",
   "reposting_status_section",
   "status",
-  "reposted",
-  "remark",
   "traceback"
  ],
  "fields": [
@@ -53,23 +51,6 @@
    "label": "Status",
    "no_copy": 1,
    "options": "Pending\nReposted\nSkipped\nFailed",
-   "read_only": 1
-  },
-  {
-   "default": "0",
-   "fieldname": "reposted",
-   "fieldtype": "Check",
-   "label": "Reposted",
-   "no_copy": 1,
-   "read_only": 1,
-   "hidden": 1,
-   "description": "Kept in step with Status for anything still reading this field."
-  },
-  {
-   "fieldname": "remark",
-   "fieldtype": "Small Text",
-   "label": "Remark",
-   "no_copy": 1,
    "read_only": 1
   },
   {

--- a/erpnext/accounts/doctype/repost_accounting_ledger_items/repost_accounting_ledger_items.json
+++ b/erpnext/accounts/doctype/repost_accounting_ledger_items/repost_accounting_ledger_items.json
@@ -11,7 +11,9 @@
   "column_break_ndex",
   "voucher_no",
   "reposting_status_section",
+  "status",
   "reposted",
+  "remark",
   "traceback"
  ],
  "fields": [
@@ -25,6 +27,10 @@
    "reqd": 1
   },
   {
+   "fieldname": "column_break_ndex",
+   "fieldtype": "Column Break"
+  },
+  {
    "columns": 5,
    "fieldname": "voucher_no",
    "fieldtype": "Dynamic Link",
@@ -34,13 +40,37 @@
    "reqd": 1
   },
   {
-   "fieldname": "column_break_ndex",
-   "fieldtype": "Column Break"
-  },
-  {
    "fieldname": "reposting_status_section",
    "fieldtype": "Section Break",
    "label": "Reposting Status"
+  },
+  {
+   "columns": 2,
+   "default": "Pending",
+   "fieldname": "status",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "label": "Status",
+   "no_copy": 1,
+   "options": "Pending\nReposted\nSkipped\nFailed",
+   "read_only": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "reposted",
+   "fieldtype": "Check",
+   "label": "Reposted",
+   "no_copy": 1,
+   "read_only": 1,
+   "hidden": 1,
+   "description": "Kept in step with Status for anything still reading this field."
+  },
+  {
+   "fieldname": "remark",
+   "fieldtype": "Small Text",
+   "label": "Remark",
+   "no_copy": 1,
+   "read_only": 1
   },
   {
    "fieldname": "traceback",
@@ -48,21 +78,12 @@
    "label": "Traceback",
    "no_copy": 1,
    "read_only": 1
-  },
-  {
-   "default": "0",
-   "fieldname": "reposted",
-   "fieldtype": "Check",
-   "in_list_view": 1,
-   "label": "Reposted",
-   "no_copy": 1,
-   "read_only": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-07-24 17:42:09.890607",
+ "modified": "2026-07-29 02:41:00.000000",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Repost Accounting Ledger Items",

--- a/erpnext/accounts/doctype/repost_accounting_ledger_items/repost_accounting_ledger_items.json
+++ b/erpnext/accounts/doctype/repost_accounting_ledger_items/repost_accounting_ledger_items.json
@@ -1,5 +1,6 @@
 {
  "actions": [],
+ "allow_bulk_edit": 1,
  "allow_rename": 1,
  "creation": "2023-07-04 14:14:01.243848",
  "doctype": "DocType",
@@ -7,33 +8,67 @@
  "engine": "InnoDB",
  "field_order": [
   "voucher_type",
-  "voucher_no"
+  "column_break_ndex",
+  "voucher_no",
+  "reposting_status_section",
+  "reposted",
+  "traceback"
  ],
  "fields": [
   {
+   "columns": 5,
    "fieldname": "voucher_type",
    "fieldtype": "Link",
    "in_list_view": 1,
    "label": "Voucher Type",
-   "options": "DocType"
+   "options": "DocType",
+   "reqd": 1
   },
   {
+   "columns": 5,
    "fieldname": "voucher_no",
    "fieldtype": "Dynamic Link",
    "in_list_view": 1,
    "label": "Voucher No",
-   "options": "voucher_type"
+   "options": "voucher_type",
+   "reqd": 1
+  },
+  {
+   "fieldname": "column_break_ndex",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "reposting_status_section",
+   "fieldtype": "Section Break",
+   "label": "Reposting Status"
+  },
+  {
+   "fieldname": "traceback",
+   "fieldtype": "Code",
+   "label": "Traceback",
+   "no_copy": 1,
+   "read_only": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "reposted",
+   "fieldtype": "Check",
+   "in_list_view": 1,
+   "label": "Reposted",
+   "no_copy": 1,
+   "read_only": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-03-27 13:10:32.170897",
+ "modified": "2026-07-24 17:42:09.890607",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Repost Accounting Ledger Items",
  "owner": "Administrator",
  "permissions": [],
+ "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": []

--- a/erpnext/accounts/doctype/repost_accounting_ledger_items/repost_accounting_ledger_items.py
+++ b/erpnext/accounts/doctype/repost_accounting_ledger_items/repost_accounting_ledger_items.py
@@ -17,8 +17,6 @@ class RepostAccountingLedgerItems(Document):
 		parent: DF.Data
 		parentfield: DF.Data
 		parenttype: DF.Data
-		remark: DF.SmallText | None
-		reposted: DF.Check
 		status: DF.Literal["Pending", "Reposted", "Skipped", "Failed"]
 		traceback: DF.Code | None
 		voucher_no: DF.DynamicLink

--- a/erpnext/accounts/doctype/repost_accounting_ledger_items/repost_accounting_ledger_items.py
+++ b/erpnext/accounts/doctype/repost_accounting_ledger_items/repost_accounting_ledger_items.py
@@ -17,7 +17,9 @@ class RepostAccountingLedgerItems(Document):
 		parent: DF.Data
 		parentfield: DF.Data
 		parenttype: DF.Data
+		remark: DF.SmallText | None
 		reposted: DF.Check
+		status: DF.Literal["Pending", "Reposted", "Skipped", "Failed"]
 		traceback: DF.Code | None
 		voucher_no: DF.DynamicLink
 		voucher_type: DF.Link

--- a/erpnext/accounts/doctype/repost_accounting_ledger_items/repost_accounting_ledger_items.py
+++ b/erpnext/accounts/doctype/repost_accounting_ledger_items/repost_accounting_ledger_items.py
@@ -17,8 +17,10 @@ class RepostAccountingLedgerItems(Document):
 		parent: DF.Data
 		parentfield: DF.Data
 		parenttype: DF.Data
-		voucher_no: DF.DynamicLink | None
-		voucher_type: DF.Link | None
+		reposted: DF.Check
+		traceback: DF.Code | None
+		voucher_no: DF.DynamicLink
+		voucher_type: DF.Link
 	# end: auto-generated types
 
 	pass

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -506,4 +506,3 @@ erpnext.patches.v16_0.rename_ar_ap_ageing_filter
 erpnext.patches.v16_0.fix_subcontracting_titles
 erpnext.patches.v16_0.move_warehouse_defaults_to_company
 erpnext.patches.v16_0.backfill_repost_accounting_ledger_status
-erpnext.patches.v16_0.set_repost_accounting_ledger_item_status

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -505,3 +505,4 @@ erpnext.patches.v16_0.recalculate_bins_for_production_plan_items
 erpnext.patches.v16_0.rename_ar_ap_ageing_filter
 erpnext.patches.v16_0.fix_subcontracting_titles
 erpnext.patches.v16_0.move_warehouse_defaults_to_company
+erpnext.patches.v16_0.backfill_repost_accounting_ledger_status

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -506,3 +506,4 @@ erpnext.patches.v16_0.rename_ar_ap_ageing_filter
 erpnext.patches.v16_0.fix_subcontracting_titles
 erpnext.patches.v16_0.move_warehouse_defaults_to_company
 erpnext.patches.v16_0.backfill_repost_accounting_ledger_status
+erpnext.patches.v16_0.set_repost_accounting_ledger_item_status

--- a/erpnext/patches/v16_0/backfill_repost_accounting_ledger_status.py
+++ b/erpnext/patches/v16_0/backfill_repost_accounting_ledger_status.py
@@ -1,0 +1,28 @@
+import frappe
+from frappe.query_builder.functions import Coalesce
+
+
+def execute():
+	"""Backfill `status` on documents that were reposted before the field existed.
+
+	Without this, older documents show up as `Draft` in the list view and are offered a
+	`Start Reposting` button, which would repost vouchers that are already reposted.
+	"""
+	ral = frappe.qb.DocType("Repost Accounting Ledger")
+	items = frappe.qb.DocType("Repost Accounting Ledger Items")
+
+	for docstatus, status in ((1, "Completed"), (2, "Cancelled")):
+		names = (
+			frappe.qb.from_(ral)
+			.select(ral.name)
+			.where((ral.docstatus == docstatus) & (Coalesce(ral.status, "") == ""))
+			.run(pluck=True)
+		)
+
+		if not names:
+			continue
+
+		frappe.qb.update(ral).set(ral.status, status).where(ral.name.isin(names)).run()
+
+		if status == "Completed":
+			frappe.qb.update(items).set(items.reposted, 1).where(items.parent.isin(names)).run()

--- a/erpnext/patches/v16_0/backfill_repost_accounting_ledger_status.py
+++ b/erpnext/patches/v16_0/backfill_repost_accounting_ledger_status.py
@@ -3,26 +3,23 @@ from frappe.query_builder.functions import Coalesce
 
 
 def execute():
-	"""Backfill `status` on documents that were reposted before the field existed.
+	"""Backfill the statuses of documents reposted before those fields existed.
 
-	Without this, older documents show up as `Draft` in the list view and are offered a
-	`Start Reposting` button, which would repost vouchers that are already reposted.
+	Without it they show up as drafts and are offered a `Start Reposting` button that would
+	repost vouchers which are already reposted.
 	"""
 	ral = frappe.qb.DocType("Repost Accounting Ledger")
 	items = frappe.qb.DocType("Repost Accounting Ledger Items")
 
+	reposted = (
+		frappe.qb.from_(ral).select(ral.name).where((ral.docstatus == 1) & (Coalesce(ral.status, "") == ""))
+	)
+	frappe.qb.update(items).set(items.status, "Reposted").where(items.parent.isin(reposted)).run()
+
 	for docstatus, status in ((1, "Completed"), (2, "Cancelled")):
-		names = (
-			frappe.qb.from_(ral)
-			.select(ral.name)
+		(
+			frappe.qb.update(ral)
+			.set(ral.status, status)
 			.where((ral.docstatus == docstatus) & (Coalesce(ral.status, "") == ""))
-			.run(pluck=True)
+			.run()
 		)
-
-		if not names:
-			continue
-
-		frappe.qb.update(ral).set(ral.status, status).where(ral.name.isin(names)).run()
-
-		if status == "Completed":
-			frappe.qb.update(items).set(items.reposted, 1).where(items.parent.isin(names)).run()

--- a/erpnext/patches/v16_0/set_repost_accounting_ledger_item_status.py
+++ b/erpnext/patches/v16_0/set_repost_accounting_ledger_item_status.py
@@ -1,0 +1,9 @@
+import frappe
+
+
+def execute():
+	"""Carry the `reposted` flag of every voucher over to its new status field."""
+	items = frappe.qb.DocType("Repost Accounting Ledger Items")
+
+	for reposted, status in ((1, "Reposted"), (0, "Pending")):
+		frappe.qb.update(items).set(items.status, status).where(items.reposted == reposted).run()

--- a/erpnext/patches/v16_0/set_repost_accounting_ledger_item_status.py
+++ b/erpnext/patches/v16_0/set_repost_accounting_ledger_item_status.py
@@ -1,9 +1,0 @@
-import frappe
-
-
-def execute():
-	"""Carry the `reposted` flag of every voucher over to its new status field."""
-	items = frappe.qb.DocType("Repost Accounting Ledger Items")
-
-	for reposted, status in ((1, "Reposted"), (0, "Pending")):
-		frappe.qb.update(items).set(items.status, status).where(items.reposted == reposted).run()


### PR DESCRIPTION
The current workflow lacks user feedback on reposting success, making it difficult to trace failures, trying to improve that.

~- [x] Add indicator on Repost Accounting Ledger List View~
~- [x] Refactor Test Cases~

---

## What changes

A repost used to be fire-and-forget: the document told you nothing about whether it ran, how far it got, or why it stopped. It now has a status of its own, every voucher records its own outcome, and a run that fails part-way can be picked up again where it left off.

### The document has a status

`Queued` → `In Progress` → `Completed` / `Partially Reposted` / `Failed`, surfaced on the form and as an indicator in the list view, which also shows the company.

<img width="1521" height="784" alt="Repost Accounting Ledger list view with status indicators" src="https://github.com/user-attachments/assets/87a4ce67-90da-425a-8708-45d2a99e5733" />

### Every voucher records its own outcome

Each row carries `Pending` / `Reposted` / `Skipped` / `Failed`, with the traceback of a failure kept on the row that failed. Reposting is per-voucher: each one runs in its own savepoint and commits on its own, so one bad voucher no longer takes the batch down with it, and progress survives a worker dying mid-run.

<img width="1521" height="784" alt="Repost Accounting Ledger with each voucher reposted" src="https://github.com/user-attachments/assets/dcd87114-0bad-4990-8f57-6e31c8fb7cdb" />

### A repost can be restarted

`Start Reposting` re-runs a document that is `Failed` or `Partially Reposted`, and picks up only the vouchers that are not done yet. It also appears for a document left in `Queued` or `In Progress` by a worker that was killed or timed out — those states are held back by the background job itself, which is asked whether it is still alive, rather than by the status string, so such a document can no longer get stuck forever.

### Safety around the ledger

- Vouchers are locked up front, so two reposts cannot touch the same GL entries.
- The checks a queued repost can outlive — a period closed, deferred accounting enabled — are re-run when the job starts, before anything is written.
- The job id is derived from the document and enqueued with `deduplicate`, so two clicks cannot queue two jobs for the same document.
- Validation on save: at least one voucher, no duplicates, all submitted, and at most 50 per document so a batch finishes well inside the queue timeout.

### Reposting is always a background job

It used to run inline for five vouchers or fewer and in the background above that, which meant two different failure modes. It is now always enqueued, on the `long` queue with an explicit timeout.

## Migration

`backfill_repost_accounting_ledger_status` fills in the statuses of documents reposted before these fields existed — otherwise they show up as drafts and are offered a `Start Reposting` button that would repost vouchers which are already reposted.

## Tests

`test_repost_accounting_ledger.py` covers the status lifecycle, the guards on `start_repost`, per-voucher failure isolation and retry, a period closed after the repost was queued, voucher locking, a run that could not finish, and the dispatch of Journal Entries and hook-allowed doctypes. Existing cases were reworked onto shared fixtures so each test covers one area.
