### PR TITLE
fix: reserve projected stock for production plan based on BOM qty

### DIFF
--- a/erpnext/manufacturing/doctype/production_plan/production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.py
@@ -9,6 +9,7 @@ from collections import defaultdict
 import frappe
 from frappe import _, msgprint
 from frappe.model.document import Document
+from frappe.query_builder import Case
 from frappe.query_builder.functions import IfNull, Sum
 from frappe.utils import (
 	add_days,
@@ -1375,7 +1376,7 @@ def get_material_request_items(
 			get_conversion_factor(row.item_code, item_details.purchase_uom).get("conversion_factor") or 1.0
 		)
 
-	if required_qty > 0:
+	if flt(row.get("qty")) > 0:
 		return {
 			"item_code": row.item_code,
 			"item_name": row.item_name,
@@ -1880,7 +1881,12 @@ def get_reserved_qty_for_production_plan(item_code, warehouse):
 		frappe.qb.from_(table)
 		.inner_join(child)
 		.on(table.name == child.parent)
-		.select(Sum(child.quantity * child.conversion_factor))
+		.select(
+			Sum(
+				(Case().when(child.quantity == 0, child.required_bom_qty).else_(child.quantity))
+				* child.conversion_factor
+			)
+		)
 		.where(
 			(table.docstatus == 1)
 			& (child.item_code == item_code)

--- a/erpnext/manufacturing/doctype/production_plan/test_production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/test_production_plan.py
@@ -212,13 +212,15 @@ class TestProductionPlan(FrappeTestCase):
 		quantities = [d["quantity"] for d in mr_items]
 		rm_qty = sum(quantities)
 
-		# Only 2 MR item created - the first SO's requirement is fully covered by stock (v15 behaviour)
-		self.assertEqual(len(mr_items), 2)
-		self.assertEqual(rm_qty, 2, "Cascading failed: total MR qty should be 2 (3 needed - 1 in stock)")
+		# 3 MR items: SO1's requirement is covered by stock (qty=0 but reserved), SO2 and SO3 need 1 each
+		self.assertEqual(len(mr_items), 3)
+		self.assertEqual(
+			rm_qty, 2, "Cascading failed: total purchase qty should be 2 (3 needed - 1 in stock)"
+		)
 		self.assertEqual(
 			quantities,
-			[1, 1],
-			"Cascading failed: only second and third SO should need procurement (qty=1) since first SO consumed stock",
+			[0, 1, 1],
+			"SO1 stock-covered item should appear with qty=0 for reservation; SO2 and SO3 need qty=1",
 		)
 
 		sr.cancel()
@@ -251,11 +253,13 @@ class TestProductionPlan(FrappeTestCase):
 		pln = create_production_plan(
 			item_code="Test Production Item 1", use_multi_level_bom=0, ignore_existing_ordered_qty=0
 		)
-		self.assertFalse(len(pln.mr_items))
 
+		items_needing_purchase = [row.item_code for row in pln.mr_items if row.quantity > 0]
+		self.assertFalse(len(items_needing_purchase))
+
+		pln.cancel()
 		sr1.cancel()
 		sr2.cancel()
-		pln.cancel()
 
 	def test_production_plan_sales_orders(self):
 		"Test if previously fulfilled SO (with WO) is pulled into Prod Plan."


### PR DESCRIPTION
Issue:
When a Production Plan is submitted, raw materials that are already available in stock are not reserved against the plan. The system only reserves materials that need to be purchased — materials already in stock are **ignored completely**.
This causes the projected stock to remain unchanged after plan submission. So when a second plan is made for the same finished good, the system still shows the full stock as available and again reports zero purchase requirement — both plans end up competing for the same physical stock without any warning.

Ref: [#72444](https://support.frappe.io/helpdesk/tickets/72444)

Steps to Reproduce:
1. Create a Finished Good item A with a BOM requiring 5 units of Raw Material X
2. Add 5 units of X to stock (enough to cover the BOM requirement)
3. Create a Production Plan for 1 unit of A
     3.1 Set Ignore Existing Projected Quantity = unchecked
4. Click Get Raw Materials for Purchase
     4.1 The Raw Materials table will be empty — the system says no purchase is needed since stock is available
5. Submit the plan
6. Open the Bin for item X and check:
    6.1 Reserved Qty for Production Plan = 0 ← should be 5
    6.2 Projected Qty = 5 ← should be 0
7. Create a second Production Plan for 1 unit of A with the same settings
8. Click Get Raw Materials for Purchase again
    8.1 Raw Materials table is empty again — system still sees 5 units projected as available
    8.2 Both plans together need 10 units, but only 5 exist — no warning given
    

Before: 

[Screencast from 2026-06-27 23-38-31.webm](https://github.com/user-attachments/assets/181da381-d65a-4d0b-b167-bc3b282c175d)

    
After:

[Screencast from 2026-06-27 23-36-15.webm](https://github.com/user-attachments/assets/6fb8c939-882d-4eb8-a282-3a60f5177b95)
