### PR TITLE
fix: safety stock and MOQ over-ordering in Production Plan raw materials

### DIFF
--- a/erpnext/manufacturing/doctype/material_request_plan_item/material_request_plan_item.json
+++ b/erpnext/manufacturing/doctype/material_request_plan_item/material_request_plan_item.json
@@ -1,6 +1,6 @@
 {
  "actions": [],
- "creation": "2017-12-01 12:12:55.048691",
+ "creation": "2026-07-21 17:16:38.891235",
  "doctype": "DocType",
  "editable_grid": 1,
  "engine": "InnoDB",
@@ -22,6 +22,7 @@
   "projected_qty",
   "column_break_wack",
   "quantity",
+  "actual_required_qty",
   "stock_reserved_qty",
   "item_details",
   "schedule_date",
@@ -79,12 +80,22 @@
   },
   {
    "columns": 3,
+   "description": "Quantity that will be used to create Material Requests.",
    "fieldname": "quantity",
    "fieldtype": "Float",
    "in_list_view": 1,
    "label": "Required Qty",
    "no_copy": 1,
-   "reqd": 1
+   "read_only": 1,
+   "reqd": 1,
+   "show_description_on_click": 1
+  },
+  {
+   "fieldname": "actual_required_qty",
+   "fieldtype": "Float",
+   "label": "Actual Required Qty",
+   "no_copy": 1,
+   "read_only": 1
   },
   {
    "columns": 2,
@@ -266,7 +277,7 @@
  "grid_page_length": 50,
  "istable": 1,
  "links": [],
- "modified": "2025-10-30 17:01:25.996352",
+ "modified": "2026-07-21 17:44:42.095315",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "Material Request Plan Item",

--- a/erpnext/manufacturing/doctype/material_request_plan_item/material_request_plan_item.py
+++ b/erpnext/manufacturing/doctype/material_request_plan_item/material_request_plan_item.py
@@ -15,6 +15,7 @@ class MaterialRequestPlanItem(Document):
 		from frappe.types import DF
 
 		actual_qty: DF.Float
+		actual_required_qty: DF.Float
 		conversion_factor: DF.Float
 		description: DF.TextEditor | None
 		from_bom: DF.Link | None

--- a/erpnext/manufacturing/doctype/production_plan/services/material_request.py
+++ b/erpnext/manufacturing/doctype/production_plan/services/material_request.py
@@ -632,7 +632,7 @@ def _transfer_from_locations(item, locations, new_mr_items, required_qty):
 		new_dict.update(
 			{
 				"quantity": quantity,
-				"actual_required_qty": quantity,
+				"actual_required_qty": min(quantity, flt(new_dict.get("required_bom_qty"))),
 				"material_request_type": "Material Transfer",
 				"uom": new_dict.get("stock_uom"),  # internal transfer should be in stock UOM
 				"from_warehouse": d.get("warehouse"),
@@ -650,7 +650,9 @@ def _add_remaining_purchase_request(item, new_mr_items, required_qty, consider_m
 	if flt(required_qty, precision) <= 0:
 		return
 
-	item["actual_required_qty"] = required_qty / item.get("conversion_factor")
+	item["actual_required_qty"] = min(required_qty, flt(item.get("required_bom_qty"))) / item.get(
+		"conversion_factor"
+	)
 
 	if consider_minimum_order_qty:
 		required_qty = max(required_qty, flt(item.get("min_order_qty")))

--- a/erpnext/manufacturing/doctype/production_plan/services/material_request.py
+++ b/erpnext/manufacturing/doctype/production_plan/services/material_request.py
@@ -491,7 +491,6 @@ def get_material_request_items(
 	required_qty, actual_required_qty = _required_qty_for_mr(
 		doc, row, ignore_existing_ordered_qty, warehouse, bin_dict, consumed_qty, include_safety_stock
 	)
-	required_qty = _adjust_required_qty_for_uom(row, required_qty)
 	item_group_defaults = get_item_group_defaults(row.item_code, company)
 	conversion_factor = _mr_purchase_conversion_factor(row)
 	return _material_request_item_row(
@@ -513,12 +512,14 @@ def _required_qty_for_mr(
 	qty = flt(row.get("qty"))
 
 	if not ignore_existing_ordered_qty or bin_dict.get("projected_qty", 0) < 0:
-		return _apply_minimum_order_qty(doc, row, qty + safety_stock), qty
+		required_qty = _apply_minimum_order_qty(doc, row, qty + safety_stock)
+		return _adjust_required_qty_for_uom(row, required_qty), qty
 
 	key = (row.get("item_code"), warehouse)
 	available_qty = flt(bin_dict.get("projected_qty", 0)) - consumed_qty[key]
 	actual_required_qty = max(0, qty - available_qty)
 	required_qty = _apply_minimum_order_qty(doc, row, max(0, qty - (available_qty - safety_stock)))
+	required_qty = _adjust_required_qty_for_uom(row, required_qty)
 	consumed_qty[key] += qty - required_qty
 
 	return required_qty, actual_required_qty

--- a/erpnext/manufacturing/doctype/production_plan/services/material_request.py
+++ b/erpnext/manufacturing/doctype/production_plan/services/material_request.py
@@ -488,35 +488,49 @@ def get_material_request_items(
 	bin_dict,
 	consumed_qty,
 ):
-	required_qty = _required_qty_for_mr(
-		doc, row, ignore_existing_ordered_qty, warehouse, bin_dict, consumed_qty
+	required_qty, actual_required_qty = _required_qty_for_mr(
+		doc, row, ignore_existing_ordered_qty, warehouse, bin_dict, consumed_qty, include_safety_stock
 	)
-	required_qty = _adjust_required_qty_for_uom(row, required_qty, include_safety_stock)
+	required_qty = _adjust_required_qty_for_uom(row, required_qty)
 	item_group_defaults = get_item_group_defaults(row.item_code, company)
 	conversion_factor = _mr_purchase_conversion_factor(row)
 	return _material_request_item_row(
-		row, sales_order, target_warehouse, bin_dict, required_qty, conversion_factor, item_group_defaults
+		row,
+		sales_order,
+		target_warehouse,
+		bin_dict,
+		required_qty,
+		actual_required_qty,
+		conversion_factor,
+		item_group_defaults,
 	)
 
 
-def _required_qty_for_mr(doc, row, ignore_existing_ordered_qty, warehouse, bin_dict, consumed_qty):
-	if not ignore_existing_ordered_qty or bin_dict.get("projected_qty", 0) < 0:
-		required_qty = flt(row.get("qty"))
-	else:
-		key = (row.get("item_code"), warehouse)
-		available_qty = flt(bin_dict.get("projected_qty", 0)) - consumed_qty[key]
-		if available_qty > 0:
-			required_qty = max(0, flt(row.get("qty")) - available_qty)
-			consumed_qty[key] += min(flt(row.get("qty")), available_qty)
-		else:
-			required_qty = flt(row.get("qty"))
+def _required_qty_for_mr(
+	doc, row, ignore_existing_ordered_qty, warehouse, bin_dict, consumed_qty, include_safety_stock
+):
+	safety_stock = flt(row["safety_stock"]) if include_safety_stock else 0
+	qty = flt(row.get("qty"))
 
+	if not ignore_existing_ordered_qty or bin_dict.get("projected_qty", 0) < 0:
+		return _apply_minimum_order_qty(doc, row, qty + safety_stock), qty
+
+	key = (row.get("item_code"), warehouse)
+	available_qty = flt(bin_dict.get("projected_qty", 0)) - consumed_qty[key]
+	actual_required_qty = max(0, qty - available_qty)
+	required_qty = _apply_minimum_order_qty(doc, row, max(0, qty - (available_qty - safety_stock)))
+	consumed_qty[key] += qty - required_qty
+
+	return required_qty, actual_required_qty
+
+
+def _apply_minimum_order_qty(doc, row, required_qty):
 	if doc.get("consider_minimum_order_qty") and 0 < required_qty < row["min_order_qty"]:
-		required_qty = row["min_order_qty"]
+		return row["min_order_qty"]
 	return required_qty
 
 
-def _adjust_required_qty_for_uom(row, required_qty, include_safety_stock):
+def _adjust_required_qty_for_uom(row, required_qty):
 	if not row["purchase_uom"]:
 		row["purchase_uom"] = row["stock_uom"]
 
@@ -531,8 +545,6 @@ def _adjust_required_qty_for_uom(row, required_qty, include_safety_stock):
 
 	if frappe.db.get_value("UOM", row["purchase_uom"], "must_be_whole_number"):
 		required_qty = ceil(required_qty)
-	if include_safety_stock:
-		required_qty += flt(row["safety_stock"])
 	return required_qty
 
 
@@ -548,7 +560,14 @@ def _mr_purchase_conversion_factor(row):
 
 
 def _material_request_item_row(
-	row, sales_order, warehouse, bin_dict, required_qty, conversion_factor, item_group_defaults
+	row,
+	sales_order,
+	warehouse,
+	bin_dict,
+	required_qty,
+	actual_required_qty,
+	conversion_factor,
+	item_group_defaults,
 ):
 	warehouse = (
 		warehouse
@@ -560,6 +579,7 @@ def _material_request_item_row(
 		"item_code": row.item_code,
 		"item_name": row.item_name,
 		"quantity": required_qty / conversion_factor,
+		"actual_required_qty": actual_required_qty / conversion_factor,
 		"conversion_factor": conversion_factor,
 		"required_bom_qty": row.get("qty"),
 		"stock_uom": row.get("stock_uom"),
@@ -612,6 +632,7 @@ def _transfer_from_locations(item, locations, new_mr_items, required_qty):
 		new_dict.update(
 			{
 				"quantity": quantity,
+				"actual_required_qty": quantity,
 				"material_request_type": "Material Transfer",
 				"uom": new_dict.get("stock_uom"),  # internal transfer should be in stock UOM
 				"from_warehouse": d.get("warehouse"),
@@ -628,6 +649,8 @@ def _add_remaining_purchase_request(item, new_mr_items, required_qty, consider_m
 	precision = frappe.get_precision("Material Request Plan Item", "quantity")
 	if flt(required_qty, precision) <= 0:
 		return
+
+	item["actual_required_qty"] = required_qty / item.get("conversion_factor")
 
 	if consider_minimum_order_qty:
 		required_qty = max(required_qty, flt(item.get("min_order_qty")))

--- a/erpnext/manufacturing/doctype/production_plan/services/reservation.py
+++ b/erpnext/manufacturing/doctype/production_plan/services/reservation.py
@@ -3,7 +3,6 @@
 
 """Stock reservation for Production Plan (extracted from production_plan.py)."""
 
-
 import frappe
 from frappe import _
 from frappe.model.document import Document
@@ -49,7 +48,7 @@ def _production_plan_reserved_qty(item_code, warehouse, non_completed_production
 	table = frappe.qb.DocType("Production Plan")
 	child = frappe.qb.DocType("Material Request Plan Item")
 	qty = (
-		Case().when(child.quantity == 0, child.required_bom_qty).else_(child.quantity)
+		Case().when(child.actual_required_qty == 0, child.required_bom_qty).else_(child.actual_required_qty)
 		* child.conversion_factor
 	)
 	query = (

--- a/erpnext/manufacturing/doctype/production_plan/services/reservation.py
+++ b/erpnext/manufacturing/doctype/production_plan/services/reservation.py
@@ -47,10 +47,8 @@ def get_reserved_qty_for_production_plan(item_code, warehouse):
 def _production_plan_reserved_qty(item_code, warehouse, non_completed_production_plans):
 	table = frappe.qb.DocType("Production Plan")
 	child = frappe.qb.DocType("Material Request Plan Item")
-	qty = (
-		Case().when(child.actual_required_qty == 0, child.required_bom_qty).else_(child.actual_required_qty)
-		* child.conversion_factor
-	)
+	reserved_qty = IfNull(child.actual_required_qty, child.quantity)
+	qty = Case().when(reserved_qty == 0, child.required_bom_qty).else_(reserved_qty) * child.conversion_factor
 	query = (
 		frappe.qb.from_(table)
 		.inner_join(child)

--- a/erpnext/manufacturing/doctype/production_plan/services/sub_assembly.py
+++ b/erpnext/manufacturing/doctype/production_plan/services/sub_assembly.py
@@ -82,7 +82,7 @@ class SubAssemblyService:
 			frappe.throw(_("Row #{0}: Please select the BOM No in Assembly Items").format(row.idx))
 
 	def _warn_sufficient_sub_assembly(self):
-		label = self.meta.get_field("skip_available_sub_assembly_item").label
+		label = self.doc.meta.get_field("skip_available_sub_assembly_item").label
 		message = (
 			_(
 				"As there are sufficient Sub Assembly Items, Work Order is not required for Warehouse {0}."

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -501,3 +501,4 @@ erpnext.patches.v16_0.crm_settings_handle_allowed_users_for_frappe_crm
 erpnext.patches.v16_0.access_control_for_project_users
 erpnext.patches.v16_0.enable_book_stock_expense_gl_entries
 execute:frappe.db.set_single_value("Stock Settings", "use_inline_serial_batch_editor", 0)
+erpnext.patches.v16_0.backfill_mr_plan_item_actual_required_qty

--- a/erpnext/patches/v16_0/backfill_mr_plan_item_actual_required_qty.py
+++ b/erpnext/patches/v16_0/backfill_mr_plan_item_actual_required_qty.py
@@ -1,0 +1,14 @@
+import frappe
+
+
+def execute():
+	plans = frappe.get_all("Production Plan", filters={"docstatus": 1}, pluck="name")
+	if not plans:
+		return
+
+	child = frappe.qb.DocType("Material Request Plan Item")
+	(
+		frappe.qb.update(child)
+		.set(child.actual_required_qty, child.quantity)
+		.where((child.quantity != 0) & (child.parent.isin(plans)))
+	).run()

--- a/erpnext/patches/v16_0/backfill_mr_plan_item_actual_required_qty.py
+++ b/erpnext/patches/v16_0/backfill_mr_plan_item_actual_required_qty.py
@@ -2,13 +2,5 @@ import frappe
 
 
 def execute():
-	plans = frappe.get_all("Production Plan", filters={"docstatus": 1}, pluck="name")
-	if not plans:
-		return
-
 	child = frappe.qb.DocType("Material Request Plan Item")
-	(
-		frappe.qb.update(child)
-		.set(child.actual_required_qty, child.quantity)
-		.where((child.quantity != 0) & (child.parent.isin(plans)))
-	).run()
+	frappe.qb.update(child).set(child.actual_required_qty, child.quantity).run()


### PR DESCRIPTION
- Safety stock is now a floor reserved out of projected qty instead of a flat per-row addition, so duplicate rows for the same item + warehouse no longer each re-add it
- Each row credits its over-order (MOQ bump / safety padding) back to availability, so later rows for the same item + warehouse consume the surplus instead of re-ordering
- New read-only `actual_required_qty` field on Material Request Plan Item holds the shortage before safety stock / MOQ; `quantity` (Required Qty) is now read-only since it is fully derived
- `get_reserved_qty_for_production_plan` reserves `actual_required_qty` instead of the inflated `quantity`; a patch backfills the field on submitted plans so existing reservations are unchanged
- Also fixes an `AttributeError` in the sufficient-sub-assembly message (`self.meta` -> `self.doc.meta` after the services extraction)