### PR TITLE
fix: negative stock issue

### DIFF
--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -134,6 +134,7 @@ def repost_current_voucher(args, allow_negative_stock=False, via_landed_cost_vou
 					"sle_id": args.get("name"),
 					"creation": args.get("creation"),
 					"reserved_stock": args.get("reserved_stock"),
+					"cancelled": args.get("is_cancelled"),
 				},
 				allow_negative_stock=allow_negative_stock,
 				via_landed_cost_voucher=via_landed_cost_voucher,


### PR DESCRIPTION
This has already fixed in v16 and develop branch 

Steps to replicate issue

1. Create a purchase receipt put posting date "29/06/2026" and time as "10:00:00", enable "Edit Posting Date and Time"
2. Create material transfer entry and set put posting date "29/06/2026" and time as "10:00:00", enable "Edit Posting Date and Time"
3. Now try to cancel the purchase receipt created at step 1, system allows to cancel the entry