### PR TITLE
test: reuse bootstrap master data in Cash Flow report tests

### DIFF
--- a/erpnext/accounts/report/cash_flow/test_cash_flow.py
+++ b/erpnext/accounts/report/cash_flow/test_cash_flow.py
@@ -59,16 +59,9 @@ class TestCashFlow(ERPNextTestSuite):
 
 	def test_cash_purchase_of_asset_is_investing_outflow(self):
 		"""Buying a fixed asset for cash is an investing outflow that reduces net change in cash."""
-		from erpnext.accounts.doctype.account.test_account import create_account
 		from erpnext.accounts.doctype.journal_entry.test_journal_entry import make_journal_entry
 
-		create_account(
-			account_name="_Test Cash Flow Asset",
-			company=self.company,
-			parent_account="Fixed Assets - _TC",
-			account_type="Fixed Asset",
-		)
-		asset_account = "_Test Cash Flow Asset - _TC"
+		asset_account = "Office Equipment - _TC"
 
 		before = self.net_change_in_cash()
 		# debit the fixed asset, credit cash -> cash goes out


### PR DESCRIPTION
Refactors the Cash Flow report tests to reuse the master data already created by `BootStrapTestData` (items, warehouses, customers, suppliers, accounts) instead of creating fresh records per test, cutting test runtime. Test behavior and assertions are unchanged.

Applies to the whole file, including pre-existing tests; records that need a specific config (e.g. batch items, currency-specific parties, isolated accounts for exact-balance assertions) are left as-is.

### How to test
Run the report's test module; all tests pass with the same assertions.
