### PR TITLE
fix: use company currency instead of global default in report

### DIFF
--- a/erpnext/accounts/report/cash_flow/cash_flow.py
+++ b/erpnext/accounts/report/cash_flow/cash_flow.py
@@ -81,6 +81,7 @@ def execute(filters=None):
 				"parent_section": None,
 				"indent": 0.0,
 				"section": cash_flow_section["section_header"],
+				"currency": company_currency,
 			}
 		)
 

--- a/erpnext/accounts/report/gross_profit/gross_profit.py
+++ b/erpnext/accounts/report/gross_profit/gross_profit.py
@@ -227,6 +227,7 @@ def get_data_when_grouped_by_invoice(columns, gross_profit_data, filters, group_
 				)
 				if total_base_amount
 				else 0,
+				"currency": filters.currency,
 			}
 		)
 	)
@@ -269,6 +270,7 @@ def get_data_when_not_grouped_by_invoice(gross_profit_data, filters, group_wise_
 		"buying_amount": total_buying_amount,
 		"gross_profit": total_gross_profit,
 		"gross_profit_percent": flt(gross_profit_percent, currency_precision),
+		"currency": filters.currency,
 	}
 
 	total_row = [total_row.get(col, None) for col in [*group_columns, "currency"]]

--- a/erpnext/buying/report/purchase_order_trends/purchase_order_trends.py
+++ b/erpnext/buying/report/purchase_order_trends/purchase_order_trends.py
@@ -4,6 +4,7 @@
 
 from frappe import _
 
+import erpnext
 from erpnext.controllers.trends import get_columns, get_data
 
 
@@ -50,6 +51,7 @@ def get_chart_data(data, conditions, filters):
 		for i in range(len(row)):
 			datapoints[i] += row[i]
 
