### PR TITLE
ci(postgres): fail setup if pg_ctl stop fails; drop redundant ALTER SYSTEM block

### DIFF
--- a/.github/helper/install.sh
+++ b/.github/helper/install.sh
@@ -297,14 +297,10 @@ if [ "$DB" == "postgres" ];then
     echo "travis" | psql -h 127.0.0.1 -p 5432 -c "CREATE DATABASE test_frappe" -U postgres;
     echo "travis" | psql -h 127.0.0.1 -p 5432 -c "CREATE USER test_frappe WITH PASSWORD 'test_frappe'" -U postgres;
 
-    # Disposable CI DB: durability off for speed (postgres fsyncs every commit by default, which
-    # dominates a commit-heavy suite). All reloadable, no restart. The postgres workflow runs a
-    # service-container DB and never calls start-db.sh, so the flags must be applied here.
-    echo "travis" | psql -h 127.0.0.1 -p 5432 -U postgres \
-        -c "ALTER SYSTEM SET synchronous_commit = 'off'" \
-        -c "ALTER SYSTEM SET fsync = 'off'" \
-        -c "ALTER SYSTEM SET full_page_writes = 'off'" \
-        -c "SELECT pg_reload_conf()";
+    # Durability-off for speed (no fsync/synchronous_commit/full_page_writes) is applied by
+    # start-db.sh's postgres `-o` flags on every start — setup job AND each test shard — so it is
+    # NOT repeated here. The postgres workflow runs in-runner via start-db.sh, not a service
+    # container.
 fi
 
 cd ~/frappe-bench || exit

--- a/.github/workflows/server-tests-postgres.yml
+++ b/.github/workflows/server-tests-postgres.yml
@@ -108,7 +108,11 @@ jobs:
       - name: Stop DB and stage datadir
         run: |
           PG_BIN=$(ls -d /usr/lib/postgresql/*/bin | sort -V | tail -1)
-          "$PG_BIN/pg_ctl" -D /home/runner/pgdata -m fast -w stop || true
+          # Clean shutdown so the baked datadir is consistent. Do NOT swallow a failed stop with
+          # `|| true`: moving and tarring a still-running cluster ships a torn datadir the shards
+          # cannot crash-recover (full_page_writes is off). Fail the job instead — mirrors the
+          # MariaDB sister's "don't bake a dirty datadir" guard.
+          "$PG_BIN/pg_ctl" -D /home/runner/pgdata -m fast -w stop
           mv /home/runner/pgdata /home/runner/frappe-bench/pgdata
 
       - name: Package bench for test shards


### PR DESCRIPTION
## Why

Follow-up to the CI fan-out sisters #56408 (Postgres) and #56410 (MariaDB). A review of both surfaced two issues in the Postgres path; this fixes the actionable ones.

### 1. `Stop DB and stage datadir` swallowed a failed Postgres shutdown

The setup job stops Postgres, then moves + tars the `PGDATA` into the bench artifact that **all four test shards** consume:

```bash
"$PG_BIN/pg_ctl" -D /home/runner/pgdata -m fast -w stop || true
mv /home/runner/pgdata /home/runner/frappe-bench/pgdata
```

The `|| true` masks a failed/timed-out stop, so a *still-running* cluster gets moved and tarred — shipping a torn, crash-inconsistent datadir to every shard. Because `full_page_writes` is off (durability tuned away for CI speed), crash recovery on the shard can't repair torn pages → corrupt reads or a refusal to start, on all shards at once, with no clear error.

The **MariaDB sister job already guards against exactly this** ([server-tests-mariadb.yml](https://github.com/frappe/erpnext/blob/develop/.github/workflows/server-tests-mariadb.yml)): it polls the pidfile and **hard-fails** if the server didn't stop before staging ("Don't bake a dirty datadir"). The Postgres path simply lost that guard.

**Fix:** drop the `|| true`. `pg_ctl -w stop` already waits for completion, so its non-zero exit now fails the job under `set -e` instead of baking a bad artifact.

### 2. Redundant `ALTER SYSTEM` durability block in `install.sh`

#56410 re-added this to the Postgres branch of `install.sh`:

```bash
# ... The postgres workflow runs a service-container DB and never calls start-db.sh,
# so the flags must be applied here.
psql ... -c "ALTER SYSTEM SET synchronous_commit='off'" -c "ALTER SYSTEM SET fsync='off'" ...
```

The justifying comment is **factually wrong**: the Postgres workflow runs in-runner via `start-db.sh` (there is no service container), and `start-db.sh` already sets `fsync` / `synchronous_commit` / `full_page_writes` off via its `-o` flags on **every** Postgres start — the setup job and each shard. The `ALTER SYSTEM` block was therefore a no-op. Removed, with a short note so it isn't re-added.

## What I did **not** change

The review flagged several lower-severity items in the shared scripts that work correctly in practice; I left them to keep this PR tight and low-risk:

- **`start-db.sh` unquoted `$PGDATA` inside the `-o` options string** — only breaks for a datadir path containing a space; CI paths never do.
- **redis-port readiness regex `:(\d+)`** (`hydrate.sh` / `install.sh`) — only matches `host:port` values; frappe always writes that form.
- **Concurrency group collapses to a constant for scheduled runs** — benign with a daily cadence.
- **Warm-bench cache-key fragility / `paths-ignore` dropping `**.css`/`**.svg`** — cosmetic / wasted-CI only.

(The `run_ci_step` `set -e` exit-code bug from the original #56408 was already fixed by #56410.)

## Risk

Both changes are safe-by-construction: #1 only changes behavior when a stop *fails* (turning silent corruption into a clear job failure), and #2 removes a verified no-op. No shard, MariaDB, or `patch.yml` path is affected.