### PR TITLE
fix: force-delete repost data file during cleanup

### DIFF
--- a/erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.py
+++ b/erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.py
@@ -242,7 +242,7 @@ class RepostItemValuation(Document):
 	def clear_attachment(self):
 		if attachments := get_attachments(self.doctype, self.name):
 			attachment = attachments[0]
-			frappe.delete_doc("File", attachment.name, ignore_permissions=True)
+			frappe.delete_doc("File", attachment.name, ignore_permissions=True, force=True)
 
 		if self.reposting_data_file:
 			self.db_set("reposting_data_file", None)

--- a/erpnext/stock/doctype/repost_item_valuation/test_repost_item_valuation.py
+++ b/erpnext/stock/doctype/repost_item_valuation/test_repost_item_valuation.py
@@ -670,6 +670,34 @@ class TestRepostItemValuation(ERPNextTestSuite, StockTestMixin):
 					)
 				)
 
+	def test_clear_attachment_skips_referenced_data_file(self):
+		riv = frappe.get_doc(
+			{
+				"doctype": "Repost Item Valuation",
+				"based_on": "Item and Warehouse",
+				"company": "_Test Company",
+				"item_code": "_Test Item",
+				"warehouse": "_Test Warehouse - _TC",
+				"posting_date": today(),
+			}
+		).insert(ignore_permissions=True)
+
+		attached = frappe.get_doc(
+			{
+				"doctype": "File",
+				"file_name": "repost_data.json.gz",
+				"content": "test",
+				"attached_to_doctype": riv.doctype,
+				"attached_to_name": riv.name,
+			}
+		).insert(ignore_permissions=True)
+		riv.db_set("reposting_data_file", attached.file_url)
+
+		riv.clear_attachment()
+
+		self.assertFalse(frappe.db.exists("File", attached.name))
+		self.assertIsNone(frappe.db.get_value("Repost Item Valuation", riv.name, "reposting_data_file"))
+
 	@ERPNextTestSuite.change_settings(
 		"Stock Reposting Settings",
 		{"item_based_reposting": 1, "enable_parallel_reposting": 1, "no_of_parallel_reposting": 2},


### PR DESCRIPTION
## Summary

Companion to https://github.com/frappe/frappe/pull/40812.

That PR adds a guard in `File.on_trash` to prevent deleting a `File` that is still referenced by an Attach field. `RepostItemValuation.clear_attachment()` deletes the `File` before clearing the `reposting_data_file` field, so the new guard causes the deletion to fail.

## Changes

- Pass `force=True` when deleting the `File` in `clear_attachment()`, matching the existing `remove_attached_file()` implementation in the same file.

## Notes

This PR should be merged together with https://github.com/frappe/frappe/pull/40812.