### PR TITLE
feat: add item tax breakup in invoice item form view

### DIFF
--- a/erpnext/accounts/doctype/pos_invoice_item/pos_invoice_item.json
+++ b/erpnext/accounts/doctype/pos_invoice_item/pos_invoice_item.json
@@ -57,6 +57,8 @@
   "column_break_24",
   "base_net_rate",
   "base_net_amount",
+  "item_tax_breakup_section",
+  "item_tax_breakup",
   "drop_ship",
   "delivered_by_supplier",
   "accounting",
@@ -471,6 +473,21 @@
   },
   {
    "collapsible": 1,
+   "fieldname": "item_tax_breakup_section",
+   "fieldtype": "Section Break",
+   "label": "Item Tax Breakup"
+  },
+  {
+   "fieldname": "item_tax_breakup",
+   "fieldtype": "Text Editor",
+   "is_virtual": 1,
+   "label": "Item Tax Breakup",
+   "no_copy": 1,
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "collapsible": 1,
    "collapsible_depends_on": "eval:doc.delivered_by_supplier==1",
    "fieldname": "drop_ship",
    "fieldtype": "Section Break",
@@ -877,7 +894,7 @@
  ],
  "istable": 1,
  "links": [],
- "modified": "2026-06-08 20:00:00.000000",
+ "modified": "2026-07-08 14:11:57.994851",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "POS Invoice Item",

--- a/erpnext/accounts/doctype/pos_invoice_item/pos_invoice_item.py
+++ b/erpnext/accounts/doctype/pos_invoice_item/pos_invoice_item.py
@@ -50,6 +50,7 @@ class POSInvoiceItem(SalesInvoiceItem):
 		income_account: DF.Link
 		is_fixed_asset: DF.Check
 		is_free_item: DF.Check
+		is_product_bundle: DF.Check
 		item_code: DF.Link | None
 		item_group: DF.Link | None
 		item_name: DF.Data
@@ -66,6 +67,7 @@ class POSInvoiceItem(SalesInvoiceItem):
 		pos_invoice_item: DF.Data | None
 		price_list_rate: DF.Currency
 		pricing_rules: DF.SmallText | None
+		product_bundle: DF.Link | None
 		project: DF.Link | None
 		qty: DF.Float
 		quality_inspection: DF.Link | None

--- a/erpnext/accounts/doctype/purchase_invoice_item/purchase_invoice_item.json
+++ b/erpnext/accounts/doctype/purchase_invoice_item/purchase_invoice_item.json
@@ -65,6 +65,8 @@
   "item_tax_amount",
   "landed_cost_voucher_amount",
   "rm_supp_cost",
+  "item_tax_breakup_section",
+  "item_tax_breakup",
   "warehouse_section",
   "warehouse",
   "add_serial_batch_bundle",
@@ -427,6 +429,21 @@
    "label": "Weight UOM",
    "options": "UOM",
    "print_hide": 1
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "item_tax_breakup_section",
+   "fieldtype": "Section Break",
+   "label": "Item Tax Breakup"
+  },
+  {
+   "fieldname": "item_tax_breakup",
+   "fieldtype": "Text Editor",
+   "is_virtual": 1,
+   "label": "Item Tax Breakup",
+   "no_copy": 1,
+   "print_hide": 1,
+   "read_only": 1
   },
   {
    "depends_on": "eval:parent.update_stock",
@@ -1010,7 +1027,7 @@
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-06-08 21:00:00.000000",
+ "modified": "2026-07-08 14:11:58.678512",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Purchase Invoice Item",

--- a/erpnext/accounts/doctype/sales_invoice_item/sales_invoice_item.json
+++ b/erpnext/accounts/doctype/sales_invoice_item/sales_invoice_item.json
@@ -61,6 +61,8 @@
   "column_break_24",
   "base_net_rate",
   "base_net_amount",
+  "item_tax_breakup_section",
+  "item_tax_breakup",
   "drop_ship",
   "delivered_by_supplier",
   "accounting",
@@ -451,6 +453,21 @@
    "fieldtype": "Currency",
    "label": "Net Amount (Company Currency)",
    "options": "Company:company:default_currency",
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "item_tax_breakup_section",
+   "fieldtype": "Section Break",
+   "label": "Item Tax Breakup"
+  },
+  {
+   "fieldname": "item_tax_breakup",
+   "fieldtype": "Text Editor",
+   "is_virtual": 1,
+   "label": "Item Tax Breakup",
+   "no_copy": 1,
    "print_hide": 1,
    "read_only": 1
   },
