### PR TITLE
fix: exclude transferred_qty from work order item to pick list item m…

### DIFF
--- a/erpnext/manufacturing/doctype/work_order/mapper.py
+++ b/erpnext/manufacturing/doctype/work_order/mapper.py
@@ -488,6 +488,7 @@ def _pick_list_mapping(postprocess):
 		"Work Order": {"doctype": "Pick List", "validation": {"docstatus": ["=", 1]}},
 		"Work Order Item": {
 			"doctype": "Pick List Item",
+			"field_no_map": ["transferred_qty"],
 			"postprocess": postprocess,
 			"condition": lambda doc: abs(doc.transferred_qty) < abs(doc.required_qty),
 		},


### PR DESCRIPTION
Issue: Work Order is not able to produce more quantity once it has already produced some partial quantity earlier.

Fixes: #57236
Related: #56596, #56670

Description:

When a Work Order is transferring material via Pick List, and production is done in multiple batches, the Work Order stops allowing further production after the first batch — even though there is remaining planned quantity and enough raw material has been transferred for it.

Steps to Reproduce:
1. Create a Work Order with a large quantity (e.g. 100144), with "Transfer Material Against" set to Work Order.
2. Create a Pick List for a partial quantity (e.g. 15000), submit it, and create & submit the Stock Entry from it.
3. Finish the Work Order for that same 15000 quantity — this works fin
4. Create a second Pick List for the remaining quantity (e.g. 55000), submit it, and create & submit the Stock Entry from it.
5. Try to Finish the Work Order again for the remaining quantity.

Expected: The Work Order should allow finishing the remaining ~55000 units, since the material has been transferred and plenty of planned quantity remains.

Actual: The system shows "Max qty to produce is 0" (or a much lower value than expected), blocking further production even though transfer and planned quantity both support it.

Backport needed for v16.