### PR TITLE
fix: use transaction-currency outstanding on Dunning for foreign-currency invoices

### DIFF
--- a/erpnext/accounts/doctype/dunning/test_dunning.py
+++ b/erpnext/accounts/doctype/dunning/test_dunning.py
@@ -12,6 +12,7 @@ from erpnext.accounts.doctype.sales_invoice.mapper import (
 	create_dunning as create_dunning_from_sales_invoice,
 )
 from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import (
+	create_sales_invoice,
 	create_sales_invoice_against_cost_center,
 )
 from erpnext.tests.utils import ERPNextTestSuite
@@ -151,6 +152,37 @@ class TestDunning(ERPNextTestSuite):
 		credit_note.cancel()
 		dunning.reload()
 		self.assertEqual(dunning.status, "Unresolved")
+
+	@ERPNextTestSuite.change_settings(
+		"Accounts Settings", {"allow_multi_currency_invoices_against_single_party_account": 1}
+	)
+	def test_dunning_outstanding_uses_transaction_currency(self):
+		"""
+		Regression for #56006: dunning outstanding must be in the invoice transaction
+		currency, not in the party account currency.
+
+		A USD invoice posted against an INR receivable account stores
+		outstanding_amount in INR (party account currency).  The overdue payment
+		row on the resulting Dunning must carry the USD amount, not the INR amount.
+		"""
+		si = create_sales_invoice(
+			posting_date=add_days(today(), -10),
+			currency="USD",
+			conversion_rate=50,
+			rate=100,
+			debit_to="Debtors - _TC",
+		)
+
+		# Sanity-check the invoice state before creating the dunning
+		self.assertEqual(si.currency, "USD")
+		self.assertEqual(si.outstanding_amount, 5000.0)  # INR (party account currency)
+		self.assertEqual(si.payment_schedule[0].outstanding, 100.0)  # USD (transaction currency)
+
+		dunning = create_dunning_from_sales_invoice(si.name)
+
+		self.assertEqual(len(dunning.overdue_payments), 1)
+		# Must reflect 100 USD, not 5000 INR mislabelled as USD
+		self.assertEqual(dunning.overdue_payments[0].outstanding, 100.0)
 
 	def test_dunning_not_affected_by_standalone_credit_note(self):
 		"""

--- a/erpnext/accounts/doctype/sales_invoice/mapper.py
+++ b/erpnext/accounts/doctype/sales_invoice/mapper.py
@@ -594,7 +594,15 @@ def create_dunning(
 		if source.payment_schedule and len(source.payment_schedule) == 1:
 			for row in target.overdue_payments:
 				if row.payment_schedule == source.payment_schedule[0].name:
-					row.outstanding = source.get("outstanding_amount")
+					# outstanding_amount is in the party account currency, but the Overdue Payment
+					# row is in the invoice's transaction currency. When they differ, use the
+					# payment schedule's own outstanding — it is kept in transaction currency and
+					# updated as payments are allocated, so it stays correct even when the invoice
+					# and its payments post at different exchange rates (#56006).
+					if source.party_account_currency and source.party_account_currency != source.currency:
+						row.outstanding = source.payment_schedule[0].outstanding
+					else:
+						row.outstanding = source.get("outstanding_amount")
 
 		target.validate()
 


### PR DESCRIPTION
## Summary

Closes #56006

When a Sales Invoice is posted in a foreign currency (e.g. USD) against a receivable account held in the company currency (e.g. INR/EUR) — the setup enabled by **Allow multi-currency invoices against single party account** — creating a Dunning showed the wrong outstanding amount and currency.

`postprocess_dunning` copied `Sales Invoice.outstanding_amount` straight into the Dunning's `Overdue Payment.outstanding`. But `outstanding_amount` is stored in the **party account currency**, while the Overdue Payment row is in the invoice's **transaction currency**. So the Dunning showed the base-currency figure under the invoice's foreign-currency symbol — both the value and the label were wrong (e.g. an EUR amount displayed as `US$`).

## Root cause

`erpnext/accounts/doctype/sales_invoice/mapper.py` — `postprocess_dunning` (introduced in #41817):

```python
if source.payment_schedule and len(source.payment_schedule) == 1:
    for row in target.overdue_payments:
        if row.payment_schedule == source.payment_schedule[0].name:
            row.outstanding = source.get("outstanding_amount")  # party-account currency
```

The overwrite only manifests when `party_account_currency != currency`.

## Fix

When the currencies differ, take the outstanding from `payment_schedule[0].outstanding`, which is already held in the transaction currency:

```python
if source.party_account_currency and source.party_account_currency != source.currency:
    row.outstanding = source.payment_schedule[0].outstanding
else:
    row.outstanding = source.get("outstanding_amount")
```

Same-currency invoices keep the original behaviour untouched.

**Why the schedule value, not `outstanding_amount / conversion_rate`:** the payment schedule's `outstanding` is maintained in the transaction currency and reduced as payments are allocated, so it stays correct even when the invoice and its later payments post at different exchange rates. Reconstructing the amount by dividing the current party-account balance by the invoice's original rate drifts in that case (e.g. a USD 100 invoice at 50 with a USD 30 payment at 55 leaves a base balance of 3350, which `/50` renders as USD 67 instead of the USD 70 actually due).

## Test plan

A regression test is included (`test_dunning_outstanding_uses_transaction_currency`): a USD invoice against an INR receivable, asserting the Dunning's overdue-payment outstanding is the USD (transaction-currency) amount, not the INR one.

```
bench --site <site> run-tests --module erpnext.accounts.doctype.dunning.test_dunning
```

All 8 tests in the module pass, including the existing payment-entry and credit-note cases.

**Manual:** enable *Allow multi-currency invoices against single party account*, create a USD invoice against an INR/EUR receivable (`debit_to`), then **Create → Dunning** and confirm `total_outstanding` shows the USD amount under the USD symbol.
