### PR TITLE
refactor:fix item property updates in POS and transactions, and add styling

### DIFF
--- a/erpnext/public/scss/point-of-sale.scss
+++ b/erpnext/public/scss/point-of-sale.scss
@@ -837,6 +837,7 @@
 		flex-direction: column;
 		padding: var(--padding-lg);
 		padding-top: var(--padding-md);
+		overflow-y: auto;
 
 		> .item-details-header {
 			display: flex;

--- a/erpnext/selling/page/point_of_sale/pos_item_details.js
+++ b/erpnext/selling/page/point_of_sale/pos_item_details.js
@@ -84,6 +84,17 @@ erpnext.PointOfSale.ItemDetails = class {
 			this.item_row = item;
 			this.currency = this.events.get_frm().doc.currency;
 
+			if (item.has_serial_no == null || item.has_batch_no == null) {
+				const r = await frappe.db.get_value("Item", item.item_code, [
+					"has_serial_no",
+					"has_batch_no",
+				]);
+				if (r && r.message) {
+					item.has_serial_no = r.message.has_serial_no;
+					item.has_batch_no = r.message.has_batch_no;
+				}
+			}
+
 			this.current_item = item;
 
 			this.render_dom(item);


### PR DESCRIPTION
**Issue:**
In ERPNext v16 POS, for items managed by Serial Number and/or Batch Number, the Batch and Serial Number selection fields are not displayed in the Item Details panel after the item is added to the cart. Because of this, we are unable to select or assign a serial/batch number during a POS transaction.

**Ref:**[#73850](https://support.frappe.io/helpdesk/tickets/73850?view=VIEW-HD+Ticket-745)