### PR TITLE
feat(sla): filter service level agreement link by document type

### DIFF
--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -494,3 +494,4 @@ erpnext.patches.v16_0.set_default_close_opportunity_after_days
 execute:frappe.db.set_single_value("Accounts Settings", "pcv_job_timeout", 3600)
 erpnext.patches.v16_0.backfill_pick_list_transferred_qty
 erpnext.patches.v16_0.create_shop_floor_roles
+erpnext.patches.v15_0.backfill_sla_link_filters_on_custom_field

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -495,3 +495,4 @@ execute:frappe.db.set_single_value("Accounts Settings", "pcv_job_timeout", 3600)
 erpnext.patches.v16_0.backfill_pick_list_transferred_qty
 erpnext.patches.v16_0.create_shop_floor_roles
 erpnext.patches.v15_0.backfill_sla_link_filters_on_custom_field
+erpnext.patches.v15_0.backfill_sla_link_filters_on_docfield

--- a/erpnext/patches/v15_0/backfill_sla_link_filters_on_custom_field.py
+++ b/erpnext/patches/v15_0/backfill_sla_link_filters_on_custom_field.py
@@ -1,0 +1,21 @@
+import frappe
+
+
+def execute():
+	for custom_field in frappe.get_all(
+		"Custom Field",
+		filters={
+			"fieldname": "service_level_agreement",
+			"fieldtype": "Link",
+			"options": "Service Level Agreement",
+			"link_filters": ("is", "not set"),
+		},
+		fields=["name", "dt"],
+	):
+		link_filters = frappe.as_json(
+			[["Service Level Agreement", "document_type", "=", custom_field.dt]], indent=None
+		)
+		frappe.db.set_value(
+			"Custom Field", custom_field.name, "link_filters", link_filters, update_modified=False
+		)
+		frappe.clear_cache(doctype=custom_field.dt)

--- a/erpnext/patches/v15_0/backfill_sla_link_filters_on_docfield.py
+++ b/erpnext/patches/v15_0/backfill_sla_link_filters_on_docfield.py
@@ -1,0 +1,20 @@
+import frappe
+
+
+def execute():
+	for docfield in frappe.get_all(
+		"DocField",
+		filters={
+			"parenttype": "DocType",
+			"fieldname": "service_level_agreement",
+			"fieldtype": "Link",
+			"options": "Service Level Agreement",
+			"link_filters": ("is", "not set"),
+		},
+		fields=["name", "parent"],
+	):
+		link_filters = frappe.as_json(
+			[["Service Level Agreement", "document_type", "=", docfield.parent]], indent=None
+		)
+		frappe.db.set_value("DocField", docfield.name, "link_filters", link_filters, update_modified=False)
+		frappe.clear_cache(doctype=docfield.parent)

--- a/erpnext/support/doctype/service_level_agreement/service_level_agreement.py
+++ b/erpnext/support/doctype/service_level_agreement/service_level_agreement.py
@@ -232,7 +232,7 @@ class ServiceLevelAgreement(Document):
 		if self.document_type == "Issue":
 			return
 
-		service_level_agreement_fields = get_service_level_agreement_fields()
+		service_level_agreement_fields = get_service_level_agreement_fields(self.document_type)
 		meta = frappe.get_meta(self.document_type, cached=False)
 
 		if meta.custom:
@@ -302,6 +302,7 @@ class ServiceLevelAgreement(Document):
 						"hidden": field.get("hidden"),
 						"description": field.get("description"),
 						"default": field.get("default"),
+						"link_filters": field.get("link_filters"),
 					}
 				).insert(ignore_permissions=True)
 			else:
@@ -320,6 +321,7 @@ class ServiceLevelAgreement(Document):
 		field.hidden = sla_field.get("hidden")
 		field.description = sla_field.get("description")
 		field.default = sla_field.get("default")
+		field.link_filters = sla_field.get("link_filters")
 		field.save(ignore_permissions=True)
 
 
@@ -907,7 +909,7 @@ def record_assigned_users_on_failure(doc):
 		doc.add_comment(comment_type="Assigned", text=message)
 
 
