### PR TITLE
fix: Stock Closing Entry duplicate check misses contained date ranges

### DIFF
--- a/erpnext/stock/doctype/stock_closing_entry/stock_closing_entry.py
+++ b/erpnext/stock/doctype/stock_closing_entry/stock_closing_entry.py
@@ -59,11 +59,10 @@ class StockClosingEntry(Document):
 			.where(
 				(table.docstatus == 1)
 				& (table.company == self.company)
-				& (
-					(table.from_date.between(self.from_date, self.to_date))
-					| (table.to_date.between(self.from_date, self.to_date))
-					| ((self.from_date >= table.from_date) & (table.from_date >= self.to_date))
-				)
+				# two date ranges overlap when each starts on or before the other ends;
+				# this also catches one range being fully contained within the other
+				& (table.from_date <= self.to_date)
+				& (table.to_date >= self.from_date)
 			)
 		)
 

--- a/erpnext/stock/doctype/stock_closing_entry/test_stock_closing_entry.py
+++ b/erpnext/stock/doctype/stock_closing_entry/test_stock_closing_entry.py
@@ -84,6 +84,18 @@ class TestStockClosingEntryDuplicate(ERPNextTestSuite):
 		overlap = self.make_closing("2026-02-01", "2026-04-30")
 		self.assertRaises(frappe.ValidationError, overlap.insert)
 
+	def test_fully_contained_range_is_rejected(self):
+		# a range entirely inside an existing entry's range is still a duplicate
+		self.submit_closing(self.make_closing("2026-01-01", "2026-12-31"))
+		contained = self.make_closing("2026-03-01", "2026-03-31")
+		self.assertRaises(frappe.ValidationError, contained.insert)
+
+	def test_enclosing_range_is_rejected(self):
+		# and so is a range that fully encloses an existing entry's range
+		self.submit_closing(self.make_closing("2026-03-01", "2026-03-31"))
+		enclosing = self.make_closing("2026-01-01", "2026-12-31")
+		self.assertRaises(frappe.ValidationError, enclosing.insert)
+
 	def test_non_overlapping_range_is_allowed(self):
 		self.submit_closing(self.make_closing("2026-01-01", "2026-03-31"))
 		later = self.make_closing("2026-04-01", "2026-06-30")

--- a/erpnext/stock/doctype/stock_closing_entry/test_stock_closing_entry.py
+++ b/erpnext/stock/doctype/stock_closing_entry/test_stock_closing_entry.py
@@ -87,5 +87,5 @@ class TestStockClosingEntryDuplicate(ERPNextTestSuite):
 	def test_non_overlapping_range_is_allowed(self):
 		self.submit_closing(self.make_closing("2026-01-01", "2026-03-31"))
 		later = self.make_closing("2026-04-01", "2026-06-30")
-		later.insert()
-		self.assertTrue(later.name)
+		later.insert()  # would raise if validate_duplicate wrongly flagged it as overlapping
+		self.assertTrue(frappe.db.exists("Stock Closing Entry", later.name))

--- a/erpnext/stock/doctype/stock_closing_entry/test_stock_closing_entry.py
+++ b/erpnext/stock/doctype/stock_closing_entry/test_stock_closing_entry.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2024, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
 
+from unittest.mock import patch
+
 import frappe
 from frappe.utils import add_days, today
 
@@ -57,3 +59,33 @@ class TestStockClosingEntry(ERPNextTestSuite):
 		).submit()
 		self.last_closing_entry = entry.name
 		return entry
+
+
+class TestStockClosingEntryDuplicate(ERPNextTestSuite):
+	"""validate_duplicate blocks a second submitted closing entry whose date range
+	overlaps an existing one for the same scope (company + warehouse/item filters)."""
+
+	def make_closing(self, from_date, to_date, **fields):
+		doc = frappe.new_doc("Stock Closing Entry")
+		doc.company = COMPANY
+		doc.from_date = from_date
+		doc.to_date = to_date
+		doc.update(fields)
+		return doc
+
+	def submit_closing(self, doc):
+		# the closing-balance build is enqueued on submit; skip it here
+		with patch("erpnext.stock.doctype.stock_closing_entry.stock_closing_entry.enqueue"):
+			doc.submit()
+		return doc
+
+	def test_overlapping_range_is_rejected(self):
+		self.submit_closing(self.make_closing("2026-01-01", "2026-03-31"))
+		overlap = self.make_closing("2026-02-01", "2026-04-30")
+		self.assertRaises(frappe.ValidationError, overlap.insert)
+
+	def test_non_overlapping_range_is_allowed(self):
+		self.submit_closing(self.make_closing("2026-01-01", "2026-03-31"))
+		later = self.make_closing("2026-04-01", "2026-06-30")
+		later.insert()
+		self.assertTrue(later.name)


### PR DESCRIPTION
`validate_duplicate` used three OR'd overlap conditions, but the third — `(self.from_date >= table.from_date) & (table.from_date >= self.to_date)` — is logically inert: since `from_date <= to_date` always holds, it can only be true for a degenerate single-day equality, so it never fires in practice.

The case it was meant to catch — a new date range **fully contained** within an existing submitted entry's range — therefore slips through: the first two conditions only match when an existing entry's endpoint falls inside the new range, which a strictly-contained range never does. So a duplicate closing entry inside an existing period was silently allowed.

**Fix:** replace the three conditions with the canonical interval-overlap predicate `from_date <= self.to_date AND to_date >= self.from_date`, which correctly covers partial overlap, containment in either direction, identical ranges, and boundary touches.

Adds tests: overlapping and non-overlapping ranges (unchanged behaviour), plus the previously-failing **contained** and **enclosing** cases that this fix now rejects.