### PR TITLE
fix: reset_mode_of_payments raises AttributeError on a POS Invoice

### DIFF
--- a/erpnext/accounts/doctype/pos_invoice/test_pos_invoice_reset_mop.py
+++ b/erpnext/accounts/doctype/pos_invoice/test_pos_invoice_reset_mop.py
@@ -5,8 +5,6 @@
 # AttributeError: 'POSInvoice' object has no attribute 'is_created_using_pos'
 # when calling reset_mode_of_payments on a draft POS Invoice.
 
-import frappe
-
 from erpnext.accounts.doctype.pos_invoice.test_pos_invoice import (
 	POSInvoiceTestMixin,
 	create_pos_invoice,

--- a/erpnext/accounts/doctype/pos_invoice/test_pos_invoice_reset_mop.py
+++ b/erpnext/accounts/doctype/pos_invoice/test_pos_invoice_reset_mop.py
@@ -1,0 +1,36 @@
+# Copyright (c) 2024, Frappe Technologies Pvt. Ltd. and Contributors
+# See license.txt
+
+# Regression test for https://github.com/frappe/erpnext/issues/56501
+# AttributeError: 'POSInvoice' object has no attribute 'is_created_using_pos'
+# when calling reset_mode_of_payments on a draft POS Invoice.
+
+import frappe
+
+from erpnext.accounts.doctype.pos_invoice.test_pos_invoice import (
+	POSInvoiceTestMixin,
+	create_pos_invoice,
+)
+from erpnext.accounts.doctype.pos_opening_entry.test_pos_opening_entry import create_opening_entry
+
+
+class TestPOSInvoiceResetModeOfPayments(POSInvoiceTestMixin):
+	def setUp(self):
+		super().setUp()
+		create_opening_entry(self.pos_profile, self.test_user.name)
+
+	def test_reset_mode_of_payments_does_not_raise_attribute_error(self):
+		"""Calling reset_mode_of_payments on a draft POS Invoice must not raise
+		AttributeError for the missing is_created_using_pos attribute.
+
+		update_multi_mode_option accesses doc.is_created_using_pos, which is a
+		field on SalesInvoice but does not exist on POSInvoice, causing the error
+		reported in #56501 when a user tries to edit a saved draft order.
+		"""
+		inv = create_pos_invoice(do_not_submit=True)
+
+		# This call must not raise AttributeError on the missing field.
+		inv.reset_mode_of_payments()
+
+		# Payments should have been repopulated from the POS profile.
+		self.assertTrue(len(inv.payments) > 0, "Payments should be populated after reset")

--- a/erpnext/accounts/doctype/sales_invoice/services/pos.py
+++ b/erpnext/accounts/doctype/sales_invoice/services/pos.py
@@ -344,7 +344,9 @@ def update_multi_mode_option(doc, pos_profile) -> None:
 		payment.account = payment_mode.default_account
 		payment.type = payment_mode.type
 
-	mop_refetched = bool(doc.payments) and not doc.is_created_using_pos
+	# is_created_using_pos exists on Sales Invoice but not POS Invoice; use get() so this
+	# shared helper doesn't raise AttributeError when called on a POS Invoice
+	mop_refetched = bool(doc.payments) and not doc.get("is_created_using_pos")
 
 	doc.set("payments", [])
 	invalid_modes = []


### PR DESCRIPTION
Fixes #56501.

`update_multi_mode_option` (shared by Sales Invoice and POS Invoice) reads `doc.is_created_using_pos`, but that field only exists on **Sales Invoice**, not **POS Invoice**. So calling `reset_mode_of_payments` on a draft POS Invoice — e.g. when a user edits a saved draft order — raises `AttributeError: 'POSInvoice' object has no attribute 'is_created_using_pos'`.

**Fix:** read the field via `doc.get("is_created_using_pos")`, which returns `None` for the missing field instead of raising, preserving the existing behaviour on Sales Invoice.

Adds a regression test that calls `reset_mode_of_payments` on a draft POS Invoice and asserts payments are repopulated without error.

no-docs