### PR TITLE
test: Trial Balance for Party report coverage

### DIFF
--- a/erpnext/accounts/report/trial_balance_for_party/test_trial_balance_for_party.py
+++ b/erpnext/accounts/report/trial_balance_for_party/test_trial_balance_for_party.py
@@ -27,27 +27,8 @@ class TestTrialBalanceForParty(ERPNextTestSuite):
 	def party_row(self, party, **extra):
 		return next(row for row in self.run_report(party=party, **extra) if row.get("party") == party)
 
-	def make_customer(self, name="_Test TB Customer"):
-		if not frappe.db.exists("Customer", name):
-			frappe.get_doc(
-				{
-					"doctype": "Customer",
-					"customer_name": name,
-					"customer_group": "_Test Customer Group",
-					"territory": "_Test Territory",
-				}
-			).insert()
-		return name
-
-	def make_supplier(self, name="_Test TB Supplier"):
-		if not frappe.db.exists("Supplier", name):
-			frappe.get_doc(
-				{"doctype": "Supplier", "supplier_name": name, "supplier_group": "_Test Supplier Group"}
-			).insert()
-		return name
-
 	def test_sales_invoice_shown_as_period_debit(self):
-		customer = self.make_customer()
+		customer = "_Test Customer"
 		create_sales_invoice(customer=customer, qty=1, rate=10000, posting_date="2026-06-01")
 
 		row = self.party_row(customer)
@@ -58,7 +39,7 @@ class TestTrialBalanceForParty(ERPNextTestSuite):
 		self.assertEqual(row["closing_credit"], 0)
 
 	def test_receipt_nets_invoice_in_closing(self):
