### PR TITLE
refactor: convert convertible raw frappe.db.sql to ORM

### DIFF
--- a/erpnext/accounts/doctype/loyalty_point_entry/test_loyalty_point_entry.py
+++ b/erpnext/accounts/doctype/loyalty_point_entry/test_loyalty_point_entry.py
@@ -2,6 +2,7 @@
 # See license.txt
 
 import frappe
+from frappe.query_builder.functions import Sum
 from frappe.utils import today
 
 from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_sales_invoice
@@ -63,13 +64,9 @@ class TestLoyaltyPointEntry(ERPNextTestSuite):
 		self.assertEqual(doc.loyalty_points, -7)
 
 		# Check balance
-		balance = frappe.db.sql(
-			"""
-			SELECT SUM(loyalty_points)
-			FROM `tabLoyalty Point Entry`
-			WHERE customer = %s
-		""",
-			(self.customer_name,),
-		)[0][0]
+		lpe = frappe.qb.DocType("Loyalty Point Entry")
+		balance = (
+			frappe.qb.from_(lpe).select(Sum(lpe.loyalty_points)).where(lpe.customer == self.customer_name)
+		).run()[0][0]
 
 		self.assertEqual(balance, 3)  # 10 added, 7 redeemed

--- a/erpnext/accounts/doctype/loyalty_program/test_loyalty_program.py
+++ b/erpnext/accounts/doctype/loyalty_program/test_loyalty_program.py
@@ -3,6 +3,7 @@
 import unittest
 
 import frappe
