### PR TITLE
fix: restore Save button on reverse journal entry

### DIFF
--- a/erpnext/accounts/doctype/journal_entry/journal_entry.js
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.js
@@ -29,7 +29,7 @@ frappe.ui.form.on("Journal Entry", {
 
 	refresh(frm) {
 		if (frm.doc.reversal_of && (frm.is_new() || frm.doc.docstatus == 0)) {
-			frm.set_read_only();
+			erpnext.journal_entry.lock_reversal_entry(frm);
 		}
 
 		erpnext.toggle_naming_series();
@@ -230,6 +230,13 @@ Object.assign(erpnext.journal_entry, {
 		if (!frm.doc.amended_from) {
 			frm.set_value("posting_date", frm.doc.posting_date || frappe.datetime.get_today());
 		}
+	},
+
+	lock_reversal_entry(frm) {
+		frm.fields
+			.filter((field) => field.has_input)
+			.forEach((field) => frm.set_df_property(field.df.fieldname, "read_only", 1));
+		frm.set_df_property("accounts", "read_only", 1);
 	},
 
 	add_custom_buttons(frm) {


### PR DESCRIPTION
## Problem

Ticket #72857

Reversing a submitted Journal Entry (Actions > Reverse Journal Entry) opens a draft with `reversal_of` set. The form's `refresh` handler called `frm.set_read_only()` on that draft, which rebuilds `frm.perm` without the `write` and `submit` permissions. The toolbar checks those perms before rendering its primary action, so the Save button (and later the Submit button) never appeared and the reversal could not be saved.

## Fix

Lock the fields and the accounts grid as `read_only` instead of stripping permissions. The entry stays fully non-editable, but the `write` and `submit` perms are left intact so Save and then Submit work as expected. This follows Frappe's own `disable_form()` pattern without disabling save.

## How to test

1. Create and submit a Journal Entry.
2. Open it and click Actions > Reverse Journal Entry.
3. On the reversal draft, confirm every field and the accounts grid are read-only.
4. Confirm the Save button is present and that saving works.
5. After saving, confirm the Submit button appears and that submitting works.
6. Confirm the reversal mirrors the source with debits and credits swapped.