### PR TITLE
fix: fetch asset category expense account on purchase receipt

### DIFF
--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -410,12 +410,26 @@ def get_basic_details(args, item, overwrite_warehouse=True):
 
 	expense_account = None
 
-	if args.get("doctype") == "Purchase Invoice" and item.is_fixed_asset:
-		from erpnext.assets.doctype.asset_category.asset_category import get_asset_category_account
+	if item.is_fixed_asset:
+		from erpnext.assets.doctype.asset.asset import get_asset_account, is_cwip_accounting_enabled
 
-		expense_account = get_asset_category_account(
-			fieldname="fixed_asset_account", item=args.item_code, company=args.company
-		)
+		if is_cwip_accounting_enabled(item.asset_category):
+			expense_account = get_asset_account(
+				"capital_work_in_progress_account",
+				asset_category=item.asset_category,
+				company=args.company,
+			)
+		elif args.get("doctype") in (
+			"Purchase Invoice",
+			"Purchase Receipt",
+			"Purchase Order",
+			"Material Request",
+		):
+			from erpnext.assets.doctype.asset_category.asset_category import get_asset_category_account
+
+			expense_account = get_asset_category_account(
+				fieldname="fixed_asset_account", item=args.item_code, company=args.company
+			)
 
 	# Set the UOM to the Default Sales UOM or Default Purchase UOM if configured in the Item Master
 	if not args.get("uom"):

--- a/erpnext/stock/tests/test_get_item_details.py
+++ b/erpnext/stock/tests/test_get_item_details.py
@@ -35,6 +35,52 @@ class TestGetItemDetail(FrappeTestCase):
 		details = get_item_details(args)
 		self.assertEqual(details.get("price_list_rate"), 100)
 
+	def test_fetch_asset_category_expense_account_on_purchase_receipt(self):
+		from erpnext.stock.doctype.item.test_item import make_item
+
+		asset_category = "Test Expense Account Asset Category"
+		if not frappe.db.exists("Asset Category", asset_category):
+			frappe.get_doc(
+				{
+					"doctype": "Asset Category",
+					"asset_category_name": asset_category,
+					"enable_cwip_accounting": 0,
+					"depreciation_method": "Straight Line",
+					"total_number_of_depreciations": 12,
+					"frequency_of_depreciation": 1,
+					"accounts": [
+						{
+							"company_name": "_Test Company",
+							"fixed_asset_account": "_Test Fixed Asset - _TC",
+							"accumulated_depreciation_account": "_Test Accumulated Depreciations - _TC",
+							"depreciation_expense_account": "_Test Depreciations - _TC",
+						}
+					],
+				}
+			).insert()
+
+		asset_item = make_item(
+			"Test Expense Account Asset Item",
+			{"is_stock_item": 0, "is_fixed_asset": 1, "asset_category": asset_category},
+		).item_code
+
+		args = frappe._dict(
+			{
+				"item_code": asset_item,
+				"company": "_Test Company",
+				"conversion_rate": 1.0,
+				"price_list_currency": "USD",
+				"plc_conversion_rate": 1.0,
+				"doctype": "Purchase Receipt",
+				"supplier": "_Test Supplier",
+				"price_list": "_Test Buying Price List",
+				"ignore_pricing_rule": 1,
+				"qty": 1,
+			}
+		)
+		details = get_item_details(args)
+		self.assertEqual(details.get("expense_account"), "_Test Fixed Asset - _TC")
+
 	# making this test in get_item_details test file as feat/fix is present in that method
 	def test_fetch_price_from_list_rate_on_doc_save(self):
 		# create item


### PR DESCRIPTION
Backport of #41024. Fixed-asset items now resolve expense_account from the asset category (CWIP account when CWIP accounting is enabled, otherwise the fixed asset account) for Purchase Receipt, Purchase Order and Material Request, matching v16 behavior. v15 previously did this only for Purchase Invoice.