### PR TITLE
fix: fetch payment entry reference amounts from invoice

### DIFF
--- a/erpnext/accounts/doctype/payment_request/payment_request.py
+++ b/erpnext/accounts/doctype/payment_request/payment_request.py
@@ -542,6 +542,7 @@ class PaymentRequest(Document):
 			bank_amount=bank_amount,
 			created_from_payment_request=True,
 		)
+		payment_entry.set_missing_ref_details(force=True)
 
 		payment_entry.update(
 			{

--- a/erpnext/accounts/doctype/payment_request/test_payment_request.py
+++ b/erpnext/accounts/doctype/payment_request/test_payment_request.py
@@ -774,6 +774,22 @@ class TestPaymentRequest(ERPNextTestSuite):
 		pi.load_from_db()
 		self.assertEqual(pr_2.grand_total, pi.outstanding_amount)
 
+	def test_payment_entry_reference_details_fetched_from_invoice(self):
+		pi = make_purchase_invoice(currency="INR", qty=1, rate=94500)
+		pi.submit()
+
+		pr = make_payment_request(dt="Purchase Invoice", dn=pi.name, mute_email=1, submit_doc=0, return_doc=1)
+		pr.grand_total = 94000
+		pr.submit()
+
+		pe = pr.create_payment_entry(submit=False)
+
+		self.assertEqual(pe.references[0].reference_name, pi.name)
+		self.assertEqual(pe.references[0].total_amount, pi.grand_total)
+		self.assertEqual(pe.references[0].outstanding_amount, pi.outstanding_amount)
+		self.assertEqual(pe.references[0].allocated_amount, 94000)
+		self.assertEqual(pe.paid_amount, 94000)
+
 	def test_consider_journal_entry_and_return_invoice(self):
 		from erpnext.accounts.doctype.journal_entry.test_journal_entry import make_journal_entry
 


### PR DESCRIPTION
**Issue:**
Invoice shows an outstanding balance of 500 and a Payment Request for 400 was submitted to settle the payment.
and clicks Create Payment Entry from that Payment Request to make the payment. At that time, in the Payment Entry form, under the Payment References table, the Grand Total should show the invoice amount 500.00, but instead it shows only the paid amount from the Payment Request 400.

**Ref:**[#59516](https://support.frappe.io/helpdesk/tickets/59516)