### PR TITLE
fix: use correct mapper path for make_work_orders call

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.js
+++ b/erpnext/selling/doctype/sales_order/sales_order.js
@@ -1368,7 +1368,7 @@ erpnext.selling.SalesOrderController = class SalesOrderController extends erpnex
 								frappe.throw(__("Please select at least one item to continue"));
 							}
 							me.frm.call({
-								method: "make_work_orders",
+								method: "erpnext.selling.doctype.sales_order.mapper.make_work_orders",
 								args: {
 									items: data,
 									company: me.frm.doc.company,


### PR DESCRIPTION
make_work_orders was moved to mapper.py during refactor but the JS call still resolved to the old sales_order.py path, breaking Work Order creation from Sales Order.