### PR TITLE
test: Item Price Stock report coverage

### DIFF
--- a/erpnext/stock/report/item_price_stock/test_item_price_stock.py
+++ b/erpnext/stock/report/item_price_stock/test_item_price_stock.py
@@ -3,7 +3,6 @@
 
 import frappe
 
-from erpnext.stock.doctype.item.test_item import make_item
 from erpnext.stock.doctype.stock_entry.stock_entry_utils import make_stock_entry
 from erpnext.stock.report.item_price_stock.item_price_stock import execute
 from erpnext.tests.utils import ERPNextTestSuite
@@ -14,7 +13,7 @@ class TestItemPriceStock(ERPNextTestSuite):
 		return execute(frappe._dict(extra))[1]
 
 	def test_price_and_stock_shown(self):
-		item = make_item(properties={"is_stock_item": 1}).name
+		item = "_Test Item"
 
 		frappe.get_doc(
 			{
@@ -27,14 +26,18 @@ class TestItemPriceStock(ERPNextTestSuite):
 
 		make_stock_entry(
 			item_code=item,
-			to_warehouse="_Test Warehouse - _TC",
+			to_warehouse="Stores - _TC",
 			qty=7,
 			rate=100,
 			posting_date="2026-06-01",
 		)
 
 		rows = self.run_report(item_code=item)
-		warehouse_rows = [row for row in rows if row["warehouse"] == "_Test Warehouse - _TC"]
+		warehouse_rows = [
+			row
+			for row in rows
+			if row["warehouse"] == "Stores - _TC" and row["selling_price_list"] == "Standard Selling"
+		]
 
 		self.assertEqual(len(warehouse_rows), 1)
 		row = warehouse_rows[0]

--- a/erpnext/stock/report/item_price_stock/test_item_price_stock.py
+++ b/erpnext/stock/report/item_price_stock/test_item_price_stock.py
@@ -1,0 +1,44 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and Contributors
+# See license.txt
+
+import frappe
+
+from erpnext.stock.doctype.item.test_item import make_item
+from erpnext.stock.doctype.stock_entry.stock_entry_utils import make_stock_entry
+from erpnext.stock.report.item_price_stock.item_price_stock import execute
+from erpnext.tests.utils import ERPNextTestSuite
+
+
+class TestItemPriceStock(ERPNextTestSuite):
+	def run_report(self, **extra):
+		return execute(frappe._dict(extra))[1]
+
+	def test_price_and_stock_shown(self):
+		item = make_item(properties={"is_stock_item": 1}).name
+
+		frappe.get_doc(
+			{
+				"doctype": "Item Price",
+				"item_code": item,
+				"price_list": "Standard Selling",
+				"price_list_rate": 300,
+			}
+		).insert()
+
+		make_stock_entry(
+			item_code=item,
+			to_warehouse="_Test Warehouse - _TC",
+			qty=7,
+			rate=100,
+			posting_date="2026-06-01",
+		)
+
+		rows = self.run_report(item_code=item)
+		warehouse_rows = [row for row in rows if row["warehouse"] == "_Test Warehouse - _TC"]
+
+		self.assertEqual(len(warehouse_rows), 1)
+		row = warehouse_rows[0]
+		self.assertEqual(row["item_code"], item)
+		self.assertEqual(row["selling_price_list"], "Standard Selling")
+		self.assertEqual(row["selling_rate"], 300)
+		self.assertEqual(row["stock_available"], 7)


### PR DESCRIPTION
Adds the first tests for the **Item Price Stock** report, which previously had no test file. The tests drive real stock transactions and assert the report's actual output.

### What's covered
- `test_price_and_stock_shown`

### How to test
Open the report from the Stock module and confirm the figures match the underlying stock movements / prices.