### PR TITLE
fix: don't attempt to create SABB for non-serialized / non-batch items

### DIFF
--- a/erpnext/stock/services/serial_batch_bundle_service.py
+++ b/erpnext/stock/services/serial_batch_bundle_service.py
@@ -176,7 +176,8 @@ class SerialBatchBundleService:
 			parent_details = self.get_parent_details_for_packed_items()
 
 		for row in self.doc.get(table_name):
-			if not self.is_serial_batch_item(row.get("rm_item_code") or row.item_code):
+			item_code = row.get("rm_item_code") or row.get("item_code")
+			if not item_code or not self.is_serial_batch_item(item_code):
 				continue
 
 			if (

--- a/erpnext/stock/services/serial_batch_bundle_service.py
+++ b/erpnext/stock/services/serial_batch_bundle_service.py
@@ -176,6 +176,9 @@ class SerialBatchBundleService:
 			parent_details = self.get_parent_details_for_packed_items()
 
 		for row in self.doc.get(table_name):
+			if not self.is_serial_batch_item(row.get("rm_item_code") or row.item_code):
+				continue
+
 			if (
 				not via_landed_cost_voucher
 				and row.serial_and_batch_bundle


### PR DESCRIPTION
### Problem 

Up to v14, we were able to (mis)use the _Serial No_ field in sales transactions (Delivery Note Item, Sales Invoice Item) to record custom number ranges on non-stock (non-serialized) items. In v15 these transactions started failing.

### Analysis

ERPNext fails when legacy row `serial_no` text is converted into a **Serial and Batch Bundle**. There is no `has_serial_no` guard there. So any **Delivery Note Item** / stock-updating **Sales Invoice Item** with `serial_no` filled gets pushed into bundle creation.

### Fix

Skip old serial/batch field bundle creation for items that are not serialised or batch-tracked.

### Comment

I know our use-case is not intended, but on the other hand it also doesn't seem correct that ERPNext fails for the current reasons.

Ref: LAN-906