### PR TITLE
fix(selling): make payment schedule due date optional on Sales Order

### DIFF
--- a/erpnext/accounts/doctype/payment_schedule/payment_schedule.json
+++ b/erpnext/accounts/doctype/payment_schedule/payment_schedule.json
@@ -58,7 +58,7 @@
    "fieldtype": "Date",
    "in_list_view": 1,
    "label": "Due Date",
-   "reqd": 1
+   "mandatory_depends_on": "eval:doc.parenttype != 'Sales Order'"
   },
   {
    "columns": 2,
@@ -220,7 +220,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-07-31 08:38:25.820701",
+ "modified": "2026-07-08 13:27:18.808006",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Payment Schedule",

--- a/erpnext/accounts/services/payment_schedule.py
+++ b/erpnext/accounts/services/payment_schedule.py
@@ -204,6 +204,9 @@ class PaymentScheduleService:
 			if not schedule.invoice_portion:
 				payment_schedule["payment_amount"] = schedule.payment_amount
 
+			if not payment_schedule["due_date"]:
+				payment_schedule["due_date"] = posting_date
+
 			doc.append("payment_schedule", payment_schedule)
 
 	def set_due_date(self) -> None:
@@ -223,6 +226,14 @@ class PaymentScheduleService:
 			if not flt(d.discount):
 				d.discount_date = None
 			d.validate_from_to_dates("discount_date", "due_date")
+			if not d.due_date:
+				# Due Date isn't known upfront on a Sales Order since it is derived from
+				# the eventual Sales Invoice's posting date. It stays mandatory elsewhere.
+				if doc.doctype != "Sales Order":
+					frappe.throw(
+						_("Row {0}: Due Date is mandatory in the Payment Schedule table").format(d.idx)
+					)
+				continue
 			if doc.doctype in ["Sales Order", "Quotation"] and getdate(d.due_date) < getdate(
 				doc.transaction_date
 			):


### PR DESCRIPTION
Description: Due Date on a Sales Order's Payment Schedule row isn't known upfront; it's derived from the eventual Sales Invoice's date, so it shouldn't be mandatory there. Relaxed it only for Sales Order (other doctypes still require it), and made sure converting such an order to an invoice still fills in a real due date instead of failing.

Fixes: [#17238](https://github.com/frappe/erpnext/issues/17238)

Before: 

<img width="1473" height="921" alt="image" src="https://github.com/user-attachments/assets/cf50350f-6d3d-4547-88b7-83b8e4f1a404" />


After:

<img width="1852" height="928" alt="image" src="https://github.com/user-attachments/assets/dc1da0f9-133d-4f0e-aeb4-a0d3611ece33" />


Backport Needed for v16 and V15