### PR TITLE
fix(controllers): compute budget requested amount per row

### DIFF
--- a/erpnext/controllers/budget_controller.py
+++ b/erpnext/controllers/budget_controller.py
@@ -3,7 +3,7 @@ from collections import OrderedDict
 import frappe
 from frappe import _, qb
 from frappe.query_builder import Criterion
-from frappe.query_builder.functions import IfNull, Max, Sum
+from frappe.query_builder.functions import IfNull, Sum
 from frappe.utils import fmt_money
 
 from erpnext.accounts.doctype.budget.budget import BudgetError, get_accumulated_monthly_budget
@@ -260,10 +260,10 @@ class BudgetValidation:
 				qb.from_(mr)
 				.inner_join(mri)
 				.on(mr.name == mri.parent)
-				# rate is outside the Sum (no GROUP BY -> implicit aggregate); Max() keeps it valid on
-				# postgres and matches MySQL's arbitrary single-rate choice for this aggregate.
 				.select(
-					(Sum(IfNull(mri.stock_qty, 0) - IfNull(mri.ordered_qty, 0)) * Max(mri.rate)).as_("amount")
+					Sum((IfNull(mri.stock_qty, 0) - IfNull(mri.ordered_qty, 0)) * IfNull(mri.rate, 0)).as_(
+						"amount"
+					)
 				)
 				.where(Criterion.all(conditions))
 				.run(as_dict=True)


### PR DESCRIPTION
`get_requested_amount` computed `Sum(stock_qty − ordered_qty) × Max(rate)` — the pooled pending qty of every matching Material Request item in the fiscal year times the single highest rate. Whenever the matched items have different rates the result is fabricated and biased upward, making false Budget Exceeded stops/warnings more likely (e.g. rows of qty 10 @ 5 and qty 10 @ 100 gave 2000 instead of 1050).

Fix: sum `(stock_qty − ordered_qty) × rate` per row, matching the sibling `get_ordered_amount` pattern.