### PR TITLE
fix: backport stock balance changes from #55774

### DIFF
--- a/erpnext/stock/report/stock_balance/stock_balance.py
+++ b/erpnext/stock/report/stock_balance/stock_balance.py
@@ -100,8 +100,6 @@ class StockBalanceReport:
 			self.filters["show_warehouse_wise_stock"] = True
 			item_wise_fifo_queue = FIFOSlots(self.filters, self.sle_entries).generate()
 
-		_func = itemgetter(1)
-
 		del self.sle_entries
 
 		sre_details = self.get_sre_reserved_qty_details()
@@ -126,16 +124,7 @@ class StockBalanceReport:
 
 				stock_ageing_data = {"average_age": 0, "earliest_age": 0, "latest_age": 0}
 				if opening_fifo_queue:
-					fifo_queue = sorted(filter(_func, opening_fifo_queue), key=_func)
-					fifo_queue = normalize_fifo_queue(fifo_queue)
-					if not fifo_queue:
-						continue
-
-					to_date = self.to_date
-					stock_ageing_data["average_age"] = get_average_age(fifo_queue, to_date)
-					stock_ageing_data["earliest_age"] = date_diff(to_date, fifo_queue[0][1])
-					stock_ageing_data["latest_age"] = date_diff(to_date, fifo_queue[-1][1])
-					stock_ageing_data["fifo_queue"] = fifo_queue
+					stock_ageing_data.update(get_stock_ageing_data(opening_fifo_queue, self.to_date))
 
 				report_data.update(stock_ageing_data)
 
@@ -692,6 +681,21 @@ class StockBalanceReport:
 			row[1] = getdate(row[1])
 
 		return opening_fifo_queue
+
+
+def get_stock_ageing_data(fifo_queue: list, to_date: str) -> dict:
+	stock_ageing_data = {"average_age": 0, "earliest_age": 0, "latest_age": 0}
+	fifo_queue = sorted(filter(itemgetter(1), normalize_fifo_queue(fifo_queue)), key=itemgetter(1))
+
+	if not fifo_queue:
+		return stock_ageing_data
+
+	stock_ageing_data["average_age"] = get_average_age(fifo_queue, to_date)
+	stock_ageing_data["earliest_age"] = date_diff(to_date, fifo_queue[0][1])
+	stock_ageing_data["latest_age"] = date_diff(to_date, fifo_queue[-1][1])
+	stock_ageing_data["fifo_queue"] = fifo_queue
+
+	return stock_ageing_data
 
 
 def filter_items_with_no_transactions(

--- a/erpnext/stock/report/stock_balance/test_stock_balance.py
+++ b/erpnext/stock/report/stock_balance/test_stock_balance.py
@@ -7,7 +7,7 @@ from frappe.utils import today
 
 from erpnext.stock.doctype.item.test_item import make_item
 from erpnext.stock.doctype.stock_entry.stock_entry_utils import make_stock_entry
-from erpnext.stock.report.stock_balance.stock_balance import execute
+from erpnext.stock.report.stock_balance.stock_balance import execute, get_stock_ageing_data
 
 
 def stock_balance(filters):
@@ -168,3 +168,19 @@ class TestStockBalance(FrappeTestCase):
 		rows = stock_balance(self.filters.update({"show_variant_attributes": 1, "item_code": [variant.name]}))
 		self.assertPartialDictEq(attributes, rows[0])
 		self.assertInvariants(rows)
+
+	def test_stock_ageing_data_accepts_batchwise_valuation_slots(self):
+		fifo_queue = [
+			["SA-BATCH-NEWER", 1, 2.0, "2021-12-05", 20.0],
+			["SA-BATCH-OLDER", 1, 3.0, "2021-12-01", 30.0],
+		]
+
+		stock_ageing_data = get_stock_ageing_data(fifo_queue, "2021-12-10")
+
+		self.assertEqual(stock_ageing_data["average_age"], 7.4)
+		self.assertEqual(stock_ageing_data["earliest_age"], 9)
+		self.assertEqual(stock_ageing_data["latest_age"], 5)
+		self.assertEqual(
+			stock_ageing_data["fifo_queue"],
+			[[3.0, "2021-12-01", 30.0], [2.0, "2021-12-05", 20.0]],
+		)


### PR DESCRIPTION
### What changed
- Backport of the `stock_balance.py` changes from #55774, which were dropped when #55776 backported #55774 to `version-15-hotfix` (only the `stock_ageing` files were cherry-picked).
- Extract `get_stock_ageing_data` and route the Stock Balance ageing computation through it.
- Add a regression test for batchwise valuation slots.

### Why
A later backport (#55229) left v15 with an *inline* ageing computation that sorts/filters the FIFO queue by `itemgetter(1)` **before** normalizing batch valuation slots. For a raw batch slot `["BATCH", 1, qty, date, value]`, `itemgetter(1)` returns the count flag `1`, not the posting date — so the queue is ordered incorrectly and `earliest_age` / `latest_age` come out swapped.

`get_stock_ageing_data` (from #55774) normalizes **before** sorting/filtering, so `itemgetter(1)` is always the posting date.

### Testing
- `python -m py_compile erpnext/stock/report/stock_balance/stock_balance.py erpnext/stock/report/stock_balance/test_stock_balance.py`
- Standalone numeric check of `get_stock_ageing_data` against the regression test's expectations (average 7.4, earliest 9, latest 5, queue sorted by date).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #56602
