### PR TITLE
fix!: item row wise tax breakup

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
@@ -2494,22 +2494,12 @@ class TestSalesInvoice(ERPNextTestSuite):
 
 		itemised_tax_data = get_itemised_tax_breakup_data(si)
 
+		# breakup cell is keyed by account head and carries the description as its label
+		cell = {"description": "Service Tax", "tax_rate": 10.0, "tax_amount": 500.0, "taxable_amount": 5000.0}
 		expected_itemised_tax = [
-			{
-				"item": "_Test Item",
-				"taxable_amount": 5000.0,
-				"Service Tax": {"tax_rate": 10.0, "tax_amount": 500.0, "taxable_amount": 5000.0},
-			},
-			{
-				"item": "_Test Item",
-				"taxable_amount": 5000.0,
-				"Service Tax": {"tax_rate": 10.0, "tax_amount": 500.0, "taxable_amount": 5000.0},
-			},
-			{
-				"item": "_Test Item 2",
-				"taxable_amount": 5000.0,
-				"Service Tax": {"tax_rate": 10.0, "tax_amount": 500.0, "taxable_amount": 5000.0},
-			},
+			{"item": "_Test Item", "taxable_amount": 5000.0, "_Test Account Service Tax - _TC": cell},
+			{"item": "_Test Item", "taxable_amount": 5000.0, "_Test Account Service Tax - _TC": cell},
+			{"item": "_Test Item 2", "taxable_amount": 5000.0, "_Test Account Service Tax - _TC": cell},
 		]
 
 		self.assertEqual(itemised_tax_data, expected_itemised_tax)

