### PR TITLE
fix: validate buying price list on material request and update item rates on change

### DIFF
--- a/erpnext/stock/doctype/material_request/material_request.js
+++ b/erpnext/stock/doctype/material_request/material_request.js
@@ -100,7 +100,10 @@ frappe.ui.form.on("Material Request", {
 
 		erpnext.accounts.dimensions.setup_dimension_filters(frm, frm.doctype);
 		if (!frm.doc.buying_price_list) {
-			frm.doc.buying_price_list = frappe.defaults.get_default("buying_price_list");
+			const buying_price_list = frappe.defaults.get_default("buying_price_list");
+			if (frappe.has_permission("Price List", "read", buying_price_list)) {
+				frm.set_value("buying_price_list", buying_price_list);
+			}
 		}
 	},
 
@@ -287,9 +290,7 @@ frappe.ui.form.on("Material Request", {
 					from_warehouse: item.from_warehouse,
 					warehouse: item.warehouse,
 					doctype: frm.doc.doctype,
-					buying_price_list: frm.doc.buying_price_list
-						? frm.doc.buying_price_list
-						: frappe.defaults.get_default("buying_price_list"),
+					buying_price_list: frm.doc.buying_price_list,
 					currency: frappe.defaults.get_default("Currency"),
 					name: frm.doc.name,
 					qty: item.qty || 1,

--- a/erpnext/stock/doctype/material_request/material_request.py
+++ b/erpnext/stock/doctype/material_request/material_request.py
@@ -202,7 +202,7 @@ class MaterialRequest(BuyingController):
 				self.buying_price_list = buying_price_list
 
 	def on_update(self):
-		if self.buying_price_list and self.has_value_changed("buying_price_list"):
+		if not self.is_new() and self.buying_price_list and self.has_value_changed("buying_price_list"):
 			self.update_item_rates()
 
 	def update_item_rates(self):
@@ -218,7 +218,8 @@ class MaterialRequest(BuyingController):
 						"transaction_date": self.transaction_date,
 						"qty": item.qty,
 						"stock_uom": item.stock_uom,
-						"price_not_uom_dependent": price_not_uom_dependent,
+						"conversion_factor": item.conversion_factor,
+						"price_list_uom_dependant": price_not_uom_dependent,
 					}
 				),
 				item.item_code,

--- a/erpnext/stock/doctype/material_request/material_request.py
+++ b/erpnext/stock/doctype/material_request/material_request.py
@@ -18,6 +18,7 @@ from frappe.utils import cint, flt, get_datetime, get_link_to_form, getdate, new
 from erpnext.buying.utils import check_on_hold_or_closed_status, validate_for_items
 from erpnext.controllers.buying_controller import BuyingController
 from erpnext.manufacturing.doctype.work_order.work_order import get_item_details
+from erpnext.stock.get_item_details import get_price_list_rate_for
 from erpnext.stock.stock_balance import get_indented_qty, update_bin_qty
 
 from .mapper import (
@@ -192,8 +193,43 @@ class MaterialRequest(BuyingController):
 
 		self.validate_pp_qty()
 
+		if self.buying_price_list and not frappe.get_value("Price List", self.buying_price_list, "buying"):
+			self.buying_price_list = None
+
 		if not self.buying_price_list:
-			self.buying_price_list = frappe.defaults.get_defaults().buying_price_list
+			buying_price_list = frappe.defaults.get_defaults().buying_price_list
+			if frappe.has_permission("Price List", "read", buying_price_list):
+				self.buying_price_list = buying_price_list
+
+	def on_update(self):
+		if self.buying_price_list and self.has_value_changed("buying_price_list"):
+			self.update_item_rates()
+
+	def update_item_rates(self):
+		price_not_uom_dependent = frappe.get_value(
+			"Price List", self.buying_price_list, "price_not_uom_dependent"
+		)
+		for item in self.items:
+			rate = get_price_list_rate_for(
+				frappe._dict(
+					{
+						"price_list": self.buying_price_list,
+						"uom": item.uom,
+						"transaction_date": self.transaction_date,
+						"qty": item.qty,
+						"stock_uom": item.stock_uom,
+						"price_not_uom_dependent": price_not_uom_dependent,
+					}
+				),
+				item.item_code,
+			)
+			item.db_set({"rate": flt(rate), "amount": flt(flt(rate) * item.qty, item.precision("amount"))})
+		frappe.msgprint(
+			_("Item rates have been updated based on the selected Buying Price List {0}").format(
+				self.buying_price_list
+			),
+			alert=True,
+		)
 
 	def validate_pp_qty(self):
 		items_from_pp = [item for item in self.items if item.material_request_plan_item]

--- a/erpnext/stock/doctype/material_request/material_request.py
+++ b/erpnext/stock/doctype/material_request/material_request.py
@@ -225,7 +225,7 @@ class MaterialRequest(BuyingController):
 				item.item_code,
 			)
 			if rate is not None:
-				item.db_set({"rate": flt(rate), "amount": flt(flt(rate) * item.qty, item.precision("amount"))})
+				item.db_set({"rate": rate, "amount": flt(rate * item.qty, item.precision("amount"))})
 
 		frappe.msgprint(
 			_("Item rates have been updated based on the selected Buying Price List {0}").format(

--- a/erpnext/stock/doctype/material_request/material_request.py
+++ b/erpnext/stock/doctype/material_request/material_request.py
@@ -224,7 +224,9 @@ class MaterialRequest(BuyingController):
 				),
 				item.item_code,
 			)
-			item.db_set({"rate": flt(rate), "amount": flt(flt(rate) * item.qty, item.precision("amount"))})
+			if rate is not None:
+				item.db_set({"rate": flt(rate), "amount": flt(flt(rate) * item.qty, item.precision("amount"))})
+
 		frappe.msgprint(
 			_("Item rates have been updated based on the selected Buying Price List {0}").format(
 				self.buying_price_list


### PR DESCRIPTION
- Default `buying_price_list` only when the user has read permission on that Price List (client and server).
- Clear the field on validate if the selected Price List is not a buying one.
- When `buying_price_list` changes, refresh item rates and amounts from the new list.