-def get_service_level_agreement_fields():
+def get_service_level_agreement_fields(doctype: str):
 	return [
 		{
 			"collapsible": 1,
@@ -920,6 +922,9 @@ def get_service_level_agreement_fields():
 			"fieldtype": "Link",
 			"label": "Service Level Agreement",
 			"options": "Service Level Agreement",
+			"link_filters": frappe.as_json(
+				[["Service Level Agreement", "document_type", "=", doctype]], indent=None
+			),
 		},
 		{"fieldname": "priority", "fieldtype": "Link", "label": "Priority", "options": "Issue Priority"},
 		{"fieldname": "response_by", "fieldtype": "Datetime", "label": "Response By", "read_only": 1},

--- a/erpnext/support/doctype/service_level_agreement/service_level_agreement.py
+++ b/erpnext/support/doctype/service_level_agreement/service_level_agreement.py
@@ -311,7 +311,7 @@ class ServiceLevelAgreement(Document):
 				self.reset_field_properties(existing_field, "Custom Field", field)
 
 	def reset_field_properties(self, field, field_dt, sla_field):
-		field = frappe.get_doc(field_dt, {"fieldname": field.fieldname})
+		field = frappe.get_doc(field_dt, field.name)
 		field.label = sla_field.get("label")
 		field.fieldname = sla_field.get("fieldname")
 		field.fieldtype = sla_field.get("fieldtype")

--- a/erpnext/support/doctype/service_level_agreement/service_level_agreement.py
+++ b/erpnext/support/doctype/service_level_agreement/service_level_agreement.py
@@ -276,6 +276,7 @@ class ServiceLevelAgreement(Document):
 						"hidden": field.get("hidden"),
 						"description": field.get("description"),
 						"default": field.get("default"),
+						"link_filters": field.get("link_filters"),
 					}
 				).insert(ignore_permissions=True)
 			else:

--- a/erpnext/support/doctype/service_level_agreement/test_service_level_agreement.py
+++ b/erpnext/support/doctype/service_level_agreement/test_service_level_agreement.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2018, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
 import datetime
+import json
 
 import frappe
 from frappe.utils import flt
@@ -152,8 +153,11 @@ class TestServiceLevelAgreement(ERPNextTestSuite):
 		sla_fields = get_service_level_agreement_fields(doctype)
 
 		for field in sla_fields:
-			self.assertTrue(
-				frappe.db.exists("Custom Field", {"dt": doctype, "fieldname": field.get("fieldname")})
+			filters = {"dt": doctype, "fieldname": field.get("fieldname")}
+			self.assertTrue(frappe.db.exists("Custom Field", filters))
+			self.assertEqual(
+				get_link_filters("Custom Field", filters),
+				json.loads(field["link_filters"]) if field.get("link_filters") else None,
 			)
 
 	def test_docfield_creation_for_sla_on_custom_dt(self):
@@ -176,9 +180,62 @@ class TestServiceLevelAgreement(ERPNextTestSuite):
 		sla_fields = get_service_level_agreement_fields(doctype.name)
 
 		for field in sla_fields:
-			self.assertTrue(
-				frappe.db.exists("DocField", {"fieldname": field.get("fieldname"), "parent": doctype.name})
+			filters = {"fieldname": field.get("fieldname"), "parent": doctype.name}
+			self.assertTrue(frappe.db.exists("DocField", filters))
+			self.assertEqual(
+				get_link_filters("DocField", filters),
+				json.loads(field["link_filters"]) if field.get("link_filters") else None,
 			)
+
+	def test_reset_field_properties_does_not_clobber_other_doctypes_field(self):
+		"""Two doctypes each get their own "service_level_agreement" custom field
+		(same fieldname, different owning doctype). Updating the field on one of
+		them must not clobber the other's, even though both share the fieldname
+		(regression test for the fix in reset_field_properties, see PR #56954)."""
+		doctype_a = create_custom_doctype("Test SLA Dt A")
+		doctype_b = create_custom_doctype("Test SLA Dt B")
+
+		for doctype in (doctype_a.name, doctype_b.name):
+			create_service_level_agreement(
+				default_service_level_agreement=1,
+				holiday_list="__Test Holiday List",
+				entity_type=None,
+				entity=None,
+				response_time=14400,
+				resolution_time=21600,
+				doctype=doctype,
+			)
+
+		def get_sla_field_link_filters(doctype):
+			return get_link_filters("DocField", {"parent": doctype, "fieldname": "service_level_agreement"})
+
+		self.assertEqual(
+			get_sla_field_link_filters(doctype_a.name),
+			[["Service Level Agreement", "document_type", "=", doctype_a.name]],
+		)
+
+		# The field on doctype_b already exists, so creating another, entity-specific
+		# SLA for doctype_b takes the "update existing field" branch (reset_field_properties)
+		# instead of creating a new field.
+		customer = create_customer()
+		create_service_level_agreement(
+			default_service_level_agreement=0,
+			holiday_list="__Test Holiday List",
+			entity_type="Customer",
+			entity=customer,
+			response_time=7200,
+			resolution_time=10800,
+			doctype=doctype_b.name,
+		)
+
+		self.assertEqual(
+			get_sla_field_link_filters(doctype_a.name),
+			[["Service Level Agreement", "document_type", "=", doctype_a.name]],
+		)
+		self.assertEqual(
+			get_sla_field_link_filters(doctype_b.name),
+			[["Service Level Agreement", "document_type", "=", doctype_b.name]],
+		)
 
 	def test_sla_application(self):
 		# Default Service Level Agreement
@@ -330,6 +387,11 @@ class TestServiceLevelAgreement(ERPNextTestSuite):
 		lead.save()
 		applied_sla = frappe.db.get_value("Lead", lead.name, "service_level_agreement")
 		self.assertFalse(applied_sla)
+
+
+def get_link_filters(field_doctype, filters):
+	value = frappe.db.get_value(field_doctype, filters, "link_filters")
+	return json.loads(value) if value else None
 
 
 def get_service_level_agreement(
@@ -572,8 +634,8 @@ def make_holiday_list():
 		).insert()
 
 
-def create_custom_doctype():
-	if not frappe.db.exists("DocType", "Test SLA on Custom Dt"):
+def create_custom_doctype(name="Test SLA on Custom Dt"):
+	if not frappe.db.exists("DocType", name):
 		doc = frappe.get_doc(
 			{
 				"doctype": "DocType",
@@ -596,13 +658,13 @@ def create_custom_doctype():
 					},
 				],
 				"permissions": [{"role": "System Manager", "read": 1, "write": 1}],
-				"name": "Test SLA on Custom Dt",
+				"name": name,
 			}
 		)
 		doc.insert()
 		return doc
 	else:
