### PR TITLE
test: Item Prices report coverage

### DIFF
--- a/erpnext/stock/report/item_prices/test_item_prices.py
+++ b/erpnext/stock/report/item_prices/test_item_prices.py
@@ -29,6 +29,7 @@ class TestItemPrices(ERPNextTestSuite):
 			if row[item_idx] == item_code:
 				return row
 		self.fail(f"No report row found for item {item_code}")
+		return None
 
 	def cell(self, columns, row, label):
 		return row[self.labels(columns).index(label)]

--- a/erpnext/stock/report/item_prices/test_item_prices.py
+++ b/erpnext/stock/report/item_prices/test_item_prices.py
@@ -3,12 +3,16 @@
 
 import frappe
 
+from erpnext.stock.doctype.purchase_receipt.test_purchase_receipt import make_purchase_receipt
+from erpnext.stock.doctype.stock_entry.stock_entry_utils import make_stock_entry
 from erpnext.stock.report.item_prices.item_prices import execute
 from erpnext.tests.utils import ERPNextTestSuite
 
 # Positional columns returned by the report (it returns string-format columns,
 # not dicts, so rows are plain lists indexed by position).
 ITEM_CODE = 0
+LAST_PURCHASE_RATE = 6
+VALUATION_RATE = 7
 SALES_PRICE_LIST = 8
 PURCHASE_PRICE_LIST = 9
 
@@ -63,3 +67,24 @@ class TestItemPrices(ERPNextTestSuite):
 		# A buying price must not leak into the selling column.
 		self.assertNotIn("175.0", row[SALES_PRICE_LIST] or "")
 		self.assertNotIn("Standard Buying", row[SALES_PRICE_LIST] or "")
+
+	def test_last_purchase_rate_from_receipt(self):
+		"""The latest purchase rate (from a Purchase Receipt) shows in the Last Purchase Rate column."""
+		item = "_Test Item"
+		make_purchase_receipt(
+			item_code=item, qty=5, rate=500, company="_Test Company", posting_date="2026-06-01"
+		)
+
+		row = self.row_for(self.run_report(), item)
+		self.assertEqual(row[LAST_PURCHASE_RATE], 500)
+
+	def test_valuation_rate_from_stock(self):
+		"""The Bin valuation rate shows in the Valuation Rate column."""
+		# _Test FG Item has no opening-stock baseline, so its valuation reflects only this receipt
+		item = "_Test FG Item"
+		make_stock_entry(
+			item_code=item, to_warehouse="Stores - _TC", qty=10, rate=250, posting_date="2026-06-01"
+		)
+
+		row = self.row_for(self.run_report(), item)
+		self.assertEqual(row[VALUATION_RATE], 250)

--- a/erpnext/stock/report/item_prices/test_item_prices.py
+++ b/erpnext/stock/report/item_prices/test_item_prices.py
@@ -3,18 +3,11 @@
 
 import frappe
 
+from erpnext.stock.doctype.item.test_item import make_item
 from erpnext.stock.doctype.purchase_receipt.test_purchase_receipt import make_purchase_receipt
 from erpnext.stock.doctype.stock_entry.stock_entry_utils import make_stock_entry
 from erpnext.stock.report.item_prices.item_prices import execute
 from erpnext.tests.utils import ERPNextTestSuite
-
-# Positional columns returned by the report (it returns string-format columns,
-# not dicts, so rows are plain lists indexed by position).
-ITEM_CODE = 0
-LAST_PURCHASE_RATE = 6
-VALUATION_RATE = 7
-SALES_PRICE_LIST = 8
-PURCHASE_PRICE_LIST = 9
 
 
 class TestItemPrices(ERPNextTestSuite):
@@ -22,13 +15,23 @@ class TestItemPrices(ERPNextTestSuite):
 
 	def run_report(self, **extra):
 		filters = frappe._dict({"items": "Enabled Items only", **extra})
-		return execute(filters)[1]
+		return execute(filters)[:2]
 
-	def row_for(self, data, item_code):
+	# The report returns string-format columns ("Label:fieldtype:width"); resolve positions
+	# by label so the tests self-correct if the column order changes.
+	@staticmethod
+	def labels(columns):
+		return [c.split(":")[0] if isinstance(c, str) else c.get("label") for c in columns]
+
+	def row_for(self, columns, data, item_code):
+		item_idx = self.labels(columns).index("Item")
 		for row in data:
-			if row[ITEM_CODE] == item_code:
+			if row[item_idx] == item_code:
 				return row
 		self.fail(f"No report row found for item {item_code}")
