### PR TITLE
test: cover inconsistent balance detection in Incorrect Balance Qty report

### DIFF
--- a/erpnext/stock/report/incorrect_balance_qty_after_transaction/test_incorrect_balance_qty_after_transaction.py
+++ b/erpnext/stock/report/incorrect_balance_qty_after_transaction/test_incorrect_balance_qty_after_transaction.py
@@ -3,6 +3,7 @@
 
 import frappe
 
+from erpnext.stock.doctype.item.test_item import make_item
 from erpnext.stock.doctype.stock_entry.stock_entry_utils import make_stock_entry
 from erpnext.stock.report.incorrect_balance_qty_after_transaction.incorrect_balance_qty_after_transaction import (
 	execute,
@@ -27,6 +28,30 @@ class TestIncorrectBalanceQtyAfterTransaction(ERPNextTestSuite):
 		data = self.run_report(item_code=item)
 		flagged = [row for row in data if row.get("item_code") == item]
 		self.assertEqual(flagged, [])
+
+	def test_inconsistent_balance_qty_is_flagged(self):
+		# a unique item keeps this SLE the only ledger entry for the item/warehouse
+		item = make_item(properties={"is_stock_item": 1}).name
+		entry = make_stock_entry(
+			item_code=item, to_warehouse=WAREHOUSE, qty=10, rate=100, posting_date="2026-06-01"
+		)
+
+		# Corrupt the running balance so it no longer matches the cumulative actual_qty --
+		# exactly the inconsistency this report exists to detect. set_value bypasses the
+		# ledger recompute that would otherwise keep the two in sync.
+		sle_name = frappe.db.get_value(
+			"Stock Ledger Entry",
+			{"voucher_no": entry.name, "item_code": item, "warehouse": WAREHOUSE},
+			"name",
+		)
+		frappe.db.set_value("Stock Ledger Entry", sle_name, "qty_after_transaction", 5)
+
+		flagged = [row for row in self.run_report(item_code=item) if row.get("name") == sle_name]
+		self.assertEqual(len(flagged), 1, "The tampered stock ledger entry should be flagged")
+		row = flagged[0]
+		self.assertEqual(row["expected_balance_qty"], 10)  # cumulative actual_qty
+		self.assertEqual(row["qty_after_transaction"], 5)  # tampered balance
+		self.assertEqual(row["differnce"], 5)
 
 	def test_sequence_of_movements_not_flagged(self):
 		item = "_Test Item 2"


### PR DESCRIPTION
Follow-up to #56519, addressing a Greptile review comment.

### Why
The existing tests only confirmed that correctly-posted stock produces no flagged rows — an outcome guaranteed by ERPNext's own ledger engine. The report's core check (`abs(expected - actual) > 0.5`) was never actually triggered, so a regression that always returned an empty result would still pass.

### Fix
Add a negative-case test: post a receipt for a uniquely-named item, then tamper with the resulting Stock Ledger Entry's `qty_after_transaction` (via `db.set_value`, bypassing the recompute) so it diverges from the cumulative `actual_qty`. The test asserts the entry is flagged with the expected balance, tampered balance and difference.

### How to test
This exercises detection logic that only manifests on genuinely corrupt ledgers, so it's verified via the test. Functionally: the report lists any Stock Ledger Entry whose stored balance qty doesn't match the running total of movements.