### PR TITLE
fix: accounting dimension search matching unrelated records

### DIFF
--- a/erpnext/controllers/queries.py
+++ b/erpnext/controllers/queries.py
@@ -20,7 +20,7 @@ from frappe.query_builder.functions import (
 	Substring,
 	Sum,
 )
-from frappe.utils import cint, nowdate, today, unique
+from frappe.utils import nowdate, today, unique
 from pypika import Order
 
 import erpnext
@@ -809,10 +809,8 @@ def get_filtered_dimensions(
 
 	for field in searchfields:
 		df = meta.get_field(field)
-		if df and df.fieldtype != "Check":
+		if not df or df.fieldtype != "Check":
 			or_filters.append([field, "LIKE", "%%%s%%" % txt])
-		else:
-			or_filters.append([field, "=", cint(txt)])
 		fields.append(field)
 
 	if dimension_filters:


### PR DESCRIPTION
Follow-up to #56871, which fixed the Postgres `LIKE`-on-Check crash but broke dimension search on both engines:

- `get_search_fields()` always appends `name`, and `meta.get_field("name")` returns `None`, so `name` fell into the `= cint(txt)` branch — on MariaDB `name = 0` coerces and matches every non-numeric name; on Postgres it becomes `name = '0'` and never matches.
- For a real Check searchfield (Cost Center has `is_group`), any non-numeric text gives `cint(txt) = 0`, so the or-filter `is_group = 0` matches every leaf record — typing anything returned all non-group cost centers.

Fix: skip Check fields from `or_filters` (a checkbox can't match search text) and keep `LIKE` for everything else, including `name`.

Verified on both engines with `get_filtered_dimensions("Cost Center", txt, ...)`:

| txt | before | after |
|---|---|---|
| `Main` | all 5 leaf cost centers | only `Main - _TC` |
| `zzz` | all 5 leaf cost centers | `[]` |