### PR TITLE
fix(stock): pick list serial batch posting date

### DIFF
--- a/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py
+++ b/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py
@@ -2185,12 +2185,11 @@ def get_reference_serial_and_batch_bundle(child_row):
 def add_serial_batch_ledgers(
 	entries: list | str,
 	child_row: PurchaseReceiptItem | dict | str,
-	doc: Document | str,
+	doc: Document | dict | str,
 	warehouse: str | None = None,
 	do_not_save: bool = False,
 ):
-	if isinstance(child_row, str):
-		child_row = frappe._dict(parse_json(child_row))
+	child_row = parse_json(child_row)
 
 	if isinstance(entries, str):
 		entries = parse_json(entries)

--- a/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py
+++ b/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py
@@ -21,6 +21,7 @@ from frappe.utils import (
 	get_link_to_form,
 	getdate,
 	now,
+	nowtime,
 	parse_json,
 	today,
 )
@@ -2221,7 +2222,9 @@ def create_serial_batch_no_ledgers(
 	if parent_doc.get("doctype") == "Stock Entry":
 		warehouse = warehouse or child_row.s_warehouse or child_row.t_warehouse
 
-	posting_datetime = combine_datetime(parent_doc.get("posting_date"), parent_doc.get("posting_time"))
+	posting_datetime = combine_datetime(
+		parent_doc.get("posting_date") or today(), parent_doc.get("posting_time") or nowtime()
+	)
 
 	doc = frappe.get_doc(
 		{
@@ -2338,7 +2341,9 @@ def update_serial_batch_no_ledgers(bundle, entries, child_row, parent_doc, wareh
 		)
 
 	doc.voucher_detail_no = child_row.name
-	doc.posting_datetime = combine_datetime(parent_doc.get("posting_date"), parent_doc.get("posting_time"))
+	doc.posting_datetime = combine_datetime(
+		parent_doc.get("posting_date") or today(), parent_doc.get("posting_time") or nowtime()
+	)
 
 	doc.warehouse = warehouse or doc.warehouse
 	doc.set("entries", [])


### PR DESCRIPTION
Issues:
1.  (TypeError: combine() argument 1 must be datetime. date, not None) — I reproduced this myself server-side (calling the exact function the dialog's "Add" button triggers) with the fix removed, on both test-case and develop sites, and again against your real Pick List record STO-PICK-2026-00009.
2. The FrappeTypeError on doc (should be of type 'frappe.model.document.Document | str' but got 'dict' instead) — this one you hit directly, live, by actually clicking through the real "Select Serial No" dialog in your browser on the develop site. I then confirmed it's a genuine bug (not a fluke) by tracing it to frappe.app.make_form_dict, and reproduced/fixed it with a dedicated test that fails without the fix and passes with it.

Fixes: [#56951](https://github.com/frappe/erpnext/issues/56951)

Steps to Reproduce:
1. Create a new Pick List (Purpose: Delivery)
2. Add a row for a serial-tracked item with use_serial_batch_fields disabled
3. Open the Select Serial No dialog, pick a serial, and confirm
4. A server error occurs before the bundle saves

**Before:**

<img width="1280" height="642" alt="image" src="https://github.com/user-attachments/assets/522153aa-6028-4f6f-944d-92061f7c2054" />

<img width="1851" height="931" alt="image" src="https://github.com/user-attachments/assets/1ac029e4-af9b-4ece-9e5e-2568273a4580" />


**After:**

<img width="1734" height="901" alt="image" src="https://github.com/user-attachments/assets/4be0c7c7-1ad1-49c4-9079-69b856920899" />



**Backport Needed for v16 and v15**