### PR TITLE
fix: fetch exchange rate as on document date for Sales Invoice & Delivery Note

### DIFF
--- a/erpnext/selling/doctype/sales_order/mapper.py
+++ b/erpnext/selling/doctype/sales_order/mapper.py
@@ -272,6 +272,12 @@ def make_delivery_note(
 			# Skip pricing rule when the dn is creating from the pick list
 			target.ignore_pricing_rule = 1
 
+		# Always fetch the exchange rate as on the Delivery Note date instead of
+		# carrying it over from the Sales Order (the Delivery Note may be raised
+		# later, or multiple Sales Orders with different rates may be merged).
+		target.conversion_rate = 0.0
+		target.plc_conversion_rate = 0.0
+
 		target.run_method("set_missing_values")
 		target.run_method("set_po_nos")
 		target.run_method("calculate_taxes_and_totals")
@@ -454,6 +460,11 @@ def make_sales_invoice(
 
 	def set_missing_values(source, target):
 		target.flags.ignore_permissions = True
+		# Always fetch the exchange rate as on the Invoice date instead of
+		# carrying it over from the Sales Order (the Invoice may be raised much
+		# later, or multiple Sales Orders with different rates may be merged).
+		target.conversion_rate = 0.0
+		target.plc_conversion_rate = 0.0
 		target.run_method("set_missing_values")
 		target.run_method("set_po_nos")
 		target.run_method("calculate_taxes_and_totals")

--- a/erpnext/selling/doctype/sales_order/test_sales_order.py
+++ b/erpnext/selling/doctype/sales_order/test_sales_order.py
@@ -272,17 +272,21 @@ class TestSalesOrder(ERPNextTestSuite):
 			original_rate = frappe.db.get_value("Currency Exchange", exchange_name, "exchange_rate")
 			frappe.db.set_value("Currency Exchange", exchange_name, "exchange_rate", document_date_rate)
 		else:
-			exchange_name = frappe.get_doc(
-				{
-					"doctype": "Currency Exchange",
-					"from_currency": "USD",
-					"to_currency": "INR",
-					"date": nowdate(),
-					"exchange_rate": document_date_rate,
-					"for_selling": 1,
-					"for_buying": 1,
-				}
-			).insert().name
+			exchange_name = (
+				frappe.get_doc(
+					{
+						"doctype": "Currency Exchange",
+						"from_currency": "USD",
+						"to_currency": "INR",
+						"date": nowdate(),
+						"exchange_rate": document_date_rate,
+						"for_selling": 1,
+						"for_buying": 1,
+					}
+				)
+				.insert()
+				.name
+			)
 
 		try:
 			so = make_sales_order(currency="USD", do_not_save=True)

--- a/erpnext/selling/doctype/sales_order/test_sales_order.py
+++ b/erpnext/selling/doctype/sales_order/test_sales_order.py
@@ -255,6 +255,43 @@ class TestSalesOrder(ERPNextTestSuite):
 		si1 = make_sales_invoice(so.name)
 		self.assertEqual(len(si1.get("items")), 0)
 
+	def test_document_date_exchange_rate(self):
+		# The exchange rate as on the target document's own date, deliberately
+		# different from the rate stored on the Sales Order.
+		so_rate = 95.0
+		document_date_rate = 80.0
+
+		exchange_name = frappe.db.get_value(
+			"Currency Exchange",
+			{"from_currency": "USD", "to_currency": "INR", "date": nowdate(), "for_selling": 1},
+		)
+		if exchange_name:
+			frappe.db.set_value("Currency Exchange", exchange_name, "exchange_rate", document_date_rate)
+		else:
+			frappe.get_doc(
+				{
+					"doctype": "Currency Exchange",
+					"from_currency": "USD",
+					"to_currency": "INR",
+					"date": nowdate(),
+					"exchange_rate": document_date_rate,
+					"for_selling": 1,
+					"for_buying": 1,
+				}
+			).insert()
+
+		so = make_sales_order(currency="USD", do_not_save=True)
+		so.conversion_rate = so_rate
+		so.plc_conversion_rate = so_rate
+		so.insert()
+		so.submit()
+		self.assertEqual(flt(so.conversion_rate), so_rate)
+
+		# Sales Invoice / Delivery Note ignore the Sales Order rate and fetch the
+		# exchange rate as on their own document date.
+		self.assertEqual(flt(make_sales_invoice(so.name).conversion_rate), document_date_rate)
+		self.assertEqual(flt(make_delivery_note(so.name).conversion_rate), document_date_rate)
+
 	def test_so_billed_amount_against_return_entry(self):
 		from erpnext.accounts.doctype.sales_invoice.mapper import make_sales_return
 

--- a/erpnext/selling/doctype/sales_order/test_sales_order.py
+++ b/erpnext/selling/doctype/sales_order/test_sales_order.py
@@ -261,14 +261,18 @@ class TestSalesOrder(ERPNextTestSuite):
 		so_rate = 95.0
 		document_date_rate = 80.0
 
+		# Set up a USD -> INR exchange rate as on today, restoring/removing it
+		# afterwards so other tests are not affected.
 		exchange_name = frappe.db.get_value(
 			"Currency Exchange",
 			{"from_currency": "USD", "to_currency": "INR", "date": nowdate(), "for_selling": 1},
 		)
+		original_rate = None
 		if exchange_name:
+			original_rate = frappe.db.get_value("Currency Exchange", exchange_name, "exchange_rate")
 			frappe.db.set_value("Currency Exchange", exchange_name, "exchange_rate", document_date_rate)
 		else:
-			frappe.get_doc(
+			exchange_name = frappe.get_doc(
 				{
 					"doctype": "Currency Exchange",
 					"from_currency": "USD",
@@ -278,19 +282,25 @@ class TestSalesOrder(ERPNextTestSuite):
 					"for_selling": 1,
 					"for_buying": 1,
 				}
-			).insert()
+			).insert().name
 
-		so = make_sales_order(currency="USD", do_not_save=True)
-		so.conversion_rate = so_rate
-		so.plc_conversion_rate = so_rate
-		so.insert()
-		so.submit()
-		self.assertEqual(flt(so.conversion_rate), so_rate)
+		try:
+			so = make_sales_order(currency="USD", do_not_save=True)
+			so.conversion_rate = so_rate
+			so.plc_conversion_rate = so_rate
+			so.insert()
+			so.submit()
+			self.assertEqual(flt(so.conversion_rate), so_rate)
 
-		# Sales Invoice / Delivery Note ignore the Sales Order rate and fetch the
-		# exchange rate as on their own document date.
-		self.assertEqual(flt(make_sales_invoice(so.name).conversion_rate), document_date_rate)
-		self.assertEqual(flt(make_delivery_note(so.name).conversion_rate), document_date_rate)
+			# Sales Invoice / Delivery Note ignore the Sales Order rate and fetch
+			# the exchange rate as on their own document date.
+			self.assertEqual(flt(make_sales_invoice(so.name).conversion_rate), document_date_rate)
+			self.assertEqual(flt(make_delivery_note(so.name).conversion_rate), document_date_rate)
+		finally:
+			if original_rate is not None:
+				frappe.db.set_value("Currency Exchange", exchange_name, "exchange_rate", original_rate)
+			else:
+				frappe.delete_doc("Currency Exchange", exchange_name, force=True)
 
 	def test_so_billed_amount_against_return_entry(self):
 		from erpnext.accounts.doctype.sales_invoice.mapper import make_sales_return

--- a/erpnext/stock/doctype/delivery_note/mapper.py
+++ b/erpnext/stock/doctype/delivery_note/mapper.py
@@ -75,6 +75,11 @@ def make_sales_invoice(
 	invoiced_qty_map = get_invoiced_qty_map(source_name)
 
 	def set_missing_values(source, target):
+		# Always fetch the exchange rate as on the Invoice date instead of
+		# carrying it over from the Delivery Note (the Invoice may be raised much
+		# later, or multiple Delivery Notes with different rates may be merged).
+		target.conversion_rate = 0.0
+		target.plc_conversion_rate = 0.0
 		target.run_method("set_missing_values")
 		target.run_method("set_po_nos")
 


### PR DESCRIPTION
## Problem

When a **Sales Invoice** or **Delivery Note** is created from an earlier document (e.g. **Sales Order**, or **Delivery Note → Sales Invoice**), the target keeps the **source document's exchange rate** instead of the rate as on its own document date.

`get_mapped_doc` auto-copies the source's `conversion_rate` (and `plc_conversion_rate`) into the target. In `set_price_list_currency` the rate is only fetched **if it is not already set**, so the copied source rate sticks and is never refreshed. When **multiple Sales Orders with different rates are merged** into a single invoice, the invoice simply inherits whichever source rate was mapped.

This is incorrect for foreign-currency flows: a Sales Order is booked when the order is received, but the Invoice / Delivery Note may be raised much later, by which time the exchange rate has changed — the target should reflect the rate as on its **own document date**.

## Fix

Clear `conversion_rate` / `plc_conversion_rate` on the target during mapping, so the controller refetches the rate as on the **target's own posting date**.

Covered flows:
- Sales Order → Sales Invoice
- Sales Order → Delivery Note
- Delivery Note → Sales Invoice

For single-currency (company-currency) documents the rate is always `1`, so there is no change. When the document has no rate available for its date, the existing fallback applies.

## Steps to reproduce

1. Enable multi-currency and create a foreign-currency **Sales Order** (e.g. USD → INR at 95.71).
2. Later, when the current USD → INR rate is different (e.g. 90.0), create a **Sales Invoice** / **Delivery Note** from that Sales Order.
3. **Before:** the target uses 95.71 (copied from the Sales Order).
4. **After:** the target uses 90.0 (rate as on the target's document date).

## Tests

Added `test_document_date_exchange_rate` in `test_sales_order.py`: creates a USD Sales Order at rate 95.0 with a differing Currency Exchange (80.0) as on today, then asserts both `SO → Sales Invoice` and `SO → Delivery Note` use 80.0 (the document-date rate) rather than the Sales Order rate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)