### PR TITLE
fix: queue statement downloads for large customer sets

### DIFF
--- a/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
+++ b/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
@@ -112,6 +112,8 @@
   "create_pr_in_draft_status",
   "budget_section",
   "use_legacy_budget_controller",
+  "process_statement_of_accounts_section",
+  "psoa_customer_threshold",
   "document_naming_tab",
   "transaction_naming_html"
  ],
@@ -757,6 +759,19 @@
    "description": "Changing the account in any transaction of the DocTypes listed below will trigger a repost. To prevent reposting, remove the relevant DocType from the list.",
    "fieldname": "column_break_mfor",
    "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "process_statement_of_accounts_section",
+   "fieldtype": "Section Break",
+   "label": "Process Statement of Accounts"
+  },
+  {
+   "default": "10",
+   "description": "Maximum customers to process immediately. Larger requests are processed in the background.",
+   "fieldname": "psoa_customer_threshold",
+   "fieldtype": "Int",
+   "label": "PSOA Customer Threshold",
+   "non_negative": 1
   }
  ],
  "grid_page_length": 50,
@@ -765,7 +780,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2026-06-24 12:59:41.868865",
+ "modified": "2026-07-05 20:06:18.022564",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Accounts Settings",

--- a/erpnext/accounts/doctype/accounts_settings/accounts_settings.py
+++ b/erpnext/accounts/doctype/accounts_settings/accounts_settings.py
@@ -92,6 +92,7 @@ class AccountsSettings(Document):
 		over_billing_allowance: DF.Currency
 		pcv_job_timeout: DF.Int
 		preview_mode: DF.Check
+		psoa_customer_threshold: DF.Int
 		receivable_payable_fetch_method: DF.Literal["Buffered Cursor", "UnBuffered Cursor"]
 		receivable_payable_remarks_length: DF.Int
 		reconciliation_queue_size: DF.Int

