### PR TITLE
fix: block journal entry against a sold or scrapped asset

### DIFF
--- a/erpnext/accounts/doctype/journal_entry/journal_entry.py
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.py
@@ -174,7 +174,10 @@ class JournalEntry(AccountsController):
 		self.validate_credit_debit_note()
 		self.validate_empty_accounts_table()
 		self.validate_inter_company_accounts()
-		AssetService(self).validate_depr_account_and_depr_entry_voucher_type()
+		asset_service = AssetService(self)
+		asset_service.validate_depr_account_and_depr_entry_voucher_type()
+		if not frappe.flags.is_reverse_depr_entry:
+			asset_service.validate_asset_not_disposed()
 		self.validate_company_in_accounting_dimension()
 		self.validate_advance_accounts()
 

--- a/erpnext/accounts/doctype/journal_entry/services/asset_service.py
+++ b/erpnext/accounts/doctype/journal_entry/services/asset_service.py
@@ -35,6 +35,19 @@ class AssetService:
 				if frappe.get_cached_value("Account", d.account, "root_type") != "Expense":
 					frappe.throw(_("Account {0} should be of type Expense").format(d.account))
 
+	def validate_asset_not_disposed(self) -> None:
+		for d in self.doc.get("accounts"):
+			if d.reference_type == "Asset" and d.reference_name:
+				asset_status = frappe.get_cached_value("Asset", d.reference_name, "status")
+				if asset_status in ("Sold", "Scrapped"):
+					frappe.throw(
+						_("Row #{0}: Asset {1} is already {2} and cannot be used in a Journal Entry").format(
+							d.idx,
+							frappe.utils.get_link_to_form("Asset", d.reference_name),
+							asset_status,
+						)
+					)
+
 	def has_asset_adjustment_entry(self) -> None:
 		"""Block cancellation while a submitted Asset Value Adjustment links to this entry."""
 		if self.doc.flags.get("via_asset_value_adjustment"):

--- a/erpnext/accounts/doctype/journal_entry/test_journal_entry.py
+++ b/erpnext/accounts/doctype/journal_entry/test_journal_entry.py
@@ -832,6 +832,39 @@ class TestJournalEntry(ERPNextTestSuite):
 		self.assertFalse(jv.accounts[1].reference_type)
 		self.assertFalse(jv.accounts[1].reference_name)
 
+	def test_journal_entry_against_sold_or_scrapped_asset_is_rejected(self):
+		from erpnext.assets.doctype.asset.test_asset import create_asset
+
+		asset = create_asset(calculate_depreciation=0, submit=1)
+
+		def asset_journal_entry():
+			jv = frappe.new_doc("Journal Entry")
+			jv.posting_date = nowdate()
+			jv.company = asset.company
+			jv.set(
+				"accounts",
+				[
+					{
+						"account": "_Test Fixed Asset - _TC",
+						"credit_in_account_currency": 1000,
+						"reference_type": "Asset",
+						"reference_name": asset.name,
+					},
+					{
+						"account": "_Test Cash - _TC",
+						"debit_in_account_currency": 1000,
+					},
+				],
+			)
+			return jv
+
+		for bad_status in ("Sold", "Scrapped"):
+			with self.subTest(f"referencing a {bad_status} asset is rejected"):
+				frappe.db.set_value("Asset", asset.name, "status", bad_status)
+				self.assertRaises(frappe.ValidationError, asset_journal_entry().insert)
+
+		frappe.db.set_value("Asset", asset.name, "status", "Submitted")
+
 	def test_get_payment_entry_against_order_builds_advance_je(self):
 		"""Characterize the mapper: an advance Bank Entry JE is built against an unbilled order."""
 		from erpnext.accounts.doctype.journal_entry.mapper import get_payment_entry_against_order


### PR DESCRIPTION
**Issue:**
Journal Entry does not validate the status of a referenced Asset. A user can create and submit a Journal Entry (e.g. a manual depreciation, write-off, or adjustment entry) against an Asset row (reference_type = "Asset") even after that Asset has already been marked Sold or Scrapped, silently posting GL entries against a disposed asset.

**Steps to Reproduce:**
  1. Create and submit an Asset.
  2. Dispose the asset — either scrap it or sell it via a Sales Invoice with is_fixed_asset checked — so its status becomes  Scrapped or Sold.
  3. Create a Journal Entry against the asset

