### PR TITLE
fix: map stock_qty in apply_price_list_on_item

### DIFF
--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -1653,6 +1653,12 @@ def apply_price_list(ctx: ItemDetailsCtx, as_doc: bool = False, doc: Document | 
 def apply_price_list_on_item(ctx, doc=None):
 	item_doc = frappe.get_cached_doc("Item", ctx.item_code)
 	item_details = get_price_list_rate(ctx, item_doc)
+
+	ctx.conversion_factor = flt(ctx.conversion_factor) or get_conversion_factor(ctx.item_code, ctx.uom).get(
+		"conversion_factor", 1
+	)
+	ctx.stock_qty = flt(ctx.qty) * flt(ctx.conversion_factor)
+
 	item_details.update(get_pricing_rule_for_item(ctx, doc=doc))
 
 	return item_details


### PR DESCRIPTION
**Issue:**
When a Pricing Rule is applied to an item that is transacted in a UOM whose conversion factor differs from the item's original  (stock) UOM — e.g., item stocked in Nos, transacted in Pair (conversion factor 150) — the Item UOM is not mapped correctly on the fetch path. The transaction quantity is not converted to the stock quantity before the Pricing Rule is evaluated, so a rule with a quantity band (min_qty/max_qty) is dropped on fetch but applied on save, causing the rate to differ between entry and save.

**Before:**
[Screencast from 2026-07-04 11-43-22.webm](https://github.com/user-attachments/assets/e9a68543-8365-4d8d-be8a-d8d614950f3d)


**After:**
[Screencast from 2026-07-04 11-41-14.webm](https://github.com/user-attachments/assets/9753c032-bf58-49cd-b8e0-12cf226e1cc6)

**Ref:**[#72843](https://support.frappe.io/helpdesk/tickets/72843?view=VIEW-HD+Ticket-745)

Backport Needed v15 and v16