### PR TITLE
fix: validate template and its variant in the same Pricing Rule

### DIFF
--- a/erpnext/accounts/doctype/pricing_rule/pricing_rule.py
+++ b/erpnext/accounts/doctype/pricing_rule/pricing_rule.py
@@ -156,6 +156,24 @@ class PricingRule(Document):
 			if len(values) != len(set(values)):
 				frappe.throw(_("Duplicate {0} found in the table").format(self.apply_on))
 
+			if self.apply_on == "Item Code":
+				self.validate_template_with_variant(values)
+
+	def validate_template_with_variant(self, item_codes):
+		# throws if a template and its variant both exist in one rule
+		variants = frappe.get_all(
+			"Item",
+			filters={"name": ("in", item_codes), "variant_of": ("in", item_codes)},
+			fields=["name", "variant_of"],
+		)
+		if variants:
+			variant = variants[0]
+			frappe.throw(
+				_("Variant {0} and its template {1} cannot both be added to the same Pricing Rule").format(
+					frappe.bold(variant.name), frappe.bold(variant.variant_of)
+				)
+			)
+
 	def validate_mandatory(self):
 		if self.has_priority and not self.priority:
 			throw(_("Priority is mandatory"), frappe.MandatoryError, _("Please Set Priority"))

--- a/erpnext/accounts/doctype/pricing_rule/test_pricing_rule.py
+++ b/erpnext/accounts/doctype/pricing_rule/test_pricing_rule.py
@@ -333,6 +333,31 @@ class TestPricingRule(ERPNextTestSuite):
 		details = get_item_details(args)
 		self.assertEqual(details.get("discount_percentage"), 17.5)
 
+	def test_pricing_rule_with_template_and_its_variant(self):
+		if not frappe.db.exists("Item", "Test Variant PRT"):
+			variant = frappe.new_doc("Item")
+			variant.item_code = "Test Variant PRT"
+			variant.item_name = "Test Variant PRT"
+			variant.item_group = "_Test Item Group"
+			variant.is_stock_item = 1
+			variant.variant_of = "_Test Variant Item"
+			variant.stock_uom = "_Test UOM"
+			variant.append("attributes", {"attribute": "Test Size", "attribute_value": "Medium"})
+			variant.insert()
+
+		rule = frappe.new_doc("Pricing Rule")
+		rule.title = "_Test Pricing Rule Template Variant"
+		rule.apply_on = "Item Code"
+		rule.currency = "USD"
+		rule.selling = 1
+		rule.rate_or_discount = "Discount Percentage"
+		rule.discount_percentage = 10
+		rule.company = "_Test Company"
+		rule.append("items", {"item_code": "_Test Variant Item"})
+		rule.append("items", {"item_code": "Test Variant PRT"})
+
+		self.assertRaises(frappe.ValidationError, rule.insert)
+
 	def test_pricing_rule_for_stock_qty(self):
 		test_record = {
 			"doctype": "Pricing Rule",


### PR DESCRIPTION
Validate template + variant in the same Pricing Rule

Adding an item template and one of its own variants to the same Pricing Rule caused a false "Multiple Price Rules exist" error at transaction time, since the lookup matches both the variant and its template. This adds a save-time check that blocks the conflicting configuration with a clear message. Includes a test.

Case: If shirt (template) is in the rule, all variants already inherit that discount. Adding shirtblue(variant) to the same rule is redundant — same discounting effect — and it's exactly what triggers the duplicate item-level + template-level match → "Multiple Price Rules exist" at voucher time.

https://support.frappe.io/helpdesk/tickets/73279?view=VIEW-HD+Ticket-70178