### PR TITLE
fix: prevent duplicate material request items in purchase order

### DIFF
--- a/erpnext/buying/doctype/purchase_order/purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.py
@@ -259,6 +259,7 @@ class PurchaseOrder(BuyingController):
 					"ref_dn_field": "material_request_item",
 					"compare_fields": mri_compare_fields,
 					"is_child_table": True,
+					"allow_duplicate_prev_row_id": True,
 				},
 			}
 		)

--- a/erpnext/buying/doctype/purchase_order/test_purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/test_purchase_order.py
@@ -220,23 +220,6 @@ class TestPurchaseOrder(ERPNextTestSuite):
 		frappe.db.set_single_value("Buying Settings", "over_order_allowance", 0)
 		frappe.db.set_single_value("Stock Settings", "over_delivery_receipt_allowance", 0)
 
-	def test_duplicate_material_request_item_row_allowed(self):
-		"""Splitting a Material Request Item's qty across multiple PO rows must be
-		allowed, mirroring how Sales Order allows duplicate Quotation Item rows."""
-		mr = make_material_request(qty=10)
-		po = make_purchase_order(mr.name)
-		po.supplier = "_Test Supplier"
-
-		duplicate_row = po.items[0].as_dict()
-		duplicate_row.qty = 4
-		po.items[0].qty = 6
-
-		po.append("items", duplicate_row)
-		po.save()
-
-		self.assertEqual(len(po.items), 2)
-		self.assertEqual(po.items[0].material_request_item, po.items[1].material_request_item)
-
 	def test_update_remove_child_linked_to_mr(self):
 		"""Test impact on linked PO and MR on deleting/updating row."""
 		mr = make_material_request(qty=10)

--- a/erpnext/buying/doctype/purchase_order/test_purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/test_purchase_order.py
@@ -220,6 +220,23 @@ class TestPurchaseOrder(ERPNextTestSuite):
 		frappe.db.set_single_value("Buying Settings", "over_order_allowance", 0)
 		frappe.db.set_single_value("Stock Settings", "over_delivery_receipt_allowance", 0)
 
+	def test_duplicate_material_request_item_row_allowed(self):
+		"""Splitting a Material Request Item's qty across multiple PO rows must be
+		allowed, mirroring how Sales Order allows duplicate Quotation Item rows."""
+		mr = make_material_request(qty=10)
+		po = make_purchase_order(mr.name)
+		po.supplier = "_Test Supplier"
+
+		duplicate_row = po.items[0].as_dict()
+		duplicate_row.qty = 4
+		po.items[0].qty = 6
+
+		po.append("items", duplicate_row)
+		po.save()
+
+		self.assertEqual(len(po.items), 2)
+		self.assertEqual(po.items[0].material_request_item, po.items[1].material_request_item)
+
 	def test_update_remove_child_linked_to_mr(self):
 		"""Test impact on linked PO and MR on deleting/updating row."""
 		mr = make_material_request(qty=10)


### PR DESCRIPTION
closes #57125 
Issue Statement

When creating a Purchase Order from a Material Request, it is not possible to add the same item in multiple rows. The system shows the error:

"Duplicate Row https://github.com/frappe/erpnext/issues/2 with same Material Request Item"

However, the same behavior is allowed when creating a Sales Order from a Quotation.

Issue Description

We need to split the quantity of the same item into multiple rows so that different rates can be applied to each row.

This works when creating a Sales Order from a Quotation, but it is blocked when creating a Purchase Order from a Material Request due to the duplicate row validation.

Steps to Reproduce

Create and submit a Material Request with an item.
Create a Purchase Order from the Material Request using Create > Purchase Order.
Duplicate the item row and split the quantity between the two rows.
Try to save the Purchase Order.
Current Behavior

The Purchase Order cannot be saved. The system shows the error:

"Duplicate Row https://github.com/frappe/erpnext/issues/2 with same Material Request Item"

Expected Behavior

Users should be able to add the same Material Request item in multiple rows in the Purchase Order, similar to the behavior of Sales Order created from a Quotation. This allows splitting quantities and applying different rates to each row while maintaining the link to the same Material Request item.

Module
buying

Version
ERPNext: 16.23.0