### PR TITLE
fix(accounts): clear clearance date when amending reconciled voucher (backport #55947)

### DIFF
--- a/erpnext/accounts/doctype/bank_transaction/test_bank_transaction.py
+++ b/erpnext/accounts/doctype/bank_transaction/test_bank_transaction.py
@@ -115,6 +115,36 @@ class TestBankTransaction(FrappeTestCase):
 		self.assertEqual(bank_transaction.unallocated_amount, 1700)
 		self.assertEqual(bank_transaction.payment_entries, [])
 
+	# Amending a reconciled payment entry must not carry over its clearance date
+	def test_clearance_date_cleared_on_amend(self):
+		bank_transaction = frappe.get_doc(
+			"Bank Transaction",
+			dict(description="1512567 BG/000003025 OPSKATTUZWXXX AT776000000098709849 Herr G"),
+		)
+		payment = frappe.get_doc("Payment Entry", dict(party="Mr G", paid_amount=1700))
+		vouchers = json.dumps(
+			[
+				{
+					"payment_doctype": "Payment Entry",
+					"payment_name": payment.name,
+					"amount": bank_transaction.unallocated_amount,
+				}
+			]
+		)
+		reconcile_vouchers(bank_transaction.name, vouchers)
+
+		self.assertTrue(frappe.db.get_value("Payment Entry", payment.name, "clearance_date"))
+
+		payment.reload()
+		payment.cancel()
+
+		amended = frappe.copy_doc(payment)
+		amended.amended_from = payment.name
+		amended.docstatus = 0
+		amended.insert()
+
+		self.assertFalse(amended.clearance_date)
+
 	# Check if ERPNext can correctly filter a linked payments based on the debit/credit amount
 	def test_debit_credit_output(self):
 		bank_transaction = frappe.get_doc(

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -141,6 +141,26 @@ class AccountsController(TransactionBase):
 			if self.doctype in relevant_docs:
 				self.set_payment_schedule()
 
+	def before_insert(self):
+		self.clear_clearance_date_on_amend()
+
+	def clear_clearance_date_on_amend(self):
+		"""Drop the bank reconciliation clearance date copied over while amending.
+
+		The framework copies `no_copy` fields when amending, so a reconciled
+		voucher would carry a stale clearance date into its amendment even though
+		the linked bank transaction gets unreconciled on cancellation.
+		"""
+		if not self.get("amended_from"):
+			return
+
+		if self.meta.has_field("clearance_date"):
+			self.clearance_date = None
+
+		for payment in self.get("payments") or []:
+			if payment.meta.has_field("clearance_date"):
+				payment.clearance_date = None
+
 	def remove_bundle_for_non_stock_invoices(self):
 		has_sabb = False
 		if self.doctype in ("Sales Invoice", "Purchase Invoice") and not self.update_stock:


### PR DESCRIPTION
Fixes #54909
Backport of #55947 to `version-15-hotfix`.

> Replaces the Mergify auto-backport #55972, which committed unresolved merge-conflict markers into `accounts_controller.py` (it also pulled in develop-only code — `PaymentScheduleService` and an `on_update`/`process_item_wise_tax_details` hook — that does not exist in v15). This PR is a clean, manual backport.

## Problem

When a reconciled Payment Entry (or Journal Entry / Purchase Invoice / Sales Invoice) is cancelled, amended, and resubmitted, the **Clearance Date** field stays filled on the amended document, even though the linked Bank Transaction is unreconciled on cancellation. The clearance date should only be set when the voucher is reconciled again.

## Root cause

`clearance_date` is marked `no_copy: 1`, but the framework's amend logic intentionally **ignores** `no_copy` while amending, so the stale clearance date is copied into the amended draft.

## Fix

Added a shared `before_insert` hook on `AccountsController` that clears `clearance_date` (both the top-level field and the Sales Invoice `payments` child rows) when the document is an amendment. `before_insert` runs exactly once at amend-draft creation, so it never wipes a legitimately reconciled date later — reconciliation sets the value post-submit via `frappe.db.set_value`, which bypasses this path.

## Manual QA

1. Create a Payment Entry and a Bank Transaction.
2. Reconcile the Payment Entry with the Bank Transaction (clearance date gets set).
3. Cancel, then amend and submit the Payment Entry.
4. The amended Payment Entry's Clearance Date is now empty, and the Bank Transaction is unreconciled.