### PR TITLE
fix: savepoint catch-and-continue DB writes to survive Postgres txn-abort (InFailedSqlTransaction)

### DIFF
--- a/erpnext/buying/doctype/purchase_order/mapper.py
+++ b/erpnext/buying/doctype/purchase_order/mapper.py
@@ -232,9 +232,11 @@ def make_subcontracting_order(
 			target_doc.save()
 
 			if submit and frappe.has_permission(target_doc.doctype, "submit", target_doc):
+				frappe.db.savepoint("submit_subcontracting_order")
 				try:
 					target_doc.submit()
 				except Exception as e:
+					frappe.db.rollback(save_point="submit_subcontracting_order")
 					target_doc.add_comment("Comment", _("Submit Action Failed") + "<br><br>" + str(e))
 
 			if notify:

--- a/erpnext/manufacturing/doctype/routing/test_routing.py
+++ b/erpnext/manufacturing/doctype/routing/test_routing.py
@@ -102,9 +102,11 @@ def create_routing(**args):
 	doc.update(args)
 
 	if not args.do_not_save:
+		frappe.db.savepoint("create_routing")
 		try:
 			doc.insert()
 		except frappe.DuplicateEntryError:
+			frappe.db.rollback(save_point="create_routing")
 			doc = frappe.get_doc("Routing", args.routing_name)
 			doc.delete_key("operations")
 			for operation in args.operations:

--- a/erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.py
+++ b/erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.py
@@ -779,6 +779,7 @@ def make_reposting_for_accounting_ledgers(transactions, company, repost_doc):
 		if reposting_map.get((voucher_type, voucher_no)):
 			continue
 
+		frappe.db.savepoint("repost_accounting_ledger")
 		try:
 			new_repost_doc = frappe.new_doc("Repost Item Valuation")
 			new_repost_doc.company = company
@@ -789,7 +790,7 @@ def make_reposting_for_accounting_ledgers(transactions, company, repost_doc):
 			new_repost_doc.flags.ignore_permissions = True
 			new_repost_doc.submit()
 		except Exception:
-			pass
+			frappe.db.rollback(save_point="repost_accounting_ledger")
 
 
 def get_existing_reposting_only_gl_entries(reposting_reference):

--- a/erpnext/subcontracting/doctype/subcontracting_receipt/mapper.py
+++ b/erpnext/subcontracting/doctype/subcontracting_receipt/mapper.py
@@ -125,9 +125,11 @@ def make_purchase_receipt(
 		target_doc.save()
 
 		if submit and frappe.has_permission(target_doc.doctype, "submit", target_doc):
+			frappe.db.savepoint("submit_subcontracting_receipt")
 			try:
 				target_doc.submit()
 			except Exception as e:
+				frappe.db.rollback(save_point="submit_subcontracting_receipt")
 				target_doc.add_comment("Comment", _("Submit Action Failed") + "<br><br>" + str(e))
 
 		if notify:


### PR DESCRIPTION
## Problem
On PostgreSQL a failed statement aborts the **entire transaction** — every later statement raises `InFailedSqlTransaction` until a `ROLLBACK`. MariaDB has no statement-level abort and continues. So "catch the error and keep doing DB work" patterns — fine on MariaDB — break on Postgres. (Frappe dropped its blanket per-insert savepoint in frappe#40075, so callers must savepoint themselves.)

Each site catches a failed `submit`/`insert` and then runs **more DB work in the same transaction** with no savepoint:

| file | pattern | on Postgres today |
|---|---|---|
| `buying/.../purchase_order/mapper.py` | `submit()` in `except` → `add_comment(…)` | comment insert dies |
| `subcontracting/.../subcontracting_receipt/mapper.py` | same `submit()`/`add_comment` | comment insert dies |
| `stock/.../repost_item_valuation.py` | per-voucher `submit()` loop in `except: pass` | next iteration dies |
| `manufacturing/.../routing/test_routing.py` (test) | dup `insert()` → `get_doc`+`save` in `except` | fetch/update dies |

## Fix (1 commit per file)
Wrap the fallible op in `frappe.db.savepoint(…)` and `frappe.db.rollback(save_point=…)` at the top of the handler — the pattern frappe#40075 prescribes (and that `install_fixtures` / `_create_bin` already use). The savepoint is taken **after** any prior successful `save()`, so only the failed `submit()`/`insert()` is rolled back; the already-saved doc and the handler's `add_comment`/fallback then run on a usable transaction.

## Why MariaDB is unchanged
MariaDB never aborts the transaction, so taking a savepoint and rolling back a no-op failure changes nothing — byte-identical behaviour. Only Postgres moves (toward MariaDB).

## Verification
Pre-commit incl. the repo's **PostgreSQL compatibility static check** is green. Found via a static MariaDB↔PostgreSQL transaction-abort audit.

_A 5th commit (`import_supplier_invoice.py`, the highest-severity loop-cascade case) was dropped after review: there the savepoint must wrap `pi.insert()`, so a later-step failure would roll back a successfully-created invoice that MariaDB keeps — a MariaDB behaviour change. Postgres can't both preserve the partial invoice and recover the transaction, so that site needs a refactor (record the error past a transaction boundary), handled separately._