### PR TITLE
refactor: auto commit on GL and ACB creation on process pcv

### DIFF
--- a/erpnext/accounts/doctype/process_period_closing_voucher/process_period_closing_voucher.py
+++ b/erpnext/accounts/doctype/process_period_closing_voucher/process_period_closing_voucher.py
@@ -424,6 +424,7 @@ def get_closing_account_closing_entry(closing_account_gle, pcv):
 
 def summarize_and_post_ledger_entries(docname):
 	# P&L accounts
+	frappe.db.auto_commit_on_many_writes = 1
 	pl_accounts_reverse_gle, closing_account_gle = get_gl_entries(docname)
 	gl_entries = pl_accounts_reverse_gle + closing_account_gle
 	from erpnext.accounts.general_ledger import make_gl_entries


### PR DESCRIPTION
Even with a higher timeout, if there are many ACB entries, framework terminates with "too many writes" error.

todo:

- [ ] add cleanup mechanism in case PCV error's out and auto commit leaves stale data