### PR TITLE
fix: remove company default on cost center in stock entry detail 

### DIFF
--- a/erpnext/manufacturing/doctype/work_order/test_work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/test_work_order.py
@@ -691,6 +691,28 @@ class TestWorkOrder(ERPNextTestSuite):
 		ste.save()
 		self.assertEqual(ste.get("items")[0].get("cost_center"), "_Test Cost Center - _TC")
 
+	@ERPNextTestSuite.change_settings("Manufacturing Settings", {"make_serial_no_batch_from_work_order": 0})
+	def test_cost_center_for_manufacture_falls_back_to_item_group_default(self):
+		# "_Test Item Group" is master data with buying_cost_center already set to
+		# "_Test Cost Center 2 - _TC" for "_Test Company"; only the FG item and its
+		# BOM need to be created, since no existing item in that group has one.
+		fg_item = make_item(
+			"_Test FG Item For Item Group Cost Center",
+			{"is_stock_item": 1, "item_group": "_Test Item Group", "include_item_in_manufacturing": 1},
+		)
+
+		if not frappe.db.exists("BOM", {"item": fg_item.name, "is_active": 1, "is_default": 1}):
+			make_bom(item=fg_item.name, raw_materials=["_Test Item"])
+
+		wo_order = make_wo_order_test_record(
+			production_item=fg_item.name, skip_transfer=1, source_warehouse="_Test Warehouse - _TC"
+		)
+		ste = frappe.get_doc(make_stock_entry(wo_order.name, "Manufacture", wo_order.qty))
+		ste.insert()
+
+		fg_row = next(d for d in ste.items if d.is_finished_item)
+		self.assertEqual(fg_row.cost_center, "_Test Cost Center 2 - _TC")
+
 	def test_operation_time_with_batch_size(self):
 		fg_item = "Test Batch Size Item For BOM"
 		rm1 = "Test Batch Size Item RM 1 For BOM"

--- a/erpnext/stock/doctype/stock_entry_detail/stock_entry_detail.json
+++ b/erpnext/stock/doctype/stock_entry_detail/stock_entry_detail.json
@@ -346,7 +346,6 @@
    "print_hide": 1
   },
   {
-   "default": ":Company",
    "depends_on": "eval:cint(erpnext.is_perpetual_inventory_enabled(parent.company))",
    "fieldname": "cost_center",
    "fieldtype": "Link",
@@ -690,7 +689,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-07-01 14:27:50.617011",
+ "modified": "2026-07-03 12:11:53.714931",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Stock Entry Detail",


### PR DESCRIPTION
**Issue:** Manufacture Stock Entry ignores Item Group / Brand cost center defaults — always falls back to Company default

**Fixes:** [#56815](https://github.com/frappe/erpnext/issues/56815)

Description:
When generating the Manufacture Stock Entry from a Work Order ("Finish"), every row's cost_center is set to the Company's default cost center, regardless of any buying_cost_center configured on the item's Item Group or Brand defaults.

**Steps to Reproduce:**

1. Create a Cost Center distinct from the Company's default (e.g. "Assembly Dept").
2. On Item Group (or Brand), set buying_cost_center = "Assembly Dept" under Item Group Defaults for the relevant company.
3. Create a manufactured Item belonging to that Item Group (with no item-level cost center override).
4. Create a BOM for that item, then a Work Order.
5. From the Work Order, click Finish to generate the Manufacture Stock Entry.
6. Inspect the finished-goods row in Stock Entry Detail → cost_center.

**Expected Behaviour:** 
cost_center = "Assembly Dept" (from the Item Group default).

**Actual Behaviour:**
 cost_center = the Company's default cost center — the Item Group default is silently ignored.

**Backport Needed For V16 and V15**