### PR TITLE
fix: prevent adding represented company to allowed to transact with list

### DIFF
--- a/erpnext/accounts/party.py
+++ b/erpnext/accounts/party.py
@@ -586,6 +586,19 @@ def validate_party_gle_currency(party_type, party, company, party_account_curren
 		)
 
 
+def validate_internal_party_companies(doc):
+	if not doc.get("represents_company"):
+		return
+
+	for row in doc.get("companies"):
+		if row.company == doc.represents_company:
+			frappe.throw(
+				_(
+					"Row #{0}: Company {1} cannot be added in 'Allowed To Transact With' as it is the company this {2} represents."
+				).format(row.idx, frappe.bold(row.company), doc.doctype)
+			)
+
+
 def validate_party_accounts(doc):
 	from erpnext.controllers.accounts_controller import validate_account_head
 

--- a/erpnext/buying/doctype/supplier/supplier.py
+++ b/erpnext/buying/doctype/supplier/supplier.py
@@ -13,6 +13,7 @@ from frappe.model.naming import set_name_by_naming_series, set_name_from_naming_
 
 from erpnext.accounts.party import (
 	get_dashboard_info,
+	validate_internal_party_companies,
 	validate_party_accounts,
 	validate_party_currency_before_merging,
 )
@@ -144,6 +145,7 @@ class Supplier(TransactionBase):
 
 		validate_party_accounts(self)
 		self.validate_internal_supplier()
+		validate_internal_party_companies(self)
 		self.add_role_for_user()
 		self.validate_currency_for_receivable_payable_and_advance_account()
 

--- a/erpnext/selling/doctype/customer/customer.py
+++ b/erpnext/selling/doctype/customer/customer.py
@@ -21,6 +21,7 @@ from frappe.utils.user import get_users_with_role
 
 from erpnext.accounts.party import (
 	get_dashboard_info,
+	validate_internal_party_companies,
 	validate_party_accounts,
 	validate_party_currency_before_merging,
 )
@@ -184,6 +185,7 @@ class Customer(TransactionBase):
 		self.check_customer_group_change()
 		self.validate_default_bank_account()
 		self.validate_internal_customer()
+		validate_internal_party_companies(self)
 		self.add_role_for_user()
 		self.validate_currency_for_receivable_payable_and_advance_account()
 


### PR DESCRIPTION
An internal Customer or Supplier has a `represents_company` field identifying which company it represents. The **Allowed To Transact With** child table lists the counterpart companies it may transact with.

There was no validation preventing a user from adding the same company as `represents_company` into the allowed list — i.e. a company transacting with itself. This pollutes the inter-company party validation in `_validate_internal_party_company` and can cause address-related errors when creating inter-company Sales/Purchase Orders.

Added a shared `validate_internal_party_companies` function in `party.py`, called from both `Customer.validate` and `Supplier.validate`, that throws if any row in the `companies` table matches the party's own `represents_company`.