--- a/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
@@ -2497,8 +2497,13 @@ class TestSalesInvoice(ERPNextTestSuite):
 		expected_itemised_tax = [
 			{
 				"item": "_Test Item",
-				"taxable_amount": 10000.0,
-				"Service Tax": {"tax_rate": 10.0, "tax_amount": 1000.0, "taxable_amount": 10000.0},
+				"taxable_amount": 5000.0,
+				"Service Tax": {"tax_rate": 10.0, "tax_amount": 500.0, "taxable_amount": 5000.0},
+			},
+			{
+				"item": "_Test Item",
+				"taxable_amount": 5000.0,
+				"Service Tax": {"tax_rate": 10.0, "tax_amount": 500.0, "taxable_amount": 5000.0},
 			},
 			{
 				"item": "_Test Item 2",

--- a/erpnext/controllers/taxes_and_totals.py
+++ b/erpnext/controllers/taxes_and_totals.py
@@ -1196,16 +1196,16 @@ def get_itemised_tax_breakup_html(doc):
 	if not doc.taxes:
 		return
 
-	# get headers
-	tax_accounts = []
-	for tax in doc.taxes:
-		if getattr(tax, "category", None) and tax.category == "Valuation":
-			continue
-		if tax.description not in tax_accounts:
-			tax_accounts.append(tax.description)
+	# one column per tax account, labelled by description
+	labels = {
+		tax.account_head: tax.description
+		for tax in doc.taxes
+		if getattr(tax, "category", None) != "Valuation"
+	}
+	tax_accounts = list(labels)
 
 	with temporary_flag("company", doc.company):
-		headers = get_itemised_tax_breakup_header(doc.doctype + " Item", tax_accounts)
+		headers = get_itemised_tax_breakup_header(doc.doctype + " Item", list(labels.values()))
 		itemised_tax_data = get_itemised_tax_breakup_data(doc)
 		get_rounded_tax_amount(itemised_tax_data, doc.precision("tax_amount", "taxes"))
 		update_itemised_tax_data(doc)
@@ -1259,11 +1259,9 @@ def get_itemised_tax_breakup_data(doc):
 
 
 def get_itemised_tax(doc, with_tax_account=False):
-	"""
-	Itemised tax grouped per physical item line: ``{item_row_object: {tax_description: {...}}}``.
+	"""Itemised tax per item line: ``{item_row_object: {tax_account: {description, rate, amount}}}``.
 
-	Keyed by the item ROW OBJECT (not item_code) on purpose: the same item on several lines -
-	e.g. at different rates via different Item Tax Templates.
+	Keyed by item row object and tax account (not description) so distinct taxes never collapse.
 	"""
 	itemised_tax = {}
 	precision = doc.precision("tax_amount", "taxes")
@@ -1279,9 +1277,10 @@ def get_itemised_tax(doc, with_tax_account=False):
 			continue
 
 		tax_info = itemised_tax.setdefault(item, frappe._dict()).setdefault(
-			tax.description,
+			tax.account_head,
 			frappe._dict(
 				{
+					"description": tax.description,
 					"tax_amount": 0.0,
 					"taxable_amount": 0.0,
 					"tax_rate": row.rate,

--- a/erpnext/controllers/taxes_and_totals.py
+++ b/erpnext/controllers/taxes_and_totals.py
@@ -1260,7 +1260,10 @@ def get_itemised_tax_breakup_data(doc):
 
 def get_itemised_tax(doc, with_tax_account=False):
 	"""
-	Itemised tax keyed by the item line object - one entry per item line.
+	Itemised tax grouped per physical item line: ``{item_row_object: {tax_description: {...}}}``.
+
+	Keyed by the item ROW OBJECT (not item_code) on purpose: the same item on several lines -
+	e.g. at different rates via different Item Tax Templates.
 	"""
 	itemised_tax = {}
 	precision = doc.precision("tax_amount", "taxes")
@@ -1298,24 +1301,20 @@ def get_itemised_tax(doc, with_tax_account=False):
 def set_item_wise_tax_rate(doc):
 	"""Set each item line's total applicable tax rate on the item object.
 
-	Sums the rates of the line's taxes from ``_item_wise_tax_details`` (skipping valuation
-	taxes) directly onto ``item.tax_rate``. Regional callers (e.g. Italy, UAE) then derive
+	Sums each line's per-tax rates (from ``get_itemised_tax``) onto ``item.tax_rate``.
+	``get_itemised_tax`` groups by tax, so a tax account that appears on more than one detail
+	row (e.g. across multiple charge rows) contributes its rate once - not once per row -
+	preserving the previous regional behaviour. Valuation taxes are excluded (they are already
+	skipped by ``get_itemised_tax``). Regional callers (Italy, UAE) derive
 	``tax_amount``/``total_amount`` from it.
 	"""
+	itemised_tax = get_itemised_tax(doc)
 	for item in doc.get("items") or []:
-		item.tax_rate = 0.0
-
-	for row in doc.get("_item_wise_tax_details") or []:
-		item = row.get("item")
-		tax = row.get("tax")
-		if not item or not tax:
-			continue
-		if getattr(tax, "category", None) and tax.category == "Valuation":
-			continue
-		item.tax_rate += flt(row.rate)
-
-	for item in doc.get("items") or []:
-		item.tax_rate = flt(item.tax_rate, item.precision("tax_rate"))
+		taxes = itemised_tax.get(item) or {}
+		item.tax_rate = flt(
+			sum(tax.get("tax_rate", 0) for tax in taxes.values()),
+			item.precision("tax_rate"),
+		)
 
 
 def get_rounded_tax_amount(itemised_tax, precision):

--- a/erpnext/controllers/taxes_and_totals.py
+++ b/erpnext/controllers/taxes_and_totals.py
@@ -1250,7 +1250,8 @@ def get_itemised_tax_breakup_header(item_doctype, tax_accounts):
 def get_itemised_tax_breakup_data(doc):
 	itemised_tax = get_itemised_tax(doc)
 	itemised_tax_data = []
-	for item_code, taxes in itemised_tax.items():
+	for item, taxes in itemised_tax.items():
+		item_code = item.item_code or item.item_name
 		taxable_amount = next(iter(taxes.values())).get("taxable_amount")
 		itemised_tax_data.append(frappe._dict({"item": item_code, "taxable_amount": taxable_amount, **taxes}))
 
@@ -1258,8 +1259,12 @@ def get_itemised_tax_breakup_data(doc):
 
 
 def get_itemised_tax(doc, with_tax_account=False):
+	"""
+	Itemised tax keyed by the item line object - one entry per item line.
+	"""
 	itemised_tax = {}
 	precision = doc.precision("tax_amount", "taxes")
+	conversion_rate = doc.conversion_rate or 1
 
 	for row in doc.get("_item_wise_tax_details"):
 		item = row.get("item")
@@ -1267,11 +1272,10 @@ def get_itemised_tax(doc, with_tax_account=False):
 		if not item or not tax:
 			continue
 
-		item_code = item.item_code or item.item_name
 		if getattr(tax, "category", None) and tax.category == "Valuation":
 			continue
 
-		tax_info = itemised_tax.setdefault(item_code, frappe._dict()).setdefault(
+		tax_info = itemised_tax.setdefault(item, frappe._dict()).setdefault(
 			tax.description,
 			frappe._dict(
 				{
@@ -1283,13 +1287,35 @@ def get_itemised_tax(doc, with_tax_account=False):
 		)
 
 		tax_info.tax_amount += flt(row.amount, precision)
-		conversion_rate = doc.conversion_rate or 1
 		tax_info.taxable_amount += flt(row.taxable_amount / conversion_rate, precision)
 
 		if with_tax_account:
 			tax_info.tax_account = tax.account_head
 
 	return itemised_tax
+
+
+def set_item_wise_tax_rate(doc):
+	"""Set each item line's total applicable tax rate on the item object.
+
+	Sums the rates of the line's taxes from ``_item_wise_tax_details`` (skipping valuation
+	taxes) directly onto ``item.tax_rate``. Regional callers (e.g. Italy, UAE) then derive
+	``tax_amount``/``total_amount`` from it.
+	"""
+	for item in doc.get("items") or []:
+		item.tax_rate = 0.0
+
+	for row in doc.get("_item_wise_tax_details") or []:
+		item = row.get("item")
+		tax = row.get("tax")
+		if not item or not tax:
+			continue
+		if getattr(tax, "category", None) and tax.category == "Valuation":
+			continue
+		item.tax_rate += flt(row.rate)
+
+	for item in doc.get("items") or []:
+		item.tax_rate = flt(item.tax_rate, item.precision("tax_rate"))
 
 
 def get_rounded_tax_amount(itemised_tax, precision):

--- a/erpnext/controllers/tests/test_item_wise_tax_details.py
+++ b/erpnext/controllers/tests/test_item_wise_tax_details.py
@@ -1,6 +1,7 @@
 import frappe
 from frappe.utils import flt
 
+from erpnext.controllers.taxes_and_totals import get_itemised_tax_breakup_data
 from erpnext.tests.utils import ERPNextTestSuite, change_settings
 
 
@@ -534,3 +535,121 @@ class TestTaxesAndTotals(ERPNextTestSuite):
 		]
 
 		self.assertEqual(actual_values, expected_values)
+
+	def _append_item_with_tax_template(self, item_tax_template):
+		self.doc.append(
+			"items",
+			{
+				"item_code": "_Test Item",
+				"qty": 1,
+				"rate": 100,
+				"income_account": "Sales - _TC",
+				"expense_account": "Cost of Goods Sold - _TC",
+				"cost_center": "_Test Cost Center - _TC",
+				"item_tax_template": item_tax_template,
+			},
+		)
+
+	@staticmethod
+	def _make_item_tax_template(title, taxes):
+		return frappe.get_doc(
+			{
+				"doctype": "Item Tax Template",
+				"title": title,
+				"company": "_Test Company",
+				"taxes": [{"tax_type": account, "tax_rate": rate} for account, rate in taxes.items()],
+			}
+		).insert(ignore_if_duplicate=True)
+
+	def _append_net_total_tax(self, account_head, description):
+		self.doc.append(
+			"taxes",
+			{
+				"charge_type": "On Net Total",
+				"account_head": account_head,
+				"cost_center": "_Test Cost Center - _TC",
+				"description": description,
+				"rate": 0,
+			},
+		)
+
+	@change_settings("Selling Settings", {"allow_multiple_items": 1})
+	def test_itemised_tax_breakup_splits_same_item_by_rate(self):
+		"""The same item on two lines at different rates for the SAME tax account must
+		produce two breakup rows, each with its own rate and a matching amount - not one
+		merged row showing the first rate against the summed amount."""
+		vat = "_Test Account VAT - _TC"
+		self.doc.items[0].item_tax_template = self._make_item_tax_template(
+			"_Test VAT 10% Template", {vat: 10}
+		).name
+		self._append_item_with_tax_template(
+			self._make_item_tax_template("_Test VAT 5% Template", {vat: 5}).name
+		)
+		self._append_net_total_tax(vat, "VAT")
+
+		self.doc.save()
+
+		breakup = get_itemised_tax_breakup_data(self.doc)
+
+		self.assertEqual(len(breakup), 2)
+		for row in breakup:
+			self.assertEqual(row["item"], "_Test Item")
+			self.assertEqual(row["taxable_amount"], 100.0)
+
+		rows_by_rate = {row["VAT"]["tax_rate"]: row for row in breakup}
+		self.assertEqual(set(rows_by_rate), {10.0, 5.0})
+		self.assertEqual(rows_by_rate[10.0]["VAT"]["tax_amount"], 10.0)
+		self.assertEqual(rows_by_rate[5.0]["VAT"]["tax_amount"], 5.0)
+
+	@change_settings("Selling Settings", {"allow_multiple_items": 1})
+	def test_itemised_tax_breakup_keeps_row_per_line_at_same_rate(self):
+		"""The breakup is row-wise: the same item on two lines at the same rate stays two
+		rows (one per line), each self-consistent."""
+		vat = "_Test Account VAT - _TC"
+		template = self._make_item_tax_template("_Test VAT 10% Template", {vat: 10})
+		self.doc.items[0].item_tax_template = template.name
+		self._append_item_with_tax_template(template.name)
+		self._append_net_total_tax(vat, "VAT")
+
+		self.doc.save()
+
+		breakup = get_itemised_tax_breakup_data(self.doc)
+
+		self.assertEqual(len(breakup), 2)
+		for row in breakup:
+			self.assertEqual(row["item"], "_Test Item")
+			self.assertEqual(row["taxable_amount"], 100.0)
+			self.assertEqual(row["VAT"]["tax_rate"], 10.0)
+			self.assertEqual(row["VAT"]["tax_amount"], 10.0)
+
+	@change_settings("Selling Settings", {"allow_multiple_items": 1})
+	def test_itemised_tax_breakup_splits_when_only_one_tax_differs(self):
+		"""When an item carries several taxes and only ONE differs in rate across lines
+		(the rest identical), the lines still render as separate rows."""
+		vat = "_Test Account VAT - _TC"
+		service_tax = "_Test Account Service Tax - _TC"
+		# VAT identical (10) on both lines; only Service Tax differs (14 vs 7)
+		self.doc.items[0].item_tax_template = self._make_item_tax_template(
+			"_Test VAT 10 ST 14 Template", {vat: 10, service_tax: 14}
+		).name
+		self._append_item_with_tax_template(
+			self._make_item_tax_template("_Test VAT 10 ST 7 Template", {vat: 10, service_tax: 7}).name
+		)
+		self._append_net_total_tax(vat, "VAT")
+		self._append_net_total_tax(service_tax, "Service Tax")
+
+		self.doc.save()
+
+		breakup = get_itemised_tax_breakup_data(self.doc)
+
+		self.assertEqual(len(breakup), 2)
+		rows_by_st_rate = {row["Service Tax"]["tax_rate"]: row for row in breakup}
+		self.assertEqual(set(rows_by_st_rate), {14.0, 7.0})
+
+		for st_rate, st_amount in ((14.0, 14.0), (7.0, 7.0)):
+			row = rows_by_st_rate[st_rate]
+			self.assertEqual(row["item"], "_Test Item")
+			self.assertEqual(row["taxable_amount"], 100.0)
+			self.assertEqual(row["VAT"]["tax_rate"], 10.0)
+			self.assertEqual(row["VAT"]["tax_amount"], 10.0)
+			self.assertEqual(row["Service Tax"]["tax_amount"], st_amount)

--- a/erpnext/controllers/tests/test_item_wise_tax_details.py
+++ b/erpnext/controllers/tests/test_item_wise_tax_details.py
@@ -1,7 +1,7 @@
 import frappe
 from frappe.utils import flt
 
-from erpnext.controllers.taxes_and_totals import get_itemised_tax_breakup_data
+from erpnext.controllers.taxes_and_totals import get_itemised_tax_breakup_data, set_item_wise_tax_rate
 from erpnext.tests.utils import ERPNextTestSuite, change_settings
 
 
@@ -653,3 +653,33 @@ class TestTaxesAndTotals(ERPNextTestSuite):
 			self.assertEqual(row["VAT"]["tax_rate"], 10.0)
 			self.assertEqual(row["VAT"]["tax_amount"], 10.0)
 			self.assertEqual(row["Service Tax"]["tax_amount"], st_amount)
+
+	def test_set_item_wise_tax_rate(self):
+		"""set_item_wise_tax_rate sums each line's tax rates onto item.tax_rate and
+		overwrites any stale value (used by the Italy/UAE regional callers)."""
+		self._append_net_total_tax("_Test Account VAT - _TC", "VAT")
+		self.doc.taxes[0].rate = 10
+		self._append_net_total_tax("_Test Account Service Tax - _TC", "Service Tax")
+		self.doc.taxes[1].rate = 5
+		self.doc.save()
+
+		# a stale value that must be recomputed (reset), not accumulated onto
+		self.doc.items[0].tax_rate = 999
+
+		set_item_wise_tax_rate(self.doc)
+
+		self.assertEqual(self.doc.items[0].tax_rate, 15.0)
+
+	def test_set_item_wise_tax_rate_counts_each_tax_once(self):
+		"""The same tax account on more than one charge row must contribute its rate once
+		(set once per tax), not once per _item_wise_tax_details row."""
+		self._append_net_total_tax("_Test Account VAT - _TC", "VAT")
+		self.doc.taxes[0].rate = 5
+		self._append_net_total_tax("_Test Account VAT - _TC", "VAT")
+		self.doc.taxes[1].rate = 5
+		self.doc.save()
+
+		set_item_wise_tax_rate(self.doc)
+
+		# 5 (counted once), not 5 + 5
+		self.assertEqual(self.doc.items[0].tax_rate, 5.0)

--- a/erpnext/controllers/tests/test_item_wise_tax_details.py
+++ b/erpnext/controllers/tests/test_item_wise_tax_details.py
@@ -596,10 +596,10 @@ class TestTaxesAndTotals(ERPNextTestSuite):
 			self.assertEqual(row["item"], "_Test Item")
 			self.assertEqual(row["taxable_amount"], 100.0)
 
-		rows_by_rate = {row["VAT"]["tax_rate"]: row for row in breakup}
+		rows_by_rate = {row[vat]["tax_rate"]: row for row in breakup}
 		self.assertEqual(set(rows_by_rate), {10.0, 5.0})
-		self.assertEqual(rows_by_rate[10.0]["VAT"]["tax_amount"], 10.0)
-		self.assertEqual(rows_by_rate[5.0]["VAT"]["tax_amount"], 5.0)
+		self.assertEqual(rows_by_rate[10.0][vat]["tax_amount"], 10.0)
+		self.assertEqual(rows_by_rate[5.0][vat]["tax_amount"], 5.0)
 
 	@change_settings("Selling Settings", {"allow_multiple_items": 1})
 	def test_itemised_tax_breakup_keeps_row_per_line_at_same_rate(self):
@@ -619,8 +619,8 @@ class TestTaxesAndTotals(ERPNextTestSuite):
 		for row in breakup:
 			self.assertEqual(row["item"], "_Test Item")
 			self.assertEqual(row["taxable_amount"], 100.0)
-			self.assertEqual(row["VAT"]["tax_rate"], 10.0)
-			self.assertEqual(row["VAT"]["tax_amount"], 10.0)
+			self.assertEqual(row[vat]["tax_rate"], 10.0)
+			self.assertEqual(row[vat]["tax_amount"], 10.0)
 
 	@change_settings("Selling Settings", {"allow_multiple_items": 1})
 	def test_itemised_tax_breakup_splits_when_only_one_tax_differs(self):
@@ -643,16 +643,34 @@ class TestTaxesAndTotals(ERPNextTestSuite):
 		breakup = get_itemised_tax_breakup_data(self.doc)
 
 		self.assertEqual(len(breakup), 2)
-		rows_by_st_rate = {row["Service Tax"]["tax_rate"]: row for row in breakup}
+		rows_by_st_rate = {row[service_tax]["tax_rate"]: row for row in breakup}
 		self.assertEqual(set(rows_by_st_rate), {14.0, 7.0})
 
 		for st_rate, st_amount in ((14.0, 14.0), (7.0, 7.0)):
 			row = rows_by_st_rate[st_rate]
 			self.assertEqual(row["item"], "_Test Item")
 			self.assertEqual(row["taxable_amount"], 100.0)
-			self.assertEqual(row["VAT"]["tax_rate"], 10.0)
-			self.assertEqual(row["VAT"]["tax_amount"], 10.0)
-			self.assertEqual(row["Service Tax"]["tax_amount"], st_amount)
+			self.assertEqual(row[vat]["tax_rate"], 10.0)
+			self.assertEqual(row[vat]["tax_amount"], 10.0)
+			self.assertEqual(row[service_tax]["tax_amount"], st_amount)
+
+	def test_itemised_tax_breakup_splits_same_description_different_accounts(self):
+		"""Two tax rows sharing a DESCRIPTION but on different accounts must stay separate cells
+		(keyed by account), not collapse into one showing the first rate against the summed amount."""
+		vat = "_Test Account VAT - _TC"
+		service_tax = "_Test Account Service Tax - _TC"
+		self._append_net_total_tax(vat, "VAT")
+		self.doc.taxes[0].rate = 10
+		self._append_net_total_tax(service_tax, "VAT")  # same description, different account
+		self.doc.taxes[1].rate = 5
+		self.doc.save()
+
+		row = get_itemised_tax_breakup_data(self.doc)[0]
+		self.assertEqual(row["taxable_amount"], 100.0)  # not doubled
+		self.assertEqual(row[vat]["tax_rate"], 10.0)
+		self.assertEqual(row[vat]["tax_amount"], 10.0)
+		self.assertEqual(row[service_tax]["tax_rate"], 5.0)
+		self.assertEqual(row[service_tax]["tax_amount"], 5.0)
 
 	def test_set_item_wise_tax_rate(self):
 		"""set_item_wise_tax_rate sums each line's tax rates onto item.tax_rate and

