### PR TITLE
fix: update Fiscal Year on company change in Trial Balance

### DIFF
--- a/erpnext/accounts/report/trial_balance/trial_balance.js
+++ b/erpnext/accounts/report/trial_balance/trial_balance.js
@@ -29,6 +29,15 @@ frappe.query_reports["Trial Balance"] = {
 						from_date: fy[1],
 						to_date: fy[2],
 					});
+				} else {
+					// No Fiscal Year found for the selected company as on today.
+					// Clear the previous company's values instead of leaving stale
+					// filters, which would run the report for the wrong period.
+					frappe.query_report.set_filter_value({
+						fiscal_year: "",
+						from_date: "",
+						to_date: "",
+					});
 				}
 			},
 		},

--- a/erpnext/accounts/report/trial_balance/trial_balance.js
+++ b/erpnext/accounts/report/trial_balance/trial_balance.js
@@ -10,6 +10,31 @@ frappe.query_reports["Trial Balance"] = {
 			options: "Company",
 			default: frappe.defaults.get_user_default("Company"),
 			reqd: 1,
+			on_change: function (query_report) {
+				var company = query_report.get_values().company;
+				if (!company) {
+					return;
+				}
+				// Update the Fiscal Year to the one applicable for the selected
+				// company, since companies can be on different fiscal years.
+				frappe.call({
+					method: "erpnext.accounts.utils.get_fiscal_year",
+					args: {
+						date: frappe.datetime.get_today(),
+						company: company,
+					},
+					callback: function (r) {
+						if (r.message) {
+							var fy = r.message;
+							frappe.query_report.set_filter_value({
+								fiscal_year: fy[0],
+								from_date: fy[1],
+								to_date: fy[2],
+							});
+						}
+					},
+				});
+			},
 		},
 		{
 			fieldname: "fiscal_year",

--- a/erpnext/accounts/report/trial_balance/trial_balance.js
+++ b/erpnext/accounts/report/trial_balance/trial_balance.js
@@ -24,7 +24,9 @@ frappe.query_reports["Trial Balance"] = {
 						company: company,
 					},
 					callback: function (r) {
-						if (r.message) {
+						// Ignore a stale response from a previous company if the
+						// user has since switched to a different company.
+						if (r.message && query_report.get_values().company === company) {
 							var fy = r.message;
 							frappe.query_report.set_filter_value({
 								fiscal_year: fy[0],

--- a/erpnext/accounts/report/trial_balance/trial_balance.js
+++ b/erpnext/accounts/report/trial_balance/trial_balance.js
@@ -17,25 +17,19 @@ frappe.query_reports["Trial Balance"] = {
 				}
 				// Update the Fiscal Year to the one applicable for the selected
 				// company, since companies can be on different fiscal years.
-				frappe.call({
-					method: "erpnext.accounts.utils.get_fiscal_year",
-					args: {
-						date: frappe.datetime.get_today(),
-						company: company,
-					},
-					callback: function (r) {
-						// Ignore a stale response from a previous company if the
-						// user has since switched to a different company.
-						if (r.message && query_report.get_values().company === company) {
-							var fy = r.message;
-							frappe.query_report.set_filter_value({
-								fiscal_year: fy[0],
-								from_date: fy[1],
-								to_date: fy[2],
-							});
-						}
-					},
-				});
+				var fy = erpnext.utils.get_fiscal_year(
+					frappe.datetime.get_today(),
+					true,
+					false,
+					company
+				);
+				if (fy) {
+					frappe.query_report.set_filter_value({
+						fiscal_year: fy[0],
+						from_date: fy[1],
+						to_date: fy[2],
+					});
+				}
 			},
 		},
 		{

--- a/erpnext/accounts/report/trial_balance/trial_balance.py
+++ b/erpnext/accounts/report/trial_balance/trial_balance.py
@@ -5,7 +5,7 @@
 import frappe
 from frappe import _
 from frappe.query_builder.functions import Max, Sum
-from frappe.utils import add_days, cstr, flt, formatdate, getdate
+from frappe.utils import add_days, cstr, flt, getdate
 
 import erpnext
 from erpnext.accounts.doctype.accounting_dimension.accounting_dimension import (
@@ -63,21 +63,13 @@ def validate_filters(filters):
 	if filters.from_date > filters.to_date:
 		frappe.throw(_("From Date cannot be greater than To Date"))
 
+	# Clamp the dates to the Fiscal Year silently. These can momentarily fall
+	# outside the year while the Company/Fiscal Year filters are being switched,
+	# and a blocking popup on every such change is just noise.
 	if (filters.from_date < filters.year_start_date) or (filters.from_date > filters.year_end_date):
-		frappe.msgprint(
-			_("From Date should be within the Fiscal Year. Assuming From Date = {0}").format(
-				formatdate(filters.year_start_date)
-			)
-		)
-
 		filters.from_date = filters.year_start_date
 
 	if (filters.to_date < filters.year_start_date) or (filters.to_date > filters.year_end_date):
-		frappe.msgprint(
-			_("To Date should be within the Fiscal Year. Assuming To Date = {0}").format(
-				formatdate(filters.year_end_date)
-			)
-		)
 		filters.to_date = filters.year_end_date
 
 

--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -514,7 +514,7 @@ $.extend(erpnext.utils, {
 		});
 	},
 
-	get_fiscal_year: function (date, with_dates = false, raise_on_missing = true) {
+	get_fiscal_year: function (date, with_dates = false, raise_on_missing = true, company = null) {
 		if (!frappe.boot.setup_complete) {
 			return;
 		}
@@ -525,18 +525,22 @@ $.extend(erpnext.utils, {
 
 		let fiscal_year = "";
 		if (
+			// boot.current_fiscal_year is system-wide, so it can only be used
+			// when a specific company is not requested.
+			!company &&
 			frappe.boot.current_fiscal_year &&
 			date >= frappe.boot.current_fiscal_year[1] &&
 			date <= frappe.boot.current_fiscal_year[2]
 		) {
 			if (with_dates) fiscal_year = frappe.boot.current_fiscal_year;
 			else fiscal_year = frappe.boot.current_fiscal_year[0];
-		} else if (today != date) {
+		} else if (company || today != date) {
 			frappe.call({
 				method: "erpnext.accounts.utils.get_fiscal_year",
 				type: "GET", // make it cacheable
 				args: {
 					date: date,
+					company: company,
 					raise_on_missing: raise_on_missing,
 				},
 				async: false,


### PR DESCRIPTION
## Problem

In the **Trial Balance** report, when companies use **different fiscal years**:

1. Switching the **Company** filter did **not** update the **Fiscal Year** filter — it stayed on the previously selected (system-wide) fiscal year, so the report showed data for the wrong period until the fiscal year was changed manually.
2. While switching the Company / Fiscal Year filters, the From/To dates briefly fall outside the newly selected fiscal year, which triggered a blocking **"From Date should be within the Fiscal Year. Assuming From Date = …"** popup on every switch.

## Fix

- **Company `on_change`**: fetch the fiscal year applicable to the selected company via `erpnext.accounts.utils.get_fiscal_year` (which respects the `Fiscal Year → Company` link) and update the `fiscal_year`, `from_date` and `to_date` filters. This mirrors the existing `fiscal_year` `on_change` in the same report.
- **Silent date clamping**: the report already clamps `from_date` / `to_date` to the fiscal-year bounds in `validate_filters`. Drop the two `msgprint` calls (and the now-unused `formatdate` import) so the clamping happens silently instead of popping a dialog on every company/fiscal-year switch.

## Steps to reproduce

1. Have two companies on different fiscal years (e.g. Company A on Jan–Dec, Company B on Apr–Mar).
2. Open **Trial Balance**, select Company A.
3. Switch to Company B.
4. **Before:** Fiscal Year stays on Company A's year, and a "From Date should be within the Fiscal Year" popup appears.
5. **After:** Fiscal Year (and From/To dates) update to Company B's fiscal year, with no popup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)