### PR TITLE
fix: Process Payment Reconciliation drops bank/cash and cost center filters

### DIFF
--- a/erpnext/accounts/doctype/process_payment_reconciliation/process_payment_reconciliation.py
+++ b/erpnext/accounts/doctype/process_payment_reconciliation/process_payment_reconciliation.py
@@ -106,6 +106,8 @@ def get_pr_instance(doc: str):
 		"party",
 		"receivable_payable_account",
 		"default_advance_account",
+		"bank_cash_account",
+		"cost_center",
 		"from_invoice_date",
 		"to_invoice_date",
 		"from_payment_date",

--- a/erpnext/accounts/doctype/process_payment_reconciliation/test_process_payment_reconciliation.py
+++ b/erpnext/accounts/doctype/process_payment_reconciliation/test_process_payment_reconciliation.py
@@ -1,11 +1,64 @@
-# Copyright (c) 2023, Frappe Technologies Pvt. Ltd. and Contributors
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
 
-# import frappe
+import frappe
 
-
+from erpnext.accounts.doctype.process_payment_reconciliation.process_payment_reconciliation import (
+	get_pr_instance,
+)
 from erpnext.tests.utils import ERPNextTestSuite
+
+COMPANY = "_Test Company"
 
 
 class TestProcessPaymentReconciliation(ERPNextTestSuite):
-	pass
+	"""Process Payment Reconciliation validates its accounts against the company,
+	moves to Queued on submit, and hands its filters to a Payment Reconciliation run."""
+
+	def setUp(self):
+		frappe.set_user("Administrator")
+
+	def make_ppr(self, **args):
+		args = frappe._dict(args)
+		doc = frappe.new_doc("Process Payment Reconciliation")
+		doc.company = COMPANY
+		doc.party_type = "Customer"
+		doc.party = "_Test Customer"
+		doc.receivable_payable_account = args.get("receivable_payable_account", "Debtors - _TC")
+		doc.bank_cash_account = args.get("bank_cash_account")
+		doc.from_invoice_date = args.get("from_invoice_date")
+		doc.to_invoice_date = args.get("to_invoice_date")
+		return doc
+
+	def test_receivable_account_must_belong_to_company(self):
+		other = frappe.get_all(
+			"Account",
+			{"company": "_Test Company 1", "account_type": "Receivable", "is_group": 0},
+			pluck="name",
+		)[0]
+		doc = self.make_ppr(receivable_payable_account=other)
+		self.assertRaises(frappe.ValidationError, doc.insert)
+
+	def test_bank_cash_account_must_belong_to_company(self):
+		other = frappe.get_all("Account", {"company": "_Test Company 1", "is_group": 0}, pluck="name")[0]
+		doc = self.make_ppr(bank_cash_account=other)
+		self.assertRaises(frappe.ValidationError, doc.insert)
+
+	def test_submit_sets_status_to_queued(self):
+		doc = self.make_ppr()
+		doc.insert()
+		doc.submit()
+		self.assertEqual(doc.status, "Queued")
+
+	def test_get_pr_instance_copies_filters_and_caps_limits(self):
+		doc = self.make_ppr(from_invoice_date="2026-01-01", to_invoice_date="2026-06-30")
+		doc.insert()
+
+		pr = get_pr_instance(doc.name)
+		self.assertEqual(pr.company, COMPANY)
+		self.assertEqual(pr.party, "_Test Customer")
+		self.assertEqual(pr.receivable_payable_account, "Debtors - _TC")
+		self.assertEqual(str(pr.from_invoice_date), "2026-01-01")
+		# the tool run is capped so a single process can't fetch unbounded rows
+		self.assertEqual(pr.invoice_limit, 1000)
+		self.assertEqual(pr.payment_limit, 1000)

--- a/erpnext/accounts/doctype/process_payment_reconciliation/test_process_payment_reconciliation.py
+++ b/erpnext/accounts/doctype/process_payment_reconciliation/test_process_payment_reconciliation.py
@@ -63,14 +63,11 @@ class TestProcessPaymentReconciliation(ERPNextTestSuite):
 		self.assertEqual(pr.invoice_limit, 1000)
 		self.assertEqual(pr.payment_limit, 1000)
 
