### PR TITLE
fix: update BOM operations when routing is changed

### DIFF
--- a/erpnext/manufacturing/doctype/bom/bom.js
+++ b/erpnext/manufacturing/doctype/bom/bom.js
@@ -586,7 +586,11 @@ frappe.ui.form.on("BOM", {
 	},
 
 	routing(frm) {
-		if (frm.doc.routing && frm.doc.with_operations && !frm.doc.operations.length) {
+		// Refetch operations whenever the routing is (re)selected, so that
+		// changing the routing - e.g. on a new BOM version copied from another
+		// BOM - replaces the operations with those of the newly selected routing
+		// instead of keeping the old ones.
+		if (frm.doc.routing && frm.doc.with_operations) {
 			frappe.call({
 				doc: frm.doc,
 				method: "get_routing",


### PR DESCRIPTION
## Problem

When a new BOM version is created via **New Version** and a **different Routing** is selected, the **Operations** table is not updated — it keeps showing the operations copied from the original BOM, even after saving.

## Steps to reproduce

1. Create a BOM with a Routing (so Operations are populated).
2. Open it and click **New Version** (copies items, operations and routing into a new BOM).
3. Change the **Routing** on the new BOM to a different one.
4. **Before:** the Operations table still shows the original routing's operations, and saving does not refresh them.

## Root cause

The `routing` field handler in `bom.js` only fetched operations when the operations table was empty:

```js
if (frm.doc.routing && frm.doc.with_operations && !frm.doc.operations.length) { ... }
```

On a new version the operations are copied from the source BOM, so `!frm.doc.operations.length` is false and `get_routing` is never called. The server-side `set_routing_operations` has the same `not self.operations` guard, so saving doesn't refresh them either.

## Fix

Drop the `!frm.doc.operations.length` guard from the `routing` handler. This handler only fires on an explicit routing change (a deliberate user action), so refetching is the intended behaviour. Selecting a routing now always calls the existing whitelisted `get_routing`, which clears and repopulates the Operations table from the selected routing. Because the operations are then non-empty with the new data, the server-side save guard correctly preserves them.

## After

Changing the Routing on the new BOM version immediately replaces the Operations with those of the selected routing, and the change persists on save.

🤖 Generated with [Claude Code](https://claude.com/claude-code)