### PR TITLE
fix: carry item-level project to Purchase Receipt GL entries

### DIFF
--- a/erpnext/accounts/services/base_gl_composer.py
+++ b/erpnext/accounts/services/base_gl_composer.py
@@ -150,6 +150,9 @@ def add_gl_entry(
 		"remarks": remarks,
 	}
 
+	if project:
+		gl_entry["project"] = project
+
 	if voucher_detail_no:
 		gl_entry["voucher_detail_no"] = voucher_detail_no
 

--- a/erpnext/stock/doctype/purchase_receipt/services/gl_composer.py
+++ b/erpnext/stock/doctype/purchase_receipt/services/gl_composer.py
@@ -67,6 +67,7 @@ class PurchaseReceiptGLComposer(BaseStockGLComposer):
 				remarks=remarks,
 				against_account=stock_asset_rbnb,
 				account_currency=account_currency,
+				project=item.project,
 				item=item,
 			)
 
@@ -118,6 +119,7 @@ class PurchaseReceiptGLComposer(BaseStockGLComposer):
 					against_account=stock_asset_account_name,
 					debit_in_account_currency=-1 * flt(outgoing_amount, item.precision("base_net_amount")),
 					account_currency=account_currency,
+					project=item.project,
 					item=item,
 				)
 
@@ -141,6 +143,7 @@ class PurchaseReceiptGLComposer(BaseStockGLComposer):
 							against_account=doc.supplier,
 							debit_in_account_currency=-1 * discrepancy_caused_by_exchange_rate_difference,
 							account_currency=account_currency,
+							project=item.project,
 							item=item,
 						)
 
@@ -154,6 +157,7 @@ class PurchaseReceiptGLComposer(BaseStockGLComposer):
 							against_account=doc.supplier,
 							debit_in_account_currency=-1 * discrepancy_caused_by_exchange_rate_difference,
 							account_currency=account_currency,
+							project=item.project,
 							item=item,
 						)
 
@@ -214,6 +218,7 @@ class PurchaseReceiptGLComposer(BaseStockGLComposer):
 					remarks=remarks,
 					against_account=stock_asset_account_name,
 					account_currency=supplier_warehouse_account_currency,
+					project=item.project,
 					item=item,
 				)
 


### PR DESCRIPTION
### Problem

On a Purchase Receipt, the stock and asset GL entries pick up the item row's cost center but always fall back to the document level project. On a Purchase Invoice the same lines use the item level project, so the two documents behave differently for the Project dimension.

The cause is in `add_gl_entry`: it accepts a `project` argument but never writes it into the GL dict, while `cost_center` is written. Project is also not a custom Accounting Dimension, so the item over parent override in `get_gl_dict` never applies to it. As a result the inward, Stock Received But Not Billed, landed cost, divisional loss, sub-contracting and exchange rate lines all drop the row's project and use the header project instead.

### Fix

- Write `project` into the GL dict in `add_gl_entry`, guarded like the other optional fields, so it falls back to the parent project when the row has none (same precedence as `item.project or doc.project` used by Purchase Invoice).
- Pass `project=item.project` on the Purchase Receipt entries that were not sending it (inward, SRBNB, both exchange rate lines, sub-contracting). The landed cost, amount difference and divisional loss entries already passed it and now take effect.

Project now behaves the same as cost center on Purchase Receipt GL entries and matches Purchase Invoice.

### How to test

1. Enable perpetual inventory and set a Project on item rows.
2. Create a Purchase Receipt with two items carrying different projects, both different from the header project.
3. Check the GL entries: the Stock and Stock Received But Not Billed lines now carry each row's project, the same way they already carried the row's cost center.

Ticket: 72523
