### PR TITLE
test: reuse bootstrap master data in Accounts Receivable/Payable report tests

### DIFF
--- a/erpnext/accounts/report/accounts_payable/test_accounts_payable.py
+++ b/erpnext/accounts/report/accounts_payable/test_accounts_payable.py
@@ -135,38 +135,9 @@ class TestAccountsPayable(ERPNextTestSuite, AccountsTestMixin):
 	def test_payment_terms_template_filters(self):
 		from erpnext.controllers.accounts_controller import get_payment_terms
 
-		payment_term1 = frappe.get_doc(
-			{"doctype": "Payment Term", "payment_term_name": "_Test 50% on 15 Days"}
-		).insert()
-		payment_term2 = frappe.get_doc(
-			{"doctype": "Payment Term", "payment_term_name": "_Test 50% on 30 Days"}
-		).insert()
-
-		template = frappe.get_doc(
-			{
-				"doctype": "Payment Terms Template",
-				"template_name": "_Test 50-50",
-				"terms": [
-					{
-						"doctype": "Payment Terms Template Detail",
-						"due_date_based_on": "Day(s) after invoice date",
-						"payment_term": payment_term1.name,
-						"description": "_Test 50-50",
-						"invoice_portion": 50,
-						"credit_days": 15,
-					},
-					{
-						"doctype": "Payment Terms Template Detail",
-						"due_date_based_on": "Day(s) after invoice date",
-						"payment_term": payment_term2.name,
-						"description": "_Test 50-50",
-						"invoice_portion": 50,
-						"credit_days": 30,
-					},
-				],
-			}
-		)
-		template.insert()
+		template = frappe.get_doc("Payment Terms Template", "_Test Payment Term Template")
+		first_term = frappe.get_doc("Payment Term", template.terms[0].payment_term)
+		expected_payment_term = first_term.description or first_term.name
 
 		filters = {
 			"company": self.company,
@@ -193,12 +164,10 @@ class TestAccountsPayable(ERPNextTestSuite, AccountsTestMixin):
 		row = report[1][0]
 
 		self.assertEqual(len(report[1]), 2)
-		self.assertEqual([pi.name, payment_term1.payment_term_name], [row.voucher_no, row.payment_term])
+		self.assertEqual([pi.name, expected_payment_term], [row.voucher_no, row.payment_term])
 
 	def test_project_filter(self):
-		project = frappe.get_doc(
-			{"doctype": "Project", "project_name": "_Test AP Project", "company": self.company}
-		).insert()
+		project = frappe.get_doc("Project", {"project_name": "_Test Project"})
 
 		pi = self.create_purchase_invoice(do_not_submit=True)
 		pi.project = project.name
@@ -227,9 +196,7 @@ class TestAccountsPayable(ERPNextTestSuite, AccountsTestMixin):
 			"range": "30, 60, 90, 120",
 		}
 
-		project = frappe.get_doc(
-			{"doctype": "Project", "project_name": "_Test AP Project Output", "company": self.company}
-		).insert()
+		project = frappe.get_doc("Project", {"project_name": "_Test Project"})
 
 		pi = self.create_purchase_invoice(do_not_submit=True)
 		pi.project = project.name

--- a/erpnext/accounts/report/accounts_receivable/test_accounts_receivable.py
+++ b/erpnext/accounts/report/accounts_receivable/test_accounts_receivable.py
@@ -1422,10 +1422,10 @@ class TestAccountsReceivable(ERPNextTestSuite, AccountsTestMixin):
 		# Party is a dynamic link on Payment Ledger Entry, so user permissions on Customer
 		# must be applied explicitly. The report should only show permitted customers.
 		original_customer = self.customer
-		second_customer = "_Test AR Perm Customer"
+		second_customer = "_Test Customer 1"
 
 		# create_customer overrides self.customer, so build the restricted invoice first
-		self.create_customer(customer_name=second_customer)
+		self.customer = second_customer
 		self.create_sales_invoice(no_payment_schedule=True)
 
 		self.customer = original_customer


### PR DESCRIPTION
Refactors the Accounts Receivable/Payable report tests to reuse the master data already created by `BootStrapTestData` (items, warehouses, customers, suppliers, accounts) instead of creating fresh records per test, cutting test runtime. Test behavior and assertions are unchanged.

Applies to the whole file, including pre-existing tests; records that need a specific config (e.g. batch items, currency-specific parties, isolated accounts for exact-balance assertions) are left as-is.

### How to test
Run the report's test module; all tests pass with the same assertions.
