### PR TITLE
test: Purchase Analytics report coverage

### DIFF
--- a/erpnext/buying/report/purchase_analytics/test_purchase_analytics.py
+++ b/erpnext/buying/report/purchase_analytics/test_purchase_analytics.py
@@ -1,0 +1,84 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and Contributors
+# See license.txt
+
+import frappe
+from frappe.utils import flt
+
+from erpnext.buying.doctype.purchase_order.test_purchase_order import create_purchase_order
+from erpnext.buying.report.purchase_analytics.purchase_analytics import execute
+from erpnext.tests.utils import ERPNextTestSuite
+
+COMPANY = "_Test Company"
+SUPPLIER = "_Test Supplier"
+SUPPLIER_GROUP = "_Test Supplier Group"
+# A historical window that ordinary test fixtures don't post into.
+FROM_DATE = "2019-04-01"
+TO_DATE = "2019-06-30"
+
+
+class TestPurchaseAnalytics(ERPNextTestSuite):
+	"""purchase_analytics reuses the shared Analytics engine; these tests lock its
+	wiring (doc_type=Purchase Order) across the Supplier Group / Item Group trees."""
+
+	def setUp(self):
+		frappe.set_user("Administrator")
+
+	def _filters(self, **overrides):
+		filters = {
+			"doc_type": "Purchase Order",
+			"value_quantity": "Value",
+			"range": "Monthly",
+			"company": COMPANY,
+			"from_date": FROM_DATE,
+			"to_date": TO_DATE,
+		}
+		filters.update(overrides)
+		return frappe._dict(filters)
+
+	def _rows(self, filters):
+		return {row["entity"]: row for row in execute(filters)[1]}
+
+	def make_po(self, qty=4, rate=250):
+		return create_purchase_order(
+			company=COMPANY, supplier=SUPPLIER, qty=qty, rate=rate, transaction_date="2019-04-10"
+		)
+
+	def test_supplier_group_tree_rolls_up_to_root(self):
+		filters = self._filters(tree_type="Supplier Group")
+		base = self._rows(filters)
+		base_group = flt(base.get(SUPPLIER_GROUP, {}).get("total", 0.0))
+
+		po = self.make_po(qty=4, rate=250)
+		rows = self._rows(filters)
+
+		# supplier is remapped to its group; the root sits at indent 0
+		self.assertIn(SUPPLIER_GROUP, rows)
+		self.assertIn("All Supplier Groups", rows)
+		self.assertNotIn(SUPPLIER, rows)
+		self.assertEqual(rows["All Supplier Groups"]["indent"], 0)
+
+		self.assertAlmostEqual(rows[SUPPLIER_GROUP]["total"] - base_group, flt(po.base_net_total), places=2)
+		self.assertGreaterEqual(flt(rows["All Supplier Groups"]["total"]), flt(po.base_net_total))
+
+	def test_item_group_tree_rolls_up_to_root(self):
+		item_group = frappe.db.get_value("Item", "_Test Item", "item_group")
+		filters = self._filters(tree_type="Item Group")
+		base = self._rows(filters)
+		base_group = flt(base.get(item_group, {}).get("total", 0.0))
+
+		po = self.make_po(qty=4, rate=250)
+		rows = self._rows(filters)
+
+		self.assertIn(item_group, rows)
+		self.assertIn("All Item Groups", rows)
+		self.assertAlmostEqual(rows[item_group]["total"] - base_group, flt(po.base_net_total), places=2)
+
+	def test_supplier_group_by_quantity(self):
+		filters = self._filters(tree_type="Supplier Group", value_quantity="Quantity")
+		base = self._rows(filters)
+		base_qty = flt(base.get(SUPPLIER_GROUP, {}).get("total", 0.0))
+
+		po = self.make_po(qty=7, rate=100)
+		rows = self._rows(filters)
+
+		self.assertAlmostEqual(rows[SUPPLIER_GROUP]["total"] - base_qty, flt(po.total_qty), places=2)

--- a/erpnext/buying/report/purchase_analytics/test_purchase_analytics.py
+++ b/erpnext/buying/report/purchase_analytics/test_purchase_analytics.py
@@ -71,14 +71,23 @@ class TestPurchaseAnalytics(ERPNextTestSuite):
 
 		self.assertIn(item_group, rows)
 		self.assertIn("All Item Groups", rows)
+		# the raw item code must not leak as its own entity; the root sits at indent 0
+		self.assertNotIn("_Test Item", rows)
+		self.assertEqual(rows["All Item Groups"]["indent"], 0)
 		self.assertAlmostEqual(rows[item_group]["total"] - base_group, flt(po.base_net_total), places=2)
+		self.assertGreaterEqual(flt(rows["All Item Groups"]["total"]), flt(po.base_net_total))
 
 	def test_supplier_group_by_quantity(self):
 		filters = self._filters(tree_type="Supplier Group", value_quantity="Quantity")
 		base = self._rows(filters)
 		base_qty = flt(base.get(SUPPLIER_GROUP, {}).get("total", 0.0))
+		base_root_qty = flt(base.get("All Supplier Groups", {}).get("total", 0.0))
 
 		po = self.make_po(qty=7, rate=100)
 		rows = self._rows(filters)
 
 		self.assertAlmostEqual(rows[SUPPLIER_GROUP]["total"] - base_qty, flt(po.total_qty), places=2)
+		# the quantity must roll up to the root too, not just the leaf group
+		self.assertAlmostEqual(
+			rows["All Supplier Groups"]["total"] - base_root_qty, flt(po.total_qty), places=2
+		)


### PR DESCRIPTION
Adds coverage for the **Purchase Analytics** report (which reuses the shared Analytics engine with doc_type = Purchase Order).

### Tests
- Supplier Group tree: a Purchase Order's value is remapped from supplier to its group and rolls up into the 'All Supplier Groups' root (root at indent 0, raw supplier not leaked).
- Item Group tree: the PO value lands under the item's group and rolls up to 'All Item Groups'.
- Quantity mode: the group total reflects the ordered quantity.

Assertions baseline the report before/after so pre-existing rows in the window don't affect them.

### How to test
Create Purchase Orders and open Purchase Analytics; switch Tree Type (Supplier/Supplier Group/Item/Item Group) and Value/Quantity to confirm the amounts and quantities roll up per tree.