### PR TITLE
fix: display outstanding amount using company default currency

### DIFF
--- a/erpnext/accounts/doctype/opening_invoice_creation_tool_item/opening_invoice_creation_tool_item.json
+++ b/erpnext/accounts/doctype/opening_invoice_creation_tool_item/opening_invoice_creation_tool_item.json
@@ -82,6 +82,7 @@
    "fieldtype": "Currency",
    "in_list_view": 1,
    "label": "Outstanding Amount",
+   "options": "Company:company:default_currency",
    "reqd": 1
   },
   {
@@ -136,7 +137,7 @@
  ],
  "istable": 1,
  "links": [],
- "modified": "2026-04-29 17:08:15.617047",
+ "modified": "2026-07-02 15:17:11.938499",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Opening Invoice Creation Tool Item",


### PR DESCRIPTION
**Issue:**
The Outstanding Amount field in the Opening Invoice Creation Tool displays the Global Default Currency instead of the selected Company's default currency, resulting in incorrect currency symbols in multi-company environments.

**Ref:**[#72787](https://support.frappe.io/helpdesk/tickets/72787?view=VIEW-HD+Ticket-746)

**Before:**
<img width="800" height="402" alt="image" src="https://github.com/user-attachments/assets/924818ca-c4f6-49cb-b8e5-e197b68ffa3c" />

**After:**
<img width="1280" height="643" alt="image" src="https://github.com/user-attachments/assets/eec5f454-2968-435e-8ba1-9a7ecb87a951" />


Backport Needed v15 & v16

Raising this PR on behalf of @ssakthivelmurugan