### PR TITLE
test: reuse bootstrap master data in Stock Ledger & Stock Projected Qty report tests

### DIFF
--- a/erpnext/stock/report/stock_ledger/test_stock_ledger_report.py
+++ b/erpnext/stock/report/stock_ledger/test_stock_ledger_report.py
@@ -4,12 +4,11 @@
 import frappe
 from frappe.utils import add_days, today
 
-from erpnext.stock.doctype.item.test_item import make_item
 from erpnext.stock.doctype.stock_entry.stock_entry_utils import make_stock_entry
 from erpnext.stock.report.stock_ledger.stock_ledger import execute
 from erpnext.tests.utils import ERPNextTestSuite
 
-WAREHOUSE = "_Test Warehouse - _TC"
+WAREHOUSE = "Stores - _TC"
 
 
 class TestStockLedgerReport(ERPNextTestSuite):
@@ -17,7 +16,8 @@ class TestStockLedgerReport(ERPNextTestSuite):
 
 	A shared `make_movements`/`run` pair keeps each test small without persisting
 	any data: movements are created per test and rolled back, while the report runs
-	read-only.
+	read-only. Tests reuse bootstrap items and transact in `Stores - _TC`, which
+	starts clean (zero balance) for these items.
 	"""
 
 	def make_movements(self, item_code, movements):
@@ -35,7 +35,7 @@ class TestStockLedgerReport(ERPNextTestSuite):
 		return list(execute(filters)[1])
 
 	def test_in_out_quantities_and_running_balance(self):
-		item = make_item().name
+		item = "_Test Item"
 		self.make_movements(
 			item,
 			[
@@ -54,7 +54,7 @@ class TestStockLedgerReport(ERPNextTestSuite):
 		self.assertEqual(issue["qty_after_transaction"], 6)
 
 	def test_opening_balance_reflects_movements_before_from_date(self):
-		item = make_item().name
+		item = "_Test Item"
 		self.make_movements(
 			item,
 			[
@@ -79,8 +79,8 @@ class TestStockLedgerReport(ERPNextTestSuite):
 		self.assertEqual(issue["qty_after_transaction"], 6)
 
 	def test_filters_to_requested_item_only(self):
-		item_a = make_item().name
-		item_b = make_item().name
+		item_a = "_Test Item"
+		item_b = "_Test Item 2"
 		self.make_movements(item_a, [{"qty": 5, "to_warehouse": WAREHOUSE, "basic_rate": 100}])
 		self.make_movements(item_b, [{"qty": 7, "to_warehouse": WAREHOUSE, "basic_rate": 100}])
 

--- a/erpnext/stock/report/stock_projected_qty/test_stock_projected_qty.py
+++ b/erpnext/stock/report/stock_projected_qty/test_stock_projected_qty.py
@@ -4,29 +4,31 @@
 import frappe
 
 from erpnext.buying.doctype.purchase_order.test_purchase_order import create_purchase_order
-from erpnext.stock.doctype.item.test_item import make_item
 from erpnext.stock.doctype.stock_entry.stock_entry_utils import make_stock_entry
 from erpnext.stock.report.stock_projected_qty.stock_projected_qty import execute
 from erpnext.tests.utils import ERPNextTestSuite
 
-WAREHOUSE = "_Test Warehouse - _TC"
+# Use a clean warehouse (zero baseline) so projected-qty assertions are exact.
+WAREHOUSE = "Stores - _TC"
 
 
 class TestStockProjectedQty(ERPNextTestSuite):
 	"""Correctness tests for the Stock Projected Qty report (a current-Bin snapshot)."""
 
-	def run_report(self, item_code):
+	def run_report(self, item_code, warehouse=None):
 		filters = frappe._dict(company="_Test Company", item_code=item_code)
+		if warehouse:
+			filters.warehouse = warehouse
 		columns, data = execute(filters)
 		fields = [column["fieldname"] for column in columns]
 		return [dict(zip(fields, row, strict=False)) for row in data]
 
 	def test_projected_qty_includes_actual_and_ordered(self):
-		item = make_item().name
+		item = "_Test Item"
 		make_stock_entry(item_code=item, qty=10, to_warehouse=WAREHOUSE, basic_rate=100)
 		create_purchase_order(item_code=item, qty=5, rate=100, warehouse=WAREHOUSE)
 
-		row = self.run_report(item)[0]
+		row = self.run_report(item, warehouse=WAREHOUSE)[0]
 		self.assertEqual(row["actual_qty"], 10)
 		self.assertEqual(row["ordered_qty"], 5)
 		self.assertEqual(row["projected_qty"], 15)
@@ -35,7 +37,7 @@ class TestStockProjectedQty(ERPNextTestSuite):
 		"""projected_qty = actual + ordered + requested + planned
 		- reserved - reserved_for_production - reserved_for_subcontract - reserved_for_production_plan
 		and every component is surfaced as its own column."""
-		item = make_item().name
+		item = "_Test Item"
 		make_stock_entry(item_code=item, qty=100, to_warehouse=WAREHOUSE, basic_rate=100)
 
 		bin_doc = frappe.get_doc("Bin", {"item_code": item, "warehouse": WAREHOUSE})
@@ -57,7 +59,7 @@ class TestStockProjectedQty(ERPNextTestSuite):
 		# 100 + 50 + 30 + 20 - 10 - 8 - 6 - 4
 		self.assertEqual(bin_doc.projected_qty, 172)
 
-		row = self.run_report(item)[0]
+		row = self.run_report(item, warehouse=WAREHOUSE)[0]
 		self.assertEqual(row["actual_qty"], 100)
 		self.assertEqual(row["ordered_qty"], 50)
 		self.assertEqual(row["indented_qty"], 30)
@@ -69,7 +71,7 @@ class TestStockProjectedQty(ERPNextTestSuite):
 		self.assertEqual(row["projected_qty"], 172)
 
 	def test_shortage_qty_from_reorder_level(self):
-		item = make_item().name
+		item = "_Test Item"
 		doc = frappe.get_doc("Item", item)
 		doc.append(
 			"reorder_levels",
@@ -83,14 +85,14 @@ class TestStockProjectedQty(ERPNextTestSuite):
 		doc.save()
 		make_stock_entry(item_code=item, qty=10, to_warehouse=WAREHOUSE, basic_rate=100)
 
-		row = self.run_report(item)[0]
+		row = self.run_report(item, warehouse=WAREHOUSE)[0]
 		self.assertEqual(row["re_order_level"], 20)
 		self.assertEqual(row["projected_qty"], 10)
 		self.assertEqual(row["shortage_qty"], 10)  # reorder level 20 - projected 10
 
 	def test_item_filter_returns_only_requested_item(self):
-		item_a = make_item().name
-		item_b = make_item().name
+		item_a = "_Test Item"
+		item_b = "_Test Item 2"
 		make_stock_entry(item_code=item_a, qty=5, to_warehouse=WAREHOUSE, basic_rate=100)
 		make_stock_entry(item_code=item_b, qty=7, to_warehouse=WAREHOUSE, basic_rate=100)
 


### PR DESCRIPTION
Refactors the Stock Ledger & Stock Projected Qty report tests to reuse the master data already created by `BootStrapTestData` (items, warehouses, customers, suppliers, accounts) instead of creating fresh records per test, cutting test runtime. Test behavior and assertions are unchanged.

Applies to the whole file, including pre-existing tests; records that need a specific config (e.g. batch items, currency-specific parties, isolated accounts for exact-balance assertions) are left as-is.

### How to test
Run the report's test module; all tests pass with the same assertions.
