### PR TITLE
ci(postgres): warm up test data before baking the datadir

### DIFF
--- a/.github/workflows/server-tests-postgres.yml
+++ b/.github/workflows/server-tests-postgres.yml
@@ -105,6 +105,11 @@ jobs:
           FRAPPE_BRANCH: develop
           BENCH_CACHE_DIR: /home/runner/bench-cache
 
+      - name: Warm up test data
+        run: |
+          cd ~/frappe-bench/
+          bench --site test_site run-tests --lightmode --module erpnext.tests.bootstrap_test_data
+
       - name: Stop DB and stage datadir
         run: |
           PG_BIN=$(ls -d /usr/lib/postgresql/*/bin | sort -V | tail -1)

--- a/.github/workflows/server-tests-postgres.yml
+++ b/.github/workflows/server-tests-postgres.yml
@@ -137,7 +137,7 @@ jobs:
           compression-level: 0
 
   test:
-    name: Python Unit Tests (PG)
+    name: Python Unit Tests
     needs: setup
     runs-on: ubuntu-latest
     timeout-minutes: 60


### PR DESCRIPTION
Mirrors frappe/erpnext#56655 (which did this for MariaDB) on the Postgres CI.

The setup job runs `erpnext.tests.bootstrap_test_data` while Postgres is still up, so the `BootStrapTestData` records land in the PGDATA that gets baked into the artifact. Every test shard then hydrates onto already-warmed data instead of rebuilding it.

Only difference from the MariaDB step: no `su -m "$ERPNEXT_CI_USER"` wrapper — Postgres CI is GitHub-hosted `ubuntu-latest` running as the runner user directly, matching its own "Run Tests" step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)