### PR TITLE
fix(budget-variance): correct month shift in comparison chart

### DIFF
--- a/erpnext/accounts/report/budget_variance_report/budget_variance_report.py
+++ b/erpnext/accounts/report/budget_variance_report/budget_variance_report.py
@@ -422,6 +422,11 @@ def build_comparison_chart_data(filters, columns, data):
 		if not fieldname:
 			continue
 
+		# skip the dimension column ("budget_against"), it only matches the
+		# "budget_" prefix by coincidence and would shift the actual values by one
+		if fieldname == "budget_against":
+			continue
+
 		if fieldname.startswith("budget_"):
 			budget_fields.append(fieldname)
 		elif fieldname.startswith("actual_"):
@@ -433,7 +438,7 @@ def build_comparison_chart_data(filters, columns, data):
 	labels = [
 		col["label"].replace("Budget", "").strip()
 		for col in columns
-		if col.get("fieldname", "").startswith("budget_")
+		if col.get("fieldname", "").startswith("budget_") and col.get("fieldname") != "budget_against"
 	]
 
 	budget_values = [0] * len(budget_fields)


### PR DESCRIPTION
## Problem

When a Budget is created against a Cost Center for an expense account (e.g. Cost of Goods Sold) and a Journal Entry is posted against that account in the current month, the **Budget Variance Report** is inconsistent:

- The **table** correctly shows the actual expense under the right month (e.g. July).
- The **chart** plots the same expense one month earlier (June).

## Root cause

`build_comparison_chart_data()` collects budget columns with `fieldname.startswith("budget_")`. The dimension column's fieldname is **`budget_against`**, which also matches that prefix, so it is added as an extra *leading* entry to both `budget_fields` and `labels`. No column matches `actual_` except the monthly ones, so `actual_fields` has no leading entry — leaving every `actual` value shifted one position ahead of its label. The table is unaffected because it reads columns by exact fieldname.

## Fix

Skip the `budget_against` dimension column in both the field collection loop and the `labels` comprehension, so budget values, actual values, and labels stay aligned per month.

## Verification

With columns for Jun + Jul where only July has an actual (500):
- Before: `budget_fields`/`labels` length 3 (leading `budget_against`/`Cost Center`), `actual_fields` length 2 -> July's 500 rendered under June.
- After: labels `['(Jun) 2026', '(Jul) 2026']`, actual `[0, 500]` -> July's 500 aligns under July.