### PR TITLE
fix(asset): conditionally show Is Fully Depreciated field

### DIFF
--- a/erpnext/assets/doctype/asset/asset.js
+++ b/erpnext/assets/doctype/asset/asset.js
@@ -93,6 +93,11 @@ frappe.ui.form.on("Asset", {
 		frappe.ui.form.trigger("Asset", "asset_type");
 		frm.toggle_display("next_depreciation_date", frm.doc.docstatus < 1);
 
+		if (frm.doc.docstatus < 1 && frm.doc.calculate_depreciation && frm.doc.is_fully_depreciated) {
+			// Is Fully Depreciated is read-only while depreciation is calculated, so keep it unchecked
+			frm.set_value("is_fully_depreciated", 0);
+		}
+
 		let has_create_buttons = false;
 		if (frm.doc.docstatus == 1) {
 			if (["Submitted", "Partially Depreciated"].includes(frm.doc.status)) {
@@ -727,6 +732,10 @@ frappe.ui.form.on("Asset", {
 
 	calculate_depreciation: function (frm) {
 		frm.toggle_reqd("finance_books", frm.doc.calculate_depreciation);
+		if (frm.doc.calculate_depreciation && frm.doc.is_fully_depreciated) {
+			// Is Fully Depreciated is read-only while depreciation is calculated, so keep it unchecked
+			frm.set_value("is_fully_depreciated", 0);
+		}
 		if (frm.doc.item_code && frm.doc.calculate_depreciation && frm.doc.net_purchase_amount) {
 			frm.trigger("set_finance_book");
 		} else {

--- a/erpnext/assets/doctype/asset/asset.json
+++ b/erpnext/assets/doctype/asset/asset.json
@@ -450,10 +450,11 @@
   },
   {
    "default": "0",
+   "depends_on": "eval:(doc.asset_type == \"Existing Asset\" && !doc.calculate_depreciation) || doc.calculate_depreciation",
    "fieldname": "is_fully_depreciated",
    "fieldtype": "Check",
-   "hidden": 1,
-   "label": "Is Fully Depreciated"
+   "label": "Is Fully Depreciated",
+   "read_only_depends_on": "eval:doc.calculate_depreciation"
   },
   {
    "depends_on": "eval:doc.docstatus > 0",

--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -132,6 +132,10 @@ class Asset(AccountsController):
 		self.validate_gross_and_purchase_amount()
 		self.validate_finance_books()
 
+		if self.calculate_depreciation:
+			# Is Fully Depreciated is only applicable to manually entered existing assets
+			self.is_fully_depreciated = 0
+
 	def before_save(self):
 		self.total_asset_cost = self.net_purchase_amount + self.additional_asset_cost
 		self.status = self.get_status()


### PR DESCRIPTION
## Problem

In v16 the **Is Fully Depreciated** checkbox on the Asset form is hidden (`hidden: 1`). The field still exists in the database but is no longer visible in the UI, so it cannot be set for manually entered existing assets.

## Fix

Make the field visible based on context:

| Calculate Depreciation | Visible | Editable | Value |
|---|---|---|---|
| off + Existing Asset | yes | yes | user-set |
| on (any asset type) | yes | read-only | forced unchecked |
| off + other type | hidden | – | – |

- `depends_on` / `read_only_depends_on` on the field handle visibility and read-only state.
- It is only meaningful for manually entered assets, so when Calculate Depreciation is on it is forced **unchecked**. This is enforced both in the form script (immediate feedback when toggled and on form load) and in server-side `validate()`, so it can never be persisted as checked while depreciation is calculated.

## Steps to verify

1. Open/create an Asset, set **Asset Type = Existing Asset**, leave **Calculate Depreciation** unchecked -> field is visible and editable.
2. Enable **Calculate Depreciation** -> field is visible but greyed out and unchecked.
3. Other asset types with Calculate Depreciation off -> field hidden.