### PR TITLE
test: cover Share Transfer consistency validations

### DIFF
--- a/erpnext/accounts/doctype/share_transfer/test_share_transfer.py
+++ b/erpnext/accounts/doctype/share_transfer/test_share_transfer.py
@@ -121,3 +121,65 @@ class TestShareTransfer(ERPNextTestSuite):
 			}
 		)
 		self.assertRaises(ShareDontExists, doc.insert)
+
+
+class TestShareTransferValidation(ERPNextTestSuite):
+	"""basic_validations() enforces the transfer's internal consistency. Exercised
+	directly (to_folio_no set to skip folio auto-naming) so no shareholder fixtures
+	are needed - it only reasons about the document's own fields."""
+
+	def make_transfer(self, **overrides):
+		doc = frappe.new_doc("Share Transfer")
+		doc.update(
+			{
+				"transfer_type": "Transfer",
+				"date": "2026-01-01",
+				"from_shareholder": "SH-A",
+				"to_shareholder": "SH-B",
+				"to_folio_no": "1",
+				"share_type": "Equity",
+				"from_no": 1,
+				"to_no": 100,
+				"no_of_shares": 100,
+				"rate": 10,
+				"amount": 1000,
+				"company": "_Test Company",
+				"equity_or_liability_account": "Creditors - _TC",
+			}
+		)
+		doc.update(overrides)
+		return doc
+
+	def test_baseline_transfer_is_consistent(self):
+		# the helper's defaults must pass, otherwise the negative cases prove nothing
+		self.make_transfer().basic_validations()
+
+	def test_seller_and_buyer_must_differ(self):
+		doc = self.make_transfer(to_shareholder="SH-A")
+		self.assertRaises(frappe.ValidationError, doc.basic_validations)
+
+	def test_share_count_must_match_the_number_range(self):
+		# 1..100 is 100 shares, not 50
+		doc = self.make_transfer(no_of_shares=50)
+		self.assertRaises(frappe.ValidationError, doc.basic_validations)
+
+	def test_amount_must_equal_rate_times_shares(self):
+		doc = self.make_transfer(amount=999)  # 10 * 100 = 1000
+		self.assertRaises(frappe.ValidationError, doc.basic_validations)
+
+	def test_amount_is_derived_when_left_blank(self):
+		doc = self.make_transfer(amount=0)
+		doc.basic_validations()
+		self.assertEqual(doc.amount, 1000)
+
+	def test_equity_or_liability_account_is_required(self):
+		doc = self.make_transfer(equity_or_liability_account=None)
+		self.assertRaises(frappe.ValidationError, doc.basic_validations)
+
+	def test_issue_requires_a_to_shareholder(self):
+		doc = self.make_transfer(transfer_type="Issue", to_shareholder="", asset_account="Cash - _TC")
+		self.assertRaises(frappe.ValidationError, doc.basic_validations)
+
+	def test_purchase_requires_a_from_shareholder(self):
+		doc = self.make_transfer(transfer_type="Purchase", from_shareholder="", asset_account="Cash - _TC")
+		self.assertRaises(frappe.ValidationError, doc.basic_validations)


### PR DESCRIPTION
Adds coverage for `basic_validations` in Share Transfer, which had none of its rules tested (the existing suite covers the share-ledger flow end to end). Exercised on the document directly so no shareholder fixtures are needed:

- Seller and buyer must differ.
- `no_of_shares` must match the from/to number range.
- `amount` must equal rate x shares, and is derived when left blank.
- Equity/Liability account is required.
- Issue requires a To Shareholder; Purchase requires a From Shareholder.

A baseline case asserts the valid document passes, so the negative cases are meaningful.