### PR TITLE
fix(payment_entry): preserve exchange gain/loss on posting date change

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.js
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.js
@@ -754,7 +754,21 @@ frappe.ui.form.on("Payment Entry", {
 		frm.set_paid_amount_based_on_received_amount = true;
 		let company_currency = frappe.get_doc(":Company", frm.doc.company).default_currency;
 
-		if (frm.doc.paid_amount && frm.doc.source_exchange_rate) {
+		if (frm.events.has_allocated_references(frm) && frm.doc.payment_type == "Receive") {
+			// For a Receive against references, the party amount (`paid_amount`) is fixed by
+			// the reference allocations, so only re-value it at the new rate. Equalizing
+			// `base_received_amount` to `base_paid_amount` (the default sync below) would wipe a
+			// legitimate Exchange Gain/Loss whenever the rate is re-fetched, e.g. when the
+			// Posting Date is changed. This mirrors the server's set_amounts_in_company_currency.
+			frm.set_value(
+				"base_paid_amount",
+				flt(
+					flt(frm.doc.paid_amount) * flt(frm.doc.source_exchange_rate),
+					precision("base_paid_amount")
+				)
+			);
+			frm.events.set_total_allocated_amount(frm);
+		} else if (frm.doc.paid_amount && frm.doc.source_exchange_rate) {
 			frm.set_value("base_paid_amount", flt(frm.doc.paid_amount) * flt(frm.doc.source_exchange_rate));
 			frm.set_value("base_received_amount", frm.doc.base_paid_amount);
 
@@ -781,10 +795,33 @@ frappe.ui.form.on("Payment Entry", {
 		frm.set_df_property("source_exchange_rate", "read_only", erpnext.stale_rate_allowed() ? 0 : 1);
 	},
 
+	has_allocated_references: function (frm) {
+		// True when a cross-currency payment is settled against references, in which case the
+		// party amount is driven by the allocations rather than mirroring the other side.
+		return (
+			frm.doc.paid_from_account_currency != frm.doc.paid_to_account_currency &&
+			(frm.doc.references || []).some((row) => flt(row.allocated_amount))
+		);
+	},
+
 	target_exchange_rate: function (frm) {
 		let company_currency = frappe.get_doc(":Company", frm.doc.company).default_currency;
 
-		if (frm.doc.received_amount && frm.doc.target_exchange_rate) {
+		if (frm.events.has_allocated_references(frm) && frm.doc.payment_type == "Pay") {
+			// For a Pay against references, the party amount (`received_amount`) is fixed by
+			// the reference allocations, so only re-value it at the new rate. Equalizing
+			// `base_paid_amount` to `base_received_amount` (the default sync below) would wipe a
+			// legitimate Exchange Gain/Loss whenever the rate is re-fetched, e.g. when the
+			// Posting Date is changed. This mirrors the server's set_amounts_in_company_currency.
+			frm.set_value(
+				"base_received_amount",
+				flt(
+					flt(frm.doc.received_amount) * flt(frm.doc.target_exchange_rate),
+					precision("base_received_amount")
+				)
+			);
+			frm.events.set_total_allocated_amount(frm);
+		} else if (frm.doc.received_amount && frm.doc.target_exchange_rate) {
 			frm.set_value(
 				"base_received_amount",
 				flt(frm.doc.received_amount) * flt(frm.doc.target_exchange_rate)


### PR DESCRIPTION
## Problem

For a foreign-currency Payment Entry settled against a reference (e.g. an Import
Supplier paid against a Purchase Invoice), changing the **Posting Date**
re-fetches the exchange rate for the new date. The `target_exchange_rate` /
`source_exchange_rate` handlers then equalize the two base amounts
(`base_paid_amount = base_received_amount`), so `base_paid − base_received = 0`
and `set_exchange_gain_loss_deduction` deletes the **Exchange Gain/Loss** row
from the *Payment Deductions or Loss* table — even though the user never changed
any Currency Exchange rate.

### Steps to reproduce
1. Create a Purchase Invoice for a foreign-currency supplier (e.g. on 15-05).
2. Create a Payment Entry against it on a later date at the current rate, and save.
   The system correctly adds the Exchange Gain/Loss row.
3. Change the Posting Date → the Exchange Gain/Loss row disappears.

## Fix

When a cross-currency payment has allocated references, the party amount is
driven by the allocation, not by mirroring the other side. In that case re-value
only the party's base amount (`amount × new rate`) instead of equalizing the two
sides. This matches what the server already does in
`set_amounts_in_company_currency`, so the gain/loss is recalculated rather than
wiped. Reference-less (advance) cross-currency entries keep the existing sync
behaviour from #55270 / #56136.