### PR TITLE
fix: sync process loss percentage when fg qty changes

### DIFF
--- a/erpnext/stock/doctype/stock_entry/services/manufacturing.py
+++ b/erpnext/stock/doctype/stock_entry/services/manufacturing.py
@@ -138,7 +138,7 @@ class BaseManufactureStockEntry(BaseStockEntry):
 			self.doc.process_loss_qty = flt(
 				(flt(self.doc.fg_completed_qty) * flt(self.doc.process_loss_percentage)) / 100
 			)
-		elif self.doc.process_loss_qty and not self.doc.process_loss_percentage:
+		elif self.doc.process_loss_qty and self.doc.fg_completed_qty:
 			self.doc.process_loss_percentage = flt(
 				(flt(self.doc.process_loss_qty) / flt(self.doc.fg_completed_qty)) * 100
 			)

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -1407,7 +1407,7 @@ class StockEntry(StockController, SubcontractingInwardController):
 			self.process_loss_qty = flt(
 				(flt(self.fg_completed_qty) * flt(self.process_loss_percentage)) / 100
 			)
-		elif self.process_loss_qty and not self.process_loss_percentage:
+		elif self.process_loss_qty and self.fg_completed_qty:
 			self.process_loss_percentage = flt(
 				(flt(self.process_loss_qty) / flt(self.fg_completed_qty)) * 100
 			)

--- a/erpnext/stock/doctype/stock_entry/test_stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/test_stock_entry.py
@@ -3414,6 +3414,28 @@ class TestStockEntryCoverage(ERPNextTestSuite):
 		frappe.db.set_value("Work Order", wo.name, "produced_qty", wo.qty)
 		self.assertNotIn(wo.name, pending_work_orders())
 
+	def test_process_loss_percentage_resyncs_from_qty(self):
+		# changing fg qty recomputes process_loss_qty and process_loss_percentage
+		se = frappe.new_doc("Stock Entry")
+		se.purpose = "Manufacture"
+		se.fg_completed_qty = 200
+		se.process_loss_qty = 100
+		se.process_loss_percentage = 80
+
+		se.set_process_loss_qty()
+
+		self.assertEqual(se.process_loss_percentage, 50)
+
+	def test_process_loss_qty_derived_from_percentage_when_qty_blank(self):
+		se = frappe.new_doc("Stock Entry")
+		se.purpose = "Manufacture"
+		se.fg_completed_qty = 200
+		se.process_loss_percentage = 25
+
+		se.set_process_loss_qty()
+
+		self.assertEqual(se.process_loss_qty, 50)
+
 
 def make_serialized_item(self, **args):
 	args = frappe._dict(args)


### PR DESCRIPTION
When FG completed qty changes on a Manufacture/Repack Stock Entry, `process_loss_qty` is recomputed but `process_loss_percentage` kept a stale value. Now the percentage is always re-derived from qty. Display-only field; no stock/valuation impact.

https://support.frappe.io/helpdesk/tickets/73468?view=VIEW-HD+Ticket-70177