### PR TITLE
fix: validate planned end date is not before planned start date in wo…

### DIFF
--- a/erpnext/manufacturing/doctype/work_order/work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/work_order.py
@@ -11,6 +11,7 @@ from frappe.query_builder.functions import Coalesce, IfNull, Sum
 from frappe.utils import (
 	cint,
 	flt,
+	get_datetime,
 	get_link_to_form,
 	now,
 	nowdate,
@@ -317,6 +318,10 @@ class WorkOrder(Document):
 		self.validate_subcontracting_inward_order()
 
 	def validate_dates(self):
+		if self.planned_start_date and self.planned_end_date:
+			if get_datetime(self.planned_end_date) < get_datetime(self.planned_start_date):
+				frappe.throw(_("Planned End Date cannot be before Planned Start Date"))
+
 		if self.actual_start_date and self.actual_end_date:
 			if self.actual_end_date < self.actual_start_date:
 				frappe.throw(_("Actual End Date cannot be before Actual Start Date"))


### PR DESCRIPTION
**Issue:** Work Order allows a Planned End Date before a Planned Start Date

**Steps to replicate:** 
1. Go to Manufacturing > Work Order > New.
2. Fill in the required fields:
  - Item to Manufacture (production item) with an active BOM
  - BOM No
  - Company, FG Warehouse, WIP Warehouse
3. Set Planned Start Date to a later date, e.g., 2026-07-10 10:00:00.
4. Set Planned End Date to an earlier date, e.g. 2026-07-05 10:00:00.
5. Save.

**Expected:** The Save should be blocked by a validation error, since the planned end date precedes the planned start date.

**Actual:** The document saves successfully with no warning.

**Backport Needed For V16 and V15**