### PR TITLE
fix: seed cancelled voucher replay from before its posting datetime (v15)

### DIFF
--- a/erpnext/stock/doctype/stock_entry/test_stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/test_stock_entry.py
@@ -2751,6 +2751,50 @@ class TestStockEntry(FrappeTestCase):
 
 		self.assertEqual(se.process_loss_qty, 50)
 
+	@change_settings("Stock Settings", {"allow_negative_stock": 0})
+	def test_cancel_seeds_replay_from_before_posting_datetime_bucket(self):
+		from erpnext.stock.doctype.warehouse.test_warehouse import create_warehouse
+
+		item = make_item().name
+		warehouse = create_warehouse("Cancel Replay Warehouse", company="_Test Company")
+
+		def stock_entry(qty, posting_date, **kwargs):
+			return make_stock_entry(
+				item_code=item,
+				qty=qty,
+				company="_Test Company",
+				posting_date=posting_date,
+				posting_time="10:00:00",
+				**kwargs,
+			)
+
+		stock_entry(25, add_days(today(), -3), to_warehouse=warehouse, rate=10)
+
+		bucket_date = add_days(today(), -2)
+		stock_entry(20, bucket_date, from_warehouse=warehouse)
+		receipt = stock_entry(75, bucket_date, to_warehouse=warehouse, rate=10)
+		duplicate_issue = stock_entry(20, bucket_date, from_warehouse=warehouse)
+
+		frappe.flags.dont_execute_stock_reposts = True
+		self.addCleanup(frappe.flags.pop, "dont_execute_stock_reposts")
+
+		duplicate_issue.reload()
+		duplicate_issue.cancel()
+
+		self.assertEqual(
+			flt(
+				frappe.db.get_value(
+					"Stock Ledger Entry",
+					{"voucher_no": receipt.name, "is_cancelled": 0},
+					"qty_after_transaction",
+				)
+			),
+			80,
+		)
+
+		overdraw = stock_entry(100, add_days(today(), -1), from_warehouse=warehouse, do_not_submit=True)
+		self.assertRaises(NegativeStockError, overdraw.submit)
+
 
 def make_serialized_item(**args):
 	args = frappe._dict(args)

--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -1762,7 +1762,7 @@ def get_previous_sle_of_current_voucher(args, operator="<", exclude_current_vouc
 		voucher_no = args.get("voucher_no")
 		voucher_condition = f"and voucher_no != '{voucher_no}'"
 
-	elif args.get("creation") and args.get("sle_id"):
+	elif args.get("creation") and args.get("sle_id") and not args.get("cancelled"):
 		creation = args.get("creation")
 		operator = "<="
 		voucher_condition = f"and creation < '{creation}'"


### PR DESCRIPTION
On cancel, `update_entries_after` replays every live SLE sharing the cancelled voucher's posting datetime (added to v15 in #52700), but `get_previous_sle_of_current_voucher` seeds that replay using the **reversal SLE's creation**. Since the reversal is newer than every row at that datetime, the "previous balance" resolves to the bucket's own closing row, and the replay re-applies the bucket on top of it — double-counting its net qty into every same-datetime row.

When the bucket's net movement is positive, all replayed balances inflate, so subsequent submissions pass negative stock validation against poisoned values. The Repost Item Valuation queued by the cancel then rewrites the correct balances with `allow_negative_stock` forced on, silently producing negative stock while the setting is disabled. Diagnosed from a production ledger where a warehouse ended at −24.68 with negative stock never enabled: cancelling a duplicate backdated issue inflated the datetime bucket's closing row from 79.17 to 133.65, and two material issues then validated against it.

Repro (negative stock disabled): receipt +25 on day 1; on day 2 at one posting datetime submit issue −20, receipt +75, issue −20; cancel the last issue — the receipt's `qty_after_transaction` becomes 135 instead of 80, and an overdraw of −100 (true stock 80) then submits without error.

develop already has the guard via eca71dce54f; this backports the missing hunk and adds a regression test.