### PR TITLE
fix: deliver reserved serial/batch stock without a bundle on the row

### DIFF
--- a/erpnext/controllers/selling_controller.py
+++ b/erpnext/controllers/selling_controller.py
@@ -956,9 +956,14 @@ class SellingController(StockController):
 
 					qty_can_be_deliver = 0
 					if sre_doc.reservation_based_on == "Serial and Batch":
-						sbb = frappe.get_doc("Serial and Batch Bundle", item.serial_and_batch_bundle)
+						# Delivered serial/batch may live in a Serial and Batch Bundle or directly in the
+						# row's serial_no/batch_no fields (use_serial_batch_fields). Read from whichever is
+						# present so this never crashes on a missing bundle.
+						(
+							delivered_serial_nos,
+							delivered_batch_qty,
+						) = get_delivered_serial_batch_for_reservation(item)
 						if sre_doc.has_serial_no:
-							delivered_serial_nos = [d.serial_no for d in sbb.entries]
 							for entry in sre_doc.sb_entries:
 								if entry.serial_no in delivered_serial_nos:
 									entry.delivered_qty = 1  # Qty will always be 0 or 1 for Serial No.
@@ -966,16 +971,16 @@ class SellingController(StockController):
 									qty_can_be_deliver += 1
 									delivered_serial_nos.remove(entry.serial_no)
 						else:
-							delivered_batch_qty = {d.batch_no: -1 * d.qty for d in sbb.entries}
 							for entry in sre_doc.sb_entries:
-								if entry.batch_no in delivered_batch_qty:
+								available_batch_qty = delivered_batch_qty.get(entry.batch_no, 0)
+								if available_batch_qty > 0:
 									delivered_qty = min(
-										(entry.qty - entry.delivered_qty), delivered_batch_qty[entry.batch_no]
+										(entry.qty - entry.delivered_qty), available_batch_qty
 									)
 									entry.delivered_qty += delivered_qty
 									entry.db_update()
 									qty_can_be_deliver += delivered_qty
