### PR TITLE
test: cover Asset Capitalization row validations

### DIFF
--- a/erpnext/assets/doctype/asset_capitalization/test_asset_capitalization.py
+++ b/erpnext/assets/doctype/asset_capitalization/test_asset_capitalization.py
@@ -587,3 +587,47 @@ def get_actual_sle_dict(name):
 		}
 
 	return sle_dict
+
+
+class TestAssetCapitalizationValidation(ERPNextTestSuite):
+	"""Row-level validations for the consumed/target items. Exercised on the document
+	directly (the integration tests above cover the full capitalization posting)."""
+
+	def make_capitalization(self, **fields):
+		doc = frappe.new_doc("Asset Capitalization")
+		doc.company = "_Test Company"
+		doc.update(fields)
+		return doc
+
+	def test_source_items_are_mandatory(self):
+		doc = self.make_capitalization()
+		self.assertRaises(frappe.ValidationError, doc.validate_source_mandatory)
+
+	def test_target_item_must_be_a_fixed_asset(self):
+		# _Test Item is a stock item, not a fixed asset
+		doc = self.make_capitalization(target_item_code="_Test Item")
+		self.assertRaises(frappe.ValidationError, doc.validate_target_item)
+
+	def test_consumed_stock_row_rejects_a_non_stock_item(self):
+		doc = self.make_capitalization()
+		doc.append("stock_items", {"item_code": "_Test Non Stock Item", "stock_qty": 1})
+		self.assertRaises(frappe.ValidationError, doc.validate_consumed_stock_item)
+
+	def test_consumed_stock_row_requires_positive_qty(self):
+		doc = self.make_capitalization()
+		doc.append("stock_items", {"item_code": "_Test Item", "stock_qty": 0})
+		self.assertRaises(frappe.ValidationError, doc.validate_consumed_stock_item)
+
+	def test_service_row_rejects_a_stock_item(self):
+		doc = self.make_capitalization()
+		doc.append("service_items", {"item_code": "_Test Item", "qty": 1, "rate": 100})
+		self.assertRaises(frappe.ValidationError, doc.validate_service_item)
+
+	def test_service_row_requires_positive_qty_and_rate(self):
+		zero_qty = self.make_capitalization()
+		zero_qty.append("service_items", {"item_code": "_Test Non Stock Item", "qty": 0, "rate": 100})
+		self.assertRaises(frappe.ValidationError, zero_qty.validate_service_item)
+
+		zero_rate = self.make_capitalization()
+		zero_rate.append("service_items", {"item_code": "_Test Non Stock Item", "qty": 1, "rate": 0})
+		self.assertRaises(frappe.ValidationError, zero_rate.validate_service_item)


### PR DESCRIPTION
Adds coverage for the row-level validations in Asset Capitalization (the existing suite covers the full capitalization posting across perpetual/periodical inventory and composite assets, but not the validation branches). Exercised on the document directly:

- At least one consumed stock/asset/service source is required.
- The target item must be a fixed asset.
- A consumed stock row rejects a non-stock item and requires a positive qty.
- A service row rejects a stock item and requires a positive qty and rate.