### PR TITLE
fix: scope three more Postgres txn-abort savepoints (fiscal year, Plaid sync, CRM customer)

### DIFF
--- a/erpnext/accounts/doctype/fiscal_year/fiscal_year.py
+++ b/erpnext/accounts/doctype/fiscal_year/fiscal_year.py
@@ -107,6 +107,9 @@ def auto_create_fiscal_year():
 	)
 
 	for d in fiscal_year:
+		# savepoint so a duplicate-year INSERT (Fiscal Year autoname=field:year) that aborts the
+		# statement doesn't poison the whole scheduler transaction on Postgres and kill the next iteration
+		frappe.db.savepoint("auto_create_fiscal_year")
 		try:
 			current_fy = frappe.get_doc("Fiscal Year", d[0])
 
@@ -127,7 +130,7 @@ def auto_create_fiscal_year():
 
 			new_fy.insert(ignore_permissions=True)
 		except frappe.NameError:
-			pass
+			frappe.db.rollback(save_point="auto_create_fiscal_year")
 
 
 def get_from_and_to_date(fiscal_year):

--- a/erpnext/crm/frappe_crm_api.py
+++ b/erpnext/crm/frappe_crm_api.py
@@ -154,15 +154,23 @@ def create_customer(customer_data: dict | None = None):
 					customer.set(field, customer_data.get(field))
 			customer.insert(ignore_permissions=True)
 			customer_name = customer.name
-
-		contacts = frappe.parse_json(customer_data.get("contacts"))
-		create_contacts(contacts, customer_name, "Customer", customer_name)
-		create_address("Customer", customer_name, customer_data.get("address"))
-		return customer_name
 	except Exception:
 		frappe.db.rollback()
 		frappe.log_error(frappe.get_traceback(), "Error while creating customer against Frappe CRM Deal")
-		pass
+		return
+
+	# Link contacts/address under a savepoint so a failure here does NOT discard the Customer just
+	# created (a full rollback would; MariaDB kept it pre-migration). Linking is best-effort.
+	frappe.db.savepoint("crm_customer_links")
+	try:
+		contacts = frappe.parse_json(customer_data.get("contacts"))
+		create_contacts(contacts, customer_name, "Customer", customer_name)
+		create_address("Customer", customer_name, customer_data.get("address"))
+	except Exception:
+		frappe.db.rollback(save_point="crm_customer_links")
+		frappe.log_error(frappe.get_traceback(), "Error while linking contacts/address to new Customer")
+
+	return customer_name
 
 
 def validate_frappe_crm_sync():

--- a/erpnext/crm/frappe_crm_api.py
+++ b/erpnext/crm/frappe_crm_api.py
@@ -169,6 +169,9 @@ def create_customer(customer_data: dict | None = None):
 	except Exception:
 		frappe.db.rollback(save_point="crm_customer_links")
 		frappe.log_error(frappe.get_traceback(), "Error while linking contacts/address to new Customer")
+		# keep the Customer, but preserve the pre-existing contract of returning None on a linking failure
+		# so CRM callers still see the failure signal
+		return
 
 	return customer_name
 

--- a/erpnext/erpnext_integrations/doctype/plaid_settings/plaid_settings.py
+++ b/erpnext/erpnext_integrations/doctype/plaid_settings/plaid_settings.py
@@ -215,7 +215,14 @@ def sync_transactions(bank, bank_account):
 		result = []
 		if transactions:
 			for transaction in reversed(transactions):
-				result += new_bank_transaction(transaction)
+				# per-transaction savepoint: a failed insert/submit must not discard the Bank
+				# Transactions already synced this run (MariaDB keeps them) nor poison the txn on Postgres
+				frappe.db.savepoint("plaid_sync_txn")
+				try:
+					result += new_bank_transaction(transaction)
+				except Exception:
+					frappe.db.rollback(save_point="plaid_sync_txn")
+					raise
 
 		if result:
 			last_transaction_date = frappe.db.get_value("Bank Transaction", result.pop(), "date")


### PR DESCRIPTION
Follow-up to the Postgres transaction-abort work (#56630 / #56622 / #56625). A parity re-audit of the catch-and-continue class surfaced three more `InFailedSqlTransaction` sites, each fixed here with a **correctly-scoped savepoint** — a strict no-op on MariaDB, recovering only the failed statement on Postgres. One commit per file.

**On Postgres a failed SQL statement poisons the whole transaction**, so the next DB call raises `InFailedSqlTransaction`; MariaDB has statement-level rollback and continues. The fix must roll back *only* the failed op — a full `frappe.db.rollback()` would additionally discard work the handler already committed, which MariaDB keeps.

- **`fix(accounts)` `fiscal_year.auto_create_fiscal_year`** — the daily scheduler loops creating next-year Fiscal Years (`autoname=field:year`); a duplicate-year INSERT aborts the statement, `except frappe.NameError: pass`, and the next iteration dies on Postgres. Per-iteration savepoint + `rollback(save_point=)`. No-op on MariaDB (same INSERT, same skip).
- **`fix(integrations)` `plaid_settings.sync_transactions`** — inserts+submits Bank Transactions in a loop in one txn; a failure poisons the txn so the `except`'s `log_error` dies on Postgres. Crucially MariaDB *keeps* the transactions synced before the failure, so a full rollback would change MariaDB — this uses a **per-transaction savepoint + re-raise**, preserving the partial-sync + stop-on-failure behaviour on both engines. (The sibling handlers `add_institution` / `add_bank_accounts` were fixed in #56630; this is the missed third one.)
- **`fix(crm)` `frappe_crm_api.create_customer`** — the try wrapped `customer.insert()` **+** `create_contacts()` **+** `create_address()` under a single full-rollback `except`, so a failure while linking contacts/address discarded the Customer just created (MariaDB kept it before the abort fix). Split the try: the customer insert keeps its full rollback (safe — nothing precedes it), and contact/address linking runs under a savepoint so its failure rolls back only the links and preserves the Customer.

### Deliberately not changed
Two other #56630 sites use a full `frappe.db.rollback()` in a batch background job — `bom_creator.create_boms` and `stock_closing_entry.prepare_closing_stock_balance`. These *do* discard partial records on a mid-batch failure, but there the atomic "roll back the incomplete batch and mark **Failed**" is the correct semantics (a partial BOM set / an incomplete stock closing is an invalid state), so they're intentionally left as-is. Noted here for the record.
