### PR TITLE
fix: rewrite user-facing messages in Accounts module

### DIFF
--- a/erpnext/accounts/doctype/account/account.py
+++ b/erpnext/accounts/doctype/account/account.py
@@ -234,7 +234,7 @@ class Account(NestedSet):
 			if not frappe.db.get_value(
 				"Account", {"account_name": self.account_name, "company": ancestors[0]}, "name"
 			):
-				frappe.throw(_("Please add the account to root level Company - {}").format(ancestors[0]))
+				frappe.throw(_("Please add the account to root level Company - {0}").format(ancestors[0]))
 		elif self.parent_account:
 			descendants = get_descendants_of("Company", self.company)
 			if not descendants:
@@ -671,7 +671,7 @@ def _ensure_idle_system():
 	if last_gl_update > add_to_date(None, minutes=-5):
 		frappe.throw(
 			_(
-				"Last GL Entry update was done {}. This operation is not allowed while system is actively being used. Please wait for 5 minutes before retrying."
+				"Last GL Entry update was done {0}. This operation is not allowed while system is actively being used. Please wait for 5 minutes before retrying."
 			).format(pretty_date(last_gl_update)),
 			title=_("System In Use"),
 		)

--- a/erpnext/accounts/doctype/bank_transaction/bank_transaction.py
+++ b/erpnext/accounts/doctype/bank_transaction/bank_transaction.py
@@ -440,7 +440,7 @@ def get_clearance_details(transaction, payment_entry, bt_allocations, gl_entries
 
 		if bt_bank_account != gl_bank_account:
 			frappe.throw(
-				_("Bank Account {} in Bank Transaction {} is not matching with Bank Account {}").format(
+				_("Bank Account {0} in Bank Transaction {1} is not matching with Bank Account {2}").format(
 					bt_bank_account, payment_entry.payment_entry, gl_bank_account
 				)
 			)
@@ -449,7 +449,7 @@ def get_clearance_details(transaction, payment_entry, bt_allocations, gl_entries
 
 	if gl_bank_account not in gl_entries:
 		frappe.throw(
-			_("{} {} is not affecting bank account {}").format(
+			_("{0} {1} is not affecting bank account {2}").format(
 				payment_entry.payment_document, payment_entry.payment_entry, gl_bank_account
 			)
 		)
@@ -457,7 +457,7 @@ def get_clearance_details(transaction, payment_entry, bt_allocations, gl_entries
 	allocable_amount = gl_entries.pop(gl_bank_account) or 0
 	if allocable_amount <= 0.0:
 		frappe.throw(
-			_("Invalid amount in accounting entries of {} {} for Account {}: {}").format(
+			_("Invalid amount in accounting entries of {0} {1} for Account {2}: {3}").format(
 				payment_entry.payment_document, payment_entry.payment_entry, gl_bank_account, allocable_amount
 			)
 		)

--- a/erpnext/accounts/doctype/bank_transaction_rule/bank_transaction_rule.py
+++ b/erpnext/accounts/doctype/bank_transaction_rule/bank_transaction_rule.py
@@ -66,7 +66,7 @@ class BankTransactionRule(Document):
 				frappe.throw(_("Party type is required to create a payment entry."))
 
 			if not self.party:
-				frappe.throw(_("Party is required create a payment entry."))
+				frappe.throw(_("Party is required to create a payment entry."))
 
 			if not self.account:
 				frappe.throw(_("Party account is required to create a payment entry."))

--- a/erpnext/accounts/doctype/chart_of_accounts_importer/chart_of_accounts_importer.py
+++ b/erpnext/accounts/doctype/chart_of_accounts_importer/chart_of_accounts_importer.py
@@ -63,8 +63,8 @@ def validate_company(company: str):
 	)
 
 	if parent_company and (not allow_account_creation_against_child_company):
-		msg = _("{} is a child company.").format(frappe.bold(company)) + " "
-		msg += _("Please import accounts against parent company or enable {} in company master.").format(
+		msg = _("{0} is a child company.").format(frappe.bold(company)) + " "
+		msg += _("Please import accounts against parent company or enable {0} in company master.").format(
 			frappe.bold(_("Allow Account Creation Against Child Company"))
 		)
 		frappe.throw(msg, title=_("Wrong Company"))

--- a/erpnext/accounts/doctype/currency_exchange_settings/currency_exchange_settings.py
+++ b/erpnext/accounts/doctype/currency_exchange_settings/currency_exchange_settings.py
@@ -90,7 +90,7 @@ class CurrencyExchangeSettings(Document):
 		try:
 			response = requests.get(api_url, params=params)
 		except requests.exceptions.RequestException as e:
-			frappe.throw("Error: " + str(e))
+			frappe.throw(_("Error: {0}").format(str(e)))
 
 		response.raise_for_status()
 		value = response.json()

--- a/erpnext/accounts/doctype/dunning/dunning.py
+++ b/erpnext/accounts/doctype/dunning/dunning.py
@@ -85,7 +85,7 @@ class Dunning(AccountsController):
 			if invoice_currency != self.currency:
 				frappe.throw(
 					_(
-						"The currency of invoice {} ({}) is different from the currency of this dunning ({})."
+						"The currency of invoice {0} ({1}) is different from the currency of this dunning ({2})."
 					).format(
 						frappe.get_desk_link(
 							"Sales Invoice",

--- a/erpnext/accounts/doctype/exchange_rate_revaluation/exchange_rate_revaluation.py
+++ b/erpnext/accounts/doctype/exchange_rate_revaluation/exchange_rate_revaluation.py
@@ -350,12 +350,14 @@ class ExchangeRateRevaluation(Document):
 		zero_balance_jv = self.make_jv_for_zero_balance()
 		if zero_balance_jv:
 			frappe.msgprint(
-				f"Zero Balance Journal: {get_link_to_form('Journal Entry', zero_balance_jv.name)}"
+				_("Zero Balance Journal: {0}").format(get_link_to_form("Journal Entry", zero_balance_jv.name))
 			)
 
 		revaluation_jv = self.make_jv_for_revaluation()
 		if revaluation_jv:
-			frappe.msgprint(f"Revaluation Journal: {get_link_to_form('Journal Entry', revaluation_jv.name)}")
+			frappe.msgprint(
+				_("Revaluation Journal: {0}").format(get_link_to_form("Journal Entry", revaluation_jv.name))
+			)
 
 		return {
 			"revaluation_jv": revaluation_jv.name if revaluation_jv else None,

--- a/erpnext/accounts/doctype/mode_of_payment/mode_of_payment.py
+++ b/erpnext/accounts/doctype/mode_of_payment/mode_of_payment.py
@@ -60,6 +60,6 @@ class ModeofPayment(Document):
 
 			if pos_profiles:
 				message = _(
-					"POS Profile {} contains Mode of Payment {}. Please remove them to disable this mode."
+					"POS Profile {0} contains Mode of Payment {1}. Please remove them to disable this mode."
 				).format(frappe.bold(", ".join(pos_profiles)), frappe.bold(str(self.name)))
 				frappe.throw(message, title=_("Not Allowed"))

--- a/erpnext/accounts/doctype/opening_invoice_creation_tool/opening_invoice_creation_tool.py
+++ b/erpnext/accounts/doctype/opening_invoice_creation_tool/opening_invoice_creation_tool.py
@@ -110,7 +110,7 @@ class OpeningInvoiceCreationTool(Document):
 	def validate_mandatory_invoice_fields(self, row):
 		if self.create_missing_party:
 			if not row.party and not row.party_name:
-				frappe.throw(_("Row #{}: Either Party ID or Party Name is required").format(row.idx))
+				frappe.throw(_("Row #{0}: Either Party ID or Party Name is required").format(row.idx))
 
 			if not row.party and row.party_name:
 				row.party = self.add_party(row.party_type, row.party_name)
@@ -120,10 +120,10 @@ class OpeningInvoiceCreationTool(Document):
 
 		else:
 			if not row.party:
-				frappe.throw(_("Row #{}: Party ID is required").format(row.idx))
+				frappe.throw(_("Row #{0}: Party ID is required").format(row.idx))
 			if not frappe.db.exists(row.party_type, row.party):
 				frappe.throw(
-					_("Row #{}: {} {} does not exist.").format(
+					_("Row #{0}: {1} {2} does not exist.").format(
 						row.idx, frappe.bold(row.party_type), frappe.bold(row.party)
 					)
 				)
@@ -307,7 +307,7 @@ def start_import(invoices):
 			doc.log_error("Opening invoice creation failed")
 	if errors:
 		frappe.msgprint(
-			_("You had {} errors while creating opening invoices. Check {} for more details").format(
+			_("You had {0} errors while creating opening invoices. Check {1} for more details").format(
 				errors, "<a href='/app/List/Error Log' class='variant-click'>Error Log</a>"
 			),
 			indicator="red",

--- a/erpnext/accounts/doctype/party_link/party_link.py
+++ b/erpnext/accounts/doctype/party_link/party_link.py
@@ -37,7 +37,7 @@ class PartyLink(Document):
 		)
 		if existing_party_link:
 			frappe.throw(
-				_("{} {} is already linked with {} {}").format(
+				_("{0} {1} is already linked with {2} {3}").format(
 					self.primary_role,
 					bold(self.primary_party),
 					self.secondary_role,
@@ -50,7 +50,7 @@ class PartyLink(Document):
 		)
 		if existing_party_link:
 			frappe.throw(
-				_("{} {} is already linked with another {}").format(
+				_("{0} {1} is already linked with another {2}").format(
 					self.secondary_role, self.secondary_party, existing_party_link[0]
 				)
 			)
@@ -60,7 +60,7 @@ class PartyLink(Document):
 		)
 		if existing_party_link:
 			frappe.throw(
-				_("{} {} is already linked with another {}").format(
+				_("{0} {1} is already linked with another {2}").format(
 					self.primary_role, self.primary_party, existing_party_link[0]
 				)
 			)

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -621,7 +621,7 @@ class PaymentEntry(AccountsController):
 
 	def validate_payment_type(self):
 		if self.payment_type not in ("Receive", "Pay", "Internal Transfer"):
-			frappe.throw(_("Payment Type must be one of Receive, Pay and Internal Transfer"))
+			frappe.throw(_("Payment Type must be one of Receive, Pay, or Internal Transfer"))
 
 	def validate_party_details(self):
 		if self.party and not frappe.db.exists(self.party_type, self.party):
@@ -678,7 +678,7 @@ class PaymentEntry(AccountsController):
 
 			elif d.reference_name:
 				if not frappe.db.exists(d.reference_doctype, d.reference_name):
-					frappe.throw(_("{0} {1} does not exist").format(d.reference_doctype, d.reference_name))
+					frappe.throw(_("{0} {1} does not exist").format(_(d.reference_doctype), d.reference_name))
 
 				ref_doc = frappe.get_lazy_doc(d.reference_doctype, d.reference_name)
 
@@ -2683,7 +2683,7 @@ def get_payment_entry(
 
 	# only Purchase Invoice can be blocked individually
 	if doc.doctype == "Purchase Invoice" and doc.invoice_is_blocked():
-		frappe.msgprint(_("{0} is on hold till {1}").format(doc.name, doc.release_date))
+		frappe.msgprint(_("{0} is on hold until {1}").format(doc.name, doc.release_date))
 	else:
 		if doc.doctype in (
 			"Sales Invoice",
@@ -3087,7 +3087,7 @@ def apply_early_payment_discount(paid_amount, received_amount, doc, party_accoun
 		if total_discount:
 			currency = doc.get("currency") if is_multi_currency else doc.company_currency
 			money = frappe.utils.fmt_money(total_discount, currency=currency)
-			frappe.msgprint(_("Discount of {} applied as per Payment Term").format(money), alert=1)
+			frappe.msgprint(_("Discount of {0} applied as per Payment Term").format(money), alert=1)
 
 	return paid_amount, received_amount, total_discount, valid_discounts
 

--- a/erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.py
+++ b/erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.py
@@ -121,13 +121,13 @@ class POSClosingEntry(StatusUpdater):
 				continue
 			if pos_invoice.pos_profile != self.pos_profile:
 				invalid_row.setdefault("msg", []).append(
-					_("POS Profile doesn't match {}").format(frappe.bold(self.pos_profile))
+					_("POS Profile doesn't match {0}").format(frappe.bold(self.pos_profile))
 				)
 			if pos_invoice.docstatus != 1:
 				invalid_row.setdefault("msg", []).append(_("POS Invoice is not submitted"))
 			if pos_invoice.owner != self.user:
 				invalid_row.setdefault("msg", []).append(
-					_("POS Invoice isn't created by user {}").format(frappe.bold(self.owner))
+					_("POS Invoice isn't created by user {0}").format(frappe.bold(self.owner))
 				)
 
 			if invalid_row.get("msg"):
@@ -139,7 +139,7 @@ class POSClosingEntry(StatusUpdater):
 		error_list = []
 		for row in invalid_rows:
 			for msg in row.get("msg"):
-				error_list.append(_("Row #{}: {}").format(row.get("idx"), msg))
+				error_list.append(_("Row #{0}: {1}").format(row.get("idx"), msg))
 
 		frappe.throw(error_list, title=_("Invalid POS Invoices"), as_list=True)
 
@@ -186,13 +186,13 @@ class POSClosingEntry(StatusUpdater):
 				invalid_row.setdefault("msg", []).append(_("Sales Invoice is not created using POS"))
 			if sales_invoice.pos_profile != self.pos_profile:
 				invalid_row.setdefault("msg", []).append(
-					_("POS Profile doesn't match {}").format(frappe.bold(self.pos_profile))
+					_("POS Profile doesn't match {0}").format(frappe.bold(self.pos_profile))
 				)
 			if sales_invoice.docstatus != 1:
 				invalid_row.setdefault("msg", []).append(_("Sales Invoice is not submitted"))
 			if sales_invoice.owner != self.user:
 				invalid_row.setdefault("msg", []).append(
-					_("Sales Invoice isn't created by user {}").format(frappe.bold(self.owner))
+					_("Sales Invoice isn't created by user {0}").format(frappe.bold(self.owner))
 				)
 
 			if invalid_row.get("msg"):
@@ -204,7 +204,7 @@ class POSClosingEntry(StatusUpdater):
 		error_list = []
 		for row in invalid_rows:
 			for msg in row.get("msg"):
-				error_list.append(_("Row #{}: {}").format(row.get("idx"), msg))
+				error_list.append(_("Row #{0}: {1}").format(row.get("idx"), msg))
 
 		frappe.throw(error_list, title=_("Invalid Sales Invoices"), as_list=True)
 

--- a/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
+++ b/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
@@ -279,7 +279,7 @@ class POSInvoice(SalesInvoice):
 				limit=1,
 			)
 			frappe.throw(
-				_("You need to cancel POS Closing Entry {} to be able to cancel this document.").format(
+				_("You need to cancel POS Closing Entry {0} to be able to cancel this document.").format(
 					get_link_to_form("POS Closing Entry", pos_closing_entry[0])
 				),
 				title=_("Not Allowed"),
@@ -498,7 +498,7 @@ class POSInvoice(SalesInvoice):
 			if d.get("qty") > 0:
 				frappe.throw(
 					_(
-						"Row #{}: You cannot add positive quantities in a return invoice. Please remove item {} to complete the return."
+						"Row #{0}: You cannot add positive quantities in a return invoice. Please remove item {1} to complete the return."
 					).format(d.idx, frappe.bold(d.item_code)),
 					title=_("Invalid Item"),
 				)
@@ -526,7 +526,7 @@ class POSInvoice(SalesInvoice):
 						bold_serial_no = frappe.bold(sr)
 						frappe.throw(
 							_(
-								"Row #{}: Serial No {} cannot be returned since it was not transacted in original invoice {}"
+								"Row #{0}: Serial No {1} cannot be returned since it was not transacted in original invoice {2}"
 							).format(d.idx, bold_serial_no, bold_return_against)
 						)
 
@@ -541,7 +541,7 @@ class POSInvoice(SalesInvoice):
 			and frappe.get_cached_value("Account", self.account_for_change_amount, "company") != self.company
 		):
 			frappe.throw(
-				_("The selected change account {} doesn't belongs to Company {}.").format(
+				_("The selected change account {0} does not belong to Company {1}.").format(
 					self.account_for_change_amount, self.company
 				)
 			)
@@ -571,12 +571,12 @@ class POSInvoice(SalesInvoice):
 			invoice_total = self.rounded_total or self.grand_total
 			total_amount_in_payments = flt(total_amount_in_payments, self.precision("grand_total"))
 			if total_amount_in_payments and total_amount_in_payments < invoice_total:
-				frappe.throw(_("Total payments amount can't be greater than {}").format(-invoice_total))
+				frappe.throw(_("Total payments amount can't be greater than {0}").format(-invoice_total))
 
 	def validate_company_with_pos_company(self):
 		if self.company != frappe.db.get_value("POS Profile", self.pos_profile, "company"):
 			frappe.throw(
-				_("Company {} does not match with POS Profile Company {}").format(
+				_("Company {0} does not match with POS Profile Company {1}").format(
 					self.company, frappe.db.get_value("POS Profile", self.pos_profile, "company")
 				)
 			)

--- a/erpnext/accounts/doctype/pos_invoice_merge_log/pos_invoice_merge_log.py
+++ b/erpnext/accounts/doctype/pos_invoice_merge_log/pos_invoice_merge_log.py
@@ -70,7 +70,7 @@ class POSInvoiceMergeLog(Document):
 		for d in self.pos_invoices:
 			if d.customer != self.customer:
 				frappe.throw(
-					_("Row #{}: POS Invoice {} is not against customer {}").format(
+					_("Row #{0}: POS Invoice {1} is not against customer {2}").format(
 						d.idx, d.pos_invoice, self.customer
 					)
 				)
@@ -85,11 +85,11 @@ class POSInvoiceMergeLog(Document):
 			bold_status = frappe.bold(status)
 			if docstatus != 1:
 				frappe.throw(
-					_("Row #{}: POS Invoice {} is not submitted yet").format(d.idx, bold_pos_invoice)
+					_("Row #{0}: POS Invoice {1} is not submitted yet").format(d.idx, bold_pos_invoice)
 				)
 			if status == "Consolidated":
 				frappe.throw(
-					_("Row #{}: POS Invoice {} has been {}").format(d.idx, bold_pos_invoice, bold_status)
+					_("Row #{0}: POS Invoice {1} has been {2}").format(d.idx, bold_pos_invoice, bold_status)
 				)
 			if (
 				is_return
@@ -101,14 +101,14 @@ class POSInvoiceMergeLog(Document):
 				if return_against_status != "Consolidated":
 					# if return entry is not getting merged in the current pos closing and if it is not consolidated
 					msg = _(
-						"Row #{}: The original Invoice {} of return invoice {} is not consolidated."
+						"Row #{0}: The original Invoice {1} of return invoice {2} is not consolidated."
 					).format(d.idx, bold_return_against, bold_pos_invoice)
 					msg += " "
 					msg += _(
 						"The original invoice should be consolidated before or along with the return invoice."
 					)
 					msg += "<br><br>"
-					msg += _("You can add the original invoice {} manually to proceed.").format(
+					msg += _("You can add the original invoice {0} manually to proceed.").format(
 						bold_return_against
 					)
 					frappe.throw(msg)
@@ -330,7 +330,7 @@ class POSInvoiceMergeLog(Document):
 
 			if not dimension_value and (dimension.mandatory_for_pl or dimension.mandatory_for_bs):
 				frappe.throw(
-					_("Please set Accounting Dimension {} in {}").format(
+					_("Please set Accounting Dimension {0} in {1}").format(
 						frappe.bold(dimension.label),
 						frappe.get_desk_link("POS Profile", invoice.pos_profile),
 					)

--- a/erpnext/accounts/doctype/pos_opening_entry/pos_opening_entry.py
+++ b/erpnext/accounts/doctype/pos_opening_entry/pos_opening_entry.py
@@ -44,22 +44,22 @@ class POSOpeningEntry(StatusUpdater):
 
 	def validate_pos_profile_and_cashier(self):
 		if not frappe.db.exists("POS Profile", self.pos_profile):
-			frappe.throw(_("POS Profile {} does not exist.").format(self.pos_profile))
+			frappe.throw(_("POS Profile {0} does not exist.").format(self.pos_profile))
 
 		pos_profile_company, pos_profile_disabled = frappe.db.get_value(
 			"POS Profile", self.pos_profile, ["company", "disabled"]
 		)
 
 		if pos_profile_disabled:
-			frappe.throw(_("POS Profile {} is disabled.").format(frappe.bold(self.pos_profile)))
+			frappe.throw(_("POS Profile {0} is disabled.").format(frappe.bold(self.pos_profile)))
 
 		if self.company != pos_profile_company:
 			frappe.throw(
-				_("POS Profile {} does not belong to company {}").format(self.pos_profile, self.company)
+				_("POS Profile {0} does not belong to company {1}").format(self.pos_profile, self.company)
 			)
 
 		if not cint(frappe.db.get_value("User", self.user, "enabled")):
-			frappe.throw(_("User {} is disabled. Please select valid user/cashier").format(self.user))
+			frappe.throw(_("User {0} is disabled. Please select valid user/cashier").format(self.user))
 
 	def check_open_pos_exists(self):
 		if frappe.db.exists("POS Opening Entry", {"pos_profile": self.pos_profile, "status": "Open"}):
@@ -91,9 +91,9 @@ class POSOpeningEntry(StatusUpdater):
 
 		if invalid_modes:
 			if invalid_modes == 1:
-				msg = _("Please set default Cash or Bank account in Mode of Payment {}")
+				msg = _("Please set default Cash or Bank account in Mode of Payment {0}")
 			else:
-				msg = _("Please set default Cash or Bank account in Mode of Payments {}")
+				msg = _("Please set default Cash or Bank account in Mode of Payments {0}")
 			frappe.throw(msg.format(", ".join(invalid_modes)), title=_("Missing Account"))
 
 	def on_submit(self):

--- a/erpnext/accounts/doctype/pos_profile/pos_profile.py
+++ b/erpnext/accounts/doctype/pos_profile/pos_profile.py
@@ -202,9 +202,9 @@ class POSProfile(Document):
 
 		if invalid_modes:
 			if invalid_modes == 1:
-				msg = _("Please set default Cash or Bank account in Mode of Payment {}")
+				msg = _("Please set default Cash or Bank account in Mode of Payment {0}")
 			else:
-				msg = _("Please set default Cash or Bank account in Mode of Payments {}")
+				msg = _("Please set default Cash or Bank account in Mode of Payments {0}")
 			frappe.throw(msg.format(", ".join(invalid_modes)), title=_("Missing Account"))
 
 	def on_update(self):

--- a/erpnext/accounts/doctype/pricing_rule/utils.py
+++ b/erpnext/accounts/doctype/pricing_rule/utils.py
@@ -343,7 +343,7 @@ def filter_pricing_rules(args, pricing_rules, doc=None):
 	if len(pricing_rules) > 1 and not args.for_shopping_cart:
 		frappe.throw(
 			_(
-				"Multiple Price Rules exists with same criteria, please resolve conflict by assigning priority. Price Rules: {0}"
+				"Multiple Price Rules exist with same criteria, please resolve conflict by assigning priority. Price Rules: {0}"
 			).format("\n".join(d.name for d in pricing_rules)),
 			MultiplePricingRuleConflict,
 		)

--- a/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.py
+++ b/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.py
@@ -156,17 +156,17 @@ class ProcessStatementOfAccounts(Document):
 		)
 
 		if invalid_values:
-			msg = _("<p>Following {0}s doesn't belong to Company {1} :</p>").format(
+			msg = _("<p>Following {0}s do not belong to Company {1}:</p>").format(
 				doctype, frappe.bold(self.company)
 			)
 
 			msg += (
 				"<ul>"
-				+ "".join(_("<li>{}</li>").format(frappe.bold(row)) for row in invalid_values)
+				+ "".join(_("<li>{0}</li>").format(frappe.bold(row)) for row in invalid_values)
 				+ "</ul>"
 			)
 
-			frappe.throw(_(msg))
+			frappe.throw(msg)
 
 
 def get_report_pdf(doc, consolidated=True):

--- a/erpnext/accounts/doctype/promotional_scheme/promotional_scheme.py
+++ b/erpnext/accounts/doctype/promotional_scheme/promotional_scheme.py
@@ -182,10 +182,9 @@ class PromotionalScheme(Document):
 			frappe.delete_doc("Pricing Rule", doc)
 
 		frappe.msgprint(
-			_("The following invalid Pricing Rules are deleted:")
-			+ "<br><br><ul><li>"
-			+ "</li><li>".join(invalid_pricing_rule)
-			+ "</li></ul>"
+			_("The following invalid Pricing Rules are deleted:{0}").format(
+				"<br><br><ul><li>" + "</li><li>".join(invalid_pricing_rule) + "</li></ul>"
+			)
 		)
 
 	def get_invalid_pricing_rules(self):

--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
@@ -463,7 +463,7 @@ class PurchaseInvoice(BuyingController):
 		):
 			for d in self.get("items"):
 				if not d.purchase_order:
-					msg = _("Purchase Order Required for item {}").format(frappe.bold(d.item_code))
+					msg = _("Purchase Order Required for item {0}").format(frappe.bold(d.item_code))
 					msg += "<br><br>"
 					msg += _(
 						"To submit the invoice without purchase order please set {0} as {1} in {2}"
@@ -485,7 +485,7 @@ class PurchaseInvoice(BuyingController):
 
 			for d in self.get("items"):
 				if not d.purchase_receipt and d.item_code in stock_and_asset_items:
-					msg = _("Purchase Receipt Required for item {}").format(frappe.bold(d.item_code))
+					msg = _("Purchase Receipt Required for item {0}").format(frappe.bold(d.item_code))
 					msg += "<br><br>"
 					msg += _(
 						"To submit the invoice without purchase receipt please set {0} as {1} in {2}"

--- a/erpnext/accounts/doctype/purchase_invoice/services/expense_account.py
+++ b/erpnext/accounts/doctype/purchase_invoice/services/expense_account.py
@@ -148,7 +148,7 @@ class ExpenseAccountService:
 					if not account:
 						form_link = get_link_to_form("Asset Category", item.asset_category)
 						throw(
-							_("Please set Fixed Asset Account in {} against {}.").format(
+							_("Please set Fixed Asset Account in {0} against {1}.").format(
 								form_link, doc.company
 							),
 							title=_("Missing Account"),

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -755,7 +755,7 @@ class SalesInvoice(SellingController):
 
 		if account.report_type != "Balance Sheet":
 			msg = (
-				_("Please ensure {} account is a Balance Sheet account.").format(frappe.bold(_("Debit To")))
+				_("Please ensure {0} account is a Balance Sheet account.").format(frappe.bold(_("Debit To")))
 				+ " "
 			)
 			msg += _(
@@ -765,7 +765,7 @@ class SalesInvoice(SellingController):
 
 		if self.customer and account.account_type != "Receivable":
 			msg = (
-				_("Please ensure {} account {} is a Receivable account.").format(
+				_("Please ensure {0} account {1} is a Receivable account.").format(
 					frappe.bold(_("Debit To")), frappe.bold(self.debit_to)
 				)
 				+ " "

--- a/erpnext/accounts/doctype/sales_invoice/services/loyalty.py
+++ b/erpnext/accounts/doctype/sales_invoice/services/loyalty.py
@@ -75,8 +75,8 @@ class LoyaltyService:
 			invoice_list = ", ".join([d.invoice for d in against_lp_entry])
 			frappe.throw(
 				_(
-					"{} can't be cancelled since the Loyalty Points earned has been redeemed. "
-					"First cancel the {} No {}"
+					"{0} cannot be cancelled since the Loyalty Points earned has been redeemed. "
+					"First cancel the {1} No {2}"
 				).format(doc.doctype, doc.doctype, invoice_list)
 			)
 		else:

--- a/erpnext/accounts/doctype/sales_invoice/services/pos.py
+++ b/erpnext/accounts/doctype/sales_invoice/services/pos.py
@@ -187,7 +187,7 @@ class POSService:
 			total_amount_in_payments = sum(payment.amount for payment in doc.payments)
 			invoice_total = doc.rounded_total or doc.grand_total
 			if total_amount_in_payments < invoice_total:
-				frappe.throw(_("Total payments amount can't be greater than {}").format(-invoice_total))
+				frappe.throw(_("Total payments amount can't be greater than {0}").format(-invoice_total))
 
 	def validate_pos_paid_amount(self) -> None:
 		doc = self.doc
@@ -273,7 +273,7 @@ class POSService:
 				pluck="pos_closing_entry",
 			)
 			if pos_closing_entry and pos_closing_entry[0]:
-				msg = _("To cancel a {} you need to cancel the POS Closing Entry {}.").format(
+				msg = _("To cancel a {0} you need to cancel the POS Closing Entry {1}.").format(
 					frappe.bold(_("Consolidated Sales Invoice")),
 					get_link_to_form("POS Closing Entry", pos_closing_entry[0]),
 				)
@@ -362,9 +362,9 @@ def update_multi_mode_option(doc, pos_profile) -> None:
 
 	if invalid_modes:
 		if invalid_modes == 1:
-			msg = _("Please set default Cash or Bank account in Mode of Payment {}")
+			msg = _("Please set default Cash or Bank account in Mode of Payment {0}")
 		else:
-			msg = _("Please set default Cash or Bank account in Mode of Payments {}")
+			msg = _("Please set default Cash or Bank account in Mode of Payments {0}")
 		frappe.throw(msg.format(", ".join(invalid_modes)), title=_("Missing Account"))
 
 	if mop_refetched:

--- a/erpnext/accounts/report/general_ledger/general_ledger.py
+++ b/erpnext/accounts/report/general_ledger/general_ledger.py
@@ -679,8 +679,9 @@ def get_columns(filters):
 		and filters["presentation_currency"] != company_currency
 	):
 		frappe.throw(
-			_(
-				f'Presentation Currency cannot be {frappe.bold(filters["presentation_currency"])} , When {frappe.bold("Show Credit / Debit in Company Currency")} is enabled.'
+			_("Presentation Currency cannot be {0}, when {1} is enabled.").format(
+				frappe.bold(filters["presentation_currency"]),
+				frappe.bold(_("Show Credit / Debit in Company Currency")),
 			)
 		)
 

--- a/erpnext/accounts/services/billing_validation.py
+++ b/erpnext/accounts/services/billing_validation.py
@@ -53,7 +53,7 @@ class BillingValidationService:
 
 		if is_overbilling_allowed and total_overbilled_amt > 0.1:
 			frappe.msgprint(
-				_("Overbilling of {} ignored because you have {} role.").format(
+				_("Overbilling of {0} ignored because you have {1} role.").format(
 					total_overbilled_amt, role_allowed_to_overbill
 				),
 				indicator="orange",
@@ -148,4 +148,4 @@ class BillingValidationService:
 			+ "</ul>"
 		)
 		message += _("<p>To allow over-billing, please set allowance in Accounts Settings.</p>")
-		frappe.throw(_(message))
+		frappe.throw(message)

--- a/erpnext/accounts/services/child_item_update.py
+++ b/erpnext/accounts/services/child_item_update.py
@@ -207,7 +207,7 @@ class ChildItemUpdater:
 		except frappe.PermissionError:
 			actions = {"create": "add", "write": "update"}
 			frappe.throw(
-				_("You do not have permissions to {} items in a {}.").format(
+				_("You do not have permissions to {0} items in a {1}.").format(
 					actions[perm_type], self.parent_doctype
 				),
 				title=_("Insufficient Permissions"),
@@ -229,7 +229,7 @@ class ChildItemUpdater:
 
 		if not allowed:
 			frappe.throw(
-				_("You are not allowed to update as per the conditions set in {} Workflow.").format(
+				_("You are not allowed to update as per the conditions set in {0} Workflow.").format(
 					get_link_to_form("Workflow", workflow)
 				),
 				title=_("Insufficient Permissions"),
@@ -512,7 +512,7 @@ def update_child_item_rate_and_discount(
 		rate_unchanged = flt(child_item.get("rate")) == flt(new_data.get("rate"))
 
 	if not rate_unchanged and not child_item.get("qty") and allow_zero_qty:
-		frappe.throw(_("Rate of '{}' items cannot be changed").format(frappe.bold(_("Unit Price"))))
+		frappe.throw(_("Rate of '{0}' items cannot be changed").format(frappe.bold(_("Unit Price"))))
 
 	row_rate = flt(new_data.get("rate"), rate_precision)
 

--- a/erpnext/accounts/services/gl_validator.py
+++ b/erpnext/accounts/services/gl_validator.py
@@ -62,7 +62,7 @@ def validate_accounting_period(gl_map):
 				return
 		frappe.throw(
 			_(
-				"You cannot create or cancel any accounting entries with in the closed Accounting Period {0}"
+				"You cannot create or cancel any accounting entries within the closed Accounting Period {0}"
 			).format(frappe.bold(accounting_periods[0].name)),
 			ClosedAccountingPeriod,
 		)
@@ -140,9 +140,9 @@ def validate_against_pcv(is_opening, posting_date, company):
 	)
 
 	if last_pcv_date and getdate(posting_date) <= getdate(last_pcv_date):
-		message = _("Books have been closed till the period ending on {0}").format(formatdate(last_pcv_date))
+		message = _("Books have been closed until the period ending on {0}").format(formatdate(last_pcv_date))
 		message += "</br >"
-		message += _("You cannot create/amend any accounting entries till this date.")
+		message += _("You cannot create/amend any accounting entries until this date.")
 		frappe.throw(message, title=_("Period Closed"))
 
 

--- a/erpnext/accounts/services/internal_transfer.py
+++ b/erpnext/accounts/services/internal_transfer.py
@@ -95,7 +95,9 @@ class InternalTransferService:
 		for row in self.doc.get("items"):
 			if not row.get(field):
 				frappe.throw(
-					_(f"At Row {row.idx}: The field {bold(label)} is mandatory for internal transfer"),
+					_("At Row {0}: The field {1} is mandatory for internal transfer").format(
+						row.idx, bold(label)
+					),
 					title=_("Internal Transfer Reference Missing"),
 				)
 
@@ -115,7 +117,7 @@ class InternalTransferService:
 		if not self.doc.get("ignore_pricing_rule") and self.is_internal_transfer():
 			self.doc.ignore_pricing_rule = 1
 			frappe.msgprint(
-				_("Disabled pricing rules since this {} is an internal transfer").format(self.doc.doctype),
+				_("Disabled pricing rules since this {0} is an internal transfer").format(self.doc.doctype),
 				alert=1,
 			)
 
@@ -131,7 +133,7 @@ class InternalTransferService:
 
 		if tax_updated:
 			frappe.msgprint(
-				_("Disabled tax included prices since this {} is an internal transfer").format(
+				_("Disabled tax included prices since this {0} is an internal transfer").format(
 					self.doc.doctype
 				),
 				alert=1,

--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -2565,7 +2565,7 @@ def create_gain_loss_journal(
 	party_account_currency = frappe.get_cached_value("Account", party_account, "account_currency")
 
 	if not gain_loss_account:
-		frappe.throw(_("Please set default Exchange Gain/Loss Account in Company {}").format(company))
+		frappe.throw(_("Please set default Exchange Gain/Loss Account in Company {0}").format(company))
 	gain_loss_account_currency = get_account_currency(gain_loss_account)
 	company_currency = frappe.get_cached_value("Company", company, "default_currency")
 


### PR DESCRIPTION
Conservative rewrite of user-facing `frappe.throw` / `frappe.msgprint` messages in the **Accounts** module — part of #53976. Meaning, severity, and the set of `.format()` arguments are unchanged; this is translatability + grammar only.

### What changed (~75 edits across 30 files)
- **Indexed placeholders** — bare `{}` → `{0}` / `{1}` so translators can reorder arguments (RTL/reordering languages can't move bare `{}`).
- **Translation-extraction fixes** — moved f-strings / `.format()` / string concatenation *out* of `_()`; inside `_()` they capture the runtime value and never translate. e.g. `_(f"…{x}…")` → `_("…{0}…").format(x)`.
- **Wrapped translatable dynamic values** (DocType / Select labels) in `_()` where sibling messages already did.
- **Grammar / phrasing** — `"doesn't belongs"` → `"does not belong"`, `"till"` → `"until"`, `"Rules exists"` → `"Rules exist"`, exclusive `"one of … and …"` → `"one of …, or …"`.
- Dropped a no-op `_()` wrapping a runtime-built HTML string.

### Sample
| Before | After |
|---|---|
| `_("Row #{}: POS Invoice {} is not against customer {}")` | `_("Row #{0}: POS Invoice {1} is not against customer {2}")` |
| `_(f'Presentation Currency cannot be {bold(cur)} , When {bold(label)} is enabled.')` | `_("Presentation Currency cannot be {0}, when {1} is enabled.").format(…)` |
| `_("The selected change account {} doesn't belongs to Company {}.")` | `_("The selected change account {0} does not belong to Company {1}.")` |

### Verification
- Whole `accounts` module compiles.
- No test assertions reference any changed message text.
- Pure string edits — no logic or query behaviour change.
