### PR TITLE
test: cover untested Payment Entry field validations

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/test_payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/test_payment_entry.py
@@ -2317,3 +2317,65 @@ def create_customer(name="_Test Customer 2 USD", currency="USD"):
 		customer.save()
 		customer = customer.name
 	return customer
+
+
+class TestPaymentEntryValidation(ERPNextTestSuite):
+	"""Field-level validations invoked on the document directly, covering branches the
+	integration suite above doesn't reach (no GL / reconciliation setup needed)."""
+
+	def make_pe(self, **fields):
+		doc = frappe.new_doc("Payment Entry")
+		doc.update(fields)
+		return doc
+
+	def test_payment_type_must_be_a_known_value(self):
+		self.assertRaises(frappe.ValidationError, self.make_pe(payment_type="Foo").validate_payment_type)
+		self.make_pe(payment_type="Receive").validate_payment_type()  # valid value passes
+
+	def test_nonexistent_party_is_rejected(self):
+		doc = self.make_pe(party_type="Customer", party="__No Such Customer__")
+		self.assertRaises(frappe.ValidationError, doc.validate_party_details)
+
+	def test_amount_and_exchange_rate_fields_are_mandatory(self):
+		# every field but target_exchange_rate is set, so that missing one raises
+		doc = self.make_pe(
+			paid_amount=100, received_amount=100, source_exchange_rate=1, target_exchange_rate=0
+		)
+		self.assertRaises(frappe.ValidationError, doc.validate_mandatory)
+
+	def test_received_amount_cannot_exceed_paid_in_same_currency(self):
+		doc = self.make_pe(
+			paid_from_account_currency="INR",
+			paid_to_account_currency="INR",
+			paid_amount=100,
+			received_amount=150,
+		)
+		self.assertRaises(frappe.ValidationError, doc.validate_received_amount)
+		# received <= paid is fine
+		doc.received_amount = 50
+		doc.validate_received_amount()
+
+	def test_duplicate_reference_rows_are_rejected(self):
+		doc = self.make_pe()
+		for _ in range(2):
+			doc.append(
+				"references",
+				{"reference_doctype": "Sales Invoice", "reference_name": "SI-X", "allocated_amount": 100},
+			)
+		self.assertRaises(frappe.ValidationError, doc.validate_duplicate_entry)
+
+	def test_receive_from_customer_against_negative_outstanding_is_rejected(self):
+		doc = self.make_pe(party_type="Customer", payment_type="Receive")
+		doc.append(
+			"references",
+			{"reference_doctype": "Sales Invoice", "reference_name": "SI-Y", "allocated_amount": -100},
+		)
+		self.assertRaises(frappe.ValidationError, doc.validate_payment_type_with_outstanding)
+
+	def test_bank_transaction_requires_a_reference_number(self):
+		doc = self.make_pe(payment_type="Pay", paid_from="_Test Bank - _TC")
+		self.assertRaises(frappe.ValidationError, doc.validate_transaction_reference)
+		# supplying the reference details clears the requirement
+		doc.reference_no = "TXN-1"
+		doc.reference_date = "2026-06-15"
+		doc.validate_transaction_reference()


### PR DESCRIPTION
Payment Entry has a large test suite but several field-level validation branches were untested. Adds targeted cases that invoke the validators directly (no GL / reconciliation setup):

- `validate_payment_type` rejects an unknown payment type.
- `validate_party_details` rejects a party that doesn't exist.
- `validate_mandatory` requires the amount / exchange-rate fields.
- `validate_received_amount` blocks received > paid in the same currency.
- `validate_duplicate_entry` rejects duplicate reference rows.
- `validate_payment_type_with_outstanding` blocks receiving from a customer against a negative outstanding.
- `validate_transaction_reference` requires a reference number/date for a bank-account transaction.

These target the dark validation paths rather than the already-covered posting flows.