### PR TITLE
fix(controllers): guard empty group-by detail row in trends

### DIFF
--- a/erpnext/controllers/trends.py
+++ b/erpnext/controllers/trends.py
@@ -203,6 +203,9 @@ def get_data(filters, conditions):
 					as_list=1,
 				)
 
+				if not row1:
+					continue
+
 				des[ind] = row[i][0]
 				des[ind - 1] = row1[0][0]
 


### PR DESCRIPTION
Since the detail query gained an explicit GROUP BY, a zero-match result returns no rows (the old bare aggregate returned one all-NULL row), so `row1[0][0]` would raise IndexError. Skip the entry when `row1` is empty.