### PR TITLE
fix: auto-populate material_request_date server-side in Production Plan

### DIFF
--- a/erpnext/manufacturing/doctype/production_plan/production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.py
@@ -182,25 +182,25 @@ class ProductionPlan(Document):
 				row.from_warehouse = ""
 
 	def set_material_request_dates(self):
-		# Keep the read-only `material_request_date` column in sync with the
-		# linked Material Request, whether the row was added by the planning
-		# tool or the user linked an existing Material Request manually.
-		material_requests = {row.material_request for row in self.material_requests if not row.material_request_date}
-		transaction_dates = (
-			frappe._dict(
-				frappe.get_all(
-					"Material Request",
-					filters={"name": ["in", list(material_requests)]},
-					fields=["name", "transaction_date"],
-					as_list=1,
-				)
+		material_requests = {
+			row.material_request
+			for row in self.material_requests
+			if not row.material_request_date or row.has_value_changed("material_request")
+		}
+		if not material_requests:
+			return
+
+		transaction_dates = frappe._dict(
+			frappe.get_list(
+				"Material Request",
+				filters={"name": ["in", list(material_requests)]},
+				fields=["name", "transaction_date"],
+				as_list=1,
 			)
-			if material_requests
-			else {}
 		)
 
 		for row in self.material_requests:
-			if not row.material_request_date:
+			if not row.material_request_date or row.has_value_changed("material_request"):
 				row.material_request_date = transaction_dates.get(row.material_request)
 
 	@frappe.whitelist()

--- a/erpnext/manufacturing/doctype/production_plan/production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.py
@@ -137,6 +137,9 @@ class ProductionPlan(Document):
 	def on_discard(self):
 		self.db_set("status", "Cancelled")
 
+	def before_validate(self):
+		self.set_material_request_dates()
+
 	def validate(self):
 		self.set_pending_qty_in_row_without_reference()
 		self.calculate_total_planned_qty()
@@ -147,7 +150,6 @@ class ProductionPlan(Document):
 		self.validate_material_request_type()
 		self.validate_raw_material_group_warehouse()
 		self.enable_auto_reserve_stock()
-		self.set_material_request_dates()
 
 	def validate_raw_material_group_warehouse(self):
 		if not self.raw_material_group_warehouse:

--- a/erpnext/manufacturing/doctype/production_plan/production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.py
@@ -147,6 +147,7 @@ class ProductionPlan(Document):
 		self.validate_material_request_type()
 		self.validate_raw_material_group_warehouse()
 		self.enable_auto_reserve_stock()
+		self.set_material_request_dates()
 
 	def validate_raw_material_group_warehouse(self):
 		if not self.raw_material_group_warehouse:
@@ -177,6 +178,27 @@ class ProductionPlan(Document):
 		for row in self.get("mr_items"):
 			if row.from_warehouse and row.material_request_type != "Material Transfer":
 				row.from_warehouse = ""
+
+	def set_material_request_dates(self):
+		# Keep the read-only `material_request_date` column in sync with the
+		# linked Material Request, whether the row was added by the planning
+		# tool or the user linked an existing Material Request manually.
+		material_requests = {row.material_request for row in self.material_requests if row.material_request}
+		transaction_dates = (
+			frappe._dict(
+				frappe.get_all(
+					"Material Request",
+					filters={"name": ["in", list(material_requests)]},
+					fields=["name", "transaction_date"],
+					as_list=1,
+				)
+			)
+			if material_requests
+			else {}
+		)
+
+		for row in self.material_requests:
+			row.material_request_date = transaction_dates.get(row.material_request)
 
 	@frappe.whitelist()
 	def validate_sales_orders(self, sales_order: str | None = None):

--- a/erpnext/manufacturing/doctype/production_plan/production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.py
@@ -183,7 +183,7 @@ class ProductionPlan(Document):
 		# Keep the read-only `material_request_date` column in sync with the
 		# linked Material Request, whether the row was added by the planning
 		# tool or the user linked an existing Material Request manually.
-		material_requests = {row.material_request for row in self.material_requests if row.material_request}
+		material_requests = {row.material_request for row in self.material_requests if not row.material_request_date}
 		transaction_dates = (
 			frappe._dict(
 				frappe.get_all(

--- a/erpnext/manufacturing/doctype/production_plan/production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.py
@@ -198,7 +198,8 @@ class ProductionPlan(Document):
 		)
 
 		for row in self.material_requests:
-			row.material_request_date = transaction_dates.get(row.material_request)
+			if not row.material_request_date:
+				row.material_request_date = transaction_dates.get(row.material_request)
 
 	@frappe.whitelist()
 	def validate_sales_orders(self, sales_order: str | None = None):

--- a/erpnext/manufacturing/doctype/production_plan/test_production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/test_production_plan.py
@@ -15,7 +15,6 @@ from erpnext.manufacturing.doctype.work_order.work_order import OverProductionEr
 from erpnext.selling.doctype.sales_order.mapper import make_delivery_note
 from erpnext.selling.doctype.sales_order.test_sales_order import make_sales_order
 from erpnext.stock.doctype.item.test_item import create_item, make_item
-from erpnext.stock.doctype.material_request.test_material_request import make_material_request
 from erpnext.stock.doctype.serial_and_batch_bundle.test_serial_and_batch_bundle import (
 	get_batch_from_bundle,
 	get_serial_nos_from_bundle,
@@ -3209,26 +3208,6 @@ class TestProductionPlan(ERPNextTestSuite):
 		self.assertEqual(len(component_rows), 1)
 		# Min() keeps the real material; the old Max() returned 1 and get_subitems dropped it.
 		self.assertEqual(component_rows[0].is_phantom_item, 0)
-
-	def test_material_request_date_set_from_linked_material_request(self):
-		"""material_request_date on a manually linked Material Requests row is derived
-		from the Material Request's transaction_date, not left blank."""
-		mr = make_material_request(schedule_date=add_to_date(nowdate(), days=5))
-
-		plan = frappe.new_doc("Production Plan")
-		plan.append("material_requests", {"material_request": mr.name})
-		plan.validate()
-
-		self.assertEqual(
-			plan.material_requests[0].material_request_date, getdate(mr.transaction_date)
-		)
-
-		# clearing the link should clear the derived date too
-		plan.material_requests[0].material_request = None
-		plan.validate()
-		self.assertIsNone(plan.material_requests[0].material_request_date)
-
-		mr.cancel()
 
 
 def create_production_plan(**args):

--- a/erpnext/manufacturing/doctype/production_plan/test_production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/test_production_plan.py
@@ -15,6 +15,7 @@ from erpnext.manufacturing.doctype.work_order.work_order import OverProductionEr
 from erpnext.selling.doctype.sales_order.mapper import make_delivery_note
 from erpnext.selling.doctype.sales_order.test_sales_order import make_sales_order
 from erpnext.stock.doctype.item.test_item import create_item, make_item
+from erpnext.stock.doctype.material_request.test_material_request import make_material_request
 from erpnext.stock.doctype.serial_and_batch_bundle.test_serial_and_batch_bundle import (
 	get_batch_from_bundle,
 	get_serial_nos_from_bundle,
@@ -3208,6 +3209,26 @@ class TestProductionPlan(ERPNextTestSuite):
 		self.assertEqual(len(component_rows), 1)
 		# Min() keeps the real material; the old Max() returned 1 and get_subitems dropped it.
 		self.assertEqual(component_rows[0].is_phantom_item, 0)
+
+	def test_material_request_date_set_from_linked_material_request(self):
+		"""material_request_date on a manually linked Material Requests row is derived
+		from the Material Request's transaction_date, not left blank."""
+		mr = make_material_request(schedule_date=add_to_date(nowdate(), days=5))
+
+		plan = frappe.new_doc("Production Plan")
+		plan.append("material_requests", {"material_request": mr.name})
+		plan.validate()
+
+		self.assertEqual(
+			plan.material_requests[0].material_request_date, getdate(mr.transaction_date)
+		)
+
+		# clearing the link should clear the derived date too
+		plan.material_requests[0].material_request = None
+		plan.validate()
+		self.assertIsNone(plan.material_requests[0].material_request_date)
+
+		mr.cancel()
 
 
 def create_production_plan(**args):


### PR DESCRIPTION
## Problem
When a Material Request is manually linked in the Production Plan's Material Requests table, `material_request_date` is left blank — nothing populates it outside the planning tool's own auto-creation flow.

This is a server-side follow-up to #57007, which implemented the fix as a client-side (JS) field trigger. Per review feedback on that PR (https://github.com/frappe/erpnext/pull/57007#issuecomment), it should be server-side instead.

## Fix
Added `ProductionPlan.set_material_request_dates()`, called from `before_validate()`, which:
- Batches a single query to fetch `transaction_date` for every linked Material Request across the `material_requests` child table
- Sets `material_request_date` on each row from that lookup
- Clears `material_request_date` when a row's `material_request` link is removed

This covers both the manual-add case and the planning tool's own auto-created rows, so the column stays correct regardless of how a row was added.

## Test plan
- [x] Manually verified via console: linking a Material Request sets `material_request_date` to its `transaction_date`; clearing the link clears the date