### PR TITLE
test: isolate COGS By Item Group test with a dedicated item group

### DIFF
--- a/erpnext/stock/report/cogs_by_item_group/test_cogs_by_item_group.py
+++ b/erpnext/stock/report/cogs_by_item_group/test_cogs_by_item_group.py
@@ -27,7 +27,9 @@ class TestCogsByItemGroup(ERPNextTestSuite):
 		# test's COGS. The report sums COGS up the whole item-group tree keyed on the
 		# company's default expense account, so a shared group would accumulate COGS
 		# booked by any other test/fixture for the same company within the date range.
-		item_group = make_item_group("_Test COGS Item Group")
+		# The group name is unique per run so items created by earlier runs (which
+		# reuse a fixed group name) can't inflate the total either.
+		item_group = make_item_group(f"_Test COGS Item Group {frappe.generate_hash(length=6)}")
 		item = make_item(properties={"is_stock_item": 1, "item_group": item_group}).name
 
 		make_stock_entry(

--- a/erpnext/stock/report/cogs_by_item_group/test_cogs_by_item_group.py
+++ b/erpnext/stock/report/cogs_by_item_group/test_cogs_by_item_group.py
@@ -4,15 +4,18 @@
 import frappe
 
 from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_sales_invoice
+from erpnext.stock.doctype.item.test_item import make_item
 from erpnext.stock.doctype.stock_entry.stock_entry_utils import make_stock_entry
 from erpnext.stock.report.cogs_by_item_group.cogs_by_item_group import execute
 from erpnext.tests.utils import ERPNextTestSuite
+
+COMPANY = "_Test Company with perpetual inventory"
 
 
 class TestCogsByItemGroup(ERPNextTestSuite):
 	def run_report(self, **extra) -> list:
 		filters = frappe._dict(
-			company="_Test Company with perpetual inventory",
+			company=COMPANY,
 			from_date="2026-01-01",
 			to_date="2026-12-31",
 		)
@@ -20,16 +23,19 @@ class TestCogsByItemGroup(ERPNextTestSuite):
 		return execute(filters)[1]
 
 	def test_cogs_for_item_group(self):
-		# Reuse the bootstrap item `_Test Item` (item group `_Test Item Group`).
-		# It has zero stock in `Stores - TCP1`, so this receipt starts from a clean balance.
-		item = "_Test Item"
+		# A dedicated item group with a single item keeps `agg_value` scoped to this
+		# test's COGS. The report sums COGS up the whole item-group tree keyed on the
+		# company's default expense account, so a shared group would accumulate COGS
+		# booked by any other test/fixture for the same company within the date range.
+		item_group = make_item_group("_Test COGS Item Group")
+		item = make_item(properties={"is_stock_item": 1, "item_group": item_group}).name
 
 		make_stock_entry(
 			item_code=item,
 			to_warehouse="Stores - TCP1",
 			qty=10,
 			rate=100,
-			company="_Test Company with perpetual inventory",
+			company=COMPANY,
 			posting_date="2026-06-01",
 		)
 
@@ -40,7 +46,7 @@ class TestCogsByItemGroup(ERPNextTestSuite):
 			qty=4,
 			rate=150,
 			warehouse="Stores - TCP1",
-			company="_Test Company with perpetual inventory",
+			company=COMPANY,
 			update_stock=1,
 			cost_center="Main - TCP1",
 			parent_cost_center="Main - TCP1",
@@ -51,7 +57,20 @@ class TestCogsByItemGroup(ERPNextTestSuite):
 		)
 
 		data = self.run_report()
-		rows = [row for row in data if "_Test Item Group" in row.get("item_group")]
-		self.assertTrue(rows, "No row found for _Test Item Group")
+		rows = [row for row in data if item_group in row.get("item_group")]
+		self.assertTrue(rows, "No row found for the dedicated item group")
 		# 4 units delivered at 100 valuation rate -> 400 COGS.
 		self.assertEqual(rows[0].get("cogs_debit"), 400)
+
+
+def make_item_group(name: str) -> str:
+	if not frappe.db.exists("Item Group", name):
+		frappe.get_doc(
+			{
+				"doctype": "Item Group",
+				"item_group_name": name,
+				"parent_item_group": "All Item Groups",
+				"is_group": 0,
+			}
+		).insert()
+	return name


### PR DESCRIPTION
Follow-up to #56542, addressing Greptile review comments.

### Why
The report sums COGS up the entire item-group tree, keyed on the company's default expense account, over the full date range — with no per-voucher scoping. The test used the shared `_Test Item` / `_Test Item Group`, so COGS booked by any other test or fixture for the same company within 2026 would accumulate into the asserted value.

### Fix
Use a dedicated item group containing a single uniquely-named item, so the asserted `cogs_debit` reflects only this test's Sales Invoice and can't be inflated by cross-test data.

### How to test
Receive an item into a perpetual-inventory warehouse, sell part of it via a Sales Invoice with update stock, and confirm the report shows the expected COGS against the item's group.