### PR TITLE
fix: type cast error on postgres

### DIFF
--- a/erpnext/controllers/queries.py
+++ b/erpnext/controllers/queries.py
@@ -20,7 +20,7 @@ from frappe.query_builder.functions import (
 	Substring,
 	Sum,
 )
-from frappe.utils import nowdate, today, unique
+from frappe.utils import cint, nowdate, today, unique
 from pypika import Order
 
 import erpnext
@@ -808,7 +808,11 @@ def get_filtered_dimensions(
 		query_filters.append(["company", "=", filters.get("company")])
 
 	for field in searchfields:
-		or_filters.append([field, "LIKE", "%%%s%%" % txt])
+		df = meta.get_field(field)
+		if df and df.fieldtype != "Check":
+			or_filters.append([field, "LIKE", "%%%s%%" % txt])
+		else:
+			or_filters.append([field, "=", cint(txt)])
 		fields.append(field)
 
 	if dimension_filters:

--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -698,7 +698,7 @@ def get_barcode_data(items_list=None, item_code=None):
 
 @frappe.whitelist()
 def get_item_tax_info(
-	doc: Document | str | None,
+	doc: Document | dict | str | None,
 	tax_category: str,
 	item_codes: list | str,
 	item_rates: dict | str | None = None,


### PR DESCRIPTION
Clicking on any cost center field threw an error. Postgres does not support `like` operator on `smallint` fields