### PR TITLE
fix(stock): show qty (company) and qty (warehouse) in sales transactions 

### DIFF
--- a/erpnext/public/js/utils/sales_common.js
+++ b/erpnext/public/js/utils/sales_common.js
@@ -284,19 +284,17 @@ erpnext.sales_common = {
 
 			set_actual_qty(doc, cdt, cdn) {
 				let row = locals[cdt][cdn];
-				let sales_doctypes = ["Sales Invoice", "Delivery Note", "Sales Order"];
+				let sales_doctypes = ["Sales Invoice", "Delivery Note", "Sales Order", "Quotation"];
 
 				if (row.item_code && row.warehouse && sales_doctypes.includes(doc.doctype)) {
-					frappe.call({
+					return this.frm.call({
 						method: "erpnext.stock.get_item_details.get_bin_details",
+						child: row,
 						args: {
 							item_code: row.item_code,
 							warehouse: row.warehouse,
-						},
-						callback(r) {
-							if (r.message) {
-								frappe.model.set_value(cdt, cdn, "actual_qty", r.message.actual_qty);
-							}
+							company: doc.company,
+							include_child_warehouses: true,
 						},
 					});
 				}

--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -323,10 +323,9 @@ def update_bin_details(ctx: frappe._dict, out: frappe._dict, doc):
 		out.update(get_bin_details(ctx.item_code, ctx.from_warehouse))
 
 	elif out.get("warehouse"):
-		company = ctx.company if (doc and doc.get("doctype") == "Purchase Order") else None
-
-		# calculate company_total_stock only for po
-		bin_details = get_bin_details(ctx.item_code, out.warehouse, company, include_child_warehouses=True)
+		bin_details = get_bin_details(
+			ctx.item_code, out.warehouse, ctx.company, include_child_warehouses=True
+		)
 
 		out.update(bin_details)
 

--- a/erpnext/stock/tests/test_get_item_details.py
+++ b/erpnext/stock/tests/test_get_item_details.py
@@ -28,6 +28,40 @@ class TestGetItemDetail(ERPNextTestSuite):
 		details = get_item_details(args)
 		self.assertEqual(details.get("price_list_rate"), 100)
 
+	def test_bin_details_for_selling_doctypes(self):
+		from erpnext.stock.doctype.item.test_item import make_item
+		from erpnext.stock.doctype.purchase_receipt.test_purchase_receipt import make_purchase_receipt
+
+		item_code = make_item(properties={"is_stock_item": 1}).name
+
+		make_purchase_receipt(item_code=item_code, warehouse="_Test Warehouse - _TC", qty=100, rate=100)
+		make_purchase_receipt(item_code=item_code, warehouse="_Test Warehouse 1 - _TC", qty=50, rate=100)
+
+		args = frappe._dict(
+			{
+				"item_code": item_code,
+				"warehouse": "_Test Warehouse - _TC",
+				"company": "_Test Company",
+				"customer": "_Test Customer",
+				"currency": "INR",
+				"conversion_rate": 1.0,
+				"price_list": "_Test Price List",
+				"price_list_currency": "INR",
+				"plc_conversion_rate": 1.0,
+				"transaction_date": None,
+				"name": None,
+				"ignore_pricing_rule": 1,
+				"qty": 1,
+			}
+		)
+
+		for doctype in ("Sales Order", "Quotation", "Sales Invoice", "Delivery Note", "Purchase Order"):
+			with self.subTest(doctype=doctype):
+				details = get_item_details(args.copy().update({"doctype": doctype}))
+
+				self.assertEqual(details.get("actual_qty"), 100)
+				self.assertEqual(details.get("company_total_stock"), 150)
+
 	# making this test in get_item_details test file as feat/fix is present in that method
 	def test_fetch_price_from_list_rate_on_doc_save(self):
 		# create item


### PR DESCRIPTION
**Issue:**
Qty (Company) showed zero on Sales Order, Quotation, Sales Invoice and Delivery Note items even when stock was available, because the company total was only ever calculated for Purchase Orders.

It is now calculated for all of them. Changing the warehouse on a row also refreshes the quantities, which it did not do before.

**Ref:** [#73636](https://support.frappe.io/helpdesk/tickets/73636)

**Before:**
<img width="849" height="213" alt="before" src="https://github.com/user-attachments/assets/af05e339-4f2f-4050-9f8b-7ee72337c112" />

**After:**
<img width="849" height="213" alt="after" src="https://github.com/user-attachments/assets/e777b133-2281-46ea-ad17-608d90f418e0" />


**Backport Needed for v15 & v16**