### PR TITLE
fix(payment reconciliation): read user permissions from current session user

### DIFF
--- a/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py
+++ b/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py
@@ -75,7 +75,10 @@ class PaymentReconciliation(Document):
 		self.accounting_dimension_filter_conditions = []
 		self.ple_posting_date_filter = []
 		self.dimensions = get_dimensions(with_cost_center_and_project=True)[0]
-		self.user_permissions = get_user_permissions(frappe.session.user)
+
+	@property
+	def user_permissions(self):
+		return get_user_permissions(frappe.session.user)
 
 	def load_from_db(self):
 		# 'modified' attribute is required for `run_doc_method` to work properly.


### PR DESCRIPTION
**Issue:**
self.user_permissions is captured once when the document object is created, but the reconciliation filters are applied later by methods like get_unreconciled_entries(). If the same document object is created before a frappe.set_user() change or reused after the session user changes, the new dimension filters run with the previous user's allowed values and can show or hide vouchers for the wrong user.

This issue is **mainly reproducible in scripts**, background jobs, or tests where the same object instance is reused across different users. It is generally **not visible in the UI** because a new object is created for each request.

**Impact:**
Users **may see payment and invoice entries that they do not have permission to access**, leading to incorrect reconciliation results and potential exposure of restricted records when the same object instance is reused across different users.