### PR TITLE
fix: delete Lead-linked Addresses on transaction deletion

### DIFF
--- a/erpnext/setup/doctype/transaction_deletion_record/transaction_deletion_record.py
+++ b/erpnext/setup/doctype/transaction_deletion_record/transaction_deletion_record.py
@@ -702,8 +702,6 @@ class TransactionDeletionRecord(Document):
 					"Dynamic Link", filters={"link_name": ("in", leads)}, pluck="parent"
 				)
 				if addresses:
-					addresses = ["%s" % frappe.db.escape(addr) for addr in addresses]
-
 					address = qb.DocType("Address")
 					dl1 = qb.DocType("Dynamic Link")
 					dl2 = qb.DocType("Dynamic Link")


### PR DESCRIPTION
## Problem

In the Transaction Deletion Record lead/address cleanup (`delete_lead_addresses`), each address name was pre-escaped before being handed to a query-builder `.isin()` filter:

```python
addresses = ["%s" % frappe.db.escape(addr) for addr in addresses]
...
qb.from_(address).delete().where((address.name.isin(addresses)) & ...).run()
```

`.isin()` escapes its values again, so the generated SQL was `name IN ('''Addr-1''')` — which matches nothing. The intended Address deletion silently removed **zero** rows on both MariaDB and Postgres.

## Fix

Remove the pre-escaping and pass the raw `addresses` list straight into `.isin()`, letting the query builder escape exactly once. The surrounding `notin` subquery uses query-builder columns (not the list), and the subsequent Dynamic Link / Customer statements use `leads`, so they are unaffected.

The double-escape produces the same non-matching `IN` clause on either engine, so the bug and fix are engine-independent.

This is a pre-existing bug, unrelated to the Postgres migration work.