### PR TITLE
fix: remove incorrect Payable account_type from Customer Deposits in Philippines CoA

### DIFF
--- a/erpnext/accounts/doctype/account/chart_of_accounts/verified/philippines.json
+++ b/erpnext/accounts/doctype/account/chart_of_accounts/verified/philippines.json
@@ -406,8 +406,7 @@
 				"Customer Deposits": {
 					"account_number": "2500",
 					"is_group": 0,
-					"root_type": "Liability",
-					"account_type": "Payable"
+					"root_type": "Liability"
 				}
 			},
 			"Non Current Liabilities": {


### PR DESCRIPTION
## Summary
- The Philippines Chart of Accounts template tags **Customer Deposits (2500)** with `account_type: "Payable"`, the same type as the real **Accounts Payable - Trade (2101)**.
- `Company.set_default_accounts` picks the default payable account via an unordered `frappe.db.get_value` query filtered on `account_type="Payable"`. With two accounts matching, new companies created from this template can non-deterministically get `default_payable_account` set to "Customer Deposits" instead of "Accounts Payable - Trade".
- This breaks the `credit_to` default on every Purchase Invoice for affected companies, silently booking supplier bills to a customer-advances account.
- Fix: drop the `account_type` tag from Customer Deposits (leave it unset), matching how every other CoA template in the repo tags similar deposit/holding accounts — none use `Liability`/`Current Liability` as an `account_type`; that classification is already carried by `root_type`.

## Notes
Confirmed no other CoA template (68 total) uses `account_type: "Liability"` or `"Current Liability"`, so leaving account type unset. 