### PR TITLE
chore: fix grammar in Exchange Rate Revaluation validation message

### DIFF
--- a/erpnext/accounts/doctype/exchange_rate_revaluation/exchange_rate_revaluation.py
+++ b/erpnext/accounts/doctype/exchange_rate_revaluation/exchange_rate_revaluation.py
@@ -73,7 +73,7 @@ class ExchangeRateRevaluation(Document):
 
 	def validate_mandatory(self):
 		if not (self.company and self.posting_date):
-			frappe.throw(_("Please select Company and Posting Date to getting entries"))
+			frappe.throw(_("Please select Company and Posting Date to get entries"))
 
 	def before_submit(self):
 		self.remove_accounts_without_gain_loss()


### PR DESCRIPTION
One-word server-side grammar fix: `to getting entries` -> `to get entries` in `exchange_rate_revaluation.py`. Matches the client-side wording fixed in #56484 so the same missing Company / Posting Date validation reads identically on client and server (resolves a Greptile cross-layer-divergence note). Part of #53976.