### PR TITLE
test: cover Stock Reservation Entry validations and helper

### DIFF
--- a/erpnext/stock/doctype/stock_reservation_entry/test_stock_reservation_entry.py
+++ b/erpnext/stock/doctype/stock_reservation_entry/test_stock_reservation_entry.py
@@ -984,8 +984,22 @@ class TestStockReservationEntryValidation(ERPNextTestSuite):
 
 	def test_all_mandatory_fields_are_required(self):
 		self.make_sre().validate_mandatory()  # everything set -> passes
-		self.assertRaises(frappe.ValidationError, self.make_sre(reserved_qty=0).validate_mandatory)
-		self.assertRaises(frappe.ValidationError, self.make_sre(item_code=None).validate_mandatory)
+		# clearing any single mandatory field is rejected
+		mandatory = [
+			"item_code",
+			"warehouse",
+			"voucher_type",
+			"voucher_no",
+			"voucher_detail_no",
+			"available_qty",
+			"voucher_qty",
+			"stock_uom",
+			"reserved_qty",
+			"company",
+		]
+		for field in mandatory:
+			with self.subTest(field=field):
+				self.assertRaises(frappe.ValidationError, self.make_sre(**{field: None}).validate_mandatory)
 
 	def test_amended_document_is_rejected(self):
 		self.assertRaises(frappe.ValidationError, self.make_sre(amended_from="SRE-0001").validate_amended_doc)

--- a/erpnext/stock/doctype/stock_reservation_entry/test_stock_reservation_entry.py
+++ b/erpnext/stock/doctype/stock_reservation_entry/test_stock_reservation_entry.py
@@ -957,3 +957,60 @@ def make_stock_reservation_entry(**args):
 			doc.submit()
 
 	return doc
+
+
+class TestStockReservationEntryValidation(ERPNextTestSuite):
+	"""Field-level validations and pure helpers, exercised on the document directly so
+	they don't need the stock-ledger / reservation fixtures the integration tests build."""
+
+	def make_sre(self, **overrides):
+		doc = frappe.new_doc("Stock Reservation Entry")
+		doc.update(
+			{
+				"item_code": "_Test Item",
+				"warehouse": "_Test Warehouse - _TC",
+				"voucher_type": "Sales Order",
+				"voucher_no": "SO-TEST",
+				"voucher_detail_no": "SOI-TEST",
+				"available_qty": 10,
+				"voucher_qty": 10,
+				"stock_uom": "Nos",
+				"reserved_qty": 10,
+				"company": "_Test Company",
+			}
+		)
+		doc.update(overrides)
+		return doc
+
+	def test_all_mandatory_fields_are_required(self):
+		self.make_sre().validate_mandatory()  # everything set -> passes
+		self.assertRaises(frappe.ValidationError, self.make_sre(reserved_qty=0).validate_mandatory)
+		self.assertRaises(frappe.ValidationError, self.make_sre(item_code=None).validate_mandatory)
+
+	def test_amended_document_is_rejected(self):
+		self.assertRaises(frappe.ValidationError, self.make_sre(amended_from="SRE-0001").validate_amended_doc)
+		self.make_sre().validate_amended_doc()  # not amended -> passes
+
+	def test_can_be_updated_guards(self):
+		self.make_sre().can_be_updated()  # a fresh entry can be updated
+		self.assertRaises(frappe.ValidationError, self.make_sre(status="Delivered").can_be_updated)
+		self.assertRaises(frappe.ValidationError, self.make_sre(status="Partially Delivered").can_be_updated)
+		self.assertRaises(frappe.ValidationError, self.make_sre(from_voucher_type="Pick List").can_be_updated)
+		self.assertRaises(frappe.ValidationError, self.make_sre(delivered_qty=5).can_be_updated)
+
+	def test_group_warehouse_cannot_be_reserved(self):
+		group_wh = frappe.db.get_value("Warehouse", {"company": "_Test Company", "is_group": 1}, "name")
+		self.assertTrue(group_wh, "need a group warehouse for _Test Company")
+		self.assertRaises(frappe.ValidationError, self.make_sre(warehouse=group_wh).validate_group_warehouse)
+		self.make_sre().validate_group_warehouse()  # leaf warehouse -> passes
+
+	def test_get_serial_batch_entries_aggregates(self):
+		doc = self.make_sre(reservation_based_on="Serial and Batch")
+		doc.append("sb_entries", {"serial_no": "SN1"})
+		doc.append("sb_entries", {"serial_no": "SN2"})
+		doc.append("sb_entries", {"batch_no": "B1", "qty": 5})
+		doc.append("sb_entries", {"batch_no": "B1", "qty": 3})
+
+		result = doc.get_serial_batch_entries()
+		self.assertEqual(result.serial_nos, ["SN1", "SN2"])
+		self.assertEqual(result.batches["B1"], 8)


### PR DESCRIPTION
Stock Reservation Entry's integration suite goes through full SO/DN/Pick List flows; several field-level validations and a pure helper were untested. Adds targeted cases invoked on the document directly (no SLE/reservation fixtures):

- `validate_mandatory` requires each of its mandatory fields.
- `validate_amended_doc` rejects an amended entry.
- `can_be_updated` blocks updates when delivered/partially-delivered, when created from a Pick List, or when any qty has been delivered.
- `validate_group_warehouse` rejects reserving stock in a group warehouse.
- `get_serial_batch_entries` aggregates serial numbers and sums batch quantities from the entries.