### PR TITLE
chore: rewrite user-facing messages in controllers module

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -274,7 +274,7 @@ class AccountsController(TransactionBase):
 			if invalid_advances := [x for x in self.advances if not x.reference_type or not x.reference_name]:
 				frappe.throw(
 					_(
-						"Rows: {0} in {1} section are Invalid. Reference Name should point to a valid Payment Entry or Journal Entry."
+						"Rows: {0} in {1} section are invalid. Reference Name should point to a valid Payment Entry or Journal Entry."
 					).format(
 						frappe.bold(comma_and([x.idx for x in invalid_advances])),
 						frappe.bold(_("Advance Payments")),
@@ -1233,7 +1233,7 @@ class AccountsController(TransactionBase):
 				{"sales_order": None, "sales_order_item": None},
 			)
 
-			frappe.msgprint(_("Purchase Orders {0} are un-linked").format("\n".join(linked_po)))
+			frappe.msgprint(_("Purchase Orders {0} are unlinked").format("\n".join(linked_po)))
 
 	def get_company_default(self, fieldname, ignore_validation=False):
 		from erpnext.accounts.utils import get_company_default

--- a/erpnext/controllers/buying_controller.py
+++ b/erpnext/controllers/buying_controller.py
@@ -129,7 +129,7 @@ class BuyingController(SubcontractingController):
 			msg += f"<li>{po} ({date})</li>"
 		msg += "</ul>"
 
-		frappe.throw(_(msg))
+		frappe.throw(msg)
 
 	def create_package_for_transfer(self) -> None:
 		"""Create serial and batch package for Sourece Warehouse in case of inter transfer."""
@@ -287,7 +287,7 @@ class BuyingController(SubcontractingController):
 		if self.is_return and len(not_cancelled_asset):
 			frappe.throw(
 				_(
-					"{} has submitted assets linked to it. You need to cancel the assets to create purchase return."
+					"{0} has submitted assets linked to it. You need to cancel the assets to create purchase return."
 				).format(self.return_against),
 				title=_("Not Allowed"),
 			)
@@ -738,7 +738,7 @@ class BuyingController(SubcontractingController):
 				frappe.throw(
 					_("Row #{idx}: {field_label} can not be negative for item {item_code}.").format(
 						idx=item_row["idx"],
-						field_label=frappe.get_meta(item_row.doctype).get_label(fieldname),
+						field_label=_(frappe.get_meta(item_row.doctype).get_label(fieldname)),
 						item_code=frappe.bold(item_row["item_code"]),
 					)
 				)

--- a/erpnext/controllers/sales_and_purchase_return.py
+++ b/erpnext/controllers/sales_and_purchase_return.py
@@ -77,7 +77,7 @@ def validate_return_against(doc):
 			# validate update stock
 			if doc.doctype == "Sales Invoice" and doc.update_stock and not ref_doc.update_stock:
 				frappe.throw(
-					_("'Update Stock' can not be checked because items are not delivered via {0}").format(
+					_("'Update Stock' cannot be checked because items are not delivered via {0}").format(
 						doc.return_against
 					)
 				)

--- a/erpnext/controllers/selling_controller.py
+++ b/erpnext/controllers/selling_controller.py
@@ -297,7 +297,7 @@ class SellingController(StockController):
 			throw(
 				_(
 					"""Row #{0}: Selling rate for item {1} is lower than its {2}.
-					Selling {3} should be atleast {4}.<br><br>Alternatively,
+					Selling {3} should be at least {4}.<br><br>Alternatively,
 					you can disable '{5}' in {6} to bypass
 					this validation."""
 				).format(
@@ -869,7 +869,7 @@ class SellingController(StockController):
 
 			duplicate_items_msg = _("Item {0} entered multiple times.").format(frappe.bold(d.item_code))
 			duplicate_items_msg += "<br><br>"
-			duplicate_items_msg += _("Please enable {} in {} to allow same item in multiple rows").format(
+			duplicate_items_msg += _("Please enable {0} in {1} to allow same item in multiple rows").format(
 				frappe.bold(_("Allow Item to Be Added Multiple Times in a Transaction")),
 				get_link_to_form("Selling Settings", "Selling Settings"),
 			)
@@ -898,7 +898,7 @@ class SellingController(StockController):
 
 		if not self.get("is_internal_customer") and any(d.get("target_warehouse") for d in items):
 			msg = _("Target Warehouse is set for some items but the customer is not an internal customer.")
-			msg += " " + _("This {} will be treated as material transfer.").format(_(self.doctype))
+			msg += " " + _("This {0} will be treated as material transfer.").format(_(self.doctype))
 			frappe.msgprint(msg, title="Internal Transfer", alert=True)
 
 	def validate_items(self):

--- a/erpnext/controllers/status_updater.py
+++ b/erpnext/controllers/status_updater.py
@@ -286,10 +286,10 @@ class StatusUpdater(Document):
 			# get unique transactions to update
 			for d in self.get_all_children():
 				if hasattr(d, "qty") and flt(d.qty) < 0 and not self.get("is_return"):
-					frappe.throw(_("For an item {0}, quantity must be positive number").format(d.item_code))
+					frappe.throw(_("For an item {0}, quantity must be a positive number").format(d.item_code))
 
 				if hasattr(d, "qty") and flt(d.qty) > 0 and self.get("is_return"):
-					frappe.throw(_("For an item {0}, quantity must be negative number").format(d.item_code))
+					frappe.throw(_("For an item {0}, quantity must be a negative number").format(d.item_code))
 
 				if (
 					not selling_negative_rate_allowed and self.doctype in ["Sales Invoice", "Delivery Note"]
@@ -300,7 +300,7 @@ class StatusUpdater(Document):
 					if hasattr(d, "item_code") and hasattr(d, "rate") and flt(d.rate) < 0:
 						frappe.throw(
 							_(
-								"For item {0}, rate must be a positive number. To Allow negative rates, enable {1} in {2}"
+								"For item {0}, rate must be a positive number. To allow negative rates, enable {1} in {2}"
 							).format(
 								frappe.bold(d.item_code),
 								frappe.bold(_("`Allow Negative rates for Items`")),

--- a/erpnext/controllers/subcontracting_controller.py
+++ b/erpnext/controllers/subcontracting_controller.py
@@ -211,7 +211,7 @@ class SubcontractingController(StockController):
 						)
 					if bom_item != item.item_code:
 						frappe.throw(
-							_("Row {0}: Please select an valid BOM for Item {1}.").format(
+							_("Row {0}: Please select a valid BOM for Item {1}.").format(
 								item.idx, item.item_name
 							)
 						)
@@ -1053,8 +1053,10 @@ class SubcontractingController(StockController):
 			link = get_link_to_form(
 				self.subcontract_data.order_doctype, row.get(self.subcontract_data.order_field)
 			)
-			msg = f'The Batch No {frappe.bold(row.get("batch_no"))} has not supplied against the {self.subcontract_data.order_doctype} {link}'
-			frappe.throw(_(msg), title=_("Incorrect Batch Consumed"))
+			msg = _("The Batch No {0} has not been supplied against the {1} {2}").format(
+				frappe.bold(row.get("batch_no")), self.subcontract_data.order_doctype, link
+			)
+			frappe.throw(msg, title=_("Incorrect Batch Consumed"))
 
 	def __validate_serial_no(self, row, key):
 		if row.get("serial_and_batch_bundle") and self.__transferred_items.get(key).get("serial_no"):
@@ -1066,8 +1068,10 @@ class SubcontractingController(StockController):
 				link = get_link_to_form(
 					self.subcontract_data.order_doctype, row.get(self.subcontract_data.order_field)
 				)
-				msg = f"The Serial Nos {incorrect_sn} has not supplied against the {self.subcontract_data.order_doctype} {link}"
-				frappe.throw(_(msg), title=_("Incorrect Serial Number Consumed"))
+				msg = _("The Serial Nos {0} have not been supplied against the {1} {2}").format(
+					incorrect_sn, self.subcontract_data.order_doctype, link
+				)
+				frappe.throw(msg, title=_("Incorrect Serial Number Consumed"))
 
 	def __validate_supplied_or_received_items(self):
 		if self.doctype not in ["Purchase Invoice", "Purchase Receipt", "Subcontracting Receipt"]:

--- a/erpnext/controllers/subcontracting_inward_controller.py
+++ b/erpnext/controllers/subcontracting_inward_controller.py
@@ -78,7 +78,7 @@ class SubcontractingInwardController:
 			):
 				frappe.throw(
 					_(
-						"Row #{0}: Item {1} mismatch. Changing of item code is not permitted, add another row instead."
+						"Row #{0}: Item {1} mismatch. Changing the item code is not permitted, add another row instead."
 					).format(item.idx, get_link_to_form("Item", item.item_code))
 				)
 
@@ -126,7 +126,7 @@ class SubcontractingInwardController:
 				or frappe.get_cached_value("Subcontracting Inward Order Item", item.scio_detail, "item_code")
 			):
 				frappe.throw(
-					_("Row #{0}: Item {1} mismatch. Changing of item code is not permitted.").format(
+					_("Row #{0}: Item {1} mismatch. Changing the item code is not permitted.").format(
 						item.idx, get_link_to_form("Item", item.item_code)
 					)
 				)
@@ -441,7 +441,7 @@ class SubcontractingInwardController:
 				):
 					frappe.throw(
 						_(
-							"Row #{0}: Batch No(s) {1} is not a part of the linked Subcontracting Inward Order. Please select valid Batch No(s)."
+							"Row #{0}: Batch No(s) {1} are not a part of the linked Subcontracting Inward Order. Please select valid Batch No(s)."
 						).format(
 							item.idx,
 							", ".join([get_link_to_form("Batch No", bn) for bn in incorrect_batch_nos]),

--- a/erpnext/controllers/taxes_and_totals.py
+++ b/erpnext/controllers/taxes_and_totals.py
@@ -131,9 +131,9 @@ class calculate_taxes_and_totals:
 					if item.item_tax_template not in taxes:
 						item.item_tax_template = taxes[0]
 						frappe.msgprint(
-							_("Row {0}: Item Tax template updated as per validity and rate applied").format(
-								item.idx, frappe.bold(item.item_code)
-							)
+							_(
+								"Row {0}: Item Tax template for {1} updated as per validity and rate applied"
+							).format(item.idx, frappe.bold(item.item_code))
 						)
 
 						# For correct tax_amount calculation re-computation is required
@@ -564,7 +564,7 @@ class calculate_taxes_and_totals:
 				+ "<br>".join(invalid_rows)
 			)
 
-			frappe.throw(_(message))
+			frappe.throw(message)
 
 	def get_tax_amount_if_for_valuation_or_deduction(self, tax_amount, tax):
 		# if just for valuation, do not add the tax amount in total

--- a/erpnext/controllers/trends.py
+++ b/erpnext/controllers/trends.py
@@ -56,10 +56,10 @@ def validate_filters(filters):
 			frappe.throw(_("{0} is mandatory").format(_(f)))
 
 	if not frappe.db.exists("Fiscal Year", filters.get("fiscal_year")):
-		frappe.throw(_("Fiscal Year {0} Does Not Exist").format(filters.get("fiscal_year")))
+		frappe.throw(_("Fiscal Year {0} does not exist").format(filters.get("fiscal_year")))
 
 	if filters.get("based_on") == filters.get("group_by"):
-		frappe.throw(_("'Based On' and 'Group By' can not be same"))
+		frappe.throw(_("'Based On' and 'Group By' can not be the same"))
 
 	if filters.get("period_based_on") and filters.period_based_on not in ["bill_date", "posting_date"]:
 		frappe.throw(

--- a/erpnext/controllers/website_list_for_contact.py
+++ b/erpnext/controllers/website_list_for_contact.py
@@ -308,4 +308,4 @@ def add_role_for_portal_user(portal_user, role):
 		return
 
 	user_doc.add_roles(role)
-	frappe.msgprint(_("Added {1} Role to User {0}.").format(frappe.bold(user_doc.name), role), alert=True)
+	frappe.msgprint(_("Added {1} role to user {0}.").format(frappe.bold(user_doc.name), role), alert=True)


### PR DESCRIPTION
Conservative rewrite of user-facing `frappe.throw` / `frappe.msgprint` messages in the **controllers** module — part of #53976. Meaning, severity, and the set of `.format()` arguments are unchanged; this is translatability + grammar only.

### What changed
- **Indexed placeholders** — bare `{}` → `{0}`/`{1}` so translators can reorder arguments.
- **Translation-extraction fixes** — moved f-strings / `.format()` / concatenation out of `_()` (inside `_()` they never translate).
- **Wrapped translatable dynamic values** (DocType / Select labels) in `_()`.
- **Grammar / phrasing** fixes; dropped no-op `_()` on runtime-built strings.

### Sample
| Before | After |
|---|---|
| `frappe.msgprint(_("Purchase Orders {0} are un-linked").format("\n".join(linked_po)))` | `frappe.msgprint(_("Purchase Orders {0} are unlinked").format("\n".join(linked_po)))` |
| `frappe.throw(_(msg))` | `frappe.throw(msg)` |
| `_("'Update Stock' can not be checked because items are not delivered via {0}").format(` | `_("'Update Stock' cannot be checked because items are not delivered via {0}").format(` |
| `duplicate_items_msg += _("Please enable {} in {} to allow same item in multiple rows").format(` | `duplicate_items_msg += _("Please enable {0} in {1} to allow same item in multiple rows").format(` |
| `msg += " " + _("This {} will be treated as material transfer.").format(_(self.doctype))` | `msg += " " + _("This {0} will be treated as material transfer.").format(_(self.doctype))` |
| `frappe.throw(_("For an item {0}, quantity must be positive number").format(d.item_code))` | `frappe.throw(_("For an item {0}, quantity must be a positive number").format(d.item_code))` |

### Verification
- Whole `controllers` module compiles.
- No test assertions reference any changed message text.
- Pure string edits — no logic or query behaviour change.