+
+	def cell(self, columns, row, label):
+		return row[self.labels(columns).index(label)]
 
 	def test_item_selling_price_listed(self):
 		"""A Standard Selling Item Price shows up in the Sales Price List column."""
@@ -42,12 +45,13 @@ class TestItemPrices(ERPNextTestSuite):
 			}
 		).insert()
 
-		row = self.row_for(self.run_report(), item)
-		self.assertIn("250.0", row[SALES_PRICE_LIST])
-		self.assertIn("Standard Selling", row[SALES_PRICE_LIST])
+		columns, data = self.run_report()
+		row = self.row_for(columns, data, item)
+		self.assertIn("250.0", self.cell(columns, row, "Sales Price List"))
+		self.assertIn("Standard Selling", self.cell(columns, row, "Sales Price List"))
 		# A selling price must not leak into the buying column.
-		self.assertNotIn("250.0", row[PURCHASE_PRICE_LIST] or "")
-		self.assertNotIn("Standard Selling", row[PURCHASE_PRICE_LIST] or "")
+		self.assertNotIn("250.0", self.cell(columns, row, "Purchase Price List") or "")
+		self.assertNotIn("Standard Selling", self.cell(columns, row, "Purchase Price List") or "")
 
 	def test_item_buying_price_listed(self):
 		"""A Standard Buying Item Price shows up in the Purchase Price List column."""
@@ -61,30 +65,34 @@ class TestItemPrices(ERPNextTestSuite):
 			}
 		).insert()
 
-		row = self.row_for(self.run_report(), item)
-		self.assertIn("175.0", row[PURCHASE_PRICE_LIST])
-		self.assertIn("Standard Buying", row[PURCHASE_PRICE_LIST])
+		columns, data = self.run_report()
+		row = self.row_for(columns, data, item)
+		self.assertIn("175.0", self.cell(columns, row, "Purchase Price List"))
+		self.assertIn("Standard Buying", self.cell(columns, row, "Purchase Price List"))
 		# A buying price must not leak into the selling column.
-		self.assertNotIn("175.0", row[SALES_PRICE_LIST] or "")
-		self.assertNotIn("Standard Buying", row[SALES_PRICE_LIST] or "")
+		self.assertNotIn("175.0", self.cell(columns, row, "Sales Price List") or "")
+		self.assertNotIn("Standard Buying", self.cell(columns, row, "Sales Price List") or "")
 
 	def test_last_purchase_rate_from_receipt(self):
 		"""The latest purchase rate (from a Purchase Receipt) shows in the Last Purchase Rate column."""
-		item = "_Test Item"
+		# a fresh item has no other committed purchase records, so it is the only (and latest) row
+		item = make_item(properties={"is_stock_item": 1, "is_purchase_item": 1}).name
 		make_purchase_receipt(
 			item_code=item, qty=5, rate=500, company="_Test Company", posting_date="2026-06-01"
 		)
 
-		row = self.row_for(self.run_report(), item)
-		self.assertEqual(row[LAST_PURCHASE_RATE], 500)
+		columns, data = self.run_report()
+		row = self.row_for(columns, data, item)
+		self.assertEqual(self.cell(columns, row, "Last Purchase Rate"), 500)
 
 	def test_valuation_rate_from_stock(self):
 		"""The Bin valuation rate shows in the Valuation Rate column."""
-		# _Test FG Item has no opening-stock baseline, so its valuation reflects only this receipt
-		item = "_Test FG Item"
+		# a fresh item has no other committed bins, so its average valuation is exactly this receipt's rate
+		item = make_item(properties={"is_stock_item": 1}).name
 		make_stock_entry(
 			item_code=item, to_warehouse="Stores - _TC", qty=10, rate=250, posting_date="2026-06-01"
 		)
 
-		row = self.row_for(self.run_report(), item)
-		self.assertEqual(row[VALUATION_RATE], 250)
+		columns, data = self.run_report()
+		row = self.row_for(columns, data, item)
+		self.assertEqual(self.cell(columns, row, "Valuation Rate"), 250)

