### PR TITLE
feat: add starter data to setup wizard

### DIFF
--- a/.github/helper/semgrep_precommit.py
+++ b/.github/helper/semgrep_precommit.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and Contributors
+# License: GNU General Public License v3. See license.txt
+
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+RULES_REPO = "https://github.com/frappe/semgrep-rules.git"
+
+
+def run(command, **kwargs):
+	return subprocess.run(command, check=True, **kwargs)
+
+
+def get_rules_repo_default_branch():
+	result = subprocess.run(
+		["git", "ls-remote", "--symref", RULES_REPO, "HEAD"],
+		check=True,
+		stdout=subprocess.PIPE,
+		text=True,
+	)
+	for line in result.stdout.splitlines():
+		if line.startswith("ref: refs/heads/"):
+			return line.split()[1].removeprefix("refs/heads/")
+
+	return "master"
+
+
+def get_frappe_rules_dir():
+	rules_dir = Path(tempfile.gettempdir()) / "frappe-semgrep-rules"
+	default_branch = get_rules_repo_default_branch()
+	if rules_dir.exists():
+		run(["git", "-C", str(rules_dir), "fetch", "--depth", "1", "origin", default_branch])
+		run(["git", "-C", str(rules_dir), "reset", "--hard", f"origin/{default_branch}"])
+	else:
+		run(["git", "clone", "--depth", "1", "--branch", default_branch, RULES_REPO, str(rules_dir)])
+
+	return rules_dir / "rules"
+
+
+def get_baseline_commit():
+	for ref in ("origin/develop", "develop"):
+		result = subprocess.run(
+			["git", "rev-parse", "--verify", "--quiet", ref],
+			check=False,
+			stdout=subprocess.DEVNULL,
+		)
+		if result.returncode == 0:
+			return ref
+
+
+def run_semgrep(configs, includes=None):
+	command = ["semgrep", "scan", "--error", "--metrics=off", "--disable-version-check"]
+	baseline_commit = get_baseline_commit()
+	if baseline_commit:
+		command.extend(["--baseline-commit", baseline_commit])
+
+	for config in configs:
+		command.extend(["--config", str(config)])
+
+	for include in includes or []:
+		command.extend(["--include", include])
+
+	return run(command)
+
+
+def main():
+	rules_dir = get_frappe_rules_dir()
+	run_semgrep([rules_dir, "r/python.lang.correctness"])
+	run_semgrep(["semgrep/test-correctness.yml"], includes=["**/test_*.py"])
+
+
+if __name__ == "__main__":
+	sys.exit(main())

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -76,6 +76,13 @@ repos:
         # patches/ are historical, version-gated migrations (skipped on fresh Postgres installs);
         # out of scope for the always-on gate.
         exclude: ^erpnext/patches/
+      - id: semgrep
+        name: "Semgrep"
+        entry: .github/helper/semgrep_precommit.py
+        language: python
+        additional_dependencies: ["semgrep==1.168.0", "cryptography==46.0.3"]
+        pass_filenames: false
+        files: \.(js|py)$
 
 ci:
     autoupdate_schedule: weekly

--- a/erpnext/public/js/setup_wizard.js
+++ b/erpnext/public/js/setup_wizard.js
@@ -15,8 +15,177 @@ frappe.setup.on("before_load", function () {
 		return;
 	}
 
+	erpnext.setup.use_progress_bar();
+	erpnext.setup.blur_active_field_before_action();
+	erpnext.setup.setup_test_user_autofill();
 	erpnext.setup.slides_settings.map(frappe.setup.add_slide);
 });
