### PR TITLE
Feat/enhance holiday list handling accross modules

### DIFF
--- a/erpnext/maintenance/doctype/maintenance_schedule/maintenance_schedule.py
+++ b/erpnext/maintenance/doctype/maintenance_schedule/maintenance_schedule.py
@@ -181,7 +181,7 @@ class MaintenanceSchedule(TransactionBase):
 
 		employee = frappe.db.get_value("Sales Person", sales_person, "employee")
 		if employee:
-			holiday_list = get_holiday_list_for_employee(employee)
+			holiday_list = get_holiday_list_for_employee(employee, as_on=schedule_date)
 		else:
 			holiday_list = frappe.get_cached_value("Company", self.company, "default_holiday_list")
 

--- a/erpnext/maintenance/doctype/maintenance_schedule/test_maintenance_schedule.py
+++ b/erpnext/maintenance/doctype/maintenance_schedule/test_maintenance_schedule.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
 
+from unittest.mock import patch
+
 import frappe
 from frappe.utils import format_date
 from frappe.utils.data import add_days, formatdate, today
@@ -212,6 +214,22 @@ class TestMaintenanceSchedule(ERPNextTestSuite):
 		non_holiday = add_days(today(), 7)
 		unchanged = ms.validate_schedule_date_for_holiday_list(getdate(non_holiday), sp.name)
 		self.assertEqual(getdate(unchanged), getdate(non_holiday))
+
+	def test_schedule_holiday_list_uses_schedule_date(self):
+		ms = make_maintenance_schedule()
+		with (
+			patch(
+				"erpnext.maintenance.doctype.maintenance_schedule.maintenance_schedule.frappe.db.get_value",
+				return_value="_Test Employee",
+			),
+			patch(
+				"erpnext.maintenance.doctype.maintenance_schedule.maintenance_schedule.get_holiday_list_for_employee",
+				return_value=None,
+			) as get_holiday_list,
+		):
+			ms.validate_schedule_date_for_holiday_list("2026-01-01", "Sales Team")
+
+		get_holiday_list.assert_called_once_with("_Test Employee", as_on="2026-01-01")
 
 
 def make_serial_item_with_serial(self, item_code):

--- a/erpnext/setup/doctype/employee/employee.py
+++ b/erpnext/setup/doctype/employee/employee.py
@@ -404,9 +404,9 @@ def is_holiday(employee, date=None, raise_exception=True, only_non_weekly=False,
 	        :param only_non_weekly: Check only non-weekly holidays, default is False
 	"""
 
-	holiday_list = get_holiday_list_for_employee(employee, raise_exception)
 	if not date:
 		date = today()
+	holiday_list = get_holiday_list_for_employee(employee, raise_exception, as_on=date)
 
 	if not holiday_list:
 		return False

--- a/erpnext/setup/doctype/employee/test_employee.py
+++ b/erpnext/setup/doctype/employee/test_employee.py
@@ -1,17 +1,27 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: GNU General Public License v3. See license.txt
 
+from unittest.mock import patch
+
 import frappe
 import frappe.utils
 from frappe.query_builder import Criterion
 
 import erpnext
 from erpnext.accounts.utils import build_qb_match_conditions
-from erpnext.setup.doctype.employee.employee import InactiveEmployeeStatusError
+from erpnext.setup.doctype.employee.employee import InactiveEmployeeStatusError, is_holiday
 from erpnext.tests.utils import ERPNextTestSuite
 
 
 class TestEmployee(ERPNextTestSuite):
+	def test_is_holiday_resolves_holiday_list_for_requested_date(self):
+		with patch(
+			"erpnext.setup.doctype.employee.employee.get_holiday_list_for_employee", return_value=None
+		) as get_holiday_list:
+			is_holiday("_Test Employee", "2026-01-01", raise_exception=False)
+
+		get_holiday_list.assert_called_once_with("_Test Employee", False, as_on="2026-01-01")
+
 	def test_employee_status_left(self):
 		employee1 = make_employee("test_employee_1@company.com", company="_Test Company")
 		employee2 = make_employee("test_employee_2@company.com", company="_Test Company")


### PR DESCRIPTION
fixes https://github.com/frappe/hrms/issues/4676
depends on https://github.com/frappe/hrms/pull/4717
Changes:
- Modified get_holiday_list_for_employee to use shift holiday list, employee holiday list, company holiday list, and the default holiday lists accordingly in this precedence.