### PR TITLE
fix: apply default accounting dimensions reliably on new documents

### DIFF
--- a/erpnext/public/js/utils/dimension_tree_filter.js
+++ b/erpnext/public/js/utils/dimension_tree_filter.js
@@ -22,6 +22,7 @@ erpnext.accounts.dimensions = {
 				});
 				me.default_dimensions = r.message[1];
 				me.setup_filters(frm, doctype);
+				me.update_dimension(frm, doctype);
 			},
 		});
 	},

--- a/erpnext/selling/doctype/sales_order/sales_order.js
+++ b/erpnext/selling/doctype/sales_order/sales_order.js
@@ -589,6 +589,11 @@ erpnext.selling.SalesOrderController = class SalesOrderController extends erpnex
 		super.onload(doc, dt, dn);
 	}
 
+	company() {
+		super.company();
+		erpnext.accounts.dimensions.update_dimension(this.frm, this.frm.doctype);
+	}
+
 	refresh(doc, dt, dn) {
 		var me = this;
 		super.refresh();


### PR DESCRIPTION
Default accounting dimensions weren't populated on new Sales Orders (never called `update_dimension`) and were inconsistent elsewhere due to a timing race with the async dimension fetch.

- `dimension_tree_filter.js`: apply defaults from the fetch callback.
- `sales_order.js`: add `company()` override to re-apply on company change.