--- a/erpnext/regional/italy/utils.py
+++ b/erpnext/regional/italy/utils.py
@@ -6,7 +6,7 @@ from frappe import _
 from frappe.utils import cstr, flt
 from frappe.utils.file_manager import remove_file
 
-from erpnext.controllers.taxes_and_totals import get_itemised_tax
+from erpnext.controllers.taxes_and_totals import set_item_wise_tax_rate
 from erpnext.regional.italy import state_codes
 from erpnext.stock.utils import get_default_stock_uom
 
@@ -18,16 +18,11 @@ def update_itemised_tax_data(doc):
 	if doc.doctype == "Purchase Invoice":
 		return
 
-	itemised_tax = get_itemised_tax(doc)
+	set_item_wise_tax_rate(doc)
 
-	for row in doc.items:
-		tax_rate = 0.0
-		if itemised_tax.get(row.item_code):
-			tax_rate = sum([tax.get("tax_rate", 0) for d, tax in itemised_tax.get(row.item_code).items()])
-
-		row.tax_rate = flt(tax_rate, row.precision("tax_rate"))
-		row.tax_amount = flt((row.net_amount * tax_rate) / 100, row.precision("net_amount"))
-		row.total_amount = flt((row.net_amount + row.tax_amount), row.precision("total_amount"))
+	for item in doc.items:
+		item.tax_amount = flt((item.net_amount * item.tax_rate) / 100, item.precision("net_amount"))
+		item.total_amount = flt((item.net_amount + item.tax_amount), item.precision("total_amount"))
 
 
 @frappe.whitelist()

