### PR TITLE
fix(financial_statement): render columnar financial statements instead of ignoring

### DIFF
--- a/erpnext/public/js/financial_statements.js
+++ b/erpnext/public/js/financial_statements.js
@@ -28,8 +28,8 @@ erpnext.financial_statements = {
 	},
 
 	is_blank_row: function (data) {
+		if (!data || data.segment_values) return false;
 		return (
-			data &&
 			!data.account &&
 			!data.accounts &&
 			!data.child_accounts &&


### PR DESCRIPTION
**Issue:**
Data Not showing in Horizontal Balance Sheet (Columnar) report template in balance sheet and P&L report

**Ref:** [#71710](https://support.frappe.io/helpdesk/tickets/71710) , https://github.com/frappe/erpnext/issues/56061

**Before:**
<img width="1295" height="612" alt="image" src="https://github.com/user-attachments/assets/cc050760-2a43-4b4a-bb90-844603078be9" />

**After:**
<img width="1295" height="612" alt="image" src="https://github.com/user-attachments/assets/a82524a5-872c-4333-9edb-7c70f5c88ecf" />

