### PR TITLE
fix: clear deferred revenue/expense fields on uncheck

### DIFF
--- a/erpnext/accounts/services/deferred_accounting.py
+++ b/erpnext/accounts/services/deferred_accounting.py
@@ -55,3 +55,16 @@ class DeferredAccountingService:
 
 	def _is_deferred(self, item) -> bool:
 		return bool(item.get("enable_deferred_revenue") or item.get("enable_deferred_expense"))
+
+	def clear_stale_deferred_fields(self) -> None:
+		account_field = DEFERRED_ACCOUNT_FIELD.get(self.doc.doctype)
+
+		for item in self.doc.get("items"):
+			if self._is_deferred(item):
+				continue
+
+			item.service_start_date = None
+			item.service_end_date = None
+			item.service_stop_date = None
+			if account_field:
+				item.set(account_field, None)

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -236,6 +236,7 @@ class AccountsController(TransactionBase):
 			else:
 				from erpnext.accounts.services.deferred_accounting import DeferredAccountingService
 
+				DeferredAccountingService(self).clear_stale_deferred_fields()
 				DeferredAccountingService(self).validate_start_and_end_date()
 
 		from erpnext.accounts.services.internal_transfer import InternalTransferService

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -236,8 +236,9 @@ class AccountsController(TransactionBase):
 			else:
 				from erpnext.accounts.services.deferred_accounting import DeferredAccountingService
 
-				DeferredAccountingService(self).clear_stale_deferred_fields()
-				DeferredAccountingService(self).validate_start_and_end_date()
+				deferred_service = DeferredAccountingService(self)
+				deferred_service.clear_stale_deferred_fields()
+				deferred_service.validate_start_and_end_date()
 
 		from erpnext.accounts.services.internal_transfer import InternalTransferService
 


### PR DESCRIPTION
**Issue:**
The Service Start Date and Service End Date remain populated even after the Deferred Revenue option is unchecked, resulting in incorrect data being retained on the submitted Sales Invoice.

**Steps to Reproduce:**

1. A Sales Invoice was created with Enable Deferred Revenue checked.
2. The user entered the Service Start Date and Service End Date.
3. Before submitting the document, the user unchecked the "Enable Deferred Revenue" checkbox at the parent level.
4. The Sales Invoice was then saved and submitted.

**Ref:**[#73548](https://support.frappe.io/helpdesk/tickets/73548?view=VIEW-HD+Ticket-745)

**Before:**

[Screencast from 2026-07-14 17-26-36.webm](https://github.com/user-attachments/assets/088f9545-7b50-4f28-bffc-4d62db5f7c47)


**After:**
[Screencast from 2026-07-14 17-24-41.webm](https://github.com/user-attachments/assets/5ab2d1b5-3318-4243-8080-9432902fa839)