-	def test_get_pr_instance_drops_bank_cash_and_cost_center_filters(self):
-		# SUSPECTED BUG: get_pr_instance's field list omits bank_cash_account and
-		# cost_center, so those filters are silently lost when the tool run is built.
-		# Locking the current (wrong) behaviour.
+	def test_get_pr_instance_copies_bank_cash_and_cost_center(self):
 		doc = self.make_ppr(bank_cash_account="Cash - _TC")
 		doc.cost_center = "_Test Cost Center - _TC"
 		doc.insert()
 
 		pr = get_pr_instance(doc.name)
-		self.assertFalse(pr.get("bank_cash_account"))
-		self.assertFalse(pr.get("cost_center"))
+		self.assertEqual(pr.bank_cash_account, "Cash - _TC")
+		self.assertEqual(pr.cost_center, "_Test Cost Center - _TC")

--- a/erpnext/accounts/doctype/process_payment_reconciliation/test_process_payment_reconciliation.py
+++ b/erpnext/accounts/doctype/process_payment_reconciliation/test_process_payment_reconciliation.py
@@ -30,18 +30,18 @@ class TestProcessPaymentReconciliation(ERPNextTestSuite):
 		doc.to_invoice_date = args.get("to_invoice_date")
 		return doc
 
+	def other_company_account(self, **extra):
+		filters = {"company": "_Test Company 1", "is_group": 0, **extra}
+		account = frappe.db.get_value("Account", filters, "name")
+		self.assertTrue(account, "need a matching account in _Test Company 1")
+		return account
+
 	def test_receivable_account_must_belong_to_company(self):
-		other = frappe.get_all(
-			"Account",
-			{"company": "_Test Company 1", "account_type": "Receivable", "is_group": 0},
-			pluck="name",
-		)[0]
-		doc = self.make_ppr(receivable_payable_account=other)
+		doc = self.make_ppr(receivable_payable_account=self.other_company_account(account_type="Receivable"))
 		self.assertRaises(frappe.ValidationError, doc.insert)
 
 	def test_bank_cash_account_must_belong_to_company(self):
-		other = frappe.get_all("Account", {"company": "_Test Company 1", "is_group": 0}, pluck="name")[0]
-		doc = self.make_ppr(bank_cash_account=other)
+		doc = self.make_ppr(bank_cash_account=self.other_company_account())
 		self.assertRaises(frappe.ValidationError, doc.insert)
 
 	def test_submit_sets_status_to_queued(self):
@@ -62,3 +62,15 @@ class TestProcessPaymentReconciliation(ERPNextTestSuite):
 		# the tool run is capped so a single process can't fetch unbounded rows
 		self.assertEqual(pr.invoice_limit, 1000)
 		self.assertEqual(pr.payment_limit, 1000)
+
+	def test_get_pr_instance_drops_bank_cash_and_cost_center_filters(self):
+		# SUSPECTED BUG: get_pr_instance's field list omits bank_cash_account and
+		# cost_center, so those filters are silently lost when the tool run is built.
+		# Locking the current (wrong) behaviour.
+		doc = self.make_ppr(bank_cash_account="Cash - _TC")
+		doc.cost_center = "_Test Cost Center - _TC"
+		doc.insert()
+
+		pr = get_pr_instance(doc.name)
+		self.assertFalse(pr.get("bank_cash_account"))
+		self.assertFalse(pr.get("cost_center"))


### PR DESCRIPTION
`get_pr_instance` builds the Payment Reconciliation run from the process document's filters, but its field list omitted `bank_cash_account` and `cost_center` - so those two filters were silently lost and the reconciliation ran unscoped by them.

**Fix:** include `bank_cash_account` and `cost_center` in the copied fields.

Also adds unit tests for the doctype (account-company validation, Queued-on-submit, filter copy + limit caps, and the two filters now carried through).

Still worth a follow-up (left as-is here): the `process__` double-underscore job name lets a duplicate `fetch_and_allocate` enqueue, and `reconcile()`'s completion check reads counts captured before the batch ran.