### PR TITLE
fix: update events order by date asc

### DIFF
--- a/erpnext/crm/utils.py
+++ b/erpnext/crm/utils.py
@@ -189,6 +189,7 @@ def get_filtered_todos(ref_doctype, ref_docname, status: str | tuple[str, str]):
 			"allocated_to",
 			"date",
 		],
+		order_by="date asc",
 	)
 
 
@@ -218,6 +219,7 @@ def get_filtered_events(ref_doctype, ref_docname, open: bool):
 			& (event_link.reference_docname == ref_docname)
 			& (event_status_filter)
 		)
+		.orderby(event.starts_on)
 	)
 	data = query.run(as_dict=True)
 


### PR DESCRIPTION
**Issue:**In the Lead form's Activities tab, the tasks under Open Tasks appear in an inappropriate order; they are not sorted by their due date.

**Fixes:** [#56399](https://github.com/frappe/erpnext/issues/56399)

**Before:** 

<img width="1280" height="670" alt="image" src="https://github.com/user-attachments/assets/4153f69c-008f-44d9-b0c4-28b56548796c" />

**After:**

<img width="1280" height="673" alt="image" src="https://github.com/user-attachments/assets/b94d1129-1757-4014-94b6-9f419d565362" />

**Backport Needed For v15 and v16**