### PR TITLE
refactor: convert Hide Currency Symbol in Global Defaults to a Check field

### DIFF
--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -497,3 +497,4 @@ erpnext.patches.v16_0.create_shop_floor_roles
 erpnext.patches.v15_0.backfill_sla_link_filters_on_custom_field
 erpnext.patches.v15_0.backfill_sla_link_filters_on_docfield
 erpnext.patches.v16_0.crm_settings_handle_allowed_users_for_frappe_crm
+erpnext.patches.v16_0.convert_hide_currency_symbol_to_check

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -261,6 +261,7 @@ erpnext.patches.v14_0.update_proprietorship_to_individual
 erpnext.patches.v15_0.rename_subcontracting_fields
 erpnext.patches.v15_0.unset_incorrect_additional_discount_percentage
 erpnext.patches.v16_0.convert_commission_rate_to_percent
+erpnext.patches.v16_0.convert_hide_currency_symbol_to_check
 
 [post_model_sync]
 erpnext.patches.v15_0.rename_gross_purchase_amount_to_net_purchase_amount
@@ -497,4 +498,3 @@ erpnext.patches.v16_0.create_shop_floor_roles
 erpnext.patches.v15_0.backfill_sla_link_filters_on_custom_field
 erpnext.patches.v15_0.backfill_sla_link_filters_on_docfield
 erpnext.patches.v16_0.crm_settings_handle_allowed_users_for_frappe_crm
-erpnext.patches.v16_0.convert_hide_currency_symbol_to_check

--- a/erpnext/patches/v16_0/convert_hide_currency_symbol_to_check.py
+++ b/erpnext/patches/v16_0/convert_hide_currency_symbol_to_check.py
@@ -2,9 +2,8 @@ import frappe
 
 
 def execute():
-	old_value = frappe.db.get_value(
-		"Singles", {"doctype": "Global Defaults", "field": "hide_currency_symbol"}, "value"
-	)
+	# runs pre_model_sync: field is still a Select, so this returns the raw "Yes"/"No"
+	old_value = frappe.db.get_single_value("Global Defaults", "hide_currency_symbol")
 	new_value = 1 if old_value == "Yes" else 0
 	frappe.db.set_single_value("Global Defaults", "hide_currency_symbol", new_value)
 	frappe.db.set_default("hide_currency_symbol", new_value)

--- a/erpnext/patches/v16_0/convert_hide_currency_symbol_to_check.py
+++ b/erpnext/patches/v16_0/convert_hide_currency_symbol_to_check.py
@@ -1,0 +1,10 @@
+import frappe
+
+
+def execute():
+	old_value = frappe.db.get_value(
+		"Singles", {"doctype": "Global Defaults", "field": "hide_currency_symbol"}, "value"
+	)
+	new_value = 1 if old_value == "Yes" else 0
+	frappe.db.set_single_value("Global Defaults", "hide_currency_symbol", new_value)
+	frappe.db.set_default("hide_currency_symbol", new_value)

--- a/erpnext/setup/doctype/global_defaults/global_defaults.json
+++ b/erpnext/setup/doctype/global_defaults/global_defaults.json
@@ -55,12 +55,12 @@
    "reqd": 1
   },
   {
+   "default": "0",
    "description": "Do not show any symbol like $ etc next to currencies.",
    "fieldname": "hide_currency_symbol",
-   "fieldtype": "Select",
+   "fieldtype": "Check",
    "in_list_view": 1,
-   "label": "Hide Currency Symbol",
-   "options": "\nNo\nYes"
+   "label": "Hide Currency Symbol"
   },
   {
    "default": "0",
@@ -121,7 +121,7 @@
  "in_create": 1,
  "issingle": 1,
  "links": [],
- "modified": "2026-07-14 15:18:25.829886",
+ "modified": "2026-07-14 18:30:00.000000",
  "modified_by": "Administrator",
  "module": "Setup",
  "name": "Global Defaults",

--- a/erpnext/setup/doctype/global_defaults/global_defaults.py
+++ b/erpnext/setup/doctype/global_defaults/global_defaults.py
@@ -53,7 +53,7 @@ class GlobalDefaults(Document):
 		disable_in_words: DF.Check
 		disable_rounded_total: DF.Check
 		enable_company_wise_masters: DF.Check
-		hide_currency_symbol: DF.Literal["", "No", "Yes"]
+		hide_currency_symbol: DF.Check
 		use_posting_datetime_for_naming_documents: DF.Check
 	# end: auto-generated types
 


### PR DESCRIPTION
Converts the `hide_currency_symbol` Select (""/No/Yes) in Global Defaults to a Check field.

- Patch converts the stored Singles value and the global default ("Yes" → 1, else 0).
- Also fixes `erpnext/utilities/product.py`, which already read the default with `cint()` — `cint("Yes")` is 0, so the setting was silently ignored there; it now works.

Companion PR on frappe updates the readers of this default: frappe/frappe#40864