-		customer = self.make_customer()
+		customer = "_Test Customer"
 		create_sales_invoice(customer=customer, qty=1, rate=10000, posting_date="2026-06-01")
 		create_payment_entry(
 			payment_type="Receive",
@@ -79,7 +60,7 @@ class TestTrialBalanceForParty(ERPNextTestSuite):
 		self.assertEqual(row["closing_credit"], 0)
 
 	def test_prior_period_invoice_shown_as_opening(self):
-		customer = self.make_customer()
+		customer = "_Test Customer"
 		# invoice dated before from_date should land in the opening balance, not within-period
 		create_sales_invoice(customer=customer, qty=1, rate=10000, posting_date="2025-12-01")
 
@@ -89,7 +70,7 @@ class TestTrialBalanceForParty(ERPNextTestSuite):
 		self.assertEqual(row["closing_debit"], 10000)
 
 	def test_exclude_zero_balance_parties(self):
-		customer = self.make_customer()
+		customer = "_Test Customer"
 		create_sales_invoice(customer=customer, qty=1, rate=10000, posting_date="2026-06-01")
 		create_payment_entry(
 			payment_type="Receive",
@@ -109,7 +90,7 @@ class TestTrialBalanceForParty(ERPNextTestSuite):
 		self.assertNotIn(customer, parties)
 
 	def test_purchase_invoice_shown_as_supplier_credit(self):
-		supplier = self.make_supplier()
+		supplier = "_Test Supplier"
 		make_purchase_invoice(supplier=supplier, qty=1, rate=8000, posting_date="2026-06-01")
 
 		row = self.party_row(supplier, party_type="Supplier")
@@ -119,15 +100,18 @@ class TestTrialBalanceForParty(ERPNextTestSuite):
 		self.assertEqual(row["closing_debit"], 0)
 
 	def test_totals_row_sums_party_rows(self):
-		create_sales_invoice(
-			customer=self.make_customer("_Test TB Customer A"), qty=1, rate=10000, posting_date="2026-06-01"
-		)
-		create_sales_invoice(
-			customer=self.make_customer("_Test TB Customer B"), qty=1, rate=6000, posting_date="2026-06-01"
-		)
+		create_sales_invoice(customer="_Test Customer 1", qty=1, rate=10000, posting_date="2026-06-01")
+		create_sales_invoice(customer="_Test Customer 2", qty=1, rate=6000, posting_date="2026-06-01")
 
 		data = self.run_report()
 		totals = data[-1]  # totals row is appended last
 		party_rows = data[:-1]
-		for column in ("opening_debit", "opening_credit", "debit", "credit", "closing_debit", "closing_credit"):
+		for column in (
+			"opening_debit",
+			"opening_credit",
+			"debit",
+			"credit",
+			"closing_debit",
+			"closing_credit",
+		):
 			self.assertEqual(totals[column], sum(row[column] for row in party_rows))

--- a/erpnext/accounts/report/trial_balance_for_party/test_trial_balance_for_party.py
+++ b/erpnext/accounts/report/trial_balance_for_party/test_trial_balance_for_party.py
@@ -1,0 +1,133 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and Contributors
+# See license.txt
+
+import frappe
+
+from erpnext.accounts.doctype.payment_entry.test_payment_entry import create_payment_entry
+from erpnext.accounts.doctype.purchase_invoice.test_purchase_invoice import make_purchase_invoice
+from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_sales_invoice
+from erpnext.accounts.report.trial_balance_for_party.trial_balance_for_party import execute
+from erpnext.tests.utils import ERPNextTestSuite
+
+
+class TestTrialBalanceForParty(ERPNextTestSuite):
+	def run_report(self, **extra):
+		filters = frappe._dict(
+			{
+				"company": "_Test Company",
+				"party_type": "Customer",
+				"fiscal_year": "_Test Fiscal Year 2026",
+				"from_date": "2026-01-01",
+				"to_date": "2026-12-31",
+				**extra,
+			}
+		)
+		return execute(filters)[1]
+
+	def party_row(self, party, **extra):
+		return next(row for row in self.run_report(party=party, **extra) if row.get("party") == party)
+
+	def make_customer(self, name="_Test TB Customer"):
+		if not frappe.db.exists("Customer", name):
+			frappe.get_doc(
+				{
+					"doctype": "Customer",
+					"customer_name": name,
+					"customer_group": "_Test Customer Group",
+					"territory": "_Test Territory",
+				}
+			).insert()
+		return name
+
+	def make_supplier(self, name="_Test TB Supplier"):
+		if not frappe.db.exists("Supplier", name):
+			frappe.get_doc(
+				{"doctype": "Supplier", "supplier_name": name, "supplier_group": "_Test Supplier Group"}
+			).insert()
+		return name
+
+	def test_sales_invoice_shown_as_period_debit(self):
+		customer = self.make_customer()
+		create_sales_invoice(customer=customer, qty=1, rate=10000, posting_date="2026-06-01")
+
+		row = self.party_row(customer)
+		self.assertEqual(row["opening_debit"], 0)
+		self.assertEqual(row["debit"], 10000)
+		self.assertEqual(row["credit"], 0)
+		self.assertEqual(row["closing_debit"], 10000)
+		self.assertEqual(row["closing_credit"], 0)
+
+	def test_receipt_nets_invoice_in_closing(self):
+		customer = self.make_customer()
+		create_sales_invoice(customer=customer, qty=1, rate=10000, posting_date="2026-06-01")
+		create_payment_entry(
+			payment_type="Receive",
+			party_type="Customer",
+			party=customer,
+			paid_from="Debtors - _TC",
+			paid_to="_Test Bank - _TC",
+			paid_amount=4000,
+			save=True,
+			submit=True,
+		)
+
+		row = self.party_row(customer)
+		self.assertEqual(row["debit"], 10000)
+		self.assertEqual(row["credit"], 4000)
+		# closing nets debit against credit: 10000 - 4000
+		self.assertEqual(row["closing_debit"], 6000)
+		self.assertEqual(row["closing_credit"], 0)
+
+	def test_prior_period_invoice_shown_as_opening(self):
+		customer = self.make_customer()
+		# invoice dated before from_date should land in the opening balance, not within-period
+		create_sales_invoice(customer=customer, qty=1, rate=10000, posting_date="2025-12-01")
+
+		row = self.party_row(customer)
+		self.assertEqual(row["opening_debit"], 10000)
+		self.assertEqual(row["debit"], 0)
+		self.assertEqual(row["closing_debit"], 10000)
+
+	def test_exclude_zero_balance_parties(self):
+		customer = self.make_customer()
+		create_sales_invoice(customer=customer, qty=1, rate=10000, posting_date="2026-06-01")
+		create_payment_entry(
+			payment_type="Receive",
+			party_type="Customer",
+			party=customer,
+			paid_from="Debtors - _TC",
+			paid_to="_Test Bank - _TC",
+			paid_amount=10000,
+			save=True,
+			submit=True,
+		)
+
+		# fully settled party still shows by default ...
+		self.assertEqual(self.party_row(customer)["closing_debit"], 0)
+		# ... but is hidden when zero-balance parties are excluded
+		parties = {row.get("party") for row in self.run_report(exclude_zero_balance_parties=1)}
+		self.assertNotIn(customer, parties)
+
+	def test_purchase_invoice_shown_as_supplier_credit(self):
+		supplier = self.make_supplier()
+		make_purchase_invoice(supplier=supplier, qty=1, rate=8000, posting_date="2026-06-01")
+
+		row = self.party_row(supplier, party_type="Supplier")
+		self.assertEqual(row["credit"], 8000)
+		self.assertEqual(row["debit"], 0)
+		self.assertEqual(row["closing_credit"], 8000)
+		self.assertEqual(row["closing_debit"], 0)
+
+	def test_totals_row_sums_party_rows(self):
+		create_sales_invoice(
+			customer=self.make_customer("_Test TB Customer A"), qty=1, rate=10000, posting_date="2026-06-01"
+		)
+		create_sales_invoice(
+			customer=self.make_customer("_Test TB Customer B"), qty=1, rate=6000, posting_date="2026-06-01"
+		)
+
+		data = self.run_report()
+		totals = data[-1]  # totals row is appended last
+		party_rows = data[:-1]
+		for column in ("opening_debit", "opening_credit", "debit", "credit", "closing_debit", "closing_credit"):
+			self.assertEqual(totals[column], sum(row[column] for row in party_rows))


### PR DESCRIPTION
Adds the first tests for the **Trial Balance for Party** report, which previously had no test file. The tests focus on the report's actual money math — how party GL entries split into opening, within-period, and netted closing balances — rather than just exercising the query.

### What's covered
- A sales invoice shows up as a within-period **debit** for the customer, with the right closing balance.
- A receipt **nets** against the invoice so the closing balance reflects debit − credit.
- An invoice dated before the period lands in the **opening balance**, not the within-period columns.
- Fully-settled (zero-balance) parties are hidden when **Exclude Zero Balance Parties** is set.
- A purchase invoice shows up as a **credit** for the supplier (party-type switch).
- The **Totals** row equals the sum of all party rows across every column.

### How to test
- Open the Trial Balance for Party report for a Customer and confirm an invoice appears under Debit and the closing column.
- Record a partial receipt and confirm the closing balance drops accordingly.
- Move the From Date after an invoice's date and confirm that invoice moves into the Opening column.
- Tick "Exclude Zero Balance Parties" and confirm settled parties drop off.
- Switch Party Type to Supplier and confirm a purchase invoice appears under Credit.
