### PR TITLE
fix: skip reposts for closed accounting periods

### DIFF
--- a/erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.py
+++ b/erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.py
@@ -15,6 +15,7 @@ from frappe.utils.user import get_users_with_role
 from rq.timeouts import JobTimeoutException
 
 import erpnext
+from erpnext.accounts.doctype.accounting_period.accounting_period import ClosedAccountingPeriod
 from erpnext.accounts.services.gl_validator import validate_accounting_period
 from erpnext.accounts.utils import get_future_stock_vouchers, repost_gle_for_stock_vouchers
 from erpnext.stock.stock_ledger import (
@@ -145,18 +146,7 @@ class RepostItemValuation(Document):
 			frappe.throw(_(msg))
 
 		# Accounting Period
-		if self.voucher_type:
-			validate_accounting_period(
-				[
-					frappe._dict(
-						{
-							"posting_date": self.posting_date,
-							"company": self.company,
-							"voucher_type": self.voucher_type,
-						}
-					)
-				]
-			)
+		self.validate_accounting_period_for_repost()
 
 		# Stock Closing Balance
 		closing_stock = self.get_closing_stock_balance()
@@ -168,6 +158,22 @@ class RepostItemValuation(Document):
 					name, to_date
 				)
 			)
+
+	def validate_accounting_period_for_repost(self):
+		if not self.voucher_type:
+			return
+
+		validate_accounting_period(
+			[
+				frappe._dict(
+					{
+						"posting_date": self.posting_date,
+						"company": self.company,
+						"voucher_type": self.voucher_type,
+					}
+				)
+			]
+		)
 
 	def reset_recreate_stock_ledgers(self):
 		if self.recreate_stock_ledgers and self.based_on != "Transaction":
@@ -410,6 +416,10 @@ def repost(doc):
 		doc.set_status("Completed")
 		doc.db_set("reposting_data_file", None)
 		remove_attached_file(doc.name)
+
+	except ClosedAccountingPeriod as e:
+		frappe.db.rollback()
+		mark_reposting_as_skipped_for_closed_accounting_period(doc, e)
 
 	except Exception as e:
 		if frappe.in_test:
@@ -711,8 +721,41 @@ def execute_reposting_entry(name):
 		return
 
 	if doc.status in ("Queued", "In Progress"):
+		if skip_reposting_if_accounting_period_closed(doc):
+			return
+
 		repost(doc)
 		doc.deduplicate_similar_repost()
+
+
+def skip_reposting_if_accounting_period_closed(doc):
+	try:
+		doc.validate_accounting_period_for_repost()
+	except ClosedAccountingPeriod as e:
+		mark_reposting_as_skipped_for_closed_accounting_period(doc, e)
+		return True
+
+	return False
+
+
+def mark_reposting_as_skipped_for_closed_accounting_period(doc, error):
+	message = frappe.message_log.pop() if frappe.message_log else str(error)
+	if isinstance(message, dict):
+		message = message.get("message")
+
+	message = message or str(error)
+	message = _("Skipped reposting because the Accounting Period is closed.") + "<br>" + message
+
+	frappe.db.set_value(
+		doc.doctype,
+		doc.name,
+		{
+			"error_log": message,
+			"status": "Skipped",
+		},
+	)
+	doc.error_log = message
+	doc.status = "Skipped"
 
 
 def get_repost_item_valuation_entries():

--- a/erpnext/stock/doctype/repost_item_valuation/test_repost_item_valuation.py
+++ b/erpnext/stock/doctype/repost_item_valuation/test_repost_item_valuation.py
@@ -2,7 +2,7 @@
 # See license.txt
 
 
-from unittest.mock import MagicMock, call
+from unittest.mock import MagicMock, call, patch
 
 import frappe
 from frappe.utils import add_days, add_to_date, now, nowdate, today
@@ -13,6 +13,7 @@ from erpnext.controllers.stock_controller import create_item_wise_repost_entries
 from erpnext.stock.doctype.item.test_item import make_item
 from erpnext.stock.doctype.purchase_receipt.test_purchase_receipt import make_purchase_receipt
 from erpnext.stock.doctype.repost_item_valuation.repost_item_valuation import (
+	execute_reposting_entry,
 	in_configured_timeslot,
 )
 from erpnext.stock.doctype.stock_entry.stock_entry_utils import make_stock_entry
@@ -123,6 +124,47 @@ class TestRepostItemValuation(ERPNextTestSuite, StockTestMixin):
 		for riv in rivs:
 			self.assertEqual(riv.company, "_Test Company with perpetual inventory")
 			self.assertEqual(riv.warehouse, "Stores - TCP1")
+
+	def test_execute_reposting_entry_skips_closed_accounting_period(self):
+		company = "_Test Company with perpetual inventory"
+		stock_entry = make_stock_entry(
+			company=company,
+			qty=1,
+			rate=10,
+			target="Stores - TCP1",
+		)
+
+		riv = frappe.get_doc(
+			doctype="Repost Item Valuation",
+			based_on="Transaction",
+			voucher_type=stock_entry.doctype,
+			voucher_no=stock_entry.name,
+			posting_date=stock_entry.posting_date,
+			posting_time=stock_entry.posting_time,
+		)
+		riv.flags.dont_run_in_test = True
+		riv.submit()
+
+		accounting_period = frappe.get_doc(
+			{
+				"doctype": "Accounting Period",
+				"company": company,
+				"period_name": f"_Test RIV Closed Period {frappe.generate_hash(length=5)}",
+				"start_date": stock_entry.posting_date,
+				"end_date": stock_entry.posting_date,
+				"closed_documents": [{"document_type": stock_entry.doctype, "closed": 1}],
+			}
+		)
+		accounting_period.insert()
+
+		with patch("erpnext.stock.doctype.repost_item_valuation.repost_item_valuation.repost") as repost_mock:
+			execute_reposting_entry(riv.name)
+
+		repost_mock.assert_not_called()
+		riv.reload()
+		self.assertEqual(riv.status, "Skipped")
+		self.assertIn("Skipped reposting because the Accounting Period is closed.", riv.error_log)
+		self.assertIn("closed Accounting Period", riv.error_log)
 
 	def test_deduplication(self):
 		def _assert_status(doc, status):


### PR DESCRIPTION
Changes:
- Skip Repost Item Valuation entries when their Accounting Period is closed.
- Mark those repost entries as `Skipped` instead of failing the scheduler job.
- Added a test to confirm closed-period repost entries are skipped and not processed.