### PR TITLE
chore: rewrite user-facing messages in stock module

### DIFF
--- a/erpnext/stock/doctype/batch/batch.py
+++ b/erpnext/stock/doctype/batch/batch.py
@@ -390,7 +390,7 @@ def validate_serial_no_with_batch(serial_nos, item_code):
 
 	serial_no_link = ",".join(get_link_to_form("Serial No", sn) for sn in serial_nos)
 
-	message = "Serial Nos" if len(serial_nos) > 1 else "Serial No"
+	message = _("Serial Nos") if len(serial_nos) > 1 else _("Serial No")
 	frappe.throw(_("There is no batch found against the {0}: {1}").format(message, serial_no_link))
 
 

--- a/erpnext/stock/doctype/delivery_note/mapper.py
+++ b/erpnext/stock/doctype/delivery_note/mapper.py
@@ -79,7 +79,7 @@ def make_sales_invoice(
 		target.run_method("set_po_nos")
 
 		if len(target.get("items")) == 0:
-			frappe.throw(_("All these items have already been Invoiced/Returned"))
+			frappe.throw(_("All these items have already been invoiced/returned"))
 
 		if args and args.get("merge_taxes"):
 			merge_taxes(source, target)

--- a/erpnext/stock/doctype/delivery_trip/delivery_trip.py
+++ b/erpnext/stock/doctype/delivery_trip/delivery_trip.py
@@ -216,7 +216,7 @@ class DeliveryTrip(Document):
 		        (list of list of str): List of address routes split at locks, if optimize is `True`
 		"""
 		if not self.driver_address:
-			frappe.throw(_("Cannot Calculate Arrival Time as Driver Address is Missing."))
+			frappe.throw(_("Cannot calculate arrival time as the driver address is missing."))
 
 		home_address = get_address_display(frappe.get_doc("Address", self.driver_address).as_dict())
 

--- a/erpnext/stock/doctype/item/item.py
+++ b/erpnext/stock/doctype/item/item.py
@@ -463,7 +463,7 @@ class Item(Document):
 
 	def validate_item_type(self):
 		if self.has_serial_no == 1 and self.is_stock_item == 0 and not self.is_fixed_asset:
-			frappe.throw(_("'Has Serial No' can not be 'Yes' for non-stock item"))
+			frappe.throw(_("'Has Serial No' cannot be 'Yes' for non-stock item"))
 
 		if self.has_serial_no == 0 and self.serial_no_series:
 			self.serial_no_series = None
@@ -1508,7 +1508,9 @@ def validate_item_default_company_links(item_defaults: list[ItemDefault]) -> Non
 				company = frappe.db.get_value(doctype, item_default.get(field), "company", cache=True)
 				if company and company != item_default.company:
 					frappe.throw(
-						_("Row #{}: {} {} doesn't belong to Company {}. Please select valid {}.").format(
+						_(
+							"Row #{0}: {1} {2} does not belong to Company {3}. Please select valid {4}."
+						).format(
 							item_default.idx,
 							doctype,
 							frappe.bold(item_default.get(field)),

--- a/erpnext/stock/doctype/item_alternative/item_alternative.py
+++ b/erpnext/stock/doctype/item_alternative/item_alternative.py
@@ -33,7 +33,7 @@ class ItemAlternative(Document):
 
 	def has_alternative_item(self):
 		if self.item_code and not frappe.db.get_value("Item", self.item_code, "allow_alternative_item"):
-			frappe.throw(_("Not allow to set alternative item for the item {0}").format(self.item_code))
+			frappe.throw(_("Cannot set alternative item for the item {0}").format(self.item_code))
 
 	def validate_alternative_item(self):
 		if self.item_code == self.alternative_item_code:
@@ -65,7 +65,7 @@ class ItemAlternative(Document):
 					indicator="Orange",
 				)
 
-		alternate_item_check_msg = _("Allow Alternative Item must be checked on Item {}")
+		alternate_item_check_msg = _("Allow Alternative Item must be checked on Item {0}")
 
 		if not item_data.allow_alternative_item:
 			frappe.throw(alternate_item_check_msg.format(self.item_code))
@@ -81,7 +81,7 @@ class ItemAlternative(Document):
 				"name": ("!=", self.name),
 			},
 		):
-			frappe.throw(_("Already record exists for the item {0}").format(self.item_code))
+			frappe.throw(_("Record already exists for the item {0}").format(self.item_code))
 
 
 @frappe.whitelist()

--- a/erpnext/stock/doctype/item_price/item_price.py
+++ b/erpnext/stock/doctype/item_price/item_price.py
@@ -68,7 +68,7 @@ class ItemPrice(Document):
 
 			if not price_list_details:
 				link = frappe.utils.get_link_to_form("Price List", self.price_list)
-				frappe.throw(f"The price list {link} does not exist or is disabled")
+				frappe.throw(_("The price list {0} does not exist or is disabled").format(link))
 
 			self.buying, self.selling, self.currency = price_list_details
 

--- a/erpnext/stock/doctype/landed_cost_voucher/landed_cost_voucher.py
+++ b/erpnext/stock/doctype/landed_cost_voucher/landed_cost_voucher.py
@@ -129,8 +129,10 @@ class LandedCostVoucher(Document):
 				d.receipt_document_type, d.receipt_document, ["docstatus", "company"]
 			)
 			if docstatus != 1:
-				msg = f"Row {d.idx}: {d.receipt_document_type} {frappe.bold(d.receipt_document)} must be submitted"
-				frappe.throw(_(msg), title=_("Invalid Document"))
+				msg = _("Row {0}: {1} {2} must be submitted").format(
+					d.idx, d.receipt_document_type, frappe.bold(d.receipt_document)
+				)
+				frappe.throw(msg, title=_("Invalid Document"))
 
 			if company != self.company:
 				frappe.throw(
@@ -244,7 +246,7 @@ class LandedCostVoucher(Document):
 		if not total:
 			frappe.throw(
 				_(
-					"Total {0} for all items is zero, may be you should change 'Distribute Charges Based On'"
+					"Total {0} for all items is zero, maybe you should change 'Distribute Charges Based On'"
 				).format(based_on)
 			)
 
@@ -375,8 +377,8 @@ class LandedCostVoucher(Document):
 				if not docs or total_asset_qty < item.qty:
 					frappe.throw(
 						_(
-							"For item <b>{0}</b>, only <b>{1}</b> asset have been created or linked to <b>{2}</b>. "
-							"Please create or link <b>{3}</b> more asset with the respective document."
+							"For item <b>{0}</b>, only <b>{1}</b> assets have been created or linked to <b>{2}</b>. "
+							"Please create or link <b>{3}</b> more assets with the respective document."
 						).format(
 							item.item_code, total_asset_qty, item.receipt_document, item.qty - total_asset_qty
 						)

--- a/erpnext/stock/doctype/material_request/material_request.py
+++ b/erpnext/stock/doctype/material_request/material_request.py
@@ -350,7 +350,7 @@ class MaterialRequest(BuyingController):
 						if d.ordered_qty and flt(d.ordered_qty, precision) > flt(allowed_qty, precision):
 							frappe.throw(
 								_(
-									"The total Issue / Transfer quantity {0} in Material Request {1}  cannot be greater than allowed requested quantity {2} for Item {3}"
+									"The total Issue / Transfer quantity {0} in Material Request {1} cannot be greater than allowed requested quantity {2} for Item {3}"
 								).format(d.ordered_qty, d.parent, allowed_qty, d.item_code)
 							)
 
@@ -576,7 +576,7 @@ def raise_work_orders(material_request: str, company: str):
 
 	if errors:
 		frappe.throw(
-			_("Work Order cannot be created for following reason: <br> {0}").format(new_line_sep(errors))
+			_("Work Order cannot be created for the following reason: <br> {0}").format(new_line_sep(errors))
 		)
 
 	return work_orders

--- a/erpnext/stock/doctype/packing_slip/packing_slip.py
+++ b/erpnext/stock/doctype/packing_slip/packing_slip.py
@@ -80,15 +80,13 @@ class PackingSlip(StatusUpdater):
 		"""Raises an exception if the `Delivery Note` status is not Draft"""
 
 		if cint(frappe.db.get_value("Delivery Note", self.delivery_note, "docstatus")) != 0:
-			frappe.throw(
-				_("A Packing Slip can only be created for Draft Delivery Note.").format(self.delivery_note)
-			)
+			frappe.throw(_("A Packing Slip can only be created for a Draft Delivery Note."))
 
 	def validate_case_nos(self):
 		"""Validate if case nos overlap. If they do, recommend next case no."""
 
 		if cint(self.from_case_no) <= 0:
-			frappe.throw(_("The 'From Package No.' field must neither be empty nor it's value less than 1."))
+			frappe.throw(_("The 'From Package No.' field must not be empty or have a value less than 1."))
 		elif not self.to_case_no:
 			self.to_case_no = self.from_case_no
 		elif cint(self.to_case_no) < cint(self.from_case_no):

--- a/erpnext/stock/doctype/pick_list/mapper.py
+++ b/erpnext/stock/doctype/pick_list/mapper.py
@@ -286,7 +286,7 @@ def create_stock_entry(pick_list: str | dict):
 	validate_item_locations(pick_list)
 
 	if stock_entry_exists(pick_list.get("name")):
-		return frappe.msgprint(_("Stock Entry has been already created against this Pick List"))
+		return frappe.msgprint(_("Stock Entry has already been created against this Pick List"))
 
 	stock_entry = frappe.new_doc("Stock Entry")
 	stock_entry.pick_list = pick_list.get("name")

--- a/erpnext/stock/doctype/pick_list/pick_list.py
+++ b/erpnext/stock/doctype/pick_list/pick_list.py
@@ -232,7 +232,7 @@ class PickList(TransactionBase):
 				and frappe.db.get_value("Sales Order", location.sales_order, "per_picked", cache=True) == 100
 			):
 				frappe.throw(
-					_("Row #{}: item {} has been picked already.").format(location.idx, location.item_code)
+					_("Row #{0}: item {1} has been picked already.").format(location.idx, location.item_code)
 				)
 
 	def before_submit(self):
@@ -647,7 +647,7 @@ class PickList(TransactionBase):
 				continue
 
 			if not item.item_code:
-				frappe.throw(f"Row #{item.idx}: Item Code is Mandatory")
+				frappe.throw(_("Row #{0}: Item Code is Mandatory").format(item.idx))
 			if not cint(
 				frappe.get_cached_value("Item", item.item_code, "is_stock_item")
 			) and not get_active_product_bundle(item.item_code):

--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
@@ -260,7 +260,7 @@ class PurchaseReceipt(BuyingController):
 		self.check_for_on_hold_or_closed_status("Purchase Order", "purchase_order")
 
 		if getdate(self.posting_date) > getdate(nowdate()):
-			throw(_("Posting Date cannot be future date"))
+			throw(_("Posting Date cannot be a future date"))
 
 		self.get_current_stock()
 		self.reset_default_field_value("set_warehouse", "items", "warehouse")
@@ -329,14 +329,18 @@ class PurchaseReceipt(BuyingController):
 				)
 
 				if qi.reference_type != self.doctype or qi.reference_name != self.name:
-					msg = f"""Row #{item.idx}: Please select a valid Quality Inspection with Reference Type
-						{frappe.bold(self.doctype)} and Reference Name {frappe.bold(self.name)}."""
-					frappe.throw(_(msg))
+					frappe.throw(
+						_(
+							"Row #{0}: Please select a valid Quality Inspection with Reference Type {1} and Reference Name {2}."
+						).format(item.idx, frappe.bold(self.doctype), frappe.bold(self.name))
+					)
 
 				if qi.item_code != item.item_code:
-					msg = f"""Row #{item.idx}: Please select a valid Quality Inspection with Item Code
-						{frappe.bold(item.item_code)}."""
-					frappe.throw(_(msg))
+					frappe.throw(
+						_("Row #{0}: Please select a valid Quality Inspection with Item Code {1}.").format(
+							item.idx, frappe.bold(item.item_code)
+						)
+					)
 
 	def get_already_received_qty(self, po, po_detail):
 		qty = frappe.get_all(

--- a/erpnext/stock/doctype/putaway_rule/putaway_rule.py
+++ b/erpnext/stock/doctype/putaway_rule/putaway_rule.py
@@ -58,7 +58,7 @@ class PutawayRule(Document):
 
 	def validate_priority(self):
 		if self.priority < 1:
-			frappe.throw(_("Priority cannot be lesser than 1."), title=_("Invalid Priority"))
+			frappe.throw(_("Priority cannot be less than 1."), title=_("Invalid Priority"))
 
 	def validate_warehouse_and_company(self):
 		company = frappe.db.get_value("Warehouse", self.warehouse, "company")
@@ -303,7 +303,7 @@ def add_row(item, to_allocate, warehouse, updated_table, rule=None, serial_nos=N
 
 
 def show_unassigned_items_message(items_not_accomodated):
-	msg = _("The following Items, having Putaway Rules, could not be accomodated:") + "<br><br>"
+	msg = _("The following Items, having Putaway Rules, could not be accommodated:") + "<br><br>"
 	formatted_item_rows = ""
 
 	for entry in items_not_accomodated:

--- a/erpnext/stock/doctype/quality_inspection/quality_inspection.py
+++ b/erpnext/stock/doctype/quality_inspection/quality_inspection.py
@@ -134,7 +134,7 @@ class QualityInspection(Document):
 		):
 			frappe.throw(
 				_(
-					"'Inspection Required before Purchase' has disabled for the item {0}, no need to create the QI"
+					"'Inspection Required before Purchase' is disabled for the item {0}, no need to create the QI"
 				).format(get_link_to_form("Item", self.item_code))
 			)
 
@@ -143,7 +143,7 @@ class QualityInspection(Document):
 		):
 			frappe.throw(
 				_(
-					"'Inspection Required before Delivery' has disabled for the item {0}, no need to create the QI"
+					"'Inspection Required before Delivery' is disabled for the item {0}, no need to create the QI"
 				).format(get_link_to_form("Item", self.item_code))
 			)
 

--- a/erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.py
+++ b/erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.py
@@ -209,7 +209,7 @@ class RepostItemValuation(Document):
 			):
 				frappe.msgprint(_("Caution: This might alter frozen accounts."))
 				return
-			frappe.throw(_("You cannot repost item valuation before {}").format(acc_frozen_till_date))
+			frappe.throw(_("You cannot repost item valuation before {0}").format(acc_frozen_till_date))
 
 	def reset_field_values(self):
 		if self.based_on == "Transaction":

--- a/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py
+++ b/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py
@@ -165,7 +165,7 @@ class SerialandBatchBundle(Document):
 
 		if invalid_serial_nos:
 			msg = _(
-				"You cannot outward following {0} as either they are Delivered, Inactive or located in a different warehouse."
+				"You cannot outward the following {0} as they are either Delivered, Inactive or located in a different warehouse."
 			).format(_("Serial Nos") if len(invalid_serial_nos) > 1 else _("Serial No"))
 			msg += "<hr>"
 			msg += ", ".join(sn for sn in invalid_serial_nos)
@@ -183,7 +183,7 @@ class SerialandBatchBundle(Document):
 		if self.voucher_type == "POS Invoice":
 			if not frappe.db.exists("POS Invoice Item", self.voucher_detail_no):
 				frappe.throw(
-					_("The serial and batch bundle {0} not linked to {1} {2}").format(
+					_("The serial and batch bundle {0} is not linked to {1} {2}").format(
 						bold(self.name), self.voucher_type, bold(self.voucher_no)
 					)
 				)
@@ -195,7 +195,7 @@ class SerialandBatchBundle(Document):
 				return
 
 			frappe.throw(
-				_("The serial and batch bundle {0} not linked to {1} {2}").format(
+				_("The serial and batch bundle {0} is not linked to {1} {2}").format(
 					bold(self.name), self.voucher_type, bold(self.voucher_no)
 				)
 			)
@@ -227,7 +227,7 @@ class SerialandBatchBundle(Document):
 		for row in data:
 			frappe.throw(
 				_(
-					"You can't process the serial number {0} as it has already been used in the SABB {1}. {2} if you want to inward same serial number multiple times then enabled 'Allow existing Serial No to be Manufactured/Received again' in the {3}"
+					"You cannot process the serial number {0} as it has already been used in the SABB {1}. {2} If you want to inward the same serial number multiple times, then enable 'Allow existing Serial No to be Manufactured/Received again' in the {3}"
 				).format(
 					row.serial_no,
 					get_link_to_form("Serial and Batch Bundle", row.parent),
@@ -376,7 +376,7 @@ class SerialandBatchBundle(Document):
 				if len(serial_nos) == 1:
 					frappe.throw(
 						_(
-							"Serial No {0} is already Delivered. You cannot use them again in Manufacture / Repack entry."
+							"Serial No {0} is already Delivered. You cannot use it again in Manufacture / Repack entry."
 						).format(bold(serial_nos[0]))
 					)
 				else:
@@ -654,12 +654,12 @@ class SerialandBatchBundle(Document):
 
 	def validate_negative_batch(self, batch_no, available_qty):
 		if available_qty < 0 and not self.is_stock_reco_for_valuation_adjustment(available_qty):
-			msg = f"""Batch No {bold(batch_no)} of an Item {bold(self.item_code)}
-				has negative stock
-				of quantity {bold(available_qty)} in the
-				warehouse {self.warehouse}"""
-
-			frappe.throw(_(msg), BatchNegativeStockError)
+			frappe.throw(
+				_("Batch No {0} of Item {1} has negative stock of quantity {2} in the warehouse {3}").format(
+					bold(batch_no), bold(self.item_code), bold(available_qty), self.warehouse
+				),
+				BatchNegativeStockError,
+			)
 
 	def is_stock_reco_for_valuation_adjustment(self, available_qty):
 		if (
@@ -1153,8 +1153,7 @@ class SerialandBatchBundle(Document):
 
 	def validate_serial_and_batch_no(self):
 		if self.item_code and not self.has_serial_no and not self.has_batch_no:
-			msg = f"The Item {self.item_code} does not have Serial No or Batch No"
-			frappe.throw(_(msg))
+			frappe.throw(_("The Item {0} does not have Serial No or Batch No").format(self.item_code))
 
 		serial_nos = []
 		batch_nos = []
@@ -1589,12 +1588,11 @@ class SerialandBatchBundle(Document):
 			date_msg = " " + _("as of {0}").format(format_datetime(posting_datetime))
 
 		msg = _(
-			"""
-			The Batch {0} of an item {1} has negative stock in the warehouse {2}{3}.
-			Please add a stock quantity of {4} to proceed with this entry.
-			If it is not possible to make an adjustment entry, please enable 'Allow Negative Stock for Batch' in the batch {0} or in the Stock Settings to proceed.
-			However, enabling this setting may lead to negative stock in the system.
-			So please ensure the stock levels are adjusted as soon as possible to maintain the correct valuation rate."""
+			"The Batch {0} of item {1} has negative stock in the warehouse {2}{3}. "
+			"Please add a stock quantity of {4} to proceed with this entry. "
+			"If it is not possible to make an adjustment entry, please enable 'Allow Negative Stock for Batch' in the batch {0} or in the Stock Settings to proceed. "
+			"However, enabling this setting may lead to negative stock in the system. "
+			"So please ensure the stock levels are adjusted as soon as possible to maintain the correct valuation rate."
 		).format(
 			bold(batch_no),
 			bold(self.item_code),
@@ -1728,9 +1726,11 @@ class SerialandBatchBundle(Document):
 			and self.voucher_detail_no
 			and frappe.db.exists(child_doctype, self.voucher_detail_no)
 		):
-			msg = f"""The {self.voucher_type} {bold(self.voucher_no)}
-				is in submitted state, please cancel it first"""
-			frappe.throw(_(msg))
+			frappe.throw(
+				_("The {0} {1} is in submitted state, please cancel it first").format(
+					self.voucher_type, bold(self.voucher_no)
+				)
+			)
 
 	def on_trash(self):
 		self.validate_voucher_no_docstatus()
@@ -3486,13 +3486,13 @@ def is_serial_batch_no_exists(
 ):
 	if serial_no and not frappe.db.exists("Serial No", serial_no):
 		if type_of_transaction != "Inward":
-			frappe.throw(_("Serial No {0} does not exists").format(serial_no))
+			frappe.throw(_("Serial No {0} does not exist").format(serial_no))
 
 		make_serial_no(serial_no, item_code)
 
 	if batch_no and not frappe.db.exists("Batch", batch_no):
 		if type_of_transaction != "Inward":
-			frappe.throw(_("Batch No {0} does not exists").format(batch_no))
+			frappe.throw(_("Batch No {0} does not exist").format(batch_no))
 
 		make_batch_no(batch_no, item_code)
 

--- a/erpnext/stock/doctype/stock_closing_entry/stock_closing_entry.py
+++ b/erpnext/stock/doctype/stock_closing_entry/stock_closing_entry.py
@@ -98,7 +98,7 @@ class StockClosingEntry(Document):
 		enqueue(prepare_closing_stock_balance, name=self.name, queue="long", timeout=1500)
 		frappe.msgprint(
 			_(
-				"Stock Closing Entry {0} has been queued for processing, system will take sometime to complete it."
+				"Stock Closing Entry {0} has been queued for processing, the system will take some time to complete it."
 			).format(self.name)
 		)
 

--- a/erpnext/stock/doctype/stock_entry/services/manufacturing.py
+++ b/erpnext/stock/doctype/stock_entry/services/manufacturing.py
@@ -124,7 +124,8 @@ class BaseManufactureStockEntry(BaseStockEntry):
 					self.doc.process_loss_qty = flt(process_loss_qty, precision)
 
 					frappe.msgprint(
-						_("The Process Loss Qty has reset as per job cards Process Loss Qty"), alert=True
+						_("The Process Loss Qty has been reset as per the Job Card's Process Loss Qty"),
+						alert=True,
 					)
 
 		if not self.doc.process_loss_percentage and not self.doc.process_loss_qty:

--- a/erpnext/stock/doctype/stock_entry/services/subcontracting.py
+++ b/erpnext/stock/doctype/stock_entry/services/subcontracting.py
@@ -91,7 +91,7 @@ class SendToSubcontractorStockEntry(BaseStockEntry):
 				child_row.db_set(self.doc.subcontract_data.rm_detail_field, order_rm_detail)
 			elif not child_row.allow_alternative_item:
 				frappe.throw(
-					_("Row {0}# Item {1} not found in 'Raw Materials Supplied' table in {2} {3}").format(
+					_("Row #{0}: Item {1} not found in 'Raw Materials Supplied' table in {2} {3}").format(
 						child_row.idx,
 						item_code,
 						self.doc.subcontract_data.order_doctype,

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -404,12 +404,11 @@ class StockEntry(StockController, SubcontractingInwardController):
 			if row.job_card_item or not row.s_warehouse:
 				continue
 
-			msg = f"""Row #{row.idx}: The job card item reference
-				is missing. Kindly create the stock entry
-				from the job card. If you have added the row manually
-				then you won't be able to add job card item reference."""
-
-			frappe.throw(_(msg))
+			frappe.throw(
+				_(
+					"Row #{0}: The job card item reference is missing. Kindly create the stock entry from the job card. If you have added the row manually then you won't be able to add job card item reference."
+				).format(row.idx)
+			)
 
 	def validate_work_order_status(self):
 		pro_doc = frappe.get_doc("Work Order", self.work_order)
@@ -885,7 +884,7 @@ class StockEntry(StockController, SubcontractingInwardController):
 
 		if not finished_items:
 			frappe.throw(
-				msg=_("There must be atleast 1 Finished Good in this Stock Entry").format(self.name),
+				msg=_("There must be at least 1 Finished Good in this Stock Entry").format(self.name),
 				title=_("Missing Finished Good"),
 				exc=FinishedGoodError,
 			)
@@ -908,7 +907,7 @@ class StockEntry(StockController, SubcontractingInwardController):
 			# No work order could mean independent Manufacture entry, if so skip validation
 			if self.work_order and self.fg_completed_qty > allowed_qty:
 				frappe.throw(
-					_("For quantity {0} should not be greater than allowed quantity {1}").format(
+					_("Quantity {0} should not be greater than allowed quantity {1}").format(
 						flt(self.fg_completed_qty), allowed_qty
 					)
 				)
@@ -1373,7 +1372,8 @@ class StockEntry(StockController, SubcontractingInwardController):
 					self.process_loss_qty = flt(process_loss_qty, precision)
 
 					frappe.msgprint(
-						_("The Process Loss Qty has reset as per job cards Process Loss Qty"), alert=True
+						_("The Process Loss Qty has been reset as per the job card's Process Loss Qty"),
+						alert=True,
 					)
 
 		if not self.process_loss_percentage and not self.process_loss_qty:

--- a/erpnext/stock/doctype/stock_entry_detail/stock_entry_detail.py
+++ b/erpnext/stock/doctype/stock_entry_detail/stock_entry_detail.py
@@ -100,7 +100,7 @@ class StockEntryDetail(Document):
 	def validate_and_update_item_details(self, item_details, company, purpose):
 		if flt(self.qty) and flt(self.qty) < 0:
 			frappe.throw(
-				_("Row {0}: The item {1}, quantity must be positive number").format(
+				_("Row {0}: The item {1}, quantity must be a positive number").format(
 					self.idx, bold(self.item_code)
 				)
 			)
@@ -153,7 +153,7 @@ class StockEntryDetail(Document):
 		if is_opening == "Yes" and acc_details.report_type == "Profit and Loss":
 			frappe.throw(
 				_(
-					"Difference Account must be a Asset/Liability type account "
+					"Difference Account must be an Asset/Liability type account "
 					"(Temporary Opening), since this Stock Entry is an Opening Entry"
 				),
 				OpeningEntryAccountError,

--- a/erpnext/stock/doctype/stock_entry_type/stock_entry_type.py
+++ b/erpnext/stock/doctype/stock_entry_type/stock_entry_type.py
@@ -62,7 +62,7 @@ class StockEntryType(Document):
 			"Subcontracting Delivery",
 			"Subcontracting Return",
 		]:
-			frappe.throw(f"Stock Entry Type {self.name} cannot be set as standard")
+			frappe.throw(_("Stock Entry Type {0} cannot be set as standard").format(self.name))
 
 
 class ManufactureEntry:

--- a/erpnext/stock/doctype/stock_ledger_entry/stock_ledger_entry.py
+++ b/erpnext/stock/doctype/stock_ledger_entry/stock_ledger_entry.py
@@ -342,7 +342,7 @@ class StockLedgerEntry(Document):
 						"You are not authorized to make/edit Stock Transactions for Item {0} under warehouse {1} before this time."
 					).format(frappe.bold(self.item_code), frappe.bold(self.warehouse))
 
-					msg += "<br><br>" + _("Please contact any of the following users to {} this transaction.")
+					msg += "<br><br>" + _("Please contact any of the following users for this transaction.")
 					msg += "<br>" + "<br>".join(authorized_users)
 					frappe.throw(msg, BackDatedStockTransaction, title=_("Backdated Stock Entry"))
 

--- a/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py
+++ b/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py
@@ -982,7 +982,7 @@ class StockReconciliation(StockController):
 			if frappe.db.get_value("Account", self.expense_account, "report_type") == "Profit and Loss":
 				frappe.throw(
 					_(
-						"Difference Account must be a Asset/Liability type account, since this Stock Reconciliation is an Opening Entry"
+						"Difference Account must be an Asset/Liability type account, since this Stock Reconciliation is an Opening Entry"
 					),
 					OpeningEntryAccountError,
 				)
@@ -1246,7 +1246,7 @@ def get_stock_balance_for(
 
 	if not item_dict:
 		# In cases of data upload to Items table
-		msg = _("Item {} does not exist.").format(item_code)
+		msg = _("Item {0} does not exist.").format(item_code)
 		frappe.throw(msg, title=_("Missing"))
 
 	serial_nos = None

--- a/erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py
+++ b/erpnext/stock/doctype/stock_reservation_entry/stock_reservation_entry.py
@@ -138,7 +138,7 @@ class StockReservationEntry(Document):
 
 			frappe.throw(
 				_(
-					"Cannot cancel Stock Reservation Entry {0}, as it has used in the work order {1}. Please cancel the work order first or unreserved the stock"
+					"Cannot cancel Stock Reservation Entry {0}, as it has been used in the work order {1}. Please cancel the work order first or unreserve the stock"
 				).format(
 					", ".join([frappe.bold(entry.name) for entry in entries]),
 					", ".join([frappe.bold(wo.name) for wo in work_orders]),
@@ -261,7 +261,7 @@ class StockReservationEntry(Document):
 		if cint(frappe.db.get_value("UOM", self.stock_uom, "must_be_whole_number", cache=True)):
 			if cint(self.reserved_qty) != flt(self.reserved_qty, self.precision("reserved_qty")):
 				msg = _(
-					"Reserved Qty ({0}) cannot be a fraction. To allow this, disable '{1}' in UOM {3}."
+					"Reserved Qty ({0}) cannot be a fraction. To allow this, disable '{1}' in UOM {2}."
 				).format(
 					flt(self.reserved_qty, self.precision("reserved_qty")),
 					frappe.bold(_("Must be Whole Number")),
@@ -427,7 +427,7 @@ class StockReservationEntry(Document):
 								entry.db_update()
 						else:
 							msg = _(
-								"Row #{0}: Qty should be less than or equal to Available Qty to Reserve (Actual Qty - Reserved Qty) {1} for Iem {2} against Batch {3} in Warehouse {4}."
+								"Row #{0}: Qty should be less than or equal to Available Qty to Reserve (Actual Qty - Reserved Qty) {1} for Item {2} against Batch {3} in Warehouse {4}."
 							).format(
 								entry.idx,
 								frappe.bold(available_qty_to_reserve),
@@ -623,19 +623,19 @@ class StockReservationEntry(Document):
 
 		if qty_to_be_reserved > allowed_qty:
 			actual_qty = get_stock_balance(self.item_code, self.warehouse)
-			msg = """
-				Cannot reserve more than Allowed Qty {} {} for Item {} against {} {}.<br /><br />
-				The <b>Allowed Qty</b> is calculated as follows:<br />
-				<ul>
-					<li>Actual Qty [Available Qty at Warehouse] = {}</li>
-					<li>Reserved Stock [Ignore current SRE] = {}</li>
-					<li>Available Qty To Reserve [Actual Qty - Reserved Stock] = {}</li>
-					<li>Voucher Qty [Voucher Item Qty] = {}</li>
-					<li>Delivered Qty [Qty delivered against the Voucher Item] = {}</li>
-					<li>Total Reserved Qty [Qty reserved against the Voucher Item] = {}</li>
-					<li>Allowed Qty [Minimum of (Available Qty To Reserve, (Voucher Qty - Delivered Qty - Total Reserved Qty))] = {}</li>
-				</ul>
-			""".format(
+			msg = _(
+				"Cannot reserve more than Allowed Qty {0} {1} for Item {2} against {3} {4}.<br /><br />"
+				"The <b>Allowed Qty</b> is calculated as follows:<br />"
+				"<ul>"
+				"<li>Actual Qty [Available Qty at Warehouse] = {5}</li>"
+				"<li>Reserved Stock [Ignore current SRE] = {6}</li>"
+				"<li>Available Qty To Reserve [Actual Qty - Reserved Stock] = {7}</li>"
+				"<li>Voucher Qty [Voucher Item Qty] = {8}</li>"
+				"<li>Delivered Qty [Qty delivered against the Voucher Item] = {9}</li>"
+				"<li>Total Reserved Qty [Qty reserved against the Voucher Item] = {10}</li>"
+				"<li>Allowed Qty [Minimum of (Available Qty To Reserve, (Voucher Qty - Delivered Qty - Total Reserved Qty))] = {11}</li>"
+				"</ul>"
+			).format(
 				frappe.bold(allowed_qty),
 				self.stock_uom,
 				frappe.bold(self.item_code),

--- a/erpnext/stock/doctype/stock_settings/stock_settings.py
+++ b/erpnext/stock/doctype/stock_settings/stock_settings.py
@@ -189,7 +189,7 @@ class StockSettings(Document):
 			if sle:
 				frappe.throw(
 					_(
-						"Can't change the valuation method, as there are transactions against some items which do not have its own valuation method"
+						"Can't change the valuation method, as there are transactions against some items which do not have their own valuation method"
 					)
 				)
 
@@ -247,7 +247,7 @@ class StockSettings(Document):
 
 				if has_reserved_stock:
 					frappe.throw(
-						_("As there are reserved stock, you cannot disable {0}.").format(
+						_("As there is reserved stock, you cannot disable {0}.").format(
 							frappe.bold(_("Stock Reservation"))
 						)
 					)

--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -355,9 +355,10 @@ def validate_item_details(ctx: ItemDetailsCtx, item):
 	validate_end_of_life(item.name, item.end_of_life, item.disabled)
 
 	if cint(item.has_variants):
-		msg = f"Item {item.name} is a template, please select one of its variants"
-
-		throw(_(msg), title=_("Template Item Selected"))
+		throw(
+			_("Item {0} is a template, please select one of its variants").format(item.name),
+			title=_("Template Item Selected"),
+		)
 
 	elif ctx.doctype != "Material Request":
 		if ctx.is_subcontracted and item.is_stock_item:

--- a/erpnext/stock/report/item_variant_details/item_variant_details.py
+++ b/erpnext/stock/report/item_variant_details/item_variant_details.py
@@ -22,7 +22,7 @@ def get_data(item):
 	)
 
 	if not variant_results:
-		frappe.msgprint(_("There aren't any item variants for the selected item"))
+		frappe.msgprint(_("There are no item variants for the selected item"))
 		return []
 	else:
 		variant_list = [variant["name"] for variant in variant_results]

--- a/erpnext/stock/serial_batch_bundle.py
+++ b/erpnext/stock/serial_batch_bundle.py
@@ -1231,7 +1231,9 @@ class SerialBatchCreation:
 			required_qty = flt(abs(self.actual_qty), precision)
 
 			if required_qty - total_qty > 0:
-				msg = f"For the item {bold(doc.item_code)}, the Available qty {bold(total_qty)} is less than the Required Qty {bold(required_qty)} in the warehouse {bold(doc.warehouse)}. Please add sufficient qty in the warehouse."
+				msg = _(
+					"For the item {0}, the Available qty {1} is less than the Required Qty {2} in the warehouse {3}. Please add sufficient qty in the warehouse."
+				).format(bold(doc.item_code), bold(total_qty), bold(required_qty), bold(doc.warehouse))
 				frappe.throw(msg, title=_("Insufficient Stock"))
 
 	def set_auto_serial_batch_entries_for_outward(self):

--- a/erpnext/stock/services/internal_transfer.py
+++ b/erpnext/stock/services/internal_transfer.py
@@ -101,7 +101,7 @@ class StockInternalTransferService:
 
 			if recevied_qty > flt(transferred_qty, precision):
 				frappe.throw(
-					_("For Item {0} cannot be received more than {1} qty against the {2} {3}").format(
+					_("Item {0} cannot be received in more than {1} qty against the {2} {3}").format(
 						bold(key[1]),
 						bold(flt(transferred_qty, precision)),
 						bold(parent_doctype),

--- a/erpnext/stock/services/serial_batch_bundle_service.py
+++ b/erpnext/stock/services/serial_batch_bundle_service.py
@@ -496,7 +496,7 @@ class SerialBatchBundleService:
 		if throw_error:
 			frappe.throw(
 				_(
-					"At row {0}: Serial and Batch Bundle {1} has already created. Please remove the values from the serial no or batch no fields."
+					"At row {0}: Serial and Batch Bundle {1} has already been created. Please remove the values from the serial no or batch no fields."
 				).format(row.idx, row.serial_and_batch_bundle)
 			)
 

--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -366,8 +366,7 @@ def create_file(doc, compressed_content):
 def validate_item_warehouse(args):
 	for field in ["item_code", "warehouse", "posting_date", "posting_time"]:
 		if args.get(field) in [None, ""]:
-			validation_msg = f"The field {frappe.unscrub(field)} is required for the reposting"
-			frappe.throw(_(validation_msg))
+			frappe.throw(_("The field {0} is required for reposting").format(frappe.unscrub(field)))
 
 
 def get_items_to_be_repost(voucher_type=None, voucher_no=None, doc=None, reposting_data=None):
@@ -831,7 +830,7 @@ class update_entries_after:
 		if previous_sle and previous_sle.get("qty_after_transaction") < 0 and sle.get("actual_qty") > 0:
 			frappe.msgprint(
 				_(
-					"The stock for the item {0} in the {1} warehouse was negative on the {2}. You should create a positive entry {3} before the date {4} and time {5} to post the correct valuation rate. For more details, please read the <a href='https://docs.erpnext.com/docs/user/manual/en/stock-adjustment-cogs-with-negative-stock'>documentation<a>."
+					"The stock for the item {0} in the {1} warehouse was negative on the {2}. You should create a positive entry {3} before the date {4} and time {5} to post the correct valuation rate. For more details, please read the <a href='https://docs.erpnext.com/docs/user/manual/en/stock-adjustment-cogs-with-negative-stock'>documentation</a>."
 				).format(
 					bold(sle.item_code),
 					bold(sle.warehouse),


### PR DESCRIPTION
Conservative rewrite of user-facing `frappe.throw` / `frappe.msgprint` messages in the **stock** module — part of #53976. Meaning, severity, and the set of `.format()` arguments are unchanged; this is translatability + grammar only.

### What changed
- **Indexed placeholders** — bare `{}` → `{0}`/`{1}` so translators can reorder arguments.
- **Translation-extraction fixes** — moved f-strings / `.format()` / concatenation out of `_()` (inside `_()` they never translate).
- **Wrapped translatable dynamic values** (DocType / Select labels) in `_()`.
- **Grammar / phrasing** fixes; dropped no-op `_()` on runtime-built strings.

### Sample
| Before | After |
|---|---|
| `frappe.throw(_("All these items have already been Invoiced/Returned"))` | `frappe.throw(_("All these items have already been invoiced/returned"))` |
| `frappe.throw(_("Cannot Calculate Arrival Time as Driver Address is Missing."))` | `frappe.throw(_("Cannot calculate arrival time as the driver address is missing."))` |
| `frappe.throw(_("'Has Serial No' can not be 'Yes' for non-stock item"))` | `frappe.throw(_("'Has Serial No' cannot be 'Yes' for non-stock item"))` |
| `_("Row #{}: {} {} doesn't belong to Company {}. Please select valid {}.").format(` | `_(` |
| `frappe.throw(_("Not allow to set alternative item for the item {0}").format(self.item_code))` | `frappe.throw(_("Cannot set alternative item for the item {0}").format(self.item_code))` |
| `alternate_item_check_msg = _("Allow Alternative Item must be checked on Item {}")` | `alternate_item_check_msg = _("Allow Alternative Item must be checked on Item {0}")` |

### Verification
- Whole `stock` module compiles.
- No test assertions reference any changed message text.
- Pure string edits — no logic or query behaviour change.