### PR TITLE
fix: don't treat batch slot at FIFO queue head as qty slot

### DIFF
--- a/erpnext/stock/report/stock_ageing/stock_ageing.py
+++ b/erpnext/stock/report/stock_ageing/stock_ageing.py
@@ -505,7 +505,7 @@ class FIFOSlots:
 			self._add_serial_fifo_slots(row, fifo_queue, serial_nos)
 		elif batch_nos and row.get("has_batch_no"):
 			self._add_batch_fifo_slots(row, fifo_queue, batch_nos)
-		elif fifo_queue and flt(fifo_queue[0][FIFO_QTY_INDEX]) <= 0:
+		elif fifo_queue and is_qty_slot(fifo_queue[0]) and flt(fifo_queue[0][FIFO_QTY_INDEX]) <= 0:
 			self._add_to_negative_fifo_head(row, fifo_queue)
 		else:
 			fifo_queue.append([flt(row.actual_qty), row.posting_date, flt(row.stock_value_difference)])

--- a/erpnext/stock/report/stock_ageing/test_stock_ageing.py
+++ b/erpnext/stock/report/stock_ageing/test_stock_ageing.py
@@ -1434,6 +1434,47 @@ class TestStockAgeing(ERPNextTestSuite):
 		self.assertEqual(item_result["total_qty"], -4.0)
 		self.assertEqual(item_result["fifo_queue"], [[batch_no, 1, -4.0, "2021-11-10", -40.0]])
 
+	def test_untagged_receipt_with_negative_batch_head(self):
+		"""An incoming SLE without batch details must not treat a negative
+		batch slot at the queue head as a qty slot (TypeError: str += float)."""
+		sle = [
+			frappe._dict(
+				name="Enclosure Item",
+				actual_qty=-10,
+				qty_after_transaction=-10,
+				stock_value_difference=-100,
+				warehouse="WH 1",
+				posting_date="2021-12-01",
+				voucher_type="Stock Entry",
+				voucher_no="001",
+				has_serial_no=False,
+				has_batch_no=True,
+				serial_no=None,
+				batch_no="QI-06448",
+			),
+			frappe._dict(
+				name="Enclosure Item",
+				actual_qty=45,
+				qty_after_transaction=35,
+				stock_value_difference=1051.65,
+				warehouse="WH 1",
+				posting_date="2021-12-05",
+				voucher_type="Purchase Receipt",
+				voucher_no="002",
+				has_serial_no=False,
+				serial_no=None,
+				batch_no=None,
+				serial_and_batch_bundle="SABB-00001294",
+			),
+		]
+
+		slots = FIFOSlots(self.filters, sle).generate()
+		queue = slots["Enclosure Item"]["fifo_queue"]
+
+		self.assertEqual(slots["Enclosure Item"]["total_qty"], 35.0)
+		self.assertEqual(queue[0][:3], ["QI-06448", None, -10.0])
+		self.assertEqual(queue[1], [45.0, "2021-12-05", 1051.65])
+
 	def test_batchwise_valuation_stock_reconciliation_with_bundle(self):
 		from frappe.utils import add_days, getdate, nowdate
 

--- a/erpnext/stock/report/stock_ageing/test_stock_ageing.py
+++ b/erpnext/stock/report/stock_ageing/test_stock_ageing.py
@@ -1472,7 +1472,7 @@ class TestStockAgeing(ERPNextTestSuite):
 		queue = slots["Enclosure Item"]["fifo_queue"]
 
 		self.assertEqual(slots["Enclosure Item"]["total_qty"], 35.0)
-		self.assertEqual(queue[0][:3], ["QI-06448", None, -10.0])
+		self.assertEqual(queue[0], ["QI-06448", None, -10.0, "2021-12-01", -100.0])
 		self.assertEqual(queue[1], [45.0, "2021-12-05", 1051.65])
 
 	def test_batchwise_valuation_stock_reconciliation_with_bundle(self):


### PR DESCRIPTION
## Problem

Stock Balance report (with *Show Stock Ageing Data*) crashes with:

```
TypeError: can only concatenate str (not "float") to str
```

in `FIFOSlots._add_to_negative_fifo_head`.

## RCA

FIFO queues mix slot shapes: plain qty slots are `[qty, date, value]`, batch slots are `[batch_no, use_batchwise_valuation, qty, date, value]` — a **string** at index 0.

Sequence that triggers it:

1. An outgoing batched SLE over-consumes stock, leaving a negative batch slot at the queue head, e.g. `['QI-06448', 0, -10.0, date, -10.0]`.
2. A later incoming SLE arrives with no resolvable serial/batch details (e.g. SLE lists passed to `FIFOSlots(filters, sle)` that lack `has_batch_no`, so bundle batch numbers are never fetched).
3. `_compute_incoming_stock` checks `flt(fifo_queue[0][FIFO_QTY_INDEX]) <= 0`. For the batch slot, index 0 is the batch number string; `flt('QI-06448')` silently returns `0.0`, the check wrongly passes, and `_add_to_negative_fifo_head` executes `str += float` → TypeError.

The sibling method `_add_transfer_slot_to_fifo_queue` already guards this exact case with `is_qty_slot(fifo_queue[0])`; this branch was missing the same guard.

## Fix

Guard the negative-head branch with `is_qty_slot`. When the head isn't a qty slot, the receipt appends a fresh qty slot (same behavior as the transfer path), leaving the negative batch slot to be neutralized by a later batch-tagged receipt.

## Test

`test_untagged_receipt_with_negative_batch_head` replicates the production sequence — fails with the exact TypeError before the fix, passes after. Full stock ageing suite (27 tests) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)