### PR TITLE
fix: validate reverse GL entries on current date under immutable ledger

### DIFF
--- a/erpnext/accounts/doctype/period_closing_voucher/test_period_closing_voucher.py
+++ b/erpnext/accounts/doctype/period_closing_voucher/test_period_closing_voucher.py
@@ -362,10 +362,13 @@ class TestPeriodClosingVoucher(ERPNextTestSuite):
 
 		frappe.db.set_value("Company", "Test PCV Company", "accounts_frozen_till_date", "2021-12-31")
 
-		make_reverse_gl_entries(
-			voucher_type="Journal Entry",
-			voucher_no=jv.name,
-		)
+		try:
+			make_reverse_gl_entries(
+				voucher_type="Journal Entry",
+				voucher_no=jv.name,
+			)
+		finally:
+			frappe.db.set_value("Company", "Test PCV Company", "accounts_frozen_till_date", None)
 
 		totals_after_cancel = frappe.get_all(
 			"GL Entry",

--- a/erpnext/accounts/doctype/period_closing_voucher/test_period_closing_voucher.py
+++ b/erpnext/accounts/doctype/period_closing_voucher/test_period_closing_voucher.py
@@ -360,11 +360,11 @@ class TestPeriodClosingVoucher(ERPNextTestSuite):
 
 		self.make_period_closing_voucher(posting_date="2021-03-31")
 
-		# Passed posting_date is after PCV end date, so cancellation should not fail.
+		frappe.db.set_value("Company", "Test PCV Company", "accounts_frozen_till_date", "2021-12-31")
+
 		make_reverse_gl_entries(
 			voucher_type="Journal Entry",
 			voucher_no=jv.name,
-			posting_date="2022-01-01",
 		)
 
 		totals_after_cancel = frappe.get_all(

--- a/erpnext/accounts/general_ledger.py
+++ b/erpnext/accounts/general_ledger.py
@@ -644,7 +644,7 @@ def make_reverse_gl_entries(
 		is_opening = any(d.get("is_opening") == "Yes" for d in gl_entries)
 
 		if immutable_ledger_enabled:
-			validation_date = frappe.form_dict.get("posting_date") or getdate()
+			validation_date = posting_date or frappe.form_dict.get("posting_date") or getdate()
 		else:
 			validation_date = posting_date if posting_date else gl_entries[0]["posting_date"]
 
@@ -717,7 +717,7 @@ def make_reverse_gl_entries(
 
 			if immutable_ledger_enabled:
 				new_gle["is_cancelled"] = 0
-				new_gle["posting_date"] = frappe.form_dict.get("posting_date") or getdate()
+				new_gle["posting_date"] = posting_date or frappe.form_dict.get("posting_date") or getdate()
 			elif posting_date:
 				new_gle["posting_date"] = posting_date
 

--- a/erpnext/accounts/general_ledger.py
+++ b/erpnext/accounts/general_ledger.py
@@ -640,13 +640,15 @@ def make_reverse_gl_entries(
 			partial_cancel=partial_cancel,
 		)
 		validate_accounting_period(gl_entries)
-		check_freezing_date(gl_entries[0]["posting_date"], gl_entries[0]["company"], adv_adj)
 
 		is_opening = any(d.get("is_opening") == "Yes" for d in gl_entries)
 
-		# For reverse entries, use the posting_date parameter if provided and valid
-		# Otherwise fall back to original posting_date
-		validation_date = posting_date if posting_date else gl_entries[0]["posting_date"]
+		if immutable_ledger_enabled:
+			validation_date = frappe.form_dict.get("posting_date") or getdate()
+		else:
+			validation_date = posting_date if posting_date else gl_entries[0]["posting_date"]
+
+		check_freezing_date(validation_date, gl_entries[0]["company"], adv_adj)
 		validate_against_pcv(is_opening, validation_date, gl_entries[0]["company"])
 
 		if partial_cancel:


### PR DESCRIPTION
**Issue**

When Immutable Ledger is enabled, the reverse GL entry is posted on the current date. But the closed-period checks in `make_reverse_gl_entries` (`check_freezing_date` and `validate_against_pcv`) still validate against the original (backdated) posting date of the entry being cancelled.

As a result, cancelling any backdated voucher whose original date falls in a closed period fails with a books-closed error, even though the reverse entry actually posts in an open (current) period.

PR #55268 corrected `validate_against_pcv` to use the passed posting date, but only when a posting date is supplied to `make_reverse_gl_entries`. The Journal Entry cancel path calls it without a posting date, so the check still falls back to the original date. `check_freezing_date` was also left validating against the original date.

**Fix**

In `make_reverse_gl_entries`, when Immutable Ledger is enabled, validate both `check_freezing_date` and `validate_against_pcv` against the current date, matching the date the reverse entry is posted on. When Immutable Ledger is disabled, behavior is unchanged.

**Tests**

Extended `test_immutable_ledger_reverse_entry_uses_passed_posting_date_after_pcv` to also set a freeze date and cancel without passing a posting date, so both the freeze-date and Period Closing Voucher checks are covered on cancellation.

Follow-up to #55268.

**Where this was hit**

In Frappe Lending, reposting a migrated NPA loan cancels a backdated accrual, which cascades into cancelling its suspense Journal Entry. With Immutable Ledger enabled, this failed with the books-closed error above, even though the reverse entry posts on the current date.

<img width="3534" height="1362" alt="image" src="https://github.com/user-attachments/assets/33a1ec5b-fc84-494a-bf81-298b8fab9954" />
