### PR TITLE
test: Total Stock Summary report coverage

### DIFF
--- a/erpnext/stock/report/total_stock_summary/test_total_stock_summary.py
+++ b/erpnext/stock/report/total_stock_summary/test_total_stock_summary.py
@@ -1,0 +1,34 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and Contributors
+# See license.txt
+
+import frappe
+
+from erpnext.stock.doctype.item.test_item import make_item
+from erpnext.stock.doctype.stock_entry.stock_entry_utils import make_stock_entry
+from erpnext.stock.doctype.warehouse.test_warehouse import create_warehouse
+from erpnext.stock.report.total_stock_summary.total_stock_summary import execute
+from erpnext.tests.utils import ERPNextTestSuite
+
+
+class TestTotalStockSummary(ERPNextTestSuite):
+	def run_report(self, **extra):
+		filters = frappe._dict({"company": "_Test Company", "group_by": "Warehouse", **extra})
+		return execute(filters)[1]
+
+	def test_warehouse_wise_quantity(self):
+		item = make_item().name
+		warehouse = create_warehouse("_Test TSS Warehouse")
+		make_stock_entry(item_code=item, to_warehouse=warehouse, qty=10, rate=100)
+
+		# rows are (warehouse, item_code, description, actual_qty)
+		row = next(r for r in self.run_report() if r[0] == warehouse and r[1] == item)
+		self.assertEqual(row[3], 10)
+
+	def test_only_non_zero_bins_are_listed(self):
+		item = make_item().name
+		warehouse = create_warehouse("_Test TSS Empty Warehouse")
+		# receive then issue everything -> bin actual_qty back to zero
+		make_stock_entry(item_code=item, to_warehouse=warehouse, qty=5, rate=100)
+		make_stock_entry(item_code=item, from_warehouse=warehouse, qty=5)
+
+		self.assertFalse([r for r in self.run_report() if r[0] == warehouse and r[1] == item])

--- a/erpnext/stock/report/total_stock_summary/test_total_stock_summary.py
+++ b/erpnext/stock/report/total_stock_summary/test_total_stock_summary.py
@@ -3,9 +3,7 @@
 
 import frappe
 
-from erpnext.stock.doctype.item.test_item import make_item
 from erpnext.stock.doctype.stock_entry.stock_entry_utils import make_stock_entry
-from erpnext.stock.doctype.warehouse.test_warehouse import create_warehouse
 from erpnext.stock.report.total_stock_summary.total_stock_summary import execute
 from erpnext.tests.utils import ERPNextTestSuite
 
@@ -16,8 +14,8 @@ class TestTotalStockSummary(ERPNextTestSuite):
 		return execute(filters)[1]
 
 	def test_warehouse_wise_quantity(self):
-		item = make_item().name
-		warehouse = create_warehouse("_Test TSS Warehouse")
+		item = "_Test Item"
+		warehouse = "Stores - _TC"  # clean zero baseline for _Test Item
 		make_stock_entry(item_code=item, to_warehouse=warehouse, qty=10, rate=100)
 
 		# rows are (warehouse, item_code, description, actual_qty)
@@ -25,8 +23,8 @@ class TestTotalStockSummary(ERPNextTestSuite):
 		self.assertEqual(row[3], 10)
 
 	def test_only_non_zero_bins_are_listed(self):
-		item = make_item().name
-		warehouse = create_warehouse("_Test TSS Empty Warehouse")
+		item = "_Test Item 2"
+		warehouse = "Stores - _TC"  # clean zero baseline for _Test Item 2
 		# receive then issue everything -> bin actual_qty back to zero
 		make_stock_entry(item_code=item, to_warehouse=warehouse, qty=5, rate=100)
 		make_stock_entry(item_code=item, from_warehouse=warehouse, qty=5)


### PR DESCRIPTION
Adds the first tests for the **Total Stock Summary** report, which previously had no test file. The tests drive real stock transactions and assert the report's actual output.

### What's covered
- `test_warehouse_wise_quantity`
- `test_only_non_zero_bins_are_listed`

### How to test
Run the report from the Stock module and confirm the figures match the underlying stock movements.