### PR TITLE
fix(crm_settings): skip allowed users check when frappe crm is installed locally

### DIFF
--- a/erpnext/crm/doctype/crm_settings/crm_settings.js
+++ b/erpnext/crm/doctype/crm_settings/crm_settings.js
@@ -2,6 +2,35 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on("CRM Settings", {
-	// refresh: function(frm) {
-	// }
+	refresh: function (frm) {
+		const flag = frm.events.calculate_visiblity_flag(frm);
+
+		frm.set_df_property("allowed_users", "hidden", !flag);
+		frm.set_df_property("allowed_users", "reqd", flag);
+	},
+
+	enable_frappe_crm_data_synchronization: function (frm) {
+		const flag = frm.events.calculate_visiblity_flag(frm);
+
+		if (flag) {
+			frappe.show_alert(
+				__("Allowed Users is required for data synchronization from remote Frappe CRM site.")
+			);
+		}
+
+		/*
+		make allowed_users field visible and mandatory if enable_frappe_crm_data_synchronization
+		is set and crm app is not installed.
+		*/
+
+		frm.set_df_property("allowed_users", "hidden", !flag);
+		frm.set_df_property("allowed_users", "reqd", flag);
+	},
+
+	calculate_visiblity_flag: function (frm) {
+		const crm_sync_enabled = frm.doc.enable_frappe_crm_data_synchronization;
+		const is_crm_installed = cint(frappe.utils.get_installed_apps().includes("crm"));
+
+		return crm_sync_enabled && !is_crm_installed;
+	},
 });

--- a/erpnext/crm/doctype/crm_settings/crm_settings.json
+++ b/erpnext/crm/doctype/crm_settings/crm_settings.json
@@ -120,9 +120,9 @@
    "fieldtype": "Column Break"
   },
   {
-   "depends_on": "eval:doc.enable_frappe_crm_data_synchronization === 1;",
    "fieldname": "allowed_users",
    "fieldtype": "Table MultiSelect",
+   "hidden": 1,
    "label": "Allowed Users",
    "options": "Frappe CRM Allowed User",
    "permlevel": 1
@@ -140,7 +140,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2026-06-22 01:26:13.474915",
+ "modified": "2026-07-01 01:09:16.461470",
  "modified_by": "Administrator",
  "module": "CRM",
  "name": "CRM Settings",

--- a/erpnext/crm/doctype/crm_settings/crm_settings.py
+++ b/erpnext/crm/doctype/crm_settings/crm_settings.py
@@ -6,6 +6,8 @@ from frappe import _
 from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
 from frappe.model.document import Document
 
+from erpnext.crm.frappe_crm_api import is_crm_installed
+
 
 class CRMSettings(Document):
 	# begin: auto-generated types
@@ -46,12 +48,15 @@ class CRMSettings(Document):
 			)
 
 	def validate_allowed_users(self):
-		if self.enable_frappe_crm_data_synchronization and not self.allowed_users:
+		if self.enable_frappe_crm_data_synchronization and not (is_crm_installed() or self.allowed_users):
 			frappe.throw(
 				_(
 					"Please add at least one user on Allowed Users to allow Data Synchronization from Frappe CRM site."
 				)
 			)
+
+		if self.enable_frappe_crm_data_synchronization and is_crm_installed() and self.allowed_users:
+			frappe.throw(_("Allowed Users is not required as Frappe CRM is already installed on the site."))
 
 	def before_save(self):
 		self.clear_allowed_users()

--- a/erpnext/crm/frappe_crm_api.py
+++ b/erpnext/crm/frappe_crm_api.py
@@ -152,7 +152,9 @@ def create_customer(customer_data: dict | None = None):
 			for field in CUSTOMER_ALLOWED_FIELDS:
 				if customer_data.get(field) is not None:
 					customer.set(field, customer_data.get(field))
