### PR TITLE
fix(manufacturing): scope Production Planning arrival qty to open POs

### DIFF
--- a/erpnext/manufacturing/report/production_planning_report/production_planning_report.py
+++ b/erpnext/manufacturing/report/production_planning_report/production_planning_report.py
@@ -246,6 +246,7 @@ class ProductionPlanReport:
 				& (poi.warehouse.isin(self.warehouses))
 				& (po.docstatus == 1)
 				& (po.status.notin(["Closed", "Completed", "Cancelled"]))
+				& (poi.qty > poi.received_qty)
 			)
 			.groupby(poi.item_code, poi.warehouse)
 		).run(as_dict=True)

--- a/erpnext/manufacturing/report/production_planning_report/production_planning_report.py
+++ b/erpnext/manufacturing/report/production_planning_report/production_planning_report.py
@@ -4,6 +4,7 @@
 
 import frappe
 from frappe import _
+from frappe.query_builder.functions import Min, Sum
 from pypika import Order
 
 from erpnext.stock.doctype.warehouse.warehouse import get_child_warehouses
@@ -228,24 +229,26 @@ class ProductionPlanReport:
 
 		self.purchase_details = {}
 
-		purchased_items = frappe.get_all(
-			"Purchase Order Item",
-			fields=[
-				"item_code",
-				{"MIN": "schedule_date", "as": "arrival_date"},
-				# qty is not in the GROUP BY, so it must be aggregated to be valid on postgres; sum the
-				# on-order qty per item+warehouse (the meaningful "arriving" figure) instead of MariaDB's
-				# arbitrary single-row pick.
-				{"SUM": "qty", "as": "arrival_qty"},
-				"warehouse",
-			],
-			filters={
-				"item_code": ("in", self.item_codes),
-				"warehouse": ("in", self.warehouses),
-				"docstatus": 1,
-			},
-			group_by="item_code, warehouse",
-		)
+		po = frappe.qb.DocType("Purchase Order")
+		poi = frappe.qb.DocType("Purchase Order Item")
+		purchased_items = (
+			frappe.qb.from_(po)
+			.join(poi)
+			.on(poi.parent == po.name)
+			.select(
+				poi.item_code,
+				Min(poi.schedule_date).as_("arrival_date"),
+				Sum(poi.qty - poi.received_qty).as_("arrival_qty"),
+				poi.warehouse,
+			)
+			.where(
+				(poi.item_code.isin(self.item_codes))
+				& (poi.warehouse.isin(self.warehouses))
+				& (po.docstatus == 1)
+				& (po.status.notin(["Closed", "Completed", "Cancelled"]))
+			)
+			.groupby(poi.item_code, poi.warehouse)
+		).run(as_dict=True)
 		for d in purchased_items:
 			key = (d.item_code, d.warehouse)
 			if key not in self.purchase_details:


### PR DESCRIPTION
The report's "Arrival Quantity" summed `qty` over every submitted PO line ever created for the item+warehouse — including fully received and closed POs — so on mature sites it grossly overstates what is actually arriving.

Fix: sum `qty − received_qty` over open POs only (status not Closed/Completed/Cancelled). `arrival_date` (MIN of schedule_date) now comes from the same open-PO scope.