--- a/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.js
+++ b/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.js
@@ -7,43 +7,124 @@ frappe.ui.form.on("Process Statement Of Accounts", {
 		frappe.set_route("Form", "Customize Form");
 	},
 	refresh: function (frm) {
-		if (!frm.doc.__islocal) {
-			frm.add_custom_button(__("Send Emails"), function () {
+		if (frm.doc.__islocal) return;
+
+		frm.add_custom_button(
+			__("Send Emails"),
+			function () {
 				if (frm.is_dirty()) frappe.throw(__("Please save before proceeding."));
-				frappe.call({
-					method: "erpnext.accounts.doctype.process_statement_of_accounts.process_statement_of_accounts.send_emails",
-					args: {
-						document_name: frm.doc.name,
-					},
-					callback: function (r) {
-						if (r && r.message) {
-							frappe.show_alert({ message: __("Emails queued"), indicator: "blue" });
-						} else {
-							frappe.msgprint(__("No records for these settings."));
-						}
-					},
-				});
-			});
-			frm.add_custom_button(__("Download"), function () {
-				if (frm.is_dirty()) frappe.throw(__("Please save before proceeding."));
-				let url = frappe.urllib.get_full_url(
-					"/api/method/erpnext.accounts.doctype.process_statement_of_accounts.process_statement_of_accounts.download_statements?" +
-						"document_name=" +
-						encodeURIComponent(frm.doc.name)
+				if (!frm.doc.customers || !frm.doc.customers.length) {
+					frappe.msgprint(__("No customers found for this document."));
+					return;
+				}
+
+				frappe.confirm(
+					__("Send statement emails to {0} customer(s)?", [frm.doc.customers.length]),
+					function () {
+						frappe.call({
+							method: "erpnext.accounts.doctype.process_statement_of_accounts.process_statement_of_accounts.queue_send_emails",
+							args: { document_name: frm.doc.name },
+							freeze: true,
+							freeze_message: __("Queuing emails..."),
+							callback: function (r) {
+								if (r.message) {
+									frappe.show_alert({ message: r.message, indicator: "blue" });
+								} else {
+									frappe.msgprint(__("No records found for these settings."));
+								}
+							},
+							error: function () {
+								frappe.msgprint(__("Failed to queue email generation. Please try again."));
+							},
+						});
+					}
 				);
-				$.ajax({
-					url: url,
-					type: "GET",
-					success: function (result) {
-						if (jQuery.isEmptyObject(result)) {
-							frappe.msgprint(__("No records for these settings."));
-						} else {
-							window.location = url;
-						}
-					},
-				});
-			});
-		}
+			},
+			__("Actions")
+		);
+
+		frm.add_custom_button(
+			__("Download"),
+			function () {
+				if (frm.is_dirty()) frappe.throw(__("Please save before proceeding."));
+				if (!frm.doc.customers || !frm.doc.customers.length) {
+					frappe.msgprint(__("No customers found for this document."));
+					return;
+				}
+
+				frappe.confirm(
+					__("Download statement for {0} customer(s)?", [frm.doc.customers.length]),
+					function () {
+						const customerCount = frm.doc.customers.length;
+
+						frappe.db
+							.get_single_value("Accounts Settings", "psoa_customer_threshold")
+							.then((psoa_customer_threshold) => {
+								if (customerCount <= psoa_customer_threshold) {
+									let url = frappe.urllib.get_full_url(
+										"/api/method/erpnext.accounts.doctype.process_statement_of_accounts.process_statement_of_accounts.download_statements?" +
+											"document_name=" +
+											encodeURIComponent(frm.doc.name)
+									);
+									$.ajax({
+										url: url,
+										type: "GET",
+										success: function (result) {
+											if (jQuery.isEmptyObject(result)) {
+												frappe.msgprint(__("No records found for these filters."));
+											} else {
+												window.location = url;
+											}
+										},
+										error: function (jqXHR) {
+											let message = __(
+												"Failed to download statement. Please try again."
+											);
+											try {
+												const parsed = JSON.parse(jqXHR.responseText);
+												if (parsed && parsed._server_messages) {
+													const server_messages = JSON.parse(
+														parsed._server_messages
+													);
+													if (server_messages.length) {
+														message =
+															JSON.parse(server_messages[0]).message || message;
+													}
+												}
+											} catch (e) {
+												// fall back to default message
+											}
+											frappe.msgprint(message);
+										},
+									});
+									return;
+								}
+
+								frappe.call({
+									method: "erpnext.accounts.doctype.process_statement_of_accounts.process_statement_of_accounts.queue_statement_download",
+									args: { document_name: frm.doc.name },
+									freeze: true,
+									freeze_message: __("Queuing statement generation..."),
+									callback: function (r) {
+										if (r.message) {
+											frappe.show_alert({ message: r.message, indicator: "blue" });
+										}
+									},
+									error: function () {
+										frappe.msgprint(
+											__("Failed to queue statement generation. Please try again.")
+										);
+									},
+								});
+							})
+							.catch(function () {
+								frappe.msgprint(__("Failed to fetch customer threshold setting."));
+							});
+					}
+				);
+			},
+			__("Actions")
+		);
 	},
 	onload: function (frm) {
 		frm.set_query("currency", function () {

--- a/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.json
+++ b/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.json
@@ -62,6 +62,7 @@
   "subject",
   "column_break_28",
   "cc_to",
+  "statement_attachment",
   "section_break_30",
   "body",
   "help_text"
@@ -422,10 +423,16 @@
    "fieldname": "show_opening_entries",
    "fieldtype": "Check",
    "label": "Show Opening Entries"
+  },
+  {
+   "fieldname": "statement_attachment",
+   "fieldtype": "Attach",
+   "label": "Statement Attachment",
+   "read_only": 1
   }
  ],
  "links": [],
- "modified": "2026-06-01 15:37:07.660442",
+ "modified": "2026-07-08 11:56:46.317025",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Process Statement Of Accounts",

--- a/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.py
+++ b/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.py
@@ -7,7 +7,8 @@ import copy
 import frappe
 from frappe import _
 from frappe.model.document import Document
-from frappe.utils import add_days, add_months, format_date, getdate, today
+from frappe.utils import add_days, add_months, format_date, getdate, now_datetime, today
+from frappe.utils.background_jobs import is_job_enqueued
 from frappe.utils.jinja import validate_template
 from frappe.utils.pdf import get_pdf
 from frappe.www.printview import get_print_style
@@ -78,6 +79,7 @@ class ProcessStatementOfAccounts(Document):
 		show_opening_entries: DF.Check
 		show_remarks: DF.Check
 		start_date: DF.Date | None
+		statement_attachment: DF.Attach | None
 		subject: DF.Data | None
 		terms_and_conditions: DF.Link | None
 		territory: DF.Link | None
@@ -524,61 +526,237 @@ def download_statements(document_name: str):
 
 
 @frappe.whitelist()
-def send_emails(document_name: str, from_scheduler: bool = False, posting_date: str | None = None):
+def queue_statement_download(document_name: str):
+	doc = frappe.get_doc("Process Statement Of Accounts", document_name)
+	doc.check_permission("read")
+
+	job_id = f"download_statement_of_accounts_{document_name}"
+	if is_job_enqueued(job_id):
+		return _("A statement generation job is already queued for this document.")
+
+	frappe.enqueue(
+		generate_statement_download,
+		queue="long",
+		document_name=document_name,
+		user=frappe.session.user,
+		enqueue_after_commit=True,
+		job_id=job_id,
+		deduplicate=True,
+	)
+
+	return _(
+		"Statement generation has been queued. You'll be notified when it's ready, and the PDF will be available in the Statement Attachment field."
+	)
+
+
+def generate_statement_download(document_name: str, user: str | None = None):
+	doc = frappe.get_doc("Process Statement Of Accounts", document_name)
+	report = get_report_pdf(doc)
+	if not report:
+		if user:
+			_notify_user(
+				user,
+				doc,
+				subject=_("Statement generation failed. Please try again or contact support."),
+			)
+		return
+
+	if doc.statement_attachment:
+		old_file = frappe.db.get_value(
+			"File",
+			{
+				"file_url": doc.statement_attachment,
+				"attached_to_doctype": doc.doctype,
+				"attached_to_name": doc.name,
+			},
+			"name",
+		)
+
+		if old_file:
+			frappe.delete_doc("File", old_file, ignore_permissions=True, delete_permanently=True, force=True)
+
+	file = frappe.get_doc(
+		{
+			"doctype": "File",
+			"file_name": get_pdf_filename(doc.name),
+			"attached_to_doctype": doc.doctype,
+			"attached_to_name": doc.name,
+			"content": report,
+			"is_private": 1,
+		}
+	).insert(ignore_permissions=True)
+
+	doc.db_set("statement_attachment", file.file_url)
+
+	if user:
+		_notify_user(
+			user,
+			doc,
+			subject=_("Statement of Accounts PDF is ready. Check the Statement Attachment field."),
+			link=doc.get_url(),
+		)
+
+
+def _notify_user(user: str, doc, subject: str, email_content: str | None = None, link: str | None = None):
+	notification = {
+		"doctype": "Notification Log",
+		"subject": subject,
+		"for_user": user,
+		"type": "Alert",
+		"document_type": doc.doctype,
+		"document_name": doc.name,
+	}
+	if email_content:
+		notification["email_content"] = email_content
+	if link:
+		notification["link"] = link
+
+	frappe.get_doc(notification).insert(ignore_permissions=True)
+
+
+def get_send_emails_job_id(document_name: str) -> str:
+	return f"send_statement_of_accounts_emails_{document_name}"
+
+
+@frappe.whitelist()
+def queue_send_emails(document_name: str):
 	doc = frappe.get_doc("Process Statement Of Accounts", document_name)
 	doc.check_permission()
-	report = get_report_pdf(doc, consolidated=False)
 
-	if report:
-		for customer, report_pdf in report.items():
-			context = get_context(customer, doc)
-			filename = frappe.render_template(doc.pdf_name, context)
-			attachments = [{"fname": filename + ".pdf", "fcontent": report_pdf}]
+	job_id = get_send_emails_job_id(document_name)
+	if is_job_enqueued(job_id):
+		return _("An email generation job is already queued or running for this document.")
 
-			recipients, cc = get_recipients_and_cc(customer, doc)
-			if not recipients:
-				continue
+	psoa_customer_threshold = frappe.db.get_single_value("Accounts Settings", "psoa_customer_threshold")
+	queue = "short" if len(doc.customers) <= psoa_customer_threshold else "long"
 
-			subject = frappe.render_template(doc.subject, context)
-			message = frappe.render_template(doc.body, context)
+	frappe.enqueue(
+		send_emails,
+		queue=queue,
+		document_name=document_name,
+		user=frappe.session.user,
+		enqueue_after_commit=True,
+		job_id=job_id,
+		deduplicate=True,
+	)
 
-			if doc.sender:
-				sender_email = frappe.db.get_value("Email Account", doc.sender, "email_id")
-			else:
-				sender_email = frappe.session.user
+	return _("Email generation has been queued and will be processed in the background.")
 
-			frappe.enqueue(
-				queue="short",
-				method=frappe.sendmail,
+
+def send_emails(
+	document_name: str,
+	from_scheduler: bool = False,
+	posting_date: str | None = None,
+	user: str | None = None,
+):
+	doc = frappe.get_doc("Process Statement Of Accounts", document_name)
+	doc.check_permission()
+
+	# In scheduler context there is no interactive session user to notify.
+	# Fall back to the document owner so failures are actually seen by someone
+	# responsible for this PSOA setup.
+	notify_user = user if (user and not from_scheduler) else (doc.owner or user)
+
+	try:
+		report = get_report_pdf(doc, consolidated=False)
+	except Exception:
+		frappe.log_error(
+			title=f"Failed to generate statement PDFs for {document_name}",
+			message=frappe.get_traceback(),
+		)
+		if notify_user:
+			_notify_user(
+				notify_user,
+				doc,
+				subject=_(
+					"Statement of Accounts email generation failed. Please try again or contact support."
+				),
+			)
+		return False
+
+	if not report:
+		return False
+
+	failed_customers = []
+	skipped_customers = []
+
+	for customer, report_pdf in report.items():
+		context = get_context(customer, doc)
+		filename = frappe.render_template(  # nosemgrep: frappe-semgrep-rules.rules.security.frappe-ssti
+			doc.pdf_name, context
+		)
+		recipients, cc = get_recipients_and_cc(customer, doc)
+		if not recipients:
+			# No recipient configured — this customer was NOT sent a statement,
+			# so the cycle is not actually complete for them.
+			skipped_customers.append(customer)
+			continue
+
+		sender_email = (
+			frappe.db.get_value("Email Account", doc.sender, "email_id")
+			if doc.sender
+			else frappe.session.user
+		)
+		try:
+			frappe.sendmail(
 				recipients=recipients,
 				sender=sender_email,
 				cc=cc,
-				subject=subject,
-				message=message,
+				subject=frappe.render_template(  # nosemgrep: frappe-semgrep-rules.rules.security.frappe-ssti
+					doc.subject, context
+				),
+				message=frappe.render_template(  # nosemgrep: frappe-semgrep-rules.rules.security.frappe-ssti
+					doc.body, context
+				),
 				now=True,
 				reference_doctype="Process Statement Of Accounts",
 				reference_name=document_name,
-				attachments=attachments,
+				attachments=[{"fname": filename + ".pdf", "fcontent": report_pdf}],
 				expose_recipients="header",
 			)
+		except Exception:
+			frappe.log_error(
+				title=f"Failed to send statement email to {customer} for {document_name}",
+				message=frappe.get_traceback(),
+			)
+			failed_customers.append(customer)
+			continue
 
-		if doc.enable_auto_email and from_scheduler:
-			new_to_date = getdate(posting_date or today())
-			if doc.frequency in ("Daily", "Weekly", "Biweekly"):
-				frequency = {"Daily": 1, "Weekly": 7, "Biweekly": 14}
-				new_to_date = add_days(new_to_date, frequency[doc.frequency])
-			else:
-				new_to_date = add_months(new_to_date, 1 if doc.frequency == "Monthly" else 3)
-			new_from_date = add_months(new_to_date, -1 * doc.filter_duration)
-			doc.add_comment("Comment", "Emails sent on: " + frappe.utils.format_datetime(frappe.utils.now()))
-			if doc.report == "General Ledger":
-				frappe.db.set_value(doc.doctype, doc.name, "to_date", new_to_date)
-				frappe.db.set_value(doc.doctype, doc.name, "from_date", new_from_date)
-			else:
-				frappe.db.set_value(doc.doctype, doc.name, "posting_date", new_to_date)
-		return True
-	else:
-		return False
+	all_incomplete = failed_customers + skipped_customers
+
+	if all_incomplete and notify_user:
+		_notify_user(
+			notify_user,
+			doc,
+			subject=_(
+				"Statement emails were not sent to {0} customer(s). Check the error log for details."
+			).format(len(all_incomplete)),
+		)
+
+	# Only roll the schedule forward once every intended customer has actually
+	# received their statement — otherwise skipped/failed customers get silently
+	# dropped from the next cycle instead of being retried.
+	if doc.enable_auto_email and from_scheduler and not all_incomplete:
+		new_to_date = getdate(posting_date or today())
+		if doc.frequency in ("Daily", "Weekly", "Biweekly"):
+			frequency = {"Daily": 1, "Weekly": 7, "Biweekly": 14}
+			new_to_date = add_days(new_to_date, frequency[doc.frequency])
+		else:
+			new_to_date = add_months(new_to_date, 1 if doc.frequency == "Monthly" else 3)
+		new_from_date = add_months(new_to_date, -1 * doc.filter_duration)
+		doc.add_comment("Comment", "Emails sent on: " + frappe.utils.format_datetime(frappe.utils.now()))
+		if doc.report == "General Ledger":
+			frappe.db.set_value(doc.doctype, doc.name, "to_date", new_to_date)
+			frappe.db.set_value(doc.doctype, doc.name, "from_date", new_from_date)
+		else:
+			frappe.db.set_value(doc.doctype, doc.name, "posting_date", new_to_date)
+
+	return not all_incomplete
+
+
+def get_pdf_filename(psoa_name):
+	timestamp = now_datetime().strftime("%Y%m%d_%H%M%S")
+	return f"Statement_of_Accounts_{psoa_name}_{timestamp}.pdf"
 
 
 @frappe.whitelist()
@@ -590,5 +768,19 @@ def send_auto_email():
 		or_filters={"to_date": today(), "posting_date": today()},
 	)
 	for entry in selected:
-		send_emails(entry.name, from_scheduler=True)
+		job_id = get_send_emails_job_id(entry.name)
+		if is_job_enqueued(job_id):
+			continue
+
+		frappe.enqueue(
+			send_emails,
+			queue="long",
+			document_name=entry.name,
+			user=None,  # send_emails resolves this to the doc owner for scheduler runs
+			from_scheduler=True,
+			posting_date=today(),
+			enqueue_after_commit=True,
+			job_id=job_id,
+			deduplicate=True,
+		)
 	return True

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -494,3 +494,4 @@ erpnext.patches.v16_0.set_default_close_opportunity_after_days
 execute:frappe.db.set_single_value("Accounts Settings", "pcv_job_timeout", 3600)
 erpnext.patches.v16_0.backfill_pick_list_transferred_qty
 erpnext.patches.v16_0.create_shop_floor_roles
+execute:frappe.db.set_single_value("Accounts Settings", "psoa_customer_threshold", 10)


### PR DESCRIPTION
**Issue Statement:**
The Process Statement of Accounts currently generates statement PDFs synchronously when users download statements or send emails. For large customer sets, generating the required reports can take longer than the HTTP request timeout, causing the request to fail before the operation completes.

As a result, users are unable to download statements or initiate email delivery for large batches of customers, even though the processing itself is valid.

**Ref:** [71280](https://support.frappe.io/helpdesk/tickets/71280?view=VIEW-HD+Ticket-746)

**Backport Needed v15 & v16**