### PR TITLE
fix: align budget variance report chart with period-wise report data

### DIFF
--- a/erpnext/accounts/report/budget_variance_report/budget_variance_report.py
+++ b/erpnext/accounts/report/budget_variance_report/budget_variance_report.py
@@ -315,21 +315,28 @@ def get_columns(filters):
 	for year in fiscal_year:
 		for from_date, to_date in get_period_date_ranges(filters["period"], year[0]):
 			if filters["period"] == "Yearly":
-				labels = [
-					_("Budget") + " " + str(year[0]),
-					_("Actual") + " " + str(year[0]),
-					_("Variance") + " " + str(year[0]),
+				label_period_pairs = [
+					(_("Budget") + " " + str(year[0]), "budget"),
+					(_("Actual") + " " + str(year[0]), "actual"),
+					(_("Variance") + " " + str(year[0]), "variance"),
 				]
-				for label in labels:
+				for label, period_type in label_period_pairs:
 					columns.append(
-						{"label": label, "fieldtype": "Float", "fieldname": frappe.scrub(label), "width": 150}
+						{
+							"label": label,
+							"fieldtype": "Float",
+							"fieldname": frappe.scrub(label),
+							"width": 150,
+							"period_type": period_type,
+						}
 					)
 			else:
-				for label in [
-					_("Budget") + " (%s)" + " " + str(year[0]),
-					_("Actual") + " (%s)" + " " + str(year[0]),
-					_("Variance") + " (%s)" + " " + str(year[0]),
-				]:
+				label_period_pairs = [
+					(_("Budget") + " (%s)" + " " + str(year[0]), "budget"),
+					(_("Actual") + " (%s)" + " " + str(year[0]), "actual"),
+					(_("Variance") + " (%s)" + " " + str(year[0]), "variance"),
+				]
+				for label, period_type in label_period_pairs:
 					if group_months:
 						label = label % (
 							formatdate(from_date, format_string="MMM")
@@ -340,13 +347,25 @@ def get_columns(filters):
 						label = label % formatdate(from_date, format_string="MMM")
 
 					columns.append(
-						{"label": label, "fieldtype": "Float", "fieldname": frappe.scrub(label), "width": 150}
+						{
+							"label": label,
+							"fieldtype": "Float",
+							"fieldname": frappe.scrub(label),
+							"width": 150,
+							"period_type": period_type,
+						}
 					)
 
 	if filters["period"] != "Yearly":
 		for label in [_("Total Budget"), _("Total Actual"), _("Total Variance")]:
 			columns.append(
-				{"label": label, "fieldtype": "Float", "fieldname": frappe.scrub(label), "width": 150}
+				{
+					"label": label,
+					"fieldtype": "Float",
+					"fieldname": frappe.scrub(label),
+					"width": 150,
+					"period_type": "total",
+				}
 			)
 
 		return columns
@@ -414,37 +433,23 @@ def build_comparison_chart_data(filters, columns, data):
 	if not data:
 		return None
 
-	budget_fields = []
-	actual_fields = []
+	budget_columns = [col for col in columns if col.get("period_type") == "budget"]
+	actual_columns = [col for col in columns if col.get("period_type") == "actual"]
 
-	for col in columns:
-		fieldname = col.get("fieldname")
-		if not fieldname:
-			continue
-
-		if fieldname.startswith("budget_"):
-			budget_fields.append(fieldname)
-		elif fieldname.startswith("actual_"):
-			actual_fields.append(fieldname)
-
-	if not budget_fields or not actual_fields:
+	if not budget_columns or not actual_columns:
 		return None
 
-	labels = [
-		col["label"].replace("Budget", "").strip()
-		for col in columns
-		if col.get("fieldname", "").startswith("budget_")
-	]
+	labels = [col["label"].replace("Budget", "").strip() for col in budget_columns]
 
-	budget_values = [0] * len(budget_fields)
-	actual_values = [0] * len(actual_fields)
+	budget_values = [0] * len(budget_columns)
+	actual_values = [0] * len(actual_columns)
 
 	for row in data:
-		for i, field in enumerate(budget_fields):
-			budget_values[i] += flt(row.get(field))
+		for i, col in enumerate(budget_columns):
+			budget_values[i] += flt(row.get(col["fieldname"]))
 
-		for i, field in enumerate(actual_fields):
-			actual_values[i] += flt(row.get(field))
+		for i, col in enumerate(actual_columns):
+			actual_values[i] += flt(row.get(col["fieldname"]))
 
 	return {
 		"data": {

--- a/erpnext/accounts/report/budget_variance_report/test_budget_variance_report.py
+++ b/erpnext/accounts/report/budget_variance_report/test_budget_variance_report.py
@@ -19,7 +19,7 @@ class TestBudgetVarianceReport(ERPNextTestSuite):
 	def setUp(self):
 		self.fy = get_fiscal_year(nowdate())[0]
 
-	def run_report(self, **extra):
+	def run_report(self, return_full=False, **extra):
 		filters = frappe._dict(
 			{
 				"company": "_Test Company",
@@ -30,7 +30,8 @@ class TestBudgetVarianceReport(ERPNextTestSuite):
 				**extra,
 			}
 		)
-		return execute(filters)[1]
+		result = execute(filters)
+		return result if return_full else result[1]
 
 	def report_row(self, data, dimension, account=ACCOUNT):
 		row = next(
@@ -115,3 +116,66 @@ class TestBudgetVarianceReport(ERPNextTestSuite):
 		# a dimension without any budget produces no report rows
 		data = self.run_report(budget_against_filter=["_Test Write Off Cost Center - _TC"])
 		self.assertEqual(data, [])
+
+	def test_chart_data_actual_aligned_with_correct_period(self):
+		# guards against the chart plotting an actual amount under the previous
+		# period's label instead of the period the transaction was actually posted in
+		set_total_expense_zero(nowdate(), "cost_center")
+		make_budget(
+			budget_against="Cost Center", cost_center=COST_CENTER, budget_amount=120000, submit_budget=1
+		)
+		make_journal_entry(ACCOUNT, "_Test Bank - _TC", 50000, cost_center=COST_CENTER, submit=True)
+
+		_columns, data, _, chart_data = self.run_report(period="Monthly", return_full=True)
+		self.assertIsNotNone(chart_data)
+
+		month_label = frappe.utils.formatdate(nowdate(), "MMM")
+		target_label = f"({month_label}) {self.fy}"
+
+		labels = chart_data["data"]["labels"]
+
+		self.assertIn(target_label, labels)
+		idx = labels.index(target_label)
+
+		actual_values = next(
+			d["values"] for d in chart_data["data"]["datasets"] if d["name"] == frappe._("Actual Expense")
+		)
+
+		self.assertEqual(len(labels), len(actual_values))
+
+		# the journal entry's amount must land under its own posting month
+		self.assertEqual(actual_values[idx], 50000)
+
+		# and must not leak into any neighbouring period (the original bug)
+		for i, value in enumerate(actual_values):
+			if i != idx:
+				self.assertEqual(value, 0)
+
+	def test_chart_data_excludes_totals(self):
+		# guards against "Total Budget"/"Total Actual" columns being swept into the
+		# chart's period datasets, which would double-count against the real periods
+		set_total_expense_zero(nowdate(), "cost_center")
+		make_budget(
+			budget_against="Cost Center", cost_center=COST_CENTER, budget_amount=120000, submit_budget=1
+		)
+		make_journal_entry(ACCOUNT, "_Test Bank - _TC", 50000, cost_center=COST_CENTER, submit=True)
+
+		_columns, data, _, chart_data = self.run_report(period="Monthly", return_full=True)
+		self.assertIsNotNone(chart_data)
+
+		labels = chart_data["data"]["labels"]
+
+		# exactly 12 monthly periods should be charted, not 12 + the 3 Total columns
+		self.assertEqual(len(labels), 12)
+
+		row = self.report_row(data, COST_CENTER)
+
+		budget_values = next(
+			d["values"] for d in chart_data["data"]["datasets"] if d["name"] == frappe._("Budget")
+		)
+
+		self.assertEqual(len(budget_values), 12)
+
+		# sum of the charted monthly budgets should equal the row's total_budget,
+		# not 2x it (which would happen if the Total column were also summed in)
+		self.assertEqual(sum(budget_values), row["total_budget"])


### PR DESCRIPTION
**Issue:**
The Budget Variance Report chart displayed Actual Expense under the previous month's label instead of the transaction month. This caused a mismatch between the chart and the report table, where the table correctly displayed period-wise values while the chart plotted them one month earlier.

**Before:**
<img width="1280" height="643" alt="image" src="https://github.com/user-attachments/assets/478c56f5-9f57-419b-ba12-cf1f2573020d" />



**After:**
<img width="1280" height="643" alt="image" src="https://github.com/user-attachments/assets/a7167e7d-2ce7-42a0-97ba-a939e0832ae1" />

**Ref:** [#723831](https://support.frappe.io/helpdesk/tickets/72831?view=VIEW-HD+Ticket-745)

Backport - v16

Raising this PR on behalf of @ssakthivelmurugan