### PR TITLE
fix(stock): typerrror in stock balance ageing report

### DIFF
--- a/erpnext/stock/report/stock_ageing/stock_ageing.py
+++ b/erpnext/stock/report/stock_ageing/stock_ageing.py
@@ -750,13 +750,20 @@ class FIFOSlots:
 
 		while qty_to_pop:
 			slot = fifo_queue[index] if fifo_queue else [0, None, 0]
-			slot_qty = flt(slot[FIFO_QTY_INDEX])
-			slot_value = flt(slot[FIFO_VALUE_INDEX])
+			qty_idx = BATCH_SLOT_QTY_INDEX if is_batch_slot(slot) else FIFO_QTY_INDEX
+			date_idx = BATCH_SLOT_DATE_INDEX if is_batch_slot(slot) else FIFO_DATE_INDEX
+			val_idx = BATCH_SLOT_VALUE_INDEX if is_batch_slot(slot) else FIFO_VALUE_INDEX
+
+			slot_qty = flt(slot[qty_idx])
+			slot_value = flt(slot[val_idx])
 
 			if 0 < slot_qty <= qty_to_pop:
 				qty_to_pop -= slot_qty
 				stock_value -= slot_value
-				self.transferred_item_details[transfer_key].append(fifo_queue.pop(index))
+				popped_slot = fifo_queue.pop(index)
+				self.transferred_item_details[transfer_key].append(
+					[slot_qty, popped_slot[date_idx], slot_value]
+				)
 			elif not fifo_queue:
 				fifo_queue.append([-(qty_to_pop), row.posting_date, -(stock_value)])
 				self.transferred_item_details[transfer_key].append(
@@ -765,11 +772,9 @@ class FIFOSlots:
 				qty_to_pop = 0
 				stock_value = 0
 			else:
-				slot[FIFO_QTY_INDEX] = slot_qty - qty_to_pop
-				slot[FIFO_VALUE_INDEX] = slot_value - stock_value
-				self.transferred_item_details[transfer_key].append(
-					[qty_to_pop, slot[FIFO_DATE_INDEX], stock_value]
-				)
+				slot[qty_idx] = slot_qty - qty_to_pop
+				slot[val_idx] = slot_value - stock_value
+				self.transferred_item_details[transfer_key].append([qty_to_pop, slot[date_idx], stock_value])
 				qty_to_pop = 0
 				stock_value = 0
 

--- a/erpnext/stock/report/stock_balance/stock_balance.py
+++ b/erpnext/stock/report/stock_balance/stock_balance.py
@@ -175,6 +175,7 @@ class StockBalanceReport:
 				item_table.item_group,
 				item_table.stock_uom,
 				item_table.item_name,
+				item_table.has_batch_no,
 			)
 			.where((sle.docstatus < 2) & (sle.is_cancelled == 0))
 			.orderby(sle.posting_datetime)

--- a/erpnext/stock/report/stock_balance/test_stock_balance.py
+++ b/erpnext/stock/report/stock_balance/test_stock_balance.py
@@ -260,3 +260,67 @@ class TestStockBalance(ERPNextTestSuite):
 			stock_ageing_data["fifo_queue"],
 			[[3.0, "2021-12-01", 30.0], [2.0, "2021-12-05", 20.0]],
 		)
+
+	def test_stock_balance_ageing_with_batch_slot_transfer(self):
+		item_code = "TEST-RCA-BATCH-ITEM-TEST"
+		frappe.delete_doc("Item", item_code, force=1, ignore_missing=1)
+		make_item(
+			item_code, {"has_batch_no": 1, "create_new_batch": 1, "is_stock_item": 1, "val_method": "FIFO"}
+		)
+
+		batch_id = "BATCH-RCA-TEST-001"
+		frappe.delete_doc("Batch", batch_id, force=1, ignore_missing=1)
+		frappe.get_doc(
+			{
+				"doctype": "Batch",
+				"batch_id": batch_id,
+				"item": item_code,
+				"item_code": item_code,
+				"use_batchwise_valuation": 1,
+			}
+		).insert()
+
+		# SLE 1: inward batch slot
+		make_stock_entry(
+			item_code=item_code,
+			qty=10.0,
+			rate=10.0,
+			to_warehouse=self.test_warehouse,
+			batch_no=batch_id,
+			posting_date="2025-01-02",
+			posting_time="12:00:00",
+		)
+
+		# SLE 2 & 3: transfer within the same warehouse (missing batch)
+		make_stock_entry(
+			item_code=item_code,
+			qty=3.0,
+			rate=10.0,
+			from_warehouse=self.test_warehouse,
+			to_warehouse=self.test_warehouse,
+			posting_date="2025-01-03",
+			posting_time="12:00:00",
+		)
+
+		filters = _dict(
+			{
+				"company": "_Test Company",
+				"from_date": "2025-01-01",
+				"to_date": "2025-01-05",
+				"item_code": [item_code],
+				"warehouse": [self.test_warehouse],
+				"show_stock_ageing_data": 1,
+				"valuation_field_type": "Currency",
+			}
+		)
+
+		columns, result = execute(filters)
+		self.assertEqual(len(result), 1)
+
+		# Assert specific queue values to prevent regression of stock value calculations
+		fifo_queue = result[0].get("fifo_queue")
+		self.assertEqual(len(fifo_queue), 2)
+		self.assertAlmostEqual(fifo_queue[0][0], 7.0)
+		self.assertAlmostEqual(fifo_queue[0][2], 70.0)
+		self.assertAlmostEqual(fifo_queue[1][0], 3.0)
+		self.assertAlmostEqual(fifo_queue[1][2], 30.0)


### PR DESCRIPTION
**Issue:**
## fix: TypeError in Stock Balance ageing report                                                                                  
  
  ### Cause of the Issue
  
  The stock ageing report uses two different list structures to track stock:
  
  • Standard items: [quantity, date, value] (length 3)
  • Batch items: [batch_no, valuation_flag, quantity, date, value] (length 5)
  
  When an outward entry of a batch item was posted without specifying a batch number, the report incorrectly processed it using standard item logic. Because it assumed a standard length-3 structure, it read the wrong index for the date (index 1 which is actually the integer valuation flag 1 or 0 for batch items). This propagated a corrupted slot with the date set to the integer 1.  When the report subsequently loaded this queue and tried to sort it, it crashed because Python cannot compare the integer 1 with a proper datetime.date object.

**Ref:** [#73572](https://support.frappe.io/helpdesk/tickets/73572)

**Before:**
<img width="1280" height="653" alt="image" src="https://github.com/user-attachments/assets/7a303c80-c8b0-4976-9689-2b23dcf6c0d8" />

**After:**
<img width="1280" height="653" alt="image" src="https://github.com/user-attachments/assets/12761c93-3a56-4121-9329-d633aa636abb" />


**Backport Needed for v15 & v16**