### PR TITLE
fix(asset): allow asset repair creation for fully depreciated assets (backport #55276)

### DIFF
--- a/erpnext/assets/doctype/asset/asset.js
+++ b/erpnext/assets/doctype/asset/asset.js
@@ -147,7 +147,15 @@ frappe.ui.form.on("Asset", {
 						__("Actions")
 					);
 				}
-
+				if (frm.doc.status === "Fully Depreciated") {
+					frm.add_custom_button(
+						__("Asset Repair"),
+						function () {
+							frm.trigger("create_asset_repair");
+						},
+						__("Actions")
+					);
+				}
 				frm.add_custom_button(
 					__("Split Asset"),
 					function () {

--- a/erpnext/assets/doctype/asset_repair/asset_repair.js
+++ b/erpnext/assets/doctype/asset_repair/asset_repair.js
@@ -84,6 +84,15 @@ frappe.ui.form.on("Asset Repair", {
 				};
 			};
 		}
+		if (frm.doc.asset) {
+			frappe.db.get_value("Asset", frm.doc.asset, "status").then(({ message }) => {
+				frm.set_df_property(
+					"capitalize_repair_cost",
+					"read_only",
+					message && message.status === "Fully Depreciated"
+				);
+			});
+		}
 	},
 
 	show_general_ledger: function (frm) {

--- a/erpnext/assets/doctype/asset_repair/asset_repair.json
+++ b/erpnext/assets/doctype/asset_repair/asset_repair.json
@@ -130,7 +130,7 @@
    "fieldtype": "Link",
    "in_list_view": 1,
    "label": "Asset",
-   "link_filters": "[[\"Asset\",\"status\",\"not in\",[\"Work In Progress\",\"Capitalized\",\"Fully Depreciated\",\"Sold\",\"Scrapped\",\"Cancelled\"]]]",
+   "link_filters": "[[\"Asset\",\"status\",\"not in\",[\"Work In Progress\",\"Capitalized\",\"Sold\",\"Scrapped\",\"Cancelled\"]]]",
    "options": "Asset",
    "reqd": 1
   },
@@ -275,7 +275,7 @@
    "link_fieldname": "asset_repair"
   }
  ],
- "modified": "2026-02-06 14:57:54.257572",
+ "modified": "2026-06-20 15:43:54.943335",
  "modified_by": "Administrator",
  "module": "Assets",
  "name": "Asset Repair",

--- a/erpnext/assets/doctype/asset_repair/asset_repair.py
+++ b/erpnext/assets/doctype/asset_repair/asset_repair.py
@@ -70,12 +70,15 @@ class AssetRepair(AccountsController):
 		self.check_repair_status()
 
 	def validate_asset(self):
-		if self.asset_doc.status in ("Sold", "Fully Depreciated", "Scrapped"):
+		if self.asset_doc.status in ("Sold", "Scrapped"):
 			frappe.throw(
 				_("Asset {0} is in {1} status and cannot be repaired.").format(
 					get_link_to_form("Asset", self.asset), self.asset_doc.status
 				)
 			)
+		if self.asset_doc.get_status() == "Fully Depreciated":
+			self.capitalize_repair_cost = 0
+			self.increase_in_asset_life = 0
 
 	def validate_dates(self):
 		if self.completion_date and (getdate(self.failure_date) > getdate(self.completion_date)):


### PR DESCRIPTION
Backport of #55276 to version-16.

Allows Asset Repair creation for fully depreciated assets so repair expenses can be recorded. Capitalization and increase in asset life stay disabled for such assets.