### PR TITLE
fix: enforce read permission on ledger preview endpoints

### DIFF
--- a/erpnext/controllers/stock_controller.py
+++ b/erpnext/controllers/stock_controller.py
@@ -2060,6 +2060,7 @@ class StockController(AccountsController):
 def show_accounting_ledger_preview(company, doctype, docname):
 	filters = frappe._dict(company=company, include_dimensions=1)
 	doc = frappe.get_lazy_doc(doctype, docname)
+	doc.check_permission("read")
 	doc.run_method("before_gl_preview")
 
 	gl_columns, gl_data = get_accounting_ledger_preview(doc, filters)
@@ -2073,6 +2074,7 @@ def show_accounting_ledger_preview(company, doctype, docname):
 def show_stock_ledger_preview(company, doctype, docname):
 	filters = frappe._dict(company=company)
 	doc = frappe.get_lazy_doc(doctype, docname)
+	doc.check_permission("read")
 	doc.run_method("before_sl_preview")
 
 	sl_columns, sl_data = get_stock_ledger_preview(doc, filters)

--- a/erpnext/controllers/tests/test_stock_controller.py
+++ b/erpnext/controllers/tests/test_stock_controller.py
@@ -1,0 +1,52 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt
+
+import frappe
+
+from erpnext.accounts.doctype.journal_entry.test_journal_entry import make_journal_entry
+from erpnext.controllers.stock_controller import (
+	show_accounting_ledger_preview,
+	show_stock_ledger_preview,
+)
+from erpnext.tests.utils import ERPNextTestSuite
+
+
+class TestLedgerPreviewPermission(ERPNextTestSuite):
+	def test_ledger_preview_requires_read_permission(self):
+		company = "_Test Company"
+		je = make_journal_entry("_Test Cash - _TC", "_Test Bank - _TC", 100, submit=True)
+
+		email = "ledger_preview_no_role@example.com"
+		if not frappe.db.exists("User", email):
+			frappe.get_doc(
+				{
+					"doctype": "User",
+					"email": email,
+					"first_name": "No Role",
+					"user_type": "Website User",
+					"send_welcome_email": 0,
+				}
+			).insert(ignore_permissions=True)
+
+		try:
+			frappe.set_user(email)
+			self.assertRaises(
+				frappe.PermissionError,
+				show_accounting_ledger_preview,
+				company,
+				"Journal Entry",
+				je.name,
+			)
+			self.assertRaises(
+				frappe.PermissionError,
+				show_stock_ledger_preview,
+				company,
+				"Journal Entry",
+				je.name,
+			)
+		finally:
+			frappe.set_user("Administrator")
+
+		# a permitted user is still able to read the preview
+		result = show_accounting_ledger_preview(company, "Journal Entry", je.name)
+		self.assertTrue(result.get("gl_data"))

--- a/erpnext/controllers/tests/test_stock_controller.py
+++ b/erpnext/controllers/tests/test_stock_controller.py
@@ -48,5 +48,8 @@ class TestLedgerPreviewPermission(ERPNextTestSuite):
 			frappe.set_user("Administrator")
 
 		# a permitted user is still able to read the preview
-		result = show_accounting_ledger_preview(company, "Journal Entry", je.name)
-		self.assertTrue(result.get("gl_data"))
+		accounting_ledger_result = show_accounting_ledger_preview(company, "Journal Entry", je.name)
+		self.assertTrue(accounting_ledger_result.get("gl_data"))
+
+		stock_ledger_result = show_stock_ledger_preview(company, "Journal Entry", je.name)
+		self.assertTrue(stock_ledger_result.get("sl_data"))

--- a/erpnext/controllers/tests/test_stock_controller.py
+++ b/erpnext/controllers/tests/test_stock_controller.py
@@ -8,11 +8,12 @@ from erpnext.controllers.stock_controller import (
 	show_accounting_ledger_preview,
 	show_stock_ledger_preview,
 )
+from erpnext.stock.doctype.purchase_receipt.test_purchase_receipt import make_purchase_receipt
 from erpnext.tests.utils import ERPNextTestSuite
 
 
 class TestLedgerPreviewPermission(ERPNextTestSuite):
-	def test_ledger_preview_requires_read_permission(self):
+	def test_accounting_ledger_preview_requires_read_permission(self):
 		company = "_Test Company"
 		je = make_journal_entry("_Test Cash - _TC", "_Test Bank - _TC", 100, submit=True)
 
@@ -37,13 +38,6 @@ class TestLedgerPreviewPermission(ERPNextTestSuite):
 				"Journal Entry",
 				je.name,
 			)
-			self.assertRaises(
-				frappe.PermissionError,
-				show_stock_ledger_preview,
-				company,
-				"Journal Entry",
-				je.name,
-			)
 		finally:
 			frappe.set_user("Administrator")
 
@@ -51,5 +45,33 @@ class TestLedgerPreviewPermission(ERPNextTestSuite):
 		accounting_ledger_result = show_accounting_ledger_preview(company, "Journal Entry", je.name)
 		self.assertTrue(accounting_ledger_result.get("gl_data"))
 
-		stock_ledger_result = show_stock_ledger_preview(company, "Journal Entry", je.name)
+	def test_stock_ledger_preview_requires_read_permission(self):
+		company = "_Test Company"
+		pr = make_purchase_receipt()
+
+		email = "ledger_preview_no_role@example.com"
+		if not frappe.db.exists("User", email):
+			frappe.get_doc(
+				{
+					"doctype": "User",
+					"email": email,
+					"first_name": "No Role",
+					"user_type": "Website User",
+					"send_welcome_email": 0,
+				}
+			).insert(ignore_permissions=True)
+
+		try:
+			frappe.set_user(email)
+			self.assertRaises(
+				frappe.PermissionError,
+				show_stock_ledger_preview,
+				company,
+				"Purchase Receipt",
+				pr.name,
+			)
+		finally:
+			frappe.set_user("Administrator")
+
+		stock_ledger_result = show_stock_ledger_preview(company, "Purchase Receipt", pr.name)
 		self.assertTrue(stock_ledger_result.get("sl_data"))


### PR DESCRIPTION
### Problem

`show_accounting_ledger_preview` and `show_stock_ledger_preview` (whitelisted endpoints in `erpnext/controllers/stock_controller.py`) loaded the caller-specified document via `frappe.get_lazy_doc(doctype, docname)` and returned its General Ledger / Stock Ledger data **without any permission check** on the target document.

As a result, any authenticated user (including a website user with no roles) could read the GL/SL data of vouchers they are otherwise denied read access to, by supplying the document name.

### Fix

Add `doc.check_permission("read")` immediately after loading the document in both endpoints, so the caller must have read access to the voucher before its ledger preview is returned.

### Test

Adds `test_ledger_preview_requires_read_permission`: a zero-role user gets `PermissionError` from both endpoints, while a permitted user still receives the preview data.