### PR TITLE
test(stock): fix Available Serial No fixture item-code case for Postgres

### DIFF
--- a/erpnext/stock/report/available_serial_no/test_available_serial_no.py
+++ b/erpnext/stock/report/available_serial_no/test_available_serial_no.py
@@ -21,7 +21,7 @@ class TestStockLedgerReeport(ERPNextTestSuite):
 			company="_Test Company",
 			from_date=today(),
 			to_date=add_days(today(), 30),
-			item_code="_Test Item With Serial No",
+			item_code="_Test Item with Serial No",
 		)
 
 	def test_available_serial_no(self):


### PR DESCRIPTION
`test_available_serial_no` sets up the item as **`_Test Item with Serial No`** (lowercase `w`, created + purchase-received + delivery-noted on lines 15/30/37) but points the report filter at **`_Test Item With Serial No`** (capital `W`, line 24).

The report runs `WHERE tabItem.name == item_code`:
- **MariaDB** — case-insensitive collation resolves the item, `data[-1]` has the expected 10/5 serial nos → green.
- **PostgreSQL** — case-sensitive, matches no item → `items=[]` → the `if items:` guard in `stock_ledger.py` silently **drops the item filter**, so the report returns serial-no rows for *every* item in the window, ordered `posting_datetime, creation` (no item tiebreaker) → `data[-1]` is order-dependent across the shared suite → a **flaky count** on Postgres.

Aligning the filter to the created item's case fixes the Postgres flake and is a **no-op on MariaDB** (which resolved it either way). One character.

Found by a cross-engine test-isolation re-audit (fixture-determinism class — same family as the earlier `make_workstation` lowercase-warehouse fix).