-		return frappe.get_doc("DocType", "Test SLA on Custom Dt")
+		return frappe.get_doc("DocType", name)
 
 
 def make_lead(creation=None, index=0, company=None):

--- a/erpnext/support/doctype/service_level_agreement/test_service_level_agreement.py
+++ b/erpnext/support/doctype/service_level_agreement/test_service_level_agreement.py
@@ -149,7 +149,7 @@ class TestServiceLevelAgreement(ERPNextTestSuite):
 		self.assertEqual(lead_sla.name, default_sla.name)
 
 		# check SLA custom fields created for leads
-		sla_fields = get_service_level_agreement_fields()
+		sla_fields = get_service_level_agreement_fields(doctype)
 
 		for field in sla_fields:
 			self.assertTrue(
@@ -173,7 +173,7 @@ class TestServiceLevelAgreement(ERPNextTestSuite):
 		self.assertEqual(sla.name, default_sla.name)
 
 		# check SLA docfields created
-		sla_fields = get_service_level_agreement_fields()
+		sla_fields = get_service_level_agreement_fields(doctype.name)
 
 		for field in sla_fields:
 			self.assertTrue(


### PR DESCRIPTION
The auto-generated _Service Level Agreement_ field on target doctypes (e.g. **Job Applicant**) currently lists every SLA in the system, including ones configured for unrelated document types. This makes it easy to select an SLA that doesn't apply to the current doctype.

This PR sets `link_filters` on that field so it only shows SLAs whose _Document Type_ matches the doctype the field lives on.

<img width="702" height="283" alt="Bildschirmfoto 2026-07-08 um 12 54 20" src="https://github.com/user-attachments/assets/8534024e-f65c-483e-a833-076a133ebbf9" />

### Changes

- Pass `document_type` into `get_service_level_agreement_fields()` and set `link_filters` on the generated field accordingly.
- Apply the filter both when creating new fields and when resetting properties on existing ones (covers both standard doctypes via `DocField` and custom doctypes via `Custom Field`).
- Add patches to backfill `link_filters` on already-existing `service_level_agreement` fields, so sites upgrading also get the fix without recreating their SLAs.