### PR TITLE
test: fix flaky test_coa_based_on_country_template (abbreviation collision)

### DIFF
--- a/erpnext/setup/doctype/company/test_company.py
+++ b/erpnext/setup/doctype/company/test_company.py
@@ -68,7 +68,12 @@ class TestCompany(ERPNextTestSuite):
 				try:
 					company = frappe.new_doc("Company")
 					company.company_name = template
-					company.abbr = random_string(3)
+					# a short random abbr collides with existing test companies often enough
+					# to flake, so pick one that is verified unique
+					abbr = random_string(3)
+					while frappe.db.exists("Company", {"abbr": abbr}):
+						abbr = random_string(3)
+					company.abbr = abbr
 					company.default_currency = "USD"
 					company.create_chart_of_accounts_based_on = "Standard Template"
 					company.chart_of_accounts = template


### PR DESCRIPTION
`test_coa_based_on_country_template` set `company.abbr = random_string(3)`. Company abbreviations must be unique, and a 3-character random value (only ~36^3 after the abbr is upper-cased) collides with the many existing test companies often enough to fail intermittently with `ValidationError: Abbreviation already used for another company`.

**Fix:** regenerate the abbreviation until it isn't already taken, so the test can't collide with a pre-existing company. No behavioural change to the assertions.