### PR TITLE
fix: detect generated subscription invoice by billing period 

### DIFF
--- a/erpnext/accounts/doctype/subscription/subscription.py
+++ b/erpnext/accounts/doctype/subscription/subscription.py
@@ -712,12 +712,18 @@ class Subscription(Document):
 			_current_start_date = self.get_current_invoice_start(add_days(self.next_billing_period_end, 1))
 			_current_end_date = self.get_current_invoice_end(_current_start_date)
 
-		if self.current_invoice and getdate(_current_start_date) <= getdate(
-			self.current_invoice.posting_date
-		) <= getdate(_current_end_date):
-			return True
-
-		return False
+		return bool(
+			frappe.db.exists(
+				self.invoice_document_type,
+				{
+					"subscription": self.name,
+					"docstatus": ("<", 2),
+					"is_return": 0,
+					"from_date": _current_start_date,
+					"to_date": _current_end_date,
+				},
+			)
+		)
 
 	@property
 	def current_invoice(self) -> Document | None:

--- a/erpnext/accounts/doctype/subscription/test_subscription.py
+++ b/erpnext/accounts/doctype/subscription/test_subscription.py
@@ -71,6 +71,23 @@ class TestSubscription(ERPNextTestSuite):
 		self.assertEqual(getdate(subscription.next_billing_period_start), getdate("2018-02-01"))
 		self.assertEqual(getdate(subscription.next_billing_period_end), getdate("2018-02-28"))
 
+	def test_late_posting_date_does_not_skip_next_billing_cycle(self):
+		subscription = create_subscription(
+			start_date=add_months(nowdate(), -1),
+			generate_invoice_at="Postpaid (bill at period end)",
+		)
+		self.assertEqual(len(subscription.invoices), 1)
+
+		invoice = subscription.invoices[-1]
+		frappe.db.set_value(subscription.invoice_document_type, invoice.name, "posting_date", nowdate())
+
+		subscription.reload()
+		self.assertFalse(
+			subscription.is_current_invoice_generated(
+				subscription.next_billing_period_start, subscription.next_billing_period_end
+			)
+		)
+
 	def test_status_goes_back_to_active_after_invoice_is_paid(self):
 		subscription = create_subscription(
 			start_date="2018-01-01", generate_invoice_at="Prepaid (bill at period start)"


### PR DESCRIPTION
**Issue:**
Subscriptions may skip generating an invoice for a billing cycle when the previous invoice has a posting date outside the billing period it belongs to. Since the system checks the invoice's posting date to determine whether the current billing cycle has already been invoiced, a delayed or edited posting date can cause it to incorrectly assume the next billing cycle is already covered. As a result, no new invoice is created, and the subscription period is simply advanced.

**Steps to Reproduce:**

1. Create a Subscription with **Generate Invoice At = Postpaid**.
2. Generate the invoice for the first billing period, but set its posting date after the billing period ends.
3. Advance to the next billing cycle and run subscription processing.
4. **Observed:** that no invoice is generated for the current billing period, and only the subscription dates are updated.
5. **Expected:** An invoice should be generated for the current billing period before the subscription advances to the next cycle.

**Backport Needed :** v15, v16

**Ref:**[#72868](https://support.frappe.io/helpdesk/tickets/72868?view=VIEW-HD+Ticket-745)