### PR TITLE
test: add coverage for Repost Payment Ledger

### DIFF
--- a/erpnext/accounts/doctype/repost_payment_ledger/test_repost_payment_ledger.py
+++ b/erpnext/accounts/doctype/repost_payment_ledger/test_repost_payment_ledger.py
@@ -26,14 +26,17 @@ class TestRepostPaymentLedger(ERPNextTestSuite):
 		return doc
 
 	def test_loads_submitted_vouchers_on_or_after_cutoff(self):
-		in_range = create_sales_invoice(company=COMPANY, posting_date="2026-06-15", rate=100, qty=1)
+		after_cutoff = create_sales_invoice(company=COMPANY, posting_date="2026-06-15", rate=100, qty=1)
+		on_cutoff = create_sales_invoice(company=COMPANY, posting_date="2026-06-01", rate=100, qty=1)
 		before_cutoff = create_sales_invoice(company=COMPANY, posting_date="2026-01-15", rate=100, qty=1)
 
 		doc = self.make_repost(posting_date="2026-06-01", voucher_type="Sales Invoice")
 		doc.save()  # before_validate loads the vouchers and sets status
 
 		loaded = {v.voucher_no for v in doc.repost_vouchers}
-		self.assertIn(in_range.name, loaded)
+		self.assertIn(after_cutoff.name, loaded)
+		# the filter is >= so an invoice posted exactly on the cutoff is included
+		self.assertIn(on_cutoff.name, loaded)
 		self.assertNotIn(before_cutoff.name, loaded)
 		self.assertEqual(doc.repost_status, "Queued")
 

--- a/erpnext/accounts/doctype/repost_payment_ledger/test_repost_payment_ledger.py
+++ b/erpnext/accounts/doctype/repost_payment_ledger/test_repost_payment_ledger.py
@@ -41,13 +41,15 @@ class TestRepostPaymentLedger(ERPNextTestSuite):
 		self.assertEqual(doc.repost_status, "Queued")
 
 	def test_add_manually_preserves_user_rows(self):
-		# a Sales Invoice that WOULD match the filter, to prove manual mode ignores it
-		si = create_sales_invoice(company=COMPANY, posting_date="2026-06-15", rate=100, qty=1)
+		# manually add a BEFORE-cutoff invoice (which the filter would never load) while a
+		# matching after-cutoff invoice also exists. If auto-loading wrongly ran it would
+		# drop the manual row and pull the after-cutoff one, so this distinguishes the modes.
+		manual_si = create_sales_invoice(company=COMPANY, posting_date="2026-01-15", rate=100, qty=1)
+		create_sales_invoice(company=COMPANY, posting_date="2026-06-15", rate=100, qty=1)
 
-		doc = self.make_repost(add_manually=1)
-		doc.append("repost_vouchers", {"voucher_type": "Sales Invoice", "voucher_no": si.name})
+		doc = self.make_repost(add_manually=1, posting_date="2026-06-01")
+		doc.append("repost_vouchers", {"voucher_type": "Sales Invoice", "voucher_no": manual_si.name})
 		doc.save()
 
 		rows = [(v.voucher_type, v.voucher_no) for v in doc.repost_vouchers]
-		# the row is kept exactly as entered; no filter-based auto-loading happens
-		self.assertEqual(rows, [("Sales Invoice", si.name)])
+		self.assertEqual(rows, [("Sales Invoice", manual_si.name)])

--- a/erpnext/accounts/doctype/repost_payment_ledger/test_repost_payment_ledger.py
+++ b/erpnext/accounts/doctype/repost_payment_ledger/test_repost_payment_ledger.py
@@ -1,11 +1,50 @@
-# Copyright (c) 2022, Frappe Technologies Pvt. Ltd. and Contributors
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
 
-# import frappe
+import frappe
 
-
+from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_sales_invoice
 from erpnext.tests.utils import ERPNextTestSuite
+
+COMPANY = "_Test Company"
 
 
 class TestRepostPaymentLedger(ERPNextTestSuite):
-	pass
+	"""Repost Payment Ledger auto-selects submitted vouchers on/after a cutoff date
+	(unless rows are added manually) and queues them for a ledger rebuild."""
+
+	def setUp(self):
+		frappe.set_user("Administrator")
+
+	def make_repost(self, **args):
+		args = frappe._dict(args)
+		doc = frappe.new_doc("Repost Payment Ledger")
+		doc.company = COMPANY
+		doc.posting_date = args.get("posting_date", "2026-06-01")
+		doc.voucher_type = args.get("voucher_type", "Sales Invoice")
+		doc.add_manually = args.get("add_manually", 0)
+		return doc
+
+	def test_loads_submitted_vouchers_on_or_after_cutoff(self):
+		in_range = create_sales_invoice(company=COMPANY, posting_date="2026-06-15", rate=100, qty=1)
+		before_cutoff = create_sales_invoice(company=COMPANY, posting_date="2026-01-15", rate=100, qty=1)
+
+		doc = self.make_repost(posting_date="2026-06-01", voucher_type="Sales Invoice")
+		doc.save()  # before_validate loads the vouchers and sets status
+
+		loaded = {v.voucher_no for v in doc.repost_vouchers}
+		self.assertIn(in_range.name, loaded)
+		self.assertNotIn(before_cutoff.name, loaded)
+		self.assertEqual(doc.repost_status, "Queued")
+
+	def test_add_manually_preserves_user_rows(self):
+		# a Sales Invoice that WOULD match the filter, to prove manual mode ignores it
+		si = create_sales_invoice(company=COMPANY, posting_date="2026-06-15", rate=100, qty=1)
+
+		doc = self.make_repost(add_manually=1)
+		doc.append("repost_vouchers", {"voucher_type": "Sales Invoice", "voucher_no": si.name})
+		doc.save()
+
+		rows = [(v.voucher_type, v.voucher_no) for v in doc.repost_vouchers]
+		# the row is kept exactly as entered; no filter-based auto-loading happens
+		self.assertEqual(rows, [("Sales Invoice", si.name)])


### PR DESCRIPTION
Adds unit tests for the **Repost Payment Ledger** doctype, which had only a boilerplate stub.

Covers the voucher-selection logic:
- Auto mode loads submitted vouchers on/after the cutoff date and skips earlier ones; a draft sits in **Queued**.
- Manual mode keeps the user's rows exactly and does no filter-based auto-loading.

### Notes for a maintainer (in `start_payment_ledger_repost`, not exercised here)
- **All-or-nothing.** One voucher's failure triggers a full `rollback()` and marks the whole run **Failed**, discarding progress on vouchers already reposted.
- **Delete-then-recreate has no crash safety.** PLEs are deleted and then recreated; if the worker dies between the two, the entries are gone with nothing to restore them.
- **`get_vouchers` has no upper date bound and no batching**, so a low cutoff can pull an unbounded set of vouchers into a single run.