### PR TITLE
fix(asset): allow asset repair creation for fully depreciated assets (backport #55276)

### DIFF
--- a/erpnext/assets/doctype/asset_repair/asset_repair.js
+++ b/erpnext/assets/doctype/asset_repair/asset_repair.js
@@ -74,6 +74,15 @@ frappe.ui.form.on("Asset Repair", {
 				};
 			};
 		}
+		if (frm.doc.asset) {
+			frappe.db.get_value("Asset", frm.doc.asset, "status").then(({ message }) => {
+				frm.set_df_property(
+					"capitalize_repair_cost",
+					"read_only",
+					message && message.status === "Fully Depreciated"
+				);
+			});
+		}
 	},
 
 	repair_status: (frm) => {

--- a/erpnext/assets/doctype/asset_repair/asset_repair.json
+++ b/erpnext/assets/doctype/asset_repair/asset_repair.json
@@ -140,7 +140,7 @@
    "fieldtype": "Link",
    "in_list_view": 1,
    "label": "Asset",
-   "link_filters": "[[\"Asset\",\"status\",\"not in\",[\"Work In Progress\",\"Capitalized\",\"Fully Depreciated\",\"Sold\",\"Scrapped\",\"Cancelled\",null]]]",
+   "link_filters": "[[\"Asset\",\"status\",\"not in\",[\"Work In Progress\",\"Capitalized\",\"Sold\",\"Scrapped\",\"Cancelled\",null]]]",
    "options": "Asset",
    "reqd": 1
   },
@@ -251,7 +251,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2026-01-06 15:48:13.862505",
+ "modified": "2026-07-14 10:00:00.000000",
  "modified_by": "Administrator",
  "module": "Assets",
  "name": "Asset Repair",

--- a/erpnext/assets/doctype/asset_repair/asset_repair.py
+++ b/erpnext/assets/doctype/asset_repair/asset_repair.py
@@ -77,12 +77,15 @@ class AssetRepair(AccountsController):
 				)
 
 	def validate_asset(self):
-		if self.asset_doc.status in ("Sold", "Fully Depreciated", "Scrapped"):
+		if self.asset_doc.status in ("Sold", "Scrapped"):
 			frappe.throw(
 				_("Asset {0} is in {1} status and cannot be repaired.").format(
 					get_link_to_form("Asset", self.asset), self.asset_doc.status
 				)
 			)
+		if self.asset_doc.get_status() == "Fully Depreciated":
+			self.capitalize_repair_cost = 0
+			self.increase_in_asset_life = 0
 
 	def validate_dates(self):
 		if self.completion_date and (getdate(self.failure_date) > getdate(self.completion_date)):


### PR DESCRIPTION
Backport of #55276 to version-15.

Allows Asset Repair creation for fully depreciated assets so repair expenses can be recorded. Capitalization and increase in asset life stay disabled for such assets.

Note: the asset.js change from #55276 is not needed here — version-15 already shows the Repair Asset button for all submitted assets.