### PR TITLE
chore: rewrite user-facing JS messages in public module

### DIFF
--- a/erpnext/public/js/bulk_transaction_processing.js
+++ b/erpnext/public/js/bulk_transaction_processing.js
@@ -25,10 +25,9 @@ $.extend(erpnext.bulk_transaction_processing, {
 					})
 					.then(() => {});
 				if (count_of_rows > 10) {
-					frappe.show_alert("Starting a background job to create {0} {1}", [
-						count_of_rows,
-						__(to_doctype),
-					]);
+					frappe.show_alert(
+						__("Starting a background job to create {0} {1}", [count_of_rows, __(to_doctype)])
+					);
 				}
 			} else {
 				frappe.msgprint(__("Selected document must be in submitted state"));

--- a/erpnext/public/js/controllers/accounts.js
+++ b/erpnext/public/js/controllers/accounts.js
@@ -228,7 +228,7 @@ erpnext.accounts.taxes = {
 					on_previous_row_error(tax.row_id == 1 ? "1" : "1 - " + tax.row_id);
 				}
 			} else if (tax.category == "Valuation") {
-				frappe.throw(__("Valuation type charges can not marked as Inclusive"));
+				frappe.throw(__("Valuation type charges cannot be marked as Inclusive"));
 			}
 		}
 	},

--- a/erpnext/public/js/controllers/buying.js
+++ b/erpnext/public/js/controllers/buying.js
@@ -552,10 +552,10 @@ erpnext.buying.link_to_mrs = function (frm) {
 						item.qty = my_qty;
 
 						frappe.msgprint(
-							"Assigning " + d.mr_name + " to " + d.item_code + " (row " + item.idx + ")"
+							__("Assigning {0} to {1} (row {2})", [d.mr_name, d.item_code, item.idx])
 						);
 						if (qty > 0) {
-							frappe.msgprint("Splitting " + qty + " units of " + d.item_code);
+							frappe.msgprint(__("Splitting {0} units of {1}", [qty, d.item_code]));
 							var newrow = frappe.model.add_child(frm.doc, item.doctype, "items");
 							item_length++;
 

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -2635,11 +2635,9 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 			) {
 				if (!me.frm.doc[fieldname]) {
 					frappe.msgprint(
-						__("Please specify") +
-							": " +
-							__(frappe.meta.get_label(me.frm.doc.doctype, fieldname, me.frm.doc.name)) +
-							". " +
-							__("It is needed to fetch Item Details.")
+						__("Please specify {0}. It is needed to fetch Item Details.", [
+							__(frappe.meta.get_label(me.frm.doc.doctype, fieldname, me.frm.doc.name)),
+						])
 					);
 					valid = false;
 				}

--- a/erpnext/public/js/utils/sales_common.js
+++ b/erpnext/public/js/utils/sales_common.js
@@ -331,9 +331,15 @@ erpnext.sales_common = {
 				if (this.frm.doc.commission_rate > 100) {
 					this.frm.set_value("commission_rate", 100);
 					frappe.throw(
-						`${__(
-							frappe.meta.get_label(this.frm.doc.doctype, "commission_rate", this.frm.doc.name)
-						)} ${__("cannot be greater than 100")}`
+						__("{0} cannot be greater than 100", [
+							__(
+								frappe.meta.get_label(
+									this.frm.doc.doctype,
+									"commission_rate",
+									this.frm.doc.name
+								)
+							),
+						])
 					);
 				}
 

--- a/erpnext/public/js/utils/serial_no_batch_selector.js
+++ b/erpnext/public/js/utils/serial_no_batch_selector.js
@@ -660,7 +660,7 @@ erpnext.SerialBatchPackageSelector = class SerialNoBatchBundleUpdate {
 		}
 
 		if ((entries && !entries.length) || !entries) {
-			frappe.throw(__("Please add atleast one Serial No / Batch No"));
+			frappe.throw(__("Please add at least one Serial No / Batch No"));
 		}
 
 		if (!warehouse) {
@@ -668,7 +668,7 @@ erpnext.SerialBatchPackageSelector = class SerialNoBatchBundleUpdate {
 		}
 
 		if (this.item?.is_rejected && this.item.rejected_warehouse === this.item.warehouse) {
-			frappe.throw(__("Rejected Warehouse and Accepted Warehouse cannot be same."));
+			frappe.throw(__("Rejected Warehouse and Accepted Warehouse cannot be the same."));
 		}
 
 		frappe


### PR DESCRIPTION
Conservative rewrite of user-facing JS `frappe.throw` / `frappe.msgprint` / `frappe.show_alert` messages in the **public** module — part of #53976. Meaning, severity, and the set of `.format()` arguments are unchanged; this is translatability + grammar only.

### What changed
- **Indexed placeholders** — bare `{}` → `{0}`/`{1}` so translators can reorder arguments.
- **Translation-extraction fixes** — moved f-strings / `.format()` / concatenation out of `_()` (inside `_()` they never translate).
- **Wrapped translatable dynamic values** (DocType / Select labels) in `_()`.
- **Grammar / phrasing** fixes; dropped no-op `_()` on runtime-built strings.

### Sample
| Before | After |
|---|---|
| `frappe.throw(__("Valuation type charges can not marked as Inclusive"));` | `frappe.throw(__("Valuation type charges cannot be marked as Inclusive"));` |
| `frappe.msgprint("Splitting " + qty + " units of " + d.item_code);` | `frappe.msgprint(__("Splitting {0} units of {1}", [qty, d.item_code]));` |
| `__("It is needed to fetch Item Details.")` | `__("Please specify {0}. It is needed to fetch Item Details.", [` |
| `const msg = __("payments app is not installed. Please install it from {0} or {1}", [` | `const msg = __("Payments app is not installed. Please install it from {0} or {1}", [` |
| `)} ${__("cannot be greater than 100")}`` | `__("{0} cannot be greater than 100", [` |
| `frappe.throw(__("Please add atleast one Serial No / Batch No"));` | `frappe.throw(__("Please add at least one Serial No / Batch No"));` |

### Verification
- JS lints clean (eslint/prettier).
- No test assertions reference any changed message text.
- Pure string edits — no logic or query behaviour change.