### PR TITLE
fix: guard against missing DocType in onboarding steps patch

### DIFF
--- a/erpnext/patches/v16_0/complete_onboarding_steps_for_older_sites.py
+++ b/erpnext/patches/v16_0/complete_onboarding_steps_for_older_sites.py
@@ -34,6 +34,7 @@ def complete_onboarding_steps_if_record_exists(steps):
 		if (
 			step.action == "Create Entry"
 			and step.reference_document
+			and frappe.db.exists("DocType", step.reference_document)
 			and frappe.get_all(step.reference_document, limit=1)
 		):
 			frappe.db.set_value("Onboarding Step", step.name, "is_complete", 1, update_modified=False)


### PR DESCRIPTION
https://support.frappe.io/helpdesk/tickets/72928?view=VIEW-HD+Ticket-70178

Migration erroring out while upgrading from erpnext v15 -> v16 
Tested locally by migrating a local v15 site to v16 👍🏻