### PR TITLE
fix: remove translation for filter

### DIFF
--- a/erpnext/setup/doctype/global_defaults/global_defaults.js
+++ b/erpnext/setup/doctype/global_defaults/global_defaults.js
@@ -17,7 +17,7 @@ frappe.ui.form.on("Global Defaults", {
 			method: "frappe.client.get_list",
 			args: {
 				doctype: "UOM Conversion Factor",
-				filters: { category: __("Length") },
+				filters: { category: "Length" },
 				fields: ["to_uom"],
 				limit_page_length: 500,
 			},


### PR DESCRIPTION
**Description:**
When the language is set to a non-English language, the Default Distance Unit is translated, causing the dropdown in Global Defaults to remain empty.

**Resolves:** #56594

**Before:**
<img width="1360" height="855" alt="telegram-cloud-document-5-6204053724764057163" src="https://github.com/user-attachments/assets/6ee34d0b-e08c-48dd-9e77-6903272bf309" />


**After:**
<img width="1379" height="904" alt="telegram-cloud-document-5-6204053724764057164" src="https://github.com/user-attachments/assets/8864c04e-1067-43d5-859e-9d20a07e7d16" />

