### PR TITLE
fix: duplicate scorecard period when supplier is created on a month end

### DIFF
--- a/erpnext/buying/doctype/supplier_scorecard/supplier_scorecard.py
+++ b/erpnext/buying/doctype/supplier_scorecard/supplier_scorecard.py
@@ -201,14 +201,16 @@ def make_all_scorecards(docname: str):
 
 	while (start_date < todays) and (end_date <= todays):
 		# check to make sure there is no scorecard period already created
+		# (inclusive bounds: a single-day period — supplier created on a month's
+		# last day — must match its own window, else it is re-created every run)
 		scorecards = frappe.get_all(
 			"Supplier Scorecard Period",
 			fields=["name"],
 			filters={
 				"scorecard": docname,
 				"docstatus": 1,
-				"start_date": ["<", end_date],
-				"end_date": [">", start_date],
+				"start_date": ["<=", end_date],
+				"end_date": [">=", start_date],
 			},
 			order_by="end_date desc",
 		)


### PR DESCRIPTION
Both nightly server suites went red on 2026-07-14 on `test_make_all_scorecards_is_idempotent` ([Postgres](https://github.com/frappe/erpnext/actions/runs/29287810624), [MariaDB](https://github.com/frappe/erpnext/actions/runs/29295365809)) — not engine-related, date-dependent: the test sets supplier creation to `nowdate() - 75 days`, which landed on April 30.

A supplier created on a month's last day gets a single-day first period under "Per Month" (`get_last_day(start) == start`). `make_all_scorecards`' dedup query uses strict bounds (`start_date < end`, `end_date > start`), so that period never matches its own window and is re-created on every call — the daily `refresh_scorecards` job inserts a duplicate submitted period each day for such suppliers.

Fixed with inclusive bounds. No false match on adjacent periods: each next period starts at `end_date + 1`, so closed intervals never touch.

Verified locally (today reproduces the condition): test fails before, full scorecard module passes after.