### PR TITLE
fix: replace raw SQL CURRENT_DATE/CURDATE() with frappe.utils.nowdate()

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -2374,7 +2374,7 @@ def get_negative_outstanding_invoices(
 	account = "debit_to" if voucher_type == "Sales Invoice" else "credit_to"
 	supplier_condition = ""
 	if voucher_type == "Purchase Invoice":
-		supplier_condition = "and (release_date is null or release_date <= CURRENT_DATE)"
+		supplier_condition = f"and (release_date is null or release_date <= '{nowdate()}')"
 	if party_account_currency == company_currency:
 		grand_total_field = "base_grand_total"
 		rounded_total_field = "base_rounded_total"

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -2373,8 +2373,10 @@ def get_negative_outstanding_invoices(
 	voucher_type = "Sales Invoice" if party_type == "Customer" else "Purchase Invoice"
 	account = "debit_to" if voucher_type == "Sales Invoice" else "credit_to"
 	supplier_condition = ""
+	query_values = {"party": party, "party_account": party_account}
 	if voucher_type == "Purchase Invoice":
-		supplier_condition = f"and (release_date is null or release_date <= '{nowdate()}')"
+		supplier_condition = "and (release_date is null or release_date <= %(today)s)"
+		query_values["today"] = nowdate()
 	if party_account_currency == company_currency:
 		grand_total_field = "base_grand_total"
 		rounded_total_field = "base_rounded_total"
@@ -2392,7 +2394,7 @@ def get_negative_outstanding_invoices(
 		from
 			`tab{voucher_type}`
 		where
-			{party_type} = %s and {party_account} = %s and docstatus = 1 and
+			{party_type} = %(party)s and {party_account} = %(party_account)s and docstatus = 1 and
 			outstanding_amount < 0
 			{supplier_condition}
 			{condition}
@@ -2411,7 +2413,7 @@ def get_negative_outstanding_invoices(
 				"account": account,
 			}
 		),
-		(party, party_account),
+		query_values,
 		as_dict=True,
 	)
 

--- a/erpnext/accounts/report/inactive_sales_items/inactive_sales_items.py
+++ b/erpnext/accounts/report/inactive_sales_items/inactive_sales_items.py
@@ -4,8 +4,8 @@
 
 import frappe
 from frappe import _
-from frappe.query_builder.functions import CurDate, DateDiff
-from frappe.utils import cint
+from frappe.query_builder.functions import DateDiff
+from frappe.utils import cint, nowdate
 
 
 def execute(filters=None):
@@ -104,9 +104,9 @@ def get_sales_details(filters):
 
 	date_col = parent.transaction_date if filters["based_on"] == "Sales Order" else parent.posting_date
 
-	# DateDiff is cross-database (DATEDIFF on MariaDB, date subtraction on postgres); CurDate()
-	# renders the bare CURRENT_DATE keyword. Yields the integer number of days.
-	days_since_last_order = DateDiff(CurDate(), date_col)
+	# Use the application's today (nowdate, System Settings timezone) rather than the database
+	# server's CURRENT_DATE, which may differ when the DB session timezone does not match.
+	days_since_last_order = DateDiff(nowdate(), date_col)
 
 	sales_data = (
 		frappe.qb.from_(parent)

--- a/erpnext/controllers/queries.py
+++ b/erpnext/controllers/queries.py
@@ -20,7 +20,7 @@ from frappe.query_builder.functions import (
 	Substring,
 	Sum,
 )
-from frappe.utils import nowdate, today, unique
+from frappe.utils import nowdate, unique
 from pypika import Order
 
 import erpnext
@@ -556,7 +556,7 @@ def get_batches_from_stock_ledger_entries(searchfields, txt, filters, start=0, p
 	stock_ledger_entry = frappe.qb.DocType("Stock Ledger Entry")
 	batch_table = frappe.qb.DocType("Batch")
 
-	expiry_date = filters.get("posting_date") or today()
+	expiry_date = filters.get("posting_date") or nowdate()
 
 	query = (
 		frappe.qb.from_(stock_ledger_entry)
@@ -618,7 +618,7 @@ def get_batches_from_serial_and_batch_bundle(searchfields, txt, filters, start=0
 	stock_ledger_entry = frappe.qb.DocType("Stock Ledger Entry")
 	batch_table = frappe.qb.DocType("Batch")
 
-	expiry_date = filters.get("posting_date") or today()
+	expiry_date = filters.get("posting_date") or nowdate()
 
 	bundle_query = (
 		frappe.qb.from_(bundle)
@@ -936,7 +936,7 @@ def get_batch_numbers(doctype: str, txt: str, searchfield: str, start: int, page
 		.select(batch.batch_id)
 		.where(
 			(batch.disabled == 0)
-			& (batch.expiry_date.isnull() | (batch.expiry_date >= today()))
+			& (batch.expiry_date.isnull() | (batch.expiry_date >= nowdate()))
 			& batch.name.like(f"%{txt}%")
 		)
 	)

--- a/erpnext/projects/doctype/project/project.py
+++ b/erpnext/projects/doctype/project/project.py
@@ -5,9 +5,19 @@ import frappe
 from email_reply_parser import EmailReplyParser
 from frappe import _, qb
 from frappe.model.document import Document
-from frappe.query_builder import Case, Interval
-from frappe.query_builder.functions import Count, CurDate, Date, Locate, Lower, Sum, UnixTimestamp
-from frappe.utils import add_days, flt, get_datetime, get_link_to_form, get_time, nowtime, today
+from frappe.query_builder import Case
+from frappe.query_builder.functions import Count, Date, Locate, Lower, Sum, UnixTimestamp
+from frappe.utils import (
+	add_days,
+	add_years,
+	flt,
+	get_datetime,
+	get_link_to_form,
+	get_time,
+	nowdate,
+	nowtime,
+	today,
+)
 from frappe.utils.user import is_website_user
 from pypika import Order
 
@@ -446,7 +456,7 @@ def get_timeline_data(doctype: str, name: str) -> dict[int, int]:
 		frappe.qb.from_(timesheet_detail)
 		.select(UnixTimestamp(Date(timesheet_detail.from_time)), Count("*"))
 		.where(timesheet_detail.project == name)
-		.where(timesheet_detail.from_time > CurDate() - Interval(years=1))
+		.where(timesheet_detail.from_time > add_years(nowdate(), -1))
 		.where(timesheet_detail.docstatus < 2)
 		.groupby(Date(timesheet_detail.from_time))
 		.run()

--- a/erpnext/projects/doctype/project_update/project_update.py
+++ b/erpnext/projects/doctype/project_update/project_update.py
@@ -4,7 +4,7 @@
 
 import frappe
 from frappe.model.document import Document
-from frappe.utils import add_days, today
+from frappe.utils import add_days, nowdate
 
 
 class ProjectUpdate(Document):
@@ -36,7 +36,7 @@ def daily_reminder():
 	frappe.only_for("Projects Manager")
 
 	# Same for every project this run, so check once instead of once per project.
-	holiday_today = frappe.db.exists("Holiday", {"holiday_date": today()})
+	holiday_today = frappe.db.exists("Holiday", {"holiday_date": nowdate()})
 
 	projects = frappe.get_all(
 		"Project",
@@ -63,7 +63,7 @@ def daily_reminder():
 		# both engines); report the columns that actually exist.
 		update = frappe.get_all(
 			"Project Update",
-			filters={"project": project_id, "date": add_days(today(), -1)},
+			filters={"project": project_id, "date": add_days(nowdate(), -1)},
 			fields=["name", "date", "time"],
 			as_list=True,
 		)

--- a/erpnext/selling/report/inactive_customers/inactive_customers.py
+++ b/erpnext/selling/report/inactive_customers/inactive_customers.py
@@ -5,8 +5,8 @@
 import frappe
 from frappe import _
 from frappe.query_builder import Case
-from frappe.query_builder.functions import Count, CurDate, DateDiff, Max, Sum
-from frappe.utils import cint
+from frappe.query_builder.functions import Count, DateDiff, Max, Sum
+from frappe.utils import cint, nowdate
 
 
 def execute(filters=None):
@@ -52,9 +52,9 @@ def get_sales_details(doctype):
 		date_col = sales_doctype.posting_date
 
 	last_order_date = Max(date_col)
-	# DateDiff is cross-database (DATEDIFF on MariaDB, date subtraction on postgres); CurDate()
-	# renders the bare CURRENT_DATE keyword. Yields the integer number of days.
-	days_since_last_order = DateDiff(CurDate(), last_order_date)
+	# Use the application's today (nowdate, System Settings timezone) rather than the database
+	# server's CURRENT_DATE, which may differ when the DB session timezone does not match.
+	days_since_last_order = DateDiff(nowdate(), last_order_date)
 
 	return (
 		frappe.qb.from_(customer)

--- a/erpnext/setup/doctype/sales_person/sales_person.py
+++ b/erpnext/setup/doctype/sales_person/sales_person.py
@@ -7,9 +7,8 @@ from itertools import chain
 
 import frappe
 from frappe import _
-from frappe.query_builder import Interval
-from frappe.query_builder.functions import Count, CurDate, UnixTimestamp
-from frappe.utils import flt
+from frappe.query_builder.functions import Count, UnixTimestamp
+from frappe.utils import add_years, flt, nowdate
 from frappe.utils.data import get_url_to_list
 from frappe.utils.nestedset import NestedSet, get_root_of
 
@@ -139,7 +138,7 @@ def get_timeline_data(doctype: str, name: str) -> dict[int, int]:
 			.on(transaction.name == sales_team.parent)
 			.select(UnixTimestamp(transaction[date_field]), Count("*"))
 			.where(sales_team.sales_person == name)
-			.where(transaction[date_field] > CurDate() - Interval(years=1))
+			.where(transaction[date_field] > add_years(nowdate(), -1))
 			.groupby(transaction[date_field])
 			.run()
 		)

--- a/erpnext/stock/doctype/item/item.py
+++ b/erpnext/stock/doctype/item/item.py
@@ -6,9 +6,9 @@ import frappe
 from frappe import _, bold
 from frappe.model.document import Document
 from frappe.model.naming import NamingSeries
-from frappe.query_builder import Interval
-from frappe.query_builder.functions import Count, CurDate, UnixTimestamp
+from frappe.query_builder.functions import Count, UnixTimestamp
 from frappe.utils import (
+	add_years,
 	cint,
 	cstr,
 	flt,
@@ -16,6 +16,7 @@ from frappe.utils import (
 	get_link_to_form,
 	getdate,
 	now_datetime,
+	nowdate,
 	nowtime,
 	strip,
 )
@@ -1267,7 +1268,7 @@ def get_timeline_data(doctype: str, name: str) -> dict[int, int]:
 		frappe.qb.from_(sle)
 		.select(UnixTimestamp(sle.posting_date), Count("*"))
 		.where(sle.item_code == name)
-		.where(sle.posting_date > CurDate() - Interval(years=1))
+		.where(sle.posting_date > add_years(nowdate(), -1))
 		.groupby(sle.posting_date)
 		.run()
 	)


### PR DESCRIPTION
Fixes #54707. Raw DB calendar functions evaluate using the database session
timezone, which may diverge from System Settings time_zone. Replace all
occurrences with parameterized nowdate() so date comparisons respect the
site's configured timezone.