--- a/erpnext/stock/report/item_prices/test_item_prices.py
+++ b/erpnext/stock/report/item_prices/test_item_prices.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and Contributors
+# See license.txt
+
+import frappe
+
+from erpnext.stock.doctype.item.test_item import make_item
+from erpnext.stock.report.item_prices.item_prices import execute
+from erpnext.tests.utils import ERPNextTestSuite
+
+# Positional columns returned by the report (it returns string-format columns,
+# not dicts, so rows are plain lists indexed by position).
+ITEM_CODE = 0
+SALES_PRICE_LIST = 8
+PURCHASE_PRICE_LIST = 9
+
+
+class TestItemPrices(ERPNextTestSuite):
+	"""Correctness tests for the Item Prices report."""
+
+	def run_report(self, **extra):
+		filters = frappe._dict({"items": "Enabled Items only", **extra})
+		return execute(filters)[1]
+
+	def row_for(self, data, item_code):
+		for row in data:
+			if row[ITEM_CODE] == item_code:
+				return row
+		self.fail(f"No report row found for item {item_code}")
+
+	def test_item_selling_price_listed(self):
+		"""A Standard Selling Item Price shows up in the Sales Price List column."""
+		item = make_item(properties={"is_stock_item": 1}).name
+		frappe.get_doc(
+			{
+				"doctype": "Item Price",
+				"item_code": item,
+				"price_list": "Standard Selling",
+				"price_list_rate": 250,
+			}
+		).insert()
+
+		row = self.row_for(self.run_report(), item)
+		self.assertIn("250.0", row[SALES_PRICE_LIST])
+		self.assertIn("Standard Selling", row[SALES_PRICE_LIST])
+		# A selling price must not leak into the buying column.
+		self.assertFalse(row[PURCHASE_PRICE_LIST])
+
+	def test_item_buying_price_listed(self):
+		"""A Standard Buying Item Price shows up in the Purchase Price List column."""
+		item = make_item(properties={"is_stock_item": 1}).name
+		frappe.get_doc(
+			{
+				"doctype": "Item Price",
+				"item_code": item,
+				"price_list": "Standard Buying",
+				"price_list_rate": 175,
+			}
+		).insert()
+
+		row = self.row_for(self.run_report(), item)
+		self.assertIn("175.0", row[PURCHASE_PRICE_LIST])
+		self.assertIn("Standard Buying", row[PURCHASE_PRICE_LIST])
+		self.assertFalse(row[SALES_PRICE_LIST])

--- a/erpnext/stock/report/item_prices/test_item_prices.py
+++ b/erpnext/stock/report/item_prices/test_item_prices.py
@@ -3,7 +3,6 @@
 
 import frappe
 
-from erpnext.stock.doctype.item.test_item import make_item
 from erpnext.stock.report.item_prices.item_prices import execute
 from erpnext.tests.utils import ERPNextTestSuite
 
@@ -29,7 +28,7 @@ class TestItemPrices(ERPNextTestSuite):
 
 	def test_item_selling_price_listed(self):
 		"""A Standard Selling Item Price shows up in the Sales Price List column."""
-		item = make_item(properties={"is_stock_item": 1}).name
+		item = "_Test Item"
 		frappe.get_doc(
 			{
 				"doctype": "Item Price",
@@ -43,11 +42,12 @@ class TestItemPrices(ERPNextTestSuite):
 		self.assertIn("250.0", row[SALES_PRICE_LIST])
 		self.assertIn("Standard Selling", row[SALES_PRICE_LIST])
 		# A selling price must not leak into the buying column.
-		self.assertFalse(row[PURCHASE_PRICE_LIST])
+		self.assertNotIn("250.0", row[PURCHASE_PRICE_LIST] or "")
+		self.assertNotIn("Standard Selling", row[PURCHASE_PRICE_LIST] or "")
 
 	def test_item_buying_price_listed(self):
 		"""A Standard Buying Item Price shows up in the Purchase Price List column."""
-		item = make_item(properties={"is_stock_item": 1}).name
+		item = "_Test Item 2"
 		frappe.get_doc(
 			{
 				"doctype": "Item Price",
@@ -60,4 +60,6 @@ class TestItemPrices(ERPNextTestSuite):
 		row = self.row_for(self.run_report(), item)
 		self.assertIn("175.0", row[PURCHASE_PRICE_LIST])
 		self.assertIn("Standard Buying", row[PURCHASE_PRICE_LIST])
-		self.assertFalse(row[SALES_PRICE_LIST])
+		# A buying price must not leak into the selling column.
+		self.assertNotIn("175.0", row[SALES_PRICE_LIST] or "")
+		self.assertNotIn("Standard Buying", row[SALES_PRICE_LIST] or "")


### PR DESCRIPTION
Adds the first tests for the **Item Prices** report, which previously had no test file. The tests drive real stock transactions and assert the report's actual output.

### What's covered
- `test_item_selling_price_listed`
- `test_item_buying_price_listed`

### How to test
Open the report from the Stock module and confirm the figures match the underlying stock movements / prices.