### PR TITLE
ci: bump pre-commit actions to v3.0.1

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -21,7 +21,7 @@ jobs:
           cache: pip
 
       - name: Install and Run Pre-commit
-        uses: pre-commit/action@v3.0.0
+        uses: pre-commit/action@v3.0.1
 
   semgrep:
     name: semgrep


### PR DESCRIPTION
`pre-commit/actions@v3.0.0` uses `actions/cache@v3`, resulting in the following annotations:

```
linters
Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/cache@v3. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
```

Bumped to `pre-commit/actions@v3.0.1`.
