### PR TITLE
fix: prevent max recursion on supplier scorecard save

### DIFF
--- a/erpnext/buying/doctype/supplier_scorecard/supplier_scorecard.py
+++ b/erpnext/buying/doctype/supplier_scorecard/supplier_scorecard.py
@@ -55,8 +55,12 @@ class SupplierScorecard(Document):
 		self.update_standing()
 
 	def on_update(self):
-		score = make_all_scorecards(self.name)
-		if score > 0:
+		# Guard against recursion: the save() below re-enters on_update().
+		if self.flags.in_rescore:
+			return
+		if make_all_scorecards(self.name) > 0:
+			# New periods were created; re-save to refresh score and standings.
+			self.flags.in_rescore = True
 			self.save()
 
 	def validate_standings(self):

--- a/erpnext/buying/doctype/supplier_scorecard/supplier_scorecard.py
+++ b/erpnext/buying/doctype/supplier_scorecard/supplier_scorecard.py
@@ -61,7 +61,10 @@ class SupplierScorecard(Document):
 		if make_all_scorecards(self.name) > 0:
 			# New periods were created; re-save to refresh score and standings.
 			self.flags.in_rescore = True
-			self.save()
+			try:
+				self.save()
+			finally:
+				self.flags.in_rescore = False
 
 	def validate_standings(self):
 		# Standings must form a continuous chain of bands covering 0 to 100 with no gaps or overlaps


### PR DESCRIPTION
## Problem

`SupplierScorecard.on_update()` calls `self.save()`, and `save()` re-enters `on_update()` via `run_post_save_methods()`:

```
save()
 └─ run_post_save_methods()
     └─ on_update()
         └─ save()  ──┐
                      │
     ◄────────────────┘
```

This recurses indefinitely whenever `make_all_scorecards()` keeps returning a non-zero count of newly created periods, blowing the recursion limit.

## Fix

Guard the re-save with an `in_rescore` flag on the document. The nested `on_update()` short-circuits before recursing, while the outer re-save still runs the full `validate()` once to refresh the score and standings from the newly created periods.

Covered by the existing `test_make_all_scorecards_is_idempotent`, which exercises the `on_update` path on insert.

Fixes #22850

🤖 Generated with [Claude Code](https://claude.com/claude-code)