+	company_currency = erpnext.get_company_currency(filters.get("company"))
 	return {
 		"data": {
 			"labels": labels,
@@ -60,4 +62,6 @@ def get_chart_data(data, conditions, filters):
 		"type": "line",
 		"lineOptions": {"regionFill": 1},
 		"fieldtype": "Currency",
+		"options": "currency",
+		"currency": company_currency,
 	}

--- a/erpnext/buying/report/purchase_order_trends/purchase_order_trends.py
+++ b/erpnext/buying/report/purchase_order_trends/purchase_order_trends.py
@@ -4,7 +4,6 @@
 
 from frappe import _
 
-import erpnext
 from erpnext.controllers.trends import get_columns, get_data
 
 
@@ -15,7 +14,6 @@ def execute(filters=None):
 	conditions = get_columns(filters, "Purchase Order")
 	data = get_data(filters, conditions)
 	chart_data = get_chart_data(data, conditions, filters)
-
 	return conditions["columns"], data, None, chart_data
 
 
@@ -40,9 +38,15 @@ def get_chart_data(data, conditions, filters):
 	labels = [column.split(":")[0].replace(" (Amt)", "") for column in columns]
 	datapoints = [0] * len(labels)
 
+	group_by_col_idx = None
+	if filters.get("group_by"):
+		group_by_col_idx = conditions["columns"].index(conditions["grbc"][0])
+
 	for row in data:
-		# If group by filter, don't add first row of group (it's already summed)
-		if not row[start]:
+		# Skip the final grand-total row
+		if row[0] == f"'{_('Total')}'":
+			continue
+		if group_by_col_idx is not None and row[group_by_col_idx] == "":
 			continue
 		# Remove None values and compute only periodic data
 		row = [x if x else 0 for x in row[start:-2]]
@@ -51,7 +55,6 @@ def get_chart_data(data, conditions, filters):
 		for i in range(len(row)):
 			datapoints[i] += row[i]
 
-	company_currency = erpnext.get_company_currency(filters.get("company"))
 	return {
 		"data": {
 			"labels": labels,
@@ -63,5 +66,5 @@ def get_chart_data(data, conditions, filters):
 		"lineOptions": {"regionFill": 1},
 		"fieldtype": "Currency",
 		"options": "currency",
-		"currency": company_currency,
+		"currency": conditions.get("company_currency"),
 	}

--- a/erpnext/buying/report/purchase_order_trends/test_purchase_order_trends.py
+++ b/erpnext/buying/report/purchase_order_trends/test_purchase_order_trends.py
@@ -2,7 +2,10 @@
 # License: GNU General Public License v3. See license.txt
 
 import frappe
+from frappe import _
+from frappe.utils import today
 
+from erpnext.accounts.utils import get_fiscal_year
 from erpnext.tests.utils import ERPNextTestSuite
 
 
@@ -30,3 +33,166 @@ class TestPurchaseOrderTrends(ERPNextTestSuite):
 		self.assertTrue(columns)
 		supplier_rows = [row for row in data if row[0] == "_Test Supplier"]
 		self.assertEqual(len(supplier_rows), 1)
+
+	def test_total_row_not_double_counted_in_chart(self):
+		# Regression test for the fix in trends.calculate_total_row that populates the
+		# Total row's Currency column. Before the fix in get_chart_data (skipping the
+		# Total row by label instead of `if not row[start]`), that populated Currency
+		# cell made the Total-row-skip guard falsy, so the already-summed Total row got
+		# added into the chart a second time (a PO of qty=3, rate=100 -> 300 read as 600).
+		from erpnext.buying.doctype.purchase_order.test_purchase_order import create_purchase_order
+		from erpnext.buying.report.purchase_order_trends.purchase_order_trends import execute
+
+		create_purchase_order(supplier="_Test Supplier", qty=3, rate=100, transaction_date=today())
+
+		fiscal_year = get_fiscal_year(today())[0]
+
+		filters = frappe._dict(
+			{
+				"company": "_Test Company",
+				"fiscal_year": fiscal_year,
+				"period": "Monthly",
+				"based_on": "Item",
+			}
+		)
+
+		columns, data, _message, chart = execute(filters)
+
+		self.assertTrue(columns)
+		self.assertTrue(data)
+
+		# The Total row (present in `data`) must not be re-summed into the chart's datapoints.
+		total_row = next(row for row in data if row[0] == f"'{_('Total')}'")
+		expected_total = total_row[-1]  # Total(Amt) is the last column
+
+		chart_total = sum(chart["data"]["datasets"][0]["values"])
+
+		self.assertEqual(chart_total, expected_total)
+		self.assertEqual(chart_total, 300)
+
+	def test_chart_currency_matches_company_currency(self):
+		# Regression test: the chart's "currency" key should reflect the transacting
+		# company's currency (conditions["company_currency"]), not a stale global default.
+		from erpnext.buying.doctype.purchase_order.test_purchase_order import create_purchase_order
+		from erpnext.buying.report.purchase_order_trends.purchase_order_trends import execute
+
+		create_purchase_order(supplier="_Test Supplier", qty=1, rate=100, transaction_date=today())
+
+		fiscal_year = get_fiscal_year(today())[0]
+
+		filters = frappe._dict(
+			{
+				"company": "_Test Company",
+				"fiscal_year": fiscal_year,
+				"period": "Monthly",
+				"based_on": "Item",
+			}
+		)
+
+		_columns, _data, _message, chart = execute(filters)
+
+		expected_currency = frappe.get_cached_value("Company", "_Test Company", "default_currency")
+		self.assertEqual(chart["currency"], expected_currency)
+
+	def test_group_by_chart_matches_table_total_with_mixed_group_sizes(self):
+		# _Test Item is split across two suppliers -> two detail rows under one header row.
+		# _Test Item 2 has only one supplier -> exactly one detail row under its header row.
+		# A regression that double-counts header rows would inflate the chart above 600;
+		# a regression that zeroes single-group rows would report less than 600.
+		from erpnext.buying.doctype.purchase_order.test_purchase_order import create_purchase_order
+		from erpnext.buying.report.purchase_order_trends.purchase_order_trends import execute
+
+		create_purchase_order(
+			item_code="_Test Item", supplier="_Test Supplier", qty=3, rate=100, transaction_date=today()
+		)
+		create_purchase_order(
+			item_code="_Test Item", supplier="_Test Supplier 1", qty=2, rate=100, transaction_date=today()
+		)
+		create_purchase_order(
+			item_code="_Test Item 2", supplier="_Test Supplier", qty=1, rate=100, transaction_date=today()
+		)
+
+		fiscal_year = get_fiscal_year(today())[0]
+		filters = frappe._dict(
+			{
+				"company": "_Test Company",
+				"fiscal_year": fiscal_year,
+				"period": "Monthly",
+				"based_on": "Item",
+				"group_by": "Supplier",
+			}
+		)
+
+		columns, data, _message, chart = execute(filters)
+		self.assertTrue(columns)
+		self.assertTrue(data)
+
+		total_row = next(row for row in data if row[0] == f"'{_('Total')}'")
+		expected_total = total_row[-1]
+		chart_total = sum(chart["data"]["datasets"][0]["values"])
+
+		# 300 (item/supplier) + 200 (item/supplier1) + 100 (item2/supplier) = 600
+		self.assertEqual(expected_total, 600)
+		self.assertEqual(chart_total, expected_total)
+
+	def test_group_by_swapped_roles_based_on_supplier_group_by_item(self):
+		# Same regression, opposite role assignment: based_on="Supplier" with group_by="Item".
+		# Supplier's based_on_cols (Supplier, Supplier Name, Supplier Group, Currency) put the
+		# group_by placeholder at a different column index than the Item-based_on case above,
+		# exercising the alternate `inc`/`ind` arithmetic.
+		from erpnext.buying.doctype.purchase_order.test_purchase_order import create_purchase_order
+		from erpnext.buying.report.purchase_order_trends.purchase_order_trends import execute
+
+		create_purchase_order(
+			item_code="_Test Item", supplier="_Test Supplier", qty=3, rate=100, transaction_date=today()
+		)
+		create_purchase_order(
+			item_code="_Test Item 2", supplier="_Test Supplier", qty=1, rate=100, transaction_date=today()
+		)
+
+		fiscal_year = get_fiscal_year(today())[0]
+		filters = frappe._dict(
+			{
+				"company": "_Test Company",
+				"fiscal_year": fiscal_year,
+				"period": "Monthly",
+				"based_on": "Supplier",
+				"group_by": "Item",
+			}
+		)
+
+		columns, data, _message, chart = execute(filters)
+		total_row = next(row for row in data if row[0] == f"'{_('Total')}'")
+		expected_total = total_row[-1]
+		chart_total = sum(chart["data"]["datasets"][0]["values"])
+
+		# 300 + 100 = 400
+		self.assertEqual(expected_total, 400)
+		self.assertEqual(chart_total, expected_total)
+
+	def test_group_by_single_group_value_not_zeroed(self):
+		# Isolates the specific failure mode flagged in review: a based_on value with exactly
+		# one associated group value must still contribute its real amount to the chart, not 0.
+		from erpnext.buying.doctype.purchase_order.test_purchase_order import create_purchase_order
+		from erpnext.buying.report.purchase_order_trends.purchase_order_trends import execute
+
+		create_purchase_order(
+			item_code="_Test Item", supplier="_Test Supplier", qty=2, rate=150, transaction_date=today()
+		)
+
+		fiscal_year = get_fiscal_year(today())[0]
+		filters = frappe._dict(
+			{
+				"company": "_Test Company",
+				"fiscal_year": fiscal_year,
+				"period": "Monthly",
+				"based_on": "Item",
+				"group_by": "Supplier",
+			}
+		)
+
+		columns, data, _message, chart = execute(filters)
+		chart_total = sum(chart["data"]["datasets"][0]["values"])
+
+		self.assertGreater(chart_total, 0)
+		self.assertEqual(chart_total, 300)

--- a/erpnext/controllers/trends.py
+++ b/erpnext/controllers/trends.py
@@ -43,6 +43,9 @@ def get_columns(filters, trans):
 		"addl_tables": based_on_details["addl_tables"],
 		"addl_tables_relational_cond": based_on_details.get("addl_tables_relational_cond", ""),
 	}
+	conditions["company_currency"] = (
+		erpnext.get_company_currency(filters.get("company")) if filters.get("company") else None
+	)
 
 	return conditions
 
@@ -215,7 +218,7 @@ def get_data(filters, conditions):
 
 				data.append(des)
 
-		total_row = calculate_total_row(data1, conditions["columns"], filters.get("company"))
+		total_row = calculate_total_row(data1, conditions["columns"], conditions.get("company_currency"))
 		data.append(total_row)
 	else:
 		data = frappe.db.sql(
@@ -240,13 +243,13 @@ def get_data(filters, conditions):
 			as_list=1,
 		)
 
-		total_row = calculate_total_row(data, conditions["columns"], filters.get("company"))
+		total_row = calculate_total_row(data, conditions["columns"], conditions.get("company_currency"))
 		data.append(total_row)
 
 	return data
 
 
-def calculate_total_row(data, columns, company=None):
+def calculate_total_row(data, columns, company_currency=None):
 	def wrap_in_quotes(label):
 		return f"'{label}'"
 
@@ -255,7 +258,7 @@ def calculate_total_row(data, columns, company=None):
 	for i, col in enumerate(columns):
 		if "Float" in col or "Currency/currency" in col:
 			total_values[i] = 0
-		if col.split(":")[0] == "Currency":
+		if "Link/Currency" in col:
 			currency_col_idx = i
 
 	for row in data:
@@ -267,7 +270,7 @@ def calculate_total_row(data, columns, company=None):
 		total_row.append(total_values.get(i, None))
 
 	if currency_col_idx is not None:
-		total_row[currency_col_idx] = company and erpnext.get_company_currency(company)
+		total_row[currency_col_idx] = company_currency
 
 	return total_row
 

--- a/erpnext/controllers/trends.py
+++ b/erpnext/controllers/trends.py
@@ -6,6 +6,7 @@ import frappe
 from frappe import _
 from frappe.utils import DateTimeLikeObject, getdate, today
 
+import erpnext
 from erpnext.accounts.utils import get_fiscal_year
 
 
@@ -214,7 +215,7 @@ def get_data(filters, conditions):
 
 				data.append(des)
 
-		total_row = calculate_total_row(data1, conditions["columns"])
+		total_row = calculate_total_row(data1, conditions["columns"], filters.get("company"))
 		data.append(total_row)
 	else:
 		data = frappe.db.sql(
@@ -239,20 +240,23 @@ def get_data(filters, conditions):
 			as_list=1,
 		)
 
-		total_row = calculate_total_row(data, conditions["columns"])
+		total_row = calculate_total_row(data, conditions["columns"], filters.get("company"))
 		data.append(total_row)
 
 	return data
 
 
-def calculate_total_row(data, columns):
+def calculate_total_row(data, columns, company=None):
 	def wrap_in_quotes(label):
 		return f"'{label}'"
 
 	total_values = {}
+	currency_col_idx = None
 	for i, col in enumerate(columns):
 		if "Float" in col or "Currency/currency" in col:
 			total_values[i] = 0
+		if col.split(":")[0] == "Currency":
+			currency_col_idx = i
 
 	for row in data:
 		for i in total_values.keys():
@@ -261,6 +265,9 @@ def calculate_total_row(data, columns):
 	total_row = [wrap_in_quotes(_("Total"))]
 	for i in range(1, len(columns)):
 		total_row.append(total_values.get(i, None))
+
+	if currency_col_idx is not None:
+		total_row[currency_col_idx] = company and erpnext.get_company_currency(company)
 
 	return total_row
 

--- a/erpnext/selling/report/quotation_trends/quotation_trends.py
+++ b/erpnext/selling/report/quotation_trends/quotation_trends.py
@@ -1,9 +1,9 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: GNU General Public License v3. See license.txt
 
-
 from frappe import _
 
+import erpnext
 from erpnext.controllers.trends import get_columns, get_data
 
 
@@ -50,7 +50,7 @@ def get_chart_data(data, conditions, filters):
 
 		for i in range(len(row)):
 			datapoints[i] += row[i]
-
+	company_currency = erpnext.get_company_currency(filters.get("company"))
 	return {
 		"data": {
 			"labels": labels,
@@ -59,4 +59,6 @@ def get_chart_data(data, conditions, filters):
 		"type": "line",
 		"lineOptions": {"regionFill": 1},
 		"fieldtype": "Currency",
+		"options": "currency",
+		"currency": company_currency,
 	}

--- a/erpnext/selling/report/quotation_trends/quotation_trends.py
+++ b/erpnext/selling/report/quotation_trends/quotation_trends.py
@@ -3,7 +3,6 @@
 
 from frappe import _
 
-import erpnext
 from erpnext.controllers.trends import get_columns, get_data
 
 
@@ -40,9 +39,15 @@ def get_chart_data(data, conditions, filters):
 	labels = [column.split(":")[0] for column in columns]
 	datapoints = [0] * len(labels)
 
+	group_by_col_idx = None
+	if filters.get("group_by"):
+		group_by_col_idx = conditions["columns"].index(conditions["grbc"][0])
+
 	for row in data:
-		# If group by filter, don't add first row of group (it's already summed)
-		if not row[start]:
+		# Skip the final grand-total row
+		if row[0] == f"'{_('Total')}'":
+			continue
+		if group_by_col_idx is not None and row[group_by_col_idx] == "":
 			continue
 		# Remove None values and compute only periodic data
 		row = [x if x else 0 for x in row[start:-2]]
@@ -50,7 +55,7 @@ def get_chart_data(data, conditions, filters):
 
 		for i in range(len(row)):
 			datapoints[i] += row[i]
-	company_currency = erpnext.get_company_currency(filters.get("company"))
+
 	return {
 		"data": {
 			"labels": labels,
@@ -60,5 +65,5 @@ def get_chart_data(data, conditions, filters):
 		"lineOptions": {"regionFill": 1},
 		"fieldtype": "Currency",
 		"options": "currency",
-		"currency": company_currency,
+		"currency": conditions.get("company_currency"),
 	}

--- a/erpnext/selling/report/quotation_trends/test_quotation_trends.py
+++ b/erpnext/selling/report/quotation_trends/test_quotation_trends.py
@@ -2,6 +2,7 @@
 # See license.txt
 
 import frappe
+from frappe import _
 
 from erpnext.selling.doctype.quotation.test_quotation import make_quotation
 from erpnext.selling.report.quotation_trends.quotation_trends import execute
@@ -86,3 +87,94 @@ class TestQuotationTrends(ERPNextTestSuite):
 
 		labels, after = self.run_report(based_on="Customer")
 		self.assertEqual(self._cell(after, "Party", "_Test Customer", amt_col, labels) - before_amt, 300)
+
+	def test_group_by_chart_matches_table_total_with_mixed_group_sizes(self):
+		# _Test Item is quoted to two customers -> two detail rows under one header row.
+		# _Test Item 2 is quoted to only one customer -> exactly one detail row under its
+		# header row. A regression that double-counts header rows would inflate the chart
+		# above 800; a regression that zeroes single-group rows would report less than 800.
+		filters = frappe._dict(
+			{
+				"company": "_Test Company",
+				"fiscal_year": FISCAL_YEAR,
+				"period": "Yearly",
+				"based_on": "Item",
+				"group_by": "Customer",
+			}
+		)
+
+		make_quotation(
+			item="_Test Item", party_name="_Test Customer", qty=4, rate=100, transaction_date=TXN_DATE
+		)
+		make_quotation(
+			item="_Test Item", party_name="_Test Customer 1", qty=1, rate=100, transaction_date=TXN_DATE
+		)
+		make_quotation(
+			item="_Test Item 2", party_name="_Test Customer", qty=3, rate=100, transaction_date=TXN_DATE
+		)
+
+		columns, data, _message, chart = execute(filters)
+		self.assertTrue(columns)
+		self.assertTrue(data)
+
+		total_row = next(row for row in data if row[0] == f"'{_('Total')}'")
+		expected_total = total_row[-1]
+		chart_total = sum(chart["data"]["datasets"][0]["values"])
+
+		# 400 (item/customer) + 100 (item/customer1) + 300 (item2/customer) = 800
+		self.assertEqual(expected_total, 800)
+		self.assertEqual(chart_total, expected_total)
+
+	def test_group_by_swapped_roles_based_on_customer_group_by_item(self):
+		# Same regression, opposite role assignment: based_on="Customer" with group_by="Item".
+		# Customer's based_on_cols for Quotation (Party, Party Name, Territory, Currency) put
+		# the group_by placeholder at a different column index than the Item-based_on case
+		# above, exercising the alternate `inc`/`ind` arithmetic.
+		filters = frappe._dict(
+			{
+				"company": "_Test Company",
+				"fiscal_year": FISCAL_YEAR,
+				"period": "Yearly",
+				"based_on": "Customer",
+				"group_by": "Item",
+			}
+		)
+
+		make_quotation(
+			party_name="_Test Customer", item="_Test Item", qty=3, rate=100, transaction_date=TXN_DATE
+		)
+		make_quotation(
+			party_name="_Test Customer", item="_Test Item 2", qty=1, rate=100, transaction_date=TXN_DATE
+		)
+
+		columns, data, _message, chart = execute(filters)
+		total_row = next(row for row in data if row[0] == f"'{_('Total')}'")
+		expected_total = total_row[-1]
+		chart_total = sum(chart["data"]["datasets"][0]["values"])
+
+		# 300 + 100 = 400
+		self.assertEqual(expected_total, 400)
+		self.assertEqual(chart_total, expected_total)
+
+	def test_group_by_single_group_value_not_zeroed(self):
+		# Isolates the specific failure mode flagged in review: a based_on value with exactly
+		# one associated group value must still contribute its real amount to the chart, not 0.
+		filters = frappe._dict(
+			{
+				"company": "_Test Company",
+				"fiscal_year": FISCAL_YEAR,
+				"period": "Yearly",
+				"based_on": "Item",
+				"group_by": "Customer",
+			}
+		)
+
+		make_quotation(
+			item="_Test Item", party_name="_Test Customer", qty=2, rate=150, transaction_date=TXN_DATE
+		)
+
+		columns, data, _message, chart = execute(filters)
+		chart_total = sum(chart["data"]["datasets"][0]["values"])
+
+		self.assertGreater(chart_total, 0)
+		self.assertEqual(chart_total, 300)

--- a/erpnext/selling/report/sales_order_trends/sales_order_trends.py
+++ b/erpnext/selling/report/sales_order_trends/sales_order_trends.py
@@ -4,6 +4,7 @@
 
 from frappe import _
 
+import erpnext
 from erpnext.controllers.trends import get_columns, get_data
 
 
@@ -50,6 +51,7 @@ def get_chart_data(data, conditions, filters):
 		for i in range(len(row)):
 			datapoints[i] += row[i]
 
+	company_currency = erpnext.get_company_currency(filters.get("company"))
 	return {
 		"data": {
 			"labels": labels,
@@ -58,4 +60,6 @@ def get_chart_data(data, conditions, filters):
 		"type": "line",
 		"lineOptions": {"regionFill": 1},
 		"fieldtype": "Currency",
+		"options": "currency",
+		"currency": company_currency,
 	}

--- a/erpnext/selling/report/sales_order_trends/sales_order_trends.py
+++ b/erpnext/selling/report/sales_order_trends/sales_order_trends.py
@@ -4,7 +4,6 @@
 
 from frappe import _
 
-import erpnext
 from erpnext.controllers.trends import get_columns, get_data
 
 
@@ -40,9 +39,15 @@ def get_chart_data(data, conditions, filters):
 	labels = [column.split(":")[0].replace(" (Amt)", "") for column in columns]
 	datapoints = [0] * len(labels)
 
+	group_by_col_idx = None
+	if filters.get("group_by"):
+		group_by_col_idx = conditions["columns"].index(conditions["grbc"][0])
+
 	for row in data:
-		# If group by filter, don't add first row of group (it's already summed)
-		if not row[start]:
+		# Skip the final grand-total row
+		if row[0] == f"'{_('Total')}'":
+			continue
+		if group_by_col_idx is not None and row[group_by_col_idx] == "":
 			continue
 		# Remove None values and compute only periodic data
 		row = [x if x else 0 for x in row[start:-2]]
@@ -51,7 +56,6 @@ def get_chart_data(data, conditions, filters):
 		for i in range(len(row)):
 			datapoints[i] += row[i]
 
-	company_currency = erpnext.get_company_currency(filters.get("company"))
 	return {
 		"data": {
 			"labels": labels,
@@ -61,5 +65,5 @@ def get_chart_data(data, conditions, filters):
 		"lineOptions": {"regionFill": 1},
 		"fieldtype": "Currency",
 		"options": "currency",
-		"currency": company_currency,
+		"currency": conditions.get("company_currency"),
 	}

--- a/erpnext/selling/report/sales_order_trends/test_sales_order_trends.py
+++ b/erpnext/selling/report/sales_order_trends/test_sales_order_trends.py
@@ -2,7 +2,10 @@
 # License: GNU General Public License v3. See license.txt
 
 import frappe
+from frappe import _
+from frappe.utils import today
 
+from erpnext.accounts.utils import get_fiscal_year
 from erpnext.tests.utils import ERPNextTestSuite
 
 
@@ -51,3 +54,160 @@ class TestSalesOrderTrends(ERPNextTestSuite):
 		self.assertTrue(columns)
 		customer_rows = [row for row in data if row[0] == "_Test Customer"]
 		self.assertEqual(len(customer_rows), 1)
+
+	def test_total_row_not_double_counted_in_chart(self):
+		# Regression test for the fix in trends.calculate_total_row that populates the
+		# Total row's Currency column. Before the fix in get_chart_data (skipping the
+		# Total row by label instead of `if not row[start]`), that populated Currency
+		# cell made the Total-row-skip guard falsy, so the already-summed Total row got
+		# added into the chart a second time (an SO of qty=3, rate=100 -> 300 read as 600).
+		from erpnext.selling.doctype.sales_order.test_sales_order import make_sales_order
+		from erpnext.selling.report.sales_order_trends.sales_order_trends import execute
+
+		make_sales_order(item_code="_Test Item", qty=3, rate=100, transaction_date=today())
+
+		fiscal_year = get_fiscal_year(today())[0]
+		filters = frappe._dict(
+			{
+				"company": "_Test Company",
+				"fiscal_year": fiscal_year,
+				"period": "Monthly",
+				"based_on": "Item",
+			}
+		)
+
+		columns, data, _message, chart = execute(filters)
+		self.assertTrue(columns)
+		self.assertTrue(data)
+
+		total_row = next(row for row in data if row[0] == f"'{_('Total')}'")
+		expected_total = total_row[-1]  # Total(Amt) is the last column
+
+		chart_total = sum(chart["data"]["datasets"][0]["values"])
+		self.assertEqual(chart_total, expected_total)
+		self.assertEqual(chart_total, 300)
+
+	def test_chart_currency_matches_company_currency(self):
+		# Regression test: the chart's "currency" key should reflect the transacting
+		# company's currency (conditions["company_currency"]), not a stale global default.
+		from erpnext.selling.doctype.sales_order.test_sales_order import make_sales_order
+		from erpnext.selling.report.sales_order_trends.sales_order_trends import execute
+
+		make_sales_order(item_code="_Test Item", qty=1, rate=100, transaction_date=today())
+
+		fiscal_year = get_fiscal_year(today())[0]
+		filters = frappe._dict(
+			{
+				"company": "_Test Company",
+				"fiscal_year": fiscal_year,
+				"period": "Monthly",
+				"based_on": "Item",
+			}
+		)
+
+		_columns, _data, _message, chart = execute(filters)
+		expected_currency = frappe.get_cached_value("Company", "_Test Company", "default_currency")
+		self.assertEqual(chart["currency"], expected_currency)
+
+	def test_group_by_chart_matches_table_total_with_mixed_group_sizes(self):
+		# _Test Item is split across two customers -> two detail rows under one header row.
+		# _Test Item 2 has only one customer -> exactly one detail row under its header row.
+		# A regression that double-counts header rows would inflate the chart above 600;
+		# a regression that zeroes single-group rows would report less than 600.
+		from erpnext.selling.doctype.sales_order.test_sales_order import make_sales_order
+		from erpnext.selling.report.sales_order_trends.sales_order_trends import execute
+
+		make_sales_order(
+			item_code="_Test Item", customer="_Test Customer", qty=3, rate=100, transaction_date=today()
+		)
+		make_sales_order(
+			item_code="_Test Item", customer="_Test Customer 1", qty=2, rate=100, transaction_date=today()
+		)
+		make_sales_order(
+			item_code="_Test Item 2", customer="_Test Customer", qty=1, rate=100, transaction_date=today()
+		)
+
+		fiscal_year = get_fiscal_year(today())[0]
+		filters = frappe._dict(
+			{
+				"company": "_Test Company",
+				"fiscal_year": fiscal_year,
+				"period": "Monthly",
+				"based_on": "Item",
+				"group_by": "Customer",
+			}
+		)
+
+		columns, data, _message, chart = execute(filters)
+		self.assertTrue(columns)
+		self.assertTrue(data)
+
+		total_row = next(row for row in data if row[0] == f"'{_('Total')}'")
+		expected_total = total_row[-1]
+		chart_total = sum(chart["data"]["datasets"][0]["values"])
+
+		# 300 (item/customer) + 200 (item/customer1) + 100 (item2/customer) = 600
+		self.assertEqual(expected_total, 600)
+		self.assertEqual(chart_total, expected_total)
+
+	def test_group_by_swapped_roles_based_on_customer_group_by_item(self):
+		# Same regression, opposite role assignment: based_on="Customer" with group_by="Item".
+		# Customer's based_on_cols (Customer, Customer Name, Territory, Currency) put the
+		# group_by placeholder at a different column index than the Item-based_on case above,
+		# exercising the alternate `inc`/`ind` arithmetic.
+		from erpnext.selling.doctype.sales_order.test_sales_order import make_sales_order
+		from erpnext.selling.report.sales_order_trends.sales_order_trends import execute
+
+		make_sales_order(
+			item_code="_Test Item", customer="_Test Customer", qty=3, rate=100, transaction_date=today()
+		)
+		make_sales_order(
+			item_code="_Test Item 2", customer="_Test Customer", qty=1, rate=100, transaction_date=today()
+		)
+
+		fiscal_year = get_fiscal_year(today())[0]
+		filters = frappe._dict(
+			{
+				"company": "_Test Company",
+				"fiscal_year": fiscal_year,
+				"period": "Monthly",
+				"based_on": "Customer",
+				"group_by": "Item",
+			}
+		)
+
+		columns, data, _message, chart = execute(filters)
+		total_row = next(row for row in data if row[0] == f"'{_('Total')}'")
+		expected_total = total_row[-1]
+		chart_total = sum(chart["data"]["datasets"][0]["values"])
+
+		# 300 + 100 = 400
+		self.assertEqual(expected_total, 400)
+		self.assertEqual(chart_total, expected_total)
+
+	def test_group_by_single_group_value_not_zeroed(self):
+		# Isolates the specific failure mode flagged in review: a based_on value with exactly
+		# one associated group value must still contribute its real amount to the chart, not 0.
+		from erpnext.selling.doctype.sales_order.test_sales_order import make_sales_order
+		from erpnext.selling.report.sales_order_trends.sales_order_trends import execute
+
+		make_sales_order(
+			item_code="_Test Item", customer="_Test Customer", qty=2, rate=150, transaction_date=today()
+		)
+
+		fiscal_year = get_fiscal_year(today())[0]
+		filters = frappe._dict(
+			{
+				"company": "_Test Company",
+				"fiscal_year": fiscal_year,
+				"period": "Monthly",
+				"based_on": "Item",
+				"group_by": "Customer",
+			}
+		)
+
+		columns, data, _message, chart = execute(filters)
+		chart_total = sum(chart["data"]["datasets"][0]["values"])
+
+		self.assertGreater(chart_total, 0)
+		self.assertEqual(chart_total, 300)

--- a/erpnext/stock/report/delivery_note_trends/delivery_note_trends.py
+++ b/erpnext/stock/report/delivery_note_trends/delivery_note_trends.py
@@ -4,6 +4,7 @@
 
 from frappe import _
 
+import erpnext
 from erpnext.controllers.trends import get_columns, get_data
 
 
@@ -45,6 +46,7 @@ def get_chart_data(data, filters):
 		labels.append(row[0])
 		datapoints.append(row[-1])
 
+	company_currency = erpnext.get_company_currency(filters.get("company"))
 	return {
 		"data": {
 			"labels": labels,
@@ -52,4 +54,6 @@ def get_chart_data(data, filters):
 		},
 		"type": "bar",
 		"fieldtype": "Currency",
+		"options": "currency",
+		"currency": company_currency,
 	}

--- a/erpnext/stock/report/delivery_note_trends/delivery_note_trends.py
+++ b/erpnext/stock/report/delivery_note_trends/delivery_note_trends.py
@@ -4,7 +4,6 @@
 
 from frappe import _
 
-import erpnext
 from erpnext.controllers.trends import get_columns, get_data
 
 
@@ -15,12 +14,12 @@ def execute(filters=None):
 	conditions = get_columns(filters, "Delivery Note")
 	data = get_data(filters, conditions)
 
-	chart_data = get_chart_data(data, filters)
+	chart_data = get_chart_data(data, conditions, filters)
 
 	return conditions["columns"], data, None, chart_data
 
 
-def get_chart_data(data, filters):
+def get_chart_data(data, conditions, filters):
 	def wrap_in_quotes(label):
 		return f"'{label}'"
 
@@ -46,7 +45,6 @@ def get_chart_data(data, filters):
 		labels.append(row[0])
 		datapoints.append(row[-1])
 
-	company_currency = erpnext.get_company_currency(filters.get("company"))
 	return {
 		"data": {
 			"labels": labels,
@@ -55,5 +53,5 @@ def get_chart_data(data, filters):
 		"type": "bar",
 		"fieldtype": "Currency",
 		"options": "currency",
-		"currency": company_currency,
+		"currency": conditions.get("company_currency"),
 	}

--- a/erpnext/stock/report/landed_cost_report/landed_cost_report.py
+++ b/erpnext/stock/report/landed_cost_report/landed_cost_report.py
@@ -24,6 +24,7 @@ def get_columns() -> list[dict]:
 			"label": _("Total Landed Cost"),
 			"fieldname": "landed_cost",
 			"fieldtype": "Currency",
+			"options": "currency",
 		},
 		{
 			"label": _("Purchase Voucher Type"),
@@ -49,6 +50,8 @@ def get_columns() -> list[dict]:
 
 
 def get_data(filters) -> list[list]:
+	company_currency = frappe.get_cached_value("Company", filters.company, "default_currency")
+
 	landed_cost_vouchers = get_landed_cost_vouchers(filters) or {}
 	landed_vouchers = list(landed_cost_vouchers.keys())
 	vendor_invoices = {}
@@ -57,7 +60,6 @@ def get_data(filters) -> list[list]:
 
 	data = []
 
-	print(vendor_invoices)
 	for name, vouchers in landed_cost_vouchers.items():
 		res = {
 			"name": name,
@@ -72,6 +74,7 @@ def get_data(filters) -> list[list]:
 						"landed_cost": d.landed_cost,
 						"voucher_type": d.voucher_type,
 						"voucher_no": d.voucher_no,
+						"currency": company_currency,
 					}
 				)
 			else:
@@ -88,7 +91,6 @@ def get_data(filters) -> list[list]:
 
 		if vendor_invoice_list and len(vendor_invoice_list) > len(vouchers):
 			for row in vendor_invoice_list[last_index + 1 :]:
-				print(row)
 				data.append({"vendor_invoice": row})
 
 	return data

--- a/erpnext/stock/report/landed_cost_report/landed_cost_report.py
+++ b/erpnext/stock/report/landed_cost_report/landed_cost_report.py
@@ -4,6 +4,8 @@
 import frappe
 from frappe import _
 
+import erpnext
+
 
 def execute(filters: dict | None = None):
 	columns = get_columns()
@@ -25,6 +27,13 @@ def get_columns() -> list[dict]:
 			"fieldname": "landed_cost",
 			"fieldtype": "Currency",
 			"options": "currency",
+		},
+		{
+			"label": _("Currency"),
+			"fieldname": "currency",
+			"fieldtype": "Link",
+			"options": "Currency",
+			"hidden": 1,
 		},
 		{
 			"label": _("Purchase Voucher Type"),
@@ -50,8 +59,7 @@ def get_columns() -> list[dict]:
 
 
 def get_data(filters) -> list[list]:
-	company_currency = frappe.get_cached_value("Company", filters.company, "default_currency")
-
+	company_currency = erpnext.get_company_currency(filters.get("company"))
 	landed_cost_vouchers = get_landed_cost_vouchers(filters) or {}
 	landed_vouchers = list(landed_cost_vouchers.keys())
 	vendor_invoices = {}

--- a/erpnext/stock/report/purchase_receipt_trends/purchase_receipt_trends.py
+++ b/erpnext/stock/report/purchase_receipt_trends/purchase_receipt_trends.py
@@ -4,7 +4,6 @@
 
 from frappe import _
 
-import erpnext
 from erpnext.controllers.trends import get_columns, get_data
 
 
@@ -15,12 +14,12 @@ def execute(filters=None):
 	conditions = get_columns(filters, "Purchase Receipt")
 	data = get_data(filters, conditions)
 
-	chart_data = get_chart_data(data, filters)
+	chart_data = get_chart_data(data, conditions, filters)
 
 	return conditions["columns"], data, None, chart_data
 
 
-def get_chart_data(data, filters):
+def get_chart_data(data, conditions, filters):
 	def wrap_in_quotes(label):
 		return f"'{label}'"
 
@@ -45,7 +44,6 @@ def get_chart_data(data, filters):
 
 		labels.append(row[0])
 		datapoints.append(row[-1])
-	company_currency = erpnext.get_company_currency(filters.get("company"))
 
 	return {
 		"data": {
@@ -56,5 +54,5 @@ def get_chart_data(data, filters):
 		"colors": ["#5e64ff"],
 		"fieldtype": "Currency",
 		"options": "currency",
-		"currency": company_currency,
+		"currency": conditions.get("company_currency"),
 	}

--- a/erpnext/stock/report/purchase_receipt_trends/purchase_receipt_trends.py
+++ b/erpnext/stock/report/purchase_receipt_trends/purchase_receipt_trends.py
@@ -4,6 +4,7 @@
 
 from frappe import _
 
+import erpnext
 from erpnext.controllers.trends import get_columns, get_data
 
 
@@ -44,6 +45,7 @@ def get_chart_data(data, filters):
 
 		labels.append(row[0])
 		datapoints.append(row[-1])
+	company_currency = erpnext.get_company_currency(filters.get("company"))
 
 	return {
 		"data": {
@@ -53,4 +55,6 @@ def get_chart_data(data, filters):
 		"type": "bar",
 		"colors": ["#5e64ff"],
 		"fieldtype": "Currency",
+		"options": "currency",
+		"currency": company_currency,
 	}


### PR DESCRIPTION
**Issue:**
Reports such as Sales Order Trend, Purchase Order Trend, Delivery Note Trend etc is showing right value (number-wise) but in symbol showing wrong symbol such as instead of showing ₹ its showing $.

**Before:**
<img width="1600" height="802" alt="image" src="https://github.com/user-attachments/assets/6d5cc7d4-029f-4a32-91cf-7d826b7ac1cd" />

**After:**
<img width="1600" height="802" alt="image" src="https://github.com/user-attachments/assets/fa143612-70ab-417a-bcfa-b9a35347def7" />

**Ref:**[#72052](https://support.frappe.io/helpdesk/tickets/72052)

Backport Needed v15 & v16

Raising this PR on behalf of @ssakthivelmurugan 