@@ -1055,7 +1072,7 @@
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-06-08 20:00:00.000000",
+ "modified": "2026-07-08 14:11:58.233863",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Sales Invoice Item",

--- a/erpnext/accounts/doctype/sales_invoice_item/sales_invoice_item.py
+++ b/erpnext/accounts/doctype/sales_invoice_item/sales_invoice_item.py
@@ -58,6 +58,7 @@ class SalesInvoiceItem(Document):
 		incoming_rate: DF.Currency
 		is_fixed_asset: DF.Check
 		is_free_item: DF.Check
+		is_product_bundle: DF.Check
 		item_code: DF.Link | None
 		item_group: DF.Link | None
 		item_name: DF.Data
@@ -76,6 +77,7 @@ class SalesInvoiceItem(Document):
 		pos_invoice_item: DF.Data | None
 		price_list_rate: DF.Currency
 		pricing_rules: DF.SmallText | None
+		product_bundle: DF.Link | None
 		project: DF.Link | None
 		purchase_order: DF.Link | None
 		purchase_order_item: DF.Data | None

--- a/erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
+++ b/erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
@@ -62,6 +62,8 @@
   "column_break_32",
   "base_net_rate",
   "base_net_amount",
+  "item_tax_breakup_section",
+  "item_tax_breakup",
   "warehouse_and_reference",
   "from_warehouse",
   "warehouse",
@@ -449,6 +451,21 @@
    "fieldtype": "Link",
    "label": "Weight UOM",
    "options": "UOM",
