### PR TITLE
test: add coverage for Process Subscription

### DIFF
--- a/erpnext/accounts/doctype/process_subscription/test_process_subscription.py
+++ b/erpnext/accounts/doctype/process_subscription/test_process_subscription.py
@@ -1,11 +1,47 @@
-# Copyright (c) 2023, Frappe Technologies Pvt. Ltd. and Contributors
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
 
-# import frappe
+from unittest.mock import patch
 
+import frappe
 
+from erpnext.accounts.doctype.process_subscription.process_subscription import (
+	create_subscription_process,
+)
+from erpnext.accounts.doctype.subscription.test_subscription import create_plan, create_subscription
 from erpnext.tests.utils import ERPNextTestSuite
 
 
 class TestProcessSubscription(ERPNextTestSuite):
-	pass
+	"""Process Subscription is a batch driver: on submit it enqueues subscription.process_all
+	for every non-cancelled Subscription (or just one when a subscription is named)."""
+
+	def setUp(self):
+		frappe.set_user("Administrator")
+		create_plan(plan_name="_Test Plan Name", currency="INR")
+
+	def enqueued_subscriptions(self, subscription=None):
+		"""Submit a Process Subscription while capturing what gets enqueued."""
+		calls = []
+
+		def capture(*args, **kwargs):
+			calls.append(kwargs)
+
+		with patch("frappe.enqueue", side_effect=capture):
+			create_subscription_process(subscription=subscription, posting_date="2026-06-15")
+
+		# each enqueue is handed a batch (list) of subscription names
+		return [name for call in calls for name in call.get("subscription", [])]
+
+	def test_named_subscription_is_the_only_one_enqueued(self):
+		sub = create_subscription(start_date="2026-01-01")
+		self.assertEqual(self.enqueued_subscriptions(subscription=sub.name), [sub.name])
+
+	def test_cancelled_subscriptions_are_skipped(self):
+		active = create_subscription(start_date="2026-01-01")
+		cancelled = create_subscription(start_date="2026-01-01")
+		cancelled.cancel_subscription()
+
+		enqueued = self.enqueued_subscriptions()
+		self.assertIn(active.name, enqueued)
+		self.assertNotIn(cancelled.name, enqueued)

--- a/erpnext/accounts/doctype/process_subscription/test_process_subscription.py
+++ b/erpnext/accounts/doctype/process_subscription/test_process_subscription.py
@@ -8,7 +8,12 @@ import frappe
 from erpnext.accounts.doctype.process_subscription.process_subscription import (
 	create_subscription_process,
 )
-from erpnext.accounts.doctype.subscription.test_subscription import create_plan, create_subscription
+from erpnext.accounts.doctype.subscription.test_subscription import (
+	create_parties,
+	create_subscription,
+	make_plans,
+	reset_settings,
+)
 from erpnext.tests.utils import ERPNextTestSuite
 
 
@@ -18,7 +23,11 @@ class TestProcessSubscription(ERPNextTestSuite):
 
 	def setUp(self):
 		frappe.set_user("Administrator")
-		create_plan(plan_name="_Test Plan Name", currency="INR")
+		# mirror TestSubscription setup so subscriptions build against known settings
+		make_plans()
+		create_parties()
+		reset_settings()
+		frappe.db.set_value("Company", "_Test Company", "accounts_frozen_till_date", None)
 
 	def enqueued_subscriptions(self, subscription=None):
 		"""Submit a Process Subscription while capturing what gets enqueued."""


### PR DESCRIPTION
Adds unit tests for the **Process Subscription** doctype, which had only a boilerplate stub.

Process Subscription is a batch driver: on submit it enqueues `subscription.process_all` for the subscriptions it selects. The tests capture what gets enqueued and assert the selection:
- Naming a subscription enqueues only that one.
- Cancelled subscriptions are skipped; active ones are enqueued.

### Notes for a maintainer
- **No idempotency guard.** `create_subscription_process` has no dedup on (subscription, posting_date), so the same run can be submitted repeatedly - each one re-processes and can re-bill the subscription.
- **`process_all` only swallows `ValidationError`.** Any other exception from one subscription aborts the whole batch rather than being logged and skipped.