-			customer.insert(ignore_permissions=True)
+
+			# If CRM is installed on the site, User Permission cannot be ignored while saving Customer Records.
+			customer.insert(ignore_permissions=not is_crm_installed())
 			customer_name = customer.name
 	except Exception:
 		frappe.db.rollback()
@@ -183,6 +185,10 @@ def validate_frappe_crm_sync():
 			_("Frappe CRM data synchronization is not enabled on ERPNext. Contact System Manager of ERPNext.")
 		)
 
+	# Skip allowed_users validation if CRM is installed on the site.
+	if is_crm_installed():
+		return
+
 	allowed_users = [d.user for d in CRMSettings.allowed_users]
 
 	if frappe.session.user not in allowed_users:
@@ -192,3 +198,7 @@ def validate_frappe_crm_sync():
 			),
 			exc=frappe.PermissionError,
 		)
+
+
+def is_crm_installed():
+	return "crm" in frappe.get_installed_apps()

--- a/erpnext/crm/frappe_crm_api.py
+++ b/erpnext/crm/frappe_crm_api.py
@@ -206,22 +206,28 @@ def is_crm_installed():
 
 
 def remove_allowed_users_on_crm_install():
-	CRMSettings = frappe.get_single("CRM Settings")
+	try:
+		CRMSettings = frappe.get_single("CRM Settings")
 
-	if not CRMSettings.enable_frappe_crm_data_synchronization:
-		return
+		if not CRMSettings.enable_frappe_crm_data_synchronization:
+			return
 
-	CRMSettings.allowed_users = []
-	CRMSettings.save()
-	click.secho("Removed Allowed Users from CRM Settings.")
+		CRMSettings.allowed_users = []
+		CRMSettings.save()
+		click.secho("Removed 'Allowed Users' from CRM Settings.")
+	except Exception:
+		click.secho("'Allowed Users' from CRM Settings couldn't be cleared.")
 
 
 def disable_frappe_crm_data_synchronization_on_crm_uninstall():
-	CRMSettings = frappe.get_single("CRM Settings")
+	try:
+		CRMSettings = frappe.get_single("CRM Settings")
 
-	if not CRMSettings.enable_frappe_crm_data_synchronization:
-		return
+		if not CRMSettings.enable_frappe_crm_data_synchronization:
+			return
 
-	CRMSettings.enable_frappe_crm_data_synchronization = 0
-	CRMSettings.save()
-	click.secho("Enable Frappe CRM Data Synchronization on CRM Settings has been disabled.")
+		CRMSettings.enable_frappe_crm_data_synchronization = 0
+		CRMSettings.save()
+		click.secho("'Enable Frappe CRM Data Synchronization' on CRM Settings has been disabled.")
+	except Exception:
+		click.secho("'Enable Frappe CRM Data Synchronization' on CRM Settings could not be disabled.")

--- a/erpnext/crm/frappe_crm_api.py
+++ b/erpnext/crm/frappe_crm_api.py
@@ -1,5 +1,6 @@
 import json
 
+import click
 import frappe
 from frappe import _
 
@@ -202,3 +203,25 @@ def validate_frappe_crm_sync():
 
 def is_crm_installed():
 	return "crm" in frappe.get_installed_apps()
+
+
+def remove_allowed_users_on_crm_install():
+	CRMSettings = frappe.get_single("CRM Settings")
+
+	if not CRMSettings.enable_frappe_crm_data_synchronization:
+		return
+
+	CRMSettings.allowed_users = []
+	CRMSettings.save()
+	click.secho("Removed Allowed Users from CRM Settings.")
+
+
+def disable_frappe_crm_data_synchronization_on_crm_uninstall():
+	CRMSettings = frappe.get_single("CRM Settings")
+
+	if not CRMSettings.enable_frappe_crm_data_synchronization:
+		return
+
+	CRMSettings.enable_frappe_crm_data_synchronization = 0
+	CRMSettings.save()
+	click.secho("Enable Frappe CRM Data Synchronization on CRM Settings has been disabled.")