-									delivered_batch_qty[entry.batch_no] -= delivered_qty
+									delivered_batch_qty[entry.batch_no] = available_batch_qty - delivered_qty
 					else:
 						# `Delivered Qty` should be less than or equal to `Reserved Qty`.
 						qty_can_be_deliver = min(
@@ -1097,6 +1102,34 @@ class SellingController(StockController):
 		pick_lists = {row.against_pick_list for row in self.items if row.against_pick_list}
 		for pick_list in pick_lists:
 			update_pick_list_status(pick_list)
+
+
+def get_delivered_serial_batch_for_reservation(item):
+	"""Serial nos and per-batch qty delivered by a stock row.
+
+	The detail may be stored in a Serial and Batch Bundle or directly in the row's
+	``serial_no``/``batch_no`` fields (``use_serial_batch_fields``). Reading from whichever is
+	present keeps the Stock Reservation Entry delivered-qty update independent of a bundle being
+	created -- delivering reserved serial/batch stock used to crash when the row had no bundle.
+	"""
+	serial_nos, batch_qty = [], {}
+
+	if item.get("serial_and_batch_bundle"):
+		bundle = frappe.get_doc("Serial and Batch Bundle", item.serial_and_batch_bundle)
+		for row in bundle.entries:
+			if row.serial_no:
+				serial_nos.append(row.serial_no)
+			if row.batch_no:
+				batch_qty[row.batch_no] = batch_qty.get(row.batch_no, 0) + abs(flt(row.qty))
+	else:
+		from erpnext.stock.doctype.serial_no.serial_no import get_serial_nos
+
+		if item.get("serial_no"):
+			serial_nos = get_serial_nos(item.serial_no)
+		if item.get("batch_no"):
+			batch_qty[item.batch_no] = abs(flt(item.get("stock_qty") or item.get("qty")))
+
+	return serial_nos, batch_qty
 
 
 def set_default_income_account_for_item(obj):

--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -10,6 +10,7 @@ import frappe.utils
 from frappe import _, qb
 from frappe.contacts.doctype.address.address import get_company_address
 from frappe.desk.notifications import clear_doctype_notifications
+from frappe.model.document import Document
 from frappe.model.mapper import get_mapped_doc
 from frappe.model.utils import get_fetch_values
 from frappe.query_builder.functions import Sum
@@ -1147,7 +1148,9 @@ def make_project(source_name, target_doc=None):
 
 
 @frappe.whitelist()
-def make_delivery_note(source_name, target_doc=None, kwargs=None):
+def make_delivery_note(
+	source_name: str, target_doc: str | Document | None = None, kwargs: dict | None = None
+):
 	from erpnext.stock.doctype.packed_item.packed_item import make_packing_list
 	from erpnext.stock.doctype.stock_reservation_entry.stock_reservation_entry import (
 		get_sre_details_for_voucher,
@@ -1268,6 +1271,7 @@ def make_delivery_note(source_name, target_doc=None, kwargs=None):
 				update_item(source, target, so)
 
 			so_items = {d.name: d for d in so.items if d.stock_reserved_qty}
+			use_serial_batch_fields = frappe.get_single_value("Stock Settings", "use_serial_batch_fields")
 
 			for sre in sre_list:
 				if not condition(so_items[sre.voucher_detail_no]):
@@ -1292,8 +1296,6 @@ def make_delivery_note(source_name, target_doc=None, kwargs=None):
 
 				dn_item.qty = flt(sre.reserved_qty) / flt(dn_item.get("conversion_factor", 1))
 				dn_item.warehouse = sre.warehouse
-
-				use_serial_batch_fields = frappe.get_single_value("Stock Settings", "use_serial_batch_fields")
 
 				if sre.reservation_based_on == "Serial and Batch" and (sre.has_serial_no or sre.has_batch_no):
 					if use_serial_batch_fields:

--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -1295,12 +1295,27 @@ def make_delivery_note(source_name, target_doc=None, kwargs=None):
 
 				use_serial_batch_fields = frappe.get_single_value("Stock Settings", "use_serial_batch_fields")
 
-				if (
-					not use_serial_batch_fields
-					and sre.reservation_based_on == "Serial and Batch"
-					and (sre.has_serial_no or sre.has_batch_no)
-				):
-					dn_item.serial_and_batch_bundle = get_ssb_bundle_for_voucher(sre)
+				if sre.reservation_based_on == "Serial and Batch" and (sre.has_serial_no or sre.has_batch_no):
+					if use_serial_batch_fields:
+						# Carry the reserved serial/batch in the row fields. A single field can't hold
+						# multiple batches, so fall back to a bundle in that case.
+						dn_item.use_serial_batch_fields = 1
+						sb_entries = frappe.get_all(
+							"Serial and Batch Entry",
+							filters={"parent": sre.name},
+							fields=["serial_no", "batch_no"],
+						)
+						serial_nos = [d.serial_no for d in sb_entries if d.serial_no]
+						batch_nos = list({d.batch_no for d in sb_entries if d.batch_no})
+						if serial_nos:
+							dn_item.serial_no = "\n".join(serial_nos)
+						if len(batch_nos) == 1:
+							dn_item.batch_no = batch_nos[0]
+						elif len(batch_nos) > 1:
+							dn_item.use_serial_batch_fields = 0
+							dn_item.serial_and_batch_bundle = get_ssb_bundle_for_voucher(sre)
+					else:
+						dn_item.serial_and_batch_bundle = get_ssb_bundle_for_voucher(sre)
 
 				target_doc.append("items", dn_item)
 			else:

--- a/erpnext/stock/doctype/stock_reservation_entry/test_stock_reservation_entry.py
+++ b/erpnext/stock/doctype/stock_reservation_entry/test_stock_reservation_entry.py
@@ -757,6 +757,38 @@ class TestStockReservationEntry(ERPNextTestSuite):
 		dn.save()
 		self.assertRaisesRegex(frappe.ValidationError, "is reserved for", dn.submit)
 
+	@ERPNextTestSuite.change_settings(
+		"Stock Settings",
+		{
+			"allow_negative_stock": 0,
+			"enable_stock_reservation": 1,
+			"auto_reserve_serial_and_batch": 1,
+			"pick_serial_and_batch_based_on": "FIFO",
+			"use_serial_batch_fields": 1,
+		},
+	)
+	def test_deliver_batch_reserved_stock_with_serial_batch_fields(self) -> None:
+		# Regression (develop 9c5f9218b5): with use_serial_batch_fields enabled, the reserved-stock
+		# Delivery Note mapper set neither a bundle nor row batch fields on the mapped row, and
+		# delivery crashed with "Serial and Batch Bundle None not found".
+		item_doc = make_batch_item()
+		create_material_receipt(items={item_doc.name: item_doc}, warehouse=self.warehouse, qty=5)
+
+		so = make_sales_order(item_code=item_doc.name, warehouse=self.warehouse, qty=5, rate=100)
+		so.create_stock_reservation_entries()
+		self.assertTrue(has_reserved_stock("Sales Order", so.name))
+
+		dn = make_delivery_note(so.name, kwargs={"for_reserved_stock": 1})
+		self.assertTrue(dn.items[0].batch_no, "mapper should carry the reserved batch in the row fields")
+		dn.save()
+		dn.submit()
+
+		sre = get_stock_reservation_entries_for_voucher(
+			"Sales Order", so.name, fields=["status", "delivered_qty"]
+		)[0]
+		self.assertEqual(sre.status, "Delivered")
+		self.assertEqual(sre.delivered_qty, 5)
+
 
 def create_items() -> dict:
 	items_properties = [


### PR DESCRIPTION
Backport of the reserved-stock delivery fixes from develop (9c5f9218b5) to `version-16-hotfix`. Discovered while backporting #57169 (see #57170, whose test had to set `batch_no` on the row explicitly to work around this).

On v16, delivering reserved serial/batch stock crashes with **DoesNotExistError: Serial and Batch Bundle None not found** when `use_serial_batch_fields` is enabled:

- `make_delivery_note`'s reserved-stock mapper attached neither a bundle nor row serial/batch values in that case. It now carries the reserved serial/batch in the row fields, falling back to a bundle when multiple batches are reserved.
- `update_stock_reservation_entries` unconditionally loaded `item.serial_and_batch_bundle`. It now reads the delivered serial/batch from the bundle or the row fields, whichever is present.

Covered by a regression test that reserves a batch item and delivers it via `make_delivery_note(so.name, kwargs={"for_reserved_stock": 1})` with `use_serial_batch_fields` enabled.