--- a/erpnext/regional/united_arab_emirates/utils.py
+++ b/erpnext/regional/united_arab_emirates/utils.py
@@ -3,7 +3,7 @@ from frappe import _
 from frappe.utils import flt, money_in_words, round_based_on_smallest_currency_fraction
 
 import erpnext
-from erpnext.controllers.taxes_and_totals import get_itemised_tax
+from erpnext.controllers.taxes_and_totals import set_item_wise_tax_rate
 
 
 def update_itemised_tax_data(doc):
@@ -13,8 +13,6 @@ def update_itemised_tax_data(doc):
 	meta = frappe.get_meta(doc.items[0].doctype)
 	if not meta.has_field("tax_rate"):
 		return
-
-	itemised_tax = get_itemised_tax(doc)
 
 	def determine_if_export(doc):
 		if doc.doctype != "Sales Invoice":
@@ -39,22 +37,14 @@ def update_itemised_tax_data(doc):
 
 	is_export = determine_if_export(doc)
 
-	for row in doc.items:
-		tax_rate, tax_amount = 0.0, 0.0
-		# dont even bother checking in item tax template as it contains both input and output accounts - double the tax rate
-		item_code = row.item_code or row.item_name
-		if itemised_tax.get(item_code):
-			for tax in itemised_tax.get(item_code).values():
-				_tax_rate = flt(tax.get("tax_rate", 0), row.precision("tax_rate"))
-				tax_amount += flt((row.net_amount * _tax_rate) / 100, row.precision("tax_amount"))
-				tax_rate += _tax_rate
+	set_item_wise_tax_rate(doc)
 
