### PR TITLE
fix: show create payment entries as an inner button on row selection

### DIFF
--- a/erpnext/accounts/report/accounts_payable/accounts_payable.js
+++ b/erpnext/accounts/report/accounts_payable/accounts_payable.js
@@ -177,17 +177,25 @@ frappe.query_reports["Accounts Payable"] = {
 		return Object.assign(options, {
 			checkboxColumn: true,
 			events: {
-				onCheckRow: () => erpnext.accounts.toggle_create_pe_primary_action(frappe.query_report),
+				onCheckRow: () => toggle_create_pe_button(frappe.query_report),
 			},
 		});
 	},
 
 	after_refresh: function (report) {
 		report.datatable?.rowmanager?.checkAll(false);
-		report.page.clear_primary_action();
+		toggle_create_pe_button(report);
 	},
 
 	onload: function (report) {
+		if (frappe.model.can_create("Payment Entry")) {
+			report.create_pe_btn = report.page
+				.add_inner_button(__("Create Payment Entries"), function () {
+					create_payment_entries_from_payable_report(report);
+				})
+				.toggle(false);
+		}
+
 		report.page.add_inner_button(__("Accounts Payable Summary"), function () {
 			var filters = report.get_values();
 			frappe.set_route("query-report", "Accounts Payable Summary", { company: filters.company });
@@ -199,25 +207,17 @@ frappe.query_reports["Accounts Payable"] = {
 	},
 };
 
-frappe.provide("erpnext.accounts");
-
-erpnext.accounts.toggle_create_pe_primary_action = function (report) {
-	if (!report || !report.datatable || !frappe.model.can_create("Payment Entry")) return;
+function toggle_create_pe_button(report) {
+	if (!report || !report.create_pe_btn || !report.datatable) return;
 
 	const has_purchase_invoice = report.datatable.rowmanager
 		.getCheckedRows()
 		.some((i) => report.datatable.datamanager.data[i]?.voucher_type === "Purchase Invoice");
 
-	if (has_purchase_invoice) {
-		report.page.set_primary_action(__("Create Payment Entries"), () =>
-			erpnext.accounts.create_payment_entries_from_payable_report(report)
-		);
-	} else {
-		report.page.clear_primary_action();
-	}
-};
+	report.create_pe_btn.toggle(has_purchase_invoice);
+}
 
-erpnext.accounts.create_payment_entries_from_payable_report = function (report) {
+function create_payment_entries_from_payable_report(report) {
 	const datatable = report.datatable;
 	if (!datatable) return;
 
@@ -340,7 +340,7 @@ erpnext.accounts.create_payment_entries_from_payable_report = function (report) 
 		},
 	});
 	dialog.show();
-};
+}
 
 erpnext.utils.add_dimensions("Accounts Payable", 10);
 


### PR DESCRIPTION
### Problem

The **Create Payment Entries** action on the Accounts Payable report was placed in the page's **primary-action slot**. That slot is shared with the framework: when a report becomes a **prepared report** , core puts its **"Generate New Report"** button in the same slot. The Toggle/clear logic would then clobber that button, breaking prepared-report generation.

### Fix

Moved the action to **inner button** instead.

Ref #56747