### PR TITLE
fix: set mr status to received when per_received is 100 even if per_o…

### DIFF
--- a/erpnext/controllers/status_updater.py
+++ b/erpnext/controllers/status_updater.py
@@ -144,7 +144,7 @@ status_map = {
 		],
 		[
 			"Partially Ordered",
-			"eval:self.status != 'Stopped' and self.per_ordered < 100 and self.per_ordered > 0 and self.docstatus == 1 and self.material_request_type not in ['Material Transfer', 'Customer Provided']",
+			"eval:self.status != 'Stopped' and self.per_ordered < 100 and self.per_ordered > 0 and self.per_received < 100 and self.docstatus == 1 and self.material_request_type not in ['Material Transfer', 'Customer Provided']",
 		],
 	],
 	"POS Opening Entry": [


### PR DESCRIPTION
When a Material Request is raised for a certain quantity and the Purchase Order is created for a lesser quantity than requested, but the full quantity is eventually received via Purchase Receipts (using over-receipt allowance), the Material Request status gets stuck as "Partially Ordered" indefinitely.

This leaves the Material Request in a state where:
- It cannot be closed; there is no Stop button visible
- The status does not reflect the actual ground reality (all goods have been received)
- The MR stays open forever with no way to resolve it from the UI

Ref:[#72552](https://support.frappe.io/helpdesk/tickets/72552)

Steps To Replicate:
1. Create a Material Request (type: Purchase) for 30 qty of any item
2. From the MR, create a Purchase Order for only 28 qty (less than the MR qty)
3. Ensure Over Receipt/Delivery Allowance is configured in Stock Settings (e.g. 15%)
4. From the PO, create Purchase Receipt 1 for 15 qty → submit
5. From the same PO, create Purchase Receipt 2 for 15 qty → submit
  - Total received = 30 (covers the full MR qty via over-receipt allowance on the 28 qty PO)
6. Open the Material Request

Backport Needed For V16 and V15