--- a/erpnext/hooks.py
+++ b/erpnext/hooks.py
@@ -65,6 +65,9 @@ setup_wizard_stages = "erpnext.setup.setup_wizard.setup_wizard.get_setup_stages"
 
 after_install = "erpnext.setup.install.after_install"
 
+after_app_install = "erpnext.setup.install.after_app_install"
+after_app_uninstall = "erpnext.setup.install.after_app_uninstall"
+
 boot_session = "erpnext.startup.boot.boot_session"
 notification_config = "erpnext.startup.notifications.get_notification_config"
 get_help_messages = "erpnext.utilities.activation.get_help_messages"

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -496,3 +496,4 @@ erpnext.patches.v16_0.backfill_pick_list_transferred_qty
 erpnext.patches.v16_0.create_shop_floor_roles
 erpnext.patches.v15_0.backfill_sla_link_filters_on_custom_field
 erpnext.patches.v15_0.backfill_sla_link_filters_on_docfield
+erpnext.patches.v16_0.crm_settings_handle_allowed_users_for_frappe_crm

--- a/erpnext/patches/v16_0/crm_settings_handle_allowed_users_for_frappe_crm.py
+++ b/erpnext/patches/v16_0/crm_settings_handle_allowed_users_for_frappe_crm.py
@@ -1,0 +1,10 @@
+import frappe
+
+
+def execute():
+	from erpnext.crm.frappe_crm_api import is_crm_installed, remove_allowed_users_on_crm_install
+
+	if not is_crm_installed():
+		return
+
+	remove_allowed_users_on_crm_install()

--- a/erpnext/setup/install.py
+++ b/erpnext/setup/install.py
@@ -417,3 +417,19 @@ DEFAULT_ROLE_PROFILES = {
 		"Purchase Manager",
 	],
 }
+
+
+def after_app_install(app_name=None):
+	if app_name == "crm":
+		from erpnext.crm.frappe_crm_api import remove_allowed_users_on_crm_install
+
+		remove_allowed_users_on_crm_install()
+
+
+def after_app_uninstall(app_name=None):
+	if app_name == "crm":
+		from erpnext.crm.frappe_crm_api import disable_frappe_crm_data_synchronization_on_crm_uninstall
+
+		disable_frappe_crm_data_synchronization_on_crm_uninstall()
+
+		frappe.db.commit()  # nosemgrep


### PR DESCRIPTION
The original implementation (#56268) assumed Frappe CRM is always running on a remote site. This PR handles the case where the CRM app is installed on the same ERPNext site, which changes validation requirements, permission behaviour, and introduces automatic settings cleanup on app install/uninstall.

Changes include:

- Introduces is_crm_installed() helper that checks whether the crm app is present on the same site, used across settings validation and the sync API.
- Skips allowed users requirement when CRM is installed locally — the allowed users list exists to authenticate requests from a remote Frappe CRM site; when CRM is on the same site, this restriction is unnecessary and is bypassed.
- Adds a reverse validation — if CRM is installed locally, filling in the Allowed Users table now raises a validation error, preventing misconfiguration.
- Respects user permissions on create_customer when CRM is local — previously ignore_permissions=True was unconditional; it is now only applied for remote site calls where permission context is unavailable.
- Moves allowed_users visibility to client script — the field is hidden by default and shown only when sync is enabled and CRM is not installed locally, replacing the static depends_on expression in the JSON with dynamic JS control.
- Registers after_app_install and after_app_uninstall hooks — when the crm app is installed on the site, the Allowed Users list is automatically cleared from CRM Settings since remote user authentication is no longer needed. When crm is uninstalled, the "Enable Frappe CRM Data Synchronization" toggle is automatically disabled to leave the settings in a clean state. Both hooks fail gracefully (logging via click.secho instead of raising) so a CRM Settings save issue never blocks app install/uninstall.
- Adds a migration patch (crm_settings_handle_allowed_users_for_frappe_crm) so existing sites where the crm app was already installed before this update also get their Allowed Users cleared out, keeping CRM Settings consistent without requiring manual cleanup.