### PR TITLE
feat(stock): automatically link portal users to their associated contact profiles for customers and suppliers

### DIFF
--- a/erpnext/buying/doctype/supplier/supplier.py
+++ b/erpnext/buying/doctype/supplier/supplier.py
@@ -16,7 +16,10 @@ from erpnext.accounts.party import (
 	validate_party_accounts,
 	validate_party_currency_before_merging,
 )
-from erpnext.controllers.website_list_for_contact import add_role_for_portal_user
+from erpnext.controllers.website_list_for_contact import (
+	add_role_for_portal_user,
+	link_portal_users_to_contacts,
+)
 from erpnext.stock.doctype.company_restriction.company_restriction import validate_allowed_companies
 from erpnext.utilities.transaction_base import TransactionBase
 
@@ -112,6 +115,7 @@ class Supplier(TransactionBase):
 	def on_update(self):
 		self.create_primary_contact()
 		self.create_primary_address()
+		link_portal_users_to_contacts(self)
 
 	def add_role_for_user(self):
 		for portal_user in self.portal_users:

--- a/erpnext/buying/doctype/supplier/test_supplier.py
+++ b/erpnext/buying/doctype/supplier/test_supplier.py
@@ -202,3 +202,24 @@ class TestSupplierPortal(ERPNextTestSuite):
 			_, suppliers = get_customers_suppliers("Purchase Order", user)
 
 			self.assertIn(supplier.name, suppliers)
+
+	def test_portal_user_contact_link(self):
+		user_email = frappe.generate_hash() + "@example.com"
+		user = frappe.new_doc("User")
+		user.email = user_email
+		user.first_name = "Test Portal Contact User"
+		user.send_welcome_email = False
+		user.insert(ignore_permissions=True)
+
+		contact = frappe.new_doc("Contact")
+		contact.first_name = "Test Portal Contact User"
+		contact.add_email(user_email, is_primary=1)
+		contact.links = []
+		contact.insert(ignore_permissions=True)
+
+		supplier = create_supplier()
+		supplier.append("portal_users", {"user": user.name})
+		supplier.save()
+
+		contact.reload()
+		self.assertTrue(contact.has_link("Supplier", supplier.name))

--- a/erpnext/controllers/website_list_for_contact.py
+++ b/erpnext/controllers/website_list_for_contact.py
@@ -7,6 +7,8 @@ import json
 import frappe
 from frappe import _
 from frappe.modules.utils import get_module_app
+from frappe.query_builder import Criterion
+from frappe.query_builder.functions import Lower
 from frappe.utils import cint, flt, has_common
 from frappe.utils.user import is_website_user
 
@@ -309,3 +311,63 @@ def add_role_for_portal_user(portal_user, role):
 
 	user_doc.add_roles(role)
 	frappe.msgprint(_("Added {1} role to user {0}.").format(frappe.bold(user_doc.name), role), alert=True)
+
+
+def link_portal_users_to_contacts(doc):
+	"""When portal users are added to Supplier/Customer, link them to the Contact profile."""
+	# a User's name is its (lowercased) email, so portal_users are already the emails
+	portal_users = {p.user for p in doc.get("portal_users") or [] if p.user}
+	if not portal_users:
+		return
+
+	before = doc.get_doc_before_save()
+	if before:
+		previous_users = {p.user for p in before.get("portal_users") or [] if p.user}
+		if portal_users == previous_users:
+			return
+
+	portal_users = list(portal_users)
+
+	contact = frappe.qb.DocType("Contact")
+	contact_email = frappe.qb.DocType("Contact Email")
+
+	query = (
+		frappe.qb.from_(contact)
+		.left_join(contact_email)
+		.on(contact_email.parent == contact.name)
+		.select(contact.name)
+		.distinct()
+	)
+
+	conditions = [
+		contact.user.isin(portal_users),
+		Lower(contact.email_id).isin(portal_users),
+		Lower(contact_email.email_id).isin(portal_users),
+	]
+
+	query = query.where(Criterion.any(conditions))
+	contacts = query.run(pluck=True)
+
+	if not contacts:
+		return
+
+	dynamic_link = frappe.qb.DocType("Dynamic Link")
+	existing_links = (
+		frappe.qb.from_(dynamic_link)
+		.select(dynamic_link.parent)
+		.where(
+			(dynamic_link.parenttype == "Contact")
+			& (dynamic_link.parent.isin(contacts))
+			& (dynamic_link.link_doctype == doc.doctype)
+			& (dynamic_link.link_name == doc.name)
+		)
+		.run(pluck=True)
+	)
+
+	contacts_to_link = [name for name in contacts if name not in existing_links]
+
+	for name in contacts_to_link:
+		contact_doc = frappe.get_doc("Contact", name)
+		if not contact_doc.has_link(doc.doctype, doc.name):
+			contact_doc.append("links", {"link_doctype": doc.doctype, "link_name": doc.name})
+			contact_doc.save(ignore_permissions=True)

--- a/erpnext/selling/doctype/customer/customer.py
+++ b/erpnext/selling/doctype/customer/customer.py
@@ -24,7 +24,10 @@ from erpnext.accounts.party import (
 	validate_party_accounts,
 	validate_party_currency_before_merging,
 )
-from erpnext.controllers.website_list_for_contact import add_role_for_portal_user
+from erpnext.controllers.website_list_for_contact import (
+	add_role_for_portal_user,
+	link_portal_users_to_contacts,
+)
 from erpnext.stock.doctype.company_restriction.company_restriction import validate_allowed_companies
 from erpnext.utilities.transaction_base import TransactionBase
 
@@ -278,6 +281,8 @@ class Customer(TransactionBase):
 			self.copy_communication()
 
 		self.update_customer_groups()
+
+		link_portal_users_to_contacts(self)
 
 	def add_role_for_user(self):
 		for portal_user in self.portal_users:

--- a/erpnext/selling/doctype/customer/test_customer.py
+++ b/erpnext/selling/doctype/customer/test_customer.py
@@ -423,6 +423,33 @@ class TestCustomer(ERPNextTestSuite):
 		customer.account_manager = None
 		self.assertIsNone(customer.get_notification_email())
 
+	def test_portal_user_contact_link(self):
+		user_email = frappe.generate_hash() + "@example.com"
+		user = frappe.new_doc("User")
+		user.email = user_email
+		user.first_name = "Test Portal Customer User"
+		user.send_welcome_email = False
+		user.insert(ignore_permissions=True)
+
+		contact = frappe.new_doc("Contact")
+		contact.first_name = "Test Portal Customer User"
+		contact.add_email(user_email, is_primary=1)
+		contact.links = []
+		contact.insert(ignore_permissions=True)
+
+		customer = frappe.get_doc(
+			{
+				"doctype": "Customer",
+				"customer_name": "Test Portal Contact Customer",
+				"customer_type": "Individual",
+			}
+		)
+		customer.append("portal_users", {"user": user.name})
+		customer.insert()
+
+		contact.reload()
+		self.assertTrue(contact.has_link("Customer", customer.name))
+
 
 def get_customer_dict(customer_name):
 	return {


### PR DESCRIPTION
**Feat:**  
When a portal user is added to a Customer or Supplier, their existing Contact isn't linked to that Customer/Supplier, so the portal user can't see the related records. This PR detects such portal users on save (matching by their user account or email) and adds the missing Contact ↔ Customer/Supplier link automatically. Existing links are skipped to avoid duplicates.

**Ref:** [#73725](https://support.frappe.io/helpdesk/tickets/73725)

**Backport Needed for v15 & v16**

no-docs