### PR TITLE
fix: fall back to the company in-transit warehouse

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry.js
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.js
@@ -943,11 +943,16 @@ frappe.ui.form.on("Stock Entry", {
 			!frm.doc.to_warehouse &&
 			frm.doc.from_warehouse
 		) {
-			let dt = frm.doc.from_warehouse ? "Warehouse" : "Company";
-			let dn = frm.doc.from_warehouse ? frm.doc.from_warehouse : frm.doc.company;
-			frappe.db.get_value(dt, dn, "default_in_transit_warehouse", (r) => {
+			// prefer the source warehouse's in-transit default, then the company's
+			frappe.db.get_value("Warehouse", frm.doc.from_warehouse, "default_in_transit_warehouse", (r) => {
 				if (r.default_in_transit_warehouse) {
 					frm.set_value("to_warehouse", r.default_in_transit_warehouse);
+				} else if (frm.doc.company) {
+					frappe.db.get_value("Company", frm.doc.company, "default_in_transit_warehouse", (res) => {
+						if (res.default_in_transit_warehouse) {
+							frm.set_value("to_warehouse", res.default_in_transit_warehouse);
+						}
+					});
 				}
 			});
 		}


### PR DESCRIPTION
## Problem

`set_transit_warehouse` (Stock Entry, Add to Transit) chooses between the source warehouse's and the company's `default_in_transit_warehouse` with a ternary on `from_warehouse` — inside a guard that already requires `from_warehouse`. The Company branch is unreachable: when the source warehouse has no in-transit default, the target stays empty and the company-level default is silently ignored.

## Fix

Try the source warehouse's default first, then fall back to the company's.

## Documentation

no-docs