### PR TITLE
fix: do not allow closing the accounting period for future dates

### DIFF
--- a/erpnext/accounts/doctype/accounting_period/accounting_period.py
+++ b/erpnext/accounts/doctype/accounting_period/accounting_period.py
@@ -5,6 +5,7 @@
 import frappe
 from frappe import _
 from frappe.model.document import Document
+from frappe.utils import getdate, nowdate
 
 
 class OverlapError(frappe.ValidationError):
@@ -36,7 +37,19 @@ class AccountingPeriod(Document):
 	# end: auto-generated types
 
 	def validate(self):
+		self.validate_dates()
 		self.validate_overlap()
+
+	def validate_dates(self):
+		if getdate(self.start_date) > getdate(self.end_date):
+			frappe.throw(_("Start Date cannot be after End Date"))
+
+		if getdate(self.end_date) > getdate(nowdate()):
+			frappe.throw(
+				_(
+					"Accounting Period cannot be created for a future date. End Date {0} is after today."
+				).format(frappe.bold(frappe.format(self.end_date, "Date")))
+			)
 
 	def before_insert(self):
 		self.bootstrap_doctypes_for_closing()

--- a/erpnext/accounts/doctype/accounting_period/test_accounting_period.py
+++ b/erpnext/accounts/doctype/accounting_period/test_accounting_period.py
@@ -2,7 +2,7 @@
 # See license.txt
 
 import frappe
-from frappe.utils import add_months, nowdate
+from frappe.utils import nowdate
 
 from erpnext.accounts.doctype.accounting_period.accounting_period import (
 	ClosedAccountingPeriod,
@@ -93,7 +93,7 @@ def create_accounting_period(**args):
 
 	accounting_period = frappe.new_doc("Accounting Period")
 	accounting_period.start_date = args.start_date or nowdate()
-	accounting_period.end_date = args.end_date or add_months(nowdate(), 1)
+	accounting_period.end_date = args.end_date or nowdate()
 	accounting_period.company = args.company or "_Test Company"
 	accounting_period.period_name = args.period_name or "_Test_Period_Name_1"
 	accounting_period.append("closed_documents", {"document_type": "Sales Invoice", "closed": 1})


### PR DESCRIPTION
Future date block — if end_date > today, it throws "Accounting Period cannot be created for a future date. 