+   "read_only": 1
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "item_tax_breakup_section",
+   "fieldtype": "Section Break",
+   "label": "Item Tax Breakup"
+  },
+  {
+   "fieldname": "item_tax_breakup",
+   "fieldtype": "Text Editor",
+   "is_virtual": 1,
+   "label": "Item Tax Breakup",
+   "no_copy": 1,
+   "print_hide": 1,
    "read_only": 1
   },
   {
@@ -941,7 +958,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-06-08 21:00:00.000000",
+ "modified": "2026-07-08 14:11:57.753650",
  "modified_by": "Administrator",
  "module": "Buying",
  "name": "Purchase Order Item",

--- a/erpnext/buying/doctype/supplier_quotation_item/supplier_quotation_item.json
+++ b/erpnext/buying/doctype/supplier_quotation_item/supplier_quotation_item.json
@@ -53,6 +53,8 @@
   "column_break_27",
   "base_net_rate",
   "base_net_amount",
+  "item_tax_breakup_section",
+  "item_tax_breakup",
   "item_weight_details",
   "weight_per_unit",
   "total_weight",
@@ -340,6 +342,21 @@
   },
   {
    "collapsible": 1,
+   "fieldname": "item_tax_breakup_section",
+   "fieldtype": "Section Break",
+   "label": "Item Tax Breakup"
+  },
+  {
+   "fieldname": "item_tax_breakup",
+   "fieldtype": "Text Editor",
+   "is_virtual": 1,
+   "label": "Item Tax Breakup",
+   "no_copy": 1,
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "collapsible": 1,
    "fieldname": "item_weight_details",
    "fieldtype": "Section Break",
    "label": "Item Weight Details"
@@ -613,7 +630,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-06-17 12:05:52.441645",
+ "modified": "2026-07-08 14:11:58.853102",
  "modified_by": "Administrator",
  "module": "Buying",
  "name": "Supplier Quotation Item",

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -93,13 +93,18 @@ erpnext.item_tax_breakup = {
 	},
 
 	render_row: function (frm, cdt, cdn) {
-		// nothing to compute if the row or the tax-detail data isn't there yet (unsaved row,
 		if (!frm || !frm.doc || !locals[cdt] || !locals[cdt][cdn]) return;
-		if (!(frm.doc.item_wise_tax_details || []).length) return;
 
-		const breakup = erpnext.item_tax_breakup.get_breakup(frm, cdn);
-		const html = erpnext.item_tax_breakup.get_template(breakup, frm.doc.currency);
-		frappe.model.set_value(cdt, cdn, "item_tax_breakup", html);
+		// On a new or dirty form `item_wise_tax_details` is stale
+		// (or absent) and would not match the current items/taxes, so show nothing until the doc
+		// is saved and clean.
+		let html = "";
+		if (!frm.is_new() && !frm.is_dirty() && (frm.doc.item_wise_tax_details || []).length) {
+			const breakup = erpnext.item_tax_breakup.get_breakup(frm, cdn);
+			html = erpnext.item_tax_breakup.get_template(breakup, frm.doc.currency);
+		}
+		// skip_dirty_trigger=true: this is a view-only virtual field; setting it must never mark
+		frappe.model.set_value(cdt, cdn, "item_tax_breakup", html, null, true);
 	},
 };
 

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -33,8 +33,8 @@ erpnext.stock.row_requires_quality_inspection = (purpose, row) => {
 erpnext.item_tax_breakup = {
 	get_breakup: function (frm, cdn) {
 		const doc = frm && frm.doc;
-		const details = (doc && doc.item_wise_tax_details) || [];
-		if (!details.length) return [];
+		const item_wise_tax_details = (doc && doc.item_wise_tax_details) || [];
+		if (!item_wise_tax_details.length) return [];
 
 		const conversion_rate = flt(doc.conversion_rate) || 1;
 
@@ -42,26 +42,23 @@ erpnext.item_tax_breakup = {
 		const tax_map = {};
 		(doc.taxes || []).forEach((t) => (tax_map[t.name] = t));
 
-		const order = [];
-		const cells = {};
-		for (const d of details) {
+		// one breakup row per tax row (one detail row per item x tax)
+		const breakup = [];
+		for (const d of item_wise_tax_details) {
 			if (d.item_row !== cdn) continue;
 
 			const tax = tax_map[d.tax_row];
-			if (!tax) continue;
-			if (tax.category && tax.category === "Valuation") continue;
+			if (!tax || tax.category === "Valuation") continue;
 
-			let cell = cells[d.tax_row];
-			if (!cell) {
-				cell = { description: tax.description, rate: flt(d.rate), amount: 0 };
-				cells[d.tax_row] = cell;
-				order.push(d.tax_row);
-			}
 			const prec = precision("tax_amount", tax);
-			cell.amount += flt(flt(d.amount, prec) / conversion_rate, prec);
+			breakup.push({
+				description: tax.description,
+				rate: flt(d.rate),
+				amount: flt(flt(d.amount, prec) / conversion_rate, prec),
+			});
 		}
 
-		return order.map((tax_row) => cells[tax_row]);
+		return breakup;
 	},
 
 	get_template: function (breakup, currency) {

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -29,6 +29,80 @@ erpnext.stock.row_requires_quality_inspection = (purpose, row) => {
 	return false;
 };
 
+erpnext.item_tax_breakup = {
+	// Data: [{description, rate, amount}, ...] for one item row (child name === cdn), in
+	// transaction currency. Same-description charge rows merge; Valuation taxes are skipped.
+	get_breakup: function (frm, cdn) {
+		const doc = frm && frm.doc;
+		const details = (doc && doc.item_wise_tax_details) || [];
+		if (!details.length) return [];
+
+		const conversion_rate = flt(doc.conversion_rate) || 1;
+
+		// tax_row (name) -> tax row, from the parent's taxes table
+		const tax_map = {};
+		(doc.taxes || []).forEach((t) => (tax_map[t.name] = t));
+
+		const order = [];
+		const cells = {};
+		for (const d of details) {
+			if (d.item_row !== cdn) continue;
+
+			const tax = tax_map[d.tax_row];
+			if (!tax) continue;
+			if (tax.category && tax.category === "Valuation") continue;
+
+			let cell = cells[tax.description];
+			if (!cell) {
+				cell = { description: tax.description, rate: flt(d.rate), amount: 0 };
+				cells[tax.description] = cell;
+				order.push(tax.description);
+			}
+			// persisted amount is in base/company currency -> divide for transaction currency
+			cell.amount += flt(d.amount) / conversion_rate;
+		}
+
+		return order.map((desc) => cells[desc]);
+	},
+
+	get_template: function (breakup, currency) {
+		if (!breakup || !breakup.length) return "";
+
+		const rows = breakup
+			.map(
+				(row) => `<tr>
+					<td>${frappe.utils.escape_html(row.description || "")}</td>
+					<td class="text-right">${row.rate}%</td>
+					<td class="text-right">${format_currency(row.amount, currency)}</td>
+				</tr>`
+			)
+			.join("");
+
+		return `<div class="tax-break-up" style="overflow-x: auto;">
+			<table class="table table-bordered table-hover">
+				<thead>
+					<tr>
+						<th class="text-left">${__("Tax")}</th>
+						<th class="text-right">${__("Rate")}</th>
+						<th class="text-right">${__("Amount")}</th>
+					</tr>
+				</thead>
+				<tbody>${rows}</tbody>
+			</table>
+		</div>`;
+	},
+
+	render_row: function (frm, cdt, cdn) {
+		// nothing to compute if the row or the tax-detail data isn't there yet (unsaved row,
+		if (!frm || !frm.doc || !locals[cdt] || !locals[cdt][cdn]) return;
+		if (!(frm.doc.item_wise_tax_details || []).length) return;
+
+		const breakup = erpnext.item_tax_breakup.get_breakup(frm, cdn);
+		const html = erpnext.item_tax_breakup.get_template(breakup, frm.doc.currency);
+		frappe.model.set_value(cdt, cdn, "item_tax_breakup", html);
+	},
+};
+
 erpnext.TransactionController = class TransactionController extends erpnext.taxes_and_totals {
 	setup() {
 		super.setup();
@@ -188,6 +262,11 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 		});
 
 		frappe.ui.form.on(this.frm.doctype + " Item", {
+			form_render: function (frm, cdt, cdn) {
+				// fires only when an item row's detail form is opened (row expand)
+				erpnext.item_tax_breakup.render_row(frm, cdt, cdn);
+			},
+
 			items_add: function (frm, cdt, cdn) {
 				var item = frappe.get_doc(cdt, cdn);
 				if (!item.warehouse && frm.doc.set_warehouse) {

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -29,9 +29,8 @@ erpnext.stock.row_requires_quality_inspection = (purpose, row) => {
 	return false;
 };
 
+// This breakup is DESK-RENDER-ONLY: the field is a virtual read-only Text Editor.
 erpnext.item_tax_breakup = {
-	// Data: [{description, rate, amount}, ...] for one item row (child name === cdn), in
-	// transaction currency. Same-description charge rows merge; Valuation taxes are skipped.
 	get_breakup: function (frm, cdn) {
 		const doc = frm && frm.doc;
 		const details = (doc && doc.item_wise_tax_details) || [];
@@ -52,17 +51,17 @@ erpnext.item_tax_breakup = {
 			if (!tax) continue;
 			if (tax.category && tax.category === "Valuation") continue;
 
-			let cell = cells[tax.description];
+			let cell = cells[d.tax_row];
 			if (!cell) {
 				cell = { description: tax.description, rate: flt(d.rate), amount: 0 };
-				cells[tax.description] = cell;
-				order.push(tax.description);
+				cells[d.tax_row] = cell;
+				order.push(d.tax_row);
 			}
-			// persisted amount is in base/company currency -> divide for transaction currency
-			cell.amount += flt(d.amount) / conversion_rate;
+			const prec = precision("tax_amount", tax);
+			cell.amount += flt(flt(d.amount, prec) / conversion_rate, prec);
 		}
 
-		return order.map((desc) => cells[desc]);
+		return order.map((tax_row) => cells[tax_row]);
 	},
 
 	get_template: function (breakup, currency) {

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -31,18 +31,16 @@ erpnext.stock.row_requires_quality_inspection = (purpose, row) => {
 
 // This breakup is DESK-RENDER-ONLY: the field is a virtual read-only Text Editor.
 erpnext.item_tax_breakup = {
-	get_breakup: function (frm, cdn) {
-		const doc = frm && frm.doc;
-		const item_wise_tax_details = (doc && doc.item_wise_tax_details) || [];
-		if (!item_wise_tax_details.length) return [];
+	compute_breakup: function (item_wise_tax_details, taxes, cdn, conversion_rate) {
+		if (!(item_wise_tax_details || []).length) return [];
 
-		const conversion_rate = flt(doc.conversion_rate) || 1;
+		conversion_rate = flt(conversion_rate) || 1;
 
-		// tax_row (name) -> tax row, from the parent's taxes table
 		const tax_map = {};
-		(doc.taxes || []).forEach((t) => (tax_map[t.name] = t));
+		(taxes || []).forEach((t) => (tax_map[t.name] = t));
 
-		// one row per tax account (not description) so distinct taxes never collapse
+		// Grouped by tax account, not description, so distinct accounts sharing a description
+		// stay separate.
 		const account_wise_breakup = {};
 		for (const d of item_wise_tax_details) {
 			if (d.item_row !== cdn) continue;
@@ -60,6 +58,18 @@ erpnext.item_tax_breakup = {
 		}
 
 		return Object.values(account_wise_breakup);
+	},
+
+	get_breakup: function (frm, cdn) {
+		const doc = frm && frm.doc;
+		if (!doc) return [];
+
+		return erpnext.item_tax_breakup.compute_breakup(
+			doc.item_wise_tax_details,
+			doc.taxes,
+			cdn,
+			doc.conversion_rate
+		);
 	},
 
 	get_template: function (breakup, currency) {
@@ -92,15 +102,13 @@ erpnext.item_tax_breakup = {
 	render_row: function (frm, cdt, cdn) {
 		if (!frm || !frm.doc || !locals[cdt] || !locals[cdt][cdn]) return;
 
-		// On a new or dirty form `item_wise_tax_details` is stale
-		// (or absent) and would not match the current items/taxes, so show nothing until the doc
-		// is saved and clean.
+		// item_wise_tax_details is stale/absent while new or dirty, so render only when saved & clean.
 		let html = "";
 		if (!frm.is_new() && !frm.is_dirty() && (frm.doc.item_wise_tax_details || []).length) {
 			const breakup = erpnext.item_tax_breakup.get_breakup(frm, cdn);
 			html = erpnext.item_tax_breakup.get_template(breakup, frm.doc.currency);
 		}
-		// skip_dirty_trigger=true: this is a view-only virtual field; setting it must never mark
+		// skip_dirty_trigger=true: a view-only field must never mark the form dirty.
 		frappe.model.set_value(cdt, cdn, "item_tax_breakup", html, null, true);
 	},
 };

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -42,23 +42,24 @@ erpnext.item_tax_breakup = {
 		const tax_map = {};
 		(doc.taxes || []).forEach((t) => (tax_map[t.name] = t));
 
-		// one breakup row per tax row (one detail row per item x tax)
-		const breakup = [];
+		// one row per tax account (not description) so distinct taxes never collapse
+		const account_wise_breakup = {};
 		for (const d of item_wise_tax_details) {
 			if (d.item_row !== cdn) continue;
 
 			const tax = tax_map[d.tax_row];
 			if (!tax || tax.category === "Valuation") continue;
 
+			let row = account_wise_breakup[tax.account_head];
+			if (!row) {
+				row = { description: tax.description, rate: flt(d.rate), amount: 0 };
+				account_wise_breakup[tax.account_head] = row;
+			}
 			const prec = precision("tax_amount", tax);
-			breakup.push({
-				description: tax.description,
-				rate: flt(d.rate),
-				amount: flt(flt(d.amount, prec) / conversion_rate, prec),
-			});
+			row.amount += flt(flt(d.amount, prec) / conversion_rate, prec);
 		}
 
-		return breakup;
+		return Object.values(account_wise_breakup);
 	},
 
 	get_template: function (breakup, currency) {

--- a/erpnext/selling/doctype/quotation_item/quotation_item.json
+++ b/erpnext/selling/doctype/quotation_item/quotation_item.json
@@ -59,6 +59,8 @@
   "base_net_amount",
   "pricing_rules",
   "stock_uom_rate",
+  "item_tax_breakup_section",
+  "item_tax_breakup",
   "section_break_43",
   "valuation_rate",
   "column_break_45",
@@ -637,6 +639,21 @@
    "print_hide": 1
   },
   {
+   "collapsible": 1,
+   "fieldname": "item_tax_breakup_section",
+   "fieldtype": "Section Break",
+   "label": "Item Tax Breakup"
+  },
+  {
+   "fieldname": "item_tax_breakup",
+   "fieldtype": "Text Editor",
+   "is_virtual": 1,
+   "label": "Item Tax Breakup",
+   "no_copy": 1,
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
    "fieldname": "section_break_43",
    "fieldtype": "Section Break"
   },
@@ -729,7 +746,7 @@
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-06-08 19:00:00.000000",
+ "modified": "2026-07-08 14:11:59.279817",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Quotation Item",

--- a/erpnext/selling/doctype/quotation_item/quotation_item.py
+++ b/erpnext/selling/doctype/quotation_item/quotation_item.py
@@ -39,6 +39,7 @@ class QuotationItem(Document):
 		image: DF.Attach | None
 		is_alternative: DF.Check
 		is_free_item: DF.Check
+		is_product_bundle: DF.Check
 		item_code: DF.Link | None
 		item_group: DF.Link | None
 		item_name: DF.Data
@@ -57,6 +58,7 @@ class QuotationItem(Document):
 		prevdoc_doctype: DF.Link | None
 		price_list_rate: DF.Currency
 		pricing_rules: DF.SmallText | None
+		product_bundle: DF.Link | None
 		projected_qty: DF.Float
 		qty: DF.Float
 		rate: DF.Currency

--- a/erpnext/selling/doctype/sales_order_item/sales_order_item.json
+++ b/erpnext/selling/doctype/sales_order_item/sales_order_item.json
@@ -68,6 +68,8 @@
   "billed_amt",
   "valuation_rate",
   "gross_profit",
+  "item_tax_breakup_section",
+  "item_tax_breakup",
   "drop_ship_section",
   "delivered_by_supplier",
   "supplier",
@@ -487,6 +489,21 @@
    "fieldtype": "Currency",
    "label": "Net Amount (Company Currency)",
    "options": "Company:company:default_currency",
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "item_tax_breakup_section",
+   "fieldtype": "Section Break",
+   "label": "Item Tax Breakup"
+  },
+  {
+   "fieldname": "item_tax_breakup",
+   "fieldtype": "Text Editor",
+   "is_virtual": 1,
+   "label": "Item Tax Breakup",
+   "no_copy": 1,
    "print_hide": 1,
    "read_only": 1
   },
@@ -1055,7 +1072,7 @@
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-06-08 20:00:00.000000",
+ "modified": "2026-07-08 14:11:59.140572",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Sales Order Item",

--- a/erpnext/selling/doctype/sales_order_item/sales_order_item.py
+++ b/erpnext/selling/doctype/sales_order_item/sales_order_item.py
@@ -48,6 +48,7 @@ class SalesOrderItem(Document):
 		gross_profit: DF.Currency
 		image: DF.Attach | None
 		is_free_item: DF.Check
+		is_product_bundle: DF.Check
 		is_stock_item: DF.Check
 		item_code: DF.Link
 		item_group: DF.Link | None
@@ -71,6 +72,7 @@ class SalesOrderItem(Document):
 		price_list_rate: DF.Currency
 		pricing_rules: DF.SmallText | None
 		produced_qty: DF.Float
+		product_bundle: DF.Link | None
 		production_plan_qty: DF.Float
 		project: DF.Link | None
 		projected_qty: DF.Float

--- a/erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
+++ b/erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
@@ -63,6 +63,8 @@
   "base_net_amount",
   "billed_amt",
   "incoming_rate",
+  "item_tax_breakup_section",
+  "item_tax_breakup",
   "item_weight_details",
   "weight_per_unit",
   "total_weight",
@@ -466,6 +468,21 @@
    "fieldtype": "Currency",
    "label": "Net Amount (Company Currency)",
    "options": "Company:company:default_currency",
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "item_tax_breakup_section",
+   "fieldtype": "Section Break",
+   "label": "Item Tax Breakup"
+  },
+  {
+   "fieldname": "item_tax_breakup",
+   "fieldtype": "Text Editor",
+   "is_virtual": 1,
+   "label": "Item Tax Breakup",
+   "no_copy": 1,
    "print_hide": 1,
    "read_only": 1
   },
@@ -971,7 +988,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-06-08 20:00:00.000000",
+ "modified": "2026-07-08 14:11:58.972689",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Delivery Note Item",

--- a/erpnext/stock/doctype/delivery_note_item/delivery_note_item.py
+++ b/erpnext/stock/doctype/delivery_note_item/delivery_note_item.py
@@ -47,6 +47,7 @@ class DeliveryNoteItem(Document):
 		incoming_rate: DF.Currency
 		installed_qty: DF.Float
 		is_free_item: DF.Check
+		is_product_bundle: DF.Check
 		item_code: DF.Link
 		item_group: DF.Link | None
 		item_name: DF.Data
@@ -66,6 +67,7 @@ class DeliveryNoteItem(Document):
 		pick_list_item: DF.Data | None
 		price_list_rate: DF.Currency
 		pricing_rules: DF.SmallText | None
+		product_bundle: DF.Link | None
 		project: DF.Link | None
 		purchase_order: DF.Link | None
 		purchase_order_item: DF.Data | None

--- a/erpnext/stock/doctype/purchase_receipt_item/purchase_receipt_item.json
+++ b/erpnext/stock/doctype/purchase_receipt_item/purchase_receipt_item.json
@@ -73,6 +73,8 @@
   "landed_cost_voucher_amount",
   "amount_difference_with_purchase_invoice",
   "billed_amt",
+  "item_tax_breakup_section",
+  "item_tax_breakup",
   "warehouse_and_reference",
   "warehouse",
   "rejected_warehouse",
@@ -487,6 +489,21 @@
    "fieldtype": "Link",
    "label": "Weight UOM",
    "options": "UOM"
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "item_tax_breakup_section",
+   "fieldtype": "Section Break",
+   "label": "Item Tax Breakup"
+  },
+  {
+   "fieldname": "item_tax_breakup",
+   "fieldtype": "Text Editor",
+   "is_virtual": 1,
+   "label": "Item Tax Breakup",
+   "no_copy": 1,
+   "print_hide": 1,
+   "read_only": 1
   },
   {
    "fieldname": "warehouse_and_reference",
@@ -1122,7 +1139,7 @@
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2026-06-08 21:00:00.000000",
+ "modified": "2026-07-08 14:11:58.423564",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Purchase Receipt Item",


### PR DESCRIPTION
<img width="867" height="761" alt="image" src="https://github.com/user-attachments/assets/ae89378b-c767-4ebe-ae9e-aabde09e76b3" />

Note:

- Added a virtual field
- Not added processing in the backend because on form render, all the fields will be computed at once causing performance issue.
- Complete processing in the frontend.

Question:

- Should values be positive or negative in return doc?


no-docs