### PR TITLE
Fix(stock): item form permission errors

### DIFF
--- a/erpnext/stock/dashboard/item_dashboard.py
+++ b/erpnext/stock/dashboard/item_dashboard.py
@@ -17,6 +17,9 @@ def get_data(
 	sort_order: str = "desc",
 ):
 	"""Return data to render the item dashboard"""
+	if not frappe.has_permission("Bin", "read"):
+		return []
+
 	filters = []
 	if item_code:
 		filters.append(["item_code", "=", item_code])
@@ -44,7 +47,10 @@ def get_data(
 		if build_match_conditions("Warehouse", user=frappe.session.user):
 			filters.append(["warehouse", "in", [w.name for w in frappe.get_list("Warehouse")]])
 	except frappe.PermissionError:
-		# user does not have access on warehouse
+		# user does not have access on warehouse; build_match_conditions already queued a
+		# "Not permitted" message via frappe.throw before this was caught, drop it so the
+		# client doesn't show a spurious error for a request that's failing gracefully here
+		frappe.clear_last_message()
 		return []
 
 	items = frappe.db.get_all(

--- a/erpnext/stock/doctype/item/item.js
+++ b/erpnext/stock/doctype/item/item.js
@@ -828,6 +828,13 @@ $.extend(erpnext.item, {
 
 	render_item_prices: function (frm) {
 		if (frm.doc.__islocal) return;
+
+		if (!frappe.model.can_read("Item Price")) {
+			frm.toggle_display("prices_html", false);
+			return;
+		}
+		frm.toggle_display("prices_html", true);
+
 		const requested_item = frm.doc.name;
 		const container = frm.fields_dict["prices_html"].$wrapper;
 


### PR DESCRIPTION
**Issue:** Item form shows permission error pop-ups instead of hiding restricted sections

**Fixes:** [#56365](https://github.com/frappe/erpnext/issues/56365)

**Description:**
Opening any Item form as a user with read access to Item but no access to Item Price and/or Warehouse/Bin throws unhandled permission error popups during form load, instead of the restricted sections failing/hiding gracefully.


**Steps to Reproduce**
1. Create a new Role (e.g. "Restricted Item Viewer") with read permission on Item only.
2. Create a new User and assign only that Role (no other roles).
3. Log in as that user.
4. Go to Item list, open any existing Item.
5. Observe permission error popups fire automatically on form load:
  - "Not permitted" (Item Price) — from the Item Prices tab fetch.
  - "Permission Error: Insufficient Permission for Warehouse" — from the stock dashboard fetch.
  
 **Before:** 
 
 
<img width="1280" height="640" alt="image" src="https://github.com/user-attachments/assets/e32cac97-5f3b-494a-af8d-22be469088dc" />


<img width="1280" height="640" alt="image" src="https://github.com/user-attachments/assets/bd8e2db7-29ce-4c07-8b09-04375118a50b" />

**After :** 

<img width="1852" height="928" alt="image" src="https://github.com/user-attachments/assets/5c51b85f-4ac9-43b5-8c94-574543ff380c" />

Backport Needed For V16