### PR TITLE
fix!: incorrect margin calculation when multiple pricing rules apply 

### DIFF
--- a/erpnext/accounts/doctype/pricing_rule/pricing_rule.py
+++ b/erpnext/accounts/doctype/pricing_rule/pricing_rule.py
@@ -489,6 +489,18 @@ def get_pricing_rule_for_item(args, doc=None, for_validate=False):
 				else:
 					get_product_discount_rule(pricing_rule, item_details, args, doc)
 
+		# apply margin if apply_multiple_pricing_rules is set
+		margin_percentage = item_details.pop("margin_percentage", 0)
+		margin_amount = item_details.pop("margin_amount", 0)
+
+		if margin_percentage and not margin_amount:
+			item_details.margin_type = "Percentage"
+			item_details.margin_rate_or_amount = margin_percentage
+		elif margin_amount or margin_percentage:
+			price_list_rate = item_details.get("price_list_rate") or args.get("price_list_rate", 0)
+			item_details.margin_type = "Amount"
+			item_details.margin_rate_or_amount = margin_amount + (margin_percentage / 100) * price_list_rate
+
 		if not item_details.get("has_margin"):
 			item_details.margin_type = None
 			item_details.margin_rate_or_amount = 0.0
@@ -554,16 +566,19 @@ def get_pricing_rule_details(args, pricing_rule):
 def apply_price_discount_rule(pricing_rule, item_details, args):
 	item_details.pricing_rule_for = pricing_rule.rate_or_discount
 
-	if (pricing_rule.margin_type in ["Amount", "Percentage"] and pricing_rule.currency == args.currency) or (
-		pricing_rule.margin_type == "Percentage"
+	if (
+		pricing_rule.margin_type
+		and pricing_rule.margin_rate_or_amount
+		and (pricing_rule.margin_type == "Percentage" or pricing_rule.currency == args.currency)
 	):
-		item_details.margin_type = pricing_rule.margin_type
 		item_details.has_margin = True
 
-		if pricing_rule.apply_multiple_pricing_rules and item_details.margin_rate_or_amount is not None:
-			item_details.margin_rate_or_amount += pricing_rule.margin_rate_or_amount
+		if pricing_rule.apply_multiple_pricing_rules:
+			key = "margin_amount" if pricing_rule.margin_type == "Amount" else "margin_percentage"
+			item_details[key] = flt(item_details.get(key)) + flt(pricing_rule.margin_rate_or_amount)
 		else:
 			item_details.margin_rate_or_amount = pricing_rule.margin_rate_or_amount
+			item_details.margin_type = pricing_rule.margin_type
 
 	if pricing_rule.rate_or_discount == "Rate":
 		pricing_rule_rate = 0.0

--- a/erpnext/accounts/doctype/pricing_rule/test_pricing_rule.py
+++ b/erpnext/accounts/doctype/pricing_rule/test_pricing_rule.py
@@ -651,6 +651,81 @@ class TestPricingRule(ERPNextTestSuite):
 		frappe.delete_doc_if_exists("Pricing Rule", "_Test Pricing Rule 1")
 		frappe.delete_doc_if_exists("Pricing Rule", "_Test Pricing Rule 2")
 
+	def test_multiple_pricing_rules_with_margin(self):
+		# Case 1: percentage margins accumulate and remain Percentage
+		percentage_rule = make_pricing_rule(
+			selling=1,
+			margin_type="Percentage",
+			margin_rate_or_amount=10,
+			apply_multiple_pricing_rules=1,
+			priority=1,
+			title="_Test Margin Rule 1",
+		)
+		second_rule = make_pricing_rule(
+			selling=1,
+			margin_type="Percentage",
+			margin_rate_or_amount=5,
+			apply_multiple_pricing_rules=1,
+			priority=2,
+			title="_Test Margin Rule 2",
+		)
+
+		si = create_sales_invoice(qty=1, price_list_rate=1000, do_not_submit=True)
+
+		item = si.items[0]
+		self.assertEqual(item.margin_type, "Percentage")
+		self.assertEqual(item.margin_rate_or_amount, 15)
+		self.assertEqual(item.rate_with_margin, 1150)
+		self.assertEqual(item.rate, 1150)
+		si.delete()
+
+		second_rule.delete()
+
+		# Case 2: mixed margin types accumulate as Amount on the price list rate
+		second_rule = make_pricing_rule(
+			selling=1,
+			margin_type="Amount",
+			margin_rate_or_amount=50,
+			apply_multiple_pricing_rules=1,
+			priority=2,
+			title="_Test Margin Rule 2",
+		)
+
+		si = create_sales_invoice(qty=1, price_list_rate=1000, do_not_submit=True)
+
+		item = si.items[0]
+		self.assertEqual(item.margin_type, "Amount")
+		self.assertEqual(item.margin_rate_or_amount, 150)
+		self.assertEqual(item.rate_with_margin, 1150)
+		self.assertEqual(item.rate, 1150)
+		si.delete()
+
+		second_rule.delete()
+
+		# Case 3: percentage margin applies on the price list rate
+		# overridden by a Rate pricing rule
+		second_rule = make_pricing_rule(
+			selling=1,
+			rate_or_discount="Rate",
+			rate=200,
+			apply_multiple_pricing_rules=1,
+			priority=2,
+			title="_Test Margin Rule 2",
+		)
+
+		si = create_sales_invoice(qty=1, do_not_submit=True)
+
+		item = si.items[0]
+		self.assertEqual(item.price_list_rate, 200)
+		self.assertEqual(item.margin_type, "Percentage")
+		self.assertEqual(item.margin_rate_or_amount, 10)
+		self.assertEqual(item.rate_with_margin, 220)
+		self.assertEqual(item.rate, 220)
+		si.delete()
+
+		second_rule.delete()
+		percentage_rule.delete()
+
 	def test_item_price_with_pricing_rule(self):
 		item = make_item("Water Flask")
 		make_item_price("Water Flask", "_Test Price List", 100)

--- a/erpnext/controllers/taxes_and_totals.py
+++ b/erpnext/controllers/taxes_and_totals.py
@@ -173,7 +173,8 @@ class calculate_taxes_and_totals:
 		has_pricing_rules = item.pricing_rules and not self.doc.ignore_pricing_rule
 		if has_pricing_rules:
 			remove_margin(item)
-
+			margin_amount = 0
+			margin_percentage = 0
 			for d in get_applied_pricing_rules(item.pricing_rules):
 				pricing_rule = frappe.get_cached_doc("Pricing Rule", d)
 
@@ -186,8 +187,27 @@ class calculate_taxes_and_totals:
 				):
 					continue
 
