### PR TITLE
fix: deterministic tiebreakers for ORDER BY <date> DESC LIMIT 1 lookups (MariaDB↔Postgres parity)

### DIFF
--- a/erpnext/accounts/doctype/exchange_rate_revaluation/exchange_rate_revaluation.py
+++ b/erpnext/accounts/doctype/exchange_rate_revaluation/exchange_rate_revaluation.py
@@ -601,6 +601,7 @@ def calculate_exchange_rate_using_last_gle(company, account, party_type, party):
 			.select(gl.voucher_type, gl.voucher_no)
 			.where(Criterion.all(conditions))
 			.orderby(gl.posting_date, order=Order.desc)
+			.orderby(gl.name, order=Order.desc)
 			.limit(1)
 			.run()[0]
 		)
@@ -615,6 +616,7 @@ def calculate_exchange_rate_using_last_gle(company, account, party_type, party):
 				(gl.voucher_type == voucher_type) & (gl.voucher_no == voucher_no) & (gl.account == account)
 			)
 			.orderby(gl.posting_date, order=Order.desc)
+			.orderby(gl.name, order=Order.desc)
 			.limit(1)
 			.run()[0][0]
 		)

--- a/erpnext/accounts/report/gross_profit/gross_profit.py
+++ b/erpnext/accounts/report/gross_profit/gross_profit.py
@@ -895,7 +895,11 @@ class GrossProfitGenerator:
 		if row.cost_center:
 			query = query.where(purchase_invoice_item.cost_center == row.cost_center)
 
-		query = query.orderby(purchase_invoice.posting_date, order=frappe.qb.desc).limit(1)
+		query = (
+			query.orderby(purchase_invoice.posting_date, order=frappe.qb.desc)
+			.orderby(purchase_invoice.name, order=frappe.qb.desc)
+			.limit(1)
+		)
 		last_purchase_rate = query.run()
 
 		return flt(last_purchase_rate[0][0]) if last_purchase_rate else 0

--- a/erpnext/assets/doctype/asset_movement/asset_movement.py
+++ b/erpnext/assets/doctype/asset_movement/asset_movement.py
@@ -139,6 +139,7 @@ class AssetMovement(Document):
 			.select(asm_item.target_location, asm_item.to_employee)
 			.where((asm_item.asset == asset) & (asm.company == self.company) & (asm.docstatus == 1))
 			.orderby(asm.transaction_date, order=frappe.qb.desc)
+			.orderby(asm.name, order=frappe.qb.desc)
 			.limit(1)
 			.run()
 		)

--- a/erpnext/selling/report/inactive_customers/inactive_customers.py
+++ b/erpnext/selling/report/inactive_customers/inactive_customers.py
@@ -86,6 +86,7 @@ def get_last_sales_amt(customer, doctype):
 		.select(sales_doctype.base_net_total)
 		.where((sales_doctype.customer == customer) & (sales_doctype.docstatus == 1))
 		.orderby(date_col, order=frappe.qb.desc)
+		.orderby(sales_doctype.name, order=frappe.qb.desc)
 		.limit(1)
 	).run()
 


### PR DESCRIPTION
## Problem
Several "latest record" lookups order by a date column `DESC LIMIT 1` with **no unique tiebreaker**. When two rows share the latest date the single returned row is undefined, so MariaDB and PostgreSQL can return **different** rows — a silent cross-engine divergence that changes real values.

## Fix (1 commit per file)
Add a deterministic `name` DESC secondary sort so both engines converge on the same row.

| file | lookup | what a same-date tie changes |
|---|---|---|
| `accounts/.../exchange_rate_revaluation.py` | last GLE voucher + exchange rate | `last_exchange_rate` → revaluation gain/loss |
| `assets/.../asset_movement.py` | latest movement | current location/custodian written to the Asset |
| `accounts/report/gross_profit.py` | last purchase rate | reported gross profit |
| `selling/report/inactive_customers.py` | last sales doc | "Last Order Amount" |

## Why MariaDB is unchanged
MariaDB's pick among same-date ties was already **undefined**, so adding a tiebreaker is the sanctioned arbitrary→deterministic change with row count preserved; on the common (non-tied) path the result is byte-identical.

## Verification
Pre-commit incl. the repo's **PostgreSQL compatibility static check** is green. Found via a static MariaDB↔PostgreSQL parity audit (`ORDER BY … LIMIT 1` class).

_A 5th commit touching `bom.py` (exploded-item display idx) was dropped after review — that subquery's `item_code`+`parent` correlation is pre-existing and a proper fix would change MariaDB output, out of scope here._