### PR TITLE
fix: root record of tree doctypes cannot be saved

### DIFF
--- a/erpnext/setup/doctype/customer_group/customer_group.py
+++ b/erpnext/setup/doctype/customer_group/customer_group.py
@@ -35,7 +35,9 @@ class CustomerGroup(NestedSet):
 
 	def validate(self):
 		if not self.parent_customer_group:
-			self.parent_customer_group = get_root_of("Customer Group")
+			root = get_root_of("Customer Group")
+			if root and root != self.name:
+				self.parent_customer_group = root
 		self.validate_currency_for_receivable_and_advance_account()
 
 	def validate_currency_for_receivable_and_advance_account(self):

--- a/erpnext/setup/doctype/department/department.py
+++ b/erpnext/setup/doctype/department/department.py
@@ -40,7 +40,7 @@ class Department(NestedSet):
 	def validate(self):
 		if not self.parent_department:
 			root = get_root_of("Department")
-			if root:
+			if root and root != self.name:
 				self.parent_department = root
 
 	def before_rename(self, old, new, merge=False):

--- a/erpnext/setup/doctype/item_group/item_group.py
+++ b/erpnext/setup/doctype/item_group/item_group.py
@@ -4,7 +4,7 @@
 
 import frappe
 from frappe import _
-from frappe.utils.nestedset import NestedSet
+from frappe.utils.nestedset import NestedSet, get_root_of
 
 
 class ItemGroup(NestedSet):
@@ -32,8 +32,9 @@ class ItemGroup(NestedSet):
 
 	def validate(self):
 		if not self.parent_item_group and not frappe.in_test:
-			if frappe.db.exists("Item Group", _("All Item Groups")):
-				self.parent_item_group = _("All Item Groups")
+			root = get_root_of("Item Group")
+			if root and root != self.name:
+				self.parent_item_group = root
 		self.validate_item_group_defaults()
 		self.check_item_tax()
 

--- a/erpnext/setup/doctype/sales_person/sales_person.py
+++ b/erpnext/setup/doctype/sales_person/sales_person.py
@@ -47,7 +47,9 @@ class SalesPerson(NestedSet):
 			self.validate_sales_person()
 
 		if not self.parent_sales_person:
-			self.parent_sales_person = get_root_of("Sales Person")
+			root = get_root_of("Sales Person")
+			if root and root != self.name:
+				self.parent_sales_person = root
 
 		for d in self.get("targets") or []:
 			if not flt(d.target_qty) and not flt(d.target_amount):

--- a/erpnext/setup/doctype/supplier_group/supplier_group.py
+++ b/erpnext/setup/doctype/supplier_group/supplier_group.py
@@ -32,7 +32,9 @@ class SupplierGroup(NestedSet):
 
 	def validate(self):
 		if not self.parent_supplier_group:
-			self.parent_supplier_group = get_root_of("Supplier Group")
+			root = get_root_of("Supplier Group")
+			if root and root != self.name:
+				self.parent_supplier_group = root
 		self.validate_currency_for_payable_and_advance_account()
 
 	def validate_currency_for_payable_and_advance_account(self):

--- a/erpnext/setup/doctype/territory/territory.py
+++ b/erpnext/setup/doctype/territory/territory.py
@@ -33,7 +33,9 @@ class Territory(NestedSet):
 
 	def validate(self):
 		if not self.parent_territory:
-			self.parent_territory = get_root_of("Territory")
+			root = get_root_of("Territory")
+			if root and root != self.name:
+				self.parent_territory = root
 
 		for d in self.get("targets") or []:
 			if not flt(d.target_qty) and not flt(d.target_amount):

--- a/erpnext/setup/doctype/territory/test_territory.py
+++ b/erpnext/setup/doctype/territory/test_territory.py
@@ -1,3 +1,20 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: GNU General Public License v3. See license.txt
 
+import frappe
+from frappe.utils.nestedset import get_root_of
+
+from erpnext.tests.utils import ERPNextTestSuite
+
+
+class TestTerritory(ERPNextTestSuite):
+	def test_root_is_not_set_as_its_own_parent(self):
+		root = frappe.get_doc("Territory", get_root_of("Territory"))
+		root.save()
+
+		self.assertFalse(root.parent_territory)
+
+	def test_territory_without_parent_is_placed_under_root(self):
+		territory = frappe.get_doc({"doctype": "Territory", "territory_name": "Western Europe"}).insert()
+
+		self.assertEqual(territory.parent_territory, get_root_of("Territory"))


### PR DESCRIPTION
## Description

Saving the root record of a tree doctype fails with:

```
NestedSetRecursionError: Item cannot be added to its own descendants.
```

The tree controllers assign a parent when the parent field is empty by defaulting to the tree root. When the record being saved is itself the root, this results in the record being assigned as its own parent. During `update_nsm`, the parent change is detected and `validate_loop` correctly rejects it because a node cannot be its own ancestor.

This affects the root records of the following tree doctypes:

- Sales Person
- Customer Group
- Supplier Group
- Territory
- Item Group
- Department

The issue occurs both when editing the root record from Desk and when the setup wizard re-runs `make_records` on an already populated site.

## Fix

Skip the automatic parent assignment when the document being saved is the root node.

Additionally, `Item Group` previously identified its root using the translated string `_("All Item Groups")`, which does not match the stored document name on non-English sites. It now uses `get_root_of`, matching the implementation used by the other tree doctypes and making the root detection consistent across all six controllers.

## Notes

`Department` still has a separate issue: its root record has no `company` value, so saving it continues to fail because of the mandatory field validation. That unrelated issue is intentionally left out of this change.

Closes frappe/frappe#41154.