### PR TITLE
test: Warehouse Wise Item Balance Age and Value report coverage

### DIFF
--- a/erpnext/stock/report/warehouse_wise_item_balance_age_and_value/test_warehouse_wise_item_balance_age_and_value.py
+++ b/erpnext/stock/report/warehouse_wise_item_balance_age_and_value/test_warehouse_wise_item_balance_age_and_value.py
@@ -3,7 +3,6 @@
 
 import frappe
 
-from erpnext.stock.doctype.item.test_item import make_item
 from erpnext.stock.doctype.stock_entry.stock_entry_utils import make_stock_entry
 from erpnext.stock.report.warehouse_wise_item_balance_age_and_value.warehouse_wise_item_balance_age_and_value import (
 	execute,
@@ -18,15 +17,15 @@ class TestWarehouseWiseItemBalanceAgeAndValue(ERPNextTestSuite):
 				"company": "_Test Company",
 				"from_date": "2026-01-01",
 				"to_date": "2026-12-31",
-				"warehouse": "_Test Warehouse - _TC",
+				"warehouse": "Stores - _TC",
 			}
 		)
 		filters.update(extra)
 		return execute(filters)[1]
 
 	def test_balance_qty_and_value(self):
-		item_code = make_item(properties={"is_stock_item": 1}).name
-		warehouse = "_Test Warehouse - _TC"
+		item_code = "_Test Item"
+		warehouse = "Stores - _TC"
 
 		make_stock_entry(
 			item_code=item_code,

--- a/erpnext/stock/report/warehouse_wise_item_balance_age_and_value/test_warehouse_wise_item_balance_age_and_value.py
+++ b/erpnext/stock/report/warehouse_wise_item_balance_age_and_value/test_warehouse_wise_item_balance_age_and_value.py
@@ -1,0 +1,56 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and Contributors
+# See license.txt
+
+import frappe
+
+from erpnext.stock.doctype.item.test_item import make_item
+from erpnext.stock.doctype.stock_entry.stock_entry_utils import make_stock_entry
+from erpnext.stock.report.warehouse_wise_item_balance_age_and_value.warehouse_wise_item_balance_age_and_value import (
+	execute,
+)
+from erpnext.tests.utils import ERPNextTestSuite
+
+
+class TestWarehouseWiseItemBalanceAgeAndValue(ERPNextTestSuite):
+	def run_report(self, **extra):
+		filters = frappe._dict(
+			{
+				"company": "_Test Company",
+				"from_date": "2026-01-01",
+				"to_date": "2026-12-31",
+				"warehouse": "_Test Warehouse - _TC",
+			}
+		)
+		filters.update(extra)
+		return execute(filters)[1]
+
+	def test_balance_qty_and_value(self):
+		item_code = make_item(properties={"is_stock_item": 1}).name
+		warehouse = "_Test Warehouse - _TC"
+
+		make_stock_entry(
+			item_code=item_code,
+			to_warehouse=warehouse,
+			qty=10,
+			rate=100,
+			posting_date="2026-06-01",
+		)
+		make_stock_entry(
+			item_code=item_code,
+			from_warehouse=warehouse,
+			qty=4,
+			posting_date="2026-06-02",
+		)
+
+		data = self.run_report(item_code=item_code)
+
+		# With a single (leaf) warehouse filter the row shape is:
+		# [item, item_name, item_group, brand, value, age, bal_qty]
+		rows = [row for row in data if row[0] == item_code]
+		self.assertEqual(len(rows), 1)
+
+		row = rows[0]
+		# index 6 -> balance qty in the filtered warehouse
+		self.assertEqual(row[6], 6)
+		# index 4 -> total stock value (6 units @ 100)
+		self.assertEqual(row[4], 600)


### PR DESCRIPTION
Adds the first tests for the **Warehouse Wise Item Balance Age and Value** report, which previously had no test file. The tests drive real stock transactions and assert the report's actual output.

### What's covered
- `test_balance_qty_and_value`

### How to test
Open the report from the Stock module and confirm the figures match the underlying stock movements / prices.