+
+erpnext.setup.use_progress_bar = function () {
+	erpnext.setup.ensure_progress_bar_styles();
+
+	if (frappe.setup.SetupWizard.prototype.erpnext_progress_bar_enabled) return;
+
+	const setup_make = frappe.setup.SetupWizard.prototype.make;
+	frappe.setup.SetupWizard.prototype.make = function () {
+		setup_make.call(this);
+		this.$slide_progress.addClass("setup-progress-bar");
+		erpnext.setup.update_progress_bar_state(this);
+	};
+
+	const setup_refresh = frappe.setup.SetupWizard.prototype.refresh;
+	frappe.setup.SetupWizard.prototype.refresh = function (id) {
+		setup_refresh.call(this, id);
+		erpnext.setup.update_progress_bar_state(this);
+	};
+
+	const setup_show_working_state = frappe.setup.SetupWizard.prototype.show_working_state;
+	frappe.setup.SetupWizard.prototype.show_working_state = function () {
+		setup_show_working_state.call(this);
+		this.$slide_progress.addClass("erpnext-progress-hidden");
+		this.$abort_btn?.on("click.erpnext_progress_bar", () => {
+			this.$slide_progress.removeClass("erpnext-progress-hidden");
+		});
+	};
+
+	frappe.setup.SetupWizard.prototype.erpnext_progress_bar_enabled = true;
+};
+
+erpnext.setup.update_progress_bar_state = function (wizard) {
+	if (!wizard?.$slide_progress?.hasClass("setup-progress-bar")) return;
+
+	wizard.$slide_progress.find(".slide-step").each(function () {
+		let step_id = cint($(this).attr("data-step-id"));
+		$(this).toggleClass("erpnext-step-filled", step_id <= wizard.current_id);
+	});
+};
+
+erpnext.setup.ensure_progress_bar_styles = function () {
+	if ($("#erpnext-setup-progress-bar-styles").length) return;
+
+	$(`<style id="erpnext-setup-progress-bar-styles">
+		.setup-progress-bar.slides-progress {
+			align-items: center;
+			display: flex;
+			gap: 0;
+			justify-content: center;
+			margin-left: auto;
+			margin-right: auto;
+			max-width: 520px;
+			width: min(520px, calc(100vw - 48px));
+		}
+		.setup-progress-bar.slides-progress .slide-step {
+			background-color: var(--control-bg);
+			border: 0;
+			border-radius: 0;
+			flex: 1 1 0;
+			height: 6px;
+			margin: 0;
+			min-width: 0;
+			width: auto;
+		}
+		.setup-progress-bar.slides-progress .slide-step:first-child {
+			border-bottom-left-radius: var(--radius-full);
+			border-top-left-radius: var(--radius-full);
+		}
+		.setup-progress-bar.slides-progress .slide-step:last-child {
+			border-bottom-right-radius: var(--radius-full);
+			border-top-right-radius: var(--radius-full);
+		}
+		.setup-progress-bar.slides-progress .slide-step.active,
+		.setup-progress-bar.slides-progress .slide-step.step-success {
+			background-color: var(--control-bg);
+			border: 0;
+		}
+		.setup-progress-bar.slides-progress .slide-step.erpnext-step-filled {
+			background-color: var(--ink-gray-9);
+			border: 0;
+		}
+		.setup-progress-bar.slides-progress .slide-step-indicator,
+		.setup-progress-bar.slides-progress .slide-step-complete {
+			display: none !important;
+		}
+		.setup-progress-bar.slides-progress.erpnext-progress-hidden {
+			display: none;
+		}
+	</style>`).appendTo("head");
+};
+
+erpnext.setup.blur_active_field_before_action = function () {
+	if (frappe.setup.SetupWizard.prototype.erpnext_blur_before_action_enabled) return;
+
+	const setup_make = frappe.setup.SetupWizard.prototype.make;
+	frappe.setup.SetupWizard.prototype.make = function () {
+		setup_make.call(this);
+		this.$next_btn.add(this.$complete_btn).on("mousedown touchstart", function () {
+			erpnext.setup.blur_active_setup_field();
+		});
+	};
+
+	const handle_enter_press = frappe.setup.SetupWizard.prototype.handle_enter_press;
+	frappe.setup.SetupWizard.prototype.handle_enter_press = function (e) {
+		if (e.which === frappe.ui.keyCode.ENTER) {
+			erpnext.setup.blur_active_setup_field();
+		}
+		return handle_enter_press.call(this, e);
+	};
+
+	frappe.setup.SetupWizard.prototype.erpnext_blur_before_action_enabled = true;
+};
+
+erpnext.setup.blur_active_setup_field = function () {
+	let active_element = document.activeElement;
+	if (!active_element || !$(active_element).closest(".setup-wizard-slide").length) return;
+
+	$(active_element).trigger("change").blur();
+};
+
+erpnext.setup.setup_test_user_autofill = function () {
+	let user_slide = frappe.setup.slides_settings?.find((slide) => slide.name === "user");
+	if (!user_slide || user_slide.erpnext_test_autofill_setup) return;
+
+	let user_slide_onload = user_slide.onload;
+	user_slide.onload = function (slide) {
+		user_slide_onload?.call(this, slide);
+		erpnext.setup.bind_test_user_autofill(slide);
+	};
+	user_slide.erpnext_test_autofill_setup = true;
+};
+
+erpnext.setup.bind_test_user_autofill = function (slide) {
+	let full_name = slide.get_field("full_name");
+	let email = slide.get_field("email");
+	let password = slide.get_field("password");
+
+	if (!full_name || !email || !password || full_name.erpnext_test_autofill_bound) return;
+
+	full_name.$input.on("input", function () {
+		if (full_name.get_value()?.trim().toLowerCase() !== "test") return;
+
+		email.set_value("test@example.com");
+		password.set_value("test");
+		erpnext.setup.set_test_setup_values();
+		slide.reset_action_button_state();
+	});
+
+	full_name.erpnext_test_autofill_bound = true;
+};
+
+erpnext.setup.set_test_setup_values = function () {
+	$.extend(frappe.wizard.values, {
+		persona_implementing_for: "My own business",
+		persona_company_size: "1–10",
+		persona_industry: "Retail",
+		persona_current_system: "Nothing yet - starting fresh",
+		module_accounting: 1,
+		module_stock: 1,
+		module_manufacturing: 0,
+		module_projects: 0,
+		company_name: "Test Company",
+		company_abbr: "TC",
+		setup_demo: 0,
+	});
+};
 
 erpnext.setup.slides_settings = [
 	{
@@ -155,6 +324,7 @@ erpnext.setup.slides_settings = [
 
 		onload: function (slide) {
 			this.bind_events(slide);
+			this.setup_collapsible_chart_of_accounts(slide);
 		},
 
 		before_show: function () {
@@ -274,6 +444,38 @@ erpnext.setup.slides_settings = [
 				.trigger("change");
 		},
 
+		setup_collapsible_chart_of_accounts: function (slide) {
+			if (slide.organization_advanced_collapsible_setup) return;
+
+			let chart_field = slide.get_field("chart_of_accounts");
+			let view_coa_field = slide.get_field("view_coa");
+			let fy_start_field = slide.get_field("fy_start_date");
+			let $fields = chart_field.$wrapper.add(view_coa_field.$wrapper).add(fy_start_field.$wrapper);
+			let $toggle = $(`
+				<div class="setup-collapsible-section">
+					<button class="setup-collapsible-toggle text-muted" type="button">
+						<span>${__("Advanced setup")}</span>
+						<span class="setup-collapsible-icon">${frappe.utils.icon("chevron-right", "sm")}</span>
+					</button>
+				</div>
+			`);
+
+			erpnext.setup.ensure_organization_styles();
+			chart_field.$wrapper.before($toggle);
+			$fields.hide();
+
+			$toggle.on("click", ".setup-collapsible-toggle", function () {
+				let expanded = $toggle.hasClass("expanded");
+				$toggle.toggleClass("expanded", !expanded);
+				$toggle
+					.find(".setup-collapsible-icon")
+					.html(frappe.utils.icon(expanded ? "chevron-right" : "chevron-down", "sm"));
+				$fields.toggle(!expanded);
+			});
+
+			slide.organization_advanced_collapsible_setup = true;
+		},
+
 		charts_modal: function (slide, chart_template) {
 			let parent = __("All Accounts");
 
@@ -335,7 +537,483 @@ erpnext.setup.slides_settings = [
 			coa_tree.load_children(coa_tree.root_node, true); // expand all node trigger
 		},
 	},
+	{
+		name: "starter_customers",
+		title: __("Add customers"),
+		help: __("Enter the details of a few customers"),
+		fields: [
+			{ fieldname: "starter_customers", fieldtype: "Small Text", hidden: 1 },
+			{ fieldname: "starter_customers_html", fieldtype: "HTML" },
+		],
+		onload: function (slide) {
+			this.slide = slide;
+			erpnext.setup.render_starter_name_rows(slide, {
+				hidden_fieldname: "starter_customers",
+				wrapper_fieldname: "starter_customers_html",
+				input_name: "customer_name",
+				label: __("Customer name"),
+				placeholder: __("Acme Retail"),
+				opening_placeholder: __("Opening receivable"),
+			});
+		},
+		validate: function () {
+			return erpnext.setup.serialize_starter_name_rows(this.slide, "starter_customers", __("Customer"));
+		},
+	},
+	{
+		name: "starter_suppliers",
+		title: __("Add suppliers"),
+		help: __("Enter the details of a few suppliers"),
+		fields: [
+			{ fieldname: "starter_suppliers", fieldtype: "Small Text", hidden: 1 },
+			{ fieldname: "starter_suppliers_html", fieldtype: "HTML" },
+		],
+		onload: function (slide) {
+			this.slide = slide;
+			erpnext.setup.render_starter_name_rows(slide, {
+				hidden_fieldname: "starter_suppliers",
+				wrapper_fieldname: "starter_suppliers_html",
+				input_name: "supplier_name",
+				label: __("Supplier name"),
+				placeholder: __("Sunrise Traders"),
+				opening_placeholder: __("Opening payable"),
+			});
+		},
+		validate: function () {
+			return erpnext.setup.serialize_starter_name_rows(this.slide, "starter_suppliers", __("Supplier"));
+		},
+	},
+	{
+		name: "starter_items",
+		title: __("Add items"),
+		help: __("Add products or services. Opening stock is optional."),
+		fields: [
+			{ fieldname: "starter_items", fieldtype: "Small Text", hidden: 1 },
+			{ fieldname: "starter_items_html", fieldtype: "HTML" },
+		],
+		onload: function (slide) {
+			this.slide = slide;
+			erpnext.setup.render_starter_item_rows(slide);
+		},
+		validate: function () {
+			return erpnext.setup.serialize_starter_item_rows(this.slide);
+		},
+	},
+	{
+		name: "starter_bank",
+		title: __("Add bank or cash balance"),
+		help: __("Optional. Add one opening bank or cash balance."),
+		fields: [
+			{ fieldname: "starter_bank_balance", fieldtype: "Small Text", hidden: 1 },
+			{
+				fieldname: "starter_bank_account_name",
+				label: __("Account Name"),
+				fieldtype: "Data",
+				placeholder: __("Main Bank"),
+			},
+			{
+				fieldname: "starter_bank_amount",
+				label: __("Opening Balance"),
+				fieldtype: "Currency",
+			},
+		],
+		onload: function (slide) {
+			this.slide = slide;
+		},
+		validate: function () {
+			return erpnext.setup.serialize_single_starter_row(this.slide, "starter_bank_balance", {
+				account_name: "starter_bank_account_name",
+				amount: "starter_bank_amount",
+			});
+		},
+	},
+	{
+		name: "starter_review",
+		title: __("Review starter data"),
+		help: __("These records will be created when setup finishes."),
+		fields: [{ fieldname: "starter_review_html", fieldtype: "HTML" }],
+		before_show: function () {
+			erpnext.setup.render_starter_review(this);
+		},
+	},
 ];
+
+erpnext.setup.render_starter_name_rows = function (slide, options) {
+	erpnext.setup.ensure_starter_spacing();
+	let wrapper = slide.get_field(options.wrapper_fieldname).$wrapper;
+	wrapper.html(`
+		<div class="erpnext-starter-rows" data-hidden-fieldname="${options.hidden_fieldname}">
+			<div class="starter-row-list"></div>
+			<button class="btn btn-sm btn-link starter-add-row" type="button">${__("+ Add another")}</button>
+		</div>
+	`);
+
+	let add_row = function (value) {
+		let show_label = wrapper.find(".starter-row").length === 0;
+		let row = $(`
+			<div class="starter-row">
+				${show_label ? `<label>${options.label}</label>` : ""}
+				<div class="starter-row-control flex align-center">
+					<input class="form-control starter-name-input" data-key="${options.input_name}" placeholder="${
+			options.placeholder || ""
+		}">
+					<button class="btn btn-sm btn-secondary starter-remove-row" type="button">${__("Remove")}</button>
+				</div>
+				${
+					options.opening_placeholder
+						? `<input class="form-control starter-opening-amount" type="text" inputmode="decimal" placeholder="${options.opening_placeholder}">`
+						: ""
+				}
+			</div>
+		`);
+		row.find(".starter-name-input").val(value || "");
+		wrapper.find(".starter-row-list").append(row);
+		return row;
+	};
+
+	add_row();
+	wrapper.on("click", ".starter-add-row", () => {
+		add_row().find(".starter-name-input").focus();
+	});
+	wrapper.on("click", ".starter-remove-row", function () {
+		if (wrapper.find(".starter-row").length > 1) {
+			$(this).closest(".starter-row").remove();
+		} else {
+			$(this).closest(".starter-row").find("input").val("");
+		}
+	});
+	wrapper.on("focus", ".starter-opening-amount", function () {
+		let amount = flt($(this).attr("data-value") || $(this).val());
+		$(this).val(amount ? amount : "");
+	});
+	wrapper.on("blur", ".starter-opening-amount", function () {
+		let amount = flt($(this).val());
+		if (!amount) {
+			$(this).val("").removeAttr("data-value");
+			return;
+		}
+
+		$(this).attr("data-value", amount).val(format_currency(amount));
+	});
+};
+
+erpnext.setup.serialize_starter_name_rows = function (slide, hidden_fieldname, label) {
+	let rows = [];
+	let seen = {};
+	let duplicate = null;
+
+	slide
+		.get_field(hidden_fieldname + "_html")
+		.$wrapper.find(".starter-name-input")
+		.each(function () {
+			let value = ($(this).val() || "").trim();
+			if (!value) return;
+
+			let key = value.toLowerCase();
+			if (seen[key]) {
+				duplicate = value;
+				return false;
+			}
+
+			seen[key] = true;
+			let row = {};
+			row[$(this).data("key")] = value;
+			let opening_amount_input = $(this).closest(".starter-row").find(".starter-opening-amount");
+			let opening_amount = flt(opening_amount_input.attr("data-value") || opening_amount_input.val());
+			if (opening_amount) {
+				row.opening_amount = opening_amount;
+			}
+			rows.push(row);
+		});
+
+	if (duplicate) {
+		frappe.msgprint(__("{0} '{1}' is entered more than once.", [label, duplicate]));
+		return false;
+	}
+
+	erpnext.setup.set_starter_hidden_value(slide, hidden_fieldname, rows);
+	return true;
+};
+
+erpnext.setup.render_starter_item_rows = function (slide) {
+	erpnext.setup.ensure_starter_spacing();
+	let wrapper = slide.get_field("starter_items_html").$wrapper;
+	let stock_enabled = !!frappe.wizard.values.module_stock;
+	wrapper.html(`
+		<div class="erpnext-starter-rows starter-item-rows">
+			<div class="starter-row-list"></div>
+			<button class="btn btn-sm btn-link starter-add-row" type="button">${__("+ Add another")}</button>
+		</div>
+	`);
+
+	let add_row = function () {
+		let show_label = wrapper.find(".starter-item-row").length === 0;
+		let row = $(`
+			<div class="starter-row starter-item-row">
+				${show_label ? `<label>${__("Item name")}</label>` : ""}
+				<div class="starter-row-control flex align-center">
+					<input class="form-control starter-item-name" placeholder="${__("Cotton T-Shirt")}">
+					<button class="btn btn-sm btn-secondary starter-remove-row" type="button">${__("Remove")}</button>
+				</div>
+				<div class="starter-checks flex flex-wrap">
+					<label><input type="checkbox" data-key="is_sales_item" checked> ${__("Sell")}</label>
+					<label><input type="checkbox" data-key="is_purchase_item" checked> ${__("Buy")}</label>
+					<label class="starter-stock-check"><input type="checkbox" data-key="is_stock_item"> ${__("Stock")}</label>
+				</div>
+				<div class="starter-opening-stock">
+					<input class="form-control starter-opening-qty" type="number" min="0" step="any" placeholder="${__(
+						"Opening stock"
+					)}">
+				</div>
+			</div>
+		`);
+		row.find('[data-key="is_stock_item"]').prop("checked", stock_enabled);
+		if (!stock_enabled) {
+			row.find(".starter-stock-check").hide();
+			row.find(".starter-opening-stock").hide();
+		}
+		wrapper.find(".starter-row-list").append(row);
+		return row;
+	};
+
+	add_row();
+	wrapper.on("click", ".starter-add-row", () => {
+		add_row().find(".starter-item-name").focus();
+	});
+	wrapper.on("click", ".starter-remove-row", function () {
+		if (wrapper.find(".starter-item-row").length > 1) {
+			$(this).closest(".starter-item-row").remove();
+		} else {
+			$(this).closest(".starter-item-row").find(".starter-item-name").val("");
+		}
+	});
+	wrapper.on("change", '[data-key="is_stock_item"]', function () {
+		let row = $(this).closest(".starter-item-row");
+		let is_stock_item = $(this).prop("checked");
+		row.find(".starter-opening-stock").toggle(is_stock_item);
+		if (!is_stock_item) {
+			row.find(".starter-opening-qty").val("");
+		}
+	});
+};
+
+erpnext.setup.ensure_starter_spacing = function () {
+	if ($("#erpnext-starter-setup-styles").length) return;
+
+	$(`<style id="erpnext-starter-setup-styles">
+		.erpnext-starter-rows {
+			text-align: left;
+		}
+		.erpnext-starter-rows .starter-row {
+			margin-bottom: 24px;
+		}
+		.erpnext-starter-rows .starter-row-list .starter-row:last-child {
+			margin-bottom: 18px;
+		}
+		.erpnext-starter-rows .starter-row-control {
+			gap: 10px;
+		}
+		.erpnext-starter-rows .starter-row-control .form-control {
+			flex: 1 1 auto;
+			min-width: 0;
+		}
+		.erpnext-starter-rows .starter-remove-row {
+			flex: 0 0 auto;
+			white-space: nowrap;
+		}
+		.erpnext-starter-rows .starter-add-row {
+			margin-top: 2px;
+			padding-left: 0;
+			padding-right: 0;
+		}
+		.erpnext-starter-rows .starter-checks {
+			gap: 14px;
+			margin-top: 10px;
+		}
+		.erpnext-starter-rows .starter-checks label {
+			margin: 0;
+		}
+		.erpnext-starter-rows .starter-opening-stock,
+		.erpnext-starter-rows .starter-opening-amount {
+			margin-top: 10px;
+			max-width: 180px;
+		}
+		.erpnext-starter-review {
+			margin: 0 auto;
+			max-width: 420px;
+			text-align: left;
+		}
+		.erpnext-starter-review .table {
+			margin-bottom: 0;
+		}
+		@media (max-width: 576px) {
+			.erpnext-starter-rows .starter-row-control {
+				align-items: stretch;
+				flex-direction: column;
+			}
+			.erpnext-starter-rows .starter-remove-row {
+				align-self: flex-start;
+			}
+		}
+	</style>`).appendTo("head");
+};
+
+erpnext.setup.ensure_organization_styles = function () {
+	if ($("#erpnext-organization-setup-styles").length) return;
+
+	$(`<style id="erpnext-organization-setup-styles">
+		.setup-collapsible-section {
+			margin-bottom: var(--margin-md);
+			text-align: left;
+		}
+		.setup-collapsible-toggle {
+			align-items: center;
+			background: transparent;
+			border: 0;
+			cursor: pointer;
+			display: inline-flex;
+			gap: 8px;
+			font-size: var(--text-base);
+			font-weight: 500;
+			padding: 0;
+		}
+		.setup-collapsible-toggle:hover {
+			color: var(--text-color);
+		}
+		.setup-collapsible-icon {
+			display: inline-block;
+		}
+	</style>`).appendTo("head");
+};
+
+erpnext.setup.serialize_starter_item_rows = function (slide) {
+	let rows = [];
+	let seen = {};
+	let duplicate = null;
+
+	slide
+		.get_field("starter_items_html")
+		.$wrapper.find(".starter-item-row")
+		.each(function () {
+			let row = $(this);
+			let item_name = (row.find(".starter-item-name").val() || "").trim();
+			if (!item_name) return;
+
+			let key = item_name.toLowerCase();
+			if (seen[key]) {
+				duplicate = item_name;
+				return false;
+			}
+
+			seen[key] = true;
+			rows.push({
+				item_name: item_name,
+				is_sales_item: row.find('[data-key="is_sales_item"]').prop("checked") ? 1 : 0,
+				is_purchase_item: row.find('[data-key="is_purchase_item"]').prop("checked") ? 1 : 0,
+				is_stock_item: row.find('[data-key="is_stock_item"]').prop("checked") ? 1 : 0,
+				opening_qty: row.find(".starter-opening-qty").val() || 0,
+			});
+		});
+
+	if (duplicate) {
+		frappe.msgprint(__("Item '{0}' is entered more than once.", [duplicate]));
+		return false;
+	}
+
+	erpnext.setup.set_starter_hidden_value(slide, "starter_items", rows);
+	return true;
+};
+
+erpnext.setup.serialize_single_starter_row = function (slide, hidden_fieldname, field_map) {
+	let row = {};
+	let has_value = false;
+
+	Object.keys(field_map).forEach(function (key) {
+		let value = slide.get_field(field_map[key]).get_value();
+		if (value) {
+			has_value = true;
+		}
+		row[key] = value;
+	});
+
+	erpnext.setup.set_starter_hidden_value(slide, hidden_fieldname, has_value ? [row] : []);
+	return true;
+};
+
+erpnext.setup.set_starter_hidden_value = function (slide, fieldname, rows) {
+	let value = JSON.stringify(rows);
+	slide.get_field(fieldname).set_value(value);
+	slide.values = slide.values || {};
+	slide.values[fieldname] = value;
+};
+
+erpnext.setup.render_starter_review = function (slide) {
+	let values = frappe.wizard.values || {};
+	let counts = [
+		[__("Customers"), erpnext.setup.count_starter_rows(values.starter_customers)],
+		[__("Suppliers"), erpnext.setup.count_starter_rows(values.starter_suppliers)],
+		[__("Items"), erpnext.setup.count_starter_rows(values.starter_items)],
+		[__("Opening Stock"), erpnext.setup.count_starter_item_stock_rows(values.starter_items)],
+		[__("Opening Receivable"), erpnext.setup.count_starter_opening_amount_rows(values.starter_customers)],
+		[__("Opening Payable"), erpnext.setup.count_starter_opening_amount_rows(values.starter_suppliers)],
+		[__("Bank/Cash Balance"), erpnext.setup.count_starter_rows(values.starter_bank_balance)],
+	];
+	let rows = counts
+		.filter((d) => d[1])
+		.map(
+			(d) => `
+				<tr>
+					<td>${d[0]}</td>
+					<td class="text-right">${d[1]}</td>
+				</tr>
+			`
+		)
+		.join("");
+
+	slide.get_field("starter_review_html").$wrapper.html(`
+		<div class="erpnext-starter-review">
+			${
+				rows
+					? `<table class="table table-bordered">
+						<thead>
+							<tr>
+								<th>${__("Record")}</th>
+								<th class="text-right">${__("Count")}</th>
+							</tr>
+						</thead>
+						<tbody>${rows}</tbody>
+					</table>`
+					: `<p>${__("No starter records selected. Setup can still finish.")}</p>`
+			}
+		</div>
+	`);
+};
+
+erpnext.setup.count_starter_rows = function (value) {
+	try {
+		return (JSON.parse(value || "[]") || []).filter((row) =>
+			Object.keys(row || {}).some((key) => row[key])
+		).length;
+	} catch (e) {
+		return 0;
+	}
+};
+
+erpnext.setup.count_starter_item_stock_rows = function (value) {
+	try {
+		return (JSON.parse(value || "[]") || []).filter((row) => Number(row.opening_qty || 0) > 0).length;
+	} catch (e) {
+		return 0;
+	}
+};
+
+erpnext.setup.count_starter_opening_amount_rows = function (value) {
+	try {
+		return (JSON.parse(value || "[]") || []).filter((row) => Number(row.opening_amount || 0) > 0).length;
+	} catch (e) {
+		return 0;
+	}
+};
 
 // Modules pre-selected on the persona slide based on the chosen industry.
 // Keys must match the persona_industry option values. Accounting is always on.

--- a/erpnext/setup/setup_wizard/operations/starter_data.py
+++ b/erpnext/setup/setup_wizard/operations/starter_data.py
@@ -1,0 +1,415 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and Contributors
+# License: GNU General Public License v3. See license.txt
+
+import json
+
+import frappe
+from frappe import _
+from frappe.utils import flt, nowdate
+
+STARTER_FIELDS = (
+	"starter_customers",
+	"starter_suppliers",
+	"starter_items",
+	"starter_stock",
+	"starter_receivables",
+	"starter_payables",
+	"starter_bank_balance",
+)
+
+
+def has_starter_data(setup_values):
+	return any(_parse_rows(setup_values.get(field)) for field in STARTER_FIELDS)
+
+
+def create_starter_data(setup_values):
+	created = frappe._dict(
+		customers=[],
+		suppliers=[],
+		items=[],
+		stock_entries=[],
+		receivables=[],
+		payables=[],
+		bank_entries=[],
+	)
+
+	created.customers = create_customers(setup_values)
+	created.suppliers = create_suppliers(setup_values)
+	created.items = create_items(setup_values)
+	created.stock_entries = create_opening_stock(setup_values)
+	created.receivables = create_opening_invoices(setup_values, "Sales")
+	created.payables = create_opening_invoices(setup_values, "Purchase")
+	created.bank_entries = create_bank_balance(setup_values)
+
+	return created
+
+
+def create_customers(setup_values):
+	customer_group = _first_existing("Customer Group", [_("Commercial"), _("Individual")])
+	territory = _first_existing("Territory", [setup_values.get("country"), _("Rest Of The World")])
+	customers = []
+
+	for row in _parse_rows(setup_values.get("starter_customers")):
+		customer_name = _clean(row.get("customer_name"))
+		if not customer_name:
+			continue
+
+		existing = frappe.db.exists("Customer", {"customer_name": customer_name})
+		if existing:
+			customers.append(existing)
+			continue
+
+		customer = frappe.get_doc(
+			{
+				"doctype": "Customer",
+				"customer_name": customer_name,
+				"customer_group": customer_group,
+				"territory": territory,
+				"customer_type": "Company",
+			}
+		)
+		customer.flags.ignore_mandatory = True
+		customer.insert(ignore_permissions=True)
+		customers.append(customer.name)
+
+	return customers
+
+
+def create_suppliers(setup_values):
+	supplier_group = _first_existing("Supplier Group", [_("Services"), _("Local")])
+	suppliers = []
+
+	for row in _parse_rows(setup_values.get("starter_suppliers")):
+		supplier_name = _clean(row.get("supplier_name"))
+		if not supplier_name:
+			continue
+
+		existing = frappe.db.exists("Supplier", {"supplier_name": supplier_name})
+		if existing:
+			suppliers.append(existing)
+			continue
+
+		supplier = frappe.get_doc(
+			{
+				"doctype": "Supplier",
+				"supplier_name": supplier_name,
+				"supplier_group": supplier_group,
+				"supplier_type": "Company",
+			}
+		)
+		supplier.flags.ignore_mandatory = True
+		supplier.insert(ignore_permissions=True)
+		suppliers.append(supplier.name)
+
+	return suppliers
+
+
+def create_items(setup_values):
+	items = []
+
+	for row in _parse_rows(setup_values.get("starter_items")):
+		item_name = _clean(row.get("item_name"))
+		if not item_name:
+			continue
+
+		existing = frappe.db.exists("Item", {"item_name": item_name}) or frappe.db.exists("Item", item_name)
+		if existing:
+			items.append(existing)
+			continue
+
+		is_stock_item = 1 if row.get("is_stock_item") else 0
+		item = frappe.get_doc(
+			{
+				"doctype": "Item",
+				"item_code": item_name,
+				"item_name": item_name,
+				"item_group": _("Products") if is_stock_item else _("Services"),
+				"stock_uom": "Nos",
+				"is_stock_item": is_stock_item,
+				"is_sales_item": 1 if row.get("is_sales_item") else 0,
+				"is_purchase_item": 1 if row.get("is_purchase_item") else 0,
+			}
+		)
+		item.flags.ignore_mandatory = True
+		item.insert(ignore_permissions=True)
+		items.append(item.name)
+
+	return items
+
+
+def create_opening_stock(setup_values):
+	entries = []
+	company = setup_values.get("company_name") or frappe.defaults.get_global_default("company")
+	default_warehouse = _get_default_warehouse(company)
+	temporary_opening_account = _get_temporary_opening_account(company)
+	rows = _parse_rows(setup_values.get("starter_stock")) + _get_opening_stock_from_items(setup_values)
+
+	for row in rows:
+		item_code = _clean(row.get("item_code"))
+		qty = flt(row.get("qty"))
+		if not item_code or qty <= 0:
+			continue
+
+		item_code = _get_item(item_code) or item_code
+		warehouse = row.get("warehouse") or default_warehouse
+		if not warehouse:
+			continue
+
+		entry_name = _setup_name("SE", item_code, warehouse)
+		if frappe.db.exists("Stock Entry", entry_name):
+			entries.append(entry_name)
+			continue
+
+		stock_entry = frappe.get_doc(
+			{
+				"doctype": "Stock Entry",
+				"name": entry_name,
+				"company": company,
+				"purpose": "Material Receipt",
+				"is_opening": "Yes",
+				"posting_date": row.get("posting_date") or nowdate(),
+				"set_posting_time": 1,
+				"items": [
+					{
+						"item_code": item_code,
+						"t_warehouse": warehouse,
+						"qty": qty,
+						"basic_rate": flt(row.get("valuation_rate")) or 0,
+						"expense_account": temporary_opening_account,
+						"allow_zero_valuation_rate": 1,
+					}
+				],
+			}
+		)
+		stock_entry.flags.ignore_mandatory = True
+		stock_entry.insert(ignore_permissions=True, set_name=entry_name)
+		stock_entry.submit()
+		entries.append(stock_entry.name)
+
+	return entries
+
+
+def _get_opening_stock_from_items(setup_values):
+	rows = []
+	for row in _parse_rows(setup_values.get("starter_items")):
+		qty = flt(row.get("opening_qty"))
+		if not row.get("is_stock_item") or qty <= 0:
+			continue
+
+		item_name = _clean(row.get("item_name"))
+		if not item_name:
+			continue
+
+		rows.append({"item_code": item_name, "qty": qty})
+
+	return rows
+
+
+def create_opening_invoices(setup_values, invoice_type):
+	fieldname = "starter_receivables" if invoice_type == "Sales" else "starter_payables"
+	party_type = "Customer" if invoice_type == "Sales" else "Supplier"
+	invoice_doctype = "Sales Invoice" if invoice_type == "Sales" else "Purchase Invoice"
+	created = []
+
+	rows = _parse_rows(setup_values.get(fieldname)) + _get_opening_invoice_rows_from_parties(
+		setup_values, invoice_type
+	)
+	if not rows:
+		return created
+
+	company = setup_values.get("company_name") or frappe.defaults.get_global_default("company")
+
+	temporary_opening_account = _get_temporary_opening_account(company)
+	from erpnext.accounts.doctype.opening_invoice_creation_tool.opening_invoice_creation_tool import (
+		start_import,
+	)
+
+	invoices = []
+	for row in rows:
+		party = _clean(row.get("customer") if party_type == "Customer" else row.get("supplier"))
+		amount = flt(row.get("amount"))
+		if not party or amount <= 0:
+			continue
+
+		party = _get_party(party_type, party) or party
+		if not frappe.db.exists(party_type, party):
+			continue
+
+		invoice_number = _setup_name("SI" if invoice_type == "Sales" else "PI", party)
+		if frappe.db.exists(invoice_doctype, invoice_number):
+			created.append(invoice_number)
+			continue
+
+		row = frappe._dict(
+			{
+				"party": party,
+				"party_type": party_type,
+				"outstanding_amount": amount,
+				"posting_date": row.get("posting_date") or nowdate(),
+				"due_date": row.get("posting_date") or nowdate(),
+				"temporary_opening_account": temporary_opening_account,
+				"invoice_number": invoice_number,
+				"item_name": _("Opening Invoice Item"),
+				"qty": 1,
+			}
+		)
+		tool = frappe.new_doc("Opening Invoice Creation Tool")
+		tool.company = company
+		tool.invoice_type = invoice_type
+		invoices.append(tool.get_invoice_dict(row))
+
+	if invoices:
+		created.extend(start_import(invoices))
+
+	return created
+
+
+def _get_opening_invoice_rows_from_parties(setup_values, invoice_type):
+	rows = []
+	if invoice_type == "Sales":
+		fieldname = "starter_customers"
+		party_name_field = "customer_name"
+		party_field = "customer"
+	else:
+		fieldname = "starter_suppliers"
+		party_name_field = "supplier_name"
+		party_field = "supplier"
+
+	for row in _parse_rows(setup_values.get(fieldname)):
+		party = _clean(row.get(party_name_field))
+		amount = flt(row.get("opening_amount"))
+		if party and amount > 0:
+			rows.append({party_field: party, "amount": amount})
+
+	return rows
+
+
+def _get_temporary_opening_account(company):
+	from erpnext.accounts.doctype.opening_invoice_creation_tool.opening_invoice_creation_tool import (
+		get_temporary_opening_account,
+	)
+
+	return get_temporary_opening_account(company)
+
+
+def create_bank_balance(setup_values):
+	rows = _parse_rows(setup_values.get("starter_bank_balance"))
+	if not rows:
+		return []
+
+	company = setup_values.get("company_name") or frappe.defaults.get_global_default("company")
+	company_abbr = frappe.get_cached_value("Company", company, "abbr")
+	equity_account = _get_account(company, root_type="Equity")
+	created = []
+
+	for row in rows:
+		account_name = _clean(row.get("account_name")) or _("Opening Bank")
+		amount = flt(row.get("amount"))
+		if amount <= 0 or not equity_account:
+			continue
+
+		account = _get_or_create_bank_account(account_name, company, company_abbr)
+		entry_name = _setup_name("JE-BANK", account)
+		if frappe.db.exists("Journal Entry", entry_name):
+			created.append(entry_name)
+			continue
+
+		journal_entry = frappe.get_doc(
+			{
+				"doctype": "Journal Entry",
+				"name": entry_name,
+				"voucher_type": "Opening Entry",
+				"is_opening": "Yes",
+				"company": company,
+				"posting_date": row.get("posting_date") or nowdate(),
+				"accounts": [
+					{"account": account, "debit_in_account_currency": amount},
+					{"account": equity_account, "credit_in_account_currency": amount},
+				],
+			}
+		)
+		journal_entry.flags.ignore_mandatory = True
+		journal_entry.insert(ignore_permissions=True, set_name=entry_name)
+		journal_entry.submit()
+		created.append(journal_entry.name)
+
+	return created
+
+
+def _parse_rows(value):
+	if not value:
+		return []
+	if isinstance(value, list):
+		return [frappe._dict(row) for row in value if row]
+	if isinstance(value, dict):
+		return [frappe._dict(value)]
+	try:
+		parsed = json.loads(value)
+	except (TypeError, ValueError):
+		return []
+	if isinstance(parsed, list):
+		return [frappe._dict(row) for row in parsed if row]
+	if isinstance(parsed, dict):
+		return [frappe._dict(parsed)]
+	return []
+
+
+def _clean(value):
+	return (value or "").strip()
+
+
+def _first_existing(doctype, names):
+	for name in names:
+		if name and frappe.db.exists(doctype, name):
+			return name
+	return frappe.db.get_value(doctype, {"is_group": 0}, "name")
+
+
+def _get_item(item):
+	return frappe.db.exists("Item", item) or frappe.db.get_value("Item", {"item_name": item})
+
+
+def _get_party(party_type, party):
+	party_name_field = "customer_name" if party_type == "Customer" else "supplier_name"
+	return frappe.db.exists(party_type, party) or frappe.db.get_value(party_type, {party_name_field: party})
+
+
+def _get_default_warehouse(company):
+	warehouse = frappe.db.get_single_value("Stock Settings", "default_warehouse")
+	if warehouse:
+		return warehouse
+	return frappe.db.get_value("Warehouse", {"company": company, "warehouse_name": _("Stores")})
+
+
+def _get_account(company, **filters):
+	filters.update({"company": company, "is_group": 0})
+	return frappe.db.get_value("Account", filters, "name")
+
+
+def _get_or_create_bank_account(account_name, company, company_abbr):
+	account = frappe.db.exists("Account", f"{account_name} - {company_abbr}")
+	if account:
+		return account
+
+	parent_account = _get_account(company, root_type="Asset", account_type="Bank") or _get_account(
+		company, root_type="Asset"
+	)
+	parent = frappe.get_cached_value("Account", parent_account, "parent_account") if parent_account else None
+
+	account = frappe.get_doc(
+		{
+			"doctype": "Account",
+			"account_name": account_name,
+			"parent_account": parent or parent_account,
+			"company": company,
+			"account_type": "Bank",
+		}
+	)
+	account.flags.ignore_mandatory = True
+	account.insert(ignore_permissions=True)
+	return account.name
+
+
+def _setup_name(prefix, *parts):
+	name = "-".join([prefix, *[frappe.scrub(str(part)).replace("_", "-") for part in parts if part]])
+	return name[:140]

--- a/erpnext/setup/setup_wizard/operations/test_starter_data.py
+++ b/erpnext/setup/setup_wizard/operations/test_starter_data.py
@@ -1,0 +1,310 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and Contributors
+# License: GNU General Public License v3. See license.txt
+
+import json
+import unittest
+from unittest.mock import MagicMock, patch
+
+import frappe
+
+from erpnext.setup.setup_wizard import setup_wizard
+from erpnext.setup.setup_wizard.operations import starter_data
+
+
+class TestStarterData(unittest.TestCase):
+	def test_has_starter_data_detects_non_empty_rows(self):
+		self.assertFalse(starter_data.has_starter_data({}))
+		self.assertFalse(starter_data.has_starter_data({"starter_customers": "[]"}))
+		self.assertTrue(
+			starter_data.has_starter_data(
+				{"starter_customers": json.dumps([{"customer_name": "Starter Customer"}])}
+			)
+		)
+		self.assertTrue(starter_data.has_starter_data({"starter_items": [{"item_name": "Starter Item"}]}))
+
+	def test_create_customers_uses_defaults(self):
+		inserted_customer = MagicMock(name="Starter Customer")
+		inserted_customer.name = "Starter Customer"
+
+		with (
+			patch.object(starter_data, "_first_existing", side_effect=["Commercial", "India"]),
+			patch.object(starter_data.frappe.db, "exists", return_value=None),
+			patch.object(starter_data.frappe, "get_doc", return_value=inserted_customer) as get_doc,
+		):
+			created = starter_data.create_customers(
+				frappe._dict(
+					{
+						"country": "India",
+						"starter_customers": json.dumps([{"customer_name": "Starter Customer"}]),
+					}
+				)
+			)
+
+		self.assertEqual(created, ["Starter Customer"])
+		get_doc.assert_called_once_with(
+			{
+				"doctype": "Customer",
+				"customer_name": "Starter Customer",
+				"customer_group": "Commercial",
+				"territory": "India",
+				"customer_type": "Company",
+			}
+		)
+		inserted_customer.insert.assert_called_once_with(ignore_permissions=True)
+
+	def test_create_items_uses_stock_and_sale_purchase_flags(self):
+		item_doc = MagicMock(name="Starter Item")
+		item_doc.name = "Starter Item"
+
+		with (
+			patch.object(starter_data.frappe.db, "exists", return_value=None),
+			patch.object(starter_data.frappe, "get_doc", return_value=item_doc) as get_doc,
+		):
+			created = starter_data.create_items(
+				frappe._dict(
+					{
+						"starter_items": json.dumps(
+							[
+								{
+									"item_name": "Starter Item",
+									"is_stock_item": 1,
+									"is_sales_item": 1,
+									"is_purchase_item": 0,
+								}
+							]
+						)
+					}
+				)
+			)
+
+		self.assertEqual(created, ["Starter Item"])
+		get_doc.assert_called_once_with(
+			{
+				"doctype": "Item",
+				"item_code": "Starter Item",
+				"item_name": "Starter Item",
+				"item_group": "Products",
+				"stock_uom": "Nos",
+				"is_stock_item": 1,
+				"is_sales_item": 1,
+				"is_purchase_item": 0,
+			}
+		)
+		item_doc.insert.assert_called_once_with(ignore_permissions=True)
+
+	def test_create_opening_stock_uses_item_opening_qty_and_temporary_account(self):
+		stock_entry = MagicMock()
+		stock_entry.name = "SE-starter-item-test-warehouse-tc"
+
+		with (
+			patch.object(starter_data, "_get_default_warehouse", return_value="_Test Warehouse - _TC"),
+			patch.object(
+				starter_data, "_get_temporary_opening_account", return_value="Temporary Opening - _TC"
+			),
+			patch.object(starter_data, "_get_item", return_value="Starter Item"),
+			patch.object(starter_data.frappe.db, "exists", return_value=None),
+			patch.object(starter_data.frappe, "get_doc", return_value=stock_entry) as get_doc,
+		):
+			created = starter_data.create_opening_stock(
+				frappe._dict(
+					{
+						"company_name": "_Test Company",
+						"starter_items": json.dumps(
+							[
+								{
+									"item_name": "Starter Item",
+									"is_stock_item": 1,
+									"opening_qty": 7,
+								},
+								{
+									"item_name": "Ignored Service",
+									"is_stock_item": 0,
+									"opening_qty": 5,
+								},
+							]
+						),
+					}
+				)
+			)
+
+		self.assertEqual(created, ["SE-starter-item-test-warehouse-tc"])
+		stock_entry_payload = get_doc.call_args.args[0]
+		self.assertEqual(stock_entry_payload["name"], "SE-starter-item--test-warehouse----tc")
+		self.assertEqual(stock_entry_payload["doctype"], "Stock Entry")
+		self.assertEqual(stock_entry_payload["company"], "_Test Company")
+		self.assertEqual(stock_entry_payload["is_opening"], "Yes")
+		self.assertEqual(stock_entry_payload["items"][0]["item_code"], "Starter Item")
+		self.assertEqual(stock_entry_payload["items"][0]["qty"], 7)
+		self.assertEqual(stock_entry_payload["items"][0]["t_warehouse"], "_Test Warehouse - _TC")
+		self.assertEqual(stock_entry_payload["items"][0]["expense_account"], "Temporary Opening - _TC")
+		stock_entry.insert.assert_called_once_with(
+			ignore_permissions=True, set_name="SE-starter-item--test-warehouse----tc"
+		)
+		stock_entry.submit.assert_called_once()
+
+	def test_create_opening_invoices_from_customer_rows(self):
+		tool = MagicMock()
+		tool.get_invoice_dict.side_effect = lambda row: frappe._dict(
+			{"party": row.party, "outstanding_amount": row.outstanding_amount}
+		)
+
+		def exists(doctype, name_or_filters=None):
+			if doctype == "Sales Invoice":
+				return None
+			if doctype == "Customer":
+				return name_or_filters
+			return None
+
+		with (
+			patch.object(
+				starter_data, "_get_temporary_opening_account", return_value="Temporary Opening - _TC"
+			),
+			patch.object(starter_data, "_get_party", side_effect=lambda _party_type, party: party),
+			patch.object(starter_data.frappe.db, "exists", side_effect=exists),
+			patch.object(starter_data.frappe, "new_doc", return_value=tool),
+			patch(
+				"erpnext.accounts.doctype.opening_invoice_creation_tool.opening_invoice_creation_tool.start_import",
+				return_value=["SI-starter-customer"],
+			) as start_import,
+		):
+			created = starter_data.create_opening_invoices(
+				frappe._dict(
+					{
+						"company_name": "_Test Company",
+						"starter_customers": json.dumps(
+							[
+								{"customer_name": "Starter Customer", "opening_amount": 1250},
+								{"customer_name": "Ignored Customer", "opening_amount": 0},
+							]
+						),
+					}
+				),
+				"Sales",
+			)
+
+		self.assertEqual(created, ["SI-starter-customer"])
+		start_import.assert_called_once()
+		invoices = start_import.call_args.args[0]
+		self.assertEqual(len(invoices), 1)
+		self.assertEqual(invoices[0].party, "Starter Customer")
+		self.assertEqual(invoices[0].outstanding_amount, 1250)
+		self.assertEqual(tool.company, "_Test Company")
+		self.assertEqual(tool.invoice_type, "Sales")
+
+	def test_create_bank_balance_creates_opening_journal_entry(self):
+		journal_entry = MagicMock()
+		journal_entry.name = "JE-BANK-starter-bank----tc"
+
+		with (
+			patch.object(starter_data, "_get_account", return_value="Opening Equity - _TC"),
+			patch.object(starter_data, "_get_or_create_bank_account", return_value="Starter Bank - _TC"),
+			patch.object(starter_data.frappe, "defaults") as defaults,
+			patch.object(starter_data.frappe, "get_cached_value", return_value="_TC"),
+			patch.object(starter_data.frappe.db, "exists", return_value=None),
+			patch.object(starter_data.frappe, "get_doc", return_value=journal_entry) as get_doc,
+			patch.object(starter_data, "nowdate", return_value="2026-07-03"),
+		):
+			defaults.get_global_default.return_value = "_Test Company"
+			created = starter_data.create_bank_balance(
+				frappe._dict(
+					{
+						"company_name": "_Test Company",
+						"starter_bank_balance": json.dumps(
+							[{"account_name": "Starter Bank", "amount": 3000}]
+						),
+					}
+				)
+			)
+
+		self.assertEqual(created, ["JE-BANK-starter-bank----tc"])
+		journal_entry_payload = get_doc.call_args.args[0]
+		self.assertEqual(journal_entry_payload["name"], "JE-BANK-starter-bank----tc")
+		self.assertEqual(journal_entry_payload["doctype"], "Journal Entry")
+		self.assertEqual(journal_entry_payload["voucher_type"], "Opening Entry")
+		self.assertEqual(journal_entry_payload["is_opening"], "Yes")
+		self.assertEqual(
+			journal_entry_payload["accounts"],
+			[
+				{"account": "Starter Bank - _TC", "debit_in_account_currency": 3000},
+				{"account": "Opening Equity - _TC", "credit_in_account_currency": 3000},
+			],
+		)
+		journal_entry.insert.assert_called_once_with(
+			ignore_permissions=True, set_name="JE-BANK-starter-bank----tc"
+		)
+		journal_entry.submit.assert_called_once()
+
+
+class TestSetupWizardStarterData(unittest.TestCase):
+	def test_setup_stages_include_starter_data_stage_only_when_needed(self):
+		stages_without_starter_data = setup_wizard.get_setup_stages({"country": "India"})
+		self.assertNotIn(
+			"Creating starter records", [stage.get("status") for stage in stages_without_starter_data]
+		)
+
+		starter_args = {"starter_customers": json.dumps([{"customer_name": "Starter Customer"}])}
+		stages = setup_wizard.get_setup_stages(starter_args)
+		stage_statuses = [stage.get("status") for stage in stages]
+
+		self.assertEqual(
+			stage_statuses,
+			[
+				"Installing presets",
+				"Setting up company",
+				"Setting defaults",
+				"Creating starter records",
+				"Personalizing your setup",
+			],
+		)
+		starter_stage = stages[3]
+		self.assertEqual(starter_stage["tasks"][0]["fn"], setup_wizard.setup_starter_data)
+		self.assertEqual(
+			starter_stage["tasks"][0]["args"].starter_customers, starter_args["starter_customers"]
+		)
+
+	def test_setup_complete_runs_starter_data_after_defaults(self):
+		call_order = []
+		args = {"starter_customers": json.dumps([{"customer_name": "Starter Customer"}])}
+
+		with (
+			patch.object(
+				setup_wizard, "stage_fixtures", side_effect=lambda _args: call_order.append("fixtures")
+			) as stage_fixtures,
+			patch.object(
+				setup_wizard, "setup_company", side_effect=lambda _args: call_order.append("company")
+			) as setup_company,
+			patch.object(
+				setup_wizard, "setup_defaults", side_effect=lambda _args: call_order.append("defaults")
+			) as setup_defaults,
+			patch.object(
+				setup_wizard, "setup_starter_data", side_effect=lambda _args: call_order.append("starter")
+			) as setup_starter_data,
+		):
+			setup_wizard.setup_complete(args)
+
+		self.assertEqual(call_order, ["fixtures", "company", "defaults", "starter"])
+		stage_fixtures.assert_called_once()
+		setup_company.assert_called_once()
+		setup_defaults.assert_called_once()
+		setup_starter_data.assert_called_once()
+		self.assertEqual(setup_starter_data.call_args.args[0].starter_customers, args["starter_customers"])
+
+	def test_setup_complete_skips_starter_data_when_empty(self):
+		call_order = []
+
+		with (
+			patch.object(
+				setup_wizard, "stage_fixtures", side_effect=lambda _args: call_order.append("fixtures")
+			),
+			patch.object(
+				setup_wizard, "setup_company", side_effect=lambda _args: call_order.append("company")
+			),
+			patch.object(
+				setup_wizard, "setup_defaults", side_effect=lambda _args: call_order.append("defaults")
+			),
+			patch.object(setup_wizard, "setup_starter_data") as setup_starter_data,
+		):
+			setup_wizard.setup_complete({"country": "India"})
+
+		self.assertEqual(call_order, ["fixtures", "company", "defaults"])
+		setup_starter_data.assert_not_called()

--- a/erpnext/setup/setup_wizard/setup_wizard.py
+++ b/erpnext/setup/setup_wizard/setup_wizard.py
@@ -8,9 +8,11 @@ from frappe.utils.telemetry import capture
 
 from erpnext.setup.demo import setup_demo_data
 from erpnext.setup.setup_wizard.operations import install_fixtures as fixtures
+from erpnext.setup.setup_wizard.operations.starter_data import create_starter_data, has_starter_data
 
 
 def get_setup_stages(args=None):  # nosemgrep
+	args = frappe._dict(args or {})
 	stages = [
 		{
 			"status": _("Installing presets"),
@@ -29,14 +31,32 @@ def get_setup_stages(args=None):  # nosemgrep
 				{"fn": setup_defaults, "args": args, "fail_msg": _("Failed to setup defaults")},
 			],
 		},
+	]
+
+	if has_starter_data(args):
+		stages.append(
+			{
+				"status": _("Creating starter records"),
+				"fail_msg": _("Failed to create starter records"),
+				"tasks": [
+					{
+						"fn": setup_starter_data,
+						"args": args,
+						"fail_msg": _("Failed to create starter records"),
+					}
+				],
+			}
+		)
+
+	stages.append(
 		{
 			"status": _("Personalizing your setup"),
 			"fail_msg": _("Failed to personalize your setup"),
 			"tasks": [
 				{"fn": capture_user_persona, "args": args, "fail_msg": _("Failed to personalize your setup")}
 			],
-		},
-	]
+		}
+	)
 
 	if args.get("setup_demo"):
 		stages.append(
@@ -85,12 +105,19 @@ def setup_defaults(args):  # nosemgrep
 	fixtures.install_defaults(frappe._dict(args))
 
 
+def setup_starter_data(args):  # nosemgrep
+	create_starter_data(frappe._dict(args))
+
+
 def setup_demo(args):  # nosemgrep
 	setup_demo_data(args.get("company_name"))
 
 
 # Only for programmatical use
 def setup_complete(args=None):  # nosemgrep
+	args = frappe._dict(args or {})
 	stage_fixtures(args)
 	setup_company(args)
 	setup_defaults(args)
+	if has_starter_data(args):
+		setup_starter_data(args)


### PR DESCRIPTION
## Summary
- add simple starter data screens to the ERPNext setup wizard
- create starter customers, suppliers, items, opening stock, opening invoices, and bank/cash balance during setup
- refine setup wizard progress, advanced setup collapse, review table, and test autofill flow

## Tests
- node --check erpnext/public/js/setup_wizard.js
- python3 -m py_compile erpnext/setup/setup_wizard/operations/starter_data.py erpnext/setup/setup_wizard/setup_wizard.py