### PR TITLE
fix: use account currency in Bank Reconciliation Statement print/PDF

### DIFF
--- a/erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.html
+++ b/erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.html
@@ -28,16 +28,16 @@
 						<br>{%= __("Clearance Date") %}: {%= frappe.datetime.str_to_user(data[i]["clearance_date"]) %}
 					{% } %}
 				</td>
-				<td style="text-align: right">{%= format_currency(data[i]["debit"]) %}</td>
-				<td style="text-align: right">{%= format_currency(data[i]["credit"]) %}</td>
+				<td style="text-align: right">{%= format_currency(data[i]["debit"], data[i]["account_currency"]) %}</td>
+				<td style="text-align: right">{%= format_currency(data[i]["credit"], data[i]["account_currency"]) %}</td>
 			</tr>
 			{% } else { %}
 			<tr>
 				<td></td>
 				<td></td>
 				<td>{%= data[i]["payment_entry"] %}</td>
-				<td style="text-align: right">{%= format_currency(data[i]["debit"]) %}</td>
-				<td style="text-align: right">{%= format_currency(data[i]["credit"]) %}</td>
+				<td style="text-align: right">{%= format_currency(data[i]["debit"], data[i]["account_currency"]) %}</td>
+				<td style="text-align: right">{%= format_currency(data[i]["credit"], data[i]["account_currency"]) %}</td>
 			</tr>
 			{% } %}
 		{% } %}


### PR DESCRIPTION
## Problem

When running the **Bank Reconciliation Statement** report for a bank account whose currency is USD, the on-screen report correctly shows amounts prefixed with \`\$\`, but the **Print / PDF** output renders every amount with the company/system default currency symbol (e.g. \`₹\` INR) instead.

### Steps to reproduce
1. Open the Bank Reconciliation Statement report.
2. Select a Bank Account whose currency is USD.
3. On screen, amounts are prefixed with \`\$\` (correct).
4. Click **Print** — amounts render with \`₹\` (INR), the default currency, instead of \`\$\`.

## Root cause

The report has a custom print template (\`bank_reconciliation_statement.html\`) that formats the debit/credit amounts with \`format_currency(data[i]["debit"])\` **without passing a currency**. With no currency argument, \`format_currency\` falls back to the system/company default currency.

The on-screen grid is unaffected because its columns declare \`"fieldtype": "Currency", "options": "account_currency"\`, so each amount is formatted using the row's own currency.

## Fix

Pass each row's \`account_currency\` to \`format_currency()\` in the print template (both the normal and separator row branches). The data already carries \`account_currency\` on every row, so the printed/PDF output now matches the on-screen currency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)