### PR TITLE
test: add coverage for Appointment Booking Settings

### DIFF
--- a/erpnext/crm/doctype/appointment_booking_settings/test_appointment_booking_settings.py
+++ b/erpnext/crm/doctype/appointment_booking_settings/test_appointment_booking_settings.py
@@ -1,9 +1,59 @@
-# Copyright (c) 2019, Frappe Technologies Pvt. Ltd. and Contributors
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
-# import frappe
+
+import datetime
+
+import frappe
 
 from erpnext.tests.utils import ERPNextTestSuite
 
 
 class TestAppointmentBookingSettings(ERPNextTestSuite):
-	pass
+	"""The settings validate each availability slot: from-time must precede to-time and
+	the slot length must be a whole multiple of the appointment duration."""
+
+	def make_settings(self, appointment_duration=30):
+		doc = frappe.new_doc("Appointment Booking Settings")
+		doc.appointment_duration = appointment_duration
+		return doc
+
+	def dt(self, hms):
+		# the controller parses times against a fixed epoch date
+		return datetime.datetime.strptime("01/01/1970 " + hms, "%d/%m/%Y %H:%M:%S")
+
+	def test_from_time_must_precede_to_time(self):
+		doc = self.make_settings()
+		record = frappe._dict(day_of_week="Monday")
+		self.assertRaises(
+			frappe.ValidationError,
+			doc.validate_from_and_to_time,
+			self.dt("18:00:00"),
+			self.dt("09:00:00"),
+			record,
+		)
+		doc.validate_from_and_to_time(self.dt("09:00:00"), self.dt("18:00:00"), record)  # valid order
+
+	def test_slot_length_must_be_a_multiple_of_the_duration(self):
+		doc = self.make_settings(appointment_duration=30)
+		# 60 minutes is two 30-minute appointments -> fine
+		doc.duration_is_divisible(self.dt("09:00:00"), self.dt("10:00:00"))
+		# 45 minutes leaves a partial appointment -> rejected
+		self.assertRaises(
+			frappe.ValidationError, doc.duration_is_divisible, self.dt("09:00:00"), self.dt("09:45:00")
+		)
+
+	def test_validate_checks_every_slot(self):
+		doc = self.make_settings(appointment_duration=30)
+		doc.append(
+			"availability_of_slots",
+			{"day_of_week": "Monday", "from_time": "09:00:00", "to_time": "09:45:00"},
+		)
+		self.assertRaises(frappe.ValidationError, doc.validate)
+
+		# a clean 60-minute slot passes end to end
+		doc.availability_of_slots = []
+		doc.append(
+			"availability_of_slots",
+			{"day_of_week": "Monday", "from_time": "09:00:00", "to_time": "10:00:00"},
+		)
+		doc.validate()

--- a/erpnext/crm/doctype/appointment_booking_settings/test_appointment_booking_settings.py
+++ b/erpnext/crm/doctype/appointment_booking_settings/test_appointment_booking_settings.py
@@ -43,17 +43,17 @@ class TestAppointmentBookingSettings(ERPNextTestSuite):
 		)
 
 	def test_validate_checks_every_slot(self):
-		doc = self.make_settings(appointment_duration=30)
-		doc.append(
+		bad = self.make_settings(appointment_duration=30)
+		bad.append(
 			"availability_of_slots",
 			{"day_of_week": "Monday", "from_time": "09:00:00", "to_time": "09:45:00"},
 		)
-		self.assertRaises(frappe.ValidationError, doc.validate)
+		self.assertRaises(frappe.ValidationError, bad.validate)
 
 		# a clean 60-minute slot passes end to end
-		doc.availability_of_slots = []
-		doc.append(
+		good = self.make_settings(appointment_duration=30)
+		good.append(
 			"availability_of_slots",
 			{"day_of_week": "Monday", "from_time": "09:00:00", "to_time": "10:00:00"},
 		)
-		doc.validate()
+		good.validate()


### PR DESCRIPTION
Adds unit tests for the **Appointment Booking Settings** doctype, which had only a boilerplate stub. Covers the slot validation (pure time math, no fixtures):

- A slot's from-time must precede its to-time.
- A slot's length must be a whole multiple of the appointment duration (60 min / 30 = ok, 45 min / 30 = rejected).
- `validate` applies both checks to every availability slot.