### PR TITLE
test: isolate Item-wise Consumption test with a unique item

### DIFF
--- a/erpnext/stock/report/item_wise_consumption/test_item_wise_consumption.py
+++ b/erpnext/stock/report/item_wise_consumption/test_item_wise_consumption.py
@@ -4,6 +4,7 @@
 import frappe
 
 from erpnext.stock.doctype.delivery_note.test_delivery_note import create_delivery_note
+from erpnext.stock.doctype.item.test_item import make_item
 from erpnext.stock.doctype.purchase_receipt.test_purchase_receipt import make_purchase_receipt
 from erpnext.stock.doctype.stock_entry.stock_entry_utils import make_stock_entry
 from erpnext.stock.report.item_wise_consumption.item_wise_consumption import execute
@@ -22,7 +23,9 @@ class TestItemWiseConsumption(ERPNextTestSuite):
 		return execute(filters)[1]
 
 	def test_consumed_vs_delivered_split(self):
-		item = "_Test Item"
+		# a uniquely-named item guarantees no residual stock/consumption from other
+		# tests leaks in -- the report aggregates an item across all warehouses.
+		item = make_item(properties={"is_stock_item": 1}).name
 		# purchase receipt gives the supplier mapping and stocks the item
 		make_purchase_receipt(
 			item_code=item,
@@ -41,5 +44,7 @@ class TestItemWiseConsumption(ERPNextTestSuite):
 		self.assertEqual(row[5], 400)  # consumed amount
 		self.assertEqual(row[6], 3)  # delivered qty
 		self.assertEqual(row[7], 300)  # delivered amount
-		self.assertEqual(row[8], 7)  # total qty
+		self.assertEqual(row[8], 7)  # total qty = consumed + delivered
+		self.assertEqual(row[9], 700)  # total amount = consumed + delivered amount
+		self.assertEqual(row[9], row[5] + row[7])  # total aggregates the two amounts
 		self.assertIn("_Test Supplier", row[10])


### PR DESCRIPTION
Follow-up to #56517, addressing Greptile review comments.

### Why
The report aggregates an item's consumption across **all** warehouses and vouchers with no per-test scoping. The test used the shared `_Test Item`, so any committed consumption of that item elsewhere in the database inflated the numbers — the consumed-qty assertion actually fails against a database that already holds other `_Test Item` issues.

### Fix
- Use a uniquely-named item (`make_item`) so there is no residual stock or consumption to leak in, making the qty/amount assertions deterministic.
- Assert the previously-unverified **Total Amount** column (`row[9]`), including that it equals consumed + delivered amount.

### How to test
Run the report after receiving an item, issuing part of it (Material Issue) and delivering part (Delivery Note); the consumed/delivered split and totals should match the postings.