### PR TITLE
fix: respect item-level accounting dimensions in Purchase Receipt GL entries

### DIFF
--- a/erpnext/accounts/services/base_gl_composer.py
+++ b/erpnext/accounts/services/base_gl_composer.py
@@ -150,6 +150,9 @@ def add_gl_entry(
 		"remarks": remarks,
 	}
 
+	if project:
+		gl_entry["project"] = project
+
 	if voucher_detail_no:
 		gl_entry["voucher_detail_no"] = voucher_detail_no
 

--- a/erpnext/stock/doctype/purchase_receipt/services/gl_composer.py
+++ b/erpnext/stock/doctype/purchase_receipt/services/gl_composer.py
@@ -67,6 +67,7 @@ class PurchaseReceiptGLComposer(BaseStockGLComposer):
 				remarks=remarks,
 				against_account=stock_asset_rbnb,
 				account_currency=account_currency,
+				project=item.project,
 				item=item,
 			)
 
@@ -141,6 +142,7 @@ class PurchaseReceiptGLComposer(BaseStockGLComposer):
 							against_account=doc.supplier,
 							debit_in_account_currency=-1 * discrepancy_caused_by_exchange_rate_difference,
 							account_currency=account_currency,
+							project=item.project,
 							item=item,
 						)
 
@@ -154,6 +156,7 @@ class PurchaseReceiptGLComposer(BaseStockGLComposer):
 							against_account=doc.supplier,
 							debit_in_account_currency=-1 * discrepancy_caused_by_exchange_rate_difference,
 							account_currency=account_currency,
+							project=item.project,
 							item=item,
 						)
 
@@ -214,6 +217,7 @@ class PurchaseReceiptGLComposer(BaseStockGLComposer):
 					remarks=remarks,
 					against_account=stock_asset_account_name,
 					account_currency=supplier_warehouse_account_currency,
+					project=item.project,
 					item=item,
 				)
 


### PR DESCRIPTION
## Problem

When **Accounting Dimensions** (e.g. **Project**) are set differently at the **item level** vs the document **header** in a **Purchase Receipt**, the generated GL entries use the **header-level** value for all items, ignoring the item-level value.

**Purchase Invoice** already respects the item-level value, so the behaviour is inconsistent between the two documents and results in incorrect accounting allocation for Purchase Receipts.

## Steps to reproduce

1. Enable perpetual inventory.
2. Create a Purchase Receipt with a header Project (e.g. `PROJ-0001`).
3. On an item row, set a different Project (e.g. `PROJ-0002`).
4. Submit and inspect the GL entries.

**Before:** the *Stock In Hand* / *Stock Received But Not Billed* entries are posted with `PROJ-0001` (header).
**Expected:** they should be posted with `PROJ-0002` (item).

## Root cause

Purchase Receipt builds its GL entries through the shared `add_gl_entry` helper in `erpnext/accounts/services/base_gl_composer.py`. That helper declared a `project` parameter but **never wrote it into the GL dict**, so the `project=item.project` passed by the callers was silently dropped and `get_gl_dict` fell back to the document (header) project.

Purchase Invoice doesn't go through this helper for its expense entries — it builds the GL dict directly with `item.project or self.project` — which is why it already worked.

Custom Accounting Dimensions are handled generically in `get_gl_dict` (item value overrides header) and Cost Center was already passed per item, so `project` was the dimension slipping through.

## Fix

- **`base_gl_composer.add_gl_entry`**: write `project` into the GL dict when provided.
- **Purchase Receipt `gl_composer`**: pass `project=item.project` on the stock asset inward, *Stock Received But Not Billed* (including the exchange-rate-difference sub-entries) and sub-contracting entries that previously omitted it.

When the item row has no project, the header project is still used (no behaviour change).

## Verification

Tested on a local v15 bench with perpetual inventory: a Purchase Receipt with header project `PROJ-0001` and item project `PROJ-0002` now posts both the *Stock In Hand* (debit) and *Stock Received But Not Billed* (credit) entries against `PROJ-0002`, matching Purchase Invoice behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)