### PR TITLE
perf: avoid per-row Warehouse doc fetches in auto reorder job

### DIFF
--- a/erpnext/stock/reorder_item.py
+++ b/erpnext/stock/reorder_item.py
@@ -182,6 +182,10 @@ def get_item_warehouse_projected_qty(items_to_consider):
 	item_warehouse_projected_qty = {}
 	items_to_consider = list(items_to_consider.keys())
 
+	warehouse_parent_map = frappe._dict(
+		frappe.get_all("Warehouse", fields=["name", "parent_warehouse"], as_list=True)
+	)
+
 	for item_code, warehouse, projected_qty in frappe.get_all(
 		"Bin",
 		filters={"item_code": ["in", items_to_consider], "warehouse": ["is", "set"]},
@@ -194,16 +198,14 @@ def get_item_warehouse_projected_qty(items_to_consider):
 		if warehouse not in item_warehouse_projected_qty.get(item_code):
 			item_warehouse_projected_qty[item_code][warehouse] = flt(projected_qty)
 
-		warehouse_doc = frappe.get_doc("Warehouse", warehouse)
+		parent_warehouse = warehouse_parent_map.get(warehouse)
 
-		while warehouse_doc.parent_warehouse:
-			if not item_warehouse_projected_qty.get(item_code, {}).get(warehouse_doc.parent_warehouse):
-				item_warehouse_projected_qty.setdefault(item_code, {})[warehouse_doc.parent_warehouse] = flt(
-					projected_qty
-				)
+		while parent_warehouse:
+			if not item_warehouse_projected_qty.get(item_code, {}).get(parent_warehouse):
+				item_warehouse_projected_qty.setdefault(item_code, {})[parent_warehouse] = flt(projected_qty)
 			else:
-				item_warehouse_projected_qty[item_code][warehouse_doc.parent_warehouse] += flt(projected_qty)
-			warehouse_doc = frappe.get_doc("Warehouse", warehouse_doc.parent_warehouse)
+				item_warehouse_projected_qty[item_code][parent_warehouse] += flt(projected_qty)
+			parent_warehouse = warehouse_parent_map.get(parent_warehouse)
 
 	return item_warehouse_projected_qty
 


### PR DESCRIPTION
**Issue:**
**get_item_warehouse_projected_qty()** in **erpnext/stock/reorder_item.py**, called from the daily reorder_item scheduled job, computes each item's projected quantity per warehouse and rolls it up to parent (group) warehouses for reorder rules set at the group level.
To walk the warehouse parent chain, it calls **frappe.get_doc("Warehouse", warehouse)** for every Bin row, uncached. On a site with nested warehouses, the same parent warehouse gets re-fetched from the database once for every item that shares it — e.g., thousands of SKUs sharing a 3-level warehouse hierarchy turns into tens of thousands of full document loads for what should be a handful of queries. This makes the auto re-order job scale poorly with catalog/warehouse size.

**Description:**
Preload the full warehouse → parent-warehouse mapping once via a single frappe.get_all("Warehouse", fields=["name", "parent_warehouse"]) query, and walk that in-memory
dict instead of issuing a frappe.get_doc per row. This reduces the war O(bins × hierarchy depth) DB round-trips to a single query, with no change in the computed projected quantities or rollup behavior.

Backport Needed For V16 and V15