### PR TITLE
fix: handle missing serial and batch bundle in print format

### DIFF
--- a/erpnext/stock/serial_batch_bundle.py
+++ b/erpnext/stock/serial_batch_bundle.py
@@ -606,9 +606,15 @@ def get_serial_nos_from_bundle(serial_and_batch_bundle, serial_nos=None):
 def get_serial_or_batch_nos(bundle):
 	# For print format
 
+	if not bundle:
+		return ""
+
 	bundle_data = frappe.get_cached_value(
 		"Serial and Batch Bundle", bundle, ["has_serial_no", "has_batch_no"], as_dict=True
 	)
+
+	if not bundle_data:
+		return bundle
 
 	fields = []
 	if bundle_data.has_serial_no:


### PR DESCRIPTION
## Problem

When printing a Purchase Receipt using the "Purchase Receipt Serial and Batch Bundle Print" format, the Jinja template crashes if any line item has no serial/batch bundle (e.g. non-serialised/non-batched items, or a bundle that was deleted post-submission).

`get_serial_or_batch_nos(bundle)` calls `frappe.get_cached_value(...)` which returns `None` when `bundle` is empty/missing, then immediately accesses `bundle_data.has_serial_no` — causing:

```
AttributeError: 'NoneType' object has no attribute 'has_serial_no'
```

## Helpdesk

https://support.frappe.io/helpdesk/tickets/72342?view=VIEW-HD+Ticket-70178