### PR TITLE
fix: recompute transferred qty before deciding work order status 

### DIFF
--- a/erpnext/manufacturing/doctype/work_order/services/required_items.py
+++ b/erpnext/manufacturing/doctype/work_order/services/required_items.py
@@ -149,6 +149,16 @@ class RequiredItemsService:
 
 		self.recompute_material_transferred_for_manufacturing(transferred_items)
 
+	def refresh_material_transferred_for_manufacturing(self):
+		"""Recompute material_transferred_for_manufacturing only, without touching per-row
+		transferred_qty or stock reservations. Used to get a status decision (Not Started vs
+		In Process) based on fresh data, ahead of the fuller update_required_items() pass.
+		"""
+		if self.doc.skip_transfer:
+			return
+		transferred_items = self._material_transfer_qty_by_item(is_return=0)
+		self.recompute_material_transferred_for_manufacturing(transferred_items)
+
 	def recompute_material_transferred_for_manufacturing(self, transferred_items):
 		"""Set material_transferred_for_manufacturing based on actual item-level transfers, not fg_completed_qty."""
 		# When fg_completed_qty > 0 (direct stock entries, excess transfer), preserve the

--- a/erpnext/manufacturing/doctype/work_order/services/status.py
+++ b/erpnext/manufacturing/doctype/work_order/services/status.py
@@ -87,6 +87,12 @@ class StatusService:
 
 	def update_status(self, status=None):
 		"""Update status of work order if unknown"""
+		if self.doc.docstatus == 1:
+			# Refresh material_transferred_for_manufacturing before deciding status so pick-list-
+			# driven transfers (where this qty is derived from item transfers, not fg_completed_qty)
+			# are reflected immediately, instead of only after the next status update call.
+			self.doc.refresh_material_transferred_for_manufacturing()
+
 		if self.doc.status != "Closed":
 			if status not in ["Stopped", "Closed"]:
 				status = self.get_status(status)

--- a/erpnext/manufacturing/doctype/work_order/work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/work_order.py
@@ -1003,6 +1003,9 @@ class WorkOrder(Document):
 	def update_transferred_qty_for_required_items(self):
 		return RequiredItemsService(self).update_transferred_qty_for_required_items()
 
+	def refresh_material_transferred_for_manufacturing(self):
+		return RequiredItemsService(self).refresh_material_transferred_for_manufacturing()
+
 	def update_returned_qty(self):
 		return RequiredItemsService(self).update_returned_qty()
 


### PR DESCRIPTION
Issue: Work Order status stays "Not Started" after submitting a Stock Entry created via Pick List

Fixes: [#56596](https://github.com/frappe/erpnext/issues/56596)

Description:
When transferring raw materials for a Work Order using the Pick List flow (Transfer Material Against = "Work Order"), the Work Order status does not update to "In Process" after submitting the Material Transfer for Manufacture Stock Entry. As a result, the Finish button never appears on the Work Order.
The same flow works correctly when the Stock Entry is created directly from the Work Order using the Start button.

Steps to Reproduce:
1. Create a BOM for a finished good item with at least one raw material.
2. Create a Work Order → set Transfer Material Against to Work Order → Submit.
3. On the Work Order, click Create Pick List → enter the qty → save the Pick List that opens.
4. Submit the Pick List.
5. On the submitted Pick List, click Create Stock Entry → a Material Transfer for Manufacture SE opens.
6. Submit the Stock Entry.
7. Navigate back to the Work Order.

Backport Needed For V16 