### PR TITLE
fix: handle None args in transaction_processing

### DIFF
--- a/erpnext/utilities/bulk_transaction.py
+++ b/erpnext/utilities/bulk_transaction.py
@@ -15,7 +15,7 @@ def transaction_processing(
 
 	deserialized_data = frappe.parse_json(data)
 
-	args = frappe._dict(frappe.parse_json(args))
+	args = frappe._dict(frappe.parse_json(args) or {})
 
 	skipped_records = [d for d in deserialized_data if d.get("status") in ("On Hold", "Closed")]
 


### PR DESCRIPTION
`transaction_processing` crashed with `TypeError: 'NoneType' object is not iterable` when called without `args`, because `frappe._dict(frappe.parse_json(None))` evaluates to `frappe._dict(None)`.

Guards the `parse_json` result with `or {}` so a missing `args` defaults to an empty dict.

<img width="1024" height="603" alt="imageb4a801" src="https://github.com/user-attachments/assets/65e1d950-989a-4777-959b-86556bcc85d1" />