### PR TITLE
fix(journal-entry): fetch outstanding on foreign currency

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -2525,9 +2525,7 @@ def get_reference_details(
 			exchange_rate = get_exchange_rate(party_account_currency, company_currency, ref_doc.posting_date)
 		else:
 			exchange_rate = 1
-			outstanding_amount, total_amount = get_outstanding_on_journal_entry(
-				reference_name, party_type, party
-			)
+		outstanding_amount, total_amount = get_outstanding_on_journal_entry(reference_name, party_type, party)
 
 	elif reference_doctype == "Payment Entry":
 		if reverse_payment_details := frappe.db.get_all(


### PR DESCRIPTION
**Description:**
The outstanding and total amounts are not fetched in the Payment Entry for a multicurrency Journal Entry when the payment reference is selected manually.

**Resolves:** #55912

**Before:**
<img width="1847" height="859" alt="telegram-cloud-document-5-6204053724764057161" src="https://github.com/user-attachments/assets/e8174056-5831-4f27-94b7-62cc15e568bf" />

**After:**
<img width="1849" height="833" alt="telegram-cloud-document-5-6204053724764057165" src="https://github.com/user-attachments/assets/1262c27b-7837-44eb-b8c8-7f0d0d642822" />

