### PR TITLE
fix: batch operation batch-size flag lookups to avoid n+1 query in wo…

### DIFF
--- a/erpnext/manufacturing/doctype/work_order/services/operations.py
+++ b/erpnext/manufacturing/doctype/work_order/services/operations.py
@@ -194,29 +194,49 @@ class OperationsService:
 				op.wip_warehouse = self.doc.wip_warehouse
 
 	def _collect_bom_operations(self):
-		operations = []
+		groups = []
 		if self.doc.use_multi_level_bom:
 			bom_tree = frappe.get_doc("BOM", self.doc.bom_no).get_tree_representation()
 			for node in reversed(bom_tree.level_order_traversal()):
 				if node.is_bom:
 					qty = node.exploded_qty / node.bom_qty
-					operations.extend(self._bom_operations(node.name, qty=qty, exploded=True))
+					groups.append((self._bom_operations(node.name), qty, True))
 
 		bom_qty = frappe.get_cached_value("BOM", self.doc.bom_no, "quantity")
-		operations.extend(self._bom_operations(self.doc.bom_no, qty=bom_qty))
+		groups.append((self._bom_operations(self.doc.bom_no), bom_qty, False))
+
+		all_rows = [d for rows, qty, exploded in groups for d in rows]
+		batch_size_flags = self._get_batch_size_flags(d.operation for d in all_rows)
+
+		operations = []
+		for rows, qty, exploded in groups:
+			for d in rows:
+				self._adjust_operation_row(d, qty, exploded, batch_size_flags)
+				operations.append(d)
 		return operations
 
-	def _bom_operations(self, bom_no, qty=1, exploded=False):
-		data = frappe.get_all(
+	def _bom_operations(self, bom_no):
+		return frappe.get_all(
 			"BOM Operation", filters={"parent": bom_no}, fields=_BOM_OPERATION_FIELDS, order_by="idx"
 		)
-		for d in data:
-			self._adjust_operation_row(d, qty, exploded)
-		return data
 
-	def _adjust_operation_row(self, d, qty, exploded):
+	def _get_batch_size_flags(self, operation_names):
+		names = {name for name in operation_names if name}
+		if not names:
+			return {}
+		return dict(
+			frappe.get_all(
+				"Operation",
+				filters={"name": ["in", list(names)]},
+				fields=["name", "create_job_card_based_on_batch_size"],
+				as_list=True,
+				limit_page_length=0,
+			)
+		)
+
+	def _adjust_operation_row(self, d, qty, exploded, batch_size_flags):
 		if not d.fixed_time:
-			if frappe.get_value("Operation", d.operation, "create_job_card_based_on_batch_size"):
+			if batch_size_flags.get(d.operation):
 				qty = d.batch_size
 			d.time_in_mins = d.time_in_mins * flt(qty) if exploded else d.time_in_mins / flt(qty)
 


### PR DESCRIPTION
Description:

- _adjust_operation_row ran an uncached frappe.get_value("Operation", d.operation, "create_job_card_based_on_batch_size") for every BOM Operation row while building a Work Order's operations table. For multi-level BOMs this fires once per row across every exploded BOM node, and the same Operation (e.g. "Assembly", "Painting") commonly repeats across BOMs, so the same data was being re-queried repeatedly instead of reused.

- This batches the lookup: all BOM Operation rows are now gathered first, the distinct Operation names across them are collected, and their create_job_card_based_on_batch_size flags are fetched in a single frappe.get_all(... "name": ["in", ...]) query before any row is adjusted — replacing N queries with one.

- No public behavior or method signatures changed; _bom_operations and _adjust_operation_row are private to OperationsService and not used elsewhere.