### PR TITLE
fix(banking): handle blank password protected PDFs and negative amounts in CR/DR columns

### DIFF
--- a/erpnext/accounts/doctype/bank_statement_import_log/bank_statement_import_log.py
+++ b/erpnext/accounts/doctype/bank_statement_import_log/bank_statement_import_log.py
@@ -829,7 +829,9 @@ def compute_final_transactions(transaction_rows: list, date_format: str, amount_
 
 		if amount_format == 'Amount column has "CR"/"DR" values':
 			amount = transaction_row.get("amount")
-			float_amount = get_float_amount(amount)
+
+			# If the amount column has CR/DR in it - we should remove any signs (negative or positive) from the amount
+			float_amount = abs(get_float_amount(amount) or 0)
 			if "cr" in amount.lower():
 				return 0, float_amount
 			else:

--- a/erpnext/accounts/doctype/bank_statement_import_log/bank_statement_import_log.py
+++ b/erpnext/accounts/doctype/bank_statement_import_log/bank_statement_import_log.py
@@ -934,14 +934,18 @@ def extract_pdf_tables(content: bytes, password: str | None = None) -> list[dict
 	from pypdf import PdfReader
 
 	reader = PdfReader(io.BytesIO(content))
-	if reader.is_encrypted and (not password or not reader.decrypt(password)):
-		frappe.throw(
-			_(
-				"This PDF is password protected. Please set the correct statement password on the"
-				" Bank Account and try again."
-			),
-			title=_("Password Required"),
-		)
+	if reader.is_encrypted:
+		# Try opening the PDF with a password - if no password is provided, try with a blank password
+		if not password:
+			password = ""
+		if not reader.decrypt(password):
+			frappe.throw(
+				_(
+					"This PDF is password protected. Please set the correct statement password on the"
+					" Bank Account and try again."
+				),
+				title=_("Password Required"),
+			)
 
 	text_settings = {"vertical_strategy": "text", "horizontal_strategy": "text"}
 	tables = []


### PR DESCRIPTION
Two fixes in this PR:

1. Some statements have "CR"/"DR" in their amount columns + a sign (positive/negative). This PR avoids using the sign if CR/DR is there and just takes the absolute value of the amount.
2. Some PDF statements are password protected - but don't require a password (yes, weird). Apparently, we should try decrypting the PDF with a blank password and see if that works, lol. 

Closes #56600 

cc: @starktail-org

`no-docs`