### PR TITLE
feat: add on hold status to project

### DIFF
--- a/erpnext/projects/doctype/project/project.json
+++ b/erpnext/projects/doctype/project/project.json
@@ -86,7 +86,7 @@
    "no_copy": 1,
    "oldfieldname": "status",
    "oldfieldtype": "Select",
-   "options": "Open\nCompleted\nCancelled",
+   "options": "Open\nOn hold\nCompleted\nCancelled",
    "search_index": 1
   },
   {
@@ -482,7 +482,7 @@
  "index_web_pages_for_search": 1,
  "links": [],
  "max_attachments": 4,
- "modified": "2026-05-22 16:45:50.762759",
+ "modified": "2026-07-14 14:20:50.418911",
  "modified_by": "Administrator",
  "module": "Projects",
  "name": "Project",

--- a/erpnext/projects/doctype/project/project.py
+++ b/erpnext/projects/doctype/project/project.py
@@ -59,7 +59,7 @@ class Project(Document):
 		project_type: DF.Link | None
 		sales_order: DF.Link | None
 		second_email: DF.Time | None
-		status: DF.Literal["Open", "Completed", "Cancelled"]
+		status: DF.Literal["Open", "On hold", "Completed", "Cancelled"]
 		subject: DF.Data | None
 		to_time: DF.Time | None
 		total_billable_amount: DF.Currency
@@ -311,8 +311,8 @@ class Project(Document):
 					pct_complete += row["progress"] * frappe.utils.safe_div(row["task_weight"], weight_sum)
 				self.percent_complete = flt(flt(pct_complete), 2)
 
-		# don't update status if it is cancelled
-		if self.status == "Cancelled":
+		# don't update status if it is manually set to cancelled or on hold
+		if self.status in ("Cancelled", "On hold"):
 			return
 
 		self.status = "Completed" if self.percent_complete == 100 else "Open"

--- a/erpnext/projects/doctype/project/project_list.js
+++ b/erpnext/projects/doctype/project/project_list.js
@@ -4,6 +4,8 @@ frappe.listview_settings["Project"] = {
 	get_indicator: function (doc) {
 		if (doc.status == "Open" && doc.percent_complete) {
 			return [__("{0}%", [cint(doc.percent_complete)]), "orange", "percent_complete,>,0|status,=,Open"];
+		} else if (doc.status == "On hold") {
+			return [__("On hold"), "blue", "status,=,On hold"];
 		} else {
 			return [__(doc.status), frappe.utils.guess_colour(doc.status), "status,=," + doc.status];
 		}


### PR DESCRIPTION
**Issue:**
Currently, the Project Status provides only Open, Completed, and Cancelled statuses. However, when a project needs to be paused temporarily, there is no appropriate status available other than Cancelled, which incorrectly indicates that the project has been permanently terminated. Introducing an On Hold status will allow users to temporarily suspend a project without marking it as cancelled, ensuring more accurate project tracking and status management.

**Closes:** #46736 

no-docs