### PR TITLE
fix: add unique tiebreakers to ORDER BY … LIMIT 1 picks for MariaDB↔Postgres parity

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -2795,6 +2795,9 @@ def get_open_payment_requests_for_references(references=None):
 		.where(PR.docstatus == 1)
 		.where(PR.outstanding_amount > 0)  # to avoid old PRs with 0 outstanding amount
 		.orderby(Coalesce(PR.transaction_date, PR.creation), order=frappe.qb.asc)
+		# unique tiebreaker so PRs sharing a transaction_date allocate in the same order on both engines
+		.orderby(PR.creation, order=frappe.qb.asc)
+		.orderby(PR.name, order=frappe.qb.asc)
 	).run(as_dict=True)
 
 	if not response:

--- a/erpnext/selling/page/point_of_sale/point_of_sale.py
+++ b/erpnext/selling/page/point_of_sale/point_of_sale.py
@@ -464,6 +464,9 @@ def set_customer_info(fieldname: str, customer: str, value: str = ""):
 					& (DynamicLink.link_doctype == "Customer")
 				)
 				.orderby(Contact.is_primary_contact, order=Order.desc)
+				# tiebreaker: contacts tie on is_primary_contact (the common no-primary case) ->
+				# pick the same one on MariaDB and Postgres
+				.orderby(DynamicLink.parent, order=Order.asc)
 			)
 
 			contacts = query.run(pluck=DynamicLink.parent)

--- a/erpnext/stock/doctype/packed_item/packed_item.py
+++ b/erpnext/stock/doctype/packed_item/packed_item.py
@@ -326,7 +326,8 @@ def update_packed_item_with_pick_list_info(main_item_row, pi_row):
 		},
 		["warehouse", "batch_no", "serial_no"],
 		as_dict=True,
-		order_by="qty desc",
+		# name tiebreaker: split pick-list rows can tie on qty -> pick the same warehouse/batch/serial on both engines
+		order_by="qty desc, name asc",
 	)
 
 	if not pl_row:

--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -1269,6 +1269,10 @@ def get_item_price(
 			& (IfNull(ip.valid_upto, "2500-12-31") >= pctx.transaction_date)
 		)
 
+	# Final unique tiebreaker: rows tied on every sort key above (same valid_from/batch/uom/party)
+	# would otherwise be picked arbitrarily -- MariaDB and Postgres can differ. Pin the pick.
+	query = query.orderby(ip.name, order=frappe.qb.desc)
+
 	return query.run(as_dict=True)
 
 


### PR DESCRIPTION
Four pre-existing `ORDER BY <non-unique col>` + single-row-pick sites (`LIMIT 1` / `[0]` / `get_value`) carry **no unique tiebreaker**. When rows tie on the ordered column, MariaDB and PostgreSQL are each free to return a different one, and the consumer reads a column that differs between the tied rows — a silent cross-engine divergence. Each fix appends a `name`/`creation` key so the pick is deterministic and identical on both engines. For *exact* ties MariaDB's current pick is already undefined, so **MariaDB output is preserved** (row count unchanged) — the same pattern as #56620.

One commit per file:

- **`fix(stock): get_item_price`** — ORDER BYs `valid_from/batch_no/uom/party` then `LIMIT 1`. Two Item Prices tied on all of those but with a different `price_list_rate` → **different price** across engines. Appends a `name` tiebreaker. *(The NULL-ordering axis here was already handled by `5fb16ca20c`; this closes the remaining tie axis.)*
- **`fix(accounts): get_open_payment_requests_for_references`** — orders by `Coalesce(transaction_date, creation)`, so when `transaction_date` is set the `creation` fallback never fires; PRs sharing a `transaction_date` had no tiebreaker → a **different Payment Request allocated first**. Appends `creation`, `name`.
- **`fix(stock): update_packed_item_with_pick_list_info`** — the Pick List Item `get_value` orders only by `qty desc`; a pick list legitimately holds multiple rows for one SO item split across warehouses/batches/serials that tie on `qty` → a **different warehouse/batch/serial** stamped onto the packed item. Adds `name asc`.
- **`fix(selling): POS customer contact`** — orders only by `is_primary_contact desc` then takes `contacts[0]`; contacts commonly tie (no primary set) → a **different contact** attached to the POS transaction. Adds a `parent` (contact name) tiebreaker.

Found by a cross-engine parity re-audit of the `ORDER BY … LIMIT 1` class (the sibling class to #56620, whose four sites are already merged and converged). All four are pre-existing and engine-agnostic in intent; the tiebreakers are deterministic no-ops on MariaDB for the exact-tie case. No behavioural change to non-tied rows.
