### PR TITLE
fix: set conversion_rate on quotation created from customer

### DIFF
--- a/erpnext/selling/doctype/customer/mapper.py
+++ b/erpnext/selling/doctype/customer/mapper.py
@@ -6,8 +6,6 @@ from frappe import _
 from frappe.model.document import Document
 from frappe.model.mapper import get_mapped_doc
 
-from erpnext.setup.utils import get_exchange_rate
-
 
 @frappe.whitelist()
 def make_quotation(source_name: str, target_doc: str | Document | None = None):
@@ -31,11 +29,7 @@ def make_quotation(source_name: str, target_doc: str | Document | None = None):
 		target_doc.selling_price_list = price_list
 	if currency:
 		target_doc.currency = currency
-		company_currency = frappe.get_cached_value("Company", target_doc.company, "default_currency")
-		if target_doc.company and target_doc.currency != company_currency:
-			target_doc.conversion_rate = get_exchange_rate(
-				target_doc.currency, company_currency, target_doc.transaction_date, "for_selling"
-			)
+
 	target_doc.run_method("set_missing_values")
 	target_doc.run_method("set_other_charges")
 	target_doc.run_method("calculate_taxes_and_totals")

--- a/erpnext/selling/doctype/customer/mapper.py
+++ b/erpnext/selling/doctype/customer/mapper.py
@@ -6,6 +6,8 @@ from frappe import _
 from frappe.model.document import Document
 from frappe.model.mapper import get_mapped_doc
 
+from erpnext.setup.utils import get_exchange_rate
+
 
 @frappe.whitelist()
 def make_quotation(source_name: str, target_doc: str | Document | None = None):
@@ -32,6 +34,11 @@ def make_quotation(source_name: str, target_doc: str | Document | None = None):
 		target_doc.selling_price_list = price_list
 	if currency:
 		target_doc.currency = currency
+		company_currency = frappe.get_cached_value("Company", target_doc.company, "default_currency")
+		if target_doc.company and target_doc.currency != company_currency:
+			target_doc.conversion_rate = get_exchange_rate(
+				target_doc.currency, company_currency, target_doc.transaction_date, "for_selling"
+			)
 
 	return target_doc
 

--- a/erpnext/selling/doctype/customer/mapper.py
+++ b/erpnext/selling/doctype/customer/mapper.py
@@ -23,9 +23,6 @@ def make_quotation(source_name: str, target_doc: str | Document | None = None):
 	)
 
 	target_doc.quotation_to = "Customer"
-	target_doc.run_method("set_missing_values")
-	target_doc.run_method("set_other_charges")
-	target_doc.run_method("calculate_taxes_and_totals")
 
 	price_list, currency = frappe.db.get_value(
 		"Customer", {"name": source_name}, ["default_price_list", "default_currency"]
@@ -39,7 +36,9 @@ def make_quotation(source_name: str, target_doc: str | Document | None = None):
 			target_doc.conversion_rate = get_exchange_rate(
 				target_doc.currency, company_currency, target_doc.transaction_date, "for_selling"
 			)
-			target_doc.run_method("calculate_taxes_and_totals")
+	target_doc.run_method("set_missing_values")
+	target_doc.run_method("set_other_charges")
+	target_doc.run_method("calculate_taxes_and_totals")
 
 	return target_doc
 

--- a/erpnext/selling/doctype/customer/mapper.py
+++ b/erpnext/selling/doctype/customer/mapper.py
@@ -39,6 +39,7 @@ def make_quotation(source_name: str, target_doc: str | Document | None = None):
 			target_doc.conversion_rate = get_exchange_rate(
 				target_doc.currency, company_currency, target_doc.transaction_date, "for_selling"
 			)
+			target_doc.run_method("calculate_taxes_and_totals")
 
 	return target_doc
 

--- a/erpnext/selling/doctype/customer/test_customer.py
+++ b/erpnext/selling/doctype/customer/test_customer.py
@@ -5,7 +5,7 @@
 import json
 
 import frappe
-from frappe.utils import flt
+from frappe.utils import flt, nowdate
 
 from erpnext.accounts.party import get_due_date
 from erpnext.exceptions import PartyDisabled, PartyFrozen
@@ -14,12 +14,53 @@ from erpnext.selling.doctype.customer.customer import (
 	get_customer_outstanding,
 )
 from erpnext.selling.doctype.customer.mapper import (
+	make_quotation,
 	parse_full_name,
 )
 from erpnext.tests.utils import ERPNextTestSuite
 
 
 class TestCustomer(ERPNextTestSuite):
+	def test_quotation_from_customer_uses_actual_exchange_rate(self):
+		company = "_Test Company"
+		company_currency = frappe.get_cached_value("Company", company, "default_currency")
+		foreign_currency = "USD" if company_currency != "USD" else "EUR"
+
+		frappe.defaults.set_user_default("company", company)
+		self.addCleanup(frappe.defaults.clear_user_default, "company")
+
+		# Seed a deterministic rate so the test does not depend on the live exchange-rate API.
+		rate = 83.0
+		exchange = frappe.get_doc(
+			{
+				"doctype": "Currency Exchange",
+				"date": nowdate(),
+				"from_currency": foreign_currency,
+				"to_currency": company_currency,
+				"exchange_rate": rate,
+				"for_selling": 1,
+				"for_buying": 1,
+			}
+		).insert(ignore_if_duplicate=True)
+		self.addCleanup(frappe.delete_doc, "Currency Exchange", exchange.name, force=1)
+
+		customer = frappe.get_doc(
+			{
+				"doctype": "Customer",
+				"customer_name": "_Test Customer FX Quotation",
+				"customer_type": "Company",
+				"default_currency": foreign_currency,
+			}
+		).insert()
+		self.addCleanup(frappe.delete_doc, "Customer", customer.name, force=1)
+
+		quotation = make_quotation(customer.name)
+
+		self.assertEqual(quotation.currency, foreign_currency)
+		self.assertNotEqual(flt(quotation.conversion_rate), 1.0)
+		self.assertNotEqual(flt(quotation.conversion_rate), 0.0)
+		self.assertEqual(flt(quotation.conversion_rate), rate)
+
 	def test_get_customer_name_dedupes_with_numeric_suffix(self):
 		# When a customer name already exists, get_customer_name appends "- <max suffix + 1>". The
 		# Postgres branch extracts the suffix with regexp_replace/NULLIF/CAST (pypika's Substring cannot


### PR DESCRIPTION
**Issue:**
If I have a customer with a “Billing Currency” diffrent that the company's currency, and create a “Quotation” via the Connections Tab. The Exchange Rate is always set to 1.

**Steps to Replicate the issue:**
1. Create a Customer with “Billing Currency” different from the company currency
2. Go to the “Connections” tab and click + next to “Quotation”

**Ref:**[#72199](https://support.frappe.io/helpdesk/tickets/72199)

**Before:**
[Screencast from 2026-06-26 13-40-07.webm](https://github.com/user-attachments/assets/fce6d205-1317-4e99-91d0-9afe96770bb2)

**After:**
[Screencast from 2026-06-26 13-39-30.webm](https://github.com/user-attachments/assets/ecbff70a-e084-4d25-afcf-f704ec4ec28b)
