### PR TITLE
test: fix flaky test_update_bom_cost_in_all_boms via valuation reset

### DIFF
--- a/erpnext/manufacturing/doctype/bom/test_bom.py
+++ b/erpnext/manufacturing/doctype/bom/test_bom.py
@@ -881,8 +881,13 @@ def reset_item_valuation_rate(item_code, warehouse_list=None, qty=None, rate=Non
 		warehouse_list = [warehouse_list]
 
 	if not warehouse_list:
+		# Reconcile every warehouse the item has a non-zero balance in -- including
+		# negative balances left by other tests. `get_valuation_rate` averages
+		# Sum(stock_value)/Sum(actual_qty) across all bins, so a leftover negative
+		# balance in one warehouse can cancel the reset qty elsewhere and make the
+		# average collapse to 0, which is a source of flaky BOM-cost failures.
 		warehouse_list = frappe.get_all(
-			"Bin", filters={"item_code": item_code, "actual_qty": [">", 0]}, pluck="warehouse"
+			"Bin", filters={"item_code": item_code, "actual_qty": ["!=", 0]}, pluck="warehouse"
 		)
 
 		if not warehouse_list:


### PR DESCRIPTION
Fixes a flaky failure in **test_update_bom_cost_in_all_boms** (`AssertionError: 0.0 != 10.0`).

### Root cause
`BOM.get_valuation_rate` computes an item's rate as `Sum(stock_value) / Sum(actual_qty)` averaged across **all** of the item's bins for the company (falling back to the last SLE / Item rate only when that is `<= 0`).

`reset_item_valuation_rate` — used by the test to force `_Test Item 2` to a known rate before `update_cost` — only reconciles warehouses where the item currently has **positive** stock (`actual_qty > 0`). When another test in the same run leaves `_Test Item 2` with a **negative** balance in a different warehouse, that warehouse is never reconciled. Its negative `actual_qty` then cancels the reset quantity in the cross-warehouse sum, `NullIf(Sum(actual_qty), 0)` makes the denominator null, and the average collapses to `0.0` — so `update_cost` writes `base_rate = 0` and the assertion fails. It's order-dependent, hence flaky.

### Fix
Reconcile every warehouse the item has a **non-zero** balance in (`actual_qty != 0`), so leftover negative balances are cleared to the target rate too and the cross-warehouse average is deterministic.

### Verification
The BOM/stock tests that exercise this can't run on my local bench (a PyPika/recursive-CTE mismatch on Python 3.14 blocks BOM inserts locally), so this is validated on CI. The change is a targeted, low-risk correction to a shared test helper — reconciling a negative-stock warehouse to a known qty/rate only cleans state and is rolled back per test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)