### PR TITLE
fix: validate mandatory date filters in reports

### DIFF
--- a/erpnext/accounts/report/tds_computation_summary/tds_computation_summary.py
+++ b/erpnext/accounts/report/tds_computation_summary/tds_computation_summary.py
@@ -21,11 +21,21 @@ class TDSComputationSummaryReport(TaxWithholdingDetailsReport):
 	AGGREGATE_FIELDS = ("total_amount", "tax_amount")
 
 	def validate_filters(self):
-		if self.filters.from_date > self.filters.to_date:
+		from_date = self.filters.from_date
+		to_date = self.filters.to_date
+		if not from_date or not to_date:
+			frappe.throw(
+				_("{0} and {1} are mandatory").format(
+					frappe.bold(_("From Date")),
+					frappe.bold(_("To Date")),
+				)
+			)
+
+		if from_date > to_date:
 			frappe.throw(_("From Date must be before To Date"))
 
-		from_year = get_fiscal_year(self.filters.from_date)[0]
-		to_year = get_fiscal_year(self.filters.to_date)[0]
+		from_year = get_fiscal_year(from_date)[0]
+		to_year = get_fiscal_year(to_date)[0]
 		if from_year != to_year:
 			frappe.throw(_("From Date and To Date lie in different Fiscal Year"))
 

--- a/erpnext/stock/report/batch_wise_balance_history/batch_wise_balance_history.py
+++ b/erpnext/stock/report/batch_wise_balance_history/batch_wise_balance_history.py
@@ -30,6 +30,11 @@ def execute(filters=None):
 			_("Please select either the Item or Warehouse or Warehouse Type filter to generate the report.")
 		)
 
+	if not filters.from_date or not filters.to_date:
+		frappe.throw(
+			_("{0} and {1} are mandatory").format(frappe.bold(_("From Date")), frappe.bold(_("To Date")))
+		)
+
 	if filters.from_date > filters.to_date:
 		frappe.throw(_("From Date must be before To Date"))
 

--- a/erpnext/stock/report/cogs_by_item_group/cogs_by_item_group.py
+++ b/erpnext/stock/report/cogs_by_item_group/cogs_by_item_group.py
@@ -34,7 +34,18 @@ def update_filters_with_account(filters: Filters) -> None:
 
 
 def validate_filters(filters: Filters) -> None:
-	if filters.from_date > filters.to_date:
+	from_date = filters.from_date
+	to_date = filters.to_date
+
+	if not from_date or not to_date:
+		frappe.throw(
+			_("{0} and {1} are mandatory").format(
+				frappe.bold(_("From Date")),
+				frappe.bold(_("To Date")),
+			)
+		)
+
+	if from_date > to_date:
 		frappe.throw(_("From Date must be before To Date"))
 
 


### PR DESCRIPTION
**Issue:**
When saving a Dashboard Chart or modifying its filters for the following reports, the report is executed without the mandatory date filters (from_date and to_date). Instead of displaying a user-friendly validation message, the reports raise a TypeError due to missing date validation.

Affected reports:

Tax Withholding Details
TDS Computation Summary
Batch-Wise Balance History
COGS by Item Group

**Before:**
<img width="1280" height="623" alt="image" src="https://github.com/user-attachments/assets/bc4e3917-f55f-4b67-a805-ee7dbfb6bfd2" />

**After:**
<img width="1280" height="623" alt="image" src="https://github.com/user-attachments/assets/83447e2d-3810-46aa-a780-5603f3739473" />

**Ref:** [#72674](https://support.frappe.io/helpdesk/tickets/72674?view=VIEW-HD+Ticket-746)

Raising this PR on behalf of @ssakthivelmurugan