### PR TITLE
test: Incorrect Balance Qty After Transaction report coverage

### DIFF
--- a/erpnext/stock/report/incorrect_balance_qty_after_transaction/test_incorrect_balance_qty_after_transaction.py
+++ b/erpnext/stock/report/incorrect_balance_qty_after_transaction/test_incorrect_balance_qty_after_transaction.py
@@ -1,0 +1,41 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and Contributors
+# See license.txt
+
+import frappe
+
+from erpnext.stock.doctype.item.test_item import make_item
+from erpnext.stock.doctype.stock_entry.stock_entry_utils import make_stock_entry
+from erpnext.stock.report.incorrect_balance_qty_after_transaction.incorrect_balance_qty_after_transaction import (
+	execute,
+)
+from erpnext.tests.utils import ERPNextTestSuite
+
+WAREHOUSE = "_Test Warehouse - _TC"
+COMPANY = "_Test Company"
+
+
+class TestIncorrectBalanceQtyAfterTransaction(ERPNextTestSuite):
+	def run_report(self, **extra):
+		filters = frappe._dict({"company": COMPANY, "warehouse": WAREHOUSE})
+		filters.update(extra)
+		return execute(filters)[1]
+
+	def test_healthy_stock_not_flagged(self):
+		item = make_item(properties={"is_stock_item": 1}).name
+		make_stock_entry(item_code=item, to_warehouse=WAREHOUSE, qty=10, rate=100, posting_date="2026-06-01")
+		make_stock_entry(item_code=item, from_warehouse=WAREHOUSE, qty=4, rate=100, posting_date="2026-06-02")
+
+		data = self.run_report(item_code=item)
+		flagged = [row for row in data if row.get("item_code") == item]
+		self.assertEqual(flagged, [])
+
+	def test_sequence_of_movements_not_flagged(self):
+		item = make_item(properties={"is_stock_item": 1}).name
+		make_stock_entry(item_code=item, to_warehouse=WAREHOUSE, qty=20, rate=50, posting_date="2026-06-01")
+		make_stock_entry(item_code=item, from_warehouse=WAREHOUSE, qty=5, rate=50, posting_date="2026-06-02")
+		make_stock_entry(item_code=item, to_warehouse=WAREHOUSE, qty=8, rate=50, posting_date="2026-06-03")
+		make_stock_entry(item_code=item, from_warehouse=WAREHOUSE, qty=3, rate=50, posting_date="2026-06-04")
+
+		data = self.run_report(item_code=item)
+		flagged = [row for row in data if row.get("item_code") == item]
+		self.assertEqual(flagged, [])

--- a/erpnext/stock/report/incorrect_balance_qty_after_transaction/test_incorrect_balance_qty_after_transaction.py
+++ b/erpnext/stock/report/incorrect_balance_qty_after_transaction/test_incorrect_balance_qty_after_transaction.py
@@ -3,14 +3,13 @@
 
 import frappe
 
-from erpnext.stock.doctype.item.test_item import make_item
 from erpnext.stock.doctype.stock_entry.stock_entry_utils import make_stock_entry
 from erpnext.stock.report.incorrect_balance_qty_after_transaction.incorrect_balance_qty_after_transaction import (
 	execute,
 )
 from erpnext.tests.utils import ERPNextTestSuite
 
-WAREHOUSE = "_Test Warehouse - _TC"
+WAREHOUSE = "Stores - _TC"
 COMPANY = "_Test Company"
 
 
@@ -21,7 +20,7 @@ class TestIncorrectBalanceQtyAfterTransaction(ERPNextTestSuite):
 		return execute(filters)[1]
 
 	def test_healthy_stock_not_flagged(self):
-		item = make_item(properties={"is_stock_item": 1}).name
+		item = "_Test Item"
 		make_stock_entry(item_code=item, to_warehouse=WAREHOUSE, qty=10, rate=100, posting_date="2026-06-01")
 		make_stock_entry(item_code=item, from_warehouse=WAREHOUSE, qty=4, rate=100, posting_date="2026-06-02")
 
@@ -30,7 +29,7 @@ class TestIncorrectBalanceQtyAfterTransaction(ERPNextTestSuite):
 		self.assertEqual(flagged, [])
 
 	def test_sequence_of_movements_not_flagged(self):
-		item = make_item(properties={"is_stock_item": 1}).name
+		item = "_Test Item 2"
 		make_stock_entry(item_code=item, to_warehouse=WAREHOUSE, qty=20, rate=50, posting_date="2026-06-01")
 		make_stock_entry(item_code=item, from_warehouse=WAREHOUSE, qty=5, rate=50, posting_date="2026-06-02")
 		make_stock_entry(item_code=item, to_warehouse=WAREHOUSE, qty=8, rate=50, posting_date="2026-06-03")


### PR DESCRIPTION
Adds the first tests for the **Incorrect Balance Qty After Transaction** report, which previously had no test file. The tests drive real stock transactions and assert the report's actual output.

### What's covered
- `test_healthy_stock_not_flagged`
- `test_sequence_of_movements_not_flagged`

### How to test
Run the report from the Stock module and confirm the figures match the underlying stock movements.