### PR TITLE
refactor: clearer labels for the overdue billing control

### DIFF
--- a/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
+++ b/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
@@ -278,17 +278,17 @@
   },
   {
    "default": "0",
-   "description": "Block submitting a new Sales Invoice when the customer's overdue amount exceeds the Overdue Billing Threshold set on the customer.",
+   "description": "Block a new Sales Invoice when the customer's overdue amount exceeds the Overdue Limit set on the customer.",
    "fieldname": "enable_overdue_billing_threshold",
    "fieldtype": "Check",
-   "label": "Enable Overdue Billing Threshold"
+   "label": "Restrict Customer Over Billing"
   },
   {
    "depends_on": "eval:doc.enable_overdue_billing_threshold",
-   "description": "Users with this role can still submit invoices for customers over their overdue billing threshold.",
+   "description": "Users with this role can still submit invoices for customers who have crossed their Overdue Limit.",
    "fieldname": "role_allowed_to_bypass_overdue_billing",
    "fieldtype": "Link",
-   "label": "Role allowed to bypass overdue billing limit",
+   "label": "Role Allowed to Bypass Over Billing Restriction",
    "options": "Role"
   },
   {

--- a/erpnext/selling/doctype/customer/customer.json
+++ b/erpnext/selling/doctype/customer/customer.json
@@ -471,7 +471,7 @@
    "report_hide": 1
   },
   {
-   "description": "Transactions are blocked when the outstanding balance exceeds the credit limit. When the overdue billing setting is enabled, new invoices are also blocked when the customer's overdue amount exceeds the overdue billing threshold.",
+   "description": "Transactions are blocked when the outstanding balance exceeds the credit limit. When Restrict Customer Over Billing is enabled, new invoices are also blocked when the customer's overdue amount exceeds the Overdue Limit.",
    "fieldname": "credit_limits",
    "fieldtype": "Table",
    "label": "Credit & Overdue Limits",

--- a/erpnext/selling/doctype/customer/customer.py
+++ b/erpnext/selling/doctype/customer/customer.py
@@ -602,19 +602,17 @@ def check_overdue_billing_threshold(customer: str, company: str) -> None:
 
 	company_currency = frappe.get_cached_value("Company", company, "default_currency")
 	frappe.throw(
-		_(
-			"Customer {0} has an overdue billing limit. Overdue amount {1} exceeds the allowed threshold {2}."
-		).format(
+		_("Overdue Limit crossed for customer {0}. Overdue amount {1} exceeds the allowed limit {2}.").format(
 			customer,
 			fmt_money(overdue_amount, currency=company_currency),
 			fmt_money(threshold, currency=company_currency),
 		),
-		title=_("Overdue Billing Limit Crossed"),
+		title=_("Overdue Limit Crossed"),
 	)
 
 
 def get_overdue_billing_threshold(customer: str, company: str) -> float:
-	"""Threshold set on the customer, falling back to its customer group."""
+	"""Overdue limit set on the customer, falling back to its customer group."""
 	threshold = frappe.db.get_value(
 		"Customer Credit Limit",
 		{"parent": customer, "parenttype": "Customer", "company": company},
@@ -652,7 +650,7 @@ def get_outstanding_invoices_for_customer(customer: str, company: str) -> list[f
 	gl_entry = frappe.qb.DocType("GL Entry")
 	sales_invoice = frappe.qb.DocType("Sales Invoice")
 
-	# debit - credit is always booked in company currency, so this is comparable to the threshold
+	# debit - credit is always booked in company currency, so this is comparable to the overdue limit
 	outstanding = Sum(gl_entry.debit) - Sum(gl_entry.credit)
 
 	return (

--- a/erpnext/selling/doctype/customer_credit_limit/customer_credit_limit.json
+++ b/erpnext/selling/doctype/customer_credit_limit/customer_credit_limit.json
@@ -21,12 +21,12 @@
   },
   {
    "columns": 3,
-   "description": "New Sales Invoices are blocked when the customer's overdue amount exceeds this. Requires 'Enable Overdue Billing Threshold' in Accounts Settings.",
+   "description": "New Sales Invoices are blocked when the customer's overdue amount exceeds this. Requires 'Restrict Customer Over Billing' in Accounts Settings.",
    "fieldname": "overdue_billing_threshold",
    "fieldtype": "Currency",
    "hidden": 1,
    "in_list_view": 1,
-   "label": "Overdue Billing Threshold"
+   "label": "Overdue Limit"
   },
   {
    "fieldname": "column_break_2",


### PR DESCRIPTION
## What

Follow-up to #57230 (merged). Clearer, consistent wording for the overdue billing control. User-facing text only, no field or behaviour changes.

| Location | Before | After |
|---|---|---|
| Accounts Settings toggle | "Enable Overdue Billing Threshold" | **"Restrict Customer Over Billing"** |
| Bypass role | "Role allowed to bypass overdue billing limit" | **"Role Allowed to Bypass Over Billing Restriction"** |
| Customer Credit Limit field | "Overdue Billing Threshold" | **"Overdue Limit"** |
| Block message | "...has an overdue billing limit... exceeds the allowed threshold..." | **"Overdue Limit crossed for customer {0}... exceeds the allowed limit {2}."** |
| Dialog title | "Overdue Billing Limit Crossed" | **"Overdue Limit Crossed"** |

Descriptions were rewritten to match, and the word "threshold" is dropped from all user-facing text. The stored fieldnames (`overdue_billing_threshold`, `enable_overdue_billing_threshold`) are unchanged, so this is label/copy only.

## How to test

Accounts Settings → Credit Limits tab now shows **Restrict Customer Over Billing**; the customer's Credit & Overdue Limits table shows the **Overdue Limit** column. Blocking a submit shows the **Overdue Limit Crossed** message.