-		if not tax_rate or row.get("is_zero_rated"):
-			row.is_zero_rated = is_export or frappe.get_cached_value("Item", row.item_code, "is_zero_rated")
+	for item in doc.items:
+		if not item.tax_rate or item.get("is_zero_rated"):
+			item.is_zero_rated = is_export or frappe.get_cached_value("Item", item.item_code, "is_zero_rated")
 
-		row.tax_rate = flt(tax_rate, row.precision("tax_rate"))
-		row.tax_amount = flt(tax_amount, row.precision("tax_amount"))
-		row.total_amount = flt((row.net_amount + row.tax_amount), row.precision("total_amount"))
+		item.tax_amount = flt((item.net_amount * item.tax_rate) / 100, item.precision("tax_amount"))
+		item.total_amount = flt((item.net_amount + item.tax_amount), item.precision("total_amount"))
 
 
 def get_account_currency(account):


### PR DESCRIPTION
Issue: If the same item is specified with different tax rates, an incorrect tax breakup is shown.

Now we will have an item row-wise and tax account wise breakup.
Before:

<img width="1041" height="208" alt="image" src="https://github.com/user-attachments/assets/06dcf7b3-ef8f-45c6-9037-8cbab5b0bbaf" />

After:
<img width="943" height="256" alt="image" src="https://github.com/user-attachments/assets/f0f615c7-b55e-412a-963b-ca7a51b5af55" />

Note: regional apps using this function need to update their code.