### PR TITLE
fix: derive stock_qty in update_args_for_pricing_rule

### DIFF
--- a/erpnext/accounts/doctype/pricing_rule/pricing_rule.py
+++ b/erpnext/accounts/doctype/pricing_rule/pricing_rule.py
@@ -512,6 +512,14 @@ def get_pricing_rule_for_item(args, doc=None, for_validate=False):
 
 
 def update_args_for_pricing_rule(args):
+	if args.qty:
+		from erpnext.stock.get_item_details import get_conversion_factor
+
+		args.conversion_factor = flt(args.conversion_factor) or get_conversion_factor(
+			args.item_code, args.uom
+		).get("conversion_factor")
+		args.stock_qty = flt(args.qty) * args.conversion_factor
+
 	if not (args.item_group and args.brand):
 		item = frappe.get_cached_value("Item", args.item_code, ("item_group", "brand"))
 		if not item:

--- a/erpnext/accounts/doctype/pricing_rule/test_pricing_rule.py
+++ b/erpnext/accounts/doctype/pricing_rule/test_pricing_rule.py
@@ -1520,6 +1520,47 @@ class TestPricingRule(ERPNextTestSuite):
 		debit_note.delete()
 		pi.cancel()
 
+	def test_qty_rule_applies_on_price_list_fetch_without_stock_qty(self):
+		from erpnext.stock.get_item_details import apply_price_list
+
+		item = make_item(
+			properties={
+				"item_code": "_Test Item Stock Qty Backfill",
+				"stock_uom": "Nos",
+				"uoms": [dict(uom="Box", conversion_factor=10)],
+			}
+		)
+		make_item_price(item.name, "_Test Price List", 100)
+		make_pricing_rule(
+			selling=1,
+			min_qty=10,
+			discount_percentage=10,
+			item_code=item.name,
+			title="_Test Stock Qty Backfill Rule",
+		)
+
+		# fetch-path payload without stock_qty/conversion_factor: 2 Box = 20 Nos >= min_qty 10
+		children = apply_price_list(
+			frappe._dict(
+				doctype="Sales Invoice",
+				company="_Test Company",
+				customer="_Test Customer",
+				selling_price_list="_Test Price List",
+				currency="INR",
+				conversion_rate=1,
+				items=[
+					{
+						"doctype": "Sales Invoice Item",
+						"item_code": item.name,
+						"qty": 2,
+						"uom": "Box",
+					}
+				],
+			)
+		)["children"]
+
+		self.assertEqual(children[0].get("discount_percentage"), 10)
+
 
 def make_pricing_rule(**args):
 	args = frappe._dict(args)


### PR DESCRIPTION
**Issue:**
Pricing rules with a qty band (min_qty/max_qty) are silently dropped when the caller does not send `stock_qty` — `filter_pricing_rules` treats it as 0. The rate then differs between fetch and save, e.g. on the `apply_price_list` path when the transaction UOM differs from the stock UOM.

**Fix:**
Derive `conversion_factor`/`stock_qty` once in `update_args_for_pricing_rule`, which runs for every caller of `get_pricing_rule_for_item`. This covers `apply_price_list`, the `apply_pricing_rule` endpoint and the webshop path (`utilities/product.py`) in one place — the same bug was previously patched per call site in a59f8640d1. Guarded on `args.qty`, so payloads that send only `stock_qty` keep their value.

Alternative to #56869, fixing the same issue one level deeper. Includes a regression test (fails on develop, passes with the fix).

**Ref:** https://support.frappe.io/helpdesk/tickets/72843
Backport needed v15 and v16