+from frappe.query_builder.functions import Sum
 from frappe.utils import cint, flt, getdate, today
 
 from erpnext.accounts.doctype.loyalty_program.loyalty_program import (
@@ -262,14 +263,12 @@ class TestLoyaltyProgram(ERPNextTestSuite):
 
 def get_points_earned(self):
 	def get_returned_amount():
-		returned_amount = frappe.db.sql(
-			"""
-			select sum(grand_total)
-			from `tabSales Invoice`
-			where docstatus=1 and is_return=1 and ifnull(return_against, '')=%s
-		""",
-			self.name,
-		)
+		si = frappe.qb.DocType("Sales Invoice")
+		returned_amount = (
+			frappe.qb.from_(si)
+			.select(Sum(si.grand_total))
+			.where((si.docstatus == 1) & (si.is_return == 1) & (si.return_against == self.name))
+		).run()
 		return abs(flt(returned_amount[0][0])) if returned_amount else 0
 
 	lp_details = get_loyalty_program_details_with_points(

--- a/erpnext/accounts/doctype/pos_invoice/test_pos_invoice_merge.py
+++ b/erpnext/accounts/doctype/pos_invoice/test_pos_invoice_merge.py
@@ -10,9 +10,9 @@ from erpnext.stock.doctype.purchase_receipt.test_purchase_receipt import make_pu
 
 class TestPOSInvoiceMerging(POSInvoiceTestMixin):
 	def clear_pos_data(self):
-		frappe.db.sql("delete from `tabPOS Opening Entry`;")
-		frappe.db.sql("delete from `tabPOS Closing Entry`;")
-		frappe.db.sql("delete from `tabPOS Invoice`;")
+		frappe.db.delete("POS Opening Entry")
+		frappe.db.delete("POS Closing Entry")
+		frappe.db.delete("POS Invoice")
 
 	def setUp(self):
 		self.clear_pos_data()

--- a/erpnext/accounts/doctype/pos_profile/test_pos_profile.py
+++ b/erpnext/accounts/doctype/pos_profile/test_pos_profile.py
@@ -79,7 +79,6 @@ class TestPOSProfile(ERPNextTestSuite):
 def get_customers_list(pos_profile=None):
 	if pos_profile is None:
 		pos_profile = {}
-	cond = "1=1"
 	customer_groups = []
 	if pos_profile.get("customer_groups"):
 		# Get customers based on the customer groups defined in the POS profile
@@ -87,14 +86,16 @@ def get_customers_list(pos_profile=None):
 			customer_groups.extend(
 				[d.get("name") for d in get_child_nodes("Customer Group", d.get("customer_group"))]
 			)
-		cond = "customer_group in ({})".format(", ".join(["%s"] * len(customer_groups)))
+
+	filters = {"disabled": 0}
+	if customer_groups:
+		filters["customer_group"] = ["in", customer_groups]
 
 	return (
-		frappe.db.sql(
-			f""" select name, customer_name, customer_group, territory from tabCustomer where disabled = 0
-		and {cond}""",
-			tuple(customer_groups),
-			as_dict=1,
+		frappe.get_all(
+			"Customer",
+			filters=filters,
+			fields=["name", "customer_name", "customer_group", "territory"],
 		)
 		or {}
 	)

--- a/erpnext/accounts/doctype/pos_profile/test_pos_profile.py
+++ b/erpnext/accounts/doctype/pos_profile/test_pos_profile.py
@@ -25,15 +25,11 @@ class TestPOSProfile(ERPNextTestSuite):
 			items = get_items_list(doc, doc.company)
 			customers = get_customers_list(doc)
 
-			products_count = frappe.db.sql(
-				""" select count(name) from tabItem where item_group = '_Test Item Group'""", as_list=1
-			)
-			customers_count = frappe.db.sql(
-				""" select count(name) from tabCustomer where customer_group = '_Test Customer Group'"""
-			)
+			products_count = frappe.db.count("Item", {"item_group": "_Test Item Group"})
+			customers_count = frappe.db.count("Customer", {"customer_group": "_Test Customer Group"})
 
-			self.assertEqual(len(items), products_count[0][0])
-			self.assertEqual(len(customers), customers_count[0][0])
+			self.assertEqual(len(items), products_count)
+			self.assertEqual(len(customers), customers_count)
 
 	def test_disabled_pos_profile_creation(self):
 		make_pos_profile(name="_Test POS Profile 001", disabled=1)
@@ -135,8 +131,8 @@ def get_items_list(pos_profile, company):
 
 
 def make_pos_profile(**args):
-	frappe.db.sql("delete from `tabPOS Payment Method`")
-	frappe.db.sql("delete from `tabPOS Profile`")
+	frappe.db.delete("POS Payment Method")
+	frappe.db.delete("POS Profile")
 
 	args = frappe._dict(args)
 

--- a/erpnext/accounts/doctype/pricing_rule/test_pricing_rule.py
+++ b/erpnext/accounts/doctype/pricing_rule/test_pricing_rule.py
@@ -91,7 +91,9 @@ class TestPricingRule(ERPNextTestSuite):
 		details = get_item_details(args)
 		self.assertEqual(details.get("discount_percentage"), 5)
 
-		frappe.db.sql("update `tabPricing Rule` set priority=NULL where campaign='_Test Campaign'")
+		frappe.db.set_value(
+			"Pricing Rule", {"campaign": "_Test Campaign"}, "priority", None, update_modified=False
+		)
 		from erpnext.accounts.doctype.pricing_rule.utils import MultiplePricingRuleConflict
 
 		self.assertRaises(MultiplePricingRuleConflict, get_item_details, args)

--- a/erpnext/accounts/report/trial_balance/trial_balance.py
+++ b/erpnext/accounts/report/trial_balance/trial_balance.py
@@ -597,11 +597,21 @@ def execute_synced_report(filters):
 
 def get_data_duckdb(filters, conn):
 	# accounts and all metadata via frappe.db — only GL Entry comes from DuckDB
-	accounts = frappe.db.sql(
-		"""select name, account_number, parent_account, account_name, root_type, report_type, is_group, lft, rgt
-		from `tabAccount` where company=%s order by lft""",
-		filters.company,
-		as_dict=True,
+	accounts = frappe.get_all(
+		"Account",
+		filters={"company": filters.company},
+		fields=[
+			"name",
+			"account_number",
+			"parent_account",
+			"account_name",
+			"root_type",
+			"report_type",
+			"is_group",
+			"lft",
+			"rgt",
+		],
+		order_by="lft",
 	)
 	if not accounts:
 		return None

--- a/erpnext/assets/doctype/asset_repair/test_asset_repair.py
+++ b/erpnext/assets/doctype/asset_repair/test_asset_repair.py
@@ -238,22 +238,13 @@ class TestAssetRepair(ERPNextTestSuite):
 			submit=1,
 		)
 
-		gl_entries = frappe.db.sql(
-			"""
-			select
-				account,
-				sum(debit) as debit,
-				sum(credit) as credit
-			from `tabGL Entry`
-			where
-				voucher_type='Asset Repair'
-				and voucher_no=%s
-			group by
-				account
-		""",
-			asset_repair.name,
-			as_dict=1,
-		)
+		gle = frappe.qb.DocType("GL Entry")
+		gl_entries = (
+			frappe.qb.from_(gle)
+			.select(gle.account, Sum(gle.debit).as_("debit"), Sum(gle.credit).as_("credit"))
+			.where((gle.voucher_type == "Asset Repair") & (gle.voucher_no == asset_repair.name))
+			.groupby(gle.account)
+		).run(as_dict=True)
 
 		self.assertTrue(gl_entries)
 
@@ -287,22 +278,13 @@ class TestAssetRepair(ERPNextTestSuite):
 			submit=1,
 		)
 
-		gl_entries = frappe.db.sql(
-			"""
-			select
-				account,
-				sum(debit) as debit,
-				sum(credit) as credit
-			from `tabGL Entry`
-			where
-				voucher_type='Asset Repair'
-				and voucher_no=%s
-			group by
-				account
-		""",
-			asset_repair.name,
-			as_dict=1,
-		)
+		gle = frappe.qb.DocType("GL Entry")
+		gl_entries = (
+			frappe.qb.from_(gle)
+			.select(gle.account, Sum(gle.debit).as_("debit"), Sum(gle.credit).as_("credit"))
+			.where((gle.voucher_type == "Asset Repair") & (gle.voucher_no == asset_repair.name))
+			.groupby(gle.account)
+		).run(as_dict=True)
 
 		self.assertTrue(gl_entries)
 

--- a/erpnext/assets/doctype/asset_value_adjustment/test_asset_value_adjustment.py
+++ b/erpnext/assets/doctype/asset_value_adjustment/test_asset_value_adjustment.py
@@ -94,11 +94,12 @@ class TestAssetValueAdjustment(ERPNextTestSuite):
 			("_Test Fixed Asset - _TC", 0.0, 4625.29),
 		)
 
-		gle = frappe.db.sql(
-			"""select account, debit, credit from `tabGL Entry`
-			where voucher_type='Journal Entry' and voucher_no = %s
-			order by account""",
-			adj_doc.journal_entry,
+		gle = frappe.get_all(
+			"GL Entry",
+			filters={"voucher_type": "Journal Entry", "voucher_no": adj_doc.journal_entry},
+			fields=["account", "debit", "credit"],
+			order_by="account",
+			as_list=True,
 		)
 
 		self.assertSequenceEqual(gle, expected_gle)
@@ -184,11 +185,12 @@ class TestAssetValueAdjustment(ERPNextTestSuite):
 			("_Test Fixed Asset - _TC", 0.0, 5175.29),
 		)
 
-		gle = frappe.db.sql(
-			"""select account, debit, credit from `tabGL Entry`
-			where voucher_type='Journal Entry' and voucher_no = %s
-			order by account""",
-			adj_doc.journal_entry,
+		gle = frappe.get_all(
+			"GL Entry",
+			filters={"voucher_type": "Journal Entry", "voucher_no": adj_doc.journal_entry},
+			fields=["account", "debit", "credit"],
+			order_by="account",
+			as_list=True,
 		)
 
 		self.assertSequenceEqual(gle, expected_gle)

--- a/erpnext/manufacturing/doctype/bom/test_bom.py
+++ b/erpnext/manufacturing/doctype/bom/test_bom.py
@@ -881,12 +881,8 @@ def reset_item_valuation_rate(item_code, warehouse_list=None, qty=None, rate=Non
 		warehouse_list = [warehouse_list]
 
 	if not warehouse_list:
-		warehouse_list = frappe.db.sql_list(
-			"""
-			select warehouse from `tabBin`
-			where item_code=%s and actual_qty > 0
-		""",
-			item_code,
+		warehouse_list = frappe.get_all(
+			"Bin", filters={"item_code": item_code, "actual_qty": [">", 0]}, pluck="warehouse"
 		)
 
 		if not warehouse_list:

--- a/erpnext/manufacturing/doctype/bom/test_bom.py
+++ b/erpnext/manufacturing/doctype/bom/test_bom.py
@@ -97,10 +97,10 @@ class TestBOM(ERPNextTestSuite):
 		update_cost_in_all_boms_in_test()
 
 		# check if new valuation rate updated in all BOMs
-		for d in frappe.db.sql(
-			"""select base_rate from `tabBOM Item`
-			where item_code='_Test Item 2' and docstatus=1 and parenttype='BOM'""",
-			as_dict=1,
+		for d in frappe.get_all(
+			"BOM Item",
+			filters={"item_code": "_Test Item 2", "docstatus": 1, "parenttype": "BOM"},
+			fields=["base_rate"],
 		):
 			self.assertEqual(d.base_rate, rm_base_rate + 10)
 

--- a/erpnext/manufacturing/doctype/work_order/test_work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/test_work_order.py
@@ -5249,11 +5249,8 @@ def update_job_card(job_card, jc_qty=None, days=None):
 
 def get_secondary_item_details(bom_no):
 	secondary_items = {}
-	for item in frappe.db.sql(
-		"""select item_code, stock_qty from `tabBOM Secondary Item`
-		where parent = %s""",
-		bom_no,
-		as_dict=1,
+	for item in frappe.get_all(
+		"BOM Secondary Item", filters={"parent": bom_no}, fields=["item_code", "stock_qty"]
 	):
 		secondary_items[item.item_code] = item.stock_qty
 

--- a/erpnext/projects/doctype/project/test_project.py
+++ b/erpnext/projects/doctype/project/test_project.py
@@ -49,7 +49,7 @@ class TestProject(ERPNextTestSuite):
 
 	def test_project_with_template_having_no_parent_and_depend_tasks(self):
 		project_name = "Test Project with Template - No Parent and Dependend Tasks"
-		frappe.db.sql(""" delete from tabTask where project = %s """, project_name)
+		frappe.db.delete("Task", {"project": project_name})
 		frappe.delete_doc("Project", project_name)
 
 		task1 = task_exists("Test Template Task with No Parent and Dependency")
@@ -82,7 +82,7 @@ class TestProject(ERPNextTestSuite):
 		if frappe.db.get_value("Project", {"project_name": project_name}, "name"):
 			project_name = frappe.db.get_value("Project", {"project_name": project_name}, "name")
 
-		frappe.db.sql(""" delete from tabTask where project = %s """, project_name)
+		frappe.db.delete("Task", {"project": project_name})
 		frappe.delete_doc("Project", project_name)
 
 		task1 = task_exists("Test Template Task Parent")
@@ -137,7 +137,7 @@ class TestProject(ERPNextTestSuite):
 
 	def test_project_template_having_dependent_tasks(self):
 		project_name = "Test Project with Template - Dependent Tasks"
-		frappe.db.sql(""" delete from tabTask where project = %s  """, project_name)
+		frappe.db.delete("Task", {"project": project_name})
 		frappe.delete_doc("Project", project_name)
 
 		task1 = task_exists("Test Template Task for Dependency")
@@ -252,7 +252,7 @@ class TestProject(ERPNextTestSuite):
 
 	def test_project_having_no_tasks_complete(self):
 		project_name = "Test Project - No Tasks Completion"
-		frappe.db.sql(""" delete from tabTask where project = %s """, project_name)
+		frappe.db.delete("Task", {"project": project_name})
 		frappe.delete_doc("Project", project_name)
 
 		project = frappe.get_doc(

--- a/erpnext/selling/doctype/sales_order/test_sales_order.py
+++ b/erpnext/selling/doctype/sales_order/test_sales_order.py
@@ -1742,9 +1742,7 @@ class TestSalesOrder(ERPNextTestSuite):
 		mr_dict["include_exploded_items"] = 0
 		mr_dict["ignore_existing_ordered_qty"] = 1
 		make_raw_material_request(mr_dict, so.company, so.name)
-		mr = frappe.db.sql(
-			"""select name from `tabMaterial Request` ORDER BY creation DESC LIMIT 1""", as_dict=1
-		)[0]
+		mr = frappe.get_all("Material Request", fields=["name"], order_by="creation desc", limit=1)[0]
 		mr_doc = frappe.get_doc("Material Request", mr.get("name"))
 		self.assertEqual(mr_doc.items[0].sales_order, so.name)
 

--- a/erpnext/selling/doctype/sales_order/test_sales_order.py
+++ b/erpnext/selling/doctype/sales_order/test_sales_order.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 import frappe
 import frappe.permissions
 from frappe.core.doctype.user_permission.test_user_permission import create_user
+from frappe.query_builder.functions import Sum
 from frappe.tests import change_settings
 from frappe.utils import add_days, flt, getdate, nowdate, today
 
@@ -907,10 +908,12 @@ class TestSalesOrder(ERPNextTestSuite):
 			item_doc.save()
 		else:
 			# update valid from
-			frappe.db.sql(
-				"""UPDATE `tabItem Tax` set valid_from = CURRENT_DATE
-				where parent = %(item)s and item_tax_template = %(tax)s""",
-				{"item": item, "tax": tax_template},
+			frappe.db.set_value(
+				"Item Tax",
+				{"parent": item, "item_tax_template": tax_template},
+				"valid_from",
+				today(),
+				update_modified=False,
 			)
 
 		so = make_sales_order(item_code=item, qty=1, do_not_save=1)
@@ -960,10 +963,12 @@ class TestSalesOrder(ERPNextTestSuite):
 		self.assertEqual(so.taxes[1].total, 480)
 
 		# teardown
-		frappe.db.sql(
-			"""UPDATE `tabItem Tax` set valid_from = NULL
-			where parent = %(item)s and item_tax_template = %(tax)s""",
-			{"item": item, "tax": tax_template},
+		frappe.db.set_value(
+			"Item Tax",
+			{"parent": item, "item_tax_template": tax_template},
+			"valid_from",
+			None,
+			update_modified=False,
 		)
 		so.cancel()
 		so.delete()
@@ -1559,10 +1564,12 @@ class TestSalesOrder(ERPNextTestSuite):
 
 		# Check if Work Orders were raised
 		for item in so_item_name:
-			wo_qty = frappe.db.sql(
-				"select sum(qty) from `tabWork Order` where sales_order=%s and sales_order_item=%s",
-				(so.name, item),
-			)
+			wo = frappe.qb.DocType("Work Order")
+			wo_qty = (
+				frappe.qb.from_(wo)
+				.select(Sum(wo.qty))
+				.where((wo.sales_order == so.name) & (wo.sales_order_item == item))
+			).run()
 			self.assertEqual(wo_qty[0][0], so_item_name.get(item))
 
 	def test_advance_payment_entry_unlink_against_sales_order(self):

--- a/erpnext/setup/doctype/item_group/test_item_group.py
+++ b/erpnext/setup/doctype/item_group/test_item_group.py
@@ -2,6 +2,7 @@
 # License: GNU General Public License v3. See license.txt
 
 import frappe
+from frappe.query_builder.functions import Max
 from frappe.utils.nestedset import (
 	NestedSetChildExistsError,
 	NestedSetInvalidMergeError,
@@ -20,7 +21,8 @@ class TestItemGroup(ERPNextTestSuite):
 
 	def test_basic_tree(self, records=None):
 		min_lft = 1
-		max_rgt = frappe.db.sql("select max(rgt) from `tabItem Group`")[0][0]
+		ig = frappe.qb.DocType("Item Group")
+		max_rgt = frappe.qb.from_(ig).select(Max(ig.rgt)).run()[0][0]
 
 		if not records:
 			records = self.globalTestRecords["Item Group"][2:]
@@ -131,12 +133,7 @@ class TestItemGroup(ERPNextTestSuite):
 		frappe.db.get_value("Item Group", parent_item_group, "rgt")
 
 		ancestors = get_ancestors_of("Item Group", "_Test Item Group B - 3")
-		ancestors = frappe.db.sql(
-			"""select name, rgt from `tabItem Group`
-			where name in ({})""".format(", ".join(["%s"] * len(ancestors))),
-			tuple(ancestors),
-			as_dict=True,
-		)
+		ancestors = frappe.get_all("Item Group", filters={"name": ["in", ancestors]}, fields=["name", "rgt"])
 
 		frappe.delete_doc("Item Group", "_Test Item Group B - 3")
 		records_to_test = self.globalTestRecords["Item Group"][2:]
@@ -168,9 +165,8 @@ class TestItemGroup(ERPNextTestSuite):
 		self.test_basic_tree()
 
 		# move its children back
-		for name in frappe.db.sql_list(
-			"""select name from `tabItem Group`
-			where parent_item_group='_Test Item Group C'"""
+		for name in frappe.get_all(
+			"Item Group", filters={"parent_item_group": "_Test Item Group C"}, pluck="name"
 		):
 			doc = frappe.get_doc("Item Group", name)
 			doc.parent_item_group = "_Test Item Group B"
@@ -218,11 +214,7 @@ class TestItemGroup(ERPNextTestSuite):
 		def get_no_of_children(item_groups, no_of_children):
 			children = []
 			for ig in item_groups:
-				children += frappe.db.sql_list(
-					"""select name from `tabItem Group`
-				where ifnull(parent_item_group, '')=%s""",
-					ig or "",
-				)
+				children += frappe.get_all("Item Group", filters={"parent_item_group": ig}, pluck="name")
 
 			if len(children):
 				return get_no_of_children(children, no_of_children + len(children))

--- a/erpnext/stock/doctype/material_request/test_material_request.py
+++ b/erpnext/stock/doctype/material_request/test_material_request.py
@@ -746,11 +746,11 @@ class TestMaterialRequest(ERPNextTestSuite):
 		mr = frappe.get_doc("Material Request", mr.name)
 		mr.submit()
 		completed_qty = mr.items[0].ordered_qty
-		requested_qty = frappe.db.sql(
-			"""select indented_qty from `tabBin` where \
-			item_code= %s and warehouse= %s """,
-			(mr.items[0].item_code, mr.items[0].warehouse),
-		)[0][0]
+		requested_qty = frappe.db.get_value(
+			"Bin",
+			{"item_code": mr.items[0].item_code, "warehouse": mr.items[0].warehouse},
+			"indented_qty",
+		)
 
 		prod_order = raise_work_orders(mr.name, mr.company)
 		po = frappe.get_doc("Work Order", prod_order[0])
@@ -760,11 +760,11 @@ class TestMaterialRequest(ERPNextTestSuite):
 		mr = frappe.get_doc("Material Request", mr.name)
 		self.assertEqual(completed_qty + po.qty, mr.items[0].ordered_qty)
 
-		new_requested_qty = frappe.db.sql(
-			"""select indented_qty from `tabBin` where \
-			item_code= %s and warehouse= %s """,
-			(mr.items[0].item_code, mr.items[0].warehouse),
-		)[0][0]
+		new_requested_qty = frappe.db.get_value(
+			"Bin",
+			{"item_code": mr.items[0].item_code, "warehouse": mr.items[0].warehouse},
+			"indented_qty",
+		)
 
 		self.assertEqual(requested_qty - po.qty, new_requested_qty)
 
@@ -773,11 +773,11 @@ class TestMaterialRequest(ERPNextTestSuite):
 		mr = frappe.get_doc("Material Request", mr.name)
 		self.assertEqual(completed_qty, mr.items[0].ordered_qty)
 
-		new_requested_qty = frappe.db.sql(
-			"""select indented_qty from `tabBin` where \
-			item_code= %s and warehouse= %s """,
-			(mr.items[0].item_code, mr.items[0].warehouse),
-		)[0][0]
+		new_requested_qty = frappe.db.get_value(
+			"Bin",
+			{"item_code": mr.items[0].item_code, "warehouse": mr.items[0].warehouse},
+			"indented_qty",
+		)
 		self.assertEqual(requested_qty, new_requested_qty)
 
 	def test_requested_qty_multi_uom(self):

--- a/erpnext/stock/doctype/stock_entry/test_stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/test_stock_entry.py
@@ -40,19 +40,12 @@ from erpnext.tests.utils import ERPNextTestSuite
 
 
 def get_sle(**args):
-	condition, values = "", []
-	for key, value in args.items():
-		condition += " and " if condition else " where "
-		condition += f"`{key}`=%s"
-		values.append(value)
-
-	return frappe.db.sql(
-		# posting_datetime is the precomputed date+time column; MySQL-only timestamp(date,time) errors on Postgres
-		"""select * from `tabStock Ledger Entry` %s
-		order by posting_datetime desc, creation desc limit 1"""
-		% condition,
-		values,
-		as_dict=1,
+	return frappe.get_all(
+		"Stock Ledger Entry",
+		filters=args,
+		fields=["*"],
+		order_by="posting_datetime desc, creation desc",
+		limit=1,
 	)
 
 
@@ -581,15 +574,15 @@ class TestStockEntry(ERPNextTestSuite):
 		expected_sle.sort(key=lambda x: x[1])
 
 		# check stock ledger entries
-		sle = frappe.db.sql(
-			"""select item_code, warehouse, actual_qty
-			from `tabStock Ledger Entry` where voucher_type = %s
-			and voucher_no = %s order by item_code, warehouse, actual_qty""",
-			(voucher_type, voucher_no),
-			as_list=1,
+		sle = frappe.get_all(
+			"Stock Ledger Entry",
+			filters={"voucher_type": voucher_type, "voucher_no": voucher_no},
+			fields=["item_code", "warehouse", "actual_qty"],
+			order_by="item_code, warehouse, actual_qty",
+			as_list=True,
 		)
 		self.assertTrue(sle)
-		sle.sort(key=lambda x: x[1])
+		sle = sorted(sle, key=lambda x: x[1])
 
 		for i, sle_value in enumerate(sle):
 			self.assertEqual(expected_sle[i][0], sle_value[0])
@@ -599,16 +592,16 @@ class TestStockEntry(ERPNextTestSuite):
 	def check_gl_entries(self, voucher_type, voucher_no, expected_gl_entries):
 		expected_gl_entries.sort(key=lambda x: x[0])
 
-		gl_entries = frappe.db.sql(
-			"""select account, debit, credit
-			from `tabGL Entry` where voucher_type=%s and voucher_no=%s
-			order by account asc, debit asc""",
-			(voucher_type, voucher_no),
-			as_list=1,
+		gl_entries = frappe.get_all(
+			"GL Entry",
+			filters={"voucher_type": voucher_type, "voucher_no": voucher_no},
+			fields=["account", "debit", "credit"],
+			order_by="account asc, debit asc",
+			as_list=True,
 		)
 
 		self.assertTrue(gl_entries)
-		gl_entries.sort(key=lambda x: x[0])
+		gl_entries = sorted(gl_entries, key=lambda x: x[0])
 		for i, gle in enumerate(gl_entries):
 			self.assertEqual(expected_gl_entries[i][0], gle[0])
 			self.assertEqual(expected_gl_entries[i][1], gle[1])

--- a/erpnext/stock/doctype/stock_entry/test_stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/test_stock_entry.py
@@ -269,20 +269,10 @@ class TestStockEntry(ERPNextTestSuite):
 		mr.cancel()
 
 		self.assertTrue(
-			frappe.db.sql(
-				"""select * from `tabStock Ledger Entry`
-			where voucher_type='Stock Entry' and voucher_no=%s""",
-				mr.name,
-			)
+			frappe.db.exists("Stock Ledger Entry", {"voucher_type": "Stock Entry", "voucher_no": mr.name})
 		)
 
-		self.assertTrue(
-			frappe.db.sql(
-				"""select * from `tabGL Entry`
-			where voucher_type='Stock Entry' and voucher_no=%s""",
-				mr.name,
-			)
-		)
+		self.assertTrue(frappe.db.exists("GL Entry", {"voucher_type": "Stock Entry", "voucher_no": mr.name}))
 
 	def test_material_issue_gl_entry(self):
 		company = frappe.db.get_value("Warehouse", "Stores - TCP1", "company")
@@ -361,12 +351,7 @@ class TestStockEntry(ERPNextTestSuite):
 		if source_warehouse_account == target_warehouse_account:
 			# no gl entry as both source and target warehouse has linked to same account.
 			self.assertFalse(
-				frappe.db.sql(
-					"""select * from `tabGL Entry`
-				where voucher_type='Stock Entry' and voucher_no=%s""",
-					mtn.name,
-					as_dict=1,
-				)
+				frappe.db.exists("GL Entry", {"voucher_type": "Stock Entry", "voucher_no": mtn.name})
 			)
 
 		else:
@@ -460,14 +445,9 @@ class TestStockEntry(ERPNextTestSuite):
 			],
 		)
 
-		gl_entries = frappe.db.sql(
-			"""select account, debit, credit
-			from `tabGL Entry` where voucher_type='Stock Entry' and voucher_no=%s
-			order by account desc""",
-			repack.name,
-			as_dict=1,
+		self.assertFalse(
+			frappe.db.exists("GL Entry", {"voucher_type": "Stock Entry", "voucher_no": repack.name})
 		)
-		self.assertFalse(gl_entries)
 
 	def test_repack_with_additional_costs(self):
 		company = frappe.db.get_value("Warehouse", "Stores - TCP1", "company")

--- a/erpnext/stock/doctype/stock_reconciliation/test_stock_reconciliation.py
+++ b/erpnext/stock/doctype/stock_reconciliation/test_stock_reconciliation.py
@@ -85,11 +85,10 @@ class TestStockReconciliation(ERPNextTestSuite, StockTestMixin):
 			)
 
 			# check stock value
-			sle = frappe.db.sql(
-				"""select * from `tabStock Ledger Entry`
-				where voucher_type='Stock Reconciliation' and voucher_no=%s""",
-				stock_reco.name,
-				as_dict=1,
+			sle = frappe.get_all(
+				"Stock Ledger Entry",
+				filters={"voucher_type": "Stock Reconciliation", "voucher_no": stock_reco.name},
+				fields=["qty_after_transaction", "stock_value"],
 			)
 
 			qty_after_transaction = flt(d[0]) if d[0] != "" else flt(last_sle.get("qty_after_transaction"))

--- a/erpnext/stock/doctype/warehouse/test_warehouse.py
+++ b/erpnext/stock/doctype/warehouse/test_warehouse.py
@@ -19,11 +19,10 @@ class TestWarehouse(ERPNextTestSuite):
 	def test_warehouse_hierarchy(self):
 		p_warehouse = frappe.get_doc("Warehouse", "_Test Warehouse Group - _TC")
 
-		child_warehouses = frappe.db.sql(
-			"""select name, is_group, parent_warehouse from `tabWarehouse` wh
-			where wh.lft > %s and wh.rgt < %s""",
-			(p_warehouse.lft, p_warehouse.rgt),
-			as_dict=1,
+		child_warehouses = frappe.get_all(
+			"Warehouse",
+			filters={"lft": [">", p_warehouse.lft], "rgt": ["<", p_warehouse.rgt]},
+			fields=["name", "is_group", "parent_warehouse"],
 		)
 
 		for child_warehouse in child_warehouses:

--- a/erpnext/support/doctype/issue/test_issue.py
+++ b/erpnext/support/doctype/issue/test_issue.py
@@ -14,11 +14,11 @@ from erpnext.tests.utils import ERPNextTestSuite
 
 class TestSetUp(ERPNextTestSuite):
 	def setUp(self):
-		frappe.db.sql("delete from `tabService Level Agreement`")
-		frappe.db.sql("delete from `tabService Level Priority`")
-		frappe.db.sql("delete from `tabSLA Fulfilled On Status`")
-		frappe.db.sql("delete from `tabPause SLA On Status`")
-		frappe.db.sql("delete from `tabService Day`")
+		frappe.db.delete("Service Level Agreement")
+		frappe.db.delete("Service Level Priority")
+		frappe.db.delete("SLA Fulfilled On Status")
+		frappe.db.delete("Pause SLA On Status")
+		frappe.db.delete("Service Day")
 		frappe.db.set_single_value("Support Settings", "track_service_level_agreement", 1)
 		create_service_level_agreements_for_issues()
 


### PR DESCRIPTION
## What

Converts the `frappe.db.sql`/`sql_list` call sites (non-`patches`) that have a **behaviour-identical ORM equivalent**, leaving only the ones that genuinely need raw SQL.

**Production (1 convertible):** `trial_balance.py` DuckDB-path Account fetch (static `SELECT … order by lft`) → `frappe.get_all`. Verified on Postgres: identical 98 rows/order/payload.

**Tests:** deletes→`frappe.db.delete`; `count`→`frappe.db.count`; `select *` used only for truthiness→`frappe.db.exists`; scalar→`frappe.db.get_value`; simple/IN/range filters→`frappe.get_all`; `sql_list`→`get_all(pluck=…)`; scalar `SUM`/`MAX` and `SUM … GROUP BY`→`frappe.qb` + `Sum`/`Max`; bulk `UPDATE … = NULL/value`→`frappe.db.set_value`; positional `as_list` reads→`get_all(as_list=True)`.

No behaviour change (all were already Postgres-valid; this is consistency cleanup).

## Left as raw — deliberately

These genuinely need raw SQL and are **not** converted:
- **Production (24):** dynamic table/field identifiers and caller-built `WHERE`/`ORDER BY` fragments (authorization_control, status_updater, pricing_rule/utils, trends, general_ledger, payment_entry, accounts/utils); CTE + window + hot `UPDATE` (stock_ledger).
- **Tests (3):** one complex multi-table `LEFT JOIN` (pos_profile `get_items_list`) and DB-catalog introspection (`pg_index` / `SHOW INDEX` in tests/test_perf).

## Verification

- pre-commit **PostgreSQL compatibility (static check)** passes
- every affected test module runs green on MariaDB: stock_entry, sales_order, work_order, asset_repair, stock_reconciliation, asset_value_adjustment, item_group, loyalty_point_entry, loyalty_program, pricing_rule, pos_profile, bom, material_request, warehouse, issue, project, pos_invoice_merge
- trial_balance conversion diffed against the raw query on Postgres (identical result set)

## Notes for reviewers

- Aggregates go through `frappe.qb` because `get_value(dt, filters, 'sum(x)')` / `get_all(fields=['sum(x)'])` are rejected by frappe (*"SQL functions are not allowed as strings in SELECT"*).
- `get_all(as_list=True)` returns a **tuple** (not a list), so consumers that mutate the result use `sorted()`.