### PR TITLE
test: isolate Profitability Analysis tests from shared cost centers

### DIFF
--- a/erpnext/accounts/report/profitability_analysis/test_profitability_analysis.py
+++ b/erpnext/accounts/report/profitability_analysis/test_profitability_analysis.py
@@ -46,8 +46,9 @@ class TestProfitabilityAnalysis(ERPNextTestSuite):
 		)
 
 	def test_income_expense_and_gross_profit(self):
-		# bootstrap leaf cost center; clean of committed GL so exact assertions hold
-		cc = "_Test Cost Center - _TC"
+		# a dedicated leaf cost center keeps these exact assertions free of GL that
+		# other tests may book against a shared cost center in the same fiscal year
+		cc = self.make_cc("_Test PA Income Expense")
 		self.book_income(cc, 10000)
 		self.book_expense(cc, 4000)
 
@@ -74,7 +75,7 @@ class TestProfitabilityAnalysis(ERPNextTestSuite):
 		self.assertEqual(parent_row["gross_profit_loss"], 7000)
 
 	def test_date_range_excludes_out_of_period_entries(self):
-		cc = "_Test Cost Center 2 - _TC"
+		cc = self.make_cc("_Test PA Date Range")
 		self.book_income(cc, 10000, posting_date="2025-06-01")
 
 		# the 2025 income must not appear in a 2026 report (zero-value rows are dropped)
@@ -97,7 +98,8 @@ class TestProfitabilityAnalysis(ERPNextTestSuite):
 		data = self.run_report()
 		# the report appends a blank separator row and a totals row at the end
 		total_row = data[-1]
-		self.assertEqual(total_row["account"], "'Total'")
+		# the report wraps the (possibly translated) "Total" label in single quotes
+		self.assertEqual(total_row["account"], "'" + frappe._("Total") + "'")
 		# total is built from direct (non-accumulated) values, so it stays internally consistent
 		self.assertEqual(total_row["gross_profit_loss"], total_row["income"] - total_row["expense"])
 		# and it includes this test's bookings


### PR DESCRIPTION
Follow-up to #56508, addressing Greptile review comments.

### Why
Two tests asserted exact income/expense against shared cost centers (`_Test Cost Center - _TC`, `_Test Cost Center 2 - _TC`) for fiscal year 2026. Other tests in the suite book GL entries against those same cost centers in the same year, which would inflate the accumulated income and break both the strict `assertEqual` and the `assertNotIn` date-range check. The totals-row assertion also compared against a hard-coded `'Total'`, which fails in non-English locales.

### Fix
- Use dedicated, uniquely-named leaf cost centers for the income/expense and date-range tests (same pattern already used by the parent/child test).
- Compare the totals-row label against `frappe._("Total")` so it holds under any locale.

### How to test
Run Profitability Analysis (based on Cost Center) for a fiscal year; income, expense and gross profit per cost center and the totals row should match the booked entries.