-				item.margin_type = pricing_rule.margin_type
-				item.margin_rate_or_amount = pricing_rule.margin_rate_or_amount
+				if pricing_rule.apply_multiple_pricing_rules:
+					if pricing_rule.margin_type == "Percentage":
+						margin_percentage = flt(
+							margin_percentage + pricing_rule.margin_rate_or_amount,
+							item.precision("margin_rate_or_amount"),
+						)
+					else:
+						margin_amount = flt(
+							margin_amount + pricing_rule.margin_rate_or_amount,
+							item.precision("margin_rate_or_amount"),
+						)
+				else:
+					item.margin_type = pricing_rule.margin_type
+					item.margin_rate_or_amount = pricing_rule.margin_rate_or_amount
+
+			if margin_percentage and not margin_amount:
+				item.margin_type = "Percentage"
+				item.margin_rate_or_amount = margin_percentage
+			elif margin_amount or margin_percentage:
+				item.margin_type = "Amount"
+				item.margin_rate_or_amount = margin_amount + (margin_percentage / 100) * item.price_list_rate
 
 		item.rate_with_margin = get_rate_with_margin(item)
 		if item.discount_percentage > 0:


### PR DESCRIPTION
# Breaking Change

Items with more than one margin-bearing pricing rule previously kept only one rule's margin on save. All applicable margins are now accumulated, so **existing drafts and amendments will compute a different (higher, correct) rate on their next save**. Mixed-type stacks (pricing rules with both `marging_type` as Amount & Percentage) now always report `margin_type = "Amount"`

## Issue

When multiple pricing rules with margins are applied (`apply_multiple_pricing_rules`):

1. **Wrong accumulation across margin types** — `margin_rate_or_amount` values were summed as raw numbers even when one rule used `Percentage` and another `Amount`, while `margin_type` was overwritten by the last rule (e.g. 10% + ₹50 became ₹60 or 60%, depending on rule order).
2. **Backend ignored accumulation entirely** — `calculate_item_rate()` in `taxes_and_totals.py` recomputes margins on every save with last-rule-wins semantics, so even a correct combined margin on the client was silently reverted to a single rule's margin on save (present since #24204).

## Fix

- Accumulate percentage and amount margins separately while looping over applied rules, and combine them once after the loop — when the final `price_list_rate` (including any Rate rule override) is known — making the result independent of rule priority order.
  - Pure percentage stacks stay `Percentage` (10% + 5% → 15%).
  - Mixed types resolve to `Amount` on the final price list rate (10% + ₹50 on ₹1000 → ₹150).