### PR TITLE
fix: fetch customer currency when creating sales order/quotation from…

### DIFF
--- a/erpnext/manufacturing/doctype/blanket_order/blanket_order.py
+++ b/erpnext/manufacturing/doctype/blanket_order/blanket_order.py
@@ -159,8 +159,15 @@ def make_order(source_name: str):
 		},
 	)
 
-	if target_doc.doctype == "Purchase Order":
-		target_doc.set_missing_values()
+	target_doc.set_missing_values()
+
+	# blanket order rate is always in the company currency (Blanket Order has no
+	# currency of its own); convert it to the target document's currency
+	conversion_rate = flt(target_doc.get("conversion_rate")) or 1.0
+	if conversion_rate != 1.0:
+		for item in target_doc.items:
+			item.rate = flt(item.blanket_order_rate) / conversion_rate
+		target_doc.calculate_taxes_and_totals()
 
 	return target_doc
 


### PR DESCRIPTION
Issue: The Blanket Order Doctype is limited only to INR. The Customer is Export, unable to create the Sales Order from BO.

Fixes: #57291

Actual behaviour (bug):
When creating a Sales Order or Quotation from a Blanket Order via the "Create" button, the resulting document always showed the company's default currency (INR), regardless of the customer's actual currency. For export customers configured with a different currency (e.g., USD), this caused a currency mismatch, and the Sales Order threw a validation error and couldn't be saved.

Expected behaviour:
The Sales Order/Quotation created from a Blanket Order should automatically use the customer's configured currency (fetched via the customer's default currency/price list), the same way it works when creating a Sales Order normally by selecting a customer directly.


Backport Needed For v16 and V15