### PR TITLE
test: zero pre-committed actuals in Budget Variance report tests

### DIFF
--- a/erpnext/accounts/report/budget_variance_report/test_budget_variance_report.py
+++ b/erpnext/accounts/report/budget_variance_report/test_budget_variance_report.py
@@ -4,7 +4,7 @@
 import frappe
 from frappe.utils import nowdate
 
-from erpnext.accounts.doctype.budget.test_budget import make_budget
+from erpnext.accounts.doctype.budget.test_budget import make_budget, set_total_expense_zero
 from erpnext.accounts.doctype.journal_entry.test_journal_entry import make_journal_entry
 from erpnext.accounts.report.budget_variance_report.budget_variance_report import execute
 from erpnext.accounts.utils import get_fiscal_year
@@ -33,7 +33,12 @@ class TestBudgetVarianceReport(ERPNextTestSuite):
 		return execute(filters)[1]
 
 	def report_row(self, data, dimension, account=ACCOUNT):
-		return next(row for row in data if row["budget_against"] == dimension and row["account"] == account)
+		row = next(
+			(r for r in data if r["budget_against"] == dimension and r["account"] == account),
+			None,
+		)
+		self.assertIsNotNone(row, f"No report row for {dimension} / {account}")
+		return row
 
 	def field(self, label):
 		return frappe.scrub(f"{label} {self.fy}")
@@ -55,6 +60,8 @@ class TestBudgetVarianceReport(ERPNextTestSuite):
 		self.assertTrue(columns)
 
 	def test_budget_amount_shown_with_zero_actual(self):
+		# neutralise any committed actuals so the exact Actual/Variance assertions hold
+		set_total_expense_zero(nowdate(), "cost_center")
 		make_budget(
 			budget_against="Cost Center", cost_center=COST_CENTER, budget_amount=120000, submit_budget=1
 		)
@@ -65,6 +72,9 @@ class TestBudgetVarianceReport(ERPNextTestSuite):
 		self.assertEqual(row[self.field("Variance")], 120000)
 
 	def test_actual_expense_updates_actual_and_variance(self):
+		# zero out pre-committed actuals: keeps Actual exact and avoids the budget's
+		# "Stop" action rejecting the journal entry when prior actuals already exist
+		set_total_expense_zero(nowdate(), "cost_center")
 		make_budget(
 			budget_against="Cost Center", cost_center=COST_CENTER, budget_amount=120000, submit_budget=1
 		)
@@ -88,6 +98,8 @@ class TestBudgetVarianceReport(ERPNextTestSuite):
 		self.assertEqual(dimensions, {COST_CENTER})
 
 	def test_monthly_period_totals(self):
+		# zero out pre-committed actuals so total_actual reflects only this test's entry
+		set_total_expense_zero(nowdate(), "cost_center")
 		make_budget(
 			budget_against="Cost Center", cost_center=COST_CENTER, budget_amount=120000, submit_budget=1
 		)


### PR DESCRIPTION
Follow-up to #56507, addressing Greptile review comments.

### Why
Three tests assert exact **Actual** figures (0 / 50000) without first zeroing any pre-committed GL entries for `_Test Account Cost for Goods Sold - _TC` / `_Test Cost Center - _TC`. If such entries survive into the run, the report picks them up through the budget's JOIN and the assertions fail. Worse, `make_budget` sets `action_if_annual_budget_exceeded = "Stop"`, so pre-existing actuals above the budget make the 50000 journal entry raise `BudgetError` before any assertion runs.

### Fix
- Call `set_total_expense_zero(nowdate(), "cost_center")` before `make_budget` in the three exact-Actual tests — the same guard `test_budget.py` uses — so actuals start from a known zero within the transaction.
- `report_row` now uses `next(..., None)` and asserts the row exists, giving a clear failure instead of an opaque `StopIteration`.

### How to test
Run Budget Variance Report for a cost center with a submitted budget and a booked expense; Budget, Actual and Variance should match the entered amounts.